### PR TITLE
samples: Bluetooth: Add minimal configuration as a compile test

### DIFF
--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -8,3 +8,9 @@ tests:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340pdk_nrf5340_cpuapp nrf5340pdk_nrf5340_cpuappns
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build
+tests:
+  samples.bluetooth.peripheral_lbs_minimal:
+    extra_args: OVERLAY_CONFIG=minimal.conf
+    build_only: true
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52810
+    tags: bluetooth ci_build


### PR DESCRIPTION
Add minimal configuration of peripheral_lbs sample as a compile
target to CI.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>