### PR TITLE
mpsl: clock: Expose and use calibration configurations

### DIFF
--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -159,9 +159,13 @@ static int mpsl_lib_init(const struct device *dev)
 	clock_cfg.skip_wait_lfclk_started =
 		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT);
 
-#ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
-	clock_cfg.rc_ctiv = MPSL_RECOMMENDED_RC_CTIV;
-	clock_cfg.rc_temp_ctiv = MPSL_RECOMMENDED_RC_TEMP_CTIV;
+#ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
+	/* clock_cfg.rc_ctiv is given in 1/4 seconds units.
+	 * CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD is given in ms. */
+	clock_cfg.rc_ctiv = (CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD * 4 / 1000);
+	clock_cfg.rc_temp_ctiv = CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP + 1;
+	BUILD_ASSERT(CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_TEMP_DIFF == 2,
+		     "MPSL always uses a temperature diff threshold of 0.5 degrees");
 #else
 	clock_cfg.rc_ctiv = 0;
 	clock_cfg.rc_temp_ctiv = 0;

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f2a69816da9ad047c40c0d2eb364e00755ec33e6
+      revision: 3420cde0e37be536cda67f293784dcc1c6a92001
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1b2e29f0c4b5a1276d6dacf754c4fdb6e6245953
+      revision: 27ce80161f50254dc07caeb1118a7cbe6b121ce8
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Use the exposed clock calibration configurations when using MPSL.
These are made available https://github.com/nrfconnect/sdk-zephyr/pull/412

An alternative temperature driver will be made available in https://github.com/nrfconnect/sdk-nrf/pull/3022

Ref: NCSIDB-180