### PR TITLE
Bluetooth: Mesh: Check DTT max value in dtt_cli

### DIFF
--- a/include/bluetooth/mesh/model_types.h
+++ b/include/bluetooth/mesh/model_types.h
@@ -20,7 +20,7 @@ extern "C" {
 #endif
 
 /** Maximum permissible transition time in milliseconds */
-#define BT_MESH_MODEL_TRANSITION_TIME_MAX_MS (K_MINUTES(10) * (0x3e))
+#define BT_MESH_MODEL_TRANSITION_TIME_MAX_MS (10 * 60 * MSEC_PER_SEC * 0x3e)
 
 /** Generic Transition parameters for the model messages. */
 struct bt_mesh_model_transition {

--- a/subsys/bluetooth/mesh/gen_dtt_cli.c
+++ b/subsys/bluetooth/mesh/gen_dtt_cli.c
@@ -65,6 +65,10 @@ int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 		    uint32_t transition_time, int32_t *rsp_transition_time)
 {
+	if (transition_time > BT_MESH_MODEL_TRANSITION_TIME_MAX_MS) {
+		return -EINVAL;
+	}
+
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DTT_OP_SET,
 				 BT_MESH_DTT_MSG_LEN_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_DTT_OP_SET);
@@ -79,6 +83,10 @@ int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 int bt_mesh_dtt_set_unack(struct bt_mesh_dtt_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx, uint32_t transition_time)
 {
+	if (transition_time > BT_MESH_MODEL_TRANSITION_TIME_MAX_MS) {
+		return -EINVAL;
+	}
+
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DTT_OP_SET_UNACK,
 				 BT_MESH_DTT_MSG_LEN_SET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_DTT_OP_SET_UNACK);


### PR DESCRIPTION
Adds check for the max value of the transition time passed to dtt_set
and dtt_set_unack, to match the documentation.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>