### PR TITLE
partition_manager: add MBR offset for nrf52840dongle

### DIFF
--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -46,6 +46,11 @@ if (CONFIG_ZIGBEE)
   add_partition_manager_config(pm.yml.zboss)
 endif()
 
+if (CONFIG_BOARD_HAS_NRF5_BOOTLOADER AND (NOT CONFIG_BOOTLOADER_MCUBOOT))
+  # The nRF5 Bootloader is flashed on the device, make room for the MBR.
+  add_partition_manager_config(pm.yml.nrf5_sdk_mbr)
+endif()
+
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
 set(using_partition_manager

--- a/subsys/partition_manager/pm.yml.nrf5_sdk_mbr
+++ b/subsys/partition_manager/pm.yml.nrf5_sdk_mbr
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+nrf5_sdk_mbr:
+  placement: {after: start}
+  size: 0x1000


### PR DESCRIPTION
This is needed to correctly mirror functionality seen before
including a subsys enabled the partition manager.

Specifically, the nrf52840dongle will either use an
nRF5 SDK based bootloader or MCUBoot to program
applications. If the nRF5 SDK based bootloader
is used, we need to make room for the MBR at
the beginning of flash.

Ref: NCSDK-5551
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>