### PR TITLE
lib: at_host: Correct string termination in Kconfig

### DIFF
--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -40,12 +40,12 @@ choice
 	help
 		Sets the termination ending from the serial terminal
 		Levels are:
-		-  \0 Termination
+		-  NULL Termination
 		-  CR Termination
 		-  LF Termination
 		-  CR+LF Termination
 	config NULL_TERMINATION
-		bool "\\0 Termination"
+		bool "NULL Termination"
 	config CR_TERMINATION
 		bool "CR Termination"
 	config LF_TERMINATION


### PR DESCRIPTION
Changing '\0 Termination' to 'NULL Termination' so
json parsing will work.

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>