### PR TITLE
zigbee: Fix zigbee stack sleep time calculation [KRKNWK-7230]

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_platform.h
+++ b/subsys/zigbee/osif/zb_nrf_platform.h
@@ -56,12 +56,12 @@ void zigbee_event_notify(zigbee_event_t event);
 /**@brief Function which waits for event in case
  *        of empty Zigbee stack scheduler queue.
  *
- * @param[in] timeout_ms  Maximum amount of time, in milliseconds
+ * @param[in] timeout_us  Maximum amount of time, in microseconds
  *                        for which the ZBOSS task processing may be blocked.
  *
- * @returns The amount of milliseconds that the ZBOSS task was blocked.
+ * @returns The amount of microseconds that the ZBOSS task was blocked.
  */
-uint32_t zigbee_event_poll(uint32_t timeout_ms);
+uint32_t zigbee_event_poll(uint32_t timeout_us);
 
 /**@brief Schedule single-param callback execution.
  *


### PR DESCRIPTION
Fix Zigbee stack slept time calculation so the Zigbee device stays in IDLE as long as possible.
As a result, data-request duration is shortened to about 3.4 - 5.6 ms. 