### PR TITLE
doc: fix typo in XRECVFROM command

### DIFF
--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -809,7 +809,7 @@ Examples
 
 ::
 
-   AT#UDPRECVFROM="test.server.com",1234
+   AT#XRECVFROM
    Test OK
    #XRECVFROM: 1, 7
    OK


### PR DESCRIPTION
Fix a typo in the example for the AT#XRECVFROM command.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>