### PR TITLE
manifest: pm: remove dependency on devicetree

### DIFF
--- a/samples/bootloader/pm.yml
+++ b/samples/bootloader/pm.yml
@@ -1,5 +1,4 @@
 #include <autoconf.h>
-#include <devicetree_legacy_unfixed.h>
 
 b0_image:
   size: CONFIG_PM_PARTITION_SIZE_B0_IMAGE
@@ -31,7 +30,7 @@ s1_pad:
   share_size: mcuboot_pad
   placement:
     after: s0
-    align: {start: DT_FLASH_ERASE_BLOCK_SIZE}
+    align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
 
 s1_image:
   share_size: {one_of: [mcuboot, s0_image]}
@@ -50,5 +49,5 @@ provision:
 #else
   placement:
     after: b0_image
-    align: {start: DT_FLASH_ERASE_BLOCK_SIZE}
+    align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
 #endif

--- a/subsys/partition_manager/pm.yml.zboss
+++ b/subsys/partition_manager/pm.yml.zboss
@@ -1,8 +1,7 @@
 #include <autoconf.h>
-#include <devicetree_legacy_unfixed.h>
 
 zboss_nvram:
-  placement: {after: [app], align: {start: DT_FLASH_ERASE_BLOCK_SIZE}}
+  placement: {after: [app], align: {start: CONFIG_FPROTECT_BLOCK_SIZE}}
   size: CONFIG_PM_PARTITION_SIZE_ZBOSS_NVRAM
 
 zboss_product_config:


### PR DESCRIPTION
The symbols we need are already available in kconfig
Update MCUBoot to do the same there.

Ref: NCSDK-7150
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>