### PR TITLE
zigbee: Add a known issue regarding Scenes commands

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -321,6 +321,13 @@ KRKNWK-9119: Zigbee shell does not work with ZBOSS development libraries
 
     **Workaround:** Use only the production version of :ref:`nrfxlib:zboss` when using :ref:`lib_zigbee_shell`.
 
+.. rst-class:: v1-5-0
+
+KRKNWK-9145: Corrupted payload in commands of the Scenes cluster
+  When receiving Scenes cluster commands, the payload is corrupted when using the :ref:`nrfxlib:zboss` production libraries.
+
+  **Workaround:** Use the development version of :ref:`nrfxlib:zboss`.
+
 nRF Desktop
 ===========
 


### PR DESCRIPTION
Add a note in known issues section about corrupted payload
in Scenes cluster commands when using the production version
of ZBOSS lib.
