### PR TITLE
Bluetooth: Mesh: Document time units

### DIFF
--- a/include/bluetooth/mesh/gen_dtt_cli.h
+++ b/include/bluetooth/mesh/gen_dtt_cli.h
@@ -62,7 +62,8 @@ struct bt_mesh_dtt_cli {
 	 *
 	 * @param[in] cli Client that received the message.
 	 * @param[in] ctx Message context.
-	 * @param[in] transition_time Transition time presented in the message.
+	 * @param[in] transition_time Transition time presented in the message,
+	 *                            in milliseconds.
 	 */
 	void (*const status_handler)(struct bt_mesh_dtt_cli *cli,
 				     struct bt_mesh_msg_ctx *ctx,
@@ -85,9 +86,10 @@ struct bt_mesh_dtt_cli {
  * @param[in] cli Client making the request.
  * @param[in] ctx Message context to use for sending, or NULL to publish with
  * the configured parameters.
- * @param[out] rsp_transition_time Pointer to a response buffer, or NULL to keep
- * from blocking. Note that the response is a signed value, that can be
- * K_FOREVER if the current state is unknown or too large to represent.
+ * @param[out] rsp_transition_time Pointer to a response buffer, or NULL to
+ * keep from blocking. The response denotes the configured transition time in
+ * milliseconds. Can be @em SYS_FOREVER_MS if the current state is unknown or
+ * too large to represent.
  *
  * @retval 0 Successfully retrieved the status of the bound srv.
  * @retval -EALREADY A blocking operation is already in progress in this model.
@@ -107,9 +109,10 @@ int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
  * the configured parameters.
  * @param[in] transition_time Transition time to set (in milliseconds). Must be
  * less than @ref BT_MESH_MODEL_TRANSITION_TIME_MAX_MS.
- * @param[out] rsp_transition_time Response buffer, or NULL to keep from
- * blocking. Note that the response is a signed value, that can be K_FOREVER if
- * the current state is unknown or too large to represent.
+ * @param[out] rsp_transition_time Pointer to a response buffer, or NULL to
+ * keep from blocking. The response denotes the configured transition time in
+ * milliseconds. Can be @em SYS_FOREVER_MS if the current state is unknown or
+ * too large to represent.
  *
  * @retval 0 Successfully sent the message and populated the
  * @p rsp_transition_time buffer.

--- a/include/bluetooth/mesh/gen_dtt_srv.h
+++ b/include/bluetooth/mesh/gen_dtt_srv.h
@@ -67,9 +67,9 @@ struct bt_mesh_dtt_srv {
 	 * @param[in] ctx Context of the set message that caused the update, or
 	 * NULL if the update was not a result of a set message.
 	 * @param[in] old_transition_time The transition time prior to the
-	 * update.
+	 * update, in milliseconds.
 	 * @param[in] new_transition_time The new transition time after the
-	 * update.
+	 * update, in milliseconds.
 	 */
 	void (*const update)(struct bt_mesh_dtt_srv *srv,
 			     struct bt_mesh_msg_ctx *ctx,
@@ -88,7 +88,7 @@ struct bt_mesh_dtt_srv {
  * publish.
  *
  * @param[in] srv Server to set the DTT of.
- * @param[in] transition_time New Default Transition Time.
+ * @param[in] transition_time New Default Transition Time, in milliseconds.
  */
 void bt_mesh_dtt_srv_set(struct bt_mesh_dtt_srv *srv, uint32_t transition_time);
 

--- a/include/bluetooth/mesh/gen_loc.h
+++ b/include/bluetooth/mesh/gen_loc.h
@@ -93,7 +93,9 @@ struct bt_mesh_loc_local {
 	int16_t floor_number;
 	/** Whether the device is movable. */
 	bool is_mobile;
-	/** Time since the previous position update, or @em K_FOREVER. */
+	/** Time since the previous position update in milliseconds, or
+	 *  @em SYS_FOREVER_MS.
+	 */
 	int32_t time_delta;
 	/** Precision of the location in millimeters. */
 	uint32_t precision_mm;

--- a/include/bluetooth/mesh/gen_lvl.h
+++ b/include/bluetooth/mesh/gen_lvl.h
@@ -103,8 +103,9 @@ struct bt_mesh_lvl_status {
 	 */
 	int16_t target;
 	/**
-	 * Time remaining of the ongoing transition, or @em K_FOREVER.
-	 * If there's no ongoing transition, @c remaining_time is 0.
+	 * Time remaining of the ongoing transition (in milliseconds),
+	 * or @em SYS_FOREVER_MS. If there's no ongoing transition,
+	 * @c remaining_time is 0.
 	 */
 	int32_t remaining_time;
 };

--- a/include/bluetooth/mesh/gen_plvl.h
+++ b/include/bluetooth/mesh/gen_plvl.h
@@ -70,8 +70,9 @@ struct bt_mesh_plvl_status {
 	/** Target Power Level. */
 	uint16_t target;
 	/**
-	 * Time remaining of the ongoing transition, or @em K_FOREVER.
-	 * If there's no ongoing transition, @c remaining_time is 0.
+	 * Time remaining of the ongoing transition in milliseconds, or
+	 * @em SYS_FOREVER_MS. If there's no ongoing transition,
+	 * @c remaining_time is 0.
 	 */
 	int32_t remaining_time;
 };

--- a/include/bluetooth/mesh/lightness.h
+++ b/include/bluetooth/mesh/lightness.h
@@ -45,8 +45,9 @@ struct bt_mesh_lightness_status {
 	/** Target Lightness level. */
 	uint16_t target;
 	/**
-	 * Time remaining of the ongoing transition, or @em K_FOREVER.
-	 * If there's no ongoing transition, @c remaining_time is 0.
+	 * Time remaining of the ongoing transition in milliseconds, or
+	 * @em SYS_FOREVER_MS. If there's no ongoing transition,
+	 * @c remaining_time is 0.
 	 */
 	int32_t remaining_time;
 };


### PR DESCRIPTION
Adds text for all model APIs with time values, denoting their time unit.
References SYS_FOREVER_MS in API doc, instead of K_FOREVER for all
affected APIs.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>