### PR TITLE
applications: nrf_desktop: Update hid_configurator doc

### DIFF
--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -44,6 +44,7 @@ Complete the following steps:
 
 1. Download the HIDAPI library from `HIDAPI releases`_.
    Use the bundled DLL or build it according to instructions in `HIDAPI library`_.
+#. Copy the proper version of :file:`hidapi.dll` file to the directory where :file:`python.exe` is located.
 #. Install `pyhidapi Python wrapper`_ and other required libraries with the following command:
 
    .. parsed-literal::

--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -43,8 +43,9 @@ Windows
 Complete the following steps:
 
 1. Download the HIDAPI library from `HIDAPI releases`_.
-   Use the bundled DLL or build it according to instructions in `HIDAPI library`_.
-#. Copy the proper version of :file:`hidapi.dll` file to the directory where :file:`python.exe` is located.
+   The release :file:`.zip` file contains library versions for different versions of Windows.
+   Use the bundled :file:`.dll` file or build the library according to the instructions in `HIDAPI library`_.
+#. Copy the :file:`hidapi.dll` file for your Windows version to the directory where :file:`python.exe` is located.
 #. Install `pyhidapi Python wrapper`_ and other required libraries with the following command:
 
    .. parsed-literal::


### PR DESCRIPTION
Lack of information that the hidapi.dll file must be copied to the directory where python.exe is located was problematic to the customers.