### PR TITLE
samples: openthread: fixed the coap client incorrect data log

### DIFF
--- a/samples/openthread/coap_client/src/coap_client.c
+++ b/samples/openthread/coap_client/src/coap_client.c
@@ -32,12 +32,12 @@ LOG_MODULE_REGISTER(coap_client, CONFIG_COAP_CLIENT_LOG_LEVEL);
 static void on_nus_received(struct bt_conn *conn, const uint8_t *const data,
 			    uint16_t len)
 {
-	LOG_INF("Received data: %s", log_strdup(data));
-
 	if (len != 1) {
-		LOG_WRN("Received invalid data length from NUS");
+		LOG_WRN("Received invalid data length (%hd) from NUS", len);
 		return;
 	}
+
+	LOG_INF("Received data: %c", data[0]);
 
 	switch (*data) {
 	case COMMAND_REQUEST_UNICAST:


### PR DESCRIPTION
%s was used to print data not ending with \0 (KRKNWK-7840)
Since only one character is expected - switched data logging with length
verification and printing only a single character (to avoid using
temporary buffer)

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>