### PR TITLE
doc: add AT host documentation

### DIFF
--- a/doc/nrf/libraries/lib_at_host.rst
+++ b/doc/nrf/libraries/lib_at_host.rst
@@ -1,0 +1,25 @@
+﻿.. _lib_at_host:
+
+AT host library
+###############
+
+|at_host_description|
+The AT host library exposes the AT command interface of the cellular modem for supported devices on an external serial interface.
+
+Configuration
+=============
+
+The library is enabled and configured entirely in the Kconfig system. The external serial port to use, termination character and other parameters are configurable.
+
+Specifically, if it is desirable for the client to use SMS functionality, the termination character should not be set to <CR>, because that character is used inside the AT+CMGS command.
+
+Usage
+=====
+
+The library has no globally available members, and thus no header file. If enabled, the library will initialize with the system. Any input on the configured serial port will be forwarded to the modem upon receipt of the configured termination character(s). Only one command can be processed at any time, and no data must be sent to the serial port while the command is being processed.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   ../../lib/at_host/*

--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -38,6 +38,10 @@ config AT_HOST_UART
 
 config AT_HOST_UART_INIT_TIMEOUT
 	int "Timeout waiting for a valid UART line on init (ms)"
+	help
+		If the selected UART has error conditions during init caused by
+		e. g. a floating RX line during boot, at_host will clear the
+		errors and retry for this amount of time.
 	default 500
 
 choice


### PR DESCRIPTION
Updates the inline documentation and adds configuration and usage
instructions for the AT host library.