### PR TITLE
manifest: nrfxlib to use new SoftDevice Controller

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: c9c7e6e9d810b30594ebbae9306d7d12ea36b29e
+      revision: 8134565d892204de74346d1f95504d8bff7b7c37
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Updates the compatibility matrix. See CHANGELOG for more details.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>

See https://github.com/nrfconnect/sdk-nrfxlib/pull/241