### PR TITLE
Added support for nrf5340pdk_nrf5340_cpuappns

### DIFF
--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -9,5 +9,5 @@ tests:
   samples.bluetooth.central_bas.build:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_dfu_smp/sample.yaml
+++ b/samples/bluetooth/central_dfu_smp/sample.yaml
@@ -9,5 +9,5 @@ tests:
   samples.bluetooth.central_dfu_smp.build:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -9,5 +9,5 @@ tests:
   samples.bluetooth.central_hids.build:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.central_uart:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/llpm/sample.yaml
+++ b/samples/bluetooth/llpm/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.llpm:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.mesh.light:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.mesh.light_switch:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_gatt_dm/sample.yaml
+++ b/samples/bluetooth/peripheral_gatt_dm/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.peripheral_gatt_dm:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -9,5 +9,5 @@ tests:
   samples.bluetooth.peripheral_hids_keyboard.build:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -9,5 +9,5 @@ tests:
   samples.bluetooth.peripheral_hids_mouse.build:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.peripheral_lbs:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_nfc_pairing/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_nfc_pairing/CMakeLists.txt
@@ -11,6 +11,7 @@ set(NRF_SUPPORTED_BOARDS
   nrf52840dk_nrf52840
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
+  nrf5340pdk_nrf5340_cpuappns
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.peripheral_uart:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/shell_bt_nus/sample.yaml
+++ b/samples/bluetooth/shell_bt_nus/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.shell_bt_nus:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/throughput/sample.yaml
+++ b/samples/bluetooth/throughput/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.throughput:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/nfc/system_off/CMakeLists.txt
+++ b/samples/nfc/system_off/CMakeLists.txt
@@ -11,6 +11,7 @@ set(NRF_SUPPORTED_BOARDS
   nrf52840dk_nrf52840
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
+  nrf5340pdk_nrf5340_cpuappns
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nfc/system_off/sample.yaml
+++ b/samples/nfc/system_off/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.nfc.system_off:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: ci_build

--- a/samples/nfc/tnep_tag/CMakeLists.txt
+++ b/samples/nfc/tnep_tag/CMakeLists.txt
@@ -11,6 +11,7 @@ set(NRF_SUPPORTED_BOARDS
   nrf52840dk_nrf52840
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
+  nrf5340pdk_nrf5340_cpuappns
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nfc/tnep_tag/sample.yaml
+++ b/samples/nfc/tnep_tag/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.nfc.tnep_tag:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: ci_build

--- a/tests/drivers/fprotect/negative/testcase.yaml
+++ b/tests/drivers/fprotect/negative/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   drivers.fprotect.negative:
-    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
+    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
     tags: b0 fprotect
     harness: console
     harness_config:

--- a/tests/drivers/fprotect/positive/testcase.yaml
+++ b/tests/drivers/fprotect/positive/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   drivers.fprotect.positive:
-    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
+    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
     tags: b0 fprotect

--- a/tests/subsys/bootloader/bl_crypto/testcase.yaml
+++ b/tests/subsys/bootloader/bl_crypto/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   bootloader.bl_crypto:
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf9160dk_nrf9160 nrf5340pdk_nrf5340_cpuapp nrf51dk_nrf51422
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf9160dk_nrf9160 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns nrf51dk_nrf51422
     tags: b0

--- a/tests/subsys/bootloader/bl_storage/testcase.yaml
+++ b/tests/subsys/bootloader/bl_storage/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   bootloader.bl_storage:
-    platform_allow: nrf9160dk_nrf9160 nrf5340pdk_nrf5340_cpuapp
+    platform_allow: nrf9160dk_nrf9160 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
     tags: b0
     harness: console
     harness_config:

--- a/tests/subsys/bootloader/bl_validation/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   bootloader.bl_validation:
-    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf51dk_nrf51422
+    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns nrf51dk_nrf51422
     tags: b0 bl_validation

--- a/tests/subsys/bootloader/bl_validation_ff_key/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_ff_key/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   bootloader.bl_validation.ff_key:
-    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
+    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
     tags: b0 bl_validation ff_key
     harness: console
     harness_config:

--- a/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   bootloader.bl_validation.negative:
-    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf9160dk_nrf9160
+    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns nrf9160dk_nrf9160
     tags: b0 bl_validation negative bl_validation_negative
     harness: console
     harness_config:

--- a/tests/subsys/fw_info/testcase.yaml
+++ b/tests/subsys/fw_info/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   fw_info.core:
-    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
+    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
     tags: b0 fw_info


### PR DESCRIPTION
The primary change is the first commit, witch adds the "nrf5340pdk_nrf5340_cpuappns" to the Jenkins build.

I also noticed that not in all places where the "nrf5340pdk_nrf5340_cpuapp" was liste, the "nrf5340pdk_nrf5340_cpuappns" was listed as well. So I added them where there where missing.