### PR TITLE
subsys: bluetooth: controller: Show library variant in menuconfig

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -20,4 +20,13 @@ config BLECTLR_SIGNAL_STACK_SIZE
 	  Size of the signal handler thread stack, used to process lower
 	  priority signals in the controller.
 
+# The BLE controller library variants are defined in nrfxlib, here we redefine
+# the choice to 'import' them, so they appear in the same menu as the rest.
+
+choice BLE_CONTROLLER_VARIANT
+	prompt "BLE Controller variant"
+	bool
+
+endchoice
+
 endmenu


### PR DESCRIPTION
The ble_controller library variant is currently shown under `Nordic nrfxlib` menu. However, the "glue" layer's configuration option are under `subsystems, Bluetooth Low Energy, Nordic BLE controller`.

I think it makes sense for the variant choice to be defined in nrfxlib, since it is part of the controller library's integration into Zephyr's build system, and for the rest of the settings to be defined in fw-nrfconnect-nrf since they belong to the integration layer between the library and Zephyr's stack.

I also believe it is desirable to have these entries grouped in the actual menu so this patch _duplicates_ those entries under `Nordic BLE controller` to make them all accessible in one place.
