### PR TITLE
doc: Fixed board names in USB-UART bridge sample doc

### DIFF
--- a/samples/usb/usb_uart_bridge/README.rst
+++ b/samples/usb/usb_uart_bridge/README.rst
@@ -13,11 +13,13 @@ The USB-UART bridge acts as a serial adapter, exposing 2 UART pairs to a USB hos
 Requirements
 ************
 
-* One of the following development boards:
+The sample supports the following nRF52840-based device:
 
-  * |Thingy91|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set17_start
+   :end-before: set17_end
 
-* A USB host which can communicate with CDC ACM devices, like a Windows or Linux PC
+The sample also requires a USB host which can communicate with CDC ACM devices, like a Windows or Linux PC.
 
 
 Building and running


### PR DESCRIPTION
ref: https://github.com/nrfconnect/sdk-nrf/pull/2425 and
NCSDK-3933
Fixed board names in USB-UART bridge sample documentation.

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>