### PR TITLE
Revert PR #3793

### DIFF
--- a/drivers/entropy/CMakeLists.txt
+++ b/drivers/entropy/CMakeLists.txt
@@ -5,3 +5,15 @@
 #
 zephyr_library_amend()
 zephyr_library_sources_ifdef(CONFIG_ENTROPY_CC3XX entropy_cc310.c)
+
+# Link with the nrf_cc3xx_platform library if the following is met:
+# -nRF52840 device
+# -nRF9160/nRF53_CPUAPP device that is not using SPM
+# -nRF9150 device that is using SPM and in a secure image
+# -nRF53_CPUAPP device that is using SPM and in a secure image
+#  (CONFIG_SPM is not defined in a secure image)
+if (CONFIG_SOC_NRF52840 OR
+   (CONFIG_SOC_NRF9160 AND (NOT CONFIG_SPM)) OR
+   (CONFIG_SOC_NRF5340_CPUAPP AND (NOT CONFIG_SPM)))
+  zephyr_link_libraries_ifdef(CONFIG_ENTROPY_CC3XX platform_cc3xx)
+endif ()

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -6,7 +6,7 @@
 
 config ENTROPY_CC3XX
 	bool "Arm CC3XX RNG driver for Nordic devices"
-	depends on HW_CC3XX || (SOC_NRF9160 && (SPM || BUILD_WITH_TFM)) || (SOC_NRF5340_CPUAPP && (SPM || BUILD_WITH_TFM))
+	depends on HW_CC3XX || (SOC_NRF9160 && SPM) || (SOC_NRF5340_CPUAPP && SPM)
 	depends on ENTROPY_GENERATOR
 	select ENTROPY_HAS_DRIVER
 	default y

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -9,7 +9,6 @@ config ENTROPY_CC3XX
 	depends on HW_CC3XX || (SOC_NRF9160 && (SPM || BUILD_WITH_TFM)) || (SOC_NRF5340_CPUAPP && (SPM || BUILD_WITH_TFM))
 	depends on ENTROPY_GENERATOR
 	select ENTROPY_HAS_DRIVER
-	select NRF_CC3XX_MBEDCRYPTO if HW_CC3XX
 	default y
 	help
 	  This option enables the Arm CC3xx RNG devices in nRF52840, nRF5340, and nRF9160

--- a/drivers/entropy/entropy_cc310.c
+++ b/drivers/entropy/entropy_cc310.c
@@ -16,10 +16,6 @@
 
 #if defined(CONFIG_SPM)
 #include "secure_services.h"
-#elif defined(CONFIG_BUILD_WITH_TFM)
-#include <psa/crypto.h>
-#include <psa/crypto_extra.h>
-#include <tfm_ns_interface.h>
 #else
 #include "nrf_cc3xx_platform_ctr_drbg.h"
 
@@ -39,14 +35,6 @@ static int entropy_cc3xx_rng_get_entropy(
 	__ASSERT_NO_MSG(buffer != NULL);
 
 
-#if defined(CONFIG_BUILD_WITH_TFM)
-
-	res = psa_generate_random(buffer, length);
-	if (res != PSA_SUCCESS) {
-		return -EINVAL;
-	}
-
-#else
 	size_t olen;
 	size_t offset = 0;
 	size_t chunk_size = CTR_DRBG_MAX_REQUEST;
@@ -90,7 +78,6 @@ static int entropy_cc3xx_rng_get_entropy(
 
 		offset += chunk_size;
 	}
-#endif
 
 	return res;
 }
@@ -99,21 +86,7 @@ static int entropy_cc3xx_rng_init(const struct device *dev)
 {
 	(void)dev;
 
-	#if defined(CONFIG_BUILD_WITH_TFM)
-		int ret = -1;
-		enum tfm_status_e tfm_status;
-
-		tfm_status = tfm_ns_interface_init();
-		if (tfm_status != TFM_SUCCESS) {
-			return -EINVAL;
-		}
-
-		ret = psa_crypto_init();
-		if (ret != PSA_SUCCESS) {
-			return -EINVAL;
-		}
-
-	#elif !defined(CONFIG_SPM)
+	#if !defined(CONFIG_SPM)
 		int ret = 0;
 
 		ret = nrf_cc3xx_platform_ctr_drbg_init(&ctr_drbg_ctx, NULL, 0);

--- a/include/secure_services.h
+++ b/include/secure_services.h
@@ -58,13 +58,18 @@ void spm_request_system_reboot(void);
 
 /** Request a random number from the Secure Firmware.
  *
- * This provides a CTR_DRBG number from the CC3XX platform libraries.
+ * This provides a True Random Number from the on-board random number generator.
  *
- * @param[out] output  The CTR_DRBG number. Must be at least @c len long.
- * @param[in]  len     The length of the output array.
+ * @note Currently, the RNG hardware is run each time this is called. This
+ *       spends significant time and power.
+ *
+ * @param[out] output  The random number. Must be at least @c len long.
+ * @param[in]  len     The length of the output array. Currently, @c len must be
+ *                     144.
  * @param[out] olen    The length of the random number provided.
  *
- * @return non-negative on success, negative errno code on fail
+ * @retval 0        If successful.
+ * @retval -EINVAL  If @c len is invalid. Currently, @c len must be 144.
  */
 int spm_request_random_number(uint8_t *output, size_t len, size_t *olen);
 

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -29,7 +29,7 @@ if IS_SPM
 # Unable to use the size template due to non-trivial defaults.
 config PM_PARTITION_SIZE_SPM
 	hex "Flash space reserved for SPM"
-	default 0x10000 if SPM_SERVICE_RNG # To build correctly with MCUboot.
+	default 0xc000 if SPM_SERVICE_RNG # To build correctly with MCUboot.
 	default 0x8000
 	help
 	  Flash space set aside for the SPM. Note, the name

--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.5.0-rc1
+      revision: ab6988f3659405cd5dc8201f77417430c9644497
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
This reverts #3793. It was merged without CI run and breaks most of BLE tests.