### PR TITLE
samples: esb: let main return to idle

### DIFF
--- a/samples/esb/prx/src/main.c
+++ b/samples/esb/prx/src/main.c
@@ -208,7 +208,6 @@ void main(void)
 		return;
 	}
 
-	while (1) {
-		/* do nothing */
-	}
+	/* return to idle thread */
+	return;
 }


### PR DESCRIPTION
Let the main thread return to idle instead of running an
empty while loop, which can block logging threads.

Signed-off-by: Håkon Alseth <haal@nordicsemi.no>