### PR TITLE
lwm2m_carrier: increase AT thread stack size

### DIFF
--- a/lib/bin/lwm2m_carrier/Kconfig
+++ b/lib/bin/lwm2m_carrier/Kconfig
@@ -28,6 +28,7 @@ menuconfig LWM2M_CARRIER
 	depends on MODEM_KEY_MGMT
 	# AT libraries
 	depends on AT_CMD
+	depends on (AT_CMD_THREAD_STACK_SIZE >= 1536)
 	depends on (AT_CMD_RESPONSE_MAX_LEN > 128)
 	depends on AT_CMD_PARSER
 	depends on AT_NOTIF

--- a/samples/nrf9160/lwm2m_carrier/prj.conf
+++ b/samples/nrf9160/lwm2m_carrier/prj.conf
@@ -24,6 +24,7 @@ CONFIG_DOWNLOAD_CLIENT=y
 
 # AT Command driver interface with Modem
 CONFIG_AT_CMD=y
+CONFIG_AT_CMD_THREAD_STACK_SIZE=1536
 CONFIG_AT_CMD_PARSER=y
 
 # Credential management


### PR DESCRIPTION
Increase AT thread stack size requirements for `lwm2m_carrier` sample and library.

This should be backported to `v1.3-branch`.