### PR TITLE
zigbee: Fix API mismatch in zb_secur_ic_add

### DIFF
--- a/subsys/zigbee/cli/zigbee_cli_cmd_bdb.c
+++ b/subsys/zigbee/cli/zigbee_cli_cmd_bdb.c
@@ -439,6 +439,22 @@ static int cmd_zb_channel(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
+#ifndef CONFIG_ZIGBEE_LIBRARY_PRODUCTION
+
+static void zb_secur_ic_add_cb(zb_ret_t status)
+{
+	if (status != RET_OK) {
+		zb_cli_print_error(ic_add_ctx.shell, "Failed to add IC",
+				   ZB_FALSE);
+	} else {
+		zb_cli_print_done(ic_add_ctx.shell, ZB_FALSE);
+	}
+
+	ic_add_ctx.taken = false;
+}
+
+#endif /* !CONFIG_ZIGBEE_LIBRARY_PRODUCTION */
+
 /**@brief Function adding install code, to be executed in Zigbee thread context.
  *
  * @param[in] param Unused param.
@@ -447,6 +463,7 @@ void zb_install_code_add(zb_uint8_t param)
 {
 	ARG_UNUSED(param);
 
+#ifdef CONFIG_ZIGBEE_LIBRARY_PRODUCTION
 	if (zb_secur_ic_add(ic_add_ctx.addr, ZB_IC_TYPE_128, ic_add_ctx.ic)
 	    != RET_OK) {
 		zb_cli_print_error(ic_add_ctx.shell, "Failed to add IC",
@@ -454,7 +471,14 @@ void zb_install_code_add(zb_uint8_t param)
 	} else {
 		zb_cli_print_done(ic_add_ctx.shell, ZB_FALSE);
 	}
+
 	ic_add_ctx.taken = false;
+
+#else /* !CONFIG_ZIGBEE_LIBRARY_PRODUCTION */
+	zb_secur_ic_add(ic_add_ctx.addr, ZB_IC_TYPE_128, ic_add_ctx.ic, zb_secur_ic_add_cb);
+	zb_cli_print_done(ic_add_ctx.shell, ZB_FALSE);
+
+#endif /* CONFIG_ZIGBEE_LIBRARY_PRODUCTION */
 }
 
 /**@brief Set install code on the device, add information about the install code


### PR DESCRIPTION
The API for zb_secur_ic_add has changed in the development libraries.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>