### PR TITLE
openthread: samples: cli: Enable the sample to substitute OT libs

### DIFF
--- a/doc/nrf/ug_thread_configuring.rst
+++ b/doc/nrf/ug_thread_configuring.rst
@@ -304,6 +304,14 @@ The following table lists the supported features for each of these sets.
       - ✔
       -
 
+Replacing OpenThread Libraries
+******************************
+
+Each OpenThread example provides a possibility to replace libraries present in the nrfxlib when configured to build OpenThread stack from source with :option:`CONFIG_OPENTHREAD_SOURCES`.
+After the sample is build execute the following to overwrite the exising nrfxlib libraries with currently built ones::
+
+  west build -t install_openthread_libraries
+
 UART recommendations for NCP
 ****************************
 

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -18,6 +18,9 @@ The CLI sample comes with the :ref:`full set of OpenThread functionalities <thre
 If used alone, the sample allows you to test the network status.
 It is recommended to use at least two development kits running the same sample to be able to test communication.
 
+An additional functionality of this particular sample is the possibility of updating OpenThread libraries
+with the version compiled from the current source.
+
 See :ref:`ug_thread_cert` for information on how to use this sample on Thread Certification Test Harness.
 
 .. _ot_cli_sample_diag_module:
@@ -59,6 +62,8 @@ Building and running
 |enable_thread_before_testing|
 
 .. include:: /includes/build_and_run.txt
+
+To update OpenThread libraries provided by the ``nrfxlib``, please invoke ``west build -b nrf52840dk_nrf52840 -t install_openthread_libraries``.
 
 Testing
 =======

--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d405ba045cf15afcf0c726aee1f48419ee785896
+      revision: 7ab7c9f1e4cc2d55bb71ec9116dfcad7efb540f2
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
The CLI sample can update OpenThread libraries provided by the nrfxlib
with the version build from the current source.

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>

Note: this PR depends on https://github.com/nrfconnect/sdk-nrfxlib/pull/223.