### PR TITLE
Add nrf53 to samples doc

### DIFF
--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -77,6 +77,7 @@ Requirements
 
 * Two of the following nRF52-series development kit boards:
 
+  * |nRF5340DK|
   * |nRF52DK|
   * |nRF52840DK|
   * Other boards running BLE Controller variants that support LLPM (see :ref:`nrfxlib:ble_controller` Proprietary feature support)

--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -24,8 +24,9 @@ Requirements
 
 * One of the nRF52 development boards. The sample has been tested on:
 
-  * nRF52 Development Kit (PCA10040)
-  * nRF52840 Development Kit (PCA10056)
+  * |nRF5340DK|
+  * |nRF52DK|
+  * |nRF52840DK|
 
 Building and Running
 ********************


### PR DESCRIPTION
Two samples lacked information about nRF5340.