### PR TITLE
doc: fixed shortcuts.txt

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -27,10 +27,10 @@
 
 .. |GSA| replace:: Getting Started Assistant
 
-.. |nRF5340DKnoref| replace:: nRF5340 PDK board (PCA10095)
+.. |nRF5340DKnoref| replace:: nRF5340 DK board (PCA10095)
 
 .. |nRF9160DK| replace:: nRF9160 DK board (PCA10090) - see :ref:`ug_nrf9160`
-.. |nRF5340DK| replace:: nRF5340 PDK board (PCA10095) - see :ref:`ug_nrf5340`
+.. |nRF5340DK| replace:: nRF5340 DK board (PCA10095) - see :ref:`ug_nrf5340`
 .. |nRF52840DK| replace:: nRF52840 DK board (PCA10056) - see :ref:`ug_nrf52`
 .. |nRF52833DK| replace:: nRF52833 DK board (PCA10100) - see :ref:`ug_nrf52`
 .. |nRF51DK| replace:: nRF51 DK board (PCA10028)


### PR DESCRIPTION
A couple of shortcuts still referred to nRF5340PDK
instead of nRF5340DK.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>