### PR TITLE
bluetooth: Disable BT_DRIVER_QUIRK_NO_AUTO_DLE by default

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -6,6 +6,7 @@
 
 menu "Device Drivers"
 
+rsource "bluetooth/Kconfig"
 rsource "entropy/Kconfig"
 rsource "hw_cc310/Kconfig"
 rsource "net/Kconfig"

--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+rsource "hci/Kconfig"

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# Override default value from zephyr to avoid
+# issuing a second data length update after connection
+# establishment.
+config BT_DRIVER_QUIRK_NO_AUTO_DLE
+	bool "Host auto-initiated Data Length Update quirk"
+	default n if !BT_LL_SW_SPLIT
+	help
+	  Enable the quirk wherein BT Host stack will auto-initiate Data Length
+	  Update procedure for new connections for controllers that do not
+	  auto-initiate the procedure if the default data length parameters are
+	  not equal to the initial parameters.
+
+	  This has to be enabled when the BLE controller connected is Zephyr
+	  open source controller.


### PR DESCRIPTION
There are two possible ways of disabling this quirk: 
1. A change in our fork of zephyr: https://github.com/nrfconnect/sdk-zephyr/pull/409/commits/a88b6cb7ffe1dbc22592c90d74cf39bc728e0673
2. Adding a new set of configuration files in this repo: https://github.com/nrfconnect/sdk-nrf/commit/ad481d571953a28dc4a9dc0e6931c115368c52d6

This quirk is only needed for the zephyr controller. This controller
does not follow the spec recommendation of initiating a DLE procedure
after connection establishment.

By changing the default value of this quirk, the throughput sample
will perform better on nrf53, as there is no longer a second DLE
procedure after connection establishment.

In a split build, there is no way the host can know if the controller
has this quirk or not. Our best assumption is therefore that the spec
recommended behavior is followed.

Therefore applications built for nrf53 with the zephyr LL will have
a lower maximum throughput.

See also:
zephyrproject-rtos/zephyr#26277
zephyrproject-rtos/zephyr#28239

ref: NCSDK-7247