### PR TITLE
applications: serial_lte_modem BUG-FIX FOTA interrupted by AT command

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -39,6 +39,9 @@ enum slm_fota_operation {
 	AT_FOTA_STOP
 };
 
+static char path[URI_PATH_MAX];
+static char hostname[URI_HOST_MAX];
+
 /* global functions defined in different files */
 void rsp_send(const uint8_t *str, size_t len);
 
@@ -89,8 +92,6 @@ static int do_fota_start(int op, const char *file_uri, int sec_tag,
 	int ret = -EINVAL;
 	struct http_parser_url parser;
 	char schema[8];
-	char path[URI_PATH_MAX];
-	char hostname[URI_HOST_MAX];
 
 	http_parser_url_init(&parser);
 	ret = http_parser_parse_url(file_uri, strlen(file_uri), 0, &parser);


### PR DESCRIPTION
When FOTA download is on-going, issue any AT command will interrupt it.
This is due to the Host and File buffers need to be kept during full
procedure of downloading (downloat_client/http.c), otherwise following
HTTP Request will contain tampered content in header and get 400 error.
Fix is to move the two buffers from function-wise to global data area.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>