### PR TITLE
samples: Fix build files after upmerge

### DIFF
--- a/samples/bluetooth/hids_mouse/CMakeLists.txt
+++ b/samples/bluetooth/hids_mouse/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/throughput/CMakeLists.txt
+++ b/samples/bluetooth/throughput/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
-
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/nrf_desktop/CMakeLists.txt
+++ b/samples/nrf_desktop/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
+cmake_minimum_required(VERSION 3.8.2)
 
 # Check if selected board is supported.
 if    (${BOARD} STREQUAL "nrf52840_pca20041")

--- a/samples/rf/esb/CMakeLists.txt
+++ b/samples/rf/esb/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
-
+cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 


### PR DESCRIPTION
Zephyr samples now require a cmake_minimum_required() statement at the
beginning of the sample CMakeLists.txt file.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>