### PR TITLE
samples: nrf9160: at_client: Request external XTAL for UART

### DIFF
--- a/samples/nrf9160/at_client/src/main.c
+++ b/samples/nrf9160/at_client/src/main.c
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <drivers/uart.h>
 #include <string.h>
+#include <drivers/clock_control.h>
+#include <drivers/clock_control/nrf_clock_control.h>
 
 /**@brief Recoverable BSD library error. */
 void bsd_recoverable_error_handler(uint32_t err)
@@ -15,7 +17,19 @@ void bsd_recoverable_error_handler(uint32_t err)
 	printk("bsdlib recoverable error: %u\n", err);
 }
 
+/* To strictly comply with UART timing, enable external XTAL oscillator */
+void enable_xtal(void)
+{
+	struct onoff_manager *clk_mgr;
+	static struct onoff_client cli = {};
+
+	clk_mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+	sys_notify_init_spinwait(&cli.notify);
+	(void)onoff_request(clk_mgr, &cli);
+}
+
 void main(void)
 {
+	enable_xtal();
 	printk("The AT host sample started\n");
 }


### PR DESCRIPTION
Ensure that the HFCLK is running on external XTAL when UART is enabled,
complying with the product spec.

Fixes NCSDK-7003

Compare https://github.com/nrfconnect/sdk-nrf/pull/3311/