### PR TITLE
Bluetooth: Mesh: Correcting model name in Light Sample

### DIFF
--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -107,7 +107,7 @@ Configuring models
 
 See :ref:`ug_bt_mesh_model_config_app` for details on how to configure the mesh models with the nRF Mesh mobile app.
 
-Configure the Generic OnOff Client model on each element on the :guilabel:`Mesh Light` node:
+Configure the Generic OnOff Server model on each element on the :guilabel:`Mesh Light` node:
 
 * Bind the model to :guilabel:`Application Key 1`.
 


### PR DESCRIPTION
Changing from Generic OnOff Client to Generic OnOff Server in documentation.

Signed-off-by: David Dilner <david.dilner@nordicsemi.no>