### PR TITLE
manifest: SoftDevice controller supporting Zephyr Read Tx Power

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -325,6 +325,7 @@ static void vs_supported_commands(sdc_hci_vs_zephyr_supported_commands_t *cmds)
 
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	cmds->write_tx_power_level = 1;
+	cmds->read_tx_power_level = 1;
 #endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
 #endif /* CONFIG_BT_HCI_VS_EXT */
 }
@@ -824,6 +825,10 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 	case SDC_HCI_OPCODE_CMD_VS_ZEPHYR_WRITE_TX_POWER:
 		*param_length_out += sizeof(sdc_hci_cmd_vs_zephyr_write_tx_power_return_t);
 		return sdc_hci_cmd_vs_zephyr_write_tx_power((void *)cmd_params,
+							    (void *)event_out_params);
+	case SDC_HCI_OPCODE_CMD_VS_ZEPHYR_READ_TX_POWER:
+		*param_length_out += sizeof(sdc_hci_cmd_vs_zephyr_read_tx_power_return_t);
+		return sdc_hci_cmd_vs_zephyr_read_tx_power((void *)cmd_params,
 							    (void *)event_out_params);
 #endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
 #endif /* CONFIG_BT_HCI_VS_EXT */

--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: f76fa16478d8718f82b3153931c97cb570d5a0ac
+      revision: 7cc9277d8e8675a7c57d78db461468b4258ff343
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
This command is used by the hci_pwr_ctrl sample