### PR TITLE
fprotect: Use MDK function nrf53_errata_19()

### DIFF
--- a/lib/fprotect/fprotect_spu.c
+++ b/lib/fprotect/fprotect_spu.c
@@ -9,11 +9,12 @@
 #include <hal/nrf_spu.h>
 #include <errno.h>
 #include <soc.h>
+#include <nrf_erratas.h>
 
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) \
 	&& defined(CONFIG_NRF5340_CPUAPP_ERRATUM19)
-#define SPU_BLOCK_SIZE (nrf53_has_erratum19() ? 32*1024 : 16*1024)
+#define SPU_BLOCK_SIZE (nrf53_errata_19() ? 32*1024 : 16*1024)
 #else
 #define SPU_BLOCK_SIZE CONFIG_FPROTECT_BLOCK_SIZE
 #endif

--- a/subsys/spm/spm_internal.h
+++ b/subsys/spm/spm_internal.h
@@ -11,6 +11,7 @@
 #include <nrfx.h>
 #include <sys/util.h>
 #include <sys/__assert.h>
+#include <nrf_erratas.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,31 +33,10 @@ extern "C" {
 /* SPU FLASH regions */
 #if (defined(CONFIG_SOC_NRF5340_CPUAPP) \
 	&& defined(CONFIG_NRF5340_CPUAPP_ERRATUM19))
-static inline uint32_t spu_flash_region_size(void)
-{
-	if (NRF_FICR->INFO.PART == 0x5340) {
-		if (NRF_FICR->INFO.VARIANT == 0x41414142) {
-			return 32*1024;
-		}
-		return 16*1024;
-	}
-	__ASSERT(false, "Function should only be called on an nRF53 device.");
-	return 0;
-}
 
-static inline uint32_t num_spu_flash_regions(void)
-{
-	if (NRF_FICR->INFO.PART == 0x5340) {
-		if (NRF_FICR->INFO.VARIANT == 0x41414142) {
-			return 32;
-		}
-		return 64;
-	}
-	__ASSERT(false, "Function should only be called on an nRF53 device.");
-	return 0;
-}
-#define FLASH_SECURE_ATTRIBUTION_REGION_SIZE spu_flash_region_size()
-#define NUM_FLASH_SECURE_ATTRIBUTION_REGIONS num_spu_flash_regions()
+#define FLASH_SECURE_ATTRIBUTION_REGION_SIZE \
+				(nrf53_errata_19() ? 32*1024 : 16*1024)
+#define NUM_FLASH_SECURE_ATTRIBUTION_REGIONS (nrf53_errata_19() ? 32 : 64)
 #else
 
 #define SOC_NV_FLASH_NODE DT_INST(0, soc_nv_flash)


### PR DESCRIPTION
Instead of Zephyr variant which causes problems on nRF53 PDK 0.8.0

Ref: NCSDK-6769

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>