### PR TITLE
manifest: Zephyr update for 802.15.4 init fixing

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.0-ncs1-rc1
+      revision: pull/373/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr revision to include a fix in 802.15.4 radio driver initialization.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-7786

Zephyr PR: https://github.com/nrfconnect/sdk-zephyr/pull/373

Pending on:

- [ ] https://github.com/nrfconnect/sdk-nrf/pull/3108