### PR TITLE
manifest: update sdk-zephyr for west group feature

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7317a1ccc32dcec249b2b21d51f6071eda42422b
+      revision: 8d7fe0bf3017968945d462175bbb780f7a7119ca
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update manifest to support west group feature for zephyr modules.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>