### PR TITLE
net: lib: download_client: Update max filename range

### DIFF
--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -103,7 +103,7 @@ config DOWNLOAD_CLIENT_MAX_HOSTNAME_SIZE
 
 config DOWNLOAD_CLIENT_MAX_FILENAME_SIZE
 	int "Maximum filename length (stack)"
-	range 8 256
+	range 8 512
 	default 192
 
 config DOWNLOAD_CLIENT_TCP_SOCK_TIMEO_MS


### PR DESCRIPTION
The current maximum is too short when trying to use the download client for a certain types of files
(i.e presigned urls). I'd like to make it possible to configure a wider range.

A future improvement that could also be made is in place copying the
client->host & client->file within `http_get_request_send` so a copy
of the data on the stack is not necessary, but that would require
updates to the `url_parse_host` & `url_parse_file` helpers.