### PR TITLE
bluetooth: services: nus_c: validate conn before gatt write

### DIFF
--- a/subsys/bluetooth/services/nus_c.c
+++ b/subsys/bluetooth/services/nus_c.c
@@ -88,6 +88,10 @@ int bt_gatt_nus_c_send(struct bt_gatt_nus_c *nus_c, const u8_t *data,
 {
 	int err;
 
+	if (!nus_c->conn) {
+		return -ENOTCONN;
+	}
+
 	if (atomic_test_and_set_bit(&nus_c->state, NUS_C_RX_WRITE_PENDING)) {
 		return -EALREADY;
 	}


### PR DESCRIPTION
This fixes an assert where the application would try to transmit data
over the BLE connection before the connection was established.

NCSDK-5752

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>