### PR TITLE
caf: Fix PM events dependency

### DIFF
--- a/include/caf/buttons.rst
+++ b/include/caf/buttons.rst
@@ -90,7 +90,8 @@ If any button state change occurs, the module sends related event.
 Power management states
 =======================
 
-If the :option:`CONFIG_CAF_BUTTONS_PM_EVENTS` Kconfig option is enabled, the module can react to power management events and the following additional states are available:
+If the :option:`CONFIG_CAF_BUTTONS_PM_EVENTS` Kconfig option is enabled, the module can react to power management events and submit ``wake_up_event``.
+In that case, the following additional states are available:
 
 * ``STATE_SUSPENDING``
 * ``STATE_IDLE``
@@ -106,4 +107,3 @@ Then, it switches to ``STATE_IDLE``.
 If a ``power_down_event`` comes while the module is in the ``STATE_ACTIVE`` state, the module switches to ``STATE_IDLE`` immediately.
 Similarly as in ``STATE_ACTIVE``, in ``STATE_IDLE`` the module enables the GPIO interrupts and waits for the pin state to change.
 However, in ``STATE_IDLE`` the module can also invoke ``wake_up_event`` and send it to all subscribing modules.
-This functionality can be enabled by :option:`CONFIG_CAF_PM_EVENTS`.

--- a/subsys/caf/Kconfig
+++ b/subsys/caf/Kconfig
@@ -8,7 +8,6 @@ menuconfig CAF
 	bool "Common Application Framework"
 	select EVENT_MANAGER
 	select CAF_MODULE_STATE_EVENTS
-	select CAF_PM_EVENTS
 	help
 	  Enable Common Application Framework for use with the application.
 

--- a/subsys/caf/modules/Kconfig.buttons
+++ b/subsys/caf/modules/Kconfig.buttons
@@ -21,8 +21,6 @@ string "Configuration file"
 config CAF_BUTTONS_PM_EVENTS
 	bool "Power management events support"
 	depends on CAF_PM_EVENTS
-	help
-	  React on power management events in buttons module.
 
 config CAF_BUTTONS_SCAN_INTERVAL
 	int "Buttons scan interval in ms"

--- a/subsys/caf/modules/buttons.c
+++ b/subsys/caf/modules/buttons.c
@@ -404,7 +404,9 @@ static void button_pressed_fn(struct k_work *work)
 
 	switch (state) {
 	case STATE_IDLE:
-		EVENT_SUBMIT(new_wake_up_event());
+		if (IS_ENABLED(CONFIG_CAF_BUTTONS_PM_EVENTS)) {
+			EVENT_SUBMIT(new_wake_up_event());
+		}
 		break;
 
 	case STATE_ACTIVE:


### PR DESCRIPTION
Change removes PM events selection by CONFIG_CAF. Submitting wake_up_event in buttons module must be optimized out to prevent build issues.