### PR TITLE
manifest: Pull cherry-picks from zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: fad096762dd04ff66da731cfe94c2671c60e04aa
+      revision: 0caecf37c71f8d0aa9364ff4aadbdf5fe7647af8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Two cherry picks included -
1. support for custom OpenThread repository - allows us to implement
linking Thread from libraries
2. support for custom mbedTLS - allows us to use nrf_security instead

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>