### PR TITLE
doc: Fixed board names for mesh sample README

### DIFF
--- a/doc/nrf/includes/boardname_tables/sample_boardnames.txt
+++ b/doc/nrf/includes/boardname_tables/sample_boardnames.txt
@@ -6,7 +6,7 @@ Peripheral UART, NUS Shell Transport, Throughput) and NFC samples
 .. set1_start
 
 +--------------------------------+-----------+------------------------------------------------+--------------------------------+
-|Hardware platforms              |PCA        |Board name                                      |Build target                   |
+|Hardware platforms              |PCA        |Board name                                      |Build target                    |
 +================================+===========+================================================+================================+
 |:ref:`nRF5340 PDK <ug_nrf5340>` |PCA10095   |:ref:`nrf5340pdk_nrf5340 <nrf5340pdk_nrf5340>`  |``nrf5340pdk_nrf5340_cpuapp``   |
 |                                |           |                                                |                                |

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -52,22 +52,23 @@ The model handling is implemented in :file:`src/model_handler.c`, which uses the
 Requirements
 ************
 
-* One of the following development kits:
+The sample supports the following development kits:
 
-  * |nRF5340DK|; if you use this development kit, add the following options to the configuration of the network sample:
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set1_start
+   :end-before: set1_end
 
-    .. code-block:: none
+.. note::
+   If you use nRF5340 PDK, add the following options to the configuration of the network sample:
 
-        CONFIG_BT_CTLR_TX_BUFFER_SIZE=74
-        CONFIG_BT_CTLR_DATA_LENGTH_MAX=74
+   .. code-block:: none
 
-    This is required because Bluetooth Mesh has different |BLE| Controller requirements than other Bluetooth samples.
+      CONFIG_BT_CTLR_TX_BUFFER_SIZE=74
+      CONFIG_BT_CTLR_DATA_LENGTH_MAX=74
 
-  * |nRF52840DK|
-  * |nRF52DK|
-  * |nRF51DK|
+   This is required because Bluetooth Mesh has different |BLE| Controller requirements than other Bluetooth samples.
 
-* Smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 
   * `nRF Mesh mobile app for Android`_
   * `nRF Mesh mobile app for iOS`_

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -47,30 +47,33 @@ If the model is configured to publish to a unicast address, the model handler ca
 The response from the target device updates the corresponding LED on the Mesh Light Switch device.
 If the model is configured to publish to a group address, it calls :cpp:func:`bt_mesh_onoff_cli_set_unack` instead, to avoid getting responses from multiple devices at once.
 
+
+
 Requirements
 ************
 
-* One of the following development kits:
+The sample supports the following development kits:
 
-  * |nRF5340DK|; if you use this development kit, add the following options to the configuration of the network sample:
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set1_start
+   :end-before: set1_end
 
-    .. code-block:: none
+.. note::
+   If you use nRF5340 PDK, add the following options to the configuration of the network sample:
 
-        CONFIG_BT_CTLR_TX_BUFFER_SIZE=74
-        CONFIG_BT_CTLR_DATA_LENGTH_MAX=74
+   .. code-block:: none
 
-    This is required because Bluetooth Mesh has different |BLE| Controller requirements than other Bluetooth samples.
+      CONFIG_BT_CTLR_TX_BUFFER_SIZE=74
+      CONFIG_BT_CTLR_DATA_LENGTH_MAX=74
 
-  * |nRF52840DK|
-  * |nRF52DK|
-  * |nRF51DK|
+   This is required because Bluetooth Mesh has different |BLE| Controller requirements than other Bluetooth samples.
 
-* Smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+The sample requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 
   * `nRF Mesh mobile app for Android`_
   * `nRF Mesh mobile app for iOS`_
 
-* :ref:`bluetooth_mesh_light` sample application programmed on a separate device and configured according to the Mesh Light sample's :ref:`bluetooth_mesh_light_testing` guide.
+An additional requirement is the :ref:`bluetooth_mesh_light` sample application programmed on a separate device and configured according to the Mesh Light sample's :ref:`bluetooth_mesh_light_testing` guide.
 
 User interface
 **************


### PR DESCRIPTION
ref: NCSDK-3933 and
https://github.com/nrfconnect/sdk-nrf/pull/2425
Fixed board names in the README of Mesh light
sample and Mesh light switch sample

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>