### PR TITLE
openthread: samples: Fix broken CMakeList.txt

### DIFF
--- a/samples/openthread/cli/CMakeLists.txt
+++ b/samples/openthread/cli/CMakeLists.txt
@@ -10,7 +10,7 @@ set(NRF_SUPPORTED_BOARDS
 	nrf52833dk_nrf52833
 )
 
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE}
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(openthread_cli)
 

--- a/samples/openthread/coap_client/CMakeLists.txt
+++ b/samples/openthread/coap_client/CMakeLists.txt
@@ -20,4 +20,4 @@ target_sources(app PRIVATE src/coap_client.c
 
 target_sources_ifdef(CONFIG_BT app PRIVATE src/ble_utils.c)
 
-target_include_directories(app PUBLIC ../coap_interface)
+target_include_directories(app PUBLIC ../coap_server/interface)

--- a/samples/openthread/coap_server/CMakeLists.txt
+++ b/samples/openthread/coap_server/CMakeLists.txt
@@ -10,7 +10,7 @@ set(NRF_SUPPORTED_BOARDS
 	nrf52833dk_nrf52833
 )
 
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE}
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(openthread_coap_server)
 


### PR DESCRIPTION
This PR fixes some includes which prevent Thread samples from building.

Reference: KRKNWK-6253

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>