### PR TITLE
manifest: update zephyr to get the zero timeout schedulling fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: e81a613c5e587589b69475db92e416ec62f2dd03
+      revision: 4ce908a2342494c19df09f347ce79ab81b415185
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr pointer to get the fix for
schedulling zero timeouts.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>