### PR TITLE
Bluetooth: Mesh: Align Occupancy On event handling with model spec

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -982,7 +982,9 @@ static void handle_sensor_status(struct bt_mesh_model *mod,
 		 * able to turn on the light:
 		 */
 		if (srv->state == LIGHT_CTRL_STATE_STANDBY &&
-		    !atomic_test_bit(&srv->flags, FLAG_OCC_MODE)) {
+		    !atomic_test_bit(&srv->flags, FLAG_OCC_MODE) &&
+		    !(atomic_test_bit(&srv->flags, FLAG_TRANSITION) &&
+		      !atomic_test_bit(&srv->flags, FLAG_MANUAL))) {
 			continue;
 		}
 


### PR DESCRIPTION
According to section 6.2.5.11 Light LC State Machine Fade Standby Auto
state, when Occupancy On event is received, the state machine should
unconditionaly transition to Fade On state even if Occupancy Mode is
disabled.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>