### PR TITLE
scripts: ncs_commands: remove TFM from _BLOCKED_PROJECTS

### DIFF
--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -460,5 +460,4 @@ _BLOCKED_PROJECTS = set(
      'modules/hal/stm32',
      'modules/hal/ti',
      'modules/hal/xtensa',
-     'modules/tee/tfm',
      ])


### PR DESCRIPTION
~~Add SOF (Sound Open Firmware) to _BLOCKED_PROJECTS and
rename Espressif HAL.~~

Remove TFM (Trusted Firmware M) from _BLOCKED_PROJECTS since
it is used by NCS.