### PR TITLE
doc: add a change log/release notes draft file

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -26,6 +26,8 @@
 
 .. _`change log`: https://github.com/nrfconnect/sdk-nrf/wiki/Changelog
 
+.. _`master branch section in the change log`: https://github.com/nrfconnect/sdk-nrf/wiki/Changelog#master-branch
+
 .. _`Known issues`: https://github.com/nrfconnect/sdk-nrf/wiki/Known-issues
 
 .. ### Links to Nordic documentation

--- a/doc/nrf/release_notes.rst
+++ b/doc/nrf/release_notes.rst
@@ -16,6 +16,7 @@ Important issues that are discovered after a release is tagged are listed in the
 .. toctree::
    :maxdepth: 1
 
+   releases/release-notes-latest
    releases/release-notes-1.3.0
    releases/release-notes-1.2.1
    releases/release-notes-1.2.0

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -1,0 +1,31 @@
+.. _ncs_release_notes_latest:
+
+Changes in |NCS| v1.3.99
+########################
+
+The most relevant changes that are present on the master branch of the |NCS|, as compared to the latest release, are tracked in this file.
+Note that this file is a work in progress and might not cover all relevant changes.
+
+
+Change log
+**********
+
+See the `master branch section in the change log`_ for a list of the most important changes.
+
+sdk-nrfxlib
+===========
+
+See the change log for each library in the :doc:`nrfxlib documentation <nrfxlib:README>` for the most current information.
+
+sdk-zephyr
+==========
+
+The Zephyr fork in |NCS| contains all commits from the upstream Zephyr repository up to and including ``ac117c8d``, plus some |NCS| specific additions.
+
+The following list summarizes the most important changes inherited from upstream Zephyr:
+
+*
+
+The following list contains |NCS| specific additions:
+
+*


### PR DESCRIPTION
Add a file where changes between releases can be tracked.
This file mostly links to change logs (on the wiki and in
sdk-nrfxlib), but will eventually contain content for
sdk-zephyr.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>