### PR TITLE
manifest: zephyr: update to fix OpenThread raw link issue

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 332206bcad13edffb14f0de684b62b795b871903
+      revision: 81abf77417fd7678f1faef5bed40b62a026fa70f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update manifest to fix an OpenThread initialization issue when
raw link is enabled.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>