### PR TITLE
doc: Add information about installing the NCS

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -45,7 +45,7 @@ Supported boards
 Required tools
 **************
 
-In addition to the :ref:`Zephyr toolchain <gs_installing_toolchain>`, the following tool versions are required to work with the |NCS|:
+In addition to the tools mentioned in :ref:`gs_installing`, the following tool versions are required to work with the |NCS|:
 
 .. list-table::
    :header-rows: 1

--- a/doc/nrf/gs_ins_fork.rst
+++ b/doc/nrf/gs_ins_fork.rst
@@ -1,0 +1,73 @@
+.. _gs_installing_forking:
+
+Forking the |NCS| repositories
+##############################
+
+If you want to change any of the code that is provided by the |NCS| and contribute this updated code back to the |NCS|, you should create your own forks of the |NCS| repositories and clone these forks instead of the base repositories.
+
+To fork and clone the repositories, complete the following steps:
+
+1. Fork the four |NCS| repositories to your own GitHub account by clicking the **Fork** button in the upper right-hand corner of each repository page:
+
+   a. |ncs_zephyr_repo|
+   #. |ncs_repo|
+   #. |ncs_mcuboot_repo|
+   #. |ncs_nrfxlib_repo|
+
+#. Create a folder named ``ncs``.
+   This folder will hold all |NCS| repositories.
+#. Open a GIT bash or terminal window in the ``ncs`` folder.
+#. Clone your forks by entering the following commands, where *<username>* must be replaced with your GitHub user name:
+
+   .. code-block:: console
+
+      git clone https://github.com/<username>/fw-nrfconnect-zephyr.git zephyr
+
+      git clone https://github.com/<username>/fw-nrfconnect-mcuboot.git mcuboot
+
+      git clone https://github.com/<username>/fw-nrfconnect-nrf.git nrf
+
+      git clone https://github.com/<username>/nrfxlib.git nrfxlib
+
+#. To link your local repositories to the |NCS| repositories, add remotes that point to the original repositories:
+
+   .. code-block:: console
+
+      cd zephyr
+      git remote add ncs https://github.com/NordicPlayground/fw-nrfconnect-zephyr.git
+
+      cd ../mcuboot
+      git remote add ncs https://github.com/NordicPlayground/fw-nrfconnect-mcuboot.git
+
+      cd ../nrf
+      git remote add ncs https://github.com/NordicPlayground/fw-nrfconnect-nrf.git
+
+      cd ../nrfxlib
+      git remote add ncs https://github.com/NordicPlayground/nrfxlib.git
+
+#. Optionally, add remotes to the upstream repositories for Zephyr and Mcuboot:
+
+   .. code-block:: console
+
+      cd ../zephyr
+      git remote add upstream https://github.com/zephyrproject-rtos/zephyr.git
+
+      cd ../mcuboot
+      git remote add upstream https://github.com/runtimeco/mcuboot.git
+
+.. include:: gs_ins_windows.rst
+   :start-after: dirstructure_start
+   :end-before: dirstructure_end
+
+To be able to build |NCS| applications for nRF91, check out branch ``nrf91`` in the fw-nrfconnect-zephyr repository:
+
+   .. code-block:: console
+
+	cd ../zephyr
+	git checkout nrf91
+
+Pull requests related to nRF91 (for example, for nRF9160 SiP or board support, drivers, and so on) in the fw-nrfconnect-zephyr repository must be submitted against the ``nrf91`` branch.
+
+.. note::
+   The ``nrf91`` branch is temporary.
+   Code changes to support the nRF9160 SiP and the nRF9160 DK board will be submitted upstream to the official Zephyr repository shortly after the v0.3.0 release.

--- a/doc/nrf/gs_ins_linux.rst
+++ b/doc/nrf/gs_ins_linux.rst
@@ -1,0 +1,85 @@
+.. _gs_installing_linux:
+
+.. |os| replace:: Linux
+
+.. include:: gs_ins_windows.rst
+   :start-after: intro_start
+   :end-before: intro_end
+
+
+
+
+.. _gs_installing_tools_linux:
+
+Installing the required tools
+*****************************
+
+To install the required tools, follow the :ref:`zephyr:linux_requirements` section of Zephyr's Getting Started Guide.
+
+In addition, make sure that you have dtc v1.4.6 or later installed.
+Depending on the Linux distribution that you use, you might need to install it manually because the current official package version might be older than v1.4.6.
+If you use Ubuntu, install v1.4.7 from Cosmic by entering the following commands::
+
+   wget http://mirrors.kernel.org/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.7-1_amd64.deb
+   sudo dpkg -i device-tree-compiler_1.4.7-1_amd64.deb
+
+.. note::
+   You do not need to install the Zephyr SDK.
+   We recommend to install the compiler toolchain separately, as detailed in `Installing the toolchain`_.
+
+
+.. _gs_installing_toolchain_linux:
+
+.. |installextract| replace:: Extract
+.. |tcfolder| replace:: ``~/gnuarmemb``
+
+.. include:: gs_ins_windows.rst
+   :start-after: toolchain_start
+   :end-before: #. If you want to build and program
+
+#. If you want to build and program applications from the command line, define the environment variables for the GNU Arm Embedded toolchain.
+   To do so, enter the following commands in a terminal window (assuming that you have installed the toolchain to |tcfolder|; if not, change the value for GNUARMEMB_TOOLCHAIN_PATH)::
+
+     export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+     export GNUARMEMB_TOOLCHAIN_PATH="~/gnuarmemb"
+
+#. Instead of setting the environment variables every time you start a new session, define them in the``~/.zephyrrc`` file as described in `Setting up the build environment`_.
+
+
+
+
+.. _cloning_the_repositories_linux:
+
+.. |bash| replace:: terminal window
+
+.. include:: gs_ins_windows.rst
+   :start-after: cloning_start
+   :end-before: cloning_end
+
+
+
+
+.. _additional_deps_linux:
+
+.. |prompt| replace:: terminal window
+
+.. include:: gs_ins_windows.rst
+   :start-after: add_deps_start
+   :end-before: add_deps_end
+
+.. code-block:: console
+
+   pip3 install --user -r zephyr/scripts/requirements.txt
+   pip3 install --user -r nrf/scripts/requirements.txt
+
+
+
+
+.. _build_environment_linux:
+
+.. |envfile| replace:: ``zephyr/zephyr-env.sh``
+.. |rcfile| replace:: ``~/.zephyrrc``
+
+.. include:: gs_ins_windows.rst
+   :start-after: buildenv_start
+   :end-before: buildenv_end

--- a/doc/nrf/gs_ins_os.rst
+++ b/doc/nrf/gs_ins_os.rst
@@ -1,0 +1,17 @@
+.. gs_installing_os:
+
+Supported operating systems
+###########################
+
+The |NCS| supports Microsoft Windows and Linux for development.
+However, there are some Zephyr features that are currently only available on Linux, including:
+
+* sanitycheck
+* BlueZ integration
+* net-tools integration
+
+.. note::
+
+   .. _gs_update_os:
+
+   Before you start setting up the toolchain, install available updates for your operating system.

--- a/doc/nrf/gs_ins_windows.rst
+++ b/doc/nrf/gs_ins_windows.rst
@@ -1,0 +1,158 @@
+.. _gs_installing_windows:
+
+.. |os| replace:: Windows
+
+.. intro_start
+
+Installing on |os|
+##################
+
+To manually install the |NCS|, you must ensure that all required tools are installed and clone the |NCS| repositories.
+See the following sections for detailed instructions.
+
+The first two steps, `Installing the required tools`_ and `Installing the toolchain`_, are identical to the installation in Zephyr.
+If you already have your system set up to work with the Zephyr OS, you can skip these steps.
+
+.. intro_end
+
+.. _gs_installing_tools_win:
+
+Installing the required tools
+*****************************
+
+The recommended way for installing the required tools on Windows is to use Chocolatey, a package manager for Windows.
+Chocolatey installs the tools so that you can use them from a Windows command prompt.
+
+To install the required tools, follow Zephyr's Getting Started Guide.
+Note that there are several ways to install the tools.
+We recommend installing according to :ref:`zephyr:windows_install_native`.
+
+.. _gs_installing_toolchain_win:
+
+.. |installextract| replace:: Install
+.. |tcfolder| replace:: ``c:\gnuarmemb``
+
+.. toolchain_start
+
+Installing the toolchain
+************************
+
+To be able to cross-compile your applications for Arm targets, you must install  the `GNU Arm Embedded Toolchain`_.
+
+To set up the toolchain, complete the following steps:
+
+.. _toolchain_setup:
+
+1. Download the `GNU Arm Embedded Toolchain`_ for your operating system.
+#. |installextract| the toolchain into a folder of your choice.
+   Make sure that the folder name does not contain any spaces or special characters.
+   We recommend to use the folder |tcfolder|.
+#. If you want to build and program applications from the command line, define the environment variables for the GNU Arm Embedded toolchain.
+   To do so, open a command prompt and enter the following commands (assuming that you have installed the toolchain to |tcfolder|; if not, change the value for GNUARMEMB_TOOLCHAIN_PATH)::
+
+     set ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+     set GNUARMEMB_TOOLCHAIN_PATH=c:\gnuarmemb
+
+#. Instead of setting the environment variables every time you open a command prompt, add them as system environment variables or define them in the ``zephyrrc.cmd`` file as described in `Setting up the build environment`_.
+
+.. _cloning_the_repositories_win:
+
+.. |bash| replace:: GIT bash
+
+.. cloning_start
+
+Cloning the repositories
+************************
+
+The |NCS| consists of the following repositories:
+
+* |ncs_zephyr_repo|
+* |ncs_repo|
+* |ncs_mcuboot_repo|
+* |ncs_nrfxlib_repo|
+
+.. note::
+   The following instructions explain how to clone the repositories to be able to develop your own applications based on the supplied libraries and samples.
+   If you want to actively contribute to the |NCS| development and submit the changes that you make, skip this step and :ref:`fork and clone the repositories <gs_installing_forking>` instead.
+
+To clone the repositories, complete the following steps:
+
+1. Create a folder named ``ncs``.
+   This folder will hold all |NCS| repositories.
+#. Open a |bash| in the ``ncs`` folder.
+#. Enter the following commands to clone the repositories::
+
+      git clone https://github.com/NordicPlayground/fw-nrfconnect-zephyr.git zephyr
+
+      git clone https://github.com/NordicPlayground/fw-nrfconnect-mcuboot.git mcuboot
+
+      git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf.git nrf
+
+      git clone https://github.com/NordicPlayground/nrfxlib.git nrfxlib
+
+.. dirstructure_start
+
+Your directory structure now looks like this::
+
+   ncs
+    |___ mcuboot
+    |___ nrf
+    |___ nrfxlib
+    |___ zephyr
+
+.. dirstructure_end
+
+The latest state of development is on the master branches of the fw-nrfconnect-nrf, fw-nrfconnect-mcuboot, and nrfxlib repositories and the nrf91 branch of the fw-nrfconnect-zephyr repository.
+Note that this might not be a stable state.
+Therefore, unless you are familiar with the development process, you should always work with a specific release of the |NCS|.
+
+To do so, go to the :ref:`release_notes` of the latest release and check which tags to use for each of the repositories.
+Then go to each repository in turn and check out the respective tag.
+
+For example, to check out the v0.3.0 tag for the nrf repository, you would enter the following commands::
+
+   cd nrf
+   git checkout tags/v0.3.0
+   cd ..
+
+.. cloning_end
+
+.. _additional_deps_win:
+
+.. |prompt| replace:: command prompt
+
+.. add_deps_start
+
+Installing additional Python dependencies
+*****************************************
+
+Both Zephyr and the |NCS| require additional Python packages to be installed.
+
+To install those, open a |prompt| in the ``ncs`` folder and enter the following commands:
+
+.. add_deps_end
+
+.. code-block:: console
+
+   pip3 install -r zephyr/scripts/requirements.txt
+   pip3 install -r nrf/scripts/requirements.txt
+
+
+.. _build_environment_win:
+
+.. |envfile| replace:: ``zephyr\zephyr-env.cmd``
+.. |rcfile| replace:: ``%userprofile%\zephyrrc.cmd``
+
+.. buildenv_start
+
+Setting up the build environment
+********************************
+
+If you want to build and program your applications from the command line, you must set up your build environment by defining the required environment variables every time you open a new |prompt|.
+
+To do so, navigate to the ``ncs`` folder and enter the following command: |envfile|
+
+If you need to define additional environment variables, create the file |rcfile| and add the variables there.
+This file is loaded automatically when you run the command above.
+
+.. buildenv_end

--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -1,125 +1,22 @@
 .. _gs_installing:
 
+
 Installing the |NCS|
 ####################
 
-To work with the |NCS|, you must install the required tools and clone the |NCS| repositories.
-These steps are interrelated, because the repositories contain information about what tools you need to install.
+The recommended way to get started with the |NCS| is to run the Getting Started Assistant app in nRF Connect for Desktop.
+See the `Getting Started information on the nRF9160 DK product page`_ for information about how to install the Getting Started Assistant.
 
-Supported operating systems
-***************************
+The Getting Started Assistant checks which of the required tools are already installed on your computer and guides you through installing the parts of the toolchain that you are missing.
+In addition, it will help you clone the |NCS| repositories and set up your first project in |SES|.
 
-The |NCS| supports Microsoft Windows and Linux for development.
-However, there are some Zephyr features that are currently only available on Linux, including:
-
-* sanitycheck
-* BlueZ integration
-* net-tools integration
+If you use the Getting Started Assistant, you can skip this section of the documentation.
+If you prefer to install the toolchain manually, or if you run into problems during the installation process, see the following documentation for instructions.
 
 
-.. _gs_installing_toolchain:
+.. toctree::
 
-Installing the toolchain
-************************
-
-Follow Zephyr's Getting Started Guide to install the toolchain on your operating system:
-
-* :ref:`zephyr:installing_zephyr_win`
-* :ref:`zephyr:installation_linux`
-
-.. important::
-   As part of the installation process, you must clone the Zephyr repository.
-   The instructions contain the URL of Zephyr's official repository; you should replace this with the |NCS| fork of the Zephyr repository.
-   See :ref:`cloning_the_repositories` for more information.
-
-.. _cloning_the_repositories:
-
-Cloning the repositories
-************************
-
-.. note::
-   The following instructions are temporary.
-   There will be a tool that automizes the process of cloning the repositories.
-
-1. Fork the four |NCS| repositories to your own GitHub account by clicking the **Fork** button in the upper right-hand corner of each repository page:
-
-   a. |ncs_zephyr_repo|
-   #. |ncs_repo|
-   #. |ncs_mcuboot_repo|
-   #. |ncs_nrfxlib_repo|
-
-#. Create a folder named ``ncs``.
-   This folder will hold all |NCS| repositories.
-#. Open a GIT bash in the ncs folder.
-#. Clone your forks:
-
-   .. code-block:: console
-
-      git clone https://github.com/<username>/_fw-nrfconnect-zephyr.git zephyr
-
-      git clone https://github.com/<username>/fw-nrfconnect-mcuboot.git mcuboot
-
-      git clone https://github.com/<username>/fw-nrfconnect-nrf.git nrf
-
-      git clone https://github.com/<username>/nrfxlib.git nrfxlib
-
-   Replace *<username>* with your GitHub user name.
-#. To link your local repositories to the |NCS| repositories, add remotes that point to the original repositories:
-
-   .. code-block:: console
-
-      cd zephyr
-      git remote add ncs https://github.com/NordicPlayground/_fw-nrfconnect-zephyr.git
-
-      cd ../mcuboot
-      git remote add ncs https://github.com/NordicPlayground/fw-nrfconnect-mcuboot.git
-
-      cd ../nrf
-      git remote add ncs https://github.com/NordicPlayground/fw-nrfconnect-nrf.git
-
-      cd ../nrfxlib
-      git remote add ncs https://github.com/NordicPlayground/nrfxlib.git
-
-#. Optionally, add remotes to the upstream repositories for Zephyr and Mcuboot:
-
-   .. code-block:: console
-
-      cd ../zephyr
-      git remote add upstream https://github.com/zephyrproject-rtos/zephyr.git
-
-      cd ../mcuboot
-      git remote add upstream https://github.com/runtimeco/mcuboot.git
-
-Your directory structure now looks like this::
-
-   ncs
-    |___ mcuboot
-    |___ nrf
-    |___ nrfxlib
-    |___ zephyr
-
-To be able to build |NCS| applications for nRF91, check out
-branch ``nrf91`` in the fw-nrfconnect-zephyr repository:
-
-   .. code-block:: console
-
-	cd ../zephyr
-	git checkout nrf91
-
-Pull requests related to nRF91 (for example, for nRF9160 SoC or Board support,
-drivers, and so on) must be submitted against the nRF91 branch.
-
-Installing additional Python dependencies
-*****************************************
-
-The |NCS| requires additional Python packages to be installed. To install those
-use the following command:
-
-   .. code-block:: console
-
-      # Linux
-      pip3 install --user -r nrf/scripts/requirements.txt
-
-      # macOS and Windows
-      pip3 install -r nrf/scripts/requirements.txt
-
+   gs_ins_os
+   gs_ins_windows
+   gs_ins_linux
+   gs_ins_fork

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -43,3 +43,7 @@
 .. _`Nordic Thingy:52`: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/Nordic-Thingy-52
 
 .. _`openSSL`: https://www.openssl.org/
+
+.. _`Getting Started information on the nRF9160 DK product page`: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF9160-DK/GetStarted#infotabs
+
+.. _`GNU Arm Embedded Toolchain`: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -1,1 +1,3 @@
 .. |NCS| replace:: nRF Connect SDK
+
+.. |SES| replace:: SEGGER Embedded Studio


### PR DESCRIPTION
Add information about how to install the requirements for NCS on Windows
and Linux and how to clone or fork the repositories.

Output: 
[Installing.pdf](https://github.com/NordicPlayground/fw-nrfconnect-nrf/files/2654128/Installing.pdf)

This PR needs https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/78
(Doc build on Jenkins is failing because of this.)

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>