### PR TITLE
drivers: gps: nrf9160_gps: Enable restart of already running gps.

### DIFF
--- a/drivers/gps/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/gps/nrf9160_gps/nrf9160_gps.c
@@ -520,8 +520,8 @@ static int start(struct device *dev, struct gps_config *cfg)
 	}
 
 	if (atomic_get(&drv_data->is_active)) {
-		LOG_WRN("GPS is already active");
-		return -EALREADY;
+		LOG_DBG("GPS is already active. Clean up before restart");
+		cancel_works(drv_data);
 	}
 
 	if (atomic_get(&drv_data->is_init) != 1) {

--- a/include/drivers/gps.h
+++ b/include/drivers/gps.h
@@ -249,6 +249,9 @@ struct gps_driver_api {
 /**
  * @brief Function to start GPS operation.
  *
+ * If gps is already running a call to this function will
+ * restart the gps.
+ *
  * @param dev Pointer to GPS device
  * @param cfg Pointer to GPS configuration.
  */


### PR DESCRIPTION
Now the gps will be restarted if already running when a start
request is sent.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>