### PR TITLE
net: openthread: Use atomic lock variant for CC310

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -52,6 +52,10 @@ config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	default 640 if NRF_802154_SER_HOST
 	default 512
 
+choice CC3XX_LOCK_VARIANT
+	default CC3XX_ATOMIC_LOCK if CC310_BACKEND
+endchoice
+
 endmenu
 
 endif

--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 2198a0984daeece7adc4b2bea2f1863463e16285
+      revision: 784df6f0093f915c0f1406393bcb6c242b02178d
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
For small AES encryption like MAC OpenThread frameas freguent mutuall exclusive access to CC3XX based on Zephyr's mutex is flexible but havy approach. This is especially noticeable while calculating Thread throughput.
Atomic lock variant fasten these operations at the expense of comfort of usage for applications which need to access CC3XX from many threads concurrently.
