### PR TITLE
Bluetooth: Mesh: Simplify scheduler design by removing unnecessary extension

### DIFF
--- a/include/bluetooth/mesh/scheduler_srv.rst
+++ b/include/bluetooth/mesh/scheduler_srv.rst
@@ -143,8 +143,8 @@ Each entry has the following fields:
 Extended models
 ***************
 
-The Scheduler Server extends the :ref:`bt_mesh_scene_srv_readme`.
-In addition, the Scheduler Setup Server extends the Scene Setup Server (see the :ref:`bt_mesh_scene_srv_readme` documentation) and the Generic Power OnOff Setup Server (see the :ref:`bt_mesh_ponoff_srv_readme` documentation).
+The Scheduler Server is implemented as a root model.
+When a Scheduler Server model is present on an element, the Scene Server model (see the :ref:`bt_mesh_scene_srv_readme` documentation) shall also be present on the same element.
 
 Persistent storage
 ******************

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -604,8 +604,6 @@ config BT_MESH_SCENE_CLI
 	help
 	  Enable mesh Scene Client model.
 
-endmenu
-
 config BT_MESH_SCHEDULER_CLI
 	bool "Scheduler Client"
 	select BT_MESH_NRF_MODELS
@@ -620,3 +618,5 @@ config BT_MESH_SCHEDULER_SRV
 	select BT_MESH_TIME_SRV
 	help
 	  Enable Mesh Scheduler Server model.
+
+endmenu

--- a/subsys/bluetooth/mesh/scheduler_srv.c
+++ b/subsys/bluetooth/mesh/scheduler_srv.c
@@ -6,9 +6,6 @@
 
 #include <stdio.h>
 #include <bluetooth/mesh/models.h>
-#include <bluetooth/mesh/scheduler_srv.h>
-#include <bluetooth/mesh/scene_srv.h>
-#include <bluetooth/mesh/gen_onoff_srv.h>
 #include <sys/byteorder.h>
 #include <sys/util.h>
 #include <sys/math_extras.h>
@@ -689,28 +686,6 @@ static int scheduler_srv_init(struct bt_mesh_model *mod)
 		 * this model, as we won't have to support multiple extenders.
 		 */
 		bt_mesh_model_extend(mod, srv->setup_mod);
-
-		/* The Scheduler Server is a main model that extends
-		 * the Scene Server model.
-		 */
-		bt_mesh_model_extend(srv->scene_srv.mod, mod);
-
-		/* The Scheduler Setup Server is a main model that extends
-		 * the Scene Setup Server model.
-		 */
-		bt_mesh_model_extend(srv->scene_srv.setup_mod, srv->setup_mod);
-
-		/* The Scheduler Setup Server is a main model that extends
-		 * the Generic Power OnOff Setup Server.
-		 */
-		struct bt_mesh_model *gen_ponoff_setup_mod =
-			bt_mesh_model_find(bt_mesh_model_elem(mod),
-				BT_MESH_MODEL_ID_GEN_POWER_ONOFF_SETUP_SRV);
-
-		if (gen_ponoff_setup_mod) {
-			bt_mesh_model_extend(gen_ponoff_setup_mod,
-					srv->setup_mod);
-		}
 	}
 
 	srv->idx = BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT;


### PR DESCRIPTION
The Scheduler Server model is a root model and the main model
that does not extend any other model anymore.
However, it still requires the Scene server on the same element.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>