### PR TITLE
Doc. Update module dependencies.

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -228,15 +228,24 @@ Dependencies
 
 This application uses the following |NCS| libraries and drivers:
 
+
 * :ref:`lib_nrf_cloud`
 * :ref:`modem_info_readme`
 * :ref:`at_cmd_parser_readme`
 * ``drivers/nrf9160_gps``
-* ``lib/bsd_lib``
 * ``drivers/sensor/sensor_sim``
 * :ref:`dk_buttons_and_leds_readme`
-* ``drivers/lte_link_control``
+* :ref:`lte_lc_readme`
+* |NCS| modules abstracted via the LwM2M carrier OS abstraction layer (:file:`lwm2m_os.h`)
 
-In addition, it uses the Secure Partition Manager sample:
+.. include:: /../../lib/bin/lwm2m_carrier/lwm2m_carrier.rst
+  :start-after: lwm2m_osal_mod_list_start
+  :end-before: lwm2m_osal_mod_list_end
+
+It uses the following `nrfxlib`_ libraries:
+
+* :ref:`nrfxlib:bsdlib`
+
+In addition, it uses the following sample:
 
 * :ref:`secure_partition_manager`

--- a/samples/nrf9160/lwm2m_carrier/README.rst
+++ b/samples/nrf9160/lwm2m_carrier/README.rst
@@ -38,7 +38,7 @@ Troubleshooting
 
 Bootstrapping can take several minutes.
 This is expected and dependent on the availability of the LTE link.
-During boostrap, several ``LWM2M_CARRIER_EVENT_CONNECT`` and ``LWM2M_CARRIER_EVENT_DISCONNECT`` events are printed.
+During bootstrap, several ``LWM2M_CARRIER_EVENT_CONNECT`` and ``LWM2M_CARRIER_EVENT_DISCONNECT`` events are printed.
 This is expected and is part of the bootstrapping procedure.
 
 
@@ -48,15 +48,14 @@ Dependencies
 This sample uses the following libraries:
 
 From |NCS|
-  * ``drivers/lte_link_control``
-  * :ref:`at_cmd_readme`
-  * :ref:`lib_download_client`
+  * |NCS| modules abstracted via the LwM2M carrier OS abstraction layer (:file:`lwm2m_os.h`)
+
+  .. include:: /../../lib/bin/lwm2m_carrier/lwm2m_carrier.rst
+    :start-after: lwm2m_osal_mod_list_start
+    :end-before: lwm2m_osal_mod_list_end
 
 From nrfxlib
   * :ref:`nrfxlib:bsdlib`
-
-From Zephyr
-  * :ref:`MQTT <zephyr:mqtt_socket_interface>`
 
 In addition, it uses the following samples:
 


### PR DESCRIPTION
Fix the modules' dependency list of the LwM2M carrier sample (ref: NCSDK-5734).

The module dependency list should match with:
* https://github.com/nrfconnect/sdk-nrf/blob/master/lib/bin/lwm2m_carrier/Kconfig
* https://github.com/nrfconnect/sdk-nrf/blob/master/samples/nrf9160/lwm2m_carrier/prj.conf

Most of the dependencies are required by the [LwM2M carrier lib abstraction layer](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/lib/bin/lwm2m_carrier/lwm2m_carrier.html#application-integration) and not the sample itself. My plan is to document those dependencies on a separate page and link to this page for each sample using the carrier library. Another PR will follow.