### PR TITLE
lib: Add support for modem traces over UART.

### DIFF
--- a/lib/bsdlib/Kconfig
+++ b/lib/bsdlib/Kconfig
@@ -8,5 +8,8 @@ menu "BSD Library for nrf91"
 config BSD_LIBRARY
 	bool "BSD Socket library for IP/TLS/DTLS"
 	select FLOAT
+	# Modem tracing over UART use the UARTE1 as dedicated peripheral.
+	# This enable UARTE1 peripheral and includes nrfx UARTE driver.
+	select NRFX_UARTE1
 	depends on CPU_CORTEX_M33
 endmenu

--- a/lib/bsdlib/bsd_os.h
+++ b/lib/bsdlib/bsd_os.h
@@ -29,7 +29,17 @@ void bsd_os_application_irq_clear(void);
 
 void bsd_os_application_irq_set(void);
 
+void bsd_os_trace_irq_set(void);
+
+void bsd_os_trace_irq_clear(void);
+
+s32_t bsd_os_trace_put(const u8_t * const data, u32_t len);
+
+/* Need extern to not generate mock in testing. */
 extern void bsd_os_application_irq_handler(void);
+
+/* Need extern to not generate mock in testing. */
+extern void bsd_os_trace_irq_handler(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Implements a basic UART transport in Zephyr using nrfx drivers in order
to do DMA transfers of more than one byte. Use UARTE in non-blocking
mode without IRQ. Nrfx is enabled by default with nrf9160 SiP, but UARTE
peripherals have to be enabled manually.
UARTE2 is configured and used to print out modem traces. Modem traces
and UART print are handled in a dedicated IRQ context with lower
priority.

Signed-off-by: Christopher Métrailler <chme@nordicsemi.no>