### PR TITLE
tests/subsys/dfu_target/mcuboot: fix mocked identity length

### DIFF
--- a/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
@@ -56,7 +56,7 @@ static void init(void)
 	/* Return 'true' when dfu_target_mcuboot_identify() is called */
 	identify_retval = true;
 
-	ret = dfu_target_img_type(0, 0);
+	ret = dfu_target_img_type(0, 32);
 
 	zassert_true(ret > 0, "Valid type not recognized");
 
@@ -79,7 +79,7 @@ static void test_init(void)
 	done_retval = 0;
 
 	identify_retval = true;
-	ret = dfu_target_img_type(0, 0);
+	ret = dfu_target_img_type(0, 32);
 	zassert_true(ret > 0, "Valid type not recognized");
 
 	err = dfu_target_init(ret, FILE_SIZE, NULL);


### PR DESCRIPTION
Even identity byte-string comparison implementations are mocked,
dfu_target_img_type() firs check the byte-string length.

This patch set the length to proper value which fix the test.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

```./zephyr/scripts/sanitycheck -p qemu_cortex_m3 -T ./nrf/tests/subsys/dfu/dfu_target/mcuboot/```