### PR TITLE
samples: nrf_rpc: Cleaned up CMake file for this sample.

### DIFF
--- a/samples/nrf_rpc/entropy_nrf53/cpuapp/CMakeLists.txt
+++ b/samples/nrf_rpc/entropy_nrf53/cpuapp/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(entropy_nrf53_cpuapp)
 
 # NORDIC SDK APP START
 target_sources(app PRIVATE

--- a/samples/nrf_rpc/entropy_nrf53/cpunet/CMakeLists.txt
+++ b/samples/nrf_rpc/entropy_nrf53/cpunet/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(NONE)
+project(entropy_nrf53_cpunet)
 
 # NORDIC SDK APP START
 target_sources(app PRIVATE


### PR DESCRIPTION
Restored CMake project names for "CPU APP" and "CPU NET" RPC samples.
This is a small cleanup after merging the last-minute bugfix: https://github.com/nrfconnect/sdk-nrf/pull/3493