### PR TITLE
doc: link to Known issues page

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -30,6 +30,7 @@
 
 .. _`change log`: https://github.com/nrfconnect/sdk-nrf/wiki/Changelog
 
+.. _`Known issues`: https://github.com/nrfconnect/sdk-nrf/wiki/Known-issues
 
 .. ### Links to Nordic documentation
 

--- a/doc/nrf/release_notes.rst
+++ b/doc/nrf/release_notes.rst
@@ -5,6 +5,8 @@
 
 See the release notes for information about specific |NCS| releases.
 
+Important issues that are discovered after a release is tagged are listed in the `Known issues`_ wiki page.
+
 .. important::
    The |NCS| follows `Semantic Versioning 2.0.0`_.
    A "99" in the version number of this documentation indicates continuous updates on the master branch since the previous major and minor release.


### PR DESCRIPTION
Known issues for a release should be listed in the wiki.
Link to the known issues page from the release notes overview.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>