### PR TITLE
lib: lte_lc: Add Kconfig option to use default system mode

### DIFF
--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -143,6 +143,11 @@ choice
 	help
 		Select either LTE-M or Narrowband-IOT (NB-IoT) network mode
 
+config LTE_NETWORK_DEFAULT
+	bool "Use default"
+	help
+	  Use the system mode that is currently set in the modem.
+
 config LTE_NETWORK_MODE_LTE_M
 	bool "LTE-M"
 
@@ -165,10 +170,11 @@ endchoice
 
 choice
 	prompt "LTE mode preference"
-	default LTE_MODE_PREFERENCE_LTE_M
+	default LTE_MODE_PREFERENCE_AUTO
 	help
 	  Selects which LTE mode the modem should use if more than one is
-	  available.
+	  available. Note that the LTE preference must match the system modes
+	  that are enabled.
 
 config LTE_MODE_PREFERENCE_AUTO
 	bool "No preference"
@@ -177,6 +183,8 @@ config LTE_MODE_PREFERENCE_AUTO
 
 config LTE_MODE_PREFERENCE_LTE_M
 	bool "LTE-M"
+	depends on LTE_NETWORK_MODE_LTE_M || LTE_NETWORK_MODE_LTEM_NBIOT || \
+		   LTE_NETWORK_MODE_LTEM_GPS || LTE_NETWORK_MODE_LTEM_NBIOT_GPS
 	help
 	  LTE-M is preferred over PLMN selection. The modem will prioritize to
 	  use LTE-M and switch over to a PLMN where LTE-M is available whenever
@@ -184,6 +192,8 @@ config LTE_MODE_PREFERENCE_LTE_M
 
 config LTE_MODE_PREFERENCE_NBIOT
 	bool "NB-IoT"
+	depends on LTE_NETWORK_MODE_NBIOT || LTE_NETWORK_MODE_LTEM_NBIOT || \
+		   LTE_NETWORK_MODE_NBIOT_GPS || LTE_NETWORK_MODE_LTEM_NBIOT_GPS
 	help
 	  NB-IoT is preferred over PLMN selection. The modem will prioritize to
 	  use NB-IoT and switch over to a PLMN where NB-IoT is available
@@ -191,6 +201,8 @@ config LTE_MODE_PREFERENCE_NBIOT
 
 config LTE_MODE_PREFERENCE_LTE_M_PLMN_PRIO
 	bool "LTE-M, PLMN prioritized"
+	depends on LTE_NETWORK_MODE_LTE_M || LTE_NETWORK_MODE_LTEM_NBIOT || \
+		   LTE_NETWORK_MODE_LTEM_GPS || LTE_NETWORK_MODE_LTEM_NBIOT_GPS
 	help
 	  LTE-M is preferred, but PLMN selection is more important. The modem
 	  will prioritize to stay on home network and switch over to NB-IoT
@@ -198,6 +210,8 @@ config LTE_MODE_PREFERENCE_LTE_M_PLMN_PRIO
 
 config LTE_MODE_PREFERENCE_NBIOT_PLMN_PRIO
 	bool "NB-IoT, PLMN prioritized"
+	depends on LTE_NETWORK_MODE_NBIOT || LTE_NETWORK_MODE_LTEM_NBIOT || \
+		   LTE_NETWORK_MODE_NBIOT_GPS || LTE_NETWORK_MODE_LTEM_NBIOT_GPS
 	help
 	  NB-IoT is preferred, but PLMN selection is more important. The modem
 	  will prioritize to stay on home network and switch over to LTE-M


### PR DESCRIPTION
- Add Kconfig option to enable use of default system mode. In this
  context, default system mode means the mode that is currently
  set in the modem at boot time.
  Fixes CIA-237

- Add dependencies for LTE preference options to prevent situations
  where the preference is not possible to use in combination with
  the default mode. That would cause an AT command error, possibly
  making it impossible for the application to connect to the network.
  Fixes CIA-270

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>