### PR TITLE
lib/subsys: enable offloading posix appl compilation without NET_SOCKETS_POSIX_NAMES

### DIFF
--- a/lib/at_cmd/at_cmd.c
+++ b/lib/at_cmd/at_cmd.c
@@ -7,7 +7,12 @@
 #include <logging/log.h>
 #include <zephyr.h>
 #include <stdio.h>
+#if defined(CONFIG_POSIX_API)
+#include <posix/unistd.h>
+#include <posix/sys/socket.h>
+#else
 #include <net/socket.h>
+#endif
 #include <init.h>
 #include <nrf_modem_limits.h>
 

--- a/lib/nrf_modem_lib/Kconfig
+++ b/lib/nrf_modem_lib/Kconfig
@@ -7,7 +7,7 @@ menuconfig NRF_MODEM_LIB
 	bool "Enable Modem library"
 	imply NRFX_IPC
 	imply NET_SOCKETS_OFFLOAD
-	imply NET_SOCKETS_POSIX_NAMES
+	imply NET_SOCKETS_POSIX_NAMES if !POSIX_API
 	select NRF_MODEM
 	help
 	  Use Nordic Modem library.

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -22,6 +22,12 @@
 #include <sys/fdtable.h>
 #include <zephyr.h>
 
+#if defined(CONFIG_POSIX_API)
+#include <posix/poll.h>
+#include <posix/sys/time.h>
+#include <posix/sys/socket.h>
+#endif
+
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
 
 #if defined(CONFIG_NRF91_SOCKET_ENABLE_DEBUG_LOGS)

--- a/subsys/dfu/dfu_target/src/dfu_target_modem_delta.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_modem_delta.c
@@ -7,7 +7,12 @@
 #include <zephyr.h>
 #include <stdio.h>
 #include <drivers/flash.h>
+#if defined(CONFIG_POSIX_API)
+#include <posix/unistd.h>
+#include <posix/sys/socket.h>
+#else
 #include <net/socket.h>
+#endif
 #include <nrf_socket.h>
 #include <logging/log.h>
 #include <dfu/dfu_target.h>

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -9,7 +9,14 @@
 #include <zephyr.h>
 #include <zephyr/types.h>
 #include <toolchain/common.h>
+#if defined(CONFIG_POSIX_API)
+#include <posix/unistd.h>
+#include <posix/netdb.h>
+#include <posix/sys/time.h>
+#include <posix/sys/socket.h>
+#else
 #include <net/socket.h>
+#endif
 #include <net/tls_credentials.h>
 #include <net/download_client.h>
 #include <logging/log.h>
@@ -65,8 +72,11 @@ static int socket_timeout_set(int fd, int type)
 		.tv_usec = (timeout_ms % 1000) * 1000,
 	};
 
+#if defined(CONFIG_POSIX_API)
+	LOG_INF("Configuring socket timeout (%d s)", (int32_t)timeo.tv_sec);
+#else
 	LOG_INF("Configuring socket timeout (%ld s)", timeo.tv_sec);
-
+#endif
 	err = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeo, sizeof(timeo));
 	if (err) {
 		LOG_WRN("Failed to set socket timeout, errno %d", errno);

--- a/subsys/net/lib/zzhc/zzhc.c
+++ b/subsys/net/lib/zzhc/zzhc.c
@@ -11,7 +11,14 @@ LOG_MODULE_REGISTER(zzhc, CONFIG_ZZHC_LOG_LEVEL);
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
+#if defined(CONFIG_POSIX_API)
+#include <posix/unistd.h>
+#include <posix/netdb.h>
+#include <posix/sys/socket.h>
+#else
 #include <net/socket.h>
+#endif
+
 #include "zzhc_internal.h"
 
 #define REGVER            2         /** Self-registration protocol version */

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5acae16d9ea808785279b1de1cd177108c1b1354
+      revision: 37430f7c6b7b1e075fff26961e8dcfab12b6c800
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION

Enable POSIX_API application compilation with offloading/libmodem, i.e. without CONFIG_NET_SOCKETS_POSIX_NAMES for certain lib/subsys conponents.
Jira: MOSH-72
Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>