### PR TITLE
Bluetooth: Mesh: Changed default values of temperature and range to be in a valid range.

### DIFF
--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -39,10 +39,6 @@ struct bt_mesh_light_temp_srv;
 				 BT_MESH_LIGHT_TEMP_STATUS,                    \
 				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_TEMP_STATUS)) }, \
 		.handlers = _handlers,                                         \
-		.range = {                                                     \
-			.min = BT_MESH_LIGHT_TEMP_MIN,                         \
-			.max = BT_MESH_LIGHT_TEMP_MAX,                         \
-		},                                                             \
 	}
 
 /** @def BT_MESH_MODEL_LIGHT_TEMP_SRV

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -318,11 +318,22 @@ static const struct bt_mesh_scene_entry_type scene_type = {
 	.maxlen = sizeof(int16_t),
 };
 
+static void light_temp_srv_reset(struct bt_mesh_light_temp_srv *srv)
+{
+	srv->dflt.delta_uv = 0;
+	srv->dflt.temp = BT_MESH_LIGHT_TEMP_MIN;
+	srv->last.delta_uv = 0;
+	srv->last.temp = BT_MESH_LIGHT_TEMP_MIN;
+	srv->range.min = BT_MESH_LIGHT_TEMP_MIN;
+	srv->range.max = BT_MESH_LIGHT_TEMP_MAX;
+}
+
 static int bt_mesh_light_temp_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_light_temp_srv *srv = model->user_data;
 
 	srv->model = model;
+	light_temp_srv_reset(srv);
 	net_buf_simple_init(srv->pub.msg, 0);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
@@ -361,6 +372,7 @@ static void bt_mesh_light_temp_srv_reset(struct bt_mesh_model *model)
 {
 	struct bt_mesh_light_temp_srv *srv = model->user_data;
 
+	light_temp_srv_reset(srv);
 	net_buf_simple_reset(srv->pub.msg);
 }
 


### PR DESCRIPTION
Changed default values of temperature and range to be in a valid range.
Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>