### PR TITLE
manifest: update sdk-zephyr with additional upstream patches

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -24,6 +24,35 @@
 #define LOG_MODULE_NAME sdc_hci_driver
 #include "common/log.h"
 
+/* As per the section "SoftDevice Controller/Integration with applications"
+ * in the nrfxlib documentation, the controller uses the following channels:
+ */
+#if defined(PPI_PRESENT)
+	/* PPI channels 17 - 31, for the nRF52 Series */
+	#define PPI_CHANNELS_USED_BY_CTLR (BIT_MASK(15) << 17)
+#else
+	/* DPPI channels 0 - 13, for the nRF53 Series */
+	#define PPI_CHANNELS_USED_BY_CTLR BIT_MASK(14)
+#endif
+
+/* Additionally, MPSL requires the following channels (as per the section
+ * "Multiprotocol Service Layer/Integration notes"):
+ */
+#if defined(PPI_PRESENT)
+	/* PPI channel 19, 30, 31, for the nRF52 Series */
+	#define PPI_CHANNELS_USED_BY_MPSL (BIT(19) | BIT(30) | BIT(31))
+#else
+	/* DPPI channels 0 - 2, for the nRF53 Series */
+	#define PPI_CHANNELS_USED_BY_MPSL BIT_MASK(3)
+#endif
+
+/* The following two constants are used in nrfx_glue.h for marking these PPI
+ * channels and groups as occupied and thus unavailable to other modules.
+ */
+const uint32_t z_bt_ctlr_used_nrf_ppi_channels =
+	PPI_CHANNELS_USED_BY_CTLR | PPI_CHANNELS_USED_BY_MPSL;
+const uint32_t z_bt_ctlr_used_nrf_ppi_groups;
+
 static K_SEM_DEFINE(sem_recv, 0, 1);
 
 static struct k_thread recv_thread_data;

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -12,6 +12,9 @@
 #include <mpsl.h>
 #include <mpsl_timeslot.h>
 #include "multithreading_lock.h"
+#if defined(CONFIG_NRFX_DPPI)
+#include <nrfx_dppi.h>
+#endif
 
 LOG_MODULE_REGISTER(mpsl_init, CONFIG_MPSL_LOG_LEVEL);
 
@@ -129,6 +132,26 @@ static int mpsl_lib_init(const struct device *dev)
 	ARG_UNUSED(dev);
 	int err = 0;
 	mpsl_clock_lfclk_cfg_t clock_cfg;
+
+#if !defined(CONFIG_BT_CTLR) && defined(CONFIG_NRFX_DPPI)
+	/* When the Bluetooth controller is used, it will include the DPPI
+	 * channels that MPSL uses in the mask that it provides for nrfx.
+	 * Otherwise, if additionaly the nrfx DPPI allocator is used (what
+	 * indicates that some other module will use some DPPI channels),
+	 * those channels needed by MPSL must be reserved in some other way.
+	 * Currently it is not possible to do it in nrfx_glue.h, so the below
+	 * code is used as a temporarily workaround.
+	 * Unfortunatelly, for PPI a similar workaround cannot be used.
+	 */
+	uint8_t channel;
+	nrfx_err_t err_code;
+	err_code = nrfx_dppi_channel_alloc(&channel);
+	__ASSERT_NO_MSG(err_code == NRFX_SUCCESS && channel == 0);
+	err_code = nrfx_dppi_channel_alloc(&channel);
+	__ASSERT_NO_MSG(err_code == NRFX_SUCCESS && channel == 1);
+	err_code = nrfx_dppi_channel_alloc(&channel);
+	__ASSERT_NO_MSG(err_code == NRFX_SUCCESS && channel == 2);
+#endif
 
 	clock_cfg.source = m_config_clock_source_get();
 	clock_cfg.accuracy_ppm = CONFIG_CLOCK_CONTROL_NRF_ACCURACY;

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7121b714fe314e849dc705daf31abccd97114bfb
+      revision: a89f951e1eb81a95d3e21338e6f4aa7b28ecd57b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
sdk-zephyr PR: https://github.com/nrfconnect/sdk-zephyr/pull/402

Update sdk-zephyr with additional upstream patches
fromlist and/or fromtree patches required for the
dev-tag.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>