### PR TITLE
partition_manager: reserve ram block for ICP

### DIFF
--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -47,6 +47,10 @@ if (CONFIG_BSD_LIBRARY)
   ncs_add_partition_manager_config(pm.yml.bsdlib)
 endif()
 
+if (CONFIG_BT_RPMSG_NRF53)
+  ncs_add_partition_manager_config(pm.yml.bt_rpmsg_nrf53)
+endif()
+
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
 set(using_partition_manager

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -53,6 +53,11 @@ menu "Zephyr samples configurations"
 if BT_RPMSG_NRF53 && SOC_NRF5340_CPUAPP
 module=HCI_RPMSG
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.build_strategy_domain"
+
+partition=RPMSG_NRF53_SRAM
+partition-size=0x10000
+rsource "Kconfig.template.partition_size"
+
 endif
 
 endmenu # Zephyr samples configurations

--- a/subsys/partition_manager/pm.yml.bt_rpmsg_nrf53
+++ b/subsys/partition_manager/pm.yml.bt_rpmsg_nrf53
@@ -1,0 +1,7 @@
+#include <autoconf.h>
+
+# This block of RAM is used for IPC
+rpmsg_nrf53_sram:
+  placement: {before: end}
+  size: CONFIG_PM_PARTITION_SIZE_RPMSG_NRF53_SRAM
+  region: sram_primary


### PR DESCRIPTION
Reflect configuration of shared RAM from DT.

This fixes an issue where the MPU would get an error
during initial configuration.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>