### PR TITLE
lib: dk_buttons_and_leds: Include nrfx.h to make GPIO defines available

### DIFF
--- a/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
+++ b/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
@@ -10,6 +10,7 @@
 #include <gpio.h>
 #include <misc/util.h>
 #include <logging/sys_log.h>
+#include <nrfx.h>
 #include <dk_buttons_and_leds.h>
 
 static struct k_delayed_work buttons_scan;


### PR DESCRIPTION
This patch adds include of nrfx.h to make necessary GPIO defines for
available for the DK buttons and LEDs library.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>