### PR TITLE
doc: mcuboot: Fix inclusion of recommonmark>=0.4.0

### DIFF
--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -23,6 +23,8 @@
 
 import sys
 import os
+import pkg_resources
+from packaging import version
 
 if "NRF_BASE" not in os.environ:
     sys.exit("$NRF_BASE environment variable undefined.")
@@ -61,22 +63,31 @@ KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.intersphinx',
-              'breathe',
-              'sphinx.ext.ifconfig']
+
+# recommonmark didn't have a setup function before 0.5.0, so source_parsers
+# must be added manually
+recommonmark_version = pkg_resources.get_distribution("recommonmark").version
+if version.parse(recommonmark_version) < version.parse('0.5.0'):
+    extensions = ['sphinx.ext.intersphinx',
+                  'breathe',
+                  'sphinx.ext.ifconfig']
+else:
+    extensions = ['sphinx.ext.intersphinx',
+                  'breathe',
+                  'sphinx.ext.ifconfig',
+                  'recommonmark']
 
 # Add any paths that contain templates here, relative to this directory.
 #templates_path = ['../_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-#
-# source_suffix = ['.rst', '.md']
 source_suffix = ['.rst', '.md']
 
-source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
-}
+if version.parse(recommonmark_version) < version.parse('0.5.0'):
+    source_parsers = {
+       '.md': 'recommonmark.parser.CommonMarkParser',
+    }
 
 # The master toctree document.
 master_doc = 'wrapper'


### PR DESCRIPTION
`recommonmark` after 0.4.0 includes a `setup()` function that needs to be called to register itself and its filetypes. This is required for Sphinx >= 3.0.0.