### PR TITLE
doc: Document the requirement for mscgen binary

### DIFF
--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -18,6 +18,7 @@ Before you can build the documentation, install the |NCS| as described in :ref:`
 Make sure that you have installed the required :ref:`Python dependencies <additional_deps>`.
 
 See the *Installing the documentation processors* section in the :ref:`zephyr:zephyr_doc` developer guide for information about installing the required tools to build the documentation and their supported versions.
+In addition to these tools, you must install `mscgen`_ and make sure the ``mscgen`` executable is in your ``PATH``.
 
 .. note::
    On Windows, the Sphinx executable ``sphinx-build.exe`` is placed in

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -221,6 +221,8 @@
 
 .. _`Setting up an AWS account`: https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/
 
+.. _`mscgen`: http://www.mcternan.me.uk/mscgen/
+
 .. ### Links to Bluetooth specs
 
 .. _`Bluetooth Core Specification`: https://www.bluetooth.com/specifications/bluetooth-core-specification


### PR DESCRIPTION
Document that the actual mscgen executable needs to be installed and
placed in the PATH in order to build the doc.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>