### PR TITLE
lib: at_cmd: return proper error code

### DIFF
--- a/lib/at_cmd/at_cmd.c
+++ b/lib/at_cmd/at_cmd.c
@@ -264,7 +264,7 @@ static void socket_thread_fn(void *arg1, void *arg2, void *arg3)
 				continue;
 			} else {
 				LOG_ERR("AT socket recv failed with err %d",
-					bytes_read);
+					errno);
 			}
 
 			if ((close(common_socket_fd) == 0) &&


### PR DESCRIPTION
AT cmd library should return the errno code instead of the retunr
variable of recv when it fails.

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>