### PR TITLE
applications: serial_lte_modem: add MQTT username/password

### DIFF
--- a/applications/serial_lte_modem/README.rst
+++ b/applications/serial_lte_modem/README.rst
@@ -156,7 +156,7 @@ MQTT AT Commands
 
 The following proprietary MQTT AT commands are used in this application:
 
-* AT#XMQTTCON=<op>[,<cid>,<url>,<port>[,<sec_tag>]]
+* AT#XMQTTCON=<op>[,<cid>,<username>,<password>,<url>,<port>[,<sec_tag>]]
 * AT#XMQTTPUB=<topic>,<datatype>,<msg>,<qos>,<retain>
 * AT#XMQTTSUB=<topic>,<qos>
 * AT#XMQTTUNSUB=<topic>


### PR DESCRIPTION
Many MQTT broker requires username/password for authentication.
This commit add username/password support to MQTT service of
Serial LTE Modem.