### PR TITLE
 event_manager: Make sure structs are word aligned. 

### DIFF
--- a/subsys/event_manager/event_manager_priv.h
+++ b/subsys/event_manager/event_manager_priv.h
@@ -38,7 +38,7 @@ extern "C" {
 /* Declare a zero-length subscriber. */
 #define _EVENT_SUBSCRIBERS_EMPTY(ename, prio)								\
 	const struct {} _CONCAT(_EVENT_SUBSCRIBERS_SECTION_PREFIX(ename, prio), empty)			\
-	__attribute__((__section__(STRINGIFY(_EVENT_SUBSCRIBERS_SECTION_NAME(ename, prio))))) = {};
+	__attribute__((__aligned__(4), __section__(STRINGIFY(_EVENT_SUBSCRIBERS_SECTION_NAME(ename, prio))))) = {};
 
 
 /* Convenience macros generating section start and stop markers. */
@@ -73,7 +73,7 @@ extern "C" {
 /* Subscribe a listener to an event. */
 #define _EVENT_SUBSCRIBE(lname, ename, prio)								\
 	const struct event_subscriber _CONCAT(_CONCAT(__event_subscriber_, ename), lname) __used	\
-	__attribute__((__section__(_EVENT_SUBSCRIBERS_SECTION_NAME(ename, prio)))) = {			\
+	__attribute__((__aligned__(4), __section__(_EVENT_SUBSCRIBERS_SECTION_NAME(ename, prio)))) = {			\
 		.listener = &_CONCAT(__event_listener_, lname),						\
 	}
 
@@ -188,7 +188,7 @@ extern "C" {
 	const static char *_CONCAT(ename, _log_arg_labels[]) __used = _ARG_LABELS_DEFINE(labels);		\
 	const static enum profiler_arg _CONCAT(ename, _log_arg_types[]) __used = _ARG_TYPES_DEFINE(types);	\
 	const static struct event_info _CONCAT(ename, _info) __used						\
-	__attribute__((__section__("event_infos"))) = {								\
+	__attribute__((__aligned__(4), __section__("event_infos"))) = {								\
 				.profile_fn	= profile_func,							\
 				.log_arg_cnt	= ARRAY_SIZE(_CONCAT(ename, _log_arg_labels)),			\
 				.log_arg_labels	= _CONCAT(ename, _log_arg_labels),				\
@@ -198,7 +198,7 @@ extern "C" {
 
 #define _EVENT_LISTENER(lname, notification_fn)					\
 	const struct event_listener _CONCAT(__event_listener_, lname) __used	\
-	__attribute__((__section__("event_listeners"))) = {			\
+	__attribute__((__aligned__(4), __section__("event_listeners"))) = {			\
 		.name = STRINGIFY(lname),					\
 		.notification = (notification_fn),				\
 	}
@@ -224,7 +224,7 @@ extern "C" {
 #define _EVENT_TYPE_DEFINE(ename, init_log_en, log_fn, ev_info_struct)							\
 	_EVENT_SUBSCRIBERS_DEFINE(ename);										\
 	const struct event_type _CONCAT(__event_type_, ename) __used							\
-	__attribute__((__section__("event_types"))) = {									\
+	__attribute__((__aligned__(4), __section__("event_types"))) = {									\
 		.name				= STRINGIFY(ename),							\
 		.subs_start	= {											\
 			[_SUBS_PRIO_FIRST]	= _EVENT_SUBSCRIBERS_START(ename, _SUBS_PRIO_ID(_SUBS_PRIO_FIRST)),	\


### PR DESCRIPTION
This fixes the event_manager sample runtime errors on the qemu_x86 platform, on which generated code has 64-byte alignment by default.