### PR TITLE
[WIP] Integrate documentation from nrfx

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -39,10 +39,16 @@ if(NOT DEFINED ENV{NRFXLIB_BASE})
   set(ENV{NRFXLIB_BASE} ${NRFXLIB_BASE})
 endif()
 
+if(NOT DEFINED ENV{NRFX_BASE})
+  get_filename_component(NRFX_BASE ${CMAKE_CURRENT_LIST_DIR}/../../modules/hal/nordic/nrfx REALPATH)
+  set(ENV{NRFX_BASE} ${NRFX_BASE})
+endif()
+
 message(STATUS "ZEPHYR_BASE: ${ZEPHYR_BASE}")
 message(STATUS "NRF_BASE: $ENV{NRF_BASE}")
 message(STATUS "MCUBOOT_BASE: $ENV{MCUBOOT_BASE}")
 message(STATUS "NRFXLIB_BASE: $ENV{NRFXLIB_BASE}")
+message(STATUS "NRFX_BASE: $ENV{NRFX_BASE}")
 
 #
 # Find programs we need (Python, Sphinx, and Doxygen)
@@ -66,6 +72,7 @@ set(ZEPHYR_BINARY_DIR ${CMAKE_BINARY_DIR}/zephyr)
 set(NRF_BINARY_DIR ${CMAKE_BINARY_DIR}/nrf)
 set(MCUBOOT_BINARY_DIR ${CMAKE_BINARY_DIR}/mcuboot)
 set(NRFXLIB_BINARY_DIR ${CMAKE_BINARY_DIR}/nrfxlib)
+set(NRFX_BINARY_DIR ${CMAKE_BINARY_DIR}/nrfx)
 
 # Output directory for the shared Kconfig documentation
 set(KCONFIG_BINARY_DIR ${CMAKE_BINARY_DIR}/kconfig)
@@ -100,9 +107,10 @@ add_dependencies(zephyr html)
 # Add 'clean-zephyr', 'clean-nrf', etc., targets
 #
 
-foreach(target zephyr nrf mcuboot nrfxlib kconfig)
+foreach(target zephyr nrf mcuboot nrfxlib nrfx kconfig)
   set(TARGET_BINARY_DIR ${CMAKE_BINARY_DIR}/${target})
-  # Cleanup build output
+  # Cleanup build output. remove_directory silently ignores missing
+  # directories.
   add_custom_target(
     clean-${target}
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${TARGET_BINARY_DIR}/doctrees
@@ -269,7 +277,7 @@ add_custom_target(mcuboot)
 add_dependencies(mcuboot mcuboot-html)
 
 #
-# Add nrfxlib-related targets
+# Add nrfxlib-related targets (not to be confused with nrfx)
 #
 
 # Create an mbedtls configuration file with all settings on
@@ -343,6 +351,23 @@ add_dependencies(nrfxlib-html nrfxlib-content nrfxlib-doxy)
 
 add_custom_target(nrfxlib)
 add_dependencies(nrfxlib nrfxlib-html)
+
+#
+# Add nrfx-related targets (not to be confusd with nrfxlib)
+#
+
+set(NRFX_DOXY_LOG ${NRFX_BINARY_DIR}/doxy.log)
+
+add_custom_target(
+  nrfx-doxy
+  COMMAND ${CMAKE_COMMAND}
+    -DCOMMAND=${DOXYGEN_EXECUTABLE}
+    -DARGS=nrfx.doxyfile
+    -DOUTPUT_FILE=${NRFX_DOXY_LOG}
+    -DERROR_FILE=${NRFX_DOXY_LOG}
+    -DWORKING_DIRECTORY=${NRFX_BASE}/doc
+    -P ${ZEPHYR_BASE}/cmake/util/execute_process.cmake
+)
 
 #
 # Add targets for building the shared Kconfig documentation

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -67,6 +67,9 @@ set(NRF_BINARY_DIR ${CMAKE_BINARY_DIR}/nrf)
 set(MCUBOOT_BINARY_DIR ${CMAKE_BINARY_DIR}/mcuboot)
 set(NRFXLIB_BINARY_DIR ${CMAKE_BINARY_DIR}/nrfxlib)
 
+# Output directory for the shared Kconfig documentation
+set(KCONFIG_BINARY_DIR ${CMAKE_BINARY_DIR}/kconfig)
+
 # HTML output directory
 set(HTML_DIR ${CMAKE_BINARY_DIR}/html)
 file(MAKE_DIRECTORY ${HTML_DIR})
@@ -78,9 +81,12 @@ file(MAKE_DIRECTORY ${HTML_DIR})
 # common Sphinx HTML output folder.
 #
 
-# Parameters to doc/CMakeLists.txt in Zephyr
+# Parameters to doc/CMakeLists.txt in Zephyr. KCONFIG_OUTPUT is used to find
+# objects.inv from the Kconfig docs, to link the Zephyr docs to the Kconfig
+# docs.
 set(SPHINXOPTS -c ${NRF_BASE}/doc/zephyr)
 set(SPHINX_OUTPUT_DIR ${HTML_DIR}/zephyr)
+set(KCONFIG_OUTPUT ${HTML_DIR}/kconfig)
 
 # Get access to the 'html' target from doc/CMakeLists.txt in Zephyr
 add_subdirectory(${ZEPHYR_BASE}/doc ${ZEPHYR_BINARY_DIR})
@@ -94,7 +100,7 @@ add_dependencies(zephyr html)
 # Add 'clean-zephyr', 'clean-nrf', etc., targets
 #
 
-foreach(target zephyr nrf mcuboot nrfxlib)
+foreach(target zephyr nrf mcuboot nrfxlib kconfig)
   set(TARGET_BINARY_DIR ${CMAKE_BINARY_DIR}/${target})
   # Cleanup build output
   add_custom_target(
@@ -176,18 +182,6 @@ else()
   set(SEP :)
 endif()
 
-add_custom_target(
-  nrf-kconfig
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${NRF_RST_OUT}/doc/nrf/reference/kconfig
-  COMMAND ${CMAKE_COMMAND} -E env
-  PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}"
-  srctree=${NRF_BASE}
-  KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
-  KCONFIG_DOC_MODE=1
-  ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/genrest.py --kconfig ${NRF_BASE}/Kconfig.nrf ${NRF_RST_OUT}/doc/nrf/reference/kconfig/
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-)
-
 set(NRF_SPHINX_BUILD_HTML_COMMAND
   ${CMAKE_COMMAND} -E env
   ZEPHYR_BUILD=${ZEPHYR_BINARY_DIR}
@@ -195,6 +189,7 @@ set(NRF_SPHINX_BUILD_HTML_COMMAND
   NRF_BASE=${NRF_BASE}
   NRF_BUILD=${NRF_BINARY_DIR}
   NRF_OUTPUT=${HTML_DIR}/nrf
+  KCONFIG_OUTPUT=${HTML_DIR}/kconfig
   NRF_RST_SRC=${NRF_RST_OUT}/doc/nrf
   MCUBOOT_OUTPUT=${HTML_DIR}/mcuboot
   NRFXLIB_OUTPUT=${HTML_DIR}/nrfxlib
@@ -210,7 +205,7 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/static/html/index.html ${HTML_DIR}
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
-add_dependencies(nrf-html nrf-doxy nrf-content nrf-kconfig)
+add_dependencies(nrf-html nrf-doxy nrf-content)
 
 add_custom_target(nrf)
 add_dependencies(nrf nrf-html)
@@ -261,6 +256,9 @@ add_custom_target(
   ZEPHYR_OUTPUT=${HTML_DIR}/zephyr
   NRF_OUTPUT=${HTML_DIR}/nrf
   NRF_RST_SRC=${NRF_RST_OUT}/doc/nrf
+  MCUBOOT_OUTPUT=${HTML_DIR}/mcuboot
+  MCUBOOT_RST_SRC=${MCUBOOT_RST_OUT}
+  KCONFIG_OUTPUT=${HTML_DIR}/kconfig
   ${SPHINXBUILD} -w ${MCUBOOT_SPHINX_LOG} -N -b html ${MCUBOOT_SPHINXOPTS} ${MCUBOOT_RST_OUT}/doc/mcuboot ${HTML_DIR}/mcuboot
 
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
@@ -309,18 +307,6 @@ add_custom_target(
 )
 
 
-add_custom_target(
-  nrfxlib-kconfig
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${NRFXLIB_RST_OUT}/kconfig
-  COMMAND ${CMAKE_COMMAND} -E env
-  PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}"
-  srctree=${NRFXLIB_BASE}
-  KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
-  KCONFIG_DOC_MODE=1
-  ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/genrest.py --kconfig ${NRFXLIB_BASE}/Kconfig.nrfxlib ${NRFXLIB_RST_OUT}/kconfig
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-)
-
 set(NRFXLIB_EXTRACT_CONTENT_COMMAND
  ${CMAKE_COMMAND} -E env
   ZEPHYR_BASE=${NRFXLIB_BASE}
@@ -346,11 +332,75 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E env
   NRF_BASE=${NRF_BASE}
   NRFXLIB_BUILD=${NRFXLIB_BINARY_DIR}
+  NRFXLIB_OUTPUT=${HTML_DIR}/nrfxlib
+  NRFXLIB_RST_SRC=${NRFXLIB_RST_OUT}
+  KCONFIG_OUTPUT=${HTML_DIR}/kconfig
   ${SPHINXBUILD} -w ${NRFXLIB_SPHINX_LOG} -N -b html ${NRFXLIB_SPHINXOPTS} ${NRFXLIB_RST_OUT} ${HTML_DIR}/nrfxlib
 
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
-add_dependencies(nrfxlib-html nrfxlib-content nrfxlib-doxy nrfxlib-kconfig)
+add_dependencies(nrfxlib-html nrfxlib-content nrfxlib-doxy)
 
 add_custom_target(nrfxlib)
 add_dependencies(nrfxlib nrfxlib-html)
+
+#
+# Add targets for building the shared Kconfig documentation
+#
+
+# The Kconfig documentation is a separate documentation set that's shared
+# between all modules (nRF, Zephyr, etc.). This makes it possible to link to
+# Kconfig symbols regardless of where they are defined.
+#
+# We rely on the Zephyr Kconfig files pulling in the other Kconfig files, and
+# use the --modules option to genrest.py to split the documentation into a
+# separate page for each module.
+
+set(KCONFIG_RST_OUT ${KCONFIG_BINARY_DIR}/rst)
+
+# The 'kconfig-content' target uses genrest.py to generate .rst files for all
+# Kconfig symbols, as well as index pages that point to them
+add_custom_target(
+  kconfig-content
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${KCONFIG_RST_OUT}
+  COMMAND ${CMAKE_COMMAND} -E env
+    PYTHONPATH=${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}
+    ZEPHYR_BASE=${ZEPHYR_BASE}
+    srctree=${ZEPHYR_BASE}
+    BOARD_DIR=boards/*/*/
+    ARCH=*
+    ARCH_DIR=arch/
+    SOC_DIR=soc/
+    CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
+    KCONFIG_WARN_UNDEF=y
+    KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
+    KCONFIG_DOC_MODE=1
+      ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/genrest.py ${KCONFIG_RST_OUT}
+        --separate-all-index
+        --modules nRF,nrf,${NRF_BASE}
+                  nrfxlib,nrfxlib,${NRFXLIB_BASE}
+
+  VERBATIM
+)
+
+# No 'kconfig' target exists, because it clashes with the imported 'kconfig'
+# target from the Zephyr repository
+
+add_custom_target(
+  kconfig-html
+  COMMAND ${CMAKE_COMMAND} -E env
+    ZEPHYR_BASE=${ZEPHYR_BASE}
+    ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
+      ${SPHINXBUILD}
+        -b html
+        -c ${NRF_BASE}/doc/kconfig
+        -d ${KCONFIG_BINARY_DIR}/doctrees
+        -N
+        -w ${KCONFIG_BINARY_DIR}/sphinx.log
+        # The Kconfig reference build doesn't use Breathe, so we can safely
+        # parallelize it
+        -j auto
+        ${KCONFIG_RST_OUT}
+        ${HTML_DIR}/kconfig
+)
+add_dependencies(kconfig-html kconfig-content)

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -1,0 +1,62 @@
+# Kconfig documentation build configuration file
+
+import os
+
+NRF_BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# -- General configuration ------------------------------------------------
+
+# Sphinx 2.0 changes the default from 'index' to 'contents'
+master_doc = 'index'
+
+# General information about the project.
+project = 'Kconfig Reference'
+copyright = '2019, Nordic Semiconductor'
+author = 'Nordic Semiconductor'
+
+version = '1.0.0'  # Dummy version
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = ['_build']
+
+# -- Options for HTML output ----------------------------------------------
+
+html_theme = "kconfig"
+html_theme_path = ['{}/doc/themes'.format(NRF_BASE)]
+html_favicon = '{}/doc/static/images/favicon.ico'.format(NRF_BASE)
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+html_title = "Kconfig Reference"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['{}/doc/static'.format(NRF_BASE)]
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
+# using the given strftime format.
+html_last_updated_fmt = '%b %d, %Y'
+
+# If false, no module index is generated.
+html_domain_indices = False
+
+# If false, no index is generated.
+html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+html_split_index = True
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
+html_show_sphinx = False
+
+# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
+html_show_copyright = True
+
+# If true, license is shown in the HTML footer. Default is True.
+html_show_license = True
+
+def setup(app):
+    app.add_stylesheet("css/common.css")
+    app.add_stylesheet("css/kconfig.css")

--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -40,6 +40,17 @@ if "NRF_RST_SRC" not in os.environ:
     sys.exit("$NRF_RST_SRC environment variable undefined.")
 NRF_RST_SRC = os.path.abspath(os.environ["NRF_RST_SRC"])
 
+if "MCUBOOT_OUTPUT" not in os.environ:
+    sys.exit("$MCUBOOT_OUTPUT environment variable undefined.")
+MCUBOOT_OUTPUT = os.path.abspath(os.environ["MCUBOOT_OUTPUT"])
+
+if "MCUBOOT_RST_SRC" not in os.environ:
+    sys.exit("$MCUBOOT_RST_SRC environment variable undefined.")
+MCUBOOT_RST_SRC = os.path.abspath(os.environ["MCUBOOT_RST_SRC"])
+
+if "KCONFIG_OUTPUT" not in os.environ:
+    sys.exit("$KCONFIG_OUTPUT environment variable undefined.")
+KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
 
 # -- General configuration ------------------------------------------------
 
@@ -146,9 +157,15 @@ html_show_copyright = True
 # If true, license is shown in the HTML footer. Default is True.
 html_show_license = True
 
-
 intersphinx_mapping = {
-    'zephyr': ('{}'.format(os.path.relpath(ZEPHYR_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(ZEPHYR_OUTPUT, NRF_RST_SRC)), 'objects.inv'))
+    # Link the Kconfig docs with Intersphinx so that references to Kconfig
+    # symbols (via :option:`CONFIG_FOO`) turn into links
+    'kconfig': (os.path.relpath(KCONFIG_OUTPUT, MCUBOOT_OUTPUT),
+                os.path.join(os.path.relpath(KCONFIG_OUTPUT, MCUBOOT_RST_SRC),
+                             'objects.inv')),
+    'zephyr': (os.path.relpath(ZEPHYR_OUTPUT, NRF_OUTPUT),
+               os.path.join(os.path.relpath(ZEPHYR_OUTPUT, NRF_RST_SRC),
+                            'objects.inv'))
 }
 
 def setup(app):

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -60,6 +60,10 @@ if "NRFXLIB_OUTPUT" not in os.environ:
     sys.exit("$NRFXLIB_OUTPUT environment variable undefined.")
 NRFXLIB_OUTPUT = os.path.abspath(os.environ["NRFXLIB_OUTPUT"])
 
+if "KCONFIG_OUTPUT" not in os.environ:
+    sys.exit("$KCONFIG_OUTPUT environment variable undefined.")
+KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -168,7 +172,10 @@ html_show_license = True
 intersphinx_mapping = {
     'zephyr': ('{}'.format(os.path.relpath(ZEPHYR_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(ZEPHYR_OUTPUT, NRF_RST_SRC)), 'objects.inv')),
     'mcuboot': ('{}'.format(os.path.relpath(MCUBOOT_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(MCUBOOT_OUTPUT, NRF_RST_SRC)), 'objects.inv')),
-    'nrfxlib': ('{}'.format(os.path.relpath(NRFXLIB_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(NRFXLIB_OUTPUT, NRF_RST_SRC)), 'objects.inv'))
+    'nrfxlib': ('{}'.format(os.path.relpath(NRFXLIB_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(NRFXLIB_OUTPUT, NRF_RST_SRC)), 'objects.inv')),
+    'kconfig': (os.path.relpath(KCONFIG_OUTPUT, NRF_OUTPUT),
+                os.path.join(os.path.relpath(KCONFIG_OUTPUT, NRF_RST_SRC),
+                             'objects.inv'))
 }
 
 breathe_projects = {

--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -87,6 +87,12 @@ Complete the following steps to build the documentation output:
 
            cmake -GNinja ..
 
+#. Run ninja to build the Kconfig documentation:
+
+        .. code-block:: console
+
+           ninja kconfig-html
+
 #. Run ninja to build the Zephyr documentation:
 
         .. code-block:: console

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -31,6 +31,5 @@ Documentation for different versions of the |NCS| is available at the following 
    drivers
    libraries
    scripts
-   reference/kconfig/index
 
 ..   cheat_sheet

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -32,6 +32,18 @@ if "NRFXLIB_BUILD" not in os.environ:
     sys.exit("$NRFXLIB_BUILD environment variable undefined.")
 NRFXLIB_BUILD = os.path.abspath(os.environ["NRFXLIB_BUILD"])
 
+if "NRFXLIB_OUTPUT" not in os.environ:
+    sys.exit("$NRFXLIB_OUTPUT environment variable undefined.")
+NRFXLIB_OUTPUT = os.path.abspath(os.environ["NRFXLIB_OUTPUT"])
+
+if "NRFXLIB_RST_SRC" not in os.environ:
+    sys.exit("$NRFXLIB_RST_SRC environment variable undefined.")
+NRFXLIB_RST_SRC = os.path.abspath(os.environ["NRFXLIB_RST_SRC"])
+
+if "KCONFIG_OUTPUT" not in os.environ:
+    sys.exit("$KCONFIG_OUTPUT environment variable undefined.")
+KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -136,6 +148,13 @@ html_show_copyright = True
 # If true, license is shown in the HTML footer. Default is True.
 html_show_license = True
 
+# Link the Kconfig docs with Intersphinx so that references to Kconfig symbols
+# (via :option:`CONFIG_FOO`) turn into links
+intersphinx_mapping = {
+    'kconfig': (os.path.relpath(KCONFIG_OUTPUT, NRFXLIB_OUTPUT),
+                os.path.join(os.path.relpath(KCONFIG_OUTPUT, NRFXLIB_RST_SRC),
+                             'objects.inv'))
+}
 
 breathe_projects = {
     "nrfxlib": "{}/doxygen/xml".format(NRFXLIB_BUILD),

--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -67,6 +67,9 @@ div.figure {
 .nrfxlib {
  background-color: #ff9933;
 }
+.kconfig {
+ background-color: #e82424
+}
 
 
 /* dbk tweak for doxygen-generated API headings (for RTD theme) */

--- a/doc/static/css/kconfig.css
+++ b/doc/static/css/kconfig.css
@@ -1,0 +1,24 @@
+/* background color top and bottom left */
+
+.wy-side-nav-search {
+ background-color: #e82424
+}
+
+.rst-versions .rst-current-version {
+ background-color: #e82424;
+}
+
+/* text color navigation menu */
+
+/* l1 not selected */
+.wy-menu-vertical a {
+ color: #e82424;
+}
+/* expanded container nodes */
+.wy-menu-vertical li.on a, .wy-menu-vertical li.current > a {
+ color: #e82424;
+}
+/* expanded nodes, not selected */
+.wy-menu-vertical li.current a {
+ color: #e82424;
+}

--- a/doc/themes/kconfig/theme.conf
+++ b/doc/themes/kconfig/theme.conf
@@ -1,0 +1,18 @@
+[theme]
+inherit = nrf
+stylesheet = css/theme.css
+pygments_style = default
+
+[options]
+canonical_url =
+analytics_id =
+collapse_navigation = True
+sticky_navigation = True
+navigation_depth = 4
+includehidden = True
+titles_only =
+logo_only =
+display_version = True
+prev_next_buttons_location = bottom
+style_external_links = False
+vcs_pageview_mode =

--- a/doc/themes/kconfig/versions.html
+++ b/doc/themes/kconfig/versions.html
@@ -11,6 +11,9 @@
       <div class="rst-other-version nrfxlib">
         <a href="{{ pathto('',1) }}../nrfxlib/README.html">nrfxlib</a>
       </div>
+      <div class="rst-other-version nrfx">
+        <a href="{{ pathto('',1) }}../nrfx/index.html">nrfx</a>
+      </div>
       <div class="rst-other-version zephyr">
         <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a>
       </div>

--- a/doc/themes/kconfig/versions.html
+++ b/doc/themes/kconfig/versions.html
@@ -1,21 +1,21 @@
 {# Add rst-badge after rst-versions for small badge style. #}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="fa fa-book"> nrfxlib</span>
+      <span class="fa fa-book">Kconfig Reference</span>
        <span class="fa fa-caret-down"></span>
     </span>
     <div class="rst-other-versions">
       <div class="rst-other-version ncs">
         <a href="{{ pathto('',1) }}../nrf/index.html">nRF Connect SDK</a>
       </div>
+      <div class="rst-other-version nrfxlib">
+        <a href="{{ pathto('',1) }}../nrfxlib/README.html">nrfxlib</a>
+      </div>
       <div class="rst-other-version zephyr">
-        <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a><br/>
+        <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a>
       </div>
       <div class="rst-other-version mcuboot">
         <a href="{{ pathto('',1) }}../mcuboot/wrapper.html">MCUboot</a>
-      </div>
-      <div class="rst-other-version kconfig">
-        <a href="{{ pathto('',1) }}../kconfig/index.html">Kconfig Reference</a>
       </div>
     </div>
   </div>

--- a/doc/themes/mcuboot/versions.html
+++ b/doc/themes/mcuboot/versions.html
@@ -14,5 +14,8 @@
       <div class="rst-other-version zephyr">
         <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a><br/>
       </div>
+      <div class="rst-other-version kconfig">
+        <a href="{{ pathto('',1) }}../kconfig/index.html">Kconfig Reference</a>
+      </div>
     </div>
   </div>

--- a/doc/themes/mcuboot/versions.html
+++ b/doc/themes/mcuboot/versions.html
@@ -11,6 +11,9 @@
       <div class="rst-other-version nrfxlib">
         <a href="{{ pathto('',1) }}../nrfxlib/README.html">nrfxlib</a>
       </div>
+      <div class="rst-other-version nrfx">
+        <a href="{{ pathto('',1) }}../nrfx/index.html">nrfx</a>
+      </div>
       <div class="rst-other-version zephyr">
         <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a><br/>
       </div>

--- a/doc/themes/nrf/versions.html
+++ b/doc/themes/nrf/versions.html
@@ -14,5 +14,8 @@
       <div class="rst-other-version mcuboot">
         <a href="{{ pathto('',1) }}../mcuboot/wrapper.html">MCUboot</a>
       </div>
+      <div class="rst-other-version kconfig">
+        <a href="{{ pathto('',1) }}../kconfig/index.html">Kconfig Reference</a>
+      </div>
     </div>
   </div>

--- a/doc/themes/nrf/versions.html
+++ b/doc/themes/nrf/versions.html
@@ -8,6 +8,9 @@
       <div class="rst-other-version nrfxlib">
         <a href="{{ pathto('',1) }}../nrfxlib/README.html">nrfxlib</a>
       </div>
+      <div class="rst-other-version nrfx">
+        <a href="{{ pathto('',1) }}../nrfx/index.html">nrfx</a>
+      </div>
       <div class="rst-other-version zephyr">
         <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a><br/>
       </div>

--- a/doc/themes/nrfxlib/versions.html
+++ b/doc/themes/nrfxlib/versions.html
@@ -8,6 +8,9 @@
       <div class="rst-other-version ncs">
         <a href="{{ pathto('',1) }}../nrf/index.html">nRF Connect SDK</a>
       </div>
+      <div class="rst-other-version nrfx">
+        <a href="{{ pathto('',1) }}../nrfx/index.html">nrfx</a>
+      </div>
       <div class="rst-other-version zephyr">
         <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a><br/>
       </div>

--- a/doc/themes/zephyr/versions.html
+++ b/doc/themes/zephyr/versions.html
@@ -14,5 +14,8 @@
       <div class="rst-other-version mcuboot">
         <a href="{{ pathto('',1) }}../mcuboot/wrapper.html">MCUboot</a>
       </div>
+      <div class="rst-other-version kconfig">
+        <a href="{{ pathto('',1) }}../kconfig/index.html">Kconfig Reference</a>
+      </div>
     </div>
   </div>

--- a/doc/themes/zephyr/versions.html
+++ b/doc/themes/zephyr/versions.html
@@ -11,6 +11,9 @@
       <div class="rst-other-version nrfxlib">
         <a href="{{ pathto('',1) }}../nrfxlib/README.html">nrfxlib</a>
       </div>
+      <div class="rst-other-version nrfx">
+        <a href="{{ pathto('',1) }}../nrfx/README.html">nrfx</a>
+      </div>
       <div class="rst-other-version mcuboot">
         <a href="{{ pathto('',1) }}../mcuboot/wrapper.html">MCUboot</a>
       </div>

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -17,13 +17,24 @@ import os
 from subprocess import CalledProcessError, check_output, DEVNULL
 
 if "ZEPHYR_BASE" not in os.environ:
-    print("$ZEPHYR_BASE environment variable undefined.")
     sys.exit("$ZEPHYR_BASE environment variable undefined.")
 ZEPHYR_BASE = os.path.abspath(os.environ["ZEPHYR_BASE"])
 
 if "ZEPHYR_BUILD" not in os.environ:
     sys.exit("$ZEPHYR_BUILD environment variable undefined.")
 ZEPHYR_BUILD = os.path.abspath(os.environ["ZEPHYR_BUILD"])
+
+if "ZEPHYR_OUTPUT" not in os.environ:
+    sys.exit("$ZEPHYR_OUTPUT environment variable undefined.")
+ZEPHYR_OUTPUT = os.path.abspath(os.environ["ZEPHYR_OUTPUT"])
+
+if "ZEPHYR_RST_SRC" not in os.environ:
+    sys.exit("$ZEPHYR_RST_SRC environment variable undefined.")
+ZEPHYR_RST_SRC = os.path.abspath(os.environ["ZEPHYR_RST_SRC"])
+
+if "KCONFIG_OUTPUT" not in os.environ:
+    sys.exit("$KCONFIG_OUTPUT environment variable undefined.")
+KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
 
 NRF_BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
@@ -61,6 +72,7 @@ except CalledProcessError as e:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.intersphinx',
     'breathe', 'sphinx.ext.todo',
     'sphinx.ext.extlinks',
     'sphinx.ext.autodoc',
@@ -256,6 +268,14 @@ html_show_copyright = True
 
 # If true, license is shown in the HTML footer. Default is True.
 html_show_license = True
+
+# Link the Kconfig docs with Intersphinx so that references to Kconfig symbols
+# (via :option:`CONFIG_FOO`) turn into links
+intersphinx_mapping = {
+    'kconfig': (os.path.relpath(KCONFIG_OUTPUT, ZEPHYR_OUTPUT),
+                os.path.join(os.path.relpath(KCONFIG_OUTPUT, ZEPHYR_RST_SRC),
+                             'objects.inv'))
+}
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the

--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 9a0a85cf67602e4fa5b0c6d7cef2c5e58ca4ac34
+      revision: pull/234/head
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Needs the Zephyr merge in
https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1750 to go in
first, and nrfx might need some RST documentation to latch onto too
(hal_nordic currently has no RST docs). This just adds most of the
scaffolding as a reference for later.

See https://github.com/zephyrproject-rtos/zephyr/issues/22151 for a
related issue too.

Builds on https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1258 to avoid
clashes. That one needs to go in first too.