### PR TITLE
lib: bsdlib: Translate MSG_WAITALL flag

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -250,13 +250,17 @@ static int z_to_nrf_flags(int z_flags)
 	if (z_flags & MSG_TRUNC) {
 		nrf_flags |= NRF_MSG_TRUNC;
 	}
+
+	if (z_flags & MSG_WAITALL) {
+		nrf_flags |= NRF_MSG_WAITALL;
+	}
+
 	/* TODO: Handle missing flags, missing from zephyr,
 	 * may also be missing from bsd socket library.
 	 * Missing flags from "man recv" or "man recvfrom":
 	 *	MSG_CMSG_CLOEXEC
 	 *	MSG_ERRQUEUE
 	 *	MSG_OOB
-	 *	MSG_WAITALL
 	 * Missing flags from "man send" or "man sendto":
 	 *	MSG_CONFIRM
 	 *	MSG_DONTROUTE
@@ -268,7 +272,7 @@ static int z_to_nrf_flags(int z_flags)
 	 *	NRF_MSG_DONTWAIT (covered)
 	 *	NRF_MSG_OOB
 	 *	NRF_MSG_PEEK (covered)
-	 *	NRF_MSG_WAITALL
+	 *	NRF_MSG_WAITALL (covered)
 	 *	NRF_MSG_TRUNC (covered)
 	 */
 	return nrf_flags;

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.0-ncs1
+      revision: a3a6410b55fa97a9c6400c37d362c9137c5050b6
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Added support for translation from Zephyr's MSG_WAITALL to the SDK's NRF_MSG_WAITALL.

Linked to https://github.com/nrfconnect/sdk-zephyr/pull/371