### PR TITLE
cmake: don't generate merged_domains.hex for single domain builds

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -419,23 +419,26 @@ else()
     ${global_hex_depends}
     )
 
-  # For convenience, generate global hex file containing all domains' hex files.
-  set(final_merged ${PROJECT_BINARY_DIR}/merged_domains.hex)
+  if (PM_DOMAINS)
+    # For convenience, generate global hex file containing all domains' hex
+    # files.
+    set(final_merged ${ZEPHYR_BINARY_DIR}/merged_domains.hex)
 
-  # Add command to merge files.
-  add_custom_command(
-    OUTPUT ${final_merged}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    ${ZEPHYR_BASE}/scripts/mergehex.py
-    -o ${final_merged}
-    ${domain_hex_files}
-    DEPENDS
-    ${global_hex_depends}
-    )
+    # Add command to merge files.
+    add_custom_command(
+      OUTPUT ${final_merged}
+      COMMAND
+      ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/mergehex.py
+      -o ${final_merged}
+      ${domain_hex_files}
+      DEPENDS
+      ${global_hex_depends}
+      )
 
-  # Wrapper target for the merge command.
-  add_custom_target(merged_domains_hex ALL DEPENDS ${final_merged})
+    # Wrapper target for the merge command.
+    add_custom_target(merged_domains_hex ALL DEPENDS ${final_merged})
+  endif()
 
   # Add ${merged}.hex as the representative hex file for flashing this app.
   if(TARGET flash)


### PR DESCRIPTION
Only generate 'merged_domains.hex' which is the result of
merging the 'merged.hex' from all different domains if
there is more than 1 domain in the build.

Ref: NCSDK-5746

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>