### PR TITLE
samples: openthread: revert extended reset delay in cert harness

### DIFF
--- a/samples/openthread/cli/harness/nrf52840-ncs.py
+++ b/samples/openthread/cli/harness/nrf52840-ncs.py
@@ -1278,7 +1278,7 @@ class nRF52840(IThci):
         try:
             self._sendline('factoryreset')
             self._read()
-            time.sleep(1.5)
+            time.sleep(0.5)
 
         except Exception as e:
             ModuleHelper.WriteIntoDebugLogger('reset() Error: ' + str(e))


### PR DESCRIPTION
The wait time was ectended for 833 boot. However the issue was already
found and the fix is on a PR. We cen revert it back to 0.5s.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>