### PR TITLE
actions: doc-publish: Install sshpass

### DIFF
--- a/.github/workflows/docpublish.yml
+++ b/.github/workflows/docpublish.yml
@@ -37,6 +37,7 @@ jobs:
           SSHUSER: ${{ secrets.NCS_TRANSFER_DOC_USR }}
           SSHPASS: ${{ secrets.NCS_TRANSFER_DOC_PWD }}
         run: |
+          sudo apt install -y sshpass
           unzip doc.zip
           # Don't upload the archive and workflow metadata
           files=$(ls -I doc.zip -I pr.txt)


### PR DESCRIPTION
Since GitHub transitioned to Ubuntu 20.04 LTS by default, sshpass is not
part of the default Docker image used to run actions. Install it
manually using apt.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>