### PR TITLE
applications: asset_tracker_v2: Do not reboot on AWS FOTA failure.

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1446,6 +1446,8 @@ void cloud_event_handler(const struct cloud_backend *const backend,
 	case CLOUD_EVT_PAIR_DONE:
 		LOG_INF("CLOUD_EVT_PAIR_DONE");
 		on_pairing_done();
+	case CLOUD_EVT_FOTA_ERROR:
+		LOG_INF("CLOUD_EVT_FOTA_ERROR");
 		break;
 	case CLOUD_EVT_FOTA_DONE:
 		LOG_INF("CLOUD_EVT_FOTA_DONE");

--- a/applications/asset_tracker_v2/src/cloud/aws_iot_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/aws_iot_integration.c
@@ -143,9 +143,15 @@ void aws_iot_event_handler(const struct aws_iot_evt *const evt)
 	case AWS_IOT_EVT_FOTA_DL_PROGRESS:
 		/* Dont spam FOTA progress events. */
 		break;
+	case AWS_IOT_EVT_FOTA_ERROR:
+		LOG_DBG("AWS_IOT_EVT_FOTA_ERROR");
+		cloud_wrap_evt.type = CLOUD_WRAP_EVT_FOTA_ERROR;
+		notify = true;
+		break;
 	case AWS_IOT_EVT_ERROR:
 		LOG_DBG("AWS_IOT_EVT_ERROR");
 		cloud_wrap_evt.type = CLOUD_WRAP_EVT_ERROR;
+		cloud_wrap_evt.err = evt->data.err;
 		notify = true;
 		break;
 	default:

--- a/applications/asset_tracker_v2/src/cloud/cloud_wrapper.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_wrapper.h
@@ -25,6 +25,8 @@ enum cloud_wrap_event_type {
 	CLOUD_WRAP_EVT_FOTA_ERASE_PENDING,
 	/** Image erase done. */
 	CLOUD_WRAP_EVT_FOTA_ERASE_DONE,
+	/** An error occurred during FOTA. */
+	CLOUD_WRAP_EVT_FOTA_ERROR,
 	/** Irrecoverable error has occurred in the cloud integration layer. */
 	CLOUD_WRAP_EVT_ERROR,
 

--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -272,6 +272,9 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 	case CLOUD_WRAP_EVT_FOTA_ERASE_DONE:
 		LOG_DBG("CLOUD_WRAP_EVT_FOTA_ERASE_DONE");
 		break;
+	case CLOUD_WRAP_EVT_FOTA_ERROR:
+		LOG_DBG("CLOUD_WRAP_EVT_FOTA_ERROR");
+		break;
 	case CLOUD_WRAP_EVT_ERROR: {
 		LOG_DBG("CLOUD_WRAP_EVT_ERROR");
 		SEND_ERROR(cloud, CLOUD_EVT_ERROR, evt->err);

--- a/include/net/aws_iot.h
+++ b/include/net/aws_iot.h
@@ -98,7 +98,12 @@ enum aws_iot_evt_type {
 	AWS_IOT_EVT_FOTA_ERASE_DONE,
 	/** FOTA progress notification. */
 	AWS_IOT_EVT_FOTA_DL_PROGRESS,
-	/** AWS IoT library error. */
+	/** FOTA error. Used to propagate FOTA-related errors to the
+	 *  application. This is to distinguish between AWS_IOT irrecoverable
+	 *  errors and FOTA errors, so they can be handled differently.
+	 */
+	AWS_IOT_EVT_FOTA_ERROR,
+	/** AWS IoT library irrecoverable error. */
 	AWS_IOT_EVT_ERROR
 };
 

--- a/include/net/cloud.h
+++ b/include/net/cloud.h
@@ -48,6 +48,8 @@ enum cloud_event_type {
 	CLOUD_EVT_FOTA_ERASE_DONE,
 	/** FOTA download progress event. */
 	CLOUD_EVT_FOTA_DL_PROGRESS,
+	/** FOTA error. */
+	CLOUD_EVT_FOTA_ERROR,
 
 	CLOUD_EVT_COUNT
 };

--- a/samples/nrf9160/agps/src/main.c
+++ b/samples/nrf9160/agps/src/main.c
@@ -165,6 +165,9 @@ static void cloud_event_handler(const struct cloud_backend *const backend,
 	case CLOUD_EVT_FOTA_DONE:
 		LOG_INF("CLOUD_EVT_FOTA_DONE");
 		break;
+	case CLOUD_EVT_FOTA_ERROR:
+		LOG_INF("CLOUD_EVT_FOTA_ERROR");
+		break;
 	default:
 		LOG_INF("Unknown cloud event type: %d", evt->type);
 		break;

--- a/samples/nrf9160/aws_iot/src/main.c
+++ b/samples/nrf9160/aws_iot/src/main.c
@@ -306,6 +306,9 @@ void aws_iot_event_handler(const struct aws_iot_evt *const evt)
 	case AWS_IOT_EVT_ERROR:
 		printk("AWS_IOT_EVT_ERROR, %d\n", evt->data.err);
 		break;
+	case AWS_IOT_EVT_FOTA_ERROR:
+		printk("AWS_IOT_EVT_FOTA_ERROR");
+		break;
 	default:
 		printk("Unknown AWS IoT event type: %d\n", evt->type);
 		break;

--- a/samples/nrf9160/cloud_client/src/main.c
+++ b/samples/nrf9160/cloud_client/src/main.c
@@ -137,6 +137,9 @@ void cloud_event_handler(const struct cloud_backend *const backend,
 	case CLOUD_EVT_FOTA_DONE:
 		LOG_INF("CLOUD_EVT_FOTA_DONE");
 		break;
+	case CLOUD_EVT_FOTA_ERROR:
+		LOG_INF("CLOUD_EVT_FOTA_ERROR");
+		break;
 	default:
 		LOG_INF("Unknown cloud event type: %d", evt->type);
 		break;

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -281,6 +281,8 @@ static void aws_iot_notify_event(const struct aws_iot_evt *aws_iot_evt)
 	case AWS_IOT_EVT_ERROR:
 		cloud_evt.data.err = aws_iot_evt->data.err;
 		cloud_evt.type = CLOUD_EVT_ERROR;
+	case AWS_IOT_EVT_FOTA_ERROR:
+		cloud_evt.type = CLOUD_EVT_FOTA_ERROR;
 		break;
 	case AWS_IOT_EVT_FOTA_DL_PROGRESS:
 		cloud_evt.type = CLOUD_EVT_FOTA_DL_PROGRESS;
@@ -330,7 +332,7 @@ static void aws_fota_cb_handler(struct aws_fota_event *fota_evt)
 		break;
 	case AWS_FOTA_EVT_ERROR:
 		LOG_ERR("AWS_FOTA_EVT_ERROR");
-		aws_iot_evt.type = AWS_IOT_EVT_ERROR;
+		aws_iot_evt.type = AWS_IOT_EVT_FOTA_ERROR;
 		break;
 	case AWS_FOTA_EVT_DL_PROGRESS:
 		LOG_DBG("AWS_FOTA_EVT_DL_PROGRESS, (%d%%)",

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_cloud_api.c
@@ -95,6 +95,10 @@ static void api_event_handler(struct azure_iot_hub_evt *evt)
 		cloud_evt.type = CLOUD_EVT_FOTA_ERASE_DONE;
 		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
 				   config->user_data);
+	case AZURE_IOT_HUB_EVT_FOTA_ERROR:
+		cloud_evt.type = CLOUD_EVT_FOTA_ERROR;
+		cloud_notify_event(azure_iot_hub_backend, &cloud_evt,
+				   config->user_data);
 		break;
 	case AZURE_IOT_HUB_EVT_ERROR:
 		cloud_evt.type = CLOUD_EVT_ERROR;


### PR DESCRIPTION
Incorporate the event AWS_IOT_EVT_FOTA_ERROR for errors related to FOTA.
If AWS FOTA fails we do not want to reboot the device. Reboots are
energy and data usage intensive operations that should be avoided if
possible.

Closes [CIA-238]