### PR TITLE
zigbee: samples: Remove broken include from CMakeList.txt

### DIFF
--- a/samples/zigbee/light_bulb/CMakeLists.txt
+++ b/samples/zigbee/light_bulb/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project("Zigbee light bulb")

--- a/samples/zigbee/light_switch/CMakeLists.txt
+++ b/samples/zigbee/light_switch/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project("Light Switch")

--- a/samples/zigbee/network_coordinator/CMakeLists.txt
+++ b/samples/zigbee/network_coordinator/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project("Zigbee coordinator")

--- a/tests/subsys/zigbee/osif/nvram/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/nvram/CMakeLists.txt
@@ -9,7 +9,6 @@ cmake_minimum_required(VERSION 3.13.1)
 # Stub for ZBOSS callout
 add_compile_definitions(zb_nvram_erase_finished=zb_nvram_erase_finished_stub)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(zigbee_osif_nvram_test)

--- a/tests/subsys/zigbee/osif/timer/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/timer/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(zigbee_osif_test)
 


### PR DESCRIPTION
This PR removes an include which prevents zibgee samples from
building.

Signed-off-by: Wojciech Bober <wojciech.bober@nordicsemi.no>