### PR TITLE
net: lib: aws jobs: Add missing dependency for random number generator

### DIFF
--- a/subsys/net/lib/aws_jobs/Kconfig
+++ b/subsys/net/lib/aws_jobs/Kconfig
@@ -5,6 +5,7 @@
 
 menuconfig AWS_JOBS
 	bool "AWS Jobs library"
+	depends on ENTROPY_DEVICE_RANDOM_GENERATOR
 
 if AWS_JOBS
 


### PR DESCRIPTION
Add a dependency to the AWS Jobs library to the zephyr random API for
random number generation.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>