### PR TITLE
codeowners: remove documentation code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 /VERSION                                  @carlescufi @tejlmand
 /CODEOWNERS                               @carlescufi
 /LICENSE                                  @carlescufi
-/README.rst                               @ru-fu @carlescufi
+/README.rst                               @carlescufi
 /Jenkinsfile                              @thst-nordic
 /west.yml                                 @carlescufi @tejlmand
 
@@ -28,7 +28,6 @@
 # All Kconfig related files
 Kconfig*                                  @tejlmand
 # All doc related files
-/doc/                                     @ru-fu
 /doc/CMakeLists.txt                       @carlescufi
 /doc/scripts/                             @carlescufi
 /doc/**/conf.py                           @carlescufi
@@ -39,19 +38,12 @@ Kconfig*                                  @tejlmand
 /ext/                                     @carlescufi
 /include/                                 @anangl @rlubos @pizi-nordic
 /include/bluetooth/                       @joerchan
-/include/bluetooth/**/*.rst               @b-gent
-/include/bluetooth/mesh/**/*.rst          @ru-fu
 /include/bluetooth/mesh/                  @trond-snekvik @joerchan
-/include/debug/**/*.rst                   @b-gent
 /include/debug/ppi_trace.h                @nordic-krch @anangl
 /include/drivers/                         @anangl
 /include/net/                             @rlubos
 /include/nfc/                             @anangl @grochu
-/include/nfc/**/*.rst                     @b-gent
 /include/shell/                           @nordic-krch
-/include/shell/**/*.rst                   @b-gent
-/include/event_manager.rst                @b-gent
-/include/profiler.rst                     @b-gent
 /lib/bin/                                 @rlubos @lemrey
 /lib/adp536x/                             @jtguggedal
 /lib/at_cmd_parser/                       @rlubos
@@ -73,28 +65,18 @@ Kconfig*                                  @tejlmand
 /lib/date_time/                           @simensrostad
 /samples/sensor/bh1749/                   @wlgrd
 /samples/bluetooth/                       @joerchan @lemrey @carlescufi
-/samples/bluetooth/**/*.rst               @b-gent
 /samples/bluetooth/mesh/                  @trond-snekvik @joerchan
-/samples/bluetooth/mesh/**/*.rst          @ru-fu
 /samples/bootloader/                      @hakonfam @ioannisg
 /samples/debug/ppi_trace/                 @nordic-krch @anangl
-/samples/debug/**/README.rst              @b-gent
 /samples/esb/                             @lemrey
-/samples/event_manager/README.rst         @b-gent
 /samples/mpsl/                            @joerchan @rugeGerritsen
-/samples/mpsl/**/*.rst                    @b-gent
 /samples/nfc/                             @grochu
-/samples/nfc/**/README.rst                @b-gent
 /samples/nrf5340/empty_app_core/          @doki-nordic
-/samples/nrf5340/**/README.rst            @b-gent
 /samples/nrf9160/                         @rlubos @lemrey
 /samples/nrf9160/spm/                     @lemrey @hakonfam @ioannisg
 /samples/openthread/                      @MarekPorwisz @lmaciejonczyk
-/samples/openthread/**/README.rst         @greg-fer
 /samples/profiler/                        @pdunaj @pizi-nordic
-/samples/profiler/README.rst              @b-gent
 /samples/peripheral/radio_test/           @kapi-no
-/samples/peripheral/radio_test/README.rst @b-gent
 /samples/usb/usb_uart_bridge/             @jhn-nordic @jtguggedal
 /samples/zigbee/                          @maciekfabia @mariuszpos
 /samples/CMakeLists.txt                   @tejlmand
@@ -123,5 +105,3 @@ Kconfig*                                  @tejlmand
 /tests/                                   @rakons
 /tests/subsys/zigbee/                     @rakons @maciekfabia @mariuszpos
 /zephyr/                                  @carlescufi
-# Make sure docs always include tech writers
-*.rst                                     @ru-fu


### PR DESCRIPTION
Teams are responsible for adding tech writers to all PRs
that update documentation.
Therefore, we don't need to be added as code owners.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>