### PR TITLE
drivers: gps: nrf9160_gps: Change log level

### DIFF
--- a/drivers/gps/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/gps/nrf9160_gps/nrf9160_gps.c
@@ -556,7 +556,7 @@ set_configuration:
 				sizeof(gps_cfg.retry));
 
 	if ((retval == -1) && ((errno == EFAULT) || (errno == EBADF))) {
-		LOG_WRN("Failed to set fix retry value, "
+		LOG_DBG("Failed to set fix retry value, "
 			"will try to re-init GPS service");
 
 		nrf_close(drv_data->socket);


### PR DESCRIPTION
If the GPS is restarted during an active GPS search
the setting of the GPS retry parameter will fail. The
GPS-service is then reinitialized before the
aforementioned parameter is successfully set. This is
expected behaviour and the error message propogated
upon the parameter set attempt should be treated as
a debug output rather than a warning.