### PR TITLE
lib: fatal_error: select REBOOT

### DIFF
--- a/lib/fatal_error/Kconfig
+++ b/lib/fatal_error/Kconfig
@@ -8,6 +8,7 @@ menuconfig RESET_ON_FATAL_ERROR
 	bool "Reset on fatal error"
 	default y if !DEBUG && !KERNEL_DEBUG && !BOARD_NATIVE_POSIX && \
 		     !QEMU_TARGET
+	select REBOOT
 	help
 	  Enable using the fatal error handler defined for Nordic DKs.
 	  When it is used, the system restarts after a fatal error.

--- a/samples/nfc/writable_ndef_msg/src/main.c
+++ b/samples/nfc/writable_ndef_msg/src/main.c
@@ -14,6 +14,7 @@
  */
 
 #include <zephyr.h>
+#include <power/reboot.h>
 #include <stdbool.h>
 #include <nfc_t4t_lib.h>
 


### PR DESCRIPTION
For some architectures, code is guarded with REBOOT.
Therefore we must select it when the fatal_error lib is
included.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>