### PR TITLE
doc: lwm2m_carrier: documentation updates

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -469,6 +469,8 @@
 .. _`Secure Location Protocol (SLP)` : https://en.wikipedia.org/wiki/Service_Location_Protocol
 
 .. _`Verizon's Thingspace`: https://thingspace.verizon.com
+.. _`Verizon's Get certified program`: https://opendevelopment.verizonwireless.com/get-certified
+.. _`AT&T's Get network ready program`: https://iotdevices.att.com/networkready.aspx
 .. _`AT&T's IoT Platform`: https://iotplatform.att.com
 .. _`Pre-Shared Key (PSK)`: https://en.wikipedia.org/wiki/Pre-shared_key
 .. _`Mbed TLS`: https://en.wikipedia.org/wiki/Mbed_TLS

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -116,7 +116,7 @@
 
 .. _`anomaly 19`: https://infocenter.nordicsemi.com/topic/errata_nRF5340_EngA/ERR/nRF5340/EngineeringA/latest/anomaly_340_19.html
 
-.. _`nRF9160 compatibility matrix`: https://infocenter.nordicsemi.com/topic/comp_matrix_nrf9160/COMP/nrf9160/nrf9160_operator_certifications.html
+.. _`Mobile network operator certifications`: https://infocenter.nordicsemi.com/topic/comp_matrix_nrf9160/COMP/nrf9160/nrf9160_operator_certifications.html
 
 .. _`nAN34`: https://infocenter.nordicsemi.com/pdf/nan_34.pdf
 

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -96,7 +96,7 @@ You can download the firmware from the `nRF9160 product website (compatible down
 The zip file contains both the full firmware and patches to upgrade from one version to another.
 
 Different versions of the LTE modem firmware are available and these versions are certified for the mobile network operators who have their own certification programs.
-See the `nRF9160 compatibility matrix`_ for more information.
+See the `Mobile network operator certifications`_ for more information.
 
 .. note::
 

--- a/lib/bin/lwm2m_carrier/doc/certification.rst
+++ b/lib/bin/lwm2m_carrier/doc/certification.rst
@@ -11,7 +11,7 @@ Every released version of the LwM2M carrier library is considered for certificat
 The LwM2M carrier library is certified together with specific versions of the modem firmware and the |NCS|.
 Refer to the :ref:`liblwm2m_carrier_changelog` or the :ref:`versiondep_table` to check the certification status of a particular version of the library, and to see the version of the |NCS| it was released with.
 
-For a list of all the carrier certifications (including those certifications with no dependency on the LwM2M carrier library), see the `nRF9160 compatibility matrix`_.
+For a list of all the carrier certifications (including those certifications with no dependency on the LwM2M carrier library), see the `Mobile network operator certifications`_.
 
 .. note::
 

--- a/lib/bin/lwm2m_carrier/doc/certification.rst
+++ b/lib/bin/lwm2m_carrier/doc/certification.rst
@@ -9,7 +9,6 @@ Certification and version dependencies
 
 Every released version of the LwM2M carrier library is considered for certification with applicable carriers.
 The LwM2M carrier library is certified together with specific versions of the modem firmware and the |NCS|.
-Refer to the :ref:`liblwm2m_carrier_changelog` or the :ref:`versiondep_table` to check the certification status of a particular version of the library, and to see the version of the |NCS| it was released with.
 
 For a list of all the carrier certifications (including those certifications with no dependency on the LwM2M carrier library), see the `Mobile network operator certifications`_.
 
@@ -17,31 +16,4 @@ For a list of all the carrier certifications (including those certifications wit
 
    Your final product will need certification from the carrier.
    Please contact the carrier for more information on their respective device certification program.
-
-.. _versiondep_table:
-
-Version dependency table
-************************
-
-See the following table for the certification status of the library and the related version dependencies:
-
-+-----------------+---------------+---------------+---------------+
-| LwM2M carrier   | Modem version | |NCS| release | Certification |
-| library version |               |               |               |
-+=================+===============+===============+===============+
-| 0.10.0          | 1.1.4         | 1.4.0         |               |
-|                 |               |               |               |
-|                 | 1.2.2         |               |               |
-+-----------------+---------------+---------------+---------------+
-| 0.9.1           | 1.2.1         | 1.3.1         | AT&T          |
-+-----------------+---------------+---------------+---------------+
-| 0.9.0           | 1.2.1         | 1.3.0         |               |
-+-----------------+---------------+---------------+---------------+
-| 0.8.2           | 1.1.2         | 1.2.1         | Verizon       |
-+-----------------+---------------+---------------+---------------+
-| 0.8.1+build1    | 1.1.0         | 1.2.0         | Verizon       |
-+-----------------+---------------+---------------+---------------+
-| 0.8.0           | 1.1.0         | 1.1.0         |               |
-+-----------------+---------------+---------------+---------------+
-| 0.6.0           | 1.0.1         | 1.0.0         |               |
-+-----------------+---------------+---------------+---------------+
+   If your carrier is AT&T or Verizon Wireless, see `AT&T's Get network ready program`_, and `Verizon's Get certified program`_ for more information.


### PR DESCRIPTION
  * Added links to carrier's "get started" certification pages.
  * Removed version dependency table, now point to infocenter's
      Mobile network operator certifications.
  * Corrected the name of the link to operator certifications.