### PR TITLE
lib: date_time: Add API to check if the library has obtained valid time

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -80,6 +80,9 @@ nRF9160
     * Added an option to set the hostname for TLS Server Name Indication (SNI) extension.
       This option is valid only when TLS is enabled.
 
+  * :ref:`lib_date_time` library - Added an API to check if the Date-Time library has obtained a valid date-time.
+    If the function returns false, it implies that the library has not yet obtained valid date-time to base its calculations and time conversions on and hence other API calls that depend on the internal date-time will fail.
+
 Common
 ======
 

--- a/include/date_time.h
+++ b/include/date_time.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/types.h>
 #include <time.h>
+#include <stdbool.h>
 
 /**
  * @defgroup date_time Date Time Library
@@ -85,6 +86,19 @@ int date_time_uptime_to_unix_time_ms(int64_t *uptime);
  *  @return -ENODATA If the library does not have a valid date time UTC.
  */
 int date_time_now(int64_t *unix_time_ms);
+
+/** @brief Convenience function that checks if the library has obtained
+ *	   an initial valid date time.
+ *
+ *  @note If this function returns false there is no point of
+ *	  subsequent calls to other functions in this API that
+ *	  depend on the validity of the internal date time. We
+ *	  know that they would fail beforehand.
+ *
+ *  @return true  The library has obtained an initial date time.
+ *  @return false The library has not obtained an initial date time.
+ */
+bool date_time_is_valid(void);
 
 /** @brief Register an event handler for Date time library events.
  *

--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -413,6 +413,11 @@ int date_time_now(int64_t *unix_time_ms)
 	return err;
 }
 
+bool date_time_is_valid(void)
+{
+	return initial_valid_time;
+}
+
 void date_time_register_handler(date_time_evt_handler_t evt_handler)
 {
 	if (evt_handler == NULL) {

--- a/tests/lib/date_time/CMakeLists.txt
+++ b/tests/lib/date_time/CMakeLists.txt
@@ -1,8 +1,8 @@
-/*
- * Copyright (c) 2020 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
- */
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
 
 cmake_minimum_required(VERSION 3.13.1)
 

--- a/tests/lib/date_time/prj.conf
+++ b/tests/lib/date_time/prj.conf
@@ -1,8 +1,8 @@
-/*
- * Copyright (c) 2020 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
- */
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
 
 # ZTEST
 CONFIG_ZTEST=y

--- a/tests/lib/date_time/src/main.c
+++ b/tests/lib/date_time/src/main.c
@@ -253,6 +253,30 @@ static void test_date_time_conversion(void)
 	zassert_equal(ts_expect, uptime, "uptime equal ts_expect");
 }
 
+static void test_date_time_validity(void)
+{
+	int ret;
+	struct tm date_time_dummy = {
+		.tm_year = 120,
+		.tm_mon = 7,
+		.tm_mday = 7,
+		.tm_hour = 15,
+		.tm_min = 11,
+		.tm_sec = 30
+	};
+
+	ret = date_time_is_valid();
+	zassert_equal(false, ret, "date_time_is_valid should equal false");
+
+	/** UNIX timestamp equavivalent to tm structure date_time_dummy. */
+	/** Fri Aug 07 2020 15:11:30 UTC. */
+	ret = date_time_set(&date_time_dummy);
+	zassert_equal(0, ret, "date_time_set should equal 0");
+
+	ret = date_time_is_valid();
+	zassert_equal(true, ret, "date_time_is_valid should equal true");
+}
+
 static void test_date_time_setup(void)
 {
 	/** */
@@ -287,6 +311,10 @@ void test_main(void)
 					test_date_time_teardown),
 		ztest_unit_test_setup_teardown(
 					test_date_time_conversion,
+					test_date_time_setup,
+					test_date_time_teardown),
+		ztest_unit_test_setup_teardown(
+					test_date_time_validity,
 					test_date_time_setup,
 					test_date_time_teardown)
 	);

--- a/tests/lib/date_time/testcase.yaml
+++ b/tests/lib/date_time/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   date_time.functionality_test:
-    platform_allow: qemu_x86
+    platform_allow: nrf9160dk_nrf9160 qemu_x86 native_posix
     tags: date_time


### PR DESCRIPTION
Convenience function that checks if the date time library has
obtained valid time. This allows the application to check if valid time
has been obtained before attempting to call other functions of the
date time library to convert/get timestamps. This patch also adds a
test for the new function.

_When the test for the new function introduced in this PR was added it was uncovered that the date time test was not building at all. Because of this, this PR also contains a commit that fixes the build issues. This should have been picked up by CI and the reason why is under investigation._