### PR TITLE
Bluetooth: Mesh: Ensure light ctrl srv disengages on manual changes

### DIFF
--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -159,6 +159,11 @@ struct bt_mesh_lightness_srv {
 	uint16_t last;
 	/** Internal flag state. */
 	atomic_t flags;
+
+#if defined(CONFIG_BT_MESH_LIGHT_CTRL_SRV)
+	/** Acting controller, if enabled. */
+	struct bt_mesh_light_ctrl_srv *ctrl;
+#endif
 };
 
 /** @brief Publish the current Light state.

--- a/subsys/bluetooth/mesh/lightness_internal.h
+++ b/subsys/bluetooth/mesh/lightness_internal.h
@@ -27,8 +27,6 @@ extern "C" {
 #define LIGHTNESS_SRV_FLAG_IS_ON 0
 /** Flag for preventing startup behavior on the server */
 #define LIGHTNESS_SRV_FLAG_NO_START 1
-/** The Lightness server is being controlled by a Light Control Server */
-#define LIGHTNESS_SRV_FLAG_CONTROLLED 2
 
 enum light_repr {
 	ACTUAL,


### PR DESCRIPTION
Introduces a disable call from the Lightness Server to the Light Control
Server whenever the Lightness Server's level is changed manually.

Adds is_enabled() check before starting the delayed work timer to avoid
any moving pieces in a disabled control server.

Before this change, the light control server could potentially still be
running timers and permit state changes when disengaged.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>