### PR TITLE
doc: Fixed board names in Enhanced ShockBurst sample rst

### DIFF
--- a/samples/esb/README.rst
+++ b/samples/esb/README.rst
@@ -29,13 +29,13 @@ If packets are successfully received from the Transmitter, the LED pattern will 
 Requirements
 ************
 
-* Two of the following development boards:
+The sample supports the following development kits:
 
-  * |nRF52840DK|
-  * |nRF52DK|
-  * |nRF51DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set2_start
+   :end-before: set2_end
 
-  You can mix different boards.
+You can use any two of the development kits listed above and mix different development kits.
 
 User interface
 ***************


### PR DESCRIPTION
ref: #2425 and
https://projecttools.nordicsemi.no/jira/browse/NCSDK-3933
Fixed board names in Enhanced ShockBurst: Transmitter/Receiver
sample rst
[Enhanced ShockBurst_ Transmitter_Receiver — nRF Connect SDK 1.2.99 documentation.pdf](https://github.com/nrfconnect/sdk-nrf/files/4765168/Enhanced.ShockBurst_.Transmitter_Receiver.nRF.Connect.SDK.1.2.99.documentation.pdf)

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>