### PR TITLE
ci: Pass build number to triggered builds.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,8 @@ pipeline {
               build job: "${it}", propagate: true, wait: false, parameters: [string(name: 'branchname', value: "$BRANCH_NAME"),
                                                                              string(name: 'API_URL', value: "${getRepoURL()}"),
                                                                              string(name: 'API_COMMIT', value: "$GIT_COMMIT"),
-                                                                             string(name: 'API_PR_NAME', value: "$PR_NAME")]
+                                                                             string(name: 'API_PR_NAME', value: "$PR_NAME"),
+                                                                             string(name: 'API_RUN_NUMBER', value: "$BUILD_NUMBER")]
             }
           }
           parallel projs


### PR DESCRIPTION
Build number will help with downloading correct artifacts
by downstream build in case of consecutive runs for same PR.

Signed-off-by: Wiktor Miesok <wiktor.miesok@nordicsemi.no>