### PR TITLE
Samples: mpsl: Add TIMER0 example usage

### DIFF
--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -20,6 +20,7 @@ The sample opens a timeslot session and starts requesting timeslots when a key i
 The first timeslot is always of type 'earliest'.
 Any following timeslots are of type 'normal'.
 In each timeslot callback, the signal type of the callback is posted to a message queue.
+Upon reception of the timeslot start signal, timer0 is configured to be triggered before the timeslot ends.
 A separate thread reads the message queue and prints the timeslot signal type.
 The timeslot session is closed when any key is pressed in the terminal.
 
@@ -52,12 +53,9 @@ After programming the sample to your development kit, test it by performing the 
    The terminal then prints the signal type for each timeslot callback:
 
    * If you press 'a', the timeslot callback requests a new timeslot.
-     Observe that ``Timeslot start`` is printed until the session is closed.
+     Observe that ``Timeslot start`` and ``Timer0 signal`` are printed until the session is closed.
    * If you press 'b', the timeslot callback ends the timeslot.
-     Observe that only one ``Timeslot start`` is printed, followed by a ``Session idle``.
-
-#. Press any key to close the session.
-   Observe that ``Session closed`` is printed.
+     Observe that ``Timeslot start`` and ``Timer0 signal`` are printed, followed by a ``Session idle``.
 
 Dependencies
 ************

--- a/samples/mpsl/timeslot/src/main.c
+++ b/samples/mpsl/timeslot/src/main.c
@@ -13,9 +13,11 @@
 
 #include <mpsl_timeslot.h>
 #include <mpsl.h>
+#include <hal/nrf_timer.h>
 
 #define TIMESLOT_REQUEST_DISTANCE_US (1000000)
 #define TIMESLOT_LENGTH_US           (200)
+#define TIMER_EXPIRY_US (TIMESLOT_LENGTH_US - 50)
 
 #define MPSL_THREAD_PRIO             CONFIG_MPSL_THREAD_COOP_PRIO
 #define STACKSIZE                    CONFIG_MAIN_STACK_SIZE
@@ -72,7 +74,27 @@ static mpsl_timeslot_signal_return_param_t *mpsl_timeslot_callback(
 	mpsl_timeslot_signal_return_param_t *p_ret_val = NULL;
 
 	switch (signal_type) {
+
 	case MPSL_TIMESLOT_SIGNAL_START:
+		/* No return action */
+		signal_callback_return_param.callback_action =
+			MPSL_TIMESLOT_SIGNAL_ACTION_NONE;
+		p_ret_val = &signal_callback_return_param;
+
+		/* Setup timer to trigger an interrupt (and thus the TIMER0
+		 * signal) before timeslot end.
+		 */
+		nrf_timer_cc_set(NRF_TIMER0, NRF_TIMER_CC_CHANNEL0,
+			TIMER_EXPIRY_US);
+		nrf_timer_int_enable(NRF_TIMER0, NRF_TIMER_INT_COMPARE0_MASK);
+
+		break;
+	case MPSL_TIMESLOT_SIGNAL_TIMER0:
+
+		/* Clear event */
+		nrf_timer_int_disable(NRF_TIMER0, NRF_TIMER_INT_COMPARE0_MASK);
+		nrf_timer_event_clear(NRF_TIMER0, NRF_TIMER_EVENT_COMPARE0);
+
 		if (request_in_cb) {
 			/* Request new timeslot when callback returns */
 			signal_callback_return_param.params.request.p_next =
@@ -80,14 +102,13 @@ static mpsl_timeslot_signal_return_param_t *mpsl_timeslot_callback(
 			signal_callback_return_param.callback_action =
 				MPSL_TIMESLOT_SIGNAL_ACTION_REQUEST;
 		} else {
-			/* No return action, so timeslot will be ended */
-			signal_callback_return_param.params.request.p_next =
-				NULL;
+			/* Timeslot will be ended */
 			signal_callback_return_param.callback_action =
-				MPSL_TIMESLOT_SIGNAL_ACTION_NONE;
+				MPSL_TIMESLOT_SIGNAL_ACTION_END;
 		}
 
 		p_ret_val = &signal_callback_return_param;
+
 		break;
 	case MPSL_TIMESLOT_SIGNAL_SESSION_IDLE:
 		break;
@@ -205,6 +226,9 @@ static void console_print_thread(void)
 			switch (signal_type) {
 			case MPSL_TIMESLOT_SIGNAL_START:
 				printk("Callback: Timeslot start\n");
+				break;
+			case MPSL_TIMESLOT_SIGNAL_TIMER0:
+				printk("Callback: Timer0 signal\n");
 				break;
 			case MPSL_TIMESLOT_SIGNAL_SESSION_IDLE:
 				printk("Callback: Session idle\n");


### PR DESCRIPTION
Add an example on how to use TIMER0 to close the timeslot session just
in time.

Signed-off-by: Azizah Ibrahim <azizah.ibrahim@nordicsemi.no>