### PR TITLE
ci: update sh to 1.14.1 and arrow 0.17.0 in requirements-ci.txt

### DIFF
--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -22,7 +22,7 @@ docutils==0.16
 ecdsa==0.15
 future==0.18.2
 gcovr==4.2
-gitlint==0.13.1
+gitlint==0.15.0
 idna==2.9
 imagesize==1.2.0
 importlib-metadata==1.6.0

--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 anytree==2.8.0
 appdirs==1.4.3
-arrow==0.15.6
+arrow==0.17.0
 astroid==2.4.1
 attrs==19.3.0
 Babel==2.8.0
@@ -64,7 +64,7 @@ pyusb==1.0.2
 PyYAML==5.3.1
 recommonmark==0.4.0
 requests==2.23.0
-sh==1.12.14
+sh==1.14.1
 six==1.14.0
 snowballstemmer==2.0.0
 sortedcontainers==2.1.0


### PR DESCRIPTION
Updating sh==1.14.1 and arrow==0.17.0 as gitlint 0.15.0 are having those
versions as dependencies.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>