### PR TITLE
Bluetooth: Mesh: Generic level scene set transaction

### DIFF
--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -244,6 +244,7 @@ static void scene_recall(struct bt_mesh_model *mod, const uint8_t data[],
 	struct bt_mesh_lvl_srv *srv = mod->user_data;
 	struct bt_mesh_lvl_set set = {
 		.lvl = sys_get_le16(data),
+		.new_transaction = true,
 		.transition = transition,
 	};
 


### PR DESCRIPTION
Mark every scene_set call in the generic level model as a new
transaction.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>