### PR TITLE
cmake: disassociate board from domain

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -47,10 +47,11 @@ if (CONFIG_BT_RPMSG_NRF53)
     add_child_image(
       NAME hci_rpmsg
       SOURCE_DIR ${ZEPHYR_BASE}/samples/bluetooth/hci_rpmsg
-      DOMAIN nrf5340pdk_nrf5340_cpunet)
+      DOMAIN CPUNET
+      BOARD ${CONFIG_DOMAIN_CPUNET_BOARD})
   else()
     message(FATAL_ERROR
-      "Board ${BOARD} not supported for including hci_rpmsg as child image")
+      "SoC not supported for including hci_rpmsg as child image")
   endif()
 endif()
 
@@ -61,5 +62,6 @@ if (CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE)
   add_child_image(
     NAME empty_app_core
     SOURCE_DIR ${NRF_DIR}/samples/nrf5340/empty_app_core
-    DOMAIN nrf5340pdk_nrf5340_cpuapp)
+    DOMAIN CPUNET
+    BOARD ${CONFIG_DOMAIN_CPUNET_BOARD})
 endif()

--- a/scripts/partition_manager_output.py
+++ b/scripts/partition_manager_output.py
@@ -148,13 +148,21 @@ def main():
 
     for partition in args.input_partitions:
         fn = path.basename(partition)
-        domain_name = fn[fn.index("partitions_") + len("partitions_"):fn.index(".yml")]
+        if 'partitions_' in fn:
+            domain_name = fn[fn.index("partitions_") + len("partitions_"):fn.index(".yml")]
+        else:
+            # Root domain does not have domain suffix in the partitions file name.
+            domain_name = ''
         with open(partition, 'r') as f:
             gpm_config[domain_name] = yaml.safe_load(f)
 
     for region in args.input_regions:
         fn = path.basename(region)
-        domain_name = fn[fn.index("regions_") + len("regions_"):fn.index(".yml")]
+        if 'regions_' in fn:
+            domain_name = fn[fn.index("regions_") + len("regions_"):fn.index(".yml")]
+        else:
+            # Root domain does not have domain suffix in the regions file name.
+            domain_name = ''
         with open(region, 'r') as f:
             greg_config[domain_name] = yaml.safe_load(f)
 

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 53bfa7b0256a3927d0193b51616db7a30f07b7fd
+      revision: 5867c6e9c8805cc8067e23b23ad34240419b7c5c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Allow out of tree users with different boards to use domain
functionality without having patches.

Depends on https://github.com/nrfconnect/sdk-zephyr/pull/328

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>