### PR TITLE
manifest: Update nrfxlib rev

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.5.0
+      revision: 7d39c81afec405f0969945b75d73bb2236c75ed8
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Nrfxlib with fixes for entropy source count and using cryptocell
as entropy source on non-secure fw in nrf9160.

Jira:NCSDK-8203

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>