### PR TITLE
samples: nrf9160: secure boot: fix initial NS SP setting

### DIFF
--- a/samples/nrf9160/secure_boot/src/main.c
+++ b/samples/nrf9160/secure_boot/src/main.c
@@ -363,7 +363,7 @@ static void secure_boot_jump(void)
 		.msp_ns = vtor_ns[0],
 		.psp_ns = 0,
 		.control_ns.npriv = 0, /* Privileged mode*/
-		.control_ns.spsel = 1 /* Use PSP in Thread mode */
+		.control_ns.spsel = 0 /* Use MSP in Thread mode */
 	};
 
 	secure_boot_configure_ns(&secure_boot_ns_conf);


### PR DESCRIPTION
This commit modifies the initial setting of the Non-Secure
instance of the CONTROL register, so upon Non-Secure system
boot the MSP is used. The patch allows any (non Zephyr-based)
non-secure firmware to boot properly.

Signed-off-by: Ioannis <Ioannis.Glaropoulos@nordicsemi.no>