### PR TITLE
Initial support for HomeKit in NCS

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -41,6 +41,8 @@ manifest:
   defaults:
     remote: ncs
 
+  group-filter: [-homekit]
+
   # "projects" is a list of git repositories which make up the NCS
   # source code.
   projects:
@@ -145,7 +147,11 @@ manifest:
       remote: nordicsemi
       revision: 24f1b2b0c64c694b7f9ac1b7eab60b39236ca0bf
       path: modules/lib/cddl-gen
-
+    - name: homekit
+      repo-path: sdk-homekit
+      revision: 8d68bb07b9217960767f7c5030ea9a4ec37af5df
+      groups:
+      - homekit
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
To have an access for the HomeKit repository your company must enroll in the MFi Program and nRF Connect organization must verify it. See https://developer.apple.com/homekit for more information.

The changes purpose is to integrate HomeKit ADK for Accessory Manufacturers into the NCS. In order to provide initial support for it in NCS following changes were introduced:
* the new west group added to the west manifest (disabled by default)
* HomeKit repository - sdk-homekit were added to the west manifest

Signed-off-by: Krzysztof Taborowski <krzysztof.taborowski@nordicsemi.no>