### PR TITLE
net: lib: azure_iot_hub: Fix parsing of direct method request ID

### DIFF
--- a/include/net/azure_iot_hub.h
+++ b/include/net/azure_iot_hub.h
@@ -160,8 +160,8 @@ struct azure_iot_hub_data {
 struct azure_iot_hub_method {
 	/** Method name, null-terminated string. */
 	const char *name;
-	/** Method request ID. */
-	uint32_t rid;
+	/** Method request ID, null-terminated string. */
+	char *rid;
 	/** Method payload. */
 	const char *payload;
 	/** Method payload length. */
@@ -176,8 +176,8 @@ struct azure_iot_hub_method {
  *	     cloud with success or failure).
  */
 struct azure_iot_hub_result {
-	/** Request ID to which the result belongs. */
-	uint32_t rid;
+	/** Request ID to which the result belongs, null-terminated string. */
+	char *rid;
 	/** Status code. */
 	uint32_t status;
 	/** Result payload. */

--- a/samples/nrf9160/azure_fota/src/main.c
+++ b/samples/nrf9160/azure_fota/src/main.c
@@ -77,11 +77,11 @@ static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 		       evt->data.method.payload);
 		break;
 	case AZURE_IOT_HUB_EVT_TWIN_RESULT_SUCCESS:
-		printk("AZURE_IOT_HUB_EVT_TWIN_RESULT_SUCCESS, ID: %d\n",
+		printk("AZURE_IOT_HUB_EVT_TWIN_RESULT_SUCCESS, ID: %s\n",
 		       evt->data.result.rid);
 		break;
 	case AZURE_IOT_HUB_EVT_TWIN_RESULT_FAIL:
-		printk("AZURE_IOT_HUB_EVT_TWIN_RESULT_FAIL, ID %d, status %d\n",
+		printk("AZURE_IOT_HUB_EVT_TWIN_RESULT_FAIL, ID %s, status %d\n",
 		       evt->data.result.rid, evt->data.result.status);
 		break;
 	case AZURE_IOT_HUB_EVT_PUBACK:

--- a/samples/nrf9160/azure_iot_hub/src/main.c
+++ b/samples/nrf9160/azure_iot_hub/src/main.c
@@ -26,7 +26,7 @@
 
 struct method_data {
 	struct k_delayed_work work;
-	uint32_t request_id;
+	char request_id[8];
 	char name[32];
 	char payload[200];
 } method_data;
@@ -129,7 +129,8 @@ static void on_evt_direct_method(struct azure_iot_hub_method *method)
 	printk("Method name: %s\n", method->name);
 	printf("Payload: %.*s\n", method->payload_len, method->payload);
 
-	method_data.request_id = method->rid;
+	strncpy(method_data.request_id, method->rid,
+		sizeof(method_data.request_id));
 
 	strncpy(method_data.name, method->name, sizeof(method_data.name));
 	snprintf(method_data.payload, sizeof(method_data.payload),
@@ -199,11 +200,11 @@ static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 		on_evt_direct_method(&evt->data.method);
 		break;
 	case AZURE_IOT_HUB_EVT_TWIN_RESULT_SUCCESS:
-		printk("AZURE_IOT_HUB_EVT_TWIN_RESULT_SUCCESS, ID: %d\n",
+		printk("AZURE_IOT_HUB_EVT_TWIN_RESULT_SUCCESS, ID: %s\n",
 		       evt->data.result.rid);
 		break;
 	case AZURE_IOT_HUB_EVT_TWIN_RESULT_FAIL:
-		printk("AZURE_IOT_HUB_EVT_TWIN_RESULT_FAIL, ID %d, status %d\n",
+		printk("AZURE_IOT_HUB_EVT_TWIN_RESULT_FAIL, ID %s, status %d\n",
 			evt->data.result.rid, evt->data.result.status);
 		break;
 	case AZURE_IOT_HUB_EVT_PUBACK:


### PR DESCRIPTION
The current direct method request ID parsing uses atoi() and stores
the value as an int variabel.
However, the request IDs appear to be integers on hexadecimal form,
so the current parsing method will only work for IDs 1 to 9.
This patch changes the request ID type to a null-terminated string
instead of integer. The Azure IoT Hub doesn't explicitly
state in its docs what format the request ID is, so a string appears
to be safest choice.

The Azure IoT Hub sample is also updated accordingly.