### PR TITLE
manifest: MCUBoot with peripheral cleanup

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.6.0-rc2-ncs1
+      revision: dc9464d003cb8fc6cc11aaf713f700928c9fc398
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
Introduce MCUBoot version with nRF peripheral cleanup
feature:
https://github.com/nrfconnect/sdk-mcuboot/pull/102

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

[DNM] untill SHA not provided