### PR TITLE
treewide: Fix license SPDX tags

### DIFF
--- a/doc/update_versions.cmake
+++ b/doc/update_versions.cmake
@@ -1,5 +1,5 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 foreach(file ${TOOLS_VERSION_FILES})
   file(STRINGS ${file} VERSIONS_ALL REGEX "^[a-zA-Z0-9_-]*=.*")

--- a/lib/nrf_modem_lib/shmem_sanity.c
+++ b/lib/nrf_modem_lib/shmem_sanity.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <toolchain.h>

--- a/modules/cddl-gen/CMakeLists.txt
+++ b/modules/cddl-gen/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 if(NOT CONFIG_CDDL_GEN)

--- a/modules/cddl-gen/Kconfig
+++ b/modules/cddl-gen/Kconfig
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 config CDDL_GEN

--- a/tests/modules/lib/cddl-gen/CMakeLists.txt
+++ b/tests/modules/lib/cddl-gen/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 cmake_minimum_required(VERSION 3.13.1)

--- a/tests/modules/lib/cddl-gen/prj.conf
+++ b/tests/modules/lib/cddl-gen/prj.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 CONFIG_ZTEST=y
 CONFIG_CDDL_GEN=y

--- a/tests/modules/lib/cddl-gen/src/main.c
+++ b/tests/modules/lib/cddl-gen/src/main.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #include <ztest.h>
 #include "test_encode.h"

--- a/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160.conf
+++ b/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160ns.conf
+++ b/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160ns.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 # Disable this since we write our own mock for 'spm_s0_active()'

--- a/tests/subsys/net/lib/fota_download/boards/qemu_x86.conf
+++ b/tests/subsys/net/lib/fota_download/boards/qemu_x86.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 CONFIG_FLASH_SIMULATOR=y

--- a/tests/subsys/spm/secure_services/CMakeLists.txt
+++ b/tests/subsys/spm/secure_services/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 cmake_minimum_required(VERSION 3.13.1)

--- a/tests/subsys/spm/secure_services/prj.conf
+++ b/tests/subsys/spm/secure_services/prj.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 CONFIG_ZTEST=y

--- a/tests/subsys/spm/secure_services/src/main.c
+++ b/tests/subsys/spm/secure_services/src/main.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <ztest.h>


### PR DESCRIPTION
Fix SPDX tags in files that fell through the cracks on the previous
cleanup.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>