### PR TITLE
samples: openthread: Add missing masterkey configuration for nRF5340

### DIFF
--- a/samples/openthread/coap_client/prj_nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/openthread/coap_client/prj_nrf5340dk_nrf5340_cpuapp.conf
@@ -25,6 +25,9 @@ CONFIG_NET_SOCKETS=y
 CONFIG_NET_SOCKETS_POSIX_NAMES=y
 CONFIG_NET_SOCKETS_POLL_MAX=4
 
+# Same network Master Key for client and server
+CONFIG_OPENTHREAD_MASTERKEY="00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"
+
 # Default PRNG entropy for nRF53 Series devices is CSPRNG CC312
 # which for that purpose is too slow yet
 # Use Xoroshiro128+ as PRNG

--- a/samples/openthread/coap_server/prj_nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/openthread/coap_server/prj_nrf5340dk_nrf5340_cpuapp.conf
@@ -24,6 +24,9 @@ CONFIG_NET_SOCKETS=y
 CONFIG_NET_SOCKETS_POSIX_NAMES=y
 CONFIG_NET_SOCKETS_POLL_MAX=4
 
+# Same network Master Key for client and server
+CONFIG_OPENTHREAD_MASTERKEY="00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"
+
 # Default PRNG entropy for nRF53 Series devices is CSPRNG CC312
 # which for that purpose is too slow yet
 # Use Xoroshiro128+ as PRNG


### PR DESCRIPTION
Singleprotocol was not working because of wrong configuration.
Samples created separate networks because of random masterkey configuration.