### PR TITLE
doc: update headings to include an automatic section divider

### DIFF
--- a/doc/nrf/ug_bt_mesh_architecture.rst
+++ b/doc/nrf/ug_bt_mesh_architecture.rst
@@ -26,8 +26,6 @@ The mesh stack's structure corresponds to the structure of the Bluetooth Mesh sp
 See the official `Bluetooth Mesh glossary`_ for definitions of the most important Bluetooth Mesh-related terms used in this documentation.
 You can also read about :ref:`basic Bluetooth Mesh concepts <mesh_concepts>` for a concise introduction to the Bluetooth Mesh.
 
-----
-
 .. _mesh_architecture_flow:
 
 Bluetooth Mesh network data flow
@@ -78,8 +76,6 @@ The following process takes place at this stage:
 
 The light bulb model may respond to acknowledge the transmission, following the same procedure back to the light switch node, which can notify the application that the on/off message was received.
 
-----
-
 .. _mesh_architecture_models:
 
 Models
@@ -92,8 +88,6 @@ All mesh communication happens through models, and any application that exposes 
 The Bluetooth Mesh Specification defines a set of immutable models for typical usage scenarios, but vendors are also free to implement their own models.
 
 You can read more about the Bluetooth Mesh models in |NCS| in :ref:`bt_mesh_models`.
-
-----
 
 .. _mesh_architecture_access:
 
@@ -111,8 +105,6 @@ As the device receives mesh messages, the access layer finds which models the me
 The access layer is implemented in Zephyr.
 For more information about the access layer, see :ref:`zephyr:bluetooth_mesh_access`.
 
-----
-
 .. _mesh_architecture_core:
 
 Bluetooth Mesh core
@@ -129,8 +121,6 @@ When receiving a mesh packet, the network layer decrypts the message, inspects t
 The Bluetooth Mesh core provides protection against malicious behavior and attacks against the mesh network through two-layer encryption, replay protection, and packet header obfuscation.
 The Bluetooth Mesh core is implemented in Zephyr.
 Read more about the Bluetooth Mesh core API in :ref:`zephyr:bluetooth_mesh_core`.
-
-----
 
 .. _mesh_architecture_provisioning:
 

--- a/doc/nrf/ug_bt_mesh_concepts.rst
+++ b/doc/nrf/ug_bt_mesh_concepts.rst
@@ -24,8 +24,6 @@ Read more about basic Bluetooth Mesh concepts in the following sections:
 
 Check the official `Bluetooth Mesh glossary`_ for definitions of the most important Bluetooth Mesh-related terms used in this documentation.
 
-----
-
 .. _mesh_concepts_app_areas:
 
 Application areas
@@ -39,8 +37,6 @@ This is mainly due to the need for keeping the radio running constantly.
 Therefore, unlike the |BLE| advertisers, active mesh devices cannot be powered by coin-cell batteries for extended periods of time.
 
 Bluetooth Mesh supports up to 32767 devices in a network, with a maximum network diameter of 126 hops.
-
-----
 
 .. _mesh_concepts_network_topo:
 
@@ -118,8 +114,6 @@ This protocol allows legacy |BLE| devices to participate in the mesh network by 
 The legacy device gets assigned an address and the necessary keys to become a full-fledged member of the network.
 The device receives the security credentials through the regular provisioning procedure or through some out-of-band mechanism.
 
-----
-
 .. _mesh_concepts_addressing:
 
 Addressing
@@ -144,8 +138,6 @@ There can at most be 16127 general purpose group addresses in a mesh network.
 Virtual addresses can be considered a special form of group addresses, and can be used to represent any number of devices.
 Each virtual address is a 128-bit UUID generated from a text label.
 The virtual addresses do not have to be tracked by a network configuration device, and in this way, users can generate virtual addresses before deployment or addresses can be generated ad-hoc between devices in the network.
-
-----
 
 .. _mesh_concepts_models_and_elements:
 
@@ -179,8 +171,6 @@ This publish address can be of any type.
    Access layer structure
 
 For more information about models, see :ref:`bt_mesh_models`.
-
-----
 
 .. _mesh_concepts_lifecycle:
 
@@ -253,8 +243,6 @@ After a new light switch has been provisioned:
 #. The user sets the model's publish address to the *Kitchen Area* group address, to which all the light bulbs in the kitchen subscribe.
 
 The next time the new light switch is pressed, all light bulbs in the kitchen turn on.
-
-----
 
 .. _mesh_concepts_security:
 

--- a/doc/nrf/ug_thread.rst
+++ b/doc/nrf/ug_thread.rst
@@ -17,7 +17,4 @@ This support is based on the OpenThread stack, which is integrated into Zephyr.
 
 See :ref:`openthread_samples` for the list of available Thread samples.
 
-----
-
-Copyright disclaimer
-    |Google_CCLicense|
+:Copyright disclaimer: |Google_CCLicense|

--- a/doc/nrf/ug_thread_commissioning.rst
+++ b/doc/nrf/ug_thread_commissioning.rst
@@ -197,8 +197,6 @@ The commissioning uses the following passwords and credentials:
 
 For details and full overview of security credentials, see `Thread protocol specification`_, table 8.2.
 
-----
-
 .. _thread_ot_commissioning_cli:
 
 Commissioning CLI commands
@@ -209,7 +207,4 @@ See the following pages in the `OpenThread CLI Reference`_ on GitHub for an over
 * `Commissioner CLI commands`_
 * `Joiner CLI commands`_
 
-----
-
-Copyright disclaimer
-    |Google_CCLicense|
+:Copyright disclaimer: |Google_CCLicense|

--- a/doc/nrf/ug_thread_commissioning_configuring.rst
+++ b/doc/nrf/ug_thread_commissioning_configuring.rst
@@ -172,7 +172,4 @@ Complete the following steps:
 
 Both devices are now able to ping each other.
 
-----
-
-Copyright disclaimer
-    |Google_CCLicense|
+:Copyright disclaimer: |Google_CCLicense|

--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -183,3 +183,11 @@ div.numbered-step>h6::before {
   counter-increment: step-count-h6;
   content: counter(step-count-h6);
 }
+
+
+/* add a section divider */
+
+.rst-content h2 {
+ border-top: 1px solid #ddd;
+ padding-top: 20px;
+}

--- a/samples/openthread/ncp/README.rst
+++ b/samples/openthread/ncp/README.rst
@@ -306,7 +306,4 @@ This sample uses the following Zephyr libraries:
 
   * ``include/logging/log.h``
 
-----
-
-Copyright disclaimer
-    |Google_CCLicense|
+:Copyright disclaimer: |Google_CCLicense|


### PR DESCRIPTION
H2 headings should always have a divider line before them, to
make it easier to see where a new section starts.

Ref. NCSDK-6535

![image](https://user-images.githubusercontent.com/11227796/95080030-c2df7a00-0717-11eb-80f9-893cb36d7669.png)


Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>