### PR TITLE
KRKNWK-7779: zigbee: suppress zboss trace via kconfig and add an option to enable ZBOSS traffic dump

### DIFF
--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -161,19 +161,24 @@ config ZBOSS_TRACE_LOG_LEVEL
 config ZBOSS_TRACE_MASK
 	hex "Trace mask of ZBOSS stack logs"
 	default 0x0000
-	range 0x0000 0x0B5C
+	range 0x0000 0xFFFF
 	help
 	  Selectively enable Zigbee binary trace logs.
 	  The mask value should be a bitwise OR of values assigned to selected modules.
 
 	  Available modules are:
 
+	  - 0x8000 SPI platform implementation
 	  - 0x4000 Zigbee Green Power
+	  - 0x2000 Custom components
+	  - 0x1000 UART and NCP transport
 	  - 0x0800 Application
+	  - 0x0400 MAC Lower Layer
 	  - 0x0200 Zigbee Light Link
 	  - 0x0100 Zigbee Cluster Library
 	  - 0x0080 Security
 	  - 0x0040 Zigbee Device Object
+	  - 0x0020 Zigbee Smart Energy
 	  - 0x0010 Application Support layer
 	  - 0x0008 Network layer
 	  - 0x0004 MAC layer
@@ -185,10 +190,10 @@ config ZBOSS_TRACE_MASK
 	  Note: For general debugging purposes, please use 0x0C48.
 
 config ZBOSS_TRAF_DUMP
-	bool "Enable MAC level traffic dump over ZBOSS traces"
+	bool "Enable logging received 802.15.4 frames over ZBOSS traces"
 	depends on !ZBOSS_TRACE_LOG_LEVEL_OFF
 	help
-	  Dumps all packets destined to the node ove ZBOSS binary trace protocol
+	  Dumps all packets destined to the node over ZBOSS binary trace protocol
 
 # Configure ZIGBEE_SHELL_LOG_LEVEL
 module = ZIGBEE_SHELL

--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -184,6 +184,12 @@ config ZBOSS_TRACE_MASK
 
 	  Note: For general debugging purposes, please use 0x0C48.
 
+config ZBOSS_TRAF_DUMP
+	bool "Enable MAC level traffic dump over ZBOSS traces"
+	depends on !ZBOSS_TRACE_LOG_LEVEL_OFF
+	help
+	  Dumps all packets destined to the node ove ZBOSS binary trace protocol
+
 # Configure ZIGBEE_SHELL_LOG_LEVEL
 module = ZIGBEE_SHELL
 module-str = Zigbee Shell

--- a/subsys/zigbee/osif/zb_nrf_logger.c
+++ b/subsys/zigbee/osif/zb_nrf_logger.c
@@ -21,6 +21,10 @@ static zb_uint_t buffered;
 
 void zb_osif_serial_put_bytes(zb_uint8_t *buf, zb_short_t len)
 {
+	if (IS_ENABLED(CONFIG_ZBOSS_TRACE_LOG_LEVEL_OFF)) {
+		return;
+	}
+
 	/* Try to fill hex dump by 8-bytes dumps */
 
 	while (len) {

--- a/subsys/zigbee/osif/zb_nrf_platform.c
+++ b/subsys/zigbee/osif/zb_nrf_platform.c
@@ -257,7 +257,11 @@ int zigbee_init(void)
 	/* Set Zigbee stack logging level and traffic dump subsystem. */
 	ZB_SET_TRACE_LEVEL(CONFIG_ZBOSS_TRACE_LOG_LEVEL);
 	ZB_SET_TRACE_MASK(CONFIG_ZBOSS_TRACE_MASK);
+#if CONFIG_ZBOSS_TRAF_DUMP
+	ZB_SET_TRAF_DUMP_ON();
+#else /* CONFIG_ZBOSS_TRAF_DUMP */
 	ZB_SET_TRAF_DUMP_OFF();
+#endif /* CONFIG_ZBOSS_TRAF_DUMP */
 #endif /* ZB_TRACE_LEVEL */
 
 #ifndef CONFIG_ZB_TEST_MODE


### PR DESCRIPTION
* Fix suppression of ZBOSS traces in Kconfig 
* Allow for enabling ZBOSS traffic dump
* Allow for setting any valid ZBOSS trace mask, including MAC LL