### PR TITLE
doc: add table-from-rows Sphinx extension and update sample's README.rst files

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -83,6 +83,7 @@ sys.path.append(os.path.join(NRF_BASE, 'scripts', 'sphinx_extensions'))
 extensions = ['sphinx.ext.intersphinx',
               'breathe',
               'interbreathe',
+              'table_from_rows',
               'sphinx.ext.ifconfig',
               'sphinxcontrib.mscgen',
               'sphinx_tabs.tabs',

--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -1,0 +1,83 @@
+.. heading
+
+| Hardware platforms | PCA | Board name | Build target |
+
+.. nrf52833dk_nrf52833
+
+| :ref:`nRF52833 DK <ug_nrf52>` | PCA10010   | :ref:`nrf52833dk_nrf52833 <nrf52833dk_nrf52833>` | ``nrf52833dk_nrf52833`` |
+
+.. nrf52dk_nrf52832
+
+| :ref:`nRF52 DK <ug_nrf52>` | PCA10040 | :ref:`nrf52dk_nrf52832 <nrf52dk_nrf52832>` | ``nrf52dk_nrf52832`` |
+
+.. nrf52840dk_nrf52840
+
+| :ref:`nRF52840 DK <ug_nrf52>` | PCA10056 | :ref:`nrf52840dk_nrf52840 <nrf52840dk_nrf52840>` | ``nrf52840dk_nrf52840`` |
+
+.. nrf52840dongle_nrf52840
+
+| :ref:`nRF52840 Dongle <ug_nrf52>` | PCA10059 | :ref:`nrf52840dongle_nrf52840 <nrf52840dongle_nrf52840>` | ``nrf52840dongle_nrf52840`` |
+
+.. nrf9160dk_nrf9160
+
+| :ref:`nRF9160 DK <ug_nrf9160>` | PCA10090 | :ref:`nrf9160dk_nrf9160 <nrf9160dk_nrf9160>` | ``nrf9160dk_nrf9160``  |
+
+.. nrf9160dk_nrf9160ns
+
+| :ref:`nRF9160 DK <ug_nrf9160>` | PCA10090 | :ref:`nrf9160dk_nrf9160 <nrf9160dk_nrf9160>` | ``nrf9160dk_nrf9160ns`` |
+
+.. nrf5340pdk_nrf5340_cpuapp
+
+| :ref:`nRF5340 PDK <ug_nrf5340>` | PCA10095 | :ref:`nrf5340pdk_nrf5340 <nrf5340pdk_nrf5340>` | ``nrf5340pdk_nrf5340_cpuapp`` |
+
+.. nrf5340pdk_nrf5340_cpuappns
+
+| :ref:`nRF5340 PDK <ug_nrf5340>` | PCA10095 | :ref:`nrf5340pdk_nrf5340 <nrf5340pdk_nrf5340>` | ``nrf5340pdk_nrf5340_cpuappns`` |
+
+.. nrf5340pdk_nrf5340_cpunet
+
+| :ref:`nRF5340 PDK <ug_nrf5340>` | PCA10095 | :ref:`nrf5340pdk_nrf5340 <nrf5340pdk_nrf5340>` | ``nrf5340pdk_nrf5340_cpunet`` |
+
+.. nrf52833dongle_nrf52833
+
+| nRF52833 Dongle | PCA10111 | nrf52833dongle_nrf52833 | ``nrf52833dongle_nrf52833`` |
+
+.. nrf52820dongle_nrf52820
+
+| nRF52820 Dongle | PCA10114 | nrf52820dongle_nrf52820 | ``nrf52820dongle_nrf52820`` |
+
+.. thingy91_nrf9160ns
+
+| :ref:`Thingy:91 <ug_thingy91>` | PCA20035 | thingy91_nrf9160 | ``thingy91_nrf9160ns`` |
+
+.. nrf52kbd_nrf52832
+
+| nRF52832 Desktop Keyboard | PCA20037 | nrf52kbd_nrf52832 | ``nrf52kbd_nrf52832`` |
+
+.. nrf52840gmouse_nrf52840
+
+| nRF52840 Gaming Mouse | PCA20041 | nrf52840gmouse_nrf52840 | ``nrf52840gmouse_nrf52840`` |
+
+.. nrf52dmouse_nrf52832
+
+| nRF52832 Desktop Mouse | PCA20044 | nrf52dmouse_nrf52832 | ``nrf52dmouse_nrf52832`` |
+
+.. nrf52810dmouse_nrf52810
+
+| nRF52810 Desktop Mouse | PCA20045 | nrf52810dmouse_nrf52810 | ``nrf52810dmouse_nrf52810`` |
+
+.. thingy91_nrf52840
+
+| :ref:`Thingy:91 <ug_thingy91>` | PCA20035 | thingy91_nrf52840 | ``thingy91_nrf52840`` |
+
+.. nrf5340pdk_nrf5340_cpuapp_and_cpuappns
+
+| :ref:`nRF5340 PDK <ug_nrf5340>` | PCA10095 | :ref:`nrf5340pdk_nrf5340 <nrf5340pdk_nrf5340>` | ``nrf5340pdk_nrf5340_cpuapp``   |
+|                                 |          |                                                |                                 |
+|                                 |          |                                                | ``nrf5340pdk_nrf5340_cpuappns`` |
+
+.. nrf5340pdk_nrf5340_cpuapp_and_cpunet
+
+| :ref:`nRF5340 PDK <ug_nrf5340>` | PCA10095 | :ref:`nrf5340pdk_nrf5340 <nrf5340pdk_nrf5340>` | ``nrf5340pdk_nrf5340_cpuapp`` |
+|                                 |          |                                                |                               |
+|                                 |          |                                                | ``nrf5340pdk_nrf5340_cpunet`` |

--- a/doc/nrf/templates/sample_README.rst
+++ b/doc/nrf/templates/sample_README.rst
@@ -28,9 +28,8 @@ Requirements
 ************
 
 .. note::
-   * Supported kits are listed in a table, which is included from the :file:`doc/nrf/includes/boardname_tables/sample_boardnames.txt` file.
-     Check if a suitable set already exists, and if not, add a new one.
-     Select the set in the ``:start-after:`` and ``:end-before:`` configuration.
+   * Supported kits are listed in a table, which is composed of rows from the :file:`doc/nrf/includes/sample_board_rows.txt` file.
+     Select the required rows in the ``:rows:`` configuration.
    * If only one kit is supported, replace the introduction text with "The sample supports the following development kit:".
    * If several kits are required to test the sample, state it after the table (for example, "You can use one or more of the development kits listed above and mix different development kits.").
    * Mention additional requirements after the table.
@@ -38,9 +37,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set1_start
-   :end-before: set1_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52dk_nrf52832, nrf52840dk_nrf52840
 
 The sample also requires ...
 

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -133,9 +133,9 @@ Requirements
 
 * The following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set20_start
-   :end-before: set20_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpunet
 
 * The Network core
 

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -54,9 +54,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set1_start
-   :end-before: set1_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpuapp_and_cpuappns, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 .. note::
    If you use nRF5340 PDK, add the following options to the configuration of the network sample:

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -76,9 +76,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set2_start
-   :end-before: set2_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -54,9 +54,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set1_start
-   :end-before: set1_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpuapp_and_cpuappns, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 .. note::
    If you use nRF5340 PDK, add the following options to the configuration of the network sample:

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -63,9 +63,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set2_start
-   :end-before: set2_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -63,9 +63,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set2_start
-   :end-before: set2_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/peripheral_bms/README.rst
+++ b/samples/bluetooth/peripheral_bms/README.rst
@@ -17,9 +17,9 @@ Requirements
 
 * One of the following Nordic development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set1_start
-   :end-before: set1_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpuapp_and_cpuappns, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 * A Bluetooth Low Energy dongle or development kit
 

--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -93,9 +93,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set16_start
-   :end-before: set16_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns, nrf5340pdk_nrf5340_cpuapp_and_cpuappns, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 .. _bootloader_build_and_run:
 

--- a/samples/esb/README.rst
+++ b/samples/esb/README.rst
@@ -31,9 +31,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set2_start
-   :end-before: set2_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 You can use any two of the development kits listed above and mix different development kits.
 

--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -24,9 +24,9 @@ Requirements
 
 The sample supports any one of the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set4_start
-   :end-before: set4_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpunet, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 .. note::
    For nRF5340 PDK, this sample is only supported on the network core (nrf5340pdk_nrf5340_cpunet), and the :ref:`nrf5340_empty_app_core` sample must be flashed on the application core.

--- a/samples/nfc/system_off/README.rst
+++ b/samples/nfc/system_off/README.rst
@@ -46,9 +46,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set1_start
-   :end-before: set1_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpuapp_and_cpuappns, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 The sample also requires a smartphone or tablet with the NFC feature.
 

--- a/samples/nrf5340/empty_app_core/README.rst
+++ b/samples/nrf5340/empty_app_core/README.rst
@@ -28,9 +28,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set15_start
-   :end-before: set15_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpuapp_and_cpuappns
 
 Building and running
 ********************

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -22,9 +22,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -106,9 +106,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 The sample requires an `AWS account`_ with access to Simple Storage Service (S3) and the IoT Core service.
 

--- a/samples/nrf9160/aws_iot/README.rst
+++ b/samples/nrf9160/aws_iot/README.rst
@@ -27,9 +27,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set6_start
-   :end-before: set6_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy91_nrf9160ns, nrf9160dk_nrf9160ns
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/cloud_client/README.rst
+++ b/samples/nrf9160/cloud_client/README.rst
@@ -34,9 +34,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set6_start
-   :end-before: set6_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy91_nrf9160ns, nrf9160dk_nrf9160ns
 
 Setup
 *****

--- a/samples/nrf9160/coap_client/README.rst
+++ b/samples/nrf9160/coap_client/README.rst
@@ -28,9 +28,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 The sample also requires a public CoAP server IP address or URL available on the internet.
 

--- a/samples/nrf9160/download/README.rst
+++ b/samples/nrf9160/download/README.rst
@@ -11,9 +11,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 
 .. include:: /includes/spm.txt

--- a/samples/nrf9160/gps/README.rst
+++ b/samples/nrf9160/gps/README.rst
@@ -30,9 +30,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 The sample can be optionally used with the SUPL Client library (for details on download, see :ref:`supl_client`).
 

--- a/samples/nrf9160/http_application_update/README.rst
+++ b/samples/nrf9160/http_application_update/README.rst
@@ -23,9 +23,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 The sample also requires a signed firmware image that is available for download from an HTTP server.
 This image is automatically generated when building the application.

--- a/samples/nrf9160/https_client/README.rst
+++ b/samples/nrf9160/https_client/README.rst
@@ -11,9 +11,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -24,9 +24,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 Additionally, the sample requires a `Nordic Thingy:52`_.
 

--- a/samples/nrf9160/lwm2m_client/README.rst
+++ b/samples/nrf9160/lwm2m_client/README.rst
@@ -44,9 +44,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 The sample also requires an LwM2M server URL address available on the internet.
 For this sample, the URL address mentioned on the `Leshan Demo Server`_ page is used.

--- a/samples/nrf9160/mqtt_simple/README.rst
+++ b/samples/nrf9160/mqtt_simple/README.rst
@@ -15,9 +15,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set5_start
-   :end-before: set5_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/nrf_cloud_agps/README.rst
+++ b/samples/nrf9160/nrf_cloud_agps/README.rst
@@ -49,9 +49,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set6_start
-   :end-before: set6_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy91_nrf9160ns, nrf9160dk_nrf9160ns
 
 The sample also requires an nRF Cloud account.
 

--- a/samples/nrf9160/udp/README.rst
+++ b/samples/nrf9160/udp/README.rst
@@ -11,9 +11,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set6_start
-   :end-before: set6_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy91_nrf9160ns, nrf9160dk_nrf9160ns
 
 Additionally, it supports :ref:`qemu_x86`.
 

--- a/samples/nrf_rpc/entropy_nrf53/README.rst
+++ b/samples/nrf_rpc/entropy_nrf53/README.rst
@@ -37,10 +37,9 @@ Requirements
 
 The sample supports the following development kit:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set21_start
-   :end-before: set21_end
-
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpuapp_and_cpunet
 
 Building and running
 ********************

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -39,9 +39,9 @@ Requirements
 
 The sample supports the following development kits for testing the network status:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set8_start
-   :end-before: set8_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833
 
 Optionally, you can use one or more compatible development kits programmed with this sample or another :ref:`Thread sample <openthread_samples>` for :ref:`testing communication or diagnostics <ot_cli_sample_testing_multiple>` and :ref:`thread_ot_commissioning_configuring_on-mesh`.
 

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -31,9 +31,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set8_start
-   :end-before: set8_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833
 
 You can use one or more of the development kits listed above as the Thread CoAP Client.
 You also need one or more compatible development kits programmed with the :ref:`coap_server_sample` sample.

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -27,9 +27,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set8_start
-   :end-before: set8_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833
 
 You can use one or more of the development kits listed above as the Thread CoAP Server.
 You also need one or more compatible development kits programmed with the :ref:`coap_client_sample` sample.

--- a/samples/openthread/ncp/README.rst
+++ b/samples/openthread/ncp/README.rst
@@ -60,9 +60,9 @@ Requirements
 
 The sample supports the following development kits for testing the network status:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set8_start
-   :end-before: set8_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833
 
 To test the sample, you need at least one development kit NCP board.
 Additional NCP boards can be used for the :ref:`optional testing of network joining <ot_ncp_sample_testing_more_boards>`.

--- a/samples/peripheral/lpuart/README.rst
+++ b/samples/peripheral/lpuart/README.rst
@@ -16,9 +16,9 @@ Requirements
 
 * One of the following development boards:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set22_start
-   :end-before: set22_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf5340pdk_nrf5340_cpuapp
 
 * The following pins shorted:
 

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -32,9 +32,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set4_start
-   :end-before: set4_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpunet, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 You can use any one of the development kits listed above.
 

--- a/samples/profiler/README.rst
+++ b/samples/profiler/README.rst
@@ -25,9 +25,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set9_start
-   :end-before: set9_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 Building and running
 ********************

--- a/samples/sensor/bh1749/README.rst
+++ b/samples/sensor/bh1749/README.rst
@@ -15,9 +15,9 @@ Requirements
 
 The sample supports the following nRF9160-based device:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set10_start
-   :end-before: set10_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy91_nrf9160ns
 
 Building and Running
 ********************

--- a/samples/spm/README.rst
+++ b/samples/spm/README.rst
@@ -54,9 +54,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set19_start
-   :end-before: set19_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340pdk_nrf5340_cpuapp, nrf9160dk_nrf9160
 
 Building and running
 ********************

--- a/samples/usb/usb_uart_bridge/README.rst
+++ b/samples/usb/usb_uart_bridge/README.rst
@@ -15,9 +15,9 @@ Requirements
 
 The sample supports the following nRF52840-based device:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set17_start
-   :end-before: set17_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy91_nrf52840
 
 The sample also requires a USB host which can communicate with CDC ACM devices, like a Windows or Linux PC.
 

--- a/samples/zigbee/light_bulb/README.rst
+++ b/samples/zigbee/light_bulb/README.rst
@@ -19,9 +19,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set8_start
-   :end-before: set8_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833
 
 You can use one or more of the development kits listed above and mix different development kits.
 

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -31,9 +31,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set8_start
-   :end-before: set8_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833
 
 You can use one or more of the development kits listed above and mix different development kits.
 

--- a/samples/zigbee/network_coordinator/README.rst
+++ b/samples/zigbee/network_coordinator/README.rst
@@ -18,9 +18,9 @@ Requirements
 
 The sample supports the following development kits:
 
-.. include:: /includes/boardname_tables/sample_boardnames.txt
-   :start-after: set8_start
-   :end-before: set8_end
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833
 
 You can use one of the development kits listed above.
 

--- a/scripts/sphinx_extensions/table_from_rows/__init__.py
+++ b/scripts/sphinx_extensions/table_from_rows/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from . import table_from_rows
+
+__version__ = '0.0.1'
+
+
+def setup(app):
+    table_from_rows.setup(app)
+
+    return {
+        'version': __version__,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/scripts/sphinx_extensions/table_from_rows/table_from_rows.py
+++ b/scripts/sphinx_extensions/table_from_rows/table_from_rows.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from docutils import io, statemachine
+from docutils.utils.error_reporting import ErrorString
+from docutils.parsers.rst import directives
+from sphinx.util.docutils import SphinxDirective
+
+
+class TableFromRows(SphinxDirective):
+
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {
+        'header': directives.unchanged,
+        'rows': directives.unchanged,
+    }
+
+    def _load_section(self, lines, section):
+        found_section = False
+        section_lines = []
+        for line in lines:
+            line = line.strip()
+            if line == '.. ' + section:
+                found_section = True
+                continue
+            elif line.startswith('.. ') and found_section:
+                break
+            if found_section and line != '':
+                section_lines.append(line)
+        if len(section_lines) == 0:
+            raise self.severe('Problems building table; "%s" section not found.' %
+                              section)
+        return section_lines
+
+    def _column_sizes(self, row):
+        cols = row.split('|')
+        if len(cols) < 2 or cols[0] != '' or cols[-1] != '':
+            raise self.severe('Row does not look like a table: "%s"' % row)
+        return [len(el.strip()) for el in cols[1:-1]]
+
+    @staticmethod
+    def _adjust_column_sizes(sizes, line):
+        columns = []
+        for size, column in zip(sizes, line.split('|')[1:-1]):
+            column = column.strip()
+            columns.append(column + ' ' * (size - len(column)))
+        return '|' + '|'.join(columns) + '|'
+
+    def _build_table(self, sizes, header_lines, rows):
+        row_sep = '+' + '+'.join(['-' * size for size in sizes]) + '+'
+        table = [row_sep]
+        # XXX for header_lines to be len==1?
+        for line in header_lines:
+            table.append(self._adjust_column_sizes(sizes, line))
+        table.append('+' + '+'.join(['=' * size for size in sizes]) + '+')
+        for row_set in rows:
+            for line in row_set:
+                table.append(self._adjust_column_sizes(sizes, line))
+            table.append(row_sep)
+        return table
+
+    def _find_column_sizes(self, header_lines, rows):
+        sizes = self._column_sizes(header_lines[0])
+        for row in header_lines[1:]:
+            row_sizes = self._column_sizes(row)
+            if len(sizes) != len(row_sizes):
+                raise self.severe('Incompatible number of columns: "%s"' % row)
+            sizes = [max(sizes[i], row_sizes[i]) for i, _ in enumerate(sizes)]
+        for row_set in rows:
+            for row in row_set:
+                row_sizes = self._column_sizes(row)
+                if len(sizes) != len(row_sizes):
+                    raise self.severe('Incompatible number of columns: "%s"' % row)
+                sizes = [max(sizes[i], row_sizes[i]) for i, _ in enumerate(sizes)]
+        return sizes
+
+    def _load_header_and_rows(self, source_path, header_section, rows_sections):
+        try:
+            self.state.document.settings.record_dependencies.add(source_path)
+            include_file = io.FileInput(source_path=source_path)
+        except IOError as error:
+            raise self.severe('Problems with "%s" directive path:\n%s.' %
+                              (self.name, ErrorString(error)))
+        lines = include_file.readlines()
+        header_lines = self._load_section(lines, header_section)
+        rows = [self._load_section(lines, section) for section in rows_sections]
+        column_sizes = self._find_column_sizes(header_lines, rows)
+        return self._build_table(column_sizes, header_lines, rows)
+
+    def run(self):
+        _, path = self.env.relfn2path(self.arguments[0])
+
+        header = self.options.get('header', None)
+        if header is not None:
+            header = header.strip()
+        else:
+            raise self.severe('Problem with "header" option of "%s" '
+                              'directive:\nEmpty content.' % self.name)
+        rows = self.options.get('rows', None)
+        if rows is not None:
+            rows = [r.strip() for r in rows.split(',') if r.strip() != '']
+        else:
+            raise self.severe('Problem with "rows" option of "%s" '
+                              'directive:\nEmpty content.' % self.name)
+
+        raw = '\n'.join(self._load_header_and_rows(path, header, rows))
+        lines = statemachine.string2lines(raw)
+        self.state_machine.insert_input(lines, path)
+        return []
+
+
+def setup(app):
+    directives.register_directive('table-from-rows', TableFromRows)


### PR DESCRIPTION
Add a new Sphinx extension to ease the creation of sample requirement tables. To add a table one can add a directive like:

```
.. table-from-rows: /includes/blabla.txt
   :header: header_row
   :rows: row1, row2, ...
```

The input file `/includes/blabla.txt` must have the following format:

```
.. header_row

| col1 | col2 | col3 |

.. row1

| data1 | data2 | data3 |

.. row2

| data1 | data2 | data3 |

.. and so on and so forth...
```

Basic error checks are done, like the header and all rows match in the number of columns, header and rows referenced in the directive exists, etc.

Spaces are not relevant but `|` must be used to separate columns, there must be one at the beginning and at the end of the line. The adjustment of column sizes if made by the extension before sending for Sphinx processing. If a section has more that one row they span.

Already added a `includes` file to be used with all current permutations existing in `sample_boardnames.txt` and update all README.rst files.

JIRA: NCSDK-6297