### PR TITLE
net: lib: aws_iot: Fix clean sessions support

### DIFF
--- a/applications/asset_tracker/prj.conf
+++ b/applications/asset_tracker/prj.conf
@@ -47,7 +47,7 @@ CONFIG_CJSON_LIB=y
 # Shorter to prevent NAT timeouts
 CONFIG_MQTT_KEEPALIVE=120
 # Don't resubscribe to topics if broker remembers them
-CONFIG_CLOUD_PERSISTENT_SESSIONS=y
+CONFIG_MQTT_CLEAN_SESSION=n
 
 # Sensors
 CONFIG_ACCEL_USE_SIM=y

--- a/applications/asset_tracker/prj_thingy91_nrf9160ns.conf
+++ b/applications/asset_tracker/prj_thingy91_nrf9160ns.conf
@@ -51,7 +51,7 @@ CONFIG_CJSON_LIB=y
 # Shorter to prevent NAT timeouts
 CONFIG_MQTT_KEEPALIVE=120
 # Don't resubscribe to topics if broker remembers them
-CONFIG_CLOUD_PERSISTENT_SESSIONS=y
+CONFIG_MQTT_CLEAN_SESSION=n
 
 # Sensors
 CONFIG_SENSOR=y

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1467,10 +1467,8 @@ void connection_evt_handler(const struct cloud_event *const evt)
 		k_delayed_work_cancel(&cloud_reboot_work);
 		k_sem_take(&cloud_disconnected, K_NO_WAIT);
 		atomic_set(&cloud_connect_attempts, 0);
-#if defined(CONFIG_CLOUD_PERSISTENT_SESSIONS)
-		LOG_INF("Persistent Sessions = %u",
+		LOG_DBG("Persistent Sessions = %u",
 			evt->data.persistent_session);
-#endif
 	} else if (evt->type == CLOUD_EVT_DISCONNECTED) {
 		int32_t connect_wait_s = CONFIG_CLOUD_CONNECT_RETRY_DELAY;
 

--- a/subsys/net/lib/aws_iot/Kconfig
+++ b/subsys/net/lib/aws_iot/Kconfig
@@ -81,14 +81,6 @@ config AWS_IOT_TOPIC_DELETE_REJECTED_SUBSCRIBE
 config AWS_IOT_CONNECTION_POLL_THREAD
 	bool "Enable polling on MQTT socket in AWS IoT backend"
 
-config AWS_IOT_PERSISTENT_SESSIONS
-	bool "Enable reusing previous subscriptions to save bandwidth"
-	help
-	  If y, the AWS IoT broker will save all subscriptions the client makes
-	  during the connection. Upon a disconnect/reconnect the broker resumes
-	  the saved subscriptions removing the need to do a resubscription by
-	  the client.
-
 config AWS_IOT_TLS_SESSION_CACHING
 	bool "Enable TLS session caching"
 	default y

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -805,10 +805,6 @@ static int client_broker_init(struct mqtt_client *const client)
 	client->tx_buf_size		= sizeof(tx_buffer);
 	client->transport.type		= MQTT_TRANSPORT_SECURE;
 
-#if defined(CONFIG_AWS_IOT_PERSISTENT_SESSIONS)
-	client->clean_session		= 0U;
-#endif
-
 	static sec_tag_t sec_tag_list[] = { CONFIG_AWS_IOT_SEC_TAG };
 	struct mqtt_sec_config *tls_cfg = &(client->transport).tls.config;
 

--- a/subsys/net/lib/cloud/Kconfig
+++ b/subsys/net/lib/cloud/Kconfig
@@ -5,11 +5,3 @@
 
 config CLOUD_API
 	bool "Cloud API"
-
-config CLOUD_PERSISTENT_SESSIONS
-	bool "Enable reusing previous subscriptions to save bandwidth"
-	default n
-	help
-	  If y, request using the previous session on connect. If allowed by the broker,
-	  the broker will indicate it is or not.  If not, the device must resubscribe. If
-	  it is allowed, then the device does not need to subscribe to its usual topics.

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -623,10 +623,6 @@ int nct_mqtt_connect(void)
 		nct.client.protocol_version = MQTT_VERSION_3_1_1;
 		nct.client.password = NULL;
 		nct.client.user_name = NULL;
-#if defined(CONFIG_CLOUD_PERSISTENT_SESSIONS)
-		nct.client.clean_session = 0U;
-		LOG_DBG("mqtt_connect requesting persistent session");
-#endif
 #if defined(CONFIG_MQTT_LIB_TLS)
 		nct.client.transport.type = MQTT_TRANSPORT_SECURE;
 		nct.client.rx_buf = nct.rx_buf;


### PR DESCRIPTION
aws_iot was assuming that the session was persistent even if CONFIG_AWS_IOT_PERSISTENT_SESSIONS was not set.