### PR TITLE
Bluetooth: Mesh: Make public the acknowledged message timeout configuration

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -12,6 +12,24 @@ config BT_MESH_NRF_MODELS
 	  Common mesh model support modules, required by all Nordic BT mesh
 	  models.
 
+menu "Configuration of the waiting time for acknowledged messages"
+
+config BT_MESH_MOD_ACKD_TIMEOUT_BASE
+	int "The base timeout for acknowledged messages"
+	default 3000
+	help
+	  The base timeout in milliseconds that the model waits for the response
+	  if it is required. The response is typically a status message.
+	  Mesh Profile recommends the waiting time a minimum of 30 seconds.
+
+config BT_MESH_MOD_ACKD_TIMEOUT_PER_HOP
+	int "The per hop timeout for acknowledged messages"
+	default 50
+	help
+	  The timeout in milliseconds that the model adds per hop
+	  to the base response time.
+
+endmenu
 
 config BT_MESH_ONOFF_SRV
 	bool "Generic OnOff Server"

--- a/subsys/bluetooth/mesh/model_utils.c
+++ b/subsys/bluetooth/mesh/model_utils.c
@@ -17,9 +17,6 @@
 /** Delay field step factor in milliseconds */
 #define DELAY_TIME_STEP_MS (5)
 
-#define MOD_ACKD_TIMEOUT_BASE 200
-#define MOD_ACKD_TIMEOUT_PER_HOP 50
-
 int tid_check_and_update(struct bt_mesh_tid_ctx *prev_transaction, uint8_t tid,
 			 const struct bt_mesh_msg_ctx *ctx)
 {
@@ -138,8 +135,8 @@ int model_ackd_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	if (ack) {
 		if (retval == 0) {
 			uint8_t ttl = (ctx ? ctx->send_ttl : mod->pub->ttl);
-			int32_t time = (MOD_ACKD_TIMEOUT_BASE +
-				      ttl * MOD_ACKD_TIMEOUT_PER_HOP);
+			int32_t time = (CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_BASE +
+				ttl * CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_PER_HOP);
 			return model_ack_wait(ack, time);
 		}
 


### PR DESCRIPTION
The acknowledged message timeout is application specific.
The configuration settings for acknowledged messages have been moved
into Kconfig.models to make them publicly available.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>