### PR TITLE
drivers: lte_link_control: Change default bandlock

### DIFF
--- a/drivers/lte_link_control/Kconfig
+++ b/drivers/lte_link_control/Kconfig
@@ -21,7 +21,7 @@ config LTE_AUTO_INIT_AND_CONNECT
 
 config LTE_LOCK_BANDS
 	bool "Enable LTE bands lock"
-	default y
+	default n
 	help
 		Enable LTE band locks for bands 3, 4, 13 and 20.
 		Other bands cannot be used when this setting is enabled.


### PR DESCRIPTION
Setting bandlock should by default be disabled.

CC @gbakke @bjorn-tore-taraldsen 