### PR TITLE
openthread: samples: Added using UART HWFC by default.

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -48,6 +48,8 @@
 
 .. |enable_thread_before_testing| replace:: Make sure to enable the OpenThread stack before building and testing this sample.
    See :ref:`ug_thread` for more information.
+.. |thread_hwfc_enabled| replace:: Thread samples have Hardware Flow Control mechanism enabled by default in serial communication.
+   When enabled, it allows devices to manage transmission by informing each other about their current state, and ensures more reliable connection in high-speed communication scenarios.
 
 .. |zigbee_version| replace:: Zigbee 3.0
 .. |zigbee_description| replace:: Zigbee is a portable, low-power software networking protocol that provides connectivity over an 802.15.4-based mesh network.

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -51,7 +51,6 @@ User interface
 All the interactions with the application are handled using serial communication.
 See `OpenThread CLI Reference`_ for the list of available serial commands.
 
-
 Building and running
 ********************
 
@@ -69,6 +68,10 @@ After building the sample and programming it to your development kit, test it by
 #. Turn on the development kit.
 #. Set up the serial connection with the development kit.
    For more details, see :ref:`putty`.
+
+   .. note::
+        |thread_hwfc_enabled|
+
 #. Invoke some of the OpenThread commands:
 
    a. Test the state of the Thread network with the ``ot state`` command.
@@ -122,6 +125,10 @@ To test communication between boards, complete the following steps:
 #. Turn on the developments kits.
 #. Set up the serial connection with both development kits.
    For more details, see :ref:`putty`.
+
+   .. note::
+        |thread_hwfc_enabled|
+
 #. Test communication between the boards with the ``ot ping <ip_address_of_the_first_board>`` command.
    For example:
 
@@ -139,6 +146,10 @@ To test diagnostic commands, complete the following steps:
 #. Turn on the developments kits.
 #. Set up the serial connection with both development kits.
    For more details, see :ref:`putty`.
+
+   .. note::
+        |thread_hwfc_enabled|.
+
 #. Make sure that the diagnostic module is enabled and configured with proper radio channel and transmission power by running the following commands on both devices:
 
    .. code-block:: console

--- a/samples/openthread/cli/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/openthread/cli/boards/nrf52833dk_nrf52833.overlay
@@ -4,12 +4,6 @@
  */
 
 &uart0 {
-	current-speed = <1000000>;
 	status = "okay";
 	hw-flow-control;
-};
-
-&uart1 {
-	current-speed = <1000000>;
-	status = "okay";
 };

--- a/samples/openthread/cli/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/cli/boards/nrf52840dk_nrf52840.overlay
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart0 {
+	status = "okay";
+	hw-flow-control;
+};
+
 / {
 	/*
 	* In some default configurations within the nRF Connect SDK,

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -136,6 +136,9 @@ Sample output
 The sample logging output can be observed through a serial port.
 For more details, see :ref:`putty`.
 
+.. note::
+     |thread_hwfc_enabled|
+
 Dependencies
 ************
 

--- a/samples/openthread/coap_client/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/openthread/coap_client/boards/nrf52833dk_nrf52833.overlay
@@ -4,12 +4,6 @@
  */
 
 &uart0 {
-	current-speed = <1000000>;
 	status = "okay";
 	hw-flow-control;
-};
-
-&uart1 {
-	current-speed = <1000000>;
-	status = "okay";
 };

--- a/samples/openthread/coap_client/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/coap_client/boards/nrf52840dk_nrf52840.overlay
@@ -17,6 +17,10 @@
 &adc {
 	status = "disabled";
 };
+&uart0 {
+	status = "okay";
+	hw-flow-control;
+};
 &uart1 {
 	status = "disabled";
 };

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -82,14 +82,18 @@ After building the sample and programming it to your development kit, test it by
 Running OpenThread CLI commands
 -------------------------------
 
-You can connect to any of the Simple CoAP Server or Simple CoAP Client nodes through a serial port and run OpenThread CLI commands.
+You can connect to any of the Simple CoAP Server or Simple CoAP Client nodes through a serial port.
 For more details, see :ref:`putty`.
+
+.. note::
+     |thread_hwfc_enabled|
+
+Once the serial connection is ready, you can run OpenThread CLI commands.
+For complete CLI documentation, refer to `OpenThread CLI Reference`_.
 
 .. note::
     In Zephyr shell, every OpenThread command needs to be prepended with the `ot` keyword.
     For example, ``ot channel 20``.
-
-For complete CLI documentation, refer to `OpenThread CLI Reference`_.
 
 Dependencies
 ************

--- a/samples/openthread/coap_server/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/openthread/coap_server/boards/nrf52833dk_nrf52833.overlay
@@ -4,12 +4,6 @@
  */
 
 &uart0 {
-	current-speed = <1000000>;
 	status = "okay";
 	hw-flow-control;
-};
-
-&uart1 {
-	current-speed = <1000000>;
-	status = "okay";
 };

--- a/samples/openthread/coap_server/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/coap_server/boards/nrf52840dk_nrf52840.overlay
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart0 {
+	status = "okay";
+	hw-flow-control;
+};
+
 / {
 	/*
 	* In some default configurations within the nRF Connect SDK,

--- a/samples/openthread/ncp/README.rst
+++ b/samples/openthread/ncp/README.rst
@@ -80,7 +80,9 @@ It is also possible to communicate with NCP board using `PySpinel`_ commands.
 
 You can use your own application instead of wpantund and PySpinel provided that it supports the spinel communication protocol.
 
-Sample by default reconfigures baudrate 1000000 bit/s for serial communication.
+.. note::
+    |thread_hwfc_enabled|
+    In addition, the NCP sample by default reconfigures the baud rate to 1000000 bit/s.
 
 Building and running
 ********************

--- a/samples/openthread/ncp/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/ncp/boards/nrf52840dk_nrf52840.overlay
@@ -1,13 +1,15 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 &uart0 {
-	compatible = "nordic,nrf-uart";
 	current-speed = <1000000>;
 	status = "okay";
+	hw-flow-control;
 };
 
 &uart1 {
-	compatible = "nordic,nrf-uart";
 	current-speed = <1000000>;
 	status = "okay";
 };


### PR DESCRIPTION
Overlays setting UART hardware flow control by default
were added/extended.

KRKNWK-7370

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>