### PR TITLE
doc: fix stylesheet for Zephyr start page

### DIFF
--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -204,6 +204,12 @@ div.numbered-step>h6::before {
  overflow-x: auto;
  line-height: 40px;
 }
+.grid-item h2 {
+ border: 0px;
+ padding-top: 0px;
+ line-height: unset;
+}
+
 
 
 /* change the bullet item for links to subpages */


### PR DESCRIPTION
We added a top-border for H2 headings in the documentation.
However, that border should not be used in the grid on the
Zephyr start page. Excluding this from our stylesheet.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>