### PR TITLE
samples: zigbee: Add overlay to enable 802154 FEM & WiFi Coex

### DIFF
--- a/samples/zigbee/network_coordinator/README.rst
+++ b/samples/zigbee/network_coordinator/README.rst
@@ -13,6 +13,32 @@ Overview
 This Zigbee network coordinator sample demonstrates the Zigbee Coordinator role.
 It is a minimal implementation that supports only the network steering commissioning mechanism.
 
+Additional radio features
+=========================
+
+The sample supports additional radio features:
+
+* Power Amplifier and Low Noise Amplifier Front-End Module (PA/LNA FEM).
+* Antenna diversity FEM feature.
+* Packet Traffic Arbiter (PTA) for systems with multiple radio modules.
+
+For more details about each of those features refer to :ref:`ug_zigbee`.
+
+.. _zigbee_network_coordinator_sample_radio_enabling:
+
+Enabling additional radio features
+----------------------------------
+
+To enable additional radio features for the sample, modify :makevar:`CONF_FILE` by applying proper configuration files before `Building and running`_ the sample.
+
+Three configuration overlay files are provided in the sample, one for each feature:
+
+* :file:`overlay-ant_div.conf` - Enables support for the antenna diversity FEM feature in automated RX mode.
+* :file:`overlay-pa_lna.conf` - Enables support for PA/LNA FEM feature.
+* :file:`overlay-wifi_coex.conf` - Enables support for PTA for systems with multiple radio modules.
+
+For more information about using configuration overlay files, see :ref:`important-build-vars` in the Zephyr documentation.
+
 Requirements
 ************
 

--- a/samples/zigbee/network_coordinator/overlay-ant_div.conf
+++ b/samples/zigbee/network_coordinator/overlay-ant_div.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# enable radio driver support for Antena Diversity FEM feature
+CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_MODE_AUTO=y
+
+#update PIN assignment
+# P1.12
+CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_PIN=44

--- a/samples/zigbee/network_coordinator/overlay-pa_lna.conf
+++ b/samples/zigbee/network_coordinator/overlay-pa_lna.conf
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# enable radio support for PA/LNA FEM feature
+CONFIG_IEEE802154_NRF5_FEM_PRESENT=y
+
+#update PIN assignment
+# P1.10
+CONFIG_IEEE802154_NRF5_FEM_PA_PIN=42
+# P1.06
+CONFIG_IEEE802154_NRF5_FEM_LNA_PIN=38
+# P1.05
+CONFIG_IEEE802154_NRF5_FEM_PDN_PIN=37

--- a/samples/zigbee/network_coordinator/overlay-wifi_coex.conf
+++ b/samples/zigbee/network_coordinator/overlay-wifi_coex.conf
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# enable WiFi Coexistence radio module
+CONFIG_IEEE802154_NRF5_WIFI_COEX=y
+
+#update PIN assignment
+# P0.13
+CONFIG_IEEE802154_NRF5_WIFI_COEX_REQ_PIN=13
+# P0.14
+CONFIG_IEEE802154_NRF5_WIFI_COEX_PRIO_PIN=14
+#P0.24/button 3
+CONFIG_IEEE802154_NRF5_WIFI_COEX_GRA_PIN=24


### PR DESCRIPTION
This adds an overlay file to enable 802154 fem and wifi coex.

This PR depends on:
https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/2208
https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/2210

Signed-off-by: Wojciech Bober <wojciech.bober@nordicsemi.no>