### PR TITLE
doc: Remove note stating that BLE is not for production

### DIFF
--- a/doc/nrf/libraries/lib_bluetooth_services.rst
+++ b/doc/nrf/libraries/lib_bluetooth_services.rst
@@ -17,6 +17,3 @@ Bluetooth libraries and services
    :glob:
 
    ../../include/bluetooth/services/*
-
-.. note::
-   |noBLE|

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -18,9 +18,6 @@ In addition, the |NCS| provides the following samples that showcase the use of a
    ../../samples/bluetooth/*/README
    ../../samples/bluetooth/mesh/*/README
 
-.. note::
-   |noBLE|
-
 .. _nfc_samples:
 
 .. toctree::

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -4,8 +4,6 @@
 
 .. |BLE| replace:: Bluetooth LE
 
-.. |noBLE| replace:: Bluetooth Low Energy device implementations including libraries, drivers, samples, and applications are currently not recommended for production.
-
 .. |connect_terminal| replace:: Connect to the board with a terminal emulator (for example, PuTTY).
    See :ref:`putty` for the required settings.
 


### PR DESCRIPTION
This note is no longer applicable.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>