### PR TITLE
net: openthread: Add possibility to use nrf_security

### DIFF
--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -6,5 +6,6 @@
 menu "Networking"
 
 rsource "lib/Kconfig"
+rsource "openthread/Kconfig"
 
 endmenu

--- a/subsys/net/openthread/CMakeLists.txt
+++ b/subsys/net/openthread/CMakeLists.txt
@@ -4,5 +4,3 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-add_subdirectory(lib)
-add_subdirectory_ifdef(CONFIG_NET_L2_OPENTHREAD openthread)

--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+if NET_L2_OPENTHREAD
+
+config OPENTHREAD_NRF_SECURITY
+	bool "Enable nrf_security module for OpenThread"
+	default y
+	depends on !OPENTHREAD_MBEDTLS
+	select NORDIC_SECURITY_BACKEND
+	select OBERON_BACKEND
+	select MBEDTLS_VANILLA_BACKEND
+	select MBEDTLS_TLS_LIBRARY
+	select VANILLA_MBEDTLS_AES_C
+	select MBEDTLS_RSA_C
+	help
+	  Enables nrf_security module for use by OpenThread. This allows
+	  OpenThread to make use of hardware accelerated cryptography functions
+	  if available as well as fast oberon backend for software encryption.
+
+
+endif


### PR DESCRIPTION
Added possibility to enable nrfsecurity for OpenThread projects.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>