### PR TITLE
Bluetooth: Mesh: Remove light temp extension in CTL

### DIFF
--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -383,14 +383,6 @@ static int bt_mesh_light_ctl_srv_start(struct bt_mesh_model *mod)
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
-		/* Breaking the pattern of extending models in the init
-		 * function, as the Light Temperature model's position in the
-		 * composition data isn't necessarily known at that point.
-		 */
-		bt_mesh_model_extend(srv->model, srv->temp_srv.model);
-	}
-
 	bt_mesh_dtt_srv_transition_get(mod, &transition);
 
 	switch (srv->lightness_srv.ponoff.on_power_up) {


### PR DESCRIPTION
According to the Bluetooth Mesh Model specification v1.0.1 section
6.4.3.1, the CTL server does not extend the Light temperature model, it
is just a "corresponding model".

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>