### PR TITLE
net: download_client: Fix includes

### DIFF
--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -10,7 +10,6 @@
 #include <zephyr/types.h>
 #include <toolchain/common.h>
 #include <net/socket.h>
-#include <nrf_socket.h>
 #include <net/tls_credentials.h>
 #include <net/download_client.h>
 #include <logging/log.h>


### PR DESCRIPTION
Download client included unnecessary header file what caused
build errors for selected configurations.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>