### PR TITLE
samples: bluetooth: peripheral_hids_keyboard: ui doc rearrangement

### DIFF
--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -71,11 +71,11 @@ LED 3:
 
 If the `NFC_OOB_PAIRING` feature is enabled:
 
-LED 4:
-   Indicates if an NFC field is present.
-
 Button 4:
    Starts advertising.
+
+LED 4:
+   Indicates if an NFC field is present.
 
 
 Building and running


### PR DESCRIPTION
Changed the order of LED4 and Button4 in the UI section for the
Peripheral HIDS Keyboard sample to align with remaining UI
description.

Ref: NCSDK-5845

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>