### PR TITLE
net: openthread: Fix invalid Kconfig

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -31,6 +31,7 @@ config OPENTHREAD_NRF_SECURITY
 	  if available as well as fast oberon backend for software encryption.
 
 config OPENTHREAD_MBEDTLS_LIB_NAME
+	string "Mbed TLS linked libraries"
 	default "mbedtls_common mbedcrypto_shared mbedcrypto_cc310 mbedcrypto_oberon mbedcrypto_vanilla" if CC310_BACKEND && OBERON_BACKEND && MBEDTLS_VANILLA_BACKEND
 	default "mbedtls_common mbedcrypto_shared mbedcrypto_cc310 mbedcrypto_oberon" if CC310_BACKEND && OBERON_BACKEND
 	default "mbedtls_common mbedcrypto_shared mbedcrypto_cc310 mbedcrypto_vanilla" if CC310_BACKEND && MBEDTLS_VANILLA_BACKEND


### PR DESCRIPTION
`OPENTHREAD_MBEDTLS_LIB_NAME` is defined without a type:
```
warning: OPENTHREAD_MBEDTLS_LIB_NAME (defined at /home/duranda/ncs/nrf/subsys/net/openthread/Kconfig:33) defined without a type

error: Aborting due to Kconfig warnings
```