### PR TITLE
kconfig: add config for enabling network core dfu

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -186,8 +186,8 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     "version_MCUBOOT=${CONFIG_MCUBOOT_IMAGE_VERSION}"
     )
 
-  if (CONFIG_BT_RPMSG_NRF53 AND CONFIG_HCI_RPMSG_BUILD_STRATEGY_FROM_SOURCE
-      AND CONFIG_SOC_NRF5340_CPUAPP)
+  if (CONFIG_NRF53_UPGRADE_NETWORK_CORE
+      AND CONFIG_HCI_RPMSG_BUILD_STRATEGY_FROM_SOURCE)
     # Network core application updates are enabled.
     # We know this since MCUBoot is enabled on the application core, and
     # a network core child image is included in the build.

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -425,9 +425,7 @@ else()
           )
       endforeach()
 
-      if (CONFIG_BT_RPMSG_NRF53
-          AND CONFIG_BOOTLOADER_MCUBOOT
-          AND CONFIG_SOC_NRF5340_CPUAPP
+      if (CONFIG_NRF53_UPGRADE_NETWORK_CORE
           AND CONFIG_HCI_RPMSG_BUILD_STRATEGY_FROM_SOURCE)
           # Create symbols for the offset reqired for moving the signed network
           # core application to MCUBoots secondary slot. This is needed

--- a/include/dfu/pcd.h
+++ b/include/dfu/pcd.h
@@ -32,15 +32,15 @@ extern "C" {
 
 #ifdef CONFIG_SOC_SERIES_NRF53X
 
-/* These must be hard coded as this code is preprocessed for both net and app
- * core.
- */
-#define APP_CORE_SRAM_START 0x20000000
-#define APP_CORE_SRAM_SIZE KB(512)
-#define RAM_SECURE_ATTRIBUTION_REGION_SIZE 0x2000
-#define PCD_CMD_ADDRESS (APP_CORE_SRAM_START \
-			+ APP_CORE_SRAM_SIZE \
-			- RAM_SECURE_ATTRIBUTION_REGION_SIZE)
+#include <pm_config.h>
+
+#ifdef PM_PCD_SRAM_ADDRESS
+#define PCD_CMD_ADDRESS PM_PCD_SRAM_ADDRESS
+#else
+/* extra '_' since its in a different domain */
+#define PCD_CMD_ADDRESS PM__PCD_SRAM_ADDRESS
+#endif /* PM_PCD_SRAM_ADDRESS */
+
 #endif
 
 enum pcd_status {

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -64,13 +64,21 @@ if (CONFIG_BT_RPMSG_NRF53)
         ${NRF_DIR}/subsys/bluetooth/controller/bt_ll_softdevice_hci_rpmsg.conf
         )
     endif()
-    if (CONFIG_BOOTLOADER_MCUBOOT)
+    if (CONFIG_BOOTLOADER_MCUBOOT AND CONFIG_NRF53_UPGRADE_NETWORK_CORE)
       # Inject this configuration from parent image hci_rpmsg to enable
       # secure bootloader on the network core. This enables firmware update
       # of the network core application.
       add_overlay_config(
         hci_rpmsg
         "${ZEPHYR_NRF_MODULE_DIR}/subsys/bootloader/image/secure_boot.conf"
+        )
+
+      # Inject this configuration from parent image mcuboot to enable
+      # the PCD subsystem which is used to communicate the firmware update
+      # to the network core bootloader.
+      add_overlay_config(
+        mcuboot
+        "${ZEPHYR_NRF_MODULE_DIR}/subsys/pcd/pcd.conf"
         )
     endif()
 

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -209,6 +209,15 @@ config SB_BPROT_IN_DEBUG
 endif # SECURE_BOOT_DEBUG
 endif # IS_SECURE_BOOTLOADER
 
+config NRF53_UPGRADE_NETWORK_CORE
+	bool "Support updating nRF53 Network Core application"
+	default y
+	depends on SOC_NRF5340_CPUAPP
+	depends on BOOTLOADER_MCUBOOT
+	help
+	  Enables support for updating the application on the nRF53 Network
+	  core.
+
 rsource "bl_crypto/Kconfig"
 rsource "bl_validation/Kconfig"
 rsource "bl_storage/Kconfig"

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -51,6 +51,10 @@ if (CONFIG_BT_RPMSG_NRF53)
   ncs_add_partition_manager_config(pm.yml.bt_rpmsg_nrf53)
 endif()
 
+if (CONFIG_NRF53_UPGRADE_NETWORK_CORE)
+  ncs_add_partition_manager_config(pm.yml.pcd)
+endif()
+
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
 set(using_partition_manager

--- a/subsys/partition_manager/pm.yml.bt_rpmsg_nrf53
+++ b/subsys/partition_manager/pm.yml.bt_rpmsg_nrf53
@@ -2,6 +2,6 @@
 
 # This block of RAM is used for IPC
 rpmsg_nrf53_sram:
-  placement: {before: end}
+  placement: {before: {one_of: [pcd_sram, end]}}
   size: CONFIG_PM_PARTITION_SIZE_RPMSG_NRF53_SRAM
   region: sram_primary

--- a/subsys/partition_manager/pm.yml.pcd
+++ b/subsys/partition_manager/pm.yml.pcd
@@ -1,0 +1,8 @@
+#include <autoconf.h>
+
+# This block of RAM is used for communicating Network Core firmware update
+# metadata
+pcd_sram:
+  placement: {before: end}
+  size: CONFIG_NRF_SPU_RAM_REGION_SIZE
+  region: sram_primary

--- a/subsys/pcd/pcd.conf
+++ b/subsys/pcd/pcd.conf
@@ -1,0 +1,1 @@
+CONFIG_PCD=y


### PR DESCRIPTION
Allow users to opt out of support for network core dfu support.

This fixes issue where MCUBoot would not compile with default
configuration for nRF53 samples which included the hci_rpmsg
child image in addition to the MCUBoot bootloader.

Ref: NCSDK-6747
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>