### PR TITLE
lib: Add Link Control Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_include_directories(include)
 add_subdirectory(ext)
 add_subdirectory(lib)
 add_subdirectory(subsys)
+add_subdirectory(drivers)
 
 # Add the mandatory nrfxlib repository
 set(               NRFXLIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../nrfxlib)

--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -9,6 +9,7 @@ menu "Nordic nRF Connect"
 rsource "ext/Kconfig"
 rsource "lib/Kconfig"
 rsource "subsys/Kconfig"
+rsource "drivers/Kconfig"
 
 orsource "../nrfxlib/Kconfig.nrfxlib"
 

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+add_subdirectory_ifdef(CONFIG_LTE_LINK_CONTROL lte_link_control)

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+menu "Device Drivers"
+
+rsource "lte_link_control/Kconfig"
+
+endmenu

--- a/drivers/lte_link_control/CMakeLists.txt
+++ b/drivers/lte_link_control/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+if(CONFIG_LTE_LINK_CONTROL)
+    zephyr_library()
+    zephyr_library_sources(lte_lc.c)
+    zephyr_library_include_directories(.)
+endif()

--- a/drivers/lte_link_control/Kconfig
+++ b/drivers/lte_link_control/Kconfig
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+menu "Link control on LTE link for nRF91"
+
+config LTE_LINK_CONTROL
+	bool "Enable link control of the LTE link"
+	depends on BSD_LIBRARY
+	default n
+
+config LTE_AUTO_INIT_AND_CONNECT
+	bool "Auto Initialize and Connect for the LTE link"
+	depends on LTE_LINK_CONTROL
+	default y
+	help
+		Turn on to make the LTE Link Controller to
+		automatically initialize and connect the modem
+		before the application starts
+endmenu

--- a/drivers/lte_link_control/lte_lc.c
+++ b/drivers/lte_link_control/lte_lc.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <zephyr.h>
+#include <zephyr/types.h>
+#include <errno.h>
+#include <net/socket.h>
+#include <string.h>
+#include <stdio.h>
+#include <device.h>
+
+#define LC_MAX_READ_LENGTH 128
+#if defined(CONFIG_LTE_AUTO_INIT_AND_CONNECT)
+DEVICE_DECLARE(lte_link_control);
+#endif
+
+/* Subscribes to notifications with level 2 */
+static const char subscribe[] = { 'A', 'T', '+', 'C', 'E',
+				  'R', 'E', 'G', '=', '2' };
+/* Set the modem to power off mode */
+static const char power_off[] = { 'A', 'T', '+', 'C', 'F', 'U', 'N', '=', '0' };
+/* Set the modem to Normal mode */
+static const char normal[] = { 'A', 'T', '+', 'C', 'F', 'U', 'N', '=', '1' };
+/* Set the modem to Offline mode */
+static const char offline[] = { 'A', 'T', '+', 'C', 'F', 'U', 'N', '=', '4' };
+/* Successful return from modem */
+static const char success[] = { 'O', 'K' };
+/* Network status read from modem */
+static const char *status[4] = {
+	"+CEREG: 1",
+	"+CEREG:1",
+	"+CEREG: 5",
+	"+CEREG:5",
+};
+
+static int w_lte_lc_init_and_connect(struct device *unused)
+{
+	int at_socket_fd;
+	int buffer;
+	u8_t read_buffer[LC_MAX_READ_LENGTH];
+
+	at_socket_fd = socket(AF_LTE, 0, NPROTO_AT);
+	if (at_socket_fd == -1) {
+		return -EFAULT;
+	}
+
+	buffer = send(at_socket_fd, subscribe, sizeof(subscribe), 0);
+	if (buffer != sizeof(subscribe)) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+
+	buffer = recv(at_socket_fd, read_buffer, sizeof(read_buffer), 0);
+	if ((buffer < sizeof(success)) ||
+	    (memcmp(success, read_buffer, sizeof(success)) != 0)) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+	buffer = send(at_socket_fd, normal, sizeof(normal), 0);
+	if (buffer != sizeof(normal)) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+
+	buffer = recv(at_socket_fd, read_buffer, sizeof(read_buffer), 0);
+	if ((buffer < sizeof(success)) ||
+	    (memcmp(success, read_buffer, sizeof(success)) != 0)) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+
+	while (true) {
+		buffer = recv(at_socket_fd, read_buffer,
+				  sizeof(read_buffer), MSG_DONTWAIT);
+		if ((memcmp(status[0], read_buffer, strlen(status[0])) == 0) ||
+		    (memcmp(status[1], read_buffer, strlen(status[1])) == 0) ||
+		    (memcmp(status[2], read_buffer, strlen(status[2])) == 0) ||
+		    (memcmp(status[3], read_buffer, strlen(status[3])) == 0)) {
+			break;
+		}
+	}
+	close(at_socket_fd);
+	return 0;
+}
+
+/* lte lc Init and connect wrapper */
+int lte_lc_init_and_connect(void)
+{
+	struct device *x = 0;
+
+	int err = w_lte_lc_init_and_connect(x);
+
+	return err;
+}
+
+int lte_lc_offline(void)
+{
+	int at_socket_fd;
+	int buffer;
+	u8_t read_buffer[LC_MAX_READ_LENGTH];
+
+	at_socket_fd = socket(AF_LTE, 0, NPROTO_AT);
+	if (at_socket_fd == -1) {
+		return -EFAULT;
+	}
+	buffer = send(at_socket_fd, offline, sizeof(offline), 0);
+	if (buffer != sizeof(offline)) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+
+	buffer = recv(at_socket_fd, read_buffer, LC_MAX_READ_LENGTH, 0);
+	if ((buffer < sizeof(success)) ||
+	    (memcmp(success, read_buffer, sizeof(success) != 0))) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+
+	close(at_socket_fd);
+	return 0;
+}
+
+int lte_lc_power_off(void)
+{
+	int at_socket_fd;
+	int buffer;
+	u8_t read_buffer[LC_MAX_READ_LENGTH];
+
+	at_socket_fd = socket(AF_LTE, 0, NPROTO_AT);
+	if (at_socket_fd == -1) {
+		return -EFAULT;
+	}
+	buffer = send(at_socket_fd, power_off, sizeof(power_off), 0);
+	if (buffer != sizeof(power_off)) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+
+	buffer = recv(at_socket_fd, read_buffer, LC_MAX_READ_LENGTH, 0);
+	if ((buffer < sizeof(success)) ||
+	    (memcmp(success, read_buffer, sizeof(success)) != 0)) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+	close(at_socket_fd);
+	return 0;
+}
+
+int lte_lc_normal(void)
+{
+	int at_socket_fd;
+	int buffer;
+	u8_t read_buffer[LC_MAX_READ_LENGTH];
+
+	at_socket_fd = socket(AF_LTE, 0, NPROTO_AT);
+	if (at_socket_fd == -1) {
+		return -EFAULT;
+	}
+	buffer = send(at_socket_fd, normal, sizeof(normal), 0);
+	if (buffer != sizeof(normal)) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+
+	buffer = recv(at_socket_fd, read_buffer, LC_MAX_READ_LENGTH, 0);
+	if ((buffer < sizeof(success)) ||
+	    (memcmp(success, read_buffer, sizeof(success)) != 0)) {
+		close(at_socket_fd);
+		return -EIO;
+	}
+	close(at_socket_fd);
+	return 0;
+}
+
+#if defined(CONFIG_LTE_AUTO_INIT_AND_CONNECT)
+DEVICE_AND_API_INIT(lte_link_control, "LTE_LINK_CONTROL",
+		    w_lte_lc_init_and_connect, NULL, NULL, APPLICATION,
+		    CONFIG_APPLICATION_INIT_PRIORITY, NULL);
+#endif /* CONFIG_LTE_AUTO_INIT_AND_CONNECT */

--- a/include/lte_lc.h
+++ b/include/lte_lc.h
@@ -1,0 +1,40 @@
+/**
+* @file lte_lc.h
+*
+* @brief Public APIs for the LTE Link Control driver.
+*/
+
+/*
+* Copyright (c) 2018 Nordic Semiconductor ASA
+*
+* SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+*/
+#ifndef ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
+#define ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
+
+/** @brief Function for initializing
+* and make a connection with the modem
+*
+* @return Zero on success or (negative) error code otherwise.
+*/
+int lte_lc_init_and_connect(void);
+
+/** @brief Function for sending the modem to offline mode
+*
+* @return Zero on success or (negative) error code otherwise.
+*/
+int lte_lc_offline(void);
+
+/** @brief Function for sending the modem to power off mode
+*
+* @return Zero on success or (negative) error code otherwise.
+*/
+int lte_lc_power_off(void);
+
+/** @brief Function for sending the modem to normal mode
+*
+* @return Zero on success or (negative) error code otherwise.
+*/
+int lte_lc_normal(void);
+
+#endif /* ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_ */


### PR DESCRIPTION
This patch adds Link Control Library for LTE. When used this library
will automatically issue a set of AT-commands which set up the LTE link.
If elided, the developer will have to do the same step manually in his/her
application.

The module will be loaded POST kernel and will go directly onto the
BSD socket library. Hence, it is not dependant on socket offloading
to be intialized first.

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>