### PR TITLE
LTE link control: Add API for active LTE mode

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -53,6 +53,17 @@ enum lte_lc_system_mode {
 	LTE_LC_SYSTEM_MODE_LTEM_NBIOT_GPS,
 };
 
+/** LTE mode. Used to indicate which LTE mode is currently active if more than
+ *  one mode is enabled in the system mode configuration.
+ *  The values for LTE-M and NB-IoT correspond to the values for the AcT field
+ *  in a AT+CEREG response.
+ */
+enum lte_lc_lte_mode {
+	LTE_LC_LTE_MODE_NONE	= 0,
+	LTE_LC_LTE_MODE_LTEM	= 7,
+	LTE_LC_LTE_MODE_NBIOT	= 9,
+};
+
 /** LTE mode preference. If more than one LTE system mode is enabled, the modem
  *  can select the mode that best meets the criteria set by this configuration.
  *  The LTE mode preference does not affect the way GPS operates.
@@ -109,6 +120,14 @@ enum lte_lc_evt_type {
 	LTE_LC_EVT_EDRX_UPDATE,
 	LTE_LC_EVT_RRC_UPDATE,
 	LTE_LC_EVT_CELL_UPDATE,
+
+	/** The currently active LTE mode is updated. If a system mode that
+	 *  enables both LTE-M and NB-IoT is configured, the modem may change
+	 *  the currently active LTE mdode based on the system mode preference
+	 *  and network availability. This event will then indicate which
+	 *  LTE mode is currently used by the modem.
+	 */
+	LTE_LC_EVT_LTE_MODE_UPDATE,
 };
 
 enum lte_lc_rrc_mode {
@@ -139,6 +158,7 @@ struct lte_lc_evt {
 		struct lte_lc_psm_cfg psm_cfg;
 		struct lte_lc_edrx_cfg edrx_cfg;
 		struct lte_lc_cell cell;
+		enum lte_lc_lte_mode lte_mode;
 	};
 };
 
@@ -403,6 +423,14 @@ int lte_lc_system_mode_get(enum lte_lc_system_mode *mode,
  * @return Zero on success or (negative) error code otherwise.
  */
 int lte_lc_func_mode_get(enum lte_lc_func_mode *mode);
+
+/**@brief Get the currently active LTE mode.
+ *
+ * @param mode Pointer to LTE mode variable.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_lte_mode_get(enum lte_lc_lte_mode *mode);
 
 /** @} */
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -123,7 +123,7 @@ enum lte_lc_evt_type {
 
 	/** The currently active LTE mode is updated. If a system mode that
 	 *  enables both LTE-M and NB-IoT is configured, the modem may change
-	 *  the currently active LTE mdode based on the system mode preference
+	 *  the currently active LTE mode based on the system mode preference
 	 *  and network availability. This event will then indicate which
 	 *  LTE mode is currently used by the modem.
 	 */

--- a/samples/nrf9160/cloud_client/src/main.c
+++ b/samples/nrf9160/cloud_client/src/main.c
@@ -192,6 +192,13 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		LOG_DBG("LTE cell changed: Cell ID: %d, Tracking area: %d",
 			evt->cell.id, evt->cell.tac);
 		break;
+	case LTE_LC_EVT_LTE_MODE_UPDATE:
+		LOG_INF("Active LTE mode changed: %s",
+			evt->lte_mode == LTE_LC_LTE_MODE_NONE ? "None" :
+			evt->lte_mode == LTE_LC_LTE_MODE_LTEM ? "LTE-M" :
+			evt->lte_mode == LTE_LC_LTE_MODE_NBIOT ? "NB-IoT" :
+			"Unknown");
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
lib: lte_lc: Add API and event to get current LTE mode

- Introduce enum for LTE mode.

- Add API to get the currently active LTE mode. If more than one
  LTE mode is enabled in the system mode configuration, this API
  can be used to know which of LTE-M and NB-IoT is currently being used
  by the modem.

- Change CEREG parsing function to handle both notifications and reads.
  Also allow to retrieve a subset of the information available in a
  CEREG message.

---

lib: lte_lc: Fix LTE preference handling 

In some cases, the LTE preference set by Kconfig could be
overwritten by the value read back from the modem during
initialization of the link controller.
This patch introduces the same scheme for handling LTE preference
as the one used to handle system mode.

---

samples: nrf9160: cloud_client: Print when LTE mode changes 

Add printing of event information when LTE mode changes.