### PR TITLE
net: mqtt: Use unique log module name

### DIFF
--- a/subsys/net/lib/mqtt_socket/Kconfig
+++ b/subsys/net/lib/mqtt_socket/Kconfig
@@ -14,7 +14,7 @@ menuconfig MQTT_SOCKET_LIB
 
 if MQTT_SOCKET_LIB
 
-module=MQTT
+module=MQTT_SOCKET
 module-dep=NET_LOG
 module-str=Log level for MQTT
 module-help=Enables mqtt debug messages.


### PR DESCRIPTION
New MQTT implementation in Zephyr upstream uses the same module name for
MQTT logs, therefore producing conflicts.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>