### PR TITLE
applications: serial_lte_modem: Enable all optional services

### DIFF
--- a/applications/serial_lte_modem/prj.conf
+++ b/applications/serial_lte_modem/prj.conf
@@ -81,12 +81,3 @@ CONFIG_SLM_DATAMODE_HWFC=n
 # Use UART_2 (when working with external MCU)
 #CONFIG_SLM_CONNECT_UART_2=y
 #CONFIG_UART_2_NRF_HW_ASYNC_TIMER=2
-
-# Use optional GPS service
-#CONFIG_SLM_GPS=y
-# Use optional FTP client service
-#CONFIG_SLM_FTPC=y
-# Use optional MQTT client service
-#CONFIG_SLM_MQTTC=y
-# Use optional HTTP client service
-#CONFIG_SLM_HTTPC=y

--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -6,16 +6,6 @@ tests:
     build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     tags: ci_build
-  samples.nrf9160.serial_lte_modem.full_services:
-    build_only: true
-    build_on_all: true
-    platform_allow: nrf9160dk_nrf9160ns
-    tags: ci_build
-    extra_configs:
-      - CONFIG_SLM_GPS=y
-      - CONFIG_SLM_FTPC=y
-      - CONFIG_SLM_MQTTC=y
-      - CONFIG_SLM_HTTPC=y
   samples.nrf9160.serial_lte_modem.native_tls:
     build_only: true
     build_on_all: true

--- a/applications/serial_lte_modem/src/ftp_c/Kconfig
+++ b/applications/serial_lte_modem/src/ftp_c/Kconfig
@@ -5,6 +5,7 @@
 
 config SLM_FTPC
 	bool "FTP client support in SLM"
+	default y
 	select FTP_CLIENT
 
 if SLM_FTPC

--- a/applications/serial_lte_modem/src/gps/Kconfig
+++ b/applications/serial_lte_modem/src/gps/Kconfig
@@ -5,6 +5,8 @@
 
 config SLM_GPS
 	bool "GPS support in SLM"
+	default y
+
 
 if SLM_GPS
 

--- a/applications/serial_lte_modem/src/http_c/Kconfig
+++ b/applications/serial_lte_modem/src/http_c/Kconfig
@@ -5,4 +5,5 @@
 
 config SLM_HTTPC
 	bool "HTTP client support in SLM"
+	default y
 	select HTTP_CLIENT

--- a/applications/serial_lte_modem/src/mqtt_c/Kconfig
+++ b/applications/serial_lte_modem/src/mqtt_c/Kconfig
@@ -5,5 +5,6 @@
 
 config SLM_MQTTC
 	bool "MQTT client support in SLM"
+	default y
 	select MQTT_LIB
 	select MQTT_LIB_TLS

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -72,6 +72,7 @@ nRF9160
     * Fixed TCP/UDP port range issue (0~65535).
     * Added AT#XSLEEP=2 to power off UART interface.
     * Added data mode to FTP service.
+    * Enabled all SLM services by default.
 
 Common
 ======


### PR DESCRIPTION
Nordic precompiled HEX needs all services enabled.
CI tests reduced by one.

JIRA reference: NCSIDB-410

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>