### PR TITLE
Bluetooth: Mesh: Models: Generic Level client: Transition time parse …

### DIFF
--- a/subsys/bluetooth/mesh/gen_lvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_lvl_cli.c
@@ -20,9 +20,10 @@ static void handle_status(struct bt_mesh_model *mod,
 	struct bt_mesh_lvl_status status;
 
 	status.current = net_buf_simple_pull_le16(buf);
-	if (buf->len == 2) {
+	if (buf->len == 3) {
 		status.target = net_buf_simple_pull_le16(buf);
-		status.remaining_time = net_buf_simple_pull_u8(buf);
+		status.remaining_time =
+			model_transition_decode(net_buf_simple_pull_u8(buf));
 	} else {
 		status.target = status.current;
 		status.remaining_time = 0;


### PR DESCRIPTION
…bug fix

Fixes bug parsing remaining transition time in status handler in Generic Level Client.

Signed-off-by: Anders Storrø <anders_storro@hotmail.com>