### PR TITLE
manifest: update nrfxlib

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 7cc9277d8e8675a7c57d78db461468b4258ff343
+      revision: pull/376/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Make mbedtls libraries link correctly with libc.

Jira:NCSDK-7689

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>