### PR TITLE
applications: nrf_desktop: Use HW ID instead of PID

### DIFF
--- a/applications/nrf_desktop/src/events/config_event.h
+++ b/applications/nrf_desktop/src/events/config_event.h
@@ -93,19 +93,6 @@ EVENT_TYPE_DYNDATA_DECLARE(config_event);
 
 #define CFG_CHAN_RECIPIENT_LOCAL 0x00
 
-#ifdef CONFIG_USB_DEVICE_PID
- #define DEVICE_PID CONFIG_USB_DEVICE_PID
- #ifdef CONFIG_BT_GATT_DIS_PNP_PID
-  #if CONFIG_USB_DEVICE_PID != CONFIG_BT_GATT_DIS_PNP_PID
-   #error Device PIDs are not consistent
-  #endif
- #endif
-#elif defined(CONFIG_BT_GATT_DIS_PNP_PID)
- #define DEVICE_PID CONFIG_BT_GATT_DIS_PNP_PID
-#else
- #error Device PID is not defined
-#endif
-
 extern const uint8_t __start_config_channel_modules[];
 
 #define GEN_CONFIG_EVENT_HANDLERS(mod_name, opt_descr, config_set_fn, config_fetch_fn)		\
@@ -125,7 +112,7 @@ extern const uint8_t __start_config_channel_modules[];
 		bool consume = false;								\
 												\
 		/* Not for us. */								\
-		if (event->recipient != DEVICE_PID) {						\
+		if (event->recipient != CFG_CHAN_RECIPIENT_LOCAL) {				\
 			return false;								\
 		}										\
 												\

--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -473,6 +473,7 @@ static struct config_event *generate_response(const struct config_event *event,
 		new_config_event(dyndata_size);
 
 	rsp->recipient = event->recipient;
+	rsp->status = event->status;
 	rsp->event_id = event->event_id;
 	rsp->transport_id = event->transport_id;
 	rsp->is_request = false;
@@ -516,6 +517,7 @@ static void handle_config_channel_peers_req(const struct config_event *event)
 		while ((per->cfg_chan_id == CFG_CHAN_UNUSED_PEER_ID) &&
 		       (cur_per < ARRAY_SIZE(peripherals))) {
 			cur_per++;
+			per = &peripherals[cur_per];
 		}
 
 		BUILD_ASSERT(sizeof(per->hwid) == HWID_LEN);

--- a/applications/nrf_desktop/src/modules/info.c
+++ b/applications/nrf_desktop/src/modules/info.c
@@ -43,7 +43,7 @@ static void submit_response(struct config_event *rsp)
 static bool handle_config_event(const struct config_event *event)
 {
 	/* Not for us. */
-	if (event->recipient != DEVICE_PID) {
+	if (event->recipient != CFG_CHAN_RECIPIENT_LOCAL) {
 		return false;
 	}
 

--- a/scripts/hid_configurator/NrfHidDevice.py
+++ b/scripts/hid_configurator/NrfHidDevice.py
@@ -197,6 +197,12 @@ class NrfHidDevice():
 
         try:
             devlist = hid.enumerate(vid=vid)
+            # Config channel can use only first HID interface of nrf_desktop
+            # device. Other HID interfaces do not provide proper config channel
+            # response.
+            devlist = list(filter(lambda x: x['interface_number'] in (-1, 0),
+                                  devlist))
+
             for d in devlist:
                 dev = hid.Device(path=d['path'])
                 dev_active = False

--- a/scripts/hid_configurator/NrfHidManager.py
+++ b/scripts/hid_configurator/NrfHidManager.py
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+from NrfHidDevice import NrfHidDevice
+
+NORDIC_VID = 0x1915
+
+class NrfHidManager():
+    TYPE2BOARDLIST = {
+        'gaming_mouse' : ['nrf52840gmouse', 'nrf52840dk'],
+        'dongle' : ['nrf52840dongle', 'nrf52833dongle', 'nrf52820dongle', 'nrf52840dk'],
+        'keyboard' : ['nrf52kbd', 'nrf52840dk'],
+        'desktop_mouse_nrf52832' : ['nrf52dmouse'],
+        'desktop_mouse_nrf52810' : ['nrf52810dmouse']
+    }
+
+    def __init__(self, vid=NORDIC_VID):
+        self.devs = NrfHidDevice.open_devices(vid)
+
+    def list_devices(self):
+        return ['Board: {} (HW ID: {})'.format(v.board_name, k)
+                for k, v in self.devs.items()]
+
+    def find_devices(self, device_type=None, hwid=None):
+        if device_type is not None:
+            try:
+                board_names = NrfHidManager.TYPE2BOARDLIST[device_type]
+            except Exception:
+                board_names = [device_type]
+
+            devs = { k:v for k,v in self.devs.items() if v.board_name in board_names}
+        else:
+            devs = self.devs
+
+        if hwid is not None:
+            try:
+                devs = [devs[hwid]]
+            except Exception:
+                devs = []
+        else:
+            devs = list(devs.values())
+
+        return devs
+
+    def __del__(self):
+        for d in self.devs:
+            NrfHidDevice.close_device(self.devs[d])

--- a/scripts/hid_configurator/modules/config.py
+++ b/scripts/hid_configurator/modules/config.py
@@ -65,14 +65,14 @@ def get_option_format(device_type, module_name, option_name_on_device):
 
     return format
 
-def change_config(dev, module_name, option_name, value, option_descr):
+def change_config(dev, dev_name, module_name, option_name, value, option_descr):
     value_range = option_descr.range
     logging.debug('Send request to update {}/{}: {}'.format(module_name,
                                                             option_name,
                                                             value))
 
     option_name_on_device = option_descr.option_name
-    format = get_option_format(dev.name, module_name, option_name_on_device)
+    format = get_option_format(dev_name, module_name, option_name_on_device)
 
     if format is not None:
         # Read out first, then modify and write back (even if there is only one member in struct, to simplify code)
@@ -109,7 +109,7 @@ def change_config(dev, module_name, option_name, value, option_descr):
     return success
 
 
-def fetch_config(dev, module_name, option_name, option_descr):
+def fetch_config(dev, dev_name, module_name, option_name, option_descr):
     logging.debug('Fetch the current value of {}/{} from the firmware'.format(module_name,
                                                                               option_name))
 
@@ -119,7 +119,7 @@ def fetch_config(dev, module_name, option_name, option_descr):
     if not success or not fetched_data:
         return success, None
 
-    format = get_option_format(dev.name, module_name, option_name_on_device)
+    format = get_option_format(dev_name, module_name, option_name_on_device)
 
     if format is None:
         return success, option_descr.type.from_bytes(fetched_data, byteorder='little')


### PR DESCRIPTION
Change switches to using HW ID instead of PID to forward config channel data.