### PR TITLE
net: lib: aws_iot: Include check for MQTT_CLEAN_SESSION flag

### DIFF
--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -689,7 +689,8 @@ static void mqtt_evt_handler(struct mqtt_client *const c,
 		aws_iot_evt.type = AWS_IOT_EVT_CONNECTED;
 		aws_iot_notify_event(&aws_iot_evt);
 
-		if (!mqtt_evt->param.connack.session_present_flag) {
+		if (!mqtt_evt->param.connack.session_present_flag ||
+		    IS_ENABLED(CONFIG_MQTT_CLEAN_SESSION)) {
 			err = topic_subscribe();
 
 			if (err < 0) {


### PR DESCRIPTION
Check if MQTT_CLEAN_SESSION has been set upon a received CONNACK from
the MQTT broker. If this is the case we always want to subscribe to
topics, even though the persistent session flag has been enabled by
the broker. This config was previously not correctly reflected where the
client subscribed to topics solely based on the incoming persistent
session flag. Which could happen even though MQTT_CLEAN_SESSION was
enabled.