### PR TITLE
net: lib: nrf_cloud: Add API to send preencoded data to nrf nrf_cloud

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -130,6 +130,7 @@ nRF9160
 
     * AWS Jobs replaced by nRF Connect for Cloud FOTA as the FOTA mechanism for devices connected to nRF Connect for Cloud.
     * Removed :option:`CONFIG_CLOUD_API` dependency from :option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD`.
+    * Added a new API :c:func:`nrf_cloud_send` that can be used for sending pre-encoded data to specified endpoint topics in nRF Connect for Cloud.
 
   * :ref:`asset_tracker` application:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -8,6 +8,7 @@
 #define NRF_CLOUD_H__
 
 #include <zephyr/types.h>
+#include <net/mqtt.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -111,6 +112,14 @@ enum nrf_cloud_sensor {
 	NRF_CLOUD_DEVICE_INFO,
 };
 
+/** @brief Topic types supported by nRF Cloud. */
+enum nrf_cloud_topic_type {
+	/** Endpoint used to update the cloud-side device shadow state . */
+	NRF_CLOUD_TOPIC_STATE = 0x1,
+	/** Endpoint used to directly message the nRF Cloud Web UI. */
+	NRF_CLOUD_TOPIC_MESSAGE,
+};
+
 /**@brief Generic encapsulation for any data that is sent to the cloud. */
 struct nrf_cloud_data {
 	/** Length of the data. */
@@ -169,6 +178,16 @@ struct nrf_cloud_evt {
 	struct nrf_cloud_data data;
 	/** Topic on which data was received. */
 	struct nrf_cloud_topic topic;
+};
+
+/**@brief Structure used to send pre-encoded data to nRF Cloud. */
+struct nrf_cloud_tx_data {
+	/** Data that is to be published. */
+	struct nrf_cloud_data data;
+	/** Endpoint topic type published to. */
+	enum nrf_cloud_topic_type topic_type;
+	/** Quality of Service of the message. */
+	enum mqtt_qos qos;
 };
 
 /**
@@ -264,6 +283,19 @@ int nrf_cloud_shadow_update(const struct nrf_cloud_sensor_data *param);
  *           Otherwise, a (negative) error code is returned.
  */
 int nrf_cloud_sensor_data_stream(const struct nrf_cloud_sensor_data *param);
+
+/**
+ * @brief Send data to nRF Cloud.
+ *
+ * This API is used to send pre-encoded data to nRF Cloud.
+ *
+ * @param[in] msg Pointer to a structure containting data and topic
+ *                information.
+ *
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int nrf_cloud_send(const struct nrf_cloud_tx_data *msg);
 
 /**
  * @brief Disconnect from the cloud.


### PR DESCRIPTION
Add API in nrf_cloud.h to send preencoded data to nRF Cloud. Prior to
this patch the only way to send data to nRF Cloud was via:

- nrf_cloud_sensor_data_stream()
- nrf_cloud_shadow_update()
- nrf_cloud_sensor_data_send()

All of these functions encodes the data before it is sent to cloud.
(Alters the payload). The new API makes it possible for the application
to send data to nRF Cloud specific endpoint types (message, state)
without the library encoding the data first.

[CIA-207]
