### PR TITLE
samples: timeslot: Build for nRF53 in CI

### DIFF
--- a/samples/mpsl/timeslot/sample.yaml
+++ b/samples/mpsl/timeslot/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.mpsl.timeslot:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpunet
     tags: ci_build


### PR DESCRIPTION
This builds the sample for the network core and places the empty app
image on the application core.

Requires: https://github.com/nrfconnect/sdk-nrf/pull/3020