### PR TITLE
net: lib: aws_jobs: Fix for native posix test

### DIFF
--- a/subsys/net/lib/aws_jobs/Kconfig
+++ b/subsys/net/lib/aws_jobs/Kconfig
@@ -5,7 +5,6 @@
 
 menuconfig AWS_JOBS
 	bool "AWS Jobs library"
-	depends on ENTROPY_DEVICE_RANDOM_GENERATOR
 
 if AWS_JOBS
 


### PR DESCRIPTION
This fixes the native posix test for aws_jobs.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>