### PR TITLE
manifest: Update nrfxlib to 4cbc6d240a29dad57faee0e1d273f1ef6edac617

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 4c2f38f1957892a7ca1ea49d0aa86cb7bf415b7c
+      revision: 4cbc6d240a29dad57faee0e1d273f1ef6edac617
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
- Ensures same python is used for west as the rest of the build system
  See: https://github.com/zephyrproject-rtos/zephyr/pull/26060

-----

nrfxlib PR: https://github.com/nrfconnect/sdk-nrfxlib/pull/246