### PR TITLE
applications: asset_tracker_v2: Replace deprecated configuration

### DIFF
--- a/applications/asset_tracker_v2/prj.conf
+++ b/applications/asset_tracker_v2/prj.conf
@@ -24,8 +24,8 @@ CONFIG_LOG_IMMEDIATE=y
 # DK - Used for buttons and LEDs in UI module.
 CONFIG_DK_LIBRARY_INVERT_LEDS=n
 
-# BSD library
-CONFIG_BSD_LIBRARY=y
+# nRF modem library
+CONFIG_NRF_MODEM_LIB=y
 
 # Network
 CONFIG_NETWORKING=y


### PR DESCRIPTION
CONFIG_BSD_LIBRARY is deprecated, replace with CONFIG_NRF_MODEM_LIB.