### PR TITLE
Get recent upstream Zephyr updates for the nrf21540dk_nrf52840 board

### DIFF
--- a/subsys/mpsl/mpsl_fem.c
+++ b/subsys/mpsl/mpsl_fem.c
@@ -58,7 +58,7 @@ static void fem_pin_num_correction(uint8_t *p_gpio_pin, const char *gpio_lbl)
 static int inactive_pin_configure(uint8_t pin, const char *gpio_lbl,
 				  gpio_flags_t flags)
 {
-	const struct device *port;
+	const struct device *port = NULL;
 
 	if (gpio_lbl != NULL) {
 		port = device_get_binding(gpio_lbl);

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3420cde0e37be536cda67f293784dcc1c6a92001
+      revision: pull/422/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr revision and fix a minor issue in the mpsl_fem code.