### PR TITLE
samples: nrf_desktop: Source NCS configuration once

### DIFF
--- a/samples/nrf_desktop/Kconfig
+++ b/samples/nrf_desktop/Kconfig
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Nordic Semiconductor
+# Copyright (c) 2018 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
@@ -10,8 +10,6 @@ rsource "src/modules/Kconfig"
 rsource "src/services/Kconfig"
 endmenu
 
-rsource ../../Kconfig.nrf
-
-menu "Zephyr kernel"
+menu "Zephyr Kernel"
 source "$ZEPHYR_BASE/Kconfig.zephyr"
 endmenu


### PR DESCRIPTION
Make NCS configuration sourced from Zephyr kernel only.

Jira:NCSDK-339

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>