### PR TITLE
documentation: Include all doc files

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -75,12 +75,12 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E env
   ZEPHYR_BASE=${NRF_BASE}
   ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${PYTHON_EXECUTABLE} ${EXTRACT_CONTENT} ${NRF_RST_OUT} samples boards
+  ${PYTHON_EXECUTABLE} ${EXTRACT_CONTENT} ${NRF_RST_OUT} samples boards include
   # Copy the .rst files in samples/ and boards/ to the doc/nrf folder inside rst
   COMMAND ${CMAKE_COMMAND} -E env
   ZEPHYR_BASE=${NRF_BASE}
   ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
-  ${PYTHON_EXECUTABLE} ${EXTRACT_CONTENT} ${NRF_RST_OUT}/doc/nrf samples boards
+  ${PYTHON_EXECUTABLE} ${EXTRACT_CONTENT} ${NRF_RST_OUT}/doc/nrf samples boards include
 
   WORKING_DIRECTORY ${NRF_DOC_DIR}
 )

--- a/doc/nrf/cheat_sheet.rst
+++ b/doc/nrf/cheat_sheet.rst
@@ -180,7 +180,7 @@ Linking between doc sets
 Doxygen
 =======
 
-.. doxygenfunction:: ble_advertising_on_ble_evt
+.. doxygenfunction:: event_manager_init
    :project: nrf
 
 See `the breathe documentation <https://breathe.readthedocs.io/en/latest/directives.html#directives>`_ for information about what you can link to.

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -13,6 +13,7 @@ The |NCS| contains libraries and application examples for Nordic Semiconductor c
    introduction
    zephyr
    samples
+   reference/kconfig/index
    api
 
 ..   cheat_sheet

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -9,6 +9,14 @@ Nordic Semiconductor provides additional examples that specifically target Nordi
 
 .. toctree::
    :maxdepth: 1
+   :caption: Bluetooth samples:
    :glob:
 
-   _samples/*/*/README
+   ../../samples/bluetooth/*/README
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Other samples:
+   :glob:
+
+   ../../samples/*/README


### PR DESCRIPTION
Include rst files from kconfig and sample folders in the documentation, add rst files from include folder, and fix the API example in the cheat sheet to not give an error

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>