### PR TITLE
lib: lte_lc: Fix parsing of system mode if preferred mode is set

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1541,8 +1541,10 @@ int lte_lc_system_mode_get(enum lte_lc_system_mode *mode)
 
 	/* We skip the first parameter, as that's the response prefix,
 	 * "%XSYSTEMMODE:" in this case."
+	 * The last parameter sets the preferred mode, and is not implemented
+	 * yet on the modem side, so we ignore it.
 	 */
-	for (size_t i = 1; i < AT_XSYSTEMMODE_PARAMS_COUNT; i++) {
+	for (size_t i = 1; i < AT_XSYSTEMMODE_PARAMS_COUNT - 1; i++) {
 		int param;
 
 		err = at_params_int_get(&resp_list, i, &param);


### PR DESCRIPTION
This patch fixes an issue where parsing of system mode in cases
where the preferred system mode is set to non-zero.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>