### PR TITLE
subsys: secure_services: expand read request to include NRF_UICR_S

### DIFF
--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -76,6 +76,8 @@ int spm_request_read(void *destination, u32_t addr, size_t len)
 		 .size = FICR_PUBLIC_SIZE},
 		{.start = FICR_RESTRICTED_ADDR,
 		 .size = FICR_RESTRICTED_SIZE},
+		{.start = (u32_t)NRF_UICR,
+		 .size = sizeof(NRF_UICR_Type)},
 	};
 
 	if (destination == NULL || len <= 0) {


### PR DESCRIPTION
The UICR peripheral is secure only, and cannot be configured otherwise.
The whole structure is set to 0x1000 in size to be future proof,
instead of limiting the size of the UICR read request to fit
with the nRF9160 only.
