### PR TITLE
Bluetooth: controller: Fix hci_driver RX thread priority

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -68,8 +68,7 @@ config BLECTRL_MAX_CONN_EVENT_LEN_DEFAULT
 config BLECTLR_PRIO
 	# Hidden option to set the priority of the controller threads
 	int
-	default BT_RX_PRIO if BT_HCI_HOST || BT_RECV_IS_RX_THREAD
-	default 8
+	default BT_RX_PRIO_HIGH
 
 config BLECTLR_RX_STACK_SIZE
 	int "Size of the receive thread stack"


### PR DESCRIPTION
The softdevice controller RX thread priority has been set incorrectly.
The hci_driver is calling bt_recv from this priority context,
then hci_core will look at the priority of the event and either
process the event in the given priority (bt_recv_prio) or add
the event to the rx_queue and process it the RX thread context.
Since both CONFIG_BT_RX_PRIO=8 and CONFIG_BLECTLR_PRIO=8 are the
same priority there is no priority distinction.
The immediate problem with this is that priority events (num complete)
are processed at a lower priority than the TX thread of the host,
see subsys/bluetooth/common/dummy.c for more details.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>