### PR TITLE
entropy: cc310: remove depends on !BT_LLL_VENDOR_NORDIC

### DIFF
--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -8,7 +8,6 @@ config ENTROPY_CC310
 	bool "Arm CC310 RNG driver for Nordic devices"
 	depends on HW_CC310 || (SOC_NRF9160 && SPM)
 	depends on ENTROPY_GENERATOR
-	depends on !BT_LLL_VENDOR_NORDIC
 	select ENTROPY_HAS_DRIVER
 	default y
 	help


### PR DESCRIPTION
The selection of BB_LLL_VENDOR_NORDIC includes the RNG driver
drivers/entropy/entropy_nrf5.c, this should work fine when the
cc310 entropy driver is also included. The bluetooth driver
will not select the device tree chosen entropy driver, instead
it always selects the RNG driver.

Therefore remove the dependency on ENTROPY_CC310 that
BB_LLL_VENDOR_NORDIC is not enabled.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>