### PR TITLE
manifest: Add UARTE driver fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 73a419c5d7d60d9e476dfee62669e96236601755
+      revision: pull/448/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This adds three fixes:
- power management fix lowering the idle current
- quicker uarte driver state update
- graceful uarte shutdown when using async api

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>

https://github.com/nrfconnect/sdk-zephyr/pull/448
KRKNWK-8730