### PR TITLE
cmake: git: Make nrfxlib a required dependency of nrf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,7 @@ zephyr_include_directories(include)
 add_subdirectory(lib)
 add_subdirectory(subsys)
 
-# Add nrfxlib repository, if found
-set(NRFXLIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../nrfxlib)
-if(EXISTS ${NRFXLIB_DIR})
-	add_subdirectory(${NRFXLIB_DIR} ${PROJECT_BINARY_DIR}/nrfxlib)
-endif()
+# Add the mandatory nrfxlib repository
+set(               NRFXLIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../nrfxlib)
+assert_exists(     NRFXLIB_DIR)
+add_subdirectory(${NRFXLIB_DIR} ${PROJECT_BINARY_DIR}/nrfxlib)


### PR DESCRIPTION
nrfxlib has been an optional dependency of fw-nrfconnect-nrf until
now, this patch makes it a required dependency instead.

When NCS is used it will consist of a set of mandatory and optional
dependencies. Until now fw-nrfconnect-zephyr and fw-nrfconnect-nrf
have been mandatory dependencies, while nrfxlib has been optional.

When NCS is distributed it will be simplest for users and contributors
of NCS if nrfxlib is always distributed with it. For instance, having
nrfxlib always present means that NCS users that enable their first
nrfxlib component will not have to first download nrfxlib, but instead
be able to directly enable it through the Kconfig configuration system
as if it was an integrated part of NCS (which it is intended to be).

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>