### PR TITLE
net: lib: azure_fota: Start FOTA download only once

### DIFF
--- a/subsys/net/lib/azure_fota/azure_fota.c
+++ b/subsys/net/lib/azure_fota/azure_fota.c
@@ -481,6 +481,14 @@ int azure_fota_msg_process(const char *const buf, size_t size)
 		.type = AZURE_FOTA_EVT_START
 	};
 
+	/* Ensure that FOTA download is not started multiple times, which
+	 * would corrupt the downloaded image.
+	 */
+	if (fota_state == STATUS_DOWNLOADING) {
+		LOG_INF("Firmware download is ongoing, message ignored");
+		return 0;
+	}
+
 	/* Check last reported FOTA status */
 	if (parse_reported_status(buf)) {
 		evt.type = AZURE_FOTA_EVT_REPORT;
@@ -496,11 +504,6 @@ int azure_fota_msg_process(const char *const buf, size_t size)
 		return 0;
 	} else if (err < 0) {
 		LOG_DBG("Firmware details not found, FOTA will not start");
-		return 0;
-	}
-
-	if (fota_state == STATUS_DOWNLOADING) {
-		LOG_INF("Firmware download is already ongoing");
 		return 0;
 	}
 


### PR DESCRIPTION
In some cases, FOTA download could be started more than once if two
or more device twin messages were received in rapid succession.
The consequence is corruption of the downloaded image.

This patch moves a state check in order to stop processing incoming
device twin messages at an earlier stage if a download is ongoing.
Moving the check prevents the state to be changed from 'downloading',
which would allow another download to start.