### PR TITLE
[RFC] Workaround to mock Zephyr kernel API

### DIFF
--- a/include/at_params.h
+++ b/include/at_params.h
@@ -79,9 +79,7 @@ struct at_param_list {
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_list_init(struct at_param_list *list,
-			     size_t max_params_count);
-
+int at_params_list_init(struct at_param_list *list, size_t max_params_count);
 
 /**
  * @brief Clear/reset all parameter types and values.
@@ -92,7 +90,6 @@ int at_params_list_init(struct at_param_list *list,
  */
 void at_params_list_clear(struct at_param_list *list);
 
-
 /**
  * @brief Free a list of parameters.
  *
@@ -101,7 +98,6 @@ void at_params_list_clear(struct at_param_list *list);
  * @param[in] list Parameter list to free.
  */
 void at_params_list_free(struct at_param_list *list);
-
 
 /**
  * @brief Clear/reset a parameter type and value.
@@ -113,7 +109,6 @@ void at_params_list_free(struct at_param_list *list);
  *           Otherwise, a (negative) error code is returned.
  */
 int at_params_clear(struct at_param_list *list, size_t index);
-
 
 /**
  * @brief Add a parameter in the list at the specified index and assign it a
@@ -131,7 +126,6 @@ int at_params_clear(struct at_param_list *list, size_t index);
 int at_params_short_put(const struct at_param_list *list, size_t index,
 			u16_t value);
 
-
 /**
  * @brief Add a parameter in the list at the specified index and assign it an
  * integer value.
@@ -146,8 +140,7 @@ int at_params_short_put(const struct at_param_list *list, size_t index,
  *           Otherwise, a (negative) error code is returned.
  */
 int at_params_int_put(const struct at_param_list *list, size_t index,
-			u32_t value);
-
+		      u32_t value);
 
 /**
  * @brief Add a parameter in the list at the specified index and assign it a
@@ -164,10 +157,8 @@ int at_params_int_put(const struct at_param_list *list, size_t index,
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_string_put(const struct at_param_list *list,
-			size_t index, const char *str,
-			size_t str_len);
-
+int at_params_string_put(const struct at_param_list *list, size_t index,
+			 const char *str, size_t str_len);
 
 /**
  * @brief Get the size of a given parameter (in bytes).
@@ -182,8 +173,7 @@ int at_params_string_put(const struct at_param_list *list,
  *           Otherwise, a (negative) error code is returned.
  */
 int at_params_size_get(const struct at_param_list *list, size_t index,
-			size_t *len);
-
+		       size_t *len);
 
 /**
  * @brief Get a parameter value as a short number.
@@ -201,7 +191,6 @@ int at_params_size_get(const struct at_param_list *list, size_t index,
 int at_params_short_get(const struct at_param_list *list, size_t index,
 			u16_t *value);
 
-
 /**
  * @brief Get a parameter value as an integer number.
  *
@@ -216,8 +205,7 @@ int at_params_short_get(const struct at_param_list *list, size_t index,
  *           Otherwise, a (negative) error code is returned.
  */
 int at_params_int_get(const struct at_param_list *list, size_t index,
-			u32_t *value);
-
+		      u32_t *value);
 
 /**
  * @brief Get a parameter value as a string.
@@ -235,9 +223,8 @@ int at_params_int_get(const struct at_param_list *list, size_t index,
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int at_params_string_get(const struct at_param_list *list,
-			size_t index, char *value, size_t len);
-
+int at_params_string_get(const struct at_param_list *list, size_t index,
+			 char *value, size_t len);
 
 /**
  * @brief Get the number of valid parameters in the list.

--- a/lib/at_cmd_parser/include/at_params_alloc.h
+++ b/lib/at_cmd_parser/include/at_params_alloc.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef AT_PARAMS_ALLOC_H_
+#define AT_PARAMS_ALLOC_H_
+
+#include <zephyr.h>
+
+/*
+ * FIXME: we need a new header file with the function we want to mock.
+ * This function cannot be part of the at_params.h header file because
+ * we do not want to mock all at_params APIs, but only this function.
+ */
+
+/* Proxy function available only in this module that we can mock. */
+static ALWAYS_INLINE void *at_params_calloc(size_t nmemb, size_t size)
+{
+	return k_calloc(nmemb, size);
+}
+
+#endif /* AT_PARAMS_ALLOC_H_ */

--- a/lib/at_cmd_parser/src/at_params.c
+++ b/lib/at_cmd_parser/src/at_params.c
@@ -12,6 +12,7 @@
 #include <zephyr/types.h>
 #include <at_params.h>
 #include <kernel.h>
+#include <errno.h>
 
 /* Internal function. */
 static void at_param_init(struct at_param *param)
@@ -20,7 +21,6 @@ static void at_param_init(struct at_param *param)
 
 	memset(param, 0, sizeof(struct at_param));
 }
-
 
 /* Internal function. */
 static void at_param_clear(struct at_param *param)
@@ -36,10 +36,9 @@ static void at_param_clear(struct at_param *param)
 	}
 }
 
-
 /* Internal function. */
 static struct at_param *at_params_get(const struct at_param_list *list,
-				size_t index)
+				      size_t index)
 {
 	__ASSERT(list != NULL, "Parameter list cannot be NULL.\n");
 
@@ -51,7 +50,6 @@ static struct at_param *at_params_get(const struct at_param_list *list,
 
 	return &param[index];
 }
-
 
 /* Internal function. Parameter cannot be null. */
 static size_t at_param_size(const struct at_param *param)
@@ -67,20 +65,14 @@ static size_t at_param_size(const struct at_param *param)
 	return 0;
 }
 
-
-int at_params_list_init(struct at_param_list *list,
-			size_t max_params_count)
+int at_params_list_init(struct at_param_list *list, size_t max_params_count)
 {
 	if (list == NULL) {
 		return -EINVAL;
 	}
 
-	if (list->params != NULL) {
-		return -EACCES;
-	}
-
-	list->params = k_calloc(max_params_count,
-				sizeof(struct at_param));
+	/* Create array of paramaters. */
+	list->params = k_calloc(max_params_count, sizeof(struct at_param));
 	if (list->params == NULL) {
 		return -ENOMEM;
 	}
@@ -90,22 +82,19 @@ int at_params_list_init(struct at_param_list *list,
 	return 0;
 }
 
-
 void at_params_list_clear(struct at_param_list *list)
 {
 	if (list == NULL || list->params == NULL) {
 		return;
 	}
 
-	for (size_t i = 0; i < list->param_count;
-		 ++i) {
+	for (size_t i = 0; i < list->param_count; ++i) {
 		struct at_param *params = list->params;
 
 		at_param_clear(&params[i]);
 		at_param_init(&params[i]);
 	}
 }
-
 
 void at_params_list_free(struct at_param_list *list)
 {
@@ -120,13 +109,11 @@ void at_params_list_free(struct at_param_list *list)
 	list->params = NULL;
 }
 
-
 int at_params_clear(struct at_param_list *list, size_t index)
 {
 	if (list == NULL || list->params == NULL) {
 		return -EINVAL;
 	}
-
 
 	struct at_param *param = at_params_get(list, index);
 
@@ -138,7 +125,6 @@ int at_params_clear(struct at_param_list *list, size_t index)
 	at_param_init(param);
 	return 0;
 }
-
 
 int at_params_short_put(const struct at_param_list *list, size_t index,
 			u16_t value)
@@ -160,9 +146,8 @@ int at_params_short_put(const struct at_param_list *list, size_t index,
 	return 0;
 }
 
-
 int at_params_int_put(const struct at_param_list *list, size_t index,
-			u32_t value)
+		      u32_t value)
 {
 	if (list == NULL || list->params == NULL) {
 		return -EINVAL;
@@ -180,7 +165,6 @@ int at_params_int_put(const struct at_param_list *list, size_t index,
 	param->value.int_val = value;
 	return 0;
 }
-
 
 int at_params_string_put(const struct at_param_list *list, size_t index,
 			 const char *str, size_t str_len)
@@ -206,14 +190,13 @@ int at_params_string_put(const struct at_param_list *list, size_t index,
 
 	at_param_clear(param);
 	param->type = AT_PARAM_TYPE_STRING;
-	param->value.str_val =	param_value;
+	param->value.str_val = param_value;
 
 	return 0;
 }
 
-
 int at_params_size_get(const struct at_param_list *list, size_t index,
-			size_t *len)
+		       size_t *len)
 {
 	if (list == NULL || list->params == NULL || len == NULL) {
 		return -EINVAL;
@@ -228,7 +211,6 @@ int at_params_size_get(const struct at_param_list *list, size_t index,
 	*len = at_param_size(param);
 	return 0;
 }
-
 
 int at_params_short_get(const struct at_param_list *list, size_t index,
 			u16_t *value)
@@ -251,9 +233,8 @@ int at_params_short_get(const struct at_param_list *list, size_t index,
 	return 0;
 }
 
-
 int at_params_int_get(const struct at_param_list *list, size_t index,
-			u32_t *value)
+		      u32_t *value)
 {
 	if (list == NULL || list->params == NULL || value == NULL) {
 		return -EINVAL;
@@ -273,9 +254,8 @@ int at_params_int_get(const struct at_param_list *list, size_t index,
 	return 0;
 }
 
-
 int at_params_string_get(const struct at_param_list *list, size_t index,
-			char *value, size_t len)
+			 char *value, size_t len)
 {
 	if (list == NULL || list->params == NULL || value == NULL) {
 		return -EINVAL;
@@ -300,7 +280,6 @@ int at_params_string_get(const struct at_param_list *list, size_t index,
 	memcpy(value, param->value.str_val, param_len);
 	return param_len;
 }
-
 
 u32_t at_params_valid_count_get(const struct at_param_list *list)
 {

--- a/lib/at_cmd_parser/src/at_params.c
+++ b/lib/at_cmd_parser/src/at_params.c
@@ -11,6 +11,7 @@
 #include <zephyr.h>
 #include <zephyr/types.h>
 #include <at_params.h>
+#include <at_params_alloc.h>
 #include <kernel.h>
 #include <errno.h>
 
@@ -72,7 +73,7 @@ int at_params_list_init(struct at_param_list *list, size_t max_params_count)
 	}
 
 	/* Create array of paramaters. */
-	list->params = k_calloc(max_params_count, sizeof(struct at_param));
+	list->params = at_params_calloc(max_params_count, sizeof(struct at_param));
 	if (list->params == NULL) {
 		return -ENOMEM;
 	}

--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -166,6 +166,6 @@ function(cmock_handle header_file)
 
   cmock_linker_wrap_trick(${mod_header_path})
 
-  target_include_directories(app PRIVATE ${CMOCK_PRODUCTS_DIR})
+  target_include_directories(zephyr_interface BEFORE INTERFACE ${CMOCK_PRODUCTS_DIR})
   message(STATUS "Generating cmock for header ${header_file}")
 endfunction()

--- a/tests/unity/at_cmd_parser/at_params/CMakeLists.txt
+++ b/tests/unity/at_cmd_parser/at_params/CMakeLists.txt
@@ -8,6 +8,10 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(test_at_params)
 
+# create mock for Kernel API
+# FIXME: Mocking kernel.h will make the native application crashing
+cmock_handle(${ZEPHYR_BASE}/include/kernel.h kernel)
+
 # generate runner for the test
 test_runner_generate(src/at_params_test.c)
 

--- a/tests/unity/at_cmd_parser/at_params/CMakeLists.txt
+++ b/tests/unity/at_cmd_parser/at_params/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(test_at_params)
+
+# generate runner for the test
+test_runner_generate(src/at_params_test.c)
+
+# add test file
+target_sources(app PRIVATE src/at_params_test.c)
+target_include_directories(app PRIVATE .)

--- a/tests/unity/at_cmd_parser/at_params/CMakeLists.txt
+++ b/tests/unity/at_cmd_parser/at_params/CMakeLists.txt
@@ -8,9 +8,8 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(test_at_params)
 
-# create mock for Kernel API
-# FIXME: Mocking kernel.h will make the native application crashing
-cmock_handle(${ZEPHYR_BASE}/include/kernel.h kernel)
+# create mock for the at_params_alloc header
+cmock_handle(${ZEPHYR_BASE}/../nrf/lib/at_cmd_parser/include/at_params_alloc.h)
 
 # generate runner for the test
 test_runner_generate(src/at_params_test.c)

--- a/tests/unity/at_cmd_parser/at_params/Kconfig
+++ b/tests/unity/at_cmd_parser/at_params/Kconfig
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+source "Kconfig.zephyr"

--- a/tests/unity/at_cmd_parser/at_params/prj.conf
+++ b/tests/unity/at_cmd_parser/at_params/prj.conf
@@ -1,0 +1,7 @@
+CONFIG_UNITY=y
+
+# To use k_calloc
+CONFIG_HEAP_MEM_POOL_SIZE=1024
+
+# Enable the module under test
+CONFIG_AT_CMD_PARSER=y

--- a/tests/unity/at_cmd_parser/at_params/sample.yaml
+++ b/tests/unity/at_cmd_parser/at_params/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  description: AT params test
+  name: at_params_test
+tests:
+  test_build:
+    build_only: true
+    build_on_all: true
+    platform_whitelist: native_posix
+    tags: ci_build

--- a/tests/unity/at_cmd_parser/at_params/src/at_params_test.c
+++ b/tests/unity/at_cmd_parser/at_params/src/at_params_test.c
@@ -8,6 +8,8 @@
 #include <at_params.h>
 #include <errno.h>
 
+#include "kernel/mock_kernel.h"
+
 void setUp(void)
 {
 	/* Empty. */
@@ -17,4 +19,16 @@ void test_at_params_list_init_null_param(void)
 {
 	int err = at_params_list_init(NULL, 0);
 	TEST_ASSERT_EQUAL(-EINVAL, err);
+}
+
+void test_at_params_list_init_no_mem(void)
+{
+	const size_t MAX_PARAMS = 4;
+
+	/* Want a null pointer when allocating memory in the at_params module. */
+	__wrap_k_calloc_ExpectAndReturn(MAX_PARAMS, sizeof(struct at_param), NULL);
+
+	struct at_param_list list;
+	int err = at_params_list_init(&list, MAX_PARAMS);
+	TEST_ASSERT_EQUAL(-ENOMEM, err);
 }

--- a/tests/unity/at_cmd_parser/at_params/src/at_params_test.c
+++ b/tests/unity/at_cmd_parser/at_params/src/at_params_test.c
@@ -8,7 +8,7 @@
 #include <at_params.h>
 #include <errno.h>
 
-#include "kernel/mock_kernel.h"
+#include "mock_at_params_alloc.h"
 
 void setUp(void)
 {
@@ -25,8 +25,8 @@ void test_at_params_list_init_no_mem(void)
 {
 	const size_t MAX_PARAMS = 4;
 
-	/* Want a null pointer when allocating memory in the at_params module. */
-	__wrap_k_calloc_ExpectAndReturn(MAX_PARAMS, sizeof(struct at_param), NULL);
+	/* Return a null pointer when allocating memory in the at_params module. */
+	__wrap_at_params_calloc_ExpectAndReturn(MAX_PARAMS, sizeof(struct at_param), NULL);
 
 	struct at_param_list list;
 	int err = at_params_list_init(&list, MAX_PARAMS);

--- a/tests/unity/at_cmd_parser/at_params/src/at_params_test.c
+++ b/tests/unity/at_cmd_parser/at_params/src/at_params_test.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <unity.h>
+#include <at_params.h>
+#include <errno.h>
+
+void setUp(void)
+{
+	/* Empty. */
+}
+
+void test_at_params_list_init_null_param(void)
+{
+	int err = at_params_list_init(NULL, 0);
+	TEST_ASSERT_EQUAL(-EINVAL, err);
+}

--- a/tests/unity/at_cmd_parser/at_params/src/at_params_test.h
+++ b/tests/unity/at_cmd_parser/at_params/src/at_params_test.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef AT_PARAMS_TEST_H_
+#define AT_PARAMS_TEST_H_
+
+#endif /* AT_PARAMS_TEST_H_ */


### PR DESCRIPTION
In this draft/RFC PR, I would like to expose a limitation of the current framework when mocking kernel.h.

I am writing a unit test for a module that as a dependency to `kernel.h` malloc function and `mempool` API. In the unit test, I would like to mock the `calloc` function to return a null-pointer for instance and test the module implementation. In the current CMock/Unity framework implementation, we cannot mock functions that are also used by the framework itself (like the kernel API that is used to create the main Thread in the test app). Commit 19e9608 show this issue.

In commit b512545 I added an alias/proxy function to be able to mock the alloc function. This is a workaround, but the solution works.

1. This adds complexity to the code and makes it less readable but it is needed to have a good unit test. Are there other alternatives?
2. Is it acceptable to add alias functions for all modules that need to mock the Kernel APIs?