### PR TITLE
manifest: Point to nrfxlib with nrf_cc3xx version 0.9.8

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 94c8d83811286e5505750a0554b9b2cd2df4ca6c
+      revision: pull/443/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-Adding version 0.9.8 of the cryptocell runtime library

Nrfxlib PR [link](https://github.com/nrfconnect/sdk-nrfxlib/pull/443)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>