### PR TITLE
samples: boards: nrf52: Use soc specific dtsi file

### DIFF
--- a/boards/arm/nrf52840_pca20041/nrf52840_pca20041.dts
+++ b/boards/arm/nrf52840_pca20041/nrf52840_pca20041.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf52840.dtsi>
+#include <nordic/nrf52840_qiaa.dtsi>
 
 / {
 	model = "Nordic PCA20041";

--- a/boards/arm/nrf52_pca63519/nrf52_pca63519.dts
+++ b/boards/arm/nrf52_pca63519/nrf52_pca63519.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include <nordic/nrf52832.dtsi>
+#include <nordic/nrf52832_qfaa.dtsi>
 
 / {
 	model = "Nordic PCA63519";


### PR DESCRIPTION
Fix broken build afer Zephyr update.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>