### PR TITLE
manifest: Update Zephyr revision to include ADXL362 fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 60a9e7c8b2836d4bf367b119835ea60688f0b5fe
+      revision: 73a419c5d7d60d9e476dfee62669e96236601755
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr with fixes for unused variables in some configurations
of ADXL362.

Zephyr PR: https://github.com/nrfconnect/sdk-zephyr/pull/446