### PR TITLE
scripts: update requirements-doc.txt

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,4 +1,3 @@
 recommonmark==0.6.0
 CommonMark>=0.9.1
 sphinxcontrib-mscgen
-west>=0.7.2


### PR DESCRIPTION
Fix error "Double requirement given: west>=0.7.2 (from -r
nrf/scripts/requirements-doc.txt (line 4)) (already in west>=0.9.0 (from
-r nrf/scripts/requirements-base.txt (line 1)), name='west')"

Signed-off-by: Alexey Markevich <buhhunyx@gmail.com>