### PR TITLE
applications: asset_tracker_v2: Add state handling for utility module.

### DIFF
--- a/applications/asset_tracker_v2/src/modules/util_module.c
+++ b/applications/asset_tracker_v2/src/modules/util_module.c
@@ -41,16 +41,18 @@ static enum state_type {
 	STATE_REBOOT_PENDING
 } state;
 
-static struct k_delayed_work reboot_work;
+/* Forward declarations. */
+static void reboot_work_fn(struct k_work *work);
+static void message_handler(struct util_msg_data *msg);
+static void send_reboot_request(void);
+
+/* Delayed work that is used to trigger a reboot. */
+static K_DELAYED_WORK_DEFINE(reboot_work, reboot_work_fn);
 
 static struct module_data self = {
 	.name = "util",
 	.msg_q = NULL,
 };
-
-/* Forward declarations. */
-static void message_handler(struct util_msg_data *msg);
-static void send_reboot_request(void);
 
 /* Convenience functions used in internal state handling. */
 static char *state2str(enum state_type new_state)
@@ -199,127 +201,109 @@ static void send_reboot_request(void)
 
 		EVENT_SUBMIT(util_module_event);
 
+		state_set(STATE_REBOOT_PENDING);
+
 		error_signaled = true;
 	}
 }
 
-/* Message handler for all states. */
-static void on_all_states(struct util_msg_data *msg)
+/* This API should be called exactly once for each _SHUTDOWN_READY event received from active
+ * modules in the application. When this API has been called a set number of times equal to the
+ * number of active modules, a reboot will be scheduled.
+ */
+static void reboot_ack_check(void)
 {
-	static int reboot_ack_cnt;
+	static uint8_t reboot_ack_count;
 
-	if (is_cloud_module_event(&msg->module.cloud.header)) {
-		switch (msg->module.cloud.type) {
-		case CLOUD_EVT_ERROR:
-			/* Fall through. */
-		case CLOUD_EVT_FOTA_DONE:
-			send_reboot_request();
-			break;
-		case CLOUD_EVT_SHUTDOWN_READY:
-			reboot_ack_cnt++;
-			break;
-		default:
-			break;
-		}
-	}
+	reboot_ack_count++;
 
-	if (is_modem_module_event(&msg->module.modem.header)) {
-		switch (msg->module.modem.type) {
-		case MODEM_EVT_ERROR:
-			send_reboot_request();
-			break;
-		case MODEM_EVT_SHUTDOWN_READY:
-			reboot_ack_cnt++;
-			break;
-		default:
-			break;
-		}
-	}
-
-	if (is_sensor_module_event(&msg->module.sensor.header)) {
-		switch (msg->module.sensor.type) {
-		case SENSOR_EVT_ERROR:
-			send_reboot_request();
-			break;
-		case SENSOR_EVT_SHUTDOWN_READY:
-			reboot_ack_cnt++;
-			break;
-		default:
-			break;
-		}
-	}
-
-	if (is_gps_module_event(&msg->module.gps.header)) {
-		switch (msg->module.gps.type) {
-		case GPS_EVT_ERROR_CODE:
-			send_reboot_request();
-			break;
-		case GPS_EVT_SHUTDOWN_READY:
-			reboot_ack_cnt++;
-			break;
-		default:
-			break;
-		}
-	}
-
-	if (is_data_module_event(&msg->module.data.header)) {
-		switch (msg->module.data.type) {
-		case DATA_EVT_ERROR:
-			send_reboot_request();
-			break;
-		case DATA_EVT_SHUTDOWN_READY:
-			reboot_ack_cnt++;
-			break;
-		default:
-			break;
-		}
-	}
-
-	if (is_app_module_event(&msg->module.app.header)) {
-		switch (msg->module.app.type) {
-		case APP_EVT_ERROR:
-			send_reboot_request();
-			break;
-		case APP_EVT_SHUTDOWN_READY:
-			reboot_ack_cnt++;
-			break;
-		default:
-			break;
-		}
-	}
-
-	if (is_ui_module_event(&msg->module.ui.header)) {
-		switch (msg->module.ui.type) {
-		case UI_EVT_ERROR:
-			send_reboot_request();
-			break;
-		case UI_EVT_SHUTDOWN_READY:
-			reboot_ack_cnt++;
-			break;
-		default:
-			break;
-		}
-	}
-
-	/* Reboot if after a shorter timeout if all modules has acknowledged
-	 * that the application is ready to shutdown. This ensures a graceful
-	 * shutdown.
+	/* Reboot after a shorter timeout if all modules have acknowledged that they are ready
+	 * to reboot, ensuring a graceful shutdown.
 	 */
-	if (reboot_ack_cnt >= module_active_count_get() - 1) {
+	if (reboot_ack_count >= module_active_count_get() - 1) {
 		LOG_WRN("All modules have ACKed the reboot request.");
 		LOG_WRN("Reboot in 5 seconds.");
 		k_delayed_work_submit(&reboot_work, K_SECONDS(5));
 	}
 }
 
-static void message_handler(struct util_msg_data *msg)
+/* Message handler for STATE_INIT. */
+static void on_state_init(struct util_msg_data *msg)
+{
+	if ((IS_EVENT(msg, cloud,  CLOUD_EVT_ERROR))	 ||
+	    (IS_EVENT(msg, cloud,  CLOUD_EVT_FOTA_DONE)) ||
+	    (IS_EVENT(msg, modem,  MODEM_EVT_ERROR))	 ||
+	    (IS_EVENT(msg, sensor, SENSOR_EVT_ERROR))	 ||
+	    (IS_EVENT(msg, gps,	   GPS_EVT_ERROR_CODE))	 ||
+	    (IS_EVENT(msg, data,   DATA_EVT_ERROR))	 ||
+	    (IS_EVENT(msg, app,	   APP_EVT_ERROR))	 ||
+	    (IS_EVENT(msg, ui,	   UI_EVT_ERROR))) {
+		send_reboot_request();
+		return;
+	}
+}
+
+/* Message handler for STATE_REBOOT_PENDING. */
+static void on_state_reboot_pending(struct util_msg_data *msg)
+{
+	if (IS_EVENT(msg, cloud, CLOUD_EVT_SHUTDOWN_READY)) {
+		reboot_ack_check();
+		return;
+	}
+
+	if (IS_EVENT(msg, modem, MODEM_EVT_SHUTDOWN_READY)) {
+		reboot_ack_check();
+		return;
+	}
+
+	if (IS_EVENT(msg, sensor, SENSOR_EVT_SHUTDOWN_READY)) {
+		reboot_ack_check();
+		return;
+	}
+
+	if (IS_EVENT(msg, gps, GPS_EVT_SHUTDOWN_READY)) {
+		reboot_ack_check();
+		return;
+	}
+
+	if (IS_EVENT(msg, data, DATA_EVT_SHUTDOWN_READY)) {
+		reboot_ack_check();
+		return;
+	}
+
+	if (IS_EVENT(msg, app, APP_EVT_SHUTDOWN_READY)) {
+		reboot_ack_check();
+		return;
+	}
+
+	if (IS_EVENT(msg, ui, UI_EVT_SHUTDOWN_READY)) {
+		reboot_ack_check();
+		return;
+	}
+}
+
+/* Message handler for all states. */
+static void on_all_states(struct util_msg_data *msg)
 {
 	if (IS_EVENT(msg, app, APP_EVT_START)) {
 		module_start(&self);
 		state_set(STATE_INIT);
-		k_delayed_work_init(&reboot_work, reboot_work_fn);
 	}
+}
 
+static void message_handler(struct util_msg_data *msg)
+{
+	switch (state) {
+	case STATE_INIT:
+		on_state_init(msg);
+		break;
+	case STATE_REBOOT_PENDING:
+		on_state_reboot_pending(msg);
+		break;
+	default:
+		LOG_WRN("Unknown utility module state.");
+		break;
+	}
 
 	on_all_states(msg);
 }


### PR DESCRIPTION
Add state handling for STATE_INIT and STATE_REBOOT in the utility module.
This includes:
 - Add switch case in message_handler() for both states.
 - Handle incoming events in state specific functions.
 - Use IS_EVENT() macro to check event types in the
   aforementioned functions.

The previous lack of state handling would cause the module to not
handle multiple error events from modules, as intended.
Typical symptoms were:
 - Multiple shutdown requests sent to other modules.
 - Reboot counter check triggering more than once resetting the
   delayed work reboot timer.

Closes CIA-243

Signed-off-by: Simen S. Røstad <simen.rostad@nordicsemi.no>