### PR TITLE
samples: openthread: fix vendor hooks symbol name

### DIFF
--- a/samples/openthread/ncp/README.rst
+++ b/samples/openthread/ncp/README.rst
@@ -122,7 +122,7 @@ For this sample, handling of extension commands and properties is done through t
 To enable the feature:
 
 1. Provide the implementation of this file.
-#. Insert information about the file location in the ``CONFIG_OPENTHREAD_NCP_VENDOR_HOOK_SOURCE`` field.
+#. Insert information about the file location in the ``CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE`` field.
    This field is located in the overlay configuration file (see :file:`overlay-vendor_hook.conf`).
    The inserted path must be relative to the NCP sample directory.
 
@@ -130,7 +130,7 @@ The NCP sample provides the vendor hook :file:`user_vendor_hook.cpp` file in the
 You can either:
 
 * Use the provided :file:`user_vendor_hook.cpp` file.
-* Provide your own implementation and replace the ``CONFIG_OPENTHREAD_NCP_VENDOR_HOOK_SOURCE`` option value in the overlay file with the path to your file.
+* Provide your own implementation and replace the ``CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE`` option value in the overlay file with the path to your file.
 
 For information about how to test the vendor hook feature, see :ref:`ug_thread_vendor_hooks_testing`.
 

--- a/samples/openthread/ncp/overlay-vendor_hook.conf
+++ b/samples/openthread/ncp/overlay-vendor_hook.conf
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-CONFIG_OPENTHREAD_NCP_VENDOR_HOOK_SOURCE="/src/user_vendor_hook.cpp"
+CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE="/src/user_vendor_hook.cpp"


### PR DESCRIPTION
Rename `CONFIG_OPENTHREAD_NCP_VENDOR_HOOK_SOURCE` to
`CONFIG_OPENTHREAD_COPROCESSOR_VENDOR_HOOK_SOURCE`, since it was
renamed in Zephyr.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-8770