### PR TITLE
Bluetooth: Mesh: Disable light control on all lightness changes 

### DIFF
--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -230,10 +230,9 @@ static void lightness_set(struct bt_mesh_model *mod,
 
 	if (!tid_check_and_update(&srv->tid, tid, ctx)) {
 		/* According to the Mesh Model Specification section 6.2.3.1,
-		 * receiving a lightness set message should disable control.
+		 * manual changes to the lightness should disable control.
 		 */
 		atomic_clear_bit(&srv->flags, LIGHTNESS_SRV_FLAG_CONTROLLED);
-
 		lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
@@ -508,6 +507,10 @@ static void lvl_set(struct bt_mesh_lvl_srv *lvl_srv,
 	struct bt_mesh_lightness_status status = { 0 };
 
 	if (lvl_set->new_transaction) {
+		/* According to the Mesh Model Specification section 6.2.3.1,
+		 * manual changes to the lightness should disable control.
+		 */
+		atomic_clear_bit(&srv->flags, LIGHTNESS_SRV_FLAG_CONTROLLED);
 		lightness_srv_change_lvl(srv, ctx, &set, &status);
 	} else if (rsp) {
 		srv->handlers->light_get(srv, NULL, &status);
@@ -558,6 +561,10 @@ static void lvl_delta_set(struct bt_mesh_lvl_srv *lvl_srv,
 		.transition = delta_set->transition,
 	};
 
+	/* According to the Mesh Model Specification section 6.2.3.1,
+	 * manual changes to the lightness should disable control.
+	 */
+	atomic_clear_bit(&srv->flags, LIGHTNESS_SRV_FLAG_CONTROLLED);
 	lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 	/* Override "last" value to be able to make corrective deltas when
@@ -621,6 +628,10 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 		}
 	}
 
+	/* According to the Mesh Model Specification section 6.2.3.1,
+	 * manual changes to the lightness should disable control.
+	 */
+	atomic_clear_bit(&srv->flags, LIGHTNESS_SRV_FLAG_CONTROLLED);
 	lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 	if (rsp) {
@@ -659,6 +670,10 @@ static void onoff_set(struct bt_mesh_onoff_srv *onoff_srv,
 		set.lvl = 0;
 	}
 
+	/* According to the Mesh Model Specification section 6.2.3.1,
+	 * manual changes to the lightness should disable control.
+	 */
+	atomic_clear_bit(&srv->flags, LIGHTNESS_SRV_FLAG_CONTROLLED);
 	lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 	if (rsp) {


### PR DESCRIPTION
Adds clearing of the CONTROLLED flag in the lightness server for all
lightness changing messages, both from the server's own messages and the
extended models' messages. This ensures compatibility with the Bluetooth
Mesh Model specification section 6.2.3.1, which states that all manual
changes to the lightness should disable the light control server.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>