### PR TITLE
manifest: update manifest to use Zephyr with OpenThread fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.4.99-ncs1-rc1
+      revision: pull/464/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
See more:
https://github.com/openthread/openthread/pull/6175

This fixes the issue reported here:
https://devzone.nordicsemi.com/f/nordic-q-a/71586/
ses-ncs-seem-to-build-ok-but-throws-error-starting-process-echo/294588

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>