### PR TITLE
lib: Add GPS simulator

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,4 +5,5 @@
 #
 
 add_subdirectory_ifdef(CONFIG_BSD_LIBRARY bsdlib)
+add_subdirectory_ifdef(CONFIG_GPS_SIM gps_sim)
 add_subdirectory_ifdef(CONFIG_SENSOR_SIM sensor_sim)

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -8,6 +8,8 @@ menu "libraries"
 
 rsource "bsdlib/Kconfig"
 
+rsource "gps_sim/Kconfig"
+
 rsource "sensor_sim/Kconfig"
 
 endmenu

--- a/lib/gps_sim/CMakeLists.txt
+++ b/lib/gps_sim/CMakeLists.txt
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+if(CONFIG_GPS_SIM)
+    zephyr_library()
+    zephyr_library_sources(gps_sim.c)
+endif()

--- a/lib/gps_sim/Kconfig
+++ b/lib/gps_sim/Kconfig
@@ -1,0 +1,136 @@
+# Kconfig - GPS data simulator
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+menuconfig GPS_SIM
+	bool "GPS simulator"
+	help
+	  Enable GPS simulator.
+
+if GPS_SIM
+
+config GPS_SIM_DEV_NAME
+	string "GPS simulator device name"
+	default "GPS_SIM"
+	help
+		GPS simulator device name.
+
+config GPS_SIM_BASE_LATITUDE
+	int "Base latitude for GPS data"
+	default 6325280
+	help
+		Start-point latitude for simulated GPS data,
+		from which the generated data will continue.
+		Calculated by deg * 100000 + minutes * 1000 N,
+		for example 63 deg 25.280' will be 6325280.
+
+config GPS_SIM_BASE_LONGITUDE
+	int "Base longitude for GPS data"
+	default 1026201
+	help
+		Start-point longitude for simulated GPS data,
+		from which the generated data will continue.
+		Calculated by deg * 100000 + minutes * 1000 E,
+		for example 10 deg 26.201' will be 1026201.
+
+config GPS_SIM_BASE_TIMESTAMP
+	int "Base timestamp for GPS data"
+	default 134627
+	help
+		Timestamp at which the simulator will start counting.
+		Format is hour * 10000 + min * 100 + sec, which means that
+		13:46:27 becomes 134627.
+
+config GPS_SIM_ELLIPSOID
+	bool "Generate ellipsoid GPS path"
+	default y
+	help
+		GPS simulator will create a path that goes in an ellipsoid
+		shape.
+
+config GPS_SIM_PSEUDO_RANDOM
+	bool "Use pseudo-random values to generate GPS coordinates"
+	help
+		Enables pseudo-random GPS coordinate creation. Based on uptime
+		that's input to a sine function, which causes the otuput
+		to not be uniformally distributed, but sinusoidal.
+
+config GPS_SIM_DYNAMIC_VALUES
+	bool "GPS simulator dynamically creates data values"
+	default y
+	select NEWLIB_LIBC
+	select NEWLIB_LIBC_FLOAT_PRINTF
+	help
+		Enables dynamically created simulator otuput as opposed
+		to static values.
+
+config GPS_SIM_MAX_STEP
+	int "Maximum step size each iteration"
+	default 5
+	help
+		Sets the maximum step size that can be taken in latitude or longitude
+		for each simulation iteration. In units of 1/1000 degrees.
+
+config GPS_SIM_TRIGGER
+	bool "GPS simulator trigger"
+	help
+		Enable trigger. When enabled, it will emit 'data ready'
+		trigger event time either by button press or at specified
+		timer intervals.
+
+if GPS_SIM_TRIGGER
+
+choice
+	prompt "Trigger type"
+	depends on GPS_SIM_TRIGGER
+	default GPS_SIM_TRIGGER_USE_TIMER
+	help
+		Specify the type of trigger that will be used to emit the
+		'data ready' trigger event.
+
+config GPS_SIM_TRIGGER_USE_TIMER
+	bool "Use timer for trigger"
+	help
+		Use timer to trigger 'data ready' event.
+
+config GPS_SIM_TRIGGER_USE_BUTTON
+	bool "Use button 2 as trigger"
+	help
+		Use button 2 to trigger 'data ready' event.
+
+endchoice
+
+if GPS_SIM_TRIGGER && GPS_SIM_TRIGGER_USE_TIMER
+	config GPS_SIM_TRIGGER_TIMER_MSEC
+		int "Time between triggers, in milliseconds"
+		default 1000
+		help
+			The time interval between each 'data ready' trigger event.
+endif
+
+if GPS_SIM_TRIGGER && !GPS_SIM_TRIGGER_USE_TIMER
+	config GPS_SIM_TRIGGER_TIMER_MSEC
+		int
+		default 0
+endif
+
+config GPS_SIM_THREAD_PRIORITY
+	int "Thread priority"
+	depends on GPS_SIM_TRIGGER
+	default 10
+	help
+	  Priority of thread used by the driver to handle interrupts.
+
+config GPS_SIM_THREAD_STACK_SIZE
+	int "Trigger thread stack size"
+	depends on GPS_SIM_TRIGGER
+	default 512
+	help
+	  Stack size of thread used by the driver to handle interrupts.
+
+endif #GPS_SIM_TRIGGER
+
+endif #GPS_SIM

--- a/lib/gps_sim/gps_sim.c
+++ b/lib/gps_sim/gps_sim.c
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <board.h>
+#include <gpio.h>
+#include <gps.h>
+#include <init.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(CONFIG_GPS_SIM_DYNAMIC_VALUES)
+#include <math.h>
+#endif
+
+#define SYS_LOG_DOMAIN "GPS_SIM"
+#define SYS_LOG_LEVEL CONFIG_SYS_LOG_GPS_SIM_LEVEL
+#include <logging/sys_log.h>
+
+struct gps_sim_data {
+#if defined(CONFIG_GPS_SIM_TRIGGER)
+	struct device *gpio;
+	const char *gpio_port;
+	u8_t gpio_pin;
+	struct gpio_callback gpio_cb;
+	struct k_sem gpio_sem;
+
+	gps_trigger_handler_t drdy_handler;
+	struct gps_trigger drdy_trigger;
+
+	K_THREAD_STACK_MEMBER(thread_stack,
+				  CONFIG_GPS_SIM_THREAD_STACK_SIZE);
+	struct k_thread thread;
+#endif  /* CONFIG_GPS_SIM_TRIGGER */
+};
+
+static struct gps_data nmea_sample;
+static double base_gps_sample_lat;
+static double base_gps_sample_lng;
+static struct k_mutex trigger_mutex;
+
+/* The base for the GPS timestamp is arbitrarily chosen */
+static const u8_t base_gps_sample_hour =
+	(CONFIG_GPS_SIM_BASE_TIMESTAMP / 10000);
+static const u8_t base_gps_sample_minute =
+	(CONFIG_GPS_SIM_BASE_TIMESTAMP / 100) % 100;
+static const u8_t base_gps_sample_second =
+	CONFIG_GPS_SIM_BASE_TIMESTAMP % 100;
+
+/**
+ * @brief Callback for GPIO when using button as trigger.
+ *
+ * @param dev Pointer to device structure.
+ * @param cb Pointer to GPIO callback structure.
+ * @param pins Pin mask for callback.
+ */
+static void gps_sim_gpio_callback(struct device *dev, struct gpio_callback *cb,
+				  u32_t pins)
+{
+	ARG_UNUSED(pins);
+	struct gps_sim_data *drv_data =
+		CONTAINER_OF(cb, struct gps_sim_data, gpio_cb);
+
+	gpio_pin_disable_callback(dev, drv_data->gpio_pin);
+	k_sem_give(&drv_data->gpio_sem);
+}
+
+/**
+ * @brief Function that runs in the GPS simulator thread when using trigger.
+ *
+ * @param dev_ptr Pointer to GPS simulator device.
+ */
+static void gps_sim_thread(int dev_ptr)
+{
+	struct device *dev = INT_TO_POINTER(dev_ptr);
+	struct gps_sim_data *drv_data = dev->driver_data;
+
+	while (true) {
+		if (IS_ENABLED(CONFIG_GPS_SIM_TRIGGER_USE_TIMER)) {
+			k_sleep(CONFIG_GPS_SIM_TRIGGER_TIMER_MSEC);
+		} else if (IS_ENABLED(CONFIG_GPS_SIM_TRIGGER_USE_BUTTON)) {
+			k_sem_take(&drv_data->gpio_sem,
+				K_FOREVER);
+		}
+
+		k_mutex_lock(&trigger_mutex, K_FOREVER);
+		if (drv_data->drdy_handler != NULL) {
+			drv_data->drdy_handler(dev, &drv_data->drdy_trigger);
+		}
+		k_mutex_unlock(&trigger_mutex);
+
+		if (IS_ENABLED(CONFIG_GPS_SIM_TRIGGER_USE_BUTTON)) {
+			gpio_pin_enable_callback(drv_data->gpio,
+				drv_data->gpio_pin);
+		}
+	}
+}
+
+/**
+ * @brief Initializing interrupt when simulator uses trigger
+ *
+ * @param dev Pointer to device instance.
+ */
+static int gps_sim_init_thread(struct device *dev)
+{
+	struct gps_sim_data *drv_data = dev->driver_data;
+
+	k_mutex_init(&trigger_mutex);
+
+	if (IS_ENABLED(CONFIG_GPS_SIM_TRIGGER_USE_BUTTON)) {
+		drv_data->gpio = device_get_binding(drv_data->gpio_port);
+		if (drv_data->gpio == NULL) {
+			SYS_LOG_ERR("Failed to get pointer to %s device",
+					drv_data->gpio_port);
+			return -EINVAL;
+		}
+
+		gpio_pin_configure(drv_data->gpio, drv_data->gpio_pin,
+					GPIO_DIR_IN | GPIO_INT | GPIO_INT_EDGE |
+					GPIO_INT_ACTIVE_LOW | GPIO_PUD_PULL_UP);
+
+		gpio_init_callback(&drv_data->gpio_cb, gps_sim_gpio_callback,
+				BIT(drv_data->gpio_pin));
+
+		if (gpio_add_callback(drv_data->gpio, &drv_data->gpio_cb) < 0) {
+			SYS_LOG_ERR("Failed to set GPIO callback");
+			return -EIO;
+		}
+
+		k_sem_init(&drv_data->gpio_sem, 0, 1);
+	}
+
+	k_thread_create(&drv_data->thread, drv_data->thread_stack,
+			CONFIG_GPS_SIM_THREAD_STACK_SIZE,
+			(k_thread_entry_t)gps_sim_thread, dev, NULL, NULL,
+			K_PRIO_COOP(CONFIG_GPS_SIM_THREAD_PRIORITY), 0, 0);
+
+	return 0;
+}
+
+static int gps_sim_trigger_set(struct device *dev,
+				   const struct gps_trigger *trig,
+				   gps_trigger_handler_t handler)
+{
+	int ret = 0;
+	struct gps_sim_data *drv_data = dev->driver_data;
+
+	switch (trig->type) {
+	case GPS_TRIG_DATA_READY:
+		k_mutex_lock(&trigger_mutex, K_FOREVER);
+		drv_data->drdy_handler = handler;
+		drv_data->drdy_trigger = *trig;
+
+		if (IS_ENABLED(CONFIG_GPS_SIM_TRIGGER_USE_BUTTON)) {
+			if (handler) {
+				gpio_pin_enable_callback(drv_data->gpio,
+					drv_data->gpio_pin);
+			} else {
+				gpio_pin_disable_callback(drv_data->gpio,
+					drv_data->gpio_pin);
+			}
+		}
+
+		k_mutex_unlock(&trigger_mutex);
+		break;
+	default:
+		SYS_LOG_ERR("Unsupported GPS trigger");
+		ret = -ENOTSUP;
+		break;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Calculates NMEA sentence checksum
+ *
+ * @param nmea_sentence Pointer to NMEA sentence.
+ */
+static u8_t nmea_checksum_get(const u8_t *nmea_sentence)
+{
+	const u8_t *i = nmea_sentence + 1;
+	u8_t checksum = 0;
+
+	while (*i != '*') {
+		if ((i - nmea_sentence) > GPS_NMEA_SENTENCE_MAX_LENGTH) {
+			return 0;
+		}
+		checksum ^= *i;
+		i++;
+	}
+
+	return checksum;
+}
+
+/**
+ * @brief Calculates sine from uptime
+ * The input to the sin() function is limited to avoid overflow issues
+ *
+ * @param offset Offset for the sine.
+ * @param amplitude Amplitude of sine.
+ */
+static double generate_sine(double offset, double amplitude)
+{
+	u32_t time = k_uptime_get_32();
+
+	return offset + amplitude * sin(time % UINT16_MAX);
+}
+
+/**
+ * @brief Calculates cosine from uptime
+ * The input to the sin() function is limited to avoid overflow issues.
+ *
+ * @param offset Offset for the cosine.
+ * @param amplitude Amplitude of cosine.
+ */
+static double generate_cosine(double offset, double amplitude)
+{
+	u32_t time = k_uptime_get_32();
+
+	return offset + amplitude * cos(time % UINT16_MAX);
+}
+
+/**
+ * @brief Generates a pseudo-random number between -1 and 1.
+ */
+static double generate_pseudo_random(void)
+{
+	static bool set_seed;
+
+	if (!set_seed) {
+		srand(k_cycle_get_32());
+		set_seed = true;
+	}
+
+	return (double)rand() / ((double) RAND_MAX / 2.0) - 1.0;;
+}
+
+/**
+ * @brief Function generatig GPS data
+ *
+ * @param nmea_sentence Pointer to gpssim_nmea struct where the NMEA
+ * sentence will be stored.
+ * @param max_variation The maximum value the latitude and longitude in the
+ * generated sentence can vary for each iteration. In units of minutes.
+ */
+static void generate_gps_data(
+	struct gps_data *nmea_sentence,
+	double max_variation)
+{
+	static u8_t hour = (const u8_t) base_gps_sample_hour;
+	static u8_t minute = base_gps_sample_minute;
+	static u8_t second = base_gps_sample_second;
+	static u32_t last_uptime;
+	double lat = base_gps_sample_lat;
+	double lng = base_gps_sample_lng;
+
+	if (IS_ENABLED(CONFIG_GPS_SIM_ELLIPSOID)) {
+		lat = generate_sine(base_gps_sample_lat, max_variation);
+		lng = generate_cosine(base_gps_sample_lng, max_variation);
+	}
+
+	if (IS_ENABLED(CONFIG_GPS_SIM_PSEUDO_RANDOM)) {
+		static double acc_lat;
+		static double acc_lng;
+
+		acc_lat += max_variation * generate_pseudo_random();
+		acc_lng += max_variation * generate_pseudo_random();
+		lat = base_gps_sample_lat + acc_lat;
+		lng = base_gps_sample_lng + acc_lng;
+	}
+
+	u32_t uptime = k_uptime_get_32() / MSEC_PER_SEC;
+
+	second += (uptime - last_uptime);
+	last_uptime = uptime;
+
+	if (second > 59) {
+		second = second % 60;
+		minute += 1;
+		if (minute > 59) {
+			minute = minute % 60;
+			hour += 1;
+			hour = hour % 24;
+		}
+	}
+
+	char tmp_str[GPS_NMEA_SENTENCE_MAX_LENGTH];
+
+	snprintf(tmp_str, GPS_NMEA_SENTENCE_MAX_LENGTH,
+		"$GPGGA,%02d%02d%02d.200,%8.3f,N,%09.3f,E,1,"
+		"12,1.0,0.0,M,0.0,M,,*",
+		hour, minute, second, lat, lng);
+
+	u8_t checksum = nmea_checksum_get(tmp_str);
+
+	nmea_sentence->len =
+		snprintf(nmea_sentence->str, GPS_NMEA_SENTENCE_MAX_LENGTH,
+			"%s%02X", tmp_str, checksum);
+}
+
+static int gps_sim_init(struct device *dev)
+{
+	base_gps_sample_lat = CONFIG_GPS_SIM_BASE_LATITUDE / 1000.0;
+	base_gps_sample_lng = CONFIG_GPS_SIM_BASE_LONGITUDE / 1000.0;
+
+	if (IS_ENABLED(CONFIG_GPS_SIM_TRIGGER)) {
+		if (IS_ENABLED(CONFIG_GPS_SIM_TRIGGER_USE_BUTTON)) {
+			struct gps_sim_data *drv_data = dev->driver_data;
+
+			drv_data->gpio_port = SW1_GPIO_NAME;
+			drv_data->gpio_pin = SW1_GPIO_PIN;
+		}
+		if (gps_sim_init_thread(dev) < 0) {
+			SYS_LOG_ERR("Failed to initialize trigger interrupt");
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Generates simulated GPS data for a channel.
+ *
+ * @param chan Channel to generate data for.
+ */
+static int gps_sim_generate_data(enum gps_channel chan)
+{
+	static double max_step = CONFIG_GPS_SIM_MAX_STEP / 1000.0;
+
+	switch (chan) {
+	case GPS_CHAN_NMEA:
+		generate_gps_data(&nmea_sample, max_step);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int gps_sim_sample_fetch(struct device *dev)
+{
+	return gps_sim_generate_data(GPS_CHAN_NMEA);
+}
+
+static int gps_sim_channel_get(struct device *dev, enum gps_channel chan,
+				   struct gps_data *sample)
+{
+	switch (chan) {
+	case GPS_CHAN_NMEA:
+		memcpy(sample->str, nmea_sample.str, nmea_sample.len);
+		sample->len = nmea_sample.len;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static struct gps_sim_data gps_sim_data;
+
+static const struct gps_driver_api gps_sim_api_funcs = {
+	.sample_fetch = gps_sim_sample_fetch,
+	.channel_get = gps_sim_channel_get,
+#if defined(CONFIG_GPS_SIM_TRIGGER)
+	.trigger_set = gps_sim_trigger_set
+#endif
+};
+
+/* TODO: Remove this when the GPS API has Kconfig that sets the priority */
+#ifdef CONFIG_GPS_INIT_PRIORITY
+#define GPS_INIT_PRIORITY CONFIG_GPS_INIT_PRIORITY
+#else
+#define GPS_INIT_PRIORITY 90
+#endif
+
+DEVICE_AND_API_INIT(gps_sim, CONFIG_GPS_SIM_DEV_NAME, gps_sim_init,
+			&gps_sim_data, NULL, POST_KERNEL, GPS_INIT_PRIORITY,
+			&gps_sim_api_funcs);


### PR DESCRIPTION
This commit adds a GPS simulator using GPS API. It can be used to
generate NMEA strings of GGA type (no other types supported now).
The strings can be dynamically created from a fixed starting-point
set in Kconfig, and either simulate a random walk or a
circular/ellipsoid pattern.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>

--

~~**Note**: The GPS simulator currently only works as intended in together with the sensor simulator added in #152 and GPS API in #146. A fix will be added later for it to run without the need of enabling the sensor simulator as well.~~ 

**Update**: Standalone issue fixed.