### PR TITLE
Tfm integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -89,6 +89,7 @@ Kconfig*                                  @tejlmand
 /samples/profiler/                        @pdunaj @pizi-nordic
 /samples/peripheral/radio_test/           @kapi-no
 /samples/peripheral/lpuart/               @nordic-krch
+/samples/tfm/tfm_hello_world/             @oyvindronningstad
 /samples/usb/usb_uart_bridge/             @jhn-nordic @jtguggedal
 /samples/zigbee/                          @maciekfabia @mariuszpos
 /samples/CMakeLists.txt                   @tejlmand

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -35,6 +35,7 @@ In addition, the |NCS| provides the following samples that showcase the use of a
    :glob:
 
    ../../samples/nrf9160/*/README
+   ../../samples/tfm/*/README
 
 .. _nrf5340_samples:
 
@@ -45,6 +46,7 @@ In addition, the |NCS| provides the following samples that showcase the use of a
 
    ../../samples/nrf5340/*/README
    ../../samples/nrf_rpc/entropy_nrf53/README
+   ../../samples/tfm/*/README
 
 .. _openthread_samples:
 

--- a/samples/tfm/tfm_hello_world/CMakeLists.txt
+++ b/samples/tfm/tfm_hello_world/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# Building TFM requires Cmake 3.15.
+cmake_minimum_required(VERSION 3.15)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(tfm_hello_world)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/tfm/tfm_hello_world/README.rst
+++ b/samples/tfm/tfm_hello_world/README.rst
@@ -1,0 +1,38 @@
+.. _tfm_hello_world:
+
+TF-M Hello World
+################
+
+A simple sample based on Hello World that demonstrates adding TF-M to an application.
+
+Overview
+********
+
+This sample uses the Platform Security Architecture (PSA) API to calculate a SHA-256 digest.
+The PSA API call is handled by the TF-M secure firmware.
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340dk_nrf5340_cpuappns, nrf9160dk_nrf9160ns
+
+Building and Running
+********************
+
+.. |sample path| replace:: :file:`samples/tfm/tfm_hello_world`
+
+.. include:: /includes/build_and_run.txt
+
+Sample Output
+=============
+
+.. code-block:: console
+
+    Hello World! nrf5340pdk_nrf5340_cpuapp
+    SHA256 digest:
+    d87280aef6d36814af7cd864bc7cf28f
+    759f8d33c97459dd28eacee7133cb60c

--- a/samples/tfm/tfm_hello_world/boards/nrf9160dk_nrf9160ns.overlay
+++ b/samples/tfm/tfm_hello_world/boards/nrf9160dk_nrf9160ns.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/* Disable uart1 in nonsecure since it is used by the TFM secure app. */
+&uart1 {
+	status = "disabled";
+};

--- a/samples/tfm/tfm_hello_world/prj.conf
+++ b/samples/tfm/tfm_hello_world/prj.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_BUILD_WITH_TFM=y

--- a/samples/tfm/tfm_hello_world/sample.yaml
+++ b/samples/tfm/tfm_hello_world/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+  description: Hello World sample, the simplest Zephyr
+    application, with TF-M enabled
+  name: hello world TFM
+common:
+    tags: tfm
+    platform_allow: nrf5340dk_nrf5340_cpuappns nrf5340pdk_nrf5340_cpuappns nrf9160dk_nrf9160ns
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Hello World! (.*)"
+        - "SHA256 Digest: 0x.*"
+tests:
+  sample.tfm.helloworld:
+    tags: tfm ci_build

--- a/samples/tfm/tfm_hello_world/src/main.c
+++ b/samples/tfm/tfm_hello_world/src/main.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <string.h>
+#include <stdio.h>
+#include <tfm_ns_interface.h>
+#include "psa/crypto.h"
+
+#define HELLO_PATTERN "Hello World! %s\n"
+
+void main(void)
+{
+	char hello_string[sizeof(HELLO_PATTERN) + sizeof(CONFIG_BOARD)];
+	char hello_digest[32];
+	size_t len;
+	psa_status_t status;
+	enum tfm_status_e tfm_status;
+
+	len = snprintf(hello_string, sizeof(hello_string),
+		HELLO_PATTERN, CONFIG_BOARD);
+
+	printk("%s", hello_string);
+
+	tfm_status = tfm_ns_interface_init();
+	if (tfm_status != TFM_SUCCESS) {
+		printk("tfm_ns_interface_init failed with status %d\n", tfm_status);
+	}
+	status = psa_crypto_init();
+	if (status != PSA_SUCCESS) {
+		printk("psa_crypto_init failed with status %d\n", status);
+	}
+	status = psa_hash_compute(PSA_ALG_SHA_256, hello_string,
+					strlen(hello_string), hello_digest,
+					sizeof(hello_digest), &len);
+
+	if (status != PSA_SUCCESS) {
+		printk("psa_hash_compute failed with status %d\n", status);
+	} else {
+		printk("SHA256 digest:\n");
+		for (int i = 0; i < len; i++) {
+			printk("%02x%s", hello_digest[i],
+					i % 16 == 15 ? "\n" : "");
+		}
+	}
+}

--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -25,6 +25,7 @@ gcovr==4.2
 gitlint==0.13.1
 idna==2.9
 imagesize==1.2.0
+imgtool==1.7.0
 importlib-metadata==1.6.0
 intelhex==2.2.1
 intervaltree==3.0.2

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -55,6 +55,16 @@ if (CONFIG_NRF53_UPGRADE_NETWORK_CORE)
   ncs_add_partition_manager_config(pm.yml.pcd)
 endif()
 
+if (CONFIG_BUILD_WITH_TFM)
+  ncs_add_partition_manager_config(pm.yml.tfm)
+
+  # Add the mcuboot hex file built by TFM as the contents of the bl2 partitions,
+  # so it can be flashed together with the app/tfm hex files.
+  set_property(GLOBAL PROPERTY
+    bl2_PM_HEX_FILE ${CMAKE_BINARY_DIR}/tfm/bin/bl2.hex
+    )
+endif()
+
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
 set(using_partition_manager

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -101,6 +101,47 @@ config PM_EXTERNAL_FLASH_BASE
 
 endif
 
+config BUILD_WITH_TFM
+	bool
+	select PM_SINGLE_IMAGE
+
+if BUILD_WITH_TFM
+
+config PM_PARTITION_SIZE_TFM_RAM
+	hex
+	default 0x16000 if SOC_NRF9160
+	default 0x40000 if SOC_NRF5340_CPUAPP
+	help
+	  Memory set aside for the TFM_RAM partition.
+	  The prompt has been removed since the value is dictated by TFM and
+	  cannot be changed.
+
+config PM_PARTITION_SIZE_BL2
+	hex
+	default 0x10000
+	help
+	  Memory set aside for the BL2 partition.
+	  The prompt has been removed since the value is dictated by TFM and
+	  cannot be changed.
+
+config PM_PARTITION_SIZE_TFM
+	hex
+	default 0x40000
+	help
+	  Memory set aside for the TFM partition.
+	  The prompt has been removed since the value is dictated by TFM and
+	  cannot be changed.
+
+config PM_PARTITION_SIZE_TFM_EXTRA
+	hex
+	default 0x10000
+	help
+	  Memory set aside for the TFM_EXTRA partition.
+	  The prompt has been removed since the value is dictated by TFM and
+	  cannot be changed.
+
+endif
+
 config PM_IMAGE_NOT_BUILT_FROM_SOURCE
 	bool
 	help

--- a/subsys/partition_manager/pm.yml.tfm
+++ b/subsys/partition_manager/pm.yml.tfm
@@ -1,0 +1,36 @@
+#include <autoconf.h>
+
+tfm_ram:
+  placement: {after: [start]}
+  size: CONFIG_PM_PARTITION_SIZE_TFM_RAM
+  region: sram_primary
+
+bl2:
+  placement: {before: [tfm]}
+  size: CONFIG_PM_PARTITION_SIZE_BL2
+
+tfm:
+  placement: {before: [app]}
+  size: CONFIG_PM_PARTITION_SIZE_TFM
+
+tfm_primary:
+  span: [tfm]
+
+app_primary:
+  span: [app]
+
+signed_tfm_app:
+  span: [app, tfm]
+
+tfm_secondary:
+  placement: {after: [app_primary]}
+  share_size: tfm_primary
+
+app_secondary:
+  placement: {after: [tfm_secondary]}
+  share_size: app_primary
+
+tfm_extra:
+  placement: {after: [app_secondary]}
+  size: CONFIG_PM_PARTITION_SIZE_TFM_EXTRA
+  align: {start: CONFIG_FPROTECT_BLOCK_SIZE}

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -9,6 +9,7 @@ menu "SPM"
 config SPM
 	bool "Use Secure Partition Manager"
 	default y if TRUSTED_EXECUTION_NONSECURE
+	depends on !BUILD_WITH_TFM
 	select FW_INFO
 	imply ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS
 


### PR DESCRIPTION
Add TFM support in NCS.

This brings TFM into partition manager, though it's partitions cannot be modified, since TFM doesn't yet allow partition sizes/addresses to be set from the outside.

Rebased on #3357 and #3268 