### PR TITLE
doc: release-notes-latest: Summarize mcuboot changes from the upmerge

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -105,22 +105,55 @@ Trusted Firmware-M:
 MCUboot
 =======
 
-sdk-mcuboot
------------
+The MCUboot fork in |NCS| (``sdk-mcuboot``) contains all commits from the upstream MCUboot repository up to and including ``c74c551ed6``, plus some |NCS| specific additions.
 
-The MCUboot fork in |NCS| contains all commits from the upstream MCUboot repository up to and including ``5a6e18148d``, plus some |NCS| specific additions.
-The list of the most important recent changes can be found in :ref:`ncs_release_notes_140`.
+The following list summarizes the most important changes inherited from upstream MCUboot:
+
+* Bootloader:
+
+  * Added hardening against hardware level fault injection and timing attacks.
+    See ``CONFIG_BOOT_FIH_PROFILE_HIGH`` and similar Kconfig options.
+  * Introduced abstract crypto primitives to simplify porting.
+  * Added ram-load upgrade mode (not enabled for Zephyr yet).
+  * Renamed single-image mode to single-slot mode.
+    See the ``CONFIG_SINGLE_APPLICATION_SLOT`` option.
+  * Added a patch for turning off cache for Cortex-M7 before chain-loading.
+  * Fixed an issue that caused HW stack protection to catch the chain-loaded application during its early initialization.
+  * Added reset of Cortex SPLIM registers before boot.
+  * Fixed a build issue that occurred if the CONF_FILE contained multiple file paths instead of a single file path.
+  * Added watchdog feed on nRF devices.
+    See the ``CONFIG_BOOT_WATCHDOG_FEED`` option.
+  * Removed the ``flash_area_read_is_empty()`` port implementation function.
+  * Updated the ARM core configuration to only be initialized when selected by the user.
+    See the ``CONFIG_MCUBOOT_CLEANUP_ARM_CORE`` option.
+  * Allowed the final data chunk in the image to be unaligned in the serial-recovery protocol.
+
+* Image tool:
+
+  * Updated the tool to print an image digest during verification.
+  * Added a possibility to set a confirm flag for HEX files as well.
+  * Updated the usage of ``--confirm`` to imply ``--pad``.
+  * Fixed the argument handling of ``custom_tlvs``.
+
+
+Mcumgr
+======
+
+The mcumgr library fork in |NCS| (``sdk-mcumgr``) contains all commits from the upstream mcumgr repository up to and including snapshot ``a3d5117b08``.
+
+The following list summarizes the most important changes inherited from upstream mcumgr:
+
+* Fixed an issue with devices running MCUboot v1.6.0 or earlier where a power outage during erase of a corrupted image in slot 1 could result in the device not being able to boot.
+  In this case, it was not possible to update the device and mcumgr would return error code 6 (``MGMT_ERR_EBADSTATE``).
+* Added support for invoking shell commands (shell management) from the mcumgr command line.
 
 
 Zephyr
 ======
 
-sdk-zephyr
-----------
-
 .. NOTE TO MAINTAINERS: The latest Zephyr commit appears in multiple places; make sure you update them all.
 
-The Zephyr fork in |NCS| contains all commits from the upstream Zephyr repository up to and including ``35264cc214fd``, plus some |NCS| specific additions.
+The Zephyr fork in |NCS| (``sdk-zephyr``) contains all commits from the upstream Zephyr repository up to and including ``35264cc214fd``, plus some |NCS| specific additions.
 
 For a complete list of upstream Zephyr commits incorporated into |NCS| since the most recent release, run the following command from the :file:`ncs/zephyr` repository (after running ``west update``):
 
@@ -241,6 +274,9 @@ The following list summarizes the most important changes inherited from upstream
     * Fixed handling of zero-length packets (ZLP) in the Nordic Semiconductor USB Device Controller driver (usb_dc_nrfx).
     * Fixed initialization of the workqueue in the usb_dc_nrfx driver, to prevent fatal errors when the driver is reattached.
     * Fixed handling of the SUSPEND and RESUME events in the Bluetooth classes.
+    * Made the USB DFU class compatible with the target configuration that does not have a secondary image slot.
+    * Added support for using USB DFU within MCUboot with single application slot mode.
+
 
 * Networking:
 
@@ -306,3 +342,25 @@ The following list summarizes the most important changes inherited from upstream
 * Trusted Firmware-M:
 
   * Updated the Trusted Firmware-M (TF-M) module to include support for the nRF5340 and nRF9160 platforms.
+
+
+* Libraries/subsystems:
+
+  * Settings:
+
+    * Removed SETTINGS_USE_BASE64 support, which has been deprecated for more than two releases.
+
+  * Storage:
+
+    * :ref:`flash_map_api`: Added an API to get the value of an erased byte in the flash_area.
+      See :c:func:`flash_area_erased_val`.
+    * :ref:`stream_flash`: Eliminated the usage of the flash API internals.
+
+
+  * File systems:
+
+    * Enabled FCB to work with non-0xff erase value flash.
+    * Added a :c:macro:`FS_MOUNT_FLAG_NO_FORMAT` flag to the FatFs options.
+      This flag removes formatting capabilities from the FAT/exFAT file system driver and prevents unformatted devices to be formatted, to FAT or exFAT, on mount attempt.
+    * Added support for the following :c:func:`fs_mount` flags: :c:macro:`FS_MOUNT_FLAG_READ_ONLY`, :c:macro:`FS_MOUNT_FLAG_NO_FORMAT`
+    * Updated the FS API to not perform a runtime check of a driver interface when the :option:`CONFIG_NO_RUNTIME_CHECKS` option is enabled.


### PR DESCRIPTION
Summary on mcubooot, flash, usb, fcb, flash_map, settings,
stream_flash changes.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>