### PR TITLE
applications: serial_lte_modem: BUG-FIX unsupported FTP command

### DIFF
--- a/applications/serial_lte_modem/doc/FTP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FTP_AT_commands.rst
@@ -38,7 +38,6 @@ The ``<cmd>`` command is a string, and can be used as follows:
 * ``AT#XFTP="ls"[,<options>[,<folder or file>]]``
 * ``AT#XFTP="mkdir",<folder>``
 * ``AT#XFTP="rmdir",<folder>``
-* ``AT#XFTP="info",<file>``
 * ``AT#XFTP="rename",<filename_old>,<filename_new>``
 * ``AT#XFTP="delete",<file>``
 * ``AT#XFTP="get",<file>``

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -38,7 +38,6 @@ enum slm_ftp_operation {
 	FTP_OP_STATUS,
 	FTP_OP_ASCII,
 	FTP_OP_BINARY,
-	FTP_OP_CLEAR,
 	/* FTP Directory Operation */
 	FTP_OP_PWD,
 	FTP_OP_LS,


### PR DESCRIPTION
Old code was left when CLEAR command support was removed.
Remove FTP_OP_CLEAR from code.
Remove "info" from doc.

JIRA reference: NCSIDB-379

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>