### PR TITLE
samples: nrf_desktop: Clear HID state in case of error

### DIFF
--- a/samples/nrf_desktop/src/modules/hid_state.c
+++ b/samples/nrf_desktop/src/modules/hid_state.c
@@ -643,7 +643,13 @@ static void report_issued(const void *subscriber_id, enum target_report tr,
 	if (error) {
 		rs->err_cnt++;
 		if (rs->err_cnt > 1) {
+			/* To maintain the sanity of HID state, clear
+			 * all recorded events and items.
+			 */
 			LOG_ERR("Error while sending report");
+			memset(&rd->items, 0, sizeof(rd->items));
+			eventq_reset(&rd->eventq);
+
 			if (rs->cnt == 0) {
 				rs->state = STATE_CONNECTED_IDLE;
 			}


### PR DESCRIPTION
State must be cleared as application does not know which event
was missed by the host. This could lead to buttons being pressed
if in reality they are not.

Jira:DESK-342

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>