### PR TITLE
doc: Fix nrf links to projects in other repos

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -74,12 +74,15 @@ KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
 # Sphinx extensions within.
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, 'doc', 'extensions'))
 
+# Let Sphinx find our extensions.
+sys.path.append(os.path.join(NRF_BASE, 'scripts', 'sphinx_extensions'))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.intersphinx',
               'breathe',
+              'interbreathe',
               'sphinx.ext.ifconfig',
               'sphinxcontrib.mscgen',
               'sphinx_tabs.tabs',

--- a/scripts/sphinx_extensions/interbreathe/__init__.py
+++ b/scripts/sphinx_extensions/interbreathe/__init__.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from sphinx.transforms.post_transforms import SphinxPostTransform
+from sphinx import addnodes
+
+
+__version__ = '0.1.0'
+
+
+class DoxygenIdentifierReferenceResolver(SphinxPostTransform):
+
+    # must run before sphinx ReferenceResolver
+    default_priority = 5
+    # only resolve identifier xrefs for these domains
+    domains = set(['c', 'cpp'])
+
+    def run(self, **kwargs):
+        for node in self.document.traverse(addnodes.pending_xref):
+            if node['reftype'] != 'identifier':
+                continue
+
+            if 'refdomain' not in node or node['refdomain'] not in self.domains:
+                continue
+
+            # skip when information required by intersphinx is available already
+            if 'refdoc' in node:
+                continue
+
+            nodecopy = node.deepcopy()
+            contnode = node[0].deepcopy()
+
+            # 'refdoc' is used by intersphinx to correctly adjust relative
+            # paths when resolving external references
+            nodecopy['refdoc'] = self.env.docname
+
+            newnode = self.app.emit_firstresult('missing-reference', self.env,
+                                                nodecopy, contnode)
+            if newnode is not None:
+                node.replace_self(newnode)
+
+
+def setup(app):
+    app.add_post_transform(DoxygenIdentifierReferenceResolver)


### PR DESCRIPTION
nRF Connect SDK doxygen based links that refer to other projects, like Zephyr, nrfxlib, etc, are broken because intersphinx is unable to resolve those references. This happens because breathe and the domain parsers (c/cpp) don't add enough metadata about which file the reference comes from, so intersphinx is not able to do proper relative path resolution.

While the issue is not fixed in a proper way upstream, I made a small python package that should patch those pending xrefs with the required metadata and fix the links.

JIRA: NCSDK-3039