### PR TITLE
Enable the radio_test building for all nRF52 soc

### DIFF
--- a/samples/peripheral/radio_test/CMakeLists.txt
+++ b/samples/peripheral/radio_test/CMakeLists.txt
@@ -6,12 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(NRF_SUPPORTED_BOARDS
-	nrf5340pdk_nrf5340_cpunet
-	nrf52dk_nrf52832
-	nrf52840dk_nrf52840
-)
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -14,7 +14,8 @@
 
 #include "radio_test.h"
 
-#define USE_MORE_NRF52_RADIO_POWER_OPTIONS (defined(NRF52840_XXAA))
+#define USE_MORE_NRF52_RADIO_POWER_OPTIONS (defined(NRF52840_XXAA) || defined(NRF52820_XXAA) || \
+					    defined(NRF52833_XXAA))
 
 #if NRF_POWER_HAS_DCDCEN_VDDH
 	#define TOGGLE_DCDC_HELP			\

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -14,9 +14,6 @@
 
 #include "radio_test.h"
 
-#define USE_MORE_NRF52_RADIO_POWER_OPTIONS (defined(NRF52840_XXAA) || defined(NRF52820_XXAA) || \
-					    defined(NRF52833_XXAA))
-
 #if NRF_POWER_HAS_DCDCEN_VDDH
 	#define TOGGLE_DCDC_HELP			\
 	"Toggle DCDC state <state>, "			\
@@ -66,7 +63,7 @@ static struct radio_test_config test_config;
 /* If true, RX sweep, TX sweep or duty cycle test is performed. */
 static bool test_in_progress;
 
-#if USE_MORE_RADIO_MODES
+#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
 static void ieee_channel_check(const struct shell *shell, uint8_t channel)
 {
 	if (config.mode == NRF_RADIO_MODE_IEEE802154_250KBIT) {
@@ -84,7 +81,7 @@ static void ieee_channel_check(const struct shell *shell, uint8_t channel)
 
 	}
 }
-#endif
+#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
 
 static int cmd_start_channel_set(const struct shell *shell, size_t argc,
 				 char **argv)
@@ -204,9 +201,9 @@ static int cmd_tx_carrier_start(const struct shell *shell, size_t argc,
 		test_in_progress = false;
 	}
 
-#if USE_MORE_RADIO_MODES
+#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
 	ieee_channel_check(shell, config.channel_start);
-#endif /* USE_MORE_RADIO_MODES */
+#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
 
 	memset(&test_config, 0, sizeof(test_config));
 	test_config.type = UNMODULATED_TX;
@@ -234,9 +231,9 @@ static int cmd_tx_modulated_carrier_start(const struct shell *shell,
 		test_in_progress = false;
 	}
 
-#if USE_MORE_RADIO_MODES
+#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
 	ieee_channel_check(shell, config.channel_start);
-#endif /* USE_MORE_RADIO_MODES */
+#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
 
 	if (argc > 2) {
 		shell_error(shell, "%s: bad parameters count.", argv[0]);
@@ -285,9 +282,9 @@ static int cmd_duty_cycle_set(const struct shell *shell, size_t argc,
 
 	config.duty_cycle = duty_cycle;
 
-#if USE_MORE_RADIO_MODES
+#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
 	ieee_channel_check(shell, config.channel_start);
-#endif /* USE_MORE_RADIO_MODES */
+#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
 
 	memset(&test_config, 0, sizeof(test_config));
 	test_config.type = MODULATED_TX_DUTY_CYCLE;
@@ -394,14 +391,14 @@ static int cmd_print(const struct shell *shell, size_t argc, char **argv)
 	shell_print(shell, "Parameters:");
 
 	switch (config.mode) {
-#ifdef NRF52832_XXAA
+#if defined(RADIO_MODE_MODE_Nrf_250Kbit)
 	case NRF_RADIO_MODE_NRF_250KBIT:
 		shell_print(shell,
 			    "Data rate: %s",
 			    STRINGIFY(NRF_RADIO_MODE_NRF_250KBIT));
 		break;
 
-#endif /* NRF52832_XXAA */
+#endif /* defined(RADIO_MODE_MODE_Nrf_250Kbit) */
 	case NRF_RADIO_MODE_NRF_1MBIT:
 		shell_print(shell,
 			    "Data rate: %s",
@@ -426,26 +423,30 @@ static int cmd_print(const struct shell *shell, size_t argc, char **argv)
 			    STRINGIFY(NRF_RADIO_MODE_BLE_2MBIT));
 		break;
 
-#if USE_MORE_RADIO_MODES
+#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
 	case NRF_RADIO_MODE_BLE_LR125KBIT:
 		shell_print(shell,
 			    "Data rate: %s",
 			    STRINGIFY(NRF_RADIO_MODE_BLE_LR125KBIT));
 		break;
+#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
 
+#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
 	case NRF_RADIO_MODE_BLE_LR500KBIT:
 		shell_print(shell,
 			    "Data rate: %s",
 			    STRINGIFY(NRF_RADIO_MODE_BLE_LR500KBIT));
 		break;
+#endif /* defined(RADIO_MODE_MODE_Ble_LR500Kbit) */
 
+#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
 	case NRF_RADIO_MODE_IEEE802154_250KBIT:
 		shell_print(shell,
 			    "Data rate: %s",
 			    STRINGIFY(NRF_RADIO_MODE_IEEE802154_250KBIT));
 		break;
+#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
 
-#endif /* USE_MORE_RADIO_MODES */
 	default:
 		shell_print(shell,
 			    "Data rate unknown or deprecated: %lu\n\r",
@@ -454,51 +455,61 @@ static int cmd_print(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	switch (config.txpower) {
-#if CONFIG_SOC_COMPATIBLE_NRF52X
-#if USE_MORE_NRF52_RADIO_POWER_OPTIONS
+#if defined(RADIO_TXPOWER_TXPOWER_Pos8dBm)
 	case RADIO_TXPOWER_TXPOWER_Pos8dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos8dBm));
 		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos8dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos7dBm)
 	case RADIO_TXPOWER_TXPOWER_Pos7dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos7dBm));
 		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos7dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos6dBm)
 	case RADIO_TXPOWER_TXPOWER_Pos6dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos6dBm));
 		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos6dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos5dBm)
 	case RADIO_TXPOWER_TXPOWER_Pos5dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos5dBm));
 		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos5dBm) */
 
-	case RADIO_TXPOWER_TXPOWER_Pos2dBm:
-		shell_print(shell,
-			    "TX power: %s",
-			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos2dBm));
-		break;
-
-#endif /* USE_MORE_NRF52_RADIO_POWER_OPTIONS */
+#if defined(RADIO_TXPOWER_TXPOWER_Pos4dBm)
 	case RADIO_TXPOWER_TXPOWER_Pos4dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos4dBm));
 		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos4dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos3dBm)
 	case RADIO_TXPOWER_TXPOWER_Pos3dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos3dBm));
 		break;
-#endif /* CONFIG_SOC_COMPATIBLE_NRF52X */
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos3dBm) */
+
+#if defined(RADIO_TXPOWER_TXPOWER_Pos2dBm)
+	case RADIO_TXPOWER_TXPOWER_Pos2dBm:
+		shell_print(shell,
+			    "TX power: %s",
+			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos2dBm));
+		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos2dBm) */
 
 	case RADIO_TXPOWER_TXPOWER_0dBm:
 		shell_print(shell,
@@ -506,25 +517,29 @@ static int cmd_print(const struct shell *shell, size_t argc, char **argv)
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_0dBm));
 		break;
 
-#if CONFIG_SOC_SERIES_NRF53X
+#if defined(RADIO_TXPOWER_TXPOWER_Neg1dBm)
 	case RADIO_TXPOWER_TXPOWER_Neg1dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg1dBm));
 		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg1dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Neg2dBm)
 	case RADIO_TXPOWER_TXPOWER_Neg2dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg2dBm));
 		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg2dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Neg3dBm)
 	case RADIO_TXPOWER_TXPOWER_Neg3dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg3dBm));
 		break;
-#endif /* CONFIG_SOC_SERIES_NRF53X */
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg3dBm) */
 
 	case RADIO_TXPOWER_TXPOWER_Neg4dBm:
 		shell_print(shell,
@@ -532,25 +547,29 @@ static int cmd_print(const struct shell *shell, size_t argc, char **argv)
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg4dBm));
 		break;
 
-#if CONFIG_SOC_SERIES_NRF53X
+#if defined(RADIO_TXPOWER_TXPOWER_Neg5dBm)
 	case RADIO_TXPOWER_TXPOWER_Neg5dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg5dBm));
 		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg5dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Neg6dBm)
 	case RADIO_TXPOWER_TXPOWER_Neg6dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg6dBm));
 		break;
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg6dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Neg7dBm)
 	case RADIO_TXPOWER_TXPOWER_Neg7dBm:
 		shell_print(shell,
 			    "TX power: %s",
 			    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg7dBm));
 		break;
-#endif /* CONFIG_SOC_SERIES_NRF53X */
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg7dBm) */
 
 	case RADIO_TXPOWER_TXPOWER_Neg8dBm:
 		shell_print(shell,
@@ -672,9 +691,9 @@ static int cmd_rx_start(const struct shell *shell, size_t argc, char **argv)
 		test_in_progress = false;
 	}
 
-#if USE_MORE_RADIO_MODES
+#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
 	ieee_channel_check(shell, config.channel_start);
-#endif /* USE_MORE_RADIO_MODES */
+#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
 
 	memset(&test_config, 0, sizeof(test_config));
 	test_config.type = RX;
@@ -687,58 +706,68 @@ static int cmd_rx_start(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-#if CONFIG_SOC_COMPATIBLE_NRF52X
-#if USE_MORE_NRF52_RADIO_POWER_OPTIONS
+#if defined(RADIO_TXPOWER_TXPOWER_Pos8dBm)
 static void cmd_pos8dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Pos8dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos8dBm));
 }
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos8dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos7dBm)
 static void cmd_pos7dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Pos7dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos7dBm));
 }
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos7dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos6dBm)
 static void cmd_pos6dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Pos6dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos6dBm));
 }
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos6dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos5dBm)
 static void cmd_pos5dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Pos5dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos5dBm));
 }
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos5dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos2dBm)
 static void cmd_pos2dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Pos2dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos2dBm));
 }
-#endif /* USE_MORE_NRF52_RADIO_POWER_OPTIONS */
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos2dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos3dBm)
 static void cmd_pos3dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Pos3dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos3dBm));
 }
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos3dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Pos4dBm)
 static void cmd_pos4dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Pos4dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Pos4dBm));
 }
-#endif /* CONFIG_SOC_COMPATIBLE_NRF52X */
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos4dBm) */
 
 static void cmd_pos0dbm(const struct shell *shell, size_t argc, char **argv)
 {
@@ -747,28 +776,32 @@ static void cmd_pos0dbm(const struct shell *shell, size_t argc, char **argv)
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_0dBm));
 }
 
-#if CONFIG_SOC_SERIES_NRF53X
+#if defined(RADIO_TXPOWER_TXPOWER_Neg1dBm)
 static void cmd_neg1dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Neg1dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg1dBm));
 }
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg1dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Neg2dBm)
 static void cmd_neg2dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Neg2dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg2dBm));
 }
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg2dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Neg3dBm)
 static void cmd_neg3dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Neg3dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg3dBm));
 }
-#endif /* CONFIG_SOC_SERIES_NRF53X */
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg3dBm) */
 
 static void cmd_neg4dbm(const struct shell *shell, size_t argc, char **argv)
 {
@@ -777,28 +810,32 @@ static void cmd_neg4dbm(const struct shell *shell, size_t argc, char **argv)
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg4dBm));
 }
 
-#if CONFIG_SOC_SERIES_NRF53X
+#if defined(RADIO_TXPOWER_TXPOWER_Neg5dBm)
 static void cmd_neg5dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Neg5dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg5dBm));
 }
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg5dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Neg6dBm)
 static void cmd_neg6dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Neg6dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg6dBm));
 }
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg6dBm) */
 
+#if defined(RADIO_TXPOWER_TXPOWER_Neg7dBm)
 static void cmd_neg7dbm(const struct shell *shell, size_t argc, char **argv)
 {
 	config.txpower = RADIO_TXPOWER_TXPOWER_Neg7dBm;
 	shell_print(shell, "TX power: %s",
 		    Z_STRINGIFY(RADIO_TXPOWER_TXPOWER_Neg7dBm));
 }
-#endif /* CONFIG_SOC_SERIES_NRF53X */
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg7dBm) */
 
 static void cmd_neg8dbm(const struct shell *shell, size_t argc, char **argv)
 {
@@ -861,7 +898,7 @@ static int cmd_nrf_2mbit(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-#ifdef NRF52832_XXAA
+#if defined(RADIO_MODE_MODE_Nrf_250Kbit)
 static int cmd_nrf_250kbit(const struct shell *shell, size_t argc,
 			   char **argv)
 {
@@ -871,7 +908,7 @@ static int cmd_nrf_250kbit(const struct shell *shell, size_t argc,
 
 	return 0;
 }
-#endif /* NRF52832_XXAA */
+#endif /* defined(RADIO_MODE_MODE_Nrf_250Kbit) */
 
 static int cmd_ble_1mbit(const struct shell *shell, size_t argc, char **argv)
 {
@@ -891,7 +928,7 @@ static int cmd_ble_2mbit(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-#if USE_MORE_RADIO_MODES
+#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
 static int cmd_ble_lr125kbit(const struct shell *shell, size_t argc,
 			     char **argv)
 {
@@ -901,7 +938,9 @@ static int cmd_ble_lr125kbit(const struct shell *shell, size_t argc,
 
 	return 0;
 }
+#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
 
+#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
 static int cmd_ble_lr500kbit(const struct shell *shell, size_t argc,
 			     char **argv)
 {
@@ -911,7 +950,9 @@ static int cmd_ble_lr500kbit(const struct shell *shell, size_t argc,
 
 	return 0;
 }
+#endif /* defined(RADIO_MODE_MODE_Ble_LR500Kbit) */
 
+#if defined(RADIO_MODE_MODE_Ieee802154_250Kbit)
 static int cmd_ble_ieee(const struct shell *shell, size_t argc, char **argv)
 {
 	config.mode = NRF_RADIO_MODE_IEEE802154_250KBIT;
@@ -920,7 +961,7 @@ static int cmd_ble_ieee(const struct shell *shell, size_t argc, char **argv)
 
 	return 0;
 }
-#endif /* USE_MORE_RADIO_MODES */
+#endif /* RADIO_MODE_MODE_Ieee802154_250Kbit */
 
 static int cmd_pattern_random(const struct shell *shell, size_t argc,
 			      char **argv)
@@ -961,27 +1002,33 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_data_rate,
 	SHELL_CMD(nrf_2Mbit, NULL, "2 Mbit/s Nordic proprietary radio mode",
 		  cmd_nrf_2mbit),
 
-#ifdef NRF52832_XXAA
+#if defined(RADIO_MODE_MODE_Nrf_250Kbit)
 	SHELL_CMD(nrf_250Kbit, NULL,
 		  "250 kbit/s Nordic proprietary radio mode",
 		  cmd_nrf_250kbit),
-#endif /* NRF52832_XXAA */
+#endif /* defined(RADIO_MODE_MODE_Nrf_250Kbit) */
 
 	SHELL_CMD(ble_1Mbit, NULL, "1 Mbit/s Bluetooth Low Energy",
 		  cmd_ble_1mbit),
 	SHELL_CMD(ble_2Mbit, NULL, "2 Mbit/s Bluetooth Low Energy",
 		  cmd_ble_2mbit),
 
-#if USE_MORE_RADIO_MODES
+#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
 	SHELL_CMD(ble_lr125Kbit, NULL,
 		  "Long range 125 kbit/s TX, 125 kbit/s and 500 kbit/s RX",
 		  cmd_ble_lr125kbit),
+#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
+
+#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
 	SHELL_CMD(ble_lr500Kbit, NULL,
 		  "Long range 500 kbit/s TX, 125 kbit/s and 500 kbit/s RX",
 		  cmd_ble_lr500kbit),
+#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
+
+#if defined(RADIO_MODE_MODE_Ieee802154_250Kbit)
 	SHELL_CMD(ieee802154_250Kbit, NULL, "IEEE 802.15.4-2006 250 kbit/s",
 		  cmd_ble_ieee),
-#endif /* USE_MORE_RADIO_MODES */
+#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
 
 	SHELL_SUBCMD_SET_END
 );
@@ -1004,29 +1051,47 @@ static int cmd_print_payload(const struct shell *shell, size_t argc,
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_output_power,
-#if CONFIG_SOC_COMPATIBLE_NRF52X
-#if USE_MORE_NRF52_RADIO_POWER_OPTIONS
+#if defined(RADIO_TXPOWER_TXPOWER_Pos8dBm)
 	SHELL_CMD(pos8dBm, NULL, "TX power: +8 dBm", cmd_pos8dbm),
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos8dBm) */
+#if defined(RADIO_TXPOWER_TXPOWER_Pos7dBm)
 	SHELL_CMD(pos7dBm, NULL, "TX power: +7 dBm", cmd_pos7dbm),
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos7dBm) */
+#if defined(RADIO_TXPOWER_TXPOWER_Pos6dBm)
 	SHELL_CMD(pos6dBm, NULL, "TX power: +6 dBm", cmd_pos6dbm),
+#endif/* defined(RADIO_TXPOWER_TXPOWER_Pos6dBm) */
+#if defined(RADIO_TXPOWER_TXPOWER_Pos5dBm)
 	SHELL_CMD(pos5dBm, NULL, "TX power: +5 dBm", cmd_pos5dbm),
-	SHELL_CMD(pos2dBm, NULL, "TX power: +2 dBm", cmd_pos2dbm),
-#endif /* USE_MORE_NRF52_RADIO_POWER_OPTIONS */
-	SHELL_CMD(pos3dBm, NULL, "TX power: +3 dBm", cmd_pos3dbm),
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos5dBm) */
+#if defined(RADIO_TXPOWER_TXPOWER_Pos4dBm)
 	SHELL_CMD(pos4dBm, NULL, "TX power: +4 dBm", cmd_pos4dbm),
-#endif /* CONFIG_SOC_COMPATIBLE_NRF52X */
+#endif /* RADIO_TXPOWER_TXPOWER_Pos4dBm */
+#if defined(RADIO_TXPOWER_TXPOWER_Pos3dBm)
+	SHELL_CMD(pos3dBm, NULL, "TX power: +3 dBm", cmd_pos3dbm),
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos3dBm) */
+#if defined(RADIO_TXPOWER_TXPOWER_Pos2dBm)
+	SHELL_CMD(pos2dBm, NULL, "TX power: +2 dBm", cmd_pos2dbm),
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Pos2dBm) */
 	SHELL_CMD(pos0dBm, NULL, "TX power: 0 dBm", cmd_pos0dbm),
-#if CONFIG_SOC_SERIES_NRF53X
+#if defined(RADIO_TXPOWER_TXPOWER_Neg1dBm)
 	SHELL_CMD(neg1dBm, NULL, "TX power: -1 dBm", cmd_neg1dbm),
+#endif /* RADIO_TXPOWER_TXPOWER_Neg1dBm */
+#if defined(RADIO_TXPOWER_TXPOWER_Neg2dBm)
 	SHELL_CMD(neg2dBm, NULL, "TX power: -2 dBm", cmd_neg2dbm),
+#endif /* RADIO_TXPOWER_TXPOWER_Neg2dBm */
+#if defined(RADIO_TXPOWER_TXPOWER_Neg3dBm)
 	SHELL_CMD(neg3dBm, NULL, "TX power: -3 dBm", cmd_neg3dbm),
-#endif /* CONFIG_SOC_SERIES_NRF53X */
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg3dBm) */
 	SHELL_CMD(neg4dBm, NULL, "TX power: -4 dBm", cmd_neg4dbm),
-#if CONFIG_SOC_SERIES_NRF53X
+#if defined(RADIO_TXPOWER_TXPOWER_Neg5dBm)
 	SHELL_CMD(neg5dBm, NULL, "TX power: -5 dBm", cmd_neg5dbm),
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg5dBm) */
+#if defined(RADIO_TXPOWER_TXPOWER_Neg6dBm)
 	SHELL_CMD(neg6dBm, NULL, "TX power: -6 dBm", cmd_neg6dbm),
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg6dBm) */
+#if defined(RADIO_TXPOWER_TXPOWER_Neg7dBm)
 	SHELL_CMD(neg7dBm, NULL, "TX power: -7 dBm", cmd_neg7dbm),
-#endif /* CONFIG_SOC_SERIES_NRF53X */
+#endif /* defined(RADIO_TXPOWER_TXPOWER_Neg7dBm) */
 	SHELL_CMD(neg8dBm, NULL, "TX power: -8 dBm", cmd_neg8dbm),
 	SHELL_CMD(neg12dBm, NULL, "TX power: -12 dBm", cmd_neg12dbm),
 	SHELL_CMD(neg16dBm, NULL, "TX power: -16 dBm", cmd_neg16dbm),

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -555,9 +555,9 @@ void radio_test_init(struct radio_test_config *config)
 {
 	nrf_rng_task_trigger(NRF_RNG, NRF_RNG_TASK_START);
 
-	if (IS_ENABLED(NVMC_FEATURE_CACHE_PRESENT)) {
-		nrf_nvmc_icache_config_set(NRF_NVMC, NRF_NVMC_ICACHE_ENABLE);
-	}
+#if defined(NVMC_FEATURE_CACHE_PRESENT)
+	nrf_nvmc_icache_config_set(NRF_NVMC, NRF_NVMC_ICACHE_ENABLE);
+#endif /* NVMC_FEATURE_CACHE_PRESENT */
 
 	timer_init(config);
 	IRQ_CONNECT(TIMER0_IRQn, NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY,

--- a/samples/peripheral/radio_test/src/radio_test.h
+++ b/samples/peripheral/radio_test/src/radio_test.h
@@ -10,11 +10,6 @@
 #include <zephyr/types.h>
 #include <nrfx/hal/nrf_radio.h>
 
-/** Indicates devices that support BLE LR and 802.15.4 radio modes. */
-#if defined(NRF52840_XXAA) || defined(NRF5340_XXAA_NETWORK)
-	#define USE_MORE_RADIO_MODES 1
-#endif
-
 /** Maximum radio RX or TX payload. */
 #define RADIO_MAX_PAYLOAD_LEN	256
 /** IEEE 802.15.4 maximum payload length. */


### PR DESCRIPTION
- Enable building for all nRF52
- Valid output power modes  for all nRF52
- NVMC_FEATURE_CACHE_PRESENT is probably only defined so instruction cache seems to be never enabled