### PR TITLE
doc: update table-from-rows to support sample.yaml

### DIFF
--- a/doc/nrf/templates/sample_README.rst
+++ b/doc/nrf/templates/sample_README.rst
@@ -29,7 +29,7 @@ Requirements
 
 .. note::
    * Supported kits are listed in a table, which is composed of rows from the :file:`doc/nrf/includes/sample_board_rows.txt` file.
-     Select the required rows in the ``:rows:`` configuration.
+     Select the required rows in the ``:rows:`` configuration, or specify ``:sample-yaml-rows:`` to include all boards specified in the :file:`sample.yaml` file.
    * If only one kit is supported, replace the introduction text with "The sample supports the following development kit:".
    * If several kits are required to test the sample, state it after the table (for example, "You can use one or more of the development kits listed above and mix different development kits.").
    * Mention additional requirements after the table.

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -65,7 +65,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832
+   :sample-yaml-rows:
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -65,7 +65,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832
+   :sample-yaml-rows:
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -108,7 +108,7 @@ The sample supports the following development kit:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf9160dk_nrf9160ns
+   :sample-yaml-rows:
 
 The sample requires an `AWS account`_ with access to Simple Storage Service (S3) and the IoT Core service.
 

--- a/samples/nrf9160/cloud_client/README.rst
+++ b/samples/nrf9160/cloud_client/README.rst
@@ -36,7 +36,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: thingy91_nrf9160ns, nrf9160dk_nrf9160ns
+   :sample-yaml-rows:
 
 Setup
 *****


### PR DESCRIPTION
Add support for getting the list of rows directly from sample.yaml instead of having to manually declare them using `:rows:`. To use this option:

```
.. table-from-rows:: /includes/sample_board_rows.txt
   :header: heading
   :sample-yaml-rows:
```

The "sample.yaml" file must exist in the same directory as the input README.rst and must follow a well defined format for where to find the rows: yaml_contents['tests'][path]['platform_whitelist'].

`:rows:` and `:sample-yaml-rows:` can be used together and only unique rows are added to the results, preserving order with `:rows:` at higher priority.