### PR TITLE
partition_manager: Cleanup missed references to b0_provision

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/pm_static_ZDebugB0.yml
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/pm_static_ZDebugB0.yml
@@ -1,4 +1,4 @@
-b0_provision:
+b0_container:
   address: 0x0
   orig_span: &id001
   - b0

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/pm_static_ZReleaseB0.yml
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/pm_static_ZReleaseB0.yml
@@ -1,4 +1,4 @@
-b0_provision:
+b0_container:
   address: 0x0
   orig_span: &id001
   - b0

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/pm_static_ZDebugB0.yml
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/pm_static_ZDebugB0.yml
@@ -1,4 +1,4 @@
-b0_provision:
+b0_container:
   address: 0x0
   orig_span: &id001
   - b0

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/pm_static_ZReleaseB0.yml
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/pm_static_ZReleaseB0.yml
@@ -1,4 +1,4 @@
-b0_provision:
+b0_container:
   address: 0x0
   orig_span: &id001
   - b0

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/pm_static_ZDebugB0.yml
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/pm_static_ZDebugB0.yml
@@ -1,4 +1,4 @@
-b0_provision:
+b0_container:
   address: 0x0
   orig_span: &id001
   - b0

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/pm_static_ZReleaseB0.yml
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/pm_static_ZReleaseB0.yml
@@ -1,4 +1,4 @@
-b0_provision:
+b0_container:
   address: 0x0
   orig_span: &id001
   - b0

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/pm_static_ZDebugB0.yml
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/pm_static_ZDebugB0.yml
@@ -1,4 +1,4 @@
-b0_provision:
+b0_container:
   address: 0x0
   orig_span: &id001
   - b0

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/pm_static_ZReleaseB0.yml
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/pm_static_ZReleaseB0.yml
@@ -1,4 +1,4 @@
-b0_provision:
+b0_container:
   address: 0x0
   orig_span: &id001
   - b0

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -221,7 +221,7 @@ Partition Manager:
 
   * If the invalid naming scheme is used in ``pm.yml`` files, Partition Manager will now fail the builds.
   * If the invalid naming scheme is used in ``pm_static.yml`` files, the build will instead print a warning prompting the user to change this, if possible.
-* Renamed ``b0`` and ``b0n`` container partitions to ``b0_provision`` and ``b0n_provision``, respectively.
+* Renamed ``b0`` and ``b0n`` container partitions to ``b0_container`` and ``b0n_container``, respectively.
 * Renamed ``b0_image`` and ``b0n_image`` image partitions to appropriately match their child image name, ``b0`` and ``b0n``, respectively.
 
   **Migration notes:** While in development, you should rename partitions appropriately.

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -386,7 +386,7 @@ The information extracted from devicetree is the alignment value for some partit
      placement:
        after: start
 
-   b0_provision:
+   b0_container:
      span: [b0, provision]
 
    s0_pad:


### PR DESCRIPTION
References to this variable were not cleaned up properly for changes in commit cdb46e732 from PR 3429.

Signed-off-by: Stephen Stauts <stephen.stauts@nordicsemi.no>