### PR TITLE
samples: bluetooth: Fix UART definition error

### DIFF
--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -291,7 +291,7 @@ static struct bt_scan_cb scan_cb = {
 
 static int uart_init(void)
 {
-	uart = device_get_binding(DT_UART_0_NAME);
+	uart = device_get_binding(UART_0_LABEL);
 	if (!uart) {
 		printk("UART binding failed\n");
 		return -ENXIO;


### PR DESCRIPTION
Change DT_UART_0_NAME to UART_0_LABEL in uart_central
sample.

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>