### PR TITLE
West flash improvements

### DIFF
--- a/subsys/bootloader/CMakeLists.txt
+++ b/subsys/bootloader/CMakeLists.txt
@@ -16,12 +16,3 @@ if (NOT IMAGE_NAME)
           "'prj.conf'.")
   zephyr_include_directories(include/dummy_values/)
 endif()
-
-if (DEFINED CONFIG_SOC_NRF9160 OR DEFINED CONFIG_SOC_NRF5340_CPUAPP)
-  message(WARNING "
-      --------------------------------------------------------
-      --- WARNING: When using the immutable bootloader on  ---
-      --- this SoC, the UICR must be erased when flashing. ---
-      --- E.g. by calling 'west flash --erase'             ---
-      --------------------------------------------------------")
-endif()

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.3.0-rc1-ncs1-rc3
+      revision: pull/322/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Depends on https://github.com/nrfconnect/sdk-zephyr/pull/322

Flash merged_domains.hex with west flash and remove warning about erasing while flashing the bootloader.