### PR TITLE
net: lib: coap_utils: Add optional socket binding to address

### DIFF
--- a/include/net/coap_utils.h
+++ b/include/net/coap_utils.h
@@ -17,9 +17,11 @@
 
 /** @brief Open socket and start the receiving thread.
  *
- * @param[in] ip_family network ip protocol family (AF_INET or AF_INET6)
+ * @param[in] ip_family Network ip protocol family (AF_INET or AF_INET6).
+ * @param[in] addr Local address to bind for receiving data.
+ *		   Pass NULL pointer if no address is provided.
  */
-void coap_init(int ip_family);
+void coap_init(int ip_family, struct sockaddr *addr);
 
 /** @brief Send CoAP non-confirmable request.
  *

--- a/samples/openthread/coap_client/src/coap_client_utils.c
+++ b/samples/openthread/coap_client/src/coap_client_utils.c
@@ -257,7 +257,7 @@ void coap_client_utils_init(ot_connection_cb_t on_connect,
 {
 	on_mtd_mode_toggle = on_toggle;
 
-	coap_init(AF_INET6);
+	coap_init(AF_INET6, NULL);
 
 	k_work_init(&on_connect_work, on_connect);
 	k_work_init(&on_disconnect_work, on_disconnect);


### PR DESCRIPTION
This patch adds the option to bind the CoAP socket to a local
address by passing a sockaddr pointer to coap_init().
NULL can be passed if the library should not call bind() on
the socket.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>