### PR TITLE
net: lib: nrf_cloud: make MQTT client ID prefix configurable

### DIFF
--- a/samples/nrf9160/aws_fota/Kconfig
+++ b/samples/nrf9160/aws_fota/Kconfig
@@ -81,5 +81,5 @@ config DEVICE_SHADOW_PAYLOAD_SIZE
 endmenu
 
 menu "Zephyr Kernel"
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "Kconfig.zephyr"
 endmenu

--- a/samples/nrf9160/aws_fota/Kconfig
+++ b/samples/nrf9160/aws_fota/Kconfig
@@ -44,6 +44,12 @@ config CLOUD_CLIENT_ID
 	default "your_client_id"
 endif
 
+if !USE_CLOUD_CLIENT_ID
+config CLOUD_CLIENT_ID_PREFIX
+	string "Prefix used when constructing the MQTT client ID from the IMEI"
+	default "nrf-"
+endif #!USE_CLOUD_CLIENT_ID
+
 config MQTT_BROKER_HOSTNAME
 	string "AWS IoT MQTT broker hostname"
 	default "your_aws_mqtt_broker_hostname.amazonaws.com"

--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -39,7 +39,11 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
 /* Define the length of the IMEI AT COMMAND response buffer */
 #define CGSN_RESP_LEN 19
 #define IMEI_LEN 15
-#define CLIENT_ID_LEN (IMEI_LEN + sizeof("nrf-"))
+#if !defined(CONFIG_USE_NRF_CLOUD)
+#define CLIENT_ID_LEN (sizeof(CONFIG_CLOUD_CLIENT_ID_PREFIX) - 1 + IMEI_LEN)
+#else
+#define CLIENT_ID_LEN (sizeof(CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX) - 1 + IMEI_LEN)
+#endif /* !defined(CONFIG_USE_NRF_CLOUD) */
 #else
 #define CLIENT_ID_LEN sizeof(CONFIG_CLOUD_CLIENT_ID)
 #endif
@@ -383,8 +387,11 @@ static int client_id_get(char *id_buf, size_t len)
 		printk("Error when trying to do at_cmd_write: %d, at_state: %d",
 			err, at_state);
 	}
-
-	snprintf(id_buf, len, "nrf-%.*s", IMEI_LEN, imei_buf);
+#if !defined(CONFIG_USE_NRF_CLOUD)
+	snprintf(id_buf, len, "%s%s", CONFIG_CLOUD_CLIENT_ID_PREFIX, imei_buf);
+#else
+	snprintf(id_buf, len, "%s%s", CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX, imei_buf);
+#endif /* !defined(CONFIG_USE_NRF_CLOUD) */
 #else
 	memcpy(id_buf, CONFIG_CLOUD_CLIENT_ID, len);
 #endif /* !defined(NRF_CLOUD_CLIENT_ID) */

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -104,4 +104,8 @@ module-str=Log level for nRF Cloud
 module-help=Enables nRF Cloud log messages.
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
+config NRF_CLOUD_CLIENT_ID_PREFIX
+	string "Prefix used when constructing the MQTT client ID from the IMEI"
+	default "nrf-"
+
 endif # NRF_CLOUD

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -36,7 +36,7 @@ LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
 #if !defined(NRF_CLOUD_CLIENT_ID)
 #define NRF_IMEI_LEN 15
-#define NRF_CLOUD_CLIENT_ID_LEN (NRF_IMEI_LEN + 4)
+#define NRF_CLOUD_CLIENT_ID_LEN (sizeof(CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX) - 1 + NRF_IMEI_LEN)
 #else
 #define NRF_CLOUD_CLIENT_ID_LEN (sizeof(NRF_CLOUD_CLIENT_ID) - 1)
 #endif
@@ -327,7 +327,7 @@ static int nct_client_id_get(char *id)
 	__ASSERT_NO_MSG(bytes_read == NRF_IMEI_LEN);
 	imei_buf[NRF_IMEI_LEN] = 0;
 
-	snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "nrf-%s", imei_buf);
+	snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s%s", CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX, imei_buf);
 
 	ret = nrf_close(at_socket_fd);
 	__ASSERT_NO_MSG(ret == 0);


### PR DESCRIPTION
The `nrf-` prefix is reserved for Nordic devices: https://api.nrfcloud.com/v1#operation/CreateDeviceCertificate:

> If you want to create a certificate for a non-Nordic device, any deviceId is sufficient that does not start with `nrf-` (we recommend using a GUID).

This change allows customers to use the `asset_tracker` application with nRF Connect for Cloud with their own SIPs without modifying the source. This is especially relevant for customers that are building development kit like products, and allows them to work out of the box with the stock `asset_tracker` and nRF Connect for Cloud.