### PR TITLE
subsys: bluetooth: controller: compile crypto.c conditionally

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -7,8 +7,12 @@
 zephyr_library()
 
 zephyr_library_sources(
-  crypto.c
   hci_driver.c
   )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CTLR_CRYPTO
+  crypto.c
+)
 
 zephyr_library_link_libraries(subsys__bluetooth)


### PR DESCRIPTION
The crypto.c wrapper was being unconditionally compiled, however,
that's not needed unless the stack is configured to use crypto
functionality in the controller, i.e. BT_CTRL_CRYPTO is defined.

Or so I understand :)

FYI: @rugeGerritsen 