### PR TITLE
drivers: serial: nrf_sw_lpuart: Add option to start HFXO on RX

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -13,6 +13,15 @@ config NRF_SW_LPUART
 
 if NRF_SW_LPUART
 
+config NRF_SW_LPUART_HFXO_ON_RX
+	bool "Turn on HFXO for RX"
+	default y
+	help
+	  According to the UART specification high frequency RC oscillator is
+	  not accurate enough. However, in normal conditions and accurate clock
+	  on the transmitter side it may be accepted to disable it. Turning on
+	  HFXO prolongs receiver activation for up to 3 milliseconds.
+
 config NRF_SW_LPUART_MAX_PACKET_SIZE
 	int "Maximum RX packet size"
 	default 128

--- a/drivers/serial/uart_nrf_sw_lpuart.c
+++ b/drivers/serial/uart_nrf_sw_lpuart.c
@@ -9,6 +9,8 @@
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_gpiote.h>
 #include <logging/log.h>
+#include <sys/onoff.h>
+#include <drivers/clock_control/nrf_clock_control.h>
 
 LOG_MODULE_REGISTER(lpuart, CONFIG_NRF_SW_LPUART_LOG_LEVEL);
 
@@ -108,6 +110,8 @@ struct lpuart_data {
 
 	/* Set to true if request has been detected. */
 	bool rx_req;
+
+	struct onoff_client rx_clk_cli;
 
 #if CONFIG_NRF_SW_LPUART_INT_DRIVEN
 	struct lpuart_int_driven int_driven;
@@ -218,12 +222,52 @@ static void activate_rx(struct lpuart_data *data)
 	data->rx_state = RX_ACTIVE;
 }
 
+static void rx_hfclk_callback(struct onoff_manager *mgr,
+			      struct onoff_client *cli,
+			      uint32_t state, int res)
+{
+	struct lpuart_data *data =
+		CONTAINER_OF(cli, struct lpuart_data, rx_clk_cli);
+
+	__ASSERT_NO_MSG(res >= 0);
+
+	activate_rx(data);
+}
+
+static void rx_hfclk_request(struct lpuart_data *data)
+{
+	struct onoff_manager *mgr =
+		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+	int err;
+
+	sys_notify_init_callback(&data->rx_clk_cli.notify, rx_hfclk_callback);
+	err = onoff_request(mgr, &data->rx_clk_cli);
+	__ASSERT_NO_MSG(err >= 0);
+}
+
+static void start_rx_activation(struct lpuart_data *data)
+{
+	if (IS_ENABLED(CONFIG_NRF_SW_LPUART_HFXO_ON_RX)) {
+		rx_hfclk_request(data);
+	} else {
+		activate_rx(data);
+	}
+}
+
 /* Called when end of transfer is detected. It sets response pin to idle and
  * disables RX.
  */
 static void deactivate_rx(struct lpuart_data *data)
 {
 	int err;
+
+	if (IS_ENABLED(CONFIG_NRF_SW_LPUART_HFXO_ON_RX)) {
+		struct onoff_manager *mgr =
+		     z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+
+		err = onoff_cancel_or_release(mgr, &data->rx_clk_cli);
+		__ASSERT_NO_MSG(err >= 0);
+	}
 
 	ctrl_pin_idle(&data->rdy_pin);
 	if (nrf_gpio_pin_read(data->rdy_pin.nrf_pin)) {
@@ -288,7 +332,7 @@ static void on_rdy_pin_change(struct lpuart_data *data)
 		LOG_DBG("RX: Request detected.");
 		data->rx_req = true;
 		if (data->rx_state == RX_IDLE) {
-			activate_rx(data);
+			start_rx_activation(data);
 		}
 	} else {
 		__ASSERT_NO_MSG(data->rx_state == RX_ACTIVE);
@@ -568,7 +612,7 @@ static int api_rx_enable(const struct device *dev, uint8_t *buf,
 	irq_unlock(key);
 
 	if (pending_rx) {
-		activate_rx(data);
+		start_rx_activation(data);
 	}
 
 	return 0;
@@ -587,7 +631,7 @@ static int api_rx_buf_rsp(const struct device *dev, uint8_t *buf, size_t len)
 
 		if (data->rx_req) {
 			LOG_DBG("RX: Pending request. Activating RX");
-			activate_rx(data);
+			start_rx_activation(data);
 		} else {
 			data->rx_state = RX_IDLE;
 			LOG_DBG("RX: Idle");


### PR DESCRIPTION
According to Product Specification HFXO should be turn on during UART
communication. Added it as an option (enabled by default). Starting
HFXO prolongs receiver start so user may want to disable if transmitter
has stable clock. HFXO starts in 300us (nrf52840) or 2.3ms (nrf91).

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>