### PR TITLE
net: mqtt: Remove redundant instance reset.

### DIFF
--- a/subsys/net/lib/mqtt_socket/mqtt.c
+++ b/subsys/net/lib/mqtt_socket/mqtt.c
@@ -92,11 +92,6 @@ void event_notify(struct mqtt_client *client, const struct mqtt_evt *evt,
 		evt_cb(client, evt);
 
 		mqtt_mutex_lock();
-
-		if (flags & MQTT_EVT_FLAG_INSTANCE_RESET) {
-			client_free(client);
-			client_init(client);
-		}
 	}
 }
 


### PR DESCRIPTION
Delete redundant instance reinitialization - it has to be done by the
application anyway, and reinitializing the client silently in the
library generates memory management issues.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>