### PR TITLE
actions: Add a contributions workflow

### DIFF
--- a/.github/workflows/contribs.yml
+++ b/.github/workflows/contribs.yml
@@ -1,0 +1,23 @@
+name: Contribs
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  contribs:
+    runs-on: ubuntu-latest
+    name: Contribs
+    steps:
+      - name: Contribs
+        uses: carlescufi/action-contribs@main
+        with:
+          github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
+          command: 'external'
+          messages: |
+                    Thank you for your contribution!
+                    It seems you are not a member of the nrfconnect GitHub organization.
+                    At this time we are not accepting external contributions, but this may change soon.
+                    Please visit https://devzone.nordicsemi.com/ to raise any issues you found or ask for help.
+                    |
+                    The author of this pull request has now been added to the nrfconnect GitHub organization.
+          labels: 'external'


### PR DESCRIPTION
This workflow uses a new action to detect whether the author of a Pull
Request is a member of the corresponding GitHub organization, and posts
a message and labels correspondingly.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>