### PR TITLE
ci: lock the CI cfg to the settings used for final testing

### DIFF
--- a/.github/workflows/contribs.yml
+++ b/.github/workflows/contribs.yml
@@ -1,0 +1,23 @@
+name: Contribs
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  contribs:
+    runs-on: ubuntu-latest
+    name: Contribs
+    steps:
+      - name: Contribs
+        uses: carlescufi/action-contribs@main
+        with:
+          github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
+          command: 'external'
+          messages: |
+                    Thank you for your contribution!
+                    It seems you are not a member of the nrfconnect GitHub organization.
+                    At this time we are not accepting external contributions, but this may change soon.
+                    Please visit https://devzone.nordicsemi.com/ to raise any issues you found or ask for help.
+                    |
+                    The author of this pull request has now been added to the nrfconnect GitHub organization.
+          labels: 'external'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v1.4-branch") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 


### PR DESCRIPTION
ci: lock the CI cfg to the settings used for final testing

PR's targeting v1.4-branch will be run with the exact same CI configuration as release day. 