### PR TITLE
doc: fix manifest in dm_adding_code.rst

### DIFF
--- a/doc/nrf/dm_adding_code.rst
+++ b/doc/nrf/dm_adding_code.rst
@@ -90,6 +90,7 @@ This is demonstrated by the following code:
          url-base: https://github.com/nrfconnect
      projects:
        - name: nrf
+         repo-path: sdk-nrf
          remote: ncs
          revision: v1.4.2
          import: true


### PR DESCRIPTION
Commit 35caaa1f25 ("treewide: Point to the new repos in the nrfconnect
GitHub org") changed the contents of the example manifest users can
copy/paste when setting up an application as their own manifest
repository.

However, the change was incorrect:

- the fetch URL for the old nrf repository was
  https://github.com/NordicPlayground/nrf, and

- the new one is https://github.com/nrfconnect/sdk-nrf, but

- it was actually set to https://github.com/nrfconnect/nrf,
  due to a missing 'repo-path:' that should have been added
  to the example manifest.

Fix it by adding the missing piece.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>