### PR TITLE
samples: openthread: update licensing headers

### DIFF
--- a/samples/openthread/cli/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/openthread/cli/boards/nrf52833dk_nrf52833.overlay
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 &uart0 {

--- a/samples/openthread/cli/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/cli/boards/nrf52840dk_nrf52840.overlay
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 &uart0 {

--- a/samples/openthread/cli/harness/nrf52840-ncs.py
+++ b/samples/openthread/cli/harness/nrf52840-ncs.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 #
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
 # Copyright (c) 2016, The OpenThread Authors.
 # All rights reserved.
 #

--- a/samples/openthread/cli/harness/overlay-cert.conf
+++ b/samples/openthread/cli/harness/overlay-cert.conf
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
 # Disable logging
 CONFIG_BOOT_BANNER=n
 CONFIG_LOG=n

--- a/samples/openthread/cli/src/ble.h
+++ b/samples/openthread/cli/src/ble.h
@@ -9,6 +9,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
 #ifndef __BLE_H__
 #define __BLE_H__
 

--- a/samples/openthread/cli/src/main.c
+++ b/samples/openthread/cli/src/main.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
 #include <zephyr.h>
 #include <logging/log.h>
 

--- a/samples/openthread/coap_client/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/openthread/coap_client/boards/nrf52833dk_nrf52833.overlay
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 &uart0 {

--- a/samples/openthread/coap_client/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/coap_client/boards/nrf52840dk_nrf52840.overlay
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 / {

--- a/samples/openthread/coap_client/overlay-mtd.conf
+++ b/samples/openthread/coap_client/overlay-mtd.conf
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-# enable MTD Sleepy End Device
+# Enable MTD Sleepy End Device
 CONFIG_OPENTHREAD_MTD=y
 CONFIG_OPENTHREAD_MTD_SED=y
 CONFIG_OPENTHREAD_POLL_PERIOD=3000

--- a/samples/openthread/coap_client/src/ble_utils.c
+++ b/samples/openthread/coap_client/src/ble_utils.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
 #include <zephyr.h>
 #include <bluetooth/gatt.h>
 #include <bluetooth/hci.h>

--- a/samples/openthread/coap_client/src/ble_utils.h
+++ b/samples/openthread/coap_client/src/ble_utils.h
@@ -9,6 +9,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
 #ifndef __BLE_UTILS_H__
 #define __BLE_UTILS_H__
 

--- a/samples/openthread/coap_client/src/coap_client.c
+++ b/samples/openthread/coap_client/src/coap_client.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
 #include <zephyr.h>
 #include <dk_buttons_and_leds.h>
 #include <logging/log.h>

--- a/samples/openthread/coap_client/src/coap_client_utils.c
+++ b/samples/openthread/coap_client/src/coap_client_utils.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
 #include <zephyr.h>
 #include <coap_server_client_interface.h>
 #include <net/coap_utils.h>

--- a/samples/openthread/coap_client/src/coap_client_utils.h
+++ b/samples/openthread/coap_client/src/coap_client_utils.h
@@ -9,6 +9,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
 #ifndef __COAP_CLIENT_UTILS_H__
 #define __COAP_CLIENT_UTILS_H__
 

--- a/samples/openthread/coap_server/CMakeLists.txt
+++ b/samples/openthread/coap_server/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
+
 cmake_minimum_required(VERSION 3.13.1)
 
 list(INSERT OVERLAY_CONFIG 0 ../common/overlay-ot-defaults.conf)

--- a/samples/openthread/coap_server/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/openthread/coap_server/boards/nrf52833dk_nrf52833.overlay
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 &uart0 {

--- a/samples/openthread/coap_server/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/coap_server/boards/nrf52840dk_nrf52840.overlay
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 &uart0 {

--- a/samples/openthread/coap_server/interface/coap_server_client_interface.h
+++ b/samples/openthread/coap_server/interface/coap_server_client_interface.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #ifndef __COAP_SERVER_CLIENT_INTRFACE_H__
 #define __COAP_SERVER_CLIENT_INTRFACE_H__
 

--- a/samples/openthread/coap_server/src/coap_server.c
+++ b/samples/openthread/coap_server/src/coap_server.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
 #include <zephyr.h>
 #include <dk_buttons_and_leds.h>
 #include <logging/log.h>

--- a/samples/openthread/coap_server/src/ot_coap_utils.c
+++ b/samples/openthread/coap_server/src/ot_coap_utils.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #include <logging/log.h>
 #include <net/net_pkt.h>
 #include <net/net_l2.h>

--- a/samples/openthread/coap_server/src/ot_coap_utils.h
+++ b/samples/openthread/coap_server/src/ot_coap_utils.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #ifndef __OT_COAP_UTILS_H__
 #define __OT_COAP_UTILS_H__
 

--- a/samples/openthread/ncp/CMakeLists.txt
+++ b/samples/openthread/ncp/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
+
 cmake_minimum_required(VERSION 3.13.1)
 
 set(OT_NCP_VENDOR_HOOK_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/samples/openthread/ncp/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/openthread/ncp/boards/nrf52833dk_nrf52833.overlay
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 &uart0 {

--- a/samples/openthread/ncp/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/openthread/ncp/boards/nrf52840dk_nrf52840.overlay
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 &uart0 {

--- a/samples/openthread/ncp/overlay-vendor_hook.conf
+++ b/samples/openthread/ncp/overlay-vendor_hook.conf
@@ -3,4 +3,5 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
+
 CONFIG_OPENTHREAD_NCP_VENDOR_HOOK_SOURCE="/src/user_vendor_hook.cpp"

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 50ef19254346847287fb078e7dcaa092256b478f
+      revision: 3455e723929fbe8751047fd208eb9a25ea25a96d
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
This commit updates licensing headers for the OpenThread files.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-7955

Pulls https://github.com/nrfconnect/sdk-nrfxlib/pull/318