### PR TITLE
doc: Fixed board names in MPSL sample documentation

### DIFF
--- a/doc/nrf/includes/boardname_tables/sample_boardnames.txt
+++ b/doc/nrf/includes/boardname_tables/sample_boardnames.txt
@@ -19,7 +19,7 @@ Peripheral UART, NUS Shell Transport, Throughput) and NFC samples
 
 .. set1_end
 
-Set used by BLE samples (LLPM, peripheral GATT Discovery Manager), Enhanced ShockBurst Transmitter/Receiver, MPSL Timeslot) and application (Serial LTE modem)
+Set used by BLE samples (LLPM, peripheral GATT Discovery Manager), Enhanced ShockBurst Transmitter/Receiver, and application (Serial LTE modem)
 
 .. set2_start
 
@@ -53,7 +53,7 @@ Set used by BLE samples (Peripheral LBS)
 
 .. set3_end
 
-Set used by samples (Radio Test)
+Set used by samples (Radio Test, MPSL Timeslot)
 
 .. set4_start
 

--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -22,17 +22,18 @@ The timeslot session is closed when any key is pressed in the terminal.
 Requirements
 ************
 
-One of the following development boards:
+The sample supports any one of the following development kits:
 
-  * |nRF52DK|
-  * |nRF52840DK|
-  * |nRF5340DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set4_start
+   :end-before: set4_end
 
-    .. note::
-       For the nRF5340DK this sample is only supported on the network core (nrf5340pdk_nrf5340_cpunet), and the :ref:`nrf5340_empty_app_core` sample must be flashed on the application core.
+.. note::
+   For nRF5340 PDK, this sample is only supported on the network core (nrf5340pdk_nrf5340_cpunet), and the :ref:`nrf5340_empty_app_core` sample must be flashed on the application core.
 
 Building and Running
 ********************
+
 .. |sample path| replace:: :file:`samples/mpsl/timeslot`
 
 .. include:: /includes/build_and_run.txt


### PR DESCRIPTION
ref: https://github.com/nrfconnect/sdk-nrf/pull/2425
and NCSDK-3933
Added the board names table to the MPSL timeslot sample
documentation.

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>