### PR TITLE
applications: serial_lte_modem Unsolicited result code (URC) format

### DIFF
--- a/applications/serial_lte_modem/doc/GPS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GPS_AT_commands.rst
@@ -94,24 +94,24 @@ Example
 
    #XGPS: 1,3
    OK
-   GPS suspended
-   SUPL injection done
-   GPS resumed
-   #XGPSS: track 3 use 3 unhealthy 0
-   #XGPSS: track 4 use 4 unhealthy 0
-   #XGPSS: track 5 use 5 unhealthy 0
-   #XGPSS: track 4 use 4 unhealthy 0
-   #XGPSS: track 5 use 5 unhealthy 0
-   #XGPSS: track 6 use 6 unhealthy 0
-   #XGPSS: track 7 use 7 unhealthy 0
-   #XGPSS: track 6 use 6 unhealthy 0
-   #XGPSP: long 139.721966 lat 35.534159
-   #XGPSP: 2020-04-30 00:11:55
-   #XGPSP: TTFF 57s
+   #XGPSS: "GPS suspended"
+   #XGPSS: "SUPL injection done"
+   #XGPSS: "GPS resumed"
+   #XGPSS: "track 3 use 3 unhealthy 0"
+   #XGPSS: "track 4 use 4 unhealthy 0"
+   #XGPSS: "track 5 use 5 unhealthy 0"
+   #XGPSS: "track 4 use 4 unhealthy 0"
+   #XGPSS: "track 5 use 5 unhealthy 0"
+   #XGPSS: "track 6 use 6 unhealthy 0"
+   #XGPSS: "track 7 use 7 unhealthy 0"
+   #XGPSS: "track 6 use 6 unhealthy 0"
+   #XGPSP: "long 139.721966 lat 35.534159"
+   #XGPSP: "2020-04-30 00:11:55"
+   #XGPSP: "TTFF 57s"
    $GPGGA,001155.87,3532.04954,N,13943.31794,E,1,06,17.40,109.53,M,0,,*19
    $GPGLL,3532.04954,N,13943.31794,E,001155.87,A,A*69
-   #XGPSP: long 139.721969 lat 35.534148
-   #XGPSP: 2020-04-30 00:11:56
+   #XGPSP: "long 139.721969 lat 35.534148"
+   #XGPSP: "2020-04-30 00:11:56"
 
 Read command
 ------------

--- a/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
@@ -85,7 +85,7 @@ Example
 ::
 
    AT#XHTTPCCON?
-   #XHTTPCCON: 1,"postman-echo.com",80
+   #XHTTPCCON: 1, "postman-echo.com", 80
    OK
 
 Test command
@@ -154,8 +154,8 @@ The following example sends a GET request to retrieve data from the server witho
 
    AT#XHTTPCREQ="GET","/get?foo1=bar1&foo2=bar2",""
    OK
-   #XHTTPCREQ:0
-   #XHTTPCRSP:576,0
+   #XHTTPCREQ: 0
+   #XHTTPCRSP: 576, 0
    HTTP/1.1 200 OK
    Date: Wed, 09 Sep 2020 08:08:45 GMT
    Content-Type: application/json; charset=utf-8
@@ -214,11 +214,11 @@ The following example sends a POST request to send data to the server with an op
    Content-Length: 20
    ",20
    OK
-   #XHTTPCREQ:1
+   #XHTTPCREQ: 1
    12345678901234567890
    OK
-   #XHTTPCREQ:0
-   #XHTTPCRSP:576,1
+   #XHTTPCREQ: 0
+   #XHTTPCRSP: 576, 1
    HTTP/1.1 200 OK
    Date: Wed, 09 Sep 2020 08:21:03 GMT
    Content-Type: application/json; charset=utf-8

--- a/applications/serial_lte_modem/doc/ICMP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/ICMP_AT_commands.rst
@@ -56,7 +56,7 @@ This is the response syntax when an echo reply is not received:
 
 ::
 
-   #XPING: timeout
+   #XPING: "timeout"
 
 Example
 ~~~~~~~
@@ -69,7 +69,7 @@ Example
    #XPING: 0.353
    #XPING: 0.313
    #XPING: 0.313
-   #XPING: average 0.341
+   #XPING: "average 0.341"
    OK
 
 Read command

--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -68,13 +68,13 @@ Examples
 
    AT#XMQTTCON=1,"MyMQTT-Client-ID","","","mqtt.server.com",1883
    OK
-   #XMQTTEVT: 0,0
+   #XMQTTEVT: 0, 0
 
 ::
 
    AT#XMQTTCON=0
    OK
-   #XMQTTEVT: 1,0
+   #XMQTTEVT: 1, 0
 
 Read command
 ------------
@@ -204,19 +204,19 @@ Examples
 
    AT#XMQTTSUB="nrf91/slm/mqtt/topic0",0
    OK
-   #XMQTTEVT: 7,0
+   #XMQTTEVT: 7, 0
 
 ::
 
    AT#XMQTTSUB="nrf91/slm/mqtt/topic1",1
    OK
-   #XMQTTEVT: 7,0
+   #XMQTTEVT: 7, 0
 
 ::
 
    AT#XMQTTSUB="nrf91/slm/mqtt/topic2",2
    OK
-   #XMQTTEVT: 7,0
+   #XMQTTEVT: 7, 0
 
 Read command
 ------------
@@ -272,7 +272,7 @@ Examples
 
    AT#XMQTTUNSUB="nrf91/slm/mqtt/topic0"
    OK
-   #XMQTTEVT: 8,0
+   #XMQTTEVT: 8, 0
 
 Read command
 ------------
@@ -356,30 +356,30 @@ Examples
 
    AT#XMQTTPUB="nrf91/slm/mqtt/topic0",1,"Test message with QoS 0",0,0
    OK
-   #XMQTTMSG: 1,21,23
+   #XMQTTMSG: 1, 21, 23
    nrf91/slm/mqtt/topic0
    Test message with QoS 0
-   #XMQTTEVT: 2,0
+   #XMQTTEVT: 2, 0
 
 ::
 
    AT#XMQTTPUB="nrf91/slm/mqtt/topic1",1,"Test message with QoS 1",1,0
    OK
-   #XMQTTEVT: 3,0
-   #XMQTTMSG: 1,21,23
+   #XMQTTEVT: 3, 0
+   #XMQTTMSG: 1, 21, 23
    nrf91/slm/mqtt/topic1
    Test message with QoS 1
-   #XMQTTEVT: 2,0
+   #XMQTTEVT: 2, 0
 
 ::
 
    AT#XMQTTPUB="nrf91/slm/mqtt/topic2",1,"Test message with QoS 2",2,0
    OK
-   #XMQTTEVT: 4,0
-   #XMQTTEVT: 6,0
-   #XMQTTMSG: 1,21,23
+   #XMQTTEVT: 4, 0
+   #XMQTTEVT: 6, 0
+   #XMQTTMSG: 1, 21, 23
    nrf91/slm/mqtt/topic2Test message with QoS 2
-   #XMQTTEVT: 2,0
+   #XMQTTEVT: 2, 0
 
 Read command
 ------------

--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -95,7 +95,7 @@ Unsolicited notification
 
 ::
 
-   #XSOCKET: <error> closed
+   #XSOCKET: <error>, "closed"
 
 The ``<error>`` value is a negative integer.
 It represents the error value according to the standard POSIX *errorno*.
@@ -112,7 +112,7 @@ Examples
    #XSOCKET: 3, 17, 0
    OK
    AT#XSOCKET=0
-   #XSOCKET: 0, closed
+   #XSOCKET: 0, "closed"
    OK
    at#xsocket=1,1,0,16842753
    #XSOCKET: 2, 1, 0, 258
@@ -279,7 +279,7 @@ Unsolicited Notification
 
 ::
 
-   #XSOCKET: <error> closed
+   #XSOCKET: <error>, "closed"
 
 ``SO_ERROR(4)``, the ``<error>`` response is the *Error Status*.
 
@@ -849,7 +849,7 @@ Response syntax
 
 ::
 
-   #XGETADDRINFO=<ip_addr>
+   #XGETADDRINFO: "<ip_addr>"
 
 * The ``<ip_addr>`` value is a string.
   It indicates the IPv4 address of the resolved hostname.
@@ -860,7 +860,7 @@ Examples
 ::
 
    at#xgetaddrinfo="www.google.com"
-   #XGETADDRINFO: 172.217.174.100
+   #XGETADDRINFO: "172.217.174.100"
    OK
 
 Read command
@@ -1037,7 +1037,7 @@ Response syntax
 
 ::
 
-   #XTCPSVR: <handle> started
+   #XTCPSVR: <handle>, "started"
 
 The ``<handle>`` value is an integer.
 When positive, it indicates that it opened successfully.
@@ -1048,7 +1048,7 @@ Unsolicited notification
 
 ::
 
-   #XTCPSVR: <error> stopped
+   #XTCPSVR: <error>, "stopped"
 
 The ``<error>`` value is a negative integer.
 It represents the error value according to the standard POSIX *errorno*.
@@ -1073,9 +1073,9 @@ Examples
 ::
 
    at#xtcpsvr=1,3442,600
-   #XTCPSVR: 2 started
+   #XTCPSVR: 2, "started"
    OK
-   #XTCPSVR: 5.123.123.99 connected
+   #XTCPSVR: "5.123.123.99", "connected"
    #XTCPRECV: 1, 13
    Hello, TCP#1!
    #XTCPRECV: 1, 13
@@ -1117,7 +1117,7 @@ Examples
    at#xtcpsvr?
    #XTCPSVR: 1, 2, 0
    OK
-   #XTCPSVR: timeout
+   #XTCPSVR: "timeout"
    at#xtcpsvr?
    #XTCPSVR: 1, -1
    OK
@@ -1188,14 +1188,14 @@ Response syntax
 
 ::
 
-   #XTCPCLI: <handle> connected
+   #XTCPCLI: <handle>, "connected"
 
 Unsolicited notification
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-   #XTCPCLI: <error> disconnected
+   #XTCPCLI: <error>, "disconnected"
 
 The ``<error>`` value is a negative integer.
 It represents the error value according to the standard POSIX *errorno*.
@@ -1223,7 +1223,7 @@ Examples
 ::
 
    at#xtcpcli=1,"remote.ip",1234
-   #XTCPCLI: 2 connected
+   #XTCPCLI: 2, "connected"
    OK
    #XTCPRECV: 1, 31
    PONG: b'Test TCP by IP address'
@@ -1416,7 +1416,7 @@ Response syntax
 
 ::
 
-   #XUDPSVR: <handle> started
+   #XUDPSVR: <handle>, "started"
 
 The ``<handle>`` value is an integer.
 When positive, it indicates that it opened successfully.
@@ -1427,7 +1427,7 @@ Unsolicited notification
 
 ::
 
-   #XUDPSVR: <error> stopped
+   #XUDPSVR: <error>, "stopped"
 
 The ``<error>`` value is a negative integer.
 It represents the error value according to the standard POSIX *errorno*.
@@ -1455,7 +1455,7 @@ Examples
 ::
 
    at#xudpsvr=1,3442
-   #XUDPSVR: 2 started
+   #XUDPSVR: 2, "started"
    OK
    #XUDPRECV: 1, 13
    Hello, UDP#1!
@@ -1555,14 +1555,14 @@ Response syntax
 
 ::
 
-   #XUDPCLI: <handle> connected
+   #XUDPCLI: <handle>, "connected"
 
 Unsolicited notification
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-   #XUDPCLI: <error> disconnected
+   #XUDPCLI: <error>, "disconnected"
 
 The ``<error>`` value is a negative integer.
 It represents the error value according to the standard POSIX *errorno*.
@@ -1589,7 +1589,7 @@ Examples
 ::
 
    at#xudpcli=1,"remote.host",2442
-   #XUDPCLI: 2 connected
+   #XUDPCLI: 2, "connected"
    OK
    at#xudpsend=1,"Test UDP by hostname"
    #XUDPSEND: 20

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -437,7 +437,7 @@ TCP client
          :class: highlight
 
          **AT#XSOCKET=0**
-         #XSOCKET: 0, closed
+         #XSOCKET: 0, "closed"
          OK
 
          **AT#XSOCKET?**
@@ -512,7 +512,7 @@ TCP client
          :class: highlight
 
          **AT#XSOCKET=0**
-         #XSOCKET: 0, closed
+         #XSOCKET: 0, "closed"
          OK
 
 #. Test a TCP client with TCP proxy service:
@@ -534,7 +534,7 @@ TCP client
          :class: highlight
 
          **AT#XTCPCLI=1,"**\ *example.com*\ **",**\ *1234*
-         #XTCPCLI: 2 connected
+         #XTCPCLI: 2, "connected"
          OK
 
          **AT#XTCPCLI?**
@@ -593,7 +593,7 @@ TCP client
          :class: highlight
 
          **AT#XTCPCLI=2,"**\ *example.com*\ **",**\ *1234*
-         #XTCPCLI: 1 connected
+         #XTCPCLI: 1, "connected"
          OK
 
          **AT#XTCPCLI?**
@@ -614,7 +614,7 @@ TCP client
          :class: highlight
 
          **AT#XTCPCLI=0**
-         #XTCPCLI: disconnected
+         #XTCPCLI: "disconnected"
          OK
 
 UDP client
@@ -670,7 +670,7 @@ UDP client
          :class: highlight
 
          **AT#XSOCKET=0**
-         #XSOCKET: 0, closed
+         #XSOCKET: 0, "closed"
          OK
 
 #. Test a UDP client with connection-based UDP:
@@ -709,7 +709,7 @@ UDP client
          :class: highlight
 
          **AT#XSOCKET=0**
-         #XSOCKET: 0, closed
+         #XSOCKET: 0, "closed"
          OK
 
 #. Test a connection-based UDP client with UDP proxy service:
@@ -730,7 +730,7 @@ UDP client
          :class: highlight
 
          **AT#XUDPCLI=1,"**\ *example.com*\ **",**\ *1234*
-         #XUDPCLI: 2 connected
+         #XUDPCLI: 2, "connected"
          OK
 
    #. Send plain text data to the UDP server and check the returned data.
@@ -773,7 +773,7 @@ UDP client
          :class: highlight
 
          **AT#XUDPCLI=2,"**\ *example.com*\ **",**\ *1234*
-         #XUDPCLI: 1 connected
+         #XUDPCLI: 1, "connected"
          OK
 
          **AT#XUDPCLI?**
@@ -794,7 +794,7 @@ UDP client
          :class: highlight
 
          **AT#XUDPCLI=0**
-         #XUDPCLI: disconnected
+         #XUDPCLI: "disconnected"
          OK
 
 
@@ -856,7 +856,7 @@ You must register the corresponding credentials on the server side.
          :class: highlight
 
          **AT#XSOCKET=0**
-         #XSOCKET: 0, closed
+         #XSOCKET: 0, "closed"
          OK
 
 #. Test a TLS client with TCP proxy service:
@@ -869,7 +869,7 @@ You must register the corresponding credentials on the server side.
          :class: highlight
 
          **AT#XTCPCLI=1,"**\ *example.com*\ **",**\ *1234*
-         #XTCPCLI: 2 connected
+         #XTCPCLI: 2, "connected"
          OK
 
          **AT#XTCPCLI?**
@@ -897,7 +897,7 @@ You must register the corresponding credentials on the server side.
          :class: highlight
 
          **AT#XTCPCLI=0**
-         #XTCPCLI: disconnected
+         #XTCPCLI: "disconnected"
          OK
 
 .. not tested
@@ -966,7 +966,7 @@ You must register the corresponding credentials on the server side.
 	     :class: highlight
 
 	     **AT#XSOCKET=0**
-	     #XSOCKET: 0, closed
+	     #XSOCKET: 0, "closed"
 	     OK
 
     #. Test a DTLS client with UDP proxy service:
@@ -979,7 +979,7 @@ You must register the corresponding credentials on the server side.
 	     :class: highlight
 
 	     **AT#XUDPCLI=1,"**\ *example.com*\ **",**\ *1234*\ **,16842756**
-	     #XUDPCLI: 2 connected
+	     #XUDPCLI: 2, "connected"
 	     OK
 
        #. Disconnect from the server.
@@ -1108,7 +1108,7 @@ To act as a TCP server, |global_private_address|
          :class: highlight
 
          **AT#XSOCKET=0**
-         #XSOCKET: closed
+         #XSOCKET: "closed"
          OK
 
 
@@ -1208,7 +1208,7 @@ To act as a TCP server, |global_private_address|
          **AT#XTCPSVR?**
          #XTCPSVR: 1, 2, 0
          OK
-         #XTCPSVR: timeout
+         #XTCPSVR: "timeout"
 
          **AT#XTCPSVR?**
          #XTCPSVR: 1, -1, 0
@@ -1220,7 +1220,7 @@ To act as a TCP server, |global_private_address|
          :class: highlight
 
          **AT#XTCPSVR=0**
-         #XTCPSVR: stopped
+         #XTCPSVR: "stopped"
          OK
 
          **AT#XTCPSVR?**
@@ -1236,7 +1236,7 @@ To act as a TCP server, |global_private_address|
          :class: highlight
 
          **AT#XTCPSVR=2,**\ *1234*
-         #XTCPSVR: 1 started
+         #XTCPSVR: 1, "started"
          OK
 
          **AT#XTCPSVR?**
@@ -1274,7 +1274,7 @@ To act as a TCP server, |global_private_address|
          :class: highlight
 
          **AT#XTCPSVR=0**
-         #XTCPSVR: stopped
+         #XTCPSVR: "stopped"
          OK
 
 UDP server
@@ -1411,7 +1411,7 @@ To act as a UDP server, |global_private_address|
          :class: highlight
 
          **AT#XSOCKET=0**
-         #XSOCKET: 0, closed
+         #XSOCKET: 0, "closed"
          OK
 
 #. Test the UDP server with UDP proxy service:
@@ -1427,7 +1427,7 @@ To act as a UDP server, |global_private_address|
          OK
 
          **AT#XUDPSVR=1,**\ *1234*
-         #XUDPSVR: 2 started
+         #XUDPSVR: 2, "started"
          OK
 
    #. Run the :file:`client_udp.py` script to start sending data to the server.
@@ -1478,7 +1478,7 @@ To act as a UDP server, |global_private_address|
          :class: highlight
 
          **AT#XUDPSVR=0**
-         #XUDPSVR: stopped
+         #XUDPSVR: "stopped"
          OK
 
 #. Test the UDP server with UDP proxy service in data mode:
@@ -1490,7 +1490,7 @@ To act as a UDP server, |global_private_address|
          :class: highlight
 
          **AT#XUDPSVR=2,**\ *1234*
-         #XUDPSVR: 1 started
+         #XUDPSVR: 1, "started"
          OK
 
          **AT#XUDPSVR?**
@@ -1529,7 +1529,7 @@ To act as a UDP server, |global_private_address|
          :class: highlight
 
          **AT#XUDPSVR=0**
-         #XUDPSVR: stopped
+         #XUDPSVR: "stopped"
          OK
 
 TLS server
@@ -1541,11 +1541,11 @@ The TLS server role is currently not supported.
    :class: highlight
 
    **AT#XSOCKET=1,1,1,16842753**
-   #XSOCKET: (D)TLS Server not supported
+   #XSOCKET: "(D)TLS Server not supported"
    ERROR
 
    **AT#XTCPSVR=1,3443,16842753**
-   #XTCPSVR: TLS Server not supported
+   #XTCPSVR: "TLS Server not supported"
    ERROR
 
 DTLS server
@@ -1557,7 +1557,7 @@ The DTLS server role is currently not supported (modem limitation).
    :class: highlight
 
    **AT#XSOCKET=1,2,1,16842755**
-   #XSOCKET: (D)TLS Server not supported
+   #XSOCKET: "(D)TLS Server not supported"
    ERROR
 
 DNS lookup
@@ -1616,19 +1616,19 @@ After opening a client-role socket, you can configure various options.
       ERROR  // to be investigated
 
       **AT#XSOCKETOPT=0,2**
-      #XSOCKETOPT: ignored
+      #XSOCKETOPT: "ignored"
       OK
 
       **AT#XSOCKETOPT=1,2,1**
-      #XSOCKETOPT: ignored
+      #XSOCKETOPT: "ignored"
       OK
 
       **AT#XSOCKETOPT=0,61**
-      #XSOCKETOPT: not supported
+      #XSOCKETOPT: "not supported"
       OK
 
       **AT#XSOCKETOPT=1,61,30**
-      #XSOCKETOPT: not supported
+      #XSOCKETOPT: "not supported"
       OK
 
 Testing ICMP AT commands

--- a/applications/serial_lte_modem/src/gps/slm_at_gps.c
+++ b/applications/serial_lte_modem/src/gps/slm_at_gps.c
@@ -178,7 +178,7 @@ void supl_handler(struct k_work *work)
 		return;
 	}
 	k_thread_suspend(gps_thread_id);
-	sprintf(rsp_buf, "GPS suspended\r\n");
+	sprintf(rsp_buf, "#XGPSS: \"GPS suspended\"\r\n");
 	rsp_send(rsp_buf, strlen(rsp_buf));
 
 	/* SUPL injection */
@@ -189,7 +189,7 @@ void supl_handler(struct k_work *work)
 		LOG_DBG("SUPL session done");
 		close(supl_fd);
 	}
-	sprintf(rsp_buf, "SUPL injection done\r\n");
+	sprintf(rsp_buf, "#XGPSS: \"SUPL injection done\"\r\n");
 	rsp_send(rsp_buf, strlen(rsp_buf));
 
 	/* Resume GPS */
@@ -200,7 +200,7 @@ void supl_handler(struct k_work *work)
 		LOG_ERR("Failed to resume GPS (err: %d)", -errno);
 	} else {
 		ttft_start = k_uptime_get();
-		sprintf(rsp_buf, "GPS resumed\r\n");
+		sprintf(rsp_buf, "#XGPSS: \"GPS resumed\"\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	}
 }
@@ -235,7 +235,8 @@ static void gps_satellite_stats(void)
 	}
 
 	if (last_tracked != tracked) {
-		sprintf(rsp_buf, "#XGPSS: track %d use %d unhealthy %d\r\n",
+		sprintf(rsp_buf,
+			"#XGPSS: \"track %d use %d unhealthy %d\"\r\n",
 			tracked, in_fix, unhealthy);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		last_tracked = tracked;
@@ -244,11 +245,11 @@ static void gps_satellite_stats(void)
 
 static void gps_pvt_notify(void)
 {
-	sprintf(rsp_buf, "#XGPSP: long %f lat %f\r\n",
+	sprintf(rsp_buf, "#XGPSP: \"long %f lat %f\"\r\n",
 		gps_data.pvt.longitude,
 		gps_data.pvt.latitude);
 	rsp_send(rsp_buf, strlen(rsp_buf));
-	sprintf(rsp_buf, "#XGPSP: %04u-%02u-%02u %02u:%02u:%02u\r\n",
+	sprintf(rsp_buf, "#XGPSP: \"%04u-%02u-%02u %02u:%02u:%02u\"\r\n",
 		gps_data.pvt.datetime.year,
 		gps_data.pvt.datetime.month,
 		gps_data.pvt.datetime.day,
@@ -282,7 +283,8 @@ static void gps_thread_fn(void *arg1, void *arg2, void *arg3)
 				if (!client.has_fix) {
 					uint64_t now = k_uptime_get();
 
-					sprintf(rsp_buf, "#XGPSP: TTFF %ds\r\n",
+					sprintf(rsp_buf,
+						"#XGPSP: \"TTFF %ds\"\r\n",
 						(int)(now - ttft_start)/1000);
 					rsp_send(rsp_buf, strlen(rsp_buf));
 					client.has_fix = true;
@@ -444,7 +446,7 @@ static int handle_at_gps(enum at_cmd_type cmd_type)
 
 	case AT_CMD_TYPE_READ_COMMAND:
 		if (client.running) {
-			sprintf(rsp_buf, "#XGPS: 1,%d\r\n", client.mask);
+			sprintf(rsp_buf, "#XGPS: 1, %d\r\n", client.mask);
 		} else {
 			sprintf(rsp_buf, "#XGPS: 0\r\n");
 		}

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -284,7 +284,7 @@ static void response_cb(struct http_response *rsp,
 	if (final_data == HTTP_DATA_MORE) {
 		LOG_DBG("Partial data received (%zd bytes)", rsp->data_len);
 		if (data_received == HTTPC_BUF_LEN) {
-			sprintf(rsp_buf, "#XHTTPCRSP:%d,1\r\n",
+			sprintf(rsp_buf, "#XHTTPCRSP: %d, 1\r\n",
 				HTTPC_BUF_LEN);
 			rsp_send(rsp_buf, strlen(rsp_buf));
 			rsp_send(data_buf, HTTPC_BUF_LEN);
@@ -292,7 +292,7 @@ static void response_cb(struct http_response *rsp,
 		}
 	} else if (final_data == HTTP_DATA_FINAL) {
 		LOG_DBG("All the data received (%zd bytes)", data_received);
-		sprintf(rsp_buf, "#XHTTPCRSP:%d,0\r\n", data_received);
+		sprintf(rsp_buf, "#XHTTPCRSP: %d, 0\r\n", data_received);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		rsp_send(data_buf, data_received);
 		httpc.rsp_completed = true;
@@ -324,7 +324,7 @@ static int payload_cb(int sock, struct http_request *req, void *user_data)
 	size_t total_sent = 0;
 
 	if (httpc.pl_len > 0) {
-		sprintf(rsp_buf, "#XHTTPCREQ:1\r\n");
+		sprintf(rsp_buf, "#XHTTPCREQ: 1\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		do {
 			/* Wait until payload is ready */
@@ -361,10 +361,10 @@ static int payload_cb(int sock, struct http_request *req, void *user_data)
 			}
 			k_sem_give(&http_data_sem);
 		} while (total_sent < httpc.pl_len);
-		sprintf(rsp_buf, "#XHTTPCREQ:0\r\n");
+		sprintf(rsp_buf, "#XHTTPCREQ: 0\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	} else {
-		sprintf(rsp_buf, "#XHTTPCREQ:0\r\n");
+		sprintf(rsp_buf, "#XHTTPCREQ: 0\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	}
 
@@ -379,10 +379,10 @@ static int do_http_connect(void)
 		if (httpc.fd < 0) {
 			LOG_ERR("server_connect fail.");
 			httpc.fd = INVALID_SOCKET;
-			sprintf(rsp_buf, "#XHTTPCCON:0\r\n");
+			sprintf(rsp_buf, "#XHTTPCCON: 0\r\n");
 			rsp_send(rsp_buf, strlen(rsp_buf));
 		} else {
-			sprintf(rsp_buf, "#XHTTPCCON:1\r\n");
+			sprintf(rsp_buf, "#XHTTPCCON: 1\r\n");
 			rsp_send(rsp_buf, strlen(rsp_buf));
 		}
 	} else {
@@ -410,7 +410,7 @@ static int do_http_disconnect(void)
 		httpc.pl_len = 0;
 		k_sem_give(&http_req_sem);
 	}
-	sprintf(rsp_buf, "#XHTTPCCON:0\r\n");
+	sprintf(rsp_buf, "#XHTTPCCON: 0\r\n");
 	rsp_send(rsp_buf, strlen(rsp_buf));
 
 	return err;
@@ -466,12 +466,12 @@ static int do_http_request(void)
 	err = http_client_req(httpc.fd, &req, timeout, "");
 	if (err < 0) {
 		/* Socket send/recv error */
-		sprintf(rsp_buf, "#XHTTPCREQ:%d\r\n", err);
+		sprintf(rsp_buf, "#XHTTPCREQ: %d\r\n", err);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	} else if (httpc.rsp_completed == false) {
 		/* Socket was closed by remote */
 		err = -ECONNRESET;
-		sprintf(rsp_buf, "#XHTTPCRSP:0,%d\r\n", err);
+		sprintf(rsp_buf, "#XHTTPCRSP: 0, %d\r\n", err);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	} else {
 		err = 0;
@@ -550,11 +550,11 @@ static int handle_AT_HTTPC_CONNECT(enum at_cmd_type cmd_type)
 
 	case AT_CMD_TYPE_READ_COMMAND:
 		if (httpc.sec_transport) {
-			sprintf(rsp_buf, "#XHTTPCCON: %d,\"%s\",%d,%d\r\n",
+			sprintf(rsp_buf, "#XHTTPCCON: %d, \"%s\", %d, %d\r\n",
 				(httpc.fd == INVALID_SOCKET)?0:1, httpc.host,
 				httpc.port, httpc.sec_tag);
 		} else {
-			sprintf(rsp_buf, "#XHTTPCCON: %d,\"%s\",%d\r\n",
+			sprintf(rsp_buf, "#XHTTPCCON: %d, \"%s\", %d\r\n",
 				(httpc.fd == INVALID_SOCKET)?0:1, httpc.host,
 				httpc.port);
 		}

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -141,7 +141,7 @@ static int handle_mqtt_publish_evt(struct mqtt_client *const c,
 		if (ret < 0) {
 			return ret;
 		}
-		sprintf(rsp_buf, "#XMQTTMSG: %d,%d,%d\r\n",
+		sprintf(rsp_buf, "#XMQTTMSG: %d, %d, %d\r\n",
 			DATATYPE_HEXADECIMAL,
 			evt->param.publish.message.topic.topic.size,
 			ret);
@@ -152,7 +152,7 @@ static int handle_mqtt_publish_evt(struct mqtt_client *const c,
 		rsp_send(data_hex, ret);
 		rsp_send("\r\n", 2);
 	} else {
-		sprintf(rsp_buf, "#XMQTTMSG: %d,%d,%d\r\n",
+		sprintf(rsp_buf, "#XMQTTMSG: %d, %d, %d\r\n",
 			DATATYPE_PLAINTEXT,
 			evt->param.publish.message.topic.topic.size,
 			evt->param.publish.message.payload.len);
@@ -257,7 +257,7 @@ void mqtt_evt_handler(struct mqtt_client *const c,
 		break;
 	}
 
-	sprintf(rsp_buf, "#XMQTTEVT: %d,%d\r\n",
+	sprintf(rsp_buf, "#XMQTTEVT: %d, %d\r\n",
 		evt->type, ret);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 }
@@ -673,14 +673,15 @@ static int handle_at_mqtt_connect(enum at_cmd_type cmd_type)
 	case AT_CMD_TYPE_READ_COMMAND:
 		if (ctx.sec_transport) {
 			sprintf(rsp_buf,
-				"#XMQTTCON: %d,\"%s\",\"%s\",\"%s\","
-				"\"%s\",%d,%d\r\n",
+				"#XMQTTCON: %d, \"%s\", \"%s\", \"%s\", "
+				"\"%s\", %d, %d\r\n",
 				ctx.connected, ctx.cid, ctx.uname,
 				ctx.pword, ctx.url, ctx.port,
 				ctx.sec_tag);
 		} else {
-			sprintf(rsp_buf, "#XMQTTCON: %d,\"%s\",\"%s\",\"%s\""
-				",\"%s\",%d\r\n",
+			sprintf(rsp_buf,
+				"#XMQTTCON: %d, \"%s\", \"%s\", \"%s\""
+				", \"%s\", %d\r\n",
 				ctx.connected, ctx.cid, ctx.uname, ctx.pword,
 				ctx.url, ctx.port);
 		}

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -148,12 +148,12 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 {
 	switch (evt->id) {
 	case FOTA_DOWNLOAD_EVT_PROGRESS:
-		sprintf(rsp_buf, "#XFOTA: %d%% downloaded\r\n",
+		sprintf(rsp_buf, "#XFOTA: \"%d%%\"\r\n",
 				evt->progress);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		break;
 	case FOTA_DOWNLOAD_EVT_FINISHED:
-		sprintf(rsp_buf, "#XFOTA: downloaded, reset to apply.\r\n");
+		sprintf(rsp_buf, "#XFOTA: \"downloaded\", \"reset now\".\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		break;
 	case FOTA_DOWNLOAD_EVT_ERASE_PENDING:
@@ -163,7 +163,7 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 		LOG_INF("FOTA_DOWNLOAD_EVT_ERASE_DONE");
 		break;
 	case FOTA_DOWNLOAD_EVT_ERROR:
-		sprintf(rsp_buf, "#XFOTA: download error.\r\n");
+		sprintf(rsp_buf, "#XFOTA: \"download error\"\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		break;
 

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -40,8 +40,8 @@ LOG_MODULE_REGISTER(at_host, CONFIG_SLM_LOG_LEVEL);
 #include "slm_at_httpc.h"
 #endif
 
-#define OK_STR		"OK\r\n"
-#define ERROR_STR	"ERROR\r\n"
+#define OK_STR		"\r\nOK\r\n"
+#define ERROR_STR	"\r\nERROR\r\n"
 #define FATAL_STR	"FATAL ERROR\r\n"
 #define SLM_SYNC_STR	"Ready\r\n"
 
@@ -503,11 +503,11 @@ static void cmd_send(struct k_work *work)
 		rsp_send(ERROR_STR, sizeof(ERROR_STR) - 1);
 		break;
 	case AT_CMD_ERROR_CMS:
-		sprintf(str, "+CMS ERROR: %d\r\n", err);
+		sprintf(str, "\r\n+CMS ERROR: %d\r\n", err);
 		rsp_send(str, strlen(str));
 		break;
 	case AT_CMD_ERROR_CME:
-		sprintf(str, "+CME ERROR: %d\r\n", err);
+		sprintf(str, "\r\n+CME ERROR: %d\r\n", err);
 		rsp_send(str, strlen(str));
 		break;
 	default:

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -209,7 +209,7 @@ static uint32_t send_ping_wait_reply(void)
 	ret = nrf_poll(fds, 1, ping_argv.waitms);
 	if (ret <= 0) {
 		LOG_ERR("nrf_poll() failed: (%d) (%d)", -errno, ret);
-		sprintf(rsp_buf, "#XPING: timeout\r\n");
+		sprintf(rsp_buf, "#XPING: \"timeout\"\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		goto close_end;
 	}
@@ -293,7 +293,8 @@ void ping_task(struct k_work *item)
 		int avg_s = avg / 1000;
 		int avg_f = avg % 1000;
 
-		sprintf(rsp_buf, "#XPING: average %d.%03d\r\n", avg_s, avg_f);
+		sprintf(rsp_buf, "#XPING: \"average %d.%03d\"\r\n",
+			avg_s, avg_f);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	}
 
@@ -339,8 +340,7 @@ static int ping_test_handler(const char *url, int length, int waittime,
 	res = NULL;
 	st = getaddrinfo(url, NULL, NULL, &res);
 	if (st != 0) {
-		LOG_ERR("getaddrinfo(dest) error: %d", st);
-		sprintf(rsp_buf, "Cannot resolve remote host\r\n");
+		sprintf(rsp_buf, "\"resolve host error: %d\"\r\n", st);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		freeaddrinfo(ping_argv.src);
 		return -st;

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -209,7 +209,7 @@ static int do_tcp_server_start(uint16_t port)
 			tcpsvr_thread_func, NULL, NULL, NULL,
 			THREAD_PRIORITY, K_USER, K_NO_WAIT);
 	proxy.role = AT_TCP_ROLE_SERVER;
-	sprintf(rsp_buf, "#XTCPSVR: %d started\r\n", proxy.sock);
+	sprintf(rsp_buf, "#XTCPSVR: %d, \"started\"\r\n", proxy.sock);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 
 exit:
@@ -323,7 +323,7 @@ static int do_tcp_client_connect(const char *url, uint16_t port)
 			THREAD_PRIORITY, K_USER, K_NO_WAIT);
 
 	proxy.role = AT_TCP_ROLE_CLIENT;
-	sprintf(rsp_buf, "#XTCPCLI: %d connected\r\n", proxy.sock);
+	sprintf(rsp_buf, "#XTCPCLI: %d, \"connected\"\r\n", proxy.sock);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 
 exit:
@@ -461,7 +461,7 @@ static void tcp_data_handle(uint8_t *data, uint32_t length)
 			return;
 		}
 		if (tcp_data_save(data_hex, ret) < 0) {
-			sprintf(rsp_buf, "#XTCPDATA: overrun\r\n");
+			sprintf(rsp_buf, "#XTCPDATA: \"overrun\"\r\n");
 		} else {
 			sprintf(rsp_buf, "#XTCPDATA: %d, %d\r\n",
 				DATATYPE_HEXADECIMAL, ret);
@@ -469,7 +469,7 @@ static void tcp_data_handle(uint8_t *data, uint32_t length)
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	} else {
 		if (tcp_data_save(data, length) < 0) {
-			sprintf(rsp_buf, "#XTCPDATA: overrun\r\n");
+			sprintf(rsp_buf, "#XTCPDATA: \"overrun\"\r\n");
 		} else {
 			sprintf(rsp_buf, "#XTCPDATA: %d, %d\r\n",
 			DATATYPE_PLAINTEXT, length);
@@ -523,7 +523,8 @@ int tcpsvr_input(int infd)
 				return -ECONNREFUSED;
 			}
 		}
-		sprintf(rsp_buf, "#XTCPSVR: %s connected\r\n", peer_addr);
+		sprintf(rsp_buf, "#XTCPSVR: \"%s\", \"connected\"\r\n",
+			peer_addr);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		proxy.sock_peer = ret;
 		LOG_DBG("New connection - %d", proxy.sock_peer);
@@ -572,7 +573,8 @@ static void tcpsvr_thread_func(void *p1, void *p2, void *p3)
 		if (k_timer_status_get(&conn_timer) > 0) {
 			k_timer_stop(&conn_timer);
 			LOG_INF("Connecion timeout");
-			sprintf(rsp_buf, "#XTCPSVR: %d timeout\r\n", -ETIME);
+			sprintf(rsp_buf, "#XTCPSVR: %d, \"timeout\"\r\n",
+				-ETIME);
 			rsp_send(rsp_buf, strlen(rsp_buf));
 			close(proxy.sock_peer);
 			proxy.sock_peer = INVALID_SOCKET;
@@ -597,8 +599,9 @@ static void tcpsvr_thread_func(void *p1, void *p2, void *p3)
 					ret = -EIO;
 					goto exit;
 				}
-				sprintf(rsp_buf, "#XTCPSVR: %d"
-					" disconnected\r\n", -EIO);
+				sprintf(rsp_buf,
+					"#XTCPSVR: %d, \"disconnected\"\r\n",
+					-EIO);
 				rsp_send(rsp_buf, strlen(rsp_buf));
 				k_timer_stop(&conn_timer);
 				close(proxy.sock_peer);
@@ -612,8 +615,9 @@ static void tcpsvr_thread_func(void *p1, void *p2, void *p3)
 					ret = -ENETDOWN;
 					goto exit;
 				}
-				sprintf(rsp_buf, "#XTCPSVR: %d"
-					" disconnected\r\n", -ECONNRESET);
+				sprintf(rsp_buf,
+					"#XTCPSVR: %d, \"disconnected\"\r\n",
+					-ECONNRESET);
 				rsp_send(rsp_buf, strlen(rsp_buf));
 				k_timer_stop(&conn_timer);
 				close(proxy.sock_peer);
@@ -627,8 +631,9 @@ static void tcpsvr_thread_func(void *p1, void *p2, void *p3)
 					ret = 0;
 					goto exit;
 				}
-				sprintf(rsp_buf, "#XTCPSVR: %d"
-					" disconnected\r\n", -ECONNABORTED);
+				sprintf(rsp_buf,
+					"#XTCPSVR: %d, \"disconnected\"\r\n",
+					-ECONNABORTED);
 				rsp_send(rsp_buf, strlen(rsp_buf));
 				k_timer_stop(&conn_timer);
 				/* Socket was closed before */
@@ -667,7 +672,7 @@ exit:
 	}
 #endif
 	slm_at_tcp_proxy_init();
-	sprintf(rsp_buf, "#XTCPSVR: %d stopped\r\n", ret);
+	sprintf(rsp_buf, "#XTCPSVR: %d, \"stopped\"\r\n", ret);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 }
 
@@ -730,7 +735,7 @@ exit:
 		}
 	}
 	slm_at_tcp_proxy_init();
-	sprintf(rsp_buf, "#XTCPCLI: %d disconnected\r\n", ret);
+	sprintf(rsp_buf, "#XTCPCLI: %d, \"disconnected\"\r\n", ret);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 }
 

--- a/applications/serial_lte_modem/src/slm_at_tcpip.c
+++ b/applications/serial_lte_modem/src/slm_at_tcpip.c
@@ -228,8 +228,7 @@ static int do_socket_open(uint8_t type, uint8_t role, int sec_tag)
 		}
 #else
 		if (role == AT_SOCKET_ROLE_SERVER) {
-			sprintf(rsp_buf,
-				"#XSOCKET: (D)TLS Server not supported\r\n");
+			sprintf(rsp_buf, "#XSOCKET: \"not supported\"\r\n");
 			rsp_send(rsp_buf, strlen(rsp_buf));
 			ret = -ENOTSUP;
 			goto error_exit;
@@ -285,7 +284,7 @@ static int do_socket_close(int error)
 			close(client.sock_peer);
 		}
 		slm_at_tcpip_init();
-		sprintf(rsp_buf, "#XSOCKET: %d, closed\r\n", error);
+		sprintf(rsp_buf, "#XSOCKET: %d, \"closed\"\r\n", error);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		LOG_DBG("Socket closed");
 	}
@@ -300,7 +299,7 @@ static int do_socketopt_set(int name, int value)
 	switch (name) {
 	case SO_REUSEADDR:	/* Ignored by Zephyr */
 	case SO_ERROR:		/* Ignored by Zephyr */
-		sprintf(rsp_buf, "#XSOCKETOPT: ignored\r\n");
+		sprintf(rsp_buf, "#XSOCKETOPT: \"ignored\"\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		ret = 0;
 		break;
@@ -320,7 +319,7 @@ static int do_socketopt_set(int name, int value)
 	case SO_TXTIME:		/* Not supported by SLM for now */
 	case SO_SOCKS5:		/* Not supported by SLM for now */
 	default:
-		sprintf(rsp_buf, "#XSOCKETOPT: not supported\r\n");
+		sprintf(rsp_buf, "#XSOCKETOPT: \"not supported\"\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		ret = 0;
 		break;
@@ -336,7 +335,7 @@ static int do_socketopt_get(int name)
 	switch (name) {
 	case SO_REUSEADDR:	/* Ignored by Zephyr */
 	case SO_ERROR:		/* Ignored by Zephyr */
-		sprintf(rsp_buf, "#XSOCKETOPT: ignored\r\n");
+		sprintf(rsp_buf, "#XSOCKETOPT: \"ignored\"\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		break;
 
@@ -349,7 +348,7 @@ static int do_socketopt_get(int name)
 		if (ret) {
 			LOG_ERR("getsockopt() error: %d", -errno);
 		} else {
-			sprintf(rsp_buf, "#XSOCKETOPT: %d sec\r\n",
+			sprintf(rsp_buf, "#XSOCKETOPT: \"%d sec\"\r\n",
 				(int)tmo.tv_sec);
 			rsp_send(rsp_buf, strlen(rsp_buf));
 		}
@@ -360,7 +359,7 @@ static int do_socketopt_get(int name)
 	case SO_TXTIME:		/* Not supported by SLM for now */
 	case SO_SOCKS5:		/* Not supported by SLM for now */
 	default:
-		sprintf(rsp_buf, "#XSOCKETOPT: not supported\r\n");
+		sprintf(rsp_buf, "#XSOCKETOPT: \"not supported\"\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		break;
 	}
@@ -484,7 +483,7 @@ static int do_accept(void)
 		LOG_WRN("Parse peer IP address failed: %d", -errno);
 		return -EINVAL;
 	}
-	sprintf(rsp_buf, "#XACCEPT: connected with %s\r\n",
+	sprintf(rsp_buf, "#XACCEPT: \"connected with %s\"\r\n",
 		peer_addr);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 	client.sock_peer = ret;
@@ -1241,13 +1240,11 @@ static int handle_at_getaddrinfo(enum at_cmd_type cmd_type)
 		}
 		err = getaddrinfo(url, NULL, &hints, &result);
 		if (err) {
-			LOG_ERR("getaddrinfo() failed %d", err);
 			sprintf(rsp_buf, "#XGETADDRINFO: %d\r\n", -err);
 			rsp_send(rsp_buf, strlen(rsp_buf));
 			return err;
 		} else if (result == NULL) {
-			LOG_ERR("Address not found\n");
-			sprintf(rsp_buf, "#XGETADDRINFO: not found\r\n");
+			sprintf(rsp_buf, "#XGETADDRINFO: \"not found\"\r\n");
 			rsp_send(rsp_buf, strlen(rsp_buf));
 			return -ENOENT;
 		}
@@ -1255,7 +1252,7 @@ static int handle_at_getaddrinfo(enum at_cmd_type cmd_type)
 		host = (struct sockaddr_in *)result->ai_addr;
 		inet_ntop(AF_INET, &(host->sin_addr.s_addr),
 			ipv4addr, sizeof(ipv4addr));
-		sprintf(rsp_buf, "#XGETADDRINFO: %s\r\n", ipv4addr);
+		sprintf(rsp_buf, "#XGETADDRINFO: \"%s\"\r\n", ipv4addr);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		freeaddrinfo(result);
 		break;

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -136,7 +136,7 @@ static int do_udp_server_start(uint16_t port)
 			udp_thread_func, NULL, NULL, NULL,
 			THREAD_PRIORITY, K_USER, K_NO_WAIT);
 
-	sprintf(rsp_buf, "#XUDPSVR: %d started\r\n", udp_sock);
+	sprintf(rsp_buf, "#XUDPSVR: %d, \"started\"\r\n", udp_sock);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 	LOG_DBG("UDP server started");
 
@@ -154,11 +154,7 @@ static int do_udp_server_stop(int error)
 			ret = -errno;
 		}
 		(void)slm_at_udp_proxy_init();
-		if (error) {
-			sprintf(rsp_buf, "#XUDPSVR: %d stopped\r\n", error);
-		} else {
-			sprintf(rsp_buf, "#XUDPSVR: stopped\r\n");
-		}
+		sprintf(rsp_buf, "#XUDPSVR: %d, \"stopped\"\r\n", error);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	}
 
@@ -245,7 +241,7 @@ static int do_udp_client_connect(const char *url, uint16_t port, int sec_tag)
 			udp_thread_func, NULL, NULL, NULL,
 			THREAD_PRIORITY, K_USER, K_NO_WAIT);
 
-	sprintf(rsp_buf, "#XUDPCLI: %d connected\r\n", udp_sock);
+	sprintf(rsp_buf, "#XUDPCLI: %d, \"connected\"\r\n", udp_sock);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 
 	return ret;
@@ -262,7 +258,7 @@ static int do_udp_client_disconnect(void)
 			ret = -errno;
 		}
 		(void)slm_at_udp_proxy_init();
-		sprintf(rsp_buf, "#XUDPCLI: disconnected\r\n");
+		sprintf(rsp_buf, "#XUDPCLI: \"disconnected\"\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	}
 


### PR DESCRIPTION
To help AT client to parse URC event message:
.Use comma ',' to separate each component in URC
.Use double quotes '"' to wrap string type component
.Add `<CR><LF>` before OK, ERROR, +CME, +CMS command result

DevZone ticket: 261674

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>