### PR TITLE
net: lib: azure_fota: Add job ID handling to avoid repeated update

### DIFF
--- a/samples/nrf9160/azure_fota/README.rst
+++ b/samples/nrf9160/azure_fota/README.rst
@@ -109,6 +109,7 @@ After programming the sample to your development kit, test it by performing the 
 	{
 	    "firmware": {
 	        "fwVersion": "v0.0.0-dev",
+	        "jobId": "ca186d4b-4171-4209-a49d-700c35567d1d",
 	        "fwLocation": {
 	            "host": "my-storage-account.blob.core.windows.net",
 	            "path": "my-app-update.bin"

--- a/subsys/net/lib/azure_fota/Kconfig
+++ b/subsys/net/lib/azure_fota/Kconfig
@@ -23,6 +23,10 @@ config AZURE_FOTA_VERSION_MAX_LEN
 	int "Version string buffer size"
 	default 64
 
+config AZURE_FOTA_JOB_ID_MAX_LEN
+	int "Job ID string buffer size"
+	default 40
+
 config AZURE_FOTA_APP_VERSION_AUTO
 	bool "Automatically create application version"
 	help


### PR DESCRIPTION
Add job handling of job ID to avoid repeatedly downloading the same
firmware image.

In certain situations, the device can get into a loop
where it concinues to download the same firmware image over and
over again without being able to apply it, spending large amounts of
power and data traffic.
This patch prevents that from happening by reporting the job ID that
was last processed and comparing it to the ID of any incoming firmware
update.

Fixes CIA-222