### PR TITLE
samples: nrf9160: secure boot: remove unnecessary inclusion

### DIFF
--- a/samples/nrf9160/secure_boot/src/main.c
+++ b/samples/nrf9160/secure_boot/src/main.c
@@ -49,7 +49,6 @@
 
 #include <zephyr.h>
 #include <misc/printk.h>
-#include <board.h>
 #include <device.h>
 #include <gpio.h>
 


### PR DESCRIPTION
Remove the inclusion of board.h in main.c.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>