### PR TITLE
doc: slm: fix typo

### DIFF
--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -184,7 +184,7 @@ If the MQTT client successfully subscribes to a topic, the following unsolicited
 
 * The ``<datatype>`` value can assume one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
 
 * The ``<topic_length>`` value is an integer.
@@ -306,7 +306,7 @@ Syntax
   It indicates the topic on which data is published.
 * The ``<datatype>`` parameter can accept one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
 
 * The ``<msg>`` parameter is a string.

--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -592,7 +592,7 @@ Syntax
 
 * The ``<datatype>`` parameter can accept one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML
@@ -665,7 +665,7 @@ Response syntax
   It contains the data being received.
 * The ``<datatype>`` parameter can accept one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML
@@ -721,7 +721,7 @@ Syntax
   It represents the port of the TCP service.
 * The ``<datatype>`` parameter can accept one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML
@@ -795,7 +795,7 @@ Response syntax
   It contains the data being received.
 * The ``<datatype>`` parameter can accept one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML
@@ -1059,7 +1059,7 @@ It represents the error value according to the standard POSIX *errorno*.
 
 * The ``<datatype>`` value can assume one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML
@@ -1209,7 +1209,7 @@ The modem needs to be in the offline state.
 
 * The ``<datatype>`` value can assume one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML
@@ -1301,7 +1301,7 @@ Syntax
 
 * The ``<datatype>`` parameter can accept one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML
@@ -1442,7 +1442,7 @@ It is reported to the client as follows:
 
 * The ``<datatype>`` parameter can accept one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML
@@ -1577,7 +1577,7 @@ It is reported to the client as follows:
 
 * The ``<datatype>`` parameter can accept one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML
@@ -1667,7 +1667,7 @@ Syntax
 
 * The ``<datatype>`` parameter can accept one of the following values:
 
-  * ``0`` - hexidecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
+  * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
   * ``2`` - JSON
   * ``3`` - HTML


### PR DESCRIPTION
It's hexadecimal, not hexidecimal.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>