### PR TITLE
lib: lte_lc: Auto-connect only if AT_CMD_SYS_INIT is enabled

### DIFF
--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -15,7 +15,7 @@ if LTE_LINK_CONTROL
 
 config LTE_AUTO_INIT_AND_CONNECT
 	bool "Auto Initialize and Connect for the LTE link"
-	default y
+	default y if AT_CMD_SYS_INIT
 	help
 		Turn on to make the LTE Link Controller to
 		automatically initialize and connect the modem


### PR DESCRIPTION
Attempting to connect to LTE network with SYS_INIT will fail if
AT_CMD_SYS_INIT is disabled. Therefore LTE_AUTO_INIT_AND_CONNECT
now only defaults to y if that option is enabled.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>