### PR TITLE
net: lib: azure_iot_hub: Improve internal connection state handling

### DIFF
--- a/include/net/azure_iot_hub.h
+++ b/include/net/azure_iot_hub.h
@@ -86,6 +86,8 @@ enum azure_iot_hub_evt_type {
 	AZURE_IOT_HUB_EVT_FOTA_ERASE_DONE,
 	/** FOTA failed */
 	AZURE_IOT_HUB_EVT_FOTA_ERROR,
+	/** Internal library error */
+	AZURE_IOT_HUB_EVT_ERROR
 };
 
 /** @brief Azure IoT Hub topic type, used to route messages to the correct

--- a/samples/nrf9160/azure_fota/src/main.c
+++ b/samples/nrf9160/azure_fota/src/main.c
@@ -101,6 +101,9 @@ static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 	case AZURE_IOT_HUB_EVT_FOTA_ERASE_DONE:
 		printk("AZURE_IOT_HUB_EVT_FOTA_ERASE_DONE\n");
 		break;
+	case AZURE_IOT_HUB_EVT_ERROR:
+		printk("AZURE_IOT_HUB_EVT_ERROR\n");
+		break;
 	default:
 		printk("Unknown Azure IoT Hub event type: %d\n", evt->type);
 		break;

--- a/samples/nrf9160/azure_iot_hub/src/main.c
+++ b/samples/nrf9160/azure_iot_hub/src/main.c
@@ -210,6 +210,9 @@ static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 	case AZURE_IOT_HUB_EVT_PUBACK:
 		printk("AZURE_IOT_HUB_EVT_PUBACK\n");
 		break;
+	case AZURE_IOT_HUB_EVT_ERROR:
+		printk("AZURE_IOT_HUB_EVT_ERROR\n");
+		break;
 	default:
 		printk("Unknown Azure IoT Hub event type: %d\n", evt->type);
 		break;

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
@@ -96,6 +96,12 @@ static void api_event_handler(struct azure_iot_hub_evt *evt)
 		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
 				   config->user_data);
 		break;
+	case AZURE_IOT_HUB_EVT_ERROR:
+		cloud_evt.type = CLOUD_EVT_ERROR;
+		cloud_evt.data.err = evt->data.err;
+		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
+				   config->user_data);
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
This patch improves/fortifies the internal connection state handling of
Azure IoT hub by:

 - Introducing common API for verification and setting of internal
   connection state.
 - Correct return code handling of some functions.
 - Checks for valid state transitions in connection state set function.
 - New error event that is propogated to the application upon an
   invalid state transition.
 - Update Azure IoT Hub samples to handle new error event.

[CIA-137]