### PR TITLE
lib: lte_link_control: adding deinit function

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -185,6 +185,12 @@ int lte_lc_connect_async(lte_lc_evt_handler_t handler);
  */
 int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler);
 
+/**@brief Deinitialize the LTE module, powers of the modem.
+ *
+ * @return Zero on success, -EIO if it fails.
+ */
+int lte_lc_deinit(void);
+
 /** @brief Function for sending the modem to offline mode
  *
  * @return Zero on success or (negative) error code otherwise.

--- a/lib/bsdlib/bsdlib.c
+++ b/lib/bsdlib/bsdlib.c
@@ -12,6 +12,10 @@
 #include <bsd.h>
 #include <bsd_platform.h>
 
+#ifdef CONFIG_LTE_LINK_CONTROL
+#include <modem/lte_lc.h>
+#endif
+
 #ifndef CONFIG_TRUSTED_EXECUTION_NONSECURE
 #error  bsdlib must be run as non-secure firmware.\
 	Are you building for the correct board ?
@@ -105,6 +109,9 @@ int bsdlib_get_init_ret(void)
 
 int bsdlib_shutdown(void)
 {
+#ifdef CONFIG_LTE_LINK_CONTROL
+	lte_lc_deinit();
+#endif
 	bsd_shutdown();
 
 	return 0;

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -799,6 +799,17 @@ int lte_lc_power_off(void)
 	return 0;
 }
 
+int lte_lc_deinit(void)
+{
+	if (is_initialized) {
+		is_initialized = false;
+		at_notif_deregister_handler(NULL, at_handler);
+		return lte_lc_power_off();
+	}
+
+	return 0;
+}
+
 int lte_lc_normal(void)
 {
 	if (at_cmd_write(normal, NULL, 0, NULL) != 0) {


### PR DESCRIPTION
Adding a deinit function to the link controller library. When somebody
calls bsdlib_shutdown() the internal "is_initalized" state must be
reset so that the library can be initalized again on bsdlib_init()

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>