### PR TITLE
samples/nrf5340/empty_app_core: Handle properly LFXO pins configuration

### DIFF
--- a/samples/nrf5340/empty_app_core/src/main.c
+++ b/samples/nrf5340/empty_app_core/src/main.c
@@ -53,8 +53,15 @@ static int network_gpio_allow(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	/* Allow Network MCU to use all GPIOs */
-	for (uint32_t i = 0; i < ARRAY_SIZE(NRF_P0_S->PIN_CNF); i++) {
+	/* When the use of the low frequency crystal oscillator (LFXO) is
+	 * enabled, do not modify the configuration of the pins P0.00 (XL1)
+	 * and P0.01 (XL2), as they need to stay configured with the value
+	 * Peripheral.
+	 */
+	uint32_t start_pin = (IS_ENABLED(CONFIG_SOC_ENABLE_LFXO) ? 2 : 0);
+
+	/* Allow the network core to use all GPIOs. */
+	for (uint32_t i = start_pin; i < P0_PIN_NUM; i++) {
 		NRF_P0_S->PIN_CNF[i] = (GPIO_PIN_CNF_MCUSEL_NetworkMCU <<
 					GPIO_PIN_CNF_MCUSEL_Pos);
 	}


### PR DESCRIPTION
When the use of the low frequency crystal oscillator (LFXO) is enabled,
the pins P0.00 (XL1) and P0.01 (XL2) need to stay configured with the
value Peripheral, so do not reconfigure them in this application then.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>