### PR TITLE
samples: Removed setting ICACHE in DTM and Radio Test.

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/dtm.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm.c
@@ -687,11 +687,6 @@ int dtm_init(void)
 	dtm_inst.new_event = false;
 	dtm_inst.packet_len = 0;
 
-	if (IS_ENABLED(NVMC_FEATURE_CACHE_PRESENT)) {
-		/* Enable cache. */
-		nrf_nvmc_icache_config_set(NRF_NVMC, NRF_NVMC_ICACHE_ENABLE);
-	}
-
 	return 0;
 }
 

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -569,10 +569,6 @@ void radio_test_init(struct radio_test_config *config)
 {
 	nrf_rng_task_trigger(NRF_RNG, NRF_RNG_TASK_START);
 
-#if defined(NVMC_FEATURE_CACHE_PRESENT)
-	nrf_nvmc_icache_config_set(NRF_NVMC, NRF_NVMC_ICACHE_ENABLE);
-#endif /* NVMC_FEATURE_CACHE_PRESENT */
-
 	timer_init(config);
 	IRQ_CONNECT(TIMER0_IRQn, NRFX_TIMER_DEFAULT_CONFIG_IRQ_PRIORITY,
 		nrfx_timer_0_irq_handler, NULL, 0);


### PR DESCRIPTION
This is a small cleanup in the 2 samples: there is no need to explicitly enable the ICACHE in NVMC, as it is done in startup for the devices which support it.