### PR TITLE
boards: arm: thingy91_nrf9160: Clean up RAM definitions

### DIFF
--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
@@ -219,16 +219,23 @@
 };
 
 / {
-	/* SRAM allocated and used by the BSD library */
-	sram0_bsd: memory@20010000 {
-		device_type = "memory";
-		compatible = "mmio-sram";
-	};
 
-	/* SRAM allocated to the Non-Secure image */
-	sram0_ns: memory@20020000 {
-		device_type = "memory";
-		compatible = "mmio-sram";
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram0_s: image_s@20000000 {
+			/* Secure image memory */
+		};
+
+		sram0_bsd: image_bsd@20010000 {
+			/* BSD (shared) memory */
+		};
+
+		sram0_ns: image_ns@20020000 {
+			/* Non-Secure image memory */
+		};
 	};
 };
 

--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_partition_conf.dts
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_partition_conf.dts
@@ -45,7 +45,7 @@
  * - Upper 128 kB allocated to Non-Secure image (sram0_ns).
  */
 
-&sram0 {
+&sram0_s {
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };
 


### PR DESCRIPTION
Align RAM definition with upstream to ensure node at 0x20000000
declares all of RAM. This fixes a bug where the partition manager
would only use parts of the available RAM

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>