### PR TITLE
net: lib: azure_iot_hub_topic: Make property bag prefix configurable

### DIFF
--- a/subsys/net/lib/azure_iot_hub/Kconfig
+++ b/subsys/net/lib/azure_iot_hub/Kconfig
@@ -99,6 +99,14 @@ config AZURE_IOT_HUB_PROPERTY_BAG_MAX_COUNT
 	  Increasing this value will increase stack usage when parsing topics,
 	  and vice versa if decreasing it.
 
+config AZURE_IOT_HUB_TOPIC_PROPERTY_BAG_PREFIX
+	bool "Include the '?' prefix before the property bag key/value"
+	default y
+	help
+	  This option adds a '?' before the property bag value for the event
+	  topics. Example
+	  devices/{device_id}/messages/events/?{property_bag}.
+
 config AZURE_IOT_HUB_DPS
 	bool "Use Device Provisioning Service"
 	select CJSON_LIB

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_topic.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_topic.c
@@ -307,12 +307,14 @@ char *azure_iot_hub_prop_bag_str_get(struct azure_iot_hub_prop_bag *bags,
 
 	for (size_t i = 0; i < count; i++) {
 		if (i == 0) {
+#if defined(CONFIG_AZURE_IOT_HUB_TOPIC_PROPERTY_BAG_PREFIX)
 			buf[0] = '?';
+			written++;
+#endif
 		} else {
 			buf[written] = '&';
+			written++;
 		}
-
-		written++;
 
 		if (bags[i].value == NULL) {
 			len = snprintk(&buf[written], total_len - written,


### PR DESCRIPTION
Make the "?" prefix for property bag value/key in event topics
configurable because it is not required and can be omitted.
