### PR TITLE
samples: nrf9160: mqtt_simple: Set MQTT transport to secure with TLS

### DIFF
--- a/samples/nrf9160/mqtt_simple/src/main.c
+++ b/samples/nrf9160/mqtt_simple/src/main.c
@@ -330,7 +330,11 @@ static void client_init(struct mqtt_client *client)
 	client->tx_buf_size = sizeof(tx_buffer);
 
 	/* MQTT transport configuration */
+#if defined(CONFIG_MQTT_LIB_TLS)
+	client->transport.type = MQTT_TRANSPORT_SECURE;
+#else
 	client->transport.type = MQTT_TRANSPORT_NON_SECURE;
+#endif
 }
 
 /**@brief Initialize the file descriptor structure used by poll.


### PR DESCRIPTION
Set the MQTT transport as secure when TLS is used.

Fixes NCSDK-5649

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>