### PR TITLE
lib: bsdlib: changed Kconfig parameters from select to imply

### DIFF
--- a/lib/bsdlib/Kconfig
+++ b/lib/bsdlib/Kconfig
@@ -8,8 +8,8 @@ menu "BSD Library for nrf91"
 config BSD_LIBRARY
 	bool
 	prompt "Use BSD Socket library for IP/TLS/DTLS"
-	select FPU
-	select FPU_SHARING
+	imply FPU
+	imply FPU_SHARING
 	select NET_SOCKETS_POSIX_NAMES
 	imply NET_SOCKETS_OFFLOAD
 	depends on TRUSTED_EXECUTION_NONSECURE


### PR DESCRIPTION
To be able to change CONFIG_FPU=y to n in my project parameters

CONFIG_FPU and CONFIG_FPU_SHARING should be changed from select
to imply. This will make them default y, but possible to set to n

Signed-off-by: <even.falch-larsen@nordicsemi.no>