### PR TITLE
[WIP] lib: bin: lwm2m_carrier: Use of SMS client

### DIFF
--- a/lib/bin/lwm2m_carrier/include/lwm2m_os.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_os.h
@@ -57,6 +57,20 @@ struct lwm2m_os_at_param_list {
 typedef void (*lwm2m_os_at_cmd_handler_t)(void *ctx, const char *response);
 
 /**
+ * @brief SMS PDU data.
+ */
+struct lwm2m_os_sms_data {
+	char *alpha;
+	u16_t length;
+	char *pdu;
+};
+
+/**
+ * @brief SMS listener callback function.
+ */
+typedef void (*lwm2m_os_sms_client_handler_t)(struct lwm2m_os_sms_data *const data, void *context);
+
+/**
  * @defgroup lwm2m_os_download_evt_id LwM2M OS download events
  * @{
  */
@@ -207,6 +221,12 @@ int lwm2m_os_bsdlib_shutdown(void);
  * @brief Initialize AT command driver.
  */
 int lwm2m_os_at_init(void);
+
+
+/**
+ * @brief Register as an SMS client/listener.
+ */
+int lwm2m_os_sms_client_register(sms_callback_t listener, void *context);
 
 /**
  * @brief Set AT command global notification handler.

--- a/lib/bin/lwm2m_carrier/lwm2m_carrier.rst
+++ b/lib/bin/lwm2m_carrier/lwm2m_carrier.rst
@@ -35,6 +35,7 @@ It provides an abstraction of the following modules:
   * :ref:`at_cmd_readme`
   * :ref:`at_cmd_parser_readme`
   * :ref:`at_notif_readme`
+  * :ref:`sms`
 
   .. lwm2m_osal_mod_list_end
 

--- a/lib/sms/sms.c
+++ b/lib/sms/sms.c
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
+#include <modem/sms.h>
+
 #include <logging/log.h>
 #include <zephyr.h>
 #include <stdio.h>
-#include <modem/sms.h>
 #include <errno.h>
+
 #include <modem/at_cmd.h>
 #include <modem/at_cmd_parser.h>
 #include <modem/at_params.h>


### PR DESCRIPTION
The LwM2M carrier library registers as an SMS client. All SMS operations are
now handled by the SMS client module.
Updated documentation and dependency list.

Ref: NCSDK-4727

Signed-off-by: Christopher Métrailler <christopher.metrailler@nordicsemi.no>