### PR TITLE
doc: changed nRF5340 PDK to nRF5340 DK

### DIFF
--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -49,7 +49,7 @@ MCUboot bootloader
 
 nRF5340 support
    nRF5340 contains two separate processors: a network core and an application core.
-   When programming applications to the nRF5340 PDK, they must be divided into at least two images, one for each core.
+   When programming applications to the nRF5340 DK, they must be divided into at least two images, one for each core.
    See :ref:`ug_nrf5340` for more information.
 
 Default configuration

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -7,10 +7,10 @@ Working with nRF53 Series
    :local:
    :depth: 2
 
-The |NCS| provides support for developing on the nRF5340 System on Chip (SoC) using the nRF5340 PDK (PCA10095).
+The |NCS| provides support for developing on the nRF5340 System on Chip (SoC) using the nRF5340 DK (PCA10095).
 
-See the `nRF5340 PDK User Guide`_ for detailed information about the nRF5340 PDK hardware.
-To get started with the nRF5340 PDK, follow the steps in the `Getting started with nRF Connect SDK (nRF53 Series)`_ guide.
+See the `nRF5340 PDK User Guide`_ for detailed information about the nRF5340 DK hardware.
+To get started with the nRF5340 DK, follow the steps in the `Getting started with nRF Connect SDK (nRF53 Series)`_ guide.
 
 
 Introduction
@@ -20,6 +20,7 @@ nRF5340 is a wireless ultra-low power multicore System on Chip (SoC) with two fu
 The |NCS| supports Bluetooth Low Energy and NFC communication on the nRF5340 SoC.
 
 See the `nRF5340 Product Specification`_ for more information about the nRF5340 SoC.
+
 :ref:`zephyr:nrf5340dk_nrf5340` gives an overview of the nRF5340 PDK support in Zephyr.
 
 Network core
@@ -128,7 +129,7 @@ Application samples
 ===================
 
 The |NCS| provides a series of :ref:`Bluetooth Low Energy samples <ble_samples>`, in addition to the :ref:`Bluetooth samples in Zephyr <zephyr:bluetooth-samples>`.
-Most of these samples should run on the nRF5340 PDK, but not all have been thoroughly tested.
+Most of these samples should run on the nRF5340 DK, but not all have been thoroughly tested.
 
 Some Bluetooth LE samples require configuration adjustments to the :ref:`zephyr:bluetooth-hci-rpmsg-sample` sample as described in the `Network samples`_ section.
 
@@ -160,7 +161,7 @@ For this to work, the network core image must be explicitly added as a child ima
 See :ref:`ug_multi_image_defining` for details.
 
 The network sample :ref:`zephyr:bluetooth-hci-rpmsg-sample` is automatically added to all Bluetooth Low Energy samples in the |NCS|.
-When :option:`CONFIG_BT_RPMSG_NRF53` is set to ``y`` (the default), the build system automatically includes the sample as a child image in the ``nrf5340_pdk_nrf5340_cpunet`` core.
+When :option:`CONFIG_BT_RPMSG_NRF53` is set to ``y`` (the default), the build system automatically includes the sample as a child image in the ``nrf5340_dk_nrf5340_cpunet`` core.
 
 If the image in the network core is not added to the application core build, you can build and program both samples separately by following the instructions in :ref:`gs_programming_ses`.
 Make sure to use ``nrf5340dk_nrf5340_cpunet`` as build target when building the network sample, and ``nrf5340dk_nrf5340_cpuapp`` or ``nrf5340dk_nrf5340_cpuappns`` when building the application sample.
@@ -188,7 +189,7 @@ Then navigate to the build folder of the application sample and enter the follow
 Getting logging output
 **********************
 
-When connected to the computer, the nRF5340 PDK emulates three virtual COM ports.
+When connected to the computer, the nRF5340 DK emulates three virtual COM ports.
 In the default configuration, logging output of the application core sample is available on the third (last) COM port.
 The first two COM ports are silent.
 
@@ -199,7 +200,7 @@ Logging output on the network core
 
 In the default configuration, you cannot access the logging output of the network core sample.
 
-To get logging output on the second COM port, you must connect certain pins on the nRF5340 PDK.
+To get logging output on the second COM port, you must connect certain pins on the nRF5340 DK.
 The following table lists which pins must be shorted:
 
 .. list-table::

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -79,7 +79,7 @@ You can use any two of the development kits listed above and mix different devel
 
 .. note::
 
-  If you use nRF5340 PDK, add the following options to the configuration of the network sample:
+  If you use nRF5340 DK, add the following options to the configuration of the network sample:
 
   .. code-block:: none
 

--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -33,7 +33,7 @@ The sample supports any one of the following development kits:
    :rows: nrf5340dk_nrf5340_cpunet, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 .. note::
-   For nRF5340 PDK, this sample is only supported on the network core (nrf5340dk_nrf5340_cpunet), and the :ref:`nrf5340_empty_app_core` sample must be programmed to the application core.
+   For nRF5340 DK, this sample is only supported on the network core (nrf5340dk_nrf5340_cpunet), and the :ref:`nrf5340_empty_app_core` sample must be programmed to the application core.
 
 Building and Running
 ********************

--- a/samples/nrf5340/netboot/README.rst
+++ b/samples/nrf5340/netboot/README.rst
@@ -62,11 +62,11 @@ To test the network core bootloader sample run the following commands:
 
 #. |connect_terminal|
 
-   Note that on the nRF5340 PDK has multiple UART instances, so the correct port must be identified.
+   Note that on the nRF5340 DK has multiple UART instances, so the correct port must be identified.
 
 #. ``west build -b nrf5340dk_nrf5340_cpuapp -d build_netboot samples/bluetooth/peripheral_uart -f -- -DCONFIG_BOOTLOADER_MCUBOOT=y -Dmcuboot_CONFIG_PCD=y``
 
-   This sample (:file:`samples/bluetooth/peripheral_uart`) will automatically include the network core sample ``hci_rpmsg`` when built for the nRF5340 PDK.
+   This sample (:file:`samples/bluetooth/peripheral_uart`) will automatically include the network core sample ``hci_rpmsg`` when built for the nRF5340 DK.
    Since we enable MCUBoot (``-DCONFIG_BOOTLOADER_MCUBOOT=y``) in the application core, the network core bootloader is automatically included as well.
    In addition to this, it is necessary to enable the :ref:`subsys_pcd` subsys for the MCUBoot image (``-Dmcuboot_CONFIG_PCD=y``).
 

--- a/samples/nrf_rpc/entropy_nrf53/README.rst
+++ b/samples/nrf_rpc/entropy_nrf53/README.rst
@@ -7,9 +7,9 @@ nRF5340: nRF RPC Entropy
    :local:
    :depth: 2
 
-The nRF RPC Entropy sample demonstrates how to use the entropy driver in a dual core device such as nRF5340 PDK.
+The nRF RPC Entropy sample demonstrates how to use the entropy driver in a dual core device such as nRF5340 DK.
 
-The sample makes use of the entropy driver on the network core of an nRF5340 PDK that generates random data, and the :ref:`nrfxlib:nrf_rpc` that sends the generated data to the application core using `Remote Procedure Calls (RPC)`_.
+The sample makes use of the entropy driver on the network core of an nRF5340 DK that generates random data, and the :ref:`nrfxlib:nrf_rpc` that sends the generated data to the application core using `Remote Procedure Calls (RPC)`_.
 
 Overview
 ********


### PR DESCRIPTION
I have changed all instances of nRF5340 PDK to nRF5340 DK.
There are a few links still to be fixed.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>