### PR TITLE
doc: bootloader: Add documentation for external flash

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -46,3 +46,5 @@
    See :ref:`ug_zigbee` for more information.
 
 .. |nrf_desktop_module_event_note| replace:: See the :ref:`nrf_desktop_architecture` for more information about the event-based communication in the nRF Desktop application and about how to read this table.
+
+.. |how_to_configure| replace:: See :ref:`configure_application` for information on how to set the required configuration options temporarily or permanently.

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -384,6 +384,8 @@ For example, see the following definitions for default regions:
     NRF_FLASH_DRV_NAME           # Device name
     )
 
+.. _pm_external_flash:
+
 External flash
 ==============
 


### PR DESCRIPTION
Add documentation for how to use external flash in MCUBoot to the bootloader
user guide.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>