### PR TITLE
bluetooth: services: Add callback in hids_c

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -329,11 +329,11 @@ static void handle_config_forward(const struct config_forward_event *event)
 
 	notify_config_forwarded(CONFIG_STATUS_PENDING);
 
-	int err = bt_gatt_hids_c_rep_write(recipient_hidc,
-					   config_rep,
-					   hidc_write_cb,
-					   report,
-					   sizeof(report));
+	int err = bt_gatt_hids_c_rep_write_wo_rsp(recipient_hidc,
+						  config_rep,
+						  hidc_write_cb,
+						  report,
+						  sizeof(report));
 	if (err) {
 		LOG_ERR("Writing report failed, err:%d", err);
 		notify_config_forwarded(CONFIG_STATUS_WRITE_ERROR);

--- a/include/bluetooth/services/hids_c.h
+++ b/include/bluetooth/services/hids_c.h
@@ -380,6 +380,7 @@ int bt_gatt_hids_c_rep_write(struct bt_gatt_hids_c *hids_c,
  *
  * @param hids_c HIDS client object.
  * @param rep    Report object.
+ * @param func   Function to be called when operation is completed.
  * @param data   Data to be sent.
  * @param length Data size.
  *
@@ -388,6 +389,7 @@ int bt_gatt_hids_c_rep_write(struct bt_gatt_hids_c *hids_c,
  */
 int bt_gatt_hids_c_rep_write_wo_rsp(struct bt_gatt_hids_c *hids_c,
 				    struct bt_gatt_hids_c_rep_info *rep,
+				    bt_gatt_hids_c_write_cb func,
 				    const void *data, u8_t length);
 
 /**

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -99,6 +99,7 @@ Testing with another board
    If Button 1 was pressed::
 
       Caps lock send (val: 0x2)
+      Caps lock sent
 
    If Button 3 was pressed::
 

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -422,6 +422,12 @@ static void button_bootmode(void)
 	}
 }
 
+static void hidc_write_cb(struct bt_gatt_hids_c *hidc,
+			  struct bt_gatt_hids_c_rep_info *rep,
+			  u8_t err)
+{
+	printk("Caps lock sent\n");
+}
 
 static void button_capslock(void)
 {
@@ -444,6 +450,7 @@ static void button_capslock(void)
 	data = capslock_state ? 0x02 : 0;
 	err = bt_gatt_hids_c_rep_write_wo_rsp(&hids_c,
 					      hids_c.rep_boot.kbd_out,
+					      hidc_write_cb,
 					      &data, sizeof(data));
 	if (err) {
 		printk("Keyboard data write error (err: %d)\n", err);

--- a/subsys/bluetooth/services/hids_c.c
+++ b/subsys/bluetooth/services/hids_c.c
@@ -941,25 +941,57 @@ int bt_gatt_hids_c_rep_write(struct bt_gatt_hids_c *hids_c,
 	return 0;
 }
 
+/**
+ *  @brief Process report write without response
+ *
+ *  @param conn Connection object.
+ *  @param rep_ptr Report object.
+ */
+static void rep_write_wo_rsp_process(struct bt_conn *conn, void *rep_ptr)
+{
+	struct bt_gatt_hids_c_rep_info *rep = rep_ptr;
+
+	if (!rep->write_cb) {
+		LOG_ERR("No write callback present");
+		return;
+	}
+	rep->write_cb(rep->hids_c, rep, 0);
+	rep->write_cb = NULL;
+}
+
 int bt_gatt_hids_c_rep_write_wo_rsp(struct bt_gatt_hids_c *hids_c,
 				   struct bt_gatt_hids_c_rep_info *rep,
+				   bt_gatt_hids_c_write_cb func,
 				   const void *data, u8_t length)
 {
 	int err;
 
-	if (!hids_c || !rep) {
+	if (!hids_c || !rep || !func) {
 		return -EINVAL;
 	}
-	if (rep->ref.type != BT_GATT_HIDS_REPORT_TYPE_OUTPUT) {
+
+	if (rep->ref.type == BT_GATT_HIDS_REPORT_TYPE_INPUT) {
 		return -ENOTSUP;
 	}
 
-	err = bt_gatt_write_without_response(hids_c->conn,
-					     rep->handlers.val,
-					     data,
-					     length,
-					     false);
-	return err;
+	if (rep->write_cb) {
+		return -EBUSY;
+	}
+
+	rep->write_cb = func;
+
+	err = bt_gatt_write_without_response_cb(hids_c->conn,
+						rep->handlers.val,
+						data,
+						length,
+						false,
+						rep_write_wo_rsp_process,
+						rep);
+	if (err) {
+		rep->write_cb = NULL;
+		return err;
+	}
+	return 0;
 }
 
 /**


### PR DESCRIPTION
Change adds callback to GATT write without response in HIDS client service and updates application to use new API. This is done to inform application when the operation is completed.