### PR TITLE
manifest: update nrfxlib for MPSL and SoftDevice controller

### DIFF
--- a/samples/mpsl/timeslot/src/main.c
+++ b/samples/mpsl/timeslot/src/main.c
@@ -21,7 +21,6 @@
 #define STACKSIZE                    CONFIG_MAIN_STACK_SIZE
 #define THREAD_PRIORITY              K_LOWEST_APPLICATION_THREAD_PRIO
 
-static volatile int timeslot_counter;
 static bool request_in_cb = true;
 
 /* MPSL API calls that can be requested for the non-preemptible thread */
@@ -94,10 +93,8 @@ static mpsl_timeslot_signal_return_param_t *mpsl_timeslot_callback(
 		break;
 	case MPSL_TIMESLOT_SIGNAL_SESSION_CLOSED:
 		break;
-	case MPSL_TIMESLOT_SIGNAL_CANCELLED:
-	case MPSL_TIMESLOT_SIGNAL_BLOCKED:
-	case MPSL_TIMESLOT_SIGNAL_INVALID_RETURN:
 	default:
+		printk("unexpected signal: %u", signal_type);
 		error();
 		break;
 	}

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -156,6 +156,8 @@ static int mpsl_lib_init(const struct device *dev)
 
 	clock_cfg.source = m_config_clock_source_get();
 	clock_cfg.accuracy_ppm = CONFIG_CLOCK_CONTROL_NRF_ACCURACY;
+	clock_cfg.skip_wait_lfclk_started =
+		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT);
 
 #ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
 	clock_cfg.rc_ctiv = MPSL_RECOMMENDED_RC_CTIV;

--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ff37d4700f6e3263ecb1d0e5945fe054197c770b
+      revision: ab60d3ca0a7befd2365d37fb19a7bd493d6b58a4
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Highlights:
- Fixes [known-issue DRGN-15064 for MPSL](http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html#multiprotocol-service-layer-mpsl)
- MPSL will now respect `CONFIG_SYSTEM_CLOCK_NO_WAIT`
- Adds new signal in MPSL timeslot: `MPSL_TIMESLOT_SIGNAL_OVERSTAYED`
- Fixes build error for nrf52dk_nrf52805