### PR TITLE
lib: Add configuration to enabled UART traces.

### DIFF
--- a/lib/bsdlib/Kconfig
+++ b/lib/bsdlib/Kconfig
@@ -6,10 +6,25 @@
 menu "BSD Library for nrf91"
 
 config BSD_LIBRARY
-	bool "BSD Socket library for IP/TLS/DTLS"
+	bool
+	prompt "Use BSD Socket library for IP/TLS/DTLS"
 	select FLOAT
+	depends on CPU_CORTEX_M33
+	help
+	  Use Nordic BSD Socket library.
+
+if BSD_LIBRARY
+
+comment "Nordic BSD Socket library configuration"
+
+config BSD_LIBRARY_TRACE_ENABLED
+	bool
+	prompt "Enable proprietary traces over UART"
+	default y
 	# Modem tracing over UART use the UARTE1 as dedicated peripheral.
 	# This enable UARTE1 peripheral and includes nrfx UARTE driver.
 	select NRFX_UARTE1
-	depends on CPU_CORTEX_M33
+
+endif # BSD_LIBRARY
+
 endmenu


### PR DESCRIPTION
Add a KConfig option to disable proprietary traces over UART. We may
want to use the BSD Socket library on some boards that do not have a
second dedicated UART for tracing.
This option can be used to disable the use of the UARTE peripheral.

Signed-off-by: Christopher Métrailler <christopher.metrailler@nordicsemi.no>