### PR TITLE
cmake: use app's imgtool extra arguments Kconfig

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -137,6 +137,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     --version     ${CONFIG_MCUBOOT_IMAGE_VERSION}
     --slot-size   $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_SIZE>
     --pad-header
+    ${CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS}
     )
 
   if(CONFIG_ZIGBEE)


### PR DESCRIPTION
Transfer CONFIG_MCUBOOT_EXTRA_IMGTOOL_ARGS to sign_cmd.
This allow to provide additional `imgtool sign` parameters
via Kconfig.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>