### PR TITLE
partition_manager: Add end_address as a calculated value

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -676,6 +676,9 @@ def get_region_config(pm_config, region_config, static_conf=None):
 
         solve_complex_region(pm_config, start, size, placement_strategy, region_name, device, static_conf, dp)
 
+    for part in pm_config:
+        pm_config[part]['end_address'] = pm_config[part]['address'] + pm_config[part]['size']
+
 
 def solve_simple_region(pm_config, start, size, placement_strategy, region_name, device, static_conf):
     reserved = 0
@@ -935,6 +938,9 @@ def expect_addr_size(td, name, expected_address, expected_size):
     if expected_address:
         assert td[name]['address'] == expected_address, \
             "Address of {} was {}, expected {}.\ntd:{}".format(name, td[name]['address'], expected_address, pformat(td))
+    if expected_size and expected_address:
+        assert td[name]['end_address'] == expected_address + expected_size, \
+            "End address of {} was {}, expected {}.\ntd:{}".format(name, td[name]['end_address'], expected_address + expected_size, pformat(td))
 
 
 def expect_list(expected, actual):

--- a/scripts/partition_manager_output.py
+++ b/scripts/partition_manager_output.py
@@ -52,6 +52,8 @@ def get_config_lines(gpm_config, greg_config, head, split, dest, current_domain=
                                       key=lambda key_value_tuple: key_value_tuple[1]['address']):
 
             add_line("%s_ADDRESS" % name.upper(), "0x%x" % partition['address'])
+            # The end address facilitates using PM values via Cmake generator expressions.
+            add_line("%s_END_ADDRESS" % name.upper(), "0x%x" % partition['end_address'])
             add_line("%s_SIZE" % name.upper(), "0x%x" % partition['size'])
             add_line("%s_NAME" % name.upper(), "%s" % name)
 


### PR DESCRIPTION
Giving PM_*_END_ADDRESS macros.
This can be calculated from the address and size, but when using partition
manager values via generator expressions, arithmetic isn't possible.

Also, add it to the tests.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>