### PR TITLE
samples: cloud_client: Changed file path in doc

### DIFF
--- a/samples/nrf9160/cloud_client/README.rst
+++ b/samples/nrf9160/cloud_client/README.rst
@@ -58,7 +58,7 @@ Each cloud backend has specific setup steps that must be executed before it can 
 Configurations
 **************
 
-The configurations used in the sample are listed below. They are located in ``cloud_client/src/prj.conf``.
+The configurations used in the sample are listed below. They are located in ``cloud_client/prj.conf``.
 
 
 .. option:: CONFIG_CLOUD_BACKEND


### PR DESCRIPTION
Fixed wrong file path, prj.conf is not located in cloud_client/src.
Signed-off-by: Heidi Sollie heidi-irene.sollie@nordicsemi.no