### PR TITLE
doc: Fixed board names in BLE mesh samples

### DIFF
--- a/doc/nrf/includes/boardname_tables/sample_boardnames.txt
+++ b/doc/nrf/includes/boardname_tables/sample_boardnames.txt
@@ -1,7 +1,6 @@
 .. _sampleboardnames:
 
-Set used by BLE (Central BAS, Central DFU SMP, Central HIDS, Central UART, EnOcean, Mesh Light, Mesh Light Switch, Peripheral HIDS Keyboard, Peripheral HIDS mouse,
-Peripheral UART, NUS Shell Transport, Throughput, Bond Management service) and NFC samples
+Set used by Bluetooth LE Samples and NFC samples
 
 .. set1_start
 
@@ -19,7 +18,7 @@ Peripheral UART, NUS Shell Transport, Throughput, Bond Management service) and N
 
 .. set1_end
 
-Set used by BLE samples (LLPM, peripheral GATT Discovery Manager), Enhanced ShockBurst Transmitter/Receiver, and application (Serial LTE modem)
+Set used by Bluetooth LE samples, Enhanced ShockBurst Transmitter/Receiver, and application (Serial LTE modem)
 
 .. set2_start
 
@@ -33,7 +32,7 @@ Set used by BLE samples (LLPM, peripheral GATT Discovery Manager), Enhanced Shoc
 
 .. set2_end
 
-Set used by BLE samples (Peripheral LBS)
+Set used by Bluetooth LE samples (Peripheral LBS)
 
 .. set3_start
 
@@ -70,7 +69,7 @@ Set used by samples (Radio Test, MPSL Timeslot)
 .. set4_end
 
 Set used by nRF9160 samples (AT Client, AWS FOTA, nRF CoAP Client, GPS sockets and SUPL client library, HTTP application update, HTTPS Client,
-LTE Sensor Gateway, LwM2M carrier, LwM2M Client, Simple MQTT,  Secure Services Sample)
+LTE Sensor Gateway, LwM2M carrier, LwM2M Client, Simple MQTT,  Secure Services Sample) and application (Serial LTE modem)
 
 .. set5_start
 
@@ -96,7 +95,7 @@ Set used by nRF9160 samples (Cloud Client, nRF Cloud A-GPS) and application (Ass
 
 .. set6_end
 
-Set used by nRF9160 sample (Secure Partition Manager)
+
 
 .. set7_start
 
@@ -240,7 +239,7 @@ Set used by sample (Immutable bootloader)
 
 .. set16_end
 
-Set used by samples (USB-UART bridge, Connectivity bridge)
+Set used by samples (USB-UART bridge) and application (Connectivity bridge)
 
 .. set17_start
 
@@ -251,6 +250,8 @@ Set used by samples (USB-UART bridge, Connectivity bridge)
 +--------------------------------+-----------+------------------+---------------------------+
 
 .. set17_end
+
+Set used by Tests (Crypto)
 
 .. set18_start
 
@@ -264,7 +265,7 @@ Set used by samples (USB-UART bridge, Connectivity bridge)
 
 .. set18_end
 
-Set used by the SPM sample
+Set used by sample (SPM)
 
 .. set19_start
 

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -74,12 +74,13 @@ The model handling is implemented in :file:`src/model_handler.c`, which uses the
 Requirements
 ************
 
-* One of the following development kits:
+The sample supports the following development kits:
 
-  * |nRF52DK|
-  * |nRF52840DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set2_start
+   :end-before: set2_end
 
-* Smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 
   * `nRF Mesh mobile app for Android`_
   * `nRF Mesh mobile app for iOS`_

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -61,17 +61,18 @@ A :c:type:`struct k_delayed_work` item is submitted recursively to periodically 
 Requirements
 ************
 
-* One of the following development kits:
+The sample supports the following development kits:
 
-  * |nRF52840DK|
-  * |nRF52DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set2_start
+   :end-before: set2_end
 
-* Smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 
-  * `nRF Mesh mobile app for Android`_
-  * `nRF Mesh mobile app for iOS`_
+* `nRF Mesh mobile app for Android`_
+* `nRF Mesh mobile app for iOS`_
 
-* :ref:`bluetooth_mesh_sensor_server` sample application, programmed on a separate board and configured according to the Mesh sensor server sample's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>`.
+Additionally, the sample requires the :ref:`bluetooth_mesh_sensor_server` sample application, programmed on a separate development kit and configured according to the Mesh sensor server sample's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>`.
 
 User interface
 **************

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -61,17 +61,18 @@ The model handling is implemented in :file:`src/model_handler.c`, which uses the
 Requirements
 ************
 
-* One of the following development kits:
+The sample supports the following development kits:
 
-  * |nRF52840DK|
-  * |nRF52DK|
+.. include:: /includes/boardname_tables/sample_boardnames.txt
+   :start-after: set2_start
+   :end-before: set2_end
 
-* Smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 
-  * `nRF Mesh mobile app for Android`_
-  * `nRF Mesh mobile app for iOS`_
+* `nRF Mesh mobile app for Android`_
+* `nRF Mesh mobile app for iOS`_
 
-* :ref:`bluetooth_mesh_sensor_client` sample application programmed on a separate device and configured according to the Mesh sensor client's :ref:`testing guide <bluetooth_mesh_sensor_client_testing>`.
+Additionally, the sample requires the :ref:`bluetooth_mesh_sensor_client` sample application, programmed on a separate device and configured according to the Mesh sensor client sample's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>`.
 
 User interface
 **************

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -33,8 +33,8 @@ Requirements
 The sample supports the following development kits:
 
 .. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set1_start
-   :end-before: set1_end
+   :start-after: set4_start
+   :end-before: set4_end
 
 You can use any one of the development kits listed above.
 


### PR DESCRIPTION
ref: NCSDK-3933 and
https://github.com/nrfconnect/sdk-nrf/pull/2425
Fixed board names in BLE mesh samples- mesh/light_ctrl,
mesh/sensor_server and mesh/sensor_client READMEs
[Bluetooth_ Mesh Light Control — nRF Connect SDK 1.3.99 documentation.pdf](https://github.com/nrfconnect/sdk-nrf/files/5142491/Bluetooth_.Mesh.Light.Control.nRF.Connect.SDK.1.3.99.documentation.pdf)
[Bluetooth_ Mesh sensor client — nRF Connect SDK 1.3.99 documentation.pdf](https://github.com/nrfconnect/sdk-nrf/files/5142492/Bluetooth_.Mesh.sensor.client.nRF.Connect.SDK.1.3.99.documentation.pdf)
[Bluetooth_ Mesh sensor server — nRF Connect SDK 1.3.99 documentation.pdf](https://github.com/nrfconnect/sdk-nrf/files/5142493/Bluetooth_.Mesh.sensor.server.nRF.Connect.SDK.1.3.99.documentation.pdf)

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>