### PR TITLE
cmake: Toolchain v1.4.0

### DIFF
--- a/share/ncs-package/cmake/NcsConfig.cmake
+++ b/share/ncs-package/cmake/NcsConfig.cmake
@@ -2,7 +2,7 @@
 set(NRF_RELATIVE_DIR "../../..")
 set(NCS_RELATIVE_DIR "../../../..")
 
-set(NCS_TOOLCHAIN_MINIMUM_REQUIRED 1.3.0)
+set(NCS_TOOLCHAIN_MINIMUM_REQUIRED 1.4.0)
 
 # Set the current NRF_DIR
 # The use of get_filename_component ensures that the final path variable will not contain `../..`.


### PR DESCRIPTION
With NCS v1.4.0 then NCS Toolchain v1.4.0 will also be released.
This ensures that NCS Toolchain v1.4.0 will be preferred.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>