### PR TITLE
manifest: zephyr: update manifest with Zephyr post-upmerge changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a4ead98051404e3b63845d9944b0c689162f1db1
+      revision: 288258e2f6a60120e87939a60b28234f33a55f1d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Includes the following Zephyr post-upmerge PRs:
- [zephyr-sdk:#360](https://github.com/nrfconnect/sdk-zephyr/pull/360)
- [zephyr-sdk:#362](https://github.com/nrfconnect/sdk-zephyr/pull/362)

Those PRs has been combined here:
https://github.com/tejlmand/fw-nrfconnect-zephyr-1/tree/upmerge_post_fixes

to allow for a single CI run with a common manifest update.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>