### PR TITLE
jenkins: Add a complete tag pair to create a valid xml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,12 @@ pipeline {
                       (source ../zephyr/zephyr-env.sh && \
                       pip install --user -r ../tools/ci-tools/requirements.txt && \
                       pip install --user pylint && \
-		      echo "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>" > compliance.xml)
+		      echo "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>" > compliance.xml
+		      echo "<testsuites errors=\\"0\\" failures=\\"0\\" tests=\\"1\\">" >> compliance.xml
+		      echo "<testsuite errors=\\"0\\" failures=\\"0\\" tests=\\"1\\">" >> compliance.xml
+		      echo "<testcase classname=\\"nop\\" name=\\"nop\\"/>" >> compliance.xml
+		      echo "</testsuite>" >> compliance.xml
+		      echo "</testsuites>" >> compliance.xml)
                     """
                   }
                   finally {


### PR DESCRIPTION
In order for the .xml file to be valid, it requires an empty but
present tag pair.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>