### PR TITLE
samples: nrf_desktop: Invert mouse wheel axis

### DIFF
--- a/samples/nrf_desktop/src/hw_interface/wheel.c
+++ b/samples/nrf_desktop/src/hw_interface/wheel.c
@@ -55,7 +55,7 @@ static void data_ready_handler(struct device *dev, struct sensor_trigger *trig)
 
 	s32_t wheel = value.val1;
 
-	if (IS_ENABLED(CONFIG_DESKTOP_WHEEL_INVERT_AXIS)) {
+	if (!IS_ENABLED(CONFIG_DESKTOP_WHEEL_INVERT_AXIS)) {
 		wheel *= -1;
 	}
 


### PR DESCRIPTION
Inverted wheel axis to match default behavior of Windows, Linux and
Android hosts.

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>