### PR TITLE
Partition Manager: Ban one_of in placement property

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -1032,8 +1032,8 @@ def test():
 
     # Verify that all 'end' and 'start' are valid references in 'one_of' dicts
     td = {
-        'a': {'placement': {'after': {'one_of': ['x0', 'x1', 'start']}}, 'size': 100},
-        'b': {'placement': {'before': {'one_of': ['x0', 'x1', 'end']}}, 'size': 200},
+        'a': {'placement': {'after': ['x0', 'x1', 'start']}, 'size': 100},
+        'b': {'placement': {'before': ['x0', 'x1', 'end']}, 'size': 200},
         'app': {},
     }
     s, sub_partitions = resolve(td, 'app')
@@ -1184,7 +1184,7 @@ def test():
     # Verify that all 'one_of' dicts are replaced with the first entry which corresponds to an existing partition
     td = {
         'a': {'placement': {'after': 'start'}, 'size': 100},
-        'b': {'placement': {'after': {'one_of': ['x0', 'x1', 'a', 'x2']}}, 'size': 200},
+        'b': {'placement': {'after': ['x0', 'x1', 'a', 'x2']}, 'size': 200},
         'c': {'placement': {'after': 'b'}, 'share_size': {'one_of': ['x0', 'x1', 'b', 'a']}},
         'd': {'placement': {'after': 'c'}, 'share_size': {'one_of': ['a', 'b']}},  # Should take first existing
         # We can use  several 'one_of' - dicts inside lists
@@ -1206,14 +1206,14 @@ def test():
     # Verify that all 'share_size' with value partition that has size 0 is compatible with 'one_of' dicts
     td = {
         'a': {'placement': {'after': 'start'}, 'size': 0},
-        'b': {'placement': {'after': {'one_of': ['a', 'start']}},
+        'b': {'placement': {'after': ['a', 'start']},
               'share_size': ['a']},
-        'c': {'placement': {'after': {'one_of': ['a', 'b', 'start']}},
+        'c': {'placement': {'after': ['a', 'b', 'start']},
               'share_size': {'one_of': ['a', 'b']}},
-        'd': {'placement': {'after': {'one_of': ['a', 'b', 'c', 'start']}},
+        'd': {'placement': {'after': ['a', 'b', 'c', 'start']},
               'share_size': {'one_of': ['a', 'b', 'c']}},
         # You get the point
-        'e': {'placement': {'after': {'one_of': ['a', 'b', 'c', 'd', 'start']}}, 'size': 100}
+        'e': {'placement': {'after': ['a', 'b', 'c', 'd', 'start']}, 'size': 100}
     }
     remove_all_zero_sized_partitions(td, 'app')
     assert 'a' not in td
@@ -1224,16 +1224,16 @@ def test():
     # Verify that all 'share_size' with value partition that has size 0 is compatible withe 'one_of' dicts.
     td = {
         'a': {'placement': {'after': 'start'}, 'size': 0},
-        'b': {'placement': {'after': {'one_of': ['a', 'start']}},
+        'b': {'placement': {'after': ['a', 'start']},
               'share_size': ['a']},
-        'c': {'placement': {'after': {'one_of': ['a', 'b', 'start']}},
+        'c': {'placement': {'after': ['a', 'b', 'start']},
               'share_size': {'one_of': ['a', 'b']}},
-        'd': {'placement': {'after': {'one_of': ['a', 'b', 'c', 'start']}},
+        'd': {'placement': {'after': ['a', 'b', 'c', 'start']},
               'share_size': {'one_of': ['a', 'b', 'c']}},
         # Empty spans should be removed
         'e': {'span': [], 'region': 'sram'},
         # You get the point
-        'f': {'placement': {'after': {'one_of': ['a', 'b', 'c', 'd', 'start']}}, 'size': 100},
+        'f': {'placement': {'after': ['a', 'b', 'c', 'd', 'start']}, 'size': 100},
         'app': {}
     }
     # Perform the same test as above, but run it through the 'resolve' function this time.
@@ -1249,7 +1249,7 @@ def test():
     # Verify that an error is raised when no partition inside 'one_of' dicts exist as dict value
     failed = False
     td = {
-        'a': {'placement': {'after': {'one_of': ['x0', 'x1']}}, 'size': 100},
+        'a': {'placement': {'after': ['x0', 'x1']}, 'size': 100},
         'app': {}
     }
     try:

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -116,6 +116,8 @@ Each partition is defined as follows:
 
 The following partition properties and property values are available:
 
+.. _partition_manager_placement:
+
 placement: dict
    This property specifies the placement of the partition relative to other partitions, to the start or end of flash, or to the root image ``app``.
 
@@ -307,48 +309,60 @@ region: string
 RAM partition configuration
    RAM partitions are partitions located in the ``sram_primary`` region.
    A RAM partition is specified by having the partition name end with ``_sram``.
-   If a partition name consists of an image name and the ending ``_sram``, it is used as a permanent image RAM partition for the image.
+   If a partition name is composed of an image name plus the ``_sram`` ending, it is used as a permanent image RAM partition for the image.
+
+The following 2 examples are equivalent:
 
    .. code-block:: yaml
-      :caption: RAM partitions configuration
+      :caption: RAM partition configuration, without the ``_sram`` ending.
 
-      # This ...
       some_permament_sram_block_used_for_logging:
          size: 0x1000
          region: sram_primary
 
-      # ... is equivalent to
+   .. code-block:: yaml
+      :caption: RAM partition configuration, using the ``_sram`` ending.
+
       some_permament_sram_block_used_for_logging_sram:
          size: 0x1000
 
-      # Specify permanent image RAM partition for MCUboot.
-      # This will be used by the MCUboot linker script.
+The following example specifies a permanent image RAM partition for MCUboot, that will be used by the MCUboot linker script.
+
+   .. code-block:: yaml
+
       mcuboot_sram:
           size: 0xa000
 
-All occurrences of a partition name can be replaced with a dict with the key ``one_of``, which is resolved to the first existing partition in the ``one_of`` value.
-An error is raised if no partition inside the ``one_of`` dict exists.
+All occurrences of a partition name can be replaced by a dict with the key ``one_of``.
+This dict is resolved to the first existing partition in the ``one_of`` value.
+
+See the following 2 examples, they are equivalent:
 
    .. code-block:: yaml
       :caption: Example use of a ``one_of`` dict
 
-      # Using 'one_of' in a list like this ...
       some_span:
          span: [something, {one_of: [does_not_exist_0, does_not_exist_1, exists1, exists2]}]
 
-      # ... is equivalent to:
+   .. code-block:: yaml
+      :caption: Example not using a ``one_of`` dict
+
       some_span:
          span: [something, exists1]
 
-      # Using 'one_of' as a dict value like this ...
-      some_partition:
-         placement:
-            before: {one_of: [does_not_exist_0, does_not_exist_1, exists1, exists2]}
+An error is triggered if none of the partitions listed inside the ``one_of`` dict exists.
 
-      # ... is equivalent to:
-      some_partition:
-         placement:
-            before: exists1
+To use this functionality, the properties that must explicitly define the ``one_of`` keyword are the following:
+
+* ``span``
+* ``share_size``
+
+The :ref:`placement property <partition_manager_placement>` contains the functionality of ``one_of`` by default.
+As such, you must not use ``one_of`` with the ``placement`` property.
+Doing so will trigger a build error.
+
+The keywords ``before`` and ``after`` already check for the first existing partition in their list.
+Therefore, you can pass a list of partitions into these keywords.
 
 
 .. _pm_yaml_preprocessing:


### PR DESCRIPTION
Ref: NCSDK-4621

This blocks the use of `one_of` from being used within `placement` property keywords. The build will fail and print out a nice message informing the user that this is already handled by using a list.

Documentation is also updated to reflect this.

### Testing

Builds with various tweaks to `samples/bootloader/pm.yml` for the `samples/nrf9160/secure_services` application using `prj_with_mcuboot.conf`

Tweak:

```
b0_image:
  size: CONFIG_PM_PARTITION_SIZE_B0_IMAGE
  placement:
    after: [not_valid, {'one_of': [also_not_valid, start]}]
```

Output:

```
Partition manager failed: 'one_of' cannot be used with the 'placement'
property. This is handled by default when using a list with the 'before'
and 'after' keywords.

Failed to partition region flash_primary, size of region: 1048576
Partition Configuration:
b0_image:
  placement:
    after:
    - not_valid
    - one_of:
      - also_not_valid
      - start
  size: 32768
...
```

---

Tweak:

```
b0_image:
  size: CONFIG_PM_PARTITION_SIZE_B0_IMAGE
  placement:
    after: {'one_of': [not_valid, start]}
```

Output:
```
  Partition manager failed: 'one_of' cannot be used with the 'placement'
property. This is handled by default when using a list with the 'before'
and 'after' keywords.

Failed to partition region flash_primary, size of region: 1048576
Partition Configuration:
b0_image:
  placement:
    after:
      one_of:
      - not_valid
      - start
  size: 32768
...
```

---

Use of `one_of` in non-placement properties, such as ` span: [s0_pad, {'one_of': [does_not_exist, s0_image]}]` does not generate the failure message and builds successfully.