### PR TITLE
samples: openthread: update FEM overlay GPIOs

### DIFF
--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -74,6 +74,7 @@ See :ref:`ug_radio_fem` for more information.
 
 To add support for the nRF21540 FEM, add the provided :file:`dts-nrf21540-fem.overlay` devicetree overlay file when building.
 The file is located in the :file:`samples/openthread/common` folder.
+Make sure that the GPIOs in the file correspond to those in which your front-end module is connected.
 
 .. note::
    You must add the provided overlay file if you use the nRF21540 EK.

--- a/samples/openthread/common/dts-nrf21540-fem.overlay
+++ b/samples/openthread/common/dts-nrf21540-fem.overlay
@@ -6,9 +6,9 @@
 / {
     nrf_radio_fem: nrf21540_fem {
         compatible = "nordic,nrf21540-fem";
-        tx-en-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
-        rx-en-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
-        pdn-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
-        ant-sel-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+        tx-en-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+        rx-en-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+        pdn-gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+        ant-sel-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
     };
 };


### PR DESCRIPTION
Make use of GPIOs which are free in all supported DKs for the FEM overlay file.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>