### PR TITLE
 doc: mcuboot: updating the MCUboot in nRF Connect SDK description

### DIFF
--- a/doc/mcuboot/readme-ncs.rst
+++ b/doc/mcuboot/readme-ncs.rst
@@ -5,8 +5,8 @@ Using MCUboot in nRF Connect SDK
 
 See :doc:`readme-zephyr` for general information on how to integrate MCUboot with Zephyr.
 
-nRF Connect SDK's `fork of MCUboot <https://github.com/nrfconnect/sdk-mcuboot>`_ provides additional functionality that is available when MCUboot is included.
-This functionality is implemented in the files in the ``zephyr`` subfolder.
+nRF Connect SDK provides additional functionality that is available when MCUboot is included.
+This functionality is implemented in the files in the ``modules/mcuboot`` subfolder in the `sdk-nrf`_ repository.
 
 To include MCUboot in your nRF Connect SDK application, enable :option:`CONFIG_BOOTLOADER_MCUBOOT`.
 
@@ -29,3 +29,5 @@ When you build your application with this option set, the following files that c
 
 * :file:`app_moved_test_update.hex` - Same as :file:`app_test_update.hex` except that it is linked against the address used to store the upgrade candidates.
   When this file is programmed to the device, MCUboot will trigger the DFU procedure upon reboot.
+
+.. _`sdk-nrf`: https://github.com/nrfconnect/sdk-nrf


### PR DESCRIPTION
The MCUboot in nRF Connect SDK description has been updated to refer
the user to the new location of NCS specific glue code files in the
sdk-nrf repository.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>