### PR TITLE
samples: bluetooth: hids_mouse support for security level 4

### DIFF
--- a/samples/bluetooth/peripheral_hids_mouse/Kconfig
+++ b/samples/bluetooth/peripheral_hids_mouse/Kconfig
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+source "$ZEPHYR_BASE/Kconfig.zephyr"
+
+menu "Nordic HIDS BLE GATT mouse service sample"
+
+config BT_GATT_HIDS_SECURITY_ENABLED
+	bool "Enable security"
+	default y
+	select BT_SMP
+	help
+	  "Enable BLE security for the HIDS service"
+
+if BT_GATT_HIDS_SECURITY_ENABLED
+
+choice BT_GATT_HIDS_SECURITY
+	prompt "Bluetooth security level"
+	default BT_GATT_HIDS_SECURITY_LEVEL_HIGH
+
+config BT_GATT_HIDS_SECURITY_LEVEL_FIPS
+	bool "Authenticated Secure Connections"
+	select BT_SMP
+	help
+	  "This level has high security level with FIPS
+	   approved encryption cipher"
+
+config BT_GATT_HIDS_SECURITY_LEVEL_HIGH
+	bool "High security level"
+	select BT_SMP
+	help
+	  "This level has encryption and authentication"
+
+config BT_GATT_HIDS_SECURITY_LEVEL_MED
+	bool "Medium security level"
+	select BT_SMP
+	help
+	  "This level has encryption and no authentication"
+
+config BT_GATT_HIDS_SECURITY_LEVEL_LOW
+	bool "Low security level"
+	select BT_SMP
+	help
+	  "This level has no encryption and no authentication"
+
+endchoice
+
+endif
+
+endmenu


### PR DESCRIPTION
Support for security level 4 has been added for
peripheral_hids_mouse also Kconfig for example
has been added. Security level is set from
configuration menu.

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>