### PR TITLE
net: lib: nrf_cloud: Shell-invoked FOTA fixes

### DIFF
--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_fota.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_fota.h
@@ -79,7 +79,7 @@ struct nrf_cloud_fota_ble_job {
 	bt_addr_t ble_id;
 	struct nrf_cloud_fota_job_info info;
 	enum nrf_cloud_fota_error error;
-	const int dl_progress; /* Download progress percent, 0-100. */
+	int dl_progress; /* Download progress percent, 0-100. */
 };
 
 /**@brief FOTA event data provided to @ref nrf_cloud_fota_callback_t */


### PR DESCRIPTION
Ensure that user can request a FOTA job from the shell, (which does not have an associated job ID) will finish without crashing.

Fix mistake in struct nrf_cloud_fota_ble_job.dl_progress: application needs to be able to update it with progress.

Log special note when modem FOTA completes.

Jira: CIA-263

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>