### PR TITLE
doc: Add/remove Thingy:91 from supported boards in samples/applications

### DIFF
--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -20,11 +20,9 @@ Requirements
 
 * One of the following development boards:
 
-  * |nRF9160DK|
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * A device running a BAS Server to connect with (for example, another board running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth Low Energy dongle and nRF Connect for Desktop)
 

--- a/samples/bluetooth/central_dfu_smp/README.rst
+++ b/samples/bluetooth/central_dfu_smp/README.rst
@@ -24,11 +24,9 @@ Requirements
 
 * One of the following development boards:
 
-  * |nRF9160DK|
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * A device running `MCUmgr`_ with `SMP over Bluetooth`_, for example, another board running the :ref:`smp_svr_sample`
 

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -24,11 +24,9 @@ Requirements
 
 * One of the following development boards:
 
-  * |nRF9160DK|
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * HIDS device to connect with (for example, another board running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth Low Energy dongle and nRF Connect for Desktop)
 

--- a/samples/bluetooth/enocean/README.rst
+++ b/samples/bluetooth/enocean/README.rst
@@ -23,7 +23,6 @@ Requirements
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * At least one :ref:`supported EnOcean device <bt_enocean_devices>`.
 

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -48,7 +48,6 @@ Requirements
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * The Nordic Semiconductor nRF Mesh app for Android or iOS.
 

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -55,9 +55,8 @@ Requirements
 
 * One of the following development boards:
 
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF52840DK|
+  * |nRF52DK|
 
 * The Nordic Semiconductor nRF Mesh app for Android or iOS.
 * The :ref:`bluetooth_mesh_light` sample application programmed on a separate device, and configured according to the Mesh Light sample's :ref:`bluetooth_mesh_light_testing` guide.

--- a/samples/bluetooth/peripheral_gatt_dm/README.rst
+++ b/samples/bluetooth/peripheral_gatt_dm/README.rst
@@ -17,7 +17,6 @@ Requirements
 
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * A device to connect to the peripheral, for example, a phone or a tablet with `nRF Connect for Mobile`_ or `nRF Toolbox`_
 

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -41,7 +41,6 @@ Requirements
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK| (with the `NFC_OOB_PAIRING` option disabled)
 
 If the `NFC_OOB_PAIRING` feature is enabled:
 

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -27,11 +27,9 @@ Requirements
 
 * One of the following development boards:
 
-  * |nRF9160DK|
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 User interface
 **************

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -22,7 +22,6 @@ Requirements
   * |nRF52840Dongle|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * A phone or tablet running a compatible application, for example `nRF Connect for Mobile`_, `nRF Blinky`_, or `nRF Toolbox`_.
 

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -77,8 +77,6 @@ Requirements
 
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK| - limited support;
-    some features, like an over-the-air data rate of 2 Ms/s, are not available on this board
 
   You can mix different boards.
 * Connection to a computer with a serial terminal for each of the boards.

--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -86,7 +86,6 @@ Requirements
   * |nRF9160DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 .. _bootloader_build_and_run:
 

--- a/samples/esb/README.rst
+++ b/samples/esb/README.rst
@@ -33,7 +33,6 @@ Requirements
 
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
   You can mix different boards.
 

--- a/samples/event_manager/README.rst
+++ b/samples/event_manager/README.rst
@@ -35,8 +35,6 @@ Requirements
   * |nRF9160DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
-
 
 Building and running
 ********************

--- a/samples/nrf9160/cloud_client/README.rst
+++ b/samples/nrf9160/cloud_client/README.rst
@@ -34,7 +34,6 @@ Requirements
 
 * One of the following development boards:
 
- * |Thingy91|
  * |nRF9160DK|
 
 Building and running

--- a/samples/profiler/README.rst
+++ b/samples/profiler/README.rst
@@ -28,8 +28,6 @@ Requirements
   * |nRF9160DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
-
 
 Building and running
 ********************


### PR DESCRIPTION
ref:https://projecttools.nordicsemi.no/jira/browse/NCSDK-3933
Removed Thingy:91 from supported boards in Cloud Client sample
as we are listing only boards which are actually tested. Also
removed nRF9160 DK from all the bluetooth samples and nRF51 DK from
all samples and applications.

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>