### PR TITLE
Enable NFC for nRF5340dk by default in Keyboard HIDS sample

### DIFF
--- a/samples/bluetooth/peripheral_hids_keyboard/Kconfig
+++ b/samples/bluetooth/peripheral_hids_keyboard/Kconfig
@@ -10,9 +10,8 @@ menu "Nordic BLE HIDS Keyboard sample"
 
 config NFC_OOB_PAIRING
 	bool "Enable NFC OOB pairing"
-	default y if BOARD_NRF5340PDK_NRF5340_CPUAPP
-	default y if BOARD_NRF52840DK_NRF52840
-	default y if BOARD_NRF52DK_NRF52832
+	depends on HAS_HW_NRF_NFCT
+	default y
 	select NFC_T2T_NRFXLIB
 	select NFC_NDEF
 	select NFC_NDEF_MSG


### PR DESCRIPTION
Enables NFC by default for nRF5340dk boards in the Keyboard Peripheral
HIDS sample.