### PR TITLE
Bluetooth: Mesh: Decode Time status before use

### DIFF
--- a/subsys/bluetooth/mesh/time_srv.c
+++ b/subsys/bluetooth/mesh/time_srv.c
@@ -201,13 +201,14 @@ static void handle_time_status(struct bt_mesh_model *model,
 
 	struct bt_mesh_time_status status;
 
+	bt_mesh_time_decode_time_params(buf, &status);
+
 	if (status.is_authority <= srv->data.sync.status.is_authority &&
 	    srv->data.sync.status.uncertainty < status.uncertainty) {
 		/* The new time status is not an improvement, ignore. */
 		return;
 	}
 
-	bt_mesh_time_decode_time_params(buf, &status);
 	srv->data.sync.uptime = k_uptime_get();
 	srv->data.sync.status.tai = status.tai;
 	srv->data.sync.status.uncertainty = status.uncertainty;


### PR DESCRIPTION
Fixes bug where the time status message were read before it was
assigned.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>