### PR TITLE
doc: lib: lwm2m_carrier: documentation update

### DIFF
--- a/lib/bin/lwm2m_carrier/lwm2m_carrier.rst
+++ b/lib/bin/lwm2m_carrier/lwm2m_carrier.rst
@@ -17,6 +17,8 @@ If you want to use LwM2M for other purposes, see :ref:`lwm2m_interface`.
 The :ref:`lwm2m_carrier` sample demonstrates how to run this library in an application.
 The LwM2M carrier library is also used in the :ref:`asset_tracker` application.
 
+.. _lwm2m_app_int:
+
 Application integration
 ***********************
 
@@ -77,6 +79,7 @@ A weak implementation is included in :file:`nrf\\lib\\bin\\lwm2m_carrier\\os\\lw
 
 See :file:`nrf\\lib\\bin\\lwm2m_carrier\\include\\lwm2m_carrier.h` for all the events and API.
 
+.. _lwm2m_events:
 
 LwM2M carrier library events
 ============================
@@ -216,6 +219,13 @@ Below are some of the requirements and limitations of the application while runn
    * The LwM2M carrier library is currently only certified for the *LTE-M* LTE mode.
    * The :option:`CONFIG_LTE_NETWORK_USE_FALLBACK` should be disabled in your application, as seen in the :ref:`lwm2m_carrier` sample project configuration (:file:`nrf/samples/nrf9160/lwm2m_carrier/prj.conf`).
 
+* The LwM2M carrier library registers to receive several AT event reports using the :ref:`at_cmd_readme` and :ref:`at_notif_readme` libraries. The following notifications should not be deregistered by the application:
+
+   * SMS events (AT+CNMI).
+   * Packet Domain events (AT+CGEREP).
+   * Report Network Error Codes events (AT+CNEC): EPS Session Management events are used by the LwM2M carrier library. The application may enable or disable EPS Mobility Management events.
+   * Network Registration Status events (AT+CEREG): Notification Level 2 is used by the LwM2M carrier library. The application may increase this level, but should not decrease it.
+
 * The LwM2M carrier library controls the LTE link.
 
    * This is needed for storing keys to the modem, which requires disconnecting from an LTE link and connecting to it.
@@ -279,6 +289,8 @@ See the changelog for the latest updates in the LwM2M carrier library, and for a
     :maxdepth: 1
 
     doc/CHANGELOG.rst
+
+.. _lwm2m_msc:
 
 Message Sequence Charts
 ***********************

--- a/samples/nrf9160/lwm2m_carrier/README.rst
+++ b/samples/nrf9160/lwm2m_carrier/README.rst
@@ -38,8 +38,11 @@ Troubleshooting
 
 Bootstrapping can take several minutes.
 This is expected and dependent on the availability of the LTE link.
-During bootstrap, several ``LWM2M_CARRIER_EVENT_CONNECT`` and ``LWM2M_CARRIER_EVENT_DISCONNECT`` events are printed.
+During bootstrap, several :c:macro:`LWM2M_CARRIER_EVENT_CONNECTED` and :c:macro:`LWM2M_CARRIER_EVENT_DISCONNECTED` events are printed.
 This is expected and is part of the bootstrapping procedure.
+For more information, see the :ref:`lwm2m_events` and :ref:`lwm2m_msc` sections in the LwM2M carrier library documentation.
+
+To completely restart and trigger a new bootstrap, the device must be erased and re-programmed, as mentioned in :ref:`lwm2m_app_int`.
 
 
 Dependencies


### PR DESCRIPTION
- listed the AT notifications used by library under
"Requirements and Application limitations" section.
- Added additional links to the LwM2M carrier library
 documentation under "troubleshooting" of NCS sample.
- Added sentence about erasing device to clear bootstrap
in the sample documentation.

Signed-off-by: Håvard Vermeer <havard.vermeer@nordicsemi.no>