### PR TITLE
cmake: use correct board for adding empty_app_core

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -78,6 +78,6 @@ if (CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE)
   add_child_image(
     NAME empty_app_core
     SOURCE_DIR ${NRF_DIR}/samples/nrf5340/empty_app_core
-    DOMAIN CPUNET
-    BOARD ${CONFIG_DOMAIN_CPUNET_BOARD})
+    DOMAIN CPUAPP
+    BOARD ${CONFIG_DOMAIN_CPUAPP_BOARD})
 endif()

--- a/samples/nrf5340/empty_app_core/CMakeLists.txt
+++ b/samples/nrf5340/empty_app_core/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_minimum_required(VERSION 3.13.1)
 
 set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuapp
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d14bfb6a9e06541842ecb73e042b076ff98ed59f
+      revision: 8c29f2762b71ad1ad47df00557ce35efcda89c3d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
when adding 'empty_app_core' sample as child image,
the domain should be the app core, not the net core.

Also update west.yml to include the domain board
configuration for the app core domain.

Ref: NCSDK-6542

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>