### PR TITLE
applications: asset_tracker_v2: Align and add shutdown states to modules

### DIFF
--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -50,7 +50,8 @@ struct app_msg_data {
 /* Application module super states. */
 static enum state_type {
 	STATE_INIT,
-	STATE_RUNNING
+	STATE_RUNNING,
+	STATE_SHUTDOWN
 } state;
 
 /* Application sub states. The application can be in either active or passive
@@ -111,6 +112,8 @@ static char *state2str(enum state_type new_state)
 		return "STATE_INIT";
 	case STATE_RUNNING:
 		return "STATE_RUNNING";
+	case STATE_SHUTDOWN:
+		return "STATE_SHUTDOWN";
 	default:
 		return "Unknown";
 	}
@@ -421,6 +424,7 @@ static void on_all_events(struct app_msg_data *msg)
 		k_timer_stop(&movement_resolution_timer);
 
 		SEND_EVENT(app, APP_EVT_SHUTDOWN_READY);
+		state_set(STATE_SHUTDOWN);
 	}
 }
 
@@ -473,6 +477,9 @@ void main(void)
 			}
 
 			on_state_running(&msg);
+			break;
+		case STATE_SHUTDOWN:
+			/* The shutdown state has no transition. */
 			break;
 		default:
 			LOG_WRN("Unknown application state");

--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -44,7 +44,8 @@ struct cloud_msg_data {
 /* Cloud module super states. */
 static enum state_type {
 	STATE_LTE_DISCONNECTED,
-	STATE_LTE_CONNECTED
+	STATE_LTE_CONNECTED,
+	STATE_SHUTDOWN
 } state;
 
 /* Cloud module sub states. */
@@ -99,6 +100,8 @@ static char *state2str(enum state_type state)
 		return "STATE_LTE_DISCONNECTED";
 	case STATE_LTE_CONNECTED:
 		return "STATE_LTE_CONNECTED";
+	case STATE_SHUTDOWN:
+		return "STATE_SHUTDOWN";
 	default:
 		return "Unknown";
 	}
@@ -560,7 +563,11 @@ static void on_sub_state_cloud_disconnected(struct cloud_msg_data *msg)
 static void on_all_states(struct cloud_msg_data *msg)
 {
 	if (IS_EVENT(msg, util, UTIL_EVT_SHUTDOWN_REQUEST)) {
+		/* The module doesn't have anything to shut down and can
+		 * report back immediately.
+		 */
 		SEND_EVENT(cloud, CLOUD_EVT_SHUTDOWN_READY);
+		state_set(STATE_SHUTDOWN);
 	}
 
 	if (is_data_module_event(&msg->module.data.header)) {
@@ -617,6 +624,9 @@ static void module_thread_fn(void)
 			break;
 		case STATE_LTE_DISCONNECTED:
 			on_state_lte_disconnected(&msg);
+			break;
+		case STATE_SHUTDOWN:
+			/* The shutdown state has no transition. */
 			break;
 		default:
 			LOG_ERR("Unknown Cloud module state.");

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -58,7 +58,8 @@ struct data_msg_data {
 /* Data module super states. */
 static enum state_type {
 	STATE_CLOUD_DISCONNECTED,
-	STATE_CLOUD_CONNECTED
+	STATE_CLOUD_CONNECTED,
+	STATE_SHUTDOWN
 } state;
 
 /* Ringbuffers. All data received by the Data module are stored in ringbuffers.
@@ -165,6 +166,8 @@ static char *state2str(enum state_type new_state)
 		return "STATE_CLOUD_DISCONNECTED";
 	case STATE_CLOUD_CONNECTED:
 		return "STATE_CLOUD_CONNECTED";
+	case STATE_SHUTDOWN:
+		return "STATE_SHUTDOWN";
 	default:
 		return "Unknown";
 	}
@@ -856,6 +859,7 @@ static void on_all_states(struct data_msg_data *msg)
 		 * report back immediately.
 		 */
 		SEND_EVENT(data, DATA_EVT_SHUTDOWN_READY);
+		state_set(STATE_SHUTDOWN);
 	}
 
 	if (IS_EVENT(msg, app, APP_EVT_DATA_GET)) {
@@ -1049,6 +1053,9 @@ static void module_thread_fn(void)
 			break;
 		case STATE_CLOUD_CONNECTED:
 			on_cloud_state_connected(&msg);
+			break;
+		case STATE_SHUTDOWN:
+			/* The shutdown state has no transition. */
 			break;
 		default:
 			LOG_WRN("Unknown sub state.");

--- a/applications/asset_tracker_v2/src/modules/gps_module.c
+++ b/applications/asset_tracker_v2/src/modules/gps_module.c
@@ -39,7 +39,8 @@ struct gps_msg_data {
 /* GPS module super states. */
 static enum state_type {
 	STATE_INIT,
-	STATE_RUNNING
+	STATE_RUNNING,
+	STATE_SHUTDOWN
 } state;
 
 /* GPS module sub states. */
@@ -78,6 +79,8 @@ static char *state2str(enum state_type new_state)
 		return "STATE_INIT";
 	case STATE_RUNNING:
 		return "STATE_RUNNING";
+	case STATE_SHUTDOWN:
+		return "STATE_SHUTDOWN";
 	default:
 		return "Unknown";
 	}
@@ -378,7 +381,11 @@ static void on_all_states(struct gps_msg_data *msg)
 	}
 
 	if (IS_EVENT(msg, util, UTIL_EVT_SHUTDOWN_REQUEST)) {
+		/* The module doesn't have anything to shut down and can
+		 * report back immediately.
+		 */
 		SEND_EVENT(gps, GPS_EVT_SHUTDOWN_READY);
+		state_set(STATE_SHUTDOWN);
 	}
 }
 
@@ -402,6 +409,9 @@ static void message_handler(struct gps_msg_data *msg)
 		}
 
 		on_state_running(msg);
+		break;
+	case STATE_SHUTDOWN:
+		/* The shutdown state has no transition. */
 		break;
 	default:
 		LOG_ERR("Unknown GPS module state.");

--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -41,7 +41,7 @@ static enum state_type {
 	STATE_DISCONNECTED,
 	STATE_CONNECTING,
 	STATE_CONNECTED,
-	STATE_SHUTTING_DOWN,
+	STATE_SHUTDOWN,
 } state;
 
 /* Struct that holds data from the modem information module. */
@@ -78,8 +78,8 @@ static char *state2str(enum state_type state)
 		return "STATE_CONNECTING";
 	case STATE_CONNECTED:
 		return "STATE_CONNECTED";
-	case STATE_SHUTTING_DOWN:
-		return "STATE_SHUTTING_DOWN";
+	case STATE_SHUTDOWN:
+		return "STATE_SHUTDOWN";
 	default:
 		return "Unknown state";
 	}
@@ -608,7 +608,7 @@ static void on_all_states(struct modem_msg_data *msg)
 
 	if (IS_EVENT(msg, util, UTIL_EVT_SHUTDOWN_REQUEST)) {
 		lte_lc_power_off();
-		state_set(STATE_SHUTTING_DOWN);
+		state_set(STATE_SHUTDOWN);
 		SEND_EVENT(modem, MODEM_EVT_SHUTDOWN_READY);
 	}
 }
@@ -643,8 +643,8 @@ static void module_thread_fn(void)
 		case STATE_CONNECTED:
 			on_state_connected(&msg);
 			break;
-		case STATE_SHUTTING_DOWN:
-			LOG_WRN("No action allowed in STATE_SHUTTING_DOWN");
+		case STATE_SHUTDOWN:
+			/* The shutdown state has no transition. */
 			break;
 		default:
 			LOG_WRN("Invalid state: %d", state);

--- a/applications/asset_tracker_v2/src/modules/ui_module.c
+++ b/applications/asset_tracker_v2/src/modules/ui_module.c
@@ -39,7 +39,7 @@ struct ui_msg_data {
 static enum state_type {
 	STATE_ACTIVE,
 	STATE_PASSIVE,
-	STATE_ERROR
+	STATE_SHUTDOWN
 } state;
 
 /* UI module sub states. */
@@ -91,8 +91,8 @@ static char *state2str(enum state_type new_state)
 		return "STATE_ACTIVE";
 	case STATE_PASSIVE:
 		return "STATE_PASSIVE";
-	case STATE_ERROR:
-		return "STATE_ERROR";
+	case STATE_SHUTDOWN:
+		return "STATE_SHUTDOWN";
 	default:
 		return "Unknown";
 	}
@@ -369,10 +369,8 @@ static void on_all_states(struct ui_msg_data *msg)
 
 	if (IS_EVENT(msg, util, UTIL_EVT_SHUTDOWN_REQUEST)) {
 		update_led_pattern(LED_ERROR_SYSTEM_FAULT);
-
-		state_set(STATE_ERROR);
-
 		SEND_EVENT(ui, UI_EVT_SHUTDOWN_READY);
+		state_set(STATE_SHUTDOWN);
 	}
 
 	if (IS_EVENT(msg, modem, MODEM_EVT_LTE_CONNECTING)) {
@@ -415,8 +413,8 @@ static void message_handler(struct ui_msg_data *msg)
 			break;
 		}
 		break;
-	case STATE_ERROR:
-		/* The error state has no transition. */
+	case STATE_SHUTDOWN:
+		/* The shutdown state has no transition. */
 		break;
 	default:
 		LOG_WRN("Unknown ui module state.");


### PR DESCRIPTION
Add shutdown states to modules. This prevents modules from handling
new events and queued events after an error has occurred.

This fixed the issue where an error would cause undefined behavior
across modules depending on the module shutdown order. This could give
a false impression of where the application failed in the first place.
The log would also get bloated with a lot of unnecessary error logs not
necessarily related to the original point of failure.