### PR TITLE
Bluetooth: controller: Use BT_CTLR_DATA_LENGTH to enable support for...

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -489,7 +489,7 @@ static int hci_driver_open(void)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_DATA_LEN_UPDATE)) {
+	if (IS_ENABLED(CONFIG_BT_CTLR_DATA_LENGTH)) {
 		err = sdc_support_dle();
 		if (err) {
 			return -ENOTSUP;


### PR DESCRIPTION
LE Data Length Update procedure in the Controller

The hidden option BT_CTLR_DATA_LENGTH is better because it takes both
BT_DATA_LEN_UPDATE and BT_CTLR_DATA_LEN_UPDATE_SUPPORT into account.

It solves that hci_driver_open returns -ENOTSUP when using S112.

Signed-off-by: Ryan Chu <ryan.chu@nordicsemi.no>