### PR TITLE
bluetooth: controller: Rename controller specific kconfigs

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -65,13 +65,13 @@ config SDC_MAX_CONN_EVENT_LEN_DEFAULT
 	  primary parameters for setting the throughput of a connection.
 
 
-config BLECTLR_PRIO
-	# Hidden option to set the priority of the controller threads
+config SDC_RX_PRIO
+	# Hidden option to set the priority of the controller receive thread
 	int
 	default BT_RX_PRIO if BT_HCI_HOST || BT_RECV_IS_RX_THREAD
 	default 8
 
-config BLECTLR_RX_STACK_SIZE
+config SDC_RX_STACK_SIZE
 	int "Size of the receive thread stack"
 	default 1024
 	help

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -26,7 +26,7 @@
 static K_SEM_DEFINE(sem_recv, 0, 1);
 
 static struct k_thread recv_thread_data;
-static K_THREAD_STACK_DEFINE(recv_thread_stack, CONFIG_BLECTLR_RX_STACK_SIZE);
+static K_THREAD_STACK_DEFINE(recv_thread_stack, CONFIG_SDC_RX_STACK_SIZE);
 
 #if defined(CONFIG_BT_CONN)
 /* It should not be possible to set CONFIG_SDC_SLAVE_COUNT larger than
@@ -346,7 +346,7 @@ static int hci_driver_open(void)
 
 	k_thread_create(&recv_thread_data, recv_thread_stack,
 			K_THREAD_STACK_SIZEOF(recv_thread_stack), recv_thread,
-			NULL, NULL, NULL, K_PRIO_COOP(CONFIG_BLECTLR_PRIO), 0,
+			NULL, NULL, NULL, K_PRIO_COOP(CONFIG_SDC_RX_PRIO), 0,
 			K_NO_WAIT);
 	k_thread_name_set(&recv_thread_data, "blectlr recv");
 

--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -9,7 +9,7 @@ menu "Nordic MPSL"
 config MPSL_THREAD_COOP_PRIO
 	int
 	default 0 if NET_L2_OPENTHREAD
-	default BLECTLR_PRIO if BT_LL_SOFTDEVICE
+	default SDC_RX_PRIO if BT_LL_SOFTDEVICE
 	default 8
 
 config MPSL_SIGNAL_STACK_SIZE


### PR DESCRIPTION
BLECTLR_PRIO -> SDC_RX_PRIO
BLECTLR_RX_STACK_SIZE -> SDC_RX_STACK_SIZE

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>