### PR TITLE
github workflows: add oss-history

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -1,0 +1,31 @@
+name: OSS history check
+on: pull_request_target
+
+jobs:
+  contribs:
+    runs-on: ubuntu-latest
+    name: Check OSS history
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        with:
+          path: ncs/nrf
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Install extra python dependencies
+        run: |
+          pip3 install west
+          pip3 install -r ncs/nrf/scripts/requirements-extra.txt
+
+      - name: Set up the workspace
+        run: |
+          west init -l ncs/nrf
+          cd ncs
+          west update zephyr
+          git -C zephyr remote add upstream https://github.com/zephyrproject-rtos/zephyr
+
+      - name: Check OSS history
+        uses: nrfconnect/action-oss-history@main
+        with:
+          workspace: 'ncs'


### PR DESCRIPTION
- add an option to `west ncs-loot` to also save its output in JSON format
- add a new github workflow to check the history of the downstream repositories in our west manifest for rebasability, starting with zephyr