### PR TITLE
samples: nrf9160: fix issue in SUPL session support code

### DIFF
--- a/samples/nrf9160/gps/src/supl_support.c
+++ b/samples/nrf9160/gps/src/supl_support.c
@@ -48,7 +48,7 @@ int open_supl_socket(void)
 		if (err) {
 			if (gai_cnt < GAI_ATTEMPT_COUNT) {
 				/* Sleep between retries */
-				k_sleep(K_MSEC(1000) * gai_cnt);
+				k_sleep(K_MSEC(1000 * gai_cnt));
 			} else {
 				/* Return if no success after many retries */
 				printk("Failed to resolve hostname %s on IPv4, errno: %d)\n",


### PR DESCRIPTION
A small typo in a k_sleep() call was not detected before
the function signature was changed  to use the k_timeout_t
type. A multiplication was done outside of the K_MSEC macro.

Signed-off-by: Even Falch-Larsen <even.flach-larsen@nordicsemi.ni>