### PR TITLE
doc: fix small style sheet issues [DOC ONLY]

### DIFF
--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -201,6 +201,8 @@ div.numbered-step>h6::before {
 .rst-content h2 {
  border-top: 1px solid #ddd;
  padding-top: 20px;
+ overflow-x: auto;
+ line-height: 40px;
 }
 
 
@@ -235,4 +237,9 @@ div.numbered-step>h6::before {
 
 .contents.local ul p {
     margin-bottom: 0px;
+}
+
+.rst-content .admonition {
+   overflow-x: auto;
+   clear: left;
 }


### PR DESCRIPTION
Make sure that notes and the divider above an h2 heading don't
extend under a local ToC.

This fixes the following issues:
https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/west/build-flash-debug.html
Fixed:
![image](https://user-images.githubusercontent.com/11227796/95761006-ff791b80-0cab-11eb-831b-cd945b1936d4.png)

https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/platformio/index.html
Fixed:
![image](https://user-images.githubusercontent.com/11227796/95761053-13248200-0cac-11eb-8790-692f7f6de20f.png)


Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>