### PR TITLE
samples: connectedhomeip: Added choosing RNG instead of crypto cell

### DIFF
--- a/samples/connectedhomeip/light_bulb/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/connectedhomeip/light_bulb/boards/nrf52840dk_nrf52840.overlay
@@ -6,6 +6,17 @@
 
 / {
 	/*
+	* In some default configurations within the nRF Connect SDK,
+	* e.g. on nRF52840, the chosen zephyr,entropy node is &cryptocell.
+	* This devicetree overlay ensures that default is overridden wherever it
+	* is set, as this application uses the RNG node for entropy exclusively.
+	*/
+
+	chosen {
+		zephyr,entropy = &rng;
+	};
+
+	/*
 	* By default, PWM module is only configured for led0 (LED1 on the board).
 	* The lighting-app, however, uses LED2 to show the state of the lighting,
 	* including its brightness level.

--- a/samples/connectedhomeip/light_switch/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/connectedhomeip/light_switch/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,16 @@
+/* Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/*
+	* In some default configurations within the nRF Connect SDK,
+	* e.g. on nRF52840, the chosen zephyr,entropy node is &cryptocell.
+	* This devicetree overlay ensures that default is overridden wherever it
+	* is set, as this application uses the RNG node for entropy exclusively.
+	*/
+	chosen {
+		zephyr,entropy = &rng;
+	};
+};

--- a/samples/connectedhomeip/lock/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/connectedhomeip/lock/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,16 @@
+/* Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/*
+	* In some default configurations within the nRF Connect SDK,
+	* e.g. on nRF52840, the chosen zephyr,entropy node is &cryptocell.
+	* This devicetree overlay ensures that default is overridden wherever it
+	* is set, as this application uses the RNG node for entropy exclusively.
+	*/
+	chosen {
+		zephyr,entropy = &rng;
+	};
+};


### PR DESCRIPTION
The https://github.com/nrfconnect/sdk-nrf/pull/3793 PR resulted in Zephyr system crash on boot in connectedhomeip samples. Changed entropy node on RNG by the time problem in crypto cell will be resolved.