### PR TITLE
doc: add info on how to link to a define

### DIFF
--- a/doc/nrf/doc_styleguide.rst
+++ b/doc/nrf/doc_styleguide.rst
@@ -177,7 +177,7 @@ To link directly to a doxygen reference from RST, use the following Breathe doma
 * Structure: ``:c:type:``
 * Enum (the list): ``:cpp:enum:``
 * Enumerator (an item): ``:cpp:enumerator:``
-* Macro: ``:c:macro:``
+* Macro or define: ``:c:macro:``
 * Structure member: ``:cpp:member:``
 
 .. note::


### PR DESCRIPTION
To link to a define in doxygen, use :c:macro:.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>