### PR TITLE
manifest: update Thread certification information in nrfxlib

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 0ae93a2f7da1b65e8b0c1f61849b78910183fc32
+      revision: 87610437d0c5c60fb3a3b24ae66d74ff857d0d09
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Update manifest to get the new information about Thread certification in nrfxlib.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-8126