### PR TITLE
doc: fix usage of board/development kit/build target

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -7,7 +7,7 @@ nRF9160: Asset Tracker
    :local:
    :depth: 2
 
-The Asset Tracker demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160-based board to the `nRF Connect for Cloud`_ via LTE, transmit GPS and sensor data, and retrieve information about the device.
+The Asset Tracker demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160-based kit to the `nRF Connect for Cloud`_ via LTE, transmit GPS and sensor data, and retrieve information about the device.
 
 
 Overview
@@ -47,7 +47,7 @@ The collected data includes the GPS position, accelerometer readings (the device
 
 On the nRF9160 DK, the application uses simulated sensor data by default, but it can be configured with Kconfig options to use real sensors to collect data.
 On the Thingy:91, onboard sensors are used by default.
-GPS is enabled by default on both the boards.
+GPS is enabled by default on both the kits.
 
 In addition to the sensor data, the application retrieves information from the LTE modem, such as the signal strength, battery voltage, and current operator.
 This information is available in nRF Connect for Cloud under the section **Cellular Link Monitor**.
@@ -114,7 +114,7 @@ Button 1 (SW3 on Thingy:91):
     * Enable or disable GPS operation (long press the button for a minimum of 10 seconds).
 
 Switch 1 (only on nRF9160 DK):
-    * Toggle to simulate orientation change (flipping) of the board.
+    * Toggle to simulate orientation change (flipping) of the kit.
 
 Switch 2 (only on nRF9160 DK):
     * Set power optimization mode, see :ref:`power_opt`.
@@ -209,13 +209,13 @@ The overlay can be found in :file:`mcuboot_overlay-rsa.conf`.
 Testing
 =======
 
-After programming the application and all prerequisites to your board, test the Asset Tracker application by performing the following steps:
+After programming the application and all prerequisites to your kit, test the Asset Tracker application by performing the following steps:
 
-1. Connect the board to the computer using a USB cable.
-   The board is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
-#. Connect to the board with a terminal emulator, for example, LTE Link Monitor.
-#. Reset the board.
-#. Observe in the terminal window that the board starts up in the Secure Partition Manager and that the application starts.
+1. Connect the kit to the computer using a USB cable.
+   The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
+#. Connect to the kit with a terminal emulator, for example, LTE Link Monitor.
+#. Reset the kit.
+#. Observe in the terminal window that the kit starts up in the Secure Partition Manager and that the application starts.
    This is indicated by output similar to the following lines::
 
       SPM: prepare to jump to Non-Secure image
@@ -234,10 +234,10 @@ After programming the application and all prerequisites to your board, test the 
       The device must be power-cycled to restart the association procedure.
 #. Observe that the LED(s) indicate that the connection is established.
 #. Observe that the device count on your nRF Connect for Cloud dashboard is incremented by one.
-#. Select the device from your device list on nRF Connect for Cloud, and observe that sensor data and modem information is received from the board.
+#. Select the device from your device list on nRF Connect for Cloud, and observe that sensor data and modem information is received from the kit.
 #. Press Button 1 (SW3 on Thingy:91) to send BUTTON data to nRF Connect for Cloud.
 #. Press Button 1 (SW3 on Thingy:91) for a minimum of 10 seconds to enable GPS tracking.
-   The board must be outdoors in clear space for a few minutes to get the first position fix.
+   The kit must be outdoors in clear space for a few minutes to get the first position fix.
 #. Optionally send AT commands from the terminal, and observe that the response is received.
 
 

--- a/applications/connectivity_bridge/README.rst
+++ b/applications/connectivity_bridge/README.rst
@@ -75,11 +75,11 @@ The overlay can be found in :file:`mcuboot_overlay-rsa.conf`.
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your kit, test it by performing the following steps:
 
-1. Connect the board to the host via a USB cable.
+1. Connect the kit to the host via a USB cable.
 #. Observe that the CDC ACM devices enumerate on the USB host (COM ports on Windows, /dev/tty* on Linux).
-#. Use a serial client on the USB host to communicate over the board's UART pins.
+#. Use a serial client on the USB host to communicate over the kit's UART pins.
 
 
 Dependencies

--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -323,7 +323,7 @@ For example, if the ``ZDebugWithShell`` build type is not supported on the selec
   Configuration file for build type ZDebugWithShell is missing.
 
 In addition to the build types mentioned above, some boards can provide more build types, which can be used to generate an application in a specific variant.
-For example, such additional configurations are used to allow generation of application with different role (such as mouse, keyboard, or dongle on a DK board) or to select a different link layer (such as LLPM capable Nordic SoftDevice LL or standard Zephyr SW LL).
+For example, such additional configurations are used to allow generation of application with different role (such as mouse, keyboard, or dongle on a DK) or to select a different link layer (such as LLPM capable Nordic SoftDevice LL or standard Zephyr SW LL).
 
 See :ref:`nrf_desktop_porting_guide` for detailed information about the application configuration and how to create build type files for your hardware.
 

--- a/applications/serial_lte_modem/doc/slm_testing.rst
+++ b/applications/serial_lte_modem/doc/slm_testing.rst
@@ -55,7 +55,7 @@ Complete the following steps to test the functionality provided by the :ref:`SLM
       *[...]*
       OK
 
-#. Check the supported values for the sleep command, then put the board in sleep mode.
+#. Check the supported values for the sleep command, then put the kit in sleep mode.
 
    .. parsed-literal::
       :class: highlight
@@ -66,7 +66,7 @@ Complete the following steps to test the functionality provided by the :ref:`SLM
 
       **AT#XSLEEP=1**
 
-   Reset the board to exit sleep mode.
+   Reset the kit to exit sleep mode.
    If you are testing with an external MCU and :option:`CONFIG_SLM_GPIO_WAKEUP` is enabled, you can wake up by GPIO as well.
 
 

--- a/doc/nrf/doc_styleguide.rst
+++ b/doc/nrf/doc_styleguide.rst
@@ -321,7 +321,7 @@ For example, Button 1, Switch 3, LED 1.
 
 If you are referring to a generic PCB element, do *not* use capitalization: *button*, *switch*, *LEDs*.
 
-If you want to provide the short name of a specific PCB element as printed on the board, write it in bold and follow the spelling and capitalization from the board: **Button 1**, **SW3**, **LED1**.
+If you want to provide the short name of a specific PCB element as printed on the kit, write it in bold and follow the spelling and capitalization from the kit: **Button 1**, **SW3**, **LED1**.
 
 .. note::
    Use bold for button elements only when you are using the short names for other PCB elements in your document.

--- a/doc/nrf/getting_started.rst
+++ b/doc/nrf/getting_started.rst
@@ -9,7 +9,7 @@ Alternatively, check the :ref:`gs_installing` section for instructions on settin
 We recommend using SEGGER Embedded Studio for building your applications. See :ref:`gs_programming` for the download links and instructions.
 
 Once you are set up, check out the :ref:`samples`.
-If this is the first time you work with embedded devices, it is probably a good idea to program an unchanged sample to your board first and test if it works as expected.
+If this is the first time you work with embedded devices, it is probably a good idea to program an unchanged sample to your development kit first and test if it works as expected.
 After that, pick a sample that is related to the application you want to create and start developing!
 
 .. toctree::

--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -690,5 +690,5 @@ Define the required environment variables as follows, depending on your operatin
       This file is loaded automatically when you run the above command.
 
 You must also make sure that nrfjprog (part of the `nRF Command Line Tools`_) is installed and its path is added to the environment variables.
-The west command programs the board by using nrfjprog by default.
-For more information on nrfjprog, see `programming development boards using nrfjprog <Programming DK boards using nrfjprog_>`_.
+The west command programs the kit by using nrfjprog by default.
+For more information on nrfjprog, see `Programming SoCs with nrfjprog`_.

--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -238,7 +238,7 @@ To select the build type when building the application from command line, specif
 
    -- -DCMAKE_BUILD_TYPE=\ *selected_build_type*\
 
-For example, you can replace the *selected_build_type* variable to build the ``ZRelease`` firmware for the PCA20041 board by running the following command in the project directory:
+For example, you can replace the *selected_build_type* variable to build the ``ZRelease`` firmware for PCA20041 by running the following command in the project directory:
 
 .. parsed-literal::
    :class: highlight

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -100,7 +100,7 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
    .. imp_note_nrf91_start
 
    .. important::
-      If you are working with an nRF9160 DK, make sure to select the correct controller before you program the application to your board.
+      If you are working with an nRF9160 DK, make sure to select the correct controller before you program the application to your development kit.
 
       Put the **SW5** switch (marked debug/prog) in the **NRF91** position to program the main controller, or in the **NRF52** position to program the board controller.
       See the `Device programming section in the nRF9160 DK User Guide`_ for more information.
@@ -111,7 +111,7 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
       a. Select your project in the Project Explorer.
       #. From the menu, select :guilabel:`Build` -> :guilabel:`Build Solution`.
-      #. When the build completes, you can program the sample to a connected board:
+      #. When the build completes, you can program the sample to a connected development kit:
 
          * For a single-image application, select :guilabel:`Target` -> :guilabel:`Download zephyr/zephyr.elf`.
          * For a multi-image application, select :guilabel:`Target` -> :guilabel:`Download zephyr/merged.hex`.
@@ -149,19 +149,19 @@ Complete the following steps to build |NCS| projects on the command line after c
 
 
 #.    Build the sample or application using the west command.
-      The development board is specified by the parameter *board_name* in the west command as follows:
+      The build target is specified by the parameter *build_target* in the west command as follows:
 
       .. parsed-literal::
          :class: highlight
 
-         west build -b *board_name*
+         west build -b *build_target*
 
       .. note::
 
 	     To build from a directory other than the application directory, run the west build command with an additional parameter *directory_name*,  specifying the application directory.
 
-      See :ref:`gs_programming_board_names` for more information on the development boards.
-      To reuse an existing build directory for building another application for another board, pass ``-p=auto`` to ``west build``.
+      See :ref:`gs_programming_board_names` for more information on the supported boards and build targets.
+      To reuse an existing build directory for building another application for another board or build target, pass ``-p=auto`` to ``west build``.
 
       If you want to configure your application, run the following west command:
 
@@ -178,24 +178,24 @@ Complete the following steps to build |NCS| projects on the command line after c
          :start-after: .. imp_note_nrf91_start
          :end-before: .. imp_note_nrf91_end
 
-#.    Connect the development board to your PC using a USB cable.
-#.    Power on the development board.
-#.    Program the sample or application to the board using the following command:
+#.    Connect the development kit to your PC using a USB cable.
+#.    Power on the development kit.
+#.    Program the sample or application to the kit using the following command:
 
       .. code-block:: console
 
          west flash
 
       This command clears only the flash memory pages that are overwritten with the new application.
-      If the application depends on other flash areas (for example, if it uses the :ref:`zephyr:settings_api` partition), erase the full board before programming to ensure that these areas are updated with the new content.
-      If you do not fully erase the board, the old data in these areas will be retained.
+      If the application depends on other flash areas (for example, if it uses the :ref:`zephyr:settings_api` partition), erase the full kit before programming to ensure that these areas are updated with the new content.
+      If you do not fully erase the kit, the old data in these areas will be retained.
 
-      To fully erase the board before programming the new application, use the following command:
+      To fully erase the kit before programming the new application, use the following command:
 
       .. code-block:: console
 
          west flash --erase
 
-      The ``west flash`` command automatically resets the board and starts the application.
+      The ``west flash`` command automatically resets the kit and starts the application.
 
 For more information on building and programming using the command line, see the Zephyr documentation on :ref:`zephyr:west-build-flash-debug`.

--- a/doc/nrf/gs_testing.rst
+++ b/doc/nrf/gs_testing.rst
@@ -17,7 +17,7 @@ See the user interface section of the sample documentation for description of th
 How to connect with PuTTY
 *************************
 
-To see the UART output, connect to the board with a terminal emulator, for example, PuTTY.
+To see the UART output, connect to the development kit with a terminal emulator, for example, PuTTY.
 
 Connect with the following settings:
 
@@ -83,10 +83,10 @@ To run RTT on your platform, complete the following steps:
 How to connect with LTE Link Monitor
 ************************************
 
-To connect to nRF9160-based boards (for example, the nRF9160 DK or Nordic Thingy:91), you can also use `LTE Link Monitor`_, which is implemented in `nRF Connect for Desktop`_.
+To connect to nRF9160-based kits (for example, the nRF9160 DK or Nordic Thingy:91), you can also use `LTE Link Monitor`_, which is implemented in `nRF Connect for Desktop`_.
 This application is used to establish LTE communication with the nRF9160 modem through AT commands, and it also displays the UART output.
 
-To connect to the nRF9160-based board with LTE Link Monitor, perform the following steps:
+To connect to the nRF9160-based kit with LTE Link Monitor, perform the following steps:
 
 1. Launch the LTE Link Monitor app.
 
@@ -94,10 +94,10 @@ To connect to the nRF9160-based board with LTE Link Monitor, perform the followi
 
       Make sure that **Automatic requests** is enabled in LTE Link Monitor.
 
-#. Connect the nRF9160-based board to the PC with a USB cable.
-#. Power on the nRF9160-based board.
-#. Click :guilabel:`Select Device` and select the particular board entry from the drop-down list in the LTE Link Monitor.
-#. Observe that the LTE Link monitor app starts AT communication with the modem of the nRF9160-based board and shows the status of the communication in the display terminal.
+#. Connect the nRF9160-based kit to the PC with a USB cable.
+#. Power on the nRF9160-based kit.
+#. Click :guilabel:`Select Device` and select the particular kit entry from the drop-down list in the LTE Link Monitor.
+#. Observe that the LTE Link monitor app starts AT communication with the modem of the nRF9160-based kit and shows the status of the communication in the display terminal.
    The app also displays any information that is logged on UART.
 
    .. note::

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -88,7 +88,7 @@ NCSDK-6689: High current consumption in Asset Tracker
 
 Sending data before connecting to nRF Connect for Cloud
   The :ref:`asset_tracker` application does not wait for connection to nRF Connect for Cloud before trying to send data.
-  This causes the application to crash if the user toggles one of the switches before the board is connected to the cloud.
+  This causes the application to crash if the user toggles one of the switches before the kit is connected to the cloud.
 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
 
@@ -343,9 +343,9 @@ NCSDK-5711: High-throughput transmission can deadlock the receive thread
 .. rst-class:: v1-2-1 v1-2-0
 
 Only secure applications can use Bluetooth LE
-  Bluetooth LE cannot be used in a non-secure application, for example, an application built for the ``nrf5340_dk_nrf5340_cpuappns`` board.
+  Bluetooth LE cannot be used in a non-secure application, for example, an application built for the ``nrf5340_dk_nrf5340_cpuappns`` build target.
 
-  **Workaround:** Use the ``nrf5340_dk_nrf5340_cpuapp`` board instead.
+  **Workaround:** Use the ``nrf5340_dk_nrf5340_cpuapp`` build target instead.
 
 .. rst-class:: v1-2-1 v1-2-0
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -191,7 +191,7 @@
 .. _`nRF21540`: https://infocenter.nordicsemi.com/topic/struct_fem/struct/nrf21540.html
 .. _`nRF21540 Product Specification`: https://infocenter.nordicsemi.com/topic/struct_fem/struct/nrf21540_ps.html
 
-.. _`Programming DK boards using nrfjprog`: https://infocenter.nordicsemi.com/topic/ug_nrf5x_cltools/UG/cltools/nrf5x_nrfjprogexe.html
+.. _`Programming SoCs with nrfjprog`: https://infocenter.nordicsemi.com/topic/ug_nrf_cltools/UG/cltools/nrf_nrfjprogexe.html
 
 .. _`Nordic Thingy:91 User Guide`: https://infocenter.nordicsemi.com/topic/ug_thingy91/UG/thingy91/intro/frontpage.html
 

--- a/doc/nrf/templates/sample_README.rst
+++ b/doc/nrf/templates/sample_README.rst
@@ -33,7 +33,7 @@ Requirements
 
 .. note::
    * Supported kits are listed in a table, which is composed of rows from the :file:`doc/nrf/includes/sample_board_rows.txt` file.
-     Select the required rows in the ``:rows:`` configuration, or specify ``:sample-yaml-rows:`` to include all boards specified in the :file:`sample.yaml` file.
+     Select the required rows in the ``:rows:`` configuration, or specify ``:sample-yaml-rows:`` to include all build targets specified in the :file:`sample.yaml` file.
    * If only one kit is supported, replace the introduction text with "The sample supports the following development kit:".
    * If several kits are required to test the sample, state it after the table (for example, "You can use one or more of the development kits listed above and mix different development kits.").
    * Mention additional requirements after the table.

--- a/doc/nrf/ug_bt_mesh_vendor_model_chat_sample_walk_through.rst
+++ b/doc/nrf/ug_bt_mesh_vendor_model_chat_sample_walk_through.rst
@@ -47,7 +47,7 @@ The model implements the :c:member:`bt_mesh_model_cb.start` handler to notify a 
    :start-after: include_startingpoint_chat_cli_rst_5
    :end-before: include_endpoint_chat_cli_rst_5
 
-The presence value of the model needs to be stored in the persistent storage, so it can be restored at the board reboot.
+The presence value of the model needs to be stored in the persistent storage, so it can be restored at the kit reboot.
 The :c:func:`bt_mesh_model_data_store` function is called to store the presence value:
 
 .. literalinclude:: ../../samples/bluetooth/mesh/chat/src/chat_cli.c

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -281,21 +281,21 @@ You can use the CMake environment variables `VERBOSE`_ and `CMAKE_BUILD_PARALLEL
 
 When using |SES|, you must set these environment variables before starting SES, and they will apply only to the build of the child images.
 On the command line, you must set them before invoking ``west``, and they will apply to both the parent image and the child images.
-For example, to build with verbose output and one parallel job, use the following commands (where *devkit_name* is the name of the development kit for which you are building):
+For example, to build with verbose output and one parallel job, use the following commands (where *build_target* is the target for the board for which you are building):
 
 * Linux/macOS:
 
      .. parsed-literal::
         :class: highlight
 
-        $ VERBOSE=True CMAKE_BUILD_PARALLEL_LEVEL=1 west build -b *devkit_name*
+        $ VERBOSE=True CMAKE_BUILD_PARALLEL_LEVEL=1 west build -b *build_target*
 
 * Windows:
 
      .. parsed-literal::
         :class: highlight
 
-        > set VERBOSE=True && set CMAKE_BUILD_PARALLEL_LEVEL=1 && west build -b *devkit_name*
+        > set VERBOSE=True && set CMAKE_BUILD_PARALLEL_LEVEL=1 && west build -b *build_target*
 
 Memory placement
 ****************

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -72,7 +72,7 @@ In Zephyr, :ref:`zephyr:nrf5340dk_nrf5340` is divided into two different build t
 * ``nrf5340dk_nrf5340_cpuapp`` for the secure domain
 * ``nrf5340dk_nrf5340_cpuappns`` for the non-secure domain
 
-When built for the ``nrf5340dk_nrf5340_cpuappns`` board, the :ref:`secure_partition_manager` sample is automatically included in the build.
+When built for the ``nrf5340dk_nrf5340_cpuappns`` build target, the :ref:`secure_partition_manager` sample is automatically included in the build.
 
 .. tfm_support_start
 
@@ -379,7 +379,7 @@ If you built the application sample and the network sample as separate images, y
 
         nrfjprog -f NRF53 --program zephyr/zephyr.hex --chiperase
 
-      Finally, reset the board::
+      Finally, reset the development kit::
 
         nrfjprog --pinreset
 

--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -5,7 +5,7 @@ Radio front-end module (FEM) support
 
 This guide describes how to add support for 2 different front-end module (FEM) implementations to your application in |NCS|.
 
-|NCS| allows you to extend the radio range of your board with an implementation of the front-end modules.
+|NCS| allows you to extend the radio range of your development kit with an implementation of the front-end modules.
 Front-end modules are range extenders, used for boosting the link robustness and link budget of wireless SoCs.
 
 The FEM support is based on the :ref:`nrfxlib:mpsl_fem`, which is integrated in the nrfxlib's MPSL library.

--- a/doc/nrf/ug_tfm.rst
+++ b/doc/nrf/ug_tfm.rst
@@ -58,5 +58,5 @@ Logging
 TF-M employs two UART interfaces for logging: one for the secure part (MCUboot and TF-M), and one for the non-secure application.
 The logs arrive on different COM ports on the host PC.
 
-On the nRF5340 DK, you must connect specific wires on the board to receive secure logs on the host PC.
+On the nRF5340 DK, you must connect specific wires on the kit to receive secure logs on the host PC.
 Wire the pins P0.25 and P0.26 to RxD and TxD respectively.

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -284,9 +284,9 @@ To build and program the source code from the command line, complete the followi
    .. parsed-literal::
       :class: highlight
 
-	  west build -b *board_name* -d *destination_directory_name*
+	  west build -b *build_target* -d *destination_directory_name*
 
-   The parameter *board_name* should be ``thingy91_nrf9160`` or ``thingy91_nrf9160ns`` if building for the nRF9160 SiP component and ``thingy91_nrf52840`` if building for the nRF52840 SoC component.
+   The parameter *build_target* should be ``thingy91_nrf9160`` or ``thingy91_nrf9160ns`` if building for the nRF9160 SiP component and ``thingy91_nrf52840`` if building for the nRF52840 SoC component.
 
    .. note::
 

--- a/doc/nrf/ug_thread_commissioning.rst
+++ b/doc/nrf/ug_thread_commissioning.rst
@@ -212,8 +212,8 @@ One device will act as a Commissioner and the other will be a Joiner.
 Requirements
 ============
 
-To configure on-mesh Thread commissioning, you need at least two development kit boards that are compatible with either the CLI or the NCP samples.
-Check the sample documentation pages for the list of compatible development kit boards.
+To configure on-mesh Thread commissioning, you need at least two development kits that are compatible with either the CLI or the NCP samples.
+Check the sample documentation pages for the list of compatible development kits.
 
 .. _thread_ot_commissioning_configuring_on-mesh_flashing:
 

--- a/doc/nrf/ug_thread_tools.rst
+++ b/doc/nrf/ug_thread_tools.rst
@@ -88,25 +88,25 @@ When working with samples that support wpantund, complete the following steps to
 
       wpanctl -I leader_if
 
-   This process can be used to control the connected NCP board.
+   This process can be used to control the connected NCP kit.
 
-Once wpantund and wpanctl are started, you can start running wpanctl commands to interact with the board.
+Once wpantund and wpanctl are started, you can start running wpanctl commands to interact with the development kit.
 
 Using wpanctl commands
 ======================
 
 To issue a wpanctl command, run it in the wpanctl shell.
-For example, the following command checks the the NCP board state:
+For example, the following command checks the the NCP kit state:
 
 .. code-block:: console
 
    wpanctl:leader_if> status
 
-The output will be different depending on the board and the sample.
+The output will be different depending on the kit and the sample.
 
 The most common wpanctl commands are the following:
 
-* ``status`` - Checks the board state.
+* ``status`` - Checks the kit state.
 * ``form "*My_OpenThread_network*"`` - Sets up a Thread network with the name ``My_OpenThread_network``.
 * ``get`` - Gets the values of all properties.
 * ``get *property*`` - Gets the value of the requested property.

--- a/doc/nrf/ug_thread_vendor_hooks.rst
+++ b/doc/nrf/ug_thread_vendor_hooks.rst
@@ -178,7 +178,7 @@ To test the vendor hook feature, you need a development kit that is programmed w
 Complete the following steps:
 
 1. Connect the Thread NCP development kit's SEGGER J-Link USB port to the USB port on your PC with an USB cable.
-#. Get the board's serial port name (for example, :file:`/dev/ttyACM0`).
+#. Get the development kit's serial port name (for example, :file:`/dev/ttyACM0`).
 #. Open a shell and run PySpinel by using the following command, with *baudrate* set to ``1000000`` and *serial_port_name* set to the port name from the previous step:
 
    .. parsed-literal::

--- a/include/dk_buttons_and_leds.rst
+++ b/include/dk_buttons_and_leds.rst
@@ -14,7 +14,7 @@ If you want to retrieve information about the button state, initialize the libra
 You can pass a callback function during initialization.
 This function is then called every time the button state changes.
 
-If you want to control the LEDs on the board, initialize the library with :c:func:`dk_leds_init`.
+If you want to control the LEDs on the development kit, initialize the library with :c:func:`dk_leds_init`.
 You can then set the value of a single LED, or set all of them to a state specified through bitmasks.
 
 API documentation

--- a/include/net/aws_iot.rst
+++ b/include/net/aws_iot.rst
@@ -26,7 +26,7 @@ Setting up a connection to AWS IoT
 Setting up a secure MQTT connection to the AWS IoT message broker consists of the following steps:
 
 1. :ref:`creating_a_thing_in_AWS_IoT` and generating certificates for the TLS connection.
-#. Programming the certificates to the on-board modem of the nRF9160 based board.
+#. Programming the certificates to the on-board modem of the nRF9160-based kit.
 #. Configuring the required library options.
 #. Configuring the optional library options.
 
@@ -35,14 +35,14 @@ Setting up a secure MQTT connection to the AWS IoT message broker consists of th
 
 .. _flash_certi_device:
 
-Programming the certificates to the on-board modem of the nRF9160 based board
-=============================================================================
+Programming the certificates to the on-board modem of the nRF9160-based kit
+===========================================================================
 
 To program the certificates, complete the following steps:
 
 1. `Download nRF Connect for Desktop`_.
-#. Update the modem firmware on the on-board modem of the nRF9160 based board to the latest version by following the steps in `Updating the nRF9160 DK cellular modem`_.
-#. Build and program the :ref:`at_client_sample` sample to the nRF9160 based board as explained in :ref:`gs_programming`.
+#. Update the modem firmware on the on-board modem of the nRF9160-based kit to the latest version by following the steps in `Updating the nRF9160 DK cellular modem`_.
+#. Build and program the :ref:`at_client_sample` sample to the nRF9160-based kit as explained in :ref:`gs_programming`.
 #. Launch the `LTE Link Monitor`_ application, which is implemented as part of `nRF Connect for Desktop`_.
 #. Click :guilabel:`Certificate manager` located at the top right corner.
 #. Copy and paste the certificates downloaded earlier from the AWS IoT console into the respective entries (``CA certificate``, ``Client certificate``, ``Private key``).
@@ -65,7 +65,7 @@ To configure the required library options, complete the following steps:
 1. In the `AWS IoT console`_, navigate to :guilabel:`IoT core` -> :guilabel:`Manage` -> :guilabel:`things` and click on the entry for the *thing* created during the steps of :ref:`creating_a_thing_in_AWS_IoT`.
 #. Navigate to :guilabel:`interact`, find the ``Rest API Endpoint`` and set the configurable option :option:`CONFIG_AWS_IOT_BROKER_HOST_NAME` to this address string.
 #. Set the option :option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC` to the name of the *thing* created during the aforementioned steps.
-#. Set the security tag configuration :option:`CONFIG_AWS_IOT_SEC_TAG` to the security tag, chosen while `Programming the certificates to the on-board modem of the nRF9160 based board`_.
+#. Set the security tag configuration :option:`CONFIG_AWS_IOT_SEC_TAG` to the security tag, chosen while `Programming the certificates to the on-board modem of the nRF9160-based kit`_.
 
 Configuring the optional library options
 ========================================

--- a/include/zigbee/zigbee_fota.rst
+++ b/include/zigbee/zigbee_fota.rst
@@ -88,7 +88,7 @@ The Zigbee FOTA library has the following limitations:
 
 * The endpoint definition in the library includes the endpoint ID, defined with :option:`CONFIG_ZIGBEE_FOTA_ENDPOINT`.
   When using the Zigbee FOTA library, this endpoint ID cannot be used for other endpoints.
-* The Zigbee FOTA upgrades are currently only supported on the nRF52840 DK board (PCA10056).
+* The Zigbee FOTA upgrades are currently only supported on the nRF52840 DK (PCA10056).
 * The Zigbee FOTA library does not currently support bootloader upgrades.
 * In case of an MCU reset between the completion of the OTA image transfer and a postponed firmware upgrade, the upgrade will be applied immediately.
 

--- a/samples/bluetooth/alexa_gadget/README.rst
+++ b/samples/bluetooth/alexa_gadget/README.rst
@@ -134,15 +134,15 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Optionally, set up log monitoring:
 
-  a. Connect the board to the computer using a USB cable.
-     The board is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
+  a. Connect the kit to the computer using a USB cable.
+     The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
   b. |connect_terminal|
 
-2. Reset the board.
+2. Reset the kit.
 3. Follow these instructions to pair your Echo device with the sample: `Alexa Gadgets Pairing`_.
 4. Observe that LED 1 turns on to indicate that a connection has been established.
 5. Observe that LED 2 turns on to indicate that the Alexa Gadgets handshake has completed.

--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -51,15 +51,15 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it either by connecting to another board that is running the :ref:`peripheral_hids_keyboard` or :ref:`peripheral_hids_mouse` sample, or by using `nRF Connect for Desktop`_ that emulates a BAS Server.
+After programming the sample to your development kit, you can test it either by connecting to another kit that is running the :ref:`peripheral_hids_keyboard` or :ref:`peripheral_hids_mouse` sample, or by using `nRF Connect for Desktop`_ that emulates a BAS Server.
 
 
-Testing with another board
---------------------------
+Testing with another kit
+------------------------
 
 1. |connect_terminal_specific|
-#. Reset the board.
-#. Program the other board with the :ref:`peripheral_hids_keyboard` or :ref:`peripheral_hids_mouse` sample and reset it.
+#. Reset the kit.
+#. Program the other development kit with the :ref:`peripheral_hids_keyboard` or :ref:`peripheral_hids_mouse` sample and reset it.
 #. Wait until the BAS Server is detected by the central.
    In the terminal window, check for information similar to the following::
 
@@ -81,7 +81,7 @@ Testing with nRF Connect for Desktop
 ------------------------------------
 
 1. |connect_terminal_specific|
-#. Reset the board.
+#. Reset the kit.
 #. Start `nRF Connect for Desktop`_ and select the connected dongle that is used for communication.
 #. Go to the :guilabel:`Server setup` tab.
    Click the dongle configuration and select :guilabel:`Load setup`.
@@ -111,7 +111,7 @@ Testing with nRF Connect for Desktop
    #. Click :guilabel:`Apply` and :guilabel:`Close`.
 
 #. In the Adapter settings, choose :guilabel:`Start advertising`.
-#. Wait until the board that runs the Central BAS sample connects.
+#. Wait until the kit that runs the Central BAS sample connects.
    In the terminal window, check for information similar to the following::
 
       The discovery procedure succeeded

--- a/samples/bluetooth/central_dfu_smp/README.rst
+++ b/samples/bluetooth/central_dfu_smp/README.rst
@@ -17,7 +17,7 @@ Overview
 After connecting, the sample starts MTU size negotiation, discovers the GATT database of the server, and configures the DFU SMP Client.
 When configuration is complete, the sample is ready to send SMP commands.
 
-To send an echo command, press Button 1 on the board.
+To send an echo command, press Button 1 on the development kit
 The string that is sent contains a number that is automatically incremented.
 This way, you can easily verify if the correct response is received.
 The response is decoded and displayed using the `TinyCBOR`_ library (which is part of Zephyr).
@@ -32,7 +32,7 @@ The sample supports the following development kits:
    :header: heading
    :rows: nrf5340dk_nrf5340_cpuapp_and_cpuappns , nrf52840dk_nrf52840, nrf52840dk_nrf52811, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52dk_nrf52832, nrf52dk_nrf52810
 
-The sample also requires a device running `MCUmgr`_ with transport protocol over Bluetooth Low Energy, for example, another board running the :ref:`smp_svr_sample`.
+The sample also requires a device running `MCUmgr`_ with transport protocol over Bluetooth Low Energy, for example, another development kit running the :ref:`smp_svr_sample`.
 
 User interface
 **************
@@ -53,19 +53,19 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
-1. Connect the board to the computer using a USB cable.
-   The board is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
+1. Connect the kit to the computer using a USB cable.
+   The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal|
-#. Reset the board.
-#. Observe that the text "Starting DFU SMP Client example" is printed on the COM listener running on the computer and the device starts scanning for Peripheral boards with SMP.
-#. Program the :ref:`smp_svr_sample` to another board.
+#. Reset the kit.
+#. Observe that the text "Starting DFU SMP Client example" is printed on the COM listener running on the computer and the device starts scanning for Peripherals with SMP.
+#. Program the :ref:`smp_svr_sample` to another development kit.
    See the documentation for that sample for more information.
-#. Observe that the boards connect.
-   When service discovery is completed, the event logs are printed on the Central board's terminal.
-   If you connect to the Server board with a terminal emulator, you can observe that it prints "connected".
-#. Press Button 1 on the Client board.
+#. Observe that the kits connect.
+   When service discovery is completed, the event logs are printed on the Central's terminal.
+   If you connect to the Server with a terminal emulator, you can observe that it prints "connected".
+#. Press Button 1 on the Client.
    Observe messages similar to the following::
 
       Echo test: 1
@@ -73,8 +73,8 @@ After programming the sample to your board, test it by performing the following 
       Total response received - decoding
       {_"r": "Echo message: 1"}
 
-#. Disconnect the devices by, for example, pressing the Reset button on the Central board.
-   Observe that the boards automatically reconnect and that it is again possible to send data between the two boards.
+#. Disconnect the devices by, for example, pressing the Reset button on the Central.
+   Observe that the kits automatically reconnect and that it is again possible to send data between the two kits.
 
 Dependencies
 ************

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -32,7 +32,7 @@ The sample supports the following development kits:
    :header: heading
    :rows: nrf5340dk_nrf5340_cpuapp_and_cpuappns , nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52dk_nrf52832
 
-The sample also requires a HIDS device to connect with (for example, another board running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth Low Energy dongle and nRF Connect for Desktop).
+The sample also requires a HIDS device to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth Low Energy dongle and nRF Connect for Desktop).
 
 User interface
 **************
@@ -65,15 +65,15 @@ Building and Running
 Testing
 =======
 
-After programming the sample to your board, you can test it either by connecting to another board that is running the :ref:`peripheral_hids_keyboard` sample, or by using `nRF Connect for Desktop`_ that emulates a HIDS server.
+After programming the sample to your development kit, you can test it either by connecting to another development kit that is running the :ref:`peripheral_hids_keyboard` sample, or by using `nRF Connect for Desktop`_ that emulates a HIDS server.
 
 
-Testing with another board
---------------------------
+Testing with another development kit
+------------------------------------
 
 1. |connect_terminal_specific|
-#. Reset the board.
-#. Program the other board with the :ref:`peripheral_hids_keyboard` sample and reset it.
+#. Reset the kit.
+#. Program the other kit with the :ref:`peripheral_hids_keyboard` sample and reset it.
 #. When connected, press Button 1 on both devices to confirm the passkey value used for bonding, or press Button 2 to reject it.
 #. Wait until the HIDS keyboard is detected by the central.
    All detected descriptors are listed.
@@ -83,23 +83,23 @@ Testing with another board
       Subscribe to report id: 1
       Subscribe to boot keyboard report
 
-#. Press **Button 1** and **Button 2** one after another on the board that runs the keyboard sample and observe the notification values in the terminal window.
+#. Press **Button 1** and **Button 2** one after another on the kit that runs the keyboard sample and observe the notification values in the terminal window.
    See :ref:`peripheral_hids_keyboard` for the expected values::
 
       Notification, id: 1, size: 8, data: 0x0 0x0 0xb 0x0 0x0 0x0 0x0 0x0
       Notification, id: 1, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
 
-#. Press **Button 2** on the board that runs the Central HIDS sample and observe that the protocol mode is updated into boot mode::
+#. Press **Button 2** on the kit that runs the Central HIDS sample and observe that the protocol mode is updated into boot mode::
 
       Setting protocol mode: BOOT
 
-#. Press **Button 1** and **Button 2** one after another on the board that runs the keyboard sample and observe the notification of the boot report values::
+#. Press **Button 1** and **Button 2** one after another on the kit that runs the keyboard sample and observe the notification of the boot report values::
 
       Notification, keyboard boot, size: 8, data: 0x0 0x0 0xf 0x0 0x0 0x0 0x0 0x0
       Notification, keyboard boot, size: 8, data: 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0
 
 
-#. Press **Button 1** and **Button 3** one after another on the Central HIDS board and observe that **LED 1** on the keyboard board changes its state.
+#. Press **Button 1** and **Button 3** one after another on the Central HIDS kit and observe that **LED 1** on the keyboard kit changes its state.
    The following information is also displayed in the terminal window.
 
    If **Button 1** was pressed::
@@ -118,7 +118,7 @@ Testing with nRF Connect for Desktop
 ------------------------------------
 
 1. |connect_terminal_specific|
-#. Reset the board.
+#. Reset the kit.
 #. Start `nRF Connect for Desktop`_ and select the connected dongle that is used for communication.
 #. Go to the :guilabel:`Server setup` tab.
    Click the dongle configuration and select :guilabel:`Load setup`.
@@ -148,7 +148,7 @@ Testing with nRF Connect for Desktop
    #. Click :guilabel:`Apply` and :guilabel:`Close`.
 
 #. In the Adapter settings, choose :guilabel:`Start advertising`.
-#. Wait until the board that runs the Central HIDS sample connects.
+#. Wait until the kit that runs the Central HIDS sample connects.
    All detected descriptors are listed.
    Check for information similar to the following::
 
@@ -157,8 +157,8 @@ Testing with nRF Connect for Desktop
       Subscribe in boot keyboard report
 
 #. Explore the first report inside Human Interface Device (the one with eight values).
-   Change any of the values and note that the board logs the change.
-#. Press **Button 2** on the board and observe that the Protocol Mode value changes from ``01`` to ``00``.
+   Change any of the values and note that the kit logs the change.
+#. Press **Button 2** on the kit and observe that the Protocol Mode value changes from ``01`` to ``00``.
 #. Press **Button 1** and **Button 3** one after another and observe that the Boot Keyboard Output Report value toggles between ``00`` and ``02``.
 
 Dependencies

--- a/samples/bluetooth/central_hr_coded/README.rst
+++ b/samples/bluetooth/central_hr_coded/README.rst
@@ -38,11 +38,11 @@ Building and Running
 Testing
 =======
 
-After programming the sample to your board, you can test it by connecting to another board that runs the :ref:`peripheral_hr_coded`.
+After programming the sample to your development kit, you can test it by connecting to another development kit that runs the :ref:`peripheral_hr_coded`.
 
 1. |connect_terminal_specific|
-#. Reset the board.
-#. Program the other board with the :ref:`peripheral_hr_coded`.
+#. Reset the kit.
+#. Program the other kit with the :ref:`peripheral_hr_coded` sample.
 #. Wait until the Coded advertiser is detected by the Central.
    In the terminal window, check for information similar to the following::
 

--- a/samples/bluetooth/central_nfc_pairing/README.rst
+++ b/samples/bluetooth/central_nfc_pairing/README.rst
@@ -86,7 +86,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Touch the :ref:`st25r3911b_nfc_readme` with a Type 2 Tag or Tag 4 Tag.
    The Tag Device can support the TNEP protocol.

--- a/samples/bluetooth/central_uart/README.rst
+++ b/samples/bluetooth/central_uart/README.rst
@@ -53,22 +53,22 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
-1. Connect the board to the computer using a USB cable. The board is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
+1. Connect the kit to the computer using a USB cable. The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal_specific|
 #. Optionally, connect the RTT console to display debug messages. See :ref:`central_uart_debug`.
-#. Reset the board.
-#. Observe that the text "Starting NUS Client example" is printed on the COM listener running on the computer and the device starts scanning for Peripheral boards with NUS.
-#. Program the :ref:`peripheral_uart` sample to the second board.
+#. Reset the kit.
+#. Observe that the text "Starting NUS Client example" is printed on the COM listener running on the computer and the device starts scanning for Peripherals with NUS.
+#. Program the :ref:`peripheral_uart` sample to the second development kit.
    See the documentation for that sample for detailed instructions.
-#. Observe that the boards connect.
-   When service discovery is completed, the event logs are printed on the Central board's terminal.
-#. Now you can send data between the two boards.
-   To do so, type some characters in the terminal of one of the boards and hit Enter.
-   Observe that the data is displayed on the UART on the other board.
-#. Disconnect the devices by, for example, pressing the Reset button on the Central board.
-   Observe that the boards automatically reconnect and that it is again possible to send data between the two boards.
+#. Observe that the kits connect.
+   When service discovery is completed, the event logs are printed on the Central's terminal.
+#. Now you can send data between the two kits.
+   To do so, type some characters in the terminal of one of the kits and hit Enter.
+   Observe that the data is displayed on the UART on the other kit.
+#. Disconnect the devices by, for example, pressing the Reset button on the Central.
+   Observe that the kits automatically reconnect and that it is again possible to send data between the two kits.
 
 Dependencies
 ************

--- a/samples/bluetooth/enocean/README.rst
+++ b/samples/bluetooth/enocean/README.rst
@@ -16,7 +16,7 @@ The EnOcean sample sets up a basic Bluetooth observer for both EnOcean switches 
 
 The observer device forwards incoming advertisements to the EnOcean library for processing.
 The application receives events from the EnOcean library through callbacks, and prints the outcome to console.
-The LEDs of the board also respond to button presses from an EnOcean switch.
+The LEDs of the kit also respond to button presses from an EnOcean switch.
 
 
 Requirements
@@ -31,12 +31,12 @@ The sample supports the following development kits:
 The sample also requires at least one :ref:`supported EnOcean device <bt_enocean_devices>`.
 
 .. note::
-    The sample supports up to four devices at a time that work with one board.
+    The sample supports up to four devices at a time that work with one kit.
 
 User interface
 **************
 
-The following board LEDs are used by this sample:
+The following LEDs are used by this sample:
 
 LED 1 and LED 2:
    At the end of commissioning, blink four times to indicate a new EnOcean device has been commissioned.
@@ -61,17 +61,17 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. :ref:`Commission one or more EnOcean devices <bt_enocean_commissioning>`.
-   The board LEDs will blink when each of the devices has been successfully commissioned.
-#. Connect the board to the computer with an USB cable.
-   The board is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
+   The LEDs will blink when each of the devices has been successfully commissioned.
+#. Connect the kit to the computer with an USB cable.
+   The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal_specific|
 #. Depending on the EnOcean devices you commissioned:
 
-    * If you commissioned a light switch, press any of its buttons or toggle the rocker to control the board LEDs.
-      The board LEDs light on and off as detailed in `User interface`_, and the received values are printed to the console.
+    * If you commissioned a light switch, press any of its buttons or toggle the rocker to control the LEDs.
+      The LEDs light on and off as detailed in `User interface`_, and the received values are printed to the console.
     * Sensor devices will automatically start reporting their sensor values to the application.
       The values are printed to the console.
 

--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -57,7 +57,7 @@ GATT Latency Service
      - BT_UUID_LATENCY_CHAR
      - BT_GATT_CHRC_WRITE, BT_GATT_PERM_WRITE
 
-This sample transmits data between two boards to measure the transmission latency in between.
+This sample transmits data between two development kits to measure the transmission latency in between.
 One of the devices is connected as a *master* and another is connected as a *slave*.
 The performance is evaluated with the transmission latency dividing the estimated round-trip time in half (RTT / 2).
 
@@ -101,12 +101,12 @@ Building and running
 Testing
 =======
 
-After programming the sample to both boards, test it by performing the following steps:
+After programming the sample to both development kits, test it by performing the following steps:
 
-1. Connect to both boards with a terminal emulator (for example, PuTTY).
+1. Connect to both kits with a terminal emulator (for example, PuTTY).
    See :ref:`putty` for the required settings.
-#. Reset both boards.
-#. Observe that the boards establish a connection.
+#. Reset both kits.
+#. Observe that the kits establish a connection.
    When they are connected, one of them serves as *master* and the other one as *slave*.
 
    - The master outputs the following information::

--- a/samples/bluetooth/mesh/chat/README.rst
+++ b/samples/bluetooth/mesh/chat/README.rst
@@ -95,7 +95,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
 Testing consists of provisioning the device and configuring it for communication with other nodes.
 
 After configuring the device, you can interact with the sample using the terminal emulator.
@@ -158,8 +158,8 @@ Repeat steps 6-11 for each mesh node in the mesh network.
 Interacting with the sample
 ---------------------------
 
-1. Connect the board to the computer using a USB cable.
-   The board is assigned a COM port (Windows), ttyACM device (Linux) or tty.usbmodem (MacOS).
+1. Connect the kit to the computer using a USB cable.
+   The kit is assigned a COM port (Windows), ttyACM device (Linux) or tty.usbmodem (MacOS).
 #. |connect_terminal_specific|
 #. Enable local echo in the terminal to see the text you are typing.
 

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -51,7 +51,7 @@ The models are used for the following purposes:
 * Health Server provides ``attention`` callbacks that are used during provisioning to call your attention to the device.
   These callbacks trigger blinking of the LEDs.
 
-The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library to control each LED on the board according to the matching received messages of Generic OnOff Server.
+The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library to control each LED on the development kit according to the matching received messages of Generic OnOff Server.
 
 Requirements
 ************
@@ -92,7 +92,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
 Testing consists of provisioning the device and configuring it for communication with the mesh models.
 
 Provisioning the device

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -74,7 +74,7 @@ Other nodes can control the Light Lightness Server through the Light LC Server, 
 
 For more details, see :ref:`bt_mesh_lightness_srv_readme` and :ref:`bt_mesh_light_ctrl_srv_readme`.
 
-The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library and the :ref:`zephyr:pwm_api` API to control the LEDs on the board.
+The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library and the :ref:`zephyr:pwm_api` API to control the LEDs on the development kit.
 
 Requirements
 ************
@@ -114,7 +114,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
 Testing consists of provisioning the device and configuring it for communication with the mesh models.
 
 Provisioning the device

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -45,7 +45,7 @@ The models are used for the following purposes:
 * Health Server provides ``attention`` callbacks that are used during provisioning to call your attention to the device.
   These callbacks trigger blinking of the LEDs.
 
-The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library to detect button presses on the board.
+The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library to detect button presses on the development kit.
 
 If the model is configured to publish to a unicast address, the model handler calls :c:func:`bt_mesh_onoff_cli_set` to turn the LEDs of a mesh light device on or off.
 The response from the target device updates the corresponding LED on the mesh light switch device.
@@ -75,7 +75,7 @@ Buttons:
    When pressed, the button toggles the LED state on a :ref:`mesh light <bluetooth_mesh_light>` device.
 
 LEDs:
-   Show the last known OnOff state of the targeted :ref:`bluetooth_mesh_light` board.
+   Show the last known OnOff state of the targeted :ref:`bluetooth_mesh_light` kit.
 
 
 Building and running
@@ -92,9 +92,9 @@ Testing
 
 .. note::
    The light switch sample cannot demonstrate any functionality on its own, and needs a device with the :ref:`bluetooth_mesh_light` sample running in the same mesh network.
-   Before testing mesh light switch, go through the mesh light's :ref:`testing guide <bluetooth_mesh_light_testing>` with a different board.
+   Before testing mesh light switch, go through the mesh light's :ref:`testing guide <bluetooth_mesh_light_testing>` with a different kit.
 
-After programming the sample to your board, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
 Testing consists of provisioning the device and configuring it for communication with the mesh models.
 
 Provisioning the device

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -27,7 +27,7 @@ The following Bluetooth mesh sensor types are used in this sample:
 
 * :c:var:`bt_mesh_sensor_present_dev_op_temp` - Published by the server according to its publishing period.
 * :c:var:`bt_mesh_sensor_rel_runtime_in_a_dev_op_temp_range` - Periodically requested by the client.
-* :c:var:`bt_mesh_sensor_presence_detected` - Published when a button is pressed on the server board.
+* :c:var:`bt_mesh_sensor_presence_detected` - Published when a button is pressed on the server.
 * :c:var:`bt_mesh_sensor_time_since_presence_detected` - Periodically requested by the client and published by the server according to its publishing period.
 
 
@@ -103,9 +103,9 @@ Testing
 
 .. note::
    The mesh sensor observer sample cannot demonstrate any functionality on its own, and needs a device with the :ref:`bluetooth_mesh_sensor_server` sample running in the same mesh network.
-   Before testing the mesh sensor observer, go through the mesh sensor's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>` with a different board.
+   Before testing the mesh sensor observer, go through the mesh sensor's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>` with a different kit.
 
-After programming the sample to your board, you can test it by using a smartphone with Nordic Semiconductor’s nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor’s nRF Mesh app installed.
 Testing consists of provisioning the device and configuring it for communication with the mesh models.
 
 All sensor values gathered from the server are printed over UART.

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -27,7 +27,7 @@ The following Bluetooth mesh sensor types are used in this sample:
 
 * :c:var:`bt_mesh_sensor_present_dev_op_temp` - Published by the server according to its publishing period (see :ref:`bluetooth_mesh_sensor_server_conf_models`).
 * :c:var:`bt_mesh_sensor_rel_runtime_in_a_dev_op_temp_range` - Periodically requested by the client.
-* :c:var:`bt_mesh_sensor_presence_detected` - Published when a button is pressed on the server board.
+* :c:var:`bt_mesh_sensor_presence_detected` - Published when a button is pressed on the server.
 * :c:var:`bt_mesh_sensor_time_since_presence_detected` - Periodically requested by the client and published by the server according to its publishing period (see :ref:`bluetooth_mesh_sensor_server_conf_models`).
 
 Moreover, the on-chip ``TEMP_NRF5`` temperature sensor is used.
@@ -104,9 +104,9 @@ Testing
 
 .. note::
    The Bluetooth mesh sensor sample cannot demonstrate any functionality on its own, and needs a device with the :ref:`bluetooth_mesh_sensor_client` sample running in the same mesh network.
-   Before testing the sensor sample, go through the sensor observer sample's :ref:`testing guide <bluetooth_mesh_sensor_client_testing>` with a different board.
+   Before testing the sensor sample, go through the sensor observer sample's :ref:`testing guide <bluetooth_mesh_sensor_client_testing>` with a different kit.
 
-After programming the sample to your board, you can test it by using a smartphone with Nordic Semiconductor’s nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor’s nRF Mesh app installed.
 Testing consists of provisioning the device, and configuring it for communication with the mesh models.
 
 Provisioning the device

--- a/samples/bluetooth/peripheral_bms/README.rst
+++ b/samples/bluetooth/peripheral_bms/README.rst
@@ -50,7 +50,7 @@ Testing
 After programming the sample to your development kit, test it by performing the following steps:
 
 1. |connect_terminal_specific|
-#. Reset the board.
+#. Reset the kit.
 #. Start `nRF Connect for Desktop`_ and select the connected device that is used for communication.
 #. Connect to the device from nRF Connect.
    The device is advertising as "Nordic_BMS".

--- a/samples/bluetooth/peripheral_cts_client/README.rst
+++ b/samples/bluetooth/peripheral_cts_client/README.rst
@@ -48,10 +48,10 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it with `nRF Connect for Desktop`_ by performing the following steps.
+After programming the sample to your development kit, you can test it with `nRF Connect for Desktop`_ by performing the following steps.
 
 1. |connect_terminal_specific|
-#. Reset the board.
+#. Reset the kit.
 #. Start `nRF Connect for Desktop`_ and select the connected dongle that is used for communication.
 #. Go to the :guilabel:`Server setup` tab.
    Click the dongle configuration and select :guilabel:`Load setup`.
@@ -69,7 +69,8 @@ After programming the sample to your board, you can test it with `nRF Connect fo
       Security changed: xx:xx:xx:xx:xx:xx (random) level 2
       Pairing completed: xx:xx:xx:xx:xx:xx (random), bonded: 1
 
-#. Press **Button 1** on the board. Verify that the current time printed on the UART matches the time that was input in the Current Time characteristic (UUID 0x2A2B)::
+#. Press **Button 1** on the kit.
+   Verify that the current time printed on the UART matches the time that was input in the Current Time characteristic (UUID 0x2A2B)::
 
       Current Time:
 

--- a/samples/bluetooth/peripheral_gatt_dm/README.rst
+++ b/samples/bluetooth/peripheral_gatt_dm/README.rst
@@ -36,11 +36,11 @@ Building and Running
 Testing
 =======
 
-After programming the sample to your dongle or development board, test it by performing the following steps.
+After programming the sample to your dongle or development kit, test it by performing the following steps.
 This testing procedure assumes that you are using `nRF Connect for Mobile`_.
 
-1. Connect the board to the computer using a USB cable.
-   The board is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
+1. Connect the kit to the computer using a USB cable.
+   The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal|
 #. Connect to the device from nRF Connect (the device is advertising as "Nordic Discovery Sample").
    When connected, the sample starts discovering the services of the connected device.

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -14,7 +14,7 @@ The sample also shows how to perform LE Secure Connections Out-of-Band pairing u
 Overview
 ********
 
-The sample uses the buttons on a development board to simulate keys on a keyboard.
+The sample uses the buttons on a development kit to simulate keys on a keyboard.
 One button simulates the letter keys by generating letter keystrokes for a predefined string.
 A second button simulates the Shift button and shows how to modify the letter keystrokes.
 An LED displays the Caps Lock state, which can be modified by another connected keyboard.
@@ -89,20 +89,20 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it either by connecting the board as keyboard device to a Microsoft Windows computer or by connecting to it with `nRF Connect for Desktop`_.
+After programming the sample to your development kit, you can test it either by connecting the kit as keyboard device to a Microsoft Windows computer or by connecting to it with `nRF Connect for Desktop`_.
 
 Testing with a Microsoft Windows computer
 -----------------------------------------
 
 To test with a Microsoft Windows computer that has a Bluetooth radio, complete the following steps:
 
-1. Power on your development board.
-#. Press Button 4 on the board if the device is not advertising.
+1. Power on your development kit.
+#. Press Button 4 on the kit if the device is not advertising.
    Advertising is indicated by blinking **LED 1**.
 #. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS keyboard".
 #. Observe that the connection state is indicated by **LED 2**.
 #. Open a text editor (for example, Notepad).
-#. Repeatedly press **Button 1** on the board.
+#. Repeatedly press **Button 1** on the kit.
    Every button press sends one character of the test message "hello" (the test message includes a carriage return) to the computer, and this will be displayed in the text editor.
 #. Press **Button 2** and hold it while pressing **Button 1**.
    Observe that the next letter of the "hello" message appears as capital letter.
@@ -120,8 +120,8 @@ Testing with nRF Connect for Desktop
 
 To test with `nRF Connect for Desktop`_, complete the following steps:
 
-1. Power on your development board.
-#. Press **Button 4** on the board if the device is not advertising.
+1. Power on your development kit.
+#. Press **Button 4** on the kit if the device is not advertising.
    Advertising is indicated by blinking **LED 1**.
 #. Connect to the device from nRF Connect (the device is advertising as "NCS HIDS keyboard").
 #. Optionally, bond to the device.
@@ -132,7 +132,7 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
 #. Observe that the connection state is indicated by **LED 2**.
 #. Observe that the services of the connected device are shown.
 #. Enable notifications for all HID characteristics.
-#. Press **Button 1** on the board.
+#. Press **Button 1** on the kit.
    Observe that two notifications are received on one of the HID Report characteristics, denoting press and release for one character of the test message.
 
    The first notification has the value ``00000B0000000000``, the second has the value ``0000000000000000``.
@@ -171,7 +171,7 @@ To test with an Android smartphone/tablet, complete the following steps:
 #. Observe that the device is advertising, as indicated by blinking **LED 1**.
 #. Confirm pairing with 'Nordic_Mouse_NFC' in a pop-up window on the smartphone/tablet.
 #. Observe that the connection state is indicated by **LED 2**.
-#. Repeatedly press **Button 1** on the board.
+#. Repeatedly press **Button 1** on the kit.
    Every button press sends one character of the test message "hello" to the smartphone (the test message includes a carriage return).
 #. Press **Button 2** and hold it while pressing **Button 1**.
    Observe that the next letter of the "hello" message appears as a capital letter.

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -13,7 +13,7 @@ This sample also shows how to perform directed advertising.
 Overview
 ********
 
-The sample uses the buttons on a development board to simulate the movement of a mouse.
+The sample uses the buttons on a development kit to simulate the movement of a mouse.
 The four buttons simulate movement to the left, upward, to the right, and downward, respectively.
 Mouse clicks are not simulated.
 
@@ -65,16 +65,16 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it either by connecting the board as a mouse device to a Microsoft Windows computer or by connecting to it with `nRF Connect for Desktop`_.
+After programming the sample to your development kit, you can test it either by connecting the development kit as a mouse device to a Microsoft Windows computer or by connecting to it with `nRF Connect for Desktop`_.
 
 Testing with a Microsoft Windows computer
 -----------------------------------------
 
 To test with a Microsoft Windows computer that has a Bluetooth radio, complete the following steps:
 
-1. Power on your development board.
+1. Power on your development kit.
 #. On your Windows computer, search for Bluetooth devices and connect to the device named "NCS HIDS mouse".
-#. Push **Button 1** on the board.
+#. Push **Button 1** on the kit.
    Observe that the mouse pointer on the computer moves to the left.
 #. Push **Button 2**.
    Observe that the mouse pointer on the computer moves upward.
@@ -90,7 +90,7 @@ Testing with nRF Connect for Desktop
 
 To test with `nRF Connect for Desktop`_, complete the following steps:
 
-1. Power on your development board.
+1. Power on your development kit.
 #. Connect to the device from nRF Connect (the device is advertising as "NCS HIDS mouse").
 #. Optionally, bond to the device.
    To do so, click the settings button for the device in nRF Connect, select :guilabel:`Pair`, check :guilabel:`Perform Bonding`, and click :guilabel:`Pair`.
@@ -99,7 +99,7 @@ To test with `nRF Connect for Desktop`_, complete the following steps:
    Wait until the bond is established before you continue.
 #. Observe that the services of the connected device are shown.
 #. Click the :guilabel:`Play` button for all HID Report characteristics.
-#. Push **Button 1** on the board.
+#. Push **Button 1** on the kit.
    Observe that a notification is received on one of the HID Report characteristics, containing the value ``FB0F00``.
 
    Mouse motion reports contain data with an X-translation and a Y-translation.

--- a/samples/bluetooth/peripheral_hr_coded/README.rst
+++ b/samples/bluetooth/peripheral_hr_coded/README.rst
@@ -41,11 +41,11 @@ Building and Running
 Testing
 =======
 
-After programming the sample to your board, you can test it by connecting to another board that runs the :ref:`bluetooth_central_hr_coded`.
+After programming the sample to your development kit, you can test it by connecting to another development kit that runs the :ref:`bluetooth_central_hr_coded`.
 
 1. |connect_terminal_specific|
-#. Reset the board.
-#. Program the other board with the :ref:`bluetooth_central_hr_coded`.
+#. Reset the kit.
+#. Program the other kit with the :ref:`bluetooth_central_hr_coded` sample.
 #. Wait until the Coded advertiser is detected by the Central.
    In the terminal window, check for information similar to the following::
 

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -12,8 +12,8 @@ The peripheral LBS sample demonstrates how to use the :ref:`lbs_readme`.
 Overview
 ********
 
-When connected, the sample sends the state of **Button 1** on the development board to the connected device, such as a phone or tablet.
-The mobile application on the device can display the received button state and can control the state of **LED 3** on the development board.
+When connected, the sample sends the state of **Button 1** on the development kit to the connected device, such as a phone or tablet.
+The mobile application on the device can display the received button state and can control the state of **LED 3** on the development kit.
 
 Alternatively, you can use this sample to control the color of RGB LED on the nRF52840 Dongle.
 
@@ -43,7 +43,7 @@ RGB LED:
 Button 1:
    * Sends a notification with the button state: "pressed" or "released".
 
-For Development Kit boards:
+For development kits:
 
 LED 1:
    * When the main loop is running (device is advertising), blinks with a period of 2 seconds, duty cycle 50%.
@@ -78,25 +78,25 @@ The sample can be built with a minimum configuration as a demonstration of how t
 Testing
 =======
 
-After programming the sample to your dongle or development board, test it by performing the following steps.
+After programming the sample to your dongle or development kit, test it by performing the following steps.
 This testing procedure assumes that you are using `nRF Connect for Mobile`_.
 
-1. Power on your development board or plug in your dongle.
+1. Power on your development kit or plug in your dongle.
 #. Connect to the device from nRF Connect (the device is advertising as "Nordic_Blinky").
 #. Observe that the services of the connected device are shown.
 #. In "Nordic LED Button Service", click the :guilabel:`Play` button for the "Button" characteristic.
-#. Press **Button 1** either on the dongle or on the development board.
+#. Press **Button 1** either on the dongle or on the development kit.
 #. Observe that notifications with the following values are received:
 
    * ``00`` when **Button 1** is released,
    * ``01`` when **Button 1** is pressed.
 
-#. Control the color of RGB LED on the dongle or status of **LED 3** on the board by writing the following values to the "LED" characteristic in the "Nordic LED Button Service":
+#. Control the color of RGB LED on the dongle or status of **LED 3** on the kit by writing the following values to the "LED" characteristic in the "Nordic LED Button Service":
 
-   * ``00`` to switch the LED off on the board or turn on the red RGB LED on the dongle.
-   * ``01`` to switch the LED on on the board or turn on the green RGB LED on the dongle.
+   * ``00`` to switch the LED off on the kit or turn on the red RGB LED on the dongle.
+   * ``01`` to switch the LED on on the kit or turn on the green RGB LED on the dongle.
 
-#. Observe that RGB LED on the dongle or **LED 3** on the board corresponds to the value of the "LED" characteristic.
+#. Observe that RGB LED on the dongle or **LED 3** on the kit corresponds to the value of the "LED" characteristic.
 
 Dependencies
 ************

--- a/samples/bluetooth/peripheral_nfc_pairing/README.rst
+++ b/samples/bluetooth/peripheral_nfc_pairing/README.rst
@@ -100,7 +100,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 Testing with NFC Poller Device
 ------------------------------

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -74,12 +74,12 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
-1. Connect the board to the computer using a USB cable. The board is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
+1. Connect the kit to the computer using a USB cable. The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal|
 #. Optionally, connect the RTT console to display debug messages. See :ref:`peripheral_uart_debug`.
-#. Reset the board.
+#. Reset the kit.
 #. Observe that LED 1 is blinking and that the device is advertising with the device name that is configured in :option:`CONFIG_BT_DEVICE_NAME`.
 #. Observe that the text "Starting Nordic UART service example" is printed on the COM listener running on the computer.
 #. Connect to the device using nRF Connect for Mobile.

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -14,7 +14,7 @@ You can use it to determine the maximum throughput, or to experiment with differ
 Overview
 ********
 
-The sample transmits data between two boards, the *tester* and the *peer*, and measures the throughput performance.
+The sample transmits data between two development kits, the *tester* and the *peer*, and measures the throughput performance.
 To do so, it uses the :ref:`throughput_readme`.
 
 The sample demonstrates the interaction of the following connection parameters:
@@ -55,15 +55,15 @@ By default, the following connection parameter values are used:
 Changing connection parameter values
 ====================================
 
-You can experiment with different connection parameter values by reconfiguring the values using menuconfig and then compiling and programming the sample again to at least one of the boards.
+You can experiment with different connection parameter values by reconfiguring the values using menuconfig and then compiling and programming the sample again to at least one of the kits.
 
 .. note::
    In a *Bluetooth* Low Energy connection, the different devices negotiate the connection parameters that are used.
    If the configuration parameters for the devices differ, they agree on the lowest common denominator.
 
    By default, the sample uses the fastest connection parameters.
-   If you change them to lower values, it is sufficient to program them to one of the boards.
-   If you were to change them to higher values, you would need to program both boards again.
+   If you change them to lower values, it is sufficient to program them to one of the kits.
+   If you were to change them to higher values, you would need to program both kits again.
 
 
 Requirements
@@ -99,14 +99,14 @@ Building and running
 Testing
 =======
 
-After programming the sample to both boards, test it by performing the following steps:
+After programming the sample to both kits, test it by performing the following steps:
 
-1. Connect to both boards with a terminal emulator (for example, PuTTY).
+1. Connect to both kits with a terminal emulator (for example, PuTTY).
    See :ref:`putty` for the required settings.
-#. Reset both boards.
-#. In one of the terminal emulators, type "s" to start the application on the connected board in the slave (peer) role.
+#. Reset both kits.
+#. In one of the terminal emulators, type "s" to start the application on the connected kit in the slave (peer) role.
 #. In the other terminal emulator, type "m" to start the application in the master (tester) role.
-#. Observe that the boards establish a connection.
+#. Observe that the kits establish a connection.
    The tester outputs the following information::
 
        Ready, press any key to start

--- a/samples/debug/ppi_trace/README.rst
+++ b/samples/debug/ppi_trace/README.rst
@@ -50,7 +50,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Connect a logic analyzer to the pins that are used for tracing.
    Check the sample configuration for information about which pins are used.

--- a/samples/esb/README.rst
+++ b/samples/esb/README.rst
@@ -13,8 +13,8 @@ Overview
 ********
 
 The sample consists of two applications, one Transmitter and one Receiver, that use the :ref:`esb_README` library.
-After programming each application on an nRF5 development board, you can test that packets that are sent by the board that runs the Transmitter application are picked up by the board that runs the Receiver application.
-Successful communication is indicated by LED changes, which should be in sync on both boards.
+After programming each application on an nRF5 Series development kit, you can test that packets that are sent by the kit that runs the Transmitter application are picked up by the kit that runs the Receiver application.
+Successful communication is indicated by LED changes, which should be in sync on both kits.
 
 Transmitter
 ===========
@@ -60,13 +60,13 @@ See :ref:`gs_programming` for information about how to build and program the app
 Testing
 =======
 
-After programming the Transmitter sample on one of the boards and the Receiver sample on the other board, test them by performing the following steps:
+After programming the Transmitter sample on one of the development kits and the Receiver sample on the other kit, test them by performing the following steps:
 
-1. Power on both boards.
-#. Observe that the LEDs change synchronously on both boards.
-#. Optionally, connect to the boards with a terminal emulator (for example, PuTTY).
+1. Power on both kits.
+#. Observe that the LEDs change synchronously on both kits.
+#. Optionally, connect to the kits with a terminal emulator (for example, PuTTY).
    See :ref:`putty` for the required settings.
-#. Observe the logging output for both boards.
+#. Observe the logging output for both kits.
 
 Dependencies
 ************

--- a/samples/event_manager/README.rst
+++ b/samples/event_manager/README.rst
@@ -51,10 +51,10 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. |connect_terminal|
-#. Reset the board.
+#. Reset the kit.
 #. Observe that output similar to the following is logged on UART::
 
       ***** Booting Zephyr OS v1.13.99-ncs1-4741-g1d6219f *****

--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -45,10 +45,9 @@ Building and Running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
-1. Connect to the board with a terminal emulator (for example, PuTTY).
-   See :ref:`putty` for the required settings.
+1. |connect_terminal|
 #. Follow the instructions in the terminal to open a session and start requesting timeslots.
    The terminal then prints the signal type for each timeslot callback:
 

--- a/samples/nfc/record_text/README.rst
+++ b/samples/nfc/record_text/README.rst
@@ -46,7 +46,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Touch the NFC antenna with the smartphone or tablet and observe that LED 1 is lit.
 #. Observe that the smartphone/tablet displays the encoded text (in the most

--- a/samples/nfc/system_off/README.rst
+++ b/samples/nfc/system_off/README.rst
@@ -77,7 +77,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Observe that LED 2 on the Tag device turns off after 3 seconds after the programming is complete.
    This indicates that the system is in the System OFF mode.

--- a/samples/nfc/tag_reader/README.rst
+++ b/samples/nfc/tag_reader/README.rst
@@ -47,11 +47,11 @@ Building and running
 
 Testing
 =======
-After programming the sample to your board, you can test it with an NFC-A Type 2 Tag or Tag 4 Type.
+After programming the sample to your development kit, you can test it with an NFC-A Type 2 Tag or Tag 4 Type.
 
-1. Connect the Nucleo expansion board to the development kit board.
+1. Connect the Nucleo expansion board to the development kit.
 #. |connect_terminal|
-#. Reset the board.
+#. Reset the kit.
 #. Touch the ST25R3911B NFC reader with a Type 2 Tag or Type 4 Tag.
 #. Observe the output in the terminal.
    The content of the tag is printed there.

--- a/samples/nfc/tnep_poller/README.rst
+++ b/samples/nfc/tnep_poller/README.rst
@@ -42,10 +42,10 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it with an NFC-A Tag device that supports NFC's TNEP.
+After programming the sample to your development kit, you can test it with an NFC-A Tag device that supports NFC's TNEP.
 
 1. |connect_terminal|
-#. Reset the board.
+#. Reset the kit.
 #. Put the NFC Tag device anntena in the range of the NFC polling device.
    The NFC polling device selects the first service and exchanges basic data with it.
    After that, the service is deselected.

--- a/samples/nfc/tnep_tag/README.rst
+++ b/samples/nfc/tnep_tag/README.rst
@@ -55,11 +55,11 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it with an NFC-A polling device that supports NFC's Tag NDEF Exchange Protocol.
+After programming the sample to your development kit, you can test it with an NFC-A polling device that supports NFC's Tag NDEF Exchange Protocol.
 
 1. |connect_terminal|
-#. Reset the board.
-#. Touch the board antenna with the NFC polling device.
+#. Reset the kit.
+#. Touch the NFC antenna with the NFC polling device.
 #. Observe the output in the terminal.
 #. If the NFC polling device selects the service two, you have 27 seconds to press Button 1 to provide application data.
    If you do not do this, the NFC polling device will deselect the service.

--- a/samples/nfc/writable_ndef_msg/README.rst
+++ b/samples/nfc/writable_ndef_msg/README.rst
@@ -54,12 +54,12 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Touch the NFC antenna with the smartphone or tablet and observe that LED 1 and LED 4 are lit.
 #. Observe that the smartphone/tablet tries to open the URL "http\://www.nordicsemi.com" in a web browser.
 #. Use a proper application (for example, NFC Tools for Android) to overwrite the existing NDEF message with your own message.
-#. Power-cycle your board and touch the antenna again.
+#. Power-cycle your kit and touch the antenna again.
    Observe that the new message is displayed.
 
 Dependencies

--- a/samples/nrf5340/empty_app_core/README.rst
+++ b/samples/nrf5340/empty_app_core/README.rst
@@ -47,7 +47,7 @@ Testing
 =======
 1. Program this sample to the application core.
 #. Program the Zephyr's :ref:`zephyr:blinky-sample` to the network core.
-#. Observe the LEDs on the board.
+#. Observe the LEDs on the kit.
 
 Dependencies
 ************

--- a/samples/nrf5340/netboot/README.rst
+++ b/samples/nrf5340/netboot/README.rst
@@ -81,7 +81,7 @@ To test the network core bootloader sample run the following commands:
    Hence, the firmware is also verified by MCUBoot on the application core.
    See :ref:`subsys_pcd` for more details.
 
-#. Reset the board.
+#. Reset the kit.
 #. Observe that the output includes ``Done updating network core``
 
 Dependencies

--- a/samples/nrf9160/agps/README.rst
+++ b/samples/nrf9160/agps/README.rst
@@ -71,7 +71,7 @@ User interface
 You can send a predefined message to nRF Connect for Cloud by pressing button 1.
 The message can be changed by setting the :option:`CONFIG_CLOUD_MESSAGE` to a new message.
 
-To ease outdoors and remote testing of A-GPS feature, two methods for resetting the board are provided, if the default A-GPS source is used.
+To ease outdoors and remote testing of A-GPS feature, two methods for resetting the kit are provided, if the default A-GPS source is used.
 Both are equivalent to pressing the reset button on the nRF9160 DK, or power-cycling the nRF9160 DK or Thingy:91.
 
 Button 1:

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -43,10 +43,10 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test the sample by performing the following steps:
+After programming the sample to your development kit, test the sample by performing the following steps:
 
-1. Press the reset button on the nRF9160 DK to reboot the board and start the AT Client sample.
-#. :ref:`Connect to the nRF9160 DK board with LTE Link Monitor<lte_connect>`.
+1. Press the reset button on the nRF9160 DK to reboot the kit and start the AT Client sample.
+#. :ref:`Connect to the nRF9160 DK with LTE Link Monitor<lte_connect>`.
 
    .. note::
 

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -31,12 +31,12 @@ The `AWS IoT Developer Guide`_ contains all required information about the Amazo
 Creating a thing in AWS IoT
 ===========================
 
-Before you can run this sample, you must create a *thing* for your board in AWS IoT so that AWS knows about your board.
+Before you can run this sample, you must create a *thing* for your development kit in AWS IoT so that AWS knows about your kit.
 This thing must be connected to a security policy.
 For testing, you can use a permissive policy, but make sure to update the policy to be more restrictive before you go into production.
 See `AWS IoT Developer Guide: Basic Policy Variables`_ and `AWS IoT Developer Guide: Security Best Practices`_ for more information about policies.
 
-To create a thing for your board:
+To create a thing for your kit:
 
 1. Log on to the `AWS IoT console`_.
 #. Go to :guilabel:`Secure` -> :guilabel:`Policies` and select :guilabel:`Create a policy`.
@@ -58,7 +58,7 @@ To create a thing for your board:
 #. Go to :guilabel:`Manage` -> :guilabel:`Things` and select :guilabel:`Register a thing` or :guilabel:`Create` (depending on whether you already have a thing registered).
 #. Select :guilabel:`Create a single thing`.
 #. Enter a name.
-   The default name used by the sample is ``nrf-IMEI``, where *IMEI* is the IMEI number of your board.
+   The default name used by the sample is ``nrf-IMEI``, where *IMEI* is the IMEI number of your kit.
    If you choose a different name, make sure to :ref:`configure a custom client ID <configuring>` in the sample before you build it.
 #. Accept the defaults and continue to the next step.
 #. Select :guilabel:`Create certificate` to generate new certificates.
@@ -73,11 +73,11 @@ To create a thing for your board:
 Updating the certificates
 =========================
 
-The certificates that you created or added for your thing in AWS IoT must be stored on your board so that it can connect to AWS IoT.
+The certificates that you created or added for your thing in AWS IoT must be stored on your kit so that it can connect to AWS IoT.
 There are two different ways of doing this:
 
 Add the certificates to the sample code:
-   If you add the certificates to the sample code, the sample will store them on your board automatically.
+   If you add the certificates to the sample code, the sample will store them on your kit automatically.
 
    .. warning_start
 
@@ -93,10 +93,10 @@ Add the certificates to the sample code:
       Make sure to not add whitespace except for the ``\n`` line breaks.
    #. Before programming the sample, configure it to provision the certificates from the :file:`certificates.h` file (:option:`PROVISION_CERTIFICATES`) and to use a different security tag (:option:`CLOUD_CERT_SEC_TAG`).
 
-Use LTE Link Monitor to write the certificates to the board:
-   The nRF Connect `LTE Link Monitor`_ provides a certificate manager that you can use to store the certificates on your board:
+Use LTE Link Monitor to write the certificates to the kit:
+   The nRF Connect `LTE Link Monitor`_ provides a certificate manager that you can use to store the certificates on your kit:
 
-   1. Make sure that you have the AT client sample programmed on your board.
+   1. Make sure that you have the AT client sample programmed on your kit.
    #. Put the modem in offline state.
    #. Paste the three certificates into the respective fields.
    #. Choose a security tag.
@@ -152,8 +152,8 @@ Before you build the sample, check and update the following configuration option
 
 .. option:: USE_CLOUD_CLIENT_ID - Custom MQTT client ID
 
-   The client ID links your board to the thing in AWS IoT.
-   By default, the client ID is ``nrf-IMEI``, where *IMEI* is the IMEI number of your board.
+   The client ID links your kit to the thing in AWS IoT.
+   By default, the client ID is ``nrf-IMEI``, where *IMEI* is the IMEI number of your kit.
    If you chose a different name for your thing in AWS IoT, check this option and specify the AWS IoT thing name as client ID.
 
 .. option:: USE_NRF_CLOUD - Use nRF Connect for Cloud
@@ -175,10 +175,10 @@ For all other values, use the default values unless you are using a custom MQTT 
 Testing
 =======
 
-After programming the sample to the board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. |connect_terminal|
-#. Reset the board.
+#. Reset the kit.
 #. Confirm that the sample prints the configured application version and connects to AWS IoT.
    You should see output like the following::
 
@@ -248,7 +248,7 @@ After programming the sample to the board, test it by performing the following s
       [00:05:20.585,266] <inf> aws_fota: Firmware download completed
 
 
-#. When the board resets, observe that the sample prints the new application version.
+#. When the kit resets, observe that the sample prints the new application version.
 #. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` -> :guilabel:`Things`, and select your thing.
 #. Go to :guilabel:`Shadow` and confirm that the application version has updated.
 

--- a/samples/nrf9160/coap_client/README.rst
+++ b/samples/nrf9160/coap_client/README.rst
@@ -20,7 +20,7 @@ The nRF CoAP Client sample performs the following actions:
 
 The public CoAP server used in this sample is Californium CoAP server (``coap://californium.eclipseprojects.io:5683``).
 This server runs Eclipse Californium, which is an open source implementation of the CoAP protocol that is targeted at the development and testing of IoT applications.
-An nRF9160 DK board is used as the CoAP client.
+An nRF9160 DK is used as the CoAP client.
 
 This sample uses the resource **obs** (Californium observable resource) in the communication between the CoAP client and the public CoAP server.
 The communication follows the standard request/response pattern and is based on the change in the state of the value of the resource.
@@ -51,7 +51,7 @@ Building and running
 Testing
 =======
 
-After programming the sample and all prerequisites to the board, test it by performing the following steps:
+After programming the sample and all prerequisites to the development kit, test it by performing the following steps:
 
 1. Connect your nRF9160 DK to the PC using a USB cable and power on or reset your nRF9160 DK.
 #. Open a terminal emulator and observe that the following information is displayed::

--- a/samples/nrf9160/download/README.rst
+++ b/samples/nrf9160/download/README.rst
@@ -98,7 +98,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Connect the development kit to your PC using a USB cable and power on or reset the kit.
 #. Open a terminal emulator and observe that the sample starts, provisions certificates, and starts to download.

--- a/samples/nrf9160/gps/README.rst
+++ b/samples/nrf9160/gps/README.rst
@@ -61,7 +61,7 @@ The SUPL client library is not required, and the sample will work without `A-GPS
 Testing
 =======
 
-After programming the sample and all the prerequisites to the board, you can test the sample by performing the following steps:
+After programming the sample and all the prerequisites to the development kit, you can test the sample by performing the following steps:
 
 1. Connect your nRF9160 DK to the PC using a USB cable and power on or reset your nRF9160 DK.
 2. Open a terminal emulator.

--- a/samples/nrf9160/http_update/application_update/README.rst
+++ b/samples/nrf9160/http_update/application_update/README.rst
@@ -76,7 +76,7 @@ Specify the file name as the remaining part of the URL.
 Testing
 =======
 
-After programming the sample to the board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Configure the application version to be 2.
    To do so, either change ``CONFIG_APPLICATION_VERSION`` to 2 in the :file:`prj.conf` file, or select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project` -> :guilabel:`HTTP application update sample` in |SES| and change the value for :guilabel:`Application version`.
@@ -95,7 +95,7 @@ After programming the sample to the board, test it by performing the following s
 #. Observe that **LED 1** is lit.
    This indicates that version 1 of the application is running.
 #. Press **Button 1** on the nRF9160 DK to start the download process and wait until "Download complete" is printed in the terminal.
-#. Press the **RESET** button on the board.
+#. Press the **RESET** button on the kit.
    MCUboot will now detect the downloaded image and write it to flash.
    This can take up to a minute and nothing is printed in the terminal while this is processing.
 #. Observe that **LED 1** and **LED 2** is lit.

--- a/samples/nrf9160/http_update/modem_delta_update/README.rst
+++ b/samples/nrf9160/http_update/modem_delta_update/README.rst
@@ -44,7 +44,7 @@ Because of this, it automatically includes the :ref:`secure_partition_manager`.
 Testing
 =======
 
-After programming the sample to the board, test it by performing the following steps:
+After programming the sample to your development kit,, test it by performing the following steps:
 
 1. Note the LED pattern (1 or 2 LEDs).
 #. Press button 1 to download the delta for the alternative firmware version.

--- a/samples/nrf9160/https_client/README.rst
+++ b/samples/nrf9160/https_client/README.rst
@@ -52,7 +52,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Connect the USB cable and power on or reset your nRF9160 DK.
 #. Open a terminal emulator and observe that the sample starts, provisions certificates, connects to the LTE network and to google.com, and then sends an HTTP HEAD request.

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -40,7 +40,7 @@ The sample also requires a `Nordic Thingy:52`_.
 User interface
 **************
 
-Two buttons and two switches are used to enter a pairing pattern to associate a specific board with an nRF Connect for Cloud user account.
+Two buttons and two switches are used to enter a pairing pattern to associate a specific development kit with an nRF Connect for Cloud user account.
 
 When the connection is established, set switch 2 to **N.C.** to send simulated GPS data to nRF Connect for Cloud once every 2 seconds.
 
@@ -90,8 +90,8 @@ After programming the main controller with the sample, you can test it as follow
 #. Open a web browser and navigate to https://nrfcloud.com/.
    Follow the instructions to set up your account and to add an LTE device.
    A pattern of switch and button actions is displayed on the webpage.
-#. Power on or reset the board.
-#. Observe in the terminal window connected to the first serial port that the board starts up in the Secure Partition Manager.
+#. Power on or reset the kit.
+#. Observe in the terminal window connected to the first serial port that the kit starts up in the Secure Partition Manager.
    This is indicated by an output similar to the following lines:
 
    .. code-block:: console
@@ -107,17 +107,17 @@ After programming the main controller with the sample, you can test it as follow
    a. Observe that both LED 3 and 4 start blinking, indicating that the pairing procedure has been initiated.
    #. Follow the instructions on `nRF Connect for Cloud`_ and enter the displayed pattern.
       In the terminal window, you can see the pattern that you have entered.
-   #. If the pattern is entered correctly, the board and your nRF Connect for Cloud account are paired and the device reboots.
+   #. If the pattern is entered correctly, the kit and your nRF Connect for Cloud account are paired and the device reboots.
       If the LEDs start blinking in pairs, check in the terminal window which error occurred.
       The device must be power-cycled to restart the pairing procedure.
-   #. After reboot, the board connects to nRF Connect for Cloud, and the pattern disappears from the web page.
+   #. After reboot, the kit connects to nRF Connect for Cloud, and the pattern disappears from the web page.
 #. Observe that LED 4 is turned on to indicate that the connection is established.
 #. Observe that the device count on your nRF Connect for Cloud dashboard is incremented by one.
 #. Set switch 2 in the position marked as **N.C.** and observe that simulated GPS data is sent to nRF Connect for Cloud.
 #. Make sure that the Thingy:52 has established a connection to the application.
    This is indicated by its led blinking green.
 #. Flip the Thingy:52, with the USB port pointing upward, to trigger the sending of the sensor data to nRF Connect for Cloud.
-#. Select the device from your device list on nRF Connect for Cloud, and observe that the sensor data is received from the board.
+#. Select the device from your device list on nRF Connect for Cloud, and observe that the sensor data is received from the kit.
 #. Observe that the data is updated in nRF Connect for Cloud.
 
 

--- a/samples/nrf9160/lwm2m_carrier/README.rst
+++ b/samples/nrf9160/lwm2m_carrier/README.rst
@@ -30,7 +30,7 @@ Building and running
 Testing
 =======
 
-After programming the sample and all prerequisites to the board, test it by performing the following steps:
+After programming the sample and all prerequisites to the development kit, test it by performing the following steps:
 
 1. Connect the USB cable and power on or reset your nRF9160 DK.
 #. Open a terminal emulator and observe that the kit prints the following information::

--- a/samples/nrf_rpc/entropy_nrf53/README.rst
+++ b/samples/nrf_rpc/entropy_nrf53/README.rst
@@ -64,7 +64,7 @@ This sample consists of the following sample applications, one each for the appl
 Both of these sample applications must be built and programmed to the dual core device before testing.
 For details on building samples for a dual core device, see :ref:`ug_nrf5340_building`.
 
-After programming the sample to your board, test it by performing the following steps:
+After programming the sample to your development kit, test it by performing the following steps:
 
 1. Connect the dual core development kit to the computer using a USB cable.
    The development kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -119,7 +119,7 @@ Optionally, you can use one or more compatible development kits programmed with 
 Thread v1.2 extension requirements
 ==================================
 
-If you enable the :ref:`experimental Thread v1.2 extension <ot_cli_sample_thread_v12>`, you will need `nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`_ to observe messages sent from the router to the leader board when :ref:`testing v1.2 features <ot_cli_sample_testing_multiple_v12>`.
+If you enable the :ref:`experimental Thread v1.2 extension <ot_cli_sample_thread_v12>`, you will need `nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`_ to observe messages sent from the router to the leader kit when :ref:`testing v1.2 features <ot_cli_sample_testing_multiple_v12>`.
 
 User interface
 **************
@@ -198,18 +198,18 @@ After building the sample and programming it to your development kit, test it by
 
 .. _ot_cli_sample_testing_multiple:
 
-Testing with more boards
-------------------------
+Testing with more kits
+----------------------
 
 If you are using more than one development kit for testing the CLI sample, you can also complete additional testing procedures.
 
 .. note::
     The following testing procedures assume you are using two development kits.
 
-Testing communication between boards
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Testing communication between kits
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To test communication between boards, complete the following steps:
+To test communication between kits, complete the following steps:
 
 #. Make sure both development kits are programmed with the CLI sample.
 #. Turn on the developments kits.
@@ -220,12 +220,12 @@ To test communication between boards, complete the following steps:
         |thread_hwfc_enabled|
 
 #. .. include:: /includes/thread_enable_network.txt
-#. Test communication between the boards with the following command:
+#. Test communication between the kits with the following command:
 
    .. parsed-literal::
       :class: highlight
 
-      ot ping *ip_address_of_the_first_board*
+      ot ping *ip_address_of_the_first_kit*
 
    For example:
 
@@ -297,7 +297,7 @@ To test the Thread Specification v1.2 features, complete the following steps:
 #. Set up the serial connection with both development kits.
    For more details, see :ref:`putty`.
 #. .. include:: /includes/thread_enable_network.txt
-#. Test the state of the Thread network with the ``ot state`` command to see which board is the leader:
+#. Test the state of the Thread network with the ``ot state`` command to see which kit is the leader:
 
    .. code-block:: console
 
@@ -305,7 +305,7 @@ To test the Thread Specification v1.2 features, complete the following steps:
       leader
       Done
 
-#. On the leader board, enable the Backbone Router function:
+#. On the leader kit, enable the Backbone Router function:
 
    .. code-block:: console
 
@@ -315,7 +315,7 @@ To test the Thread Specification v1.2 features, complete the following steps:
       I: State changed! Flags: 0x00000200 Current role: 4
       I: State changed! Flags: 0x02000001 Current role: 4
 
-#. On the leader board, configure the Domain prefix:
+#. On the leader kit, configure the Domain prefix:
 
    .. code-block:: console
 
@@ -326,7 +326,7 @@ To test the Thread Specification v1.2 features, complete the following steps:
       I: State changed! Flags: 0x00000200 Current role: 4
       I: State changed! Flags: 0x00001001 Current role: 4
 
-#. On the router board, display the autoconfigured Domain Unicast Address and set another one manually:
+#. On the router kit, display the autoconfigured Domain Unicast Address and set another one manually:
 
    .. code-block:: console
 
@@ -345,7 +345,7 @@ To test the Thread Specification v1.2 features, complete the following steps:
       fe80:0:0:0:acbd:53bf:1461:a861
       Done
 
-#. On the router board, configure a multicast address with a scope greater than realm-local:
+#. On the router kit, configure a multicast address with a scope greater than realm-local:
 
    .. code-block:: console
 
@@ -363,7 +363,7 @@ To test the Thread Specification v1.2 features, complete the following steps:
       ff03:0:0:0:0:0:0:fc
       Done
 
-   The router board will send an ``MLR.req`` message to the leader board (Backbone Router).
+   The router kit will send an ``MLR.req`` message to the leader kit (Backbone Router).
    This can be observed using the `nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`_.
 
    .. note::

--- a/samples/openthread/ncp/README.rst
+++ b/samples/openthread/ncp/README.rst
@@ -10,7 +10,7 @@ Thread: NCP
 The :ref:`Thread <ug_thread>` NCP sample demonstrates the usage of OpenThread's :ref:`thread_architectures_designs_cp_ncp` architecture inside the Zephyr environment.
 
 The sample is based on Zephyr's :ref:`zephyr:coprocessor-sample` sample.
-However, it customizes Zephyr's sample to the NCS requirements (for example, by increasing the stack size dedicated for the user application), and also extends it with several features:
+However, it customizes Zephyr's sample to the |NCS| requirements (for example, by increasing the stack size dedicated for the user application), and also extends it with several features:
 
 * Increased mbedTLS heap size.
 * Lowered main stack size to increase user application space.
@@ -66,8 +66,8 @@ The sample supports the following development kits for testing the network statu
    :header: heading
    :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
 
-To test the sample, you need at least one development kit NCP board.
-Additional NCP boards can be used for the :ref:`optional testing of network joining <ot_ncp_sample_testing_more_boards>`.
+To test the sample, you need at least one development kit.
+Additional development kits programmed with the NCP sample can be used for the :ref:`optional testing of network joining <ot_ncp_sample_testing_more_boards>`.
 
 Moreover, the sample requires a Userspace higher layer process running on user's device in order to communicate with the MCU NCP part.
 This sample uses `wpantund`_ as reference.
@@ -78,7 +78,7 @@ User interface
 All the interactions with the application are handled using serial communication.
 
 For the interaction with the application, this sample uses :ref:`ug_thread_tools_wpantund` process with ``wpanctl`` commands.
-It is also possible to communicate with NCP board using `PySpinel`_ commands.
+It is also possible to communicate with the kit using `PySpinel`_ commands.
 
 You can use your own application instead of wpantund and PySpinel provided that it supports the spinel communication protocol.
 
@@ -136,10 +136,10 @@ Testing
 
 After building the sample and programming it to your development kit, test it by performing the following steps:
 
-1. Connect the NCP board's SEGGER J-Link USB port to the PC USB port with an USB cable.
-#. Get the board's serial port name (e.g. /dev/ttyACM0).
+1. Connect the development kit's SEGGER J-Link USB port to the PC USB port with an USB cable.
+#. Get the kit's serial port name (e.g. /dev/ttyACM0).
 #. Run and configure wpantund and wpanctl as described in :ref:`ug_thread_tools_wpantund_configuring`.
-#. In the wpanctl shell, run the following command to check the NCP board state:
+#. In the wpanctl shell, run the following command to check the kit state:
 
    .. code-block:: console
 
@@ -204,31 +204,31 @@ This output means that you have successfully formed the Thread network.
 
 .. _ot_ncp_sample_testing_more_boards:
 
-Testing network joining with more NCP boards
---------------------------------------------
+Testing network joining with more kits
+--------------------------------------
 
-Optionally, if you are using more than one NCP board, you can test the network joining process by completing the following steps:
+Optionally, if you are using more than one kit, you can test the network joining process by completing the following steps:
 
-1. Connect the second NCP board's SEGGER J-Link USB port to the PC USB port with an USB cable.
-#. Get the board's serial port name.
-#. Open a shell and run another wpantund process for the second board by using the following command:
+1. Connect the second kit's SEGGER J-Link USB port to the PC USB port with an USB cable.
+#. Get the kit's serial port name.
+#. Open a shell and run another wpantund process for the second kit by using the following command:
 
    .. parsed-literal::
       :class: highlight
 
-      wpantund -I *network_interface_name_board2* -s *serial_port_name_board2* -b *baudrate*
+      wpantund -I *network_interface_name_kit2* -s *serial_port_name_kit2* -b *baudrate*
 
    For *baudrate*, use value 1000000.
-   For *serial_port_name_board2*, use the value from the previous step.
-   For *network_interface_name_board2*, use a name of your choice.
+   For *serial_port_name_kit2*, use the value from the previous step.
+   For *network_interface_name_kit2*, use a name of your choice.
    In this testing procedure, this will be `joiner_if`.
-#. Open another shell and run another wpanctl process for the second board by using following command:
+#. Open another shell and run another wpanctl process for the second kit by using following command:
 
    .. code-block:: console
 
       wpanctl -I joiner_if
 
-#. In the wpanctl shell, run the following command to check the NCP board state:
+#. In the wpanctl shell, run the following command to check the kit state:
 
    .. code-block:: console
 
@@ -248,7 +248,7 @@ Optionally, if you are using more than one NCP board, you can test the network j
       ]
 
    This output means that NCP is offline.
-#. In the wpanctl shell of the first NCP board, run the following command to get the network key from the leader NCP board:
+#. In the wpanctl shell of the first kit, run the following command to get the network key from the leader kit:
 
    .. code-block:: console
 
@@ -260,13 +260,13 @@ Optionally, if you are using more than one NCP board, you can test the network j
 
       Network:Key = [2429EFAF21421AE3CB30B9204016EDC9]
 
-#. Copy the network key form the output and set it on the second (joiner) NCP board by running the following command in the second board's wpanctl shell:
+#. Copy the network key form the output and set it on the second (joiner) kit by running the following command in the second kit's wpanctl shell:
 
    .. code-block:: console
 
       wpanctl:joiner_if> set Network:Key 2429EFAF21421AE3CB30B9204016EDC9
 
-#. In the second board's wpanctl shell, run the following command to scan your neighborhood and find the network formed with the leader NCP board:
+#. In the second kit's wpanctl shell, run the following command to scan your neighborhood and find the network formed with the leader kit:
 
    .. code-block:: console
 
@@ -283,7 +283,7 @@ Optionally, if you are using more than one NCP board, you can test the network j
 
    The first column is the network ID number.
    For the network formed for this testing procedure, the ID equals ``2``.
-#. In the second board's wpanctl shell, run the following command with the network ID as variable to join your joiner NCP board to the network:
+#. In the second kit's wpanctl shell, run the following command with the network ID as variable to join your joiner kit to the network:
 
    .. code-block:: console
 
@@ -296,7 +296,7 @@ Optionally, if you are using more than one NCP board, you can test the network j
       Joining WPAN "My_OpenThread_network" as node type "end-device", channel:13, panid:0xF54B, xpanid:0x77969855F947758D [scanned network index 2]
       Successfully Joined!
 
-This output means that the joiner board node has successfully joined the network.
+This output means that the joiner kit node has successfully joined the network.
 
 Dependencies
 ************

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -17,11 +17,11 @@ The sample provides a set of predefined commands that allow you to configure the
 Overview
 ********
 
-You can run the tests by connecting to the board through the serial port and sending shell commands.
+You can run the tests by connecting to the development kit through the serial port and sending shell commands.
 Zephyr's :ref:`zephyr:shell_api` module is used to handle the commands.
 At any time during the tests, you can dynamically set the radio parameters, such as output power, bit rate, and channel.
 In sweep mode, you can set the time for which the radio scans each channel from 1 millisecond to 99 milliseconds, in steps of 1 millisecond.
-The sample also allows you to send a data pattern to another board.
+The sample also allows you to send a data pattern to another development kit.
 
 The sample starts with enabling the high frequency crystal oscillator and configuring the shell.
 You can then start running commands to set up and control the radio.
@@ -47,9 +47,9 @@ You can use any one of the development kits listed above.
 
 The sample also requires one of the following testing devices:
 
-  * Another board with the same sample.
+  * Another development kit with the same sample.
     See :ref:`radio_test_testing_board`.
-  * Another board connected to a PC with RSSI Viewer application (available in the `nRF Connect for Desktop`_).
+  * Another development kit connected to a PC with RSSI Viewer application (available in the `nRF Connect for Desktop`_).
     See :ref:`radio_test_testing_rssi`.
 
 .. note::
@@ -131,27 +131,27 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it in one of two ways.
+After programming the sample to your development kit, you can test it in one of two ways.
 
 .. note::
    For the |nRF5340DKnoref|, see :ref:`logging_cpunet` for information about the COM terminals on which the logging output is available.
 
 .. _radio_test_testing_board:
 
-Testing with another board
---------------------------
+Testing with another development kit
+------------------------------------
 
-1. Connect both boards to the computer using a USB cable.
-   The boards are assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
+1. Connect both development kits to the computer using a USB cable.
+   The kits are assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal_both|
-#. Run the following commands on one of the boards:
+#. Run the following commands on one of the kits:
    #. Set the data rate with the ``data_rate`` command to ``ble_2Mbit``.
    #. Set the transmission pattern with the ``transmit_pattern`` command to ``pattern_11110000``.
    #. Set the radio channel with the ``start_channel`` command to 40.
-#. Repeat all steps for the second board.
-#. On both boards, run the ``parameters_print`` command to confirm that the radio configuration is the same on both boards.
-#. Set one board in the Modulated TX Carrier mode using the ``start_tx_modulated_carrier`` command.
-#. Set the other board in the RX Carrier mode using the ``start_rx`` command.
+#. Repeat all steps for the second kit.
+#. On both kits, run the ``parameters_print`` command to confirm that the radio configuration is the same on both kits.
+#. Set one kit in the Modulated TX Carrier mode using the ``start_tx_modulated_carrier`` command.
+#. Set the other kit in the RX Carrier mode using the ``start_rx`` command.
 #. Print the received data with the ``print_rx`` command and confirm that they match the transmission pattern (0xF0).
 
 .. _radio_test_testing_rssi:
@@ -159,14 +159,14 @@ Testing with another board
 Testing with RSSI Viewer
 ------------------------
 
-1. Connect the board to the computer using a USB cable.
-   The board is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
+1. Connect the kit to the computer using a USB cable.
+   The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal|
 #. Set the start channel with the ``start_channel`` command to 20.
 #. Set the end channel with the ``end_channel`` command to 60.
 #. Set the time on channel with the ``time_on_channel`` command to 50ms.
-#. Set the board in the TX sweep mode using the ``start_tx_sweep`` command.
-#. Start the RSSI Viewer application and select the board to communicate with.
+#. Set the kit in the TX sweep mode using the ``start_tx_sweep`` command.
+#. Start the RSSI Viewer application and select the kit to communicate with.
 #. On the application chart, observe the TX sweep in the form of a wave that starts at 2420 MHz frequency and ends with 2480MHz.
 
 Dependencies

--- a/samples/profiler/README.rst
+++ b/samples/profiler/README.rst
@@ -42,14 +42,14 @@ Building and running
 Testing
 =======
 
-After programming the sample to your board, you can test it by running the script ``real_time_plot.py`` (located under :file:`scripts/profiler`).
+After programming the sample to your development kit, you can test it by running the script ``real_time_plot.py`` (located under :file:`scripts/profiler`).
 As an argument, pass the name that should be used to store the data.
 For example, run ``real_time_plot.py test_name`` to generate a :file:`test_name.csv` and a :file:`test_name.json` file.
 
 The script opens a GUI window that displays events as points on timelines.
 See the Profiler documentation for more information.
 
-Connect to the board with a terminal emulator (for example, PuTTY) to see messages displayed by the sample.
+Connect to the development kit with a terminal emulator (for example, PuTTY) to see messages displayed by the sample.
 See :ref:`putty` for the required settings.
 
 .. tip::

--- a/samples/spm/README.rst
+++ b/samples/spm/README.rst
@@ -72,14 +72,14 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-The sample is built as a secure firmware image for the nrf9160dk_nrf9160 and nrf5340dk_nrf5340 boards.
+The sample is built as a secure firmware image for the nrf9160dk_nrf9160 and nrf5340dk_nrf5340 build targets.
 See `Automatic building of SPM`_ if you want to program it independently from the non-secure application firmware.
 
 
 Testing
 =======
 
-Program both the sample and your application firmware to the board.
+Program both the sample and your application firmware to the development kit.
 After power-up, the sample starts your application firmware.
 
 Observe that the application firmware operates as expected.

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -148,7 +148,7 @@ Sleepy End Device behavior assignments
 ======================================
 
 Button 3:
-    When pressed while resetting the board, enable the :ref:`zigbee_ug_sed`.
+    When pressed while resetting the kit, enable the :ref:`zigbee_ug_sed`.
 
 Multiprotocol Bluetooth LE extension assignments
 ================================================

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -613,7 +613,7 @@ See the following example, which assigns a cryptographically signed HEX file bui
    )
 
 
-As output, the Partition Manager creates a HEX file called :file:`merged.hex`, which is programmed to the board when calling ``ninja flash``.
+As output, the Partition Manager creates a HEX file called :file:`merged.hex`, which is programmed to the development kit when calling ``ninja flash``.
 When creating :file:`merged.hex`, all assigned HEX files are included in the merge operation.
 If the HEX files overlap, the conflict is resolved as follows:
 


### PR DESCRIPTION
Make the usage of the terms "board", "development kit"/"kit", and
"build target" more consistent.
A board is what has a board folder in Zephyr. A development kit is a
device and corresponds to one or more boards (for example, the
nRF9160 DK has two boards, nrf9160dk_nrf9160 and nrf9160dk_nrf52840).
A build target is what you specify for building. A board can have
several build targets. For example, nrf9160dk_nrf9160 has the build
targets nrf9160dk_nrf9160 and nrf9160dk_nrf9160ns.

Ref. NCSDK-7839

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>