### PR TITLE
zigbee: samples: Link to BLE stack in Zigbee examples

### DIFF
--- a/samples/zigbee/light_bulb/prj.conf
+++ b/samples/zigbee/light_bulb/prj.conf
@@ -33,9 +33,13 @@ CONFIG_DK_LIBRARY=y
 # This example requires more workqueue stack
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 
-# Enable nRF ECB driver
-CONFIG_CRYPTO=y
-CONFIG_CRYPTO_NRF_ECB=y
-
 # Cryptocell is not supported through CSPRNG driver API: NCSDK-4813
 CONFIG_ENTROPY_CC310=n
+
+# BLE stack is required for MPSL compatible flash driver.
+CONFIG_BT=y
+CONFIG_BT_HCI=y
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_NRFXLIB=y
+CONFIG_BT_LL_NRFXLIB_DEFAULT=y
+CONFIG_SOC_FLASH_NRF_LL_NRFXLIB=y

--- a/samples/zigbee/light_switch/prj.conf
+++ b/samples/zigbee/light_switch/prj.conf
@@ -28,9 +28,13 @@ CONFIG_DK_LIBRARY=y
 # This example requires more workqueue stack
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 
-# Enable nRF ECB driver
-CONFIG_CRYPTO=y
-CONFIG_CRYPTO_NRF_ECB=y
-
 # Cryptocell is not supported through CSPRNG driver API: NCSDK-4813
 CONFIG_ENTROPY_CC310=n
+
+# BLE stack is required for MPSL compatible flash driver.
+CONFIG_BT=y
+CONFIG_BT_HCI=y
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_NRFXLIB=y
+CONFIG_BT_LL_NRFXLIB_DEFAULT=y
+CONFIG_SOC_FLASH_NRF_LL_NRFXLIB=y

--- a/samples/zigbee/network_coordinator/prj.conf
+++ b/samples/zigbee/network_coordinator/prj.conf
@@ -32,9 +32,13 @@ CONFIG_DK_LIBRARY=y
 # This example requires more workqueue stack
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 
-# Enable nRF ECB driver
-CONFIG_CRYPTO=y
-CONFIG_CRYPTO_NRF_ECB=y
-
 # Cryptocell is not supported through CSPRNG driver API: NCSDK-4813
 CONFIG_ENTROPY_CC310=n
+
+# BLE stack is required for MPSL compatible flash driver.
+CONFIG_BT=y
+CONFIG_BT_HCI=y
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_NRFXLIB=y
+CONFIG_BT_LL_NRFXLIB_DEFAULT=y
+CONFIG_SOC_FLASH_NRF_LL_NRFXLIB=y


### PR DESCRIPTION
MPSL requires its own version of the flash driver which is
only implemented in BLE controler. This PR links the BLE
stack so that MPSL doesn't assert on flash operations.

This also disables NRF ECB driver which is not used when BLE stack is present.

Signed-off-by: Wojciech Bober <wojciech.bober@nordicsemi.no>