### PR TITLE
partition_manager: Add flash_map_partition_manager.c

### DIFF
--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -4,6 +4,14 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+if (CONFIG_PARTITION_MANAGER_ENABLED)
+  if (NOT CONFIG_FLASH_MAP_CUSTOM)
+    message(FATAL_ERROR "CONFIG_FLASH_MAP_CUSTOM must be set when \
+      CONFIG_PARTITION_MANAGER_ENABLED is set")
+  endif()
+  zephyr_sources(flash_map_partition_manager.c)
+endif()
+
 function(preprocess_pm_yml in_file out_file)
   execute_process(
     COMMAND ${CMAKE_C_COMPILER}

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -15,6 +15,13 @@ config PARTITION_MANAGER_ENABLED
 	  in how parent images impose options on child images. Don't
 	  change the value of this option.
 
+# Override this option to use custom flash map implementation when partition
+# manager is enabled.
+config FLASH_MAP_CUSTOM
+	bool
+	default y
+	depends on PARTITION_MANAGER_ENABLED
+
 # These values are now set by partition manager, so hide the option.
 config SRAM_SIZE
 	int

--- a/subsys/partition_manager/flash_map_partition_manager.c
+++ b/subsys/partition_manager/flash_map_partition_manager.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <storage/flash_map.h>
+#include <pm_config.h>
+#include <sys/util.h>
+
+#define FLASH_MAP_OFFSET(i) UTIL_CAT(PM_, UTIL_CAT(PM_##i##_LABEL, _ADDRESS))
+#define FLASH_MAP_DEV(i)    UTIL_CAT(PM_, UTIL_CAT(PM_##i##_LABEL, _DEV_NAME))
+#define FLASH_MAP_SIZE(i)   UTIL_CAT(PM_, UTIL_CAT(PM_##i##_LABEL, _SIZE))
+#define FLASH_MAP_NUM       PM_NUM
+
+#define FLASH_AREA_FOO(i, _)                \
+	{                                       \
+		.fa_id       = i,                   \
+		.fa_off      = FLASH_MAP_OFFSET(i), \
+		.fa_dev_name = FLASH_MAP_DEV(i),    \
+		.fa_size     = FLASH_MAP_SIZE(i)    \
+	},
+
+const struct flash_area default_flash_map[] = {
+	UTIL_LISTIFY(FLASH_MAP_NUM, FLASH_AREA_FOO, ~)
+};
+
+const int flash_map_entries = ARRAY_SIZE(default_flash_map);
+const struct flash_area *flash_map = default_flash_map;

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 75cdf13b2425689d10d4cd6375faa0d4cc55aeef
+      revision: 5acae16d9ea808785279b1de1cd177108c1b1354
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add flash_map_partition_manager.c so we don't need to have our own
patched version of zephyr's flash_map_default.c

REF: NCSDK-5469

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>