### PR TITLE
doc: update Bluetooth Host naming

### DIFF
--- a/doc/nrf/releases/release-notes-1.2.0.rst
+++ b/doc/nrf/releases/release-notes-1.2.0.rst
@@ -209,7 +209,7 @@ BSD library
 nRF5340
 =======
 
-This release demonstrates a dual-core solution with the Bluetooth LE Controller running on the network core and the Bluetooth LE Host and application running on the application core of the nRF5340.
+This release demonstrates a dual-core solution with the Bluetooth LE Controller running on the network core and the Bluetooth Host and application running on the application core of the nRF5340.
 
 Both Nordic Semiconductor's nRF Bluetooth LE Controller and Zephyr's Bluetooth LE Controller have been ported to run on the network core (nrf5340_dk_nrf5340_cpunet).
 The application core (nrf5340_dk_nrf5340_cpuapp) can run Bluetooth LE samples from both the |NCS| and Zephyr.
@@ -344,7 +344,7 @@ Bluetooth Low Energy
 * Enabled UART flow control in the :ref:`peripheral_uart` sample to avoid data loss.
 
 * Changed the :ref:`ble_throughput` sample to prevent it from running Bluetooth LE scanning and advertising in parallel.
-  The feature to establish a connection in both master and slave role at the same time is not supported by the Zephyr Bluetooth LE Host.
+  The feature to establish a connection in both master and slave role at the same time is not supported by the Zephyr Bluetooth Host.
 
 * :ref:`nrf_bt_scan_readme`:
 

--- a/doc/nrf/ug_ble_controller.rst
+++ b/doc/nrf/ug_ble_controller.rst
@@ -19,7 +19,7 @@ The |NCS| contains two implementations of a Bluetooth LE Controller:
 The SoftDevice Controller is implemented by Nordic Semiconductor.
 The Zephyr Bluetooth LE Controller is an open source Link Layer developed in `Zephyr`_, to which Nordic Semiconductor is a contributor.
 
-Both Link Layers integrate with the Zephyr Bluetooth LE Host, which completes the full Bluetooth LE protocol stack solution in the |NCS|.
+Both Link Layers integrate with the Zephyr Bluetooth Host, which completes the full Bluetooth LE protocol stack solution in the |NCS|.
 It is possible to select either Bluetooth LE Controller for application development.
 See `Usage in samples`_ for more information.
 

--- a/doc/nrf/ug_bt_mesh_concepts.rst
+++ b/doc/nrf/ug_bt_mesh_concepts.rst
@@ -13,7 +13,7 @@ For more information about the |NCS| implementation of the Bluetooth mesh, see :
 
 The Bluetooth mesh is based on the Bluetooth LE part of the Bluetooth 4.0 Specification, and shares the lowest layers with this protocol.
 On-air, the Bluetooth mesh physical representation is compatible with existing Bluetooth LE devices, as mesh messages are contained inside the payload of Bluetooth LE *advertisement* packets.
-However, Bluetooth mesh specifies a completely new host layer, and although some concepts are shared, Bluetooth mesh is incompatible with the Bluetooth LE host layer.
+However, Bluetooth mesh specifies a completely new host stack, and although some concepts are shared, Bluetooth mesh is incompatible with the Bluetooth Host.
 
 .. figure:: /images/bt_mesh_and_ble.svg
    :alt: Relationship between Bluetooth mesh and Bluetooth LE specifications


### PR DESCRIPTION
Changed the remaining occurrences of Bluetooth LE Host in sdk-nrf.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>