### PR TITLE
nrf: source nrfxlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,5 +5,12 @@
 #
 
 zephyr_include_directories(include)
+
 add_subdirectory(lib)
 add_subdirectory(subsys)
+
+# Add nrfxlib repository, if found
+set(NRFXLIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../nrfxlib)
+if(EXISTS ${NRFXLIB_DIR})
+	add_subdirectory(${NRFXLIB_DIR} ${PROJECT_BINARY_DIR}/nrfxlib)
+endif()

--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -9,4 +9,6 @@ menu "Nordic nRF Connect"
 rsource "lib/Kconfig"
 rsource "subsys/Kconfig"
 
+orsource "../nrfxlib/Kconfig.nrfxlib"
+
 endmenu


### PR DESCRIPTION
Add the nrfxlib repository to CMake's subdirectories, if found, and source the repository Kconfig file.