### PR TITLE
zigbee: Link Zigbee subsys based on Kconfig option

### DIFF
--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -22,7 +22,7 @@ add_subdirectory_ifdef(CONFIG_DFU_TARGET		dfu)
 add_subdirectory_ifdef(CONFIG_IS_SPM		spm)
 add_subdirectory_ifdef(CONFIG_TRUSTED_EXECUTION_NONSECURE nonsecure)
 add_subdirectory_ifdef(CONFIG_MPSL mpsl)
-add_subdirectory_ifdef(CONFIG_ZIGBEE zigbee)
+add_subdirectory_ifdef(CONFIG_APP_LINK_WITH_ZIGBEE zigbee)
 
 if (CONFIG_NFC_T2T_NRFXLIB OR
     CONFIG_NFC_T4T_NRFXLIB OR

--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -7,7 +7,7 @@
 menuconfig ZIGBEE
 	bool "Enable Zigbee stack"
 	select FLOAT
-	select APP_LINK_WITH_ZBOSS
+	imply APP_LINK_WITH_ZBOSS if APP_LINK_WITH_ZIGBEE
 	imply COUNTER
 	imply COUNTER_TIMER3
 	imply NRF_802154_RADIO_DRIVER
@@ -179,9 +179,15 @@ config RADIO_STATISTICS
 endmenu #menu "ZBOSS osif configuration"
 
 config APP_LINK_WITH_ZIGBEE
-	bool
+	bool "Link application with Zigbee subsystem"
 	default y
 	help
-	  Link application with Zigbee subsystem
+	  This option enables compilation and linkage of Zigbee subsystem.
+	  It consists of ZBOSS OSIF implementation and helper functions.
+
+	  It was introduced in order to:
+	   - Compile ZBOSS stack with backward incompatible API.
+	   - Write unit tests that uses Zigbee's Kconfig options and generate
+	     ZBOSS library mocks.
 
 endif #ZIGBEE


### PR DESCRIPTION
In case APP_LINK_WITH_ZIGBEE is not set, none of Zigbee subsys sources should be included in the final application.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>