### PR TITLE
net: lib: azure_iot_hub: Forward the device twin to the application

### DIFF
--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -298,11 +298,11 @@ static void device_twin_result_process(struct topic_parser_data *topic,
 
 		if (err < 0) {
 			LOG_ERR("Failed to process FOTA msg");
-			return;
 		} else if (err == 1) {
 			LOG_DBG("FOTA message handled");
-			return;
 		}
+
+		/* Forward the device twin to the application. */
 #endif /* IS_ENABLED(CONFIG_AZURE_FOTA) */
 		evt.type = AZURE_IOT_HUB_EVT_TWIN_RECEIVED;
 		break;
@@ -435,11 +435,11 @@ static void on_publish(struct mqtt_client *const client,
 		err = azure_fota_msg_process(payload_buf, payload_len);
 		if (err < 0) {
 			LOG_ERR("Failed to process FOTA message");
-			return;
 		} else if (err == 1) {
 			LOG_DBG("Device twin update handled (FOTA)");
-			return;
 		}
+
+		/* Forward the device twin to the application. */
 #endif /* IS_ENABLED(CONFIG_AZURE_FOTA) */
 		evt.type = AZURE_IOT_HUB_EVT_TWIN_DESIRED_RECEIVED;
 


### PR DESCRIPTION
Forward messages containing the device twin to the application even
though FOTA has handled the message. This is accommodate applications
that depends on information present in the device twin, such as device
configuration.