### PR TITLE
partition_manager: err if no static conf when not building from source

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -38,6 +38,17 @@ if (EXISTS ${static_configuration_file})
   set(static_configuration --static-config ${static_configuration_file})
 endif()
 
+if (NOT static_configuration AND CONFIG_PM_IMAGE_NOT_BUILT_FROM_SOURCE)
+  message(WARNING
+    "One or more child image is not configured to be built from source. \
+    However, there is no static configuration provided to the \
+    partition manager. Please provide a static configuration as described in \
+    the 'Scripts -> Partition Manager -> Static configuration' chapter in the \
+    documentation. Without this information, the build system is not able to \
+    place the image correctly in flash.")
+endif()
+
+
 # Check if current image is the dynamic partition in its domain.
 # I.E. it is the only partition without a statically configured size in this
 # domain. This is equivalent to the 'app' partition in the root domain.

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -50,8 +50,10 @@ endmenu # Zephyr subsystem configurations
 
 menu "Zephyr samples configurations"
 
+if BT_RPMSG_NRF53 && SOC_NRF5340_CPUAPP
 module=HCI_RPMSG
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.build_strategy_domain"
+endif
 
 endmenu # Zephyr samples configurations
 
@@ -83,5 +85,11 @@ config PM_EXTERNAL_FLASH_BASE
 	default 0
 
 endif
+
+config PM_IMAGE_NOT_BUILT_FROM_SOURCE
+	bool
+	help
+	  Promptless helper config used to indicate that one or more
+	  image is not built from source.
 
 endmenu # Partition Manager

--- a/subsys/partition_manager/Kconfig.template.build_strategy
+++ b/subsys/partition_manager/Kconfig.template.build_strategy
@@ -5,6 +5,7 @@ choice
 config $(module)_BUILD_STRATEGY_USE_HEX_FILE
 	# Mandatory option when being built through add_child_image'
 	bool "Use hex file instead of building $(module)"
+	select PM_IMAGE_NOT_BUILT_FROM_SOURCE
 
 if $(module)_BUILD_STRATEGY_USE_HEX_FILE
 
@@ -17,6 +18,7 @@ endif # $(module)_BUILD_STRATEGY_USE_HEX_FILE
 config $(module)_BUILD_STRATEGY_SKIP_BUILD
 	# Mandatory option when being built through add_child_image'
 	bool "Skip building $(module)"
+	select PM_IMAGE_NOT_BUILT_FROM_SOURCE
 
 config $(module)_BUILD_STRATEGY_FROM_SOURCE
 	# Mandatory option when being built through add_child_image'

--- a/subsys/partition_manager/Kconfig.template.build_strategy_domain
+++ b/subsys/partition_manager/Kconfig.template.build_strategy_domain
@@ -14,6 +14,7 @@ choice
 config $(module)_BUILD_STRATEGY_SKIP_BUILD
 	# Mandatory option when being built through add_child_image'
 	bool "Skip building $(module)"
+	select PM_IMAGE_NOT_BUILT_FROM_SOURCE
 
 config $(module)_BUILD_STRATEGY_FROM_SOURCE
 	# Mandatory option when being built through add_child_image'


### PR DESCRIPTION
If one or more image is not built from source, it is necessary to
provide a static configuration to place the remainding images
correctly.

Throw an error if no static configuration is provided and
one or more image is not built from source.

Ref: NCSDK-6052

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>