### PR TITLE
Bluetooth: Mesh: Make DK prov's UUID RFC-4122 compliant

### DIFF
--- a/subsys/bluetooth/mesh/dk_prov.c
+++ b/subsys/bluetooth/mesh/dk_prov.c
@@ -160,6 +160,31 @@ static const struct bt_mesh_prov prov = {
 
 const struct bt_mesh_prov *bt_mesh_dk_prov_init(void)
 {
+	/* Generate an RFC-4122 version 4 compliant UUID.
+	 * Format:
+	 *
+	 * 0                   1                   2                   3
+	 * 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |                          time_low                             |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |       time_mid                |         time_hi_and_version   |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |clk_seq_hi_res |  clk_seq_low  |         node (0-1)            |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |                         node (2-5)                            |
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 *
+	 * Where the 4 most significant bits of time_hi_and_version shall be
+	 * 0b0010 and the 2 most significant bits of clk_seq_hi_res shall be
+	 * 0b10. The remaining fields have no required values, and are fetched
+	 * from the HW info device ID. The fields are encoded in big endian
+	 * format.
+	 *
+	 * https://tools.ietf.org/html/rfc4122
+	 */
 	hwinfo_get_device_id(dev_uuid, sizeof(dev_uuid));
+	dev_uuid[6] = (dev_uuid[6] & BIT_MASK(4)) | BIT(6);
+	dev_uuid[8] = (dev_uuid[8] & BIT_MASK(6)) | BIT(7);
 	return &prov;
 }


### PR DESCRIPTION
Masks the required fields of the DK prov's generated UUID to make it
compilant with the RFC-4122 version 4 UUID.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>