### PR TITLE
lib/fatal_error: Disabled by default for testing

### DIFF
--- a/lib/fatal_error/Kconfig
+++ b/lib/fatal_error/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig RESET_ON_FATAL_ERROR
 	bool "Reset on fatal error"
-	default y if !DEBUG && !BOARD_NATIVE_POSIX && !QEMU_TARGET
+	default y if !DEBUG && !BOARD_NATIVE_POSIX && !QEMU_TARGET && !ZTEST
 	select REBOOT
 	help
 	  Enable using the fatal error handler defined for Nordic DKs.


### PR DESCRIPTION
CONFIG_RESET_ON_FATAL_ERROR=y enables NCS own implementation of
k_sys_fatal_error_handler() which cause linking conflicts with
test's own implementations of the function.

This cause fail of all sanitycheck zephyr test with have their own k_sys_fatal_error_handler().

Objective for this PR is to be able to run and pass sdk-zephyr sanitycheck in the company of rest NCS components.