### PR TITLE
Bluetooth: Mesh: Resolve all Coverity errors for January 2021

### DIFF
--- a/include/bluetooth/mesh/gen_onoff_srv.h
+++ b/include/bluetooth/mesh/gen_onoff_srv.h
@@ -58,8 +58,7 @@ struct bt_mesh_onoff_srv_handlers {
 	 * @param[in] ctx Message context for the message that triggered the
 	 * change, or NULL if the change is not coming from a message.
 	 * @param[in] set Parameters of the state change.
-	 * @param[out] rsp Response structure to be filled, or NULL if no
-	 * response is required.
+	 * @param[out] rsp Response structure to be filled.
 	 */
 	void (*const set)(struct bt_mesh_onoff_srv *srv,
 			  struct bt_mesh_msg_ctx *ctx,

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -139,12 +139,13 @@ static void scene_recall(struct bt_mesh_model *mod, const uint8_t data[],
 		       size_t len, struct bt_mesh_model_transition *transition)
 {
 	struct bt_mesh_onoff_srv *srv = mod->user_data;
+	struct bt_mesh_onoff_status dummy;
 	struct bt_mesh_onoff_set set = {
 		.on_off = data[0],
 		.transition = transition,
 	};
 
-	srv->handlers->set(srv, NULL, &set, NULL);
+	srv->handlers->set(srv, NULL, &set, &dummy);
 }
 
 static const struct bt_mesh_scene_entry_type scene_type = {

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -238,6 +238,7 @@ static int bt_mesh_ponoff_srv_settings_set(struct bt_mesh_model *model,
 					   void *cb_arg)
 {
 	struct bt_mesh_ponoff_srv *srv = model->user_data;
+	struct bt_mesh_onoff_status dummy;
 	struct ponoff_settings_data data;
 
 	if (name) {
@@ -266,7 +267,7 @@ static int bt_mesh_ponoff_srv_settings_set(struct bt_mesh_model *model,
 		return -EINVAL;
 	}
 
-	srv->onoff.handlers->set(&srv->onoff, NULL, &onoff_set, NULL);
+	srv->onoff.handlers->set(&srv->onoff, NULL, &onoff_set, &dummy);
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/gen_prop_srv.c
+++ b/subsys/bluetooth/mesh/gen_prop_srv.c
@@ -404,19 +404,17 @@ static void handle_user_property_get(struct bt_mesh_model *mod,
 
 	net_buf_simple_add_u8(&rsp, prop->user_access);
 
-	if (!(prop->user_access & BT_MESH_PROP_ACCESS_READ)) {
-		goto respond;
+	if (prop->user_access & BT_MESH_PROP_ACCESS_READ) {
+		struct bt_mesh_prop_val value = {
+			.meta = *prop,
+			.value = net_buf_simple_tail(&rsp),
+			.size = CONFIG_BT_MESH_PROP_MAXSIZE,
+		};
+
+		srv->get(srv, ctx, &value);
+
+		net_buf_simple_add(&rsp, value.size);
 	}
-
-	struct bt_mesh_prop_val value = {
-		.meta = *prop,
-		.value = net_buf_simple_tail(&rsp),
-		.size = CONFIG_BT_MESH_PROP_MAXSIZE,
-	};
-
-	srv->get(srv, ctx, &value);
-
-	net_buf_simple_add(&rsp, value.size);
 
 respond:
 	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -84,8 +84,7 @@ static void xyl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_model_transition transition;
 	struct bt_mesh_light_xy_set set;
 	struct bt_mesh_light_xy_status status = { 0 };
-
-	struct bt_mesh_lightness_status light_rsp;
+	struct bt_mesh_lightness_status light_rsp = { 0 };
 	struct bt_mesh_lightness_set light = {
 		.transition = &transition,
 	};
@@ -186,7 +185,7 @@ static void target_get_handle(struct bt_mesh_model *model,
 
 	struct bt_mesh_light_xyl_srv *srv = model->user_data;
 	struct bt_mesh_light_xy_status status = { 0 };
-	struct bt_mesh_lightness_status light;
+	struct bt_mesh_lightness_status light = { 0 };
 
 	srv->lightness_srv.handlers->light_get(&srv->lightness_srv, ctx,
 					       &light);
@@ -395,7 +394,7 @@ const struct bt_mesh_model_op _bt_mesh_light_xyl_setup_srv_op[] = {
 static ssize_t scene_store(struct bt_mesh_model *mod, uint8_t data[])
 {
 	struct bt_mesh_light_xyl_srv *srv = mod->user_data;
-	struct bt_mesh_light_xy_status xy_rsp;
+	struct bt_mesh_light_xy_status xy_rsp = { 0 };
 
 	srv->handlers->xy_get(srv, NULL, &xy_rsp);
 

--- a/subsys/bluetooth/mesh/sensor_types.c
+++ b/subsys/bluetooth/mesh/sensor_types.c
@@ -342,8 +342,9 @@ static int exp_1_1_encode(const struct bt_mesh_sensor_format *format,
 		return -ENOMEM;
 	}
 
-	net_buf_simple_add_u8(buf, sensor_powtime_encode((val->val1 * 1000) +
-							 (val->val2 / 1000)));
+	net_buf_simple_add_u8(buf,
+			      sensor_powtime_encode((val->val1 * 1000ULL) +
+						    (val->val2 / 1000ULL)));
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/time_util.c
+++ b/subsys/bluetooth/mesh/time_util.c
@@ -8,6 +8,7 @@
 #include <time.h>
 #include "model_utils.h"
 #include <zephyr/types.h>
+#include <sys/util.h>
 #include "time_util.h"
 
 #define TAI_START_YEAR 2000
@@ -100,7 +101,9 @@ void tai_to_ts(const struct bt_mesh_time_tai *tai, struct tm *timeptr)
 
 	const uint8_t *months = is_leap ? month_leap_cfg : month_cfg;
 
-	for (timeptr->tm_mon = 0; months[timeptr->tm_mon] <= day_cnt;
+	for (timeptr->tm_mon = 0;
+	     timeptr->tm_mon < ARRAY_SIZE(month_cfg) &&
+	     months[timeptr->tm_mon] <= day_cnt;
 	     timeptr->tm_mon++) {
 		day_cnt -= months[timeptr->tm_mon];
 	}


### PR DESCRIPTION
- Always provide a rsp buffer in onoff_set
- Avoid variable declaration after goto
- Light xyL: Initialize rsp parameters
- Time srv mktime: Adjust seconds as signed
- Ensure month adjustment doesn't exceed array
- Cast pow encoded sensor val to uint64_t