### PR TITLE
samples: Fix kconfig warning attempt HW stack protection not enabled

### DIFF
--- a/samples/Kconfig
+++ b/samples/Kconfig
@@ -10,7 +10,7 @@ config NCS_SAMPLES_DEFAULTS
 	imply LOG
 	imply LOG_MINIMAL
 	imply ASSERT
-	imply HW_STACK_PROTECTION
+	imply HW_STACK_PROTECTION if ARCH_HAS_STACK_PROTECTION
 	help
 	  Use the default configuration for NCS samples.
 


### PR DESCRIPTION
Fix kconfig warning when build samples for HW that does not have
HW stack protection.

 warning: HW_STACK_PROTECTION (defined at arch/Kconfig:198) was
 assigned the value 'y' but got the value 'n'.
 Check these unsatisfied dependencies: ARCH_HAS_STACK_PROTECTION (=n).

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>