### PR TITLE
bootloader: use minimal log in mcuboot when built for 53 and secure_boot

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -47,6 +47,12 @@ if (CONFIG_SECURE_BOOT)
       SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bootloader
       )
   endif()
+  if (CONFIG_SOC_NRF5340_CPUAPP AND CONFIG_BOOTLOADER_MCUBOOT)
+      add_overlay_config(
+        mcuboot
+        ${NRF_DIR}/subsys/bootloader/image/log_minimal.conf
+        )
+  endif()
 endif()
 
 # Special handling for the nRF53 when using RPMSG HCI.

--- a/subsys/bootloader/image/log_minimal.conf
+++ b/subsys/bootloader/image/log_minimal.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+CONFIG_LOG_MINIMAL=y


### PR DESCRIPTION
If logging is enabled the image with appended TLV values
will be bigger than the default MCUBoot partition size
and updates of MCUBoot will fail.

Ref: NCSDK-7156
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>