### PR TITLE
manifest: update mcuboot

### DIFF
--- a/doc/nrf/ug_bootloader.rst
+++ b/doc/nrf/ug_bootloader.rst
@@ -114,11 +114,23 @@ To add MCUboot as upgradable bootloader to your application, set :option:`CONFIG
 |how_to_configure|
 
 To make MCUboot upgradable, you must also add the immutable bootloader.
+Set option :option:`CONFIG_SECURE_BOOT` to do this.
 
 .. note::
    It is possible to include this bootloader without the immutable bootloader.
    In this case, MCUboot will act as an immutable bootloader.
 
+It is possible for MCUboot to use the cryptographic functionality exposed by the immutable bootloader, reducing the flash usage for MCUboot to less than 16 kB.
+To enable this configuration, apply the :file:`overlay-minimal-size.conf` Kconfig overlay file for the MCUboot image.
+This can be done in the following way:
+
+* Using cmake::
+
+     cmake -GNinja -DBOARD=nrf52840dk_nrf5840 -Dmcuboot_OVERLAY_CONFIG=overlay-minimal-size.conf -DCONFIG_SECURE_BOOT=y -DCONFIG_BOOTLOADER_MCUBOOT=y ../
+
+* Using west::
+
+     west build -b nrf52840dk_nrf52840 zephyr/samples/hello_world -- -Dmcuboot_OVERLAY_CONFIG=overlay-minimal-external-crypto.conf -DCONFIG_SECURE_BOOT=y -DCONFIG_BOOTLOADER_MCUBOOT=y
 
 See :doc:`mcuboot:index` for information about the default implementation of MCUboot.
 :ref:`mcuboot:mcuboot_ncs` gives details on the integration of MCUboot in |NCS|.

--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: d7373a00f65b7545c025cbb63cfd8bc153afe5e7
+      revision: e473ee375bc6d53a976408fc133bd0bc6eb3f0a5
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
Get ECDSA as default signature scheme.

Ref: NCSDK-5167
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>