### PR TITLE
manifest: OpenThread NCP library and plat log fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 33e59d44afb636c4fea4671a7ad301cbb619b7ec
+      revision: pull/299/head
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
This PR adds two fixes:
- provides two libraries needed by NCP to the  nrfxlib


Depends on PRs:

- [ ] sdk-nrfxlib - https://github.com/nrfconnect/sdk-nrfxlib/pull/299

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>