### PR TITLE
AWS IoT and jobs: use k_cycle_get_32() to generate message ID

### DIFF
--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -917,7 +917,7 @@ int aws_iot_send(const struct aws_iot_data *const tx_data)
 	param.message.topic.topic.size	= tx_data_pub.topic.len;
 	param.message.payload.data	= tx_data_pub.ptr;
 	param.message.payload.len	= tx_data_pub.len;
-	param.message_id		= sys_rand32_get();
+	param.message_id		= k_cycle_get_32();
 	param.dup_flag			= 0;
 	param.retain_flag		= 0;
 

--- a/subsys/net/lib/aws_jobs/src/aws_jobs.c
+++ b/subsys/net/lib/aws_jobs/src/aws_jobs.c
@@ -229,7 +229,7 @@ static int publish(struct mqtt_client *const client, const uint8_t *job_id,
 		.message.topic = topic,
 		.message.payload.data = payload_data,
 		.message.payload.len = payload_data_len,
-		.message_id = sys_rand32_get(),
+		.message_id = k_cycle_get_32(),
 		.dup_flag = 0,
 		.retain_flag = 0,
 	};


### PR DESCRIPTION
On nRF9160, sys_rand32_get() is a non-secure callable function,
which leads to some complication, and currently a risk of
hardfault. Therefore use k_cycle_get32() instead to generate
the message ID.
