### PR TITLE
net: lib: download_client: Add option to enable partial request in HTTP

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -364,6 +364,14 @@ Secure Partition Manager and application building together
 DFU and FOTA
 ============
 
+.. rst-class:: v1-4-0
+
+NCSDK-6238: Socket API calls may hang when using Download client
+  When using the :ref:`lib_download_client` library with HTTP (without TLS), the application might not process incoming fragments fast enough, which can starve the :ref:`nrfxlib:bsdlib` buffers and make calls to BSD library hang.
+  Samples and applications that are affected include those that use :ref:`lib_download_client` to download files through HTTP, or those that use :ref:`lib_fota_download` with modem updates enabled.
+
+**Workaround:** Set :option:`CONFIG_DOWNLOAD_CLIENT_RANGE_REQUESTS`.
+
 .. rst-class:: v1-1-0
 
 Jobs not received after reset

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -33,6 +33,7 @@ config DFU_TARGET_MCUBOOT_SAVE_PROGRESS
 
 config DFU_TARGET_MODEM
 	bool "Modem update support"
+	imply DOWNLOAD_CLIENT_RANGE_REQUESTS
 	default y
 	depends on SOC_NRF9160_SICA
 	help

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -115,6 +115,15 @@ config DOWNLOAD_CLIENT_SOCK_TIMEOUT_MS
 	  when a retrasmission is necessary.
 	  Set to -1 disable.
 
+config DOWNLOAD_CLIENT_RANGE_REQUESTS
+	bool "Always use HTTP Range requests"
+	help
+	  Always use HTTP Range requests when downloading (RFC 7233).
+	  This option can be useful to limit the amount of incoming data from the server
+	  by downloading only one fragment at a time. It increases the protocol overhead
+	  but also gives time to the application to process the fragments as they are
+	  downloaded, instead of having to keep up to speed while downloading the whole file.
+
 config DOWNLOAD_CLIENT_IPV6
 	bool "Use IPv6 when possible"
 	help

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -483,7 +483,8 @@ restart_and_suspend:
 send_again:
 		dl->offset = 0;
 		/* Request next fragment, if necessary (HTTPS/CoAP) */
-		if (dl->proto != IPPROTO_TCP || len == 0) {
+		if (dl->proto != IPPROTO_TCP || len == 0
+		   || IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_RANGE_REQUESTS)) {
 			dl->http.has_header = false;
 
 			rc = request_send(dl);

--- a/subsys/net/lib/download_client/src/http.c
+++ b/subsys/net/lib/download_client/src/http.c
@@ -73,7 +73,8 @@ int http_get_request_send(struct download_client *client)
 	 * When using HTTP, we request the whole resource to minimize
 	 * network usage (only one request/response are sent).
 	 */
-	if (client->proto == IPPROTO_TLS_1_2) {
+	if (client->proto == IPPROTO_TLS_1_2
+	   || IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_RANGE_REQUESTS)) {
 		len = snprintf(client->buf,
 			CONFIG_DOWNLOAD_CLIENT_BUF_SIZE,
 			GET_HTTPS_TEMPLATE, file, host, client->progress, off);
@@ -131,7 +132,8 @@ static int http_header_parse(struct download_client *client, size_t *hdr_len)
 
 	p = strstr(client->buf, "http/1.1 206");
 	if (!p) {
-		if (client->proto == IPPROTO_TLS_1_2) {
+		if (client->proto == IPPROTO_TLS_1_2
+		   || IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_RANGE_REQUESTS)) {
 			LOG_ERR("Server did not honor partial content request");
 			return -1;
 		}
@@ -146,7 +148,8 @@ static int http_header_parse(struct download_client *client, size_t *hdr_len)
 	 * and via "Content-Range" in case of HTTPS with range requests.
 	 */
 	if (client->file_size == 0) {
-		if (client->proto == IPPROTO_TLS_1_2) {
+		if (client->proto == IPPROTO_TLS_1_2
+		   || IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_RANGE_REQUESTS)) {
 			p = strstr(client->buf, "content-range");
 			if (!p) {
 				LOG_ERR("Server did not send "


### PR DESCRIPTION
When doing a modem DFU it halts after 2nd fragment due to the packet
handler being overfilled leading the application to halt since it
doesn't receive a notification for the result of modem DFU writes.

This is due to the packet handler being full when you are doing a request for all the content at once. This adds a `Kconfig` option which makes sure that you do partial content-range requests so that the packet handler won't be filled.

This fixes:

NCSDK-6238

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>