### PR TITLE
net: download_client: Correct errno on UDP socket timeout

### DIFF
--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2019-2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
@@ -445,7 +445,8 @@ restart_and_suspend:
 			error_cause = ECONNRESET;
 
 			if (len == -1) {
-				if (errno == ETIMEDOUT) {
+				if ((errno == ETIMEDOUT) || (errno == EWOULDBLOCK) ||
+				    (errno == EAGAIN)) {
 					if (dl->proto == IPPROTO_UDP ||
 					    dl->proto == IPPROTO_DTLS_1_2) {
 						LOG_DBG("Socket timeout, resending");


### PR DESCRIPTION
BSD socket receive function return -1 when timeout caused by
SO_RCVTIMEO occurs. The value of errno is EAGAIN, EWOULDBLOCK,
or for TCP sockets EINPROGRESS.

This patch modifies download client module to detect UDP receive
timeout condition based on EAGAIN or EWOULDBLOCK errno, alongside
ETIMEDOUT already used to detect TCP connection timeout.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>