### PR TITLE
doc: Fixed board names in GPS sample documentation

### DIFF
--- a/samples/nrf9160/gps/README.rst
+++ b/samples/nrf9160/gps/README.rst
@@ -28,11 +28,15 @@ Finally, after the download completes, the sample switches back to the previous 
 Requirements
 ************
 
-* The following development board:
+The sample supports the following development kit:
 
-  * |nRF9160DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set5_start
+   :end-before: set5_end
 
-* Optional: SUPL Client library (for details on download, see :ref:`supl_client`)
+The sample can be optionally used with the SUPL Client library (for details on download, see :ref:`supl_client`).
+
+.. include:: /includes/spm.txt
 
 Building and running
 ********************


### PR DESCRIPTION

ref: https://github.com/nrfconnect/sdk-nrf/pull/2425
and NCSDK-3933
Added the board name table in the GPS sample documentation.

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>
[nRF9160_ GPS sockets and SUPL client library — nRF Connect SDK 1.3.99 documentation.pdf](https://github.com/nrfconnect/sdk-nrf/files/5062872/nRF9160_.GPS.sockets.and.SUPL.client.library.nRF.Connect.SDK.1.3.99.documentation.pdf)
