### PR TITLE
manifest: create a dedicated west-homekit.yml manifest file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,7 @@
 /README.rst                               @carlescufi
 /Jenkinsfile                              @thst-nordic
 /west.yml                                 @carlescufi @tejlmand
+/west-homekit.yml                         @carlescufi @tejlmand
 
 # Github Actions
 /.github/                                 @thst-nordic

--- a/west-homekit.yml
+++ b/west-homekit.yml
@@ -1,0 +1,52 @@
+# The west manifest file (west-homekit.yml) for the nRF Connect SDK (NCS)
+# including homekit repository.
+#
+# The per-workspace west configuration file, ncs/.west/config,
+# specifies the location of this manifest file like this:
+#
+#     [manifest]
+#     path = nrf
+#     file = west-homekit.yml
+#
+# See the west documentation for more information:
+#
+# https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/west/index.html
+
+manifest:
+  # This west.yml requires west 0.9 or later, because the "submodules"
+  # feature used below was introduced then.
+  version: 0.9
+
+  # "remotes" is a list of locations where git repositories are cloned
+  # and fetched from.
+  remotes:
+    # nRF Connect SDK GitHub organization.
+    # NCS repositories are hosted here.
+    - name: ncs
+      url-base: https://github.com/nrfconnect
+
+  # If not otherwise specified, the projects below should be obtained
+  # from the ncs remote.
+  defaults:
+    remote: ncs
+
+  group-filter: [+homekit]
+
+
+  # "projects" is a list of git repositories which make up the NCS with homekit
+  # source code.
+  projects:
+    - name: homekit
+      repo-path: sdk-homekit
+      revision: 8d68bb07b9217960767f7c5030ea9a4ec37af5df
+      groups:
+      - homekit
+
+  # West-related configuration for the nrf repository.
+  self:
+    # This repository should be cloned to ncs/nrf.
+    path: nrf
+    # This line configures west extensions which are currently only
+    # for internal use by NCS maintainers.
+    west-commands: scripts/west-commands.yml
+    import: west.yml

--- a/west.yml
+++ b/west.yml
@@ -41,8 +41,6 @@ manifest:
   defaults:
     remote: ncs
 
-  group-filter: [-homekit]
-
   # "projects" is a list of git repositories which make up the NCS
   # source code.
   projects:
@@ -147,11 +145,6 @@ manifest:
       remote: nordicsemi
       revision: 24f1b2b0c64c694b7f9ac1b7eab60b39236ca0bf
       path: modules/lib/cddl-gen
-    - name: homekit
-      repo-path: sdk-homekit
-      revision: 8d68bb07b9217960767f7c5030ea9a4ec37af5df
-      groups:
-      - homekit
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
The initial approach of specifying the homekit project in the existing
manifest file and locate that project in a private groups has turned
out to have unforeseen implication for non-homekit NCS users.

Therefore a dedicated NCS Homekit manifest file has been created as:
west-home.yml

This manifest contains only the homekit project and imports everything
else from the main NCS manifest file, west.yml.

To clone NCS with homekit, a user can do:
```
west init -m west init -m https://github.com/nrfconnect/sdk-nrf
          --mr <NCS_revision> --mf west-homekit.yml
```

a NCS user that already has a NCS west workspace and fetches the
latest NCS release can update to using the homekit manifest file by
running the following command after updating nrf repository:
```
west config manifest.file west-homekit.yml
west update
```

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>