### PR TITLE
OpenThread CLI sample: enable certification features

### DIFF
--- a/doc/nrf/ug_thread.rst
+++ b/doc/nrf/ug_thread.rst
@@ -132,14 +132,14 @@ Configuring this process is optional, because the Thread :ref:`openthread_sample
 If you want to manually enable the Thread network Commissioner role on a device, set the following Kconfig options to the provided values:
 
 * :option:`CONFIG_OPENTHREAD_COMMISSIONER` to ``y``.
-* :option:`CONFIG_MBEDTLS_HEAP_SIZE` to ``8192``.
+* :option:`CONFIG_MBEDTLS_HEAP_SIZE` to ``10240``.
 
 To enable the Thread network Joiner role on a device, set the following Kconfig options to the provided values:
 
 * :option:`CONFIG_OPENTHREAD_JOINER` to ``y``.
-* :option:`CONFIG_MBEDTLS_HEAP_SIZE` to ``8192``.
+* :option:`CONFIG_MBEDTLS_HEAP_SIZE` to ``10240``.
 
-The MBEDTLS heap size needs to be increased for both Commissioner and Joiner, because the joining process is memory-consuming and requires at least 8 KB of RAM.
+The MBEDTLS heap size needs to be increased for both Commissioner and Joiner, because the joining process is memory-consuming and requires at least 10 KB of RAM.
 
 You can also configure how the commissioning process is to be started:
 

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -13,7 +13,7 @@ OpenThread CLI is integrated into the system shell accessible over serial connec
 To indicate a Thread command, the ``ot`` keyword needs to precede the command.
 
 The amount of commands you can test depends on the application configuration.
-For example, because commissioning is disabled by default, the commissioning commands are not available.
+This sample has Commisioner, Joiner, and Border Router roles enabled by default.
 
 If used alone, the sample allows you to test the network status.
 It is recomended to use at least two development kits running the same sample to be able to test communication.
@@ -42,7 +42,6 @@ Building and running
 |enable_thread_before_testing|
 
 .. include:: /includes/build_and_run.txt
-
 
 Testing
 =======

--- a/samples/openthread/cli/prj.conf
+++ b/samples/openthread/cli/prj.conf
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
 # Generic networking options
 CONFIG_NETWORKING=y
 CONFIG_NET_UDP=y
@@ -39,6 +45,16 @@ CONFIG_OPENTHREAD_L2_DEBUG=y
 CONFIG_OPENTHREAD_L2_LOG_LEVEL_INF=y
 
 CONFIG_OPENTHREAD_CHANNEL=11
+
+# Enable joiner and commissioner optional features
+CONFIG_OPENTHREAD_COMMISSIONER=y
+CONFIG_OPENTHREAD_JOINER=y
+CONFIG_MBEDTLS_HEAP_SIZE=10240
+
+# Other optional OpenThread features
+CONFIG_OPENTHREAD_DHCP6_CLIENT=y
+CONFIG_OPENTHREAD_SLAAC=y
+CONFIG_OPENTHREAD_BORDER_ROUTER=y
 
 # Thread by default registers quite a lot addresses.
 CONFIG_NET_IF_UNICAST_IPV6_ADDR_COUNT=6


### PR DESCRIPTION
Enabled OpenThread features required by certification.
Updated documentation.
Updated minimum mbed TLS heap size as the value in user guide seems to be too small.

The changes were extracted from https://github.com/nrfconnect/sdk-nrf/pull/2299 as there is a risk that FEM/coex/ant div features may not be merged on time