### PR TITLE
mcuboot: fixed swap-move, bootstrapping and fast overwrite mode 

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -33,6 +33,8 @@ The following list summarizes the most important changes inherited from upstream
   * Allowed to set VTOR to a relay vector before chain-loading the application.
   * Allowed using a larger primary slot in swap-move.
     Before, both slots had to be the same size, which imposed an unused sector in the secondary slot.
+  * Fixed bootstrapping in swap-move mode.
+  * Fixed an issue that caused an interrupted swap-move operation to potentially brick the device if the primary image was padded.
   * Various fixes, enhancements, and changes needed to work with the latest Zephyr version.
 
 sdk-nrfxlib

--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: e473ee375bc6d53a976408fc133bd0bc6eb3f0a5
+      revision: 2cb130637b5d94934023a1b4758b0e59794c4b74
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
introduces https://github.com/nrfconnect/sdk-mcuboot/pull/126

Update contains bugfix for:
- swap-move might brick device if image-0 is padded

- boostrapping in swap-move was malfunctioning

- garbage bits might be copied while MCUBOOT_OVERWRITE_ONLY_FAST
  (only the exact amount of data used by the image is copied)

Extra trailer management was added which suits using the copy upgrade
routine also for bootstrapping.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>