### PR TITLE
lib: at_host: Use CR termination by default

### DIFF
--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -42,7 +42,7 @@ config AT_HOST_UART_INIT_TIMEOUT
 
 choice
 	prompt "Termination Mode"
-	default LF_TERMINATION
+	default CR_TERMINATION
 	depends on AT_HOST_LIBRARY
 	help
 		Sets the termination ending from the serial terminal


### PR DESCRIPTION
Revert to using CR termination for AT commands instead of LF
termination. LF termination was needed for inputting SMS commands
using the AT host, but it causes usability issued with commonly
used terminal applications.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>