### PR TITLE
partition_manager: enable RAM partitioning

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -141,6 +141,14 @@ elseif (DEFINED CONFIG_SOC_NRF5340_CPUAPP)
   set(otp_size 764)  # 191 * 4
 endif()
 
+add_region(
+  NAME sram_primary
+  SIZE ${CONFIG_PM_SRAM_SIZE}
+  BASE ${CONFIG_PM_SRAM_BASE}
+  PLACEMENT complex
+  DYNAMIC_PARTITION sram_primary
+  )
+
 math(EXPR flash_size "${CONFIG_FLASH_SIZE} * 1024" OUTPUT_FORMAT HEXADECIMAL)
 
 if (CONFIG_SOC_NRF9160 OR CONFIG_SOC_NRF5340_CPUAPP)

--- a/samples/spm/pm.yml
+++ b/samples/spm/pm.yml
@@ -5,3 +5,13 @@ spm:
   placement:
     before: app
   inside: mcuboot_primary_app
+
+spm_sram:
+  size: CONFIG_PM_PARTITION_SIZE_SPM_SRAM
+  placement: {after: start}
+  inside: sram_secure
+
+# Create a span for the RAM to be configured as SECURE by the spm.
+sram_secure:
+  span: []
+  region: sram_primary

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -3,8 +3,8 @@
 Partition Manager
 #################
 
-The Partition Manager is a Python script that sets the start address and size of all image partitions in a multi-image build context.
-When creating an application that requires child images (for example, a bootloader), you can configure the Partition Manager to control where in memory each image should be placed.
+The Partition Manager is a Python script that sets the start address and size of all flash and RAM partitions in a multi-image build context.
+When creating an application that requires child images (for example, a bootloader), you can configure the Partition Manager to control where in memory each image should be placed, and how the RAM should be shared.
 
 See :ref:`ug_multi_image` for more information about multi-image builds.
 
@@ -15,11 +15,15 @@ The Partition Manager is activated for all multi-image builds, no matter what bu
 Overview
 ********
 
-The Partition Manager script reads configuration files named :file:`pm.yml`, which define flash partitions.
-A partition's definition includes its name and constraints on its size and placement on flash.
+The Partition Manager script reads configuration files named :file:`pm.yml`, which define flash and RAM partitions.
+A flash partition's definition includes its name and constraints on its size and placement in flash.
+A RAM partition's definition includes its name and constraints on its size.
 The Partition Manager allocates a start address and sometimes a size to each partition in a way that satisfies these constraints.
 
-There are different kinds of partitions:
+There are different kinds of **flash partitions** and **RAM partitions**, as described below.
+
+Flash partition types
+=====================
 
 Image partitions
    An image partition is the flash area reserved for an image, to which the image binary is written.
@@ -37,6 +41,26 @@ Container partitions
    A container partition does not reserve space, but is used to logically and/or physically group other partitions.
 
 The start addresses and sizes of image partitions are used in the preprocessing of the linker script for each image.
+
+RAM partition types
+=====================
+
+Default image RAM partition
+   The default image RAM partition consists of all RAM that is not defined as a permanent image RAM partition or placeholder RAM partition.
+   It is the default RAM partition associated with an image and is set as the RAM region when linking the image.
+   If an image must reserve its RAM area permanently (i.e. at the same time as other images are running), it must use a permanent image RAM partition, described below.
+
+.. _pm_permanent_image_ram_partition:
+
+Permanent image RAM partitions
+   A permanent image RAM partition reserves RAM for an image permanently.
+   It is typically used for images that will remain active after they have booted the next step in the boot chain.
+   If an image has configured a permanent image RAM partition, it is set as the RAM region when linking the image instead of the default image RAM partition.
+
+.. _pm_permanent_placeholder_ram_partition:
+
+Permanent placeholder RAM partitions
+   A permanent placeholder RAM partition is used to permanently reserve RAM regions that are not associated with an image.
 
 .. _pm_configuration:
 
@@ -85,6 +109,7 @@ Each partition is defined as follows:
          property_value
 
 *partition_name* is the name of the partition (for example, ``mcuboot``).
+
 The following partition properties and property values are available:
 
 placement: dict
@@ -272,6 +297,30 @@ share_size: list
 region: string
    Specify the region where a partition should be placed.
    See :ref:`pm_regions`.
+
+.. _partition_manager_ram_configuration:
+
+RAM partition configuration
+   RAM partitions are partitions located in the ``sram_primary`` region.
+   A RAM partition is specified by having the partition name end with ``_sram``.
+   If a partition name consists of an image name and the ending ``_sram``, it is used as a permanent image RAM partition for the image.
+
+   .. code-block:: yaml
+      :caption: RAM partitions configuration
+
+      # This ...
+      some_permament_sram_block_used_for_logging:
+         size: 0x1000
+         region: sram_primary
+
+      # ... is equivalent to
+      some_permament_sram_block_used_for_logging_sram:
+         size: 0x1000
+
+      # Specify permanent image RAM partition for MCUboot.
+      # This will be used by the MCUboot linker script.
+      mcuboot_sram:
+          size: 0xa000
 
 All occurrences of a partition name can be replaced with a dict with the key ``one_of``, which is resolved to the first existing partition in the ``one_of`` value.
 An error is raised if no partition inside the ``one_of`` dict exists.

--- a/scripts/partition_manager_output.py
+++ b/scripts/partition_manager_output.py
@@ -104,7 +104,14 @@ def write_gpm_config(gpm_config, regions_config, name, out_path):
     image_config_lines.append("#define PM_ADDRESS 0x{:x}".format(gpm_config[domain][image]['address']))
     image_config_lines.append("#define PM_SIZE 0x{:x}".format(gpm_config[domain][image]['size']))
 
-    image_config_lines.insert(0, "#include <autoconf.h>")
+    image_sram_partition = f'{image}_sram'
+    image_has_custom_sram = image_sram_partition in gpm_config[domain]
+    if image_has_custom_sram:
+        image_config_lines.append("#define PM_SRAM_ADDRESS 0x%x" % gpm_config[domain][image_sram_partition]['address'])
+        image_config_lines.append("#define PM_SRAM_SIZE 0x%x" % gpm_config[domain][image_sram_partition]['size'])
+    else:
+        image_config_lines.append("#define PM_SRAM_ADDRESS 0x%x" % gpm_config[domain]['sram_primary']['address'])
+        image_config_lines.append("#define PM_SRAM_SIZE 0x%x" % gpm_config[domain]['sram_primary']['size'])
     image_config_lines.insert(0, get_header_guard_start(pm_config_file))
 
     image_config_lines.append(get_header_guard_end(pm_config_file))

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -43,6 +43,10 @@ if (CONFIG_NVS AND NOT CONFIG_SETTINGS_NVS)
   ncs_add_partition_manager_config(pm.yml.nvs)
 endif()
 
+if (CONFIG_BSD_LIBRARY)
+  ncs_add_partition_manager_config(pm.yml.bsdlib)
+endif()
+
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
 set(using_partition_manager

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -57,6 +57,16 @@ endif
 
 endmenu # Zephyr samples configurations
 
+menu "NCS subsystem configurations"
+
+if BSD_LIBRARY
+partition=BSDLIB_SRAM
+partition-size=0x10000
+rsource "Kconfig.template.partition_size"
+endif
+
+endmenu # NCS subsystem configurations
+
 config PM_SINGLE_IMAGE
 	bool "Use the Partition Manager for single image builds"
 	help
@@ -91,5 +101,16 @@ config PM_IMAGE_NOT_BUILT_FROM_SOURCE
 	help
 	  Promptless helper config used to indicate that one or more
 	  image is not built from source.
+
+# Helper configs needed since 'SRAM_SIZE/BASE' use the chosen node.
+config PM_SRAM_BASE
+	hex
+	default $(dt_node_reg_addr_hex,/soc/memory@21000000) if SOC_NRF5340_CPUNET
+	default $(dt_node_reg_addr_hex,/soc/memory@20000000)
+
+config PM_SRAM_SIZE
+	hex
+	default $(dt_node_reg_size_hex,/soc/memory@21000000) if SOC_NRF5340_CPUNET
+	default $(dt_node_reg_size_hex,/soc/memory@20000000)
 
 endmenu # Partition Manager

--- a/subsys/partition_manager/Kconfig.template.partition_size
+++ b/subsys/partition_manager/Kconfig.template.partition_size
@@ -1,6 +1,6 @@
 # Define used by partition_manager.py to deduce size of partition
 config PM_PARTITION_SIZE_$(partition)
-	hex "Flash space reserved for $(partition)."
+	hex "Memory reserved for $(partition)."
 	default $(partition-size)
 	help
-	  Flash space set aside for the $(partition) partition.
+	  Memory set aside for the $(partition) partition.

--- a/subsys/partition_manager/pm.yml.bsdlib
+++ b/subsys/partition_manager/pm.yml.bsdlib
@@ -1,0 +1,6 @@
+#include <autoconf.h>
+
+bsdlib_sram:
+  placement: {after: [spm_sram, start]}
+  size: CONFIG_PM_PARTITION_SIZE_BSDLIB_SRAM
+  region: sram_primary

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -35,6 +35,18 @@ config PM_PARTITION_SIZE_SPM
 	  of this configuration needs to match the requirements set by the
 	  script 'partition_manager.py'. See pm.yml.
 
+config PM_PARTITION_SIZE_SPM_SRAM
+	hex "RAM reserved for SPM"
+	default 0x10000 if SOC_NRF9160
+	default 0x8000
+	help
+	  RAM area set aside for the SPM.
+	  On the nRF9160 the BSDLib needs to be included in the build.
+	  There are scrict requirements to the RAM area reserved for BSDLib.
+	  Specifically it must be 64kB from RAM offset 0x10000.
+	  By setting the SPM RAM to 0x10000 we ensure that BSDLib RAM ends
+	  up in the right place.
+
 config SPM_BOOT_SILENTLY
 	bool "Boot silently"
 	default n

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -27,13 +27,13 @@
 #if USE_PARTITION_MANAGER
 #include <pm_config.h>
 #define NON_SECURE_APP_ADDRESS PM_APP_ADDRESS
+#define NON_SECURE_RAM_OFFSET PM_SRAM_SECURE_SIZE
 #else
 #include <storage/flash_map.h>
 #define NON_SECURE_APP_ADDRESS FLASH_AREA_ID(image_0_nonsecure)
-#endif /* USE_PARTITION_MANAGER */
-
 /* This reflects the configuration in DTS. */
 #define NON_SECURE_RAM_OFFSET 0x10000
+#endif /* USE_PARTITION_MANAGER */
 
 #define NON_SECURE_FLASH_REGION_INDEX \
 	((NON_SECURE_APP_ADDRESS) / (FLASH_SECURE_ATTRIBUTION_REGION_SIZE))
@@ -61,23 +61,11 @@
  *        |      Flash          |
  *  0 kB  |---------------------|
  *
- *  * The security configuration for SRAM is applied:
+ *  * The SRAM configuration is given by the partition manager.
+ *  * To see the current configuration, run the 'pm_report' target.
+ *  * E.g. 'ninja pm_report, in your build folder. All partitions
+ *  * within the 'secure_ram' span is configured as secure by the SPM.
  *
- *                SRAM
- * 256 kB |---------------------|
- *        |                     |
- *        |                     |
- *        |                     |
- *        |     Non-Secure      |
- *        |    SRAM (image)     |
- *        |                     |
- * 128 kB |.................... |
- *        |     Non-Secure      |
- *        |  SRAM (BSD Library) |
- *  64 kB |---------------------|
- *        |      Secure         |
- *        |       SRAM          |
- *  0 kB  |---------------------|
  */
 
 extern irq_target_state_t irq_target_state_set(unsigned int irq,

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 288258e2f6a60120e87939a60b28234f33a55f1d
+      revision: 647f0d83cab2bf3c0653a7b65cb8901053751485
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add support for partitioning RAM using partition manager.

Depends on https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/275

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>