### PR TITLE
manifest: Add nrfxlib PR fixing CMAC issues

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.4.0-rc1
+      revision: 33e59d44afb636c4fea4671a7ad301cbb619b7ec
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
-Pointing to nrfxlib pr 298
-This fixes CMAC 192, 256 (failed with gluing)

nrfxlib PR: https://github.com/nrfconnect/sdk-nrfxlib/pull/298

ref: NCSDK-5883

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>