### PR TITLE
doc: bootloader: Change it from DTS to partition manager

### DIFF
--- a/doc/nrf/ug_bootloader.rst
+++ b/doc/nrf/ug_bootloader.rst
@@ -41,8 +41,7 @@ The following image shows an abstract representation of the memory layout, assum
 
    Memory layout
 
-For detailed information about the memory layout, see the partition configuration in the DTS overlay file for the board that you are using.
-This file is located in ``subsys\bootloader\dts``.
+For detailed information about the memory layout, see the partition configuration in the :file:`<build folder>/partitions.yml` file or run ``ninja partition_manager_report``.
 
 .. _immutable_bootloader:
 


### PR DESCRIPTION
The doc stated that you should look at the DTS. This is wrong when using
NCS the partition manager is the one who will setup the partitions.

NCSDK-6752

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>