### PR TITLE
event_manager: Make printing of event types optional

### DIFF
--- a/subsys/event_manager/Kconfig
+++ b/subsys/event_manager/Kconfig
@@ -37,6 +37,10 @@ config DESKTOP_EVENT_MANAGER_EVENT_LOG_BUF_LEN
 	default 128
 	range 2 1024
 
+config DESKTOP_EVENT_MANAGER_LOG_EVENT_TYPE
+	bool "Include event type in the event log output"
+	default y
+
 config DESKTOP_EVENT_MANAGER_PROFILER_ENABLED
 	bool "Log events to Profiler"
 	select PROFILER

--- a/subsys/event_manager/event_manager.c
+++ b/subsys/event_manager/event_manager.c
@@ -69,8 +69,13 @@ static void log_event(const struct event_header *eh)
 			log_buf[sizeof(log_buf) - 2] = '~';
 		}
 
-		LOG_INF("e: %s %s", et->name, log_strdup(log_buf));
-	} else {
+		if (IS_ENABLED(CONFIG_DESKTOP_EVENT_MANAGER_LOG_EVENT_TYPE)) {
+			LOG_INF("e: %s %s", et->name, log_strdup(log_buf));
+		} else {
+			LOG_INF("%s", log_strdup(log_buf));
+		}
+
+	} else if (IS_ENABLED(CONFIG_DESKTOP_EVENT_MANAGER_LOG_EVENT_TYPE)) {
 		LOG_INF("e: %s", et->name);
 	}
 }


### PR DESCRIPTION
This patch adds a configurable option that enables/disables
the printing of event type names in the log output for the
event manager.