### PR TITLE
Bluetooth: Mesh: Fix Light CTL Temperature

### DIFF
--- a/include/bluetooth/mesh/light_ctl.h
+++ b/include/bluetooth/mesh/light_ctl.h
@@ -21,9 +21,9 @@ extern "C" {
 #endif
 
 /** Minimum permitted Temperature level */
-#define BT_MESH_LIGHT_TEMP_RANGE_MIN 800
+#define BT_MESH_LIGHT_TEMP_MIN 800
 /** Maximum permitted Temperature level */
-#define BT_MESH_LIGHT_TEMP_RANGE_MAX 20000
+#define BT_MESH_LIGHT_TEMP_MAX 20000
 
 /** All Light CTL parameters */
 struct bt_mesh_light_ctl {

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -40,8 +40,8 @@ struct bt_mesh_light_temp_srv;
 				 BT_MESH_LIGHT_TEMP_STATUS,                    \
 				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_TEMP_STATUS)) }, \
 		.temp_range = {                                                \
-			.min = BT_MESH_LIGHT_TEMP_RANGE_MIN,                   \
-			.max = BT_MESH_LIGHT_TEMP_RANGE_MAX                    \
+			.min = BT_MESH_LIGHT_TEMP_MIN,                         \
+			.max = BT_MESH_LIGHT_TEMP_MAX,                         \
 		}                                                              \
 	}
 

--- a/subsys/bluetooth/mesh/light_ctl_internal.h
+++ b/subsys/bluetooth/mesh/light_ctl_internal.h
@@ -14,18 +14,6 @@
 #include <bluetooth/mesh/light_temp_srv.h>
 #include "model_utils.h"
 
-static inline uint16_t set_temp(struct bt_mesh_light_temp_srv *srv,
-				uint16_t temp_val)
-{
-	if (temp_val < srv->temp_range.min) {
-		return srv->temp_range.min;
-	} else if (temp_val > srv->temp_range.max) {
-		return srv->temp_range.max;
-	} else {
-		return temp_val;
-	}
-}
-
 static inline uint16_t lvl_to_temp(struct bt_mesh_light_temp_srv *srv,
 				   int16_t lvl)
 {

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -98,10 +98,14 @@ static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_light_ctl_gen_cb_set set;
 	struct bt_mesh_model_transition transition;
 	uint16_t light = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
-	uint16_t temp =
-		set_temp(&(srv->temp_srv), net_buf_simple_pull_le16(buf));
+	uint16_t temp = net_buf_simple_pull_le16(buf);
 	uint16_t delta_uv = net_buf_simple_pull_le16(buf);
 	uint8_t tid = net_buf_simple_pull_u8(buf);
+
+	if ((temp < BT_MESH_LIGHT_TEMP_MIN) ||
+	    (temp > BT_MESH_LIGHT_TEMP_MAX)) {
+		return;
+	}
 
 	if (light != 0) {
 		if (light > srv->lightness_srv.range.max) {
@@ -231,10 +235,10 @@ static void temp_range_set(struct bt_mesh_model *model,
 	uint16_t new_min = net_buf_simple_pull_le16(buf);
 	uint16_t new_max = net_buf_simple_pull_le16(buf);
 
-	if ((new_min < BT_MESH_LIGHT_TEMP_RANGE_MIN) || (new_min >= new_max)) {
+	if ((new_min < BT_MESH_LIGHT_TEMP_MIN) || (new_min > new_max)) {
 		status = BT_MESH_MODEL_ERROR_INVALID_RANGE_MIN;
 		goto respond;
-	} else if (new_max > BT_MESH_LIGHT_TEMP_RANGE_MAX) {
+	} else if (new_max > BT_MESH_LIGHT_TEMP_MAX) {
 		status = BT_MESH_MODEL_ERROR_INVALID_RANGE_MAX;
 		goto respond;
 	}
@@ -316,9 +320,9 @@ static void default_set(struct bt_mesh_model *model,
 	uint16_t temp = net_buf_simple_pull_le16(buf);
 	uint16_t delta_uv = net_buf_simple_pull_le16(buf);
 
-	if ((temp < BT_MESH_LIGHT_TEMP_RANGE_MIN) ||
-	    (temp > BT_MESH_LIGHT_TEMP_RANGE_MAX)) {
-		goto respond;
+	if ((temp < BT_MESH_LIGHT_TEMP_MIN) ||
+	    (temp > BT_MESH_LIGHT_TEMP_MAX)) {
+		return;
 	}
 
 	srv->default_params.light = light;
@@ -332,7 +336,6 @@ static void default_set(struct bt_mesh_model *model,
 
 	(void)bt_mesh_light_ctl_default_pub(srv, NULL);
 
-respond:
 	if (ack) {
 		default_rsp(model, ctx);
 	}
@@ -614,7 +617,7 @@ static int bt_mesh_light_ctl_srv_start(struct bt_mesh_model *mod)
 		.time = srv->lightness_srv.ponoff.dtt.transition_time,
 		.delay = 0,
 	};
-	uint16_t temp = set_temp(&(srv->temp_srv), srv->default_params.temp);
+	uint16_t temp = srv->default_params.temp;
 
 	switch (srv->lightness_srv.ponoff.on_power_up) {
 	case BT_MESH_ON_POWER_UP_ON:

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -48,9 +48,14 @@ static void temp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_light_temp_cb_set cb_msg;
 	struct bt_mesh_light_temp_status status = { 0 };
 	struct bt_mesh_model_transition transition;
-	uint16_t temp = set_temp(srv, net_buf_simple_pull_le16(buf));
+	uint16_t temp = net_buf_simple_pull_le16(buf);
 	int16_t delta_uv = net_buf_simple_pull_le16(buf);
 	uint8_t tid = net_buf_simple_pull_u8(buf);
+
+	if ((temp < BT_MESH_LIGHT_TEMP_MIN) ||
+	    (temp > BT_MESH_LIGHT_TEMP_MAX)) {
+		return;
+	}
 
 	if (tid_check_and_update(&srv->prev_transaction, tid, ctx) != 0) {
 		/* If this is the same transaction, we don't need to send it


### PR DESCRIPTION
Add validation for boundary light temperature values instead of its rounding to min or max values. And avoid responding in the case of prohibited light temperature values. Fix comparison of Light CTL Temperature Range Min and Range Max since they may be equal, according to the specification - "The value of the Range Max field shall be greater or equal to the value of the Range Min field".
`onoff_set` function from `gen_onoff_srv.c` doesn't respond to an originator in the case of receiving a prohibited Generic OnOff value, but `default_set` from `light_ctl_srv.c` sends a response even if a new temperature value is out of borders. Indeed, I don't see clearly in the Bluetooth mesh specification whether it should send a response in such cases or not, but I think that behaviour has to be the same in all models. 

Signed-off-by: Roman Alexeev <roman@alexeyev.su>