### PR TITLE
mcuboot: kconfig: add option for signature key file

### DIFF
--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -1,6 +1,19 @@
 config SIGN_IMAGES
 	bool "Sign images for MCUBoot"
 	default y
+	depends on MCUBOOT_BUILD_STRATEGY_FROM_SOURCE \
+		   || BOOT_SIGNATURE_KEY_FILE != ""
 	help
 	  Sign images for MCUBoot as integrated part of the build stages using
 	  the private key.
+
+config BOOT_SIGNATURE_KEY_FILE
+	string "MCUBoot PEM key file"
+	depends on !MCUBOOT_BUILD_STRATEGY_FROM_SOURCE
+	help
+	  Absolute path to PEM key file containing the private key corresponding
+	  to the public key included in MCUBoot. This will be used to sign the
+	  image so that it can be verified by MCUBoot. Since MCUBoot is not
+	  built from source, it is not possible for the build system to deduce
+	  what key was used when compiling it. Hence, it is required that the
+	  key is passed to the build system through this option.


### PR DESCRIPTION
If MCUBoot is not build from source, there is currently no way to
inform the build system about what key file should be used for
signing the application hex file. As a result of this, it is
currently not possible to build applications which enable MCUBoot
without building MCUBoot from source, as opposed to skipping
its build (if it is already programmed to the flash memory of
the device) or merging the application hex file with the MCUBoot
hex file.

This commit fixes this issue by adding a duplicate of the
BOOT_SIGNATURE_KEY_FILE kconfig option which is visible for the
application.

Note that this duplicate is only visible if the build strategy
used for MCUBoot indicates that MCUBoot is not built from source.

Ref: NCSDK-6859
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>