### PR TITLE
Bluetooth: HCI: Set missing bits in supported commands

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -239,11 +239,12 @@ static void supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 
 	cmds->hci_le_read_supported_states = 1;
 
-#if defined(CONFIG_BT_CTLR_DTM)
+	/* NOTE: The DTM commands are *not* supported by the SoftDevice
+	 * controller. See doc/nrf/known_issues.rst.
+	 */
 	cmds->hci_le_receiver_test_v1 = 1;
 	cmds->hci_le_transmitter_test_v1 = 1;
 	cmds->hci_le_test_end = 1;
-#endif
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_CTLR_LE_PING)
 	cmds->hci_read_authenticated_payload_timeout = 1;
@@ -275,10 +276,11 @@ static void supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_set_phy = 1;
 #endif
 
-#if defined(CONFIG_BT_CTLR_DTM)
+	/* NOTE: The DTM commands are *not* supported by the SoftDevice
+	 * controller. See doc/nrf/known_issues.rst.
+	 */
 	cmds->hci_le_receiver_test_v2 = 1;
 	cmds->hci_le_transmitter_test_v2 = 1;
-#endif
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_BROADCASTER)

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -245,6 +245,11 @@ static void supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_test_end = 1;
 #endif
 
+#if defined(CONFIG_BT_CTLR_LE_ENC) && defined(CONFIG_BT_CTLR_LE_PING)
+	cmds->hci_read_authenticated_payload_timeout = 1;
+	cmds->hci_write_authenticated_payload_timeout = 1;
+#endif
+
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	cmds->hci_le_set_data_length = 1;
 	cmds->hci_le_read_suggested_default_data_length = 1;

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -165,6 +165,10 @@ static void supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_set_event_mask = 1;
 	cmds->hci_reset = 1;
 
+#if defined(CONFIG_BT_CONN)
+	cmds->hci_read_transmit_power_level = 1;
+#endif
+
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
 	cmds->hci_set_controller_to_host_flow_control = 1;
 	cmds->hci_host_buffer_size = 1;


### PR DESCRIPTION
This cherry-picks the changes from https://github.com/nrfconnect/sdk-nrf/pull/3372 to master.

---

There were a few bits missing to be set in the bitfield of supported commands.
This fixes it.