### PR TITLE
manifest: update MCUBoot for fix serial recovery

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.6.99-ncs1-rc1
+      revision: c74627b65540fdb4105216361688199b6eceff4d
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
DNM until SHA not updated

Update sdk-mcuboot to version with fixed serial recovery
mode.

Introduces https://github.com/nrfconnect/sdk-mcuboot/pull/127

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>