### PR TITLE
samples: nrf9160: udp: Configure low power before connecting.

### DIFF
--- a/samples/nrf9160/udp/src/main.c
+++ b/samples/nrf9160/udp/src/main.c
@@ -199,15 +199,15 @@ void main(void)
 	work_init();
 
 #if defined(CONFIG_BSD_LIBRARY)
-	modem_configure();
-
-	k_sem_take(&lte_connected, K_FOREVER);
-
 	err = configure_low_power();
 	if (err) {
 		printk("Unable to set low power configuration, error: %d\n",
 		       err);
 	}
+
+	modem_configure();
+
+	k_sem_take(&lte_connected, K_FOREVER);
 #endif
 
 	err = server_init();


### PR DESCRIPTION
Do the low power configuration before trying to connect to
network.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>