### PR TITLE
Bluetooth: Documentation updates

### DIFF
--- a/include/bluetooth/gatt_pool.h
+++ b/include/bluetooth/gatt_pool.h
@@ -9,9 +9,9 @@
 
 /**
  * @file
- * @defgroup bt_gatt_pool  BLE GATT attribute pools API
+ * @defgroup bt_gatt_pool  Bluetooth LE GATT attribute pools API
  * @{
- * @brief BLE GATT attribute pools.
+ * @brief Bluetooth LE GATT attribute pools.
  */
 
 #ifdef __cplusplus
@@ -38,7 +38,7 @@ extern "C" {
 		.attr_array_size = _attr_array_size                            \
 	}
 
-/** @brief Define a new BLE GATT attribute pool.
+/** @brief Define a new GATT attribute pool.
  *
  *  This macro creates a new attribute pool.
  *

--- a/include/bluetooth/scan.h
+++ b/include/bluetooth/scan.h
@@ -9,7 +9,7 @@
  * @{
  * @brief BT Scanning module
  *
- * @details The Scanning Module handles the BLE scanning for
+ * @details The Scanning Module handles the Bluetooth LE scanning for
  *          your application. The module offers several criteria
  *          for filtering the devices available for connection,
  *          and it can also work in the simple mode without using the filtering.
@@ -136,7 +136,7 @@ struct bt_filter_status {
 /**@brief Advertising info structure.
  */
 struct bt_scan_adv_info {
-	/** BLE advertising type. According to
+	/** Bluetooth LE advertising type. According to
 	 *  Bluetooth Specification 7.8.5
 	 */
 	uint8_t adv_type;
@@ -285,7 +285,7 @@ struct bt_scan_device_info {
 	/** Information about advertising. */
 	struct bt_scan_adv_info adv_info;
 
-	/** Pointer to device BLE address. */
+	/** Pointer to device LE address. */
 	const bt_addr_le_t *addr;
 
 	/** Connection parameters for LE connection. */

--- a/include/bluetooth/services/bas_c.h
+++ b/include/bluetooth/services/bas_c.h
@@ -10,7 +10,7 @@
  * @file
  * @defgroup bt_gatt_bas_c_api Battery Service Client API
  * @{
- * @brief API for the BLE GATT Battery Service (BAS) Client.
+ * @brief API for the Bluetooth LE GATT Battery Service (BAS) Client.
  */
 
 #include <kernel.h>

--- a/include/bluetooth/services/bas_c.h
+++ b/include/bluetooth/services/bas_c.h
@@ -127,16 +127,11 @@ void bt_gatt_bas_c_init(struct bt_gatt_bas_c *bas_c);
 /**
  * @brief Assign handles to the BAS Client instance.
  *
- * This function should be called when a link with a peer has been established,
- * to associate the link to this instance of the module. This makes it
- * possible to handle several links and associate each link to a particular
- * instance of this module. The GATT attribute handles are provided by the
- * GATT Discovery Manager.
- *
- * @note
- * This function starts the report discovery process.
- * Wait for one of the functions in @ref bt_gatt_hids_c_init_params
- * before using the BAS Client object.
+ * This function should be called when a connection with a peer has been
+ * established, to associate the connection to this instance of the module.
+ * This makes it possible to handle multiple connections and associate each
+ * connection to a particular instance of this module.
+ * The GATT attribute handles are provided by the GATT Discovery Manager.
  *
  * @param dm    Discovery object.
  * @param bas_c BAS Client object.

--- a/include/bluetooth/services/dfu_smp_c.h
+++ b/include/bluetooth/services/dfu_smp_c.h
@@ -9,9 +9,9 @@
 
 /**
  * @file
- * @defgroup bt_gatt_dfu_smp_c BLE GATT DFU SMP Client API
+ * @defgroup bt_gatt_dfu_smp_c Bluetooth LE GATT DFU SMP Client API
  * @{
- * @brief API for the BLE GATT DFU SMP (DFU_SMP) Client.
+ * @brief API for the Bluetooth LE GATT DFU SMP (DFU_SMP) Client.
  */
 
 #ifdef __cplusplus

--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -9,9 +9,9 @@
 
 /**
  * @file
- * @defgroup bt_gatt_hids BLE GATT Human Interface Device Service API
+ * @defgroup bt_gatt_hids Bluetooth LE GATT Human Interface Device Service API
  * @{
- * @brief API for the BLE GATT Human Interface Device (HID) Service.
+ * @brief API for the Bluetooth LE GATT Human Interface Device (HID) Service.
  */
 
 #ifdef __cplusplus
@@ -62,7 +62,7 @@ extern "C" {
 
 
 /**@brief Helping macro for @ref BT_GATT_HIDS_DEF, that calculates
- *        the link context size for BLE HIDS instance.
+ *        the link context size for HIDS instance.
  */
 #define _BT_GATT_HIDS_CONN_CTX_SIZE_CALC(...)		   \
 	(FOR_EACH(GET_ARG1, (+), __VA_ARGS__)	+ \

--- a/include/bluetooth/services/hids_c.h
+++ b/include/bluetooth/services/hids_c.h
@@ -9,9 +9,9 @@
 
 /**
  * @file
- * @defgroup bt_gatt_hids_c BLE GATT HIDS Client API
+ * @defgroup bt_gatt_hids_c Bluetooth LE GATT HIDS Client API
  * @{
- * @brief API for the BLE GATT HID Service (HIDS) Client.
+ * @brief API for the Bluetooth LE GATT HID Service (HIDS) Client.
  */
 
 #ifdef __cplusplus
@@ -303,7 +303,7 @@ void bt_gatt_hids_c_release(struct bt_gatt_hids_c *hids_c);
  *
  * @note
  * This function disables transfers inside the HIDS client library.
- * It does not abort any pending transfers in the BLE stack.
+ * It does not abort any pending transfers in the Bluetooth LE stack.
  *
  * @param hids_c HIDS client object.
  */

--- a/include/bluetooth/services/latency.h
+++ b/include/bluetooth/services/latency.h
@@ -6,9 +6,9 @@
 
 /**
  * @file
- * @defgroup bt_gatt_latency BLE GATT Latency Service API
+ * @defgroup bt_gatt_latency Bluetooth LE GATT Latency Service API
  * @{
- * @brief API for the BLE GATT Latency Service.
+ * @brief API for the Bluetooth LE GATT Latency Service.
  */
 
 #ifndef BT_GATT_LATENCY_H_

--- a/include/bluetooth/services/latency_c.h
+++ b/include/bluetooth/services/latency_c.h
@@ -6,9 +6,9 @@
 
 /**
  * @file
- * @defgroup bt_gatt_latency_c BLE GATT Latency Client API
+ * @defgroup bt_gatt_latency_c Bluetooth LE GATT Latency Client API
  * @{
- * @brief API for the BLE GATT Latency Client.
+ * @brief API for the Bluetooth LE GATT Latency Client.
  */
 
 #ifndef BT_GATT_LATENCY_C_H_

--- a/include/bluetooth/services/lbs.h
+++ b/include/bluetooth/services/lbs.h
@@ -47,9 +47,10 @@ struct bt_gatt_lbs_cb {
 
 /** @brief Initialize the LBS Service.
  *
- * This function registers a BLE service with two characteristics: Button
- * and LED. Enable notifications for the Button Characteristic to let a
- * connected BLE unit know when the button state changes.
+ * This function registers a GATT service with two characteristics: Button
+ * and LED.
+ * Send notifications for the Button Characteristic to let connected peers know
+ * when the button state changes.
  * Write to the LED Characteristic to change the state of the LED on the
  * board.
  *
@@ -66,7 +67,7 @@ int bt_gatt_lbs_init(struct bt_gatt_lbs_cb *callbacks);
 /** @brief Send the button state.
  *
  * This function sends a binary state, typically the state of a
- * button, to the connected BLE unit.
+ * button, to all connected peers.
  *
  * @param[in] button_state The state of the button.
  *

--- a/include/bluetooth/services/nus.h
+++ b/include/bluetooth/services/nus.h
@@ -58,9 +58,9 @@ struct bt_gatt_nus_cb {
 
 /**@brief Initialize the service.
  *
- * @details This function registers a BLE service with two characteristics,
- *          TX and RX. A BLE unit that is connected to this service can send
- *          data to the RX Characteristic. When the BLE unit enables
+ * @details This function registers a GATT service with two characteristics,
+ *          TX and RX. A remote device that is connected to this service
+ *          can send data to the RX Characteristic. When the remote enables
  *          notifications, it is notified when data is sent to the TX
  *          Characteristic.
  *
@@ -75,10 +75,11 @@ int bt_gatt_nus_init(struct bt_gatt_nus_cb *callbacks);
 
 /**@brief Send data.
  *
- * @details This function sends data from the BLE unit that runs this service
- *          to another BLE unit that is connected to it.
+ * @details This function sends data to a connected peer, or all connected
+ *          peers.
  *
- * @param[in] conn Pointer to connection Object.
+ * @param[in] conn Pointer to connection object, or NULL to send to all
+ *                 connected peers.
  * @param[in] data Pointer to a data buffer.
  * @param[in] len  Length of the data in the buffer.
  *

--- a/include/bluetooth/services/nus_c.h
+++ b/include/bluetooth/services/nus_c.h
@@ -9,9 +9,9 @@
 
 /**
  * @file
- * @defgroup bt_gatt_nus_c BLE GATT NUS Client API
+ * @defgroup bt_gatt_nus_c Bluetooth LE GATT NUS Client API
  * @{
- * @brief API for the BLE GATT Nordic UART Service (NUS) Client.
+ * @brief API for the Bluetooth LE GATT Nordic UART Service (NUS) Client.
  */
 
 #ifdef __cplusplus

--- a/include/bluetooth/services/throughput.h
+++ b/include/bluetooth/services/throughput.h
@@ -6,9 +6,9 @@
 
 /**
  * @file
- * @defgroup bt_gatt_throughput BLE GATT Throughput Service API
+ * @defgroup bt_gatt_throughput Bluetooth LE GATT Throughput Service API
  * @{
- * @brief API for the BLE GATT Throughput Service.
+ * @brief API for the Bluetooth LE GATT Throughput Service.
  */
 
 #ifndef BT_GATT_THROUGHPUT_H_


### PR DESCRIPTION
Remove note that was wrongly copied from hid_c.h header. This
note does not apply to the BAS client.
Change "link" to "connection", which is more appropriate terminology.

Remove use of abbreviation BLE in public headers, this abbreviation
does not belong in public headers. Instead Bluetooth LE should
be used.