### PR TITLE
doc: updating app_memory for peripheral_uart

### DIFF
--- a/doc/nrf/app_memory.rst
+++ b/doc/nrf/app_memory.rst
@@ -61,7 +61,7 @@ Complete the following actions to optimize the Bluetooth part of your applicatio
   * :option:`CONFIG_BT_CTLR_TX_BUFFERS`
   * :option:`CONFIG_BT_CTLR_TX_BUFFER_SIZE`
 
-For reference, you can find a minimal footprint configuration of the :ref:`peripheral_lbs` sample in :file:`nrf/samples/bluetooth/peripheral_lbs/minimal.conf`.
+For reference, you can find minimal footprint configurations of the :ref:`peripheral_lbs` sample in :file:`nrf/samples/bluetooth/peripheral_lbs/minimal.conf` and the :ref:`peripheral_uart` sample in :file:`nrf/samples/bluetooth/peripheral_uart/minimal.conf`.
 
 
 Thread


### PR DESCRIPTION
A minimal configuration for the peripheral_uart example is now available
and its reference has been added to the documentation here.

Signed-off-by: Akash Patel <akash.patel@nordicsemi.no>