### PR TITLE
dts: bindings: Preserve newlines in descriptions

### DIFF
--- a/dts/bindings/radio_fem/generic-fem-two-ctrl-pins.yaml
+++ b/dts/bindings/radio_fem/generic-fem-two-ctrl-pins.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 
-description: >
+description: |
     This is a representation of generic Radio Front-End module
     that has a two-pin control interface (CTX, CRX).
 
@@ -13,31 +13,31 @@ properties:
     ctx-gpios:
         type: phandle-array
         required: false
-        description: >
+        description: |
             Gpio of the SOC controlling CTX pin of the FEM device.
 
     crx-gpios:
         type: phandle-array
         required: false
-        description: >
+        description: |
             Gpio of the SOC controlling CRX pin of the FEM device.
 
     ctx-settle-time-us:
         type: int
-        description: >
+        description: |
             Settling time in microseconds from activation of CTX to transmit.
 
     crx-settle-time-us:
         type: int
-        description: >
+        description: |
             Settling time in microseconds from activation of CRX to receive.
 
     tx-gain-db:
         type: int
-        description: >
+        description: |
             TX gain of the PA amplifier of the FEM device in dB.
 
     rx-gain-db:
         type: int
-        description: >
+        description: |
             RX gain of the LNA amplifier of the FEM device in dB.

--- a/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
+++ b/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 
-description: >
+description: |
     This is a representation of the Skyworks SKY66112-11 Radio Front-End module.
     It is supplementing the generic representation of FEM with settling time and
     gain values appropriate for SKY66112-11 device.
@@ -14,7 +14,7 @@ properties:
     ctx-settle-time-us:
         type: int
         default: 23
-        description: >
+        description: |
             Settling time in microseconds from activation of CTX to transmit.
 
             The default value has been determined experimentally: it is the
@@ -27,7 +27,7 @@ properties:
     crx-settle-time-us:
         type: int
         default: 5
-        description: >
+        description: |
             Settling time in microseconds from activation of CRX to receive.
 
             The default value has been determined experimentally: it is the
@@ -41,7 +41,7 @@ properties:
     tx-gain-db:
         type: int
         default: 22
-        description: >
+        description: |
             TX gain of the PA amplifier of SKY66112-11 in dB.
 
             Default value is based on Table 5 of the SKY66112-11 data sheet
@@ -53,7 +53,7 @@ properties:
     rx-gain-db:
         type: int
         default: 11
-        description: >
+        description: |
             RX gain of the LNA amplifier of SKY66112-11 in dB.
 
             Default value is based on Table 5 of the SKY66112-11 data sheet

--- a/dts/bindings/sensor/pixart,paw3212.yaml
+++ b/dts/bindings/sensor/pixart,paw3212.yaml
@@ -5,7 +5,7 @@
 #
 
 
-description: >
+description: |
     This is a representation of the PAW3212 optical motion sensor
 
 compatible: "pixart,paw3212"

--- a/dts/bindings/sensor/pixart,pmw3360.yaml
+++ b/dts/bindings/sensor/pixart,pmw3360.yaml
@@ -5,7 +5,7 @@
 #
 
 
-description: >
+description: |
     This is a representation of the PMW3360 optical motion sensor
 
 compatible: "pixart,pmw3360"

--- a/dts/bindings/sensor/rohm,bh1749.yaml
+++ b/dts/bindings/sensor/rohm,bh1749.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: >
+description: |
     This is a representation of the BH1749 sensor
 
 compatible: "rohm,bh1749"

--- a/dts/bindings/serial/nordic,nrf-sw-lpuart.yaml
+++ b/dts/bindings/serial/nordic,nrf-sw-lpuart.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 
-description: >
+description: |
     Low power UART
 
 compatible: "nordic,nrf-sw-lpuart"


### PR DESCRIPTION
This matches changes done in Zephyr commit b9240a3cbc ("dts: bindings:
Preserve newlines in descriptions"). The ">" style removes newlines,
which messes up the output in places like the bindings index.

The replacement was done with

    $ git ls-files 'dts/bindings/*.yaml' | \
          xargs sed -i 's/description:\s*>/description: |/'

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>