### PR TITLE
Disable TLS session caching for AWS IoT and Azure IoT Hub

### DIFF
--- a/subsys/net/lib/aws_iot/Kconfig
+++ b/subsys/net/lib/aws_iot/Kconfig
@@ -106,10 +106,6 @@ config AWS_IOT_CONNECTION_POLL_THREAD
 	bool "Enable polling on MQTT socket in AWS IoT backend"
 	default y
 
-config AWS_IOT_TLS_SESSION_CACHING
-	bool "Enable TLS session caching"
-	default y
-
 module=AWS_IOT
 module-dep=LOG
 module-str=AWS IoT

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -975,15 +975,9 @@ static int client_broker_init(struct mqtt_client *const client)
 	tls_cfg->sec_tag_count		= ARRAY_SIZE(sec_tag_list);
 	tls_cfg->sec_tag_list		= sec_tag_list;
 	tls_cfg->hostname		= CONFIG_AWS_IOT_BROKER_HOST_NAME;
-
-#if defined(CONFIG_NRF_MODEM_LIB)
-	tls_cfg->session_cache		=
-		IS_ENABLED(CONFIG_AWS_IOT_TLS_SESSION_CACHING) ?
-			TLS_SESSION_CACHE_ENABLED : TLS_SESSION_CACHE_DISABLED;
-#else
-	/* TLS session caching is not supported by the Zephyr network stack */
 	tls_cfg->session_cache = TLS_SESSION_CACHE_DISABLED;
 
+#if !defined(CONFIG_NRF_MODEM_LIB)
 	err = certificates_provision();
 	if (err) {
 		LOG_ERR("Could not provision certificates, error: %d", err);

--- a/subsys/net/lib/azure_iot_hub/Kconfig
+++ b/subsys/net/lib/azure_iot_hub/Kconfig
@@ -34,10 +34,6 @@ config AZURE_IOT_HUB_PORT
 	int "Azure IoT Hub port"
 	default 8883
 
-config AZURE_IOT_HUB_TLS_SESSION_CACHING
-	bool "Enable TLS session caching"
-	default y
-
 config AZURE_IOT_HUB_MQTT_RX_TX_BUFFER_LEN
 	int "Buffer sizes for the MQTT library"
 	default 256

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -846,15 +846,9 @@ static int client_broker_init(struct mqtt_client *const client, bool dps)
 	tls_cfg->cipher_list		= NULL; /* Use default */
 	tls_cfg->sec_tag_count		= ARRAY_SIZE(sec_tag_list);
 	tls_cfg->sec_tag_list		= sec_tag_list;
+	tls_cfg->session_cache		= TLS_SESSION_CACHE_DISABLED;
 
-#if defined(CONFIG_NRF_MODEM_LIB)
-	tls_cfg->session_cache		=
-		IS_ENABLED(CONFIG_AZURE_IOT_HUB_TLS_SESSION_CACHING) ?
-			TLS_SESSION_CACHE_ENABLED : TLS_SESSION_CACHE_DISABLED;
-#else
-	/* TLS session caching is not supported by the Zephyr network stack */
-	tls_cfg->session_cache = TLS_SESSION_CACHE_DISABLED;
-
+#if !defined(CONFIG_NRF_MODEM_LIB)
 	err = certificates_provision();
 	if (err) {
 		LOG_ERR("Could not provision certificates, error: %d", err);


### PR DESCRIPTION
Having TLS session caching enabled may cause issues when using
nRF9160 modem firmware version 1.1.x. As session caching is
currently not supported by AWS IoT and Azure IoT Hub, the expected behavior
is the same also with session caching disabled.

Fixes NCSDK-8298