### PR TITLE
samples: nrf9160: secure_boot: Add TWIM2 and SPIM3 to secure boot

### DIFF
--- a/samples/nrf9160/secure_boot/src/main.c
+++ b/samples/nrf9160/secure_boot/src/main.c
@@ -317,6 +317,12 @@ static void secure_boot_config_peripherals(void)
 	/* Configure FPU as non-secure */
 	secure_boot_config_peripheral(
 		NRFX_PERIPHERAL_ID_GET(NRF_FPU_S), 0);
+	/* Configure TWIM2 as non-secure */
+	secure_boot_config_peripheral(
+		NRFX_PERIPHERAL_ID_GET(NRF_TWIM2_S), 0);
+	/* Configure SPIM3 as non-secure */
+	secure_boot_config_peripheral(
+		NRFX_PERIPHERAL_ID_GET(NRF_SPIM3_S), 0);
 }
 
 static void secure_boot_config(void)


### PR DESCRIPTION
Adds TWIM2 and SPIM3 peripherals as non-secure.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>