### PR TITLE
subsys: profiler: declare log_event_buf contents conditionally

### DIFF
--- a/include/profiler.h
+++ b/include/profiler.h
@@ -49,10 +49,12 @@ enum profiler_arg {
  * Buffer required for data, which is send with event.
  */
 struct log_event_buf {
+#ifdef CONFIG_PROFILER
 	/** Pointer to the end of payload */
 	u8_t *payload;
 	/** Array where payload is located before it is send */
 	u8_t payload_start[CONFIG_PROFILER_CUSTOM_EVENT_BUF_LEN];
+#endif
 };
 
 


### PR DESCRIPTION
In profiler.h, the struct log_event_buf relies on PROFILER_CUSTOM_EVENT_BUF_LEN being defined, which is not the case if the profiler is disabled. This patch lets the contents of log_event_buf be compiled out in such case, to prevent errors when compiling a C file including profiler.h.

This is possible since event_manager does not uses the contents of the log_event_buf struct directly but only passes that to the profiler; when the profiler is disabled, the struct can be empty.