### PR TITLE
samples: nrf9160: download: add sha256 hash check

### DIFF
--- a/samples/nrf9160/download/Kconfig
+++ b/samples/nrf9160/download/Kconfig
@@ -32,6 +32,10 @@ config SAMPLE_FILE_URL
 	default "http://speedtest.ftp.otenet.gr/files/test100k.db" if SAMPLE_FILE_HTTP
 	default "https://file-examples-com.github.io/uploads/2017/10/file_example_JPG_100kB.jpg" if SAMPLE_FILE_HTTPS
 
+config SAMPLE_COMPUTE_HASH
+	bool "Compute sha256 hash"
+	select MBEDTLS
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/samples/nrf9160/download/Kconfig
+++ b/samples/nrf9160/download/Kconfig
@@ -36,6 +36,16 @@ config SAMPLE_COMPUTE_HASH
 	bool "Compute sha256 hash"
 	select MBEDTLS
 
+config SAMPLE_COMPARE_HASH
+	bool "Compare hash"
+	depends on SAMPLE_COMPUTE_HASH
+
+config SAMPLE_SHA256_HASH
+	string "sha256 hash"
+	depends on SAMPLE_COMPARE_HASH
+	default "f627ca4c2c322f15db26152df306bd4f983f0146409b81a4341b9b340c365a16" if SAMPLE_FILE_HTTP
+	default "88aeb1f4467bd1e50cf624de972fbf3f40801632fedb64aaa7b1a8a9ef786fc6" if SAMPLE_FILE_HTTPS
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/samples/nrf9160/download/README.rst
+++ b/samples/nrf9160/download/README.rst
@@ -78,6 +78,14 @@ This option sets the certificate file name.
 
 If enabled, this option computes the SHA256 hash of the downloaded file.
 
+.. option:: CONFIG_SAMPLE_COMPARE_HASH - Hash compare configuration
+
+If enabled, this option compares the hash against the SHA256 hash set by :option:`CONFIG_SAMPLE_SHA256_HASH` for a match.
+
+.. option:: CONFIG_SAMPLE_SHA256_HASH - Hash configuration
+
+This option sets the SHA256 hash to be compared with :option:`CONFIG_SAMPLE_COMPUTE_HASH`.
+
 
 Building and running
 ********************

--- a/samples/nrf9160/download/README.rst
+++ b/samples/nrf9160/download/README.rst
@@ -64,16 +64,19 @@ Check and configure the following configuration options for the sample:
 
 .. option:: CONFIG_SAMPLE_SECURE_SOCKET - Secure socket configuration
 
-   If enabled, this option provisions the certificate to the modem.
+If enabled, this option provisions the certificate to the modem.
 
 .. option:: CONFIG_SAMPLE_SEC_TAG - Security tag configuration
 
-   This option configures the security tag.
+This option configures the security tag.
 
 .. option:: CONFIG_SAMPLE_CERT_FILE - Certificate file name configuration
 
-   This option sets the certificate file name.
+This option sets the certificate file name.
 
+.. option:: CONFIG_SAMPLE_COMPUTE_HASH - Hash compute configuration
+
+If enabled, this option computes the SHA256 hash of the downloaded file.
 
 
 Building and running

--- a/samples/nrf9160/download/src/main.c
+++ b/samples/nrf9160/download/src/main.c
@@ -165,6 +165,13 @@ static int callback(const struct download_client_evt *event)
 		bin2hex(hash, sizeof(hash), hash_str, sizeof(hash_str));
 
 		printk("SHA256: %s\n", hash_str);
+
+#if CONFIG_SAMPLE_COMPARE_HASH
+		if (strcmp(hash_str, CONFIG_SAMPLE_SHA256_HASH)) {
+			printk("Expect: %s\n", CONFIG_SAMPLE_SHA256_HASH);
+			printk("SHA256 mismatch!\n");
+		}
+#endif /* CONFIG_SAMPLE_COMPARE_HASH */
 #endif /* CONFIG_SAMPLE_COMPUTE_HASH */
 
 		printk("Bye\n");


### PR DESCRIPTION
Add a couple of options to print and check the sha256 hash of the file being downloaded.
It can be useful to spot errors by verifying all the bytes received by the application.