### PR TITLE
mpsl: Allow application to specify MPSL assert handler.

### DIFF
--- a/doc/nrf/libraries/lib_mpsl.rst
+++ b/doc/nrf/libraries/lib_mpsl.rst
@@ -1,0 +1,11 @@
+.. _lib_mpsl_libraries:
+
+Multiprotocol Service Layer libraries
+#####################################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subpages:
+   :glob:
+
+   ../../include/mpsl/*

--- a/include/mpsl/mpsl_assert.h
+++ b/include/mpsl/mpsl_assert.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file mpsl_assert.h
+ *
+ * @defgroup mpsl_assert Multiprotocol Service Layer assert
+ *
+ * @brief MPSL assert
+ * @{
+ */
+
+#ifndef MPSL_ASSERT__
+#define MPSL_ASSERT__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Application-defined sink for the MPSL assertion mechanism.
+ *
+ * @param file  The file name where the assertion occurred.
+ * @param line  The line number where the assertion occurred.
+ */
+void mpsl_assert_handle(char *file, uint32_t line);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MPSL_ASSERT__ */
+
+/**@} */

--- a/include/mpsl/mpsl_assert.rst
+++ b/include/mpsl/mpsl_assert.rst
@@ -1,0 +1,24 @@
+.. _mpsl_assert:
+
+Multiprotocol Service Layer assert
+##################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Multiprotocol Service Layer assert library makes it possible to add a custom assert handler to the :ref:`nrfxlib:mpsl` library.
+You can then use this assert handler to print custom error messages or log assert information.
+
+:option:`CONFIG_MPSL_ASSERT_HANDLER` enables the custom assert handler.
+If enabled, the application must provide the definition of :c:func:`mpsl_assert_handle`.
+The :c:func:`mpsl_assert_handle` function is invoked whenever the MPSL code encounters an unrecoverable error.
+
+API documentation
+*****************
+
+| Header file: :file:`include/mpsl/mpsl_assert.h`
+
+.. doxygengroup:: mpsl_assert
+   :project: nrf
+   :members:

--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -25,6 +25,14 @@ config MPSL_TIMESLOT_SESSION_COUNT
 	help
 	  Maximum number of timeslot sessions.
 
+config MPSL_ASSERT_HANDLER
+	bool "Application defined assertion handler"
+	help
+	  This option enables an application-defined sink for the
+	  MPSL assertion mechanism. This must be defined in
+	  application code and will be invoked whenever the
+	  MPSL code encounters an unrecoverable error.
+
 rsource "Kconfig.fem"
 
 module=MPSL

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -11,6 +11,7 @@
 #include <sys/__assert.h>
 #include <mpsl.h>
 #include <mpsl_timeslot.h>
+#include <mpsl/mpsl_assert.h>
 #include "mpsl_fem_internal.h"
 #include "multithreading_lock.h"
 #if defined(CONFIG_NRFX_DPPI)
@@ -110,11 +111,19 @@ ISR_DIRECT_DECLARE(mpsl_radio_isr_wrapper)
 	return 1;
 }
 
+#if IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER)
+void m_assert_handler(const char *const file, const uint32_t line)
+{
+	mpsl_assert_handle((char *) file, line);
+}
+
+#else /* !IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER) */
 static void m_assert_handler(const char *const file, const uint32_t line)
 {
 	LOG_ERR("MPSL ASSERT: %s, %d", log_strdup(file), line);
 	k_oops();
 }
+#endif /* IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER) */
 
 static uint8_t m_config_clock_source_get(void)
 {


### PR DESCRIPTION
Add Kconfig option to enable application level MPSL assert handler.
Update MPSL driver to redirect asserts to application handler.

Signed-off-by: Nikita Fomin <nikita.fomin@nordicsemi.no>