### PR TITLE
flash_map: reduce NCS patch size

### DIFF
--- a/include/flash_map_pm.h
+++ b/include/flash_map_pm.h
@@ -13,6 +13,9 @@
 /* Aliases for zephyr - mcuboot/ncs style naming */
 #define image_0 mcuboot_primary
 #define image_1 mcuboot_secondary
+#define image_0_nonsecure mcuboot_primary
+#define image_1_nonsecure mcuboot_secondary
+#define image_scratch mcuboot_scratch
 
 #if (CONFIG_SETTINGS_FCB || CONFIG_SETTINGS_NVS)
 #define storage settings_storage

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b160c8c5caa53694c0be57ee224c078dc4adb53c
+      revision: 53bfa7b0256a3927d0193b51616db7a30f07b7fd
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Leverage label translation to avoid patching partition names.

NCSDK-5538

Depends on https://github.com/nrfconnect/sdk-zephyr/pull/342

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>