### PR TITLE
manifest: update sdk-connectedhomeip for Android fix

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -81,14 +81,14 @@
 
 .. _`SMP over Bluetooth`: https://github.com/apache/mynewt-mcumgr/blob/master/transport/smp-bluetooth.md
 
-.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/00ac05/src/android/CHIPTool
-.. _`Commissioning nRF Connect Accessory using Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/00ac05/docs/guides/nrfconnect_android_commissioning.md
-.. _`Building and programming OpenThread RCP firmware`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/00ac05/docs/guides/nrfconnect_android_commissioning.md#building-rcp-firmware
-.. _`Building and installing Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/00ac05/docs/guides/nrfconnect_android_commissioning.md#building-chiptool
-.. _`Configuring PC as Thread Border Router`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/00ac05/docs/guides/nrfconnect_android_commissioning.md#configuring-pc
-.. _`Preparing and commissioning accessory device`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/00ac05/docs/guides/nrfconnect_android_commissioning.md#preparing-accessory
-.. _`CHIP Protocol Overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/00ac05/README.md
-.. _`nRF Connect platform overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/00ac05/docs/guides/nrfconnect_platform_overview.md
+.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/c73b8e0/src/android/CHIPTool
+.. _`Commissioning nRF Connect Accessory using Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/c73b8e0/docs/guides/nrfconnect_android_commissioning.md
+.. _`Building and programming OpenThread RCP firmware`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/c73b8e0/docs/guides/nrfconnect_android_commissioning.md#building-rcp-firmware
+.. _`Building and installing Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/c73b8e0/docs/guides/nrfconnect_android_commissioning.md#building-chiptool
+.. _`Configuring PC as Thread Border Router`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/c73b8e0/docs/guides/nrfconnect_android_commissioning.md#configuring-pc
+.. _`Preparing and commissioning accessory device`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/c73b8e0/docs/guides/nrfconnect_android_commissioning.md#preparing-accessory
+.. _`CHIP Protocol Overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/c73b8e0/README.md
+.. _`nRF Connect platform overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/c73b8e0/docs/guides/nrfconnect_platform_overview.md
 
 .. ### Source: developer.nordicsemi.com
 

--- a/west.yml
+++ b/west.yml
@@ -111,7 +111,7 @@ manifest:
     - name: connectedhomeip
       repo-path: sdk-connectedhomeip
       path: modules/lib/connectedhomeip
-      revision: 00ac05f5fd880aad6acf332b198353696b9ddf9e
+      revision: c73b8e0ada5b38b0b9fdb73b582b09b62f242b60
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Bump revision of the sdk-connectedhomeip to allow controlling of newly
commissioned devices.

The change does affect only Android tool, there are no changes in the firmware.

Signed-off-by: Lukasz Duda <lukasz.duda@nordicsemi.no>