### PR TITLE
Bluetooth: Mesh: Fix a sequence of response and publishing

### DIFF
--- a/include/bluetooth/mesh/gen_lvl.h
+++ b/include/bluetooth/mesh/gen_lvl.h
@@ -50,8 +50,6 @@ extern "C" {
 struct bt_mesh_lvl_set {
 	/** New level. */
 	int16_t lvl;
-	/** Whether this is a new action. */
-	bool new_transaction;
 	/**
 	 * Transition time parameters for the state change. Setting the
 	 * transition to NULL makes the server use its default transition time
@@ -82,8 +80,6 @@ struct bt_mesh_lvl_delta_set {
 struct bt_mesh_lvl_move_set {
 	/** Translation to make for every transition step. */
 	int16_t delta;
-	/** Whether this is a new action. */
-	bool new_transaction;
 	/**
 	 * Transition parameters. @c delay indicates time until the move
 	 * should start, @c transition indicates the amount of time each

--- a/subsys/bluetooth/mesh/gen_lvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_lvl_cli.c
@@ -80,16 +80,12 @@ int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
 			const struct bt_mesh_lvl_set *set,
 			struct bt_mesh_lvl_status *rsp)
 {
-	if (set->new_transaction) {
-		cli->tid++;
-	}
-
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_SET,
 				 BT_MESH_LVL_MSG_MAXLEN_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_SET);
 
 	net_buf_simple_add_le16(&msg, set->lvl);
-	net_buf_simple_add_u8(&msg, cli->tid);
+	net_buf_simple_add_u8(&msg, cli->tid++);
 	if (set->transition) {
 		model_transition_buf_add(&msg, set->transition);
 	}
@@ -103,16 +99,12 @@ int bt_mesh_lvl_cli_set_unack(struct bt_mesh_lvl_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
 			      const struct bt_mesh_lvl_set *set)
 {
-	if (set->new_transaction) {
-		cli->tid++;
-	}
-
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_SET_UNACK,
 				 BT_MESH_LVL_MSG_MAXLEN_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_SET_UNACK);
 
 	net_buf_simple_add_le16(&msg, set->lvl);
-	net_buf_simple_add_u8(&msg, cli->tid);
+	net_buf_simple_add_u8(&msg, cli->tid++);
 	if (set->transition) {
 		model_transition_buf_add(&msg, set->transition);
 	}
@@ -170,16 +162,12 @@ int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
 			     const struct bt_mesh_lvl_move_set *move_set,
 			     struct bt_mesh_lvl_status *rsp)
 {
-	if (move_set->new_transaction) {
-		cli->tid++;
-	}
-
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_MOVE_SET,
 				 BT_MESH_LVL_MSG_MAXLEN_MOVE_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_MOVE_SET);
 
 	net_buf_simple_add_le16(&msg, move_set->delta);
-	net_buf_simple_add_u8(&msg, cli->tid);
+	net_buf_simple_add_u8(&msg, cli->tid++);
 
 	if (move_set->transition) {
 		model_transition_buf_add(&msg, move_set->transition);
@@ -194,16 +182,12 @@ int bt_mesh_lvl_cli_move_set_unack(struct bt_mesh_lvl_cli *cli,
 				   struct bt_mesh_msg_ctx *ctx,
 				   const struct bt_mesh_lvl_move_set *move_set)
 {
-	if (move_set->new_transaction) {
-		cli->tid++;
-	}
-
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_MOVE_SET_UNACK,
 				 BT_MESH_LVL_MSG_MAXLEN_MOVE_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_MOVE_SET_UNACK);
 
 	net_buf_simple_add_le16(&msg, move_set->delta);
-	net_buf_simple_add_u8(&msg, cli->tid);
+	net_buf_simple_add_u8(&msg, cli->tid++);
 
 	if (move_set->transition) {
 		model_transition_buf_add(&msg, move_set->transition);

--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -26,17 +26,6 @@ static void encode_status(const struct bt_mesh_lvl_status *status,
 			      model_transition_encode(status->remaining_time));
 }
 
-static void transition_get(struct bt_mesh_lvl_srv *srv,
-			   struct bt_mesh_model_transition *transition,
-			   struct net_buf_simple *buf)
-{
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->model, transition);
-	}
-}
-
 static void rsp_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       const struct bt_mesh_lvl_status *status)
 {
@@ -78,7 +67,8 @@ static void set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	set.lvl = net_buf_simple_pull_le16(buf);
 	set.new_transaction = !tid_check_and_update(
 		&srv->tid, net_buf_simple_pull_u8(buf), ctx);
-	transition_get(srv, &transition, buf);
+
+	transition_get(srv->model, buf, &transition);
 	set.transition = &transition;
 
 	srv->handlers->set(srv, ctx, &set, &status);
@@ -110,7 +100,8 @@ static void delta_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	delta_set.delta = net_buf_simple_pull_le32(buf);
 	delta_set.new_transaction = !tid_check_and_update(
 		&srv->tid, net_buf_simple_pull_u8(buf), ctx);
-	transition_get(srv, &transition, buf);
+
+	transition_get(srv->model, buf, &transition);
 	delta_set.transition = &transition;
 
 	srv->handlers->delta_set(srv, ctx, &delta_set, &status);
@@ -142,7 +133,8 @@ static void move_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	move_set.delta = net_buf_simple_pull_le16(buf);
 	move_set.new_transaction = !tid_check_and_update(
 		&srv->tid, net_buf_simple_pull_u8(buf), ctx);
-	transition_get(srv, &transition, buf);
+
+	transition_get(srv->model, buf, &transition);
 	move_set.transition = &transition;
 
 	/* If transition.time is 0, we shouldn't move. Align these two

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -78,12 +78,7 @@ static void onoff_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		goto respond;
 	}
 
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, &transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
-	}
-
+	transition_get(srv->model, buf, &transition);
 	set.transition = &transition;
 
 	srv->handlers->set(srv, ctx, &set, &status);

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -84,17 +84,6 @@ static int pub(struct bt_mesh_plvl_srv *srv, struct bt_mesh_msg_ctx *ctx,
 	return model_send(srv->plvl_model, ctx, &msg);
 }
 
-static void transition_get(struct bt_mesh_plvl_srv *srv,
-			   struct bt_mesh_model_transition *transition,
-			   struct net_buf_simple *buf)
-{
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->plvl_model, transition);
-	}
-}
-
 static void rsp_plvl_status(struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct bt_mesh_plvl_status *status)
@@ -174,7 +163,8 @@ static void plvl_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 
 	set.power_lvl = net_buf_simple_pull_le16(buf);
 	tid = net_buf_simple_pull_u8(buf);
-	transition_get(srv, &transition, buf);
+
+	transition_get(srv->plvl_model, buf, &transition);
 	set.transition = &transition;
 
 	if (!tid_check_and_update(&srv->tid, tid, ctx)) {

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -412,11 +412,7 @@ static void lvl_set(struct bt_mesh_lvl_srv *lvl_srv,
 	};
 	struct bt_mesh_plvl_status status = { 0 };
 
-	if (lvl_set->new_transaction) {
-		change_lvl(srv, ctx, &set, &status);
-	} else if (rsp) {
-		srv->handlers->power_get(srv, NULL, &status);
-	}
+	change_lvl(srv, ctx, &set, &status);
 
 	if (rsp) {
 		rsp->current = POWER_TO_LVL(status.current);

--- a/subsys/bluetooth/mesh/gen_prop_srv.c
+++ b/subsys/bluetooth/mesh/gen_prop_srv.c
@@ -193,7 +193,11 @@ static void owner_property_set(struct bt_mesh_model *mod,
 		/* If the prop doesn't exist, we should only send the ID as a
 		 * response.
 		 */
-		goto respond;
+		if (ack) {
+			bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+		}
+
+		return;
 	}
 
 	set_user_access(srv, prop, user_access);
@@ -225,13 +229,12 @@ static void owner_property_set(struct bt_mesh_model *mod,
 		}
 	}
 
-	bt_mesh_prop_srv_pub(srv, NULL, &value);
-
 	net_buf_simple_add(&rsp, value.size);
-respond:
 	if (ack) {
 		bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
 	}
+
+	bt_mesh_prop_srv_pub(srv, NULL, &value);
 }
 
 static void handle_owner_property_set(struct bt_mesh_model *mod,
@@ -452,7 +455,11 @@ static void user_property_set(struct bt_mesh_model *mod,
 		/* If the prop doesn't exist, we should only send the ID as a
 		 * response.
 		 */
-		goto respond;
+		if (ack) {
+			bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+		}
+
+		return;
 	}
 
 	net_buf_simple_add_u8(&rsp, prop->user_access);
@@ -462,7 +469,11 @@ static void user_property_set(struct bt_mesh_model *mod,
 		/* IF write is not supported, we should only send the ID
 		 * and user_access as a response.
 		 */
-		goto respond;
+		if (ack) {
+			bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+		}
+
+		return;
 	}
 
 	struct bt_mesh_prop_val value = {
@@ -482,13 +493,11 @@ static void user_property_set(struct bt_mesh_model *mod,
 	}
 
 	net_buf_simple_add(&rsp, value.size);
-
-	bt_mesh_prop_srv_pub(user_srv, NULL, &value);
-
-respond:
 	if (ack) {
 		bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
 	}
+
+	bt_mesh_prop_srv_pub(user_srv, NULL, &value);
 }
 
 static void handle_user_property_set(struct bt_mesh_model *mod,

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -120,11 +120,7 @@ static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		goto respond;
 	}
 
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, &transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
-	}
+	transition_get(srv->model, buf, &transition);
 
 	srv->temp_srv.temp_last = temp;
 	srv->temp_srv.delta_uv_last = delta_uv;

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -167,6 +167,8 @@ static void light_set(struct bt_mesh_light_ctrl_srv *srv, uint16_t lvl,
 	struct bt_mesh_lightness_status dummy;
 
 	lightness_srv_change_lvl(srv->lightness, NULL, &set, &dummy);
+
+	bt_mesh_light_ctrl_srv_pub(srv, NULL);
 }
 
 static uint32_t curr_fade_time(struct bt_mesh_light_ctrl_srv *srv)

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -165,12 +165,8 @@ static void lvl_set(struct bt_mesh_lvl_srv *lvl_srv,
 	cb_msg.time = lvl_set->transition->time;
 	cb_msg.delay = lvl_set->transition->delay;
 
-	if (lvl_set->new_transaction) {
-		srv->handlers->set(srv, NULL, &cb_msg, &status);
-		srv->temp_last = temp;
-	} else if (rsp) {
-		srv->handlers->get(srv, NULL, &status);
-	}
+    srv->handlers->set(srv, NULL, &cb_msg, &status);
+    srv->temp_last = temp;
 
 	(void)bt_mesh_light_temp_srv_pub(srv, NULL, &status);
 

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -65,11 +65,7 @@ static void temp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		goto respond;
 	}
 
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, &transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
-	}
+	transition_get(srv->model, buf, &transition);
 
 	cb_msg.temp = &temp;
 	cb_msg.delta_uv = &delta_uv;

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -105,18 +105,6 @@ static int pub(struct bt_mesh_lightness_srv *srv, struct bt_mesh_msg_ctx *ctx,
 	return model_send(srv->lightness_model, ctx, &msg);
 }
 
-static void transition_get(struct bt_mesh_lightness_srv *srv,
-			   struct bt_mesh_model_transition *transition,
-			   struct net_buf_simple *buf)
-{
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->lightness_model,
-					       transition);
-	}
-}
-
 static void rsp_lightness_status(struct bt_mesh_model *mod,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct bt_mesh_lightness_status *status,
@@ -222,7 +210,8 @@ static void lightness_set(struct bt_mesh_model *mod,
 
 	set.lvl = repr_to_light(net_buf_simple_pull_le16(buf), repr);
 	tid = net_buf_simple_pull_u8(buf);
-	transition_get(srv, &transition, buf);
+
+	transition_get(srv->lightness_model, buf, &transition);
 	set.transition = &transition;
 
 	BT_DBG("Light set %s: %u [%u + %u ms]", repr_str[repr], set.lvl,

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -496,11 +496,7 @@ static void lvl_set(struct bt_mesh_lvl_srv *lvl_srv,
 	};
 	struct bt_mesh_lightness_status status = { 0 };
 
-	if (lvl_set->new_transaction) {
-		lightness_srv_change_lvl(srv, ctx, &set, &status);
-	} else if (rsp) {
-		srv->handlers->light_get(srv, NULL, &status);
-	}
+    lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 	if (rsp) {
 		rsp->current = LIGHT_TO_LVL(status.current);

--- a/subsys/bluetooth/mesh/model_utils.c
+++ b/subsys/bluetooth/mesh/model_utils.c
@@ -152,3 +152,16 @@ bool bt_mesh_model_pub_is_unicast(const struct bt_mesh_model *mod)
 {
 	return mod->pub && BT_MESH_ADDR_IS_UNICAST(mod->pub->addr);
 }
+
+void transition_get(struct bt_mesh_model *model,
+			struct net_buf_simple *buf,
+			struct bt_mesh_model_transition *transition)
+{
+	if (buf->len == 2) {
+		/* Message buffer contains transition parameters. */
+		model_transition_buf_pull(buf, transition);
+	} else {
+		/* Message buffer doesn't contain transition parameters. */
+		bt_mesh_dtt_srv_transition_get(model, transition);
+	}
+}

--- a/subsys/bluetooth/mesh/model_utils.h
+++ b/subsys/bluetooth/mesh/model_utils.h
@@ -157,6 +157,20 @@ model_transition_is_active(const struct bt_mesh_model_transition *transition)
 	return (transition->time > 0 || transition->delay > 0);
 }
 
+/** @brief Get the transition parameters from the received message buffer if
+ *         the message contains them or get the default transition parameters
+ *         for the given model.
+ *
+ * @param[in] model       Model instance receiving the message.
+ * @param[in] buf         Message buffer containing the message payload since
+ *                        the position of transition time field, even if the
+ *                        message doesn't really contain transition parameters.
+ * @param[out] transition Transition buffer.
+ */
+void transition_get(struct bt_mesh_model *model,
+			struct net_buf_simple *buf,
+			struct bt_mesh_model_transition *transition);
+
 #endif /* MODEL_UTILS_H__ */
 
 /** @} */

--- a/subsys/bluetooth/mesh/scene_srv.c
+++ b/subsys/bluetooth/mesh/scene_srv.c
@@ -91,6 +91,11 @@ static void scene_set(struct bt_mesh_scene_srv *srv, uint16_t scene)
 static void scene_recall(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf, bool ack)
 {
+	if (buf->len != BT_MESH_SCENE_MSG_MINLEN_RECALL &&
+		buf->len != BT_MESH_SCENE_MSG_MAXLEN_RECALL) {
+		return;
+	}
+
 	struct bt_mesh_scene_srv *srv = mod->user_data;
 	struct bt_mesh_model_transition transition;
 	enum bt_mesh_scene_status status;
@@ -104,13 +109,8 @@ static void scene_recall(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	}
 
 	tid = net_buf_simple_pull_u8(buf);
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, &transition);
-	} else if (!buf->len) {
-		bt_mesh_dtt_srv_transition_get(mod, &transition);
-	} else {
-		return;
-	}
+
+	transition_get(mod, buf, &transition);
 
 	if (tid_check_and_update(&srv->tid, tid, ctx)) {
 		BT_DBG("Duplicate TID");


### PR DESCRIPTION
According to the Mesh Model specification v1.0.1, the server should respond to the originator initially, and only after it the server should publish to the group address configured as the model's Publish Address. You can clearly see it шт 7.4.2.2 Generic OnOff Set.

Since transition_get() function or its functionality is the same for various Bluetooth Mesh server models, I added the common function to model_utils to not define it in each particular file.

`net_buf_simple_add_u8(buf, !!status->present_on_off);` - I supposed that double logical NOT operator (!) was merely a typo.

Unfortunately, I haven't found a clear explanation in Bluetooth Mesh specification about sending response and publishing in the case of transactions.

When a transaction identifier indicates that the message is a retransmission of a previously sent message, then how exactly should the model handle the message? Should it send a response to the originator and publish to the group or maybe it should only send the response without publishing? As I can see from the source code of the SDK of various models, now they have various logics. For example,

- `gen_onoff_srv.c:onoff_set` if a transaction is not new, then it only sends a response without publishing.
- `gen_lvl_srv.c:set` if a transaction is not new, then it sends a response and publishes to the group also.

Does "Mesh Profile 3.7.6.1.4 Publish retransmissions" suggest that SDK should publish each time, but if retransmissions of the previous message hasn't finished yet, then cancel it, and start to publish again? You can see such cancelation in logs: "bt_mesh_access: Clearing publish retransmit timer" from bt_mesh_model_publish() function. I am not sure that it exactly relates to the issue.
So, how is it correct to handle not new transactions? Should we send a response to the originator and publish the message each time again and again?

Also, it would be great to unify handling the new transaction in terms of calling set handle. When the transaction is not new, "gen_onoff_srv.c" calls `get` handler and go to a response, but "gen_lvl_srv.c" calls `set` handler both for new and not new transactions merely adding the flag new_transaction, so the `set` handle should have different logics of handling new and not new transactions.

> 3.3.1.2.2 Receiving a Generic OnOff Set / Generic OnOff Set Unacknowledged message
> When a Generic OnOff Server receives a Generic OnOff Set message or a Generic OnOff Set Unacknowledged message, it shall set the Generic OnOff state to the OnOff field of the message, unless the message has the same value for the SRC, DST, and TID fields as the previous message received within the past 6 seconds.

It seems that it would be logical to handle transactions on the side of SDK ("gen_lvl_srv.c"), and not add the flag new_transaction, and just call the user `set` handler when the transaction is new, as it is in "gen_onoff_srv.c". What do you think about it? It seems that it would be better to rid of "bool new_transaction;" flag from "struct bt_mesh_lvl_set" and call user `set` handler only in the case of new transactions.

Let's summarize. As I think, the correct flow of handling Set message on the server side is:

1. send a response to the originator
2. publish message to the publish address

Not all models follow this logic, so I wanted to clarify this point with you initially before modifying other models.
And another confusing part is transactions. What is the right flow of handling them, when the message is not new? Send a response and publish a message? Only send the response? Maybe do nothing :-)

Signed-off-by: Roman Alexeev <roman@alexeyev.su>