### PR TITLE
west.yml: Update nrfxlib revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 24a347218dbd2dbc626f1ce85de9565137ad02cf
+      revision: 8243ed209863ee1a3bf2a5d2735a939e8f890f4f
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
FEM implementation has been moved to MPSL. 
Remove obsolete FEM implementation and API from nRF 802.15.4 SL.
Signed-off-by: Jakub Pegza <Jakub.Pegza@nordicsemi.no>