### PR TITLE
cmake: boot: Always set public key file target

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -486,6 +486,7 @@ The following list summarizes the most important changes inherited from upstream
 
   * Ensured that shields can be placed in other BOARD_ROOT folders.
   * Added basic support for Clang 10 with x86.
+  * Fixed a bug that prevented compiling the :ref:`bootloader` with :option:`CONFIG_SB_SIGNING_PUBLIC_KEY`
 
 * System:
 

--- a/subsys/bootloader/cmake/sign.cmake
+++ b/subsys/bootloader/cmake/sign.cmake
@@ -29,6 +29,9 @@ elseif (CONFIG_SB_SIGNING_OPENSSL)
     )
 elseif (CONFIG_SB_SIGNING_CUSTOM)
   set(SIGNATURE_PUBLIC_KEY_FILE ${CONFIG_SB_SIGNING_PUBLIC_KEY})
+  if (NOT EXISTS ${SIGNATURE_PUBLIC_KEY_FILE} OR IS_DIRECTORY ${SIGNATURE_PUBLIC_KEY_FILE})
+    message(WARNING "Invalid public key file: ${SIGNATURE_PUBLIC_KEY_FILE}")
+  endif()
 else ()
   message(WARNING "Unable to parse signing config.")
 endif()
@@ -47,13 +50,14 @@ if (CONFIG_SB_PRIVATE_KEY_PROVIDED)
     ${PROJECT_BINARY_DIR}
     USES_TERMINAL
     )
+endif()
 
-  add_custom_target(
+# Public key file target is required for all signing options
+add_custom_target(
     signature_public_key_file_target
     DEPENDS
     ${SIGNATURE_PUBLIC_KEY_FILE}
   )
-endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/bl_validation_magic.cmake)
 


### PR DESCRIPTION
A public key file target is required for all signing options for b0.
This was previously only set for when a private key was provided, which
breaks the use of custom signing.

Ref: NCSDK-7697
Signed-off-by: Stephen Stauts <stephen.stauts@nordicsemi.no>