### PR TITLE
actions: Add a new stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: "Close stale pull requests/issues"
+on:
+  schedule:
+  - cron: "16 00 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 60 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 14 days. Note, that you can always re-open a closed pull request at any time.'
+        stale-issue-message: 'This issue has been marked as stale because it has been open (more than) 60 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 14 days. Note, that you can always re-open a closed issue at any time.'
+        days-before-stale: 60
+        days-before-close: 14
+        stale-issue-label: 'Stale'
+        stale-pr-label: 'Stale'
+        exempt-pr-labels: 'DNM,In progress,RFC'
+        exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'


### PR DESCRIPTION
Add an action that checks issues and PRs for activity and tags them as
stale if there's been no activity for 60 days.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>