### PR TITLE
lib: at_cmd_parser: support negative numbers

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -136,6 +136,10 @@ nRF9160
 
     * Updated to use the new FOTA (fota_v2) based on nRF Connect for Cloud.
 
+  * :ref:`at_cmd_parser_readme` library:
+
+    * The library can now parse AT command strings with negative numbers in the range supported by the int32_t type.
+
 Common
 ======
 

--- a/include/modem/at_params.h
+++ b/include/modem/at_params.h
@@ -51,7 +51,7 @@ enum at_param_type {
 /** @brief Parameter value. */
 union at_param_value {
 	/** Integer value. */
-	uint32_t int_val;
+	int32_t int_val;
 	/** String value. */
 	char *str_val;
 	/** Array of uint32_t */
@@ -124,7 +124,7 @@ void at_params_list_free(struct at_param_list *list);
  *           Otherwise, a (negative) error code is returned.
  */
 int at_params_short_put(const struct at_param_list *list, size_t index,
-			uint16_t value);
+			int16_t value);
 
 /**
  * @brief Add a parameter in the list at the specified index and assign it an
@@ -140,7 +140,7 @@ int at_params_short_put(const struct at_param_list *list, size_t index,
  *           Otherwise, a (negative) error code is returned.
  */
 int at_params_int_put(const struct at_param_list *list, size_t index,
-		      uint32_t value);
+		      int32_t value);
 
 /**
  * @brief Add a parameter in the list at the specified index and assign it a
@@ -226,7 +226,7 @@ int at_params_size_get(const struct at_param_list *list, size_t index,
  *           Otherwise, a (negative) error code is returned.
  */
 int at_params_short_get(const struct at_param_list *list, size_t index,
-			uint16_t *value);
+			int16_t *value);
 
 /**
  * @brief Get a parameter value as an integer number.
@@ -242,7 +242,7 @@ int at_params_short_get(const struct at_param_list *list, size_t index,
  *           Otherwise, a (negative) error code is returned.
  */
 int at_params_int_get(const struct at_param_list *list, size_t index,
-		      uint32_t *value);
+		      int32_t *value);
 
 /**
  * @brief Get a parameter value as a string.

--- a/lib/at_cmd_parser/at_cmd_parser.c
+++ b/lib/at_cmd_parser/at_cmd_parser.c
@@ -249,12 +249,12 @@ static int at_parse_process_element(const char **str, int index,
 		tmpstr++;
 	} else if (state == NUMBER) {
 		char *next;
-		int value = (uint32_t)strtoul(tmpstr, &next, 10);
+		int32_t value = (int32_t)strtol(tmpstr, &next, 10);
 
 		tmpstr = next;
 
-		if (value <= USHRT_MAX) {
-			at_params_short_put(list, index, (uint16_t)value);
+		if ((value <= SHRT_MAX) && (value >= SHRT_MIN)) {
+			at_params_short_put(list, index, (int16_t)value);
 		} else {
 			at_params_int_put(list, index, value);
 		}

--- a/lib/at_cmd_parser/at_params.c
+++ b/lib/at_cmd_parser/at_params.c
@@ -112,7 +112,7 @@ void at_params_list_free(struct at_param_list *list)
 }
 
 int at_params_short_put(const struct at_param_list *list, size_t index,
-			uint16_t value)
+			int16_t value)
 {
 	if (list == NULL || list->params == NULL) {
 		return -EINVAL;
@@ -127,7 +127,7 @@ int at_params_short_put(const struct at_param_list *list, size_t index,
 	at_param_clear(param);
 
 	param->type = AT_PARAM_TYPE_NUM_SHORT;
-	param->value.int_val = (uint32_t)(value & USHRT_MAX);
+	param->value.int_val = value;
 	return 0;
 }
 
@@ -152,7 +152,7 @@ int at_params_empty_put(const struct at_param_list *list, size_t index)
 }
 
 int at_params_int_put(const struct at_param_list *list, size_t index,
-		      uint32_t value)
+		      int32_t value)
 {
 	if (list == NULL || list->params == NULL) {
 		return -EINVAL;
@@ -247,7 +247,7 @@ int at_params_size_get(const struct at_param_list *list, size_t index,
 }
 
 int at_params_short_get(const struct at_param_list *list, size_t index,
-			uint16_t *value)
+			int16_t *value)
 {
 	if (list == NULL || list->params == NULL || value == NULL) {
 		return -EINVAL;
@@ -263,12 +263,12 @@ int at_params_short_get(const struct at_param_list *list, size_t index,
 		return -EINVAL;
 	}
 
-	*value = (uint16_t)param->value.int_val;
+	*value = (int16_t)param->value.int_val;
 	return 0;
 }
 
 int at_params_int_get(const struct at_param_list *list, size_t index,
-		      uint32_t *value)
+		      int32_t *value)
 {
 	if (list == NULL || list->params == NULL || value == NULL) {
 		return -EINVAL;


### PR DESCRIPTION
There are some usecases where the numbers returned from the AT
interface is negative. These negative numbers should be supported by the
AT parser. This update should be safe because there is already a bug in
the parser code that converts a uint32_t to a int and back again.

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>