### PR TITLE
Fix issues with Doxygen 1.8.17

### DIFF
--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -234,7 +234,7 @@ ALIASES += "req=\xrefitem req \"Requirement\" \"Requirements\" "
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
 
-TCL_SUBST              = YES
+TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -2046,12 +2046,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2064,15 +2058,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = NO
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/doc/nrfxlib/nrfxlib.doxyfile.in
+++ b/doc/nrfxlib/nrfxlib.doxyfile.in
@@ -233,7 +233,7 @@ ALIASES += "req=\xrefitem req \"Requirement\" \"Requirements\" "
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
 
-TCL_SUBST              = YES
+TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -2052,12 +2052,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2070,15 +2064,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = NO
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/include/bluetooth/mesh/gen_battery_cli.h
+++ b/include/bluetooth/mesh/gen_battery_cli.h
@@ -110,4 +110,4 @@ extern const struct bt_mesh_model_cb _bt_mesh_battery_cli_cb;
 
 #endif /* BT_MESH_GEN_BATTERY_CLI_H__ */
 
-/* @} */
+/** @} */

--- a/include/bluetooth/mesh/gen_loc_cli.h
+++ b/include/bluetooth/mesh/gen_loc_cli.h
@@ -243,4 +243,4 @@ extern const struct bt_mesh_model_cb _bt_mesh_loc_cli_cb;
 
 #endif /* BT_MESH_GEN_LOC_CLI_H__ */
 
-/* @} */
+/** @} */

--- a/include/bluetooth/mesh/gen_lvl_cli.h
+++ b/include/bluetooth/mesh/gen_lvl_cli.h
@@ -146,7 +146,11 @@ int bt_mesh_lvl_cli_set_unack(struct bt_mesh_lvl_cli *cli,
 
 /** @brief Trigger a differential level state change in the server.
  *
- * @copydetails bt_mesh_lvl_cli_delta_set_unack
+ * Makes the server move its level state by some delta value. If multiple
+ * delta_set messages are sent in a row (with less than 6 seconds interval),
+ * and @p delta_set::new_transaction is set to false, the server will continue
+ * using the same base value for its delta as in the first message, unless
+ * some other client made changes to the server.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
  * function will return, and the response will be passed to the
@@ -201,7 +205,16 @@ int bt_mesh_lvl_cli_delta_set_unack(
 
 /** @brief Trigger a continuous level change in the server.
  *
- * @copydetails bt_mesh_lvl_cli_move_set_unack
+ * Makes the server continuously move its level state by the set rate:
+ *
+ * @code
+ * rate_of_change = move_set->delta / move_set->transition->time
+ * @endcode
+ *
+ * The server will continue moving its level until it is told to stop, or until
+ * it reaches some application specific boundary value. The server may choose
+ * to wrap around the level value, depending on its usage. The move can be
+ * stopped by sending a new move message with a delta value of 0.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
  * function will return, and the response will be passed to the

--- a/include/bluetooth/mesh/gen_onoff_cli.h
+++ b/include/bluetooth/mesh/gen_onoff_cli.h
@@ -158,4 +158,4 @@ extern const struct bt_mesh_model_cb _bt_mesh_onoff_cli_cb;
 
 #endif /* BT_MESH_GEN_ONOFF_CLI_H__ */
 
-/* @} */
+/** @} */

--- a/include/bluetooth/mesh/gen_prop_cli.h
+++ b/include/bluetooth/mesh/gen_prop_cli.h
@@ -160,7 +160,11 @@ int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,
 
 /** @brief Set a property value in a User Property Server.
  *
- * @copydetails bt_mesh_prop_cli_user_prop_set_unack
+ * The User Property may only be set if the server enabled user write access to
+ * it. If this is not the case, the server will only respond with the set user
+ * access mode for the given property.
+ *
+ * @note The @p val::meta::user_access level will be ignored.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
  * function will return, and the response will be passed to the

--- a/include/bluetooth/mesh/light_ctl_cli.h
+++ b/include/bluetooth/mesh/light_ctl_cli.h
@@ -403,4 +403,4 @@ extern const struct bt_mesh_model_cb _bt_mesh_light_ctl_cli_cb;
 
 #endif /* BT_MESH_LIGHT_CTL_CLI_H__ */
 
-/* @} */
+/** @} */

--- a/include/bluetooth/mesh/light_ctl_srv.h
+++ b/include/bluetooth/mesh/light_ctl_srv.h
@@ -271,4 +271,4 @@ extern const struct bt_mesh_lightness_srv_handlers
 
 #endif /* BT_MESH_LIGHT_CTL_SRV_H__ */
 
-/* @} */
+/** @} */

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -165,4 +165,4 @@ extern const struct bt_mesh_lvl_srv_handlers
 
 #endif /* BT_MESH_LIGHT_TEMP_SRV_H__ */
 
-/* @} */
+/** @} */

--- a/include/bluetooth/mesh/sensor_cli.h
+++ b/include/bluetooth/mesh/sensor_cli.h
@@ -602,7 +602,6 @@ int bt_mesh_sensor_cli_series_entry_get(
  *                         has been changed to the number of columns in the
  *                         response.
  *  @retval -ENOTSUP       The sensor doesn't support series data.
- *  @retval -ENODEV        The sensor server doesn't have the given sensor.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.

--- a/include/bluetooth/mesh/time_cli.h
+++ b/include/bluetooth/mesh/time_cli.h
@@ -335,4 +335,4 @@ extern const struct bt_mesh_model_cb _bt_mesh_time_cli_cb;
 
 #endif /* BT_MESH_TIME_CLI_H__ */
 
-/* @} */
+/** @} */

--- a/include/bluetooth/mesh/time_srv.h
+++ b/include/bluetooth/mesh/time_srv.h
@@ -306,4 +306,4 @@ int _bt_mesh_time_srv_update_handler(struct bt_mesh_model *model);
 
 #endif /* BT_MESH_TIME_SRV_H__ */
 
-/* @} */
+/** @} */

--- a/include/bluetooth/scan.h
+++ b/include/bluetooth/scan.h
@@ -60,7 +60,7 @@ extern "C" {
 
 /**@brief Uses the combination of all filters. */
 #define BT_SCAN_ALL_FILTER 0x3F
-/* @} */
+/** @} */
 
 
 /**@brief Scan types.
@@ -547,8 +547,6 @@ void bt_scan_blocklist_clear(void);
 }
 #endif
 
-/**
- * @}
- */
-
 #endif /* BT_SCAN_H_ */
+
+/** @} */

--- a/include/nfc/ndef/payload_type_common.h
+++ b/include/nfc/ndef/payload_type_common.h
@@ -10,7 +10,7 @@
 /**@file
  *
  * @defgroup nfc_ndef_payload_type_common Standard NDEF Record Type definitions
- *
+ * @{
  * @brief    Set of standard NDEF Record Types defined in NFC Forum
  *           specifications.
  *

--- a/lib/multithreading_lock/multithreading_lock.h
+++ b/lib/multithreading_lock/multithreading_lock.h
@@ -43,8 +43,8 @@ extern "C" {
  * @param[in] timeout     Timeout value for the locking API.
  *
  * @retval 0              Success
- * @retval - @em EBUSY    Returned without waiting.
- * @retval - @em EAGAIN   Waiting period timed out.
+ * @retval -EBUSY         Returned without waiting.
+ * @retval -EAGAIN        Waiting period timed out.
  */
 int multithreading_lock_acquire(k_timeout_t timeout);
 


### PR DESCRIPTION
Fix warnings that show up when running 1.8.17, update config, fix mismatched groups, duplicated or invalid usage of params/retvals, remove \copydetails usage.

/cc @thst-nordic - This should work OK on both 1.8.13 and 1.8.17