### PR TITLE
net: lib: azure_fota: Do not process same FOTA multiple times

### DIFF
--- a/subsys/net/lib/azure_fota/azure_fota.c
+++ b/subsys/net/lib/azure_fota/azure_fota.c
@@ -227,6 +227,14 @@ static bool parse_reported_status(const char *msg)
 	LOG_DBG("Currently reported 'fwUpdateStatus' in device twin: %s",
 		log_strdup(fw_status_obj->valuestring));
 
+	/* "current" status indicates no FOTA was in progress, only allow
+	 * updates with this status to be applied.
+	 */
+	if (strcmp("current", fw_status_obj->valuestring) != 0) {
+		LOG_DBG("Firmware update already in progress.");
+		goto clean_exit;
+	}
+
 	/* Current firmware object (currentFwVersion) */
 	fw_current_obj = cJSON_GetObjectItemCaseSensitive(fw_obj,
 							 "currentFwVersion");


### PR DESCRIPTION
This adds a check to the FOTA routine which ensures
that only FOTA instructions of status "current" are processed.

Otherwise, if an update is schedule which has a wrong
pendingFwVersion it would cause the device to download and
apply the same update over and over again.

Signed-off-by: Markus Tacker <Markus.Tacker@NordicSemi.no>