### PR TITLE
partition_manager: fix report after regression

### DIFF
--- a/scripts/partition_manager_report.py
+++ b/scripts/partition_manager_report.py
@@ -86,7 +86,10 @@ def main():
 
     for i in args.input:
         fn = path.basename(i)
-        domain_name = fn[fn.index("partitions_") + len("partitions_"):fn.index(".yml")]
+        if '_' in fn:
+            domain_name = fn[fn.index("partitions_") + len("partitions_"):fn.index(".yml")]
+        else:
+            domain_name = ''
         with open(i, 'r') as f:
             pm_config_primary = {k: v for k, v in yaml.safe_load(f).items() if v['region'] == 'flash_primary'}
         min_address = min((part['address'] for part in pm_config_primary.values() if 'address' in part))


### PR DESCRIPTION
Broke when domain prefix was stripped from root domain PM files.

Ref: NCSDK-6147

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>