### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a89f951e1eb81a95d3e21338e6f4aa7b28ecd57b
+      revision: pull/403/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Version with bugfix for the settings subsystem:

It was possible that settings_line_entry_copy() did unaligned
flash write.
This patch introduce respecting the flash write-block-size.

depends on https://github.com/nrfconnect/sdk-zephyr/pull/403