### PR TITLE
nRF5340 support in ESB library

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -36,6 +36,10 @@ nRF52832 SoC
 nRF5340 SoC
 -----------
 
+* Added:
+
+  * ``esb`` subsystem - Added support for nRF5340 SoC (CPUNET) in ESB subsystem.
+
 * Updated:
 
   * ``bl_boot`` library - Disabled clock interrupts before booting the application.

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -22,6 +22,17 @@ nRF5
 
 The following changes are relevant for the nRF52 and nRF53 Series.
 
+nRF52832 SoC
+------------
+
+* Removed:
+
+  * ``esb`` subystem - Removed support for older SoC revision workarounds.
+
+    * Removed support for nRF52832 revision 1 workarounds for Errata 102, Errata 106, and Errata 107.
+    * Removed support for nRF52832 revision 2 workarounds for Errata 143.
+
+
 nRF5340 SoC
 -----------
 

--- a/include/esb.h
+++ b/include/esb.h
@@ -25,11 +25,18 @@ extern "C" {
  *        acknowledgment, and automatic retransmission of lost packets.
  */
 
-
+#if defined(CONFIG_SOC_NRF5340_CPUNET)
+/** nRF5340 Errata 29 workaround (SWI interrupts missing in network core) */
+/** The ESB event IRQ number when running on an nRF5 device. */
+#define ESB_EVT_IRQ EGU0_IRQn
+/** The handler for @ref ESB_EVT_IRQ when running on an nRF5 device. */
+#define ESB_EVT_IRQHandler EGU0_IRQHandler
+#else
 /** The ESB event IRQ number when running on an nRF5 device. */
 #define ESB_EVT_IRQ SWI0_IRQn
 /** The handler for @ref ESB_EVT_IRQ when running on an nRF5 device. */
 #define ESB_EVT_IRQHandler SWI0_IRQHandler
+#endif
 
 /** @brief Default radio parameters.
  *
@@ -114,7 +121,7 @@ enum esb_bitrate {
 	/** 2 Mb radio mode. */
 	ESB_BITRATE_2MBPS = RADIO_MODE_MODE_Nrf_2Mbit,
 #if !(defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52810) ||          \
-      defined(CONFIG_SOC_NRF52811))
+      defined(CONFIG_SOC_NRF52811) || defined(CONFIG_SOC_NRF5340_CPUNET))
 	/** 250 Kb radio mode. */
 	ESB_BITRATE_250KBPS = RADIO_MODE_MODE_Nrf_250Kbit,
 #endif
@@ -136,7 +143,9 @@ enum esb_crc {
 /** @brief Enhanced ShockBurst radio transmission power modes. */
 enum esb_tx_power {
 	/** 4 dBm radio transmit power. */
+#if !defined(CONFIG_SOC_NRF5340_CPUNET)
 	ESB_TX_POWER_4DBM = RADIO_TXPOWER_TXPOWER_Pos4dBm,
+#endif
 #if defined(CONFIG_SOC_SERIES_NRF52X)
 	/** 3 dBm radio transmit power. */
 	ESB_TX_POWER_3DBM = RADIO_TXPOWER_TXPOWER_Pos3dBm,

--- a/samples/esb/prx/sample.yaml
+++ b/samples/esb/prx/sample.yaml
@@ -9,5 +9,5 @@ tests:
   samples.esb.prx.build:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpunet nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/esb/ptx/sample.yaml
+++ b/samples/esb/ptx/sample.yaml
@@ -9,5 +9,5 @@ tests:
   samples.esb.ptx.build:
     build_only: true
     build_on_all: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpunet nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/subsys/esb/Kconfig
+++ b/subsys/esb/Kconfig
@@ -45,36 +45,6 @@ config ESB_PIPE_COUNT
 
 menu "Hardware selection (alter with care)"
 
-config ESB_PPI_BUGFIX1
-	int "PPI channel used on nRF52832 to work around radio erratas."
-	default 11
-	range 0 19
-	help
-	  PPI channel used on nRF52832 to work around radio erratas. Note that
-	  this value can not overlap with PPI channels used by other subsystems.
-	  Only change this if you have an understanding of the other nRF5
-	  specific submodules your implementation is currently using.
-
-config ESB_PPI_BUGFIX2
-	int "PPI channel used on nRF52832 to work around radio erratas."
-	default 10
-	range 0 19
-	help
-	  PPI channel used on nRF52832 to work around radio erratas. Note that
-	  this value can not overlap with PPI channels used by other subsystems.
-	  Only change this if you have an understanding of the other nRF5
-	  specific submodules your implementation is currently using.
-
-config ESB_PPI_BUGFIX3
-	int "PPI channel used on nRF52832 to work around radio erratas."
-	default 9
-	range 0 19
-	help
-	  PPI channel used on nRF52832 to work around radio erratas. Note that
-	  this value can not overlap with PPI channels used by other subsystems.
-	  Only change this if you have an understanding of the other nRF5
-	  specific submodules your implementation is currently using.
-
 choice ESB_SYS_TIMER
 	default ESB_SYS_TIMER2
 	prompt "Timer to use for the ESB system timer."
@@ -95,38 +65,6 @@ config ESB_SYS_TIMER4
 	bool "TIMER4"
 
 endchoice
-
-config ESB_ADDR_HANG_BUGFIX
-	depends on SOC_NRF52832
-	bool "Apply address hang bugfix"
-	help
-	  Apply address hang bugfix.
-	  Only affects nRF52832 Rev. 1 SoCs.
-
-if ESB_ADDR_HANG_BUGFIX
-
-choice ESB_BUGFIX_TIMER
-	default ESB_BUGFIX_TIMER3
-	prompt "Timer to use for the ESB bugfix timer."
-
-config ESB_BUGFIX_TIMER0
-	bool "TIMER0"
-
-config ESB_BUGFIX_TIMER1
-	bool "TIMER1"
-
-config ESB_BUGFIX_TIMER2
-	bool "TIMER2"
-
-config ESB_BUGFIX_TIMER3
-	bool "TIMER3"
-
-config ESB_BUGFIX_TIMER4
-	bool "TIMER4"
-
-endchoice
-
-endif # ESB_ADDR_HANG_BUGFIX
 
 endmenu
 

--- a/subsys/esb/Kconfig
+++ b/subsys/esb/Kconfig
@@ -6,6 +6,8 @@
 
 menuconfig ESB
 	bool "Enhanced ShockBurst"
+	select NRFX_PPI if HAS_HW_NRF_PPI
+	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 	default n
 	help
 	  Enable ESB functionality.
@@ -42,46 +44,6 @@ config ESB_PIPE_COUNT
 	  this at 8 even if fewer pipes are used.
 
 menu "Hardware selection (alter with care)"
-
-config ESB_PPI_TIMER_START
-	int "PPI channel used to start the sys timer."
-	default 5
-	range 0 19
-	help
-	  PPI channel used to start the sys timer. Note that this value can not
-	  overlap with PPI channels used by other subsystems. Only change this
-	  if you have an understanding of the other nRF5 specific submodules
-	  your implementation is currently using.
-
-config ESB_PPI_TIMER_STOP
-	int "PPI channel used to stop the sys timer."
-	default 6
-	range 0 19
-	help
-	  PPI channel used to stop the sys timer. Note that this value can not
-	  overlap with PPI channels used by other subsystems. Only change this
-	  if you have an understanding of the other nRF5 specific submodules
-	  your implementation is currently using.
-
-config ESB_PPI_RX_TIMEOUT
-	int "PPI channel used to stop the radio when the timer expires."
-	default 7
-	range 0 19
-	help
-	  PPI channel used to stop the radio when the timer expires. Note
-	  that this value can not overlap with PPI channels used by other
-	  subsystems. Only change this if you have an understanding of the other
-	  nRF5 specific submodules your implementation is currently using.
-
-config ESB_PPI_TX_START
-	int "PPI channel used to start the radio when the timer expires."
-	default 8
-	range 0 19
-	help
-	  PPI channel used to start the radio when the timer expires. Note that
-	  this value can not overlap with PPI channels used by other subsystems.
-	  Only change this if you have an understanding of the other nRF5
-	  specific submodules your implementation is currently using.
 
 config ESB_PPI_BUGFIX1
 	int "PPI channel used on nRF52832 to work around radio erratas."

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -79,28 +79,6 @@
 #define ESB_SYS_TIMER_IRQn TIMER4_IRQn
 #endif
 
-#ifdef CONFIG_ESB_BUGFIX_TIMER0
-#define ESB_BUGFIX_TIMER NRF_TIMER0
-#define ESB_BUGFIX_TIMER_IRQn TIMER0_IRQn
-#endif
-#ifdef CONFIG_ESB_BUGFIX_TIMER1
-#define ESB_BUGFIX_TIMER NRF_TIMER1
-#define ESB_BUGFIX_TIMER_IRQn TIMER1_IRQn
-#endif
-#ifdef CONFIG_ESB_BUGFIX_TIMER2
-#define ESB_BUGFIX_TIMER NRF_TIMER2
-#define ESB_BUGFIX_TIMER_IRQn TIMER2_IRQn
-#endif
-#ifdef CONFIG_ESB_BUGFIX_TIMER3
-#define ESB_BUGFIX_TIMER NRF_TIMER3
-#define ESB_BUGFIX_TIMER_IRQn TIMER3_IRQn
-#endif
-#ifdef CONFIG_ESB_BUGFIX_TIMER4
-#define ESB_BUGFIX_TIMER NRF_TIMER4
-#define ESB_BUGFIX_TIMER_IRQn TIMER4_IRQn
-#endif
-
-
 /* Internal Enhanced ShockBurst module state. */
 enum esb_state {
 	ESB_STATE_IDLE,		/* Idle. */
@@ -246,69 +224,6 @@ static uint32_t bytewise_bit_swap(const uint8_t *input)
 static uint32_t addr_conv(const uint8_t *addr)
 {
 	return __REV(bytewise_bit_swap(addr));
-}
-
-static void apply_address_workarounds(void)
-{
-#ifdef CONFIG_SOC_NRF52832
-	/* Check if the device is an nRF52832 Rev. 1. */
-	if ((NRF_FICR->INFO.VARIANT & 0x0000FF00) == 0x00004200) {
-		/* Workaround for nRF52832 Rev 1 erratas */
-		/* Set up radio parameters. */
-		NRF_RADIO->MODECNF0 =
-			(NRF_RADIO->MODECNF0 & ~RADIO_MODECNF0_RU_Msk) |
-			RADIO_MODECNF0_RU_Default << RADIO_MODECNF0_RU_Pos;
-
-		/* Workaround for nRF52832 Rev 1 Errata 102 and nRF52832 Rev 1
-		 * Errata 106. This will reduce sensitivity by 3dB.
-		 */
-		*((volatile uint32_t *)0x40001774) =
-		    (*((volatile uint32_t *)0x40001774) & 0xFFFFFFFE) | 0x01000000;
-	}
-
-	/* Check if the device is an nRF52832 Rev. 2. */
-	if ((NRF_FICR->INFO.VARIANT & 0x0000FF00) == 0x00004500) {
-		/* Workaround for nRF52832 Rev 2 Errata 143
-		 * Check if the most significant bytes of address 0(including
-		 * prefix) match those of another address. It's recommended to
-		 * use a unique address 0 since this will avoid the 3dBm penalty
-		 * incurred from the workaround.
-		 */
-		uint32_t base_address_mask =
-			esb_addr.addr_length == 5 ? 0xFFFF0000 : 0xFF000000;
-
-		/* Load the two addresses before comparing them to ensure
-		 * defined ordering of volatile accesses.
-		 */
-		uint32_t addr0 = NRF_RADIO->BASE0 & base_address_mask;
-		uint32_t addr1 = NRF_RADIO->BASE1 & base_address_mask;
-
-		if (addr0 == addr1) {
-			uint32_t prefix0 = NRF_RADIO->PREFIX0 & 0x000000FF;
-			uint32_t prefix1 = (NRF_RADIO->PREFIX0 & 0x0000FF00) >> 8;
-			uint32_t prefix2 = (NRF_RADIO->PREFIX0 & 0x00FF0000) >> 16;
-			uint32_t prefix3 = (NRF_RADIO->PREFIX0 & 0xFF000000) >> 24;
-			uint32_t prefix4 = NRF_RADIO->PREFIX1 & 0x000000FF;
-			uint32_t prefix5 = (NRF_RADIO->PREFIX1 & 0x0000FF00) >> 8;
-			uint32_t prefix6 = (NRF_RADIO->PREFIX1 & 0x00FF0000) >> 16;
-			uint32_t prefix7 = (NRF_RADIO->PREFIX1 & 0xFF000000) >> 24;
-
-			if (prefix0 == prefix1 || prefix0 == prefix2 ||
-			    prefix0 == prefix3 || prefix0 == prefix4 ||
-			    prefix0 == prefix5 || prefix0 == prefix6 ||
-			    prefix0 == prefix7) {
-				/* This will cause a 3dBm sensitivity loss,
-				 * avoid using such address combinations if
-				 * possible.
-				 */
-				*(volatile uint32_t *)0x40001774 =
-					((*(volatile uint32_t *)0x40001774) &
-					 0xfffffffe) |
-					0x01000000;
-			}
-		}
-	}
-#endif
 }
 
 static void update_rf_payload_format_esb_dpl(uint32_t payload_length)
@@ -988,23 +903,6 @@ static void ESB_SYS_TIMER_IRQHandler(void)
 {
 }
 
-#ifdef CONFIG_ESB_ADDR_HANG_BUGFIX
-/* Workaround necessary on nRF52832 Rev. 1. */
-static void ESB_BUGFIX_TIMER_IRQHandler(void)
-{
-	if (ESB_BUGFIX_TIMER->EVENTS_COMPARE[0]) {
-		ESB_BUGFIX_TIMER->EVENTS_COMPARE[0] = 0;
-
-		/* If the timeout timer fires and we are in the PTX receive ACK
-		 * state, disable the radio
-		 */
-		if (esb_state == ESB_STATE_PTX_RX_ACK) {
-			NRF_RADIO->TASKS_DISABLE = 1;
-		}
-	}
-}
-#endif
-
 int esb_init(const struct esb_config *config)
 {
 	if (config == NULL) {
@@ -1046,54 +944,6 @@ int esb_init(const struct esb_config *config)
 	irq_enable(RADIO_IRQn);
 	irq_enable(SWI0_IRQn);
 	irq_enable(ESB_SYS_TIMER_IRQn);
-
-#ifdef CONFIG_ESB_ADDR_HANG_BUGFIX
-	/* Check if the device is an nRF52832 Rev. 1. */
-	if ((NRF_FICR->INFO.VARIANT & 0x0000FF00) == 0x00004200) {
-		/* Setup a timeout timer to start on an ADDRESS match,
-		 * and stop on a BCMATCH event.
-		 */
-		/* If the BCMATCH event never occurs the CC[0] event
-		 * will fire, and the timer interrupt will disable the
-		 * radio to recover.
-		 */
-		radio_shorts_common |= RADIO_SHORTS_ADDRESS_BCSTART_Msk;
-		NRF_RADIO->BCC = 2;
-		ESB_BUGFIX_TIMER->BITMODE = TIMER_BITMODE_BITMODE_32Bit
-					    << TIMER_BITMODE_BITMODE_Pos;
-		ESB_BUGFIX_TIMER->PRESCALER = 4;
-		ESB_BUGFIX_TIMER->CC[0] = 5;
-		ESB_BUGFIX_TIMER->SHORTS = TIMER_SHORTS_COMPARE0_STOP_Msk |
-					   TIMER_SHORTS_COMPARE0_CLEAR_Msk;
-		ESB_BUGFIX_TIMER->MODE = TIMER_MODE_MODE_Timer
-					 << TIMER_MODE_MODE_Pos;
-		ESB_BUGFIX_TIMER->INTENSET = TIMER_INTENSET_COMPARE0_Msk;
-		ESB_BUGFIX_TIMER->TASKS_CLEAR = 1;
-
-		IRQ_DIRECT_CONNECT(ESB_BUGFIX_TIMER_IRQn,
-				   config->event_irq_priority,
-				   ESB_BUGFIX_TIMER_IRQHandler, 0);
-
-		NRF_PPI->CH[CONFIG_ESB_PPI_BUGFIX1].EEP =
-		    (uint32_t)&NRF_RADIO->EVENTS_ADDRESS;
-		NRF_PPI->CH[CONFIG_ESB_PPI_BUGFIX1].TEP =
-		    (uint32_t)&ESB_BUGFIX_TIMER->TASKS_START;
-
-		NRF_PPI->CH[CONFIG_ESB_PPI_BUGFIX2].EEP =
-		    (uint32_t)&NRF_RADIO->EVENTS_BCMATCH;
-		NRF_PPI->CH[CONFIG_ESB_PPI_BUGFIX2].TEP =
-		    (uint32_t)&ESB_BUGFIX_TIMER->TASKS_SHUTDOWN;
-
-		NRF_PPI->CH[CONFIG_ESB_PPI_BUGFIX3].EEP =
-		    (uint32_t)&NRF_RADIO->EVENTS_BCMATCH;
-		NRF_PPI->CH[CONFIG_ESB_PPI_BUGFIX3].TEP =
-		    (uint32_t)&ESB_BUGFIX_TIMER->TASKS_CLEAR;
-
-		NRF_PPI->CHENSET = (1 << CONFIG_ESB_PPI_BUGFIX1) |
-				   (1 << CONFIG_ESB_PPI_BUGFIX2) |
-				   (1 << CONFIG_ESB_PPI_BUGFIX3);
-	}
-#endif
 
 	esb_state = ESB_STATE_IDLE;
 	esb_initialized = true;
@@ -1361,57 +1211,9 @@ int esb_set_address_length(uint8_t length)
 		return -EINVAL;
 	}
 
-#ifdef CONFIG_SOC_NRF52832
-	uint32_t base_address_mask = length == 5 ? 0xFFFF0000 : 0xFF000000;
-
-	/* Check if the device is an nRF52832 Rev. 1. */
-	if ((NRF_FICR->INFO.VARIANT & 0x0000FF00) == 0x00004200) {
-		/*
-		 * Workaround for nRF52832 Rev 1 Errata 107
-		 * Check if pipe 0 or pipe 1-7 has a 'zero address'.
-		 * Avoid using access addresses in the following pattern
-		 * (where X is don't care):
-		 * ADDRLEN=5
-		 * BASE0 = 0x0000XXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0x00XXXXXX
-		 *
-		 * ADDRLEN=4
-		 * BASE0 = 0x00XXXXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0x00XXXXXX
-		 */
-		if ((NRF_RADIO->BASE0 & base_address_mask) == 0 &&
-		    (NRF_RADIO->PREFIX0 & 0x000000FF) == 0) {
-			return -EINVAL;
-		}
-		if ((NRF_RADIO->BASE1 & base_address_mask) == 0 &&
-		    ((NRF_RADIO->PREFIX0 & 0x0000FF00) == 0 ||
-		     (NRF_RADIO->PREFIX0 & 0x00FF0000) == 0 ||
-		     (NRF_RADIO->PREFIX0 & 0xFF000000) == 0 ||
-		     (NRF_RADIO->PREFIX1 & 0xFF000000) == 0 ||
-		     (NRF_RADIO->PREFIX1 & 0x00FF0000) == 0 ||
-		     (NRF_RADIO->PREFIX1 & 0x0000FF00) == 0 ||
-		     (NRF_RADIO->PREFIX1 & 0x000000FF) == 0)) {
-			return -EINVAL;
-		}
-	}
-#endif
-
 	esb_addr.addr_length = length;
 
 	update_rf_payload_format(esb_cfg.payload_length);
-	apply_address_workarounds();
 
 	return 0;
 }
@@ -1425,47 +1227,9 @@ int esb_set_base_address_0(const uint8_t *addr)
 		return -EINVAL;
 	}
 
-#ifdef CONFIG_SOC_NRF52832
-	/* Check if the device is an nRF52832 Rev. 1. */
-	if ((NRF_FICR->INFO.VARIANT & 0x0000FF00) == 0x00004200) {
-		/*
-		 * Workaround for nRF52832 Rev 1 Errata 107
-		 * Check if pipe 0 or pipe 1-7 has a 'zero address'.
-		 * Avoid using access addresses in the following pattern
-		 * (where X is don't care):
-		 * ADDRLEN=5
-		 * BASE0 = 0x0000XXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0x00XXXXXX
-		 *
-		 * ADDRLEN=4
-		 * BASE0 = 0x00XXXXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0x00XXXXXX
-		 */
-		uint32_t base_address_mask =
-			esb_addr.addr_length == 5 ? 0xFFFF0000 : 0xFF000000;
-		if ((addr_conv(addr) & base_address_mask) == 0 &&
-		    (NRF_RADIO->PREFIX0 & 0x000000FF) == 0) {
-			return -EINVAL;
-		}
-	}
-#endif
-
 	memcpy(esb_addr.base_addr_p0, addr, sizeof(esb_addr.base_addr_p0));
 
 	update_radio_addresses(ADDR_UPDATE_MASK_BASE0);
-	apply_address_workarounds();
 
 	return 0;
 }
@@ -1479,53 +1243,9 @@ int esb_set_base_address_1(const uint8_t *addr)
 		return -EINVAL;
 	}
 
-#ifdef CONFIG_SOC_NRF52832
-	/* Check if the device is an nRF52832 Rev. 1. */
-	{
-		/*
-		 * Workaround for nRF52832 Rev 1 Errata 107
-		 * Check if pipe 0 or pipe 1-7 has a 'zero address'.
-		 * Avoid using access addresses in the following pattern
-		 * (where X is don't care):
-		 * ADDRLEN=5
-		 * BASE0 = 0x0000XXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0x00XXXXXX
-		 *
-		 * ADDRLEN=4
-		 * BASE0 = 0x00XXXXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0x00XXXXXX
-		 */
-		uint32_t base_address_mask =
-			esb_addr.addr_length == 5 ? 0xFFFF0000 : 0xFF000000;
-		if ((addr_conv(addr) & base_address_mask) == 0 &&
-		    ((NRF_RADIO->PREFIX0 & 0x0000FF00) == 0 ||
-		     (NRF_RADIO->PREFIX0 & 0x00FF0000) == 0 ||
-		     (NRF_RADIO->PREFIX0 & 0xFF000000) == 0 ||
-		     (NRF_RADIO->PREFIX1 & 0xFF000000) == 0 ||
-		     (NRF_RADIO->PREFIX1 & 0x00FF0000) == 0 ||
-		     (NRF_RADIO->PREFIX1 & 0x0000FF00) == 0 ||
-		     (NRF_RADIO->PREFIX1 & 0x000000FF) == 0)) {
-			return -EINVAL;
-		}
-	}
-#endif
-
 	memcpy(esb_addr.base_addr_p1, addr, sizeof(esb_addr.base_addr_p1));
 
 	update_radio_addresses(ADDR_UPDATE_MASK_BASE1);
-	apply_address_workarounds();
 
 	return 0;
 }
@@ -1542,59 +1262,11 @@ int esb_set_prefixes(const uint8_t *prefixes, uint8_t num_pipes)
 		return -EINVAL;
 	}
 
-#ifdef CONFIG_SOC_NRF52832
-	/* Check if the device is an nRF52832 Rev. 1. */
-	if ((NRF_FICR->INFO.VARIANT & 0x0000FF00) == 0x00004200) {
-		/*
-		 * Workaround for nRF52832 Rev 1 Errata 107
-		 * Check if pipe 0 or pipe 1-7 has a 'zero address'.
-		 * Avoid using access addresses in the following pattern
-		 * (where X is don't care):
-		 * ADDRLEN=5
-		 * BASE0 = 0x0000XXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0x00XXXXXX
-		 *
-		 * ADDRLEN=4
-		 * BASE0 = 0x00XXXXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0x00XXXXXX
-		 */
-		uint32_t base_address_mask =
-			esb_addr.addr_length == 5 ? 0xFFFF0000 : 0xFF000000;
-
-		if (num_pipes >= 1 &&
-		    (NRF_RADIO->BASE0 & base_address_mask) == 0 &&
-		    prefixes[0] == 0) {
-			return -EINVAL;
-		}
-
-		if ((NRF_RADIO->BASE1 & base_address_mask) == 0) {
-			for (uint8_t i = 1; i < num_pipes; i++) {
-				if (prefixes[i] == 0) {
-					return -EINVAL;
-				}
-			}
-		}
-	}
-#endif
-
 	memcpy(esb_addr.pipe_prefixes, prefixes, num_pipes);
 	esb_addr.num_pipes = num_pipes;
 	esb_addr.rx_pipes_enabled = BIT_MASK_UINT_8(num_pipes);
 
 	update_radio_addresses(ADDR_UPDATE_MASK_PREFIX);
-	apply_address_workarounds();
 
 	return 0;
 }
@@ -1608,53 +1280,9 @@ int esb_update_prefix(uint8_t pipe, uint8_t prefix)
 		return -EINVAL;
 	}
 
-#ifdef CONFIG_SOC_NRF52832
-	/* Check if the device is an nRF52832 Rev. 1. */
-	if ((NRF_FICR->INFO.VARIANT & 0x0000FF00) == 0x00004200) {
-		/*
-		 * Workaround for nRF52832 Rev 1 Errata 107
-		 * Check if pipe 0 or pipe 1-7 has a 'zero address'.
-		 * Avoid using access addresses in the following pattern
-		 * (where X is don't care):
-		 * ADDRLEN=5
-		 * BASE0 = 0x0000XXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x0000XXXX, PREFIX1 = 0x00XXXXXX
-		 *
-		 * ADDRLEN=4
-		 * BASE0 = 0x00XXXXXX, PREFIX0 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX0 = 0x00XXXXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXXXX00
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXXXX00XX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0xXX00XXXX
-		 * BASE1 = 0x00XXXXXX, PREFIX1 = 0x00XXXXXX
-		 */
-		uint32_t base_address_mask =
-			esb_addr.addr_length == 5 ? 0xFFFF0000 : 0xFF000000;
-		if (pipe == 0) {
-			if ((NRF_RADIO->BASE0 & base_address_mask) == 0 &&
-			    prefix == 0) {
-				return -EINVAL;
-			}
-		} else {
-			if ((NRF_RADIO->BASE1 & base_address_mask) == 0 &&
-			    prefix == 0) {
-				return -EINVAL;
-			}
-		}
-	}
-#endif
 	esb_addr.pipe_prefixes[pipe] = prefix;
 
 	update_radio_addresses(ADDR_UPDATE_MASK_PREFIX);
-	apply_address_workarounds();
 
 	return 0;
 }
@@ -1670,7 +1298,6 @@ int esb_enable_pipes(uint8_t enable_mask)
 	}
 
 	esb_addr.rx_pipes_enabled = enable_mask;
-	apply_address_workarounds();
 
 	return 0;
 }


### PR DESCRIPTION
Changes:
- Support added for the nRF5340 network core
- nRF52832 rev 1 workarounds removed
- nrfx_ppi and nrfx_dppi support added