### PR TITLE
subsys: mpsl: use NRFX PPI allocator to assign PPI channels

### DIFF
--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -90,12 +90,6 @@ To use nRF21540 in GPIO mode, complete the following steps:
    * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_RX_EN`
    * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN`
 
-#. Set the following Kconfig parameters to assign unique PPI channel numbers to be used exclusively by the FEM driver:
-
-   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_0`
-   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_1`
-   * :option:`CONFIG_MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_2`
-
 Optional properties
 ===================
 
@@ -165,11 +159,6 @@ To use the Simple GPIO implementation of FEM with SKY66112-11, complete the foll
 
    * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CTX`
    * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_GPIOTE_CRX`
-
-#. Set the following Kconfig parameters to assign unique PPI channel numbers to be used exclusively by the FEM driver:
-
-   * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_0`
-   * :option:`CONFIG_MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_1`
 
 Optional properties
 ===================

--- a/subsys/mpsl/Kconfig.fem
+++ b/subsys/mpsl/Kconfig.fem
@@ -72,27 +72,6 @@ config MPSL_FEM_NRF21540_GPIO_GPIOTE_PDN
 	  Unique GPIOTE channel number to be used exclusively by the FEM driver
 	  for PDN pin control.
 
-config MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_0
-	int "PPI channel reserved for the front-end module"
-	default 15
-	help
-	  The first of three unique PPI channel numbers to be used exclusively
-	  by the FEM driver.
-
-config MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_1
-	int "PPI channel reserved for the front-end module"
-	default 16
-	help
-	  The second of three unique PPI channel numbers to be used exclusively
-	  by the FEM driver.
-
-config MPSL_FEM_NRF21540_GPIO_PPI_CHANNEL_2
-	int "PPI channel reserved for the front-end module"
-	default 5
-	help
-	  Third of three unique PPI channel numbers to be used exclusively
-	  by the FEM driver.
-
 config MPSL_FEM_NRF21540_TX_GAIN_DB
 	int "TX gain of the nRF21540 PA amplifier in dB"
 	default 20
@@ -125,20 +104,6 @@ config MPSL_FEM_SIMPLE_GPIO_GPIOTE_CRX
 	help
 	  Unique GPIOTE channel number to be used exclusively by the FEM driver
 	  for RTX pin control.
-
-config MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_0
-	int "PPI channel reserved for the front-end module"
-	default 15
-	help
-	  The first of two unique PPI channel numbers to be used exclusively
-	  by the FEM driver.
-
-config MPSL_FEM_SIMPLE_GPIO_PPI_CHANNEL_1
-	int "PPI channel reserved for the front-end module"
-	default 16
-	help
-	  The second of two unique PPI channel numbers to be used exclusively
-	  by the FEM driver.
 
 endif
 


### PR DESCRIPTION
Previously the user was required to manually provide unused PPI channels
for use by the FEM module. Since PPI channel allocators now exist,
the FEM module was changed to allocate the channels by itself to avoid
hard to detect bugs stemming from misconfiguration.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>