### PR TITLE
spm: support s0 s1 use case with spm and app

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b160c8c5caa53694c0be57ee224c078dc4adb53c
+      revision: pull/344/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
If spm and app is stored in s0 and s1 then we need
two secure areas (B0+s0_SPM and s1_SPM) and two
non-secure areas (s0_APP and s1_APP + the rest).

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>