### PR TITLE
manifest: Update for TX modes removal when not supported

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: cdc4c217fbd0972a4270b4ca546f6d34bf5b120c
+      revision: pull/390/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Manifest update for TX modes removal when not supported

Depends on: nrfconnect/sdk-zephyr#390

Signed-off-by: Pawel Kwiek <pawel.kwiek@nordicsemi.no>