### PR TITLE
[DNM] west.yml: Enable mcuboot with single slot application support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: dc9464d003cb8fc6cc11aaf713f700928c9fc398
+      revision: pull/99/head
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
Elevates mcuboot revision to include single slot application support.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Depends on: https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/99