### PR TITLE
Prevent "simultaneous" DNS request from multiple contexts to preempt each other.

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -78,11 +78,6 @@ defined(CONFIG_NRF_CLOUD_PROVISION_CERTIFICATES)
 #define CLOUD_LED_OFF_STR "{\"led\":\"off\"}"
 #define CLOUD_LED_MSK UI_LED_1
 
-/* Timeout in seconds in which the application will wait for an initial event
- * from the date time library.
- */
-#define DATE_TIME_TIMEOUT_S 15
-
 /* Interval in milliseconds after which the device will reboot
  * if the disconnect event has not been handled.
  */
@@ -180,7 +175,6 @@ static K_SEM_DEFINE(bsdlib_initialized, 0, 1);
 static K_SEM_DEFINE(lte_connected, 0, 1);
 static K_SEM_DEFINE(cloud_ready_to_connect, 0, 1);
 #endif
-static K_SEM_DEFINE(date_time_obtained, 0, 1);
 
 #if CONFIG_MODEM_INFO
 static struct k_delayed_work rsrp_work;
@@ -1865,17 +1859,10 @@ static void date_time_event_handler(const struct date_time_evt *evt)
 	default:
 		break;
 	}
-
-	/* Do not depend on obtained time, continue upon any event from the
-	 * date time library.
-	 */
-	k_sem_give(&date_time_obtained);
 }
 
 void main(void)
 {
-	int ret;
-
 	LOG_INF("Asset tracker started");
 	k_work_q_start(&application_work_q, application_stack_area,
 		       K_THREAD_STACK_SIZEOF(application_stack_area),
@@ -1912,12 +1899,5 @@ void main(void)
 #endif
 
 	date_time_update_async(date_time_event_handler);
-
-	ret = k_sem_take(&date_time_obtained, K_SECONDS(DATE_TIME_TIMEOUT_S));
-	if (ret) {
-		LOG_WRN("Date time, no callback event within %d seconds",
-			DATE_TIME_TIMEOUT_S);
-	}
-
 	connect_to_cloud(0);
 }

--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -241,20 +241,6 @@ static void new_date_time_get(void)
 
 		LOG_DBG("Current time not valid");
 
-#if defined(CONFIG_DATE_TIME_MODEM)
-		LOG_DBG("Fallback on cellular network time");
-
-		err = time_modem_get();
-		if (err == 0) {
-			LOG_DBG("Time from cellular network obtained");
-			initial_valid_time = true;
-			evt.type = DATE_TIME_OBTAINED_MODEM;
-			date_time_notify_event(&evt);
-			continue;
-		}
-
-		LOG_DBG("Not getting cellular network time");
-#endif
 #if defined(CONFIG_DATE_TIME_NTP)
 		LOG_DBG("Fallback on NTP server");
 
@@ -268,6 +254,20 @@ static void new_date_time_get(void)
 		}
 
 		LOG_DBG("Not getting time from NTP server");
+#endif
+#if defined(CONFIG_DATE_TIME_MODEM)
+		LOG_DBG("Fallback on cellular network time");
+
+		err = time_modem_get();
+		if (err == 0) {
+			LOG_DBG("Time from cellular network obtained");
+			initial_valid_time = true;
+			evt.type = DATE_TIME_OBTAINED_MODEM;
+			date_time_notify_event(&evt);
+			continue;
+		}
+
+		LOG_DBG("Not getting cellular network time");
 #endif
 		LOG_DBG("Not getting time from any time source");
 


### PR DESCRIPTION
This patch addresses an issue occurring when multiple DNS requests
are called from different contexts at the same time. By protecting
the getaddrinfo call with a mutex we can be sure to know that a thread
cannot preempt another thread that has just called a DNS request and
potentially receiving the result from the first request.

The patch also includes:
 - Removal of the semaphore in samples/applications using the date time library. This semaphore was previously used
   to solve the issue this PR addresses.
 - Prioritize NTP time over network time from modem.
