### PR TITLE
checkpatch: Increase maximum line length to 100

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -3,7 +3,7 @@
 --emacs
 --summary-file
 --show-types
---max-line-length=80
+--max-line-length=100
 --min-conf-desc-length=1
 --typedefsfile=scripts/checkpatch/typedefsfile
 


### PR DESCRIPTION
Increase the maximum line length to 100 characters.
The limit of 80 is so often exceeded due to readability concerns that
to keep enforcing a maximum of 80 does not make much sense anymore.

Prefer to have 80 characters as guidance, and then checkpatch warning on 100.
Then checkpatch warnings can be more easily enforced.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>