### PR TITLE
manifest: update nrfxlib for nrf security updates

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: a28d68f925b10887daf006a833cebddb00323017
+      revision: 80d4c109f8e704b25011325fca124c7fe395cda6
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Update manifest to fix nrf security CMake code, this ensures that
build works correctly on all platforms and with SES / Ninja / Make.

This also fixes a particular issue where repackaging of libraries didn't
work correctly which were observed in SES-NE.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

------
nrfxlib PR: https://github.com/nrfconnect/sdk-nrfxlib/pull/322