### PR TITLE
cmake: Using find_package(Zephyr)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -100,6 +100,7 @@ Kconfig*                                  @tejlmand
 /samples/CMakeLists.txt                   @tejlmand
 /scripts/                                 @mbolivar @tejlmand
 /scripts/hid_configurator/                @pdunaj
+/share/zephyrbuild-package/               @tejlmand
 /subsys/bluetooth/                        @joerchan @carlescufi
 /subsys/bluetooth/mesh/                   @trond-snekvik @joerchan
 /subsys/bluetooth/controller/             @joerchan @rugeGerritsen

--- a/applications/asset_tracker/CMakeLists.txt
+++ b/applications/asset_tracker/CMakeLists.txt
@@ -8,7 +8,6 @@ cmake_minimum_required(VERSION 3.8.2)
 
 set(spm_CONF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/spm.conf)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 
 set(PM_STATIC_YML_FILE
   ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static.yml

--- a/applications/asset_tracker/CMakeLists.txt
+++ b/applications/asset_tracker/CMakeLists.txt
@@ -14,7 +14,7 @@ set(PM_STATIC_YML_FILE
   ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static.yml
   )
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(asset_tracker)
 zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})
 zephyr_compile_definitions(_POSIX_C_SOURCE=200809L)

--- a/applications/connectivity_bridge/CMakeLists.txt
+++ b/applications/connectivity_bridge/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/applications/connectivity_bridge/CMakeLists.txt
+++ b/applications/connectivity_bridge/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE src/main.c)

--- a/applications/nrf_desktop/CMakeLists.txt
+++ b/applications/nrf_desktop/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE ZDebug)

--- a/applications/nrf_desktop/CMakeLists.txt
+++ b/applications/nrf_desktop/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CONF_FILE "configuration/${BOARD}/app_${CMAKE_BUILD_TYPE}.conf")
 
 ################################################################################
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("nRF52 Desktop"
         VERSION 0.1)
 

--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-# Point to NCS root directory.
-set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+# This boilerplate is automatically included through ZephyrBuildConfig.cmake, found in
+# ${NRF_DIR}/share/zephyrbuild-package/cmake/ZephyrBuildConfig.cmake
+# For more information regarding the Zephyr Build Configuration CMake package, please refer to:
+# https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/zephyr_cmake_package.html#zephyr-build-configuration-cmake-package
 
 include(${NRF_DIR}/boards/deprecated.cmake)
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.13.1)
 project(nrf-connect-sdk-doc LANGUAGES)
 
 set(NO_BOILERPLATE TRUE)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE} ..)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} ..)
 
 #
 # Set various *_BASE variables pointing to the nrf/, zephyr/, etc.,

--- a/doc/nrf/ug_app_dev.rst
+++ b/doc/nrf/ug_app_dev.rst
@@ -32,23 +32,13 @@ See the following links for information about the different building blocks ment
 ===============
 
 The |NCS| adds some functionality on top of the Zephyr build and configuration system.
+Those additions are automatically included into the Zephyr build system using a :ref:`cmake_build_config_package`.
+
 You must be aware of these additions when you start writing your own applications based on this SDK.
 
-  * The |NCS| provides an additional :file:`boilerplate.cmake` that must be included before Zephyr's in the :file:`CMakeLists.txt` file of your application::
+  * The |NCS| provides an additional :file:`boilerplate.cmake` that is automatically included when using the Zephyr CMake package in the :file:`CMakeLists.txt` file of your application::
 
-      include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-      include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
-
-    Since the |NCS| does not require or provide an environment variable equivalent to :makevar:`ZEPHYR_BASE`, you can either create your own or locate the full path in your own :file:`CMakeLists.txt`.
-    In order to obtain the path to the :file:`nrf` folder, you can use west::
-
-      execute_process(COMMAND west list -f {abspath} nrf OUTPUT_VARIABLE NRF_BASE
-                      RESULT_VARIABLE west_list_err OUTPUT_STRIP_TRAILING_WHITESPACE)
-      if (west_list_err)
-        message(FATAL_ERROR "cannot find nrf directory with west")
-      endif()
-
-      include(${NRF_BASE}/cmake/boilerplate.cmake)
+      find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
   * The |NCS| allows you to :ref:`create custom build type files <gs_modifying_build_types>` instead of using a single :file:`prj.conf` file.
   * The |NCS| build system extends Zephyr's with support for multi-image builds.

--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -137,6 +137,9 @@ static int z_to_nrf_optname(int z_in_level, int z_in_optname,
 		case TLS_DTLS_ROLE:
 			*nrf_out_optname = NRF_SO_SEC_ROLE;
 			break;
+		case TLS_SESSION_CACHE:
+			*nrf_out_optname = NRF_SO_SEC_SESSION_CACHE;
+			break;
 		default:
 			retval = -1;
 			break;
@@ -650,6 +653,8 @@ static int nrf91_socket_offload_setsockopt(void *obj, int level, int optname,
 		nrf_rcvtimeo.tv_usec = ((struct timeval *)optval)->tv_usec;
 		nrf_optval = &nrf_rcvtimeo;
 		nrf_optlen = sizeof(struct nrf_timeval);
+	} else if ((level == SOL_TLS) && (optname == TLS_SESSION_CACHE)) {
+		nrf_optlen = sizeof(nrf_sec_session_cache_t);
 	}
 
 	retval = nrf_setsockopt(sd, nrf_level, nrf_optname, nrf_optval,

--- a/samples/bluetooth/central_bas/CMakeLists.txt
+++ b/samples/bluetooth/central_bas/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/central_bas/CMakeLists.txt
+++ b/samples/bluetooth/central_bas/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/central_dfu_smp/CMakeLists.txt
+++ b/samples/bluetooth/central_dfu_smp/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/central_dfu_smp/CMakeLists.txt
+++ b/samples/bluetooth/central_dfu_smp/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/central_hids/CMakeLists.txt
+++ b/samples/bluetooth/central_hids/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/central_hids/CMakeLists.txt
+++ b/samples/bluetooth/central_hids/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/central_uart/CMakeLists.txt
+++ b/samples/bluetooth/central_uart/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(central_uart)
 
 # NORDIC SDK APP START

--- a/samples/bluetooth/central_uart/CMakeLists.txt
+++ b/samples/bluetooth/central_uart/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(central_uart)
 

--- a/samples/bluetooth/enocean/CMakeLists.txt
+++ b/samples/bluetooth/enocean/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/enocean/CMakeLists.txt
+++ b/samples/bluetooth/enocean/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/llpm/CMakeLists.txt
+++ b/samples/bluetooth/llpm/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/llpm/CMakeLists.txt
+++ b/samples/bluetooth/llpm/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/mesh/light/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/mesh/light/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE

--- a/samples/bluetooth/mesh/light_switch/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light_switch/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_light_switch)
 

--- a/samples/bluetooth/mesh/light_switch/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light_switch/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_light_switch)
 
 target_sources(app PRIVATE

--- a/samples/bluetooth/peripheral_gatt_dm/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_gatt_dm/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 # NORDIC SDK APP START

--- a/samples/bluetooth/peripheral_gatt_dm/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_gatt_dm/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/peripheral_hids_keyboard/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids_keyboard/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/peripheral_hids_keyboard/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids_keyboard/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/peripheral_hids_mouse/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids_mouse/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bluetooth/peripheral_hids_mouse/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids_mouse/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/peripheral_lbs/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_lbs/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 # NORDIC SDK APP START

--- a/samples/bluetooth/peripheral_lbs/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_lbs/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/peripheral_uart/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_uart/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 # NORDIC SDK APP START

--- a/samples/bluetooth/peripheral_uart/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_uart/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/shell_bt_nus/CMakeLists.txt
+++ b/samples/bluetooth/shell_bt_nus/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE

--- a/samples/bluetooth/shell_bt_nus/CMakeLists.txt
+++ b/samples/bluetooth/shell_bt_nus/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/throughput/CMakeLists.txt
+++ b/samples/bluetooth/throughput/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/throughput/CMakeLists.txt
+++ b/samples/bluetooth/throughput/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/bootloader/CMakeLists.txt
+++ b/samples/bootloader/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bootloader)
 
 zephyr_library_sources(src/main.c)

--- a/samples/bootloader/CMakeLists.txt
+++ b/samples/bootloader/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bootloader)
 

--- a/samples/debug/ppi_trace/CMakeLists.txt
+++ b/samples/debug/ppi_trace/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("PPI trace sample")
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/debug/ppi_trace/CMakeLists.txt
+++ b/samples/debug/ppi_trace/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("PPI trace sample")
 

--- a/samples/esb/prx/CMakeLists.txt
+++ b/samples/esb/prx/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/esb/prx/CMakeLists.txt
+++ b/samples/esb/prx/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/esb/ptx/CMakeLists.txt
+++ b/samples/esb/ptx/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/esb/ptx/CMakeLists.txt
+++ b/samples/esb/ptx/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/event_manager/CMakeLists.txt
+++ b/samples/event_manager/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Event Manager sample")
 

--- a/samples/event_manager/CMakeLists.txt
+++ b/samples/event_manager/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Event Manager sample")
 
 # Include application event headers

--- a/samples/mpsl/timeslot/CMakeLists.txt
+++ b/samples/mpsl/timeslot/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 # NORDIC SDK APP START

--- a/samples/mpsl/timeslot/CMakeLists.txt
+++ b/samples/mpsl/timeslot/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/record_text/CMakeLists.txt
+++ b/samples/nfc/record_text/CMakeLists.txt
@@ -13,7 +13,7 @@ set(NRF_SUPPORTED_BOARDS
   )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/nfc/record_text/CMakeLists.txt
+++ b/samples/nfc/record_text/CMakeLists.txt
@@ -12,7 +12,6 @@ set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp
   )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/system_off/CMakeLists.txt
+++ b/samples/nfc/system_off/CMakeLists.txt
@@ -13,7 +13,7 @@ set(NRF_SUPPORTED_BOARDS
   )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/nfc/system_off/CMakeLists.txt
+++ b/samples/nfc/system_off/CMakeLists.txt
@@ -12,7 +12,6 @@ set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp
   )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/tag_reader/CMakeLists.txt
+++ b/samples/nfc/tag_reader/CMakeLists.txt
@@ -13,7 +13,6 @@ set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp
   )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/tag_reader/CMakeLists.txt
+++ b/samples/nfc/tag_reader/CMakeLists.txt
@@ -14,7 +14,7 @@ set(NRF_SUPPORTED_BOARDS
   )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/nfc/tnep_poller/CMakeLists.txt
+++ b/samples/nfc/tnep_poller/CMakeLists.txt
@@ -15,7 +15,7 @@ set(NRF_SUPPORTED_BOARDS
 
 include(../../../cmake/boilerplate.cmake)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/nfc/tnep_poller/CMakeLists.txt
+++ b/samples/nfc/tnep_poller/CMakeLists.txt
@@ -13,8 +13,6 @@ set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp
   )
 
-include(../../../cmake/boilerplate.cmake)
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/tnep_tag/CMakeLists.txt
+++ b/samples/nfc/tnep_tag/CMakeLists.txt
@@ -13,7 +13,7 @@ set(NRF_SUPPORTED_BOARDS
   )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/nfc/tnep_tag/CMakeLists.txt
+++ b/samples/nfc/tnep_tag/CMakeLists.txt
@@ -12,7 +12,6 @@ set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp
   )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/writable_ndef_msg/CMakeLists.txt
+++ b/samples/nfc/writable_ndef_msg/CMakeLists.txt
@@ -13,7 +13,7 @@ set(NRF_SUPPORTED_BOARDS
   )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/nfc/writable_ndef_msg/CMakeLists.txt
+++ b/samples/nfc/writable_ndef_msg/CMakeLists.txt
@@ -12,7 +12,6 @@ set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp
   )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nrf9160/at_client/CMakeLists.txt
+++ b/samples/nrf9160/at_client/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 # NORDIC SDK APP START

--- a/samples/nrf9160/at_client/CMakeLists.txt
+++ b/samples/nrf9160/at_client/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nrf9160/aws_fota/CMakeLists.txt
+++ b/samples/nrf9160/aws_fota/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 if(CONFIG_PROVISION_CERTIFICATES)
   message(WARNING "
       ------------------------------------------------------------

--- a/samples/nrf9160/aws_fota/CMakeLists.txt
+++ b/samples/nrf9160/aws_fota/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 if(CONFIG_PROVISION_CERTIFICATES)
   message(WARNING "

--- a/samples/nrf9160/cloud_client/CMakeLists.txt
+++ b/samples/nrf9160/cloud_client/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake NO_POLICY_SCOPE)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cloud_client)
 
 # NORDIC SDK APP START

--- a/samples/nrf9160/cloud_client/CMakeLists.txt
+++ b/samples/nrf9160/cloud_client/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake NO_POLICY_SCOPE)
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cloud_client)
 

--- a/samples/nrf9160/coap_client/CMakeLists.txt
+++ b/samples/nrf9160/coap_client/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf-coap-client)
 

--- a/samples/nrf9160/coap_client/CMakeLists.txt
+++ b/samples/nrf9160/coap_client/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf-coap-client)
 
 # NORDIC SDK APP START

--- a/samples/nrf9160/gps/CMakeLists.txt
+++ b/samples/nrf9160/gps/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gps_socket_sample)
 

--- a/samples/nrf9160/gps/CMakeLists.txt
+++ b/samples/nrf9160/gps/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gps_socket_sample)
 
 zephyr_library_sources(src/main.c)
@@ -16,4 +16,3 @@ zephyr_library_sources_ifdef(
   CONFIG_SUPL_CLIENT_LIB
   src/supl_support.c
 )
-

--- a/samples/nrf9160/http_application_update/CMakeLists.txt
+++ b/samples/nrf9160/http_application_update/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(http_application_update)
 

--- a/samples/nrf9160/http_application_update/CMakeLists.txt
+++ b/samples/nrf9160/http_application_update/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(http_application_update)
 
 # NORDIC SDK APP START

--- a/samples/nrf9160/https_client/CMakeLists.txt
+++ b/samples/nrf9160/https_client/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 project(https_client)
 

--- a/samples/nrf9160/https_client/CMakeLists.txt
+++ b/samples/nrf9160/https_client/CMakeLists.txt
@@ -7,7 +7,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 project(https_client)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/nrf9160/lte_ble_gateway/CMakeLists.txt
+++ b/samples/nrf9160/lte_ble_gateway/CMakeLists.txt
@@ -18,7 +18,7 @@ set(spm_CONF_FILE
   )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lte-ble-gateway)
 
 # NORDIC SDK APP START

--- a/samples/nrf9160/lte_ble_gateway/CMakeLists.txt
+++ b/samples/nrf9160/lte_ble_gateway/CMakeLists.txt
@@ -17,7 +17,6 @@ set(spm_CONF_FILE
   ${CMAKE_CURRENT_LIST_DIR}/child_secure_partition_manager.conf
   )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lte-ble-gateway)
 

--- a/samples/nrf9160/lwm2m_carrier/CMakeLists.txt
+++ b/samples/nrf9160/lwm2m_carrier/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lwm2m-carrier)
 

--- a/samples/nrf9160/lwm2m_carrier/CMakeLists.txt
+++ b/samples/nrf9160/lwm2m_carrier/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lwm2m-carrier)
 
 # NORDIC SDK APP START

--- a/samples/nrf9160/lwm2m_client/CMakeLists.txt
+++ b/samples/nrf9160/lwm2m_client/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lwm2m_client)
 zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})

--- a/samples/nrf9160/lwm2m_client/CMakeLists.txt
+++ b/samples/nrf9160/lwm2m_client/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lwm2m_client)
 zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})
 

--- a/samples/nrf9160/mqtt_simple/CMakeLists.txt
+++ b/samples/nrf9160/mqtt_simple/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mqtt-simple)
 
 # NORDIC SDK APP START

--- a/samples/nrf9160/mqtt_simple/CMakeLists.txt
+++ b/samples/nrf9160/mqtt_simple/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mqtt-simple)
 

--- a/samples/nrf9160/nrf_cloud_agps/CMakeLists.txt
+++ b/samples/nrf9160/nrf_cloud_agps/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake NO_POLICY_SCOPE)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_cloud_agps)
 
 # NORDIC SDK APP START

--- a/samples/nrf9160/nrf_cloud_agps/CMakeLists.txt
+++ b/samples/nrf9160/nrf_cloud_agps/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake NO_POLICY_SCOPE)
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_cloud_agps)
 

--- a/samples/nrf9160/secure_services/CMakeLists.txt
+++ b/samples/nrf9160/secure_services/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(secure_services)
 

--- a/samples/nrf9160/secure_services/CMakeLists.txt
+++ b/samples/nrf9160/secure_services/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(secure_services)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/nrf9160/serial_lte_modem/CMakeLists.txt
+++ b/samples/nrf9160/serial_lte_modem/CMakeLists.txt
@@ -16,7 +16,7 @@ set(spm_CONF_FILE
   prj.conf
   ${CMAKE_CURRENT_LIST_DIR}/child_secure_partition_manager.conf
   )
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(serial_lte_modem)
 

--- a/samples/nrf9160/serial_lte_modem/CMakeLists.txt
+++ b/samples/nrf9160/serial_lte_modem/CMakeLists.txt
@@ -17,7 +17,7 @@ set(spm_CONF_FILE
   ${CMAKE_CURRENT_LIST_DIR}/child_secure_partition_manager.conf
   )
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(serial_lte_modem)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/nrf9160/spm/CMakeLists.txt
+++ b/samples/nrf9160/spm/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nrf9160/spm/CMakeLists.txt
+++ b/samples/nrf9160/spm/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 zephyr_include_directories(

--- a/samples/openthread/cli/CMakeLists.txt
+++ b/samples/openthread/cli/CMakeLists.txt
@@ -10,7 +10,6 @@ set(NRF_SUPPORTED_BOARDS
 	nrf52833dk_nrf52833
 )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE}
 
 project(openthread_cli)

--- a/samples/openthread/cli/CMakeLists.txt
+++ b/samples/openthread/cli/CMakeLists.txt
@@ -11,7 +11,7 @@ set(NRF_SUPPORTED_BOARDS
 )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE}
 
 project(openthread_cli)
 

--- a/samples/openthread/coap_client/CMakeLists.txt
+++ b/samples/openthread/coap_client/CMakeLists.txt
@@ -10,7 +10,7 @@ set(NRF_SUPPORTED_BOARDS
 	nrf52833dk_nrf52833
 )
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(openthread_coap_client)
 
@@ -20,4 +20,4 @@ target_sources(app PRIVATE src/coap_client.c
 
 target_sources_ifdef(CONFIG_BT app PRIVATE src/ble_utils.c)
 
-target_include_directories(app PRIVATE ../coap_server/interface)
+target_include_directories(app PUBLIC ../coap_interface)

--- a/samples/openthread/coap_server/CMakeLists.txt
+++ b/samples/openthread/coap_server/CMakeLists.txt
@@ -11,7 +11,7 @@ set(NRF_SUPPORTED_BOARDS
 )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE}
 
 project(openthread_coap_server)
 

--- a/samples/openthread/coap_server/CMakeLists.txt
+++ b/samples/openthread/coap_server/CMakeLists.txt
@@ -10,7 +10,6 @@ set(NRF_SUPPORTED_BOARDS
 	nrf52833dk_nrf52833
 )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE}
 
 project(openthread_coap_server)

--- a/samples/peripheral/radio_test/CMakeLists.txt
+++ b/samples/peripheral/radio_test/CMakeLists.txt
@@ -13,7 +13,7 @@ set(NRF_SUPPORTED_BOARDS
 )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/peripheral/radio_test/CMakeLists.txt
+++ b/samples/peripheral/radio_test/CMakeLists.txt
@@ -12,7 +12,6 @@ set(NRF_SUPPORTED_BOARDS
 	nrf52840dk_nrf52840
 )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/profiler/CMakeLists.txt
+++ b/samples/profiler/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Profiler sample")
 

--- a/samples/profiler/CMakeLists.txt
+++ b/samples/profiler/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Profiler sample")
 
 # NORDIC SDK APP START

--- a/samples/sensor/bh1749/CMakeLists.txt
+++ b/samples/sensor/bh1749/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bh1749)
 

--- a/samples/sensor/bh1749/CMakeLists.txt
+++ b/samples/sensor/bh1749/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bh1749)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/usb/usb_uart_bridge/CMakeLists.txt
+++ b/samples/usb/usb_uart_bridge/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/usb/usb_uart_bridge/CMakeLists.txt
+++ b/samples/usb/usb_uart_bridge/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/zigbee/light_bulb/CMakeLists.txt
+++ b/samples/zigbee/light_bulb/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project("Zigbee light bulb")
 

--- a/samples/zigbee/light_switch/CMakeLists.txt
+++ b/samples/zigbee/light_switch/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project("Light Switch")
 

--- a/samples/zigbee/network_coordinator/CMakeLists.txt
+++ b/samples/zigbee/network_coordinator/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project("Zigbee coordinator")
 

--- a/share/zephyrbuild-package/cmake/ZephyrBuildConfig.cmake
+++ b/share/zephyrbuild-package/cmake/ZephyrBuildConfig.cmake
@@ -1,0 +1,8 @@
+# Relative directory of NRF dir as seen from ZephyrExtension package file
+set(NRF_RELATIVE_DIR "../../..")
+
+# Set the current NRF_DIR
+# The use of get_filename_component ensures that the final path variable will not contain `../..`.
+get_filename_component(NRF_DIR ${CMAKE_CURRENT_LIST_DIR}/${NRF_RELATIVE_DIR} ABSOLUTE)
+
+include(${NRF_DIR}/cmake/boilerplate.cmake NO_POLICY_SCOPE)

--- a/tests/crypto/CMakeLists.txt
+++ b/tests/crypto/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.8.2)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(NONE)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/tests/drivers/clock_control/clock_control_mpsl/CMakeLists.txt
+++ b/tests/drivers/clock_control/clock_control_mpsl/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/fprotect/negative/CMakeLists.txt
+++ b/tests/drivers/fprotect/negative/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/tests/drivers/fprotect/negative/CMakeLists.txt
+++ b/tests/drivers/fprotect/negative/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/drivers/fprotect/positive/CMakeLists.txt
+++ b/tests/drivers/fprotect/positive/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/tests/drivers/fprotect/positive/CMakeLists.txt
+++ b/tests/drivers/fprotect/positive/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/at_cmd_parser/at_cmd_parser/CMakeLists.txt
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(at_cmd_parser)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/at_cmd_parser/at_cmd_parser/CMakeLists.txt
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(at_cmd_parser)
 

--- a/tests/lib/at_cmd_parser/at_params/CMakeLists.txt
+++ b/tests/lib/at_cmd_parser/at_params/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(at_cmd_parser)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/at_cmd_parser/at_params/CMakeLists.txt
+++ b/tests/lib/at_cmd_parser/at_params/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(at_cmd_parser)
 

--- a/tests/lib/at_cmd_parser/at_utils/CMakeLists.txt
+++ b/tests/lib/at_cmd_parser/at_utils/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(at_cmd_parser)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/lib/at_cmd_parser/at_utils/CMakeLists.txt
+++ b/tests/lib/at_cmd_parser/at_utils/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(at_cmd_parser)
 

--- a/tests/subsys/bluetooth/gatt_dm/CMakeLists.txt
+++ b/tests/subsys/bluetooth/gatt_dm/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/bluetooth/gatt_dm/CMakeLists.txt
+++ b/tests/subsys/bluetooth/gatt_dm/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/tests/subsys/bootloader/bl_crypto/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_crypto/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/tests/subsys/bootloader/bl_crypto/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_crypto/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/bootloader/bl_storage/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_storage/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/tests/subsys/bootloader/bl_storage/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_storage/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/bootloader/bl_validation/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_validation/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/tests/subsys/bootloader/bl_validation/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_validation/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/debug/cpu_load/CMakeLists.txt
+++ b/tests/subsys/debug/cpu_load/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13.1)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cpu_load_test)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/dfu/dfu_target/mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/dfu_target/mcuboot/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dfu_target_test)
 

--- a/tests/subsys/dfu/dfu_target/mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/dfu_target/mcuboot/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dfu_target_test)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(json)
 

--- a/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(json)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/event_manager/CMakeLists.txt
+++ b/tests/subsys/event_manager/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Event Manager unit tests")
 
 # Include event headers

--- a/tests/subsys/event_manager/CMakeLists.txt
+++ b/tests/subsys/event_manager/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Event Manager unit tests")
 

--- a/tests/subsys/fw_info/CMakeLists.txt
+++ b/tests/subsys/fw_info/CMakeLists.txt
@@ -42,7 +42,7 @@ set_property(
   provision_PM_HEX_FILE
   ${provision_path})
 
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 if (NOT ((DEFINED CONFIG_SOC_NRF9160
               AND provision_hex STREQUAL "provision_nrf9160.hex")

--- a/tests/subsys/net/lib/aws_fota/aws_fota_json/CMakeLists.txt
+++ b/tests/subsys/net/lib/aws_fota/aws_fota_json/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(json)
 

--- a/tests/subsys/net/lib/aws_fota/aws_fota_json/CMakeLists.txt
+++ b/tests/subsys/net/lib/aws_fota/aws_fota_json/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(json)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/net/lib/aws_jobs/CMakeLists.txt
+++ b/tests/subsys/net/lib/aws_jobs/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(json)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/net/lib/aws_jobs/CMakeLists.txt
+++ b/tests/subsys/net/lib/aws_jobs/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(json)
 

--- a/tests/subsys/net/lib/fota_download/CMakeLists.txt
+++ b/tests/subsys/net/lib/fota_download/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fota_download)
 
 FILE(GLOB app_sources src/*.c)

--- a/tests/subsys/net/lib/fota_download/CMakeLists.txt
+++ b/tests/subsys/net/lib/fota_download/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fota_download)
 

--- a/tests/subsys/zigbee/osif/crypto/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/crypto/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 target_compile_options(app PRIVATE -Wno-packed-bitfield-compat)
 

--- a/tests/subsys/zigbee/osif/logger/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/logger/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(app)
 add_definitions(-Wno-packed-bitfield-compat)

--- a/tests/subsys/zigbee/osif/nvram/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/nvram/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.13.1)
 add_compile_definitions(zb_nvram_erase_finished=zb_nvram_erase_finished_stub)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(zigbee_osif_nvram_test)
 

--- a/tests/subsys/zigbee/osif/timer/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/timer/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(zigbee_osif_test)
 
 zephyr_compile_definitions(CONFIG_ZBOSS_OSIF_LOG_LEVEL=3)

--- a/tests/subsys/zigbee/zboss_api/callback_api/CMakeLists.txt
+++ b/tests/subsys/zigbee/zboss_api/callback_api/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(NONE)
 

--- a/tests/unity/example_test/CMakeLists.txt
+++ b/tests/unity/example_test/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(example_test)
 

--- a/tests/unity/example_test/CMakeLists.txt
+++ b/tests/unity/example_test/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(example_test)
 
 # generate runner for the test

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 04f51e004c0f91f361727a55a765c32338f906c8
+      revision: c33de413cf336aa0d050c42064d81d5c0fc54af0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -87,7 +87,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: c161f44a5e4065c235a4f5b92c3c73137ce5dd58
+      revision: 2888ab20365e128e0d22ca7ab94ed6e77dfe598a
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
This commit align the inclusion of Zephyr boilerplate code with
upstream Zephyr by using find_package(Zephyr).

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-----
This PR is dependent on:
https://github.com/nrfconnect/sdk-zephyr/pull/305
https://github.com/nrfconnect/sdk-mcuboot/pull/104
