### PR TITLE
nfc: st25r3911b fix SPI configuration

### DIFF
--- a/lib/st25r3911b/st25r3911b_spi.c
+++ b/lib/st25r3911b/st25r3911b_spi.c
@@ -37,6 +37,7 @@ static struct device *spi_dev;
 /* SPI CS pin configuration */
 static struct spi_cs_control spi_cs = {
 	.gpio_pin = DT_SPI_DEV_CS_GPIOS_PIN(ST25R3911B_NODE),
+	.gpio_dt_flags = DT_SPI_DEV_CS_GPIOS_FLAGS(ST25R3911B_NODE),
 	.delay = T_NCS_SCLK
 };
 

--- a/samples/nfc/tag_reader/nrf52840dk_nrf52840.overlay
+++ b/samples/nfc/tag_reader/nrf52840dk_nrf52840.overlay
@@ -4,7 +4,7 @@
 	sck-pin = <47>;
 	mosi-pin = <45>;
 	miso-pin = <46>;
-	cs-gpios = <&gpio1 12 0>;
+	cs-gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
 
 	st25r3911b@0 {
 		label = "ST25R3911B";

--- a/samples/nfc/tag_reader/nrf52dk_nrf52832.overlay
+++ b/samples/nfc/tag_reader/nrf52dk_nrf52832.overlay
@@ -4,7 +4,7 @@
 	sck-pin = <25>;
 	mosi-pin = <23>;
 	miso-pin = <24>;
-	cs-gpios = <&gpio0 22 0>;
+	cs-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 
 	st25r3911b@0 {
 		label = "ST25R3911B";

--- a/samples/nfc/tag_reader/nrf5340pdk_nrf5340_cpuapp.overlay
+++ b/samples/nfc/tag_reader/nrf5340pdk_nrf5340_cpuapp.overlay
@@ -4,7 +4,7 @@
 	sck-pin = <47>;
 	mosi-pin = <45>;
 	miso-pin = <46>;
-	cs-gpios = <&gpio1 12 0>;
+	cs-gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
 
 	st25r3911b@0 {
 		label = "ST25R3911B";


### PR DESCRIPTION
This commit provides fix for CS pin configuration
for ST25R3911B NFC Reader

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>