### PR TITLE
samples: nrf_desktop: advertise after services are ready

### DIFF
--- a/samples/nrf_desktop/src/modules/Kconfig
+++ b/samples/nrf_desktop/src/modules/Kconfig
@@ -43,7 +43,7 @@ config DESKTOP_SYS_LOG_BLE_STATE_LEVEL
 	default 2
 	range 0 4
 	help
-	  Sets log level for HID state.
+	  Sets log level for BLE state.
 	  Levels are:
 	  - 0 OFF, do not write
 	  - 1 ERROR, only write SYS_LOG_ERR
@@ -52,6 +52,23 @@ config DESKTOP_SYS_LOG_BLE_STATE_LEVEL
 	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
 endmenu
 
+
+menu "BLE Advertising"
+
+config DESKTOP_SYS_LOG_BLE_ADV_LEVEL
+	int "BLE advertising log level"
+	depends on SYS_LOG
+	default 2
+	range 0 4
+	help
+	  Sets log level for BLE advertising.
+	  Levels are:
+	  - 0 OFF, do not write
+	  - 1 ERROR, only write SYS_LOG_ERR
+	  - 2 WARNING, write SYS_LOG_WRN in addition to previous level
+	  - 3 INFO, write SYS_LOG_INF in addition to previous levels
+	  - 4 DEBUG, write SYS_LOG_DBG in addition to previous levels
+endmenu
 
 menu "Power manager"
 

--- a/samples/nrf_desktop/src/modules/ble_adv.c
+++ b/samples/nrf_desktop/src/modules/ble_adv.c
@@ -1,0 +1,87 @@
+#include <zephyr/types.h>
+
+#include <misc/reboot.h>
+
+#include <bluetooth/bluetooth.h>
+
+#include "module_state_event.h"
+
+
+#define MODULE		ble_adv
+#define MODULE_NAME	STRINGIFY(MODULE)
+
+#define SYS_LOG_DOMAIN	MODULE_NAME
+#define SYS_LOG_LEVEL	CONFIG_DESKTOP_SYS_LOG_BLE_ADV_LEVEL
+#include <logging/sys_log.h>
+
+
+#define DEVICE_NAME		CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN		(sizeof(DEVICE_NAME) - 1)
+
+
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL,
+			  0x12, 0x18,	/* HID Service */
+			  0x0f, 0x18),	/* Battery Service */
+};
+
+static const struct bt_data sd[] = {
+	BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
+};
+
+static void ble_adv_start(void)
+{
+	/* TODO: use bond manager to check if it possible to pair with another
+	 * device. Currently bt_keys and bt_settings APIs are private
+	 */
+	int err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
+				  sd, ARRAY_SIZE(sd));
+
+	if (err) {
+		SYS_LOG_ERR("Advertising failed to start (err %d)", err);
+		sys_reboot(SYS_REBOOT_WARM);
+	}
+
+	SYS_LOG_INF("Advertising started");
+}
+
+static bool event_handler(const struct event_header *eh)
+{
+	if (is_module_state_event(eh)) {
+		static const char *const required_srv[] = {"hog", "bas", "dis"};
+		static unsigned int srv_ready_cnt;
+
+		struct module_state_event *event = cast_module_state_event(eh);
+
+		SYS_LOG_DBG("event from %s", event->name);
+
+		for (size_t i = 0; i < ARRAY_SIZE(required_srv); i++) {
+			if (check_state(event, required_srv[i], "ready")) {
+				srv_ready_cnt++;
+				SYS_LOG_DBG("received %s ready! cnt: %u",
+					    required_srv[i], srv_ready_cnt);
+
+				if (srv_ready_cnt == ARRAY_SIZE(required_srv)) {
+					static bool initialized;
+
+					__ASSERT_NO_MSG(!initialized);
+					initialized = true;
+
+					ble_adv_start();
+				}
+				break;
+			}
+		}
+		__ASSERT_NO_MSG(srv_ready_cnt <= ARRAY_SIZE(required_srv));
+
+		return false;
+	}
+
+	/* If event is unhandled, unsubscribe. */
+	__ASSERT_NO_MSG(false);
+
+	return false;
+}
+EVENT_LISTENER(MODULE, event_handler);
+EVENT_SUBSCRIBE(MODULE, module_state_event);

--- a/samples/nrf_desktop/src/services/bas.c
+++ b/samples/nrf_desktop/src/services/bas.c
@@ -90,6 +90,8 @@ static bool event_handler(const struct event_header *eh)
 				return false;
 			}
 			SYS_LOG_INF("service initialized");
+
+			module_set_state("ready");
 		}
 		return false;
 	}

--- a/samples/nrf_desktop/src/services/dis.c
+++ b/samples/nrf_desktop/src/services/dis.c
@@ -74,6 +74,8 @@ static bool event_handler(const struct event_header *eh)
 				return false;
 			}
 			SYS_LOG_INF("service initialized");
+
+			module_set_state("ready");
 		}
 		return false;
 	}

--- a/samples/nrf_desktop/src/services/hog.c
+++ b/samples/nrf_desktop/src/services/hog.c
@@ -337,6 +337,8 @@ static bool event_handler(const struct event_header *eh)
 				return false;
 			}
 			SYS_LOG_INF("service initialized");
+
+			module_set_state("ready");
 		}
 		return false;
 	}


### PR DESCRIPTION
DESK-182. Moved advertising to separate module.
Changed order of initialization of modules so device starts advertising
only after BLE services are ready.

Signed-off-by: Kubicz, Filip <filip.kubicz@nordicsemi.no>