### PR TITLE
net: fota_download: Add API to cancel downloading

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -57,6 +57,7 @@ nRF9160
   * :ref:`lib_fota_download` library:
 
     * Added an API to retrieve the image type that is being downloaded.
+    * Added an API to cancel current downloading.
 
   * :ref:`lib_ftp_client` library:
 

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -40,6 +40,8 @@ enum fota_download_evt_id {
 	FOTA_DOWNLOAD_EVT_ERASE_DONE,
 	/** FOTA download error. */
 	FOTA_DOWNLOAD_EVT_ERROR,
+	/** FOTA download cancelled. */
+	FOTA_DOWNLOAD_EVT_CANCELLED
 };
 
 /**
@@ -104,6 +106,14 @@ int fota_download_init(fota_download_callback_t client_callback);
  */
 int fota_download_start(const char *host, const char *file, int sec_tag,
 			const char *apn, size_t fragment_size);
+
+/**@brief Cancel FOTA image downloading.
+ *
+ * @retval 0       If FOTA download is cancelled successfully.
+ * @retval -EAGAIN If download is not started, aborted or completed.
+ *                 Otherwise, a negative value is returned.
+ */
+int fota_download_cancel(void);
 
 /**@brief Get target image type.
  *

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -590,6 +590,10 @@ static void http_fota_handler(const struct fota_download_evt *evt)
 		aws_fota_evt.dl.progress = download_progress;
 		callback(&aws_fota_evt);
 		break;
+
+	default:
+		LOG_WRN("Unhandled FOTA event ID: %d", evt->id);
+		break;
 	}
 }
 

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -38,6 +38,7 @@ static int socket_retries_left;
 static uint8_t mcuboot_buf[CONFIG_FOTA_DOWNLOAD_MCUBOOT_FLASH_BUF_SZ];
 #endif
 static enum dfu_target_image_type img_type;
+static bool first_fragment;
 
 static void send_evt(enum fota_download_evt_id id)
 {
@@ -84,7 +85,6 @@ static void dfu_target_callback_handler(enum dfu_target_evt_id evt)
 
 static int download_client_callback(const struct download_client_evt *event)
 {
-	static bool first_fragment = true;
 	static size_t file_size;
 	size_t offset;
 	int err;
@@ -367,7 +367,35 @@ int fota_download_init(fota_download_callback_t client_callback)
 		return err;
 	}
 
+	first_fragment = true;
 	return 0;
+}
+
+int fota_download_cancel(void)
+{
+	int err;
+
+	if (dlc.fd == -1) {
+		/* Download not started, aborted or completed */
+		LOG_WRN("%s invalid state", __func__);
+		return -EAGAIN;
+	}
+
+	err = download_client_disconnect(&dlc);
+	if (err) {
+		LOG_ERR("%s failed to disconnect: %d", __func__, err);
+		return err;
+	}
+
+	err = dfu_target_done(false);
+	if (err && err != -EACCES) {
+		LOG_ERR("%s failed to clean up: %d", __func__, err);
+	} else {
+		first_fragment = true;
+		send_evt(FOTA_DOWNLOAD_EVT_CANCELLED);
+	}
+
+	return err;
 }
 
 int fota_download_target(void)


### PR DESCRIPTION
From customer project, cancelling FOTA download is required.
Affect module (no default in switch)
      subsys\net\lib\aws_fota\src\aws_fota

JIRA reference: NCSIDB-353

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>