### PR TITLE
samples: zigbee: add FEM support

### DIFF
--- a/doc/nrf/includes/sample_fem_support.txt
+++ b/doc/nrf/includes/sample_fem_support.txt
@@ -1,0 +1,31 @@
+.. note::
+   Software FEM support is not present on nRF53 Series devices yet.
+   For now, it also cannot be combined with multiprotocol operation.
+
+You can add support for the nRF21540 front-end module to the sample.
+See :ref:`ug_radio_fem` for more information.
+
+To add support for the nRF21540 FEM, add the provided :file:`dts-nrf21540-fem.overlay` devicetree overlay file when building.
+The file is located in the |fem_file_path| folder.
+Make sure that the GPIOs in the file correspond to those in which your front-end module is connected.
+
+.. note::
+   You must add the provided overlay file if you use the nRF21540 EK.
+   If you use the nRF21540 DK, build your application for the :ref:`nrf21540dk_nrf52840 <zephyr:nrf21540dk_nrf52840>` board.
+   The devicetree for the nRF21540 DK already contains the required FEM configuration, so you do not need to add the overlay file.
+
+See :ref:`zephyr:set-devicetree-overlays` for different ways of adding the overlay file.
+
+The easiest way to add the file when building is to set it in the ``DTC_OVERLAY_FILE`` variable.
+However, doing so will override the default settings.
+For some boards, this sample requires additional overlay files, which are automatically included when building with the default settings.
+When you set the ``DTC_OVERLAY_FILE`` variable, you must specify all overlay files that are needed for building.
+Check the :file:`boards` folder to see the additional overlay files.
+
+Follow the instructions in :ref:`cmake_options` to specify the ``DTC_OVERLAY_FILE`` variable.
+For example, to build the sample from the command line for an nRF52833 DK with an attached nRF21540 EK, invoke the following command within the sample directory:
+``west build -b nrf52833dk_nrf52833 -- -DDTC_OVERLAY_FILE="boards/nrf52833dk_nrf52833.overlay;../common/dts-nrf21540-fem.overlay"``
+
+Alternatively, you can copy the contents of :file:`dts-nrf21540-fem.overlay` to the board's overlay file.
+
+To add support for other front-end modules, add the respective overlay files in the same way.

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -63,7 +63,6 @@
 .. |zigbee_shell_config| replace:: You can add support for Zigbee shell commands to any of the available :ref:`Zigbee samples <zigbee_samples>`.
    Some of the commands use an endpoint for sending packets, so no endpoint handler is allowed to be registered for this endpoint.
 
-
 .. |nrf_desktop_module_event_note| replace:: See the :ref:`nrf_desktop_architecture` for more information about the event-based communication in the nRF Desktop application and about how to read this table.
 
 .. |how_to_configure| replace:: See :ref:`configure_application` for information on how to set the required configuration options temporarily or permanently.

--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -21,7 +21,7 @@ They are also valid for cases where an application uses just one protocol, but b
 To avoid conflicts, check the protocol documentation to see if it uses FEM support provided by MPSL.
 
 Work is underway to make the protocols shipped with |NCS| use FEM.
-At the moment, :ref:`ug_thread` supports the :ref:`nrf21540 DK <nrf21540dk_nrf52840>` and the nRF21540 EK for nRF52 Series devices, but there is no multiprotocol support or support for nRF5340 yet.
+At the moment, :ref:`ug_thread` and :ref:`ug_zigbee` support the :ref:`nrf21540 DK <nrf21540dk_nrf52840>` and the nRF21540 EK for nRF52 Series devices, but there is no multiprotocol support or support for nRF5340 yet.
 
 |NCS| provides a friendly wrapper that configures FEM based on devicetree (DTS) and Kconfig information.
 To enable FEM support, you must enable FEM and MPSL, and add an ``nrf_radio_fem`` node in the devicetree file.

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -64,43 +64,12 @@ The provided configurations optimize the memory footprint of the sample for sing
 
 For more information, see :ref:`app_memory`.
 
-.. ot_cli_sample_fem_support_start
-
 FEM support
 ===========
 
-You can add support for the nRF21540 front-end module to the sample.
-See :ref:`ug_radio_fem` for more information.
+.. |fem_file_path| replace:: :file:`samples/openthread/common`
 
-To add support for the nRF21540 FEM, add the provided :file:`dts-nrf21540-fem.overlay` devicetree overlay file when building.
-The file is located in the :file:`samples/openthread/common` folder.
-Make sure that the GPIOs in the file correspond to those in which your front-end module is connected.
-
-.. note::
-   You must add the provided overlay file if you use the nRF21540 EK.
-   If you use the nRF21540 DK, build your application for the :ref:`nrf21540dk_nrf52840 <zephyr:nrf21540dk_nrf52840>` board.
-   The devicetree for the nRF21540 DK already contains the required FEM configuration, so you do not need to add the overlay file.
-
-See :ref:`zephyr:set-devicetree-overlays` for different ways of adding the overlay file.
-
-The easiest way to add the file when building is to set it in the ``DTC_OVERLAY_FILE`` variable.
-However, doing so will override the default settings.
-For some boards, this sample requires additional overlay files, which are automatically included when building with the default settings.
-When you set the ``DTC_OVERLAY_FILE`` variable, you must specify all overlay files that are needed for building.
-Check the :file:`boards` folder to see the additional overlay files.
-
-Follow the instructions in :ref:`cmake_options` to specify the ``DTC_OVERLAY_FILE`` variable.
-For example, to build the sample from the command line for an nRF52833 DK with an attached nRF21540 EK, invoke the following command within the sample directory:
-``west build -b nrf52833dk_nrf52833 -- -DDTC_OVERLAY_FILE="boards/nrf52833dk_nrf52833.overlay;../common/dts-nrf21540-fem.overlay"``
-
-Alternatively, you can copy the contents of :file:`dts-nrf21540-fem.overlay` to the board's overlay file.
-
-To add support for other front-end modules, add the respective overlay files in the same way.
-
-.. note::
-   Software FEM support is not present on nRF53 Series devices yet.
-
-.. ot_cli_sample_fem_support_end
+.. include:: /includes/sample_fem_support.txt
 
 Requirements
 ************

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -38,9 +38,12 @@ This optional extension can demonstrate the OpenThread stack and :ref:`nrfxlib:s
 It uses the :ref:`nus_service_readme` library to control the LED states over Bluetooth LE in a Thread network.
 For more information about the multiprotocol feature, see :ref:`ug_multiprotocol_support`.
 
-.. include:: ../cli/README.rst
-   :start-after: ot_cli_sample_fem_support_start
-   :end-before: ot_cli_sample_fem_support_end
+FEM support
+===========
+
+.. |fem_file_path| replace:: :file:`samples/openthread/common`
+
+.. include:: /includes/sample_fem_support.txt
 
 Requirements
 ************

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -26,9 +26,12 @@ This sample uses the native `OpenThread CoAP API`_ for communication.
 For new application development, use :ref:`Zephyr's CoAP API<zephyr:coap_sock_interface>`.
 For example usage of the Zephyr CoAp API, see the :ref:`coap_client_sample` sample.
 
-.. include:: ../cli/README.rst
-   :start-after: ot_cli_sample_fem_support_start
-   :end-before: ot_cli_sample_fem_support_end
+FEM support
+===========
+
+.. |fem_file_path| replace:: :file:`samples/openthread/common`
+
+.. include:: /includes/sample_fem_support.txt
 
 Requirements
 ************

--- a/samples/openthread/ncp/README.rst
+++ b/samples/openthread/ncp/README.rst
@@ -53,9 +53,12 @@ By default, the log levels for all modules are set to critical to not engage the
 To make the solution flexible, you can change independently the log levels for your modules, for the whole Zephyr system, and for OpenThread.
 Use the :file:`overlay-logging.conf` overlay file as reference for this purpose.
 
-.. include:: ../cli/README.rst
-   :start-after: ot_cli_sample_fem_support_start
-   :end-before: ot_cli_sample_fem_support_end
+FEM support
+===========
+
+.. |fem_file_path| replace:: :file:`samples/openthread/common`
+
+.. include:: /includes/sample_fem_support.txt
 
 Requirements
 ************

--- a/samples/zigbee/common/dts-nrf21540-fem.overlay
+++ b/samples/zigbee/common/dts-nrf21540-fem.overlay
@@ -1,0 +1,14 @@
+/* Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/ {
+    nrf_radio_fem: nrf21540_fem {
+        compatible = "nordic,nrf21540-fem";
+        tx-en-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+        rx-en-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+        pdn-gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+        ant-sel-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+    };
+};

--- a/samples/zigbee/light_bulb/README.rst
+++ b/samples/zigbee/light_bulb/README.rst
@@ -18,7 +18,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
 
 You can use one or more of the development kits listed above and mix different development kits.
 
@@ -32,6 +32,18 @@ Overview
 
 The Zigbee light bulb sample takes the Zigbee Router role and implements the Dimmable Light profile.
 This profile allows changing the brightness level of a LED of the light bulb.
+
+Configuration
+*************
+
+|config|
+
+FEM support
+===========
+
+.. |fem_file_path| replace:: :file:`samples/zigbee/common`
+
+.. include:: /includes/sample_fem_support.txt
 
 User interface
 **************

--- a/samples/zigbee/light_bulb/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/zigbee/light_bulb/boards/nrf21540dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/ {
+	chosen {
+		zephyr,entropy = &rng;
+	};
+};

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -22,7 +22,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
 
 You can use one or more of the development kits listed above and mix different development kits.
 
@@ -118,6 +118,13 @@ To activate the optional extensions supported by this sample, modify :makevar:`O
 
 See :ref:`cmake_options` for instructions on how to add this option.
 For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
+FEM support
+===========
+
+.. |fem_file_path| replace:: :file:`samples/zigbee/common`
+
+.. include:: /includes/sample_fem_support.txt
 
 .. _zigbee_light_switch_user_interface:
 

--- a/samples/zigbee/light_switch/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/zigbee/light_switch/boards/nrf21540dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/ {
+	chosen {
+		zephyr,entropy = &rng;
+	};
+};

--- a/samples/zigbee/network_coordinator/README.rst
+++ b/samples/zigbee/network_coordinator/README.rst
@@ -18,7 +18,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
 
 You can use one of the development kits listed above.
 
@@ -34,6 +34,18 @@ Overview
 
 This Zigbee network coordinator sample demonstrates the Zigbee Coordinator role.
 It is a minimal implementation that supports only the network steering commissioning mechanism.
+
+Configuration
+*************
+
+|config|
+
+FEM support
+===========
+
+.. |fem_file_path| replace:: :file:`samples/zigbee/common`
+
+.. include:: /includes/sample_fem_support.txt
 
 User interface
 **************

--- a/samples/zigbee/network_coordinator/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/zigbee/network_coordinator/boards/nrf21540dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/ {
+	chosen {
+		zephyr,entropy = &rng;
+	};
+};


### PR DESCRIPTION
This adds support for FEM in Zigbee examples. This is mainly docs
updates plus a few overlay files for nRF21540.

Signed-off-by: Wojciech Bober <wojciech.bober@nordicsemi.no>