### PR TITLE
manifest: nrf_modem: release 1.0.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 94c8d83811286e5505750a0554b9b2cd2df4ca6c
+      revision: 45ef62105b35af352082b7bd48ad21490dc4e08d
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Updates manifest for modemlib v1.0.2

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>