### PR TITLE
applications: serial_lte_modem Adjust flow control for UART2

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -40,7 +40,6 @@ choice
 		bool "UART 2"
 	  select UART_2_NRF_UARTE
 	  select UART_2_NRF_HW_ASYNC
-	  select UART_2_NRF_FLOW_CONTROL
 endchoice
 
 choice

--- a/applications/serial_lte_modem/nrf9160dk_nrf9160ns.overlay
+++ b/applications/serial_lte_modem/nrf9160dk_nrf9160ns.overlay
@@ -1,8 +1,10 @@
 &uart2 {
+	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
 	tx-pin = <10>;
 	rx-pin = <11>;
 	rts-pin = <12>;
 	cts-pin = <13>;
+	hw-flow-control;
 };


### PR DESCRIPTION
After recent up-merge, UART flow control moves to device tree.
And Zephyr Serial's KConfig item is also removed.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>