### PR TITLE
samples: openthread: Add support for additional features

### DIFF
--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -16,7 +16,35 @@ The amount of commands you can test depends on the application configuration.
 This sample has Commisioner, Joiner, and Border Router roles enabled by default.
 
 If used alone, the sample allows you to test the network status.
-It is recomended to use at least two development kits running the same sample to be able to test communication.
+It is recommended to use at least two development kits running the same sample to be able to test communication.
+
+.. _ot_cli_sample_radio:
+
+Additional radio features for CLI sample
+========================================
+
+The Thread CLI sample supports additional radio features:
+
+* Power Amplifier and Low Noise Amplifier Front-End Module (PA/LNA FEM).
+* Antenna diversity FEM feature.
+* Packet Traffic Arbiter (PTA) for systems with multiple radio modules.
+
+For more details about each of those features refer to :ref:`ug_thread`.
+
+.. _ot_cli_sample_radio_enabling:
+
+Enabling additional radio features
+----------------------------------
+
+To enable additional radio features for the CLI sample, modify :makevar:`CONF_FILE` by applying proper configuration files before `Building and running`_ the sample.
+
+Three configuration overlay files are provided in the sample, one for each feature:
+
+* :file:`overlay-ant_div.conf` - Enables support for the antenna diversity FEM feature in automated RX mode.
+* :file:`overlay-pa_lna.conf` - Enables support for PA/LNA FEM feature.
+* :file:`overlay-wifi_coex.conf` - Enables support for PTA for systems with multiple radio modules.
+
+For more information about using configuration overlay files, see :ref:`important-build-vars` in the Zephyr documentation.
 
 Requirements
 ************
@@ -92,6 +120,7 @@ After building the sample and programming it to your development kit, test it by
 
          uart:~$ ot ping fdde:ad00:beef:0:3102:d00b:5cbe:a61
          16 bytes from fdde:ad00:beef:0:3102:d00b:5cbe:a61: icmp_seq=1 hlim=64 time=22ms
+
 
 Dependencies
 ************

--- a/samples/openthread/cli/overlay-ant_div.conf
+++ b/samples/openthread/cli/overlay-ant_div.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# enable radio driver support for Antena Diversity FEM feature
+CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_MODE_AUTO=y
+
+#update PIN assignment
+# P1.12
+CONFIG_IEEE802154_NRF5_ANT_DIVERSITY_PIN=44

--- a/samples/openthread/cli/overlay-pa_lna.conf
+++ b/samples/openthread/cli/overlay-pa_lna.conf
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# enable radio support for PA/LNA FEM feature
+CONFIG_IEEE802154_NRF5_FEM_PRESENT=y
+
+#update PIN assignment
+# P1.10
+CONFIG_IEEE802154_NRF5_FEM_PA_PIN=42
+# P1.06
+CONFIG_IEEE802154_NRF5_FEM_LNA_PIN=38
+# P1.05
+CONFIG_IEEE802154_NRF5_FEM_PDN_PIN=37

--- a/samples/openthread/cli/overlay-wifi_coex.conf
+++ b/samples/openthread/cli/overlay-wifi_coex.conf
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# enable WiFi Coexistence radio module
+CONFIG_IEEE802154_NRF5_WIFI_COEX=y
+
+#update PIN assignment
+# P0.13
+CONFIG_IEEE802154_NRF5_WIFI_COEX_REQ_PIN=13
+# P0.14
+CONFIG_IEEE802154_NRF5_WIFI_COEX_PRIO_PIN=14
+#P0.24/button 3
+CONFIG_IEEE802154_NRF5_WIFI_COEX_GRA_PIN=24


### PR DESCRIPTION
Added support for FEMs Antenna Diversity and PA/LNA features.
Added support for WiFi coexistence feature
Enabled Commissioner, Joiner and Border Router OpenThread roles in
default sample configuration file (plus two smaller ones)
Updated documentation to reflect changes done to the sample.

NOTE: As the FEM/coex features are not yet merged they were not tested yet