### PR TITLE
west.yml: update sdk-zephyr to fix Windows build

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d6d0ffde53a88d6de834e07dceac47af8f7687a3
+      revision: e81a613c5e587589b69475db92e416ec62f2dd03
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The change introduces a fix for too long build paths on Windows.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>