### PR TITLE
doc: link to NFC user guide from Working with nRF52

### DIFF
--- a/doc/nrf/ug_nrf52.rst
+++ b/doc/nrf/ug_nrf52.rst
@@ -115,7 +115,7 @@ The range of NFC is typically <10 cm.
 
 |NCS| provides two protocol stacks for developing NFC applications: Type 2 Tag and Type 4 Tag.
 These stacks are provided in binary format in the `nrfxlib`_ repository.
-See :ref:`nrfxlib:nfc` for documentation about the NFC stacks.
+See :ref:`nrfxlib:nfc` for documentation about the NFC stacks, and :ref:`ug_nfc` for general information.
 
 The NFC stack requires the NFCT driver for nRF52 devices, which is available as part of `nrfx`_.
 The nrfx repository is included in the |NCS| as a module of the Zephyr repository.


### PR DESCRIPTION
The Working with nRF52 user guide lists different protocols.
Since we now have a Working with NFC user guide, add a link.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>