### PR TITLE
samples: nrf9160: Use correct length for custom topic

### DIFF
--- a/samples/nrf9160/aws_iot/src/main.c
+++ b/samples/nrf9160/aws_iot/src/main.c
@@ -383,7 +383,7 @@ static int app_topics_subscribe(void)
 		[0].str = custom_topic,
 		[0].len = strlen(custom_topic),
 		[1].str = custom_topic_2,
-		[1].len = strlen(custom_topic)
+		[1].len = strlen(custom_topic_2)
 	};
 
 	err = aws_iot_subscription_topics_add(topics_list,


### PR DESCRIPTION
Use the corresponding length for example topic 2 when
passing the topic through the AWS IoT API.