### PR TITLE
update zephyr DT helper for kconfig

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/ui/Kconfig
+++ b/samples/nrf9160/lwm2m_client/src/ui/Kconfig
@@ -9,7 +9,7 @@ menu "User Interface"
 config UI_LED_USE_PWM
 	bool "Use PWM to control LEDs"
 	default y
-	depends on $(dt_alias_enabled,rgb-pwm)
+	depends on $(dt_node_enabled,rgb-pwm)
 	select PWM if BOARD_THINGY91_NRF9160NS
 	select PWM_0 if BOARD_THINGY91_NRF9160NS
 	help
@@ -23,7 +23,7 @@ config UI_LED_USE_PWM
 config UI_BUZZER
 	bool "Enable buzzer"
 	default y
-	depends on $(dt_alias_enabled,buzzer-pwm)
+	depends on $(dt_node_enabled,buzzer-pwm)
 	select PWM if BOARD_THINGY91_NRF9160NS
 	select PWM_1 if BOARD_THINGY91_NRF9160NS
 	help

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a6a1fb4642fa9ba5e5dcb5174e127a36a47d9ff6
+      revision: pull/330/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update the name of a helper function available from kconfig to query
the devicetree in response to upstream review.

sdk-zephyr PR: https://github.com/nrfconnect/sdk-zephyr/pull/330