### PR TITLE
partition manager: Add source directory option for b0

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -44,7 +44,7 @@ if (CONFIG_SECURE_BOOT)
   else()
     add_child_image(
       NAME b0
-      SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bootloader
+      SOURCE_DIR ${CONFIG_B0_SOURCE_DIR}
       )
   endif()
   if (CONFIG_SOC_NRF5340_CPUAPP AND CONFIG_BOOTLOADER_MCUBOOT)

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -36,6 +36,13 @@ if SECURE_BOOT
 module=B0
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.build_strategy"
 
+config B0_SOURCE_DIR
+  string "B0 source directory"
+  depends on B0_BUILD_STRATEGY_FROM_SOURCE
+  default "${ZEPHYR_NRF_MODULE_DIR}/samples/bootloader"
+  help
+    Source directory containing the B0 bootloader.
+
 config SB_PRIVATE_KEY_PROVIDED
 	bool
 	help


### PR DESCRIPTION
- Add an option to select the source directory for b0
  (relative to the current project path)
- Only affects b0
- Doesn't change the default behavior

Ref: NCSDK-7516

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>