### PR TITLE
applications: asset_tracker_v2: Check nrf_modem_lib_init return code

### DIFF
--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <event_manager.h>
+#include <modem/nrf_modem_lib.h>
 
 #if defined(CONFIG_WATCHDOG_APPLICATION)
 #include "watchdog.h"
@@ -157,6 +158,43 @@ static void sub_state_set(enum sub_state_type new_state)
 		sub_state2str(new_state));
 
 	sub_state = new_state;
+}
+
+/* Check the return code from nRF modem library initializaton to ensure that
+ * the modem is rebooted if a modem firmware update is ready to be applied or
+ * an error condition occurred during firmware update or library initialization.
+ */
+static void handle_nrf_modem_lib_init_ret(void)
+{
+	int ret = nrf_modem_lib_get_init_ret();
+
+	/* Handle return values relating to modem firmware update */
+	switch (ret) {
+	case 0:
+		/* Initialization successful, no action required. */
+		return;
+	case MODEM_DFU_RESULT_OK:
+		LOG_INF("MODEM UPDATE OK. Will run new firmware after reboot");
+		break;
+	case MODEM_DFU_RESULT_UUID_ERROR:
+	case MODEM_DFU_RESULT_AUTH_ERROR:
+		LOG_ERR("MODEM UPDATE ERROR %d. Will run old firmware", ret);
+		break;
+	case MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case MODEM_DFU_RESULT_INTERNAL_ERROR:
+		LOG_ERR("MODEM UPDATE FATAL ERROR %d. Modem failure", ret);
+		break;
+	default:
+		/* All non-zero return codes other than DFU result codes are
+		 * considered irrecoverable and a reboot is needed.
+		 */
+		LOG_ERR("nRF modem lib initialization failed, error: %d", ret);
+		break;
+	}
+
+	LOG_WRN("Rebooting...");
+	LOG_PANIC();
+	sys_reboot(SYS_REBOOT_COLD);
 }
 
 /* Event manager handler. Puts event data into messages and adds them to the
@@ -435,6 +473,7 @@ void main(void)
 	self.thread_id = k_current_get();
 
 	module_start(&self);
+	handle_nrf_modem_lib_init_ret();
 
 	if (event_manager_init()) {
 		/* Without the event manager, the application will not work


### PR DESCRIPTION
On boot the return code from nrf_modem_lib_init() should be checked
to determine if the modem requires a reboot.
A reboot is needed in the event of an ongoing modem firmware
update or an error happened during library initialization.

This patch prevents that the application proceeds and attempts
to send AT commands when the modem library is uninitialized,
resulting in a series of error messages and eventually a reboot.

Addresses CIA-239

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>