### PR TITLE
drivers: gps: Add options to set use case and accuracy

### DIFF
--- a/include/drivers/gps.h
+++ b/include/drivers/gps.h
@@ -76,6 +76,30 @@ enum gps_nav_mode {
 	GPS_NAV_MODE_PERIODIC,
 };
 
+enum gps_use_case {
+	/* Target best single cold start performance. */
+	GPS_USE_CASE_SINGLE_COLD_START,
+
+	/* Target best multiple hot starts performance. */
+	GPS_USE_CASE_MULTIPLE_HOT_START,
+};
+
+enum gps_accuracy {
+	/** Use normal accuracy thresholds for producing GPS fix. */
+	GPS_ACCURACY_NORMAL,
+
+	/** Allow low accuracy fixes using 3 satellites.
+	 *  Note that one of the two conditions must be met:
+	 *	- Altitude, accurate within 10s of meters provided using
+	 *	  gps_agps_write(). Valid for 24 hours.
+	 *	- One fix using 5 or more satellites in the previous 24 hours,
+	 *	  without the device rebooting in the meantime.
+	 *
+	 *  See the GNSS documentation for more details.
+	 */
+	GPS_ACCURACY_LOW,
+};
+
 enum gps_power_mode {
 	/* Best GPS performance. */
 	GPS_POWER_MODE_DISABLED,
@@ -94,6 +118,12 @@ struct gps_config {
 
 	/* Power mode, @ref enum gps_power_mode. */
 	enum gps_power_mode power_mode;
+
+	/* GPS use case, @ref enum gps_use_case. */
+	enum gps_use_case use_case;
+
+	/* Accuracy threshold for producing fix, @ref enum gps_accuracy. */
+	enum gps_accuracy accuracy;
 
 	/* Interval, in seconds, at which to start GPS search. The value is
 	 * ignored outside periodic mode. Minimum accepted value is 10 seconds.


### PR DESCRIPTION
The nRF9160 GPS now supports configuring an intended use case
and accepted accuracy level.
This patch adds those features to the GPS API and nRF9160 GPS driver.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>