### PR TITLE
crypto: Fixed issue in doxyfile to fix KMU/KDR documentation

### DIFF
--- a/doc/nrfxlib/nrfxlib.doxyfile.in
+++ b/doc/nrfxlib/nrfxlib.doxyfile.in
@@ -807,8 +807,9 @@ EXCLUDE_PATTERNS       = */zboss/* \
                          */openthread/lib/* \
                          */nrf_cc312_platform/* \
                          */nrf_cc312_mbedcrypto/* \
-                         */nrf_cc310_mbedcrypto/include/* \
-                         */nrf_802154_sl/*
+                         */nrf_cc310_mbedcrypto/include/mbedtls_extra/* \
+                         */nrf_802154_sl/* \
+                         */nrf_cc310_mbedcrypto/include/nrf-config-cc310.h
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -1985,7 +1986,14 @@ PREDEFINED             = "MBEDTLS_CONFIG_FILE=\"@NRFXLIB_BINARY_DIR@/mbedtls_dox
 			 "CONFIG_BT_SCAN_NAME_CNT:=1" \
 			 "CONFIG_BT_SCAN_SHORT_NAME_CNT:=1" \
 			 "CONFIG_BT_SCAN_ADDRESS_CNT:=1" \
-			 "CONFIG_BT_SCAN_APPEARANCE_CNT:=1"
+			 "CONFIG_BT_SCAN_APPEARANCE_CNT:=1" \
+			 "NRF9160_XXAA=" \
+			 "NRF5340_XXAA_APPLICATION=" \
+			 "NRF52840_XXAA=" \
+			 "MBEDTLS_AES_C=" \
+			 "MBEDTLS_CCM_C=" \
+			 "MBEDTLS_GCM_C=" \
+			 "MBEDTLS_CONFIG_FILE="
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 52f4b7163fb4c1b7bd4b4c8c79142198b1a9a341
+      revision: f1df2736741c7d645d0738a12a7d4317d0eb348b
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
- Added required predefined statements in the doxyfile for nrfxlib/crypto so that the KMU/KDR functionality is shown as expected
- Removed the exclusion of mbedcrypto header files

Ref: NCSDK-7232

nrfxlib pr: https://github.com/nrfconnect/sdk-nrfxlib/pull/343

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>