### PR TITLE
Bluetooth: Improve throughput of nRF53 multi-image via NRFXLIB overlay

### DIFF
--- a/subsys/bluetooth/controller/bt_ll_nrfxlib_hci_rpmsg.conf
+++ b/subsys/bluetooth/controller/bt_ll_nrfxlib_hci_rpmsg.conf
@@ -2,3 +2,5 @@
 # zephyr/samples/bluetooth/hci_rpmsg as a child image.
 
 CONFIG_BT_LL_NRFXLIB_DEFAULT=y
+CONFIG_BT_MAX_CONN=4
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251


### PR DESCRIPTION
To demonstrate the best throughput, the NCS sampls require the maximum
data length of PDU supported in the controller. The
CONFIG_BT_CTLR_DATA_LENGTH_MAX is set to 251 bytes in the sample, but
it is not well configured to hci_rpmsg in the multi-image builds.

In addition, because the controller reserves more memory space for the
maximum data length of PDU, this commit adjusts CONFIG_BT_MAX_CONN to
support at most 4 simultaneous connections accordingly.

Signed-off-by: Ryan Chu <ryan.chu@nordicsemi.no>