### PR TITLE
doc: Fixed board names in nfc/system_off and nRF5340/empty_app_core

### DIFF
--- a/samples/nfc/system_off/README.rst
+++ b/samples/nfc/system_off/README.rst
@@ -44,13 +44,13 @@ See the `System OFF mode`_ page in the nRF52840 Product Specification for more i
 Requirements
 ************
 
-* One of the following development boards:
+The sample supports the following development kits:
 
-  * |nRF5340DK|
-  * |nRF52840DK|
-  * |nRF52DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set1_start
+   :end-before: set1_end
 
-* Smartphone or tablet with the NFC feature.
+The sample also requires a smartphone or tablet with the NFC feature.
 
 
 User interface

--- a/samples/nrf5340/empty_app_core/README.rst
+++ b/samples/nrf5340/empty_app_core/README.rst
@@ -25,9 +25,12 @@ It does the following things:
 
 Requirements
 ************
-The following development board:
 
-  * |nRF5340DK|
+The sample supports the following development kit:
+
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set15_start
+   :end-before: set15_end
 
 Building and running
 ********************
@@ -47,8 +50,8 @@ Dependencies
 
 This sample uses the following `nrfx`_ dependencies:
 
-  * ``nrfx/nrf.h``
-  * ``nrfx/nrfx.h``
+* ``nrfx/nrf.h``
+* ``nrfx/nrfx.h``
 
 In addition, it uses the following Zephyr libraries:
 


### PR DESCRIPTION
ref: NCSDK-3933 and
https://github.com/nrfconnect/sdk-nrf/pull/2425
Fixed board names in the sample documentation of NFC: System OFF
and nRF5340: Empty firmware for application core samples

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>