### PR TITLE
net: mqtt: Fix path to net logger config

### DIFF
--- a/subsys/net/lib/mqtt_socket/Kconfig
+++ b/subsys/net/lib/mqtt_socket/Kconfig
@@ -18,7 +18,7 @@ module=MQTT
 module-dep=NET_LOG
 module-str=Log level for MQTT
 module-help=Enables mqtt debug messages.
-source "subsys/net/Kconfig.template.log_config.net"
+source "${ZEPHYR_BASE}/subsys/net/Kconfig.template.log_config.net"
 
 config MQTT_MAX_CLIENTS
 	int "Maximum number of clients"


### PR DESCRIPTION
The net logger Kconfig template is in the Zephyr tree and not in
the nrf tree. Fix the path so that it refers to it properly.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>