### PR TITLE
manifest: nrfxlib selects SoftDevice Controller as default LL

### DIFF
--- a/doc/nrf/ug_ble_controller.rst
+++ b/doc/nrf/ug_ble_controller.rst
@@ -54,5 +54,5 @@ Usage in samples
 Most :ref:`Bluetooth LE samples <ble_samples>` in the |NCS| can use either Bluetooth LE Controller.
 An exception is the :ref:`ble_llpm` sample, which requires the SoftDevice Controller that supports LLPM.
 
-By default, all samples except for the :ref:`ble_llpm` sample are currently configured to use Zephyr's Bluetooth LE Controller.
-To use the SoftDevice Controller instead, set :option:`CONFIG_BT_LL_SOFTDEVICE_DEFAULT` to ``y`` in the :file:`prj.conf` file (see :ref:`configure_application`) and make sure to build from a clean build directory.
+By default, all samples except for the Bluetooth Mesh samples are currently configured to use SoftDevice Controller.
+To use the Zephyr Bluetooth LE Controller instead, set :option:`CONFIG_BT_LL_SW_SPLIT` to ``y`` in the :file:`prj.conf` file (see :ref:`configure_application`) and make sure to build from a clean build directory.

--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 8134565d892204de74346d1f95504d8bff7b7c37
+      revision: 3f51b79d3415604d31289ac85d04b152e5facf22
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
For Bluetooth Mesh use BT_LL_SW_SPLIT.
For all other Bluetooth use cases, use the SoftDevice Controller.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>

nrfxlib: https://github.com/nrfconnect/sdk-nrfxlib/pull/243