### PR TITLE
ci: allow publishing to multiple servers

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -97,12 +97,16 @@ jobs:
           file="doc_build_${GITHUB_RUN_ID}.tgz"
           tar -C ../html -zcf $file .
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "publish PR-${{ github.event.number }} $file" > monitor_$GITHUB_RUN_ID.txt
+            echo "publish2 dev PR-${{ github.event.number }} $file" > monitor_$GITHUB_RUN_ID.txt
             echo "${{ github.event.number }}" > pr.txt
           else
             # basename will work for both branches and tags
             branch=$(basename "${{ github.ref }}")
-            echo "publish ${branch} $file" > monitor_$GITHUB_RUN_ID.txt
+            if [[ $branch == "master" ]]; then
+              echo "publish2 main latest $file" > monitor_$GITHUB_RUN_ID.txt
+            else
+              echo "publish2 main ${branch} $file" > monitor_$GITHUB_RUN_ID.txt
+            fi
           fi
 
       - name: Upload artifact


### PR DESCRIPTION
Update publishing instructions to file to use "publish2"; this command gets an extra argument providing a location name to use for publishing.

The location must match the names used in the server side script, which currently are "dev" for the development server, and "main" for the production server. PRs are left published to the development server, and switch "master" and other branches (currently disabled in the workflow) to push to the production server.