### PR TITLE
doc: release-notes-latest: Update summaries for mcumgr and fs subsystem

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -97,6 +97,20 @@ sdk-mcuboot
 The MCUboot fork in |NCS| contains all commits from the upstream MCUboot repository up to and including ``5a6e18148d``, plus some |NCS| specific additions.
 The list of the most important recent changes can be found in :ref:`ncs_release_notes_140`.
 
+sdk-mcumgr
+==========
+
+The mcumgr library fork in |NCS| contains all commits from the upstream mcumgr
+up to and including snapshot ``a3d5117b08``.
+
+* Changes:
+
+  * Fixed issue with devices mcuboot version 1.6.0 and earlier where power outage
+    during erase of corrupted image in slot-1 could lead to device not being able to boot
+    nor update with mcumgr returning error code 6 (MGMT_ERR_EBADSTATE).
+  * Added support for invoking shell commands (shell management) with mcumgr command line.
+  * Removed broken log management support.
+
 
 Zephyr
 ======
@@ -214,3 +228,11 @@ The following list summarizes the most important changes inherited from upstream
     * Fixed handling of zero-length packets (ZLP) in the Nordic Semiconductor USB Device Controller driver (usb_dc_nrfx).
     * Fixed initialization of the workqueue in the usb_dc_nrfx driver, to prevent fatal errors when the driver is reattached.
     * Fixed handling of the SUSPEND and RESUME events in the Bluetooth classes.
+
+* File Systems
+
+  * Enabled FCB to work with non-0xff erase value flash.
+  * Added ``CONFIG_FS_MOUNT_FLAG_NO_FORMAT`` flag to FATFS Kconfig options, that removes formatting capabilities from FAT FS;
+    the option also prevents unformatted devices to be formatted to FAT FS on mount attempt.
+  * Added support for ``fs_mount()`` flags: ``FS_MOUNT_FLAG_READ_ONLY`` and ``FS_MOUNT_FLAG_NO_FORMAT``.
+  * The runtime check of FS API of a driver interface will not be perfromed when ``CONFIG_NO_RUNTIME_CHECKS`` option is enabled.


### PR DESCRIPTION
The commit adds summary of changes for modules/lib/mcumgr and fs subsystem.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>