### PR TITLE
samples: nrf9160: asset_tracker: LED pattern while LTE connect.

### DIFF
--- a/samples/nrf9160/asset_tracker/src/main.c
+++ b/samples/nrf9160/asset_tracker/src/main.c
@@ -582,6 +582,7 @@ static void modem_configure(void)
 		int err;
 
 		printk("LTE LC config ...\n");
+		display_state = LEDS_CONNECTING;
 		err = lte_lc_init_and_connect();
 		__ASSERT(err == 0, "LTE link could not be established.");
 	}


### PR DESCRIPTION
Enable connecting LED pattern while LTE link is connecting.

Signed-off-by: Joakim Andre Tønnesen <joakim.tonnesen@nordicsemi.no>