### PR TITLE
applications: nrf_desktop: Allow USB to drain enqueued reports

### DIFF
--- a/applications/nrf_desktop/configuration/common/hid_report_desc.h
+++ b/applications/nrf_desktop/configuration/common/hid_report_desc.h
@@ -45,6 +45,15 @@ enum report_id {
 	REPORT_ID_COUNT
 };
 
+static const uint8_t input_reports[] = {
+	REPORT_ID_MOUSE,
+	REPORT_ID_KEYBOARD_KEYS,
+	REPORT_ID_SYSTEM_CTRL,
+	REPORT_ID_CONSUMER_CTRL,
+	REPORT_ID_BOOT_MOUSE,
+	REPORT_ID_BOOT_KEYBOARD,
+};
+
 
 extern const uint8_t hid_report_desc[];
 extern const size_t hid_report_desc_size;


### PR DESCRIPTION
The change reworks hid_forward - cleaning up how reports are enqueued.
On top of that the enqueued reports are migrated from per to sub on per disconnection and from sub to per of per connection.
This way number of enqueued reports should be within bounds and we should still be able to drain enqueued reports after the peripheral disconnects.

Jira:DESK-1085