### PR TITLE
modules: Defining BOARD and DTS root in zephyr/module.yml

### DIFF
--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -28,9 +28,3 @@ if(DEFINED NRF_SUPPORTED_BUILD_TYPES)
                 message(FATAL_ERROR "${CMAKE_BUILD_TYPE} variant is not supported")
         endif()
 endif()
-
-# Add NRF_DIR as a BOARD_ROOT in case the board is in NRF_DIR
-list(APPEND BOARD_ROOT ${NRF_DIR})
-
-# Add NRF_DIR as a DTS_ROOT to include nrf/dts
-list(APPEND DTS_ROOT ${NRF_DIR})

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,6 @@
 build:
   cmake: .
   kconfig: Kconfig.nrf
+  settings:
+    board_root: .
+    dts_root: .


### PR DESCRIPTION
This commit moves BOARD_ROOT and DTS_ROOT from boilerplate.cmake into the
module.yml file.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>
