### PR TITLE
[DOC ONLY] docs: style guide fixes

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -168,7 +168,7 @@ To enable the LwM2M carrier library, add the following parameter to your build c
 
 ``-DOVERLAY_CONFIG=lwm2m_carrier_overlay.conf``
 
-In |SES|, select :guilabel:`Tools` > :guilabel:`Options` > :guilabel:`nRF Connect` to add the above CMake parameter.
+In |SES|, select :guilabel:`Tools` -> :guilabel:`Options` -> :guilabel:`nRF Connect` to add the above CMake parameter.
 See :ref:`cmake_options` for more information.
 
 Alternatively, you can manually set the configuration options to match the contents of the overlay config file.
@@ -182,8 +182,8 @@ Building and running
 
 The Kconfig file of the application contains options to configure the application.
 For example, configure ``CONFIG_POWER_OPTIMIZATION_ENABLE`` to enable power optimization or ``CONFIG_TEMP_USE_EXTERNAL`` to use an external temperature sensor instead of simulated temperature data.
-In |SES|, select **Project** > **Configure nRF Connect SDK project** to browse and configure these options.
-Alternatively, use the command line tool ``menuconfig`` or configure the options directly in ``prj.conf``.
+In |SES|, select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK project` to browse and configure these options.
+Alternatively, use the command line tool ``menuconfig`` or configure the options directly in :file:`prj.conf`.
 
 .. external_antenna_note_start
 

--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -1277,7 +1277,7 @@ The nRF Desktop devices use one of the following Link Layers:
       Such conflicts could lead to a drop in HID input report rate or a disconnection.
       Setting the value to ``3000`` also enables the nRF Desktop central to exchange data with up to 2 standard |BLE| peripherals during every connection interval (every 7.5 ms).
 
-    * When :option:`CONFIG_DESKTOP_BLE_USE_LLPM` is disabled, the device will use only standard BLE connection parameters with the lowest available connection interval of 7.5 ms.
+    * When :option:`CONFIG_DESKTOP_BLE_USE_LLPM` is disabled, the device will use only standard Bluetooth LE connection parameters with the lowest available connection interval of 7.5 ms.
 
       If the LLPM is disabled and more than 2 simultaneous Bluetooth connections are supported (:option:`CONFIG_BT_MAX_CONN`), you can set the value for :option:`CONFIG_SDC_MAX_CONN_EVENT_LEN_DEFAULT` to ``2500``.
       With this value, the nRF Desktop central is able to exchange the data with up to 3 |BLE| peripherals during every 7.5-ms connection interval.

--- a/doc/mcuboot/readme-ncs.rst
+++ b/doc/mcuboot/readme-ncs.rst
@@ -28,4 +28,4 @@ When you build your application with this option set, the following files that c
   It will not trigger a DFU procedure.
 
 * :file:`app_moved_test_update.hex` - Same as :file:`app_test_update.hex` except that it is linked against the address used to store the upgrade candidates.
-  When this file is flashed to the device, MCUboot will trigger the DFU procedure upon reboot.
+  When this file is programmed to the device, MCUboot will trigger the DFU procedure upon reboot.

--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -19,17 +19,17 @@ See :ref:`zephyr:documentation-processors` in the Zephyr developer guide for inf
 In addition to these tools, you must install `mscgen`_ and make sure the ``mscgen`` executable is in your ``PATH``.
 
 .. note::
-   On Windows, the Sphinx executable ``sphinx-build.exe`` is placed in the ``Scripts`` folder of your Python installation path.
-   Dependending on how you have installed Python, you might need to add this folder to your ``PATH`` environment variable.
+   On Windows, the Sphinx executable ``sphinx-build.exe`` is placed in the :file:`Scripts` folder of your Python installation path.
+   Depending on how you have installed Python, you might need to add this folder to your ``PATH`` environment variable.
    Follow the instructions in `Windows Python Path`_ if needed.
 
 
 Documentation structure
 ***********************
 
-All documentation build files are located in the ``ncs/nrf/doc`` folder.
-The ``nrf`` subfolder in that directory contains all .rst source files that are not directly related to a sample application or a library.
-Documentation for samples and libraries are provided in a ``README.rst`` or ``*.rst`` file in the same directory as the code.
+All documentation build files are located in the :file:`ncs/nrf/doc` folder.
+The :file:`nrf` subfolder in that directory contains all :file:`.rst` source files that are not directly related to a sample application or a library.
+Documentation for samples and libraries are provided in a :file:`README.rst` or :file:`.rst` file in the same directory as the code.
 
 Building the documentation output requires building output for all documentation sets.
 Currently, there are four sets: nrf, nrfxlib, zephyr, and mcuboot (covering the contents of :file:`bootloader/mcuboot`).
@@ -40,18 +40,18 @@ Building documentation output
 
 Complete the following steps to build the documentation output:
 
-1. Open a shell and enter the doc folder ``ncs/nrf/doc``.
+1. Open a shell and enter the doc folder :file:`ncs/nrf/doc`.
 
    * On Windows:
 
-     a. Navigate to ``ncs/nrf``.
-     #. Hold shift and right-click on the ``doc`` folder.
-        Select **Open command window here**.
+     a. Navigate to :file:`ncs/nrf`.
+     #. Hold shift and right-click on the :file:`doc` folder.
+        Select :guilabel:`Open command window here`.
 
    * On Linux or macOS:
 
      a. Open a shell window.
-     #. Navigate to ``ncs/nrf/doc``.
+     #. Navigate to :file:`ncs/nrf/doc`.
         If the ncs folder is in your home directory, enter:
 
         .. code-block:: console
@@ -119,8 +119,8 @@ Complete the following steps to build the documentation output:
 
          ninja nrfxlib
 
-The documentation output is written to ``_build\html``.
-Double-click the ``index.html`` file to display the documentation in your browser.
+The documentation output is written to :file:`_build\html`.
+Double-click the :file:`index.html` file to display the documentation in your browser.
 
 .. tip::
 

--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -23,7 +23,7 @@ Editing :file:`CMakeList.txt` directly
 
 Add all files that your application uses to the ``target_sources`` function in :file:`CMakeList.txt`.
 To include several files, it can be useful to specify them with a wildcard.
-For example, to include all ``.c`` files from the ``src`` folder, add the following lines to your :file:`CMakeList.txt`::
+For example, to include all :file:`.c` files from the :file:`src` folder, add the following lines to your :file:`CMakeList.txt`::
 
    FILE(GLOB app_sources src/*.c)
    target_sources(app PRIVATE ${app_sources})
@@ -58,7 +58,7 @@ In the window that is displayed, you can define compilation options for the proj
 
 .. note::
    These compilation options apply to the application project only.
-   To manage Zephyr and other subsystems, go to :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK Project`.
+   To manage Zephyr and other subsystems, go to :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project`.
 
 
 SES tags in :file:`CMakeLists.txt`
@@ -126,7 +126,7 @@ Changes are picked up immediately, and you do not need to re-open the project in
 While it is possible to edit the :file:`.config` file directly, you should use SES or a tool like menuconfig or guiconfig to update it.
 These tools present all available options and allow you to select the ones that you need.
 
-To edit the file in SES, select :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK Project`.
+To edit the file in SES, select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project`.
 If your application contains more than one image (see :ref:`ug_multi_image`), you must select the correct target.
 To configure the parent image (the main application), select :guilabel:`menuconfig`.
 The other options allow you to configure the child images.
@@ -168,7 +168,7 @@ Configuring build types
 .. build_types_overview_start
 
 Build types enable you to use different sets of configuration options for each board.
-You can create several build type ``.conf`` files per board and select one of them when building the application.
+You can create several build type :file:`.conf` files per board and select one of them when building the application.
 This means that you do not have to use one :file:`prj.conf` file for your project and modify it each time to fit your needs.
 
 .. build_types_overview_end

--- a/doc/nrf/gs_testing.rst
+++ b/doc/nrf/gs_testing.rst
@@ -92,7 +92,7 @@ To connect to the nRF9160-based board with LTE Link Monitor, perform the followi
 
 #. Connect the nRF9160-based board to the PC with a USB cable.
 #. Power on the nRF9160-based board.
-#. Click **Select Device** and select the particular board entry from the drop-down list in the LTE Link Monitor.
+#. Click :guilabel:`Select Device` and select the particular board entry from the drop-down list in the LTE Link Monitor.
 #. Observe that the LTE Link monitor app starts AT communication with the modem of the nRF9160-based board and shows the status of the communication in the display terminal.
    The app also displays any information that is logged on UART.
 

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -273,7 +273,7 @@ Reconnection issues on some operating systems
 .. rst-class:: v1-0-0
 
 :ref:`bluetooth_central_hids` loses UART connectivity
-  After flashing a HEX file to the nrf52_pca10040 board, UART connectivity is lost when using the BLE Controller.
+  After programming a HEX file to the nrf52_pca10040 board, UART connectivity is lost when using the BLE Controller.
   The board must be reset to get UART output.
 
 .. rst-class:: v1-0-0 v1-1-0

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -230,8 +230,8 @@
 .. _`NMEA`: https://www.gpsworld.com/what-exactly-is-gps-nmea-data/
 
 .. _`EnOcean`: https://www.enocean.com
-.. _`Easyfit Single/Double Rocker Wall Switch for BLE - EWSSB/EWSDB`: https://www.enocean.com/en/products/enocean_modules_24ghz_ble/easyfit-single-double-rocker-wall-switch-for-ble-ewssb-ewsdb
-.. _`Easyfit Single/Double Rocker Pad for BLE - ESRPB/EDRPB`: https://www.enocean.com/en/products/enocean_modules_24ghz_ble/easyfit-single-double-rocker-pad-for-ble-esrpb-edrpb
+.. _`Easyfit Single/Double Rocker Wall Switch for Bluetooth LE - EWSSB/EWSDB`: https://www.enocean.com/en/products/enocean_modules_24ghz_ble/easyfit-single-double-rocker-wall-switch-for-ble-ewssb-ewsdb
+.. _`Easyfit Single/Double Rocker Pad for Bluetooth LE - ESRPB/EDRPB`: https://www.enocean.com/en/products/enocean_modules_24ghz_ble/easyfit-single-double-rocker-pad-for-ble-esrpb-edrpb
 .. _`Easyfit Motion Detector with Illumination Sensor - EMDCB`: https://www.enocean.com/en/products/enocean_modules_24ghz_ble/easyfit-motion-detector-with-illumination-sensor-emdcb
 
 .. _`ISO/IEC 7816-4`: https://www.iso.org/standard/54550.html

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -418,7 +418,7 @@ The following list summarizes the most important changes inherited from upstream
   * Updated the :ref:`zephyr:nrf-system-off-sample` to better support low-power states of Nordic Semiconductor devices.
   * Updated the :ref:`zephyr:usb_mass` to perform all application-level configuration before the USB subsystem starts.
     The sample now also supports FAT file systems on external storage.
-  * Updated the :ref:`zephyr:nvs-sample` sample to do a full chip erase when flashing.
+  * Updated the :ref:`zephyr:nvs-sample` sample to do a full chip erase when programming.
   * Fixed the build of the :ref:`zephyr:bluetooth-mesh-onoff-level-lighting-vnd-sample` application with mcumgr.
   * Added new commands ``write_unaligned`` and ``write_pattern`` to the :ref:`zephyr:samples_flash_shell`.
   * Fixed the ``cmd_hdr`` and ``acl_hdr`` usage in the :ref:`zephyr:bluetooth-hci-spi-sample` sample.

--- a/doc/nrf/ug_dev_model.rst
+++ b/doc/nrf/ug_dev_model.rst
@@ -151,9 +151,10 @@ The current values of ``[nrf xyz]`` are:
 * ``[nrf temphack]``: temporary patches with some known issues
 * ``[nrf fromtree]``: patches which have been cherry-picked from an upstream tree
 
-It is important to note that the **downstream project history is periodically rewritten**.
-This is important to prevent the number of downstream patches included in a specific NCS release from increasing forever.
-A repository's history is typically only rewritten once for every |NCS| release.
+.. note::
+    The downstream project history is periodically rewritten.
+    This is important to prevent the number of downstream patches included in a specific |NCS| release from increasing forever.
+    A repository's history is typically only rewritten once for every |NCS| release.
 
 To make incorporating new history into your own forks easier, a new point in the downstream |NCS| history is always created which has an empty ``git diff`` with the previous version.
 The empty diff means you can always use:
@@ -271,7 +272,7 @@ You can also create standard forks with GitHub by just creating an empty reposit
 
 If you want to create a `GitHub fork`_ follow the steps below:
 
-#. Create a `GitHub fork`_ using the **Fork** button in the GitHub user interface.
+#. Create a `GitHub fork`_ using the :guilabel:`Fork` button in the GitHub user interface.
 #. Add the newly created remote repository as a Git remote::
 
      cd ncs/{folder_path}
@@ -299,7 +300,7 @@ If you want to create a `GitHub fork`_ follow the steps below:
   * ``ncs`` pointing to the |NCS| `sdk-zephyr`_.
   * ``upstream`` pointing to the upstream `official Zephyr repository`_.
 
-To create a regular fork, follow the exact same steps as above, but the actual repository must be created by you beforehand, instead of clicking **Fork** in GitHub.
+To create a regular fork, follow the exact same steps as above, but the actual repository must be created by you beforehand, instead of clicking :guilabel:`Fork` in GitHub.
 Also, since a GitHub fork automatically initializes the forked repository with the exact same contents as the original one, you must push the contents yourself::
 
   cd ncs/{folder_path}
@@ -318,7 +319,7 @@ All workflows are described under the following basic assumptions:
 * One or more applications are to be developed using the |NCS|.
 * Additional board definitions might be required by the user.
 * Additional libraries might be required by the user.
-* The term "application" refers to the application code and any board definitions and libraries it requires.
+* The term *application* refers to the application code and any board definitions and libraries it requires.
 * The application(s) will require updates of the |NCS| revision.
 
 Workflow 1: Eschew Git and west
@@ -387,7 +388,7 @@ This is demonstrated by the following code:
      self:
        path: application
 
-Importing :file:`west.yml` also results in the addition of all the NCS projects, including those imported from Zephyr, into your workspace.
+Importing :file:`west.yml` also results in the addition of all the |NCS| projects, including those imported from Zephyr, into your workspace.
 
 Then, make the following changes:
 

--- a/doc/nrf/ug_esb.rst
+++ b/doc/nrf/ug_esb.rst
@@ -123,7 +123,7 @@ Setting up an ESB application
 Perform the following steps to set up an application to send and receive packets:
 
 1. Initialize ESB using :c:func:`esb_init`.
-   You can use the default parameters in :c:macro:`ESB_DEFAULT_CONFIG` as starting point for the **p_config** parameter and reconfigure them if needed.
+   You can use the default parameters in :c:macro:`ESB_DEFAULT_CONFIG` as starting point for the ``p_config`` parameter and reconfigure them if needed.
 #. If necessary, use any of the folowing functions to update the addresses, the address prefix, the channel, and the bitrate:
 
    * :c:func:`esb_set_base_address_0`

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -44,7 +44,7 @@ Firmware
 
 The firmware of Thingy:91 has been developed using the nRF Connect SDK.
 It is open source, and can be modified according to specific needs.
-The :ref:`asset_tracker` application firmware, which is pre-flashed in the Thingy:91, enables the device to use the environment sensors and provides an option of tracking the device using GPS.
+The :ref:`asset_tracker` application firmware, which is preprogrammed in the Thingy:91, enables the device to use the environment sensors and provides an option of tracking the device using GPS.
 
 The data, along with information about the device, is transmitted to Nordic Semiconductor's cloud solution, `nRF Cloud`_, where it can be visualized.
 See :ref:`asset_tracker` for more information on the asset tracker application.
@@ -66,7 +66,7 @@ LTE Band Lock
 
 The modem within Thingy:91 can be configured to use specific LTE bands by using the band lock AT command.
 See :ref:`nrf9160_ug_band_lock` and the `band lock section in the AT Commands reference document`_ for additional information.
-The pre-flashed firmware configures the modem to use the bands currently certified on the Thingy:91 hardware.
+The preprogrammed firmware configures the modem to use the bands currently certified on the Thingy:91 hardware.
 When building the firmware, you can configure which bands should be enabled.
 
 LTE-M / NB-IoT switching
@@ -109,7 +109,7 @@ Downloading precompiled firmware images
 
 To obtain precompiled firmware images for updating the firmware, perform the following steps:
 
-	1. Go to the `Thingy:91 product page`_ and under the **Downloads** tab, navigate to **Precompiled firmware**.
+	1. Go to the `Thingy:91 product page`_ and under the :guilabel:`Downloads` tab, navigate to :guilabel:`Precompiled firmware`.
 	#. Download and extract the latest Thingy:91 firmware package.
 	#. Check the :file:`CONTENTS.txt` file in the extracted folder for the location and names of the different firmware images.
 
@@ -217,7 +217,7 @@ Building and programming using SEGGER Embedded Studio
       The *Board Directory* folder can be found in the following location: ``ncs/nrf/boards/arm``.
 
 
-4. Click **OK** to import the project into SES.
+4. Click :guilabel:`OK` to import the project into SES.
    You can now work with the project in the IDE.
 
    .. include:: gs_programming.rst
@@ -227,7 +227,7 @@ Building and programming using SEGGER Embedded Studio
 #. To build the sample or application:
 
    a. Select your project in the Project Explorer.
-   #. From the menu, select **Build -> Build Solution**.
+   #. From the menu, select :guilabel:`Build` -> :guilabel:`Build Solution`.
       This builds the project.
 
    You can find the output of the build, which includes the merged HEX file containing both the application and the SPM, in the ``zephyr`` subfolder in the build directory.
@@ -249,8 +249,8 @@ Building and programming using SEGGER Embedded Studio
 .. prog_extdebugprobe_end
 ..
 
-   e. In SES, select **Target -> Connect J-Link**.
-   #. Select **Target -> Download zephyr/merged.hex** to program the sample or application onto Thingy:91.
+   e. In SES, select :guilabel:`Target` -> :guilabel:`Connect J-Link`.
+   #. Select :guilabel:`Target` -> :guilabel:`Download zephyr/merged.hex` to program the sample or application onto Thingy:91.
    #. The device will reset and run the programmed sample or application.
 
 .. _build_pgm_cmdline:

--- a/doc/nrf/ug_thread_commissioning.rst
+++ b/doc/nrf/ug_thread_commissioning.rst
@@ -218,7 +218,7 @@ Check the sample documentation pages for the list of compatible development kit 
 Programming the DKs
 ===================
 
-Flash both development kits with the :ref:`Thread CLI sample <ot_cli_sample>` or flash both of them with the :ref:`Thread NCP sample <ot_ncp_sample>`.
+Program both development kits with the :ref:`Thread CLI sample <ot_cli_sample>` or program both of them with the :ref:`Thread NCP sample <ot_ncp_sample>`.
 See the sample's page for details.
 
 After programming the DKs and turning them on, both devices will be pre-commissioned and will form a Thread network.

--- a/include/bluetooth/enocean.rst
+++ b/include/bluetooth/enocean.rst
@@ -3,7 +3,7 @@
 Bluetooth EnOcean
 #################
 
-The Bluetooth EnOcean library allows passive observation of BLE-based wall switches and sensors from `EnOcean`_, such as wall switches based on the Push Button Transmitter module (PTM 215B) and the Easyfit Motion Detector with Illumination (EMDCB) sensor module.
+The Bluetooth EnOcean library allows passive observation of wall switches and sensors based on Bluetooth LE from `EnOcean`_, such as wall switches based on the Push Button Transmitter module (PTM 215B) and the Easyfit Motion Detector with Illumination (EMDCB) sensor module.
 The library is only capable of observing the output of the devices, and does not send anything back.
 NFC-based configuration is not supported.
 
@@ -24,10 +24,10 @@ For a demonstration of the library features, see the :ref:`enocean_sample` sampl
 Supported devices
 =================
 
-This library supports both PTM 215B-based switches and the BLE-enabled sensor module:
+This library supports both PTM 215B-based switches and the sensor module enabled for Bluetooth LE:
 
-* `Easyfit Single/Double Rocker Wall Switch for BLE - EWSSB/EWSDB`_
-* `Easyfit Single/Double Rocker Pad for BLE - ESRPB/EDRPB`_
+* `Easyfit Single/Double Rocker Wall Switch for Bluetooth LE - EWSSB/EWSDB`_
+* `Easyfit Single/Double Rocker Pad for Bluetooth LE - ESRPB/EDRPB`_
 * `Easyfit Motion Detector with Illumination Sensor - EMDCB`_
 
 By default, the library supports one EnOcean device, and the :ref:`enocean_sample` sample supports only up to four devices.

--- a/include/bluetooth/services/nus.rst
+++ b/include/bluetooth/services/nus.rst
@@ -3,7 +3,7 @@
 Nordic UART Service (NUS)
 #########################
 
-The BLE GATT Nordic UART Service is a custom service that receives and writes data and serves as a bridge to the UART interface.
+The Bluetooth LE GATT Nordic UART Service is a custom service that receives and writes data and serves as a bridge to the UART interface.
 
 The NUS Service is used in the :ref:`peripheral_uart` sample.
 

--- a/include/dk_buttons_and_leds.rst
+++ b/include/dk_buttons_and_leds.rst
@@ -1,7 +1,7 @@
 .. _dk_buttons_and_leds_readme:
 
-DK Button and LED library
-#########################
+DK Button and LEDs
+##################
 
 The DK Button and LED library is a simple module to interface with the buttons and LEDs on a Nordic Semiconductor development kit.
 It supports reading the state of up to four buttons or switches and controlling up to four LEDs.

--- a/include/net/aws_iot.rst
+++ b/include/net/aws_iot.rst
@@ -22,7 +22,7 @@ Setting up a secure MQTTS connection to the AWS IoT message broker consists of t
 
 1. Creating a Thing
 #. Generating a CA certificate.
-#. Flashing the certificates to the on-board modem of the nRF9160 based board.
+#. Programming the certificates to the on-board modem of the nRF9160 based board.
 #. Configuring the library options.
 
 For more information on creating a thing in AWS IoT and generating the certificate, see :ref:`creating_a_thing_in_AWS_IoT`.
@@ -32,16 +32,16 @@ For more information on creating a thing in AWS IoT and generating the certifica
 
 .. _flash_certi_device:
 
-Flashing the certificates to the on-board modem of the nRF9160 based board
-==========================================================================
+Programming the certificates to the on-board modem of the nRF9160 based board
+=============================================================================
 
 1. `Download nRF Connect for Desktop`_
 #. Update the modem firmware on the on-board modem of the nRF9160 based board to the latest version by following the steps in `Updating the nRF9160 DK cellular modem`_.
 #. Build and program the  :ref:`at_client_sample` sample to the nRF9160 based board as explained in :ref:`gs_programming`.
 #. Launch the `LTE Link Monitor`_ application, which is implemented as part of `nRF Connect for Desktop`_.
-#. Click **Certificate manager** located at the top right corner.
+#. Click :guilabel:`Certificate manager` located at the top right corner.
 #. Copy and paste the certificates, downloaded earlier from AWS IoT, into the respective entries (``CA certificate``, ``Client certificate``, ``Private key``).
-#. Select a desired security tag and click **Update certificates**.
+#. Select a desired security tag and click :guilabel:`Update certificates`.
 
 .. note::
    The default security tag *16842753* is reserved for the :ref:`lib_nrf_cloud`.
@@ -51,10 +51,10 @@ Configuring library options
 ===========================
 To configure the library options, complete the following steps:
 
-1. In the `AWS IoT console`_, navigate to **IoT core** -> **Manage** -> **things** and click on the entry for the *thing*, created during the steps of :ref:`creating_a_thing_in_AWS_IoT`.
-#. Navigate to **interact**, find the **Rest API Endpoint** and set the configurable option :option:`CONFIG_AWS_IOT_BROKER_HOST_NAME` to this address.
+1. In the `AWS IoT console`_, navigate to :guilabel:`IoT core` -> :guilabel:`Manage` -> :guilabel:`things` and click on the entry for the *thing*, created during the steps of :ref:`creating_a_thing_in_AWS_IoT`.
+#. Navigate to :guilabel:`interact`, find ``Rest API Endpoint`` and set the configurable option :option:`CONFIG_AWS_IOT_BROKER_HOST_NAME` to this address.
 #. Set the option :option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC` to the name of the *thing* created during the aforementioned steps.
-#. Set the security tag configuration :option:`CONFIG_AWS_IOT_SEC_TAG` to the security tag, chosen while `Flashing the certificates to the on-board modem of the nRF9160 based board`_.
+#. Set the security tag configuration :option:`CONFIG_AWS_IOT_SEC_TAG` to the security tag, chosen while `Programming the certificates to the on-board modem of the nRF9160 based board`_.
 
 Initializing
 ************

--- a/include/profiler.rst
+++ b/include/profiler.rst
@@ -128,7 +128,7 @@ When running ``plot_from_files.py`` or ``real_time_plot.py``, the profiled event
 When displaying Event Manager events, submissions are marked as dots.
 Processing of the events is displayed as rectangles, visualizing the processing time.
 
-Use the **start/stop** button below the plot to pause or resume real time plot translation.
+Use the :guilabel:`start/stop` button below the plot to pause or resume real time plot translation.
 Scroll to zoom in or out.
 When paused, scrolling zooms to the cursor location.
 When plotting in real time, scrolling zooms to the right edge of the plot.

--- a/include/secure_services.rst
+++ b/include/secure_services.rst
@@ -9,7 +9,7 @@ Calling functions in this API requires that the service is enabled in the :ref:`
 See :option:`CONFIG_SPM_SECURE_SERVICES` in the :ref:`secure_partition_manager`'s menuconfig.
 Some services are enabled by default.
 
-.. Remove parts with regards to debugging and flashing when NRF91-313 is resolved
+.. Remove parts with regards to debugging and programming when NRF91-313 is resolved
 
 By default :option:`CONFIG_SPM_BLOCK_NON_SECURE_RESET` is disabled. This is to make sure that your debugger will be able to issue a system reset during the development stage and that devices which do not have pin-reset routed can do a re-flashing routine correctly. This option should be turned off when you are putting a product into production to increase the security of your device.
 

--- a/include/shell/shell_bt_nus.rst
+++ b/include/shell/shell_bt_nus.rst
@@ -3,7 +3,7 @@
 Nordic UART Service (NUS) shell transport
 #########################################
 
-The |BLE| GATT Nordic UART Service shell transport allows you to receive shell commands remotely over *Bluetooth*.
+The Bluetooth LE GATT Nordic UART Service shell transport allows you to receive shell commands remotely over *Bluetooth*.
 It uses the :ref:`nus_service_readme`.
 
 The NUS Service shell transport is used in the :ref:`shell_bt_nus` sample.

--- a/include/supl_os_client.rst
+++ b/include/supl_os_client.rst
@@ -1,7 +1,7 @@
 .. _supl_client:
 
-SUPL client and SUPL client OS integration library
-##################################################
+SUPL client and SUPL client OS integration
+##########################################
 
 This section documents both the Secure User-Plane Location (SUPL) client library and the SUPL client OS integration library.
 

--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -69,7 +69,7 @@ Testing with another board
       [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 98%
       [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 97%
 
-#. Press Button 1 to send a read request and process the response::
+#. Press **Button 1** to send a read request and process the response::
 
       Reading BAS value:
       [xx.xx.xx.xx.xx.xx (random)]: Battery read: 97%
@@ -81,12 +81,12 @@ Testing with nRF Connect for Desktop
 1. |connect_terminal_specific|
 #. Reset the board.
 #. Start `nRF Connect for Desktop`_ and select the connected dongle that is used for communication.
-#. Go to the **Server setup** tab.
-   Click the dongle configuration and select **Load setup**.
+#. Go to the :guilabel:`Server setup` tab.
+   Click the dongle configuration and select :guilabel:`Load setup`.
    Load the ``hids_keyboard.ncs`` file that is located under :file:`samples/bluetooth/central_bas` in the |NCS| folder structure.
-#. Click **Apply to device**.
-#. Go to the **Connection Map** tab.
-   Click the dongle configuration and select **Advertising setup**.
+#. Click :guilabel:`Apply to device`.
+#. Go to the :guilabel:`Connection Map` tab.
+   Click the dongle configuration and select :guilabel:`Advertising setup`.
 
    The current version of nRF Connect cannot store the advertising setup, so it must be configured manually.
    See the following image for the required target configuration:
@@ -106,20 +106,20 @@ Testing with nRF Connect for Desktop
    #. Add a **UUID 16 bit complete list** with two comma-separated values: ``1812`` and ``180F``.
       These are the values for HIDS and BAS.
    #. Add a **Complete local name** of your choice to the **Scan response data**.
-   #. Click **Apply** and **Close**.
+   #. Click :guilabel:`Apply` and :guilabel:`Close`.
 
-#. In the Adapter settings, choose **Start advertising**.
+#. In the Adapter settings, choose :guilabel:`Start advertising`.
 #. Wait until the board that runs the Central BAS sample connects.
    In the terminal window, check for information similar to the following::
 
       The discovery procedure succeeded
 
-#. Press Button 1 to send read request and process the response::
+#. Press **Button 1** to send read request and process the response::
 
       Reading BAS value:
       [xx.xx.xx.xx.xx.xx (random)]: Battery read: 100%
 
-#. Change the value in **Battery Service** > **Battery Level** to generate notifications.
+#. Change the value in :guilabel:`Battery Service` -> :guilabel:`Battery Level` to generate notifications.
 #. Observe that the notification information is displayed::
 
       [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 99%

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -77,31 +77,31 @@ Testing with another board
       Subscribe to report id: 1
       Subscribe to boot keyboard report
 
-#. Press Button 1 and Button 2 one after another on the board that runs the keyboard sample and observe the notification values in the terminal window.
+#. Press **Button 1** and **Button 2** one after another on the board that runs the keyboard sample and observe the notification values in the terminal window.
    See :ref:`peripheral_hids_keyboard` for the expected values::
 
       Notification, id: 1, size: 8, data: 0x0 0x0 0xb 0x0 0x0 0x0 0x0 0x0
       Notification, id: 1, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
 
-#. Press Button 2 on the board that runs the Central HIDS sample and observe that the protocol mode is updated into boot mode::
+#. Press **Button 2** on the board that runs the Central HIDS sample and observe that the protocol mode is updated into boot mode::
 
       Setting protocol mode: BOOT
 
-#. Press Button 1 and Button 2 one after another on the board that runs the keyboard sample and observe the notification of the boot report values::
+#. Press **Button 1** and **Button 2** one after another on the board that runs the keyboard sample and observe the notification of the boot report values::
 
       Notification, keyboard boot, size: 8, data: 0x0 0x0 0xf 0x0 0x0 0x0 0x0 0x0
       Notification, keyboard boot, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
 
 
-#. Press Button 1 and Button 3 one after another on the Central HIDS board and observe that LED 1 on the keyboard board changes its state.
+#. Press **Button 1** and **Button 3** one after another on the Central HIDS board and observe that **LED 1** on the keyboard board changes its state.
    The following information is also displayed in the terminal window.
 
-   If Button 1 was pressed::
+   If **Button 1** was pressed::
 
       Caps lock send (val: 0x2)
       Caps lock sent
 
-   If Button 3 was pressed::
+   If **Button 3** was pressed::
 
       Caps lock send using write with response (val: 0x2)
       Capslock write result: 0
@@ -114,12 +114,12 @@ Testing with nRF Connect for Desktop
 1. |connect_terminal_specific|
 #. Reset the board.
 #. Start `nRF Connect for Desktop`_ and select the connected dongle that is used for communication.
-#. Go to the **Server setup** tab.
-   Click the dongle configuration and select **Load setup**.
+#. Go to the :guilabel:`Server setup` tab.
+   Click the dongle configuration and select :guilabel:`Load setup`.
    Load the ``hids_keyboard.ncs`` file that is located under :file:`samples/bluetooth/central_hids` in the |NCS| folder structure.
-#. Click **Apply to device**.
-#. Go to the **Connection Map** tab.
-   Click the dongle configuration and select **Advertising setup**.
+#. Click :guilabel:`Apply to device`.
+#. Go to the :guilabel:`Connection Map` tab.
+   Click the dongle configuration and select :guilabel:`Advertising setup`.
 
    The current version of nRF Connect cannot store the advertising setup, so it must be configured manually.
    See the following image for the required target configuration:
@@ -139,9 +139,9 @@ Testing with nRF Connect for Desktop
    #. Add a **UUID 16 bit complete list** with two comma-separated values: ``1812`` and ``180F``.
       These are the values for HIDS and BAS.
    #. Add a **Complete local name** of your choice to the **Scan response data**.
-   #. Click **Apply** and **Close**.
+   #. Click :guilabel:`Apply` and :guilabel:`Close`.
 
-#. In the Adapter settings, choose **Start advertising**.
+#. In the Adapter settings, choose :guilabel:`Start advertising`.
 #. Wait until the board that runs the Central HIDS sample connects.
    All detected descriptors are listed.
    Check for information similar to the following::
@@ -150,10 +150,10 @@ Testing with nRF Connect for Desktop
       Subscribe in report id: 1
       Subscribe in boot keyboard report
 
-#. Explore the first report inside **Human Interface Device** (the one with eight values).
+#. Explore the first report inside Human Interface Device (the one with eight values).
    Change any of the values and note that the board logs the change.
-#. Press Button 2 on the board and observe that the **Protocol Mode** value changes from ``01`` to ``00``.
-#. Press Button 1 and Button 3 one after another and observe that the **Boot Keyboard Output Report** value toggles between ``00`` and ``02``.
+#. Press **Button 2** on the board and observe that the Protocol Mode value changes from ``01`` to ``00``.
+#. Press **Button 1** and **Button 3** one after another and observe that the Boot Keyboard Output Report value toggles between ``00`` and ``02``.
 
 Dependencies
 *************

--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -17,7 +17,7 @@ See the following subsections for a description of the key LLPM elements.
 
 LLPM connection interval (1 ms)
    The connection interval defines how often the devices must listen on the radio.
-   The LLPM introduces the possibility to reduce the connection interval below what is supported in BLE.
+   The LLPM introduces the possibility to reduce the connection interval below what is supported in Bluetooth LE.
    The lowest supported connection interval is 1 ms for one link.
 
 Physical layer (PHY)

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -47,7 +47,7 @@ The models are used for the following purposes:
 * Health Server provides ``attention`` callbacks that are used during provisioning to call your attention to the device.
   These callbacks trigger blinking of the LEDs.
 
-The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` to control each LED on the board according to the matching received messages of Generic OnOff Server.
+The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library to control each LED on the board according to the matching received messages of Generic OnOff Server.
 
 Requirements
 ************

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -70,8 +70,7 @@ Other nodes can control the Light Lightness Server through the Light Control Ser
 
 For more details, see :ref:`bt_mesh_lightness_srv_readme` and :ref:`bt_mesh_light_ctrl_srv_readme`.
 
-The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` and the
-:ref:`zephyr:pwm_api` API to control the LEDs on the board.
+The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library and the :ref:`zephyr:pwm_api` API to control the LEDs on the board.
 
 Requirements
 ************

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -41,13 +41,11 @@ The models are used for the following purposes:
 * Health Server provides ``attention`` callbacks that are used during provisioning to call your attention to the device.
   These callbacks trigger blinking of the LEDs.
 
-The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` to detect button presses on the board.
+The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library to detect button presses on the board.
 
 If the model is configured to publish to a unicast address, the model handler calls :c:func:`bt_mesh_onoff_cli_set` to turn the LEDs of a Mesh Light device on or off.
 The response from the target device updates the corresponding LED on the Mesh Light Switch device.
 If the model is configured to publish to a group address, it calls :c:func:`bt_mesh_onoff_cli_set_unack` instead, to avoid getting responses from multiple devices at once.
-
-
 
 Requirements
 ************

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -56,7 +56,7 @@ The models are used for the following purposes:
   These callbacks trigger blinking of the LEDs.
 * Mesh sensor server provides sensor data to one or more :ref:`Mesh sensor client(s) <bt_mesh_sensor_cli_readme>`.
 
-The model handling is implemented in :file:`src/model_handler.c`, which uses the ``TEMP_NRF5`` temperature sensor, and :ref:`dk_buttons_and_leds_readme` to detect button presses.
+The model handling is implemented in :file:`src/model_handler.c`, which uses the ``TEMP_NRF5`` temperature sensor, and the :ref:`dk_buttons_and_leds_readme` library to detect button presses.
 
 Requirements
 ************

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -24,7 +24,7 @@ The following paragraphs describe the application behavior when NFC pairing is e
 
 When the application starts, it initializes and starts the NFCT peripheral, which is used for pairing.
 The application does not start advertising immediately, but only when the NFC tag is read by an NFC polling device, for example a smartphone or a tablet with NFC support.
-To trigger advertising without NFC, you can press Button 4.
+To trigger advertising without NFC, you can press **Button 4**.
 The NDEF message that the tag sends to the NFC device contains data required to initiate pairing.
 To start the NFC data transfer, the NFC device must touch the NFC antenna that is connected to the nRF52 device.
 
@@ -96,20 +96,20 @@ To test with a Microsoft Windows computer that has a Bluetooth radio, complete t
 
 1. Power on your development board.
 #. Press Button 4 on the board if the device is not advertising.
-   Advertising is indicated by blinking LED 1.
+   Advertising is indicated by blinking **LED 1**.
 #. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS keyboard".
-#. Observe that the connection state is indicated by LED 2.
+#. Observe that the connection state is indicated by **LED 2**.
 #. Open a text editor (for example, Notepad).
-#. Repeatedly press Button 1 on the board.
+#. Repeatedly press **Button 1** on the board.
    Every button press sends one character of the test message "hello" (the test message includes a carriage return) to the computer, and this will be displayed in the text editor.
-#. Press Button 2 and hold it while pressing Button 1.
+#. Press **Button 2** and hold it while pressing **Button 1**.
    Observe that the next letter of the "hello" message appears as capital letter.
-   This is because Button 2 simulates the Shift key.
+   This is because **Button 2** simulates the Shift key.
 #. Turn Caps Lock on on the computer.
-   Observe that LED 3 turns on.
+   Observe that **LED 3** turns on.
    This confirms that the output report characteristic has been written successfully on the HID device.
 #. Turn Caps Lock off on the computer.
-   Observe that LED 3 turns off.
+   Observe that **LED 3** turns off.
 #. Disconnect the computer from the device by removing the device from the computer's devices list.
 
 
@@ -119,16 +119,18 @@ Testing with nRF Connect for Desktop
 To test with `nRF Connect for Desktop`_, complete the following steps:
 
 1. Power on your development board.
-#. Press Button 4 on the board if the device is not advertising.
-   Advertising is indicated by blinking LED 1.
+#. Press **Button 4** on the board if the device is not advertising.
+   Advertising is indicated by blinking **LED 1**.
 #. Connect to the device from nRF Connect (the device is advertising as "NCS HIDS keyboard").
 #. Optionally, bond to the device.
-   To bond, click the settings button for the device in nRF Connect, select **Pair**, check **Perform Bonding**, and click **Pair**. Optionally, check **Enable MITM protection** to pair with MITM protection and use a button on the device to confirm or reject the passkey value. Click **Match** in the nRF Connect app.
+   To bond, click the settings button for the device in nRF Connect, select :guilabel:`Pair`, check :guilabel:`Perform Bonding`, and click :guilabel:`Pair`.
+   Optionally, check :guilabel:`Enable MITM protection` to pair with MITM protection and use a button on the device to confirm or reject the passkey value.
+#. Click :guilabel:`Match` in the nRF Connect app.
    Wait until the bond is established before you continue.
-#. Observe that the connection state is indicated by LED 2.
+#. Observe that the connection state is indicated by **LED 2**.
 #. Observe that the services of the connected device are shown.
 #. Enable notifications for all HID characteristics.
-#. Press Button 1 on the board.
+#. Press **Button 1** on the board.
    Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
 
    The first notification has the value ``00000B0000000000``, the second has the value ``0000000000000000``.
@@ -136,23 +138,23 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
    The format used for keyboard reports is the following byte array: ``[modifier, reserved, Key1, Key2, Key3, Key4, Key6]``.
 
    Similarly, further press and release events will result in press and release notifications of subsequent characters of the test string.
-   Therefore, pressing Button 1 again will result in notification of press and release reports for character "e".
-#. Press Button 2 and hold it while pressing Button 1.
-   Pressing Button 2 changes the modifier bit to 02, which simulates pressing the Shift key on a keyboard.
+   Therefore, pressing **Button 1** again will result in notification of press and release reports for character "e".
+#. Press **Button 2** and hold it while pressing **Button 1**.
+   Pressing **Button 2** changes the modifier bit to 02, which simulates pressing the Shift key on a keyboard.
 
    Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
    The first one has the value ``02000F0000000000``, the second has the value ``0200000000000000``.
    These values correspond to press and release of character "l" with the Shift key pressed.
 #. In nRF Connect, select the HID Report (which has UUID 0x2A4D and the properties Read, WriteWithoutResponse, and Write).
-   Enter ``02`` in the text box and click the **Write** button.
+   Enter ``02`` in the text box and click the :guilabel:`Write` button.
    This sets the modifier bit of the Output Report to 02, which simulates turning Caps Lock ON.
 
-   Observe that LED 3 turns on.
+   Observe that **LED 3** turns on.
 #. Select the same HID Report again.
-   Enter ``00`` in the text box and click the **Write** button.
+   Enter ``00`` in the text box and click the :guilabel:`Write` button.
    This sets the modifier bit to 00, which simulates turning Caps Lock OFF.
 
-   Observe that LED 3 turns off.
+   Observe that **LED 3** turns off.
 #. Disconnect the device in nRF Connect.
    Observe that no new notifications are received and the device is advertising.
 #. As bond information is preserved by nRF Connect, you can immediately reconnect to the device by clicking the Connect button again.
@@ -163,15 +165,15 @@ Testing with Android using NFC for pairing
 
 To test with an Android smartphone/tablet, complete the following steps:
 
-1. Touch the NFC antenna with the smartphone or tablet and observe that LED 4 is lit.
-#. Observe that the device is advertising, as indicated by blinking LED 1.
+1. Touch the NFC antenna with the smartphone or tablet and observe that **LED 4** is lit.
+#. Observe that the device is advertising, as indicated by blinking **LED 1**.
 #. Confirm pairing with 'Nordic_Mouse_NFC' in a pop-up window on the smartphone/tablet.
-#. Observe that the connection state is indicated by LED 2.
-#. Repeatedly press Button 1 on the board.
+#. Observe that the connection state is indicated by **LED 2**.
+#. Repeatedly press **Button 1** on the board.
    Every button press sends one character of the test message "hello" to the smartphone (the test message includes a carriage return).
-#. Press Button 2 and hold it while pressing Button 1.
+#. Press **Button 2** and hold it while pressing **Button 1**.
    Observe that the next letter of the "hello" message appears as a capital letter.
-   This is because Button 2 simulates the Shift key.
+   This is because **Button 2** simulates the Shift key.
 #. Touch the NFC antenna with the same central device again.
 #. Observe that devices disconnect.
 

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -17,7 +17,7 @@ This sample exposes the HID GATT Service.
 It uses a report map for a generic mouse.
 
 You can also disable directed advertising feature by clearing the BT_DIRECTED_ADVERTISING flag in the application configuration.
-This feature is enabled by default and it changes the way in which advertising works in comparison to the other BLE samples.
+This feature is enabled by default and it changes the way in which advertising works in comparison to the other Bluetooth LE samples.
 When the device wants to advertise, it starts with high duty cycle directed advertising provided that it has bonding information.
 If the timeout occurs, then the device starts directed advertising to the next bonded peer.
 If all bonding information is used and there is still no connection, then the regular advertising starts.
@@ -72,13 +72,13 @@ To test with a Microsoft Windows computer that has a Bluetooth radio, complete t
 
 1. Power on your development board.
 #. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS mouse".
-#. Push Button 1 on the board.
+#. Push **Button 1** on the board.
    Observe that the mouse pointer on the computer moves to the left.
-#. Push Button 2.
+#. Push **Button 2**.
    Observe that the mouse pointer on the computer moves upward.
-#. Push Button 3.
+#. Push **Button 3**.
    Observe that the mouse pointer on the computer moves to the right.
-#. Push Button 4.
+#. Push **Button 4**.
    Observe that the mouse pointer on the computer moves downward.
 #. Disconnect the computer from the device by removing the device from the computer's devices list.
 
@@ -91,11 +91,13 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
 1. Power on your development board.
 #. Connect to the device from nRF Connect (the device is advertising as "NCS HIDS mouse").
 #. Optionally, bond to the device.
-   To do so, click the settings button for the device in nRF Connect, select **Pair**, check **Perform Bonding**, and click **Pair**. Optionally check **Enable MITM protection** to pair with MITM protection and use a button on the device to confirm or reject passkey value. Clik Match in nRF Connect app.
+   To do so, click the settings button for the device in nRF Connect, select :guilabel:`Pair`, check :guilabel:`Perform Bonding`, and click :guilabel:`Pair`.
+   Optionally check :guilabel:`Enable MITM protection` to pair with MITM protection and use a button on the device to confirm or reject passkey value.
+#. Clik Match in nRF Connect app.
    Wait until the bond is established before you continue.
 #. Observe that the services of the connected device are shown.
-#. Click the **Play** button for all HID Report characteristics.
-#. Push Button 1 on the board.
+#. Click the :guilabel:`Play` button for all HID Report characteristics.
+#. Push **Button 1** on the board.
    Observe that a notification is received on one of the HID Report characteristics, containing the value ``FB0F00``.
 
    Mouse motion reports contain data with an X-translation and a Y-translation.
@@ -103,11 +105,11 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
    The format used for mouse reports is the following byte array, where LSB/MSB is the least/most significant bit: ``[8 LSB (X), 4 LSB (Y) | 4 MSB(X), 8 MSB(Y)]``.
 
    Therefore, ``FB0F00`` denotes an X-translation of FFB = -5 (two's complement format), which means a movement of 5 pixels to the left, and a Y-translation of 000 = 0.
-#. Push Button 2.
+#. Push **Button 2**.
    Observe that the value ``00B0FF`` is received on the same HID Report characteristic.
-#. Push Button 3.
+#. Push **Button 3**.
    Observe that the value ``050000`` is received on the same HID Report characteristic.
-#. Push Button 4.
+#. Push **Button 4**.
    Observe that the value ``005000`` is received on the same HID Report characteristic.
 #. Disconnect the device in nRF Connect.
    Observe that no new notifications are received and the device is advertising.

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -8,8 +8,8 @@ The peripheral LBS sample demonstrates how to use the :ref:`lbs_readme`.
 Overview
 ********
 
-When connected, the sample sends the state of Button 1 on the development board to the connected device, such as a phone or tablet.
-The mobile application on the device can display the received button state and can control the state of LED 3 on the development board.
+When connected, the sample sends the state of **Button 1** on the development board to the connected device, such as a phone or tablet.
+The mobile application on the device can display the received button state and can control the state of **LED 3** on the development board.
 
 Alternatively, you can use this sample to control the color of RGB LED on the nRF52840 Dongle.
 
@@ -71,19 +71,19 @@ This testing procedure assumes that you are using `nRF Connect for Mobile`_.
 1. Power on your development board or plug in your dongle.
 #. Connect to the device from nRF Connect (the device is advertising as "Nordic_Blinky").
 #. Observe that the services of the connected device are shown.
-#. In "Nordic LED Button Service", click the **Play** button for the "Button" characteristic.
-#. Press Button 1 either on the dongle or on the development board.
+#. In "Nordic LED Button Service", click the :guilabel:`Play` button for the "Button" characteristic.
+#. Press **Button 1** either on the dongle or on the development board.
 #. Observe that notifications with the following values are received:
 
-   * ``00`` when Button 1 is released,
-   * ``01`` when Button 1 is pressed.
+   * ``00`` when **Button 1** is released,
+   * ``01`` when **Button 1** is pressed.
 
-#. Control the color of RGB LED on the dongle or status of LED 3 on the board by writing the following values to the "LED" characteristic in the "Nordic LED Button Service":
+#. Control the color of RGB LED on the dongle or status of **LED 3** on the board by writing the following values to the "LED" characteristic in the "Nordic LED Button Service":
 
    * ``00`` to switch the LED off on the board or turn on the red RGB LED on the dongle.
    * ``01`` to switch the LED on on the board or turn on the green RGB LED on the dongle.
 
-#. Observe that RGB LED on the dongle or LED 3 on the board corresponds to the value of the "LED" characteristic.
+#. Observe that RGB LED on the dongle or **LED 3** on the board corresponds to the value of the "LED" characteristic.
 
 Dependencies
 ************

--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -78,7 +78,7 @@ If you choose to do so, use the Python scripts in ``scripts\bootloader`` to crea
       On nRF9160, the UICR can only be erased by erasing the whole chip.
       To do so on the command line, call ``west flash`` with the ``--erase`` option.
       This will erase the whole chip before programming the new image.
-      In |SES|, choose :guilabel:`Target` > :guilabel:`Connect J-Link` and then :guilabel:`Target` > :guilabel:`Erase All` to erase the whole chip.
+      In |SES|, choose :guilabel:`Target` -> :guilabel:`Connect J-Link` and then :guilabel:`Target` -> :guilabel:`Erase All` to erase the whole chip.
 
    .. note::
       On some chips (for example, nRF9160 or nRF5340), the provisioned data is held in the OTP region in UICR.
@@ -122,9 +122,9 @@ Complete the following steps to add the bootloader sample as child image to your
 
 #. Run ``menuconfig`` on your application to enable Secure Boot:
 
-   a. Select **Project** > **Configure nRF Connect SDK project**.
-   #. Go to **Modules** > **Nordic nRF Connect** and select **Use Secure Bootloader** to enable :option:`CONFIG_SECURE_BOOT`.
-   #. Under **Private key PEM file** (:option:`CONFIG_SB_SIGNING_KEY_FILE`), enter the path to the private key that you created.
+   a. Select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK project`.
+   #. Go to :guilabel:`Modules` -> :guilabel:`Nordic nRF Connect` and select :guilabel:`Use Secure Bootloader` to enable :option:`CONFIG_SECURE_BOOT`.
+   #. Under :guilabel:`Private key PEM file` (:option:`CONFIG_SB_SIGNING_KEY_FILE`), enter the path to the private key that you created.
       If you choose to run the sample with default debug keys, you can skip this step.
 
       There are additional configuration options that you can modify, but it is not recommended to do so.
@@ -135,11 +135,11 @@ Complete the following steps to add the bootloader sample as child image to your
          This option allows you to define the signing command.
          In this case, you must also specify :option:`CONFIG_SB_SIGNING_COMMAND` and :option:`CONFIG_SB_SIGNING_PUBLIC_KEY`.
 
-   #. Click **Configure**.
+   #. Click :guilabel:`Configure`.
 
-#. Select **Build** > **Build Solution** to compile your application.
+#. Select :guilabel:`Build` -> :guilabel:`Build Solution` to compile your application.
    The build process creates two images, one for the bootloader and one for the application, and merges them together.
-#.  Select **Build** > **Build and Run** to program the resulting image to your device.
+#.  Select :guilabel:`Build` -> :guilabel:`Build and Run` to program the resulting image to your device.
 
 
 Testing

--- a/samples/debug/ppi_trace/README.rst
+++ b/samples/debug/ppi_trace/README.rst
@@ -21,7 +21,6 @@ Initially, RTC runs on RC low frequency (lower precision) as clock source.
 When the crystal is ready, it switches seamlessly to crystal (precise) as clock source.
 When the low-frequency crystal is ready, an ``NRF_CLOCK_EVENT_LFCLKSTARTED`` event is generated.
 
-
 Requirements
 ************
 
@@ -39,7 +38,6 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-
 Testing
 =======
 
@@ -47,12 +45,13 @@ After programming the sample to your board, test it by performing the following 
 
 1. Connect a logic analyzer to the pins that are used for tracing.
    Check the sample configuration for information about which pins are used.
-   To do so in |SES|, select **Project** > **Configure nRF Connect SDK Project** and navigate to **PPI trace pins configuration**.
+   To do so in |SES|, select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project` and navigate to :guilabel:`PPI trace pins configuration`.
 #. Observe that:
 
    * The pin that is tracing the RTC Tick event is toggling with a frequency of approximately 32 kHz.
    * The pin that is tracing the RTC Compare event is toggling approximately every 50 ms.
    * The pin that is tracing the LFCLK Started event is set at some point.
+
 #. Measure the typical time between two consecutive toggles of the pin that is tracing the RTC Compare event, before and after the LFCLK Started event is generated.
    Observe that the precision increases when the low-frequency crystal is started.
 #. Observe periodical radio activity during Bluetooth advertising.

--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -29,7 +29,7 @@ The sample supports any one of the following development kits:
    :rows: nrf5340pdk_nrf5340_cpunet, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 .. note::
-   For nRF5340 PDK, this sample is only supported on the network core (nrf5340pdk_nrf5340_cpunet), and the :ref:`nrf5340_empty_app_core` sample must be flashed on the application core.
+   For nRF5340 PDK, this sample is only supported on the network core (nrf5340pdk_nrf5340_cpunet), and the :ref:`nrf5340_empty_app_core` sample must be programmed to the application core.
 
 Building and Running
 ********************

--- a/samples/nrf5340/netboot/README.rst
+++ b/samples/nrf5340/netboot/README.rst
@@ -68,11 +68,11 @@ To test the network core bootloader sample run the following commands:
 
 #. ``west flash -d build_netboot``
 
-   Flash the merged hex files for both domains (application core and network core).
+   Program the merged hex files for both domains (application core and network core).
 
 #. ``nrfjprog --program build_netboot/zephyr/net_core_app_moved_test_update.hex --sectorerase -r``
 
-   This command will flash the update firmware for the network core to the secondary slot of MCUBoot in the application core.
+   This command will program the update firmware for the network core to the secondary slot of MCUBoot in the application core.
    The firmware is signed the same way that the application firmware is signed.
    Hence, the firmware is also verified by MCUBoot on the application core.
    See :ref:`subsys_pcd` for more details.

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -35,9 +35,9 @@ See `AWS IoT Developer Guide: Basic Policy Variables`_ and `AWS IoT Developer Gu
 To create a thing for your board:
 
 1. Log on to the `AWS IoT console`_.
-#. Go to **Secure** > **Policies** and select **Create a policy**.
+#. Go to :guilabel:`Secure` -> :guilabel:`Policies` and select :guilabel:`Create a policy`.
 #. Enter a name and define your policy.
-   For testing purposes, you can use the following policy (switch to **Advanced mode** to copy and paste it):
+   For testing purposes, you can use the following policy (switch to :guilabel:`Advanced mode` to copy and paste it):
 
    .. code-block:: javascript
 
@@ -51,20 +51,20 @@ To create a thing for your board:
              }
           ]
        }
-#. Go to **Manage** > **Things** and select **Register a thing** or **Create** (depending on whether you already have a thing registered).
-#. Select **Create a single thing**.
+#. Go to :guilabel:`Manage` -> :guilabel:`Things` and select :guilabel:`Register a thing` or :guilabel:`Create` (depending on whether you already have a thing registered).
+#. Select :guilabel:`Create a single thing`.
 #. Enter a name.
    The default name used by the sample is ``nrf-IMEI``, where *IMEI* is the IMEI number of your board.
    If you choose a different name, make sure to :ref:`configure a custom client ID <configuring>` in the sample before you build it.
 #. Accept the defaults and continue to the next step.
-#. Select **Create certificate** to generate new certificates.
+#. Select :guilabel:`Create certificate` to generate new certificates.
    Alternatively, you can use existing certificates.
    In this case, follow the instructions in AWS IoT.
 #. Download the certificates for later use.
-   You need the thing certificate (``*-certificate.pem.crt``), the private key (``*.private.pem.key``), and the root CA (choose the Amazon Root CA 1, ``AmazonRootCA1.pem``).
-#. Click **Activate** to activate the certificates.
-#. Click **Attach a policy** to continue to the next step.
-#. Select the policy that you created in step 3 and click **Register Thing**.
+   You need the thing certificate (:file:`*-certificate.pem.crt`), the private key (:file:`*.private.pem.key`), and the root CA (choose the Amazon Root CA 1, :file:`AmazonRootCA1.pem`).
+#. Click :guilabel:`Activate` to activate the certificates.
+#. Click :guilabel:`Attach a policy` to continue to the next step.
+#. Select the policy that you created in step 3 and click :guilabel:`Register Thing`.
 
 Updating the certificates
 =========================
@@ -84,10 +84,10 @@ Add the certificates to the sample code:
 
    .. warning_end
 
-   1. Open the ``certificates.h`` file in the ``src`` folder of the sample.
+   1. Open the :file:`certificates.h` file in the :file:`src` folder of the sample.
    #. Add the three certificates in the given format.
       Make sure to not add whitespace except for the ``\n`` line breaks.
-   #. Before programming the sample, configure it to provision the certificates from the certificates.h file (:option:`PROVISION_CERTIFICATES`) and to use a different security tag (:option:`CLOUD_CERT_SEC_TAG`).
+   #. Before programming the sample, configure it to provision the certificates from the :file:`certificates.h` file (:option:`PROVISION_CERTIFICATES`) and to use a different security tag (:option:`CLOUD_CERT_SEC_TAG`).
 
 Use LTE Link Monitor to write the certificates to the board:
    The nRF Connect `LTE Link Monitor`_ provides a certificate manager that you can use to store the certificates on your board:
@@ -96,7 +96,7 @@ Use LTE Link Monitor to write the certificates to the board:
    #. Put the modem in offline state.
    #. Paste the three certificates into the respective fields.
    #. Choose a security tag.
-   #. Click **Update certificates**.
+   #. Click :guilabel:`Update certificates`.
    #. Before programming the sample, make sure to configure the :option:`security tag <CLOUD_CERT_SEC_TAG>` to the one that you chose.
 
 .. include:: /includes/aws_s3_bucket.txt
@@ -144,7 +144,7 @@ Before you build the sample, check and update the following configuration option
 
    By default, the sample uses nRF Cloud's MQTT broker.
    Change this value to AWS IoT's MQTT broker.
-   To find the address of the AWS IoT MQTT broker, open the AWS IoT console, go to **Test** and select **View endpoint** from the **Connected as XXX** drop-down menu.
+   To find the address of the AWS IoT MQTT broker, open the AWS IoT console, go to :guilabel:`Test` and select :guilabel:`View endpoint` from the :guilabel:`Connected as XXX` drop-down menu.
 
 .. option:: USE_CLOUD_CLIENT_ID - Custom MQTT client ID
 
@@ -156,11 +156,11 @@ Before you build the sample, check and update the following configuration option
 
    If this option is checked, the sample uses the certificates that are stored in the modem with the nRF Cloud security tag.
 
-   Uncheck this option if you want to use the certificates added to the ``certificates.h`` file.
+   Uncheck this option if you want to use the certificates added to the :file:`certificates.h` file.
 
 .. option:: PROVISION_CERTIFICATES - Provision certificates from the certificates.h file
 
-   If this option is checked, the sample stores the certificates from the ``certificates.h`` file with the security tag that is defined as :option:`Security tag for TLS credentials <CLOUD_CERT_SEC_TAG>`.
+   If this option is checked, the sample stores the certificates from the :file:`certificates.h` file with the security tag that is defined as :option:`Security tag for TLS credentials <CLOUD_CERT_SEC_TAG>`.
 
    .. include:: README.rst
       :start-after: warning_start
@@ -194,15 +194,15 @@ After programming the sample to the board, test it by performing the following s
       [mqtt_evt_handler:129] MQTT client connected!
       [00:00:14.106,140] <inf> aws_jobs: Subscribe: $aws/things/nrf-aws-fota/jobs/notify-next
 
-#. Log on to the `AWS IoT console`_, go to **Manage** > **Things**, and select your thing.
-#. Go to **Shadow** and confirm that the application version (``nrfcloud__dfu_v1__app_v``) is the one that you configured for the sample.
+#. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` -> :guilabel:`Things`, and select your thing.
+#. Go to :guilabel:`Shadow` and confirm that the application version (``nrfcloud__dfu_v1__app_v``) is the one that you configured for the sample.
 #. In the :ref:`configuring`, change the application version.
    Then rebuild the application, but do not program it.
 #. Go to `AWS S3 console`_ and sign in.
 #. Go to the bucket you have created.
-#. Click **Upload** and select the file ``app_update.bin`` (located in the ``zephyr`` subfolder of your build directory).
-#. Click the file you uploaded in the bucket and check the **Object URL** field to find the download URL for the file.
-#. Create a job document (a text file) with the following content, replacing *host_url* with the server part of the URL that you created (for example, ``s3.amazonaws.com``) and *file_path* with the path and file name (for example, ``nordic-firmware-files/app_update.bin``):
+#. Click :guilabel:`Upload` and select the file :file:`app_update.bin` (located in the :file:`zephyr` subfolder of your build directory).
+#. Click the file you uploaded in the bucket and check the :guilabel:`Object URL` field to find the download URL for the file.
+#. Create a job document (a text file) with the following content, replacing *host_url* with the server part of the URL that you created (for example, ``s3.amazonaws.com``) and *file_path* with the path and file name (for example, :file:`nordic-firmware-files/app_update.bin`):
 
    .. parsed-literal::
       :class: highlight
@@ -220,10 +220,10 @@ After programming the sample to the board, test it by performing the following s
 
    See `AWS IoT Developer Guide: Jobs`_ for more information about AWS jobs.
 #. Log on to the `AWS S3 console`_.
-#. Select the bucket, click **Upload**, and select your job document.
+#. Select the bucket, click :guilabel:`Upload`, and select your job document.
    Use the default settings when uploading the file.
-#. Log on to the `AWS IoT console`_, go to **Manage** > **Jobs**, and select **Create a job**.
-#. Click **Create custom job** and enter a unique job ID.
+#. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` -> :guilabel:`Jobs`, and select :guilabel:`Create a job`.
+#. Click :guilabel:`Create custom job` and enter a unique job ID.
    Select your device and the job file that you uploaded to AWS S3.
    Use the default settings for all other options.
 #. Since the sample is configured to subscribe to the ``app_fw_update`` job topic, it picks up the job automatically.
@@ -245,8 +245,8 @@ After programming the sample to the board, test it by performing the following s
 
 
 #. When the board resets, observe that the sample prints the new application version.
-#. Log on to the `AWS IoT console`_, go to **Manage** > **Things**, and select your thing.
-#. Go to **Shadow** and confirm that the application version has updated.
+#. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` -> :guilabel:`Things`, and select your thing.
+#. Go to :guilabel:`Shadow` and confirm that the application version has updated.
 
 
 Troubleshooting
@@ -254,7 +254,7 @@ Troubleshooting
 
 ERROR: mqtt_connect -45:
    Error -45 ("operation is not supported on socket") indicates an error with the configured certificates.
-   Check that you added the certificates correctly in ``certificates.h`` and that you did not mix up the different certificates.
+   Check that you added the certificates correctly in :file:`certificates.h` and that you did not mix up the different certificates.
    Certificates must be formatted correctly, without extra whitespace.
 
 Content range is not defined:

--- a/samples/nrf9160/aws_iot/README.rst
+++ b/samples/nrf9160/aws_iot/README.rst
@@ -42,7 +42,7 @@ Before starting this sample, you should complete the following steps that are de
 
 1. `Setting up an AWS account`_
 #. :ref:`set_up_conn_to_iot`
-#. :ref:`Flashing device certificates <flash_certi_device>`
+#. :ref:`Programming device certificates <flash_certi_device>`
 #. :ref:`Configuring the sample options <configure_options>`
 
 For FOTA DFU related documentation, see :ref:`aws_fota_sample`.
@@ -76,7 +76,7 @@ Testing
    This retrieves the AWS IoT broker hostname, security tag and client-id.
 
 #. Set the :option:`CONFIG_AWS_IOT_BROKER_HOST_NAME`, :option:`CONFIG_AWS_IOT_SEC_TAG`, and :option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC` options to reflect the values retrieved during step 1.
-#. Flash the sample.
+#. Program the sample to hardware.
 
 .. note::
 

--- a/samples/nrf9160/azure_fota/README.rst
+++ b/samples/nrf9160/azure_fota/README.rst
@@ -60,7 +60,7 @@ Check and configure the following library options that are used by the sample:
 * :option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID` - Specifies the device ID, which is used when connecting to Azure IoT Hub or when DPS is enabled.
 
 .. note::
-   If the :option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID_APP` option is disabled, the device ID must be set in ``prj.conf``.
+   If the :option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID_APP` option is disabled, the device ID must be set in :file:`prj.conf`.
    If the :option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID_APP` option is enabled, the device ID must be provided using the :c:struct:`azure_iot_hub_config` configuration struct in a call to the :c:func:`azure_iot_hub_init` function.
 
 Building and running

--- a/samples/nrf9160/azure_iot_hub/README.rst
+++ b/samples/nrf9160/azure_iot_hub/README.rst
@@ -87,12 +87,14 @@ Optionally, follow the instructions at `Azure IoT Explorer`_ to install and conf
 #. Observe the log output and verify that it is similar to the :ref:`sampoutput_azure_iot`.
 #. Use the `Azure IoT Explorer`_, or log in to the `Azure Portal`_.
 #. Select the connected IoT hub and then your device.
-#. Change the device twin's *desired* property ``telemetryInterval`` to a new value, for instance ``10``, and save the updated device twin. If it does not exist, you can add the *desired* property.
+#. Change the device twin's *desired* property ``telemetryInterval`` to a new value, for instance ``10``, and save the updated device twin.
+   If it does not exist, you can add the *desired* property.
 #. Observe that the device receives the updated ``telemetryInterval`` value, applies it, and starts sending new telemetry events every 10 seconds.
 #. Verify that the ``reported`` object in the device twin now has a ``telemetryInterval`` property with the correct value reported back from the device.
 #. In the `Azure IoT Explorer`_ or device page in `Azure Portal`_, navigate to the :guilabel:`Direct method` tab.
 #. Enter ``led`` as the method name. In the ``payload`` field, enter the value ``1`` (or ``0``) and click :guilabel:`Invoke method`.
-#. Observe that LED 1 on the development kit lights up (or switches off if ``0`` is entered as the payload). If you are using `Azure IoT Explorer`_, you can observe a notification in the top right corner stating if the direct method was successfully invoked based on the report received from the device.
+#. Observe that LED 1 on the development kit lights up (or switches off if ``0`` is entered as the payload).
+   If you are using `Azure IoT Explorer`_, you can observe a notification in the top right corner stating if the direct method was successfully invoked based on the report received from the device.
 #. If you are using the `Azure IoT Explorer`_, navigate to the :guilabel:`Telemetry` tab and click :guilabel:`start`.
 #. Observe that the event messages from the device are displayed in the terminal within the specified telemetry interval.
 

--- a/samples/nrf9160/cloud_client/README.rst
+++ b/samples/nrf9160/cloud_client/README.rst
@@ -45,7 +45,7 @@ For configuring the different cloud backends, refer to the documentation on :ref
 Each cloud backend has specific setup steps that must be executed before it can be used.
 
 .. note::
-   The nRF9160 DK and Thingy:91 come pre-flashed with the certificates required for a connection to `nRF Cloud`_.
+   The nRF9160 DK and Thingy:91 come preprogrammed with the certificates required for a connection to `nRF Cloud`_.
    No extra steps are required to use the Cloud client sample with nRF Cloud.
 
 

--- a/samples/nrf9160/http_application_update/README.rst
+++ b/samples/nrf9160/http_application_update/README.rst
@@ -54,9 +54,9 @@ See `Setting up an AWS S3 bucket`_ for instructions.
 
 To specify the location in |SES|:
 
-1. Select **Project** > **Configure nRF Connect SDK Project**.
-#. Navigate to **HTTP application update sample** and specify the **Download host name** (``CONFIG_DOWNLOAD_HOST``) and **The file to download** (``CONFIG_DOWNLOAD_FILE``).
-#. Click **Configure** to save the configuration.
+1. Select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project`.
+#. Navigate to :guilabel:`HTTP application update sample` and specify the download host name (``CONFIG_DOWNLOAD_HOST``) and the file to download (``CONFIG_DOWNLOAD_FILE``).
+#. Click :guilabel:`Configure` to save the configuration.
 
 .. include:: /includes/aws_s3_bucket.txt
 
@@ -65,8 +65,8 @@ Hosting your image on an AWS S3 Server
 
 1. Go to `AWS S3 console`_ and sign in.
 #. Go to the bucket you have created.
-#. Click **Upload** and select the file ``app_update.bin`` (located in the ``zephyr`` subfolder of your build directory).
-#. Click the file you uploaded in the bucket and check the **Object URL** field to find the download URL for the file.
+#. Click :guilabel:`Upload` and select the file :file:`app_update.bin` (located in the :file:`zephyr` subfolder of your build directory).
+#. Click the file you uploaded in the bucket and check the :guilabel:`Object URL` field to find the download URL for the file.
 
 When specifying the image file, use the ``<bucket-name>.s3.<region>.amazonaws.com`` part of the URL for the download hostname.
 Make sure to not include the ``https``.
@@ -79,24 +79,24 @@ Testing
 After programming the sample to the board, test it by performing the following steps:
 
 1. Configure the application version to be 2.
-   To do so, either change ``CONFIG_APPLICATION_VERSION`` to 2 in the ``prj.conf`` file, or select **Project** > **Configure nRF Connect SDK Project** > **HTTP application update sample** in |SES| and change the value for **Application version**.
+   To do so, either change ``CONFIG_APPLICATION_VERSION`` to 2 in the :file:`prj.conf` file, or select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project` -> :guilabel:`HTTP application update sample` in |SES| and change the value for :guilabel:`Application version`.
    Then rebuild the application.
-#. Upload the file ``update.bin`` to the server you have chosen.
-   To upload the file on nRF Cloud, click **Upload** for the firmware URL that you generated earlier.
-   Then select the file ``update.bin`` and upload it.
+#. Upload the file :file:`update.bin` to the server you have chosen.
+   To upload the file on nRF Cloud, click :guilabel:`Upload` for the firmware URL that you generated earlier.
+   Then select the file :file:`update.bin` and upload it.
 #. Reset your nRF9160 DK to start the application.
 #. Open a terminal emulator and observe that an output similar to this is printed::
 
     SPM: prepare to jump to Non-Secure image
     ***** Booting Zephyr OS v1.13.99 *****
 
-#. Observe that LED1 is lit.
+#. Observe that **LED 1** is lit.
    This indicates that version 1 of the application is running.
-#. Press Button 1 on the nRF9160 DK to start the download process and wait until "Download complete" is printed in the terminal.
+#. Press **Button 1** on the nRF9160 DK to start the download process and wait until "Download complete" is printed in the terminal.
 #. Press the **RESET** button on the board.
    MCUboot will now detect the downloaded image and write it to flash.
    This can take up to a minute and nothing is printed in the terminal while this is processing.
-#. Observe that LED1 and LED2 is lit.
+#. Observe that **LED 1** and **LED 2** is lit.
    This indicates that version 2 or higher of the application is running.
 
 Dependencies

--- a/samples/nrf_rpc/entropy_nrf53/README.rst
+++ b/samples/nrf_rpc/entropy_nrf53/README.rst
@@ -57,7 +57,7 @@ This sample consists of the following sample applications, one each for the appl
    * Application core sample: :file:`entropy_nrf53/cpuapp`
    * Network core sample: :file:`entropy_nrf53/cpunet`
 
-Both of these sample applications must be built and flashed to the dual core device before testing.
+Both of these sample applications must be built and programmed to the dual core device before testing.
 For details on building samples for a dual core device, see :ref:`ug_nrf5340_building`.
 
 After programming the sample to your board, test it by performing the following steps:

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -120,7 +120,7 @@ Activating sample extensions
 To activate the optional extensions supported by this sample, modify :makevar:`OVERLAY_CONFIG` in the following manner:
 
 * For the Minimal Thread Device variant, set :file:`overlay-mtd.conf`.
-* For the Multiprotocol BLE extension, set :file:`overlay-multiprotocol_ble.conf`.
+* For the Multiprotocol Bluetooth LE extension, set :file:`overlay-multiprotocol_ble.conf`.
 
 See :ref:`cmake_options` for instructions on how to add this option.
 

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -150,7 +150,7 @@ To activate the optional extensions supported by this sample, modify :makevar:`O
   .. note::
      The :file:`overlay-fota.conf` file can be used only for nRF52840 DK.
 
-* For the Multiprotocol BLE extension, set :file:`overlay-multiprotocol_ble.conf`.
+* For the Multiprotocol Bluetooth LE extension, set :file:`overlay-multiprotocol_ble.conf`.
   Check :ref:`gs_programming_board_names` for the board name to use instead of the ``nrf52840dk_nrf52840``.
 
 See :ref:`cmake_options` for instructions on how to add this option.

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -292,7 +292,7 @@ share_size: list
    If the target partition is the ``app`` or a partition that spans over the ``app``, the size is effectively split between them, because the size of the ``app`` is dynamically decided.
 
    If none of the partitions in the ``share_size`` list exists, and the partition does not define a ``size`` property, then the partition is removed.
-   If none of the partitions in the ``share_size`` list exists, and the partition **does** define a ``size`` property, then the ``size`` property is used to set the size.
+   If none of the partitions in the ``share_size`` list exists, and the partition *does* define a ``size`` property, then the ``size`` property is used to set the size.
 
 region: string
    Specify the region where a partition should be placed.

--- a/scripts/shell/ble_console/README.rst
+++ b/scripts/shell/ble_console/README.rst
@@ -3,8 +3,7 @@
 BLE Console
 ###########
 
-BLE Console is a desktop application that can be used to communicate with an nRF
-device over *Bluetooth* Low Energy using the :ref:`shell_bt_nus_readme`.
+Bluetooth LE Console is a desktop application that can be used to communicate with an nRF device over Bluetooth Low Energy using the :ref:`shell_bt_nus_readme`.
 
 The application supports Linux only and cannot be run on Windows.
 You should run it on a natively installed Linux.
@@ -59,6 +58,6 @@ Pairing with the device
 ***********************
 
 After configuring the Bluetooth daemon, you can pair with the device using the Bluetooth tools provided by your Linux vendor.
-For example, in Ubuntu simply go to **Settings > Bluetooth**.
+For example, in Ubuntu simply go to :guilabel:`Settings` -> :guilabel:`Bluetooth`.
 
 After pairing successfully, you can start using BLE Console.


### PR DESCRIPTION
Modified files to be consistent with style guide rules.
Replaced BLE with Bluetooth LE where BLE was used in plain text.
Exception made for BLE Console.

Applied content highlighting markup rules for asterisk.
Applied markup for buttons, leds, and GUI elements.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>