### PR TITLE
doc: move versions.txt generation to own file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,7 @@
 Kconfig*                                  @tejlmand
 # All doc related files
 /doc/CMakeLists.txt                       @carlescufi
+/doc/update_versions.cmake                @carlescufi
 /doc/scripts/                             @carlescufi
 /doc/static/                              @carlescufi
 /doc/themes/                              @carlescufi

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -141,47 +141,38 @@ set(NRF_KI_DIR ${NRF_BASE}/.known-issues/doc)
 
 configure_file(${NRF_DOXYFILE_IN} ${NRF_DOXYFILE_OUT} @ONLY)
 
-file(STRINGS ${NRF_BASE}/scripts/tools-versions-minimum.txt MINIMUM_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
-file(STRINGS ${NRF_BASE}/scripts/tools-versions-darwin.txt DARWIN_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
-file(STRINGS ${NRF_BASE}/scripts/tools-versions-win10.txt WIN10_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
-file(STRINGS ${NRF_BASE}/scripts/tools-versions-linux.txt LINUX_VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
-
-foreach(os MINIMUM DARWIN WIN10 LINUX)
-  foreach(program ${${os}_VERSIONS_ALL})
-    string(REGEX REPLACE "(^[^=]*)=([^\;]*)\;*.*" "\\1" program_name "${program}")
-    string(TOUPPER ${program_name} PROGRAM_NAME_UPPER)
-    set(${PROGRAM_NAME_UPPER}_VERSION_${os} ${CMAKE_MATCH_2})
-  endforeach()
-endforeach()
-
-# Loading Zephyr requirements-base.txt first, then mcuboot, and afterwards NCS
-# specific ensures that any packages present in multiple files will present the
-# version defined by NCS.
-file(STRINGS ${ZEPHYR_BASE}/scripts/requirements-base.txt ZEPHYR_BASE_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${ZEPHYR_BASE}/scripts/requirements-doc.txt ZEPHYR_DOCS_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${MCUBOOT_BASE}/scripts/requirements.txt MCUBOOT_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${NRF_BASE}/scripts/requirements-base.txt NRF_BASE_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${NRF_BASE}/scripts/requirements-doc.txt NRF_DOC_PACKAGE_VERSIONS REGEX "^[^#].*")
-file(STRINGS ${NRF_BASE}/scripts/requirements-build.txt NRF_BUILD_PACKAGE_VERSIONS REGEX "^[^#].*")
-
-foreach(package ${ZEPHYR_BASE_PACKAGE_VERSIONS}
-                ${ZEPHYR_DOCS_PACKAGE_VERSIONS}
-                ${MCUBOOT_PACKAGE_VERSIONS}
-                ${NRF_BASE_PACKAGE_VERSIONS}
-                ${NRF_DOC_PACKAGE_VERSIONS}
-                ${NRF_BUILD_PACKAGE_VERSIONS}
+set(tools_version_files
+    ${NRF_BASE}/scripts/tools-versions-minimum.txt
+    ${NRF_BASE}/scripts/tools-versions-darwin.txt
+    ${NRF_BASE}/scripts/tools-versions-win10.txt
+    ${NRF_BASE}/scripts/tools-versions-linux.txt
 )
-  string(REGEX REPLACE "(^[^>=\;]*)([\;]|([>=][^\;]*))\;*.*" "\\1" package_name "${package}")
-  string(TOUPPER ${package_name} PACKAGE_NAME_UPPER)
-  set(${PACKAGE_NAME_UPPER}_VERSION ${CMAKE_MATCH_3})
-  if("${${PACKAGE_NAME_UPPER}_VERSION}" STREQUAL "")
-    set(${PACKAGE_NAME_UPPER}_VERSION "\\ ")
-  endif()
-endforeach()
 
-set(NRF_VERSION_IN ${NRF_DOC_DIR}/versions.txt.in)
-set(NRF_RST_VERSION_OUT ${NRF_RST_OUT}/doc/nrf/versions.txt)
-configure_file(${NRF_VERSION_IN} ${NRF_RST_VERSION_OUT} @ONLY)
+set(pip_requirements_files
+    ${ZEPHYR_BASE}/scripts/requirements-base.txt
+    ${ZEPHYR_BASE}/scripts/requirements-doc.txt
+    ${MCUBOOT_BASE}/scripts/requirements.txt
+    ${NRF_BASE}/scripts/requirements-base.txt
+    ${NRF_BASE}/scripts/requirements-doc.txt
+    ${NRF_BASE}/scripts/requirements-build.txt
+)
+
+string(REPLACE ";" "\\;" tools_files_escaped "${tools_version_files}")
+string(REPLACE ";" "\\;" pip_files_escaped "${pip_requirements_files}")
+
+add_custom_command(
+  OUTPUT ${NRF_RST_OUT}/doc/nrf/versions.txt
+  COMMAND ${CMAKE_COMMAND}
+    -DTOOLS_VERSION_FILES="${tools_files_escaped}"
+    -DPIP_REQUIREMENTS_FILES="${pip_files_escaped}"
+    -DVERSION_IN=${NRF_DOC_DIR}/versions.txt.in
+    -DVERSION_OUT=${NRF_RST_OUT}/doc/nrf/versions.txt
+    -P ${NRF_BASE}/doc/update_versions.cmake
+  DEPENDS
+    ${NRF_DOC_DIR}/versions.txt.in
+    ${tools_version_files}
+    ${pip_requirements_files}
+)
 
 add_custom_target(
   nrf-doxy
@@ -225,6 +216,7 @@ add_custom_target(
   # Copy all files in doc/ to the rst folder
   COMMAND ${NRF_EXTRACT_CONTENT_COMMAND}
   WORKING_DIRECTORY ${NRF_DOC_DIR}
+  DEPENDS ${NRF_RST_OUT}/doc/nrf/versions.txt
 )
 
 if(WIN32)

--- a/doc/update_versions.cmake
+++ b/doc/update_versions.cmake
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+foreach(file ${TOOLS_VERSION_FILES})
+  file(STRINGS ${file} VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")
+  get_filename_component(file_name ${file} NAME_WE)
+  string(REPLACE "tools-versions-" "" os ${file_name})
+  string(TOUPPER ${os} OS_UPPER)
+  foreach(program ${VERSIONS_ALL})
+    string(REGEX REPLACE "(^[^=]*)=([^\;]*)\;*.*" "\\1" program_name "${program}")
+    string(TOUPPER ${program_name} PROGRAM_NAME_UPPER)
+    set(${PROGRAM_NAME_UPPER}_VERSION_${OS_UPPER} ${CMAKE_MATCH_2})
+  endforeach()
+endforeach()
+
+foreach(pip_file ${PIP_REQUIREMENTS_FILES})
+  file(STRINGS ${pip_file} PACKAGE_VERSIONS REGEX "^[^#].*")
+  foreach(package ${PACKAGE_VERSIONS})
+    string(REGEX REPLACE "(^[^>=\;]*)([\;]|([>=][^\;]*))\;*.*" "\\1" package_name "${package}")
+    string(TOUPPER ${package_name} PACKAGE_NAME_UPPER)
+    set(${PACKAGE_NAME_UPPER}_VERSION ${CMAKE_MATCH_3})
+    if("${${PACKAGE_NAME_UPPER}_VERSION}" STREQUAL "")
+      set(${PACKAGE_NAME_UPPER}_VERSION "\\ ")
+    endif()
+  endforeach()
+endforeach()
+
+configure_file(${VERSION_IN} ${VERSION_OUT} @ONLY)


### PR DESCRIPTION
This fixes an issue after running `ninja clean-nrf` followed by `ninja
nrf`. Since `cmake` is not invoked, the global `configure_file` was not
being run and would not regenerate the pre-requisite versions.txt file.

The version generation was moved into another "cmake" file and the
versions.txt is now an output of  add_custom_command.
versions.txt will be re-generated whenever it is missing or one of its
input is modified.

The nrf-content depends on versions.txt ensuring that it will always be
up-to date before nrf-content target is executed.

JIRA: NCSDK-7514

Signed-off-by: Fabio Utzig <fabio.utzig@nordicsemi.no>
Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

----- 

This PR is followup on https://github.com/nrfconnect/sdk-nrf/pull/3775#discussion_r567809602