### PR TITLE
drivers/mpsl/flash_synch: FTPAN-242 workaround

### DIFF
--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -72,6 +72,7 @@ static void reschedule_next_timeslot(void)
 static mpsl_timeslot_signal_return_param_t *
 timeslot_callback(mpsl_timeslot_session_id_t session_id, uint32_t signal)
 {
+	int rc;
 	__ASSERT_NO_MSG(session_id == _context.session_id);
 
 	if (atomic_get(&_context.timeout_occured)) {
@@ -80,9 +81,9 @@ timeslot_callback(mpsl_timeslot_session_id_t session_id, uint32_t signal)
 
 	switch (signal) {
 	case MPSL_TIMESLOT_SIGNAL_START:
-		if (_context.op_desc->handler(_context.op_desc->context) ==
-		    FLASH_OP_DONE) {
-			_context.status = 0;
+		rc = _context.op_desc->handler(_context.op_desc->context);
+		if (rc != FLASH_OP_ONGOING) {
+			_context.status = (rc == FLASH_OP_DONE) ? 0 : rc;
 			_context.return_param.callback_action =
 				MPSL_TIMESLOT_SIGNAL_ACTION_END;
 		} else {

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 60a9e7c8b2836d4bf367b119835ea60688f0b5fe
+      revision: pull/426/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
- support in-progress abort of flash operation
- introduces https://github.com/nrfconnect/sdk-zephyr/pull/426