### PR TITLE
driver: Add LTE band lock in Link Control Driver

### DIFF
--- a/drivers/lte_link_control/Kconfig
+++ b/drivers/lte_link_control/Kconfig
@@ -19,4 +19,11 @@ config LTE_AUTO_INIT_AND_CONNECT
 		automatically initialize and connect the modem
 		before the application starts
 
+config LTE_LOCK_BANDS
+	bool "Enable LTE bands lock"
+	default y
+	help
+		Enable LTE band locks for bands 3, 4, 13 and 20.
+		Other bands cannot be used when this setting is enabled.
+
 endif # LTE_LINK_CONTROL


### PR DESCRIPTION
Set LTE band lock using an AT command before activating the modem. This
is required to use only bands 3, 4, 13 and 20. Bit set to 1 for those
bands. This lock is a non volatile settings (disappears after reset). It
is done before every modem activation.

All samples using the Link Control driver will have band lock.

Signed-off-by: Christopher Métrailler <christopher.metrailler@nordicsemi.no>