### PR TITLE
.gitignore: Add twister-out* since sanitycheck has been renamed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tags
 .envrc
 .vscode
 sanity-out*
+twister-out*
 
 doc/_build
 doc/nrf/_doxygen/


### PR DESCRIPTION
sanitycheck has been renamed to twister.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>