### PR TITLE
zigbee: Fix zigbee headers include path

### DIFF
--- a/subsys/zigbee/cli/zigbee_cli_cmd_ping.c
+++ b/subsys/zigbee/cli/zigbee_cli_cmd_ping.c
@@ -9,7 +9,7 @@
 #include <shell/shell.h>
 
 #include <zb_nrf_platform.h>
-#include <zb_error_handler.h>
+#include <zigbee/zigbee_error_handler.h>
 #include "zigbee_cli.h"
 #include "zigbee_cli_ping_types.h"
 #include "zigbee_cli_utils.h"

--- a/subsys/zigbee/cli/zigbee_cli_cmd_zcl.c
+++ b/subsys/zigbee/cli/zigbee_cli_cmd_zcl.c
@@ -7,7 +7,7 @@
 #include <shell/shell.h>
 
 #include <zboss_api.h>
-#include <zb_error_handler.h>
+#include <zigbee/zigbee_error_handler.h>
 #include "zigbee_cli.h"
 #include "zigbee_cli_cmd_zcl.h"
 


### PR DESCRIPTION
Quick fix for include path of zigbee headers in the zigbee subsys