### PR TITLE
doc: Updated nRF53 User Guide for NCS 1.3.0

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -194,6 +194,8 @@
 
 .. _`OpenAMP`: https://github.com/OpenAMP/open-amp/
 
+.. _`RPMsg`: https://github.com/OpenAMP/open-amp/wiki/RPMsg-Messaging-Protocol
+
 .. _`SSL Labs`: https://www.ssllabs.com/ssltest/
 
 .. _`GNSS`: https://en.wikipedia.org/wiki/Satellite_navigation

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -9,7 +9,7 @@ Introduction
 ************
 
 nRF5340 is a wireless ultra-low power multicore System on Chip (SoC) with two fully programmable Arm Cortex-M33 processors: a network core and an application core.
-The |NCS| supports Bluetooth Low Energy communication on the nRF5340 SoC.
+The |NCS| supports Bluetooth Low Energy and NFC communication on the nRF5340 SoC.
 
 See the `nRF5340 Product Specification`_ for more information about the nRF5340 SoC.
 :ref:`zephyr:nrf5340pdk_nrf5340` gives an overview of the nRF5340 PDK support in Zephyr.
@@ -21,15 +21,15 @@ The network core is an Arm Cortex-M33 processor with a reduced feature set, desi
 
 This core is used for radio communication.
 With regards to the nRF5340 samples, this means that the network core runs the radio stack and real-time procedures.
-Currently, the following solutions are available for the network core:
 
-* Bluetooth Low Energy Controller - compatible with several BLE samples.
-  Both the BLE Controller from Zephyr and :ref:`nrfxlib:ble_controller` are supported.
-* The :ref:`radio_test` sample that runs only on the network core and is used for testing the Radio peripheral.
-  To start the network core, this sample requires any sample programmed on the application core.
-  For example, you can use :ref:`nrf5340_empty_app_core` for this purpose.
+Currently, the |NCS| provides the following solutions for the network core:
 
-In general, this core should be used for real-time processing tasks involving low-level protocols and layers.
+* :ref:`ug_ble_controller` (both the nRF Bluetooth LE Controller and the Zephyr Bluetooth LE Controller)
+* Samples that directly use the radio peripheral
+
+See `Network samples`_ for more information.
+
+In general, this core should be used for real-time processing tasks involving low-level radio protocol layers.
 
 The board name for the network core in Zephyr is ``nrf5340pdk_nrf5340_cpunet``.
 
@@ -40,18 +40,18 @@ The application core is a full-featured Arm Cortex-M33 processor including DSP i
 
 Currently, the |NCS| provides the following solutions for the application core:
 
-* high-level radio stack (the host part of the Bluetooth Low Energy stack) and application logic,
-* samples running only on the application core (for example, NFC samples with nRF53 support).
+* High-level radio stack (the host part of the Bluetooth Low Energy stack) and application logic
+* Samples running only on the application core (for example, NFC samples with nRF5340 support)
 
-In general, this core should be used for tasks that require high performance and application-level logic.
+See `Application samples`_ for more information.
 
-The board name for the application core in Zephyr is ``nrf5340pdk_nrf5340_cpuapp``.
+In general, this core should be used for tasks that require high performance and for application-level logic.
 
 The user application can run in the secure or non-secure domain.
-Therefore, it can be built for two different board targets:
+Therefore, it can be built for two different build targets:
 
-* ``nrf5340pdk_nrf5340_cpuapp`` for the secure domain,
-* ``nrf5340pdk_nrf5340_cpuappns`` for the non-secure domain.
+* ``nrf5340pdk_nrf5340_cpuapp`` for the secure domain
+* ``nrf5340pdk_nrf5340_cpuappns`` for the non-secure domain
 
 When built for the ``nrf5340pdk_nrf5340_cpuappns`` board, the :ref:`nrf9160_ug_secure_partition_manager` is automatically included in the build.
 
@@ -81,41 +81,51 @@ The OpenAMP library uses the IPM SHIM layer, which in turn uses the IPC driver i
 Available samples
 *****************
 
-nRF5340 samples consist of two separate images: one that runs on the network core and one that runs on the application core.
+nRF5340 samples usually consist of two separate images: one that runs on the network core and one that runs on the application core.
+
+Most samples that support nRF5340 are not dedicated exclusively to this device, but can also be built for other chips that have the radio peripheral (for example, the nRF52 Series).
+The following subsections give a general overview of what samples can run on nRF5340.
 
 Network samples
 ===============
 
-The |NCS| provides the following samples for the nRF53 network core:
+The nRF5340 network core supports samples that directly use the radio peripheral, for example, :ref:`radio_test`.
 
-* :ref:`zephyr:bluetooth-hci-rpmsg-sample` - a Zephyr sample that implements a Bluetooth Low Energy controller.
-  This sample must be programmed to the network core to run standard Bluetooth Low Energy samples on nRF5340.
+For Bluetooth Low Energy, the |NCS| provides the :ref:`zephyr:bluetooth-hci-rpmsg-sample` sample.
+This Zephyr sample is designed specifically to enable the Bluetooth LE Controller functionality on a remote MCU (for example, the nRF5340 network core) using the `RPMsg`_ protocol as a transport for Bluetooth HCI.
+The sample implements the RPMsg transport using the `OpenAMP`_ library to communicate with a Bluetooth Host stack that runs on a separate core (for example, the nRF5340 application core).
 
-  You might need to adjust the Kconfig configuration of this sample to make it compatible with the peer application.
-  For example:
+This sample must be programmed to the network core to run standard Bluetooth Low Energy samples on nRF5340.
+You can choose whether to use the nRF Bluetooth LE Controller or the Zephyr Bluetooth LE Controller for this sample.
+See :ref:`ug_ble_controller` for more information.
 
-  * :option:`CONFIG_BT_MAX_CONN` must be equal to the maximum number of connections supported by the application sample.
-  * If the application sample uses a specific Bluetooth LE functionality, this functionality must be enabled in the network sample as well.
-    For example, you must modify the configuration of the network sample to make it compatible with the :ref:`ble_throughput` sample::
+You might need to adjust the Kconfig configuration of this sample to make it compatible with the peer application.
+For example:
 
-      CONFIG_BT_CTLR_TX_BUFFER_SIZE=251
-      CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+* :option:`CONFIG_BT_MAX_CONN` must be greater than or equal to the maximum number of connections configured for the Bluetooth Host in the application core firmware.
+* If the application sample uses specific Bluetooth LE functionalities, these functionalities must be enabled in the network sample as well.
+  For example, you must modify the configuration of the network sample to make it compatible with the :ref:`ble_throughput` sample::
 
-    This configuration guarantees that the network sample can handle the Bluetooth LE DLE update procedure, which is used in the :ref:`ble_throughput` sample.
+    CONFIG_BT_CTLR_TX_BUFFER_SIZE=251
+    CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 
-* :ref:`radio_test` - an sample application used for testing available modes of the Radio peripheral.
+  This configuration guarantees that the network sample can handle the Bluetooth LE DLE update procedure, which is used in the :ref:`ble_throughput` sample.
+
 
 Application samples
 ===================
 
 The |NCS| provides a series of :ref:`Bluetooth Low Energy samples <ble_samples>`, in addition to the :ref:`Bluetooth samples in Zephyr <zephyr:bluetooth-samples>`.
 Most of these samples should run on the nRF5340 PDK, but not all have been thoroughly tested.
-Samples that use non-standard features of the Bluetooth Low Energy controller, like the :ref:`ble_llpm` sample, are not supported.
-Additionally, the |NCS| NFC samples are also available for nRF53 - they run only on the application core and do not require any firmware for the network core.
+Samples that use non-standard features of the Bluetooth Low Energy Controller, like the :ref:`ble_llpm` sample, are not supported.
 
-Some samples require configuration adjustments to the :ref:`zephyr:bluetooth-hci-rpmsg-sample` sample as described in the `Network samples`_ section.
+Some Bluetooth LE samples require configuration adjustments to the :ref:`zephyr:bluetooth-hci-rpmsg-sample` sample as described in the `Network samples`_ section.
 
-These samples must be programmed to the application core, in the secure domain.
+Additionally, the |NCS| provides :ref:`NFC samples <nfc_samples>` that are available for nRF5340.
+These samples run only on the application core and do not require any firmware for the network core.
+
+When programming any of these samples to the application core, configure :option:`CONFIG_BOARD_ENABLE_CPUNET` to select whether the network core should be enabled.
+When radio protocols (Bluetooth LE, IEEE 802.15.4) are used, this option is enabled by default.
 
 
 Building and programming a sample
@@ -124,13 +134,13 @@ Building and programming a sample
 Depending on the sample, you must program only the application core (for example, when using NFC samples) or both the network and the application core.
 
 .. note::
-   On nRF53, the application core is responsible for starting the network core and connecting its GPIO pins.
-   Therefore, to run any sample on nRF53, the application core must be programmed, even if the firmware is supposed to run only on the network core.
-   You can use the :ref:`zephyr:hello_world` sample for this purpose.
+   On nRF5340, the application core is responsible for starting the network core and connecting its GPIO pins.
+   Therefore, to run any sample on nRF5340, the application core must be programmed, even if the firmware is supposed to run only on the network core, and the firmware for the application core must set :option:`CONFIG_BOARD_ENABLE_CPUNET` to ``y``.
+   You can use the :ref:`nrf5340_empty_app_core` sample for this purpose.
    For details, see the code in :file:`zephyr/boards/arm/nrf5340pdk_nrf5340/nrf5340_cpunet_reset.c`.
 
 Build and program both samples separately by following the instructions in :ref:`gs_programming_ses`.
-Make sure to use ``nrf5340pdk_nrf5340_cpunet`` as board name when building the network sample, and ``nrf5340pdk_nrf5340_cpuapp`` when building the application sample.
+Make sure to use ``nrf5340pdk_nrf5340_cpunet`` as build target when building the network sample, and ``nrf5340pdk_nrf5340_cpuapp`` or ``nrf5340pdk_nrf5340_cpuappns`` when building the application sample.
 
 
 Programming from the command line


### PR DESCRIPTION
- re-phrased the nRF53 User Guide to be more generic,
- reduced the number of direct references to samples,
- added more description for the Bluetooth hci_rpmsg example.

Ref. NCSDK-5119