### PR TITLE
application: serial_lte_modem NCSIDB-148 SLM Two features improvement

### DIFF
--- a/applications/serial_lte_modem/README.rst
+++ b/applications/serial_lte_modem/README.rst
@@ -124,7 +124,7 @@ If the configuration option ``CONFIG_SLM_TCP_PROXY`` is defined, the following A
 * AT#XTCPSVR=<op>[,<port>[,[sec_tag]]
 * AT#XTCPCLI=<op>[,<url>,<port>[,[sec_tag]]
 * AT#XTCPSEND=<datatype>,<data>
-* AT#XTCPRECV
+* AT#XTCPRECV[=<length>]
 
 If the configuration option ``CONFIG_SLM_UDP_PROXY`` is defined, the following AT commands are available to use the UDP proxy service:
 


### PR DESCRIPTION
Customer engineering, two improvements
1. support status read of TCP Proxy server/client when it's not
started/connected yet (return socket handle -1)
2. support partial receiving of RX data. NOTE rest of RX data is
dropped and could not be fetched any more.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>