### PR TITLE
manifest: nrfxlib: 802.15.4 multiprotocol support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: aeeb6a08afd0529c366728183367adf009104a4a
+      revision: pull/234/head
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
MPSL library is now capable of configuring the nRF IEEE 802.15.4 radio driver to support multi-protocol use cases.

Related to nrfxlib [PR#234](https://github.com/nrfconnect/sdk-nrfxlib/pull/234)

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>