### PR TITLE
cmake: multi image: pass on the DTC_OVERLAY_FILE to sub images

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -108,6 +108,7 @@ function(add_child_image_from_source)
     NCS_TOOLCHAIN_VERSION
     PM_DOMAINS
     ${ACI_DOMAIN}_PM_DOMAIN_DYNAMIC_PARTITION
+    DTC_OVERLAY_FILE
     )
 
   foreach(kconfig_target ${EXTRA_KCONFIG_TARGETS})


### PR DESCRIPTION
Device tree overlay files can be used to modify a board's device tree,
including things such as the UART TX/RX/CTS/RTS lines. This must be
passed on to sub images, especially mcuboot, so that, for example,
the logging UART uses the correct hardware pins for mcuboot.

Jira: NCSDK-5972

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>