### PR TITLE
secure_services: Lock scheduler before calling secure services.

### DIFF
--- a/include/secure_services.h
+++ b/include/secure_services.h
@@ -111,6 +111,15 @@ int spm_firmware_info(uint32_t fw_address, struct fw_info *info);
  */
 int spm_prevalidate_b1_upgrade(uint32_t dst_addr, uint32_t src_addr);
 
+/** Busy wait in secure mode (debug function)
+ *
+ * This function is for writing tests that require the execution to be in
+ * secure mode
+ *
+ * @param[in]  busy_wait_us  The number of microseconds to wait for.
+ */
+void spm_busy_wait(uint32_t busy_wait_us);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -5,6 +5,20 @@
 #
 
 if (CONFIG_SPM)
+  get_cmake_property(VARIABLES              VARIABLES)
+  get_cmake_property(VARIABLES_CACHED CACHE_VARIABLES)
+
+  set(regex "^CONFIG_SPM_SERVICE.+")
+
+  list(FILTER VARIABLES        INCLUDE REGEX ${regex})
+  list(FILTER VARIABLES_CACHED INCLUDE REGEX ${regex})
+
+  foreach(var_name ${VARIABLES} ${VARIABLES_CACHED})
+    set(spm_${var_name} ${${var_name}})
+  endforeach()
+
+  set(spm_CONFIG_SPM_SECURE_SERVICES ${CONFIG_SPM_SECURE_SERVICES})
+
   add_child_image(
     NAME spm
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/spm

--- a/subsys/nonsecure/secure_services_ns.c
+++ b/subsys/nonsecure/secure_services_ns.c
@@ -38,3 +38,7 @@ NRF_NSE(int, spm_firmware_info, uint32_t fw_address, struct fw_info *info);
 #ifdef CONFIG_SPM_SERVICE_PREVALIDATE
 NRF_NSE(int, spm_prevalidate_b1_upgrade, uint32_t dst_addr, uint32_t src_addr);
 #endif /* CONFIG_SPM_SERVICE_PREVALIDATE */
+
+#ifdef CONFIG_SPM_SERVICE_BUSY_WAIT
+NRF_NSE(void, spm_busy_wait, uint32_t busy_wait_us);
+#endif /* CONFIG_SPM_SERVICE_BUSY_WAIT */

--- a/subsys/nonsecure/secure_services_ns.c
+++ b/subsys/nonsecure/secure_services_ns.c
@@ -6,15 +6,35 @@
 #include <autoconf.h>
 #include <secure_services.h>
 #include <toolchain.h>
+#include <fw_info.h>
+
+#ifdef CONFIG_SPM_SERVICE_REBOOT
+NRF_NSE(void, spm_request_system_reboot);
 
 /* Overrides the weak ARM implementation:
  * Call into secure firmware if in the non-secure firmware since the non-secure
  * firmware is not allowed to directly reboot the system.
  */
-#ifdef CONFIG_SPM_SERVICE_REBOOT
 void sys_arch_reboot(int type)
 {
 	ARG_UNUSED(type);
 	spm_request_system_reboot();
 }
-#endif
+#endif /* CONFIG_SPM_SERVICE_REBOOT */
+
+#ifdef CONFIG_SPM_SERVICE_RNG
+NRF_NSE(int, spm_request_random_number, uint8_t *output, size_t len,
+					size_t *olen);
+#endif /* CONFIG_SPM_SERVICE_RNG */
+
+#ifdef CONFIG_SPM_SERVICE_READ
+NRF_NSE(int, spm_request_read, void *destination, uint32_t addr, size_t len);
+#endif /* CONFIG_SPM_SERVICE_READ */
+
+#ifdef CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO
+NRF_NSE(int, spm_firmware_info, uint32_t fw_address, struct fw_info *info);
+#endif /* CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO */
+
+#ifdef CONFIG_SPM_SERVICE_PREVALIDATE
+NRF_NSE(int, spm_prevalidate_b1_upgrade, uint32_t dst_addr, uint32_t src_addr);
+#endif /* CONFIG_SPM_SERVICE_PREVALIDATE */

--- a/subsys/spm/CMakeLists.txt
+++ b/subsys/spm/CMakeLists.txt
@@ -8,7 +8,6 @@ zephyr_sources(spm.c)
 zephyr_sources_ifdef(CONFIG_SPM_SECURE_SERVICES secure_services.c)
 zephyr_linker_sources(SECTIONS secure_services.ld)
 
-
 if(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
   share(
     "list(APPEND ${IMAGE_NAME}BUILD_BYPRODUCTS

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -50,21 +50,28 @@ config PM_PARTITION_SIZE_SPM_SRAM
 config SPM_BOOT_SILENTLY
 	bool "Boot silently"
 	default n
+endif #IS_SPM
 
+if IS_SPM || SPM
 config SPM_SECURE_SERVICES
 	bool "Enable secure services"
-	default y
-	select ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS
+	default y if SPM
+	select ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS if IS_SPM
+	select ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS if SPM
 	help
 	  Secure services can be invoked from the Non-Secure Firmware via
 	  secure entry functions.
+	  Note: Please set this and SPM_SERVICE_* configs from the app, instead
+	  of the SPM. This ensures that the values are in sync between the two
+	  images.
+endif #IS_SPM || SPM
 
 if SPM_SECURE_SERVICES
 config SPM_SERVICE_RNG
 	bool "Request random numbers"
-	default y
-	select NORDIC_SECURITY_BACKEND
-	select FPU
+	default y if SPM
+	select NORDIC_SECURITY_BACKEND if IS_SPM
+	select FPU if IS_SPM
 
 # NORDIC_SECURITY_BACKEND is not supported on 53 yet
 	depends on ! SOC_NRF5340_CPUAPP
@@ -75,7 +82,7 @@ config SPM_SERVICE_RNG
 
 config SPM_SERVICE_READ
 	bool "Read from memory"
-	default y
+	default y if SPM
 	help
 	  The Non-Secure Firmware is not allowed to read the memory
 	  marked as secure. This service allows it to request random
@@ -93,7 +100,7 @@ config SPM_SERVICE_REBOOT
 
 config SPM_SERVICE_FIND_FIRMWARE_INFO
 	bool "Find firmware info"
-	default y
+	default y if SPM
 	help
 	  The Non-Secure Firmware is not allowed to read the memory
 	  marked as secure. This service allows it to request firmware info
@@ -102,9 +109,9 @@ config SPM_SERVICE_FIND_FIRMWARE_INFO
 config SPM_SERVICE_PREVALIDATE
 	bool "Prevalidate B1 upgrades (Requires Immutable Bootloader)"
 	default n
-	select SECURE_BOOT_CRYPTO
-	select SECURE_BOOT_VALIDATION
-	select BL_VALIDATE_FW_EXT_API_ATLEAST_OPTIONAL
+	select SECURE_BOOT_CRYPTO if IS_SPM
+	select SECURE_BOOT_VALIDATION if IS_SPM
+	select BL_VALIDATE_FW_EXT_API_ATLEAST_OPTIONAL if IS_SPM
 	help
 	  The B0 bootloader allows calls into it for prevalidating upgrades of
 	  the stage it verifies. The B0 bootloader is in secure memory, so this
@@ -113,13 +120,15 @@ config SPM_SERVICE_PREVALIDATE
 
 config SPM_SERVICE_BUSY_WAIT
 	bool "Busy wait in secure mode (debug function)"
-	default y
+	default y if TEST && SPM
+	default n
 	help
 	  Busy wait in secure mode. Will keep the CPU in secure mode for the
 	  duration specified. Use to write tests that require secure mode.
 
 endif # SPM_SECURE_SERVICES
 
+if IS_SPM
 config SPM_BLOCK_NON_SECURE_RESET
 	bool "Block system reset calls from Non-Secure domain"
 	default n #FIXME: Remove mention of debugger with regards to reboot in help text when NRF91-313 has been resolved

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -111,6 +111,13 @@ config SPM_SERVICE_PREVALIDATE
 	  secure service is needed for the app to access the prevalidation
 	  function.
 
+config SPM_SERVICE_BUSY_WAIT
+	bool "Busy wait in secure mode (debug function)"
+	default y
+	help
+	  Busy wait in secure mode. Will keep the CPU in secure mode for the
+	  duration specified. Use to write tests that require secure mode.
+
 endif # SPM_SECURE_SERVICES
 
 config SPM_BLOCK_NON_SECURE_RESET

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -9,7 +9,6 @@
 #include <power/reboot.h>
 #include <sys/util.h>
 #include <autoconf.h>
-#include <secure_services.h>
 #include <string.h>
 #include <bl_validation.h>
 
@@ -26,6 +25,9 @@
  *
  * Note: the function will be located in a Non-Secure
  * Callable region of the Secure Firmware Image.
+ *
+ * These should not be called directly. Instead call them through their wrapper
+ * functions, e.g. call spm_request_read_nse() via spm_request_read().
  */
 
 #ifdef CONFIG_SPM_SERVICE_RNG
@@ -66,7 +68,7 @@ struct read_range {
 
 
 __TZ_NONSECURE_ENTRY_FUNC
-int spm_request_read(void *destination, uint32_t addr, size_t len)
+int spm_request_read_nse(void *destination, uint32_t addr, size_t len)
 {
 	static const struct read_range ranges[] = {
 #ifdef PM_MCUBOOT_ADDRESS
@@ -101,7 +103,7 @@ int spm_request_read(void *destination, uint32_t addr, size_t len)
 
 #ifdef CONFIG_SPM_SERVICE_REBOOT
 __TZ_NONSECURE_ENTRY_FUNC
-void spm_request_system_reboot(void)
+void spm_request_system_reboot_nse(void)
 {
 	sys_reboot(SYS_REBOOT_COLD);
 }
@@ -110,7 +112,7 @@ void spm_request_system_reboot(void)
 
 #ifdef CONFIG_SPM_SERVICE_RNG
 __TZ_NONSECURE_ENTRY_FUNC
-int spm_request_random_number(uint8_t *output, size_t len, size_t *olen)
+int spm_request_random_number_nse(uint8_t *output, size_t len, size_t *olen)
 {
 	int err;
 
@@ -126,7 +128,7 @@ int spm_request_random_number(uint8_t *output, size_t len, size_t *olen)
 
 #ifdef CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO
 __TZ_NONSECURE_ENTRY_FUNC
-int spm_firmware_info(uint32_t fw_address, struct fw_info *info)
+int spm_firmware_info_nse(uint32_t fw_address, struct fw_info *info)
 {
 	const struct fw_info *tmp_info;
 
@@ -148,7 +150,7 @@ int spm_firmware_info(uint32_t fw_address, struct fw_info *info)
 
 #ifdef CONFIG_SPM_SERVICE_PREVALIDATE
 __TZ_NONSECURE_ENTRY_FUNC
-int spm_prevalidate_b1_upgrade(uint32_t dst_addr, uint32_t src_addr)
+int spm_prevalidate_b1_upgrade_nse(uint32_t dst_addr, uint32_t src_addr)
 {
 	if (!bl_validate_firmware_available()) {
 		return -ENOTSUP;

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -159,3 +159,12 @@ int spm_prevalidate_b1_upgrade_nse(uint32_t dst_addr, uint32_t src_addr)
 	return result;
 }
 #endif /* CONFIG_SPM_SERVICE_PREVALIDATE */
+
+
+#ifdef CONFIG_SPM_SERVICE_BUSY_WAIT
+__TZ_NONSECURE_ENTRY_FUNC
+void spm_busy_wait_nse(uint32_t busy_wait_us)
+{
+	k_busy_wait(busy_wait_us);
+}
+#endif /* CONFIG_SPM_SERVICE_BUSY_WAIT */

--- a/tests/subsys/spm/thread_swap/CMakeLists.txt
+++ b/tests/subsys/spm/thread_swap/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(NONE)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/spm/thread_swap/prj.conf
+++ b/tests/subsys/spm/thread_swap/prj.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_THREAD_PRIORITY=0

--- a/tests/subsys/spm/thread_swap/src/main.c
+++ b/tests/subsys/spm/thread_swap/src/main.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <ztest.h>
+#include <secure_services.h>
+#include <kernel.h>
+
+static struct k_delayed_work interrupting_work;
+static volatile bool work_done;
+
+static void work_func(struct k_work *work)
+{
+	work_done = true;
+
+	/* Call the secure service here as well, to test the added complexity of
+	 * calling secure services from two threads.
+	 */
+	spm_busy_wait(20000);
+}
+
+void test_spm_service_thread_swap1(void)
+{
+	int err;
+
+	work_done = false;
+
+	/* Set up interrupting_work to fire while spm_busy_wait() is executing.
+	 * This tests that it is safe to switch threads while a secure service
+	 * is running.
+	 */
+	k_delayed_work_init(&interrupting_work, work_func);
+	err = k_delayed_work_submit(&interrupting_work, K_MSEC(10));
+	zassert_equal(0, err, "k_delayed_work failed: %d\n", err);
+
+	/* Call into the secure service which will be interrupted. If the
+	 * scheduler is locked before entering secure services, it will prevent
+	 * work_func from being run until after the below function returns, but
+	 * this is valid behavior.
+	 */
+	spm_busy_wait(20000);
+	zassert_true(work_done, "work_func should have interrupted wait.");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(test_spm_service_thread_swap,
+			ztest_unit_test(test_spm_service_thread_swap1)
+			);
+	ztest_run_test_suite(test_spm_service_thread_swap);
+}

--- a/tests/subsys/spm/thread_swap/testcase.yaml
+++ b/tests/subsys/spm/thread_swap/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  spm.secure_services.thread_swap:
+    platform_allow: nrf9160dk_nrf9160ns nrf5340pdk_nrf5340_cpuappns
+    tags: spm secure_services thread_swap


### PR DESCRIPTION
call k_sched_lock before and k_sched_unlock after.

Rename the services from spm_foo() to spm_foo_nsc() and call
spm_foo_nsc() from spm_foo() along with k_sched_*()

Ref: NCSIDB-108

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>