### PR TITLE
manifest: Update SoftDevice Controller

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -816,6 +816,13 @@ KRKNWK-8133: CSMA-CA issues
 SoftDevice Controller
 =====================
 
+.. rst-class:: v1-5-0
+
+DRGN-15382: The SoftDevice Controller cannot be qualified on nRF52832
+  The SoftDevice Controller cannot be qualified on nRF52832.
+
+  **Workaround:** Upgrade to v1.5.1 (once available) or use the master branch.
+
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
 
 DRGN-15226: Link disconnects with reason "LMP Response Timeout (0x22)"

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -23,6 +23,13 @@ Changelog
 
 The following sections provide detailed lists of changes by component.
 
+Bluetooth LE
+------------
+
+* Updated:
+
+   * The SoftDevice Controller can now be qualified on nRF52832.
+
 nRF5
 ====
 

--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ef9e33ee5c1d5d951d0415f0944fc52a15a55a95
+      revision: bedc08376043de27a59c7ea0af51c9cc177b0f18
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
SoftDevice Controller can now be qualified on nRF52832.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>