### PR TITLE
net: lib: nrf_cloud: remove cloud API dependency from poll thread

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -129,6 +129,7 @@ nRF9160
   * :ref:`lib_nrf_cloud` library:
 
     * AWS Jobs replaced by nRF Cloud FOTA as the FOTA mechanism for devices connected to nRF Cloud.
+    * Removed :option:`CONFIG_CLOUD_API` dependency from :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD`.
 
   * :ref:`asset_tracker` application:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -34,6 +34,8 @@ extern "C" {
 enum nrf_cloud_evt_type {
 	/** The transport to the nRF Cloud is established. */
 	NRF_CLOUD_EVT_TRANSPORT_CONNECTED = 0x1,
+	/** In the process of connecting to nRF Cloud. */
+	NRF_CLOUD_EVT_TRANSPORT_CONNECTING,
 	/** There was a request from nRF Cloud to associate the device
 	 * with a user on the nRF Cloud.
 	 */
@@ -56,6 +58,35 @@ enum nrf_cloud_evt_type {
 	NRF_CLOUD_EVT_FOTA_DONE,
 	/** There was an error communicating with the cloud. */
 	NRF_CLOUD_EVT_ERROR = 0xFF
+};
+
+/**@ nRF Cloud disconnect status. */
+enum nrf_cloud_disconnect_status {
+	NRF_CLOUD_DISCONNECT_USER_REQUEST,
+	NRF_CLOUD_DISCONNECT_CLOSED_BY_REMOTE,
+	NRF_CLOUD_DISCONNECT_INVALID_REQUEST,
+	NRF_CLOUD_DISCONNECT_MISC,
+	NRF_CLOUD_DISCONNECT_COUNT
+};
+
+/**@ nRF Cloud connect result. */
+enum nrf_cloud_connect_result {
+	NRF_CLOUD_CONNECT_RES_SUCCESS = 0,
+	NRF_CLOUD_CONNECT_RES_ERR_NOT_INITD = -1,
+	NRF_CLOUD_CONNECT_RES_ERR_INVALID_PARAM = -2,
+	NRF_CLOUD_CONNECT_RES_ERR_NETWORK = -3,
+	NRF_CLOUD_CONNECT_RES_ERR_BACKEND = -4,
+	NRF_CLOUD_CONNECT_RES_ERR_MISC = -5,
+	NRF_CLOUD_CONNECT_RES_ERR_NO_MEM = -6,
+	/* Invalid private key */
+	NRF_CLOUD_CONNECT_RES_ERR_PRV_KEY = -7,
+	/* Invalid CA or client cert */
+	NRF_CLOUD_CONNECT_RES_ERR_CERT = -8,
+	/* Other cert issue */
+	NRF_CLOUD_CONNECT_RES_ERR_CERT_MISC = -9,
+	/* Timeout, SIM card may be out of data */
+	NRF_CLOUD_CONNECT_RES_ERR_TIMEOUT_NO_DATA = -10,
+	NRF_CLOUD_CONNECT_RES_ERR_ALREADY_CONNECTED = -11,
 };
 
 /** @brief Sensor types supported by the nRF Cloud. */
@@ -177,8 +208,7 @@ int nrf_cloud_init(const struct nrf_cloud_init_param *param);
  *
  * @param[in] param Parameters to be used for the connection.
  *
- * @retval 0 If successful.
- *           Otherwise, a (negative) error code is returned.
+ * @retval Connect result defined by enum nrf_cloud_connect_result.
  */
 int nrf_cloud_connect(const struct nrf_cloud_connect_param *param);
 

--- a/include/net/nrf_cloud.rst
+++ b/include/net/nrf_cloud.rst
@@ -9,7 +9,7 @@ nRF Cloud
 
 The nRF Cloud library enables applications to connect to Nordic Semiconductor's `nRF Cloud`_.
 It abstracts and hides the details of the transport and the encoding scheme that is used for the payload and provides a simplified API interface for sending data from supported sensor types to the cloud.
-The current implementation supports the following technology:
+The current implementation supports the following technologies:
 
 * GPS and FLIP sensor data
 * TLS secured MQTT as the communication protocol
@@ -34,26 +34,26 @@ The application can use :c:func:`nrf_cloud_connect` to connect to the cloud.
 This API triggers a series of events and actions in the system.
 If the API fails, the application must retry to connect.
 If the :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` Kconfig option is enabled, an nRF Cloud library thread monitors the connection socket.
-When :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` is enabled, an additional event, :c:enumerator:`NRF_CLOUD_EVT_TRANSPORT_CONNECTING`, is sent to the application.
-The status field of :c:struct:`nrf_cloud_evt` contains connection status defined by :c:enumerator:`nrf_cloud_connect_result`.
-The event :c:enumerator:`NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED` also contains additional information in the status field, defined by :c:enumerator:`nrf_cloud_disconnect_status`.
-Additional details for :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` can be found in the Cloud API section below.
-When the poll thread option is used directly with the nRF Cloud library the enumeration values are prefixed with "NRF_".
+When :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` is enabled, an additional event, :c:enum:`NRF_CLOUD_EVT_TRANSPORT_CONNECTING`, is sent to the application.
+The status field of :c:struct:`nrf_cloud_evt` contains the connection status that is defined by :c:enumerator:`nrf_cloud_connect_result`.
+The event :c:enumerator:`NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED` also contains additional information in the status field that is defined by :c:enumerator:`nrf_cloud_disconnect_status`.
+Additional details for :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` can be found in the :ref:`connectg_to_cloud` section.
+When the poll thread option is used directly with the nRF Cloud library, the enumeration values are prefixed with ``NRF``.
 
 First, the library tries to establish the transport for communicating with the cloud.
 This procedure involves a TLS handshake that might take up to three seconds.
 The API blocks for the duration of the handshake.
 
 Next, the API subscribes to an MQTT topic to start receiving user association requests from the cloud.
-The cloud uses the device's certificates for authentication.
+The cloud uses the certificates of the device for authentication.
 See `Updating the nRF Connect for Cloud certificate`_ and the :ref:`modem_key_mgmt` library for more information on modem credentials.
-The certificates are generated using the device's ID and PIN/HWID.
+The certificates are generated using the device ID and PIN/HWID.
 
 Every time nRF Cloud starts a communication session with a device, it verifies whether the device is uniquely associated with a user.
 If not, the user association procedure is triggered.
 When adding the device to an nRF cloud account, the user must provide the correct device ID and PIN (for Thingy:91) or HWID (for nRF9160 DK) to nRF Cloud.
 
-The following message sequence chart shows the flow of events and expected application responses to each event during the user association procedure:
+The following message sequence chart shows the flow of events and the expected application responses to each event during the user association procedure:
 
 .. msc::
    hscale = "1.3";
@@ -70,9 +70,10 @@ The following message sequence chart shows the flow of events and expected appli
    Module>>Application      [label="NRF_CLOUD_EVT_USER_ASSOCIATED"];
    Module>>Application      [label="NRF_CLOUD_EVT_READY"];
 
+The chart shows the sequence of successful user association of an unassociated device.
 
 .. note::
-   This chart shows the sequence of successful user association of an unassociated device.
+   
    Currently, nRF Cloud requires that communication is re-established to update the device's permission to send user data.
    The application must disconnect using :c:func:`nrf_cloud_disconnect` and then reconnect using :c:func:`nrf_cloud_connect`.
 
@@ -105,7 +106,7 @@ It triggers the event :c:enumerator:`NRF_CLOUD_EVT_SENSOR_ATTACHED` if the execu
 
 Removing the link between device and user
 *****************************************
-If you want to remove the link between a device and an nRF Cloud user, you must do this from the nRF Cloud.
+If you want to remove the link between a device and an nRF Cloud user, you must do this removal from the nRF Cloud.
 It is not possible for a device to unlink itself.
 
 When a user disassociates a device, the library disallows any further sensor data to be sent to the cloud and generates an :c:enumerator:`NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST` event.
@@ -131,19 +132,21 @@ The following sections describe the various stages in the process of connection 
 Initialization
 ==============
 
-To use a defined Cloud API backend, a binding must be obtained using the Cloud API function :c:func:`cloud_get_binding` to which you can pass the name of the desired backend.
+To use a defined Cloud API backend, a binding must be obtained using the Cloud API function :c:func:`cloud_get_binding`, to which you can pass the name of the desired backend.
 The nRF Cloud library defines the Cloud API backend as ``NRF_CLOUD`` via the :c:macro:`CLOUD_BACKEND_DEFINE` macro.
 
-The backend must be initialized using the :c:func:`cloud_init` function, with the binding, and a function pointer to user defined Cloud API event handler as parameters.
+The backend must be initialized using the :c:func:`cloud_init` function, with the binding, and a function pointer to user-defined Cloud API event handler as parameters.
 If :c:func:`cloud_init` returns success, the backend is ready for use.
 The return values for a failure scenario of the :c:func:`cloud_init` function are described below for the nRF Cloud backend:
 
-*	-EACCES: invalid state; already initialized
-*	-EINVAL: invalid event handler provided
-*	-ENOMEM: error building MQTT topics; the given client ID of the device could be too long
+*	-EACCES - Invalid state. Already initialized.
+*	-EINVAL - Invalid event handler provided.
+*	-ENOMEM - Error building MQTT topics. The given client ID of the device could be too long.
 
 .. note::
    If :option:`CONFIG_NRF_CLOUD_PROVISION_CERTIFICATES` is enabled, error values could be different or have different error descriptions.
+
+.. _connectg_to_cloud:
 
 Connecting to the Cloud
 =======================
@@ -158,8 +161,8 @@ The dual functionalities of the :c:func:`cloud_connect` function in the two scen
    Function does not block and returns success if the connection monitoring thread has started.
    Below are some of the error codes that can be returned:
 
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NOT_INITD`: Cloud backend is not initialized
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_ALREADY_CONNECTED`: Connection process has already been started
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NOT_INITD` - Cloud backend is not initialized
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_ALREADY_CONNECTED` - Connection process has already been started
 
    Upon success, the monitoring thread sends an event of type :c:enumerator:`CLOUD_EVT_CONNECTING` to the user’s cloud event handler, with the ``err`` field set to success.
    If an error occurs, another event of the same type is sent, with the ``err`` field set to indicate the cause.
@@ -171,14 +174,14 @@ The dual functionalities of the :c:func:`cloud_connect` function in the two scen
    Below are some of the error codes that can be returned:
 
    * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NOT_INITD`
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NETWORK`: Host cannot be found with the available network interfaces
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_BACKEND`: A backend-specific error; In the case of nRF Cloud, this can indicate a FOTA initialization error
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_MISC`: Error cause cannot be determined
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NO_MEM`: MQTT RX/TX buffers were not initialized
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_PRV_KEY`: Invalid private key
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_CERT`: Invalid CA or client certificate
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_CERT_MISC`: Miscellaneous certificate error
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_TIMEOUT_NO_DATA`: Timeout; typically occurs when the inserted SIM card has no data
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NETWORK` - Host cannot be found with the available network interfaces.
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_BACKEND` - A backend-specific error. In the case of nRF Cloud, this can indicate a FOTA initialization error.
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_MISC` - Error cause cannot be determined.
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NO_MEM` - MQTT RX/TX buffers were not initialized.
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_PRV_KEY` - Invalid private key.
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_CERT` - Invalid CA or client certificate.
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_CERT_MISC` - Miscellaneous certificate error.
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_TIMEOUT_NO_DATA` - Timeout. Typically occurs when the inserted SIM card has no data.
 
   For both connection methods, when a device with JITP certificates attempts to connect to nRF Cloud for the first time, the cloud rejects the connection attempt so that it can provision the device.
   When this occurs, the Cloud API generates a :c:enumerator:`CLOUD_EVT_DISCONNECTED` event with the ``err`` field set to :c:enumerator:`CLOUD_DISCONNECT_INVALID_REQUEST`.
@@ -189,7 +192,7 @@ Connected to the Cloud
 
 When the connection between the device and the cloud has been successfully established, the Cloud API dispatches a :c:enumerator:`CLOUD_EVT_CONNECTED` event.
 If the device is not associated with an nRF Cloud account, a :c:enumerator:`CLOUD_EVT_PAIR_REQUEST` event is generated.
-The device must wait until it is added to an account, which is indicated by the :c:enumerator:`CLOUD_EVT_PAIR_DONE` event.
+The device must wait until it is added to an account, and this pairing is indicated by the :c:enumerator:`CLOUD_EVT_PAIR_DONE` event.
 If a device pair request is received, the device must disconnect and reconnect after receiving the :c:enumerator:`CLOUD_EVT_PAIR_DONE` event.
 This is necessary because the updated policy of the cloud becomes effective only on a new connection.
 Following the :c:enumerator:`CLOUD_EVT_PAIR_DONE` event, the Cloud API sends a :c:enumerator:`CLOUD_EVT_READY` event to indicate that the cloud is ready to receive data from the device.
@@ -206,9 +209,11 @@ The user application should use the connection socket to determine a reason.
 
 If the socket is being monitored by the backend thread, the following causes of disconnection can occur:
 
-* :c:enumerator:`CLOUD_DISCONNECT_CLOSED_BY_REMOTE`: The connection was closed by the cloud; POLLHUP
-* :c:enumerator:`CLOUD_DISCONNECT_INVALID_REQUEST`: The connection is no longer valid; POLLNVAL
-* :c:enumerator:`CLOUD_DISCONNECT_MISC`: Miscellaneous error; POLLERR
+* :c:enumerator:`CLOUD_DISCONNECT_CLOSED_BY_REMOTE` - The connection was closed by the cloud (POLLHUP).
+* :c:enumerator:`CLOUD_DISCONNECT_INVALID_REQUEST` - The connection is no longer valid (POLLNVAL).
+* :c:enumerator:`CLOUD_DISCONNECT_MISC` - Miscellaneous error (POLLERR).
+
+.. _nrf_cloud_api:
 
 API documentation
 *****************

--- a/include/net/nrf_cloud.rst
+++ b/include/net/nrf_cloud.rst
@@ -33,6 +33,12 @@ Connecting
 The application can use :c:func:`nrf_cloud_connect` to connect to the cloud.
 This API triggers a series of events and actions in the system.
 If the API fails, the application must retry to connect.
+If the :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` Kconfig option is enabled, an nRF Cloud library thread monitors the connection socket.
+When :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` is enabled, an additional event, :c:enumerator:`NRF_CLOUD_EVT_TRANSPORT_CONNECTING`, is sent to the application.
+The status field of :c:struct:`nrf_cloud_evt` contains connection status defined by :c:enumerator:`nrf_cloud_connect_result`.
+The event :c:enumerator:`NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED` also contains additional information in the status field, defined by :c:enumerator:`nrf_cloud_disconnect_status`.
+Additional details for :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` can be found in the Cloud API section below.
+When the poll thread option is used directly with the nRF Cloud library the enumeration values are prefixed with "NRF_".
 
 First, the library tries to establish the transport for communicating with the cloud.
 This procedure involves a TLS handshake that might take up to three seconds.

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -182,7 +182,6 @@ endmenu
 
 config NRF_CLOUD_CONNECTION_POLL_THREAD
 	bool "Poll cloud connection in a separate thread"
-	depends on CLOUD_API
 
 module=NRF_CLOUD
 module-dep=LOG

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_fsm.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_fsm.h
@@ -7,6 +7,7 @@
 #ifndef NRF_CLOUD_FSM_H__
 #define NRF_CLOUD_FSM_H__
 
+#include <stdbool.h>
 #include <net/nrf_cloud.h>
 #include "nrf_cloud_transport.h"
 
@@ -57,6 +58,13 @@ void nfsm_set_current_state_and_notify(enum nfsm_state state,
  * To be implemented by the user application.
  */
 void nfsm_disconnect(void);
+
+/**@brief Get flag which indicates if user/app requested a disconnect.
+ *
+ * @retval true  User/application requested a disconnect.
+ *         false Unexpected disconnect.
+ */
+bool nfsm_get_disconnect_requested(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -302,9 +302,14 @@ static int disconnection_handler(const struct nct_evt *nct_evt)
 	/* Set the state to INITIALIZED and notify the application of
 	 * disconnection.
 	 */
-	const struct nrf_cloud_evt evt = {
-		.type = NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED
+	struct nrf_cloud_evt evt = {
+		.type = NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED,
+		.status = NRF_CLOUD_DISCONNECT_CLOSED_BY_REMOTE,
 	};
+
+	if (nfsm_get_disconnect_requested()) {
+		evt.status = NRF_CLOUD_DISCONNECT_USER_REQUEST;
+	}
 
 	nfsm_set_current_state_and_notify(STATE_INITIALIZED, &evt);
 


### PR DESCRIPTION
Allow CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD to be used without
requiring the cloud API (CONFIG_CLOUD_API).
ref:CIA-173