### PR TITLE
cmake: multi image: escaping semicolon for shared vars

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -227,8 +227,10 @@ function(add_child_image_from_source)
   list(REMOVE_DUPLICATES SHARED_MULTI_IMAGE_VARIABLES)
   foreach(shared_var ${SHARED_MULTI_IMAGE_VARIABLES})
     if(DEFINED ${shared_var})
+      # Any  shared var that is a list must be escaped to ensure correct behaviour.
+      string(REPLACE \; \\\\\; val "${${shared_var}}")
       list(APPEND image_cmake_args
-        -D${shared_var}=${${shared_var}}
+        -D${shared_var}=${val}
         )
     endif()
   endforeach()


### PR DESCRIPTION
Shared vars from parent to child image was not having semicolons escaped
which resulted in wrong behaviour for vars that could be a list, such as
ZEPHYR_EXTRA_MODULES.

This is now fixed with proper escaping of semicolons.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>