### PR TITLE
fix: NVS sample doesn't build when PM enabled, fix: PM FLASH_AREA_OFFSET() macro

### DIFF
--- a/include/flash_map_pm.h
+++ b/include/flash_map_pm.h
@@ -18,6 +18,8 @@
 #define storage settings_storage
 #elif CONFIG_FILE_SYSTEM_LITTLEFS
 #define storage littlefs_storage
+#elif CONFIG_NVS
+#define storage nvs_storage
 #endif
 
 #if (CONFIG_SETTINGS_FCB || CONFIG_SETTINGS_NVS) && CONFIG_FILE_SYSTEM_LITTLEFS

--- a/include/flash_map_pm.h
+++ b/include/flash_map_pm.h
@@ -29,7 +29,7 @@
 #define FLASH_AREA_ID(label) PM_ID(label)
 
 #define FLASH_AREA_OFFSET(label) \
-	UTIL_CAT(PM_, UTIL_CAT(UTIL_CAT(PM_, UTIL_CAT(PM_ID(label), _LABEL)), _OFFSET))
+	UTIL_CAT(PM_, UTIL_CAT(UTIL_CAT(PM_, UTIL_CAT(PM_ID(label), _LABEL)), _ADDRESS))
 
 #define FLASH_AREA_SIZE(label) \
 	UTIL_CAT(PM_, UTIL_CAT(UTIL_CAT(PM_, UTIL_CAT(PM_ID(label), _LABEL)), _SIZE))

--- a/include/flash_map_pm.h
+++ b/include/flash_map_pm.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef FLASH_MAP_PM_H_
+#define FLASH_MAP_PM_H_
+
+#include <pm_config.h>
+#include <sys/util.h>
+
+/* Aliases for zephyr - mcuboot/ncs style naming */
+#define image_0 mcuboot_primary
+#define image_1 mcuboot_secondary
+
+#if (CONFIG_SETTINGS_FCB || CONFIG_SETTINGS_NVS)
+#define storage settings_storage
+#elif CONFIG_FILE_SYSTEM_LITTLEFS
+#define storage littlefs_storage
+#endif
+
+#if (CONFIG_SETTINGS_FCB || CONFIG_SETTINGS_NVS) && CONFIG_FILE_SYSTEM_LITTLEFS
+#error "Not supported"
+#endif
+
+#define PM_ID(label) PM_##label##_ID
+
+#define FLASH_AREA_ID(label) PM_ID(label)
+
+#define FLASH_AREA_OFFSET(label) \
+	UTIL_CAT(PM_, UTIL_CAT(UTIL_CAT(PM_, UTIL_CAT(PM_ID(label), _LABEL)), _OFFSET))
+
+#define FLASH_AREA_SIZE(label) \
+	UTIL_CAT(PM_, UTIL_CAT(UTIL_CAT(PM_, UTIL_CAT(PM_ID(label), _LABEL)), _SIZE))
+
+#define FLASH_AREA_LABEL_EXISTS(label) \
+	IS_ENABLED(FLASH_AREA_SIZE(label))
+
+#endif /* FLASH_MAP_PM_H_*/

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -46,6 +46,10 @@ if (CONFIG_ZIGBEE)
   add_partition_manager_config(pm.yml.zboss)
 endif()
 
+if (CONFIG_NVS AND NOT CONFIG_SETTINGS_NVS)
+  add_partition_manager_config(pm.yml.nvs)
+endif()
+
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
 set(using_partition_manager

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -21,6 +21,12 @@ partition-size=0x2000
 rsource "Kconfig.template.partition_size"
 endif
 
+if NVS && !SETTINGS_NVS
+partition=NVS_STORAGE
+partition-size=0x6000
+rsource "Kconfig.template.partition_size"
+endif
+
 if ZIGBEE
 partition=ZBOSS_NVRAM
 partition-size=0x8000

--- a/subsys/partition_manager/pm.yml.nvs
+++ b/subsys/partition_manager/pm.yml.nvs
@@ -1,0 +1,5 @@
+#include <autoconf.h>
+
+nvs_storage:
+  placement: {before: [end]}
+  size: CONFIG_PM_PARTITION_SIZE_NVS_STORAGE

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: fde8b6badf955c98f535b1c51903d682b45173f7
+      revision: pull/314/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: pull/314/head
+      revision: f4aa2eaa0b2c71e892ce95f6d85dfb9459f91f93
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
jira: NCSDK-5602
jira: NCSDK-5607

Added partition for pure NVS usage.
This changes allow to use NVS without the setting, especially
zephyr/sample/subsys/NVS is working now.

(suggest @hakonfam)
PM related code form zephyr flash_map.h file is moved
to nrf repository for better repository decoupling.

While the partition_manager is used
FLASH_AREA_OFFSET() macro should leads to PM_xxx_ADDRESS defines instead
of PM_xxx_OFFSET.

linked with https://github.com/nrfconnect/sdk-zephyr/pull/314