### PR TITLE
github: actions: Label documentation PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,8 @@
+# https://github.com/actions/labeler/blob/main/README.md
+
 "manifest":
   - "west.yml"
+
+"doc-required":
+  - "doc/**/*"
+  - "*.rst"


### PR DESCRIPTION
Apply the doc-required label to all PRs modifying files in the doc/
folder or an .rst file anywhere in the tree.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>