### PR TITLE
net: lib: download_client: only set socket timeout for UDP sockets

### DIFF
--- a/samples/nrf9160/azure_fota/prj.conf
+++ b/samples/nrf9160/azure_fota/prj.conf
@@ -81,10 +81,6 @@ CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE_1024=y
 CONFIG_DOWNLOAD_CLIENT_STACK_SIZE=4096
 CONFIG_DOWNLOAD_CLIENT_LOG_LEVEL_INF=y
 CONFIG_DOWNLOAD_CLIENT_BUF_SIZE=2300
-# Disable receive timeout, the underlying TCP protocol handles
-# resending of HTTP GET requests.
-# This timeout is only useful when using UDP, e.g. with CoAP.
-CONFIG_DOWNLOAD_CLIENT_SOCK_TIMEOUT_MS=-1
 
 # DFU Target
 CONFIG_DFU_TARGET=y

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -105,8 +105,8 @@ config DOWNLOAD_CLIENT_MAX_FILENAME_SIZE
 	range 8 256
 	default 192
 
-config DOWNLOAD_CLIENT_SOCK_TIMEOUT_MS
-	int "Receive timeout, in milliseconds"
+config DOWNLOAD_CLIENT_UDP_SOCK_TIMEO_MS
+	int "Receive timeout on UDP sockets, in milliseconds"
 	default 4000
 	range -1 30000
 	help

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -50,11 +50,11 @@ static int socket_timeout_set(int fd)
 {
 	int err;
 
-	if (CONFIG_DOWNLOAD_CLIENT_SOCK_TIMEOUT_MS == SYS_FOREVER_MS) {
+	if (CONFIG_DOWNLOAD_CLIENT_UDP_SOCK_TIMEO_MS == SYS_FOREVER_MS) {
 		return 0;
 	}
 
-	const uint32_t timeout_ms = CONFIG_DOWNLOAD_CLIENT_SOCK_TIMEOUT_MS;
+	const uint32_t timeout_ms = CONFIG_DOWNLOAD_CLIENT_UDP_SOCK_TIMEO_MS;
 
 	struct timeval timeo = {
 		.tv_sec = (timeout_ms / 1000),
@@ -572,12 +572,6 @@ int download_client_connect(struct download_client *client, const char *host,
 		return err;
 	}
 
-	/* Set socket timeout, if configured */
-	err = socket_timeout_set(client->fd);
-	if (err) {
-		return err;
-	}
-
 	return 0;
 }
 
@@ -622,6 +616,11 @@ int download_client_start(struct download_client *client, const char *file,
 
 	if (IS_ENABLED(CONFIG_COAP)) {
 		coap_block_init(client, from);
+		/* Set socket timeout, if configured */
+		err = socket_timeout_set(client->fd);
+		if (err) {
+			return err;
+		}
 	}
 
 	err = request_send(client);


### PR DESCRIPTION
Let the socket timeout be configured for UDP sockets only.
    
With TCP sockets and HTTP, a timeout caused a re-transmission of
the GET request which may have led to recv() reading the same header
twice, mistaking one for the actual payload. This could have either
triggered an assert or silently passed wrong data to the application
in a fragment.
    
Since the download is running in a separate thread, it is not very
useful to have a timeout on a TCP socket, plus the socket will
anyway return an error if the server closes the connection and no
further data is expected.

---

Fixes: NCSDK-6916 (hopefully :)
Switching to NB-IOT made the transfer slower and triggered the socket timeout, which was not handled correctly.

**Needs update in changelog after merge**