### PR TITLE
west.yml: pull in mdb runner fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: e28e9a75ab51f1b13a72296d59ef541ef63d0a11
+      revision: 3c41201293627ba3208e40de06ab117355fabe57
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a fix for a broken third party import in an unrelated zephyr
runner. See sdk-zephyr https://github.com/nrfconnect/sdk-zephyr/pull/410 for details.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>