### PR TITLE
samples: kconfig: select PARTITION_MANAGER_ENABLED when adding child …

### DIFF
--- a/samples/Kconfig
+++ b/samples/Kconfig
@@ -20,6 +20,7 @@ config NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE
 	bool "Enable empty_app_core as a child image"
 	default n
 	depends on SOC_NRF5340_CPUNET
+	select PARTITION_MANAGER_ENABLED
 	help
 	  Add the empty_app_core as a child image for the given sample.
 	  Used by samples that only require SOC_NRF5340_CPUNET.


### PR DESCRIPTION
…image

It is required that this kconfig option is set when adding a child image.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>