### PR TITLE
bsdlib: make sure bsdlib dependent services handle shutdown and init

### DIFF
--- a/include/modem/at_cmd.h
+++ b/include/modem/at_cmd.h
@@ -54,7 +54,7 @@ enum at_cmd_state {
  */
 typedef void (*at_cmd_handler_t)(const char *response);
 
-/**@brief Initialize AT command driver.
+/**@brief Initialize or recover the AT command driver.
  *
  * @return Zero on success, non-zero otherwise.
  */
@@ -82,9 +82,10 @@ int at_cmd_init(void);
  *
  * @retval -ENOBUFS is returned if AT_CMD_RESPONSE_MAX_LEN is not large enough
  *         to hold the data returned from the modem.
- * @retval ENOEXEC is returned if the modem returned ERROR.
+ * @retval -ENOEXEC is returned if the modem returned ERROR.
  * @retval -ENOMEM is returned if allocation of callback worker failed.
  * @retval -EIO is returned if the function failed to send the command.
+ * @retval -EHOSTDOWN is returned if bsdlib is shutdown.
  */
 int at_cmd_write_with_callback(const char *const cmd,
 					  at_cmd_handler_t  handler);
@@ -120,9 +121,10 @@ int at_cmd_write_with_callback(const char *const cmd,
  *
  * @retval -ENOBUFS is returned if AT_CMD_RESPONSE_MAX_LEN is not large enough
  *         to hold the data returned from the modem.
- * @retval ENOEXEC is returned if the modem returned ERROR.
+ * @retval -ENOEXEC is returned if the modem returned ERROR.
  * @retval -EMSGSIZE is returned if the supplied buffer is to small or NULL.
  * @retval -EIO is returned if the function failed to send the command.
+ * @retval -EHOSTDOWN is returned if bsdlib is shutdown.
  *
  */
 int at_cmd_write(const char *const cmd,

--- a/include/modem/bsdlib.h
+++ b/include/modem/bsdlib.h
@@ -23,6 +23,14 @@ extern "C" {
 int bsdlib_init(void);
 
 /**
+ * @brief Makes a thread sleep until next time bsdlib_init() is called.
+ *
+ * When bsdlib_shutdown() is called a thread can call this function to be
+ * woken up next time bsdlib_init() is called.
+ */
+void bsdlib_shutdown_wait(void);
+
+/**
  * @brief Get the last return value of bsdlib_init.
  *
  * This function can be used to access the last return value of

--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -418,6 +418,8 @@ static int nrf_to_z_dns_error_code(int nrf_error)
 		return DNS_EAI_NONAME;
 	case NRF_EINPROGRESS:
 		return DNS_EAI_INPROGRESS;
+	case NRF_ENETUNREACH:
+		errno = ENETUNREACH;
 	default:
 		return DNS_EAI_SYSTEM;
 	}


### PR DESCRIPTION
I am working on an update to bsdlib to make it possible to run shutdown and init in multiple subsequent sequences. This has some implications for some of the services in NCS that depends on bsdlib because a shutdown of bsdlib will invalidate any socket used by and component in NCS. A shutdown will wake all threads that is sleeping on a socket (in a recv call for instance) and return EHOSTDOWN. 

* The thread in the at_cmd service will go to sleep on bsdlib_shutdown and wakeup and resume operation in bsdlib_ini.
* The thread in the gps driver will go to sleep on bsdlib_shutdown and wakeup on bsdlib_init(). It the GPS driver was in started started it will be reset to initialized state. 
* The thread in the download client will be terminated on bsdlib_shutdown.

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>