### PR TITLE
manifest: Update to nrfxlib PR 253

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d71ca932ad47e38e9ac4afef7ccbb97f289c9e8d
+      revision: pull/253/head
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
-PR adds small fixes for nrf_security advanced configs specific
 to the oberon backend

nrfxlib pr: https://github.com/nrfconnect/sdk-nrfxlib/pull/253

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>