### PR TITLE
manifest: mcuboot - fix nrf53 board name

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -87,7 +87,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.5.99-ncs1-snapshot1
+      revision: e81a207f8b94b15c09a63e9e5ebf074d44315cb4
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
Fix board name for nrf53 in kconfig to fix default value.

Ref: NCSDK-5599
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>