### PR TITLE
samples: Bluetooth: Add Direction Finding connectionless Tx sample

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -81,6 +81,7 @@ Kconfig*                                  @tejlmand
 /samples/sensor/bh1749/                   @wlgrd
 /samples/bluetooth/                       @joerchan @lemrey @carlescufi
 /samples/bluetooth/mesh/                  @trond-snekvik @joerchan
+/samples/bluetooth/direction_finding_connectionless_tx/ @ppryga @joerchan
 /samples/bootloader/                      @hakonfam @ioannisg
 /samples/connectedhomeip/                 @Damian-Nordic @kkasperczyk-no
 /samples/debug/ppi_trace/                 @nordic-krch @anangl

--- a/samples/bluetooth/direction_finding_connectionless_tx/CMakeLists.txt
+++ b/samples/bluetooth/direction_finding_connectionless_tx/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(direction_finding_connectionless)
+
+# NORDIC SDK APP START
+target_sources(app PRIVATE
+  src/main.c
+)
+# NORDIC SDK APP END

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -1,0 +1,153 @@
+.. _direction_finding_connectionless_tx:
+
+Bluetooth: Direction finding connectionless beacon
+##################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Overview
+********
+
+The direction finding connectionless beacon sample demonstrates Bluetooth LE Direction Finding transmission.
+It uses the Constant Tone Extension (CTE), that is transmitted with periodic advertising PDUs.
+
+The sample supports two Direction Finding modes:
+
+* Angle of Arrival
+* Angle of Departure
+
+By default, both modes are available in the sample.
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52833dk_nrf52833
+
+The sample also requires an antenna matrix when operating in Angle of Departure mode.
+It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.
+
+Configuration
+*************
+
+|config|
+
+Angle of Arrival mode
+=====================
+
+To build this sample with Angle of Arrival mode only, set ``OVERLAY_CONFIG`` to :file:`overlay-aoa.conf`.
+
+See :ref:`cmake_options` for instructions on how to add this option.
+For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
+Antenna matrix configuration for Angle of Departure mode
+========================================================
+
+To use this sample when Angle of Departure mode is enabled, additional configuration of GPIOs is required to control the antenna array.
+Example of such configuration is provided in a devicetree overlay file :file:`nrf52833dk_nrf52833.overlay`.
+
+The overlay file provides the information about which GPIOs should be used by the Radio peripheral to switch between antenna patches during the CTE transmission in the AoD mode.
+At least two GPIOs must be provided to enable antenna switching.
+
+The GPIOs are used by the Radio peripheral in order given by the ``dfegpio#-gpios`` properties.
+The order is important because it affects mapping of the antenna switching patterns to GPIOs (see `Antenna patterns`_).
+
+To successfully use the Direction Finding beacon when the AoD mode is enabled, provide the following data related to antenna matrix design:
+
+* Provide the GPIO pins to ``dfegpio#-gpios`` properties in :file:`nrf52833dk_nrf52833.overlay` file
+* Provide the default antenna that will be used to transmit PDU ``dfe-pdu-antenna`` property in :file:`nrf52833dk_nrf52833.overlay` file
+* Update the antenna switching patterns in :c:member:`ant_patterns` array in :file:`main.c`.
+
+Antenna patterns
+================
+
+The antenna switching pattern is a binary number where each bit is applied to a particular antenna GPIO pin.
+For example, the pattern 0x3 means that antenna GPIOs at index 0,1 will be set, while the following are left unset.
+
+This also means that, for example, when using four GPIOs, the pattern count cannot be greater than 16 and maximum allowed value is 15.
+
+If the number of switch-sample periods is greater than the number of stored switching patterns, then the radio loops back to the first pattern.
+
+The following table presents the patterns that you can use to switch antennas on the Nordic-designed antenna matrix:
+
++--------+--------------+
+|Antenna | PATTERN[3:0] |
++========+==============+
+| ANT_12 |  0 (0b0000)  |
++--------+--------------+
+| ANT_10 |  1 (0b0001)  |
++--------+--------------+
+| ANT_11 |  2 (0b0010)  |
++--------+--------------+
+| RFU    |  3 (0b0011)  |
++--------+--------------+
+| ANT_3  |  4 (0b0100)  |
++--------+--------------+
+| ANT_1  |  5 (0b0101)  |
++--------+--------------+
+| ANT_2  |  6 (0b0110)  |
++--------+--------------+
+| RFU    |  7 (0b0111)  |
++--------+--------------+
+| ANT_6  |  8 (0b1000)  |
++--------+--------------+
+| ANT_4  |  9 (0b1001)  |
++--------+--------------+
+| ANT_5  | 10 (0b1010)  |
++--------+--------------+
+| RFU    | 11 (0b1011)  |
++--------+--------------+
+| ANT_9  | 12 (0b1100)  |
++--------+--------------+
+| ANT_7  | 13 (0b1101)  |
++--------+--------------+
+| ANT_8  | 14 (0b1110)  |
++--------+--------------+
+| RFU    | 15 (0b1111)  |
++--------+--------------+
+
+Building and Running
+********************
+.. |sample path| replace:: :file:`samples/bluetooth/direction_finding_connectionless_tx`
+
+.. include:: /includes/build_and_run.txt
+
+Testing
+=======
+
+After programming the sample to your development kit, test it by performing the following steps:
+
+1. |connect_terminal_specific|
+#. In the terminal window, check for information similar to the following::
+
+      Starting Direction Finding periodic advertising Beacon Demo
+      Bluetooth initialization...success
+      Advertising set create...success
+      Update CTE params...success
+      Periodic advertising params set...success
+      Enable CTE...success
+      Periodic advertising enable...success
+      Extended advertising enable...success
+      Started extended advertising as XX:XX:XX:XX:XX:XX (random)
+
+Dependencies
+************
+
+This sample uses the following Zephyr libraries:
+
+* ``include/zephyr/types.h``
+* ``lib/libc/minimal/include/errno.h``
+* ``include/sys/printk.h``
+* ``include/sys/byteorder.h``
+* ``include/sys/util.h``
+* :ref:`zephyr:bluetooth_api`:
+
+  * ``include/bluetooth/bluetooth.h``
+  * ``include/bluetooth/hci.h``
+  * ``include/bluetooth/direction.h``
+  * ``include/bluetooth/gatt.h``

--- a/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is a number of antennas that are available on antenna matrix
+	 * designed by Nordic. For more information see README.rst.
+	 */
+	dfe-antenna-num = < 12 >;
+	/* This is a setting that enables antenna 12 (in antenna matrix designed
+	 * by Nordic) for Tx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoD is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
+};

--- a/samples/bluetooth/direction_finding_connectionless_tx/overlay-aoa.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/overlay-aoa.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable AoD Feature (antenna switching) in Tx mode
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n

--- a/samples/bluetooth/direction_finding_connectionless_tx/prj.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/prj.conf
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT=y
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+CONFIG_BT_DEVICE_NAME="DF Connectionless Beacon App"
+
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_PER_ADV=y
+CONFIG_BT_CTLR_ADV_EXT=y
+CONFIG_BT_CTLR_ADV_PERIODIC=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_DF=y
+CONFIG_BT_CTLR_DF=y
+CONFIG_BT_CTLR_DF_ADV_CTE_TX=y

--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  name: Direction Finding Connectionless Beacon
+  description: Sample application showing connectionless Direction Finding transmission
+tests:
+  sample.bluetooth.direction_finding_connectionless:
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth
+  sample.bluetooth.direction_finding_connectionless.aoa:
+    extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth

--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <errno.h>
+#include <zephyr.h>
+#include <sys/printk.h>
+
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/direction.h>
+#include <sys/byteorder.h>
+#include <sys/util.h>
+
+/* Length of CTE in unit of 8[us] */
+#define CTE_LEN (0x14U)
+
+static void adv_sent_cb(struct bt_le_ext_adv *adv,
+			struct bt_le_ext_adv_sent_info *info);
+
+const static struct bt_le_ext_adv_cb adv_callbacks = {
+	.sent = adv_sent_cb,
+};
+
+static struct bt_le_ext_adv *adv_set;
+
+const static struct bt_le_adv_param param =
+		BT_LE_ADV_PARAM_INIT(BT_LE_ADV_OPT_EXT_ADV |
+				     BT_LE_ADV_OPT_USE_NAME,
+				     BT_GAP_ADV_FAST_INT_MIN_2,
+				     BT_GAP_ADV_FAST_INT_MAX_2,
+				     NULL);
+
+static struct bt_le_ext_adv_start_param ext_adv_start_param = {
+	.timeout = 0,
+	.num_events = 0,
+};
+
+const static struct bt_le_per_adv_param per_adv_param = {
+	.interval_min = BT_GAP_ADV_SLOW_INT_MIN,
+	.interval_max = BT_GAP_ADV_SLOW_INT_MAX,
+	.options = BT_LE_ADV_OPT_USE_TX_POWER,
+};
+
+#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+/* Example sequence of antenna switch patterns for antenna matrix designed by
+ * Nordic. For more information about antenna switch patterns see README.rst.
+ */
+static uint8_t ant_patterns[] = {0x2, 0x0, 0x5, 0x6, 0x1, 0x4, 0xC, 0x9, 0xE,
+				 0xD, 0x8, 0xA};
+#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+
+const struct bt_df_adv_cte_tx_param cte_params = {
+	.cte_len = CTE_LEN,
+	.cte_count = 1,
+#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+	.cte_type = BT_HCI_LE_AOD_CTE_2US,
+	.num_ant_ids = ARRAY_SIZE(ant_patterns),
+	.ant_ids = ant_patterns
+#else
+	.cte_type = BT_HCI_LE_AOA_CTE,
+	.num_ant_ids = 0,
+	.ant_ids = NULL
+#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+	};
+
+static void adv_sent_cb(struct bt_le_ext_adv *adv,
+			struct bt_le_ext_adv_sent_info *info)
+{
+	printk("Advertiser[%d] %p sent %d\n", bt_le_ext_adv_get_index(adv),
+	       adv, info->num_sent);
+}
+
+void main(void)
+{
+	char addr_s[BT_ADDR_LE_STR_LEN];
+	struct bt_le_oob oob_local;
+	int err;
+
+	printk("Starting Direction Finding periodic advertising Beacon Demo\n");
+
+	/* Initialize the Bluetooth Subsystem */
+	printk("Bluetooth initialization...");
+	err = bt_enable(NULL);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success\n");
+
+	printk("Advertising set create...");
+	err = bt_le_ext_adv_create(&param, &adv_callbacks, &adv_set);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success\n");
+
+	printk("Update CTE params...");
+	err = bt_df_set_adv_cte_tx_param(adv_set, &cte_params);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success\n");
+
+	printk("Periodic advertising params set...");
+	err = bt_le_per_adv_set_param(adv_set, &per_adv_param);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success\n");
+
+	printk("Enable CTE...");
+	err = bt_df_adv_cte_tx_enable(adv_set);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success\n");
+
+	printk("Periodic advertising enable...");
+	err = bt_le_per_adv_start(adv_set);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success\n");
+
+	printk("Extended advertising enable...");
+	err = bt_le_ext_adv_start(adv_set, &ext_adv_start_param);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success\n");
+
+	bt_le_ext_adv_oob_get_local(adv_set, &oob_local);
+	bt_addr_le_to_str(&oob_local.addr, addr_s, sizeof(addr_s));
+
+	printk("Started extended advertising as %s\n", addr_s);
+}


### PR DESCRIPTION
Add sample of Direction Finding connectionless beacon application.
The sample provides configuration for DF extension for Nordic
Radio peripheral that allows to use it with Nordic design 12 patches
antenna matrix.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>