### PR TITLE
scripts: profiler: Fix Python profiler code issues

### DIFF
--- a/scripts/profiler/plot_nordic.py
+++ b/scripts/profiler/plot_nordic.py
@@ -63,6 +63,8 @@ class DrawState():
         self.selected_event_textbox = None
 
         self.added_time = 0
+        self.synchronized_with_events = False
+        self.stale_events_displayed = False
 
 
 class ProcessedData():
@@ -462,6 +464,17 @@ class PlotNordic():
                 events.append(event)
 
         # translating plot
+        if not self.draw_state.synchronized_with_events:
+            # ignore translating plot for stale events
+            if not self.draw_state.stale_events_displayed:
+                self.draw_state.stale_events_displayed = True
+            else:
+            # translate plot for new events
+                if len(events) != 0:
+                    self.draw_state.added_time = events[-1].timestamp - \
+                                                   0.3 * self.draw_state.timeline_width
+                    self.draw_state.synchronized_with_events = True
+
         if not self.draw_state.paused:
             self.draw_state.timeline_max = time.time() - self.start_time + \
                 self.draw_state.added_time

--- a/scripts/profiler/rtt_nordic_config.py
+++ b/scripts/profiler/rtt_nordic_config.py
@@ -9,7 +9,7 @@ RttNordicConfig = {
     'rtt_command_channel': 1,
     'ms_per_timestamp_tick': 0.03125,
     'byteorder': 'little',
-    'reset_on_start': True,
+    'reset_on_start': False,
     'connection_timeout': -1,
     'timestamp_raw_max': 2**32 #timestamp on uC is stored as 32-bit value
 }


### PR DESCRIPTION
Add proper initial plot translation in profiler events displaying. 
Fixed bug, where sometimes events processings were improperly mached with submissions.