### PR TITLE
samples: nrf9160: lwm2m_client: Fix build for Thingy91

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/ui/led_pwm.c
+++ b/samples/nrf9160/lwm2m_client/src/ui/led_pwm.c
@@ -130,7 +130,7 @@ static void work_handler(struct k_work *work)
 		int32_t next_delay =
 			leds.effect->steps[leds.effect_step].substep_time;
 
-		k_delayed_work_submit(&leds.work, next_delay);
+		k_delayed_work_submit(&leds.work, K_MSEC(next_delay));
 	}
 }
 
@@ -152,7 +152,7 @@ static void led_update(struct led *led)
 		int32_t next_delay =
 			led->effect->steps[led->effect_step].substep_time;
 
-		k_delayed_work_submit(&led->work, next_delay);
+		k_delayed_work_submit(&led->work, K_MSEC(next_delay));
 	} else {
 		LOG_DBG("LED effect with no effect");
 	}


### PR DESCRIPTION
led_pwm.c is only built for Thingy91, so it was not spotted by the CI
that there's some leftover from an old Zephyr timing rework.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>