### PR TITLE
debug: ppi_trace: Allocate GPIOTE channels with nrfx

### DIFF
--- a/subsys/debug/ppi_trace/Kconfig
+++ b/subsys/debug/ppi_trace/Kconfig
@@ -6,6 +6,7 @@
 
 menuconfig PPI_TRACE
 	bool "Enable PPI trace"
+	select NRFX_GPIOTE
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 	help


### PR DESCRIPTION
The PPI trace module uses a proprietary GPIOTE channel allocator.
This commit makes it use the allocation mechanism provided by nrfx.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>

Note that this PR depends on changes introduced upstream in zephyrproject-rtos/zephyr#31606. Without these changes available in NCS, allocation of overlapping GPIOTE channels performed by PPI trace and Zephyr's GPIO driver causes PPI trace to break. Therefore this PR must not be merged until the commits from zephyrproject-rtos/zephyr#31606 are present in sdk-zephyr.