### PR TITLE
ci: Include CONF options for samples

### DIFF
--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -9,5 +9,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -5,5 +5,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -9,5 +9,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -5,5 +5,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -5,5 +5,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
     tags: bluetooth ci_build

--- a/samples/bluetooth/throughput/sample.yaml
+++ b/samples/bluetooth/throughput/sample.yaml
@@ -5,5 +5,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
     tags: bluetooth ci_build

--- a/samples/esb/prx/sample.yaml
+++ b/samples/esb/prx/sample.yaml
@@ -8,5 +8,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
     tags: ci_build

--- a/samples/esb/ptx/sample.yaml
+++ b/samples/esb/ptx/sample.yaml
@@ -8,5 +8,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
     tags: ci_build

--- a/samples/nfc/record_text/sample.yaml
+++ b/samples/nfc/record_text/sample.yaml
@@ -5,5 +5,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf52840_pca10056 nrf52_pca10040
     tags: ci_build

--- a/samples/nfc/writable_ndef_msg/sample.yaml
+++ b/samples/nfc/writable_ndef_msg/sample.yaml
@@ -5,5 +5,6 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
+    extra_args: CONF_FILE="prj.conf"
     platform_whitelist: nrf52840_pca10056 nrf52_pca10040
     tags: ci_build


### PR DESCRIPTION
Some samples do not set the conf file within CMakeLists. Explicitly
set these in the sample.yaml files.

Signed-off-by: Ulrich Myhre <ulmy@nordicsemi.no>