### PR TITLE
doc: Add TF-M documentation

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -538,6 +538,15 @@
 
 .. _`Leshan Demo Server`: https://github.com/eclipse/leshan/blob/master/README.md
 
+.. _`Platform Security Architecture (PSA)`: https://www.psacertified.org/what-is-psa-certified/
+
+.. _`Trusted Firmware M source code`: https://git.trustedfirmware.org/
+
+.. _`Zephyr TF-M module`: https://github.com/zephyrproject-rtos/trusted-firmware-m
+
+.. _`TF-M documentation`: https://ci-builds.trustedfirmware.org/static-files/DkdCrQzFZSnnOE237JnAP31qbSUWnEhVzQwxZ_NIpaExNjA2NDMwMTIxODMyOjk6YW5vbnltb3VzOnZpZXcvVEYtTS9qb2IvdGYtbS1idWlsZC1kb2NzLW5pZ2h0bHkvbGFzdFN0YWJsZUJ1aWxkL2FydGlmYWN0/trusted-firmware-m/build/install/doc/user_guide/html/docs/introduction/readme.html
+
+
 .. ### Links to specific files on GitHub
 
 .. _`nrf9160dk_nrf9160_partition_conf.dts`: https://github.com/nrfconnect/sdk-zephyr/blob/master/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts

--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -35,7 +35,6 @@ In addition, the |NCS| provides the following samples that showcase the use of a
    :glob:
 
    ../../samples/nrf9160/*/README
-   ../../samples/tfm/*/README
 
 .. _nrf5340_samples:
 
@@ -46,7 +45,6 @@ In addition, the |NCS| provides the following samples that showcase the use of a
 
    ../../samples/nrf5340/*/README
    ../../samples/nrf_rpc/entropy_nrf53/README
-   ../../samples/tfm/*/README
 
 .. _openthread_samples:
 
@@ -77,5 +75,6 @@ In addition, the |NCS| provides the following samples that showcase the use of a
    ../../samples/peripheral/*/README
    ../../samples/sensor/*/README
    ../../samples/usb/*/README
+   ../../samples/tfm/*/README
 
 For more complex examples, see :ref:`applications`.

--- a/doc/nrf/ug_app_dev.rst
+++ b/doc/nrf/ug_app_dev.rst
@@ -18,3 +18,4 @@ The following user guides introduce important concepts that you should be  famil
    ug_multi_image
    ug_bootloader
    ug_unity_testing
+   ug_tfm

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -70,6 +70,17 @@ In Zephyr, :ref:`zephyr:nrf5340dk_nrf5340` is divided into two different build t
 
 When built for the ``nrf5340dk_nrf5340_cpuappns`` board, the :ref:`secure_partition_manager` sample is automatically included in the build.
 
+.. tfm_support_start
+
+Trusted Firmware-M (TF-M) support
+---------------------------------
+
+You can use Trusted Firmware-M (TF-M) as an alternative to :ref:`secure_partition_manager` for running an application from the non-secure area of the memory.
+
+For more information and instructions on how to do this, see :ref:`ug_tfm`.
+
+.. tfm_support_finish
+
 Inter-core communication
 ========================
 

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -64,6 +64,10 @@ This firmware is required to set up the nRF9160 DK so that it can run user appli
 The Secure Partition Manager sample is automatically included in the build for the ``nrf9160dk_nrf9160ns`` build target.
 To disable the automatic inclusion of the Secure Partition Manager sample, set the option :option:`CONFIG_SPM` to "n" in the project configuration.
 
+.. include:: ug_nrf5340.rst
+   :start-after: tfm_support_start
+   :end-before: tfm_support_finish
+
 Application
 -----------
 

--- a/doc/nrf/ug_tfm.rst
+++ b/doc/nrf/ug_tfm.rst
@@ -1,0 +1,62 @@
+.. _ug_tfm:
+
+Running applications with Trusted Firmware-M
+############################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+On nRF5340 and nRF9160, you can use Trusted Firmware-M (TF-M) as an alternative to :ref:`secure_partition_manager` for running an application from the non-secure area of the memory.
+
+Overview
+********
+
+TF-M is the reference implementation of `Platform Security Architecture (PSA)`_.
+
+It provides a highly configurable set of software components to create a Trusted Execution Environment.
+This is achieved by a set of secure run time services such as Secure Storage, Cryptography, Audit Logs, and Attestation.
+Additionally, secure boot via MCUboot in TF-M ensures integrity of run time software and supports firmware upgrade.
+
+For official documentation, see `TF-M documentation`_.
+
+The TF-M implementation in |NCS| is currently demonstrated in the :ref:`tfm_hello_world` sample.
+
+Building
+********
+
+TF-M is one of the images that are built as part of a multi-image application.
+For more information about multi-image builds, see :ref:`ug_multi_image`.
+
+To add TF-M to your build, enable the :option:`CONFIG_BUILD_WITH_TFM` configuration option by adding it to your :file:`prj.conf` file.
+
+.. note::
+   If you use menuconfig to enable :option:`CONFIG_BUILD_WITH_TFM`, you must also enable its dependencies.
+
+You must build TF-M using a non-secure build target.
+The following targets are currently supported:
+
+* ``nrf5340dk_nrf5340_cpuappns``
+* ``nrf9160dk_nrf9160ns``
+
+When building for ``nrf9160dk_nrf9160ns``, UART1 must be disabled in the non-secure application, because it is used by the TF-M secure application.
+Otherwise, the non-secure application will fail to run.
+The recommended way to do this is to copy the .overlay file from the :ref:`tfm_hello_world` sample.
+
+Programming
+***********
+
+The procedure for programming an application with TF-M is the same as for other multi-image applications in |NCS|.
+
+After building the application, a :file:`merged.hex` file is created that contains MCUboot, TF-M, and the application.
+The :file:`merged.hex` file can be then :ref:`programmed using SES <gs_programming_ses>`.
+When using the command line, the file is programmed automatically when you call ``ninja flash`` or ``west flash``.
+
+Logging
+*******
+
+TF-M employs two UART interfaces for logging: one for the secure part (MCUboot and TF-M), and one for the non-secure application.
+The logs arrive on different COM ports on the host PC.
+
+On the nRF5340 DK, you must connect specific wires on the board to receive secure logs on the host PC.
+Wire the pins P0.25 and P0.26 to RxD and TxD respectively.

--- a/samples/spm/README.rst
+++ b/samples/spm/README.rst
@@ -10,6 +10,9 @@ Secure Partition Manager
 The Secure Partition Manager sample provides a reference use of the System Protection Unit peripheral.
 This firmware is required to set up an nRF device with Trusted Execution (|trusted_execution|) so that it can run user applications in the non-secure domain.
 
+.. note::
+   An alternative for using the SPM is Trusted Firmware-M (TF-M). See :ref:`ug_tfm`.
+
 Overview
 ********
 

--- a/samples/tfm/tfm_hello_world/README.rst
+++ b/samples/tfm/tfm_hello_world/README.rst
@@ -27,12 +27,21 @@ Building and Running
 
 .. include:: /includes/build_and_run.txt
 
-Sample Output
-=============
+Testing
+=======
+
+After programming the sample, the following output is displayed in the console:
 
 .. code-block:: console
 
-    Hello World! nrf5340pdk_nrf5340_cpuapp
+    Hello World! nrf5340dk_nrf5340_cpuapp
     SHA256 digest:
     d87280aef6d36814af7cd864bc7cf28f
     759f8d33c97459dd28eacee7133cb60c
+
+Dependencies
+*************
+
+This sample uses the TF-M module that can be found in the following location in the |NCS| folder structure:
+
+* ``modules/tee/tfm/``


### PR DESCRIPTION
First changes in documentation reflecting TF-M support in NCS.

Signed-off-by: Bartosz Gentkowski <bartosz.gentkowski@nordicsemi.no>