### PR TITLE
profiler: New way of sending info data

### DIFF
--- a/subsys/profiler/Kconfig
+++ b/subsys/profiler/Kconfig
@@ -56,7 +56,7 @@ config PROFILER_NORDIC_DATA_BUFFER_SIZE
 
 config PROFILER_NORDIC_INFO_BUFFER_SIZE
 	int "Info buffer size"
-	default 1024
+	default 256
 
 config PROFILER_NORDIC_RTT_CHANNEL_DATA
 	int "Data up channel index"


### PR DESCRIPTION
Change switches from asserting that all the data fit in the buffer to periodically retrying data write operation. When asserts were disabled, previous implementation resulted in strange errors during profiler script execution.