### PR TITLE
github: labeler: Fix the glob for doc-required

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,4 +5,4 @@
 
 "doc-required":
   - "doc/**/*"
-  - "*.rst"
+  - "**/*.rst"


### PR DESCRIPTION
Fix the glob pattern so all .rst files, anywhere in the folder are
matched.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>