### PR TITLE
Bluetooth: Controller Updated HCI VS API naming

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_conn_params.c
+++ b/applications/nrf_desktop/src/modules/ble_conn_params.c
@@ -62,7 +62,7 @@ static int set_conn_params(struct bt_conn *conn, uint16_t conn_latency,
 #ifdef CONFIG_DESKTOP_BLE_USE_LLPM
 	if (peer_llpm_support) {
 		struct net_buf *buf;
-		sdc_hci_vs_cmd_conn_update_t *cmd_conn_update;
+		sdc_hci_cmd_vs_conn_update_t *cmd_conn_update;
 		uint16_t conn_handle;
 
 		err = bt_hci_get_conn_handle(conn, &conn_handle);
@@ -71,7 +71,7 @@ static int set_conn_params(struct bt_conn *conn, uint16_t conn_latency,
 			return err;
 		}
 
-		buf = bt_hci_cmd_create(SDC_HCI_VS_OPCODE_CMD_CONN_UPDATE,
+		buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_CONN_UPDATE,
 					sizeof(*cmd_conn_update));
 		if (!buf) {
 			LOG_ERR("Could not allocate command buffer");
@@ -84,7 +84,7 @@ static int set_conn_params(struct bt_conn *conn, uint16_t conn_latency,
 		cmd_conn_update->conn_latency        = conn_latency;
 		cmd_conn_update->supervision_timeout = CONN_SUPERVISION_TIMEOUT;
 
-		err = bt_hci_cmd_send_sync(SDC_HCI_VS_OPCODE_CMD_CONN_UPDATE, buf,
+		err = bt_hci_cmd_send_sync(SDC_HCI_OPCODE_CMD_VS_CONN_UPDATE, buf,
 					   NULL);
 	} else
 #endif /* CONFIG_DESKTOP_BLE_USE_LLPM */

--- a/applications/nrf_desktop/src/modules/ble_qos.c
+++ b/applications/nrf_desktop/src/modules/ble_qos.c
@@ -408,14 +408,14 @@ static void hid_pkt_stats_print(uint32_t ble_recv)
 static bool on_vs_evt(struct net_buf_simple *buf)
 {
 	uint8_t *subevent_code;
-	sdc_hci_vs_subevent_qos_conn_event_report_t *evt;
+	sdc_hci_subevent_vs_qos_conn_event_report_t *evt;
 
 	subevent_code = net_buf_simple_pull_mem(
 		buf,
 		sizeof(*subevent_code));
 
 	switch (*subevent_code) {
-	case SDC_HCI_VS_SUBEVENT_QOS_CONN_EVENT_REPORT:
+	case SDC_HCI_SUBEVENT_VS_QOS_CONN_EVENT_REPORT:
 		if (atomic_get(&processing)) {
 			/* Cheaper to skip this update */
 			/* instead of using locks */
@@ -446,9 +446,9 @@ static void enable_qos_reporting(void)
 		return;
 	}
 
-	sdc_hci_vs_cmd_qos_conn_event_report_enable_t *cmd_enable;
+	sdc_hci_cmd_vs_qos_conn_event_report_enable_t *cmd_enable;
 
-	buf = bt_hci_cmd_create(SDC_HCI_VS_OPCODE_CMD_QOS_CONN_EVENT_REPORT_ENABLE,
+	buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_QOS_CONN_EVENT_REPORT_ENABLE,
 				sizeof(*cmd_enable));
 	if (!buf) {
 		LOG_ERR("Failed to enable HCI VS QoS");
@@ -459,7 +459,7 @@ static void enable_qos_reporting(void)
 	cmd_enable->enable = 1;
 
 	err = bt_hci_cmd_send_sync(
-		SDC_HCI_VS_OPCODE_CMD_QOS_CONN_EVENT_REPORT_ENABLE, buf, NULL);
+		SDC_HCI_OPCODE_CMD_VS_QOS_CONN_EVENT_REPORT_ENABLE, buf, NULL);
 	if (err) {
 		LOG_ERR("Failed to enable HCI VS QoS");
 		return;

--- a/applications/nrf_desktop/src/modules/ble_state.c
+++ b/applications/nrf_desktop/src/modules/ble_state.c
@@ -352,15 +352,15 @@ static void bt_ready(int err)
 	LOG_INF("Bluetooth initialized");
 
 #ifdef CONFIG_DESKTOP_BLE_USE_LLPM
-	sdc_hci_vs_cmd_llpm_mode_set_t *p_cmd_enable;
+	sdc_hci_cmd_vs_llpm_mode_set_t *p_cmd_enable;
 
-	struct net_buf *buf = bt_hci_cmd_create(SDC_HCI_VS_OPCODE_CMD_LLPM_MODE_SET,
+	struct net_buf *buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_LLPM_MODE_SET,
 						sizeof(*p_cmd_enable));
 
 	p_cmd_enable = net_buf_add(buf, sizeof(*p_cmd_enable));
 	p_cmd_enable->enable = 1;
 
-	err = bt_hci_cmd_send_sync(SDC_HCI_VS_OPCODE_CMD_LLPM_MODE_SET, buf, NULL);
+	err = bt_hci_cmd_send_sync(SDC_HCI_OPCODE_CMD_VS_LLPM_MODE_SET, buf, NULL);
 	if (err) {
 		LOG_ERR("Error enabling LLPM (err: %d)", err);
 	} else {

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -219,9 +219,9 @@ static int enable_llpm_mode(void)
 {
 	int err;
 	struct net_buf *buf;
-	sdc_hci_vs_cmd_llpm_mode_set_t *cmd_enable;
+	sdc_hci_cmd_vs_llpm_mode_set_t *cmd_enable;
 
-	buf = bt_hci_cmd_create(SDC_HCI_VS_OPCODE_CMD_LLPM_MODE_SET,
+	buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_LLPM_MODE_SET,
 				sizeof(*cmd_enable));
 	if (!buf) {
 		printk("Could not allocate LLPM command buffer\n");
@@ -231,7 +231,7 @@ static int enable_llpm_mode(void)
 	cmd_enable = net_buf_add(buf, sizeof(*cmd_enable));
 	cmd_enable->enable = true;
 
-	err = bt_hci_cmd_send_sync(SDC_HCI_VS_OPCODE_CMD_LLPM_MODE_SET, buf, NULL);
+	err = bt_hci_cmd_send_sync(SDC_HCI_OPCODE_CMD_VS_LLPM_MODE_SET, buf, NULL);
 	if (err) {
 		printk("Error enabling LLPM %d\n", err);
 		return err;
@@ -246,9 +246,9 @@ static int enable_llpm_short_connection_interval(void)
 	int err;
 	struct net_buf *buf;
 
-	sdc_hci_vs_cmd_conn_update_t *cmd_conn_update;
+	sdc_hci_cmd_vs_conn_update_t *cmd_conn_update;
 
-	buf = bt_hci_cmd_create(SDC_HCI_VS_OPCODE_CMD_CONN_UPDATE,
+	buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_CONN_UPDATE,
 				sizeof(*cmd_conn_update));
 	if (!buf) {
 		printk("Could not allocate command buffer\n");
@@ -269,7 +269,7 @@ static int enable_llpm_short_connection_interval(void)
 	cmd_conn_update->conn_latency        = 0;
 	cmd_conn_update->supervision_timeout = 300;
 
-	err = bt_hci_cmd_send_sync(SDC_HCI_VS_OPCODE_CMD_CONN_UPDATE, buf, NULL);
+	err = bt_hci_cmd_send_sync(SDC_HCI_OPCODE_CMD_VS_CONN_UPDATE, buf, NULL);
 	if (err) {
 		printk("Update connection parameters failed (err %d)\n", err);
 		return err;
@@ -281,10 +281,10 @@ static int enable_llpm_short_connection_interval(void)
 static bool on_vs_evt(struct net_buf_simple *buf)
 {
 	uint8_t code;
-	sdc_hci_vs_subevent_qos_conn_event_report_t *evt;
+	sdc_hci_subevent_vs_qos_conn_event_report_t *evt;
 
 	code = net_buf_simple_pull_u8(buf);
-	if (code != SDC_HCI_VS_SUBEVENT_QOS_CONN_EVENT_REPORT) {
+	if (code != SDC_HCI_SUBEVENT_VS_QOS_CONN_EVENT_REPORT) {
 		return false;
 	}
 
@@ -306,9 +306,9 @@ static int enable_qos_conn_evt_report(void)
 		return err;
 	}
 
-	sdc_hci_vs_cmd_qos_conn_event_report_enable_t *cmd_enable;
+	sdc_hci_cmd_vs_qos_conn_event_report_enable_t *cmd_enable;
 
-	buf = bt_hci_cmd_create(SDC_HCI_VS_OPCODE_CMD_QOS_CONN_EVENT_REPORT_ENABLE,
+	buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_QOS_CONN_EVENT_REPORT_ENABLE,
 				sizeof(*cmd_enable));
 	if (!buf) {
 		printk("Could not allocate command buffer\n");
@@ -319,7 +319,7 @@ static int enable_qos_conn_evt_report(void)
 	cmd_enable->enable = true;
 
 	err = bt_hci_cmd_send_sync(
-		SDC_HCI_VS_OPCODE_CMD_QOS_CONN_EVENT_REPORT_ENABLE, buf, NULL);
+		SDC_HCI_OPCODE_CMD_VS_QOS_CONN_EVENT_REPORT_ENABLE, buf, NULL);
 	if (err) {
 		printk("Could not send command buffer (err %d)\n", err);
 		return err;

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -215,7 +215,7 @@ static bool event_packet_is_discardable(const uint8_t *hci_buf)
 		uint8_t subevent = hci_buf[2];
 
 		switch (subevent) {
-		case SDC_HCI_VS_SUBEVENT_QOS_CONN_EVENT_REPORT:
+		case SDC_HCI_SUBEVENT_VS_QOS_CONN_EVENT_REPORT:
 			return true;
 		default:
 			return false;
@@ -499,9 +499,9 @@ uint8_t bt_read_static_addr(struct bt_hci_vs_static_addr addrs[], uint8_t size)
 
 void bt_ctlr_set_public_addr(const uint8_t *addr)
 {
-	const sdc_hci_vs_cmd_zephyr_write_bd_addr_t *bd_addr = (void *)addr;
+	const sdc_hci_cmd_vs_zephyr_write_bd_addr_t *bd_addr = (void *)addr;
 
-	(void)sdc_hci_vs_cmd_zephyr_write_bd_addr(bd_addr);
+	(void)sdc_hci_cmd_vs_zephyr_write_bd_addr(bd_addr);
 }
 
 static int hci_driver_init(struct device *unused)

--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 94a32f05ab918ba4a142745134bbfd60d194f766
+      revision: d32c12686a15a4c0303ad1de6927c1a68bfa939e
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
From the SoftDevice Controller changelog:
    * Vendor specific HCI APIs have been renamed (DRGN-14701):
      * HCI_VS_OPCODE   -> HCI_OPCODE_VS
      * HCI_VS_SUBEVENT -> HCI_SUBEVENT_VS
      * hci_vs_cmd      -> hci_cmd_vs

Corresponding PR in nrfxlib: https://github.com/nrfconnect/sdk-nrfxlib/pull/252