### PR TITLE
samples: nrf53: Use SOC instead of BOARD

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -32,8 +32,10 @@ endif ()
 # Automatically include the hci_rpmsg sample as child image, and change
 # the board to be the network core.
 if (CONFIG_BT_RPMSG_NRF53)
-  if ((BOARD STREQUAL nrf5340pdk_nrf5340_cpuappns) OR
-      (BOARD STREQUAL nrf5340pdk_nrf5340_cpuapp))
+  if (CONFIG_SOC_NRF5340_CPUAPP)
+
+    message("Adding 'hci_rpmsg' sample as child image since "
+      "CONFIG_BT_RPMSG_NRF53 is set to 'y'")
 
     if (CONFIG_BT_LL_NRFXLIB_DEFAULT)
       add_overlay_config(
@@ -53,6 +55,9 @@ if (CONFIG_BT_RPMSG_NRF53)
 endif()
 
 if (CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE)
+  message("Adding 'empty_app_core' sample as child image since "
+    "CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE is set to 'y'")
+
   add_child_image(
     NAME empty_app_core
     SOURCE_DIR ${NRF_DIR}/samples/nrf5340/empty_app_core

--- a/samples/mpsl/timeslot/CMakeLists.txt
+++ b/samples/mpsl/timeslot/CMakeLists.txt
@@ -8,8 +8,7 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
-if ((BOARD STREQUAL nrf5340pdk_nrf5340_cpuappns) OR
-    (BOARD STREQUAL nrf5340pdk_nrf5340_cpuapp))
+if (CONFIG_SOC_NRF5340_CPUAPP)
   message(FATAL_ERROR "This sample is not supported on the nRF53 application core")
 endif()
 

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7bd90a18c319548415ede8f7a2edc752661aecdb
+      revision: 2400b4921ea99785da708012f84281a75d9b53ba
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Adding hci_rpmsg is dependent on the SOC, not BOARD. Same with timeslot
support. Use of the BOARD define will not work with custom boards.

Ref.: https://github.com/nrfconnect/sdk-nrf/pull/2467#discussion_r439854006