### PR TITLE
applications: asset_tracker: fix issue with motion trigger of GPS

### DIFF
--- a/applications/asset_tracker/src/gps_controller/gps_controller.c
+++ b/applications/asset_tracker/src/gps_controller/gps_controller.c
@@ -102,7 +102,7 @@ static void stop(struct k_work *work)
 		LOG_ERR("Failed to disable GPS, error: %d", err);
 		return;
 	}
-
+	k_delayed_work_cancel(&start_work);
 	atomic_set(&gps_is_enabled, 0);
 	gps_control_set_active(false);
 	LOG_INF("GPS operation was stopped");


### PR DESCRIPTION
Fix problem with the motion trigger restarting GPS during already
active GPS search and GPS starting after beeing stopped under
certain conditions.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>