### PR TITLE
manifest: update softdevice controller and mpsl

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -418,6 +418,34 @@ static int hci_driver_open(void)
 		return -ENOMEM;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
+		err = sdc_support_adv();
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+		err = sdc_support_slave();
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_OBSERVER)) {
+		err = sdc_support_scan();
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		err = sdc_support_master();
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
 	if (IS_ENABLED(CONFIG_BT_DATA_LEN_UPDATE)) {
 		err = sdc_support_dle();
 		if (err) {

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 721f19da2be9e2848e507b9a12b6a504e227f2b7
+      revision: 8383a3600f87940982865ea015e01843f1d4e999
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Introduce some size optimization of SDC by using the new feature APIs.
See CHANGELOG for more details.

Update MPSL and SoftDevice Controller:
https://github.com/nrfconnect/sdk-nrfxlib/pull/285

(GNU Tools Arm Embedded/8 2019-q3-update/bin/arm-none-eabi-gcc)

nrf52840dk_nrf52840 |   | Before: 0639d781a6 | After | Change | Percentage
-- | -- | -- | -- | -- | --
beacon | FLASH | 156 | 108 | -48 | -30.77%
  | SRAM | 26 | 25 | -1 | -3.85%
central_hids | FLASH | 246 | 230 | -16 | -6.50%
  | SRAM | 34 | 35 | 1 | 2.94%
peripheral_hids_mouse | FLASH | 240 | 204 | -36 | -15.00%
  | SRAM | 35 | 35 | 0 | 0.00%
peripheral_hids_keyboard | FLASH | 253 | 217 | -36 | -14.23%
  | SRAM | 36 | 35 | -1 | -2.78%
nrf_desktop_gmouse | FLASH | 282 | 246 | -36 | -12.77%
  | SRAM | 39 | 39 | 0 | 0.00%
nrf_desktop_dongle | FLASH | 274 | 259 | -15 | -5.47%
  | SRAM | 42 | 42 | 0 | 0.00%

nrf52840dk_nrf52811 |   | Before: 0639d781a6 | After | Change | Percentage
-- | -- | -- | -- | -- | --
beacon | FLASH | 94 | 73 | -21 | -22.34%
  | SRAM | 19 | 19 | 0 | 0.00%
peripheral_hids_mouse | FLASH | 176 | 176 | 0 | 0.00%
overflowed by 4573 bytes | SRAM | 28 | 29 | 1 | 3.57%
peripheral_hids_keyboard | FLASH | 176 | 176 | 0 | 0.00%
overflowed by 4397 bytes | SRAM | 28 | 28 | 0 | 0.00%

Signed-off-by: Ryan Chu <Ryan.Chu@nordicsemi.no>