### PR TITLE
net: lib: Cleanup and align generic cloud API across backends.

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -578,7 +578,7 @@ static void send_modem_at_cmd_work_fn(struct k_work *work)
 	};
 	struct cloud_msg msg = {
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
-		.endpoint.type = CLOUD_EP_TOPIC_MSG
+		.endpoint.type = CLOUD_EP_MSG
 	};
 	size_t len = strlen(modem_at_cmd_buff);
 
@@ -843,7 +843,7 @@ static void motion_data_send(struct k_work *work)
 
 	struct cloud_msg msg = {
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
-		.endpoint.type = CLOUD_EP_TOPIC_MSG
+		.endpoint.type = CLOUD_EP_MSG
 	};
 
 	int err = 0;
@@ -1057,7 +1057,7 @@ static void device_status_send(struct k_work *work)
 
 	struct cloud_msg msg = {
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
-		.endpoint.type = CLOUD_EP_TOPIC_STATE
+		.endpoint.type = CLOUD_EP_STATE
 	};
 
 	ret = cloud_encode_device_status_data(modem_ptr,
@@ -1084,7 +1084,7 @@ static void device_config_send(struct k_work *work)
 	int ret;
 	struct cloud_msg msg = {
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
-		.endpoint.type = CLOUD_EP_TOPIC_STATE
+		.endpoint.type = CLOUD_EP_STATE
 	};
 	enum cloud_cmd_state gps_cfg_state =
 		cloud_get_channel_enable_state(CLOUD_CHANNEL_GPS);
@@ -1125,7 +1125,7 @@ static void env_data_send(void)
 	env_sensor_data_t env_data;
 	struct cloud_msg msg = {
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
-		.endpoint.type = CLOUD_EP_TOPIC_MSG
+		.endpoint.type = CLOUD_EP_MSG
 	};
 
 	if (!data_send_enabled()) {
@@ -1198,7 +1198,7 @@ void light_sensor_data_send(void)
 	int err;
 	struct light_sensor_data light_data;
 	struct cloud_msg msg = { .qos = CLOUD_QOS_AT_MOST_ONCE,
-				 .endpoint.type = CLOUD_EP_TOPIC_MSG };
+				 .endpoint.type = CLOUD_EP_MSG };
 
 	if (!data_send_enabled() || gps_control_is_active()) {
 		return;
@@ -1242,7 +1242,7 @@ static void sensor_data_send(struct cloud_channel_data *data)
 	int err = 0;
 	struct cloud_msg msg = {
 			.qos = CLOUD_QOS_AT_MOST_ONCE,
-			.endpoint.type = CLOUD_EP_TOPIC_MSG
+			.endpoint.type = CLOUD_EP_MSG
 		};
 
 	if (!data_send_enabled() || gps_control_is_active()) {

--- a/include/net/cloud.h
+++ b/include/net/cloud.h
@@ -15,33 +15,40 @@
 
 #include <zephyr.h>
 
-/**@brief Cloud backend states. */
-enum cloud_state {
-	CLOUD_STATE_DISCONNECTED,
-	CLOUD_STATE_DISCONNECTING,
-	CLOUD_STATE_CONNECTED,
-	CLOUD_STATE_CONNECTING,
-	CLOUD_STATE_BUSY,
-	CLOUD_STATE_ERROR,
-	CLOUD_STATE_COUNT
-};
-
 /**@brief Cloud events that can be notified asynchronously by the backend. */
 enum cloud_event_type {
+	/** The cloud backend is connecting to the configured cloud vendor. */
 	CLOUD_EVT_CONNECTING,
+	/** The cloud backend is connected to the cloud. */
 	CLOUD_EVT_CONNECTED,
+	/** The cloud backend got disconnected from the cloud. */
 	CLOUD_EVT_DISCONNECTED,
+	/** The cloud backend has established the appropriate resources for the
+	 *  connection.
+	 */
 	CLOUD_EVT_READY,
+	/** An error has occurred in the cloud backend. */
 	CLOUD_EVT_ERROR,
+	/** Data has been sent to the cloud. */
 	CLOUD_EVT_DATA_SENT,
+	/** Data has been received from the cloud. */
 	CLOUD_EVT_DATA_RECEIVED,
+	/** The device is not yet associated with the user. Pairing requested.
+	 */
 	CLOUD_EVT_PAIR_REQUEST,
+	/** Pairing with the user has been carried out. */
 	CLOUD_EVT_PAIR_DONE,
+	/** FOTA has started. */
 	CLOUD_EVT_FOTA_START,
+	/** FOTA has finished. */
 	CLOUD_EVT_FOTA_DONE,
+	/** The underlying FOTA process has a pending image erase. */
 	CLOUD_EVT_FOTA_ERASE_PENDING,
+	/** The FOTA image erase has finished. */
 	CLOUD_EVT_FOTA_ERASE_DONE,
+	/** FOTA download progress event. */
 	CLOUD_EVT_FOTA_DL_PROGRESS,
+
 	CLOUD_EVT_COUNT
 };
 
@@ -53,6 +60,7 @@ enum cloud_disconnect_reason {
 	CLOUD_DISCONNECT_INVALID_REQUEST,
 	/** Miscellaneous error */
 	CLOUD_DISCONNECT_MISC,
+
 	CLOUD_DISCONNECT_COUNT
 };
 
@@ -61,18 +69,23 @@ enum cloud_qos {
 	CLOUD_QOS_AT_MOST_ONCE,
 	CLOUD_QOS_AT_LEAST_ONCE,
 	CLOUD_QOS_EXACTLY_ONCE,
+
 	CLOUD_QOS_COUNT
 };
 
 /**@brief Cloud endpoint type. */
 enum cloud_endpoint_type {
-	CLOUD_EP_TOPIC_MSG,
-	CLOUD_EP_TOPIC_STATE,
-	CLOUD_EP_TOPIC_STATE_DELETE,
-	CLOUD_EP_TOPIC_CONFIG,
-	CLOUD_EP_TOPIC_PAIR,
-	CLOUD_EP_TOPIC_BATCH,
-	CLOUD_EP_URI,
+	/** Endpoint used to send messages to cloud. */
+	CLOUD_EP_MSG,
+	/** Endpoint used to update the cloud-side device state. */
+	CLOUD_EP_STATE,
+	/** Endpoint used to delete the cloud-side device state. */
+	CLOUD_EP_STATE_DELETE,
+	/** Enpoint used to request the cloud-side device state. */
+	CLOUD_EP_STATE_GET,
+	/** Endpoint used to pair the device with a user. */
+	CLOUD_EP_PAIR,
+
 	CLOUD_EP_COMMON_COUNT,
 	CLOUD_EP_PRIV_START = CLOUD_EP_COMMON_COUNT,
 	CLOUD_EP_PRIV_END = INT16_MAX
@@ -83,12 +96,13 @@ enum cloud_connect_result {
 	CLOUD_CONNECT_RES_SUCCESS = 0,
 	/** Cloud backend is not initialized. */
 	CLOUD_CONNECT_RES_ERR_NOT_INITD = -1,
+	/** Invalid parameters in cloud connection request. */
 	CLOUD_CONNECT_RES_ERR_INVALID_PARAM = -2,
 	/** Host cannot be found with the available network interfaces. */
 	CLOUD_CONNECT_RES_ERR_NETWORK = -3,
 	/** A backend-specific error. */
 	CLOUD_CONNECT_RES_ERR_BACKEND = -4,
-    /** Error cause cannot be determined.*/
+	/** Error cause cannot be determined.*/
 	CLOUD_CONNECT_RES_ERR_MISC = -5,
 	/** MQTT RX/TX buffers were not initialized. */
 	CLOUD_CONNECT_RES_ERR_NO_MEM = -6,

--- a/samples/nrf9160/agps/src/main.c
+++ b/samples/nrf9160/agps/src/main.c
@@ -37,7 +37,7 @@ static void cloud_send_msg(void)
 
 	struct cloud_msg msg = {
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
-		.endpoint.type = CLOUD_EP_TOPIC_MSG,
+		.endpoint.type = CLOUD_EP_MSG,
 		.buf = CONFIG_CLOUD_MESSAGE,
 		.len = sizeof(CONFIG_CLOUD_MESSAGE)
 	};
@@ -87,7 +87,7 @@ static void send_service_info(void)
 	int err;
 	struct cloud_msg msg = {
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
-		.endpoint.type = CLOUD_EP_TOPIC_STATE,
+		.endpoint.type = CLOUD_EP_STATE,
 		.buf = SERVICE_INFO_GPS,
 		.len = strlen(SERVICE_INFO_GPS)
 	};
@@ -248,7 +248,7 @@ static void send_nmea(char *nmea)
 	char buf[150];
 	struct cloud_msg msg = {
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
-		.endpoint.type = CLOUD_EP_TOPIC_MSG,
+		.endpoint.type = CLOUD_EP_MSG,
 		.buf = buf,
 	};
 

--- a/samples/nrf9160/cloud_client/src/main.c
+++ b/samples/nrf9160/cloud_client/src/main.c
@@ -55,10 +55,20 @@ static void cloud_update_work_fn(struct k_work *work)
 
 	struct cloud_msg msg = {
 		.qos = CLOUD_QOS_AT_MOST_ONCE,
-		.endpoint.type = CLOUD_EP_TOPIC_MSG,
 		.buf = CONFIG_CLOUD_MESSAGE,
 		.len = strlen(CONFIG_CLOUD_MESSAGE)
 	};
+
+	/* When using the nRF Cloud backend data is sent to the message topic.
+	 * This is in order to visualize the data in the web UI terminal.
+	 * For Azure IoT Hub and AWS IoT, messages are addressed directly to the
+	 * device twin (Azure) or device shadow (AWS).
+	 */
+	if (strcmp(CONFIG_CLOUD_BACKEND, "NRF_CLOUD") == 0) {
+		msg.endpoint.type = CLOUD_EP_MSG;
+	} else {
+		msg.endpoint.type = CLOUD_EP_STATE;
+	}
 
 	err = cloud_send(cloud_backend, &msg);
 	if (err) {

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -236,7 +236,7 @@ static void aws_iot_notify_event(const struct aws_iot_evt *aws_iot_evt)
 		cloud_evt.type = CLOUD_EVT_DATA_RECEIVED;
 		cloud_evt.data.msg.buf = aws_iot_evt->data.msg.ptr;
 		cloud_evt.data.msg.len = aws_iot_evt->data.msg.len;
-		cloud_evt.data.msg.endpoint.type = CLOUD_EP_TOPIC_MSG;
+		cloud_evt.data.msg.endpoint.type = CLOUD_EP_MSG;
 		cloud_evt.data.msg.endpoint.str =
 				(char *)aws_iot_evt->data.msg.topic.str;
 		cloud_evt.data.msg.endpoint.len =
@@ -880,15 +880,15 @@ int aws_iot_send(const struct aws_iot_data *const tx_data)
 
 	switch (tx_data_pub.topic.type) {
 #if defined(CONFIG_CLOUD_API)
-	case CLOUD_EP_TOPIC_STATE:
+	case CLOUD_EP_STATE_GET:
 		tx_data_pub.topic.str = get_topic;
 		tx_data_pub.topic.len = strlen(get_topic);
 		break;
-	case CLOUD_EP_TOPIC_MSG:
+	case CLOUD_EP_STATE:
 		tx_data_pub.topic.str = update_topic;
 		tx_data_pub.topic.len = strlen(update_topic);
 		break;
-	case CLOUD_EP_TOPIC_STATE_DELETE:
+	case CLOUD_EP_STATE_DELETE:
 		tx_data_pub.topic.str = delete_topic;
 		tx_data_pub.topic.len = strlen(delete_topic);
 		break;

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
@@ -50,7 +50,7 @@ static void api_event_handler(struct azure_iot_hub_evt *evt)
 		cloud_evt.type = CLOUD_EVT_DATA_RECEIVED;
 		cloud_evt.data.msg.buf = evt->data.msg.ptr;
 		cloud_evt.data.msg.len = evt->data.msg.len;
-		cloud_evt.data.msg.endpoint.type = CLOUD_EP_TOPIC_MSG;
+		cloud_evt.data.msg.endpoint.type = CLOUD_EP_MSG;
 		cloud_evt.data.msg.endpoint.str = evt->topic.str;
 		cloud_evt.data.msg.endpoint.len = evt->topic.len;
 		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
@@ -60,7 +60,7 @@ static void api_event_handler(struct azure_iot_hub_evt *evt)
 		cloud_evt.type = CLOUD_EVT_DATA_RECEIVED;
 		cloud_evt.data.msg.buf = evt->data.msg.ptr;
 		cloud_evt.data.msg.len = evt->data.msg.len;
-		cloud_evt.data.msg.endpoint.type = CLOUD_EP_TOPIC_STATE;
+		cloud_evt.data.msg.endpoint.type = CLOUD_EP_STATE;
 		cloud_evt.data.msg.endpoint.str = evt->topic.str;
 		cloud_evt.data.msg.endpoint.len = evt->topic.len;
 		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
@@ -70,7 +70,7 @@ static void api_event_handler(struct azure_iot_hub_evt *evt)
 		cloud_evt.type = CLOUD_EVT_DATA_RECEIVED;
 		cloud_evt.data.msg.buf = evt->data.msg.ptr;
 		cloud_evt.data.msg.len = evt->data.msg.len;
-		cloud_evt.data.msg.endpoint.type = CLOUD_EP_TOPIC_STATE;
+		cloud_evt.data.msg.endpoint.type = CLOUD_EP_STATE;
 		cloud_evt.data.msg.endpoint.str = evt->topic.str;
 		cloud_evt.data.msg.endpoint.len = evt->topic.len;
 		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
@@ -171,10 +171,13 @@ static int api_send(const struct cloud_backend *const backend,
 	};
 
 	switch (msg->endpoint.type) {
-	case CLOUD_EP_TOPIC_STATE:
+	case CLOUD_EP_STATE_GET:
+		tx_data.topic.type = AZURE_IOT_HUB_TOPIC_TWIN_REQUEST;
+		break;
+	case CLOUD_EP_STATE:
 		tx_data.topic.type = AZURE_IOT_HUB_TOPIC_TWIN_REPORTED;
 		break;
-	case CLOUD_EP_TOPIC_MSG:
+	case CLOUD_EP_MSG:
 		tx_data.topic.type = AZURE_IOT_HUB_TOPIC_EVENT;
 		break;
 	default:

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
@@ -56,6 +56,26 @@ static void api_event_handler(struct azure_iot_hub_evt *evt)
 		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
 				   config->user_data);
 		break;
+	case AZURE_IOT_HUB_EVT_TWIN_RECEIVED:
+		cloud_evt.type = CLOUD_EVT_DATA_RECEIVED;
+		cloud_evt.data.msg.buf = evt->data.msg.ptr;
+		cloud_evt.data.msg.len = evt->data.msg.len;
+		cloud_evt.data.msg.endpoint.type = CLOUD_EP_TOPIC_STATE;
+		cloud_evt.data.msg.endpoint.str = evt->topic.str;
+		cloud_evt.data.msg.endpoint.len = evt->topic.len;
+		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
+				   config->user_data);
+		break;
+	case AZURE_IOT_HUB_EVT_TWIN_DESIRED_RECEIVED:
+		cloud_evt.type = CLOUD_EVT_DATA_RECEIVED;
+		cloud_evt.data.msg.buf = evt->data.msg.ptr;
+		cloud_evt.data.msg.len = evt->data.msg.len;
+		cloud_evt.data.msg.endpoint.type = CLOUD_EP_TOPIC_STATE;
+		cloud_evt.data.msg.endpoint.str = evt->topic.str;
+		cloud_evt.data.msg.endpoint.len = evt->topic.len;
+		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
+				   config->user_data);
+		break;
 	case AZURE_IOT_HUB_EVT_FOTA_START:
 		cloud_evt.type = CLOUD_EVT_FOTA_START;
 		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -308,7 +308,7 @@ static void api_event_handler(const struct nrf_cloud_evt *nrf_cloud_evt)
 		evt.type = CLOUD_EVT_DATA_RECEIVED;
 		evt.data.msg.buf = (char *)nrf_cloud_evt->data.ptr;
 		evt.data.msg.len = nrf_cloud_evt->data.len;
-		evt.data.msg.endpoint.type = CLOUD_EP_TOPIC_MSG;
+		evt.data.msg.endpoint.type = CLOUD_EP_MSG;
 		evt.data.msg.endpoint.str =
 			(char *)nrf_cloud_evt->topic.ptr;
 		evt.data.msg.endpoint.len = nrf_cloud_evt->topic.len;
@@ -427,7 +427,7 @@ static int api_send(const struct cloud_backend *const backend,
 	}
 
 	switch (msg->endpoint.type) {
-	case CLOUD_EP_TOPIC_MSG: {
+	case CLOUD_EP_MSG: {
 		const struct nct_dc_data buf = {
 			.data.ptr = msg->buf,
 			.data.len = msg->len
@@ -444,7 +444,7 @@ static int api_send(const struct cloud_backend *const backend,
 		}
 		break;
 	}
-	case CLOUD_EP_TOPIC_STATE: {
+	case CLOUD_EP_STATE: {
 		struct nct_cc_data shadow_data = {
 			.opcode = NCT_CC_OPCODE_UPDATE_REQ,
 			.data.ptr = msg->buf,


### PR DESCRIPTION
This patch adds:
 * Forwarding of device twin messages to the application in azure cloud backend.
 * Cleanup and generalization of the cloud API. This involves small changes in AWS and Azure backends.
 * Added further documentation of the cloud API.
