### PR TITLE
doc: Fixed the display of SPM sample in documentation

### DIFF
--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -65,7 +65,6 @@ In addition, the |NCS| provides the following samples that showcase the use of a
    ../../samples/mpsl/*/README
    ../../samples/peripheral/*/README
    ../../samples/sensor/*/README
-   ../../samples/spm/README
    ../../samples/usb/*/README
    ../../samples/nrf_rpc/*/README
 


### PR DESCRIPTION
Fixed the duplicate display of SPM under sample listing in documentation.

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>