### PR TITLE
manifest: Update nrfxlib to PR #389

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: abab9109ce6e3a10cafcaba75876030da7367a9a
+      revision: 560a0fd8f2cac3a33d1e667279877bd053e02257
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-Adding nrf_oberon v3.0.8

ref: NCSDK-7780

nrfxlib pr: https://github.com/nrfconnect/sdk-nrfxlib/pull/389

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>