### PR TITLE
doc: slm tcp xsocket set command fix

### DIFF
--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -30,8 +30,8 @@ Syntax
 
 * The ``<op>`` parameter can accept one of the following values:
 
-  * ``0`` - Open
-  * ``1`` - Close
+  * ``0`` - Close
+  * ``1`` - Open
 
 * The ``<sec_tag>`` parameter is an integer.
   It indicates to the modem the credential of the security tag used for establishing a secure connection.


### PR DESCRIPTION
Fixed set command op parameter.

Signed-off-by: Francesco Servidio <francesco.servidio@nordicsemi.no>