### PR TITLE
zigbee: Fix coverity issues

### DIFF
--- a/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
+++ b/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
@@ -134,7 +134,7 @@ static void send_progress(zb_uint8_t progress)
 static void ota_client_attr_init(void)
 {
 	struct mcuboot_img_header mcuboot_header;
-	union zb_ota_app_ver app_image_ver;
+	union zb_ota_app_ver app_image_ver = {0};
 
 	int err = boot_read_bank_header(PM_MCUBOOT_PRIMARY_ID,
 					&mcuboot_header,

--- a/tests/subsys/zigbee/zboss_api/callback_api/src/main.c
+++ b/tests/subsys/zigbee/zboss_api/callback_api/src/main.c
@@ -80,7 +80,7 @@ void test_zboss_startup_signals(void)
 
 K_MSGQ_DEFINE(zb_callback_queue, sizeof(uint32_t), N_THREADS, 4);
 
-void add_to_queue_from_callback(uint8_t int_to_put)
+static void add_to_queue_from_callback(uint8_t int_to_put)
 {
 	const uint32_t ref_int[N_THREADS] = {0, 1, 2, 3};
 	int ret_val;


### PR DESCRIPTION
Initialize a variable in "ota_client_attr_init".
Make "add_to_queue_from_callback" static.

Signed-off-by: Filip Zajdel <filip.zajdel@nordicsemi.no>