### PR TITLE
Bluetooth: Mesh: LL_SW_SPLIT in nrf53 samples

### DIFF
--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -65,6 +65,7 @@ The sample supports the following development kits:
 
       CONFIG_BT_CTLR_TX_BUFFER_SIZE=74
       CONFIG_BT_CTLR_DATA_LENGTH_MAX=74
+      CONFIG_BT_LL_SW_SPLIT=y
 
    This is required because Bluetooth Mesh has different |BLE| Controller requirements than other Bluetooth samples.
 

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -65,6 +65,7 @@ The sample supports the following development kits:
 
       CONFIG_BT_CTLR_TX_BUFFER_SIZE=74
       CONFIG_BT_CTLR_DATA_LENGTH_MAX=74
+      CONFIG_BT_LL_SW_SPLIT=y
 
    This is required because Bluetooth Mesh has different |BLE| Controller requirements than other Bluetooth samples.
 


### PR DESCRIPTION
Adds CONFIG_BT_LL_SW_SPLIT to required changes for the nRF53 network
core sample, to override the new softdevice controller default for
standalone controllers.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>