### PR TITLE
doc: Add troubleshooting related to building with SES

### DIFF
--- a/doc/nrf/getting_started.rst
+++ b/doc/nrf/getting_started.rst
@@ -7,7 +7,7 @@ To quickly get started with the |NCS|, use the `Getting Started Assistant`_ to s
 Alternatively, check the :ref:`gs_installing` section for instructions on setting up your environment manually.
 
 We recommend using SEGGER Embedded Studio for building your applications. See :ref:`gs_programming` for the download links and instructions.
-There is also a troubleshooting section, in case you run into problems.
+In case you run into problems, see :ref:`gs_programming_ts` .
 
 Once you are set up, check out the :ref:`samples`.
 If this is the first time you work with embedded devices, it is probably a good idea to program an unchanged sample to your board first and test if it works as expected.

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -70,3 +70,21 @@ To do this, select **Target -> Download zephyr/zephyr.elf**.
 
 7. To inspect the details of the flashed code and the memory usage,
 click **Debug -> Go**.
+
+.. _gs_programming_ts:
+
+Troublehooting SES
+==================
+
+When using SES to build the |NCS| samples,
+it might return an error indicating a project load failure. For example::
+
+	Can't load project file
+	The project file <filepath> is invalid.
+	The reported error is 'solution load command failed (1)'
+
+This issue might be caused by a variety of problems, such as incorrectly specified
+project file paths.
+SES helps you to identify the source of the issue by providing a text output
+with detailed information about the error. Make sure to click **OK** on the
+error pop-up message and then inspect the text output in SES.


### PR DESCRIPTION
Provides information and solutions on the issues observed when building samples with SES.

Signed-off-by: Bartosz Gentkowski <bartosz.gentkowski@nordicsemi.no>

Output: 
[Troublehooting SES.pdf](https://github.com/NordicPlayground/fw-nrfconnect-nrf/files/2675596/Troublehooting.SES.pdf)

(Output updated)
