### PR TITLE
applications: asset_tracker: bsec: recover when state is outdated

### DIFF
--- a/applications/asset_tracker/src/env_sensors/bsec.c
+++ b/applications/asset_tracker/src/env_sensors/bsec.c
@@ -324,6 +324,10 @@ int env_sensors_init_and_start(struct k_work_q *work_q,
 	} else if (bsec_ret.bsec_status) {
 		LOG_ERR("Could not initialize BSEC library: %d",
 			(int)bsec_ret.bsec_status);
+		if ((int)bsec_ret.bsec_status == -34) {
+			LOG_ERR("Deleting state from flash");
+			settings_delete(SETTINGS_BSEC_STATE);
+		}
 		return (int)bsec_ret.bsec_status;
 	}
 

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1673,6 +1673,12 @@ static void sensors_init(void)
 	err = env_sensors_init_and_start(&application_work_q, env_data_send);
 	if (err) {
 		LOG_ERR("Environmental sensors init failed, error: %d", err);
+#if CONFIG_USE_BME680_BSEC
+		if (err == -34) {
+			LOG_ERR("Reboot to initialize BSEC with clean state");
+			sys_reboot(SYS_REBOOT_COLD);
+		}
+#endif /* CONFIG_USE_BME680_BSEC */
 	}
 #if CONFIG_LIGHT_SENSOR
 	err = light_sensor_init_and_start(&application_work_q,


### PR DESCRIPTION
If initialization of BSEC library fails with error -34, we delete
the stored state from flash and reboot the device.

Jira: NCSDK-6860

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>