### PR TITLE
mpsl: subsys: Add support for nrf21540_gpio and sky66112-11

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -185,6 +185,9 @@
 
 .. _`nRF52810 Product Specification`: https://infocenter.nordicsemi.com/topic/ps_nrf52810/keyfeatures_html5.html
 
+.. _`nRF21540`: https://infocenter.nordicsemi.com/topic/struct_fem/struct/nrf21540.html
+.. _`nRF21540 Product Specification`: https://infocenter.nordicsemi.com/topic/struct_fem/struct/nrf21540_ps.html
+
 .. _`Programming DK boards using nrfjprog`: https://infocenter.nordicsemi.com/topic/ug_nrf5x_cltools/UG/cltools/nrf5x_nrfjprogexe.html
 
 .. _`Nordic Thingy:91 User Guide`: https://infocenter.nordicsemi.com/topic/ug_thingy91/UG/thingy91/intro/frontpage.html
@@ -505,3 +508,5 @@
 .. _`NMEA`: https://www.gpsworld.com/what-exactly-is-gps-nmea-data/
 
 .. _`Baltimore CyberTrust Root certificate`: https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem
+
+.. _`SKY66112-11 page`: https://www.skyworksinc.com/en/Products/Front-end-Modules/SKY66112-11

--- a/doc/nrf/ug_app_dev.rst
+++ b/doc/nrf/ug_app_dev.rst
@@ -19,3 +19,4 @@ The following user guides introduce important concepts that you should be  famil
    ug_bootloader
    ug_unity_testing
    ug_tfm
+   ug_radio_fem

--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -1,0 +1,207 @@
+.. _ug_radio_fem:
+
+Radio Front-end Module (FEM) support
+####################################
+
+This guide describes how to add support for 2 different Front-End Modules (FEM) implementations to your application in |NCS|.
+
+|NCS| allows you to extend the radio range of your board with an implementation of the Front-End Modules.
+Front end modules are range extenders, used for boosting the link robustness and link budget of wireless SoCs.
+
+The FEM support is based on the :ref:`nrfxlib:mpsl_fem`, which is integrated in the nrfxlib's MPSL library.
+This library provides nRF21540 GPIO and Simple GPIO implementations, for 3-pin and 2-pin PA/LNA interfaces, respectively.
+
+The implementations described in this guide are the following:
+
+* :ref:`ug_radio_fem_nrf21540_gpio` - For the nRF21540 GPIO implementation that uses nRF21540.
+* :ref:`ug_radio_fem_skyworks` - For the Simple GPIO implementation that uses the SKY66112-11 device.
+
+These methods are only available to protocol drivers that are using FEM features provided by the MPSL library in multiprotocol scenarios.
+They are also valid for cases where an application uses just one protocol, but benefits from features provided by MPSL.
+To avoid conflicts, check the protocol documentation to see if it uses FEM support provided by MPSL.
+
+Work is underway to make the protocols shipped with |NCS| use FEM, but none of them currently have this feature.
+
+|NCS| provides a friendly wrapper that configures FEM based on Devicetree (DTS) and Kconfig information.
+To enable FEM support, you must enable FEM and MPSL, and add an ``nrf_radio_fem`` node in the Devicetree file.
+The node can also be provided by the target board Devicetree file or by an overlay file.
+See :ref:`zephyr:dt-guide` for more information about the DTS data structure, and :ref:`zephyr:dt_vs_kconfig` for information about differences between DTS and Kconfig.
+
+.. _ug_radio_fem_requirements:
+
+Enabling FEM and MPSL
+*********************
+
+Before you add the Devicetree node in your application, complete the following steps:
+
+1. Add support for the MPSL library in your application.
+   The MPSL library provides API to configure FEM.
+   See :ref:`nrfxlib:mpsl_lib` in the nrfxlib documentation for details.
+#. Enable support for MPSL implementation in |NCS| by setting the :option:`CONFIG_MPSL` Kconfig option to ``y``.
+
+.. _ug_radio_fem_nrf21540_gpio:
+
+Adding support for nRF21540 in GPIO mode
+****************************************
+
+The nRF21540 device is a range extender that can be used with the nRF52 and nRF53 Series devices.
+For more information about this device, see the `nRF21540`_ documentation.
+
+The nRF21540 GPIO mode implementation of FEM is compatible with this device and implements the 3-pin PA/LNA interface.
+
+.. note::
+  In the naming convention used in the API of the MPSL library, the functionalities designated as ``PA`` and ``LNA`` apply to the ``tx-en-gpios`` and ``rx-en-gpios`` pins listed below, respectively.
+
+To use nRF21540 in GPIO mode, complete the following steps:
+
+1. Add the following node in the Devicetree file:
+
+.. code-block::
+
+   / {
+       nrf_radio_fem: name_of_fem_node {
+           compatible  = "nordic,nrf21540-fem";
+           tx-en-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+           rx-en-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+           pdn-gpios   = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+       };
+   };
+
+#. Optionally replace the node name ``name_of_fem_node``.
+#. Replace the pin numbers provided for each of the required properties:
+
+   * ``tx-en-gpios`` - GPIO characteristic of the device that controls the ``TX_EN`` signal of nRF21540.
+   * ``rx-en-gpios`` - GPIO characteristic of the device that controls the ``RX_EN`` signal of nRF21540.
+   * ``pdn-gpios`` - GPIO characteristic of the device that controls the ``PDN`` signal of nRF21540.
+
+   These properties correspond to ``TX_EN``, ``RX_EN``, and ``PDN`` pins of nRF21540 that are supported by software FEM.
+
+   Type ``phandle-array`` is used here, which is common in Zephyr's Devicetree to describe GPIO signals.
+   The first element ``&gpio0`` refers to the GPIO port ("port 0" has been selected in the example shown).
+   The second element is the pin number on that port.
+   The last element must be ``GPIO_ACTIVE_HIGH`` for nRF21540, but for a different FEM module you can use ``GPIO_ACTIVE_LOW``.
+
+   The state of the remaining control pins should be set in other ways and according to `nRF21540 Product Specification`_.
+#. Set the following Kconfig parameters to assign unique GPIOTE channel numbers to be used exclusively by the FEM driver:
+
+   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_TX_EN`
+   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_RX_EN`
+   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN`
+
+#. Set the following Kconfig parameters to assign unique PPI channel numbers to be used exclusively by the FEM driver:
+
+   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_0`
+   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_1`
+   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_2`
+
+Optional properties
+===================
+
+The following properties are optional and can be added to the Devicetree node if needed:
+
+* Properties that control the timing of interface signals:
+
+  * ``tx-en-settle-time-us`` - Minimal time interval between asserting the ``TX_EN`` signal and starting the radio transmission, in microseconds.
+  * ``rx-en-settle-time-us`` - Minimal time interval between asserting the ``RX_EN`` signal and starting the radio transmission, in microseconds.
+
+    .. important::
+        Values for these two properties cannot be higher than the Radio Ramp-Up time defined by :c:macro:`TX_RAMP_UP_TIME` and :c:macro:`RX_RAMP_UP_TIME`.
+        If the value is too high, the radio driver will not work properly and will not control FEM.
+        Moreover, setting a value that is lower than the default value can cause disturbances in the radio transmission, because FEM may be triggered too late.
+
+  * ``pdn-settle-time-us`` - Time interval before the PA or LNA activation reserved for the FEM ramp-up, in microseconds.
+  * ``trx-hold-time-us`` - Time interval for which the FEM is kept powered up after the event that triggers the PDN deactivation, in microseconds.
+
+  The default values of these properties are appropriate for default hardware and most use cases.
+  You can override them if you need additional capacitors, for example when using custom hardware.
+  In such cases, add the property name under the required properties in the device tree node and set a new custom value.
+
+  .. note::
+    These values have some constraints.
+    For details, see `nRF21540 Product Specification`_.
+
+.. _ug_radio_fem_skyworks:
+
+Adding support for SKY66112-11
+******************************
+
+SKY66112-11 is one of many FEM devices that support the 2-pin PA/LNA interface.
+
+.. note::
+  In the naming convention used in the API of the MPSL library, the functionalities designated as ``PA`` and ``LNA`` apply to the ``ctx-gpios`` and ``crx-gpios`` pins listed below, respectively.
+
+To use the Simple GPIO implementation of FEM with SKY66112-11, complete the following steps:
+
+1. Add the following node in the Devicetree file:
+
+.. code-block::
+
+   / {
+       nrf_radio_fem: name_of_fem_node {
+           compatible = "skyworks,sky66112-11", "generic-fem-two-ctrl-pins";
+           ctx-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+           crx-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+       };
+   };
+
+#. Optionally replace the node name ``name_of_fem_node``.
+#. Replace the pin numbers provided for each of the required properties:
+
+   * ``ctx-gpios`` - GPIO characteristic of the device that controls the ``CTX`` signal of SKY66112-11.
+   * ``crx-gpios`` - GPIO characteristic of the device that controls the ``CRX`` signal of SKY66112-11.
+
+   These properties correspond to ``CTX`` and ``CRX`` pins of SKY66112-11 that are supported by software FEM.
+
+   Type ``phandle-array`` is used here, which is common in Zephyr's Devicetree to describe GPIO signals.
+   The first element ``&gpio0`` refers to the GPIO port ("port 0" has been selected in the example shown).
+   The second element is the pin number on that port.
+   The last element must be ``GPIO_ACTIVE_HIGH`` for SKY66112-11, but for a different FEM module you can use ``GPIO_ACTIVE_LOW``.
+
+   The state of the other control pins should be set according to the SKY66112-11 documentation.
+   See the official `SKY66112-11 page`_ for more information.
+#. Set the following Kconfig parameters to assign unique GPIOTE channel numbers to be used exclusively by the FEM driver:
+
+   * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CTX`
+   * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CRX`
+
+#. Set the following Kconfig parameters to assign unique PPI channel numbers to be used exclusively by the FEM driver:
+
+   * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_0`
+   * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_1`
+
+Optional properties
+===================
+
+The following properties are optional and can be added to the Devicetree node if needed:
+
+* Properties that control the timing of interface signals:
+
+  * ``ctx-settle-time-us`` - Minimal time interval between asserting the ``CTX`` signal and starting the radio transmission, in microseconds.
+  * ``crx-settle-time-us`` - Minimal time interval between asserting the ``CRX`` signal and starting the radio transmission, in microseconds.
+
+  The default values of these properties are appropriate for default hardware and most use cases.
+  You can override them if you need additional capacitors, for example when using custom hardware.
+  In such cases, add the property name under the required properties in the device tree node and set a new custom value.
+
+  .. note::
+    These values have some constraints.
+    For details, see the official documentation at the `SKY66112-11 page`_.
+
+* Properties that inform protocol drivers about gains provided by SKY66112-11:
+
+  * ``tx-gain-db`` - Transmission gain value in dB.
+  * ``rx-gain-db`` - Reception gain value in dB.
+
+  The default values are accurate for SKY66112-11 but can be overridden when using a similar device with a different gain.
+
+.. _ug_radio_fem_incomplete_connections:
+
+Use case of incomplete physical connections to the FEM module
+*************************************************************
+
+The method of configuring FEM using the Devicetree file allows you to opt out of using some pins.
+For example if power consumption is not critical, the nRF21540 module PDN pin can be connected to a fixed logic level.
+Then there is no need to define a GPIO to control the PDN signal. The line ``pdn-gpios = < .. >;`` can then be removed from the Devicetree file.
+
+Generally, if pin ``X`` is not used, the ``X-gpios = < .. >;`` property can be removed.
+This applies to all properties with a ``-gpios`` suffix, for both nRF21540 and SKY66112-11.

--- a/dts/bindings/radio_fem/generic-fem-two-ctrl-pins.yaml
+++ b/dts/bindings/radio_fem/generic-fem-two-ctrl-pins.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+description: >
+    This is a representation of generic Radio Front-End module
+    that has a two-pin control interface (CTX, CRX).
+
+compatible: "generic-fem-two-ctrl-pins"
+
+include: base.yaml
+
+properties:
+    ctx-gpios:
+        type: phandle-array
+        required: false
+        description: >
+            Gpio of the SOC controlling CTX pin of the FEM device.
+
+    crx-gpios:
+        type: phandle-array
+        required: false
+        description: >
+            Gpio of the SOC controlling CRX pin of the FEM device.
+
+    ctx-settle-time-us:
+        type: int
+        description: >
+            Settling time in microseconds from activation of CTX to transmit.
+
+    crx-settle-time-us:
+        type: int
+        description: >
+            Settling time in microseconds from activation of CRX to receive.
+
+    tx-gain-db:
+        type: int
+        description: >
+            TX gain of the PA amplifier of the FEM device in dB.
+
+    rx-gain-db:
+        type: int
+        description: >
+            RX gain of the LNA amplifier of the FEM device in dB.

--- a/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
+++ b/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
@@ -1,0 +1,63 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+description: >
+    This is a representation of the Skyworks SKY66112-11 Radio Front-End module.
+    It is supplementing the generic representation of FEM with settling time and
+    gain values appropriate for SKY66112-11 device.
+
+compatible: "skyworks,sky66112-11"
+
+include: generic-fem-two-ctrl-pins.yaml
+
+properties:
+    ctx-settle-time-us:
+        type: int
+        default: 23
+        description: >
+            Settling time in microseconds from activation of CTX to transmit.
+
+            The default value has been determined experimentally: it is the
+            minimum time interval between asserting the CTX signal and starting
+            the radio transmission, which does not generate unacceptable
+            interference level on adjacent channels. The tests concerned a
+            configuration in which nRF5x SoC controlling the SKY66112-11.
+            The value can be adjusted for other tuned configurations.
+
+    crx-settle-time-us:
+        type: int
+        default: 5
+        description: >
+            Settling time in microseconds from activation of CRX to receive.
+
+            The default value has been determined experimentally: it is the
+            minimum time interval between asserting the CRX signal and starting
+            the radio reception, which does not degrade transmission quality
+            indicators (compared to a constantly turned on FEM LNA). The tests
+            concerned a configuration in which nRF5x SoC controlling
+            the SKY66112-11. The value can be adjusted for other tuned
+            configurations.
+
+    tx-gain-db:
+        type: int
+        default: 22
+        description: >
+            TX gain of the PA amplifier of SKY66112-11 in dB.
+
+            Default value is based on Table 5 of the SKY66112-11 data sheet
+            (July 19, 2019). This is a fixed parameter of the device. The value
+            can be changed if, instead of SKY66112-11, another device with
+            different gain, but compatible with the control interface via the
+            CTX, CRX pins is used.
+
+    rx-gain-db:
+        type: int
+        default: 11
+        description: >
+            RX gain of the LNA amplifier of SKY66112-11 in dB.
+
+            Default value is based on Table 5 of the SKY66112-11 data sheet
+            (July 19, 2019). This is a fixed parameter of the device. The value
+            can be changed if, instead of SKY66112-11, another device with
+            different gain, but compatible with the control interface via the
+            CTX, CRX pins is used.

--- a/subsys/mpsl/CMakeLists.txt
+++ b/subsys/mpsl/CMakeLists.txt
@@ -9,3 +9,5 @@ zephyr_library()
 zephyr_library_sources(
   mpsl_init.c
   )
+
+zephyr_library_sources_ifdef(CONFIG_MPSL_FEM mpsl_fem.c)

--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -25,6 +25,8 @@ config MPSL_TIMESLOT_SESSION_COUNT
 	help
 	  Maximum number of timeslot sessions.
 
+rsource "Kconfig.fem"
+
 module=MPSL
 module-str=MPSL
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/mpsl/Kconfig.fem
+++ b/subsys/mpsl/Kconfig.fem
@@ -1,0 +1,145 @@
+#
+# Copyright (c) 2019 - 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+DT_COMPAT_NORDIC_NRF21540_GPIO := nordic,nrf21540-fem
+DT_COMPAT_GENERIC_FEM_2_CTRL_PIN := generic-fem-two-ctrl-pins
+
+config MPSL_FEM_NRF21540_GPIO_SUPPORT
+	bool
+	default $(dt_nodelabel_has_compat,nrf_radio_fem,$(DT_COMPAT_NORDIC_NRF21540_GPIO)) && !BT
+
+config MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT
+	bool
+	default $(dt_nodelabel_has_compat,nrf_radio_fem,$(DT_COMPAT_GENERIC_FEM_2_CTRL_PIN))
+
+config MPSL_FEM
+	bool "Radio front-end module (FEM) support"
+# MPSL FEM is not supported on 53 yet
+	depends on !(SOC_NRF5340_CPUAPP || SOC_NRF5340_CPUNET) && \
+		   (MPSL_FEM_NRF21540_GPIO_SUPPORT || MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT)
+	default y
+	help
+	  Controls if front-end module (FEM) is to be configured and enabled
+	  when MPSL is initialized. Default type of FEM to use depends on which
+	  compatible nodes are in devicetree.
+
+if MPSL_FEM
+
+choice MPSL_FEM_CHOICE
+	prompt "Radio front-end module (FEM) type"
+
+config MPSL_FEM_NRF21540_GPIO
+	depends on MPSL_FEM_NRF21540_GPIO_SUPPORT
+	bool "nRF21540 front-end module in GPIO mode"
+	help
+	  FEM device is nRF21540 and its control mode is GPIO.
+	  Note: nRF21540 is unavailable when Bluetooth LE is enabled
+
+config MPSL_FEM_SIMPLE_GPIO
+	depends on MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT
+	bool "Generic front-end module with two-pin control"
+	help
+	  FEM device has a generic two-pin control interface.
+	  This option was originally designed to support the SKY66112-11,
+	  but is potentially compatible with other devices with the same
+	  control method.
+
+endchoice	# MPSL_FEM_CHOICE
+
+if MPSL_FEM_NRF21540_GPIO
+
+config MPSL_FEM_NRF21540_GPIO_GPIOTE_TX_EN
+	int "GPIOTE channel number used to control TX_EN pin"
+	default 7
+	help
+	  Unique GPIOTE channel number to be used exclusively by the FEM driver
+	  for TX_EN pin control.
+
+config MPSL_FEM_NRF21540_GPIO_GPIOTE_RX_EN
+	int "GPIOTE channel number used to control RX_EN pin"
+	default 6
+	help
+	  Unique GPIOTE channel number to be used exclusively by the FEM driver
+	  for RX_EN pin control.
+
+config MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN
+	int "GPIOTE channel number used to control PDN pin"
+	default 5
+	help
+	  Unique GPIOTE channel number to be used exclusively by the FEM driver
+	  for PDN pin control.
+
+config MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_0
+	int "PPI channel reserved for the front-end module"
+	default 15
+	help
+	  The first of three unique PPI channel numbers to be used exclusively
+	  by the FEM driver.
+
+config MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_1
+	int "PPI channel reserved for the front-end module"
+	default 16
+	help
+	  The second of three unique PPI channel numbers to be used exclusively
+	  by the FEM driver.
+
+config MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_2
+	int "PPI channel reserved for the front-end module"
+	default 5
+	help
+	  Third of three unique PPI channel numbers to be used exclusively
+	  by the FEM driver.
+
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	int "TX gain of the nRF21540 PA amplifier in dB"
+	default 20
+	help
+	  The default value of 20 dB is based on nRF21540 Product Specification
+	  (v1.0) and it corresponds to the configuration in which the pin
+	  MODE=0 and pin POUTA_SEL=0
+
+config MPSL_FEM_NRF21540_RX_GAIN_DB
+	int "RX gain of the nRF21540 LNA amplifier in dB"
+	default 13
+	help
+	  The default value of 13 dB is based on nRF21540 Product Specification
+	  (v1.0)
+
+endif
+
+if MPSL_FEM_SIMPLE_GPIO
+
+config MPSL_FEM_SIMPLE_GPIO_GPIOTE_CTX
+	int "GPIOTE channel number used to control CTX pin"
+	default 7
+	help
+	  Unique GPIOTE channel number to be used exclusively by the FEM driver
+	  for CTX pin control.
+
+config MPSL_FEM_SIMPLE_GPIO_GPIOTE_CRX
+	int "GPIOTE channel number used to control CRX pin"
+	default 6
+	help
+	  Unique GPIOTE channel number to be used exclusively by the FEM driver
+	  for RTX pin control.
+
+config MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_0
+	int "PPI channel reserved for the front-end module"
+	default 15
+	help
+	  The first of two unique PPI channel numbers to be used exclusively
+	  by the FEM driver.
+
+config MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_1
+	int "PPI channel reserved for the front-end module"
+	default 16
+	help
+	  The second of two unique PPI channel numbers to be used exclusively
+	  by the FEM driver.
+
+endif
+
+endif	# MPSL_FEM

--- a/subsys/mpsl/mpsl_fem.c
+++ b/subsys/mpsl/mpsl_fem.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <devicetree.h>
+#include <drivers/gpio.h>
+#include <string.h>
+#include <sys/__assert.h>
+#include <mpsl_fem_config_nrf21540_gpio.h>
+#include <mpsl_fem_config_simple_gpio.h>
+
+#define MPSL_FEM_GPIO_POLARITY_GET(dt_property) \
+	((GPIO_ACTIVE_LOW & \
+	  DT_GPIO_FLAGS(DT_NODELABEL(nrf_radio_fem), dt_property)) \
+	 ? false : true)
+
+#define MPSL_FEM_GPIO_INVALID_PIN        0xFFU
+#define MPSL_FEM_GPIOTE_INVALID_CHANNEL  0xFFU
+#define MPSL_FEM_DISABLED_GPIO_CONFIG_INIT \
+	.enable       = false, \
+	.active_high  = true, \
+	.gpio_pin     = MPSL_FEM_GPIO_INVALID_PIN, \
+	.gpiote_ch_id = MPSL_FEM_GPIOTE_INVALID_CHANNEL
+
+static void fem_pin_num_correction(uint8_t *p_gpio_pin, const char *gpio_lbl)
+{
+	(void)p_gpio_pin;
+
+	/* The pin numbering in the FEM configuration API follows the
+	 * convention:
+	 *   pin numbers 0..31 correspond to the gpio0 port
+	 *   pin numbers 32..63 correspond to the gpio1 port
+	 *
+	 * Values obtained from devicetree are here adjusted to the ranges
+	 * given above.
+	 */
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio0), okay)
+	if (strcmp(gpio_lbl, DT_LABEL(DT_NODELABEL(gpio0))) == 0) {
+		return;
+	}
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio1), okay)
+	if (strcmp(gpio_lbl, DT_LABEL(DT_NODELABEL(gpio1))) == 0) {
+		*p_gpio_pin += 32;
+		return;
+	}
+#endif
+
+	__ASSERT(false, "Unknown GPIO port DT label");
+}
+
+#if IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_GPIO)
+static int fem_nrf21540_gpio_configure(void)
+{
+	/* FEM configuration requires gpiote and ppi channels.
+	 * Currently there is no reliable common method to dynamically
+	 * allocate such channels. FEM module needs only "some" channels
+	 * to use whichever they are, but FEM needs them for exclusive use
+	 * and does not enable them immediately.
+	 *
+	 * When common api to assign gpiote and ppi channels is available
+	 * current solution based on macros coming from Kconfig should be
+	 * reworked.
+	 */
+
+#if !DT_NODE_EXISTS(DT_NODELABEL(nrf_radio_fem))
+#error Node with label 'nrf_radio_fem' not found in the devicetree.
+#endif
+
+	mpsl_fem_nrf21540_gpio_interface_config_t cfg = {
+		.fem_config = {
+			.pa_time_gap_us  =
+				DT_PROP(DT_NODELABEL(nrf_radio_fem),
+					tx_en_settle_time_us),
+			.lna_time_gap_us =
+				DT_PROP(DT_NODELABEL(nrf_radio_fem),
+					rx_en_settle_time_us),
+			.pdn_settle_us   =
+				DT_PROP(DT_NODELABEL(nrf_radio_fem),
+					pdn_settle_time_us),
+			.trx_hold_us     =
+				DT_PROP(DT_NODELABEL(nrf_radio_fem),
+					trx_hold_time_us),
+			.pa_gain_db      =
+				CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB,
+			.lna_gain_db     =
+				CONFIG_MPSL_FEM_NRF21540_RX_GAIN_DB
+		},
+		.pa_pin_config = {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), tx_en_gpios)
+			.enable       = true,
+			.active_high  =
+				MPSL_FEM_GPIO_POLARITY_GET(tx_en_gpios),
+			.gpio_pin     =
+				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
+					    tx_en_gpios),
+			.gpiote_ch_id =
+				CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_TX_EN
+#else
+			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+#endif
+		},
+		.lna_pin_config = {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), rx_en_gpios)
+			.enable       = true,
+			.active_high  =
+				MPSL_FEM_GPIO_POLARITY_GET(rx_en_gpios),
+			.gpio_pin     =
+				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
+					    rx_en_gpios),
+			.gpiote_ch_id =
+				CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_RX_EN
+#else
+			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+#endif
+		},
+		.pdn_pin_config = {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
+			.enable       = true,
+			.active_high  =
+				MPSL_FEM_GPIO_POLARITY_GET(pdn_gpios),
+			.gpio_pin     =
+				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
+					    pdn_gpios),
+			.gpiote_ch_id =
+				CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN
+#else
+			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+#endif
+		},
+		.ppi_channels = {
+			CONFIG_MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_0,
+			CONFIG_MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_1,
+			CONFIG_MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_2
+		}
+	};
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), tx_en_gpios)
+	fem_pin_num_correction(&cfg.pa_pin_config.gpio_pin,
+			       DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem),
+					     tx_en_gpios));
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), rx_en_gpios)
+	fem_pin_num_correction(&cfg.lna_pin_config.gpio_pin,
+			       DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem),
+					     rx_en_gpios));
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
+	fem_pin_num_correction(&cfg.pdn_pin_config.gpio_pin,
+			       DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem),
+					     pdn_gpios));
+#endif
+
+	return mpsl_fem_nrf21540_gpio_interface_config_set(&cfg);
+}
+#endif
+
+#if IS_ENABLED(CONFIG_MPSL_FEM_SIMPLE_GPIO)
+static int fem_simple_gpio_configure(void)
+{
+	/* FEM configuration requires gpiote and ppi channels.
+	 * Currently there is no reliable common method to dynamically
+	 * allocate such channels. FEM module needs only "some" channels
+	 * to use whichever they are, but FEM needs them for exclusive use
+	 * and does not enable them immediately.
+	 *
+	 * When common api to assign gpiote and ppi channels is available
+	 * current solution based on macros coming from Kconfig should be
+	 * reworked.
+	 */
+
+#if !DT_NODE_EXISTS(DT_NODELABEL(nrf_radio_fem))
+#error Node with label 'nrf_radio_fem' not found in the devicetree.
+#endif
+
+	mpsl_fem_simple_gpio_interface_config_t cfg = {
+		.fem_config = {
+			.pa_time_gap_us  =
+				DT_PROP(DT_NODELABEL(nrf_radio_fem),
+					ctx_settle_time_us),
+			.lna_time_gap_us =
+				DT_PROP(DT_NODELABEL(nrf_radio_fem),
+					crx_settle_time_us),
+			.pa_gain_db      =
+				DT_PROP(DT_NODELABEL(nrf_radio_fem),
+					tx_gain_db),
+			.lna_gain_db     =
+				DT_PROP(DT_NODELABEL(nrf_radio_fem),
+					rx_gain_db)
+		},
+		.pa_pin_config = {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ctx_gpios)
+			.enable       = true,
+			.active_high  =
+				MPSL_FEM_GPIO_POLARITY_GET(ctx_gpios),
+			.gpio_pin     =
+				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
+					    ctx_gpios),
+			.gpiote_ch_id =
+				CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CTX
+#else
+			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+#endif
+		},
+		.lna_pin_config = {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), crx_gpios)
+			.enable       = true,
+			.active_high  =
+				MPSL_FEM_GPIO_POLARITY_GET(crx_gpios),
+			.gpio_pin     =
+				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
+					    crx_gpios),
+			.gpiote_ch_id =
+				CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CRX
+#else
+			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+#endif
+		},
+		.ppi_channels = {
+			CONFIG_MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_0,
+			CONFIG_MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_1
+		}
+	};
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ctx_gpios)
+	fem_pin_num_correction(&cfg.pa_pin_config.gpio_pin,
+			       DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem),
+					     ctx_gpios));
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), crx_gpios)
+	fem_pin_num_correction(&cfg.lna_pin_config.gpio_pin,
+			       DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem),
+					     crx_gpios));
+#endif
+
+	return mpsl_fem_simple_gpio_interface_config_set(&cfg);
+}
+#endif
+
+int mpsl_fem_configure(void)
+{
+	int err = 0;
+
+#if IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_GPIO)
+	err = fem_nrf21540_gpio_configure();
+#elif IS_ENABLED(CONFIG_MPSL_FEM_SIMPLE_GPIO)
+	err = fem_simple_gpio_configure();
+#else
+#error Incomplete CONFIG_MPSL_FEM configuration. No supported FEM type found.
+#endif
+
+	return err;
+}

--- a/subsys/mpsl/mpsl_fem_internal.h
+++ b/subsys/mpsl/mpsl_fem_internal.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @brief Internal MPSL FEM initialization
+ */
+
+#ifndef MPSL_FEM_INTERNAL__
+#define MPSL_FEM_INTERNAL__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int mpsl_fem_configure(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MPSL_FEM_INTERNAL__ */

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -11,6 +11,7 @@
 #include <sys/__assert.h>
 #include <mpsl.h>
 #include <mpsl_timeslot.h>
+#include "mpsl_fem_internal.h"
 #include "multithreading_lock.h"
 #if defined(CONFIG_NRFX_DPPI)
 #include <nrfx_dppi.h>
@@ -183,6 +184,13 @@ static int mpsl_lib_init(const struct device *dev)
 			   mpsl_rtc0_isr_wrapper, IRQ_ZERO_LATENCY);
 	IRQ_DIRECT_CONNECT(RADIO_IRQn, MPSL_HIGH_IRQ_PRIORITY,
 			   mpsl_radio_isr_wrapper, IRQ_ZERO_LATENCY);
+
+#if IS_ENABLED(CONFIG_MPSL_FEM)
+	err = mpsl_fem_configure();
+	if (err) {
+		return err;
+	}
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
User has the ability to use front-end module (FEM) type by
adding a node with label nrf_radio_fem to the devicetree.
When mpsl library is initialized selected FEM is configured
and becomes ready to use by higher layer protocol drivers.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>