### PR TITLE
dfu_target_mcuboot: ensure that pointer to file is in RAM

### DIFF
--- a/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
@@ -19,6 +19,7 @@
 #include <zephyr.h>
 #include <pm_config.h>
 #include <logging/log.h>
+#include <nrfx.h>
 #include <dfu/mcuboot.h>
 #include <dfu/dfu_target.h>
 #include <dfu/dfu_target_stream.h>
@@ -37,11 +38,18 @@ int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active,
 				const char **update)
 {
 	if (file == NULL || update == NULL) {
+		LOG_ERR("Got NULL pointer");
 		return -EINVAL;
+	}
+
+	if (!nrfx_is_in_ram(file)) {
+		LOG_ERR("'file' pointer is not located in RAM");
+		return -EFAULT;
 	}
 
 	/* Ensure that 'file' is null-terminated. */
 	if (strnlen(file, MAX_FILE_SEARCH_LEN) == MAX_FILE_SEARCH_LEN) {
+		LOG_ERR("Input is not null terminated");
 		return -ENOTSUP;
 	}
 

--- a/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
@@ -20,6 +20,8 @@ char buf[1024];
 #define S0_S1 "s0 s1"
 #define NO_SPACE "s0s1"
 
+const char *flash_ptr = S0_S1;
+
 static void test_dfu_ctx_mcuboot_set_b1_file(void)
 {
 	int err;
@@ -38,6 +40,17 @@ static void test_dfu_ctx_mcuboot_set_b1_file(void)
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp("s0", update) == 0, NULL);
 }
+
+static void test_dfu_ctx_mcuboot_set_b1_file__ptr_placement(void)
+{
+	int err;
+	const char *update;
+	bool s0_active = true;
+
+	err = dfu_ctx_mcuboot_set_b1_file(flash_ptr, s0_active, &update);
+	zassert_true(err != 0, "Did not fail when given flash pointer");
+}
+
 
 static void test_dfu_ctx_mcuboot_set_b1_file__no_separator(void)
 {
@@ -84,14 +97,16 @@ static void test_dfu_ctx_mcuboot_set_b1_file__empty(void)
 	int err;
 	const char *update;
 	bool s0_active = true;
+	char empty[] = "";
 
-	err = dfu_ctx_mcuboot_set_b1_file("", s0_active, &update);
+	err = dfu_ctx_mcuboot_set_b1_file(empty, s0_active, &update);
 	zassert_true(update == NULL, "update should not be set");
 }
 
 void test_main(void)
 {
 	ztest_test_suite(lib_dfu_target_mcuboot_test,
+	     ztest_unit_test(test_dfu_ctx_mcuboot_set_b1_file__ptr_placement),
 	     ztest_unit_test(test_dfu_ctx_mcuboot_set_b1_file__no_separator),
 	     ztest_unit_test(test_dfu_ctx_mcuboot_set_b1_file__null),
 	     ztest_unit_test(test_dfu_ctx_mcuboot_set_b1_file__not_terminated),

--- a/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   dfu.dfu_target_mcuboot:
     tags: dfu mcuboot
+    # nrfx is used to ensure that variables are stored in RAM, so no qemu.
+    platform_exclude: qemu_cortex_m3 qemu_x86


### PR DESCRIPTION
This is needed so that a null-terminator can be injected
into the file argument to select the first part of the
space separated list.

Ref: NCSDK-6809
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>