### PR TITLE
KRKNWK-7779: zigbee: Add API for continuous carrier and CCA

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_transceiver.c
+++ b/subsys/zigbee/osif/zb_nrf_transceiver.c
@@ -474,6 +474,20 @@ zb_uint8_t zb_trans_get_next_packet(zb_bufid_t buf)
 	return 1;
 }
 
+zb_ret_t zb_trans_cca(void)
+{
+	int cca_result = radio_api->cca(radio_dev);
+
+	switch (cca_result) {
+	case 0:
+		return RET_OK;
+	case -EBUSY:
+		return RET_BUSY;
+	default:
+		return RET_ERROR;
+	}
+}
+
 void zb_osif_get_ieee_eui64(zb_ieee_addr_t ieee_eui64)
 {
 	__ASSERT_NO_MSG(net_iface);


### PR DESCRIPTION
Add APIs that are required by Zigbee PHY and/or MAC certification tests.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>