### PR TITLE
Add checks fw info

### DIFF
--- a/tests/subsys/net/lib/fota_download/CMakeLists.txt
+++ b/tests/subsys/net/lib/fota_download/CMakeLists.txt
@@ -24,16 +24,22 @@ target_include_directories(app
   . # To get 'pm_config.h'
   )
 
+if (NOT CONFIG_TRUSTED_EXECUTION_NONSECURE)
+  # If non secure then fw_info will be pulled in automatically.
+  set(info_magic "-DFIRMWARE_INFO_MAGIC=0xbabababa,0xbabababa,0xbabababa")
+  set(ext_api_magic "-DEXT_API_MAGIC=0xdededede")
+endif()
+
 target_compile_options(app
   PRIVATE
   -DCONFIG_DOWNLOAD_CLIENT_BUF_SIZE=500
   -DCONFIG_DOWNLOAD_CLIENT_STACK_SIZE=500
   -DCONFIG_FW_MAGIC_LEN=32
-  -DFIRMWARE_INFO_MAGIC=0xbabababa,0xbabababa,0xbabababa
   -DABI_INFO_MAGIC=0xdededede
-  -DEXT_API_MAGIC=0xdededede
   -DCONFIG_FW_FIRMWARE_INFO_OFFSET=0x200
   -DCONFIG_FOTA_DOWNLOAD_LOG_LEVEL=2
   -DCONFIG_FOTA_SOCKET_RETRIES=2
   -DCONFIG_FW_INFO_MAGIC_LEN=12
+  ${info_magic}
+  ${ext_api_magic}
   )

--- a/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160.conf
+++ b/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160ns.conf
+++ b/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160ns.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# Disable this since we write our own mock for 'spm_s0_active()'
+CONFIG_SPM_SECURE_SERVICES=n

--- a/tests/subsys/net/lib/fota_download/boards/qemu_x86.conf
+++ b/tests/subsys/net/lib/fota_download/boards/qemu_x86.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_FLASH_SIMULATOR=y
+CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y

--- a/tests/subsys/net/lib/fota_download/pm_config.h
+++ b/tests/subsys/net/lib/fota_download/pm_config.h
@@ -7,6 +7,6 @@
 /* generated file copied to simplify building the test */
 #ifndef PM_CONFIG_H__
 #define PM_CONFIG_H__
-#define PM_S0_ADDRESS 0x8000
-#define PM_S1_ADDRESS 0x15000
+#define PM_S0_ADDRESS 0x10000
+#define PM_S1_ADDRESS 0x20000
 #endif /* PM_CONFIG_H__ */

--- a/tests/subsys/net/lib/fota_download/prj.conf
+++ b/tests/subsys/net/lib/fota_download/prj.conf
@@ -4,3 +4,4 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 CONFIG_ZTEST=y
+CONFIG_FLASH=y

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -28,10 +28,9 @@ char buf[1024];
 
 /* Stubs and mocks */
 bool dfu_ctx_mcuboot_set_b1_file__s0_active;
-static uint32_t s0_version;
-static uint32_t s1_version;
 const char *download_client_start_file;
 char *dfu_ctx_mcuboot_set_b1_file__update;
+static bool spm_s0_active_retval;
 
 int dfu_target_init(int img_type, size_t file_size)
 {
@@ -86,21 +85,6 @@ int download_client_init(struct download_client *client,
 	return 0;
 }
 
-int spm_firmware_info(uint32_t fw_address, struct fw_info *info)
-{
-	zassert_true(info != NULL, NULL);
-
-	if (fw_address == PM_S0_ADDRESS) {
-		info->version = s0_version;
-	} else if (fw_address == PM_S1_ADDRESS) {
-		info->version = s1_version;
-	} else {
-		zassert_true(false, "Unexpected address");
-	}
-
-	return 0;
-}
-
 int download_client_connect(struct download_client *client, const char *host,
 			    const struct download_client_cfg *config)
 {
@@ -116,7 +100,80 @@ int dfu_ctx_mcuboot_set_b1_file(char *file, bool s0_active, char **update)
 
 /* END stubs and mocks */
 
-void client_callback(const struct fota_download_evt *evt) { }
+#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
+
+int spm_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active)
+{
+	*s0_active = spm_s0_active_retval;
+
+	return 0;
+}
+
+void set_s0_active(bool s0_active)
+{
+	spm_s0_active_retval = s0_active;
+}
+#else /* ! CONFIG_TRUSTED_EXECUTION_NONSECURE */
+
+/* The test is _NOT_ executed as non-secure. Hence 'spm_s0_active' will not
+ * be called. This means that we cannot create a mock of that function to
+ * modify whether or not S0 should be considered the active B1 slot.
+ *
+ * To solve this issue, we perform flash write operations to the locations
+ * where 'fw_info.h' will look for the S0 and S1 metadata. This allows
+ * us to dictate what B1 slot should be considered active
+ */
+#include <zephyr.h>
+#include <drivers/flash.h>
+#include <nrfx_nvmc.h>
+#include <device.h>
+
+#define FLASH_NAME DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
+
+static const struct device *fdev;
+void set_s0_active(bool s0_active)
+{
+	int err;
+	struct fw_info s0_info = { .magic = { FIRMWARE_INFO_MAGIC } };
+	struct fw_info s1_info = { .magic = { FIRMWARE_INFO_MAGIC } };
+
+	spm_s0_active_retval = s0_active;
+
+	s1_info.version = 1;
+	if (s0_active) {
+		s0_info.version = s1_info.version + 1;
+	} else {
+		s0_info.version = s1_info.version - 1;
+	}
+
+	fdev = device_get_binding(FLASH_NAME);
+	zassert_not_equal(fdev, 0, "Unable to get fdev");
+
+	err = flash_erase(fdev, PM_S0_ADDRESS, nrfx_nvmc_flash_page_size_get());
+	zassert_equal(err, 0, "flash_erase failed");
+
+	err = flash_erase(fdev, PM_S1_ADDRESS, nrfx_nvmc_flash_page_size_get());
+	zassert_equal(err, 0, "flash_erase failed");
+
+	err = flash_write_protection_set(fdev, false);
+	zassert_equal(err, 0, "Disabling flash protection failed");
+
+	err = flash_write(fdev, PM_S0_ADDRESS, (void *)&s0_info,
+			  sizeof(s0_info));
+	zassert_equal(err, 0, "Unable to write to flash");
+
+	err = flash_write(fdev, PM_S1_ADDRESS, (void *)&s1_info,
+			  sizeof(s1_info));
+	zassert_equal(err, 0, "Unable to write to flash");
+
+	err = flash_write_protection_set(fdev, true);
+	zassert_equal(err, 0, "Enabling flash protection failed");
+}
+#endif
+
+void client_callback(const struct fota_download_evt *evt)
+{
+}
 
 static void init(void)
 {
@@ -129,28 +186,22 @@ static void init(void)
 static void test_fota_download_start(void)
 {
 	int err;
-	bool expect_s0_active = false;
 
 	init();
 
 	/* Verify that correct argument for s0_active is given */
-	s0_version = 0;
-	s1_version = 1;
-	expect_s0_active = false;
+	set_s0_active(false);
 	strcpy(buf, S0_S1);
 	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
-	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
-		      "Incorrect param for s0_active");
+	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active,
+		      spm_s0_active_retval, "Incorrect param for s0_active");
 
-	s0_version = 2;
-	s1_version = 1;
-	expect_s0_active = true;
+	set_s0_active(true);
 	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
-	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
-		      "Incorrect param for s0_active");
-
+	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active,
+		      spm_s0_active_retval, "Incorrect param for s0_active");
 
 	/* Next, verify that the update path given by mcuboot_set_b1_file
 	 * is used correctly.
@@ -174,8 +225,7 @@ static void test_fota_download_start(void)
 void test_main(void)
 {
 	ztest_test_suite(lib_fota_download_test,
-	     ztest_unit_test(test_fota_download_start)
-	 );
+			 ztest_unit_test(test_fota_download_start));
 
 	ztest_run_test_suite(lib_fota_download_test);
 }

--- a/tests/subsys/net/lib/fota_download/testcase.yaml
+++ b/tests/subsys/net/lib/fota_download/testcase.yaml
@@ -1,5 +1,8 @@
 tests:
   net.lib.fota_download:
     tags: aws fota
+    platform_allow: nrf9160dk_nrf9160 nrf9160dk_nrf9160ns
+  net.lib.fota_download_build_only:
+    tags: aws fota
     build_only: true
-    platform_allow: nrf9160dk_nrf9160
+    platform_allow: qemu_x86

--- a/tests/subsys/spm/secure_services/CMakeLists.txt
+++ b/tests/subsys/spm/secure_services/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(NONE)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/spm/secure_services/prj.conf
+++ b/tests/subsys/spm/secure_services/prj.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+CONFIG_ZTEST=y
+CONFIG_BOOTLOADER_MCUBOOT=y
+CONFIG_BUILD_S1_VARIANT=y
+CONFIG_SECURE_BOOT=y
+CONFIG_SPM_SERVICE_S0_ACTIVE=y

--- a/tests/subsys/spm/secure_services/src/main.c
+++ b/tests/subsys/spm/secure_services/src/main.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <ztest.h>
+#include <secure_services.h>
+#include <pm_config.h>
+
+static const struct fw_info ns_fw_info = { .magic = { FIRMWARE_INFO_MAGIC } };
+static uint8_t non_secure_buf[128];
+
+static bool is_secure(intptr_t ptr)
+{
+	/* We can not use 'arm_cmse_addr_is_secure here since this firmware
+	 * is built as non secure.
+	 */
+	if (ptr >= CONFIG_PM_SRAM_BASE) {
+		/* Check if RAM address is secure */
+		return ptr < PM_SRAM_ADDRESS;
+	}
+
+	/* Check if flash address is secure */
+	return ptr < PM_ADDRESS;
+}
+
+void test_spm_firmware_info(void)
+{
+	int err;
+	struct fw_info info;
+
+	/* Prove that the struct is stored in non-secure flash. */
+	zassert_true(!is_secure((intptr_t)&ns_fw_info),
+		     "Test fw-info is not stored in non-secure firmware");
+
+	/* Normal execution */
+	err = spm_firmware_info(PM_SPM_ADDRESS, &info);
+	zassert_equal(err, 0, "Got unexpected failure");
+
+	/* Verify that the function fails if the address of the firmware info
+	 * is not in secure firmware.
+	 */
+	err = spm_firmware_info((uint32_t)&ns_fw_info, &info);
+	zassert_true(err != 0, "Did not fail for fw_address in secure fw");
+
+	/* Verify that the function fails if the output argument for the info
+	 * is in secure RAM. First verify that it passes when it is in
+	 * non-secure, indicating that a valid fw_info is found at the
+	 * specified address, then verify that it fails for an output pointer
+	 * in secure RAM.
+	 */
+	err = spm_firmware_info(PM_SPM_ADDRESS,
+				(struct fw_info *)PM_SPM_SRAM_ADDRESS);
+	zassert_true(err != 0, "Did not fail when passing invalid output ptr");
+}
+
+void test_spm_s0_active(void)
+{
+	int err;
+	bool output;
+	bool *secure_ptr = (bool *)PM_SPM_SRAM_ADDRESS;
+
+	/* Prove that test objects is stored in non-secure addresses. */
+	zassert_true(!is_secure((intptr_t)&output),
+		     "Test object is not non-secure");
+
+	/* Prove that secure test objects is stored in secure addresses. */
+	zassert_true(is_secure((intptr_t)secure_ptr),
+		     "Test object is not secure");
+
+	/* Normal execution */
+	err = spm_s0_active(PM_S0_ADDRESS, PM_S1_ADDRESS, &output);
+	zassert_equal(err, 0, "Got unexpected failure");
+
+	/* Verify that the function fails if it is passed secure pointers */
+	err = spm_s0_active(PM_S0_ADDRESS, PM_S1_ADDRESS, secure_ptr);
+	zassert_true(err != 0, "Did not fail for secure pointer");
+}
+
+void test_spm_request_random_number(void)
+{
+	int err;
+	size_t olen;
+	uint8_t output[144];
+	void *secure_ptr =
+		(size_t *)(PM_SPM_SRAM_ADDRESS + PM_SPM_SRAM_SIZE - 1024);
+
+	/* Prove that test objects is stored in non-secure addresses. */
+	zassert_true(!is_secure((intptr_t)&olen),
+		     "Test object is not non-secure");
+
+	/* Prove that test objects is stored in non-secure addresses. */
+	zassert_true(!is_secure((intptr_t)output),
+		     "Test object is not non-secure");
+
+	/* Prove that secure test objects is stored in secure addresses. */
+	zassert_true(is_secure((intptr_t)secure_ptr),
+		     "Test object is not secure");
+
+	/* Normal execution */
+	err = spm_request_random_number(output, sizeof(output), &olen);
+	zassert_equal(err, 0, "Got unexpected failure");
+
+	/* Verify that the function fails if it is passed secure pointers */
+	err = spm_request_random_number(secure_ptr, sizeof(output), &olen);
+	zassert_true(err != 0, "Did not fail for secure pointer");
+
+	err = spm_request_random_number(output, sizeof(output), secure_ptr);
+	zassert_true(err != 0, "Got unexpected failure");
+}
+
+void test_spm_request_read(void)
+{
+	const uint32_t valid_read_addr = (NRF_FICR_S_BASE + 0x204);
+	int err;
+	uint8_t output[32];
+	void *secure_ptr = (size_t *)PM_SPM_SRAM_ADDRESS;
+
+	/* Prove that test objects is stored in non-secure addresses. */
+	zassert_true(!is_secure((intptr_t)output),
+		     "Test object is not non-secure");
+
+	/* Prove that test objects is stored in non-secure addresses. */
+	zassert_true(!is_secure((intptr_t)non_secure_buf),
+		     "Test object is not non-secure");
+
+	/* Prove that secure test objects is stored in secure addresses. */
+	zassert_true(is_secure((intptr_t)secure_ptr),
+		     "Test object is not secure");
+
+	/* Normal execution */
+	err = spm_request_read(output, valid_read_addr, sizeof(output));
+	zassert_equal(err, 0, "Got unexpected failure");
+
+	/* Verify that the function fails if it is passed secure pointers */
+	err = spm_request_read(secure_ptr, valid_read_addr, sizeof(output));
+	zassert_true(err != 0, "Did not fail for secure pointer");
+
+	/* Verify that the function fails if it is passed non-secure address */
+	err = spm_request_read(output, (intptr_t)&non_secure_buf,
+			       sizeof(output));
+	zassert_true(err != 0, "Did not fail for non secure read addr");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(test_secure_service,
+			 ztest_unit_test(test_spm_firmware_info),
+			 ztest_unit_test(test_spm_request_random_number),
+			 ztest_unit_test(test_spm_s0_active),
+			 ztest_unit_test(test_spm_request_read));
+	ztest_run_test_suite(test_secure_service);
+}

--- a/tests/subsys/spm/secure_services/testcase.yaml
+++ b/tests/subsys/spm/secure_services/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  spm.secure_services:
+    platform_allow: nrf9160dk_nrf9160ns nrf5340dk_nrf5340_cpuappns
+    tags: spm secure_services


### PR DESCRIPTION
First two commits are misc fixes to related unit tests which are failing.
Last commit adds the fix for checking the address and output pointer of spm_firmware_info, and the unit test for this.