### PR TITLE
lib: dk_buttons_and_leds: Add library for buttons and LEDs on Nordic DKs

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,3 +7,4 @@
 add_subdirectory_ifdef(CONFIG_BSD_LIBRARY bsdlib)
 add_subdirectory_ifdef(CONFIG_GPS_SIM gps_sim)
 add_subdirectory_ifdef(CONFIG_SENSOR_SIM sensor_sim)
+add_subdirectory_ifdef(CONFIG_DK_LIBRARY dk_buttons_and_leds)

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -10,6 +10,8 @@ rsource "bsdlib/Kconfig"
 
 rsource "gps_sim/Kconfig"
 
+rsource "dk_buttons_and_leds/Kconfig"
+
 rsource "sensor_sim/Kconfig"
 
 endmenu

--- a/lib/dk_buttons_and_leds/CMakeLists.txt
+++ b/lib/dk_buttons_and_leds/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_library()
+zephyr_library_sources(dk_buttons_and_leds.c)
+zephyr_include_directories(.)

--- a/lib/dk_buttons_and_leds/Kconfig
+++ b/lib/dk_buttons_and_leds/Kconfig
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+menu "Button and LED Library for Nordic DKs"
+
+config DK_LIBRARY
+	bool "Button and LED Library for Nordic DKs"
+
+if DK_LIBRARY
+
+config DK_LIBRARY_BUTTON_SCAN_INTERVAL
+	int "Scanning interval of buttons in milliseconds"
+	default 10
+
+config DK_LIBRARY_INVERT_BUTTONS
+	bool "Invert buttons pins on DK"
+	default y
+
+config DK_LIBRARY_INVERT_LEDS
+	bool "Invert LED pins on DK"
+	default y
+
+endif # DK_LIBRARY
+
+endmenu

--- a/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
+++ b/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+#include <board.h>
+#include <device.h>
+#include <gpio.h>
+#include <misc/util.h>
+#include <logging/sys_log.h>
+#include <dk_buttons_and_leds.h>
+
+static struct k_delayed_work buttons_scan;
+static const u8_t button_pins[] = { SW0_GPIO_PIN, SW1_GPIO_PIN,
+				    SW2_GPIO_PIN, SW3_GPIO_PIN };
+static const u8_t led_pins[] = { LED0_GPIO_PIN, LED1_GPIO_PIN,
+				 LED2_GPIO_PIN, LED3_GPIO_PIN };
+static button_handler_t button_handler_cb;
+static atomic_t my_buttons;
+struct device *gpio_dev;
+
+static int get_buttons(u32_t *mask)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(button_pins); i++) {
+		u32_t val;
+
+		if (gpio_pin_read(gpio_dev, button_pins[i], &val)) {
+			SYS_LOG_ERR("Cannot read gpio pin");
+			return -EFAULT;
+		}
+
+		if (IS_ENABLED(CONFIG_DK_LIBRARY_INVERT_BUTTONS)) {
+			val = (~val) & 0x01;
+		}
+
+		*mask |= (val << i);
+	}
+
+	return 0;
+}
+
+static void buttons_scan_fn(struct k_work *work)
+{
+	static u32_t last_button_scan;
+	static bool initial_run = true;
+	u32_t button_scan = 0;
+
+	get_buttons(&button_scan);
+	atomic_set(&my_buttons, (atomic_val_t)button_scan);
+
+	if (!initial_run) {
+		if (button_handler_cb != NULL) {
+			if (button_scan != last_button_scan) {
+				u32_t has_changed;
+
+				has_changed = (button_scan ^ last_button_scan);
+				button_handler_cb(button_scan, has_changed);
+			}
+		}
+	} else {
+		initial_run = false;
+	}
+
+	last_button_scan = button_scan;
+	int err = k_delayed_work_submit(&buttons_scan,
+		  CONFIG_DK_LIBRARY_BUTTON_SCAN_INTERVAL);
+
+	if (err) {
+		SYS_LOG_ERR("Cannot add work to workqueue");
+	}
+}
+
+int dk_buttons_and_leds_init(button_handler_t button_handler)
+{
+	int err;
+
+	if (button_handler != NULL) {
+		button_handler_cb = button_handler;
+	}
+
+	gpio_dev = device_get_binding(CONFIG_GPIO_P0_DEV_NAME);
+	if (!gpio_dev) {
+		SYS_LOG_ERR("Cannot bind gpio device");
+		return -ENODEV;
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(button_pins); i++) {
+		err = gpio_pin_configure(gpio_dev, button_pins[i],
+				GPIO_DIR_IN | GPIO_PUD_PULL_UP);
+
+		if (err) {
+			SYS_LOG_ERR("Cannot configure button gpio");
+			return err;
+		}
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(led_pins); i++) {
+		err = gpio_pin_configure(gpio_dev, led_pins[i],
+				GPIO_DIR_OUT);
+
+		if (err) {
+			SYS_LOG_ERR("Cannot configure LED gpio");
+			return err;
+		}
+	}
+
+	dk_set_leds_state(DK_NO_LEDS_MSK, DK_ALL_LEDS_MSK);
+
+	k_delayed_work_init(&buttons_scan, buttons_scan_fn);
+	err = k_delayed_work_submit(&buttons_scan, 0);
+	if (err) {
+		SYS_LOG_ERR("Cannot add work to workqueue");
+		return err;
+	}
+
+	dk_read_buttons(NULL, NULL);
+
+	return 0;
+}
+
+void dk_read_buttons(u32_t *button_state, u32_t *has_changed)
+{
+	static u32_t last_state;
+	u32_t current_state = atomic_get(&my_buttons);
+
+	if (button_state != NULL) {
+		*button_state = current_state;
+	}
+
+	if (has_changed != NULL) {
+		*has_changed = (current_state ^ last_state);
+	}
+
+	last_state = current_state;
+}
+
+int dk_set_leds(u32_t leds)
+{
+	return dk_set_leds_state(leds, DK_ALL_LEDS_MSK);
+}
+
+int dk_set_leds_state(u32_t leds_on_mask, u32_t leds_off_mask)
+{
+	if ((leds_on_mask & ~DK_ALL_LEDS_MSK) != 0 ||
+	   (leds_off_mask & ~DK_ALL_LEDS_MSK) != 0) {
+		return -EINVAL;
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(led_pins); i++) {
+		if ((BIT(i) & leds_on_mask) || (BIT(i) & leds_off_mask)) {
+			u32_t val = (BIT(i) & leds_on_mask) ? (1) : (0);
+
+			if (IS_ENABLED(CONFIG_DK_LIBRARY_INVERT_LEDS)) {
+				val = 1 - val;
+			}
+
+			int err = gpio_pin_write(gpio_dev, led_pins[i], val);
+
+			if (err) {
+				SYS_LOG_ERR("Cannot write LED gpio");
+				return err;
+			}
+		}
+	}
+
+	return 0;
+}

--- a/lib/dk_buttons_and_leds/dk_buttons_and_leds.h
+++ b/lib/dk_buttons_and_leds/dk_buttons_and_leds.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef DK_BUTTON_AND_LEDS_H__
+#define DK_BUTTON_AND_LEDS_H__
+
+/** @file dk_buttons_and_leds.h
+ * @brief Module to handle buttons and LEDs on Nordic DKs.
+ * @defgroup dk_buttons_and_leds DK buttons and leds
+ * @{
+ */
+
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DK_NO_LEDS_MSK    (0)
+#define DK_LED1_MSK       BIT(0)
+#define DK_LED2_MSK       BIT(1)
+#define DK_LED3_MSK       BIT(2)
+#define DK_LED4_MSK       BIT(3)
+#define DK_ALL_LEDS_MSK   (DK_LED1_MSK | DK_LED2_MSK |\
+			   DK_LED3_MSK | DK_LED4_MSK)
+
+/**
+ * @typedef button_handler_t
+ * @brief Callback executed when button state change is detected
+ *
+ * @param button_state Bitmask of button states
+ * @param has_changed Bitmask that shows wich buttons that have changed.
+ */
+typedef void (*button_handler_t)(u32_t button_state, u32_t has_changed);
+
+/** @brief Initialize the button and led library.
+ *
+ *  @param  button_handler Callback handler for button state changes.
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int dk_buttons_and_leds_init(button_handler_t button_handler);
+
+/** @brief Read current button states
+ *
+ * @param button_state Bitmask of button states
+ * @param has_changed Bitmask that shows wich buttons that have changed.
+ */
+void dk_read_buttons(u32_t *button_state, u32_t *has_changed);
+
+/** @brief Set value of LED pins
+ *
+ *  @param  leds Bitmask that that will turn on and of the LEDs
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int dk_set_leds(u32_t leds);
+
+
+/** @brief Set value of LED pins.
+ *
+ *  @param  leds_on_mask Bitmask that that will turn on the corresponding
+ *                       LEDs. In cases where it overlaps with
+ *                       leds_off_mask, the leds_on_mask will have priority.
+ *
+ *  @param  leds_off_mask Bitmask that that will turn off the corresponding
+ *                        LEDs. In cases where it overlaps with
+ *                        leds_on_mask, the leds_on_mask will have priority.
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int dk_set_leds_state(u32_t leds_on_mask, u32_t leds_off_mask);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* DK_BUTTON_AND_LEDS_H__ */


### PR DESCRIPTION
Adding a simple library to interface with the buttons and LEDs on Nordic
DKs.
Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>

Simple library to interface with LEDs and Buttons on the DK.  It is needed for the nrf cloud demo, but is tested on PCA10040, PCA10056 and PCA10090. Button presses can be detected with both using  callback and a polling function. The library itself uses polling at 10 ms interval to detect changes. This is a simple de-bouncing technique that works quite well. 

edit: Now also tested with nRF51 on the PCA10028