### PR TITLE
bluetooth: hci: Fix hci_driver defines in controller only build

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -18,4 +18,8 @@ rsource "common/Kconfig"
 rsource "services/Kconfig"
 endif # NRF_BT
 
+if BT_LL_NRFXLIB
+rsource "controller/Kconfig"
+endif # CONFIG_BT_LL_NRFXLIB
+
 endmenu

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -1,1 +1,19 @@
-# nothing here
+config BLECTLR_PRIO
+	# Hidden option to set the priority of the controller threads
+	int
+	default BT_RX_PRIO if BT_HCI_HOST || BT_RECV_IS_RX_THREAD
+	default 8
+
+config BLECTLR_RX_STACK_SIZE
+	int "Size of the receive thread stack"
+	default 1024
+	help
+	  Size of the receiving thread stack, used to retrieve HCI events and
+	  data from the controller.
+
+config BLECTLR_SIGNAL_STACK_SIZE
+	int "Size of the signal handler thread stack"
+	default 1024
+	help
+	  Size of the signal handler thread stack, used to process lower
+	  priority signals in the controller.

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -17,15 +17,13 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #include "common/log.h"
 
-#define SIGNAL_HANDLER_STACK_SIZE 1024
-
 static K_SEM_DEFINE(sem_recv, 0, UINT_MAX);
 static K_SEM_DEFINE(sem_signal, 0, UINT_MAX);
 
 static struct k_thread recv_thread_data;
 static struct k_thread signal_thread_data;
-static BT_STACK_NOINIT(recv_thread_stack, CONFIG_BT_RX_STACK_SIZE);
-static BT_STACK_NOINIT(signal_thread_stack, SIGNAL_HANDLER_STACK_SIZE);
+static BT_STACK_NOINIT(recv_thread_stack, CONFIG_BLECTLR_RX_STACK_SIZE);
+static BT_STACK_NOINIT(signal_thread_stack, CONFIG_BLECTLR_SIGNAL_STACK_SIZE);
 
 void blectlr_assertion_handler(const char *const file, const u32_t line)
 {
@@ -216,13 +214,13 @@ static int hci_driver_open(void)
 
 	k_thread_create(&recv_thread_data, recv_thread_stack,
 			K_THREAD_STACK_SIZEOF(recv_thread_stack), recv_thread,
-			NULL, NULL, NULL, K_PRIO_COOP(CONFIG_BT_RX_PRIO), 0,
+			NULL, NULL, NULL, K_PRIO_COOP(CONFIG_BLECTLR_PRIO), 0,
 			K_NO_WAIT);
 
 	k_thread_create(&signal_thread_data, signal_thread_stack,
 			K_THREAD_STACK_SIZEOF(signal_thread_stack),
 			signal_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_RX_PRIO), 0, K_NO_WAIT);
+			K_PRIO_COOP(CONFIG_BLECTLR_PRIO), 0, K_NO_WAIT);
 
 	return 0;
 }


### PR DESCRIPTION
In a controller only build, BT_RX_PRIO and BT_RX_STACK_SIZE is not
defined. If BT_RX_PRIO is defined we need to use that priority to avoid
deadlock in the host, if not we are free to choose a priority.
BT_RX_STACK_SIZE is meant for the host RX thread, so use our own
definition instead

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>