### PR TITLE
samples: openthread: Add multiprotocol extension of CoAP Client

### DIFF
--- a/samples/openthread/coap_client/CMakeLists.txt
+++ b/samples/openthread/coap_client/CMakeLists.txt
@@ -14,4 +14,6 @@ project(openthread_coap_client)
 target_sources(app PRIVATE src/coap_client.c
 			   src/coap_client_utils.c)
 
+target_sources_ifdef(CONFIG_BT_GATT_NUS app PRIVATE src/ble_utils.c)
+
 target_include_directories(app PUBLIC ../coap_server/interface)

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -8,7 +8,7 @@ To show this interaction, the sample requires a server sample that is compatible
 The recommended server sample referenced on this page is :ref:`coap_server_sample`.
 
 .. note::
-    This sample supports the Minimal Thread Device variant.
+    This sample supports optional :ref:`coap_client_sample_multi_ext` and Minimal Thread Device variants.
     See :ref:`coap_client_sample_activating_variants` for details.
 
 Overview
@@ -26,6 +26,15 @@ The following CoAP resources are accessed on the server side:
 This sample uses :ref:`Zephyr CoAP API<zephyr:coap_sock_interface>` for communication, which is the preferred API to use for new CoAP applications.
 For example usage of the native Thread CoAP API, see the :ref:`coap_server_sample` sample.
 
+.. _coap_client_sample_multi_ext:
+
+Multiprotocol |BLE| extension
+=============================
+
+This optional extension can demonstrate the OpenThread stack and :ref:`nrfxlib:softdevice_controller` working concurrently.
+It uses the :ref:`nus_service_readme` library to control the LED states over |BLE| in a Thread network.
+For more information about multiprotocol feature, see :ref:`ug_multiprotocol_support`.
+
 Requirements
 ************
 
@@ -37,6 +46,14 @@ The sample supports the following development kits:
 
 You can use one or more of the development kits listed above as the Thread CoAP Client.
 You also need one or more compatible development kits programmed with the :ref:`coap_server_sample` sample.
+
+Multiprotocol extension requirements
+====================================
+
+If you enable the :ref:`coap_client_sample_multi_ext`, make sure you have a phone or a tablet with the `nRF Toolbox`_ application installed.
+
+.. note::
+  The :ref:`testing instructions <coap_client_sample_testing_ble>` refer to nRF Toolbox, but similar applications can be used as well, for example `nRF Connect for Mobile`_.
 
 User interface
 **************
@@ -63,15 +80,28 @@ Minimal Thread Device assignments
 When the device is working as Minimal Thread Device (MTD), the following LED and Button assignments are also available:
 
 LED 3:
-    Indicates the mode the device is working in:
+    The mode the device is working in:
 
     * On when in the Minimal End Device (MED) mode.
     * Off when in the Sleepy End Device (SED) mode.
 
 Button 3:
-    Pressing results in toggling the power consumption between SED and MED.
+    Toggle the power consumption between SED and MED.
 
 For more information, see :ref:`thread_ug_device_type` in the Thread user guide.
+
+Multiprotocol |BLE| extension assignments
+=========================================
+
+LED 2:
+   On when |BLE| connection is established.
+
+UART command assignments:
+   The following command assignments are configured and used in nRF Toolbox when :ref:`coap_client_sample_testing_ble`:
+
+   * ``u`` - Send a unicast CoAP message over Thread (the same operation as **Button 1**).
+   * ``m`` - Send a multicast CoAP message over Thread (the same operation as **Button 2**).
+   * ``p`` - Send a pairing request as CoAP message over Thread (the same operation as **Button 4**).
 
 Building and running
 ********************
@@ -87,9 +117,10 @@ Building and running
 Activating sample extensions
 ============================
 
-To activate the extensions supported by this sample, modify :makevar:`OVERLAY_CONFIG` in the following manner:
+To activate the optional extensions supported by this sample, modify :makevar:`OVERLAY_CONFIG` in the following manner:
 
 * For the Minimal Thread Device variant, set :file:`overlay-mtd.conf`.
+* For the Multiprotocol BLE extension, set :file:`overlay-multiprotocol_ble.conf`.
 
 See :ref:`cmake_options` for instructions on how to add this option.
 
@@ -130,6 +161,69 @@ At this point, the radio is disabled when it is idle and the serial console is n
 Pressing **Button 3** again will switch the mode back to MED.
 Switching between SED and MED modes does not affect the standard testing procedure, but terminal logs are not available in the SED mode.
 
+.. _coap_client_sample_testing_ble:
+
+Testing multiprotocol |BLE| extension
+-------------------------------------
+
+To test the multiprotocol |BLE| extension, complete the following steps after the standard `Testing`_ procedure:
+
+#. Set up nRF Toolbox by completing the following steps:
+
+   .. tabs::
+
+      .. tab:: a. Start UART
+
+         Tap :guilabel:`UART` to open the UART application in nRF Toolbox.
+
+         .. figure:: /images/nrftoolbox_uart_default.png
+            :alt: UART application in nRF Toolbox
+
+            UART application in nRF Toolbox
+
+      .. tab:: b. Configure commands
+
+         Configure the UART commands by completing the following steps:
+
+         1. Tap the :guilabel:`EDIT` button in the top right corner of the application.
+            The button configuration window appears.
+         #. Create the active application buttons by completing the following steps:
+
+            a. Bind the top left button to the ``u`` command, with EOL set to LF and an icon of your choice.
+               For this testing procedure, the :guilabel:`>` icon is used.
+            #. Bind the top middle button to the ``m`` command, with EOL set to LF and an icon of your choice.
+               For this testing procedure, the play button icon is used.
+            #. Bind the top right button to the ``p`` command, with EOL set to LF and an icon of your choice.
+               For this testing procedure, the settings gear icon is used.
+
+            .. figure:: /images/nrftoolbox_uart_settings.png
+               :alt: Configuring buttons in nRF Toolbox - UART application
+
+               Configuring buttons in the UART application of nRF Toolbox
+
+         #. Tap the :guilabel:`DONE` button in the top right corner of the application.
+
+      .. tab:: c. Connect to device
+
+         Tap :guilabel:`CONNECT` and select the ``NUS_CoAP_client`` device from the list of devices.
+
+         .. figure:: /images/nrftoolbox_uart_connected.png
+            :alt: nRF Toolbox - UART application view after establishing connection
+
+            The UART application of nRF Toolbox after establishing the connection
+
+         .. note::
+            Observe that **LED 2** on your CoAP Multiprotocol Client node is solid, which indicates that the Bluetooth connection is established.
+   ..
+
+#. In nRF Toolbox, press the middle button to control **LED 4** on all CoAP server nodes.
+#. Pair a client with a server by completing the following steps:
+
+   a. Press **Button 4** on a server node to enable pairing.
+   #. In nRF Toolbox, press the right button to pair the two nodes.
+
+#. In nRF Toolbox, press the left button to control **LED 4** on the paired server node.
+
 Sample output
 =============
 
@@ -157,3 +251,14 @@ In addition, it uses the following Zephyr libraries:
 * :ref:`zephyr:kernel_api`:
 
   * ``include/kernel.h``
+
+The following dependencies are added by the optional multiprotocol |BLE| extension:
+
+* :ref:`nrfxlib:softdevice_controller`
+* :ref:`nus_service_readme`
+* Zephyr's :ref:`zephyr:bluetooth_api`:
+
+  * ``include/bluetooth/bluetooth.h``
+  * ``include/bluetooth/gatt.h``
+  * ``include/bluetooth/hci.h``
+  * ``include/bluetooth/uuid.h``

--- a/samples/openthread/coap_client/overlay-multiprotocol_ble.conf
+++ b/samples/openthread/coap_client/overlay-multiprotocol_ble.conf
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# Enable multiprotocol service layer
+CONFIG_MPSL=y
+
+# Enable Bluetooth LE controller which supports multiprotocol
+CONFIG_BT_LL_SOFTDEVICE_DEFAULT=y
+
+# Enable and configure Bluetooth LE
+CONFIG_BT=y
+CONFIG_BT_SMP=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_NAME="NUS_CoAP_client"
+CONFIG_BT_DEVICE_APPEARANCE=833
+CONFIG_BT_MAX_CONN=1
+CONFIG_BT_MAX_PAIRED=1
+
+# Enable the NUS service
+CONFIG_BT_GATT_NUS=y
+
+# Enable bonding
+CONFIG_BT_SETTINGS=y
+
+# Configure sample logging setting
+CONFIG_BLE_UTILS_LOG_LEVEL_DBG=y

--- a/samples/openthread/coap_client/src/ble_utils.c
+++ b/samples/openthread/coap_client/src/ble_utils.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <zephyr.h>
+#include <bluetooth/gatt.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/uuid.h>
+#include <logging/log.h>
+#include <settings/settings.h>
+
+#include "ble_utils.h"
+
+LOG_MODULE_REGISTER(ble_utils, CONFIG_BLE_UTILS_LOG_LEVEL);
+
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
+
+static void connected(struct bt_conn *conn, uint8_t err);
+static void disconnected(struct bt_conn *conn, uint8_t reason);
+static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey);
+static void auth_cancel(struct bt_conn *conn);
+static void pairing_confirm(struct bt_conn *conn);
+static void pairing_complete(struct bt_conn *conn, bool bonded);
+static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason);
+static void __attribute__((unused))
+security_changed(struct bt_conn *conn, bt_security_t level,
+		 enum bt_security_err err);
+
+static struct bt_conn_auth_cb conn_auth_callbacks = {
+	.passkey_display = auth_passkey_display,
+	.cancel = auth_cancel,
+	.pairing_confirm = pairing_confirm,
+	.pairing_complete = pairing_complete,
+	.pairing_failed = pairing_failed
+};
+
+static struct bt_conn_cb conn_callbacks = {
+	.connected = connected,
+	.disconnected = disconnected,
+	COND_CODE_1(CONFIG_BT_SMP, (.security_changed = security_changed), ())
+};
+
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
+};
+
+static const struct bt_data sd[] = {
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL, NUS_UUID_SERVICE),
+};
+
+static struct k_work on_connect_work;
+static struct k_work on_disconnect_work;
+
+static struct bt_conn *current_conn;
+
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	if (err) {
+		LOG_ERR("Connection failed (err %u)", err);
+		return;
+	}
+
+	LOG_INF("Connected");
+	current_conn = bt_conn_ref(conn);
+
+	k_work_submit(&on_connect_work);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	LOG_INF("Disconnected (reason %u)", reason);
+
+	if (current_conn) {
+		bt_conn_unref(current_conn);
+		current_conn = NULL;
+
+		k_work_submit(&on_disconnect_work);
+	}
+}
+
+static char *ble_addr(struct bt_conn *conn)
+{
+	static char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	return addr;
+}
+
+static void __attribute__((unused))
+security_changed(struct bt_conn *conn, bt_security_t level,
+		 enum bt_security_err err)
+{
+	char *addr = ble_addr(conn);
+
+	if (!err) {
+		LOG_INF("Security changed: %s level %u", log_strdup(addr),
+			level);
+	} else {
+		LOG_INF("Security failed: %s level %u err %d", log_strdup(addr),
+			level, err);
+	}
+}
+
+static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
+{
+	char *addr = ble_addr(conn);
+
+	LOG_INF("Passkey for %s: %06u", log_strdup(addr), passkey);
+}
+
+static void auth_cancel(struct bt_conn *conn)
+{
+	char *addr = ble_addr(conn);
+
+	LOG_INF("Pairing cancelled: %s", log_strdup(addr));
+}
+
+static void pairing_confirm(struct bt_conn *conn)
+{
+	char *addr = ble_addr(conn);
+
+	bt_conn_auth_pairing_confirm(conn);
+
+	LOG_INF("Pairing confirmed: %s", log_strdup(addr));
+}
+
+static void pairing_complete(struct bt_conn *conn, bool bonded)
+{
+	char *addr = ble_addr(conn);
+
+	LOG_INF("Pairing completed: %s, bonded: %d", log_strdup(addr), bonded);
+}
+
+static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
+{
+	char *addr = ble_addr(conn);
+
+	LOG_INF("Pairing failed conn: %s, reason %d", log_strdup(addr), reason);
+}
+
+static struct bt_gatt_nus_cb *set_nus_clbs(nus_received_cb_t on_nus_received,
+					   nus_sent_cb_t on_nus_send)
+{
+	static struct bt_gatt_nus_cb nus_cb;
+
+	nus_cb.received_cb = on_nus_received;
+	nus_cb.sent_cb = on_nus_send;
+
+	return &nus_cb;
+}
+
+int ble_utils_init(nus_received_cb_t on_nus_received, nus_sent_cb_t on_nus_send,
+		   ble_connection_cb_t on_connect,
+		   ble_disconnection_cb_t on_disconnect)
+{
+	int ret;
+	struct bt_gatt_nus_cb *nus_clbs;
+
+	k_work_init(&on_connect_work, on_connect);
+	k_work_init(&on_disconnect_work, on_disconnect);
+
+	bt_conn_cb_register(&conn_callbacks);
+
+	if (IS_ENABLED(CONFIG_BT_SMP)) {
+		bt_conn_auth_cb_register(&conn_auth_callbacks);
+	}
+
+	ret = bt_enable(NULL);
+	if (ret) {
+		LOG_ERR("Bluetooth initialization failed (error: %d)", ret);
+		goto end;
+	}
+
+	LOG_INF("Bluetooth initialized");
+
+	if (IS_ENABLED(CONFIG_SETTINGS)) {
+		settings_load();
+	}
+
+	nus_clbs = set_nus_clbs(on_nus_received, on_nus_send);
+	ret = bt_gatt_nus_init(nus_clbs);
+	if (ret) {
+		LOG_ERR("Failed to initialize UART service (error: %d)", ret);
+		goto end;
+	}
+
+	ret = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd,
+			      ARRAY_SIZE(sd));
+	if (ret) {
+		LOG_ERR("Advertising failed to start (error: %d)", ret);
+		goto end;
+	}
+
+end:
+	return ret;
+}

--- a/samples/openthread/coap_client/src/ble_utils.h
+++ b/samples/openthread/coap_client/src/ble_utils.h
@@ -1,0 +1,49 @@
+/**
+ * @file
+ * @defgroup ble_utils Bluetooth LE utilities API
+ * @{
+ */
+
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#ifndef __BLE_UTILS_H__
+#define __BLE_UTILS_H__
+
+#include <bluetooth/services/nus.h>
+
+/** @brief Type indicates function called when Bluetooth LE connection
+ *         is established.
+ *
+ * @param[in] item pointer to work item.
+ */
+typedef void (*ble_connection_cb_t)(struct k_work *item);
+
+/** @brief Type indicates function called when Bluetooth LE connection is ended.
+ *
+ * @param[in] item pointer to work item.
+ */
+typedef void (*ble_disconnection_cb_t)(struct k_work *item);
+
+/** @brief Initialize CoAP utilities.
+ *
+ * @param[in] on_nus_received function to call when NUS receives message
+ * @param[in] on_nus_send     function to call when NUS sends message
+ * @param[in] on_connect      function to call when Bluetooth LE connection
+ *                            is established
+ * @param[in] on_disconnect   function to call when Bluetooth LE connection
+ *                            is ended
+ * @retval 0    On success.
+ * @retval != 0 On failure.
+ */
+int ble_utils_init(nus_received_cb_t on_nus_received, nus_sent_cb_t on_nus_send,
+		   ble_connection_cb_t on_connect,
+		   ble_disconnection_cb_t on_disconnect);
+
+#endif
+
+/**
+ * @}
+ */

--- a/samples/openthread/coap_client/src/coap_client.c
+++ b/samples/openthread/coap_client/src/coap_client.c
@@ -10,10 +10,65 @@
 
 #include "coap_client_utils.h"
 
+#if CONFIG_BT_GATT_NUS
+#include "ble_utils.h"
+#endif
+
 LOG_MODULE_REGISTER(coap_client, CONFIG_COAP_CLIENT_LOG_LEVEL);
 
 #define OT_CONNECTION_LED DK_LED1
+#define BLE_CONNECTION_LED DK_LED2
 #define MTD_SED_LED DK_LED3
+
+#if CONFIG_BT_GATT_NUS
+
+#define COMMAND_REQUEST_UNICAST 'u'
+#define COMMAND_REQUEST_MULTICAST 'm'
+#define COMMAND_REQUEST_PROVISIONING 'p'
+
+static void on_nus_received(struct bt_conn *conn, const uint8_t *const data,
+			    uint16_t len)
+{
+	LOG_INF("Received data: %s", log_strdup(data));
+
+	if (len != 1) {
+		LOG_WRN("Received invalid data length from NUS");
+		return;
+	}
+
+	switch (*data) {
+	case COMMAND_REQUEST_UNICAST:
+		coap_client_toggle_one_light();
+		break;
+
+	case COMMAND_REQUEST_MULTICAST:
+		coap_client_toggle_mesh_lights();
+		break;
+
+	case COMMAND_REQUEST_PROVISIONING:
+		coap_client_send_provisioning_request();
+		break;
+
+	default:
+		LOG_WRN("Received invalid data from NUS");
+	}
+}
+
+static void on_ble_connect(struct k_work *item)
+{
+	ARG_UNUSED(item);
+
+	dk_set_led_on(BLE_CONNECTION_LED);
+}
+
+static void on_ble_disconnect(struct k_work *item)
+{
+	ARG_UNUSED(item);
+
+	dk_set_led_off(BLE_CONNECTION_LED);
+}
+
+#endif /* CONFIG_BT_GATT_NUS */
 
 static void on_ot_connect(struct k_work *item)
 {
@@ -76,6 +131,16 @@ void main(void)
 		LOG_ERR("Connot init leds, (error: %d)", ret);
 		return;
 	}
+
+#if CONFIG_BT_GATT_NUS
+	ret = ble_utils_init(&on_nus_received, NULL, on_ble_connect,
+			     on_ble_disconnect);
+	if (ret) {
+		LOG_ERR("Cannot init BLE utilities");
+		return;
+	}
+
+#endif /* CONFIG_BT_GATT_NUS */
 
 	coap_client_utils_init(on_ot_connect, on_ot_disconnect,
 			       on_mtd_mode_toggle);


### PR DESCRIPTION
This CoAP Client sample extension demonstrates the OpenThread stack and the Softdevice Controller working concurrently. It uses NUS service to control the LED states over BLE in a Thread network.

- [x] it waits for the new Radio Driver to work properly
- [x] it waits for merge https://github.com/nrfconnect/sdk-nrfxlib/pull/254