### PR TITLE
Bluetooth: Mesh: Add all missing extension calls

### DIFF
--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -609,6 +609,7 @@ static int bt_mesh_plvl_srv_init(struct bt_mesh_model *mod)
 		 * to support multiple extenders.
 		 */
 		bt_mesh_model_extend(mod, srv->ponoff.ponoff_model);
+		bt_mesh_model_extend(mod, srv->lvl.model);
 		bt_mesh_model_extend(
 			mod,
 			bt_mesh_model_find(

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -607,6 +607,14 @@ static int bt_mesh_light_ctl_srv_start(struct bt_mesh_model *mod)
 		return -EINVAL;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
+		/* Breaking the pattern of extending models in the init
+		 * function, as the Light Temperature model's position in the
+		 * composition data isn't necessarily known at that point.
+		 */
+		bt_mesh_model_extend(srv->model, srv->temp_srv.model);
+	}
+
 	struct bt_mesh_light_ctl_rsp dummy;
 	struct bt_mesh_light_ctl_gen_cb_set set = {
 		.light = NULL,

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -719,6 +719,7 @@ static int bt_mesh_lightness_srv_init(struct bt_mesh_model *mod)
 		 * we won't have to support multiple extenders.
 		 */
 		bt_mesh_model_extend(mod, srv->ponoff.ponoff_model);
+		bt_mesh_model_extend(mod, srv->lvl.model);
 		bt_mesh_model_extend(
 			mod,
 			bt_mesh_model_find(

--- a/subsys/bluetooth/mesh/scene_srv.c
+++ b/subsys/bluetooth/mesh/scene_srv.c
@@ -655,6 +655,20 @@ static int scene_setup_srv_init(struct bt_mesh_model *mod)
 	}
 
 	srv->setup_mod = mod;
+
+	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
+		/* Model extensions:
+		 * To simplify the model extension tree, we're flipping the
+		 * relationship between the scene server and the scene
+		 * setup server. In the specification, the scene setup
+		 * server extends the scene server, which is the opposite of
+		 * what we're doing here. This makes no difference for the mesh
+		 * stack, but it makes it a lot easier to extend this model, as
+		 * we won't have to support multiple extenders.
+		 */
+		bt_mesh_model_extend(srv->mod, srv->setup_mod);
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Some models did not have all the spec required model extensions, this
adds them for all models in master.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>