### PR TITLE
manifest: Update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.0-ncs1-rc1
+      revision: pull/369/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
sdk-zephyr update that bugfixes tx_started semaphore
issue in ieee802.15.4 radio driver

- [x] https://github.com/nrfconnect/sdk-zephyr/pull/369

Jira: KRKNWK-7789