### PR TITLE
Bluetooth: Mesh: Fix a documentation typo

### DIFF
--- a/include/bluetooth/mesh/sensor_cli.h
+++ b/include/bluetooth/mesh/sensor_cli.h
@@ -399,7 +399,7 @@ int bt_mesh_sensor_cli_cadence_set_unack(
 
 /** @brief Get the list of settings for the given sensor.
  *
- *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  This call is blocking if the @c ids buffer is non-NULL. Otherwise, this
  *  function will return, and the response will be passed to the
  *  bt_mesh_sensor_cli_handlers::settings callback.
  *


### PR DESCRIPTION
Function `bt_mesh_sensor_cli_settings_get()` call is blocking when its `ids` buffer is non-NULL, and not `rsp`. You can see it in the function definition here https://github.com/nrfconnect/sdk-nrf/blob/master/subsys/bluetooth/mesh/sensor_cli.c#L725-L726:
`err = model_ackd_send(cli->mod, ctx, &msg, ids ? &cli->ack : NULL, BT_MESH_SENSOR_OP_SETTINGS_STATUS, &rsp);`

So I've fixed a documentation description for this function.

Signed-off-by: Roman Alexeev <roman@alexeyev.su>