### PR TITLE
Bluetooth: Mesh: Fix Scene client function name typo

### DIFF
--- a/subsys/bluetooth/mesh/scene_cli.c
+++ b/subsys/bluetooth/mesh/scene_cli.c
@@ -234,7 +234,7 @@ int bt_mesh_scene_cli_recall(struct bt_mesh_scene_cli *cli,
 			       BT_MESH_SCENE_OP_STATUS, rsp);
 }
 
-int bt_esh_scene_cli_recall_unack(
+int bt_mesh_scene_cli_recall_unack(
 	struct bt_mesh_scene_cli *cli, struct bt_mesh_msg_ctx *ctx,
 	uint16_t scene, const struct bt_mesh_model_transition *transition)
 {


### PR DESCRIPTION
The Scene client recall_unack function had a typo in its name, making it
not match the header declaration

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>