### PR TITLE
manifest: pull zephyr for bluetooth shell fix and nrfxlib for MPSL fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 19cff87ddc90cb84e338b1b04e19b976c355508a
+      revision: 4c06139d1f4cb90fee6baabc1a8f4e9d035ea44a
     # Other third-party repositories.
     - name: cmock
       path: test/cmock

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 41ce8e165a9af4171ef52a73aede89da6ce60920
+      revision: 746d14a3380fb6807afed61c4c024485ae8212f9
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr revision to include the fix for building the shell
with the SoftDevice controller, which is the default configuration.

Update nrfxlib revision to include fixes to MPSL.