### PR TITLE
tfm: Remove special RAM configuration for when modem is enabled

### DIFF
--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -135,7 +135,6 @@ if BUILD_WITH_TFM
 
 config PM_PARTITION_SIZE_TFM_SRAM
 	hex "Memory reserved for TFM_RAM."
-	default 0x10000 if NRF_MODEM_LIB
 	default 0x16000 if SOC_NRF9160
 	default 0x40000 if SOC_NRF5340_CPUAPP
 	help
@@ -153,17 +152,6 @@ partition=TFM_EXTRA
 partition-size=0x10000
 rsource "Kconfig.template.partition_size"
 
-if NRF_MODEM_LIB
-
-config TFM_PROFILE
-	string "The build profile used for TFM Secure image."
-	default "profile_small"
-	help
-	  Use profile_small when the modem is enabled to get the RAM usage below
-	  64 kB, so the Modem's IPC RAM area can fit at 0x10000.
-	  This overrides the default TFM_PROFILE.
-
-endif # TFM_PROFILE
 endif # BUILD_WITH_TFM
 
 config PM_IMAGE_NOT_BUILT_FROM_SOURCE


### PR DESCRIPTION
The new modem lib uses less RAM, so the default configuration of TFM
now works fine.

Ref: NCSDK-8184

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>