### PR TITLE
net: fota_download: Add missing first_fragment reset

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -123,6 +123,7 @@ static int download_client_callback(const struct download_client_evt *event)
 			if (res != 0) {
 				LOG_ERR("Unable to free DFU target resources");
 			}
+			first_fragment = true;
 			(void) download_client_disconnect(&dlc);
 			send_evt(FOTA_DOWNLOAD_EVT_ERROR);
 			return err;


### PR DESCRIPTION
Missed this on the last PR so this is a fixup of #2443.

Ref. NCSDK-5327

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>