### PR TITLE
samples: clock: use on-off-manager for clock init

### DIFF
--- a/samples/esb/prx/src/main.c
+++ b/samples/esb/prx/src/main.c
@@ -18,8 +18,6 @@ LOG_MODULE_REGISTER(esb_prx, CONFIG_ESB_PRX_APP_LOG_LEVEL);
 #define LED_ON 0
 #define LED_OFF 1
 
-#define DT_DRV_COMPAT nordic_nrf_clock
-
 static const struct device *led_port;
 static struct esb_payload rx_payload;
 static struct esb_payload tx_payload = ESB_CREATE_PAYLOAD(0,
@@ -107,26 +105,31 @@ void event_handler(struct esb_evt const *event)
 int clocks_start(void)
 {
 	int err;
-	const struct device *clk;
+	int res;
+	struct onoff_manager *clk_mgr;
+	struct onoff_client clk_cli;
 
-	clk = device_get_binding(DT_INST_LABEL(0));
-	if (!clk) {
-		LOG_ERR("Clock device not found!");
-		return -EIO;
+	clk_mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
+	if (!clk_mgr) {
+		LOG_ERR("Unable to get the Clock manager");
+		return -ENXIO;
 	}
 
-	err = clock_control_on(clk, CLOCK_CONTROL_NRF_SUBSYS_HF);
-	if (err && (err != -EINPROGRESS)) {
-		LOG_ERR("HF clock start fail: %d", err);
+	sys_notify_init_spinwait(&clk_cli.notify);
+
+	err = onoff_request(clk_mgr, &clk_cli);
+	if (err < 0) {
+		LOG_ERR("Clock request failed: %d", err);
 		return err;
 	}
 
-	/* Block until clock is started.
-	 */
-	while (clock_control_get_status(clk, CLOCK_CONTROL_NRF_SUBSYS_HF) !=
-		CLOCK_CONTROL_STATUS_ON) {
-
-	}
+	do {
+		err = sys_notify_fetch_result(&clk_cli.notify, &res);
+		if (!err && res) {
+			LOG_ERR("Clock could not be started: %d", res);
+			return res;
+		}
+	} while (err);
 
 	LOG_DBG("HF clock started");
 	return 0;


### PR DESCRIPTION
When the sample is configured to be used with LFRC:

```
CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
CONFIG_CLOCK_CONTROL_NRF_K32SRC_500PPM=y
```

The function clock_control_on(clock, CLOCK_CONTROL_NRF_SUBSYS_HF) will fail and return -EPERM.
The HFXO is being requested to turn off by the LFRC calibration driver when calibration is not on-going, so any code that needs the HFXO, e.g. to use the RADIO, needs to use the on-off service to request the HFXO.

All samples that require HFCLK for radio operations are refactored to use the Zephyr On-off Manager module to prevent the issue described above.