### PR TITLE
doc: move versions.txt generation to own file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,7 @@
 Kconfig*                                  @tejlmand
 # All doc related files
 /doc/CMakeLists.txt                       @carlescufi
+/doc/update_versions.cmake                @carlescufi
 /doc/scripts/                             @carlescufi
 /doc/static/                              @carlescufi
 /doc/themes/                              @carlescufi

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -141,47 +141,16 @@ set(NRF_KI_DIR ${NRF_BASE}/.known-issues/doc)
 
 configure_file(${NRF_DOXYFILE_IN} ${NRF_DOXYFILE_OUT} @ONLY)
 
-file(STRINGS ${NRF_BASE}/scripts/tools-versions-minimum.txt MINIMUM_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
-file(STRINGS ${NRF_BASE}/scripts/tools-versions-darwin.txt DARWIN_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
-file(STRINGS ${NRF_BASE}/scripts/tools-versions-win10.txt WIN10_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
-file(STRINGS ${NRF_BASE}/scripts/tools-versions-linux.txt LINUX_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
-
-foreach(os MINIMUM DARWIN WIN10 LINUX)
-  foreach(program ${${os}_VERSIONS_ALL})
-    string(REGEX REPLACE "(^[^=]*)=([^\;]*)\;*.*" "\\1" program_name "${program}")
-    string(TOUPPER ${program_name} PROGRAM_NAME_UPPER)
-    set(${PROGRAM_NAME_UPPER}_VERSION_${os} ${CMAKE_MATCH_2})
-  endforeach()
-endforeach()
-
-# Loading Zephyr requirements-base.txt first, then mcuboot, and afterwards NCS
-# specific ensures that any packages present in multiple files will present the
-# version defined by NCS.
-file(STRINGS ${ZEPHYR_BASE}/scripts/requirements-base.txt ZEPHYR_BASE_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${ZEPHYR_BASE}/scripts/requirements-doc.txt ZEPHYR_DOCS_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${MCUBOOT_BASE}/scripts/requirements.txt MCUBOOT_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${NRF_BASE}/scripts/requirements-base.txt NRF_BASE_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${NRF_BASE}/scripts/requirements-doc.txt NRF_DOC_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${NRF_BASE}/scripts/requirements-build.txt NRF_BUILD_PACKAGE_VERSIONS REGEX "^[^#].*")
-
-foreach(package ${ZEPHYR_BASE_PACKAGE_VERSIONS}
-                ${ZEPHYR_DOCS_PACKAGE_VERSIONS}
-                ${MCUBOOT_PACKAGE_VERSIONS}
-                ${NRF_BASE_PACKAGE_VERSIONS}
-                ${NRF_DOC_PACKAGE_VERSIONS}
-                ${NRF_BUILD_PACKAGE_VERSIONS}
+add_custom_target(
+  nrf-update-versions
+  COMMAND ${CMAKE_COMMAND}
+    -DNRF_BASE=${NRF_BASE}
+    -DZEPHYR_BASE=${ZEPHYR_BASE}
+    -DMCUBOOT_BASE=${MCUBOOT_BASE}
+    -DNRF_DOC_DIR=${NRF_DOC_DIR}
+    -DNRF_RST_OUT="${NRF_RST_OUT}"
+    -P ${NRF_BASE}/doc/update_versions.cmake
 )
-  string(REGEX REPLACE "(^[^>=\;]*)([\;]|([>=][^\;]*))\;*.*" "\\1" package_name "${package}")
-  string(TOUPPER ${package_name} PACKAGE_NAME_UPPER)
-  set(${PACKAGE_NAME_UPPER}_VERSION ${CMAKE_MATCH_3})
-  if("${${PACKAGE_NAME_UPPER}_VERSION}" STREQUAL "")
-    set(${PACKAGE_NAME_UPPER}_VERSION "\\ ")
-  endif()
-endforeach()
-
-set(NRF_VERSION_IN ${NRF_DOC_DIR}/versions.txt.in)
-set(NRF_RST_VERSION_OUT ${NRF_RST_OUT}/doc/nrf/versions.txt)
-configure_file(${NRF_VERSION_IN} ${NRF_RST_VERSION_OUT} @ONLY)
 
 add_custom_target(
   nrf-doxy
@@ -226,6 +195,7 @@ add_custom_target(
   COMMAND ${NRF_EXTRACT_CONTENT_COMMAND}
   WORKING_DIRECTORY ${NRF_DOC_DIR}
 )
+add_dependencies(nrf-content nrf-update-versions)
 
 if(WIN32)
   set(SEP $<SEMICOLON>)

--- a/doc/update_versions.cmake
+++ b/doc/update_versions.cmake
@@ -1,0 +1,64 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+if(NOT DEFINED NRF_BASE)
+  message(FATAL_ERROR "No NRF_BASE argument supplied")
+endif()
+
+if(NOT DEFINED ZEPHYR_BASE)
+  message(FATAL_ERROR "No ZEPHYR_BASE argument supplied")
+endif()
+
+if(NOT DEFINED MCUBOOT_BASE)
+  message(FATAL_ERROR "No MCUBOOT_BASE argument supplied")
+endif()
+
+if(NOT DEFINED NRF_DOC_DIR)
+  message(FATAL_ERROR "No NRF_DOC_DIR argument supplied")
+endif()
+
+if(NOT DEFINED NRF_RST_OUT)
+  message(FATAL_ERROR "No NRF_RST_OUT argument supplied")
+endif()
+
+file(STRINGS ${NRF_BASE}/scripts/tools-versions-minimum.txt MINIMUM_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
+file(STRINGS ${NRF_BASE}/scripts/tools-versions-darwin.txt DARWIN_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
+file(STRINGS ${NRF_BASE}/scripts/tools-versions-win10.txt WIN10_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
+file(STRINGS ${NRF_BASE}/scripts/tools-versions-linux.txt LINUX_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
+
+foreach(os MINIMUM DARWIN WIN10 LINUX)
+  foreach(program ${${os}_VERSIONS_ALL})
+    string(REGEX REPLACE "(^[^=]*)=([^\;]*)\;*.*" "\\1" program_name "${program}")
+    string(TOUPPER ${program_name} PROGRAM_NAME_UPPER)
+    set(${PROGRAM_NAME_UPPER}_VERSION_${os} ${CMAKE_MATCH_2})
+  endforeach()
+endforeach()
+
+# Loading Zephyr requirements-base.txt first, then mcuboot, and afterwards NCS
+# specific ensures that any packages present in multiple files will present the
+# version defined by NCS.
+file(STRINGS ${ZEPHYR_BASE}/scripts/requirements-base.txt ZEPHYR_BASE_PACKAGE_VERSIONS REGEX "^[^#].*")
+file(STRINGS ${ZEPHYR_BASE}/scripts/requirements-doc.txt ZEPHYR_DOCS_PACKAGE_VERSIONS REGEX "^[^#].*")
+file(STRINGS ${MCUBOOT_BASE}/scripts/requirements.txt MCUBOOT_PACKAGE_VERSIONS REGEX "^[^#].*")
+file(STRINGS ${NRF_BASE}/scripts/requirements-base.txt NRF_BASE_PACKAGE_VERSIONS REGEX "^[^#].*")
+file(STRINGS ${NRF_BASE}/scripts/requirements-doc.txt NRF_DOC_PACKAGE_VERSIONS REGEX "^[^#].*")
+file(STRINGS ${NRF_BASE}/scripts/requirements-build.txt NRF_BUILD_PACKAGE_VERSIONS REGEX "^[^#].*")
+
+foreach(package ${ZEPHYR_BASE_PACKAGE_VERSIONS}
+                ${ZEPHYR_DOCS_PACKAGE_VERSIONS}
+                ${MCUBOOT_PACKAGE_VERSIONS}
+                ${NRF_BASE_PACKAGE_VERSIONS}
+                ${NRF_DOC_PACKAGE_VERSIONS}
+                ${NRF_BUILD_PACKAGE_VERSIONS}
+)
+  string(REGEX REPLACE "(^[^>=\;]*)([\;]|([>=][^\;]*))\;*.*" "\\1" package_name "${package}")
+  string(TOUPPER ${package_name} PACKAGE_NAME_UPPER)
+  set(${PACKAGE_NAME_UPPER}_VERSION ${CMAKE_MATCH_3})
+  if("${${PACKAGE_NAME_UPPER}_VERSION}" STREQUAL "")
+    set(${PACKAGE_NAME_UPPER}_VERSION "\\ ")
+  endif()
+endforeach()
+
+set(NRF_VERSION_IN ${NRF_DOC_DIR}/versions.txt.in)
+set(NRF_RST_VERSION_OUT ${NRF_RST_OUT}/doc/nrf/versions.txt)
+configure_file(${NRF_VERSION_IN} ${NRF_RST_VERSION_OUT} @ONLY)


### PR DESCRIPTION
This fixes an issue after running `ninja clean-nrf` followed by `ninja nrf`. Since `cmake` is not invoked, the global `configure_file` was not being run and would not regenerate the pre-requisite versions.txt file.

The version generation was moved into another "cmake" file and imported as a dependency of the nrf-content target, forcing it to always run on each build.

JIRA: NCSDK-7514