### PR TITLE
samples: Fix 802.15.4 radio config in radio_test

### DIFF
--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -136,6 +136,9 @@ static void radio_config(nrf_radio_mode_t mode, enum transmit_pattern pattern)
 		 */
 		packet_conf.plen = NRF_RADIO_PREAMBLE_LENGTH_32BIT_ZERO;
 		packet_conf.maxlen = IEEE_MAX_PAYLOAD_LEN;
+		packet_conf.balen = 0;
+		packet_conf.big_endian = false;
+		packet_conf.whiteen = false;
 
 		/* Set fast ramp-up time. */
 		nrf_radio_modecnf0_set(NRF_RADIO, true,


### PR DESCRIPTION
Fix for radio test sample 802.15.4 mode