### PR TITLE
net: lib: nrf_cloud: Fix typo in A-GPS type

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
@@ -384,7 +384,7 @@ static int agps_send_to_modem(struct nrf_cloud_apgs_element *agps_data)
 		LOG_DBG("A-GPS type: NRF_CLOUD_AGPS_KLOBUCHAR_CORRECTION");
 
 		return send_to_modem(&klobuchar, sizeof(klobuchar),
-				NRF_CLOUD_AGPS_KLOBUCHAR_CORRECTION);
+				NRF_GNSS_AGPS_KLOBUCHAR_IONOSPHERIC_CORRECTION);
 	}
 	case NRF_CLOUD_AGPS_GPS_SYSTEM_CLOCK: {
 		nrf_gnss_agps_data_system_time_and_sv_tow_t time_and_tow;


### PR DESCRIPTION
Fix typo in translation of Klobuchar correction from nRF Cloud enum
to nRF socket enum.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>