### PR TITLE
manifest: Set sdk-zephyr to PR 425

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3420cde0e37be536cda67f293784dcc1c6a92001
+      revision: pull/425/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls in kernel idle patch from [PR 425](https://github.com/nrfconnect/sdk-zephyr/pull/425).

Signed-off-by: Stephen Stauts <stephen.stauts@nordicsemi.no>