### PR TITLE
Bluetooth: Mesh: Remove -ENOTSUP for unsupported pub

### DIFF
--- a/include/bluetooth/mesh/gen_battery_cli.h
+++ b/include/bluetooth/mesh/gen_battery_cli.h
@@ -88,8 +88,6 @@ struct bt_mesh_battery_cli {
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_battery_srv.h
+++ b/include/bluetooth/mesh/gen_battery_srv.h
@@ -93,8 +93,6 @@ struct bt_mesh_battery_srv {
  * @param[in] status Current status.
  *
  * @retval 0 Successfully published a Generic Battery Status message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_dtt_cli.h
+++ b/include/bluetooth/mesh/gen_dtt_cli.h
@@ -134,8 +134,6 @@ int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
  *
  * @retval 0 Successfully sent the message.
  * @retval -EINVAL The given transition time is invalid.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_dtt_srv.h
+++ b/include/bluetooth/mesh/gen_dtt_srv.h
@@ -99,8 +99,6 @@ void bt_mesh_dtt_srv_set(struct bt_mesh_dtt_srv *srv, uint32_t transition_time);
  * configured parameters.
  *
  * @retval 0 Successfully published the current transition time.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_loc_cli.h
+++ b/include/bluetooth/mesh/gen_loc_cli.h
@@ -108,8 +108,6 @@ struct bt_mesh_loc_cli {
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -133,8 +131,6 @@ int bt_mesh_loc_cli_global_get(struct bt_mesh_loc_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -153,8 +149,6 @@ int bt_mesh_loc_cli_global_set(struct bt_mesh_loc_cli *cli,
  * @param[in] loc New Global Location value to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -177,8 +171,6 @@ int bt_mesh_loc_cli_global_set_unack(struct bt_mesh_loc_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -202,8 +194,6 @@ int bt_mesh_loc_cli_local_get(struct bt_mesh_loc_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -222,8 +212,6 @@ int bt_mesh_loc_cli_local_set(struct bt_mesh_loc_cli *cli,
  * @param[in] loc New Local Location value to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_loc_srv.h
+++ b/include/bluetooth/mesh/gen_loc_srv.h
@@ -156,8 +156,6 @@ struct bt_mesh_loc_srv {
  * @param[in] global Current global location.
  *
  * @retval 0 Successfully published a Global Location status message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -183,8 +181,6 @@ int32_t bt_mesh_loc_srv_global_pub(struct bt_mesh_loc_srv *srv,
  * @param[in] local Current local location.
  *
  * @retval 0 Successfully published a Local Location status message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_lvl_cli.h
+++ b/include/bluetooth/mesh/gen_lvl_cli.h
@@ -87,8 +87,6 @@ struct bt_mesh_lvl_cli {
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -113,8 +111,6 @@ int bt_mesh_lvl_cli_get(struct bt_mesh_lvl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -134,8 +130,6 @@ int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
  * the server's default transition parameters.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -165,8 +159,6 @@ int bt_mesh_lvl_cli_set_unack(struct bt_mesh_lvl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -193,8 +185,6 @@ int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
  * use the server's default transition parameters.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -229,8 +219,6 @@ int bt_mesh_lvl_cli_delta_set_unack(
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -262,8 +250,6 @@ int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
  * use the server's default transition parameters.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_lvl_srv.h
+++ b/include/bluetooth/mesh/gen_lvl_srv.h
@@ -160,8 +160,6 @@ struct bt_mesh_lvl_srv {
  * @param[in] status Current status.
  *
  * @retval 0 Successfully published a Generic Level Status message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_onoff_cli.h
+++ b/include/bluetooth/mesh/gen_onoff_cli.h
@@ -88,8 +88,6 @@ struct bt_mesh_onoff_cli {
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -115,8 +113,6 @@ int bt_mesh_onoff_cli_get(struct bt_mesh_onoff_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -137,8 +133,6 @@ int bt_mesh_onoff_cli_set(struct bt_mesh_onoff_cli *cli,
  * transition parameters on the server.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_onoff_srv.h
+++ b/include/bluetooth/mesh/gen_onoff_srv.h
@@ -117,8 +117,6 @@ struct bt_mesh_onoff_srv {
  * @param[in] status Current status.
  *
  * @retval 0 Successfully published a Generic OnOff Status message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_plvl_cli.h
+++ b/include/bluetooth/mesh/gen_plvl_cli.h
@@ -123,8 +123,6 @@ struct bt_mesh_plvl_cli {
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -149,8 +147,6 @@ int bt_mesh_plvl_cli_power_get(struct bt_mesh_plvl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -170,8 +166,6 @@ int bt_mesh_plvl_cli_power_set(struct bt_mesh_plvl_cli *cli,
  * to use the server's default transition parameters.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -193,8 +187,6 @@ int bt_mesh_plvl_cli_power_set_unack(struct bt_mesh_plvl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -218,8 +210,6 @@ int bt_mesh_plvl_cli_range_get(struct bt_mesh_plvl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -239,8 +229,6 @@ int bt_mesh_plvl_cli_range_set(struct bt_mesh_plvl_cli *cli,
  * @param[in] range New Power Range value to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -262,8 +250,6 @@ int bt_mesh_plvl_cli_range_set_unack(struct bt_mesh_plvl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -286,8 +272,6 @@ int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -307,8 +291,6 @@ int bt_mesh_plvl_cli_default_set(struct bt_mesh_plvl_cli *cli,
  *
  * @retval 0 Successfully sent the message.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -334,8 +316,6 @@ int bt_mesh_plvl_cli_default_set_unack(struct bt_mesh_plvl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_plvl_srv.h
+++ b/include/bluetooth/mesh/gen_plvl_srv.h
@@ -174,8 +174,6 @@ struct bt_mesh_plvl_srv {
  * @param[in] status Status to publish.
  *
  * @return 0 Successfully published the current Power state.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_ponoff_cli.h
+++ b/include/bluetooth/mesh/gen_ponoff_cli.h
@@ -88,8 +88,6 @@ struct bt_mesh_ponoff_cli {
  * @retval 0 Successfully sent a get message. If a response buffer is
  * provided, it has been populated.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -115,8 +113,6 @@ int bt_mesh_ponoff_cli_on_power_up_get(struct bt_mesh_ponoff_cli *cli,
  * @retval 0 Successfully sent a set message. If a response buffer is
  * provided, it has been populated.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -135,8 +131,6 @@ int bt_mesh_ponoff_cli_on_power_up_set(struct bt_mesh_ponoff_cli *cli,
  * @param[in] on_power_up New OnPowerUp state of the server.
  *
  * @retval 0 Successfully sent a set message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -130,8 +130,6 @@ void bt_mesh_ponoff_srv_set(struct bt_mesh_ponoff_srv *srv,
  * parameters.
  *
  * @return 0 Successfully published the current OnPowerUp state.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_prop_cli.h
+++ b/include/bluetooth/mesh/gen_prop_cli.h
@@ -114,8 +114,6 @@ struct bt_mesh_prop_cli {
  * fit in the response buffers were copied into it, and the @p rsp::count
  * field was left unchanged.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -146,8 +144,6 @@ int bt_mesh_prop_cli_props_get(struct bt_mesh_prop_cli *cli,
  * fit in the response buffers were copied into it, and the @p rsp::count
  * field was left unchanged.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -179,8 +175,6 @@ int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -207,8 +201,6 @@ int bt_mesh_prop_cli_user_prop_set(struct bt_mesh_prop_cli *cli,
  * will be ignored.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -231,8 +223,6 @@ int bt_mesh_prop_cli_user_prop_set_unack(struct bt_mesh_prop_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -252,8 +242,6 @@ int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
  * @param[in] val New property value to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -276,8 +264,6 @@ int bt_mesh_prop_cli_admin_prop_set_unack(struct bt_mesh_prop_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -297,8 +283,6 @@ int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
  * @param[in] prop New property value to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/gen_prop_srv.h
+++ b/include/bluetooth/mesh/gen_prop_srv.h
@@ -224,8 +224,6 @@ struct bt_mesh_prop_srv {
  *
  * @retval 0 Successfully publish a Generic Level Status message.
  * @retval -EMSGSIZE The given property size is not supported.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -244,8 +242,6 @@ int bt_mesh_prop_srv_pub_list(struct bt_mesh_prop_srv *srv,
  * @retval -EINVAL The server is a Client Property server, which does not
  * support publishing of property values.
  * @retval -EMSGSIZE The given property size is not supported.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/light_ctl_cli.h
+++ b/include/bluetooth/mesh/light_ctl_cli.h
@@ -122,8 +122,6 @@ struct bt_mesh_light_ctl_cli {
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -146,8 +144,6 @@ int bt_mesh_light_ctl_get(struct bt_mesh_light_ctl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -166,8 +162,6 @@ int bt_mesh_light_ctl_set(struct bt_mesh_light_ctl_cli *cli,
  * @param[in] set CTL state to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -193,8 +187,6 @@ int bt_mesh_light_ctl_set_unack(struct bt_mesh_light_ctl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -222,8 +214,6 @@ int bt_mesh_light_temp_get(struct bt_mesh_light_ctl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -248,8 +238,6 @@ int bt_mesh_light_temp_set(struct bt_mesh_light_ctl_cli *cli,
  * @param[in] set CTL Temperature state to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -270,8 +258,6 @@ int bt_mesh_light_temp_set_unack(
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -294,8 +280,6 @@ int bt_mesh_light_ctl_default_get(struct bt_mesh_light_ctl_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -315,8 +299,6 @@ int bt_mesh_light_ctl_default_set(struct bt_mesh_light_ctl_cli *cli,
  * @param[in] set Default CTL value to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -337,8 +319,6 @@ int bt_mesh_light_ctl_default_set_unack(
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -361,8 +341,6 @@ int bt_mesh_light_temp_range_get(
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -382,8 +360,6 @@ int bt_mesh_light_temp_range_set(
  * @param[in] set Range state to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/light_ctl_srv.h
+++ b/include/bluetooth/mesh/light_ctl_srv.h
@@ -198,8 +198,6 @@ struct bt_mesh_light_ctl_srv {
  * @param[in] status Current status.
  *
  * @retval 0 Successfully published a Generic OnOff Status message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -222,8 +220,6 @@ int32_t bt_mesh_light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
  * @param[in] status Current status.
  *
  * @retval 0 Successfully published a Generic OnOff Status message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -245,8 +241,6 @@ int32_t bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
  * default publish parameters.
  *
  * @retval 0 Successfully published a Generic OnOff Status message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -256,8 +256,6 @@ bool bt_mesh_light_ctrl_srv_is_on(struct bt_mesh_light_ctrl_srv *srv);
  *                 parameters.
  *
  *  @return 0              Successfully published the current Light state.
- *  @retval -ENOTSUP       A message context was not provided and publishing is
- *                         not supported.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -142,8 +142,6 @@ struct bt_mesh_light_temp_srv {
  * @param[in] status Current status.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/lightness_cli.h
+++ b/include/bluetooth/mesh/lightness_cli.h
@@ -125,8 +125,6 @@ struct bt_mesh_lightness_cli {
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -151,8 +149,6 @@ int bt_mesh_lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -172,8 +168,6 @@ int bt_mesh_lightness_cli_light_set(struct bt_mesh_lightness_cli *cli,
  * to use the server's default transition parameters.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -195,8 +189,6 @@ int bt_mesh_lightness_cli_light_set_unack(
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -220,8 +212,6 @@ int bt_mesh_lightness_cli_range_get(struct bt_mesh_lightness_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -241,8 +231,6 @@ int bt_mesh_lightness_cli_range_set(struct bt_mesh_lightness_cli *cli,
  * @param[in] range New Light Range value to set.
  *
  * @retval 0 Successfully sent the message.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -264,8 +252,6 @@ int bt_mesh_lightness_cli_range_set_unack(
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -288,8 +274,6 @@ int bt_mesh_lightness_cli_default_get(struct bt_mesh_lightness_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -309,8 +293,6 @@ int bt_mesh_lightness_cli_default_set(struct bt_mesh_lightness_cli *cli,
  *
  * @retval 0 Successfully sent the message.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -336,8 +318,6 @@ int bt_mesh_lightness_cli_default_set_unack(struct bt_mesh_lightness_cli *cli,
  *
  * @retval 0 Successfully sent the message and populated the @c rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -175,8 +175,6 @@ struct bt_mesh_lightness_srv {
  * @param[in] status Status to publish.
  *
  * @return 0 Successfully published the current Light state.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.

--- a/include/bluetooth/mesh/time_cli.h
+++ b/include/bluetooth/mesh/time_cli.h
@@ -147,8 +147,6 @@ struct bt_mesh_time_cli {
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
  * @retval -EALREADY      A blocking request is already in progress.
- * @retval -ENOTSUP       A message context was not provided and
- *                        publishing is not supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
@@ -170,8 +168,6 @@ int bt_mesh_time_cli_time_get(struct bt_mesh_time_cli *cli,
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
  * @retval -EALREADY      A blocking request is already in progress.
- * @retval -ENOTSUP       A message context was not provided and
- *                        publishing is not supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
@@ -193,8 +189,6 @@ int bt_mesh_time_cli_time_set(struct bt_mesh_time_cli *cli,
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
  * @retval -EALREADY      A blocking request is already in progress.
- * @retval -ENOTSUP       A message context was not provided and
- *                        publishing is not supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
@@ -219,8 +213,6 @@ int bt_mesh_time_cli_zone_get(struct bt_mesh_time_cli *cli,
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
  * @retval -EALREADY      A blocking request is already in progress.
- * @retval -ENOTSUP       A message context was not provided and
- *                        publishing is not supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
@@ -242,8 +234,6 @@ int bt_mesh_time_cli_zone_set(struct bt_mesh_time_cli *cli,
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
  * @retval -EALREADY      A blocking request is already in progress.
- * @retval -ENOTSUP       A message context was not provided and
- *                        publishing is not supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
@@ -268,8 +258,6 @@ int bt_mesh_time_cli_tai_utc_delta_get(
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
  * @retval -EALREADY      A blocking request is already in progress.
- * @retval -ENOTSUP       A message context was not provided and
- *                        publishing is not supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
@@ -291,8 +279,6 @@ int bt_mesh_time_cli_tai_utc_delta_set(
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
  * @retval -EALREADY      A blocking request is already in progress.
- * @retval -ENOTSUP       A message context was not provided and
- *                        publishing is not supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.
@@ -313,8 +299,6 @@ int bt_mesh_time_cli_role_get(struct bt_mesh_time_cli *cli,
  * @retval 0              Successfully sent the message and populated
  *                        the @p rsp buffer.
  * @retval -EALREADY      A blocking request is already in progress.
- * @retval -ENOTSUP       A message context was not provided and
- *                        publishing is not supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
  * @retval -EAGAIN        The device has not been provisioned.

--- a/include/bluetooth/mesh/time_srv.h
+++ b/include/bluetooth/mesh/time_srv.h
@@ -128,8 +128,6 @@ struct bt_mesh_time_srv {
  *                   parameters.
  *
  * @return 0              Successfully published the current Light state.
- * @retval -ENOTSUP       A message context was not provided and publishing is
- *                        not supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                        not configured.
  * @retval -EAGAIN        The device has not been provisioned.


### PR DESCRIPTION
Publishing is always supported in the model implementations, so this
error return can never happen.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>