### PR TITLE
boards:arm:nrf52840_pca20041: Added soft reset.

### DIFF
--- a/boards/arm/nrf52840_pca20041/board.cmake
+++ b/boards/arm/nrf52840_pca20041/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
 
-board_runner_args(nrfjprog "--nrf-family=NRF52")
+board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
 board_runner_args(jlink "--device=nrf52" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
The nrf52840_pca20041 has no pin reset support in HW.
This change will prevent nrfjprog to enable pinreset during
programming to target, and also reset the target properly after
programming.

Signed-off-by: jhn-nordic <jon.helge.nistad@nordicsemi.no>