### PR TITLE
kconfig: Default MAIN_STACK_SIZE=2048 for ZTEST in nrf

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -11,6 +11,16 @@ menu "Nordic nRF Connect"
 config BOARD_THINGY91_NRF9160NS
 	bool
 
+# nRF Connect SDK needs a larger default stacks for running certain tests.
+config MAIN_STACK_SIZE
+	default 2048 if ZTEST
+
+config ZTEST_STACKSIZE
+	default 2048 if ZTEST
+
+config PRIVILEGED_STACK_SIZE
+	default 2048 if ZTEST
+
 rsource "samples/Kconfig"
 rsource "subsys/Kconfig"
 rsource "lib/Kconfig"


### PR DESCRIPTION
This adjust the upstream MAIN_STACK_SIZE default of 512 when using ZTEST
to 2048.

It also adjust the default ZTEST_STACKSIZE to 2048.

This allows to run entropy, crypto and more tests without stack
overflows.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>