### PR TITLE
doc: cmake: Make GEN_DEVICETREE_REST_ZEPHYR_DOCSET a white space string

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -91,6 +91,7 @@ set(KI_SCRIPT ${ZEPHYR_BASE}/scripts/filter-known-issues.py)
 set(SPHINXOPTS -c ${NRF_BASE}/doc/zephyr)
 set(SPHINX_OUTPUT_DIR ${HTML_DIR}/zephyr)
 set(KCONFIG_OUTPUT ${HTML_DIR}/kconfig)
+set(GEN_DEVICETREE_REST_ZEPHYR_DOCSET " ")
 
 # Get access to the 'html' target from doc/CMakeLists.txt in Zephyr
 add_subdirectory(${ZEPHYR_BASE}/doc ${ZEPHYR_BINARY_DIR})


### PR DESCRIPTION
Setting GEN_DEVICETREE_REST_ZEPHYR_DOCSET to a white space string will
make the GEN_DEVICETREE_REST_ZEPHYR_DOCSET.

The GEN_DEVICETREE_REST_ZEPHYR_DOCSET environment variable will be
striped before testing, which means the environment variable will be
defined, but effectively treated as empty.

This fixes an issue with building docs on windows.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>