### PR TITLE
Bluetooth: Mesh: DK Prov: Clarify UUID usage

### DIFF
--- a/include/bluetooth/mesh/dk_prov.rst
+++ b/include/bluetooth/mesh/dk_prov.rst
@@ -54,7 +54,9 @@ UUID
 ====
 
 The provisioning handler uses :cpp:func:`hwinfo_get_device_id` from the ``hwinfo`` driver to generate a unique, deterministic UUID for each device.
-The UUID is used in the unprovisioned beacon to identify the device.
+
+The UUID is used in the unprovisioned beacon and the broadcasted Mesh Provisioning Service data.
+It allows the Provisioners to uniquely identify the device before starting provisioning.
 
 API documentation
 =================


### PR DESCRIPTION
Expands the UUID text in the DK Prov module to specify exactly how the
UUID is used.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>