### PR TITLE
partition_manager: Set default TFM BL2 (mcuboot) size to 32kB

### DIFF
--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -150,7 +150,7 @@ config PM_PARTITION_SIZE_TFM_RAM
 
 config PM_PARTITION_SIZE_BL2
 	hex
-	default 0x10000
+	default 0x8000
 	help
 	  Memory set aside for the BL2 partition.
 	  The prompt has been removed since the value is dictated by TFM and


### PR DESCRIPTION
The default build is 28kB so reduce the partition size to save space.

Ref: NCSDK-7662

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>