### PR TITLE
manifest: sdk-zephyr: Update manifest to sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.0-ncs1
+      revision: 38b88bdfa73ea632cb1cf34590c7d0c410fa6aa1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add missing functionality required for ncs 1.4 qualification

Update sdk-zephyr: nrfconnect/sdk-zephyr#385

Signed-off-by: Ryan Chu <ryan.chu@nordicsemi.no>