### PR TITLE
zigbee: Make usage of TXTIME conditional

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_transceiver.c
+++ b/subsys/zigbee/osif/zb_nrf_transceiver.c
@@ -314,7 +314,8 @@ zb_bool_t zb_trans_transmit(zb_uint8_t wait_type, zb_time_t tx_at,
 	case ZB_MAC_TX_WAIT_ZGP: {
 		struct net_pkt *pkt = NULL;
 
-		if (!(radio_api->get_capabilities(radio_dev)
+		if (IS_ENABLED(NET_PKT_TXTIME) &&
+		    !(radio_api->get_capabilities(radio_dev)
 		      & IEEE802154_HW_TXTIME)) {
 			return ZB_FALSE;
 		}


### PR DESCRIPTION
This commit makes usage of TXTIME Hardware Capability conditional
on the NET_PKT_TXTIME kconfig. This is needed to align with
the new run-time capabilities fetching in nRF IEEE 802.15.4 shim.

Signed-off-by: Czeslaw Makarski <Czeslaw.Makarski@nordicsemi.no>