### PR TITLE
doc: update year in doc footer

### DIFF
--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -11,7 +11,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Kconfig reference'
-copyright = '2019, Nordic Semiconductor'
+copyright = '2019-2021, Nordic Semiconductor'
 author = 'Nordic Semiconductor'
 
 # Get rid of version number while keeping the spacing the same as for other

--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -94,7 +94,7 @@ master_doc = 'wrapper'
 
 # General information about the project.
 project = 'MCUboot'
-copyright = '2019-2020'
+copyright = '2019-2021'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -104,7 +104,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'nRF Connect SDK'
-copyright = '2019-2020, Nordic Semiconductor'
+copyright = '2019-2021, Nordic Semiconductor'
 author = 'Nordic Semiconductor'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -87,7 +87,7 @@ master_doc = 'README'
 
 # General information about the project.
 project = 'nrfxlib'
-copyright = '2019-2020, Nordic Semiconductor'
+copyright = '2019-2021, Nordic Semiconductor'
 author = 'Nordic Semiconductor'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -99,7 +99,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Zephyr Project'
-copyright = u'2015-2020 Zephyr Project members and individual contributors.'
+copyright = u'2015-2021 Zephyr Project members and individual contributors'
 author = u'The Zephyr Project'
 
 # The following code tries to extract the information by reading the Makefile,


### PR DESCRIPTION
Update year to 2021 in the footer for all docsets.

Signed-off-by: Bartosz Gentkowski <bartosz.gentkowski@nordicsemi.no>