### PR TITLE
Bluetooth: controller: Update BT_LL_NRFXLIB

### DIFF
--- a/applications/nrf_desktop/doc/ble_qos.rst
+++ b/applications/nrf_desktop/doc/ble_qos.rst
@@ -102,7 +102,7 @@ Bluetoooth LE controller interaction
 ====================================
 
 The module uses CRC information from the Bluetoooth LE controller to adjust the channel map.
-The CRC information is received through the vendor-specific Bluetooth HCI event (:cpp:enum:`HCI_VS_SUBEVENT_CODE_QOS_CONN_EVENT_REPORT`).
+The CRC information is received through the vendor-specific Bluetooth HCI event (:cpp:enum:`HCI_VS_SUBEVENT_QOS_CONN_EVENT_REPORT`).
 
 Additional thread
 =================

--- a/applications/nrf_desktop/src/modules/ble_qos.c
+++ b/applications/nrf_desktop/src/modules/ble_qos.c
@@ -408,14 +408,14 @@ static void hid_pkt_stats_print(u32_t ble_recv)
 static bool on_vs_evt(struct net_buf_simple *buf)
 {
 	u8_t *subevent_code;
-	hci_vs_evt_qos_conn_event_report_t *evt;
+	hci_vs_subevent_qos_conn_event_report_t *evt;
 
 	subevent_code = net_buf_simple_pull_mem(
 		buf,
 		sizeof(*subevent_code));
 
 	switch (*subevent_code) {
-	case HCI_VS_SUBEVENT_CODE_QOS_CONN_EVENT_REPORT:
+	case HCI_VS_SUBEVENT_QOS_CONN_EVENT_REPORT:
 		if (atomic_get(&processing)) {
 			/* Cheaper to skip this update */
 			/* instead of using locks */

--- a/doc/nrfxlib/nrfxlib.doxyfile.in
+++ b/doc/nrfxlib/nrfxlib.doxyfile.in
@@ -1966,6 +1966,7 @@ PREDEFINED             = "MBEDTLS_CONFIG_FILE=\"@NRFXLIB_BINARY_DIR@/mbedtls_dox
                          "BUILD_ASSERT()=" \
                          "__deprecated=" \
                          "__PACKED_STRUCT=struct" \
+                         "__PACKED_UNION=union" \
                          "__packed=" \
                          "__aligned(x)=" \
                          "__printf_like(x, y)=" \

--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -29,7 +29,7 @@ QoS connection event reports
    When reports are enabled, one report will be generated on every connection event.
    The report gives information about the quality of service of the connection event.
    The values in the report are used to describe the quality of links.
-   For parameter descriptions, see :cpp:enum:`hci_vs_evt_qos_conn_event_report_t` (in :file:`ble_controller_hci_vs.h`).
+   For parameter descriptions, see :cpp:enum:`hci_vs_subevent_qos_conn_event_report_t` (in :file:`ble_controller_hci_vs.h`).
 
 Transmission latency
    The definition of the latency used in this example counts the time interval from the sender's application to the GATT service of the receiver.

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -281,10 +281,10 @@ static int enable_llpm_short_connection_interval(void)
 static bool on_vs_evt(struct net_buf_simple *buf)
 {
 	u8_t code;
-	hci_vs_evt_qos_conn_event_report_t *evt;
+	hci_vs_subevent_qos_conn_event_report_t *evt;
 
 	code = net_buf_simple_pull_u8(buf);
-	if (code != HCI_VS_SUBEVENT_CODE_QOS_CONN_EVENT_REPORT) {
+	if (code != HCI_VS_SUBEVENT_QOS_CONN_EVENT_REPORT) {
 		return false;
 	}
 

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -214,7 +214,7 @@ static bool event_packet_is_discardable(const u8_t *hci_buf)
 		u8_t subevent = hci_buf[2];
 
 		switch (subevent) {
-		case HCI_VS_SUBEVENT_CODE_QOS_CONN_EVENT_REPORT:
+		case HCI_VS_SUBEVENT_QOS_CONN_EVENT_REPORT:
 			return true;
 		default:
 			return false;

--- a/west.yml
+++ b/west.yml
@@ -96,7 +96,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 06c75f63d2dbd32b099fd01b9d1f1f112762a228
+      revision: 9e9e9932356fed814d024236c6e571ea73ebef80
     - name: hal_nordic
       repo-path: sdk-hal_nordic
       path: modules/hal/nordic


### PR DESCRIPTION
The HCI_VS_SUBEVENT_CODE_QOS_CONN_EVENT_REPORT name was changed to
HCI_VS_SUBEVENT_QOS_CONN_EVENT_REPORT.

Added __PACKED_UNION=union to nrfxlib doxyfile to workaround this bug:
sphinx-doc/sphinx#2683
michaeljones/breathe#346

Ref.: DRGN-13156 DRGN-12681

Signed-off-by: Thomas Stenersen <thomas.stenersen@nordicsemi.no>

---

This PR adds the required changes from https://github.com/nrfconnect/sdk-nrfxlib/pull/194 and should be merged in quick succession.