### PR TITLE
drivers: temp_nrf5: Make sensor available on build time

### DIFF
--- a/drivers/mpsl/temp_nrf5/temp_nrf5_mpsl.c
+++ b/drivers/mpsl/temp_nrf5/temp_nrf5_mpsl.c
@@ -91,6 +91,11 @@ static int temp_nrf5_mpsl_init(const struct device *dev)
 
 static struct temp_nrf5_mpsl_data temp_nrf5_mpsl_driver;
 
-DEVICE_AND_API_INIT(temp_nrf5_mpsl, DT_INST_LABEL(0), temp_nrf5_mpsl_init,
-		    &temp_nrf5_mpsl_driver, NULL, POST_KERNEL,
-		    CONFIG_SENSOR_INIT_PRIORITY, &temp_nrf5_mpsl_driver_api);
+DEVICE_DT_INST_DEFINE(0,
+		      temp_nrf5_mpsl_init,
+		      device_pm_control_nop,
+		      &temp_nrf5_mpsl_driver,
+		      NULL,
+		      POST_KERNEL,
+		      CONFIG_SENSOR_INIT_PRIORITY,
+		      &temp_nrf5_mpsl_driver_api);


### PR DESCRIPTION
Change TEMP_NRF5_MPSL temperature sensor definition to allow retrieval
of the device pointer on build time by using DEVICE_DT_GET macro.