### PR TITLE
doc: Fix Sphinx 3.3.1 warnings

### DIFF
--- a/.known-issues/doc/duplicate.conf
+++ b/.known-issues/doc/duplicate.conf
@@ -1,6 +1,6 @@
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]include[/\\]bluetooth[/\\]mesh[/\\]light_ctl_cli.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C declaration, also defined in (.*)\.\s?
+^(?P<filename>([\-:\\/\w\.])+[/\\]include[/\\]bluetooth[/\\]mesh[/\\]light_ctl_cli.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C declaration, also defined (in|at) (.*)\.\s?
 ^Declaration is \'.*\'\.\s?
 #
-^(?P<filename>([\-:\\/\w\.])+[/\\]include[/\\]bluetooth[/\\]services[/\\]dfu_smp.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C declaration, also defined in (.*)\.\s?
+^(?P<filename>([\-:\\/\w\.])+[/\\]include[/\\]bluetooth[/\\]services[/\\]dfu_smp.rst):(?P<lineno>[0-9]+): WARNING: Duplicate C declaration, also defined (in|at) (.*)\.\s?
 ^Declaration is \'.*\'\.\s?

--- a/doc/nrf/doc_styleguide.rst
+++ b/doc/nrf/doc_styleguide.rst
@@ -1,6 +1,6 @@
-.. _doc_styleguide:
-
 .. |sg| replace:: style guide
+
+.. _doc_styleguide:
 
 Documentation |sg|
 ##################


### PR DESCRIPTION
Fixes two issues building on Sphinx==3.3.1. This should be merged once the Docker image is updated from 3.2.1 to 3.3.1.