### PR TITLE
bootloader: add minimal overlay for b0

### DIFF
--- a/doc/nrf/ug_bootloader.rst
+++ b/doc/nrf/ug_bootloader.rst
@@ -110,6 +110,18 @@ To add the immutable bootloader to your application, set :option:`CONFIG_SECURE_
 See the documentation of the :ref:`bootloader` sample for more information.
 The :ref:`bootloader_build_and_run` section has detailed instructions for adding the immutable bootloader as first stage of the secure bootloader chain.
 
+To ensure that the immutable bootloader occupies as little flash as possible, apply the :file:`overlay-minimal-size.conf` Kconfig overlay file for the b0 image.
+This can be done in the following way:
+
+* Using cmake::
+
+     cmake -GNinja -DBOARD=nrf52840dk_nrf5840 -Db0_OVERLAY_CONFIG=overlay-minimal-size.conf -DCONFIG_SECURE_BOOT=y ../
+
+* Using west::
+
+     west build -b nrf52840dk_nrf52840 zephyr/samples/hello_world -- -Db0_OVERLAY_CONFIG=overlay-minimal-size.conf -DCONFIG_SECURE_BOOT=y
+
+
 Adding MCUboot as an upgradable bootloader
 ==========================================
 
@@ -124,12 +136,12 @@ Set option :option:`CONFIG_SECURE_BOOT` to do this.
    In this case, MCUboot will act as an immutable bootloader.
 
 It is possible for MCUboot to use the cryptographic functionality exposed by the immutable bootloader, reducing the flash usage for MCUboot to less than 16 kB.
-To enable this configuration, apply the :file:`overlay-minimal-size.conf` Kconfig overlay file for the MCUboot image.
+To enable this configuration, apply the :file:`overlay-minimal-external-crypto.conf` Kconfig overlay file for the MCUboot image.
 This can be done in the following way:
 
 * Using cmake::
 
-     cmake -GNinja -DBOARD=nrf52840dk_nrf5840 -Dmcuboot_OVERLAY_CONFIG=overlay-minimal-size.conf -DCONFIG_SECURE_BOOT=y -DCONFIG_BOOTLOADER_MCUBOOT=y ../
+     cmake -GNinja -DBOARD=nrf52840dk_nrf5840 -Dmcuboot_OVERLAY_CONFIG=overlay-minimal-external-crypto.conf -DCONFIG_SECURE_BOOT=y -DCONFIG_BOOTLOADER_MCUBOOT=y ../
 
 * Using west::
 

--- a/samples/bootloader/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bootloader/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# CC3xx is currently not used for nrf53
+CONFIG_HW_CC3XX=n
+CONFIG_NRF_CC3XX_PLATFORM=n

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -158,8 +158,12 @@ config PM_PARTITION_SIZE_PROVISION
 	help
 	  Flash space set aside for the PROVISION partition.
 
+config B0_MIN_PARTITION_SIZE
+	bool "Use minimimum partition size"
+
 config PM_PARTITION_SIZE_B0_IMAGE
 	hex "Flash space reserved for B0_IMAGE"
+	default 0x8000 if !B0_MIN_PARTITION_SIZE
 	default FPROTECT_BLOCK_SIZE if SOC_NRF9160 || SOC_NRF5340_CPUAPP
 	default 0x3800 if SOC_NRF5340_CPUNET
 	default 0x7000


### PR DESCRIPTION
Also disable CC3xx for nrf53 as it is not supported currently.

Ref: NCSDK-6699
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>