### PR TITLE
Fix doxygen warnings

### DIFF
--- a/applications/asset_tracker/src/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker/src/cloud_codec/cloud_codec.h
@@ -206,7 +206,7 @@ int cloud_encode_data(const struct cloud_channel_data *channel,
 /**
  * @brief Decode cloud data.
  *
- * @param output Pointer to the cloud data input.
+ * @param input Pointer to the cloud data input.
  *
  * @return 0 if the operation was successful, otherwise a (negative) error code.
  */

--- a/applications/asset_tracker/src/ui/include/ui.h
+++ b/applications/asset_tracker/src/ui/include/ui.h
@@ -223,6 +223,7 @@ int ui_nmos_write(size_t nmos_idx, u8_t value);
 /**
  * @brief Control NMOS with PWM signal.
  *
+ * @param nmos_idx	NMOS to control.
  * @param period	PWM signal period in microseconds.
  * @param pulse	PWM signal Pulse in microseconds.
  *

--- a/applications/nrf_desktop/configuration/common/led_effect.h
+++ b/applications/nrf_desktop/configuration/common/led_effect.h
@@ -124,10 +124,10 @@ struct led_effect {
  *
  * LED color remains constant for a defined time, then goes off.
  *
- * @param _color	Selected LED color.
- * @param _on_time	Time LED will remain on in milliseconds.
- * @param _off_time	Time in which LED will gradually switch to off
- *			(in milliseconds).
+ * @param _color      Selected LED color.
+ * @param _on_time    Time LED will remain on in milliseconds.
+ * @param _off_delay  Time in which LED will gradually switch to off
+ *                    (in milliseconds).
  */
 #define LED_EFFECT_LED_ON_GO_OFF(_color, _on_time, _off_delay)			\
 	{									\

--- a/applications/nrf_desktop/src/events/battery_event.h
+++ b/applications/nrf_desktop/src/events/battery_event.h
@@ -58,4 +58,6 @@ EVENT_TYPE_DECLARE(battery_level_event);
 }
 #endif
 
+/** @} */
+
 #endif /* _BATTERY_EVENT_H_ */

--- a/applications/nrf_desktop/src/events/cpu_load_event.h
+++ b/applications/nrf_desktop/src/events/cpu_load_event.h
@@ -32,4 +32,6 @@ EVENT_TYPE_DECLARE(cpu_load_event);
 }
 #endif
 
+/** @} */
+
 #endif /* _CPU_LOAD_EVENT_H_ */

--- a/applications/nrf_desktop/src/util/chmap_filter/include/chmap_filter.h
+++ b/applications/nrf_desktop/src/util/chmap_filter/include/chmap_filter.h
@@ -180,7 +180,7 @@ bool chmap_filter_process(struct chmap_instance *p_inst);
  *
  * @param[in] p_inst Channel map instance pointer
  *
- * @return pointer to @ref CHMAP_BLE_BITMASK_SIZE sized channel map array
+ * @return pointer to @em CHMAP_BLE_BITMAP_SIZE sized channel map array
  */
 u8_t *chmap_filter_suggested_map_get(struct chmap_instance *p_inst);
 

--- a/applications/nrf_desktop/src/util/config_channel.h
+++ b/applications/nrf_desktop/src/util/config_channel.h
@@ -91,6 +91,7 @@ void config_channel_init(struct config_channel_state *cfg_chan);
  *                 when handling the get request.
  * @param length   Length of the data to be filled.
  * @param usb @c true if the operation occurs for USB, @c false for Bluetooth.
+ * @param local_product_id Product ID (USB PID) of the targeted device.
  *
  * @return 0 if the operation was successful. Otherwise, a (negative) error
  *	     code is returned.

--- a/applications/serial_lte_modem/src/slm_at_mqtt.h
+++ b/applications/serial_lte_modem/src/slm_at_mqtt.h
@@ -35,8 +35,6 @@ void slm_at_mqtt_clac(void);
 /**
  * @brief Initialize MQTT AT command parser.
  *
- * @param callback Callback function to send AT response
- *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -47,8 +47,8 @@ bool slm_util_cmd_casecmp(const char *cmd, const char *slm_cmd);
 /**
  * @brief Detect hexdecimal data type
  *
- * @param hex[in] Hex arrary to be encoded
- * @param hex_len[in] Length of hex array
+ * @param[in] hex Hex arrary to be encoded
+ * @param[in] hex_len Length of hex array
  *
  * @return true if the input is hexdecimal array, otherwise false
  */
@@ -57,10 +57,10 @@ bool slm_util_hex_check(const u8_t *hex, u16_t hex_len);
 /**
  * @brief Encode hex array to hexdecimal string (ASCII text)
  *
- * @param hex[in] Hex arrary to be encoded
- * @param hex_len[in] Length of hex array
- * @param ascii[out] encoded hexdecimal string
- * @param ascii_len[in] reserved buffer size
+ * @param[in]  hex Hex arrary to be encoded
+ * @param[in]  hex_len Length of hex array
+ * @param[out] ascii encoded hexdecimal string
+ * @param[in]  ascii_len reserved buffer size
  *
  * @return actual size of ascii string if the operation was successful.
  *           Otherwise, a (negative) error code is returned.
@@ -71,10 +71,10 @@ int slm_util_htoa(const u8_t *hex, u16_t hex_len,
 /**
  * @brief Decode hexdecimal string (ASCII text) to hex array
  *
- * @param ascii[in] encoded hexdecimal string
- * @param ascii_len[in] size of hexdecimal string
- * @param hex[out] decoded hex arrary
- * @param hex_len[in] reserved size of hex array
+ * @param[in]  ascii encoded hexdecimal string
+ * @param[in]  ascii_len size of hexdecimal string
+ * @param[out] hex decoded hex arrary
+ * @param[in]  hex_len reserved size of hex array
  *
  * @return actual size of hex array if the operation was successful.
  *           Otherwise, a (negative) error code is returned.

--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -738,7 +738,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = nrf_warnings.txt
+WARN_LOGFILE           =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/include/adp536x.h
+++ b/include/adp536x.h
@@ -193,4 +193,6 @@ int adp536x_oc_chg_current_set(u8_t value);
  */
 int adp536x_buck_discharge_set(bool enable);
 
+/** @} */
+
 #endif /* ADP536X_H_ */

--- a/include/bl_crypto.h
+++ b/include/bl_crypto.h
@@ -155,7 +155,7 @@ typedef int (*bl_sha256_finalize_t)(bl_sha256_ctx_t *ctx, u8_t *output);
  *
  * @param[in]  data      The data to hash.
  * @param[in]  data_len  The length of @p data.
- * @param[in]  expected  The expected digest over @data.
+ * @param[in]  expected  The expected digest over @p data.
  *
  * @retval 0          If the procedure succeeded and the resulting digest is
  *                    identical to @p expected.
@@ -180,7 +180,7 @@ typedef int (*bl_sha256_verify_t)(const u8_t *data, u32_t data_len,
  *
  * @retval 0         The operation succeeded and the signature is valid for the
  *                   hash.
- * @retval -EINVAL   A parameter was NULL, or the @hash_len was not 32 bytes.
+ * @retval -EINVAL   A parameter was NULL, or the @p hash_len was not 32 bytes.
  * @retval -ESIGINV  The signature validation failed.
  */
 int bl_secp256r1_validate(const u8_t *hash,

--- a/include/bl_storage.h
+++ b/include/bl_storage.h
@@ -101,8 +101,8 @@ u16_t get_monotonic_counter(void);
  * @retval 0        The counter was updated successfully.
  * @retval -EINVAL  @p new_counter is invalid (must be larger than current
  *                  counter, and cannot be 0xFFFF).
- * @retval -ENOMEM  There are no more free counter slots (see @ref
- *                  CONFIG_SB_NUM_VER_COUNTER_SLOTS).
+ * @retval -ENOMEM  There are no more free counter slots (see
+ *                  @em CONFIG_SB_NUM_VER_COUNTER_SLOTS).
  */
 int set_monotonic_counter(u16_t new_counter);
 

--- a/include/bl_validation.h
+++ b/include/bl_validation.h
@@ -21,15 +21,12 @@ extern "C" {
 
 /** Function for validating firmware.
  *
- * @details This will run a series of checks on the fw_info contents, then
- *          locate the validation info and check the signature of the image.
+ * @details This will run a series of checks on the @p fw_src_address contents,
+ *          then locate the validation info and check the signature of the
+ *          image.
  *
- * @note If this function returns false, the fw_info struct can be invalidated
- *       by modifying its 'valid' field, causing any subsequent call to this
- *       function to quickly return false.
- *
- * @param[in] fw_address  Address the firmware is currently at.
- * @param[in] fwinfo      Firmware info structure belonging to the image.
+ * @param[in] fw_dst_address  Address where the firmware will be written.
+ * @param[in] fw_src_address  Address of the firmware to be validated.
  *
  * @retval  true   if the image is valid
  * @retval  false  if the image is invalid

--- a/include/bluetooth/conn_ctx.h
+++ b/include/bluetooth/conn_ctx.h
@@ -148,7 +148,6 @@ void *bt_conn_ctx_get(struct bt_conn_ctx_lib *ctx_lib, struct bt_conn *conn);
  * @ref bt_conn_ctx_release to ensure proper operation.
  *
  * @param ctx_lib	Bluetooth connection context library instance.
- * @param conn		Bluetooth connection.
  * @param id		Connection context index.
  *
  * @return Pointer to the @ref bt_conn_ctx struct if the operation

--- a/include/bluetooth/enocean.h
+++ b/include/bluetooth/enocean.h
@@ -174,7 +174,7 @@ int bt_enocean_commission(const bt_addr_le_t *addr, const u8_t key[16],
  *
  *  Removes the EnOcean device's security information, freeing up space for new
  *  devices. May be used directly in the
- *  @ref bt_enocean_callbacks::commissioning callback to reject a device before
+ *  @em bt_enocean_callbacks::commissioning callback to reject a device before
  *  it gets commissioned.
  *
  *  @param dev Device to forget.

--- a/include/bluetooth/gatt_dm.h
+++ b/include/bluetooth/gatt_dm.h
@@ -31,7 +31,7 @@ struct bt_gatt_dm;
  *
  * This structure is used to hold GATT attribute information.
  * The Discovery Manager attribute descriptor is a reduced version of
- * @ref bt_gatt_attr. The new definition is used to save memory that is used
+ * @em bt_gatt_attr. The new definition is used to save memory that is used
  * by this module.
  */
 struct bt_gatt_dm_attr {
@@ -58,7 +58,7 @@ struct bt_gatt_dm_cb {
 	 *
 	 * @param[in,out] dm Discovery Manager instance
 	 * @param[in,out] context The value passed to
-	 *                @ref gatt_db_discovery_start
+	 *                @em gatt_db_discovery_start()
 	 */
 	void (*completed)(struct bt_gatt_dm *dm,
 			  void *context);
@@ -69,7 +69,7 @@ struct bt_gatt_dm_cb {
 	 *
 	 * @param[in,out] conn Connection object.
 	 * @param[in,out] context The value passed to
-	 *                @ref gatt_db_discovery_start
+	 *                @em gatt_db_discovery_start()
 	 */
 	void (*service_not_found)(struct bt_conn *conn,
 				  void *context);
@@ -81,7 +81,7 @@ struct bt_gatt_dm_cb {
 	 * @param[in,out] conn Connection object.
 	 * @param[in]     err The error code.
 	 * @param[in,out] context The value passed to
-	 *                @ref gatt_db_discovery_start
+	 *                @em gatt_db_discovery_start()
 	 */
 	void (*error_found)(struct bt_conn *conn,
 			    int err,
@@ -183,7 +183,7 @@ const struct bt_gatt_dm_attr *bt_gatt_dm_char_next(
  * @param[in] uuid The UUID of the characteristic
  *
  * @return The characteristic attribute
- *         (the one with UUID set to @ref BT_UUID_GATT_CHRC)
+ *         (the one with UUID set to @em BT_UUID_GATT_CHRC)
  *         with the selected UUID inside the characteristic value.
  *         Returns NULL if no such characteristic is present in the
  *         current service.

--- a/include/bluetooth/gatt_pool.h
+++ b/include/bluetooth/gatt_pool.h
@@ -106,7 +106,7 @@ extern "C" {
  *
  *  @param _gp GATT service object with dynamic attribute allocation.
  *  @param _ccc CCC descriptor configuration.
- *  @param _cb CCC descriptor callback.
+ *  @param _ccc_changed CCC value changed callback.
  *  @param _perm CCC descriptor permissions.
  */
 #define BT_GATT_POOL_CCC(_gp, _ccc, _ccc_changed, _perm)                       \
@@ -147,10 +147,9 @@ int bt_gatt_pool_svc_alloc(struct bt_gatt_pool *gp,
 
 /** @brief Take a characteristic descriptor from the pool.
  *
- *  @param gp   GATT service object with dynamic attribute allocation.
- *  @param _chrc_uuid Characteristic UUID.
- *  @param _char_props Properties of the characteristic.
- *  @param _attr Characteristic value attribute.
+ *  @param gp    GATT service object with dynamic attribute allocation.
+ *  @param props Properties of the characteristic.
+ *  @param attr  Characteristic value attribute.
  *
  *  @return 0 or a negative error code.
  */

--- a/include/bluetooth/mesh/dk_prov.h
+++ b/include/bluetooth/mesh/dk_prov.h
@@ -22,7 +22,7 @@ extern "C" {
 
 /** @brief Initialize the provisioning handler.
  *
- * @return The provisioning properties to pass to @ref bt_mesh_init.
+ * @return The provisioning properties to pass to @em bt_mesh_init().
  */
 const struct bt_mesh_prov *bt_mesh_dk_prov_init(void);
 

--- a/include/bluetooth/mesh/gen_loc.h
+++ b/include/bluetooth/mesh/gen_loc.h
@@ -93,7 +93,7 @@ struct bt_mesh_loc_local {
 	s16_t floor_number;
 	/** Whether the device is movable. */
 	bool is_mobile;
-	/** Time since the previous position update, or @ref K_FOREVER. */
+	/** Time since the previous position update, or @em K_FOREVER. */
 	s32_t time_delta;
 	/** Precision of the location in millimeters. */
 	u32_t precision_mm;

--- a/include/bluetooth/mesh/gen_lvl.h
+++ b/include/bluetooth/mesh/gen_lvl.h
@@ -103,7 +103,7 @@ struct bt_mesh_lvl_status {
 	 */
 	s16_t target;
 	/**
-	 * Time remaining of the ongoing transition, or @ref K_FOREVER.
+	 * Time remaining of the ongoing transition, or @em K_FOREVER.
 	 * If there's no ongoing transition, @c remaining_time is 0.
 	 */
 	s32_t remaining_time;

--- a/include/bluetooth/mesh/gen_plvl.h
+++ b/include/bluetooth/mesh/gen_plvl.h
@@ -70,7 +70,7 @@ struct bt_mesh_plvl_status {
 	/** Target Power Level. */
 	u16_t target;
 	/**
-	 * Time remaining of the ongoing transition, or @ref K_FOREVER.
+	 * Time remaining of the ongoing transition, or @em K_FOREVER.
 	 * If there's no ongoing transition, @c remaining_time is 0.
 	 */
 	s32_t remaining_time;

--- a/include/bluetooth/mesh/gen_prop_cli.h
+++ b/include/bluetooth/mesh/gen_prop_cli.h
@@ -267,7 +267,7 @@ int bt_mesh_prop_cli_admin_prop_set_unack(struct bt_mesh_prop_cli *cli,
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
- * @param[in] val New property value to set.
+ * @param[in] prop New property value to set.
  * @param[out] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
@@ -290,7 +290,7 @@ int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
- * @param[in] val New property value to set.
+ * @param[in] prop New property value to set.
  *
  * @retval 0 Successfully sent the message.
  * @retval -ENOTSUP A message context was not provided and publishing is not

--- a/include/bluetooth/mesh/gen_prop_cli.h
+++ b/include/bluetooth/mesh/gen_prop_cli.h
@@ -160,7 +160,7 @@ int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,
 
 /** @brief Set a property value in a User Property Server.
  *
- * @copydetails bt_mesH_prop_cli_user_prop_set_unack
+ * @copydetails bt_mesh_prop_cli_user_prop_set_unack
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
  * function will return, and the response will be passed to the

--- a/include/bluetooth/mesh/gen_prop_srv.h
+++ b/include/bluetooth/mesh/gen_prop_srv.h
@@ -238,8 +238,7 @@ int bt_mesh_prop_srv_pub_list(struct bt_mesh_prop_srv *srv,
  * @param[in] srv Server that owns the property.
  * @param[in] ctx Message context to publish with, or NULL to publish on the
  * configured publish parameters.
- * @param[in] prop Property to publish.
- * @param[in] value Value of the property.
+ * @param[in] val Value of the property.
  *
  * @retval 0 Successfully publish a Generic Level Status message.
  * @retval -EINVAL The server is a Client Property server, which does not

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -187,7 +187,6 @@ struct bt_mesh_light_ctrl_srv {
  *  Prolong state, it's moved back into the On state.
  *
  *  @param[in] srv        Light Lightness Control Server instance.
- *  @param[in] transition Transition time or NULL.
  *
  *  @retval 0      The Light Lightness Control Server was successfully turned
  *                 on.
@@ -204,7 +203,6 @@ int bt_mesh_light_ctrl_srv_on(struct bt_mesh_light_ctrl_srv *srv);
  *  @ref CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_MANUAL.
  *
  *  @param[in] srv        Light Lightness Control Server instance.
- *  @param[in] transition Transition time or NULL.
  *
  *  @retval 0      The Light Lightness Control Server was successfully turned
  *                 off.

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -200,7 +200,7 @@ int bt_mesh_light_ctrl_srv_on(struct bt_mesh_light_ctrl_srv *srv);
  *  state). Calling this function temporarily disables occupancy sensor
  *  triggering (referred to as "manual mode" in the documentation). The server
  *  will remain in manual mode until the manual mode timer expires, see
- *  @ref CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_MANUAL.
+ *  @em CONFIG_BT_MESH_LIGHT_CTRL_SRV_TIME_MANUAL.
  *
  *  @param[in] srv        Light Lightness Control Server instance.
  *

--- a/include/bluetooth/mesh/lightness.h
+++ b/include/bluetooth/mesh/lightness.h
@@ -45,7 +45,7 @@ struct bt_mesh_lightness_status {
 	/** Target Lightness level. */
 	u16_t target;
 	/**
-	 * Time remaining of the ongoing transition, or @ref K_FOREVER.
+	 * Time remaining of the ongoing transition, or @em K_FOREVER.
 	 * If there's no ongoing transition, @c remaining_time is 0.
 	 */
 	s32_t remaining_time;

--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -49,13 +49,13 @@ enum bt_mesh_sensor_sampling {
 	BT_MESH_SENSOR_SAMPLING_MINIMUM,
 	/** The presented value is the accumulated moving average value of the
 	 *  samples. The updating frequency of the moving average should be
-	 *  indicated in @ref bt_mesh_descriptor::update_interval. The total
-	 *  measurement period should be indicated in @ref
+	 *  indicated in @em bt_mesh_descriptor::update_interval. The total
+	 *  measurement period should be indicated in @em
 	 *  bt_mesh_descriptor::period.
 	 */
 	BT_MESH_SENSOR_SAMPLING_ACCUMULATED,
 	/** The presented value is a count of events in a specific measurement
-	 *  period. @ref bt_mesh_descriptor::period should denote the
+	 *  period. @em bt_mesh_descriptor::period should denote the
 	 *  measurement period, or left to 0 to indicate that the sample is a
 	 *  lifetime value.
 	 */
@@ -420,7 +420,7 @@ bool bt_mesh_sensor_delta_threshold(const struct bt_mesh_sensor *sensor,
 /** @brief Get the sensor type associated with the given Device Property ID.
  *
  *  Only known sensor types from @ref bt_mesh_sensor_types will be available.
- *  Sensor types can be made known to the sensor module by enabling @ref
+ *  Sensor types can be made known to the sensor module by enabling @em
  *  CONFIG_BT_MESH_SENSOR_ALL_TYPES or by referencing them in the application.
  *
  *  @param[in] id A Device Property ID.

--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -408,8 +408,8 @@ struct bt_mesh_sensor {
  *        true from this function. Single-channel sensors that haven't been
  *        assigned a threshold will return true if the value is different.
  *
- *  @param[in] threshold Threshold parameters.
- *  @param[in] curr      Sensor value.
+ *  @param[in] sensor    The sensor instance.
+ *  @param[in] value     Sensor value.
  *
  *  @return true if the difference between the measurements exceeds the delta
  *          threshold, false otherwise.

--- a/include/bluetooth/mesh/sensor_cli.h
+++ b/include/bluetooth/mesh/sensor_cli.h
@@ -252,7 +252,7 @@ struct bt_mesh_sensor_cli_handlers {
  *
  *  This call is blocking if the @c sensors buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::sensor callback as a list of sensor
+ *  bt_mesh_sensor_cli_handlers::sensor callback as a list of sensor
  *  descriptors.
  *
  *  If a @c sensors array is provided and the client received a response, the
@@ -291,7 +291,7 @@ int bt_mesh_sensor_cli_list_get(struct bt_mesh_sensor_cli *cli,
  *
  *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::sensor callback.
+ *  bt_mesh_sensor_cli_handlers::sensor callback.
  *
  *  @param[in]  cli    Sensor client instance.
  *  @param[in]  ctx    Message context parameters, or NULL to use the configured
@@ -317,7 +317,7 @@ int bt_mesh_sensor_cli_desc_get(struct bt_mesh_sensor_cli *cli,
  *
  *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::cadence callback.
+ *  bt_mesh_sensor_cli_handlers::cadence callback.
  *
  *  @param[in]  cli    Sensor client instance.
  *  @param[in]  ctx    Message context parameters, or NULL to use the configured
@@ -343,7 +343,7 @@ int bt_mesh_sensor_cli_cadence_get(struct bt_mesh_sensor_cli *cli,
  *
  *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::cadence callback.
+ *  bt_mesh_sensor_cli_handlers::cadence callback.
  *
  *  @note Only single-channel sensors support cadence.
  *
@@ -394,7 +394,7 @@ int bt_mesh_sensor_cli_cadence_set_unack(
  *
  *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::settings callback.
+ *  bt_mesh_sensor_cli_handlers::settings callback.
  *
  *  If an @c ids array is provided and the client received a response, the array
  *  will be filled with as many of the response ids as it can fit, even if the
@@ -432,7 +432,7 @@ int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
  *
  *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::setting callback.
+ *  bt_mesh_sensor_cli_handlers::setting_status callback.
  *
  *  @param[in]  cli     Sensor client instance.
  *  @param[in]  ctx     Message context parameters, or NULL to use the
@@ -460,7 +460,7 @@ int bt_mesh_sensor_cli_setting_get(struct bt_mesh_sensor_cli *cli,
  *
  *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::setting callback.
+ *  bt_mesh_sensor_cli_handlers::setting_status callback.
  *
  *  @param[in]  cli     Sensor client instance.
  *  @param[in]  ctx     Message context parameters, or NULL to use the
@@ -513,7 +513,7 @@ int bt_mesh_sensor_cli_setting_set_unack(
  *
  *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::data callback.
+ *  bt_mesh_sensor_cli_handlers::data callback.
  *
  *  @param[in]  cli    Sensor client instance.
  *  @param[in]  ctx    Message context parameters, or NULL to use the configured
@@ -538,7 +538,7 @@ int bt_mesh_sensor_cli_get(
  *
  *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::series_entries callback as a list of
+ *  bt_mesh_sensor_cli_handlers::series_entry callback as a list of
  *  sensor descriptors.
  *
  *  @param[in]  cli    Sensor client instance.
@@ -579,7 +579,7 @@ int bt_mesh_sensor_cli_series_entry_get(
  *
  *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
- *  @ref bt_mesh_sensor_cli_handlers::series_entries callback as a list of
+ *  bt_mesh_sensor_cli_handlers::series_entry callback as a list of
  *  sensor descriptors.
  *
  *  @param[in]     cli    Sensor client instance.

--- a/include/bluetooth/mesh/sensor_srv.h
+++ b/include/bluetooth/mesh/sensor_srv.h
@@ -29,8 +29,8 @@ struct bt_mesh_sensor_srv;
  *        sensor type. Duplicate sensors will be ignored.
  *
  *  @param[in] _sensors Array of pointers to sensors owned by this server.
- *  @param[in] _count Number of sensors in the array. Can at most be @ref
- *                    CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX.
+ *  @param[in] _count Number of sensors in the array. Can at most be
+ *                    @em CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX.
  */
 #define BT_MESH_SENSOR_SRV_INIT(_sensors, _count)                              \
 	{                                                                      \

--- a/include/bluetooth/mesh/sensor_types.h
+++ b/include/bluetooth/mesh/sensor_types.h
@@ -24,7 +24,7 @@ extern "C" {
  *
  *  @brief Force the given sensor type to be included in the build.
  *
- *  If @ref CONFIG_BT_MESH_SENSOR_FORCE_ALL is disabled, only referenced sensor
+ *  If @em CONFIG_BT_MESH_SENSOR_FORCE_ALL is disabled, only referenced sensor
  *  types will be included in the build, and the node will be unable to
  *  interpret the rest. Use this macro inside a function to force the type to be
  *  included in the build:

--- a/include/bluetooth/scan.h
+++ b/include/bluetooth/scan.h
@@ -293,7 +293,7 @@ struct bt_scan_device_info {
 
 	/** Received advertising data. If further
 	 *  data proccesing is needed, you should
-	 *  use @ref bt_data_parse to get specific
+	 *  use @em bt_data_parse() to get specific
 	 *  advertising data type.
 	 */
 	struct net_buf_simple *adv_data;
@@ -445,7 +445,7 @@ void bt_scan_update_init_conn_params(struct bt_le_conn_param *new_conn_param);
  * @param[in] mode Filter mode: @ref BT_SCAN_FILTER_MODE.
  * @param[in] match_all If this flag is set, all types of enabled filters
  *                      must be matched before generating
- *                      @ref BT_SCAN_EVT_FILTER_MATCH to the main
+ *                      @em BT_SCAN_EVT_FILTER_MATCH to the main
  *                      application. Otherwise, it is enough to
  *                      match one filter to trigger the filter match event.
  *

--- a/include/bluetooth/services/hids_c.h
+++ b/include/bluetooth/services/hids_c.h
@@ -33,7 +33,7 @@ struct bt_gatt_hids_c_rep_info;
  * This function is called when new data related to the given report object
  * appears.
  * The data size can be obtained from the report object from the
- * @ref bt_gatt_hids_c_rep_info::size field.
+ * @em bt_gatt_hids_c_rep_info::size field.
  *
  * @param hids_c HIDS client object.
  * @param rep    Report object.

--- a/include/date_time.h
+++ b/include/date_time.h
@@ -58,4 +58,6 @@ void date_time_update(void);
 }
 #endif
 
+/** @} */
+
 #endif /* DATE_TIME_H__ */

--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -120,4 +120,6 @@ int dfu_target_reset(void);
 }
 #endif
 
+/** @} */
+
 #endif /* DFU_TARGET_H__ */

--- a/include/drivers/gps.h
+++ b/include/drivers/gps.h
@@ -176,7 +176,7 @@ struct gps_event {
 };
 
 /**
- * @typedef gps_evt_handler_t
+ * @typedef gps_event_handler_t
  * @brief Callback API on GPS event
  *
  * @param dev Pointer to GPS device
@@ -202,7 +202,7 @@ typedef int (*gps_start_t)(struct device *dev, struct gps_config *cfg);
 typedef int (*gps_stop_t)(struct device *dev);
 
 /**
- * @typedef gps_write_t
+ * @typedef gps_agps_write_t
  * @brief Callback API for writing to A-GPS data to GPS module.
  *
  * See gps_write() for argument description
@@ -290,6 +290,7 @@ static inline int gps_stop(struct device *dev)
  * @param dev Pointer to GPS device
  * @param type A-GPS data type
  * @param data Pointer to A-GPS data
+ * @param data_len Length of @p data
  *
  * @return Zero on success or (negative) error code otherwise.
  */

--- a/include/esb.h
+++ b/include/esb.h
@@ -377,7 +377,7 @@ int esb_set_base_address_1(const u8_t *addr);
  *
  *  @param[in] prefixes		Prefixes for each pipe.
  *  @param[in] num_pipes	Number of pipes. Must be less than or equal to
- *				@ref CONFIG_ESB_PIPE_COUNT.
+ *				@em CONFIG_ESB_PIPE_COUNT.
  *
  * @retval 0 If successful.
  *           Otherwise, a (negative) error code is returned.
@@ -388,7 +388,7 @@ int esb_set_prefixes(const u8_t *prefixes, u8_t num_pipes);
  *
  *  The @p enable_mask parameter must contain the same number of pipes as has
  *  been configured with @ref esb_set_prefixes. This number may not be
- *  greater than the number defined by @ref CONFIG_ESB_PIPE_COUNT
+ *  greater than the number defined by @em CONFIG_ESB_PIPE_COUNT
  *
  *  @param enable_mask	Bitfield mask to enable or disable pipes.
  *			Setting a bit to 0 disables the pipe.

--- a/include/event_manager.h
+++ b/include/event_manager.h
@@ -210,7 +210,7 @@ extern const struct event_type __stop_event_types[];
  * @param ename Name of the event.
  * @param types Types of values to profile (represented as @ref profiler_arg).
  * @param labels Labels of values to profile.
- * @param log_arg_func Function used to profile event data.
+ * @param profile_func Function used to profile event data.
  */
 #define EVENT_INFO_DEFINE(ename, types, labels, profile_func) \
 	_EVENT_INFO_DEFINE(ename, ENCODE(types), ENCODE(labels), profile_func)

--- a/include/fw_info.h
+++ b/include/fw_info.h
@@ -367,7 +367,7 @@ static inline const struct fw_info *fw_info_find(u32_t firmware_address)
  * @note This is should be called immediately before booting the other firmware
  *       since it will likely corrupt the memory of the running firmware.
  *
- * @param[in]  fw_info  Pointer to the other firmware's information structure.
+ * @param[in]  fwinfo   Pointer to the other firmware's information structure.
  * @param[in]  provide  If true, populate ext_api_in.
  *                      If false, only check whether requirements can be
  *                      satisfied.

--- a/include/modem/at_cmd.h
+++ b/include/modem/at_cmd.h
@@ -39,7 +39,7 @@ enum at_cmd_state {
 };
 
 /**
- * @typedefs at_cmd_handler_t
+ * @typedef at_cmd_handler_t
  *
  * Because this driver let multiple threads share the same socket, it must make
  * sure that the correct thread gets the correct data returned from the AT

--- a/include/modem/at_cmd.h
+++ b/include/modem/at_cmd.h
@@ -98,19 +98,19 @@ int at_cmd_write_with_callback(const char *const cmd,
  *
  * @param cmd Pointer to null terminated AT command string
  * @param buf Buffer to put the response in. NULL pointer is allowed, see
- *            behaviour explanation for @ref buf_len equals 0.
+ *            behaviour explanation for @p buf_len equals 0.
  * @param buf_len Length of response buffer. 0 length is allowed and will send
  *                the command, process the return code from the modem, but
  *                any returned data will be dropped.
- * @param state   Pointer to @ref enum at_cmd_state variable that can hold
+ * @param state   Pointer to enum @em at_cmd_state variable that can hold
  *                the error state returned by the modem. If the return state
  *                is a CMS or CME errors will the error code be returned in the
  *                the function return code as a positive value. NULL pointer is
  *                allowed.
  *
- * @note It is allowed to use the same buffer for both, @ref cmd and @ref buf
- *       parameters in order to save RAM. The function will not modify @ref buf
- *       contents until the entire @ref cmd is sent.
+ * @note It is allowed to use the same buffer for both, @p cmd and @p buf
+ *       parameters in order to save RAM. The function will not modify @p buf
+ *       contents until the entire @p cmd is sent.
  *
  * @retval 0 If command execution was successful (same as OK returned from
  *           modem). Error codes returned from the driver or by the socket are

--- a/include/modem/at_cmd_parser.h
+++ b/include/modem/at_cmd_parser.h
@@ -123,7 +123,7 @@ enum at_cmd_type {
 /**
  * @brief Identify the AT command type.
  *
- * @param[in] cmd A pointer to the AT command string.
+ * @param[in] at_cmd A pointer to the AT command string.
  *
  * @return Command type.
  */

--- a/include/modem/at_cmd_parser.h
+++ b/include/modem/at_cmd_parser.h
@@ -8,7 +8,6 @@
  * @file at_cmd_parser.h
  *
  * @defgroup at_cmd_parser AT command parser
- * @ingroup at_cmd_parser
  * @{
  * @brief Basic parser for AT commands.
  */
@@ -42,7 +41,7 @@ extern "C" {
  * @param at_params_str    AT parameters as a null-terminated string. Can be
  *                         numeric or string parameters.
  *
- * @next_param_str         In the case a string contains multiple notifications,
+ * @param next_param_str   In the case a string contains multiple notifications,
  *                         the parser will stop parsing when it is done parsing
  *                         the first notification, and return the remainder of
  *                         the string in this pointer. The return code will be
@@ -57,7 +56,7 @@ extern "C" {
  *
  * @retval 0 If the operation was successful.
  * @retval -EAGAIN New notification detected in string re-run the parser
- *                 with the string pointed to by next_param_str.
+ *                 with the string pointed to by @p next_param_str.
  * @retval -E2BIG  The at_param_list supplied cannot hold all detected
  *                 parameters in string. The list will contain the maximum
  *                 number of parameters possible.
@@ -82,23 +81,23 @@ int at_parser_max_params_from_str(const char *at_params_str,
  * If an error is returned by the parser, the content of @p list should be
  * ignored.
  *
- * @param at_params_str AT parameters as a null-terminated string. Can be
- *                      numeric or string parameters.
+ * @param at_params_str  AT parameters as a null-terminated string. Can be
+ *                       numeric or string parameters.
  *
- * @next_param_str      In the case a string contains multiple notifications,
- *                      the parser will stop parsing when it is done parsing
- *                      the first notification, and return the remainder of
- *                      the string in this pointer. The return code will be
- *                      EAGAIN. If multinotification is not used, this
- *                      pointer can be set to NULL.
+ * @param next_param_str In the case a string contains multiple notifications,
+ *                       the parser will stop parsing when it is done parsing
+ *                       the first notification, and return the remainder of
+ *                       the string in this pointer. The return code will be
+ *                       EAGAIN. If multinotification is not used, this
+ *                       pointer can be set to NULL.
  *
- * @param list          Pointer to an initialized list where parameters
- *                      are stored. Must not be NULL.
+ * @param list           Pointer to an initialized list where parameters
+ *                       are stored. Must not be NULL.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  * @retval -EAGAIN New notification detected in string re-run the parser
- *                 with the string pointed to by next_param_str.
+ *                 with the string pointed to by @p next_param_str.
  * @retval -E2BIG  The at_param_list supplied cannot hold all detected
  *                 parameters in string. The list will contain the maximum
  *                 number of parameters possible.

--- a/include/modem/at_notif.h
+++ b/include/modem/at_notif.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <zephyr/types.h>
 
 /**
- * @typedefs at_notif_handler_t
+ * @typedef at_notif_handler_t
  *
  * Because this driver let multiple threads share the same socket, it must make
  * sure that the correct thread gets the correct data returned from the AT

--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -178,7 +178,7 @@ int modem_info_short_get(enum modem_info info, u16_t *buf);
 /** @brief Request the name of a modem information data type.
  *
  * @param info The requested information type.
- * @param buf  The string where to store the name.
+ * @param name The string where to store the name.
  *
  * @return Length of received data if the operation was successful.
  *         Otherwise, a (negative) error code is returned.

--- a/include/net/aws_jobs.h
+++ b/include/net/aws_jobs.h
@@ -240,6 +240,7 @@ int aws_jobs_unsubscribe_topic_update(struct mqtt_client *const client,
  *                             incremented by 1 for every update.
  * @param[in] client_token     This can be an arbitrary value and will be
  *                             reflected in the response to the update.
+ * @param[out] topic_buf       Buffer to store the topic in.
  *
  * @retval 0       If the update is published successfully, otherwise return
  *                 mqtt_publish error code or the error code of snprintf.

--- a/include/net/ftp_client.h
+++ b/include/net/ftp_client.h
@@ -221,8 +221,8 @@ typedef void (*ftp_client_callback_t)(const u8_t *msg, u16_t len);
 
 /**@brief Initialize the FTP client library.
  *
- * @param callback ctrl_callback for FTP command result.
- * @param callback data_callback for FTP received data.
+ * @param ctrl_callback Callback for FTP command result.
+ * @param data_callback Callback for FTP received data.
  *
  * @retval 0 If successfully initialized.
  *           Otherwise, a negative value is returned.

--- a/include/net/nrf_cloud_agps.h
+++ b/include/net/nrf_cloud_agps.h
@@ -9,7 +9,6 @@
 
 /** @file nrf_cloud_agps.h
  * @brief Module to provide nRF Cloud A-GPS support to nRF9160 SiP.
- * @{
  */
 
 #include <zephyr.h>
@@ -50,10 +49,10 @@ int nrf_cloud_agps_request_all(void);
  */
 int nrf_cloud_agps_process(const char *buf, size_t buf_len, const int *socket);
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
-
-/** @} */
 
 #endif /* NRF_CLOUD_AGPS_H_ */

--- a/include/nfc/ndef/ch.h
+++ b/include/nfc/ndef/ch.h
@@ -406,7 +406,7 @@ int nfc_ndef_ch_hc_rec_payload_encode(const struct nfc_ndef_ch_hc_rec *hc_rec,
 
 /**
  * @brief Macro for accessing the NFC NDEF Handover Carrier record descriptor
- * instance that was created with @ref NFC_NDEF_CH_HC_GENERIC_RECORD_DESC_DEF.
+ * instance that was created with @em NFC_NDEF_CH_HC_GENERIC_RECORD_DESC_DEF.
  */
 #define NFC_NDEF_CH_HC_RECORD_DESC(_name) NFC_NDEF_GENERIC_RECORD_DESC(_name)
 
@@ -472,7 +472,7 @@ int nfc_ndef_ch_ac_rec_payload_encode(const struct nfc_ndef_ch_ac_rec *nfc_rec_a
 
 /**
  * @brief Macro for accessing the NFC NDEF Alternative Carrier record descriptor
- * instance that was created with @ref NFC_NDEF_AC_RECORD_DESC_DEF.
+ * instance that was created with @em NFC_NDEF_AC_RECORD_DESC_DEF.
  */
 #define NFC_NDEF_CH_AC_RECORD_DESC(_name) NFC_NDEF_GENERIC_RECORD_DESC(_name)
 

--- a/include/nfc/ndef/ch.h
+++ b/include/nfc/ndef/ch.h
@@ -185,7 +185,7 @@ int nfc_ndef_ch_rec_payload_encode(const struct nfc_ndef_ch_rec *ch_rec,
  *                           Connection Handover specification.
  * @param[in] _minor_version Minor version number of the supported
  *                           Connection Handover specification.
- * @param[in] _max_record Maximum number of local records.
+ * @param[in] _max_records Maximum number of local records.
  */
 #define NFC_NDEF_CH_RECORD_DESC_DEF(_name,			         \
 				    _rec_type_field,		         \
@@ -224,7 +224,7 @@ int nfc_ndef_ch_rec_payload_encode(const struct nfc_ndef_ch_rec *ch_rec,
  *                           Connection Handover specification.
  * @param[in] _minor_version Minor version number of the supported
  *                           Connection Handover specification.
- * @param[in] _max_record Maximum number of local records
+ * @param[in] _max_records Maximum number of local records
  *                      struct  (ac records plus optional err record).
  */
 #define NFC_NDEF_CH_HS_RECORD_DESC_DEF(_name,			   \
@@ -254,7 +254,7 @@ int nfc_ndef_ch_rec_payload_encode(const struct nfc_ndef_ch_rec *ch_rec,
  *                           Connection Handover specification.
  * @param[in] _minor_version Minor version number of the supported
  *                           Connection Handover specification.
- * @param[in] _max_record Maximum number of local records
+ * @param[in] _max_records Maximum number of local records
  *                        (cr record plus ac records).
  */
 #define NFC_NDEF_CH_HR_RECORD_DESC_DEF(_name,			   \
@@ -284,7 +284,7 @@ int nfc_ndef_ch_rec_payload_encode(const struct nfc_ndef_ch_rec *ch_rec,
  *                           Connection Handover specification.
  * @param[in] _minor_version Minor version number of the supported
  *                           Connection Handover specification.
- * @param[in] _max_record Maximum number of local records
+ * @param[in] _max_records Maximum number of local records
  *                        (ac records).
  */
 #define NFC_NDEF_CH_HM_RECORD_DESC_DEF(_name,                      \
@@ -312,7 +312,7 @@ int nfc_ndef_ch_rec_payload_encode(const struct nfc_ndef_ch_rec *ch_rec,
  *                           Connection Handover specification.
  * @param[in] _minor_version Minor version number of the supported
  *                           Connection Handover specification.
- * @param[in] _max_record Maximum number of local records (ac records).
+ * @param[in] _max_records Maximum number of local records (ac records).
  */
 #define NFC_NDEF_CH_HI_RECORD_DESC_DEF(_name,			   \
 				       _major_version,		   \
@@ -386,13 +386,9 @@ int nfc_ndef_ch_hc_rec_payload_encode(const struct nfc_ndef_ch_hc_rec *hc_rec,
  * NDEF Connection Handover record descriptor instance.
  *
  * @param[in] _name Name of the created record descriptor instance.
- * @param[in] _rec_type_field The NFC Forum Well Known Type
- *                            Handover Connection record type.
- * @param[in] _major_version Major version number of the supported
- *                           Connection Handover specification.
- * @param[in] _minor_version Minor version number of the supported
- *                           Connection Handover specification.
- * @param[in] _max_record Maximum number of local records.
+ * @param[in] _payload_id ID of the payload.
+ * @param[in] _payload_id_length Length of the payload.
+ * @param[in] _payload_desc Description of the payload.
  */
 #define NFC_NDEF_CH_HC_RECORD_DESC_DEF(_name,				    \
 				       _payload_id,			    \

--- a/include/nfc/ndef/payload_type_common.h
+++ b/include/nfc/ndef/payload_type_common.h
@@ -30,49 +30,49 @@ extern const u8_t nfc_ndef_le_oob_rec_type_field[32];
 /**
  * @brief An external reference to the type field of the Handover Select
  * record, defined in the file @c ch_rec.c. It is used in the
- * @ref NFC_NDEF_HS_RECORD_DESC_DEF macro.
+ * @em NFC_NDEF_HS_RECORD_DESC_DEF macro.
  */
 extern const u8_t nfc_ndef_ch_hs_rec_type_field[2];
 
 /**
  * @brief An external reference to the type field of the Handover Request
  * record, defined in the file @c ch_rec.c. It is used in the
- * @ref NFC_NDEF_HR_RECORD_DESC_DEF macro.
+ * @em NFC_NDEF_HR_RECORD_DESC_DEF macro.
  */
 extern const u8_t nfc_ndef_ch_hr_rec_type_field[2];
 
 /**
  * @brief An external reference to the type field of the Handover Mediation
  * Record, defined in the file @c ch_rec.c. It is used in the
- * @ref NFC_NDEF_HM_RECORD_DESC_DEF macro.
+ * @em NFC_NDEF_HM_RECORD_DESC_DEF macro.
  */
 extern const u8_t nfc_ndef_ch_hm_rec_type_field[2];
 
 /**
  * @brief An external reference to the type field of the Handover Initiate
  * Record, defined in the file @c ch_rec.c. It is used in the
- * @ref NFC_NDEF_HI_RECORD_DESC_DEF macro.
+ * @em NFC_NDEF_HI_RECORD_DESC_DEF macro.
  */
 extern const u8_t nfc_ndef_ch_hi_rec_type_field[2];
 
 /**
  * @brief An external reference to the type field of the Handover Carrier
  * Record, defined in the file @c ch_rec.c. It is used in the
- * @ref NFC_NDEF_HC_RECORD_DESC_DEF macro.
+ * @em NFC_NDEF_HC_RECORD_DESC_DEF macro.
  */
 extern const u8_t nfc_ndef_ch_hc_rec_type_field[2];
 
 /**
  * @brief External reference to the type field of the Alternative Carrier
  * Record, defined in the file @c ch_rec.c. It is used in the
- * @ref NFC_NDEF_AC_RECORD_DESC_DEF macro.
+ * @em NFC_NDEF_AC_RECORD_DESC_DEF macro.
  */
 extern const u8_t nfc_ndef_ch_ac_rec_type_field[2];
 
 /**
  * @brief External reference to the type field of the Collision Resolution
  * Record, defined in the file @c ch_rec.c. It is used in the
- * @ref NFC_NDEF_CR_RECORD_DESC_DEF macro.
+ * @em NFC_NDEF_CR_RECORD_DESC_DEF macro.
  */
 extern const u8_t nfc_ndef_ch_cr_rec_type_field[2];
 

--- a/include/nfc/ndef/tnep_rec.h
+++ b/include/nfc/ndef/tnep_rec.h
@@ -124,9 +124,8 @@ int nfc_ndef_tnep_rec_svc_param_payload(struct nfc_ndef_tnep_rec_svc_param *payl
  *        a TENP Status Record.
  *
  * This macro creates and initializes an instance of type
- * @ref nfc_ndef_record_desc and an instance of type
- * @ref nfc_tnep_status, which together constitute an instance of
- * a TNEP status record.
+ * nfc_ndef_record_desc and an instance of type nfc_ndef_tnep_rec_status,
+ * which together constitute an instance of a TNEP status record.
  *
  * Use the macro @ref NFC_NDEF_TNEP_RECORD_DESC to access the NDEF TENP record
  * descriptor instance. Use name to access a TNEP Status description.
@@ -151,9 +150,8 @@ int nfc_ndef_tnep_rec_svc_param_payload(struct nfc_ndef_tnep_rec_svc_param *payl
  *	 a TNEP Service Select Record.
  *
  * This macro creates and initializes an instance of type
- * @ref nfc_ndef_record_desc and an instance of type
- * @ref nfc_tnep_service_select, which together constitute an instance of
- * a TNEP service select record.
+ * nfc_ndef_record_desc and an instance of type nfc_ndef_tnep_rec_svc_select,
+ * which together constitute an instance of a TNEP service select record.
  *
  * Use the macro @ref NFC_NDEF_TNEP_RECORD_DESC to access the NDEF TNEP record
  * descriptor instance. Use name to access a TNEP Service Select description.
@@ -180,9 +178,8 @@ int nfc_ndef_tnep_rec_svc_param_payload(struct nfc_ndef_tnep_rec_svc_param *payl
  *	 a TNEP Service Parameter Record.
  *
  * This macro creates and initializes an instance of type
- * @ref nfc_ndef_record_desc and an instance of type
- * @ref nfc_tnep_service_parameters, which together constitute an instance of
- * a TNEP service parameter record.
+ * nfc_ndef_record_desc and an instance of type nfc_ndef_tnep_rec_svc_param,
+ * which together constitute an instance of a TNEP service parameter record.
  *
  * Use the macro @ref NFC_NDEF_TNEP_RECORD_DESC to access the
  * NDEF TNEP record descriptor instance. Use name to access a

--- a/include/nfc/tnep/poller.h
+++ b/include/nfc/tnep/poller.h
@@ -258,8 +258,8 @@ int nfc_tnep_poller_svc_read(const struct nfc_tnep_buf *svc_buf);
  * This operation is asynchronous.
  *
  * @param[in] msg Pointer to the NDEF Message which will be written.
- * @param[in] resp_data Pointer to received data buffer. Buffer must be stored
- *                      until the update procedure is finished.
+ * @param[in] resp_buf Pointer to received data buffer. Buffer must be stored
+ *                     until the update procedure is finished.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
@@ -273,7 +273,7 @@ int nfc_tnep_poller_svc_write(const struct nfc_ndef_msg_desc *msg,
  * Device read new NDEF message from NFC TNEP Tag Device.
  *
  * @param[in] data NDEF Read raw data.
- * @param[in] Read data length.
+ * @param[in] len Read data length.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.

--- a/include/nfc/tnep/tag.h
+++ b/include/nfc/tnep/tag.h
@@ -53,7 +53,7 @@ struct nfc_tnep_tag_service_cb {
  *
  * This structure contains all information about user service.
  * It contains service parameters, service parameters record
- * and services callbacks. It is used by @ref tnep_init function.
+ * and services callbacks. It is used by @em tnep_init() function.
  */
 struct nfc_tnep_tag_service {
 	/** Services parameters. */
@@ -202,7 +202,7 @@ int nfc_tnep_tag_initial_msg_create(const struct nfc_tnep_tag_service *svc,
  * This function must be called periodically from
  * thread to process the TNEP Tag Device.
  *
- * @note This function cannot be called before @ref nfc_tnep_init.
+ * @note This function cannot be called before @em nfc_tnep_init().
  */
 void nfc_tnep_tag_process(void);
 

--- a/include/nfc/tnep/tag.h
+++ b/include/nfc/tnep/tag.h
@@ -159,9 +159,9 @@ int nfc_tnep_tag_tx_msg_buffer_register(u8_t *tx_buff,
  * @brief Start communication using TNEP.
  *
  * @param[out] events TNEP Tag Events.
- * @param[in] cnt Event count. This library needs 2 events.
- * @param[in,out] Pointer to NDEF message structure. It is used to
- *                create TNEP NDEF message.
+ * @param[in] event_cnt Event count. This library needs 2 events.
+ * @param[in,out] msg Pointer to NDEF message structure. It is used to
+ *                    create TNEP NDEF message.
  * @param[in] payload_set Function for setting NDEF data for NFC TNEP
  *                        Tag Device. This library use it internally
  *                        to set raw NDEF message to the Tag NDEF file.

--- a/include/nfc/tnep/tag.h
+++ b/include/nfc/tnep/tag.h
@@ -98,9 +98,9 @@ struct nfc_tnep_tag_service {
  * @param[in] _deselect_cb Callback function, called by protocol library when
  *                         service is deselected by the Reader/Writer.
  * @param[in] _message_cb Callback function, called by protocol library when
- *                         new message is received from the Reader/Writer.
- * @parami[in] _error_cb Callback function, called by protocol library when
- *                       an internal error occurred.
+ *                        new message is received from the Reader/Writer.
+ * @param[in] _error_cb Callback function, called by protocol library when
+ *                      an internal error occurred.
  */
 #define NFC_TNEP_TAG_SERVICE_DEF(_name, _uri, _uri_length,                  \
 				 _mode, _t_wait, _n_wait,                   \
@@ -228,7 +228,7 @@ void nfc_tnep_tag_rx_msg_indicate(const u8_t *rx_buffer, size_t len);
  * selection to set service application data and use it also
  * during service data exchange with the NFC Polling Device.
  * To indicate that application has no more data use
- * @nfc_tnep_tag_tx_msg_no_app_data.
+ * nfc_tnep_tag_tx_msg_no_app_data().
  *
  * @param[in] record Pointer to application data records.
  * @param[in] cnt Records count.

--- a/include/st25r3911b_nfca.h
+++ b/include/st25r3911b_nfca.h
@@ -228,6 +228,8 @@ int st25r3911b_nfca_anticollision_start(void);
  *
  *  @param[in] tx TX data buffer.
  *  @param[in,out] rx RX data buffer.
+ *  @param[in] fdt Maximum frame delay time (according to NFC Forum Digital 2.0
+ *                 6.10.1).
  *  @param[in] auto_crc If set, the CRC is generated automatically by the
  *                      NFC Reader. Otherwise, the CRC must be added
  *                      manually to the TX buffer.

--- a/include/st25r3911b_nfca.h
+++ b/include/st25r3911b_nfca.h
@@ -181,8 +181,7 @@ int st25r3911b_nfca_init(struct k_poll_event *events, u8_t cnt,
 /** @brief Switch on the NFC Reader field.
  *
  *  @details If the field is switched on successfully,
- *           the @ref nfca_cb.field_on callback is
- *           called.
+ *           the @em nfca_cb.field_on() callback is called.
  *
  *  @retval 0 If the operation was successful.
  *            Otherwise, a (negative) error code is returned.
@@ -192,8 +191,7 @@ int st25r3911b_nfca_field_on(void);
 /** @brief Switch off the NFC Reader field.
  *
  *  @details If the field is switched off successfully,
- *           the @ref nfca_cb.field_off callback is
- *           called.
+ *           the @em nfca_cb.field_off() callback is called.
  *
  *  @retval 0 If the operation was successful.
  *            Otherwise, a (negative) error code is returned.
@@ -203,7 +201,7 @@ int st25r3911b_nfca_field_off(void);
 /** @brief Detect tag by sending a detection command.
  *
  *  @details The command is sent according to NFC Forum Digital 2.0
- *           6.6. After success, the @ref nfca_cb.tag_detected
+ *           6.6. After success, the @em nfca_cb.tag_detected()
  *           callback is called.
  *
  *  @param cmd Command.
@@ -217,8 +215,7 @@ int st25r3911b_nfca_tag_detect(enum st25r3911b_nfca_detect_cmd cmd);
  *
  *  @details The collision resolution procedure is described in
  *           NFC Forum Activity 2.0 9.4.4. After this
- *           procedure, @ref nfca_cb.anticollision_completed
- *           is called.
+ *           procedure, @em nfca_cb.anticollision_completed() is called.
  *
  *  @retval 0 If the operation was successful.
  *            Otherwise, a (negative) error code is returned.

--- a/lib/at_cmd_parser/at_utils.h
+++ b/lib/at_cmd_parser/at_utils.h
@@ -12,6 +12,7 @@
  * @{
  * @brief AT parser utility functions to deal with strings.
  */
+
 #ifndef AT_UTILS_H__
 #define AT_UTILS_H__
 
@@ -115,7 +116,7 @@ static inline bool is_separator(char chr)
 /**
  * @brief Check if character linefeed or carry return characters
  *
- * A line shift in an AT string is always identified by a '\r\n' sequence
+ * A line shift in an AT string is always identified by a '\\r\\n' sequence
  *
  * @param[in] chr Character that should be examined
  *

--- a/lib/bin/lwm2m_carrier/include/lwm2m_os.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_os.h
@@ -192,7 +192,7 @@ void lwm2m_os_log(int level, const char *fmt, ...);
  *
  * @return 0  on success
  * @return -1 on error
- * @return an error from @ref bsd_modem_dfu in case of modem DFU
+ * @return an error from @em bsd_modem_dfu in case of modem DFU
  */
 int lwm2m_os_bsdlib_init(void);
 

--- a/lib/bin/lwm2m_carrier/include/lwm2m_os.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_os.h
@@ -376,7 +376,7 @@ int lwm2m_os_sec_ca_chain_write(uint32_t sec_tag, const void *buf, size_t len);
  *                          Only valid if the operation is successful.
  * @param[out]  perm_flags  The permission flags of the credential.
  *                          Only valid if the operation is successful
- *                          and @param exists is @c true.
+ *                          and @p exists is @c true.
  *                          Not yet implemented.
  *
  * @retval 0        On success.
@@ -433,7 +433,7 @@ int lwm2m_os_sec_psk_delete(uint32_t sec_tag);
  *                        Only valid if the operation is successful.
  * @param[out] perm_flags The permission flags of the credential.
  *                        Only valid if the operation is successful
- *                        and @param exists is true.
+ *                        and @p exists is @c true.
  *                        Not yet implemented.
  *
  * @retval 0        On success.

--- a/lib/multithreading_lock/multithreading_lock.h
+++ b/lib/multithreading_lock/multithreading_lock.h
@@ -43,8 +43,8 @@ extern "C" {
  * @param[in] timeout     Timeout value for the locking API.
  *
  * @retval 0              Success
- * @retval - ::EBUSY      Returned without waiting.
- * @retval - ::EAGAIN     Waiting period timed out.
+ * @retval - @em EBUSY    Returned without waiting.
+ * @retval - @em EAGAIN   Waiting period timed out.
  */
 int multithreading_lock_acquire(k_timeout_t timeout);
 

--- a/lib/supl/include/utils.h
+++ b/lib/supl/include/utils.h
@@ -29,7 +29,7 @@ int hexstr2hex(const char *in,
  *        String shall be '\0' terminated.
  *        Newline characters are not included in the count.
  *        Example: "+CEREG: 1" -> 9
- *                 "+CEREG: 1\r\n" -> 9
+ *                 "+CEREG: 1\\r\\n" -> 9
  *
  * @param[in]   buf       String buffer
  * @param[in]   buf_len   Input buffer length


### PR DESCRIPTION
This fixes all Doxygen warnings for Doxygen 1.8.13 (the version used by the CI), there are a few warnings left for Doxygen 1.8.15 (and maybe later versions as well).

JIRA: NCSDK-4971