### PR TITLE
NFC/ISO-DEP (Poller): Fixed minor issues.

### DIFF
--- a/include/nfc/t4t/isodep.h
+++ b/include/nfc/t4t/isodep.h
@@ -26,7 +26,7 @@ extern "C" {
 #define NFC_T4T_ISODEP_SYNTAX_ERROR 1
 
 /** Correct frame was received when it is not expected. */
-#define NFC_T4T_ISODEP_SEMATIC_ERROR 2
+#define NFC_T4T_ISODEP_SEMANTIC_ERROR 2
 
 /** Unrecoverable transmission error. */
 #define NFC_T4T_ISODEP_TRANSMISSION_ERROR 3


### PR DESCRIPTION
When debugging an nRF5 SDK T4T application I detected some minor issues in the ISO-DEP implementation (though overall the NFC Reader/Writer support in NCS is really good).
Fixed:
- timeout error recovery after a receipt of an I-block
- FSDI encoding in RATS command
- error type naming