### PR TITLE
lib: lte_lc: Initialize semaphore in init function

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -528,6 +528,8 @@ static int w_lte_lc_init(void)
 		return -EALREADY;
 	}
 
+	k_sem_init(&link, 0, 1);
+
 	err = lte_lc_system_mode_get(&sys_mode_current);
 	if (err) {
 		LOG_ERR("Could not get current system mode, error: %d", err);


### PR DESCRIPTION
When CONFIG_LTE_AUTO_INIT_AND_CONNECT is disabled and modem is switched
to online mode using AT commands the link semaphore is used before it's
initialized and crashes the application. This is not the usual use case,
but we ran into this with a shell application where user can easily mix
LTE LC and AT command usage and the fix is simple.

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>