### PR TITLE
doc: Fix broken build after SUPL msc merge

### DIFF
--- a/include/supl_os_client.rst
+++ b/include/supl_os_client.rst
@@ -61,7 +61,7 @@ The following image shows the steps in the SUPL client connection session.
    SET=>SLP      [label="SUPL START (session-id, lid, SET capabilities)"];
    SET<=SLP      [label="SUPL RESPONSE (session-id, posmethod)"];
    SET=>SLP      [label="SUPL POS INIT (session-id, lid, SET capabilities)"];
-   SET..SLP [linecolor="#00a9ce", textcolor="#00a9ce", label="\nloop 1..N times"];
+   SET..SLP [linecolor="#00a9ce", textcolor="#00a9ce", label="loop 1..N times"];
    SET<=SLP      [label="SUPL POS (session-id, LPP)"];
    ...;
    SET..SLP [linecolor="#00a9ce"];


### PR DESCRIPTION
PR #2009 introduced changes to the SUPL rST file including a msc block. This is currently breaking the build with:

```
writing output... [ 90%] include/supl_os_client

Exception occurred:
  File "/home/utzig/.pyenv/versions/3.7.4/lib/python3.7/site-packages/sphinxcontrib/mscgen.py", line 171, in render_msc_html
    self.builder.warn('mscgen code %r: ' % code + str(exc))
AttributeError: 'StandaloneHTMLBuilder' object has no attribute 'warn'
The full traceback has been saved in /tmp/sphinx-err-qlho2z7s.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make[3]: *** [CMakeFiles/nrf-html.dir/build.make:77: CMakeFiles/nrf-html] Error 2
make[2]: *** [CMakeFiles/Makefile2:470: CMakeFiles/nrf-html.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:559: CMakeFiles/nrf.dir/rule] Error 2
make: *** [Makefile:333: nrf] Error 2
```

It seems to be related to a label including a '\n'.

The current setup has sphinx==2.4.4 and sphinxcontrib-mscgen==0.5.