### PR TITLE
Add common Azure IoT Hub topic parser

### DIFF
--- a/include/net/azure_iot_hub.h
+++ b/include/net/azure_iot_hub.h
@@ -91,7 +91,7 @@ enum azure_iot_hub_evt_type {
 /** @brief Azure IoT Hub topic type, used to route messages to the correct
  *	   destination.
  */
-enum azure_iot_topic_type {
+enum azure_iot_hub_topic_type {
 	/** Data received on the devicebound topic. */
 	AZURE_IOT_HUB_TOPIC_DEVICEBOUND,
 	/** Event topic used to send event data to Azure IoT Hub. */
@@ -104,14 +104,34 @@ enum azure_iot_topic_type {
 	AZURE_IOT_HUB_TOPIC_TWIN_REQUEST,
 };
 
+/** @brief Property bag structure for key/value string pairs. Per Azure
+ *	   IoT Hub documentation, the key must be defined, while the
+ *	   value can be a string, an empty string or NULL.
+ *
+ *  @note If value is provided as a string, it's the equivalent to "key=value".
+ *	  If the value is an empty string (only null-terminator), it's the
+ *	  equivalent of "key=". If value is NULL, it's the equivalent of
+ *	  "key".
+ */
+struct azure_iot_hub_prop_bag {
+	/** Null-terminated key string. */
+	char *key;
+	/** Null-terminated value string. */
+	char *value;
+};
+
 /** @brief Azure IoT Hub topic data. */
 struct azure_iot_hub_topic_data {
 	/** Topic type. */
-	enum azure_iot_topic_type type;
+	enum azure_iot_hub_topic_type type;
 	/** Pointer to topic name. */
 	char *str;
 	/** Length of topic name. */
 	size_t len;
+	/* Array of property bags. */
+	struct azure_iot_hub_prop_bag *prop_bag;
+	/* Number of property bag elements in the prop_bag array. */
+	size_t prop_bag_count;
 };
 
 /** @brief Azure IoT Hub transmission data. */

--- a/subsys/net/lib/azure_fota/azure_fota.c
+++ b/subsys/net/lib/azure_fota/azure_fota.c
@@ -210,6 +210,9 @@ static bool parse_reported_status(const char *msg)
 	fw_obj = cJSON_GetObjectItemCaseSensitive(reported_obj, "firmware");
 	if (fw_obj == NULL) {
 		LOG_DBG("No 'firmware' object found");
+
+		report_needed = true;
+
 		goto clean_exit;
 	}
 

--- a/subsys/net/lib/azure_iot_hub/CMakeLists.txt
+++ b/subsys/net/lib/azure_iot_hub/CMakeLists.txt
@@ -8,6 +8,7 @@ zephyr_library()
 zephyr_library_sources(
 	src/azure_iot_hub.c
 )
+zephyr_library_sources(src/azure_iot_hub_topic.c)
 zephyr_library_sources_ifdef(CONFIG_AZURE_IOT_HUB_DPS src/azure_iot_hub_dps.c)
 zephyr_library_sources_ifdef(CONFIG_CLOUD_API src/azure_iot_hub_cloud_api.c)
 zephyr_include_directories(include)

--- a/subsys/net/lib/azure_iot_hub/Kconfig
+++ b/subsys/net/lib/azure_iot_hub/Kconfig
@@ -71,6 +71,34 @@ config AZURE_IOT_HUB_AUTO_DEVICE_TWIN_REQUEST
 	bool "Request device twin automatically when connected"
 	default y
 
+config AZURE_IOT_HUB_TOPIC_MAX_LEN
+	int "Max length of topic"
+	default 100
+	help
+	  Sets the maximum length of a topic. If a user plans to make extensive
+	  use of property bags, it should be considered to increase this value
+	  to fit the topic into the allocated buffers.
+
+config AZURE_IOT_HUB_TOPIC_ELEMENT_MAX_LEN
+	int "Maximum length of topic element strings"
+	default 22
+	help
+	  Azure IoT Hub uses dynamically constructed topics to transfer
+	  information elements such as response codes, direct method names and
+	  property bag keys and values.
+	  This option configures the maximum length of such an element.
+	  Note that all values are also represented as strings, regardless
+	  of their content, so a boolean or a number will require its length as
+	  a string, and not the size of its binary representation.
+
+config AZURE_IOT_HUB_PROPERTY_BAG_MAX_COUNT
+	int "Maximum number of property bag elements"
+	default 2
+	help
+	  The maximum number of property bags that can be parsed from a topic.
+	  Increasing this value will increase stack usage when parsing topics,
+	  and vice versa if decreasing it.
+
 config AZURE_IOT_HUB_DPS
 	bool "Use Device Provisioning Service"
 	select CJSON_LIB

--- a/subsys/net/lib/azure_iot_hub/include/azure_iot_hub_dps.h
+++ b/subsys/net/lib/azure_iot_hub/include/azure_iot_hub_dps.h
@@ -14,6 +14,8 @@
 #include <stdio.h>
 #include <net/azure_iot_hub.h>
 
+#include "azure_iot_hub_topic.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -50,10 +52,15 @@ int dps_init(struct dps_config *cfg);
 /* @brief Parse incoming MQTT message to see if it's DPS related and process
  *	  accordingly.
  *
+ * @param evt Pointer to Azure IoT Hub event.
+ * @param topic_data Pointer to parsed topic data. If NULL, only the event
+ *		     data will be processed.
+ *
  * @retval true The message was DPS-related and is consumed.
  * @retval false The message was not DPS-related.
  */
-bool dps_process_message(struct azure_iot_hub_evt *evt);
+bool dps_process_message(struct azure_iot_hub_evt *evt,
+			 struct topic_parser_data *topic_data);
 
 /* @brief Start Azure Device Provisioning Service process.
  *

--- a/subsys/net/lib/azure_iot_hub/include/azure_iot_hub_topic.h
+++ b/subsys/net/lib/azure_iot_hub/include/azure_iot_hub_topic.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef AZURE_IOT_HUB_TOPIC_H__
+#define AZURE_IOT_HUB_TOPIC_H__
+
+#include <stdio.h>
+#include <net/azure_iot_hub.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TOPIC_DYNAMIC_VALUE_MAX_LEN  CONFIG_AZURE_IOT_HUB_TOPIC_ELEMENT_MAX_LEN
+#define TOPIC_PROP_BAG_FIELD_MAX_LEN CONFIG_AZURE_IOT_HUB_TOPIC_ELEMENT_MAX_LEN
+#define TOPIC_PROP_BAG_COUNT	     CONFIG_AZURE_IOT_HUB_PROPERTY_BAG_MAX_COUNT
+
+#define TOPIC_PREFIX_DEVICEBOUND	"devices/"
+#define TOPIC_PREFIX_TWIN_DESIRED	"$iothub/twin/PATCH/properties/desired/"
+#define TOPIC_PREFIX_TWIN_RES		"$iothub/twin/res/"
+#define TOPIC_PREFIX_DPS_REG_RESULT	"$dps/registrations/res/"
+#define TOPIC_PREFIX_DIRECT_METHOD	"$iothub/methods/POST/"
+
+enum topic_type {
+	TOPIC_TYPE_DEVICEBOUND,
+	TOPIC_TYPE_TWIN_UPDATE_DESIRED,
+	TOPIC_TYPE_TWIN_UPDATE_RESULT,
+	TOPIC_TYPE_DPS_REG_RESULT,
+	TOPIC_TYPE_DIRECT_METHOD,
+
+	TOPIC_TYPE_UNKNOWN,
+	TOPIC_TYPE_UNEXPECTED,
+	TOPIC_TYPE_EMPTY,
+};
+
+struct topic_parser_prop_bag {
+	/* Null-terminated key string. */
+	char key[TOPIC_PROP_BAG_FIELD_MAX_LEN + 1];
+	/* Null-terminated value string. */
+	char value[TOPIC_PROP_BAG_FIELD_MAX_LEN + 1];
+};
+
+/* Topic parser data. Used for both input and output. It's the caller's
+ * responsibility to allocate memory to the various array members before
+ * calling any function that may operate on the structure members.
+ */
+struct topic_parser_data {
+	/* Topic type. */
+	enum topic_type type;
+	/* Topic buffer. */
+	const char *topic;
+	/* Length of topic buffer. */
+	size_t topic_len;
+	/* Each topic may contain one dynamic topic level that carries
+	 * information.
+	 */
+	union {
+		/* Direct method name for TOPIC_TYPE_DIRECT_METHOD. */
+		char name[TOPIC_DYNAMIC_VALUE_MAX_LEN + 1];
+		/* Status code for TOPIC_TYPE_TWIN_UPDATE_DESIRED and
+		 * TOPIC_TYPE_DPS_REG_RESULT.
+		 */
+		uint32_t status;
+	};
+	/* Array of property bag elements. */
+	struct topic_parser_prop_bag prop_bag[TOPIC_PROP_BAG_COUNT];
+	/* Number of property bag elements in the above array. */
+	size_t prop_bag_count;
+};
+
+/* @brief Free an allocated property bag buffer.
+ *
+ * @param buf Pointer to property bag.
+ */
+static inline void azure_iot_hub_prop_bag_free(char *buf)
+{
+	k_free(buf);
+}
+
+/* @brief Get topic type.
+ *
+ * @param buf Topic buffer.
+ * @param len Length of topic buffer.
+ *
+ * @return Topic type @ref topic_type.
+ */
+enum topic_type topic_type_get(const char *buf, const size_t len);
+
+/* @brief Parse topic.
+ *
+ * @param data Pointer to topic data structure. The structure must
+ *	       be initialized with a topic buffer pointer and topic
+ *	       length. The struct member type must be set to
+ *	       TOPIC_TYPE_UNKNOWN if the topic type has not already
+ *	       been correctly determined.
+ *
+ * @return 0 on success, otherwise negative error code.
+ */
+int azure_iot_hub_topic_parse(struct topic_parser_data *const data);
+
+/* @brief Create a string with all property bags as a querystring.
+ *	  The caller is responsible for calling k_free() on the returned
+ *	  (non-NULL) pointer after use.
+ *
+ * @param bags Array of property bags.
+ * @param count Number of property bag elements n the bags array.
+ *
+ * @return Pointer to the created querystring on success, NULL on failure.
+ */
+char *azure_iot_hub_prop_bag_str_get(struct azure_iot_hub_prop_bag *bags,
+				     size_t count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AZURE_IOT_HUB_TOPIC_H__ */

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_topic.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_topic.c
@@ -1,0 +1,342 @@
+/*
+ * Copyright (client) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "azure_iot_hub_topic.h"
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(azure_iot_hub_topic, CONFIG_AZURE_IOT_HUB_LOG_LEVEL);
+
+#define PROP_BAG_STR		"%s=%s"
+#define PROP_BAG_STR_EMPTY_VAL	"%s="
+#define PROP_BAG_STR_NO_VAL	"%s"
+
+static char *topic_prefixes[] = {
+	[TOPIC_TYPE_DEVICEBOUND] = TOPIC_PREFIX_DEVICEBOUND,
+	[TOPIC_TYPE_TWIN_UPDATE_DESIRED] = TOPIC_PREFIX_TWIN_DESIRED,
+	[TOPIC_TYPE_TWIN_UPDATE_RESULT] = TOPIC_PREFIX_TWIN_RES,
+	[TOPIC_TYPE_DPS_REG_RESULT] = TOPIC_PREFIX_DPS_REG_RESULT,
+	[TOPIC_TYPE_DIRECT_METHOD] = TOPIC_PREFIX_DIRECT_METHOD,
+};
+
+/* If the topic type is TOPIC_TYPE_DEVICEBOUND, the dynamic value in the
+ * topic (the device ID), is placed in the middle of the topic, and
+ * the following string needs to be skipped before reaching the property
+ * bag part of the topic. This can't be achieved by searching for '?' as
+ * the separator indicating start of property bag component, as its not
+ * consistently enforced on the cloud side, and the topic may or may not
+ * contain '?' as separator.
+ */
+#define TOPIC_DEVICE_BOUND_SUFFIX	"messages/devicebound/"
+
+/* Move a pointer forward by the number of bytes corresponding to the
+ * prefix length of the relevant topic.
+ */
+static inline char *skip_prefix(char *const buf, enum topic_type type)
+{
+	return buf + strlen(topic_prefixes[type]);
+}
+
+/* Get the next occurence of a character within a string, where the length
+ * of the string to inspect is set by the max argument.
+ */
+static inline char *get_next_occurrence(char *str, char c, size_t max)
+{
+	for (size_t i = 0; i < max; i++) {
+		if (str[i] == c) {
+			return &str[i];
+		}
+	}
+
+	return NULL;
+}
+
+/* Gets the next property bag, on the format "<key>[=[<value>]]", where '=' and
+ * value are optional.
+ *
+ * @retval the length of parsed property bag on success.
+ * @retval 0 if there was no property bag the provided buffer.
+ * @retval -ENOMEM if the key or value is too long for the buffer set by
+ *	   CONFIG_AZURE_IOT_HUB_TOPIC_ELEMENT_MAX_LEN.
+ */
+static int get_next_prop_bag(char *buf, size_t buf_len,
+			     struct topic_parser_prop_bag *const bag)
+{
+	char *start_ptr = buf;
+	const char *max_ptr = buf + buf_len;
+	char *end_ptr;
+	size_t len;
+	size_t parsed_len;
+
+	if (buf_len == 0) {
+		return 0;
+	}
+
+	/* Skip forward to next property bag */
+	if ((*start_ptr == '?') || (*start_ptr == '&')) {
+		start_ptr += 1;
+		if (start_ptr >= max_ptr) {
+			return 0;
+		}
+	} else if ((*(start_ptr + 1) == '?') || (*(start_ptr + 1) == '&')) {
+		start_ptr += 2;
+		if (start_ptr >= max_ptr) {
+			return 0;
+		}
+	}
+
+	parsed_len = buf - start_ptr;
+
+	/* Pointer is at '/', '?' or '&', move to first character of the key */
+
+	/* The key has one of three formats:
+	 *	<key>
+	 *	<key>=
+	 *	<key>=<value>
+	 *
+	 * The end of the key can be detected in following ways:
+	 *	<key><end of buffer>
+	 *	<key>&
+	 *	<key>=
+	 */
+	end_ptr = start_ptr;
+
+	while ((*end_ptr != '=') &&
+	       (*end_ptr != '&') &&
+	       (end_ptr < max_ptr)) {
+		end_ptr++;
+	}
+
+	len = end_ptr - start_ptr;
+
+	if (len > TOPIC_PROP_BAG_FIELD_MAX_LEN) {
+		LOG_ERR("Property bag element is too long for buffer");
+		return -ENOMEM;
+	}
+
+	memcpy(bag->key, start_ptr, len);
+	bag->key[len] = '\0';
+
+	LOG_DBG("Key: %s", log_strdup(bag->key));
+
+	if (end_ptr == max_ptr) {
+		return 0;
+	} else if (*end_ptr == '&') {
+		LOG_DBG("No value in bag");
+		bag->value[0] = '\0';
+
+		return len;
+	} else if (end_ptr + 1 == max_ptr) {
+		LOG_DBG("Value is empty string");
+
+		return len + 1;
+	}
+
+	/* Set start_ptr to first character of value */
+	start_ptr = end_ptr + 1;
+	end_ptr = start_ptr;
+
+	while ((*end_ptr != '&') && (end_ptr < max_ptr)) {
+		end_ptr++;
+	}
+
+	len = end_ptr - start_ptr;
+
+	if (len > TOPIC_PROP_BAG_FIELD_MAX_LEN) {
+		LOG_ERR("Property bag element is too long for buffer");
+		return -ENOMEM;
+	}
+
+	parsed_len = start_ptr - buf + len;
+
+	memcpy(bag->value, start_ptr, len);
+	bag->value[len] = '\0';
+
+	LOG_DBG("Value: %s", log_strdup(bag->value));
+
+	return parsed_len;
+}
+
+enum topic_type topic_type_get(const char *buf, const size_t len)
+{
+	if (buf == NULL || len == 0) {
+		return TOPIC_TYPE_EMPTY;
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(topic_prefixes); i++) {
+		if (strncmp(topic_prefixes[i], buf,
+			    MIN(strlen(topic_prefixes[i]), len)) == 0) {
+			return i;
+		}
+	}
+
+	return TOPIC_TYPE_UNEXPECTED;
+}
+
+int azure_iot_hub_topic_parse(struct topic_parser_data *const data)
+{
+	char *start_ptr, *stop_ptr;
+	const char *max_ptr = data->topic + data->topic_len;
+	size_t len;
+
+	if (!data->topic || (data->topic_len == 0)) {
+		return -EINVAL;
+	}
+
+	if (data->type >= TOPIC_TYPE_UNKNOWN) {
+		data->type = topic_type_get(data->topic, data->topic_len);
+
+		if ((data->type == TOPIC_TYPE_EMPTY) ||
+		    (data->type == TOPIC_TYPE_UNEXPECTED)) {
+			return 0;
+		}
+	}
+
+	start_ptr = skip_prefix((char *)data->topic, data->type);
+
+	/* This is the common format for topics:
+	 *	<prefix>/<dynamic value>/<suffix>/<property bags>
+	 *
+	 * Where <dynamic value> and <suffix> fields are not present for all.
+	 *
+	 * Property bags have the following format:
+	 *	<key 1>=<value 1>&<key 2>=<value 2>&...
+	 *
+	 * Where the value field may be left empty. It's also allowed to leave
+	 * out the '=' sign.
+	 */
+
+	/* Detect if the topic carries more information than just the prefix. */
+	if (start_ptr == max_ptr) {
+		return 0;
+	}
+
+	/* Get the dynamic value for topics that have one */
+	if (data->type != TOPIC_TYPE_TWIN_UPDATE_DESIRED) {
+		stop_ptr = get_next_occurrence(start_ptr, '/',
+					data->topic_len -
+					(start_ptr - data->topic));
+		len = stop_ptr ? stop_ptr - start_ptr : 0;
+
+		if (len == 0) {
+			return -EFAULT;
+		} else if (len > TOPIC_DYNAMIC_VALUE_MAX_LEN) {
+			return -ENOMEM;
+		}
+
+		memcpy(data->name, start_ptr, len);
+		data->name[len] = '\0';
+
+		LOG_DBG("Dynamic value: %s", log_strdup(data->name));
+
+		if ((data->type == TOPIC_TYPE_TWIN_UPDATE_RESULT) ||
+		    (data->type == TOPIC_TYPE_DPS_REG_RESULT)) {
+			char *end_ptr;
+
+			errno = 0;
+			data->status = strtoul(data->name, &end_ptr, 10);
+
+			if ((errno == ERANGE) || (*end_ptr != '\0')) {
+				LOG_ERR("Failed to parse string as number");
+				return -EFAULT;
+			}
+		} else if (data->type == TOPIC_TYPE_DEVICEBOUND) {
+			stop_ptr += sizeof(TOPIC_DEVICE_BOUND_SUFFIX) - 1;
+		}
+
+		/* Move the start pointer to the end of the method name plus the
+		 * subsequent '/'. start_ptr will now be at the start of the
+		 * property bags, if there are any.
+		 */
+		start_ptr = stop_ptr + 1;
+	}
+
+	data->prop_bag_count = 0;
+
+	while ((start_ptr < max_ptr) &&
+	       (data->prop_bag_count < TOPIC_PROP_BAG_COUNT)) {
+		int ret = get_next_prop_bag(start_ptr, max_ptr - start_ptr,
+				&data->prop_bag[data->prop_bag_count]);
+
+		if (ret <= 0) {
+			return ret;
+		}
+
+		data->prop_bag_count += 1;
+		start_ptr  += ret;
+	}
+
+
+	return 0;
+}
+
+char *azure_iot_hub_prop_bag_str_get(struct azure_iot_hub_prop_bag *bags,
+				     size_t count)
+{
+	/* Reserve space for null-terminator. */
+	size_t total_len = 1;
+	size_t len, written = 0;
+	char *buf;
+
+	for (size_t i = 0; i < count; i++) {
+		if (bags[i].key) {
+			/* Allocate space also for '?' or '&'. */
+			total_len += strlen(bags[i].key) + 1;
+		}
+
+		if (bags[i].value) {
+			/* Allocate space also for '='. */
+			total_len += strlen(bags[i].value) + 1;
+		}
+	}
+
+	LOG_DBG("Requested memory block size: %d", total_len);
+
+	buf = k_malloc(total_len);
+	if (buf == NULL) {
+		LOG_ERR("Memory could not be allocated");
+		return NULL;
+	}
+
+	for (size_t i = 0; i < count; i++) {
+		if (i == 0) {
+			buf[0] = '?';
+		} else {
+			buf[written] = '&';
+		}
+
+		written++;
+
+		if (bags[i].value == NULL) {
+			len = snprintk(&buf[written], total_len - written,
+				       PROP_BAG_STR_NO_VAL, bags[i].key);
+		} else if (strlen(bags[i].value) == 0) {
+			len = snprintk(&buf[written], total_len - written,
+				       PROP_BAG_STR_EMPTY_VAL, bags[i].key);
+		} else {
+			len = snprintk(&buf[written], total_len - written,
+				       PROP_BAG_STR, bags[i].key,
+				       bags[i].value);
+		}
+
+		if ((len < 0) || (len > total_len)) {
+			LOG_ERR("Failed to add property bag");
+			goto clean_exit;
+		}
+
+		written += len;
+	}
+
+	return buf;
+
+clean_exit:
+	k_free(buf);
+	return NULL;
+}

--- a/tests/subsys/net/lib/azure_iot_hub/CMakeLists.txt
+++ b/tests/subsys/net/lib/azure_iot_hub/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(json)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_sources(app
+  PRIVATE
+  ${ZEPHYR_BASE}/../nrf/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_topic.c
+)
+
+target_include_directories(app
+  PRIVATE
+  ${ZEPHYR_BASE}/../nrf/subsys/net/lib/azure_iot_hub/include/
+)
+
+target_compile_options(app
+  PRIVATE
+  -DCONFIG_AZURE_IOT_HUB_TOPIC_ELEMENT_MAX_LEN=48
+  -DCONFIG_AZURE_IOT_HUB_PROPERTY_BAG_MAX_COUNT=5
+  -DCONFIG_AZURE_IOT_HUB_LOG_LEVEL=0
+)

--- a/tests/subsys/net/lib/azure_iot_hub/prj.conf
+++ b/tests/subsys/net/lib/azure_iot_hub/prj.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_ZTEST=y
+CONFIG_HEAP_MEM_POOL_SIZE=1024

--- a/tests/subsys/net/lib/azure_iot_hub/src/main.c
+++ b/tests/subsys/net/lib/azure_iot_hub/src/main.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+#include <ztest.h>
+#include <net/azure_iot_hub.h>
+
+#include "azure_iot_hub_topic.h"
+
+static void test_topic_parse_devicebound(void)
+{
+	int err;
+	const char *topic = "devices/my-device/messages/devicebound/";
+	struct topic_parser_data topic_data = {
+		.topic = topic,
+		.topic_len = strlen(topic),
+		.type = TOPIC_TYPE_UNKNOWN,
+	};
+
+	err = azure_iot_hub_topic_parse(&topic_data);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(topic_data.type, TOPIC_TYPE_DEVICEBOUND,
+		      "Incorrect topic type");
+	zassert_equal(topic_data.prop_bag_count, 0,
+		      "Incorrect property bag count");
+}
+
+static void test_topic_parse_twin_update_desired(void)
+{
+	int err;
+	const char *topic = "$iothub/twin/PATCH/properties/desired/?$version=9";
+	struct topic_parser_data topic_data = {
+		.topic = topic,
+		.topic_len = strlen(topic),
+		.type = TOPIC_TYPE_UNKNOWN,
+	};
+
+	err = azure_iot_hub_topic_parse(&topic_data);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(topic_data.type, TOPIC_TYPE_TWIN_UPDATE_DESIRED,
+		      "Incorrect topic type");
+	zassert_equal(topic_data.prop_bag_count, 1,
+		      "Incorrect property bag count");
+	zassert_true(strcmp(topic_data.prop_bag[0].key, "$version") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[0].value, "9") == 0, NULL);
+}
+
+static void test_topic_parse_twin_update_result(void)
+{
+	int err;
+	const char *topic = "$iothub/twin/res/200/?$rid=738&$version=135";
+	struct topic_parser_data topic_data = {
+		.topic = topic,
+		.topic_len = strlen(topic),
+		.type = TOPIC_TYPE_UNKNOWN,
+	};
+
+	err = azure_iot_hub_topic_parse(&topic_data);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(topic_data.type, TOPIC_TYPE_TWIN_UPDATE_RESULT,
+		      "Incorrect topic type");
+	zassert_equal(topic_data.status, 200, NULL);
+	zassert_equal(topic_data.prop_bag_count, 2,
+		      "Incorrect property bag count");
+	zassert_true(strcmp(topic_data.prop_bag[0].key, "$rid") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[0].value, "738") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[1].key, "$version") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[1].value, "135") == 0, NULL);
+}
+
+static void test_topic_parse_direct_method(void)
+{
+	int err;
+	const char *topic = "$iothub/methods/POST/my_method/?$rid=387";
+	struct topic_parser_data topic_data = {
+		.topic = topic,
+		.topic_len = strlen(topic),
+		.type = TOPIC_TYPE_UNKNOWN,
+	};
+
+	err = azure_iot_hub_topic_parse(&topic_data);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(topic_data.type, TOPIC_TYPE_DIRECT_METHOD,
+		      "Incorrect topic type");
+	zassert_true(strcmp(topic_data.name, "my_method") == 0, NULL);
+	zassert_equal(topic_data.prop_bag_count, 1,
+		      "Incorrect property bag count");
+	zassert_true(strcmp(topic_data.prop_bag[0].key, "$rid") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[0].value, "387") == 0, NULL);
+}
+
+static void test_topic_parse_dps_reg_result(void)
+{
+	int err;
+	const char *topic =
+		"$dps/registrations/res/204/?$rid=59765&retry-after=3";
+	struct topic_parser_data topic_data = {
+		.topic = topic,
+		.topic_len = strlen(topic),
+		.type = TOPIC_TYPE_UNKNOWN,
+	};
+
+	err = azure_iot_hub_topic_parse(&topic_data);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(topic_data.type, TOPIC_TYPE_DPS_REG_RESULT,
+		      "Incorrect topic type");
+	zassert_equal(topic_data.status, 204, NULL);
+	zassert_equal(topic_data.prop_bag_count, 2,
+		      "Incorrect property bag count");
+	zassert_true(strcmp(topic_data.prop_bag[0].key, "$rid") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[0].value, "59765") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[1].key, "retry-after") == 0,
+			    NULL);
+	zassert_true(strcmp(topic_data.prop_bag[1].value, "3") == 0, NULL);
+}
+
+static void test_topic_parse_prop_bag_overload(void)
+{
+	int err;
+	const char *topic =
+		"$dps/registrations/res/204/?$rid=59765&retry-after=3&"
+		"test1=0x0&tes2&test3&test4&test5";
+	struct topic_parser_data topic_data = {
+		.topic = topic,
+		.topic_len = strlen(topic),
+		.type = TOPIC_TYPE_UNKNOWN,
+	};
+
+	err = azure_iot_hub_topic_parse(&topic_data);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(topic_data.type, TOPIC_TYPE_DPS_REG_RESULT,
+		      "Incorrect topic type");
+	zassert_equal(topic_data.status, 204, NULL);
+	zassert_equal(topic_data.prop_bag_count, 5,
+		      "Incorrect property bag count");
+	zassert_true(strcmp(topic_data.prop_bag[0].key, "$rid") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[0].value, "59765") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[1].key, "retry-after") == 0,
+			    NULL);
+	zassert_true(strcmp(topic_data.prop_bag[1].value, "3") == 0, NULL);
+}
+
+static void test_topic_parse_unknown_topic(void)
+{
+	int err;
+	const char *topic =
+		"ive/never/seen/this/topic/before/?whos=this";
+	struct topic_parser_data topic_data = {
+		.topic = topic,
+		.topic_len = strlen(topic),
+		.type = TOPIC_TYPE_UNKNOWN,
+	};
+
+	err = azure_iot_hub_topic_parse(&topic_data);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(topic_data.type, TOPIC_TYPE_UNEXPECTED,
+		      "Incorrect topic type");
+	zassert_equal(topic_data.prop_bag_count, 0,
+		      "Incorrect property bag count");
+}
+
+static void test_topic_add_prop_bags(void)
+{
+	char *key1 = "key1";
+	char *val1 = "value1";
+	char *key2 = "key2";
+	char *val2 = "";
+	char *key3 = "key3";
+	struct azure_iot_hub_prop_bag bags[] = {
+		{
+			.key = key1,
+			.value = val1,
+		},
+		{
+			.key = key2,
+			.value = val2,
+		},
+		{
+			.key = key3,
+			.value = NULL,
+		},
+	};
+	char *prop_bag_str = azure_iot_hub_prop_bag_str_get(bags,
+							    ARRAY_SIZE(bags));
+
+	zassert_not_null(prop_bag_str, NULL);
+	zassert_equal(strcmp(prop_bag_str, "?key1=value1&key2=&key3"), 0,
+		      "Incorrect property bag string");
+	azure_iot_hub_prop_bag_free(prop_bag_str);
+}
+
+static void test_topic_add_prop_bags_reverse(void)
+{
+	char *key1 = "key1";
+	char *value1 = "value1";
+	char *key2 = "key2";
+	char *value2 = "";
+	char *key3 = "key3";
+	struct azure_iot_hub_prop_bag bags[] = {
+		{
+			.key = key3,
+			.value = NULL,
+		},
+		{
+			.key = key2,
+			.value = value2,
+		},
+		{
+			.key = key1,
+			.value = value1,
+		},
+	};
+	char *prop_bag_str = azure_iot_hub_prop_bag_str_get(bags,
+							    ARRAY_SIZE(bags));
+
+	zassert_not_null(prop_bag_str, NULL);
+	zassert_equal(strcmp(prop_bag_str, "?key3&key2=&key1=value1"), 0,
+		      "Incorrect property bag string");
+	azure_iot_hub_prop_bag_free(prop_bag_str);
+}
+
+static void test_topic_parse_long(void)
+{
+	int err;
+	const char *topic =
+		"devices/my-device/messages/devicebound/"
+		"%24.mid=456132-235-a2fd-8458-56432854d&"
+		"%24.to=%2Fdevices%2Fmy-device%2Fmessages%2Fdevicebound&"
+		"key1&key2=&key3=value3";
+	struct topic_parser_data topic_data = {
+		.topic = topic,
+		.topic_len = strlen(topic),
+		.type = TOPIC_TYPE_UNKNOWN,
+	};
+
+	err = azure_iot_hub_topic_parse(&topic_data);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(topic_data.type, TOPIC_TYPE_DEVICEBOUND,
+		      "Incorrect topic type");
+	zassert_equal(topic_data.prop_bag_count, 5,
+		      "Incorrect property bag count");
+	zassert_true(strcmp(topic_data.prop_bag[0].key, "%24.mid") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[0].value,
+			    "456132-235-a2fd-8458-56432854d") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[1].key, "%24.to") == 0,
+			    NULL);
+	zassert_true(strcmp(topic_data.prop_bag[1].value,
+		     "%2Fdevices%2Fmy-device%2Fmessages%2Fdevicebound") == 0,
+		     NULL);
+	zassert_true(strcmp(topic_data.prop_bag[2].key, "key1") == 0, NULL);
+	zassert_equal(strlen(topic_data.prop_bag[2].value), 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[3].key, "key2") == 0, NULL);
+	zassert_equal(strlen(topic_data.prop_bag[3].value), 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[4].key, "key3") == 0, NULL);
+	zassert_true(strcmp(topic_data.prop_bag[4].value, "value3") == 0, NULL);
+}
+
+static void test_topic_prop_bag_too_long(void)
+{
+	int err;
+	const char *topic =
+		"devices/my-device/messages/devicebound/"
+		"?thispropbagisjustwaytoolongtobeparsedandputintothebuffer";
+	struct topic_parser_data topic_data = {
+		.topic = topic,
+		.topic_len = strlen(topic),
+		.type = TOPIC_TYPE_UNKNOWN,
+	};
+
+	err = azure_iot_hub_topic_parse(&topic_data);
+	zassert_equal(err, -ENOMEM, NULL);
+	zassert_equal(topic_data.type, TOPIC_TYPE_DEVICEBOUND,
+		      "Incorrect topic type");
+	zassert_equal(topic_data.prop_bag_count, 0,
+		      "Incorrect property bag count");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(azure_iot_hub_topic,
+			 ztest_unit_test(test_topic_parse_devicebound),
+			 ztest_unit_test(test_topic_parse_twin_update_desired),
+			 ztest_unit_test(test_topic_parse_twin_update_result),
+			 ztest_unit_test(test_topic_parse_direct_method),
+			 ztest_unit_test(test_topic_parse_dps_reg_result),
+			 ztest_unit_test(test_topic_parse_prop_bag_overload),
+			 ztest_unit_test(test_topic_parse_unknown_topic),
+			 ztest_unit_test(test_topic_add_prop_bags),
+			 ztest_unit_test(test_topic_add_prop_bags_reverse),
+			 ztest_unit_test(test_topic_parse_long),
+			 ztest_unit_test(test_topic_prop_bag_too_long)
+			 );
+	ztest_run_test_suite(azure_iot_hub_topic);
+}

--- a/tests/subsys/net/lib/azure_iot_hub/testcase.yaml
+++ b/tests/subsys/net/lib/azure_iot_hub/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  net.lib.azure_iot_hub:
+    platform_allow: nrf9160dk_nrf9160 qemu_x86 native_posix
+    tags: azure_iot_hub


### PR DESCRIPTION
This PR adds the following:
- Common Azure IoT Hub topic parser
- Suppoort for property bags, both in received messages and when sending messages
- Tests for the topic parser