### PR TITLE
cmake: prototyping support for CMake presets json file.

### DIFF
--- a/applications/asset_tracker/CMakePresets.json
+++ b/applications/asset_tracker/CMakePresets.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Asset Tracker build (prj.conf)",
+      "description": "Asset Tracker build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "test",
+      "inherits": "default",
+      "displayName": "Asset Tracker Test build (prj_test.conf)",
+      "description": "Asset Tracker Test build",
+      "cacheVariables": {
+        "CONF_FILE": {
+          "type": "STRING",
+          "value": "prj_test.conf"
+        }
+      }
+    }
+  ],
+  "vendor": {
+    "zephyr": {
+      "twister": {
+        "sample": {
+           "name": "Asset Tracker Application"
+        },
+        "tests": {
+          "applications.asset_tracker": {
+            "build_only": true,
+            "build_on_all": true,
+            "platform_allow": "nrf9160dk_nrf9160ns thingy91_nrf9160ns qemu_x86",
+            "tags": "ci_build"
+          }
+        }
+      }
+    }
+  }
+}

--- a/applications/asset_tracker/CMakePresets.json
+++ b/applications/asset_tracker/CMakePresets.json
@@ -11,7 +11,13 @@
       "displayName": "Asset Tracker build (prj.conf)",
       "description": "Asset Tracker build",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build"
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "NCS_TOOLCHAIN_VERSION": {
+          "type": "STRING",
+          "value": "1.5.0"
+        }
+      }
     },
     {
       "name": "test",

--- a/applications/asset_tracker/sample.yaml
+++ b/applications/asset_tracker/sample.yaml
@@ -1,8 +1,0 @@
-sample:
-  name: Asset Tracker Application
-tests:
-  applications.asset_tracker:
-    build_only: true
-    build_on_all: true
-    platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns qemu_x86
-    tags: ci_build

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7598e62f2e1a64191281f137ec553ed3017f1100
+      revision: pull/469/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit introduces a CMakePresets.json in asset tracker.

CMake presets allows for additional sample and build description in a
single file.

The CMake presets also allows vendor specific fields, and thus allows
it to contain information that normally lives in sample.yaml or
testcase.yaml.

It is also possible to introduce IDE specific data to improve user
experience.

The sample can still be build with existing commands, but the preset
file also allows for building of the application as:
`cmake -DBOARD=nrf9160dk_nrf9160ns --preset=default .`
or
`cmake -DBOARD=nrf9160dk_nrf9160ns --preset=test.`

instead of:
`cmake -DBOARD=nrf9160dk_nrf9160ns -GNinja -Bbuild .`
or
`cmake -DBOARD=nrf9160dk_nrf9160ns -GNinja -Bbuild
       -DCONF_FILE=prj_test.conf .`

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>