### PR TITLE
drivers: temp_nrf5: Add temperature sensor using MPSL

### DIFF
--- a/drivers/mpsl/CMakeLists.txt
+++ b/drivers/mpsl/CMakeLists.txt
@@ -6,3 +6,4 @@
 
 add_subdirectory_ifdef(CONFIG_CLOCK_CONTROL_MPSL clock_control)
 add_subdirectory_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL flash_sync)
+add_subdirectory_ifdef(CONFIG_TEMP_NRF5_MPSL temp_nrf5)

--- a/drivers/mpsl/Kconfig
+++ b/drivers/mpsl/Kconfig
@@ -6,3 +6,9 @@
 
 rsource "clock_control/Kconfig"
 rsource "flash_sync/Kconfig"
+
+if SENSOR
+
+rsource "temp_nrf5/Kconfig"
+
+endif # SENSOR

--- a/drivers/mpsl/temp_nrf5/CMakeLists.txt
+++ b/drivers/mpsl/temp_nrf5/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_library()
+
+zephyr_library_sources_ifdef(CONFIG_TEMP_NRF5_MPSL temp_nrf5_mpsl.c)
+
+if(CONFIG_TEMP_NRF5 AND CONFIG_TEMP_NRF5_MPSL)
+  message(FATAL_ERROR "CONFIG_TEMP_NRF5 and CONFIG_TEMP_NRF5_MPSL have both been enabled, but must not be used together.")
+endif()

--- a/drivers/mpsl/temp_nrf5/Kconfig
+++ b/drivers/mpsl/temp_nrf5/Kconfig
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+# nRF5 MPSL temperature API configuration options
+
+config TEMP_NRF5_MPSL
+	bool "nRF5 MPSL Temperature Sensor"
+	depends on HAS_HW_NRF_TEMP && MPSL
+	help
+	  Enable MPSL driver for nRF5 temperature sensor.

--- a/drivers/mpsl/temp_nrf5/temp_nrf5_mpsl.c
+++ b/drivers/mpsl/temp_nrf5/temp_nrf5_mpsl.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nordic_nrf_temp
+
+#include <device.h>
+#include <drivers/sensor.h>
+#include <logging/log.h>
+#include <mpsl_temp.h>
+
+LOG_MODULE_REGISTER(temp_nrf5_mpsl, CONFIG_SENSOR_LOG_LEVEL);
+
+/* The MPSL temperature API returns measurements in 0.25C
+ * increments. Increments per degree.
+ */
+#define TEMP_NRF5_MPSL_INC_PER_DEGREE_C 4UL
+/* Mask for fractional increments */
+#define TEMP_NRF5_MPSL_FRACTIONAL_INC_MSK 3UL
+/* Millidegrees Celsius per increment */
+#define TEMP_NRF5_MPSL_MILLIDEGREE_C_PER_INC 250000UL
+
+struct temp_nrf5_mpsl_data {
+	int32_t sample;
+};
+
+static int temp_nrf5_mpsl_sample_fetch(const struct device *dev,
+				       enum sensor_channel chan)
+{
+	struct temp_nrf5_mpsl_data *data = dev->data;
+
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_DIE_TEMP) {
+		return -ENOTSUP;
+	}
+
+	data->sample = mpsl_temperature_get();
+	LOG_DBG("sample: %d", data->sample);
+
+	return 0;
+}
+
+static int temp_nrf5_mpsl_channel_get(const struct device *dev,
+				      enum sensor_channel chan,
+				      struct sensor_value *val)
+{
+	struct temp_nrf5_mpsl_data *data = dev->data;
+	int32_t uval;
+	uint32_t uval_abs;
+	uint32_t val1_abs;
+	uint32_t val2_abs;
+
+	if (chan != SENSOR_CHAN_DIE_TEMP) {
+		return -ENOTSUP;
+	}
+
+	uval = data->sample;
+	uval_abs = (uval < 0) ? (-uval) : uval;
+
+	val1_abs = uval_abs / TEMP_NRF5_MPSL_INC_PER_DEGREE_C;
+	val2_abs = (uval_abs & TEMP_NRF5_MPSL_FRACTIONAL_INC_MSK) *
+		   TEMP_NRF5_MPSL_MILLIDEGREE_C_PER_INC;
+
+	if (uval < 0) {
+		val->val1 = -(int32_t)val1_abs;
+		val->val2 = -(int32_t)val2_abs;
+	} else {
+		val->val1 = (int32_t)val1_abs;
+		val->val2 = (int32_t)val2_abs;
+	}
+
+	LOG_DBG("Temperature:%d,%d", val->val1, val->val2);
+
+	return 0;
+}
+
+static const struct sensor_driver_api temp_nrf5_mpsl_driver_api = {
+	.sample_fetch = temp_nrf5_mpsl_sample_fetch,
+	.channel_get = temp_nrf5_mpsl_channel_get,
+};
+
+static int temp_nrf5_mpsl_init(const struct device *dev)
+{
+	(void)dev;
+
+	LOG_DBG("");
+
+	return 0;
+}
+
+static struct temp_nrf5_mpsl_data temp_nrf5_mpsl_driver;
+
+DEVICE_AND_API_INIT(temp_nrf5_mpsl, DT_INST_LABEL(0), temp_nrf5_mpsl_init,
+		    &temp_nrf5_mpsl_driver, NULL, POST_KERNEL,
+		    CONFIG_SENSOR_INIT_PRIORITY, &temp_nrf5_mpsl_driver_api);


### PR DESCRIPTION
temp_nrf5 sensor driver in Zephyr is not designed do co-exist with MPSL.
This implementation introduces temperature sensor using MPSL temperature
measurement API.

Signed-off-by: Pawel Kwiek <pawel.kwiek@nordicsemi.no>