### PR TITLE
doc: known issues: fix font size

### DIFF
--- a/doc/nrf/includes/filter.js
+++ b/doc/nrf/includes/filter.js
@@ -20,6 +20,10 @@
 
     };
 
+    /** Fix a bug in the theme that displays the dl > dt in different
+        font sizes depending on if the dd has one or more paragraphs  **/
+    $( "dl:not(.simple)" ).addClass( "simple" );
+
     /** Display classes of the format vX-X-X as tag vX.X.X **/
     $("#known-issues dl").each(function() {
 


### PR DESCRIPTION
We are using definition lists to display each known issue.
The RST processing tries to be smart by picking a font size
depending on how much content each entry in the definition
list has. However, we want the same font size for every
definition list on this page - therefore, adapting the script
to insert class="simple" for all definition lists (not only
the ones that the processing picks).

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>