### PR TITLE
samples: Use the new dts-generated device names.

### DIFF
--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -12,7 +12,7 @@
 #include <misc/byteorder.h>
 #include <zephyr.h>
 #include <gpio.h>
-#include <board.h>
+#include <soc.h>
 #include <assert.h>
 
 #include <settings/settings.h>

--- a/samples/bluetooth/peripheral_lbs/src/main.c
+++ b/samples/bluetooth/peripheral_lbs/src/main.c
@@ -12,7 +12,7 @@
 #include <misc/byteorder.h>
 #include <zephyr.h>
 #include <gpio.h>
-#include <board.h>
+#include <soc.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
@@ -46,7 +46,7 @@
 #ifdef SW0_GPIO_NAME
 #define SW0_GPIO_CONTROLLER SW0_GPIO_NAME
 #else
-#error SW0_GPIO_NAME or SW0_GPIO_CONTROLLER needs to be set in board.h
+#error SW0_GPIO_NAME or SW0_GPIO_CONTROLLER needs to be set in soc.h
 #endif
 #endif
 #define BUTTON_PORT SW0_GPIO_CONTROLLER
@@ -55,7 +55,7 @@
 #ifdef SW0_GPIO_PIN
 #define USER_BUTTON SW0_GPIO_PIN
 #else
-#error SW0_GPIO_PIN needs to be set in board.h
+#error SW0_GPIO_PIN needs to be set in soc.h
 #endif
 
 /* change to use another GPIO pin interrupt config */

--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -12,7 +12,7 @@
 #include <zephyr.h>
 #include <uart.h>
 
-#include <board.h>
+#include <soc.h>
 #include <gpio.h>
 
 #include <bluetooth/bluetooth.h>

--- a/samples/nfc/record_text/src/main.c
+++ b/samples/nfc/record_text/src/main.c
@@ -11,7 +11,7 @@
 #include <nfc/ndef/nfc_ndef_msg.h>
 #include <nfc/ndef/nfc_text_rec.h>
 
-#include <board.h>
+#include <soc.h>
 #include <device.h>
 #include <gpio.h>
 

--- a/samples/nfc/writable_ndef_msg/src/main.c
+++ b/samples/nfc/writable_ndef_msg/src/main.c
@@ -20,7 +20,7 @@
 #include "ndef_file_m.h"
 #include <nfc/ndef/nfc_ndef_msg.h>
 
-#include <board.h>
+#include <soc.h>
 #include <device.h>
 #include <gpio.h>
 

--- a/samples/nfc/writable_ndef_msg/src/ndef_file_m.c
+++ b/samples/nfc/writable_ndef_msg/src/ndef_file_m.c
@@ -14,7 +14,7 @@
  */
 
 #include <zephyr.h>
-#include <board.h>
+#include <soc.h>
 #include <device.h>
 #include <string.h>
 #include <nvs/nvs.h>


### PR DESCRIPTION
Alignment to generated names form device tree use soc.h
instead of board.h

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>