### PR TITLE
doc: Fixed board names in nRF Desktop and Profiler documentation

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -241,39 +241,47 @@ Depending on what development kit you use, you need to select the respective con
       .. figure:: /images/nrf_desktop_gaming_mouse_top_no_captions.svg
          :alt: nRF Desktop gaming mouse (top view)
 
-      * nRF52840 Gaming Mouse (nrf52840gmouse_nrf52840)
+      .. include:: /includes/boardname_tables/sample_boardnames.txt
+         :start-after: set11_start
+         :end-before: set11_end
 
    .. tab:: Desktop mouse
 
       .. figure:: /images/nrf_desktop_desktop_mouse_side_no_captions.svg
          :alt: nRF Desktop desktop mouse (side view)
 
-      * nRF52832 Desktop Mouse (nrf52dmouse_nrf52832)
-      * nRF52810 Desktop Mouse (nrf52810dmouse_nrf52810)
+      .. include:: /includes/boardname_tables/sample_boardnames.txt
+         :start-after: set12_start
+         :end-before: set12_end
 
    .. tab:: Keyboard
 
       .. figure:: /images/nrf_desktop_keyboard_top_no_captions.svg
          :alt: nRF Desktop keyboard (top view)
 
-      * nRF52832 Desktop Keyboard (nrf52kbd_nrf52832)
+      .. include:: /includes/boardname_tables/sample_boardnames.txt
+         :start-after: set13_start
+         :end-before: set13_end
 
    .. tab:: HID dongle
 
       .. figure:: /images/nrf_desktop_dongle_no_captions.svg
          :alt: nRF Desktop dongle (top view)
 
-      * nRF52840 USB Dongle (nrf52840dongle_nrf52840)
-      * nRF52833 USB Dongle (nrf52833dongle_nrf52833)
-      * nRF52820 USB Dongle (nrf52820dongle_nrf52820)
+      .. include:: /includes/boardname_tables/sample_boardnames.txt
+         :start-after: set14_start
+         :end-before: set14_end
 
    .. tab:: DK
 
       .. figure:: /images/nrf_desktop_nrf52840_dk_no_captions.svg
          :alt: DK
 
-      * nRF52840 DK (nrf52840dk_nrf52840) - The application is configured to work as gaming mouse (with motion emulated by using DK buttons).
-      * nRF52833 DK (nrf52833dk_nrf52833) - The application is configured to work as HID dongle.
+      .. include:: /includes/boardname_tables/sample_boardnames.txt
+         :start-after: set8_start
+         :end-before: set8_end
+
+      In nRF52840 DK, the application is configured to work as gaming mouse (with motion emulated by using DK buttons) and in nRF52833 DK, the application is configured to work as HID dongle.
 
 ..
 

--- a/doc/nrf/includes/boardname_tables/sample_boardnames.txt
+++ b/doc/nrf/includes/boardname_tables/sample_boardnames.txt
@@ -150,7 +150,7 @@ Set used by samples (BH1749: Ambient Light Sensor IC)
 
 .. set10_end
 
-Set used by application (nRF Desktop- Gaming Mouse)
+Set used by application (nRF Desktop - Gaming Mouse)
 
 .. set11_start
 
@@ -162,7 +162,7 @@ Set used by application (nRF Desktop- Gaming Mouse)
 
 .. set11_end
 
-Set used by application (nRF Desktop - Mouse)
+Set used by application (nRF Desktop - Desktop Mouse)
 
 
 .. set12_start

--- a/samples/profiler/README.rst
+++ b/samples/profiler/README.rst
@@ -23,13 +23,11 @@ Event with data (``data event``):
 Requirements
 ************
 
-* One of the following development boards:
+The sample supports the following development kits:
 
-  * |nRF9160DK|
-  * |nRF52840DK|
-  * |nRF52DK|
-  * |nRF51DK|
-
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set9_start
+   :end-before: set9_end
 
 Building and running
 ********************


### PR DESCRIPTION
ref: https://github.com/nrfconnect/sdk-nrf/pull/2425
and NCSDK-3933.
Added the board names table in nRF Desktop application and Profiler
sample documentation.

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>