### PR TITLE
doc: tools: created minimum required and recommended tools

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -92,6 +92,7 @@ Kconfig*                                  @tejlmand
 /samples/CMakeLists.txt                   @tejlmand
 /scripts/                                 @mbolivar @tejlmand
 /scripts/hid_configurator/                @pdunaj
+/scripts/tools-versions-*.txt             @tejlmand @asle-nordic @groh @shanta-14
 /share/zephyrbuild-package/               @tejlmand
 /share/ncs-package/                       @tejlmand
 /subsys/bluetooth/                        @joerchan @carlescufi

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -135,6 +135,44 @@ set(NRF_CONTENT_OUTPUTS ${NRF_BINARY_DIR}/extracted-content.txt)
 
 configure_file(${NRF_DOXYFILE_IN} ${NRF_DOXYFILE_OUT} @ONLY)
 
+file(STRINGS ${NRF_BASE}/scripts/tools-versions-minimum.txt MINIMUM_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
+file(STRINGS ${NRF_BASE}/scripts/tools-versions-darwin.txt DARWIN_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
+file(STRINGS ${NRF_BASE}/scripts/tools-versions-win10.txt WIN10_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
+file(STRINGS ${NRF_BASE}/scripts/tools-versions-linux.txt LINUX_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
+
+foreach(os MINIMUM DARWIN WIN10 LINUX)
+  foreach(program ${${os}_VERSIONS_ALL})
+    string(REGEX REPLACE "(^[^=]*)=([^\;]*)\;*.*" "\\1" program_name "${program}")
+    string(TOUPPER ${program_name} PROGRAM_NAME_UPPER)
+    set(${PROGRAM_NAME_UPPER}_VERSION_${os} ${CMAKE_MATCH_2})
+  endforeach()
+endforeach()
+
+# Loading Zephyr requirements-base.txt first, then mcuboot, and afterwards NCS
+# specific ensures that any packages present in multiple files will present the
+# version defined by NCS.
+file(STRINGS ${ZEPHYR_BASE}/scripts/requirements-base.txt ZEPHYR_BASE_PACKAGE_VERSIONS REGEX "^[^#].*")
+file(STRINGS ${ZEPHYR_BASE}/scripts/requirements-doc.txt ZEPHYR_DOCS_PACKAGE_VERSIONS REGEX "^[^#].*")
+file(STRINGS ${MCUBOOT_BASE}/scripts/requirements.txt MCUBOOT_PACKAGE_VERSIONS REGEX "^[^#].*")
+file(STRINGS ${NRF_BASE}/scripts/requirements.txt NRF_PACKAGE_VERSIONS REGEX "^[^#].*")
+
+foreach(package ${ZEPHYR_BASE_PACKAGE_VERSIONS}
+                ${ZEPHYR_DOCS_PACKAGE_VERSIONS}
+                ${MCUBOOT_PACKAGE_VERSIONS}
+                ${NRF_PACKAGE_VERSIONS}
+)
+  string(REGEX REPLACE "(^[^>=\;]*)([\;]|([>=][^\;]*))\;*.*" "\\1" package_name "${package}")
+  string(TOUPPER ${package_name} PACKAGE_NAME_UPPER)
+  set(${PACKAGE_NAME_UPPER}_VERSION ${CMAKE_MATCH_3})
+  if("${${PACKAGE_NAME_UPPER}_VERSION}" STREQUAL "")
+    set(${PACKAGE_NAME_UPPER}_VERSION "\\ ")
+  endif()
+endforeach()
+
+set(NRF_VERSION_IN ${NRF_DOC_DIR}/versions.txt.in)
+set(NRF_RST_VERSION_OUT ${NRF_RST_OUT}/doc/nrf/versions.txt)
+configure_file(${NRF_VERSION_IN} ${NRF_RST_VERSION_OUT} @ONLY)
+
 add_custom_target(
   nrf-doxy
   COMMAND ${CMAKE_COMMAND}

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -224,6 +224,7 @@ html_redirect_pages = [
 rst_epilog = """
 .. include:: /links.txt
 .. include:: /shortcuts.txt
+.. include:: /versions.txt
 """
 
 def setup(app):

--- a/doc/nrf/getting_started.rst
+++ b/doc/nrf/getting_started.rst
@@ -16,6 +16,7 @@ After that, pick a sample that is related to the application you want to create 
    :maxdepth: 2
 
    gs_ins_os
+   gs_recommended_versions
    gs_assistant
    gs_installing
    gs_programming

--- a/doc/nrf/gs_recommended_versions.rst
+++ b/doc/nrf/gs_recommended_versions.rst
@@ -1,0 +1,196 @@
+.. _gs_recommended_versions:
+
+Required tools
+##############
+
+The following table shows the tools that are required for working with |NCS| v\ |version|.
+It lists the minimum version that is required and the version that is installed when using the :ref:`gs_app_tcm` as described in :ref:`gs_assistant`.
+
+.. tabs::
+
+   .. group-tab:: Windows
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Tool
+           - Minimum version
+           - Toolchain manager version
+         * - CMake
+           - |cmake_min_ver|
+           - |cmake_recommended_ver_win10|
+         * - dtc
+           - |dtc_min_ver|
+           - |dtc_recommended_ver_win10|
+         * - git
+           -
+           - |git_recommended_ver_win10|
+         * - GNU Arm Embedded Toolchain
+           - |gnuarmemb_min_ver|
+           - |gnuarmemb_recommended_ver_win10|
+         * - gperf
+           - |gperf_min_ver|
+           - |gperf_recommended_ver_win10|
+         * - ninja
+           - |ninja_min_ver|
+           - |ninja_recommended_ver_win10|
+         * - Python
+           - |python_min_ver|
+           - |python_recommended_ver_win10|
+         * - SEGGER Embedded Studio (Nordic Edition)
+           - |ses_min_ver|
+           - |ses_recommended_ver_win10|
+         * - west
+           - |west_min_ver|
+           - |west_recommended_ver_win10|
+
+   .. group-tab:: Linux
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Tool
+           - Minimum version
+           - Tested version
+         * - ccache
+           -
+           - |ccache_recommended_ver_linux|
+         * - CMake
+           - |cmake_min_ver|
+           - |cmake_recommended_ver_linux|
+         * - dfu_util
+           -
+           - |dfu_util_recommended_ver_linux|
+         * - dtc
+           - |dtc_min_ver|
+           - |dtc_recommended_ver_linux|
+         * - git
+           -
+           - |git_recommended_ver_linux|
+         * - GNU Arm Embedded Toolchain
+           - |gnuarmemb_min_ver|
+           - |gnuarmemb_recommended_ver_linux|
+         * - gperf
+           - |gperf_min_ver|
+           - |gperf_recommended_ver_linux|
+         * - ninja
+           - |ninja_min_ver|
+           - |ninja_recommended_ver_linux|
+         * - Python
+           - |python_min_ver|
+           - |python_recommended_ver_linux|
+         * - SEGGER Embedded Studio (Nordic Edition)
+           - |ses_min_ver|
+           - |ses_recommended_ver_linux|
+         * - west
+           - |west_min_ver|
+           - |west_recommended_ver_linux|
+
+   .. group-tab:: macOS
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Tool
+           - Minimum version
+           - Toolchain manager version
+         * - CMake
+           - |cmake_min_ver|
+           - |cmake_recommended_ver_darwin|
+         * - dtc
+           - |dtc_min_ver|
+           - |dtc_recommended_ver_darwin|
+         * - git
+           -
+           - |git_recommended_ver_darwin|
+         * - GNU Arm Embedded Toolchain
+           - |gnuarmemb_min_ver|
+           - |gnuarmemb_recommended_ver_darwin|
+         * - gperf
+           - |gperf_min_ver|
+           - |gperf_recommended_ver_darwin|
+         * - ninja
+           - |ninja_min_ver|
+           - |ninja_recommended_ver_darwin|
+         * - Python
+           - |python_min_ver|
+           - |python_recommended_ver_darwin|
+         * - SEGGER Embedded Studio (Nordic Edition)
+           - |ses_min_ver|
+           - |ses_recommended_ver_darwin|
+         * - west
+           - |west_min_ver|
+           - |west_recommended_ver_darwin|
+
+
+Required Python dependencies
+****************************
+
+The following table shows the Python packages that are required for working with |NCS| v\ |version|.
+If no version is specified, the default version provided with pip is recommended.
+If a version is specified, it is important that the installed version matches the required version.
+See :ref:`additional_deps` for instructions on how to install the Python dependencies.
+
+Building and running applications, samples, and tests
+=====================================================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Package
+     - Version
+   * - anytree
+     - |anytree_ver|
+   * - canopen
+     - |canopen_ver|
+   * - cbor
+     - |cbor_ver|
+   * - click
+     - |click_ver|
+   * - cryptography
+     - |cryptography_ver|
+   * - ecdsa
+     - |ecdsa_ver|
+   * - imagesize
+     - |imagesize_ver|
+   * - intelhex
+     - |intelhex_ver|
+   * - packaging
+     - |packaging_ver|
+   * - progress
+     - |progress_ver|
+   * - pyelftools
+     - |pyelftools_ver|
+   * - pylint
+     - |pylint_ver|
+   * - PyYAML
+     - |PyYAML_ver|
+   * - west
+     - |west_ver|
+   * - windows-curses (only Windows)
+     - |windows-curses_ver|
+
+Building documentation
+======================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Package
+     - Version
+   * - recommonmark
+     - |recommonmark_ver|
+   * - sphinxcontrib-mscgen
+     - |sphinxcontrib-mscgen_ver|
+   * - breathe
+     - |breathe_ver|
+   * - docutils
+     - |docutils_ver|
+   * - sphinx
+     - |sphinx_ver|
+   * - sphinx_rtd_theme
+     - |sphinx_rtd_theme_ver|
+   * - sphinx-tabs
+     - |sphinx-tabs_ver|
+   * - sphinxcontrib-svg2pdfconverter
+     - |sphinxcontrib-svg2pdfconverter_ver|

--- a/doc/nrf/versions.txt.in
+++ b/doc/nrf/versions.txt.in
@@ -1,0 +1,72 @@
+.. |ccache_recommended_ver_linux| replace:: @CCACHE_VERSION_LINUX@
+
+.. |cmake_min_ver| replace:: @CMAKE_VERSION_MINIMUM@
+.. |cmake_recommended_ver_win10| replace:: @CMAKE_VERSION_WIN10@
+.. |cmake_recommended_ver_darwin| replace:: @CMAKE_VERSION_DARWIN@
+.. |cmake_recommended_ver_linux| replace:: @CMAKE_VERSION_LINUX@
+
+.. |dfu_util_recommended_ver_linux| replace:: @DFU_UTIL_VERSION_LINUX@
+
+.. |dtc_min_ver| replace:: @DTC_VERSION_MINIMUM@
+.. |dtc_recommended_ver_win10| replace:: @DTC_VERSION_WIN10@
+.. |dtc_recommended_ver_darwin| replace:: @DTC_VERSION_DARWIN@
+.. |dtc_recommended_ver_linux| replace:: @DTC_VERSION_LINUX@
+
+.. |git_recommended_ver_win10| replace:: @GIT_VERSION_WIN10@
+.. |git_recommended_ver_darwin| replace:: @GIT_VERSION_DARWIN@
+.. |git_recommended_ver_linux| replace:: @GIT_VERSION_LINUX@
+
+.. |gnuarmemb_min_ver| replace:: @GNUARMEMB_VERSION_MINIMUM@
+.. |gnuarmemb_recommended_ver_win10| replace:: @GNUARMEMB_VERSION_WIN10@
+.. |gnuarmemb_recommended_ver_darwin| replace:: @GNUARMEMB_VERSION_DARWIN@
+.. |gnuarmemb_recommended_ver_linux| replace:: @GNUARMEMB_VERSION_LINUX@
+
+.. |gperf_min_ver| replace:: @GPERF_VERSION_MINIMUM@
+.. |gperf_recommended_ver_win10| replace:: @GPERF_VERSION_WIN10@
+.. |gperf_recommended_ver_darwin| replace:: @GPERF_VERSION_DARWIN@
+.. |gperf_recommended_ver_linux| replace:: @GPERF_VERSION_LINUX@
+
+.. |ninja_min_ver| replace:: @NINJA_VERSION_MINIMUM@
+.. |ninja_recommended_ver_win10| replace:: @NINJA_VERSION_WIN10@
+.. |ninja_recommended_ver_darwin| replace:: @NINJA_VERSION_DARWIN@
+.. |ninja_recommended_ver_linux| replace:: @NINJA-BUILD_VERSION_LINUX@
+
+.. |python_min_ver| replace:: @PYTHON_VERSION_MINIMUM@
+.. |python_recommended_ver_win10| replace:: @PYTHON_VERSION_WIN10@
+.. |python_recommended_ver_darwin| replace:: @PYTHON_VERSION_DARWIN@
+.. |python_recommended_ver_linux| replace:: @PYTHON3_VERSION_LINUX@
+
+.. |ses_min_ver| replace:: @SES_VERSION_MINIMUM@
+.. |ses_recommended_ver_win10| replace:: @SES_VERSION_WIN10@
+.. |ses_recommended_ver_darwin| replace:: @SES_VERSION_DARWIN@
+.. |ses_recommended_ver_linux| replace:: @SES_VERSION_LINUX@
+
+.. |west_min_ver| replace:: @WEST_VERSION_MINIMUM@
+.. |west_recommended_ver_win10| replace:: @WEST_VERSION_WIN10@
+.. |west_recommended_ver_darwin| replace:: @WEST_VERSION_DARWIN@
+.. |west_recommended_ver_linux| replace:: @WEST_VERSION_LINUX@
+
+.. |anytree_ver| replace:: @ANYTREE_VERSION@
+.. |canopen_ver| replace:: @CANOPEN_VERSION@
+.. |click_ver| replace:: @CLICK_VERSION@
+.. |cbor_ver| replace:: @CBOR_VERSION@
+.. |cryptography_ver| replace:: @CRYPTOGRAPHY_VERSION@
+.. |ecdsa_ver| replace:: @ECDSA_VERSION@
+.. |imagesize_ver| replace:: @IMAGESIZE_VERSION@
+.. |intelhex_ver| replace:: @INTELHEX_VERSION@
+.. |packaging_ver| replace:: @PACKAGING_VERSION@
+.. |progress_ver| replace:: @PROGRESS_VERSION@
+.. |pyelftools_ver| replace:: @PYELFTOOLS_VERSION@
+.. |pylint_ver| replace:: @PYLINT_VERSION@
+.. |PyYAML_ver| replace:: @PYYAML_VERSION@
+.. |west_ver| replace:: @WEST_VERSION@
+.. |windows-curses_ver| replace:: @WINDOWS-CURSES_VERSION@
+
+.. |breathe_ver| replace:: @BREATHE_VERSION@
+.. |docutils_ver| replace:: @DOCUTILS_VERSION@
+.. |recommonmark_ver| replace:: @RECOMMONMARK_VERSION@
+.. |sphinx_ver| replace:: @SPHINX_VERSION@
+.. |sphinx-tabs_ver| replace:: @SPHINX-TABS_VERSION@
+.. |sphinx_rtd_theme_ver| replace:: @SPHINX_RTD_THEME_VERSION@
+.. |sphinxcontrib-mscgen_ver| replace:: @SPHINXCONTRIB-MSCGEN_VERSION@
+.. |sphinxcontrib-svg2pdfconverter_ver| replace:: @SPHINXCONTRIB-SVG2PDFCONVERTER_VERSION@

--- a/scripts/tools-versions-darwin.txt
+++ b/scripts/tools-versions-darwin.txt
@@ -1,0 +1,10 @@
+python=3.8.2;hash=b703318dd9eb7bc5e8d97c8b95e9445f754ca22f
+git=2.26.2;hash=fd0766dbc0032ff22914cae6530440c48757c4e1
+cmake=3.13.4;hash=018b2743c40b6ed3ad033788df9c829771f38fda
+ninja=1.8.2;hash=e12c3d678a6e10a922928eeefcca2824dd56ae2f
+gperf=3.1;hash=258483ea2fd445d42d869d495504f960202fe0c3
+dtc=1.4.7;hash=0747cc9d6b50ac8a3b1b576e4509494f2258aef2
+gnuarmemb=9-2019-q4-major
+gnuarmemb-short=9-2019q4
+ses=4.52
+west=0.8.0

--- a/scripts/tools-versions-linux.txt
+++ b/scripts/tools-versions-linux.txt
@@ -1,0 +1,12 @@
+python3=3.8.0-3~18.04
+git=1:2.17.1-1ubuntu0.7
+cmake=3.17.3-0kitware1
+ninja-build=1.8.2-1
+gperf=3.1-1
+dtc=1.4.7-3ubuntu2
+gnuarmemb=9-2019-q4-major
+gnuarmemb-short=9-2019q4
+ses=4.52
+ccache=3.4.1-1
+dfu_util=0.9-1
+west=0.8.0

--- a/scripts/tools-versions-minimum.txt
+++ b/scripts/tools-versions-minimum.txt
@@ -1,0 +1,9 @@
+python=3.6
+cmake=3.13.1
+ninja=1.8.2
+gperf=3.1
+dtc=1.4.6
+gnuarmemb=9-2019-q4-major
+gnuarmemb-short=9-2019q4
+ses=4.52
+west=0.7.0

--- a/scripts/tools-versions-win10.txt
+++ b/scripts/tools-versions-win10.txt
@@ -1,0 +1,10 @@
+python=3.8.2
+git=2.26.2.windows.1
+cmake=3.13.4
+ninja=1.8.2
+gperf=3.1
+dtc=1.4.7-1
+gnuarmemb=9-2019-q4-major
+gnuarmemb-short=9-2019q4
+ses=4.52
+west=0.8.0


### PR DESCRIPTION
This commit add requirement text files for tools such as
- Python
- CMake
- GNU ARM Embedded
- SES
and more

Those files can be shared between CI and the Toolchain manager repo to
ensure those are using same versions of tools when building.

Also a page in doxygen has been created to present the main versions of those tools to
users of NCS.

Ref: NCSDK-4914

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

------

- [x] Linux-tools
- [x] Code owners for tool versions