### PR TITLE
openthread: manifest: Adjust config option name

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -26,7 +26,7 @@ config OPENTHREAD_NRF_SECURITY
 	  OpenThread to make use of hardware accelerated cryptography functions
 	  if available as well as fast oberon backend for software encryption.
 
-config OPENTHREAD_MBEDTLS_TARGET
+config OPENTHREAD_MBEDTLS_LIB_NAME
 	default "mbedtls_common" if OPENTHREAD_NRF_SECURITY
 
 endmenu

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 91d81dc7e0ce35987e66c4c2e11c6372808a904a
+      revision: 332206bcad13edffb14f0de684b62b795b871903
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d71ca932ad47e38e9ac4afef7ccbb97f289c9e8d
+      revision: 94a32f05ab918ba4a142745134bbfd60d194f766
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Pulling in new cherrypicked zephyrs commit that also renames
OPENTHREAD_MBEDTLS_TARGET to OPENTHREAD_MBEDTLS_LIB_NAME.
This cherry-picked zephyr uses openthread with improved build script
that allows passing multiple libraries for mbedtls. Multiple libraries
support is needed tu use nfr_security crypto functions.
Making use of it will be a separate PR. This PR makes sure that new
zephyr/OpenThread will work in NCS.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>