### PR TITLE
applications: nrf_desktop: Fix handling heap OOM

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -324,8 +324,9 @@ static void enqueue_hid_report(struct enqueued_reports *enqueued_reports,
 	}
 
 	if (!item) {
-		LOG_ERR("OOM error");
-		module_set_state(MODULE_STATE_ERROR);
+		LOG_ERR("Dropped HID report");
+		/* Should never happen. */
+		__ASSERT_NO_MSG(false);
 	} else {
 		item->report = report;
 		sys_slist_append(&reports->list, &item->node);

--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -257,7 +257,9 @@ static void eventq_append(struct eventq *eventq, uint16_t usage_id, int16_t valu
 	struct item_event *hid_event = k_malloc(sizeof(*hid_event));
 
 	if (!hid_event) {
-		LOG_WRN("Failed to allocate HID event");
+		LOG_ERR("Failed to allocate HID event");
+		/* Should never happen. */
+		__ASSERT_NO_MSG(false);
 		return;
 	}
 


### PR DESCRIPTION
Change adds assert to make sure that the OOM related to HID data will not be overlooked in debug configurations. In release configurations, the application will drop the HID data.

Jira:DESK-1092