### PR TITLE
doc: provisioning and config info in mesh samples

### DIFF
--- a/doc/nrf/includes/mesh_device_provisioning.txt
+++ b/doc/nrf/includes/mesh_device_provisioning.txt
@@ -1,0 +1,9 @@
+The provisioning assigns an address range to the device, and adds it to the mesh network.
+Complete the following steps in the nRF Mesh app:
+
+1. Tap :guilabel:`Add node` to start scanning for unprovisioned mesh devices.
+#. Select the |device name| device to connect to it.
+#. Tap :guilabel:`Identify`, and then :guilabel:`Provision`, to provision the device.
+#. When prompted, select an OOB method and follow the instructions in the app.
+
+Once the provisioning is complete, the app returns to the Network screen.

--- a/doc/nrf/ug_bt_mesh.rst
+++ b/doc/nrf/ug_bt_mesh.rst
@@ -18,5 +18,6 @@ The Bluetooth mesh samples use the `nRF Mesh mobile app`_ to perform provisionin
    ug_bt_mesh_concepts.rst
    ug_bt_mesh_architecture.rst
    ug_bt_mesh_configuring.rst
+   ug_bt_mesh_model_config_app.rst
    ug_bt_mesh_vendor_model.rst
    ug_bt_mesh_reserved_ids.rst

--- a/doc/nrf/ug_bt_mesh_model_config_app.rst
+++ b/doc/nrf/ug_bt_mesh_model_config_app.rst
@@ -1,0 +1,74 @@
+.. _ug_bt_mesh_model_config_app:
+
+Configuring mesh models using the nRF Mesh mobile app
+#####################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Bluetooth mesh :ref:`samples <samples>` use the nRF Mesh mobile app to perform provisioning and configuration.
+
+Binding a model to an application key
+*************************************
+
+Mesh models encrypt all their messages using the application keys.
+Models that should communicate with each other must be bound to the same application key.
+
+Complete the following steps in the nRF Mesh app to bind a model to an application key:
+
+1. On the Network screen, tap the mesh device node.
+   Basic information about the mesh node and its configuration is displayed.
+#. In the mesh node view, expand an element.
+   It contains the list of models instantiated in the selected element of the node.
+#. Tap the model entry to see the model's configuration.
+#. Bind the model to application key to make it open for communication:
+
+   a. Tap :guilabel:`BIND KEY` at the top of the screen.
+   #. Select the key from the list.
+
+#. Tap :guilabel:`APPLY`, in the right bottom corner of the screen, to confirm the configuration.
+
+Creating a group
+****************
+
+To send messages to more than one node in the mesh network, you must define groups for the models to publish and subscribe to.
+Complete the following steps in the nRF Mesh mobile app to create a new group:
+
+1. On the Groups screen, tap :guilabel:`CREATE GROUP`.
+#. Ensure that the group address type is selected from the drop-down menu.
+#. In the :guilabel:`Name` field, enter the group name.
+#. In the :guilabel:`Address` field, enter the group address.
+#. Tap :guilabel:`OK`.
+
+Configuring model publication parameters
+****************************************
+
+The publication parameters define how the model sends its messages.
+To configure the model publication parameters, complete the following steps in the nRF Mesh app:
+
+1. Tap :guilabel:`SET PUBLICATION` under the :guilabel:`Publish` section.
+#. Tap :guilabel:`Publish Address` under the :guilabel:`Address` section to set the publish address for the node.
+#. Select :guilabel:`Groups` from the drop-down menu.
+#. Select an existing group or create a new one.
+#. Tap :guilabel:`OK`.
+#. If necessary, set the publication interval and publication retransmission configuration.
+   Otherwise, leave the publication parameters at their default values.
+
+   a. Scroll down to the :guilabel:`Publish Period` view and set the publication interval by using the :guilabel:`Interval` slider.
+      This will make the node publish its presence status periodically at the defined interval.
+   b. Change the publication retransmission configuration under the :guilabel:`Publish Retransmission` section. Set the value for the Retransmit Count.
+
+#. Tap :guilabel:`APPLY` in the right bottom corner of the screen to confirm the configuration.
+
+Subscribing to a group
+**********************
+
+To receive messages sent to group addresses, the models must subscribe to them.
+Complete the following steps in the nRF Mesh mobile app to configure subscription parameters:
+
+1. Tap :guilabel:`SUBSCRIBE` under the :guilabel:`Subscriptions` section.
+#. Select :guilabel:`Groups`.
+#. Select an existing group or create a new one.
+#. Tap :guilabel:`OK`.
+#. Double-tap the back arrow button at the top left corner of the app to get back to the main application screen.

--- a/samples/bluetooth/mesh/chat/README.rst
+++ b/samples/bluetooth/mesh/chat/README.rst
@@ -3,6 +3,10 @@
 Bluetooth: Mesh chat
 ####################
 
+.. contents::
+   :local:
+   :depth: 2
+
 The Bluetooth mesh chat sample demonstrates how the mesh network can be used to facilitate communication between nodes by text, using the :ref:`bt_mesh_chat_client_model`.
 By means of the mesh network, the clients as mesh nodes can communicate with each other without the need of a server.
 The sample is mainly designed for group communication, but it also supports one-on-one communication, as well as sharing the nodes presence.
@@ -103,57 +107,27 @@ After configuring the device, you can interact with the sample using the termina
 Provisioning the device
 -----------------------
 
-The provisioning assigns an address range to the device, and adds it to the mesh network.
-Complete the following steps in the nRF Mesh app:
+.. |device name| replace:: :guilabel:`Mesh Chat`
 
-1. Tap :guilabel:`Add node` to start scanning for unprovisioned mesh devices.
-#. Select the :guilabel:`Mesh Chat` device to connect to it.
-#. Tap :guilabel:`Identify` and then :guilabel:`Provision` to provision the device.
-#. When prompted, select the OOB method and follow the instructions in the app.
-
-Once the provisioning is complete, the app returns to the Network screen.
+.. include:: /includes/mesh_device_provisioning.txt
 
 Configuring models
 ------------------
 
-Complete the following steps in the nRF Mesh app to configure models:
+See :ref:`ug_bt_mesh_model_config_app` for details on how to configure the mesh models with the nRF Mesh mobile app.
 
-1. On the Groups screen, tap the :guilabel:`CREATE GROUP` button.
-#. Ensure that the group address type is selected from the drop-down menu.
-#. In the :guilabel:`Name` field, enter the group name, e.g. :guilabel: `Chat Channel`.
-#. Enter the group address in the :guilabel:`Address` field.
-#. Tap :guilabel:`OK`.
+Create a new group and name it *Chat Channel*, then configure the Vendor model on the :guilabel:`Mesh Chat` node:
 
-#. On the Network screen, tap the :guilabel:`Mesh Chat` node.
-   Basic information about the mesh node and its configuration is displayed.
-#. In the Mesh node view, expand the element.
-   It contains the list of models instantiated on the node.
-#. Tap :guilabel:`Vendor Model` to see the model's configuration.
-#. Bind the model to application keys to make it open for communication:
+* Bind the model to :guilabel:`Application Key 1`.
+* Set the publication parameters:
 
-   1. Tap :guilabel:`BIND KEY` at the top of the screen.
-   #. Select :guilabel:`Application Key 1` from the list.
+  * Destination/publish address: Select just created group :guilabel:`Chat Channel`.
+  * Publication interval: Set the interval to recommended value of 10 seconds.
+  * Retransmit count: Change the count as preferred.
 
-#. Set a model publication address:
+* Set the subscription parameters: Select just created group :guilabel:`Chat Channel`.
 
-   1. Tap :guilabel:`SET PUBLICATION` under the :guilabel:`Publish` section.
-   #. Tap :guilabel:`Publish Address` under the :guilabel:`Address` section.
-   #. Select :guilabel:`Groups`
-   #. Select just created group :guilabel:`Chat Channel`.
-   #. Tap :guilabel:`OK`.
-   #. Scroll down to the :guilabel:`Publish Period` view and set the publication interval.
-      This will make the node publish its presence status periodically at the defined interval. Recommended value is 10 seconds.
-   #. You can also change the publication retransmission configuration under the :guilabel:`Publish Retransmission` section.
-   #. Tap :guilabel:`APPLY` button in the right bottom corner of the screen to apply the changes.
-
-#. Set a model subscription:
-
-   1. Tap :guilabel:`SUBSCRIBE` under the :guilabel:`Subscriptions` section.
-   #. Select :guilabel:`Groups`
-   #. Select just created group :guilabel:`Chat Channel`.
-   #. Tap :guilabel:`OK`.
-
-Repeat steps 6-11 for each mesh node in the mesh network.
+Make sure to configure the parameters for each mesh node in the mesh network.
 
 Interacting with the sample
 ---------------------------

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -98,35 +98,23 @@ Testing consists of provisioning the device and configuring it for communication
 Provisioning the device
 -----------------------
 
-The provisioning assigns an address range to the device, and adds it to the mesh network.
-Complete the following steps in the nRF Mesh app:
+.. |device name| replace:: :guilabel:`Mesh Light`
 
-1. Tap :guilabel:`Add node` to start scanning for unprovisioned mesh devices.
-#. Select the :guilabel:`Mesh Light` device to connect to it.
-#. Tap :guilabel:`Identify` and then :guilabel:`Provision` to provision the device.
-#. When prompted, select the OOB method and follow the instructions in the app.
-
-Once the provisioning is complete, the app returns to the Network screen.
+.. include:: /includes/mesh_device_provisioning.txt
 
 Configuring models
 ------------------
 
-Complete the following steps in the nRF Mesh app to configure models:
+See :ref:`ug_bt_mesh_model_config_app` for details on how to configure the mesh models with the nRF Mesh mobile app.
 
-1. On the Network screen, tap the :guilabel:`Mesh Light` node.
-   Basic information about the mesh node and its configuration is displayed.
-#. In the mesh node view, expand the first element.
-   It contains the list of models in the first element of the node.
-#. Tap :guilabel:`Generic OnOff Server` to see the model's configuration.
-#. Bind the model to application keys to make it open for communication:
+Configure the Generic OnOff Client model on each element on the :guilabel:`Mesh Light` node:
 
-   1. Tap :guilabel:`BIND KEY` at the top of the screen.
-   #. Select :guilabel:`Application Key 1` from the list.
+* Bind the model to :guilabel:`Application Key 1`.
 
-   You are now able to control the first LED on the device by using the Generic On Off Controls in the model view.
-#. Tap :guilabel:`ON` to light up the first LED on the development kit.
+  Once the model is bound to the application key, you can control the first LED on the device.
+* In the model view, tap :guilabel:`ON` (one of the Generic On Off Controls) to light up the first LED on the development kit.
 
-Repeat steps 3-5 for each of the elements on the node to enable controling each of the remaining three LEDs.
+Make sure to complete the configuration on each of the elements on the node to enable controlling each of the remaining three LEDs.
 
 Dependencies
 ************

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -120,33 +120,21 @@ Testing consists of provisioning the device and configuring it for communication
 Provisioning the device
 -----------------------
 
-The provisioning assigns an address range to the device, and adds it to the mesh network.
-Complete the following steps in the nRF Mesh app:
+.. |device name| replace:: :guilabel:`Mesh Light Fixture`
 
-1. Tap :guilabel:`Add node` to start scanning for unprovisioned mesh devices.
-#. Select the :guilabel:`Mesh Light Fixture` device to connect to it.
-#. Tap :guilabel:`Identify` and then :guilabel:`Provision` to provision the device.
-#. When prompted, select the OOB method and follow the instructions in the app.
-
-Once the provisioning is complete, the app returns to the Network screen.
+.. include:: /includes/mesh_device_provisioning.txt
 
 Configuring models
 ------------------
 
-Complete the following steps in the nRF Mesh app to configure models:
+See :ref:`ug_bt_mesh_model_config_app` for details on how to configure the mesh models with the nRF Mesh mobile app.
 
-1. On the Network screen, tap the :guilabel:`Mesh Light Fixture` node.
-   Basic information about the mesh node and its configuration is displayed.
-#. In the mesh node view, expand the second element.
-   It contains the list of models in the second element of the node.
-#. Tap :guilabel:`Generic OnOff Server` to see the model's configuration.
-#. Bind the model to application keys to make it open for communication:
+Configure the Generic OnOff Client model on each element on the :guilabel:`Mesh Light Fixture` node:
 
-   1. Tap :guilabel:`BIND KEY` at the top of the screen.
-   #. Select :guilabel:`Application Key 1` from the list.
+* Bind the model to :guilabel:`Application Key 1`.
 
-   You are now able to control the first LED on the device by using the Generic On Off Controls in the model view.
-#. Tap :guilabel:`ON` to light up the first LED on the development kit.
+  Once the model is bound to the application key, you can control the first LED on the device.
+* In the model view, tap :guilabel:`ON` (one of the Generic On Off Controls) to light up the first LED on the development kit.
 
 You should now see the following actions:
 

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -100,42 +100,24 @@ Testing consists of provisioning the device and configuring it for communication
 Provisioning the device
 -----------------------
 
-The provisioning assigns an address range to the device, and adds it to the mesh network.
-Complete the following steps in the nRF Mesh app:
+.. |device name| replace:: :guilabel:`Mesh Light Switch`
 
-1. Tap :guilabel:`Add node` to start scanning for unprovisioned mesh devices.
-#. Select the :guilabel:`Mesh Light Switch` device to connect to it.
-#. Tap :guilabel:`Identify` and then :guilabel:`Provision` to provision the device.
-#. When prompted, select the OOB method and follow the instructions in the app.
-
-Once the provisioning and initial configuration is complete, the app will go back to the Network screen.
+.. include:: /includes/mesh_device_provisioning.txt
 
 Configuring models
 ------------------
 
-Complete the following steps in the nRF Mesh app to configure models:
+See :ref:`ug_bt_mesh_model_config_app` for details on how to configure the mesh models with the nRF Mesh mobile app.
 
-1. On the Network screen, tap the :guilabel:`Mesh Light Switch` node.
-   Basic information about the mesh node and its configuration is displayed.
-#. In the mesh node view, expand the first element.
-   It contains the list of models in the first element of the node.
-#. Tap :guilabel:`Generic OnOff Client` to see the model's configuration.
-#. Bind the model to application keys to make it open for communication:
+Configure the Generic OnOff Client model on each element on the :guilabel:`Mesh Light Switch` node:
 
-   1. Tap :guilabel:`BIND KEY` at the top of the screen.
-   #. Select :guilabel:`Application Key 1` from the list.
+* Bind the model to :guilabel:`Application Key 1`.
+* Set the publication parameters:
 
-#. Configure the Client model publish parameters, which define how the model will send its messages:
+  * Destination/publish address: Set the :guilabel:`Publish Address` to the first unicast address of the Mesh Light node.
+  * Retransmit count: Set the count to zero (:guilabel:`Disabled`), to prevent the model from sending each button press multiple times.
 
-   1. Tap :guilabel:`SET PUBLICATION`.
-   #. Set the Publish Address to the first unicast address of the Mesh Light node.
-   #. Set the Retransmit Count to zero (:guilabel:`Disabled`) to prevent the model from sending each button press multiple times.
-   #. Leave the rest of the publish parameters at their default values.
-   #. Tap :guilabel:`APPLY` to confirm the configuration.
-
-You are now be able to control the first LED on the mesh light device by pressing Button 1 on the mesh light switch development kit.
-
-Repeat steps 3-5 for each of the elements on the node to control each of the remaining three LEDs on the mesh light device.
+You can now control the first LED on the mesh light device by pressing Button 1 on the mesh light switch development kit.
 
 Dependencies
 ************

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -114,56 +114,24 @@ For more details, see :ref:`gs_testing`.
 Provisioning the device
 -----------------------
 
-The provisioning assigns an address range to the device, and adds it to the mesh network.
-Complete the following steps in the nRF Mesh app:
+.. |device name| replace:: :guilabel:`Mesh Sensor Observer`
 
-1. Tap :guilabel:`Add node` to start scanning for unprovisioned mesh devices.
-#. Select the :guilabel:`Mesh Sensor Observer` device to connect to it.
-#. Tap :guilabel:`Identify` and then :guilabel:`Provision` to provision the device.
-#. When prompted, select an OOB method and follow the instructions in the app.
-
-Once the provisioning is complete, the app returns to the Network screen.
+.. include:: /includes/mesh_device_provisioning.txt
 
 Configuring models
 ------------------
 
-Complete the following steps in the nRF Mesh app to configure models:
+See :ref:`ug_bt_mesh_model_config_app` for details on how to configure the mesh models with the nRF Mesh mobile app.
 
-1. On the Network screen, tap the :guilabel:`Mesh Sensor Observer` node.
-   Basic information about the mesh node and its configuration is displayed.
-#. In the mesh node view, expand the element.
-   It contains the list of models in the first and only element of the node.
-#. Tap :guilabel:`Sensor Client` to see the model's configuration.
-#. Bind the model to application keys to make it open for communication:
+Configure the Sensor Client model on the :guilabel:`Mesh Sensor Observer` node:
 
-   a. Tap :guilabel:`BIND KEY` at the top of the screen.
-   #. Select :guilabel:`Application Key 1` from the list.
+* Bind the model to :guilabel:`Application Key 1`.
+* Set the publication parameters:
 
-#. Set the publishing parameters:
+  * Destination/publish address: Select an existing group or create a new one, but make sure that the Sensor Server subscribes to the same group.
+  * Retransmit count: Set the count to zero (:guilabel:`Disabled`), to avoid duplicate logging in the UART terminal.
 
-   a. Tap :guilabel:`SET PUBLICATION`.
-   #. Tap :guilabel:`Publish Address`.
-   #. Select :guilabel:`Groups` from the drop-down menu.
-   #. Select an existing group or create a new one.
-
-      .. note::
-         The sensor server must subscribe to the same group.
-
-   #. Tap :guilabel:`OK`.
-   #. Set the Retransmit Count to zero (:guilabel:`Disabled`) to avoid duplicate logging in the UART terminal.
-   #. Tap the confirmation button at the bottom right corner of the app to save the parameters.
-
-#. Set subscription parameters:
-
-   a. Tap :guilabel:`SUBSCRIBE`.
-   #. Select an existing group or create a new one.
-
-      .. note::
-         The Sensor Server must publish to the same group.
-
-   #. Tap :guilabel:`OK`.
-
-#. Double-tap the back arrow button at the top left corner of the app to get back to the main application screen.
+* Set the subscription parameters: Select an existing group or create a new one, but make sure that the Sensor Server publishes to the same group.
 
 The Sensor Client model is now configured and able to receive data from the Sensor Server.
 

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -112,59 +112,26 @@ Testing consists of provisioning the device, and configuring it for communicatio
 Provisioning the device
 -----------------------
 
-The provisioning assigns an address range to the device, and adds it to the mesh network.
-Complete the following steps in the nRF Mesh app:
+.. |device name| replace:: :guilabel:`Mesh Sensor`
 
-1. Tap :guilabel:`Add node` to start scanning for unprovisioned mesh devices.
-#. Select the :guilabel:`Mesh Sensor` device to connect to it.
-#. Tap :guilabel:`Identify` and then :guilabel:`Provision` to provision the device.
-#. When prompted, select an OOB method and follow the instructions in the app.
-
-Once the provisioning is complete, the app returns to the Network screen.
+.. include:: /includes/mesh_device_provisioning.txt
 
 .. _bluetooth_mesh_sensor_server_conf_models:
 
 Configuring models
 ------------------
 
-Complete the following steps in the nRF Mesh app to configure models:
+See :ref:`ug_bt_mesh_model_config_app` for details on how to configure the mesh models with the nRF Mesh mobile app.
 
-1. On the Network screen, tap the :guilabel:`Mesh Sensor` node.
-   Basic information about the mesh node and its configuration is displayed.
-#. In the mesh node view, expand the element.
-   It contains the list of models in the first and only element of the node.
-#. Tap :guilabel:`Sensor Server` to see the model's configuration.
-#. Bind the model to application keys to make it open for communication:
+Configure the Sensor Server model on the :guilabel:`Mesh Sensor` node:
 
-   a. Tap :guilabel:`BIND KEY` at the top of the screen.
-   #. Select :guilabel:`Application Key 1` from the list.
+* Bind the model to :guilabel:`Application Key 1`.
+* Set the publication parameters:
 
-#. Set the publishing parameters:
+  * Destination/publish address: Select an existing group or create a new one, but make sure that the Sensor Client subscribes to the same group.
+  * Retransmit count: Set the count to zero (:guilabel:`Disabled`), to avoid duplicate logging in the :ref:`bt_mesh_sensor_cli_readme`'s UART terminal.
 
-   a. Tap :guilabel:`SET PUBLICATION`.
-   #. Tap :guilabel:`Publish Address`.
-   #. Select :guilabel:`Groups` from the drop-down menu.
-   #. Select an existing group or create a new one.
-
-      .. note::
-         The Sensor Client must subscribe to the same group.
-
-   #. Tap :guilabel:`OK`.
-   #. Select a publishing period by using the :guilabel:`Interval` slider.
-   #. Set the Retransmit Count to zero (:guilabel:`Disabled`) to avoid duplicate logging in the :ref:`bt_mesh_sensor_cli_readme`'s UART terminal.
-   #. Tap the confirmation button at the bottom right corner of the app to save the parameters.
-
-#. Set subscription parameters:
-
-   a. Tap :guilabel:`SUBSCRIBE`.
-   #. Select an existing group or create a new one.
-
-      .. note::
-         The Sensor Client must publish to the same group.
-
-   #. Tap :guilabel:`OK`.
-
-#. Double-tap the back arrow button at the top left corner of the app to get back to the main application screen.
+* Set the subscription parameters: Select an existing group or create a new one, but make sure that the Sensor Client publishes to the same group.
 
 The Sensor Server model is now configured and able to send data to the Sensor Client.
 


### PR DESCRIPTION
NCSDK-7423: Creating template for provisioning doc. Cleaning up model
config.

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>