### PR TITLE
Bluetooth: Mesh: Fix 64-bit value trim in Sensor Threshold

### DIFF
--- a/subsys/bluetooth/mesh/sensor.c
+++ b/subsys/bluetooth/mesh/sensor.c
@@ -56,7 +56,7 @@ bool bt_mesh_sensor_delta_threshold(const struct bt_mesh_sensor *sensor,
 	 */
 	if (sensor->state.threshold.delta.type ==
 	    BT_MESH_SENSOR_DELTA_PERCENT) {
-		int64_t prev_mill = abs(SENSOR_MILL(&sensor->state.prev));
+		int64_t prev_mill = llabs(SENSOR_MILL(&sensor->state.prev));
 
 		thrsh_mill = (prev_mill * thrsh_mill) / (100LL * 1000000LL);
 	}


### PR DESCRIPTION
Passing 64-bit value to abs() function which accepts ints was causing a
trim and in consequence an invalid value was calculated.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>