### PR TITLE
mpsl: subsys: Add support for nrf21540_gpio and sky66112-11

### DIFF
--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -1,0 +1,109 @@
+.. _ug_radio_fem:
+
+Working with radio front-end modules
+####################################
+
+The |NCS| provides support for using a front-end module (FEM) for radio on a target board.
+Front-end modules usually consist of a power amplifier (PA) used for transmission and
+low-noise amplifier (LNA) used for reception. Front-end modules allow extension of radio
+range.
+
+Methods of using FEM described by this chapter cover protocol drivers using FEM support
+provided by the MPSL library only. This is true also when an application uses just one
+protocol but benefits from features provided by the MPSL. Please refer to a protocol driver
+to check if it uses FEM support provided by the MPSL.
+
+The MPLS library provides an API to configure FEM (TODO: link here). However |NCS| provides
+a friendly wrapper which configures FEM based on devicetree and Kconfig information.
+To enable FEM support there must be a node labeled `nrf_radio_fem` within device tree.
+It can be provided by target board device tree file or by an overlay.
+
+.. _ug_radio_fem_nrf21540_gpio:
+
+Support for nRF21540 in gpio mode
+*********************************
+
+To use nRF21540 in gpio mode device tree need to contain node as shown below.
+
+/ {
+    nrf_radio_fem: my_fem {
+        compatible = "nordic,nrf21540_gpio";
+        tx-en-pin  = < 13 >;
+        rx-en-pin  = < 14 >;
+        pdn-pin    = < 15 >;
+    };
+};
+
+Provided pin numbers and node name `my_fem` are just exemplary. Software FEM
+support controls `TX_EN`, `RX_EN` and `PDN` pins of the nRF21540. State of other
+control pins should be setby other means according to nRF21540 Product Specification
+what is out of scope of this user guide.
+
+Required properties:
+`tx-en-pin` Pin number of a SOC controlling `TX_EN` signal of the nRF21540
+`rx-en-pin` Pin number a SOC controlling `RX_EN` signal of the nRF21540
+`pdn-pin` Pin number of a SOC controlling `PDN` signal of the nRF21540
+
+Optional properties:
+
+`tx-en-settle-time-us`, `rx-en-settle-time-us`, `pdn-settle-time-us`,
+`trx-hold-time-us` control timing of interface signals. Provided default values are
+appropriate for most cases. If overriding them is necessary please put custom value
+just below pin mapping properties. For constraints of these values please refer to
+nRF21540 Product Specification.
+
+`tx-gain-db`, `rx-gain-db` inform protocol drivers about gain provided by the nRF21540.
+The way of writing gain information into nRF21540 is currently out of scope.
+
+Kconfig parameters:
+
+`MPSL_FEM_NRF21540_GPIO_GPIOTE_TX_EN`, `MPSL_FEM_NRF21540_GPIO_GPIOTE_RX_EN`,
+`MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN` serve to assign unique GPIOTE channel numbers
+to be used exclusively by the FEM driver.
+
+`MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_0`, `MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_1`,
+`MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_2` serve to assign unique PPI channel numbers
+to be used exclusively by the FEM driver.
+
+Support for SKY66112-11
+***********************
+
+To use SKY66112-11 device tree need to contain node as shown below.
+
+/ {
+    nrf_radio_fem: skyworks_shield {
+        compatible = "skyworks,sky66112-11";
+        ctx-pin = < 13 >;
+        crx-pin = < 14 >;
+    };
+};
+
+Name `my_fem` is just an example, there is no requirement for certain node name.
+
+Provided pin numbers and node name `my_fem` are just exemplary. Software FEM
+support controls `CTX` and `CRX` pins of the SKY66112-11. State of other
+control pins should be set by other means according to SKY66112-11 Product Specification
+what is out of scope of this user guide.
+
+Required properties:
+`ctx-en-pin` Pin number of a SOC controlling `CTX` signal of the SKY66112-11
+`crx-en-pin` Pin number a SOC controlling `CRX` signal of the SKY66112-11
+
+Optional properties:
+
+`ctx-settle-time-us`, `crx-settle-time-us` control timing of interface signals.
+Provided default values are appropriate for most cases. If overriding them is necessary
+please put custom value just below pin mapping properties. For constraints
+of these values please refer to SKY66112-11 Product Specification.
+
+`tx-gain-db`, `rx-gain-db` inform protocol drivers about gain provided by the
+SKY66112-11. Default values are accurate for SKY66112-11, but can be overridden
+when using simillar device with different gain.
+
+Kconfig parameters:
+
+`MPSL_FEM_SKY66112_11_GPIOTE_CTX`, `MPSL_FEM_SKY66112_11_GPIOTE_CRX`,
+serve to assign unique GPIOTE channel numbers to be used exclusively by the FEM driver.
+
+`MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_0`, `MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_1`,
+serve to assign unique PPI channel numbers to be used exclusively by the FEM driver.

--- a/doc/nrf/user_guides.rst
+++ b/doc/nrf/user_guides.rst
@@ -20,6 +20,7 @@ They introduce you to important concepts and guide you through developing your a
    ug_thread
    ug_zigbee
    ug_ble_controller
+   ug_radio_fem
    ug_esb
    ug_multi_image
    ug_bootloader

--- a/dts/bindings/radio_fem/nordic,nrf21540_gpio.yaml
+++ b/dts/bindings/radio_fem/nordic,nrf21540_gpio.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+
+description: >
+    This is a representation of the nRF21540 Radio Front-End module
+
+compatible: "nordic,nrf21540_gpio"
+
+include: base.yaml
+
+properties:
+    tx-en-pin:
+        type: int
+        description: >
+            Pin number of the SOC controlling TX_EN pin of the nRF21540
+
+    rx-en-pin:
+        type: int
+        description: >
+            Pin number of the SOC controlling RX_EN pin of the nRFf21540
+
+    pdn-pin:
+        type: int
+        description: >
+            Pin number of the SOC controlling PDN pin of the nRF21540
+
+    tx-en-settle-time-us:
+        type: int
+        default: 13
+        description: >
+            Settling time in microseconds from state PG to TX
+
+    rx-en-settle-time-us:
+        type: int
+        default: 13
+        description: >
+            Settling time in microseconds from state PG to RX
+
+    pdn-settle-time-us:
+        type: int
+        default: 18
+        description: >
+            Settling time in microseconds from state PD to PG
+
+    trx-hold-time-us:
+        type: int
+        default: 5
+        description: >
+            Power-off time in microseconds when changing from RX or TX to PG
+
+    tx-gain-db:
+        type: int
+        default: 20
+        description: >
+            TX gain of the nRF21540 PA amplifier in dB.
+
+    rx-gain-db:
+        type: int
+        default: 20
+        description: >
+            RX gain of the nRF21540 LNA amplifier in dB.

--- a/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
+++ b/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+
+description: >
+    This is a representation of the Skyworks SKY66112-11 Radio Front-End module.
+
+compatible: "skyworks,sky66112-11"
+
+include: base.yaml
+
+properties:
+    ctx-pin:
+        type: int
+        description: >
+            Pin number of the SOC controlling CTX pin of the SKY66112-11
+
+    crx-pin:
+        type: int
+        description: >
+            Pin number of the SOC controlling CRX pin of the SKY66112-11
+
+    ctx-settle-time-us:
+        type: int
+        default: 23
+        description: >
+            Settling time in microseconds from activation of CTX to trasnsmit.
+
+    crx-settle-time-us:
+        type: int
+        default: 5
+        description: >
+            Settling time in microseconds from activation of CRX to receive.
+
+    tx-gain-db:
+        type: int
+        default: 22
+        description: >
+            TX gain of the PA amplifier of SKY66112-11 in dB.
+
+    rx-gain-db:
+        type: int
+        default: 11
+        description: >
+            RX gain of the LNA amplifier of SKY66112-11 in dB.

--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -24,6 +24,85 @@ config MPSL_TIMESLOT_SESSION_COUNT
 	help
 	  Maximum number of timeslot sessions.
 
+DT_COMPAT_NORDIC_NRF21540_GPIO := nordic,nrf21540_gpio
+DT_COMPAT_SKYWORKS_SKY66112_11 := skyworks,sky66112-11
+
+config MPSL_FEM
+	bool "Radio front-end module (FEM) support"
+	default $(dt_nodelabel_has_compat,nrf_radio_fem,$(DT_COMPAT_NORDIC_NRF21540_GPIO)) || \
+			$(dt_nodelabel_has_compat,nrf_radio_fem,$(DT_COMPAT_SKYWORKS_SKY66112_11))
+	help
+	  Controls if front-end module (FEM) it to be configured automatically
+	  when MPSL is initialized. Default value and type of FEM to use
+	  is determined by the devicetree.
+
+if MPSL_FEM
+
+choice MPSL_FEM_CHOICE
+	prompt "Radio front-end module (FEM) type"
+	default MPSL_FEM_NRF21540_GPIO if \
+		$(dt_nodelabel_has_compat,nrf_radio_fem,$(DT_COMPAT_NORDIC_NRF21540_GPIO))
+	default MPSL_FEM_SKY66112_11 if \
+		$(dt_nodelabel_has_compat,nrf_radio_fem,$(DT_COMPAT_SKYWORKS_SKY66112_11))
+
+config MPSL_FEM_NRF21540_GPIO
+	bool "nRF21540 front-end module in GPIO mode"
+
+config MPSL_FEM_SKY66112_11
+	bool "SKY66112-11 front-end module"
+
+endchoice	# MPSL_FEM_CHOICE
+
+if MPSL_FEM_NRF21540_GPIO
+
+config MPSL_FEM_NRF21540_GPIO_GPIOTE_TX_EN
+	int "GPIOTE channel number used to control TX_EN pin of the front-end module"
+	default 7
+
+config MPSL_FEM_NRF21540_GPIO_GPIOTE_RX_EN
+	int "GPIOTE channel number used to control RX_EN pin of the front-end module"
+	default 6
+
+config MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN
+	int "GPIOTE channel number used to control PDN pin of the front-end module"
+	default 5
+
+config MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_0
+	int "PPI channel reserved for the front-end module"
+	default 15
+
+config MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_1
+	int "PPI channel reserved for the front-end module"
+	default 16
+
+config MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_2
+	int "PPI channel reserved for the front-end module"
+	default 5
+
+endif
+
+if MPSL_FEM_SKY66112_11
+
+config MPSL_FEM_SKY66112_11_GPIOTE_CTX
+	int "GPIOTE channel number used to control CTX pin of the front-end module"
+	default 7
+
+config MPSL_FEM_SKY66112_11_GPIOTE_CRX
+	int "GPIOTE channel number used to control CRX pin of the front-end module"
+	default 6
+
+config MPSL_FEM_SKY66112_11_PPI_CHANNEL_0
+	int "PPI channel reserved for the front-end module"
+	default 15
+
+config MPSL_FEM_SKY66112_11_PPI_CHANNEL_1
+	int "PPI channel reserved for the front-end module"
+	default 16
+
+endif
+
+endif	# MPSL_FEM
+
 module=MPSL
 module-str=MPSL
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 8954ae46b2fc89a8bbd57de88c4dc48dcdb14a7f
+      revision: pull/224/head
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
User has the ability to use front-end module (FEM) type by
adding a node with label nrf_radio_fem to the devicetree.
When mpsl library is initialized selected FEM is configured
and becomes ready to use by higher layer protocol drivers.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>