### PR TITLE
Make TFM work with the nrf91 modem

### DIFF
--- a/modules/tfm/boards/partition/region_defs.h
+++ b/modules/tfm/boards/partition/region_defs.h
@@ -82,8 +82,8 @@
 #define S_CODE_SIZE     (IMAGE_S_CODE_SIZE)
 #define S_CODE_LIMIT    (S_CODE_START + S_CODE_SIZE - 1)
 
-#define S_DATA_START    (PM_TFM_RAM_ADDRESS)
-#define S_DATA_SIZE     (PM_TFM_RAM_SIZE)
+#define S_DATA_START    (PM_TFM_SRAM_ADDRESS)
+#define S_DATA_SIZE     (PM_TFM_SRAM_SIZE)
 #define S_DATA_LIMIT    (S_DATA_START + S_DATA_SIZE - 1)
 
 /* The CMSE veneers shall be placed in an NSC region
@@ -131,8 +131,8 @@
 #define BL2_CODE_SIZE     (FLASH_AREA_BL2_SIZE)
 #define BL2_CODE_LIMIT    (BL2_CODE_START + BL2_CODE_SIZE - 1)
 
-#define BL2_DATA_START    (PM_TFM_RAM_ADDRESS)
-#define BL2_DATA_SIZE     (PM_TFM_RAM_SIZE)
+#define BL2_DATA_START    (PM_TFM_SRAM_ADDRESS)
+#define BL2_DATA_SIZE     (PM_TFM_SRAM_SIZE)
 #define BL2_DATA_LIMIT    (BL2_DATA_START + BL2_DATA_SIZE - 1)
 #endif /* BL2 */
 
@@ -140,7 +140,7 @@
  * Shared data area is allocated at the beginning of the RAM, it is overlapping
  * with TF-M Secure code's MSP stack
  */
-#define BOOT_TFM_SHARED_DATA_BASE PM_TFM_RAM_ADDRESS
+#define BOOT_TFM_SHARED_DATA_BASE PM_TFM_SRAM_ADDRESS
 #define BOOT_TFM_SHARED_DATA_SIZE (0x400)
 #define BOOT_TFM_SHARED_DATA_LIMIT (BOOT_TFM_SHARED_DATA_BASE + \
 				    BOOT_TFM_SHARED_DATA_SIZE - 1)

--- a/modules/tfm/boards/partition/region_defs.h
+++ b/modules/tfm/boards/partition/region_defs.h
@@ -110,8 +110,8 @@
 #define NS_CODE_SIZE    (IMAGE_NS_CODE_SIZE)
 #define NS_CODE_LIMIT   (NS_CODE_START + NS_CODE_SIZE - 1)
 
-#define NS_DATA_START   (PM_SRAM_PRIMARY_ADDRESS)
-#define NS_DATA_SIZE    (PM_SRAM_PRIMARY_SIZE)
+#define NS_DATA_START   (PM_SRAM_NONSECURE_ADDRESS)
+#define NS_DATA_SIZE    (PM_SRAM_NONSECURE_SIZE)
 #define NS_DATA_LIMIT   (NS_DATA_START + NS_DATA_SIZE - 1)
 
 /* NS partition information is used for SPU configuration */

--- a/samples/nrf9160/download/boards/nrf9160dk_nrf9160ns.overlay
+++ b/samples/nrf9160/download/boards/nrf9160dk_nrf9160ns.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Disable uart1 in nonsecure since it is used by the TFM secure app. */
+&uart1 {
+	status = "disabled";
+};

--- a/samples/nrf9160/download/overlay-tfm.conf
+++ b/samples/nrf9160/download/overlay-tfm.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BUILD_WITH_TFM=y
+CONFIG_FPU=n

--- a/samples/nrf9160/download/sample.yaml
+++ b/samples/nrf9160/download/sample.yaml
@@ -10,3 +10,9 @@ tests:
       - CONFIG_SHELL=y
       - CONFIG_COAP=y
       - CONFIG_DOWNLOAD_CLIENT_SHELL=y
+  samples.nrf9160.download.tfm:
+    build_only: true
+    build_on_all: true
+    platform_allow: nrf9160dk_nrf9160ns
+    tags: ci_build
+    extra_args: OVERLAY_CONFIG="overlay-tfm.conf"

--- a/samples/spm/pm.yml
+++ b/samples/spm/pm.yml
@@ -10,8 +10,3 @@ spm_sram:
   size: CONFIG_PM_PARTITION_SIZE_SPM_SRAM
   placement: {after: start}
   inside: sram_secure
-
-# Create a span for the RAM to be configured as SECURE by the spm.
-sram_secure:
-  span: []
-  region: sram_primary

--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -305,8 +305,12 @@ def resolve(reqs, dp):
     solve_first_last(reqs, unsolved, solution)
 
     while unsolved:
+        current_len = len(unsolved)
         solve_direction(reqs, sub_partitions, unsolved, solution, 'before')
         solve_direction(reqs, sub_partitions, unsolved, solution, 'after')
+        if current_len == len(unsolved):
+            raise PartitionError('Unable to solve the following partitions (endless loop):\n'
+                                 + pformat(unsolved))
 
     # Validate partition spanning.
     for sub in sub_partitions:

--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -203,17 +203,6 @@ def solve_direction(reqs, sub_partitions, unsolved, solution, ab):
             current = pool[current_index]
 
 
-def solve_first_last(reqs, unsolved, solution):
-    for fl in [('after', 'start', lambda x: solution.insert(0, x)), ('before', 'end', solution.append)]:
-        first_or_last = [x for x in reqs.keys() if 'placement' in reqs[x]
-                         and fl[0] in reqs[x]['placement'].keys()
-                         and fl[1] in reqs[x]['placement'][fl[0]]]
-        if first_or_last:
-            fl[2](first_or_last[0])
-            if first_or_last[0] in unsolved:
-                unsolved.remove(first_or_last[0])
-
-
 def solve_inside(reqs, sub_partitions):
     for key, value in reqs.items():
         if 'inside' in value.keys():
@@ -289,7 +278,7 @@ def resolve_ambiguous_requirements(reqs, unsolved):
 
 def resolve(reqs, dp):
     convert_str_to_list(reqs)
-    solution = list([dp])
+    solution = ["start", dp, "end"]
 
     remove_irrelevant_requirements(reqs, dp)
     sub_partitions = {k: v for k, v in reqs.items() if 'span' in v}
@@ -302,7 +291,6 @@ def resolve(reqs, dp):
 
     unsolved = get_images_which_need_resolving(reqs, sub_partitions)
     resolve_ambiguous_requirements(reqs, unsolved)
-    solve_first_last(reqs, unsolved, solution)
 
     while unsolved:
         current_len = len(unsolved)
@@ -311,6 +299,10 @@ def resolve(reqs, dp):
         if current_len == len(unsolved):
             raise PartitionError('Unable to solve the following partitions (endless loop):\n'
                                  + pformat(unsolved))
+
+    assert(solution[0] == "start" and solution[-1] == "end"), "invalid solution wrt. start and end."
+    solution.remove("start")
+    solution.remove("end")
 
     # Validate partition spanning.
     for sub in sub_partitions:

--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -79,6 +79,7 @@ pytz==2020.5
 pyusb==1.1.1
 PyYAML==5.4.1
 recommonmark==0.6.0
+regex==2020.11.13
 requests==2.25.1
 ruamel.yaml==0.16.12
 ruamel.yaml.clib==0.2.2

--- a/scripts/requirements-extra.txt
+++ b/scripts/requirements-extra.txt
@@ -1,3 +1,4 @@
 pygit2>=0.26.0
 editdistance>=0.5.0
 PyGithub
+regex==2020.11.13

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -73,6 +73,10 @@ if (CONFIG_BUILD_WITH_TFM)
   ncs_add_partition_manager_config(pm.yml.tfm)
 endif()
 
+if (CONFIG_TRUSTED_EXECUTION_NONSECURE OR CONFIG_TRUSTED_EXECUTION_SECURE)
+  ncs_add_partition_manager_config(pm.yml.trustzone)
+endif()
+
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
 set(using_partition_manager

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -141,6 +141,7 @@ if BUILD_WITH_TFM
 
 config PM_PARTITION_SIZE_TFM_RAM
 	hex "Memory reserved for TFM_RAM."
+	default 0x10000 if NRF_MODEM_LIB
 	default 0x16000 if SOC_NRF9160
 	default 0x40000 if SOC_NRF5340_CPUAPP
 	help
@@ -158,6 +159,17 @@ partition=TFM_EXTRA
 partition-size=0x10000
 rsource "Kconfig.template.partition_size"
 
+if NRF_MODEM_LIB
+
+config TFM_PROFILE
+	string "The build profile used for TFM Secure image."
+	default "profile_small"
+	help
+	  Use profile_small when the modem is enabled to get the RAM usage below
+	  64 kB, so the Modem's IPC RAM area can fit at 0x10000.
+	  This overrides the default TFM_PROFILE.
+
+endif # TFM_PROFILE
 endif # BUILD_WITH_TFM
 
 config PM_IMAGE_NOT_BUILT_FROM_SOURCE

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -139,13 +139,13 @@ config BUILD_WITH_TFM
 
 if BUILD_WITH_TFM
 
-config PM_PARTITION_SIZE_TFM_RAM
+config PM_PARTITION_SIZE_TFM_SRAM
 	hex "Memory reserved for TFM_RAM."
 	default 0x10000 if NRF_MODEM_LIB
 	default 0x16000 if SOC_NRF9160
 	default 0x40000 if SOC_NRF5340_CPUAPP
 	help
-	  Memory set aside for the TFM_RAM partition.
+	  Memory set aside for the TFM_SRAM partition.
 
 partition=BL2
 partition-size=0x8000

--- a/subsys/partition_manager/pm.yml.libmodem
+++ b/subsys/partition_manager/pm.yml.libmodem
@@ -3,4 +3,5 @@
 nrf_modem_lib_sram:
   placement: {after: [tfm_sram, spm_sram, start]}
   size: CONFIG_PM_PARTITION_SIZE_NRF_MODEM_LIB_SRAM
+  inside: sram_nonsecure
   region: sram_primary

--- a/subsys/partition_manager/pm.yml.libmodem
+++ b/subsys/partition_manager/pm.yml.libmodem
@@ -1,6 +1,6 @@
 #include <autoconf.h>
 
 nrf_modem_lib_sram:
-  placement: {after: [spm_sram, start]}
+  placement: {after: [tfm_sram, spm_sram, start]}
   size: CONFIG_PM_PARTITION_SIZE_NRF_MODEM_LIB_SRAM
   region: sram_primary

--- a/subsys/partition_manager/pm.yml.tfm
+++ b/subsys/partition_manager/pm.yml.tfm
@@ -1,8 +1,8 @@
 #include <autoconf.h>
 
-tfm_ram:
+tfm_sram:
   placement: {after: [start]}
-  size: CONFIG_PM_PARTITION_SIZE_TFM_RAM
+  size: CONFIG_PM_PARTITION_SIZE_TFM_SRAM
   region: sram_primary
 
 tfm:

--- a/subsys/partition_manager/pm.yml.tfm
+++ b/subsys/partition_manager/pm.yml.tfm
@@ -2,6 +2,7 @@
 
 tfm_sram:
   placement: {after: [start]}
+  inside: sram_secure
   size: CONFIG_PM_PARTITION_SIZE_TFM_SRAM
   region: sram_primary
 

--- a/subsys/partition_manager/pm.yml.trustzone
+++ b/subsys/partition_manager/pm.yml.trustzone
@@ -1,0 +1,8 @@
+# Create a span for the RAM to be configured as SECURE by the spm.
+sram_secure:
+  span: []
+  region: sram_primary
+
+sram_nonsecure:
+  span: [sram_primary] /* Here, sram_primary refers to the (NS) app's RAM. */
+  region: sram_primary

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 92e598ee0265b188f94959b06fcf7e2e06711699
+      revision: 3b3f0c541cb4a8b1540e0f34a092fce47b95e141
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -105,7 +105,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
-      revision: d4e45c1d254c2aea3f842a7221a92202a50ad35b
+      revision: 96ef980add272be24442d9140d7c90c80f89e663
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
~Based on #3636~

There were two things making the build fail when the modem was enabled:
1. The TFM RAM section was not placed in the correct place relative to the modem RAM.
2. When 1. was fixed, the TFM RAM was too large to fit in the 64k before the modem RAM.

This fixes those two things and adds an overlay config file to the nrf9160/download sample so that tfm can automatically be tested with a modem sample.