### PR TITLE
manifest: nrfxlib with updated OT libraries

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 784df6f0093f915c0f1406393bcb6c242b02178d
+      revision: 2eb6ef83a1353a8abb3ed54a4f62c0aea802be3b
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Take new nrfxlib revision with updated OpenThread libraries supporting nRF53.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-8616