### PR TITLE
actions: Enable new manifest workflow

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,0 +1,26 @@
+name: Manifest
+on:
+  - pull_request_target
+
+jobs:
+  contribs:
+    runs-on: ubuntu-latest
+    name: Manifest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        with:
+          path: ncs/nrf
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Manifest
+        uses: zephyrproject-rtos/action-manifest@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          manifest-path: 'west.yml'
+          checkout-path: 'ncs/nrf'
+          label-prefix: 'manifest-'
+          verbosity-level: '1'
+          labels: 'manifest'
+          dnm-labels: 'DNM'


### PR DESCRIPTION
The manifest workflow uses the manifest action to detect changes in the
west manifest. It then analyzes the changes and posts labels and a
comment in table format accordingly.

It is meant to be used as a helper bot for developers submitting changes
to modules, reducing the need for manual work and oversight and
automating common operations.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>