### PR TITLE
doc: fix requirements section

### DIFF
--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -16,7 +16,7 @@ The application supports the following development kit:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf9160dk_nrf9160
+   :rows: nrf9160dk_nrf9160ns
 
 .. include:: /includes/spm.txt
 


### PR DESCRIPTION
Fix the requirements of the Serial LTE modem application
to support the nrf9160dk_nrf9160**ns** target.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>