### PR TITLE
zigbee: Update ZBOSS libraries to v3.5.0.0+1.0.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ab6988f3659405cd5dc8201f77417430c9644497
+      revision: 984e6f9b9c5b124c94caff52807c9d5c66eacb60
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Update west.yml entry to use the updated ZBOSS libraries.
Only the set of development libraries are updated by this change.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>