### PR TITLE
applications: asset_tracker: UI LED PWM frequency option

### DIFF
--- a/applications/asset_tracker/src/ui/Kconfig
+++ b/applications/asset_tracker/src/ui/Kconfig
@@ -26,6 +26,11 @@ config UI_LED_PWM_DEV_NAME
 	string "PWM device name for RGB LED"
 	default "PWM_0" if BOARD_THINGY91_NRF9160NS
 
+config UI_LED_PWM_FREQUENCY
+	int "LED PWM frequency"
+	range 100 1000000
+	default 20000
+
 config UI_LED_RED_PIN
 	int "Red LED pin number"
 	default 29 if BOARD_THINGY91_NRF9160NS

--- a/applications/asset_tracker/src/ui/led_pwm.c
+++ b/applications/asset_tracker/src/ui/led_pwm.c
@@ -91,7 +91,8 @@ static void pwm_out(struct led *led, struct led_color *color)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(color->c); i++) {
 		pwm_pin_set_usec(led->pwm_dev, led_pins[i],
-				 255, color->c[i], 0);
+				 (1000000 / CONFIG_UI_LED_PWM_FREQUENCY),
+				 color->c[i], 0);
 	}
 }
 


### PR DESCRIPTION
Add option to set LED PWM frequency.
Set default frequency to be outside of audible range.

Signed-off-by: Audun Korneliussen <audun.korneliussen@nordicsemi.no>