### PR TITLE
applications: serial_lte_modem: add CONFIG for external XTAL usage

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -23,6 +23,13 @@ config SLM_NATIVE_TLS
 	bool "Use Zephyr mbedTLS"
 
 #
+# external XTAL for UART
+#
+config SLM_EXTERNAL_XTAL
+	bool "Use external XTAL for UARTE"
+	default y
+
+#
 # Inter-Connect
 #
 choice

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -115,6 +115,11 @@ Check and configure the following configuration options for the sample:
    It requires additional configuration.
    See :ref:`slm_native_tls` for more information.
 
+.. option:: CONFIG_SLM_EXTERNAL_XTAL - Use external XTAL for UARTE
+
+   This option configures the application to use an external XTAL for UARTE.
+   See the `nRF9160 Product Specification`_ (section 6.19 UARTE) for more information.
+
 .. option:: CONFIG_SLM_CONNECT_UART_0 - UART 0
 
    This option selects UART 0 for the UART connection.

--- a/applications/serial_lte_modem/prj.conf
+++ b/applications/serial_lte_modem/prj.conf
@@ -75,6 +75,8 @@ CONFIG_IMG_ERASE_PROGRESSIVELY=y
 # SLM-specific configurations
 #
 CONFIG_SLM_LOG_LEVEL_INF=y
+# Configure external XTAL for UART
+CONFIG_SLM_EXTERNAL_XTAL=n
 # Enable GPIO wakeup if sleep is expected
 #CONFIG_SLM_GPIO_WAKEUP=y
 # Use UART_0 (when working with PC terminal)

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -158,11 +158,14 @@ void handle_nrf_modem_lib_init_ret(void)
 void start_execute(void)
 {
 	int err;
+#if defined(CONFIG_SLM_EXTERNAL_XTAL)
 	struct onoff_manager *clk_mgr;
 	struct onoff_client cli = {};
+#endif
 
 	LOG_INF("Serial LTE Modem");
 
+#if defined(CONFIG_SLM_EXTERNAL_XTAL)
 	/* request external XTAL for UART */
 	clk_mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
 	sys_notify_init_spinwait(&cli.notify);
@@ -171,6 +174,7 @@ void start_execute(void)
 		LOG_ERR("Clock request failed: %d", err);
 		return;
 	}
+#endif
 
 	/* check FOTA result */
 	handle_nrf_modem_lib_init_ret();


### PR DESCRIPTION
The use of external XTAL was added in PR#3311 following spec of UARTE in PS.
Based on test, it increases power consumption when SLM is put to Idle mode.
Add CONFIG_SLM_EXTERNAL_XTAL (default 'y') to control the use of external XTAL.
Temporarily disable the usage in prj.conf so as to save power consumption.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>