### PR TITLE
tests: crypto: Add oberon test support

### DIFF
--- a/tests/crypto/overlay-backend-oberon.conf
+++ b/tests/crypto/overlay-backend-oberon.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_OBERON_BACKEND=y
+CONFIG_MBEDTLS_VANILLA_BACKEND=n
+CONFIG_CC310_BACKEND=n
+CONFIG_MBEDTLS_ECP_C=y

--- a/tests/crypto/testcase.yaml
+++ b/tests/crypto/testcase.yaml
@@ -5,14 +5,19 @@ tests:
     extra_args: OVERLAY_CONFIG=overlay-backend-sw.conf
     platform_whitelist: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     tags: crypto ci_build
-  crypto.hw:
     timeout: 600
+  crypto.hw:
     extra_args: OVERLAY_CONFIG=overlay-backend-hw.conf
     platform_whitelist: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     tags: crypto ci_build
-  crypto.sw_hw:
     timeout: 100
+  crypto.sw_hw:
     extra_args: OVERLAY_CONFIG=overlay-backend-hw-sw.conf
+    platform_whitelist: nrf52840dk_nrf52840 nrf9160dk_nrf9160
+    tags: crypto ci_build
+    timeout: 200
+  crypto.oberon:
+    extra_args: OVERLAY_CONFIG=overlay-backend-oberon.conf
     platform_whitelist: nrf52840dk_nrf52840 nrf9160dk_nrf9160
     tags: crypto ci_build
     timeout: 200


### PR DESCRIPTION
Adds changes necessary to run tests/crypto with Oberon.

This PR requires:

-  ~https://github.com/nrfconnect/sdk-nrf/pull/2307 <-- nrfxlib update~ merged
-  ~https://github.com/nrfconnect/sdk-nrf/pull/2261 <-- Entropy: prefer CC310~ merged
