### PR TITLE
Bluetooth: Mesh: Sensor fixes

### DIFF
--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -95,8 +95,6 @@ enum bt_mesh_sensor_delta {
 	 *  old value (resolution: 0.01 %).
 	 */
 	BT_MESH_SENSOR_DELTA_PERCENT,
-	/** Delta threshold is disabled. */
-	BT_MESH_SENSOR_DELTA_DISABLED,
 };
 
 /** Sensor sampling cadence */

--- a/subsys/bluetooth/mesh/sensor.c
+++ b/subsys/bluetooth/mesh/sensor.c
@@ -431,6 +431,10 @@ int sensor_cadence_encode(struct net_buf_simple *buf,
 		return err;
 	}
 
+	if (min_int > BT_MESH_SENSOR_INTERVAL_MAX) {
+		return -EINVAL;
+	}
+
 	net_buf_simple_add_u8(buf, min_int);
 
 	/* Flip the order if the cadence is fast outside. */

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -833,6 +833,8 @@ static int sensor_srv_init(struct bt_mesh_model *mod)
 		min_id = best->type->id + 1;
 	}
 
+	srv->seq = 1;
+
 	srv->model = mod;
 
 	srv->pub.update = update_handler;


### PR DESCRIPTION
This PR fixes:
- Setting minimum interval outside of allowed values on the Sensor Client.
- Skipping the first publication on the Sensor Server.