### PR TITLE
manifest: Update tags for 1.4.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.0-ncs2-rc1
+      revision: v2.4.0-ncs2
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 65562a97094f74d578d1c76744b92571e7938d53
+      revision: v1.4.1
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Point to the corresponding 1.4.1 release tags.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>