### PR TITLE
partition_manager: opt-in to use pm in single image build

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -66,14 +66,14 @@ get_property(PM_SUBSYS_PREPROCESSED GLOBAL PROPERTY PM_SUBSYS_PREPROCESSED)
 # - It's the root image, and a static configuration has been provided
 # - It's the root image, and PM_IMAGES is populated.
 # - It's the root image, and other domains exist.
-# - A subsys has defined a partition.
+# - A subsys has defined a partition and CONFIG_PM_SINGLE_IMAGE is set.
 # Otherwise, return here
 if (NOT (
   (IMAGE_NAME AND is_dynamic_partition_in_domain) OR
   (NOT IMAGE_NAME AND static_configuration) OR
   (NOT IMAGE_NAME AND PM_IMAGES) OR
   (NOT IMAGE_NAME AND PM_DOMAINS) OR
-  (PM_SUBSYS_PREPROCESSED)
+  (PM_SUBSYS_PREPROCESSED AND CONFIG_PM_SINGLE_IMAGE)
   ))
   return()
 endif()

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -33,6 +33,12 @@ endif
 
 endmenu
 
+config PM_SINGLE_IMAGE
+	bool "Use the Partition Manager for single image builds"
+	help
+	  Use the Partition Manager feature to partition the device even if
+	  only a single image is included in the build.
+
 menuconfig PM_EXTERNAL_FLASH
 	bool "Support external flash in Partition Manager"
 

--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -8,6 +8,7 @@ menuconfig ZIGBEE
 	bool "Enable Zigbee stack"
 	imply FPU
 	select APP_LINK_WITH_ZBOSS
+	select PM_SINGLE_IMAGE
 	imply COUNTER
 	imply COUNTER_TIMER3
 	imply NRF_802154_RADIO_DRIVER


### PR DESCRIPTION
Prior to this a single image build withy a subsys that defined
a partition manager configuration would result in the
partition manager being invoked.

Instead, make the user opt-in to use partition manager in this
situation.

This is done to avoid breaking backwards compatibility and
require actions by downstream users.

Ref: NCSDK-5560
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>