### PR TITLE
applications: asset_tracker_v2: Only send data values that are new.

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
@@ -33,7 +33,7 @@ struct cloud_data_battery {
 	/** Battery data timestamp. UNIX milliseconds. */
 	int64_t bat_ts;
 	/** Flag signifying that the data entry is to be encoded. */
-	bool queued;
+	bool queued : 1;
 };
 
 /** @brief Structure containing GPS data published to cloud. */
@@ -53,7 +53,7 @@ struct cloud_data_gps {
 	/** Heading of movement in degrees. */
 	float hdg;
 	/** Flag signifying that the data entry is to be encoded. */
-	bool queued;
+	bool queued : 1;
 };
 
 struct cloud_data_cfg {
@@ -71,6 +71,14 @@ struct cloud_data_cfg {
 	int movement_timeout;
 	/** Accelerometer trigger threshold value in m/s2. */
 	double accelerometer_threshold;
+
+	/** Flags to signify if the corresponding data value is fresh and can be used. */
+	bool active_mode_fresh		   : 1;
+	bool gps_timeout_fresh		   : 1;
+	bool active_wait_timeout_fresh	   : 1;
+	bool movement_resolution_fresh	   : 1;
+	bool movement_timeout_fresh	   : 1;
+	bool accelerometer_threshold_fresh : 1;
 };
 
 struct cloud_data_accelerometer {
@@ -79,7 +87,7 @@ struct cloud_data_accelerometer {
 	/** Accelerometer readings. */
 	double values[3];
 	/** Flag signifying that the data entry is to be published. */
-	bool queued;
+	bool queued : 1;
 };
 
 struct cloud_data_sensors {
@@ -90,7 +98,7 @@ struct cloud_data_sensors {
 	/** Humidity level in percentage */
 	double hum;
 	/** Flag signifying that the data entry is to be encoded. */
-	bool queued;
+	bool queued : 1;
 };
 
 struct cloud_data_modem_static {
@@ -113,7 +121,7 @@ struct cloud_data_modem_static {
 	/** Modem firmware. */
 	char fw[40];
 	/** Flag signifying that the data entry is to be encoded. */
-	bool queued;
+	bool queued : 1;
 };
 
 struct cloud_data_modem_dynamic {
@@ -130,7 +138,14 @@ struct cloud_data_modem_dynamic {
 	/* Mobile Country Code*/
 	char mccmnc[7];
 	/** Flag signifying that the data entry is to be encoded. */
-	bool queued;
+	bool queued : 1;
+
+	/** Flags to signify if the corresponding data value is fresh and can be used. */
+	bool area_code_fresh	: 1;
+	bool cell_id_fresh	: 1;
+	bool rsrp_fresh		: 1;
+	bool ip_address_fresh	: 1;
+	bool mccmnc_fresh	: 1;
 };
 
 struct cloud_data_ui {
@@ -139,7 +154,7 @@ struct cloud_data_ui {
 	/** Button data timestamp. UNIX milliseconds. */
 	int64_t btn_ts;
 	/** Flag signifying that the data entry is to be encoded. */
-	bool queued;
+	bool queued : 1;
 };
 
 struct cloud_codec_data {

--- a/applications/asset_tracker_v2/src/events/modem_module_event.h
+++ b/applications/asset_tracker_v2/src/events/modem_module_event.h
@@ -80,6 +80,15 @@ struct modem_module_dynamic_modem_data {
 	uint16_t rsrp;
 	char ip_address[INET6_ADDRSTRLEN];
 	char mccmnc[7];
+
+	/* Flags to signify if the corresponding data value has been updated and is concidered
+	 * fresh.
+	 */
+	bool area_code_fresh	: 1;
+	bool cell_id_fresh	: 1;
+	bool rsrp_fresh		: 1;
+	bool ip_address_fresh	: 1;
+	bool mccmnc_fresh	: 1;
 };
 
 struct modem_module_battery_data {

--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -19,6 +19,14 @@ config FAILED_DATA_COUNT
 	int "Number of entries in failed data list"
 	default 10
 
+config DATA_SEND_ALL_DEVICE_CONFIGURATIONS
+	bool "Encode and send all device configurations regardless if they have changed or not"
+	help
+	  If this option is disabled the data module will only include device configuration values
+	  that have changed from the last configuration update. This is to save costs related to
+	  data transfers and to lower the device's overall current consumption due to less CPU and
+	  radio-activity.
+
 config DATA_THREAD_STACK_SIZE
 	int "Data module thread stack size"
 	default 2560

--- a/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
@@ -12,6 +12,14 @@ menuconfig MODEM_MODULE
 
 if MODEM_MODULE
 
+config MODEM_SEND_ALL_SAMPLED_DATA
+	bool "Include all sampled data upon a sample request"
+	help
+	  If this option is disabled the modem module will only include data values that have
+	  changed from the last sample request. Currently this option is only supported for
+	  dynamic modem data. This is to save costs related to data transfers and to lower the
+	  device's overall current consumption due to less CPU and radio-activity.
+
 config MODEM_THREAD_STACK_SIZE
 	int "Modem module thread stack size"
 	default 1280

--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -335,6 +335,99 @@ static int static_modem_data_get(void)
 	return 0;
 }
 
+static void populate_event_with_dynamic_modem_data(struct modem_module_event *event,
+						   struct modem_param_info *param)
+{
+	/* If this flag is set all sampled parameter values will be included in the event regardless
+	 * if they have changed or not.
+	 */
+	bool include = IS_ENABLED(CONFIG_MODEM_SEND_ALL_SAMPLED_DATA);
+
+	/* Flag that checks if parameters has been added to the event. */
+	bool params_added = false;
+
+	/* Set all entries in the dynamic modem data structure to 0 to be sure that all 'fresh'
+	 * flags become false by default. This is to avoid sending garbage or old data due to a flag
+	 * being accidently set to true.
+	 */
+	memset(&event->data.modem_dynamic, 0, sizeof(struct modem_module_dynamic_modem_data));
+
+	/* Structure that holds previous sampled dynamic modem data. By default, set all members of
+	 * the structure to invalid values.
+	 */
+	static struct modem_module_dynamic_modem_data prev = { .rsrp = UINT8_MAX };
+
+	/* Compare the latest sampled parameters with the previous. If there has been a change we
+	 * want to include the parameters in the event.
+	 */
+	if ((prev.rsrp != rsrp_value_latest) || include) {
+		event->data.modem_dynamic.rsrp = rsrp_value_latest;
+		prev.rsrp = rsrp_value_latest;
+
+		event->data.modem_dynamic.rsrp_fresh = true;
+		params_added = true;
+	}
+
+	if ((strcmp(prev.ip_address, param->network.ip_address.value_string) != 0) || include) {
+		strncpy(event->data.modem_dynamic.ip_address,
+			modem_param.network.ip_address.value_string,
+			sizeof(event->data.modem_dynamic.ip_address) - 1);
+
+		strncpy(prev.ip_address,
+			param->network.ip_address.value_string,
+			sizeof(prev.ip_address) - 1);
+
+		event->data.modem_dynamic.ip_address
+			[sizeof(event->data.modem_dynamic.ip_address) - 1] = '\0';
+
+		prev.ip_address[sizeof(prev.ip_address) - 1] = '\0';
+
+		event->data.modem_dynamic.ip_address_fresh = true;
+		params_added = true;
+	}
+
+	if ((prev.cell_id != param->network.cellid_dec) || include) {
+		event->data.modem_dynamic.cell_id = param->network.cellid_dec;
+		prev.cell_id = param->network.cellid_dec;
+
+		event->data.modem_dynamic.cell_id_fresh = true;
+		params_added = true;
+	}
+
+	if ((strcmp(prev.mccmnc, param->network.current_operator.value_string) != 0) || include) {
+		strncpy(event->data.modem_dynamic.mccmnc,
+			modem_param.network.current_operator.value_string,
+			sizeof(event->data.modem_dynamic.mccmnc));
+
+		strncpy(prev.mccmnc, param->network.current_operator.value_string,
+			sizeof(prev.mccmnc));
+
+		event->data.modem_dynamic.mccmnc
+			[sizeof(event->data.modem_dynamic.mccmnc) - 1] = '\0';
+
+		prev.mccmnc[sizeof(prev.mccmnc) - 1] = '\0';
+
+		event->data.modem_dynamic.mccmnc_fresh = true;
+		params_added = true;
+	}
+
+	if ((prev.area_code != modem_param.network.area_code.value) || include) {
+		event->data.modem_dynamic.area_code = param->network.area_code.value;
+		prev.area_code = param->network.area_code.value;
+
+		event->data.modem_dynamic.area_code_fresh = true;
+		params_added = true;
+	}
+
+	if (params_added) {
+		event->type = MODEM_EVT_MODEM_DYNAMIC_DATA_READY;
+		event->data.modem_dynamic.timestamp = k_uptime_get();
+	} else {
+		LOG_DBG("No dynamic modem parameters have changed from the last sample request.");
+		event->type = MODEM_EVT_MODEM_DYNAMIC_DATA_NOT_READY;
+	}
+}
+
 static int dynamic_modem_data_get(void)
 {
 	int err;
@@ -348,26 +441,7 @@ static int dynamic_modem_data_get(void)
 
 	struct modem_module_event *modem_module_event = new_modem_module_event();
 
-	modem_module_event->data.modem_dynamic.rsrp = rsrp_value_latest;
-	modem_module_event->data.modem_dynamic.cell_id = modem_param.network.cellid_dec;
-	modem_module_event->data.modem_dynamic.area_code = modem_param.network.area_code.value;
-
-	strncpy(modem_module_event->data.modem_dynamic.ip_address,
-		modem_param.network.ip_address.value_string,
-		sizeof(modem_module_event->data.modem_dynamic.ip_address) - 1);
-
-	strncpy(modem_module_event->data.modem_dynamic.mccmnc,
-		modem_param.network.current_operator.value_string,
-		sizeof(modem_module_event->data.modem_dynamic.mccmnc) - 1);
-
-	modem_module_event->data.modem_dynamic.ip_address
-		[sizeof(modem_module_event->data.modem_dynamic.ip_address) - 1] = '\0';
-
-	modem_module_event->data.modem_dynamic.mccmnc
-		[sizeof(modem_module_event->data.modem_dynamic.mccmnc) - 1] = '\0';
-
-	modem_module_event->data.modem_dynamic.timestamp = k_uptime_get();
-	modem_module_event->type = MODEM_EVT_MODEM_DYNAMIC_DATA_READY;
+	populate_event_with_dynamic_modem_data(modem_module_event, &modem_param);
 
 	EVENT_SUBMIT(modem_module_event);
 	return 0;


### PR DESCRIPTION
Dynamic modem data is by default included in all packets published by
the device. However, a large portion of this type of data does not
change in between publications. This patch adds options and
functionality in the data and modem module that filters out parameters
if they have not changed since the last publication/sampling.

Initially, this involves dynamic modem data and the
device configuration. Data types such as battery,
accelerometer readings, and GPS coordinates are not affected by this PR
because they should be filtered based on ranges rather than their
previous value. This is a future improvement.

This PR includes:
- Retaining of previous data values for dynamic modem data
  and device configuration.
- Implement fresh flags for parameters that are considered
  updated and should be included in the encoding process.
- Segmenting code into own static functions that handles the
   data in question. This is primarily to abstract away code from
    the event-handlers to make the code flow easier to read
    with this new change.
- Add options to publish all data if desired. This is to provide
   an option for users that do not want this new functionality.

Closes CIA-254