### PR TITLE
toolchain: make toolchain 1.5.0 minimum supported

### DIFF
--- a/share/ncs-package/cmake/NcsConfig.cmake
+++ b/share/ncs-package/cmake/NcsConfig.cmake
@@ -2,7 +2,7 @@
 set(NRF_RELATIVE_DIR "../../..")
 set(NCS_RELATIVE_DIR "../../../..")
 
-set(NCS_TOOLCHAIN_MINIMUM_REQUIRED 1.4.0)
+set(NCS_TOOLCHAIN_MINIMUM_REQUIRED 1.5.0)
 
 # Set the current NRF_DIR
 # The use of get_filename_component ensures that the final path variable will not contain `../..`.

--- a/share/ncs-package/cmake/NcsConfig.cmake
+++ b/share/ncs-package/cmake/NcsConfig.cmake
@@ -26,7 +26,7 @@ if(NOT NO_BOILERPLATE)
   if(NOT ${NCS_TOOLCHAIN_MINIMUM_REQUIRED} STREQUAL NONE)
     find_package(NcsToolchain ${NCS_TOOLCHAIN_MINIMUM_REQUIRED} ${EXACT} QUIET)
     if(${NcsToolchain_FOUND})
-      message("-- Using NCS Toolchain ${NCS_TOOLCHAIN_MINIMUM_REQUIRED} for building. (${NcsToolchain_DIR})")
+      message("-- Using NCS Toolchain ${NcsToolchain_VERSION} for building. (${NcsToolchain_DIR})")
       set(GIT_EXECUTABLE           ${NCS_TOOLCHAIN_GIT}     CACHE FILEPATH "NCS Toolchain Git")
 
       set(DTC                      ${NCS_TOOLCHAIN_DTC}     CACHE FILEPATH "NCS Toolchain DTC")


### PR DESCRIPTION
With west 0.9.0 introduced for NCS 1.5.0, then NCS Toolchain 1.4.0 can
no longer be used for building latest NCS.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>