### PR TITLE
doc: rework wiki links

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -26,10 +26,6 @@
 .. |ncs_nrfxlib_repo| replace:: https://github.com/nrfconnect/nrfxlib
 .. _`nrfxlib`: https://github.com/nrfconnect/nrfxlib
 
-.. _`nRF Connect SDK changelog`: https://github.com/nrfconnect/sdk-nrf/wiki/Changelog
-
-.. _`master branch section in the changelog`: https://github.com/nrfconnect/sdk-nrf/wiki/Changelog#master-branch
-
 .. ### Links to Nordic documentation
 
 .. _`nRF Connect SDK v1.3.0 documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.3.0/nrf/index.html

--- a/doc/nrf/release_notes.rst
+++ b/doc/nrf/release_notes.rst
@@ -9,9 +9,9 @@ Important issues that are discovered after a release is tagged are listed on the
 
 .. important::
    A "99" at the end of the version number of this documentation indicates continuous updates on the master branch since the previous major.minor release.
-   Changes between releases that are merged into the master branch are tracked in the `nRF Connect SDK changelog`_ in the sdk-nrf repository wiki.
+   Changes between releases that are merged into the master branch are tracked on the :ref:`ncs_release_notes_latest` page, which is available only in the "99" version of documentation.
 
-   Note that there might be additional changes on the master branch that are not listed in the changelog.
+   Note that there might be additional changes on the master branch that are not listed on that page.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -16,7 +16,7 @@ The most relevant changes that are present on the master branch of the |NCS|, as
 Changelog
 *********
 
-See the `master branch section in the changelog`_ for a list of the most important changes.
+See the following sections for a list of the most important changes.
 
 
 sdk-mcuboot


### PR DESCRIPTION
Replace links to wiki with links to release-notes-latest.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>