### PR TITLE
scripts: remove west from documentation requirements

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,6 +1,5 @@
 recommonmark==0.6.0
 CommonMark>=0.9.1
 sphinxcontrib-mscgen
-west>=0.7.2
 sphinx-ncs-theme==0.6.2
 pygments>=2.7.0


### PR DESCRIPTION
Remove west from the list of documentation dependencies. It is already
defined in requirements-base.txt, and it seems to be causing errors on some `pip` versions (20.0.2 confirmed):

```
➜  nrf git:(master) pip3 --version                                 
pip 20.0.2 from /usr/lib/python3/dist-packages/pip (python 3.8)
➜  nrf git:(master) pip3 install --user -r scripts/requirements.txt
ERROR: Double requirement given: west>=0.7.2 (from -r scripts/requirements-doc.txt (line 4)) (already in west>=0.9.0 (from -r scripts/requirements-base.txt (line 1)), name='west')
```

Note that it does not seem to happen on `pip==21.0.1`.
