### PR TITLE
zigbee: Add ZBOSS alarm unit test

### DIFF
--- a/tests/subsys/zigbee/zboss_api/alarm_api/CMakeLists.txt
+++ b/tests/subsys/zigbee/zboss_api/alarm_api/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(NONE)
+
+target_sources(app PRIVATE
+  src/main.c
+)

--- a/tests/subsys/zigbee/zboss_api/alarm_api/app.overlay
+++ b/tests/subsys/zigbee/zboss_api/alarm_api/app.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		zephyr,entropy = &rng;
+	};
+};

--- a/tests/subsys/zigbee/zboss_api/alarm_api/prj.conf
+++ b/tests/subsys/zigbee/zboss_api/alarm_api/prj.conf
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_ZTEST=y
+
+CONFIG_NCS_SAMPLES_DEFAULTS=y
+
+CONFIG_UART_INTERRUPT_DRIVEN=y
+CONFIG_SERIAL=y
+
+# Cryptocell does not work with ZTEST
+CONFIG_ENTROPY_CC3XX=n
+
+# Make sure printk is not printing to the UART console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+CONFIG_HEAP_MEM_POOL_SIZE=2048
+
+CONFIG_ZIGBEE=y
+CONFIG_ZIGBEE_APP_UTILS=y
+CONFIG_ZIGBEE_ROLE_COORDINATOR=y
+
+# This example requires more workqueue stack
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+# Enable nRF ECB driver
+CONFIG_CRYPTO=y
+CONFIG_CRYPTO_NRF_ECB=y
+
+#Networking
+CONFIG_NET_IPV6_MLD=n
+CONFIG_NET_IPV6_NBR_CACHE=n
+CONFIG_NET_IPV6_RA_RDNSS=n
+CONFIG_NET_IP_ADDR_CHECK=n
+CONFIG_NET_UDP=n

--- a/tests/subsys/zigbee/zboss_api/alarm_api/src/main.c
+++ b/tests/subsys/zigbee/zboss_api/alarm_api/src/main.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <ztest.h>
+#include <zephyr/types.h>
+#include <zephyr.h>
+
+#include <zboss_api.h>
+#include <zigbee/zigbee_app_utils.h>
+#include <zb_nrf_platform.h>
+
+
+#define STACKSIZE               1024
+#define PRIORITY                (CONFIG_ZBOSS_DEFAULT_THREAD_PRIORITY + 1)
+#define N_THREADS               4
+#define ZB_TIMER_PRECISION      ZB_TIME_BEACON_INTERVAL_TO_MSEC(2)
+
+#define IEEE_CHANNEL_MASK       (1l << CONFIG_ZIGBEE_CHANNEL)
+
+
+K_SEM_DEFINE(zboss_init_lock, 0, 1);
+static uint32_t zboss_signals_collected;
+
+/**@brief Zigbee stack event handler.
+ *
+ * @param[in]   bufid   Reference to the Zigbee stack buffer
+ *                      used to pass signal.
+ */
+void zboss_signal_handler(zb_bufid_t bufid)
+{
+	zb_zdo_app_signal_hdr_t *sg_p = NULL;
+	zb_zdo_app_signal_type_t sig = zb_get_app_signal(bufid, &sg_p);
+	zb_ret_t status = ZB_GET_APP_SIGNAL_STATUS(bufid);
+
+	/* Count received signals. */
+	zboss_signals_collected++;
+
+	switch (sig) {
+	case ZB_ZDO_SIGNAL_PRODUCTION_CONFIG_READY:
+		zassert_not_equal(status, RET_OK,
+			"Production configuration must not be present on erased device.");
+		break;
+
+	case ZB_COMMON_SIGNAL_CAN_SLEEP:
+		/* Enter poll so other tasks may be processed.
+		 * This should be the third and the last startup signal.
+		 */
+		k_sem_give(&zboss_init_lock);
+		zb_sleep_now();
+		break;
+
+	default:
+		zassert_equal(sig, ZB_ZDO_SIGNAL_SKIP_STARTUP,
+			"Unexpected signal received after zboss_start_no_autostart().");
+		break;
+	}
+
+	/* Free passed buffer to avoid buffer leaks. */
+	if (bufid) {
+		zb_buf_free(bufid);
+	}
+}
+
+void test_zboss_startup_signals(void)
+{
+	zboss_signals_collected = 0;
+
+	/*
+	 * The whole ZBOSS flash area needs to be erased,
+	 * so the timeout value has to be quite big.
+	 */
+	k_sem_take(&zboss_init_lock, K_MSEC(1000));
+
+	zassert_equal(zboss_signals_collected, 3,
+		"ZBOSS startup failed. Not all startup signals were collected.");
+}
+
+
+K_MSGQ_DEFINE(zb_callback_queue, sizeof(uint32_t), N_THREADS, 4);
+
+static void add_to_queue_from_callback(uint8_t int_to_put)
+{
+	static uint32_t ref_int[N_THREADS] = {0, 0, 0, 0};
+	int ret_val;
+
+	ref_int[int_to_put] = k_uptime_get_32();
+
+	ret_val = k_msgq_put(&zb_callback_queue,
+			     (void *)&ref_int[int_to_put],
+			     K_NO_WAIT);
+	__ASSERT(ret_val == 0, "Can not put data into the queue");
+}
+
+
+void thread_0(void)
+{
+	zigbee_schedule_alarm(add_to_queue_from_callback, 0,
+			      ZB_TIME_ONE_SECOND * 1);
+	while (1) {
+		k_sleep(K_MSEC(10));
+	}
+}
+
+void thread_1(void)
+{
+	zigbee_schedule_alarm(add_to_queue_from_callback, 1,
+			      ZB_TIME_ONE_SECOND * 2);
+	while (1) {
+		k_sleep(K_MSEC(10));
+	}
+}
+
+void thread_2(void)
+{
+	zigbee_schedule_alarm(add_to_queue_from_callback, 2,
+			      ZB_TIME_ONE_SECOND * 3);
+	while (1) {
+		k_sleep(K_MSEC(10));
+	}
+}
+
+void thread_3(void)
+{
+	zigbee_schedule_alarm(add_to_queue_from_callback, 3,
+			      ZB_TIME_ONE_SECOND * 4);
+	while (1) {
+		k_sleep(K_MSEC(10));
+	}
+}
+
+K_THREAD_DEFINE(THREAD_0, STACKSIZE, thread_0, NULL, NULL, NULL,
+		PRIORITY, 0, -1);
+
+K_THREAD_DEFINE(THREAD_1, STACKSIZE, thread_1, NULL, NULL, NULL,
+		PRIORITY, 0, -1);
+
+K_THREAD_DEFINE(THREAD_2, STACKSIZE, thread_2, NULL, NULL, NULL,
+		PRIORITY, 0, -1);
+
+K_THREAD_DEFINE(THREAD_3, STACKSIZE, thread_3, NULL, NULL, NULL,
+		PRIORITY, 0, -1);
+
+void test_zboss_app_alarm(void)
+{
+	k_tid_t thread_id_array[N_THREADS] = {THREAD_0, THREAD_1,
+					      THREAD_2, THREAD_3};
+	uint8_t expected_queue_usage_cnt = 0;
+	uint32_t alarm_times[N_THREADS] = {0};
+
+	for (uint8_t i = 0; i < ARRAY_SIZE(thread_id_array); i++) {
+		k_thread_start(thread_id_array[i]);
+		alarm_times[i] = k_uptime_get_32() + 1000 * (i + 1);
+
+		/* Wait for the ZBOSS alarm timeout time. */
+		k_sleep(K_MSEC(1000 * (i + 1)));
+		expected_queue_usage_cnt++;
+	}
+
+	/* Verify if all callbacks has fired. */
+	zassert_equal(
+		expected_queue_usage_cnt,
+		k_msgq_num_used_get(&zb_callback_queue),
+		"Some ZBOSS alarms has not fired within the timeout.");
+
+	for (uint8_t i = 0; i < ARRAY_SIZE(thread_id_array); i++) {
+		int data;
+		int err = k_msgq_get(&zb_callback_queue, &data, K_NO_WAIT);
+
+		zassert_equal(err, 0,
+			      "Unable to fetch all elements from the queue.");
+
+		zassert_within(data, alarm_times[i], ZB_TIMER_PRECISION,
+			      "Incorrect element found on the queue.");
+	}
+}
+
+void test_main(void)
+{
+	/* Erase NVRAM to have repeatability of test runs. */
+	zigbee_erase_persistent_storage(ZB_TRUE);
+
+	/* Start Zigbee default thread */
+	zigbee_enable();
+
+	ztest_test_suite(zboss_api_alarm,
+			 ztest_unit_test(test_zboss_startup_signals),
+			 ztest_unit_test(test_zboss_app_alarm));
+
+	ztest_run_test_suite(zboss_api_alarm);
+}

--- a/tests/subsys/zigbee/zboss_api/alarm_api/testcase.yaml
+++ b/tests/subsys/zigbee/zboss_api/alarm_api/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  zigbee.zboss_api.alarm_api:
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    tags: zboss_api_alarm


### PR DESCRIPTION
Add test that verifies if ZBOSS alarms fires after the specified period, within beacon-interval-based precision.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>