### PR TITLE
samples: nrf9160: lwm2m_carrier library size

### DIFF
--- a/samples/nrf9160/lwm2m_carrier/src/main.c
+++ b/samples/nrf9160/lwm2m_carrier/src/main.c
@@ -3,9 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
+#ifdef CONFIG_LWM2M_CARRIER
 #include <lwm2m_carrier.h>
+#endif /* CONFIG_LWM2M_CARRIER */
 #include <zephyr.h>
 
+#ifdef CONFIG_LWM2M_CARRIER
 void bsd_recoverable_error_handler(uint32_t err)
 {
 	printk("bsdlib recoverable error: %u\n", (unsigned int)err);
@@ -119,6 +123,7 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 
 	return 0;
 }
+#endif /* CONFIG_LWM2M_CARRIER */
 
 void main(void)
 {


### PR DESCRIPTION
Added #ifdef CONFIG_LWM2M_CARRIER to main.c so that sample can be
built with the carrier library disabled. This is for calcultating
the carrier library's application footprint.

See NCSDK-5518

Signed-off-by: Richard McCrae <richard.mccrae@nordicsemi.no>