### PR TITLE
doc: add css rule to hide struct/union #includes

### DIFF
--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -76,9 +76,15 @@ div.figure {
  background-color: #e82424
 }
 
-
-/* dbk tweak for doxygen-generated API headings (for RTD theme) */
-.rst-content dl.group>dt, .rst-content dl.group>dd>p, .rst-content dl.class p.breathe-sectiondef-title{
+/*
+ * dbk tweak for doxygen-generated API headings (for RTD theme)
+ */
+/* hide a heading doxygen adds before details and the details section */
+.rst-content dl.group > dt, .rst-content dl.group > dd > p,
+/* hide the #include line for every class (aka struct) and union */
+.rst-content dl.class > dd > em, .rst-content dl.union > dd > em,
+/* hide "Public Members"/"Defines"/etc heading for structs */
+.rst-content dl.class p.breathe-sectiondef-title {
    display:none !important;
 }
 .rst-content dl.group {


### PR DESCRIPTION
breathe automatically adds a "#include ..." line for every class/struct/union, and this behavior cannot be disabled at the moment. The added lines are missing the path, which makes them less useful. The issue happens because doxygen does not add the file path to the particular XML path breathe consumes to generate the page information. An alternative solution is to just hide those "#include" lines through a CSS property, which is being done here.

JIRA: NCSDK-4850