### PR TITLE
Bluetooth: scan: Update to support extended advertising

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_scan.c
+++ b/applications/nrf_desktop/src/modules/ble_scan.c
@@ -411,7 +411,7 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	LOG_INF("Filters matched. %s %sconnectable",
 		log_strdup(addr), connectable ? "" : "non");

--- a/applications/nrf_desktop/src/modules/ble_scan.c
+++ b/applications/nrf_desktop/src/modules/ble_scan.c
@@ -468,8 +468,8 @@ static void scan_init(void)
 	reset_subscribers();
 
 	static const struct bt_le_scan_param sp = {
-		.type = BT_HCI_LE_SCAN_ACTIVE,
-		.filter_dup = BT_HCI_LE_SCAN_FILTER_DUP_ENABLE,
+		.type = BT_LE_SCAN_TYPE_ACTIVE,
+		.options = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
 		.interval = BT_GAP_SCAN_FAST_INTERVAL,
 		.window = BT_GAP_SCAN_FAST_WINDOW,
 	};

--- a/include/bluetooth/scan.h
+++ b/include/bluetooth/scan.h
@@ -27,7 +27,7 @@
 
 #include <zephyr/types.h>
 #include <sys/slist.h>
-#include <bluetooth/hci.h>
+#include <bluetooth/bluetooth.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/conn.h>
 
@@ -282,17 +282,14 @@ struct bt_scan_filter_match {
  *        connection and advertising information.
  */
 struct bt_scan_device_info {
-	/** Information about advertising. */
-	struct bt_scan_adv_info adv_info;
-
-	/** Pointer to device LE address. */
-	const bt_addr_le_t *addr;
+	/** Received advertising packet information */
+	const struct bt_le_scan_recv_info *recv_info;
 
 	/** Connection parameters for LE connection. */
 	const struct bt_le_conn_param *conn_param;
 
 	/** Received advertising data. If further
-	 *  data proccesing is needed, you should
+	 *  data processing is needed, you should
 	 *  use @em bt_data_parse() to get specific
 	 *  advertising data type.
 	 */

--- a/samples/bluetooth/central_bas/src/main.c
+++ b/samples/bluetooth/central_bas/src/main.c
@@ -49,7 +49,7 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	printk("Filters matched. Address: %s connectable: %s\n",
 		addr, connectable ? "yes" : "no");
@@ -73,12 +73,13 @@ static void scan_filter_no_match(struct bt_scan_device_info *device_info,
 	struct bt_conn *conn;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	if (device_info->adv_info.adv_type == BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {
-		bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	if (device_info->recv_info->adv_type == BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {
+		bt_addr_le_to_str(device_info->recv_info->addr, addr,
+				  sizeof(addr));
 		printk("Direct advertising received from %s\n", addr);
 		bt_scan_stop();
 
-		err = bt_conn_le_create(device_info->addr,
+		err = bt_conn_le_create(device_info->recv_info->addr,
 					BT_CONN_LE_CREATE_CONN,
 					device_info->conn_param, &conn);
 

--- a/samples/bluetooth/central_dfu_smp/src/main.c
+++ b/samples/bluetooth/central_dfu_smp/src/main.c
@@ -50,7 +50,7 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	printk("Filters matched. Address: %s connectable: %s\n",
 		addr, connectable ? "yes" : "no");

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -74,7 +74,7 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 
 	const struct bt_uuid *uuid = filter_match->uuid.uuid[0];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	printk("Filters matched on UUID 0x%04x.\nAddress: %s connectable: %s\n",
 		BT_UUID_16(uuid)->val,
@@ -99,12 +99,13 @@ static void scan_filter_no_match(struct bt_scan_device_info *device_info,
 	struct bt_conn *conn;
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	if (device_info->adv_info.adv_type == BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {
-		bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	if (device_info->recv_info->adv_type == BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {
+		bt_addr_le_to_str(device_info->recv_info->addr, addr,
+				  sizeof(addr));
 		printk("Direct advertising received from %s\n", addr);
 		bt_scan_stop();
 
-		err = bt_conn_le_create(device_info->addr,
+		err = bt_conn_le_create(device_info->recv_info->addr,
 					BT_CONN_LE_CREATE_CONN,
 					device_info->conn_param, &conn);
 

--- a/samples/bluetooth/central_hr_coded/src/main.c
+++ b/samples/bluetooth/central_hr_coded/src/main.c
@@ -127,7 +127,7 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 	char addr[BT_ADDR_LE_STR_LEN];
 	struct bt_conn_le_create_param *conn_params;
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	printk("Filters matched. Address: %s connectable: %s\n",
 		addr, connectable ? "yes" : "no");
@@ -142,7 +142,7 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 			BT_GAP_SCAN_FAST_INTERVAL,
 			BT_GAP_SCAN_FAST_INTERVAL);
 
-	err = bt_conn_le_create(device_info->addr, conn_params,
+	err = bt_conn_le_create(device_info->recv_info->addr, conn_params,
 				BT_LE_CONN_PARAM_DEFAULT,
 				&default_conn);
 

--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -422,7 +422,7 @@ static void scan_filter_match(struct bt_scan_device_info *device_info,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	LOG_INF("Filters matched. Address: %s connectable: %d",
 		log_strdup(addr), connectable);

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -55,7 +55,7 @@ void scan_filter_match(struct bt_scan_device_info *device_info,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	printk("Filters matched. Address: %s connectable: %d\n",
 	       addr, connectable);
@@ -66,7 +66,7 @@ void scan_filter_no_match(struct bt_scan_device_info *device_info,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	printk("Filter does not match. Address: %s connectable: %d\n",
 	       addr, connectable);

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -84,8 +84,8 @@ static void scan_init(void)
 {
 	int err;
 	struct bt_le_scan_param scan_param = {
-		.type = BT_HCI_LE_SCAN_PASSIVE,
-		.filter_dup = BT_HCI_LE_SCAN_FILTER_DUP_ENABLE,
+		.type = BT_LE_SCAN_TYPE_PASSIVE,
+		.options = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
 		.interval = 0x0010,
 		.window = 0x0010,
 	};

--- a/samples/bluetooth/throughput/src/main.c
+++ b/samples/bluetooth/throughput/src/main.c
@@ -55,7 +55,7 @@ void scan_filter_match(struct bt_scan_device_info *device_info,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	printk("Filters matched. Address: %s connectable: %d\n",
 		addr, connectable);
@@ -66,7 +66,7 @@ void scan_filter_no_match(struct bt_scan_device_info *device_info,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	printk("Filter not match. Address: %s connectable: %d\n",
 				addr, connectable);

--- a/samples/bluetooth/throughput/src/main.c
+++ b/samples/bluetooth/throughput/src/main.c
@@ -189,10 +189,10 @@ static void scan_init(void)
 {
 	int err;
 	struct bt_le_scan_param scan_param = {
-	    .type = BT_HCI_LE_SCAN_PASSIVE,
-	    .filter_dup = BT_HCI_LE_SCAN_FILTER_DUP_ENABLE,
-	    .interval = 0x0010,
-	    .window = 0x0010,
+		.type = BT_LE_SCAN_TYPE_PASSIVE,
+		.options = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+		.interval = 0x0010,
+		.window = 0x0010,
 	};
 
 	struct bt_scan_init_param scan_init = {

--- a/samples/nrf9160/lte_ble_gateway/src/ble.c
+++ b/samples/nrf9160/lte_ble_gateway/src/ble.c
@@ -153,7 +153,7 @@ void scan_filter_match(struct bt_scan_device_info *device_info,
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
-	bt_addr_le_to_str(device_info->addr, addr, sizeof(addr));
+	bt_addr_le_to_str(device_info->recv_info->addr, addr, sizeof(addr));
 
 	printk("Device found: %s\n", addr);
 }

--- a/samples/nrf9160/lte_ble_gateway/src/ble.c
+++ b/samples/nrf9160/lte_ble_gateway/src/ble.c
@@ -6,6 +6,7 @@
 
 #include <zephyr.h>
 
+#include <bluetooth/bluetooth.h>
 #include <bluetooth/gatt.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt_dm.h>
@@ -170,8 +171,8 @@ static void scan_start(void)
 	int err;
 
 	struct bt_le_scan_param scan_param = {
-		.type = BT_HCI_LE_SCAN_ACTIVE,
-		.filter_dup = BT_HCI_LE_SCAN_FILTER_DUP_ENABLE,
+		.type = BT_LE_SCAN_TYPE_ACTIVE,
+		.options = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
 		.interval = 0x0010,
 		.window = 0x0010,
 	};

--- a/subsys/bluetooth/scan.c
+++ b/subsys/bluetooth/scan.c
@@ -1309,11 +1309,11 @@ int bt_scan_start(enum bt_scan_type scan_type)
 {
 	switch (scan_type) {
 	case BT_SCAN_TYPE_SCAN_ACTIVE:
-		bt_scan.scan_param.type = BT_HCI_LE_SCAN_ACTIVE;
+		bt_scan.scan_param.type = BT_LE_SCAN_TYPE_ACTIVE;
 		break;
 
 	case BT_SCAN_TYPE_SCAN_PASSIVE:
-		bt_scan.scan_param.type = BT_HCI_LE_SCAN_PASSIVE;
+		bt_scan.scan_param.type = BT_LE_SCAN_TYPE_PASSIVE;
 		break;
 
 	default:


### PR DESCRIPTION
Update the scan module for extended advertising PDUs. We need to
determine if the advertiser is connectable by looking at the
advertising properties for extended advertising PDUs.
    
Instead of copying over all of the additional advertising information
provide a pointer to the scan report recv information struct,
this one includes the address as well, so remove it from the device
info struct.
