### PR TITLE
lib: bsdlib: getaddrinfo: move down the stack hints verification

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -999,20 +999,10 @@ static int nrf91_socket_offload_getaddrinfo(const char *node,
 	memset(&nrf_hints, 0, sizeof(struct nrf_addrinfo));
 
 	if (hints != NULL) {
-		error = z_to_nrf_addrinfo_hints(hints, &nrf_hints);
-		if (error == -EPROTONOSUPPORT) {
-			return DNS_EAI_SOCKTYPE;
-		} else if (error == -EAFNOSUPPORT) {
-			return DNS_EAI_ADDRFAMILY;
-		}
+		z_to_nrf_addrinfo_hints(hints, &nrf_hints);
 
 		if (hints->ai_next != NULL) {
 			z_to_nrf_addrinfo_hints(hints->ai_next, &nrf_hints_pdn);
-			if (error == -EPROTONOSUPPORT) {
-				return DNS_EAI_SOCKTYPE;
-			} else if (error == -EAFNOSUPPORT) {
-				return DNS_EAI_ADDRFAMILY;
-			}
 			nrf_hints.ai_next = &nrf_hints_pdn;
 		}
 		nrf_hints_ptr = &nrf_hints;

--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -21,7 +21,7 @@
 #include <sockets_internal.h>
 #include <sys/fdtable.h>
 #include <zephyr.h>
-#include "nrf_gai_errors.h"
+#include <nrf_gai_errors.h>
 
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
 

--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -21,6 +21,7 @@
 #include <sockets_internal.h>
 #include <sys/fdtable.h>
 #include <zephyr.h>
+#include "nrf_gai_errors.h"
 
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
 
@@ -410,6 +411,22 @@ static int z_to_nrf_protocol(int proto)
 static int nrf_to_z_dns_error_code(int nrf_error)
 {
 	switch (nrf_error) {
+	// New error codes
+	case NRF_EAI_AGAIN:
+		return DNS_EAI_AGAIN;
+	case NRF_EAI_BADFLAGS:
+		return DNS_EAI_BADFLAGS;
+	case NRF_EAI_FAMILY:
+		return DNS_EAI_FAMILY;
+	case NRF_EAI_MEMORY:
+		return DNS_EAI_MEMORY;
+	case NRF_EAI_NONAME:
+		return DNS_EAI_NONAME;
+	case NRF_EAI_SERVICE:
+		return DNS_EAI_SERVICE;
+	case NRF_EAI_SOCKTYPE:
+		return DNS_EAI_SOCKTYPE;
+	// Old error codes
 	case NRF_ENOMEM:
 		return DNS_EAI_MEMORY;
 	case NRF_EAGAIN:


### PR DESCRIPTION
This PR proposes to move down the stack hints verification. The verification is handled in libmodem (previously bsdlib) and any error, if present, is then propagated back to the offload function which will then translate it to the correct Zephyr error.