### PR TITLE
manifest: Update sdk-zephyr to pull/376/head

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.0-ncs1-rc1
+      revision: pull/376/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update manifest for sdk-zephyr to: pull/376/head

This fixes a critical issue when using dts_root in Zephyr module.yml on
windows. Ninja could invoke CMake in an endless loop due to mixed style
path separators.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

NCS uses dts_root in its `zephyr/module.yml`
See also: https://github.com/zephyrproject-rtos/zephyr/issues/29235

--------
sdk-zephyr: https://github.com/nrfconnect/sdk-zephyr/pull/376
