### PR TITLE
 [Manual backport] samples: nrf9160: lte_gateway agreggator fifo_entry size

### DIFF
--- a/samples/nrf9160/lte_ble_gateway/src/aggregator.c
+++ b/samples/nrf9160/lte_ble_gateway/src/aggregator.c
@@ -17,7 +17,7 @@ static uint32_t entry_count;
 
 struct fifo_entry {
 	void *fifo_reserved;
-	uint8_t data[ENTRY_MAX_SIZE];
+	uint8_t data[sizeof(struct sensor_data)];
 };
 
 int aggregator_put(struct sensor_data in_data)


### PR DESCRIPTION
Aggregator fifo data element size was set to the data element of
sensor_data. Should have been the size of entire sensor_data struct.

Signed-off-by: Håvard Vermeer <havard.vermeer@nordicsemi.no>