### PR TITLE
net: lib: nrf_cloud: make MQTT client ID prefix configurable

### DIFF
--- a/samples/nrf9160/aws_fota/Kconfig
+++ b/samples/nrf9160/aws_fota/Kconfig
@@ -81,5 +81,5 @@ config DEVICE_SHADOW_PAYLOAD_SIZE
 endmenu
 
 menu "Zephyr Kernel"
-source "$ZEPHYR_BASE/Kconfig.zephyr"
+source "Kconfig.zephyr"
 endmenu

--- a/samples/nrf9160/aws_fota/Kconfig
+++ b/samples/nrf9160/aws_fota/Kconfig
@@ -14,12 +14,13 @@ config USE_NRF_CLOUD
 	bool "Use nRF Cloud"
 	default n
 
-if !USE_NRF_CLOUD
 config CLOUD_CERT_SEC_TAG
+	depends on !USE_NRF_CLOUD
 	int "Security tag for TLS credentials"
 	default 12345678
 
 config PROVISION_CERTIFICATES
+	depends on !USE_NRF_CLOUD
 	bool "Provision certificates from the certificates.h file"
 	select MODEM_KEY_MGMT
 	default n
@@ -36,35 +37,53 @@ config PROVISION_CERTIFICATES
 	  certificates with anyone.
 
 config USE_CLOUD_CLIENT_ID
+	depends on !USE_NRF_CLOUD
 	bool "Custom MQTT client ID"
 	default y
-if USE_CLOUD_CLIENT_ID
+
 config CLOUD_CLIENT_ID
+	depends on !USE_NRF_CLOUD
+	depends on USE_CLOUD_CLIENT_ID
 	string "Client ID"
 	default "your_client_id"
-endif
 
 config MQTT_BROKER_HOSTNAME
+	depends on !USE_NRF_CLOUD
 	string "AWS IoT MQTT broker hostname"
 	default "your_aws_mqtt_broker_hostname.amazonaws.com"
 	help
 	  Default is set to be the nRF Cloud MQTT broker.
+
 config MQTT_BROKER_PORT
+	depends on !USE_NRF_CLOUD
 	int "AWS IoT MQTT broker port"
 	default 8883
-endif #!USE_NRF_CLOUD
 
-if USE_NRF_CLOUD
 config MQTT_BROKER_HOSTNAME
+	depends on USE_NRF_CLOUD
 	string
 	default "a2n7tk1kp18wix-ats.iot.us-east-1.amazonaws.com"
 	help
 	  Default is set to be the nRF Cloud MQTT broker.
 
 config MQTT_BROKER_PORT
+	depends on USE_NRF_CLOUD
 	int
 	default 8883
-endif #USE_NRF_CLOUD
+
+config NRF_CLOUD_CLIENT_ID_PREFIX
+	depends on !USE_CLOUD_CLIENT_ID
+	depends on !NRF_CLOUD
+	string "Prefix used when constructing the MQTT client ID from the IMEI"
+	default "nrf-"
+	help
+	  The nrf- prefix is reserved on nRF Connect for Cloud for official Nordic
+	  devices (e.g. the nRF9160 DK or the Thingy:91).
+	  In case you wish to use aws_fota on nRF Connect for Cloud with your own
+	  devices you need to modify the prefix used to generate the MQTT client
+	  ID from the IMEI.
+	  This property is provided here in case the nrf_cloud module itself is not
+	  enabled.
 
 config MQTT_MESSAGE_BUFFER_SIZE
 	int "MQTT message buffer size"

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -89,7 +89,7 @@ config NRF_CLOUD_AGPS_AUTO
 
 module = NRF_CLOUD_AGPS
 module-str = nRF Cloud A-GPS
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # NRF_CLOUD_AGPS"
 endmenu
@@ -102,6 +102,6 @@ module=NRF_CLOUD
 module-dep=LOG
 module-str=Log level for nRF Cloud
 module-help=Enables nRF Cloud log messages.
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # NRF_CLOUD

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -37,6 +37,15 @@ config NRF_CLOUD_SEC_TAG
 	int "Security tag to use for nRF Cloud connection"
 	default 16842753
 
+config NRF_CLOUD_CLIENT_ID_PREFIX
+	string "Prefix used when constructing the MQTT client ID from the IMEI"
+	default "nrf-"
+	help
+	  The nrf- prefix is reserved on nRF Connect for Cloud for official Nordic
+	  devices (e.g. the nRF9160 DK or the Thingy:91).
+	  In case you wish to use nrf_cloud with your own devices you need to modify
+	  the prefix used to generate the MQTT client ID from the IMEI.
+
 config NRF_CLOUD_HOST_NAME
 	string "nRF Cloud server hostname"
 	default "a2n7tk1kp18wix-ats.iot.us-east-1.amazonaws.com"

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -36,7 +36,7 @@ LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
 #if !defined(NRF_CLOUD_CLIENT_ID)
 #define NRF_IMEI_LEN 15
-#define NRF_CLOUD_CLIENT_ID_LEN (NRF_IMEI_LEN + 4)
+#define NRF_CLOUD_CLIENT_ID_LEN (sizeof(CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX) - 1 + NRF_IMEI_LEN)
 #else
 #define NRF_CLOUD_CLIENT_ID_LEN (sizeof(NRF_CLOUD_CLIENT_ID) - 1)
 #endif
@@ -327,7 +327,7 @@ static int nct_client_id_get(char *id)
 	__ASSERT_NO_MSG(bytes_read == NRF_IMEI_LEN);
 	imei_buf[NRF_IMEI_LEN] = 0;
 
-	snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "nrf-%s", imei_buf);
+	snprintf(id, NRF_CLOUD_CLIENT_ID_LEN + 1, "%s%s", CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX, imei_buf);
 
 	ret = nrf_close(at_socket_fd);
 	__ASSERT_NO_MSG(ret == 0);


### PR DESCRIPTION
The `nrf-` prefix is reserved for Nordic devices: https://api.nrfcloud.com/v1#operation/CreateDeviceCertificate:

> If you want to create a certificate for a non-Nordic device, any deviceId is sufficient that does not start with `nrf-` (we recommend using a GUID).

This change allows customers to use the `asset_tracker` application with nRF Connect for Cloud with their own SIPs without modifying the source. This is especially relevant for customers that are building development kit like products, and allows them to work out of the box with the stock `asset_tracker` and nRF Connect for Cloud.