### PR TITLE
cmake: Support BOARD from environment variable in samples

### DIFF
--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: BSD-5-Clause-Nordic
+#
+
+if(NOT BOARD)
+        set(BOARD $ENV{BOARD})
+endif()
+
+# Check if selected board is supported.
+if(DEFINED NRF_SUPPORTED_BOARDS)
+        if(NOT BOARD IN_LIST NRF_SUPPORTED_BOARDS)
+                message(FATAL_ERROR "board ${BOARD} is not supported")
+        endif()
+endif()
+
+# Point to NCS root directory.
+set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+
+# Set BOARD_ROOT if board definition exists out of tree.
+find_path(_BOARD_DIR NAMES "${BOARD}_defconfig" PATHS ${NRF_DIR}/boards/*/*
+          NO_DEFAULT_PATH)
+
+if (_BOARD_DIR)
+        set(BOARD_ROOT ${NRF_DIR})
+endif()

--- a/samples/nrf_desktop/CMakeLists.txt
+++ b/samples/nrf_desktop/CMakeLists.txt
@@ -6,27 +6,17 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-# Check if selected board is supported.
-if    (${BOARD} STREQUAL "nrf52840_pca20041")
-elseif(${BOARD} STREQUAL "nrf52840_pca10056")
-elseif(${BOARD} STREQUAL "nrf52_pca63519")
-else()
-	message(FATAL_ERROR "board ${BOARD} is not supported")
-endif()
+set(NRF_SUPPORTED_BOARDS
+  nrf52840_pca20041
+  nrf52840_pca10056
+  nrf52_pca63519)
 
-# Point to NCS root directory.
-set(NRF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+include(../../cmake/boilerplate.cmake)
 
 # Define configuration files.
 set(CONF_FILE "configuration/app_${BOARD}.conf")
 list(APPEND CONF_FILE "configuration/nrfconnect.conf")
 list(APPEND CONF_FILE "configuration/zephyr.conf")
-
-# Use boards defined in NCS.
-if ((${BOARD} STREQUAL "nrf52840_pca20041") OR
-    (${BOARD} STREQUAL "nrf52_pca63519"))
-	set(BOARD_ROOT ${NRF_DIR})
-endif()
 
 ################################################################################
 


### PR DESCRIPTION
Environment variable BOARD does not work in the nrf_desktop sample.
The zephyr handling of BOARD cannot be reused because we need to set
BOARD_ROOT for out of tree boards.