### PR TITLE
net: lib: azure_fota: Prefix APP_VERSION macro

### DIFF
--- a/subsys/net/lib/azure_fota/CMakeLists.txt
+++ b/subsys/net/lib/azure_fota/CMakeLists.txt
@@ -9,11 +9,11 @@ zephyr_library_sources(
 )
 
 find_package(Git QUIET)
-if(NOT APP_VERSION AND GIT_FOUND)
+if(NOT AZURE_FOTA_APP_VERSION AND GIT_FOUND)
   execute_process(
     COMMAND ${GIT_EXECUTABLE} describe
     WORKING_DIRECTORY                ${NRF_DIR}
-    OUTPUT_VARIABLE                  APP_VERSION
+    OUTPUT_VARIABLE                  AZURE_FOTA_APP_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_STRIP_TRAILING_WHITESPACE
     ERROR_VARIABLE                   stderr
@@ -21,15 +21,15 @@ if(NOT APP_VERSION AND GIT_FOUND)
   )
   if(return_code)
     message(STATUS "git describe failed: ${stderr};
-    APP_VERSION is left undefined")
+    AZURE_FOTA_APP_VERSION is left undefined")
   elseif(CMAKE_VERBOSE_MAKEFILE)
     message(STATUS "git describe stderr: ${stderr}")
   endif()
 endif()
 
-if(APP_VERSION)
+if(AZURE_FOTA_APP_VERSION)
   zephyr_compile_definitions(
-    APP_VERSION=${APP_VERSION}
+    AZURE_FOTA_APP_VERSION=${AZURE_FOTA_APP_VERSION}
   )
 endif()
 

--- a/subsys/net/lib/azure_fota/azure_fota.c
+++ b/subsys/net/lib/azure_fota/azure_fota.c
@@ -71,7 +71,7 @@ static char *status_str[STATUS_COUNT] = {
 
 #if IS_ENABLED(CONFIG_AZURE_FOTA_APP_VERSION_AUTO)
 static char current_version[CONFIG_AZURE_FOTA_VERSION_MAX_LEN] =
-	STRINGIFY(APP_VERSION);
+	STRINGIFY(AZURE_FOTA_APP_VERSION);
 #else
 BUILD_ASSERT(sizeof(CONFIG_AZURE_FOTA_APP_VERSION) > 1, "No app version given");
 static char current_version[CONFIG_AZURE_FOTA_VERSION_MAX_LEN] =


### PR DESCRIPTION
Add prefix to APP_VERSION macro to avoid redefinition warning
when compiling with libraries that uses the same macro name.