### PR TITLE
manifest: nrf_modem: release 1.0.1

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -21,7 +21,6 @@
 #include <sockets_internal.h>
 #include <sys/fdtable.h>
 #include <zephyr.h>
-#include <nrf_gai_errors.h>
 
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
 
@@ -415,20 +414,16 @@ static int z_to_nrf_protocol(int proto)
 static int nrf_to_z_dns_error_code(int nrf_error)
 {
 	switch (nrf_error) {
-	case NRF_EAI_AGAIN:
-		return DNS_EAI_AGAIN;
-	case NRF_EAI_BADFLAGS:
-		return DNS_EAI_BADFLAGS;
-	case NRF_EAI_FAMILY:
-		return DNS_EAI_FAMILY;
-	case NRF_EAI_MEMORY:
+	case NRF_ENOMEM:
 		return DNS_EAI_MEMORY;
-	case NRF_EAI_NONAME:
+	case NRF_EAGAIN:
+		return DNS_EAI_AGAIN;
+	case NRF_EAFNOSUPPORT:
 		return DNS_EAI_NONAME;
-	case NRF_EAI_SERVICE:
-		return DNS_EAI_SERVICE;
-	case NRF_EAI_SOCKTYPE:
-		return DNS_EAI_SOCKTYPE;
+	case NRF_EINPROGRESS:
+		return DNS_EAI_INPROGRESS;
+	case NRF_ENETUNREACH:
+		errno = ENETUNREACH;
 	default:
 		return DNS_EAI_SYSTEM;
 	}

--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ae04cb1410bb9e66a3b5c77c3c86e5a0afabdf5e
+      revision: 720c420d9fa796452d27b26b159ec05b9017c05e
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
This version reverts the new `nrf_getaddrinfo()` behavior introduced
in v1.0.0 due to compatibility issues with the Carrier library.