### PR TITLE
applications: serial_lte_modem: Coverity Fix out-of-bounds write

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -167,27 +167,23 @@ static int do_ftp_open(void)
 	int param_count = at_params_valid_count_get(&at_param_list);
 
 	/* Parse AT command */
-	memset(username, 0x00, sz_username); /* Important for optional params*/
-	ret = at_params_string_get(&at_param_list, 2, username, &sz_username);
+	ret = util_string_get(&at_param_list, 2, username, &sz_username);
 	if (ret || strlen(username) == 0) {
 		memcpy(username, CONFIG_SLM_FTP_USER_ANONYMOUS,
 			sizeof(CONFIG_SLM_FTP_USER_ANONYMOUS) - 1);
 		memcpy(password, CONFIG_SLM_FTP_PASSWORD_ANONYMOUS,
 			sizeof(CONFIG_SLM_FTP_PASSWORD_ANONYMOUS) - 1);
 	} else {
-		username[sz_username] = '\0';
-		ret = at_params_string_get(&at_param_list, 3, password,
+		ret = util_string_get(&at_param_list, 3, password,
 					&sz_password);
 		if (ret) {
 			return -EINVAL;
 		}
-		password[sz_password] = '\0';
 	}
-	ret = at_params_string_get(&at_param_list, 4, hostname, &sz_hostname);
+	ret = util_string_get(&at_param_list, 4, hostname, &sz_hostname);
 	if (ret) {
 		return ret;
 	}
-	hostname[sz_hostname] = '\0';
 	if (param_count > 5) {
 		ret = at_params_short_get(&at_param_list, 5, &port);
 		if (ret) {
@@ -266,24 +262,20 @@ static int do_ftp_ls(void)
 	int sz_target = FTP_MAX_FILEPATH;
 	int param_count = at_params_valid_count_get(&at_param_list);
 
-	memset(options, 0x00, sz_options);
-	memset(target, 0x00, sz_target);
 	/* Parse AT command */
 	if (param_count > 2) {
-		ret = at_params_string_get(&at_param_list, 2,
+		ret = util_string_get(&at_param_list, 2,
 				options, &sz_options);
 		if (ret) {
 			return ret;
 		}
-		options[sz_options] = '\0';
 	}
 	if (param_count > 3) {
-		ret = at_params_string_get(&at_param_list, 3,
+		ret = util_string_get(&at_param_list, 3,
 				target, &sz_target);
 		if (ret) {
 			return ret;
 		}
-		target[sz_target] = '\0';
 	}
 
 	ring_buf_reset(&ftp_data_buf);
@@ -304,11 +296,10 @@ static int do_ftp_cd(void)
 	int sz_folder = FTP_MAX_FILEPATH;
 
 	/* Parse AT command */
-	ret = at_params_string_get(&at_param_list, 2, folder, &sz_folder);
+	ret = util_string_get(&at_param_list, 2, folder, &sz_folder);
 	if (ret) {
 		return ret;
 	}
-	folder[sz_folder] = '\0';
 
 	ret = ftp_cwd(folder);
 	return (ret == FTP_CODE_250) ? 0 : -1;
@@ -322,11 +313,10 @@ static int do_ftp_mkdir(void)
 	int sz_folder = FTP_MAX_FILEPATH;
 
 	/* Parse AT command */
-	ret = at_params_string_get(&at_param_list, 2, folder, &sz_folder);
+	ret = util_string_get(&at_param_list, 2, folder, &sz_folder);
 	if (ret) {
 		return ret;
 	}
-	folder[sz_folder] = '\0';
 
 	ret = ftp_mkd(folder);
 	return (ret == FTP_CODE_257) ? 0 : -1;
@@ -340,11 +330,10 @@ static int do_ftp_rmdir(void)
 	int sz_folder = FTP_MAX_FILEPATH;
 
 	/* Parse AT command */
-	ret = at_params_string_get(&at_param_list, 2, folder, &sz_folder);
+	ret = util_string_get(&at_param_list, 2, folder, &sz_folder);
 	if (ret) {
 		return ret;
 	}
-	folder[sz_folder] = '\0';
 
 	ret = ftp_rmd(folder);
 	return (ret == FTP_CODE_250) ? 0 : -1;
@@ -360,16 +349,14 @@ static int do_ftp_rename(void)
 	int sz_file_new = FTP_MAX_FILEPATH;
 
 	/* Parse AT command */
-	ret = at_params_string_get(&at_param_list, 2, file_old, &sz_file_old);
+	ret = util_string_get(&at_param_list, 2, file_old, &sz_file_old);
 	if (ret) {
 		return ret;
 	}
-	file_old[sz_file_old] = '\0';
-	ret = at_params_string_get(&at_param_list, 3, file_new, &sz_file_new);
+	ret = util_string_get(&at_param_list, 3, file_new, &sz_file_new);
 	if (ret) {
 		return ret;
 	}
-	file_new[sz_file_new] = '\0';
 
 	ret = ftp_rename(file_old, file_new);
 	return (ret == FTP_CODE_250) ? 0 : -1;
@@ -383,11 +370,10 @@ static int do_ftp_delete(void)
 	int sz_file = 128;
 
 	/* Parse AT command */
-	ret = at_params_string_get(&at_param_list, 2, file, &sz_file);
+	ret = util_string_get(&at_param_list, 2, file, &sz_file);
 	if (ret) {
 		return ret;
 	}
-	file[sz_file] = '\0';
 
 	ret = ftp_delete(file);
 	return (ret == FTP_CODE_250) ? 0 : -1;
@@ -401,11 +387,10 @@ static int do_ftp_get(void)
 	int sz_file = FTP_MAX_FILEPATH;
 
 	/* Parse AT command */
-	ret = at_params_string_get(&at_param_list, 2, file, &sz_file);
+	ret = util_string_get(&at_param_list, 2, file, &sz_file);
 	if (ret) {
 		return ret;
 	}
-	file[sz_file] = '\0';
 
 	ring_buf_reset(&ftp_data_buf);
 	ret = ftp_get(file);
@@ -426,11 +411,10 @@ static int do_ftp_put(void)
 	int param_count = at_params_valid_count_get(&at_param_list);
 
 	/* Parse AT command */
-	ret = at_params_string_get(&at_param_list, 2, file, &sz_file);
+	ret = util_string_get(&at_param_list, 2, file, &sz_file);
 	if (ret) {
 		return ret;
 	}
-	file[sz_file] = '\0';
 
 	if (param_count > 4) {
 		uint16_t type;
@@ -442,7 +426,7 @@ static int do_ftp_put(void)
 			return ret;
 		}
 		size = NET_IPV4_MTU;
-		ret = at_params_string_get(&at_param_list, 4, data, &size);
+		ret = util_string_get(&at_param_list, 4, data, &size);
 		if (ret) {
 			return ret;
 		}
@@ -480,11 +464,10 @@ int slm_at_ftp_parse(const char *at_cmd)
 		if (at_parser_cmd_type_get(at_cmd) != AT_CMD_TYPE_SET_COMMAND) {
 			return -EINVAL;
 		}
-		ret = at_params_string_get(&at_param_list, 1, op_str, &size);
+		ret = util_string_get(&at_param_list, 1, op_str, &size);
 		if (ret) {
 			return ret;
 		}
-		op_str[size] = '\0';
 		ret = -EINVAL;
 		for (int i = 0; i < FTP_OP_MAX; i++) {
 			if (slm_util_casecmp(op_str,

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -164,13 +164,9 @@ static int do_ftp_open(void)
 	int sz_hostname = FTP_MAX_HOSTNAME;
 	uint16_t port = CONFIG_SLM_FTP_SERVER_PORT;
 	sec_tag_t sec_tag = INVALID_SEC_TAG;
-	int param_count;
+	int param_count = at_params_valid_count_get(&at_param_list);
 
 	/* Parse AT command */
-	param_count = at_params_valid_count_get(&at_param_list);
-	if (param_count < 5) {
-		return -EINVAL;
-	}
 	memset(username, 0x00, sz_username); /* Important for optional params*/
 	ret = at_params_string_get(&at_param_list, 2, username, &sz_username);
 	if (ret || strlen(username) == 0) {
@@ -268,12 +264,11 @@ static int do_ftp_ls(void)
 	int sz_options = FTP_MAX_OPTION;
 	char target[FTP_MAX_FILEPATH];
 	int sz_target = FTP_MAX_FILEPATH;
-	int param_count;
+	int param_count = at_params_valid_count_get(&at_param_list);
 
 	memset(options, 0x00, sz_options);
 	memset(target, 0x00, sz_target);
 	/* Parse AT command */
-	param_count = at_params_valid_count_get(&at_param_list);
 	if (param_count > 2) {
 		ret = at_params_string_get(&at_param_list, 2,
 				options, &sz_options);
@@ -307,13 +302,8 @@ static int do_ftp_cd(void)
 	int ret;
 	char folder[FTP_MAX_FILEPATH];
 	int sz_folder = FTP_MAX_FILEPATH;
-	int param_count;
 
 	/* Parse AT command */
-	param_count = at_params_valid_count_get(&at_param_list);
-	if (param_count < 3) {
-		return -EINVAL;
-	}
 	ret = at_params_string_get(&at_param_list, 2, folder, &sz_folder);
 	if (ret) {
 		return ret;
@@ -330,13 +320,8 @@ static int do_ftp_mkdir(void)
 	int ret;
 	char folder[FTP_MAX_FILEPATH];
 	int sz_folder = FTP_MAX_FILEPATH;
-	int param_count;
 
 	/* Parse AT command */
-	param_count = at_params_valid_count_get(&at_param_list);
-	if (param_count < 3) {
-		return -EINVAL;
-	}
 	ret = at_params_string_get(&at_param_list, 2, folder, &sz_folder);
 	if (ret) {
 		return ret;
@@ -353,13 +338,8 @@ static int do_ftp_rmdir(void)
 	int ret;
 	char folder[FTP_MAX_FILEPATH];
 	int sz_folder = FTP_MAX_FILEPATH;
-	int param_count;
 
 	/* Parse AT command */
-	param_count = at_params_valid_count_get(&at_param_list);
-	if (param_count < 3) {
-		return -EINVAL;
-	}
 	ret = at_params_string_get(&at_param_list, 2, folder, &sz_folder);
 	if (ret) {
 		return ret;
@@ -378,13 +358,8 @@ static int do_ftp_rename(void)
 	int sz_file_old = FTP_MAX_FILEPATH;
 	char file_new[FTP_MAX_FILEPATH];
 	int sz_file_new = FTP_MAX_FILEPATH;
-	int param_count;
 
 	/* Parse AT command */
-	param_count = at_params_valid_count_get(&at_param_list);
-	if (param_count < 4) {
-		return -EINVAL;
-	}
 	ret = at_params_string_get(&at_param_list, 2, file_old, &sz_file_old);
 	if (ret) {
 		return ret;
@@ -406,13 +381,8 @@ static int do_ftp_delete(void)
 	int ret;
 	char file[FTP_MAX_FILEPATH];
 	int sz_file = 128;
-	int param_count;
 
 	/* Parse AT command */
-	param_count = at_params_valid_count_get(&at_param_list);
-	if (param_count < 3) {
-		return -EINVAL;
-	}
 	ret = at_params_string_get(&at_param_list, 2, file, &sz_file);
 	if (ret) {
 		return ret;
@@ -429,13 +399,8 @@ static int do_ftp_get(void)
 	int ret;
 	char file[FTP_MAX_FILEPATH];
 	int sz_file = FTP_MAX_FILEPATH;
-	int param_count;
 
 	/* Parse AT command */
-	param_count = at_params_valid_count_get(&at_param_list);
-	if (param_count < 3) {
-		return -EINVAL;
-	}
 	ret = at_params_string_get(&at_param_list, 2, file, &sz_file);
 	if (ret) {
 		return ret;
@@ -458,13 +423,9 @@ static int do_ftp_put(void)
 	int ret;
 	char file[FTP_MAX_FILEPATH];
 	int sz_file = FTP_MAX_FILEPATH;
-	int param_count;
+	int param_count = at_params_valid_count_get(&at_param_list);
 
 	/* Parse AT command */
-	param_count = at_params_valid_count_get(&at_param_list);
-	if (param_count < 3) {
-		return -EINVAL;
-	}
 	ret = at_params_string_get(&at_param_list, 2, file, &sz_file);
 	if (ret) {
 		return ret;
@@ -517,9 +478,6 @@ int slm_at_ftp_parse(const char *at_cmd)
 			return -EINVAL;
 		}
 		if (at_parser_cmd_type_get(at_cmd) != AT_CMD_TYPE_SET_COMMAND) {
-			return -EINVAL;
-		}
-		if (at_params_valid_count_get(&at_param_list) < 2) {
 			return -EINVAL;
 		}
 		ret = at_params_string_get(&at_param_list, 1, op_str, &size);

--- a/applications/serial_lte_modem/src/gps/slm_at_gps.c
+++ b/applications/serial_lte_modem/src/gps/slm_at_gps.c
@@ -416,9 +416,6 @@ static int handle_at_gps(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 2) {
-			return -EINVAL;
-		}
 		err = at_params_short_get(&at_param_list, 1, &op);
 		if (err < 0) {
 			return err;

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -603,9 +603,6 @@ static int handle_AT_HTTPC_REQUEST(enum at_cmd_type cmd_type)
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
 		param_count = at_params_valid_count_get(&at_param_list);
-		if (param_count < 3) {
-			return -EINVAL;
-		}
 		err = at_params_string_get(&at_param_list, 1,
 					   data_buf, &method_sz);
 		if (err < 0) {

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -508,14 +508,13 @@ static int handle_AT_HTTPC_CONNECT(enum at_cmd_type cmd_type)
 			if (httpc.fd != INVALID_SOCKET) {
 				return -EINPROGRESS;
 			}
-			err = at_params_string_get(&at_param_list, 2,
+			err = util_string_get(&at_param_list, 2,
 							httpc.host, &host_sz);
 			if (err < 0) {
 				LOG_ERR("Fail to get host: %d", err);
 				return err;
 			}
 
-			httpc.host[host_sz] = '\0';
 			err = at_params_int_get(&at_param_list, 3, &httpc.port);
 			if (err < 0) {
 				LOG_ERR("Fail to get port: %d", err);
@@ -603,33 +602,30 @@ static int handle_AT_HTTPC_REQUEST(enum at_cmd_type cmd_type)
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
 		param_count = at_params_valid_count_get(&at_param_list);
-		err = at_params_string_get(&at_param_list, 1,
+		err = util_string_get(&at_param_list, 1,
 					   data_buf, &method_sz);
 		if (err < 0) {
 			LOG_ERR("Fail to get method string: %d", err);
 			return err;
 		}
-		data_buf[method_sz] = '\0';
 		httpc.method_str = data_buf;
 		offset = method_sz + 1;
 		/* Get resource path string */
-		err = at_params_string_get(&at_param_list, 2,
+		err = util_string_get(&at_param_list, 2,
 					   data_buf + offset, &resource_sz);
 		if (err < 0) {
 			LOG_ERR("Fail to get resource string: %d", err);
 			return err;
 		}
-		data_buf[offset + resource_sz] = '\0';
 		httpc.resource = data_buf + offset;
 		offset = offset + resource_sz + 1;
 		/* Get header string */
-		err = at_params_string_get(&at_param_list, 3,
+		err = util_string_get(&at_param_list, 3,
 					   data_buf + offset, &headers_sz);
 		if (err < 0) {
 			LOG_ERR("Fail to get option string: %d", err);
 			return err;
 		}
-		data_buf[offset + headers_sz] = '\0';
 		httpc.headers = data_buf + offset;
 		if (param_count >= 5) {
 			err = at_params_int_get(&at_param_list, 4,

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -617,34 +617,30 @@ static int handle_at_mqtt_connect(enum at_cmd_type cmd_type)
 			memset(&ctx, 0, sizeof(ctx));
 			ctx.sec_tag = INVALID_SEC_TAG;
 
-			err = at_params_string_get(&at_param_list, 2,
+			err = util_string_get(&at_param_list, 2,
 							ctx.cid, &cid_sz);
 			if (err < 0) {
 				return err;
 			}
-			ctx.cid[cid_sz] = '\0';
-			err = at_params_string_get(&at_param_list, 3,
+			err = util_string_get(&at_param_list, 3,
 						ctx.uname, &username_sz);
 			if (err < 0) {
 				return err;
 			}
-			ctx.uname[username_sz] = '\0';
-			err = at_params_string_get(&at_param_list, 4,
+			err = util_string_get(&at_param_list, 4,
 						ctx.pword, &password_sz);
 			if (err < 0) {
 				return err;
 			}
-			ctx.pword[password_sz] = '\0';
 			if ((username_sz == 0) && (password_sz > 0)) {
 				/* Password without username is invalid. */
 				return -EINVAL;
 			}
-			err = at_params_string_get(&at_param_list, 5,
+			err = util_string_get(&at_param_list, 5,
 						ctx.url, &url_sz);
 			if (err < 0) {
 				return err;
 			}
-			ctx.url[url_sz] = '\0';
 			err = at_params_int_get(&at_param_list, 6, &ctx.port);
 			if (err < 0) {
 				return err;
@@ -723,20 +719,18 @@ static int handle_at_mqtt_publish(enum at_cmd_type cmd_type)
 		if (at_params_valid_count_get(&at_param_list) != 6) {
 			return -EINVAL;
 		}
-		err = at_params_string_get(&at_param_list, 1, topic, &topic_sz);
+		err = util_string_get(&at_param_list, 1, topic, &topic_sz);
 		if (err < 0) {
 			return err;
 		}
-		topic[topic_sz] = '\0';
 		err = at_params_short_get(&at_param_list, 2, &datatype);
 		if (err < 0) {
 			return err;
 		}
-		err = at_params_string_get(&at_param_list, 3, msg, &msg_sz);
+		err = util_string_get(&at_param_list, 3, msg, &msg_sz);
 		if (err < 0) {
 			return err;
 		}
-		msg[msg_sz] = '\0';
 		err = at_params_short_get(&at_param_list, 4, &qos);
 		if (err < 0) {
 			return err;
@@ -795,12 +789,11 @@ static int handle_at_mqtt_subscribe(enum at_cmd_type cmd_type)
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
 		if (at_params_valid_count_get(&at_param_list) == 3) {
-			err = at_params_string_get(&at_param_list, 1,
+			err = util_string_get(&at_param_list, 1,
 							topic, &topic_sz);
 			if (err < 0) {
 				return err;
 			}
-			topic[topic_sz] = '\0';
 			err = at_params_short_get(&at_param_list, 2, &qos);
 			if (err < 0) {
 				return err;
@@ -839,12 +832,11 @@ static int handle_at_mqtt_unsubscribe(enum at_cmd_type cmd_type)
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
 		if (at_params_valid_count_get(&at_param_list) == 2) {
-			err = at_params_string_get(&at_param_list, 1,
+			err = util_string_get(&at_param_list, 1,
 							topic, &topic_sz);
 			if (err < 0) {
 				return err;
 			}
-			topic[topic_sz] = '\0';
 			err = do_mqtt_subscribe(AT_MQTTSUB_UNSUB,
 						topic, topic_sz, 0);
 		} else {

--- a/applications/serial_lte_modem/src/slm_at_cmng.c
+++ b/applications/serial_lte_modem/src/slm_at_cmng.c
@@ -114,14 +114,13 @@ static int handle_at_xcmng(enum at_cmd_type cmd_type)
 				return -EINVAL;
 			}
 			content = k_malloc(CONFIG_AT_CMD_RESPONSE_MAX_LEN);
-			err = at_params_string_get(&at_param_list, 4, content,
+			err = util_string_get(&at_param_list, 4, content,
 						   &len);
 			if (err != 0) {
 				LOG_ERR("Failed to get content");
 				k_free(content);
 				return err;
 			}
-			*(content + len) = '\0';
 			err = modem_key_mgmt_write(
 				slm_tls_map_sectag(sec_tag, type),
 				0, content, len);

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -186,9 +186,6 @@ static int handle_at_fota(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) <= 1) {
-			return -EINVAL;
-		}
 		err = at_params_short_get(&at_param_list, 1, &op);
 		if (err < 0) {
 			return err;
@@ -201,9 +198,6 @@ static int handle_at_fota(enum at_cmd_type cmd_type)
 			sec_tag_t sec_tag = INVALID_SEC_TAG;
 			char apn[APN_MAX];
 
-			if (at_params_valid_count_get(&at_param_list) <= 2) {
-				return -EINVAL;
-			}
 			size = FILE_URI_MAX;
 			err = at_params_string_get(&at_param_list, 2, uri,
 						&size);

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -194,25 +194,24 @@ static int handle_at_fota(enum at_cmd_type cmd_type)
 			err = do_fota_erase();
 		} else if (op == AT_FOTA_START) {
 			char uri[FILE_URI_MAX];
-			int size;
-			sec_tag_t sec_tag = INVALID_SEC_TAG;
 			char apn[APN_MAX];
+			int size = FILE_URI_MAX;
+			sec_tag_t sec_tag = INVALID_SEC_TAG;
 
-			size = FILE_URI_MAX;
-			err = at_params_string_get(&at_param_list, 2, uri,
-						&size);
+			err = util_string_get(&at_param_list, 2, uri, &size);
 			if (err) {
 				return err;
 			}
-			uri[size] = '\0';
 			if (at_params_valid_count_get(&at_param_list) > 3) {
 				at_params_int_get(&at_param_list, 3, &sec_tag);
 			}
 			if (at_params_valid_count_get(&at_param_list) > 4) {
 				size = APN_MAX;
-				at_params_string_get(&at_param_list, 4, apn,
-							&size);
-				apn[size] = '\0';
+				err = util_string_get(&at_param_list, 4, apn,
+						&size);
+				if (err) {
+					return err;
+				}
 				err = do_fota_start(op, uri, sec_tag, apn);
 			} else {
 				err = do_fota_start(op, uri, sec_tag, NULL);

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -381,22 +381,19 @@ static int handle_at_icmp_ping(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 4) {
-			return -EINVAL;
-		}
 		err = at_params_string_get(&at_param_list, 1, url, &size);
 		if (err < 0) {
 			return err;
-		};
+		}
 		url[size] = '\0';
 		err = at_params_short_get(&at_param_list, 2, &length);
 		if (err < 0) {
 			return err;
-		};
+		}
 		err = at_params_short_get(&at_param_list, 3, &timeout);
 		if (err < 0) {
 			return err;
-		};
+		}
 		if (at_params_valid_count_get(&at_param_list) > 4) {
 			err = at_params_short_get(&at_param_list, 4, &count);
 			if (err < 0) {

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -381,11 +381,10 @@ static int handle_at_icmp_ping(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_string_get(&at_param_list, 1, url, &size);
+		err = util_string_get(&at_param_list, 1, url, &size);
 		if (err < 0) {
 			return err;
 		}
-		url[size] = '\0';
 		err = at_params_short_get(&at_param_list, 2, &length);
 		if (err < 0) {
 			return err;

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -760,7 +760,7 @@ static int handle_at_tcp_filter(enum at_cmd_type cmd_type)
 			memset(ip_allowlist, 0x00, sizeof(ip_allowlist));
 			for (int i = 2; i < param_count; i++) {
 				size = INET_ADDRSTRLEN;
-				err = at_params_string_get(&at_param_list, i,
+				err = util_string_get(&at_param_list, i,
 							   address, &size);
 				if (err) {
 					return err;
@@ -903,12 +903,11 @@ static int handle_at_tcp_client(enum at_cmd_type cmd_type)
 				LOG_ERR("Client is already running.");
 				return -EINVAL;
 			}
-			err = at_params_string_get(&at_param_list,
+			err = util_string_get(&at_param_list,
 						2, url, &size);
 			if (err) {
 				return err;
 			}
-			url[size] = '\0';
 			err = at_params_short_get(&at_param_list, 3, &port);
 			if (err) {
 				return err;
@@ -972,7 +971,7 @@ static int handle_at_tcp_send(enum at_cmd_type cmd_type)
 		if (err) {
 			return err;
 		}
-		err = at_params_string_get(&at_param_list, 2, data, &size);
+		err = util_string_get(&at_param_list, 2, data, &size);
 		if (err) {
 			return err;
 		}

--- a/applications/serial_lte_modem/src/slm_at_tcpip.c
+++ b/applications/serial_lte_modem/src/slm_at_tcpip.c
@@ -889,11 +889,10 @@ static int handle_at_connect(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_string_get(&at_param_list, 1, url, &size);
+		err = util_string_get(&at_param_list, 1, url, &size);
 		if (err) {
 			return err;
 		}
-		url[size] = '\0';
 		err = at_params_short_get(&at_param_list, 2, &port);
 		if (err) {
 			return err;
@@ -1022,7 +1021,7 @@ static int handle_at_send(enum at_cmd_type cmd_type)
 		if (err) {
 			return err;
 		}
-		err = at_params_string_get(&at_param_list, 2, data, &size);
+		err = util_string_get(&at_param_list, 2, data, &size);
 		if (err) {
 			return err;
 		}
@@ -1087,10 +1086,10 @@ static int handle_at_sendto(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
 	char url[TCPIP_MAX_URL];
+	int size = TCPIP_MAX_URL;
 	uint16_t port;
 	uint16_t datatype;
 	char data[NET_IPV4_MTU];
-	int size;
 
 	if (client.sock < 0) {
 		LOG_ERR("Socket not opened yet");
@@ -1104,12 +1103,10 @@ static int handle_at_sendto(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		size = TCPIP_MAX_URL;
-		err = at_params_string_get(&at_param_list, 1, url, &size);
+		err = util_string_get(&at_param_list, 1, url, &size);
 		if (err) {
 			return err;
 		}
-		url[size] = '\0';
 		err = at_params_short_get(&at_param_list, 2, &port);
 		if (err) {
 			return err;
@@ -1119,7 +1116,7 @@ static int handle_at_sendto(enum at_cmd_type cmd_type)
 			return err;
 		}
 		size = NET_IPV4_MTU;
-		err = at_params_string_get(&at_param_list, 4, data, &size);
+		err = util_string_get(&at_param_list, 4, data, &size);
 		if (err) {
 			return err;
 		}
@@ -1199,11 +1196,10 @@ static int handle_at_getaddrinfo(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_string_get(&at_param_list, 1, url, &size);
+		err = util_string_get(&at_param_list, 1, url, &size);
 		if (err) {
 			return err;
 		}
-		url[size] = '\0';
 		if (check_for_ipv4(url, strlen(url))) {
 			LOG_ERR("already IPv4 address");
 			return -EINVAL;

--- a/applications/serial_lte_modem/src/slm_at_tcpip.c
+++ b/applications/serial_lte_modem/src/slm_at_tcpip.c
@@ -717,9 +717,6 @@ static int handle_at_socket(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 2) {
-			return -EINVAL;
-		}
 		err = at_params_short_get(&at_param_list, 1, &op);
 		if (err) {
 			return err;
@@ -728,9 +725,6 @@ static int handle_at_socket(enum at_cmd_type cmd_type)
 			uint16_t type;
 			sec_tag_t sec_tag = INVALID_SEC_TAG;
 
-			if (at_params_valid_count_get(&at_param_list) < 4) {
-				return -EINVAL;
-			}
 			err = at_params_short_get(&at_param_list, 2, &type);
 			if (err) {
 				return err;
@@ -807,9 +801,6 @@ static int handle_at_socketopt(enum at_cmd_type cmd_type)
 			LOG_ERR("Invalid role");
 			return err;
 		}
-		if (at_params_valid_count_get(&at_param_list) < 3) {
-			return -EINVAL;
-		}
 		err = at_params_short_get(&at_param_list, 1, &op);
 		if (err) {
 			return err;
@@ -821,9 +812,6 @@ static int handle_at_socketopt(enum at_cmd_type cmd_type)
 		if (op == AT_SOCKETOPT_SET) {
 			int value;
 
-			if (at_params_valid_count_get(&at_param_list) < 4) {
-				return -EINVAL;
-			}
 			err = at_params_int_get(&at_param_list, 3, &value);
 			if (err) {
 				return err;
@@ -864,9 +852,6 @@ static int handle_at_bind(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 2) {
-			return -EINVAL;
-		}
 		err = at_params_short_get(&at_param_list, 1, &port);
 		if (err < 0) {
 			return err;
@@ -904,9 +889,6 @@ static int handle_at_connect(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 3) {
-			return -EINVAL;
-		}
 		err = at_params_string_get(&at_param_list, 1, url, &size);
 		if (err) {
 			return err;
@@ -1036,9 +1018,6 @@ static int handle_at_send(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 3) {
-			return -EINVAL;
-		}
 		err = at_params_short_get(&at_param_list, 1, &datatype);
 		if (err) {
 			return err;
@@ -1125,9 +1104,6 @@ static int handle_at_sendto(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 5) {
-			return -EINVAL;
-		}
 		size = TCPIP_MAX_URL;
 		err = at_params_string_get(&at_param_list, 1, url, &size);
 		if (err) {
@@ -1223,9 +1199,6 @@ static int handle_at_getaddrinfo(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 2) {
-			return -EINVAL;
-		}
 		err = at_params_string_get(&at_param_list, 1, url, &size);
 		if (err) {
 			return err;

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -396,13 +396,9 @@ static int handle_at_udp_server(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
 	uint16_t op;
-	int param_count = at_params_valid_count_get(&at_param_list);
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (param_count < 2) {
-			return -EINVAL;
-		}
 		err = at_params_short_get(&at_param_list, 1, &op);
 		if (err) {
 			return err;
@@ -411,9 +407,6 @@ static int handle_at_udp_server(enum at_cmd_type cmd_type)
 		    op == AT_SERVER_START_WITH_DATAMODE) {
 			uint16_t port;
 
-			if (param_count < 3) {
-				return -EINVAL;
-			}
 			err = at_params_short_get(&at_param_list, 2, &port);
 			if (err) {
 				return err;
@@ -474,9 +467,6 @@ static int handle_at_udp_client(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (param_count < 2) {
-			return -EINVAL;
-		}
 		err = at_params_short_get(&at_param_list, 1, &op);
 		if (err) {
 			return err;
@@ -488,9 +478,6 @@ static int handle_at_udp_client(enum at_cmd_type cmd_type)
 			int size = TCPIP_MAX_URL;
 			sec_tag_t sec_tag = INVALID_SEC_TAG;
 
-			if (param_count < 4) {
-				return -EINVAL;
-			}
 			err = at_params_string_get(&at_param_list,
 						2, url, &size);
 			if (err) {
@@ -563,9 +550,6 @@ static int handle_at_udp_send(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) < 3) {
-			return -EINVAL;
-		}
 		err = at_params_short_get(&at_param_list, 1, &datatype);
 		if (err) {
 			return err;

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -478,12 +478,10 @@ static int handle_at_udp_client(enum at_cmd_type cmd_type)
 			int size = TCPIP_MAX_URL;
 			sec_tag_t sec_tag = INVALID_SEC_TAG;
 
-			err = at_params_string_get(&at_param_list,
-						2, url, &size);
+			err = util_string_get(&at_param_list, 2, url, &size);
 			if (err) {
 				return err;
 			}
-			url[size] = '\0';
 			err = at_params_short_get(&at_param_list, 3, &port);
 			if (err) {
 				return err;
@@ -554,7 +552,7 @@ static int handle_at_udp_send(enum at_cmd_type cmd_type)
 		if (err) {
 			return err;
 		}
-		err = at_params_string_get(&at_param_list, 2, data, &size);
+		err = util_string_get(&at_param_list, 2, data, &size);
 		if (err) {
 			return err;
 		}

--- a/applications/serial_lte_modem/src/slm_util.c
+++ b/applications/serial_lte_modem/src/slm_util.c
@@ -8,7 +8,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include "slm_util.h"
-#include <modem/at_cmd.h>
 #include <net/socket.h>
 
 #define PRINTABLE_ASCII(ch) (ch > 0x1f && ch < 0x7f)
@@ -172,4 +171,26 @@ bool util_get_ipv4_addr(char *address)
 	memcpy(address, tmp1, tmp2 - tmp1);
 	address[tmp2 - tmp1] = '\0';
 	return true;
+}
+
+/**
+ * @brief Get string value from AT command with length check
+ */
+int util_string_get(const struct at_param_list *list, size_t index,
+			 char *value, size_t *len)
+{
+	int ret;
+	size_t size = *len;
+
+	/* at_params_string_get calls "memcpy" instead of "strcpy" */
+	ret = at_params_string_get(list, index, value, len);
+	if (ret) {
+		return ret;
+	}
+	if (*len < size) {
+		*(value + *len) = '\0';
+		return 0;
+	}
+
+	return -ENOMEM;
 }

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -16,6 +16,8 @@
 #include <zephyr/types.h>
 #include <ctype.h>
 #include <stdbool.h>
+#include <modem/at_cmd.h>
+#include <modem/at_cmd_parser.h>
 
 #define INVALID_SOCKET	-1
 #define INVALID_PORT	-1
@@ -100,6 +102,25 @@ bool check_for_ipv4(const char *address, uint8_t length);
  * @return true if IPv4 address obtained, false otherwise
  */
 bool util_get_ipv4_addr(char *address);
+
+/**
+ * @brief Get string value from AT command with length check.
+ *
+ * @p len must be bigger than the string length, or an error is returned.
+ * The copied string is null-terminated.
+ *
+ * @param[in]     list    Parameter list.
+ * @param[in]     index   Parameter index in the list.
+ * @param[out]    value   Pointer to the buffer where to copy the value.
+ * @param[in,out] len     Available space in @p value, returns actual length
+ *                        copied into string buffer in bytes, excluding the
+ *                        terminating null character.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int util_string_get(const struct at_param_list *list, size_t index,
+			 char *value, size_t *len);
 
 /** @} */
 


### PR DESCRIPTION
Add util function util_string_get() to call at_params_string_get()
and null-treminate the result string.

Plus code cleaning of unnecessary check of AT param count.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>