### PR TITLE
Bluetooth: Mesh: Time server qualification fixes

### DIFF
--- a/include/bluetooth/mesh/time.h
+++ b/include/bluetooth/mesh/time.h
@@ -34,10 +34,16 @@ enum bt_mesh_time_role {
 	BT_MESH_TIME_CLIENT,
 };
 
+/** TAI time. */
+struct bt_mesh_time_tai {
+	uint64_t sec:40, /**< Seconds */
+		 subsec:8; /**< 1/256th seconds */
+};
+
 /** Parameters for the Time Status message. */
 struct bt_mesh_time_status {
-	/** TAI in milliseconds. */
-	uint64_t tai;
+	/** TAI time. */
+	struct bt_mesh_time_tai tai;
 	/** Accumulated uncertainty of the Mesh Timestamp in milliseconds. */
 	uint64_t uncertainty;
 	/** Current TAI-UTC Delta (leap seconds). */

--- a/subsys/bluetooth/mesh/time.c
+++ b/subsys/bluetooth/mesh/time.c
@@ -9,26 +9,13 @@
 #include "time_internal.h"
 
 #define UNCERTAINTY_STEP_MS 10
-#define SUBSEC_MAX 256U
 #define UNCERTAINTY_MS_MAX 2550U
-
-static uint8_t ms_to_subsec_conv(uint16_t ms)
-{
-	return ((ms * SUBSEC_MAX) / MSEC_PER_SEC);
-}
-
-static uint16_t subsec_to_ms_conv(uint8_t subsec)
-{
-	return ((subsec * MSEC_PER_SEC) / SUBSEC_MAX);
-}
 
 void bt_mesh_time_decode_time_params(struct net_buf_simple *buf,
 				     struct bt_mesh_time_status *status)
 {
-	uint64_t sec = bt_mesh_time_buf_pull_tai_sec(buf);
-	uint8_t subsec = net_buf_simple_pull_u8(buf);
-
-	status->tai = (sec * MSEC_PER_SEC) + subsec_to_ms_conv(subsec);
+	status->tai.sec = bt_mesh_time_buf_pull_tai_sec(buf);
+	status->tai.subsec = net_buf_simple_pull_u8(buf);
 	uint8_t raw_uncertainty = net_buf_simple_pull_u8(buf);
 
 	status->uncertainty = raw_uncertainty * UNCERTAINTY_STEP_MS;
@@ -44,16 +31,13 @@ void bt_mesh_time_decode_time_params(struct net_buf_simple *buf,
 void bt_mesh_time_encode_time_params(struct net_buf_simple *buf,
 				     const struct bt_mesh_time_status *status)
 {
-	uint64_t sec = status->tai / MSEC_PER_SEC;
-	uint8_t subsec = ms_to_subsec_conv(status->tai % MSEC_PER_SEC);
-
 	uint8_t raw_uncertainty =
 		(status->uncertainty < UNCERTAINTY_MS_MAX ?
 			 (status->uncertainty / UNCERTAINTY_STEP_MS) :
 			 UINT8_MAX);
 
-	bt_mesh_time_buf_put_tai_sec(buf, sec);
-	net_buf_simple_add_u8(buf, subsec);
+	bt_mesh_time_buf_put_tai_sec(buf, status->tai.sec);
+	net_buf_simple_add_u8(buf, status->tai.subsec);
 	net_buf_simple_add_u8(buf, raw_uncertainty);
 	net_buf_simple_add_le16(
 		buf, (status->is_authority |

--- a/subsys/bluetooth/mesh/time_util.h
+++ b/subsys/bluetooth/mesh/time_util.h
@@ -14,8 +14,8 @@
 extern "C" {
 #endif
 
-void tai_to_ts(uint64_t uptime, struct tm *timeptr);
-int ts_to_tai(int64_t *uptime, struct tm *timeptr);
+void tai_to_ts(const struct bt_mesh_time_tai *tai, struct tm *timeptr);
+int ts_to_tai(struct bt_mesh_time_tai *tai, struct tm *timeptr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Implements several changes to pass the Time Server qualification tests.

Converts the time models to storing TAI time as a structure of seconds
and subseconds, instead of as milliseconds, to remove rounding errors in
the conversion between milliseconds and subseconds breaking
qualification test cases.

Check role value before applying.

Removes code moving change times.

Additionally applying general boy scout rule, doing some simplification.

Changes the time server model's update callback to alter the publication
packet instead of sending a new packet, which can generate unexpected
results.