### PR TITLE
Bluetooth: Mesh: Add mesh subdirectory if BT_MESH is set

### DIFF
--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -11,6 +11,6 @@ zephyr_sources_ifdef(CONFIG_BT_CONN_CTX conn_ctx.c)
 zephyr_sources_ifdef(CONFIG_BT_ENOCEAN enocean)
 
 add_subdirectory_ifdef(CONFIG_BT_LL_SOFTDEVICE controller)
-add_subdirectory_ifdef(CONFIG_BT_MESH_NRF_MODELS mesh)
+add_subdirectory_ifdef(CONFIG_BT_MESH mesh)
 
 add_subdirectory_ifdef(CONFIG_BT_NRF_SERVICES services)


### PR DESCRIPTION
This allows to use BT_MESH_DK_PROV in an application without any mesh
models.

Signed-off-by: Vasilyev, Pavel <pavel.vasilyev@nordicsemi.no>