### PR TITLE
Bluetooth: Pull zephyr and give build warning for Bluetooth unqualified options

### DIFF
--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -14,3 +14,28 @@ add_subdirectory_ifdef(CONFIG_BT_LL_SOFTDEVICE controller)
 add_subdirectory_ifdef(CONFIG_BT_MESH_NRF_MODELS mesh)
 
 add_subdirectory_ifdef(CONFIG_BT_NRF_SERVICES services)
+
+if(CONFIG_BT_EATT OR
+   CONFIG_BT_L2CAP_ECRED OR
+   CONFIG_BT_PER_ADV OR
+   CONFIG_BT_AUDIO)
+  message(WARNING "
+  One or more of the options have been enabled:
+  CONFIG_BT_EATT, CONFIG_BT_L2CAP_ECRED, CONFIG_BT_PER_ADV, CONFIG_BT_AUDIO
+  These bluetooth features have not been qualified, supported for development only."
+  )
+endif()
+
+if(CONFIG_BT_LL_SW_SPLIT)
+  message(WARNING "
+  Software-based BLE Link Layer (BT_LL_SW_SPLIT) option has been enabled.
+  This feature has not been qualified, supported for development only."
+  )
+endif()
+
+if(CONFIG_BT_MESH)
+  message(WARNING "
+  Bluetooth Mesh support (BT_MESH) option has been enabled.
+  This feature has not been qualified, supported for development only."
+  )
+endif()

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1664f186a30956003c8644fb37f5135d8cca2f0b
+      revision: e34b2f477e1adc26b66690171508bfa102eb8538
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull zephyr to include zephyr Kconfig experimental update
to align with Bluetooth qualified features.

Add build warning for non-qualified Bluetooth Kconfig options.