### PR TITLE
nrf9160: samples: Erase modem dfu bank before connecting

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -364,6 +364,15 @@ Secure Partition Manager and application building together
 DFU and FOTA
 ============
 
+.. rst-class:: v1-4-0
+
+NCSDK-6754: Modem DFU erase may be halted
+  Modem erase may be halted if you delete the modem update bank while downloading with the :ref:`lib_fota_download` library.
+
+  **Workaround:** Ensure that the modem update bank is empty before you start downloading a modem delta update.
+  If you have downloaded a wrong or corrupted update, the modem update bank will also need to be erased.
+  In the :ref:`aws_fota_sample` sample and the :ref:`http_application_update_sample` sample, there are now functions that delete the modem firmware.
+
 .. rst-class:: v1-1-0
 
 Jobs not received after reset

--- a/samples/nrf9160/aws_iot/src/main.c
+++ b/samples/nrf9160/aws_iot/src/main.c
@@ -19,6 +19,7 @@
 #include <power/reboot.h>
 #include <date_time.h>
 #include <dfu/mcuboot.h>
+#include <dfu/dfu_target.h>
 #include <cJSON.h>
 #include <cJSON_os.h>
 
@@ -420,6 +421,18 @@ static void date_time_event_handler(const struct date_time_evt *evt)
 	k_sem_give(&date_time_obtained);
 }
 
+void erase_modem_update_bank(void)
+{
+	int err = dfu_target_init(DFU_TARGET_IMAGE_TYPE_MODEM_DELTA, 0, NULL);
+
+	if (err != 0) {
+		printk("Unable to clear modem update bank\n\r");
+	}
+
+	err = dfu_target_done(false);
+	__ASSERT(err == 0, "Unable to deinitialize dfu_target.");
+}
+
 void main(void)
 {
 	int err;
@@ -430,6 +443,13 @@ void main(void)
 
 #if defined(CONFIG_BSD_LIBRARY)
 	bsd_lib_modem_dfu_handler();
+#endif
+#if CONFIG_DFU_TARGET_MODEM
+	/* The modem bank should be clean so that the device is ready to recive
+	 * an update. If not it may halt when trying to erase the modem firmware
+	 * while downloading.
+	 */
+	erase_modem_update_bank();
 #endif
 
 	err = aws_iot_init(NULL, aws_iot_event_handler);

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
@@ -190,6 +190,18 @@ int lwm2m_init_firmware(void)
 	return 0;
 }
 
+void erase_modem_update_bank(void)
+{
+	int err = dfu_target_init(DFU_TARGET_IMAGE_TYPE_MODEM_DELTA, 0, NULL);
+
+	if (err != 0) {
+		LOG_ERR("Unable to clear modem update bank");
+	}
+
+	err = dfu_target_done(false);
+	__ASSERT(err == 0, "Unable to deinitialize dfu_target.");
+}
+
 void lwm2m_verify_modem_fw_update(void)
 {
 	int ret = bsdlib_get_init_ret();
@@ -228,6 +240,11 @@ void lwm2m_verify_modem_fw_update(void)
 		break;
 
 	default:
+		/* The modem bank should be clean so that the device is ready to
+		 * recive an update. If not it may halt when trying to erase the
+		 * modem firmware while downloading.
+		 */
+		erase_modem_update_bank();
 		return;
 	}
 


### PR DESCRIPTION
Issues have been discovered with erasing the modem bank while
downloading a modem delta. To mitigate this we should ensure that the
modem DFU bank is empty on every boot. A better solution is in the works
but temporarily as mitigation, this is a suggestion to improve the experience
of the samples.

NCSDK-6754

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>