### PR TITLE
tests: drivers: Add nrfx integration test application

### DIFF
--- a/tests/drivers/nrfx_integration_test/CMakeLists.txt
+++ b/tests/drivers/nrfx_integration_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(NONE)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/nrfx_integration_test/Kconfig
+++ b/tests/drivers/nrfx_integration_test/Kconfig
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+source "Kconfig.zephyr"
+
+# This hidden option is intended to enable (include into compilation) all nrfx
+# drivers that are available for the SoC that is the build target.
+config NRFX_ALL_DRIVERS
+	def_bool y
+	depends on HAS_NRFX
+	select NRFX_ADC		if HAS_HW_NRF_ADC
+	select NRFX_CLOCK	if HAS_HW_NRF_CLOCK
+	select NRFX_COMP	if HAS_HW_NRF_COMP
+	select NRFX_DPPI	if HAS_HW_NRF_DPPIC
+	select NRFX_EGU0	if HAS_HW_NRF_EGU0
+	select NRFX_EGU1	if HAS_HW_NRF_EGU1
+	select NRFX_EGU2	if HAS_HW_NRF_EGU2
+	select NRFX_EGU3	if HAS_HW_NRF_EGU3
+	select NRFX_EGU4	if HAS_HW_NRF_EGU4
+	select NRFX_EGU5	if HAS_HW_NRF_EGU5
+	select NRFX_GPIOTE	if HAS_HW_NRF_GPIOTE
+	select NRFX_I2S		if HAS_HW_NRF_I2S
+	select NRFX_IPC		if HAS_HW_NRF_IPC
+	select NRFX_LPCOMP	if HAS_HW_NRF_LPCOMP
+	select NRFX_NFCT	if HAS_HW_NRF_NFCT
+	select NRFX_NVMC
+	select NRFX_PDM		if HAS_HW_NRF_PDM
+	select NRFX_POWER	if HAS_HW_NRF_POWER
+	select NRFX_PPI		if HAS_HW_NRF_PPI
+	select NRFX_PWM0	if HAS_HW_NRF_PWM0
+	select NRFX_PWM1	if HAS_HW_NRF_PWM1
+	select NRFX_PWM2	if HAS_HW_NRF_PWM2
+	select NRFX_PWM3	if HAS_HW_NRF_PWM3
+	select NRFX_QDEC	if HAS_HW_NRF_QDEC
+	select NRFX_QSPI	if HAS_HW_NRF_QSPI
+	select NRFX_RNG		if HAS_HW_NRF_RNG
+	select NRFX_RTC0	if HAS_HW_NRF_RTC0
+	select NRFX_RTC1	if HAS_HW_NRF_RTC1
+	select NRFX_RTC2	if HAS_HW_NRF_RTC2
+	select NRFX_SAADC	if HAS_HW_NRF_SAADC
+	select NRFX_SPI0	if HAS_HW_NRF_SPI0
+	select NRFX_SPI1	if HAS_HW_NRF_SPI1
+	select NRFX_SPI2	if HAS_HW_NRF_SPI2
+	select NRFX_SPIM0	if HAS_HW_NRF_SPIM0
+	select NRFX_SPIM1	if HAS_HW_NRF_SPIM1
+	select NRFX_SPIM2	if HAS_HW_NRF_SPIM2
+	select NRFX_SPIM3	if HAS_HW_NRF_SPIM3
+	select NRFX_SPIM4	if HAS_HW_NRF_SPIM4
+	select NRFX_SPIS0	if HAS_HW_NRF_SPIS0
+	select NRFX_SPIS1	if HAS_HW_NRF_SPIS1
+	select NRFX_SPIS2	if HAS_HW_NRF_SPIS2
+	select NRFX_SPIS3	if HAS_HW_NRF_SPIS3
+	select NRFX_SYSTICK	if CPU_CORTEX_M_HAS_SYSTICK
+	select NRFX_TEMP	if HAS_HW_NRF_TEMP
+	select NRFX_TIMER0	if HAS_HW_NRF_TIMER0
+	select NRFX_TIMER1	if HAS_HW_NRF_TIMER1
+	select NRFX_TIMER2	if HAS_HW_NRF_TIMER2
+	select NRFX_TIMER3	if HAS_HW_NRF_TIMER3
+	select NRFX_TIMER4	if HAS_HW_NRF_TIMER4
+	select NRFX_TWI0	if HAS_HW_NRF_TWI0
+	select NRFX_TWI1	if HAS_HW_NRF_TWI1
+	select NRFX_TWIM0	if HAS_HW_NRF_TWIM0
+	select NRFX_TWIM1	if HAS_HW_NRF_TWIM1
+	select NRFX_TWIM2	if HAS_HW_NRF_TWIM2
+	select NRFX_TWIM3	if HAS_HW_NRF_TWIM3
+	select NRFX_TWIS0	if HAS_HW_NRF_TWIS0
+	select NRFX_TWIS1	if HAS_HW_NRF_TWIS1
+	select NRFX_TWIS2	if HAS_HW_NRF_TWIS2
+	select NRFX_TWIS3	if HAS_HW_NRF_TWIS3
+	select NRFX_UART0	if HAS_HW_NRF_UART0
+	select NRFX_UARTE0	if HAS_HW_NRF_UARTE0
+	select NRFX_UARTE1	if HAS_HW_NRF_UARTE1
+	select NRFX_UARTE2	if HAS_HW_NRF_UARTE2
+	select NRFX_UARTE3	if HAS_HW_NRF_UARTE3
+	select NRFX_USBD	if HAS_HW_NRF_USBD
+	select NRFX_USBREG	if HAS_HW_NRF_USBREG
+	select NRFX_WDT0	if HAS_HW_NRF_WDT || HAS_HW_NRF_WDT0
+	select NRFX_WDT1	if HAS_HW_NRF_WDT1
+	select NRFX_PRS_BOX_0
+	select NRFX_PRS_BOX_1
+	select NRFX_PRS_BOX_2
+	select NRFX_PRS_BOX_3
+	select NRFX_PRS_BOX_4

--- a/tests/drivers/nrfx_integration_test/prj.conf
+++ b/tests/drivers/nrfx_integration_test/prj.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_ZTEST=y
+CONFIG_ASSERT=y
+CONFIG_BT=y
+# Prevent compilation of Zephyr I2C and SPI driver shims (enabling of the nrfx
+# Kconfig options would cause them to be compiled, even though the corresponding
+# DT nodes might be not enabled, and as a result certain static functions in
+# those shims might turn out to be defined but not used).
+CONFIG_I2C=n
+CONFIG_SPI=n

--- a/tests/drivers/nrfx_integration_test/src/main.c
+++ b/tests/drivers/nrfx_integration_test/src/main.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <ztest.h>
+#include <nrfx.h>
+
+/*
+ * The code below is not intended to do anything meaningful. Its only purpose
+ * is to use the definitions provided in nrfx_glue.h, to ensure that they are
+ * correct and thus nrfx is properly integrated into the environment of Zephyr.
+ */
+
+NRFX_STATIC_ASSERT(true);
+
+static void test_build(void)
+{
+	IRQn_Type dummy_irq_number = (IRQn_Type)0;
+	nrfx_atomic_t dummy_atomic_object;
+	volatile uint32_t used_resources;
+
+	NRFX_ASSERT(true);
+
+	NRFX_IRQ_PRIORITY_SET(dummy_irq_number, 0);
+	NRFX_IRQ_ENABLE(dummy_irq_number);
+	if (NRFX_IRQ_IS_ENABLED(dummy_irq_number)) {
+		NRFX_IRQ_DISABLE(dummy_irq_number);
+	}
+	NRFX_IRQ_PENDING_SET(dummy_irq_number);
+	if (NRFX_IRQ_IS_PENDING(dummy_irq_number)) {
+		NRFX_IRQ_PENDING_CLEAR(dummy_irq_number);
+	}
+
+	NRFX_CRITICAL_SECTION_ENTER();
+	NRFX_CRITICAL_SECTION_EXIT();
+
+	NRFX_DELAY_US(0);
+
+	NRFX_ATOMIC_FETCH_STORE(&dummy_atomic_object, 0);
+	NRFX_ATOMIC_FETCH_OR(&dummy_atomic_object, 0);
+	NRFX_ATOMIC_FETCH_AND(&dummy_atomic_object, 0);
+	NRFX_ATOMIC_FETCH_XOR(&dummy_atomic_object, 0);
+	NRFX_ATOMIC_FETCH_ADD(&dummy_atomic_object, 0);
+	NRFX_ATOMIC_FETCH_SUB(&dummy_atomic_object, 0);
+
+	used_resources = NRFX_DPPI_CHANNELS_USED | NRFX_DPPI_GROUPS_USED |
+			 NRFX_PPI_CHANNELS_USED | NRFX_PPI_GROUPS_USED |
+			 NRFX_EGUS_USED | NRFX_TIMERS_USED;
+}
+
+void test_main(void)
+{
+	ztest_test_suite(test_nrfx_integration,
+		ztest_unit_test(test_build)
+	);
+
+	ztest_run_test_suite(test_nrfx_integration);
+}

--- a/tests/drivers/nrfx_integration_test/testcase.yaml
+++ b/tests/drivers/nrfx_integration_test/testcase.yaml
@@ -1,0 +1,11 @@
+tests:
+  nrfx_integration_test.build:
+    build_only: true
+    filter: CONFIG_HAS_NRFX
+    tags: drivers ci_build
+  nrfx_integration_test.build.softdevice:
+    build_only: true
+    filter: CONFIG_HAS_NRFX
+    tags: drivers ci_build
+    extra_configs:
+      - CONFIG_BT_LL_SOFTDEVICE=y


### PR DESCRIPTION
The purpose of this test is to check if the nrfx adaptation layer
provided in nrfx_glue.h is correct and all nrfx drivers available
for particular nRF SoCs can be successfully compiled, and to perform
these checks as a part of CI testing.