### PR TITLE
manifest: Update zephyr to get the power consumption related fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 746d14a3380fb6807afed61c4c024485ae8212f9
+      revision: pull/383/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr to get the following two commits:
- drivers: usb_dc_nrfx: Correct the nrfx_power driver configuration
- modules: hal_nordic: Fix workaround for nRF52 anomaly 197 in nrf_power

See https://github.com/nrfconnect/sdk-zephyr/pull/383