### PR TITLE
cmake: Prevent use of UART1 when building with TF-M

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -35,6 +35,15 @@ if (CONFIG_SPM)
   endif()
 endif()
 
+if (CONFIG_BUILD_WITH_TFM AND CONFIG_UART_1_NRF_UARTE)
+  message(FATAL_ERROR "
+    Non-secure applications built with TF-M cannot use UART1, because this
+    instance is used by the TF-M secure application. Disable the uart1 node
+    in devicetree. See the following file:
+    nrf/samples/tfm/tfm_hello_world/boards/nrf9160dk_nrf9160ns.overlay
+    for an example how to do it.")
+endif()
+
 if (CONFIG_SECURE_BOOT)
   if (CONFIG_SOC_NRF5340_CPUNET)
     add_child_image(


### PR DESCRIPTION
Non-secure applications built with TF-M cannot use UART1, because this
instance is used by the TF-M secure application. Issue an error message
when UART1 is enabled while building with TF-M.

Ref. NCSDK-8243