### PR TITLE
applications: nrf_desktop: Fix for usb_enable error

### DIFF
--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -563,14 +563,14 @@ static int usb_init(void)
 		}
 	}
 
-	int err = usb_enable(device_status);
-	if (err) {
-		LOG_ERR("Cannot enable USB");
-		return err;
-	}
-
 	if (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE)) {
 		config_channel_transport_init(&cfg_chan_transport);
+	}
+
+	int err = usb_enable(device_status);
+
+	if (err) {
+		LOG_ERR("Cannot enable USB (err: %d)", err);
 	}
 
 	return err;


### PR DESCRIPTION
After usb_enable returns an error, the provided USB status callback may still be called. That could lead to assertion fail in config_channel, because it is not initialized. Change initializes config_channel before calling the usb_enable function to prevent assertion fail.

Jira:DESK-1102