### PR TITLE
scripts: hid_configurator: Fix DFU error

### DIFF
--- a/scripts/hid_configurator/modules/dfu.py
+++ b/scripts/hid_configurator/modules/dfu.py
@@ -507,7 +507,7 @@ def send_chunks(dev, img_csum, img_file, img_length, offset, sync_buffer_size, p
             if (dfu_info.get_img_length() != img_length) or (dfu_info.get_img_csum() != img_csum):
                 print('Invalid sync information {}'.format(dfu_info))
                 return False
-            if not dfu_info.is_busy():
+            if (not dfu_info.is_busy()) and (dfu_info.get_offset() != img_length):
                 print('DFU interrupted by device')
                 return False
             if dfu_info.is_storing():


### PR DESCRIPTION
Change fixes DFU interrupted by device error. The error occurred right after the device received whole FW - DFU no longer reported busy state, because whole image was already received.

Jira: NCSDK-7728