### PR TITLE
manifest: Allow initiating LFCLK but do not wait for readiness

### DIFF
--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -132,6 +132,8 @@ static int mpsl_lib_init(const struct device *dev)
 
 	clock_cfg.source = m_config_clock_source_get();
 	clock_cfg.accuracy_ppm = CONFIG_CLOCK_CONTROL_NRF_ACCURACY;
+	clock_cfg.skip_wait_lfclk_started =
+		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT);
 
 #ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
 	clock_cfg.rc_ctiv = MPSL_RECOMMENDED_RC_CTIV;

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.4.0
+      revision: 65562a97094f74d578d1c76744b92571e7938d53
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Updated manifest for MPSL driver in nrfxlib. Add an option to not wait
for LFCLK to start using MPSL clock API.

Corresponding PR in nrf: nrfconnect/sdk-nrfxlib#349

Signed-off-by: Ryan Chu <ryan.chu@nordicsemi.no>