### PR TITLE
scripts: unity: Fix header_prepare comments removal regex

### DIFF
--- a/scripts/unity/header_prepare.py
+++ b/scripts/unity/header_prepare.py
@@ -13,19 +13,26 @@ def header_prepare(in_file, out_file, out_wrap_file):
         content = f_in.read()
 
     # remove comments
-    comments_pattern = re.compile(
-        r'//.*?$|/\*.*?\*/|\'(?:\\.|[^\\\'])*\'|"(?:\\.|[^\\"])*"',
+    c_comments_pattern = re.compile(
+        r'/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/',
         re.DOTALL | re.MULTILINE
     )
-    content = comments_pattern.sub(r"", content)
+
+    content = c_comments_pattern.sub(r"", content)
+
+    cpp_comments_pattern = re.compile(
+        r'(?!.*\".*)\/\/.*$',
+        re.MULTILINE
+    )
+
+    content = cpp_comments_pattern.sub(r"", content)
 
     # change static inline functions to normal function declaration
     static_inline_pattern = re.compile(
         r'(?:__deprecated\s+)?(?:static\s+inline\s+|static\s+ALWAYS_INLINE\s+|__STATIC_INLINE\s+)'
         r'((?:\w+[*\s]+)+\w+?\(.*?\))\n\{.+?\n\}',
         re.M | re.S)
-    (content, static_inline_cnt) = static_inline_pattern.subn(r"\1;",
-                                                              content)
+    content = static_inline_pattern.sub(r"\1;", content)
 
     # remove syscall include
     syscall_pattern = re.compile(r"#include <syscalls/\w+?.h>", re.M | re.S)
@@ -50,7 +57,7 @@ def header_prepare(in_file, out_file, out_wrap_file):
     # mock generation.
     func_pattern = re.compile(
         r"^\s*((?:\w+[*\s]+)+)(\w+?\(.*?\);)", re.M | re.S)
-    (content2, m2) = func_pattern.subn(r"\n\1__wrap_\2", content)
+    content2 = func_pattern.sub(r"\n\1__wrap_\2", content)
 
     with open(out_wrap_file, 'w') as f_wrap:
         f_wrap.write(content2)

--- a/tests/unity/example_test/CMakeLists.txt
+++ b/tests/unity/example_test/CMakeLists.txt
@@ -27,6 +27,7 @@ target_include_directories(app PRIVATE ./src/uut)
 # add test file
 target_sources(app PRIVATE src/example_test.c)
 target_include_directories(app PRIVATE .)
+target_include_directories(app PRIVATE src/foo)
 
 # Preinclude file to the module under test to redefine IS_ENABLED() macro
 # which is used in the module.

--- a/tests/unity/example_test/src/example_test.c
+++ b/tests/unity/example_test/src/example_test.c
@@ -10,6 +10,8 @@
 
 bool runtime_CONFIG_UUT_PARAM_CHECK;
 
+#define TEST_FOO_ADDR FOO_ADDR
+
 void setUp(void)
 {
 	runtime_CONFIG_UUT_PARAM_CHECK = false;

--- a/tests/unity/example_test/src/foo/foo.h
+++ b/tests/unity/example_test/src/foo/foo.h
@@ -9,11 +9,23 @@
 
 #include <toolchain/common.h>
 
+#include "foo_internal.h"
+// c++ comment
+/* c comment */
+/* c
+ * multi line comment
+ */
+#define FOO_ADDR "https://my.page.com/somewhere"
+
 int foo_init(void *handle);
+
+static const char test_string[] = "test string";
 
 static inline int foo_execute(void)
 {
-	return 0;
+	foo_t val = 0;
+
+	return (int)val;
 }
 
 static ALWAYS_INLINE int foo_execute2(void)

--- a/tests/unity/example_test/src/foo/foo_internal.h
+++ b/tests/unity/example_test/src/foo/foo_internal.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#ifndef __FOO_INTERNAL_H
+#define __FOO_INTERNAL_H
+
+typedef int foo_t;
+
+#endif /* __FOO_INTERNAL_H */


### PR DESCRIPTION
scripts: unity: Fix header_prepare comments removal regex

Regex for comments removal was also removing strings which resulted in corrupted files if includes were in quotation marks (`#include "foo.h"`).

tests: unity: example_test: Add various comments to mock header

In order to test that header_prepare.py script is properly handling comments removal from the mocked header, added various types of comments to foo.h.