### PR TITLE
doc: known_issues: add Thread known issue with UART in NCP sample

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -173,6 +173,13 @@ Thread
 
 .. rst-class:: v1-4-99-dev1
 
+KRKNWK-8286: Faulty UART responsiveness in Thread NCP sample
+  A race condition in the UARTE driver causes the retrieval of Spinel responses to fail sometimes for the :ref:`ot_ncp_sample` sample.
+
+  **Workaround:** Build the sample with :option:`CONFIG_UART_0_ENHANCED_POLL_OUT` set to ``n`` or cherry-pick the upstream `Zephyr commit 2db49c`_.
+
+.. rst-class:: v1-4-99-dev1
+
 KRKNWK-8262: CoAP Client Sample crashes for nRF5340
   For nRF5340, the :ref:`coap_client_sample` sample crashes when changing from SED to MED mode.
   Other devices are not affected.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -565,3 +565,4 @@
 .. ### Links to commits
 
 .. _`Zephyr commit f12536`: https://github.com/zephyrproject-rtos/hal_nordic/commit/f12536cbfb27b7bb05b40b97bd8a8857f2bf23ec
+.. _`Zephyr commit 2db49c`: https://github.com/zephyrproject-rtos/zephyr/commit/2db49c4b99850b3e7a53667fe7bb9ba6fc2a5b7d


### PR DESCRIPTION
Update Thread known issues for v1-4-99-dev1 about NCP sample faulty UART responsiveness.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-8286