### PR TITLE
pcd: don't set secure attribute on PCD RAM region

### DIFF
--- a/subsys/pcd/src/pcd.c
+++ b/subsys/pcd/src/pcd.c
@@ -164,7 +164,7 @@ void pcd_lock_ram(void)
 {
 	uint32_t region = PCD_CMD_ADDRESS/CONFIG_NRF_SPU_RAM_REGION_SIZE;
 
-	nrf_spu_ramregion_set(NRF_SPU, region, true, NRF_SPU_MEM_PERM_READ,
+	nrf_spu_ramregion_set(NRF_SPU, region, false, NRF_SPU_MEM_PERM_READ,
 			true);
 }
 #endif /* CONFIG_SOC_NRF5340_CPUAPP && CONFIG_MCUBOOT */


### PR DESCRIPTION
There is no reason to set the secure attribute on the RAM
region used for IPC in the PCD module. This because the
region is write-protected, and there is no sensitive
information placed in the region.

Not setting the secure attribute allows the user of the
system to configure the network core as non-secure and
still leverage the PCD functionality to have upgrade
capabilities of the network core.

Ref: NCSIDB-409

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>