### PR TITLE
zigbee: Add support for delayed packet sending

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: dc1d8b4da3d58bbe5f4b8c290d2e1da3ce921cbd
+      revision: 851eac4ae2d724ba7865230494fd9689c2dd1496
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add support for sending a packet at a specific time in the future.
The feature is required for Zigbee Green Power.

Depends on:
- [x] https://github.com/nrfconnect/sdk-zephyr/pull/368

