### PR TITLE
license: add missing license to several files

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/config.h
+++ b/samples/nrf9160/lwm2m_client/src/config.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
 static char client_psk[] = "000102030405060708090a0b0c0d0e0f";
 

--- a/samples/nrf9160/lwm2m_client/src/settings.c
+++ b/samples/nrf9160/lwm2m_client/src/settings.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 

--- a/samples/nrf9160/lwm2m_client/src/settings.h
+++ b/samples/nrf9160/lwm2m_client/src/settings.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 #ifndef FOTA_STORAGE_H__

--- a/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #include <ztest.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/lib/at_cmd_parser/at_params/src/main.c
+++ b/tests/lib/at_cmd_parser/at_params/src/main.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #include <ztest.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/lib/at_cmd_parser/at_utils/src/main.c
+++ b/tests/lib/at_cmd_parser/at_utils/src/main.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #include <ztest.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Added license to some files that were missing it.
**Changed license from Apache-2.0 to LicenseRef-BSD-5-Clause-Nordic** in a couple of files; I do not think the previous license was the correct one, @carlescufi please review that change. I kept it in a separate commit (https://github.com/nrfconnect/sdk-nrf/pull/3251/commits/53cebdb0324ab1c60b9bbd493ce3a640bc2c38af) let me know if I should drop it.