### PR TITLE
openthread: Increase radio workqueue stack size for multicore devices

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -47,6 +47,11 @@ config OPENTHREAD_MBEDTLS_LIB_NAME
 	default "mbedtls_common mbedcrypto_shared mbedcrypto_oberon" if OBERON_BACKEND
 	default "mbedtls_common" if OPENTHREAD_NRF_SECURITY
 
+config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
+	int "OpenThread radio transmit workqueue stack size"
+	default 640 if NRF_802154_SER_HOST
+	default 512
+
 endmenu
 
 endif

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: cc45eb1a08ed345b1b306722f744a99b166f5f3d
+      revision: f2a69816da9ad047c40c0d2eb364e00755ec33e6
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Multicore devices like nRF5340 have radio on separate core. Radio
transmission goes through nrf_802154_serialization driver which
requires increased radio transmit workqueue stack size.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>