### PR TITLE
zigbee: Align zb_get_reset_source API

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_platform.c
+++ b/subsys/zigbee/osif/zb_nrf_platform.c
@@ -575,9 +575,9 @@ void zigbee_enable(void)
 /**
  * @brief Get the reason that triggered the last reset
  *
- * @return zb_reset_source_t
+ * @return @ref reset_source
  * */
-zb_reset_source_t zb_get_reset_source(void)
+zb_uint8_t zb_get_reset_source(void)
 {
 	uint32_t reas;
 

--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: f83fb7180c1ea50c5b719708802c2d79e14481b0
+      revision: 2198a0984daeece7adc4b2bea2f1863463e16285
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
The enum type has been changed to the series of defines.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>