### PR TITLE
subsys: mpsl: Initialize MPSL without scheduler

### DIFF
--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -25,6 +25,15 @@ config MPSL_TIMESLOT_SESSION_COUNT
 	help
 	  Maximum number of timeslot sessions.
 
+config MPSL_SCHEDULER
+	bool
+	default y if ((MPSL_TIMESLOT_SESSION_COUNT > 0) || (SOC_FLASH_NRF_RADIO_SYNC_MPSL_TIMESLOT_SESSION_COUNT > 0))
+	help
+	  Initialize MPSL scheduler. MPSL scheduler is needed when using:
+	    - Radio scheduler used for Bluetooth LE and/or 802.15.4
+	    - Timeslot
+	    - Radio notifications
+
 module=MPSL
 module-str=MPSL
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -12,6 +12,7 @@ menuconfig ZIGBEE
 	select NET_L2_ZIGBEE
 	select NETWORKING
 	imply MPSL
+	imply MPSL_SCHEDULER
 	imply COUNTER
 	imply COUNTER_TIMER3
 	imply ENTROPY_GENERATOR

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 7ee4e81ce306c4a0ee1fa7b166a375cbda8c2ce0
+      revision: pull/331/head
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
This PR shows how to use mpsl without scheduler. This functionality is needed for samples like the DTM and the radio test which
not running any radio protocol and will use the FEM API

Corresponding PR in nrfxlib: nrfconnect/sdk-nrfxlib#331