### PR TITLE
manifest: update zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.0-ncs1-rc1
+      revision: pull/374/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr version to include bugfixes to bluetooth since 2.4
release.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>