### PR TITLE
kernel: Include "remove interior use of K_POLL" fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3a311235b2c4f60a42fbc5fb89a59166700bbf86
+      revision: bbd71e23a2d56f05cefc9dca7bef609c22c1966c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr revision to include the fix:
"kernel: Remove interior use of K_POLL"

Without this fix k_queue_get(queue, K_FOREVER) can timeout
and return NULL.

Zephyr:
https://github.com/nrfconnect/sdk-zephyr/pull/320

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>