### PR TITLE
Bluetooth: Mesh: Light Control regulator improvements

### DIFF
--- a/include/bluetooth/mesh/light_ctrl.h
+++ b/include/bluetooth/mesh/light_ctrl.h
@@ -84,42 +84,6 @@ enum bt_mesh_light_ctrl_prop {
 	BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY =
 		BT_MESH_PROP_ID_LIGHT_CTRL_REG_ACCURACY,
 
-	/** Regulator downwards integral coeffient (Kid).
-	 *
-	 *  - Unit: Unitless
-	 *  - Encoding: 32 bit floating point.
-	 *  - Range: 0 to 1000.0
-	 */
-	BT_MESH_LIGHT_CTRL_PROP_REG_KID =
-		BT_MESH_PROP_ID_LIGHT_CTRL_REG_KID,
-
-	/** Regulator upwards integral coeffient (Kiu).
-	 *
-	 *  - Unit: Unitless
-	 *  - Encoding: 32 bit floating point.
-	 *  - Range: 0 to 1000.0
-	 */
-	BT_MESH_LIGHT_CTRL_PROP_REG_KIU =
-		BT_MESH_PROP_ID_LIGHT_CTRL_REG_KIU,
-
-	/** Regulator downwards proportional coeffient (Kpd).
-	 *
-	 *  - Unit: Unitless
-	 *  - Encoding: 32 bit floating point.
-	 *  - Range: 0 to 1000.0
-	 */
-	BT_MESH_LIGHT_CTRL_PROP_REG_KPD =
-		BT_MESH_PROP_ID_LIGHT_CTRL_REG_KPD,
-
-	/** Regulator upwards proportional coeffient (Kpu).
-	 *
-	 *  - Unit: Unitless
-	 *  - Encoding: 32 bit floating point.
-	 *  - Range: 0 to 1000.0
-	 */
-	BT_MESH_LIGHT_CTRL_PROP_REG_KPU =
-		BT_MESH_PROP_ID_LIGHT_CTRL_REG_KPU,
-
 	/** Fade time for fading to the Prolong state.
 	 *
 	 *  - Unit: Seconds
@@ -182,6 +146,41 @@ enum bt_mesh_light_ctrl_prop {
 	 */
 	BT_MESH_LIGHT_CTRL_PROP_TIME_ON =
 		BT_MESH_PROP_ID_LIGHT_CTRL_TIME_RUN_ON,
+};
+
+/** Light Control Regulator Coefficients */
+enum bt_mesh_light_ctrl_coeff {
+	/** Regulator downwards integral coeffient (Kid).
+	 *
+	 *  - Unit: Unitless
+	 *  - Encoding: 32 bit floating point.
+	 *  - Range: 0 to 1000.0
+	 */
+	BT_MESH_LIGHT_CTRL_COEFF_KID = BT_MESH_PROP_ID_LIGHT_CTRL_REG_KID,
+
+	/** Regulator upwards integral coeffient (Kiu).
+	 *
+	 *  - Unit: Unitless
+	 *  - Encoding: 32 bit floating point.
+	 *  - Range: 0 to 1000.0
+	 */
+	BT_MESH_LIGHT_CTRL_COEFF_KIU = BT_MESH_PROP_ID_LIGHT_CTRL_REG_KIU,
+
+	/** Regulator downwards proportional coeffient (Kpd).
+	 *
+	 *  - Unit: Unitless
+	 *  - Encoding: 32 bit floating point.
+	 *  - Range: 0 to 1000.0
+	 */
+	BT_MESH_LIGHT_CTRL_COEFF_KPD = BT_MESH_PROP_ID_LIGHT_CTRL_REG_KPD,
+
+	/** Regulator upwards proportional coeffient (Kpu).
+	 *
+	 *  - Unit: Unitless
+	 *  - Encoding: 32 bit floating point.
+	 *  - Range: 0 to 1000.0
+	 */
+	BT_MESH_LIGHT_CTRL_COEFF_KPU = BT_MESH_PROP_ID_LIGHT_CTRL_REG_KPU,
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/bluetooth/mesh/light_ctrl_cli.h
+++ b/include/bluetooth/mesh/light_ctrl_cli.h
@@ -110,6 +110,21 @@ struct bt_mesh_light_ctrl_cli_handlers {
 		     struct bt_mesh_msg_ctx *ctx,
 		     enum bt_mesh_light_ctrl_prop id,
 		     const struct sensor_value *value);
+
+	/** @brief Light LC Regulator Coefficient status handler.
+	 *
+	 *  The Light Lightness Control Server's Regulator Coeffients control
+	 *  its Illuminance Regulator's response.
+	 *
+	 *  @param[in] cli   Client that received the message.
+	 *  @param[in] ctx   Context of the message.
+	 *  @param[in] id    ID of the property.
+	 *  @param[in] value Value of the property.
+	 */
+	void (*coeff)(struct bt_mesh_light_ctrl_cli *cli,
+		     struct bt_mesh_msg_ctx *ctx,
+		     enum bt_mesh_light_ctrl_coeff id,
+		     float value);
 };
 
 /** @brief Light Lightness Control Client instance.
@@ -194,8 +209,7 @@ int bt_mesh_light_ctrl_cli_mode_set(struct bt_mesh_light_ctrl_cli *cli,
  *                     parameters.
  *  @param[in] enabled The new Mode to set.
  *
- *  @retval 0              Successfully sent the message and populated the @c
- *                         rsp buffer.
+ *  @retval 0              Successfully sent the message.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
@@ -272,8 +286,7 @@ int bt_mesh_light_ctrl_cli_occupancy_enabled_set(
  *                     parameters.
  *  @param[in] enabled The new Occupancy Mode to set.
  *
- *  @retval 0              Successfully sent the message and populated the @c
- *                         rsp buffer.
+ *  @retval 0              Successfully sent the message.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
@@ -353,8 +366,7 @@ int bt_mesh_light_ctrl_cli_light_onoff_set(struct bt_mesh_light_ctrl_cli *cli,
  *                  to override the Server's default fade time, or @c transition
  *                  may be set to NULL.
  *
- *  @retval 0              Successfully sent the message and populated the @c
- *                         rsp buffer.
+ *  @retval 0              Successfully sent the message.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
@@ -432,11 +444,10 @@ int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
  *  @param[in]  cli Client model to send on.
  *  @param[in]  ctx Message context, or NULL to use the configured publish
  *                  parameters.
- *  @param[in]  id  Light Lightness Control Server property to get.
+ *  @param[in]  id  Light Lightness Control Server property to set.
  *  @param[in]  val New property value.
  *
- *  @retval 0              Successfully sent the message and populated the @c
- *                         rsp buffer.
+ *  @retval 0              Successfully sent the message.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
@@ -445,6 +456,79 @@ int bt_mesh_light_ctrl_cli_prop_set_unack(struct bt_mesh_light_ctrl_cli *cli,
 					  struct bt_mesh_msg_ctx *ctx,
 					  enum bt_mesh_light_ctrl_prop id,
 					  const struct sensor_value *val);
+
+/** @brief Get a Light Lightness Control Server Regulator Coefficient value.
+ *
+ *  Regulator coefficients are the configuration parameters for the Light
+ *  Lightness Control Server Illuminance Regulator.
+ *
+ *  @param[in]  cli Client model to send on.
+ *  @param[in]  ctx Message context, or NULL to use the configured publish
+ *                  parameters.
+ *  @param[in]  id  Light Lightness Control Server coefficient to get.
+ *  @param[in]  rsp Coefficient value response buffer, or NULL to keep from
+ *                  blocking.
+ *
+ *  @retval 0              Successfully sent the message and populated the @c
+ *                         rsp buffer.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
+ */
+int bt_mesh_light_ctrl_cli_coeff_get(struct bt_mesh_light_ctrl_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     enum bt_mesh_light_ctrl_coeff id,
+				     float *rsp);
+
+/** @brief Set a Light Lightness Control Server Regulator Coefficient value.
+ *
+ *  Regulator coefficients are the configuration parameters for the Light
+ *  Lightness Control Server Illuminance Regulator.
+ *
+ *  @param[in]  cli Client model to send on.
+ *  @param[in]  ctx Message context, or NULL to use the configured publish
+ *                  parameters.
+ *  @param[in]  id  Light Lightness Control Server coefficient to set.
+ *  @param[in]  val New coefficient value.
+ *  @param[in]  rsp Coefficient value response buffer, or NULL to keep from
+ *                  blocking.
+ *
+ *  @retval 0              Successfully sent the message and populated the @c
+ *                         rsp buffer.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
+ */
+int bt_mesh_light_ctrl_cli_coeff_set(struct bt_mesh_light_ctrl_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     enum bt_mesh_light_ctrl_coeff id,
+				     float val, float *rsp);
+
+/** @brief Set a Light Lightness Control Server Regulator Coefficient value
+ *         without requesting a response.
+ *
+ *  Regulator coefficients are the configuration parameters for the Light
+ *  Lightness Control Server Illuminance Regulator.
+ *
+ *  @param[in]  cli Client model to send on.
+ *  @param[in]  ctx Message context, or NULL to use the configured publish
+ *                  parameters.
+ *  @param[in]  id  Light Lightness Control Server coefficient to set.
+ *  @param[in]  val New coefficient value.
+ *
+ *  @retval 0              Successfully sent the message.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_light_ctrl_cli_coeff_set_unack(struct bt_mesh_light_ctrl_cli *cli,
+					   struct bt_mesh_msg_ctx *ctx,
+					   enum bt_mesh_light_ctrl_coeff id,
+					   float val);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_light_ctrl_cli_op[];

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -105,14 +105,14 @@ struct bt_mesh_light_ctrl_srv_cfg {
 struct bt_mesh_light_ctrl_srv_reg_cfg {
 	/** Target illuminance values */
 	struct sensor_value lux[LIGHT_CTRL_STATE_COUNT];
-	/** Regulator positive integral coefficient */
-	uint16_t kiu;
-	/** Regulator negative integral coefficient */
-	uint16_t kid;
-	/** Regulator positive propotional coefficient */
-	uint16_t kpu;
-	/** Regulator negative propotional coefficient */
-	uint16_t kpd;
+	/** Regulator upwards integral coefficient */
+	float kiu;
+	/** Regulator downwards integral coefficient */
+	float kid;
+	/** Regulator upwards propotional coefficient */
+	float kpu;
+	/** Regulator downwards propotional coefficient */
+	float kpd;
 	/** Regulator dead zone (in percent) */
 	uint8_t accuracy;
 };
@@ -122,7 +122,7 @@ struct bt_mesh_light_ctrl_srv_reg {
 	/** Regulator step timer */
 	struct k_delayed_work timer;
 	/** Internal integral sum. */
-	uint16_t i;
+	float i;
 	/** Regulator configuration */
 	struct bt_mesh_light_ctrl_srv_reg_cfg cfg;
 };

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -123,6 +123,8 @@ struct bt_mesh_light_ctrl_srv_reg {
 	struct k_delayed_work timer;
 	/** Internal integral sum. */
 	float i;
+	/** Previous output */
+	uint16_t prev;
 	/** Regulator configuration */
 	struct bt_mesh_light_ctrl_srv_reg_cfg cfg;
 };

--- a/include/bluetooth/mesh/light_ctrl_srv.rst
+++ b/include/bluetooth/mesh/light_ctrl_srv.rst
@@ -302,14 +302,11 @@ For each step, the regulator:
 #. Multiplies this sum by an integral coefficient.
 #. Summarizes the sum with the raw difference multiplied by a proportional coefficient.
 
-Both the internal integral sum and the output level is represented as an unsigned 16-bit integer.
+The error, the regulator coefficients, and the internal sum, are represented as 32-bit floating point values.
+The resulting output level is represented as an unsigned 16-bit integer.
 
 To reduce noise, the regulator has a configurable accuracy property, which allows it to ignore errors smaller than the configured accuracy (represented as a percentage of the light level).
 See :option:`CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_ACCURACY` and :cpp:enumerator:`BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY <bt_mesh_light_ctrl::BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY>` for more information.
-
-.. note::
-   The illuminance regulator implementation only supports integers in its configuration.
-   The fractional part of coefficients, accuracy, and target levels is ignored.
 
 Sensor input
 ------------

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -321,7 +321,7 @@ comment "Target Illuminance"
 config BT_MESH_LIGHT_CTRL_SRV_REG_LUX_ON
 	int "Default target illuminance in the On state"
 	range 0 167772
-	default 167772
+	default 500
 	help
 	  Target ambient illuminance for the On state (in lux). May be
 	  reconfigured at runtime by other models in the mesh network.
@@ -329,7 +329,7 @@ config BT_MESH_LIGHT_CTRL_SRV_REG_LUX_ON
 config BT_MESH_LIGHT_CTRL_SRV_REG_LUX_PROLONG
 	int "Default target illuminance in the Prolong state"
 	range 0 167772
-	default 83886
+	default 80
 	help
 	  Target ambient illuminance for the Prolong state (in lux). May be
 	  reconfigured at runtime by other models in the mesh network.

--- a/subsys/bluetooth/mesh/light_ctrl_cli.c
+++ b/subsys/bluetooth/mesh/light_ctrl_cli.c
@@ -8,6 +8,15 @@
 #include "model_utils.h"
 #include "light_ctrl_internal.h"
 
+union prop_value {
+	struct sensor_value prop;
+	float coeff;
+};
+struct prop_status_ctx {
+	uint16_t id;
+	union prop_value val;
+};
+
 static void handle_mode(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -111,32 +120,50 @@ static void handle_prop(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_light_ctrl_cli *cli = mod->user_data;
+	struct prop_status_ctx *rsp = cli->ack.user_data;
 	const struct bt_mesh_sensor_format *format;
-	struct sensor_value value;
+	union prop_value value;
 	int err;
 
 	uint16_t id = net_buf_simple_pull_le16(buf);
+	bool coeff = (id == BT_MESH_LIGHT_CTRL_COEFF_KID ||
+		      id == BT_MESH_LIGHT_CTRL_COEFF_KIU ||
+		      id == BT_MESH_LIGHT_CTRL_COEFF_KPD ||
+		      id == BT_MESH_LIGHT_CTRL_COEFF_KPU);
 
-	format = prop_format_get(id);
-	if (!format) {
-		return;
-	}
+	if (coeff) {
+		if (buf->len != sizeof(float)) {
+			return;
+		}
 
-	err = sensor_ch_decode(buf, format, &value);
-	if (err) {
-		return;
+		memcpy(&value.coeff,
+		       net_buf_simple_pull_mem(buf, sizeof(float)),
+		       sizeof(float));
+	} else {
+		format = prop_format_get(id);
+		if (!format) {
+			return;
+		}
+
+		err = sensor_ch_decode(buf, format, &value.prop);
+		if (err) {
+			return;
+		}
 	}
 
 	if (model_ack_match(&cli->ack, BT_MESH_LIGHT_CTRL_OP_PROP_STATUS,
-			    ctx)) {
-		struct sensor_value *ack_buf = cli->ack.user_data;
+			    ctx) && rsp->id == id) {
 
-		*ack_buf = value;
+		rsp->val = value;
 		model_ack_rx(&cli->ack);
 	}
 
-	if (cli->handlers && cli->handlers->prop) {
-		cli->handlers->prop(cli, ctx, id, &value);
+	if (coeff) {
+		if (cli->handlers && cli->handlers->coeff) {
+			cli->handlers->coeff(cli, ctx, id, value.coeff);
+		}
+	} else if (cli->handlers && cli->handlers->prop) {
+		cli->handlers->prop(cli, ctx, id, &value.prop);
 	}
 }
 
@@ -282,12 +309,26 @@ int bt_mesh_light_ctrl_cli_prop_get(struct bt_mesh_light_ctrl_cli *cli,
 				    enum bt_mesh_light_ctrl_prop id,
 				    struct sensor_value *rsp)
 {
+	struct prop_status_ctx ack = {
+		.id = id,
+	};
+	int err;
+
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHT_CTRL_OP_PROP_GET, 2);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_PROP_GET);
 	net_buf_simple_add_le16(&buf, id);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
-			       BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, rsp);
+	err = model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
+			      BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, &ack);
+	if (err) {
+		return err;
+	}
+
+	if (rsp) {
+		*rsp = ack.val.prop;
+	}
+
+	return 0;
 }
 
 int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
@@ -297,6 +338,9 @@ int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
 				    struct sensor_value *rsp)
 {
 	const struct bt_mesh_sensor_format *format;
+	struct prop_status_ctx ack = {
+		.id = id,
+	};
 	int err;
 
 	BT_MESH_MODEL_BUF_DEFINE(
@@ -315,8 +359,17 @@ int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
 		return err;
 	}
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
-			       BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, rsp);
+	err = model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
+			      BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, &ack);
+	if (err) {
+		return err;
+	}
+
+	if (rsp) {
+		*rsp = ack.val.prop;
+	}
+
+	return 0;
 }
 
 int bt_mesh_light_ctrl_cli_prop_set_unack(struct bt_mesh_light_ctrl_cli *cli,
@@ -342,6 +395,76 @@ int bt_mesh_light_ctrl_cli_prop_set_unack(struct bt_mesh_light_ctrl_cli *cli,
 	if (err) {
 		return err;
 	}
+
+	return model_send(cli->model, ctx, &buf);
+}
+
+int bt_mesh_light_ctrl_cli_coeff_get(struct bt_mesh_light_ctrl_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     enum bt_mesh_light_ctrl_coeff id,
+				     float *rsp)
+{
+	struct prop_status_ctx ack = {
+		.id = id,
+	};
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHT_CTRL_OP_PROP_GET, 2);
+	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_PROP_GET);
+	net_buf_simple_add_le16(&buf, id);
+
+	err = model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
+			      BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, &ack);
+	if (err) {
+		return err;
+	}
+
+	if (rsp) {
+		*rsp = ack.val.coeff;
+	}
+
+	return 0;
+}
+
+int bt_mesh_light_ctrl_cli_coeff_set(struct bt_mesh_light_ctrl_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     enum bt_mesh_light_ctrl_coeff id,
+				     float val, float *rsp)
+{
+	struct prop_status_ctx ack = {
+		.id = id,
+	};
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHT_CTRL_OP_PROP_SET,
+				 2 + sizeof(float));
+	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_PROP_SET);
+	net_buf_simple_add_le16(&buf, id);
+	net_buf_simple_add_mem(&buf, &val, sizeof(float));
+
+	err = model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
+			      BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, &ack);
+	if (err) {
+		return err;
+	}
+
+	if (rsp) {
+		*rsp = ack.val.coeff;
+	}
+
+	return 0;
+}
+
+int bt_mesh_light_ctrl_cli_coeff_set_unack(struct bt_mesh_light_ctrl_cli *cli,
+					   struct bt_mesh_msg_ctx *ctx,
+					   enum bt_mesh_light_ctrl_coeff id,
+					   float val)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHT_CTRL_OP_PROP_SET_UNACK,
+				 2 + sizeof(float));
+	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_PROP_SET_UNACK);
+	net_buf_simple_add_le16(&buf, id);
+	net_buf_simple_add_mem(&buf, &val, sizeof(float));
 
 	return model_send(cli->model, ctx, &buf);
 }

--- a/subsys/bluetooth/mesh/light_ctrl_internal.h
+++ b/subsys/bluetooth/mesh/light_ctrl_internal.h
@@ -35,11 +35,6 @@ prop_format_get(enum bt_mesh_light_ctrl_prop id)
 		return &bt_mesh_sensor_format_perceived_lightness;
 	case BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY:
 		return &bt_mesh_sensor_format_percentage_8;
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KID:
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KIU:
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPD:
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPU:
-		return &bt_mesh_sensor_format_coefficient;
 	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_PROLONG:
 	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_ON:
 	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_STANDBY_AUTO:

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -289,10 +289,16 @@ static uint16_t light_get(struct bt_mesh_light_ctrl_srv *srv)
 	return start + ((end - start) * curr) / srv->fade.duration;
 }
 
+#if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
+
+static float sensor_to_float(struct sensor_value *val)
+{
+	return val->val1 + val->val2 / 1000000.0f;
+}
+
 static void lux_get(struct bt_mesh_light_ctrl_srv *srv,
 		    struct sensor_value *lux)
 {
-#if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
 	if (!is_enabled(srv)) {
 		memset(lux, 0, sizeof(*lux));
 		return;
@@ -310,10 +316,35 @@ static void lux_get(struct bt_mesh_light_ctrl_srv *srv,
 	uint32_t centi_lux = init + ((cfg - init) * delta) / srv->fade.duration;
 
 	from_centi_lux(centi_lux, lux);
-#else
-	memset(lux, 0, sizeof(*lux));
-#endif
 }
+
+static float lux_getf(struct bt_mesh_light_ctrl_srv *srv)
+{
+	if (!is_enabled(srv)) {
+		return 0.0f;
+	}
+
+	if (atomic_test_bit(&srv->flags, FLAG_TRANSITION) &&
+	    srv->fade.duration) {
+		uint32_t delta = curr_fade_time(srv);
+		float init = sensor_to_float(&srv->fade.initial_lux);
+		float cfg = sensor_to_float(&srv->reg.cfg.lux[srv->state]);
+
+		return init + ((cfg - init) * delta) / srv->fade.duration;
+	}
+
+	return to_centi_lux(&srv->reg.cfg.lux[srv->state]) / 100.0f;
+}
+
+#else
+
+static void lux_get(struct bt_mesh_light_ctrl_srv *srv,
+		    struct sensor_value *lux)
+{
+	memset(lux, 0, sizeof(*lux));
+}
+
+#endif
 
 static void transition_start(struct bt_mesh_light_ctrl_srv *srv,
 			     enum bt_mesh_light_ctrl_srv_state state,
@@ -427,7 +458,7 @@ static void prolong(struct bt_mesh_light_ctrl_srv *srv)
 static void ctrl_enable(struct bt_mesh_light_ctrl_srv *srv)
 {
 	atomic_set_bit(&srv->lightness->flags, LIGHTNESS_SRV_FLAG_CONTROLLED);
-	BT_DBG("Light Control Enabled\n");
+	BT_DBG("Light Control Enabled");
 	transition_start(srv, LIGHT_CTRL_STATE_STANDBY, 0);
 	reg_start(srv);
 }
@@ -461,40 +492,38 @@ static void reg_step(struct k_work *work)
 		return;
 	}
 
-	struct sensor_value raw_lux;
+	k_delayed_work_submit(&srv->reg.timer, K_MSEC(REG_INT));
 
-	lux_get(srv, &raw_lux);
+	float target = lux_getf(srv);
+	float ambient = sensor_to_float(&srv->ambient_lux);
+	float error = target - ambient;
 
-	uint32_t lux = raw_lux.val1;
-	uint32_t ambient = srv->ambient_lux.val1;
-
-	int32_t error = lux - ambient;
 	/* Accuracy should be in percent and both up and down: */
-	uint32_t accuracy = (srv->reg.cfg.accuracy * lux) / (2 * 100);
-	int16_t input;
-	uint16_t output;
+	float accuracy = (srv->reg.cfg.accuracy * target) / (2 * 100.0f);
 
+	float input;
 	if (error > accuracy) {
 		input = error - accuracy;
 	} else if (error < -accuracy) {
 		input = error + accuracy;
 	} else {
-		return;
+		input = 0.0f;
 	}
 
+	float kp, ki;
 	if (input >= 0) {
-		int32_t p = input * srv->reg.cfg.kpu;
-		int32_t i = (input * REG_INT * srv->reg.cfg.kiu) / MSEC_PER_SEC;
-
-		srv->reg.i = MIN(UINT16_MAX, srv->reg.i + i);
-		output = MIN(UINT16_MAX, srv->reg.i + p);
+		kp = srv->reg.cfg.kpu;
+		ki = srv->reg.cfg.kiu;
 	} else {
-		int32_t p = input * srv->reg.cfg.kpd;
-		int32_t i = (input * REG_INT * srv->reg.cfg.kid) / MSEC_PER_SEC;
-
-		srv->reg.i = MAX(0, srv->reg.i + i);
-		output = MAX(0, srv->reg.i + p);
+		kp = srv->reg.cfg.kpd;
+		ki = srv->reg.cfg.kid;
 	}
+
+	srv->reg.i += (input * ki) * ((float)REG_INT / (float)MSEC_PER_SEC);
+	srv->reg.i = MIN(UINT16_MAX, MAX(0, srv->reg.i));
+
+	float p = input * kp;
+	uint16_t output = MIN(UINT16_MAX, MAX(0, (srv->reg.i + p)));
 
 	/* The regulator output is always in linear format. We'll convert to
 	 * the configured representation again before calling the Lightness
@@ -509,8 +538,6 @@ static void reg_step(struct k_work *work)
 	} else if (atomic_test_and_clear_bit(&srv->flags, FLAG_REGULATOR)) {
 		light_set(srv, light_to_repr(lvl, LINEAR), REG_INT);
 	}
-
-	k_delayed_work_submit(&srv->reg.timer, K_MSEC(REG_INT));
 }
 #endif
 
@@ -952,21 +979,23 @@ static int prop_get(struct net_buf_simple *buf,
 		    const struct bt_mesh_light_ctrl_srv *srv, uint16_t id)
 {
 	struct sensor_value val = { 0 };
-
 	switch (id) {
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KID:
-		val.val1 = srv->reg.cfg.kid;
-		break;
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KIU:
-		val.val1 = srv->reg.cfg.kiu;
-		break;
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPD:
-		val.val1 = srv->reg.cfg.kpd;
-		break;
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPU:
-		val.val1 = srv->reg.cfg.kpu;
-		break;
+	/* Regulator coefficients are raw IEEE-754 floats, push them straight
+	 * to the buffer instead of using sensor to encode them:
+	 */
+	case BT_MESH_LIGHT_CTRL_COEFF_KID:
+		net_buf_simple_add_mem(buf, &srv->reg.cfg.kid, sizeof(float));
+		return 0;
+	case BT_MESH_LIGHT_CTRL_COEFF_KIU:
+		net_buf_simple_add_mem(buf, &srv->reg.cfg.kiu, sizeof(float));
+		return 0;
+	case BT_MESH_LIGHT_CTRL_COEFF_KPD:
+		net_buf_simple_add_mem(buf, &srv->reg.cfg.kpd, sizeof(float));
+		return 0;
+	case BT_MESH_LIGHT_CTRL_COEFF_KPU:
+		net_buf_simple_add_mem(buf, &srv->reg.cfg.kpu, sizeof(float));
+		return 0;
 	case BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY:
 		val.val1 = srv->reg.cfg.accuracy;
 		break;
@@ -980,10 +1009,10 @@ static int prop_get(struct net_buf_simple *buf,
 		val = srv->reg.cfg.lux[LIGHT_CTRL_STATE_STANDBY];
 		break;
 #else
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KID:
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KIU:
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPD:
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPU:
+	case BT_MESH_LIGHT_CTRL_COEFF_KID:
+	case BT_MESH_LIGHT_CTRL_COEFF_KIU:
+	case BT_MESH_LIGHT_CTRL_COEFF_KPD:
+	case BT_MESH_LIGHT_CTRL_COEFF_KPU:
 	case BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY:
 	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_ON:
 	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_PROLONG:
@@ -1033,6 +1062,34 @@ static int prop_set(struct net_buf_simple *buf,
 	struct sensor_value val;
 	int err;
 
+#if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
+	/* Regulator coefficients are raw IEEE-754 floats, pull them straight
+	 * from the buffer instead of using sensor to decode them:
+	 */
+	switch (id) {
+	case BT_MESH_LIGHT_CTRL_COEFF_KID:
+		memcpy(&srv->reg.cfg.kid,
+		       net_buf_simple_pull_mem(buf, sizeof(float)),
+		       sizeof(float));
+		return 0;
+	case BT_MESH_LIGHT_CTRL_COEFF_KIU:
+		memcpy(&srv->reg.cfg.kiu,
+		       net_buf_simple_pull_mem(buf, sizeof(float)),
+		       sizeof(float));
+		return 0;
+	case BT_MESH_LIGHT_CTRL_COEFF_KPD:
+		memcpy(&srv->reg.cfg.kpd,
+		       net_buf_simple_pull_mem(buf, sizeof(float)),
+		       sizeof(float));
+		return 0;
+	case BT_MESH_LIGHT_CTRL_COEFF_KPU:
+		memcpy(&srv->reg.cfg.kpu,
+		       net_buf_simple_pull_mem(buf, sizeof(float)),
+		       sizeof(float));
+		return 0;
+	}
+#endif
+
 	err = prop_decode(buf, id, &val);
 	if (err) {
 		return err;
@@ -1042,18 +1099,6 @@ static int prop_set(struct net_buf_simple *buf,
 
 	switch (id) {
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KID:
-		srv->reg.cfg.kid = val.val1;
-		break;
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KIU:
-		srv->reg.cfg.kiu = val.val1;
-		break;
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPD:
-		srv->reg.cfg.kpd = val.val1;
-		break;
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPU:
-		srv->reg.cfg.kpu = val.val1;
-		break;
 	case BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY:
 		srv->reg.cfg.accuracy = val.val1;
 		break;
@@ -1067,10 +1112,10 @@ static int prop_set(struct net_buf_simple *buf,
 		srv->reg.cfg.lux[LIGHT_CTRL_STATE_STANDBY] = val;
 		break;
 #else
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KID:
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KIU:
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPD:
-	case BT_MESH_LIGHT_CTRL_PROP_REG_KPU:
+	case BT_MESH_LIGHT_CTRL_COEFF_KID:
+	case BT_MESH_LIGHT_CTRL_COEFF_KIU:
+	case BT_MESH_LIGHT_CTRL_COEFF_KPD:
+	case BT_MESH_LIGHT_CTRL_COEFF_KPU:
 	case BT_MESH_LIGHT_CTRL_PROP_REG_ACCURACY:
 	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_ON:
 	case BT_MESH_LIGHT_CTRL_PROP_ILLUMINANCE_PROLONG:

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -533,6 +533,11 @@ static void reg_step(struct k_work *work)
 
 	/* Output value is max out of regulator and configured level. */
 	if (output > lvl) {
+		if (output == srv->reg.prev) {
+			return;
+		}
+
+		srv->reg.prev = output;
 		atomic_set_bit(&srv->flags, FLAG_REGULATOR);
 		light_set(srv, light_to_repr(output, LINEAR), REG_INT);
 	} else if (atomic_test_and_clear_bit(&srv->flags, FLAG_REGULATOR)) {


### PR DESCRIPTION
Makes all illuminance regulator coefficients, as well as internal values
in the regulator processing floating point values.

Separates the Light Control Client's coefficient configuration from the
other properties to allow floating point coefficients in the client as
well.

Adds steady state detection to the illuminance regulator to reduce the
amount of value changes propagated to the application.
