### PR TITLE
cmake: Remove now unnecessary CMake code

### DIFF
--- a/samples/bluetooth/peripheral_lbs/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_lbs/CMakeLists.txt
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/bluetooth/peripheral_uart/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_uart/CMakeLists.txt
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8)
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)

--- a/samples/nrf_desktop/CMakeLists.txt
+++ b/samples/nrf_desktop/CMakeLists.txt
@@ -17,10 +17,6 @@ endif()
 # Point to NCS root directory.
 set(NRF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
-# Application is root for the entire configuration and binds
-# its own, kernel and NCS configuration trees.
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
-
 # Define configuration files.
 set(CONF_FILE "configuration/app_${BOARD}.conf")
 list(APPEND CONF_FILE "configuration/nrfconnect.conf")


### PR DESCRIPTION
There is now an established convention where if a Kconfig file exists
in the application directory it is automatically set as the
KCONFIG_ROOT. This allows us to avoid explicitly setting KCONFIG_ROOT.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>