### PR TITLE
west.yml: switch to 'allowlist'

### DIFF
--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -351,7 +351,7 @@ class NcsCompare(NcsWestCommand):
                 f"  To add to NCS:\n"
                 f"    1. do the zephyr mergeup\n"
                 f"    2. update zephyr revision in {west_yml}\n"
-                f"    3. add projects to zephyr's name_whitelist in "
+                f"    3. add projects to zephyr's name-allowlist in "
                 f"{west_yml}\n"
                 f"    4. run west {self.name} again to check your work\n"
                 f"  To block: edit _BLOCKED_PROJECTS in {__file__}")

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
         # revision. Only the projects explicitly named in the
-        # following whitelist are imported.
+        # following allowlist are imported.
         #
         # Note that the zephyr west extensions (like 'build', 'flash',
         # 'debug', etc.) are automatically provided by this import, so
@@ -65,7 +65,7 @@ manifest:
         # the zephyr project.
         #
         # Please keep this list sorted alphabetically.
-        name-whitelist:
+        name-allowlist:
           - canopennode
           - cmsis
           - civetweb


### PR DESCRIPTION
Now that west 0.9 is the minimum version, we can use 'allowlist' when
specifying the projects to import from the zephyr repository.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>