### PR TITLE
lib: bsdlib: select NET_RAW_MODE

### DIFF
--- a/lib/bsdlib/Kconfig
+++ b/lib/bsdlib/Kconfig
@@ -9,6 +9,7 @@ config BSD_LIBRARY
 	bool
 	prompt "Use BSD Socket library for IP/TLS/DTLS"
 	select FLOAT
+	select NET_RAW_MODE
 	depends on CPU_CORTEX_M33
 	help
 	  Use Nordic BSD Socket library.


### PR DESCRIPTION
Select NET_RAW_MODE when using bsdlib to compile only the minimum required from Zephyr networking stack. This shaves off flash memory usage by quite a bit, and also fixes the annoying error message from the networking subsys: `<err> net_if.net_if_init: There is no network interface to work with!`

`asset_tracker` (nrf/master, zephyr/nrf91)

|Resource | Before | After |
| - | - | - |
| Flash | 181164 B  | 151240 B  |
| SRAM | 58696 B  | 52556 B  |



`lte_ble_gateway` (feature branch, zephyr/nrf91)

|Resource | Before | After |
| - | - | - |
| Flash | 221800 B  | 192836 B  |
| SRAM | 65020 B  | 58872  B  |


