### PR TITLE
manifest: update sdk-zephyr with upstream patch (usb_dc_nrfx)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a89f951e1eb81a95d3e21338e6f4aa7b28ecd57b
+      revision: pull/397/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr with upstream from-tree patch which
fixes k_mem_pool_free related bug in usb_dc_nrfx driver.