### PR TITLE
manifest: update mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -87,7 +87,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: c161f44a5e4065c235a4f5b92c3c73137ce5dd58
+      revision: 4e84208b2a105b623179c902c388b1aa9f72610f
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
Update mcuboot to fix update of mcuboot bootloader.

NCSDK-5330

Depends on https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/97

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>