### PR TITLE
Bluetooth: Mesh: Fix off by one error in tai_to_ts month calculation

### DIFF
--- a/subsys/bluetooth/mesh/time_util.c
+++ b/subsys/bluetooth/mesh/time_util.c
@@ -8,6 +8,7 @@
 #include <time.h>
 #include "model_utils.h"
 #include <zephyr/types.h>
+#include "time_util.h"
 
 #define TAI_START_YEAR 2000
 #define TM_START_YEAR 1900
@@ -99,7 +100,7 @@ void tai_to_ts(const struct bt_mesh_time_tai *tai, struct tm *timeptr)
 
 	const uint8_t *months = is_leap ? month_leap_cfg : month_cfg;
 
-	for (timeptr->tm_mon = 0; months[timeptr->tm_mon] < day_cnt;
+	for (timeptr->tm_mon = 0; months[timeptr->tm_mon] <= day_cnt;
 	     timeptr->tm_mon++) {
 		day_cnt -= months[timeptr->tm_mon];
 	}


### PR DESCRIPTION
Prevents the time server from counting the 32nd day of the year as
January 32nd and similar off-by-one errors for every month.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>