### PR TITLE
Bluetooth: hci_driver: Set thread names.

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -347,6 +347,7 @@ static int hci_driver_open(void)
 			K_THREAD_STACK_SIZEOF(recv_thread_stack), recv_thread,
 			NULL, NULL, NULL, K_PRIO_COOP(CONFIG_BLECTLR_PRIO), 0,
 			K_NO_WAIT);
+	k_thread_name_set(&recv_thread_data, "blectlr recv");
 
 	uint8_t build_revision[BLE_CONTROLLER_BUILD_REVISION_SIZE];
 

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -159,6 +159,7 @@ static int mpsl_signal_thread_init(struct device *dev)
 			signal_thread, NULL, NULL, NULL,
 			K_PRIO_COOP(CONFIG_MPSL_THREAD_COOP_PRIO),
 			0, K_NO_WAIT);
+	k_thread_name_set(&signal_thread_data, "MPSL signal");
 
 	IRQ_CONNECT(MPSL_LOW_PRIO_IRQn, MPSL_LOW_PRIO,
 		    mpsl_low_prio_irq_handler, NULL, 0);


### PR DESCRIPTION
Set name for the hci_driver recv thread and the MPSL signal thread.
This makes it easier to debug thread usage with CONFIG_THREAD_ANALYZER.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>