### PR TITLE
samples: ASSERT to not include all info

### DIFF
--- a/samples/Kconfig
+++ b/samples/Kconfig
@@ -10,6 +10,8 @@ config NCS_SAMPLES_DEFAULTS
 	imply LOG
 	imply LOG_MINIMAL
 	imply ASSERT
+	imply ASSERT_NO_COND_INFO
+	imply ASSERT_NO_MSG_INFO
 	imply HW_STACK_PROTECTION if ARCH_HAS_STACK_PROTECTION
 	help
 	  Use the default configuration for NCS samples.


### PR DESCRIPTION
Assertions is currently enabled for all samples. These assertions contribute a lot to the flash usage of the samples.
Disabling some extra assert debugging info can reduce the size a lot. The proposal below shaves of **8 kb** of a typical Bluetooth LE sample.

The current `NCS_SAMPLES_DEFAULTS` defaults to the following:
 - `ASSERT=y`
 - `ASSERT_VERBOSE=y`
 - `ASSERT_NO_FILE_INFO=n`
 - `ASSERT_NO_COND_INFO=n`
 - `ASSERT_NO_MSG_INFO=n`

Using `samples/bluetooth/throughput`, the following observations were made:

- `ASSERT_NO_COND_INFO=y` shaves of 4.5 kb of flash.
- `ASSERT_NO_MSG_INFO=y` shaves of 3.5 kb of flash.
- `ASSERT_NO_FILE_INFO=y` shaves of 5 kb of flash.
- `ASSERT_VERBOSE=n` shaves of an additional 1 kb when the above are enabled. 12 kb if it is the only option turned off.

Although changing all these configurations to a minimum shaves of a lot of flash, it also makes it harder to debug an assert. 

A new proposed configuration is:
 - `ASSERT=y`
 - `ASSERT_VERBOSE=y`
 - `ASSERT_NO_FILE_INFO=n`
 - `ASSERT_NO_COND_INFO=y`
 - `ASSERT_NO_MSG_INFO=y`
 
**That shaves of 8 kb** of flash for this particular sample without making it much harder to debug:

Currently an assert prints something similar to:

```
ASSERTION FAIL [1 + 1 == 3] @ ../src/main.c:432
        Custom assertion failed
E: r0/a1:  0x00000004  r1/a2:  0x000001b0  r2/a3:  0x00000001
E: r3/a4:  0x00028a15 r12/ip:  0x00000000 r14/lr:  0x0001af19
E:  xpsr:  0x61000000
E: Faulting instruction address (r15/pc): 0x0002e484
E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
E: Current thread: 0x20002d40 (unknown)
```

After the change, the following is printed:
```
ASSERTION FAIL @ ../src/main.c:432
E: r0/a1:  0x00000004  r1/a2:  0x000001b0  r2/a3:  0x00000001
E: r3/a4:  0x000284b9 r12/ip:  0x00000000 r14/lr:  0x0001af11
E:  xpsr:  0x61000000
E: Faulting instruction address (r15/pc): 0x0002d654
E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
E: Current thread: 0x20002d40 (unknown)
```

Note, if we use `ASSERT_VERBOSE=n`, the file and line number is not printed.
This may be a bit hard to debug for some users not familiar with zephyr:
```
E: r0/a1:  0x00000004  r1/a2:  0x0000000a  r2/a3:  0x00000001
E: r3/a4:  0x00027065 r12/ip:  0x00000000 r14/lr:  0x0001aeff
E:  xpsr:  0x61000000
E: Faulting instruction address (r15/pc): 0x0002b71a
E: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
E: Current thread: 0x20002d40 (unknown)
```