### PR TITLE
actions: labeler: Add a no-changelog rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -179,3 +179,6 @@
   - "modules/nrfxlib/nrf_802154/**/*"
   - "modules/mcuboot/**/*"
   - "samples/matter/**/*"
+
+"no-changelog":
+  - "!doc/nrf/releases/release-notes-latest.rst"


### PR DESCRIPTION
Whenever a Pull Request is posted, we need to check if the changes it
contains warrant an addition to the changelog.
In order to better make sure that this rule is abided by, label the PR
by default with the no-changelog label. If the PR is updated with a
change to the changelog, the label will be automatically removed by the
action. If the user determines that no changes to the changelog are
required, they can remove the label themselves, creating a record of
this action.

Pull Requests witht he "no-changelog" label present should not be merged.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>