### PR TITLE
CODEOWNERS: Set myself as doc Code Owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,7 +31,7 @@ Kconfig*                                  @tejlmand
 /doc/CMakeLists.txt                       @carlescufi
 /doc/scripts/                             @carlescufi
 /doc/**/conf.py                           @carlescufi
-/doc/nrf/                                 @ru-fu @b-gent
+/doc/nrf/                                 @carlescufi
 # All subfolders
 /drivers/                                 @anangl
 /drivers/bt_ll_nrfxlib/                   @anangl @rugeGerritsen


### PR DESCRIPTION
Since members of the documentation team are not to be assigned directly
with Pull Requests anymore, set myself as the documentation folder code
owner.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>