### PR TITLE
bootloader: print before de-initializing peripherals

### DIFF
--- a/subsys/bootloader/bl_boot/bl_boot.c
+++ b/subsys/bootloader/bl_boot/bl_boot.c
@@ -65,6 +65,8 @@ void bl_boot(const struct fw_info *fw_info)
 			"Not in Privileged mode");
 #endif
 
+	printk("Booting (0x%x).\r\n", fw_info->address);
+
 	uninit_used_peripherals();
 
 	/* Allow any pending interrupts to be recognized */
@@ -80,7 +82,6 @@ void bl_boot(const struct fw_info *fw_info)
 		nvic->ICPR[i] = 0xFFFFFFFF;
 	}
 
-	printk("Booting (0x%x).\r\n", fw_info->address);
 
 	SysTick->CTRL = 0;
 


### PR DESCRIPTION
Fixes issue with tests.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>