### PR TITLE
pm: use 'merged_domains.hex' as 'hex_file' property in runner

### DIFF
--- a/cmake/partition_manager.cmake.orig
+++ b/cmake/partition_manager.cmake.orig
@@ -38,17 +38,6 @@ if (EXISTS ${static_configuration_file})
   set(static_configuration --static-config ${static_configuration_file})
 endif()
 
-if (NOT static_configuration AND CONFIG_PM_IMAGE_NOT_BUILT_FROM_SOURCE)
-  message(WARNING
-    "One or more child image is not configured to be built from source. \
-    However, there is no static configuration provided to the \
-    partition manager. Please provide a static configuration as described in \
-    the 'Scripts -> Partition Manager -> Static configuration' chapter in the \
-    documentation. Without this information, the build system is not able to \
-    place the image correctly in flash.")
-endif()
-
-
 # Check if current image is the dynamic partition in its domain.
 # I.E. it is the only partition without a statically configured size in this
 # domain. This is equivalent to the 'app' partition in the root domain.
@@ -141,14 +130,6 @@ elseif (DEFINED CONFIG_SOC_NRF5340_CPUAPP)
   set(otp_size 764)  # 191 * 4
 endif()
 
-add_region(
-  NAME sram_primary
-  SIZE ${CONFIG_PM_SRAM_SIZE}
-  BASE ${CONFIG_PM_SRAM_BASE}
-  PLACEMENT complex
-  DYNAMIC_PARTITION sram_primary
-  )
-
 math(EXPR flash_size "${CONFIG_FLASH_SIZE} * 1024" OUTPUT_FORMAT HEXADECIMAL)
 
 if (CONFIG_SOC_NRF9160 OR CONFIG_SOC_NRF5340_CPUAPP)
@@ -177,21 +158,17 @@ if (CONFIG_PM_EXTERNAL_FLASH)
     )
 endif()
 
-if (DOMAIN)
-  set(UNDERSCORE_DOMAIN _${DOMAIN})
-endif()
-
-set(pm_out_partition_file ${APPLICATION_BINARY_DIR}/partitions${UNDERSCORE_DOMAIN}.yml)
-set(pm_out_region_file ${APPLICATION_BINARY_DIR}/regions${UNDERSCORE_DOMAIN}.yml)
-set(pm_out_dotconf_file ${APPLICATION_BINARY_DIR}/pm${UNDERSCORE_DOMAIN}.config)
+set(pm_out_partition_files ${ZEPHYR_BINARY_DIR}/../partitions_${DOMAIN}.yml)
+set(pm_out_region_files ${ZEPHYR_BINARY_DIR}/../regions_${DOMAIN}.yml)
+set(pm_out_dotconf_files ${ZEPHYR_BINARY_DIR}/../pm_${DOMAIN}.config)
 
 set(pm_cmd
   ${PYTHON_EXECUTABLE}
   ${NRF_DIR}/scripts/partition_manager.py
   --input-files ${input_files}
   --regions ${regions}
-  --output-partitions ${pm_out_partition_file}
-  --output-regions ${pm_out_region_file}
+  --output-partitions ${pm_out_partition_files}
+  --output-regions ${pm_out_region_files}
   ${dynamic_partition_argument}
   ${static_configuration}
   ${region_arguments}
@@ -200,9 +177,9 @@ set(pm_cmd
 set(pm_output_cmd
   ${PYTHON_EXECUTABLE}
   ${NRF_DIR}/scripts/partition_manager_output.py
-  --input-partitions ${pm_out_partition_file}
-  --input-regions ${pm_out_region_file}
-  --config-file ${pm_out_dotconf_file}
+  --input-partitions ${pm_out_partition_files}
+  --input-regions ${pm_out_region_files}
+  --config-file ${pm_out_dotconf_files}
   )
 
 # Run the partition manager algorithm.
@@ -232,7 +209,7 @@ endif()
 add_custom_target(partition_manager)
 
 # Make Partition Manager configuration available in CMake
-import_kconfig(PM_ ${pm_out_dotconf_file} pm_var_names)
+import_kconfig(PM_ ${pm_out_dotconf_files} pm_var_names)
 
 foreach(name ${pm_var_names})
   set_property(
@@ -330,6 +307,17 @@ foreach(container ${containers} ${merged})
 
 endforeach()
 
+get_target_property(runners_content runner_yml_props_target yaml_contents)
+
+string(REGEX REPLACE "--hex-file=[^\n]*"
+  "--hex-file=${PROJECT_BINARY_DIR}/${merged}.hex" new  ${runners_content})
+
+set_property(
+  TARGET         runner_yml_props_target
+  PROPERTY       yaml_contents
+  ${new}
+  )
+
 if (CONFIG_SECURE_BOOT AND CONFIG_BOOTLOADER_MCUBOOT)
   # Create symbols for the offsets required for moving test update hex files
   # to MCUBoots secondary slot. This is needed because objcopy does not
@@ -357,14 +345,22 @@ if (is_dynamic_partition_in_domain)
   # Expose the generated partition manager configuration files to parent image.
   # This is used by the root image to create the global configuration in
   # pm_config.h.
-  share("set(${DOMAIN}_PM_DOMAIN_PARTITIONS ${pm_out_partition_file})")
-  share("set(${DOMAIN}_PM_DOMAIN_REGIONS ${pm_out_region_file})")
+<<<<<<< HEAD
+  share("set(${DOMAIN}_PM_DOMAIN_PARTITIONS ${pm_out_partition_files})")
+  share("set(${DOMAIN}_PM_DOMAIN_REGIONS ${pm_out_region_files})")
   share("set(${DOMAIN}_PM_DOMAIN_HEADER_FILES ${header_files})")
   share("set(${DOMAIN}_PM_DOMAIN_IMAGES ${prefixed_images})")
   share("set(${DOMAIN}_PM_HEX_FILE ${PROJECT_BINARY_DIR}/${merged}.hex)")
-  share("set(${DOMAIN}_PM_DOTCONF_FILES ${pm_out_dotconf_file})")
-  share("set(${DOMAIN}_PM_APP_HEX ${PROJECT_BINARY_DIR}/app.hex)")
-  share("set(${DOMAIN}_PM_SIGNED_APP_HEX ${PROJECT_BINARY_DIR}/signed_by_b0_app.hex)")
+=======
+  share("set(${domain}_PM_DOMAIN_PARTITIONS ${pm_out_partition_files})")
+  share("set(${domain}_PM_DOMAIN_REGIONS ${pm_out_region_files})")
+  share("set(${domain}_PM_DOMAIN_HEADER_FILES ${header_files})")
+  share("set(${domain}_PM_DOMAIN_IMAGES ${prefixed_images})")
+  share("set(${domain}_PM_HEX_FILE ${PROJECT_BINARY_DIR}/${merged}.hex)")
+  share("set(${domain}_PM_DOTCONF_FILES ${pm_out_dotconf_files})")
+  # The partition manager script ensures that the 'app' hex always exists.
+  share("set(${domain}_PM_APP_HEX ${PROJECT_BINARY_DIR}/app.hex)")
+>>>>>>> 9a8225a0d... dump WITH PCD
 else()
   # This is the root image, generate the global pm_config.h
   # First, include the shared_vars.cmake file for all child images.
@@ -385,8 +381,8 @@ else()
       include(${shared_vars_file})
       list(APPEND header_files ${${d}_PM_DOMAIN_HEADER_FILES})
       list(APPEND prefixed_images ${${d}_PM_DOMAIN_IMAGES})
-      list(APPEND pm_out_partition_file ${${d}_PM_DOMAIN_PARTITIONS})
-      list(APPEND pm_out_region_file ${${d}_PM_DOMAIN_REGIONS})
+      list(APPEND pm_out_partition_files ${${d}_PM_DOMAIN_PARTITIONS})
+      list(APPEND pm_out_region_files ${${d}_PM_DOMAIN_REGIONS})
       list(APPEND global_hex_depends ${${d}_PM_DOMAIN_DYNAMIC_PARTITION}_subimage)
       list(APPEND domain_hex_files ${${d}_PM_HEX_FILE})
 
@@ -406,19 +402,21 @@ else()
           )
       endforeach()
 
-      if (CONFIG_NRF53_UPGRADE_NETWORK_CORE
-          AND CONFIG_HCI_RPMSG_BUILD_STRATEGY_FROM_SOURCE)
+      # TODO don't check BOARD, don'c check for BT_RPMSG. Do something smarter, look at domains?
+      # Don't hard code domain/board names.
+      if (CONFIG_BT_RPMSG_NRF53 AND CONFIG_BOOTLOADER_MCUBOOT AND
+          (CONFIG_SOC_NRF5340_CPUAPP))
           # Create symbols for the offset reqired for moving the signed network
           # core application to MCUBoots secondary slot. This is needed
           # because  objcopy does not support arithmetic expressions as argument
           # (e.g. '0x100+0x200'), and all of the symbols used to generate the
-          # offset are only available as a generator expression when MCUBoots
+          # offset is only available as a generator expression when MCUBoots
           # cmake code exectues.
 
           get_target_property(
             net_app_addr
             partition_manager
-            CPUNET_PM_APP_ADDRESS
+            nrf5340pdk_nrf5340_cpunet_PM_APP_ADDRESS
             )
 
           # There is no padding in front of the network core application.
@@ -444,8 +442,8 @@ else()
   set(pm_global_output_cmd
     ${PYTHON_EXECUTABLE}
     ${NRF_DIR}/scripts/partition_manager_output.py
-    --input-partitions ${pm_out_partition_file}
-    --input-regions ${pm_out_region_file}
+    --input-partitions ${pm_out_partition_files}
+    --input-regions ${pm_out_region_files}
     --header-files ${header_files}
     --images ${prefixed_images}
     )
@@ -464,7 +462,7 @@ else()
   set_property(
     TARGET partition_manager
     PROPERTY PM_CONFIG_FILES
-    ${pm_out_partition_file}
+    ${pm_out_partition_files}
     )
 
   set_property(
@@ -473,26 +471,23 @@ else()
     ${global_hex_depends}
     )
 
-  if (PM_DOMAINS)
-    # For convenience, generate global hex file containing all domains' hex
-    # files.
-    set(final_merged ${ZEPHYR_BINARY_DIR}/merged_domains.hex)
+  # For convenience, generate global hex file containing all domains' hex files.
+  set(final_merged ${PROJECT_BINARY_DIR}/merged_domains.hex)
 
-    # Add command to merge files.
-    add_custom_command(
-      OUTPUT ${final_merged}
-      COMMAND
-      ${PYTHON_EXECUTABLE}
-      ${ZEPHYR_BASE}/scripts/mergehex.py
-      -o ${final_merged}
-      ${domain_hex_files}
-      DEPENDS
-      ${global_hex_depends}
-      )
+  # Add command to merge files.
+  add_custom_command(
+    OUTPUT ${final_merged}
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/mergehex.py
+    -o ${final_merged}
+    ${domain_hex_files}
+    DEPENDS
+    ${global_hex_depends}
+    )
 
-    # Wrapper target for the merge command.
-    add_custom_target(merged_domains_hex ALL DEPENDS ${final_merged})
-  endif()
+  # Wrapper target for the merge command.
+  add_custom_target(merged_domains_hex ALL DEPENDS ${final_merged})
 
   # Add ${merged}.hex as the representative hex file for flashing this app.
   if(TARGET flash)
@@ -502,30 +497,3 @@ else()
     CACHE STRING "Path to merged image in Intel Hex format" FORCE)
 
 endif()
-
-# We need to tell the flash runner use the merged hex file instead of
-# 'zephyr.hex'This is typically done by setting the 'hex_file' property of the
-# 'runners_yaml_props_target' target. However, since the CMakeLists.txt file
-# reading those properties has already run, and the 'hex_file' property
-# is not evaluated in a generator expression, it is too late at this point to
-# set that variable. Hence we must operate on the 'yaml_contents' property,
-# which is evaluated in a generator expression.
-
-if (final_merged)
-  # Multiple domains are included in the build, point to the result of
-  # merging the merged hex file for all domains.
-  set(merged_hex_to_flash ${final_merged})
-else()
-  set(merged_hex_to_flash ${PROJECT_BINARY_DIR}/${merged}.hex)
-endif()
-
-get_target_property(runners_content runners_yaml_props_target yaml_contents)
-
-string(REGEX REPLACE "hex_file:[^\n]*"
-  "hex_file: ${merged_hex_to_flash}" new  ${runners_content})
-
-set_property(
-  TARGET         runners_yaml_props_target
-  PROPERTY       yaml_contents
-  ${new}
-  )


### PR DESCRIPTION
... when multiple domains are included in the build.

This to facilitate tools capable of programming hex files which spans
multiple domains (cores).

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>