### PR TITLE
doc: add styling for local ToCs

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -25,12 +25,6 @@ This means that parts of the application functionality are separated into isolat
 Modules register themselves as listeners of those events that they are configured to react to.
 An application event can be submitted by multiple modules and it can have multiple listeners.
 
-See the following subsections for more information about the firmware architecture:
-
-.. contents::
-    :local:
-    :depth: 1
-
 Module and component overview
 =============================
 
@@ -91,12 +85,7 @@ Module usage per hardware type
 ==============================
 
 Since the application architecture is uniform and the code is shared, the set of modules in use depends on the selected device role.
-A different set of modules is enabled when the application is working as mouse, keyboard, or dongle:
-
-.. contents::
-    :local:
-    :depth: 1
-
+A different set of modules is enabled when the application is working as mouse, keyboard, or dongle.
 In other words, not all of the :ref:`nrf_desktop_app_internal_modules` need to be enabled for a given reference design.
 
 Gaming mouse module set
@@ -333,11 +322,7 @@ User interface
 **************
 
 The nRF Desktop configuration files have a set of preprogrammed options bound to different parts of the hardware.
-These options are related to the following functionalities:
-
-.. contents::
-    :local:
-    :depth: 1
+These options are related to the functionalities discussed in this section.
 
 Turning devices on and off
 ==========================
@@ -374,11 +359,7 @@ See the following figures for the exact location of these switches:
 Connectability
 ==============
 
-The nRF Desktop devices provide user input to the host in the same way as other mice and keyboards, using the following connection options:
-
-.. contents::
-    :local:
-    :depth: 1
+The nRF Desktop devices provide user input to the host in the same way as other mice and keyboards, using connection through USB or Bluetooth LE.
 
 The nRF Desktop devices support additional operations, like firmware upgrade or configuration change.
 The support is implemented through the :ref:`nrf_desktop_config_channel`.
@@ -416,11 +397,7 @@ No additional software or drivers are required.
 
 ..
 
-The following devices support the HID data transmission through USB:
-
-.. contents::
-    :local:
-    :depth: 1
+Gaming mouse, dongle, and DK support the HID data transmission through USB.
 
 Gaming mouse USB
 ~~~~~~~~~~~~~~~~
@@ -813,11 +790,7 @@ Integrating your own hardware
 *****************************
 
 This section describes how to adapt the nRF Desktop application to different hardware.
-It describes the configuration sources that are used for the default configuration, and lists steps required for adding a new board:
-
-.. contents::
-    :local:
-    :depth: 2
+It describes the configuration sources that are used for the default configuration, and lists steps required for adding a new board.
 
 Configuration sources
 =====================
@@ -983,11 +956,7 @@ You can use it as a reference for adding other hardware components.
 The nRF Desktop application comes with a :ref:`nrf_desktop_motion` that is able to read data from a motion sensor.
 While |NCS| provides support for two motion sensor drivers (PMW3360 and PAW3212), you can add support for a different sensor, based on your development needs.
 
-Complete the following steps to add a new motion sensor:
-
-.. contents::
-    :local:
-    :depth: 1
+Complete the steps described in the following sections to add a new motion sensor.
 
 1. Add a new sensor driver
 --------------------------
@@ -1404,12 +1373,7 @@ Background Device Firmware Upgrade
 ==================================
 
 The nRF Desktop application uses the background image transfer for the background DFU process.
-The firmware update process has the following stages:
-
-.. contents::
-    :local:
-    :depth: 1
-
+The firmware update process has three stages, discussed below.
 At the end of these three stages, the nRF Desktop application will be rebooted with the new firmware package installed.
 
 .. note::

--- a/applications/nrf_desktop/doc/usb_state.rst
+++ b/applications/nrf_desktop/doc/usb_state.rst
@@ -29,11 +29,7 @@ When enabling the USB support for the device, set the following generic device o
 * :option:`CONFIG_USB_DEVICE_VID` - Vendor ID (VID) number.
 * :option:`CONFIG_USB_DEVICE_PID` - Product ID (PID) number.
 
-Additionally, you can also configure the following options:
-
-.. contents::
-    :local:
-    :depth: 1
+Additionally, you can also configure the options described in the following sections.
 
 Low latency device configuration
 ================================

--- a/doc/nrf/ug_bt_mesh_architecture.rst
+++ b/doc/nrf/ug_bt_mesh_architecture.rst
@@ -38,11 +38,7 @@ The following figure demonstrates how the data packets flow between mesh nodes a
 
    Basic data flow within a mesh network in the |NCS| Bluetooth Mesh
 
-As an example, consider a Bluetooth Mesh network with three devices/mesh network nodes listed below, and the process that takes place on each node when the light switch on the source node is pressed:
-
-.. contents::
-   :local:
-   :depth: 1
+As an example, consider a Bluetooth Mesh network with three devices/mesh network nodes and the process that takes place on each node when the light switch on the source node is pressed, as discussed in the following sections.
 
 Source node with a light switch
 ===============================

--- a/doc/nrf/ug_bt_mesh_concepts.rst
+++ b/doc/nrf/ug_bt_mesh_concepts.rst
@@ -16,12 +16,7 @@ However, Bluetooth Mesh specifies a completely new host layer, and although some
 
    Relationship between Bluetooth Mesh and |BLE| specifications
 
-Read more about basic Bluetooth Mesh concepts in the following sections:
-
-.. contents::
-   :local:
-   :depth: 2
-
+This page describes basic Bluetooth Mesh concepts.
 Check the official `Bluetooth Mesh glossary`_ for definitions of the most important Bluetooth Mesh-related terms used in this documentation.
 
 .. _mesh_concepts_app_areas:

--- a/doc/nrf/ug_logging.rst
+++ b/doc/nrf/ug_logging.rst
@@ -18,11 +18,7 @@ You can obtain logging information from the following sources:
 For example, you can gather logging information about network events from network protocol applications and logging information about threads from Zephyr system kernel at the same time.
 
 This flexibility comes at a cost: the system's complexity requires different approach to configuration for single components and backends.
-See the following sections for more information:
-
-.. contents::
-    :local:
-    :depth: 1
+See the following sections for more information.
 
 .. _ug_logging_zephyr:
 
@@ -73,12 +69,6 @@ You can enable many backends at once and make them work simultaneously, if you w
 .. tip::
     As a recommendation, avoid selecting many backends using the same physical interface instance to avoid mutual interference.
     For example, instead of ``UART0`` for both, choose ``UART0`` for one backend and ``UART1`` for another.
-
-The following backends are available in |NCS|:
-
-.. contents::
-    :local:
-    :depth: 1
 
 UART
 ====

--- a/doc/nrf/ug_thread_architectures.rst
+++ b/doc/nrf/ug_thread_architectures.rst
@@ -7,10 +7,6 @@ This page describes the OpenThread stack architecture and platform designs that 
 
 The designs are described from the least to the most complex, that is from simple applications that consist of a single chip running single or multiple protocols to scenarios in which the nRF SoC acts as a network co-processor when the application is running on a much more powerful host processor.
 
-.. contents::
-    :local:
-    :depth: 1
-
 .. _openthread_stack_architecture:
 
 OpenThread stack architecture
@@ -123,10 +119,6 @@ Co-processor designs
 
 In the co-processor designs, with either network co-processor (NCP) or radio co-processor (RCP), the application layer runs on a host processor and communicates with OpenThread through a serial connection using a standardized host-controller protocol (Spinel).
 OpenThread can run on either the radio or the host processor.
-
-.. contents::
-    :local:
-    :depth: 1
 
 .. _thread_architectures_designs_cp_ncp:
 

--- a/doc/nrf/ug_thread_certification.rst
+++ b/doc/nrf/ug_thread_certification.rst
@@ -11,12 +11,7 @@ For general information about the certification process, check the `Thread Group
 Thread certification options
 ****************************
 
-Depending on your development approach, you have the following certification options when using Nordic Semiconductor devices.
-
-.. contents::
-	:local:
-	:depth: 2
-
+Depending on your development approach, you have several certification options when using Nordic Semiconductor devices.
 
 Certification by inheritance without modifications to binaries
 ==============================================================

--- a/doc/nrf/ug_thread_commissioning.rst
+++ b/doc/nrf/ug_thread_commissioning.rst
@@ -11,12 +11,6 @@ The whole process can happen within the Thread network (connectivity within the 
 This is the main difference between :ref:`thread_ot_commissioning_types_on-mesh` and :ref:`thread_ot_commissioning_types_external`, respectively.
 The whole commissioning process benefits from :ref:`several security measures <thread_ot_commissioning_roles_authentication>`, especially the DTLS protocol.
 
-This page describes the following commissioning topics:
-
-.. contents::
-    :local:
-    :depth: 2
-
 Once familiar with these concepts, read the following page:
 
 .. toctree::
@@ -118,11 +112,7 @@ See :ref:`thread_ot_commissioning_roles_authentication` for related information.
 Commissioning phases
 ********************
 
-The commissioning process has the following phases:
-
-.. contents::
-    :local:
-    :depth: 1
+The commissioning process goes through petitioning and joining.
 
 .. _thread_ot_commissioning_phases_petitioning:
 

--- a/doc/nrf/ug_thread_configuring.rst
+++ b/doc/nrf/ug_thread_configuring.rst
@@ -3,11 +3,7 @@
 Configuring Thread in |NCS|
 ###########################
 
-This page describes what is needed to start working with Thread in |NCS|:
-
-.. contents::
-    :local:
-    :depth: 2
+This page describes what is needed to start working with Thread in |NCS|.
 
 Required modules
 ****************
@@ -60,11 +56,7 @@ This includes the following options:
 Default configuration reference
     The default configuration for all :ref:`openthread_samples` is defined in :file:`nrf/samples/openthread/openthread.conf`.
 
-For other optional configuration options, see the following sections:
-
-.. contents::
-    :local:
-    :depth: 2
+For other optional configuration options, see the following sections.
 
 .. _ug_thread_configuring_crypto:
 

--- a/doc/nrf/ug_thread_ot_integration.rst
+++ b/doc/nrf/ug_thread_ot_integration.rst
@@ -4,11 +4,7 @@ OpenThread integration
 ######################
 
 This page explains how the OpenThread stack is integrated with Zephyr and |NCS|.
-It describes the location of components in the file structure, threads and synchronization primitives used, and the network traffic flow:
-
-.. contents::
-    :local:
-    :depth: 2
+It describes the location of components in the file structure, threads and synchronization primitives used, and the network traffic flow.
 
 Overview
 ********

--- a/doc/nrf/ug_zigbee_configuring.rst
+++ b/doc/nrf/ug_zigbee_configuring.rst
@@ -3,11 +3,7 @@
 Configuring Zigbee in |NCS|
 ###########################
 
-This page describes what is needed to start working with Zigbee in |NCS|:
-
-.. contents::
-    :local:
-    :depth: 2
+This page describes what is needed to start working with Zigbee in |NCS|.
 
 .. _zigbee_ug_libs:
 

--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -202,3 +202,24 @@ div.numbered-step>h6::before {
  border-top: 1px solid #ddd;
  padding-top: 20px;
 }
+
+
+/* add styling for a local ToC */
+
+.contents.local {
+    float: right;
+    border: 1px solid #ddd;
+    background-color: #fafafa;
+    padding: 10px 10px 0px 0px;
+    margin: 5px;
+    max-width: 30%;
+}
+
+.contents.local a {
+    font-size: 13px;
+    line-height: 13px;
+}
+
+.contents.local ul p {
+    margin-bottom: 0px;
+}

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -136,13 +136,10 @@ After building the sample and programming it to your development kit, test it by
 Testing with more boards
 ------------------------
 
-If you are using more than one development kit for testing the CLI sample, you can also complete the following testing procedures:
+If you are using more than one development kit for testing the CLI sample, you can also complete additional testing procedures.
 
-.. contents::
-    :local:
-    :depth: 1
-
-The following testing procedures assume you are using two development kits.
+.. note::
+    The following testing procedures assume you are using two development kits.
 
 Testing communication between boards
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Add styling for a local table of contents.
The local ToC will be added consistently in a separate commit.

Ref. NCSDK-6533

![image](https://user-images.githubusercontent.com/11227796/95058926-805a7500-06f8-11eb-9d12-834e55ce0244.png)

Do not merge yet - the text of existing pages must be updated first.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>