### PR TITLE
doc: fix links to Zephyr

### DIFF
--- a/doc/nrf/doc_styleguide.rst
+++ b/doc/nrf/doc_styleguide.rst
@@ -433,7 +433,7 @@ Enums
 =====
 
 The documentation block should precede the documented element.
-This is in accordance with the `Zephyr coding style`_.
+This is in accordance with the :ref:`Zephyr coding style <zephyr:contribute_guidelines>`.
 
 
 .. code-block:: c
@@ -452,7 +452,7 @@ Structs
 =======
 
 The documentation block should precede the documented element.
-This is in accordance with the `Zephyr coding style`_.
+This is in accordance with the :ref:`Zephyr coding style <zephyr:contribute_guidelines>`.
 Make sure to add ``:members:`` when you include the API documentation in RST; otherwise, the member documentation will not show up.
 
 .. code-block:: c
@@ -498,7 +498,7 @@ Typedefs
 ========
 
 The documentation block should precede the documented element.
-This is in accordance with the `Zephyr coding style`_.
+This is in accordance with the :ref:`Zephyr coding style <zephyr:contribute_guidelines>`.
 
 .. code-block:: c
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -7,10 +7,6 @@
 .. _`official Zephyr repository`: https://github.com/zephyrproject-rtos/zephyr
 .. _`Zephyr repository`: https://github.com/zephyrproject-rtos/zephyr
 
-.. _`Zephyr coding style`: https://docs.zephyrproject.org/contribute/contribute_guidelines.html
-
-.. _`RTT Viewer`: https://docs.zephyrproject.org/latest/guides/tools/nordic_segger.html
-
 .. ### Links to MCUboot
 
 .. _`MCUboot`: https://mcuboot.com

--- a/tests/crypto/README.rst
+++ b/tests/crypto/README.rst
@@ -166,7 +166,7 @@ Testing
 =======
 
 1. Compile and program the application.
-#. Observe the result of the different test vectors in the log using `RTT Viewer`_ or a terminal emulator.
+#. Observe the result of the different test vectors in the log using :ref:`RTT Viewer <zephyr:nordic_segger>` or a terminal emulator.
    The last line of the output indicates the test result::
 
       PROJECT EXECUTION SUCCESSFUL


### PR DESCRIPTION
Links to Zephyr should link to our doc set, not the external
Zephyr documentation.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>