### PR TITLE
Bluetooth: Mesh: Time models documentation

### DIFF
--- a/include/bluetooth/mesh/models.rst
+++ b/include/bluetooth/mesh/models.rst
@@ -29,6 +29,7 @@ Nordic Semiconductor provides a variety of model implementations from the `Mesh 
    ../../../include/bluetooth/mesh/light_ctrl.rst
    ../../../include/bluetooth/mesh/light_ctl.rst
    ../../../include/bluetooth/mesh/sensor_models.rst
+   ../../../include/bluetooth/mesh/time.rst
 
 For more information about these and other models, see also `Mesh Model Overview`_.
 

--- a/include/bluetooth/mesh/time.rst
+++ b/include/bluetooth/mesh/time.rst
@@ -1,0 +1,51 @@
+.. _bt_mesh_time_readme:
+
+Time models
+###########
+
+The Time models allow network-wide time and date synchronization with a granularity of 3.9 ms (1/256th second), and provide services for converting timestamps to and from time zone adjusted UTC time (Coordinated Universal Time).
+The time is measured based on the International Atomic Time (TAI).
+
+The following Time models are supported:
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   time_srv.rst
+   time_cli.rst
+
+The Time models also feature their own common types, listed in the `Common types`_ section below.
+For types common to all models, see :ref:`bt_mesh_models`.
+
+.. _bt_mesh_time_tai:
+
+International Atomic Time (TAI)
+===============================
+
+Contrary to UTC, TAI operates on an absolutely linear timeline, based on the atomic second.
+
+As earth's rotational speed changes by a couple of milliseconds per century, the number of seconds in a solar day has changed since the second was defined in the 19th century.
+The length of a solar day is now slightly longer than the original 86400 seconds, and to compensate, UTC adds a "leap second" every 800 days or so.
+Just like leap days, leap seconds are extra seconds added at a scheduled time to make up for the accumulated offset since the last leap second.
+The leap seconds allow UTC to follow the solar day (which otherwise would be skewed by a few milliseconds every year), but cause some minutes to be more than 60 seconds long.
+Leap seconds are not regular events, but are scheduled by a governing board about 6 months ahead of time.
+This makes it impossible to predict future leap seconds, which makes it impossible to determine the number of UTC seconds between two future dates.
+At the time of writing, UTC is 37 seconds behind TAI (since July 2019).
+
+Instead of moving the timestamp with leap seconds, TAI never performs any jumps, but keeps running at a rate of one second per second forever.
+This allows applications to calculate the number of seconds between any two TAI timestamps, while this is not possible with UTC due to its irregular leap seconds.
+
+To convert to UTC, TAI based applications keep track of the UTC leap seconds separately, as well as the time zone and time zone adjustments.
+
+The Bluetooth Mesh Time models share time as a composite state of TAI seconds, 256 subseconds, UTC offset, time zone steps and uncertainty.
+See :cpp:type:`bt_mesh_time_status` for details.
+
+Common types
+============
+
+| Header file: :file:`include/bluetooth/mesh/lightness.h`
+
+.. doxygengroup:: bt_mesh_time
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/time.rst
+++ b/include/bluetooth/mesh/time.rst
@@ -18,7 +18,7 @@ The following Time models are supported:
 The Time models also feature their own common types, listed in the `Common types`_ section below.
 For types common to all models, see :ref:`bt_mesh_models`.
 
-.. _bt_mesh_time_tai:
+.. _bt_mesh_time_tai_readme:
 
 International Atomic Time (TAI)
 ===============================

--- a/include/bluetooth/mesh/time_cli.rst
+++ b/include/bluetooth/mesh/time_cli.rst
@@ -1,0 +1,29 @@
+.. _bt_mesh_time_cli_readme:
+
+Time Client
+###########
+
+The Time Client model provides time sources for and configures :ref:`bt_mesh_time_srv_readme` models.
+
+Unlike the server model, the client only creates a single model instance in the mesh composition data.
+The Time Client can send messages to both the Time Server and the Time Setup Server, as long as it has the right application keys.
+
+Extended models
+===============
+
+None.
+
+Persistent storage
+==================
+
+None.
+
+API documentation
+=================
+
+| Header file: :file:`include/bluetooth/mesh/time_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/time_cli.c`
+
+.. doxygengroup:: bt_mesh_time_cli
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/time_srv.rst
+++ b/include/bluetooth/mesh/time_srv.rst
@@ -1,0 +1,221 @@
+.. _bt_mesh_time_srv_readme:
+
+Time Server
+###########
+
+The Time Server model allows mesh nodes to synchronize the current time and date by publishing and subscribing to Time Status messages.
+
+The Time Server model relies on an external clock source to provide the current time and date, but takes care of distributing this information through the network.
+
+The Time Server model adds the following new model instances in the composition data:
+
+* Time Server
+* Time Setup Server
+
+Operation
+=========
+
+The Time Server model builds an ad-hoc time synchronization hierarchy through the mesh network, that propagates the current wall-clock time as TAI timestamps.
+
+To ensure consistent synchronization, the Time Server model should be configured to publish its Time Status with regular intervals using a :ref:`zephyr:bluetooth_mesh_models_cfg_cli` model.
+
+..note::
+
+   To ensure a high level of accuracy, Time Status messages are always transmitted one hop at a time.
+   This means that every mesh node that needs access to the common time reference must be within radio range of at least one other node with the Time Server model.
+   Time Server nodes that have no neighboring Time Servers need to get this information in some other way.
+
+Roles
+*****
+
+The Time Server model operates in 3 different roles:
+
+Time Authority
+   A Time Server that has access to an external clock source, and can propagate the current time to other nodes in the network.
+   The Time Authority will publish Time Status messages, but will not receive them.
+
+Time Relay
+   A Time Server that both publishes and receives Time Status messages.
+   The Time Relay relies on other mesh nodes to tell time.
+
+Time Client
+   A Time Server that receives Time Status messages, but does not relay them.
+   The Time Client relies on other mesh nodes to tell time.
+
+Whenever a Time Server model that is not a Time Authority receives a Time Status message, it will update its internal clock to match the new Time Status - if it improves its clock uncertainty.
+
+The Time Authority role should not be confused with the Authority state, which denotes whether the device is actively monitoring a reliable external time source.
+
+Clock uncertainty
+*****************
+
+The Time Server's time synchronization mechanism is not perfect, and every timestamp it provides has some uncertainty.
+The clock uncertainty is measured in milliseconds, and can come from various sources, like inaccuracies in the original clock source, internal clock drift or uncertainty in the mesh stack itself.
+The Time Server inherits the uncertainty of the node it got its Time Status from, and the clock uncertainty of each mesh node increases for every hop the Time Status had to make from the Time Authority.
+
+The expected uncertainty in the mesh stack comes from the fluctuation in time to encrypt a message and broadcast it, and can be configured through the :option:`CONFIG_BT_MESH_TIME_MESH_HOP_UNCERTAINTY`.
+
+In addition to the uncertainty added by the mesh stack itself, the internal clock of each device will increase the uncertainty of the timestamp over time.
+As crystal hardware is not perfectly accurate, it will gradually drift away from the correct time.
+The potential range of this clock drift is generally a known property of the onboard hardware, even if the actual drift fluctuates.
+As it's impossible to measure the actual clock drift at any given moment, the Time Server will instead gradually increase the uncertainty of its timestamp based on the known clock accuracy.
+
+The Time Server's notion of the local clock accuracy can be configured with :option:`CONFIG_BT_MESH_TIME_SRV_CLOCK_ACCURACY`.
+By default, it uses the configured kernel clock control accuracy.
+
+Leap seconds and time zones
+***************************
+
+As described in the section on :ref:`bt_mesh_time_tai_readme`, the Time Server measures time as TAI seconds, and adds the UTC leap second offset and local time zone as additional information.
+
+Both leap seconds and time zone changes are irregular events that are scheduled by governing boards ahead of time.
+Because of this, it's impossible to algorithmically determine the time zone and UTC offset for future dates, as there's no way to tell when and how many changes will be scheduled in the future.
+
+.. note::
+   The time zone of the device not only changes with its location on the globe, but also with Daylight Saving Time.
+   For instance, Central Europe is in the UTC+2 (CEST) time zone during the summer, but the UTC+1 (CET) time zone during the winter.
+
+Time Servers' Time Status messages include the current time zone and UTC offset, but Time models may also distribute information about known future changes to these states.
+For instance, if a Time Authority node learns through its time source that the device will change to Daylight Saving Time on March 29th, it can broadcast a Time Zone change message, which includes the new time zone offset as well as the TAI timestamp of the change.
+All Time Server models that receive this message will automatically store this change and notify the application.
+The application can then reschedule any timeouts that happen after the change to reflect the new offset.
+
+Timestamp conversion
+********************
+
+To convert between human readable time and device time, the Time Server model API includes three functions with signatures similar to the C standard library's time.h API:
+
+* :cpp:func:`bt_mesh_time_srv_mktime`: Get the uptime at a specific date/time.
+* :cpp:func:`bt_mesh_time_srv_localtime`: Get the local date/time at a specific uptime.
+* :cpp:func:`bt_mesh_time_srv_localtime_r`: A thread safe version of ``localtime``.
+
+For example, if you want to schedule your mesh device to send up fireworks exactly at midnight on New Year's Eve, you can use ``mktime`` to find the device uptime at this exact timestamp:
+
+.. code-block:: c
+
+   void schedule_fireworks(void)
+   {
+      struct tm new_years_eve = {
+         .tm_year = 2021 - 1900, /* struct tm measures years since 1900 */
+         /* January 1st: */
+         .tm_mon = 0,
+         .tm_mday = 1,
+         /* Midnight: */
+         .tm_hour = 0,
+         .tm_min = 0,
+         .tm_sec = 0,
+      };
+
+      int64_t uptime = bt_mesh_time_srv_mktime(&time_srv, &new_years_eve);
+      if (uptime < 0) {
+         /* Time Server doesn't know */
+         return;
+      }
+
+      k_timer_start(&start_fireworks, uptime - k_uptime_get(), 0);
+   }
+
+And, to print the current date and time, you can use ``localtime``:
+
+.. code-block:: c
+
+   void print_datetime(void)
+   {
+      struct tm *today = bt_mesh_time_srv_localtime(&time_srv, k_uptime_get());
+      if (!today) {
+         /* Time Server doesn't know */
+         return;
+      }
+
+      const char *weekdays[] = {
+         "Sunday",
+         "Monday",
+         "Tuesday",
+         "Wednesday",
+         "Thursday",
+         "Friday",
+         "Saturday",
+      };
+
+      printk("Today is %s %04u-%02u-%02u\n", weekdays[today->tm_wday],
+            today->tm_year + 1900, today->tm_mon + 1, today->tm_mday);
+      printk("The time is %02u:%02u\n", today->tm_hour, today->tm_min);
+   }
+
+Additionally, the Time Server API includes :cpp:func:`bt_mesh_time_srv_uncertainty_get`, which allows the application to determine the current uncertainty of a specific uptime.
+This function can be used in combination with the three others to determine the accuracy of a provided timestamp.
+
+.. note::
+   All time and uncertainty conversion is based on the Time Server's current data, and assumes that no corrections are made between the call and the provided timestamp.
+   Timestamps that are weeks or months into the future may have an uncertainty of several hours, due to clock drift.
+   The application can subscribe to changes in the Time Server state through the :cpp:type:`bt_mesh_time_srv_cb` callback structure.
+
+   Any time zone or UTC delta changes are taken into account.
+
+Configuration
+=============
+
+The clock uncertainty of the Time Server model can be configured with the following configuration options:
+
+* :option:`CONFIG_BT_MESH_TIME_MESH_HOP_UNCERTAINTY`: The amount of uncertainty introduced in the mesh stack through sending a single message, in milliseconds.
+* :option:`CONFIG_BT_MESH_TIME_SRV_CLOCK_ACCURACY`: The largest possible clock drift introduced by the kernel clock's hardware, in parts per million.
+
+States
+======
+
+The Time Server model contains the following states:
+
+TAI time: :cpp:type:`bt_mesh_time_tai`
+   The TAI time is a composite state, with members ``sec`` and an 8-bit ``subsec``.
+   If the current time is known, the TAI time changes continuously.
+
+Uncertainty: ``uint64_t``
+   Current clock uncertainty in milliseconds.
+   Without new data, clock uncertainty increases gradually due to clock drift.
+
+UTC delta: ``int16_t``
+   Number of seconds between the TAI and UTC timestamps due to UTC leap seconds.
+
+Time zone offset: ``int16_t``
+   Local time zone offset in 15-minute increments.
+
+Authority: ``bool``
+   Whether this device has continuous access to a reliable TAI source, such as a GPS receiver or an NTP-synchronized clock.
+   The Authority state does not transfer to other devices.
+
+Role: :cpp:enum:`bt_mesh_time_role`
+   The Time Server's current role in the Time Status propagation.
+
+Time zone change: :cpp:type:`bt_mesh_time_zone_change`
+   The Time zone change state determines the next scheduled change in time zones, and includes both the new time zone offset and the timestamp of the scheduled change.
+   If no change is known, the timestamp is 0.
+
+UTC delta change: :cpp:type:`bt_mesh_tai_utc_change`
+   The UTC delta change state determines the next scheduled leap second, and includes both the new UTC offset and the timestamp of the scheduled change.
+   If no change is known, the timestamp is 0.
+
+Extended models
+===============
+
+None.
+
+Persistent storage
+==================
+
+The Timer Server stores the following states persistently:
+
+* Role
+* Time zone change
+* UTC delta change
+
+All other states change with time, and are not stored.
+
+API documentation
+==================
+
+| Header file: :file:`include/bluetooth/mesh/time_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/time_srv.c`
+
+.. doxygengroup:: bt_mesh_time_srv
+   :project: nrf
+   :members:

--- a/subsys/bluetooth/mesh/time_srv.c
+++ b/subsys/bluetooth/mesh/time_srv.c
@@ -201,6 +201,12 @@ static void handle_time_status(struct bt_mesh_model *model,
 
 	struct bt_mesh_time_status status;
 
+	if (status.is_authority <= srv->data.sync.status.is_authority &&
+	    srv->data.sync.status.uncertainty < status.uncertainty) {
+		/* The new time status is not an improvement, ignore. */
+		return;
+	}
+
 	bt_mesh_time_decode_time_params(buf, &status);
 	srv->data.sync.uptime = k_uptime_get();
 	srv->data.sync.status.tai = status.tai;


### PR DESCRIPTION
Adds documentation for the time models, and ensures that the time server
relay doesn't end up in a feedback loop.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>