### PR TITLE
kconfig: imply spm_s0_active secure service

### DIFF
--- a/subsys/net/lib/fota_download/Kconfig
+++ b/subsys/net/lib/fota_download/Kconfig
@@ -8,6 +8,7 @@ menuconfig FOTA_DOWNLOAD
 	bool "FOTA Download"
 	depends on DOWNLOAD_CLIENT
 	depends on DFU_TARGET
+	imply SPM_SERVICE_S0_ACTIVE
 
 if (FOTA_DOWNLOAD)
 


### PR DESCRIPTION
fota download uses this function when it is avaliable.

Ref: NCSDK-8231
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>