### PR TITLE
KRKNWK-7497: zigbee: Enable MPSL in all Zigbee examples

### DIFF
--- a/samples/zigbee/light_switch/overlay-multiprotocol_ble.conf
+++ b/samples/zigbee/light_switch/overlay-multiprotocol_ble.conf
@@ -1,6 +1,3 @@
-# Enable multiprotocol service layer
-CONFIG_MPSL=y
-
 # Enable Bluetooth LE controller which supports multiprotocol
 CONFIG_BT_LL_SOFTDEVICE_DEFAULT=y
 

--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -11,6 +11,7 @@ menuconfig ZIGBEE
 	select PM_SINGLE_IMAGE
 	select NET_L2_ZIGBEE
 	select NETWORKING
+	imply MPSL
 	imply COUNTER
 	imply COUNTER_TIMER3
 	imply ENTROPY_GENERATOR


### PR DESCRIPTION
Change configuration of Zigbee examples to use MPSL in both single and multiprotocol examples.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>