### PR TITLE
Add TLS session cache option translation for BSD library

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -137,6 +137,9 @@ static int z_to_nrf_optname(int z_in_level, int z_in_optname,
 		case TLS_DTLS_ROLE:
 			*nrf_out_optname = NRF_SO_SEC_ROLE;
 			break;
+		case TLS_SESSION_CACHE:
+			*nrf_out_optname = NRF_SO_SEC_SESSION_CACHE;
+			break;
 		default:
 			retval = -1;
 			break;
@@ -650,6 +653,8 @@ static int nrf91_socket_offload_setsockopt(void *obj, int level, int optname,
 		nrf_rcvtimeo.tv_usec = ((struct timeval *)optval)->tv_usec;
 		nrf_optval = &nrf_rcvtimeo;
 		nrf_optlen = sizeof(struct nrf_timeval);
+	} else if ((level == SOL_TLS) && (optname == TLS_SESSION_CACHE)) {
+		nrf_optlen = sizeof(nrf_sec_session_cache_t);
 	}
 
 	retval = nrf_setsockopt(sd, nrf_level, nrf_optname, nrf_optval,

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 04f51e004c0f91f361727a55a765c32338f906c8
+      revision: 4ec7ec210e45903faf07362dc32052f32f44b366
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
lib: bsdlib: Add translation of TLS_SESSION_CACHE

Translate TLS_SESSION_CACHE socket option to nRF sockets
equivalent.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>