### PR TITLE
Bluetooth: Mesh: Follow sec 6.5.2.11 of MeshMDLv1.0.1 for Light Off evt

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -447,11 +447,7 @@ static int turn_off(struct bt_mesh_light_ctrl_srv *srv,
 		atomic_clear_bit(&srv->flags, FLAG_ON);
 		store(srv, FLAG_STORE_STATE);
 		light_onoff_pub(srv, prev_state, pub_gen_onoff);
-	} else if (fade_time < remaining_fade_time(srv)) {
-		/* Replacing current transition with a manual transition if it's
-		 * faster. This ensures that the manual override looks
-		 * responsive:
-		 */
+	} else {
 		transition_start(srv, LIGHT_CTRL_STATE_STANDBY, fade_time);
 	}
 


### PR DESCRIPTION
According to section 6.2.5.11 Light LC State Machine Fade Standby Auto
state, when Light Off event is received, the state machine should
unconditionally set transition time to Fade Standby Manual state time.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>