### PR TITLE
samples: throughput stable transfer speed

### DIFF
--- a/samples/bluetooth/throughput/CMakeLists.txt
+++ b/samples/bluetooth/throughput/CMakeLists.txt
@@ -6,6 +6,8 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
+set(DTC_OVERLAY_FILE "dts.overlay")
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 

--- a/samples/bluetooth/throughput/dts.overlay
+++ b/samples/bluetooth/throughput/dts.overlay
@@ -1,0 +1,4 @@
+&uart0 {
+     /delete-property/ rts-pin;
+     /delete-property/ cts-pin;
+};


### PR DESCRIPTION
This PR provides a following changes:
- disables a hardware flow control to make sample independent of a PC terminal speed(PC CPU load)