### PR TITLE
Fix board reference in connectivity bridge README

### DIFF
--- a/applications/connectivity_bridge/README.rst
+++ b/applications/connectivity_bridge/README.rst
@@ -46,11 +46,11 @@ It can be turned on at runtime by setting the appropriate option in the :file:`C
 Requirements
 ************
 
-The sample supports the following nRF9160-based device:
+The sample supports the following nRF52840-based device:
 
 .. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set10_start
-   :end-before: set10_end
+   :start-after: set17_start
+   :end-before: set17_end
 
 The sample also requires a USB host which can communicate with CDC ACM devices, such as a Windows or Linux PC.
 

--- a/doc/nrf/includes/boardname_tables/sample_boardnames.txt
+++ b/doc/nrf/includes/boardname_tables/sample_boardnames.txt
@@ -138,7 +138,7 @@ Set used by samples (Immutable bootloader, Event Manager, Profiler, PPI Trace)
 
 .. set9_end
 
-Set used by samples (BH1749: Ambient Light Sensor IC, USB-UART bridge, Connectivity bridge)
+Set used by samples (BH1749: Ambient Light Sensor IC)
 
 .. set10_start
 
@@ -239,3 +239,15 @@ Set used by Tests (Crypto)
 +--------------------------------+-----------+------------------------------------------------+--------------------------------+
 
 .. set16_end
+
+Set used by samples (USB-UART bridge, Connectivity bridge)
+
+.. set17_start
+
++--------------------------------+-----------+------------------+---------------------------+
+|Hardware platforms              |PCA        |Board name        |Build target               |
++================================+===========+==================+===========================+
+|:ref:`Thingy:91 <ug_thingy91>`  |PCA20035   |thingy91_nrf52840 |``thingy91_nrf52840``      |
++--------------------------------+-----------+------------------+---------------------------+
+
+.. set17_end


### PR DESCRIPTION
Fixes a typo in connectivity bridge README to now refer to thingy91_nrf52840 as build target.
Also adds a table with board description for the same target that can be referred to in samples and applications.