### PR TITLE
subsys: net: lib: nrf_cloud: fix typo in nrf_cloud_transport.c

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -403,7 +403,7 @@ static int nct_provision(void)
 		/* Delete certificates */
 		nrf_sec_tag_t sec_tag = CONFIG_NRF_CLOUD_SEC_TAG;
 
-		for (enum modem_key_mgnt_cred_type_t type = 0; type < 5;
+		for (enum modem_key_mgnt_cred_type type = 0; type < 5;
 		     type++) {
 			err = modem_key_mgmt_delete(sec_tag, type);
 			LOG_DBG("modem_key_mgmt_delete(%u, %d) => result = %d",


### PR DESCRIPTION
Fixed small typo in nrf_cloud_transport.c

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>