### PR TITLE
doc: known_issues: Add new NCS 1.5 Thread known issues

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -214,6 +214,13 @@ Thread
 
 .. rst-class:: v1-5-0 v1-4-2 v1-4-1 v1-4-0
 
+KRKNWK-9094: Possible deadlock in shell subsystem
+  Issuing OpenThread commands too fast might cause a deadlock in the shell subsystem.
+
+  **Workaround:** If possible, avoid invoking a new command before execution of the previous one has completed.
+
+.. rst-class:: v1-5-0 v1-4-2 v1-4-1 v1-4-0
+
 KRKNWK-6848: Reduced throughput
   Performance testing for :ref:`NCP sample <ot_ncp_sample>` shows a decrease of throughput of around 10-20% compared with the standard OpenThread.
 


### PR DESCRIPTION
Added known issue (shell deadlock) found during NCS 1.5 testing that
affects also NCS 1.4

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>