### PR TITLE
Bluetooth: Mesh: Remove lightness model extension from init handler

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1430,11 +1430,6 @@ static int light_ctrl_srv_init(struct bt_mesh_model *mod)
 	k_delayed_work_init(&srv->reg.timer, reg_step);
 #endif
 
-	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
-		bt_mesh_model_extend(mod, srv->onoff.model);
-		bt_mesh_model_extend(mod, srv->lightness->lightness_model);
-	}
-
 	srv->pub.msg = &srv->pub_buf;
 	srv->pub.update = update_handler;
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,


### PR DESCRIPTION
Light Lightness Server model may not have lightness_model pointer
set before Light LC Server model initialization because both
models are initialized on different elements.

Light Lightness server extension is done in `start` handler
in Light LC server instead.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>