### PR TITLE
doc: expand note about programming DKs

### DIFF
--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -12,7 +12,9 @@ The recommended way of building and programming an |NCS| sample is to use the No
 
 .. note::
 
-   See :ref:`precompiled_fw` and :ref:`building_pgming` for information about programming a Thingy:91.
+   For additional information, check the user guide for the hardware platform that you are using.
+   These user guides contain platform-specific instructions for building and programming.
+   For example, see :ref:`ug_nrf5340_building` in the :ref:`ug_nrf5340` user guide for information about programming an nRF5340 DK, or :ref:`precompiled_fw` and :ref:`building_pgming` for information about programming a Thingy:91.
 
 .. _gs_programming_ses:
 
@@ -184,17 +186,19 @@ Complete the following steps to build |NCS| projects on the command line after c
 
       .. code-block:: console
 
-         west flash
+         west flash --erase
 
-      This command clears only the flash memory pages that are overwritten with the new application.
-      If the application depends on other flash areas (for example, if it uses the :ref:`zephyr:settings_api` partition where bonding information is stored), erase the full kit before programming to ensure that these areas are updated with the new content.
-      If you do not fully erase the kit, the old data in these areas will be retained.
+      This command clears the full flash memory before programming, which is the recommended approach.
+      If the application depends on other flash memory areas (for example, if it uses the :ref:`zephyr:settings_api` partition where bonding information is stored), erasing the full kit before programming ensures that these areas are updated with the new content.
 
-      To fully erase the kit before programming the new application, use the following command:
+      As an alternative, you can also clear only those flash memory pages that are to be overwritten with the new application.
+      With such approach, the old data in other areas will be retained.
+
+      To erase only the areas of flash memory that are required for programming the new application, use the following command:
 
       .. code-block:: console
 
-         west flash --erase
+         west flash
 
       The ``west flash`` command automatically resets the kit and starts the application.
 


### PR DESCRIPTION
Expanded a note in the GS building guide.
The note now mentions specific building sections in DK UGs.
Added a note at the bottom, in the programming section.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>