### PR TITLE
gpio: Adapt to new gpio_nrfx driver

### DIFF
--- a/boards/arm/nrf52840_pca20041/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca20041/Kconfig.defconfig
@@ -9,16 +9,6 @@ if BOARD_NRF52840_PCA20041
 config BOARD
 	default "nrf52840_pca20041"
 
-if GPIO_NRF5
-
-config GPIO_NRF5_P0
-	default y
-
-config GPIO_NRF5_P1
-	default y
-
-endif # GPIO_NRF5
-
 if UART_NRFX
 
 config UART_0_NRF_FLOW_CONTROL

--- a/boards/arm/nrf52_pca63519/Kconfig.defconfig
+++ b/boards/arm/nrf52_pca63519/Kconfig.defconfig
@@ -9,13 +9,6 @@ if BOARD_NRF52_PCA63519
 config BOARD
 	default "nrf52_pca63519"
 
-if GPIO_NRF5
-
-config GPIO_NRF5_P0
-	default y
-
-endif # GPIO_NRF5
-
 if UART_NRFX
 
 config UART_0_NRF_TX_PIN

--- a/samples/nrf_desktop/src/hw_interface/board_pca10056.c
+++ b/samples/nrf_desktop/src/hw_interface/board_pca10056.c
@@ -25,7 +25,7 @@ static int turn_board_on(void)
 	int err = 0;
 
 	struct device *gpio_dev =
-		device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+		device_get_binding(CONFIG_GPIO_P0_DEV_NAME);
 
 	if (!gpio_dev) {
 		SYS_LOG_ERR("cannot get GPIO device");
@@ -49,7 +49,7 @@ static int turn_board_off(void)
 	int err = 0;
 
 	struct device *gpio_dev
-		= device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+		= device_get_binding(CONFIG_GPIO_P0_DEV_NAME);
 
 	if (!gpio_dev) {
 		SYS_LOG_ERR("cannot get GPIO device");

--- a/samples/nrf_desktop/src/hw_interface/board_pca20041.c
+++ b/samples/nrf_desktop/src/hw_interface/board_pca20041.c
@@ -25,7 +25,7 @@ static int turn_board_on(void)
 	int err = 0;
 
 	struct device *gpio_dev =
-		device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+		device_get_binding(CONFIG_GPIO_P0_DEV_NAME);
 
 	if (!gpio_dev) {
 		SYS_LOG_ERR("cannot get GPIO device");
@@ -49,7 +49,7 @@ static int turn_board_off(void)
 	int err = 0;
 
 	struct device *gpio_dev
-		= device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+		= device_get_binding(CONFIG_GPIO_P0_DEV_NAME);
 
 	if (!gpio_dev) {
 		SYS_LOG_ERR("cannot get GPIO device");

--- a/samples/nrf_desktop/src/hw_interface/board_pca63519.c
+++ b/samples/nrf_desktop/src/hw_interface/board_pca63519.c
@@ -31,7 +31,7 @@ static int turn_board_on(void)
 	int err = 0;
 
 	struct device *gpio_dev =
-		device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+		device_get_binding(CONFIG_GPIO_P0_DEV_NAME);
 
 	if (!gpio_dev) {
 		SYS_LOG_ERR("cannot get GPIO device");
@@ -77,7 +77,7 @@ static int turn_board_off(void)
 	int err = 0;
 
 	struct device *gpio_dev
-		= device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+		= device_get_binding(CONFIG_GPIO_P0_DEV_NAME);
 
 	if (!gpio_dev) {
 		SYS_LOG_ERR("cannot get GPIO device");

--- a/samples/nrf_desktop/src/hw_interface/motion_touchpad.c
+++ b/samples/nrf_desktop/src/hw_interface/motion_touchpad.c
@@ -110,7 +110,7 @@ static void async_init_fn(struct k_work *work)
 	int err = 0;
 
 	struct device *gpio_dev =
-		device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+		device_get_binding(CONFIG_GPIO_P0_DEV_NAME);
 
 	if (!gpio_dev) {
 		SYS_LOG_ERR("cannot get GPIO device");
@@ -189,7 +189,7 @@ static void async_term_fn(struct k_work *work)
 	 */
 
 	struct device *gpio_dev =
-		device_get_binding(CONFIG_GPIO_NRF5_P0_DEV_NAME);
+		device_get_binding(CONFIG_GPIO_P0_DEV_NAME);
 
 	if (!gpio_dev) {
 		SYS_LOG_ERR("cannot get GPIO device");

--- a/samples/nrf_desktop/src/modules/power_manager.c
+++ b/samples/nrf_desktop/src/modules/power_manager.c
@@ -12,6 +12,7 @@
 #include <board.h>
 #include <device.h>
 #include <gpio.h>
+#include <hal/nrf_gpiote.h>
 
 #include <misc/printk.h>
 
@@ -48,11 +49,6 @@ static struct device_list device_list;
 
 static enum power_state power_state = POWER_STATE_IDLE;
 static struct k_delayed_work power_down_trigger;
-
-
-extern int nrf_gpiote_interrupt_enable(uint32_t mask);
-extern void nrf_gpiote_clear_port_event(void);
-
 
 static void suspend_devices(struct device_list *dl)
 {
@@ -174,9 +170,8 @@ static bool event_handler(const struct event_header *eh)
 		SYS_LOG_INF("power down the board");
 
 		/* Port events are needed to leave system off state */
-		nrf_gpiote_clear_port_event();
-		nrf_gpiote_interrupt_enable(GPIOTE_INTENSET_PORT_Msk);
-		NVIC_EnableIRQ(GPIOTE_IRQn);
+		nrf_gpiote_int_enable(GPIOTE_INTENSET_PORT_Msk);
+		irq_enable(GPIOTE_IRQn);
 
 		power_state = POWER_STATE_SUSPENDING2;
 


### PR DESCRIPTION
After the transition from home-grown to nrfx-based GPIO driver in:
https://github.com/zephyrproject-rtos/zephyr/pull/8729
some changes were required in application. Fix those in the nrf
repository.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>