### PR TITLE
lib: date_time: Add support for IPv6

### DIFF
--- a/lib/date_time/Kconfig
+++ b/lib/date_time/Kconfig
@@ -34,6 +34,9 @@ config DATE_TIME_NTP_QUERY_TIME_SECONDS
 	int "Duration in which the library will query for NTP time, in seconds"
 	default 5
 
+config DATE_TIME_IPV6
+	bool "Use IPv6"
+
 module=DATE_TIME
 module-dep=LOG
 module-str=Date time module

--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -145,7 +145,11 @@ static int sntp_time_request(struct ntp_servers *server, uint32_t timeout,
 	static struct addrinfo hints;
 	struct sntp_ctx sntp_ctx;
 
-	hints.ai_family = AF_INET;
+	if (IS_ENABLED(CONFIG_DATE_TIME_IPV6)) {
+		hints.ai_family = AF_INET6;
+	} else {
+		hints.ai_family = AF_INET;
+	}
 	hints.ai_socktype = SOCK_DGRAM;
 	hints.ai_protocol = 0;
 


### PR DESCRIPTION
Add IPv6 support for the Date-Time library because it was not working with IPv6 when getting time from NTP servers. The getaddrinfo() was failing when using IPv6 instead of IPv4 (at least when APN is set to use IPv6).

DevZone ticket: [Date-Time with IPv6](https://devzone.nordicsemi.com/f/nordic-q-a/70874/date-time-with-ipv6)

Signed-off-by: Tero Nikula tero.nikula@anicare.fi