### PR TITLE
subsys: esb: Add functions to check esb transmission state

### DIFF
--- a/include/esb.h
+++ b/include/esb.h
@@ -276,6 +276,18 @@ void esb_disable(void);
  */
 bool esb_is_idle(void);
 
+/** @brief Check if the Enhanced ShockBurst module is in rx mode.
+ *
+ *  @return True if the module is in rx mode, false otherwise.
+ */
+bool esb_is_rx(void);
+
+/** @brief Check if the Enhanced ShockBurst module is in tx mode.
+ *
+ *  @return True if the module is in tx mode, false otherwise.
+ */
+bool esb_is_tx(void);
+
 /** @brief Write a payload for transmission or acknowledgement.
  *
  *  This function writes a payload that is added to the queue. When the module

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -1140,6 +1140,19 @@ bool esb_is_idle(void)
 	return (esb_state == ESB_STATE_IDLE);
 }
 
+bool esb_is_rx(void)
+{
+	return (esb_state == ESB_STATE_PRX ||
+		esb_state == ESB_STATE_PRX_SEND_ACK);
+}
+
+bool esb_is_tx(void)
+{
+	return (esb_state == ESB_STATE_PTX_TX ||
+		esb_state == ESB_STATE_PTX_RX_ACK ||
+		esb_state == ESB_STATE_PTX_TX_ACK);
+}
+
 int esb_write_payload(const struct esb_payload *payload)
 {
 	if (!esb_initialized) {


### PR DESCRIPTION
It may be useful to check if the device is in rx or tx mode.

Signed-off-by: Caspar Friedrich <c.s.w.friedrich@gmail.com>