### PR TITLE
manifest: nrfxlib: nfc t4t lib update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 0b7f6ee395d48089edffe343419b6a62ead6c0ee
+      revision: aeeb6a08afd0529c366728183367adf009104a4a
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
In the NFC T4T library, FWT is now changed according to ISO-DEP blocks
timing requirements (e.g. WTX frame).