### PR TITLE
tests: skip dfu_target_mcuboot test for native posix

### DIFF
--- a/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   dfu.dfu_target_mcuboot:
     tags: dfu mcuboot
-    # nrfx is used to ensure that variables are stored in RAM, so no qemu.
-    platform_exclude: qemu_cortex_m3 qemu_x86
+    # nrfx is used to ensure that variables are stored in RAM, so no qemu
+    # or native posix
+    platform_exclude: qemu_cortex_m3 qemu_x86 native_posix


### PR DESCRIPTION
The DUT use nrfx, so can only be executed on target.
Hence we need to add native_posix to the list of platforms
to exclud.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>