### PR TITLE
manifest: Update mcuboot revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 97c92cd707fffa1bd35c98e820826aaff347e9a5
+      revision: c54c728f8c99d494bc3837eaf60153ff1f188872
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
Update mcuboot revision to include following commits:
  98c4bf17: [nrf noup] zephyr: Fix redefinition compiler warning

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

The fix is reviewed here: https://github.com/nrfconnect/sdk-mcuboot/pull/110