### PR TITLE
Bluetooth: controller: Use the maximum RX buffer length from Kconfig

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -315,7 +315,7 @@ static void recv_thread(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
-	static uint8_t hci_buffer[HCI_MSG_BUFFER_MAX_SIZE];
+	static uint8_t hci_buffer[CONFIG_BT_RX_BUF_LEN];
 
 	bool received_evt = false;
 	bool received_data = false;

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -24,7 +24,7 @@
 static struct
 {
 	bool occurred; /**< Set in only one execution context */
-	uint8_t raw_event[HCI_EVENT_PACKET_MAX_SIZE];
+	uint8_t raw_event[CONFIG_BT_RX_BUF_LEN];
 } cmd_complete_or_status;
 
 static bool command_generates_command_complete_event(uint16_t hci_opcode)


### PR DESCRIPTION
Use the maximum possible RX buffer length from Kconfig to size the
static RX buffers in the controller.
This saves 368 bytes in the default configuration.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>