### PR TITLE
zigbee: Fix pending bit logic

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_transceiver.c
+++ b/subsys/zigbee/osif/zb_nrf_transceiver.c
@@ -303,7 +303,7 @@ zb_bool_t zb_trans_set_pending_bit(zb_uint8_t *addr, zb_bool_t value,
 				   zb_bool_t extended)
 {
 	LOG_DBG("Function: %s, value: %d", __func__, value);
-	if (value) {
+	if (!value) {
 		return (zb_bool_t)nrf_802154_pending_bit_for_addr_set(
 			(const u8_t *)addr, (bool)extended);
 	} else {


### PR DESCRIPTION
By default, Zigbee sets pending bit for all addresses. The radio driver API is used to clear it, so the logic has to be inverted.
This type of operation is enabled by setting the NRF_802154_SRC_ADDR_MATCH_ZIGBEE address matching method.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>