### PR TITLE
subsys: bluetooth: fixing memory management in gatt db discovery

### DIFF
--- a/subsys/bluetooth/common/gatt_db_discovery.c
+++ b/subsys/bluetooth/common/gatt_db_discovery.c
@@ -73,7 +73,7 @@ static void svc_attr_memory_release(void)
 	memset(attrs, 0, sizeof(attrs));
 	cur_attr_id = 0;
 	/* Release dynamic memory data chunks */
-	for (size_t i = 0; i < cur_chunk_id; i++) {
+	for (size_t i = 0; i <= cur_chunk_id; i++) {
 		k_free(user_data_chunks[i]);
 		user_data_chunks[i] = NULL;
 	}


### PR DESCRIPTION
This change fixes a memory management bug in the GATT DB discovery
module, which made it impossible to free up the memory of the last data
chunk. As a result, the second discovery procedure with the same or
greater memory requirements always fails.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>