### PR TITLE
applications: serial_lte_modem: add IP filtering for TCP/TLS server

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -85,6 +85,11 @@ config SLM_INTERFACE_PIN
 #
 # TCP/TLS proxy
 #
+config SLM_TCP_FILTER_SIZE
+	int "Size of IPv4 address allowlist"
+	range 1 6
+	default 6
+
 config SLM_TCP_POLL_TIME
 	int "Poll time-out in seconds for TCP connection"
 	default 10

--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -873,6 +873,135 @@ Test command
 
 The test command is not supported.
 
+TCP filtering #XTCPFILTER
+=========================
+
+The ``#XTCPFILTER`` command allows you to set or clear an allowlist for the TCP server.
+If the allowlist is set, only IPv4 addresses in the list are allowed for connection.
+
+Set command
+-----------
+
+The set command allows you to set or clear an allowlist for the TCP server.
+
+Syntax
+~~~~~~
+
+::
+
+   #XTCPFILTER=<op>[,<ip_addr1>[,<ip_addr2>[,...]]]
+
+* The ``<op>`` parameter can accept one of the following values:
+
+  * ``0`` - clear list and turn filtering mode off
+  * ``1`` - set list and turn filtering mode on
+
+* The ``<ip_addr#>`` value is a string.
+  It indicates the IPv4 address of an allowed TCP/TLS client.
+  The maximum number of IPv4 addresses that can be specified in the list is six.
+
+Examples
+~~~~~~~~
+
+::
+
+   AT#XTCPFILTER=1,"192.168.1.1"
+   OK
+
+::
+
+   AT#XTCPFILTER=1,"192.168.1.1","192.168.1.2","192.168.1.3","192.168.1.4","192.168.1.5","192.168.1.6"
+   OK
+
+::
+
+   AT#XTCPFILTER=0
+   OK
+
+::
+
+   AT#XTCPFILTER=1
+   OK
+
+Read command
+------------
+
+The read command allows you to check TCP filtering settings.
+
+Syntax
+~~~~~~
+
+::
+
+   #XTCPFILTER?
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XTCPFILTER: <filter_mode>[,<ip_addr1>[,<ip_addr2>[,...]]]
+
+* The ``<filter_mode>`` value can assume one of the following values:
+
+  * ``0`` - Disabled
+  * ``1`` - Enabled
+
+Examples
+~~~~~~~~
+
+::
+
+   AT#XTCPFILTER?
+   #XTCPFILTER: 1,"192.168.1.1"
+   OK
+
+::
+
+   AT#XTCPFILTER?
+   #XTCPFILTER: 1,"192.168.1.1","192.168.1.2","192.168.1.3","192.168.1.4","192.168.1.5","192.168.1.6"
+   OK
+
+::
+
+   AT#XTCPFILTER?
+   #XTCPFILTER: 0
+   OK
+
+::
+
+   AT#XTCPFILTER?
+   #XTCPFILTER: 1
+   OK
+
+Test command
+------------
+
+The test command tests the existence of the command and provides information about the type of its subparameters.
+
+Syntax
+~~~~~~
+
+::
+
+   #XTCPFILTER=?
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XTCPFILTER: (list of op value),",<IP_ADDR#1>[,<IP_ADDR#2>[,...]]
+
+Examples
+~~~~~~~~
+
+::
+
+   at#XTCPFILTER=?
+   #XTCPFILTER: (0, 1),<IP_ADDR#1>[,<IP_ADDR#2>[,...]]
+   OK
+
 TCP server #XTCPSVR
 ===================
 

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -155,6 +155,11 @@ Check and configure the following configuration options for the sample:
 
    This option configures the application to accept AT commands ending with carriage return and line feed.
 
+.. option:: CONFIG_SLM_TCP_FILTER_SIZE - Size of IPv4 address allowlist
+
+   This option specifies the number of IPv4 addresses that you can add to an allowlist for TCP connections.
+   If the list is set, only connections from the specified addresses are allowed.
+
 .. option:: CONFIG_SLM_TCP_POLL_TIME - Poll time-out in seconds for TCP connection
 
    This option specifies the poll time-out for the TCP connection, in seconds.

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -318,8 +318,7 @@ static int handle_at_slmuart(const char *at_cmd, uint32_t *baudrate)
 
 static void cmd_send(struct k_work *work)
 {
-	size_t chars;
-	char str[24];
+	char str[32];
 	static char buf[AT_MAX_CMD_LEN];
 	enum at_cmd_state state;
 	int err;
@@ -504,12 +503,12 @@ static void cmd_send(struct k_work *work)
 		rsp_send(ERROR_STR, sizeof(ERROR_STR) - 1);
 		break;
 	case AT_CMD_ERROR_CMS:
-		chars = sprintf(str, "+CMS: %d\r\n", err);
-		rsp_send(str, ++chars);
+		sprintf(str, "+CMS ERROR: %d\r\n", err);
+		rsp_send(str, strlen(str));
 		break;
 	case AT_CMD_ERROR_CME:
-		chars = sprintf(str, "+CME: %d\r\n", err);
-		rsp_send(str, ++chars);
+		sprintf(str, "+CME ERROR: %d\r\n", err);
+		rsp_send(str, strlen(str));
 		break;
 	default:
 		break;

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -99,6 +99,13 @@ nRF9160
   * :ref:`lib_date_time` library - Added an API to check if the Date-Time library has obtained a valid date-time.
     If the function returns false, it implies that the library has not yet obtained valid date-time to base its calculations and time conversions on and hence other API calls that depend on the internal date-time will fail.
 
+  * :ref:`serial_lte_modem` application:
+
+    * Fixed an issue where FOTA downloads were interrupted if an AT command was issued.
+    * Fixed an issue with overflowing HTTP request buffers.
+    * Fixed issues with TCP/UDP server restart.
+    * Added support for allowing only specified TCP/TLS client IP addresses (using the #XTCPFILTER command).
+
 Common
 ======
 


### PR DESCRIPTION
Add a simple IP address filtering mechanism to disconnect incoming
connection from filtered TCP client when filtering mode is on, with
a new #XTCPFILTER command. Also include a small fix for +CME and
+CMS error string format.

JIRA Reference: NCSIDB-218

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>