### PR TITLE
subsys: ble: controller: Place Kconfig options inside a menu

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -6,6 +6,10 @@
 
 menu "Nordic nRF Bluetooth"
 
+if BT_LL_NRFXLIB
+rsource "controller/Kconfig"
+endif # CONFIG_BT_LL_NRFXLIB
+
 config NRF_BT
 	bool
 	prompt "Enable Bluetooth"
@@ -17,9 +21,5 @@ if NRF_BT
 rsource "common/Kconfig"
 rsource "services/Kconfig"
 endif # NRF_BT
-
-if BT_LL_NRFXLIB
-rsource "controller/Kconfig"
-endif # CONFIG_BT_LL_NRFXLIB
 
 endmenu

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -1,3 +1,5 @@
+menu "Nordic BLE controller"
+
 config BLECTLR_PRIO
 	# Hidden option to set the priority of the controller threads
 	int
@@ -17,3 +19,5 @@ config BLECTLR_SIGNAL_STACK_SIZE
 	help
 	  Size of the signal handler thread stack, used to process lower
 	  priority signals in the controller.
+
+endmenu


### PR DESCRIPTION
The controller menuconfig entries appeared next to unrelated entries, and without any comment indicating they pertained to the BLE controller. This patch creates a menuconfig menu entry for the BLE controller, and makes that entry appear first in the Bluetooth subsystem menu.