### PR TITLE
jenkins: Fix quoting the empty compliance.xml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
                       (source ../zephyr/zephyr-env.sh && \
                       pip install --user -r ../tools/ci-tools/requirements.txt && \
                       pip install --user pylint && \
-		      echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>" > compliance.xml)
+		      echo "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>" > compliance.xml)
                     """
                   }
                   finally {


### PR DESCRIPTION
Jenkins is complaining with:

org.dom4j.DocumentException: Error on line 1 of document:
The value following "version" in the XML declaration must be a
quoted string.

Use escaped ASCII to make sure the double quotes are stored in the
file.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>