### PR TITLE
net: lib: Fix issues related to recent changes in AWS FOTA

### DIFF
--- a/subsys/net/lib/aws_fota/Kconfig
+++ b/subsys/net/lib/aws_fota/Kconfig
@@ -25,7 +25,7 @@ config AWS_FOTA_FILE_PATH_MAX_LEN
 
 config AWS_FOTA_DOWNLOAD_SECURITY_TAG
 	int "Security tag to be used for downloads"
-	default 42
+	default -1
 
 
 module=AWS_FOTA

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -1132,7 +1132,7 @@ reset:
 #ifdef CONFIG_BOARD_QEMU_X86
 #define POLL_THREAD_STACK_SIZE 4096
 #else
-#define POLL_THREAD_STACK_SIZE 2560
+#define POLL_THREAD_STACK_SIZE 3072
 #endif
 K_THREAD_DEFINE(connection_poll_thread, POLL_THREAD_STACK_SIZE,
 		aws_iot_cloud_poll, NULL, NULL, NULL,

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -602,7 +602,7 @@ reset:
 #ifdef CONFIG_BOARD_QEMU_X86
 #define POLL_THREAD_STACK_SIZE 4096
 #else
-#define POLL_THREAD_STACK_SIZE 2560
+#define POLL_THREAD_STACK_SIZE 3072
 #endif
 K_THREAD_DEFINE(connection_poll_thread, POLL_THREAD_STACK_SIZE,
 		nrf_cloud_run, NULL, NULL, NULL,


### PR DESCRIPTION
Previous to this PR AWS FOTA would fail for applications depending on ```nrf_cloud.c``` and ```aws_iot.c```.

This PR:
 * Increases the default stack size of the connection_poll thread in ```nrf_cloud.c``` and ```aws_iot.c```
 * Changes the default value for ```CONFIG_AWS_FOTA_DOWNLOAD_SECURITY_TAG```

Closes [CIA-116]