### PR TITLE
tree-wide: Update requirements to CMake 3.13.1

### DIFF
--- a/applications/asset_tracker/CMakeLists.txt
+++ b/applications/asset_tracker/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 set(spm_CONF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/spm.conf)
 

--- a/applications/connectivity_bridge/CMakeLists.txt
+++ b/applications/connectivity_bridge/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/applications/nrf_desktop/CMakeLists.txt
+++ b/applications/nrf_desktop/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/applications/serial_lte_modem/CMakeLists.txt
+++ b/applications/serial_lte_modem/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 # This sample runs as a non-secure application on nRF91. Therefore, it
 # requires the secure_partition_manager that prepares the required

--- a/samples/bluetooth/central_bas/CMakeLists.txt
+++ b/samples/bluetooth/central_bas/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/central_dfu_smp/CMakeLists.txt
+++ b/samples/bluetooth/central_dfu_smp/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/central_hids/CMakeLists.txt
+++ b/samples/bluetooth/central_hids/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/central_uart/CMakeLists.txt
+++ b/samples/bluetooth/central_uart/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(central_uart)

--- a/samples/bluetooth/enocean/CMakeLists.txt
+++ b/samples/bluetooth/enocean/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/llpm/CMakeLists.txt
+++ b/samples/bluetooth/llpm/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/mesh/light/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/mesh/light_switch/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light_switch/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_light_switch)

--- a/samples/bluetooth/peripheral_gatt_dm/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_gatt_dm/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/peripheral_hids_keyboard/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids_keyboard/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/peripheral_hids_mouse/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids_mouse/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/peripheral_lbs/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_lbs/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/peripheral_uart/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_uart/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/shell_bt_nus/CMakeLists.txt
+++ b/samples/bluetooth/shell_bt_nus/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bluetooth/throughput/CMakeLists.txt
+++ b/samples/bluetooth/throughput/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/bootloader/CMakeLists.txt
+++ b/samples/bootloader/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bootloader)

--- a/samples/debug/ppi_trace/CMakeLists.txt
+++ b/samples/debug/ppi_trace/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("PPI trace sample")

--- a/samples/esb/prx/CMakeLists.txt
+++ b/samples/esb/prx/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/esb/ptx/CMakeLists.txt
+++ b/samples/esb/ptx/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/event_manager/CMakeLists.txt
+++ b/samples/event_manager/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Event Manager sample")

--- a/samples/mpsl/timeslot/CMakeLists.txt
+++ b/samples/mpsl/timeslot/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/nfc/record_text/CMakeLists.txt
+++ b/samples/nfc/record_text/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 set(NRF_SUPPORTED_BOARDS
   nrf52dk_nrf52832

--- a/samples/nfc/system_off/CMakeLists.txt
+++ b/samples/nfc/system_off/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 set(NRF_SUPPORTED_BOARDS
   nrf52dk_nrf52832

--- a/samples/nfc/tag_reader/CMakeLists.txt
+++ b/samples/nfc/tag_reader/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 # Set supported board
 set(NRF_SUPPORTED_BOARDS

--- a/samples/nfc/tnep_poller/CMakeLists.txt
+++ b/samples/nfc/tnep_poller/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 # Set supported board
 set(NRF_SUPPORTED_BOARDS

--- a/samples/nfc/tnep_tag/CMakeLists.txt
+++ b/samples/nfc/tnep_tag/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 set(NRF_SUPPORTED_BOARDS
   nrf52dk_nrf52832

--- a/samples/nfc/writable_ndef_msg/CMakeLists.txt
+++ b/samples/nfc/writable_ndef_msg/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 set(NRF_SUPPORTED_BOARDS
   nrf52dk_nrf52832

--- a/samples/nrf5340/empty_app_core/CMakeLists.txt
+++ b/samples/nrf5340/empty_app_core/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp

--- a/samples/nrf9160/at_client/CMakeLists.txt
+++ b/samples/nrf9160/at_client/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/nrf9160/aws_fota/CMakeLists.txt
+++ b/samples/nrf9160/aws_fota/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 if(CONFIG_PROVISION_CERTIFICATES)

--- a/samples/nrf9160/cloud_client/CMakeLists.txt
+++ b/samples/nrf9160/cloud_client/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cloud_client)

--- a/samples/nrf9160/coap_client/CMakeLists.txt
+++ b/samples/nrf9160/coap_client/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf-coap-client)

--- a/samples/nrf9160/gps/CMakeLists.txt
+++ b/samples/nrf9160/gps/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gps_socket_sample)

--- a/samples/nrf9160/http_application_update/CMakeLists.txt
+++ b/samples/nrf9160/http_application_update/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(http_application_update)

--- a/samples/nrf9160/https_client/CMakeLists.txt
+++ b/samples/nrf9160/https_client/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(https_client)

--- a/samples/nrf9160/lte_ble_gateway/CMakeLists.txt
+++ b/samples/nrf9160/lte_ble_gateway/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 # This sample runs as a non-secure application on nRF91. Therefore, it
 # requires the secure_partition_manager that prepares the required

--- a/samples/nrf9160/lwm2m_carrier/CMakeLists.txt
+++ b/samples/nrf9160/lwm2m_carrier/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(lwm2m-carrier)

--- a/samples/nrf9160/mqtt_simple/CMakeLists.txt
+++ b/samples/nrf9160/mqtt_simple/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mqtt-simple)

--- a/samples/nrf9160/nrf_cloud_agps/CMakeLists.txt
+++ b/samples/nrf9160/nrf_cloud_agps/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_cloud_agps)

--- a/samples/nrf9160/secure_services/CMakeLists.txt
+++ b/samples/nrf9160/secure_services/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(secure_services)

--- a/samples/nrf9160/spm/CMakeLists.txt
+++ b/samples/nrf9160/spm/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/peripheral/radio_test/CMakeLists.txt
+++ b/samples/peripheral/radio_test/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 set(NRF_SUPPORTED_BOARDS
 	nrf5340pdk_nrf5340_cpunet

--- a/samples/profiler/CMakeLists.txt
+++ b/samples/profiler/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Profiler sample")

--- a/samples/usb/usb_uart_bridge/CMakeLists.txt
+++ b/samples/usb/usb_uart_bridge/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/tests/crypto/CMakeLists.txt
+++ b/tests/crypto/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(NONE)

--- a/tests/drivers/fprotect/negative/CMakeLists.txt
+++ b/tests/drivers/fprotect/negative/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/tests/drivers/fprotect/positive/CMakeLists.txt
+++ b/tests/drivers/fprotect/positive/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/tests/subsys/bluetooth/gatt_dm/CMakeLists.txt
+++ b/tests/subsys/bluetooth/gatt_dm/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/tests/subsys/bootloader/bl_crypto/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_crypto/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/tests/subsys/bootloader/bl_storage/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_storage/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/tests/subsys/bootloader/bl_validation/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_validation/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/tests/subsys/event_manager/CMakeLists.txt
+++ b/tests/subsys/event_manager/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Event Manager unit tests")

--- a/tests/subsys/fw_info/CMakeLists.txt
+++ b/tests/subsys/fw_info/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.13.1)
 
 # Modified provision(_nrf9160).hex generated with command
 # nRF9160:


### PR DESCRIPTION
To follow Zephyr upstream's 5060ca6a302f185ece606adbf07c17e3171fbd24

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

I don't know if this has been considered.