### PR TITLE
drivers: gps: Initialize driver on POST_KERNEL level

### DIFF
--- a/drivers/gps/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/gps/nrf9160_gps/nrf9160_gps.c
@@ -916,7 +916,9 @@ static int init(const struct device *dev, gps_event_handler_t handler)
 	return 0;
 }
 
-static struct gps_drv_data gps_drv_data;
+static struct gps_drv_data gps_drv_data = {
+	.socket = -1,
+};
 
 static const struct gps_driver_api gps_api_funcs = {
 	.init = init,
@@ -926,5 +928,5 @@ static const struct gps_driver_api gps_api_funcs = {
 };
 
 DEVICE_AND_API_INIT(nrf9160_gps, CONFIG_NRF9160_GPS_DEV_NAME, setup,
-		    &gps_drv_data, NULL, APPLICATION,
+		    &gps_drv_data, NULL, POST_KERNEL,
 		    CONFIG_NRF9160_GPS_INIT_PRIO, &gps_api_funcs);


### PR DESCRIPTION
Change initialization level to POST_KERNEL to fix an issue with
invalid GNSS socket being used if gps_init() is called when
long-blocking initialization on APPLICATION level takes place.
This typically happens if an LTE connection is automatically
established in the initialization, which can take minutes.

The GNSS interface is usable after BSDlib is initialized, and
this happens at POST_KERNEL level, with priority 0, while the GPS
driver is now set to have priority 90 by default.

Also initialize the socket to an invalid value for the same reasons.

Fixes CIA-135

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>