### PR TITLE
manifest: Pull new nrfxlib - ot lib master update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -97,7 +97,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d32c12686a15a4c0303ad1de6927c1a68bfa939e
+      revision: pull/259/head
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
OpenThread library master configuration had one incorrect setting not
allowing CLI sample to work correctly. Pulling in new xlib with setting
removed.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>