### PR TITLE
license: Fix license to match Nordic 5-clause BSD

### DIFF
--- a/samples/nrf9160/secure_boot/src/main.c
+++ b/samples/nrf9160/secure_boot/src/main.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA.
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 /*

--- a/subsys/net/lib/mqtt_socket/Kconfig
+++ b/subsys/net/lib/mqtt_socket/Kconfig
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2018 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
 menuconfig MQTT_SOCKET_LIB

--- a/subsys/nfc/ndef/Kconfig
+++ b/subsys/nfc/ndef/Kconfig
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2017 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
 config NFC_NDEF


### PR DESCRIPTION
Fix the license in those files.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>