### PR TITLE
subsys: bluetooth: services: removing hids uuid definitions

### DIFF
--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -10,28 +10,8 @@ extern "C" {
 
 #include <bluetooth/gatt.h>
 
-/* @TODO Move it to the main Zephyr repository (include/bluetooth/uuid.h). */
-
-/** @def BT_UUID_HIDS_PROTOCOL_MODE
- *  @brief HID Protocol Mode Characteristic
- */
-#define BT_UUID_HIDS_PROTOCOL_MODE         BT_UUID_DECLARE_16(0x2a4e)
-/** @def BT_UUID_BOOT_KEYBOARD_INPUT_REPORT
- *  @brief HID Boot Keyboard Input Report Characteristic
- */
-#define BT_UUID_BOOT_KEYBOARD_INPUT_REPORT BT_UUID_DECLARE_16(0x2a22)
-/** @def BT_UUID_BOOT_KEYBOARD_OUTPUT_REPORT
- *  @brief HID Boot Keyboard Output Report Characteristic
- */
-#define BT_UUID_BOOT_KEYBOARD_OUTPUT_REP   BT_UUID_DECLARE_16(0x2a32)
-/** @def BT_UUID_BOOT_MOUSE_INPUT_REPORT
- *  @brief HID Boot Mouse Input Report Characteristic
- */
-#define BT_UUID_BOOT_MOUSE_INPUT_REPORT    BT_UUID_DECLARE_16(0x2a33)
-
 #define BOOT_MOUSE_INPUT_REP_CHAR_LEN 8
 #define HIDS_INFORMATION_CHAR_LEN     4
-
 
 /** @def HIDS_DEF
  *  @brief HIDS instance declaration macro.

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -317,14 +317,14 @@ int hids_init(struct hids *hids_obj,
 	 * and CCC.
 	 */
 	if (hids_init_obj->is_mouse) {
-		CHRC_REGISTER(&hids_obj->svc, BT_UUID_BOOT_MOUSE_INPUT_REPORT,
+		CHRC_REGISTER(&hids_obj->svc, BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT,
 			      BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY);
 
 		hids_obj->boot_mouse_inp_rep.att_ind = hids_obj->svc.attr_count;
 
 		DESCRIPTOR_REGISTER(&hids_obj->svc,
 				    BT_GATT_DESCRIPTOR(
-					BT_UUID_BOOT_MOUSE_INPUT_REPORT,
+					BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT,
 					BT_GATT_PERM_READ,
 					hids_boot_mouse_inp_report_read,
 					NULL,


### PR DESCRIPTION
Now that all UUIDs of HIDS characteristics are available in the zephyr
upstream, temporary definitions in the nrf repository can be removed.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>