### PR TITLE
WIP drivers: mpsl: Allow initiating lf clock but do not wait for readiness

### DIFF
--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -132,6 +132,7 @@ static int mpsl_lib_init(const struct device *dev)
 
 	clock_cfg.source = m_config_clock_source_get();
 	clock_cfg.accuracy_ppm = CONFIG_CLOCK_CONTROL_NRF_ACCURACY;
+	clock_cfg.no_wait_lfclk = IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT);
 
 #ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
 	clock_cfg.rc_ctiv = MPSL_RECOMMENDED_RC_CTIV;

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 6ee81029d57d77ee7cbd9e9b7f1740f347e4dce2
+      revision: pull/344/head
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Add an option to not wait for lf clock to start using MPSL clock API.