### PR TITLE
Bluetooth: Mesh: Replace all usage of "mod" with "model" 

### DIFF
--- a/include/bluetooth/mesh/gen_dtt_srv.h
+++ b/include/bluetooth/mesh/gen_dtt_srv.h
@@ -117,25 +117,25 @@ int bt_mesh_dtt_srv_pub(struct bt_mesh_dtt_srv *srv,
 static inline struct bt_mesh_dtt_srv *
 bt_mesh_dtt_srv_get(const struct bt_mesh_elem *elem)
 {
-	struct bt_mesh_model *mod = bt_mesh_model_find(
+	struct bt_mesh_model *model = bt_mesh_model_find(
 		elem, BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_SRV);
 
-	return (struct bt_mesh_dtt_srv *)(mod ? mod->user_data : NULL);
+	return (struct bt_mesh_dtt_srv *)(model ? model->user_data : NULL);
 }
 
 /** @brief Get the default transition parameters for the given model.
  *
- * @param[in] mod Model to get the DTT for.
+ * @param[in] model Model to get the DTT for.
  * @param[out] transition Transition buffer.
  *
  * @return Whether the transition was set.
  */
 static inline bool
-bt_mesh_dtt_srv_transition_get(struct bt_mesh_model *mod,
+bt_mesh_dtt_srv_transition_get(struct bt_mesh_model *model,
 			       struct bt_mesh_model_transition *transition)
 {
 	struct bt_mesh_dtt_srv *srv =
-		bt_mesh_dtt_srv_get(bt_mesh_model_elem(mod));
+		bt_mesh_dtt_srv_get(bt_mesh_model_elem(model));
 
 	transition->time = srv ? srv->transition_time : 0;
 	transition->delay = 0;

--- a/include/bluetooth/mesh/gen_prop_srv.h
+++ b/include/bluetooth/mesh/gen_prop_srv.h
@@ -151,7 +151,7 @@ enum bt_mesh_prop_srv_state {
  */
 struct bt_mesh_prop_srv {
 	/** Pointer to the mesh model entry. */
-	struct bt_mesh_model *mod;
+	struct bt_mesh_model *model;
 	/** Model publication parameters. */
 	struct bt_mesh_model_pub pub;
 	/* Publication buffer */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -65,11 +65,11 @@
 
 /** @brief Check whether the model publishes to a unicast address.
  *
- * @param[in] mod Model to check
+ * @param[in] model Model to check
  *
  * @return true if the model publishes to a unicast address, false otherwise.
  */
-bool bt_mesh_model_pub_is_unicast(const struct bt_mesh_model *mod);
+bool bt_mesh_model_pub_is_unicast(const struct bt_mesh_model *model);
 
 /** Shorthand macro for defining a model list directly in the element. */
 #define BT_MESH_MODEL_LIST(...) ((struct bt_mesh_model[]){ __VA_ARGS__ })

--- a/include/bluetooth/mesh/scene_cli.h
+++ b/include/bluetooth/mesh/scene_cli.h
@@ -84,7 +84,7 @@ struct bt_mesh_scene_cli {
 			       const struct bt_mesh_scene_register *reg);
 
 	/* Composition data entry pointer. */
-	struct bt_mesh_model *mod;
+	struct bt_mesh_model *model;
 	/* Model publication parameters. */
 	struct bt_mesh_model_pub pub;
 	/* Publication message */

--- a/include/bluetooth/mesh/scene_srv.h
+++ b/include/bluetooth/mesh/scene_srv.h
@@ -78,7 +78,7 @@ struct bt_mesh_scene_srv {
 	/** TID context. */
 	struct bt_mesh_tid_ctx tid;
 	/** Composition data model pointer. */
-	struct bt_mesh_model *mod;
+	struct bt_mesh_model *model;
 	/** Composition data setup model pointer. */
 	struct bt_mesh_model *setup_mod;
 	/** Publication state. */
@@ -102,13 +102,13 @@ struct bt_mesh_scene_entry_type {
 	 *  and return the number of bytes written. @c data is guaranteed to
 	 *  fit @c maxlen number of bytes.
 	 *
-	 *  @param mod Model to get the scene data of.
+	 *  @param model Model to get the scene data of.
 	 *  @param data Scene data buffer to fill. Fits @c maxlen bytes.
 	 *
 	 *  @return The number of bytes written to @c data or a negative value
 	 *          on failure.
 	 */
-	ssize_t (*store)(struct bt_mesh_model *mod, uint8_t data[]);
+	ssize_t (*store)(struct bt_mesh_model *model, uint8_t data[]);
 
 	/** @brief Recall a scene based on the given scene data.
 	 *
@@ -117,12 +117,12 @@ struct bt_mesh_scene_entry_type {
 	 *  shall start transitioning to the given scene with the given
 	 *  transition parameters.
 	 *
-	 *  @param mod        Model to restore the scene of.
+	 *  @param model        Model to restore the scene of.
 	 *  @param data       Scene data to restore.
 	 *  @param len        Scene data length.
 	 *  @param transition Transition parameters.
 	 */
-	void (*recall)(struct bt_mesh_model *mod, const uint8_t data[],
+	void (*recall)(struct bt_mesh_model *model, const uint8_t data[],
 		       size_t len, struct bt_mesh_model_transition *transition);
 };
 
@@ -139,7 +139,7 @@ struct bt_mesh_scene_entry {
 	/** Scene Server this entry got registered to. */
 	struct bt_mesh_scene_srv *srv;
 	/** Model this scene entry belongs to. */
-	struct bt_mesh_model *mod;
+	struct bt_mesh_model *model;
 	/** Scene entry callbacks */
 	const struct bt_mesh_scene_entry_type *type;
 	/** Scene entry list node */
@@ -162,12 +162,12 @@ struct bt_mesh_scene_entry {
  *        procedure to correctly recover a scene on startup. The initial Scene
  *        is recovered as part of the model start procedure.
  *
- *  @param[in] mod   Model this scene entry represents.
+ *  @param[in] model   Model this scene entry represents.
  *  @param[in] entry Scene entry.
  *  @param[in] type  Scene entry type.
  *  @param[in] vnd   Whether this is a vendor model.
  */
-void bt_mesh_scene_entry_add(struct bt_mesh_model *mod,
+void bt_mesh_scene_entry_add(struct bt_mesh_model *model,
 			     struct bt_mesh_scene_entry *entry,
 			     const struct bt_mesh_scene_entry_type *type,
 			     bool vnd);

--- a/include/bluetooth/mesh/scene_srv.h
+++ b/include/bluetooth/mesh/scene_srv.h
@@ -102,8 +102,8 @@ struct bt_mesh_scene_entry_type {
 	 *  and return the number of bytes written. @c data is guaranteed to
 	 *  fit @c maxlen number of bytes.
 	 *
-	 *  @param model Model to get the scene data of.
-	 *  @param data Scene data buffer to fill. Fits @c maxlen bytes.
+	 *  @param[in]  model Model to get the scene data of.
+	 *  @param[out] data  Scene data buffer to fill. Fits @c maxlen bytes.
 	 *
 	 *  @return The number of bytes written to @c data or a negative value
 	 *          on failure.
@@ -117,10 +117,10 @@ struct bt_mesh_scene_entry_type {
 	 *  shall start transitioning to the given scene with the given
 	 *  transition parameters.
 	 *
-	 *  @param model        Model to restore the scene of.
-	 *  @param data       Scene data to restore.
-	 *  @param len        Scene data length.
-	 *  @param transition Transition parameters.
+	 *  @param[in] model      Model to restore the scene of.
+	 *  @param[in] data       Scene data to restore.
+	 *  @param[in] len        Scene data length.
+	 *  @param[in] transition Transition parameters.
 	 */
 	void (*recall)(struct bt_mesh_model *model, const uint8_t data[],
 		       size_t len, struct bt_mesh_model_transition *transition);
@@ -162,7 +162,7 @@ struct bt_mesh_scene_entry {
  *        procedure to correctly recover a scene on startup. The initial Scene
  *        is recovered as part of the model start procedure.
  *
- *  @param[in] model   Model this scene entry represents.
+ *  @param[in] model Model this scene entry represents.
  *  @param[in] entry Scene entry.
  *  @param[in] type  Scene entry type.
  *  @param[in] vnd   Whether this is a vendor model.

--- a/include/bluetooth/mesh/scheduler_cli.h
+++ b/include/bluetooth/mesh/scheduler_cli.h
@@ -62,7 +62,7 @@ struct bt_mesh_scheduler_cli {
 			const struct bt_mesh_schedule_entry *action);
 
 	/* Composition data entry pointer. */
-	struct bt_mesh_model *mod;
+	struct bt_mesh_model *model;
 	/* Model publication parameters. */
 	struct bt_mesh_model_pub pub;
 	/* Publication message */

--- a/include/bluetooth/mesh/scheduler_srv.h
+++ b/include/bluetooth/mesh/scheduler_srv.h
@@ -83,7 +83,7 @@ struct bt_mesh_scheduler_srv {
 		sch_reg[BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT];
 	};
 	/** Composition data model pointer. */
-	struct bt_mesh_model *mod;
+	struct bt_mesh_model *model;
 	/** Composition data setup model pointer. */
 	struct bt_mesh_model *setup_mod;
 	/** Publication state. */

--- a/include/bluetooth/mesh/sensor_cli.h
+++ b/include/bluetooth/mesh/sensor_cli.h
@@ -54,7 +54,7 @@ struct bt_mesh_sensor_cli_handlers;
  */
 struct bt_mesh_sensor_cli {
 	/** Composition data model instance. */
-	struct bt_mesh_model *mod;
+	struct bt_mesh_model *model;
 	/** Model publication parameters. */
 	struct bt_mesh_model_pub pub;
 	/* Publication buffer */

--- a/subsys/bluetooth/mesh/gen_dtt_cli.c
+++ b/subsys/bluetooth/mesh/gen_dtt_cli.c
@@ -35,11 +35,11 @@ const struct bt_mesh_model_op _bt_mesh_dtt_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int bt_mesh_dtt_init(struct bt_mesh_model *mod)
+static int bt_mesh_dtt_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_dtt_cli *cli = mod->user_data;
+	struct bt_mesh_dtt_cli *cli = model->user_data;
 
-	cli->model = mod;
+	cli->model = model;
 	cli->pub.msg = &cli->pub_buf;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data,
 				      sizeof(cli->pub_data));
@@ -48,11 +48,11 @@ static int bt_mesh_dtt_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void bt_mesh_dtt_reset(struct bt_mesh_model *mod)
+static void bt_mesh_dtt_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_dtt_cli *cli = mod->user_data;
+	struct bt_mesh_dtt_cli *cli = model->user_data;
 
-	net_buf_simple_reset(mod->pub->msg);
+	net_buf_simple_reset(model->pub->msg);
 	model_ack_reset(&cli->ack_ctx);
 }
 

--- a/subsys/bluetooth/mesh/gen_loc_cli.c
+++ b/subsys/bluetooth/mesh/gen_loc_cli.c
@@ -8,7 +8,7 @@
 #include "model_utils.h"
 #include "gen_loc_internal.h"
 
-static void handle_global_loc(struct bt_mesh_model *mod,
+static void handle_global_loc(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -16,7 +16,7 @@ static void handle_global_loc(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_cli *cli = model->user_data;
 	struct bt_mesh_loc_global loc;
 
 	bt_mesh_loc_global_decode(buf, &loc);
@@ -34,7 +34,7 @@ static void handle_global_loc(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_local_loc(struct bt_mesh_model *mod,
+static void handle_local_loc(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -42,7 +42,7 @@ static void handle_local_loc(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_cli *cli = model->user_data;
 	struct bt_mesh_loc_local loc;
 
 	bt_mesh_loc_local_decode(buf, &loc);
@@ -68,11 +68,11 @@ const struct bt_mesh_model_op _bt_mesh_loc_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int bt_mesh_loc_init(struct bt_mesh_model *mod)
+static int bt_mesh_loc_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_cli *cli = model->user_data;
 
-	cli->model = mod;
+	cli->model = model;
 	cli->pub.msg = &cli->pub_buf;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data,
 				      sizeof(cli->pub_data));
@@ -81,11 +81,11 @@ static int bt_mesh_loc_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void bt_mesh_loc_reset(struct bt_mesh_model *mod)
+static void bt_mesh_loc_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_cli *cli = model->user_data;
 
-	net_buf_simple_reset(mod->pub->msg);
+	net_buf_simple_reset(model->pub->msg);
 	model_ack_reset(&cli->ack_ctx);
 }
 

--- a/subsys/bluetooth/mesh/gen_lvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_lvl_cli.c
@@ -7,7 +7,7 @@
 #include <bluetooth/mesh/gen_lvl_cli.h>
 #include "model_utils.h"
 
-static void handle_status(struct bt_mesh_model *mod,
+static void handle_status(struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -16,7 +16,7 @@ static void handle_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_lvl_cli *cli = mod->user_data;
+	struct bt_mesh_lvl_cli *cli = model->user_data;
 	struct bt_mesh_lvl_status status;
 
 	status.current = net_buf_simple_pull_le16(buf);
@@ -47,11 +47,11 @@ const struct bt_mesh_model_op _bt_mesh_lvl_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int bt_mesh_lvl_init(struct bt_mesh_model *mod)
+static int bt_mesh_lvl_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_lvl_cli *cli = mod->user_data;
+	struct bt_mesh_lvl_cli *cli = model->user_data;
 
-	cli->model = mod;
+	cli->model = model;
 	cli->pub.msg = &cli->pub_buf;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data,
 				      sizeof(cli->pub_data));
@@ -61,11 +61,11 @@ static int bt_mesh_lvl_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void bt_mesh_lvl_reset(struct bt_mesh_model *mod)
+static void bt_mesh_lvl_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_lvl_cli *cli = mod->user_data;
+	struct bt_mesh_lvl_cli *cli = model->user_data;
 
-	net_buf_simple_reset(mod->pub->msg);
+	net_buf_simple_reset(model->pub->msg);
 	model_ack_reset(&cli->ack_ctx);
 }
 

--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -225,9 +225,9 @@ const struct bt_mesh_model_op _bt_mesh_lvl_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int scene_store(struct bt_mesh_model *mod, uint8_t data[])
+static int scene_store(struct bt_mesh_model *model, uint8_t data[])
 {
-	struct bt_mesh_lvl_srv *srv = mod->user_data;
+	struct bt_mesh_lvl_srv *srv = model->user_data;
 	struct bt_mesh_lvl_status status = { 0 };
 
 	srv->handlers->get(srv, NULL, &status);
@@ -237,11 +237,11 @@ static int scene_store(struct bt_mesh_model *mod, uint8_t data[])
 	return 2;
 }
 
-static void scene_recall(struct bt_mesh_model *mod, const uint8_t data[],
+static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 			 size_t len,
 			 struct bt_mesh_model_transition *transition)
 {
-	struct bt_mesh_lvl_srv *srv = mod->user_data;
+	struct bt_mesh_lvl_srv *srv = model->user_data;
 	struct bt_mesh_lvl_set set = {
 		.lvl = sys_get_le16(data),
 		.new_transaction = true,

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -123,9 +123,9 @@ const struct bt_mesh_model_op _bt_mesh_onoff_srv_op[] = {
 };
 
 /* .. include_startingpoint_scene_srv_rst_1 */
-static ssize_t scene_store(struct bt_mesh_model *mod, uint8_t data[])
+static ssize_t scene_store(struct bt_mesh_model *model, uint8_t data[])
 {
-	struct bt_mesh_onoff_srv *srv = mod->user_data;
+	struct bt_mesh_onoff_srv *srv = model->user_data;
 	struct bt_mesh_onoff_status status = { 0 };
 
 	/* Only store the next stable on_off state: */
@@ -136,10 +136,10 @@ static ssize_t scene_store(struct bt_mesh_model *mod, uint8_t data[])
 	return 1;
 }
 
-static void scene_recall(struct bt_mesh_model *mod, const uint8_t data[],
+static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 		       size_t len, struct bt_mesh_model_transition *transition)
 {
-	struct bt_mesh_onoff_srv *srv = mod->user_data;
+	struct bt_mesh_onoff_srv *srv = model->user_data;
 	struct bt_mesh_onoff_status dummy;
 	struct bt_mesh_onoff_set set = {
 		.on_off = data[0],

--- a/subsys/bluetooth/mesh/gen_plvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_plvl_cli.c
@@ -6,7 +6,7 @@
 #include <bluetooth/mesh/gen_plvl_cli.h>
 #include "model_utils.h"
 
-static void handle_power_status(struct bt_mesh_model *mod,
+static void handle_power_status(struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -15,7 +15,7 @@ static void handle_power_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_cli *cli = model->user_data;
 	struct bt_mesh_plvl_status status;
 
 	status.current = net_buf_simple_pull_le16(buf);
@@ -39,7 +39,7 @@ static void handle_power_status(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_last_status(struct bt_mesh_model *mod,
+static void handle_last_status(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -47,7 +47,7 @@ static void handle_last_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_cli *cli = model->user_data;
 	uint16_t last = net_buf_simple_pull_le16(buf);
 
 	if (model_ack_match(&cli->ack_ctx, BT_MESH_PLVL_OP_LAST_STATUS, ctx)) {
@@ -61,7 +61,7 @@ static void handle_last_status(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_default_status(struct bt_mesh_model *mod,
+static void handle_default_status(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
@@ -69,7 +69,7 @@ static void handle_default_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_cli *cli = model->user_data;
 	uint16_t default_lvl = net_buf_simple_pull_le16(buf);
 
 	if (model_ack_match(&cli->ack_ctx, BT_MESH_PLVL_OP_DEFAULT_STATUS, ctx)) {
@@ -83,7 +83,7 @@ static void handle_default_status(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_range_status(struct bt_mesh_model *mod,
+static void handle_range_status(struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -91,7 +91,7 @@ static void handle_range_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_cli *cli = model->user_data;
 	struct bt_mesh_plvl_range_status status;
 
 	status.status = net_buf_simple_pull_u8(buf);
@@ -121,11 +121,11 @@ const struct bt_mesh_model_op _bt_mesh_plvl_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int bt_mesh_lvl_cli_init(struct bt_mesh_model *mod)
+static int bt_mesh_lvl_cli_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_cli *cli = model->user_data;
 
-	cli->model = mod;
+	cli->model = model;
 	cli->pub.msg = &cli->pub_buf;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data,
 				      sizeof(cli->pub_data));
@@ -134,11 +134,11 @@ static int bt_mesh_lvl_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void bt_mesh_lvl_cli_reset(struct bt_mesh_model *mod)
+static void bt_mesh_lvl_cli_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_cli *cli = model->user_data;
 
-	net_buf_simple_reset(mod->pub->msg);
+	net_buf_simple_reset(model->pub->msg);
 	model_ack_reset(&cli->ack_ctx);
 }
 

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -95,7 +95,7 @@ static void transition_get(struct bt_mesh_plvl_srv *srv,
 	}
 }
 
-static void rsp_plvl_status(struct bt_mesh_model *mod,
+static void rsp_plvl_status(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct bt_mesh_plvl_status *status)
 {
@@ -103,10 +103,10 @@ static void rsp_plvl_status(struct bt_mesh_model *mod,
 				 BT_MESH_PLVL_MSG_MAXLEN_LEVEL_STATUS);
 	lvl_status_encode(&rsp, status);
 
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_lvl_get(struct bt_mesh_model *mod,
+static void handle_lvl_get(struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -114,12 +114,12 @@ static void handle_lvl_get(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 	struct bt_mesh_plvl_status status = { 0 };
 
 	srv->handlers->power_get(srv, ctx, &status);
 
-	rsp_plvl_status(mod, ctx, &status);
+	rsp_plvl_status(model, ctx, &status);
 }
 
 static void change_lvl(struct bt_mesh_plvl_srv *srv,
@@ -158,7 +158,7 @@ static void change_lvl(struct bt_mesh_plvl_srv *srv,
 	pub(srv, NULL, status);
 }
 
-static void plvl_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void plvl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf, bool ack)
 {
 	if (buf->len != BT_MESH_PLVL_MSG_MINLEN_LEVEL_SET &&
@@ -166,7 +166,7 @@ static void plvl_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		return;
 	}
 
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 	struct bt_mesh_model_transition transition;
 	struct bt_mesh_plvl_status status;
 	struct bt_mesh_plvl_set set;
@@ -184,25 +184,25 @@ static void plvl_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	}
 
 	if (ack) {
-		rsp_plvl_status(mod, ctx, &status);
+		rsp_plvl_status(model, ctx, &status);
 	}
 }
 
-static void handle_plvl_set(struct bt_mesh_model *mod,
+static void handle_plvl_set(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	plvl_set(mod, ctx, buf, true);
+	plvl_set(model, ctx, buf, true);
 }
 
-static void handle_plvl_set_unack(struct bt_mesh_model *mod,
+static void handle_plvl_set_unack(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
-	plvl_set(mod, ctx, buf, false);
+	plvl_set(model, ctx, buf, false);
 }
 
-static void handle_last_get(struct bt_mesh_model *mod,
+static void handle_last_get(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -210,17 +210,17 @@ static void handle_last_get(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 
 	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PLVL_OP_LAST_STATUS,
 				 BT_MESH_PLVL_MSG_LEN_LAST_STATUS);
 	bt_mesh_model_msg_init(&rsp, BT_MESH_PLVL_OP_LAST_STATUS);
 
 	net_buf_simple_add_le16(&rsp, srv->last);
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_default_get(struct bt_mesh_model *mod,
+static void handle_default_get(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -228,24 +228,24 @@ static void handle_default_get(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 
 	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS,
 				 BT_MESH_PLVL_MSG_LEN_DEFAULT_STATUS);
 	bt_mesh_model_msg_init(&rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS);
 
 	net_buf_simple_add_le16(&rsp, srv->default_power);
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void set_default(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void set_default(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf, bool ack)
 {
 	if (buf->len != BT_MESH_PLVL_MSG_LEN_DEFAULT_SET) {
 		return;
 	}
 
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 	uint16_t new = net_buf_simple_pull_le16(buf);
 
 	if (new != srv->default_power) {
@@ -268,24 +268,24 @@ static void set_default(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	bt_mesh_model_msg_init(&rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS);
 	net_buf_simple_add_le16(&rsp, srv->default_power);
 
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_default_set(struct bt_mesh_model *mod,
+static void handle_default_set(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
-	set_default(mod, ctx, buf, true);
+	set_default(model, ctx, buf, true);
 }
 
-static void handle_default_set_unack(struct bt_mesh_model *mod,
+static void handle_default_set_unack(struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
-	set_default(mod, ctx, buf, false);
+	set_default(model, ctx, buf, false);
 }
 
-static void handle_range_get(struct bt_mesh_model *mod,
+static void handle_range_get(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -293,7 +293,7 @@ static void handle_range_get(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 
 	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PLVL_OP_RANGE_STATUS,
 				 BT_MESH_PLVL_MSG_LEN_RANGE_STATUS);
@@ -303,17 +303,17 @@ static void handle_range_get(struct bt_mesh_model *mod,
 	net_buf_simple_add_le16(&rsp, srv->range.min);
 	net_buf_simple_add_le16(&rsp, srv->range.max);
 
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void set_range(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void set_range(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf, bool ack)
 {
 	if (buf->len != BT_MESH_PLVL_MSG_LEN_RANGE_SET) {
 		return;
 	}
 
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 	struct bt_mesh_plvl_range new;
 
 	new.min = net_buf_simple_pull_le16(buf);
@@ -350,21 +350,21 @@ static void set_range(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	net_buf_simple_add_le16(&rsp, srv->range.min);
 	net_buf_simple_add_le16(&rsp, srv->range.max);
 
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_range_set(struct bt_mesh_model *mod,
+static void handle_range_set(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
-	set_range(mod, ctx, buf, true);
+	set_range(model, ctx, buf, true);
 }
 
-static void handle_range_set_unack(struct bt_mesh_model *mod,
+static void handle_range_set_unack(struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
-	set_range(mod, ctx, buf, false);
+	set_range(model, ctx, buf, false);
 }
 
 const struct bt_mesh_model_op _bt_mesh_plvl_srv_op[] = {
@@ -588,12 +588,12 @@ static void plvl_srv_reset(struct bt_mesh_plvl_srv *srv)
 	srv->is_on = false;
 }
 
-static void bt_mesh_plvl_srv_reset(struct bt_mesh_model *mod)
+static void bt_mesh_plvl_srv_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 
 	plvl_srv_reset(srv);
-	net_buf_simple_reset(mod->pub->msg);
+	net_buf_simple_reset(model->pub->msg);
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		(void)bt_mesh_model_data_store(srv->plvl_model, false, NULL,
 					       NULL, 0);
@@ -610,11 +610,11 @@ static int update_handler(struct bt_mesh_model *model)
 	return 0;
 }
 
-static int bt_mesh_plvl_srv_init(struct bt_mesh_model *mod)
+static int bt_mesh_plvl_srv_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 
-	srv->plvl_model = mod;
+	srv->plvl_model = model;
 	plvl_srv_reset(srv);
 	srv->pub.msg = &srv->pub_buf;
 	srv->pub.update = update_handler;
@@ -631,12 +631,12 @@ static int bt_mesh_plvl_srv_init(struct bt_mesh_model *mod)
 		 * makes it a lot easier to extend this model, as we won't have
 		 * to support multiple extenders.
 		 */
-		bt_mesh_model_extend(mod, srv->ponoff.ponoff_model);
-		bt_mesh_model_extend(mod, srv->lvl.model);
+		bt_mesh_model_extend(model, srv->ponoff.ponoff_model);
+		bt_mesh_model_extend(model, srv->lvl.model);
 		bt_mesh_model_extend(
-			mod,
+			model,
 			bt_mesh_model_find(
-				bt_mesh_model_elem(mod),
+				bt_mesh_model_elem(model),
 				BT_MESH_MODEL_ID_GEN_POWER_LEVEL_SETUP_SRV));
 	}
 
@@ -644,11 +644,11 @@ static int bt_mesh_plvl_srv_init(struct bt_mesh_model *mod)
 }
 
 #ifdef CONFIG_BT_SETTINGS
-static int bt_mesh_plvl_srv_settings_set(struct bt_mesh_model *mod,
+static int bt_mesh_plvl_srv_settings_set(struct bt_mesh_model *model,
 					 const char *name, size_t len_rd,
 					 settings_read_cb read_cb, void *cb_arg)
 {
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 	struct bt_mesh_plvl_srv_settings_data data;
 
 	if (name) {
@@ -667,9 +667,9 @@ static int bt_mesh_plvl_srv_settings_set(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int bt_mesh_plvl_srv_start(struct bt_mesh_model *mod)
+static int bt_mesh_plvl_srv_start(struct bt_mesh_model *model)
 {
-	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv *srv = model->user_data;
 	struct bt_mesh_plvl_status dummy = { 0 };
 	struct bt_mesh_model_transition transition = {
 		.time = srv->ponoff.dtt.transition_time,

--- a/subsys/bluetooth/mesh/gen_ponoff_cli.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_cli.c
@@ -41,11 +41,11 @@ const struct bt_mesh_model_op _bt_mesh_ponoff_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int bt_mesh_ponoff_cli_init(struct bt_mesh_model *mod)
+static int bt_mesh_ponoff_cli_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_ponoff_cli *cli = mod->user_data;
+	struct bt_mesh_ponoff_cli *cli = model->user_data;
 
-	cli->model = mod;
+	cli->model = model;
 	cli->pub.msg = &cli->pub_buf;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data,
 				      sizeof(cli->pub_data));
@@ -54,11 +54,11 @@ static int bt_mesh_ponoff_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void bt_mesh_ponoff_cli_reset(struct bt_mesh_model *mod)
+static void bt_mesh_ponoff_cli_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_ponoff_cli *cli = mod->user_data;
+	struct bt_mesh_ponoff_cli *cli = model->user_data;
 
-	net_buf_simple_reset(mod->pub->msg);
+	net_buf_simple_reset(model->pub->msg);
 	model_ack_reset(&cli->ack_ctx);
 }
 

--- a/subsys/bluetooth/mesh/gen_prop_cli.c
+++ b/subsys/bluetooth/mesh/gen_prop_cli.c
@@ -24,7 +24,7 @@ struct prop_list_ctx {
 	int status;
 };
 
-static void properties_status(struct bt_mesh_model *mod,
+static void properties_status(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf,
 			      enum bt_mesh_prop_srv_kind kind)
@@ -33,7 +33,7 @@ static void properties_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_prop_cli *cli = mod->user_data;
+	struct bt_mesh_prop_cli *cli = model->user_data;
 	struct bt_mesh_prop_list list;
 
 	list.count = buf->len / 2;
@@ -59,35 +59,35 @@ static void properties_status(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_mfr_properties_status(struct bt_mesh_model *mod,
+static void handle_mfr_properties_status(struct bt_mesh_model *model,
 					 struct bt_mesh_msg_ctx *ctx,
 					 struct net_buf_simple *buf)
 {
-	properties_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_MFR);
+	properties_status(model, ctx, buf, BT_MESH_PROP_SRV_KIND_MFR);
 }
 
-static void handle_admin_properties_status(struct bt_mesh_model *mod,
+static void handle_admin_properties_status(struct bt_mesh_model *model,
 					   struct bt_mesh_msg_ctx *ctx,
 					   struct net_buf_simple *buf)
 {
-	properties_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_ADMIN);
+	properties_status(model, ctx, buf, BT_MESH_PROP_SRV_KIND_ADMIN);
 }
 
-static void handle_user_properties_status(struct bt_mesh_model *mod,
+static void handle_user_properties_status(struct bt_mesh_model *model,
 					  struct bt_mesh_msg_ctx *ctx,
 					  struct net_buf_simple *buf)
 {
-	properties_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_USER);
+	properties_status(model, ctx, buf, BT_MESH_PROP_SRV_KIND_USER);
 }
 
-static void handle_client_properties_status(struct bt_mesh_model *mod,
+static void handle_client_properties_status(struct bt_mesh_model *model,
 					    struct bt_mesh_msg_ctx *ctx,
 					    struct net_buf_simple *buf)
 {
-	properties_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_CLIENT);
+	properties_status(model, ctx, buf, BT_MESH_PROP_SRV_KIND_CLIENT);
 }
 
-static void property_status(struct bt_mesh_model *mod,
+static void property_status(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf,
 			    enum bt_mesh_prop_srv_kind kind)
@@ -97,7 +97,7 @@ static void property_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_prop_cli *cli = mod->user_data;
+	struct bt_mesh_prop_cli *cli = model->user_data;
 	struct bt_mesh_prop_val val;
 
 	val.meta.id = net_buf_simple_pull_le16(buf);
@@ -120,25 +120,25 @@ static void property_status(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_mfr_property_status(struct bt_mesh_model *mod,
+static void handle_mfr_property_status(struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
-	property_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_MFR);
+	property_status(model, ctx, buf, BT_MESH_PROP_SRV_KIND_MFR);
 }
 
-static void handle_admin_property_status(struct bt_mesh_model *mod,
+static void handle_admin_property_status(struct bt_mesh_model *model,
 					 struct bt_mesh_msg_ctx *ctx,
 					 struct net_buf_simple *buf)
 {
-	property_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_ADMIN);
+	property_status(model, ctx, buf, BT_MESH_PROP_SRV_KIND_ADMIN);
 }
 
-static void handle_user_property_status(struct bt_mesh_model *mod,
+static void handle_user_property_status(struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
-	property_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_USER);
+	property_status(model, ctx, buf, BT_MESH_PROP_SRV_KIND_USER);
 }
 
 const struct bt_mesh_model_op _bt_mesh_prop_cli_op[] = {
@@ -160,11 +160,11 @@ const struct bt_mesh_model_op _bt_mesh_prop_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int bt_mesh_prop_cli_init(struct bt_mesh_model *mod)
+static int bt_mesh_prop_cli_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_prop_cli *cli = mod->user_data;
+	struct bt_mesh_prop_cli *cli = model->user_data;
 
-	cli->model = mod;
+	cli->model = model;
 	cli->pub.msg = &cli->pub_buf;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data,
 				      sizeof(cli->pub_data));
@@ -173,11 +173,11 @@ static int bt_mesh_prop_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void bt_mesh_prop_cli_reset(struct bt_mesh_model *mod)
+static void bt_mesh_prop_cli_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_prop_cli *cli = mod->user_data;
+	struct bt_mesh_prop_cli *cli = model->user_data;
 
-	net_buf_simple_reset(mod->pub->msg);
+	net_buf_simple_reset(model->pub->msg);
 	model_ack_reset(&cli->ack_ctx);
 }
 

--- a/subsys/bluetooth/mesh/gen_prop_internal.h
+++ b/subsys/bluetooth/mesh/gen_prop_internal.h
@@ -28,9 +28,9 @@ enum bt_mesh_prop_op_type {
 };
 
 static inline enum bt_mesh_prop_srv_kind
-srv_kind(const struct bt_mesh_model *mod)
+srv_kind(const struct bt_mesh_model *model)
 {
-	switch (mod->id) {
+	switch (model->id) {
 	case BT_MESH_MODEL_ID_GEN_ADMIN_PROP_SRV:
 		return BT_MESH_PROP_SRV_KIND_ADMIN;
 	case BT_MESH_MODEL_ID_GEN_MANUFACTURER_PROP_SRV:

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -377,9 +377,9 @@ static void bt_mesh_light_ctl_srv_reset(struct bt_mesh_model *model)
 	}
 }
 
-static int bt_mesh_light_ctl_srv_start(struct bt_mesh_model *mod)
+static int bt_mesh_light_ctl_srv_start(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_ctl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctl_srv *srv = model->user_data;
 	struct bt_mesh_model_transition transition;
 	struct bt_mesh_light_temp_set temp = {
 		.params = srv->temp_srv.dflt,
@@ -397,7 +397,7 @@ static int bt_mesh_light_ctl_srv_start(struct bt_mesh_model *mod)
 		return -EINVAL;
 	}
 
-	bt_mesh_dtt_srv_transition_get(mod, &transition);
+	bt_mesh_dtt_srv_transition_get(model, &transition);
 
 	switch (srv->lightness_srv.ponoff.on_power_up) {
 	case BT_MESH_ON_POWER_UP_OFF:

--- a/subsys/bluetooth/mesh/light_ctrl_cli.c
+++ b/subsys/bluetooth/mesh/light_ctrl_cli.c
@@ -17,10 +17,10 @@ struct prop_status_ctx {
 	union prop_value val;
 };
 
-static void handle_mode(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void handle_mode(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_cli *cli = mod->user_data;
+	struct bt_mesh_light_ctrl_cli *cli = model->user_data;
 
 	if (buf->len != 1) {
 		return;
@@ -45,11 +45,11 @@ static void handle_mode(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	}
 }
 
-static void handle_occupancy(struct bt_mesh_model *mod,
+static void handle_occupancy(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_cli *cli = mod->user_data;
+	struct bt_mesh_light_ctrl_cli *cli = model->user_data;
 
 	if (buf->len != 1) {
 		return;
@@ -73,11 +73,11 @@ static void handle_occupancy(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_light_onoff(struct bt_mesh_model *mod,
+static void handle_light_onoff(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_cli *cli = mod->user_data;
+	struct bt_mesh_light_ctrl_cli *cli = model->user_data;
 	struct bt_mesh_onoff_status status;
 
 	uint8_t onoff = net_buf_simple_pull_u8(buf);
@@ -117,10 +117,10 @@ static void handle_light_onoff(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_prop(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void handle_prop(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_cli *cli = mod->user_data;
+	struct bt_mesh_light_ctrl_cli *cli = model->user_data;
 	struct prop_status_ctx *rsp = cli->ack.user_data;
 	const struct bt_mesh_sensor_format *format;
 	union prop_value value;
@@ -176,11 +176,11 @@ const struct bt_mesh_model_op _bt_mesh_light_ctrl_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int light_ctrl_cli_init(struct bt_mesh_model *mod)
+static int light_ctrl_cli_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_ctrl_cli *cli = mod->user_data;
+	struct bt_mesh_light_ctrl_cli *cli = model->user_data;
 
-	cli->model = mod;
+	cli->model = model;
 	cli->pub.msg = &cli->pub_buf;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data,
 				      sizeof(cli->pub_data));
@@ -189,9 +189,9 @@ static int light_ctrl_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void light_ctrl_cli_reset(struct bt_mesh_model *mod)
+static void light_ctrl_cli_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_ctrl_cli *cli = mod->user_data;
+	struct bt_mesh_light_ctrl_cli *cli = model->user_data;
 
 	net_buf_simple_reset(cli->pub.msg);
 	model_ack_reset(&cli->ack);

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -706,11 +706,11 @@ static void mode_rsp(struct bt_mesh_light_ctrl_srv *srv,
 	model_send(srv->model, ctx, &rsp);
 }
 
-static void handle_mode_get(struct bt_mesh_model *mod,
+static void handle_mode_get(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
 	if (buf->len != 0) {
 		return;
@@ -743,11 +743,11 @@ static int mode_set(struct bt_mesh_light_ctrl_srv *srv,
 	return 0;
 }
 
-static void handle_mode_set(struct bt_mesh_model *mod,
+static void handle_mode_set(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	int err;
 
 	err = mode_set(srv, buf);
@@ -759,11 +759,11 @@ static void handle_mode_set(struct bt_mesh_model *mod,
 	mode_rsp(srv, NULL); /* publish */
 }
 
-static void handle_mode_set_unack(struct bt_mesh_model *mod,
+static void handle_mode_set_unack(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	int err;
 
 	err = mode_set(srv, buf);
@@ -785,11 +785,11 @@ static void om_rsp(struct bt_mesh_light_ctrl_srv *srv,
 	model_send(srv->model, ctx, &rsp);
 }
 
-static void handle_om_get(struct bt_mesh_model *mod,
+static void handle_om_get(struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
 	if (buf->len != 0) {
 		return;
@@ -823,11 +823,11 @@ static int om_set(struct bt_mesh_light_ctrl_srv *srv,
 	return 0;
 }
 
-static void handle_om_set(struct bt_mesh_model *mod,
+static void handle_om_set(struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	int err;
 
 	err = om_set(srv, buf);
@@ -839,11 +839,11 @@ static void handle_om_set(struct bt_mesh_model *mod,
 	om_rsp(srv, NULL); /* publish */
 }
 
-static void handle_om_set_unack(struct bt_mesh_model *mod,
+static void handle_om_set_unack(struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	int err;
 
 	err = om_set(srv, buf);
@@ -854,11 +854,11 @@ static void handle_om_set_unack(struct bt_mesh_model *mod,
 	om_rsp(srv, NULL); /* publish */
 }
 
-static void handle_light_onoff_get(struct bt_mesh_model *mod,
+static void handle_light_onoff_get(struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
 	if (buf->len != 0) {
 		return;
@@ -915,29 +915,29 @@ static void light_onoff_set(struct bt_mesh_light_ctrl_srv *srv,
 	}
 }
 
-static void handle_light_onoff_set(struct bt_mesh_model *mod,
+static void handle_light_onoff_set(struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
 	light_onoff_set(srv, ctx, buf, true);
 }
 
-static void handle_light_onoff_set_unack(struct bt_mesh_model *mod,
+static void handle_light_onoff_set_unack(struct bt_mesh_model *model,
 					 struct bt_mesh_msg_ctx *ctx,
 					 struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
 	light_onoff_set(srv, ctx, buf, false);
 }
 
-static void handle_sensor_status(struct bt_mesh_model *mod,
+static void handle_sensor_status(struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	int err;
 
 	while (buf->len >= 3) {
@@ -1236,11 +1236,11 @@ static void prop_tx(struct bt_mesh_light_ctrl_srv *srv,
 	model_send(srv->setup_srv, ctx, &buf);
 }
 
-static void handle_prop_get(struct bt_mesh_model *mod,
+static void handle_prop_get(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
 	if (buf->len != 2) {
 		return;
@@ -1251,11 +1251,11 @@ static void handle_prop_get(struct bt_mesh_model *mod,
 	prop_tx(srv, ctx, id);
 }
 
-static void handle_prop_set(struct bt_mesh_model *mod,
+static void handle_prop_set(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	int err;
 
 	uint16_t id = net_buf_simple_pull_le16(buf);
@@ -1274,11 +1274,11 @@ static void handle_prop_set(struct bt_mesh_model *mod,
 	store(srv, FLAG_STORE_CFG);
 }
 
-static void handle_prop_set_unack(struct bt_mesh_model *mod,
+static void handle_prop_set_unack(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	int err;
 
 	uint16_t id = net_buf_simple_pull_le16(buf);
@@ -1354,9 +1354,9 @@ struct __packed scene_data {
 #endif
 };
 
-static int scene_store(struct bt_mesh_model *mod, uint8_t data[])
+static int scene_store(struct bt_mesh_model *model, uint8_t data[])
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	struct scene_data *scene = (struct scene_data *)&data[0];
 
 	scene->enabled = is_enabled(srv);
@@ -1369,11 +1369,11 @@ static int scene_store(struct bt_mesh_model *mod, uint8_t data[])
 	return sizeof(struct scene_data);
 }
 
-static void scene_recall(struct bt_mesh_model *mod, const uint8_t data[],
+static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 			 size_t len,
 			 struct bt_mesh_model_transition *transition)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	struct scene_data *scene = (struct scene_data *)&data[0];
 
 	atomic_set_bit_to(&srv->flags, FLAG_OCC_MODE, scene->occ);
@@ -1394,11 +1394,11 @@ static const struct bt_mesh_scene_entry_type scene_type = {
 	.recall = scene_recall,
 };
 
-static int update_handler(struct bt_mesh_model *mod)
+static int update_handler(struct bt_mesh_model *model)
 {
 	BT_DBG("");
 
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
 	light_onoff_encode(srv, srv->pub.msg, srv->state);
 
@@ -1406,11 +1406,11 @@ static int update_handler(struct bt_mesh_model *mod)
 }
 
 
-static int light_ctrl_srv_init(struct bt_mesh_model *mod)
+static int light_ctrl_srv_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
-	srv->model = mod;
+	srv->model = model;
 
 	if (IS_ENABLED(CONFIG_BT_MESH_LIGHT_CTRL_SRV_OCCUPANCY_MODE)) {
 		atomic_set_bit(&srv->flags, FLAG_OCC_MODE);
@@ -1442,23 +1442,23 @@ static int light_ctrl_srv_init(struct bt_mesh_model *mod)
 				      sizeof(srv->pub_data));
 
 	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
-		bt_mesh_model_extend(mod, srv->onoff.model);
+		bt_mesh_model_extend(model, srv->onoff.model);
 	}
 
 	atomic_set_bit(&srv->onoff.flags, GEN_ONOFF_SRV_NO_DTT);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(mod, &srv->scene, &scene_type, false);
+		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
 	}
 
 	return 0;
 }
 
-static int light_ctrl_srv_settings_set(struct bt_mesh_model *mod,
+static int light_ctrl_srv_settings_set(struct bt_mesh_model *model,
 				       const char *name, size_t len_rd,
 				       settings_read_cb read_cb, void *cb_arg)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	atomic_t data;
 	ssize_t result;
 
@@ -1490,13 +1490,13 @@ static int light_ctrl_srv_settings_set(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int light_ctrl_srv_start(struct bt_mesh_model *mod)
+static int light_ctrl_srv_start(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
 	atomic_set_bit(&srv->flags, FLAG_STARTED);
 
-	if (srv->lightness->lightness_model->elem_idx == mod->elem_idx) {
+	if (srv->lightness->lightness_model->elem_idx == model->elem_idx) {
 		BT_ERR("Lightness: Invalid element index");
 		return -EINVAL;
 	}
@@ -1558,9 +1558,9 @@ static int light_ctrl_srv_start(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void light_ctrl_srv_reset(struct bt_mesh_model *mod)
+static void light_ctrl_srv_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	struct bt_mesh_light_ctrl_srv_cfg cfg = BT_MESH_LIGHT_CTRL_SRV_CFG_INIT;
 
 	srv->cfg = cfg;
@@ -1580,11 +1580,11 @@ const struct bt_mesh_model_cb _bt_mesh_light_ctrl_srv_cb = {
 	.settings_set = light_ctrl_srv_settings_set,
 };
 
-static int lc_setup_srv_init(struct bt_mesh_model *mod)
+static int lc_setup_srv_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 
-	srv->setup_srv = mod;
+	srv->setup_srv = model;
 
 	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
 		/* Model extensions:
@@ -1607,11 +1607,11 @@ static int lc_setup_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static int lc_setup_srv_settings_set(struct bt_mesh_model *mod,
+static int lc_setup_srv_settings_set(struct bt_mesh_model *model,
 				     const char *name, size_t len_rd,
 				     settings_read_cb read_cb, void *cb_arg)
 {
-	struct bt_mesh_light_ctrl_srv *srv = mod->user_data;
+	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	struct setup_srv_storage_data data;
 	ssize_t result;
 

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -419,9 +419,9 @@ const struct bt_mesh_model_op _bt_mesh_light_hsl_setup_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int hsl_srv_pub_update(struct bt_mesh_model *mod)
+static int hsl_srv_pub_update(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_hsl_srv *srv = mod->user_data;
+	struct bt_mesh_light_hsl_srv *srv = model->user_data;
 	struct bt_mesh_light_hsl_status status;
 
 	hsl_get(srv, NULL, &status);
@@ -463,9 +463,9 @@ static int bt_mesh_light_hsl_srv_init(struct bt_mesh_model *model)
 	return 0;
 }
 
-static int bt_mesh_light_hsl_srv_start(struct bt_mesh_model *mod)
+static int bt_mesh_light_hsl_srv_start(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_hsl_srv *srv = mod->user_data;
+	struct bt_mesh_light_hsl_srv *srv = model->user_data;
 	struct bt_mesh_model_transition transition;
 	struct bt_mesh_light_hue hue = { .transition = &transition };
 	struct bt_mesh_light_sat sat = { .transition = &transition };
@@ -484,7 +484,7 @@ static int bt_mesh_light_hsl_srv_start(struct bt_mesh_model *mod)
 		return -EINVAL;
 	}
 
-	bt_mesh_dtt_srv_transition_get(mod, &transition);
+	bt_mesh_dtt_srv_transition_get(model, &transition);
 
 	switch (srv->lightness.ponoff.on_power_up) {
 	case BT_MESH_ON_POWER_UP_ON:

--- a/subsys/bluetooth/mesh/light_hue_srv.c
+++ b/subsys/bluetooth/mesh/light_hue_srv.c
@@ -275,9 +275,9 @@ const struct bt_mesh_lvl_srv_handlers _bt_mesh_light_hue_srv_lvl_handlers = {
 	.move_set = lvl_move_set,
 };
 
-static int hue_srv_pub_update(struct bt_mesh_model *mod)
+static int hue_srv_pub_update(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_hue_srv *srv = mod->user_data;
+	struct bt_mesh_light_hue_srv *srv = model->user_data;
 	struct bt_mesh_light_hue_status status;
 
 	srv->handlers->get(srv, NULL, &status);
@@ -304,11 +304,11 @@ static int hue_srv_init(struct bt_mesh_model *model)
 	return 0;
 }
 
-static int hue_srv_settings_set(struct bt_mesh_model *mod, const char *name,
+static int hue_srv_settings_set(struct bt_mesh_model *model, const char *name,
 				size_t len_rd, settings_read_cb read_cb,
 				void *cb_data)
 {
-	struct bt_mesh_light_hue_srv *srv = mod->user_data;
+	struct bt_mesh_light_hue_srv *srv = model->user_data;
 	struct settings_data data;
 	ssize_t len;
 

--- a/subsys/bluetooth/mesh/light_sat_srv.c
+++ b/subsys/bluetooth/mesh/light_sat_srv.c
@@ -318,9 +318,9 @@ const struct bt_mesh_lvl_srv_handlers _bt_mesh_light_sat_srv_lvl_handlers = {
 	.move_set = lvl_move_set,
 };
 
-static int sat_srv_pub_update(struct bt_mesh_model *mod)
+static int sat_srv_pub_update(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_sat_srv *srv = mod->user_data;
+	struct bt_mesh_light_sat_srv *srv = model->user_data;
 	struct bt_mesh_light_sat_status status;
 
 	srv->handlers->get(srv, NULL, &status);
@@ -347,11 +347,11 @@ static int sat_srv_init(struct bt_mesh_model *model)
 	return 0;
 }
 
-static int sat_srv_settings_set(struct bt_mesh_model *mod, const char *name,
+static int sat_srv_settings_set(struct bt_mesh_model *model, const char *name,
 				size_t len_rd, settings_read_cb read_cb,
 				void *cb_data)
 {
-	struct bt_mesh_light_sat_srv *srv = mod->user_data;
+	struct bt_mesh_light_sat_srv *srv = model->user_data;
 	struct settings_data data;
 	ssize_t len;
 

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -287,20 +287,20 @@ const struct bt_mesh_lvl_srv_handlers _bt_mesh_light_temp_srv_lvl_handlers = {
 	.move_set = lvl_move_set,
 };
 
-static int scene_store(struct bt_mesh_model *mod, uint8_t data[])
+static int scene_store(struct bt_mesh_model *model, uint8_t data[])
 {
-	struct bt_mesh_light_temp_srv *srv = mod->user_data;
+	struct bt_mesh_light_temp_srv *srv = model->user_data;
 
 	sys_put_le16(srv->last.delta_uv, data);
 
 	return sizeof(int16_t);
 }
 
-static void scene_recall(struct bt_mesh_model *mod, const uint8_t data[],
+static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 			 size_t len,
 			 struct bt_mesh_model_transition *transition)
 {
-	struct bt_mesh_light_temp_srv *srv = mod->user_data;
+	struct bt_mesh_light_temp_srv *srv = model->user_data;
 	struct bt_mesh_light_temp_set set = {
 		.params = {
 			.temp = srv->last.temp,
@@ -347,12 +347,12 @@ static int bt_mesh_light_temp_srv_init(struct bt_mesh_model *model)
 	return 0;
 }
 
-static int bt_mesh_light_temp_srv_settings_set(struct bt_mesh_model *mod,
+static int bt_mesh_light_temp_srv_settings_set(struct bt_mesh_model *model,
 					       const char *name, size_t len_rd,
 					       settings_read_cb read_cb,
 					       void *cb_data)
 {
-	struct bt_mesh_light_temp_srv *srv = mod->user_data;
+	struct bt_mesh_light_temp_srv *srv = model->user_data;
 	struct settings_data data;
 	ssize_t len;
 

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -391,9 +391,9 @@ const struct bt_mesh_model_op _bt_mesh_light_xyl_setup_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static ssize_t scene_store(struct bt_mesh_model *mod, uint8_t data[])
+static ssize_t scene_store(struct bt_mesh_model *model, uint8_t data[])
 {
-	struct bt_mesh_light_xyl_srv *srv = mod->user_data;
+	struct bt_mesh_light_xyl_srv *srv = model->user_data;
 	struct bt_mesh_light_xy_status xy_rsp = { 0 };
 
 	srv->handlers->xy_get(srv, NULL, &xy_rsp);
@@ -409,11 +409,11 @@ static ssize_t scene_store(struct bt_mesh_model *mod, uint8_t data[])
 	return sizeof(struct bt_mesh_light_xy);
 }
 
-static void scene_recall(struct bt_mesh_model *mod, const uint8_t data[],
+static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 			 size_t len,
 			 struct bt_mesh_model_transition *transition)
 {
-	struct bt_mesh_light_xyl_srv *srv = mod->user_data;
+	struct bt_mesh_light_xyl_srv *srv = model->user_data;
 	struct bt_mesh_light_xy_status xy_dummy;
 	struct bt_mesh_light_xy_set xy_set = {
 		.params.x = sys_get_le16(data),
@@ -494,9 +494,9 @@ static int bt_mesh_light_xyl_srv_settings_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int bt_mesh_light_xyl_srv_start(struct bt_mesh_model *mod)
+static int bt_mesh_light_xyl_srv_start(struct bt_mesh_model *model)
 {
-	struct bt_mesh_light_xyl_srv *srv = mod->user_data;
+	struct bt_mesh_light_xyl_srv *srv = model->user_data;
 	struct bt_mesh_light_xy_status xy_dummy;
 	struct bt_mesh_model_transition transition = {
 		.time = srv->lightness_srv.ponoff.dtt.transition_time,

--- a/subsys/bluetooth/mesh/lightness_cli.c
+++ b/subsys/bluetooth/mesh/lightness_cli.c
@@ -7,7 +7,7 @@
 #include "model_utils.h"
 #include "lightness_internal.h"
 
-static void light_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void light_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf, enum light_repr repr)
 {
 	if (buf->len != BT_MESH_LIGHTNESS_MSG_MINLEN_STATUS &&
@@ -15,7 +15,7 @@ static void light_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		return;
 	}
 
-	struct bt_mesh_lightness_cli *cli = mod->user_data;
+	struct bt_mesh_lightness_cli *cli = model->user_data;
 	struct bt_mesh_lightness_status status;
 
 	status.current = repr_to_light(net_buf_simple_pull_le16(buf), repr);
@@ -41,21 +41,21 @@ static void light_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	}
 }
 
-static void handle_light_status(struct bt_mesh_model *mod,
+static void handle_light_status(struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
-	light_status(mod, ctx, buf, ACTUAL);
+	light_status(model, ctx, buf, ACTUAL);
 }
 
-static void handle_light_linear_status(struct bt_mesh_model *mod,
+static void handle_light_linear_status(struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
-	light_status(mod, ctx, buf, LINEAR);
+	light_status(model, ctx, buf, LINEAR);
 }
 
-static void handle_last_status(struct bt_mesh_model *mod,
+static void handle_last_status(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -63,7 +63,7 @@ static void handle_last_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_lightness_cli *cli = mod->user_data;
+	struct bt_mesh_lightness_cli *cli = model->user_data;
 	uint16_t last = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
 
 	if (model_ack_match(&cli->ack_ctx, BT_MESH_LIGHTNESS_OP_LAST_STATUS, ctx)) {
@@ -77,7 +77,7 @@ static void handle_last_status(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_default_status(struct bt_mesh_model *mod,
+static void handle_default_status(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
@@ -85,7 +85,7 @@ static void handle_default_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_lightness_cli *cli = mod->user_data;
+	struct bt_mesh_lightness_cli *cli = model->user_data;
 	uint16_t default_lvl =
 		repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
 
@@ -100,7 +100,7 @@ static void handle_default_status(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_range_status(struct bt_mesh_model *mod,
+static void handle_range_status(struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -108,7 +108,7 @@ static void handle_range_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_lightness_cli *cli = mod->user_data;
+	struct bt_mesh_lightness_cli *cli = model->user_data;
 	struct bt_mesh_lightness_range_status status;
 
 	status.status = net_buf_simple_pull_u8(buf);
@@ -141,11 +141,11 @@ const struct bt_mesh_model_op _bt_mesh_lightness_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int bt_mesh_lvl_cli_init(struct bt_mesh_model *mod)
+static int bt_mesh_lvl_cli_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_lightness_cli *cli = mod->user_data;
+	struct bt_mesh_lightness_cli *cli = model->user_data;
 
-	cli->model = mod;
+	cli->model = model;
 	cli->pub.msg = &cli->pub_buf;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data,
 				      sizeof(cli->pub_data));
@@ -154,11 +154,11 @@ static int bt_mesh_lvl_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void bt_mesh_lvl_cli_reset(struct bt_mesh_model *mod)
+static void bt_mesh_lvl_cli_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_lightness_cli *cli = mod->user_data;
+	struct bt_mesh_lightness_cli *cli = model->user_data;
 
-	net_buf_simple_reset(mod->pub->msg);
+	net_buf_simple_reset(model->pub->msg);
 	model_ack_reset(&cli->ack_ctx);
 }
 

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -125,7 +125,7 @@ static void transition_get(struct bt_mesh_lightness_srv *srv,
 	}
 }
 
-static void rsp_lightness_status(struct bt_mesh_model *mod,
+static void rsp_lightness_status(struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct bt_mesh_lightness_status *status,
 				 enum light_repr repr)
@@ -139,10 +139,10 @@ static void rsp_lightness_status(struct bt_mesh_model *mod,
 		light_to_repr(status->target, repr),
 		status->remaining_time);
 
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_light_get(struct bt_mesh_model *mod,
+static void handle_light_get(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf, enum light_repr repr)
 {
@@ -152,26 +152,26 @@ static void handle_light_get(struct bt_mesh_model *mod,
 
 	BT_DBG("%s", repr_str[repr]);
 
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 	struct bt_mesh_lightness_status status = { 0 };
 
 	srv->handlers->light_get(srv, ctx, &status);
 
-	rsp_lightness_status(mod, ctx, &status, repr);
+	rsp_lightness_status(model, ctx, &status, repr);
 }
 
-static void handle_actual_get(struct bt_mesh_model *mod,
+static void handle_actual_get(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	handle_light_get(mod, ctx, buf, ACTUAL);
+	handle_light_get(model, ctx, buf, ACTUAL);
 }
 
-static void handle_linear_get(struct bt_mesh_model *mod,
+static void handle_linear_get(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	handle_light_get(mod, ctx, buf, LINEAR);
+	handle_light_get(model, ctx, buf, LINEAR);
 }
 
 void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
@@ -214,7 +214,7 @@ void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
 	pub(srv, NULL, status, ACTUAL);
 }
 
-static void lightness_set(struct bt_mesh_model *mod,
+static void lightness_set(struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf, bool ack,
 			  enum light_repr repr)
@@ -224,7 +224,7 @@ static void lightness_set(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 	struct bt_mesh_model_transition transition;
 	struct bt_mesh_lightness_status status;
 	struct bt_mesh_lightness_set set;
@@ -253,39 +253,39 @@ static void lightness_set(struct bt_mesh_model *mod,
 	}
 
 	if (ack) {
-		rsp_lightness_status(mod, ctx, &status, repr);
+		rsp_lightness_status(model, ctx, &status, repr);
 	}
 }
 
-static void handle_actual_set(struct bt_mesh_model *mod,
+static void handle_actual_set(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	lightness_set(mod, ctx, buf, true, ACTUAL);
+	lightness_set(model, ctx, buf, true, ACTUAL);
 }
 
-static void handle_actual_set_unack(struct bt_mesh_model *mod,
+static void handle_actual_set_unack(struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
-	lightness_set(mod, ctx, buf, false, ACTUAL);
+	lightness_set(model, ctx, buf, false, ACTUAL);
 }
 
-static void handle_linear_set(struct bt_mesh_model *mod,
+static void handle_linear_set(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	lightness_set(mod, ctx, buf, true, LINEAR);
+	lightness_set(model, ctx, buf, true, LINEAR);
 }
 
-static void handle_linear_set_unack(struct bt_mesh_model *mod,
+static void handle_linear_set_unack(struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
-	lightness_set(mod, ctx, buf, false, LINEAR);
+	lightness_set(model, ctx, buf, false, LINEAR);
 }
 
-static void handle_last_get(struct bt_mesh_model *mod,
+static void handle_last_get(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -293,17 +293,17 @@ static void handle_last_get(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 
 	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_LIGHTNESS_OP_LAST_STATUS,
 				 BT_MESH_LIGHTNESS_MSG_LEN_LAST_STATUS);
 	bt_mesh_model_msg_init(&rsp, BT_MESH_LIGHTNESS_OP_LAST_STATUS);
 
 	net_buf_simple_add_le16(&rsp, light_to_repr(srv->last, ACTUAL));
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_default_get(struct bt_mesh_model *mod,
+static void handle_default_get(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -311,7 +311,7 @@ static void handle_default_get(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 
 	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_LIGHTNESS_OP_DEFAULT_STATUS,
 				 BT_MESH_LIGHTNESS_MSG_LEN_DEFAULT_STATUS);
@@ -319,7 +319,7 @@ static void handle_default_get(struct bt_mesh_model *mod,
 
 	net_buf_simple_add_le16(&rsp,
 				light_to_repr(srv->default_light, ACTUAL));
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
 void lightness_srv_default_set(struct bt_mesh_lightness_srv *srv,
@@ -341,14 +341,14 @@ void lightness_srv_default_set(struct bt_mesh_lightness_srv *srv,
 	store_state(srv);
 }
 
-static void set_default(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void set_default(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf, bool ack)
 {
 	if (buf->len != BT_MESH_LIGHTNESS_MSG_LEN_DEFAULT_SET) {
 		return;
 	}
 
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 	uint16_t new = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
 
 	lightness_srv_default_set(srv, ctx, new);
@@ -361,24 +361,24 @@ static void set_default(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	bt_mesh_model_msg_init(&rsp, BT_MESH_LIGHTNESS_OP_DEFAULT_STATUS);
 	net_buf_simple_add_le16(&rsp, srv->default_light);
 
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_default_set(struct bt_mesh_model *mod,
+static void handle_default_set(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
-	set_default(mod, ctx, buf, true);
+	set_default(model, ctx, buf, true);
 }
 
-static void handle_default_set_unack(struct bt_mesh_model *mod,
+static void handle_default_set_unack(struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
-	set_default(mod, ctx, buf, false);
+	set_default(model, ctx, buf, false);
 }
 
-static void handle_range_get(struct bt_mesh_model *mod,
+static void handle_range_get(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -386,7 +386,7 @@ static void handle_range_get(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 
 	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_LIGHTNESS_OP_RANGE_STATUS,
 				 BT_MESH_LIGHTNESS_MSG_LEN_RANGE_STATUS);
@@ -396,17 +396,17 @@ static void handle_range_get(struct bt_mesh_model *mod,
 	net_buf_simple_add_le16(&rsp, light_to_repr(srv->range.min, ACTUAL));
 	net_buf_simple_add_le16(&rsp, light_to_repr(srv->range.max, ACTUAL));
 
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void set_range(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void set_range(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf, bool ack)
 {
 	if (buf->len != BT_MESH_LIGHTNESS_MSG_LEN_RANGE_SET) {
 		return;
 	}
 
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 	struct bt_mesh_lightness_range new;
 
 	new.min = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
@@ -443,21 +443,21 @@ static void set_range(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	net_buf_simple_add_le16(&rsp, light_to_repr(srv->range.min, ACTUAL));
 	net_buf_simple_add_le16(&rsp, light_to_repr(srv->range.max, ACTUAL));
 
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_range_set(struct bt_mesh_model *mod,
+static void handle_range_set(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
-	set_range(mod, ctx, buf, true);
+	set_range(model, ctx, buf, true);
 }
 
-static void handle_range_set_unack(struct bt_mesh_model *mod,
+static void handle_range_set_unack(struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
-	set_range(mod, ctx, buf, false);
+	set_range(model, ctx, buf, false);
 }
 
 const struct bt_mesh_model_op _bt_mesh_lightness_srv_op[] = {
@@ -738,9 +738,9 @@ static void lightness_srv_reset(struct bt_mesh_lightness_srv *srv)
 	atomic_clear_bit(&srv->flags, LIGHTNESS_SRV_FLAG_IS_ON);
 }
 
-static void bt_mesh_lightness_srv_reset(struct bt_mesh_model *mod)
+static void bt_mesh_lightness_srv_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 
 	lightness_srv_reset(srv);
 	net_buf_simple_reset(srv->pub.msg);
@@ -763,11 +763,11 @@ static int update_handler(struct bt_mesh_model *model)
 }
 
 
-static int bt_mesh_lightness_srv_init(struct bt_mesh_model *mod)
+static int bt_mesh_lightness_srv_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 
-	srv->lightness_model = mod;
+	srv->lightness_model = model;
 
 	lightness_srv_reset(srv);
 	srv->pub.msg = &srv->pub_buf;
@@ -785,12 +785,12 @@ static int bt_mesh_lightness_srv_init(struct bt_mesh_model *mod)
 		 * stack, but it makes it a lot easier to extend this model, as
 		 * we won't have to support multiple extenders.
 		 */
-		bt_mesh_model_extend(mod, srv->ponoff.ponoff_model);
-		bt_mesh_model_extend(mod, srv->lvl.model);
+		bt_mesh_model_extend(model, srv->ponoff.ponoff_model);
+		bt_mesh_model_extend(model, srv->lvl.model);
 		bt_mesh_model_extend(
-			mod,
+			model,
 			bt_mesh_model_find(
-				bt_mesh_model_elem(mod),
+				bt_mesh_model_elem(model),
 				BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SETUP_SRV));
 	}
 
@@ -798,12 +798,12 @@ static int bt_mesh_lightness_srv_init(struct bt_mesh_model *mod)
 }
 
 #ifdef CONFIG_BT_SETTINGS
-static int bt_mesh_lightness_srv_settings_set(struct bt_mesh_model *mod,
+static int bt_mesh_lightness_srv_settings_set(struct bt_mesh_model *model,
 					      const char *name, size_t len_rd,
 					      settings_read_cb read_cb,
 					      void *cb_arg)
 {
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 	struct bt_mesh_lightness_srv_settings_data data;
 	ssize_t result;
 
@@ -861,9 +861,9 @@ int lightness_on_power_up(struct bt_mesh_lightness_srv *srv)
 }
 
 #ifdef CONFIG_BT_SETTINGS
-static int bt_mesh_lightness_srv_start(struct bt_mesh_model *mod)
+static int bt_mesh_lightness_srv_start(struct bt_mesh_model *model)
 {
-	struct bt_mesh_lightness_srv *srv = mod->user_data;
+	struct bt_mesh_lightness_srv *srv = model->user_data;
 
 	if (atomic_test_bit(&srv->flags, LIGHTNESS_SRV_FLAG_NO_START)) {
 		return 0;

--- a/subsys/bluetooth/mesh/model_utils.c
+++ b/subsys/bluetooth/mesh/model_utils.c
@@ -102,39 +102,39 @@ int32_t model_delay_decode(uint8_t encoded_delay)
 	return encoded_delay * DELAY_TIME_STEP_MS;
 }
 
-int model_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+int model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	       struct net_buf_simple *buf)
 {
-	if (!ctx && !mod->pub) {
+	if (!ctx && !model->pub) {
 		return -ENOTSUP;
 	}
 
 	if (ctx) {
-		return bt_mesh_model_send(mod, ctx, buf, NULL, 0);
+		return bt_mesh_model_send(model, ctx, buf, NULL, 0);
 	}
 
-	net_buf_simple_reset(mod->pub->msg);
-	net_buf_simple_add_mem(mod->pub->msg, buf->data, buf->len);
+	net_buf_simple_reset(model->pub->msg);
+	net_buf_simple_add_mem(model->pub->msg, buf->data, buf->len);
 
-	return bt_mesh_model_publish(mod);
+	return bt_mesh_model_publish(model);
 }
 
-int model_ackd_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+int model_ackd_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		    struct net_buf_simple *buf,
 		    struct bt_mesh_model_ack_ctx *ack, uint32_t rsp_op,
 		    void *user_data)
 {
 	if (ack &&
-	    model_ack_ctx_prepare(ack, rsp_op, ctx ? ctx->addr : mod->pub->addr,
+	    model_ack_ctx_prepare(ack, rsp_op, ctx ? ctx->addr : model->pub->addr,
 				  user_data) != 0) {
 		return -EALREADY;
 	}
 
-	int retval = model_send(mod, ctx, buf);
+	int retval = model_send(model, ctx, buf);
 
 	if (ack) {
 		if (retval == 0) {
-			uint8_t ttl = (ctx ? ctx->send_ttl : mod->pub->ttl);
+			uint8_t ttl = (ctx ? ctx->send_ttl : model->pub->ttl);
 			int32_t time = (CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_BASE +
 				ttl * CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_PER_HOP);
 			return model_ack_wait(ack, time);
@@ -145,7 +145,7 @@ int model_ackd_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return retval;
 }
 
-bool bt_mesh_model_pub_is_unicast(const struct bt_mesh_model *mod)
+bool bt_mesh_model_pub_is_unicast(const struct bt_mesh_model *model)
 {
-	return mod->pub && BT_MESH_ADDR_IS_UNICAST(mod->pub->addr);
+	return model->pub && BT_MESH_ADDR_IS_UNICAST(model->pub->addr);
 }

--- a/subsys/bluetooth/mesh/model_utils.h
+++ b/subsys/bluetooth/mesh/model_utils.h
@@ -20,7 +20,7 @@
  * Sends a model message with the given context. If the context is NULL, this
  * updates the publish message, and publishes with the configured parameters.
  *
- * @param mod Model to send on.
+ * @param model Model to send on.
  * @param ctx Context to send with, or NULL to publish on the configured
  * publish parameters.
  * @param buf Message to send.
@@ -32,7 +32,7 @@
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
  */
-int model_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+int model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	       struct net_buf_simple *buf);
 
 /** @brief Send an acknowledged model message.
@@ -45,7 +45,7 @@ int model_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
  * If a response context is provided, the call blocks for
  * 200 + TTL * 50 milliseconds, or until the acknowledgment is received.
  *
- * @param mod Model to send the message on.
+ * @param model Model to send the message on.
  * @param ctx Message context, or NULL to send with the configured publish
  * parameters.
  * @param buf Message to send.
@@ -62,7 +62,7 @@ int model_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
  * @retval -EAGAIN The device has not been provisioned.
  * @retval -ETIMEDOUT The request timed out without a response.
  */
-int model_ackd_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+int model_ackd_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		    struct net_buf_simple *buf,
 		    struct bt_mesh_model_ack_ctx *ack, uint32_t rsp_op,
 		    void *user_data);

--- a/subsys/bluetooth/mesh/scene_cli.c
+++ b/subsys/bluetooth/mesh/scene_cli.c
@@ -7,10 +7,10 @@
 #include <bluetooth/mesh/models.h>
 #include "model_utils.h"
 
-static void scene_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void scene_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
-	struct bt_mesh_scene_cli *cli = mod->user_data;
+	struct bt_mesh_scene_cli *cli = model->user_data;
 	struct bt_mesh_scene_state state;
 
 	state.status = net_buf_simple_pull_u8(buf);
@@ -38,10 +38,10 @@ static void scene_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	}
 }
 
-static void scene_reg(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void scene_reg(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
-	struct bt_mesh_scene_cli *cli = mod->user_data;
+	struct bt_mesh_scene_cli *cli = model->user_data;
 	struct bt_mesh_scene_register reg;
 
 	reg.status = net_buf_simple_pull_u8(buf);
@@ -98,15 +98,15 @@ const struct bt_mesh_model_op _bt_mesh_scene_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int scene_cli_init(struct bt_mesh_model *mod)
+static int scene_cli_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_scene_cli *cli = mod->user_data;
+	struct bt_mesh_scene_cli *cli = model->user_data;
 
 	if (!cli) {
 		return -EINVAL;
 	}
 
-	cli->mod = mod;
+	cli->model = model;
 
 	net_buf_simple_init_with_data(&cli->pub_msg, cli->buf,
 				      sizeof(cli->buf));
@@ -117,9 +117,9 @@ static int scene_cli_init(struct bt_mesh_model *mod)
 }
 
 
-static void scene_cli_reset(struct bt_mesh_model *mod)
+static void scene_cli_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_scene_cli *cli = mod->user_data;
+	struct bt_mesh_scene_cli *cli = model->user_data;
 
 	net_buf_simple_reset(cli->pub.msg);
 	model_ack_reset(&cli->ack);
@@ -138,7 +138,7 @@ int bt_mesh_scene_cli_get(struct bt_mesh_scene_cli *cli,
 				 BT_MESH_SCENE_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_SCENE_OP_GET);
 
-	return model_ackd_send(cli->mod, ctx, &buf, rsp ? &cli->ack : NULL,
+	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
 			       BT_MESH_SCENE_OP_STATUS, rsp);
 }
 
@@ -150,7 +150,7 @@ int bt_mesh_scene_cli_register_get(struct bt_mesh_scene_cli *cli,
 				 BT_MESH_SCENE_MSG_LEN_REGISTER_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_SCENE_OP_REGISTER_GET);
 
-	return model_ackd_send(cli->mod, ctx, &buf, rsp ? &cli->ack : NULL,
+	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
 			       BT_MESH_SCENE_OP_REGISTER_STATUS, rsp);
 }
 
@@ -168,7 +168,7 @@ int bt_mesh_scene_cli_store(struct bt_mesh_scene_cli *cli,
 
 	net_buf_simple_add_le16(&buf, scene);
 
-	return model_ackd_send(cli->mod, ctx, &buf, rsp ? &cli->ack : NULL,
+	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
 			       BT_MESH_SCENE_OP_REGISTER_STATUS, rsp);
 }
 
@@ -185,7 +185,7 @@ int bt_mesh_scene_cli_store_unack(struct bt_mesh_scene_cli *cli,
 
 	net_buf_simple_add_le16(&buf, scene);
 
-	return model_send(cli->mod, ctx, &buf);
+	return model_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_scene_cli_delete(struct bt_mesh_scene_cli *cli,
@@ -202,7 +202,7 @@ int bt_mesh_scene_cli_delete(struct bt_mesh_scene_cli *cli,
 
 	net_buf_simple_add_le16(&buf, scene);
 
-	return model_ackd_send(cli->mod, ctx, &buf, rsp ? &cli->ack : NULL,
+	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
 			       BT_MESH_SCENE_OP_REGISTER_STATUS, rsp);
 }
 
@@ -219,7 +219,7 @@ int bt_mesh_scene_cli_delete_unack(struct bt_mesh_scene_cli *cli,
 
 	net_buf_simple_add_le16(&buf, scene);
 
-	return model_send(cli->mod, ctx, &buf);
+	return model_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_scene_cli_recall(struct bt_mesh_scene_cli *cli,
@@ -242,7 +242,7 @@ int bt_mesh_scene_cli_recall(struct bt_mesh_scene_cli *cli,
 		model_transition_buf_add(&buf, transition);
 	}
 
-	return model_ackd_send(cli->mod, ctx, &buf, rsp ? &cli->ack : NULL,
+	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
 			       BT_MESH_SCENE_OP_STATUS, rsp);
 }
 
@@ -265,5 +265,5 @@ int bt_mesh_scene_cli_recall_unack(
 		model_transition_buf_add(&buf, transition);
 	}
 
-	return model_send(cli->mod, ctx, &buf);
+	return model_send(cli->model, ctx, &buf);
 }

--- a/subsys/bluetooth/mesh/scheduler_cli.c
+++ b/subsys/bluetooth/mesh/scheduler_cli.c
@@ -8,11 +8,11 @@
 #include "scheduler_internal.h"
 #include "model_utils.h"
 
-static void status_op(struct bt_mesh_model *mod,
+static void status_op(struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
-	struct bt_mesh_scheduler_cli *cli = mod->user_data;
+	struct bt_mesh_scheduler_cli *cli = model->user_data;
 	uint16_t schedules;
 
 	if (buf->len != BT_MESH_SCHEDULER_MSG_LEN_STATUS) {
@@ -32,11 +32,11 @@ static void status_op(struct bt_mesh_model *mod,
 	}
 }
 
-static void action_status_op(struct bt_mesh_model *mod,
+static void action_status_op(struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
-	struct bt_mesh_scheduler_cli *cli = mod->user_data;
+	struct bt_mesh_scheduler_cli *cli = model->user_data;
 	struct bt_mesh_schedule_entry action = {0};
 	uint8_t idx;
 
@@ -81,15 +81,15 @@ const struct bt_mesh_model_op _bt_mesh_scheduler_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int scheduler_cli_init(struct bt_mesh_model *mod)
+static int scheduler_cli_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_scheduler_cli *cli = mod->user_data;
+	struct bt_mesh_scheduler_cli *cli = model->user_data;
 
 	if (!cli) {
 		return -EINVAL;
 	}
 
-	cli->mod = mod;
+	cli->model = model;
 
 	net_buf_simple_init_with_data(&cli->pub_msg, cli->buf,
 				      sizeof(cli->buf));
@@ -100,9 +100,9 @@ static int scheduler_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void scheduler_cli_reset(struct bt_mesh_model *mod)
+static void scheduler_cli_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_scheduler_cli *cli = mod->user_data;
+	struct bt_mesh_scheduler_cli *cli = model->user_data;
 
 	net_buf_simple_reset(cli->pub.msg);
 	model_ack_reset(&cli->ack);
@@ -121,7 +121,7 @@ int bt_mesh_scheduler_cli_get(struct bt_mesh_scheduler_cli *cli,
 			BT_MESH_SCHEDULER_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_SCHEDULER_OP_GET);
 
-	return model_ackd_send(cli->mod, ctx, &buf, rsp ? &cli->ack : NULL,
+	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
 			BT_MESH_SCHEDULER_OP_STATUS, rsp);
 }
 
@@ -141,7 +141,7 @@ int bt_mesh_scheduler_cli_action_get(struct bt_mesh_scheduler_cli *cli,
 	net_buf_simple_add_u8(&buf, idx);
 	cli->ack_idx = rsp ? idx : BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT;
 
-	return model_ackd_send(cli->mod, ctx, &buf, rsp ? &cli->ack : NULL,
+	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
 			BT_MESH_SCHEDULER_OP_ACTION_STATUS, rsp);
 }
 
@@ -162,7 +162,7 @@ int bt_mesh_scheduler_cli_action_set(struct bt_mesh_scheduler_cli *cli,
 	scheduler_action_pack(&buf, idx, entry);
 	cli->ack_idx = rsp ? idx : BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT;
 
-	return model_ackd_send(cli->mod, ctx, &buf, rsp ? &cli->ack : NULL,
+	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack : NULL,
 			BT_MESH_SCHEDULER_OP_ACTION_STATUS, rsp);
 }
 
@@ -181,5 +181,5 @@ int bt_mesh_scheduler_cli_action_set_unack(struct bt_mesh_scheduler_cli *cli,
 
 	scheduler_action_pack(&buf, idx, entry);
 
-	return model_send(cli->mod, ctx, &buf);
+	return model_send(cli->model, ctx, &buf);
 }

--- a/subsys/bluetooth/mesh/scheduler_srv.c
+++ b/subsys/bluetooth/mesh/scheduler_srv.c
@@ -440,18 +440,18 @@ static void scheduled_action_handle(struct k_work *work)
 		.delay = 0,
 	};
 	uint16_t scene = srv->sch_reg[srv->idx].scene_number;
-	struct bt_mesh_elem *elem = bt_mesh_model_elem(srv->mod);
+	struct bt_mesh_elem *elem = bt_mesh_model_elem(srv->model);
 
 	BT_DBG("Scheduler action fired: %d", srv->sch_reg[srv->idx].action);
 
 	do {
-		struct bt_mesh_model *handled_mod =
+		struct bt_mesh_model *handled_model =
 				bt_mesh_model_find(elem, model_id);
 
 		if (model_id == BT_MESH_MODEL_ID_SCENE_SRV &&
-				handled_mod != NULL) {
+		    handled_model != NULL) {
 			struct bt_mesh_scene_srv *scene_srv =
-			(struct bt_mesh_scene_srv *)handled_mod->user_data;
+			(struct bt_mesh_scene_srv *)handled_model->user_data;
 
 			bt_mesh_scene_srv_set(scene_srv, scene, &transition);
 			bt_mesh_scene_srv_pub(scene_srv, NULL);
@@ -460,10 +460,10 @@ static void scheduled_action_handle(struct k_work *work)
 				srv->sch_reg[srv->idx].scene_number);
 		}
 
-		if (model_id == BT_MESH_MODEL_ID_GEN_ONOFF_SRV  &&
-				handled_mod != NULL) {
+		if (model_id == BT_MESH_MODEL_ID_GEN_ONOFF_SRV &&
+		    handled_model != NULL) {
 			struct bt_mesh_onoff_srv *onoff_srv =
-			(struct bt_mesh_onoff_srv *)handled_mod->user_data;
+			(struct bt_mesh_onoff_srv *)handled_model->user_data;
 			struct bt_mesh_onoff_set set = {
 				.on_off = srv->sch_reg[srv->idx].action,
 				.transition = &transition
@@ -595,15 +595,15 @@ static void action_set(struct bt_mesh_model *model,
 	}
 }
 
-static void handle_scheduler_get(struct bt_mesh_model *mod,
+static void handle_scheduler_get(struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
 	BT_DBG("Rx: scheduler server get");
-	send_scheduler_status(mod, ctx);
+	send_scheduler_status(model, ctx);
 }
 
-static void handle_scheduler_action_get(struct bt_mesh_model *mod,
+static void handle_scheduler_action_get(struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
@@ -614,21 +614,21 @@ static void handle_scheduler_action_get(struct bt_mesh_model *mod,
 	}
 
 	BT_DBG("Rx: scheduler server action index %d get", idx);
-	send_scheduler_action_status(mod, ctx, idx);
+	send_scheduler_action_status(model, ctx, idx);
 }
 
-static void handle_scheduler_action_set(struct bt_mesh_model *mod,
+static void handle_scheduler_action_set(struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
-	action_set(mod, ctx, buf, true);
+	action_set(model, ctx, buf, true);
 }
 
-static void handle_scheduler_action_set_unack(struct bt_mesh_model *mod,
+static void handle_scheduler_action_set_unack(struct bt_mesh_model *model,
 					      struct bt_mesh_msg_ctx *ctx,
 					      struct net_buf_simple *buf)
 {
-	action_set(mod, ctx, buf, false);
+	action_set(model, ctx, buf, false);
 }
 
 const struct bt_mesh_model_op _bt_mesh_scheduler_srv_op[] = {
@@ -659,15 +659,15 @@ static int update_handler(struct bt_mesh_model *model)
 	return 0;
 }
 
-static int scheduler_srv_init(struct bt_mesh_model *mod)
+static int scheduler_srv_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_scheduler_srv *srv = mod->user_data;
+	struct bt_mesh_scheduler_srv *srv = model->user_data;
 
 	if (srv->time_srv == NULL) {
 		return -ECANCELED;
 	}
 
-	srv->mod = mod;
+	srv->model = model;
 	srv->pub.msg = &srv->pub_buf;
 	srv->pub.update = update_handler;
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
@@ -685,7 +685,7 @@ static int scheduler_srv_init(struct bt_mesh_model *mod)
 		 * the mesh stack, but it makes it a lot easier to extend
 		 * this model, as we won't have to support multiple extenders.
 		 */
-		bt_mesh_model_extend(mod, srv->setup_mod);
+		bt_mesh_model_extend(model, srv->setup_mod);
 	}
 
 	srv->idx = BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT;
@@ -700,9 +700,9 @@ static int scheduler_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void scheduler_srv_reset(struct bt_mesh_model *mod)
+static void scheduler_srv_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_scheduler_srv *srv = mod->user_data;
+	struct bt_mesh_scheduler_srv *srv = model->user_data;
 
 	srv->idx = BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT;
 	srv->status_bitmap = 0;

--- a/subsys/bluetooth/mesh/sensor_cli.c
+++ b/subsys/bluetooth/mesh/sensor_cli.c
@@ -59,7 +59,7 @@ static void unknown_type(struct bt_mesh_sensor_cli *cli,
 	}
 }
 
-static void handle_descriptor_status(struct bt_mesh_model *mod,
+static void handle_descriptor_status(struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -67,7 +67,7 @@ static void handle_descriptor_status(struct bt_mesh_model *mod,
 		return;
 	}
 
-	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct bt_mesh_sensor_cli *cli = model->user_data;
 	struct list_rsp *ack_ctx = cli->ack.user_data;
 	uint32_t count = 0;
 	bool is_rsp;
@@ -105,11 +105,11 @@ yield_ack:
 	}
 }
 
-static void handle_status(struct bt_mesh_model *mod,
+static void handle_status(struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct bt_mesh_sensor_cli *cli = model->user_data;
 	struct sensor_data_list_rsp *rsp = cli->ack.user_data;
 	uint32_t count = 0;
 	bool is_rsp;
@@ -216,11 +216,11 @@ static int parse_series_entry(const struct bt_mesh_sensor_type *type,
 	return sensor_value_decode(buf, type, entry->value);
 }
 
-static void handle_column_status(struct bt_mesh_model *mod,
+static void handle_column_status(struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct bt_mesh_sensor_cli *cli = model->user_data;
 	struct series_data_rsp *rsp = cli->ack.user_data;
 	const struct bt_mesh_sensor_format *col_format;
 	const struct bt_mesh_sensor_type *type;
@@ -270,11 +270,11 @@ yield_ack:
 	}
 }
 
-static void handle_series_status(struct bt_mesh_model *mod,
+static void handle_series_status(struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct bt_mesh_sensor_cli *cli = model->user_data;
 	const struct bt_mesh_sensor_format *col_format;
 	const struct bt_mesh_sensor_type *type;
 	struct series_data_rsp *rsp = NULL;
@@ -334,11 +334,11 @@ static void handle_series_status(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_cadence_status(struct bt_mesh_model *mod,
+static void handle_cadence_status(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct bt_mesh_sensor_cli *cli = model->user_data;
 	struct cadence_rsp *rsp = cli->ack.user_data;
 	int err;
 
@@ -381,11 +381,11 @@ yield_ack:
 	}
 }
 
-static void handle_settings_status(struct bt_mesh_model *mod,
+static void handle_settings_status(struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct bt_mesh_sensor_cli *cli = model->user_data;
 	struct settings_rsp *rsp = cli->ack.user_data;
 
 	if (buf->len % 2) {
@@ -423,11 +423,11 @@ static void handle_settings_status(struct bt_mesh_model *mod,
 	}
 }
 
-static void handle_setting_status(struct bt_mesh_model *mod,
+static void handle_setting_status(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct bt_mesh_sensor_cli *cli = model->user_data;
 	struct setting_rsp *rsp = cli->ack.user_data;
 	int err;
 
@@ -507,11 +507,11 @@ const struct bt_mesh_model_op _bt_mesh_sensor_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int sensor_cli_init(struct bt_mesh_model *mod)
+static int sensor_cli_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct bt_mesh_sensor_cli *cli = model->user_data;
 
-	cli->mod = mod;
+	cli->model = model;
 	cli->pub.msg = &cli->pub_buf;
 	net_buf_simple_init_with_data(&cli->pub_buf, cli->pub_data,
 				      sizeof(cli->pub_data));
@@ -520,9 +520,9 @@ static int sensor_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void sensor_cli_reset(struct bt_mesh_model *mod)
+static void sensor_cli_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct bt_mesh_sensor_cli *cli = model->user_data;
 
 	net_buf_simple_reset(cli->pub.msg);
 	model_ack_reset(&cli->ack);
@@ -549,7 +549,7 @@ int bt_mesh_sensor_cli_desc_all_get(struct bt_mesh_sensor_cli *cli,
 		.count = *count,
 	};
 
-	err = model_ackd_send(cli->mod, ctx, &msg, sensors ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, sensors ? &cli->ack : NULL,
 			      BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS, &list_rsp);
 
 	*count = list_rsp.count;
@@ -577,7 +577,7 @@ int bt_mesh_sensor_cli_desc_get(struct bt_mesh_sensor_cli *cli,
 		.count = 1,
 	};
 
-	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack : NULL,
 			      BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS, &list_rsp);
 	if (err) {
 		return err;
@@ -615,7 +615,7 @@ int bt_mesh_sensor_cli_cadence_get(struct bt_mesh_sensor_cli *cli,
 		.cadence = rsp,
 	};
 
-	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack : NULL,
 			       BT_MESH_SENSOR_OP_CADENCE_STATUS, &rsp_data);
 	if (err) {
 		return err;
@@ -660,7 +660,7 @@ int bt_mesh_sensor_cli_cadence_set(
 		return err;
 	}
 
-	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack : NULL,
 			      BT_MESH_SENSOR_OP_CADENCE_STATUS, &rsp_data);
 	if (err) {
 		return err;
@@ -701,7 +701,7 @@ int bt_mesh_sensor_cli_cadence_set_unack(
 		return err;
 	}
 
-	return model_send(cli->mod, ctx, &msg);
+	return model_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
@@ -723,7 +723,7 @@ int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
 		.count = *count,
 	};
 
-	err = model_ackd_send(cli->mod, ctx, &msg, ids ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, ids ? &cli->ack : NULL,
 			      BT_MESH_SENSOR_OP_SETTINGS_STATUS, &rsp);
 
 	if (ids && !err) {
@@ -754,7 +754,7 @@ int bt_mesh_sensor_cli_setting_get(struct bt_mesh_sensor_cli *cli,
 		.setting = rsp,
 	};
 
-	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack : NULL,
 			      BT_MESH_SENSOR_OP_SETTING_STATUS, &rsp_data);
 	if (err) {
 		return err;
@@ -793,7 +793,7 @@ int bt_mesh_sensor_cli_setting_set(struct bt_mesh_sensor_cli *cli,
 		.setting = rsp,
 	};
 
-	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack : NULL,
 			       BT_MESH_SENSOR_OP_SETTING_STATUS, &rsp_data);
 	if (err) {
 		return err;
@@ -829,7 +829,7 @@ int bt_mesh_sensor_cli_setting_set_unack(
 		return err;
 	}
 
-	return model_send(cli->mod, ctx, &msg);
+	return model_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_sensor_cli_all_get(struct bt_mesh_sensor_cli *cli,
@@ -850,7 +850,7 @@ int bt_mesh_sensor_cli_all_get(struct bt_mesh_sensor_cli *cli,
 		memset(sensors, 0, sizeof(*sensors) * (*count));
 	}
 
-	err = model_ackd_send(cli->mod, ctx, &msg, sensors ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, sensors ? &cli->ack : NULL,
 			      BT_MESH_SENSOR_OP_STATUS, &rsp_data);
 	if (err) {
 		return err;
@@ -883,7 +883,7 @@ int bt_mesh_sensor_cli_get(struct bt_mesh_sensor_cli *cli,
 	struct sensor_data_list_rsp rsp_data = { .count = 1,
 						 .sensors = &sensor_data };
 
-	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack : NULL,
 			      BT_MESH_SENSOR_OP_STATUS, &rsp_data);
 	if (err) {
 		return err;
@@ -925,7 +925,7 @@ int bt_mesh_sensor_cli_series_entry_get(
 		.col = column,
 	};
 
-	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack : NULL,
 			      BT_MESH_SENSOR_OP_COLUMN_STATUS, &rsp_data);
 	if (err) {
 		return err;
@@ -974,7 +974,7 @@ int bt_mesh_sensor_cli_series_entries_get(
 		.count = *count,
 	};
 
-	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack : NULL,
 			       BT_MESH_SENSOR_OP_SERIES_STATUS, &rsp_data);
 	if (err) {
 		return err;

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -106,11 +106,11 @@ static int buf_status_add(struct bt_mesh_sensor *sensor,
 	return err;
 }
 
-static void handle_descriptor_get(struct bt_mesh_model *mod,
+static void handle_descriptor_get(struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 
 	if (buf->len != 0 && buf->len != 2) {
 		return;
@@ -150,13 +150,13 @@ static void handle_descriptor_get(struct bt_mesh_model *mod,
 	}
 
 respond:
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void handle_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 
 	if (buf->len != 0 && buf->len != 2) {
 		return;
@@ -190,7 +190,7 @@ static void handle_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	}
 
 respond:
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
 static const struct bt_mesh_sensor_column *
@@ -207,11 +207,11 @@ column_get(const struct bt_mesh_sensor_series *series,
 	return NULL;
 }
 
-static void handle_column_get(struct bt_mesh_model *mod,
+static void handle_column_get(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 	int err;
 
 	if (buf->len < 2) {
@@ -266,14 +266,14 @@ static void handle_column_get(struct bt_mesh_model *mod,
 	}
 
 respond:
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void handle_series_get(struct bt_mesh_model *mod,
+static void handle_series_get(struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 	const struct bt_mesh_sensor_format *col_format;
 
 	if (buf->len < 2) {
@@ -345,7 +345,7 @@ static void handle_series_get(struct bt_mesh_model *mod,
 	}
 
 respond:
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
 const struct bt_mesh_model_op _bt_mesh_sensor_srv_op[] = {
@@ -359,11 +359,11 @@ const struct bt_mesh_model_op _bt_mesh_sensor_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static void handle_cadence_get(struct bt_mesh_model *mod,
+static void handle_cadence_get(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 	struct bt_mesh_sensor *sensor;
 	uint16_t id;
 	int err;
@@ -396,10 +396,10 @@ respond:
 	bt_mesh_model_send(srv->model, ctx, &rsp, NULL, NULL);
 }
 
-static void cadence_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void cadence_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf, bool ack)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 	struct bt_mesh_sensor *sensor;
 	uint16_t id;
 
@@ -456,33 +456,33 @@ static void cadence_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		return;
 	}
 
-	model_send(mod, NULL, &rsp);
+	model_send(model, NULL, &rsp);
 
 respond:
 	if (ack) {
-		bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+		bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 	}
 }
 
-static void handle_cadence_set(struct bt_mesh_model *mod,
+static void handle_cadence_set(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
-	cadence_set(mod, ctx, buf, true);
+	cadence_set(model, ctx, buf, true);
 }
 
-static void handle_cadence_set_unack(struct bt_mesh_model *mod,
+static void handle_cadence_set_unack(struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
-	cadence_set(mod, ctx, buf, false);
+	cadence_set(model, ctx, buf, false);
 }
 
-static void handle_settings_get(struct bt_mesh_model *mod,
+static void handle_settings_get(struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 
 	uint16_t id = net_buf_simple_pull_le16(buf);
 
@@ -512,7 +512,7 @@ static void handle_settings_get(struct bt_mesh_model *mod,
 	}
 
 respond:
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
 static const struct bt_mesh_sensor_setting *
@@ -526,11 +526,11 @@ setting_get(struct bt_mesh_sensor *sensor, uint16_t setting_id)
 	return NULL;
 }
 
-static void handle_setting_get(struct bt_mesh_model *mod,
+static void handle_setting_get(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 	uint16_t id = net_buf_simple_pull_le16(buf);
 	uint16_t setting_id = net_buf_simple_pull_le16(buf);
 	int err;
@@ -576,13 +576,13 @@ static void handle_setting_get(struct bt_mesh_model *mod,
 	}
 
 respond:
-	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-static void setting_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static void setting_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf, bool ack)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 	uint16_t id = net_buf_simple_pull_le16(buf);
 	uint16_t setting_id = net_buf_simple_pull_le16(buf);
 	int err;
@@ -640,26 +640,26 @@ static void setting_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 
 	BT_DBG("0x%04x: 0x%04x", id, setting_id);
 
-	model_send(mod, NULL, &rsp);
+	model_send(model, NULL, &rsp);
 
 respond:
 	if (ack) {
-		bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+		bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 	}
 }
 
-static void handle_setting_set(struct bt_mesh_model *mod,
+static void handle_setting_set(struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
-	setting_set(mod, ctx, buf, true);
+	setting_set(model, ctx, buf, true);
 }
 
-static void handle_setting_set_unack(struct bt_mesh_model *mod,
+static void handle_setting_set_unack(struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
-	setting_set(mod, ctx, buf, false);
+	setting_set(model, ctx, buf, false);
 }
 
 const struct bt_mesh_model_op _bt_mesh_sensor_setup_srv_op[] = {
@@ -760,9 +760,9 @@ static void pub_msg_add(struct bt_mesh_sensor_srv *srv,
 	s->state.seq = srv->seq;
 }
 
-static int update_handler(struct bt_mesh_model *mod)
+static int update_handler(struct bt_mesh_model *model)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 	struct bt_mesh_sensor *s;
 
 	bt_mesh_model_msg_init(srv->pub.msg, BT_MESH_SENSOR_OP_STATUS);
@@ -771,13 +771,13 @@ static int update_handler(struct bt_mesh_model *mod)
 	uint8_t period_div = srv->pub.period_div;
 
 	BT_DBG("#%u Period: %u ms Divisor: %u (%s)", srv->seq,
-	       bt_mesh_model_pub_period_get(mod), period_div,
+	       bt_mesh_model_pub_period_get(model), period_div,
 	       srv->pub.fast_period ? "fast" : "normal");
 
 	srv->pub.period_div = 0;
 	srv->pub.fast_period = 0;
 
-	uint32_t base_period = bt_mesh_model_pub_period_get(mod);
+	uint32_t base_period = bt_mesh_model_pub_period_get(model);
 
 	SENSOR_FOR_EACH(&srv->sensors, s)
 	{
@@ -800,9 +800,9 @@ static int update_handler(struct bt_mesh_model *mod)
 	return (srv->pub.msg->len > original_len) ? 0 : -ENOENT;
 }
 
-static int sensor_srv_init(struct bt_mesh_model *mod)
+static int sensor_srv_init(struct bt_mesh_model *model)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 
 	sys_slist_init(&srv->sensors);
 
@@ -835,7 +835,7 @@ static int sensor_srv_init(struct bt_mesh_model *mod)
 
 	srv->seq = 1;
 
-	srv->model = mod;
+	srv->model = model;
 
 	srv->pub.update = update_handler;
 	srv->pub.msg = &srv->pub_buf;
@@ -848,9 +848,9 @@ static int sensor_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void sensor_srv_reset(struct bt_mesh_model *mod)
+static void sensor_srv_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 
 	net_buf_simple_reset(srv->pub.msg);
 	net_buf_simple_reset(srv->setup_pub.msg);
@@ -869,11 +869,11 @@ static void sensor_srv_reset(struct bt_mesh_model *mod)
 	}
 }
 
-static int sensor_srv_settings_set(struct bt_mesh_model *mod, const char *name,
+static int sensor_srv_settings_set(struct bt_mesh_model *model, const char *name,
 				   size_t len_rd, settings_read_cb read_cb,
 				   void *cb_arg)
 {
-	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor_srv *srv = model->user_data;
 	int err = 0;
 
 	NET_BUF_SIMPLE_DEFINE(buf, (CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX *


### PR DESCRIPTION
The model implementations sometimes use mod, sometimes model when
referring to struct bt_mesh_model pointers. Replaces all instances of
mod with model for consistency.
