### PR TITLE
sample: secure_services: read spm fw info instead of app

### DIFF
--- a/samples/nrf9160/secure_services/src/main.c
+++ b/samples/nrf9160/secure_services/src/main.c
@@ -76,9 +76,9 @@ void main(void)
 	printk("CONFIG_SPM_SERVICE_RNG is disabled.\n\n");
 #endif
 
-	ret = spm_firmware_info(PM_APP_ADDRESS, &info_app);
+	ret = spm_firmware_info(PM_SPM_ADDRESS, &info_app);
 	if (ret != 0) {
-		printk("Could find firmware info (err: %d)\n", ret);
+		printk("Could not find SPM firmware info (err: %d)\n", ret);
 	}
 
 	printk("App FW version: %d\n\n", info_app.version);


### PR DESCRIPTION
Passing address to non-secure memory is not allowed in
spm_firmware_info, also it is not a good test since this
memory is already readable by the app.

Instead, try to read the fw_info from the SPM address.
This is supported by spm_firmware_info, and verifies
that you can access data through the NSC which is not
available otherwise.

Ref: NCSDK-8348
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>