### PR TITLE
lib: bin: lwm2m_carrier: Add oper_id check to lwm2m_os_sec_psk_delete()

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -104,6 +104,11 @@ IRIS-2676: Missing support for FOTA on nRF Connect for Cloud
 Other issues
 ============
 
+.. rst-class:: v1-4-2 v1-4-1 v1-4-0
+
+NRF91-989: Unable to bootstrap after changing SIMs
+  In some cases, swapping the SIM card may trigger the bootstrap Pre-Shared Key to be deleted from the device. This can prevent future bootstraps from succeeding.
+
 .. rst-class:: v1-4-99-dev1 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
 
 NCSDK-5666: LTE Sensor Gateway

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -797,7 +797,26 @@ int lwm2m_os_sec_psk_write(uint32_t sec_tag, const void *buf, uint16_t len)
 
 int lwm2m_os_sec_psk_delete(uint32_t sec_tag)
 {
-	return modem_key_mgmt_delete(sec_tag, MODEM_KEY_MGMT_CRED_TYPE_PSK);
+	char xoperid[20];
+	char oper_id = 0;
+
+	int code = at_cmd_write("AT%XOPERID", xoperid, sizeof(xoperid),
+				(enum at_cmd_state *)NULL);
+
+	/* Expected result: "%XOPERID: <oper_id>" */
+	if ((code == 0) && (strncmp(xoperid, "%XOPERID: ", 10) == 0) &&
+	    (strlen(xoperid) >= 11)) {
+		oper_id = xoperid[10] - '0';
+	}
+
+	/* Delete only for specific operators. */
+	if ((oper_id == 2) || (oper_id == 3) || (oper_id == 4) ||
+	    (oper_id == 5)) {
+		return modem_key_mgmt_delete(sec_tag,
+					     MODEM_KEY_MGMT_CRED_TYPE_PSK);
+	}
+
+	return 0;
 }
 
 int lwm2m_os_sec_identity_exists(uint32_t sec_tag, bool *exists,


### PR DESCRIPTION
This delete from lwm2m_carrier library is only intended for
specific operators. Add a check for this.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>