### PR TITLE
manifest: nrfxlib with updated SoftDevice Controller

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -419,9 +419,16 @@ static int hci_driver_open(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
-		err = sdc_support_adv();
-		if (err) {
-			return -ENOTSUP;
+		if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT)) {
+			err = sdc_support_ext_adv();
+			if (err) {
+				return -ENOTSUP;
+			}
+		} else {
+			err = sdc_support_adv();
+			if (err) {
+				return -ENOTSUP;
+			}
 		}
 	}
 
@@ -433,13 +440,13 @@ static int hci_driver_open(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_OBSERVER)) {
-		err = sdc_support_scan();
-		if (err) {
-			return -ENOTSUP;
-		}
-
 		if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT)) {
 			err = sdc_support_ext_scan();
+			if (err) {
+				return -ENOTSUP;
+			}
+		} else {
+			err = sdc_support_scan();
 			if (err) {
 				return -ENOTSUP;
 			}

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 80d4c109f8e704b25011325fca124c7fe395cda6
+      revision: 2d4bab0176100e266f5a0b6a5e49cb18de380ace
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Now extended advertising is also configurable

Corresponding PR in nrfxlib: https://github.com/nrfconnect/sdk-nrfxlib/pull/325

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>