### PR TITLE
Add AT_CMD_PROMPT as valid state for at_cmd_write()

### DIFF
--- a/include/at_cmd.h
+++ b/include/at_cmd.h
@@ -29,6 +29,7 @@ extern "C" {
  */
 enum at_cmd_state {
 	AT_CMD_OK,
+	AT_CMD_PROMPT,
 	AT_CMD_ERROR,
 	AT_CMD_ERROR_CMS,
 	AT_CMD_ERROR_CME,


### PR DESCRIPTION
Allow at_cmd_write() to recognize ">" as a valid return value with state AT_CMD_PROMPT rather than treating it like a notification.  AT+CMGS will return a ">" prompt when sending the command as two parts.