### PR TITLE
net: lib: Allign upstream changes to mqtt_keepalive_time_left()

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1488,6 +1488,8 @@ void connection_evt_handler(const struct cloud_event *const evt)
 
 		switch (evt->data.err) {
 		case CLOUD_DISCONNECT_INVALID_REQUEST:
+			/* Fall through */
+		case CLOUD_DISCONNECT_MISC:
 			LOG_INF("Cloud connection closed.");
 			if ((atomic_get(&cloud_connect_attempts) == 1) &&
 			    (atomic_get(&cloud_association) ==
@@ -1519,7 +1521,6 @@ void connection_evt_handler(const struct cloud_event *const evt)
 		case CLOUD_DISCONNECT_CLOSED_BY_REMOTE:
 			LOG_INF("Disconnected by the cloud.");
 			break;
-		case CLOUD_DISCONNECT_MISC:
 		default:
 			break;
 		}

--- a/include/net/azure_iot_hub.h
+++ b/include/net/azure_iot_hub.h
@@ -302,8 +302,9 @@ int azure_iot_hub_method_respond(struct azure_iot_hub_result *result);
  *	   automatically by the library.
  *
  *  @return Time in milliseconds until next keepalive ping will be sent.
+ *  @return -1 if keepalive messages are not enabled.
  */
-uint32_t azure_iot_hub_keepalive_time_left(void);
+int azure_iot_hub_keepalive_time_left(void);
 
 #ifdef __cplusplus
 }

--- a/include/net/cloud.h
+++ b/include/net/cloud.h
@@ -324,6 +324,7 @@ static inline int cloud_ping(const struct cloud_backend *const backend)
  *
  * @return Time in milliseconds until next keep alive message is expected to
  *         be sent.
+ * @return -1 if keep alive messages are not enabled.
  */
 static inline int cloud_keepalive_time_left(const struct cloud_backend *const backend)
 {

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -105,8 +105,6 @@ static char delete_rejected_topic[DELETE_REJECTED_TOPIC_LEN + 1];
 static struct cloud_backend *aws_iot_backend;
 #endif
 
-#define AWS_IOT_POLL_TIMEOUT_MS 500
-
 /* Empty string used to request the AWS IoT shadow document. */
 #define AWS_IOT_SHADOW_REQUEST_STRING ""
 
@@ -724,14 +722,6 @@ static void mqtt_evt_handler(struct mqtt_client *const c,
 		aws_iot_evt.data.err = AWS_IOT_DISCONNECT_MISC;
 
 		if (atomic_get(&disconnect_requested)) {
-#if defined(CONFIG_AWS_IOT_CONNECTION_POLL_THREAD)
-			if (atomic_get(&connection_poll_active)) {
-				/* The connection poll event will handle the
-				 * disconnect.
-				 */
-				break;
-			}
-#endif
 			aws_iot_evt.data.err = AWS_IOT_DISCONNECT_USER_REQUEST;
 		}
 
@@ -1024,7 +1014,7 @@ int aws_iot_ping(void)
 
 int aws_iot_keepalive_time_left(void)
 {
-	return (int)mqtt_keepalive_time_left(&client);
+	return mqtt_keepalive_time_left(&client);
 }
 
 int aws_iot_input(void)
@@ -1242,18 +1232,22 @@ start:
 	atomic_set(&aws_iot_disconnected, 0);
 
 	while (true) {
-		err = poll(fds, ARRAY_SIZE(fds), AWS_IOT_POLL_TIMEOUT_MS);
+		err = poll(fds, ARRAY_SIZE(fds), aws_iot_keepalive_time_left());
 
+		/* If poll returns 0 the timeout has expired. */
 		if (err == 0) {
-			if (aws_iot_keepalive_time_left() <
-			    AWS_IOT_POLL_TIMEOUT_MS) {
-				aws_iot_ping();
-			}
+			aws_iot_ping();
 			continue;
 		}
 
 		if ((fds[0].revents & POLLIN) == POLLIN) {
 			aws_iot_input();
+
+			if (atomic_get(&aws_iot_disconnected) == 1) {
+				LOG_DBG("The cloud socket is already closed.");
+				break;
+			}
+
 			continue;
 		}
 
@@ -1261,14 +1255,6 @@ start:
 			LOG_ERR("poll() returned an error: %d", err);
 			aws_iot_evt.data.err = AWS_IOT_DISCONNECT_MISC;
 			break;
-		}
-
-		if (atomic_get(&disconnect_requested)) {
-			atomic_set(&disconnect_requested, 0);
-			LOG_DBG("Expected disconnect event.");
-			aws_iot_evt.data.err = AWS_IOT_DISCONNECT_USER_REQUEST;
-			aws_iot_notify_event(&aws_iot_evt);
-			goto reset;
 		}
 
 		if ((fds[0].revents & POLLNVAL) == POLLNVAL) {

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -930,8 +930,6 @@ static int connect_client(struct azure_iot_hub_config *cfg)
 	/* Set the current socket and start reading from it in polling thread */
 	conn_config.socket = client.transport.tls.sock;
 
-	k_sem_give(&connection_poll_sem);
-
 	return 0;
 }
 
@@ -988,9 +986,12 @@ static void dps_handler(enum dps_reg_state state)
 	LOG_DBG("Connecting to assigned IoT hub (%s)",
 		log_strdup(dps_hostname_get()));
 
-	err = azure_iot_hub_connect();
+	connection_state_set(STATE_CONNECTING);
+
+	err = connect_client(&conn_config);
 	if (err) {
-		LOG_ERR("Failed connection to IoT hub, err: %d", err);
+		LOG_ERR("Failed to connect MQTT client, error: %d", err);
+		connection_state_set(STATE_INIT);
 	}
 }
 #endif
@@ -1074,7 +1075,7 @@ int azure_iot_hub_ping(void)
 	return mqtt_live(&client);
 }
 
-uint32_t azure_iot_hub_keepalive_time_left(void)
+int azure_iot_hub_keepalive_time_left(void)
 {
 	return mqtt_keepalive_time_left(&client);
 }
@@ -1207,6 +1208,8 @@ int azure_iot_hub_connect(void)
 		return err;
 	}
 
+	k_sem_give(&connection_poll_sem);
+
 	return 0;
 }
 
@@ -1322,11 +1325,11 @@ start:
 
 	while (true) {
 		ret = poll(fds, ARRAY_SIZE(fds),
-			mqtt_keepalive_time_left(&client));
+			   azure_iot_hub_keepalive_time_left());
+
+		/* If poll returns 0 the timeout has expired. */
 		if (ret == 0) {
-			if (mqtt_keepalive_time_left(&client) < 1000) {
-				azure_iot_hub_ping();
-			}
+			azure_iot_hub_ping();
 			continue;
 		}
 
@@ -1342,6 +1345,16 @@ start:
 			 * account for the event that it has changed.
 			 */
 			fds[0].fd = conn_config.socket;
+
+			if (connection_state_verify(STATE_INIT)) {
+				/* If connection state is set to STATE_INIT at
+				 * this point we know that the socket has
+				 * been closed and we can break out of poll.
+				 */
+				LOG_DBG("The socket is already closed");
+				break;
+			}
+
 			continue;
 		}
 

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -117,6 +117,10 @@ void nct_process(void);
 /**
  * @brief Helper function to determine when next keep alive message should be
  *        sent. Can be used for instance as a source for `poll` timeout.
+ *
+ * @return Time in milliseconds until next keep alive message is expected to
+ *         be sent.
+ * @return -1 if keep alive messages are not enabled.
  */
 int nct_keepalive_time_left(void);
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -36,6 +36,7 @@ static const fsm_transition not_implemented_fsm_transition[NCT_EVT_TOTAL];
 
 static const fsm_transition initialized_fsm_transition[NCT_EVT_TOTAL] = {
 	[NCT_EVT_CONNECTED] = connection_handler,
+	[NCT_EVT_DISCONNECTED] = disconnection_handler,
 };
 
 static const fsm_transition connected_fsm_transition[NCT_EVT_TOTAL] = {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -1128,7 +1128,7 @@ void nct_process(void)
 
 int nct_keepalive_time_left(void)
 {
-	return (int)mqtt_keepalive_time_left(&nct.client);
+	return mqtt_keepalive_time_left(&nct.client);
 }
 
 int nct_socket_get(void)


### PR DESCRIPTION
 - mqtt_keepalive_time_left() now returns -1 if keep alive messages are
   disabled. Handle this in the various cloud backends.

 - Use the variuos library wrappers for mqtt_keepalive_time_left() as
   the timeout argument in poll().

 - Add check upon a poll POLLIN event. If the client is disconncted
   break out of poll() to avoid waiting the remaining timeout. **This was previosuly not a problem when mqtt_keepalive_time_left() was not used as a direct argument to poll() and a shorter timeout was used.**

 - Update state handling in Azure IoT and nRF Cloud to make the
   libraries handle state properly with the new changes.

_Disabling keepalive messages will cause mqtt_keepalive_time_lef() to
return -1. By sending in -1 for timeout in poll() poll wait forever._

[CIA-162]