### PR TITLE
manifest: Updated manifest to nrfxlib PR 340

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,9 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 0ae93a2f7da1b65e8b0c1f61849b78910183fc32
+
+      revision: pull/340/head
+
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
-Adds nrf_cc3xx_platform/mbedcrypto v0.9.5
-Adds correct TRNG characterization for nrF5340

nrfxlib pr: https://github.com/nrfconnect/sdk-nrfxlib/pull/340

ref: NCSDK-6890

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>