### PR TITLE
samples: openthread: provide certification overlay file for nRF53

### DIFF
--- a/doc/nrf/ug_thread_certification.rst
+++ b/doc/nrf/ug_thread_certification.rst
@@ -66,8 +66,13 @@ Complete the following steps to run the certification tests:
          west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG="harness/overlay-cert.conf"
 
    .. note::
-      The overlay file selects the precompiled OpenThread libraries by default.
-      It also enables :ref:`multiprotocol support <ug_multiprotocol_support>` with Bluetooth LE advertising.
+      The overlay file selects the precompiled OpenThread libraries.
+
+      For nRF52 Series devices, use :file:`harness/overlay-cert.conf`.
+      This file also enables :ref:`multiprotocol support <ug_multiprotocol_support>` with Bluetooth LE advertising.
+
+      For nRF53 Series devices, use :file:`harness/overlay-cert-nrf53.conf`.
+      This file does not enable multiprotocol support, because there is no multiprotocol support for nRF53 Series devices yet.
 
 #. Prepare Thread Test Harness.
 

--- a/samples/openthread/cli/harness/overlay-cert-nrf53.conf
+++ b/samples/openthread/cli/harness/overlay-cert-nrf53.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# Disable logging
+CONFIG_BOOT_BANNER=n
+CONFIG_LOG=n
+CONFIG_LOG_MINIMAL=n
+CONFIG_NET_LOG=n
+CONFIG_NET_STATISTICS=n
+CONFIG_OPENTHREAD_DEBUG=n
+CONFIG_OPENTHREAD_L2_DEBUG=n
+CONFIG_ASSERT=n
+
+# Shell configuration for harness
+CONFIG_SHELL_PROMPT_UART=""
+CONFIG_SHELL_VT100_COLORS=n
+CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=416
+
+# Use the precompiled OpenThread libraries
+CONFIG_OPENTHREAD_LIBRARY_1_1=y


### PR DESCRIPTION
Use a different overlay for Thread Certification of nRF53 devices, without multiprotocol support.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-8799