### PR TITLE
net: lib: nrf_cloud: align poll timeout with mqtt keepalive

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -535,7 +535,8 @@ start:
 	atomic_set(&transport_disconnected, 0);
 
 	while (true) {
-		ret = poll(fds, ARRAY_SIZE(fds), POLL_TIMEOUT_MS);
+		ret = poll(fds, ARRAY_SIZE(fds),
+			cloud_keepalive_time_left(nrf_cloud_backend));
 
 		if (ret == 0) {
 			if (cloud_keepalive_time_left(nrf_cloud_backend) <


### PR DESCRIPTION
Poll timeout of cloud socket is now aligned with the mqtt
keepalive.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>