### PR TITLE
partition_manager: Remove one_of from pm.yml.pcd configuration

### DIFF
--- a/subsys/partition_manager/pm.yml.pcd
+++ b/subsys/partition_manager/pm.yml.pcd
@@ -3,6 +3,6 @@
 # This block of RAM is used for communicating Network Core firmware update
 # metadata
 pcd_sram:
-  placement: {before: {one_of: [rpmsg_nrf53_sram, end]}}
+  placement: {before: [rpmsg_nrf53_sram, end]}
   size: CONFIG_NRF_SPU_RAM_REGION_SIZE
   region: sram_primary


### PR DESCRIPTION
This file was overlooked during PR #3420, breaking nRF5340 builds that
use bluetooth rpmsg and the PCD library.

This includes the SMP sample for DFU.

Ref: NCSDK-7465
Signed-off-by: Stephen Stauts <stephen.stauts@nordicsemi.no>

### Failing Samples

1. `zephyr/samples/hello_world`
2. `nrf/samples/bluetooth/peripheral_uart`
3. `zephyr/samples/subsys/mgmt/mcumgr/smp_svr`

### Local Testing

This fix allowed the failing samples to build successfully. Commands used:

1. `west build -b nrf5340dk_nrf5340_cpuappns zephyr/samples/hello_world – -DCONFIG_BOOTLOADER_MCUBOOT=y`
2.  `west build -b nrf5340dk_nrf5340_cpuappns nrf/samples/bluetooth/peripheral_uart – -DCONFIG_BOOTLOADER_MCUBOOT=y`
3. `west build -b nrf5340dk_nrf5340_cpuappns zephyr/samples/subsys/mgmt/mcumgr/smp_svr – -DOVERLAY_CONFIG=overlay-bt-tiny.conf`