### PR TITLE
samples: cloud_client: Use length when printing data

### DIFF
--- a/samples/nrf9160/cloud_client/src/main.c
+++ b/samples/nrf9160/cloud_client/src/main.c
@@ -125,7 +125,8 @@ void cloud_event_handler(const struct cloud_backend *const backend,
 		break;
 	case CLOUD_EVT_DATA_RECEIVED:
 		LOG_INF("CLOUD_EVT_DATA_RECEIVED");
-		LOG_INF("Data received from cloud: %s",
+		LOG_INF("Data received from cloud: %.*s",
+			evt->data.msg.len,
 			log_strdup(evt->data.msg.buf));
 		break;
 	case CLOUD_EVT_PAIR_REQUEST:


### PR DESCRIPTION
Use length when printing data received from cloud. This fixes the issue
where the print would include previosuly stored data in the
printed buffer.

Closes [NCSDK-8312]