### PR TITLE
Bluetooth: Mesh: Fix typo in docstring of publish APIs

### DIFF
--- a/include/bluetooth/mesh/gen_battery_srv.h
+++ b/include/bluetooth/mesh/gen_battery_srv.h
@@ -84,8 +84,8 @@ struct bt_mesh_battery_srv {
  * Asynchronously publishes a Generic Battery status message with the
  * configured publish parameters.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set messages are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @param[in] srv Server instance to publish on.
  * @param[in] ctx Message context to send with, or NULL to send with the

--- a/include/bluetooth/mesh/gen_loc_srv.h
+++ b/include/bluetooth/mesh/gen_loc_srv.h
@@ -144,8 +144,8 @@ struct bt_mesh_loc_srv {
  * Asynchronously publishes a Global Location status message with the
  * configured publish parameters.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @note The server will only publish one state at the time. Calling this
  * function will terminate any publishing of the Local Location state.
@@ -169,8 +169,8 @@ int32_t bt_mesh_loc_srv_global_pub(struct bt_mesh_loc_srv *srv,
  * Asynchronously publishes a Local Location status message with the configured
  * publish parameters.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @note The server will only publish one state at the time. Calling this
  * function will terminate any publishing of the Global Location state.

--- a/include/bluetooth/mesh/gen_onoff_srv.h
+++ b/include/bluetooth/mesh/gen_onoff_srv.h
@@ -108,8 +108,8 @@ struct bt_mesh_onoff_srv {
  * Asynchronously publishes a Generic OnOff status message with the configured
  * publish parameters.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set messages are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @param[in] srv Server instance to publish on.
  * @param[in] ctx Message context to send with, or NULL to send with the

--- a/include/bluetooth/mesh/gen_plvl_srv.h
+++ b/include/bluetooth/mesh/gen_plvl_srv.h
@@ -165,8 +165,8 @@ struct bt_mesh_plvl_srv {
  * Publishes a Generic Power Level status message with the configured publish
  * parameters, or using the given message context.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set messages are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @param[in] srv Server instance to publish with.
  * @param[in] ctx Message context, or NULL to publish with the configured

--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -122,8 +122,8 @@ void bt_mesh_ponoff_srv_set(struct bt_mesh_ponoff_srv *srv,
  * Publishes a Generic Power OnOff status message with the configured publish
  * parameters, or using the given message context.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set messages are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @param[in] srv Server instance to publish with.
  * @param[in] ctx Message context, or NULL to publish with the configured

--- a/include/bluetooth/mesh/light_ctl_srv.h
+++ b/include/bluetooth/mesh/light_ctl_srv.h
@@ -189,8 +189,8 @@ struct bt_mesh_light_ctl_srv {
  * Asynchronously publishes a CTL status message with the configured
  * publish parameters.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set messages are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @param[in] srv Server instance to publish on.
  * @param[in] ctx Message context to send with, or NULL to send with the
@@ -211,8 +211,8 @@ int32_t bt_mesh_light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
  * Asynchronously publishes a CTL Range status message with the configured
  * publish parameters.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set messages are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @param[in] srv Server instance to publish on.
  * @param[in] ctx Message context to send with, or NULL to send with the
@@ -233,8 +233,8 @@ int32_t bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
  * Asynchronously publishes a CTL Default status message with the configured
  * publish parameters.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set messages are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @param[in] srv Server instance to publish on.
  * @param[in] ctx Message context to send with, or NULL to send with the

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -133,8 +133,8 @@ struct bt_mesh_light_temp_srv {
  * Asynchronously publishes a CTL Temperature status message with the configured
  * publish parameters.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set messages are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @param[in] srv Server instance to publish on.
  * @param[in] ctx Message context to send with, or NULL to send with the

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -166,8 +166,8 @@ struct bt_mesh_lightness_srv {
  * Publishes a Light Lightness status message with the configured publish
  * parameters, or using the given message context.
  *
- * @note This API is only used publishing unprompted status messages. Response
- * messages for get and set messages are handled internally.
+ * @note This API is only used for publishing unprompted status messages.
+ * Response messages for get and set messages are handled internally.
  *
  * @param[in] srv Server instance to publish with.
  * @param[in] ctx Message context, or NULL to publish with the configured


### PR DESCRIPTION
A lot of the server models' API documentation contains a note about the
usage of the publish functions. All of these have dropped a word,
leading to some broken english. Fix for all instances.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>