### PR TITLE
doc: Fixed board names in radio test sample readme

### DIFF
--- a/doc/nrf/includes/boardname_tables/sample_boardnames.txt
+++ b/doc/nrf/includes/boardname_tables/sample_boardnames.txt
@@ -6,7 +6,7 @@ Peripheral UART, NUS Shell Transport, Throughput) and NFC samples
 .. set1_start
 
 +--------------------------------+-----------+------------------------------------------------+--------------------------------+
-|Hardware platforms              |PCA        |Board name                                      |Build target                   |
+|Hardware platforms              |PCA        |Board name                                      |Build target                    |
 +================================+===========+================================================+================================+
 |:ref:`nRF5340 PDK <ug_nrf5340>` |PCA10095   |:ref:`nrf5340pdk_nrf5340 <nrf5340pdk_nrf5340>`  |``nrf5340pdk_nrf5340_cpuapp``   |
 |                                |           |                                                |                                |

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -30,16 +30,18 @@ See :ref:`radio_test_ui` for a list of available commands.
 Requirements
 ************
 
-* One of the following development boards:
+The sample supports the following development kits:
 
-  * |nRF5340DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set1_start
+   :end-before: set1_end
 
-    * Network core
+You can use any one of the development kits listed above.
 
-  * |nRF52840DK|
-  * |nRF52DK|
+.. note::
+   On nRF5340 DK, the sample is designed to run on the network core.
 
-* One of the following testing devices:
+The sample also requires one of the following testing devices:
 
   * Another board with the same sample.
     See :ref:`radio_test_testing_board`.


### PR DESCRIPTION
ref: https://github.com/nrfconnect/sdk-nrf/pull/2425
and NCSDK-3933
Fixed board names in radio test sample readme.

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>