### PR TITLE
west.yml: rewrite OSS project histories for NCS v1.3 [NCSDK-5554]

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.3.0-rc1-ncs1-rc1
+      revision: v2.3.0-rc1-ncs1-snapshot1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -87,11 +87,11 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.5.99-ncs1-rc1
+      revision: v1.5.99-ncs1-snapshot1
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr
-      revision: v0.0.1-ncs2-rc1
+      revision: v0.0.1-ncs2-snapshot1
       path: modules/lib/mcumgr
     - name: nrfxlib
       repo-path: sdk-nrfxlib


### PR DESCRIPTION
Move the Git histories for zephyr, mcuboot, and mcumgr to rewritten
versions for the release. No code changes.

@rlubos @carlescufi I think we may have made a mistake in tagging mcuboot.

Our current tag is v1.5.99-ncs1-rc1, but it includes v1.6.0-rc2 in its history, and that's inconsistent with how we tagged zephyr v2.3.0-rc1-ncs1-rc1 since that commit includes Zephyr v2.3.0-rc1.

Should we fix it for the snapshot or just live with it? This PR "lives with it", but we could make a new tag if we wanted.

I kind of wonder if we should just be creating "nrfconnect-sdk-v1.3-rc1" type tags in each repository, rather than basing our tag names off of upstream history.
