### PR TITLE
cmake: Add cmake_minimum_required to samples

### DIFF
--- a/samples/bluetooth/hids_mouse/CMakeLists.txt
+++ b/samples/bluetooth/hids_mouse/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/throughput/CMakeLists.txt
+++ b/samples/bluetooth/throughput/CMakeLists.txt
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
 
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/nrf_desktop/CMakeLists.txt
+++ b/samples/nrf_desktop/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
 
+cmake_minimum_required(VERSION 3.8.2)
+
 # Check if selected board is supported.
 if    (${BOARD} STREQUAL "nrf52840_pca20041")
 elseif(${BOARD} STREQUAL "nrf52840_pca10056")

--- a/samples/rf/esb/CMakeLists.txt
+++ b/samples/rf/esb/CMakeLists.txt
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
 
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 


### PR DESCRIPTION
Add cmake_minimum_required to samples to comply with a breaking change
from zephyr in PR
https://github.com/zephyrproject-rtos/zephyr/pull/9186

This patch is compatible with Zephyr both before and after PR 9186 is
merged.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>