### PR TITLE
samples: nrf_cloud: Add common error handling and reconnect on disconnect event

### DIFF
--- a/samples/nrf9160/nrf_cloud/src/main.c
+++ b/samples/nrf9160/nrf_cloud/src/main.c
@@ -77,7 +77,7 @@ static bool flip_mode_enabled = true;
 
 /* Structures for work */
 static struct k_delayed_work leds_update_work;
-static struct k_delayed_work connect_work;
+static struct k_work connect_work;
 
 enum error_type {
 	ERROR_NRF_CLOUD,
@@ -357,8 +357,8 @@ static void cloud_event_handler(const struct nrf_cloud_evt *p_evt)
 		atomic_set(&send_data_enable, 0);
 		display_state = LEDS_INITIALIZING;
 
-		/* Try to reconnect after 1 second back off time */
-		k_delayed_work_submit(&connect_work, K_SECONDS(1));
+		/* Reconnect to nRF Cloud. */
+		k_work_submit(&connect_work);
 		break;
 	case NRF_CLOUD_EVT_ERROR:
 		printk("NRF_CLOUD_EVT_ERROR, status: %d\n", p_evt->status);


### PR DESCRIPTION
This PR adds common error handling for
graceful shutdown of LTE link and BSD library, when possible.
After shutdown of link and BSD lib, it either reboots the
system or displays a pattern of blinking LEDs to signal
which kind of error occured. Rebooting is set as default.

The PR also adds immediate reconnect to nRF Cloud after a disconnect
event, as the underlying layers now allow this.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>