### PR TITLE
zigbee: Allow for using software aes

### DIFF
--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -252,6 +252,10 @@ config ZIGBEE_UART_TX_BUF_LEN
 
 endif #ZIGBEE_HAVE_SERIAL
 
+config ZIGBEE_USE_SOFTWARE_AES
+	bool "Use software based AES"
+	select TINYCRYPT
+	default n
 
 config ZIGBEE_USE_LEDS
 	bool "LEDs abstract for ZBOSS OSIF"

--- a/subsys/zigbee/osif/zb_nrf_crypto.c
+++ b/subsys/zigbee/osif/zb_nrf_crypto.c
@@ -12,6 +12,9 @@
 #include <crypto/cipher.h>
 #elif CONFIG_BT_CTLR
 #include <bluetooth/crypto.h>
+#elif CONFIG_ZIGBEE_USE_SOFTWARE_AES
+#include <tinycrypt/aes.h>
+#include <tinycrypt/constants.h>
 #else
 #error No crypto suite for Zigbee stack has been selected
 #endif
@@ -70,6 +73,18 @@ static void encrypt_aes(zb_uint8_t *key, zb_uint8_t *msg, zb_uint8_t *c)
 
 	err = bt_encrypt_be(key, msg, c);
 	__ASSERT(!err, "Encryption failed");
+}
+#elif CONFIG_ZIGBEE_USE_SOFTWARE_AES
+static void encrypt_aes(zb_uint8_t *key, zb_uint8_t *msg, zb_uint8_t *c)
+{
+	int err;
+	struct tc_aes_key_sched_struct s;
+
+	err = tc_aes128_set_encrypt_key(&s, key);
+	__ASSERT(err == TC_CRYPTO_SUCCESS, "Key set failed");
+
+	err = tc_aes_encrypt(c, msg, &s);
+	__ASSERT(err == TC_CRYPTO_SUCCESS, "Encryption failed");
 }
 #endif
 


### PR DESCRIPTION
This provides an option to use software based AES for
testing and development purposes.

Signed-off-by: Wojciech Bober <wojciech.bober@nordicsemi.no>