### PR TITLE
Setting arbitrary output voltages for ADP536x buck converter.

### DIFF
--- a/boards/arm/thingy91_nrf9160/board_secure.c
+++ b/boards/arm/thingy91_nrf9160/board_secure.c
@@ -23,7 +23,7 @@ static int power_mgmt_init(void)
 		return err;
 	}
 
-	err = adp536x_buck_1v8_set();
+	err = adp536x_buck_set(ADP536X_VOUT_BUCK(1.8));
 	if (err) {
 		LOG_ERR("Could not set buck to 1.8 V, error: %d\n", err);
 		return err;

--- a/include/adp536x.h
+++ b/include/adp536x.h
@@ -220,4 +220,20 @@ int adp536x_oc_chg_current_set(u8_t value);
  */
 int adp536x_buck_discharge_set(bool enable);
 
+/**
+ * @brief Enable or disable the fuel gauge
+ * @param[in] enable Boolean value to enable or disable the fuel gauge
+ * @return 0 If the operation was successful,
+ *           Otherwise, a (negative) error code is returned.
+ */
+int adp536x_fuel_gauge_enable_set(bool enable);
+
+/**
+ * @brief Read the value of the fuel gauge
+ * @param[out] gauge Fuel gauge value in percent if read was successful
+ * @return 0 If operation was successful,
+ *           Otherwise a (negative) error code is returned.
+ */
+int adp536x_fuel_gauge_get(u8_t *gauge);
+
 #endif /* ADP536X_H_ */

--- a/include/adp536x.h
+++ b/include/adp536x.h
@@ -46,6 +46,9 @@
 #define ADP536X_OC_CHG_THRESHOLD_300mA	0x06
 #define ADP536X_OC_CHG_THRESHOLD_400mA	0x07
 
+/* Macro for setting buck output voltage */
+#define ADP536X_VOUT_BUCK(volt) ((u8_t)(((volt)-0.6)/0.05))
+
 /**
  * @brief Initialize ADP536X.
  *
@@ -55,6 +58,18 @@
  *           Otherwise, a (negative) error code is returned.
  */
 int adp536x_init(const char *dev_name);
+
+/**
+ * @brief  Arbitrary register read function
+ *
+ * @param[in] reg Register address
+ *
+ * @param[out] buff Buffer for the result
+ *
+ * @return 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int adp536x_get_reg(u8_t reg, u8_t *buff);
 
 /**
  * @brief Set the VBUS current limit.
@@ -150,13 +165,25 @@ int adp536x_oc_dis_hiccup_set(bool enable);
 int adp536x_buckbst_enable(bool enable);
 
 /**
- * @brief Set the buck regulator to 1.8 V.
+ * @brief Set the buck regulator output voltage.
+ *
+ * @param[in] value The requested output voltage. Use @ref ADP536X_VOUT_BUCK for conversion.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int adp536x_buck_1v8_set(void);
+int adp536x_buck_set(u8_t value);
 
+
+/**
+ * @brief  Enable or Disable the buck regulator.
+ *
+ * @param[in] enable Should the buck regulator be enabled or disabled?
+ *
+ * @return 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int adp536x_buck_enable(bool enable);
 /**
  * @brief Set the buck/boost regulator to 3.3 V.
  *

--- a/include/adp536x.h
+++ b/include/adp536x.h
@@ -72,6 +72,18 @@ int adp536x_init(const char *dev_name);
 int adp536x_get_reg(u8_t reg, u8_t *buff);
 
 /**
+ * @brief Arbitrary register write function
+ *
+ * @param[in] reg Register address
+ *
+ * @param[in] val Value to write
+ *
+ * @return 0 If the operation was successful,
+ *           Otherwise, a (negative) error code is returned.
+ */
+int adp536x_write_reg(u8_t reg, u8_t val);
+
+/**
  * @brief Set the VBUS current limit.
  *
  * @param[in] value The upper current threshold in LSB.

--- a/lib/adp536x/adp536x.c
+++ b/lib/adp536x/adp536x.c
@@ -24,6 +24,8 @@
 #define ADP536X_CHG_STATUS_2				0x09
 #define ADP536X_BAT_PROTECT_CTRL			0x11
 #define ADP536X_BAT_OC_CHG				0x15
+#define ADP536X_BAT_SOC				0x21
+#define ADP536X_FUEL_GAUGE_MODE				0x27
 #define ADP536X_BUCK_CFG				0x29
 #define ADP536X_BUCK_OUTPUT				0x2A
 #define ADP536X_BUCKBST_CFG				0x2B
@@ -112,6 +114,18 @@
 #define ADP536X_BAT_OC_CHG_OC_CHG(x)			(((x) & 0x07) << 5)
 #define ADP536X_BAT_OC_CHG_DGT_OC_CHG_MSK		GENMASK(4, 3)
 #define ADP536X_BAT_OC_CHG_DGT_OC_CHG(x)		(((x) & 0x03) << 3)
+
+/* Fuel gauge mode register */
+#define ADP536X_FUEL_GAUGE_MODE_SOC_LOW_TH_MASK		GENMASK(7,6)
+#define ADP536X_FUEL_GAUGE_MODE_SOC_LOW_TH(x)		(((x) & 0x03) << 6)
+#define ADP536X_FUEL_GAUGE_MODE_SLP_CURR_MASK		GENMASK(5,4)
+#define ADP536X_FUEL_GAUGE_MODE_SLP_CURR(x)		(((x) & 0x03) << 4)
+#define ADP536X_FUEL_GAUGE_MODE_SLP_TIME_MASK		GENMASK(3,2)
+#define ADP536X_FUEL_GAUGE_MODE_SLP_TIME(x)		(((x) & 0x03) << 2)
+#define ADP536X_FUEL_GAUGE_MODE_FG_MODE_MASK		BIT(1)
+#define ADP536X_FUEL_GAUGE_MODE_FG_MODE(x)		(((x) & 0x01) << 1)
+#define ADP536X_FUEL_GAUGE_MODE_EN_FG_MASK		BIT(0)
+#define ADP536X_FUEL_GAUGE_MODE_EN_FG(x)		(((x) & 0x01) << 0)
 
 /* Buck configure register. */
 #define ADP536X_BUCK_CFG_DISCHG_BUCK_MSK		BIT(1)
@@ -260,6 +274,18 @@ int adp536x_buck_discharge_set(bool enable)
 	return adp536x_reg_write_mask(ADP536X_BUCK_CFG,
 				ADP536X_BUCK_CFG_DISCHG_BUCK_MSK,
 				ADP536X_BUCK_CFG_DISCHG_BUCK(enable));
+}
+
+int adp536x_fuel_gauge_enable_set(bool enable)
+{
+		return adp536x_reg_write_mask(ADP536X_FUEL_GAUGE_MODE,
+																	ADP536X_FUEL_GAUGE_MODE_EN_FG_MASK,
+																	ADP536X_FUEL_GAUGE_MODE_EN_FG(enable));
+}
+
+int adp536x_fuel_gauge_get(u8_t *gauge)
+{
+		return adp536x_reg_read(ADP536X_BAT_SOC, gauge);
 }
 
 int adp536x_buckbst_3v3_set(void)

--- a/lib/adp536x/adp536x.c
+++ b/lib/adp536x/adp536x.c
@@ -116,6 +116,9 @@
 /* Buck configure register. */
 #define ADP536X_BUCK_CFG_DISCHG_BUCK_MSK		BIT(1)
 #define ADP536X_BUCK_CFG_DISCHG_BUCK(x)			(((x) & 0x01) << 1)
+#define ADP536X_BUCK_CFG_ENABLE_BUCK_MSK		BIT(0)
+#define ADP536X_BUCK_CFG_ENABLE_BUCK(x)			(((x) & 0x01) << 0)
+
 
 /* Buck output voltage setting register. */
 #define ADP536X_BUCK_OUTPUT_VOUT_BUCK_MSK		GENMASK(5, 0)
@@ -166,6 +169,10 @@ static int adp536x_reg_write_mask(u8_t reg_addr,
 	tmp |= data;
 
 	return adp536x_reg_write(reg_addr, tmp);
+}
+
+int adp536x_get_reg(u8_t reg, u8_t *buff){
+	return adp536x_reg_read(reg, buff);
 }
 
 int adp536x_charger_current_set(u8_t value)
@@ -234,14 +241,18 @@ int adp536x_oc_chg_current_set(u8_t value)
 					ADP536X_BAT_OC_CHG_OC_CHG(value));
 }
 
-int adp536x_buck_1v8_set(void)
+int adp536x_buck_set(u8_t value)
 {
-	/* 1.8V equals to 0b11000 = 0x18 according to ADP536X datasheet. */
-	u8_t value = 0x18;
 
 	return adp536x_reg_write_mask(ADP536X_BUCK_OUTPUT,
 					ADP536X_BUCK_OUTPUT_VOUT_BUCK_MSK,
 					ADP536X_BUCK_OUTPUT_VOUT_BUCK(value));
+}
+
+int adp536x_buck_enable(bool enable) {
+	return adp536x_reg_write_mask(ADP536X_BUCK_CFG,
+																ADP536X_BUCK_CFG_ENABLE_BUCK_MSK,
+																ADP536X_BUCK_CFG_ENABLE_BUCK(enable));
 }
 
 int adp536x_buck_discharge_set(bool enable)

--- a/lib/adp536x/adp536x.c
+++ b/lib/adp536x/adp536x.c
@@ -189,6 +189,11 @@ int adp536x_get_reg(u8_t reg, u8_t *buff){
 	return adp536x_reg_read(reg, buff);
 }
 
+int adp536x_write_reg(u8_t reg, u8_t val) {
+    return adp536x_reg_write(reg, val);
+}
+
+
 int adp536x_charger_current_set(u8_t value)
 {
 	return adp536x_reg_write_mask(ADP536X_CHG_CURRENT_SET,


### PR DESCRIPTION
For our board, we need to set the ADP536x buck converter output voltage to a different level than 1.8V. We also needed an arbitrary function to read some registers.

It would be nice if these functions could be merged back into the v1.3 main development line.