### PR TITLE
[DNM] Add configuration module for nRF 802.15.4 radio driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,7 +102,7 @@ Kconfig*                                  @tejlmand
 /subsys/esb/                              @Raane @lemrey
 /subsys/event_manager/                    @pdunaj
 /subsys/fw_info/                          @hakonfam
-/subsys/ieee802154                        @rlubos
+/subsys/ieee802154/                       @rlubos
 /subsys/mpsl/                             @joerchan @rugeGerritsen
 /subsys/net/                              @rlubos
 /subsys/nfc/                              @grochu @anangl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,6 +102,7 @@ Kconfig*                                  @tejlmand
 /subsys/esb/                              @Raane @lemrey
 /subsys/event_manager/                    @pdunaj
 /subsys/fw_info/                          @hakonfam
+/subsys/ieee802154                        @rlubos
 /subsys/mpsl/                             @joerchan @rugeGerritsen
 /subsys/net/                              @rlubos
 /subsys/nfc/                              @grochu @anangl

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -22,6 +22,7 @@ add_subdirectory_ifdef(CONFIG_DFU_TARGET		dfu)
 add_subdirectory_ifdef(CONFIG_IS_SPM		spm)
 add_subdirectory_ifdef(CONFIG_TRUSTED_EXECUTION_NONSECURE nonsecure)
 add_subdirectory_ifdef(CONFIG_MPSL mpsl)
+add_subdirectory_ifdef(CONFIG_NRF_802154_RADIO_DRIVER ieee802154)
 
 if (CONFIG_NFC_T2T_NRFXLIB OR
     CONFIG_NFC_T4T_NRFXLIB OR

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -32,3 +32,5 @@ rsource "shell/Kconfig"
 rsource "mpsl/Kconfig"
 
 rsource "partition_manager/Kconfig"
+
+rsource "ieee802154/Kconfig"

--- a/subsys/ieee802154/CMakeLists.txt
+++ b/subsys/ieee802154/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_library()
+
+zephyr_library_sources(ieee802154_nrf5_cfg.c)

--- a/subsys/ieee802154/Kconfig
+++ b/subsys/ieee802154/Kconfig
@@ -1,0 +1,209 @@
+# Nordic Semiconductor nRF5 802.15.4 extended (FEM, Antenna Diversity, Coex)
+# configuration options
+
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if NRF_802154_RADIO_DRIVER
+
+menu "IEEE 802.15.4 nRF5 Radio Driver configuration"
+
+config IEEE802154_NRF5_CFG_PRIO
+	int "Radio driver configuration priority"
+	default 90
+	help
+	  Set the configuration priority number. Must be higher than radio driver
+	  initialization priority. Do not mess with it unless you know what you
+	  are doing.
+
+choice IEEE802154_NRF5_ANT_DIVERSITY_MODE
+	prompt "Antenna Diversity mode"
+	default IEEE802154_NRF5_ANT_DIVERSITY_MODE_DISABLED
+	help
+	  Select Antenna Diversity mode
+
+config IEEE802154_NRF5_ANT_DIVERSITY_MODE_DISABLED
+	bool "Antenna Diversity disabled"
+
+config IEEE802154_NRF5_ANT_DIVERSITY_MODE_MANUAL
+	bool "Antenna Diversity manual"
+
+config IEEE802154_NRF5_ANT_DIVERSITY_MODE_AUTO
+	bool "Antenna Diversity automatic"
+
+endchoice
+
+if !IEEE802154_NRF5_ANT_DIVERSITY_MODE_DISABLED
+config IEEE802154_NRF5_ANT_DIVERSITY_PIN
+	int "Antenna selection pin"
+	default 20
+	help
+	  Pin used for antenna selection.
+
+config IEEE802154_NRF5_ANT_DIVERSITY_TOGGLE_TIME
+	int "Toggle time"
+	default 13
+	help
+	  Time between antenna switches in automatic mode [us]
+endif
+
+config IEEE802154_NRF5_WIFI_COEX
+	bool "Enable WiFi Coexistance"
+	help
+	  Enable WiFi Coexistance
+
+if IEEE802154_NRF5_WIFI_COEX
+
+choice IEEE802154_NRF5_WIFI_COEX_RX_REQ_MODE
+	prompt "WiFi Coex RX request mode"
+	default IEEE802154_NRF5_WIFI_COEX_RX_REQ_MODE_ED
+	help
+	  Mode of triggering receive request to Coex arbiter
+
+config IEEE802154_NRF5_WIFI_COEX_RX_REQ_MODE_ED
+	bool "Energy detected"
+
+config IEEE802154_NRF5_WIFI_COEX_RX_REQ_MODE_PREAMBLE
+	bool "Preamble reception"
+
+config IEEE802154_NRF5_WIFI_COEX_RX_REQ_MODE_DESTINED
+	bool "Frame detected"
+
+endchoice
+
+choice IEEE802154_NRF5_WIFI_COEX_TX_REQ_MODE
+	prompt "WiFi Coex TX request mode"
+	default IEEE802154_NRF5_WIFI_COEX_TX_REQ_MODE_FRAME_READY
+	help
+	  Mode of triggering transmit request to Coex arbiter
+
+config IEEE802154_NRF5_WIFI_COEX_TX_REQ_MODE_FRAME_READY
+	bool "Frame ready"
+
+config IEEE802154_NRF5_WIFI_COEX_TX_REQ_MODE_CCA_START
+	bool "Pre CCA"
+
+config IEEE802154_NRF5_WIFI_COEX_TX_REQ_MODE_CCA_DONE
+	bool "Post CCA"
+
+endchoice
+endif
+
+config IEEE802154_NRF5_FEM_PRESENT
+	bool "Enable Front End Module (FEM) control"
+	help
+	  Enable FEM control and its configuration options.
+
+if IEEE802154_NRF5_FEM_PRESENT
+
+config IEEE802154_NRF5_FEM_PA_PIN_CTRL_ENABLE
+	bool "Enable PA pin control"
+	default y
+
+config IEEE802154_NRF5_FEM_PA_TIME_IN_ADVANCE_US
+	int "PA time advance"
+	default 13
+	help
+	  Time in microseconds when PA GPIO is activated before the radio
+	  is ready for transmission.
+
+config IEEE802154_NRF5_FEM_LNA_PIN_CTRL_ENABLE
+	bool "Enable LNA pin control"
+	default y
+
+config IEEE802154_NRF5_FEM_LNA_TIME_IN_ADVANCE_US
+	int "LNA time advance"
+	default 13
+	help
+	  Time in microseconds when LNA GPIO is activated before the radio
+	  is ready for reception.
+
+config IEEE802154_NRF5_FEM_PDN_PIN_CTRL_ENABLE
+	bool "Enable PDN pin control"
+	default y
+
+config IEEE802154_NRF5_FEM_PDN_SETTLE_US
+	int "PDN settle time"
+	default 18
+	help
+	  The time between activating the PDN and asserting RX_EN/TX_EN.
+
+config IEEE802154_NRF5_FEM_TRX_HOLD_US
+	int "TRX hold time"
+	default 5
+	help
+	  The time between deasserting the RX_EN/TX_EN and deactivating PDN.
+
+config IEEE802154_NRF5_FEM_PA_PIN
+	int "PA pin"
+	default 22
+
+config IEEE802154_NRF5_FEM_LNA_PIN
+	int "LNA pin"
+	default 19
+
+config IEEE802154_NRF5_FEM_PDN_PIN
+	int "PDN pin"
+	default 23
+
+config IEEE802154_NRF5_FEM_MODE_PIN
+	int "Mode pin"
+	default 17
+
+config IEEE802154_NRF5_SPI
+	bool "Configure SPI interface"
+	default y
+
+if IEEE802154_NRF5_SPI
+
+config IEEE802154_NRF5_FEM_MOSI_PIN
+	int "MOSI pin of the FEM module"
+	default 45
+
+config IEEE802154_NRF5_FEM_MISO_PIN
+	int "MISO pin of the FEM module"
+	default 46
+
+config IEEE802154_NRF5_FEM_CLK_PIN
+	int "CLK pin of the FEM module"
+	default 47
+
+config IEEE802154_NRF5_FEM_CSN_PIN
+	int "CSN pin of the FEM module"
+	default 21
+
+endif
+
+config IEEE802154_NRF5_FEM_SET_PPI_CHANNEL
+	int "PPI channel for pin setting"
+	default 15
+
+config IEEE802154_NRF5_FEM_CLR_PPI_CHANNEL
+	int "PPI channel for pin clearing"
+	default 16
+
+config IEEE802154_NRF5_FEM_PDN_PPI_CHANNEL
+	int "PPI channel for PDN pin handling"
+	default 5
+
+config IEEE802154_NRF5_FEM_PDN_GPIOTE_CHANNEL
+	int "GPIOTE channel for PDN control"
+	default 5
+
+config IEEE802154_NRF5_FEM_LNA_GPIOTE_CHANNEL
+	int "GPIOTE channel for LNA control"
+	default 6
+
+config IEEE802154_NRF5_FEM_PA_GPIOTE_CHANNEL
+	int "GPIOTE channel for PA control"
+	default 7
+
+endif
+
+module = IEEE802154_NRF5_CFG
+module-str = ieee802154_nrf5_cfg
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endmenu
+
+endif

--- a/subsys/ieee802154/ieee802154_nrf5_cfg.c
+++ b/subsys/ieee802154/ieee802154_nrf5_cfg.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <init.h>
+#include <irq.h>
+#include <kernel.h>
+#include <logging/log.h>
+#include <nrf_802154.h>
+#include <hal/nrf_gpio.h>
+#include "rd_stubs.x"
+
+LOG_MODULE_REGISTER(ieee802154_nrf5_cfg, CONFIG_IEEE802154_NRF5_CFG_LOG_LEVEL);
+
+#if (CONFIG_IEEE802154_NRF5_FEM_PRESENT)
+static const nrf_fem_interface_config_t fem_iface_config = {
+	.fem_config = {
+		.pa_time_gap_us  = CONFIG_IEEE802154_NRF5_FEM_PA_TIME_IN_ADVANCE_US,
+		.lna_time_gap_us = CONFIG_IEEE802154_NRF5_FEM_LNA_TIME_IN_ADVANCE_US,
+		.pdn_settle_us   = CONFIG_IEEE802154_NRF5_FEM_PDN_SETTLE_US,
+		.trx_hold_us     = CONFIG_IEEE802154_NRF5_FEM_TRX_HOLD_US,
+		.pa_gain_db      = 0,
+		.lna_gain_db     = 0
+	},
+	.pa_pin_config = {
+		.enable       = CONFIG_IEEE802154_NRF5_FEM_PA_PIN_CTRL_ENABLE,
+		.active_high  = 1,
+		.gpio_pin     = CONFIG_IEEE802154_NRF5_FEM_PA_PIN,
+		.gpiote_ch_id = CONFIG_IEEE802154_NRF5_FEM_PA_GPIOTE_CHANNEL
+	},
+	.lna_pin_config = {
+		.enable       = CONFIG_IEEE802154_NRF5_FEM_LNA_PIN_CTRL_ENABLE,
+		.active_high  = 1,
+		.gpio_pin     = CONFIG_IEEE802154_NRF5_FEM_LNA_PIN,
+		.gpiote_ch_id = CONFIG_IEEE802154_NRF5_FEM_LNA_GPIOTE_CHANNEL
+	},
+	.pdn_pin_config = {
+		.enable       = CONFIG_IEEE802154_NRF5_FEM_PDN_PIN_CTRL_ENABLE,
+		.active_high  = 1,
+		.gpio_pin     = CONFIG_IEEE802154_NRF5_FEM_PDN_PIN,
+		.gpiote_ch_id = CONFIG_IEEE802154_NRF5_FEM_PDN_GPIOTE_CHANNEL
+	},
+	.ppi_ch_id_pdn = CONFIG_IEEE802154_NRF5_FEM_PDN_PPI_CHANNEL,
+	.ppi_ch_id_set = CONFIG_IEEE802154_NRF5_FEM_SET_PPI_CHANNEL,
+	.ppi_ch_id_clr = CONFIG_IEEE802154_NRF5_FEM_CLR_PPI_CHANNEL,
+};
+#endif
+
+static void nrf5_gpio_configure(void)
+{
+#if !CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_MODE_DISABLED
+	nrf_gpio_cfg_output(CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_PIN);
+	nrf_gpio_pin_clear(CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_PIN);
+#endif
+
+#if CONFIG_IEEE802154_NRF5_FEM_PRESENT
+	/* Set default FEM pin direction. */
+	nrf_gpio_cfg_output(CONFIG_IEEE802154_NRF5_FEM_PA_PIN);
+	nrf_gpio_cfg_output(CONFIG_IEEE802154_NRF5_FEM_LNA_PIN);
+	nrf_gpio_cfg_output(CONFIG_IEEE802154_NRF5_FEM_PDN_PIN);
+	nrf_gpio_cfg_output(CONFIG_IEEE802154_NRF5_FEM_MODE_PIN);
+
+	/* Set default FEM pin polarity. */
+	/* Disable PA, radio driver will override this setting */
+	nrf_gpio_pin_clear(CONFIG_IEEE802154_NRF5_FEM_PA_PIN);
+	/* Disable LNA, radio driver will override this setting */
+	nrf_gpio_pin_clear(CONFIG_IEEE802154_NRF5_FEM_LNA_PIN);
+	/* Disable FEM, radio driver will override this setting */
+	nrf_gpio_pin_clear(CONFIG_IEEE802154_NRF5_FEM_PDN_PIN);
+	/* Use POUTA_PROD TX gain by default */
+	nrf_gpio_pin_clear(CONFIG_IEEE802154_NRF5_FEM_MODE_PIN);
+
+#if CONFIG_IEEE802154_NRF5_SPI
+	nrf_gpio_cfg_output(CONFIG_IEEE802154_NRF5_FEM_MOSI_PIN);
+	nrf_gpio_cfg_default(CONFIG_IEEE802154_NRF5_FEM_MISO_PIN);
+	nrf_gpio_cfg_output(CONFIG_IEEE802154_NRF5_FEM_CLK_PIN);
+	nrf_gpio_cfg_output(CONFIG_IEEE802154_NRF5_FEM_CSN_PIN);
+
+	/* SPI mode not used. Use high polarity by default. */
+	nrf_gpio_pin_set(CONFIG_IEEE802154_NRF5_FEM_MOSI_PIN);
+	/* SPI mode not used. Use high polarity by default. */
+	nrf_gpio_pin_set(CONFIG_IEEE802154_NRF5_FEM_CLK_PIN);
+	/* SPI mode not used. Use low polarity by default.*/
+	nrf_gpio_pin_clear(CONFIG_IEEE802154_NRF5_FEM_CSN_PIN);
+#endif
+#endif
+}
+
+static int nrf5_cfg(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	nrf5_gpio_configure();
+
+#if CONFIG_IEEE802154_NRF5_FEM_PRESENT
+	if (!nrf_fem_interface_configuration_set(&fem_iface_config)) {
+		LOG_ERR("Failed to configure FEM");
+	}
+#endif
+
+#if !CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_MODE_DISABLED
+	nrf_802154_ant_diversity_config_t cfg;
+
+	cfg = nrf_802154_antenna_diversity_config_get();
+	cfg.ant_sel_pin = CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_PIN;
+	cfg.toggle_time = CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_TOGGLE_TIME;
+
+	nrf_802154_antenna_diversity_config_set(cfg);
+	nrf_802154_antenna_diversity_init();
+#endif
+
+#if CONFIG_IEEE802154_NRF5_WIFI_COEX
+	nrf_802154_coex_rx_request_mode_t rx_mode;
+	nrf_802154_coex_tx_request_mode_t tx_mode;
+
+#if CONFIG_IEEE802154_NRF5_WIFI_COEX_RX_REQ_MODE_ED
+	rx_mode = NRF_802154_COEX_RX_REQUEST_MODE_ENERGY_DETECTION;
+#elif CONFIG_IEEE802154_NRF5_WIFI_COEX_RX_REQ_MODE_PREAMBLE
+	rx_mode = NRF_802154_COEX_RX_REQUEST_MODE_PREAMBLE;
+#elif CONFIG_IEEE802154_NRF5_WIFI_COEX_RX_REQ_MODE_DESTINED
+	rx_mode = NRF_802154_COEX_RX_REQUEST_MODE_DESTINED;
+#endif
+
+#if CONFIG_IEEE802154_NRF5_WIFI_COEX_TX_REQ_MODE_FRAME_READY
+	tx_mode = NRF_802154_COEX_TX_REQUEST_MODE_FRAME_READY;
+#elif CONFIG_IEEE802154_NRF5_WIFI_COEX_TX_REQ_MODE_CCA_START
+	tx_mode = NRF_802154_COEX_TX_REQUEST_MODE_CCA_START;
+#elif CONFIG_IEEE802154_NRF5_WIFI_COEX_TX_REQ_MODE_CCA_DONE
+	tx_mode = NRF_802154_COEX_TX_REQUEST_MODE_CCA_DONE;
+#endif
+
+	if (!nrf_802154_coex_rx_request_mode_set(rx_mode)) {
+		LOG_ERR("Failed to set wifi coex rx request mode");
+	}
+	if (!nrf_802154_coex_tx_request_mode_set(tx_mode)) {
+		LOG_ERR("Failed to set wifi coex tx request mode");
+	}
+	if (!nrf_802154_wifi_coex_enable()) {
+		LOG_ERR("Failed to enable wifi coex");
+	}
+
+#endif
+	return 0;
+}
+
+SYS_INIT(nrf5_cfg, POST_KERNEL, CONFIG_IEEE802154_NRF5_CFG_PRIO);

--- a/subsys/ieee802154/rd_stubs.x
+++ b/subsys/ieee802154/rd_stubs.x
@@ -1,0 +1,390 @@
+/**
+ * @brief Configuration parameters for pins that enable or disable (or both) either Power Amplifier (PA) or Low Noise Amplifier (LNA).
+ */
+typedef struct
+{
+    bool    enable;       /* Enable toggling for this pin. */
+    bool    active_high;  /* If true, the pin will be active high. Otherwise, the pin will be active low. */
+    uint8_t gpio_pin;     /* GPIO pin number for the pin. */
+    uint8_t gpiote_ch_id; /* GPIOTE channel to be used for toggling pins. */
+} nrf_fem_gpiote_pin_config_t;
+
+/**
+ * @brief Configuration parameters for the PA/LNA interface.
+ */
+typedef struct
+{
+    struct
+    {
+        uint32_t pa_time_gap_us;                /* Time between the activation of the PA pin and the start of the radio transmission. */
+        uint32_t lna_time_gap_us;               /* Time between the activation of the LNA pin and the start of the radio reception. */
+        uint32_t pdn_settle_us;                 /* The time between activating the PDN and asserting the PA/LNA pin. */
+        uint32_t trx_hold_us;                   /* The time between deasserting the PA/LNA pin and deactivating PDN. */
+        int8_t   pa_gain_db;                    /* Configurable PA gain. Ignored if the amplifier is not supporting this feature. */
+        int8_t   lna_gain_db;                   /* Configurable LNA gain. Ignored if the amplifier is not supporting this feature. */
+    }                           fem_config;
+
+    nrf_fem_gpiote_pin_config_t pa_pin_config;  /* Power Amplifier pin configuration. */
+    nrf_fem_gpiote_pin_config_t lna_pin_config; /* Low Noise Amplifier pin configuration. */
+    nrf_fem_gpiote_pin_config_t pdn_pin_config; /* Power Down pin configuration. */
+
+    uint8_t                     ppi_ch_id_set;  /* PPI channel to be used for setting pins. */
+    uint8_t                     ppi_ch_id_clr;  /* PPI channel to be used for clearing pins. */
+    uint8_t                     ppi_ch_id_pdn;  /* PPI channel to handle PDN pin. */
+} nrf_fem_interface_config_t;
+
+/**
+ * @brief Mode of the antenna diversity module.
+ *
+ * Possible values:
+ * - @ref NRF_802154_ANT_DIVERSITY_MODE_DISABLED,
+ * - @ref NRF_802154_ANT_DIVERSITY_MODE_MANUAL,
+ * - @ref NRF_802154_ANT_DIVERSITY_MODE_AUTO
+ */
+typedef uint8_t nrf_802154_ant_diversity_mode_t;
+
+#define NRF_802154_ANT_DIVERSITY_MODE_DISABLED 0x00 // !< Antenna diversity is disabled - Antenna will not be controlled by ant_diversity module. While in this mode, current antenna is unspecified.
+#define NRF_802154_ANT_DIVERSITY_MODE_MANUAL   0x01 // !< Antenna is selected manually
+#define NRF_802154_ANT_DIVERSITY_MODE_AUTO     0x02 // !< Antenna is selected automatically based on RSSI - not supported for transmission.
+
+/**
+ * @brief Available antennas
+ *
+ * Possible values:
+ * - @ref NRF_802154_ANT_DIVERSITY_ANTENNA_1,
+ * - @ref NRF_802154_ANT_DIVERSITY_ANTENNA_2,
+ * - @ref NRF_802154_ANT_DIVERSITY_ANTENNA_NONE
+ */
+typedef uint8_t nrf_802154_ant_diversity_antenna_t;
+
+#define NRF_802154_ANT_DIVERSITY_ANTENNA_1    0x00 // !< First antenna
+#define NRF_802154_ANT_DIVERSITY_ANTENNA_2    0x01 // !< Second antenna
+#define NRF_802154_ANT_DIVERSITY_ANTENNA_NONE 0x02 // !< Used to indicate that antenna for the last reception was not selected via antenna diversity algorithm.
+
+/**
+ * Default antenna used in cases where no antenna was specified.
+ */
+#ifndef NRF_802154_ANT_DIVERSITY_DEFAULT_ANTENNA
+#define NRF_802154_ANT_DIVERSITY_DEFAULT_ANTENNA NRF_802154_ANT_DIVERSITY_ANTENNA_1
+
+/**
+ * @brief Mode of triggering receive request to Coex arbiter.
+ *
+ * Possible values:
+ * - @ref NRF_802154_COEX_RX_REQUEST_MODE_ENERGY_DETECTION,
+ * - @ref NRF_802154_COEX_RX_REQUEST_MODE_PREAMBLE,
+ * - @ref NRF_802154_COEX_RX_REQUEST_MODE_DESTINED
+ */
+typedef uint8_t nrf_802154_coex_rx_request_mode_t;
+
+#define NRF_802154_COEX_RX_REQUEST_MODE_ENERGY_DETECTION 0x01 // !< Coex requests to arbiter in receive mode upon energy detected.
+#define NRF_802154_COEX_RX_REQUEST_MODE_PREAMBLE         0x02 // !< Coex requests to arbiter in receive mode upon preamble reception.
+#define NRF_802154_COEX_RX_REQUEST_MODE_DESTINED         0x03 // !< Coex requests to arbiter in receive mode upon detection that frame is addressed to this device.
+
+/**
+ * @brief Mode of triggering transmit request to Coex arbiter.
+ *
+ * Possible values:
+ * - @ref NRF_802154_COEX_TX_REQUEST_MODE_FRAME_READY,
+ * - @ref NRF_802154_COEX_TX_REQUEST_MODE_CCA_START,
+ * - @ref NRF_802154_COEX_TX_REQUEST_MODE_CCA_DONE
+ */
+typedef uint8_t nrf_802154_coex_tx_request_mode_t;
+
+#define NRF_802154_COEX_TX_REQUEST_MODE_FRAME_READY 0x01 // !< Coex requests to arbiter in transmit mode when the frame is ready to be transmitted.
+#define NRF_802154_COEX_TX_REQUEST_MODE_CCA_START   0x02 // !< Coex requests to arbiter in transmit mode before CCA is started.
+#define NRF_802154_COEX_TX_REQUEST_MODE_CCA_DONE    0x03 // !< Coex requests to arbiter in transmit mode after CCA is finished.
+
+static inline int32_t nrf_fem_interface_configuration_set(nrf_fem_interface_config_t const * const p_config)
+{
+    (void)p_config;
+    return 0;
+}
+
+/**
+ * @brief Configuration of the antenna diversity module.
+ *
+ */
+typedef struct
+{
+    uint8_t ant_sel_pin; // !< Pin used for antenna selection. Should not be changed after calling @ref nrf_802154_ant_diversity_init.
+    uint8_t toggle_time; // !< Time between antenna switches in automatic mode [us].
+} nrf_802154_ant_diversity_config_t;
+
+/**
+ * @brief Sets the antenna diversity rx mode.
+ *
+ * @note This function should not be called while reception or transmission are currently ongoing.
+ *
+ * @param[in] mode Antenna diversity rx mode to be set.
+ *
+ * @retval true  Antenna diversity rx mode set successfully.
+ * @retval false Invalid mode passed as argument.
+ */
+static inline bool nrf_802154_antenna_diversity_rx_mode_set(nrf_802154_ant_diversity_mode_t mode)
+{
+    (void)mode;
+    return true;
+}
+
+/**
+ * @brief Gets current antenna diversity rx mode.
+ *
+ * @return Current antenna diversity mode for rx.
+ */
+static inline nrf_802154_ant_diversity_mode_t nrf_802154_antenna_diversity_rx_mode_get(void)
+{
+    return NRF_802154_ANT_DIVERSITY_MODE_DISABLED;
+}
+
+/**
+ * @brief Sets the antenna diversity tx mode.
+ *
+ * @note This function should not be called while reception or transmission are currently ongoing.
+ * @note NRF_802154_ANT_DIVERSITY_MODE_AUTO is not supported for transmission.
+ *
+ * @param[in] mode Antenna diversity tx mode to be set.
+ *
+ * @retval true  Antenna diversity tx mode set successfully.
+ * @retval false Invalid mode passed as argument.
+ */
+static inline bool nrf_802154_antenna_diversity_tx_mode_set(nrf_802154_ant_diversity_mode_t mode)
+{
+    (void)mode;
+    return false;
+}
+
+/**
+ * @brief Gets current antenna diversity tx mode.
+ *
+ * @return Current antenna diversity mode for tx.
+ */
+static inline nrf_802154_ant_diversity_mode_t nrf_802154_antenna_diversity_tx_mode_get(void)
+{
+    return NRF_802154_ANT_DIVERSITY_MODE_DISABLED;
+}
+
+/**
+ * @brief Manually selects the antenna to be used for rx.
+ *
+ * For antenna to be switched, antenna diversity rx mode needs
+ * to be @ref NRF_802154_ANT_DIVERSITY_MODE_MANUAL. Otherwise, antenna will
+ * be only switched after @ref NRF_802154_ANT_DIVERSITY_MODE_MANUAL is set.
+ *
+ * @param[in] antenna Antenna to be used.
+ *
+ * @retval true  Antenna set successfully.
+ * @retval false Invalid antenna passed as argument.
+ */
+static inline bool nrf_802154_antenna_diversity_rx_antenna_set(nrf_802154_ant_diversity_antenna_t antenna)
+{
+    (void)antenna;
+    return false;
+}
+
+/**
+ * @brief Gets antenna currently used for rx.
+ *
+ * @note The antenna read by this function is currently used rx antenna only if
+ * antenna diversity rx mode is set to @ref NRF_802154_ANT_DIVERSITY_MODE_MANUAL. Otherwise,
+ * currently used antenna may be different.
+ * @sa nrf_802154_ant_diversity_mode_set
+ *
+ * @return Currently used antenna.
+ */
+static inline nrf_802154_ant_diversity_antenna_t nrf_802154_antenna_diversity_rx_antenna_get(void)
+{
+    return NRF_802154_ANT_DIVERSITY_ANTENNA_1;
+}
+
+/**
+ * @brief Manually selects the antenna to be used for tx.
+ *
+ * For antenna to be switched, antenna diversity tx mode needs
+ * to be @ref NRF_802154_ANT_DIVERSITY_MODE_MANUAL. Otherwise, antenna will
+ * be only switched after @ref NRF_802154_ANT_DIVERSITY_MODE_MANUAL is set.
+ *
+ * @param[in] antenna Antenna to be used.
+ *
+ * @retval true  Antenna set successfully.
+ * @retval false Invalid antenna passed as argument.
+ */
+static inline bool nrf_802154_antenna_diversity_tx_antenna_set(nrf_802154_ant_diversity_antenna_t antenna)
+{
+    (void)antenna;
+    return false;
+}
+
+/**
+ * @brief Gets antenna currently used for tx.
+ *
+ * @note The antenna read by this function is currently used tx antenna only if
+ * antenna diversity tx mode is set to @ref NRF_802154_ANT_DIVERSITY_MODE_MANUAL. Otherwise,
+ * currently used antenna may be different.
+ * @sa nrf_802154_ant_diversity_mode_set
+ *
+ * @return Currently used antenna.
+ */
+static inline nrf_802154_ant_diversity_antenna_t nrf_802154_antenna_diversity_tx_antenna_get(void)
+{
+    return NRF_802154_ANT_DIVERSITY_ANTENNA_1;
+}
+
+/**
+ * @brief Gets which antenna was selected as best for the last reception.
+ *
+ * @note In three cases @ref NRF_802154_ANT_DIVERSITY_ANTENNA_NONE may be returned:
+ *  - No frame was received yet.
+ *  - Last frame was received with antenna diversity auto mode disabled.
+ *  - RSSI measurements didn't have enough time to finish during last frame reception
+ *    and it is unspecified which antenna was selected.
+ *
+ * @return Antenna selected during last successful reception in automatic mode.
+ */
+static inline nrf_802154_ant_diversity_antenna_t nrf_802154_antenna_diversity_last_rx_best_antenna_get(void)
+{
+    return NRF_802154_ANT_DIVERSITY_ANTENNA_1;
+}
+
+/**
+ * @brief Sets antenna diversity configuration.
+ *
+ * If configuration other than default is required, this should be called
+ * before @ref nrf_802154_antenna_diversity_init.
+ *
+ * @param[in] config Configuration of antenna diversity module to be set.
+ */
+static inline void nrf_802154_antenna_diversity_config_set(nrf_802154_ant_diversity_config_t config)
+{
+    (void)config;
+}
+
+/**
+ * @brief Gets current antenna diversity configuration.
+ *
+ * @return Configuration of antenna diversity module.
+ */
+static inline nrf_802154_ant_diversity_config_t nrf_802154_antenna_diversity_config_get(void)
+{
+    static nrf_802154_ant_diversity_config_t cfg;
+    return cfg;
+}
+
+/**
+ * @brief Initializes antenna diversity module.
+ *
+ * This function should be called before starting radio operations, but at any time
+ * after driver initialization. Also, if ant_sel pin other than default is required,
+ * pin configuration should be set beforehand. See @ref nrf_802154_antenna_config_set.
+ * Example:
+ * @code
+ * nrf_802154_init();
+ * // If pin configuration is required
+ * nrf_802154_ant_diversity_config_t cfg = nrf_802154_antenna_config_get();
+ * cfg.ant_sel_pin = ANT_SEL_PIN;
+ * nrf_802154_antenna_config_set(cfg);
+ * // Pin configuration end
+ * nrf_802154_antenna_diversity_init();
+ * // At any later time
+ * nrf_802154_receive();
+ * @endcode
+ */
+static inline void nrf_802154_antenna_diversity_init(void)
+{
+
+}
+#endif // ENABLE_ANT_DIVERSITY
+
+
+/**
+ * @brief Enables wifi coex signaling.
+ *
+ * When @ref nrf_802154_init is called, the wifi coex signaling is initially enabled or disabled
+ * depending on @ref NRF_802154_COEX_INITIALLY_ENABLED. You can call this function
+ * (after @ref nrf_802154_init) to enable the wifi coex signaling. When wifi coex signaling
+ * has been already enabled, this function has no effect.
+ *
+ * When this function is called during receive or transmit operation, the effect on coex interface
+ * may be delayed until current frame (or ack) is received or transmitted.
+ * To avoid this issue please call this function when the driver is in sleep mode.
+ *
+ * @retval true     Wifi coex is supported and is enabled after call to this function.
+ * @retval false    Wifi coex is not supported.
+ */
+static inline bool nrf_802154_wifi_coex_enable(void)
+{
+    return true;
+}
+
+/**
+ * @brief Disables wifi coex signaling.
+ *
+ * You can call this function (after @ref nrf_802154_init) to disable the wifi coex signaling.
+ * When wifi coex signaling has been already disabled, this function has no effect.
+ *
+ * When this function is called during receive or transmit operation, the effect on coex interface
+ * may be delayed until current frame (or ack) is received or transmitted.
+ * To avoid this issue please call this function when the driver is in sleep mode.
+ */
+static inline void nrf_802154_wifi_coex_disable(void)
+{
+}
+
+/**
+ * @brief Checks if wifi coex signaling is enabled.
+ *
+ * @retval true     Wifi coex signaling is enabled.
+ * @retval false    Wifi coex signaling is disabled.
+ */
+static inline bool nrf_802154_wifi_coex_is_enabled(void)
+{
+    return true;
+}
+
+/**
+ * @brief Sets Coex request mode used in receive operations.
+ *
+ * @param[in] mode  Coex receive request mode. For allowed values see @ref nrf_802154_coex_rx_request_mode_t type.
+ *
+ * @retval true     Operation succeeded.
+ * @retval false    Requested mode is not supported.
+ */
+static inline bool nrf_802154_coex_rx_request_mode_set(nrf_802154_coex_rx_request_mode_t mode)
+{
+    (void)NRF_802154_COEX_RX_REQUEST_MODE_ENERGY_DETECTION;
+    return false;
+}
+
+/**
+ * @brief Gets Coex request mode used in receive operations.
+ *
+ * @return Current Coex receive request mode. For allowed values see @ref nrf_802154_coex_rx_request_mode_t type.
+ */
+static inline nrf_802154_coex_rx_request_mode_t nrf_802154_coex_rx_request_mode_get(void)
+{
+    return NRF_802154_COEX_RX_REQUEST_MODE_ENERGY_DETECTION;
+}
+
+/**
+ * @brief Sets Coex request mode used in transmit operations.
+ *
+ * @param[in] mode  Coex transmit request mode. For allowed values see @ref nrf_802154_coex_tx_request_mode_t type.
+ *
+ * @retval true     Operation succeeded.
+ * @retval false    Requested mode is not supported.
+ */
+static inline bool nrf_802154_coex_tx_request_mode_set(nrf_802154_coex_tx_request_mode_t mode)
+{
+    (void)mode;
+    return true;
+}
+
+/**
+ * @brief Gets Coex request mode used in transmit operations.
+ *
+ * @return Current Coex transmit request mode. For allowed values see @ref nrf_802154_coex_tx_request_mode_t type.
+ */
+static inline nrf_802154_coex_tx_request_mode_t nrf_802154_coex_tx_request_mode_get(void)
+{
+    return NRF_802154_COEX_TX_REQUEST_MODE_FRAME_READY;
+}


### PR DESCRIPTION
This adds a module which configures initial parameters (pinout,
timings) of FEM, Antenna Diversity, and WiFi Coex of the 802.15.4 radio
driver. The configuration is applied on system initialization.

Note that ```rd_stubs.h``` should not be review. This is just a placeholder for functions that will come when updated radio driver is merged. 

~~This PR depends on:
https://github.com/zephyrproject-rtos/hal_nordic/pull/38
https://github.com/zephyrproject-rtos/zephyr/pull/25065~~

Signed-off-by: Wojciech Bober <wojciech.bober@nordicsemi.no>