### PR TITLE
lib: at_host: Expand stack size with optimizations

### DIFF
--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(at_host, CONFIG_AT_HOST_LOG_LEVEL);
 
 /* Stack definition for AT host workqueue */
 #ifdef CONFIG_SIZE_OPTIMIZATIONS
-#define AT_HOST_STACK_SIZE 512
+#define AT_HOST_STACK_SIZE 768
 #else
 #define AT_HOST_STACK_SIZE 1024
 #endif


### PR DESCRIPTION
Expands the available stack size when compiled with optimizations, to
prevent a stack overflow in at_host.