### PR TITLE
samples: nrf9160: aws_iot: Add static keyword

### DIFF
--- a/samples/nrf9160/aws_iot/src/main.c
+++ b/samples/nrf9160/aws_iot/src/main.c
@@ -431,8 +431,8 @@ static void bsd_lib_modem_dfu_handler(void)
 static int app_topics_subscribe(void)
 {
 	int err;
-	char custom_topic[75] = "my-custom-topic/example";
-	char custom_topic_2[75] = "my-custom-topic/example_2";
+	static char custom_topic[75] = "my-custom-topic/example";
+	static char custom_topic_2[75] = "my-custom-topic/example_2";
 
 	const struct aws_iot_topic_data topics_list[APP_TOPICS_COUNT] = {
 		[0].str = custom_topic,


### PR DESCRIPTION
Application specific topics are passed in the aws_iot library by
reference. Add the static keyword to the topic strings to ensure that
the memory location pointed to upon subscription is valid.
