### PR TITLE
doc: typo fix config name

### DIFF
--- a/include/fw_info.h
+++ b/include/fw_info.h
@@ -383,7 +383,7 @@ typedef bool (*fw_info_ext_api_provide_t)(const struct fw_info *fwinfo,
  *
  * @details Invalidation happens by setting the @c valid value to INVALID_VAL.
  *
- * @note This function needs to have CONFIG_NRF_NVMC enabled.
+ * @note This function needs to have @option{CONFIG_NRFX_NVMC} enabled.
  *
  * @param[in]  fw_info  The info structure to invalidate.
  *                      This memory will be modified directly in flash.


### PR DESCRIPTION
Fixed typo in config name.

Signed-off-by: Chris Bittner <chris.bittner@nordicsemi.no>