### PR TITLE
applications: machine_learning: Add Thingy52 configuration

### DIFF
--- a/applications/machine_learning/configuration/thingy52_nrf52832/app_ZDebug.conf
+++ b/applications/machine_learning/configuration/thingy52_nrf52832/app_ZDebug.conf
@@ -1,0 +1,80 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+################################################################################
+# Application configuration
+
+CONFIG_ML_APP_ML_RUNNER_ENABLE=y
+CONFIG_ML_APP_ML_RUNNER_WINDOW_SHIFT=0
+CONFIG_ML_APP_ML_RUNNER_FRAME_SHIFT=5
+
+CONFIG_CAF=y
+
+CONFIG_CAF_INIT_LOG_SENSOR_EVENTS=n
+
+CONFIG_CAF_SENSOR_SAMPLER=y
+
+CONFIG_CAF_BUTTONS=y
+CONFIG_CAF_BUTTONS_POLARITY_INVERSED=y
+
+################################################################################
+# EI wrapper configuration
+
+CONFIG_CPLUSPLUS=y
+CONFIG_LIB_CPLUSPLUS=y
+CONFIG_STD_CPP11=y
+CONFIG_FPU=y
+
+# Use the NCS machine learning model for simulated acceleration signal
+CONFIG_EDGE_IMPULSE=y
+CONFIG_EDGE_IMPULSE_URI="https://studio.edgeimpulse.com/v1/api/18121/deployment/download?type=zip"
+CONFIG_EI_WRAPPER=y
+
+################################################################################
+# System configuration
+
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+CONFIG_ISR_STACK_SIZE=1536
+CONFIG_MAIN_STACK_SIZE=768
+CONFIG_IDLE_STACK_SIZE=512
+
+CONFIG_HEAP_MEM_POOL_SIZE=2048
+
+CONFIG_SPEED_OPTIMIZATIONS=y
+CONFIG_HW_STACK_PROTECTION=y
+
+CONFIG_BOOT_BANNER=n
+CONFIG_NUM_COOP_PRIORITIES=10
+CONFIG_NUM_PREEMPT_PRIORITIES=11
+
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+
+CONFIG_EVENT_MANAGER=y
+CONFIG_LINKER_ORPHAN_SECTION_PLACE=y
+CONFIG_REBOOT=y
+
+CONFIG_GPIO=y
+
+# Using built-in sensor
+CONFIG_SENSOR=y
+CONFIG_LIS2DH=y
+CONFIG_LIS2DH_ACCEL_RANGE_16G=y
+CONFIG_LIS2DH_ODR_4=y
+
+################################################################################
+# Debug configuration (logger using RTT)
+
+CONFIG_ASSERT=y
+CONFIG_RESET_ON_FATAL_ERROR=n
+
+CONFIG_LOG=y
+CONFIG_USE_SEGGER_RTT=y
+CONFIG_LOG_BACKEND_RTT=y
+CONFIG_LOG_PRINTK=y
+CONFIG_NEWLIB_LIBC=y
+CONFIG_NEWLIB_LIBC_FLOAT_PRINTF=y
+
+CONFIG_LOG_STRDUP_BUF_COUNT=20
+CONFIG_LOG_STRDUP_MAX_STRING=64

--- a/applications/machine_learning/configuration/thingy52_nrf52832/buttons_def.h
+++ b/applications/machine_learning/configuration/thingy52_nrf52832/buttons_def.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <caf/gpio_pins.h>
+
+/* This configuration file is included only once from buttons module and holds
+ * information about pins forming keyboard matrix.
+ */
+
+/* This structure enforces the header file is included only once in the build.
+ * Violating this requirement triggers a multiple definition error at link time.
+ */
+const struct {} buttons_def_include_once;
+
+static const struct gpio_pin col[] = {};
+
+static const struct gpio_pin row[] = {
+	{ .port = 0, .pin = DT_GPIO_PIN(DT_NODELABEL(button0), gpios) },
+};

--- a/applications/machine_learning/configuration/thingy52_nrf52832/sensor_sampler_def.h
+++ b/applications/machine_learning/configuration/thingy52_nrf52832/sensor_sampler_def.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <caf/sensor_sampler.h>
+
+/* This configuration file is included only once from sensor_sampler module and holds
+ * information about the sampled sensors.
+ */
+
+/* This structure enforces the header file is included only once in the build.
+ * Violating this requirement triggers a multiple definition error at link time.
+ */
+const struct {} sensor_sampler_def_include_once;
+
+
+static const struct sampled_channel accel_chan[] = {
+	{
+		.chan = SENSOR_CHAN_ACCEL_XYZ,
+		.data_cnt = 3,
+	},
+};
+
+static const struct sensor_config sensor_configs[] = {
+	{
+		.dev_name = "LIS2DH12-ACCEL",
+		.event_descr = "accel_xyz",
+		.chans = accel_chan,
+		.chan_cnt = ARRAY_SIZE(accel_chan),
+		.sampling_period_ms = 50,
+	},
+};


### PR DESCRIPTION
Change adds debug configuration for Thingy52 board. The configuration uses LIS2DH accelerometer.

- [x] #4077 must be merged first.