### PR TITLE
drivers: bt_ll_softdevice: Allow config MPU to be disabled

### DIFF
--- a/drivers/bt_ll_softdevice/flash/Kconfig
+++ b/drivers/bt_ll_softdevice/flash/Kconfig
@@ -13,7 +13,7 @@ config SOC_FLASH_NRF_LL_SOFTDEVICE
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_DRIVER_ENABLED
 	select NRFX_NVMC
-	select MPU_ALLOW_FLASH_WRITE if CPU_HAS_MPU
+	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select MULTITHREADING_LOCK
 	help
 	  Enables SoftDevice Controller flash driver.


### PR DESCRIPTION
The configuration SOC_FLASH_NRF_LL_SOFTDEVICE selects the option
MPU_ALLOW_FLASH_WRITE if the CPU supports MPU.
This option depends on MPU so when MPU has been disabled this
throws a kconfig error.

NCSDK-6734

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>