### PR TITLE
doc: subsys: bluetooth: services: add throughput service dox

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -3,3 +3,6 @@
 
 .. |link_zephyr_doc| replace:: Zephyr Project documentation
 .. _link_zephyr_doc: http://docs.zephyrproject.org/
+
+.. |core_spec| replace:: Bluetooth Core Specification
+.. _core_spec: https://www.bluetooth.com/specifications/bluetooth-core-specification

--- a/include/bluetooth/services/throughput.h
+++ b/include/bluetooth/services/throughput.h
@@ -1,11 +1,14 @@
-/** @file
- *  @brief Throughput service sample
- */
-
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup nrf_bt_throughput BLE GATT Throughput Service API
+ * @{
+ * @brief BLE GATT Throughput Service API.
  */
 
 #ifndef __GATT_THROUGHPUT_H
@@ -17,22 +20,37 @@
 extern "C" {
 #endif
 
+/**@brief BLE GATT throughput metrics.
+ *
+ * @param write_count Number of GATT writes received.
+ * @param write_len Number of bytes received.
+ * @param write_rate Transfer speed in bits per second.
+ */
 struct metrics {
 	u32_t write_count;
 	u32_t write_len;
 	u32_t write_rate;
 };
 
+/** Throughput characteristic UUID. */
 #define BT_UUID_THROUGHPUT_CHAR BT_UUID_DECLARE_16(0x1524)
 
+/** Throughput Service UUID. */
 #define BT_UUID_THROUGHPUT                                                     \
 	BT_UUID_DECLARE_128(0xBB, 0x4A, 0xFF, 0x4F, 0xAD, 0x03, 0x41, 0x5D,    \
 			    0xA9, 0x6C, 0x9D, 0x6C, 0xDD, 0xDA, 0x83, 0x04)
 
+/**
+ * @brief Initialize the BLE GATT Throughput Service.
+ */
 void throughput_init(void);
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* __GATT_THROUGHPUT_H */

--- a/include/bluetooth/services/throughput_README.rst
+++ b/include/bluetooth/services/throughput_README.rst
@@ -1,0 +1,41 @@
+.. _throughput_readme:
+
+GATT Throughput Service
+#######################
+
+The GATT Throughput Service is a custom service that receives writes and returns metrics about these writes.
+To test GATT throughput, the client (central) writes without response to the characteristic on the server (peripheral).
+The client can then read the characteristic to retrieve the metrics.
+
+The GATT Throughput Service is used in the :ref:`ble_throughput` sample.
+
+Service UUID
+************
+
+The 128-bit service UUID is 0xBB, 0x4A, 0xFF, 0x4F, 0xAD, 0x03, 0x41, 0x5D, 0xA9, 0x6C, 0x9D, 0x6C, 0xDD, 0xDA, 0x83, 0x04.
+
+Characteristics
+***************
+
+This service has one characteristic.
+
+Throughput (0x1524)
+===================
+
+Write Without Response
+   * Write any data to the characteristic to measure throughput.
+   * Write 0 bytes to the characteristic to reset the metrics.
+
+Read
+   The read operation returns 3*4 bytes (12 bytes) that contain the metrics:
+
+   * 4 bytes unsigned: Number of GATT writes received
+   * 4 bytes unsigned: Total bytes received
+   * 4 bytes unsigned: Throughput in bits per second
+
+
+API documentation
+*****************
+
+.. doxygengroup::  nrf_bt_throughput
+   :project: nrf

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -1,31 +1,223 @@
 .. _ble_throughput:
 
 Bluetooth: Throughput
-########################
+#####################
+
+The Bluetooth Throughput sample measures *Bluetooth* Low Energy throughput performance.
+You can use it to determine the maximum throughput, or to experiment with different connection parameters and check their influence on the throughput.
+
 
 Overview
 ********
 
-This sample demonstrates BLE throughput by transfering data between two boards,
-or a board and a compatible mobile application. In the first scenario, the sample has
-to be programmed on two separate boards that will automatically connect to each other
-upon boot and print a message on the console when the test is ready. The user can then
-run the test by pressing a key in the console. The progress of the test is shown on screen.
-At the end, both peers will print the throughput metrics.
-To repeat the test with different parameters, run menuconfig to reconfigure the BLE
-parameters as necessary, then flash the new firmware image on one of the two boards.
+The sample transmits data between two boards, the *tester* and the *peer*, and measures the throughput performance.
+It demonstrates the interaction of the following connection parameters:
 
+ATT_MTU size
+   In *Bluetooth* Low Energy, the default Maximum Transmission Unit (MTU) is 23 bytes.
+   When increasing this value, longer ATT payloads can be achieved, increasing ATT throughput.
+
+Data length
+   In *Bluetooth* Low Energy, the default data length for a radio packet is 27 bytes.
+   Data length extension allows to use larger radio packets, so that more data can be sent in one packet, increasing throughput.
+
+Connection interval
+   The connection interval defines how often the devices must listen on the radio.
+   When increasing this value, more packets may be sent in one interval, but if a packet is lost, the wait until the retransmission is longer.
+
+Physical layer (PHY) data rate
+   Starting with Bluetooth 5, the over-the-air data rate in Bluetooth Low Energy can exceed 1 Ms/s (mega symbol per second), which allows for faster transmission.
+   In addition, it is possible to use coded PHY (available on the nRF52840 SoC only) for long-range transmission.
+
+By default, the following connection parameter values are used:
+
+.. list-table:: Default parameter values
+   :header-rows: 1
+
+   * - Parameter
+     - Value
+   * - ATT_MTU size
+     - 247 bytes
+   * - Data length
+     - 251 bytes
+   * - Connection interval
+     - 320 units (400 ms)
+   * - PHY data rate
+     - 2 Ms/s
+
+
+Changing connection parameter values
+====================================
+
+You can experiment with different connection parameter values by reconfiguring the values using menuconfig and then compiling and flashing the sample again to at least one of the boards.
+
+.. note::
+   In a *Bluetooth* Low Energy connection, the different devices negotiate the connection parameters that are used.
+   If the configuration parameters for the devices differ, they agree on the lowest common denominator.
+
+   By default, the sample uses the fastest connection parameters.
+   If you change them to lower values, it is sufficient to program them to one of the boards.
+   If you were to change them to higher values, you would need to program both boards again.
+
+See :ref:`gs_configuring` for instructions on how to change the connection parameter values.
 
 Requirements
 ************
 
-* Any Nordic board
-* Connection to a computer with a serial terminal
+* Two of the following development boards:
 
-Building and Running
+  * nRF52840 Development Kit board (PCA10056)
+  * nRF52 Development Kit board (PCA10040)
+  * nRF51 Development Kit board (PCA10028) - limited support;
+    some features, like an over-the-air data rate of 2 Ms/s, are not available on this board
+
+  You can mix different boards.
+* Connection to a computer with a serial terminal for each of the boards.
+
+Building and running
 ********************
 
 This sample can be found under :file:`samples/bluetooth/throughput` in the
-Nordic Connect SDK tree.
+nRF Connect SDK tree.
 
-See :ref:`bluetooth setup section <zephyr:bluetooth_setup>` for details.
+See :ref:`gs_programming` for information about how to build and program the application.
+
+
+Testing
+=======
+
+After programming the sample to both boards, test it by performing the following steps:
+
+1. Power on both boards.
+#. Connect to both boards with a terminal emulator (for example, PuTTY).
+   See **insert link** for the required settings.
+#. Observe that the boards establish a connection.
+   When they are connected, one of them serves as *tester* and the other one as *peer*.
+   The tester outputs the following information::
+
+       Ready, press any key to start
+
+#. Press a key in the terminal that is connected to the tester.
+#. Observe the output while the tester sends data to the peer.
+   At the end of the test, both tester and peer display the results of the test.
+
+
+Sample output
+==============
+
+The result should look similar to the following output.
+
+For the tester::
+
+   ***** Booting Zephyr OS 1.12.99 *****
+   [bt] [INF] hci_vs_init: HW Platform: Nordic Semiconductor (0x0002)
+   [bt] [INF] hci_vs_init: HW Variant: nRF52x (0x0002)
+   [bt] [INF] hci_vs_init: Firmware: Standard Bluetooth controller (0x00) Version 1.12 Build 99
+   [bt] [INF] bt_dev_show_info: Identity: c5:ca:14:98:3b:90 (random)
+   [bt] [INF] bt_dev_show_info: HCI: version 5.0 (0x09) revision 0x0000, manufacturer 0x05f1
+   [bt] [INF] bt_dev_show_info: LMP: version 5.0 (0x09) subver 0xffff
+   Bluetooth initialized
+   Advertising successfully started
+   Scanning successfully started
+   Found a peer device c5:6f:8a:38:95:27 (random)
+   Connected as master
+   Conn. interval is 320 units
+   MTU exchange pending
+   MTU exchange successful
+   Ready, press any key to start
+
+                       ^.-.^                               ^..^
+                    ^-/ooooo+:.^                       ^.--:+syo/.
+                 ^-/oooooooooooo+:.                 ^.-:::::+yyyyyy+:^
+              ^-/+oooooooooooooooooo/-^          ^.-::::::::/yyyyyyyhhs/-
+           ^-:/++++oooooooooooooooooooo+:.   ^.-::::::::::::/yyyyyyyhhhhhho:^
+         ^::///++++oooooooooooooooooooooooo//:::::::::::::::/yyyyyyyhhhhhddds
+         -::://+++ooooooooooooooooooooooooooooo+/:::::::::::/yyyyyyyhhhhhdddd^
+         -::::::/++ooooooooooooooooooooooooooooooo+/::::::::/yyyyyyyhhhhhdddd^
+         -:::::::::/+ooooooooooooooooooooooooooooossso+/::::/yyyyyyyhhhhhdddd^
+         -::::::::::::/+oooooooooooooooooooooooooossssssso+//yyyyyyyhhhhhdddd^
+         -::::::::::::::::/+ooooooooooooooooooooooossssssssssyyyyyyyhhhhhdddd.
+         -:::::::::::::::::::/+oooooooooooooooooooossssssssssyyyyyyyhhhhhdddd.
+         -:::::::::::::::::::::::/+ooooooooooooooosssssssssssyyyyyyyhhhhhdddd.
+         -::::::::::::::::::::::::::/+ooooooooooooossssssssssyyyyyyyhhhhhdddd.
+         -::::::::::::::::::::::::::::::/+ooooooooossssssssssyyyyyyyhhhhhdddd-
+         -:::::::::::::::::::::::::::::::::/+ooooosssssssssssyyyyyyyhhhhhdddd-
+         -:::::::::::::::::::::::::::::::::::::/+oossssssssssyyyyyyyhhhhhdddd:
+         -::::::::::::::::::::::::::::::::::::::::/+ossssssssyyyyyyyhhhhhdddd:
+         -::::::::::::::::::::::::::::::::::::::::::::/osssssyyyyyyyhhhhhdddd:
+         -:::::::::::::::::::::::::::::::::::::::::::::::/+ossyyyyyyhhhhhdddd:
+         -:::::::::::::::::o+/:::::::::::::::::::::::::::::::+oyyyyyhhhhhdddd:
+         -:::::::::::::::::ossyso/::::::::::::::::::::::::::::::/osyhhhhhdddd/
+         -:::::::::::::::::ossyyyyys+:::::::::::::::::::::::::::::::+shhhdddd/
+         -:::::::::::::::::ossyyyyhhhhyo/::::::::::::::::::::::::::::::/oyddd/
+         .-::::::::::::::::ossyyyyhhhhddddy/-::::::::::::::::::::::::::::::+y:
+           ^.-:::::::::::::ossyyyyhhhhdhs/.  ^.--:::::::::::::::::::::::::-.^
+              ^.--:::::::::ossyyyyhhy+-^         ^.-::::::::::::::::::--.^
+                  ^.-::::::ossyyyo/.                ^^.-:::::::::::-.^
+                     ^..-::oss+:^                       ^.-:::::-.^
+                         ^.:.^                             ^^.^^
+
+   Done
+   [local] sent 612684 bytes (598 KB) in 4042 ms at 1212 kbps
+   [peer] received 612684 bytes (598 KB) in 2511 GATT writes at 1261557 bps
+   Ready, press any key to start
+
+
+For the peer::
+
+   ***** Booting Zephyr OS 1.12.99 *****
+   [bt] [INF] hci_vs_init: HW Platform: Nordic Semiconductor (0x0002)
+   [bt] [INF] hci_vs_init: HW Variant: nRr (0x00) Version 1.12 Build 99
+   [bt] [INF] bt_dev_show_info: Identity: c5:6f:8a:38:95:27 (random)
+   [bt] [INF] bt_devized
+   Advertising successfully started
+   Scanning successfully started
+   Found a peer device c5:ca:14:98:3b:90 (random)
+   Connected as slave
+   Conn. interval is 320 units
+
+   =============================================================================
+   =============================================================================
+   =============================================================================
+   =============================================================================
+   =============================================================================
+   =============================================================================
+   =============================================================================
+   ===========================================================
+   [local] received 612684 bytes (598 KB) in 2511 GATT writes at 1261557 bps
+
+
+Dependencies
+*************
+
+This sample uses the following nRF Connect SDK libraries:
+
+* :ref:`throughput_readme`
+
+In addition, it uses the following Zephyr libraries:
+
+* ``include/console.h``
+* :ref:`zephyr:kernel_apis`:
+
+  * ``include/kernel.h``
+
+* ``include/misc/printk.h``
+* ``include/zephyr/types.h``
+* :ref:`zephyr:bluetooth_api`:
+
+  * ``include/bluetooth/bluetooth.h``
+  * ``include/bluetooth/conn.h``
+  * ``include/bluetooth/gatt.h``
+  * ``include/bluetooth/hci.h``
+  * ``include/bluetooth/uuid.h``
+
+
+References
+***********
+
+For more information about the connection parameters that are used in this sample, see the following chapters in the |core_spec|_:
+
+* Vol 3, Part F, 3.2.8 Exchanging MTU Size
+* Vol 6, Part B, 5.1.1 Connection Update Procedure
+* Vol 6, Part B, 5.1.9 Data Length Update Procedure
+* Vol 6, Part B, 5.1.10 PHY Update Procedure

--- a/subsys/bluetooth/services/throughput.c
+++ b/subsys/bluetooth/services/throughput.c
@@ -1,6 +1,3 @@
-/** @file
- *  @brief Throughput service sample
- */
 
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA


### PR DESCRIPTION
This PR adds doxygen documentation for the BLE GATT Throughput service.
CC @ru-fu , do not mind the non-documentation commits, I will rebase at some point.