### PR TITLE
doc: add build-all target

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -440,3 +440,13 @@ add_custom_target(
         ${HTML_DIR}/kconfig
 )
 add_dependencies(kconfig-html kconfig-content)
+
+add_custom_target(
+  build-all
+  COMMAND ${CMAKE_MAKE_PROGRAM} kconfig-html
+  COMMAND ${CMAKE_MAKE_PROGRAM} zephyr
+  COMMAND ${CMAKE_MAKE_PROGRAM} mcuboot
+  COMMAND ${CMAKE_MAKE_PROGRAM} nrfxlib-inventory
+  COMMAND ${CMAKE_MAKE_PROGRAM} nrf
+  COMMAND ${CMAKE_MAKE_PROGRAM} nrfxlib
+)


### PR DESCRIPTION
Add new target "build-all" the can be called to build all documentation sets in the correct order. This avoids having to run one ninja/make command for every target.

JIRA: NCSDK-5968