### PR TITLE
manifest: nrf5340ns DTS fix in sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a077c29554be6e3a9e1dc95cac303305fa80aa6e
+      revision: 59c5ac83cc7b6ca417a0871f9aea248917fac397
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
-Updates to sdk-zephyr PR 462.
-This add DTS support for nRF5340ns cryptocell_sw to enable
 random numbers from SPM.

sdk-zephyr pr: https://github.com/nrfconnect/sdk-zephyr/pull/462

ref: NCSDK-8246

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>