### PR TITLE
applications: nrf_desktop: Support multiple USB HID instances with hid_state

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.usb_state
+++ b/applications/nrf_desktop/src/modules/Kconfig.usb_state
@@ -10,9 +10,19 @@ menu "USB state"
 
 config DESKTOP_USB_ENABLE
 	bool "Enable USB module"
-	depends on USB_DEVICE_HID
 	help
 	  Enables USB module.
+
+config DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION
+	bool "Subscribe only for predefined subset of HID reports"
+	depends on DESKTOP_USB_ENABLE
+	depends on DESKTOP_HID_STATE_ENABLE
+	help
+	  By default, every USB HID instance subscribes for all the HID reports.
+	  Enable this option to specify a subset of HID reports for every USB
+	  HID instance. The subset of HID reports must be specified in
+	  usb_state_def.h file in application configuration directory for given
+	  board and configuration.
 
 if DESKTOP_USB_ENABLE
 

--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -43,8 +43,12 @@ enum state {
 	STATE_CONNECTED_BUSY	/**< Connected, report is generated. */
 };
 
+#ifndef CONFIG_USB_HID_DEVICE_COUNT
+  #define CONFIG_USB_HID_DEVICE_COUNT	0
+#endif
+
 #define SUBSCRIBER_COUNT (IS_ENABLED(CONFIG_DESKTOP_HIDS_ENABLE) + \
-			  IS_ENABLED(CONFIG_DESKTOP_USB_ENABLE))
+			  CONFIG_USB_HID_DEVICE_COUNT)
 
 #define INPUT_REPORT_DATA_COUNT (IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_MOUSE_SUPPORT) +		\
 				 IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_KEYBOARD_SUPPORT) +	\
@@ -126,7 +130,6 @@ struct subscriber {
 struct hid_state {
 	struct report_data report_data[INPUT_REPORT_DATA_COUNT];
 	struct subscriber subscriber[SUBSCRIBER_COUNT];
-	struct subscriber *selected;
 };
 
 
@@ -463,120 +466,6 @@ static struct subscriber *get_subscriber(const void *subscriber_id)
 	return NULL;
 }
 
-static struct subscriber *get_subscriber_by_type(bool is_usb)
-{
-	for (size_t i = 0; i < ARRAY_SIZE(state.subscriber); i++) {
-		if (state.subscriber[i].id &&
-		    (state.subscriber[i].is_usb == is_usb)) {
-			return &state.subscriber[i];
-		}
-	}
-	LOG_WRN("No subscriber of type %s", (is_usb)?("USB"):("BLE"));
-	return NULL;
-}
-
-static void connect_subscriber(const void *subscriber_id, bool is_usb, uint8_t report_max)
-{
-	for (size_t i = 0; i < ARRAY_SIZE(state.subscriber); i++) {
-		if (!state.subscriber[i].id) {
-			state.subscriber[i].id = subscriber_id;
-			state.subscriber[i].is_usb = is_usb;
-			state.subscriber[i].report_max = report_max;
-			state.subscriber[i].report_cnt = 0;
-			LOG_INF("Subscriber %p connected", subscriber_id);
-
-			if (state.selected && is_usb) {
-				/* If USB is connected force disconnect report
-				 * data from the connected report states. */
-				for (size_t j = 0; j < ARRAY_SIZE(state.report_data); j++) {
-					struct report_data *rd = &state.report_data[j];
-
-					rd->linked_rs = NULL;
-					clear_report_data(rd);
-				}
-				state.selected = NULL;
-			}
-
-			if (!state.selected) {
-				state.selected = &state.subscriber[i];
-				LOG_INF("Active subscriber %p",
-					state.selected->id);
-			}
-			return;
-		}
-	}
-	LOG_WRN("Cannot connect subscriber");
-}
-
-static void disconnect_subscriber(const void *subscriber_id)
-{
-	struct subscriber *s = NULL;
-
-	for (size_t i = 0; i < ARRAY_SIZE(state.subscriber); i++) {
-		if (subscriber_id == state.subscriber[i].id) {
-			s = &state.subscriber[i];
-			break;
-		}
-	}
-
-	if (s == NULL) {
-		LOG_WRN("Subscriber %p was not connected", subscriber_id);
-		return;
-	}
-
-	if (s == state.selected) {
-		for (size_t i = 0; i < ARRAY_SIZE(s->state); i++) {
-			struct report_state *rs = &s->state[i];
-
-			/* Disconnect report data from report state. */
-			if (rs->linked_rd) {
-				struct report_data *rd = rs->linked_rd;
-
-				__ASSERT_NO_MSG((rs->report_id > 0) &&
-						(rs->report_id < REPORT_ID_COUNT));
-				__ASSERT_NO_MSG(rd->linked_rs == rs);
-
-				clear_report_data(rd);
-
-				rd->linked_rs = NULL;
-			}
-		}
-	}
-
-	memset(s, 0, sizeof(*s));
-
-	LOG_INF("Subscriber %p disconnected", subscriber_id);
-
-	if (s == state.selected) {
-
-		/* Select subscriber - USB has priority. */
-		state.selected = get_subscriber_by_type(true);
-		if (!state.selected) {
-			state.selected = get_subscriber_by_type(false);
-		}
-
-		if (!state.selected) {
-			LOG_INF("No active subscriber");
-		} else {
-			LOG_INF("Active subscriber %p", state.selected->id);
-
-			/* Route report data to subscriber report states. */
-			for (size_t i = 0; i < ARRAY_SIZE(state.selected->state); i++) {
-				struct report_state *rs = &state.selected->state[i];
-
-				if (rs->linked_rd) {
-					LOG_INF("Report data %p routed to report state %p",
-						rs->linked_rd, rs);
-					rs->linked_rd->linked_rs = rs;
-
-					/* Refresh state of the newly routed subscriber. */
-					report_send(rs->linked_rd, true, true);
-				}
-			}
-		}
-	}
-}
-
 static bool key_value_set(struct items *items, uint16_t usage_id, int16_t value)
 {
 	const uint8_t prev_item_count = items->item_count;
@@ -668,7 +557,7 @@ static void send_report_keyboard(uint8_t report_id, struct report_data *rd)
 
 	struct hid_report_event *event = new_hid_report_event(sizeof(report_id) + REPORT_SIZE_KEYBOARD_KEYS);
 
-	event->subscriber = state.selected->id;
+	event->subscriber = rd->linked_rs->subscriber->id;
 
 	event->dyndata.data[0] = report_id;
 	event->dyndata.data[2] = 0; /* Reserved byte */
@@ -756,7 +645,7 @@ static void send_report_mouse(uint8_t report_id, struct report_data *rd)
 
 	struct hid_report_event *event = new_hid_report_event(sizeof(report_id) + REPORT_SIZE_MOUSE);
 
-	event->subscriber = state.selected->id;
+	event->subscriber = rd->linked_rs->subscriber->id;
 
 	/* Convert to little-endian. */
 	uint8_t x_buff[sizeof(dx)];
@@ -823,7 +712,7 @@ static void send_report_boot_mouse(uint8_t report_id, struct report_data *rd)
 			     sizeof(button_bm);
 	struct hid_report_event *event = new_hid_report_event(report_size);
 
-	event->subscriber = state.selected->id;
+	event->subscriber = rd->linked_rs->subscriber->id;
 
 	event->dyndata.data[0] = report_id;
 	event->dyndata.data[1] = button_bm;
@@ -859,7 +748,7 @@ static void send_report_ctrl(uint8_t report_id, struct report_data *rd)
 
 	struct hid_report_event *event = new_hid_report_event(report_size);
 
-	event->subscriber = state.selected->id;
+	event->subscriber = rd->linked_rs->subscriber->id;
 
 	/* Only one item can fit in the consumer control report. */
 	__ASSERT_NO_MSG(report_size == sizeof(report_id) +
@@ -915,8 +804,6 @@ static bool report_send(struct report_data *rd, bool check_state, bool send_alwa
 	}
 
 	struct report_state *rs = rd->linked_rs;
-	__ASSERT_NO_MSG(rs->subscriber == state.selected);
-	__ASSERT_NO_MSG(state.selected);
 
 	if (!check_state || (rs->state != STATE_DISCONNECTED)) {
 		unsigned int pipeline_depth;
@@ -1035,7 +922,6 @@ static void report_issued(const void *subscriber_id, uint8_t report_id, bool err
 		if ((next_rs->state != STATE_DISCONNECTED) &&
 		    (next_rs->linked_rd->linked_rs == next_rs) &&
 		    (next_rs->cnt == 0)) {
-			__ASSERT_NO_MSG(state.selected == subscriber);
 			if (report_send(next_rs->linked_rd, false, false)) {
 				break;
 			}
@@ -1051,6 +937,39 @@ static void report_issued(const void *subscriber_id, uint8_t report_id, bool err
 			next_rs = &subscriber->state[0];
 		}
 	}
+}
+
+static int8_t get_subscriber_priority(const struct subscriber *sub)
+{
+	return (sub->is_usb) ? (1) : (0);
+}
+
+static struct report_state *find_next_report_state(const struct report_data *rd)
+{
+	struct report_state *rs_result = NULL;
+	int8_t sub_prio_result = -1;
+
+	for (size_t i = 0; i < ARRAY_SIZE(state.subscriber); i++) {
+		if (!state.subscriber[i].id) {
+			continue;
+		}
+
+		struct subscriber *sub = &state.subscriber[i];
+		int8_t sub_prio = get_subscriber_priority(sub);
+
+		for (size_t j = 0; j < ARRAY_SIZE(sub->state); j++) {
+			struct report_state *rs = &sub->state[j];
+
+			if ((rs->linked_rd == rd) &&
+			    (sub_prio_result <= sub_prio)) {
+				__ASSERT_NO_MSG(sub_prio_result != sub_prio);
+				rs_result = rs;
+				sub_prio_result = sub_prio;
+			}
+		}
+	}
+
+	return rs_result;
 }
 
 static void connect(const void *subscriber_id, uint8_t report_id)
@@ -1087,11 +1006,21 @@ static void connect(const void *subscriber_id, uint8_t report_id)
 
 	rs->linked_rd = rd;
 
-	if (state.selected == subscriber) {
-		/* Route report data to report state. */
-		if (rd->linked_rs) {
+	if (rd->linked_rs) {
+		__ASSERT_NO_MSG(rd->linked_rs != rs);
+
+		int8_t cur_sub_prio = get_subscriber_priority(rd->linked_rs->subscriber);
+		int8_t new_sub_prio = get_subscriber_priority(subscriber);
+
+		__ASSERT_NO_MSG(cur_sub_prio != new_sub_prio);
+		if (cur_sub_prio < new_sub_prio) {
 			LOG_WRN("Force report data unlink");
+			rd->linked_rs = NULL;
+			clear_report_data(rd);
 		}
+	}
+
+	if (!rd->linked_rs) {
 		rd->linked_rs = rs;
 
 		if (!eventq_is_empty(&rd->eventq)) {
@@ -1123,12 +1052,80 @@ static void disconnect(const void *subscriber_id, uint8_t report_id)
 
 	struct report_data *rd = rs->linked_rd;
 
+	rs->linked_rd = NULL;
+
 	if (rd->linked_rs == rs) {
-		rd->linked_rs = NULL;
 		clear_report_data(rd);
+		rd->linked_rs = find_next_report_state(rd);
+		__ASSERT_NO_MSG(rd->linked_rs != rs);
+
+		if (rd->linked_rs) {
+			/* Refresh state of the newly routed subscriber. */
+			report_send(rd, true, true);
+		}
+	}
+}
+
+static void connect_subscriber(const void *subscriber_id, bool is_usb, uint8_t report_max)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(state.subscriber); i++) {
+		if (!state.subscriber[i].id) {
+			state.subscriber[i].id = subscriber_id;
+			state.subscriber[i].is_usb = is_usb;
+			state.subscriber[i].report_max = report_max;
+			state.subscriber[i].report_cnt = 0;
+			LOG_INF("Subscriber %p connected", subscriber_id);
+			return;
+		}
+	}
+	LOG_WRN("Cannot connect subscriber");
+	/* Should not happen. */
+	__ASSERT_NO_MSG(false);
+}
+
+static void disconnect_subscriber(const void *subscriber_id)
+{
+	struct subscriber *s = NULL;
+
+	for (size_t i = 0; i < ARRAY_SIZE(state.subscriber); i++) {
+		if (subscriber_id == state.subscriber[i].id) {
+			s = &state.subscriber[i];
+			break;
+		}
 	}
 
-	rs->linked_rd = NULL;
+	if (s == NULL) {
+		LOG_WRN("Subscriber %p was not connected", subscriber_id);
+		return;
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(s->state); i++) {
+		struct report_state *rs = &s->state[i];
+
+		/* Disconnect report data from report state. */
+		if (rs->linked_rd) {
+			struct report_data *rd = rs->linked_rd;
+
+			__ASSERT_NO_MSG((rs->report_id > 0) &&
+					(rs->report_id < REPORT_ID_COUNT));
+			if (rd->linked_rs == rs) {
+				clear_report_data(rd);
+				rs->linked_rd = NULL;
+
+				rd->linked_rs = find_next_report_state(rd);
+				__ASSERT_NO_MSG(rd->linked_rs != rs);
+
+				if (rd->linked_rs) {
+					/* Refresh state of the newly routed subscriber. */
+					report_send(rd, true, true);
+				}
+			}
+		}
+	}
+
+	memset(s, 0, sizeof(*s));
+
+	LOG_INF("Subscriber %p disconnected", subscriber_id);
 }
 
 /**@brief Enqueue event that updates a given usage. */
@@ -1381,9 +1378,7 @@ static bool handle_ble_peer_event(const struct ble_peer_event *event)
 static bool handle_usb_hid_event(const struct usb_hid_event *event)
 {
 	if (event->enabled) {
-		if (!get_subscriber_by_type(true)) {
-			connect_subscriber(event->id, true, 1);
-		}
+		connect_subscriber(event->id, true, 1);
 	} else {
 		disconnect_subscriber(event->id);
 	}

--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -28,18 +28,30 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_DESKTOP_USB_STATE_LOG_LEVEL);
 #include "config_event.h"
 #include "power_event.h"
 
+#if CONFIG_DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION
+  #include "usb_state_def.h"
+#else
+  #if (CONFIG_DESKTOP_HID_STATE_ENABLE) && (CONFIG_USB_HID_DEVICE_COUNT > 1)
+    #error USB selective HID subscription must be enabled.
+  #endif
+#endif /* CONFIG_DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION */
+
 #define REPORT_TYPE_INPUT	0x01
 #define REPORT_TYPE_OUTPUT	0x02
 #define REPORT_TYPE_FEATURE	0x03
 
 
 #ifndef CONFIG_USB_HID_PROTOCOL_CODE
-#define CONFIG_USB_HID_PROTOCOL_CODE -1
+  #define CONFIG_USB_HID_PROTOCOL_CODE -1
 #endif
 
+#if DT_PROP(DT_NODELABEL(usbd), num_in_endpoints) < (CONFIG_USB_HID_DEVICE_COUNT + 1)
+  #error Too few USB IN Endpoints enabled. Modify dts.overlay file.
+#endif
 
 struct usb_hid_device {
 	const struct device *dev;
+	uint32_t report_bm;
 	uint8_t hid_protocol;
 	uint8_t sent_report_id;
 	bool report_enabled[REPORT_ID_COUNT];
@@ -297,7 +309,8 @@ static void broadcast_subscription_change(struct usb_hid_device *usb_hid)
 				(usb_hid->hid_protocol == HID_PROTOCOL_BOOT);
 
 	if (IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_MOUSE_SUPPORT) &&
-	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_MOUSE])) {
+	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_MOUSE]) &&
+	    (usb_hid->report_bm & BIT(REPORT_ID_MOUSE))) {
 		struct hid_report_subscription_event *event =
 			new_hid_report_subscription_event();
 
@@ -310,7 +323,8 @@ static void broadcast_subscription_change(struct usb_hid_device *usb_hid)
 		usb_hid->report_enabled[REPORT_ID_MOUSE] = new_rep_enabled;
 	}
 	if (IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_KEYBOARD_SUPPORT) &&
-	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_KEYBOARD_KEYS])) {
+	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_KEYBOARD_KEYS]) &&
+	    (usb_hid->report_bm & BIT(REPORT_ID_KEYBOARD_KEYS))) {
 		struct hid_report_subscription_event *event =
 			new_hid_report_subscription_event();
 
@@ -323,7 +337,8 @@ static void broadcast_subscription_change(struct usb_hid_device *usb_hid)
 		usb_hid->report_enabled[REPORT_ID_KEYBOARD_KEYS] = new_rep_enabled;
 	}
 	if (IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_SYSTEM_CTRL_SUPPORT) &&
-	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_SYSTEM_CTRL])) {
+	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_SYSTEM_CTRL]) &&
+	    (usb_hid->report_bm & BIT(REPORT_ID_SYSTEM_CTRL))) {
 		struct hid_report_subscription_event *event =
 			new_hid_report_subscription_event();
 
@@ -335,7 +350,8 @@ static void broadcast_subscription_change(struct usb_hid_device *usb_hid)
 		usb_hid->report_enabled[REPORT_ID_SYSTEM_CTRL] = new_rep_enabled;
 	}
 	if (IS_ENABLED(CONFIG_DESKTOP_HID_REPORT_CONSUMER_CTRL_SUPPORT) &&
-	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_CONSUMER_CTRL])) {
+	    (new_rep_enabled != usb_hid->report_enabled[REPORT_ID_CONSUMER_CTRL]) &&
+	    (usb_hid->report_bm & BIT(REPORT_ID_CONSUMER_CTRL))) {
 		struct hid_report_subscription_event *event =
 			new_hid_report_subscription_event();
 
@@ -347,7 +363,8 @@ static void broadcast_subscription_change(struct usb_hid_device *usb_hid)
 		usb_hid->report_enabled[REPORT_ID_CONSUMER_CTRL] = new_rep_enabled;
 	}
 	if (IS_ENABLED(CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE) &&
-	    (new_boot_enabled != usb_hid->report_enabled[REPORT_ID_BOOT_MOUSE])) {
+	    (new_boot_enabled != usb_hid->report_enabled[REPORT_ID_BOOT_MOUSE]) &&
+	    (usb_hid->report_bm & BIT(REPORT_ID_BOOT_MOUSE))) {
 		struct hid_report_subscription_event *event =
 			new_hid_report_subscription_event();
 
@@ -359,7 +376,8 @@ static void broadcast_subscription_change(struct usb_hid_device *usb_hid)
 		usb_hid->report_enabled[REPORT_ID_BOOT_MOUSE] = new_boot_enabled;
 	}
 	if (IS_ENABLED(CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD) &&
-	    (new_boot_enabled != usb_hid->report_enabled[REPORT_ID_BOOT_KEYBOARD])) {
+	    (new_boot_enabled != usb_hid->report_enabled[REPORT_ID_BOOT_KEYBOARD]) &&
+	    (usb_hid->report_bm & BIT(REPORT_ID_BOOT_KEYBOARD))) {
 		struct hid_report_subscription_event *event =
 			new_hid_report_subscription_event();
 
@@ -533,6 +551,37 @@ static void usb_wakeup(void)
 	}
 }
 
+static uint32_t get_report_bm(size_t hid_id)
+{
+	BUILD_ASSERT(REPORT_ID_COUNT <=
+		     sizeof(usb_hid_device[0].report_bm) * CHAR_BIT);
+#if CONFIG_DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION
+	BUILD_ASSERT(ARRAY_SIZE(usb_hid_report_bm) ==
+		     CONFIG_USB_HID_DEVICE_COUNT);
+	return usb_hid_report_bm[hid_id];
+#else
+	return UINT32_MAX;
+#endif
+}
+
+static void verify_report_bm(void)
+{
+#if defined(CONFIG_DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION) && defined(CONFIG_ASSERT)
+	/* Make sure that selected reports bitmasks are proper. */
+	uint32_t common_bitmask = 0;
+
+	for (size_t i = 0; i < CONFIG_USB_HID_DEVICE_COUNT; i++) {
+		/* USB HID instance that does not subscribe to any report
+		 * should be removed. On nRF Desktop peripheral device, given
+		 * HID report can be handled only by one USB HID instance.
+		 */
+		__ASSERT_NO_MSG(usb_hid_report_bm[i] != 0);
+		__ASSERT_NO_MSG((common_bitmask & usb_hid_report_bm[i]) == 0);
+		common_bitmask |= usb_hid_report_bm[i];
+	}
+#endif
+}
+
 static int usb_init(void)
 {
 	static const struct hid_ops hid_ops = {
@@ -541,6 +590,8 @@ static int usb_init(void)
 		.int_in_ready = report_sent_cb,
 		.protocol_change = protocol_change,
 	};
+
+	verify_report_bm();
 
 	for (size_t i = 0; i < CONFIG_USB_HID_DEVICE_COUNT; i++) {
 		char name[32];
@@ -552,6 +603,7 @@ static int usb_init(void)
 
 		usb_hid_device[i].hid_protocol = HID_PROTOCOL_REPORT;
 		usb_hid_device[i].sent_report_id = REPORT_ID_COUNT;
+		usb_hid_device[i].report_bm = get_report_bm(i);
 
 		usb_hid_register_device(usb_hid_device[i].dev, hid_report_desc,
 					hid_report_desc_size, &hid_ops);


### PR DESCRIPTION
Add support for multiple USB HID instances on nrf_desktop peripheral device.