### PR TITLE
samples: connectedhomeip: include CHIP as an NCS module

### DIFF
--- a/samples/connectedhomeip/light_bulb/CMakeLists.txt
+++ b/samples/connectedhomeip/light_bulb/CMakeLists.txt
@@ -6,13 +6,11 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-get_filename_component(CHIP_ROOT ../../../../modules/lib/connectedhomeip REALPATH)
-get_filename_component(COMMON_ROOT ../common REALPATH)
-
-list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/config/nrfconnect/chip-module)
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-light-bulb)
+
+set(COMMON_ROOT ${CMAKE_CURRENT_LIST_DIR}/../common)
 
 target_include_directories(app PRIVATE src ${COMMON_ROOT}/src)
 
@@ -27,21 +25,21 @@ target_sources(app PRIVATE
                ${COMMON_ROOT}/src/led_widget.cpp
                ${COMMON_ROOT}/src/nfc_widget.cpp
                ${COMMON_ROOT}/src/thread_util.cpp
-               ${CHIP_ROOT}/src/app/server/DataModelHandler.cpp
-               ${CHIP_ROOT}/src/app/reporting/reporting-default-configuration.cpp
-               ${CHIP_ROOT}/src/app/reporting/reporting.cpp
-               ${CHIP_ROOT}/src/app/util/af-event.cpp
-               ${CHIP_ROOT}/src/app/util/af-main-common.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-size.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-storage.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-table.cpp
-               ${CHIP_ROOT}/src/app/util/binding-table.cpp
-               ${CHIP_ROOT}/src/app/util/chip-message-send.cpp
-               ${CHIP_ROOT}/src/app/util/client-api.cpp
-               ${CHIP_ROOT}/src/app/util/ember-print.cpp
-               ${CHIP_ROOT}/src/app/util/message.cpp
-               ${CHIP_ROOT}/src/app/util/process-cluster-message.cpp
-               ${CHIP_ROOT}/src/app/util/process-global-message.cpp
-               ${CHIP_ROOT}/src/app/util/util.cpp
-               ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off.cpp
-               ${CHIP_ROOT}/src/app/clusters/level-control/level-control.cpp)
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/server/DataModelHandler.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/reporting/reporting-default-configuration.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/reporting/reporting.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/af-event.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/af-main-common.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/attribute-size.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/attribute-storage.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/attribute-table.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/binding-table.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/chip-message-send.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/client-api.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/ember-print.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/message.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/process-cluster-message.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/process-global-message.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/util.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/on-off-server/on-off.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/level-control/level-control.cpp)

--- a/samples/connectedhomeip/light_switch/CMakeLists.txt
+++ b/samples/connectedhomeip/light_switch/CMakeLists.txt
@@ -6,15 +6,13 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-get_filename_component(CHIP_ROOT ../../../../modules/lib/connectedhomeip REALPATH)
-get_filename_component(COMMON_ROOT ../common REALPATH)
-
-list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/config/nrfconnect/chip-module)
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-light-switch)
 
-target_include_directories(app PRIVATE src ${COMMON_ROOT}/src ${CHIP_ROOT}/src/app)
+set(COMMON_ROOT ${CMAKE_CURRENT_LIST_DIR}/../common)
+
+target_include_directories(app PRIVATE src ${COMMON_ROOT}/src ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app)
 
 target_compile_options(app PRIVATE -Wno-deprecated-declarations)
 

--- a/samples/connectedhomeip/lock/CMakeLists.txt
+++ b/samples/connectedhomeip/lock/CMakeLists.txt
@@ -6,13 +6,11 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-get_filename_component(CHIP_ROOT ../../../../modules/lib/connectedhomeip REALPATH)
-get_filename_component(COMMON_ROOT ../common REALPATH)
-
-list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/config/nrfconnect/chip-module)
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-lock)
+
+set(COMMON_ROOT ${CMAKE_CURRENT_LIST_DIR}/../common)
 
 target_include_directories(app PRIVATE src ${COMMON_ROOT}/src)
 
@@ -26,21 +24,21 @@ target_sources(app PRIVATE
                ${COMMON_ROOT}/src/led_widget.cpp
                ${COMMON_ROOT}/src/nfc_widget.cpp
                ${COMMON_ROOT}/src/thread_util.cpp
-               ${CHIP_ROOT}/src/app/reporting/reporting-default-configuration.cpp
-               ${CHIP_ROOT}/src/app/reporting/reporting.cpp
-               ${CHIP_ROOT}/src/app/server/DataModelHandler.cpp
-               ${CHIP_ROOT}/src/app/util/af-event.cpp
-               ${CHIP_ROOT}/src/app/util/af-main-common.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-size.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-storage.cpp
-               ${CHIP_ROOT}/src/app/util/attribute-table.cpp
-               ${CHIP_ROOT}/src/app/util/binding-table.cpp
-               ${CHIP_ROOT}/src/app/util/chip-message-send.cpp
-               ${CHIP_ROOT}/src/app/util/client-api.cpp
-               ${CHIP_ROOT}/src/app/util/ember-print.cpp
-               ${CHIP_ROOT}/src/app/util/message.cpp
-               ${CHIP_ROOT}/src/app/util/process-cluster-message.cpp
-               ${CHIP_ROOT}/src/app/util/process-global-message.cpp
-               ${CHIP_ROOT}/src/app/util/util.cpp
-               ${CHIP_ROOT}/src/app/clusters/bindings/bindings.cpp
-               ${CHIP_ROOT}/src/app/clusters/on-off-server/on-off.cpp)
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/reporting/reporting-default-configuration.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/reporting/reporting.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/server/DataModelHandler.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/af-event.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/af-main-common.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/attribute-size.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/attribute-storage.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/attribute-table.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/binding-table.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/chip-message-send.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/client-api.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/ember-print.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/message.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/process-cluster-message.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/process-global-message.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/util.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/bindings/bindings.cpp
+               ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/on-off-server/on-off.cpp)

--- a/west.yml
+++ b/west.yml
@@ -113,7 +113,7 @@ manifest:
     - name: connectedhomeip
       repo-path: sdk-connectedhomeip
       path: modules/lib/connectedhomeip
-      revision: 7a5431f00726a09051cf45689490de3d9cc43070
+      revision: 3e9c650c91cde7833586acb217fbb6c3ef6a95b0
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
So far, CHIP has been included in an NCS-based project as an out-of-tree Zephyr module to assure that it is possible to switch between NCS-supplied and standalone CHIP version.

Now that https://github.com/nrfconnect/sdk-zephyr/pull/436 has been merged, it is possible to override a module which is already on the list. Consequently, there is no harm in including the NCS-supplied CHIP automatically since applications are able to use an upstream CHIP revision if needed.

Note that the change was requested by @tejlmand as a followup to #3670.