### PR TITLE
spm: Allow to use RNG for nRF5340 NS build.

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -75,9 +75,6 @@ config SPM_SERVICE_RNG
 	select NORDIC_SECURITY_BACKEND if IS_SPM
 	select FPU if IS_SPM
 
-# NORDIC_SECURITY_BACKEND is not supported on 53 yet
-	depends on ! SOC_NRF5340_CPUAPP
-
 	help
 	  The Non-Secure Firmware is not allowed to use the crypto hardware.
 	  This service allows it to request random numbers from the SPM.


### PR DESCRIPTION
Non-secure code has no acces to entropy HW directly, but
it is possible to get random numbers by Secure Services.

On nRF5340_cpuapp NS RNG is provided by enabling RNG service.
This however does not work due to limitation in Kconfig which this
patch removes.

The limitation does not allow to compile Secure Service function
for getting random numbers.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>