### PR TITLE
doc: release notes for 1.4.99 dev-tag: zephyr architectures' section

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -132,6 +132,11 @@ The current |NCS| release is based on Zephyr v2.4.99.
 
 The following list summarizes the most important changes inherited from upstream Zephyr:
 
+* Architectures:
+
+  * Enabled interrupts before ``main()`` in single-thread kernel mode for Cortex-M architecture.
+  * Introduced functionality for forcing core architecture HW initialization during system boot, for chain-loadable images.
+
 * Boards:
 
   * Fixed arguments for the J-Link runners for nRF5340 DK and added the DAP Link (CMSIS-DAP) interface to the OpenOCD runner for nRF5340.

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -96,6 +96,12 @@ BSD library
 
 * Added information about low accuracy mode to the :ref:`nrfxlib:gnss_extension` documentation.
 
+Trusted Firmware-M:
+-------------------
+
+* Added a simple sample that demonstrates how to integrate TF-M in an application.
+
+
 MCUboot
 =======
 
@@ -296,3 +302,7 @@ The following list summarizes the most important changes inherited from upstream
 
     * Added an API for resetting a node (:c:func:`bt_mesh_cfg_node_reset`).
     * Added an API for setting network transmit parameters (:c:func:`bt_mesh_cfg_net_transmit_set`).
+
+* Trusted Firmware-M:
+
+  * Updated the Trusted Firmware-M (TF-M) module to include support for the nRF5340 and nRF9160 platforms.


### PR DESCRIPTION
Add a small section in the latest release notes listing
the key changes in Zephyr for architectures.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>