### PR TITLE
manifest: update fw-nrfconnect-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 98804daed7a9745302391e581073f2c29878470c
+      revision: fc95403819ca26d7db05496ea4142a5d0ccaddd3
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Upgrade downstream zephyr version used in NCS.

Signed-off-by: Solveig Fure <solveig.fure@nordicsemi.no>