### PR TITLE
Bluetooth: Mesh: Light LC Server models fixes

### DIFF
--- a/include/bluetooth/mesh/gen_dtt_srv.h
+++ b/include/bluetooth/mesh/gen_dtt_srv.h
@@ -139,7 +139,7 @@ bt_mesh_dtt_srv_transition_get(struct bt_mesh_model *mod,
 
 	transition->time = srv ? srv->transition_time : 0;
 	transition->delay = 0;
-	return (transition->time != 0);
+	return (srv != NULL);
 }
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/bluetooth/mesh/gen_onoff_srv.h
+++ b/include/bluetooth/mesh/gen_onoff_srv.h
@@ -99,6 +99,8 @@ struct bt_mesh_onoff_srv {
 		BT_MESH_ONOFF_OP_STATUS, BT_MESH_ONOFF_MSG_MAXLEN_STATUS)];
 	/* Scene entry */
 	struct bt_mesh_scene_entry scene;
+	/** Internal flag state. */
+	atomic_t flags;
 };
 
 /** @brief Publish the Generic OnOff Server model status.

--- a/subsys/bluetooth/mesh/gen_onoff_internal.h
+++ b/subsys/bluetooth/mesh/gen_onoff_internal.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_onoff_internal Generic OnOff model internals
+ * @ingroup bt_mesh_onoff
+ * @{
+ * @brief Common internal API for the Generic OnOff models.
+ */
+
+#ifndef BT_MESH_GEN_ONOFF_INTERNAL_H__
+#define BT_MESH_GEN_ONOFF_INTERNAL_H__
+
+enum {
+	/** Don't use DTT if transition time is not present in set message. */
+	GEN_ONOFF_SRV_NO_DTT,
+};
+
+#endif /* BT_MESH_GEN_ONOFF_INTERNAL_H__ */
+
+/** @} */

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -251,7 +251,8 @@ static int bt_mesh_ponoff_srv_settings_set(struct bt_mesh_model *model,
 
 	set_on_power_up(srv, NULL, (enum bt_mesh_on_power_up)data.on_power_up);
 
-	struct bt_mesh_onoff_set onoff_set = { 0 };
+	struct bt_mesh_model_transition transition = { 0 };
+	struct bt_mesh_onoff_set onoff_set = { .transition = &transition };
 
 	switch (data.on_power_up) {
 	case BT_MESH_ON_POWER_UP_OFF:

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -477,6 +477,9 @@ static void ctrl_disable(struct bt_mesh_light_ctrl_srv *srv)
 	atomic_and(&srv->flags, FLAGS_CONFIGURATION);
 	srv->lightness->ctrl = NULL;
 	srv->state = LIGHT_CTRL_STATE_STANDBY;
+#if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
+	srv->reg.i = 0;
+#endif
 
 	k_delayed_work_cancel(&srv->action_delay);
 	k_delayed_work_cancel(&srv->timer);

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1547,6 +1547,8 @@ static int light_ctrl_srv_start(struct bt_mesh_model *mod)
 			reg_start(srv);
 			if (atomic_test_bit(&srv->flags, FLAG_ON)) {
 				turn_on(srv, NULL, true);
+			} else {
+				onoff_pub(srv, srv->state, true);
 			}
 		} else if (atomic_test_bit(&srv->lightness->flags,
 					   LIGHTNESS_SRV_FLAG_IS_ON)) {

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -10,6 +10,7 @@
 #include <bluetooth/mesh/properties.h>
 #include "lightness_internal.h"
 #include "light_ctrl_internal.h"
+#include "gen_onoff_internal.h"
 #include "sensor.h"
 #include "model_utils.h"
 
@@ -1316,7 +1317,7 @@ static void onoff_set(struct bt_mesh_onoff_srv *onoff,
 		CONTAINER_OF(onoff, struct bt_mesh_light_ctrl_srv, onoff);
 	enum bt_mesh_light_ctrl_srv_state prev_state = srv->state;
 
-	if (set->transition->delay) {
+	if (set->transition && set->transition->delay > 0) {
 		delayed_set(srv, set->transition, set->on_off);
 	} else if (set->on_off) {
 		turn_on(srv, set->transition, false);
@@ -1450,6 +1451,8 @@ static int light_ctrl_srv_init(struct bt_mesh_model *mod)
 	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
 		bt_mesh_model_extend(mod, srv->onoff.model);
 	}
+
+	atomic_set_bit(&srv->onoff.flags, GEN_ONOFF_SRV_NO_DTT);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
 		bt_mesh_scene_entry_add(mod, &srv->scene, &scene_type, false);

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1515,8 +1515,7 @@ static int light_ctrl_srv_start(struct bt_mesh_model *mod)
 				    FLAG_CTRL_SRV_MANUALLY_ENABLED)) {
 			ctrl_enable(srv);
 		} else {
-			light_set(srv, 0,
-				  srv->lightness->ponoff.dtt.transition_time);
+			lightness_on_power_up(srv->lightness);
 			ctrl_disable(srv);
 		}
 
@@ -1533,11 +1532,7 @@ static int light_ctrl_srv_start(struct bt_mesh_model *mod)
 				    FLAG_CTRL_SRV_MANUALLY_ENABLED)) {
 			ctrl_enable(srv);
 		} else {
-			light_set(srv,
-				  (srv->lightness->default_light ?
-					   srv->lightness->default_light :
-					   srv->lightness->last),
-				  srv->lightness->ponoff.dtt.transition_time);
+			lightness_on_power_up(srv->lightness);
 			ctrl_disable(srv);
 		}
 		store(srv, FLAG_STORE_STATE);
@@ -1552,8 +1547,7 @@ static int light_ctrl_srv_start(struct bt_mesh_model *mod)
 			}
 		} else if (atomic_test_bit(&srv->lightness->flags,
 					   LIGHTNESS_SRV_FLAG_IS_ON)) {
-			light_set(srv, srv->lightness->last,
-				  srv->lightness->ponoff.dtt.transition_time);
+			lightness_on_power_up(srv->lightness);
 		}
 		break;
 	default:

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -483,6 +483,8 @@ static void ctrl_disable(struct bt_mesh_light_ctrl_srv *srv)
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
 	k_delayed_work_cancel(&srv->reg.timer);
 #endif
+
+	onoff_pub(srv, srv->state, true);
 }
 
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG

--- a/subsys/bluetooth/mesh/lightness_internal.h
+++ b/subsys/bluetooth/mesh/lightness_internal.h
@@ -164,6 +164,8 @@ int lightness_cli_light_set_unack(struct bt_mesh_lightness_cli *cli,
 void lightness_srv_default_set(struct bt_mesh_lightness_srv *srv,
 			       struct bt_mesh_msg_ctx *ctx, uint16_t set);
 
+int lightness_on_power_up(struct bt_mesh_lightness_srv *srv);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -830,12 +830,8 @@ static int bt_mesh_lightness_srv_start(struct bt_mesh_model *mod)
 
 	switch (srv->ponoff.on_power_up) {
 	case BT_MESH_ON_POWER_UP_OFF:
-		/* Not calling the lightness server's callback when the value is
-		 * supposed to be zero, so we'll just set the "last" value for
-		 * correctness:
-		 */
 		srv->last = 0;
-		return 0;
+		break;
 	case BT_MESH_ON_POWER_UP_ON:
 		set.lvl = (srv->default_light ? srv->default_light : srv->last);
 		break;

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -679,6 +679,12 @@ static void onoff_set(struct bt_mesh_onoff_srv *onoff_srv,
 	};
 	struct bt_mesh_lightness_status status;
 
+	if (!bt_mesh_is_provisioned()) {
+		/* Avoid picking up Power OnOff loaded onoff, we'll use our own.
+		 */
+		return;
+	}
+
 	if (onoff_set->on_off) {
 		set.lvl = (srv->default_light ? srv->default_light : srv->last);
 	} else {

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -814,19 +814,15 @@ static int bt_mesh_lightness_srv_settings_set(struct bt_mesh_model *mod,
 
 	return 0;
 }
+#endif
 
-static int bt_mesh_lightness_srv_start(struct bt_mesh_model *mod)
+int lightness_on_power_up(struct bt_mesh_lightness_srv *srv)
 {
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
 	struct bt_mesh_lightness_status dummy = { 0 };
 	struct bt_mesh_model_transition transition = {
 		.time = srv->ponoff.dtt.transition_time,
 	};
 	struct bt_mesh_lightness_set set = { .transition = &transition };
-
-	if (atomic_test_bit(&srv->flags, LIGHTNESS_SRV_FLAG_NO_START)) {
-		return 0;
-	}
 
 	switch (srv->ponoff.on_power_up) {
 	case BT_MESH_ON_POWER_UP_OFF:
@@ -851,6 +847,18 @@ static int bt_mesh_lightness_srv_start(struct bt_mesh_model *mod)
 
 	lightness_srv_change_lvl(srv, NULL, &set, &dummy);
 	return 0;
+}
+
+#ifdef CONFIG_BT_SETTINGS
+static int bt_mesh_lightness_srv_start(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_lightness_srv *srv = mod->user_data;
+
+	if (atomic_test_bit(&srv->flags, LIGHTNESS_SRV_FLAG_NO_START)) {
+		return 0;
+	}
+
+	return lightness_on_power_up(srv);
 }
 #endif
 

--- a/subsys/bluetooth/mesh/scheduler_srv.c
+++ b/subsys/bluetooth/mesh/scheduler_srv.c
@@ -440,7 +440,7 @@ static void scheduled_action_handle(struct k_work *work)
 	struct bt_mesh_model_transition transition = {
 		.time = model_transition_decode(
 				srv->sch_reg[srv->idx].transition_time),
-		.delay = 0
+		.delay = 0,
 	};
 	uint16_t scene = srv->sch_reg[srv->idx].scene_number;
 	struct bt_mesh_elem *elem = bt_mesh_model_elem(srv->mod);


### PR DESCRIPTION
Summary of the fixes (each fix in a separate commit):
- Fixed binding between Light LC Light OnOff and Generic OnOff states
- Internal sum of PI Feedback Regulator is reset when Light LC State Machine is in Off state
- Restoring Light Lightness model states after power up is moved to a separate function
- Added Light LC Light OnOff state publication on power up and after Light LC State Machine transitions to Off state