### PR TITLE
Bluetooth: Mesh: Remove nRF53 from chat sample compat list

### DIFF
--- a/samples/bluetooth/mesh/chat/sample.yaml
+++ b/samples/bluetooth/mesh/chat/sample.yaml
@@ -6,5 +6,4 @@ tests:
     build_only: true
     build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build


### PR DESCRIPTION
The chat sample does not support nRF53 out of the box, and should not
list it in its sample.yaml.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>