### PR TITLE
ci: lock the CI cfg to the settings used for final testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v1.4-branch") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 


### PR DESCRIPTION
ci: lock the CI cfg to the settings used for final testing

PR's targeting v1.4-branch will be run with the exact same CI configuration as release day.