### PR TITLE
Samples: add nrf53dk board in the nrf_rpc sample

### DIFF
--- a/samples/bluetooth/central_nfc_pairing/CMakeLists.txt
+++ b/samples/bluetooth/central_nfc_pairing/CMakeLists.txt
@@ -6,15 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-# Set supported board
-set(NRF_SUPPORTED_BOARDS
-  nrf52dk_nrf52832
-  nrf52840dk_nrf52840
-  nrf52833dk_nrf52833
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuapp
-  )
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/peripheral_nfc_pairing/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_nfc_pairing/CMakeLists.txt
@@ -6,16 +6,6 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-set(NRF_SUPPORTED_BOARDS
-  nrf52dk_nrf52832
-  nrf52840dk_nrf52840
-  nrf52833dk_nrf52833
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340pdk_nrf5340_cpuappns
-  nrf5340dk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuappns
-  )
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/record_text/CMakeLists.txt
+++ b/samples/nfc/record_text/CMakeLists.txt
@@ -6,16 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(NRF_SUPPORTED_BOARDS
-  nrf52dk_nrf52832
-  nrf52840dk_nrf52840
-  nrf52833dk_nrf52833
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340pdk_nrf5340_cpuappns
-  nrf5340dk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuappns
-  )
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/system_off/CMakeLists.txt
+++ b/samples/nfc/system_off/CMakeLists.txt
@@ -6,16 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(NRF_SUPPORTED_BOARDS
-  nrf52dk_nrf52832
-  nrf52840dk_nrf52840
-  nrf52833dk_nrf52833
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340pdk_nrf5340_cpuappns
-  nrf5340dk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuappns
-  )
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/tag_reader/CMakeLists.txt
+++ b/samples/nfc/tag_reader/CMakeLists.txt
@@ -6,15 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-# Set supported board
-set(NRF_SUPPORTED_BOARDS
-  nrf52dk_nrf52832
-  nrf52840dk_nrf52840
-  nrf52833dk_nrf52833
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuapp
-  )
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/tnep_poller/CMakeLists.txt
+++ b/samples/nfc/tnep_poller/CMakeLists.txt
@@ -6,15 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-# Set supported board
-set(NRF_SUPPORTED_BOARDS
-  nrf52dk_nrf52832
-  nrf52840dk_nrf52840
-  nrf52833dk_nrf52833
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuapp
-  )
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/tnep_tag/CMakeLists.txt
+++ b/samples/nfc/tnep_tag/CMakeLists.txt
@@ -6,16 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(NRF_SUPPORTED_BOARDS
-  nrf52dk_nrf52832
-  nrf52840dk_nrf52840
-  nrf52833dk_nrf52833
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340pdk_nrf5340_cpuappns
-  nrf5340dk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuappns
-  )
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nfc/writable_ndef_msg/CMakeLists.txt
+++ b/samples/nfc/writable_ndef_msg/CMakeLists.txt
@@ -6,16 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(NRF_SUPPORTED_BOARDS
-  nrf52dk_nrf52832
-  nrf52840dk_nrf52840
-  nrf52833dk_nrf52833
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340pdk_nrf5340_cpuappns
-  nrf5340dk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuappns
-  )
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/nrf5340/empty_app_core/CMakeLists.txt
+++ b/samples/nrf5340/empty_app_core/CMakeLists.txt
@@ -6,11 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set(NRF_SUPPORTED_BOARDS
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuapp
-  )
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(empty_app_core)
 

--- a/samples/nrf_rpc/entropy_nrf53/cpuapp/CMakeLists.txt
+++ b/samples/nrf_rpc/entropy_nrf53/cpuapp/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.13.1)
 
 set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpuapp
+  nrf5340dk_nrf5340_cpuapp
 )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nrf_rpc/entropy_nrf53/cpuapp/CMakeLists.txt
+++ b/samples/nrf_rpc/entropy_nrf53/cpuapp/CMakeLists.txt
@@ -5,13 +5,8 @@
 #
 cmake_minimum_required(VERSION 3.13.1)
 
-set(NRF_SUPPORTED_BOARDS
-  nrf5340pdk_nrf5340_cpuapp
-  nrf5340dk_nrf5340_cpuapp
-)
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(entropy_nrf53_cpuapp)
+project(NONE)
 
 # NORDIC SDK APP START
 target_sources(app PRIVATE

--- a/samples/nrf_rpc/entropy_nrf53/cpuapp/sample.yaml
+++ b/samples/nrf_rpc/entropy_nrf53/cpuapp/sample.yaml
@@ -5,4 +5,4 @@ tests:
   samples.nrf_rpc.entropy_cpuapp:
     build_only: true
     build_on_all: true
-    platform_allow: nrf5340pdk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/samples/nrf_rpc/entropy_nrf53/cpunet/CMakeLists.txt
+++ b/samples/nrf_rpc/entropy_nrf53/cpunet/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.13.1)
 
 set(NRF_SUPPORTED_BOARDS
   nrf5340pdk_nrf5340_cpunet
+  nrf5340dk_nrf5340_cpunet
 )
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nrf_rpc/entropy_nrf53/cpunet/CMakeLists.txt
+++ b/samples/nrf_rpc/entropy_nrf53/cpunet/CMakeLists.txt
@@ -5,13 +5,8 @@
 #
 cmake_minimum_required(VERSION 3.13.1)
 
-set(NRF_SUPPORTED_BOARDS
-  nrf5340pdk_nrf5340_cpunet
-  nrf5340dk_nrf5340_cpunet
-)
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(entropy_nrf53_cpuapp)
+project(NONE)
 
 # NORDIC SDK APP START
 target_sources(app PRIVATE

--- a/samples/nrf_rpc/entropy_nrf53/cpunet/sample.yaml
+++ b/samples/nrf_rpc/entropy_nrf53/cpunet/sample.yaml
@@ -5,4 +5,4 @@ tests:
   samples.nrf_rpc.entropy_cpunet:
     build_only: true
     build_on_all: true
-    platform_allow: nrf5340pdk_nrf5340_cpunet nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf5340dk_nrf5340_cpunet

--- a/subsys/nrf_rpc/rp_ll.c
+++ b/subsys/nrf_rpc/rp_ll.c
@@ -125,7 +125,7 @@ const struct virtio_dispatch dispatch = {
 };
 
 /* Callback launch right after some data has arrived. */
-static void ipm_callback(struct device *ipmdev, void *user_data, uint32_t id,
+static void ipm_callback(const struct device *ipmdev, void *user_data, uint32_t id,
 			 volatile void *data)
 {
 	k_work_submit_to_queue(&my_work_q, &work_item);


### PR DESCRIPTION
The nrf53 DK was missing in this sample (APP and NET) cores. Additionally fixed a warning in the nRF RPC transport LL module.