### PR TITLE
manifest: Update to fix matching platform_cc310

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1fa17467676d5d4c28c28dcde6f2702a9021995d
+      revision: c552a8488f9266039e5d8e453c9478000abd5dcf
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
-Updated manifest to point to nrfxlib in pr https://github.com/nrfconnect/sdk-nrfxlib/pull/205

Ref: NCSDK-5706

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>