### PR TITLE
samples: nrf9160: lte_ble_gateway: do not call k_cpu_idle

### DIFF
--- a/samples/nrf9160/lte_ble_gateway/src/main.c
+++ b/samples/nrf9160/lte_ble_gateway/src/main.c
@@ -506,6 +506,5 @@ void main(void)
 		nrf_cloud_process();
 		send_aggregated_data();
 		k_sleep(K_MSEC(10));
-		k_cpu_idle();
 	}
 }


### PR DESCRIPTION
The `main` thread should not put the CPU to idle, the `idle` thread does that.
