### PR TITLE
manifest: Updating mbedtls-nrf to v2.23.0, Add nrf_oberon 3.0.7

### DIFF
--- a/tests/crypto/test_cases/test_vectors_aes_cbc.c
+++ b/tests/crypto/test_cases/test_vectors_aes_cbc.c
@@ -1376,7 +1376,7 @@ ITEM_REGISTER(test_vector_aes_cbc_data,
 	.p_iv = "d6d86e0c82dd8788f4147a26f9a71c74"
 };
 
-#if !defined(CONFIG_CRYPTO_TEST_LONG_RUNNING_VECTORS)
+#if defined(CONFIG_CRYPTO_TEST_LONG_RUNNING_VECTORS)
 /* AES CBC - NIST CAVS 11.1 Monte Carlo 192 Encrypt */
 ITEM_REGISTER(test_vector_aes_cbc_monte_carlo_data,
 	      test_vector_aes_t test_vector_aes_cbc_192_encrypt_monte_carlo) = {
@@ -2104,7 +2104,7 @@ ITEM_REGISTER(test_vector_aes_cbc_data,
 	.p_iv = "e49651988ebbb72eb8bb80bb9abbca34"
 };
 
-#if !defined(CONFIG_CRYPTO_TEST_LONG_RUNNING_VECTORS)
+#if defined(CONFIG_CRYPTO_TEST_LONG_RUNNING_VECTORS)
 /* AES CBC - NIST CAVS 11.1 Monte Carlo 256 Encrypt */
 ITEM_REGISTER(test_vector_aes_cbc_monte_carlo_data,
 	      test_vector_aes_t test_vector_aes_cbc_256_encrypt_monte_carlo) = {

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 3965a452daec9d5edb703e9599cf5e77b5971fc9
+      revision: 8e6bf748d6e61bcbcf7161d8d60910a1ec0eb131
     # Other third-party repositories.
     - name: cmock
       path: test/cmock
@@ -114,7 +114,7 @@ manifest:
     - name: mbedtls-nrf
       path: mbedtls
       repo-path: mbedtls
-      revision: mbedtls-2.16.6
+      revision: mbedtls-2.23.0
       remote: armmbed
     - name: nanopb
       path: modules/lib/nanopb


### PR DESCRIPTION
-Updating to PR of nrfxlib with TLS/DTLS fixes for v2.23.0
-Updating mbedtls-nrf to mbed TLS 2.23.0
-This does not update the mbed TLS in zephyr submodule
-Adds nrf_oberon v3.0.7

ref: NCSDK-6097
ref NCSDK-6367

nrfxlib update: https://github.com/nrfconnect/sdk-nrfxlib/pull/287

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>