### PR TITLE
cmake: changed NRF_DIR to CMAKE_CURRENT_LIST_DIR in boilerplate.cmake

### DIFF
--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -9,7 +9,7 @@
 # For more information regarding the Zephyr Build Configuration CMake package, please refer to:
 # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/zephyr_cmake_package.html#zephyr-build-configuration-cmake-package
 
-include(${NRF_DIR}/boards/deprecated.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../boards/deprecated.cmake)
 
 if(NOT BOARD)
         set(BOARD $ENV{BOARD})


### PR DESCRIPTION
boilerplate.cmake is sourced through the Zephyr Build Configuration
CMake package. This means that `NRF_DIR` has not yet been defined.

Code using `NRF_DIR` has been updated to use `CMAKE_CURRENT_LIST_DIR`
instead.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>