### PR TITLE
zigbee: Make writing data of length 0 into nvram valid

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_nvram.c
+++ b/subsys/zigbee/osif/zb_nrf_nvram.c
@@ -115,6 +115,10 @@ zb_ret_t zb_osif_nvram_write(zb_uint8_t page, zb_uint32_t pos, void *buf,
 		return RET_INVALID_PARAMETER_3;
 	}
 
+	if (len == 0) {
+		return RET_OK;
+	}
+
 	if (!(len >> 2)) {
 		return RET_INVALID_PARAMETER_4;
 	}


### PR DESCRIPTION
Check whether length of data written to nvram is 0 and
return RET_OK without any attempt of saving it.

Signed-off-by: Filip Zajdel <filip.zajdel@nordicsemi.no>