### PR TITLE
doc: Fix full path output for Kconfig.modules

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -380,7 +380,8 @@ add_custom_target(
     KCONFIG_DOC_MODE=1
       ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/genrest.py ${KCONFIG_RST_OUT}
         --separate-all-index
-        --modules Zephyr,zephyr,${ZEPHYR_BASE}
+        --modules BuildDir,builddir,${CMAKE_BINARY_DIR}
+                  Zephyr,zephyr,${ZEPHYR_BASE}
                   nRF,nrf,${NRF_BASE}
                   nrfxlib,nrfxlib,${NRFXLIB_BASE}
 


### PR DESCRIPTION
When Kconfig documentation pages reference `Kconfig.modules` which is auto-generated in the build dir, the full path is being shown. Pass the "BuildDir" string to genrest.py script so that <BuildDir> is shown instead. The output will look like this:

→ \<Zephyr>/Kconfig.zephyr:9 → \<BuildDir>/Kconfig.modules:5 →

The drawback is that this changes generates a new warning:

index-builddir.rst:20: WARNING: Insufficient data supplied (1 row(s)); no data remaining for table body, required by "list-table" directive.

JIRA: NCSDK-1459