### PR TITLE
nrf_modem_os: maps NRF_ENOTSOCK to errno ENOTSOCK

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -258,6 +258,9 @@ void nrf_modem_os_errno_set(int err_code)
 	case NRF_EPROTONOSUPPORT:
 		errno = EPROTONOSUPPORT;
 		break;
+	case NRF_ENOTSOCK:
+		errno = ENOTSOCK;
+		break;
 	case NRF_ESOCKTNOSUPPORT:
 		errno = ESOCKTNOSUPPORT;
 		break;


### PR DESCRIPTION
This will require introducing ENOTSOCK first. It hasn't been defined yet but the PR NordicPlayground/libmodem#56 introduces it once it gets merged.