### PR TITLE
manifest: move homekit elsewhere

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -41,8 +41,6 @@ manifest:
   defaults:
     remote: ncs
 
-  group-filter: [-homekit]
-
   # "projects" is a list of git repositories which make up the NCS
   # source code.
   projects:
@@ -147,11 +145,6 @@ manifest:
       remote: nordicsemi
       revision: 24f1b2b0c64c694b7f9ac1b7eab60b39236ca0bf
       path: modules/lib/cddl-gen
-    - name: homekit
-      repo-path: sdk-homekit
-      revision: 8d68bb07b9217960767f7c5030ea9a4ec37af5df
-      groups:
-      - homekit
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
We originally anticipated users getting the homekit repository by
first enabling the homekit group, then running west update.

Unfortunately, this interacts badly with another recommended workflow,
which is getting NCS by setting up a custom user manifest and
importing nrf/west.yml, as documented in "Workflow 4: Application as
the manifest repository" in nrf/dm_adding_code.rst.

The reason why is that west states:

    "Only the top level manifest file’s manifest: group-filter: value
    has any effect. The manifest: group-filter: values in any imported
    manifests are ignored."

This means all users doing workflow 4 will have to manually deactivate
the homekit group before proceeding. This is not a good user
experience.

Until we can revise the west project group behavior so that both
workflows interoperate nicely, remove the homekit repository from the
main manifest file entirely, placing it in a separate manifest for
now.

To use homekit, users will need to do something like setting up
workflow 4, but also importing the homekit file, like this:

```yaml
   manifest:
     remotes:
       - name: ncs
         url-base: https://github.com/nrfconnect
     projects:
       - name: nrf
         repo-path: sdk-nrf
         remote: ncs
         revision: v1.5.0
         import:
           - west.yml
           - west-private/homekit.yaml
```

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>