### PR TITLE
applications: serial_lte_mode: add TWI AT command

### DIFF
--- a/applications/serial_lte_modem/CMakeLists.txt
+++ b/applications/serial_lte_modem/CMakeLists.txt
@@ -28,5 +28,6 @@ add_subdirectory_ifdef(CONFIG_SLM_GPS src/gps)
 add_subdirectory_ifdef(CONFIG_SLM_FTPC src/ftp_c)
 add_subdirectory_ifdef(CONFIG_SLM_MQTTC src/mqtt_c)
 add_subdirectory_ifdef(CONFIG_SLM_HTTPC src/http_c)
+add_subdirectory_ifdef(CONFIG_SLM_TWI src/twi)
 
 zephyr_include_directories(src)

--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -140,6 +140,7 @@ rsource "src/gps/Kconfig"
 rsource "src/ftp_c/Kconfig"
 rsource "src/mqtt_c/Kconfig"
 rsource "src/http_c/Kconfig"
+rsource "src/twi/Kconfig"
 
 module = SLM
 module-str = serial modem

--- a/applications/serial_lte_modem/doc/AT_commands_intro.rst
+++ b/applications/serial_lte_modem/doc/AT_commands_intro.rst
@@ -41,3 +41,4 @@ The modem-specific AT commands are documented in the `nRF91 AT Commands Referenc
    MQTT_AT_commands
    TCPIP_AT_commands
    HTTPC_AT_commands
+   TWI_AT_commands

--- a/applications/serial_lte_modem/doc/TWI_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TWI_AT_commands.rst
@@ -1,0 +1,240 @@
+.. _SLM_AT_TWI:
+
+TWI AT commands
+***************
+
+.. contents::
+   :local:
+   :depth: 2
+
+The following commands list contains AT commands related to the two-wire interface (TWI).
+
+List TWI instances #XTWILS
+==========================
+
+The ``#XTWILS`` command lists all available TWI instances.
+
+Set command
+-----------
+
+The set command allows you to list all available TWI instances.
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XTWILS: <index>[[[,<index>],<index>],<index>]
+
+The ``<index>`` parameter corresponds to the following TWI instances:
+
+* ``0`` - TWI0 (``i2c0``).
+* ``1`` - TWI1 (``i2c1``).
+* ``2`` - TWI2 (``i2c2``).
+* ``3`` - TWI3 (``i2c3``).
+
+  See :ref:`zephyr:dtbinding_nordic_nrf_twi`.
+
+Example
+~~~~~~~
+
+::
+
+   AT#XTWILS
+   #XTWILS: 2
+   OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.
+
+Write to TWI peripheral device #XTWIW
+=====================================
+
+The ``#XTWIW`` command writes data to a TWI peripheral device.
+
+Set command
+-----------
+
+The set command allows you to write data to a TWI peripheral device.
+
+Syntax
+~~~~~~
+
+::
+
+   #XTWIW=<index>,<dev_addr>,<data>
+
+* The ``<index>`` parameter accepts the following integer values:
+
+  * ``0`` - Use TWI0 (``i2c0``).
+  * ``1`` - Use TWI1 (``i2c1``).
+  * ``2`` - Use TWI2 (``i2c2``).
+  * ``3`` - Use TWI3 (``i2c3``).
+
+  See :ref:`zephyr:dtbinding_nordic_nrf_twi`.
+
+* The ``<dev_addr>`` parameter is a hexadecimal string.
+  It represents the peripheral device address to write to.
+  The maximum length is 2 characters (for example, "DE" for 0xDE).
+* The ``<data>`` parameter is a hexadecimal string.
+  It represents the data to be written to the peripheral device.
+  The maximum length is 255 characters (for example, "DEADBEEF" for 0xDEADBEEF).
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+There is no response.
+
+Example
+~~~~~~~
+
+::
+
+   AT#XTWIW=2,"76","D0"
+   OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.
+
+Read from TWI peripheral device #XTWIR
+======================================
+
+The ``#XTWIR`` command reads data from a TWI peripheral device.
+
+Set command
+-----------
+
+The set command allows you to read data from a TWI peripheral device.
+
+Syntax
+~~~~~~
+
+::
+
+   #XTWIR=<index>,<dev_addr>,<num_read>
+
+* The ``<index>`` parameter accepts the following integer values:
+
+  * ``0`` - Use TWI0 (``i2c0``).
+  * ``1`` - Use TWI1 (``i2c1``).
+  * ``2`` - Use TWI2 (``i2c2``).
+  * ``3`` - Use TWI3 (``i2c3``).
+
+* The ``<dev_addr>`` parameter is a hexadecimal string.
+  It represents the peripheral device address to read from.
+  The maximum length is 2 characters (for example, "DE" for 0xDE).
+* The ``<num_read>`` parameter is an unsigned 8-bit integer.
+  It represents the amount of data to read from the peripheral device.
+  The available range is from 0 to 255 bytes.
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XTWIR:
+   <data>
+
+* The ``<data>`` parameter is a hexadecimal string.
+  It represents the data read from the peripheral device.
+
+Example
+~~~~~~~
+
+::
+
+   AT#XTWIR=2,"76",1
+
+   #XTWIR: 61
+   OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.
+
+Write data and read from TWI peripheral device #XTWIWR
+======================================================
+
+The ``#XTWIWR`` command writes data to a TWI peripheral device and then reads data from the device.
+
+Set command
+-----------
+
+The set command allows you to first write data to a TWI peripheral device and then read the returned data.
+
+Syntax
+~~~~~~
+
+::
+
+   #XTWIW=<index>,<dev_addr>,<data>,<num_read>
+
+* The ``<index>`` parameter accepts the following integer values:
+
+  * ``0`` - Use TWI0 (``i2c0``).
+  * ``1`` - Use TWI1 (``i2c1``).
+  * ``2`` - Use TWI2 (``i2c2``).
+  * ``3`` - Use TWI3 (``i2c3``).
+
+  See :ref:`zephyr:dtbinding_nordic_nrf_twi`.
+
+* The ``<dev_addr>`` parameter is a hexadecimal string.
+  It represents the peripheral device address to write to.
+  The maximum length is 2 characters (for example, "DE" for 0xDE).
+* The ``<data>`` parameter is a hexadecimal string.
+  It represents the data to be written to the peripheral device.
+  The maximum length is 255 characters (for example, "DEADBEEF" for 0xDEADBEEF).
+* The ``<num_read>`` parameter is an unsigned 8-bit integer.
+  It represents the amount of data to read from the peripheral device.
+  The available range is from 0 to 255 bytes.
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XTWIWR:
+   <data>
+
+* The ``<data>`` parameter is a hexadecimal string.
+  It represents the data read from the peripheral device.
+
+Example
+~~~~~~~
+
+::
+
+   AT#XTWIWR=2,"76","D0",1
+
+   #XTWIWR: 61
+   OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -236,6 +236,9 @@ Check and configure the following configuration options for the sample:
 
    This option enables additional AT commands for using the HTTP client service.
 
+.. option:: CONFIG_SLM_TWI - TWI support in SLM
+
+   This option enables additional AT commands for using the TWI service.
 
 Additional configuration
 ========================

--- a/applications/serial_lte_modem/nrf9160dk_nrf9160ns.overlay
+++ b/applications/serial_lte_modem/nrf9160dk_nrf9160ns.overlay
@@ -8,3 +8,8 @@
 	cts-pin = <13>;
 	hw-flow-control;
 };
+
+
+&i2c2 {
+	status = "disabled";
+};

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -38,6 +38,9 @@
 #if defined(CONFIG_SLM_HTTPC)
 #include "slm_at_httpc.h"
 #endif
+#if defined(CONFIG_SLM_TWI)
+#include "slm_at_twi.h"
+#endif
 
 LOG_MODULE_REGISTER(slm_at, CONFIG_SLM_LOG_LEVEL);
 
@@ -354,6 +357,13 @@ int handle_at_httpc_connect(enum at_cmd_type cmd_type);
 int handle_at_httpc_request(enum at_cmd_type cmd_type);
 #endif
 
+#if defined(CONFIG_SLM_TWI)
+int handle_at_twi_list(enum at_cmd_type cmd_type);
+int handle_at_twi_write(enum at_cmd_type cmd_type);
+int handle_at_twi_read(enum at_cmd_type cmd_type);
+int handle_at_twi_write_read(enum at_cmd_type cmd_type);
+#endif
+
 static struct slm_at_cmd {
 	char *string;
 	slm_at_handler_t handler;
@@ -421,6 +431,13 @@ static struct slm_at_cmd {
 #if defined(CONFIG_SLM_HTTPC)
 	{"AT#XHTTPCCON", handle_at_httpc_connect},
 	{"AT#XHTTPCREQ", handle_at_httpc_request},
+#endif
+
+#if defined(CONFIG_SLM_TWI)
+	{"AT#XTWILS", handle_at_twi_list},
+	{"AT#XTWIW", handle_at_twi_write},
+	{"AT#XTWIR", handle_at_twi_read},
+	{"AT#XTWIWR", handle_at_twi_write_read},
 #endif
 };
 
@@ -529,6 +546,13 @@ int slm_at_init(void)
 		return -EFAULT;
 	}
 #endif
+#if defined(CONFIG_SLM_TWI)
+	err = slm_at_twi_init();
+	if (err) {
+		LOG_ERR("TWI could not be initialized: %d", err);
+		return -EFAULT;
+	}
+#endif
 
 	return err;
 }
@@ -585,6 +609,12 @@ void slm_at_uninit(void)
 	err = slm_at_httpc_uninit();
 	if (err) {
 		LOG_WRN("HTTP could not be uninitialized: %d", err);
+	}
+#endif
+#if defined(CONFIG_SLM_TWI)
+	err = slm_at_twi_uninit();
+	if (err) {
+		LOG_ERR("TWI could not be uninit: %d", err);
 	}
 #endif
 }

--- a/applications/serial_lte_modem/src/twi/CMakeLists.txt
+++ b/applications/serial_lte_modem/src/twi/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_include_directories(.)
+target_sources_ifdef(CONFIG_SLM_TWI app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/slm_at_twi.c)

--- a/applications/serial_lte_modem/src/twi/Kconfig
+++ b/applications/serial_lte_modem/src/twi/Kconfig
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+config SLM_TWI
+	bool "Access TWI interface with SLM AT command"
+	select I2C
+	default y if "$(dt_nodelabel_enabled,i2c0)" || \
+		     "$(dt_nodelabel_enabled,i2c1)" || \
+		     "$(dt_nodelabel_enabled,i2c2)" || \
+		     "$(dt_nodelabel_enabled,i2c3)"

--- a/applications/serial_lte_modem/src/twi/slm_at_twi.c
+++ b/applications/serial_lte_modem/src/twi/slm_at_twi.c
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <logging/log.h>
+#include <zephyr.h>
+#include <drivers/i2c.h>
+#include <stdio.h>
+#include "slm_util.h"
+#include "slm_at_twi.h"
+
+LOG_MODULE_REGISTER(slm_twi, CONFIG_SLM_LOG_LEVEL);
+
+#if defined(CONFIG_HAS_HW_NRF_TWIM3)
+#define TWI_MAX_INSTANCE	4
+#elif defined(CONFIG_HAS_HW_NRF_TWIM2)
+#define TWI_MAX_INSTANCE	3
+#elif defined(CONFIG_HAS_HW_NRF_TWIM1)
+#define TWI_MAX_INSTANCE	2
+#elif defined(CONFIG_HAS_HW_NRF_TWIM0)
+#define TWI_MAX_INSTANCE	1
+#endif
+#define TWI_ADDR_LEN		2
+#define TWI_DATA_LEN		255
+
+#if (TWI_DATA_LEN * 2) > (CONFIG_SLM_SOCKET_RX_MAX * 2)
+# error "Please specify smaller TWI_DATA_LEN"
+#endif
+
+static const struct device *slm_twi_dev[TWI_MAX_INSTANCE];
+static uint8_t twi_data[TWI_DATA_LEN * 2 + 1];
+
+/* global functions defined in different files */
+void rsp_send(const uint8_t *str, size_t len);
+
+/* global variable defined in different files */
+extern struct at_param_list at_param_list;
+extern char rsp_buf[CONFIG_SLM_SOCKET_RX_MAX * 2];
+
+static void do_twi_list(void)
+{
+	memset(rsp_buf, 0, sizeof(rsp_buf));
+	sprintf(rsp_buf, "\r\n#XTWILS: ");
+
+	for (int i = 0; i < TWI_MAX_INSTANCE; i++) {
+		if (slm_twi_dev[i]) {
+			sprintf(rsp_buf + strlen(rsp_buf), "%d,", i);
+		}
+	}
+	if (strlen(rsp_buf) > 0) {
+		strcat(rsp_buf, "\r\n");
+		rsp_send(rsp_buf, strlen(rsp_buf));
+	}
+}
+
+static int do_twi_write(uint16_t index, uint16_t dev_addr,
+			const uint8_t *twi_data_ascii, uint16_t ascii_len)
+{
+	int ret = -EINVAL;
+
+	if (!slm_twi_dev[index]) {
+		LOG_ERR("TWI device is not opened");
+		return ret;
+	}
+
+	/* Decode hex string to hex array */
+	memset(rsp_buf, 0, sizeof(rsp_buf));
+	ret = slm_util_atoh(twi_data_ascii, ascii_len, rsp_buf, ascii_len / 2);
+	if (ret < 0) {
+		LOG_ERR("Fail to decode hex string to hex array");
+		return ret;
+	}
+
+	ret = i2c_write(slm_twi_dev[index], rsp_buf, ret, dev_addr);
+	if (ret < 0) {
+		LOG_ERR("Fail to write twi data at address: %hx", dev_addr);
+	}
+
+	return ret;
+}
+
+static int do_twi_read(uint16_t index, uint16_t dev_addr, uint8_t num_read)
+{
+	int ret = -EINVAL;
+
+	if (!slm_twi_dev[index]) {
+		LOG_ERR("TWI device is not opened");
+		return ret;
+	}
+
+	if (num_read > TWI_DATA_LEN) {
+		LOG_ERR("Not enough buffer. Increase TWI_DATA_LEN");
+		return -ENOBUFS;
+	}
+
+	memset(twi_data, 0, sizeof(twi_data));
+	ret = i2c_read(slm_twi_dev[index], twi_data, (uint32_t)num_read, dev_addr);
+	if (ret < 0) {
+		LOG_ERR("Fail to read twi data");
+		return ret;
+	}
+	memset(rsp_buf, 0, sizeof(rsp_buf));
+	ret = slm_util_htoa(twi_data, num_read, rsp_buf, num_read * 2);
+	if (ret > 0) {
+		sprintf(rsp_buf + ret, "\r\n#XTWIR: ");
+		rsp_send(rsp_buf + ret, strlen(rsp_buf + ret));
+		rsp_send(rsp_buf, ret);
+		rsp_send("\r\n", 2);
+		ret = 0;
+	} else {
+		LOG_ERR("hex convert error: %d", ret);
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+static int do_twi_write_read(uint16_t index, uint16_t dev_addr,
+			     const uint8_t *twi_data_ascii, uint16_t ascii_len,
+			     uint16_t num_read)
+{
+	int ret = -EINVAL;
+
+	if (!slm_twi_dev[index]) {
+		LOG_ERR("TWI device is not opened");
+		return ret;
+	}
+
+	/* Decode hex string to hex array */
+	memset(rsp_buf, 0, sizeof(rsp_buf));
+	ret = slm_util_atoh(twi_data_ascii, ascii_len, rsp_buf, ascii_len / 2);
+	if (ret < 0) {
+		LOG_ERR("Fail to decode hex string to hex array");
+		return ret;
+	}
+	memset(twi_data, 0, sizeof(twi_data));
+	ret = i2c_write_read(slm_twi_dev[index], dev_addr,
+			     rsp_buf, ret,
+			     twi_data, num_read);
+	if (ret < 0) {
+		LOG_ERR("Fail to write and read data at address: %hx", dev_addr);
+		return ret;
+	}
+	/* Encode hex arry to hex string */
+	memset(rsp_buf, 0, sizeof(rsp_buf));
+	ret = slm_util_htoa(twi_data, num_read, rsp_buf, num_read * 2);
+	if (ret > 0) {
+		sprintf(rsp_buf + ret, "\r\n#XTWIWR: ");
+		rsp_send(rsp_buf + ret, strlen(rsp_buf + ret));
+		rsp_send(rsp_buf, ret);
+		rsp_send("\r\n", 2);
+		ret = 0;
+	} else {
+		LOG_ERR("hex convert error: %d", ret);
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+/**@brief handle AT#XTWILS commands
+ *  AT#XTWILS
+ *  AT#XTWILS? READ command not supported
+ *  AT#XTWILS=? TEST command not supported
+ */
+int handle_at_twi_list(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		do_twi_list();
+		err = 0;
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief handle AT#XTWIW commands
+ *  AT#XTWIW=<index>,<dev_addr>,<data>
+ *  AT#XTWIW? READ command not supported
+ *  AT#XTWIW=?
+ */
+int handle_at_twi_write(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	uint16_t index, dev_addr;
+	uint8_t twi_addr_ascii[TWI_ADDR_LEN + 1];
+	size_t ascii_len;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		if (at_params_valid_count_get(&at_param_list) != 4) {
+			LOG_ERR("Wrong input parameters");
+			return -EINVAL;
+		}
+		err = at_params_unsigned_short_get(&at_param_list, 1, &index);
+		if (err < 0) {
+			LOG_ERR("Fail to get twi index: %d", err);
+			return err;
+		}
+		ascii_len = TWI_ADDR_LEN + 1;
+		err = util_string_get(&at_param_list, 2, twi_addr_ascii, &ascii_len);
+		if (err < 0) {
+			LOG_ERR("Fail to get device address");
+			return err;
+		}
+		sscanf(twi_addr_ascii, "%hx", &dev_addr);
+		LOG_DBG("dev_addr: %hx", dev_addr);
+		ascii_len = sizeof(twi_data);
+		err = util_string_get(&at_param_list, 3, twi_data, &ascii_len);
+		if (err) {
+			return err;
+		}
+		LOG_DBG("Data to write: %s", log_strdup(twi_data));
+		err = do_twi_write(index, dev_addr, twi_data, (uint16_t)ascii_len);
+		break;
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf, "#XTWIW: <index>,<dev_addr>,<data>\r\n");
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief handle AT#XTWIR commands
+ *  AT#XTWIR=<index>,<dev_addr>,<num_read>
+ *  AT#XTWIR? READ command not supported
+ *  AT#XTWIR=?
+ */
+int handle_at_twi_read(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	uint16_t index, dev_addr, num_read;
+	uint8_t twi_addr_ascii[TWI_ADDR_LEN + 1];
+	size_t ascii_len;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		err = at_params_unsigned_short_get(&at_param_list, 1, &index);
+		if (err < 0) {
+			LOG_ERR("Fail to get twi index: %d", err);
+			return err;
+		}
+		ascii_len = TWI_ADDR_LEN + 1;
+		err = util_string_get(&at_param_list, 2, twi_addr_ascii, &ascii_len);
+		if (err < 0) {
+			LOG_ERR("Fail to get device address: %d", err);
+			return err;
+		}
+		sscanf(twi_addr_ascii, "%hx", &dev_addr);
+		LOG_DBG("dev_addr: %hx", dev_addr);
+		err = at_params_unsigned_short_get(&at_param_list, 3, &num_read);
+		if (err < 0) {
+			LOG_ERR("Fail to get bytes to read: %d", err);
+			return err;
+		}
+		if (num_read > TWI_DATA_LEN) {
+			LOG_ERR("No enough buffer to read %d bytes", num_read);
+			return -ENOBUFS;
+		}
+		err = do_twi_read(index, dev_addr, (uint8_t)num_read);
+		if (err < 0) {
+			return err;
+		}
+		break;
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf, "#XTWIR: <index>,<dev_addr>,<num_read>\r\n");
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief handle AT#XTWIWR commands
+ *  AT#XTWIWR=<index>,<dev_addr>,<data>,<num_read>
+ *  AT#XTWIWR? READ command not supported
+ *  AT#XTWIWR=?
+ */
+int handle_at_twi_write_read(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	uint16_t index, dev_addr, num_read;
+	uint8_t twi_addr_ascii[TWI_ADDR_LEN + 1];
+	size_t ascii_len;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		err = at_params_unsigned_short_get(&at_param_list, 1, &index);
+		if (err < 0) {
+			LOG_ERR("Fail to get twi index: %d", err);
+			return err;
+		}
+		ascii_len = TWI_ADDR_LEN + 1;
+		err = util_string_get(&at_param_list, 2, twi_addr_ascii, &ascii_len);
+		if (err < 0) {
+			LOG_ERR("Fail to get device address");
+			return err;
+		}
+		sscanf(twi_addr_ascii, "%hx", &dev_addr);
+		LOG_DBG("dev_addr: %hx", dev_addr);
+		ascii_len = sizeof(twi_data);
+		err = util_string_get(&at_param_list, 3, twi_data, &ascii_len);
+		if (err) {
+			return err;
+		}
+		LOG_DBG("Data to write: %s", log_strdup(twi_data));
+		err = at_params_unsigned_short_get(&at_param_list, 4, &num_read);
+		if (err < 0) {
+			LOG_ERR("Fail to get twi index: %d", err);
+			return err;
+		}
+		if (num_read > TWI_DATA_LEN) {
+			LOG_ERR("No enough buffer to read %d bytes", num_read);
+			return -ENOBUFS;
+		}
+		err = do_twi_write_read(index, dev_addr,
+					twi_data, (uint16_t)ascii_len,
+					num_read);
+		if (err < 0) {
+			return err;
+		}
+		break;
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf, "#XTWIWR: <index>,<dev_addr>,<data>,<num_read>\r\n");
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+	default:
+		break;
+	}
+
+	return err;
+}
+
+int slm_at_twi_init(void)
+{
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(i2c0), nordic_nrf_twim, okay)
+	slm_twi_dev[0] = device_get_binding(DT_LABEL(DT_NODELABEL(i2c0)));
+	LOG_DBG("bind %s", slm_twi_dev[0]->name);
+#endif
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(i2c1), nordic_nrf_twim, okay)
+	slm_twi_dev[1] = device_get_binding(DT_LABEL(DT_NODELABEL(i2c1)));
+	LOG_DBG("bind %s", slm_twi_dev[1]->name);
+#endif
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(i2c2), nordic_nrf_twim, okay)
+	slm_twi_dev[2] = device_get_binding(DT_LABEL(DT_NODELABEL(i2c2)));
+	LOG_DBG("bind %s", slm_twi_dev[2]->name);
+#endif
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(i2c3), nordic_nrf_twim, okay)
+	slm_twi_dev[3] = device_get_binding(DT_LABEL(DT_NODELABEL(i2c3)));
+	LOG_DBG("bind %s", slm_twi_dev[3]->name);
+#endif
+
+	return 0;
+}
+
+int slm_at_twi_uninit(void)
+{
+	return 0;
+}

--- a/applications/serial_lte_modem/src/twi/slm_at_twi.h
+++ b/applications/serial_lte_modem/src/twi/slm_at_twi.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef SLM_AT_TWI_
+#define SLM_AT_TWI_
+
+/**@file slm_at_twi.h
+ *
+ * @brief Vendor-specific AT command for TWI service.
+ * @{
+ */
+
+/**
+ * @brief Initialize TWI AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_twi_init(void);
+
+/**
+ * @brief Uninitialize TWI AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_twi_uninit(void);
+
+/** @} */
+
+#endif /* SLM_AT_TWI_ */


### PR DESCRIPTION
The TWI AT commands support communication for TWI master device.
Currently the supported commands are:

AT#XTWIOP: Open TWI instance.
AT#XTWIW: Write data to a TWI slave device.
AT#XTWIR: Read data from a TWI slave device.
AT#XTWIWR: Write then read data from an TWI device.

Signed-off-by: Larry Tsai <larry.tsai@nordicsemi.no>