### PR TITLE
dfu: fota: add licence text

### DIFF
--- a/subsys/dfu/src/dfu_target_modem.c
+++ b/subsys/dfu/src/dfu_target_modem.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #include <zephyr.h>
 #include <stdio.h>
 #include <drivers/flash.h>

--- a/tests/subsys/dfu/dfu_target_mcuboot/pm_config.h
+++ b/tests/subsys/dfu/dfu_target_mcuboot/pm_config.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 /* generated file copied to simplify building the test */
 #ifndef PM_CONFIG_H__
 #define PM_CONFIG_H__

--- a/tests/subsys/net/lib/fota_download/pm_config.h
+++ b/tests/subsys/net/lib/fota_download/pm_config.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 /* generated file copied to simplify building the test */
 #ifndef PM_CONFIG_H__
 #define PM_CONFIG_H__


### PR DESCRIPTION
Add missing licenses

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>