### PR TITLE
doc: align installing manually guide sections

### DIFF
--- a/doc/nrf/gs_assistant.rst
+++ b/doc/nrf/gs_assistant.rst
@@ -115,9 +115,9 @@ Once the verification is successful, the vertical progress bar changes color to 
 At the same time, the :guilabel:`Mark done` button changes to :guilabel:`Mark not done`.
 
 .. figure:: images/gs-assistant_UI.gif
-   :alt: Verifying the |NCS| toolchain installation in the |GSA| app
+   :alt: Example of how to verify |NCS| toolchain installation in the |GSA| app
 
-   Verifying the |NCS| toolchain installation
+   Example of how to verify the |NCS| toolchain installation
 
 If there is an issue, the Log section is updated with the related error.
 

--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -17,15 +17,17 @@ See the :ref:`gs_assistant` section for information about how to install the |NC
 To manually install the |NCS|, you must install all required tools and clone the |NCS| repositories.
 See the following sections for detailed instructions.
 
-The first two steps, `Installing the required tools`_ and `Installing the toolchain`_, are identical to the installation in Zephyr.
+The steps `Install the required tools`_ and `Install the toolchain`_ are similar to the installation steps in Zephyr's :ref:`zephyr:getting_started`.
 If you already have your system set up to work with the Zephyr OS, you can skip these steps.
 
 See :ref:`gs_installing_os` for information on the supported operating systems and Zephyr features.
 
 .. _gs_installing_tools:
 
-Installing the required tools
-*****************************
+.. rst-class:: numbered-step
+
+Install the required tools
+**************************
 
 The installation process is different depending on your operating system.
 
@@ -45,7 +47,7 @@ The installation process is different depending on your operating system.
 
       .. note::
          You do not need to install the Zephyr SDK.
-         We recommend to install the compiler toolchain separately, as detailed in `Installing the toolchain`_.
+         We recommend to install the compiler toolchain separately, as detailed in `Install the toolchain`_.
 
    .. group-tab:: macOS
 
@@ -54,6 +56,8 @@ The installation process is different depending on your operating system.
       Install Homebrew and install the required tools using the ``brew`` command line tool.
 
       Also see :ref:`zephyr:mac-setup-alts` for additional information.
+
+..
 
 If you are interested in building `Project Connected Home over IP`_ applications, install also the `GN`_ meta-build system to generate the Ninja files that the |NCS| uses.
 
@@ -113,115 +117,18 @@ If you are interested in building `Project Connected Home over IP`_ applications
             echo 'export PATH=${HOME}/gn:"$PATH"' >> ${HOME}/.bashrc
             source ${HOME}/.bashrc
 
-.. _gs_installing_toolchain:
+..
 
-Installing the toolchain
-************************
+.. _gs_installing_west:
 
-To be able to cross-compile your applications for Arm targets, you must install version 9-2019-q4-major of the `GNU Arm Embedded Toolchain`_.
+.. rst-class:: numbered-step
 
-.. important::
-   Make sure to install the version that is mentioned above.
-   Other versions might not work with this version of the |NCS|.
+Install west
+************
 
-   Note that other versions of the |NCS| might require a different toolchain version.
+To manage the combination of repositories and versions, the |NCS| uses :ref:`Zephyr's west <zephyr:west>`.
 
-To set up the toolchain, complete the following steps:
-
-.. _toolchain_setup:
-
-1. Download the `GNU Arm Embedded Toolchain`_ for your operating system.
-#. Extract the toolchain into a folder of your choice.
-   We recommend to use the folder ``c:\gnuarmemb`` on Windows and ``~/gnuarmemb`` on Linux or macOS.
-
-   Make sure that the folder name does not contain any spaces or special characters.
-#. If you want to build and program applications from the command line, define the environment variables for the GNU Arm Embedded toolchain.
-   Depending on your operating system:
-
-    .. tabs::
-
-       .. group-tab:: Windows
-
-          Open a command prompt and enter the following commands (assuming that you have installed the toolchain to ``c:\gnuarmemb``; if not, change the value for GNUARMEMB_TOOLCHAIN_PATH):
-
-            .. parsed-literal::
-               :class: highlight
-
-               set ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-               set GNUARMEMB_TOOLCHAIN_PATH=\ c:\\gnuarmemb
-
-       .. group-tab:: Linux
-
-          Open a terminal window and enter the following commands (assuming that you have installed the toolchain to ``~/gnuarmemb``; if not, change the value for GNUARMEMB_TOOLCHAIN_PATH):
-
-            .. parsed-literal::
-              :class: highlight
-
-              export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-              export GNUARMEMB_TOOLCHAIN_PATH=\ "~/gnuarmemb"
-
-       .. group-tab:: macOS
-
-          Open a terminal window and enter the following commands (assuming that you have installed the toolchain to ``~/gnuarmemb``; if not, change the value for GNUARMEMB_TOOLCHAIN_PATH):
-
-            .. parsed-literal::
-              :class: highlight
-
-              export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-              export GNUARMEMB_TOOLCHAIN_PATH=\ "~/gnuarmemb"
-
-#. Set the environment variables persistently.
-   Depending on your operating system:
-
-    .. tabs::
-
-       .. group-tab:: Windows
-
-          Add the environment variables as system environment variables or define them in the ``%userprofile%\zephyrrc.cmd`` file as described in `Setting up the build environment`_.
-          This will allow you to avoid setting them every time you open a command prompt.
-
-       .. group-tab:: Linux
-
-          Define the environment variables in the ``~/.zephyrrc`` file as described in `Setting up the build environment`_.
-          This will allow you to avoid setting them every time you open a terminal window.
-
-       .. group-tab:: macOS
-
-          Define the environment variables in the ``~/.zephyrrc`` file as described in `Setting up the build environment`_.
-          This will allow you to avoid setting them every time you open a terminal window.
-
-
-.. _cloning_the_repositories_win:
-.. _cloning_the_repositories:
-
-Getting the |NCS| code
-**********************
-
-The |NCS| consists of a set of Git repositories.
-
-Every |NCS| release consists of a combination of these repositories at different revisions.
-The revision of each of those repositories is determined by the current revision of the main (or manifest) repository, `sdk-nrf`_.
-
-.. note::
-   The latest state of development is on the master branch of the `sdk-nrf`_ repository.
-   To ensure a usable state, the `sdk-nrf`_ repository defines the compatible states of the other repositories.
-   However, this state is not necessarily tested.
-   For a higher degree of quality assurance, check out a tagged release.
-
-   Therefore, unless you are familiar with the development process, you should always work with a specific release of the |NCS|.
-
-To manage the combination of repositories and versions, the |NCS| uses :ref:`zephyr:west`.
-The main repository, `sdk-nrf`_, contains a `west manifest file`_, :file:`west.yml`, that determines the revision of all other repositories.
-This means that sdk-nrf acts as the :ref:`manifest repository <zephyr:west-basics>`, while the other repositories are project repositories.
-
-You can find additional information about the repository and development model in the :ref:`development model section <dev-model>`.
-
-See the :ref:`west documentation <zephyr:west>` for detailed information about the tool itself.
-
-Installing west
-===============
-
-Install west by entering the following command:
+To install west, enter the following command:
 
 .. tabs::
 
@@ -248,36 +155,31 @@ Install west by entering the following command:
 
 You only need to do this once.
 
-.. _west_update:
+.. _cloning_the_repositories_win:
+.. _cloning_the_repositories:
 
-Like any other Python package, the west tool is updated regularly.
-Therefore, remember to regularly check for updates:
+.. rst-class:: numbered-step
 
-.. tabs::
+Get the |NCS| code
+******************
 
-   .. group-tab:: Windows
+The |NCS| consists of a set of :ref:`Git repositories <ncs_introduction>`.
 
-      .. parsed-literal::
-         :class: highlight
+Every |NCS| release consists of a combination of these repositories at different revisions.
+The revision of each of those repositories is determined by the current revision of the main (or manifest) repository, `sdk-nrf`_.
 
-         pip3 install -U west
+.. note::
+   The latest state of development is on the master branch of the `sdk-nrf`_ repository.
+   To ensure a usable state, the `sdk-nrf`_ repository defines the compatible states of the other repositories.
+   However, this state is not necessarily tested.
+   For a higher degree of quality assurance, check out a tagged release.
 
-   .. group-tab:: Linux
+   Therefore, unless you are familiar with the development process, you should always work with a specific release of the |NCS|.
 
-      .. parsed-literal::
-         :class: highlight
+The main repository, `sdk-nrf`_, contains a `west manifest file`_, :file:`west.yml`, that determines the revision of all other repositories.
+This means that sdk-nrf acts as the :ref:`manifest repository <zephyr:west-basics>`, while the other repositories are project repositories.
 
-         pip3 install --user -U west
-
-   .. group-tab:: macOS
-
-      .. parsed-literal::
-         :class: highlight
-
-         pip3 install -U west
-
-Cloning the repositories
-========================
+For more information about the repository and development model, see the :ref:`development model section <dev-model>`.
 
 .. tip::
    If you cloned the |NCS| repositories before they were moved to the nrfconnect GitHub organization and want to update them, follow the instructions in :ref:`repo_move`.
@@ -352,122 +254,12 @@ Your directory structure now looks similar to this::
 Note that there are additional folders, and that the structure might change.
 The full set of repositories and folders is defined in the manifest file.
 
-
-
-
-Updating the repositories
-=========================
-
-If you work with a specific release of the |NCS|, you do not need to update your repositories, because the release will not change.
-However, you might want to switch to a newer release or check out the latest state of development.
-
-To manage the ``nrf`` repository (the manifest repository), use Git.
-To make sure that you have the latest changes, run ``git fetch origin`` to :ref:`fetch the latest code <dm-wf-update-ncs>` from the `sdk-nrf`_ repository.
-Checking out a branch or tag in the ``nrf`` repository gives you a different version of the manifest file.
-Running ``west update`` will then update the project repositories to the state specified in this manifest file.
-
-.. include:: gs_installing.rst
-   :start-after: west-error-start
-   :end-before: west-error-end
-
-For example, to switch to release |release| of the |NCS|, enter the following commands in the ``ncs/nrf`` directory:
-
-.. parsed-literal::
-   :class: highlight
-
-   git fetch origin
-   git checkout |release|
-   west update
-
-To update to a particular revision (SHA), make sure that you have that particular revision locally before you check it out (by running ``git fetch origin``)::
-
-   git fetch origin
-   git checkout 224bee9055d986fe2677149b8cbda0ff10650a6e
-   west update
-
-To switch to the latest state of development, enter the following commands::
-
-   git fetch origin
-   git checkout origin/master
-   west update
-
-.. note::
-   Run ``west update`` every time you change or modify the current working branch (for example, when you pull, rebase, or check out a different branch).
-   This will bring the project repositories to the matching revision defined by the manifest file.
-
-.. _repo_move:
-
-Pointing the repositories to the right remotes after they were moved
-====================================================================
-
-Before |NCS| version 1.3.0, the Git repositories were moved from the NordicPlayground GitHub organization to the nrfconnect organization.
-They were also renamed, replacing the ``fw-nrfconnect-`` prefix with ``sdk-``.
-
-If you cloned the repositories before the move, your local repositories and forks of the |NCS| repositories are automatically be redirected to the new ones.
-However, you should point them directly to their new locations as described in this section.
-
-The full list of repositories with their old and new URLs can be found in the following table:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Old URL
-     - New URL
-     - File system path
-
-   * - https:\ //github.com/NordicPlayground/fw-nrfconnect-nrf
-     - https://github.com/nrfconnect/sdk-nrf
-     - :file:`ncs/nrf`
-
-   * - https:\ //github.com/NordicPlayground/fw-nrfconnect-zephyr
-     - https://github.com/nrfconnect/sdk-zephyr
-     - :file:`ncs/zephyr`
-
-   * - https:\ //github.com/NordicPlayground/fw-nrfconnect-mcuboot
-     - https://github.com/nrfconnect/sdk-mcuboot
-     - :file:`ncs/bootloader/mcuboot`
-
-   * - https:\ //github.com/NordicPlayground/fw-nrfconnect-mcumgr
-     - https://github.com/nrfconnect/sdk-mcumgr
-     - :file:`ncs/modules/lib/mcumgr`
-
-   * - https:\ //github.com/NordicPlayground/nrfxlib
-     - https://github.com/nrfconnect/sdk-nrfxlib
-     - :file:`ncs/nrfxlib`
-
-
-Before you change the remotes, rename any personal forks that you have of the
-|NCS| repositories to their new names.
-
-To do so, visit your personal fork in a browser and edit the name there.
-For example, to rename the fw-nrfconnect-nrf repository, access your fork on GitHub (for example, ``https://github.com/<username>/fw-nrfconnect-nrf``), switch to the :guilabel:`Settings` tab, and change the name in the :guilabel:`Repository name` field to ``sdk-nrf``.
-
-Then rename the actual remotes.
-To do so, go to your local copy of each of the repositories listed in the table above and enter the following command:
-
-.. parsed-literal::
-   :class: highlight
-
-   git remote set-url *remote_name* *new_url*
-
-Replace *remote_name* with the name of your remote (for example, ``origin`` for your fork or ``ncs`` for the upstream repository) and *new_url* with the URL of your fork or the new URL from the table above.  If you are unsure about the remotes that are configured in your local repository, enter ``git remote -v``.
-
-For example, to point your existing fw-nrfconnect-nrf clone to its new URL, enter the following command::
-
-    cd ncs/nrf
-    git remote set-url origin https://github.com/nrfconnect/sdk-nrf
-
-Similarly, to point your existing fw-nrfconnect-zephyr clone to the new URL, enter the following command::
-
-    cd ncs/zephyr
-    git remote set-url ncs https://github.com/nrfconnect/sdk-zephyr
-
-Additional information about remotes and how to handle them can be found in :ref:`dm-wf-fork`.
-
 .. _additional_deps:
 
-Installing additional Python dependencies
-*****************************************
+.. rst-class:: numbered-step
+
+Install additional Python dependencies
+**************************************
 
 The |NCS| requires additional Python packages to be installed.
 
@@ -508,14 +300,94 @@ Use the following commands to install the requirements for each repository.
            pip3 install -r nrf/scripts/requirements.txt
            pip3 install -r bootloader/mcuboot/scripts/requirements.txt
 
+..
 
+.. _gs_installing_toolchain:
 
+.. rst-class:: numbered-step
+
+Install the toolchain
+*********************
+
+To be able to cross-compile your applications for Arm targets, you must install version 9-2019-q4-major of the `GNU Arm Embedded Toolchain`_.
+
+.. important::
+   Make sure to install the version that is mentioned above.
+   Other versions might not work with this version of the |NCS|.
+
+   Other versions of the |NCS| might require a different toolchain version.
+
+To set up the toolchain, complete the following steps:
+
+.. _toolchain_setup:
+
+1. Download the `GNU Arm Embedded Toolchain`_ for your operating system.
+#. Extract the toolchain into a folder of your choice.
+   We recommend to use the folder ``c:\gnuarmemb`` on Windows and ``~/gnuarmemb`` on Linux or macOS.
+
+   Make sure that the folder name does not contain any spaces or special characters.
+#. If you want to build and program applications from the command line, define the environment variables for the GNU Arm Embedded toolchain.
+   Depending on your operating system:
+
+    .. tabs::
+
+       .. group-tab:: Windows
+
+          Open a command prompt and enter the following commands (assuming that you have installed the toolchain to ``c:\gnuarmemb``; if not, change the value for GNUARMEMB_TOOLCHAIN_PATH):
+
+            .. parsed-literal::
+               :class: highlight
+
+               set ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+               set GNUARMEMB_TOOLCHAIN_PATH=\ c:\\gnuarmemb
+
+       .. group-tab:: Linux
+
+          Open a terminal window and enter the following commands (assuming that you have installed the toolchain to ``~/gnuarmemb``; if not, change the value for GNUARMEMB_TOOLCHAIN_PATH):
+
+            .. parsed-literal::
+              :class: highlight
+
+              export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+              export GNUARMEMB_TOOLCHAIN_PATH=\ "~/gnuarmemb"
+
+       .. group-tab:: macOS
+
+          Open a terminal window and enter the following commands (assuming that you have installed the toolchain to ``~/gnuarmemb``; if not, change the value for GNUARMEMB_TOOLCHAIN_PATH):
+
+            .. parsed-literal::
+              :class: highlight
+
+              export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+              export GNUARMEMB_TOOLCHAIN_PATH=\ "~/gnuarmemb"
+
+#. Set the environment variables persistently.
+   Depending on your operating system:
+
+    .. tabs::
+
+       .. group-tab:: Windows
+
+          Add the environment variables as system environment variables or define them in the ``%userprofile%\zephyrrc.cmd`` file as described in :ref:`build_environment_cli`.
+          This lets you avoid setting them every time you open a command prompt.
+
+       .. group-tab:: Linux
+
+          Define the environment variables in the ``~/.zephyrrc`` file as described in :ref:`build_environment_cli`.
+          This lets you avoid setting them every time you open a terminal window.
+
+       .. group-tab:: macOS
+
+          Define the environment variables in the ``~/.zephyrrc`` file as described in :ref:`build_environment_cli`.
+          This lets you avoid setting them every time you open a terminal window.
 
 
 .. _installing_ses:
 
-Installing |SES| Nordic Edition
-*******************************
+.. rst-class:: numbered-step
+
+Install |SES| Nordic Edition
+****************************
 
 You must install |SES| (SES) Nordic Edition to be able to open and compile projects in the |NCS|.
 
@@ -566,106 +438,103 @@ To install |SES| Nordic Edition, complete the following steps:
        The license activation window will close and SES will open the Project Explorer window.
 
 .. _build_environment:
+.. _setting_up_SES:
 
-Setting up the build environment
-********************************
+.. rst-class:: numbered-step
+
+Set up the build environment in SES
+***********************************
 
 Before you start :ref:`building and programming a sample application <gs_programming>`, you must set up your build environment.
 
-.. _setting_up_SES:
+1. Set up the SES environment.
+   If you plan to :ref:`build with SEGGER Embedded Studio <gs_programming_ses>`, the first time you import an |NCS| project, SES might prompt you to set the paths to the Zephyr Base directory and the GNU ARM Embedded Toolchain.
+   You only need to do this once.
+   Complete the following steps:
 
-Setting up the SES environment
-==============================
+   a. Run the file :file:`bin/emStudio`.
 
-If you plan to :ref:`build with SEGGER Embedded Studio <gs_programming_ses>`, the first time you import an |NCS| project, SES might prompt you to set the paths to the Zephyr Base directory and the GNU ARM Embedded Toolchain.
-This must be done only once.
+   #. Select :guilabel:`File` -> :guilabel:`Open nRF Connect SDK Project`.
 
-Complete the following steps to set up the |SES| environment:
+      .. figure:: images/ses_open.png
+         :alt: Open nRF Connect SDK Project menu
 
-1. Run the file :file:`bin/emStudio`.
+         Open nRF Connect SDK Project menu
 
-#. Select :guilabel:`File` -> :guilabel:`Open nRF Connect SDK Project`.
+   #. Set the Zephyr Base directory to the full path to ``ncs/zephyr``.
+      The GNU ARM Embedded Toolchain directory is the directory where you installed the toolchain (for example, ``c:/gnuarmemb``).
 
-    .. figure:: images/ses_open.png
-       :alt: Open nRF Connect SDK Project menu
+      .. figure:: images/ses_notset.png
+         :alt: Zephyr Base Not Set prompt
 
-       Open nRF Connect SDK Project menu
+         Zephyr Base Not Set prompt
 
-#. Set the Zephyr Base directory to the full path to ``ncs/zephyr``.
-   The GNU ARM Embedded Toolchain directory is the directory where you installed the toolchain (for example, ``c:/gnuarmemb``).
+#. Set up executables.
+   The process is different depending on your operating system.
 
-    .. figure:: images/ses_notset.png
-       :alt: Zephyr Base Not Set prompt
+   .. tabs::
 
-       Zephyr Base Not Set prompt
+      .. group-tab:: Windows
 
-Setting up executables
-======================
+         Make sure the locations of tools are added to the PATH variable.
+         On Windows, SES uses the PATH variable to find executables if they are not set in SES.
 
-The process is different depending on your operating system.
+      .. group-tab:: Linux
 
-.. tabs::
+         Make sure the locations of tools are added to the PATH variable.
+         On Linux, SES uses the PATH variable to find executables if they are not set in SES.
 
-   .. group-tab:: Windows
+      .. group-tab:: macOS
 
-      Make sure the locations of tools are added to the PATH variable.
-      On Windows, SES uses the PATH variable to find executables if they are not set in SES.
+         If you start SES on macOS by running the file :file:`bin/emStudio`, make sure to complete the following steps:
 
-   .. group-tab:: Linux
+         1. Specify the path to all executables under :guilabel:`Tools` -> :guilabel:`Options` (in the :guilabel:`nRF Connect` tab).
 
-      Make sure the locations of tools are added to the PATH variable.
-      On Linux, SES uses the PATH variable to find executables if they are not set in SES.
-
-   .. group-tab:: macOS
-
-      If you start SES on macOS by running the file :file:`bin/emStudio`, make sure to complete the following steps:
-
-      1. Specify the path to all executables under :guilabel:`Tools` -> :guilabel:`Options` (in the :guilabel:`nRF Connect` tab).
-
-          .. figure:: images/ses_options.png
+            .. figure:: images/ses_options.png
                :alt: nRF Connect SDK options in SES on Windows
 
                nRF Connect SDK options in SES (Windows)
 
-         Use this section to change the SES environment settings later as well.
+            Use this section to change the SES environment settings later as well.
 
-      #. Specify the path to the west tool as additional CMake option, replacing *path_to_west* with the path to the west executable (for example, ``/usr/local/bin/west``):
+         #. Specify the path to the west tool as an additional CMake option, replacing *path_to_west* with the path to the west executable (for example, ``/usr/local/bin/west``):
 
-          .. parsed-literal::
-             :class: highlight
+            .. parsed-literal::
+               :class: highlight
 
-             -DWEST=\ *path_to_west*
-
-
-      If you start SES from the command line, it uses the global PATH variable to find the executables.
-      You do not need to explicitly configure the executables in SES.
-
-      Regardless of how you start SES, if you get an error that a tool or command cannot be found, first make sure that the tool is installed.
-      If it is installed, verify that its path is configured correctly in the SES settings or in the PATH variable.
+               -DWEST=\ *path_to_west*
 
 
-Changing the SES environment settings
-=====================================
+         If you start SES from the command line, it uses the global PATH variable to find the executables.
+         You do not need to explicitly configure the executables in SES.
 
-If you want to change the SES environment settings, click :guilabel:`Tools` -> :guilabel:`Options` and select the :guilabel:`nRF Connect` tab, as shown on the following screenshot from the Windows installation.
+         Regardless of how you start SES, if you get an error that a tool or command cannot be found, first make sure that the tool is installed.
+         If it is installed, verify that its path is configured correctly in the SES settings or in the PATH variable.
+
+   ..
+
+#. Change the SES environment settings.
+   If you want to change the SES environment settings, click :guilabel:`Tools` -> :guilabel:`Options` and select the :guilabel:`nRF Connect` tab, as shown on the following screenshot from the Windows installation.
 
 .. _ses_options_figure:
 
-.. figure:: images/ses_options.png
-     :alt: nRF Connect SDK options in SES on Windows
+   .. figure:: images/ses_options.png
+      :alt: nRF Connect SDK options in SES on Windows
 
-     nRF Connect SDK options in SES (Windows)
+      nRF Connect SDK options in SES (Windows)
 
-If you want to configure tools that are not listed in the SES options, add them to the PATH variable.
+   If you want to configure tools that are not listed in the SES options, add them to the PATH variable.
 
 .. _build_environment_cli:
 
-Setting up the command line build environment
-=============================================
+Set up the command-line build environment
+*****************************************
 
-If you want to build and program your application from the command line, you must set up your build environment by defining the required environment variables every time you open a new command prompt or terminal window.
+The default build environment for |NCS| is SES.
+However, you can also build and program your application from the command line.
+You have to set up your build environment by defining the required environment variables every time you open a new command prompt or terminal window.
 
-See :ref:`zephyr:env_vars_important` information about the various relevant environment variables.
+See :ref:`zephyr:env_vars_important` for more information about the various relevant environment variables.
 
 Define the required environment variables as follows, depending on your operating system:
 
@@ -677,6 +546,7 @@ Define the required environment variables as follows, depending on your operatin
 
       If you need to define additional environment variables, create the file ``%userprofile%\zephyrrc.cmd`` and add the variables there.
       This file is loaded automatically when you run the above command.
+      See :ref:`zephyr:zephyr-env` for more information.
 
    .. group-tab:: Linux
 
@@ -684,6 +554,8 @@ Define the required environment variables as follows, depending on your operatin
 
       If you need to define additional environment variables, create the file ``~/.zephyrrc`` and add the variables there.
       This file is loaded automatically when you run the above command.
+      See :ref:`zephyr:zephyr-env` for more information.
+
 
    .. group-tab:: macOS
 
@@ -691,7 +563,171 @@ Define the required environment variables as follows, depending on your operatin
 
       If you need to define additional environment variables, create the file ``~/.zephyrrc`` and add the variables there.
       This file is loaded automatically when you run the above command.
+      See :ref:`zephyr:zephyr-env` for more information.
 
 You must also make sure that nrfjprog (part of the `nRF Command Line Tools`_) is installed and its path is added to the environment variables.
 The west command programs the kit by using nrfjprog by default.
 For more information on nrfjprog, see `Programming SoCs with nrfjprog`_.
+
+.. _gs_updating:
+
+Updating tools and repositories
+*******************************
+
+Remember to regularly check for updates to tools.
+Like any other Python package, the west tool is updated regularly.
+
+You might also want to switch to a newer release or check out the latest state of development.
+However, if you work with a specific release of the |NCS|, you do not need to update your repositories, because the release will not change.
+
+.. _west_update:
+
+Updating west
+=============
+
+To update west, run the following command:
+
+.. tabs::
+
+   .. group-tab:: Windows
+
+      .. parsed-literal::
+         :class: highlight
+
+         pip3 install -U west
+
+   .. group-tab:: Linux
+
+      .. parsed-literal::
+         :class: highlight
+
+         pip3 install --user -U west
+
+   .. group-tab:: macOS
+
+      .. parsed-literal::
+         :class: highlight
+
+         pip3 install -U west
+
+..
+
+This command updates west to the latest available version in the PyPi repository.
+
+Updating the repositories
+=========================
+
+To manage the ``nrf`` repository (the manifest repository), use Git.
+To make sure that you have the latest changes, run ``git fetch origin`` to :ref:`fetch the latest code <dm-wf-update-ncs>` from the `sdk-nrf`_ repository.
+Checking out a branch or tag in the ``nrf`` repository gives you a different version of the manifest file.
+Running ``west update`` updates the project repositories to the state specified in this manifest file.
+
+.. include:: gs_installing.rst
+   :start-after: west-error-start
+   :end-before: west-error-end
+
+Examples of commands
+--------------------
+
+To switch to release |release| of the |NCS|, enter the following commands in the ``ncs/nrf`` directory:
+
+.. parsed-literal::
+   :class: highlight
+
+   git fetch origin
+   git checkout |release|
+   west update
+
+To update to a particular revision (SHA), make sure that you have that particular revision locally before you check it out (by running ``git fetch origin``)::
+
+   git fetch origin
+   git checkout 224bee9055d986fe2677149b8cbda0ff10650a6e
+   west update
+
+To switch to the latest state of development, enter the following commands::
+
+   git fetch origin
+   git checkout origin/master
+   west update
+
+.. note::
+   Run ``west update`` every time you change or modify the current working branch (for example, when you pull, rebase, or check out a different branch).
+   This will bring the project repositories to the matching revision defined by the manifest file.
+
+.. _repo_move:
+
+Pointing the repositories to the right remotes after they were moved
+====================================================================
+
+Before |NCS| version 1.3.0, the Git repositories were moved from the NordicPlayground GitHub organization to the nrfconnect organization.
+They were also renamed, replacing the ``fw-nrfconnect-`` prefix with ``sdk-``.
+
+The full list of repositories with their old and new URLs is in the following table:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Old URL
+     - New URL
+     - File system path
+
+   * - https:\ //github.com/NordicPlayground/fw-nrfconnect-nrf
+     - https://github.com/nrfconnect/sdk-nrf
+     - :file:`ncs/nrf`
+
+   * - https:\ //github.com/NordicPlayground/fw-nrfconnect-zephyr
+     - https://github.com/nrfconnect/sdk-zephyr
+     - :file:`ncs/zephyr`
+
+   * - https:\ //github.com/NordicPlayground/fw-nrfconnect-mcuboot
+     - https://github.com/nrfconnect/sdk-mcuboot
+     - :file:`ncs/bootloader/mcuboot`
+
+   * - https:\ //github.com/NordicPlayground/fw-nrfconnect-mcumgr
+     - https://github.com/nrfconnect/sdk-mcumgr
+     - :file:`ncs/modules/lib/mcumgr`
+
+   * - https:\ //github.com/NordicPlayground/nrfxlib
+     - https://github.com/nrfconnect/sdk-nrfxlib
+     - :file:`ncs/nrfxlib`
+
+
+If you cloned the repositories before the move, your local repositories and forks of the |NCS| repositories are automatically be redirected to the new ones.
+However, you should point them directly to their new locations as described in this section.
+
+To change the remotes, complete the following steps:
+
+1. Rename any personal forks that you have of the |NCS| repositories to their new names:
+
+   a. Visit your personal fork in a browser.
+      For example, to rename the fw-nrfconnect-nrf repository, access your fork on GitHub (``https://github.com/<username>/fw-nrfconnect-nrf``, where *<username>* is your GitHub account name).
+   b. Switch to the :guilabel:`Settings` tab and edit the name in the :guilabel:`Repository name` field to ``sdk-nrf``.
+
+#. Rename the remotes:
+
+   a. Go to your local copy of each of the repositories listed in the preceding table.
+   #. Enter the following command:
+
+      .. parsed-literal::
+        :class: highlight
+
+        git remote set-url *remote_name* *new_url*
+
+      In this command, replace *remote_name* with the name of your remote (for example, ``origin`` for your fork or ``ncs`` for the upstream repository) and *new_url* with the URL of your fork or the new URL from the preceding table.
+      If you are not sure about the remotes that are configured in your local repository, enter ``git remote -v`` to see your remotes.
+
+For example, to point your existing fw-nrfconnect-nrf clone to its new URL, enter the following command:
+
+.. code-block::
+
+   cd ncs/nrf
+   git remote set-url origin https://github.com/nrfconnect/sdk-nrf
+
+Similarly, to point your existing fw-nrfconnect-zephyr clone to the new URL, enter the following command:
+
+.. code-block::
+
+   cd  ncs/zephyr
+   git remote set-url ncs https://github.com/nrfconnect/sdk-zephyr
+
+For more information about remotes and how to handle them, see :ref:`dm-wf-fork`.


### PR DESCRIPTION
Moved west section under required tools.
Aligned sections in Installing NCS manually with GSA and Zephyr GSG.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>

- [x] Include link to https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/env_vars.html#zephyr-environment-scripts in the section about Setting environmental variables