### PR TITLE
esb: enable BLE 2 mbps bitrate on nRF53.

### DIFF
--- a/include/esb.h
+++ b/include/esb.h
@@ -127,7 +127,7 @@ enum esb_bitrate {
 #endif
 	/** 1 Mb radio mode using @e Bluetooth low energy radio parameters. */
 	ESB_BITRATE_1MBPS_BLE = RADIO_MODE_MODE_Ble_1Mbit,
-#if defined(CONFIG_SOC_SERIES_NRF52X)
+#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_NRF5340_CPUNET)
 	/** 2 Mb radio mode using @e Bluetooth low energy radio parameters. */
 	ESB_BITRATE_2MBPS_BLE = 4,
 #endif

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -356,7 +356,7 @@ static bool update_radio_bitrate(void)
 
 	switch (esb_cfg.bitrate) {
 	case ESB_BITRATE_2MBPS:
-#ifdef CONFIG_SOC_SERIES_NRF52X
+#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_NRF5340_CPUNET)
 	case ESB_BITRATE_2MBPS_BLE:
 #endif
 		wait_for_ack_timeout_us = RX_ACK_TIMEOUT_US_2MBPS;


### PR DESCRIPTION
Quick bugfix for enabling the BLE 2 mbps bitrate.