### PR TITLE
net: lib: fota_download: Set a buffer for MCUboot DFU targets

### DIFF
--- a/subsys/net/lib/fota_download/Kconfig
+++ b/subsys/net/lib/fota_download/Kconfig
@@ -18,6 +18,13 @@ config FOTA_SOCKET_RETRIES
 config FOTA_DOWNLOAD_PROGRESS_EVT
 	bool "Emit progress event upon receiving a download fragment"
 
+config FOTA_DOWNLOAD_MCUBOOT_FLASH_BUF_SZ
+	int "Size of buffer used for flash write operations during MCUboot updates"
+	depends on DFU_TARGET_MCUBOOT
+	default 512
+	help
+	  Buffer size must be aligned to the minimal flash write block size
+
 module=FOTA_DOWNLOAD
 module-dep=LOG
 module-str=Firmware Over the Air Download


### PR DESCRIPTION
MCUboot DFU targets now require a buffer to be set before they
are initialized.

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>