### PR TITLE
doc: better differentiation between heading levels

### DIFF
--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -59,6 +59,17 @@ div.figure {
  padding-top: 10px;
 }
 
+/* differentiate more between headings */
+
+h5 {
+ font-size: 105%;
+}
+
+h6 {
+ font-size: 90%;
+}
+
+
 /* Background colors for the different sets */
 .ncs {
  background-color: #00a9ce;


### PR DESCRIPTION
Currently, the difference between h4 and h5 levels is basically
not visible.
Increase the difference between h4 and h5, and make h6 (which
we're currently not using) smaller just in case.


Picture shows h3, h4, and h5

![image](https://user-images.githubusercontent.com/11227796/95089025-f45e4280-0723-11eb-931e-cdd01299e971.png)


Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>