### PR TITLE
Adapt to clock control updates: access using onoff manager

### DIFF
--- a/applications/nrf_desktop/src/modules/hfclk_lock.c
+++ b/applications/nrf_desktop/src/modules/hfclk_lock.c
@@ -17,38 +17,43 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(MODULE);
 
-#define DT_DRV_COMPAT nordic_nrf_clock
-
-static struct device *clk_dev;
-
+static struct onoff_manager *mgr;
+static struct onoff_client cli;
 
 static void hfclk_lock(void)
 {
-	if (clk_dev) {
+	if (mgr) {
 		return;
 	}
 
-	clk_dev = device_get_binding(DT_INST_LABEL(0));
-
-	if (!clk_dev) {
+	mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+	if (!mgr) {
 		module_set_state(MODULE_STATE_ERROR);
 	} else {
-		clock_control_on(clk_dev, CLOCK_CONTROL_NRF_SUBSYS_HF);
-		module_set_state(MODULE_STATE_READY);
+		int err;
+
+		sys_notify_init_spinwait(&cli.notify);
+		err = onoff_request(mgr, &cli);
+		if (err < 0) {
+			mgr = NULL;
+			module_set_state(MODULE_STATE_ERROR);
+		} else {
+			module_set_state(MODULE_STATE_READY);
+		}
 	}
 }
 
 static void hfclk_unlock(void)
 {
-	if (!clk_dev) {
+	int err;
+
+	if (!mgr) {
 		return;
 	}
 
-	clock_control_off(clk_dev, CLOCK_CONTROL_NRF_SUBSYS_HF);
-
-	clk_dev = NULL;
-
-	module_set_state(MODULE_STATE_OFF);
+	err = onoff_cancel_or_release(mgr, &cli);
+	module_set_state((err < 0) ? MODULE_STATE_ERROR : MODULE_STATE_OFF);
+	mgr = NULL;
 }
 
 


### PR DESCRIPTION
Updated in 2 places where old approach was used. Using old approach led to asserts.