### PR TITLE
event_manager: Explicit cast when using k_malloc.

### DIFF
--- a/subsys/event_manager/event_manager_priv.h
+++ b/subsys/event_manager/event_manager_priv.h
@@ -89,7 +89,7 @@ extern "C" {
 #define _EVENT_ALLOCATOR_FN(ename)					\
 	static inline struct ename *_CONCAT(new_, ename)(void)		\
 	{								\
-		struct ename *event = k_malloc(sizeof(*event));		\
+		struct ename *event = (struct ename *)k_malloc(sizeof(*event));\
 		BUILD_ASSERT(offsetof(struct ename, header) == 0,	\
 				 "");					\
 		if (unlikely(!event)) {					\
@@ -111,8 +111,8 @@ extern "C" {
 #define _EVENT_ALLOCATOR_DYNDATA_FN(ename)				\
 	static inline struct ename *_CONCAT(new_, ename)(size_t size)	\
 	{								\
-		struct ename *event = k_malloc(sizeof(*event) + size);	\
-		BUILD_ASSERT((offsetof(struct ename, dyndata) +	\
+		struct ename *event = (struct ename *)k_malloc(sizeof(*event) + size);\
+		BUILD_ASSERT((offsetof(struct ename, dyndata) +		\
 				  sizeof(event->dyndata.size)) ==	\
 				 sizeof(*event), "");			\
 		BUILD_ASSERT(offsetof(struct ename, header) == 0,	\


### PR DESCRIPTION
When included in C++ files compilation will end up with invalid
conversion error. Add explicit cast to a type when allocating
memory for events.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>