### PR TITLE
spm: sample: Disable CONFIG_ASSERT to reduce image bloat

### DIFF
--- a/samples/spm/prj.conf
+++ b/samples/spm/prj.conf
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
+CONFIG_ASSERT=n     # NCSDK-7354: CONFIG_ASSERT overflows SPM flash when enabled
 
 CONFIG_IS_SPM=y
 CONFIG_FW_INFO=y


### PR DESCRIPTION
Enabling ASSERT doubles the SPM subimage, breaking all nRF91 builds.
Disable this configuration while leaving the other NRF_SAMPLE_DEFAULT
configurations enabled to avoid breaking SPM builds.

Signed-off-by: Stephen Stauts <stephen.stauts@nordicsemi.no>