### PR TITLE
download_client: Check dynamically set fragment size when downloading

### DIFF
--- a/samples/nrf9160/azure_fota/prj.conf
+++ b/samples/nrf9160/azure_fota/prj.conf
@@ -81,6 +81,10 @@ CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE_1024=y
 CONFIG_DOWNLOAD_CLIENT_STACK_SIZE=4096
 CONFIG_DOWNLOAD_CLIENT_LOG_LEVEL_INF=y
 CONFIG_DOWNLOAD_CLIENT_BUF_SIZE=2300
+# Disable receive timeout, the underlying TCP protocol handles
+# resending of HTTP GET requests.
+# This timeout is only useful when using UDP, e.g. with CoAP.
+CONFIG_DOWNLOAD_CLIENT_SOCK_TIMEOUT_MS=-1
 
 # DFU Target
 CONFIG_DFU_TARGET=y

--- a/subsys/net/lib/download_client/src/http.c
+++ b/subsys/net/lib/download_client/src/http.c
@@ -247,8 +247,10 @@ int http_parse(struct download_client *client, size_t len)
 	client->progress += MIN(client->offset, len);
 
 	/* Have we received a whole fragment or the whole file? */
-	if ((client->offset < CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE) &&
-	    (client->progress != client->file_size)) {
+	if (client->progress != client->file_size &&
+	    client->offset < (client->config.frag_size_override != 0 ?
+			      client->config.frag_size_override :
+			      CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE)) {
 		return 1;
 	}
 


### PR DESCRIPTION
- TCP handles retransmissions. "Manual" resending of HTTP
  GET requests is not needed, and does more harm than good
  with the current download_client functionality.

- Adds a check for dynamically set fragment size in addition to
the compile time default value when determining if a full file
fragment has been downloaded.

Fixes NCSDK-6856