### PR TITLE
net: openthread: Increase Thread radio workqueue stack size

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -51,8 +51,7 @@ config OPENTHREAD_MBEDTLS_LIB_NAME
 
 config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	int "OpenThread radio transmit workqueue stack size"
-	default 640 if NRF_802154_SER_HOST
-	default 512
+	default 1024
 
 choice CC3XX_LOCK_VARIANT
 	default CC3XX_ATOMIC_LOCK if SOC_NRF52840


### PR DESCRIPTION
In some cases eg. stress tests with SED, 512 bytes showed up to be too
small. Incresed the queue size with some extra buffer for future
improvements.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>