### PR TITLE
applications: asset_tracker: Add missing bootloader string to FOTA

### DIFF
--- a/applications/asset_tracker/Kconfig
+++ b/applications/asset_tracker/Kconfig
@@ -280,6 +280,13 @@ config CLOUD_FOTA_MODEM
 	depends on DFU_TARGET_MODEM
 	default y
 
+config CLOUD_FOTA_BOOT
+	bool "Enable firmware over-the-air upgrades for bootloader"
+	depends on AWS_FOTA
+	depends on DFU_TARGET_MCUBOOT
+	depends on SECURE_BOOT
+	default y
+
 config CLOUD_CONNECT_ERR_REBOOT_S
 	int "Seconds to wait before rebooting when a cloud connect error occurs"
 	default 300

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1051,7 +1051,10 @@ static void device_status_send(struct k_work *work)
 		SERVICE_INFO_FOTA_STR_APP,
 #endif
 #if defined(CONFIG_CLOUD_FOTA_MODEM)
-		SERVICE_INFO_FOTA_STR_MODEM
+		SERVICE_INFO_FOTA_STR_MODEM,
+#endif
+#if defined(CONFIG_CLOUD_FOTA_BOOT)
+		SERVICE_INFO_FOTA_STR_BOOTLOADER
 #endif
 	};
 


### PR DESCRIPTION
This string is needed for enabling bootloader upgrades through nRF
Cloud.

NCSDK-6900

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>