### PR TITLE
tests: zigbee: Fix path calculation to ZBOSS include dir

### DIFF
--- a/tests/subsys/zigbee/osif/crypto/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/crypto/CMakeLists.txt
@@ -16,8 +16,8 @@ target_compile_definitions(app PRIVATE
 
 target_include_directories(app PRIVATE
   ${NRF_DIR}/subsys/zigbee/osif
-  ${NRFXLIB_DIR}/zboss/include
-  ${NRFXLIB_DIR}/zboss/include/osif
+  ${NRFXLIB_DIR}/zboss/production/include
+  ${NRFXLIB_DIR}/zboss/production/include/osif
 )
 
 project(osif_crypto)

--- a/tests/subsys/zigbee/osif/serial/serial_async_api/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/CMakeLists.txt
@@ -23,8 +23,8 @@ zephyr_compile_definitions(CONFIG_ZIGBEE_UART_RX_BUF_LEN=16)
 zephyr_compile_definitions(CONFIG_ZIGBEE_UART_TX_BUF_LEN=128)
 
 zephyr_include_directories(${ZEPHYR_BASE}/../nrf/subsys/zigbee/osif)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include/osif)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include/osif)
 
 
 target_sources(app PRIVATE

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/CMakeLists.txt
@@ -23,8 +23,8 @@ zephyr_compile_definitions(CONFIG_ZIGBEE_UART_RX_BUF_LEN=16)
 zephyr_compile_definitions(CONFIG_ZIGBEE_UART_TX_BUF_LEN=128)
 
 zephyr_include_directories(${ZEPHYR_BASE}/../nrf/subsys/zigbee/osif)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include/osif)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include/osif)
 
 
 target_sources(app PRIVATE

--- a/tests/subsys/zigbee/osif/serial/serial_via_logger/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/serial/serial_via_logger/CMakeLists.txt
@@ -11,8 +11,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(app)
 add_definitions(-Wno-packed-bitfield-compat)
 
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include/osif)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include/osif)
 target_include_directories(app BEFORE PRIVATE mock)
 
 target_sources(app PRIVATE

--- a/tests/subsys/zigbee/osif/timer/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/timer/CMakeLists.txt
@@ -22,5 +22,5 @@ target_include_directories(app
   PRIVATE
   ${NRF_DIR}/tests/subsys/zigbee/osif/timer/mock
   ${NRF_DIR}/tests/subsys/zigbee/osif/timer/stubs
-  ${NRFXLIB_DIR}/zboss/include/osif
+  ${NRFXLIB_DIR}/zboss/production/include/osif
 )

--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 46efc8f14e8f0e9d07ea00d6d62e7b013d46965a
+      revision: 99e7250594af5eead3323062236d0f231946a442
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
- fix paths to zboss headers in zigbee tests
- update sdk-nrfxlib in manifest to add to the ZBOSS KConfig missing dependency on ZIGBEE symbol (https://github.com/nrfconnect/sdk-nrfxlib/pull/425)

