### PR TITLE
drivers: gps: nrf9160_gps: Don't clear TCXO offset in delete mask

### DIFF
--- a/drivers/gps/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/gps/nrf9160_gps/nrf9160_gps.c
@@ -561,7 +561,7 @@ static int parse_cfg(struct gps_config *cfg_src,
 	}
 
 	if (cfg_src->delete_agps_data) {
-		cfg_dst->delete_mask = 0xFF;
+		cfg_dst->delete_mask = 0x7F;
 	}
 
 	set_nmea_mask(&cfg_dst->nmea_mask);


### PR DESCRIPTION
The delete_apgs_data boolean is used to indicate that GNSS
assistance data should be deleted. The TCXO offset (bit 7) is not
part of the A-GPS data set that can be input to the device,
so it should not be included in the bitmask of the data
to be deleted.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>