### PR TITLE
Bluetooth: Mesh: Fix CTL state transition time reporting

### DIFF
--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -46,7 +46,7 @@ static void ctl_get(struct bt_mesh_light_ctl_srv *srv,
 	status->current_light = light.current;
 	status->target_temp = temp.target.temp;
 	status->target_light = light.target;
-	status->remaining_time = temp.remaining_time;
+	status->remaining_time = MAX(temp.remaining_time, light.remaining_time);
 }
 
 static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,


### PR DESCRIPTION
Fix transition time reporting for CTL state when GET is processed.
This should be reported as a maximum of the remaining time for all
components of the multi-dimensional state.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>