### PR TITLE
manifest: Pull in Openthread Prebuilt Libraries

### DIFF
--- a/doc/nrfxlib/nrfxlib.doxyfile.in
+++ b/doc/nrfxlib/nrfxlib.doxyfile.in
@@ -802,7 +802,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */zboss/*
+EXCLUDE_PATTERNS       = */zboss/* */openthread/include/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 2f2aab4efc075d1a06a488e227a39acf4c55d84c
+      revision: 108e18666370a96f72461177256eee80c54b6a32
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Update manifest to allow using OpenThread as a library

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>