### PR TITLE
partition_manager: Skip end_address test if not present

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -939,7 +939,7 @@ def expect_addr_size(td, name, expected_address, expected_size):
     if expected_address:
         assert td[name]['address'] == expected_address, \
             "Address of {} was {}, expected {}.\ntd:{}".format(name, td[name]['address'], expected_address, pformat(td))
-    if expected_size and expected_address:
+    if td[name].get('end_address') and expected_size and expected_address:
         assert td[name]['end_address'] == expected_address + expected_size, \
             "End address of {} was {}, expected {}.\ntd:{}".format(name, td[name]['end_address'], expected_address + expected_size, pformat(td))
 


### PR DESCRIPTION
Fixes a bug preventing self-testing of `partition_manager.py`.

The test dictionary may not contain an `end_address` key, as with the current test implementation. While `_END_ADDRESS` is part of PM config, it did not appear necessary to the test dict to be present for every call of `expect_addr_size` and could be skipped if not present.