### PR TITLE
zigbee: Use NET_PKT_TXTIME symbol for delayed packet transmissions

### DIFF
--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -11,6 +11,7 @@ menuconfig ZIGBEE
 	select PM_SINGLE_IMAGE
 	select NET_L2_ZIGBEE
 	select NETWORKING
+	select NET_PKT_TXTIME
 	imply MPSL
 	imply COUNTER
 	imply COUNTER_TIMER2

--- a/subsys/zigbee/osif/zb_nrf_transceiver.c
+++ b/subsys/zigbee/osif/zb_nrf_transceiver.c
@@ -325,11 +325,7 @@ zb_bool_t zb_trans_transmit(zb_uint8_t wait_type, zb_time_t tx_at,
 			return ZB_FALSE;
 		}
 
-		struct net_ptp_time timestamp = {
-			.second = tx_at / USEC_PER_SEC,
-			.nanosecond = (tx_at % USEC_PER_SEC) * NSEC_PER_USEC
-		};
-		net_pkt_set_timestamp(pkt, &timestamp);
+		net_pkt_set_txtime(pkt, (uint64_t)tx_at * NSEC_PER_USEC);
 		state_cache.radio_state = RADIO_802154_STATE_TRANSMIT;
 		err = radio_api->tx(radio_dev,
 				    IEEE802154_TX_MODE_TXTIME,


### PR DESCRIPTION
Use NET_PKT_TXTIME symbol for delayed packet transmissions.
This aligns zigbee with upstream ieee802.15.4 driver.
It has been changed by PR https://github.com/zephyrproject-rtos/zephyr/pull/29123
