### PR TITLE
applications: asset_tracker_v2: Remove broker hostname default string

### DIFF
--- a/applications/asset_tracker_v2/prj.conf
+++ b/applications/asset_tracker_v2/prj.conf
@@ -54,7 +54,7 @@ CONFIG_AWS_FOTA=y
 
 ## AWS IoT options that must be configured.
 CONFIG_AWS_IOT_SEC_TAG=42
-CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
+CONFIG_AWS_IOT_BROKER_HOST_NAME=""
 
 # MQTT
 # Keepalive should be set to the maximum specified MQTT keepalive timeout of the

--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -5,4 +5,6 @@ tests:
     build_only: true
     build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
+    extra_configs:
+      - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
     tags: ci_build


### PR DESCRIPTION
Remove the default broker hostname string from the prj.conf. This will
cause the application to not build due to an assert statement in
AWS IoT. This is to give the user a strong indication that this config
must be set to the appropriate hostname, which is also reflected in the
documentation.