### PR TITLE
samples: nrf5340: empty_app_core: fix cmake

### DIFF
--- a/samples/nrf5340/empty_app_core/CMakeLists.txt
+++ b/samples/nrf5340/empty_app_core/CMakeLists.txt
@@ -10,8 +10,7 @@ set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp
   )
 
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(empty_app_core)
 
 target_sources(app PRIVATE src/main.c)


### PR DESCRIPTION
Fixed CMake file for the Empty Core sample.

Ref: NCSDK-5621

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>