### PR TITLE
manifest: synchronize trusted-firmware-m module with Zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
-      revision: dcfa70e66e91d9bf31fd6f083e2fba19b4305f4e
+      revision: 96340fb6c0b7e31c2070e1f428ca24076d2700a6
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Update trusted-firmware-m manifest pointer, to synchronize
the module with upstream Zephyr master, commit
96340fb6c0b7e31c2070e1f428ca24076d2700a6

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>