### PR TITLE
partition_manager: Add dependency to all pm.yml source files

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -120,6 +120,14 @@ foreach (image ${PM_IMAGES})
   list(APPEND images ${image})
   list(APPEND input_files  ${${image}_PM_YML_FILES})
   list(APPEND header_files ${${image}_ZEPHYR_BINARY_DIR}/${generated_path}/pm_config.h)
+
+  # Re-configure (Re-execute all CMakeLists.txt code) when original
+  # (not preprocessed) configuration file changes.
+  set_property(
+    DIRECTORY APPEND PROPERTY
+    CMAKE_CONFIGURE_DEPENDS
+    ${${image}_PM_YML_DEP_FILES}
+    )
 endforeach()
 
 # Explicitly add the dynamic partition image

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -118,7 +118,7 @@ foreach (image ${PM_IMAGES})
   include(${shared_vars_file})
   list(APPEND prefixed_images ${DOMAIN}:${image})
   list(APPEND images ${image})
-  list(APPEND input_files  ${${image}_ZEPHYR_BINARY_DIR}/${generated_path}/pm.yml)
+  list(APPEND input_files  ${${image}_PM_YML_FILES})
   list(APPEND header_files ${${image}_ZEPHYR_BINARY_DIR}/${generated_path}/pm_config.h)
 endforeach()
 

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -21,11 +21,19 @@ function(preprocess_pm_yml in_file out_file)
     message(FATAL_ERROR "command failed with return code: ${ret}")
   endif()
 
-  if (IMAGE_NAME)
+  if (DEFINED IMAGE_NAME)
+    # Share location of original source file so that the parent image can add it
+    # to the CMAKE_CONFIGURE_DEPENDS list.
+    share("list(APPEND ${IMAGE_NAME}PM_YML_DEP_FILES ${in_file})")
+
     # Share location of preprocessed pm.yml file so that the parent image can
     # use it as source for partition manager configuration.
     share("list(APPEND ${IMAGE_NAME}PM_YML_FILES ${out_file})")
   endif()
+
+  # Re-configure (Re-execute all CMakeLists.txt code) when original
+  # (not preprocessed) configuration file changes.
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${in_file})
 
 endfunction()
 

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -21,6 +21,12 @@ function(preprocess_pm_yml in_file out_file)
     message(FATAL_ERROR "command failed with return code: ${ret}")
   endif()
 
+  if (IMAGE_NAME)
+    # Share location of preprocessed pm.yml file so that the parent image can
+    # use it as source for partition manager configuration.
+    share("list(APPEND ${IMAGE_NAME}PM_YML_FILES ${out_file})")
+  endif()
+
 endfunction()
 
 


### PR DESCRIPTION
Currently cmake will not be automatically re-run if any pm.yml file is modified.
This since there is no dependency to them.

This PR fixes this.

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>