### PR TITLE
Fix mcuboot_CONF_FILE list handling

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -109,10 +109,13 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   endif ()
 
   if (DEFINED mcuboot_CONF_FILE)
-    get_filename_component(mcuboot_CONF_DIR ${mcuboot_CONF_FILE} DIRECTORY)
-    if (EXISTS ${mcuboot_CONF_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})
-      set(mcuboot_key_file ${mcuboot_CONF_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})
-    endif()
+    foreach(F in LISTS mcuboot_CONF_FILE)
+      get_filename_component(mcuboot_CONF_DIR ${F} DIRECTORY)
+      if (EXISTS ${mcuboot_CONF_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})
+        set(mcuboot_key_file ${mcuboot_CONF_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})
+        break()
+      endif()
+    endforeach()
   endif()
 
   # Set default key

--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -109,7 +109,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   endif ()
 
   if (DEFINED mcuboot_CONF_FILE)
-    foreach(F in LISTS mcuboot_CONF_FILE)
+    foreach(F IN LISTS mcuboot_CONF_FILE)
       get_filename_component(mcuboot_CONF_DIR ${F} DIRECTORY)
       if (EXISTS ${mcuboot_CONF_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})
         set(mcuboot_key_file ${mcuboot_CONF_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})


### PR DESCRIPTION
Per zephyr documentation, project's 'CONF_FILE' can be a list of files.

Instead of 'get_filename_component unknown component' CMake error,
process 'mcuboot_CONF_FILE' as a list. First existing key file is used.