### PR TITLE
manifest: update zephyr to get temphack fixing assert

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 41ce8e165a9af4171ef52a73aede89da6ce60920
+      revision: pull/379/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes assert when configuring MPU regions

Depends on https://github.com/nrfconnect/sdk-zephyr/pull/379

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>