### PR TITLE
openthread: remove libs selection from Harness overlay

### DIFF
--- a/doc/nrf/ug_thread_certification.rst
+++ b/doc/nrf/ug_thread_certification.rst
@@ -63,11 +63,11 @@ Complete the following steps to run the certification tests:
    .. code-block::
 
          cd ncs/nrf/samples/openthread/cli/
-         west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG="harness/overlay-cert.conf"
+         west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG=harness/overlay-cert.conf -DCONFIG_OPENTHREAD_LIBRARY_1_1=y
 
    .. note::
-      The overlay file selects the precompiled OpenThread libraries.
-      It also enables :ref:`multiprotocol support <ug_multiprotocol_support>` with Bluetooth LE advertising.
+      The configuration option selects the precompiled OpenThread libraries.
+      The overlay file enables :ref:`multiprotocol support <ug_multiprotocol_support>` with Bluetooth LE advertising.
 
 #. Prepare Thread Test Harness.
 

--- a/samples/openthread/cli/harness/overlay-cert.conf
+++ b/samples/openthread/cli/harness/overlay-cert.conf
@@ -19,9 +19,6 @@ CONFIG_SHELL_PROMPT_UART=""
 CONFIG_SHELL_VT100_COLORS=n
 CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=416
 
-# Use the precompiled OpenThread libraries
-CONFIG_OPENTHREAD_LIBRARY_1_1=y
-
 # Enable Bluetooth LE controller which supports multiprotocol
 CONFIG_BT_LL_SOFTDEVICE_DEFAULT=y
 


### PR DESCRIPTION
Deselect the Thread 1.1. precompiled libraries from the Harness overlay file.

This allows for easier adaptation for Thread 1.2 testing in the future.

This will also detach Thread CI from using libraries.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-9139