### PR TITLE
samples: openthread: add Thread 1.2 extension for CLI sample

### DIFF
--- a/doc/nrf/ug_thread_configuring.rst
+++ b/doc/nrf/ug_thread_configuring.rst
@@ -95,7 +95,16 @@ By selecting support for the v1.2, you enable the following features in addition
 
 * Enhanced Frame Pending
 * Enhanced Keep Alive
-* Thread domain name
+* Thread Domain Name
+
+Moreover, the v1.2 also comes with the following features supported in experimental status:
+
+* :option:`CONFIG_OPENTHREAD_DUA` - Enable Domain Unicast Addresses.
+* :option:`CONFIG_OPENTHREAD_MLR` - Enable Multicast Listener Registration.
+* :option:`CONFIG_OPENTHREAD_BACKBONE_ROUTER` - Enable Backbone Router.
+
+.. note::
+    To test Thread Specification v1.2 options, you can use the :ref:`Thread CLI sample <ot_cli_sample>` with the :ref:`experimental v1.2 extension <ot_cli_sample_thread_v12>`.
 
 Thread commissioning
 ====================

--- a/doc/nrf/ug_thread_overview.rst
+++ b/doc/nrf/ug_thread_overview.rst
@@ -62,3 +62,4 @@ By default, |NCS| supports Thread Specification v1.1, but you can enable and con
 .. note::
     Not all v1.2 functionalities are currently supported.
     See the dedicated options link for the list of v1.2 features currently available in |NCS|, with information about how to enable them.
+    Currently, the :ref:`Thread CLI sample <ot_cli_sample>` is the only sample to offer :ref:`experimental v1.2 extension <ot_cli_sample_thread_v12>`.

--- a/samples/openthread/cli/overlay-thread_1_2.conf
+++ b/samples/openthread/cli/overlay-thread_1_2.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# Enable Thread 1.2 features
+CONFIG_OPENTHREAD_THREAD_VERSION_1_2=y
+CONFIG_OPENTHREAD_DUA=y
+CONFIG_OPENTHREAD_MLR=y
+CONFIG_OPENTHREAD_BACKBONE_ROUTER=y


### PR DESCRIPTION
This commit adds an overlay to the OpenThread CLI sample that
enables the experimentally supported Thread 1.2 features.

It also updates documentation in how to test them.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>