### PR TITLE
applications: serial_lte_modem Exit datamode by callback

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.h
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.h
@@ -27,10 +27,6 @@ int slm_at_ftp_init(void);
  *           Otherwise, a (negative) error code is returned.
  */
 int slm_at_ftp_uninit(void);
-
-/**@brief API to set datamode off from external
- */
-void slm_ftp_set_datamode_off(void);
 /** @} */
 
 #endif /* SLM_AT_FTP_ */

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -18,8 +18,14 @@
 #include <modem/at_cmd_parser.h>
 #include <modem/at_cmd.h>
 
+/**@brief Operations in datamode. */
+enum slm_datamode_operation_t {
+	DATAMODE_SEND,  /* Send data in datamode */
+	DATAMODE_EXIT   /* Exit data mode */
+};
+
 /**@brief Data mode sending handler type. */
-typedef int (*slm_data_mode_handler_t) (const uint8_t *data, int len);
+typedef int (*slm_datamode_handler_t)(uint8_t op, const uint8_t *data, int len);
 
 /**@brief Arbitrary data type over AT channel. */
 enum slm_data_type_t {

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.h
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.h
@@ -28,8 +28,4 @@ int slm_at_tcp_proxy_init(void);
  */
 int slm_at_tcp_proxy_uninit(void);
 /** @} */
-
-/**@brief API to set datamode off from external
- */
-void slm_tcp_set_datamode_off(void);
 #endif /* SLM_AT_TCP_PROXY_ */

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.h
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.h
@@ -28,9 +28,4 @@ int slm_at_udp_proxy_init(void);
  */
 int slm_at_udp_proxy_uninit(void);
 /** @} */
-
-/**@brief API to set datamode off from external
- */
-void slm_udp_set_datamode_off(void);
-
 #endif /* SLM_AT_UDP_PROXY_ */


### PR DESCRIPTION
Internal update, enable datamode callback for slm_at_host to
notify service module of quitting data mode, which makes
alm_at_host agnostic of which module is in data mode.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>