### PR TITLE
cmake: don't flash zephyr.hex and merged.hex for domain

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -266,17 +266,23 @@ function(add_child_image_from_source)
 
   if (ACI_DOMAIN)
     add_custom_target(${ACI_NAME}_flash
-                      COMMAND
-                      ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/${ACI_NAME}
-                      --target flash
-                      DEPENDS
-                      ${ACI_NAME}_subimage
-    )
+      COMMAND
+      ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/${ACI_NAME}
+      --target flash
+      DEPENDS
+      ${ACI_NAME}_subimage
+      )
 
-    set_property(TARGET zephyr_property_target
-                 APPEND PROPERTY FLASH_DEPENDENCIES
-                 ${ACI_NAME}_flash
-  )
+    # If the dynamic partition has child images, their hex files will be
+    # included in the 'merged_{DOMAIN_NAME}.hex' file which is flashed
+    # by the flash target of the dynamic partition. Hence, we only add a
+    # dependency to the flash target of the dynamic partition in the domain.
+    if ("${ACI_NAME}" STREQUAL "${${ACI_DOMAIN}_PM_DOMAIN_DYNAMIC_PARTITION}")
+      set_property(TARGET zephyr_property_target
+        APPEND PROPERTY FLASH_DEPENDENCIES
+        ${ACI_NAME}_flash
+        )
+    endif()
   endif()
 
 endfunction()


### PR DESCRIPTION
Fix bug where overlapping zephyr.hex and merged.hex were flashed
when a child image on a different domain had child images.

Ref: NCSDK-6744
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>