### PR TITLE
lib: Add sensor simulator

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,3 +5,4 @@
 #
 
 add_subdirectory_ifdef(CONFIG_BSD_LIBRARY bsdlib)
+add_subdirectory_ifdef(CONFIG_SENSOR_SIM sensor_sim)

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -8,4 +8,6 @@ menu "libraries"
 
 rsource "bsdlib/Kconfig"
 
+rsource "sensor_sim/Kconfig"
+
 endmenu

--- a/lib/sensor_sim/CMakeLists.txt
+++ b/lib/sensor_sim/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+if(CONFIG_SENSOR_SIM)
+    zephyr_library()
+    zephyr_library_sources(sensor_sim.c)
+    zephyr_library_include_directories(.)
+endif()

--- a/lib/sensor_sim/Kconfig
+++ b/lib/sensor_sim/Kconfig
@@ -1,0 +1,83 @@
+# Kconfig - Sensor data simulator
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+menuconfig SENSOR_SIM
+	bool "Sensor simulator"
+	depends on SENSOR
+	help
+	  Enable sensor simulator.
+
+if SENSOR_SIM
+
+config SENSOR_SIM_DEV_NAME
+	string "Sensor simulator device name"
+	default "SENSOR_SIM"
+	help
+		Device name for sensor simulator.
+
+config SENSOR_SIM_DYNAMIC_VALUES
+	bool "Sensor simulator with dynamic values"
+	default y
+	select NEWLIB_LIBC
+	help
+		Enables dynamically created simulator otuput as opposed
+		to static values.
+
+config SENSOR_SIM_STATIC_VALUES
+	bool "Sensor simulator uses static values"
+	default n
+	help
+		Sensor simulator values will change between statically
+		defined values on each call to fetch data.
+
+config SENSOR_SIM_TRIGGER
+	bool "Sensor simulator trigger"
+	help
+		Enable trigger mode.
+
+if SENSOR_SIM_TRIGGER
+
+config SENSOR_SIM_TRIGGER_USE_TIMER
+	bool "Use timer for trigger"
+	depends on SENSOR_SIM_TRIGGER
+	default y
+	help
+		Enable trigger. When enabled, it will emit 'data ready'
+		trigger event time either by button press or at specified
+		timer intervals.
+
+config SENSOR_SIM_TRIGGER_USE_BUTTON
+	bool "Use button 1 for trigger"
+	depends on SENSOR_SIM_TRIGGER
+	default n
+	help
+		Use button 1 to trigger 'data ready' event.
+
+config SENSOR_SIM_TRIGGER_TIMER_MSEC
+	int "Time between 'data ready' triggers, in milliseconds"
+	depends on SENSOR_SIM_TRIGGER
+	default 1000
+	help
+		The time interval between each 'data ready' trigger event.
+
+config SENSOR_SIM_THREAD_PRIORITY
+	int "Thread priority"
+	depends on SENSOR_SIM_TRIGGER
+	default 10
+	help
+	  Priority of thread used by the driver to handle interrupts.
+
+config SENSOR_SIM_THREAD_STACK_SIZE
+	int "Trigger thread stack size"
+	depends on SENSOR_SIM_TRIGGER
+	default 512
+	help
+	  Stack size of thread used by the driver to handle interrupts.
+
+endif #SENSOR_SIM_TRIGGER
+
+endif #SENSOR_SIM

--- a/lib/sensor_sim/sensor_sim.c
+++ b/lib/sensor_sim/sensor_sim.c
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <board.h>
+#include <gpio.h>
+#include <init.h>
+#include <sensor.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "sensor_sim.h"
+
+#if defined(CONFIG_SENSOR_SIM_DYNAMIC_VALUES)
+	#include <math.h>
+#endif
+
+static const double base_accel_samples[3] = {0.0, 0.0, 0.0};
+static double accel_samples[3];
+
+/*
+ * @brief Helper function to convert from double to sensor_value struct
+ *
+ * @param val Sensor value to convert.
+ * @param sense_val Pointer to sensor_value to store the converted data.
+ */
+static void double_to_sensor_value(double val,
+				struct sensor_value *sense_val)
+{
+	sense_val->val1 = (int)val;
+	sense_val->val2 = (val - (int)val) * 1000000;
+}
+
+#if defined(CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON)
+/*
+ * @brief Callback for GPIO when using button as trigger.
+ *
+ * @param dev Pointer to device structure.
+ * @param cb Pointer to GPIO callback structure.
+ * @param pins Pin mask for callback.
+ */
+static void sensor_sim_gpio_callback(struct device *dev,
+				struct gpio_callback *cb,
+				u32_t pins)
+{
+	ARG_UNUSED(pins);
+	struct sensor_sim_data *drv_data =
+		CONTAINER_OF(cb, struct sensor_sim_data, gpio_cb);
+
+	gpio_pin_disable_callback(dev, drv_data->gpio_pin);
+	k_sem_give(&drv_data->gpio_sem);
+}
+#endif /* CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON */
+
+/*
+ * @brief Function that runs in the sensor simulator thread when using trigger.
+ *
+ * @param dev_ptr Pointer to sensor simulator device.
+ */
+static void sensor_sim_thread(int dev_ptr)
+{
+	struct device *dev = INT_TO_POINTER(dev_ptr);
+	struct sensor_sim_data *drv_data = dev->driver_data;
+
+	while (true) {
+		if (IS_ENABLED(CONFIG_SENSOR_SIM_TRIGGER_USE_TIMER)) {
+			k_sleep(CONFIG_SENSOR_SIM_TRIGGER_TIMER_MSEC);
+		} else if (IS_ENABLED(CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON)) {
+			k_sem_take(&drv_data->gpio_sem, K_FOREVER);
+		}
+
+		if (drv_data->drdy_handler != NULL) {
+			drv_data->drdy_handler(dev, &drv_data->drdy_trigger);
+		}
+
+#if defined(CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON)
+		gpio_pin_enable_callback(drv_data->gpio, drv_data->gpio_pin);
+#endif
+	}
+}
+
+/*
+ * @brief Initializing thread when simulator uses trigger
+ *
+ * @param dev Pointer to device instance.
+ */
+static int sensor_sim_init_thread(struct device *dev)
+{
+	struct sensor_sim_data *drv_data = dev->driver_data;
+
+#if defined(CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON)
+	drv_data->gpio = device_get_binding(drv_data->gpio_port);
+	if (drv_data->gpio == NULL) {
+		SYS_LOG_ERR("Failed to get pointer to %s device",
+			    drv_data->gpio_port);
+		return -EINVAL;
+	}
+
+	gpio_pin_configure(drv_data->gpio, drv_data->gpio_pin,
+			   GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
+			   GPIO_INT_ACTIVE_LOW | GPIO_INT_DEBOUNCE |
+			   GPIO_PUD_PULL_UP);
+
+	gpio_init_callback(&drv_data->gpio_cb,
+			   sensor_sim_gpio_callback,
+			   BIT(drv_data->gpio_pin));
+
+	if (gpio_add_callback(drv_data->gpio, &drv_data->gpio_cb) < 0) {
+		SYS_LOG_ERR("Failed to set GPIO callback");
+		return -EIO;
+	}
+
+	k_sem_init(&drv_data->gpio_sem, 0, UINT_MAX);
+
+#endif   /* CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON */
+
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_SENSOR_SIM_THREAD_STACK_SIZE,
+			(k_thread_entry_t)sensor_sim_thread, dev,
+			NULL, NULL,
+			K_PRIO_COOP(CONFIG_SENSOR_SIM_THREAD_PRIORITY),
+			0, 0);
+
+	return 0;
+}
+
+static int sensor_sim_trigger_set(struct device *dev,
+			   const struct sensor_trigger *trig,
+			   sensor_trigger_handler_t handler)
+{
+	int ret = 0;
+	struct sensor_sim_data *drv_data = dev->driver_data;
+
+#if defined(CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON)
+	gpio_pin_disable_callback(drv_data->gpio, drv_data->gpio_pin);
+#endif
+
+	switch (trig->type) {
+	case SENSOR_TRIG_DATA_READY:
+		drv_data->drdy_handler = handler;
+		drv_data->drdy_trigger = *trig;
+		break;
+	default:
+		SYS_LOG_ERR("Unsupported sensor trigger");
+		ret = -ENOTSUP;
+		break;
+	}
+
+#if defined(CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON)
+	gpio_pin_enable_callback(drv_data->gpio, drv_data->gpio_pin);
+#endif
+	return ret;
+}
+
+/*
+ * @brief Initializes sensor simulator
+ *
+ * @param dev Pointer to device instance.
+ *
+ * @return 0 when successful or negative error code
+ */
+static int sensor_sim_init(struct device *dev)
+{
+#if defined(CONFIG_SENSOR_SIM_TRIGGER)
+#if defined(CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON)
+	struct sensor_sim_data *drv_data = dev->driver_data;
+
+	drv_data->gpio_port = SW0_GPIO_NAME;
+	drv_data->gpio_pin = SW0_GPIO_PIN;
+#endif
+	if (sensor_sim_init_thread(dev) < 0) {
+		SYS_LOG_ERR("Failed to initialize trigger interrupt");
+		return -EIO;
+	}
+#endif
+
+	return 0;
+}
+
+/*
+ * @brief Calculates sine from uptime
+ * The input to the sin() function is limited to avoid overflow issues
+ *
+ * @param offset Offset for the sine.
+ * @param amplitude Amplitude of sine.
+ */
+static double generate_sine(double offset, double amplitude)
+{
+	u32_t time = k_uptime_get_32();
+
+	return offset + amplitude * sin(time % 65535);
+}
+
+/*
+ * @brief Generates accelerometer data.
+ *
+ * @param chan Channel to generate data for.
+ */
+static int generate_accel_data(enum sensor_channel chan)
+{
+	int retval = 0;
+	double max_variation = 20.0;
+	static int static_val_coeff = 1.0;
+
+	if (IS_ENABLED(CONFIG_SENSOR_SIM_DYNAMIC_VALUES)) {
+		switch (chan) {
+		case SENSOR_CHAN_ACCEL_X:
+			accel_samples[0] = generate_sine(base_accel_samples[0],
+								max_variation);
+			break;
+		case SENSOR_CHAN_ACCEL_Y:
+			accel_samples[1] = generate_sine(base_accel_samples[1],
+								max_variation);
+			break;
+		case SENSOR_CHAN_ACCEL_Z:
+			accel_samples[2] = generate_sine(base_accel_samples[2],
+								max_variation);
+			break;
+		case SENSOR_CHAN_ACCEL_XYZ:
+			accel_samples[0] = generate_sine(base_accel_samples[0],
+								max_variation);
+			k_sleep(1);
+			accel_samples[1] = generate_sine(base_accel_samples[1],
+								max_variation);
+			k_sleep(1);
+			accel_samples[2] = generate_sine(base_accel_samples[2],
+								max_variation);
+			break;
+		default:
+			retval = -ENOTSUP;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_SENSOR_SIM_STATIC_VALUES)) {
+		switch (chan) {
+		case SENSOR_CHAN_ACCEL_X:
+			accel_samples[0] = static_val_coeff * max_variation;
+			break;
+		case SENSOR_CHAN_ACCEL_Y:
+			accel_samples[1] = static_val_coeff * max_variation;
+			break;
+		case SENSOR_CHAN_ACCEL_Z:
+			accel_samples[2] = static_val_coeff * max_variation;
+			break;
+		case SENSOR_CHAN_ACCEL_XYZ:
+			accel_samples[0] = static_val_coeff * max_variation;
+			accel_samples[1] = static_val_coeff * max_variation;
+			accel_samples[2] = static_val_coeff * max_variation;
+			break;
+		default:
+			retval = -ENOTSUP;
+		}
+
+		static_val_coeff *= -1.0;
+	}
+
+	return retval;
+}
+
+/*
+ * @brief Generates simulated sensor data for a channel.
+ *
+ * @param chan Channel to generate data for.
+ */
+static int sensor_sim_generate_data(enum sensor_channel chan)
+{
+	switch (chan) {
+	case SENSOR_CHAN_ACCEL_X:
+		generate_accel_data(SENSOR_CHAN_ACCEL_X);
+		break;
+	case SENSOR_CHAN_ACCEL_Y:
+		generate_accel_data(SENSOR_CHAN_ACCEL_Y);
+		break;
+	case SENSOR_CHAN_ACCEL_Z:
+		generate_accel_data(SENSOR_CHAN_ACCEL_Z);
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ:
+		generate_accel_data(SENSOR_CHAN_ACCEL_XYZ);
+		break;
+	default:
+		generate_accel_data(SENSOR_CHAN_ACCEL_XYZ);
+	}
+
+	return 0;
+}
+
+static int sensor_sim_attr_set(struct device *dev,
+		enum sensor_channel chan,
+		enum sensor_attribute attr,
+		const struct sensor_value *val)
+{
+	return 0;
+}
+
+static int sensor_sim_sample_fetch(struct device *dev,
+				enum sensor_channel chan)
+{
+	return sensor_sim_generate_data(chan);
+}
+
+static int sensor_sim_channel_get(struct device *dev,
+				  enum sensor_channel chan,
+				  struct sensor_value *sample)
+{
+	switch (chan) {
+	case SENSOR_CHAN_ACCEL_X:
+			double_to_sensor_value(accel_samples[0], sample);
+		break;
+	case SENSOR_CHAN_ACCEL_Y:
+			double_to_sensor_value(accel_samples[1], sample);
+		break;
+	case SENSOR_CHAN_ACCEL_Z:
+			double_to_sensor_value(accel_samples[2], sample);
+		break;
+	case SENSOR_CHAN_ACCEL_XYZ:
+			double_to_sensor_value(accel_samples[0], sample);
+			double_to_sensor_value(accel_samples[1], ++sample);
+			double_to_sensor_value(accel_samples[2], ++sample);
+		break;
+
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static struct sensor_sim_data sensor_sim_data;
+
+static const struct sensor_driver_api sensor_sim_api_funcs = {
+	.attr_set = sensor_sim_attr_set,
+	.sample_fetch = sensor_sim_sample_fetch,
+	.channel_get = sensor_sim_channel_get,
+#if defined(CONFIG_SENSOR_SIM_TRIGGER)
+	.trigger_set = sensor_sim_trigger_set
+#endif
+};
+
+DEVICE_AND_API_INIT(sensor_sim, CONFIG_SENSOR_SIM_DEV_NAME, sensor_sim_init,
+		    &sensor_sim_data, NULL, POST_KERNEL,
+		    CONFIG_SENSOR_INIT_PRIORITY, &sensor_sim_api_funcs);

--- a/lib/sensor_sim/sensor_sim.h
+++ b/lib/sensor_sim/sensor_sim.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef __SENSOR_SENSOR_SIM_H__
+#define __SENSOR_SENSOR_SIM_H__
+
+#include <zephyr/types.h>
+#include <device.h>
+
+struct sensor_sim_data {
+#if defined(CONFIG_SENSOR_SIM_TRIGGER)
+	struct device *gpio;
+	const char *gpio_port;
+	u8_t gpio_pin;
+	struct gpio_callback gpio_cb;
+	struct k_sem gpio_sem;
+
+	sensor_trigger_handler_t drdy_handler;
+	struct sensor_trigger drdy_trigger;
+
+	K_THREAD_STACK_MEMBER(thread_stack,
+			      CONFIG_SENSOR_SIM_THREAD_STACK_SIZE);
+	struct k_thread thread;
+#endif  /* CONFIG_SENSOR_SIM_TRIGGER */
+};
+
+#define SYS_LOG_DOMAIN "SENSOR_SIM"
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_SENSOR_LEVEL
+#include <logging/sys_log.h>
+#endif /* __SENSOR_SENSOR_SIM_H__ */


### PR DESCRIPTION
Adds a simple sensor simulator. Currently it supports getting accelerometer data via the sensor API. Data generation is triggered by button press or at intervals, and can either be pseudo-random based on clock, or toggle between hard-coded values.

As it is now, it's intended to be used for simple demonstration purposes like simulating a device's orientation. It can be extended to support all the channels in the sensor API.

I'm not certain this belongs in `lib/`, so please let me know if I should put it somewhere else.

---
This commit adds a sensor simulator. Currently it's capable
of generating accelerometer data, and can be used via the
sensor API.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>