### PR TITLE
samples: nrf9160: nrf_cloud_agps: Enable PSM before connecting to network 

### DIFF
--- a/samples/nrf9160/nrf_cloud_agps/src/main.c
+++ b/samples/nrf9160/nrf_cloud_agps/src/main.c
@@ -328,15 +328,6 @@ static int modem_configure(void)
 	} else {
 		LOG_INF("Connecting to LTE network. This may take minutes.");
 
-		err = lte_lc_init_and_connect();
-		if (err) {
-			LOG_ERR("LTE link could not be established, error: %d",
-				err);
-			return err;
-		}
-
-		LOG_INF("Connected to LTE network");
-
 #if defined(CONFIG_LTE_POWER_SAVING_MODE)
 		err = lte_lc_psm_req(true);
 		if (err) {
@@ -346,6 +337,15 @@ static int modem_configure(void)
 
 		LOG_INF("PSM mode requested");
 #endif
+
+		err = lte_lc_init_and_connect();
+		if (err) {
+			LOG_ERR("LTE link could not be established, error: %d",
+				err);
+			return err;
+		}
+
+		LOG_INF("Connected to LTE network");
 	}
 
 	return err;

--- a/samples/nrf9160/nrf_cloud_agps/src/main.c
+++ b/samples/nrf9160/nrf_cloud_agps/src/main.c
@@ -109,23 +109,23 @@ static void cloud_event_handler(const struct cloud_backend *const backend,
 
 	switch (evt->type) {
 	case CLOUD_EVT_CONNECTED:
-		LOG_DBG("CLOUD_EVT_CONNECTED");
+		LOG_INF("CLOUD_EVT_CONNECTED");
 		break;
 	case CLOUD_EVT_READY:
-		LOG_DBG("CLOUD_EVT_READY");
+		LOG_INF("CLOUD_EVT_READY");
 		on_ready_evt();
 		break;
 	case CLOUD_EVT_DISCONNECTED:
-		LOG_DBG("CLOUD_EVT_DISCONNECTED");
+		LOG_INF("CLOUD_EVT_DISCONNECTED");
 		break;
 	case CLOUD_EVT_ERROR:
-		LOG_DBG("CLOUD_EVT_ERROR");
+		LOG_INF("CLOUD_EVT_ERROR");
 		break;
 	case CLOUD_EVT_DATA_SENT:
-		LOG_DBG("CLOUD_EVT_DATA_SENT");
+		LOG_INF("CLOUD_EVT_DATA_SENT");
 		break;
 	case CLOUD_EVT_DATA_RECEIVED:
-		LOG_DBG("CLOUD_EVT_DATA_RECEIVED");
+		LOG_INF("CLOUD_EVT_DATA_RECEIVED");
 
 		/* Convenience functionality for remote testing.
 		 * The device is reset if it receives "{"reboot":true}"
@@ -146,16 +146,16 @@ static void cloud_event_handler(const struct cloud_backend *const backend,
 		process_agps_data(evt->data.msg.buf, evt->data.msg.len);
 		break;
 	case CLOUD_EVT_PAIR_REQUEST:
-		LOG_DBG("CLOUD_EVT_PAIR_REQUEST");
+		LOG_INF("CLOUD_EVT_PAIR_REQUEST");
 		break;
 	case CLOUD_EVT_PAIR_DONE:
-		LOG_DBG("CLOUD_EVT_PAIR_DONE");
+		LOG_INF("CLOUD_EVT_PAIR_DONE");
 		break;
 	case CLOUD_EVT_FOTA_DONE:
-		LOG_DBG("CLOUD_EVT_FOTA_DONE");
+		LOG_INF("CLOUD_EVT_FOTA_DONE");
 		break;
 	default:
-		LOG_DBG("Unknown cloud event type: %d", evt->type);
+		LOG_INF("Unknown cloud event type: %d", evt->type);
 		break;
 	}
 }


### PR DESCRIPTION
samples: nrf9160: nrf_cloud_agps: Enable PSM before connecting 

Some networks will fail to enable PSM if it is requested after
the connection is established. This may cause the application
to behave unexpectedly by for example never sending or
receiving any data.

Fixes TG91-269

---

samples: nrf9160: nrf_cloud_agps: Set cloud event log level to INF 

Cloud event information is needed to understand what's going on
in the sample. The log level should therefore be INF.