### PR TITLE
ci: Explicitly select junitparser==1.6.3 in compliance check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -25,7 +25,7 @@ jobs:
         pip3 install  -U setuptools
         export PATH="$HOME/.local/bin:$PATH"
         pip3 install  -U wheel
-        pip3 install  -U python-magic junitparser gitlint pylint pykwalify
+        pip3 install  -U python-magic junitparser==1.6.3 gitlint pylint pykwalify
         pip3 install --user -U west
         pip3 show -f west
 


### PR DESCRIPTION
Fixes crashes on gitlint failures. Followup to
zephyrproject-rtos/zephyr/pull/31276.

This is a long commit message line added to trigger a gitlint error. This line will be removed before merging.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>