### PR TITLE
samples: nfc: Add support for nRF5340dk

### DIFF
--- a/samples/bluetooth/central_nfc_pairing/CMakeLists.txt
+++ b/samples/bluetooth/central_nfc_pairing/CMakeLists.txt
@@ -10,7 +10,9 @@ cmake_minimum_required(VERSION 3.13.1)
 set(NRF_SUPPORTED_BOARDS
   nrf52dk_nrf52832
   nrf52840dk_nrf52840
+  nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuapp
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/bluetooth/central_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/central_nfc_pairing/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.central_nfc_pairing:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_nfc_pairing/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_nfc_pairing/CMakeLists.txt
@@ -12,6 +12,8 @@ set(NRF_SUPPORTED_BOARDS
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
   nrf5340pdk_nrf5340_cpuappns
+  nrf5340dk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuappns
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.bluetooth.peripheral_nfc_pairing:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840_pca10056 nrf52_pca10040 nrf5340pdk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/nfc/record_text/CMakeLists.txt
+++ b/samples/nfc/record_text/CMakeLists.txt
@@ -12,6 +12,8 @@ set(NRF_SUPPORTED_BOARDS
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
   nrf5340pdk_nrf5340_cpuappns
+  nrf5340dk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuappns
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nfc/record_text/sample.yaml
+++ b/samples/nfc/record_text/sample.yaml
@@ -5,6 +5,5 @@ tests:
   samples.nfc.record_text:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: ci_build

--- a/samples/nfc/system_off/CMakeLists.txt
+++ b/samples/nfc/system_off/CMakeLists.txt
@@ -12,6 +12,8 @@ set(NRF_SUPPORTED_BOARDS
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
   nrf5340pdk_nrf5340_cpuappns
+  nrf5340dk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuappns
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nfc/system_off/sample.yaml
+++ b/samples/nfc/system_off/sample.yaml
@@ -5,6 +5,5 @@ tests:
   samples.nfc.system_off:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: ci_build

--- a/samples/nfc/tag_reader/CMakeLists.txt
+++ b/samples/nfc/tag_reader/CMakeLists.txt
@@ -12,6 +12,7 @@ set(NRF_SUPPORTED_BOARDS
   nrf52840dk_nrf52840
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuapp
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nfc/tag_reader/sample.yaml
+++ b/samples/nfc/tag_reader/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.nfc.tag_reader:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/nfc/tnep_poller/CMakeLists.txt
+++ b/samples/nfc/tnep_poller/CMakeLists.txt
@@ -12,6 +12,7 @@ set(NRF_SUPPORTED_BOARDS
   nrf52840dk_nrf52840
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuapp
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nfc/tnep_poller/sample.yaml
+++ b/samples/nfc/tnep_poller/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.nfc.tnep_poller:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/nfc/tnep_tag/CMakeLists.txt
+++ b/samples/nfc/tnep_tag/CMakeLists.txt
@@ -12,6 +12,8 @@ set(NRF_SUPPORTED_BOARDS
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
   nrf5340pdk_nrf5340_cpuappns
+  nrf5340dk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuappns
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nfc/tnep_tag/sample.yaml
+++ b/samples/nfc/tnep_tag/sample.yaml
@@ -5,6 +5,5 @@ tests:
   samples.nfc.tnep_tag:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: ci_build

--- a/samples/nfc/writable_ndef_msg/CMakeLists.txt
+++ b/samples/nfc/writable_ndef_msg/CMakeLists.txt
@@ -12,6 +12,8 @@ set(NRF_SUPPORTED_BOARDS
   nrf52833dk_nrf52833
   nrf5340pdk_nrf5340_cpuapp
   nrf5340pdk_nrf5340_cpuappns
+  nrf5340dk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuappns
   )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nfc/writable_ndef_msg/sample.yaml
+++ b/samples/nfc/writable_ndef_msg/sample.yaml
@@ -5,6 +5,5 @@ tests:
   samples.nfc.writable_ndef_msg:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: ci_build


### PR DESCRIPTION
This PR adds support for nRF5340dk in NFC samples
