### PR TITLE
readme: Fix the length of the underlining marker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 nRF Connect SDK: sdk-nrf
-##################################
+########################
 
 This repository contains the Nordic-specific source code additions to open
 source projects (Zephyr RTOS and MCUboot).


### PR DESCRIPTION
Trivial fix to align the length of the marke to the one of the title.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>