### PR TITLE
doc: update doc to reflect support for multi core builds

### DIFF
--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -5,7 +5,7 @@ Multi-image builds
 
 In many cases, the firmware that is programmed to a device consists of not only one application, but several separate images, where one of the images (the *parent image*) requires one or more other images (the *child images*) to be present.
 The child image then *chain-loads* (or *boots*) the parent image, which in turn might be a child image to another parent image and boot that one.
-The most common use case for builds consisting of multiple images is an application that requires a bootloader to be present.
+The most common use cases for builds consisting of multiple images are applications that require a bootloader to be present, or applications for multi-core CPUs.
 
 
 When to use multiple images
@@ -23,6 +23,7 @@ Using multiple images has the following advantages:
   This partitioning is often useful for bootloaders.
 * Since there is a symbol table for each image, the same symbol names can exist multiple times in the final firmware.
   This is useful for bootloader images, which might required their own copy of a library that the application uses, but in a different version or configuration.
+* In multi-core builds, the build configuration of a child image in a separate core can be made known to the parent image.
 
 In the |NCS|, multiple images are required in the following scenarios:
 
@@ -46,11 +47,6 @@ nRF5340 support
    nRF5340 contains two separate processors: a network core and an application core.
    When programming applications to the nRF5340 PDK, they must be divided into at least two images, one for each core.
    See :ref:`ug_nrf5340` for more information.
-
-   .. important::
-      Currently, the two images must be built and programmed separately.
-      Multi-image builds are not yet supported for nRF5340.
-
 
 Default configuration
 *********************
@@ -108,6 +104,17 @@ See the following example code:
 In this code, ``add_child_image`` registers the child image with the given name and file path and executes the build scripts of the child image.
 Note that both the child image's application build scripts and the core build scripts are executed.
 The core build scripts might use a different configuration and possibly different DeviceTree settings.
+
+If a child image is to be executed on a different core, you must specify the name space for the child image as *domain* when adding the child image.
+For example:
+
+.. code-block:: cmake
+
+   add_child_image(
+      NAME hci_rpmsg
+      SOURCE_DIR ${ZEPHYR_BASE}/samples/bluetooth/hci_rpmsg
+      DOMAIN nrf5340pdk_nrf5340_cpunet)
+
 
 Adding configuration options
 ============================

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -139,7 +139,18 @@ Depending on the sample, you must program only the application core (for example
    You can use the :ref:`nrf5340_empty_app_core` sample for this purpose.
    For details, see the code in :file:`zephyr/boards/arm/nrf5340pdk_nrf5340/nrf5340_cpunet_reset.c`.
 
-Build and program both samples separately by following the instructions in :ref:`gs_programming_ses`.
+To program only the application core, follow the instructions in :ref:`gs_programming_ses` and use ``nrf5340pdk_nrf5340_cpuapp`` or ``nrf5340pdk_nrf5340_cpuappns`` as build target.
+
+When programming both the application core and the network core, you can choose whether you want to build and program both images separately or combined as a :ref:`multi-image build <ug_multi_image>`.
+
+In a multi-image build, the image for the application core is the parent image, and the image for the network core is treated as a child image in a separate domain.
+For this to work, the network core image must be explicitly added as a child image to one of the application core images.
+See :ref:`ug_multi_image_defining` for details.
+
+The network sample :ref:`zephyr:bluetooth-hci-rpmsg-sample` is automatically added to all Bluetooth Low Energy samples in the |NCS|.
+When :option:`CONFIG_BT_RPMSG_NRF53` is set to ``y`` (the default), the build system automatically includes the sample as a child image in the ``nrf5340_pdk_nrf5340_cpunet`` core.
+
+If the image in the network core is not added to the application core build, you can build and program both samples separately by following the instructions in :ref:`gs_programming_ses`.
 Make sure to use ``nrf5340pdk_nrf5340_cpunet`` as build target when building the network sample, and ``nrf5340pdk_nrf5340_cpuapp`` or ``nrf5340pdk_nrf5340_cpuappns`` when building the application sample.
 
 


### PR DESCRIPTION
Also mention that this is automatically done for nRF53 for
given configuration.

Ref: NCSDK-5663
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>