### PR TITLE
doc: fix key name while accessing sample.yaml

### DIFF
--- a/scripts/sphinx_extensions/table_from_rows/table_from_rows.py
+++ b/scripts/sphinx_extensions/table_from_rows/table_from_rows.py
@@ -107,7 +107,7 @@ class TableFromRows(SphinxDirective):
             raise self.severe('"%s" not found' % path)
         data = yaml.load(sample_yaml, Loader=yaml.BaseLoader)
         path_key = '.'.join(rel_path.split(os.path.sep))
-        for key in ['tests', path_key, 'platform_whitelist']:
+        for key in ['tests', path_key, 'platform_allow']:
             if key not in data:
                 raise self.severe('Unexpected sample.yaml format detected, '
                                   '"%s" key not found!' % key)


### PR DESCRIPTION
Fix table-from-rows extension to look for 'platform_allow', instead of old 'platform_whitelist'. Should fix the build errors in in https://github.com/nrfconnect/sdk-nrf/pull/2918.