### PR TITLE
lib: nrf_modem: socket offloading trying to translate error code 0

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -726,10 +726,13 @@ static int nrf91_socket_offload_getsockopt(void *obj, int level, int optname,
 		if (level == SOL_SOCKET) {
 			if (optname == SO_ERROR) {
 				/* Use nrf_modem_os_errno_set() to translate from nRF
-				 * error to native error.
+				 * error to native error. If there is no error,
+				 * don't translate it.
 				 */
-				nrf_modem_os_errno_set(*(int *)optval);
-				*(int *)optval = errno;
+				if (*(int *)optval != 0) {
+					nrf_modem_os_errno_set(*(int *)optval);
+					*(int *)optval = errno;
+				}
 			} else if ((optname == SO_RCVTIMEO) ||
 				(optname == SO_SNDTIMEO)) {
 				((struct timeval *)optval)->tv_sec =


### PR DESCRIPTION
When getsockopt is used with SO_ERROR and there is no error on the
socket the offloading layer will try to translate error code 0 which
will fail in an assert.

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>