### PR TITLE
doc: Fixed board names for nRF91  networking samples and applications

### DIFF
--- a/applications/serial_lte_modem/README.rst
+++ b/applications/serial_lte_modem/README.rst
@@ -9,32 +9,33 @@ An nRF9160 DK is used as the host, while the client can be simulated using eithe
 This application is an enhancement to the :ref:`at_client_sample` sample.
 It provides the following features:
 
- * Support for generic proprietary AT commands
- * Support for BSD Socket proprietary AT commands
- * Support for TCP/UDP proxy proprietary AT commands (optional)
- * Support for ICMP proprietary AT commands
- * Support for GPS proprietary AT commands
- * Support for MQTT client proprietary AT commands
- * Support for FTP client proprietary AT commands
- * Support for communication to external MCU over UART
+* Support for generic proprietary AT commands
+* Support for BSD Socket proprietary AT commands
+* Support for TCP/UDP proxy proprietary AT commands (optional)
+* Support for ICMP proprietary AT commands
+* Support for GPS proprietary AT commands
+* Support for MQTT client proprietary AT commands
+* Support for FTP client proprietary AT commands
+* Support for communication to external MCU over UART
 
 All nRF91 modem AT commands are also supported.
 
 Requirements
 ************
 
-* The following development board:
+The application supports the following development kit:
 
-    * |nRF9160DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set5_start
+   :end-before: set5_end
 
-* If the client is a PC:
+If the client is a PC, the application requires any terminal software, such as TeraTerm.
 
-    * Any terminal software, such as TeraTerm.
+If the client is an nRF52 device, the application supports the following development kits:
 
-* If the client is an nRF52 device:
-
-    * |nRF52840DK|
-    * |nRF52DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set2_start
+   :end-before: set2_end
 
 .. terminal_config
 
@@ -46,9 +47,9 @@ This means that you can use the J-Link COM port on the PC side to connect with n
 
 Terminal serial configuration:
 
-    * Hardware flow control: disabled
-    * Baud rate: 115200
-    * Parity bit: no
+* Hardware flow control: disabled
+* Baud rate: 115200
+* Parity bit: no
 
 .. note::
    * The default AT command terminator is Carrier Return and Line Feed, i.e. ``\r\n``.
@@ -80,15 +81,15 @@ The pin interconnection between nRF91 and nRF52 is presented in the following ta
 
 UART instance in use:
 
-    * nRF52840 and nRF52832 (UART0)
-    * nRF9160 (UART2)
+* nRF52840 and nRF52832 (UART0)
+* nRF9160 (UART2)
 
 UART configuration:
 
-    * Hardware flow control: enabled
-    * Baud rate: 115200
-    * Parity bit: no
-    * Operation mode: IRQ
+* Hardware flow control: enabled
+* Baud rate: 115200
+* Parity bit: no
+* Operation mode: IRQ
 
 Note that the GPIO output level on nRF91 side should be 3 V.
 
@@ -214,24 +215,24 @@ See `Terminal connection`_ section for the serial connection configuration detai
 
 When testing the application with an nRF52 client, the DKs go through the following start-up sequence:
 
-    1. nRF91 starts up and enters sleep state.
-    #. nRF52 starts up and starts a periodical timer to toggle the GPIO interface.
-    #. nRF52 deasserts the GPIO interface.
-    #. nRF91 is woken up and sends a ``Ready\r\n`` message to the nRF52.
-    #. On receiving the message, nRF52 can proceed to issue AT commands.
+1. nRF91 starts up and enters sleep state.
+#. nRF52 starts up and starts a periodical timer to toggle the GPIO interface.
+#. nRF52 deasserts the GPIO interface.
+#. nRF91 is woken up and sends a ``Ready\r\n`` message to the nRF52.
+#. On receiving the message, nRF52 can proceed to issue AT commands.
 
 Dependencies
 ************
 
 This application uses the following |NCS| libraries and drivers:
 
-    * ``nrf/drivers/lte_link_control``
-    * ``nrf/drivers/at_cmd``
-    * ``nrf/lib/bsd_lib``
-    * ``nrf/lib/at_cmd_parser``
-    * ``nrf/lib/at_notif``
-    * ``nrf/lib/modem_info``
-    * ``nrf/subsys/net/lib/ftp_client``
+* ``nrf/drivers/lte_link_control``
+* ``nrf/drivers/at_cmd``
+* ``nrf/lib/bsd_lib``
+* ``nrf/lib/at_cmd_parser``
+* ``nrf/lib/at_notif``
+* ``nrf/lib/modem_info``
+* ``nrf/subsys/net/lib/ftp_client``
 
 In addition, it uses the Secure Partition Manager sample:
 

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -20,11 +20,13 @@ For more information on the AT commands, see the `AT Commands Reference Guide`_.
 Requirements
 ************
 
-* The following development board:
+The sample supports the following development kit:
 
-  * |nRF9160DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set5_start
+   :end-before: set5_end
 
-* .. include:: /includes/spm.txt
+.. include:: /includes/spm.txt
 
 Building and running
 ********************

--- a/samples/nrf9160/coap_client/README.rst
+++ b/samples/nrf9160/coap_client/README.rst
@@ -26,12 +26,15 @@ Other resources can be configured using the Kconfig option ``CONFIG_COAP_RESOURC
 Requirements
 ************
 
-* The following development board:
+The sample supports the following development kit:
 
-  * |nRF9160DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set5_start
+   :end-before: set5_end
 
-* .. include:: /includes/spm.txt
-* A public CoAP server IP address or URL available on the internet
+The sample also requires a public CoAP server IP address or URL available on the internet.
+
+.. include:: /includes/spm.txt
 
 Building and running
 ********************

--- a/samples/nrf9160/https_client/README.rst
+++ b/samples/nrf9160/https_client/README.rst
@@ -61,11 +61,13 @@ See the comprehensive `tutorial on SSL.com`_ for instructions on how to convert 
 Requirements
 ************
 
-* The following development board:
+The sample supports the following development kit:
 
-  * |nRF9160DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set5_start
+   :end-before: set5_end
 
-* .. include:: /includes/spm.txt
+.. include:: /includes/spm.txt
 
 
 Building and running

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -22,13 +22,17 @@ Flipping the Thingy:52, which causes a change in the flip state to "UPSIDE_DOWN"
 Requirements
 ************
 
-* A `Nordic Thingy:52`_
-* The following development board:
+The sample supports the following development kit:
 
-  * |nRF9160DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set5_start
+   :end-before: set5_end
 
-* :ref:`zephyr:bluetooth-hci-uart-sample` must be programmed to the nRF52 board controller on the board.
-* .. include:: /includes/spm.txt
+Additionally, the sample requires a `Nordic Thingy:52`_.
+
+The :ref:`zephyr:bluetooth-hci-uart-sample` sample must be programmed to the nRF52 board controller on the board.
+
+.. include:: /includes/spm.txt
 
 User interface
 **************

--- a/samples/nrf9160/lwm2m_client/README.rst
+++ b/samples/nrf9160/lwm2m_client/README.rst
@@ -42,14 +42,16 @@ can also receive actuation commands such as buzzer activation and light control.
 Requirements
 ************
 
-* The following development board:
+The sample supports the following development kit:
 
-    * |nRF9160DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set5_start
+   :end-before: set5_end
 
-* .. include:: /includes/spm.txt
+The sample also requires an LwM2M server URL address available on the internet.
+For this sample, the URL address mentioned on the `Leshan Demo Server`_ page is used.
 
-* An LwM2M server URL address available on the internet.
-  For this sample, the URL address mentioned on the `Leshan Demo Server`_ page is used.
+.. include:: /includes/spm.txt
 
 Building and Running
 ********************

--- a/samples/nrf9160/mqtt_simple/README.rst
+++ b/samples/nrf9160/mqtt_simple/README.rst
@@ -13,11 +13,13 @@ The sample connects to an MQTT broker and publishes whatever data it receives on
 Requirements
 ************
 
-* The following development board:
+The sample supports the following development kit:
 
-  * |nRF9160DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set5_start
+   :end-before: set5_end
 
-* .. include:: /includes/spm.txt
+.. include:: /includes/spm.txt
 
 Building and running
 ********************


### PR DESCRIPTION
ref: NCSDK-3933 and
https://github.com/nrfconnect/sdk-nrf/pull/2425
Fixed board names for the following nRF91 networking samples:
AT client
COAP client
HTTPS client
LTE BLE gateway
LwM2M client
MQTT simple
and the serial LTE modem application

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>