### PR TITLE
softdevice_controller: Fix event length on command disallowed

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -927,9 +927,11 @@ int hci_internal_cmd_put(uint8_t *cmd_in)
 		 * by mixing legacy and extended commands.
 		 */
 		if (command_generates_command_complete_event(opcode)) {
+			uint8_t param_length = sizeof(struct bt_hci_evt_cmd_complete)
+					     + sizeof(struct bt_hci_evt_cc_status);
 			(void)encode_command_complete_header(cmd_complete_or_status.raw_event,
 							     opcode,
-							     CMD_COMPLETE_MIN_SIZE,
+							     param_length,
 							     BT_HCI_ERR_CMD_DISALLOWED);
 		} else {
 			(void)encode_command_status(cmd_complete_or_status.raw_event,


### PR DESCRIPTION
The command complete event indicated a too long event length
for the case where the host was mixing legacy and extended
advertising or scanning commands.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>