### PR TITLE
crypto: test: Fixed issue with internal rng in ecdh tests

### DIFF
--- a/tests/crypto/test_cases/test_ecdh.c
+++ b/tests/crypto/test_cases/test_ecdh.c
@@ -274,10 +274,17 @@ void exec_test_case_ecdh_deterministic_full(void)
 
 	/* Execute ECDH on initiator side. */
 	start_time_measurement();
-	err_code =
-		mbedtls_ecdh_compute_shared(&initiator_ctx.grp,
-					    &initiator_ctx.z, &responder_ctx.Q,
-					    &initiator_ctx.d, drbg_random, NULL);
+	err_code = mbedtls_ecdh_compute_shared(
+			&initiator_ctx.grp,
+			&initiator_ctx.z,
+			&responder_ctx.Q,
+			&initiator_ctx.d,
+#if defined(CONFIG_MBEDTLS_VANILLA_BACKEND)
+			NULL,
+#else
+			drbg_random,
+#endif
+			NULL);
 	stop_time_measurement();
 
 	LOG_DBG("Error code compute shared: -0x%04X", -err_code);
@@ -290,10 +297,17 @@ void exec_test_case_ecdh_deterministic_full(void)
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
 	/* Execute ECDH on responder side. */
-	err_code =
-		mbedtls_ecdh_compute_shared(&responder_ctx.grp,
-					    &responder_ctx.z, &initiator_ctx.Q,
-					    &responder_ctx.d, drbg_random, NULL);
+	err_code = mbedtls_ecdh_compute_shared(
+			&responder_ctx.grp,
+			&responder_ctx.z,
+			&initiator_ctx.Q,
+			&responder_ctx.d,
+#if defined(CONFIG_MBEDTLS_VANILLA_BACKEND)
+			NULL,
+#else
+			drbg_random,
+#endif
+			NULL);
 
 	TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code, err_code);
 
@@ -368,10 +382,17 @@ void exec_test_case_ecdh_deterministic(void)
 	}
 
 	start_time_measurement();
-	err_code =
-		mbedtls_ecdh_compute_shared(&responder_ctx.grp,
-					    &responder_ctx.z, &initiator_ctx.Q,
-					    &responder_ctx.d, drbg_random, NULL);
+	err_code = mbedtls_ecdh_compute_shared(
+			&responder_ctx.grp,
+			&responder_ctx.z,
+			&initiator_ctx.Q,
+			&responder_ctx.d,
+#if defined(CONFIG_MBEDTLS_VANILLA_BACKEND)
+			NULL,
+#else
+			drbg_random,
+#endif
+			NULL);
 	stop_time_measurement();
 
 	LOG_DBG("Error code ss computation: -0x%04X", -err_code);

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 9dbc0e786924ea1e42e6f732d0d19a58265f4559
+      revision: 19cff87ddc90cb84e338b1b04e19b976c355508a
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
- Note: Internal rng configuration changed in mbedtls 2.23.0.
- Used NULL for f_rng for vanilla backend in ecdh tests.
- Also adds nrf_cc3xx_platform/nrf_cc3xx_mbedcrypto 0.9.4 in nrfxlib PR

Ref: NCSDK-6789
Ref: NCSDK-6765

nrfxlib PR: https://github.com/nrfconnect/sdk-nrfxlib/pull/310

Signed-off-by: Magne Værnes <magne.varnes@nordicsemi.no>
Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>