### PR TITLE
lib: Fix MPSL build without BLE LL library

### DIFF
--- a/lib/multithreading_lock/multithreading_lock.c
+++ b/lib/multithreading_lock/multithreading_lock.c
@@ -8,11 +8,9 @@
 
 static K_SEM_DEFINE(mpsl_lock, 1, 1);
 
-int multithreading_lock_acquire(int32_t timeout)
+int multithreading_lock_acquire(k_timeout_t timeout)
 {
-	return k_sem_take(&mpsl_lock,
-			  ((timeout == K_FOREVER || timeout == K_NO_WAIT) ?
-			   timeout : K_MSEC(timeout)));
+	return k_sem_take(&mpsl_lock, timeout);
 }
 
 void multithreading_lock_release(void)

--- a/lib/multithreading_lock/multithreading_lock.h
+++ b/lib/multithreading_lock/multithreading_lock.h
@@ -40,13 +40,13 @@ extern "C" {
  * This API call will be blocked for the time specified by @p timeout and then
  * return error code.
  *
- * @param[in] timeout     Timeout value (in milliseconds) for the locking API.
+ * @param[in] timeout     Timeout value for the locking API.
  *
  * @retval 0              Success
  * @retval - ::EBUSY      Returned without waiting.
  * @retval - ::EAGAIN     Waiting period timed out.
  */
-int multithreading_lock_acquire(int timeout);
+int multithreading_lock_acquire(k_timeout_t timeout);
 
 /** @brief Unlock the lock.
  *


### PR DESCRIPTION
When building a project using MPSL without BLE LL library, there was a
compilation error.