### PR TITLE
lib: date_time: remove incorrect use of legacy API

### DIFF
--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -163,7 +163,7 @@ static int time_NTP_server_get(void)
 
 	for (int i = 0; i < ARRAY_SIZE(servers); i++) {
 		err =  sntp_time_request(&servers[i],
-			K_SECONDS(CONFIG_DATE_TIME_NTP_QUERY_TIME_SECONDS),
+			CONFIG_DATE_TIME_NTP_QUERY_TIME_SECONDS * MSEC_PER_SEC,
 			&sntp_time);
 		if (err) {
 			LOG_DBG("Not getting time from NTP server %s, error %d",


### PR DESCRIPTION
sntp_time_request requires a delay in milliseconds, not a timeout.

Jira:NCSIDB-189
Signed-off-by: Peter A. Bigot <pab@pabigot.com>