### PR TITLE
Kconfig: Increase default main stack size when CC3XX is enabled.

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -11,9 +11,12 @@ menu "Nordic nRF Connect"
 config BOARD_THINGY91_NRF9160NS
 	bool
 
-# nRF Connect SDK needs a larger default stacks for running certain tests.
+# nRF Connect SDK needs a larger default stacks in certain configurations
+#  - For running tests.
+#  - For CC3XX RNG
 config MAIN_STACK_SIZE
 	default 2048 if ZTEST
+	default 2048 if ENTROPY_CC3XX
 
 config ZTEST_STACKSIZE
 	default 2048 if ZTEST

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 37430f7c6b7b1e075fff26961e8dcfab12b6c800
+      revision: a2d2a5e169f7aec8d9de16787af99e59c56c09b7
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Increase the default main stack size when CC3XX is enabled. This
avoids issues in samples where the default of 1024 would be enough
in upstream, but not in downstream.

Update sdk-zephyr, reverting the patch in SMP SVR sample for increasing
the main stack size. No longer needed when stack size is increased when
default is increased with ENTROPY_CC3XX.
