### PR TITLE
scripts: adding cryptography to requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
+cryptography
 ecdsa
 imagesize>=1.2.0
 intelhex


### PR DESCRIPTION
When installing using GS guide, then users are requested to run:
`pip install --user scripts/requirements.txt`, but if they then tries to
build asset_tracker, they will see following error:
```
    ModuleNotFoundError: No module named 'cryptography'
```

The commit adds cryptography as a required python package.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>