### PR TITLE
net: lib: nrf_cloud: allow modem re-init by app after fota

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -36,6 +36,8 @@ nRF9160
 
     * Added cell-based location support to :ref:`lib_nrf_cloud_agps`.
     * Added Kconfig option :option:`CONFIG_NRF_CLOUD_AGPS_SINGLE_CELL_ONLY` to obtain cell-based location from nRF Connect for Cloud instead of using the modem's GPS.
+    * Added function :c:func:`nrf_cloud_modem_fota_completed` which is to be called by the application after it re-initializes the modem (instead of rebooting) after a modem FOTA update.
+    * Updated to include the FOTA type value in the :c:enumerator:`NRF_CLOUD_EVT_FOTA_DONE` event.
 
   * :ref:`asset_tracker` application:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -120,6 +120,20 @@ enum nrf_cloud_topic_type {
 	NRF_CLOUD_TOPIC_MESSAGE,
 };
 
+/**@brief FOTA update type. */
+enum nrf_cloud_fota_type {
+	NRF_CLOUD_FOTA_TYPE__FIRST = 0,
+
+	/** Application update. */
+	NRF_CLOUD_FOTA_APPLICATION = NRF_CLOUD_FOTA_TYPE__FIRST,
+	/** Modem update. */
+	NRF_CLOUD_FOTA_MODEM = 1,
+	/** Bootloader update. */
+	NRF_CLOUD_FOTA_BOOTLOADER = 2,
+
+	NRF_CLOUD_FOTA_TYPE__INVALID
+};
+
 /**@brief Generic encapsulation for any data that is sent to the cloud. */
 struct nrf_cloud_data {
 	/** Length of the data. */
@@ -315,6 +329,18 @@ int nrf_cloud_disconnect(void);
  * functional.
  */
 void nrf_cloud_process(void);
+
+/**
+ * @brief The application has handled re-init after a modem FOTA update and the
+ *        LTE link has been re-established.
+ *        This function must be called in order to complete the modem update.
+ *
+ * @param[in] fota_success true if modem update was successful, false otherwise.
+ *
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int nrf_cloud_modem_fota_completed(const bool fota_success);
 
 /** @} */
 

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_fota.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_fota.h
@@ -8,25 +8,12 @@
 #define NRF_CLOUD_FOTA_H__
 
 #include <net/mqtt.h>
+#include <net/nrf_cloud.h>
 #include <bluetooth/bluetooth.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**@brief FOTA update type. */
-enum nrf_cloud_fota_type {
-	NRF_CLOUD_FOTA_TYPE__FIRST = 0,
-
-	/** Application update. */
-	NRF_CLOUD_FOTA_APPLICATION = NRF_CLOUD_FOTA_TYPE__FIRST,
-	/** Modem update. */
-	NRF_CLOUD_FOTA_MODEM = 1,
-	/** Bootloader update. */
-	NRF_CLOUD_FOTA_BOOTLOADER = 2,
-
-	NRF_CLOUD_FOTA_TYPE__INVALID
-};
 
 /**@brief FOTA status reported to nRF Cloud. */
 enum nrf_cloud_fota_status {

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -128,7 +128,7 @@ int nct_keepalive_time_left(void);
 int nct_input(const struct nct_evt *evt);
 
 /**@brief Signal to apply FOTA update. */
-void nct_apply_update(void);
+void nct_apply_update(const struct nrf_cloud_evt * const evt);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -318,13 +318,9 @@ int nct_input(const struct nct_evt *evt)
 	return nfsm_handle_incoming_event(evt, current_state);
 }
 
-void nct_apply_update(void)
+void nct_apply_update(const struct nrf_cloud_evt * const evt)
 {
-	static const struct nrf_cloud_evt evt = {
-		.type = NRF_CLOUD_EVT_FOTA_DONE
-	};
-
-	app_event_handler(&evt);
+	app_event_handler(evt);
 }
 
 void nrf_cloud_process(void)
@@ -589,6 +585,8 @@ static void api_event_handler(const struct nrf_cloud_evt *nrf_cloud_evt)
 		LOG_DBG("NRF_CLOUD_EVT_FOTA_DONE");
 
 		evt.type = CLOUD_EVT_FOTA_DONE;
+		evt.data.msg.buf = (char *)nrf_cloud_evt->data.ptr;
+		evt.data.msg.len = nrf_cloud_evt->data.len;
 
 		cloud_notify_event(nrf_cloud_backend, &evt, config->user_data);
 		break;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -117,6 +117,7 @@ static int save_validate_status(const char *const job_id,
 			   const enum fota_validate_status status);
 static int fota_settings_set(const char *key, size_t len_rd,
 			     settings_read_cb read_cb, void *cb_arg);
+static int report_validated_job_status(void);
 
 static struct mqtt_client *client_mqtt;
 static nrf_cloud_fota_callback_t event_cb;
@@ -283,6 +284,22 @@ int nrf_cloud_fota_init(nrf_cloud_fota_callback_t cb)
 	return ret;
 }
 
+int nrf_cloud_modem_fota_completed(const bool fota_success)
+{
+	if (saved_job.type != NRF_CLOUD_FOTA_MODEM ||
+	    saved_job.validate != NRF_CLOUD_FOTA_VALIDATE_PENDING) {
+		return -EOPNOTSUPP;
+	}
+
+	cleanup_job(&current_fota);
+
+	/* Failure to save settings here is not critical, ignore return */
+	(void)save_validate_status(saved_job.id, saved_job.type,
+		fota_success ? NRF_CLOUD_FOTA_VALIDATE_PASS : NRF_CLOUD_FOTA_VALIDATE_FAIL);
+
+	return report_validated_job_status();
+}
+
 static void reset_topic(struct mqtt_utf8 *const topic)
 {
 	if (!topic) {
@@ -342,6 +359,50 @@ static int build_topic(const char *const client_id,
 	return 0;
 }
 
+static int report_validated_job_status(void)
+{
+	int ret = 0;
+
+	if (saved_job.type == NRF_CLOUD_FOTA_TYPE__INVALID) {
+		return 1;
+	}
+
+	struct nrf_cloud_fota_job job = {
+		.info = {
+			.type = saved_job.type,
+			.id = saved_job.id
+		}
+	};
+
+	switch (saved_job.validate) {
+	case NRF_CLOUD_FOTA_VALIDATE_UNKNOWN:
+		job.error = NRF_CLOUD_FOTA_ERROR_UNABLE_TO_VALIDATE;
+		/* fall-through */
+	case NRF_CLOUD_FOTA_VALIDATE_PASS:
+		job.status = NRF_CLOUD_FOTA_SUCCEEDED;
+		break;
+	case NRF_CLOUD_FOTA_VALIDATE_FAIL:
+		job.status = NRF_CLOUD_FOTA_FAILED;
+		break;
+	default:
+		LOG_ERR("Unexpected job validation status: %d",
+			saved_job.validate);
+		ret = save_validate_status(job.info.id, job.info.type,
+					   NRF_CLOUD_FOTA_VALIDATE_DONE);
+		job.info.type = NRF_CLOUD_FOTA_TYPE__INVALID;
+		break;
+	}
+
+	if (job.info.type != NRF_CLOUD_FOTA_TYPE__INVALID) {
+		ret = send_job_update(&job);
+		if (ret) {
+			LOG_ERR("Error sending job update: %d", ret);
+		}
+	}
+
+	return ret;
+}
+
 int nrf_cloud_fota_endpoint_set_and_report(struct mqtt_client *const client,
 	const char *const client_id, const struct mqtt_utf8 *const endpoint)
 {
@@ -352,41 +413,10 @@ int nrf_cloud_fota_endpoint_set_and_report(struct mqtt_client *const client,
 		return ret;
 	}
 
-	/* Report status of saved job now that the endpoint is available */
-	if (saved_job.type != NRF_CLOUD_FOTA_TYPE__INVALID) {
-
-		struct nrf_cloud_fota_job job = {
-			.info = {
-				.type = saved_job.type,
-				.id = saved_job.id
-			}
-		};
-
-		switch (saved_job.validate) {
-		case NRF_CLOUD_FOTA_VALIDATE_UNKNOWN:
-			job.error = NRF_CLOUD_FOTA_ERROR_UNABLE_TO_VALIDATE;
-			/* fall-through */
-		case NRF_CLOUD_FOTA_VALIDATE_PASS:
-			job.status = NRF_CLOUD_FOTA_SUCCEEDED;
-			break;
-		case NRF_CLOUD_FOTA_VALIDATE_FAIL:
-			job.status = NRF_CLOUD_FOTA_FAILED;
-			break;
-		default:
-			LOG_ERR("Unexpected job validation status: %d",
-				saved_job.validate);
-			save_validate_status(job.info.id, job.info.type,
-					     NRF_CLOUD_FOTA_VALIDATE_DONE);
-			job.info.type = NRF_CLOUD_FOTA_TYPE__INVALID;
-			break;
-		}
-
-		if (job.info.type != NRF_CLOUD_FOTA_TYPE__INVALID) {
-			ret = send_job_update(&job);
-			if (ret) {
-				LOG_ERR("Error sending job update: %d", ret);
-			}
-		}
+	ret = report_validated_job_status();
+	/* Positive value indicates no job exists, ignore */
+	if (ret > 0) {
+		ret = 0;
 	}
 
 	return ret;
@@ -1168,9 +1198,12 @@ int nrf_cloud_fota_mqtt_evt_handler(const struct mqtt_evt *evt)
 					NRF_CLOUD_FOTA_VALIDATE_DONE);
 			break;
 		case NRF_CLOUD_FOTA_VALIDATE_PENDING:
-			/* this event should cause reboot */
+			/* This event should cause reboot or modem-reinit.
+			 * Do not cleanup the job since a reboot should
+			 * occur or the user will call:
+			 * nrf_cloud_modem_fota_completed()
+			 */
 			send_event(NRF_CLOUD_FOTA_EVT_DONE, &current_fota);
-			cleanup_job(&current_fota);
 			break;
 		default:
 			break;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -556,8 +556,23 @@ static void nrf_cloud_fota_cb_handler(const struct nrf_cloud_fota_evt
 		break;
 	}
 	case NRF_CLOUD_FOTA_EVT_DONE: {
+		enum nrf_cloud_fota_type fota_type;
+		struct nrf_cloud_evt cloud_evt = {
+			.type = NRF_CLOUD_EVT_FOTA_DONE,
+		};
+
 		LOG_DBG("NRF_CLOUD_FOTA_EVT_DONE: rebooting");
-		nct_apply_update();
+
+		if (evt) {
+			fota_type = evt->type;
+			cloud_evt.data.ptr = &fota_type;
+			cloud_evt.data.len = sizeof(fota_type);
+		} else {
+			cloud_evt.data.ptr = NULL;
+			cloud_evt.data.len = 0;
+		}
+
+		nct_apply_update(&cloud_evt);
 		break;
 	}
 	case NRF_CLOUD_FOTA_EVT_ERROR: {


### PR DESCRIPTION
Provide mechanism so that the application can optionally re-init the modem after a modem fota instead of rebooting.

CIA-175