### PR TITLE
pm: use 'merged_domains.hex' as 'hex_file' property in runner

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -264,26 +264,4 @@ function(add_child_image_from_source)
       )
   endif()
 
-  if (ACI_DOMAIN)
-    add_custom_target(${ACI_NAME}_flash
-      COMMAND
-      ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/${ACI_NAME}
-      --target flash
-      DEPENDS
-      ${ACI_NAME}_subimage
-      USES_TERMINAL
-      )
-
-    # If the dynamic partition has child images, their hex files will be
-    # included in the 'merged_{DOMAIN_NAME}.hex' file which is flashed
-    # by the flash target of the dynamic partition. Hence, we only add a
-    # dependency to the flash target of the dynamic partition in the domain.
-    if ("${ACI_NAME}" STREQUAL "${${ACI_DOMAIN}_PM_DOMAIN_DYNAMIC_PARTITION}")
-      set_property(TARGET zephyr_property_target
-        APPEND PROPERTY FLASH_DEPENDENCIES
-        ${ACI_NAME}_flash
-        )
-    endif()
-  endif()
-
 endfunction()

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -515,6 +515,11 @@ if (final_merged)
   # Multiple domains are included in the build, point to the result of
   # merging the merged hex file for all domains.
   set(merged_hex_to_flash ${final_merged})
+  set_property(
+    TARGET zephyr_property_target
+    APPEND PROPERTY FLASH_DEPENDENCIES
+    ${final_merged}
+    )
 else()
   set(merged_hex_to_flash ${PROJECT_BINARY_DIR}/${merged}.hex)
 endif()

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 839ee1821638946e20ffac00f16ccb2fe0d4446e
+      revision: 5a7b4eb71047805c00e76b758212d622a0c5df55
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
... when multiple domains are included in the build.

This to facilitate tools capable of programming hex files which spans
multiple domains (cores).

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>