### PR TITLE
cmake: Multi domain flashing using ninja flash or west flash

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2400b4921ea99785da708012f84281a75d9b53ba
+      revision: pull/324/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This is same PR as #2487 which was accidentally closed.
Please look into #2487 for old comments.

-------

This commit uses the zephyr_property_target:ZEPHYR_RUNNERS_YAML to
specify additional ZEPHYR_RUNNERS_YAML files to include when flashing
multi domain systems, such as the nRF53.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-----------

Companion: https://github.com/nrfconnect/sdk-zephyr/pull/324

------------
This produces:
```
$ west flash --build-dir build/
-- west flash: rebuilding
[1/231] Preparing syscall dependency handling

[214/221] Linking C executable zephyr/zephyr_prebuilt.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      108112 B       256 KB     41.24%
            SRAM:       35633 B        64 KB     54.37%
        IDT_LIST:         136 B         2 KB      6.64%
[221/221] Generating zephyr/merged_nrf5340pdk_nrf5340_cpunet.hex
[17/231] Performing build step for 'spm_subimage'
[1/135] Preparing syscall dependency handling

[130/135] Linking C executable zephyr/zephyr_prebuilt.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:         32 KB        32 KB    100.00%
            SRAM:        3856 B        64 KB      5.88%
        IDT_LIST:          40 B         2 KB      1.95%
[135/135] Linking C executable zephyr/zephyr.elf
[224/231] Linking C executable zephyr/zephyr_prebuilt.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      116228 B       984 KB     11.53%
            SRAM:       18526 B       384 KB      4.71%
        IDT_LIST:          72 B         2 KB      3.52%
[231/231] Generating zephyr/merged_domains.hex
-- west flash: using runner nrfjprog
-- runners.nrfjprog: Flashing file: /projects/github/ncs/nrf/samples/bluetooth/central_bas/build/zephyr/merged.hex
Parsing hex file.
Erasing page at address 0x0.
Erasing page at address 0x1000.
...
Erasing page at address 0x22000.
Erasing page at address 0x23000.
Erasing page at address 0x24000.
Applying system reset.
Checking that the area to write is not protected.
Programming device.
Applying pin reset.
-- runners.nrfjprog: Board with serial number 960133506 flashed successfully.
-- west flash: using runner nrfjprog
-- runners.nrfjprog: Flashing file: /projects/github/ncs/nrf/samples/bluetooth/central_bas/build/hci_rpmsg/zephyr/merged_nrf5340pdk_nrf5340_cpunet.hex
Parsing hex file.
Erasing page at address 0x1000000.
Erasing page at address 0x1000800.
Erasing page at address 0x1001000.
....
Erasing page at address 0x1019000.
Erasing page at address 0x1019800.
Erasing page at address 0x101A000.
Applying system reset.
Checking that the area to write is not protected.
Programming device.
Applying pin reset.
-- runners.nrfjprog: Board with serial number 960133506 flashed successfully.
```