### PR TITLE
doc: Fixed board names in the Zigbee samples

### DIFF
--- a/samples/zigbee/light_bulb/README.rst
+++ b/samples/zigbee/light_bulb/README.rst
@@ -17,15 +17,20 @@ In the default sample configuration, the changes to the light bulb brightness ar
 Requirements
 ************
 
-* One or more of the following development kits:
+The sample supports the following development kits:
 
-  * |nRF52840DK|
-  * |nRF52833DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set8_start
+   :end-before: set8_end
 
-* The :ref:`Zigbee network coordinator <zigbee_network_coordinator_sample>` sample programmed on one separate device.
-* The :ref:`Zigbee light switch <zigbee_light_switch_sample>` sample programmed on one or more separate devices.
+You can use one or more of the development kits listed above and mix different development kits.
 
-You can mix different development kits.
+For this sample to work, the following samples also need to be programmed:
+
+* The :ref:`Zigbee network coordinator <zigbee_network_coordinator_sample>` sample on one separate device.
+* The :ref:`Zigbee light switch <zigbee_light_switch_sample>` sample on one or more separate devices.
+
+
 
 User interface
 **************

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -25,15 +25,18 @@ The sleepy behavior can be enabled by pressing **Button 3** while the light swit
 Requirements
 ************
 
-* One or more of the following development kits:
+The sample supports the following development kits:
 
-  * |nRF52840DK|
-  * |nRF52833DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set8_start
+   :end-before: set8_end
 
-* The :ref:`zigbee_network_coordinator_sample` sample programmed on one separate device.
-* The :ref:`zigbee_light_bulb_sample` sample programmed on one or more separate devices.
+You can use one or more of the development kits listed above and mix different development kits.
 
-You can mix different development kits.
+For this sample to work, the following samples also need to be programmed:
+
+* The :ref:`Zigbee network coordinator <zigbee_network_coordinator_sample>` sample on one separate device.
+* The :ref:`zigbee_light_bulb_sample` sample on one or more separate devices.
 
 .. _zigbee_light_switch_user_interface:
 

--- a/samples/zigbee/network_coordinator/README.rst
+++ b/samples/zigbee/network_coordinator/README.rst
@@ -16,15 +16,18 @@ It is a minimal implementation that supports only the network steering commissio
 Requirements
 ************
 
-* One of the following development kits:
+The sample supports the following development kits:
 
-  * |nRF52840DK|
-  * |nRF52833DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set8_start
+   :end-before: set8_end
 
-* One or both of the following samples:
+You can use one of the development kits listed above.
 
-  * The :ref:`Zigbee light bulb <zigbee_light_bulb_sample>` sample programmed on one or more separate devices.
-  * The :ref:`Zigbee light switch <zigbee_light_switch_sample>` sample programmed on one or more separate devices.
+Optionally, you can use this sample with one or both of the following samples:
+
+* The :ref:`Zigbee light bulb <zigbee_light_bulb_sample>` sample programmed on one or more separate devices.
+* The :ref:`Zigbee light switch <zigbee_light_switch_sample>` sample programmed on one or more separate devices.
 
 You can mix different development kits.
 


### PR DESCRIPTION
ref: NCSDK-3933 and
https://github.com/nrfconnect/sdk-nrf/pull/2425
Fixed board names in Zigbee samples

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>