### PR TITLE
Zigbee: Fix building light bulb on nrf21540dk_nrf52840

### DIFF
--- a/samples/zigbee/light_bulb/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/zigbee/light_bulb/boards/nrf21540dk_nrf52840.overlay
@@ -8,4 +8,15 @@
 	chosen {
 		zephyr,entropy = &rng;
 	};
+
+	pwmleds {
+		pwm_led3: pwm_led_3 {
+			pwms = <&pwm0 16>;
+		};
+	};
+};
+
+&pwm0 {
+	ch1-pin = <16>;
+	ch1-inverted;
 };


### PR DESCRIPTION
Add missing configuration for nrf21540dk_nrf52840 board.
Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>