### PR TITLE
applications: asset_tracker: bsec: Update to new timeout API

### DIFF
--- a/applications/asset_tracker/src/env_sensors/bsec.c
+++ b/applications/asset_tracker/src/env_sensors/bsec.c
@@ -143,6 +143,11 @@ static s64_t get_timestamp_us(void)
 	return k_uptime_get()*1000;
 }
 
+static void delay_ms(u32_t period)
+{
+	k_sleep(K_MSEC(period));
+}
+
 static void output_ready(s64_t timestamp, float iaq, u8_t iaq_accuracy,
 			float temperature, float humidity, float pressure,
 			float raw_temperature, float raw_humidity, float gas,
@@ -290,7 +295,7 @@ int env_sensors_init_and_start(struct k_work_q *work_q,
 		return ret;
 	}
 	bsec_ret = bsec_iot_init(BSEC_SAMPLE_RATE, 1.2f, bus_write,
-				bus_read, (void *)k_sleep, state_load,
+				bus_read, delay_ms, state_load,
 				config_load);
 	if (bsec_ret.bme680_status) {
 		/* Could not initialize BME680 */


### PR DESCRIPTION
Update the delay_ms() function used by bsec to follow the new
timeout API.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>

The Asset tracker on Thingy:91 was broken when the Bosch BSEC library was enabled. This is the configuration used for the precompiled builds we provide here https://www.nordicsemi.com/Software-and-tools/Prototyping-platforms/Nordic-Thingy-91/Download