### PR TITLE
samples: bluetooth: Fix extended advertising configuration

### DIFF
--- a/samples/bluetooth/central_hr_coded/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/central_hr_coded/child_image/hci_rpmsg.conf
@@ -4,5 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+CONFIG_BT_EXT_ADV=y
 CONFIG_BT_CTLR_ADV_EXT=y
 CONFIG_BT_CTLR_PHY_CODED=y

--- a/samples/bluetooth/peripheral_hr_coded/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/peripheral_hr_coded/child_image/hci_rpmsg.conf
@@ -4,5 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+CONFIG_BT_EXT_ADV=y
 CONFIG_BT_CTLR_ADV_EXT=y
 CONFIG_BT_CTLR_PHY_CODED=y


### PR DESCRIPTION
After upmerge condiguration fix for samples which support extended advertising and scanning for the nRF5340