### PR TITLE
scripts: unity: header_prepare.py: Improve regex

### DIFF
--- a/scripts/unity/header_prepare.py
+++ b/scripts/unity/header_prepare.py
@@ -56,7 +56,7 @@ def header_prepare(in_file, out_file, out_wrap_file):
     # Prepare file with functions prefixed with __wrap_ that will be used for
     # mock generation.
     func_pattern = re.compile(
-        r"^\s*((?:\w+[*\s]+)+)(\w+?\(.*?\);)", re.M | re.S)
+        r"^\s*((?:\w+[*\s]+)+)(\w+?\([^\\{}#]*?\);)", re.M | re.S)
     content2 = func_pattern.sub(r"\n\1__wrap_\2", content)
 
     with open(out_wrap_file, 'w') as f_wrap:


### PR DESCRIPTION
Regex for finding function declarations was fooled by the
extended macro declaration. Added forbidden characters between
parenthesis.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>