### PR TITLE
subsys: esb: Fix stopping Enhanced ShockBurst rx during acking

### DIFF
--- a/subsys/enhanced_shockburst/nrf_esb.c
+++ b/subsys/enhanced_shockburst/nrf_esb.c
@@ -1269,7 +1269,7 @@ int nrf_esb_start_rx(void)
 
 int nrf_esb_stop_rx(void)
 {
-	if (esb_state != ESB_STATE_PRX) {
+	if (esb_state != ESB_STATE_PRX || esb_state != ESB_STATE_PRX_SEND_ACK) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
In the current implementation it's possible to call stop rx in the small
time window where the device is sending an ack package. This will cause
the stop rx to fail, and if the application isn't set up to handle this
error with a retry it's going to be a problem. This commit adds support
for disabling rx in this time window.

Signed-off-by: Rune Holmgren <Rune.Holmgren@nordicsemi.no>