### PR TITLE
mpsl: Allocate GPIOTE channels in run-time

### DIFF
--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -3,12 +3,16 @@
 Radio front-end module (FEM) support
 ####################################
 
+.. contents::
+   :local:
+   :depth: 2
+
 This guide describes how to add support for 2 different front-end module (FEM) implementations to your application in |NCS|.
 
 |NCS| allows you to extend the radio range of your development kit with an implementation of the front-end modules.
-Front-end modules are range extenders, used for boosting the link robustness and link budget of wireless SoCs.
+Front-end modules are range extenders used for boosting the link robustness and link budget of wireless SoCs.
 
-The FEM support is based on the :ref:`nrfxlib:mpsl_fem`, which is integrated in the nrfxlib's MPSL library.
+The FEM support is based on the :ref:`nrfxlib:mpsl_fem`, which is integrated into the nrfxlib's MPSL library.
 This library provides nRF21540 GPIO and Simple GPIO implementations, for 3-pin and 2-pin PA/LNA interfaces, respectively.
 
 The implementations described in this guide are the following:
@@ -25,7 +29,7 @@ At the moment, :ref:`ug_thread` and :ref:`ug_zigbee` support the :ref:`nrf21540 
 
 |NCS| provides a friendly wrapper that configures FEM based on devicetree (DTS) and Kconfig information.
 To enable FEM support, you must enable FEM and MPSL, and add an ``nrf_radio_fem`` node in the devicetree file.
-The node can also be provided by the target board devicetree file or by an overlay file.
+The node can also be provided by the devicetree file of the target devkit or by an overlay file.
 See :ref:`zephyr:dt-guide` for more information about the DTS data structure, and :ref:`zephyr:dt_vs_kconfig` for information about differences between DTS and Kconfig.
 
 .. _ug_radio_fem_requirements:
@@ -84,11 +88,6 @@ To use nRF21540 in GPIO mode, complete the following steps:
    The last element must be ``GPIO_ACTIVE_HIGH`` for nRF21540, but for a different FEM module you can use ``GPIO_ACTIVE_LOW``.
 
    The state of the remaining control pins should be set in other ways and according to `nRF21540 Product Specification`_.
-#. Set the following Kconfig parameters to assign unique GPIOTE channel numbers to be used exclusively by the FEM driver:
-
-   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_TX_EN`
-   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_RX_EN`
-   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN`
 
 Optional properties
 ===================
@@ -155,10 +154,6 @@ To use the Simple GPIO implementation of FEM with SKY66112-11, complete the foll
 
    The state of the other control pins should be set according to the SKY66112-11 documentation.
    See the official `SKY66112-11 page`_ for more information.
-#. Set the following Kconfig parameters to assign unique GPIOTE channel numbers to be used exclusively by the FEM driver:
-
-   * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CTX`
-   * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CRX`
 
 Optional properties
 ===================

--- a/subsys/mpsl/Kconfig.fem
+++ b/subsys/mpsl/Kconfig.fem
@@ -33,6 +33,7 @@ choice MPSL_FEM_CHOICE
 
 config MPSL_FEM_NRF21540_GPIO
 	depends on MPSL_FEM_NRF21540_GPIO_SUPPORT
+	select NRFX_GPIOTE
 	bool "nRF21540 front-end module in GPIO mode"
 	help
 	  FEM device is nRF21540 and its control mode is GPIO.
@@ -40,6 +41,7 @@ config MPSL_FEM_NRF21540_GPIO
 
 config MPSL_FEM_SIMPLE_GPIO
 	depends on MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT
+	select NRFX_GPIOTE
 	bool "Generic front-end module with two-pin control"
 	help
 	  FEM device has a generic two-pin control interface.
@@ -50,27 +52,6 @@ config MPSL_FEM_SIMPLE_GPIO
 endchoice	# MPSL_FEM_CHOICE
 
 if MPSL_FEM_NRF21540_GPIO
-
-config MPSL_FEM_NRF21540_GPIO_GPIOTE_TX_EN
-	int "GPIOTE channel number used to control TX_EN pin"
-	default 7
-	help
-	  Unique GPIOTE channel number to be used exclusively by the FEM driver
-	  for TX_EN pin control.
-
-config MPSL_FEM_NRF21540_GPIO_GPIOTE_RX_EN
-	int "GPIOTE channel number used to control RX_EN pin"
-	default 6
-	help
-	  Unique GPIOTE channel number to be used exclusively by the FEM driver
-	  for RX_EN pin control.
-
-config MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN
-	int "GPIOTE channel number used to control PDN pin"
-	default 5
-	help
-	  Unique GPIOTE channel number to be used exclusively by the FEM driver
-	  for PDN pin control.
 
 config MPSL_FEM_NRF21540_TX_GAIN_DB
 	int "TX gain of the nRF21540 PA amplifier in dB"
@@ -86,24 +67,6 @@ config MPSL_FEM_NRF21540_RX_GAIN_DB
 	help
 	  The default value of 13 dB is based on nRF21540 Product Specification
 	  (v1.0)
-
-endif
-
-if MPSL_FEM_SIMPLE_GPIO
-
-config MPSL_FEM_SIMPLE_GPIO_GPIOTE_CTX
-	int "GPIOTE channel number used to control CTX pin"
-	default 7
-	help
-	  Unique GPIOTE channel number to be used exclusively by the FEM driver
-	  for CTX pin control.
-
-config MPSL_FEM_SIMPLE_GPIO_GPIOTE_CRX
-	int "GPIOTE channel number used to control CRX pin"
-	default 6
-	help
-	  Unique GPIOTE channel number to be used exclusively by the FEM driver
-	  for RTX pin control.
 
 endif
 

--- a/subsys/mpsl/mpsl_fem.c
+++ b/subsys/mpsl/mpsl_fem.c
@@ -10,6 +10,7 @@
 #include <sys/__assert.h>
 #include <mpsl_fem_config_nrf21540_gpio.h>
 #include <mpsl_fem_config_simple_gpio.h>
+#include <nrfx_gpiote.h>
 #if IS_ENABLED(CONFIG_HAS_HW_NRF_PPI)
 #include <nrfx_ppi.h>
 #elif IS_ENABLED(CONFIG_HAS_HW_NRF_DPPIC)
@@ -119,6 +120,30 @@ static int fem_nrf21540_gpio_configure(void)
 #endif
 	int err;
 
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), tx_en_gpios)
+	uint8_t txen_gpiote_channel;
+
+	if (nrfx_gpiote_channel_alloc(&txen_gpiote_channel) != NRFX_SUCCESS) {
+		return -ENOMEM;
+	}
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), rx_en_gpios)
+	uint8_t rxen_gpiote_channel;
+
+	if (nrfx_gpiote_channel_alloc(&rxen_gpiote_channel) != NRFX_SUCCESS) {
+		return -ENOMEM;
+	}
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
+	uint8_t pdn_gpiote_channel;
+
+	if (nrfx_gpiote_channel_alloc(&pdn_gpiote_channel) != NRFX_SUCCESS) {
+		return -ENOMEM;
+	}
+#endif
+
 	mpsl_fem_nrf21540_gpio_interface_config_t cfg = {
 		.fem_config = {
 			.pa_time_gap_us  =
@@ -146,8 +171,7 @@ static int fem_nrf21540_gpio_configure(void)
 			.gpio_pin     =
 				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
 					    tx_en_gpios),
-			.gpiote_ch_id =
-				CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_TX_EN
+			.gpiote_ch_id = txen_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
 #endif
@@ -160,8 +184,7 @@ static int fem_nrf21540_gpio_configure(void)
 			.gpio_pin     =
 				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
 					    rx_en_gpios),
-			.gpiote_ch_id =
-				CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_RX_EN
+			.gpiote_ch_id = rxen_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
 #endif
@@ -174,8 +197,7 @@ static int fem_nrf21540_gpio_configure(void)
 			.gpio_pin     =
 				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
 					    pdn_gpios),
-			.gpiote_ch_id =
-				CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN
+			.gpiote_ch_id = pdn_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
 #endif
@@ -278,6 +300,22 @@ static int fem_simple_gpio_configure(void)
 #endif
 	int err;
 
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ctx_gpios)
+	uint8_t ctx_gpiote_channel;
+
+	if (nrfx_gpiote_channel_alloc(&ctx_gpiote_channel) != NRFX_SUCCESS) {
+		return -ENOMEM;
+	}
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), crx_gpios)
+	uint8_t crx_gpiote_channel;
+
+	if (nrfx_gpiote_channel_alloc(&crx_gpiote_channel) != NRFX_SUCCESS) {
+		return -ENOMEM;
+	}
+#endif
+
 	mpsl_fem_simple_gpio_interface_config_t cfg = {
 		.fem_config = {
 			.pa_time_gap_us  =
@@ -301,8 +339,7 @@ static int fem_simple_gpio_configure(void)
 			.gpio_pin     =
 				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
 					    ctx_gpios),
-			.gpiote_ch_id =
-				CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CTX
+			.gpiote_ch_id = ctx_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
 #endif
@@ -315,8 +352,7 @@ static int fem_simple_gpio_configure(void)
 			.gpio_pin     =
 				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
 					    crx_gpios),
-			.gpiote_ch_id =
-				CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CRX
+			.gpiote_ch_id = crx_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
 #endif

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 21713af6fa70d1dad4be699907de5c1c059a4bdc
+      revision: a86ac1f8c2a48e32ed824f0f5ea49d45ceaa345f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
GPIOTE channels for the Front-End Module are configurable, but chosen statically via Kconfig entries. This commit removes the Kconfig entries that represent GPIOTE channels for FEM and uses nrfx GPIOTE driver to allocate the channels in run-time.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>

Note that this PR depends on changes introduced upstream in https://github.com/zephyrproject-rtos/zephyr/pull/31606. Without these changes available in NCS, allocation of overlapping GPIOTE channels performed by MPSL and Zephyr's GPIO driver causes FEM to break. Therefore this PR must not be merged until the commits from https://github.com/zephyrproject-rtos/zephyr/pull/31606 are present in sdk-zephyr.