### PR TITLE
net: lib: aws_fota: Fix issues with reciving multiple notify-next

### DIFF
--- a/subsys/net/lib/aws_fota/Kconfig
+++ b/subsys/net/lib/aws_fota/Kconfig
@@ -11,6 +11,10 @@ menuconfig AWS_FOTA
 
 if AWS_FOTA
 
+config AWS_FOTA_UPDATE_TIMEOUT
+	int "Max amount of time in seconds to wait for a document update response"
+	default 60
+
 config AWS_FOTA_PAYLOAD_SIZE
 	int "MQTT payload reception buffer size for AWS IoT Jobs messages"
 	default 1350


### PR DESCRIPTION
When entering PSM the network will cache TCP packets. This lead to
multiple notify-next messages being sent when the device was in PSM as
the MQTT ack was never recived so the server would do retrasmission.

To combat this we check what state we are in when we receive a
notify-next topic so that we won't accept it and break the download.

Addition to this we add a timeout on accepted so that things running in
the same context won't be blocked forever.

Ref: NCSDK-8251

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>