### PR TITLE
doc: Updated release-notes-latest.rst for dev1 tag (crypto additions)

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -44,6 +44,27 @@ Common
 
 The following changes are relevant for all device families.
 
+Crypto
+------
+
+* Added:
+
+  * nrf_cc3xx_platform v0.9.5, with the following highlights:
+
+    * Added correct TRNG characterization values for nRF5340 devices.
+
+    See the :ref:`crypto_changelog_nrf_cc3xx_platform` for detailed information.
+  * nrf_cc3xx_mbedcrypto version v0.9.5, with the following highlights:
+
+    * Built to match the nrf_cc3xx_platform v0.9.5 including correct TRNG characterization values for nRF5340 devices.
+
+    See the :ref:`crypto_changelog_nrf_cc3xx_mbedcrypto` for detailed information.
+
+* Updated:
+
+  * Rewrote the :ref:`nrfxlib:nrf_security`'s library stripping mechanism to not use the POST_BUILD option in a custom build rule.
+    The library stripping mechanism was non-functional in certain versions of SEGGER Embedded Studio Nordic Edition.
+
 MCUboot
 =======
 


### PR DESCRIPTION
-Added release note or nrf_cc3xx_platform v0.9.5
-Added release note on nrf_cc3xx_mbedcrypto v0.9.5
-Added release note on nrf_security library stripping rewrite

Ref: NCSDK-6890
Ref: NCSDK-6989

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>