### PR TITLE
samples: lwm2m_client: Modem FW upgrade improvements

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
@@ -36,6 +36,8 @@ static int image_type;
 
 static struct k_delayed_work reboot_work;
 
+void client_acknowledge(void);
+
 static void reboot_work_handler(struct k_work *work)
 {
 	LOG_PANIC();
@@ -119,6 +121,8 @@ static int firmware_block_received_cb(uint16_t obj_inst_id,
 	}
 
 	if (bytes_downloaded == 0) {
+		client_acknowledge();
+
 		image_type = dfu_target_img_type(data, data_len);
 
 		ret = dfu_target_init(image_type, total_size, dfu_target_cb);

--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -58,6 +58,11 @@ static struct k_sem lwm2m_restart;
 static void rd_client_event(struct lwm2m_ctx *client,
 			    enum lwm2m_rd_client_event client_event);
 
+void client_acknowledge(void)
+{
+	lwm2m_acknowledge(&client);
+}
+
 /**@brief User interface event handler. */
 static void ui_evt_handler(struct ui_evt *evt)
 {


### PR DESCRIPTION
* Send empty ACK before initializing FOTA, to prevent needless retransmissions.
* Fix FW download, when part of the firmware is already written.