### PR TITLE
doc: known issues: Add LL control procedure busy issue

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -552,6 +552,14 @@ Front-End Modules API implementation missing
 SoftDevice Controller
 =====================
 
+.. rst-class:: v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
+
+DRGN-11963: LL control procedures cannot be initiated at the same time
+  The LL control procedures (LE start encryption and LE connection parameter update) cannot be initiated at the same time or more than once.
+  The controller will return an HCI error code "Controller Busy (0x3a)", as per specification's chapter 2.55.
+
+  **Workaround:** Do not initiate these procedures at the same time.
+
 The following known issues and limitations have been moved from :ref:`SD Controller's changelog <nrfxlib:softdevice_controller_changelog>` for the |NCS| v1.4.0 release.
 
 .. rst-class:: v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0


### PR DESCRIPTION
Add known issue for LL controller procedures that cannot be initiated
at the same in the SoftDevice controller.

NCSDK-6872
DRGN-11963