### PR TITLE
test: fota_download: disable qemu_x86 test variant

### DIFF
--- a/tests/subsys/net/lib/fota_download/testcase.yaml
+++ b/tests/subsys/net/lib/fota_download/testcase.yaml
@@ -2,7 +2,3 @@ tests:
   net.lib.fota_download:
     tags: aws fota
     platform_allow: nrf9160dk_nrf9160 nrf9160dk_nrf9160ns
-  net.lib.fota_download_build_only:
-    tags: aws fota
-    build_only: true
-    platform_allow: qemu_x86


### PR DESCRIPTION
This test can never be executed on qemu, so there is no point
in having a test which ensures that you can build it for that
board.

Ref: NCSDK-8245

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>