### PR TITLE
cmake: fix dependency for zip generation which caused rerun

### DIFF
--- a/cmake/fw_zip.cmake
+++ b/cmake/fw_zip.cmake
@@ -20,8 +20,7 @@ function(generate_dfu_zip)
   endif()
 
   add_custom_command(
-    TARGET ${GENZIP_TARGET}
-    POST_BUILD
+    OUTPUT ${GENZIP_OUTPUT}
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${NRF_DIR}/scripts/bootloader/generate_zip.py
@@ -31,6 +30,16 @@ function(generate_dfu_zip)
     "type=${GENZIP_TYPE}"
     "board=${CONFIG_BOARD}"
     "soc=${CONFIG_SOC}"
+    DEPENDS ${GENZIP_TARGET}
+    )
+
+  get_filename_component(TARGET_NAME ${GENZIP_OUTPUT} NAME)
+  string(REPLACE "." "_" TARGET_NAME ${TARGET_NAME})
+
+  add_custom_target(
+    ${TARGET_NAME}
+    ALL
+    DEPENDS ${GENZIP_OUTPUT}
     )
 
 endfunction()


### PR DESCRIPTION
Prior to this the command for generating the zip was always executed.

Ref: NCSDK-6993
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>