### PR TITLE
net: fota_download: Add API to get fota image type

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -52,6 +52,10 @@ nRF9160
 
     * Updated to prevent reinitialization of param list in :c:func:`modem_info_init`.
 
+  * :ref:`lib_fota_download` library:
+
+    * Added an API to retrieve the image type that is being downloaded.
+
 Common
 ======
 

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -105,6 +105,15 @@ int fota_download_init(fota_download_callback_t client_callback);
 int fota_download_start(const char *host, const char *file, int sec_tag,
 			const char *apn, size_t fragment_size);
 
+/**@brief Get target image type.
+ *
+ * Image type becomes known after download starts.
+ *
+ * @retval 0 Unknown type before download starts.
+ *           Otherwise, a type defined in enum dfu_target_image_type.
+ */
+int fota_download_target(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -37,6 +37,8 @@ static int socket_retries_left;
 #ifdef CONFIG_DFU_TARGET_MCUBOOT
 static uint8_t mcuboot_buf[CONFIG_FOTA_DOWNLOAD_MCUBOOT_FLASH_BUF_SZ];
 #endif
+static enum dfu_target_image_type img_type;
+
 static void send_evt(enum fota_download_evt_id id)
 {
 	__ASSERT(id != FOTA_DOWNLOAD_EVT_PROGRESS, "use send_progress");
@@ -102,7 +104,7 @@ static int download_client_callback(const struct download_client_evt *event)
 				return err;
 			}
 			first_fragment = false;
-			int img_type = dfu_target_img_type(event->fragment.buf,
+			img_type = dfu_target_img_type(event->fragment.buf,
 							event->fragment.len);
 			err = dfu_target_init(img_type, file_size,
 					      dfu_target_callback_handler);
@@ -366,4 +368,9 @@ int fota_download_init(fota_download_callback_t client_callback)
 	}
 
 	return 0;
+}
+
+int fota_download_target(void)
+{
+	return img_type;
 }


### PR DESCRIPTION
Return the DFU target image type, available when download start
This enables APP to determine what type of FOTA is going on.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>