### PR TITLE
doc: updates in the wake of removing _fw-nrfconnect-nRF91-zephyr repo

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,8 +24,8 @@ Repositories
      - master
    * - `nrfxlib <https://github.com/NordicPlayground/nrfxlib>`_
      - master
-   * - `_fw-nrfconnect-nrf91-zephyr <https://github.com/NordicPlayground/_fw-nrfconnect-nrf91-zephyr>`_
-     - master
+   * - `_fw-nrfconnect-zephyr <https://github.com/NordicPlayground/_fw-nrfconnect-zephyr>`_
+     - nrf91
    * - `fw-nrfconnect-mcuboot <https://github.com/NordicPlayground/fw-nrfconnect-mcuboot>`_
      - master
 

--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -55,7 +55,7 @@ Cloning the repositories
 
    .. code-block:: console
 
-      git clone https://github.com/<username>/_fw-nrfconnect-nrf91-zephyr.git zephyr
+      git clone https://github.com/<username>/_fw-nrfconnect-zephyr.git zephyr
 
       git clone https://github.com/<username>/fw-nrfconnect-mcuboot.git mcuboot
 
@@ -69,7 +69,7 @@ Cloning the repositories
    .. code-block:: console
 
       cd zephyr
-      git remote add ncs https://github.com/NordicPlayground/_fw-nrfconnect-nrf91-zephyr.git
+      git remote add ncs https://github.com/NordicPlayground/_fw-nrfconnect-zephyr.git
 
       cd ../mcuboot
       git remote add ncs https://github.com/NordicPlayground/fw-nrfconnect-mcuboot.git
@@ -97,6 +97,17 @@ Your directory structure now looks like this::
     |___ nrf
     |___ nrfxlib
     |___ zephyr
+
+To be able to build |NCS| applications for nRF91, check out
+branch ``nrf91`` in the fw-nrfconnect-zephyr repository:
+
+   .. code-block:: console
+
+	cd ../zephyr
+	git checkout nrf91
+
+Pull requests related to nRF91 (for example, for nRF9160 SoC or Board support,
+drivers, and so on) must be submitted against the nRF91 branch.
 
 Installing additional Python dependencies
 *****************************************

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -15,7 +15,7 @@
 
 .. |ncs_repo| replace:: https://github.com/NordicPlayground/fw-nrfconnect-nrf
 
-.. |ncs_zephyr_repo| replace:: https://github.com/NordicPlayground/_fw-nrfconnect-nrf91-zephyr
+.. |ncs_zephyr_repo| replace:: https://github.com/NordicPlayground/_fw-nrfconnect-zephyr
 
 .. |ncs_mcuboot_repo| replace:: https://github.com/NordicPlayground/fw-nrfconnect-mcuboot
 
@@ -24,7 +24,7 @@
 .. |link_mcuboot| replace:: MCUboot
 .. _link_mcuboot: https://mcuboot.com
 
-.. _`nrf9160_pca10090_partition_conf.dts`: https://github.com/NordicPlayground/_fw-nrfconnect-nrf91-zephyr/blob/master/boards/arm/nrf9160_pca10090/nrf9160_pca10090_partition_conf.dts
+.. _`nrf9160_pca10090_partition_conf.dts`: https://github.com/NordicPlayground/_fw-nrfconnect-zephyr/blob/nrf91/boards/arm/nrf9160_pca10090/nrf9160_pca10090_partition_conf.dts
 
 .. _`J-Link Software and Documentation Pack`: https://www.segger.com/downloads/jlink
 


### PR DESCRIPTION
This commit updates several pages in the documentation
in the wake of the removal of the _fw-nrfconnect-nRF91-zephyr
repository.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>