### PR TITLE
applications: nrf_desktop: Remove assert in usb_state

### DIFF
--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -326,7 +326,6 @@ static void device_status(enum usb_dc_status_code cb_status, const u8_t *param)
 		break;
 
 	case USB_DC_DISCONNECTED:
-		__ASSERT_NO_MSG(state != USB_STATE_DISCONNECTED);
 		new_state = USB_STATE_DISCONNECTED;
 		break;
 


### PR DESCRIPTION
The USB stack may report disconnected as the first status (it was already replicated). That triggers the removed assert.