### PR TITLE
applications: asset_tracker_v2: Disable/enable ADXL362 trigger on events

### DIFF
--- a/applications/asset_tracker_v2/src/events/app_module_event.c
+++ b/applications/asset_tracker_v2/src/events/app_module_event.c
@@ -35,6 +35,10 @@ static char *get_evt_type_str(enum app_module_event_type type)
 		return "APP_EVT_DATA_GET";
 	case APP_EVT_CONFIG_GET:
 		return "APP_EVT_CONFIG_GET";
+	case APP_EVT_ACTIVITY_DETECTION_ENABLE:
+		return "APP_EVT_ACTIVITY_DETECTION_ENABLE";
+	case APP_EVT_ACTIVITY_DETECTION_DISABLE:
+		return "APP_EVT_ACTIVITY_DETECTION_DISABLE";
 	case APP_EVT_DATA_GET_ALL:
 		return "APP_EVT_DATA_GET_ALL";
 	case APP_EVT_START:

--- a/applications/asset_tracker_v2/src/events/app_module_event.h
+++ b/applications/asset_tracker_v2/src/events/app_module_event.h
@@ -22,7 +22,7 @@ extern "C" {
 /** @brief Application event types submitted by Application module. */
 enum app_module_event_type {
 	/** Signal that the application has done necessary setup, and
-	 * now started.
+	 *  now started.
 	 */
 	APP_EVT_START,
 
@@ -33,33 +33,43 @@ enum app_module_event_type {
 	APP_EVT_LTE_DISCONNECT,
 
 	/** Signal other modules to start sampling and report the data when
-	 * it's ready.
-	 * The event must also contain a list with requested data types,
-	 * @ref app_module_data_type.
+	 *  it's ready.
+	 *  The event must also contain a list with requested data types,
+	 *  @ref app_module_data_type.
 	 */
 	APP_EVT_DATA_GET,
 
 	/** Create a list with all available sensor types in the system and
-	 * distribute it as a APP_EVT_DATA_GET event.
+	 *  distribute it as a APP_EVT_DATA_GET event.
 	 */
 	APP_EVT_DATA_GET_ALL,
 
 	/** Request latest configuration from the cloud. */
 	APP_EVT_CONFIG_GET,
 
+	/** Application module is waiting for movement to trigger the next sample request. This
+	 *  event is used to signal the sensor module to enable activity detection.
+	 */
+	APP_EVT_ACTIVITY_DETECTION_ENABLE,
+
+	/** Application module does not depend on activity detection. This event is used to signal
+	 *  the sensor module to disable activity detection.
+	 */
+	APP_EVT_ACTIVITY_DETECTION_DISABLE,
+
 	/** The application module has performed all procedures to prepare for
-	 * a shutdown of the system.
+	 *  a shutdown of the system.
 	 */
 	APP_EVT_SHUTDOWN_READY,
 
 	/** An error has occurred in the application module. Error details are
-	 * attached in the event structure.
+	 *  attached in the event structure.
 	 */
 	APP_EVT_ERROR
 };
 
 /** @brief Data types that the application module requests samples for in
- * @ref app_module_event_type APP_EVT_DATA_GET.
+ *	   @ref app_module_event_type APP_EVT_DATA_GET.
  */
 enum app_module_data_type {
 	APP_DATA_ENVIRONMENTAL,
@@ -85,7 +95,7 @@ struct app_module_event {
 	size_t count;
 
 	/** The time each module has to fetch data before what is available
-	 * is transmitted.
+	 *  is transmitted.
 	 */
 	int timeout;
 };

--- a/applications/asset_tracker_v2/src/ext_sensors/Kconfig
+++ b/applications/asset_tracker_v2/src/ext_sensors/Kconfig
@@ -9,6 +9,13 @@ menuconfig EXTERNAL_SENSORS
 
 if EXTERNAL_SENSORS
 
+config EXTERNAL_SENSORS_ACTIVITY_DETECTION_AUTO
+	bool "Start activity detection automatically"
+	help
+	  Enable this option to start activity detection when the library is initialized.
+	  If the option is disabled, the accelerometer trigger handler must manually be enabled to
+	  detect activity.
+
 module = EXTERNAL_SENSORS
 module-str = External sensors
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.h
+++ b/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.h
@@ -87,6 +87,15 @@ int ext_sensors_humidity_get(double *humid);
  */
 int ext_sensors_mov_thres_set(double threshold_new);
 
+/**
+ * @brief Enable or disable accelerometer trigger handler.
+ *
+ * @param[in] enable Flag that enables or disables callback triggers from the accelerometer.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int ext_sensors_accelerometer_trigger_callback_set(bool enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -1023,11 +1023,6 @@ static void on_all_states(struct data_msg_data *msg)
 	}
 
 	if (IS_EVENT(msg, sensor, SENSOR_EVT_MOVEMENT_DATA_READY)) {
-		if (current_cfg.active_mode) {
-			/* Do not store movement data in active mode. */
-			return;
-		}
-
 		struct cloud_data_accelerometer new_movement_data = {
 			.values[0] = msg->module.sensor.data.accel.values[0],
 			.values[1] = msg->module.sensor.data.accel.values[1],


### PR DESCRIPTION
This patch adds events to the application module that lets it decide
when it wants movement to trigger the next sample request.

Prior to this patch the accelerometer ringbuffer in the data module
would get saturated with accelerometer data from the sensor module
after the initial movement trigger. If the device was under constant
movement over the set threshold each cloud update would include
multiple instances of accelerometer data in the batch data update.

Changes included in this patch:
- Add function to external sensors API to enable/disable callbacks
  from ADXL362 driver.
- Add configurable option to decide if callbacks from the ADXL362 driver
  should be enabled during initialization of external sensor API.
- Add events to application module that signals the sensor module when
  it wants movement to trigger the next sample request.

Closes CIA-231 and CIA-278