### PR TITLE
subsys: net: lib: nrf_cloud: Adding IPv6 support

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -46,4 +46,8 @@ config NRF_CLOUD_PORT
 	depends on NRF_CLOUD
 	default 8883
 
+config NRF_CLOUD_IPV6
+	bool "Configure nRF Cloud library to use IPv6 addressing. Otherwise IPv4 is used."
+	depends on NRF_CLOUD
+
 endmenu


### PR DESCRIPTION
Adding IPv6 support to nRF Cloud Lib.

Depend on merging https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/166 first. Also fixes issues reported here: https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/154#discussion_r226611925

cc @oxalistriangularis @gbakke @rlubos 