### PR TITLE
manifest: update sdk-zephyr for remove unnecessary parenteses

### DIFF
--- a/samples/connectedhomeip/lock/CMakeLists.txt
+++ b/samples/connectedhomeip/lock/CMakeLists.txt
@@ -14,9 +14,6 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-lock)
 
-# Temporary get rid of compilation warnings till zephyrproject-rtos/zephyr/pull/31471 is fetched
-zephyr_compile_options(-Wno-parentheses)
-
 target_include_directories(app PRIVATE src ${COMMON_ROOT}/src)
 
 target_sources(app PRIVATE

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 17948b71589cfa38ab96c7465d2adcdafeef6038
+      revision: 56271929efa1904d3ba89264c1f975c74cf75ac9
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Get rid of compilation warnings caused by additional parentheses.

This only affects CHIP example that is built using C++ compiler.

Signed-off-by: Duda, Lukasz <lukasz.duda@nordicsemi.no>