### PR TITLE
at_cmd asynchronous command handling

### DIFF
--- a/include/modem/at_cmd.h
+++ b/include/modem/at_cmd.h
@@ -32,6 +32,9 @@ enum at_cmd_state {
 	AT_CMD_ERROR,
 	AT_CMD_ERROR_CMS,
 	AT_CMD_ERROR_CME,
+	AT_CMD_ERROR_QUEUE, /* Error enqueueing message */
+	AT_CMD_ERROR_WRITE, /* Error during socket write */
+	AT_CMD_ERROR_READ, /* Error during socket read */
 	AT_CMD_NOTIFICATION,
 };
 
@@ -67,11 +70,9 @@ int at_cmd_init(void);
  *                NULL pointer is allowed, which means that any returned data
  *                will not processed other than the return code (OK, ERROR, CMS
  *                or CME).
- * @param state   Pointer to @ref enum at_cmd_state variable that can hold
- *                the error state returned by the modem. If the return state
- *                is a CMS or CME errors will the error code be returned in the
- *                the function return code as a positive value. NULL pointer is
- *                allowed.
+ *
+ * @note The handler function runs from at_cmd's thread. It must not call
+ *       at_cmd_write, as that would lead to a deadlock.
  *
  * @retval 0 If command execution was successful (same as OK returned from
  *           modem). Error codes returned from the driver or by the socket are
@@ -86,8 +87,7 @@ int at_cmd_init(void);
  * @retval -EIO is returned if the function failed to send the command.
  */
 int at_cmd_write_with_callback(const char *const cmd,
-					  at_cmd_handler_t  handler,
-					  enum at_cmd_state *state);
+					  at_cmd_handler_t  handler);
 
 /**
  * @brief Function to send an AT command and receive response immediately
@@ -135,6 +135,9 @@ int at_cmd_write(const char *const cmd,
  *
  * @param handler Pointer to a received notification handler function of type
  *                @ref at_cmd_handler_t.
+ *
+ * @note The handler function runs from at_cmd's thread. It must not call
+ *       at_cmd_write, as that would lead to a deadlock.
  */
 void at_cmd_set_notification_handler(at_cmd_handler_t handler);
 

--- a/lib/at_cmd/Kconfig
+++ b/lib/at_cmd/Kconfig
@@ -34,13 +34,13 @@ config AT_CMD_THREAD_STACK_SIZE
 	int "AT thread stack size"
 	default 1024
 
+config AT_CMD_QUEUE_LEN
+	int "Maximum number of queued AT commands"
+	default 16
+
 config AT_CMD_RESPONSE_MAX_LEN
 	int "Maximum AT command response length"
 	default 2700
-
-config AT_CMD_RESPONSE_BUFFER_COUNT
-	int "Number of buffers provided by AT command driver."
-	default 2
 
 module = AT_CMD
 module-str = AT command driver

--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -17,11 +17,7 @@
 LOG_MODULE_REGISTER(at_host, CONFIG_AT_HOST_LOG_LEVEL);
 
 /* Stack definition for AT host workqueue */
-#ifdef CONFIG_SIZE_OPTIMIZATIONS
-#define AT_HOST_STACK_SIZE 768
-#else
 #define AT_HOST_STACK_SIZE 1024
-#endif
 
 K_THREAD_STACK_DEFINE(at_host_stack_area, AT_HOST_STACK_SIZE);
 


### PR DESCRIPTION
Reimplements much of at_cmd to enable asynchronous handling of commands. This PR focuses on keeping `at_cmd_write` working as before while laying the groundwork for asynchronous handling.

The metadata for commands and responses is stored in message queues, while the strings are allocated on the heap if required. The handling logic is designed to accept flags that enable easy expansion of the interface for different use cases (e. g. executing a command from static memory, where the command string need not be copied). This expansion could take the form of exposing the flags (or even the whole `cmd_item` struct), and/or making convenience functions for the different use cases.

Since the changes to at_cmd.c are relatively extensive, it might make more sense to review that file as a whole, rather than as a change from the previous version.