### PR TITLE
samples: nrf9160: coap_client: Update default server URL

### DIFF
--- a/samples/nrf9160/coap_client/Kconfig
+++ b/samples/nrf9160/coap_client/Kconfig
@@ -12,7 +12,7 @@ config COAP_RESOURCE
 
 config COAP_SERVER_HOSTNAME
 	string "CoAP server hostname"
-	default "californium.eclipse.org"
+	default "californium.eclipseprojects.io"
 
 config COAP_SERVER_PORT
 	int "CoAP server port"

--- a/samples/nrf9160/coap_client/README.rst
+++ b/samples/nrf9160/coap_client/README.rst
@@ -18,7 +18,7 @@ The nRF CoAP Client sample performs the following actions:
 #. Send periodic GET request for a test resource (specified by the Kconfig parameter ``CONFIG_COAP_RESOURCE``) that is available on the server.
 #. Display the received data about the resource on a terminal emulator.
 
-The public CoAP server used in this sample is Californium CoAP server (``coap://californium.eclipse.org:5683``).
+The public CoAP server used in this sample is Californium CoAP server (``coap://californium.eclipseprojects.io:5683``).
 This server runs Eclipse Californium, which is an open source implementation of the CoAP protocol that is targeted at the development and testing of IoT applications.
 An nRF9160 DK board is used as the CoAP client.
 


### PR DESCRIPTION
The californium interop server has new address since 9th of December
2020, the old one is no longer functional.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>