### PR TITLE
doc: nrfCloud: add documentation

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -67,7 +67,8 @@ MCUBOOT_OUTPUT = os.path.abspath(os.environ["MCUBOOT_OUTPUT"])
 # ones.
 extensions = ['sphinx.ext.intersphinx',
               'breathe',
-              'sphinx.ext.ifconfig']
+              'sphinx.ext.ifconfig',
+              'sphinxcontrib.mscgen']
 
 # Add any paths that contain templates here, relative to this directory.
 #templates_path = ['../_templates']

--- a/doc/nrf/libraries.rst
+++ b/doc/nrf/libraries.rst
@@ -20,3 +20,10 @@ Here you can find documentation for these libraries, including API documentation
    :glob:
 
    ../../include/bluetooth/services/*
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Other libraries:
+   :glob:
+
+   ../../include/*

--- a/include/nrf_cloud.h
+++ b/include/nrf_cloud.h
@@ -13,14 +13,16 @@
 extern "C" {
 #endif
 
-/**@defgroup enum nrf_cloud_evt_type nRF Cloud events
+/** @defgroup nrf_cloud nRF Cloud
  * @{
- * @brief Asynchronous events notified by the module.
  */
+
+
+/** @brief Asynchronous nRF Cloud events notified by the module. */
 enum nrf_cloud_evt_type {
 	/** The transport to the nRF Cloud is established. */
 	NRF_CLOUD_EVT_TRANSPORT_CONNECTED = 0x1,
-	/** A request from nRF Cloud to associate the device
+	/** There was a request from nRF Cloud to associate the device
 	 * with a user on the nRF Cloud. On receiving this
 	 * event, the user must enter the user association sequence using
 	 * the @ref nrf_cloud_user_associate API.
@@ -31,7 +33,7 @@ enum nrf_cloud_evt_type {
 	/** The device can now start sending sensor data to the cloud. */
 	NRF_CLOUD_EVT_READY,
 	/** A sensor was successfully attached to the cloud.
-	 * Supported sensor types are defined @ref nrf_cloud_sensor_types.
+	 * Supported sensor types are defined in @ref nrf_cloud_sensor.
 	 */
 	NRF_CLOUD_EVT_SENSOR_ATTACHED,
 	/** The device received data from the cloud. */
@@ -43,34 +45,23 @@ enum nrf_cloud_evt_type {
 	/** There was an error communicating with the cloud. */
 	NRF_CLOUD_EVT_ERROR = 0xFF
 };
-/**@}  */
 
-/**@defgroup nrf_cloud_user_association_types nRF Cloud user association types
- * @{
- * @brief User association types supported by the nRF Cloud.
- */
+
+/** @brief User association types supported by the nRF Cloud. */
 enum nrf_cloud_ua {
 	/** Button input. */
 	NRF_CLOUD_UA_BUTTON,
 };
-/**@}  */
 
-/**@defgroup nrf_cloud_sensor_types nRF Cloud sensor types
- * @{
- * @brief Sensor types supported by the nRF Cloud.
- */
+/** @brief Sensor types supported by the nRF Cloud. */
 enum nrf_cloud_sensor {
 	/** The GPS sensor on the device. */
 	NRF_CLOUD_SENSOR_GPS,
 	/** The FLIP movement sensor on the device. */
 	NRF_CLOUD_SENSOR_FLIP,
 };
-/**@}  */
 
-/**@defgroup nrf_cloud_ua_button_valid_input nRF Cloud input values for
- * user association.
- * @{
- * @brief User input sequence for user association type
+/** @brief User input sequence values for user association type
  * @ref NRF_CLOUD_UA_BUTTON.
  */
 enum nrf_cloud_ua_button {
@@ -79,7 +70,6 @@ enum nrf_cloud_ua_button {
 	NRF_CLOUD_UA_BUTTON_INPUT_3,       /**< Button Input 3. */
 	NRF_CLOUD_UA_BUTTON_INPUT_4,       /**< Button Input 4. */
 };
-/**@}  */
 
 /**@brief Generic encapsulation for any data that is sent to the cloud. */
 struct nrf_cloud_data {
@@ -137,7 +127,7 @@ struct nrf_cloud_sensor_data {
 	u32_t tag;
 };
 
-/**@brief Structure of asynchronous events received from the module. */
+/**@brief Asynchronous events received from the module. */
 struct nrf_cloud_evt {
 	/** The event that occurred. */
 	enum nrf_cloud_evt_type type;
@@ -173,34 +163,23 @@ struct nrf_cloud_init_param {
  *
  * @param[in] param Initialization parameters.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
  */
 int nrf_cloud_init(const struct nrf_cloud_init_param *param);
 
 /**
  * @brief Connect to the cloud.
  *
- * If this API succeeds, expect the following sequence:
- *
- * @msc
- * hscale = "1.3";
- * Module,Application;
- * Module<<Application      [label="nrf_cloud_connect() returns successfully"];
- * Module>>Application      [label="NRF_CLOUD_EVT_TRANSPORT_CONNECTED"];
- * Module>>Application      [label="NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST
- * (conditional)"]; Module<<Application [label="nrf_cloud_user_associate()"];
- * Module box Application   [label="nrf_cloud_user_associate() must be called
- * only if NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST is received."];
- * Module>>Application      [label="NRF_CLOUD_EVT_USER_ASSOCIATED"];
- * @endmsc
- *
- * During any of these phases, an @ref NRF_CLOUD_EVT_ERROR might be received.
+ * In any stage of connecting to the cloud, an @ref NRF_CLOUD_EVT_ERROR
+ * might be received.
  * If it is received before @ref NRF_CLOUD_EVT_TRANSPORT_CONNECTED,
  * the application may repeat the call to @ref nrf_cloud_connect to try again.
  *
  * @param[in] param Parameters to be used for the connection.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
  */
 int nrf_cloud_connect(const struct nrf_cloud_connect_param *param);
 
@@ -213,7 +192,8 @@ int nrf_cloud_connect(const struct nrf_cloud_connect_param *param);
  *
  * @param[in] param	User association information.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
  */
 int nrf_cloud_user_associate(const struct nrf_cloud_ua_param *param);
 
@@ -227,7 +207,8 @@ int nrf_cloud_user_associate(const struct nrf_cloud_ua_param *param);
  *
  * @param[in] param	Sensor information.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
  */
 int nrf_cloud_sensor_attach(const struct nrf_cloud_sa_param *param);
 
@@ -241,7 +222,8 @@ int nrf_cloud_sensor_attach(const struct nrf_cloud_sa_param *param);
  *
  * @param[in] param Sensor data.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
  */
 int nrf_cloud_sensor_data_send(const struct nrf_cloud_sensor_data *param);
 
@@ -253,7 +235,8 @@ int nrf_cloud_sensor_data_send(const struct nrf_cloud_sensor_data *param);
  *
  * @param[in] param Sensor data.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
  */
 int nrf_cloud_sensor_data_stream(const struct nrf_cloud_sensor_data *param);
 
@@ -265,7 +248,8 @@ int nrf_cloud_sensor_data_stream(const struct nrf_cloud_sensor_data *param);
  * If the API succeeds, you can expect the
  * @ref NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED event.
  *
- * @return Zero on success or (negative) error code otherwise.
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
  */
 int nrf_cloud_disconnect(void);
 
@@ -274,6 +258,9 @@ int nrf_cloud_disconnect(void);
  * functional.
  */
 void nrf_cloud_process(void);
+
+
+  /** @} */
 
 #ifdef __cplusplus
 }

--- a/include/nrf_cloud.rst
+++ b/include/nrf_cloud.rst
@@ -1,0 +1,142 @@
+.. _lib_nrf_cloud:
+
+nRF Cloud library
+#################
+
+The nRF Cloud library enables applications to connect to Nordic Semiconductor's nRF Cloud. It abstracts and hides the details of the transport and the encoding scheme that is used for the payload and provides a simplified API interface for sending data from supported sensor types to the cloud. The current implementation supports the following technology:
+
+* GPS and FLIP sensor data
+* TLS secured MQTT as communication protocol
+* JSON as data format
+
+.. _lib_nrf_cloud_init:
+
+Initializing
+************
+Before using any other APIs of the module, the application must call :c:func:`nrf_cloud_init`. If this API fails, the application must not use any APIs of the module.
+
+.. note::
+   Initialize the module before starting any timers, sensor drivers, or communication on the link.
+
+.. _lib_nrf_cloud_connect:
+
+Connecting
+**********
+The application can use :c:func:`nrf_cloud_connect` to connect to the cloud. This API triggers a series of events and actions in the system. If the API fails, the application must retry to connect.
+:c:func:`nrf_cloud_connect` requires a list of supported features in the application.
+Use the following code in your application to initialize this list:
+
+
+.. code-block:: c
+
+   /* Array of supported user association methods. */
+   const enum nrf_cloud_ua supported_uas[] = {
+		NRF_CLOUD_UA_BUTTON
+   };
+
+   /* Array of supported sensors. */
+   const enum nrf_cloud_sensor supported_sensors[] = {
+		NRF_CLOUD_SENSOR_GPS,
+		NRF_CLOUD_SENSOR_FLIP
+   };
+
+   /* List of supported user association methods. */
+   const struct nrf_cloud_ua_list ua_list = {
+		.size = ARRAY_SIZE(supported_uas),
+		.ptr = supported_uas
+   };
+
+   /* List of supported sensors. */
+   const struct nrf_cloud_sensor_list sensor_list = {
+		.size = ARRAY_SIZE(supported_sensors),
+		.ptr = supported_sensors
+   };
+
+   /* Struct containing both lists. */
+   const struct nrf_cloud_connect_param param = {
+		.ua = &ua_list,
+		.sensor = &sensor_list,
+   };
+
+   int err = nrf_cloud_connect(&param);
+
+
+First, the library tries to establish the transport for communicating with the cloud. This procedure involves a TLS handshake that might take up to three seconds. The API blocks for the duration of the handshake.
+
+Next, the API subscribes to an MQTT topic to start receiving user association requests from the cloud.
+
+Every time nRF Cloud starts a communication session with a device, it verifies if the device is uniquely associated with a user. If not, the user association procedure is triggered. The following message sequence chart shows the flow of events and expected application responses to each event:
+
+.. msc::
+   hscale = "1.3";
+   Module,Application;
+   Module<<Application      [label="nrf_cloud_connect() returns successfully"];
+   Module>>Application      [label="NRF_CLOUD_EVT_TRANSPORT_CONNECTED"];
+   Module>>Application      [label="NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST"];
+   Module<<Application      [label="nrf_cloud_user_associate()"];
+   Module>>Application      [label="NRF_CLOUD_EVT_USER_ASSOCIATED"];
+   Module>>Application      [label="NRF_CLOUD_EVT_READY"];
+   Module>>Application      [label="NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED"];
+
+.. note::
+   This chart shows the sequence of successful user association of an unassociated device. Currently, nRF Cloud requires that communication is re-established to update the device's permission to send user data. This is why the :c:data:`NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED` event occurs. The application must reconnect to the cloud using the :c:func:`nrf_cloud_connect` API.
+
+When the device is successfully associated with a user on the cloud, subsequent connections to the cloud (also across power cycles) follow this sequence:
+
+.. msc::
+   hscale = "1.3";
+   Module,Application;
+   Module<<Application      [label="nrf_cloud_connect() returns successfully"];
+   Module>>Application      [label="NRF_CLOUD_EVT_TRANSPORT_CONNECTED"];
+   Module>>Application      [label="NRF_CLOUD_EVT_USER_ASSOCIATED"];
+   Module>>Application      [label="NRF_CLOUD_EVT_READY"];
+
+After receiving :c:data:`NRF_CLOUD_EVT_READY`, the application can start sending sensor data to the cloud.
+
+.. _lib_nrf_cloud_ua_failure:
+
+User association failure
+************************
+User association might fail due to the following reasons:
+
+* Mismatch in the input sequence from the device
+* Time-out on the cloud
+
+If there is a mismatch in the sequence, the library generates a new :c:data:`NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST` event, and the user can try again. This event may be triggered several times until the cloud receives a matching sequence.
+
+If a time-out occurs, :c:data:`NRF_CLOUD_EVT_ERROR` is triggered and sent to the application. If this event is received, disconnect from the cloud using the :c:func:`nrf_cloud_disconnect` API. The application must wait for the :c:data:`NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED` event before attempting a new connection to the cloud.
+
+.. _lib_nrf_cloud_data:
+
+Sending sensor data
+*******************
+The library offers two APIs, :c:func:`nrf_cloud_sensor_data_send` and :c:func:`nrf_cloud_sensor_data_stream`, for sending sensor data to the cloud. Currently, the supported sensor types are GPS and FLIP (see :c:type:`nrf_cloud_sensor_types`).
+
+Use :c:func:`nrf_cloud_sensor_data_stream` to send sensor data with best quality.
+
+Before sending any sensor data, call the function :c:func:`nrf_cloud_sensor_attach` with the type of the sensor.
+Note that this function must be called after receiving the event :c:data:`NRF_CLOUD_EVT_READY`. It triggers the event :c:data:`NRF_CLOUD_EVT_SENSOR_ATTACHED` if the execution was successful.
+
+.. _lib_nrf_cloud_unlink:
+
+Removing the link between device and user
+*****************************************
+If you want to remove the link between a device and an nRF Cloud user, you must do this from the nRF Cloud. It is not possible for a device to unlink itself.
+
+When a user disassociates a device, the library disallows any further sensor data to be sent to the cloud and generates an :c:data:`NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST` event. The application can then decide to associate again by responding with :c:func:`nrf_cloud_user_associate` with the new input sequence. See the following message sequence chart:
+
+.. msc:
+   hscale = "1.3";
+   Module,Application;
+   Module>>Application      [label="NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST"];
+   Module<<Application      [label="nrf_cloud_user_associate()"];
+   Module>>Application      [label="NRF_CLOUD_EVT_USER_ASSOCIATED"];
+   Module>>Application      [label="NRF_CLOUD_EVT_READY"];
+   Module>>Application      [label="NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED"];
+
+
+API documentation
+*****************
+
+.. doxygengroup:: nrf_cloud
+   :project: nrf


### PR DESCRIPTION
Add documentation for nRF Cloud library and fix API documentation.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>

Not sure if this will go in, but here's a draft of the nRF Cloud library documentation, copied from the nRF5 SDK. There are problems with MSCs that must be discussed.

Output: 
[nRF Cloud library — nRF SDK 0.1.0 documentation.pdf](https://github.com/NordicPlayground/fw-nrfconnect-nrf/files/2514993/nRF.Cloud.library.nRF.SDK.0.1.0.documentation.pdf)
