### PR TITLE
subsys: Bluetooth: Add hid report state bitmap.

### DIFF
--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -152,6 +152,18 @@ struct hids_inp_rep {
 	/** Report data offset. */
 	u8_t offset;
 
+	/** Pointer to report mask. The least significant bit
+	 * corresponds to the least significant byte of the report value.
+	 * If this bit is set to 1 then the first byte of report is stored.
+	 * For example, report is 16 byte length to mask this the 2 byte is
+	 * needed, so if first byte is 0b11111111 then the first 8 byte of
+	 * report is stored, if second byte is 0b00001111 the only next 4
+	 * bytes so first 12 byte of report is stored. The user must provide
+	 * a mask of the appropriate length to mask all bytes of the report.
+	 * If rep_mask is NULL then whole report is stored.
+	 */
+	const u8_t *rep_mask;
+
 	/** Callback with the notification event. */
 	hids_notif_handler_t handler;
 };

--- a/samples/bluetooth/hids_mouse/src/main.c
+++ b/samples/bluetooth/hids_mouse/src/main.c
@@ -228,6 +228,7 @@ static void hid_init(void)
 	int err;
 	struct hids_init hids_init_obj = { 0 };
 	struct hids_inp_rep *hids_inp_rep;
+	static const u8_t mouse_movement_mask[ceiling_fraction(INPUT_REP_MOVEMENT_LEN, 8)] = {0};
 
 	static const u8_t report_map[] = {
 		0x05, 0x01,     /* Usage Page (Generic Desktop) */
@@ -324,6 +325,7 @@ static void hid_init(void)
 	hids_inp_rep++;
 	hids_inp_rep->size = INPUT_REP_MOVEMENT_LEN;
 	hids_inp_rep->id = INPUT_REP_REF_MOVEMENT_ID;
+	hids_inp_rep->rep_mask = mouse_movement_mask;
 	hids_init_obj.inp_rep_group_init.cnt++;
 
 	hids_inp_rep++;

--- a/samples/nrf_desktop/src/services/hids.c
+++ b/samples/nrf_desktop/src/services/hids.c
@@ -312,6 +312,8 @@ static int module_init(void)
 
 	/* HID service configuration */
 	struct hids_init hids_init_obj = { 0 };
+	static const u8_t mouse_xy_mask[ceiling_fraction(REPORT_SIZE_MOUSE_XY, 8)] = {0};
+	static const u8_t mouse_wheel_mask[ceiling_fraction(REPORT_SIZE_MOUSE_WP, 8)] = {0};
 
 	hids_init_obj.info.bcd_hid        = BASE_USB_HID_SPEC_VERSION;
 	hids_init_obj.info.b_country_code = 0x00;
@@ -338,35 +340,37 @@ static int module_init(void)
 		ir_pos++;
 
 
-		input_report[ir_pos].id      = REPORT_ID_MOUSE_WP;
-		input_report[ir_pos].size    = REPORT_SIZE_MOUSE_WP;
-		input_report[ir_pos].handler = mouse_wp_notif_handler;
+		input_report[ir_pos].id       = REPORT_ID_MOUSE_WP;
+		input_report[ir_pos].size     = REPORT_SIZE_MOUSE_WP;
+		input_report[ir_pos].handler  = mouse_wp_notif_handler;
+		input_report[ir_pos].rep_mask = mouse_wheel_mask;
 
 		report_index[input_report[ir_pos].id] = ir_pos;
 		ir_pos++;
 
 
-		input_report[ir_pos].id      = REPORT_ID_MOUSE_XY;
-		input_report[ir_pos].size    = REPORT_SIZE_MOUSE_XY;
-		input_report[ir_pos].handler = mouse_xy_notif_handler;
+		input_report[ir_pos].id       = REPORT_ID_MOUSE_XY;
+		input_report[ir_pos].size     = REPORT_SIZE_MOUSE_XY;
+		input_report[ir_pos].handler  = mouse_xy_notif_handler;
+		input_report[ir_pos].rep_mask = mouse_xy_mask;
 
 		report_index[input_report[ir_pos].id] = ir_pos;
 		ir_pos++;
 	}
 
 	if (IS_ENABLED(CONFIG_DESKTOP_HID_KEYBOARD)) {
-		input_report[ir_pos].id      = REPORT_ID_KEYBOARD;
-		input_report[ir_pos].size    = REPORT_SIZE_KEYBOARD;
-		input_report[ir_pos].handler = keyboard_notif_handler;
+		input_report[ir_pos].id          = REPORT_ID_KEYBOARD;
+		input_report[ir_pos].size        = REPORT_SIZE_KEYBOARD;
+		input_report[ir_pos].handler     = keyboard_notif_handler;
 
 		report_index[input_report[ir_pos].id] = ir_pos;
 		ir_pos++;
 	}
 
 	if (IS_ENABLED(CONFIG_DESKTOP_HID_MPLAYER)) {
-		input_report[ir_pos].id      = REPORT_ID_MPLAYER;
-		input_report[ir_pos].size    = REPORT_SIZE_MPLAYER;
-		input_report[ir_pos].handler = mplayer_notif_handler;
+		input_report[ir_pos].id          = REPORT_ID_MPLAYER;
+		input_report[ir_pos].size        = REPORT_SIZE_MPLAYER;
+		input_report[ir_pos].handler     = mplayer_notif_handler;
 
 		report_index[input_report[ir_pos].id] = ir_pos;
 		ir_pos++;


### PR DESCRIPTION
This change introduces the ability to decide during
the HIDs service initialization which report values
should be stored.

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>