### PR TITLE
[RFC] AWS FOTA: Add support for TLS download and parsing of url field in JSON

### DIFF
--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -73,11 +73,15 @@ int fota_download_init(fota_download_callback_t client_callback);
  * When the download is complete, the secondary slot of MCUboot is tagged as having
  * valid firmware inside it. The completion is reported through an event.
  *
+ * @param host Hostname which you should start downloading from.
+ * @param file Filepath to the file you wish to download.
+ * @param sec_tag Security tag you want to use with HTTPS set to -1 to Disable.
+ *
  * @retval 0	     If download has started successfully.
  * @retval -EALREADY If download is already ongoing.
  *                   Otherwise, a negative value is returned.
  */
-int fota_download_start(const char *host, const char *file);
+int fota_download_start(const char *host, const char *file, int sec_tag);
 
 #ifdef __cplusplus
 }

--- a/samples/nrf9160/http_application_update/src/main.c
+++ b/samples/nrf9160/http_application_update/src/main.c
@@ -27,13 +27,14 @@ void bsd_recoverable_error_handler(uint32_t err)
 	printk("bsdlib recoverable error: %u\n", err);
 }
 
+#define NO_TLS -1
 /**@brief Start transfer of the file. */
 static void app_dfu_transfer_start(struct k_work *unused)
 {
 	int retval;
 
 	retval = fota_download_start(CONFIG_DOWNLOAD_HOST,
-				     CONFIG_DOWNLOAD_FILE);
+				     CONFIG_DOWNLOAD_FILE, NO_TLS);
 	if (retval != 0) {
 		/* Re-enable button callback */
 		gpio_pin_enable_callback(gpiob, DT_ALIAS_SW0_GPIOS_PIN);

--- a/subsys/net/lib/aws_fota/Kconfig
+++ b/subsys/net/lib/aws_fota/Kconfig
@@ -21,7 +21,11 @@ config AWS_FOTA_HOSTNAME_MAX_LEN
 
 config AWS_FOTA_FILE_PATH_MAX_LEN
 	int "File path buffer size"
-	default 255
+	default 1246
+
+config AWS_FOTA_DOWNLOAD_SEC_TAG
+	int "Security tag for download root certificate"
+	default 42
 
 
 module=AWS_FOTA

--- a/subsys/net/lib/aws_fota/include/aws_fota_json.h
+++ b/subsys/net/lib/aws_fota/include/aws_fota_json.h
@@ -46,6 +46,8 @@ extern "C" {
  * @param[in] payload_len  The length of the provided string.
  * @param[out] job_id_buf  Output buffer for the "jobId" field from the
  *			   JobExecution data type.
+ * @param[out] schema_buf  Output buffer for the "protocol" field from the Job
+ *			     Document
  * @param[out] hostname_buf  Output buffer for the "host" field from the Job
  *			     Document
  * @param[out] file_path_buf  Output buffer for the "file" field from the Job
@@ -59,6 +61,7 @@ extern "C" {
 int aws_fota_parse_DescribeJobExecution_rsp(const char *job_document,
 					    u32_t payload_len,
 					    char *job_id_buf,
+					    char *schema_buf,
 					    char *hostname_buf,
 					    char *file_path_buf,
 					    int *version_number);

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -234,7 +234,7 @@ static int job_update_accepted(struct mqtt_client *const client,
 		execution_state = AWS_JOBS_IN_PROGRESS;
 		LOG_INF("Start downloading firmware from %s/%s",
 			log_strdup(hostname), log_strdup(file_path));
-		err = fota_download_start(hostname, file_path);
+		err = fota_download_start(hostname, file_path, -1);
 		if (err) {
 			LOG_ERR("Error (%d) when trying to start firmware "
 				"download", err);

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -203,12 +203,12 @@ static void download_with_offset(struct k_work *unused)
 	}
 }
 
-int fota_download_start(const char *host, const char *file)
+int fota_download_start(const char *host, const char *file, int sec_tag)
 {
 	int err = -1;
 
 	struct download_client_cfg config = {
-		.sec_tag = -1, /* HTTP */
+		.sec_tag = sec_tag,
 	};
 
 	if (host == NULL || file == NULL || callback == NULL) {

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -119,6 +119,7 @@ static void init(void)
 	zassert_equal(err, 0, NULL);
 }
 
+#define NO_TLS -1
 static void test_fota_download_start(void)
 {
 	int err;
@@ -131,7 +132,7 @@ static void test_fota_download_start(void)
 	s1_version = 1;
 	expect_s0_active = false;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf);
+	err = fota_download_start("something.com", buf, NO_TLS);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
 		      "Incorrect param for s0_active");
@@ -139,7 +140,7 @@ static void test_fota_download_start(void)
 	s0_version = 2;
 	s1_version = 1;
 	expect_s0_active = true;
-	err = fota_download_start("something.com", buf);
+	err = fota_download_start("something.com", buf, NO_TLS);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
 		      "Incorrect param for s0_active");
@@ -152,14 +153,14 @@ static void test_fota_download_start(void)
 	/* update set to null indicates to use original file param */
 	dfu_ctx_mcuboot_set_b1_file__update = NULL;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf);
+	err = fota_download_start("something.com", buf, NO_TLS);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S0_S1) == 0, NULL);
 
 	/* update set to not null indicates to use update for file param */
 	dfu_ctx_mcuboot_set_b1_file__update = S1;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf);
+	err = fota_download_start("something.com", buf, NO_TLS);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S1) == 0, NULL);
 }


### PR DESCRIPTION
Now that TLS is supported in Download client we can add support for using both TLS for downloading the file over HTTPS from an S3 bucket and presigned URLs(https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html)

Previously we defaulted to using http on public S3 buckets which is still the behavior when not having defined `DOWNLOAD_CLIENT_TLS`. I'm not sure if we should start throwing an error or keep the previous behavior. It's now made so that it will parse out the `protocol` field of a job document and decide wether to use **HTTP** or **HTTPS** if `DOWNLOAD_CLIENT_TLS` is enabled.

```
{
	"operation": "app_fw_update",
	"fwversion": "v1.0.2",
	"size": 181124,
	"location": {
		"protocol": "http:",
		"host": "fota-test-bucket.s3.eu-central-1.amazonaws.com",
		"path": "app_update.bin"
	}
}
```

I've added support to use pre-signed urls from AWS IoT Jobs(no documentation in library/sample yet it's missing from the PR I'll add it later when some decision points have been made). https://docs.aws.amazon.com/iot/latest/developerguide/iot-jobs.html#presigned

These should currently be put into a `url` field in the location object in the **job document**:
```
{
	"operation": "app_fw_update",
	"fwversion": "v1.0.2",
	"size": 181124,
	"location": {
		"url": "${aws:iot:s3-presigned-url:https://s3.amazonaws.com/<bucket>/<resource(file)>}",
	}
}
```
which then is parsed out using the `http_parse_url` module. Into their separate fields.

The current behavior of the program is that it will ignore the `url` field if you haven't enabled the `http_parse_url` module. 
One issue with presigned urls is that you need a much bigger buffer to read out the path previously 255 bytes, now 1246 bytes. Also this information is replicated in every HTTPS request leading to more data being sent.

Enabling TLS for download comes at a cost which is some of the reason of not enabling it by default. Not only do you send additional data over TCP you also restrict the sizes of the fragments you can receive over HTTP due to the TLS overhead. This means it will be slower(higher latency) and use more bandwidth.

`http_parse_url` module adds `1236 bytes` in extra code size.

### Decision points:
- [ ] Have backwards compatibility with the previous format if you want to use pre-signed urls
- [ ] Default to http instead of throwing an error if `DOWNLOAD_CLIENT_TLS` have not been enabled but `protocol: https` is present in the **job document.**
- [ ] Should we even support presigned URLs?


