### PR TITLE
bluetooth: services: Add callback in hids_c

### DIFF
--- a/include/bluetooth/services/hids_c.h
+++ b/include/bluetooth/services/hids_c.h
@@ -382,13 +382,15 @@ int bt_gatt_hids_c_rep_write(struct bt_gatt_hids_c *hids_c,
  * @param rep    Report object.
  * @param data   Data to be sent.
  * @param length Data size.
+ * @param func   Function to be called when operation is completed.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
 int bt_gatt_hids_c_rep_write_wo_rsp(struct bt_gatt_hids_c *hids_c,
 				    struct bt_gatt_hids_c_rep_info *rep,
-				    const void *data, u8_t length);
+				    const void *data, u8_t length,
+				    bt_gatt_hids_c_write_cb func);
 
 /**
  * @brief Subscribe to report notifications.

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -99,6 +99,7 @@ Testing with another board
    If Button 1 was pressed::
 
       Caps lock send (val: 0x2)
+      Caps lock sent
 
    If Button 3 was pressed::
 

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -422,6 +422,12 @@ static void button_bootmode(void)
 	}
 }
 
+static void hidc_write_cb(struct bt_gatt_hids_c *hidc,
+			  struct bt_gatt_hids_c_rep_info *rep,
+			  u8_t err)
+{
+	printk("Caps lock sent\n");
+}
 
 static void button_capslock(void)
 {
@@ -444,7 +450,9 @@ static void button_capslock(void)
 	data = capslock_state ? 0x02 : 0;
 	err = bt_gatt_hids_c_rep_write_wo_rsp(&hids_c,
 					      hids_c.rep_boot.kbd_out,
-					      &data, sizeof(data));
+					      &data, sizeof(data),
+					      hidc_write_cb);
+
 	if (err) {
 		printk("Keyboard data write error (err: %d)\n", err);
 		return;


### PR DESCRIPTION
Change adds callback to GATT write without response in HIDS client service. This is done to inform application when the operation is completed. Sample was also modified to use new API.