### PR TITLE
spm: remove NSC function spm_firmware_info

### DIFF
--- a/include/secure_services.h
+++ b/include/secure_services.h
@@ -97,17 +97,6 @@ int spm_request_read(void *destination, uint32_t addr, size_t len);
  */
 int spm_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active);
 
-/** Search for the fw_info structure in firmware image located at address.
- *
- * @param[in]   fw_address  Address where firmware image is stored.
- * @param[out]  info        Pointer to where found info is stored.
- *
- * @retval 0        If successful.
- * @retval -EINVAL  If info is NULL.
- * @retval -EFAULT  If no info is found.
- */
-int spm_firmware_info(uint32_t fw_address, struct fw_info *info);
-
 /** Prevalidate a B1 update
  *
  * This is performed by the B0 bootloader.

--- a/samples/nrf9160/secure_services/src/main.c
+++ b/samples/nrf9160/secure_services/src/main.c
@@ -47,7 +47,6 @@ static int read_ficr_word(uint32_t *result, const volatile uint32_t *addr)
 
 void main(void)
 {
-	struct fw_info info_app;
 	const int sleep_time_s = 5;
 	const int random_number_count = 16;
 	const int random_number_len = 144;
@@ -75,13 +74,6 @@ void main(void)
 #else
 	printk("CONFIG_SPM_SERVICE_RNG is disabled.\n\n");
 #endif
-
-	ret = spm_firmware_info(PM_APP_ADDRESS, &info_app);
-	if (ret != 0) {
-		printk("Could find firmware info (err: %d)\n", ret);
-	}
-
-	printk("App FW version: %d\n\n", info_app.version);
 
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
 	const int num_bytes_to_read = PM_MCUBOOT_PAD_SIZE;

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -276,19 +276,23 @@ int fota_download_start(const char *host, const char *file, int sec_tag,
 		return err;
 	}
 #else /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
-	const struct fw_info *tmp_info;
+	const struct fw_info *s0;
+	const struct fw_info *s1;
 
-	tmp_info = fw_info_find(PM_S0_ADDRESS);
-	if (tmp_info == NULL) {
+	s0 = fw_info_find(PM_S0_ADDRESS);
+	if (s0 == NULL) {
 		return -EFAULT;
 	}
-	memcpy(&s0, tmp_info, sizeof(s0));
 
-	tmp_info = fw_info_find(PM_S1_ADDRESS);
-	if (tmp_info == NULL) {
-		return -EFAULT;
+	s1 = fw_info_find(PM_S1_ADDRESS);
+	if (s1 == NULL) {
+		/* No s1 found, s0 is active */
+		s0_active = true;
+	} else {
+		/* Both s0 and s1 found, check who is active */
+		s0_active = s0->version >= s1->version;
 	}
-	memcpy(&s1, tmp_info, sizeof(s1));
+
 #endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
 
 	err = dfu_ctx_mcuboot_set_b1_file(file, s0_active, &update);

--- a/subsys/nonsecure/secure_services_ns.c
+++ b/subsys/nonsecure/secure_services_ns.c
@@ -31,10 +31,6 @@ NRF_NSE(int, spm_request_random_number, uint8_t *output, size_t len,
 NRF_NSE(int, spm_request_read, void *destination, uint32_t addr, size_t len);
 #endif /* CONFIG_SPM_SERVICE_READ */
 
-#ifdef CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO
-NRF_NSE(int, spm_firmware_info, uint32_t fw_address, struct fw_info *info);
-#endif /* CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO */
-
 #ifdef CONFIG_SPM_SERVICE_PREVALIDATE
 NRF_NSE(int, spm_prevalidate_b1_upgrade, uint32_t dst_addr, uint32_t src_addr);
 #endif /* CONFIG_SPM_SERVICE_PREVALIDATE */

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -100,14 +100,6 @@ config SPM_SERVICE_REBOOT
 	  service will allow it to issue a request to do a system reset through
 	  a secure service.
 
-config SPM_SERVICE_FIND_FIRMWARE_INFO
-	bool "Find firmware info"
-	default y if SPM
-	help
-	  The Non-Secure Firmware is not allowed to read the memory
-	  marked as secure. This service allows it to request firmware info
-	  about image stored at a given address.
-
 config SPM_SERVICE_S0_ACTIVE
 	bool "Enable secure service to check if S0 is active B1 slot"
 	default y

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -154,27 +154,6 @@ int spm_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active)
 }
 #endif /* CONFIG_SPM_SERVICE_S0_ACTIVE */
 
-#ifdef CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO
-__TZ_NONSECURE_ENTRY_FUNC
-int spm_firmware_info_nse(uint32_t fw_address, struct fw_info *info)
-{
-	const struct fw_info *tmp_info;
-
-	if (info == NULL) {
-		return -EINVAL;
-	}
-
-	tmp_info = fw_info_find(fw_address);
-
-	if (tmp_info != NULL) {
-		memcpy(info, tmp_info, sizeof(*tmp_info));
-		return 0;
-	}
-
-	return -EFAULT;
-}
-#endif /* CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO */
-
 
 #ifdef CONFIG_SPM_SERVICE_PREVALIDATE
 __TZ_NONSECURE_ENTRY_FUNC

--- a/tests/subsys/net/lib/fota_download/CMakeLists.txt
+++ b/tests/subsys/net/lib/fota_download/CMakeLists.txt
@@ -24,16 +24,22 @@ target_include_directories(app
   . # To get 'pm_config.h'
   )
 
+if (NOT CONFIG_TRUSTED_EXECUTION_NONSECURE)
+  # If non secure then fw_info will be pulled in automatically.
+  set(info_magic "-DFIRMWARE_INFO_MAGIC=0xbabababa,0xbabababa,0xbabababa")
+  set(ext_api_magic "-DEXT_API_MAGIC=0xdededede")
+endif()
+
 target_compile_options(app
   PRIVATE
   -DCONFIG_DOWNLOAD_CLIENT_BUF_SIZE=500
   -DCONFIG_DOWNLOAD_CLIENT_STACK_SIZE=500
   -DCONFIG_FW_MAGIC_LEN=32
-  -DFIRMWARE_INFO_MAGIC=0xbabababa,0xbabababa,0xbabababa
   -DABI_INFO_MAGIC=0xdededede
-  -DEXT_API_MAGIC=0xdededede
   -DCONFIG_FW_FIRMWARE_INFO_OFFSET=0x200
   -DCONFIG_FOTA_DOWNLOAD_LOG_LEVEL=2
   -DCONFIG_FOTA_SOCKET_RETRIES=2
   -DCONFIG_FW_INFO_MAGIC_LEN=12
+  ${info_magic}
+  ${ext_api_magic}
   )

--- a/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160.conf
+++ b/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160ns.conf
+++ b/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160ns.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# Disable this since we write our own mock for 'spm_s0_active()'
+CONFIG_SPM_SECURE_SERVICES=n

--- a/tests/subsys/net/lib/fota_download/boards/qemu_x86.conf
+++ b/tests/subsys/net/lib/fota_download/boards/qemu_x86.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_FLASH_SIMULATOR=y
+CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y

--- a/tests/subsys/net/lib/fota_download/pm_config.h
+++ b/tests/subsys/net/lib/fota_download/pm_config.h
@@ -7,6 +7,6 @@
 /* generated file copied to simplify building the test */
 #ifndef PM_CONFIG_H__
 #define PM_CONFIG_H__
-#define PM_S0_ADDRESS 0x8000
-#define PM_S1_ADDRESS 0x15000
+#define PM_S0_ADDRESS 0x10000
+#define PM_S1_ADDRESS 0x20000
 #endif /* PM_CONFIG_H__ */

--- a/tests/subsys/net/lib/fota_download/prj.conf
+++ b/tests/subsys/net/lib/fota_download/prj.conf
@@ -4,3 +4,4 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 CONFIG_ZTEST=y
+CONFIG_FLASH=y

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -28,10 +28,9 @@ char buf[1024];
 
 /* Stubs and mocks */
 bool dfu_ctx_mcuboot_set_b1_file__s0_active;
-static uint32_t s0_version;
-static uint32_t s1_version;
 const char *download_client_start_file;
 char *dfu_ctx_mcuboot_set_b1_file__update;
+static bool spm_s0_active_retval;
 
 int dfu_target_init(int img_type, size_t file_size)
 {
@@ -86,21 +85,6 @@ int download_client_init(struct download_client *client,
 	return 0;
 }
 
-int spm_firmware_info(uint32_t fw_address, struct fw_info *info)
-{
-	zassert_true(info != NULL, NULL);
-
-	if (fw_address == PM_S0_ADDRESS) {
-		info->version = s0_version;
-	} else if (fw_address == PM_S1_ADDRESS) {
-		info->version = s1_version;
-	} else {
-		zassert_true(false, "Unexpected address");
-	}
-
-	return 0;
-}
-
 int download_client_connect(struct download_client *client, const char *host,
 			    const struct download_client_cfg *config)
 {
@@ -116,7 +100,80 @@ int dfu_ctx_mcuboot_set_b1_file(char *file, bool s0_active, char **update)
 
 /* END stubs and mocks */
 
-void client_callback(const struct fota_download_evt *evt) { }
+#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
+
+int spm_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active)
+{
+	*s0_active = spm_s0_active_retval;
+
+	return 0;
+}
+
+void set_s0_active(bool s0_active)
+{
+	spm_s0_active_retval = s0_active;
+}
+#else /* ! CONFIG_TRUSTED_EXECUTION_NONSECURE */
+
+/* The test is _NOT_ executed as non-secure. Hence 'spm_s0_active' will not
+ * be called. This means that we cannot create a mock of that function to
+ * modify whether or not S0 should be considered the active B1 slot.
+ *
+ * To solve this issue, we perform flash write operations to the locations
+ * where 'fw_info.h' will look for the S0 and S1 metadata. This allows
+ * us to dictate what B1 slot should be considered active
+ */
+#include <zephyr.h>
+#include <drivers/flash.h>
+#include <nrfx_nvmc.h>
+#include <device.h>
+
+#define FLASH_NAME DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
+
+static const struct device *fdev;
+void set_s0_active(bool s0_active)
+{
+	int err;
+	struct fw_info s0_info = { .magic = { FIRMWARE_INFO_MAGIC } };
+	struct fw_info s1_info = { .magic = { FIRMWARE_INFO_MAGIC } };
+
+	spm_s0_active_retval = s0_active;
+
+	s1_info.version = 1;
+	if (s0_active) {
+		s0_info.version = s1_info.version + 1;
+	} else {
+		s0_info.version = s1_info.version - 1;
+	}
+
+	fdev = device_get_binding(FLASH_NAME);
+	zassert_not_equal(fdev, 0, "Unable to get fdev");
+
+	err = flash_erase(fdev, PM_S0_ADDRESS, nrfx_nvmc_flash_page_size_get());
+	zassert_equal(err, 0, "flash_erase failed");
+
+	err = flash_erase(fdev, PM_S1_ADDRESS, nrfx_nvmc_flash_page_size_get());
+	zassert_equal(err, 0, "flash_erase failed");
+
+	err = flash_write_protection_set(fdev, false);
+	zassert_equal(err, 0, "Disabling flash protection failed");
+
+	err = flash_write(fdev, PM_S0_ADDRESS, (void *)&s0_info,
+			  sizeof(s0_info));
+	zassert_equal(err, 0, "Unable to write to flash");
+
+	err = flash_write(fdev, PM_S1_ADDRESS, (void *)&s1_info,
+			  sizeof(s1_info));
+	zassert_equal(err, 0, "Unable to write to flash");
+
+	err = flash_write_protection_set(fdev, true);
+	zassert_equal(err, 0, "Enabling flash protection failed");
+}
+#endif
+
+void client_callback(const struct fota_download_evt *evt)
+{
+}
 
 static void init(void)
 {
@@ -129,28 +186,22 @@ static void init(void)
 static void test_fota_download_start(void)
 {
 	int err;
-	bool expect_s0_active = false;
 
 	init();
 
 	/* Verify that correct argument for s0_active is given */
-	s0_version = 0;
-	s1_version = 1;
-	expect_s0_active = false;
+	set_s0_active(false);
 	strcpy(buf, S0_S1);
 	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
-	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
-		      "Incorrect param for s0_active");
+	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active,
+		      spm_s0_active_retval, "Incorrect param for s0_active");
 
-	s0_version = 2;
-	s1_version = 1;
-	expect_s0_active = true;
+	set_s0_active(true);
 	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
-	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
-		      "Incorrect param for s0_active");
-
+	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active,
+		      spm_s0_active_retval, "Incorrect param for s0_active");
 
 	/* Next, verify that the update path given by mcuboot_set_b1_file
 	 * is used correctly.
@@ -174,8 +225,7 @@ static void test_fota_download_start(void)
 void test_main(void)
 {
 	ztest_test_suite(lib_fota_download_test,
-	     ztest_unit_test(test_fota_download_start)
-	 );
+			 ztest_unit_test(test_fota_download_start));
 
 	ztest_run_test_suite(lib_fota_download_test);
 }

--- a/tests/subsys/net/lib/fota_download/testcase.yaml
+++ b/tests/subsys/net/lib/fota_download/testcase.yaml
@@ -1,5 +1,8 @@
 tests:
   net.lib.fota_download:
     tags: aws fota
+    platform_allow: nrf9160dk_nrf9160 nrf9160dk_nrf9160ns
+  net.lib.fota_download_build_only:
+    tags: aws fota
     build_only: true
-    platform_allow: nrf9160dk_nrf9160
+    platform_allow: qemu_x86


### PR DESCRIPTION
This function is no longer needed after the
introduction of 'spm_s0_active'

Ref: NCSDK-7883

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>