### PR TITLE
samples: nrf_desktop: motion interface for pca10056

### DIFF
--- a/samples/nrf_desktop/src/hw_interface/CMakeLists.txt
+++ b/samples/nrf_desktop/src/hw_interface/CMakeLists.txt
@@ -10,8 +10,14 @@ target_sources_ifdef(CONFIG_HAS_DTS_BMA400 app PRIVATE
 target_sources_ifdef(CONFIG_BOARD_NRF52_PCA20041 app PRIVATE
                      ${CMAKE_CURRENT_SOURCE_DIR}/board.c)
 
+target_sources_ifdef(CONFIG_BOARD_NRF52840_PCA10056 app PRIVATE
+                     ${CMAKE_CURRENT_SOURCE_DIR}/board_pca10056.c)
+
 target_sources_ifdef(CONFIG_BOARD_NRF52_PCA20041 app PRIVATE
                      ${CMAKE_CURRENT_SOURCE_DIR}/buttons.c)
 
 target_sources_ifdef(CONFIG_HAS_DTS_PMW3360 app PRIVATE
                      ${CMAKE_CURRENT_SOURCE_DIR}/motion.c)
+
+target_sources_ifdef(CONFIG_BOARD_NRF52840_PCA10056 app PRIVATE
+                     ${CMAKE_CURRENT_SOURCE_DIR}/btn_emu_motion.c)

--- a/samples/nrf_desktop/src/hw_interface/board_pca10056.c
+++ b/samples/nrf_desktop/src/hw_interface/board_pca10056.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+
+#include <device.h>
+#include <board.h>
+#include <gpio.h>
+
+#include "module_state_event.h"
+#include "power_event.h"
+
+
+#define MODULE		board
+#define MODULE_NAME	STRINGIFY(MODULE)
+
+#define SYS_LOG_DOMAIN	MODULE_NAME
+#define SYS_LOG_LEVEL	CONFIG_DESKTOP_SYS_LOG_BOARD_MODULE_LEVEL
+#include <logging/sys_log.h>
+
+
+static int turn_board_on(void)
+{
+	int err = 0;
+
+	struct device *gpio_dev =
+		device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+
+	if (!gpio_dev) {
+		SYS_LOG_ERR("cannot get GPIO device");
+		return -1;
+	}
+
+	/* Turn on LED indicator */
+	err |= gpio_pin_configure(gpio_dev, LED2_GPIO_PIN, GPIO_DIR_OUT);
+	err |= gpio_pin_write(gpio_dev, LED2_GPIO_PIN, 0);
+	if (err) {
+		return -1;
+	}
+
+	module_set_state("ready");
+
+	return 0;
+}
+
+static int turn_board_off(void)
+{
+	int err = 0;
+
+	struct device *gpio_dev
+		= device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+
+	if (!gpio_dev) {
+		SYS_LOG_ERR("cannot get GPIO device");
+		return -1;
+	}
+
+	/* Turn off LED indicator */
+	err |= gpio_pin_configure(gpio_dev, LED2_GPIO_PIN, GPIO_DIR_OUT);
+	err |= gpio_pin_write(gpio_dev, LED2_GPIO_PIN, 1);
+	if (err) {
+		return -1;
+	}
+
+	module_set_state("off");
+
+	return 0;
+}
+
+static bool event_handler(const struct event_header *eh)
+{
+	static bool initialized;
+
+	if (is_module_state_event(eh)) {
+		struct module_state_event *event = cast_module_state_event(eh);
+
+		if (check_state(event, "main", "ready")) {
+			__ASSERT_NO_MSG(!initialized);
+			initialized = true;
+
+			if (turn_board_on()) {
+				SYS_LOG_ERR("cannot initialize board");
+			}
+		}
+		return false;
+	}
+
+	if (is_power_down_event(eh)) {
+		__ASSERT_NO_MSG(initialized);
+		initialized = false;
+
+		if (turn_board_off()) {
+			SYS_LOG_ERR("cannot suspend board");
+		}
+		return false;
+	}
+
+	/* If event is unhandled, unsubscribe. */
+	__ASSERT_NO_MSG(false);
+
+	return false;
+}
+EVENT_LISTENER(MODULE, event_handler);
+EVENT_SUBSCRIBE_EARLY(MODULE, module_state_event);
+EVENT_SUBSCRIBE(MODULE, power_down_event);

--- a/samples/nrf_desktop/src/hw_interface/btn_emu_motion.c
+++ b/samples/nrf_desktop/src/hw_interface/btn_emu_motion.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+
+#include <device.h>
+#include <board.h>
+#include <gpio.h>
+
+#include "event_manager.h"
+#include "module_state_event.h"
+#include "motion_event.h"
+#include "power_event.h"
+
+#define MODULE		motion
+#define MODULE_NAME	STRINGIFY(MODULE)
+
+#define SYS_LOG_DOMAIN	MODULE_NAME
+#define SYS_LOG_LEVEL	CONFIG_DESKTOP_SYS_LOG_MOTION_MODULE_LEVEL
+#include <logging/sys_log.h>
+
+#define BUTTONS_NUM	4
+#define MOVEMENT_SPEED	5
+
+static struct device       *gpio_devs[BUTTONS_NUM];
+static struct gpio_callback gpio_cbs[BUTTONS_NUM];
+static const  u32_t         pin_id[BUTTONS_NUM] = {
+	SW0_GPIO_PIN, SW1_GPIO_PIN, SW2_GPIO_PIN, SW3_GPIO_PIN
+};
+
+enum {
+	IDLE_STATE,
+	ACTIVE_STATE,
+	TERMINATING_STATE,
+	STATES_NUM
+};
+atomic_t state;
+
+static void motion_event_send(s8_t dx, s8_t dy)
+{
+	struct motion_event *event = new_motion_event();
+
+	if (event) {
+		event->dx = dx;
+		event->dy = dy;
+
+		EVENT_SUBMIT(event);
+	}
+}
+
+
+void button_pressed(struct device *gpio_dev, struct gpio_callback *cb,
+		    u32_t pins)
+{
+	s8_t val_x = 0;
+	s8_t val_y = 0;
+
+	if (pins & (1 << SW0_GPIO_PIN)) {
+		val_x -= MOVEMENT_SPEED;
+		SYS_LOG_DBG("Left");
+	}
+	if (pins & (1 << SW1_GPIO_PIN)) {
+		val_y -= MOVEMENT_SPEED;
+		SYS_LOG_DBG("Up");
+	}
+	if (pins & (1 << SW2_GPIO_PIN)) {
+		val_x += MOVEMENT_SPEED;
+		SYS_LOG_DBG("Right");
+	}
+	if (pins & (1 << SW3_GPIO_PIN)) {
+		val_y += MOVEMENT_SPEED;
+		SYS_LOG_DBG("Down");
+	}
+
+	motion_event_send(val_x, val_y);
+}
+
+
+static void async_init_fn(struct k_work *work)
+{
+	static const char *port_name[BUTTONS_NUM] = { SW0_GPIO_NAME,
+		SW1_GPIO_NAME, SW2_GPIO_NAME, SW3_GPIO_NAME };
+
+	for (size_t i = 0; i < ARRAY_SIZE(pin_id); i++) {
+		gpio_devs[i] = device_get_binding(port_name[i]);
+		if (gpio_devs[i]) {
+			SYS_LOG_DBG("Port %zu bound", i);
+
+			gpio_pin_configure(gpio_devs[i], pin_id[i],
+					   GPIO_PUD_PULL_UP | GPIO_DIR_IN |
+					   GPIO_INT | GPIO_INT_EDGE |
+					   GPIO_INT_ACTIVE_LOW);
+			gpio_init_callback(&gpio_cbs[i], button_pressed,
+					   BIT(pin_id[i]));
+			gpio_add_callback(gpio_devs[i], &gpio_cbs[i]);
+			gpio_pin_enable_callback(gpio_devs[i], pin_id[i]);
+		}
+	}
+
+	/* Inform all that module is ready */
+	module_set_state("ready");
+}
+K_WORK_DEFINE(motion_async_init, async_init_fn);
+
+static void async_term_fn(struct k_work *work)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(gpio_devs); i++) {
+		if (gpio_devs[i]) {
+			SYS_LOG_DBG("Port %zu unbound", i);
+
+			gpio_pin_disable_callback(gpio_devs[i], pin_id[i]);
+			gpio_remove_callback(gpio_devs[i], &gpio_cbs[i]);
+			gpio_pin_configure(gpio_devs[i], pin_id[i],
+					   GPIO_DIR_IN);
+		}
+	}
+
+	atomic_set(&state, IDLE_STATE);
+	module_set_state("off");
+}
+K_WORK_DEFINE(motion_async_term, async_term_fn);
+
+static bool event_handler(const struct event_header *eh)
+{
+	if (is_module_state_event(eh)) {
+		struct module_state_event *event = cast_module_state_event(eh);
+
+		if (check_state(event, "board", "ready")) {
+			if (atomic_cas(&state, IDLE_STATE, ACTIVE_STATE)) {
+				k_work_submit(&motion_async_init);
+			}
+		}
+
+		return false;
+	}
+
+	if (is_power_down_event(eh)) {
+		if (atomic_cas(&state, ACTIVE_STATE, TERMINATING_STATE)) {
+			k_work_submit(&motion_async_term);
+		}
+
+		return (atomic_get(&state) != IDLE_STATE);
+	}
+
+	/* If event is unhandled, unsubscribe. */
+	__ASSERT_NO_MSG(false);
+
+	return false;
+}
+EVENT_LISTENER(MODULE, event_handler);
+EVENT_SUBSCRIBE(MODULE, module_state_event);
+EVENT_SUBSCRIBE_EARLY(MODULE, power_down_event);


### PR DESCRIPTION
Now that pca10056 is one of the targets for the nRF Desktop application,
proper HW interfaces can be defined for this board. The first interface
is used to initialize the board at the start and uninitialize it before
going to system off. The second one is used to emulate mouse motion with
DK buttons.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>