### PR TITLE
net: lib: download_client: Add support for TCP receive timeout

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -60,6 +60,15 @@ Bluetooth Mesh
   * Time client model callbacks for all message types.
   * Support for the nRF52833 DK in the :ref:`bluetooth_mesh_light` and :ref:`bluetooth_mesh_light_switch` samples.
 
+nRF9160
+=======
+
+* Updated:
+
+  * :ref:`lib_download_client` library - Re-introduced optional TCP timeout, which is enabled by default.
+    This change re-introduces the optional timeout on the TCP socket used for the download.
+    Upon timeout on a TCP socket, the HTTP download will fail and the ``ETIMEDOUT`` error will be returned via the callback handler.
+
 Common
 ======
 

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -43,6 +43,7 @@ enum download_client_evt_id {
 	 *
 	 * Error reason may be one of the following:
 	 * - ECONNRESET: socket error, peer closed connection
+	 * - ETIMEDOUT: socket error, connection timed out
 	 * - EHOSTDOWN: host went down during download
 	 * - EBADMSG: HTTP response header not as expected
 	 * - E2BIG: HTTP response header could not fit in buffer

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -105,6 +105,16 @@ config DOWNLOAD_CLIENT_MAX_FILENAME_SIZE
 	range 8 256
 	default 192
 
+config DOWNLOAD_CLIENT_TCP_SOCK_TIMEO_MS
+	int "Receive timeout on TCP sockets, in milliseconds"
+	default 30000
+	range -1 600000
+	help
+	  Socket timeout for recv() calls, in milliseconds.
+	  When using HTTP or HTTPS, set a timeout to be able to detect
+	  when the server is not responding and client should give up.
+	  Set to -1 disable.
+
 config DOWNLOAD_CLIENT_UDP_SOCK_TIMEO_MS
 	int "Receive timeout on UDP sockets, in milliseconds"
 	default 4000


### PR DESCRIPTION
It should be possible to set receive timeout also for
TCP sockets. For example if device goes out of LTE
coverage during the download, the recv() call will
block for a very long time if receive timeout has not
been set. In case of a receive timeout with TCP,
the request is not retransmitted.

Setting of the socket timeout is moved to
client_connect(), because earlier the timeout option
was incorrectly not set during reconnect. Also the
decision to set the socket receive timeout is done
based on the used protocol, not based on CONFIG_COAP
(even though COAP has been enabled, the download may
still use HTTP).

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>