### PR TITLE
doc: update recommonmark to 0.6.0

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,7 +1,7 @@
 ecdsa
 imagesize>=1.2.0
 intelhex
-recommonmark==0.4.0
+recommonmark==0.6.0
 sphinxcontrib-mscgen
 west>=0.7.2
 pylint


### PR DESCRIPTION
Bump recommonmark==0.6.0 to correctly build the MCUboot documentation.