### PR TITLE
manifest: Set sdk-zephyr to v2.3.0-rc1-ncs3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3026111719563ecdc89cf34490cbe9f26c91113f
+      revision: v2.3.0-rc1-ncs3
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
For the NCS 1.3.2 release, point sdk-zephyr to the corresponding tag.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>