### PR TITLE
scripts: requirements-ci.txt: update to PyGithub version 1.54.1

### DIFF
--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -61,7 +61,7 @@ psutil==5.8.0
 py==1.10.0
 pycparser==2.20
 pyelftools==0.27
-PyGithub==1.54
+PyGithub==1.54.1
 PyJWT==1.7.1
 Pygments==2.7.4
 pykwalify==1.8.0


### PR DESCRIPTION
Changing Pygithub to version 1.54.1 makes the new pip dependency checker
from pip 20.3 pass on all dependency relations.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>