### PR TITLE
mpsl: Provide bit masks for PPI/DPPI channels used by mpsl

### DIFF
--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -19,6 +19,12 @@
 
 LOG_MODULE_REGISTER(mpsl_init, CONFIG_MPSL_LOG_LEVEL);
 
+/* The following two constants are used in nrfx_glue.h for marking these PPI
+ * channels and groups as occupied and thus unavailable to other modules.
+ */
+const uint32_t z_mpsl_used_nrf_ppi_channels = MPSL_RESERVED_PPI_CHANNELS;
+const uint32_t z_mpsl_used_nrf_ppi_groups;
+
 #if IS_ENABLED(CONFIG_SOC_SERIES_NRF52X)
 	#define MPSL_LOW_PRIO_IRQn SWI5_IRQn
 #elif IS_ENABLED(CONFIG_SOC_SERIES_NRF53X)


### PR DESCRIPTION
This PR should not be merged before [#359](https://github.com/nrfconnect/sdk-nrfxlib/pull/359/files)

Define constants that the nrfx_glue layer will access in order to
exclude the PPI/DPPI channels and groups used by the MPSL from those
available to be allocated by other modules.