### PR TITLE
cmake: partition_manager: expose function for adding pm.yml

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -33,3 +33,28 @@ function(add_overlay_config image overlay_file)
   endif()
 endfunction()
 
+# Add a partition manager configuration file to the build.
+# Note that is only one image is included in the build,
+# you must set CONFIG_PM_SINGLE_IMAGE=y for the partition manager
+# configuration to take effect.
+function(ncs_add_partition_manager_config config_file)
+  get_filename_component(pm_path ${config_file} REALPATH)
+  get_filename_component(pm_filename ${config_file} NAME)
+
+  if (NOT EXISTS ${pm_path})
+    message(FATAL_ERROR
+      "Could not find specified partition manager configuration file "
+      "${config_file} at ${pm_path}"
+      )
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY
+    PM_SUBSYS_PATHS
+    ${pm_path}
+    )
+  set_property(GLOBAL APPEND PROPERTY
+    PM_SUBSYS_OUTPUT_PATHS
+    ${CMAKE_CURRENT_BINARY_DIR}/${pm_filename}
+    )
+endfunction()
+

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -4,13 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-macro(add_partition_manager_config config_file)
-  get_filename_component(pm_path ${config_file} REALPATH)
-  get_filename_component(pm_filename ${config_file} NAME)
-  list(APPEND PM_SUBSYS_PATHS ${pm_path})
-  list(APPEND PM_SUBSYS_OUTPUT_PATHS ${CMAKE_CURRENT_BINARY_DIR}/${pm_filename})
-endmacro()
-
 function(preprocess_pm_yml in_file out_file)
   execute_process(
     COMMAND ${CMAKE_C_COMPILER}
@@ -35,19 +28,19 @@ endfunction()
 # Store the preprocessed output in the binary dir of the subsystems
 # to avoid overwriting pm.yml files.
 if (CONFIG_SETTINGS_FCB OR CONFIG_SETTINGS_NVS)
-  add_partition_manager_config(pm.yml.settings)
+  ncs_add_partition_manager_config(pm.yml.settings)
 endif()
 
 if (CONFIG_FILE_SYSTEM)
-  add_partition_manager_config(pm.yml.file_system)
+  ncs_add_partition_manager_config(pm.yml.file_system)
 endif()
 
 if (CONFIG_ZIGBEE)
-  add_partition_manager_config(pm.yml.zboss)
+  ncs_add_partition_manager_config(pm.yml.zboss)
 endif()
 
 if (CONFIG_NVS AND NOT CONFIG_SETTINGS_NVS)
-  add_partition_manager_config(pm.yml.nvs)
+  ncs_add_partition_manager_config(pm.yml.nvs)
 endif()
 
 # We are using partition manager if we are a child image or if we are
@@ -73,6 +66,9 @@ if((EXISTS ${CMAKE_SOURCE_DIR}/pm.yml) AND IMAGE_NAME)
     ${ZEPHYR_BINARY_DIR}/include/generated/pm.yml
     )
 endif()
+
+get_property(PM_SUBSYS_PATHS GLOBAL PROPERTY PM_SUBSYS_PATHS)
+get_property(PM_SUBSYS_OUTPUT_PATHS GLOBAL PROPERTY PM_SUBSYS_OUTPUT_PATHS)
 
 # Check for partition manager configurations defined by subsystems
 # This is a list of absolute paths to these pm.yml files.


### PR DESCRIPTION
To facilitate OOT users, expose the function for adding
partition manager configuration files.

NCSDK-5493

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>