### PR TITLE
manifest: update nrfxlib

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: f76fa16478d8718f82b3153931c97cb570d5a0ac
+      revision: 4e494ee109639461a4cafbcad86b30cc1144c677
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Added missing option to nrf_security mbedtls.

Jira:NCSDK-7689

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>