### PR TITLE
applications: nrf_desktop: Use uint8_t for config channel recipient

### DIFF
--- a/applications/nrf_desktop/src/events/config_event.c
+++ b/applications/nrf_desktop/src/events/config_event.c
@@ -21,7 +21,7 @@ static int log_config_event(const struct event_header *eh, char *buf,
 
 	__ASSERT_NO_MSG(event->status < ARRAY_SIZE(status_name));
 
-	return snprintf(buf, buf_len, "%s %s rcpt: %04x id: %02x",
+	return snprintf(buf, buf_len, "%s %s rcpt: %02x id: %02x",
 			status_name[event->status],
 			event->is_request ? "req" : "rsp",
 			event->recipient,

--- a/applications/nrf_desktop/src/events/config_event.h
+++ b/applications/nrf_desktop/src/events/config_event.h
@@ -73,6 +73,9 @@ enum config_status {
 /* Description of the option representing module type. */
 #define OPT_DESCR_MODULE_TYPE "module_type"
 
+/* Configuration channel local recipient. */
+#define CFG_CHAN_RECIPIENT_LOCAL 0x00
+
 /** @brief Configuration channel event.
  * Used to forward configuration channel request/response.
  */
@@ -84,14 +87,12 @@ struct config_event {
 
 	/* Data exchanged with host. */
 	uint8_t event_id;
-	uint16_t recipient;
+	uint8_t recipient;
 	uint8_t status;
 	struct event_dyndata dyndata;
 };
 
 EVENT_TYPE_DYNDATA_DECLARE(config_event);
-
-#define CFG_CHAN_RECIPIENT_LOCAL 0x00
 
 extern const uint8_t __start_config_channel_modules[];
 

--- a/scripts/hid_configurator/NrfHidDevice.py
+++ b/scripts/hid_configurator/NrfHidDevice.py
@@ -148,7 +148,8 @@ class NrfHidTransport():
                 # Response was not ready
                 continue
 
-            if (rsp_recipient != recipient) or (rsp_event_id != event_id):
+            if (rsp_status != ConfigStatus.TIMEOUT) and \
+               ((rsp_recipient != recipient) or (rsp_event_id != event_id)):
                 logging.error('Response does not match the request:\n'
                               '\trequest: recipient {} event_id {}\n'
                               '\tresponse: recipient {}, event_id {}'.format(recipient,


### PR DESCRIPTION
Use uint8_t instead of uint16_t to identify config channel recipient.