### PR TITLE
tests: nrfx_integration_test: Fix test case configurations

### DIFF
--- a/tests/drivers/nrfx_integration_test/Kconfig
+++ b/tests/drivers/nrfx_integration_test/Kconfig
@@ -4,15 +4,13 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-source "Kconfig.zephyr"
-
 # This hidden option is intended to enable (include into compilation) all nrfx
 # drivers that are available for the SoC that is the build target.
 config NRFX_ALL_DRIVERS
 	def_bool y
 	depends on HAS_NRFX
 	select NRFX_ADC		if HAS_HW_NRF_ADC
-	select NRFX_CLOCK	if HAS_HW_NRF_CLOCK
+	select NRFX_CLOCK	if HAS_HW_NRF_CLOCK && !CLOCK_CONTROL_MPSL
 	select NRFX_COMP	if HAS_HW_NRF_COMP
 	select NRFX_DPPI	if HAS_HW_NRF_DPPIC
 	select NRFX_EGU0	if HAS_HW_NRF_EGU0
@@ -84,3 +82,18 @@ config NRFX_ALL_DRIVERS
 	select NRFX_PRS_BOX_2
 	select NRFX_PRS_BOX_3
 	select NRFX_PRS_BOX_4
+
+config NRFX_AND_BT_LL_SOFTDEVICE
+	bool "Test nrfx integration with SoftDevice BLE LL"
+	select BT
+
+config NRFX_AND_BT_LL_SW_SPLIT
+	bool "Test nrfx integration with Zephyr BLE LL"
+	select BT
+
+choice BT_LL_CHOICE
+	default BT_LL_SOFTDEVICE if NRFX_AND_BT_LL_SOFTDEVICE
+	default BT_LL_SW_SPLIT   if NRFX_AND_BT_LL_SW_SPLIT
+endchoice
+
+source "Kconfig.zephyr"

--- a/tests/drivers/nrfx_integration_test/prj.conf
+++ b/tests/drivers/nrfx_integration_test/prj.conf
@@ -6,7 +6,6 @@
 
 CONFIG_ZTEST=y
 CONFIG_ASSERT=y
-CONFIG_BT=y
 # Prevent compilation of Zephyr I2C and SPI driver shims (enabling of the nrfx
 # Kconfig options would cause them to be compiled, even though the corresponding
 # DT nodes might be not enabled, and as a result certain static functions in

--- a/tests/drivers/nrfx_integration_test/testcase.yaml
+++ b/tests/drivers/nrfx_integration_test/testcase.yaml
@@ -3,9 +3,15 @@ tests:
     build_only: true
     filter: CONFIG_HAS_NRFX
     tags: drivers ci_build
-  nrfx_integration_test.build.softdevice:
+  nrfx_integration_test.build.bt.softdevice:
     build_only: true
-    filter: CONFIG_HAS_NRFX
+    filter: CONFIG_HAS_NRFX and CONFIG_BT_LL_SOFTDEVICE
     tags: drivers ci_build
     extra_configs:
-      - CONFIG_BT_LL_SOFTDEVICE=y
+      - CONFIG_NRFX_AND_BT_LL_SOFTDEVICE=y
+  nrfx_integration_test.build.bt.sw_split:
+    build_only: true
+    filter: CONFIG_HAS_NRFX and CONFIG_BT_LL_SW_SPLIT
+    tags: drivers ci_build
+    extra_configs:
+      - CONFIG_NRFX_AND_BT_LL_SW_SPLIT=y


### PR DESCRIPTION
Provide configurations for 3 test cases:
- without BLE
- with BLE using the SoftDevice LL
- with BLE using the Zephyr SW split LL

The last two cases are accordingly filtered out if the given LL is not
available for a particular target (e.g. for nRF9160, which does not
have the BLE capable radio).

In configuration with CLOCK_CONTROL_MPSL enabled, do not compile
the nrfx_clock driver, as in such case a mocked version of this
driver needs to be used.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>