### PR TITLE
MPSL flash sync (with SDC driver intact)

### DIFF
--- a/drivers/mpsl/CMakeLists.txt
+++ b/drivers/mpsl/CMakeLists.txt
@@ -5,3 +5,4 @@
 #
 
 add_subdirectory_ifdef(CONFIG_CLOCK_CONTROL_MPSL clock_control)
+add_subdirectory_ifdef(CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL flash_sync)

--- a/drivers/mpsl/Kconfig
+++ b/drivers/mpsl/Kconfig
@@ -5,3 +5,4 @@
 #
 
 rsource "clock_control/Kconfig"
+rsource "flash_sync/Kconfig"

--- a/drivers/mpsl/flash_sync/CMakeLists.txt
+++ b/drivers/mpsl/flash_sync/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_library()
+zephyr_library_sources(flash_sync_mpsl.c)
+zephyr_include_directories(${ZEPHYR_BASE}/drivers/flash)

--- a/drivers/mpsl/flash_sync/Kconfig
+++ b/drivers/mpsl/flash_sync/Kconfig
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+if SOC_FLASH_NRF
+
+choice SOC_FLASH_NRF_RADIO_SYNC_CHOICE
+	prompt "Nordic nRFx flash driver synchronization"
+	default SOC_FLASH_NRF_RADIO_SYNC_MPSL if MPSL
+
+config SOC_FLASH_NRF_RADIO_SYNC_MPSL
+	bool "Nordic nRFx flash driver synchronized using MPSL"
+	depends on MPSL
+	help
+	  Enable synchronization between flash memory driver and MPSL.
+
+endchoice
+
+endif
+
+config SOC_FLASH_NRF_RADIO_SYNC_MPSL_TIMESLOT_SESSION_COUNT
+	int
+	default 1 if SOC_FLASH_NRF_RADIO_SYNC_MPSL
+	default 0

--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <errno.h>
+
+#include <mpsl.h>
+#include <mpsl_timeslot.h>
+#include <hal/nrf_timer.h>
+
+#include "multithreading_lock.h"
+#include "soc_flash_nrf.h"
+
+#define LOG_LEVEL CONFIG_FLASH_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(flash_sync_mpsl);
+
+/* The request length specified by the upper layers is only time required to do
+ * the flash operations itself. Therefore we need to add some additional slack
+ * to each timeslot request.
+ */
+#if defined(CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE)
+#define TIMESLOT_LENGTH_SLACK_US 1000
+#else
+#define TIMESLOT_LENGTH_SLACK_US 100
+#endif
+
+struct mpsl_context {
+	/* This semaphore is taken with a timeout when the flash operation starts. */
+	struct k_sem timeout_sem;
+	mpsl_timeslot_session_id_t session_id; /* Timeslot session ID. */
+	/* The flash operation may be split into multiple requests.
+	 * This represents the length of such a request. */
+	uint32_t request_length_us;
+	/* Argument passed to nrf_flash_sync_exe(). */
+	struct flash_op_desc *op_desc;
+	mpsl_timeslot_request_t timeslot_request;
+	/* Return parameter for the timeslot session. */
+	mpsl_timeslot_signal_return_param_t return_param;
+	int status; /* Return value for nrf_flash_sync_exe(). */
+	/* Indicate timeout condition to the timeslot callback. */
+	atomic_t timeout_occured;
+};
+
+static struct mpsl_context _context;
+
+/**
+ * Get time in microseconds since the beginning of the timeslot.
+ *
+ * This should only be called inside the timeslot.
+ */
+static uint32_t get_timeslot_time_us(void)
+{
+	nrf_timer_task_trigger(NRF_TIMER0, NRF_TIMER_TASK_CAPTURE0);
+	return nrf_timer_cc_get(NRF_TIMER0, NRF_TIMER_CC_CHANNEL0);
+}
+
+static void reschedule_next_timeslot(void)
+{
+	_context.timeslot_request.params.earliest.priority =
+		MPSL_TIMESLOT_PRIORITY_HIGH;
+
+	int32_t ret = mpsl_timeslot_request(_context.session_id,
+					    &_context.timeslot_request);
+
+	__ASSERT_EVAL((void)ret, (void)ret, ret == 0,
+		      "mpsl_timeslot_request failed: %d", ret);
+}
+
+static mpsl_timeslot_signal_return_param_t *
+timeslot_callback(mpsl_timeslot_session_id_t session_id, uint32_t signal)
+{
+	__ASSERT_NO_MSG(session_id == _context.session_id);
+
+	if (atomic_get(&_context.timeout_occured)) {
+		return NULL;
+	}
+
+	switch (signal) {
+	case MPSL_TIMESLOT_SIGNAL_START:
+		if (_context.op_desc->handler(_context.op_desc->context) ==
+		    FLASH_OP_DONE) {
+			_context.status = 0;
+			_context.return_param.callback_action =
+				MPSL_TIMESLOT_SIGNAL_ACTION_END;
+		} else {
+			/* Reset the priority back to normal after a successful
+			 * timeslot. */
+			_context.timeslot_request.params.earliest.priority =
+				MPSL_TIMESLOT_PRIORITY_NORMAL;
+
+			_context.return_param.callback_action =
+				MPSL_TIMESLOT_SIGNAL_ACTION_REQUEST;
+			_context.return_param.params.request.p_next =
+				&_context.timeslot_request;
+		}
+
+		break;
+
+	case MPSL_TIMESLOT_SIGNAL_SESSION_IDLE:
+		/* All requests are done, that means we are done. */
+		k_sem_give(&_context.timeout_sem);
+		return NULL;
+
+	case MPSL_TIMESLOT_SIGNAL_SESSION_CLOSED:
+		return NULL;
+
+	case MPSL_TIMESLOT_SIGNAL_CANCELLED:
+	case MPSL_TIMESLOT_SIGNAL_BLOCKED:
+		/* Retry the failed request. */
+		reschedule_next_timeslot();
+		return NULL;
+
+	default:
+		__ASSERT(false, "unexpected signal: %u", signal);
+		return NULL;
+	}
+
+	return &_context.return_param;
+}
+
+int nrf_flash_sync_init(void)
+{
+	LOG_DBG("");
+	return k_sem_init(&_context.timeout_sem, 0, 1);
+}
+
+void nrf_flash_sync_set_context(uint32_t duration)
+{
+	LOG_DBG("duration: %u", duration);
+	_context.request_length_us = duration;
+}
+
+bool nrf_flash_sync_is_required(void)
+{
+	return mpsl_is_initialized();
+}
+
+int nrf_flash_sync_exe(struct flash_op_desc *op_desc)
+{
+	LOG_DBG("");
+
+	int errcode = MULTITHREADING_LOCK_ACQUIRE();
+	__ASSERT_NO_MSG(errcode == 0);
+	int32_t ret = mpsl_timeslot_session_open(timeslot_callback,
+						 &_context.session_id);
+	MULTITHREADING_LOCK_RELEASE();
+
+	if (ret < 0) {
+		LOG_ERR("mpsl_timeslot_session_open failed: %d", ret);
+		return -ENOMEM;
+	}
+
+	mpsl_timeslot_request_t *req = &_context.timeslot_request;
+	req->request_type = MPSL_TIMESLOT_REQ_TYPE_EARLIEST;
+	req->params.earliest.hfclk = MPSL_TIMESLOT_HFCLK_CFG_NO_GUARANTEE;
+	req->params.earliest.priority = MPSL_TIMESLOT_PRIORITY_NORMAL;
+	req->params.earliest.length_us =
+		_context.request_length_us + TIMESLOT_LENGTH_SLACK_US;
+	req->params.earliest.timeout_us = MPSL_TIMESLOT_EARLIEST_TIMEOUT_MAX_US;
+
+	_context.op_desc = op_desc;
+	_context.status = -ETIMEDOUT;
+	atomic_clear(&_context.timeout_occured);
+
+	__ASSERT_NO_MSG(k_sem_count_get(&_context.timeout_sem) == 0);
+
+	errcode = MULTITHREADING_LOCK_ACQUIRE();
+	__ASSERT_NO_MSG(errcode == 0);
+	ret = mpsl_timeslot_request(_context.session_id, req);
+	__ASSERT_EVAL((void)ret, (void)ret, ret == 0,
+		      "mpsl_timeslot_request failed: %d", ret);
+	MULTITHREADING_LOCK_RELEASE();
+
+	if (k_sem_take(&_context.timeout_sem, K_MSEC(FLASH_TIMEOUT_MS)) < 0) {
+		LOG_ERR("timeout");
+		atomic_set(&_context.timeout_occured, 1);
+	}
+
+	/* This will cancel the timeslot if it is still in progress. */
+	errcode = MULTITHREADING_LOCK_ACQUIRE();
+	__ASSERT_NO_MSG(errcode == 0);
+	mpsl_timeslot_session_close(_context.session_id);
+	MULTITHREADING_LOCK_RELEASE();
+
+	/* Reset the semaphore after timeout, in case if the operation _did_
+	 * complete before closing the session. */
+	if (atomic_get(&_context.timeout_occured)) {
+		k_sem_reset(&_context.timeout_sem);
+	}
+
+	return _context.status;
+}
+
+void nrf_flash_sync_get_timestamp_begin(void)
+{
+	/* Not needed for this driver. */
+}
+
+bool nrf_flash_sync_check_time_limit(uint32_t iteration)
+{
+	uint32_t now_us = get_timeslot_time_us();
+	uint32_t time_per_iteration_us = now_us / iteration;
+	return now_us + time_per_iteration_us >= _context.request_length_us;
+}

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -27,10 +27,16 @@ static struct k_thread signal_thread_data;
 static K_THREAD_STACK_DEFINE(signal_thread_stack,
 			     CONFIG_MPSL_SIGNAL_STACK_SIZE);
 
-#if CONFIG_MPSL_TIMESLOT_SESSION_COUNT > 0
+#define MPSL_TIMESLOT_SESSION_COUNT (\
+	CONFIG_MPSL_TIMESLOT_SESSION_COUNT + \
+	CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL_TIMESLOT_SESSION_COUNT)
+BUILD_ASSERT(MPSL_TIMESLOT_SESSION_COUNT <= MPSL_TIMESLOT_CONTEXT_COUNT_MAX,
+	     "Too many timeslot sessions");
+
+#if MPSL_TIMESLOT_SESSION_COUNT > 0
 #define TIMESLOT_MEM_SIZE \
 	((MPSL_TIMESLOT_CONTEXT_SIZE) * \
-	(CONFIG_MPSL_TIMESLOT_SESSION_COUNT))
+	(MPSL_TIMESLOT_SESSION_COUNT))
 static uint8_t __aligned(4) timeslot_context[TIMESLOT_MEM_SIZE];
 #endif
 
@@ -140,9 +146,9 @@ static int mpsl_lib_init(const struct device *dev)
 		return err;
 	}
 
-#if CONFIG_MPSL_TIMESLOT_SESSION_COUNT > 0
+#if MPSL_TIMESLOT_SESSION_COUNT > 0
 	err = mpsl_timeslot_session_count_set((void *) timeslot_context,
-			CONFIG_MPSL_TIMESLOT_SESSION_COUNT);
+			MPSL_TIMESLOT_SESSION_COUNT);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
This PR adds flash sync support for the soc_flash_nrf driver using MPSL timeslot API.

Ref: DRGN-14778

This is a version of https://github.com/nrfconnect/sdk-nrf/pull/3003 with SDC flash driver intact.