### PR TITLE
Zigbee: Reorganize test cases

### DIFF
--- a/samples/zigbee/light_bulb/sample.yaml
+++ b/samples/zigbee/light_bulb/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   zigbee.light_bulb:
     build_only: true
-    build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
-    tags: ci_build
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+    tags: ci_build smoke

--- a/samples/zigbee/light_switch/sample.yaml
+++ b/samples/zigbee/light_switch/sample.yaml
@@ -4,6 +4,29 @@ sample:
 tests:
   zigbee.light_switch:
     build_only: true
-    build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+    tags: ci_build smoke
+
+  zigbee.light_switch.fota:
+    build_only: true
+    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840
+    tags: ci_build smoke
+    extra_args: DOVERLAY_CONFIG=overlay-fota.conf
+
+  zigbee.light_switch.fota_and_multiprotocol:
+    build_only: true
+    platform_allow: nrf52840dk_nrf52840
     tags: ci_build
+    extra_args: DOVERLAY_CONFIG=overlay-fota.conf DOVERLAY_CONFIG=overlay-multiprotocol_ble.conf
+
+  zigbee.light_switch.multiprotocol:
+    build_only: true
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    tags: ci_build
+    extra_args: DOVERLAY_CONFIG=overlay-multiprotocol_ble.conf
+
+  zigbee.light_switch.current_measurement:
+    build_only: true
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    tags: ci_build
+    extra_args: CONFIG_SERIAL=n

--- a/samples/zigbee/network_coordinator/sample.yaml
+++ b/samples/zigbee/network_coordinator/sample.yaml
@@ -1,9 +1,8 @@
 sample:
-  name: Zigbee Light control
+  name: Zigbee Network coordinator
   description: Zigbee Light control - coordinator sample
 tests:
   zigbee.network_coordinator:
     build_only: true
-    build_on_all: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
-    tags: ci_build
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+    tags: ci_build smoke


### PR DESCRIPTION
Add more test cases to Zigbee sample.yaml files. 
All supported sample variants should be included in sample.yaml.

Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>