### PR TITLE
mpsl: Perform low priority processing in system workqueue

### DIFF
--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -15,17 +15,16 @@
 
 LOG_MODULE_REGISTER(mpsl_init, CONFIG_MPSL_LOG_LEVEL);
 
+static void mpsl_low_prio_work_handler(struct k_work *item);
+
+static K_WORK_DEFINE(mpsl_low_prio_work, mpsl_low_prio_work_handler);
+
 #if IS_ENABLED(CONFIG_SOC_SERIES_NRF52X)
 	#define MPSL_LOW_PRIO_IRQn SWI5_IRQn
 #elif IS_ENABLED(CONFIG_SOC_SERIES_NRF53X)
 	#define MPSL_LOW_PRIO_IRQn EGU0_IRQn
 #endif
 #define MPSL_LOW_PRIO (4)
-
-static K_SEM_DEFINE(sem_signal, 0, UINT_MAX);
-static struct k_thread signal_thread_data;
-static K_THREAD_STACK_DEFINE(signal_thread_stack,
-			     CONFIG_MPSL_SIGNAL_STACK_SIZE);
 
 #define MPSL_TIMESLOT_SESSION_COUNT (\
 	CONFIG_MPSL_TIMESLOT_SESSION_COUNT + \
@@ -42,25 +41,19 @@ static uint8_t __aligned(4) timeslot_context[TIMESLOT_MEM_SIZE];
 
 static void mpsl_low_prio_irq_handler(void)
 {
-	k_sem_give(&sem_signal);
+	k_work_submit(&mpsl_low_prio_work);
 }
 
-static void signal_thread(void *p1, void *p2, void *p3)
+static void mpsl_low_prio_work_handler(struct k_work *item)
 {
-	ARG_UNUSED(p1);
-	ARG_UNUSED(p2);
-	ARG_UNUSED(p3);
+	ARG_UNUSED(item);
 
 	int errcode;
 
-	while (true) {
-		k_sem_take(&sem_signal, K_FOREVER);
-
-		errcode = MULTITHREADING_LOCK_ACQUIRE();
-		__ASSERT_NO_MSG(errcode == 0);
-		mpsl_low_priority_process();
-		MULTITHREADING_LOCK_RELEASE();
-	}
+	errcode = MULTITHREADING_LOCK_ACQUIRE();
+	__ASSERT_NO_MSG(errcode == 0);
+	mpsl_low_priority_process();
+	MULTITHREADING_LOCK_RELEASE();
 }
 
 ISR_DIRECT_DECLARE(mpsl_timer0_isr_wrapper)
@@ -160,21 +153,6 @@ static int mpsl_lib_init(const struct device *dev)
 			   mpsl_rtc0_isr_wrapper, IRQ_ZERO_LATENCY);
 	IRQ_DIRECT_CONNECT(RADIO_IRQn, MPSL_HIGH_IRQ_PRIORITY,
 			   mpsl_radio_isr_wrapper, IRQ_ZERO_LATENCY);
-
-	return 0;
-}
-
-static int mpsl_signal_thread_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	k_thread_create(&signal_thread_data, signal_thread_stack,
-			K_THREAD_STACK_SIZEOF(signal_thread_stack),
-			signal_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_MPSL_THREAD_COOP_PRIO),
-			0, K_NO_WAIT);
-	k_thread_name_set(&signal_thread_data, "MPSL signal");
-
 	IRQ_CONNECT(MPSL_LOW_PRIO_IRQn, MPSL_LOW_PRIO,
 		    mpsl_low_prio_irq_handler, NULL, 0);
 
@@ -182,5 +160,3 @@ static int mpsl_signal_thread_init(const struct device *dev)
 }
 
 SYS_INIT(mpsl_lib_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-SYS_INIT(mpsl_signal_thread_init, POST_KERNEL,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Do this instead of having a dedicated thread.

Advantages:
 - Reduces required RAM size.
 - Simpler implementation.

Disadvantages:
 - Low priority processing may get an additional delay if there
   is much work in the work queue.
 - The application must ensure that the items in the system work
   queue are not waiting for each other. That is, low priority
   MPSL timeslot signal handlers must ensure they are not waiting
   for other system work queue items.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>