### PR TITLE
Bluetooth: Mesh: Add reset handlers in the HSL and xyL clients

### DIFF
--- a/subsys/bluetooth/mesh/light_hsl_cli.c
+++ b/subsys/bluetooth/mesh/light_hsl_cli.c
@@ -240,8 +240,17 @@ static int bt_mesh_light_hsl_cli_init(struct bt_mesh_model *model)
 	return 0;
 }
 
+static void bt_mesh_light_hsl_cli_reset(struct bt_mesh_model *model)
+{
+	struct bt_mesh_light_hsl_cli *cli = model->user_data;
+
+	net_buf_simple_reset(cli->pub.msg);
+	model_ack_reset(&cli->ack_ctx);
+}
+
 const struct bt_mesh_model_cb _bt_mesh_light_hsl_cli_cb = {
 	.init = bt_mesh_light_hsl_cli_init,
+	.reset = bt_mesh_light_hsl_cli_reset,
 };
 
 static int get_msg(struct bt_mesh_light_hsl_cli *cli,

--- a/subsys/bluetooth/mesh/light_xyl_cli.c
+++ b/subsys/bluetooth/mesh/light_xyl_cli.c
@@ -153,8 +153,17 @@ static int bt_mesh_light_xyl_cli_init(struct bt_mesh_model *model)
 	return 0;
 }
 
+static void bt_mesh_light_xyl_cli_reset(struct bt_mesh_model *model)
+{
+	struct bt_mesh_light_xyl_cli *cli = model->user_data;
+
+	net_buf_simple_reset(cli->pub.msg);
+	model_ack_reset(&cli->ack_ctx);
+}
+
 const struct bt_mesh_model_cb _bt_mesh_light_xyl_cli_cb = {
 	.init = bt_mesh_light_xyl_cli_init,
+	.reset = bt_mesh_light_xyl_cli_reset,
 };
 
 static int get_msg(struct bt_mesh_light_xyl_cli *cli,


### PR DESCRIPTION
Copies the standard client model reset handler into the HSL and xyL
client models.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>