### PR TITLE
Bluetooth: Mesh: Split CTL server set callbacks

### DIFF
--- a/include/bluetooth/mesh/light_ctl.h
+++ b/include/bluetooth/mesh/light_ctl.h
@@ -29,93 +29,97 @@ extern "C" {
 struct bt_mesh_light_ctl {
 	/** Light level */
 	uint16_t light;
-	/** Temperature level */
+	/** Light temperature */
 	uint16_t temp;
-	/** Delta UV level */
+	/** Delta UV */
 	int16_t delta_uv;
 };
 
-/** Temperature subset of Light CTL parameters. */
+/** Light temperature parameters. */
 struct bt_mesh_light_temp {
-	/** Temperature level */
+	/** Light temperature */
 	uint16_t temp;
-	/** Delta UV level */
+	/** Delta UV */
 	int16_t delta_uv;
 };
 
 /** Light CTL set message parameters. */
 struct bt_mesh_light_ctl_set {
-	/** CTL set parameters */
+	/** CTL set parameters. */
 	struct bt_mesh_light_ctl params;
-	/** Transition time parameters for the state change. */
+	/** Transition time parameters for the state change, or NULL to use the
+	 *  default transition time.
+	 */
 	const struct bt_mesh_model_transition *transition;
 };
 
 /** Light CTL status message parameters. */
 struct bt_mesh_light_ctl_status {
-	/** Current light level */
+	/** Current light level. */
 	uint16_t current_light;
-	/** Current Temperature level */
+	/** Current light temperature. */
 	uint16_t current_temp;
-	/** Target light level */
+	/** Target light level. */
 	uint16_t target_light;
-	/** Target Temperature level */
+	/** Target light temperature. */
 	uint16_t target_temp;
 	/** Remaining time for the state change (ms). */
-	int32_t remaining_time;
+	uint32_t remaining_time;
 };
 
 /** Light CTL Temperature set message parameters. */
 struct bt_mesh_light_temp_set {
-	/** CTL Temperature set parameters */
+	/** New light temperature. */
 	struct bt_mesh_light_temp params;
-	/** Transition time parameters for the state change. */
+	/** Transition time parameters for the state change, or NULL to use the
+	 *  default transition time.
+	 */
 	const struct bt_mesh_model_transition *transition;
 };
 
-/** Light CTL Temperature status message parameters. */
+/** Light temperature status. */
 struct bt_mesh_light_temp_status {
-	/** Current Temperature set parameters */
+	/** Current light temperature parameters. */
 	struct bt_mesh_light_temp current;
-	/** Target Temperature set parameters */
+	/** Target light temperature parameters. */
 	struct bt_mesh_light_temp target;
 	/** Remaining time for the state change (ms). */
-	int32_t remaining_time;
+	uint32_t remaining_time;
 };
 
-/** Light CTL range parameters. */
+/** Light temperature range parameters. */
 struct bt_mesh_light_temp_range {
-	/** Minimum range value */
+	/** Minimum light temperature. */
 	uint16_t min;
-	/** Maximum range value */
+	/** Maximum light temperature. */
 	uint16_t max;
 };
 
 /** Light CTL range status message parameters. */
 struct bt_mesh_light_temp_range_status {
-	/** Range set status code */
-	enum bt_mesh_model_status status_code;
-	/** Range set parameters */
+	/** Status of the previous operation. */
+	enum bt_mesh_model_status status;
+	/** Current light temperature range. */
 	struct bt_mesh_light_temp_range range;
 };
 
 /** @cond INTERNAL_HIDDEN */
-#define BT_MESH_LIGHT_CTL_GET BT_MESH_MODEL_OP_2(0x82, 0X5D)
-#define BT_MESH_LIGHT_CTL_SET BT_MESH_MODEL_OP_2(0x82, 0X5E)
-#define BT_MESH_LIGHT_CTL_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0X5F)
-#define BT_MESH_LIGHT_CTL_STATUS BT_MESH_MODEL_OP_2(0x82, 0X60)
-#define BT_MESH_LIGHT_TEMP_GET BT_MESH_MODEL_OP_2(0x82, 0X61)
-#define BT_MESH_LIGHT_TEMP_RANGE_GET BT_MESH_MODEL_OP_2(0x82, 0X62)
-#define BT_MESH_LIGHT_TEMP_RANGE_STATUS BT_MESH_MODEL_OP_2(0x82, 0X63)
-#define BT_MESH_LIGHT_TEMP_SET BT_MESH_MODEL_OP_2(0x82, 0X64)
-#define BT_MESH_LIGHT_TEMP_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0X65)
-#define BT_MESH_LIGHT_TEMP_STATUS BT_MESH_MODEL_OP_2(0x82, 0X66)
-#define BT_MESH_LIGHT_CTL_DEFAULT_GET BT_MESH_MODEL_OP_2(0x82, 0X67)
-#define BT_MESH_LIGHT_CTL_DEFAULT_STATUS BT_MESH_MODEL_OP_2(0x82, 0X68)
-#define BT_MESH_LIGHT_CTL_DEFAULT_SET BT_MESH_MODEL_OP_2(0x82, 0X69)
-#define BT_MESH_LIGHT_CTL_DEFAULT_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0X6A)
-#define BT_MESH_LIGHT_TEMP_RANGE_SET BT_MESH_MODEL_OP_2(0x82, 0X6B)
-#define BT_MESH_LIGHT_TEMP_RANGE_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0X6C)
+#define BT_MESH_LIGHT_CTL_GET BT_MESH_MODEL_OP_2(0x82, 0x5D)
+#define BT_MESH_LIGHT_CTL_SET BT_MESH_MODEL_OP_2(0x82, 0x5E)
+#define BT_MESH_LIGHT_CTL_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x5F)
+#define BT_MESH_LIGHT_CTL_STATUS BT_MESH_MODEL_OP_2(0x82, 0x60)
+#define BT_MESH_LIGHT_TEMP_GET BT_MESH_MODEL_OP_2(0x82, 0x61)
+#define BT_MESH_LIGHT_TEMP_RANGE_GET BT_MESH_MODEL_OP_2(0x82, 0x62)
+#define BT_MESH_LIGHT_TEMP_RANGE_STATUS BT_MESH_MODEL_OP_2(0x82, 0x63)
+#define BT_MESH_LIGHT_TEMP_SET BT_MESH_MODEL_OP_2(0x82, 0x64)
+#define BT_MESH_LIGHT_TEMP_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x65)
+#define BT_MESH_LIGHT_TEMP_STATUS BT_MESH_MODEL_OP_2(0x82, 0x66)
+#define BT_MESH_LIGHT_CTL_DEFAULT_GET BT_MESH_MODEL_OP_2(0x82, 0x67)
+#define BT_MESH_LIGHT_CTL_DEFAULT_STATUS BT_MESH_MODEL_OP_2(0x82, 0x68)
+#define BT_MESH_LIGHT_CTL_DEFAULT_SET BT_MESH_MODEL_OP_2(0x82, 0x69)
+#define BT_MESH_LIGHT_CTL_DEFAULT_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x6A)
+#define BT_MESH_LIGHT_TEMP_RANGE_SET BT_MESH_MODEL_OP_2(0x82, 0x6B)
+#define BT_MESH_LIGHT_TEMP_RANGE_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x6C)
 
 #define BT_MESH_LIGHT_CTL_MSG_LEN_GET 0
 #define BT_MESH_LIGHT_CTL_MSG_MINLEN_SET 7

--- a/include/bluetooth/mesh/light_ctl_srv.h
+++ b/include/bluetooth/mesh/light_ctl_srv.h
@@ -29,15 +29,15 @@ struct bt_mesh_light_ctl_srv;
  *
  * @brief Initialization parameters for a @ref bt_mesh_light_ctl_srv instance.
  *
- * @param[in] _handlers Light CTL server callbacks.
+ * @param[in] _lightness_handlers Lightness server callbacks.
+ * @param[in] _light_temp_handlers Light temperature server callbacks.
  */
-#define BT_MESH_LIGHT_CTL_SRV_INIT(_handlers)                                  \
+#define BT_MESH_LIGHT_CTL_SRV_INIT(_lightness_handlers, _light_temp_handlers)  \
 	{                                                                      \
-		.handlers = _handlers,                                         \
-		.lightness_srv = BT_MESH_LIGHTNESS_SRV_INIT(                   \
-			&_bt_mesh_light_ctl_lightness_handlers),               \
-		.temp_srv = BT_MESH_LIGHT_TEMP_SRV_INIT(                       \
-			&_bt_mesh_light_temp_handlers),                        \
+		.lightness_srv =                                               \
+			BT_MESH_LIGHTNESS_SRV_INIT(_lightness_handlers),      \
+		.temp_srv =                                                    \
+			BT_MESH_LIGHT_TEMP_SRV_INIT(_light_temp_handlers),    \
 		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
 				 BT_MESH_LIGHT_CTL_STATUS,                     \
 				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_STATUS)) },      \
@@ -62,126 +62,23 @@ struct bt_mesh_light_ctl_srv;
 						 _srv),                        \
 			 NULL)
 
-/** Generic status response structure for CTL messages. */
-struct bt_mesh_light_ctl_rsp {
-	/** Current CTL parameters */
-	struct bt_mesh_light_ctl current;
-	/** Target CTL parameters */
-	struct bt_mesh_light_ctl target;
-	/** Remaining time for the state change (ms). */
-	int32_t remaining_time;
-};
-
-/** Generic set structure for CTL messages. */
-struct bt_mesh_light_ctl_gen_cb_set {
-	/**
-	 * Pointer to new Light level to set.
-	 * @note NULL if not applicable.
-	 */
-	uint16_t *light;
-	/**
-	 * Pointer to new Temperature level to set.
-	 * @note NULL if not applicable.
-	 */
-	uint16_t *temp;
-	/**
-	 * Pointer to new Delta UV level to set.
-	 * @note NULL if not applicable.
-	 */
-	int16_t *delta_uv;
-	/** Transition time value in milliseconds. */
-	uint32_t time;
-	/** Message execution delay in milliseconds. */
-	uint32_t delay;
-};
-
-/** Light CTL Server state access handlers. */
-struct bt_mesh_light_ctl_srv_handlers {
-	/** @brief Set the CTL state.
-	 *
-	 * @note This handler is mandatory.
-	 *
-	 * @param[in] srv Server to set the CTL state of.
-	 * @param[in] ctx Message context.
-	 * @param[in] set Parameters of the state change.
-	 * @param[out] rsp Response structure to be filled.
-	 */
-	void (*const set)(struct bt_mesh_light_ctl_srv *srv,
-			  struct bt_mesh_msg_ctx *ctx,
-			  const struct bt_mesh_light_ctl_gen_cb_set *set,
-			  struct bt_mesh_light_ctl_rsp *rsp);
-
-	/** @brief Get the CTL state.
-	 *
-	 * @note This handler is mandatory.
-	 *
-	 * @param[in] srv Server to get the CTL state of.
-	 * @param[in] ctx Message context.
-	 * @param[out] rsp Response structure to be filled.
-	 */
-	void (*const get)(struct bt_mesh_light_ctl_srv *srv,
-			  struct bt_mesh_msg_ctx *ctx,
-			  struct bt_mesh_light_ctl_rsp *rsp);
-
-	/** @brief The Temperature Range state has changed.
-	 *
-	 * @param[in] srv Server the Temperature Range state was changed on.
-	 * @param[in] ctx Context of the set message that triggered the update.
-	 * @param[in] set The new Temperature Range.
-	 */
-	void (*const temp_range_update)(
-		struct bt_mesh_light_ctl_srv *srv, struct bt_mesh_msg_ctx *ctx,
-		const struct bt_mesh_light_temp_range *set);
-
-	/** @brief The Default Parameter state has changed.
-	 *
-	 * @param[in] srv Server the Default Parameter state was changed on.
-	 * @param[in] ctx Context of the set message that triggered the update.
-	 * @param[in] set The new Default Parameters.
-	 */
-	void (*const default_update)(struct bt_mesh_light_ctl_srv *srv,
-				     struct bt_mesh_msg_ctx *ctx,
-				     const struct bt_mesh_light_ctl *set);
-
-	/** @brief The Light Range state has changed.
-	 *
-	 * @param[in] srv Server the Light Range state was changed on.
-	 * @param[in] ctx Context of the set message that triggered the update,
-	 * or NULL if it was not triggered by a message.
-	 * @param[in] old_range The Light Range before the change.
-	 * @param[in] new_range The Light Range after the change.
-	 */
-	void (*const lightness_range_update)(
-		struct bt_mesh_light_ctl_srv *srv, struct bt_mesh_msg_ctx *ctx,
-		const struct bt_mesh_lightness_range *old_range,
-		const struct bt_mesh_lightness_range *new_range);
-};
-
 /**
  * Light CTL Server instance. Should be initialized with
  * @ref BT_MESH_LIGHT_CTL_SRV_INIT.
  */
 struct bt_mesh_light_ctl_srv {
-	/** Model entry. */
-	struct bt_mesh_model *model;
 	/** Light CTL Temp. Server instance. */
 	struct bt_mesh_light_temp_srv temp_srv;
 	/** Lightness Server instance. */
 	struct bt_mesh_lightness_srv lightness_srv;
+	/** Model entry. */
+	struct bt_mesh_model *model;
 	/** Publish parameters. */
 	struct bt_mesh_model_pub pub;
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
 	/** Setup model publish parameters */
 	struct bt_mesh_model_pub setup_pub;
-	/** Acknowledged message tracking. */
-	struct bt_mesh_model_ack_ctx ack_ctx;
-	/** Model state structure */
-	struct bt_mesh_light_ctl default_params;
-	/** Handler function structure. */
-	const struct bt_mesh_light_ctl_srv_handlers *handlers;
-	/** Scene entry */
-	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Publish the current CTL status.
@@ -197,14 +94,14 @@ struct bt_mesh_light_ctl_srv {
  * default publish parameters.
  * @param[in] status Current status.
  *
- * @retval 0 Successfully published a Generic OnOff Status message.
+ * @retval 0 Successfully sent the message.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
  */
-int32_t bt_mesh_light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct bt_mesh_light_ctl_status *status);
+int bt_mesh_light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct bt_mesh_light_ctl_status *status);
 
 /** @brief Publish the current CTL Range status.
  *
@@ -219,14 +116,14 @@ int32_t bt_mesh_light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
  * default publish parameters.
  * @param[in] status Current status.
  *
- * @retval 0 Successfully published a Generic OnOff Status message.
+ * @retval 0 Successfully sent the message.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
  */
-int32_t bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
-				    struct bt_mesh_msg_ctx *ctx,
-				    enum bt_mesh_model_status status);
+int bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				enum bt_mesh_model_status status);
 
 /** @brief Publish the current CTL Default status.
  *
@@ -240,22 +137,18 @@ int32_t bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
  * @param[in] ctx Message context to send with, or NULL to send with the
  * default publish parameters.
  *
- * @retval 0 Successfully published a Generic OnOff Status message.
+ * @retval 0 Successfully sent the message.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
  */
-int32_t bt_mesh_light_ctl_default_pub(struct bt_mesh_light_ctl_srv *srv,
-				      struct bt_mesh_msg_ctx *ctx);
+int bt_mesh_light_ctl_default_pub(struct bt_mesh_light_ctl_srv *srv,
+				  struct bt_mesh_msg_ctx *ctx);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_light_ctl_srv_op[];
 extern const struct bt_mesh_model_op _bt_mesh_light_ctl_setup_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_light_ctl_srv_cb;
-extern const struct bt_mesh_light_temp_srv_handlers
-	_bt_mesh_light_temp_handlers;
-extern const struct bt_mesh_lightness_srv_handlers
-	_bt_mesh_light_ctl_lightness_handlers;
 
 /** @endcond */
 

--- a/include/bluetooth/mesh/light_ctl_srv.h
+++ b/include/bluetooth/mesh/light_ctl_srv.h
@@ -57,7 +57,7 @@ struct bt_mesh_light_ctl_srv;
 						 _srv),                        \
 			 &_bt_mesh_light_ctl_srv_cb),                          \
 	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_LIGHT_CTL_SETUP_SRV,                 \
-			 _bt_mesh_light_ctl_setup_srv_op, &(_srv)->setup_pub,  \
+			 _bt_mesh_light_ctl_setup_srv_op, NULL,                \
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_ctl_srv, \
 						 _srv),                        \
 			 NULL)
@@ -77,8 +77,6 @@ struct bt_mesh_light_ctl_srv {
 	struct bt_mesh_model_pub pub;
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
-	/** Setup model publish parameters */
-	struct bt_mesh_model_pub setup_pub;
 };
 
 /** @brief Publish the current CTL status.

--- a/include/bluetooth/mesh/light_ctl_srv.rst
+++ b/include/bluetooth/mesh/light_ctl_srv.rst
@@ -30,9 +30,9 @@ The Light Temperature Server should reference the :c:member:`bt_mesh_light_ctl_s
 
 Conventionally, the Light Temperature Server model is instantiated on the very next element, and the composition data looks as presented below.
 
-.. code-block:: console
+.. code-block:: c
 
-    static struct bt_mesh_light_ctl_srv light_ctl_srv = BT_MESH_LIGHT_CTL_SRV_INIT(&light_ctl_handlers);
+    static struct bt_mesh_light_ctl_srv light_ctl_srv = BT_MESH_LIGHT_CTL_SRV_INIT(&lightness_handlers, &light_temp_handlers);
 
     static struct bt_mesh_elem elements[] = {
         BT_MESH_ELEM(
@@ -45,11 +45,13 @@ Conventionally, the Light Temperature Server model is instantiated on the very n
             BT_MESH_MODEL_NONE),
     };
 
+The Light CTL Server does not require any message handler callbacks, as all its states are bound to the included :ref:`bt_mesh_lightness_srv_readme` and :ref:`bt_mesh_light_temp_srv_readme` models.
+The Lightness and Light Temperature server callbacks will pass pointers to :c:member:`bt_mesh_light_ctl_srv.lightness_srv` and :c:member:`bt_mesh_light_ctl_srv.temp_srv`, respectively.
+
 .. note::
 
     The Light CTL Server will verify that its internal Light Temperature Server is instantiated on a subsequent element on startup.
-    If the Light Temperature Server is missing or instantiated on the same or a preceding element, the Bluetooth Mesh startup procedure will
-    fail, and the device will not be responsive.
+    If the Light Temperature Server is missing or instantiated on the same or a preceding element, the Bluetooth Mesh startup procedure will fail, and the device will not be responsive.
 
 States
 ======

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -33,16 +33,16 @@ struct bt_mesh_light_temp_srv;
  */
 #define BT_MESH_LIGHT_TEMP_SRV_INIT(_handlers)                                 \
 	{                                                                      \
-		.handlers = _handlers,                                         \
 		.lvl = BT_MESH_LVL_SRV_INIT(                                   \
 			&_bt_mesh_light_temp_srv_lvl_handlers),                \
 		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
 				 BT_MESH_LIGHT_TEMP_STATUS,                    \
 				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_TEMP_STATUS)) }, \
-		.temp_range = {                                                \
+		.handlers = _handlers,                                         \
+		.range = {                                                     \
 			.min = BT_MESH_LIGHT_TEMP_MIN,                         \
 			.max = BT_MESH_LIGHT_TEMP_MAX,                         \
-		}                                                              \
+		},                                                             \
 	}
 
 /** @def BT_MESH_MODEL_LIGHT_TEMP_SRV
@@ -59,24 +59,9 @@ struct bt_mesh_light_temp_srv;
 		BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_temp_srv, _srv),  \
 		&_bt_mesh_light_temp_srv_cb)
 
-/** Set structure for CTL Temperature messages */
-struct bt_mesh_light_temp_cb_set {
-	/** Pointer to new Temperature level to set. */
-	uint16_t *temp;
-	/**
-	 * Pointer to new Delta UV level to set.
-	 * @note NULL if not applicable.
-	 */
-	int16_t *delta_uv;
-	/** Transition time value in milliseconds. */
-	uint32_t time;
-	/** Message execution delay in milliseconds. */
-	uint32_t delay;
-};
-
 /** Light CTL Temperature Server state access handlers. */
 struct bt_mesh_light_temp_srv_handlers {
-	/** @brief Set the CTL Temperature state.
+	/** @brief Set the Light Temperature state.
 	 *
 	 * @note This handler is mandatory.
 	 *
@@ -87,7 +72,7 @@ struct bt_mesh_light_temp_srv_handlers {
 	 */
 	void (*const set)(struct bt_mesh_light_temp_srv *srv,
 			  struct bt_mesh_msg_ctx *ctx,
-			  const struct bt_mesh_light_temp_cb_set *set,
+			  const struct bt_mesh_light_temp_set *set,
 			  struct bt_mesh_light_temp_status *rsp);
 
 	/** @brief Get the CTL Temperature state.
@@ -101,6 +86,31 @@ struct bt_mesh_light_temp_srv_handlers {
 	void (*const get)(struct bt_mesh_light_temp_srv *srv,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct bt_mesh_light_temp_status *rsp);
+
+	/** @brief The Temperature Range state has changed.
+	 *
+	 *  @param[in] srv Server the Temperature Range state was changed on.
+	 *  @param[in] ctx Context of the set message that triggered the update.
+	 *  @param[in] old_range The old Temperature Range.
+	 *  @param[in] new_range The new Temperature Range.
+	 */
+	void (*const range_update)(
+		struct bt_mesh_light_temp_srv *srv, struct bt_mesh_msg_ctx *ctx,
+		const struct bt_mesh_light_temp_range *old_range,
+		const struct bt_mesh_light_temp_range *new_range);
+
+	/** @brief The Default Light Temperature has changed.
+	 *
+	 *  @param[in] srv Server the Default Light Temperature state was
+	 *                 changed on.
+	 *  @param[in] ctx Context of the set message that triggered the update.
+	 *  @param[in] old_default The old Default Light Temperature.
+	 *  @param[in] new_default The new Default Light Temperature.
+	 */
+	void (*const default_update)(
+		struct bt_mesh_light_temp_srv *srv, struct bt_mesh_msg_ctx *ctx,
+		const struct bt_mesh_light_temp *old_default,
+		const struct bt_mesh_light_temp *new_default);
 };
 
 /**
@@ -116,16 +126,16 @@ struct bt_mesh_light_temp_srv {
 	struct bt_mesh_model_pub pub;
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
-	/** Acknowledged message tracking. */
-	struct bt_mesh_model_ack_ctx ack_ctx;
 	/** Handler function structure. */
 	const struct bt_mesh_light_temp_srv_handlers *handlers;
-	/** The last known Temperature Level. */
-	uint16_t temp_last;
-	/** The last known Delta UV Level. */
-	int16_t delta_uv_last;
+	/** Default light temperature and delta UV */
+	struct bt_mesh_light_temp dflt;
 	/** Current Temperature range. */
-	struct bt_mesh_light_temp_range temp_range;
+	struct bt_mesh_light_temp_range range;
+	/** The last known color temperature. */
+	struct bt_mesh_light_temp last;
+	/** Scene data entry */
+	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Publish the current CTL Temperature status.
@@ -146,9 +156,9 @@ struct bt_mesh_light_temp_srv {
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
  */
-int32_t bt_mesh_light_temp_srv_pub(struct bt_mesh_light_temp_srv *srv,
-				   struct bt_mesh_msg_ctx *ctx,
-				   struct bt_mesh_light_temp_status *status);
+int bt_mesh_light_temp_srv_pub(struct bt_mesh_light_temp_srv *srv,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_light_temp_status *status);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_light_temp_srv_op[];

--- a/subsys/bluetooth/mesh/light_ctl_cli.c
+++ b/subsys/bluetooth/mesh/light_ctl_cli.c
@@ -66,7 +66,7 @@ static void temp_range_status_handle(struct bt_mesh_model *model,
 	struct bt_mesh_light_ctl_cli *cli = model->user_data;
 	struct bt_mesh_light_temp_range_status status;
 
-	status.status_code = net_buf_simple_pull_u8(buf);
+	status.status = net_buf_simple_pull_u8(buf);
 	status.range.min = net_buf_simple_pull_le16(buf);
 	status.range.max = net_buf_simple_pull_le16(buf);
 
@@ -264,17 +264,17 @@ int bt_mesh_light_ctl_set_unack(struct bt_mesh_light_ctl_cli *cli,
 }
 
 int bt_mesh_light_temp_get(struct bt_mesh_light_ctl_cli *cli,
-			       struct bt_mesh_msg_ctx *ctx,
-			       struct bt_mesh_light_temp_status *rsp)
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct bt_mesh_light_temp_status *rsp)
 {
 	return get_msg(cli, ctx, rsp, BT_MESH_LIGHT_TEMP_GET,
 		       BT_MESH_LIGHT_TEMP_STATUS);
 }
 
 int bt_mesh_light_temp_set(struct bt_mesh_light_ctl_cli *cli,
-			       struct bt_mesh_msg_ctx *ctx,
-			       const struct bt_mesh_light_temp_set *set,
-			       struct bt_mesh_light_temp_status *rsp)
+			   struct bt_mesh_msg_ctx *ctx,
+			   const struct bt_mesh_light_temp_set *set,
+			   struct bt_mesh_light_temp_status *rsp)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_TEMP_SET,
 				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_TEMP_SET);

--- a/subsys/bluetooth/mesh/light_ctl_internal.h
+++ b/subsys/bluetooth/mesh/light_ctl_internal.h
@@ -17,21 +17,33 @@
 static inline uint16_t lvl_to_temp(struct bt_mesh_light_temp_srv *srv,
 				   int16_t lvl)
 {
-	return srv->temp_range.min +
-	       (lvl + ((UINT16_MAX / 2) + 1)) *
-		       (srv->temp_range.max - srv->temp_range.min) / UINT16_MAX;
+	return srv->range.min + (lvl + ((UINT16_MAX / 2) + 1)) *
+					(srv->range.max - srv->range.min) /
+					UINT16_MAX;
 }
 
 static inline int16_t temp_to_lvl(struct bt_mesh_light_temp_srv *srv,
 				  uint16_t raw_temp)
 {
-	uint16_t temp = MAX(raw_temp, srv->temp_range.min);
+	uint16_t temp = CLAMP(raw_temp, srv->range.min, srv->range.max);
 
-	temp = MIN(raw_temp, srv->temp_range.max);
-
-	return (temp - srv->temp_range.min) * UINT16_MAX /
-		       (srv->temp_range.max - srv->temp_range.min) -
+	return (temp - srv->range.min) * UINT16_MAX /
+		       (srv->range.max - srv->range.min) -
 	       ((UINT16_MAX / 2) + 1);
 }
+
+void bt_mesh_light_temp_srv_set(struct bt_mesh_light_temp_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_light_temp_set *set,
+				struct bt_mesh_light_temp_status *rsp);
+
+enum bt_mesh_model_status
+bt_mesh_light_temp_srv_range_set(struct bt_mesh_light_temp_srv *srv,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct bt_mesh_light_temp_range *range);
+
+void bt_mesh_light_temp_srv_default_set(struct bt_mesh_light_temp_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				const struct bt_mesh_light_temp *dflt);
 
 #endif /* BT_MESH_INTERNAL_LIGHT_CTL_H__ */

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
-#include <sys/byteorder.h>
 #include <bluetooth/mesh/light_ctl_srv.h>
 #include <bluetooth/mesh/light_temp_srv.h>
 #include <bluetooth/mesh/gen_dtt_srv.h>
@@ -15,30 +14,6 @@
 #define LOG_MODULE_NAME bt_mesh_light_ctl_srv
 #include "common/log.h"
 
-struct bt_mesh_light_ctl_srv_settings_data {
-	struct bt_mesh_light_ctl default_params;
-	struct bt_mesh_light_temp_range temp_range;
-	uint16_t temp_last;
-	int16_t delta_uv_last;
-} __packed;
-
-static int store_state(struct bt_mesh_light_ctl_srv *srv)
-{
-	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		return 0;
-	}
-
-	struct bt_mesh_light_ctl_srv_settings_data data = {
-		.default_params = srv->default_params,
-		.temp_range = srv->temp_srv.temp_range,
-		.temp_last = srv->temp_srv.temp_last,
-		.delta_uv_last = srv->temp_srv.delta_uv_last,
-	};
-
-	return bt_mesh_model_data_store(srv->model, false, NULL, &data,
-					sizeof(data));
-}
-
 static void ctl_encode_status(struct net_buf_simple *buf,
 			      struct bt_mesh_light_ctl_status *status)
 {
@@ -46,7 +21,8 @@ static void ctl_encode_status(struct net_buf_simple *buf,
 	net_buf_simple_add_le16(buf,
 				light_to_repr(status->current_light, ACTUAL));
 	net_buf_simple_add_le16(buf, status->current_temp);
-	if (status->remaining_time != 0) {
+
+	if (status->remaining_time) {
 		net_buf_simple_add_le16(buf, light_to_repr(status->target_light,
 							   ACTUAL));
 		net_buf_simple_add_le16(buf, status->target_temp);
@@ -55,34 +31,22 @@ static void ctl_encode_status(struct net_buf_simple *buf,
 	}
 }
 
-static void ctl_rsp(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *rx_ctx,
-		    struct bt_mesh_light_ctl_rsp *gen_status)
+static void ctl_get(struct bt_mesh_light_ctl_srv *srv,
+		    struct bt_mesh_msg_ctx *ctx,
+		    struct bt_mesh_light_ctl_status *status)
 {
-	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_CTL_STATUS,
-				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_STATUS);
-	struct bt_mesh_light_ctl_status status = {
-		.current_light = gen_status->current.light,
-		.current_temp = gen_status->current.temp,
-		.target_light = gen_status->target.light,
-		.target_temp = gen_status->target.temp,
-		.remaining_time = gen_status->remaining_time,
-	};
-	ctl_encode_status(&msg, &status);
-	(void)bt_mesh_model_send(model, rx_ctx, &msg, NULL, NULL);
-}
+	struct bt_mesh_light_temp_status temp;
+	struct bt_mesh_lightness_status light;
 
-static void light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
-			  struct bt_mesh_light_ctl_rsp *gen_status)
-{
-	struct bt_mesh_light_ctl_status status = {
-		.current_light = gen_status->current.light,
-		.current_temp = gen_status->current.temp,
-		.target_light = gen_status->target.light,
-		.target_temp = gen_status->target.temp,
-		.remaining_time = gen_status->remaining_time,
-	};
+	srv->lightness_srv.handlers->light_get(&srv->lightness_srv, ctx,
+					       &light);
+	srv->temp_srv.handlers->get(&srv->temp_srv, ctx, &temp);
 
-	(void)bt_mesh_light_ctl_pub(srv, NULL, &status);
+	status->current_temp = temp.current.temp;
+	status->current_light = light.current;
+	status->target_temp = temp.target.temp;
+	status->target_light = light.target;
+	status->remaining_time = temp.remaining_time;
 }
 
 static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
@@ -94,29 +58,38 @@ static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	}
 
 	struct bt_mesh_light_ctl_srv *srv = model->user_data;
-	struct bt_mesh_light_ctl_rsp status = { 0 };
-	struct bt_mesh_light_ctl_gen_cb_set set;
 	struct bt_mesh_model_transition transition;
-	uint16_t light = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
-	uint16_t temp = net_buf_simple_pull_le16(buf);
-	uint16_t delta_uv = net_buf_simple_pull_le16(buf);
-	uint8_t tid = net_buf_simple_pull_u8(buf);
+	struct bt_mesh_lightness_status light_rsp;
+	struct bt_mesh_light_temp_status temp_rsp;
+	struct bt_mesh_light_ctl_status status;
+	struct bt_mesh_lightness_set light = {
+		.transition = &transition,
+	};
+	struct bt_mesh_light_temp_set temp = {
+		.transition = &transition,
+	};
+	uint8_t tid;
 
-	if ((temp < BT_MESH_LIGHT_TEMP_MIN) ||
-	    (temp > BT_MESH_LIGHT_TEMP_MAX)) {
+	light.lvl = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	temp.params.temp = net_buf_simple_pull_le16(buf);
+	temp.params.delta_uv = net_buf_simple_pull_le16(buf);
+	tid = net_buf_simple_pull_u8(buf);
+
+	if ((temp.params.temp < BT_MESH_LIGHT_TEMP_MIN) ||
+	    (temp.params.temp > BT_MESH_LIGHT_TEMP_MAX)) {
 		return;
 	}
 
-	if (light != 0) {
-		light = CLAMP(light, srv->lightness_srv.range.min,
-			      srv->lightness_srv.range.max);
+	if (light.lvl != 0) {
+		light.lvl = CLAMP(light.lvl, srv->lightness_srv.range.min,
+				  srv->lightness_srv.range.max);
 	}
 
 	if (tid_check_and_update(&srv->prev_transaction, tid, ctx) != 0) {
 		/* If this is the same transaction, we don't need to send it
 		 * to the app, but we still have to respond with a status.
 		 */
-		srv->handlers->get(srv, NULL, &status);
+		ctl_get(srv, ctx, &status);
 		goto respond;
 	}
 
@@ -126,49 +99,20 @@ static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
 	}
 
-	srv->temp_srv.temp_last = temp;
-	srv->temp_srv.delta_uv_last = delta_uv;
-	store_state(srv);
+	lightness_srv_change_lvl(&srv->lightness_srv, ctx, &light, &light_rsp);
+	bt_mesh_light_temp_srv_set(&srv->temp_srv, ctx, &temp, &temp_rsp);
 
-	set.light = &light;
-	set.temp = &temp;
-	set.delta_uv = &delta_uv;
-	set.time = transition.time;
-	set.delay = transition.delay;
-	srv->handlers->set(srv, ctx, &set, &status);
+	status.current_temp = temp_rsp.current.temp;
+	status.current_light = light_rsp.current;
+	status.target_temp = temp_rsp.target.temp;
+	status.target_light = light_rsp.target;
+	status.remaining_time = temp_rsp.remaining_time;
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
-	}
-
-	struct bt_mesh_light_temp_status temp_status = {
-		.current.temp = status.current.temp,
-		.current.delta_uv = status.current.delta_uv,
-		.target.temp = status.target.temp,
-		.target.delta_uv = status.target.delta_uv,
-		.remaining_time = status.remaining_time,
-	};
-	struct bt_mesh_lvl_status lvl_status = {
-		.current = temp_to_lvl(&srv->temp_srv, status.current.temp),
-		.target = temp_to_lvl(&srv->temp_srv, status.target.temp),
-		.remaining_time = status.remaining_time,
-	};
-	struct bt_mesh_lightness_status lightness_status = {
-		.current = status.current.light,
-		.target = status.target.light,
-		.remaining_time = status.remaining_time,
-	};
-
-	light_ctl_pub(srv, &status);
-	(void)bt_mesh_light_temp_srv_pub(&srv->temp_srv, NULL,
-					     &temp_status);
-	(void)bt_mesh_lvl_srv_pub(&srv->temp_srv.lvl, NULL, &lvl_status);
-	(void)bt_mesh_lightness_srv_pub(&srv->lightness_srv, NULL,
-					&lightness_status);
+	bt_mesh_light_ctl_pub(srv, NULL, &status);
 
 respond:
 	if (ack) {
-		ctl_rsp(model, ctx, &status);
+		bt_mesh_light_ctl_pub(srv, ctx, &status);
 	}
 }
 
@@ -176,11 +120,11 @@ static void handle_ctl_get(struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctl_srv *ctl_srv = model->user_data;
-	struct bt_mesh_light_ctl_rsp status = { 0 };
+	struct bt_mesh_light_ctl_srv *srv = model->user_data;
+	struct bt_mesh_light_ctl_status status = { 0 };
 
-	ctl_srv->handlers->get(ctl_srv, NULL, &status);
-	ctl_rsp(model, ctx, &status);
+	ctl_get(srv, ctx, &status);
+	bt_mesh_light_ctl_pub(srv, ctx, &status);
 }
 
 static void handle_ctl_set(struct bt_mesh_model *model,
@@ -203,8 +147,8 @@ static void range_encode_status(struct net_buf_simple *buf,
 {
 	bt_mesh_model_msg_init(buf, BT_MESH_LIGHT_TEMP_RANGE_STATUS);
 	net_buf_simple_add_u8(buf, status);
-	net_buf_simple_add_le16(buf, srv->temp_srv.temp_range.min);
-	net_buf_simple_add_le16(buf, srv->temp_srv.temp_range.max);
+	net_buf_simple_add_le16(buf, srv->temp_srv.range.min);
+	net_buf_simple_add_le16(buf, srv->temp_srv.range.max);
 }
 
 static void temp_range_rsp(struct bt_mesh_model *model,
@@ -219,43 +163,25 @@ static void temp_range_rsp(struct bt_mesh_model *model,
 	(void)bt_mesh_model_send(model, rx_ctx, &msg, NULL, NULL);
 }
 
-static void temp_range_set(struct bt_mesh_model *model,
-			   struct bt_mesh_msg_ctx *ctx,
-			   struct net_buf_simple *buf, bool ack)
+static enum bt_mesh_model_status temp_range_set(struct bt_mesh_model *model,
+						struct bt_mesh_msg_ctx *ctx,
+						struct net_buf_simple *buf)
 {
-	if (buf->len != BT_MESH_LIGHT_CTL_MSG_LEN_TEMP_RANGE_SET) {
-		return;
-	}
-
 	struct bt_mesh_light_ctl_srv *srv = model->user_data;
+	struct bt_mesh_light_temp_range temp = {
+		.min = net_buf_simple_pull_le16(buf),
+		.max = net_buf_simple_pull_le16(buf),
+	};
 	enum bt_mesh_model_status status;
-	uint16_t new_min = net_buf_simple_pull_le16(buf);
-	uint16_t new_max = net_buf_simple_pull_le16(buf);
 
-	if ((new_min < BT_MESH_LIGHT_TEMP_MIN) || (new_min > new_max)) {
-		status = BT_MESH_MODEL_ERROR_INVALID_RANGE_MIN;
-		goto respond;
-	} else if (new_max > BT_MESH_LIGHT_TEMP_MAX) {
-		status = BT_MESH_MODEL_ERROR_INVALID_RANGE_MAX;
-		goto respond;
-	}
-
-	srv->temp_srv.temp_range.min = new_min;
-	srv->temp_srv.temp_range.max = new_max;
-	store_state(srv);
-	status = BT_MESH_MODEL_SUCCESS;
-
-	if (srv->handlers->temp_range_update) {
-		srv->handlers->temp_range_update(srv, ctx,
-						 &srv->temp_srv.temp_range);
+	status = bt_mesh_light_temp_srv_range_set(&srv->temp_srv, ctx, &temp);
+	if (status != BT_MESH_MODEL_SUCCESS) {
+		return status;
 	}
 
 	(void)bt_mesh_light_ctl_range_pub(srv, NULL, status);
 
-respond:
-	if (ack) {
-		temp_range_rsp(model, ctx, status);
-	}
+	return BT_MESH_MODEL_SUCCESS;
 }
 
 static void handle_temp_range_get(struct bt_mesh_model *model,
@@ -273,24 +199,32 @@ static void handle_temp_range_set(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
-	temp_range_set(model, ctx, buf, true);
+	if (buf->len != BT_MESH_LIGHT_CTL_MSG_LEN_TEMP_RANGE_SET) {
+		return;
+	}
+
+	temp_range_rsp(model, ctx, temp_range_set(model, ctx, buf));
 }
 
 static void handle_temp_range_set_unack(struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
-	temp_range_set(model, ctx, buf, false);
+	if (buf->len != BT_MESH_LIGHT_CTL_MSG_LEN_TEMP_RANGE_SET) {
+		return;
+	}
+
+	temp_range_set(model, ctx, buf);
 }
 
 static void default_encode_status(struct net_buf_simple *buf,
 				  struct bt_mesh_light_ctl_srv *srv)
 {
 	bt_mesh_model_msg_init(buf, BT_MESH_LIGHT_CTL_DEFAULT_STATUS);
-	net_buf_simple_add_le16(buf, light_to_repr(srv->default_params.light,
-						   ACTUAL));
-	net_buf_simple_add_le16(buf, srv->default_params.temp);
-	net_buf_simple_add_le16(buf, srv->default_params.delta_uv);
+	net_buf_simple_add_le16(
+		buf, light_to_repr(srv->lightness_srv.default_light, ACTUAL));
+	net_buf_simple_add_le16(buf, srv->temp_srv.dflt.temp);
+	net_buf_simple_add_le16(buf, srv->temp_srv.dflt.delta_uv);
 }
 
 static void default_rsp(struct bt_mesh_model *model,
@@ -305,37 +239,25 @@ static void default_rsp(struct bt_mesh_model *model,
 }
 
 static void default_set(struct bt_mesh_model *model,
-			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf,
-			bool ack)
+			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 {
-	if (buf->len != BT_MESH_LIGHT_CTL_MSG_LEN_DEFAULT_MSG) {
-		return;
-	}
-
 	struct bt_mesh_light_ctl_srv *srv = model->user_data;
-	uint16_t light = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
-	uint16_t temp = net_buf_simple_pull_le16(buf);
-	uint16_t delta_uv = net_buf_simple_pull_le16(buf);
+	struct bt_mesh_light_temp temp;
+	uint16_t light;
 
-	if ((temp < BT_MESH_LIGHT_TEMP_MIN) ||
-	    (temp > BT_MESH_LIGHT_TEMP_MAX)) {
+	light = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	temp.temp = net_buf_simple_pull_le16(buf);
+	temp.delta_uv = net_buf_simple_pull_le16(buf);
+
+	if ((temp.temp < BT_MESH_LIGHT_TEMP_MIN) ||
+	    (temp.temp > BT_MESH_LIGHT_TEMP_MAX)) {
 		return;
 	}
 
-	srv->default_params.light = light;
-	srv->default_params.temp = temp;
-	srv->default_params.delta_uv = delta_uv;
-	store_state(srv);
-
-	if (srv->handlers->default_update) {
-		srv->handlers->default_update(srv, ctx, &srv->default_params);
-	}
+	lightness_srv_default_set(&srv->lightness_srv, ctx, light);
+	bt_mesh_light_temp_srv_default_set(&srv->temp_srv, ctx, &temp);
 
 	(void)bt_mesh_light_ctl_default_pub(srv, NULL);
-
-	if (ack) {
-		default_rsp(model, ctx);
-	}
 }
 
 static void handle_default_get(struct bt_mesh_model *model,
@@ -353,128 +275,24 @@ static void handle_default_set(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
-	default_set(model, ctx, buf, true);
+	if (buf->len != BT_MESH_LIGHT_CTL_MSG_LEN_DEFAULT_MSG) {
+		return;
+	}
+
+	default_set(model, ctx, buf);
+	default_rsp(model, ctx);
 }
 
 static void handle_default_set_unack(struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
-	default_set(model, ctx, buf, false);
-}
-
-static void temp_set(struct bt_mesh_light_temp_srv *srv,
-		     struct bt_mesh_msg_ctx *ctx,
-		     const struct bt_mesh_light_temp_cb_set *set,
-		     struct bt_mesh_light_temp_status *rsp)
-{
-	struct bt_mesh_light_ctl_srv *ctl_srv =
-		CONTAINER_OF(srv, struct bt_mesh_light_ctl_srv, temp_srv);
-	struct bt_mesh_light_ctl_rsp gen_rsp = { 0 };
-	struct bt_mesh_light_ctl_gen_cb_set gen_set = {
-		.light = NULL,
-		.temp = set->temp,
-		.time = set->time,
-		.delay = set->delay,
-		.delta_uv = set->delta_uv ? set->delta_uv : NULL,
-	};
-
-	ctl_srv->handlers->set(ctl_srv, ctx, &gen_set, &gen_rsp);
-
-	store_state(ctl_srv);
-	light_ctl_pub(ctl_srv, &gen_rsp);
-
-	rsp->current.delta_uv = gen_rsp.current.delta_uv;
-	rsp->current.temp = gen_rsp.current.temp;
-	rsp->remaining_time = gen_rsp.remaining_time;
-	rsp->target.delta_uv = gen_rsp.target.delta_uv;
-	rsp->target.temp = gen_rsp.target.temp;
-}
-
-static void temp_get(struct bt_mesh_light_temp_srv *srv,
-		     struct bt_mesh_msg_ctx *ctx,
-		     struct bt_mesh_light_temp_status *rsp)
-{
-	struct bt_mesh_light_ctl_srv *ctl_srv =
-		CONTAINER_OF(srv, struct bt_mesh_light_ctl_srv, temp_srv);
-	struct bt_mesh_light_ctl_rsp gen_rsp = { 0 };
-
-	ctl_srv->handlers->get(ctl_srv, ctx, &gen_rsp);
-
-	rsp->current.delta_uv = gen_rsp.current.delta_uv;
-	rsp->current.temp = gen_rsp.current.temp;
-	rsp->remaining_time = gen_rsp.remaining_time;
-	rsp->target.delta_uv = gen_rsp.target.delta_uv;
-	rsp->target.temp = gen_rsp.target.temp;
-}
-
-static void light_set(struct bt_mesh_lightness_srv *srv,
-		      struct bt_mesh_msg_ctx *ctx,
-		      const struct bt_mesh_lightness_set *set,
-		      struct bt_mesh_lightness_status *rsp)
-{
-	struct bt_mesh_light_ctl_srv *ctl_srv =
-		CONTAINER_OF(srv, struct bt_mesh_light_ctl_srv, lightness_srv);
-	struct bt_mesh_light_ctl_rsp gen_rsp = { 0 };
-	uint16_t lvl = set->lvl;
-	struct bt_mesh_light_ctl_gen_cb_set gen_set = {
-		.light = &lvl,
-		.temp = NULL,
-		.delta_uv = NULL,
-		.time = set->transition->time,
-		.delay = set->transition->delay,
-	};
-
-	ctl_srv->handlers->set(ctl_srv, ctx, &gen_set, &gen_rsp);
-	light_ctl_pub(ctl_srv, &gen_rsp);
-
-	rsp->current = gen_rsp.current.light;
-	rsp->target = gen_rsp.target.light;
-	rsp->remaining_time = gen_rsp.remaining_time;
-}
-
-static void light_get(struct bt_mesh_lightness_srv *srv,
-		      struct bt_mesh_msg_ctx *ctx,
-		      struct bt_mesh_lightness_status *rsp)
-{
-	struct bt_mesh_light_ctl_srv *ctl_srv =
-		CONTAINER_OF(srv, struct bt_mesh_light_ctl_srv, lightness_srv);
-	struct bt_mesh_light_ctl_rsp gen_rsp = { 0 };
-
-	ctl_srv->handlers->get(ctl_srv, ctx, &gen_rsp);
-
-	rsp->current = gen_rsp.current.light;
-	rsp->target = gen_rsp.target.light;
-	rsp->remaining_time = gen_rsp.remaining_time;
-}
-
-static void
-lightness_range_update(struct bt_mesh_lightness_srv *srv,
-		       struct bt_mesh_msg_ctx *ctx,
-		       const struct bt_mesh_lightness_range *old_range,
-		       const struct bt_mesh_lightness_range *new_range)
-{
-	struct bt_mesh_light_ctl_srv *ctl_srv =
-		CONTAINER_OF(srv, struct bt_mesh_light_ctl_srv, lightness_srv);
-	if (ctl_srv->handlers->lightness_range_update) {
-		ctl_srv->handlers->lightness_range_update(ctl_srv, ctx,
-							  old_range, new_range);
+	if (buf->len != BT_MESH_LIGHT_CTL_MSG_LEN_DEFAULT_MSG) {
+		return;
 	}
+
+	default_set(model, ctx, buf);
 }
-
-const struct bt_mesh_lightness_srv_handlers
-	_bt_mesh_light_ctl_lightness_handlers = {
-		.light_set = light_set,
-		.light_get = light_get,
-		.default_update = NULL,
-		.range_update = lightness_range_update,
-	};
-
-const struct bt_mesh_light_temp_srv_handlers
-	_bt_mesh_light_temp_handlers = {
-		.set = temp_set,
-		.get = temp_get,
-	};
 
 const struct bt_mesh_model_op _bt_mesh_light_ctl_srv_op[] = {
 	{ BT_MESH_LIGHT_CTL_GET, BT_MESH_LIGHT_CTL_MSG_LEN_GET,
@@ -501,46 +319,6 @@ const struct bt_mesh_model_op _bt_mesh_light_ctl_setup_srv_op[] = {
 	{ BT_MESH_LIGHT_CTL_DEFAULT_SET_UNACK,
 	  BT_MESH_LIGHT_CTL_MSG_LEN_DEFAULT_MSG, handle_default_set_unack },
 	BT_MESH_MODEL_OP_END,
-};
-
-static ssize_t scene_store(struct bt_mesh_model *mod, uint8_t data[])
-{
-	struct bt_mesh_light_ctl_srv *srv = mod->user_data;
-	struct bt_mesh_light_ctl_rsp rsp;
-
-	srv->handlers->get(srv, NULL, &rsp);
-
-	/* Only need to store the delta UV in the scene, the rest is stored by
-	 * the extended models.
-	 */
-	if (rsp.remaining_time) {
-		sys_put_le16(rsp.target.delta_uv, data);
-	} else {
-		sys_put_le16(rsp.current.delta_uv, data);
-	}
-
-	return 2;
-}
-
-static void scene_recall(struct bt_mesh_model *mod, const uint8_t data[],
-			 size_t len,
-			 struct bt_mesh_model_transition *transition)
-{
-	struct bt_mesh_light_ctl_srv *srv = mod->user_data;
-	uint16_t delta_uv = sys_get_le16(data);
-	struct bt_mesh_light_ctl_gen_cb_set set = {
-		.delta_uv = &delta_uv,
-		.time = transition->time,
-		.delay = transition->delay,
-	};
-
-	srv->handlers->set(srv, NULL, &set, NULL);
-}
-
-static const struct bt_mesh_scene_entry_type scene_type = {
-	.maxlen = 2,
-	.store = scene_store,
-	.recall = scene_recall,
 };
 
 static int bt_mesh_light_ctl_srv_init(struct bt_mesh_model *model)
@@ -570,10 +348,6 @@ static int bt_mesh_light_ctl_srv_init(struct bt_mesh_model *model)
 				       BT_MESH_MODEL_ID_LIGHT_CTL_SETUP_SRV));
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
-
 	return 0;
 }
 
@@ -589,28 +363,18 @@ static void bt_mesh_light_ctl_srv_reset(struct bt_mesh_model *model)
 	}
 }
 
-static int bt_mesh_light_ctl_srv_settings_set(struct bt_mesh_model *model,
-					 const char *name, size_t len_rd,
-					 settings_read_cb read_cb, void *cb_arg)
-{
-	struct bt_mesh_light_ctl_srv *srv = model->user_data;
-	struct bt_mesh_light_ctl_srv_settings_data data;
-
-	if (read_cb(cb_arg, &data, sizeof(data)) != sizeof(data)) {
-		return -EINVAL;
-	}
-
-	srv->default_params = data.default_params;
-	srv->temp_srv.temp_range = data.temp_range;
-	srv->temp_srv.temp_last = data.temp_last;
-	srv->temp_srv.delta_uv_last = data.delta_uv_last;
-
-	return 0;
-}
-
 static int bt_mesh_light_ctl_srv_start(struct bt_mesh_model *mod)
 {
 	struct bt_mesh_light_ctl_srv *srv = mod->user_data;
+	struct bt_mesh_model_transition transition;
+	struct bt_mesh_light_temp_set temp = {
+		.params = srv->temp_srv.dflt,
+		.transition = &transition,
+	};
+	struct bt_mesh_lightness_set light = {
+		.lvl = srv->lightness_srv.default_light,
+		.transition = &transition,
+	};
 
 	if (!srv->temp_srv.model ||
 	    (srv->model->elem_idx > srv->temp_srv.model->elem_idx)) {
@@ -627,38 +391,36 @@ static int bt_mesh_light_ctl_srv_start(struct bt_mesh_model *mod)
 		bt_mesh_model_extend(srv->model, srv->temp_srv.model);
 	}
 
-	struct bt_mesh_light_ctl_rsp dummy;
-	struct bt_mesh_light_ctl_gen_cb_set set = {
-		.light = NULL,
-		.delta_uv = NULL,
-		.time = srv->lightness_srv.ponoff.dtt.transition_time,
-		.delay = 0,
-	};
-	uint16_t temp = srv->default_params.temp;
+	bt_mesh_dtt_srv_transition_get(mod, &transition);
 
 	switch (srv->lightness_srv.ponoff.on_power_up) {
-	case BT_MESH_ON_POWER_UP_ON:
-		set.light = &srv->default_params.light;
-		/* Intentional fallthrough */
 	case BT_MESH_ON_POWER_UP_OFF:
-		set.delta_uv = &srv->default_params.delta_uv;
-		set.temp = &temp;
+		bt_mesh_light_temp_srv_set(&srv->temp_srv, NULL, &temp, NULL);
 		break;
-	case BT_MESH_ON_POWER_UP_RESTORE:
-		set.temp = &srv->temp_srv.temp_last;
-		set.delta_uv = &srv->temp_srv.delta_uv_last;
 
-		if (atomic_test_bit(&srv->lightness_srv.flags,
-				    LIGHTNESS_SRV_FLAG_IS_ON)) {
-			set.light = &srv->lightness_srv.last;
+	case BT_MESH_ON_POWER_UP_ON:
+		bt_mesh_light_temp_srv_set(&srv->temp_srv, NULL, &temp, NULL);
+		lightness_srv_change_lvl(&srv->lightness_srv, NULL, &light,
+					 NULL);
+		break;
+
+	case BT_MESH_ON_POWER_UP_RESTORE:
+		temp.params = srv->temp_srv.last;
+		bt_mesh_light_temp_srv_set(&srv->temp_srv, NULL, &temp, NULL);
+
+		if (!atomic_test_bit(&srv->lightness_srv.flags,
+				     LIGHTNESS_SRV_FLAG_IS_ON)) {
+			break;
 		}
 
+		light.lvl = srv->lightness_srv.last;
+		lightness_srv_change_lvl(&srv->lightness_srv, NULL, &light,
+					 NULL);
 		break;
+
 	default:
 		return -EINVAL;
 	}
-
-	srv->handlers->set(srv, NULL, &set, &dummy);
 
 	return 0;
 }
@@ -667,12 +429,11 @@ const struct bt_mesh_model_cb _bt_mesh_light_ctl_srv_cb = {
 	.init = bt_mesh_light_ctl_srv_init,
 	.reset = bt_mesh_light_ctl_srv_reset,
 	.start = bt_mesh_light_ctl_srv_start,
-	.settings_set = bt_mesh_light_ctl_srv_settings_set,
 };
 
-int32_t bt_mesh_light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct bt_mesh_light_ctl_status *status)
+int bt_mesh_light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct bt_mesh_light_ctl_status *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_CTL_STATUS,
 				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_STATUS);
@@ -681,9 +442,9 @@ int32_t bt_mesh_light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
 	return model_send(srv->model, ctx, &msg);
 }
 
-int32_t bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
-				    struct bt_mesh_msg_ctx *ctx,
-				    enum bt_mesh_model_status status)
+int bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				enum bt_mesh_model_status status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_TEMP_RANGE_STATUS,
 				 BT_MESH_LIGHT_CTL_MSG_LEN_TEMP_RANGE_STATUS);
@@ -691,8 +452,8 @@ int32_t bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
 	return model_send(srv->model, ctx, &msg);
 }
 
-int32_t bt_mesh_light_ctl_default_pub(struct bt_mesh_light_ctl_srv *srv,
-				      struct bt_mesh_msg_ctx *ctx)
+int bt_mesh_light_ctl_default_pub(struct bt_mesh_light_ctl_srv *srv,
+				  struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_CTL_DEFAULT_STATUS,
 				 BT_MESH_LIGHT_CTL_MSG_LEN_DEFAULT_MSG);

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -5,13 +5,35 @@
  */
 
 #include <stdlib.h>
+#include <sys/byteorder.h>
 #include <bluetooth/mesh/light_temp_srv.h>
 #include <bluetooth/mesh/gen_dtt_srv.h>
 #include "light_ctl_internal.h"
 #include "model_utils.h"
 
+struct settings_data {
+	struct bt_mesh_light_temp dflt;
+	struct bt_mesh_light_temp_range range;
+	struct bt_mesh_light_temp last;
+} __packed;
+
+static void store_state(const struct bt_mesh_light_temp_srv *srv)
+{
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return;
+	}
+
+	struct settings_data data = {
+		.dflt = srv->dflt,
+		.range = srv->range,
+		.last = srv->last,
+	};
+
+	bt_mesh_model_data_store(srv->model, false, NULL, &data, sizeof(data));
+}
+
 static void encode_status(struct net_buf_simple *buf,
-			  struct bt_mesh_light_temp_status *status)
+			  const struct bt_mesh_light_temp_status *status)
 {
 	bt_mesh_model_msg_init(buf, BT_MESH_LIGHT_TEMP_STATUS);
 	net_buf_simple_add_le16(buf, status->current.temp);
@@ -45,15 +67,18 @@ static void temp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	}
 
 	struct bt_mesh_light_temp_srv *srv = model->user_data;
-	struct bt_mesh_light_temp_cb_set cb_msg;
 	struct bt_mesh_light_temp_status status = { 0 };
 	struct bt_mesh_model_transition transition;
-	uint16_t temp = net_buf_simple_pull_le16(buf);
-	int16_t delta_uv = net_buf_simple_pull_le16(buf);
+	struct bt_mesh_light_temp_set set = {
+		.transition = &transition,
+	};
+
+	set.params.temp = net_buf_simple_pull_le16(buf);
+	set.params.delta_uv = net_buf_simple_pull_le16(buf);
 	uint8_t tid = net_buf_simple_pull_u8(buf);
 
-	if ((temp < BT_MESH_LIGHT_TEMP_MIN) ||
-	    (temp > BT_MESH_LIGHT_TEMP_MAX)) {
+	if ((set.params.temp < BT_MESH_LIGHT_TEMP_MIN) ||
+	    (set.params.temp > BT_MESH_LIGHT_TEMP_MAX)) {
 		return;
 	}
 
@@ -71,28 +96,11 @@ static void temp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
 	}
 
-	cb_msg.temp = &temp;
-	cb_msg.delta_uv = &delta_uv;
-	cb_msg.time = transition.time;
-	cb_msg.delay = transition.delay;
-
-	srv->temp_last = temp;
-	srv->delta_uv_last = delta_uv;
-	srv->handlers->set(srv, ctx, &cb_msg, &status);
+	bt_mesh_light_temp_srv_set(srv, ctx, &set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
 		bt_mesh_scene_invalidate(&srv->lvl.scene);
 	}
-
-	struct bt_mesh_lvl_status lvl_status = {
-		.current = temp_to_lvl(srv, status.current.temp),
-		.target = temp_to_lvl(srv, status.target.temp),
-		.remaining_time = status.remaining_time,
-
-	};
-
-	(void)bt_mesh_light_temp_srv_pub(srv, NULL, &status);
-	(void)bt_mesh_lvl_srv_pub(&srv->lvl, NULL, &lvl_status);
 
 respond:
 	if (ack) {
@@ -160,23 +168,20 @@ static void lvl_set(struct bt_mesh_lvl_srv *lvl_srv,
 {
 	struct bt_mesh_light_temp_srv *srv =
 		CONTAINER_OF(lvl_srv, struct bt_mesh_light_temp_srv, lvl);
-	struct bt_mesh_light_temp_cb_set cb_msg;
 	struct bt_mesh_light_temp_status status = { 0 };
-	uint16_t temp = lvl_to_temp(srv, lvl_set->lvl);
-
-	cb_msg.temp = &temp;
-	cb_msg.delta_uv = NULL;
-	cb_msg.time = lvl_set->transition->time;
-	cb_msg.delay = lvl_set->transition->delay;
+	struct bt_mesh_light_temp_set set = {
+		.params = {
+			.temp = lvl_to_temp(srv, lvl_set->lvl),
+			.delta_uv = srv->last.delta_uv,
+		},
+		.transition = lvl_set->transition,
+	};
 
 	if (lvl_set->new_transaction) {
-		srv->handlers->set(srv, NULL, &cb_msg, &status);
-		srv->temp_last = temp;
+		bt_mesh_light_temp_srv_set(srv, ctx, &set, &status);
 	} else if (rsp) {
 		srv->handlers->get(srv, NULL, &status);
 	}
-
-	(void)bt_mesh_light_temp_srv_pub(srv, NULL, &status);
 
 	if (rsp) {
 		rsp->current = temp_to_lvl(srv, status.current.temp);
@@ -193,14 +198,17 @@ static void lvl_delta_set(struct bt_mesh_lvl_srv *lvl_srv,
 	struct bt_mesh_light_temp_srv *srv =
 		CONTAINER_OF(lvl_srv, struct bt_mesh_light_temp_srv, lvl);
 	struct bt_mesh_light_temp_status status = { 0 };
-	struct bt_mesh_light_temp_cb_set cb_msg;
+	struct bt_mesh_light_temp_set set = {
+		.params = srv->last,
+		.transition = delta_set->transition,
+	};
 	int16_t start_lvl, target_lvl;
 
 	if (delta_set->new_transaction) {
 		srv->handlers->get(srv, NULL, &status);
 		start_lvl = temp_to_lvl(srv, status.current.temp);
 	} else {
-		start_lvl = temp_to_lvl(srv, srv->temp_last);
+		start_lvl = temp_to_lvl(srv, srv->last.temp);
 	}
 
 	/* Clamp to int16_t range before storing the value in a 16 bit integer
@@ -209,20 +217,16 @@ static void lvl_delta_set(struct bt_mesh_lvl_srv *lvl_srv,
 	target_lvl = CLAMP(start_lvl + delta_set->delta, BT_MESH_LVL_MIN,
 			   BT_MESH_LVL_MAX);
 
-	uint16_t new_temp = lvl_to_temp(srv, target_lvl);
+	set.params.temp = lvl_to_temp(srv, target_lvl);
 
-	cb_msg.temp = &new_temp;
-	cb_msg.delta_uv = NULL;
-	cb_msg.time = delta_set->transition->time;
-	cb_msg.delay = delta_set->transition->delay;
-	srv->handlers->set(srv, ctx, &cb_msg, &status);
+	bt_mesh_light_temp_srv_set(srv, ctx, &set, &status);
 
-	/* Override "temp_last" value to be able to make corrective deltas when
-	 * new_transaction is false. Note that the "temp_last" value in
+	/* Override last temp value to be able to make corrective deltas when
+	 * new_transaction is false. Note that the last temp value in
 	 * persistent storage will still be the target value, allowing us to
-	 * recover Scorrectly on power loss.
+	 * recover correctly on power loss.
 	 */
-	srv->temp_last = lvl_to_temp(srv, start_lvl);
+	srv->last.temp = lvl_to_temp(srv, start_lvl);
 
 	(void)bt_mesh_light_temp_srv_pub(srv, NULL, &status);
 
@@ -241,36 +245,33 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 	struct bt_mesh_light_temp_srv *srv =
 		CONTAINER_OF(lvl_srv, struct bt_mesh_light_temp_srv, lvl);
 	struct bt_mesh_light_temp_status status = { 0 };
-	uint16_t target;
+	struct bt_mesh_model_transition transition = {
+		.delay = move_set->transition->delay,
+	};
+	struct bt_mesh_light_temp_set set = {
+		.params = srv->last,
+		.transition = &transition,
+	};
 
 	srv->handlers->get(srv, NULL, &status);
 
 	if (move_set->delta > 0) {
-		target = srv->temp_range.max;
+		set.params.temp = srv->range.max;
 	} else if (move_set->delta < 0) {
-		target = srv->temp_range.min;
+		set.params.temp = srv->range.min;
 	} else {
-		target = status.current.temp;
+		set.params.temp = status.current.temp;
 	}
-
-	struct bt_mesh_light_temp_cb_set cb_msg = {
-		.temp = &target,
-		.delta_uv = NULL,
-	};
 
 	if (move_set->delta != 0 && move_set->transition) {
-		uint32_t distance = abs(target - status.current.temp);
-		uint32_t time_to_edge = ((uint64_t)distance *
-					 (uint64_t)move_set->transition->time) /
-					abs(move_set->delta);
+		uint64_t distance = abs(set.params.temp - status.current.temp);
 
-		if (time_to_edge > 0) {
-			cb_msg.delay = move_set->transition->delay;
-			cb_msg.time = time_to_edge;
-		}
+		transition.time =
+			(distance * (uint64_t)move_set->transition->time) /
+			abs(move_set->delta);
 	}
 
-	srv->handlers->set(srv, ctx, &cb_msg, &status);
+	bt_mesh_light_temp_srv_set(srv, ctx, &set, &status);
 
 	if (rsp) {
 		rsp->current = temp_to_lvl(srv, status.current.temp);
@@ -286,6 +287,37 @@ const struct bt_mesh_lvl_srv_handlers _bt_mesh_light_temp_srv_lvl_handlers = {
 	.move_set = lvl_move_set,
 };
 
+static int scene_store(struct bt_mesh_model *mod, uint8_t data[])
+{
+	struct bt_mesh_light_temp_srv *srv = mod->user_data;
+
+	sys_put_le16(srv->last.delta_uv, data);
+
+	return sizeof(int16_t);
+}
+
+static void scene_recall(struct bt_mesh_model *mod, const uint8_t data[],
+			 size_t len,
+			 struct bt_mesh_model_transition *transition)
+{
+	struct bt_mesh_light_temp_srv *srv = mod->user_data;
+	struct bt_mesh_light_temp_set set = {
+		.params = {
+			.temp = srv->last.temp,
+			.delta_uv = sys_get_le16(data),
+		},
+		.transition = transition,
+	};
+
+	bt_mesh_light_temp_srv_set(srv, NULL, &set, NULL);
+}
+
+static const struct bt_mesh_scene_entry_type scene_type = {
+	.store = scene_store,
+	.recall = scene_recall,
+	.maxlen = sizeof(int16_t),
+};
+
 static int bt_mesh_light_temp_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_light_temp_srv *srv = model->user_data;
@@ -296,6 +328,31 @@ static int bt_mesh_light_temp_srv_init(struct bt_mesh_model *model)
 	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
 		bt_mesh_model_extend(model, srv->lvl.model);
 	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_SCENES)) {
+		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
+	}
+
+	return 0;
+}
+
+static int bt_mesh_light_temp_srv_settings_set(struct bt_mesh_model *mod,
+					       const char *name, size_t len_rd,
+					       settings_read_cb read_cb,
+					       void *cb_data)
+{
+	struct bt_mesh_light_temp_srv *srv = mod->user_data;
+	struct settings_data data;
+	ssize_t len;
+
+	len = read_cb(cb_data, &data, sizeof(data));
+	if (len < sizeof(data)) {
+		return -EINVAL;
+	}
+
+	srv->last = data.last;
+	srv->dflt = data.dflt;
+	srv->range = data.range;
 
 	return 0;
 }
@@ -310,11 +367,86 @@ static void bt_mesh_light_temp_srv_reset(struct bt_mesh_model *model)
 const struct bt_mesh_model_cb _bt_mesh_light_temp_srv_cb = {
 	.init = bt_mesh_light_temp_srv_init,
 	.reset = bt_mesh_light_temp_srv_reset,
+	.settings_set = bt_mesh_light_temp_srv_settings_set,
 };
 
-int32_t bt_mesh_light_temp_srv_pub(struct bt_mesh_light_temp_srv *srv,
-				   struct bt_mesh_msg_ctx *ctx,
-				   struct bt_mesh_light_temp_status *status)
+void bt_mesh_light_temp_srv_set(struct bt_mesh_light_temp_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_light_temp_set *set,
+				struct bt_mesh_light_temp_status *rsp)
+{
+	struct bt_mesh_light_temp_status status = { 0 };
+
+	set->params.temp =
+		MIN(MAX(set->params.temp, srv->range.min), srv->range.max);
+
+	srv->last = set->params;
+	store_state(srv);
+
+	srv->handlers->set(srv, ctx, set, &status);
+	if (rsp) {
+		*rsp = status;
+	}
+
+	(void)bt_mesh_light_temp_srv_pub(srv, NULL, &status);
+
+	struct bt_mesh_lvl_status lvl_status = {
+		.current = temp_to_lvl(srv, status.current.temp),
+		.target = temp_to_lvl(srv, status.target.temp),
+		.remaining_time = status.remaining_time,
+	};
+
+	(void)bt_mesh_lvl_srv_pub(&srv->lvl, NULL, &lvl_status);
+}
+
+enum bt_mesh_model_status
+bt_mesh_light_temp_srv_range_set(struct bt_mesh_light_temp_srv *srv,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct bt_mesh_light_temp_range *range)
+{
+	const struct bt_mesh_light_temp_range old = srv->range;
+
+	if ((range->min < BT_MESH_LIGHT_TEMP_MIN) ||
+	    (range->min > range->max)) {
+		return BT_MESH_MODEL_ERROR_INVALID_RANGE_MIN;
+	}
+
+	if (range->max > BT_MESH_LIGHT_TEMP_MAX) {
+		return BT_MESH_MODEL_ERROR_INVALID_RANGE_MAX;
+	}
+
+	srv->range = *range;
+	store_state(srv);
+
+	if (srv->handlers->range_update) {
+		srv->handlers->range_update(srv, ctx, &old, &srv->range);
+	}
+
+	return BT_MESH_MODEL_SUCCESS;
+}
+
+void bt_mesh_light_temp_srv_default_set(struct bt_mesh_light_temp_srv *srv,
+					struct bt_mesh_msg_ctx *ctx,
+					const struct bt_mesh_light_temp *dflt)
+{
+	const struct bt_mesh_light_temp old = srv->dflt;
+
+	if ((dflt->temp < BT_MESH_LIGHT_TEMP_MIN) ||
+	    (dflt->temp > BT_MESH_LIGHT_TEMP_MAX)) {
+		return;
+	}
+
+	srv->dflt = *dflt;
+	store_state(srv);
+
+	if (srv->handlers->default_update) {
+		srv->handlers->default_update(srv, ctx, &old, &srv->dflt);
+	}
+}
+
+int bt_mesh_light_temp_srv_pub(struct bt_mesh_light_temp_srv *srv,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_light_temp_status *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_TEMP_STATUS,
 				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_TEMP_STATUS);

--- a/tests/subsys/bluetooth/mesh/models/src/main.c
+++ b/tests/subsys/bluetooth/mesh/models/src/main.c
@@ -17,7 +17,7 @@ static struct bt_mesh_lightness_srv lightness_srv =
 static struct bt_mesh_light_ctrl_srv light_ctrl_srv =
 	BT_MESH_LIGHT_CTRL_SRV_INIT(NULL);
 static struct bt_mesh_light_ctl_srv light_ctl_srv =
-	BT_MESH_LIGHT_CTL_SRV_INIT(NULL);
+	BT_MESH_LIGHT_CTL_SRV_INIT(NULL, NULL);
 static struct bt_mesh_onoff_srv onoff_srv = BT_MESH_ONOFF_SRV_INIT(NULL);
 static struct bt_mesh_onoff_cli onoff_cli = BT_MESH_ONOFF_CLI_INIT(NULL);
 static struct bt_mesh_time_srv time_srv = BT_MESH_TIME_SRV_INIT(NULL);


### PR DESCRIPTION
Implements the pattern set by the xyL and HSL models for the CTL model,
in which the overarching collection model does not have a separate
callback structure, but relies on the underlying models. This changes
the CTL server's INIT macro into taking two callback structure
arguments, and the CTL callback structure is removed.