### PR TITLE
doc: update introductory text

### DIFF
--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -3,7 +3,7 @@
 Welcome to the |NCS|!
 #####################
 
-The |NCS| contains libraries and application examples for Nordic Semiconductor chips. It uses the |link_zephyr|_ as real-time operating system.
+The |NCS| contains libraries and application examples for Nordic Semiconductor devices. It uses the |link_zephyr|_ as real-time operating system.
 
 
 .. toctree::

--- a/doc/nrf/introduction.rst
+++ b/doc/nrf/introduction.rst
@@ -3,12 +3,9 @@
 About the |NCS|
 ###############
 
-The |NCS|:
+The |NCS| is hosted by Nordic Semiconductor to demonstrate the integration of Nordic SoC support in open source projects, like MCUBoot and the Zephyr RTOS, with libraries and source code for low-power wireless applications.
 
-* is a collection of repos that provide Nordic applications
-* uses Zephyr as RTOS
-* provides sample and demo applications for Nordic Semiconductor chips
-* adds libraries that are not present in Zephyr
+It is not intended or supported by Nordic Semiconductor for product development.
 
 See :ref:`getting_started` for information about how to install the |NCS| and about the first steps.
 


### PR DESCRIPTION
Update to the text on the start page and under "About the NCS".

Also, are the release notes where we want them? Or should they be on the same level as "About the NCS"?

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>