### PR TITLE
manifest: nrfxlib: update MPSL to include latest RAAL_REM fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 485cf290aff0407e846a844ce8f29c076b4481d2
+      revision: 9dbc0e786924ea1e42e6f732d0d19a58265f4559
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
This PR updates the version of MPSL to the one with the latest
patches in RAAL_REM module. These fixes the remaining stability issues
in running 802.15.4 Radio Driver with MPSL (KRKNWK-7705).

Signed-off-by: Czeslaw Makarski <Czeslaw.Makarski@nordicsemi.no>