### PR TITLE
doc: Fix spacing in README

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -108,6 +108,7 @@ Out-of-tree builds are also supported, so you can actually build from outside
 the source tree:
 
 .. code-block:: console
+
    # On Linux/macOS
    cd ~
    source ncs/zephyr/zephyr-env.sh


### PR DESCRIPTION
In order for GitHub to display it correctly, an additional blank line
is required.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>