### PR TITLE
doc: switch to Zephyr max-width style

### DIFF
--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -1,3 +1,8 @@
+/* make the page width fill the window */
+.wy-nav-content {
+   max-width: none;
+}
+
 /* Display version number in white */
 .wy-side-nav-search > div.version {
  color: #fff;


### PR DESCRIPTION
Zephyr overrides the "read the docs" standard size of the content pane, which is 800px, to use all of the available space. For the nRF documentation generation this property was not overridden resulting in a fixed size pane. This applies the same change that Zephyr does for all documentation.

JIRA: NCSDK-1018