### PR TITLE
drivers: serial: nrf_sw_lpuart: Fix uart_irq_rx_ready

### DIFF
--- a/drivers/serial/uart_nrf_sw_lpuart.c
+++ b/drivers/serial/uart_nrf_sw_lpuart.c
@@ -772,7 +772,7 @@ static int api_irq_rx_ready(struct device *dev)
 {
 	struct lpuart_data *data = get_dev_data(dev);
 
-	return data->int_driven.rx_enabled &
+	return data->int_driven.rx_enabled &&
 		int_driven_rd_available(get_dev_data(dev));
 }
 


### PR DESCRIPTION
Fixed wrong operator in the function.

Looks like this error slipped through.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>