### PR TITLE
spm: set certain peripherals to secure by default

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -254,7 +254,11 @@ config SPM_NRF_DPPIC_NS
 if SOC_NRF5340_CPUAPP
 config SPM_NRF_DCNF_NS
 	bool "DCNF is Non-Secure"
-	default y
+	default n
+
+config SPM_NRF_CTRLAP_NS
+	bool "CTRLAP is Non-Secure"
+	default n
 
 config SPM_NRF_OSCILLATORS_NS
 	bool "Oscillators is Non-Secure"
@@ -262,10 +266,6 @@ config SPM_NRF_OSCILLATORS_NS
 
 config SPM_NRF_RESET_NS
 	bool "Reset is Non-Secure"
-	default y
-
-config SPM_NRF_CTRLAP_NS
-	bool "CTRLAP is Non-Secure"
 	default y
 
 config SPM_NRF_SPIM4_NS


### PR DESCRIPTION
Changed the NRF_DCNF and NRF_CTRLAP peripherals to be secure by default
due to potential configuration mismatch that can arise when they are
non-secure. They are still configurable by the developer. This is a small revision of #3802.

Signed-off-by: Carl Richard Steen Fosse carl.fosse@nordicsemi.no