### PR TITLE
openthread: zigbee: lib: Fix RAM power down functionality

### DIFF
--- a/lib/ram_pwrdn/Kconfig
+++ b/lib/ram_pwrdn/Kconfig
@@ -7,12 +7,12 @@
 menuconfig RAM_POWER_DOWN_LIBRARY
 	bool "Enable API for turning off unused RAM segments"
 	help
-	  This allows application to call API for disabling unused RAM segments.
+	  This allows application to call API for disabling unused RAM segments
+	  in the System ON mode. Effectively the application looses possibility
+	  to use disabled portion of RAM.
 	  This is usually not needed, but can improve battery lifetime for
 	  applications that spend most of the time in the sleep mode with most
 	  peripherals disabled.
-
-
 
 if RAM_POWER_DOWN_LIBRARY
 

--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -81,7 +81,7 @@ void power_down_unused_ram(void)
 	uint8_t     section_id              = 5;
 	uint32_t    section_size            = 0;
 	/* Mask to power down whole RAM bank. */
-	uint32_t    ram_bank_power_off_mask = 0xFFFFFFFF;
+	uint32_t    ram_bank_power_off_mask = 0x0000FFFF;
 	/* Mask to select sections of RAM bank to power off. */
 	uint32_t    mask_off;
 
@@ -109,8 +109,7 @@ void power_down_unused_ram(void)
 			section_id,
 			bank_id);
 
-		mask_off = (NRF_POWER_RAMPOWER_S0POWER << section_id);
-		mask_off |= (NRF_POWER_RAMPOWER_S0RETENTION << section_id);
+		mask_off = ((1 << section_id) << NRF_POWER_RAMPOWER_S0POWER);
 
 		nrf_power_rampower_mask_off(NRF_POWER, bank_id, mask_off);
 		section_id--;


### PR DESCRIPTION
This is a follow up on https://github.com/nrfconnect/sdk-nrf/pull/2653.

The ram_pwrdn functionality was not disabling all unused RAM when only part of the block was to be disabled.
There was no need to adjust retenetion settings as it is disabled by default.
The Kconfig documentation has been adjusted to clarify  that the RAM in the System On mode is powered off.
