### PR TITLE
samples: cloud_client: use strlen() instead of sizeof()

### DIFF
--- a/samples/nrf9160/cloud_client/src/main.c
+++ b/samples/nrf9160/cloud_client/src/main.c
@@ -29,7 +29,7 @@ static void cloud_update_work_fn(struct k_work *work)
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
 		.endpoint.type = CLOUD_EP_TOPIC_MSG,
 		.buf = CONFIG_CLOUD_MESSAGE,
-		.len = sizeof(CONFIG_CLOUD_MESSAGE)
+		.len = strlen(CONFIG_CLOUD_MESSAGE)
 	};
 
 	err = cloud_send(cloud_backend, &msg);


### PR DESCRIPTION
The message published to cloud should not include the
null termination character. AWS IoT, for instance, does
not recognize the JSON string if it is null-terminated.

Signed-off-by: Simen S. Røstad <simen.rostad@nordicsemi.no>