### PR TITLE
CODEOWNERS: add codeowners for Azure related code

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,6 +41,7 @@ Kconfig*                                  @tejlmand
 /dts/                                     @anangl
 /ext/                                     @carlescufi
 /include/                                 @anangl @rlubos @pizi-nordic
+/include/net/azure_*                      @jtguggedal @simensrostad @coderbyheart
 /include/bluetooth/                       @joerchan
 /include/bluetooth/mesh/                  @trond-snekvik @joerchan
 /include/debug/ppi_trace.h                @nordic-krch @anangl
@@ -80,6 +81,7 @@ Kconfig*                                  @tejlmand
 /samples/nrf_rpc/                         @doki-nordic @KAGA164
 /samples/nrf5340/empty_app_core/          @doki-nordic
 /samples/nrf9160/                         @rlubos @lemrey
+/samples/nrf9160/azure_*                  @jtguggedal @simensrostad @coderbyheart
 /samples/spm/                             @lemrey @hakonfam @ioannisg
 /samples/openthread/                      @MarekPorwisz @lmaciejonczyk
 /samples/profiler/                        @pdunaj @pizi-nordic
@@ -103,6 +105,7 @@ Kconfig*                                  @tejlmand
 /subsys/fw_info/                          @hakonfam
 /subsys/mpsl/                             @joerchan @rugeGerritsen
 /subsys/net/                              @rlubos
+/subsys/net/lib/azure_*                   @jtguggedal @simensrostad @coderbyheart
 /subsys/nfc/                              @grochu @anangl
 /subsys/nrf_rpc/                          @doki-nordic @KAGA164
 /subsys/partition_manager/                @hakonfam


### PR DESCRIPTION
This adds @jtguggedal @simensrostad @coderbyheart as the code owners
for Azure related code.

This is a follow up to #2715 