### PR TITLE
doc: fix linking to doxygen structs

### DIFF
--- a/applications/nrf_desktop/doc/battery_charger.rst
+++ b/applications/nrf_desktop/doc/battery_charger.rst
@@ -47,7 +47,7 @@ The module enables charging when USB is powered or active.
     Make sure that the hardware configuration enables charging by default (for example, when the pin to enable charging is not configured).
     Otherwise it will be impossible to enable charging when the battery is empty.
 
-The module checks the battery state using :c:type:`struct k_delayed_work`.
+The module checks the battery state using :cpp:class:`k_delayed_work`.
 The check is based on the edge interrupt count on the CSO pin in a period of time defined in ``ERROR_CHECK_TIMEOUT_MS``, and on the CSO pin state while the work is processed.
 
 On a battery state change, the new state is sent using ``battery_state_event``.

--- a/applications/nrf_desktop/doc/battery_meas.rst
+++ b/applications/nrf_desktop/doc/battery_meas.rst
@@ -53,7 +53,7 @@ Because Zephyr's :ref:`zephyr:gpio_api` driver is used to control this pin, also
 Implementation details
 **********************
 
-:c:type:`struct k_delayed_work` starts the asynchronous voltage measurement and resubmits itself.
+:cpp:class:`k_delayed_work` starts the asynchronous voltage measurement and resubmits itself.
 When it is processed the next time, it reads the measured voltage.
 This read sequence is repeated periodically.
 When the system goes to the low-power state, the work is canceled.

--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -36,7 +36,7 @@ When the device is in the low power mode and :ref:`nrf_desktop_config_channel` i
 Implementation details
 **********************
 
-The |ble_latency| uses delayed works (:c:type:`struct k_delayed_work`) to control the connection latency and trigger the security time-out.
+The |ble_latency| uses delayed works (:cpp:class:`k_delayed_work`) to control the connection latency and trigger the security time-out.
 
 The module listens for ``config_event`` and ``config_fetch_request_event`` to detect when the :ref:`nrf_desktop_config_channel` is in use.
 

--- a/applications/nrf_desktop/doc/ble_state.rst
+++ b/applications/nrf_desktop/doc/ble_state.rst
@@ -6,8 +6,8 @@ Bluetooth LE state module
 Use the Bluetooth LE state module to:
 
 * Enable Bluetooth (:cpp:func:`bt_enable`).
-* Handle Zephyr connection callbacks (:c:type:`struct bt_conn_cb`).
-* Handle Zephyr authenticated pairing callbacks (:c:type:`struct bt_conn_auth_cb`).
+* Handle Zephyr connection callbacks (:cpp:type:`bt_conn_cb`).
+* Handle Zephyr authenticated pairing callbacks (:cpp:type:`bt_conn_auth_cb`).
 * Propagate information about the connection state and parameters by using :ref:`event_manager` events.
 
 Module events
@@ -59,9 +59,9 @@ The :ref:`nrf_desktop_ble_conn_params` updates the connection parameters on ``bl
 Connection references
 =====================
 
-The |ble_state| keeps references to :c:type:`struct bt_conn` objects to ensure that they remain valid when other application modules access them.
+The |ble_state| keeps references to :cpp:class:`bt_conn` objects to ensure that they remain valid when other application modules access them.
 When a new connection is established, the module calls :cpp:func:`bt_conn_ref` to increase the object reference counter.
-After ``ble_peer_event`` regarding disconnection or connection failure is received by all other application modules, the |ble_state| unreferences the :c:type:`struct bt_conn` object by using :cpp:func:`bt_conn_unref`.
+After ``ble_peer_event`` regarding disconnection or connection failure is received by all other application modules, the |ble_state| unreferences the :cpp:class:`bt_conn` object by using :cpp:func:`bt_conn_unref`.
 
 For Bluetooth Peripheral, the |ble_state| is used to request the connection security level 2.
 If the connection security level 2 is not established, the peripheral device disconnects.
@@ -69,7 +69,7 @@ If the connection security level 2 is not established, the peripheral device dis
 Passkey enabled
 ===============
 
-If you set the ``CONFIG_DESKTOP_BLE_ENABLE_PASSKEY`` option, the |ble_state| registers the set of authenticated pairing callbacks (:c:type:`struct bt_conn_auth_cb`).
+If you set the ``CONFIG_DESKTOP_BLE_ENABLE_PASSKEY`` option, the |ble_state| registers the set of authenticated pairing callbacks (:cpp:type:`bt_conn_auth_cb`).
 The callbacks can be used to achieve higher security levels.
 The passkey input is handled in the :ref:`nrf_desktop_passkey`.
 

--- a/applications/nrf_desktop/doc/board.rst
+++ b/applications/nrf_desktop/doc/board.rst
@@ -29,13 +29,13 @@ The :file:`port_state_def.h` file defines the states set to the GPIO ports by th
 * ``port_state_on`` - State set on the system start and wake-up.
 * ``port_state_off`` - State set when the system enters the low-power mode.
 
-Every :c:type:`struct port_state` refers to a single GPIO port and contains the following information:
+Every :cpp:class:`port_state` refers to a single GPIO port and contains the following information:
 
 * :cpp:member:`name` - GPIO device name (obtained from :ref:`devicetree <zephyr:dt-guide>`, for example with ``DT_LABEL(DT_NODELABEL(gpio0))``).
-* :cpp:member:`ps` - Pointer to the array of :c:type:`struct pin_state`.
+* :cpp:member:`ps` - Pointer to the array of :cpp:class:`pin_state`.
 * :cpp:member:`ps_count` - Size of the `ps` array.
 
-Every :c:type:`struct pin state` defines the state of a single GPIO pin:
+Every :cpp:class:`pin_state` defines the state of a single GPIO pin:
 
 * :cpp:member:`pin` - Pin number.
 * :cpp:member:`val` - Value set for the pin.

--- a/applications/nrf_desktop/doc/buttons_sim.rst
+++ b/applications/nrf_desktop/doc/buttons_sim.rst
@@ -36,7 +36,7 @@ By default, the sequence is generated only once.
 Implementation details
 **********************
 
-The |button_sim| generates button sequence using :c:type:`struct k_delayed_work`, which resubmits itself.
+The |button_sim| generates button sequence using :cpp:class:`k_delayed_work`, which resubmits itself.
 The work handler submits the press and the release of a single button from the sequence.
 
 Receiving ``button_event`` with the key ID set to ``CONFIG_DESKTOP_BUTTONS_SIM_TRIGGER_KEY_ID`` either stops generating the sequence (in case it is already being generated) or starts generating it.

--- a/applications/nrf_desktop/doc/click_detector.rst
+++ b/applications/nrf_desktop/doc/click_detector.rst
@@ -34,7 +34,7 @@ The |click_detector| detects click types based on ``button_event``.
 Make sure you define the :ref:`nrf_desktop_buttons` hardware interface.
 
 Set ``CONFIG_DESKTOP_CLICK_DETECTOR_ENABLE`` and define the module configuration.
-The configuration (array of :c:type:`struct click_detector_config`) is written in the :file:`click_detector_def.h`` file located in the board-specific directory in the application configuration directory.
+The configuration (array of :cpp:class:`click_detector_config`) is written in the :file:`click_detector_def.h`` file located in the board-specific directory in the application configuration directory.
 
 For every click detector, make sure to define the following information:
 
@@ -44,7 +44,7 @@ For every click detector, make sure to define the following information:
 Implementation details
 **********************
 
-Tracing of key states is implemented using a periodically submitted work (:c:type:`struct k_delayed_work`).
+Tracing of key states is implemented using a periodically submitted work (:cpp:class:`k_delayed_work`).
 The work updates the states of traced keys and sends ``click_event``.
 The work is not submitted if there is no key for which the state should be updated.
 

--- a/applications/nrf_desktop/doc/hid_state.rst
+++ b/applications/nrf_desktop/doc/hid_state.rst
@@ -67,7 +67,7 @@ Out of all available input data types, the following types are collected by the 
 * `Relative value data`_ (axes)
 * `Absolute value data`_ (buttons)
 
-Both types are stored in the :c:type:`struct report_data` structure.
+Both types are stored in the :cpp:class:`report_data` structure.
 
 Relative value data
 -------------------
@@ -77,7 +77,7 @@ Both ``motion_event`` and ``wheel_event`` are sources of this type of data.
 
 To indicate a change to this input data, overwrite the value that is already stored.
 
-When either ``motion_event`` or ``wheel_event`` is received, the |hid_state| selects the :c:type:`struct report_data` structure associated with the mouse HID report and stores the values at the right position within this structure's ``axes`` member.
+When either ``motion_event`` or ``wheel_event`` is received, the |hid_state| selects the :cpp:class:`report_data` structure associated with the mouse HID report and stores the values at the right position within this structure's ``axes`` member.
 
 .. note::
     The values of axes are stored every time the input data is received, but these values are cleared when a report is connected to the subscriber.
@@ -92,12 +92,12 @@ The ``button_event`` is the source of this type of data.
 To indicate a change to this input data, overwrite the value that is already stored.
 
 Since keys on the board can be associated to a usage ID, and thus be part of different HID reports, the first step is to identify to which report the key belongs and what usage it represents.
-This is done by obtaining the key mapping from the :c:type:`struct hid_keymap` structure.
+This is done by obtaining the key mapping from the :cpp:class:`hid_keymap` structure.
 This structure is part of the application configuration files for the specific board and is defined in :file:`hid_keymap_def.h`.
 
 Once the mapping is obtained, the application checks if the report to which the usage belongs is connected:
 
-* If the report is connected, the value is stored at the right position in the ``items`` member of :c:type:`struct report_data` associated with the report.
+* If the report is connected, the value is stored at the right position in the ``items`` member of :cpp:class:`report_data` associated with the report.
 * If the report is not connected, the value is stored in the ``eventq`` event queue member of the same structure.
 
 The difference between these operations is that storing value onto the queue (second case) preserves the order of input events.
@@ -113,7 +113,7 @@ The storing approach before the connection depends on the data type:
 
 The reason for this operation is to allow to track key presses that happen right after the device is woken up, but before it is able to connect to the host.
 
-When the device is disconnected and the input event with the absolute value data is received, the data is stored onto the event queue (``eventq``), a member of :c:type:`struct report_data` structure.
+When the device is disconnected and the input event with the absolute value data is received, the data is stored onto the event queue (``eventq``), a member of :cpp:class:`report_data` structure.
 This queue preserves an order at which input data events are received.
 
 Storing limitations
@@ -157,8 +157,8 @@ Tracking state of HID report notifications
 ==========================================
 
 For each subscriber, the |hid_state| module tracks the state of notifications for each of the available HID reports.
-These are tracked in the subscriber's structure :c:type:`struct subscriber`.
-This structure's member ``state`` is an array of :c:type:`struct report_state` structures.
+These are tracked in the subscriber's structure :cpp:class:`subscriber`.
+This structure's member ``state`` is an array of :cpp:class:`report_state` structures.
 Each element corresponds to one available HID report.
 
 The subscriber connects to the HID reports by submitting ``hid_report_subscription_event``.
@@ -167,17 +167,17 @@ Depending on the connection method, this event can be submitted:
 * For Bluetooth, when the notification is enabled for a given HID report.
 * For USB, when the device is connected to USB.
 
-The :c:type:`struct report_state` structure serves the following purposes:
+The :cpp:class:`report_state` structure serves the following purposes:
 
 * Tracks the state of the connection.
-* Contains the link connecting the object to the right :c:type:`struct report_data` structure, from which the data is taken when the HID report is formed.
+* Contains the link connecting the object to the right :cpp:class:`report_data` structure, from which the data is taken when the HID report is formed.
 * Tracks the number of reports of the associated type that were sent to the subscriber.
 
 Forming HID reports
 ===================
 
 When a HID report is to be sent to the subscriber, the |hid_state| calls the function responsible for the report generation.
-The :c:type:`struct report_data` structure is passed as an argument to this function.
+The :cpp:class:`report_data` structure is passed as an argument to this function.
 
 .. note::
     The HID report formatting function must work according to the HID report descriptor (``hid_report_desc``).

--- a/applications/nrf_desktop/doc/leds.rst
+++ b/applications/nrf_desktop/doc/leds.rst
@@ -13,7 +13,7 @@ This allows for different RGB or monochromatic colors.
 An example may be an LED that is blinking or breathing with a given color.
 Such LED behavior is referred to as *LED effect*.
 
-The LED effect (:c:type:`struct led_effect`) is described by the following characteristics:
+The LED effect (:cpp:class:`led_effect`) is described by the following characteristics:
 
 * Pointer to array of LED steps (:cpp:member:`steps`).
 * Size of the array (:cpp:member:`step_count`).
@@ -66,7 +66,7 @@ Implementation details
 **********************
 
 The LED color is achieved by setting the proper pulse widths for the PWM signals.
-To achieve the desired LED effect, colors for the given LED are periodically updated using work (:c:type:`struct k_delayed_work`).
+To achieve the desired LED effect, colors for the given LED are periodically updated using work (:cpp:class:`k_delayed_work`).
 One work automatically updates the color of a single LED.
 
 This module turns off all LEDs when the application goes to the power down state.

--- a/applications/nrf_desktop/doc/selector.rst
+++ b/applications/nrf_desktop/doc/selector.rst
@@ -23,14 +23,14 @@ The module implemented in :file:`selector_hw.c` uses the Zephyr :ref:`zephyr:gpi
 For this reason, you should set :option:`CONFIG_GPIO` option.
 
 Set ``CONFIG_DESKTOP_SELECTOR_HW_ENABLE`` option to enable the module.
-The configuration for this module is an array of :c:type:`struct selector_config` pointers.
+The configuration for this module is an array of :cpp:class:`selector_config` pointers.
 The array is written in the :file:`selector_hw_def.h` file located in the board-specific directory in the application configuration directory.
 
 For every hardware selector, define the following parameters:
 
 * :cpp:member:`id` - ID of the hardware selector.
-* :cpp:member:`pins` - Pointer to the array of :c:type:`struct gpio_pin`.
-* :cpp:member:`pins_size` - Size of the array of :c:type:`struct gpio_pin`.
+* :cpp:member:`pins` - Pointer to the array of :cpp:class:`gpio_pin`.
+* :cpp:member:`pins_size` - Size of the array of :cpp:class:`gpio_pin`.
 
 .. warning::
     Each source of ``selector_event`` must have a unique ID to properly distinguish events from different sources.
@@ -47,6 +47,6 @@ When the application goes to sleep, selectors are not informing about state chan
 
 If a selector is placed between states, it is in unknown state and ``selector_event`` is not sent.
 
-Recording of selector state changes is implemented using GPIO callbacks (:c:type:`struct gpio_callback`) and work (:c:type:`struct k_delayed_work`).
+Recording of selector state changes is implemented using GPIO callbacks (:cpp:class:`gpio_callback`) and work (:cpp:class:`k_delayed_work`).
 Each state change triggers an interrupt (GPIO interrupt for pin level high).
 Callback of an interrupt submits work, which sends ``selector_event``.

--- a/applications/nrf_desktop/doc/watchdog.rst
+++ b/applications/nrf_desktop/doc/watchdog.rst
@@ -37,6 +37,6 @@ Implementation details
 **********************
 
 The watchdog timer is started when the :ref:`nrf_desktop_main` is ready (which is reported using ``module_state_event``).
-The module periodically resets the watchdog timer using :c:type:`struct k_delayed_work`.
+The module periodically resets the watchdog timer using :cpp:class:`k_delayed_work`.
 The work resubmits itself with delay equal to ``CONFIG_DESKTOP_WATCHDOG_TIMEOUT / 3``.
 In case of the system hang, the work will not be processed, the watchdog timer will not be reset on time, and the system will be restarted.

--- a/doc/nrf/doc_styleguide.rst
+++ b/doc/nrf/doc_styleguide.rst
@@ -174,7 +174,8 @@ The `Breathe documentation`_ contains information about what you can link to.
 To link directly to a doxygen reference from RST, use the following Breathe domains:
 
 * Function: ``:cpp:func:``
-* Structure: ``:c:type:``
+* Structure: ``:cpp:class:``
+* Type: ``:cpp:type:``
 * Enum (the list): ``:cpp:enum:``
 * Enumerator (an item): ``:cpp:enumerator:``
 * Macro or define: ``:c:macro:``

--- a/doc/nrf/releases/release-notes-1.2.0.rst
+++ b/doc/nrf/releases/release-notes-1.2.0.rst
@@ -246,7 +246,7 @@ Updated libraries
 * :ref:`doc_fw_info`:
 
   * Renamed ABIs to EXT_APIs.
-  * Restructured the :c:type:`fw_info` structure:
+  * Restructured the :cpp:class:`fw_info` structure:
 
     * Renamed the fields ``firmware_size``, ``firmware_address``, and ``firmware_version`` to ``size``, ``address``, and ``version``.
     * Added a field to invalidate the structure.

--- a/doc/nrf/releases/release-notes-1.3.0.rst
+++ b/doc/nrf/releases/release-notes-1.3.0.rst
@@ -406,7 +406,7 @@ Build system
 Zephyr
 ======
 
-* Updated the time-out type to :c:type:`k_timeout_t`, because the Zephyr kernel deprecated its integer type as time-out in different APIs (timeout, scheduling, ...).
+* Updated the time-out type to :cpp:type:`k_timeout_t`, because the Zephyr kernel deprecated its integer type as time-out in different APIs (timeout, scheduling, ...).
 * Updated all files to use the C/C++ Devicetree generic API, because the C/C++ Devicetree value fetching API was reworked in Zephyr so that it uses compatible strings and new function-like macros to match properties.
   See :ref:`zephyr:dt-from-c`.
 

--- a/doc/nrf/ug_esb.rst
+++ b/doc/nrf/ug_esb.rst
@@ -96,7 +96,7 @@ To do so, the PRX adds a packet to its TX FIFO, which is sent as the payload in 
 
 
 If the PTX does not receive the ACK after the initial transmitted packet, it attempts to retransmit the packet until the ACK is finally being received.
-The maximum number of allowed retransmission attempts and the delay between each attempt is specified by the most recent call to either :cpp:func:`esb_init` (where the values of :cpp:member:`retransmit_count` and :cpp:member:`retransmit_delay` in the :cpp:type:`esb_config` structure specify the number of retransmission attempts and the delay between them, respectively) or the functions :cpp:func:`esb_set_retransmit_count` and :cpp:func:`esb_set_retransmit_delay`.
+The maximum number of allowed retransmission attempts and the delay between each attempt is specified by the most recent call to either :cpp:func:`esb_init` (where the values of :cpp:member:`retransmit_count` and :cpp:member:`retransmit_delay` in the :cpp:class:`esb_config` structure specify the number of retransmission attempts and the delay between them, respectively) or the functions :cpp:func:`esb_set_retransmit_count` and :cpp:func:`esb_set_retransmit_delay`.
 The retransmission delay is defined as the duration between the start of each transmission attempt.
 Note that this differs from the legacy nRF24L Series hardware implementation, where the delay was defined as the duration from the end of a packet transmission until the start of the retransmission.
 
@@ -111,7 +111,7 @@ However, repeated packets will always be ACKed by the PRX, even though they are 
 
 
 A PTX can select that individual packets that are transmitted to the PRX do not require an ACK to be sent in return from the PRX.
-This decision is taken by the application when uploading a packet to the TX FIFO using the :cpp:member:`esb_payload::noack` field of the :cpp:type:`p_payload` parameter that is passed to the :cpp:func:`esb_write_payload` function.
+This decision is taken by the application when uploading a packet to the TX FIFO using the :cpp:member:`esb_payload::noack` field of the :cpp:class:`esb_payload` parameter that is passed to the :cpp:func:`esb_write_payload` function.
 
 When the PRX receives a packet that does not require an ACK, it does not send an ACK packet to the PTX, and as a result the PTX will continue retransmitting the packet until the maximum number of allowed retransmission attempts is reached.
 

--- a/doc/nrf/ug_thread_ot_integration.rst
+++ b/doc/nrf/ug_thread_ot_integration.rst
@@ -47,8 +47,8 @@ The OpenThread network stack uses the following threads:
 * ``tx_workq`` - Responsible for receiving the UDP packet, scheduling the OpenThread Tasklet for transmission, and unlocking the ``openthread`` thread by giving the semaphore.
 * ``workqueue`` - Responsible for invoking the radio driver API to schedule a transmission.
 * ``802154 RX`` - Responsible for the upper half processing of the radio frame reception (that is, the core stack part).
-  Works on objects of type :c:type:`nrf5_802154_rx_frame` that are put to the :c:type:`nrf5_data.rx_fifo` from the RX IRQ context.
-  The thread is responsible for creating the :c:type:`net_pkt` structure and passing it to the upper layer with :cpp:func:`net_recv_data()`.
+  Works on objects of type :cpp:class:`nrf5_802154_rx_frame` that are put to the :c:type:`nrf5_data.rx_fifo` from the RX IRQ context.
+  The thread is responsible for creating the :cpp:class:`net_pkt` structure and passing it to the upper layer with :cpp:func:`net_recv_data()`.
 
 Apart from these threads, the OpenThread stack also uses the :ref:`application threads <threads_v2>`.
 Usually one or more, these threads execute the application logic.
@@ -66,7 +66,7 @@ The OpenThread network stack components are located in the following directories
 
 The responsibilities of the OpenThread shim layer are as follows:
 
-* Translating the data into the Zephyr's native :c:type:`net_pkt` structure.
+* Translating the data into the Zephyr's native :cpp:class:`net_pkt` structure.
 * Providing the OpenThread thread body and synchronization API.
 * Providing :cpp:func:`openthread_send()` and :cpp:func:`openthread_recv()` calls that are registered as the L2 interface API.
 * Providing a way to initialize the OpenThread stack.
@@ -113,12 +113,12 @@ The numbers in the figure correspond to the step numbers in the following data r
     As a result, it puts a work item with :cpp:func:`net_recv_data()` to have the frame processed.
 4.  The work queue thread ``rx_workq`` calls the registered handler for every queued frame.
     In this case, the registered handler :cpp:func:`openthread_recv()` checks if the frame is of the IEEE 802.15.4 type.
-    If this is the case, it inserts the frame into :c:type:``rx_pkt_fifo` and returns ``NET_OK``.
+    If this is the case, it inserts the frame into :cpp:class:`rx_pkt_fifo` and returns ``NET_OK``.
 5.  The ``openthread`` thread gets a frame from the FIFO and processes it.
     It also handles the IP header compression and reassembly of fragmented traffic.
 6.  As soon as the thread detects a valid IPv6 packet that needs to be handled by the higher layer, it calls the registered callback :cpp:func:`ot_receive_handler()`.
-    This callback creates a buffer for a :c:type:`net_pkt` structure that is going to be passed to Zephyr's IP stack.
-    It also calls :cpp:func:`net_recv_data()` to have the :c:type:`net_pkt` structure processed.
+    This callback creates a buffer for a :cpp:class:`net_pkt` structure that is going to be passed to Zephyr's IP stack.
+    It also calls :cpp:func:`net_recv_data()` to have the :cpp:class:`net_pkt` structure processed.
 7.  This time the :cpp:func:`openthread_recv()` called by the workqueue returns ``NET_CONTINUE``.
     This indicates that the valid IPv6 packet is present and needs to be processed by Zephyr's higher layer.
 8.  :cpp:func:`net_ipv6_input()` passes the packet to the next higher layer.
@@ -145,12 +145,12 @@ The numbers in the figure correspond to the step numbers in the following data t
 
 1. The application uses the :ref:`BSD socket API <bsd_sockets_interface>` when sending the data.
    However, direct interaction with the OpenThread API is possible, for example to use its CoAP implementation.
-2. The application data is prepared for sending to the kernel space and copied to internal :c:type:`net_buf` structures.
+2. The application data is prepared for sending to the kernel space and copied to internal :cpp:class:`net_buf` structures.
 3. Depending on the socket type, a protocol header is added in front of the data.
    For example, if the socket is a UDP socket, a UDP header is constructed and placed in front of the data.
-4. A UDP :c:type:`net_pkt` structured is queued to be processed with :cpp:func:`process_tx_packet()`.
+4. A UDP :cpp:class:`net_pkt` structured is queued to be processed with :cpp:func:`process_tx_packet()`.
    In the call chain, the :cpp:func:`openthread_send()` is called.
-   It converts the :c:type:`net_pkt` to the :c:type:`otMessage` format and invokes :cpp:func:`otIp6Send()`.
+   It converts the :cpp:class:`net_pkt` to the :cpp:class:`otMessage` format and invokes :cpp:func:`otIp6Send()`.
    In this step, the message is processed by the OpenThread stack.
 5. The tasklet to schedule the transmission is posted and the semaphore that unlocks the ``openthread`` thread is given.
    Mac and Submac operations take place.

--- a/include/bluetooth/mesh/sensor.rst
+++ b/include/bluetooth/mesh/sensor.rst
@@ -92,7 +92,7 @@ Each sensor type may consist of one or more channels.
 The list of sensor channels in each sensor type is immutable, and all channels must always have a valid value when the sensor data is passed around.
 This is slightly different from the sensor type representation in the Bluetooth Mesh Specification, which represents multi-channel sensors as structures, rather than flat lists.
 
-Each channel in a sensor type is represented by a single :c:type:`sensor_value`.
+Each channel in a sensor type is represented by a single :cpp:class:`sensor_value`.
 For sensor values that are represented as whole numbers, the fractional part of the value (:cpp:member:`sensor_value::val2`) is ignored.
 Boolean types are inferred only from the integer part of the value (:cpp:member:`sensor_value::val1`).
 

--- a/include/bluetooth/services/bas_c.rst
+++ b/include/bluetooth/services/bas_c.rst
@@ -15,7 +15,7 @@ Usage
 *****
 
 .. note::
-   Do not access any of the values in the :cpp:type:`bt_gatt_bas_c` object structure directly.
+   Do not access any of the values in the :cpp:class:`bt_gatt_bas_c` object structure directly.
    All values that should be accessed have accessor functions.
    The reason that the structure is fully defined is to allow the application to allocate the memory for it.
 

--- a/include/bluetooth/services/dfu_smp_c.rst
+++ b/include/bluetooth/services/dfu_smp_c.rst
@@ -38,7 +38,7 @@ Usage
 *****
 
 .. note::
-   Do not access any of the values in the :cpp:type:`bt_gatt_dfu_smp_c` object structure directly.
+   Do not access any of the values in the :cpp:class:`bt_gatt_dfu_smp_c` object structure directly.
    All values that should be accessed have accessor functions.
    The reason that the structure is fully defined is to allow the application to allocate the memory for it.
 
@@ -56,7 +56,7 @@ Sending a command
 =================
 
 To send a command, use :cpp:func:`bt_gatt_dfu_smp_c_command`.
-The command is provided as a raw binary buffer consisting of a :cpp:type:`dfu_smp_header` and the payload.
+The command is provided as a raw binary buffer consisting of a :cpp:class:`dfu_smp_header` and the payload.
 
 
 Processing the response
@@ -67,7 +67,7 @@ It is passed to the callback function that was provided when issuing the command
 
 Use :cpp:func:`bt_gatt_dfu_smp_c_rsp_state` to access the data of the current part of the response.
 As the response might be received in multiple notifications, use :cpp:func:`bt_gatt_dfu_smp_c_rsp_total_check` to verify if this is the last part of the response.
-The offset size of the current part and the total size are available in fields of the :cpp:type:`bt_gatt_dfu_smp_rsp_state` structure.
+The offset size of the current part and the total size are available in fields of the :cpp:class:`bt_gatt_dfu_smp_rsp_state` structure.
 
 
 API documentation

--- a/include/bluetooth/services/hids_c.rst
+++ b/include/bluetooth/services/hids_c.rst
@@ -29,7 +29,7 @@ Usage
 *****
 
 .. note::
-   Do not access any of the values in the :cpp:type:`bt_gatt_hids_c` object structure directly.
+   Do not access any of the values in the :cpp:class:`bt_gatt_hids_c` object structure directly.
    All values that should be accessed have accessor functions.
    The reason that the structure is fully defined is to allow the application to allocate the memory for it.
 

--- a/include/fw_info.rst
+++ b/include/fw_info.rst
@@ -17,7 +17,7 @@ It must be located at one of the following offsets from the start of the image: 
 The reason that the structure is not located at 0x00 is that this can be problematic in some use cases, such as when the vector table must be located at 0x00.
 
 These rules make it simple to retrieve the information by checking for each possible offset (0x0, 0x200, 0x400, 0x800, 0x1000) if the first 12 bytes match the magic value.
-If they do, the information can be retrieved according to the definition in :c:type:`fw_info`.
+If they do, the information can be retrieved according to the definition in :cpp:class:`fw_info`.
 
 Information structure
 *********************
@@ -122,7 +122,7 @@ To create an EXT_API, complete the following steps:
       ver = 1
       source "${ZEPHYR_BASE}/../nrf/subsys/fw_info/Kconfig.template.fw_info_ext_api"
 
-#. Declare a new struct type that starts with the :c:type:`fw_info_ext_api` struct:
+#. Declare a new struct type that starts with the :cpp:class:`fw_info_ext_api` struct:
 
    .. code-block:: c
 

--- a/include/net/aws_iot.rst
+++ b/include/net/aws_iot.rst
@@ -66,7 +66,7 @@ Connecting
 **********
 
 .. note::
-   The API requires that a configuration structure :c:type:`aws_iot_config` is declared in the application and passed into the :cpp:func:`aws_iot_init` and :cpp:func:`aws_iot_connect` functions.
+   The API requires that a configuration structure :cpp:class:`aws_iot_config` is declared in the application and passed into the :cpp:func:`aws_iot_init` and :cpp:func:`aws_iot_connect` functions.
    This exposes the application to the MQTT socket used for the connection, which is polled on, in the application.
    It also enables the application to pass in a client id (*thingname*) at runtime.
 
@@ -165,7 +165,7 @@ To connect to the AWS IoT broker, set the following mandatory options (specified
 - :option:`CONFIG_AWS_IOT_BROKER_HOST_NAME`
 - :option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC`
 
-To enable the application to optionally pass a client id at runtime, set the ``client_id`` entry in the :c:type:`aws_iot_config` structure passed in the :cpp:func:`aws_iot_init` function and set the following option:
+To enable the application to optionally pass a client id at runtime, set the ``client_id`` entry in the :cpp:class:`aws_iot_config` structure passed in the :cpp:func:`aws_iot_init` function and set the following option:
 
 - :option:`CONFIG_AWS_IOT_CLIENT_ID_APP`
 

--- a/include/net/icalendar_parser.rst
+++ b/include/net/icalendar_parser.rst
@@ -8,7 +8,7 @@ The library parses the calendaring information and returns parsed calendar event
 
 The library first detects the beginning of the calendar object by locating the delimiter ``BEGIN:VCALENDAR``.
 It then parses the following calendar content fragment by fragment.
-For each calendar component that is parsed, the library sends a parsed event (:c:type:`ical_parser_evt`) to the application.
+For each calendar component that is parsed, the library sends a parsed event (:cpp:class:`ical_parser_evt`) to the application.
 
 Supported features
 ******************

--- a/include/supl_os_client.rst
+++ b/include/supl_os_client.rst
@@ -185,8 +185,8 @@ The various steps in the communication session are described below:
    See the documentation on the `SET-Initiated Non-Roaming Successful Case (Proxy mode)`_ for more information on the SUPL session.
    The callback functions used for data transfer are listed below:
 
-    * SUPL Write (:c:type:`supl_write_t`) : callback for sending outgoing data to the SUPL server
-    * SUPL Read (:c:type:`supl_read_t`) : callback for receiving incoming data from the SUPL server
+    * SUPL Write (:cpp:type:`supl_write_t`) : callback for sending outgoing data to the SUPL server
+    * SUPL Read (:cpp:type:`supl_read_t`) : callback for receiving incoming data from the SUPL server
 
 #. The decoded SUPL data is sent to the GPS module using the AGPS Handler (:cpp:func:`agps_handler_t`) callback function.
 #. After the application returns from the :cpp:func:`supl_client_session` function, the TCP socket is no longer used by the SUPL client library and can be closed.

--- a/lib/bin/lwm2m_carrier/lwm2m_carrier.rst
+++ b/lib/bin/lwm2m_carrier/lwm2m_carrier.rst
@@ -118,7 +118,7 @@ LwM2M carrier library events
 
 :c:macro:`LWM2M_CARRIER_EVENT_ERROR`
    This event indicates an error.
-   The event data struct :c:type:`lwm2m_carrier_event_error_t` contains the information about the error (:cpp:member:`code` and :cpp:member:`value`).
+   The event data struct :cpp:type:`lwm2m_carrier_event_error_t` contains the information about the error (:cpp:member:`code` and :cpp:member:`value`).
 
    :c:macro:`LWM2M_CARRIER_ERROR_CONNECT_FAIL`
       This error is generated from the :cpp:func:`lte_lc_init_and_connect` function.
@@ -137,7 +137,7 @@ LwM2M carrier library events
    :c:macro:`LWM2M_CARRIER_ERROR_FOTA_PKG`
       This error indicates that the update package has been rejected.
       The integrity check has failed because of a wrong package sent from the server, or a wrong package received by client.
-      The :cpp:member:`value` field will have an error of type :c:type:`nrf_dfu_err_t` from the file :file:`nrfxlib\\bsdlib\\include\\nrf_socket.h`.
+      The :cpp:member:`value` field will have an error of type :cpp:type:`nrf_dfu_err_t` from the file :file:`nrfxlib\\bsdlib\\include\\nrf_socket.h`.
 
    :c:macro:`LWM2M_CARRIER_ERROR_FOTA_PROTO`
       This error indicates a protocol error.
@@ -198,8 +198,8 @@ Below are some of the requirements and limitations of the application while runn
 * The LwM2M carrier library uses a TLS session for FOTA.
   TLS handshakes performed by the application might fail if the LwM2M carrier library is performing one at the same time.
 
-   * If the application is in a TLS session and a :c:type:`LWM2M_CARRIER_EVENT_FOTA_START` event is sent to the application, the application must immediately end the TLS session.
-   * TLS becomes available again upon the next :c:type:`LWM2M_CARRIER_EVENT_READY` or :c:type:`LWM2M_CARRIER_EVENT_DEFERRED` event.
+   * If the application is in a TLS session and a :c:macro:`LWM2M_CARRIER_EVENT_FOTA_START` event is sent to the application, the application must immediately end the TLS session.
+   * TLS becomes available again upon the next :c:macro:`LWM2M_CARRIER_EVENT_READY` or :c:macro:`LWM2M_CARRIER_EVENT_DEFERRED` event.
    * The application should implement a retry mechanism so that the application can perform the TLS handshake later.
    * Another alternative is to supply TLS from a source other than the modem, for example `Mbed TLS`_.
 

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -56,7 +56,7 @@ The models are used for the following purposes:
 * Mesh sensor client gets sensor data from one or more :ref:`Mesh sensor server(s) <bt_mesh_sensor_srv_readme>`.
 
 The model handling is implemented in :file:`src/model_handler.c`.
-A :c:type:`struct k_delayed_work` item is submitted recursively to periodically request sensor data.
+A :cpp:class:`k_delayed_work` item is submitted recursively to periodically request sensor data.
 
 Requirements
 ************


### PR DESCRIPTION
To link to structs in Doxygen, use :cpp:class:.
To link to type definitions, use :cpp:type:.
Using :c:type: does not work.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>