### PR TITLE
ci: update gitlint to 0.15.0 in requirements-ci.txt

### DIFF
--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -22,7 +22,7 @@ docutils==0.16
 ecdsa==0.15
 future==0.18.2
 gcovr==4.2
-gitlint==0.13.1
+gitlint==0.15.0
 idna==2.9
 imagesize==1.2.0
 imgtool==1.7.0


### PR DESCRIPTION
Updating gitlint==0.15.0 as that is having click==7.1.2 as dependency
which matches the current click version in requirements-ci.txt.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>