### PR TITLE
License tag cleanup - nRF53/nRF RPC samples and NFC.

### DIFF
--- a/dts/bindings/net/nfc/st,st25r3911b.yaml
+++ b/dts/bindings/net/nfc/st,st25r3911b.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 description: |
     STMicroelectronics ST25R3911B NFC Initiator / HF Reader

--- a/samples/nrf5340/empty_app_core/src/main.c
+++ b/samples/nrf5340/empty_app_core/src/main.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr.h>

--- a/samples/nrf_rpc/entropy_nrf53/cpuapp/src/entropy_ser.h
+++ b/samples/nrf_rpc/entropy_nrf53/cpuapp/src/entropy_ser.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #ifndef ENTROPY_SER_H_


### PR DESCRIPTION
This PR changes the license tags to point to the Nordic-5-Clause license text.