### PR TITLE
cmake: move patch from extensions.cmake to nrf repo

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -1,0 +1,15 @@
+# Included by zephyr/cmake/extensions.cmake
+
+# Usage:
+#   add_partition_manager_config(pm.yml)
+#
+# Will add all configurations defined in pm.yml to the global list of partition
+# manager configurations.
+function(add_partition_manager_config config_file)
+  get_filename_component(pm_path ${config_file} REALPATH)
+  set_property(
+    GLOBAL APPEND PROPERTY
+    PM_SUBSYS
+    ${pm_path}
+    )
+endfunction()

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: c025ef3dd5667e185c46f0255f6003f778d22b62
+      revision: pull/279/head
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger


### PR DESCRIPTION
This is done to reduce the diff from upstream, and to
facilitate downstream patches.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>