### PR TITLE
lib: lte_lc: Use fallback when only one LTE mode is enabled

### DIFF
--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -224,13 +224,18 @@ config LTE_RAI_REQ_VALUE
 
 config LTE_NETWORK_USE_FALLBACK
 	bool "Use fallback network mode if selected mode fails"
-	default y
+	default y if !(LTE_NETWORK_MODE_LTEM_NBIOT || LTE_NETWORK_MODE_LTEM_NBIOT_GPS)
 	help
 		When enabled, the network mode will be switched to the other
 		available if the preferred fails to establish connection within
 		specified timeout.
 		If LTE-M is selected as the network mode, NB-IoT will be the
 		fallback mode and vice versa.
+		Fallback should not be enabled if both LTE-M and NB-IoT are enabled.
+		Instead, the LTE preference configuration should be used to
+		instruct the modem on which network to use. This is more efficient
+		both in terms of time to connection establishment and energy
+		consumption.
 
 config LTE_NETWORK_TIMEOUT
 	int "Time period [s] to attempt establishing connection"


### PR DESCRIPTION
If both LTE-M and NB-IoT is enabled at the same time, the
fallback mechanism should not be used. Instead, the LTE preference
configuration should be used to control which technology is used to
connect to the network. Using the modem's logic to control the
switching of mode is likely to be more efficient both in terms
og time to connection establishment and energy consumption.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>