### PR TITLE
application: serial_lte_modem: Fix proxy server restart

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -89,6 +89,10 @@ config SLM_TCP_POLL_TIME
 	int "Poll time-out in seconds for TCP connection"
 	default 10
 
+config SLM_UDP_POLL_TIME
+	int "Poll time-out in seconds for UDP connection"
+	default 10
+
 config SLM_TCP_CONN_TIME
 	int "Connection time-out in seconds for TCP server"
 	default 60


### PR DESCRIPTION
To support stop/restart of proxy server, the changes include:
     - TCP server polls listening port before accept()
     - Gracefully exit thread
     - TCP server allow reuse of local address. Currently
       reuse local address is not allowed from modem. It
       requires future suppot from modem)