### PR TITLE
net: sockets: Enable native TLS sockets on nRF91

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -1161,6 +1161,15 @@ static const struct socket_op_vtable nrf91_socket_fd_op_vtable = {
 
 static bool nrf91_socket_is_supported(int family, int type, int proto)
 {
+	if (IS_ENABLED(CONFIG_NET_SOCKETS_OFFLOAD_TLS)) {
+		return true;
+	}
+
+	if ((proto >= IPPROTO_TLS_1_0 && proto <= IPPROTO_TLS_1_2) ||
+	    (proto >= IPPROTO_DTLS_1_0 && proto <= IPPROTO_DTLS_1_2)) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a87b995bec8717597a81e2eb8b68901dbdc889b4
+      revision: 91d81dc7e0ce35987e66c4c2e11c6372808a904a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The TLS sockets rework has been done upstream mostly, here we only need to update Zephyr revision and slightly adjust `nrf91s_sockets.c`.