### PR TITLE
lib: modem: modem_key_mgmt: fix typo in typename

### DIFF
--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -18,7 +18,7 @@
 #include <nrf_socket.h>
 
 /**@brief Credential types. */
-enum modem_key_mgnt_cred_type {
+enum modem_key_mgmt_cred_type {
 	MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN,
 	MODEM_KEY_MGMT_CRED_TYPE_PUBLIC_CERT,
 	MODEM_KEY_MGMT_CRED_TYPE_PRIVATE_CERT,
@@ -49,7 +49,7 @@ enum modem_key_mgnt_cred_type {
  * @retval -EPERM	Insufficient permissions.
  */
 int modem_key_mgmt_write(nrf_sec_tag_t sec_tag,
-			 enum modem_key_mgnt_cred_type cred_type,
+			 enum modem_key_mgmt_cred_type cred_type,
 			 const void *buf, size_t len);
 
 /**
@@ -69,7 +69,7 @@ int modem_key_mgmt_write(nrf_sec_tag_t sec_tag,
  * @retval -EPERM	Insufficient permissions.
  */
 int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
-			enum modem_key_mgnt_cred_type cred_type,
+			enum modem_key_mgmt_cred_type cred_type,
 			void *buf, size_t *len);
 
 /**
@@ -88,7 +88,7 @@ int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
  * @retval -EPERM	Insufficient permissions.
  */
 int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
-		       enum modem_key_mgnt_cred_type cred_type,
+		       enum modem_key_mgmt_cred_type cred_type,
 		       const void *buf, size_t len);
 
 /**
@@ -108,7 +108,7 @@ int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
  * @retval -EPERM	Insufficient permissions.
  */
 int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
-			  enum modem_key_mgnt_cred_type cred_type);
+			  enum modem_key_mgmt_cred_type cred_type);
 
 /**
  * @brief Set permissions for a credential in persistent storage.
@@ -124,7 +124,7 @@ int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
  * @retval -EPERM	Insufficient permissions.
  */
 int modem_key_mgmt_permission_set(nrf_sec_tag_t sec_tag,
-				  enum modem_key_mgnt_cred_type cred_type,
+				  enum modem_key_mgmt_cred_type cred_type,
 				  uint8_t perm_flags);
 
 /**
@@ -142,7 +142,7 @@ int modem_key_mgmt_permission_set(nrf_sec_tag_t sec_tag,
  * @retval -EPERM	Insufficient permissions.
  */
 int modem_key_mgmt_exists(nrf_sec_tag_t sec_tag,
-			  enum modem_key_mgnt_cred_type cred_type,
+			  enum modem_key_mgmt_cred_type cred_type,
 			  bool *exists, uint8_t *perm_flags);
 
 #endif /* MODEM_KEY_MGMT_H__ */

--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -110,7 +110,7 @@ static int write_at_cmd_with_cme_enabled(char *cmd, char *buf, size_t buf_len,
 
 /* Read the given credential into the static buffer */
 static int key_fetch(nrf_sec_tag_t tag,
-		     enum modem_key_mgnt_cred_type cred_type)
+		     enum modem_key_mgmt_cred_type cred_type)
 {
 	int err;
 	int written;
@@ -135,7 +135,7 @@ static int key_fetch(nrf_sec_tag_t tag,
 }
 
 int modem_key_mgmt_write(nrf_sec_tag_t sec_tag,
-			 enum modem_key_mgnt_cred_type cred_type,
+			 enum modem_key_mgmt_cred_type cred_type,
 			 const void *buf, size_t len)
 {
 	int err;
@@ -168,7 +168,7 @@ int modem_key_mgmt_write(nrf_sec_tag_t sec_tag,
 }
 
 int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
-			enum modem_key_mgnt_cred_type cred_type,
+			enum modem_key_mgmt_cred_type cred_type,
 			void *buf, size_t *len)
 {
 	int err;
@@ -194,7 +194,7 @@ int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
 }
 
 int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
-		       enum modem_key_mgnt_cred_type cred_type,
+		       enum modem_key_mgmt_cred_type cred_type,
 		       const void *buf, size_t len)
 {
 	int err;
@@ -235,7 +235,7 @@ int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
 }
 
 int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
-			  enum modem_key_mgnt_cred_type cred_type)
+			  enum modem_key_mgmt_cred_type cred_type)
 {
 	int err;
 	int written;
@@ -254,14 +254,14 @@ int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
 }
 
 int modem_key_mgmt_permission_set(nrf_sec_tag_t sec_tag,
-				  enum modem_key_mgnt_cred_type cred_type,
+				  enum modem_key_mgmt_cred_type cred_type,
 				  uint8_t perm_flags)
 {
 	return -EOPNOTSUPP;
 }
 
 int modem_key_mgmt_exists(nrf_sec_tag_t sec_tag,
-			  enum modem_key_mgnt_cred_type cred_type,
+			  enum modem_key_mgmt_cred_type cred_type,
 			  bool *exists, uint8_t *perm_flags)
 {
 	int err;

--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -347,21 +347,21 @@ static int provision_certificates(void)
 		"\n");
 	printk("************************* WARNING *************************\n");
 	nrf_sec_tag_t sec_tag = CONFIG_CLOUD_CERT_SEC_TAG;
-	enum modem_key_mgnt_cred_type cred[] = {
+	enum modem_key_mgmt_cred_type cred[] = {
 		MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN,
 		MODEM_KEY_MGMT_CRED_TYPE_PRIVATE_CERT,
 		MODEM_KEY_MGMT_CRED_TYPE_PUBLIC_CERT,
 	};
 
 	/* Delete certificates */
-	for (enum modem_key_mgnt_cred_type type = 0; type < 3; type++) {
+	for (enum modem_key_mgmt_cred_type type = 0; type < 3; type++) {
 		err = modem_key_mgmt_delete(sec_tag, type);
 		printk("modem_key_mgmt_delete(%u, %d) => result=%d\n",
 				sec_tag, type, err);
 	}
 
 	/* Write certificates */
-	for (enum modem_key_mgnt_cred_type type = 0; type < 3; type++) {
+	for (enum modem_key_mgmt_cred_type type = 0; type < 3; type++) {
 		err = modem_key_mgmt_write(sec_tag, cred[type],
 				certificates[type], cert_len[type]);
 		printk("modem_key_mgmt_write => result=%d\n", err);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -417,7 +417,7 @@ static int nct_provision(void)
 		/* Delete certificates */
 		nrf_sec_tag_t sec_tag = CONFIG_NRF_CLOUD_SEC_TAG;
 
-		for (enum modem_key_mgnt_cred_type type = 0; type < 5;
+		for (enum modem_key_mgmt_cred_type type = 0; type < 5;
 		     type++) {
 			err = modem_key_mgmt_delete(sec_tag, type);
 			LOG_DBG("modem_key_mgmt_delete(%u, %d) => result = %d",


### PR DESCRIPTION
The header file defines modem_key_mgnt_cred_type,
(with 'n' in mgnt), while all the functions are
named modem_key_mgmt_* (with only 'm's in mgmt).

Signed-off-by: Didrik Rokhaug <didrik.rokhaug@gmail.com>