### PR TITLE
SPM: sample: Use NCS default configurations

### DIFF
--- a/samples/spm/prj.conf
+++ b/samples/spm/prj.conf
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
+CONFIG_NCS_SAMPLES_DEFAULTS=y
+
 CONFIG_IS_SPM=y
 CONFIG_FW_INFO=y
 CONFIG_GPIO=n

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -30,7 +30,7 @@
 #define NON_SECURE_RAM_OFFSET PM_SRAM_SECURE_SIZE
 #else
 #include <storage/flash_map.h>
-#define NON_SECURE_APP_ADDRESS FLASH_AREA_ID(image_0_nonsecure)
+#define NON_SECURE_APP_ADDRESS FLASH_AREA_OFFSET(image_0_nonsecure)
 /* This reflects the configuration in DTS. */
 #define NON_SECURE_RAM_OFFSET 0x10000
 #endif /* USE_PARTITION_MANAGER */


### PR DESCRIPTION
Update SPM sample to use NCS default configuration, as is common with NCS samples.

`nrf9160/at_client` was used for testing. Configurations were correctly set into the application binary without causing a change in sample application functionality.

### Bugfix

While checking the single-image build of SPM sample separately from the application, it was noticed that SPM was incorrectly deriving the secure image address from the devicetree and causing a fault. The secure region memory address was being seen as the ID of image 0 (e.g. `2`) rather than its actual address. Updated to use correct macro `FLASH_AREA_OFFSET`.