### PR TITLE
applications: nrf_desktop: Fix handling send_always

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -863,6 +863,11 @@ static bool report_send(struct report_data *rd, bool check_state, bool send_alwa
 		}
 	}
 
+	/* Ensure that report marked as send_always will be sent. */
+	if (send_always && !report_sent) {
+		rd->update_needed = true;
+	}
+
 	return report_sent;
 }
 


### PR DESCRIPTION
Change fixes handling send_always argument of report_send function. In case HID report cannot be sent now, we need to make sure it will be submitted later.

Jira: NCSDK-7877