### PR TITLE
kconfig: Use rsource to source files

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
 
-source "../fw-nrfconnect-nrf/lib/Kconfig"
+rsource "lib/Kconfig"
 


### PR DESCRIPTION
Now that rsource is available use it to source the Kconfig files
relative to the nrf tree.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>