### PR TITLE
applications: nrf_desktop: Add section to orient orphan sections into

### DIFF
--- a/subsys/event_manager/CMakeLists.txt
+++ b/subsys/event_manager/CMakeLists.txt
@@ -7,3 +7,5 @@
 zephyr_include_directories(.)
 zephyr_sources(event_manager.c)
 zephyr_sources_ifdef(CONFIG_SHELL event_manager_shell.c)
+
+zephyr_linker_sources(SECTIONS em.ld)

--- a/subsys/event_manager/em.ld
+++ b/subsys/event_manager/em.ld
@@ -1,0 +1,4 @@
+SECTION_DATA_PROLOGUE(event_manager,,)
+{
+	KEEP(*("event_manager"));
+} GROUP_DATA_LINK_IN(ROMABLE_REGION, ROMABLE_REGION)

--- a/subsys/event_manager/event_manager.c
+++ b/subsys/event_manager/event_manager.c
@@ -14,6 +14,12 @@
 LOG_MODULE_REGISTER(event_manager, CONFIG_DESKTOP_EVENT_MANAGER_LOG_LEVEL);
 
 
+/* Event manager uses orphan sections. Below tag will allow linker to
+ * find a section usable to put the orphan sections next to.
+ */
+const struct {} linker_tag __attribute__((__section__("event_manager"))) __used;
+
+
 static void event_processor_fn(struct k_work *work);
 
 


### PR DESCRIPTION
This commit adds a section into which an zero size element is places.
Its only purpose is to allow linker to place orphan sections
used by event manager behind it so arrays it creates won't be
moved to RAM.

Jira:DESK-1091

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>