### PR TITLE
secure_service: add service for checking if s1 is active b1 slot

### DIFF
--- a/include/secure_services.h
+++ b/include/secure_services.h
@@ -86,6 +86,17 @@ int spm_request_random_number(uint8_t *output, size_t len, size_t *olen);
  */
 int spm_request_read(void *destination, uint32_t addr, size_t len);
 
+/** Check if S0 is the active B1 slot.
+ *
+ * @param[in]   s0_address Address of s0 slot.
+ * @param[in]   s1_address Address of s1 slot.
+ * @param[out]  s0_active  Set to 'true' if s0 is active slot, 'false' otherwise
+ *
+ * @retval 0        If successful.
+ * @retval -EINVAL  If info for both slots are NULL.
+ */
+int spm_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active);
+
 /** Search for the fw_info structure in firmware image located at address.
  *
  * @param[in]   fw_address  Address where firmware image is stored.

--- a/samples/nrf9160/secure_services/b0_mcuboot_overlay.conf
+++ b/samples/nrf9160/secure_services/b0_mcuboot_overlay.conf
@@ -1,9 +1,9 @@
 #
-# Copyright (c) 2019 Nordic Semiconductor ASA
+# Copyright (c) 2020 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-CONFIG_REBOOT=y
+CONFIG_SECURE_BOOT=y
 CONFIG_BOOTLOADER_MCUBOOT=y
 CONFIG_SECURE_BOOT=y
-CONFIG_FW_INFO=y
+CONFIG_BUILD_S1_VARIANT=y

--- a/samples/nrf9160/secure_services/sample.yaml
+++ b/samples/nrf9160/secure_services/sample.yaml
@@ -100,3 +100,10 @@ tests:
         - "FICR.INFO.VARIANT ..0x210. = 0x41414142"
         - "Reboot in 5 seconds."
         - "Secure Services example."
+
+  samples.nrf9160.secure_services.b0_mcuboot:
+    platform_allow: nrf9160dk_nrf9160ns
+    extra_args: OVERLAY_CONFIG="b0_mcuboot_overlay.conf"
+    build_only: true
+    build_on_all: true
+    tags: ci_build

--- a/samples/nrf9160/secure_services/src/main.c
+++ b/samples/nrf9160/secure_services/src/main.c
@@ -130,6 +130,18 @@ void main(void)
 		printk("FICR.INFO.VARIANT (+0x210) = 0x%08X\n\n", ficr_info);
 	}
 
+#ifdef PM_S1_ADDRESS
+	bool s0_active;
+
+	ret = spm_s0_active(PM_S0_ADDRESS, PM_S1_ADDRESS, &s0_active);
+	if (ret != 0) {
+		printk("Unexpected failure from spm_s0_active: %d\n", ret);
+	}
+
+	printk("S0 active? %s\n", s0_active ? "True" : "False");
+
+#endif /*  PM_S1_ADDRESS */
+
 	printk("Reboot in %d seconds.\n", sleep_time_s);
 	k_sleep(K_SECONDS(5));
 

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -268,16 +268,10 @@ int fota_download_start(const char *host, const char *file, int sec_tag,
 	 * space separated file is given.
 	 */
 	const char *update;
-	struct fw_info s0;
-	struct fw_info s1;
-
+	bool s0_active;
 #ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
-	err = spm_firmware_info(PM_S0_ADDRESS, &s0);
-	if (err != 0) {
-		return err;
-	}
 
-	err = spm_firmware_info(PM_S1_ADDRESS, &s1);
+	err = spm_s0_active(PM_S0_ADDRESS, PM_S1_ADDRESS, &s0_active);
 	if (err != 0) {
 		return err;
 	}
@@ -296,8 +290,6 @@ int fota_download_start(const char *host, const char *file, int sec_tag,
 	}
 	memcpy(&s1, tmp_info, sizeof(s1));
 #endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
-
-	bool s0_active = s0.version >= s1.version;
 
 	err = dfu_ctx_mcuboot_set_b1_file(file, s0_active, &update);
 	if (err != 0) {

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -108,6 +108,10 @@ config SPM_SERVICE_FIND_FIRMWARE_INFO
 	  marked as secure. This service allows it to request firmware info
 	  about image stored at a given address.
 
+config SPM_SERVICE_S0_ACTIVE
+	bool "Enable secure service to check if S0 is active B1 slot"
+	default y
+
 config SPM_SERVICE_PREVALIDATE
 	bool "Prevalidate B1 upgrades (Requires Immutable Bootloader)"
 	default n

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -125,6 +125,34 @@ int spm_request_random_number_nse(uint8_t *output, size_t len, size_t *olen)
 }
 #endif /* CONFIG_SPM_SERVICE_RNG */
 
+#ifdef CONFIG_SPM_SERVICE_S0_ACTIVE
+__TZ_NONSECURE_ENTRY_FUNC
+int spm_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active)
+{
+	const struct fw_info *s0;
+	const struct fw_info *s1;
+	bool s0_valid;
+	bool s1_valid;
+
+	s0 = fw_info_find(s0_address);
+	s1 = fw_info_find(s1_address);
+
+	s0_valid = (s0 != NULL) && (s0->valid == CONFIG_FW_INFO_VALID_VAL);
+	s1_valid = (s1 != NULL) && (s1->valid == CONFIG_FW_INFO_VALID_VAL);
+
+	if (!s1_valid && !s0_valid) {
+		return -EINVAL;
+	} else if (!s1_valid) {
+		*s0_active = true;
+	} else if (!s0_valid) {
+		*s0_active = false;
+	} else {
+		*s0_active = s0->version >= s1->version;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_SPM_SERVICE_S0_ACTIVE */
 
 #ifdef CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO
 __TZ_NONSECURE_ENTRY_FUNC


### PR DESCRIPTION
Provide this function instead of using 'find_info' since
it will be used in several places.

Ref: NCSDK-5542

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>