### PR TITLE
spm: peripheral: Add UARTE3 to the list of configurable peripherals

### DIFF
--- a/include/spm.rst
+++ b/include/spm.rst
@@ -50,7 +50,7 @@ Peripherals configured as Non-Secure
    * SPIM3
    * TIMER0-2
    * TWIM2
-   * UARTE0, UARTE1
+   * UARTE0, UARTE1, UARTE3
    * WDT
 
 .. _lib_spm_secure_services:

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -140,6 +140,10 @@ config SPM_NRF_UARTE2_NS
 	bool "UARTE2 is Non-Secure"
 	default n
 
+config SPM_NRF_UARTE3_NS
+	bool "UARTE3 is Non-Secure"
+	default y
+
 config SPM_NRF_EGU1_NS
 	bool "EGU1 is Non-Secure"
 	default y

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -318,6 +318,9 @@ static void spm_config_peripherals(void)
 #ifdef NRF_UARTE2
 		PERIPH("NRF_UARTE2", NRF_UARTE2, CONFIG_SPM_NRF_UARTE2_NS),
 #endif
+#ifdef NRF_UARTE3
+		PERIPH("NRF_UARTE3", NRF_UARTE3, CONFIG_SPM_NRF_UARTE3_NS),
+#endif
 #ifdef NRF_TWIM2
 		PERIPH("NRF_TWIM2", NRF_TWIM2, CONFIG_SPM_NRF_TWIM2_NS),
 #endif


### PR DESCRIPTION
UARTE1-2 is on the list. This adds UARTE3 to the list of configurable
peripherals.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>