### PR TITLE
manifest: Point to the latest homekit SHA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       path: modules/lib/cddl-gen
     - name: homekit
       repo-path: sdk-homekit
-      revision: pull/64/head
+      revision: 03a1a7de2828e5a132b51209a8bd5d5b788522c2
       groups:
       - homekit
 


### PR DESCRIPTION
When https://github.com/nrfconnect/sdk-nrf/pull/4139 was merged, it was
mistakenly pointing to a PR in the homekit repo. Fix this now with a
proper SHA reference.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>