### PR TITLE
cmake: adding missing NORDIC SDK APP tags to CMakeLists.txt files

### DIFF
--- a/applications/connectivity_bridge/CMakeLists.txt
+++ b/applications/connectivity_bridge/CMakeLists.txt
@@ -9,7 +9,9 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END
 
 # Include application events and disk files
 zephyr_library_include_directories(

--- a/applications/nrf_desktop/CMakeLists.txt
+++ b/applications/nrf_desktop/CMakeLists.txt
@@ -54,10 +54,12 @@ project("nRF52 Desktop"
 
 assert(CONFIG_DESKTOP_HID_REPORT_DESC "HID report descriptor file must be specified")
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE
   src/main.c
   ${CONFIG_DESKTOP_HID_REPORT_DESC}
   )
+# NORDIC SDK APP END
 
 # Include application events and configuration headers
 zephyr_library_include_directories(

--- a/applications/serial_lte_modem/CMakeLists.txt
+++ b/applications/serial_lte_modem/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(serial_lte_modem)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
 target_sources(app PRIVATE src/slm_util.c)
 target_sources(app PRIVATE src/slm_at_host.c)
@@ -17,6 +18,7 @@ target_sources(app PRIVATE src/slm_at_tcp_proxy.c)
 target_sources(app PRIVATE src/slm_at_udp_proxy.c)
 target_sources(app PRIVATE src/slm_at_icmp.c)
 target_sources(app PRIVATE src/slm_at_fota.c)
+# NORDIC SDK APP END
 target_sources_ifdef(CONFIG_SLM_NATIVE_TLS app PRIVATE src/slm_native_tls.c)
 target_sources_ifdef(CONFIG_SLM_NATIVE_TLS app PRIVATE src/slm_at_cmng.c)
 

--- a/samples/bluetooth/mesh/chat/CMakeLists.txt
+++ b/samples/bluetooth/mesh/chat/CMakeLists.txt
@@ -8,8 +8,10 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE
 	src/main.c
 	src/model_handler.c
 	src/chat_cli.c)
 target_include_directories(app PRIVATE include)
+# NORDIC SDK APP END

--- a/samples/connectedhomeip/light_bulb/CMakeLists.txt
+++ b/samples/connectedhomeip/light_bulb/CMakeLists.txt
@@ -12,6 +12,7 @@ project(chip-light-bulb)
 
 set(COMMON_ROOT ${CMAKE_CURRENT_LIST_DIR}/../common)
 
+# NORDIC SDK APP START
 target_include_directories(app PRIVATE src ${COMMON_ROOT}/src)
 
 target_sources(app PRIVATE
@@ -43,3 +44,4 @@ target_sources(app PRIVATE
                ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/util.cpp
                ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/on-off-server/on-off.cpp
                ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/level-control/level-control.cpp)
+# NORDIC SDK APP END

--- a/samples/connectedhomeip/light_switch/CMakeLists.txt
+++ b/samples/connectedhomeip/light_switch/CMakeLists.txt
@@ -12,6 +12,7 @@ project(chip-light-switch)
 
 set(COMMON_ROOT ${CMAKE_CURRENT_LIST_DIR}/../common)
 
+# NORDIC SDK APP START
 target_include_directories(app PRIVATE src ${COMMON_ROOT}/src ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app)
 
 target_compile_options(app PRIVATE -Wno-deprecated-declarations)
@@ -22,3 +23,4 @@ target_sources(app PRIVATE
                src/main.cpp
                ${COMMON_ROOT}/src/led_widget.cpp
                ${COMMON_ROOT}/src/thread_util.cpp)
+# NORDIC SDK APP END

--- a/samples/connectedhomeip/lock/CMakeLists.txt
+++ b/samples/connectedhomeip/lock/CMakeLists.txt
@@ -12,6 +12,7 @@ project(chip-lock)
 
 set(COMMON_ROOT ${CMAKE_CURRENT_LIST_DIR}/../common)
 
+# NORDIC SDK APP START
 target_include_directories(app PRIVATE src ${COMMON_ROOT}/src)
 
 target_sources(app PRIVATE
@@ -42,3 +43,4 @@ target_sources(app PRIVATE
                ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/util/util.cpp
                ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/bindings/bindings.cpp
                ${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/on-off-server/on-off.cpp)
+# NORDIC SDK APP END

--- a/samples/debug/ppi_trace/CMakeLists.txt
+++ b/samples/debug/ppi_trace/CMakeLists.txt
@@ -9,7 +9,9 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("PPI trace sample")
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END
 target_sources_ifdef(
 	CONFIG_USE_BLUETOOTH_RADIO_EVENTS
 	app PRIVATE src/bluetooth.c

--- a/samples/nrf5340/empty_app_core/CMakeLists.txt
+++ b/samples/nrf5340/empty_app_core/CMakeLists.txt
@@ -9,4 +9,6 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(empty_app_core)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/nrf5340/multiprotocol_rpmsg/CMakeLists.txt
+++ b/samples/nrf5340/multiprotocol_rpmsg/CMakeLists.txt
@@ -5,4 +5,6 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(multiprotocol_rpmsg)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/nrf9160/download/CMakeLists.txt
+++ b/samples/nrf9160/download/CMakeLists.txt
@@ -9,4 +9,6 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(download)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/nrf9160/fmfu_smp_svr/CMakeLists.txt
+++ b/samples/nrf9160/fmfu_smp_svr/CMakeLists.txt
@@ -9,4 +9,6 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fmfu_smp_svr)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/nrf9160/http_update/application_update/CMakeLists.txt
+++ b/samples/nrf9160/http_update/application_update/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(application_update)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
 target_sources(app PRIVATE ../common/src/update.c)
 target_include_directories(app PRIVATE ../common/include)
+# NORDIC SDK APP END

--- a/samples/nrf9160/http_update/full_modem_update/CMakeLists.txt
+++ b/samples/nrf9160/http_update/full_modem_update/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(full_modem_update)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
 target_sources(app PRIVATE ../common/src/update.c)
 target_include_directories(app PRIVATE ../common/include)
+# NORDIC SDK APP END

--- a/samples/nrf9160/http_update/modem_delta_update/CMakeLists.txt
+++ b/samples/nrf9160/http_update/modem_delta_update/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(modem_delta_update)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
 target_sources(app PRIVATE ../common/src/update.c)
 target_include_directories(app PRIVATE ../common/include)
+# NORDIC SDK APP END

--- a/samples/nrf9160/https_client/CMakeLists.txt
+++ b/samples/nrf9160/https_client/CMakeLists.txt
@@ -9,4 +9,6 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(https_client)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/nrf9160/secure_services/CMakeLists.txt
+++ b/samples/nrf9160/secure_services/CMakeLists.txt
@@ -9,4 +9,6 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(secure_services)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/openthread/cli/CMakeLists.txt
+++ b/samples/openthread/cli/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(openthread_cli)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END
 
 target_sources_ifdef(CONFIG_BT app PRIVATE src/ble.c)

--- a/samples/openthread/coap_client/CMakeLists.txt
+++ b/samples/openthread/coap_client/CMakeLists.txt
@@ -11,9 +11,11 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(openthread_coap_client)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/coap_client.c
 			   src/coap_client_utils.c)
 
-target_sources_ifdef(CONFIG_BT_NUS app PRIVATE src/ble_utils.c)
-
 target_include_directories(app PUBLIC ../coap_server/interface)
+# NORDIC SDK APP END
+
+target_sources_ifdef(CONFIG_BT_NUS app PRIVATE src/ble_utils.c)

--- a/samples/openthread/coap_server/CMakeLists.txt
+++ b/samples/openthread/coap_server/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(openthread_coap_server)
 
 FILE(GLOB app_sources src/*.c)
+# NORDIC SDK APP START
 target_sources(app PRIVATE ${app_sources})
 
 target_include_directories(app PRIVATE interface)
+# NORDIC SDK APP END

--- a/samples/openthread/ncp/CMakeLists.txt
+++ b/samples/openthread/ncp/CMakeLists.txt
@@ -14,4 +14,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(openthread_ncp)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c src/nrf_802154_radio_wrapper.c)
+# NORDIC SDK APP END

--- a/samples/peripheral/lpuart/CMakeLists.txt
+++ b/samples/peripheral/lpuart/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(low_power_uart)
 
 FILE(GLOB app_sources src/*.c)
+# NORDIC SDK APP START
 target_sources(app PRIVATE
 	${app_sources}
 )
+# NORDIC SDK APP END

--- a/samples/peripheral/radio_test/CMakeLists.txt
+++ b/samples/peripheral/radio_test/CMakeLists.txt
@@ -15,6 +15,8 @@ target_sources_ifdef(CONFIG_NRF21540_FEM app
 zephyr_include_directories(../../bluetooth/direct_test_mode/src/fem/)
 
 FILE(GLOB app_sources src/*.c)
+# NORDIC SDK APP START
 target_sources(app PRIVATE
 	${app_sources}
 )
+# NORDIC SDK APP END

--- a/samples/sensor/bh1749/CMakeLists.txt
+++ b/samples/sensor/bh1749/CMakeLists.txt
@@ -4,4 +4,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bh1749)
 
 FILE(GLOB app_sources src/*.c)
+# NORDIC SDK APP START
 target_sources(app PRIVATE ${app_sources})
+# NORDIC SDK APP END

--- a/samples/tfm/tfm_hello_world/CMakeLists.txt
+++ b/samples/tfm/tfm_hello_world/CMakeLists.txt
@@ -11,4 +11,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(tfm_hello_world)
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE src/main.c)
+# NORDIC SDK APP END

--- a/samples/zigbee/ncp/CMakeLists.txt
+++ b/samples/zigbee/ncp/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project("ZBOSS NCP SoC firmware")
 
+# NORDIC SDK APP START
 target_sources(app PRIVATE
   src/main.c
 )
+# NORDIC SDK APP END


### PR DESCRIPTION
This commit add NORDIC SDK APP START / END tags to samples and
applications missing those tags.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>