### PR TITLE
net: lib: azure_iot_hub: Add event for connection failure

### DIFF
--- a/include/net/azure_iot_hub.h
+++ b/include/net/azure_iot_hub.h
@@ -30,6 +30,12 @@ enum azure_iot_hub_evt_type {
 	AZURE_IOT_HUB_EVT_CONNECTING = 0x1,
 	/** Connected to Azure IoT Hub. */
 	AZURE_IOT_HUB_EVT_CONNECTED,
+	/** Connection attempt failed. The reported error code from the
+	 *  IoT Hub is available in the data.err member in the event structure.
+	 *  The error codes correspond to return codes in MQTT CONNACK
+	 *  messages.
+	 */
+	AZURE_IOT_HUB_EVT_CONNECTION_FAILED,
 	/** Azure IoT Hub connection established and ready. */
 	AZURE_IOT_HUB_EVT_READY,
 	/** Disconnected from Azure IoT Hub. */

--- a/samples/nrf9160/azure_fota/src/main.c
+++ b/samples/nrf9160/azure_fota/src/main.c
@@ -34,6 +34,11 @@ static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 	case AZURE_IOT_HUB_EVT_CONNECTED:
 		printk("AZURE_IOT_HUB_EVT_CONNECTED\n");
 		break;
+	case AZURE_IOT_HUB_EVT_CONNECTION_FAILED:
+		printk("AZURE_IOT_HUB_EVT_CONNECTION_FAILED\n");
+		printk("Error code received from IoT Hub: %d\n",
+		       evt->data.err);
+		break;
 	case AZURE_IOT_HUB_EVT_DISCONNECTED:
 		printk("AZURE_IOT_HUB_EVT_DISCONNECTED\n");
 		break;

--- a/samples/nrf9160/azure_iot_hub/src/main.c
+++ b/samples/nrf9160/azure_iot_hub/src/main.c
@@ -148,6 +148,11 @@ static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 	case AZURE_IOT_HUB_EVT_CONNECTED:
 		printk("AZURE_IOT_HUB_EVT_CONNECTED\n");
 		break;
+	case AZURE_IOT_HUB_EVT_CONNECTION_FAILED:
+		printk("AZURE_IOT_HUB_EVT_CONNECTION_FAILED\n");
+		printk("Error code received from IoT Hub: %d\n",
+		       evt->data.err);
+		break;
 	case AZURE_IOT_HUB_EVT_DISCONNECTED:
 		printk("AZURE_IOT_HUB_EVT_DISCONNECTED\n");
 		break;

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -508,7 +508,10 @@ static void mqtt_evt_handler(struct mqtt_client *const client,
 			LOG_ERR("Connection was rejected with return code %d",
 				mqtt_evt->param.connack.return_code);
 			LOG_WRN("Is the device certificate valid?");
-				return;
+			evt.data.err = mqtt_evt->param.connack.return_code;
+			evt.type = AZURE_IOT_HUB_EVT_CONNECTION_FAILED;
+			azure_iot_hub_notify_event(&evt);
+			return;
 		}
 
 		connection_state = STATE_CONNECTED;

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
@@ -30,6 +30,12 @@ static void api_event_handler(struct azure_iot_hub_evt *evt)
 				   config->user_data);
 
 		break;
+	case AZURE_IOT_HUB_EVT_CONNECTION_FAILED:
+		cloud_evt.type = CLOUD_EVT_ERROR;
+		cloud_evt.data.err = evt->data.err;
+		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
+				   config->user_data);
+		break;
 	case AZURE_IOT_HUB_EVT_DISCONNECTED:
 		cloud_evt.type = CLOUD_EVT_DISCONNECTED;
 		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,


### PR DESCRIPTION
An event for failure to connect to the IoT Hub is added to
let the user know that connection will not be established.
The error code returned in the CONNACK message is provided
in the event to ease debugging.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>