### PR TITLE
Bluetooth: Mesh: Add Scene prohibited value validation

### DIFF
--- a/subsys/bluetooth/mesh/scene_srv.c
+++ b/subsys/bluetooth/mesh/scene_srv.c
@@ -422,8 +422,14 @@ static void handle_store(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 {
 	struct bt_mesh_scene_srv *srv = mod->user_data;
 	enum bt_mesh_scene_status status;
+	uint16_t scene_number;
 
-	status = scene_store(srv, net_buf_simple_pull_le16(buf));
+	scene_number = net_buf_simple_pull_le16(buf);
+	if (scene_number == BT_MESH_SCENE_NONE) {
+		return;
+	}
+
+	status = scene_store(srv, scene_number);
 	scene_register_status_send(srv, ctx, status);
 }
 
@@ -432,8 +438,14 @@ static void handle_store_unack(struct bt_mesh_model *mod,
 			       struct net_buf_simple *buf)
 {
 	struct bt_mesh_scene_srv *srv = mod->user_data;
+	uint16_t scene_number;
 
-	(void)scene_store(srv, net_buf_simple_pull_le16(buf));
+	scene_number = net_buf_simple_pull_le16(buf);
+	if (scene_number == BT_MESH_SCENE_NONE) {
+		return;
+	}
+
+	(void)scene_store(srv, scene_number);
 }
 
 static void handle_delete(struct bt_mesh_model *mod,


### PR DESCRIPTION
Scene Store and Scene Store Unacknowledged handlers have to validate scene number to not be equal to value 0x0000, which is Prohibited, according to Mesh Model specification v1.0.1 (5.2.2.1 Scene Store and 5.2.2.2 Scene Store Unacknowledged). Client side functions (`bt_mesh_scene_cli_store` and `bt_mesh_scene_cli_store_unack`) do such checks, but not the server side (`handle_store` and `handle_store_unack`).

Signed-off-by: Roman Alexeev <roman@alexeyev.su>