### PR TITLE
tests: lib: date_time: correct comments in build files

### DIFF
--- a/tests/lib/date_time/CMakeLists.txt
+++ b/tests/lib/date_time/CMakeLists.txt
@@ -1,8 +1,8 @@
-/*
- * Copyright (c) 2020 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
- */
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
 
 cmake_minimum_required(VERSION 3.13.1)
 

--- a/tests/lib/date_time/prj.conf
+++ b/tests/lib/date_time/prj.conf
@@ -1,8 +1,8 @@
-/*
- * Copyright (c) 2020 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
- */
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
 
 # ZTEST
 CONFIG_ZTEST=y


### PR DESCRIPTION
Comments in CMakeLists.txt and prj.conf were in C style.
This is breaking my CI build in #3394.

That license was added 2 months ago, how did it pass CI then and how did it only affect my CI build but not others?