### PR TITLE
Asset tracker + carrier library fixes

### DIFF
--- a/boards/arm/thingy91_nrf9160/board_nonsecure.c
+++ b/boards/arm/thingy91_nrf9160/board_nonsecure.c
@@ -28,6 +28,12 @@ static int thingy91_magpio_configure(void)
 	int buffer;
 	uint8_t read_buffer[AT_CMD_MAX_READ_LENGTH];
 
+	if (!IS_ENABLED(CONFIG_BSD_LIBRARY_SYS_INIT)) {
+		LOG_INF("BSDlib is not yet initialized, AT commands not sent");
+		LOG_INF("Configuration of MAGPIO and COEX0 is left to drivers");
+		return 0;
+	}
+
 	at_socket_fd = socket(AF_LTE, SOCK_DGRAM, NPROTO_AT);
 	if (at_socket_fd == -1) {
 		LOG_ERR("AT socket could not be opened");


### PR DESCRIPTION
- ~Increase at_cmd's stack size to meet the carrier library's requirements~ Handled by #3051 
- For Thingy:91, do not attempt to send AT commands in board files if CONFIG_BSD_LIBARY_SYS_INIT is not enabled, as that will always fail. Instead, print log message saying that COEX0 and MAGPIO setup must be handled by drivers at a later stage.

Fixes CIA-114.