### PR TITLE
applications: serial_lte_modem: Improve SLM AT host

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -54,12 +54,9 @@ choice
 	help
 		Sets the command terminator used by the serial terminal.
 		Available options are:
-		-  NULL termination
 		-  CR termination
 		-  LF termination
 		-  CR+LF termination
-	config SLM_NULL_TERMINATION
-		bool "NULL termination"
 	config SLM_CR_TERMINATION
 		bool "CR termination"
 	config SLM_LF_TERMINATION
@@ -67,13 +64,6 @@ choice
 	config SLM_CR_LF_TERMINATION
 		bool "CR+LF termination"
 endchoice
-
-config SLM_AT_HOST_TERMINATION
-	int
-	default 0 if SLM_NULL_TERMINATION
-	default 1 if SLM_CR_TERMINATION
-	default 2 if SLM_LF_TERMINATION
-	default 3 if SLM_CR_LF_TERMINATION
 
 #
 # GPIO wakeup

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -162,10 +162,6 @@ Check and configure the following configuration options for the sample:
 
    This option impacts the total RAM usage.
 
-.. option:: CONFIG_SLM_NULL_TERMINATION - NULL termination
-
-   This option configures the application to accept AT commands without a termination character.
-
 .. option:: CONFIG_SLM_CR_TERMINATION - CR termination
 
    This option configures the application to accept AT commands ending with a carriage return.


### PR DESCRIPTION
Check AT command syntax based on the following rules:
      AT< NULL >
      AT< separator >< body >< NULL >
      AT< separator >< body >=< NULL >
      AT< separator >< body >?< NULL >
      AT< separator >< body >=?< NULL >
      AT< separator >< body >=< parameters >< NULL >
Where:
      < separator >: +, %, #
      < body >: alphabetic char only, size > 0
      < parameters >: arbitrary, size > 0

Other minor updates:
    .Remove CONFIG_SLM_NULL_TERMINATION (not used)
    .Call uart_receive() at different scenario to enable RX

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>