### PR TITLE
applications: asset_tracker_v2: Purge message queues if enqueue fails.

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modules_common.h
+++ b/applications/asset_tracker_v2/src/modules/modules_common.h
@@ -36,6 +36,8 @@ void module_set_name(struct module_data *module, char *name);
 
 void module_set_queue(struct module_data *module,  struct k_msgq *msg_q);
 
+void module_purge_queue(struct module_data *module);
+
 int module_get_next_msg(struct module_data *module, void *msg);
 
 /** @brief Enqueue message to a module's queue.


### PR DESCRIPTION
Purge message queue if k_msgq_put() returns an error.
This is to ensure that the calling module can continue
to process events.

This fixes the issue where a module with a full message queue
would never handle the incoming shutdown request event from the utility
module after an error.

Closes CIA-240