### PR TITLE
nrf_rpc: Adjust ipm_callback to normalized IPM callback signature

### DIFF
--- a/subsys/nrf_rpc/rp_ll.c
+++ b/subsys/nrf_rpc/rp_ll.c
@@ -125,7 +125,8 @@ const struct virtio_dispatch dispatch = {
 };
 
 /* Callback launch right after some data has arrived. */
-static void ipm_callback(void *context, uint32_t id, volatile void *data)
+static void ipm_callback(struct device *ipmdev, void *user_data, uint32_t id,
+			 volatile void *data)
 {
 	k_work_submit_to_queue(&my_work_q, &work_item);
 }


### PR DESCRIPTION
IPM has a new callback signature as described in Zephyr issue #26923.
This PR adjusts nRF RPC code the new signature.