### PR TITLE
doc: fix make zephyr after clean-zephyr

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -111,6 +111,7 @@ foreach(target zephyr nrf mcuboot nrfxlib kconfig)
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${TARGET_BINARY_DIR}/rst
     COMMAND ${CMAKE_COMMAND} -E remove ${TARGET_BINARY_DIR}/*.log
     COMMAND ${CMAKE_COMMAND} -E remove ${TARGET_BINARY_DIR}/*.warnings
+    COMMAND ${CMAKE_COMMAND} -E remove ${TARGET_BINARY_DIR}/last_doxy_run_tstamp
     # Remove generated HTML as well
     COMMAND ${CMAKE_COMMAND} -E remove_directory ${HTML_DIR}/${target}
   )


### PR DESCRIPTION
When running the `zephyr` target after `clean-zephyr` the build fails because a modification time script is called to run on the Doxygen XML output, which does not exist. It happens because Doxygen is not run due to a timestamp file. This adds a rule to remove the file that Zephyr uses to determine if Doxygen needs to run on clean-*.

Since `-E remove` seems to work like `rm -f` this still works for other
clean-* rules without side-effects.

JIRA: NCSDK-3012