### PR TITLE
manifest: mcuboot update

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -103,6 +103,11 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   set(app_sign_depends
     $<IF:${sign_merged},${merged_hex_file_depends},zephyr_final>)
 
+  if (NOT DEFINED CONFIG_BOOT_SIGNATURE_KEY_FILE)
+    include(${CMAKE_BINARY_DIR}/mcuboot/shared_vars.cmake)
+    set(CONFIG_BOOT_SIGNATURE_KEY_FILE ${mcuboot_SIGNATURE_KEY_FILE})
+  endif ()
+
   if (DEFINED mcuboot_CONF_FILE)
     get_filename_component(mcuboot_CONF_DIR ${mcuboot_CONF_FILE} DIRECTORY)
     if (EXISTS ${mcuboot_CONF_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})

--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -27,6 +27,11 @@ if(IMAGE_NAME)
   share("set(${IMAGE_NAME}KERNEL_ELF_NAME ${KERNEL_ELF_NAME})")
   share("list(APPEND ${IMAGE_NAME}BUILD_BYPRODUCTS ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME})")
   share("list(APPEND ${IMAGE_NAME}BUILD_BYPRODUCTS ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME})")
+  # Share the signing key file so that the parent image can use it to
+  # generate signed update candidates.
+  if(CONFIG_BOOT_SIGNATURE_KEY_FILE)
+   share("set(${IMAGE_NAME}SIGNATURE_KEY_FILE ${CONFIG_BOOT_SIGNATURE_KEY_FILE})")
+  endif()
 
   file(GENERATE OUTPUT ${CMAKE_BINARY_DIR}/shared_vars.cmake
     CONTENT $<TARGET_PROPERTY:zephyr_property_target,shared_vars>

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -23,7 +23,7 @@ The following list summarizes the most important changes inherited from upstream
   * Fixed an issue where after erasing an image, an image trailer might be left behind.
   * Added a ``CONFIG_BOOT_INTR_VEC_RELOC`` option to relocate interrupts to application.
   * Fixed single image compilation with serial recovery.
-  * Added support for single-image applications (see :option:`CONFIG_SINGLE_IMAGE_DFU`).
+  * Added support for single-image applications (see `CONFIG_SINGLE_IMAGE_DFU`).
   * Added a ``CONFIG_BOOT_SIGNATURE_TYPE_NONE`` option to disable the cryptographic check of the image.
   * Reduced the minimum number of members in SMP packet for serial recovery.
   * Introduced direct execute-in-place (XIP) mode (see ``CONFIG_BOOT_DIRECT_XIP``).

--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: a401d3a056b6ef41a9ead1a7ad5263e028f52549
+      revision: d7373a00f65b7545c025cbb63cfd8bc153afe5e7
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
Removed Kconfig SINGLE_IMAGE_DFU duplication.

https://github.com/nrfconnect/sdk-mcuboot/pull/119

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>