### PR TITLE
applications: nrf_desktop: Fix LED state

### DIFF
--- a/applications/nrf_desktop/src/modules/CMakeLists.txt
+++ b/applications/nrf_desktop/src/modules/CMakeLists.txt
@@ -44,6 +44,9 @@ target_sources_ifdef(CONFIG_DESKTOP_HID_STATE_ENABLE
 target_sources_ifdef(CONFIG_DESKTOP_USB_ENABLE
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/usb_state.c)
 
+target_sources_ifdef(CONFIG_CAF_LEDS
+		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/led_state.c)
+
 target_sources_ifdef(CONFIG_DESKTOP_LED_STREAM_ENABLE
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/led_stream.c)
 


### PR DESCRIPTION
Change enables LED state. The module was disabled when LEDs were moved to CAF.