### PR TITLE
bluetooth: mesh: CTL Temperature binding fix

### DIFF
--- a/subsys/bluetooth/mesh/model_utils.h
+++ b/subsys/bluetooth/mesh/model_utils.h
@@ -15,6 +15,12 @@
 #include <string.h>
 #include <bluetooth/mesh/model_types.h>
 
+/**
+ * @brief Returns rounded division of @p A divided by @p B.
+ * @note Arguments are evaluated twice.
+ */
+#define ROUNDED_DIV(A, B) (((A) + ((B) / 2)) / (B))
+
 /** @brief Send a model message.
  *
  * Sends a model message with the given context. If the context is NULL, this


### PR DESCRIPTION
CTL temperature bindings should use rounding
operation for division in the binding formula.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>