### PR TITLE
Optimize default config of perpipheral LBS.

### DIFF
--- a/samples/bluetooth/peripheral_lbs/prj.conf
+++ b/samples/bluetooth/peripheral_lbs/prj.conf
@@ -9,6 +9,13 @@ CONFIG_BT=y
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_DEVICE_NAME="Nordic_Blinky"
 
+# Bluetooth features disabled to fit RAM requirements
+# of the most constrained nRf52 devices
+CONFIG_BT_PHY_UPDATE=n
+CONFIG_BT_GATT_CACHING=n
+CONFIG_BT_GATT_SERVICE_CHANGED=n
+CONFIG_BT_DATA_LEN_UPDATE=n
+
 # Enable the LBS service
 CONFIG_BT_LBS=y
 CONFIG_BT_LBS_POLL_BUTTON=y


### PR DESCRIPTION
CI detected failing builds of bluetooth/peripheral_LBS  for 810 and 811 devices. This is an attempt to find a default config which fits also the most constrained devices. It was on the edge recently occupying 99.9 % of their RAM.
