### PR TITLE
lib: date_time: Update internal thread priority.

### DIFF
--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -282,7 +282,7 @@ static void new_date_time_get(void)
 
 K_THREAD_DEFINE(time_thread, CONFIG_DATE_TIME_THREAD_SIZE,
 		new_date_time_get, NULL, NULL, NULL,
-		K_HIGHEST_APPLICATION_THREAD_PRIO, 0, 0);
+		K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
 
 static void date_time_handler(struct k_work *work)
 {


### PR DESCRIPTION
Use K_LOWEST_APPLICATION_THREAD_PRIO for the internal time thread used
in the date_time library.

The previous thread priority made the time thread run in
cooperative mode instead of preemptive mode. Preemptive mode is
typically enforced in applications and samples with the default
configuration for threading.

Closes CIA-216