### PR TITLE
drivers: gps: nrf9160_gps: Set GPS priority window on block

### DIFF
--- a/applications/asset_tracker/Kconfig
+++ b/applications/asset_tracker/Kconfig
@@ -405,7 +405,7 @@ config GPS_START_AFTER_CLOUD_EVT_READY
 
 config ASSET_TRACKER_WATCHDOG_TIMEOUT_MSEC
 	int "Watchdog timeout in milliseconds"
-	default 10000
+	default 60000
 
 config USE_AT_HOST
 	bool "Enable AT commands"

--- a/drivers/gps/nrf9160_gps/Kconfig
+++ b/drivers/gps/nrf9160_gps/Kconfig
@@ -38,6 +38,24 @@ config NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
 	  application send the AT commands to configure the GPS
 	  properly.
 
+config NRF9160_GPS_PRIORITY_WINDOW_TIMEOUT_SEC
+	int "Enable GPS priority window if the GPS is blocked for this duration"
+	default 10
+	help
+	  This configuration sets the amount of time the GPS must be blocked by
+	  LTE before requesting GPS priority. For GPS priority to be requested
+	  after this timeout, the GPS must also be configured with the priority
+	  flag enabled when starting it. When GPS priority is enabled, the
+	  modem grants the GPS prioritized access to the radio at the cost of
+	  LTE activity. If the value of this option is kept low, GPS priority is
+	  requested at an earlier point of time after the GPS is actively
+	  blocked by LTE activity. This means that data traffic scheduled during
+	  a GPS search is more likely to be blocked by the GPS. Increasing the
+	  value of this option will favor data traffic since the GPS will be
+	  blocked for a longer duration before GPS priority is requested.
+	  Note that GPS priority might not be granted by the modem, even though
+	  it is requested by the driver.
+
 if NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
 
 choice NRF9160_GPS_ANTENNA

--- a/drivers/gps/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/gps/nrf9160_gps/nrf9160_gps.c
@@ -42,6 +42,8 @@ LOG_MODULE_REGISTER(nrf9160_gps, CONFIG_NRF9160_GPS_LOG_LEVEL);
 #define sv_used_str(x) ((x)?"    used":"not used")
 #define sv_unhealthy_str(x) ((x)?"not healthy":"    healthy")
 
+#define GPS_BLOCKED_TIMEOUT CONFIG_NRF9160_GPS_PRIORITY_WINDOW_TIMEOUT_SEC
+
 struct gps_drv_data {
 	struct device *dev;
 	gps_event_handler_t handler;
@@ -57,6 +59,7 @@ struct gps_drv_data {
 	struct k_sem thread_run_sem;
 	struct k_delayed_work stop_work;
 	struct k_delayed_work timeout_work;
+	struct k_delayed_work blocked_work;
 };
 
 struct nrf9160_gps_config {
@@ -199,6 +202,49 @@ static int open_socket(struct gps_drv_data *drv_data)
 static void cancel_works(struct gps_drv_data *drv_data)
 {
 	k_delayed_work_cancel(&drv_data->timeout_work);
+	k_delayed_work_cancel(&drv_data->blocked_work);
+}
+
+static int gps_priority_set(struct gps_drv_data *drv_data, bool enable)
+{
+	int retval;
+	nrf_gnss_delete_mask_t delete_mask = 0;
+
+	if (enable) {
+		retval = nrf_setsockopt(drv_data->socket,
+					NRF_SOL_GNSS,
+					NRF_SO_GNSS_ENABLE_PRIORITY, NULL, 0);
+		if (retval != 0) {
+			return -EIO;
+		}
+
+		LOG_DBG("GPS priority enabled");
+	} else {
+		retval = nrf_setsockopt(drv_data->socket,
+					NRF_SOL_GNSS,
+					NRF_SO_GNSS_DISABLE_PRIORITY, NULL, 0);
+		if (retval != 0) {
+			return -EIO;
+		}
+
+		LOG_DBG("GPS priority disabled");
+	}
+
+	/* The GPS has to be started again here because setting the option
+	 * NRF_SO_GNSS_ENABLE_PRIORITY or NRF_SO_GNSS_DISABLE_PRIORITY
+	 * implicitly stops the GPS.
+	 */
+	retval = nrf_setsockopt(drv_data->socket,
+				NRF_SOL_GNSS,
+				NRF_SO_GNSS_START,
+				&delete_mask,
+				sizeof(delete_mask));
+	if (retval != 0) {
+		LOG_ERR("Failed to start GPS");
+		return -EIO;
+	}
+
+	return 0;
 }
 
 static void gps_thread(int dev_ptr)
@@ -296,6 +342,16 @@ wait:
 
 				notify_event(dev, &evt);
 
+				/* If GPS is blocked more than the specified
+				 * duration and GPS priority is set by the
+				 * application, GPS priority is requested.
+				 */
+				if (drv_data->current_cfg.priority) {
+					k_delayed_work_submit(
+						&drv_data->blocked_work,
+						K_SECONDS(GPS_BLOCKED_TIMEOUT));
+				}
+
 				continue;
 			} else if (operation_blocked) {
 				/* GPS has been unblocked. */
@@ -305,6 +361,8 @@ wait:
 				evt.type = GPS_EVT_OPERATION_UNBLOCKED;
 
 				notify_event(dev, &evt);
+
+				k_delayed_work_cancel(&drv_data->blocked_work);
 			}
 
 			copy_pvt(&evt.pvt, &raw_gps_data.pvt);
@@ -617,36 +675,13 @@ set_configuration:
 		return -EIO;
 	}
 
-	if (gps_cfg.priority) {
-		retval = nrf_setsockopt(drv_data->socket,
-					NRF_SOL_GNSS,
-					NRF_SO_GNSS_ENABLE_PRIORITY, NULL, 0);
+	if (!gps_cfg.priority) {
+		retval = gps_priority_set(drv_data, false);
 		if (retval != 0) {
-			LOG_ERR("Failed to enable GPS priority");
-			return -EIO;
+			LOG_ERR("Failed to set GPS priority, error: %d",
+				retval);
+			return retval;
 		}
-	} else {
-		retval = nrf_setsockopt(drv_data->socket,
-					NRF_SOL_GNSS,
-					NRF_SO_GNSS_DISABLE_PRIORITY, NULL, 0);
-		if (retval != 0) {
-			LOG_ERR("Failed to disable GPS priority");
-			return -EIO;
-		}
-	}
-
-	/* The GPS has to be started again here because setting the options
-	 * NRF_SO_GNSS_ENABLE_PRIORITY or NRF_SO_GNSS_ENABLE_PRIORITY
-	 * implicitly stops the GPS.
-	 */
-	retval = nrf_setsockopt(drv_data->socket,
-				NRF_SOL_GNSS,
-				NRF_SO_GNSS_START,
-				&gps_cfg.delete_mask,
-				sizeof(gps_cfg.delete_mask));
-	if (retval != 0) {
-		LOG_ERR("Failed to start GPS");
-		return -EIO;
 	}
 
 	atomic_set(&drv_data->is_active, 1);
@@ -778,6 +813,18 @@ static void timeout_work_fn(struct k_work *work)
 	notify_event(dev, &evt);
 }
 
+static void blocked_work_fn(struct k_work *work)
+{
+	int retval;
+	struct gps_drv_data *drv_data =
+		CONTAINER_OF(work, struct gps_drv_data, blocked_work);
+
+	retval = gps_priority_set(drv_data, true);
+	if (retval != 0) {
+		LOG_ERR("Failed to set GPS priority, error: %d", retval);
+	}
+}
+
 static int agps_write(struct device *dev, enum gps_agps_type type, void *data,
 		      size_t data_len)
 {
@@ -825,6 +872,7 @@ static int init(struct device *dev, gps_event_handler_t handler)
 
 	k_delayed_work_init(&drv_data->stop_work, stop_work_fn);
 	k_delayed_work_init(&drv_data->timeout_work, timeout_work_fn);
+	k_delayed_work_init(&drv_data->blocked_work, blocked_work_fn);
 	k_sem_init(&drv_data->thread_run_sem, 0, 1);
 
 	err = init_thread(dev);


### PR DESCRIPTION
Add functionality that checks if GPS is blocked for
more than a configurable amount of time. If this is the
case and the GPS prio flag has been enabled in the GPS
configuration struct, GPS priority is enabled.