### PR TITLE
net: lib: download_client: max filename size is too small

### DIFF
--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -102,7 +102,7 @@ config DOWNLOAD_CLIENT_MAX_HOSTNAME_SIZE
 
 config DOWNLOAD_CLIENT_MAX_FILENAME_SIZE
 	int "Maximum filename length (stack)"
-	range 8 256
+	range 8 2048
 	default 192
 
 config DOWNLOAD_CLIENT_TCP_SOCK_TIMEO_MS


### PR DESCRIPTION
The kconfig parameter DOWNLOAD_CLIENT_MAX_FILENAME_SIZE in
download_client defaults to 192 and the range is set to 8-256. When
using download client in combination with aws_fota for downloading
firmware images from S3 it is usual to use the so called signed URLs.
These URLs allow the URL holder to download files that are not
accessible publicly, they do that by adding cryptogrphic parameters to
the file path for example:

https://pres-url-test.s3-eu-west-1.amazonaws.com/test.txt
?X-Amz-Algorithm=AWS4-HMAC-SHA256
&X-Amz-Credential=AKIAJQ6UAEQOACU54C3A%2F20180927%2Feu-west-1%2Fs3%2Faws4_request
&X-Amz-Date=20180927T100139Z
&X-Amz-Expires=900
&X-Amz-Signature=f6fa35129753e7626c850a531379436a555447bfbd597c19e3177ae3d2c48387
&X-Amz-SignedHeaders=host

This filename is then embedded in the AWS job document which in turn
makes it into the download client which fails with error -7 due to the
file path being longer than the default 192.
This PR increases the range for the DOWNLOAD_CLIENT_MAX_FILENAME_SIZE to 8-2048 and
sets the default to 1024 which should be enough for S3 signed URLs.

Signed-off-by: Xavier Naveira <xnaveira@gmail.com>