### PR TITLE
manifest: sdk-zephyr: Update manifest to sdk-zephyr.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.0-ncs1-rc1
+      revision: 45f2d5cf8ea437b9189255691980a4dc140b7a2b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
A single manifest update for the following sdk-zephyr PRs for 1.4.0-rc1
fixes.
- zephyr-sdk:#373
- zephyr-sdk:#374
- zephyr-sdk:#376
- zephyr-sdk:#377
and a hal_nordic update.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

------

Combined PR: https://github.com/nrfconnect/sdk-zephyr/pull/378