### PR TITLE
net: lib: Support setting fragment size in FOTA downloader

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -95,6 +95,10 @@ struct download_client_cfg {
 	 *  or NULL to use the default APN.
 	 */
 	const char *apn;
+	/** Maximum fragment size to download. 0 indicates that Kconfigured
+	 *  values shall be used.
+	 */
+	size_t frag_size_override;
 };
 
 /**

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -78,13 +78,15 @@ int fota_download_init(fota_download_callback_t client_callback);
  * @param file Filepath to the file you wish to download.
  * @param sec_tag Security tag you want to use with HTTPS set to -1 to Disable.
  * @param apn Access Point Name to use or NULL to use the default APN.
+ * @param fragment_size Fragment size to be used for the download.
+ *			If 0, CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE is used.
  *
  * @retval 0	     If download has started successfully.
  * @retval -EALREADY If download is already ongoing.
  *                   Otherwise, a negative value is returned.
  */
 int fota_download_start(const char *host, const char *file, int sec_tag,
-			const char *apn);
+			const char *apn, size_t fragment_size);
 
 #ifdef __cplusplus
 }

--- a/samples/nrf9160/http_application_update/src/main.c
+++ b/samples/nrf9160/http_application_update/src/main.c
@@ -89,7 +89,8 @@ static void app_dfu_transfer_start(struct k_work *unused)
 	retval = fota_download_start(CONFIG_DOWNLOAD_HOST,
 				     CONFIG_DOWNLOAD_FILE,
 				     sec_tag,
-				     apn);
+				     apn,
+				     0);
 	if (retval != 0) {
 		/* Re-enable button callback */
 		gpio_pin_interrupt_configure(gpiob,

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -250,7 +250,7 @@ static int job_update_accepted(struct mqtt_client *const client,
 		sec_tag = CONFIG_AWS_FOTA_DOWNLOAD_SECURITY_TAG;
 #endif
 
-		err = fota_download_start(hostname, file_path, sec_tag, apn);
+		err = fota_download_start(hostname, file_path, sec_tag, apn, 0);
 		if (err) {
 			LOG_ERR("Error (%d) when trying to start firmware "
 				"download", err);

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -546,6 +546,11 @@ int download_client_connect(struct download_client *client, const char *host,
 		return 0;
 	}
 
+	if (config->frag_size_override > CONFIG_DOWNLOAD_CLIENT_BUF_SIZE) {
+		LOG_ERR("The configured fragment size is larger than buffer");
+		return -E2BIG;
+	}
+
 	/* Attempt IPv6 connection if configured, fallback to IPv4 */
 	if (IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_IPV6)) {
 		err = host_lookup(host, AF_INET6, config->apn, &sa);

--- a/subsys/net/lib/download_client/src/http.c
+++ b/subsys/net/lib/download_client/src/http.c
@@ -57,7 +57,12 @@ int http_get_request_send(struct download_client *client)
 	}
 
 	/* Offset of last byte in range (Content-Range) */
-	off = client->progress + CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE - 1;
+	if (client->config.frag_size_override) {
+		off = client->progress + client->config.frag_size_override - 1;
+	} else {
+		off = client->progress +
+			CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE - 1;
+	}
 
 	if (client->file_size != 0) {
 		/* Don't request bytes past the end of file */

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -217,13 +217,14 @@ static void download_with_offset(struct k_work *unused)
 }
 
 int fota_download_start(const char *host, const char *file, int sec_tag,
-			const char *apn)
+			const char *apn, size_t fragment_size)
 {
 	int err = -1;
 
 	struct download_client_cfg config = {
 		.sec_tag = sec_tag,
 		.apn = apn,
+		.frag_size_override = fragment_size,
 	};
 
 	if (host == NULL || file == NULL || callback == NULL) {

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -133,7 +133,7 @@ static void test_fota_download_start(void)
 	s1_version = 1;
 	expect_s0_active = false;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
 		      "Incorrect param for s0_active");
@@ -141,7 +141,7 @@ static void test_fota_download_start(void)
 	s0_version = 2;
 	s1_version = 1;
 	expect_s0_active = true;
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
 		      "Incorrect param for s0_active");
@@ -154,14 +154,14 @@ static void test_fota_download_start(void)
 	/* update set to null indicates to use original file param */
 	dfu_ctx_mcuboot_set_b1_file__update = NULL;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S0_S1) == 0, NULL);
 
 	/* update set to not null indicates to use update for file param */
 	dfu_ctx_mcuboot_set_b1_file__update = S1;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN);
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S1) == 0, NULL);
 }


### PR DESCRIPTION
This PR adds support for setting fragment size in the FOTA download library.
