### PR TITLE
doc: release-notes: add zephyr commit 'git log' lines

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -20,7 +20,17 @@ See the change log for each library in the :doc:`nrfxlib documentation <nrfxlib:
 sdk-zephyr
 ==========
 
+.. NOTE TO MAINTAINERS: The latest Zephyr commit appears in multiple places; make sure you update them all.
+
 The Zephyr fork in |NCS| contains all commits from the upstream Zephyr repository up to and including ``4ef29b34e3``, plus some |NCS| specific additions.
+
+For a complete list of upstream Zephyr commits incorporated into |NCS| since the most recent release, run this command from the :file:`ncs/zephyr` repository after running ``west update``::
+
+   git log --oneline 4ef29b34e3 ^v2.3.0-rc1-ncs1
+
+For a complete list of |NCS| specific commits, run::
+
+   git log --oneline manifest-rev ^4ef29b34e3
 
 The following list summarizes the most important changes inherited from upstream Zephyr:
 


### PR DESCRIPTION
Add some git log lines the user can run to find out:

- NCS-specific commits in ncs/zephyr, i.e. OOT patches
- upstream commits in ncs/zephyr added since the last release

These require a bit of manual maintenance, but it's pretty easy to
copy/paste and pattern match your way through it.
