### PR TITLE
applications: nrf_desktop: Fix log level in bas

### DIFF
--- a/applications/nrf_desktop/src/modules/bas.c
+++ b/applications/nrf_desktop/src/modules/bas.c
@@ -59,7 +59,9 @@ static bool event_handler(const struct event_header *eh)
 			int err = bt_gatt_notify(NULL, &bas_svc.attrs[1],
 						 &battery, sizeof(battery));
 
-			if (err) {
+			if (err == -ENOTCONN) {
+				LOG_WRN("Cannot notify. Peer disconnecting.");
+			} else if (err) {
 				LOG_ERR("GATT notify failed (err=%d)", err);
 			}
 		}


### PR DESCRIPTION
Change fixes log level in bas. This log could be observed when device is disconnecting - in that case it's not related to an error.