### PR TITLE
Bluetooth: Mesh: Commit to new model data API

### DIFF
--- a/subsys/bluetooth/mesh/gen_dtt_srv.c
+++ b/subsys/bluetooth/mesh/gen_dtt_srv.c
@@ -110,7 +110,7 @@ static int bt_mesh_dtt_srv_settings_set(struct bt_mesh_model *model,
 	struct bt_mesh_dtt_srv *srv = model->user_data;
 
 	if (name) {
-		return -ENOTSUP; /* TODO support this */
+		return -ENOENT;
 	}
 
 	ssize_t bytes = read_cb(cb_arg, &srv->transition_time,

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -617,11 +617,15 @@ static int bt_mesh_plvl_srv_init(struct bt_mesh_model *mod)
 
 #ifdef CONFIG_BT_SETTINGS
 static int bt_mesh_plvl_srv_settings_set(struct bt_mesh_model *mod,
-					 size_t len_rd,
+					 const char *name, size_t len_rd,
 					 settings_read_cb read_cb, void *cb_arg)
 {
 	struct bt_mesh_plvl_srv *srv = mod->user_data;
 	struct bt_mesh_plvl_srv_settings_data data;
+
+	if (name) {
+		return -ENOENT;
+	}
 
 	if (read_cb(cb_arg, &data, sizeof(data)) != sizeof(data)) {
 		return -EINVAL;

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -222,7 +222,7 @@ static int bt_mesh_ponoff_srv_settings_set(struct bt_mesh_model *model,
 	struct ponoff_settings_data data;
 
 	if (name) {
-		return -ENOTSUP; /* TODO support this */
+		return -ENOENT;
 	}
 
 	if (read_cb(cb_arg, &data, sizeof(data)) != sizeof(data)) {

--- a/subsys/bluetooth/mesh/gen_prop_srv.c
+++ b/subsys/bluetooth/mesh/gen_prop_srv.c
@@ -541,12 +541,16 @@ static int bt_mesh_prop_srv_init(struct bt_mesh_model *mod)
 
 #ifdef CONFIG_BT_SETTINGS
 static int bt_mesh_prop_srv_settings_set(struct bt_mesh_model *model,
-					 size_t len_rd,
+					 const char *name, size_t len_rd,
 					 settings_read_cb read_cb, void *cb_arg)
 {
 	struct bt_mesh_prop_srv *srv = model->user_data;
 	uint8_t entries[CONFIG_BT_MESH_PROP_MAXCOUNT];
 	ssize_t size = MIN(sizeof(entries), len_rd);
+
+	if (name) {
+		return -ENOENT;
+	}
 
 	size = read_cb(cb_arg, &entries, size);
 

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1391,7 +1391,7 @@ static int lc_setup_srv_settings_set(struct bt_mesh_model *mod,
 	ssize_t result;
 
 	if (name) {
-		return -ENOTSUP; /* TODO support this */
+		return -ENOENT;
 	}
 
 	result = read_cb(cb_arg, &data, sizeof(data));

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -734,7 +734,7 @@ static int bt_mesh_lightness_srv_settings_set(struct bt_mesh_model *mod,
 	ssize_t result;
 
 	if (name) {
-		return -ENOTSUP; /* TODO support this */
+		return -ENOENT;
 	}
 
 	result = read_cb(cb_arg, &data, sizeof(data));

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -751,14 +751,19 @@ static int sensor_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static int sensor_srv_settings_set(struct bt_mesh_model *mod, size_t len_rd,
-				   settings_read_cb read_cb, void *cb_arg)
+static int sensor_srv_settings_set(struct bt_mesh_model *mod, const char *name,
+				   size_t len_rd, settings_read_cb read_cb,
+				   void *cb_arg)
 {
 	struct bt_mesh_sensor_srv *srv = mod->user_data;
 	int err = 0;
 
 	NET_BUF_SIMPLE_DEFINE(buf, (CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX *
 				    BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_STATUS));
+
+	if (name) {
+		return -ENOENT;
+	}
 
 	ssize_t len = read_cb(cb_arg, net_buf_simple_add(&buf, len_rd), len_rd);
 


### PR DESCRIPTION
Completes the transition to the new model data API with an extra
parameter, returning EINVAL on unexpected path names and fixing
remaining errors.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>