### PR TITLE
samples: secure_boot: add timers

### DIFF
--- a/samples/nrf9160/secure_boot/src/main.c
+++ b/samples/nrf9160/secure_boot/src/main.c
@@ -326,6 +326,15 @@ static void secure_boot_config_peripherals(void)
 	/* Configure SPIM3 as non-secure */
 	secure_boot_config_peripheral(
 		NRFX_PERIPHERAL_ID_GET(NRF_SPIM3_S), 0);
+	/* Configure TIMER0 as non-secure */
+	secure_boot_config_peripheral(
+		NRFX_PERIPHERAL_ID_GET(NRF_TIMER0_S), 0);
+	/* Configure TIMER1 as non-secure */
+	secure_boot_config_peripheral(
+		NRFX_PERIPHERAL_ID_GET(NRF_TIMER1_S), 0);
+	/* Configure TIMER2 as non-secure */
+	secure_boot_config_peripheral(
+		NRFX_PERIPHERAL_ID_GET(NRF_TIMER2_S), 0);
 }
 
 static void secure_boot_config(void)


### PR DESCRIPTION
Add TIMERs 0, 1, and 2 to the example
in order for the non-secure application to access them.