### PR TITLE
known_issue: add known issue about child image overlay

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -51,6 +51,14 @@ nRF9160
 Asset tracker
 =============
 
+.. rst-class:: v1-4-0
+
+NCSDK-6898: Setting :option:`CONFIG_SECURE_BOOT` does not work
+  The immutable bootloader is not able to find the required metadata in the MCUboot image.
+  See the related NCSDK-6898 known issue in `Build system`_ for more details.
+
+  **Workaround:** Set :option:`CONFIG_FW_INFO` in MCUboot.
+
 .. rst-class:: v1-4-0 v1-3-2 v1-3-1 v1-3-0
 
 External antenna performance setting
@@ -409,6 +417,13 @@ Immutable bootloader board restrictions
 
 Build system
 ============
+
+.. rst-class:: v1-4-0
+
+NCSDK-6898: Overriding child images
+  Adding child image overlay from the :file:`CMakeLists.txt` top-level file located in the :file:`samples` directory overrides the existing child image overlay.
+
+  **Workaround:** Apply the configuration from the overlay to the child image manually.
 
 .. rst-class:: v1-4-0
 


### PR DESCRIPTION
Also explicitly state in asset tracker known issue.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>