### PR TITLE
cmake: correct signature key file handling for multi image builds

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -23,6 +23,7 @@ config PRIVILEGED_STACK_SIZE
 
 rsource "samples/Kconfig"
 rsource "subsys/Kconfig"
+rsource "modules/Kconfig.mcuboot"
 rsource "lib/Kconfig"
 rsource "drivers/Kconfig"
 rsource "ext/Kconfig"

--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -1,0 +1,6 @@
+config SIGN_IMAGES
+	bool "Sign images for MCUBoot"
+	default y
+	help
+	  Sign images for MCUBoot as integrated part of the build stages using
+	  the private key.


### PR DESCRIPTION
Fixes: NCSDK-7277

This commit ensure that the path to signature key files is properly
handled when an absolute path is provided.

It aligns handling of relative path to MCUBoot upstream when multiple
mcuboot_CONF_FILE are provided as list.

The PEM may contain just a public key to be embedded into mcuboot,
therefore a KConfig option to disable signing has been introduced.
Also it is checked that the key file contains a private key, and if not
then a warning is printed to the user, and no signing will be performed.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>