### PR TITLE
doc: add a hide search matches option

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,8 @@ Kconfig*                                  @tejlmand
 # All doc related files
 /doc/CMakeLists.txt                       @carlescufi
 /doc/scripts/                             @carlescufi
+/doc/static/                              @carlescufi
+/doc/themes/                              @carlescufi
 /doc/**/conf.py                           @carlescufi
 /doc/nrf/                                 @carlescufi
 # All subfolders

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -62,3 +62,4 @@ html_show_license = True
 def setup(app):
     app.add_stylesheet("css/common.css")
     app.add_stylesheet("css/kconfig.css")
+    app.add_js_file("js/removesearch.js")

--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -172,3 +172,4 @@ intersphinx_mapping = {
 def setup(app):
     app.add_stylesheet("css/common.css")
     app.add_stylesheet("css/mcuboot.css")
+    app.add_js_file("js/removesearch.js")

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -223,3 +223,4 @@ rst_epilog = """
 def setup(app):
     app.add_stylesheet("css/common.css")
     app.add_stylesheet("css/nrf.css")
+    app.add_js_file("js/removesearch.js")

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -178,3 +178,4 @@ rst_epilog = """
 def setup(app):
     app.add_stylesheet("css/common.css")
     app.add_stylesheet("css/nrfxlib.css")
+    app.add_js_file("js/removesearch.js")

--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -104,3 +104,11 @@ div.figure {
 .rst-content div.breathe-sectiondef {
   padding-left: 0 !important;
 }
+p.highlight-link {
+  font-size: 90%;
+  margin: 0;
+  margin-top: 5px;
+}
+p.highlight-link > a {
+  color: white;
+}

--- a/doc/static/js/removesearch.js
+++ b/doc/static/js/removesearch.js
@@ -1,0 +1,12 @@
+/*
+ * When the "Hide Search Matches" (from Sphinx's doctools) link is clicked,
+ * rewrite the URL to remove the search term.
+ */
+$(document).ready(function(){
+  $('.highlight-link > a').on('click', function(){
+    // Remove any ?highlight=* search querystring element
+    window.location.assign(
+      window.location.href.replace(/[?]highlight=[^#]*/, '')
+    );
+  });
+});

--- a/doc/themes/kconfig/searchbox.html
+++ b/doc/themes/kconfig/searchbox.html
@@ -1,0 +1,12 @@
+{%- if builder != 'singlehtml' %}
+<div id="searchbox" role="search">
+  <div class="searchformwrapper">
+    <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
+      <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+      <input type="hidden" name="check_keywords" value="yes" />
+      <input type="hidden" name="area" value="default" />
+    </form>
+  </div>
+</div>
+<script>$('#searchbox').show(0);</script>
+{%- endif %}

--- a/doc/themes/mcuboot/searchbox.html
+++ b/doc/themes/mcuboot/searchbox.html
@@ -1,0 +1,12 @@
+{%- if builder != 'singlehtml' %}
+<div id="searchbox" role="search">
+  <div class="searchformwrapper">
+    <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
+      <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+      <input type="hidden" name="check_keywords" value="yes" />
+      <input type="hidden" name="area" value="default" />
+    </form>
+  </div>
+</div>
+<script>$('#searchbox').show(0);</script>
+{%- endif %}

--- a/doc/themes/nrf/searchbox.html
+++ b/doc/themes/nrf/searchbox.html
@@ -1,0 +1,12 @@
+{%- if builder != 'singlehtml' %}
+<div id="searchbox" role="search">
+  <div class="searchformwrapper">
+    <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
+      <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+      <input type="hidden" name="check_keywords" value="yes" />
+      <input type="hidden" name="area" value="default" />
+    </form>
+  </div>
+</div>
+<script>$('#searchbox').show(0);</script>
+{%- endif %}

--- a/doc/themes/nrfxlib/searchbox.html
+++ b/doc/themes/nrfxlib/searchbox.html
@@ -1,0 +1,12 @@
+{%- if builder != 'singlehtml' %}
+<div id="searchbox" role="search">
+  <div class="searchformwrapper">
+    <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
+      <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+      <input type="hidden" name="check_keywords" value="yes" />
+      <input type="hidden" name="area" value="default" />
+    </form>
+  </div>
+</div>
+<script>$('#searchbox').show(0);</script>
+{%- endif %}

--- a/doc/themes/zephyr/searchbox.html
+++ b/doc/themes/zephyr/searchbox.html
@@ -1,0 +1,12 @@
+{%- if builder != 'singlehtml' %}
+<div id="searchbox" role="search">
+  <div class="searchformwrapper">
+    <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
+      <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+      <input type="hidden" name="check_keywords" value="yes" />
+      <input type="hidden" name="area" value="default" />
+    </form>
+  </div>
+</div>
+<script>$('#searchbox').show(0);</script>
+{%- endif %}

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -344,3 +344,4 @@ def setup(app):
     app.add_stylesheet("zephyr-custom.css")
     app.add_stylesheet("css/zephyr.css")
     app.add_stylesheet("css/common.css")
+    app.add_js_file("js/removesearch.js")


### PR DESCRIPTION
This brings in the searchbox from sphinx, which also adds a "Hide Search Matches" button below the search bar, to remove the search elements highlighting.

This also adds a static js with a callback to allow rewriting the url location bar to remove the search arguments, so one can copy/paste it without submitting the hightlight terms.

JIRA: NCSDK-5245