### PR TITLE
doc: add a 404 page

### DIFF
--- a/doc/nrf/404.rst
+++ b/doc/nrf/404.rst
@@ -1,0 +1,15 @@
+:orphan:
+
+.. _404:
+
+Page not found
+##############
+
+Ooops... it seems the page you are looking for is no longer here!
+
+If you were directed to this page through an external link, try doing a search - most likely the content still exists but has moved location.
+
+If you switched between different versions of the documentation, the content might not exist in this version.
+
+
+:ref:`Go to the start page. <index>`


### PR DESCRIPTION
When switching between versions, we might end up on a page that
does not exist in one of the versions.
Add a custom 404 page to redirect to in this case.

![image](https://user-images.githubusercontent.com/11227796/89179540-34704000-d590-11ea-92b2-72185a8f4009.png)


Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>