### PR TITLE
sample: aws_fota: re-introduce overwritten changes to buffer sizes

### DIFF
--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -37,6 +37,7 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
 
 #if !defined(CONFIG_CLOUD_CLIENT_ID)
 /* Define the length of the IMEI AT COMMAND response buffer */
+#define CGSN_RESP_LEN 19
 #define IMEI_LEN 15
 #define CLIENT_ID_LEN (sizeof(CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX) + IMEI_LEN)
 #else
@@ -374,7 +375,7 @@ static int client_id_get(char *id_buf, size_t len)
 {
 #if !defined(CONFIG_CLOUD_CLIENT_ID)
 	enum at_cmd_state at_state;
-	char imei_buf[IMEI_LEN + 1];
+	char imei_buf[CGSN_RESP_LEN];
 	int err = at_cmd_write("AT+CGSN", imei_buf, sizeof(imei_buf),
 				&at_state);
 
@@ -383,8 +384,8 @@ static int client_id_get(char *id_buf, size_t len)
 			err, at_state);
 		return err;
 	}
-	snprintf(id_buf, len, "%s%s", CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX,
-		 imei_buf);
+	snprintf(id_buf, len, "%s%.*s", CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX,
+		 IMEI_LEN, imei_buf);
 #else
 	memcpy(id_buf, CONFIG_CLOUD_CLIENT_ID, len);
 #endif /* !defined(NRF_CLOUD_CLIENT_ID) */


### PR DESCRIPTION
Re-introduce changes incorrectly overwritten. See commit message for details.

NCSDK-6750

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>