### PR TITLE
tests: unity: Add support for custom suite tear down

### DIFF
--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -29,7 +29,7 @@ zephyr_library_sources(
 	${CMOCK_DIR}/src/cmock.c
 )
 
-zephyr_library_sources_ifdef(CONFIG_BOARD_NATIVE_POSIX src/native_posix.c)
+zephyr_library_sources(src/generic_teardown.c)
 zephyr_compile_definitions(UNITY_INCLUDE_CONFIG_H)
 
 # Generate test runner file.
@@ -43,9 +43,9 @@ function(test_runner_generate test_file_path)
   add_custom_command(
     COMMAND ${RUBY_EXECUTABLE}
     ${CMOCK_DIR}/vendor/unity/auto/generate_test_runner.rb
-    --main_name=unity_main
+    ${UNITY_CONFIG_FILE}
     ${test_file_path} ${output_file}
-    DEPENDS ${test_file_path}
+    DEPENDS ${test_file_path} ${UNITY_CONFIG_FILE}
     OUTPUT ${output_file}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )

--- a/tests/unity/example_test/src/example_test.c
+++ b/tests/unity/example_test/src/example_test.c
@@ -17,6 +17,14 @@ void setUp(void)
 	runtime_CONFIG_UUT_PARAM_CHECK = false;
 }
 
+/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
+extern int generic_suiteTearDown(int num_failures);
+
+int test_suiteTearDown(int num_failures)
+{
+	return generic_suiteTearDown(num_failures);
+}
+
 void test_uut_init(void)
 {
 	int err;

--- a/tests/unity/src/generic_teardown.c
+++ b/tests/unity/src/generic_teardown.c
@@ -9,21 +9,34 @@
  * @brief Additional Unity support code for the native_posix board.
  */
 #include <zephyr.h>
+#ifdef CONFIG_BOARD_NATIVE_POSIX
 #include "posix_board_if.h"
+#endif
 
-int suiteTearDown(int num_failures)
+/** @brief A generic suite teardown which implements platform specific tear down. */
+int generic_suiteTearDown(int num_failures)
 {
+	int ret = num_failures > 0 ? 1 : 0;
 	/* Sanitycheck bases the result of native_posix based unit tests on the
 	 * output:
 	 */
 	printk("PROJECT EXECUTION %s\n",
 	       num_failures == 0 ? "SUCCESSFUL" : "FAILED");
 
+#ifdef CONFIG_BOARD_NATIVE_POSIX
 	/* The native posix board will loop forever after leaving the runner's
 	 * main, so we have to explicitly call exit() to terminate the test.
 	 */
-	posix_exit(num_failures > 0 ? 1 : 0);
+	posix_exit(ret);
 
 	/* Should be unreachable: */
 	return 1;
+#endif
+
+	return ret;
+}
+
+__weak int test_suiteTearDown(int num_failures)
+{
+	return generic_suiteTearDown(num_failures);
 }

--- a/tests/unity/unity_cfg.yaml
+++ b/tests/unity/unity_cfg.yaml
@@ -30,3 +30,8 @@
         'uint32_t': 'HEX32'
         'int64_t': 'INT64'
         'uint64_t': 'HEX64'
+
+:unity:
+    :suite_teardown: >
+       extern int test_suiteTearDown(int); return test_suiteTearDown(num_failures);
+    :main_name: unity_main


### PR DESCRIPTION
 It may be necessary to call platform specific suite tear down function and there was no solution for case when user would like to call test specific suite tear down. Extended unity framework to support that case.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>
