### PR TITLE
manifest: update mcuboot

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -103,11 +103,6 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   set(app_sign_depends
     $<IF:${sign_merged},${merged_hex_file_depends},zephyr_final>)
 
-  if (NOT DEFINED CONFIG_BOOT_SIGNATURE_KEY_FILE)
-    include(${CMAKE_BINARY_DIR}/mcuboot/shared_vars.cmake)
-    set(CONFIG_BOOT_SIGNATURE_KEY_FILE ${mcuboot_SIGNATURE_KEY_FILE})
-  endif ()
-
   if (DEFINED mcuboot_CONF_FILE)
     get_filename_component(mcuboot_CONF_DIR ${mcuboot_CONF_FILE} DIRECTORY)
     if (EXISTS ${mcuboot_CONF_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})

--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -27,11 +27,6 @@ if(IMAGE_NAME)
   share("set(${IMAGE_NAME}KERNEL_ELF_NAME ${KERNEL_ELF_NAME})")
   share("list(APPEND ${IMAGE_NAME}BUILD_BYPRODUCTS ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME})")
   share("list(APPEND ${IMAGE_NAME}BUILD_BYPRODUCTS ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME})")
-  # Share the signing key file so that the parent image can use it to
-  # generate signed update candidates.
-  if(CONFIG_BOOT_SIGNATURE_KEY_FILE)
-   share("set(${IMAGE_NAME}SIGNATURE_KEY_FILE ${CONFIG_BOOT_SIGNATURE_KEY_FILE})")
-  endif()
 
   file(GENERATE OUTPUT ${CMAKE_BINARY_DIR}/shared_vars.cmake
     CONTENT $<TARGET_PROPERTY:zephyr_property_target,shared_vars>

--- a/west.yml
+++ b/west.yml
@@ -92,7 +92,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.6.99-ncs1-rc2
+      revision: pull/129/head
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: sdk-mcumgr


### PR DESCRIPTION
To get hold of signing key in parent image regardless of
build strategy.

Ref: NCSDK-6859
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>