### PR TITLE
net: fota_download: emit error when dfu_target fails initializing

### DIFF
--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -107,6 +107,15 @@ int dfu_target_write(const void *const buf, size_t len);
  **/
 int dfu_target_done(bool successful);
 
+/**
+ * @brief Deinitialize the resources that were needed for the current DFU
+ *	  target if any and resets the current dfu target.
+ *
+ * @return 0 for an successful deinitialization and reset or a negative error
+ *	   code identicating reason of failure.
+ **/
+int dfu_target_reset(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/dfu/src/dfu_target.c
+++ b/subsys/dfu/src/dfu_target.c
@@ -123,3 +123,17 @@ int dfu_target_done(bool successful)
 
 	return 0;
 }
+
+int dfu_target_reset(void)
+{
+	if (current_target != NULL) {
+		int err = current_target->done(false);
+
+		if (err != 0) {
+			LOG_ERR("Unable to clean up dfu_target");
+			return err;
+		}
+	}
+	current_target = NULL;
+	return 0;
+}

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -85,6 +85,13 @@ static int download_client_callback(const struct download_client_evt *event)
 					      dfu_target_callback_handler);
 			if ((err < 0) && (err != -EBUSY)) {
 				LOG_ERR("dfu_target_init error %d", err);
+				send_evt(FOTA_DOWNLOAD_EVT_ERROR);
+				int res = dfu_target_reset();
+
+				if (res != 0) {
+					LOG_ERR("Unable to reset DFU target");
+				}
+				first_fragment = true;
 				return err;
 			}
 


### PR DESCRIPTION
FOTA download library would not emit an error when it could not initialize
the dfu target.

Ref: NCSDK-5587

