### PR TITLE
samples: nrf9160: gps sample

### DIFF
--- a/samples/nrf9160/gps/Kconfig
+++ b/samples/nrf9160/gps/Kconfig
@@ -11,6 +11,18 @@ config GPS_SAMPLE_NMEA_ONLY
 	help
 	  Outputs only NMEA strings from the GPS.
 
+choice GPS_SAMPLE_ANTENNA
+	default GPS_SAMPLE_ANTENNA_ONBOARD
+	prompt "Select which antenna to use for GPS"
+
+config GPS_SAMPLE_ANTENNA_ONBOARD
+	bool "Use onboard antenna"
+
+config GPS_SAMPLE_ANTENNA_EXTERNAL
+	bool "Use external antenna"
+
+endchoice
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/samples/nrf9160/gps/src/main.c
+++ b/samples/nrf9160/gps/src/main.c
@@ -28,10 +28,13 @@
 
 #define AT_CMD_SIZE(x) (sizeof(x) - 1)
 
-
 #ifdef CONFIG_BOARD_NRF9160DK_NRF9160NS
 #define AT_MAGPIO      "AT\%XMAGPIO=1,0,0,1,1,1574,1577"
+#ifdef CONFIG_GPS_SAMPLE_ANTENNA_ONBOARD
 #define AT_COEX0       "AT\%XCOEX0=1,1,1570,1580"
+#elif CONFIG_GPS_SAMPLE_ANTENNA_EXTERNAL
+#define AT_COEX0       "AT\%COEX0"
+#endif
 #endif
 
 static const char            update_indicator[] = {'\\', '|', '/', '-'};


### PR DESCRIPTION
Disable coex0 pin when using external antenna to lower
noise from the LNA.

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>