### PR TITLE
lib: dk_buttons_and_leds: Select GPIO

### DIFF
--- a/lib/dk_buttons_and_leds/Kconfig
+++ b/lib/dk_buttons_and_leds/Kconfig
@@ -6,6 +6,7 @@
 
 menuconfig DK_LIBRARY
 	bool "Button and LED Library for Nordic DKs"
+	select GPIO
 
 if DK_LIBRARY
 


### PR DESCRIPTION
DK buttons and LEDs library is a layer on top of GPIO, and
should therefore select the GPIO symbol.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>