### PR TITLE
lib: at_cmd_parser: Bug-fix CLAC response parsing

### DIFF
--- a/lib/at_cmd_parser/at_utils.h
+++ b/lib/at_cmd_parser/at_utils.h
@@ -255,6 +255,11 @@ static inline bool is_command(const char *str)
  */
 static bool is_clac(const char *str)
 {
+	/* skip leading <CR><LF>, if any, as check not from index 0 */
+	while (is_lfcr(*str)) {
+		str++;
+	}
+
 	if (strlen(str) < 4) {
 		return false;
 	}


### PR DESCRIPTION
Problem: all modem AT commands (AT+, AT%) parsed as CLAC rsp
How to fix:
- The parser has both COMMAND and CLAC states
- Do CLAC check from index 1, as index 0 could be CMD or CLAC
- If index 1 is CLAC, retart from index 0 and parse as CLAC

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>