### PR TITLE
west.yml: Update manifest file with v1.2.1 tags

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: 8d46f44ba488d36e5a83bc2fc57d313f4db8d1f4
+      revision: v1.2.1
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Updated the west.yml file to use v1.2.1 release tags.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>