### PR TITLE
bootloader: clear timer interrupts before booting next image

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -12,6 +12,10 @@ The most relevant changes that are present on the master branch of the |NCS|, as
 .. note::
     This file is a work in progress and might not cover all relevant changes.
 
+* ``bl_boot`` library:
+
+    * Disable clock interrupts before booting app.
+      This fixes an issue where the :ref:`bootloader` sample would not be able to boot a zephyr application on the nRF5340.
 
 Changelog
 *********

--- a/subsys/bootloader/bl_boot/bl_boot.c
+++ b/subsys/bootloader/bl_boot/bl_boot.c
@@ -9,6 +9,7 @@
 #include <pm_config.h>
 #include <fw_info.h>
 #include <fprotect.h>
+#include <hal/nrf_clock.h>
 #ifdef CONFIG_UART_NRFX
 #ifdef CONFIG_UART_0_NRF_UART
 #include <hal/nrf_uart.h>
@@ -28,6 +29,7 @@ static void uninit_used_peripherals(void)
 #elif defined(CONFIG_UART_2_NRF_UARTE)
 	nrf_uarte_disable(NRF_UARTE2);
 #endif
+	nrf_clock_int_disable(NRF_CLOCK, 0xFFFFFFFF);
 }
 
 #ifdef CONFIG_SW_VECTOR_RELAY
@@ -63,6 +65,8 @@ void bl_boot(const struct fw_info *fw_info)
 			"Not in Privileged mode");
 #endif
 
+	uninit_used_peripherals();
+
 	/* Allow any pending interrupts to be recognized */
 	__ISB();
 	__disable_irq();
@@ -77,8 +81,6 @@ void bl_boot(const struct fw_info *fw_info)
 	}
 
 	printk("Booting (0x%x).\r\n", fw_info->address);
-
-	uninit_used_peripherals();
 
 	SysTick->CTRL = 0;
 


### PR DESCRIPTION
This fixes issue where zephyr apps would not start
correctly when booted on nRF53.

NCSDK-7078

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>