### PR TITLE
lib: lte_lc: Add API for setting eDRX Paging Time Window (PTW)

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -236,6 +236,16 @@ int lte_lc_psm_req(bool enable);
  */
 int lte_lc_psm_get(int *tau, int *active_time);
 
+/** @brief Function for setting Paging Time Window (PTW) value to be used when
+ *	   eDRX is requested using `lte_lc_edrx_req`.
+ *	   For reference see subclause 10.5.5.32 of 3GPP TS 24.008.
+ *
+ * @param ptw Paging Time Window value as null-terminated string.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_ptw_set(const char *ptw);
+
 /** @brief Function for setting modem eDRX value to be used when
  * eDRX is subsequently enabled using `lte_lc_edrx_req`.
  * For reference see 3GPP 27.007 Ch. 7.40.

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -91,6 +91,15 @@ config LTE_EDRX_REQ_VALUE
 		The value 1001 corresponds to 163.84 seconds, and is valid for
 		both LTE-M and NB-IoT networks.
 
+config LTE_PTW_VALUE
+	string "Requested PTW value"
+	help
+		Sets the Paging Time Window value to be requested when enabling
+		eDRX. The allowed values for LTE-M and NB-IoT differ.
+		The format is a string with half a byte in 4-bit format,
+		corresponding to bits 8 to 5 in octet 3 of eDRX information
+		element	according to 10.5.5.32 of 3GPP TS 24.008.
+
 config LTE_LEGACY_PCO_MODE
 	bool "Enable legacy LTE Protocol Configuration Options mode"
 


### PR DESCRIPTION
Add API for setting eDRX PTW.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>

Depends on #2724