### PR TITLE
kconfig: fix module-str for NRF_RPC

### DIFF
--- a/subsys/nrf_rpc/Kconfig
+++ b/subsys/nrf_rpc/Kconfig
@@ -53,7 +53,7 @@ config NRF_RPC_TR_PRMSG_RX_PRIORITY
 	  messages from rpmsg.
 
 module = NRF_RPC
-module-str = NRF_RPC_
+module-str = NRF_RPC
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 module = NRF_RPC_TR


### PR DESCRIPTION
The underscore at the end of the module-str makes the documentation
build fail.

This should fix the build error.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>