### PR TITLE
samples: nrf9160: udp: Correct documentation

### DIFF
--- a/samples/nrf9160/udp/README.rst
+++ b/samples/nrf9160/udp/README.rst
@@ -3,7 +3,7 @@
 nRF9160: UDP
 ############
 
-The UDP sample demonstrates the sequential transmission of UDP packets to a pre-determined server address or port.
+The UDP sample demonstrates the sequential transmission of UDP packets to a predetermined server identified by an IP address and a port.
 The sample uses the :ref:`nrfxlib:bsdlib` and :ref:`lte_lc_readme` library.
 
 Requirements
@@ -21,7 +21,7 @@ Overview
 ********
 
 The sample acts directly on socket level abstraction.
-It configures a UDP socket and continuously transmits data over the socket to the modem's TCP/IP stack, where the data eventually gets transmitted to the specified server address or port.
+It configures a UDP socket and continuously transmits data over the socket to the modem's TCP/IP stack, where the data eventually gets transmitted to a server specified by an IP address and a port number.
 To control the LTE link, it uses the :ref:`lte_lc_readme` library and requests Power Saving Mode (PSM), extended Discontinuous Reception (eDRX) mode and `Release Assistance Indication (RAI)`_ parameters.
 These parameters can be set through the sample configuration file ``prj.conf``.
 


### PR DESCRIPTION
It was previously stated that the UDP sample transmits
UDP packets to either a server address or a server port.
This patch corrects the documentation to reflect that
the sample does infact use both.