### PR TITLE
doc: Rename Network operator certifications link

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -116,7 +116,7 @@
 
 .. _`anomaly 19`: https://infocenter.nordicsemi.com/topic/errata_nRF5340_EngA/ERR/nRF5340/EngineeringA/latest/anomaly_340_19.html
 
-.. _`nRF9160 compatibility matrix`: https://infocenter.nordicsemi.com/topic/comp_matrix_nrf9160/COMP/nrf9160/nrf9160_operator_certifications.html
+.. _`Mobile network operator certifications`: https://infocenter.nordicsemi.com/topic/comp_matrix_nrf9160/COMP/nrf9160/nrf9160_operator_certifications.html
 
 .. _`nAN34`: https://infocenter.nordicsemi.com/pdf/nan_34.pdf
 

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -96,7 +96,7 @@ You can download the firmware from the `nRF9160 product website (compatible down
 The zip file contains both the full firmware and patches to upgrade from one version to another.
 
 Different versions of the LTE modem firmware are available and these versions are certified for the mobile network operators who have their own certification programs.
-See the `nRF9160 compatibility matrix`_ for more information.
+See the `Mobile network operator certifications`_ for more information.
 
 .. note::
 

--- a/lib/bin/lwm2m_carrier/doc/certification.rst
+++ b/lib/bin/lwm2m_carrier/doc/certification.rst
@@ -11,7 +11,7 @@ Every released version of the LwM2M carrier library is considered for certificat
 The LwM2M carrier library is certified together with specific versions of the modem firmware and the |NCS|.
 Refer to the :ref:`liblwm2m_carrier_changelog` or the :ref:`versiondep_table` to check the certification status of a particular version of the library, and to see the version of the |NCS| it was released with.
 
-For a list of all the carrier certifications (including those certifications with no dependency on the LwM2M carrier library), see the `nRF9160 compatibility matrix`_.
+For a list of all the carrier certifications (including those certifications with no dependency on the LwM2M carrier library), see the `Mobile network operator certifications`_.
 
 .. note::
 


### PR DESCRIPTION
The link name refers to the parent name (compatibility matrix)
But it links to the child page network operator certifications.

This is just a small future-proofing change.

I did not see any .rst linking to any of the other child pages
or the parent page, but there might be in the future.

Signed-off-by: Håvard Vermeer <havard.vermeer@nordicsemi.no>