### PR TITLE
subsys: bluetooth: services: aligning api docs for bluetooth libs

### DIFF
--- a/doc/nrf/api.rst
+++ b/doc/nrf/api.rst
@@ -3,11 +3,9 @@
 API documentation
 #################
 
-TODO: add API documentation once header files have been added
+The following sections contain information about the public APIs of the |NCS|:
 
-Syntax is, for example::
+.. toctree::
+   :maxdepth: 2
 
-  .. doxygenfunction:: ble_advertising_on_ble_evt
-     :project: nrf
-
-See `the breathe documentation <https://breathe.readthedocs.io/en/latest/directives.html#directives>`_ for information about what you can link to.
+   bluetooth.rst

--- a/doc/nrf/bluetooth.rst
+++ b/doc/nrf/bluetooth.rst
@@ -1,0 +1,23 @@
+.. _bluetooth_api:
+
+Bluetooth API
+#############
+
+.. contents::
+   :depth: 2
+   :local:
+   :backlinks: top
+
+The following Bluetooth APIs are available in the |NCS|.
+
+Common service utilities
+************************
+
+.. doxygengroup:: nrf_bt_svc_common
+   :project: nrf
+
+Human Interface Device (HID) Service
+************************************
+
+.. doxygengroup:: nrf_bt_hids
+   :project: nrf

--- a/include/bluetooth/common/svc_common.h
+++ b/include/bluetooth/common/svc_common.h
@@ -4,19 +4,28 @@
  * SPDX-License-Identifier: BSD-5-Clause-Nordic
  */
 
-#include <bluetooth/gatt.h>
-#include <bluetooth/uuid.h>
+#ifndef __SVC_COMMON_H
+#define __SVC_COMMON_H
+
+/**
+ * @file
+ * @defgroup nrf_bt_svc_common Common BLE GATT service utilities API
+ * @{
+ * @brief Common utilities for BLE GATT services.
+ */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#include <bluetooth/gatt.h>
+#include <bluetooth/uuid.h>
 
-/** @def PRIMARY_SVC_REGISTER
- *  @brief Macro for Primary Service descriptor registration.
+/**
+ *  @brief Register a primary service descriptor.
  *
- *  @param _svc GATT service descriptor
- *  @param _svc_uuid_init service UUID
+ *  @param _svc GATT service descriptor.
+ *  @param _svc_uuid_init Service UUID.
  */
 #define PRIMARY_SVC_REGISTER(_svc, _svc_uuid_init)	    \
 	{						    \
@@ -25,12 +34,12 @@ extern "C" {
 	}
 
 
-/** @def CHRC_REGISTER
- *  @brief Macro for characteristic descriptor registration.
+/**
+ *  @brief Register a characteristic descriptor.
  *
- *  @param _svc GATT service descriptor
- *  @param _chrc_uuid_init characteristic uuid
- *  @param _char_props characteristic properties
+ *  @param _svc GATT service descriptor.
+ *  @param _chrc_uuid_init Characteristic UUID.
+ *  @param _char_props Properties of the characteristic.
  */
 #define CHRC_REGISTER(_svc, _chrc_uuid_init, _char_props) \
 	{						  \
@@ -42,11 +51,11 @@ extern "C" {
 		chrc_register(_svc, &_chrc);		  \
 	}
 
-/** @def DESCRIPTOR_REGISTER
- *  @brief Macro for attribute descriptor registration.
+/**
+ *  @brief Register an attribute descriptor.
  *
- *  @param _svc GATT service descriptor
- *  @param _descriptor_init attribute descriptor
+ *  @param _svc GATT service descriptor.
+ *  @param _descriptor_init Attribute descriptor.
  */
 #define DESCRIPTOR_REGISTER(_svc, _descriptor_init)		    \
 	{							    \
@@ -54,12 +63,12 @@ extern "C" {
 		descriptor_register(_svc, &_descriptor);	    \
 	}
 
-/** @def CCC_REGISTER
- *  @brief Macro for CCC descriptor registration.
+/**
+ *  @brief Register a CCC descriptor.
  *
- *  @param _svc GATT service descriptor
- *  @param _ccc_cfg CCC descriptor configuration
- *  @param _ccc_cb CCC descriptor callback
+ *  @param _svc GATT service descriptor.
+ *  @param _ccc_cfg CCC descriptor configuration.
+ *  @param _ccc_cb CCC descriptor callback.
  */
 #define CCC_REGISTER(_svc, _ccc_cfg, _ccc_cb)		 \
 	{						 \
@@ -72,63 +81,63 @@ extern "C" {
 		ccc_register(_svc, &_ccc);		 \
 	}
 
-/** @brief Registers Primary service descriptor.
+/** @brief Register a primary service descriptor.
  *
- *  @param svc GATT service descriptor
- *  @param svc_uuid_init service UUID
+ *  @param svc GATT service descriptor.
+ *  @param svc_uuid Service UUID.
  */
 void primary_svc_register(struct bt_gatt_service *svc,
 			  struct bt_uuid const *svc_uuid);
 
-/** @brief Unregisters Primary service descriptor.
+/** @brief Unregister a primary service descriptor.
  *
- *  @param attr attribute describing previously registered primary service
+ *  @param attr Attribute describing a previously registered primary service.
  */
 void primary_svc_unregister(struct bt_gatt_attr const *attr);
 
-/** @brief Registers characteristic descriptor.
+/** @brief Register a characteristic descriptor.
  *
- *  @param svc GATT service descriptor
- *  @param chrc characteristic descriptor
+ *  @param svc GATT service descriptor.
+ *  @param chrc Characteristic descriptor.
  */
 void chrc_register(struct bt_gatt_service *svc,
 		   struct bt_gatt_chrc const *chrc);
 
-/** @brief Unregisters characteristic descriptor.
+/** @brief Unregister a characteristic descriptor.
  *
- *  @param attr attribute describing previously registered characteristic
+ *  @param attr Attribute describing a previously registered characteristic.
  */
 void chrc_unregister(struct bt_gatt_attr const *attr);
 
-/** @brief Registers attribute descriptor.
+/** @brief Register an attribute descriptor.
  *
- *  @param svc GATT service descriptor
- *  @param descriptor attribute descriptor
+ *  @param svc GATT service descriptor.
+ *  @param descriptor Attribute descriptor.
  */
 void descriptor_register(struct bt_gatt_service *svc,
 			 struct bt_gatt_attr const *descriptor);
 
-/** @brief Unregisters attribute descriptor.
+/** @brief Unregister an attribute descriptor.
  *
- *  @param attr attribute describing previously registered descriptor
+ *  @param attr Attribute describing a previously registered descriptor.
  */
 void descriptor_unregister(struct bt_gatt_attr const *attr);
 
-/** @brief Registers CCC descriptor.
+/** @brief Register a CCC descriptor.
  *
- *  @param svc GATT service descriptor
- *  @param ccc CCC descriptor
+ *  @param svc GATT service descriptor.
+ *  @param ccc CCC descriptor.
  */
 void ccc_register(struct bt_gatt_service *svc, struct _bt_gatt_ccc const *ccc);
 
-/** @brief Unregisters CCC descriptor.
+/** @brief Unregister a CCC descriptor.
  *
- *  @param attr attribute describing previously registered CCC descriptor
+ *  @param attr Attribute describing a previously registered CCC descriptor.
  */
 void ccc_unregister(struct bt_gatt_attr const *attr);
 
 #if CONFIG_NRF_BT_STATISTICS_PRINT != 0
-/** @brief Prints basic module statistics containing pool size usage.
+/** @brief Print basic module statistics (containing pool size usage).
  */
 void statistics_print(void);
 #endif
@@ -136,3 +145,9 @@ void statistics_print(void);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
+
+#endif /* __SVC_COMMON_H */

--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -4,19 +4,34 @@
  * SPDX-License-Identifier: BSD-5-Clause-Nordic
  */
 
+#ifndef __HIDS_H
+#define __HIDS_H
+
+/**
+ * @file
+ * @defgroup nrf_bt_hids BLE GATT Human Interface Device Service API
+ * @{
+ * @brief API for the BLE GATT Human Interface Device (HID) Service.
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <bluetooth/gatt.h>
 
+/** Length of the Boot Mouse Input Report. */
 #define BOOT_MOUSE_INPUT_REP_CHAR_LEN	8
+/** Length of the Boot Keyboard Input Report. */
 #define BOOT_KB_INPUT_REP_CHAR_LEN	8
+/** Length of the Boot Keyboard Output Report. */
 #define BOOT_KB_OUTPUT_REP_CHAR_LEN	1
+
+/** Length of encoded HID Information. */
 #define HIDS_INFORMATION_CHAR_LEN	4
 
-/** @def HIDS_DEF
- *  @brief HIDS instance declaration macro.
+/**
+ *  @brief Declare a HIDS instance.
  *
  *  @param _name Name of the HIDS instance.
  */
@@ -28,25 +43,31 @@ extern "C" {
 		.svc = { .attrs = CONCAT(_name, _attr_tab) },		       \
 	}
 
-/* HID Information flags. */
-enum {
+/** HID Service information flags. */
+enum hids_flags {
+	/** Device is capable of sending a wake-signal to a host. */
 	HIDS_REMOTE_WAKE          = BIT(0),
+	/** Device advertises when bonded but not connected. */
 	HIDS_NORMALLY_CONNECTABLE = BIT(1),
 };
 
-/* HID Service Protocol Mode event. */
+/** HID Service Protocol Mode events. */
 enum hids_pm_evt {
+	/** Boot mode entered. */
 	HIDS_PM_EVT_BOOT_MODE_ENTERED,
+	/** Report mode entered. */
 	HIDS_PM_EVT_REPORT_MODE_ENTERED,
 };
 
-/* HID Service Control Point event. */
+/** HID Service Control Point events. */
 enum hids_cp_evt {
+	/** Suspend command received. */
 	HIDS_CP_EVT_HOST_SUSP,
+	/** Exit suspend command received. */
 	HIDS_CP_EVT_HOST_EXIT_SUSP,
 };
 
-/** HID notification event. */
+/** HID notification events. */
 enum hids_notif_evt {
 	/** Notification enabled event. */
 	HIDS_CCCD_EVT_NOTIF_ENABLED,
@@ -54,13 +75,23 @@ enum hids_notif_evt {
 	HIDS_CCCD_EVT_NOTIF_DISABLED,
 };
 
+/** @brief HID Service information.
+ *
+ * @param bcd_hid Version of the base USB HID specification.
+ * @param b_country_code Country ID code.
+ * @param flags Information flags (see @ref hids_flags).
+ */
 struct hids_info {
 	u16_t bcd_hid;
 	u8_t b_country_code;
 	u8_t flags;
 };
 
-/* Report data descriptor. */
+/** @brief Report data.
+ *
+ * @param data Pointer to the report data.
+ * @param size Size of the report.
+ */
 struct hids_rep {
 	u8_t *data;
 	u8_t size;
@@ -72,10 +103,20 @@ struct hids_rep {
  */
 typedef void (*hids_notif_handler_t) (enum hids_notif_evt evt);
 
-/* HID Report event handler. */
+/** @brief HID Report event handler.
+ *
+ * @param rep Pointer to the report descriptor.
+ */
 typedef void (*hids_rep_handler_t) (struct hids_rep const *rep);
 
-/* Input Report descriptor. */
+/** @brief Input Report.
+ *
+ * @param buff Report data.
+ * @param ccc CCC descriptor.
+ * @param id Report ID defined in the HIDS Report Map.
+ * @param att_ind Index in the service attribute array.
+ * @param handler Callback with the notification event.
+ */
 struct hids_inp_rep {
 	struct hids_rep buff;
 	struct bt_gatt_ccc_cfg ccc[1];
@@ -84,7 +125,13 @@ struct hids_inp_rep {
 	hids_notif_handler_t handler;
 };
 
-/* Output/Feature Report descriptor. */
+/** @brief Output or Feature Report.
+ *
+ * @param buff Report data.
+ * @param id Report ID defined in the HIDS Report Map.
+ * @param att_ind Index in the service attribute array.
+ * @param handler Callback with updated report data.
+ */
 struct hids_outp_feat_rep {
 	struct hids_rep buff;
 	u8_t id;
@@ -92,7 +139,13 @@ struct hids_outp_feat_rep {
 	hids_rep_handler_t handler;
 };
 
-/* Boot Mouse Input report descriptor. */
+/** @brief Boot Mouse Input Report.
+ *
+ * @param buff Report data.
+ * @param ccc CCC descriptor.
+ * @param att_ind Index in the service attribute array.
+ * @param handler Callback with the notification event.
+ */
 struct hids_boot_mouse_inp_rep {
 	u8_t buff[BOOT_MOUSE_INPUT_REP_CHAR_LEN];
 	struct bt_gatt_ccc_cfg ccc[1];
@@ -100,7 +153,13 @@ struct hids_boot_mouse_inp_rep {
 	hids_notif_handler_t handler;
 };
 
-/* Boot Keyboard Input report descriptor. */
+/** @brief Boot Keyboard Input Report.
+ *
+ * @param buff Report data.
+ * @param ccc CCC descriptor.
+ * @param att_ind Index in the service attribute array.
+ * @param handler Callback with the notification event.
+ */
 struct hids_boot_kb_inp_rep {
 	u8_t buff[BOOT_KB_INPUT_REP_CHAR_LEN];
 	struct bt_gatt_ccc_cfg ccc[1];
@@ -108,54 +167,106 @@ struct hids_boot_kb_inp_rep {
 	hids_notif_handler_t handler;
 };
 
-/* Boot Keyboard Output report descriptor. */
+/** @brief Boot Keyboard Output Report.
+ *
+ * @param buff Report data.
+ * @param att_ind Index in the service attribute array.
+ * @param handler Callback with updated report data.
+ */
 struct hids_boot_kb_outp_rep {
 	u8_t buff[BOOT_KB_OUTPUT_REP_CHAR_LEN];
 	u8_t att_ind;
 	hids_rep_handler_t handler;
 };
 
-/* Collection of all Input Reports. */
+/** @brief Collection of all input reports.
+ *
+ * @param reports Pointer to the report collection.
+ * @param cnt Total number of reports.
+ */
 struct hids_inp_rep_group {
 	struct hids_inp_rep reports[CONFIG_NRF_BT_HIDS_INPUT_REP_MAX];
 	u8_t cnt;
 };
 
-/* Collection of all Output Reports. */
+/** @brief Collection of all output reports.
+ *
+ * @param reports Pointer to the report collection.
+ * @param cnt Total number of reports.
+ */
 struct hids_outp_rep_group {
 	struct hids_outp_feat_rep reports[CONFIG_NRF_BT_HIDS_OUTPUT_REP_MAX];
 	u8_t cnt;
 };
 
-/* Collection of all Feature Reports. */
+/** @brief Collection of all feature reports.
+ *
+ * @param reports Pointer to the report collection.
+ * @param cnt Total number of reports.
+ */
 struct hids_feat_rep_group {
 	struct hids_outp_feat_rep reports[CONFIG_NRF_BT_HIDS_FEATURE_REP_MAX];
 	u8_t cnt;
 };
 
-/* Report Map descriptor. */
+/** @brief Report Map.
+ *
+ * @param data Pointer to the map.
+ * @param size Size of the map.
+ */
 struct hids_rep_map {
 	u8_t const *data;
 	u8_t size;
 };
 
-/* HID Protocol Mode event handler. */
+/** @brief HID Protocol Mode event handler.
+ *
+ * @param evt Protocol Mode event (see @ref hids_pm_evt).
+ */
 typedef void (*hids_pm_evt_handler_t) (enum hids_pm_evt evt);
 
+/** @brief Protocol Mode.
+ *
+ * @param value Current value of Protocol Mode.
+ * @param evt_handler Callback with new Protocol Mode.
+ */
 struct protocol_mode {
 	u8_t value;
 	hids_pm_evt_handler_t evt_handler;
 };
 
-/* HID Control Point event handler. */
+/** @brief HID Control Point event handler.
+ *
+ * @param evt Event indicating that the Control Point value has changed.
+ * (see @ref hids_cp_evt).
+ */
 typedef void (*hids_cp_evt_handler_t) (enum hids_cp_evt evt);
 
+/** @brief Control Point.
+ *
+ * @param value Current value of the Control Point.
+ * @param evt_handler Callback with new Control Point state.
+ */
 struct control_point {
 	u8_t value;
 	hids_cp_evt_handler_t evt_handler;
 };
 
-/* HID initialization structure. */
+/** @brief HID initialization.
+ *
+ * @param info HIDS Information.
+ * @param inp_rep_group_init Input Report collection.
+ * @param outp_rep_group_init Output Report collection.
+ * @param feat_rep_group_init Feature Report collection.
+ * @param rep_map Report Map.
+ * @param pm_evt_handler Callback for Protocol Mode characteristic.
+ * @param cp_evt_handler Callback for Control Point characteristic.
+ * @param boot_mouse_notif_handler Callback for Boot Mouse Input Report.
+ * @param boot_kb_notif_handler Callback for Boot Keyboard Input Report.
+ * @param boot_kb_outp_rep_handler Callback for Boot Keyboard Output Report.
+ * @param is_mouse Flag indicating that the device has mouse capabilities.
+ * @param is_kb Flag indicating that the device has keyboard capabilities.
+ */
 struct hids_init {
 	struct hids_info info;
 	struct hids_inp_rep_group inp_rep_group_init;
@@ -171,7 +282,22 @@ struct hids_init {
 	bool is_kb;
 };
 
-/* HID Service structure. */
+/** @brief HID Service structure.
+ *
+ * @param svc Descriptor of the service attribute array.
+ * @param inp_rep_group Input Report collection.
+ * @param outp_rep_group Output Report collection.
+ * @param feat_rep_group Feature Report collection.
+ * @param boot_mouse_inp_rep Boot Mouse Input Report.
+ * @param boot_kb_inp_rep Boot Keyboard Input Report.
+ * @param boot_kb_outp_rep Boot Keyboard Output Report.
+ * @param rep_map Report Map.
+ * @param pm Protocol Mode.
+ * @param cp Control Point.
+ * @param info Buffer with encoded HID Information.
+ * @param is_mouse Flag indicating that the device has mouse capabilities.
+ * @param is_kb Flag indicating that the device has keyboard capabilities.
+ */
 struct hids {
 	struct bt_gatt_service svc;
 	struct hids_inp_rep_group inp_rep_group;
@@ -189,57 +315,62 @@ struct hids {
 };
 
 
-/** @brief Initializes HIDS instance.
+/** @brief Initialize the HIDS instance.
  *
- *  @param hids_obj HIDS instance
- *  @param hids_init_obj HIDS initialization descriptor
+ *  @param hids_obj HIDS instance.
+ *  @param hids_init_obj HIDS initialization descriptor.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ *  @retval 0 If the operation was successful. Otherwise, a (negative) error
+ *  code is returned.
  */
 int hids_init(struct hids *hids_obj,
 	      struct hids_init const * const hids_init_obj);
 
-/** @brief Uninitializes HIDS instance.
+/** @brief Uninitialize a HIDS instance.
  *
- *  @param hids_obj HIDS instance
+ *  @param hids_obj HIDS instance.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ *  @retval 0 If the operation was successful. Otherwise, a (negative) error
+ *  code is returned.
  */
 int hids_uninit(struct hids *hids_obj);
 
-/** @brief Sends Input Report.
+/** @brief Send Input Report.
  *
- *  @param hids_obj HIDS instance
- *  @param rep_index Index of report descriptor
- *  @param rep Pointer to report data
- *  @param len Length of report data
+ *  @param hids_obj HIDS instance.
+ *  @param rep_index Index of report descriptor.
+ *  @param rep Pointer to the report data.
+ *  @param len Length of report data.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ *  @retval 0 If the operation was successful. Otherwise, a (negative) error
+ *  code is returned.
  */
 int hids_inp_rep_send(struct hids *hids_obj, u8_t rep_index, u8_t const *rep,
 		      u8_t len);
 
-/** @brief Sends Boot Mouse Input Report.
+/** @brief Send Boot Mouse Input Report.
  *
- *  @param hids_obj HIDS instance
- *  @param buttons Pointer to the state of mouse buttons - buttons are set to
- *                 the previously passed value if null
- *  @param x_delta Horizontal movement
- *  @param y_delta Vertical movement
+ *  @param hids_obj HIDS instance.
+ *  @param buttons Pointer to the state of the mouse buttons - if null,
+ *                 buttons are set to the previously passed value.
+ *  @param x_delta Horizontal movement.
+ *  @param y_delta Vertical movement.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ *  @retval 0 If the operation was successful. Otherwise, a (negative) error
+ *  code is returned.
  */
 int hids_boot_mouse_inp_rep_send(struct hids *hids_obj, const u8_t *buttons,
 				 s8_t x_delta, s8_t y_delta);
 
 
-/** @brief Sends Boot Keyboard Input Report.
+/** @brief Send Boot Keyboard Input Report.
  *
- *  @param hids_obj HIDS instance
- *  @param rep Pointer to report data
- *  @param len Length of report data
+ *  @param hids_obj HIDS instance.
+ *  @param rep Pointer to the report data.
+ *  @param len Length of report data.
  *
- *  @return Zero on success or (negative) error code otherwise.
+ *  @retval 0 If the operation was successful. Otherwise, a (negative) error
+ *  code is returned.
  */
 int hids_boot_kb_inp_rep_send(struct hids *hids_obj, u8_t const *rep,
 			      u16_t len);
@@ -248,3 +379,9 @@ int hids_boot_kb_inp_rep_send(struct hids *hids_obj, u8_t const *rep,
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
+
+#endif /* __HIDS_H */


### PR DESCRIPTION
Now that documentation framework is in place, it is possible to
integrate API documentation for HID Service and Service Common libraries
with it. API documentation for both modules has been extended to be more
complete.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>