### PR TITLE
doc: samples: remove nRF51 from requirements

### DIFF
--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -28,7 +28,6 @@ Requirements
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * A device running a BAS Server to connect with (for example, another board running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth Low Energy dongle and nRF Connect for Desktop)
 

--- a/samples/bluetooth/central_dfu_smp/README.rst
+++ b/samples/bluetooth/central_dfu_smp/README.rst
@@ -32,7 +32,6 @@ Requirements
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * A device running `MCUmgr`_ with `SMP over Bluetooth`_, for example, another board running the :ref:`smp_svr_sample`
 

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -32,7 +32,6 @@ Requirements
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * HIDS device to connect with (for example, another board running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth Low Energy dongle and nRF Connect for Desktop)
 

--- a/samples/bluetooth/enocean/README.rst
+++ b/samples/bluetooth/enocean/README.rst
@@ -27,7 +27,6 @@ Requirements
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * At least one :ref:`supported EnOcean device <bt_enocean_devices>`.
 

--- a/samples/bluetooth/peripheral_gatt_dm/README.rst
+++ b/samples/bluetooth/peripheral_gatt_dm/README.rst
@@ -21,7 +21,6 @@ Requirements
 
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * A device to connect to the peripheral, for example, a phone or a tablet with `nRF Connect for Mobile`_ or `nRF Toolbox`_
 

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -45,7 +45,6 @@ Requirements
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK| (with the `NFC_OOB_PAIRING` option disabled)
 
 If the `NFC_OOB_PAIRING` feature is enabled:
 

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -35,7 +35,6 @@ Requirements
   * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 User interface
 **************

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -26,7 +26,6 @@ Requirements
   * |nRF52840Dongle|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 * A phone or tablet running a compatible application, for example `nRF Connect for Mobile`_, `nRF Blinky`_, or `nRF Toolbox`_.
 

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -81,8 +81,6 @@ Requirements
 
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK| - limited support;
-    some features, like an over-the-air data rate of 2 Ms/s, are not available on this board
 
   You can mix different boards.
 * Connection to a computer with a serial terminal for each of the boards.

--- a/samples/event_manager/README.rst
+++ b/samples/event_manager/README.rst
@@ -39,7 +39,6 @@ Requirements
   * |nRF9160DK|
   * |nRF52840DK|
   * |nRF52DK|
-  * |nRF51DK|
 
 
 Building and running


### PR DESCRIPTION
Removed nRF51 DK from Requirements list for several samples.
NCSDK-6846

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>