### PR TITLE
spm: Add TWIM1 to non secure config

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -180,6 +180,10 @@ config SPM_NRF_FPU_NS
 	bool "FPU is Non-Secure"
 	default y
 
+config SPM_NRF_TWIM1_NS
+	bool "TWIM1 is Non-Secure"
+	default y
+
 config SPM_NRF_TWIM2_NS
 	bool "TWIM2 is Non-Secure"
 	default y

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -312,6 +312,9 @@ static void spm_config_peripherals(void)
 #ifdef NRF_UARTE2
 		PERIPH("NRF_UARTE2", NRF_UARTE2, CONFIG_SPM_NRF_UARTE2_NS),
 #endif
+#ifdef NRF_TWIM1
+		PERIPH("NRF_TWIM1", NRF_TWIM1, CONFIG_SPM_NRF_TWIM1_NS),
+#endif
 #ifdef NRF_TWIM2
 		PERIPH("NRF_TWIM2", NRF_TWIM2, CONFIG_SPM_NRF_TWIM2_NS),
 #endif


### PR DESCRIPTION
Added TWIM1 so I2C_1 can be used with non-secure images.

Signed-off-by: Thorvald Natvig <thorvald@natvig.com>