### PR TITLE
samples: nrf9160: nrf_cloud_agps: document CLOUD_EVT_DISCONNECTED event

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -257,6 +257,8 @@
 .. _`Add certificates to the DPS instance`: https://docs.microsoft.com/en-us/azure/iot-dps/how-to-verify-certificates
 .. _`Registering the device with Azure IoT Hub`: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-create-through-portal#register-a-new-device-in-the-iot-hub
 
+.. _`AWS IoT Just-in-time-provisioning`: https://aws.amazon.com/blogs/iot/just-in-time-registration-of-device-certificates-on-aws-iot/
+
 .. ### Links to Bluetooth specs
 
 .. _`Bluetooth Core Specification`: https://www.bluetooth.com/specifications/bluetooth-core-specification

--- a/samples/nrf9160/agps/README.rst
+++ b/samples/nrf9160/agps/README.rst
@@ -134,6 +134,13 @@ Testing
 	  +CEREG: 1,"7725","0138E000",7,,,"00000010","00000110"
 	  I: Network registration status: Connected - home network
 
+   .. note::
+      If the credentials on the device are used to connect to nRF Cloud for the first time, the device will be disconnected, and a :cpp:enumerator:`CLOUD_EVT_DISCONNECTED <cloud_api::CLOUD_EVT_DISCONNECTED>` event will be logged on the terminal.
+      This happens due to the configuring of the device on the cloud by `AWS IoT Just-in-time-provisioning`_ and the subsequent termination of the connection.
+      In general, the devices reconnect automatically.
+      However, for the simplicity of the sample, reconnection is not implemented.
+      Hence you must reset the device manually.
+
 #. Make sure that GPS has started by confirming that the device requests GPS assistance data and receives a response.
    You can do this by checking the logs.
 


### PR DESCRIPTION
This documents the appearance of the `CLOUD_EVT_DISCONNECTED` event
and that users must manually reset the device.