### PR TITLE
net: lib: fota_download: Disconnect if dfu_target_init() fails

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -100,6 +100,7 @@ static int download_client_callback(const struct download_client_evt *event)
 					      dfu_target_callback_handler);
 			if ((err < 0) && (err != -EBUSY)) {
 				LOG_ERR("dfu_target_init error %d", err);
+				(void)download_client_disconnect(&dlc);
 				send_error_evt(FOTA_DOWNLOAD_ERROR_CAUSE_DOWNLOAD_FAILED);
 				int res = dfu_target_reset();
 


### PR DESCRIPTION
If dfu_target_init() fails, download_client remains connected because
disconnect is not called. Because of this the next FOTA attempt always
fails.

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>