### PR TITLE
Bluetooth: Mesh: Fix time client model

### DIFF
--- a/include/bluetooth/mesh/time_cli.h
+++ b/include/bluetooth/mesh/time_cli.h
@@ -26,6 +26,10 @@ struct bt_mesh_time_cli;
 /** @def BT_MESH_TIME_CLI_INIT
  *
  * @brief Initialization parameters for a @ref bt_mesh_time_cli instance.
+ *
+ * @sa bt_mesh_time_cli_handlers
+ *
+ * @param[in] _handlers Optional message handler structure.
  */
 #define BT_MESH_TIME_CLI_INIT(_handlers)                                       \
 	{                                                                      \
@@ -51,9 +55,15 @@ struct bt_mesh_time_cli;
 struct bt_mesh_time_cli_handlers {
 	/** @brief Time status message handler.
 	 *
+	 * Called when the client receives a Time Status message, either as a
+	 * result of calling @ref bt_mesh_time_cli_time_get,
+	 * @ref bt_mesh_time_cli_time_set, or as an unsolicited message.
+	 *
+	 * @note This handler is optional.
+	 *
 	 * @param[in] cli Client that received the status message.
-	 * @param[in] ctx Context of the message.
-	 * @param[in] status Time status contained in the message.
+	 * @param[in] ctx Context of the incoming message.
+	 * @param[in] status Time Status contained in the message.
 	 */
 	void (*const time_status)(struct bt_mesh_time_cli *cli,
 				  struct bt_mesh_msg_ctx *ctx,
@@ -61,9 +71,15 @@ struct bt_mesh_time_cli_handlers {
 
 	/** @brief Time Zone status message handler.
 	 *
+	 * Called when the client receives a Time Zone Status message, either
+	 * as a result of calling @ref bt_mesh_time_cli_zone_get,
+	 * @ref bt_mesh_time_cli_zone_set, or as an unsolicited message.
+	 *
+	 * @note This handler is optional.
+	 *
 	 * @param[in] cli Client that received the status message.
-	 * @param[in] ctx Context of the message.
-	 * @param[in] status Time Zone status contained in the message.
+	 * @param[in] ctx Context of the incoming message.
+	 * @param[in] status Time Zone Status contained in the message.
 	 */
 	void (*const time_zone_status)(
 		struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -71,9 +87,15 @@ struct bt_mesh_time_cli_handlers {
 
 	/** @brief TAI-UTC Delta status message handler.
 	 *
+	 * Called when the client receives a TAI-UTC Delta Status message, either
+	 * as a result of calling @ref bt_mesh_time_cli_tai_utc_delta_get,
+	 * @ref bt_mesh_time_cli_tai_utc_delta_set, or as an unsolicited message.
+	 *
+	 * @note This handler is optional.
+	 *
 	 * @param[in] cli Client that received the status message.
-	 * @param[in] ctx Context of the message.
-	 * @param[in] status TAI-UTC delta status contained in the message.
+	 * @param[in] ctx Context of the incoming message.
+	 * @param[in] status TAI-UTC Delta Status contained in the message.
 	 */
 	void (*const tai_utc_delta_status)(
 		struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -81,8 +103,14 @@ struct bt_mesh_time_cli_handlers {
 
 	/** @brief Time Role status message handler.
 	 *
+	 * Called when the client receives a Time Role Status message, either
+	 * as a result of calling @ref bt_mesh_time_cli_role_get,
+	 * @ref bt_mesh_time_cli_role_set, or as an unsolicited message.
+	 *
+	 * @note This handler is optional.
+	 *
 	 * @param[in] cli Client that received the status message.
-	 * @param[in] ctx Context of the message.
+	 * @param[in] ctx Context of the incoming message.
 	 * @param[in] time_role Time Role of the server.
 	 */
 	void (*const time_role_status)(struct bt_mesh_time_cli *cli,
@@ -101,7 +129,10 @@ struct bt_mesh_time_cli {
 	struct bt_mesh_model_pub pub;
 	/** Acknowledged message tracking. */
 	struct bt_mesh_model_ack_ctx ack_ctx;
-	/** Handler function structure. */
+	/** Collection of handler callbacks.
+	*
+	* @note Must point to memory that remains valid.
+	*/
 	const struct bt_mesh_time_cli_handlers *handlers;
 };
 

--- a/include/bluetooth/mesh/time_cli.h
+++ b/include/bluetooth/mesh/time_cli.h
@@ -27,8 +27,9 @@ struct bt_mesh_time_cli;
  *
  * @brief Initialization parameters for a @ref bt_mesh_time_cli instance.
  */
-#define BT_MESH_TIME_CLI_INIT                                                  \
+#define BT_MESH_TIME_CLI_INIT(_handlers)                                       \
 	{                                                                      \
+		.handlers = _handlers,                                         \
 		.pub = {.msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(           \
 				BT_MESH_TIME_OP_TIME_SET,                      \
 				BT_MESH_TIME_MSG_LEN_TIME_SET)) }              \
@@ -46,6 +47,49 @@ struct bt_mesh_time_cli;
 		BT_MESH_MODEL_USER_DATA(struct bt_mesh_time_cli, _cli),        \
 		&_bt_mesh_time_cli_cb)
 
+/** Time Client handler functions. */
+struct bt_mesh_time_cli_handlers {
+	/** @brief Time status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] status Time status contained in the message.
+	 */
+	void (*const time_status)(struct bt_mesh_time_cli *cli,
+				  struct bt_mesh_msg_ctx *ctx,
+				  const struct bt_mesh_time_status *status);
+
+	/** @brief Time Zone status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] status Time Zone status contained in the message.
+	 */
+	void (*const time_zone_status)(
+		struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
+		const struct bt_mesh_time_zone_status *status);
+
+	/** @brief TAI-UTC Delta status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] status TAI-UTC delta status contained in the message.
+	 */
+	void (*const tai_utc_delta_status)(
+		struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
+		const struct bt_mesh_time_tai_utc_delta_status *status);
+
+	/** @brief Time Role status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] time_role Time Role of the server.
+	 */
+	void (*const time_role_status)(struct bt_mesh_time_cli *cli,
+				       struct bt_mesh_msg_ctx *ctx,
+				       enum bt_mesh_time_role time_role);
+};
+
 /**
  * Time Client instance. Should be initialized with
  * @ref BT_MESH_TIME_CLI_INIT.
@@ -57,6 +101,8 @@ struct bt_mesh_time_cli {
 	struct bt_mesh_model_pub pub;
 	/** Acknowledged message tracking. */
 	struct bt_mesh_model_ack_ctx ack_ctx;
+	/** Handler function structure. */
+	const struct bt_mesh_time_cli_handlers *handlers;
 };
 
 /** @brief Get the current Time Status of a Time Server.
@@ -65,8 +111,7 @@ struct bt_mesh_time_cli {
  * @param[in]  ctx Message context, or NULL to use the configured publish
  *                 parameters.
  * @param[out] rsp Status response buffer, returning the Server's current time
- *                 Status, or NULL to keep
- *                 from blocking.
+ *                 Status, or NULL to keep from blocking.
  *
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
@@ -77,7 +122,6 @@ struct bt_mesh_time_cli {
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
  * @retval -ETIMEDOUT     The request timed out without a response.
- * @retval -EFAULT        Response buffer pointer is NULL.
  */
 int bt_mesh_time_cli_time_get(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -90,8 +134,7 @@ int bt_mesh_time_cli_time_get(struct bt_mesh_time_cli *cli,
  *                 parameters.
  * @param[in]  set Time Status parameter to set.
  * @param[out] rsp Status response buffer, returning the Server's current time
- *                 Status, or NULL to keep
- *                 from blocking.
+ *                 Status, or NULL to keep from blocking.
  *
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
@@ -102,7 +145,6 @@ int bt_mesh_time_cli_time_get(struct bt_mesh_time_cli *cli,
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
  * @retval -ETIMEDOUT     The request timed out without a response.
- * @retval -EFAULT        Response buffer pointer is NULL.
  */
 int bt_mesh_time_cli_time_set(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -115,8 +157,7 @@ int bt_mesh_time_cli_time_set(struct bt_mesh_time_cli *cli,
  * @param[in]  ctx Message context, or NULL to use the configured publish
  *                 parameters.
  * @param[out] rsp Status response buffer, returning the Server's current
- *                 Time Zone Offset new state, or NULL
- *                 to keep from blocking.
+ *                 Time Zone Offset new state, or NULL to keep from blocking.
  *
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
@@ -127,7 +168,6 @@ int bt_mesh_time_cli_time_set(struct bt_mesh_time_cli *cli,
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
  * @retval -ETIMEDOUT     The request timed out without a response.
- * @retval -EFAULT        Response buffer pointer is NULL.
  */
 int bt_mesh_time_cli_zone_get(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -143,8 +183,7 @@ int bt_mesh_time_cli_zone_get(struct bt_mesh_time_cli *cli,
  *                 parameters.
  * @param[in]  set Time Zone Change parameters to set.
  * @param[out] rsp Status response buffer, returning the Server's current time
- *                 Status, or NULL to keep
- *                 from blocking.
+ *                 Status, or NULL to keep from blocking.
  *
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
@@ -155,7 +194,6 @@ int bt_mesh_time_cli_zone_get(struct bt_mesh_time_cli *cli,
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
  * @retval -ETIMEDOUT     The request timed out without a response.
- * @retval -EFAULT        Response buffer pointer is NULL.
  */
 int bt_mesh_time_cli_zone_set(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -168,8 +206,7 @@ int bt_mesh_time_cli_zone_set(struct bt_mesh_time_cli *cli,
  * @param[in]  ctx Message context, or NULL to use the configured publish
  *                 parameters.
  * @param[out] rsp Status response buffer, returning the Server's TAI-UTC
- *                 Delta new state, or NULL to keep
- *                 from blocking.
+ *                 Delta new state, or NULL to keep from blocking.
  *
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
@@ -180,7 +217,6 @@ int bt_mesh_time_cli_zone_set(struct bt_mesh_time_cli *cli,
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
  * @retval -ETIMEDOUT     The request timed out without a response.
- * @retval -EFAULT        Response buffer pointer is NULL.
  */
 int bt_mesh_time_cli_tai_utc_delta_get(
 	struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -207,7 +243,6 @@ int bt_mesh_time_cli_tai_utc_delta_get(
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
  * @retval -ETIMEDOUT     The request timed out without a response.
- * @retval -EFAULT        Response buffer pointer is NULL.
  */
 int bt_mesh_time_cli_tai_utc_delta_set(
 	struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -231,7 +266,6 @@ int bt_mesh_time_cli_tai_utc_delta_set(
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
  * @retval -ETIMEDOUT     The request timed out without a response.
- * @retval -EFAULT        Response buffer pointer is NULL.
  */
 int bt_mesh_time_cli_role_get(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx, uint8_t *rsp);
@@ -254,7 +288,6 @@ int bt_mesh_time_cli_role_get(struct bt_mesh_time_cli *cli,
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
  * @retval -ETIMEDOUT     The request timed out without a response.
- * @retval -EFAULT        Response buffer pointer is NULL.
  */
 int bt_mesh_time_cli_role_set(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx, const uint8_t *set,

--- a/subsys/bluetooth/mesh/time_cli.c
+++ b/subsys/bluetooth/mesh/time_cli.c
@@ -28,6 +28,10 @@ static void handle_status(struct bt_mesh_model *model,
 		*rsp = status;
 		model_ack_rx(&cli->ack_ctx);
 	}
+
+	if (cli->handlers->time_status) {
+		cli->handlers->time_status(cli, ctx, &status);
+	}
 }
 
 static void time_role_status_handle(struct bt_mesh_model *model,
@@ -39,7 +43,7 @@ static void time_role_status_handle(struct bt_mesh_model *model,
 	}
 
 	struct bt_mesh_time_cli *cli = model->user_data;
-	uint8_t status;
+	enum bt_mesh_time_role status;
 
 	status = net_buf_simple_pull_u8(buf);
 
@@ -48,6 +52,10 @@ static void time_role_status_handle(struct bt_mesh_model *model,
 		uint8_t *rsp = (uint8_t *)cli->ack_ctx.user_data;
 		*rsp = status;
 		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->handlers->time_role_status) {
+		cli->handlers->time_role_status(cli, ctx, status);
 	}
 }
 
@@ -76,6 +84,10 @@ static void time_zone_status_handle(struct bt_mesh_model *model,
 		*rsp = status;
 		model_ack_rx(&cli->ack_ctx);
 	}
+
+	if (cli->handlers->time_zone_status) {
+		cli->handlers->time_zone_status(cli, ctx, &status);
+	}
 }
 
 static void tai_utc_delta_status_handle(struct bt_mesh_model *model,
@@ -102,6 +114,10 @@ static void tai_utc_delta_status_handle(struct bt_mesh_model *model,
 				cli->ack_ctx.user_data;
 		*rsp = status;
 		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->handlers->tai_utc_delta_status) {
+		cli->handlers->tai_utc_delta_status(cli, ctx, &status);
 	}
 }
 
@@ -147,10 +163,6 @@ int bt_mesh_time_cli_time_get(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct bt_mesh_time_status *rsp)
 {
-	if (rsp == NULL) {
-		return -EFAULT;
-	}
-
 	return get_msg(cli, ctx, rsp, BT_MESH_TIME_OP_TIME_GET,
 		       BT_MESH_TIME_OP_TIME_STATUS);
 }
@@ -160,10 +172,6 @@ int bt_mesh_time_cli_time_set(struct bt_mesh_time_cli *cli,
 			      const struct bt_mesh_time_status *set,
 			      struct bt_mesh_time_status *rsp)
 {
-	if (rsp == NULL) {
-		return -EFAULT;
-	}
-
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_TIME_OP_TIME_SET,
 				 BT_MESH_TIME_MSG_LEN_TIME_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_TIME_OP_TIME_SET);
@@ -178,10 +186,6 @@ int bt_mesh_time_cli_zone_get(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct bt_mesh_time_zone_status *rsp)
 {
-	if (rsp == NULL) {
-		return -EFAULT;
-	}
-
 	return get_msg(cli, ctx, rsp, BT_MESH_TIME_OP_TIME_ZONE_GET,
 		       BT_MESH_TIME_OP_TIME_ZONE_STATUS);
 }
@@ -191,10 +195,6 @@ int bt_mesh_time_cli_zone_set(struct bt_mesh_time_cli *cli,
 			      const struct bt_mesh_time_zone_change *set,
 			      struct bt_mesh_time_zone_status *rsp)
 {
-	if (rsp == NULL) {
-		return -EFAULT;
-	}
-
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_TIME_OP_TIME_ZONE_SET,
 				 BT_MESH_TIME_MSG_LEN_TIME_ZONE_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_TIME_OP_TIME_ZONE_SET);
@@ -210,10 +210,6 @@ int bt_mesh_time_cli_tai_utc_delta_get(
 	struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_time_tai_utc_delta_status *rsp)
 {
-	if (rsp == NULL) {
-		return -EFAULT;
-	}
-
 	return get_msg(cli, ctx, rsp, BT_MESH_TIME_OP_TAI_UTC_DELTA_GET,
 		       BT_MESH_TIME_OP_TAI_UTC_DELTA_STATUS);
 }
@@ -223,10 +219,6 @@ int bt_mesh_time_cli_tai_utc_delta_set(
 	const struct bt_mesh_time_tai_utc_change *set,
 	struct bt_mesh_time_tai_utc_delta_status *rsp)
 {
-	if (rsp == NULL) {
-		return -EFAULT;
-	}
-
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_TIME_OP_TAI_UTC_DELTA_SET,
 				 BT_MESH_TIME_MSG_LEN_TAI_UTC_DELTA_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_TIME_OP_TAI_UTC_DELTA_SET);
@@ -242,10 +234,6 @@ int bt_mesh_time_cli_tai_utc_delta_set(
 int bt_mesh_time_cli_role_get(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx, uint8_t *rsp)
 {
-	if (rsp == NULL) {
-		return -EFAULT;
-	}
-
 	return get_msg(cli, ctx, rsp, BT_MESH_TIME_OP_TIME_ROLE_GET,
 		       BT_MESH_TIME_OP_TIME_ROLE_STATUS);
 }
@@ -254,10 +242,6 @@ int bt_mesh_time_cli_role_set(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx, const uint8_t *set,
 			      uint8_t *rsp)
 {
-	if (rsp == NULL) {
-		return -EFAULT;
-	}
-
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_TIME_OP_TIME_ROLE_SET,
 				 BT_MESH_TIME_MSG_LEN_TIME_ROLE_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_TIME_OP_TIME_ROLE_SET);

--- a/subsys/bluetooth/mesh/time_cli.c
+++ b/subsys/bluetooth/mesh/time_cli.c
@@ -29,7 +29,7 @@ static void handle_status(struct bt_mesh_model *model,
 		model_ack_rx(&cli->ack_ctx);
 	}
 
-	if (cli->handlers->time_status) {
+	if (cli->handlers && cli->handlers->time_status) {
 		cli->handlers->time_status(cli, ctx, &status);
 	}
 }
@@ -54,7 +54,7 @@ static void time_role_status_handle(struct bt_mesh_model *model,
 		model_ack_rx(&cli->ack_ctx);
 	}
 
-	if (cli->handlers->time_role_status) {
+	if (cli->handlers && cli->handlers->time_role_status) {
 		cli->handlers->time_role_status(cli, ctx, status);
 	}
 }
@@ -85,7 +85,7 @@ static void time_zone_status_handle(struct bt_mesh_model *model,
 		model_ack_rx(&cli->ack_ctx);
 	}
 
-	if (cli->handlers->time_zone_status) {
+	if (cli->handlers && cli->handlers->time_zone_status) {
 		cli->handlers->time_zone_status(cli, ctx, &status);
 	}
 }
@@ -116,7 +116,7 @@ static void tai_utc_delta_status_handle(struct bt_mesh_model *model,
 		model_ack_rx(&cli->ack_ctx);
 	}
 
-	if (cli->handlers->tai_utc_delta_status) {
+	if (cli->handlers && cli->handlers->tai_utc_delta_status) {
 		cli->handlers->tai_utc_delta_status(cli, ctx, &status);
 	}
 }


### PR DESCRIPTION
Description of functions contradicted their logic. Although functions' declarations allowed response argument to be NULL to keep from blocking, their definitions returned error -EFAULT in this case. And Time client instance didn't have handlers for Status messages.