### PR TITLE
Bluetooth: services: bas_c: Fix unsubscribe handling

### DIFF
--- a/subsys/bluetooth/services/bas_c.c
+++ b/subsys/bluetooth/services/bas_c.c
@@ -337,11 +337,12 @@ int bt_gatt_bas_c_unsubscribe(struct bt_gatt_bas_c *bas_c)
 		return -EINVAL;
 	}
 
-	if (!bas_c->notify_params.notify) {
+	if (!bas_c->notify_cb) {
 		return -EFAULT;
 	}
+
 	err = bt_gatt_unsubscribe(bas_c->conn, &bas_c->notify_params);
-	bas_c->notify_params.notify = NULL;
+	bas_c->notify_cb = NULL;
 	return err;
 }
 


### PR DESCRIPTION
Fix handling of bt_gatt_bas_c_unsubscribe checking for the internal
notify callback instead of the one set by the application.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>