### PR TITLE
caf: Don't call PM device API if it is not available

### DIFF
--- a/subsys/caf/modules/leds.c
+++ b/subsys/caf/modules/leds.c
@@ -165,12 +165,14 @@ static int leds_init(void)
 static void leds_start(void)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(leds); i++) {
+#ifdef CONFIG_PM_DEVICE
 		int err = device_set_power_state(leds[i].pwm_dev,
 						 DEVICE_PM_ACTIVE_STATE,
 						 NULL, NULL);
 		if (err) {
 			LOG_ERR("PWM enable failed");
 		}
+#endif
 		led_update(&leds[i]);
 	}
 }
@@ -182,12 +184,14 @@ static void leds_stop(void)
 
 		pwm_off(&leds[i]);
 
+#ifdef CONFIG_PM_DEVICE
 		int err = device_set_power_state(leds[i].pwm_dev,
 						 DEVICE_PM_SUSPEND_STATE,
 						 NULL, NULL);
 		if (err) {
 			LOG_ERR("PWM disable failed");
 		}
+#endif
 	}
 }
 


### PR DESCRIPTION
Don't try to call disabled system API.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>