### PR TITLE
subsys: bluetooth: services: mouse boot in report can omit buttons

### DIFF
--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -186,13 +186,14 @@ int hids_inp_rep_send(struct hids *hids_obj, u8_t rep_index, u8_t const *rep,
 /** @brief Sends Boot Mouse Input Report.
  *
  *  @param hids_obj HIDS instance
- *  @param buttons State of mouse buttons
+ *  @param buttons Pointer to the state of mouse buttons - buttons are set to
+ *                 the previously passed value if null
  *  @param x_delta Horizontal movement
  *  @param y_delta Vertical movement
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int hids_boot_mouse_inp_rep_send(struct hids *hids_obj, u8_t buttons,
+int hids_boot_mouse_inp_rep_send(struct hids *hids_obj, const u8_t *buttons,
 				 s8_t x_delta, s8_t y_delta);
 
 

--- a/samples/bluetooth/hids_mouse/src/main.c
+++ b/samples/bluetooth/hids_mouse/src/main.c
@@ -322,7 +322,7 @@ static void mouse_movement_send(s16_t x_delta, s16_t y_delta)
 		y_delta = max(min(y_delta, SCHAR_MAX), SCHAR_MIN);
 
 		hids_boot_mouse_inp_rep_send(&hids_obj,
-					     0x00,
+					     NULL,
 					     (s8_t) x_delta,
 					     (s8_t) y_delta);
 	} else {

--- a/samples/nrf_desktop/src/services/hids.c
+++ b/samples/nrf_desktop/src/services/hids.c
@@ -307,7 +307,7 @@ static void send_mouse_xy(const struct hid_mouse_xy_event *event)
 		s8_t x = max(min(event->dx, SCHAR_MAX), SCHAR_MIN);
 		s8_t y = max(min(event->dy, SCHAR_MAX), SCHAR_MIN);
 
-		hids_boot_mouse_inp_rep_send(&hids_obj, 0x00, x, y);
+		hids_boot_mouse_inp_rep_send(&hids_obj, NULL, x, y);
 	} else {
 		s16_t x = max(min(event->dx, 0x07ff), -0x07ff);
 		s16_t y = max(min(event->dy, 0x07ff), -0x07ff);
@@ -342,7 +342,7 @@ static void send_mouse_wp(const struct hid_mouse_wp_event *event)
 static void send_mouse_buttons(const struct hid_mouse_button_event *event)
 {
 	if (in_boot_mode) {
-		hids_boot_mouse_inp_rep_send(&hids_obj, event->button_bm, 0, 0);
+		hids_boot_mouse_inp_rep_send(&hids_obj, &event->button_bm, 0, 0);
 	} else {
 		u8_t report[REPORT_SIZE_MOUSE_BUTTONS];
 


### PR DESCRIPTION
Allow mouse input report transmitted under boot protocol to use value of
buttons delivered in earlier calls. This will allow a case when only motion
is updated while button state is not affected.

Jira:DESK-247

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>