### PR TITLE
zigbee: KRKNWK-7115 Remove zb_void_t type

### DIFF
--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -401,7 +401,7 @@ static void bulb_clusters_attr_init(void)
  * @param[in]   bufid   Reference to Zigbee stack buffer
  *                      used to pass received data.
  */
-static zb_void_t zcl_device_cb(zb_bufid_t bufid)
+static void zcl_device_cb(zb_bufid_t bufid)
 {
 	zb_uint8_t cluster_id;
 	zb_uint8_t attr_id;

--- a/samples/zigbee/network_coordinator/src/main.c
+++ b/samples/zigbee/network_coordinator/src/main.c
@@ -51,7 +51,7 @@ LOG_MODULE_REGISTER(app);
  *
  * @param[in]   param   Not used. Required by callback type definition.
  */
-static zb_void_t steering_finished(zb_uint8_t param)
+static void steering_finished(zb_uint8_t param)
 {
 	ARG_UNUSED(param);
 	LOG_INF("Network steering finished");

--- a/subsys/zigbee/cli/zigbee_cli.c
+++ b/subsys/zigbee/cli/zigbee_cli.c
@@ -31,7 +31,7 @@ zb_uint8_t zb_cli_get_endpoint(void)
 
 /**@brief Sets the Endpoint number used by the CLI.
  */
-zb_void_t zb_cli_set_endpoint(zb_uint8_t ep)
+void zb_cli_set_endpoint(zb_uint8_t ep)
 {
 	cli_ep = ep;
 }
@@ -39,7 +39,7 @@ zb_void_t zb_cli_set_endpoint(zb_uint8_t ep)
 /**@brief Configures CLI endpoint by setting number of endpoint to be used
  * by the CLI and for chosen endpoint registers CLI endpoint handler.
  */
-zb_void_t zb_cli_configure_endpoint(void)
+void zb_cli_configure_endpoint(void)
 {
 	zb_zcl_globals_t *zcl_ctx = zb_zcl_get_ctx();
 	zb_af_endpoint_desc_t *cli_ep_desc;
@@ -77,7 +77,7 @@ zb_void_t zb_cli_configure_endpoint(void)
 
 /**@brief Sets the debug mode.
  */
-zb_void_t zb_cli_debug_set(zb_bool_t debug)
+void zb_cli_debug_set(zb_bool_t debug)
 {
 	debug_mode = debug;
 }

--- a/subsys/zigbee/cli/zigbee_cli.h
+++ b/subsys/zigbee/cli/zigbee_cli.h
@@ -21,12 +21,12 @@ zb_uint8_t zb_cli_get_endpoint(void);
 
 /**@brief Sets the Endpoint number used by the CLI.
  */
-zb_void_t zb_cli_set_endpoint(zb_uint8_t ep);
+void zb_cli_set_endpoint(zb_uint8_t ep);
 
 /**@brief Configures CLI endpoint by setting number of endpoint to be used
  * by the CLI and registers CLI endpoint handler for chosen endpoint.
  */
-zb_void_t zb_cli_configure_endpoint(void);
+void zb_cli_configure_endpoint(void);
 
 /**@brief Function for intercepting every frame coming to the endpoint,
  *        so the frame may be processed before it is processed by the Zigbee
@@ -44,7 +44,7 @@ zb_uint8_t zb_cli_ep_handler(zb_bufid_t bufid);
  *
  * @param debug    Turns the debug mode on (ZB_TRUE) or off (ZB_FALSE).
  */
-zb_void_t zb_cli_debug_set(zb_bool_t debug);
+void zb_cli_debug_set(zb_bool_t debug);
 /**@brief Function for getting the state of the debug mode of the CLI.
  *
  * @retval ZB_TRUE  Debug mode is turned on.

--- a/subsys/zigbee/cli/zigbee_cli_cmd_bdb.c
+++ b/subsys/zigbee/cli/zigbee_cli_cmd_bdb.c
@@ -444,7 +444,7 @@ static int cmd_zb_channel(const struct shell *shell, size_t argc, char **argv)
  *
  * @param[in] param Unused param.
  */
-zb_void_t zb_install_code_add(zb_uint8_t param)
+void zb_install_code_add(zb_uint8_t param)
 {
 	ARG_UNUSED(param);
 

--- a/subsys/zigbee/common/zigbee_helpers.c
+++ b/subsys/zigbee/common/zigbee_helpers.c
@@ -54,7 +54,7 @@ static void stop_network_rejoin(zb_uint8_t was_scheduled);
 /**@brief Function to set the Erase persistent storage
  *        depending on the erase pin
  */
-zb_void_t zigbee_erase_persistent_storage(zb_bool_t erase)
+void zigbee_erase_persistent_storage(zb_bool_t erase)
 {
 #ifdef ZB_USE_NVRAM
 	zb_set_nvram_erase_at_start(erase);

--- a/subsys/zigbee/common/zigbee_helpers.h
+++ b/subsys/zigbee/common/zigbee_helpers.h
@@ -23,7 +23,7 @@
  * @param[in] erase Whether to erase the persistent storage in case
  *                  the erase pin is not shortened to the ground.
  */
-zb_void_t zigbee_erase_persistent_storage(zb_bool_t erase);
+void zigbee_erase_persistent_storage(zb_bool_t erase);
 
 /**@brief Function for converting an input buffer to a hex string.
  *

--- a/subsys/zigbee/osif/zb_nrf_nvram.c
+++ b/subsys/zigbee/osif/zb_nrf_nvram.c
@@ -24,7 +24,7 @@ LOG_MODULE_DECLARE(zboss_osif, CONFIG_ZBOSS_OSIF_LOG_LEVEL);
 /* ZBOSS callout that should be called once flash erase page operation
  * is finished.
  */
-zb_void_t zb_nvram_erase_finished(zb_uint8_t page);
+void zb_nvram_erase_finished(zb_uint8_t page);
 
 static const struct flash_area *fa; /* ZBOSS nvram */
 

--- a/subsys/zigbee/osif/zb_nrf_platform.c
+++ b/subsys/zigbee/osif/zb_nrf_platform.c
@@ -487,7 +487,7 @@ void zb_osif_abort(void)
 	k_fatal_halt(K_ERR_KERNEL_PANIC);
 }
 
-zb_void_t zb_reset(zb_uint8_t param)
+void zb_reset(zb_uint8_t param)
 {
 	ZVUNUSED(param);
 

--- a/subsys/zigbee/osif/zb_nrf_pwr_mgmt.c
+++ b/subsys/zigbee/osif/zb_nrf_pwr_mgmt.c
@@ -73,7 +73,7 @@ __weak zb_uint32_t zb_osif_sleep(zb_uint32_t sleep_tmo)
  * wants to implement their own going-to-deep-sleep policy/share resources
  * between Zigbee stack and other components.
  */
-__weak zb_void_t zb_osif_wake_up(void)
+__weak void zb_osif_wake_up(void)
 {
 #if ZB_TRACE_LEVEL
 	ZB_SET_TRACE_ON();

--- a/subsys/zigbee/osif/zb_nrf_timer.c
+++ b/subsys/zigbee/osif/zb_nrf_timer.c
@@ -28,7 +28,7 @@ static zb_timer_t zb_timer = {
 };
 
 /* Forward declaration, dependency to ZBOSS */
-zb_void_t zb_osif_zboss_timer_tick(void);
+void zb_osif_zboss_timer_tick(void);
 
 /* Timer interrupt handler. */
 static void zb_timer_alarm_handler(struct device *counter_dev, uint8_t chan_id,

--- a/tests/subsys/zigbee/osif/nvram/src/main.c
+++ b/tests/subsys/zigbee/osif/nvram/src/main.c
@@ -23,7 +23,7 @@ BUILD_ASSERT((ZBOSS_NVRAM_PAGE_SIZE % PHYSICAL_PAGE_SIZE) == 0,
 static char zb_nvram_buf[PAGE_SIZE];
 
 /* Stub for ZBOSS callout */
-zb_void_t zb_nvram_erase_finished_stub(zb_uint8_t page)
+void zb_nvram_erase_finished_stub(zb_uint8_t page)
 {
 }
 

--- a/tests/subsys/zigbee/osif/timer/src/main.c
+++ b/tests/subsys/zigbee/osif/timer/src/main.c
@@ -12,7 +12,7 @@
 static zb_uint32_t alarm_counter;
 
 /* mock for timer alarm handler */
-zb_void_t zb_osif_zboss_timer_tick(void)
+void zb_osif_zboss_timer_tick(void)
 {
 	alarm_counter++;
 }

--- a/tests/subsys/zigbee/osif/timer/stubs/zb_types.h
+++ b/tests/subsys/zigbee/osif/timer/stubs/zb_types.h
@@ -20,8 +20,6 @@ typedef unsigned short     zb_uint16_t;
 
 typedef signed short       zb_int16_t;
 
-typedef void               zb_void_t;
-
 
 /** @brief General purpose boolean type. */
 typedef enum zb_bool_e zb_bool_t;


### PR DESCRIPTION
The zb_void_t type is no longer available on the ZOI current branch.
This PR aligns our examples and components, so they can be built with the ZBOSS placed inside nrfxlib as well as with the development version.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>