### PR TITLE
doc: hide <ul> elements under details sections

### DIFF
--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -83,6 +83,8 @@ div.figure {
 .rst-content dl.group > dt, .rst-content dl.group > dd > p,
 /* hide the #include line for every class (aka struct) and union */
 .rst-content dl.class > dd > em, .rst-content dl.union > dd > em,
+/* hide <ul> inside description blocks */
+.rst-content dl.group > dd > ul,
 /* hide "Public Members"/"Defines"/etc heading for structs */
 .rst-content dl.class p.breathe-sectiondef-title {
    display:none !important;


### PR DESCRIPTION
This adds an extra CSS rule to hide the contents of an `<ul>` element inside the details section.

JIRA: NCSDK-1493