### PR TITLE
samples: nrf9160: lwm2m_client: Use the actual network mode

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/lwm2m/include/lwm2m_client.h
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/include/lwm2m_client.h
@@ -34,7 +34,7 @@ int lwm2m_verify_modem_fw_update(void);
 
 #if defined(CONFIG_LWM2M_CONN_MON_OBJ_SUPPORT)
 int lwm2m_init_connmon(void);
-int lwm2m_start_connmon(void);
+int lwm2m_update_connmon(void);
 #endif
 
 #if defined(CONFIG_LWM2M_IPSO_LIGHT_CONTROL)

--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -475,14 +475,14 @@ void main(void)
 
 	modem_connect();
 
+	while (true) {
 #if defined(CONFIG_LWM2M_CONN_MON_OBJ_SUPPORT)
-	ret = lwm2m_start_connmon();
-	if (ret < 0) {
-		LOG_ERR("Error registering rsrp handler (%d)", ret);
-	}
+		ret = lwm2m_update_connmon();
+		if (ret < 0) {
+			LOG_ERR("Error registering rsrp handler (%d)", ret);
+		}
 #endif
 
-	while (true) {
 		lwm2m_rd_client_start(&client, endpoint_name, flags,
 				      rd_client_event);
 


### PR DESCRIPTION
Update the network mode set in the Connectivity Monitoring object to the
actual network mode returned by the modem instead of a hardcoded LTE
mode.

Rename `lwm2m_start_conmon()` function to `lwm2m_update_conmon()` to
better reflect it's purpose. Make sure the function is called on after
we reconnect to the network.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>