### PR TITLE
mpsl: Add missing multithreading lock

### DIFF
--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -8,8 +8,10 @@
 #include <irq.h>
 #include <kernel.h>
 #include <logging/log.h>
+#include <sys/__assert.h>
 #include <mpsl.h>
 #include <mpsl_timeslot.h>
+#include "multithreading_lock.h"
 
 LOG_MODULE_REGISTER(mpsl_init, CONFIG_MPSL_LOG_LEVEL);
 
@@ -43,9 +45,15 @@ static void signal_thread(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
+	int errcode;
+
 	while (true) {
 		k_sem_take(&sem_signal, K_FOREVER);
+
+		errcode = MULTITHREADING_LOCK_ACQUIRE();
+		__ASSERT_NO_MSG(errcode == 0);
 		mpsl_low_priority_process();
+		MULTITHREADING_LOCK_RELEASE();
 	}
 }
 


### PR DESCRIPTION
Wrap mpsl_low_priority_process with a multithreading lock to
avoid the following race condition:

1. The application calls ble_controller_flash_write(). This API obtains
   lock. The API is called from thread priority.
2. A low priority MPSL signal becomes available.
   mpsl_low_priority_process() interrupts the call to
   ble_controller_flash_write().
   This may give a race condition in MPSL.

In the future we may ensure that the flash APIs are called from a
cooperative thread. That will eliminate the need for the lock.

The flash driver now no longer obtains the lock when continuing flash
operations from the OPERATION_COMPLETE callback, because this callback
is executed from the execution context of mpsl_low_priority_process().

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>