### PR TITLE
manifest: update for no spm request read when no secure services

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2b2102c07857a591dccad3fed64cbb2e41a35c49
+      revision: e28e9a75ab51f1b13a72296d59ef541ef63d0a11
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Manifest update for no spm request read when no secure services

Depends on https://github.com/nrfconnect/sdk-zephyr/pull/388

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>