### PR TITLE
bsdlib: socket options added:

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -160,6 +160,18 @@ static int z_to_nrf_optname(int z_in_level, int z_in_optname,
 		case SO_BINDTODEVICE:
 			*nrf_out_optname = NRF_SO_BINDTODEVICE;
 			break;
+		case SO_REUSEADDR:
+			*nrf_out_optname = NRF_SO_REUSEADDR;
+			break;
+		case SO_SILENCE_ALL:
+			*nrf_out_optname = NRF_SO_SILENCE_ALL;
+			break;
+		case SO_IP_ECHO_REPLY:
+			*nrf_out_optname = NRF_SO_SILENCE_IP_ECHO_REPLY;
+			break;
+		case SO_IPV6_ECHO_REPLY:
+			*nrf_out_optname = NRF_SO_SILENCE_IPV6_ECHO_REPLY;
+			break;
 		default:
 			retval = -1;
 			break;

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2400b4921ea99785da708012f84281a75d9b53ba
+      revision: a6a1fb4642fa9ba5e5dcb5174e127a36a47d9ff6
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
- SO_SILENCE_ALL to disable/enable all replies to unexpected traffics
- SO_IP_ECHO_REPLY to disable/enable replies to IPv4 ICMPs
- SO_IPV6_ECHO_REPLY to disable/enable replies to IPv6 ICMPs
- SO_REUSEADDR to enable server address reuse

Signed-off-by: Petri Honkala <petri.honkala@nordicsemi.no>