### PR TITLE
samples: openthread: Fix bug in samples CMakeLists.txt

### DIFF
--- a/samples/openthread/cli/CMakeLists.txt
+++ b/samples/openthread/cli/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.13.1)
 
-list(PREPEND OVERLAY_CONFIG ../common/overlay-ot-defaults.conf)
+list(INSERT OVERLAY_CONFIG 0 ../common/overlay-ot-defaults.conf)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 

--- a/samples/openthread/coap_client/CMakeLists.txt
+++ b/samples/openthread/coap_client/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.13.1)
 
-list(PREPEND OVERLAY_CONFIG ../common/overlay-ot-defaults.conf)
+list(INSERT OVERLAY_CONFIG 0 ../common/overlay-ot-defaults.conf)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 

--- a/samples/openthread/coap_server/CMakeLists.txt
+++ b/samples/openthread/coap_server/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.13.1)
 
-list(PREPEND OVERLAY_CONFIG ../common/overlay-ot-defaults.conf)
+list(INSERT OVERLAY_CONFIG 0 ../common/overlay-ot-defaults.conf)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 

--- a/samples/openthread/ncp/CMakeLists.txt
+++ b/samples/openthread/ncp/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.13.1)
 
 set(OT_NCP_VENDOR_HOOK_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-list(PREPEND OVERLAY_CONFIG ../common/overlay-ot-defaults.conf)
+list(INSERT OVERLAY_CONFIG 0 ../common/overlay-ot-defaults.conf)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 


### PR DESCRIPTION
The samples should be compilable with CMake version starting from 3.13.1. Currently they do not copile with CMake version earlier than 3.15.7, because of option (list PREPEND) which is evailable starting from that version.