### PR TITLE
drivers: flash_ll_nrfxlib: Fix size of len

### DIFF
--- a/drivers/bt_ll_nrfxlib/flash/flash_ll_nrfxlib.c
+++ b/drivers/bt_ll_nrfxlib/flash/flash_ll_nrfxlib.c
@@ -34,8 +34,8 @@ static struct {
 	struct k_sem sync;
 	const void *data;
 	off_t addr;
-	u16_t len;
-	u16_t prev_len;
+	u32_t len;
+	u32_t prev_len;
 	u32_t tmp_word;      /**< Used for unalinged writes. */
 	/* NOTE: Read is not async, so not a part of this enum. */
 	enum {


### PR DESCRIPTION
Change increases size of variable used to handle operation length. This is necessary to prevent silent overflows.