### PR TITLE
manifest: new nrfxlib with HK requirements for OpenThread

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: e6e02cb83d238fae2f54f084858bd5e49a31afa1
+      revision: 6c6ca1ddda3549a9f5dc9df316b3a4e3a7f296fd
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Update manifest with nrfxlib including new OpenThread requirements from HomeKit.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-8609