### PR TITLE
tfm: Adapt to new signing algorithm

### DIFF
--- a/modules/tfm/CMakeLists.txt
+++ b/modules/tfm/CMakeLists.txt
@@ -20,31 +20,3 @@ endif()
 set_property(GLOBAL PROPERTY
   tfm_PM_HEX_FILE $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>
   )
-
-
-# Set srec_cat binary name
-find_program(SREC_CAT srec_cat)
-if(${SREC_CAT} STREQUAL SREC_CAT-NOTFOUND)
-    message(FATAL_ERROR "'srec_cat' not found. Please install it, or add it to $PATH.")
-endif()
-
-set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-  # Generate an intel hex file from the signed output binary
-  COMMAND ${SREC_CAT} ${CMAKE_BINARY_DIR}/tfm_s_signed.bin
-    -binary
-    -offset $<TARGET_PROPERTY:partition_manager,PM_TFM_ADDRESS>
-    -o ${CMAKE_BINARY_DIR}/tfm_s_signed.hex
-    -intel
-
-  # Generate an intel hex file from the signed output binary
-  COMMAND ${SREC_CAT} ${CMAKE_BINARY_DIR}/zephyr_ns_signed.bin
-    -binary
-    -offset $<TARGET_PROPERTY:partition_manager,PM_APP_ADDRESS>
-    -o ${CMAKE_BINARY_DIR}/zephyr_ns_signed.hex
-    -intel
-)
-
-set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
-  ${CMAKE_BINARY_DIR}/tfm_s_signed.hex
-  ${CMAKE_BINARY_DIR}/zephyr_ns_signed.hex
-)

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.99-ncs1-rc1
+      revision: 7598e62f2e1a64191281f137ec553ed3017f1100
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -103,7 +103,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
-      revision: v1.2.99-ncs1-rc1
+      revision: 26a46ef5980f311169342bbb84dea927bd42724f
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
All the needed files are now created by the code in Zephyr
This removes the need for srec_cat.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>