### PR TITLE
doc: Fix absolute paths in generated output

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -380,10 +380,13 @@ add_custom_target(
     KCONFIG_WARN_UNDEF=y
     KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
     KCONFIG_DOC_MODE=1
-      ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/genrest.py ${KCONFIG_RST_OUT}
+      ${PYTHON_EXECUTABLE}
+        ${NRF_BASE}/doc/scripts/genrest_custom.py
+        --custom-modules BuildDir,${CMAKE_BINARY_DIR}
+                         MCUboot,${MCUBOOT_BASE}
+        --zephyr-genrest ${ZEPHYR_BASE}/doc/scripts/genrest.py ${KCONFIG_RST_OUT}
         --separate-all-index
-        --modules BuildDir,builddir,${CMAKE_BINARY_DIR}
-                  Zephyr,zephyr,${ZEPHYR_BASE}
+        --modules Zephyr,zephyr,${ZEPHYR_BASE}
                   nRF,nrf,${NRF_BASE}
                   nrfxlib,nrfxlib,${NRFXLIB_BASE}
 

--- a/doc/scripts/genrest_custom.py
+++ b/doc/scripts/genrest_custom.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+#
+# This tool works as a frontend to Zephyr's genrest.py script. It receives
+# a `--custom-modules` argument which is used to populate a list of
+# path -> abbreviation resolvers, similarly to the `--modules` parameter of
+# Zephyr's genrest.py. It monkey patches Zephyr's genrest `strip_module_path`
+# routine to resolve those extra symbols.
+#
+
+import argparse
+import importlib.util
+import os
+import os.path
+import pathlib
+import sys
+
+
+def parse_custom_modules(args):
+    global custom_modules
+
+    custom_modules = []
+    for module_spec in args.custom_modules:
+        title, path_s = module_spec.split(',')
+
+        abspath = pathlib.Path(path_s).resolve()
+        if not abspath.exists():
+            sys.exit("error: path '{}' in --custom-modules argument does not "
+                     "exist".format(abspath))
+
+        custom_modules.append((title, abspath))
+
+
+def strip_custom_module_path(path):
+    if strip_module_paths:
+        abspath = pathlib.Path(kconf.srctree).joinpath(path).resolve()
+        for title, mod_path in custom_modules:
+            try:
+                relpath = abspath.relative_to(mod_path)
+            except ValueError:
+                continue
+
+            return f"<{title}>{os.path.sep}{relpath}"
+
+    # fallback on Zephyr's resolver
+    return strip_module_path(path)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--custom-modules', nargs="+", default=[])
+    parser.add_argument('--zephyr-genrest')
+    args, unknown_args = parser.parse_known_args()
+
+    parse_custom_modules(args)
+
+    # load Zephyr's genrest
+    spec = importlib.util.spec_from_file_location("module.name",
+                                                  args.zephyr_genrest)
+    genrest = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(genrest)
+
+    # call init() from genrest, passing unknown arguments
+    sys.argv = [args.zephyr_genrest] + unknown_args
+    genrest.init()
+
+    # reuse some of Zephyr's genrest variables and functions
+    global kconf
+    global strip_module_paths
+    global strip_module_path
+
+    kconf = genrest.kconf
+    strip_module_paths = genrest.strip_module_paths
+    strip_module_path = genrest.strip_module_path
+
+    # monkey patch Zephyr's strip_module_path routine
+    genrest.strip_module_path = strip_custom_module_path
+
+    genrest.write_index_pages()
+
+    if os.getenv("KCONFIG_TURBO_MODE") == "1":
+        genrest.write_dummy_syms_page()
+    else:
+        genrest.write_sym_pages()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The previous fix (1de8a498c3d72a17412297e27c24a05ce9e36f7c) added the build directory to `--modules` parameter for genrest.py but this has some side-effects, because it creates new files for each option, which generate non-wanted pages, warnings, etc.

In this commit a new tool, /doc/scripts/custom_genrest.py, is added which does monkey patching on Zephyr's genrest.py, so that some absolute paths can be converted in nicer looking abbreviations, similarly to current parameters passed to Zephyr's genrest `--modules`. This tool still relies on Zephyr's genrest to do most of the work, leaving only the resolving of custom parameters to do internally (monkey patched on Zephyr's resolver).

The CMakeFile was updated to call this tool, and pass the new parameters together with Zephyr's genrest parameters.

JIRA: NCSDK-1459
JIRA: NCSDK-5612