### PR TITLE
doc: samples: Change name of nRF9160 DK

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -39,7 +39,7 @@ Supported boards
 * PCA10059 (nRF52840 Dongle)
 * PCA63519 (Smart Remote 3 DK add-on)
 * PCA20041 (TBD)
-* PCA10090 (nRF9160 Preview Development Kit)
+* PCA10090 (nRF9160 DK)
 
 
 Required tools

--- a/samples/nrf9160/asset_tracker/README.rst
+++ b/samples/nrf9160/asset_tracker/README.rst
@@ -3,13 +3,13 @@
 nRF9160: Asset Tracker
 ######################
 
-The Asset Tracker sample demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160 Development Kit to the `nRF Cloud`_ via LTE and transmit GPS and device orientation data.
+The Asset Tracker sample demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160 DK to the `nRF Cloud`_ via LTE and transmit GPS and device orientation data.
 
 
 Overview
 ********
 
-The sample sends GPS position data and accelerometer data that is collected by an nRF9160 Development Kit to Nordic Semiconductor's cloud solution, `nRF Cloud`_, where the data is visualized.
+The sample sends GPS position data and accelerometer data that is collected by an nRF9160 DK to Nordic Semiconductor's cloud solution, `nRF Cloud`_, where the data is visualized.
 The accelerometer data is used to infer the device's physical orientation.
 It is sent as the nRF Cloud sensor data type "FLIP".
 
@@ -22,7 +22,7 @@ Requirements
 
 * The following development board:
 
-    * nRF9160 Preview Development Kit board (PCA10090)
+    * nRF9160 DK board (PCA10090)
 
 * :ref:`secure_boot` must be programmed on the board.
 

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -3,7 +3,7 @@
 nRF9160: LTE Sensor Gateway
 ###########################
 
-The LTE Sensor Gateway sample demonstrates how to transmit sensor data from an nRF9160 Development Kit to the `nRF Cloud`_.
+The LTE Sensor Gateway sample demonstrates how to transmit sensor data from an nRF9160 DK to the `nRF Cloud`_.
 Unlike the :ref:`nrf_cloud` sample, the sensor data is collected via Bluetooth LE.
 Therefore, this sample acts as a gateway between Bluetooth LE and the LTE connection to the nRF Cloud.
 
@@ -25,7 +25,7 @@ Requirements
 * A `Nordic Thingy:52`_
 * The following development board:
 
-  * nRF9160 Preview Development Kit board (PCA10090)
+  * nRF9160 DK board (PCA10090)
 
 * :ref:`zephyr:bluetooth-hci-uart-sample` must be programmed to the nRF52 board controller on the board.
 * :ref:`secure_boot` must be programmed on the board.
@@ -44,7 +44,7 @@ It can be programmed independently from the secure boot firmware.
 Programming the sample
 ======================
 
-When you connect the nRF9160 Preview Development Kit board to your computer, three virtual serial ports (USB CDC class) should appear.
+When you connect the nRF9160 DK board to your computer, three virtual serial ports (USB CDC class) should appear.
 The first port is connected to the main controller (nRF9160) on the board, while the second port is connected to the board controller (nRF52840).
 
 Before you program the sample application onto the main controller, you must program the :ref:`zephyr:bluetooth-hci-uart-sample` sample onto the board controller:

--- a/samples/nrf9160/secure_boot/README.rst
+++ b/samples/nrf9160/secure_boot/README.rst
@@ -4,7 +4,7 @@ nRF9160: Secure Boot
 ####################
 
 The Secure Boot sample application provides a reference implementation of a first-stage boot firmware.
-This firmware is required to set up the nRF9160 Development Kit so that it can run user applications in the non-secure domain.
+This firmware is required to set up the nRF9160 DK so that it can run user applications in the non-secure domain.
 
 Overview
 ********
@@ -53,7 +53,7 @@ Requirements
 
 The following development board:
 
-* nRF9160 Preview Development Kit board (PCA10090)
+* nRF9160 DK board (PCA10090)
 
 Building and running
 ********************


### PR DESCRIPTION
The name of the nRF9160 Preview Development Kit has changed to
nRF9160 DK.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>