### PR TITLE
Bluetooth: Mesh: Put NCS files in separate library

### DIFF
--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+zephyr_library()
+
 zephyr_library_sources(model_utils.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_ONOFF_SRV gen_onoff_srv.c)


### PR DESCRIPTION
Creates a Zephyr library for the Bluetooth Mesh folder in NCS to make
the source files show up in a dedicated library.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>