### PR TITLE
ci: run doc build on release branches

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -5,9 +5,11 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - master
+      - 'v*-branch'
   push:
     branches:
       - master
+      - 'v*-branch'
 
 jobs:
   build:


### PR DESCRIPTION
Release branches still need to build the documentation.