### PR TITLE
NRF9160: MQTT simple: Minor Fixup

### DIFF
--- a/samples/nrf9160/mqtt_simple/prj.conf
+++ b/samples/nrf9160/mqtt_simple/prj.conf
@@ -27,11 +27,11 @@ CONFIG_MQTT_LIB=y
 CONFIG_MQTT_LIB_TLS=n
 
 # Application
-#CONFIG_MQTT_PUB_TOPIC="/my/publish/topic"
-#CONFIG_MQTT_SUB_TOPIC="/my/subscribe/topic"
-#CONFIG_MQTT_CLIENT_ID="my-client-id"
-#CONFIG_MQTT_BROKER_HOSTNAME="mqtt.eclipse.org"
-#CONFIG_MQTT_BROKER_PORT=1883
+# CONFIG_MQTT_PUB_TOPIC="my/publish/topic"
+# CONFIG_MQTT_SUB_TOPIC="my/subscribe/topic"
+# CONFIG_MQTT_CLIENT_ID="my-client-id"
+# CONFIG_MQTT_BROKER_HOSTNAME="mqtt.eclipse.org"
+# CONFIG_MQTT_BROKER_PORT=1883
 
 # Memory
 CONFIG_MAIN_STACK_SIZE=4096

--- a/samples/nrf9160/mqtt_simple/src/main.c
+++ b/samples/nrf9160/mqtt_simple/src/main.c
@@ -32,9 +32,6 @@ static struct mqtt_client client;
 /* MQTT Broker details. */
 static struct sockaddr_storage broker;
 
-/* Connected flag */
-static bool connected;
-
 /* File descriptor */
 static struct pollfd fds;
 
@@ -227,7 +224,6 @@ void mqtt_evt_handler(struct mqtt_client *const c,
 			break;
 		}
 
-		connected = true;
 		printk("[%s:%d] MQTT client connected!\n", __func__, __LINE__);
 
 #if defined(CONFIG_MQTT_LIB_TLS)
@@ -241,7 +237,6 @@ void mqtt_evt_handler(struct mqtt_client *const c,
 		printk("[%s:%d] MQTT client disconnected %d\n", __func__,
 		       __LINE__, evt->result);
 
-		connected = false;
 		break;
 
 	case MQTT_EVT_PUBLISH: {
@@ -290,7 +285,6 @@ void mqtt_evt_handler(struct mqtt_client *const c,
 	case MQTT_EVT_PINGRESP:
 		if (evt->result != 0) {
 			printk("MQTT PINGRESP error %d\n", evt->result);
-			break;
 		}
 		break;
 
@@ -348,7 +342,6 @@ static int broker_init(void)
 		}
 
 		addr = addr->ai_next;
-		break;
 	}
 
 	/* Free the address. */


### PR DESCRIPTION
Removes unused connected flag, and removes "/" at the head of publish- and subscribe topics in prj.conf so they reflect the default values in Kconfig.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>