### PR TITLE
Add option to give GPS prioritized radio access

### DIFF
--- a/applications/asset_tracker/src/gps_controller/gps_controller.c
+++ b/applications/asset_tracker/src/gps_controller/gps_controller.c
@@ -33,7 +33,8 @@ static void start(struct k_work *work)
 		.power_mode = GPS_POWER_MODE_DISABLED,
 		.timeout = CONFIG_GPS_CONTROL_FIX_TRY_TIME,
 		.interval = CONFIG_GPS_CONTROL_FIX_TRY_TIME +
-			gps_reporting_interval_seconds
+			gps_reporting_interval_seconds,
+		.priority = true,
 	};
 
 	if (gps_dev == NULL) {

--- a/include/drivers/gps.h
+++ b/include/drivers/gps.h
@@ -109,6 +109,12 @@ struct gps_config {
 
 	/* Delete stored assistance data before starting GPS search. */
 	bool delete_agps_data;
+
+	/* Give GPS priority in competition with other radio resource users.
+	 * This may affect the operation of other protocols, such as LTE in the
+	 * case of nRF9160.
+	 */
+	bool priority;
 };
 
 /* Flags indicating which AGPS assistance data set is written to the GPS module.

--- a/samples/nrf9160/nrf_cloud_agps/src/main.c
+++ b/samples/nrf9160/nrf_cloud_agps/src/main.c
@@ -55,6 +55,7 @@ static void gps_start_work_fn(struct k_work *work)
 		.power_mode = GPS_POWER_MODE_DISABLED,
 		.timeout = 120,
 		.interval = 240,
+		.priority = true,
 	};
 
 	ARG_UNUSED(work);


### PR DESCRIPTION
drivers: gps: Add priority flag to configuration struct

Add a flag to the GPS configuration struct to indicate that
the GPS should have prioritized access to shared radio resource.

---

drivers: gps: nrf9160_gps: Set GPS priority when enabled

GPS can be given priority over LTE to let it search for
satellites also in situations where the radio would usually
be in use by LTE. This is useful when the LTE network doesnn't
offer functionality like eDRX or PSM where the GPS can have full
access to the radio.

---

samples: nrf9160: nrf_cloud_agps: Enabled GPS radio priority

Enable that GPS has prioritized access to the shared radio
resource in nRF9160.

---

applications: asset_tracker: Enable GPS radio priority

Enable prioritized access to shared radio resource for GPS.