### PR TITLE
subsys: net: Add MQTT library

### DIFF
--- a/include/net/mqtt_socket.h
+++ b/include/net/mqtt_socket.h
@@ -1,0 +1,655 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt.h
+ *
+ * @defgroup mqtt_socket MQTT Client library
+ * @ingroup networking
+ * @{
+ * @brief MQTT Client Implementation
+ *
+ * @details
+ * MQTT Client's Application interface is defined in this header.
+ *
+ * @note The implementation assumes TCP module is enabled.
+ *
+ * @note By default the implementation uses MQTT version 3.1.1.
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_MQTT_H_
+#define ZEPHYR_INCLUDE_NET_MQTT_H_
+
+#include <stddef.h>
+
+#include <zephyr/types.h>
+#include <net/tls_credentials.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MQTT Asynchronous Events notified to the application from the module
+ *        through the callback registered by the application.
+ */
+enum mqtt_evt_type {
+	/** Acknowledgment of connection request. Event result accompanying
+	 *  the event indicates whether the connection failed or succeeded.
+	 */
+	MQTT_EVT_CONNACK,
+
+	/** Disconnection Event. MQTT Client Reference is no longer valid once
+	 *  this event is received for the client.
+	 */
+	MQTT_EVT_DISCONNECT,
+
+	/** Publish event received when message is published on a topic client
+	 *  is subscribed to.
+	 */
+	MQTT_EVT_PUBLISH,
+
+	/** Acknowledgment for published message with QoS 1. */
+	MQTT_EVT_PUBACK,
+
+	/** Reception confirmation for published message with QoS 2. */
+	MQTT_EVT_PUBREC,
+
+	/** Release of published message with QoS 2. */
+	MQTT_EVT_PUBREL,
+
+	/** Confirmation to a publish release message with QoS 2. */
+	MQTT_EVT_PUBCOMP,
+
+	/** Acknowledgment to a subscribe request. */
+	MQTT_EVT_SUBACK,
+
+	/** Acknowledgment to a unsubscribe request. */
+	MQTT_EVT_UNSUBACK
+};
+
+/** @brief MQTT version protocol level. */
+enum mqtt_version {
+	MQTT_VERSION_3_1_0 = 3, /**< Protocol level for 3.1.0. */
+	MQTT_VERSION_3_1_1 = 4  /**< Protocol level for 3.1.1. */
+};
+
+/** @brief MQTT Quality of Service types. */
+enum mqtt_qos {
+	/** Lowest Quality of Service, no acknowledgment needed for published
+	 *  message.
+	 */
+	MQTT_QOS_0_AT_MOST_ONCE = 0x00,
+
+	/** Medium Quality of Service, if acknowledgment expected for published
+	 *  message, duplicate messages permitted.
+	 */
+	MQTT_QOS_1_AT_LEAST_ONCE = 0x01,
+
+	/** Highest Quality of Service, acknowledgment expected and message
+	 *  shall be published only once. Message not published to interested
+	 *  parties unless client issues a PUBREL.
+	 */
+	MQTT_QOS_2_EXACTLY_ONCE  = 0x02
+};
+
+/** @brief MQTT CONNACK return codes. */
+enum mqtt_conn_return_code {
+	/** Connection accepted. */
+	MQTT_CONNECTION_ACCEPTED                = 0x00,
+
+	/** The Server does not support the level of the MQTT protocol
+	 * requested by the Client.
+	 */
+	MQTT_UNACCEPTABLE_PROTOCOL_VERSION      = 0x01,
+
+	/** The Client identifier is correct UTF-8 but not allowed by the
+	 *  Server.
+	 */
+	MQTT_IDENTIFIER_REJECTED                = 0x02,
+
+	/** The Network Connection has been made but the MQTT service is
+	 *  unavailable.
+	 */
+	MQTT_SERVER_UNAVAILABLE                 = 0x03,
+
+	/** The data in the user name or password is malformed. */
+	MQTT_BAD_USER_NAME_OR_PASSWORD          = 0x04,
+
+	/** The Client is not authorized to connect. */
+	MQTT_NOT_AUTHORIZED                     = 0x05
+};
+
+/** @brief MQTT SUBACK return codes. */
+enum mqtt_suback_return_code {
+	/** Subscription with QoS 0 succeeded. */
+	MQTT_SUBACK_SUCCESS_QoS_0 = 0x00,
+
+	/** Subscription with QoS 1 succeeded. */
+	MQTT_SUBACK_SUCCESS_QoS_1 = 0x01,
+
+	/** Subscription with QoS 2 succeeded. */
+	MQTT_SUBACK_SUCCESS_QoS_2 = 0x02,
+
+	/** Subscription for a topic failed. */
+	MQTT_SUBACK_FAILURE = 0x80
+};
+
+/** @brief Abstracts UTF-8 encoded strings. */
+struct mqtt_utf8 {
+	u8_t *utf8;             /**< Pointer to UTF-8 string. */
+	u32_t size;             /**< Size of UTF string, in bytes. */
+};
+
+/** @brief Abstracts binary strings. */
+struct mqtt_binstr {
+	u8_t *data;             /**< Pointer to binary stream. */
+	u32_t len;              /**< Length of binary stream. */
+};
+
+/** @brief Abstracts MQTT UTF-8 encoded topic that can be subscribed
+ *         to or published.
+ */
+struct mqtt_topic {
+	/** Topic on to be published or subscribed to. */
+	struct mqtt_utf8 topic;
+
+	/** Quality of service requested for the subscription.
+	 *  @ref mqtt_qos for details.
+	 */
+	u8_t qos;
+};
+
+/** @brief Parameters for a publish message. */
+struct mqtt_publish_message {
+	struct mqtt_topic topic;     /**< Topic on which data was published. */
+	struct mqtt_binstr payload; /**< Payload on the topic published. */
+};
+
+/** @brief Parameters for a connection acknowledgment (CONNACK). */
+struct mqtt_connack_param {
+	/** The Session Present flag enables a Client to establish whether
+	 *  the Client and Server have a consistent view about whether there
+	 *  is already stored Session state.
+	 */
+	u8_t session_present_flag;
+
+	/** The appropriate non-zero Connect return code indicates if the Server
+	 *  is unable to process a connection request for some reason.
+	 */
+	enum mqtt_conn_return_code return_code;
+};
+
+/** @brief Parameters for MQTT publish acknowledgment (PUBACK). */
+struct mqtt_puback_param {
+	u16_t message_id;
+};
+
+/** @brief Parameters for MQTT publish receive (PUBREC). */
+struct mqtt_pubrec_param {
+	u16_t message_id;
+};
+
+/** @brief Parameters for MQTT publish release (PUBREL). */
+struct mqtt_pubrel_param {
+	u16_t message_id;
+};
+
+/** @brief Parameters for MQTT publish complete (PUBCOMP). */
+struct mqtt_pubcomp_param {
+	u16_t message_id;
+};
+
+/** @brief Parameters for MQTT subscription acknowledgment (SUBACK). */
+struct mqtt_suback_param {
+	u16_t message_id;
+	struct mqtt_binstr return_codes;
+};
+
+/** @brief Parameters for MQTT unsubscribe acknowledgment (UNSUBACK). */
+struct mqtt_unsuback_param {
+	u16_t message_id;
+};
+
+/** @brief Parameters for a publish message. */
+struct mqtt_publish_param {
+	/** Messages including topic, QoS and its payload (if any)
+	 *  to be published.
+	 */
+	struct mqtt_publish_message message;
+
+	/** Message id used for the publish message. Redundant for QoS 0. */
+	u16_t message_id;
+
+	/** Duplicate flag. If 1, it indicates the message is being
+	 *  retransmitted. Has no meaning with QoS 0.
+	 */
+	u8_t dup_flag : 1;
+
+	/** Retain flag. If 1, the message shall be stored persistently
+	 *  by the broker.
+	 */
+	u8_t retain_flag : 1;
+};
+
+/** @brief List of topics in a subscription request. */
+struct mqtt_subscription_list {
+	/** Array containing topics along with QoS for each. */
+	struct mqtt_topic *list;
+
+	/** Number of topics in the subscription list */
+	u16_t list_count;
+
+	/** Message id used to identify subscription request. */
+	u16_t message_id;
+};
+
+/**
+ * @brief Defines event parameters notified along with asynchronous events
+ *        to the application.
+ */
+union mqtt_evt_param {
+	/** Parameters accompanying MQTT_EVT_CONNACK event. */
+	struct mqtt_connack_param connack;
+
+	/** Parameters accompanying MQTT_EVT_PUBLISH event. */
+	struct mqtt_publish_param publish;
+
+	/** Parameters accompanying MQTT_EVT_PUBACK event. */
+	struct mqtt_puback_param puback;
+
+	/** Parameters accompanying MQTT_EVT_PUBREC event. */
+	struct mqtt_pubrec_param pubrec;
+
+	/** Parameters accompanying MQTT_EVT_PUBREL event. */
+	struct mqtt_pubrel_param pubrel;
+
+	/** Parameters accompanying MQTT_EVT_PUBCOMP event. */
+	struct mqtt_pubcomp_param pubcomp;
+
+	/** Parameters accompanying MQTT_EVT_SUBACK event. */
+	struct mqtt_suback_param suback;
+
+	/** Parameters accompanying MQTT_EVT_UNSUBACK event. */
+	struct mqtt_unsuback_param unsuback;
+};
+
+/** @brief Defines MQTT asynchronous event notified to the application. */
+struct mqtt_evt {
+	/** Identifies the event. */
+	enum mqtt_evt_type type;
+
+	/** Contains parameters (if any) accompanying the event. */
+	union mqtt_evt_param param;
+
+	/** Event result. 0 or a negative error code (errno.h) indicating
+	 *  reason of failure.
+	 */
+	int result;
+};
+
+struct mqtt_client;
+
+/**
+ * @brief Asynchronous event notification callback registered by the
+ *        application.
+ *
+ * @param[inout] client Identifies the client for which the event is notified.
+ * @param[in] evt Event description along with result and associated
+ *                parameters (if any).
+ */
+typedef void (*mqtt_evt_cb_t)(struct mqtt_client *client,
+			      const struct mqtt_evt *evt);
+
+/** @brief TLS configuration for secure MQTT transports. */
+struct mqtt_sec_config {
+	/** Indicates the preference for peer verification. */
+	int peer_verify;
+
+	/** Indicates the number of entries in the cipher list. */
+	u32_t cipher_count;
+
+	/** Indicates the list of ciphers to be used for the session.
+	 *  May be NULL to use the default ciphers.
+	 */
+	int *cipher_list;
+
+	/** Indicates the number of entries in the sec tag list. */
+	u32_t sec_tag_count;
+
+	/** Indicates the list of security tags to be used for the session. */
+	sec_tag_t *seg_tag_list;
+
+	/** Peer hostname for ceritificate verification.
+	 *  May be NULL to skip hostname verification.
+	 */
+	char *hostname;
+};
+
+/** @brief MQTT transport type. */
+enum mqtt_transport_type {
+	/** Use non secure TCP transport for MQTT connection. */
+	MQTT_TRANSPORT_NON_SECURE = 0x00,
+
+#if defined(CONFIG_MQTT_LIB_TLS)
+	/** Use secure TCP transport (TLS) for MQTT connection. */
+	MQTT_TRANSPORT_SECURE     = 0x01,
+#endif /* CONFIG_MQTT_LIB_TLS */
+
+	/** Shall not be used as a transport type.
+	 *  Indicator of maximum transport types possible.
+	 */
+	MQTT_TRANSPORT_NUM        = 0x02
+};
+
+/** @brief MQTT transport specific data. */
+struct mqtt_transport {
+	/** Transport type selection for client instance.
+	 *  @ref mqtt_transport_type for possible values. MQTT_TRANSPORT_MAX
+	 *  is not a valid type.
+	 */
+	enum mqtt_transport_type type;
+
+	union {
+		/* TCP socket transport for MQTT */
+		struct {
+			/** Socket descriptor. */
+			int sock;
+		} tcp;
+
+#if defined(CONFIG_MQTT_LIB_TLS)
+		/* TLS socket transport for MQTT */
+		struct {
+			/** Socket descriptor. */
+			int sock;
+
+			/** TLS configuration. See @ref mqtt_sec_config for
+			 *  details.
+			 */
+			struct mqtt_sec_config config;
+		} tls;
+#endif /* CONFIG_MQTT_LIB_TLS */
+	};
+};
+
+/**
+ * @brief MQTT Client definition to maintain information relevant to the
+ *        client.
+ */
+struct mqtt_client {
+	/** MQTT transport configuration and data. */
+	struct mqtt_transport transport;
+
+	/** Broker details, for example, address, port. Address type should
+	 *  be compatible with transport used.
+	 */
+	const void *broker;
+
+	/** User name (if any) to be used for the connection. NULL indicates
+	 *  no user name.
+	 */
+	struct mqtt_utf8 *user_name;
+
+	/** Password (if any) to be used for the connection. Note that if
+	 *  password is provided, user name shall also be provided. NULL
+	 *  indicates no password.
+	 */
+	struct mqtt_utf8 *password;
+
+	/** Will topic and QoS. Can be NULL. */
+	struct mqtt_topic *will_topic;
+
+	/** Will message. Can be NULL. Non NULL value valid only if will topic
+	 *  is not NULL.
+	 */
+	struct mqtt_utf8 *will_message;
+
+	/** Application callback registered with the module to get MQTT events.
+	 */
+	mqtt_evt_cb_t evt_cb;
+
+	/** Internal. Wall clock value (in milliseconds) of the last activity
+	 *  that occurred. Needed for periodic PING.
+	 */
+	u32_t last_activity;
+
+	/** Internal. Shall not be touched by the application.
+	 *  Client's state in the connection.
+	 */
+	u32_t state;
+
+	/** Internal. Shall not be touched by the application. Used for creating
+	 *  MQTT packet in TX path.
+	 */
+	u8_t *tx_buf;
+
+	/** Internal. Shall not be touched by the application. */
+	u8_t *rx_buf;
+
+	/** Internal. Shall not be touched by the application. */
+	u32_t rx_buf_datalen;
+
+	/** Unique client identification to be used for the connection. */
+	struct mqtt_utf8 client_id;
+
+	/** MQTT protocol version. */
+	u8_t protocol_version;
+
+	/** Will retain flag, 1 if will message shall be retained persistently.
+	 */
+	u8_t will_retain : 1;
+
+	/** Clean session flag indicating a fresh (1) or a retained session (0).
+	 *  Default is 1.
+	 */
+	u8_t clean_session : 1;
+};
+
+/**
+ * @brief Initializes the module.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ *
+ * @note Shall be called before initiating any procedures on the module.
+ * @note If module initialization fails, no module APIs shall be called.
+ */
+int mqtt_init(void);
+
+/**
+ * @brief Initializes the client instance.
+ *
+ * @param[in] client Client instance for which the procedure is requested.
+ *                   Shall not be NULL.
+ *
+ * @note Shall be called before connecting the client in order to avoid
+ *       unexpected behavior caused by uninitialized parameters.
+ */
+void mqtt_client_init(struct mqtt_client *client);
+
+/**
+ * @brief API to request new MQTT client connection.
+ *
+ * @param[in] client Client instance for which the procedure is requested.
+ *                   Shall not be NULL.
+ *
+ * @note This memory is assumed to be resident until mqtt_disconnect is called.
+ * @note Any subsequent changes to parameters like broker address, user name,
+ *       device id, etc. have no effect once MQTT connection is established.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ *
+ * @note Default protocol revision used for connection request is 3.1.1. Please
+ *       set client.protocol_version = MQTT_VERSION_3_1_0 to use protocol 3.1.0.
+ * @note If more than one simultaneous client connections are needed, please
+ *       modify :option:`CONFIG_MQTT_MAX_CLIENTS` to override default of 1.
+ * @note Please modify :option:`CONFIG_MQTT_KEEPALIVE` time to override default
+ *       of 1 minute.
+ * @note Please modify :option:`CONFIG_MQTT_MAX_PACKET_LENGTH` time to override
+ *       default of 128 bytes. Ensure the system has enough memory for the new
+ *       length per client.
+ */
+int mqtt_connect(struct mqtt_client *client);
+
+/**
+ * @brief API to publish messages on topics.
+ *
+ * @param[in] client Client instance for which the procedure is requested.
+ *                   Shall not be NULL.
+ * @param[in] param Parameters to be used for the publish message.
+ *                  Shall not be NULL.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_publish(struct mqtt_client *client,
+		 const struct mqtt_publish_param *param);
+
+/**
+ * @brief API used by client to send acknowledgment on receiving QoS1 publish
+ *        message. Should be called on reception of @ref MQTT_EVT_PUBLISH with
+ *        QoS level @ref MQTT_QOS_1_AT_LEAST_ONCE.
+ *
+ * @param[in] client Client instance for which the procedure is requested.
+ *                   Shall not be NULL.
+ * @param[in] param Identifies message being acknowledged.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_publish_qos1_ack(struct mqtt_client *client,
+			  const struct mqtt_puback_param *param);
+
+/**
+ * @brief API used by client to send acknowledgment on receiving QoS2 publish
+ *        message. Should be called on reception of @ref MQTT_EVT_PUBLISH with
+ *        QoS level @ref MQTT_QOS_2_EXACTLY_ONCE.
+ *
+ * @param[in] client Identifies client instance for which the procedure is
+ *                   requested. Shall not be NULL.
+ * @param[in] param Identifies message being acknowledged.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_publish_qos2_receive(struct mqtt_client *client,
+			      const struct mqtt_pubrec_param *param);
+
+/**
+ * @brief API used by client to request release of QoS2 publish message.
+ *        Should be called on reception of @ref MQTT_EVT_PUBREC.
+ *
+ * @param[in] client Client instance for which the procedure is requested.
+ *                   Shall not be NULL.
+ * @param[in] param Identifies message being released.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_publish_qos2_release(struct mqtt_client *client,
+			      const struct mqtt_pubrel_param *param);
+
+/**
+ * @brief API used by client to send acknowledgment on receiving QoS2 publish
+ *        release message. Should be called on reception of
+ *        @ref MQTT_EVT_PUBREL.
+ *
+ * @param[in] client Identifies client instance for which the procedure is
+ *                   requested. Shall not be NULL.
+ * @param[in] param Identifies message being completed.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_publish_qos2_complete(struct mqtt_client *client,
+			       const struct mqtt_pubcomp_param *param);
+
+/**
+ * @brief API to request subscription of one or more topics on the connection.
+ *
+ * @param[in] client Identifies client instance for which the procedure
+ *                   is requested. Shall not be NULL.
+ * @param[in] param Subscription parameters. Shall not be NULL.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_subscribe(struct mqtt_client *client,
+		   const struct mqtt_subscription_list *param);
+
+/**
+ * @brief API to request unsubscribtion of one or more topics on the connection.
+ *
+ * @param[in] client Identifies client instance for which the procedure is
+ *                   requested. Shall not be NULL.
+ * @param[in] param Parameters describing topics being unsubscribed from.
+ *                  Shall not be NULL.
+ *
+ * @note QoS included in topic description is unused in this API.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_unsubscribe(struct mqtt_client *client,
+		     const struct mqtt_subscription_list *param);
+
+/**
+ * @brief API to send MQTT ping. The use of this API is optional, as the library
+ *        handles the connection keep-alive on it's own, see @ref mqtt_live.
+ *
+ * @param[in] client Identifies client instance for which procedure is
+ *                   requested.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_ping(struct mqtt_client *client);
+
+/**
+ * @brief API to disconnect MQTT connection.
+ *
+ * @param[in] client Identifies client instance for which procedure is
+ *                   requested.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_disconnect(struct mqtt_client *client);
+
+/**
+ * @brief API to abort MQTT connection. This will close the corresponding
+ *        transport without closing the connection gracefully at the MQTT level
+ *        (with disconnect message).
+ *
+ * @param[in] client Identifies client instance for which procedure is
+ *                   requested.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_abort(struct mqtt_client *client);
+
+/**
+ * @brief This API should be called periodically for the module to be able
+ *        to keep the connection alive by sending Ping Requests if need be.
+ *
+ * @note  Application shall ensure that the periodicity of calling this function
+ *        makes it possible to respect the Keep Alive time agreed with the
+ *        broker on connection. @ref mqtt_connect for details on Keep Alive
+ *        time.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_live(void);
+
+/**
+ * @brief Receive an incoming MQTT packet. The registered callback will be
+ *        called with the packet payload.
+ *
+ * @note This is a non-blocking call.
+ *
+ * @param[in] client Client instance for which the procedure is requested.
+ *                   Shall not be NULL.
+ *
+ * @return 0 or a negative error code (errno.h) indicating reason of failure.
+ */
+int mqtt_input(struct mqtt_client *client);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_NET_MQTT_H_ */
+
+/**@}  */

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -13,6 +13,8 @@ add_subdirectory_ifdef(CONFIG_NRF_ESB enhanced_shockburst)
 
 add_subdirectory_if_kconfig(event_manager)
 
+add_subdirectory(net)
+
 add_subdirectory_ifdef(CONFIG_NRFXLIB_NFC nfc)
 
 add_subdirectory_ifdef(CONFIG_PROFILER profiler)

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -12,6 +12,8 @@ rsource "enhanced_shockburst/Kconfig"
 
 rsource "event_manager/Kconfig"
 
+rsource "net/Kconfig"
+
 rsource "nfc/Kconfig"
 
 rsource "profiler/Kconfig"

--- a/subsys/net/CMakeLists.txt
+++ b/subsys/net/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: BSD-5-Clause-Nordic
+#
+
+add_subdirectory(lib)

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: BSD-5-Clause-Nordic
+#
+
+menu "Networking"
+
+rsource "lib/Kconfig"
+
+endmenu

--- a/subsys/net/lib/CMakeLists.txt
+++ b/subsys/net/lib/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: BSD-5-Clause-Nordic
+#
+
+add_subdirectory_ifdef(CONFIG_MQTT_SOCKET_LIB mqtt_socket)

--- a/subsys/net/lib/Kconfig
+++ b/subsys/net/lib/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: BSD-5-Clause-Nordic
+#
+
+menu "Application protocols"
+
+rsource "mqtt_socket/Kconfig"
+
+endmenu

--- a/subsys/net/lib/mqtt_socket/CMakeLists.txt
+++ b/subsys/net/lib/mqtt_socket/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: BSD-5-Clause-Nordic
+#
+
+zephyr_library()
+
+zephyr_library_sources(
+  mqtt_decoder.c
+  mqtt_encoder.c
+  mqtt_rx.c
+  mqtt_transport_socket_tcp.c
+  mqtt_transport.c
+  mqtt.c
+  )
+
+zephyr_library_sources_ifdef(CONFIG_MQTT_LIB_TLS
+  mqtt_transport_socket_tls.c
+  )

--- a/subsys/net/lib/mqtt_socket/Kconfig
+++ b/subsys/net/lib/mqtt_socket/Kconfig
@@ -1,0 +1,48 @@
+# Kconfig - Socket MQTT Library for Zephyr
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config MQTT_SOCKET_LIB
+	bool "Socket MQTT Library Support"
+	select NET_SOCKETS
+	select NET_SOCKETS_POSIX_NAMES
+	help
+	  Enable the Zephyr MQTT Library
+
+if MQTT_SOCKET_LIB
+
+module=MQTT
+module-dep=NET_LOG
+module-str=Log level for MQTT
+module-help=Enables mqtt debug messages.
+source "subsys/net/Kconfig.template.log_config.net"
+
+config MQTT_MAX_CLIENTS
+	int "Maximum number of clients"
+	default 1
+	help
+	  Maximum number of clients that can be managed by the module.
+
+config MQTT_KEEPALIVE
+	int "Maximum number of clients Keep alive time for MQTT (in seconds)"
+	default 60
+	help
+	  Keep alive time for MQTT (in seconds). Sending of Ping Requests to
+	  keep the connection alive are governed by this value.
+
+config MQTT_MAX_PACKET_LENGTH
+	int "Maximum MQTT packet size"
+	default 128
+	help
+	  Maximum MQTT packet size that can be sent (including the fixed and
+	  variable header).
+
+config MQTT_LIB_TLS
+	bool "TLS support for socket MQTT Library"
+	help
+	  Enable TLS support for socket MQTT Library
+
+endif # MQTT_SOCKET_LIB

--- a/subsys/net/lib/mqtt_socket/mqtt.c
+++ b/subsys/net/lib/mqtt_socket/mqtt.c
@@ -1,0 +1,699 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt.c
+ *
+ * @brief MQTT Client API Implementation.
+ */
+
+#define LOG_MODULE_NAME net_mqtt
+#define NET_LOG_LEVEL CONFIG_MQTT_LOG_LEVEL
+
+#include <net/mqtt_socket.h>
+
+#include "mqtt_transport.h"
+#include "mqtt_internal.h"
+#include "mqtt_os.h"
+
+/** Number of buffers needed per client - one for RX and one for TX */
+#define BUFFER_COUNT_PER_CLIENT 2
+
+/** Total number of buffers needed by the module. */
+#define TOTAL_BUFFER_COUNT (BUFFER_COUNT_PER_CLIENT * MQTT_MAX_CLIENTS)
+
+/** MQTT Client table. */
+static struct mqtt_client *mqtt_client[MQTT_MAX_CLIENTS];
+
+/** Mutex used by MQTT implementation. */
+struct k_mutex mqtt_mutex;
+
+/** Memory slab submitted to the MQTT memory management.*/
+struct k_mem_slab mqtt_slab;
+static char __aligned(4) mqtt_slab_buffer[TOTAL_BUFFER_COUNT *
+					  MQTT_MAX_PACKET_LENGTH];
+
+static u32_t get_client_index(struct mqtt_client *client)
+{
+	for (u32_t index = 0; index < MQTT_MAX_CLIENTS; index++) {
+		if (mqtt_client[index] == client) {
+			return index;
+		}
+	}
+
+	return MQTT_MAX_CLIENTS;
+}
+
+static void client_free(struct mqtt_client *client)
+{
+	MQTT_STATE_INIT(client);
+
+	/* Free memory used for TX packets and reset the pointer. */
+	if (client->tx_buf != NULL) {
+		mqtt_free(client->tx_buf);
+		client->tx_buf = NULL;
+	}
+
+	if (client->rx_buf != NULL) {
+		mqtt_free(client->rx_buf);
+		client->rx_buf = NULL;
+	}
+}
+
+static void client_init(struct mqtt_client *client)
+{
+	memset(client, 0, sizeof(*client));
+
+	MQTT_STATE_INIT(client);
+
+	client->protocol_version = MQTT_VERSION_3_1_1;
+	client->clean_session = 1;
+
+	/* Allocate buffer packets in TX and RX path. */
+	client->tx_buf = mqtt_malloc(MQTT_MAX_PACKET_LENGTH);
+	client->rx_buf = mqtt_malloc(MQTT_MAX_PACKET_LENGTH);
+}
+
+/**@brief Notifies event to the application.
+ *
+ * @param[in] client Identifies the client for which the procedure is requested.
+ * @param[in] evt Reason for disconnection.
+ */
+void event_notify(struct mqtt_client *client, const struct mqtt_evt *evt,
+		  u32_t flags)
+{
+	const mqtt_evt_cb_t evt_cb = client->evt_cb;
+
+	if (evt_cb != NULL) {
+		mqtt_mutex_unlock();
+
+		evt_cb(client, evt);
+
+		mqtt_mutex_lock();
+
+		if (flags & MQTT_EVT_FLAG_INSTANCE_RESET) {
+			client_free(client);
+			client_init(client);
+		}
+	}
+}
+
+/**@brief Notifies disconnection event to the application.
+ *
+ * @param[in] client Identifies the client for which the procedure is requested.
+ * @param[in] result Reason for disconnection.
+ */
+static void disconnect_event_notify(struct mqtt_client *client, int result)
+{
+	const u32_t client_index = get_client_index(client);
+	struct mqtt_evt evt;
+
+	/* Remove the client from internal table. */
+	if (client_index != MQTT_MAX_CLIENTS) {
+		mqtt_client[client_index] = NULL;
+	}
+
+	/* Determine appropriate event to generate. */
+	if (MQTT_VERIFY_STATE(client, MQTT_STATE_CONNECTED) ||
+	    MQTT_VERIFY_STATE(client, MQTT_STATE_DISCONNECTING)) {
+		evt.type = MQTT_EVT_DISCONNECT;
+		evt.result = result;
+	} else {
+		evt.type = MQTT_EVT_CONNACK;
+		evt.result = -ECONNREFUSED;
+	}
+
+	/* Free the instance. */
+	client_free(client);
+
+	/* Notify application. */
+	event_notify(client, &evt, MQTT_EVT_FLAG_INSTANCE_RESET);
+}
+
+static void client_abort(struct mqtt_client *client)
+{
+	if (mqtt_transport_disconnect(client) < 0) {
+		MQTT_ERR("Failed to disconnect transport!");
+	} else {
+		disconnect_event_notify(client, -ECONNABORTED);
+	}
+}
+
+static int client_disconnect(struct mqtt_client *client, int result)
+{
+	int err_code = -EACCES;
+
+	if (MQTT_VERIFY_STATE(client, MQTT_STATE_TCP_CONNECTED) ||
+	    MQTT_VERIFY_STATE(client, MQTT_STATE_DISCONNECTING)) {
+		err_code = mqtt_transport_disconnect(client);
+		if (err_code < 0) {
+			MQTT_ERR("Failed to disconnect transport!");
+		} else {
+			disconnect_event_notify(client, result);
+		}
+	}
+
+	return err_code;
+}
+
+static int client_connect(struct mqtt_client *client)
+{
+	int err_code = mqtt_transport_connect(client);
+	const u8_t *packet;
+	u32_t packetlen;
+
+	if (err_code == 0) {
+		MQTT_SET_STATE(client, MQTT_STATE_TCP_CONNECTED);
+
+		err_code = connect_request_encode(client, &packet, &packetlen);
+
+		if (err_code == 0) {
+			/* Send MQTT identification message to broker. */
+			MQTT_SET_STATE(client, MQTT_STATE_PENDING_WRITE);
+
+			err_code = mqtt_transport_write(client, packet,
+							packetlen);
+
+			MQTT_RESET_STATE(client, MQTT_STATE_PENDING_WRITE);
+		}
+
+		if (err_code == 0) {
+			client->last_activity = mqtt_sys_tick_in_ms_get();
+		} else {
+			client_abort(client);
+		}
+	}
+
+	MQTT_TRC("Connect completed");
+
+	return err_code;
+}
+
+static int client_read(struct mqtt_client *client)
+{
+	u32_t data_len = MQTT_MAX_PACKET_LENGTH - client->rx_buf_datalen;
+	int err_code = 0;
+
+	err_code = mqtt_transport_read(client,
+				       client->rx_buf + client->rx_buf_datalen,
+				       &data_len);
+
+	if (err_code < 0) {
+		if (err_code == -EAGAIN) {
+			/* No data received yet. Try again later. */
+			err_code = 0;
+		} else {
+			MQTT_TRC("Error receiving data, error = %d, "
+				 "closing connection", err_code);
+			client_abort(client);
+		}
+	} else {
+		if (data_len == 0) {
+			/* Receiving 0 bytes indicates an orderly shutdown. */
+			MQTT_TRC("Received end of stream, closing connection");
+			err_code = client_disconnect(client, 0);
+		} else {
+			u32_t processed_length = 0;
+
+			client->rx_buf_datalen += data_len;
+
+			processed_length =
+				mqtt_handle_rx_data(client,
+						    client->rx_buf,
+						    client->rx_buf_datalen);
+
+			MQTT_TRC("Processed %d bytes", processed_length);
+
+			if (processed_length > client->rx_buf_datalen) {
+				client_disconnect(client, -EIO);
+				err_code = -EIO;
+			} else {
+				/* Flush data consumed. */
+				client->rx_buf_datalen -= processed_length;
+				if (client->rx_buf_datalen > 0) {
+					memmove(
+					    client->rx_buf,
+					    client->rx_buf + processed_length,
+					    client->rx_buf_datalen);
+				}
+			}
+		}
+	}
+
+	return err_code;
+}
+
+static int client_write(struct mqtt_client *client, const u8_t *data,
+			u32_t datalen)
+{
+	int err_code;
+
+	MQTT_TRC("[%p]: Transport writing %d bytes.", client, datalen);
+
+	MQTT_SET_STATE(client, MQTT_STATE_PENDING_WRITE);
+
+	err_code = mqtt_transport_write(client, data, datalen);
+
+	MQTT_RESET_STATE(client, MQTT_STATE_PENDING_WRITE);
+
+	if (err_code != 0) {
+		MQTT_TRC("TCP write failed, errno = %d, "
+			 "closing connection", errno);
+		client_disconnect(client, err_code);
+		return -EIO;
+	}
+
+	MQTT_TRC("[%p]: Transport write complete.", client);
+	client->last_activity = mqtt_sys_tick_in_ms_get();
+
+	return 0;
+}
+
+int mqtt_init(void)
+{
+	mqtt_mutex_init();
+
+	mqtt_mutex_lock();
+
+	memset(mqtt_client, 0, sizeof(mqtt_client));
+
+	k_mem_slab_init(&mqtt_slab, mqtt_slab_buffer,
+			MQTT_MAX_PACKET_LENGTH, TOTAL_BUFFER_COUNT);
+
+	mqtt_mutex_unlock();
+
+	return 0;
+}
+
+void mqtt_client_init(struct mqtt_client *client)
+{
+	NULL_PARAM_CHECK_VOID(client);
+
+	mqtt_mutex_lock();
+
+	client_init(client);
+
+	mqtt_mutex_unlock();
+}
+
+int mqtt_connect(struct mqtt_client *client)
+{
+	/* Look for a free instance if available. */
+	int err_code;
+	u32_t client_index;
+
+	NULL_PARAM_CHECK(client);
+	NULL_PARAM_CHECK(client->client_id.utf8);
+
+	mqtt_mutex_lock();
+
+	for (client_index = 0; client_index < MQTT_MAX_CLIENTS;
+	     client_index++) {
+		if (mqtt_client[client_index] == NULL) {
+			/* Found a free instance. */
+			mqtt_client[client_index] = client;
+			break;
+		}
+	}
+
+	if ((client_index == MQTT_MAX_CLIENTS) || (client->tx_buf == NULL) ||
+	    (client->rx_buf == NULL)) {
+		client_free(client);
+		err_code = -ENOMEM;
+	} else {
+		err_code = client_connect(client);
+		if (err_code != 0) {
+			/* Free the instance. */
+			client_free(client);
+			mqtt_client[client_index] = NULL;
+			err_code = -ECONNREFUSED;
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	return err_code;
+}
+
+static int verify_tx_state(const struct mqtt_client *client)
+{
+	if (MQTT_VERIFY_STATE(client, MQTT_STATE_PENDING_WRITE)) {
+		return -EBUSY;
+	}
+
+	if (!MQTT_VERIFY_STATE(client, MQTT_STATE_CONNECTED)) {
+		return -ENOTCONN;
+	}
+
+	return 0;
+}
+
+int mqtt_publish(struct mqtt_client *client,
+		 const struct mqtt_publish_param *param)
+{
+	int err_code;
+	const u8_t *packet;
+	u32_t packetlen;
+
+	NULL_PARAM_CHECK(client);
+	NULL_PARAM_CHECK(param);
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Topic size 0x%08x, "
+		 "Data size 0x%08x", client, client->state,
+		 param->message.topic.topic.size,
+		 param->message.payload.len);
+
+	mqtt_mutex_lock();
+
+	err_code = verify_tx_state(client);
+	if (err_code == 0) {
+		err_code = publish_encode(client, param, &packet, &packetlen);
+
+		if (err_code == 0) {
+			err_code = client_write(client, packet, packetlen);
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+			 client, client->state, err_code);
+
+	return err_code;
+}
+
+int mqtt_publish_qos1_ack(struct mqtt_client *client,
+			  const struct mqtt_puback_param *param)
+{
+	int err_code;
+	const u8_t *packet;
+	u32_t packetlen;
+
+	NULL_PARAM_CHECK(client);
+	NULL_PARAM_CHECK(param);
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
+		 client, client->state, param->message_id);
+
+	mqtt_mutex_lock();
+
+	err_code = verify_tx_state(client);
+	if (err_code == 0) {
+		err_code = publish_ack_encode(client, param, &packet,
+					      &packetlen);
+
+		if (err_code == 0) {
+			err_code = client_write(client, packet, packetlen);
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+		 client, client->state, err_code);
+
+	return err_code;
+}
+
+int mqtt_publish_qos2_receive(struct mqtt_client *client,
+			      const struct mqtt_pubrec_param *param)
+{
+	int err_code;
+	const u8_t *packet;
+	u32_t packetlen;
+
+	NULL_PARAM_CHECK(client);
+	NULL_PARAM_CHECK(param);
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
+		 client, client->state, param->message_id);
+
+	mqtt_mutex_lock();
+
+	err_code = verify_tx_state(client);
+	if (err_code == 0) {
+		err_code = publish_receive_encode(client, param, &packet,
+						   &packetlen);
+
+		if (err_code == 0) {
+			err_code = client_write(client, packet, packetlen);
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+		 client, client->state, err_code);
+
+	return err_code;
+}
+
+int mqtt_publish_qos2_release(struct mqtt_client *client,
+			      const struct mqtt_pubrel_param *param)
+{
+	int err_code;
+	const u8_t *packet;
+	u32_t packetlen;
+
+	NULL_PARAM_CHECK(client);
+	NULL_PARAM_CHECK(param);
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
+		 client, client->state, param->message_id);
+
+	mqtt_mutex_lock();
+
+	err_code = verify_tx_state(client);
+	if (err_code == 0) {
+		err_code = publish_release_encode(client, param, &packet,
+						   &packetlen);
+
+		if (err_code == 0) {
+			err_code = client_write(client, packet, packetlen);
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+		 client, client->state, err_code);
+
+	return err_code;
+}
+
+int mqtt_publish_qos2_complete(struct mqtt_client *client,
+			       const struct mqtt_pubcomp_param *param)
+{
+	int err_code;
+	const u8_t *packet;
+	u32_t packetlen;
+
+	NULL_PARAM_CHECK(client);
+	NULL_PARAM_CHECK(param);
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
+		 client, client->state, param->message_id);
+
+	mqtt_mutex_lock();
+
+	err_code = verify_tx_state(client);
+	if (err_code == 0) {
+		err_code = publish_complete_encode(client, param, &packet,
+						   &packetlen);
+
+		if (err_code == 0) {
+			err_code = client_write(client, packet, packetlen);
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+		 client, client->state, err_code);
+
+	return err_code;
+}
+
+int mqtt_disconnect(struct mqtt_client *client)
+{
+	int err_code;
+	const u8_t *packet;
+	u32_t packetlen;
+
+	NULL_PARAM_CHECK(client);
+
+	mqtt_mutex_lock();
+
+	err_code = verify_tx_state(client);
+	if (err_code == 0) {
+		err_code = disconnect_encode(client, &packet, &packetlen);
+
+		if (err_code == 0) {
+			err_code = client_write(client, packet, packetlen);
+		}
+
+		if (err_code == 0) {
+			MQTT_SET_STATE_EXCLUSIVE(client,
+						 MQTT_STATE_DISCONNECTING);
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	return err_code;
+}
+
+int mqtt_subscribe(struct mqtt_client *client,
+		   const struct mqtt_subscription_list *param)
+{
+	int err_code;
+	const u8_t *packet;
+	u32_t packetlen;
+
+	NULL_PARAM_CHECK(client);
+	NULL_PARAM_CHECK(param);
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: >> message id 0x%04x "
+		 "topic count 0x%04x", client, client->state,
+		 param->message_id, param->list_count);
+
+	mqtt_mutex_lock();
+
+	err_code = verify_tx_state(client);
+	if (err_code == 0) {
+		err_code = subscribe_encode(client, param, &packet, &packetlen);
+
+		if (err_code == 0) {
+			err_code = client_write(client, packet, packetlen);
+		}
+	}
+
+	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+		 client, client->state, err_code);
+
+	mqtt_mutex_unlock();
+
+	return err_code;
+}
+
+int mqtt_unsubscribe(struct mqtt_client *client,
+		     const struct mqtt_subscription_list *param)
+{
+	int err_code;
+	const u8_t *packet;
+	u32_t packetlen;
+
+	NULL_PARAM_CHECK(client);
+	NULL_PARAM_CHECK(param);
+
+	mqtt_mutex_lock();
+
+	err_code = verify_tx_state(client);
+	if (err_code == 0) {
+		err_code = unsubscribe_encode(client, param, &packet,
+					      &packetlen);
+
+		if (err_code == 0) {
+			err_code = client_write(client, packet, packetlen);
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	return err_code;
+}
+
+int mqtt_ping(struct mqtt_client *client)
+{
+	int err_code;
+	const u8_t *packet;
+	u32_t packetlen;
+
+	NULL_PARAM_CHECK(client);
+
+	mqtt_mutex_lock();
+
+	err_code = verify_tx_state(client);
+	if (err_code == 0) {
+		err_code = ping_request_encode(client, &packet, &packetlen);
+
+		if (err_code == 0) {
+			err_code = client_write(client, packet, packetlen);
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	return err_code;
+}
+
+int mqtt_abort(struct mqtt_client *client)
+{
+	mqtt_mutex_lock();
+
+	NULL_PARAM_CHECK(client);
+
+	if (client->state != MQTT_STATE_IDLE) {
+		client_abort(client);
+	}
+
+	mqtt_mutex_unlock();
+
+	return 0;
+}
+
+int mqtt_live(void)
+{
+	u32_t elapsed_time;
+	u32_t index;
+
+	mqtt_mutex_lock();
+
+	for (index = 0; index < MQTT_MAX_CLIENTS; index++) {
+		struct mqtt_client *client = mqtt_client[index];
+
+		if (client != NULL) {
+			if (MQTT_VERIFY_STATE(client,
+					      MQTT_STATE_DISCONNECTING)) {
+				client_disconnect(client, 0);
+			} else {
+				elapsed_time = mqtt_elapsed_time_in_ms_get(
+							client->last_activity);
+
+				if ((MQTT_KEEPALIVE > 0) &&
+				    (elapsed_time >= (MQTT_KEEPALIVE * 1000))) {
+					(void)mqtt_ping(client);
+				}
+			}
+		}
+	}
+
+	mqtt_mutex_unlock();
+
+	return 0;
+}
+
+int mqtt_input(struct mqtt_client *client)
+{
+	int err_code;
+
+	NULL_PARAM_CHECK(client);
+
+	mqtt_mutex_lock();
+
+	MQTT_TRC("state:0x%08x", client->state);
+
+	if (MQTT_VERIFY_STATE(client, MQTT_STATE_DISCONNECTING)) {
+		err_code = client_disconnect(client, 0);
+	} else if (MQTT_VERIFY_STATE(client, MQTT_STATE_TCP_CONNECTED)) {
+		err_code = client_read(client);
+	} else {
+		err_code = -EACCES;
+	}
+
+	mqtt_mutex_unlock();
+
+	return err_code;
+}

--- a/subsys/net/lib/mqtt_socket/mqtt_decoder.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_decoder.c
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt_decoder.c
+ *
+ * @brief Decoder functions needed for decoding packets received from the broker.
+ */
+
+#define LOG_MODULE_NAME net_mqtt_dec
+#define NET_LOG_LEVEL CONFIG_MQTT_LOG_LEVEL
+
+#include "mqtt_internal.h"
+#include "mqtt_os.h"
+
+/**
+ * @brief Unpacks unsigned 8 bit value from the buffer from the offset
+ *        requested.
+ *
+ * @param[out] val Memory where the value is to be unpacked.
+ * @param[in] buffer_len Total size of the buffer. This shall not be zero.
+ * @param[in] buffer Buffer from which the value is to be unpacked.
+ * @param[inout] offset Offset on the buffer from where the value is to be
+ *                      unpacked. If the procedure is successful, the offset is
+ *                      incremented to point to the next read/unpack location
+ *                      on the buffer.
+ *
+ * @retval 0 if the procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length.
+ */
+static int unpack_uint8(u8_t *val, u32_t buffer_len, u8_t *buffer,
+			u32_t *offset)
+{
+	int err_code = -EINVAL;
+
+	if (buffer_len > *offset) {
+		const u32_t available_len = buffer_len - *offset;
+
+		MQTT_TRC(">> BL:%08x, B:%p, O:%08x A:%08x", buffer_len, buffer,
+			 *offset, available_len);
+
+		if (available_len >= sizeof(u8_t)) {
+			/* Create unit8 value. */
+			*val = buffer[*offset];
+
+			/* Increment offset. */
+			*offset += sizeof(u8_t);
+
+			/* Indicate success. */
+			err_code = 0;
+		}
+	}
+
+	MQTT_TRC("<< result: 0x%08x val: 0x%02x", err_code, *val);
+
+	return err_code;
+}
+
+/**
+ * @brief Unpacks unsigned 16 bit value from the buffer from the offset
+ *        requested.
+ *
+ * @param[out] val Memory where the value is to be unpacked.
+ * @param[in] buffer_len Total size of the buffer. This shall not be zero.
+ * @param[in] buffer Buffer from which the value is to be unpacked.
+ * @param[inout] offset Offset on the buffer from where the value is to be
+ *                      unpacked. If the procedure is successful, the offset
+ *                      is incremented to point to the next read/unpack location
+ *                      on the buffer.
+ *
+ * @retval 0 if the procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length.
+ */
+static int unpack_uint16(u16_t *val, u32_t buffer_len, u8_t *buffer,
+			 u32_t *offset)
+{
+	int err_code = -EINVAL;
+
+	if (buffer_len > *offset) {
+		const u32_t available_len = buffer_len - *offset;
+
+		MQTT_TRC(">> BL:%08x, B:%p, O:%08x A:%08x", buffer_len, buffer,
+			 *offset, available_len);
+
+		if (available_len >= sizeof(u16_t)) {
+			/* Create unit16 value. */
+			*val = ((buffer[*offset] & 0x00FF) << 8); /* MSB */
+			*val |= (buffer[*offset + 1] & 0x00FF); /* LSB */
+
+			/* Increment offset. */
+			*offset += sizeof(u16_t);
+
+			/* Indicate success. */
+			err_code = 0;
+		}
+	}
+
+	MQTT_TRC("<< result:0x%08x val:0x%04x", err_code, *val);
+
+	return err_code;
+}
+
+/**
+ * @brief Unpacks utf8 string from the buffer from the offset requested.
+ *
+ * @param[out] str Pointer to a string that will hold the string location
+ *                 in the buffer.
+ * @param[in] buffer_len Total size of the buffer. This shall not be zero.
+ * @param[in] buffer Buffer from which the string is to be unpacked.
+ * @param[inout] offset Offset on the buffer from where the value is to be
+ *                      unpacked. If the procedure is successful, the offset
+ *                      is incremented to point to the next read/unpack location
+ *                      on the buffer.
+ *
+ * @retval 0 if the procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length.
+ */
+static int unpack_utf8_str(struct mqtt_utf8 *str, u32_t buffer_len,
+			   u8_t *buffer, u32_t *offset)
+{
+	u16_t utf8_strlen;
+	int err_code;
+
+	err_code = unpack_uint16(&utf8_strlen, buffer_len, buffer, offset);
+
+	str->utf8 = NULL;
+	str->size = 0;
+
+	if (err_code == 0) {
+		const u32_t available_len = buffer_len - *offset;
+
+		MQTT_TRC(">> BL:%08x, B:%p, O:%08x A:%08x", buffer_len, buffer,
+			 *offset, available_len);
+
+		if (utf8_strlen <= available_len) {
+			/* Zero length UTF8 strings permitted. */
+			if (utf8_strlen) {
+				/* Point to right location in buffer. */
+				str->utf8 = &buffer[*offset];
+			}
+
+			/* Populate length field. */
+			str->size = utf8_strlen;
+
+			/* Increment offset. */
+			*offset += utf8_strlen;
+
+			/* Indicate success */
+			err_code = 0;
+		} else {
+			/* Reset to original value. */
+			*offset -= sizeof(u16_t);
+
+			err_code = -EINVAL;
+		}
+	}
+
+	MQTT_TRC("<< result:0x%08x utf8 len:0x%08x", err_code, str->size);
+
+	return err_code;
+}
+
+/**
+ * @brief Unpacks binary string from the buffer from the offset requested.
+ *
+ * @param[out] str Pointer to a binary string that will hold the binary string
+ *                 location in the buffer.
+ * @param[in] buffer_len Total size of the buffer. This shall not be zero.
+ * @param[in] buffer Buffer where the value is to be unpacked.
+ * @param[inout] offset Offset on the buffer from where the value is to be
+ *                      unpacked. If the procedure is successful, the offset
+ *                      is incremented to point to the next read/unpack location
+ *                      on the buffer.
+ *
+ * @retval 0 if the procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length.
+ */
+static int unpack_data(struct mqtt_binstr *str, u32_t buffer_len,
+		       u8_t *buffer, u32_t *offset)
+{
+	int err_code = -EINVAL;
+
+	MQTT_TRC(">> BL:%08x, B:%p, O:%08x ", buffer_len, buffer, *offset);
+
+	if (buffer_len >= *offset) {
+		str->data = NULL;
+		str->len = 0;
+
+		/* Indicate success zero length binary strings are permitted. */
+		err_code = 0;
+
+		const u32_t available_len = buffer_len - *offset;
+
+		if (available_len) {
+			/* Point to start of binary string. */
+			str->data = &buffer[*offset];
+			str->len = available_len;
+
+			/* Increment offset. */
+			*offset += available_len;
+		}
+	}
+
+	MQTT_TRC("<< bin len:0x%08x", str->len);
+
+	return err_code;
+}
+
+int packet_length_decode(u8_t *buffer, u32_t buffer_len,
+			 u32_t *remaining_length, u32_t *offset)
+{
+	u32_t index = *offset;
+	u32_t length = 0;
+	u8_t shift = 0;
+
+	do {
+		if (index >= buffer_len) {
+			return -EINVAL;
+		}
+
+		length += ((u32_t)buffer[index] & MQTT_LENGTH_VALUE_MASK)
+								<< shift;
+		shift += MQTT_LENGTH_SHIFT;
+	} while ((buffer[index++] & MQTT_LENGTH_CONTINUATION_BIT) != 0);
+
+	*offset = index;
+	*remaining_length = length;
+
+	MQTT_TRC("RL:0x%08x RLS:0x%08x", length, index);
+
+	return 0;
+}
+
+int connect_ack_decode(const struct mqtt_client *client, u8_t *data,
+		       u32_t datalen, u32_t offset,
+		       struct mqtt_connack_param *param)
+{
+	int err_code;
+	u8_t flags, ret_code;
+
+	err_code = unpack_uint8(&flags, datalen, data, &offset);
+	if (err_code == 0) {
+		if (client->protocol_version == MQTT_VERSION_3_1_1) {
+			param->session_present_flag =
+				flags & MQTT_CONNACK_FLAG_SESSION_PRESENT;
+
+			MQTT_TRC("[CID %p]: session_present_flag: %d", client,
+				 param->session_present_flag);
+		}
+
+		err_code = unpack_uint8(&ret_code, datalen, data, &offset);
+	}
+
+	if (err_code == 0) {
+		param->return_code = (enum mqtt_conn_return_code)ret_code;
+	}
+
+	return err_code;
+}
+
+int publish_decode(u8_t *data, u32_t datalen, u32_t offset,
+		   struct mqtt_publish_param *param)
+{
+	int err_code;
+
+	param->dup_flag = data[0] & MQTT_HEADER_DUP_MASK;
+	param->retain_flag =
+		data[0] & MQTT_HEADER_RETAIN_MASK;
+	param->message.topic.qos =
+		((data[0] & MQTT_HEADER_QOS_MASK) >> 1);
+
+	err_code = unpack_utf8_str(
+		&param->message.topic.topic,
+		datalen, data, &offset);
+
+	if (err_code == 0) {
+		if (param->message.topic.qos) {
+			err_code = unpack_uint16(&param->message_id,
+						 datalen, data, &offset);
+		}
+	}
+
+	if (err_code == 0) {
+		err_code = unpack_data(&param->message.payload,
+					  datalen, data, &offset);
+
+		/* Zero length publish messages are permitted. */
+		if (err_code != 0) {
+			param->message.payload.data = NULL;
+			param->message.payload.len = 0;
+		}
+	}
+
+	return err_code;
+}
+
+int publish_ack_decode(u8_t *data, u32_t datalen, u32_t offset,
+		       struct mqtt_puback_param *param)
+{
+	return unpack_uint16(&param->message_id, datalen, data, &offset);
+}
+
+int publish_receive_decode(u8_t *data, u32_t datalen, u32_t offset,
+			   struct mqtt_pubrec_param *param)
+{
+	return unpack_uint16(&param->message_id, datalen, data, &offset);
+}
+
+int publish_release_decode(u8_t *data, u32_t datalen, u32_t offset,
+			   struct mqtt_pubrel_param *param)
+{
+	return unpack_uint16(&param->message_id, datalen, data, &offset);
+}
+
+int publish_complete_decode(u8_t *data, u32_t datalen, u32_t offset,
+			    struct mqtt_pubcomp_param *param)
+{
+	return unpack_uint16(&param->message_id, datalen, data, &offset);
+}
+
+int subscribe_ack_decode(u8_t *data, u32_t datalen, u32_t offset,
+			 struct mqtt_suback_param *param)
+{
+	int err_code;
+
+	err_code = unpack_uint16(&param->message_id, datalen, data, &offset);
+
+	if (err_code == 0) {
+		err_code = unpack_data(&param->return_codes, datalen,
+					  data, &offset);
+	}
+
+	return err_code;
+}
+
+int unsubscribe_ack_decode(u8_t *data, u32_t datalen, u32_t offset,
+			   struct mqtt_unsuback_param *param)
+{
+	return unpack_uint16(&param->message_id, datalen, data, &offset);
+}

--- a/subsys/net/lib/mqtt_socket/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_encoder.c
@@ -1,0 +1,793 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt_encoder.c
+ *
+ * @brief Encoding functions needed to create packet to be sent to the broker.
+ */
+
+#define LOG_MODULE_NAME net_mqtt_enc
+#define NET_LOG_LEVEL CONFIG_MQTT_LOG_LEVEL
+
+#include "mqtt_internal.h"
+#include "mqtt_os.h"
+
+#define MQTT_3_1_0_PROTO_DESC_LEN 6
+#define MQTT_3_1_1_PROTO_DESC_LEN 4
+
+static const u8_t mqtt_3_1_0_proto_desc_str[MQTT_3_1_0_PROTO_DESC_LEN] = {
+	'M', 'Q', 'I', 's', 'd', 'p'
+};
+static const u8_t mqtt_3_1_1_proto_desc_str[MQTT_3_1_1_PROTO_DESC_LEN] = {
+	'M', 'Q', 'T', 'T'
+};
+
+static const struct mqtt_utf8 mqtt_3_1_0_proto_desc = {
+	.utf8 = (u8_t *)mqtt_3_1_0_proto_desc_str,
+	.size = MQTT_3_1_0_PROTO_DESC_LEN
+};
+
+static const struct mqtt_utf8 mqtt_3_1_1_proto_desc = {
+	.utf8 = (u8_t *)mqtt_3_1_1_proto_desc_str,
+	.size = MQTT_3_1_1_PROTO_DESC_LEN
+};
+
+/** Never changing ping request, needed for Keep Alive. */
+static const u8_t ping_packet[MQTT_PKT_HEADER_SIZE] = {
+	MQTT_PKT_TYPE_PINGREQ,
+	0x00
+};
+
+/** Never changing disconnect request. */
+static const u8_t disc_packet[MQTT_PKT_HEADER_SIZE] = {
+	MQTT_PKT_TYPE_DISCONNECT,
+	0x00
+};
+
+/**
+ * @brief Packs unsigned 8 bit value to the buffer at the offset requested.
+ *
+ * @param[in] val Value to be packed.
+ * @param[in] buffer_len Total size of the buffer on which value is to be
+ *                       packed. This shall not be zero.
+ * @param[out] buffer Buffer where the value is to be packed.
+ * @param[inout] offset Offset on the buffer where the value is to be packed.
+ *                      If the procedure is successful, the offset is
+ *                      incremented to point to the next write/pack location
+ *                      on the buffer.
+ *
+ * @retval 0 if procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length.
+ */
+static int pack_uint8(u8_t val, u32_t buffer_len, u8_t *buffer,
+		      u32_t *offset)
+{
+	int err_code = -EINVAL;
+
+	if (buffer_len > *offset) {
+		MQTT_TRC(">> V:%02x BL:%08x, B:%p, O:%08x", val, buffer_len,
+			 buffer, *offset);
+
+		/* Pack value. */
+		buffer[*offset] = val;
+
+		/* Increment offset. */
+		*offset += sizeof(u8_t);
+
+		/* Indicate success. */
+		err_code = 0;
+	}
+
+	return err_code;
+}
+
+/**
+ * @brief Packs unsigned 16 bit value to the buffer at the offset requested.
+ *
+ * @param[in] val Value to be packed.
+ * @param[in] buffer_len Total size of the buffer on which value is to be
+ *                       packed. This shall not be zero.
+ * @param[out] buffer Buffer where the value is to be packed.
+ * @param[inout] offset Offset on the buffer where the value is to be packed.
+ *                      If the procedure is successful, the offset is
+ *                      incremented to point to the next write/pack location on
+ *                      the buffer.
+ *
+ * @retval 0 if the procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length
+ *                 minus the size of unsigned 16 bit integer.
+ */
+static int pack_uint16(u16_t val, u32_t buffer_len, u8_t *buffer,
+		       u32_t *offset)
+{
+	int err_code = -EINVAL;
+
+	if (buffer_len > *offset) {
+		const u32_t available_len = buffer_len - *offset;
+
+		MQTT_TRC(">> V:%04x BL:%08x, B:%p, O:%08x A:%08x", val,
+			 buffer_len, buffer, *offset, available_len);
+
+		if (available_len >= sizeof(u16_t)) {
+			/* Pack value. */
+			buffer[*offset] = (val >> 8) & 0xFF;
+			buffer[*offset + 1] = val & 0xFF;
+
+			/* Increment offset. */
+			*offset += sizeof(u16_t);
+
+			/* Indicate success. */
+			err_code = 0;
+		}
+	}
+
+	return err_code;
+}
+
+/**
+ * @brief Packs utf8 string to the buffer at the offset requested.
+ *
+ * @param[in] str UTF-8 string and its length to be packed.
+ * @param[in] buffer_len Total size of the buffer on which string is to be
+ *                       packed. This shall not be zero.
+ * @param[out] buffer Buffer where the string is to be packed.
+ * @param[inout] offset Offset on the buffer where the string is to be packed.
+ *                      If the procedure is successful, the offset is
+ *                      incremented to point to the next write/pack location on
+ *                      the buffer.
+ *
+ * @retval 0 if the procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length
+ *                 minus the size of unsigned 16 bit integer.
+ * @retval -ENOMEM if there is no room on the buffer to pack the string.
+ */
+static int pack_utf8_str(const struct mqtt_utf8 *str, u32_t buffer_len,
+			 u8_t *buffer, u32_t *offset)
+{
+	int err_code = -EINVAL;
+
+	if (buffer_len > *offset) {
+		const u32_t available_len = buffer_len - *offset;
+
+		MQTT_TRC(">> USL:%08x BL:%08x, B:%p, O:%08x A:%08x",
+			 GET_UT8STR_BUFFER_SIZE(str), buffer_len,
+			 buffer, *offset, available_len);
+
+		if (available_len >= GET_UT8STR_BUFFER_SIZE(str)) {
+			/* Length followed by string. */
+			err_code = pack_uint16(str->size, buffer_len,
+					       buffer, offset);
+
+			if (err_code == 0) {
+				memcpy(&buffer[*offset], str->utf8,
+				       str->size);
+
+				*offset += str->size;
+			}
+		} else {
+			err_code = -ENOMEM;
+		}
+	}
+
+	return err_code;
+}
+
+/**
+ * @brief Packs binary string to the buffer at the offset requested.
+ *
+ * @param[in] str Binary string and its length to be packed.
+ * @param[in] buffer_len Total size of the buffer on which string is to be
+ *                       packed.
+ * @param[in] buffer Buffer where the string is to be packed.
+ * @param[inout] offset Offset on the buffer where the string is to be packed.
+ *                      If the procedure is successful, the offset is
+ *                      incremented to point to the next write/pack location on
+ *                      the buffer.
+ *
+ * @retval 0 if the procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length.
+ * @retval -ENOMEM if there is no room on the buffer to pack the string.
+ */
+static int pack_data(const struct mqtt_binstr *str, u32_t buffer_len,
+		     u8_t *buffer, u32_t *offset)
+{
+	int err_code = -EINVAL;
+
+	if (buffer_len > *offset) {
+		const u32_t available_len = buffer_len - *offset;
+
+		MQTT_TRC(">> BSL:%08x BL:%08x, B:%p, O:%08x A:%08x",
+			 GET_BINSTR_BUFFER_SIZE(str), buffer_len,
+			 buffer, *offset, available_len);
+
+		if (available_len >= GET_BINSTR_BUFFER_SIZE(str)) {
+			memcpy(&buffer[*offset], str->data,
+			       str->len);
+
+			*offset += str->len;
+			err_code = 0;
+		} else {
+			err_code = -ENOMEM;
+		}
+	}
+
+	return err_code;
+}
+
+/**
+ * @brief Computes and encodes length for the MQTT fixed header.
+ *
+ * @note The remaining length is not packed as a fixed unsigned 32 bit integer.
+ *       Instead it is packed on algorithm below:
+ *
+ * @code
+ * do
+ *            encodedByte = X MOD 128
+ *            X = X DIV 128
+ *            // if there are more data to encode, set the top bit of this byte
+ *            if ( X > 0 )
+ *                encodedByte = encodedByte OR 128
+ *            endif
+ *                'output' encodedByte
+ *       while ( X > 0 )
+ * @endcode
+ *
+ * @param[in] remaining_length Length of variable header and payload in the
+ *                             MQTT message.
+ * @param[out] buffer Buffer where the length is to be packed.
+ * @param[inout] offset Offset on the buffer where the length is to be packed.
+ */
+static void packet_length_encode(u32_t remaining_length, u8_t *buff,
+				 u32_t *size)
+{
+	u16_t index = 0;
+	const u32_t offset = *size;
+
+	MQTT_TRC(">> RL:0x%08x O:%08x P:%p", remaining_length, offset, buff);
+
+	do {
+		if (buff != NULL) {
+			buff[offset + index] = remaining_length &
+							MQTT_LENGTH_VALUE_MASK;
+		}
+
+		remaining_length >>= MQTT_LENGTH_SHIFT;
+		if (remaining_length > 0) {
+			if (buff != NULL) {
+				buff[offset + index] |=
+						MQTT_LENGTH_CONTINUATION_BIT;
+			}
+		}
+
+		index++;
+
+	} while (remaining_length > 0);
+
+	MQTT_TRC("<< RLS:0x%08x", index);
+
+	*size += index;
+}
+
+/**
+ * @brief Encodes fixed header for the MQTT message and provides pointer to
+ *        start of the header.
+ *
+ * @param[in] message_type Message type containing packet type and the flags.
+ *                         Use @ref MQTT_MESSAGES_OPTIONS to construct the
+ *                         message_type.
+ * @param[in] length Length of the encoded variable header and payload.
+ * @param[inout] packet Pointer to the MQTT message variable header and payload.
+ *                      The 5 bytes before the start of the message are assumed
+ *                      by the routine to be available to pack the fixed header.
+ *                      However, since the fixed header length is variable
+ *                      length, the pointer to the start of the MQTT message
+ *                      along with encoded fixed header is supplied as output
+ *                      parameter if the procedure was successful.
+ *
+ * @retval 0xFFFFFFFF if the procedure failed, else length of total MQTT message
+ *                    along with the fixed header.
+ */
+static u32_t mqtt_encode_fixed_header(u8_t message_type, u32_t length,
+				      u8_t **packet)
+{
+	u32_t packet_length = 0xFFFFFFFF;
+
+	if (length <= MQTT_MAX_PAYLOAD_SIZE) {
+		u32_t offset = 1;
+
+		MQTT_TRC("<< MT:0x%02x L:0x%08x", message_type, length);
+		packet_length_encode(length, NULL, &offset);
+
+		MQTT_TRC("Remaining length size = %02x", offset);
+
+		u8_t *mqtt_header = *packet - offset;
+
+		/* Reset offset. */
+		offset = 0;
+		(void)pack_uint8(message_type, MQTT_MAX_PACKET_LENGTH,
+				 mqtt_header, &offset);
+		packet_length_encode(length, mqtt_header, &offset);
+
+		*packet = mqtt_header;
+
+		packet_length = (length + offset);
+	}
+
+	return packet_length;
+}
+
+/**
+ * @brief Encodes a string of a zero length.
+ *
+ * @param[in] buffer_len Total size of the buffer on which string will be
+ *                       encoded. This shall not be zero.
+ * @param[out] buffer Buffer where the string is to be encoded.
+ * @param[inout] offset Offset on the buffer where the string is to be encoded.
+ *                      If the procedure is successful, the offset is
+ *                      incremented to point to the next write/pack location on
+ *                      the buffer.
+ *
+ * @retval 0 if the procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length.
+ */
+static int zero_len_str_encode(u32_t buffer_len, u8_t *buffer,
+			       u32_t *offset)
+{
+	return pack_uint16(0x0000, buffer_len, buffer, offset);
+}
+
+/**
+ * @brief Encodes and sends messages that contain only message id in
+ *        the variable header.
+ *
+ * @param[in] client Identifies the client for which the procedure is requested.
+ * @param[in] message_type Message type and reserved bit fields.
+ * @param[in] message_id Message id to be encoded in the variable header.
+ * @param[out] packet A pointer to store a pointer to encoded message.
+ * @param[out] packet_length A pointer to store message length.
+ * @retval 0 or an error code indicating a reason for failure.
+ */
+static int mqtt_message_id_only_enc(const struct mqtt_client *client,
+				    u8_t message_type, u16_t message_id,
+				    const u8_t **packet, u32_t *packet_length)
+{
+	int err_code = -ENOTCONN;
+	u32_t offset = 0;
+	u32_t mqtt_packetlen = 0;
+	u8_t *payload;
+
+	/* Message id zero is not permitted by spec. */
+	if (message_id == 0) {
+		return -EINVAL;
+	}
+
+	payload = &client->tx_buf[MQTT_FIXED_HEADER_EXTENDED_SIZE];
+	memset(payload, 0, MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD);
+
+	err_code = pack_uint16(message_id,
+			       MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+			       payload, &offset);
+
+	if (err_code == 0) {
+		mqtt_packetlen = mqtt_encode_fixed_header(message_type,
+							  offset,
+							  &payload);
+
+		*packet_length = mqtt_packetlen;
+		*packet = payload;
+	} else {
+		*packet_length = 0;
+		*packet = NULL;
+	}
+
+	return err_code;
+}
+
+int connect_request_encode(const struct mqtt_client *client,
+			   const u8_t **packet, u32_t *packet_length)
+{
+	u32_t offset = 0;
+	u8_t *payload = &client->tx_buf[MQTT_FIXED_HEADER_EXTENDED_SIZE];
+	/* Clean session always. */
+	u8_t connect_flags = client->clean_session << 1;
+	int err_code;
+	const struct mqtt_utf8 *mqtt_proto_desc;
+
+	if (client->protocol_version == MQTT_VERSION_3_1_1) {
+		mqtt_proto_desc = &mqtt_3_1_1_proto_desc;
+	} else {
+		mqtt_proto_desc = &mqtt_3_1_0_proto_desc;
+	}
+
+	memset(payload, 0, MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD);
+
+	/* Pack protocol description. */
+	MQTT_TRC("Encoding Protocol Description. Str:%s Size:%08x.",
+		 mqtt_proto_desc->utf8, mqtt_proto_desc->size);
+
+	err_code = pack_utf8_str(
+		mqtt_proto_desc, MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+		payload, &offset);
+	if (err_code == 0) {
+		MQTT_TRC("Encoding Protocol Version %02x.",
+			 client->protocol_version);
+		/* Pack protocol version. */
+		err_code = pack_uint8(client->protocol_version,
+				      MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+				      payload, &offset);
+	}
+
+	/* Remember position of connect flag and leave one byte for it to
+	 * be packed once we determine its value.
+	 */
+	const u32_t connect_flag_offset =
+		MQTT_FIXED_HEADER_EXTENDED_SIZE + offset;
+	offset++;
+
+	if (err_code == 0) {
+		MQTT_TRC("Encoding Keep Alive Time %04x.", MQTT_KEEPALIVE);
+		/* Pack keep alive time. */
+		err_code = pack_uint16(MQTT_KEEPALIVE,
+				       MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+				       payload, &offset);
+	}
+
+	if (err_code == 0) {
+		MQTT_TRC("Encoding Client Id. Str:%s Size:%08x.",
+			 client->client_id.utf8,
+			 client->client_id.size);
+
+		/* Pack client id */
+		err_code = pack_utf8_str(&client->client_id,
+					 MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+					 payload, &offset);
+	}
+
+	if (err_code == 0) {
+		/* Pack will topic and QoS */
+		if (client->will_topic != NULL) {
+			MQTT_TRC("Encoding Will Topic. Str:%s Size:%08x.",
+				 client->will_topic->topic.utf8,
+				 client->will_topic->topic.size);
+
+			/* Set Will topic in connect flags. */
+			connect_flags |= MQTT_CONNECT_FLAG_WILL_TOPIC;
+
+			err_code = pack_utf8_str(
+				&client->will_topic->topic,
+				MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+				payload, &offset);
+
+			if (err_code == 0) {
+				/* QoS is always 1 as of now. */
+				connect_flags |=
+					((client->will_topic->qos & 0x03) << 3);
+				connect_flags |= client->will_retain << 5;
+
+				if (client->will_message != NULL) {
+					MQTT_TRC(
+					    "Encoding Will Message. "
+					    "Str:%s Size:%08x.",
+					    client->will_message->utf8,
+					    client->will_message->size);
+
+					err_code = pack_utf8_str(
+					    client->will_message,
+					    MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+					    payload, &offset);
+				} else {
+					MQTT_TRC("Encoding Zero Length Will "
+						 "Message.");
+					err_code = zero_len_str_encode(
+					    MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+					    payload, &offset);
+				}
+			}
+		}
+	}
+
+	if (err_code == 0) {
+		/* Pack Username if any. */
+		if (client->user_name != NULL) {
+			connect_flags |= MQTT_CONNECT_FLAG_USERNAME;
+
+			MQTT_TRC("Encoding Username. Str:%s, Size:%08x.",
+				 client->user_name->utf8,
+				 client->user_name->size);
+
+			err_code = pack_utf8_str(
+				client->user_name,
+				MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+				payload, &offset);
+
+			if (err_code == 0) {
+				/* Pack Password if any. */
+				if (client->password != NULL) {
+					MQTT_TRC("Encoding Password. "
+						 "Str:%s Size:%08x.",
+						 client->password->utf8,
+						 client->password->size);
+
+					connect_flags |=
+						MQTT_CONNECT_FLAG_PASSWORD;
+					err_code = pack_utf8_str(
+					    client->password,
+					    MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+					    payload, &offset);
+				}
+			}
+		}
+	}
+
+	if (err_code == 0) {
+		u8_t connect_pkt_qos = MQTT_QOS_0_AT_MOST_ONCE;
+
+		if (client->protocol_version == MQTT_VERSION_3_1_0) {
+			connect_pkt_qos = MQTT_QOS_1_AT_LEAST_ONCE;
+		}
+
+		/* Pack the connect flags. */
+		client->tx_buf[connect_flag_offset] = connect_flags;
+
+		const u8_t message_type = MQTT_MESSAGES_OPTIONS(
+			MQTT_PKT_TYPE_CONNECT,
+			0, connect_pkt_qos, 0);
+
+		offset = mqtt_encode_fixed_header(message_type, offset,
+						  &payload);
+
+		*packet_length = offset;
+		*packet = payload;
+	} else {
+		*packet_length = 0;
+		*packet = NULL;
+	}
+
+	return err_code;
+}
+
+int publish_encode(const struct mqtt_client *client,
+		   const struct mqtt_publish_param *param,
+		   const u8_t **packet, u32_t *packet_length)
+{
+	int err_code = -ENOTCONN;
+	u32_t offset = 0;
+	u32_t mqtt_packetlen = 0;
+	u8_t *payload;
+
+	/* Message id zero is not permitted by spec. */
+	if ((param->message.topic.qos) && (param->message_id == 0)) {
+		return -EINVAL;
+	}
+
+	payload = &client->tx_buf[MQTT_FIXED_HEADER_EXTENDED_SIZE];
+	memset(payload, 0, MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD);
+
+	/* Pack topic. */
+	err_code = pack_utf8_str(&param->message.topic.topic,
+				 MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+				 payload, &offset);
+
+	if (err_code == 0) {
+		if (param->message.topic.qos) {
+			err_code = pack_uint16(
+				param->message_id,
+				MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+				payload, &offset);
+		}
+	}
+
+	if (err_code == 0) {
+		/* Pack message on the topic. */
+		err_code = pack_data(&param->message.payload,
+					MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+					payload, &offset);
+	}
+
+	if (err_code == 0) {
+		const u8_t message_type = MQTT_MESSAGES_OPTIONS(
+			MQTT_PKT_TYPE_PUBLISH, param->dup_flag,
+			param->message.topic.qos, param->retain_flag);
+
+		mqtt_packetlen = mqtt_encode_fixed_header(message_type,
+							  offset,
+							  &payload);
+
+		*packet_length = mqtt_packetlen;
+		*packet = payload;
+	} else {
+		*packet_length = 0;
+		*packet = NULL;
+	}
+
+	return err_code;
+}
+
+int publish_ack_encode(const struct mqtt_client *client,
+		       const struct mqtt_puback_param *param,
+		       const u8_t **packet, u32_t *packet_length)
+{
+	const u8_t message_type =
+		MQTT_MESSAGES_OPTIONS(MQTT_PKT_TYPE_PUBACK, 0, 0, 0);
+
+	return mqtt_message_id_only_enc(client, message_type, param->message_id,
+					packet, packet_length);
+}
+
+int publish_receive_encode(const struct mqtt_client *client,
+			   const struct mqtt_pubrec_param *param,
+			   const u8_t **packet, u32_t *packet_length)
+{
+	const u8_t message_type =
+		MQTT_MESSAGES_OPTIONS(MQTT_PKT_TYPE_PUBREC, 0, 0, 0);
+
+	return mqtt_message_id_only_enc(client, message_type, param->message_id,
+					packet, packet_length);
+}
+
+int publish_release_encode(const struct mqtt_client *client,
+			   const struct mqtt_pubrel_param *param,
+			   const u8_t **packet, u32_t *packet_length)
+{
+	const u8_t message_type =
+		MQTT_MESSAGES_OPTIONS(MQTT_PKT_TYPE_PUBREL, 0, 1, 0);
+
+	return mqtt_message_id_only_enc(client, message_type, param->message_id,
+					packet, packet_length);
+}
+
+int publish_complete_encode(const struct mqtt_client *client,
+			    const struct mqtt_pubcomp_param *param,
+			    const u8_t **packet, u32_t *packet_length)
+{
+	const u8_t message_type =
+		MQTT_MESSAGES_OPTIONS(MQTT_PKT_TYPE_PUBCOMP, 0, 0, 0);
+
+	return mqtt_message_id_only_enc(client, message_type, param->message_id,
+					packet, packet_length);
+}
+
+int disconnect_encode(const struct mqtt_client *client, const u8_t **packet,
+		      u32_t *packet_length)
+{
+	(void)client;
+
+	*packet = disc_packet;
+	*packet_length = sizeof(disc_packet);
+
+	return 0;
+}
+
+int subscribe_encode(const struct mqtt_client *client,
+		     const struct mqtt_subscription_list *param,
+		     const u8_t **packet, u32_t *packet_length)
+{
+	int err_code;
+	u32_t offset = 0;
+	u32_t count = 0;
+	u32_t mqtt_packetlen = 0;
+	u8_t *payload;
+
+	/* Message id zero is not permitted by spec. */
+	if (param->message_id == 0) {
+		return -EINVAL;
+	}
+
+	payload = &client->tx_buf[MQTT_FIXED_HEADER_EXTENDED_SIZE];
+	memset(payload, 0, MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD);
+
+	err_code = pack_uint16(param->message_id,
+			       MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+			       payload, &offset);
+	if (err_code == 0) {
+		do {
+			err_code = pack_utf8_str(
+				&param->list[count].topic,
+				MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+				payload, &offset);
+			if (err_code == 0) {
+				err_code = pack_uint8(
+				    param->list[count].qos,
+				    MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+				    payload, &offset);
+			}
+			count++;
+		} while ((err_code == 0) &&
+			 (count < param->list_count));
+	}
+
+	if (err_code == 0) {
+		const u8_t message_type = MQTT_MESSAGES_OPTIONS(
+			MQTT_PKT_TYPE_SUBSCRIBE, 0, 1, 0);
+
+		/* Rewind the packet to encode the packet correctly. */
+		mqtt_packetlen = mqtt_encode_fixed_header(message_type,
+							  offset,
+							  &payload);
+	}
+
+	if (err_code == 0) {
+		*packet_length = mqtt_packetlen;
+		*packet = payload;
+	} else {
+		*packet_length = 0;
+		*packet = NULL;
+	}
+
+	return err_code;
+}
+
+int unsubscribe_encode(const struct mqtt_client *client,
+		       const struct mqtt_subscription_list *param,
+		       const u8_t **packet, u32_t *packet_length)
+{
+	int err_code;
+	u32_t count = 0;
+	u32_t offset = 0;
+	u32_t mqtt_packetlen = 0;
+	u8_t *payload;
+
+	payload = &client->tx_buf[MQTT_FIXED_HEADER_EXTENDED_SIZE];
+	memset(payload, 0, MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD);
+
+	err_code = pack_uint16(param->message_id,
+			       MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+			       payload,
+			       &offset);
+
+	if (err_code == 0) {
+		do {
+			err_code = pack_utf8_str(
+				&param->list[count].topic,
+				MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD,
+				payload, &offset);
+			count++;
+		} while ((err_code == 0) &&
+			 (count < param->list_count));
+	}
+
+	if (err_code == 0) {
+		const u8_t message_type =
+			MQTT_MESSAGES_OPTIONS(MQTT_PKT_TYPE_UNSUBSCRIBE,
+					      0,
+					      MQTT_QOS_1_AT_LEAST_ONCE,
+					      0);
+
+		/* Rewind the packet to encode the packet correctly. */
+		mqtt_packetlen = mqtt_encode_fixed_header(
+			/* Message type, Duplicate Flag, QoS and
+			 * retain flag setting.
+			 */
+			message_type,
+			/* Payload size without the fixed header */
+			offset,
+			/* Address where the payload is contained.
+			 * Header will encoded by rewinding the location
+			 */
+			&payload);
+	}
+
+	if (err_code == 0) {
+		*packet_length = mqtt_packetlen;
+		*packet = payload;
+	} else {
+		*packet_length = 0;
+		*packet = NULL;
+	}
+
+	return err_code;
+}
+
+int ping_request_encode(const struct mqtt_client *client, const u8_t **packet,
+			u32_t *packet_length)
+{
+	(void)client;
+
+	*packet = ping_packet;
+	*packet_length = sizeof(ping_packet);
+
+	return 0;
+}

--- a/subsys/net/lib/mqtt_socket/mqtt_internal.h
+++ b/subsys/net/lib/mqtt_socket/mqtt_internal.h
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt_internal.h
+ *
+ * @brief Function and data structures internal to MQTT module.
+ */
+
+#ifndef MQTT_INTERNAL_H_
+#define MQTT_INTERNAL_H_
+
+#include <stdint.h>
+#include <string.h>
+
+#include <net/mqtt_socket.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@brief Maximum number of clients that can be managed by the module. */
+#define MQTT_MAX_CLIENTS CONFIG_MQTT_MAX_CLIENTS
+
+/**@brief Keep alive time for MQTT (in seconds). Sending of Ping Requests to
+ *        keep the connection alive are governed by this value.
+ */
+#define MQTT_KEEPALIVE CONFIG_MQTT_KEEPALIVE
+
+/**@brief Maximum MQTT packet size that can be sent (including the fixed and
+ *        variable header).
+ */
+#define MQTT_MAX_PACKET_LENGTH CONFIG_MQTT_MAX_PACKET_LENGTH
+
+/**@brief Fixed header minimum size. Remaining length size is 1 in this case. */
+#define MQTT_FIXED_HEADER_SIZE 2
+
+/**@brief Maximum size of the fixed header. Remaining length size is 4 in this
+ *        case.
+ */
+#define MQTT_FIXED_HEADER_EXTENDED_SIZE 5
+
+/**@brief MQTT Control Packet Types. */
+#define MQTT_PKT_TYPE_CONNECT     0x10
+#define MQTT_PKT_TYPE_CONNACK     0x20
+#define MQTT_PKT_TYPE_PUBLISH     0x30
+#define MQTT_PKT_TYPE_PUBACK      0x40
+#define MQTT_PKT_TYPE_PUBREC      0x50
+#define MQTT_PKT_TYPE_PUBREL      0x60
+#define MQTT_PKT_TYPE_PUBCOMP     0x70
+#define MQTT_PKT_TYPE_SUBSCRIBE   0x82 /* QoS 1 for subscribe */
+#define MQTT_PKT_TYPE_SUBACK      0x90
+#define MQTT_PKT_TYPE_UNSUBSCRIBE 0xA2
+#define MQTT_PKT_TYPE_UNSUBACK    0xB0
+#define MQTT_PKT_TYPE_PINGREQ     0xC0
+#define MQTT_PKT_TYPE_PINGRSP     0xD0
+#define MQTT_PKT_TYPE_DISCONNECT  0xE0
+
+/**@brief Masks for MQTT header flags. */
+#define MQTT_HEADER_DUP_MASK     0x08
+#define MQTT_HEADER_QOS_MASK     0x06
+#define MQTT_HEADER_RETAIN_MASK  0x01
+
+
+/**@brief Masks for MQTT header flags. */
+#define MQTT_CONNECT_FLAG_CLEAN_SESSION   0x02
+#define MQTT_CONNECT_FLAG_WILL_TOPIC      0x04
+#define MQTT_CONNECT_FLAG_WILL_RETAIN     0x20
+#define MQTT_CONNECT_FLAG_PASSWORD        0x40
+#define MQTT_CONNECT_FLAG_USERNAME        0x80
+
+#define MQTT_CONNACK_FLAG_SESSION_PRESENT 0x01
+
+/**@brief Size of mandatory header of MQTT packet. */
+#define MQTT_PKT_HEADER_SIZE 2
+
+/**@brief Maximum payload size of MQTT packet. */
+#define MQTT_MAX_PAYLOAD_SIZE 0x0FFFFFFF
+
+/**@brief Maximum size of variable and payload in the packet. */
+#define MQTT_MAX_VARIABLE_HEADER_N_PAYLOAD \
+	(MQTT_MAX_PACKET_LENGTH - MQTT_FIXED_HEADER_EXTENDED_SIZE)
+
+/**@brief Computes total size needed to pack a UTF8 string. */
+#define GET_UT8STR_BUFFER_SIZE(STR) (sizeof(u16_t) + (STR)->size)
+
+/**@brief Computes total size needed to pack a binary stream. */
+#define GET_BINSTR_BUFFER_SIZE(STR) ((STR)->len)
+
+/**@brief Unsubscribe packet size. */
+#define MQTT_UNSUBSCRIBE_PKT_SIZE 4
+
+/**@brief Sets MQTT Client's state with one indicated in 'STATE'. */
+#define MQTT_SET_STATE(CLIENT, STATE) ((CLIENT)->state |= (STATE))
+
+/**@brief Sets MQTT Client's state exclusive to 'STATE'. */
+#define MQTT_SET_STATE_EXCLUSIVE(CLIENT, STATE) ((CLIENT)->state = (STATE))
+
+/**@brief Verifies if MQTT Client's state is set with one indicated in 'STATE'.
+ */
+#define MQTT_VERIFY_STATE(CLIENT, STATE) ((CLIENT)->state & (STATE))
+
+/**@brief Reset 'STATE' in MQTT Client's state. */
+#define MQTT_RESET_STATE(CLIENT, STATE) ((CLIENT)->state &= ~(STATE))
+
+/**@brief Initialize MQTT Client's state. */
+#define MQTT_STATE_INIT(CLIENT) ((CLIENT)->state = MQTT_STATE_IDLE)
+
+/**@brief Computes the first byte of MQTT message header based on message type,
+ *        duplication flag, QoS and  the retain flag.
+ */
+#define MQTT_MESSAGES_OPTIONS(TYPE, DUP, QOS, RETAIN) \
+	(((TYPE)      & 0xF0)  | \
+	 (((DUP) << 3) & 0x08) | \
+	 (((QOS) << 1) & 0x06) | \
+	 ((RETAIN) & 0x01))
+
+
+#define MQTT_EVT_FLAG_NONE 0x00000000
+#define MQTT_EVT_FLAG_INSTANCE_RESET 0x00000001
+
+#define MQTT_LENGTH_VALUE_MASK 0x7F
+#define MQTT_LENGTH_CONTINUATION_BIT 0x80
+#define MQTT_LENGTH_SHIFT 7
+
+/**@brief Check if the input pointer is NULL, if so it returns -EINVAL. */
+#define NULL_PARAM_CHECK(param) \
+	do { \
+		if ((param) == NULL) { \
+			return -EINVAL; \
+		} \
+	} while (0)
+
+#define NULL_PARAM_CHECK_VOID(param) \
+	do { \
+		if ((param) == NULL) { \
+			return; \
+		} \
+	} while (0)
+
+/**@brief MQTT States. */
+enum mqtt_state {
+	/** Idle state, implying the client entry in the table is unused/free.
+	 */
+	MQTT_STATE_IDLE                 = 0x00000000,
+
+	/** TCP Connection has been requested, awaiting result of the request.
+	 */
+	MQTT_STATE_TCP_CONNECTING       = 0x00000001,
+
+	/** TCP Connection successfully established. */
+	MQTT_STATE_TCP_CONNECTED        = 0x00000002,
+
+	/** MQTT Connection successful. */
+	MQTT_STATE_CONNECTED            = 0x00000004,
+
+	/** State that indicates write callback is awaited for an issued
+	 *  request.
+	 */
+	MQTT_STATE_PENDING_WRITE        = 0x00000008,
+
+	/** TCP Disconnect has been requested, awaiting result of the request.
+	 */
+	MQTT_STATE_DISCONNECTING        = 0x00000010
+};
+
+/**@brief Notify application about MQTT event.
+ *
+ * @param[in] client Identifies the client for which event occurred.
+ * @param[in] evt MQTT event.
+ * @param[in] flags MQTT event flags.
+ */
+void event_notify(struct mqtt_client *client, const struct mqtt_evt *evt,
+		  u32_t flags);
+
+/**@brief Handles MQTT messages received from the peer. For TLS, this routine
+ *        is evoked to handle decrypted application data. For TCP, this routine
+ *        is evoked to handle TCP data.
+ *
+ * @param[in] client Identifies the client for which the data was received.
+ * @param[in] data MQTT data received.
+ * @param[in] datalen Length of data received.
+ *
+ * @retval Number of bytes processed from the incoming packet.
+ */
+u32_t mqtt_handle_rx_data(struct mqtt_client *client, u8_t *data,
+			  u32_t datalen);
+
+/**@brief Constructs/encodes Connect packet.
+ *
+ * @param[in] client Identifies the client for which the procedure is requested.
+ *                   All information required for creating the packet like
+ *                   client id, clean session flag, retain session flag etc are
+ *                   assumed to be populated for the client instance when this
+ *                   procedure is requested.
+ * @param[out] packet Pointer to the MQTT connect message.
+ * @param[out] packet_length Length of the connect request.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int connect_request_encode(const struct mqtt_client *client,
+			   const u8_t **packet, u32_t *packet_length);
+
+/**@brief Constructs/encodes Publish packet.
+ *
+ * @param[in] client Identifies the client for which packet is encoded.
+   @param[in] param Publish message parameters.
+ * @param[out] packet Pointer to the MQTT Publish message.
+ * @param[out] packet_length Length of the Publish message.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_encode(const struct mqtt_client *client,
+		   const struct mqtt_publish_param *param,
+		   const u8_t **packet, u32_t *packet_length);
+
+/**@brief Constructs/encodes Publish Ack packet.
+ *
+ * @param[in] client Identifies the client for which packet is encoded.
+   @param[in] param Publish Ack message parameters.
+ * @param[out] packet Pointer to the MQTT Publish Ack message.
+ * @param[out] packet_length Length of the Publish Ack message.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_ack_encode(const struct mqtt_client *client,
+		       const struct mqtt_puback_param *param,
+		       const u8_t **packet, u32_t *packet_length);
+
+/**@brief Constructs/encodes Publish Receive packet.
+ *
+ * @param[in] client Identifies the client for which packet is encoded.
+   @param[in] param Publish Receive message parameters.
+ * @param[out] packet Pointer to the MQTT Publish Receive message.
+ * @param[out] packet_length Length of the Publish Receive message.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_receive_encode(const struct mqtt_client *client,
+			   const struct mqtt_pubrec_param *param,
+			   const u8_t **packet, u32_t *packet_length);
+
+/**@brief Constructs/encodes Publish Release packet.
+ *
+ * @param[in] client Identifies the client for which packet is encoded.
+   @param[in] param Publish Release message parameters.
+ * @param[out] packet Pointer to the MQTT Publish Release message.
+ * @param[out] packet_length Length of the Publish Relase message.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_release_encode(const struct mqtt_client *client,
+			   const struct mqtt_pubrel_param *param,
+			   const u8_t **packet, u32_t *packet_length);
+
+/**@brief Constructs/encodes Publish Complete packet.
+ *
+ * @param[in] client Identifies the client for which packet is encoded.
+   @param[in] param Publish Complete message parameters.
+ * @param[out] packet Pointer to the MQTT Publish Complete message.
+ * @param[out] packet_length Length of the Publish Complete message.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_complete_encode(const struct mqtt_client *client,
+			    const struct mqtt_pubcomp_param *param,
+			    const u8_t **packet, u32_t *packet_length);
+
+/**@brief Constructs/encodes Disconnect packet.
+ *
+ * @param[in] client Identifies the client for which packet is encoded.
+ * @param[out] packet Pointer to the MQTT Disconnect message.
+ * @param[out] packet_length Length of the Disconnect message.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int disconnect_encode(const struct mqtt_client *client,
+		      const u8_t **packet, u32_t *packet_length);
+
+/**@brief Constructs/encodes Subscribe packet.
+ *
+ * @param[in] client Identifies the client for which packet is encoded.
+   @param[in] param Subscribe message parameters.
+ * @param[out] packet Pointer to the MQTT Subscribe message.
+ * @param[out] packet_length Length of the Subscribe message.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int subscribe_encode(const struct mqtt_client *client,
+		     const struct mqtt_subscription_list *param,
+		     const u8_t **packet, u32_t *packet_length);
+
+/**@brief Constructs/encodes Unsubscribe packet.
+ *
+ * @param[in] client Identifies the client for which packet is encoded.
+   @param[in] param Unsubscribe message parameters.
+ * @param[out] packet Pointer to the MQTT Unsubscribe message.
+ * @param[out] packet_length Length of the Unsubscribe message.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int unsubscribe_encode(const struct mqtt_client *client,
+		       const struct mqtt_subscription_list *param,
+		       const u8_t **packet, u32_t *packet_length);
+
+/**@brief Constructs/encodes Ping Request packet.
+ *
+ * @param[in] client Identifies the client for which packet is encoded.
+   @param[in] param Ping Request message parameters.
+ * @param[out] packet Pointer to the MQTT Ping Request message.
+ * @param[out] packet_length Length of the Ping Request message.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int ping_request_encode(const struct mqtt_client *client,
+			const u8_t **packet, u32_t *packet_length);
+
+/**@brief Decode MQTT Packet Length in the MQTT fixed header.
+ *
+ * @param[in] buffer Buffer where the length is to be decoded.
+ * @param[in] buffer_len Length of buffer.
+ * @param[out] remaining_length Length of variable header and payload in the
+ *                              MQTT message.
+ * @param[inout] offset Offset on the buffer from where the length is to be
+ *                      unpacked.
+ *
+ * @retval 0 if the procedure is successful.
+ * @retval -EINVAL if the offset is greater than or equal to the buffer length.
+ */
+int packet_length_decode(u8_t *buffer, u32_t buffer_len,
+			 u32_t *remaining_length, u32_t *offset);
+
+/**@brief Decode MQTT Connect Ack packet.
+ *
+ * @param[in] client MQTT client for which packet is decoded.
+ * @param[in] data Buffer containing message to decode.
+ * @param[in] datalen Length of the message.
+ * @param[in] offset Offset of the first byte after MQTT fixed header.
+ * @param[out] param Pointer to buffer for decoded Connect Ack parameters.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int connect_ack_decode(const struct mqtt_client *client, u8_t *data,
+		       u32_t datalen, u32_t offset,
+		       struct mqtt_connack_param *param);
+
+/**@brief Decode MQTT Publish packet.
+ *
+ * @param[in] data Buffer containing message to decode.
+ * @param[in] datalen Length of the message.
+ * @param[in] offset Offset of the first byte after MQTT fixed header.
+ * @param[out] param Pointer to buffer for decoded Publish parameters.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_decode(u8_t *data, u32_t datalen, u32_t offset,
+		   struct mqtt_publish_param *param);
+
+/**@brief Decode MQTT Publish Ack packet.
+ *
+ * @param[in] data Buffer containing message to decode.
+ * @param[in] datalen Length of the message.
+ * @param[in] offset Offset of the first byte after MQTT fixed header.
+ * @param[out] param Pointer to buffer for decoded Publish Ack parameters.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_ack_decode(u8_t *data, u32_t datalen, u32_t offset,
+		       struct mqtt_puback_param *param);
+
+/**@brief Decode MQTT Publish Receive packet.
+ *
+ * @param[in] data Buffer containing message to decode.
+ * @param[in] datalen Length of the message.
+ * @param[in] offset Offset of the first byte after MQTT fixed header.
+ * @param[out] param Pointer to buffer for decoded Publish Receive parameters.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_receive_decode(u8_t *data, u32_t datalen, u32_t offset,
+			   struct mqtt_pubrec_param *param);
+
+/**@brief Decode MQTT Publish Release packet.
+ *
+ * @param[in] data Buffer containing message to decode.
+ * @param[in] datalen Length of the message.
+ * @param[in] offset Offset of the first byte after MQTT fixed header.
+ * @param[out] param Pointer to buffer for decoded Publish Release parameters.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_release_decode(u8_t *data, u32_t datalen, u32_t offset,
+			   struct mqtt_pubrel_param *param);
+
+/**@brief Decode MQTT Publish Complete packet.
+ *
+ * @param[in] data Buffer containing message to decode.
+ * @param[in] datalen Length of the message.
+ * @param[in] offset Offset of the first byte after MQTT fixed header.
+ * @param[out] param Pointer to buffer for decoded Publish Complete parameters.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int publish_complete_decode(u8_t *data, u32_t datalen, u32_t offset,
+			    struct mqtt_pubcomp_param *param);
+
+/**@brief Decode MQTT Subscribe packet.
+ *
+ * @param[in] data Buffer containing message to decode.
+ * @param[in] datalen Length of the message.
+ * @param[in] offset Offset of the first byte after MQTT fixed header.
+ * @param[out] param Pointer to buffer for decoded Subscribe parameters.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int subscribe_ack_decode(u8_t *data, u32_t datalen, u32_t offset,
+			 struct mqtt_suback_param *param);
+
+/**@brief Decode MQTT Unsubscribe packet.
+ *
+ * @param[in] data Buffer containing message to decode.
+ * @param[in] datalen Length of the message.
+ * @param[in] offset Offset of the first byte after MQTT fixed header.
+ * @param[out] param Pointer to buffer for decoded Unsubscribe parameters.
+ *
+ * @return 0 if the procedure is successful, an error code otherwise.
+ */
+int unsubscribe_ack_decode(u8_t *data, u32_t datalen, u32_t offset,
+			   struct mqtt_unsuback_param *param);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MQTT_INTERNAL_H_ */

--- a/subsys/net/lib/mqtt_socket/mqtt_os.h
+++ b/subsys/net/lib/mqtt_socket/mqtt_os.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt_os.h
+ *
+ * @brief MQTT Client depends on certain OS specific functionality. The needed
+ *        methods are mapped here and should be implemented based on OS in use.
+ *
+ * @details Memory management, mutex, logging and wall clock are the needed
+ *          functionality for MQTT module. The needed interfaces are defined
+ *          in the OS. OS specific port of the interface shall be provided.
+ *
+ */
+
+#ifndef MQTT_OS_H_
+#define MQTT_OS_H_
+
+#include <stddef.h>
+#include <kernel.h>
+
+#include <net/net_core.h>
+
+#include "mqtt_internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern struct k_mutex mqtt_mutex;
+extern struct k_mem_slab mqtt_slab;
+
+/**@brief Method to get trace logs from the module. */
+#define MQTT_TRC(...) NET_DBG(__VA_ARGS__)
+
+/**@brief Method to error logs from the module. */
+#define MQTT_ERR(...) NET_ERR(__VA_ARGS__)
+
+/**@brief Initialize the mutex for the module, if any.
+ *
+ * @details This method is called during module initialization @ref mqtt_init.
+ */
+static inline void mqtt_mutex_init(void)
+{
+	k_mutex_init(&mqtt_mutex);
+}
+
+/**@brief Acquire lock on the module specific mutex, if any.
+ *
+ * @details This is assumed to be a blocking method until the acquisition
+ *          of the mutex succeeds.
+ */
+static inline void mqtt_mutex_lock(void)
+{
+	(void)k_mutex_lock(&mqtt_mutex, K_FOREVER);
+}
+
+/**@brief Release the lock on the module specific mutex, if any.
+ */
+static inline void mqtt_mutex_unlock(void)
+{
+	k_mutex_unlock(&mqtt_mutex);
+}
+
+/**@brief Method to allocate memory for internal use in the module.
+ *
+ * @param[in] size Size of memory requested.
+ *
+ * @retval A valid pointer on success, NULL otherwise.
+ */
+static inline void *mqtt_malloc(size_t size)
+{
+	void *mem;
+
+	if (size != MQTT_MAX_PACKET_LENGTH) {
+		return NULL;
+	}
+
+	if (k_mem_slab_alloc(&mqtt_slab, (void **)&mem, K_NO_WAIT) < 0) {
+		return NULL;
+	}
+
+	return mem;
+}
+
+/**@brief Method to free any allocated memory for internal use in the module.
+ *
+ * @param[in] ptr Memory to be freed.
+ */
+static inline void mqtt_free(void *ptr)
+{
+	void *mem = ptr;
+
+	k_mem_slab_free(&mqtt_slab, (void **)&mem);
+}
+
+/**@brief Method to get the sys tick or a wall clock in millisecond resolution.
+ *
+ * @retval Current wall clock or sys tick value in milliseconds.
+ */
+static inline u32_t mqtt_sys_tick_in_ms_get(void)
+{
+	return k_uptime_get_32();
+}
+
+/**@brief Method to get elapsed time in milliseconds since the last activity.
+ *
+ * @param[in] last_activity The value since elapsed time is requested.
+ *
+ * @retval Time elapsed since last_activity time.
+ */
+static inline u32_t mqtt_elapsed_time_in_ms_get(uint32_t last_activity)
+{
+	s32_t diff = k_uptime_get_32() - last_activity;
+
+	if (diff < 0) {
+		return 0;
+	}
+
+	return diff;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MQTT_OS_H_ */

--- a/subsys/net/lib/mqtt_socket/mqtt_rx.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_rx.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#define LOG_MODULE_NAME net_mqtt_rx
+#define NET_LOG_LEVEL CONFIG_MQTT_LOG_LEVEL
+
+#include "mqtt_internal.h"
+#include "mqtt_os.h"
+
+/** @file mqtt_rx.c
+ *
+ * @brief MQTT Received data handling.
+ */
+
+static int mqtt_handle_packet(struct mqtt_client *client, u8_t *data,
+			      u32_t datalen, u32_t offset)
+{
+	int err_code = 0;
+	bool notify_event = true;
+	struct mqtt_evt evt;
+
+	/* Success by default, overwritten in special cases. */
+	evt.result = 0;
+
+	switch (data[0] & 0xF0) {
+	case MQTT_PKT_TYPE_CONNACK:
+		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_CONNACK!", client);
+
+		evt.type = MQTT_EVT_CONNACK;
+		err_code = connect_ack_decode(client, data, datalen, offset,
+					      &evt.param.connack);
+
+		if (err_code == 0) {
+			MQTT_TRC("[CID %p]: return_code: %d", client,
+				 evt.param.connack.return_code);
+
+			if (evt.param.connack.return_code ==
+						MQTT_CONNECTION_ACCEPTED) {
+				/* Set state. */
+				MQTT_SET_STATE(client, MQTT_STATE_CONNECTED);
+			}
+
+			evt.result = evt.param.connack.return_code;
+		} else {
+			evt.result = err_code;
+		}
+
+		break;
+
+	case MQTT_PKT_TYPE_PUBLISH:
+		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBLISH", client);
+
+		evt.type = MQTT_EVT_PUBLISH;
+		err_code = publish_decode(data, datalen, offset,
+					  &evt.param.publish);
+		evt.result = err_code;
+
+		MQTT_TRC("PUB QoS:%02x, message len %08x, topic len %08x",
+			 evt.param.publish.message.topic.qos,
+			 evt.param.publish.message.payload.len,
+			 evt.param.publish.message.topic.topic.size);
+
+		break;
+
+	case MQTT_PKT_TYPE_PUBACK:
+		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBACK!", client);
+
+		evt.type = MQTT_EVT_PUBACK;
+		err_code = publish_ack_decode(data, datalen, offset,
+					      &evt.param.puback);
+		evt.result = err_code;
+		break;
+
+	case MQTT_PKT_TYPE_PUBREC:
+		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBREC!", client);
+
+		evt.type = MQTT_EVT_PUBREC;
+		err_code = publish_receive_decode(data, datalen, offset,
+						  &evt.param.pubrec);
+		evt.result = err_code;
+		break;
+
+	case MQTT_PKT_TYPE_PUBREL:
+		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBREL!", client);
+
+		evt.type = MQTT_EVT_PUBREL;
+		err_code = publish_release_decode(data, datalen, offset,
+						  &evt.param.pubrel);
+		evt.result = err_code;
+		break;
+
+	case MQTT_PKT_TYPE_PUBCOMP:
+		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBCOMP!", client);
+
+		evt.type = MQTT_EVT_PUBCOMP;
+		err_code = publish_complete_decode(data, datalen, offset,
+						   &evt.param.pubcomp);
+		evt.result = err_code;
+		break;
+
+	case MQTT_PKT_TYPE_SUBACK:
+		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_SUBACK!", client);
+
+		evt.type = MQTT_EVT_SUBACK;
+		err_code = subscribe_ack_decode(data, datalen, offset,
+						&evt.param.suback);
+		evt.result = err_code;
+		break;
+
+	case MQTT_PKT_TYPE_UNSUBACK:
+		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_UNSUBACK!", client);
+
+		evt.type = MQTT_EVT_UNSUBACK;
+		err_code = unsubscribe_ack_decode(data, datalen, offset,
+						  &evt.param.unsuback);
+		evt.result = err_code;
+		break;
+
+	case MQTT_PKT_TYPE_PINGRSP:
+		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PINGRSP!", client);
+
+		/* No notification of Ping response to application. */
+		notify_event = false;
+		break;
+
+	default:
+		/* Nothing to notify. */
+		notify_event = false;
+		break;
+	}
+
+	if (notify_event == true) {
+		event_notify(client, &evt, MQTT_EVT_FLAG_NONE);
+	}
+
+	return err_code;
+}
+
+u32_t mqtt_handle_rx_data(struct mqtt_client *client, u8_t *data, u32_t datalen)
+{
+	int err_code = 0;
+	u32_t offset = 0;
+
+	while (offset < datalen) {
+		u32_t start = offset;
+		u32_t remaining_length = 0;
+
+		offset = 1; /* Skip first byte to offset MQTT packet length. */
+		err_code = packet_length_decode(data + start, datalen - start,
+						&remaining_length, &offset);
+		if (err_code != 0) {
+			return datalen;
+		}
+
+		u32_t packet_length = offset + remaining_length;
+
+		if (packet_length > MQTT_MAX_PACKET_LENGTH) {
+			/* We receiving data we cannot handle. */
+			return packet_length;
+		}
+
+		if (start + packet_length > datalen) {
+			/* We may want to save this packet for later use.
+			 * This means we received a truncated packet.
+			 */
+			return start;
+		}
+
+		err_code = mqtt_handle_packet(client, data + start,
+					      packet_length, offset);
+		if (err_code != 0) {
+			return packet_length;
+		}
+
+		offset = start + packet_length;
+	}
+
+	return datalen;
+}

--- a/subsys/net/lib/mqtt_socket/mqtt_transport.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_transport.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt_transport.c
+ *
+ * @brief Internal functions to handle transport in MQTT module.
+ */
+
+#include "mqtt_transport.h"
+
+/* Transport handler functions for TCP socket transport. */
+extern int mqtt_client_tcp_connect(struct mqtt_client *client);
+extern int mqtt_client_tcp_write(struct mqtt_client *client, const u8_t *data,
+				 u32_t datalen);
+extern int mqtt_client_tcp_read(struct mqtt_client *client, u8_t *data,
+				u32_t *datalen);
+extern int mqtt_client_tcp_disconnect(struct mqtt_client *client);
+
+#if defined(CONFIG_MQTT_LIB_TLS)
+/* Transport handler functions for TLS socket transport. */
+extern int mqtt_client_tls_connect(struct mqtt_client *client);
+extern int mqtt_client_tls_write(struct mqtt_client *client, const u8_t *data,
+				 u32_t datalen);
+extern int mqtt_client_tls_read(struct mqtt_client *client, u8_t *data,
+				u32_t *datalen);
+extern int mqtt_client_tls_disconnect(struct mqtt_client *client);
+#endif /* CONFIG_MQTT_LIB_TLS */
+
+/**@brief Function pointer array for TCP/TLS transport handlers. */
+const struct transport_procedure transport_fn[MQTT_TRANSPORT_NUM] = {
+	{
+		mqtt_client_tcp_connect,
+		mqtt_client_tcp_write,
+		mqtt_client_tcp_read,
+		mqtt_client_tcp_disconnect,
+	},
+#if defined(CONFIG_MQTT_LIB_TLS)
+	{
+		mqtt_client_tls_connect,
+		mqtt_client_tls_write,
+		mqtt_client_tls_read,
+		mqtt_client_tls_disconnect,
+	}
+#endif /* CONFIG_MQTT_LIB_TLS */
+};
+
+int mqtt_transport_connect(struct mqtt_client *client)
+{
+	return transport_fn[client->transport.type].connect(client);
+}
+
+int mqtt_transport_write(struct mqtt_client *client, const u8_t *data,
+			 u32_t datalen)
+{
+	return transport_fn[client->transport.type].write(client, data,
+							  datalen);
+}
+
+int mqtt_transport_read(struct mqtt_client *client, u8_t *data, u32_t *datalen)
+{
+	return transport_fn[client->transport.type].read(client, data, datalen);
+}
+
+int mqtt_transport_disconnect(struct mqtt_client *client)
+{
+	return transport_fn[client->transport.type].disconnect(client);
+}

--- a/subsys/net/lib/mqtt_socket/mqtt_transport.h
+++ b/subsys/net/lib/mqtt_socket/mqtt_transport.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt_transport.h
+ *
+ * @brief Internal functions to handle transport in MQTT module.
+ */
+
+#ifndef MQTT_TRANSPORT_H_
+#define MQTT_TRANSPORT_H_
+
+#include <net/mqtt_socket.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@brief Transport for handling transport connect procedure. */
+typedef int (*transport_connect_handler_t)(struct mqtt_client *client);
+
+/**@brief Transport write handler. */
+typedef int (*transport_write_handler_t)(struct mqtt_client *client,
+					 const u8_t *data, u32_t datalen);
+
+/**@brief Transport read handler. */
+typedef int (*transport_read_handler_t)(struct mqtt_client *client, u8_t *data,
+					u32_t *datalen);
+
+/**@brief Transport disconnect handler. */
+typedef int (*transport_disconnect_handler_t)(struct mqtt_client *client);
+
+/**@brief Transport procedure handlers. */
+struct transport_procedure {
+	/** Transport connect handler. Handles TCP connection callback based on
+	 *  type of transport.
+	 */
+	transport_connect_handler_t connect;
+
+	/** Transport write handler. Handles transport write based on type of
+	 *  transport.
+	 */
+	transport_write_handler_t write;
+
+	/** Transport read handler. Handles transport read based on type of
+	 *  transport.
+	 */
+	transport_read_handler_t read;
+
+	/** Transport disconnect handler. Handles transport disconnection based
+	 *  on type of transport.
+	 */
+	transport_disconnect_handler_t disconnect;
+};
+
+/**@brief Handles TCP Connection Complete for configured transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_transport_connect(struct mqtt_client *client);
+
+/**@brief Handles write requests on configured transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ * @param[in] data Data to be written on the transport.
+ * @param[in] datalen Length of data to be written on the transport.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_transport_write(struct mqtt_client *client, const u8_t *data,
+			 u32_t datalen);
+
+/**@brief Handles read requests on configured transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ * @param[in] data Pointer where read data is to be fetched.
+ * @param[inout] datalen Size of memory provided for the operation as input,
+ *                       received data length as output.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_transport_read(struct mqtt_client *client, u8_t *data, u32_t *datalen);
+
+/**@brief Handles transport disconnection requests on configured transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_transport_disconnect(struct mqtt_client *client);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MQTT_TRANSPORT_H_ */

--- a/subsys/net/lib/mqtt_socket/mqtt_transport_socket_tcp.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_transport_socket_tcp.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt_transport_socket_tcp.h
+ *
+ * @brief Internal functions to handle transport over TCP socket.
+ */
+
+#define LOG_MODULE_NAME net_mqtt_sock_tcp
+#define NET_LOG_LEVEL CONFIG_MQTT_LOG_LEVEL
+
+#include <errno.h>
+#include <net/socket.h>
+#include <net/mqtt_socket.h>
+
+#include "mqtt_os.h"
+
+/**@brief Handles connect request for TCP socket transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_client_tcp_connect(struct mqtt_client *client)
+{
+	const struct sockaddr *broker = client->broker;
+	int ret;
+
+	client->transport.tcp.sock = socket(broker->sa_family, SOCK_STREAM,
+					    IPPROTO_TCP);
+	if (client->transport.tcp.sock < 0) {
+		return -errno;
+	}
+
+	MQTT_TRC("Created socket %d", client->transport.tcp.sock);
+
+	size_t peer_addr_size = sizeof(struct sockaddr_in6);
+
+	if (broker->sa_family == AF_INET) {
+		peer_addr_size = sizeof(struct sockaddr_in);
+	}
+
+	ret = connect(client->transport.tcp.sock, client->broker,
+		      peer_addr_size);
+	if (ret < 0) {
+		(void)close(client->transport.tcp.sock);
+		return -errno;
+	}
+
+	MQTT_TRC("Connect completed");
+	return 0;
+}
+
+/**@brief Handles write requests on TCP socket transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ * @param[in] data Data to be written on the transport.
+ * @param[in] datalen Length of data to be written on the transport.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_client_tcp_write(struct mqtt_client *client, const u8_t *data,
+			  u32_t datalen)
+{
+	u32_t offset = 0;
+	int ret;
+
+	while (offset < datalen) {
+		ret = send(client->transport.tcp.sock, data + offset,
+			   datalen - offset, 0);
+		if (ret < 0) {
+			return -errno;
+		}
+
+		offset += ret;
+	}
+
+	return 0;
+}
+
+/**@brief Handles read requests on TCP socket transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ * @param[in] data Pointer where read data is to be fetched.
+ * @param[inout] datalen Size of memory provided for the operation,
+ *                       received data length as output.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_client_tcp_read(struct mqtt_client *client, u8_t *data, u32_t *datalen)
+{
+	int ret;
+
+	ret = recv(client->transport.tcp.sock, data, *datalen, MSG_DONTWAIT);
+	if (ret < 0) {
+		return -errno;
+	}
+
+	*datalen = ret;
+	return 0;
+}
+
+/**@brief Handles transport disconnection requests on TCP socket transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_client_tcp_disconnect(struct mqtt_client *client)
+{
+	int ret;
+
+	MQTT_TRC("Closing socket %d", client->transport.tcp.sock);
+
+	ret = close(client->transport.tcp.sock);
+	if (ret < 0) {
+		return -errno;
+	}
+
+	return 0;
+}

--- a/subsys/net/lib/mqtt_socket/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_transport_socket_tls.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file mqtt_transport_socket_tls.h
+ *
+ * @brief Internal functions to handle transport over TLS socket.
+ */
+
+#define LOG_MODULE_NAME net_mqtt_sock_tls
+#define NET_LOG_LEVEL CONFIG_MQTT_LOG_LEVEL
+
+#include <errno.h>
+#include <net/socket.h>
+#include <net/mqtt_socket.h>
+
+#include "mqtt_os.h"
+
+/**@brief Handles connect request for TLS socket transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_client_tls_connect(struct mqtt_client *client)
+{
+	const struct sockaddr *broker = client->broker;
+	struct mqtt_sec_config *tls_config = &client->transport.tls.config;
+	int ret;
+
+	client->transport.tls.sock = socket(broker->sa_family,
+					    SOCK_STREAM, IPPROTO_TLS_1_2);
+	if (client->transport.tls.sock < 0) {
+		return -errno;
+	}
+
+	MQTT_TRC("Created socket %d", client->transport.tls.sock);
+
+	/* Set secure socket options. */
+	ret = setsockopt(client->transport.tls.sock, SOL_TLS, TLS_PEER_VERIFY,
+			 &tls_config->peer_verify,
+			 sizeof(tls_config->peer_verify));
+	if (ret < 0) {
+		goto error;
+	}
+
+	if (tls_config->cipher_list != NULL && tls_config->cipher_count > 0) {
+		ret = setsockopt(client->transport.tls.sock, SOL_TLS,
+				 TLS_CIPHERSUITE_LIST, tls_config->cipher_list,
+				 sizeof(int) * tls_config->cipher_count);
+		if (ret < 0) {
+			goto error;
+		}
+	}
+
+	if (tls_config->seg_tag_list != NULL && tls_config->sec_tag_count > 0) {
+		ret = setsockopt(client->transport.tls.sock, SOL_TLS,
+				 TLS_SEC_TAG_LIST, tls_config->seg_tag_list,
+				 sizeof(sec_tag_t) * tls_config->sec_tag_count);
+		if (ret < 0) {
+			goto error;
+		}
+	}
+
+	if (tls_config->hostname) {
+		ret = setsockopt(client->transport.tls.sock, SOL_TLS,
+				 TLS_HOSTNAME, tls_config->hostname,
+				 strlen(tls_config->hostname));
+		if (ret < 0) {
+			goto error;
+		}
+	}
+
+	size_t peer_addr_size = sizeof(struct sockaddr_in6);
+
+	if (broker->sa_family == AF_INET) {
+		peer_addr_size = sizeof(struct sockaddr_in);
+	}
+
+	ret = connect(client->transport.tls.sock, client->broker,
+		      peer_addr_size);
+	if (ret < 0) {
+		goto error;
+	}
+
+	MQTT_TRC("Connect completed");
+	return 0;
+
+error:
+	(void)close(client->transport.tls.sock);
+	return -errno;
+}
+
+/**@brief Handles write requests on TLS socket transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ * @param[in] data Data to be written on the transport.
+ * @param[in] datalen Length of data to be written on the transport.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_client_tls_write(struct mqtt_client *client, const u8_t *data,
+			  u32_t datalen)
+{
+	u32_t offset = 0;
+	int ret;
+
+	while (offset < datalen) {
+		ret = send(client->transport.tls.sock, data + offset,
+			   datalen - offset, 0);
+		if (ret < 0) {
+			return -errno;
+		}
+
+		offset += ret;
+	}
+
+	return 0;
+}
+
+/**@brief Handles read requests on TLS socket transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ * @param[in] data Pointer where read data is to be fetched.
+ * @param[in] datalen Size of memory provided for the operation.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_client_tls_read(struct mqtt_client *client, u8_t *data, u32_t *datalen)
+{
+	int ret;
+
+	ret = recv(client->transport.tls.sock, data, *datalen, MSG_DONTWAIT);
+	if (ret < 0) {
+		return -errno;
+	}
+
+	*datalen = ret;
+	return 0;
+}
+
+/**@brief Handles transport disconnection requests on TLS socket transport.
+ *
+ * @param[in] client Identifies the client on which the procedure is requested.
+ *
+ * @retval 0 or an error code indicating reason for failure.
+ */
+int mqtt_client_tls_disconnect(struct mqtt_client *client)
+{
+	int ret;
+
+	MQTT_TRC("Closing socket %d", client->transport.tls.sock);
+	ret = close(client->transport.tls.sock);
+	if (ret < 0) {
+		return -errno;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Add MQTT library from the pending PR on upstream Zephyr.

As the upstream MQTT PR is taking more time than expected, the library has to be merged internally first.

@joakimtoe This version of the library uses `CONFIG_MQTT_SOCKET_LIB` to enable library, and the public header is called `mqtt_socket.h`. The reason for this is to avoid conflict with the existing Zephyr MQTT lib.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>