### PR TITLE
net: lib: aws_iot: yield READY event after subscribing to configured topics

### DIFF
--- a/include/net/aws_iot.h
+++ b/include/net/aws_iot.h
@@ -69,7 +69,7 @@ enum aws_iot_evt_type {
 	AWS_IOT_EVT_CONNECTING = 0x1,
 	/** Connected to AWS IoT broker. */
 	AWS_IOT_EVT_CONNECTED,
-	/** AWS IoT broker ready. */
+	/** AWS IoT library has subscribed to all configured topics. */
 	AWS_IOT_EVT_READY,
 	/** Disconnected to AWS IoT broker. */
 	AWS_IOT_EVT_DISCONNECTED,


### PR DESCRIPTION
This changes the purpose of the `AWS_IOT_EVT_READY` to communicate
that the client has subscribed to all configured topics.

Previously it was a duplication of the `AWS_IOT_EVT_CONNECTED`
event and provided no meaningful information.

An error is returned from `mqtt_evt_handler()` if the subscription
fails.

The documentation is updated to reflect this change and
no longer mentions a ready state of the broker which
does not exist in AWS IoT.