### PR TITLE
doc: add information about setting the VDD voltage

### DIFF
--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -95,7 +95,10 @@ UART configuration:
 * Parity bit: no
 * Operation mode: IRQ
 
-Note that the GPIO output level on nRF9160 side must be 3 V.
+.. note::
+   The GPIO output level on nRF9160 side must be 3 V.
+   You can set the VDD voltage with the **VDD IO** switch (**SW9**).
+   See the `VDD supply rail section in the nRF9160 DK User Guide`_ for more information.
 
 Configuration
 *************

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -156,6 +156,7 @@
 .. _`nRF9160 DK Hardware`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/intro.html
 .. _`nRF9160 DK board control section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/board_controller.html
 .. _`Device programming section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/mcu_device_programming.html
+.. _`VDD supply rail section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/power_sources_vdd.html
 
 .. _`AT Commands Reference Guide`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/intro.html
 .. _`band lock section in the AT Commands reference document`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xbandlock.html


### PR DESCRIPTION
Add more information about how to set the required VDD
voltage on the nRF9160 DK.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>