### PR TITLE
crypto: Use CTR_DRBG as entropy source in the cc310 driver

### DIFF
--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -5,15 +5,3 @@
 #
 zephyr_library_amend()
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_CC3XX entropy_cc310.c)
-
-# Link with the nrf_cc3xx_platform library if the following is met:
-# -nRF52840 device
-# -nRF9160/nRF53_CPUAPP device that is not using SPM
-# -nRF9150 device that is using SPM and in a secure image
-# -nRF53_CPUAPP device that is using SPM and in a secure image
-#  (CONFIG_SPM is not defined in a secure image)
-if (CONFIG_SOC_NRF52840 OR
-   (CONFIG_SOC_NRF9160 AND (NOT CONFIG_SPM)) OR
-   (CONFIG_SOC_NRF5340_CPUAPP AND (NOT CONFIG_SPM)))
-  zephyr_link_libraries_ifdef(CONFIG_ENTROPY_CC3XX platform_cc3xx)
-endif ()

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -6,7 +6,7 @@
 
 config ENTROPY_CC3XX
 	bool "Arm CC3XX RNG driver for Nordic devices"
-	depends on HW_CC3XX || (SOC_NRF9160 && SPM) || (SOC_NRF5340_CPUAPP && SPM)
+	depends on HW_CC3XX || (SOC_NRF9160 && (SPM || BUILD_WITH_TFM)) || (SOC_NRF5340_CPUAPP && (SPM || BUILD_WITH_TFM))
 	depends on ENTROPY_GENERATOR
 	select ENTROPY_HAS_DRIVER
 	default y

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -9,6 +9,7 @@ config ENTROPY_CC3XX
 	depends on HW_CC3XX || (SOC_NRF9160 && (SPM || BUILD_WITH_TFM)) || (SOC_NRF5340_CPUAPP && (SPM || BUILD_WITH_TFM))
 	depends on ENTROPY_GENERATOR
 	select ENTROPY_HAS_DRIVER
+	select NRF_CC3XX_MBEDCRYPTO if HW_CC3XX
 	default y
 	help
 	  This option enables the Arm CC3xx RNG devices in nRF52840, nRF5340, and nRF9160

--- a/drivers/entropy/entropy_cc310.c
+++ b/drivers/entropy/entropy_cc310.c
@@ -17,8 +17,12 @@
 #if defined(CONFIG_SPM)
 #include "secure_services.h"
 #else
-#include "nrf_cc3xx_platform_entropy.h"
+#include "nrf_cc3xx_platform_ctr_drbg.h"
+
+static nrf_cc3xx_platform_ctr_drbg_context_t ctr_drbg_ctx;
 #endif
+
+#define CTR_DRBG_MAX_REQUEST 1024
 
 static int entropy_cc3xx_rng_get_entropy(
 	const struct device *dev,
@@ -26,57 +30,70 @@ static int entropy_cc3xx_rng_get_entropy(
 	uint16_t length)
 {
 	int res = -EINVAL;
-	size_t olen;
 
 	__ASSERT_NO_MSG(dev != NULL);
 	__ASSERT_NO_MSG(buffer != NULL);
 
-#if defined(CONFIG_SPM)
-	size_t offset = 0;
-	size_t to_copy;
-	uint8_t spm_buf[144]; /* 144 is the only length supported by
-			       * spm_request_random_number.
-			       */
 
-	/** This is a call from a non-secure app that enables secure services,
-	 *  in which case entropy is gathered by calling through SPM
+	size_t olen;
+	size_t offset = 0;
+	size_t chunk_size = CTR_DRBG_MAX_REQUEST;
+	/** This is a call from a secure app, in which case entropy is
+	 *  gathered using CC3xx HW using the CTR_DRBG features of the
+	 *  nrf_cc310_platform/nrf_cc312_platform library.
 	 */
-	while (length > 0) {
-		res = spm_request_random_number(spm_buf, sizeof(spm_buf),
-						&olen);
-		if (res < 0) {
-			return res;
+	while (offset < length) {
+
+		if ((length - offset) < CTR_DRBG_MAX_REQUEST) {
+			chunk_size = length - offset;
 		}
 
-		if (olen != sizeof(spm_buf)) {
+		#if defined(CONFIG_SPM)
+			/** This is a call from a non-secure app that
+			 * enables secure services, in which case entropy
+			 * is gathered by calling through SPM.
+			 */
+			res = spm_request_random_number(buffer + offset,
+								chunk_size,
+								&olen);
+		#else
+			/** This is a call from a secure app, in which
+			 * case entropy is gathered using CC3xx HW
+			 * using the CTR_DRBG features of the
+			 * nrf_cc310_platform/nrf_cc312_platform library.
+			 */
+			res = nrf_cc3xx_platform_ctr_drbg_get(&ctr_drbg_ctx,
+								buffer + offset,
+								chunk_size,
+								&olen);
+		#endif
+
+		if (olen != chunk_size) {
 			return -EINVAL;
 		}
 
-		to_copy = MIN(length, sizeof(spm_buf));
+		if (res != 0) {
+			break;
+		}
 
-		memcpy(buffer + offset, spm_buf, to_copy);
-		length -= to_copy;
-		offset += to_copy;
+		offset += chunk_size;
 	}
-
-#else
-	/** This is a call from a secure app, in which case entropy is
-	 *  gathered using CC3xx HW using the
-	 *  nrf_cc310_platform/nrf_cc312_platform library.
-	 */
-	res = nrf_cc3xx_platform_entropy_get(buffer, length, &olen);
-	if (olen != length) {
-		return -EINVAL;
-	}
-#endif
 
 	return res;
 }
 
 static int entropy_cc3xx_rng_init(const struct device *dev)
 {
-	/* No initialization is required */
 	(void)dev;
+
+	#if !defined(CONFIG_SPM)
+		int ret = 0;
+
+		ret = nrf_cc3xx_platform_ctr_drbg_init(&ctr_drbg_ctx, NULL, 0);
+		if (ret != 0) {
+			return -EINVAL;
+		}
+	#endif
 
 	return 0;
 }

--- a/include/secure_services.h
+++ b/include/secure_services.h
@@ -58,18 +58,13 @@ void spm_request_system_reboot(void);
 
 /** Request a random number from the Secure Firmware.
  *
- * This provides a True Random Number from the on-board random number generator.
+ * This provides a CTR_DRBG number from the CC3XX platform libraries.
  *
- * @note Currently, the RNG hardware is run each time this is called. This
- *       spends significant time and power.
- *
- * @param[out] output  The random number. Must be at least @c len long.
- * @param[in]  len     The length of the output array. Currently, @c len must be
- *                     144.
+ * @param[out] output  The CTR_DRBG number. Must be at least @c len long.
+ * @param[in]  len     The length of the output array.
  * @param[out] olen    The length of the random number provided.
  *
- * @retval 0        If successful.
- * @retval -EINVAL  If @c len is invalid. Currently, @c len must be 144.
+ * @return non-negative on success, negative errno code on fail
  */
 int spm_request_random_number(uint8_t *output, size_t len, size_t *olen);
 

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -29,7 +29,7 @@ if IS_SPM
 # Unable to use the size template due to non-trivial defaults.
 config PM_PARTITION_SIZE_SPM
 	hex "Flash space reserved for SPM"
-	default 0xc000 if SPM_SERVICE_RNG # To build correctly with MCUboot.
+	default 0x10000 if SPM_SERVICE_RNG # To build correctly with MCUboot.
 	default 0x8000
 	help
 	  Flash space set aside for the SPM. Note, the name

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -31,14 +31,9 @@
  */
 
 #ifdef CONFIG_SPM_SERVICE_RNG
-#ifdef MBEDTLS_CONFIG_FILE
-#include MBEDTLS_CONFIG_FILE
-#else
-#include "mbedtls/config.h"
-#endif /* MBEDTLS_CONFIG_FILE */
+#include "nrf_cc3xx_platform_ctr_drbg.h"
 
-#include <mbedtls/platform.h>
-#include <mbedtls/entropy_poll.h>
+static nrf_cc3xx_platform_ctr_drbg_context_t ctr_drbg_ctx;
 #endif /* CONFIG_SPM_SERVICE_RNG */
 
 
@@ -47,9 +42,9 @@ int spm_secure_services_init(void)
 	int err = 0;
 
 #ifdef CONFIG_SPM_SERVICE_RNG
-	mbedtls_platform_context platform_ctx = {0};
-	err = mbedtls_platform_setup(&platform_ctx);
+	err = nrf_cc3xx_platform_ctr_drbg_init(&ctr_drbg_ctx, NULL, 0);
 #endif
+
 	return err;
 }
 
@@ -114,13 +109,13 @@ void spm_request_system_reboot_nse(void)
 __TZ_NONSECURE_ENTRY_FUNC
 int spm_request_random_number_nse(uint8_t *output, size_t len, size_t *olen)
 {
-	int err;
+	int err = -EINVAL;
 
-	if (len != MBEDTLS_ENTROPY_MAX_GATHER) {
+	err = nrf_cc3xx_platform_ctr_drbg_get(&ctr_drbg_ctx, output, len, olen);
+	if (*olen != len) {
 		return -EINVAL;
 	}
 
-	err = mbedtls_hardware_poll(NULL, output, len, olen);
 	return err;
 }
 #endif /* CONFIG_SPM_SERVICE_RNG */

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: f1df2736741c7d645d0738a12a7d4317d0eb348b
+      revision: ac06d5322f97b08d1d8beb87fc266bb06a9570e9
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
- Changed entropy driver to use CTR_DRBG using the cc3xx when in secure mode
- Added PSA apis calls when TF-M is enabled
- Changed SPM RNG service to use CTR_DRBG cc3xx apis 
- Changed the default size of SPM to 64kb when RNG service is enabled
 
Ref: NCSDK-4813

Relevant nrfxlib PR:  [sdk-nrfxlib/pull/397](https://github.com/nrfconnect/sdk-nrfxlib/pull/397)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
