### PR TITLE
doc: sample_board_rows.txt fixing nrf9160dk_nrf52840 entry

### DIFF
--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -28,7 +28,7 @@
 
 .. nrf9160dk_nrf52840
 
-| :ref:`nRF9160 DK <ug_nrf9160>` | PCA10090 | :ref:`nrf9160dk_nrf9160 <nrf9160dk_nrf9160>` | ``nrf9160dk_nrf52840`` |
+| :ref:`nRF9160 DK <ug_nrf9160>` | PCA10090 | :ref:`nrf9160dk_nrf52840 <nrf9160dk_nrf52840>` | ``nrf9160dk_nrf52840`` |
 
 .. nrf5340dk_nrf5340_cpuapp
 


### PR DESCRIPTION
Entry for nrf9160dk_nrf52840 was referencing wrong IC on board

Signed-off-by: Akash Patel <akash.patel@nordicsemi.no>