### PR TITLE
tests: fota_download: only build for nrf9160dk_nrf9160

### DIFF
--- a/tests/subsys/net/lib/fota_download/testcase.yaml
+++ b/tests/subsys/net/lib/fota_download/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   net.lib.fota_download:
     tags: aws fota
+    build_only: true
+    platform_allow: nrf9160dk_nrf9160


### PR DESCRIPTION
There is a known bug in this module, so only
build this test for now to avoid blocking.

Ref: NCSDK-7737
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>