### PR TITLE
dfu: dfu_target_modem: Bugfix for failure on chunks larger than 2048

### DIFF
--- a/subsys/dfu/src/dfu_target_modem.c
+++ b/subsys/dfu/src/dfu_target_modem.c
@@ -193,11 +193,18 @@ int dfu_target_modem_write(const void *const buf, size_t len)
 	int err = 0;
 	int sent = 0;
 	int modem_error = 0;
+	int send_result = 0;
 
-	sent = send(fd, buf, len, 0);
-	if (sent > 0) {
-		offset += len;
-		return 0;
+	while (send_result >= 0) {
+		send_result = send(fd, (((u8_t *)buf) + sent),
+				   (len - sent), 0);
+		if (send_result > 0) {
+			sent += send_result;
+			if (sent >= len) {
+				offset += len;
+				return 0;
+			}
+		}
 	}
 
 	if (errno != ENOEXEC) {


### PR DESCRIPTION
The call to send() in the modem DFU handler only checked for pass/fail
results, and didn't notice if only partial data had been written, which
could happen if a chunk larger than 2048 bytes was being written.
Adjust to loop until either failure condition or all data has been
sent.

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>