### PR TITLE
Multiprotocol rpmsg

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -89,6 +89,7 @@ Zigbee
 * Added:
 
   * Development support for the nRF5340 DK in single-protocol configuration for the :ref:`zigbee_light_switch_sample`, :ref:`zigbee_light_bulb_sample`, and :ref:`zigbee_network_coordinator_sample` samples.
+  * Development support for the nRF5340 DK in multi-protocol configuration for the :ref:`zigbee_light_switch_sample` sample.
   * New ``zcl ping`` command in the :ref:`lib_zigbee_shell` library.
   * New libraries there were extracted from common code under :file:`subsys/zigbee/common`:
 

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -78,6 +78,7 @@ Thread
 * Added:
 
   * Development support for the nRF5340 DK in single-protocol configuration for the :ref:`ot_cli_sample`, :ref:`coap_client_sample`, and :ref:`coap_server_sample` samples.
+  * Development support for the nRF5340 DK in the multiprotocol configuration for the :ref:`ot_cli_sample` and :ref:`coap_client_sample` samples.
   * Development support for nRF21540 FEM (front-end module) in the Thread samples.
 
 * Optimized ROM and RAM used by Thread samples.
@@ -88,8 +89,8 @@ Zigbee
 
 * Added:
 
-  * Development support for the nRF5340 DK in single-protocol configuration for the :ref:`zigbee_light_switch_sample`, :ref:`zigbee_light_bulb_sample`, and :ref:`zigbee_network_coordinator_sample` samples.
-  * Development support for the nRF5340 DK in multi-protocol configuration for the :ref:`zigbee_light_switch_sample` sample.
+  * Development support for the nRF5340 DK in the single-protocol configuration for the :ref:`zigbee_light_switch_sample`, :ref:`zigbee_light_bulb_sample`, and :ref:`zigbee_network_coordinator_sample` samples.
+  * Development support for the nRF5340 DK in the multiprotocol configuration for the :ref:`zigbee_light_switch_sample` sample.
   * New ``zcl ping`` command in the :ref:`lib_zigbee_shell` library.
   * New libraries there were extracted from common code under :file:`subsys/zigbee/common`:
 

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -25,6 +25,7 @@ Introduction
 
 nRF5340 is a wireless ultra-low power multicore System on Chip (SoC) with two fully programmable Arm Cortex-M33 processors: a network core and an application core.
 The |NCS| supports Bluetooth Low Energy and NFC communication on the nRF5340 SoC.
+In addition, Thread and Zigbee protocols can use the SoC in the multiprotocol configuration.
 
 See the `nRF5340 Product Specification`_ for more information about the nRF5340 SoC.
 :ref:`zephyr:nrf5340dk_nrf5340` gives an overview of the nRF5340 DK support in Zephyr.
@@ -108,6 +109,13 @@ The OpenAMP library uses the IPM SHIM layer, which in turn uses the IPC driver i
    :start-after: fota_upgrades_start
    :end-before: fota_upgrades_end
 
+Multiprotocol support
+*********************
+
+nRF5340 supports running another protocol in parallel with the :ref:`nrfxlib:softdevice_controller`.
+See the :ref:`ug_multiprotocol_support` user guide for instructions on how to enable multiprotocol support for Thread or Zigbee in combination with Bluetooth.
+
+The :ref:`nrfxlib:mpsl` library provides services for multiprotocol applications.
 
 Available samples
 *****************

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -80,9 +80,6 @@ The sample supports the following development kits for testing the network statu
    :header: heading
    :rows: nrf5340dk_nrf5340_cpuapp, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
 
-.. note::
-   The multiprotocol variant is not supported on nRF53 Series devices yet.
-
 Optionally, you can use one or more compatible development kits programmed with this sample or another :ref:`Thread sample <openthread_samples>` for :ref:`testing communication or diagnostics <ot_cli_sample_testing_multiple>` and :ref:`thread_ot_commissioning_configuring_on-mesh`.
 
 Thread v1.2 extension requirements
@@ -348,3 +345,14 @@ This sample uses the following Zephyr libraries:
   * ``include/kernel.h``
 
 * :ref:`zephyr:thread_protocol_interface`
+
+The following dependencies are added by the optional multiprotocol Bluetooth LE extension:
+
+* :ref:`nrfxlib:softdevice_controller`
+* :ref:`nus_service_readme`
+* Zephyr's :ref:`zephyr:bluetooth_api`:
+
+  * ``include/bluetooth/bluetooth.h``
+  * ``include/bluetooth/gatt.h``
+  * ``include/bluetooth/hci.h``
+  * ``include/bluetooth/uuid.h``

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -54,9 +54,6 @@ The sample supports the following development kits:
    :header: heading
    :rows: nrf5340dk_nrf5340_cpuapp, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
 
-.. note::
-   The multiprotocol variant is not supported on nRF53 Series devices yet.
-
 You can use one or more of the development kits listed above as the Thread CoAP Client.
 You also need one or more compatible development kits programmed with the :ref:`coap_server_sample` sample.
 

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -42,9 +42,6 @@ The sample supports the following development kits:
    :header: heading
    :rows: nrf5340dk_nrf5340_cpuapp, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
 
-.. note::
-   The multiprotocol variant is not supported on nRF53 Series devices yet.
-
 You can use one or more of the development kits listed above as the Thread CoAP Server.
 You also need one or more compatible development kits programmed with the :ref:`coap_client_sample` sample.
 

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -34,9 +34,6 @@ For this sample to work, the following samples also need to be programmed:
 Multiprotocol Bluetooth LE extension requirements
 =================================================
 
-.. note::
-   The multiprotocol variant is not supported on nRF53 Series devices.
-
 If you enable the :ref:`zigbee_light_switch_sample_nus`, make sure you have a phone or a tablet with the `nRF Toolbox`_ application installed.
 
 .. note::

--- a/samples/zigbee/light_switch/sample.yaml
+++ b/samples/zigbee/light_switch/sample.yaml
@@ -21,7 +21,7 @@ tests:
 
   zigbee.light_switch.multiprotocol:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
     tags: ci_build
     extra_args: DOVERLAY_CONFIG=overlay-multiprotocol_ble.conf
 


### PR DESCRIPTION
Add test case for building Zigbee light switch on nRF5340 DK.
Corresponding changes in documentation has been made.