### PR TITLE
github: Switch to a new backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled
@@ -10,10 +10,7 @@ jobs:
     runs-on: ubuntu-18.04
     name: Backport
     steps:
-      - name: Backport Bot
-        uses: Gaurav0/backport@v1.0.24
+      - name: Backport
+        uses: zephyrproject-rtos/action-backport@v1.1.99
         with:
-          bot_username: NordicBuilder
-          bot_token: 151a9b45052f9ee8be5a59963d31ad7b92c3ecb5
-          bot_token_key: 67bb1f1f998d546859786a4088917c65415c0ebd
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the backport action defined in:
https://github.com/zephyrproject-rtos/action-backport
which is a fork of:
https://github.com/tibdex/backport

with some additional changes.

This is able to work with the "pull_request_target" event.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>