### PR TITLE
manifest: Update mbed TLS to 2.16.6

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -113,7 +113,7 @@ manifest:
     - name: mbedtls-nrf
       path: mbedtls
       repo-path: mbedtls
-      revision: mbedtls-2.16.4
+      revision: mbedtls-2.16.6
       remote: armmbed
 
   # West-related configuration for the nrf repository.


### PR DESCRIPTION
-Updating west.yml to point to latest mbed TLS LTS tag (2.16.6)

Ref: NCSDK-5563

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>