### PR TITLE
nrf9160: http_application_update: Change hosting for default file

### DIFF
--- a/samples/nrf9160/http_application_update/prj.conf
+++ b/samples/nrf9160/http_application_update/prj.conf
@@ -54,7 +54,7 @@ CONFIG_MODEM_KEY_MGMT=y
 CONFIG_BOOTLOADER_MCUBOOT=y
 
 # Sample configuration
-CONFIG_DOWNLOAD_HOST="s3.amazonaws.com"
+CONFIG_DOWNLOAD_HOST="nrfconnectsdk.s3.eu-central-1.amazonaws.com"
 CONFIG_DOWNLOAD_PORT=0
-CONFIG_DOWNLOAD_FILE="nordic-firmware-files/c1838e44-9d6f-4f41-990e-70b4e60770ce"
+CONFIG_DOWNLOAD_FILE="app_update.bin"
 CONFIG_APPLICATION_VERSION=1


### PR DESCRIPTION
Changing hosting service for default update file to a new AWS bucket.