### PR TITLE
cmake: nrf_desktop: Modernize how CONF_FILE is set

### DIFF
--- a/samples/nrf_desktop/CMakeLists.txt
+++ b/samples/nrf_desktop/CMakeLists.txt
@@ -14,9 +14,13 @@ set(NRF_SUPPORTED_BOARDS
 include(../../cmake/boilerplate.cmake)
 
 # Define configuration files.
-set(CONF_FILE "configuration/app_${BOARD}.conf")
-list(APPEND CONF_FILE "configuration/nrfconnect.conf")
-list(APPEND CONF_FILE "configuration/zephyr.conf")
+macro(set_conf_file)
+  set(CONF_FILE
+	"configuration/app_${BOARD}.conf"
+	"configuration/nrfconnect.conf"
+	"configuration/zephyr.conf"
+	)
+endmacro()
 
 ################################################################################
 


### PR DESCRIPTION
The nrf_desktop application needs to set CONF_FILE differently
depending on the board. But the board is not easily knowable at the
time when CONF_FILE needs to be set.

To work around this chicken-and-egg problem we defer evaluation with a
macro hook. This is the recommended and standard way of maintaining a
complex board-dependent conf file.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>