### PR TITLE
manifest: local ci test of mbedtls stack increase

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3420cde0e37be536cda67f293784dcc1c6a92001
+      revision: pull/421/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This is a NCS test of the impact of ZTEST_STACKSIZE increase to 8192.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>