### PR TITLE
cmake: multi-image: fix bug where domain was not passed to grandchildren

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -84,7 +84,6 @@ function(add_child_image_from_source)
 
     # This needs to be made globally available as it is used in other files.
     set(${ACI_DOMAIN}_PM_DOMAIN_DYNAMIC_PARTITION ${ACI_NAME} CACHE INTERNAL "")
-    set(${ACI_NAME}_DOMAIN ${ACI_DOMAIN})
 
     if (NOT (${ACI_DOMAIN} IN_LIST PM_DOMAINS))
       list(APPEND PM_DOMAINS ${ACI_DOMAIN})
@@ -96,10 +95,17 @@ function(add_child_image_from_source)
     get_board_without_ns_suffix(${BOARD} ACI_BOARD)
   endif()
 
+  if (NOT ACI_DOMAIN AND DOMAIN)
+    # If no domain is specified, a child image will inherit the domain of
+    # its parent.
+    set(ACI_DOMAIN ${DOMAIN})
+    set(inherited " (inherited)")
+  endif()
+
+  set(${ACI_NAME}_DOMAIN ${ACI_DOMAIN})
   set(${ACI_NAME}_BOARD ${ACI_BOARD})
 
-
-  message("\n=== child image ${ACI_NAME} - ${ACI_DOMAIN} begin ===")
+  message("\n=== child image ${ACI_NAME} - ${ACI_DOMAIN}${inherited} begin ===")
   # Construct a list of variables that, when present in the root
   # image, should be passed on to all child images as well.
   list(APPEND
@@ -189,7 +195,7 @@ function(add_child_image_from_source)
     message(FATAL_ERROR "CMake generation for ${ACI_NAME} failed, aborting. Command: ${ret}")
   endif()
 
-  message("=== child image ${ACI_NAME} - ${ACI_DOMAIN} end ===\n")
+  message("=== child image ${ACI_NAME} - ${ACI_DOMAIN}${inherited} end ===\n")
 
   # Include some variables from the child image into the parent image
   # namespace


### PR DESCRIPTION
Fixed an issue where the domains were not properly propagated down to
the grandchildren of the domain.



Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>