### PR TITLE
manifest: update Zephyr with OT radio assert fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7598e62f2e1a64191281f137ec553ed3017f1100
+      revision: a637ffe254a0c1eee90ef859cc4efbf36c8a984c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Manifest update with new Zephyr adding fix for OpenThread radio assert issue.

KRKNWK-8998

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>