### PR TITLE
applications: serial_lte_modem: FOTA mistake in PRs

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -39,6 +39,9 @@ enum slm_fota_operation {
 	AT_FOTA_STOP
 };
 
+static char path[URI_PATH_MAX];
+static char hostname[URI_HOST_MAX];
+
 /* global functions defined in different files */
 void rsp_send(const uint8_t *str, size_t len);
 
@@ -89,8 +92,6 @@ static int do_fota_start(int op, const char *file_uri, int sec_tag,
 	int ret = -EINVAL;
 	struct http_parser_url parser;
 	char schema[8];
-	char path[URI_PATH_MAX];
-	char hostname[URI_HOST_MAX];
 
 	http_parser_url_init(&parser);
 	ret = http_parser_parse_url(file_uri, strlen(file_uri), 0, &parser);


### PR DESCRIPTION
The FOTA fix in PR#3503 was reverted by mistake in later PR#3645.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>