### PR TITLE
applications: nrf_desktop: Add chmap_filter lib license file

### DIFF
--- a/applications/nrf_desktop/src/util/chmap_filter/license.txt
+++ b/applications/nrf_desktop/src/util/chmap_filter/license.txt
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */


### PR DESCRIPTION
Add licensing information next to chmap_filter library.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>