### PR TITLE
lib: adp536x: Fix return value of init function

### DIFF
--- a/lib/adp536x/adp536x.c
+++ b/lib/adp536x/adp536x.c
@@ -293,12 +293,10 @@ int adp536x_factory_reset(void)
 
 int adp536x_init(const char *dev_name)
 {
-	int err = 0;
-
 	i2c_dev = device_get_binding(dev_name);
-	if (err) {
-		err = -ENODEV;
+	if (i2c_dev == NULL) {
+		return -ENODEV;
 	}
 
-	return err;
+	return 0;
 }


### PR DESCRIPTION
The wrong variable was returned in adp536x_init().
This patch removes redundant variable and fixes return value.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>