### PR TITLE
samples: nrf9160: lwm2m_client: Clarify APP_LWM2M_SERVER config docs

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -61,6 +61,7 @@
 .. _`Sphinx parser issue`: https://github.com/sphinx-doc/sphinx/issues/2683
 
 .. _`Leshan Demo Server`: https://github.com/eclipse/leshan/blob/master/README.md
+.. _`public Leshan Demo Server`: https://leshan.eclipseprojects.io
 
 .. _`wpantund`: https://github.com/openthread/wpantund/blob/master/README.md
 .. _`wpantund Installation Guide`: https://github.com/openthread/wpantund/blob/master/INSTALL.md

--- a/samples/nrf9160/lwm2m_client/README.rst
+++ b/samples/nrf9160/lwm2m_client/README.rst
@@ -88,7 +88,7 @@ Check and configure the following configuration options for the sample:
 .. option:: CONFIG_APP_LWM2M_SERVER - LWM2M Server configuration
 
    The sample configuration specifies the LWM2M Server to be used.
-   In this sample, this option is set to ``leshan.eclipseprojects.io``.
+   In this sample, you can set this option to ``leshan.eclipseprojects.io`` (`public Leshan Demo Server`_).
 
 
 


### PR DESCRIPTION
Clarify in the docs, that the server URL is not set by default but
should be set by the user.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>