### PR TITLE
github: Add a labeler job and label manifest PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+"manifest":
+  - "west.yml"

--- a/.github/workflows/periodic-labeler.yml
+++ b/.github/workflows/periodic-labeler.yml
@@ -1,0 +1,13 @@
+name: Pull Request labeler
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: paulfantom/periodic-labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler.yml


### PR DESCRIPTION
Add a labeler job that runs every 5 minutes and labels PRs according to
a set of rules. For now only label PRs that touch the manifest
(west.yml) with the "manifest" label.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>