### PR TITLE
Bluetooth: Mesh: Scene server extends scene setup server

### DIFF
--- a/subsys/bluetooth/mesh/scene_srv.c
+++ b/subsys/bluetooth/mesh/scene_srv.c
@@ -514,6 +514,23 @@ static int scene_srv_init(struct bt_mesh_model *mod)
 				      sizeof(srv->buf));
 	srv->pub.msg = &srv->pub_msg;
 	srv->pub.update = scene_srv_pub_update;
+
+	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
+		/* Model extensions:
+		 * To simplify the model extension tree, we're flipping the
+		 * relationship between the scene server and the Scene
+		 * Setup Server. In the specification, the Scene Setup
+		 * Server extends the Scene Server, which is the opposite of
+		 * what we're doing here. This makes no difference for the mesh
+		 * stack, but it makes it a lot easier to extend this model, as
+		 * we won't have to support multiple extenders.
+		 */
+		bt_mesh_model_extend(
+			mod,
+			bt_mesh_model_find(bt_mesh_model_elem(mod),
+					   BT_MESH_MODEL_ID_SCENE_SETUP_SRV));
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Adds a bt_mesh_model_extend call to the scene server to make it share
subscription lists with its scene setup server.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>