### PR TITLE
Bluetooth: Mesh: manifest: Bluetooth bugfixes for v1.5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3b3f0c541cb4a8b1540e0f34a092fce47b95e141
+      revision: pull/457/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This adds a set of post-upmerge bugfix commits for the Bluetooth
subsystem.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>