### PR TITLE
Shell bt nus wait for notification to be enabled

### DIFF
--- a/include/bluetooth/services/nus.h
+++ b/include/bluetooth/services/nus.h
@@ -39,6 +39,14 @@ extern "C" {
 #define BT_UUID_NUS_RX        BT_UUID_DECLARE_128(BT_UUID_NUS_RX_VAL)
 #define BT_UUID_NUS_TX        BT_UUID_DECLARE_128(BT_UUID_NUS_TX_VAL)
 
+/** @brief NUS send status. */
+enum bt_nus_send_status {
+	/** Send notification enabled. */
+	BT_NUS_SEND_STATUS_ENABLED,
+	/** Send notification disabled. */
+	BT_NUS_SEND_STATUS_DISABLED,
+};
+
 /** @brief Pointers to the callback functions for service events. */
 struct bt_nus_cb {
 	/** @brief Data received callback.
@@ -62,6 +70,15 @@ struct bt_nus_cb {
 	 *                 connected peers.
 	 */
 	void (*sent)(struct bt_conn *conn);
+
+	/** @brief Send state callback.
+	 *
+	 * Indicate the CCCD descriptor status of the NUS TX characteristic.
+	 *
+	 * @param[in] status Send notification status.
+	 */
+	void (*send_enabled)(enum bt_nus_send_status status);
+
 };
 
 /**@brief Initialize the service.

--- a/subsys/bluetooth/services/nus.c
+++ b/subsys/bluetooth/services/nus.c
@@ -15,6 +15,17 @@ LOG_MODULE_REGISTER(bt_nus, CONFIG_BT_NUS_LOG_LEVEL);
 
 static struct bt_nus_cb nus_cb;
 
+static void nus_ccc_cfg_changed(const struct bt_gatt_attr *attr,
+				  uint16_t value)
+{
+	if (nus_cb.send_enabled) {
+		LOG_DBG("Notification has been turned %s",
+			value == BT_GATT_CCC_NOTIFY ? "on" : "off");
+		nus_cb.send_enabled(value == BT_GATT_CCC_NOTIFY ?
+			BT_NUS_SEND_STATUS_ENABLED : BT_NUS_SEND_STATUS_DISABLED);
+	}
+}
+
 static ssize_t on_receive(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr,
 			  const void *buf,
@@ -49,7 +60,7 @@ BT_GATT_PRIMARY_SERVICE(BT_UUID_NUS_SERVICE),
 			       BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_READ,
 			       NULL, NULL, NULL),
-	BT_GATT_CCC(NULL, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+	BT_GATT_CCC(nus_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
 	BT_GATT_CHARACTERISTIC(BT_UUID_NUS_RX,
 			       BT_GATT_CHRC_WRITE |
 			       BT_GATT_CHRC_WRITE_WITHOUT_RESP,
@@ -62,6 +73,7 @@ int bt_nus_init(struct bt_nus_cb *callbacks)
 	if (callbacks) {
 		nus_cb.received = callbacks->received;
 		nus_cb.sent = callbacks->sent;
+		nus_cb.send_enabled = callbacks->send_enabled;
 	}
 
 	return 0;

--- a/subsys/shell/shell_bt_nus.c
+++ b/subsys/shell/shell_bt_nus.c
@@ -18,6 +18,8 @@ SHELL_DEFINE(shell_bt_nus, "bt_nus:~$ ", &shell_transport_bt_nus,
 	     CONFIG_SHELL_BT_NUS_LOG_MESSAGE_QUEUE_TIMEOUT,
 	     SHELL_FLAG_OLF_CRLF);
 
+static K_SEM_DEFINE(shell_bt_nus_ready, 0, 1);
+
 static bool is_init;
 
 static void rx_callback(struct bt_conn *conn, const uint8_t *const data, uint16_t len)
@@ -74,6 +76,14 @@ static void tx_callback(struct bt_conn *conn)
 				  bt_nus->ctrl_blk->context);
 }
 
+static void send_enabled_callback(enum bt_nus_send_status status)
+{
+	if (status == BT_NUS_SEND_STATUS_ENABLED) {
+		LOG_DBG("NUS notification has been enabled");
+		k_sem_give(&shell_bt_nus_ready);
+	}
+}
+
 static int init(const struct shell_transport *transport,
 		const void *config,
 		shell_transport_handler_t evt_handler,
@@ -104,6 +114,9 @@ static int enable(const struct shell_transport *transport, bool blocking_tx)
 		bt_nus->ctrl_blk->conn = NULL;
 		return -ENOTSUP;
 	}
+
+	LOG_DBG("Waiting for the NUS notification to be enabled");
+	k_sem_take(&shell_bt_nus_ready, K_FOREVER);
 
 	return 0;
 }
@@ -146,6 +159,7 @@ void shell_bt_nus_disable(void)
 			(const struct shell_bt_nus *)shell_transport_bt_nus.ctx;
 
 	bt_nus->ctrl_blk->conn = NULL;
+	k_sem_give(&shell_bt_nus_ready);
 }
 
 void shell_bt_nus_enable(struct bt_conn *conn)
@@ -159,6 +173,8 @@ void shell_bt_nus_enable(struct bt_conn *conn)
 		CONFIG_LOG_MAX_LEVEL : CONFIG_SHELL_BT_NUS_INIT_LOG_LEVEL;
 
 	bt_nus->ctrl_blk->conn = conn;
+
+	k_sem_reset(&shell_bt_nus_ready);
 
 	if (!is_init) {
 		err = shell_init(&shell_bt_nus, NULL, true, log_backend, level);
@@ -179,7 +195,8 @@ int shell_bt_nus_init(void)
 {
 	struct bt_nus_cb callbacks = {
 		.received = rx_callback,
-		.sent = tx_callback
+		.sent = tx_callback,
+		.send_enabled = send_enabled_callback
 	};
 
 	return bt_nus_init(&callbacks);


### PR DESCRIPTION
Add the callback to the NUS service which pass an information about notification state. This callback is needed for the bt_shell_nus transport to synchronize shell start with notification enabled event to avoid loosing shell data when notifications are disabled for the NUS. 