### PR TITLE
net: lib: fota_download: Add support to set used APN

### DIFF
--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -77,13 +77,14 @@ int fota_download_init(fota_download_callback_t client_callback);
  * @param file Filepath to the file you wish to download.
  * @param sec_tag Security tag you want to use with HTTPS set to -1 to Disable.
  * @param port Port which to connect to. Set to 0 for default HTTP/HTTPS port.
+ * @param apn Access Point Name to use or NULL to use the default APN.
  *
  * @retval 0	     If download has started successfully.
  * @retval -EALREADY If download is already ongoing.
  *                   Otherwise, a negative value is returned.
  */
 int fota_download_start(const char *host, const char *file, int sec_tag,
-			u16_t port);
+			u16_t port, const char *apn);
 
 #ifdef __cplusplus
 }

--- a/samples/nrf9160/http_application_update/src/main.c
+++ b/samples/nrf9160/http_application_update/src/main.c
@@ -78,6 +78,7 @@ static void app_dfu_transfer_start(struct k_work *unused)
 {
 	int retval;
 	int sec_tag;
+	char *apn = NULL;
 
 #ifndef CONFIG_USE_HTTPS
 	sec_tag = -1;
@@ -88,7 +89,8 @@ static void app_dfu_transfer_start(struct k_work *unused)
 	retval = fota_download_start(CONFIG_DOWNLOAD_HOST,
 				     CONFIG_DOWNLOAD_FILE,
 				     sec_tag,
-				     CONFIG_DOWNLOAD_PORT);
+				     CONFIG_DOWNLOAD_PORT,
+				     apn);
 	if (retval != 0) {
 		/* Re-enable button callback */
 		gpio_pin_interrupt_configure(gpiob, DT_ALIAS_SW0_GPIOS_PIN,

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -220,6 +220,7 @@ static int job_update_accepted(struct mqtt_client *const client,
 {
 	int sec_tag = -1;
 	u16_t port = 0;
+	char *apn = NULL;
 	int err = get_published_payload(client, payload_buf, payload_len);
 
 	if (err) {
@@ -250,7 +251,8 @@ static int job_update_accepted(struct mqtt_client *const client,
 		sec_tag = CONFIG_AWS_FOTA_DOWNLOAD_SECURITY_TAG
 #endif
 
-		err = fota_download_start(hostname, file_path, sec_tag, port);
+		err = fota_download_start(hostname, file_path, sec_tag, port,
+					  apn);
 		if (err) {
 			LOG_ERR("Error (%d) when trying to start firmware "
 				"download", err);

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -204,13 +204,14 @@ static void download_with_offset(struct k_work *unused)
 }
 
 int fota_download_start(const char *host, const char *file, int sec_tag,
-			u16_t port)
+			u16_t port, const char *apn)
 {
 	int err = -1;
 
 	struct download_client_cfg config = {
-		.sec_tag = sec_tag,
 		.port = port,
+		.sec_tag = sec_tag,
+		.apn = apn,
 	};
 
 	if (host == NULL || file == NULL || callback == NULL) {

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -25,6 +25,7 @@ char buf[1024];
 #define NO_SPACE "s0s1"
 #define NO_TLS -1
 #define DEFAULT_PORT 0
+#define DEFAULT_APN NULL
 
 /* Stubs and mocks */
 bool dfu_ctx_mcuboot_set_b1_file__s0_active;
@@ -133,7 +134,8 @@ static void test_fota_download_start(void)
 	s1_version = 1;
 	expect_s0_active = false;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_PORT);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_PORT,
+				  DEFAULT_APN);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
 		      "Incorrect param for s0_active");
@@ -141,7 +143,8 @@ static void test_fota_download_start(void)
 	s0_version = 2;
 	s1_version = 1;
 	expect_s0_active = true;
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_PORT);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_PORT,
+				  DEFAULT_APN);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
 		      "Incorrect param for s0_active");
@@ -154,14 +157,16 @@ static void test_fota_download_start(void)
 	/* update set to null indicates to use original file param */
 	dfu_ctx_mcuboot_set_b1_file__update = NULL;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_PORT);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_PORT,
+				  DEFAULT_APN);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S0_S1) == 0, NULL);
 
 	/* update set to not null indicates to use update for file param */
 	dfu_ctx_mcuboot_set_b1_file__update = S1;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_PORT);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_PORT,
+				  DEFAULT_APN);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S1) == 0, NULL);
 }


### PR DESCRIPTION
Download client library supports setting the Access Point Name used for
downloading the data, but the functionality has not been available in FOTA
download library.

Signed-off-by: Tommi Kangas <tommi.kangas@gmail.com>