### PR TITLE
samples: nrf910: lte_gateway agreggator fifo_entry size

### DIFF
--- a/samples/nrf9160/lte_ble_gateway/src/aggregator.c
+++ b/samples/nrf9160/lte_ble_gateway/src/aggregator.c
@@ -17,7 +17,7 @@ static uint32_t entry_count;
 
 struct fifo_entry {
 	void *fifo_reserved;
-	uint8_t data[ENTRY_MAX_SIZE];
+	uint8_t data[sizeof(struct sensor_data)];
 };
 
 int aggregator_put(struct sensor_data in_data)


### PR DESCRIPTION
Fixes NCSDK-5666. Mentioned as known issue v1.4.0, v1.3.2, v1.3.1, v1.3.0

Aggregator fifo data element size was set to the data element size of
sensor_data. Should instead be the size of the entire sensor_data struct.

This would copy 89 bytes into the 87 byte buffer, causing random
asserts when the thingy is flipped.

Signed-off-by: Håvard Vermeer <havard.vermeer@nordicsemi.no>