### PR TITLE
applications: nrf_desktop: Start scan when ble_bond is ready

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_scan.c
+++ b/applications/nrf_desktop/src/modules/ble_scan.c
@@ -328,6 +328,10 @@ static void scan_start(void)
 	size_t bond_count = count_bond();
 	int err;
 
+	if (scanning) {
+		scan_stop();
+	}
+
 	if (IS_ENABLED(CONFIG_DESKTOP_BLE_NEW_PEER_SCAN_REQUEST) &&
 	    (conn_count == bond_count) && peers_only) {
 		LOG_INF("All known peers connected - scanning disabled");
@@ -342,10 +346,6 @@ static void scan_start(void)
 
 	if (IS_ENABLED(CONFIG_DESKTOP_BLE_USE_LLPM) &&
 	    (CONFIG_BT_MAX_CONN == 2)) {
-		if (scanning) {
-			scan_stop();
-		}
-
 		update_init_conn_params(is_llpm_peer_connected());
 	}
 
@@ -526,11 +526,6 @@ static bool event_handler(const struct event_header *eh)
 
 			module_set_state(MODULE_STATE_READY);
 		} else if (check_state(event, MODULE_ID(ble_bond), MODULE_STATE_READY)) {
-			static bool started;
-
-			__ASSERT_NO_MSG(!started);
-			started = true;
-
 			/* Settings need to be loaded before scan start */
 			scan_start();
 		}


### PR DESCRIPTION
When device goes to standby ble_bond switches to off mode.
On wakeup it will issue a module ready event that should cause
ble_scan to restart scanning instead of leading to a crash.

Jira:DESK-1086

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>