### PR TITLE
Enable HWFC in seriali_lte_modem and lte_ble_gateway

### DIFF
--- a/samples/nrf9160/lte_ble_gateway/nrf9160dk_nrf9160ns.overlay
+++ b/samples/nrf9160/lte_ble_gateway/nrf9160dk_nrf9160ns.overlay
@@ -12,4 +12,5 @@
 	rx-pin = <17>;
 	rts-pin = <21>;
 	cts-pin = <19>;
+	hw-flow-control;
 };


### PR DESCRIPTION
Zephyr at some point moved hwfc configuration from Kconfig to device tree. Overlay must enabled hwfc.