### PR TITLE
samples: application_update: Add application downgrade.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -105,6 +105,11 @@ nRF9160 samples
 
   * Added a new shell command ``cloud`` for establishing an MQTT connection to nRF Cloud.
 
+* :ref:`http_application_update_sample` sample:
+
+  * Added support for application downgrade.
+    The sample now alternates updates between two different application images.
+
 * :ref:`gnss_sample` sample:
 
   * Added support for minimal assistance using factory almanac, time and location.

--- a/samples/nrf9160/http_update/application_update/Kconfig
+++ b/samples/nrf9160/http_update/application_update/Kconfig
@@ -13,13 +13,19 @@ config DOWNLOAD_HOST
 	  if the file is stored in http://foo.bar/update.bin the value
 	  of this configuration should be 'foo.bar'
 
-config DOWNLOAD_FILE
-	string "Application update file name"
+config DOWNLOAD_FILE_V2
+	string "Application update file name (application version 2)"
 	help
-	  File part of URL to application update binary. For example
+	  File part of URL to application update binary version 2. For example
 	  if the file is stored in http://foo.bar/update.bin the value
 	  of this configuration should be 'update.bin'
 
+config DOWNLOAD_FILE_V1
+	string "Application downgrade file name (application version 1)"
+	help
+	  File part of URL to application update binary version 1. For example
+	  if the file is stored in http://foo.bar/downgrade.bin the value
+	  of this configuration should be 'downgrade.bin'
 
 config APPLICATION_VERSION
 	int "Application version"

--- a/samples/nrf9160/http_update/application_update/prj.conf
+++ b/samples/nrf9160/http_update/application_update/prj.conf
@@ -55,5 +55,6 @@ CONFIG_BOOTLOADER_MCUBOOT=y
 
 # Sample configuration
 CONFIG_DOWNLOAD_HOST="nrfconnectsdk.s3.eu-central-1.amazonaws.com"
-CONFIG_DOWNLOAD_FILE="app_update.bin"
+CONFIG_DOWNLOAD_FILE_V2="app_update.bin"
+CONFIG_DOWNLOAD_FILE_V1="app_downgrade.bin"
 CONFIG_APPLICATION_VERSION=1

--- a/samples/nrf9160/http_update/application_update/src/main.c
+++ b/samples/nrf9160/http_update/application_update/src/main.c
@@ -17,6 +17,15 @@
 #define NUM_LEDS 1
 #endif
 
+static const char *get_file(void)
+{
+#if CONFIG_APPLICATION_VERSION == 2
+	return CONFIG_DOWNLOAD_FILE_V1;
+#else
+	return CONFIG_DOWNLOAD_FILE_V2;
+#endif
+}
+
 static void fota_dl_handler(const struct fota_download_evt *evt)
 {
 	switch (evt->id) {
@@ -35,8 +44,9 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 static void update_start(void)
 {
 	int err;
+	const char *filename = get_file();
 
-	err = fota_download_start(CONFIG_DOWNLOAD_HOST, CONFIG_DOWNLOAD_FILE,
+	err = fota_download_start(CONFIG_DOWNLOAD_HOST, filename,
 				  SEC_TAG, 0, 0);
 	if (err != 0) {
 		update_sample_done();


### PR DESCRIPTION
Add optional functionality for using two image files in the sample.
When two images are specified, the sample will toggle between them
during updates. If only one image is specified, the sample behaves
as before.

Ref: NCSDK-7328

Signed-off-by: Jonathan Nilsen <jonathan.nilsen@nordicsemi.no>