### PR TITLE
hal_nordic: Fix undefined reference to z_bt_ctlr_used_nrf_ppi_channels

### DIFF
--- a/applications/connectivity_bridge/src/modules/uart_handler.c
+++ b/applications/connectivity_bridge/src/modules/uart_handler.c
@@ -82,11 +82,6 @@ static bool framing_error_msg_sent[UART_DEVICE_COUNT];
 static char framing_error_msg[] =
 	"[UART FRAMING ERROR! CHECK BAUDRATE!]";
 
-#if CONFIG_BT_LL_NRFXLIB
-/* Required by nrfx_ppi, which is used by nrfx_uart */
-const u32_t z_bt_ctlr_used_nrf_ppi_channels;
-#endif
-
 static void enable_uart_rx(u8_t dev_idx);
 static void disable_uart_rx(u8_t dev_idx);
 static void set_uart_power_state(u8_t dev_idx, bool active);

--- a/west.yml
+++ b/west.yml
@@ -100,7 +100,7 @@ manifest:
     - name: hal_nordic
       repo-path: sdk-hal_nordic
       path: modules/hal/nordic
-      revision: 27d3886b0aaf2d1a16f2f3f53a6418145a5d007d
+      revision: ef6c7c3e82fee6e9e58c5295a4de7201b4b99b3c
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
See https://github.com/nrfconnect/sdk-hal_nordic/pull/4.

---

Update hal_nordic revision to fix a problem in nrfx_glue that causes
an undefined reference error when CONFIG_BT_CTLR is enabled but
CONFIG_BT_LL_SW_SPLIT is not.
Remove also a no longer needed workaround for this problem that was
used in the connectivity_brigde application.

NCSDK-5589

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>