### PR TITLE
zigbee: Change zigbee test macros [KRKNWK-8643]

### DIFF
--- a/subsys/zigbee/lib/zigbee_app_utils/CMakeLists.txt
+++ b/subsys/zigbee/lib/zigbee_app_utils/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 zephyr_library()
-zephyr_library_sources_ifndef(CONFIG_ZB_TEST_MODE zigbee_app_utils.c)
+zephyr_library_sources(zigbee_app_utils.c)
 
 zephyr_library_link_libraries(zboss)
 zephyr_library_link_libraries(zigbee)

--- a/subsys/zigbee/osif/zb_nrf_platform.c
+++ b/subsys/zigbee/osif/zb_nrf_platform.c
@@ -263,7 +263,7 @@ int zigbee_init(void)
 #endif /* CONFIG_ZBOSS_TRAF_DUMP */
 #endif /* ZB_TRACE_LEVEL */
 
-#ifndef CONFIG_ZB_TEST_MODE
+#ifndef CONFIG_ZB_TEST_MODE_MAC
 	/* Initialize Zigbee stack. */
 	ZB_INIT("zigbee_thread");
 
@@ -298,7 +298,7 @@ int zigbee_init(void)
 #error Zigbee device role undefined!
 #endif
 
-#endif /* CONFIG_ZB_TEST_MODE */
+#endif /* CONFIG_ZB_TEST_MODE_MAC */
 
 	return 0;
 }


### PR DESCRIPTION
This commit removes unnecessary conditional in Zigbee app utils library
and changes macro to more specific one in zb_nrf_platform.c

ref: KRKNWK-8643