### PR TITLE
zigbee: Update sdk-nrfxlib SHA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 9f9a53a9952d85c9a5249f98c93a0d6a205a143a
+      revision: e67dc1277abd3a263f03486829d66a631b8ee4e3
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Update sdk-nrfxlib SHA to include recent fix in ZBOSS headers:
https://github.com/nrfconnect/sdk-nrfxlib/pull/212

Signed-off-by: Maciej Fabia <maciej.fabia@nordicsemi.no>