### PR TITLE
applications: serial_lte_modem: fix invalid port range

### DIFF
--- a/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
@@ -33,7 +33,7 @@ Syntax
 
 * The ``<host>`` parameter is a string.
   It represents the HTTP server hostname.
-* The ``<port>`` parameter is an integer.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the HTTP server port.
 * The ``<sec_tag>`` parameter is an integer.
   It indicates to the modem the credential of the security tag used for establishing a secure connection.

--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -40,7 +40,7 @@ Syntax
   It indicates the MQTT Client password in cleartext.
 * The ``<url>`` parameter is a string.
   It indicates the MQTT broker hostname.
-* The ``<port>`` parameter is an integer.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It indicates the MQTT broker port.
 * The ``<sec_tag>`` parameter is an integer.
   It indicates the credential of the security tag used for establishing a secure connection.
@@ -103,7 +103,7 @@ Response syntax
   It indicates the MQTT Client password in cleartext.
 * The ``<url>`` value is a string.
   It indicates the MQTT broker hostname.
-* The ``<port>`` value is an integer.
+* The ``<port>`` value is an unsigned 16-bit integer (0 - 65535).
   It indicates the MQTT broker port.
 * The ``<sec_tag>`` value is an integer.
   It indicates the credential of the security tag used for establishing a secure connection.

--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -347,7 +347,7 @@ Syntax
 
    #XBIND=<port>
 
-* The ``<port>`` parameter is an integer.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the specific port to use to bind the socket with.
 
 Examples
@@ -391,7 +391,7 @@ Syntax
   Its maximum size can be 128 bytes.
   When the parameter is an IP address, it supports IPv4 only, not IPv6.
 
-* The ``<port>`` parameter is an integer.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the port of the TCP service.
 
 Response syntax
@@ -717,7 +717,7 @@ Syntax
   It indicates the hostname or the IP address to connect to.
   Its maximum size can be 128 bytes.
   When the parameter is an IP address, it supports IPv4 only, not IPv6.
-* The ``<port>`` parameter is an integer.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the port of the TCP service.
 * The ``<datatype>`` parameter can accept one of the following values:
 
@@ -1026,7 +1026,7 @@ Syntax
   * ``1`` - Start the server
   * ``2`` - Start the server with data mode support
 
-* The ``<port>`` parameter is an integer.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the TCP service port.
   It is mandatory to set it when starting the server.
 * The ``<sec_tag>`` parameter is an integer.
@@ -1177,7 +1177,7 @@ Syntax
   It indicates the hostname or the IP address to connect to.
   Its maximum size is 128 bytes.
   When the parameter is an IP address, it supports IPv4 only, not IPv6.
-* The ``<port>`` parameter is an integer.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the TCP/TLS service port.
   It is mandatory for starting the server.
 * The ``<sec_tag>`` parameter is an integer.
@@ -1406,7 +1406,7 @@ Syntax
   * ``1`` - Start the server
   * ``2`` - Start the server with data mode support
 
-* The ``<port>`` parameter is an integer.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the UDP service port.
   It is mandatory for starting the server.
   The data mode is enabled when the TCP/TLS server is started.
@@ -1545,7 +1545,7 @@ Syntax
   It indicates the hostname or the IP address to connect to.
   Its maximum size can be 128 bytes.
   When the parameter is an IP address, it supports IPv4 only, not IPv6.
-* The ``<port>`` parameter is an integer.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the UDP/DTLS service port.
 * The ``<sec_tag>`` parameter is an integer.
   It indicates to the modem the credential of the security tag used for establishing a secure connection.

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -161,7 +161,7 @@ static int do_ftp_open(void)
 	int sz_password = FTP_MAX_PASSWORD;
 	char hostname[FTP_MAX_HOSTNAME];
 	int sz_hostname = FTP_MAX_HOSTNAME;
-	uint16_t port = CONFIG_SLM_FTP_SERVER_PORT;
+	int32_t port = CONFIG_SLM_FTP_SERVER_PORT;
 	sec_tag_t sec_tag = INVALID_SEC_TAG;
 	int param_count = at_params_valid_count_get(&at_param_list);
 
@@ -184,10 +184,14 @@ static int do_ftp_open(void)
 		return ret;
 	}
 	if (param_count > 5) {
-		ret = at_params_short_get(&at_param_list, 5, &port);
+		ret = at_params_int_get(&at_param_list, 5, &port);
 		if (ret) {
 			return ret;
 		}
+	}
+	if (!check_port_range(port)) {
+		LOG_ERR("Invalid port");
+		return -EINVAL;
 	}
 	if (param_count > 6) {
 		ret = at_params_int_get(&at_param_list, 6, &sec_tag);
@@ -197,7 +201,7 @@ static int do_ftp_open(void)
 	}
 
 	/* FTP open */
-	ret = ftp_open(hostname, port, sec_tag);
+	ret = ftp_open(hostname, (uint16_t)port, sec_tag);
 	if (ret != FTP_CODE_200) {
 		return -ENETUNREACH;
 	}

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -60,7 +60,7 @@ static struct slm_httpc_ctx {
 	bool sec_transport;		/* secure session flag */
 	uint32_t sec_tag;		/* security tag to be used */
 	char host[HTTPC_HOST_LEN + 1];	/* HTTP server address */
-	uint32_t port;			/* HTTP server port */
+	uint16_t port;			/* HTTP server port */
 	char *method_str;		/* request method */
 	char *resource;			/* resource */
 	char *headers;			/* headers */
@@ -502,6 +502,8 @@ static int handle_AT_HTTPC_CONNECT(enum at_cmd_type cmd_type)
 		}
 
 		if (op == AT_HTTPCCON_CONNECT) {
+			int32_t port;
+
 			if (at_params_valid_count_get(&at_param_list) <= 3) {
 				return -EINVAL;
 			}
@@ -515,12 +517,16 @@ static int handle_AT_HTTPC_CONNECT(enum at_cmd_type cmd_type)
 				return err;
 			}
 
-			err = at_params_int_get(&at_param_list, 3, &httpc.port);
+			err = at_params_int_get(&at_param_list, 3, &port);
 			if (err < 0) {
 				LOG_ERR("Fail to get port: %d", err);
 				return err;
 			}
-
+			if (!check_port_range(port)) {
+				LOG_ERR("Invalid port");
+				return -EINVAL;
+			}
+			httpc.port = (uint16_t)port;
 			if (at_params_valid_count_get(&at_param_list) == 5) {
 				err = at_params_int_get(&at_param_list, 4,
 							&httpc.sec_tag);

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -69,7 +69,7 @@ static struct slm_mqtt_ctx {
 	struct mqtt_utf8 password;
 	uint8_t pword[MQTT_MAX_PASSWORD_LEN + 1];
 	char url[MQTT_MAX_URL_LEN + 1];
-	uint32_t port;
+	uint16_t port;
 	sec_tag_t sec_tag;
 } ctx;
 
@@ -607,6 +607,8 @@ static int handle_at_mqtt_connect(enum at_cmd_type cmd_type)
 			return err;
 		}
 		if (op == AT_MQTTCON_CONNECT) {
+			int32_t port;
+
 			if (at_params_valid_count_get(&at_param_list) <= 6) {
 				return -EINVAL;
 			}
@@ -641,10 +643,15 @@ static int handle_at_mqtt_connect(enum at_cmd_type cmd_type)
 			if (err < 0) {
 				return err;
 			}
-			err = at_params_int_get(&at_param_list, 6, &ctx.port);
+			err = at_params_int_get(&at_param_list, 6, &port);
 			if (err < 0) {
 				return err;
 			}
+			if (!check_port_range(port)) {
+				LOG_ERR("Invalid port");
+				return -EINVAL;
+			}
+			ctx.port = (uint16_t)port;
 			if (at_params_valid_count_get(&at_param_list) == 8) {
 				err = at_params_int_get(&at_param_list, 7,
 							&ctx.sec_tag);

--- a/applications/serial_lte_modem/src/slm_at_tcpip.c
+++ b/applications/serial_lte_modem/src/slm_at_tcpip.c
@@ -843,7 +843,7 @@ static int handle_at_socketopt(enum at_cmd_type cmd_type)
 static int handle_at_bind(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
-	uint16_t port;
+	int32_t port;
 
 	if (client.sock < 0) {
 		LOG_ERR("Socket not opened yet");
@@ -852,11 +852,15 @@ static int handle_at_bind(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_short_get(&at_param_list, 1, &port);
+		err = at_params_int_get(&at_param_list, 1, &port);
 		if (err < 0) {
 			return err;
 		}
-		err = do_bind(port);
+		if (!check_port_range(port)) {
+			LOG_ERR("Invalid port");
+			return -EINVAL;
+		}
+		err = do_bind((uint16_t)port);
 		break;
 
 	default:
@@ -876,7 +880,7 @@ static int handle_at_connect(enum at_cmd_type cmd_type)
 	int err = -EINVAL;
 	char url[TCPIP_MAX_URL];
 	int size = TCPIP_MAX_URL;
-	uint16_t port;
+	int32_t port;
 
 	if (client.sock < 0) {
 		LOG_ERR("Socket not opened yet");
@@ -893,11 +897,15 @@ static int handle_at_connect(enum at_cmd_type cmd_type)
 		if (err) {
 			return err;
 		}
-		err = at_params_short_get(&at_param_list, 2, &port);
+		err = at_params_int_get(&at_param_list, 2, &port);
 		if (err) {
 			return err;
 		}
-		err = do_connect(url, port);
+		if (!check_port_range(port)) {
+			LOG_ERR("Invalid port");
+			return -EINVAL;
+		}
+		err = do_connect(url, (uint16_t)port);
 		break;
 
 	case AT_CMD_TYPE_READ_COMMAND:
@@ -1087,7 +1095,7 @@ static int handle_at_sendto(enum at_cmd_type cmd_type)
 	int err = -EINVAL;
 	char url[TCPIP_MAX_URL];
 	int size = TCPIP_MAX_URL;
-	uint16_t port;
+	int32_t port;
 	uint16_t datatype;
 	char data[NET_IPV4_MTU];
 
@@ -1107,9 +1115,13 @@ static int handle_at_sendto(enum at_cmd_type cmd_type)
 		if (err) {
 			return err;
 		}
-		err = at_params_short_get(&at_param_list, 2, &port);
+		err = at_params_int_get(&at_param_list, 2, &port);
 		if (err) {
 			return err;
+		}
+		if (!check_port_range(port)) {
+			LOG_ERR("Invalid port");
+			return -EINVAL;
 		}
 		err = at_params_short_get(&at_param_list, 3, &datatype);
 		if (err) {
@@ -1128,7 +1140,7 @@ static int handle_at_sendto(enum at_cmd_type cmd_type)
 				err = do_sendto(url, port, data_hex, err);
 			}
 		} else {
-			err = do_sendto(url, port, data, size);
+			err = do_sendto(url, (uint16_t)port, data, size);
 		}
 		break;
 

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -426,11 +426,15 @@ static int handle_at_udp_server(enum at_cmd_type cmd_type)
 		}
 		if (op == AT_SERVER_START ||
 		    op == AT_SERVER_START_WITH_DATAMODE) {
-			uint16_t port;
+			int32_t port;
 
-			err = at_params_short_get(&at_param_list, 2, &port);
+			err = at_params_int_get(&at_param_list, 2, &port);
 			if (err) {
 				return err;
+			}
+			if (!check_port_range(port)) {
+				LOG_ERR("Invalid port");
+				return -EINVAL;
 			}
 			if (udp_sock > 0) {
 				LOG_WRN("Server is running");
@@ -442,7 +446,7 @@ static int handle_at_udp_server(enum at_cmd_type cmd_type)
 				return -EINVAL;
 			}
 #endif
-			err = do_udp_server_start(port);
+			err = do_udp_server_start((uint16_t)port);
 			if (err == 0 && op == AT_SERVER_START_WITH_DATAMODE) {
 				udp_datamode = true;
 				enter_datamode();
@@ -500,7 +504,7 @@ static int handle_at_udp_client(enum at_cmd_type cmd_type)
 		}
 		if (op == AT_CLIENT_CONNECT ||
 		    op == AT_CLIENT_CONNECT_WITH_DATAMODE) {
-			uint16_t port;
+			int32_t port;
 			char url[TCPIP_MAX_URL];
 			int size = TCPIP_MAX_URL;
 			sec_tag_t sec_tag = INVALID_SEC_TAG;
@@ -509,9 +513,13 @@ static int handle_at_udp_client(enum at_cmd_type cmd_type)
 			if (err) {
 				return err;
 			}
-			err = at_params_short_get(&at_param_list, 3, &port);
+			err = at_params_int_get(&at_param_list, 3, &port);
 			if (err) {
 				return err;
+			}
+			if (!check_port_range(port)) {
+				LOG_ERR("Invalid port");
+				return -EINVAL;
 			}
 			if (at_params_valid_count_get(&at_param_list) > 4) {
 				at_params_int_get(&at_param_list, 4, &sec_tag);
@@ -522,7 +530,7 @@ static int handle_at_udp_client(enum at_cmd_type cmd_type)
 				return -EINVAL;
 			}
 #endif
-			err = do_udp_client_connect(url, port, sec_tag);
+			err = do_udp_client_connect(url, (uint16_t)port, sec_tag);
 			if (err == 0 &&
 			    op == AT_CLIENT_CONNECT_WITH_DATAMODE) {
 				udp_datamode = true;

--- a/applications/serial_lte_modem/src/slm_util.c
+++ b/applications/serial_lte_modem/src/slm_util.c
@@ -145,6 +145,17 @@ bool check_for_ipv4(const char *address, uint8_t length)
 	return true;
 }
 
+/**@brief Check whether an integer value is in valid port range
+ */
+bool check_port_range(int32_t port)
+{
+	if (port > 65535 || port < 0) {
+		return false;
+	}
+
+	return true;
+}
+
 /**brief use AT command to get IPv4 address
  */
 bool util_get_ipv4_addr(char *address)

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -94,6 +94,13 @@ int slm_util_atoh(const char *ascii, uint16_t ascii_len,
  */
 bool check_for_ipv4(const char *address, uint8_t length);
 
+/**@brief Check whether an integer value is in valid port range
+ *
+ * @param port value to be checked
+ *
+ * @return true if integer value is in valid port range, false otherwise
+ */
+bool check_port_range(int32_t port);
 
 /**brief use AT command to get IPv4 address
  *


### PR DESCRIPTION
The <port> parameter parsed by at_params_short_get()
can not cover correct port range 0 - 65535. The change
in this commit parse the <port> parameter by at_params_int_get()
and check whether the parsed port value is in valid range or not.

Signed-off-by: Larry Tsai <larry.tsai@nordicsemi.no>