### PR TITLE
samples: timeslot: Add nrf5340dk_nrf5340_cpunet to platform_allow

### DIFF
--- a/samples/mpsl/timeslot/sample.yaml
+++ b/samples/mpsl/timeslot/sample.yaml
@@ -5,5 +5,5 @@ tests:
   samples.mpsl.timeslot:
     build_only: true
     build_on_all: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpunet
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340pdk_nrf5340_cpunet nrf5340dk_nrf5340_cpunet
     tags: ci_build


### PR DESCRIPTION
Ensures the sample is built in CI.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>