### PR TITLE
Bluetooth: Mesh: Sensor type IDs doc cleaning up

### DIFF
--- a/include/bluetooth/mesh/sensor_types.rst
+++ b/include/bluetooth/mesh/sensor_types.rst
@@ -15,7 +15,7 @@ Note that if the Sensor Client is enabled, :option:`CONFIG_BT_MESH_SENSOR_ALL_TY
 
 Sensor types can be forced into the build by the :c:macro:`BT_MESH_SENSOR_TYPE_FORCE` macro.
 
-Sensor types may only be declared in the ``bt_mesh_sensor_types`` static linker section, and any additional, proprietary sensor types should be added to sensor_types.c, following the existing pattern.
+Sensor types may only be declared in the ``bt_mesh_sensor_types`` static linker section.
 
 .. doxygengroup:: bt_mesh_sensor_types
    :project: nrf


### PR DESCRIPTION
Bluetooth Mesh Sensors page has noted that it is not possible to add
sensors with Device Proprietary ID apart from the Bluetooth Mesh Device
Properties Specification. However, Sensor types documentation has
recommendations on how to add a proprietary ID. Documentation
contradicts itself.

Signed-off-by: Khromykh, Aleksandr <Aleksandr.Khromykh@nordicsemi.no>