### PR TITLE
doc: add installing section for Connected Home over IP dependencies

### DIFF
--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -55,6 +55,61 @@ The installation process is different depending on your operating system.
 
       Also see :ref:`zephyr:mac-setup-alts` for additional information.
 
+If you are interested in building `Connected Home over IP`_ applications, install also the `GN`_ meta-build system to generate the Ninja files that the |NCS| uses.
+
+.. tabs::
+
+   .. group-tab:: Windows
+
+      |NCS| does not support the usage of GN on Windows.
+      For this reason, the Connected Home over IP project is not yet supported on Windows.
+
+   .. group-tab:: Linux
+
+      To install the GN tool, complete the following steps:
+
+      1. Download the GN binary archive and extract it by using the following commands:
+
+         .. parsed-literal::
+            :class: highlight
+
+            mkdir ${HOME}/gn && cd ${HOME}/gn
+            wget -O gn.zip https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest
+            unzip gn.zip
+            rm gn.zip
+
+      #. Add the location of the GN tool to the system PATH.
+         For example, if you are using ``bash``, run the following commands:
+
+         .. parsed-literal::
+            :class: highlight
+
+            echo 'export PATH=${HOME}/gn:"$PATH"' >> ${HOME}/.bashrc
+            source ${HOME}/.bashrc
+
+   .. group-tab:: macOS
+
+      To install the GN tool, complete the following steps:
+
+      1. Download the GN binary archive and extract it by using the following commands:
+
+         .. parsed-literal::
+            :class: highlight
+
+            mkdir ${HOME}/gn && cd ${HOME}/gn
+            wget -O gn.zip https://chrome-infra-packages.appspot.com/dl/gn/gn/mac-amd64/+/latest
+            unzip gn.zip
+            rm gn.zip
+
+      #. Add the location of the GN tool to the system PATH.
+         For example, if you are using ``bash``, run the following commands:
+
+         .. parsed-literal::
+            :class: highlight
+
+            echo 'export PATH=${HOME}/gn:"$PATH"' >> ${HOME}/.bashrc
+            source ${HOME}/.bashrc
+
 .. _gs_installing_toolchain:
 
 Installing the toolchain
@@ -217,7 +272,6 @@ Therefore, remember to regularly check for updates:
          :class: highlight
 
          pip3 install -U west
-
 
 Cloning the repositories
 ========================

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -506,6 +506,8 @@
 
 .. _`TinyCBOR`: https://intel.github.io/tinycbor/current/
 
+.. _`Connected Home over IP`: https://www.connectedhomeip.com/
+
 .. _`BH1749NUC-E`: https://www.rohm.com/datasheet/BH1749NUC/bh1749nuc-e
 
 .. _`GNU Arm Embedded Toolchain`: https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads
@@ -520,3 +522,5 @@
 .. _`Baltimore CyberTrust Root certificate`: https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem
 
 .. _`SKY66112-11 page`: https://www.skyworksinc.com/en/Products/Front-end-Modules/SKY66112-11
+
+.. _`GN` : https://gn.googlesource.com/gn/


### PR DESCRIPTION
Information on how to install GN build system needed by Connected
Home over IP project were added to the nRF Connect SDK
installation guide.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>