### PR TITLE
lib: lte_lc: Add support for automatic system mode selection

### DIFF
--- a/drivers/gps/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/gps/nrf9160_gps/nrf9160_gps.c
@@ -474,8 +474,9 @@ static int enable_gps(const struct device *dev)
 	int err;
 	enum lte_lc_system_mode system_mode;
 	enum lte_lc_func_mode functional_mode;
+	enum lte_lc_system_mode_preference preference;
 
-	err = lte_lc_system_mode_get(&system_mode);
+	err = lte_lc_system_mode_get(&system_mode, &preference);
 	if (err) {
 		LOG_ERR("Could not get modem system mode, error: %d", err);
 		return err;
@@ -483,7 +484,8 @@ static int enable_gps(const struct device *dev)
 
 	if ((system_mode != LTE_LC_SYSTEM_MODE_GPS) &&
 	    (system_mode != LTE_LC_SYSTEM_MODE_LTEM_GPS) &&
-	    (system_mode != LTE_LC_SYSTEM_MODE_NBIOT_GPS)) {
+	    (system_mode != LTE_LC_SYSTEM_MODE_NBIOT_GPS) &&
+	    (system_mode != LTE_LC_SYSTEM_MODE_LTEM_NBIOT_GPS)) {
 		enum lte_lc_system_mode new_mode = LTE_LC_SYSTEM_MODE_GPS;
 
 		if (system_mode == LTE_LC_SYSTEM_MODE_LTEM) {
@@ -494,7 +496,7 @@ static int enable_gps(const struct device *dev)
 
 		LOG_DBG("GPS mode is not enabled, attempting to enable it");
 
-		err = lte_lc_system_mode_set(new_mode);
+		err = lte_lc_system_mode_set(new_mode, preference);
 		if (err) {
 			LOG_ERR("Could not enable GPS mode, error: %d", err);
 			return err;

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -48,7 +48,44 @@ enum lte_lc_system_mode {
 	LTE_LC_SYSTEM_MODE_NBIOT,
 	LTE_LC_SYSTEM_MODE_GPS,
 	LTE_LC_SYSTEM_MODE_LTEM_GPS,
-	LTE_LC_SYSTEM_MODE_NBIOT_GPS
+	LTE_LC_SYSTEM_MODE_NBIOT_GPS,
+	LTE_LC_SYSTEM_MODE_LTEM_NBIOT,
+	LTE_LC_SYSTEM_MODE_LTEM_NBIOT_GPS,
+};
+
+/** LTE mode preference. If more than one LTE system mode is enabled, the modem
+ *  can select the mode that best meets the criteria set by this configuration.
+ *  The LTE mode preference does not affect the way GPS operates.
+ *
+ *  Note that there's a distinction between preferred and prioritized mode.
+ */
+enum lte_lc_system_mode_preference {
+	/** No LTE preference, automatically selected by the modem. */
+	LTE_LC_SYSTEM_MODE_PREFER_AUTO = 0,
+
+	/** LTE-M is preferred over PLMN selection. The modem will prioritize to
+	 *  use LTE-M and switch over to a PLMN where LTE-M is available whenever
+	 *  possible.
+	 */
+	LTE_LC_SYSTEM_MODE_PREFER_LTEM,
+
+	/** NB-IoT is preferred over PLMN selection. The modem will prioritize to
+	 *  use NB-IoT and switch over to a PLMN where NB-IoT is available
+	 *  whenever possible.
+	 */
+	LTE_LC_SYSTEM_MODE_PREFER_NBIOT,
+
+	/** LTE-M is preferred, but PLMN selection is more important. The modem
+	 *  will prioritize to stay on home network and switch over to NB-IoT
+	 *  if LTE-M is not available.
+	 */
+	LTE_LC_SYSTEM_MODE_PREFER_LTEM_PLMN_PRIO,
+
+	/** NB-IoT is preferred, but PLMN selection is more important. The modem
+	 *  will prioritize to stay on home network and switch over to LTE-M
+	 *  if NB-IoT is not available.
+	 */
+	LTE_LC_SYSTEM_MODE_PREFER_NBIOT_PLMN_PRIO
 };
 
 /* NOTE: enum lte_lc_func_mode maps directly to the functional mode
@@ -139,8 +176,11 @@ int lte_lc_init(void);
 
 /** @brief Function to make a connection with the modem.
  *
- * @note prior to calling this function a call to @ref lte_lc_init
+ * @note Prior to calling this function a call to @ref lte_lc_init
  *	 must be made, otherwise -EPERM is returned.
+ *
+ * @note After initialization, the system mode will be set to the default mode
+ *	 selected with Kconfig and LTE preference set to automatic selection.
  *
  * @return Zero on success, -EPERM if the module has not been initialized,
  *	   otherwise a (negative) error code.
@@ -336,21 +376,25 @@ int lte_lc_pdn_auth_set(enum lte_lc_pdn_auth_type auth_prot,
  */
 int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status);
 
-/**@brief Set the modem's system mode.
+/**@brief Set the modem's system mode and LTE preference.
  *
  * @param mode System mode to set.
+ * @param preference System mode preference.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
-int lte_lc_system_mode_set(enum lte_lc_system_mode mode);
+int lte_lc_system_mode_set(enum lte_lc_system_mode mode,
+			   enum lte_lc_system_mode_preference preference);
 
-/**@brief Get the modem's system mode.
+/**@brief Get the modem's system mode and LTE preference.
  *
  * @param mode Pointer to system mode variable.
+ * @param preference Pointer to system mode preference variable. Can be NULL.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
-int lte_lc_system_mode_get(enum lte_lc_system_mode *mode);
+int lte_lc_system_mode_get(enum lte_lc_system_mode *mode,
+			   enum lte_lc_system_mode_preference *preference);
 
 /**@brief Get the modem's functional mode.
  *

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -155,7 +155,63 @@ config LTE_NETWORK_MODE_NBIOT
 config LTE_NETWORK_MODE_NBIOT_GPS
 	bool "NB-IoT and GPS"
 
+config LTE_NETWORK_MODE_LTEM_NBIOT
+	bool "LTE-M and NB-IoT"
+
+config LTE_NETWORK_MODE_LTEM_NBIOT_GPS
+	bool "LTE-M, NB-IoT and GPS"
+
 endchoice
+
+choice
+	prompt "LTE mode preference"
+	default LTE_MODE_PREFERENCE_LTE_M
+	help
+	  Selects which LTE mode the modem should use if more than one is
+	  available.
+
+config LTE_MODE_PREFERENCE_AUTO
+	bool "No preference"
+	help
+	  No LTE preference, automatically selected by the modem.
+
+config LTE_MODE_PREFERENCE_LTE_M
+	bool "LTE-M"
+	help
+	  LTE-M is preferred over PLMN selection. The modem will prioritize to
+	  use LTE-M and switch over to a PLMN where LTE-M is available whenever
+	  possible.
+
+config LTE_MODE_PREFERENCE_NBIOT
+	bool "NB-IoT"
+	help
+	  NB-IoT is preferred over PLMN selection. The modem will prioritize to
+	  use NB-IoT and switch over to a PLMN where NB-IoT is available
+	  whenever possible.
+
+config LTE_MODE_PREFERENCE_LTE_M_PLMN_PRIO
+	bool "LTE-M, PLMN prioritized"
+	help
+	  LTE-M is preferred, but PLMN selection is more important. The modem
+	  will prioritize to stay on home network and switch over to NB-IoT
+	  if LTE-M is not available.
+
+config LTE_MODE_PREFERENCE_NBIOT_PLMN_PRIO
+	bool "NB-IoT, PLMN prioritized"
+	help
+	  NB-IoT is preferred, but PLMN selection is more important. The modem
+	  will prioritize to stay on home network and switch over to LTE-M
+	  if NB-IoT is not available.
+
+endchoice
+
+config LTE_MODE_PREFERENCE
+	int
+	default 0 if LTE_MODE_PREFERENCE_AUTO
+	default 1 if LTE_MODE_PREFERENCE_LTE_M
+	default 2 if LTE_MODE_PREFERENCE_NBIOT
+	default 3 if LTE_MODE_PREFERENCE_LTE_M_PLMN_PRIO
+	default 4 if LTE_MODE_PREFERENCE_NBIOT_PLMN_PRIO
 
 config LTE_RAI_REQ_VALUE
 	string "Requested RAI value"


### PR DESCRIPTION
This patch adds support for automatic system mode selection.
Both LTE-M and NB-IoT can now be enabled at the same time.
An LTE preference parameter instructs the modem on how to select
mode and which network to use.

THe following changes are introduces to accomplish this:
- Enum for LTE preference
- Kconfig option to set LTE preference at compile time
- Added LTE preference parameter to lte_lc_system_mode_*() APIs
- Added lte_lc_system_mode enums to enable LTE-M and NB-IoT at the
  same time