### PR TITLE
Bluetooth: Mesh: Add page with reserved ids

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -317,6 +317,8 @@
 
 .. _`TLS`: https://www.ietf.org/rfc/rfc5246.txt
 
+.. _`Bluetooth SIG Company Identifiers`: https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+
 .. _`RFC 5639 - ECC Brainpool Standard Curves and Curve Generation`: https://tools.ietf.org/html/rfc5639
 .. _`RFC 5869 - HMAC-based Extract-and-Expand Key Derivation Function (HKDF)`: https://tools.ietf.org/html/rfc5869
 .. _`RFC 7027 - ECC Brainpool Curves for TLS`: https://tools.ietf.org/html/rfc7027

--- a/doc/nrf/ug_bt_mesh.rst
+++ b/doc/nrf/ug_bt_mesh.rst
@@ -18,3 +18,4 @@ The Bluetooth Mesh samples use the `nRF Mesh mobile app`_ to perform provisionin
    ug_bt_mesh_concepts.rst
    ug_bt_mesh_architecture.rst
    ug_bt_mesh_configuring.rst
+   ug_bt_mesh_reserved_ids.rst

--- a/doc/nrf/ug_bt_mesh_reserved_ids.rst
+++ b/doc/nrf/ug_bt_mesh_reserved_ids.rst
@@ -1,0 +1,75 @@
+.. _bt_mesh_ug_reserved_ids:
+
+Reserved vendor model IDs and opcodes
+#####################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This page contains information about vendor model IDs and opcodes allocated by Nordic Semiconductor.
+
+As the Bluetooth SIG member, Nordic Semiconductor has been assigned the Company ID *0x0059*.
+You can find this information on the `Bluetooth SIG Company Identifiers`_ page.
+
+Reserved vendor model IDs
+*************************
+
+The table below lists all vendor-assigned model identifiers allocated by Nordic Semiconductor:
+
+   +---------------------+-----------------+
+   | Model name          | Vendor Model ID |
+   +=====================+=================+
+   | Simple OnOff Server | 0x0000          |
+   +---------------------+-----------------+
+   | Simple OnOff Client | 0x0001          |
+   +---------------------+-----------------+
+   | Rssi Server         | 0x0005          |
+   +---------------------+-----------------+
+   | Rssi Client         | 0x0006          |
+   +---------------------+-----------------+
+   | Rssi Util           | 0x0007          |
+   +---------------------+-----------------+
+   | Thingy52 Server     | 0x0008          |
+   +---------------------+-----------------+
+   | Thingy52 Client     | 0x0009          |
+   +---------------------+-----------------+
+   | Chat Client         | 0x000A          |
+   +---------------------+-----------------+
+
+Reserved opcodes
+****************
+
+The table below lists the manufactor-specific opcodes allocated by Nordic Semiconductor:
+
+   +-----------------------------------+--------+
+   | Message name                      | Opcode |
+   +===================================+========+
+   | Simple OnOff Set                  | 0x01   |
+   +-----------------------------------+--------+
+   | Simple OnOff Get                  | 0x02   |
+   +-----------------------------------+--------+
+   | Simple OnOff Set Unreliable       | 0x03   |
+   +-----------------------------------+--------+
+   | Simple OnOff Status               | 0x04   |
+   +-----------------------------------+--------+
+   | Rssi Ack                          | 0x05   |
+   +-----------------------------------+--------+
+   | Rssi Send Data                    | 0x06   |
+   +-----------------------------------+--------+
+   | Rssi Util Request Database Beacon | 0x07   |
+   +-----------------------------------+--------+
+   | Rssi Util Send Database Beacon    | 0x08   |
+   +-----------------------------------+--------+
+   | Thingy52 RGB Set                  | 0x09   |
+   +-----------------------------------+--------+
+   | Chat Message                      | 0x0A   |
+   +-----------------------------------+--------+
+   | Chat Private Message              | 0x0B   |
+   +-----------------------------------+--------+
+   | Chat Message Reply                | 0x0C   |
+   +-----------------------------------+--------+
+   | Chat Presence                     | 0x0D   |
+   +-----------------------------------+--------+
+   | Chat Presence Get                 | 0x0E   |
+   +-----------------------------------+--------+


### PR DESCRIPTION
This page adds list of vendor model IDs and opcodes allocated by Nordic
Semiconductor.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>