### PR TITLE
Bluetooth: Mesh: Generic POnOff breaks power-up behavior of other models.

### DIFF
--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -104,6 +104,8 @@ struct bt_mesh_ponoff_srv {
 
 	/** Current OnPowerUp state. */
 	enum bt_mesh_on_power_up on_power_up;
+	/** Internal flag state. */
+	atomic_t flags;
 };
 
 /** @brief Set the OnPowerUp state of a Power OnOff server.

--- a/subsys/bluetooth/mesh/gen_ponoff_internal.h
+++ b/subsys/bluetooth/mesh/gen_ponoff_internal.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_ponoff_internal Generic Power OnOff model internals
+ * @ingroup bt_mesh_ponoff
+ * @{
+ * @brief Common internal API for the Generic Power OnOff models.
+ */
+
+#ifndef BT_MESH_GEN_PONOFF_INTERNAL_H__
+#define BT_MESH_GEN_PONOFF_INTERNAL_H__
+
+enum {
+	/** Don't use Generic OnOff set if Generic Power OnOff is extended. */
+	GEN_PONOFF_SRV_NO_ONOFF,
+};
+
+#endif /* BT_MESH_GEN_PONOFF_INTERNAL_H__ */
+
+/** @} */


### PR DESCRIPTION
Models that extend Generic Power OnOff Server and, which states are bound
with Generic OnOff state, store the value of the bound state separately,
therefore they don't need to set Generic OnOff.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>