### PR TITLE
Bluetooth: Mesh: Fix Light control build errors

### DIFF
--- a/include/bluetooth/mesh/light_ctrl.h
+++ b/include/bluetooth/mesh/light_ctrl.h
@@ -203,6 +203,19 @@ enum bt_mesh_light_ctrl_prop {
 #define BT_MESH_LIGHT_CTRL_OP_PROP_SET_UNACK BT_MESH_MODEL_OP_1(0x63)
 #define BT_MESH_LIGHT_CTRL_OP_PROP_STATUS BT_MESH_MODEL_OP_1(0x64)
 
+#define BT_MESH_LIGHT_CTRL_CLI_BUF_MAXLEN                                      \
+	(BT_MESH_MODEL_BUF_LEN(                                                \
+		BT_MESH_LIGHT_CTRL_OP_PROP_SET,                                \
+		2 + CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX))
+
+#define BT_MESH_LIGHT_CTRL_SRV_BUF_MAXLEN                                      \
+	(BT_MESH_MODEL_BUF_LEN(BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_STATUS, 3))
+
+#define BT_MESH_LIGHT_CTRL_SETUP_SRV_BUF_MAXLEN                                \
+	(BT_MESH_MODEL_BUF_LEN(                                                \
+		BT_MESH_LIGHT_CTRL_OP_PROP_STATUS,                             \
+		2 + CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX))
+
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
 #define BT_MESH_LIGHT_CTRL_SRV_REG_INIT .reg = {                               \
 	.cfg = {                                                               \
@@ -225,12 +238,11 @@ enum bt_mesh_light_ctrl_prop {
 			CONFIG_BT_MESH_LIGHT_CTRL_SRV_OCCUPANCY_DELAY,         \
 		.fade_on =                                                     \
 			CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_FADE_ON,            \
-		.on =                                                          \
-			K_SECONDS(CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_ON),      \
+		.on = (MSEC_PER_SEC * CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_ON),  \
 		.fade_prolong =                                                \
 			CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_FADE_PROLONG,       \
-		.prolong =                                                     \
-			K_SECONDS(CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_PROLONG), \
+		.prolong = (MSEC_PER_SEC *                                     \
+			    CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_PROLONG),       \
 		.fade_standby_auto =                                           \
 			CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_FADE_STANDBY_AUTO,  \
 		.fade_standby_manual =                                         \

--- a/include/bluetooth/mesh/light_ctrl_cli.h
+++ b/include/bluetooth/mesh/light_ctrl_cli.h
@@ -33,12 +33,11 @@ struct bt_mesh_light_ctrl_cli;
  *
  *  @sa bt_mesh_light_ctrl_cli_handlers
  */
-#define BT_MESH_LIGHT_CTRL_CLI_INIT(_handlers)                                \
-	{                                                                     \
-		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(         \
-				 BT_MESH_LIGHT_CTRL_OP_LEVEL_SET,             \
-				 BT_MESH_LIGHT_CTRL_MSG_MAXLEN_LEVEL_SET)) }, \
-		.handlers = _handlers,                                        \
+#define BT_MESH_LIGHT_CTRL_CLI_INIT(_handlers)                                 \
+	{                                                                      \
+		.pub = { .msg = NET_BUF_SIMPLE(                                \
+				 BT_MESH_LIGHT_CTRL_CLI_BUF_MAXLEN) },         \
+		.handlers = _handlers,                                         \
 	}
 
 /** @def BT_MESH_MODEL_LIGHT_CTRL_CLI

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -41,12 +41,10 @@ struct bt_mesh_light_ctrl_srv;
 			&_bt_mesh_light_ctrl_srv_onoff),                       \
 		.lightness = _lightness_srv,                                   \
 		.pub = { .update = _bt_mesh_light_ctrl_srv_update,             \
-			 .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
-				 BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_STATUS,     \
-				 3)) },                                        \
-		.setup_pub.msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(         \
-			BT_MESH_LIGHT_CTRL_OP_PROP_STATUS,                     \
-			2 + CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX)),  \
+			 .msg = NET_BUF_SIMPLE(                                \
+				 BT_MESH_LIGHT_CTRL_SRV_BUF_MAXLEN) },         \
+		.setup_pub.msg = NET_BUF_SIMPLE(                               \
+			BT_MESH_LIGHT_CTRL_SETUP_SRV_BUF_MAXLEN),              \
 		BT_MESH_LIGHT_CTRL_SRV_REG_INIT                                \
 	}
 

--- a/include/bluetooth/mesh/lightness_cli.h
+++ b/include/bluetooth/mesh/lightness_cli.h
@@ -33,8 +33,8 @@ struct bt_mesh_lightness_cli;
 #define BT_MESH_LIGHTNESS_CLI_INIT(_handlers)                                  \
 	{                                                                      \
 		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
-				 BT_MESH_LIGHTNESS_OP_LEVEL_SET,               \
-				 BT_MESH_LIGHTNESS_MSG_MAXLEN_LEVEL_SET)) },   \
+				 BT_MESH_LIGHTNESS_OP_SET,               \
+				 BT_MESH_LIGHTNESS_MSG_MAXLEN_SET)) },   \
 		.handlers = _handlers,                                         \
 	}
 

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -424,6 +424,7 @@ endif
 config BT_MESH_LIGHT_CTRL_CLI
 	bool "Light LC Client"
 	select BT_MESH_NRF_MODELS
+	select BT_MESH_SENSOR
 	help
 	  Enable Mesh Light Lightness Control Client model.
 


### PR DESCRIPTION
Resolves build errors when using light control initialization macros in
applications. Fixes NCSDK-5594.

Signed-off-by: Trond Einar Snekvik <trond.einar.snekvik@nordicsemi.no>