### PR TITLE
cmake: multi image: Added USES_TERMINAL when flashing ACI Domain

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -271,6 +271,7 @@ function(add_child_image_from_source)
       --target flash
       DEPENDS
       ${ACI_NAME}_subimage
+      USES_TERMINAL
       )
 
     # If the dynamic partition has child images, their hex files will be


### PR DESCRIPTION
Fixes: #NCSDK-6901

By specifying USES_TERMINAL we ensure that user are able to select the
board when being prompted, thus ensuring correct behaviour when flashing
nRF5340 board when hci_rpmsg is included in the build.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>