### PR TITLE
Expose MQTT topics AWS IoT and nRF Cloud libs for received data

### DIFF
--- a/include/net/aws_iot.h
+++ b/include/net/aws_iot.h
@@ -28,7 +28,8 @@ extern "C" {
  *         topic that will be published to.
  */
 enum aws_iot_topic_type {
-	AWS_IOT_SHADOW_TOPIC_GET = 0x1,
+	AWS_IOT_SHADOW_TOPIC_UNKNOWN = 0x0,
+	AWS_IOT_SHADOW_TOPIC_GET,
 	AWS_IOT_SHADOW_TOPIC_UPDATE,
 	AWS_IOT_SHADOW_TOPIC_DELETE
 };
@@ -53,16 +54,6 @@ enum aws_iot_evt_type {
 	AWS_IOT_EVT_FOTA_ERASE_DONE,
 };
 
-/** @brief Struct with data received from AWS IoT broker. */
-struct aws_iot_evt {
-	/** Type of event. */
-	enum aws_iot_evt_type type;
-	/** Pointer to data received from the AWS IoT broker. */
-	char *ptr;
-	/** Length of data. */
-	size_t len;
-};
-
 /** @brief AWS IoT topic data. */
 struct aws_iot_topic_data {
 	/** Type of shadow topic that will be published to. */
@@ -71,6 +62,18 @@ struct aws_iot_topic_data {
 	char *str;
 	/** Length of application specific topic. */
 	size_t len;
+};
+
+/** @brief Struct with data received from AWS IoT broker. */
+struct aws_iot_evt {
+	/** Type of event. */
+	enum aws_iot_evt_type type;
+	/** Pointer to data received from the AWS IoT broker. */
+	char *ptr;
+	/** Length of data. */
+	size_t len;
+	/** Topic the data was received on. **/
+	struct aws_iot_topic_data topic;
 };
 
 /** @brief Structure used to declare a list of application specific topics

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -75,6 +75,14 @@ struct nrf_cloud_data {
 	const void *ptr;
 };
 
+/**@brief MQTT topic. */
+struct nrf_cloud_topic {
+	/** Length of the topic. */
+	u32_t len;
+	/** Pointer to the topic. */
+	const void *ptr;
+};
+
 /**@brief Sensors that are supported by the device. */
 struct nrf_cloud_sensor_list {
 	/** Size of the list. */
@@ -113,7 +121,10 @@ struct nrf_cloud_evt {
 	enum nrf_cloud_evt_type type;
 	/** Any status associated with the event. */
 	u32_t status;
+	/** Received data. */
 	struct nrf_cloud_data data;
+	/** Topic on which data was received. */
+	struct nrf_cloud_topic topic;
 };
 
 /**

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -472,6 +472,9 @@ static void mqtt_evt_handler(struct mqtt_client *const c,
 		cloud_evt.type = CLOUD_EVT_DATA_RECEIVED;
 		cloud_evt.data.msg.buf = payload_buf;
 		cloud_evt.data.msg.len = p->message.payload.len;
+		cloud_evt.data.msg.endpoint.type = CLOUD_EP_TOPIC_MSG;
+		cloud_evt.data.msg.endpoint.str = p->message.topic.topic.utf8;
+		cloud_evt.data.msg.endpoint.len = p->message.topic.topic.size;
 
 		cloud_notify_event(aws_iot_backend, &cloud_evt,
 				   config->user_data);
@@ -479,6 +482,9 @@ static void mqtt_evt_handler(struct mqtt_client *const c,
 		aws_iot_evt.type = AWS_IOT_EVT_DATA_RECEIVED;
 		aws_iot_evt.ptr = payload_buf;
 		aws_iot_evt.len = p->message.payload.len;
+		aws_iot_evt.topic.type = AWS_IOT_SHADOW_TOPIC_UNKNOWN;
+		aws_iot_evt.topic.str = p->message.topic.topic.utf8;
+		aws_iot_evt.topic.len = p->message.topic.topic.size;
 		aws_iot_notify_event(&aws_iot_evt);
 #endif
 

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -36,11 +36,13 @@ enum nct_cc_opcode {
 
 struct nct_dc_data {
 	struct nrf_cloud_data data;
+	struct nrf_cloud_topic topic;
 	u32_t id;
 };
 
 struct nct_cc_data {
 	struct nrf_cloud_data data;
+	struct nrf_cloud_topic topic;
 	u32_t id;
 	enum nct_cc_opcode opcode;
 };

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -305,6 +305,10 @@ static void api_event_handler(const struct nrf_cloud_evt *nrf_cloud_evt)
 		evt.type = CLOUD_EVT_DATA_RECEIVED;
 		evt.data.msg.buf = (char *)nrf_cloud_evt->data.ptr;
 		evt.data.msg.len = nrf_cloud_evt->data.len;
+		evt.data.msg.endpoint.type = CLOUD_EP_TOPIC_MSG;
+		evt.data.msg.endpoint.str =
+			(char *)nrf_cloud_evt->topic.ptr;
+		evt.data.msg.endpoint.len = nrf_cloud_evt->topic.len;
 
 		cloud_notify_event(nrf_cloud_backend, &evt, config->user_data);
 		break;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -225,6 +225,8 @@ static int handle_device_config_update(const struct nct_evt *const evt,
 	}
 
 	cloud_evt.data = evt->param.cc->data;
+	cloud_evt.topic = evt->param.cc->topic;
+
 	nfsm_set_current_state_and_notify(nfsm_get_current_state(), &cloud_evt);
 
 	return err;
@@ -488,6 +490,7 @@ static int dc_rx_data_handler(const struct nct_evt *nct_evt)
 	struct nrf_cloud_evt cloud_evt = {
 		.type = NRF_CLOUD_EVT_RX_DATA,
 		.data = nct_evt->param.dc->data,
+		.topic = nct_evt->param.dc->topic,
 	};
 
 	/* All data is forwared to the app */

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -719,6 +719,8 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 			cc.id = p->message_id;
 			cc.data.ptr = nct.payload_buf;
 			cc.data.len = p->message.payload.len;
+			cc.topic.len = p->message.topic.topic.size;
+			cc.topic.ptr = p->message.topic.topic.utf8;
 
 			evt.type = NCT_EVT_CC_RX_DATA;
 			evt.param.cc = &cc;
@@ -728,6 +730,8 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 			dc.id = p->message_id;
 			dc.data.ptr = nct.payload_buf;
 			dc.data.len = p->message.payload.len;
+			dc.topic.len = p->message.topic.topic.size;
+			dc.topic.ptr = p->message.topic.topic.utf8;
 
 			evt.type = NCT_EVT_DC_RX_DATA;
 			evt.param.dc = &dc;


### PR DESCRIPTION
net: lib: aws_iot: Include topic in RX events

Include information about which topic the data arrived on in
the data RX event.

---
net: lib: nrf_cloud: Include topic in nRF Cloud events 

Add MQTT topics to transport event structures. Propagate to
nRF Cloud events and cloud API events when data is received.
