### PR TITLE
lib: aws_iot: honor CONFIG_AWS_IOT_CLIENT_ID_MAX_LEN

### DIFF
--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -27,7 +27,7 @@ BUILD_ASSERT(sizeof(CONFIG_AWS_IOT_BROKER_HOST_NAME) > 1,
 #endif
 
 #define AWS_TOPIC "$aws/things/"
-#define AWS_TOPIC_LEN (sizeof(AWS_TOPIC) - 1)
+#define AWS_TOPIC_LEN (sizeof(AWS_TOPIC))
 
 #define AWS_CLIENT_ID_PREFIX "%s"
 #define AWS_CLIENT_ID_LEN_MAX CONFIG_AWS_IOT_CLIENT_ID_MAX_LEN
@@ -323,13 +323,19 @@ static int aws_iot_topics_populate(char *const id, size_t id_len)
 #if defined(CONFIG_AWS_IOT_CLIENT_ID_APP)
 	err = snprintf(client_id_buf, sizeof(client_id_buf),
 		       AWS_CLIENT_ID_PREFIX, id);
-	if (err >= AWS_CLIENT_ID_LEN_MAX) {
+	if (err <= 0) {
+		return -EINVAL;
+	}
+	if (err >= sizeof(client_id_buf)) {
 		return -ENOMEM;
 	}
 #else
 	err = snprintf(client_id_buf, sizeof(client_id_buf),
 		       AWS_CLIENT_ID_PREFIX, CONFIG_AWS_IOT_CLIENT_ID_STATIC);
-	if (err >= AWS_CLIENT_ID_LEN_MAX) {
+	if (err <= 0) {
+		return -EINVAL;
+	}
+	if (err >= sizeof(client_id_buf)) {
 		return -ENOMEM;
 	}
 #endif


### PR DESCRIPTION
This corrects the checks for the allowed maximum client id string
length to be equal the `CONFIG_AWS_IOT_CLIENT_ID_MAX_LEN` value.

Previously the client id string was rejected if it had the maximum
allowed length.

Also corrects the invalid `AWS_TOPIC_LEN`. Previously the library
would not populate the client id into the shadow topic properyl
due to mismatch in expected length for the topics after snprintf.
