### PR TITLE
doc: add link to nRF52 user guide

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -19,11 +19,11 @@
 
 .. |nRF9160DK| replace:: nRF9160 DK board (PCA10090) - see :ref:`ug_nrf9160`
 .. |nRF5340DK| replace:: nRF5340 PDK board (PCA10095) - see :ref:`ug_nrf5340`
-.. |nRF52840DK| replace:: nRF52840 DK board (PCA10056)
-.. |nRF52833DK| replace:: nRF52833 DK board (PCA10100)
+.. |nRF52840DK| replace:: nRF52840 DK board (PCA10056) - see :ref:`ug_nrf52`
+.. |nRF52833DK| replace:: nRF52833 DK board (PCA10100) - see :ref:`ug_nrf52`
 .. |nRF51DK| replace:: nRF51 DK board (PCA10028)
-.. |nRF52DK| replace:: nRF52 DK board (PCA10040)
-.. |nRF52840Dongle| replace:: nRF52840 Dongle (PCA10059)
+.. |nRF52DK| replace:: nRF52 DK board (PCA10040) - see :ref:`ug_nrf52`
+.. |nRF52840Dongle| replace:: nRF52840 Dongle (PCA10059) - see :ref:`ug_nrf52`
 .. |Thingy91| replace:: Thingy:91 (PCA20035) - see :ref:`ug_thingy91`
 .. |nRF21540DK| replace:: nRF21540 DK board (PCA10112)
 


### PR DESCRIPTION
Add a link from the sample documentation to the "Working with
nRF52" user guide.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>