### PR TITLE
lib: modem_info: Fix reading numerical value as string

### DIFF
--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -530,8 +530,8 @@ parse:
 			LOG_ERR("Unable to obtain short: %d", err);
 			return err;
 		}
-		err = snprintf(buf, buf_size, "%d", param_value);
-		if ((err <= 0) || (err > buf_size)) {
+		len = snprintf(buf, buf_size, "%d", param_value);
+		if ((len <= 0) || (len > buf_size)) {
 			return -EMSGSIZE;
 		}
 	} else if (modem_data[info]->data_type == AT_PARAM_TYPE_STRING) {


### PR DESCRIPTION
Resolve an EMSGSIZE error in reading a numerical value as a string.

Fixes NCSIDB-266