### PR TITLE
bsdlib: mainfest update release 0.8.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 33e59d44afb636c4fea4671a7ad301cbb619b7ec
+      revision: 33097a7450d14fc0fc52f05896606958c9d032b5
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Manifest update for bsdlib release 0.8.1

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>