### PR TITLE
tests: unity: Enable compilation on platforms without setjmp

### DIFF
--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 zephyr_include_directories(
 	${CMOCK_DIR}/vendor/unity/src
 	${CMOCK_DIR}/src
+	${CMAKE_CURRENT_LIST_DIR}
 )
 
 zephyr_library_sources(
@@ -29,6 +30,7 @@ zephyr_library_sources(
 )
 
 zephyr_library_sources_ifdef(CONFIG_BOARD_NATIVE_POSIX src/native_posix.c)
+zephyr_compile_definitions(UNITY_INCLUDE_CONFIG_H)
 
 # Generate test runner file.
 function(test_runner_generate test_file_path)

--- a/tests/unity/unity_cfg.yaml
+++ b/tests/unity/unity_cfg.yaml
@@ -20,6 +20,7 @@
         - :expect_any_args
     :treat_externs: :include
     :callback_after_arg_check: true
+    :exclude_setjmp_h: true
     :treat_as:
         'int8_t': 'INT8'
         'uint8_t': 'HEX8'

--- a/tests/unity/unity_config.h
+++ b/tests/unity/unity_config.h
@@ -1,0 +1,15 @@
+/* Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#ifndef UNITY_CONFIG_H__
+#define UNITY_CONFIG_H__
+
+#ifndef CONFIG_BOARD_NATIVE_POSIX
+#include <stddef.h>
+#include <stdio.h>
+#define UNITY_EXCLUDE_SETJMP_H 1
+#define UNITY_OUTPUT_CHAR(a) printf("%c", a)
+#endif
+
+#endif /* UNITY_CONFIG_H__ */

--- a/west.yml
+++ b/west.yml
@@ -107,11 +107,11 @@ manifest:
     # Other third-party repositories.
     - name: cmock
       path: test/cmock
-      revision: c243b9a7a7b3c471023193992b46cf1bd1910450
+      revision: 9d092898ef26ece140d9225e037274b64d4f851e
       remote: throwtheswitch
     - name: unity
       path: test/cmock/vendor/unity
-      revision: 031f3bbe45f8adf504ca3d13e6f093869920b091
+      revision: cf949f45ca6d172a177b00da21310607b97bc7a7
       remote: throwtheswitch
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Updated cmock/unity to version which supports turning off setjmp
in cmock.

Added unity_config.h which excludes setjmp for platforms other
than native_posix.

Example test compiles now for qemu_cortex_m3

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>