### PR TITLE
Full modem serial update

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -113,6 +113,7 @@ Kconfig*                                  @tejlmand
 /subsys/bootloader/                       @hakonfam @ioannisg
 /subsys/debug/                            @nordic-krch @anangl
 /subsys/dfu/                              @hakonfam @sigvartmh
+/subsys/mgmt/                             @hakonfam @sigvartmh
 /subsys/esb/                              @Raane @lemrey
 /subsys/event_manager/                    @pdunaj
 /subsys/fw_info/                          @hakonfam

--- a/doc/nrf/libraries/lib_dfu.rst
+++ b/doc/nrf/libraries/lib_dfu.rst
@@ -9,3 +9,4 @@ DFU libraries
    :caption: Subpages:
 
    ../../include/dfu/*
+   ../../include/mgmt/*

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -75,6 +75,14 @@ HTTP Update
   * Extracted certificate, button, and LED handling functionality from :ref:`http_application_update_sample` to :file:`samples/nrf9160/http_update/common`, to share them with :ref:`http_modem_delta_update_sample`.
   * Moved the :ref:`http_application_update_sample` sample from :file:`samples/nrf9160/http_application_update/` to :file:`samples/nrf9160/http_update/application_update`
 
+Full modem serial update
+------------------------
+
+* Added:
+
+  * New sample :ref:`fmfu_smp_svr_sample` which shows how to add the full modem serial update functionality to an application.
+  * New module called :ref:`lib_fmfu_mgmt` which implements parts of the MCUMgr management protocol for doing full modem serial updates.
+
 Thread
 ------
 

--- a/include/mgmt/fmfu_mgmt.h
+++ b/include/mgmt/fmfu_mgmt.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file fmfu_mgmt.h
+ * @defgroup fmfu_mgmt MCUMgr module for full Modem Firmware Upgrade
+ * @{
+ * @brief MCUMgr based Full Modem Firmware Update(FMFU).
+ *
+ * The Full Modem Firmware Upgrade (FMFU) is a module with functions
+ * that hooks into MCUMgr for doing a full modem update over a transport layer
+ * with the SMP protocol.
+ *
+ * The command values are 0 for get_hash and 1 for firmware_upload
+ *
+ */
+
+#ifndef FMFU_MGMT_H__
+#define FMFU_MGMT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Setup and register the command handler for full modem
+ *  update command handler group.
+ *
+ * The modem library must be initialized in DFU mode before calling this
+ * function - nrf_modem_lib_init(FULL_DFU_MODE).
+ *
+ * @retval 0 on success, negative integer on failure.
+ */
+int fmfu_mgmt_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* FMFU_MGMT_H__ */

--- a/include/mgmt/fmfu_mgmt.rst
+++ b/include/mgmt/fmfu_mgmt.rst
@@ -1,0 +1,30 @@
+.. _lib_fmfu_mgmt:
+
+MCUMgr based full modem update
+##############################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The full modem update management library allows performing an update over UART using the SMP protocol, providing an API that exposes functions to register command hooks into the MCUMgr management protocol.
+
+It is used by the :ref:`fmfu_smp_svr_sample` sample to provide the following functionalities:
+
+* Modem firmware update to the modem
+* Memory hash function for write verification
+
+It uses command value 0 for getting the hash of an address range and command value 1 for uploading firmware data.
+
+Before calling :c:func:`fmfu_mgmt_init` the modem needs to be set into DFU mode.
+For more information on how to change the modem mode see :ref:`nrfxlib:nrf_modem`.
+
+API documentation
+*****************
+
+| Header file: :file:`include/fmfu_mgmt.h` and :file:`include/fmfu_mgmt_stat.h`
+| Source files: :file:`subsys/mgmt/src/`
+
+.. doxygengroup:: fmfu_mgmt
+   :project: nrf
+   :members:

--- a/include/mgmt/fmfu_mgmt_stat.h
+++ b/include/mgmt/fmfu_mgmt_stat.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file fmfu_mgmt_stat.h
+ * @defgroup fmfu_mgmt_stat MCUMgr hooks for Full Modem Firmware Upgrade stats
+ * @{
+ * @brief Full Modem Firmware Update(FMFU) statistics for MCUMgr over SMP.
+ *
+ * This registers a handler for the MCUMgr stat command to report back the
+ * SMP protocol MTU and frame size.
+ *
+ */
+
+#ifndef MGMT_FMFU_STAT_H__
+#define MGMT_FMFU_STAT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Setup and register the command handlers responsible for communicating
+ *	   SMP buffer sizes.
+ *
+ *  This functions setups the stat group for mcumgr so that the serial modem
+ *  module update script can negotiate the SMP protocol frame size.
+ *
+ *  @retval 0 on success, negative integer on failure.
+ */
+int fmfu_mgmt_stat_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* MGMT_FMFU_STAT_H__ */

--- a/samples/nrf9160/fmfu_smp_svr/CMakeLists.txt
+++ b/samples/nrf9160/fmfu_smp_svr/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(fmfu_smp_svr)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/nrf9160/fmfu_smp_svr/README.rst
+++ b/samples/nrf9160/fmfu_smp_svr/README.rst
@@ -1,0 +1,129 @@
+.. _fmfu_smp_svr_sample:
+
+Full Modem firmware update using SMP Server Sample
+##################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+This sample application implements a Simple Management Protocol (SMP) Server, using the SMP transfer encoding with the MCUMgr management protocol, to provide an interface over UART which enables the device to do full modem firmware updates.
+
+For more information about MCUmgr and SMP, see :ref:`device_mgmt`.
+
+Requirements
+************
+
+This sample supports the following development kit:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160ns
+
+.. include:: /includes/spm.txt
+
+Overview
+********
+
+The sample does the following:
+
+1. It deinitializes the :ref:`nrfxlib:nrf_modem`.
+#. It registers to MCUMgr a ``stat`` command.
+#. It then registers the commands to upload the firmware and to get the hash.
+#. It finally enters an idle loop, waiting for any communication over the serial line.
+
+The sample also provides a UART overlay that will allow your sample to transfer at a speed of 1M baud, and it enables support for the ``fmfu_mgmt`` command group.
+See :ref:`lib_fmfu_mgmt` for more details.
+
+Building and running
+********************
+
+.. |sample path| replace:: :file:`samples/nrf9160/fmfu_smp_svr`
+
+.. include:: /includes/build_and_run_nrf9160.txt
+
+To use the UART overlay for increasing the transfer speed, add the ``-DOVERLAY_FILE=uart.overlay`` flag to your build.
+
+Testing
+=======
+
+After programming the sample to your development kit, perform the following steps to test it:
+
+1. Connect the USB cable and power on or reset your nRF9160 DK.
+#. Open a terminal emulator, observe that the sample starts, and then close the terminal emulator.
+#. Call the provided :file:`update_modem.py` script specifying the COM port, the firmware ZIP file, and the UART baud rate shown in the following examples.
+   * If you used the default baud rate:
+
+   .. parsed-literal::
+     :class: highlight
+
+      python update_modem.py mfw_nrf9160_1.2.2.zip /dev/ttyACM0 *115200*
+
+   * If you used the `-DOVERLAY_FILE=uart.overlay` flag:
+
+   .. parsed-literal::
+     :class: highlight
+
+      python update_modem.py mfw_nrf9160_1.2.2.zip /dev/ttyACM0 *1000000*
+
+
+
+Sample Output
+-------------
+
+The python script should print the following output:
+
+.. code-block:: console
+
+   # nrf9160 modem firmware upgrade over serial port example started.
+   {
+   "duration": 406,
+   "error_code": "Ok",
+   "operation": "open_uart",
+   "outcome": "success",
+   "progress_percentage": 100
+   }
+   Programming modem bootloader.
+   ...
+   Finished with file.
+   Verifying memory range 1 of 3
+   Verifying memory range 2 of 3
+   Verifying memory range 3 of 3
+   Verification success.
+   {
+   "duration": 5,
+   "error_code": "Ok",
+   "operation": "close_uart",
+   "outcome": "success",
+   "progress_percentage": 100
+   }
+   ------------------------------------------------------------
+
+Troubleshooting
+===============
+
+You can use the MCUMgr CLI tool to test if the sample is running correctly, as follows:
+
+.. parsed-literal::
+  :class: highlight
+
+   mcumgr --conntype serial --connstring="dev=*COM Port*,baud=*Baudrate*" stat smp_com
+   stat group: smp_com
+       512 frame_max
+       504 pack_max
+
+Dependencies
+************
+
+This sample uses the following nRF Connect SDK libraries:
+
+* :ref:`lib_fmfu_mgmt`
+* :ref:`modem_info_readme`
+
+This sample uses the following nrfxlib libraries:
+
+* :ref:`nrfxlib:nrf_modem`
+
+In addition, it uses the following nRF Connect SDK sample:
+
+* :ref:`secure_partition_manager`

--- a/samples/nrf9160/fmfu_smp_svr/prj.conf
+++ b/samples/nrf9160/fmfu_smp_svr/prj.conf
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable mcumgr.
+CONFIG_MCUMGR=y
+
+# Some command handlers require a large stack.
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+# Enable the UART mcumgr transports.
+CONFIG_MCUMGR_SMP_UART=y
+CONFIG_UART_MCUMGR_RX_BUF_SIZE=512
+CONFIG_MCUMGR_BUF_SIZE=512
+
+# Required by the `taskstat` command.
+CONFIG_THREAD_MONITOR=y
+
+# Enable statistics and statistic names.
+CONFIG_STATS=y
+CONFIG_STATS_NAMES=y
+
+# Enable STAT and OS from the core commands
+CONFIG_MGMT_FMFU=y
+CONFIG_MCUMGR_CMD_OS_MGMT=y
+CONFIG_MCUMGR_CMD_STAT_MGMT=y
+
+CONFIG_NRF_MODEM_LIB=y
+CONFIG_NRF_MODEM_LIB_SYS_INIT=n
+
+# Used for getting the modem version
+CONFIG_AT_CMD=y
+CONFIG_AT_CMD_SYS_INIT=n
+CONFIG_AT_CMD_PARSER=y
+CONFIG_MODEM_INFO=y
+
+CONFIG_NETWORKING=y
+CONFIG_NET_SOCKETS=y
+CONFIG_NET_SOCKETS_OFFLOAD=y
+CONFIG_HEAP_MEM_POOL_SIZE=8192

--- a/samples/nrf9160/fmfu_smp_svr/sample.yaml
+++ b/samples/nrf9160/fmfu_smp_svr/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  description: Full modem firmware update Simple Management Protocol sample
+  name: Full modem serial update sample
+tests:
+  samples.nrf9160.fmfu_smp_svr:
+    build_only: true
+    build_on_all: true
+    platform_allow: nrf9160dk_nrf9160ns
+    tags: ci_build

--- a/samples/nrf9160/fmfu_smp_svr/src/main.c
+++ b/samples/nrf9160/fmfu_smp_svr/src/main.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <mgmt/fmfu_mgmt.h>
+#include <mgmt/fmfu_mgmt_stat.h>
+#include <modem/modem_info.h>
+#include <modem/nrf_modem_lib.h>
+#include <modem/at_cmd.h>
+
+void main(void)
+{
+	int err = nrf_modem_lib_init(NORMAL_MODE);
+
+	if (err == 0) {
+		char modem_version[MODEM_INFO_MAX_RESPONSE_SIZE];
+
+		err = at_cmd_init();
+		if (err != 0) {
+			printk("AT CMD Init error: %d\n\r", err);
+		} else {
+			err = modem_info_init();
+			if (err != 0) {
+				printk("Modem info Init error: %d\n\r", err);
+			} else {
+				modem_info_string_get(MODEM_INFO_FW_VERSION,
+						modem_version,
+						MODEM_INFO_MAX_RESPONSE_SIZE);
+				printk("Starting modem mgmt sample\n\r");
+				printk("Modem version: %s\n\r", modem_version);
+			}
+		}
+
+	}
+	/* Shutdown modem to prepare for DFU */
+	nrf_modem_lib_shutdown();
+
+	nrf_modem_lib_init(FULL_DFU_MODE);
+	/* Register SMP Communication stats */
+	fmfu_mgmt_stat_init();
+	/* Initialize MCUMgr handlers for full modem update */
+	err = fmfu_mgmt_init();
+	if (err) {
+		printk("Error in fmfu init: %d\n\r", err);
+	}
+	printk("FMFU initialized and ready to receive firmware\n\r");
+}

--- a/samples/nrf9160/fmfu_smp_svr/uart.overlay
+++ b/samples/nrf9160/fmfu_smp_svr/uart.overlay
@@ -1,0 +1,3 @@
+&uart0 {
+	current-speed = <1000000>;
+};

--- a/samples/nrf9160/fmfu_smp_svr/update_modem.py
+++ b/samples/nrf9160/fmfu_smp_svr/update_modem.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+import argparse
+import logging
+import time
+import os
+from pynrfjprog import HighLevel
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+def run(uart, modem_firmware_zip, baudrate):
+    if not os.path.exists(modem_firmware_zip):
+        raise Exception("Modem firmware zip file does not exist")
+    logging.info('# modem firmware upgrade over serial port example started.')
+
+
+    # Find the hex file to flash. It should be located in the same directory as
+    # this example file.
+    with HighLevel.API() as api:
+        start_time = time.time()
+        with HighLevel.ModemUARTDFUProbe(api, uart, baudrate) as modem_dfu_probe:
+            modem_dfu_probe.program(modem_firmware_zip)
+            modem_dfu_probe.verify(modem_firmware_zip)
+
+        # Print upload time
+        logging.info("-------------------------------------------------------")
+        logging.info("The operation took {0:.2f} seconds "
+                    .format(time.time() - start_time))
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("firmware", default=None,
+            help="Path to nrf9160 modem firmware zip folder")
+    parser.add_argument("uart", default=None,
+            help="Serial device name for UART")
+    parser.add_argument("baudrate", default=115200,
+            help="Baud rate of UART communication", type=int)
+    args = parser.parse_args()
+    run(args.uart, args.firmware, args.baudrate)

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -24,6 +24,7 @@ add_subdirectory_ifdef(CONFIG_IS_SPM		spm)
 add_subdirectory_ifdef(CONFIG_TRUSTED_EXECUTION_NONSECURE nonsecure)
 add_subdirectory_ifdef(CONFIG_MPSL mpsl)
 add_subdirectory_ifdef(CONFIG_ZIGBEE zigbee)
+add_subdirectory_ifdef(CONFIG_MGMT_FMFU mgmt/fmfu)
 
 if (CONFIG_NFC_T2T_NRFXLIB OR
     CONFIG_NFC_T4T_NRFXLIB OR

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -38,3 +38,5 @@ rsource "partition_manager/Kconfig"
 rsource "nrf_rpc/Kconfig"
 
 rsource "zigbee/Kconfig"
+
+rsource "mgmt/fmfu/Kconfig"

--- a/subsys/mgmt/fmfu/CMakeLists.txt
+++ b/subsys/mgmt/fmfu/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+
+# This is needed to get the library paths for cbor attrs etc.
+# used by MCUMgr but also reused in this module
+zephyr_library_link_libraries(MCUMGR)
+
+zephyr_library_sources(
+  src/fmfu_mgmt.c
+  src/fmfu_mgmt_stat.c
+  )

--- a/subsys/mgmt/fmfu/Kconfig
+++ b/subsys/mgmt/fmfu/Kconfig
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "Full Modem Firmware Update Management(FMFU)"
+
+config MGMT_FMFU
+	bool "Serial Modem Firmware Update support"
+	depends on MCUMGR_SMP_UART
+	depends on MCUMGR
+	depends on NRF_MODEM_LIB && !NRF_MODEM_LIB_SYS_INIT
+
+module=MGMT_FMFU
+module-dep=LOG
+module-str=FMFU
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+endmenu

--- a/subsys/mgmt/fmfu/src/fmfu_mgmt.c
+++ b/subsys/mgmt/fmfu/src/fmfu_mgmt.c
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <logging/log.h>
+#include <mgmt/mgmt.h>
+#include <nrfx_ipc.h>
+#include <nrf_modem_full_dfu.h>
+#include <mgmt/fmfu_mgmt.h>
+#include "fmfu_mgmt_internal.h"
+#include <cborattr/cborattr.h>
+#include <stats/stats.h>
+
+LOG_MODULE_REGISTER(mgmt_fmfu, CONFIG_MGMT_FMFU_LOG_LEVEL);
+
+/* Full modem update mgmt spesific SMP return codes */
+#define MGMT_ERR_EMODEM_INVALID_COMMAND 200
+#define MGMT_ERR_EMODEM_FAULT           201
+
+/* Full modem IPC failures*/
+#define FMFU_ERR_COMMAND_FAILED -3
+#define FMFU_ERR_COMMAND_FAULT -4
+
+#define FIRMWARE_SHA_LENGTH 32
+
+/* Struct used for parsing upload requests. */
+struct firmware_packet {
+	uint8_t data[SMP_PACKET_MTU];
+	uint32_t target_address;
+	uint32_t data_len;
+};
+
+static int unpack(struct mgmt_ctxt *ctxt, struct firmware_packet *packet,
+		  bool *whole_file_received)
+{
+	static uint32_t file_length;
+	/*
+	 * These data types are long long so that we don't have to typecast
+	 * and get compiler warnings when using them as assign data in
+	 * cbor_attr_t
+	 */
+	uint64_t offset;
+	uint64_t read_file_length;
+	size_t data_len;
+	size_t firmware_sha_len;
+	uint8_t firmware_sha[FIRMWARE_SHA_LENGTH];
+
+	CborError cbor_err = 0;
+	uint64_t fw_target_address = 0;
+	/* Description/skeleton of CBOR object */
+	const struct cbor_attr_t off_attr[] = {
+		[0] = {
+			.attribute = "data",
+			.type = CborAttrByteStringType,
+			.addr.bytestring.data = packet->data,
+			.addr.bytestring.len = &data_len,
+			.len = SMP_PACKET_MTU
+		},
+		[1] = {
+			.attribute = "len",
+			.type = CborAttrUnsignedIntegerType,
+			.addr.uinteger = &read_file_length,
+			.nodefault = true
+		},
+		[2] = {
+			.attribute = "off",
+			.type = CborAttrUnsignedIntegerType,
+			.addr.uinteger = &offset,
+			.nodefault = true
+		},
+		/* Unused but needed for parsing the CBOR*/
+		[3] = {
+			.attribute = "sha",
+			.type = CborAttrByteStringType,
+			.addr.bytestring.data = firmware_sha,
+			.addr.bytestring.len = &firmware_sha_len,
+			.len = FIRMWARE_SHA_LENGTH,
+		},
+		[4] = {
+			.attribute = "addr",
+			.type = CborAttrUnsignedIntegerType,
+			.addr.uinteger = &fw_target_address,
+			.nodefault = true
+		},
+		/* End of array */
+		[5] = { 0 },
+	};
+
+	cbor_err = cbor_read_object(&ctxt->it, off_attr);
+	if (cbor_err) {
+		return -MGMT_ERR_EINVAL;
+	}
+
+	if (offset == 0) {
+		file_length = (uint32_t)read_file_length;
+	}
+
+	packet->target_address  = (uint32_t)fw_target_address;
+	packet->data_len = (uint32_t)data_len;
+	uint32_t new_offset = (uint32_t)offset + packet->data_len;
+	*whole_file_received = (((uint32_t)offset + packet->data_len)
+				== file_length);
+	LOG_INF("Writing %d/%d bytes", new_offset, file_length);
+
+	return offset + packet->data_len;
+}
+
+static int get_mgmt_err_from_modem_ret_err(int err)
+{
+	switch (err) {
+	case FMFU_ERR_COMMAND_FAILED:
+		LOG_ERR("RPC_COMMAND_FAILED");
+		return MGMT_ERR_EMODEM_INVALID_COMMAND;
+	case FMFU_ERR_COMMAND_FAULT:
+		LOG_ERR("RPC_COMMAND_FAULT");
+		return MGMT_ERR_EMODEM_FAULT;
+	default:
+		LOG_ERR("MODEM_BAD_STATE: %d", err);
+		return MGMT_ERR_EBADSTATE;
+	}
+}
+
+static int encode_response(struct mgmt_ctxt *ctx, uint32_t expected_offset)
+{
+	CborError err = 0;
+	int status = 0;
+
+	err |= cbor_encode_text_stringz(&ctx->encoder, "rc");
+	err |= cbor_encode_int(&ctx->encoder, status);
+	err |= cbor_encode_text_stringz(&ctx->encoder, "off");
+	err |= cbor_encode_uint(&ctx->encoder, expected_offset);
+
+	if (err != 0) {
+		return MGMT_ERR_ENOMEM;
+	}
+
+	return 0;
+}
+
+static int fmfu_firmware_upload(struct mgmt_ctxt *ctx)
+{
+	static bool bootloader = true;
+
+	int rc;
+	bool whole_file_received;
+	struct firmware_packet packet;
+	uint32_t next_expected_offset;
+
+	rc = unpack(ctx, &packet, &whole_file_received);
+	if (rc < 0) {
+		return rc;
+	}
+
+	next_expected_offset = rc;
+
+	if (packet.data_len > 0) {
+		if (bootloader) {
+			rc = nrf_modem_full_dfu_bl_write(packet.data_len,
+					packet.data);
+			if (rc != 0) {
+				LOG_ERR("Error in starting transfer");
+				return get_mgmt_err_from_modem_ret_err(rc);
+			}
+		} else {
+			LOG_DBG("next_offset: 0x%x, target_address: 0x%x,"
+				"packet len: %d", next_expected_offset,
+						  packet.target_address,
+						  packet.data_len);
+
+			rc = nrf_modem_full_dfu_fw_write(packet.target_address,
+							 packet.data_len,
+							 packet.data);
+			if (rc != 0) {
+				LOG_ERR("Error in writing data, rc: %d,"
+					" errno: %d", rc, errno);
+				return get_mgmt_err_from_modem_ret_err(
+						rc);
+			}
+		}
+	}
+
+	if (whole_file_received) {
+		rc = nrf_modem_full_dfu_apply();
+		if (rc != 0) {
+			LOG_ERR("Error in transfer_end");
+			return get_mgmt_err_from_modem_ret_err(rc);
+		}
+		bootloader = false;
+	}
+
+	return encode_response(ctx, next_expected_offset);
+}
+
+static int fmfu_get_memory_hash(struct mgmt_ctxt *ctxt)
+{
+	uint64_t start;
+	uint64_t end;
+	struct nrf_modem_full_dfu_digest digest;
+
+	/* We expect two variables: the start and end address of a memory region
+	 * that we want to verify (obtain a hash for)
+	 */
+	const struct cbor_attr_t off_attr[] = {
+		[0] = {
+			.attribute = "start",
+			.type = CborAttrUnsignedIntegerType,
+			.addr.uinteger = &start,
+			.nodefault = true
+		},
+		[1] = {
+			.attribute = "end",
+			.type = CborAttrUnsignedIntegerType,
+			.addr.uinteger = &end,
+			.nodefault = true
+		},
+		[2] = { 0 },
+	};
+	start = 0;
+	end = 0;
+
+	int rc = cbor_read_object(&ctxt->it, off_attr);
+
+	if (rc || start == 0 || end == 0) {
+		return MGMT_ERR_EINVAL;
+	}
+
+	rc = nrf_modem_full_dfu_digest(start, end - start, &digest);
+
+	if (rc != 0) {
+		LOG_ERR("nrf_fmfu_hash_get failed, errno: %d.", errno);
+		LOG_ERR("start:%d end: %d\n.", (uint32_t)start, (uint32_t)end);
+		return get_mgmt_err_from_modem_ret_err(rc);
+	}
+
+	/* Put the digest response in the response */
+	CborError cbor_err = 0;
+
+	cbor_err |= cbor_encode_text_stringz(&ctxt->encoder, "digest");
+	cbor_err |= cbor_encode_byte_string(&ctxt->encoder,
+			(uint8_t *)digest.data, NRF_MODEM_FULL_DFU_DIGEST_LEN);
+	cbor_err |= cbor_encode_text_stringz(&ctxt->encoder, "rc");
+	cbor_err |= cbor_encode_int(&ctxt->encoder, rc);
+	if (cbor_err != 0) {
+		return MGMT_ERR_ENOMEM;
+	}
+
+	return MGMT_ERR_EOK;
+}
+
+static const struct mgmt_handler mgmt_fmfu_handlers[] = {
+	[FMFU_MGMT_ID_GET_HASH] = {
+		.mh_read  = fmfu_get_memory_hash,
+		.mh_write = fmfu_get_memory_hash,
+	},
+	[FMFU_MGMT_ID_UPLOAD] = {
+		.mh_read  = NULL,
+		.mh_write = fmfu_firmware_upload
+	},
+};
+
+static struct mgmt_group fmfu_mgmt_group = {
+	.mg_handlers = (struct mgmt_handler *)mgmt_fmfu_handlers,
+	.mg_handlers_count = ARRAY_SIZE(mgmt_fmfu_handlers),
+	.mg_group_id = (MGMT_GROUP_ID_PERUSER + 1),
+};
+
+int fmfu_mgmt_init(void)
+{
+	struct nrf_modem_full_dfu_digest digest;
+
+	int err = nrf_modem_full_dfu_init(&digest);
+
+	if (err != 0) {
+		LOG_ERR("nrf_fmfu_init failed, errno: %d\n.", errno);
+		return err;
+	}
+	mgmt_register_group(&fmfu_mgmt_group);
+	return err;
+}

--- a/subsys/mgmt/fmfu/src/fmfu_mgmt_internal.h
+++ b/subsys/mgmt/fmfu/src/fmfu_mgmt_internal.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef FMFU_MGMT_INTERNAL_H__
+#define FMFU_MGMT_INTERNAL_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Define full modem update MCUMgr commands */
+#define FMFU_MGMT_ID_GET_HASH 0
+#define FMFU_MGMT_ID_UPLOAD 1
+
+/*
+ * Calculate the MTU through buffer size of mcumgr and subtracting overhead
+ * of the RX buffer.
+ */
+#define SMP_PACKET_MTU\
+	(CONFIG_MCUMGR_BUF_SIZE - \
+	((CONFIG_UART_MCUMGR_RX_BUF_SIZE/CONFIG_MCUMGR_BUF_SIZE) + 1) * 4)
+/*
+ * Define the buffer sizes used for full modem update SMP server
+ * SMP uart buffer is the same as the buffer configured as the RX buffer for
+ * MCUMgr
+ */
+#define SMP_UART_BUFFER_SIZE CONFIG_UART_MCUMGR_RX_BUF_SIZE
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMFU_MGMT_INTERNAL_H__ */

--- a/subsys/mgmt/fmfu/src/fmfu_mgmt_stat.c
+++ b/subsys/mgmt/fmfu/src/fmfu_mgmt_stat.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <stats/stats.h>
+#include <mgmt/mgmt.h>
+#include <stat_mgmt/stat_mgmt.h>
+#include "fmfu_mgmt_internal.h"
+#include <mgmt/fmfu_mgmt.h>
+#include <mgmt/fmfu_mgmt_stat.h>
+
+STATS_SECT_START(smp_com_param)
+STATS_SECT_ENTRY(frame_max)
+STATS_SECT_ENTRY(pack_max)
+STATS_SECT_END;
+
+/* Assign a name to each stat. */
+STATS_NAME_START(smp_com_param)
+STATS_NAME(smp_com_param, frame_max)
+STATS_NAME(smp_com_param, pack_max)
+STATS_NAME_END(smp_com_param);
+
+/* Define an instance of the stats group. */
+STATS_SECT_DECL(smp_com_param) smp_com_param;
+
+int fmfu_mgmt_stat_init(void)
+{
+	/* Register/start the stat service */
+	stat_mgmt_register_group();
+
+	int rc = STATS_INIT_AND_REG(smp_com_param, STATS_SIZE_32, "smp_com");
+
+	STATS_INCN(smp_com_param, frame_max, SMP_UART_BUFFER_SIZE);
+	STATS_INCN(smp_com_param, pack_max, SMP_PACKET_MTU);
+
+	return rc;
+}


### PR DESCRIPTION
This adds the functionality of doing a full modem serial update with the SMP protocol.

Blocked by https://github.com/nrfconnect/sdk-nrf/pull/3792