### PR TITLE
bluetooth: gatt_dm: report failed discovery to app

### DIFF
--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -650,6 +650,7 @@ int bt_gatt_dm_continue(struct bt_gatt_dm *dm, void *context)
 	if (err) {
 		LOG_ERR("Discover failed, error: %d.", err);
 		atomic_clear_bit(dm->state_flags, STATE_ATTRS_LOCKED);
+		discovery_complete_error(dm, err);
 	}
 
 	return err;


### PR DESCRIPTION
If a device turns off during discovery, the call to bt_gatt_discover() fails in bt_gatt_dm_continue. However, the call to discovery_complete_error() is missing, so application code is not alerted to the failure.  It can wait forever for the scan to complete, as a result.

Add the missing call to discovery_complete_error().

Jira: NCSDK-8641

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>