### PR TITLE
python: ci: update cryptography package to 3.2

### DIFF
--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -15,7 +15,7 @@ cmsis-pack-manager==0.2.10
 colorama==0.4.3
 CommonMark==0.5.4
 configobj==5.0.6
-cryptography==2.9.2
+cryptography==3.2
 Deprecated==1.2.9
 docopt==0.6.2
 docutils==0.16


### PR DESCRIPTION
This is security vulnerability fix recommended by dependabot
(who doesn't know how to sign CLA).

Bumps [cryptography](https://github.com/pyca/cryptography) from 2.9.2 to 3.2.
- [Release notes](https://github.com/pyca/cryptography/releases)
- [Changelog](https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst)
- [Commits](https://github.com/pyca/cryptography/compare/2.9.2...3.2)

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

---- 

Clone of: #3246 to make CI pass.