### PR TITLE
pcd: add busy wait to fix network core update

### DIFF
--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -54,9 +54,12 @@ if BT_RPMSG_NRF53 && SOC_NRF5340_CPUAPP
 module=HCI_RPMSG
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.build_strategy_domain"
 
-partition=RPMSG_NRF53_SRAM
-partition-size=0x10000
-rsource "Kconfig.template.partition_size"
+DT_CHOSEN_Z_IPC_SHM := zephyr,ipc_shm
+
+config RPMSG_NRF53_SRAM_SIZE
+	# Hidden configuration to expose DT property as kconfig variable
+	hex
+	default "$(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_IPC_SHM))"
 
 endif
 

--- a/subsys/partition_manager/pm.yml.bt_rpmsg_nrf53
+++ b/subsys/partition_manager/pm.yml.bt_rpmsg_nrf53
@@ -2,6 +2,6 @@
 
 # This block of RAM is used for IPC
 rpmsg_nrf53_sram:
-  placement: {before: {one_of: [pcd_sram, end]}}
-  size: CONFIG_PM_PARTITION_SIZE_RPMSG_NRF53_SRAM
+  placement: {before: end}
+  size: CONFIG_RPMSG_NRF53_SRAM_SIZE
   region: sram_primary

--- a/subsys/partition_manager/pm.yml.pcd
+++ b/subsys/partition_manager/pm.yml.pcd
@@ -3,6 +3,6 @@
 # This block of RAM is used for communicating Network Core firmware update
 # metadata
 pcd_sram:
-  placement: {before: end}
+  placement: {before: {one_of: [rpmsg_nrf53_sram, end]}}
   size: CONFIG_NRF_SPU_RAM_REGION_SIZE
   region: sram_primary

--- a/subsys/pcd/src/pcd.c
+++ b/subsys/pcd/src/pcd.c
@@ -162,7 +162,7 @@ int pcd_network_core_update(const void *src_addr, size_t len)
 
 void pcd_lock_ram(void)
 {
-	uint32_t region = (PCD_CMD_ADDRESS/CONFIG_NRF_SPU_RAM_REGION_SIZE) + 1;
+	uint32_t region = PCD_CMD_ADDRESS/CONFIG_NRF_SPU_RAM_REGION_SIZE;
 
 	nrf_spu_ramregion_set(NRF_SPU, region, true, NRF_SPU_MEM_PERM_READ,
 			true);

--- a/subsys/pcd/src/pcd.c
+++ b/subsys/pcd/src/pcd.c
@@ -141,6 +141,11 @@ int pcd_network_core_update(const void *src_addr, size_t len)
 	LOG_INF("Turned on network core");
 
 	do {
+		/* Wait for 1 second to avoid issue where network core
+		 * is unable to write to shared RAM.
+		 */
+		k_busy_wait(1 * USEC_PER_SEC);
+
 		err = pcd_fw_copy_status_get();
 	} while (err == PCD_STATUS_COPY);
 


### PR DESCRIPTION
There is an issue where the application core
will block the network core from writing to
shared RAM while it is reading a variable
in a busy loop.

Fix this issue by adding a busy_wait instead.

The update of the network core takes seconds,
so using 1 second as a wait value makes sense.

Ref: NCSDK-7289
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>