### PR TITLE
ci: update documentation publishing workflow

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -2,6 +2,10 @@ name: Documentation Build
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
+  push:
     branches:
       - master
 
@@ -89,12 +93,20 @@ jobs:
       - name: Archive documentation
         working-directory: ncs/_build
         run: |
-          # FIXME: must be updated once push (master) is added to events
-          mkdir pr && cd pr
-          tar -C ../html -zcf doc_build_pr-${{ github.event.number }}.tar.gz .
+          mkdir doc && cd doc
+          file="doc_build_${GITHUB_RUN_ID}.tgz"
+          tar -C ../html -zcf $file .
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "publish PR-${{ github.event.number }} $file" > monitor_$GITHUB_RUN_ID.txt
+            echo "${{ github.event.number }}" > pr.txt
+          else
+            # basename will work for both branches and tags
+            branch=$(basename "${{ github.ref }}")
+            echo "publish ${branch} $file" > monitor_$GITHUB_RUN_ID.txt
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: pr
-          path: ncs/_build/pr/
+          name: doc
+          path: ncs/_build/doc

--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -2,17 +2,14 @@ name: Documentation Publish
 
 on:
   workflow_run:
-    workflows: ["Documentation Build"]
+    workflows: ["Documentation Build", "Documentation Remove"]
     types:
       - completed
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' }}
-
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: 'Download artifact'
         uses: actions/github-script@v3.1.0
@@ -24,7 +21,7 @@ jobs:
                run_id: ${{ github.event.workflow_run.id }},
             });
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr"
+              return artifact.name == "doc"
             })[0];
             var download = await github.actions.downloadArtifact({
                owner: context.repo.owner,
@@ -33,16 +30,27 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+            fs.writeFileSync('${{github.workspace}}/doc.zip', Buffer.from(download.data));
 
       - name: Upload documentation
         env:
           SSHUSER: ${{ secrets.NCS_TRANSFER_DOC_USR }}
           SSHPASS: ${{ secrets.NCS_TRANSFER_DOC_PWD }}
         run: |
-          unzip pr.zip
-          file=$(ls doc_build_pr-*.tar.gz)
+          unzip doc.zip
+          # Don't upload the archive and workflow metadata
+          files=$(ls -I doc.zip -I pr.txt)
           mkdir -p ~/.ssh && \
             ssh-keyscan -p 2222 transfer.nordicsemi.no >> ~/.ssh/known_hosts
-          echo "put ${file}" | \
-            sshpass -e sftp -P 2222 -o BatchMode=no -b - $SSHUSER@transfer.nordicsemi.no
+          for file in $files; do
+            echo "put ${file}" | \
+              sshpass -e sftp -P 2222 -o BatchMode=no -b - $SSHUSER@transfer.nordicsemi.no
+          done
+
+      - name: Add preview URL comment for PRs
+        uses: carlescufi/action-doc-url@main
+        with:
+          github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
+          urlroot: ${{ secrets.NCS_DOC_URL_ROOT }}
+          pr-prefix: "PR-"
+          pr-file: pr.txt

--- a/.github/workflows/docremove.yml
+++ b/.github/workflows/docremove.yml
@@ -1,0 +1,23 @@
+name: Documentation Remove
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Remove documentation
+        run: |
+          mkdir doc && cd doc
+          echo "remove PR-${{ github.event.number }}" > monitor_$GITHUB_RUN_ID.txt
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: doc
+          path: doc


### PR DESCRIPTION
This updates the documentation publishing to use a better format to communicate information to the backend. As well as sending the archive, a file named `monitor_$GITHUB_RUN_ID.txt` (for uniquenes) is also added with commands and parameters. The backend currently supports `"publish <folder> <archive.tgz>"` for uncompressing `archive.tgz` under `folder`, and `"remove <folder>"` to remove a tree under `folder`.

A new worflow was add to run when a PR is merged/closed, sending information to the backend to remove the local folder.
    
An extra step was added to invoke `carlescufi/action-doc-url` to comment on the PR with the link to the published documentation. A new secret, `NCS_DOC_URL_ROOT`, must be configured with the URL root where the documentation will live.
    
Publishing of the `master` branch was also enabled.