### PR TITLE
Bluetooth: Kconfig: Add connection count rules for SD controller

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -8,6 +8,15 @@ menu "Bluetooth Low Energy"
 
 if BT
 
+# BT_MAX_CONN is declared in Zephyr, here we add the range and default for
+# BT_LL_SOFTDEVICE which is tested with 20 connections.
+# When both connection roles are enabled there has to be one for each role.
+config BT_MAX_CONN
+	int
+	range 2 20 if BT_LL_SOFTDEVICE && BT_CENTRAL && BT_PERIPHERAL
+	range 1 20 if BT_LL_SOFTDEVICE
+	default 2 if BT_LL_SOFTDEVICE && BT_CENTRAL && BT_PERIPHERAL
+
 if BT_LL_SOFTDEVICE
 rsource "controller/Kconfig"
 endif # CONFIG_BT_LL_SOFTDEVICE


### PR DESCRIPTION
Add connection count rules for SoftDevice controller Kconfig.
This prevents the application user from selecting the invalid
configuration of BT_CENTRAL and BT_PERIPHERAL with BT_MAX_CONN=1.

Limit the range to the tested connection count of 20.

NCSDK-6741

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>