### PR TITLE
Bluetooth: samples: Improve central samples use of scan module

### DIFF
--- a/samples/bluetooth/central_bas/src/main.c
+++ b/samples/bluetooth/central_bas/src/main.c
@@ -47,18 +47,12 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 			      struct bt_scan_filter_match *filter_match,
 			      bool connectable)
 {
-	int err;
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
 
 	printk("Filters matched. Address: %s connectable: %s\n",
 		addr, connectable ? "yes" : "no");
-
-	err = bt_scan_stop();
-	if (err) {
-		printk("Stop LE scan failed (err %d)\n", err);
-	}
 }
 
 static void scan_connecting_error(struct bt_scan_device_info *device_info)

--- a/samples/bluetooth/central_bas/src/main.c
+++ b/samples/bluetooth/central_bas/src/main.c
@@ -178,6 +178,18 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 
 	if (conn_err) {
 		printk("Failed to connect to %s (%u)\n", addr, conn_err);
+		if (conn == default_conn) {
+			bt_conn_unref(default_conn);
+			default_conn = NULL;
+
+			/* This demo doesn't require active scan */
+			err = bt_scan_start(BT_SCAN_TYPE_SCAN_ACTIVE);
+			if (err) {
+				printk("Scanning failed to start (err %d)\n",
+				       err);
+			}
+		}
+
 		return;
 	}
 

--- a/samples/bluetooth/central_dfu_smp/src/main.c
+++ b/samples/bluetooth/central_dfu_smp/src/main.c
@@ -133,6 +133,18 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 
 	if (conn_err) {
 		printk("Failed to connect to %s (%u)\n", addr, conn_err);
+		if (conn == default_conn) {
+			bt_conn_unref(default_conn);
+			default_conn = NULL;
+
+			/* This demo doesn't require active scan */
+			err = bt_scan_start(BT_SCAN_TYPE_SCAN_ACTIVE);
+			if (err) {
+				printk("Scanning failed to start (err %d)\n",
+				       err);
+			}
+		}
+
 		return;
 	}
 

--- a/samples/bluetooth/central_dfu_smp/src/main.c
+++ b/samples/bluetooth/central_dfu_smp/src/main.c
@@ -48,18 +48,12 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 			      struct bt_scan_filter_match *filter_match,
 			      bool connectable)
 {
-	int err;
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
 
 	printk("Filters matched. Address: %s connectable: %s\n",
 		addr, connectable ? "yes" : "no");
-
-	err = bt_scan_stop();
-	if (err) {
-		printk("Stop LE scan failed (err %d)\n", err);
-	}
 }
 
 static void scan_connecting_error(struct bt_scan_device_info *device_info)

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -62,7 +62,6 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 			      struct bt_scan_filter_match *filter_match,
 			      bool connectable)
 {
-	int err;
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	if (!filter_match->uuid.match ||
@@ -80,11 +79,6 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 	printk("Filters matched on UUID 0x%04x.\nAddress: %s connectable: %s\n",
 		BT_UUID_16(uuid)->val,
 		addr, connectable ? "yes" : "no");
-
-	err = bt_scan_stop();
-	if (err) {
-		printk("Stop LE scan failed (err %d)\n", err);
-	}
 }
 
 static void scan_connecting_error(struct bt_scan_device_info *device_info)

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -188,6 +188,18 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 
 	if (conn_err) {
 		printk("Failed to connect to %s (%u)\n", addr, conn_err);
+		if (conn == default_conn) {
+			bt_conn_unref(default_conn);
+			default_conn = NULL;
+
+			/* This demo doesn't require active scan */
+			err = bt_scan_start(BT_SCAN_TYPE_SCAN_ACTIVE);
+			if (err) {
+				printk("Scanning failed to start (err %d)\n",
+				       err);
+			}
+		}
+
 		return;
 	}
 

--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -336,6 +336,18 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	if (conn_err) {
 		LOG_INF("Failed to connect to %s (%d)", log_strdup(addr),
 			conn_err);
+
+		if (default_conn == conn) {
+			bt_conn_unref(default_conn);
+			default_conn = NULL;
+
+			err = bt_scan_start(BT_SCAN_TYPE_SCAN_ACTIVE);
+			if (err) {
+				LOG_ERR("Scanning failed to start (err %d)",
+					err);
+			}
+		}
+
 		return;
 	}
 

--- a/subsys/bluetooth/scan.c
+++ b/subsys/bluetooth/scan.c
@@ -303,11 +303,11 @@ static void scan_connect_with_target(struct bt_scan_control *control,
 			       BT_CONN_LE_CREATE_CONN,
 			       &bt_scan.conn_param, &conn);
 
-	LOG_DBG("Connecting");
+	LOG_DBG("Connecting (%d)", err);
 
 	if (err) {
 		/* If an error occurred, send an event to
-		 * the all intrested.
+		 * the all interested.
 		 */
 		notify_connecting_error(&control->device_info);
 	} else {


### PR DESCRIPTION
Fix central samples taking a reference in the scan_connecting
callback but not releasing this reference in the connected callback
when creating the connection failed.

In this a bt_conn_unref missing in connected callback would lead to
the connection not being freed.

Also restart the scanner in this case so that the sample can find
a new advertiser.

Remove the redundant call to bt_scan_stop in the filter match
callback when the scan module will automatically connect to devices
with a filter match. The scan module handles stopping the scanner
in this case.