### PR TITLE
net: lib: nrf_cloud: Let control and data messages share ID counter

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -193,7 +193,7 @@ static void dc_endpoint_reset(void)
 }
 
 /* Get the next unused message id. */
-static uint32_t dc_get_next_message_id(void)
+static uint32_t get_next_message_id(void)
 {
 	nct.message_id++;
 
@@ -255,7 +255,7 @@ static uint32_t dc_send(const struct nct_dc_data *dc_data, uint8_t qos)
 	if (dc_data->id != 0) {
 		publish.message_id = dc_data->id;
 	} else {
-		publish.message_id = dc_get_next_message_id();
+		publish.message_id = get_next_message_id();
 	}
 
 	return mqtt_publish(&nct.client, &publish);
@@ -957,8 +957,6 @@ int nct_cc_connect(void)
 
 int nct_cc_send(const struct nct_cc_data *cc_data)
 {
-	static uint32_t msg_id;
-
 	if (cc_data == NULL) {
 		LOG_ERR("cc_data == NULL");
 		return -EINVAL;
@@ -983,7 +981,7 @@ int nct_cc_send(const struct nct_cc_data *cc_data)
 		publish.message.payload.len = cc_data->data.len;
 	}
 
-	publish.message_id = cc_data->id ? cc_data->id : ++msg_id;
+	publish.message_id = cc_data->id ? cc_data->id : get_next_message_id();
 
 	LOG_DBG("mqtt_publish: id = %d opcode = %d len = %d", publish.message_id,
 		cc_data->opcode, cc_data->data.len);


### PR DESCRIPTION
The MQTT specification states that there can be only one unacknowledged
message with a given message ID in a connection. In the nRF Cloud
library, the data and control messages have had separate message ID
counters, which can lead to the same message ID being used at the same
time, resulting in the last arriving of them to be dropped by the
broker. This patch fixes this issue by introducing a shared counter.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>