### PR TITLE
samples: nrf_desktop: Ensure state is clear on disconnection

### DIFF
--- a/samples/nrf_desktop/src/modules/usb_state.c
+++ b/samples/nrf_desktop/src/modules/usb_state.c
@@ -180,9 +180,13 @@ static void device_status(enum usb_dc_status_code cb_status, const u8_t *param)
 
 		state = new_state;
 
+		if (old_state == USB_STATE_ACTIVE) {
+			broadcast_subscription_change();
+		}
+
 		broadcast_usb_state();
-		if ((new_state == USB_STATE_ACTIVE) ||
-		    (old_state == USB_STATE_ACTIVE)) {
+
+		if (new_state == USB_STATE_ACTIVE) {
 			broadcast_subscription_change();
 		}
 	}


### PR DESCRIPTION
Make sure that HID state maintains sanity when device disconnects.
When USB disconnects, disable notifications first.
Fix small log text issues.

Jira:DESK-364

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>