### PR TITLE
manifest: update softdevice controller and mpsl

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -655,7 +655,7 @@ DRGN-9083: AAR populated with zero IRK
 
 .. rst-class:: v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
-DRGN-10659: Directed advertising issues using RPA in TargetA
+DRGN-13921: Directed advertising issues using RPA in TargetA
   The SoftDevice Controller will generate a resolvable address for the TargetA field in directed advertisements if the target device address is in the resolving list with a non-zero IRK, even if privacy is not enabled and the local device address is set to a public address.
 
   **Workaround:** Remove the device address from the resolving list.

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 2d4bab0176100e266f5a0b6a5e49cb18de380ace
+      revision: 31c4bf8bc789beed0d5eb4f6e7b2995cb3ffa909
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Fixed an issue where a directed advertiser used a resolvable address as
the TargetA when the local device address was set to public or random
device address

Update MPSL and SoftDevice Controller:
nrfconnect/sdk-nrfxlib#326

Signed-off-by: Ryan Chu <ryan.chu@nordicsemi.no>