### PR TITLE
zigbee: Change the platform API

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_platform.c
+++ b/subsys/zigbee/osif/zb_nrf_platform.c
@@ -575,9 +575,9 @@ void zigbee_enable(void)
 /**
  * @brief Get the reason that triggered the last reset
  *
- * @return zb_reset_source_t
+ * @return zb_uint8_t
  * */
-zb_reset_source_t zb_get_reset_source(void)
+zb_uint8_t zb_get_reset_source(void)
 {
 	uint32_t reas;
 


### PR DESCRIPTION
Change the return type of zb_get_reset_source.

Signed-off-by: Filip Zajdel <filip.zajdel@nordicsemi.no>