### PR TITLE
samples: openthread: Update HWFC description

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -51,7 +51,7 @@
 
 .. |enable_thread_before_testing| replace:: Make sure to enable the OpenThread stack before building and testing this sample.
    See :ref:`ug_thread` for more information.
-.. |thread_hwfc_enabled| replace:: Thread samples have Hardware Flow Control mechanism enabled by default in serial communication.
+.. |thread_hwfc_enabled| replace:: This sample has Hardware Flow Control mechanism enabled by default in serial communication.
    When enabled, it allows devices to manage transmission by informing each other about their current state, and ensures more reliable connection in high-speed communication scenarios.
 
 .. |zigbee_version| replace:: Zigbee 3.0

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -237,9 +237,6 @@ Sample output
 The sample logging output can be observed through a serial port.
 For more details, see :ref:`putty`.
 
-.. note::
-     |thread_hwfc_enabled|
-
 Dependencies
 ************
 

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -92,9 +92,6 @@ Running OpenThread CLI commands
 You can connect to any of the Simple CoAP Server or Simple CoAP Client nodes through a serial port.
 For more details, see :ref:`putty`.
 
-.. note::
-     |thread_hwfc_enabled|
-
 Once the serial connection is ready, you can run OpenThread CLI commands.
 For complete CLI documentation, refer to `OpenThread CLI Reference`_.
 


### PR DESCRIPTION
Concerning hardware flow control has been removed from coap_client and
coap_server, the documentation needs to be updated.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>