### PR TITLE
samples: nrf_desktop: Load settings after GATT services setup

### DIFF
--- a/samples/nrf_desktop/src/modules/ble_state.c
+++ b/samples/nrf_desktop/src/modules/ble_state.c
@@ -5,10 +5,7 @@
  */
 
 #include <zephyr/types.h>
-
 #include <misc/reboot.h>
-
-#include <settings/settings.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
@@ -95,14 +92,6 @@ static void bt_ready(int err)
 	}
 
 	SYS_LOG_INF("Bluetooth initialized");
-
-	if (IS_ENABLED(CONFIG_SETTINGS)) {
-		if (settings_load()) {
-			SYS_LOG_ERR("Cannot load settings");
-			sys_reboot(SYS_REBOOT_WARM);
-		}
-		SYS_LOG_INF("Settings loaded");
-	}
 
 	module_set_state(MODULE_STATE_READY);
 }


### PR DESCRIPTION
Prior to this change, CCC for HIDS service was loaded from flash before initialization of the service and was not written to GATT database.

This fixes DESK-288 in case if there was BLE disconnection before
peripheral reset. For other cases, a subsequent PR to Zephyr is going to
be prepared.

Jira: DESK-288

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>