### PR TITLE
lib: bsdlib: doc update to fix missing doxygen group in documentation

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: a28d68f925b10887daf006a833cebddb00323017
+      revision: pull/320/head
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Manifest update.

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no