### PR TITLE
subsys: profiler: Fix profiler header file

### DIFF
--- a/include/profiler.h
+++ b/include/profiler.h
@@ -27,10 +27,7 @@
  */
 
 
-#include <zephyr.h>
-#include <stdio.h>
-#include <systemview/SEGGER_SYSVIEW.h>
-#include <rtt/SEGGER_RTT.h>
+#include <zephyr/types.h>
 
 
 /** @brief Data types for logging in system profiler.

--- a/subsys/profiler/profiler_nordic.c
+++ b/subsys/profiler/profiler_nordic.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
+#include <stdio.h>
 #include <kernel_structs.h>
 #include <misc/printk.h>
 #include <misc/util.h>

--- a/subsys/profiler/profiler_sysview.c
+++ b/subsys/profiler/profiler_sysview.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
+#include <stdio.h>
 #include <profiler.h>
 #include <kernel_structs.h>
 


### PR DESCRIPTION
Remove unneeded headers. Move one needed into source files.

Jira:DESK-298

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>