### PR TITLE
net: lib: download_client: add option for setting TLS_HOSTNAME sockopt

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -65,9 +65,12 @@ nRF9160
 
 * Updated:
 
-  * :ref:`lib_download_client` library - Re-introduced optional TCP timeout, which is enabled by default.
-    This change re-introduces the optional timeout on the TCP socket used for the download.
-    Upon timeout on a TCP socket, the HTTP download will fail and the ``ETIMEDOUT`` error will be returned via the callback handler.
+  * :ref:`lib_download_client` library:
+
+    * Re-introduced optional TCP timeout (enabled by default) on the TCP socket used for the download.
+      Upon timeout on a TCP socket, the HTTP download will fail and the ``ETIMEDOUT`` error will be returned via the callback handler.
+    * Added an option to set the hostname for TLS Server Name Indication (SNI) extension.
+      This option is valid only when TLS is enabled.
 
 Common
 ======

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -100,6 +100,8 @@ struct download_client_cfg {
 	 *  values shall be used.
 	 */
 	size_t frag_size_override;
+	/** Set hostname for TLS Server Name Indication extension */
+	bool set_tls_hostname;
 };
 
 /**


### PR DESCRIPTION
Add flag in download_client config for setting the TLS hostname which
is used by the Server Name Indication (SNI) TLS extension.
CIA-159

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>