### PR TITLE
applications: asset_tracker_v2: Add Kconfigs to optionally store data.

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec_ringbuffer.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec_ringbuffer.c
@@ -19,6 +19,10 @@ void cloud_codec_populate_sensor_buffer(
 				int *head_sensor_buf,
 				size_t buffer_count)
 {
+	if (!IS_ENABLED(CONFIG_DATA_SENSOR_BUFFER_STORE)) {
+		return;
+	}
+
 	if (!new_sensor_data->queued) {
 		return;
 	}
@@ -40,6 +44,10 @@ void cloud_codec_populate_ui_buffer(struct cloud_data_ui *ui_buffer,
 				   int *head_ui_buf,
 				   size_t buffer_count)
 {
+	if (!IS_ENABLED(CONFIG_DATA_UI_BUFFER_STORE)) {
+		return;
+	}
+
 	if (!new_ui_data->queued) {
 		return;
 	}
@@ -62,6 +70,10 @@ void cloud_codec_populate_accel_buffer(
 				int *head_mov_buf,
 				size_t buffer_count)
 {
+	if (!IS_ENABLED(CONFIG_DATA_ACCELEROMETER_BUFFER_STORE)) {
+		return;
+	}
+
 	if (!new_accel_data->queued) {
 		return;
 	}
@@ -83,6 +95,10 @@ void cloud_codec_populate_bat_buffer(struct cloud_data_battery *bat_buffer,
 				     int *head_bat_buf,
 				     size_t buffer_count)
 {
+	if (!IS_ENABLED(CONFIG_DATA_BATTERY_BUFFER_STORE)) {
+		return;
+	}
+
 	if (!new_bat_data->queued) {
 		return;
 	}
@@ -104,6 +120,10 @@ void cloud_codec_populate_gps_buffer(struct cloud_data_gps *gps_buffer,
 				    int *head_gps_buf,
 				    size_t buffer_count)
 {
+	if (!IS_ENABLED(CONFIG_DATA_GPS_BUFFER_STORE)) {
+		return;
+	}
+
 	if (!new_gps_data->queued) {
 		return;
 	}
@@ -126,6 +146,10 @@ void cloud_codec_populate_modem_dynamic_buffer(
 				int *head_modem_buf,
 				size_t buffer_count)
 {
+	if (!IS_ENABLED(CONFIG_DATA_DYNAMIC_MODEM_BUFFER_STORE)) {
+		return;
+	}
+
 	if (!new_modem_data->queued) {
 		return;
 	}

--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -31,28 +31,28 @@ config DATA_THREAD_STACK_SIZE
 	int "Data module thread stack size"
 	default 2560
 
-config GPS_BUFFER_MAX
-	int "GPS data ringbuffer entries"
+config DATA_GPS_BUFFER_COUNT
+	int "Number of GPS data ringbuffer entries"
 	default 10
 
-config SENSOR_BUFFER_MAX
-	int "Sensor data ringbuffer entries"
+config DATA_SENSOR_BUFFER_COUNT
+	int "Number of sensor data ringbuffer entries"
 	default 10
 
-config MODEM_BUFFER_DYNAMIC_MAX
-	int "Dynamic modem data ringbuffer entries"
+config DATA_MODEM_DYNAMIC_BUFFER_COUNT
+	int "Number of dynamic modem data ringbuffer entries"
 	default 3
 
-config UI_BUFFER_MAX
-	int "UI data ringbuffer entries"
+config DATA_UI_BUFFER_COUNT
+	int "Number of UI data ringbuffer entries"
 	default 3
 
-config ACCEL_BUFFER_MAX
-	int "Accelerometer data ringbuffer entries"
+config DATA_ACCELEROMETER_BUFFER_COUNT
+	int "Number of accelerometer data ringbuffer entries"
 	default 3
 
-config BAT_BUFFER_MAX
-	int "Battery data ringbuffer entries"
+config DATA_BATTERY_BUFFER_COUNT
+	int "Number of battery data ringbuffer entries"
 	default 3
 
 endif # DATA_MODULE

--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -33,27 +33,66 @@ config DATA_THREAD_STACK_SIZE
 
 config DATA_GPS_BUFFER_COUNT
 	int "Number of GPS data ringbuffer entries"
+	range 1 100
 	default 10
+	help
+	  Currently, the range for ringbuffer entries is limited to a minimum of 1 and a
+	  maximum of 100. A minimum of 1 is set to make sure that the application builds with the
+	  current implementation of the data module. The buffers are essentially arrays of a
+	  certain data type and arrays cannot be compiled with a count of 0.
+	  The Kconfig range statement requires that a maximum value is also set.
+	  The maximum value of 100 is an arbitrary number that can be increased if desired.
+	  Note that when increasing the maximum count of a buffer there is no guarantee beyond
+	  using the default values that there is enough heap memory to successfully encode
+	  enqueued entries into a JSON object string.
 
 config DATA_SENSOR_BUFFER_COUNT
 	int "Number of sensor data ringbuffer entries"
+	range 1 100
 	default 10
 
 config DATA_MODEM_DYNAMIC_BUFFER_COUNT
 	int "Number of dynamic modem data ringbuffer entries"
+	range 1 100
 	default 3
 
 config DATA_UI_BUFFER_COUNT
 	int "Number of UI data ringbuffer entries"
+	range 1 100
 	default 3
 
 config DATA_ACCELEROMETER_BUFFER_COUNT
 	int "Number of accelerometer data ringbuffer entries"
+	range 1 100
 	default 3
 
 config DATA_BATTERY_BUFFER_COUNT
 	int "Number of battery data ringbuffer entries"
+	range 1 100
 	default 3
+
+config DATA_GPS_BUFFER_STORE
+	bool "Store GPS data received from the GPS module"
+	default y
+
+config DATA_SENSOR_BUFFER_STORE
+	bool "Store environmental sensor data received from the sensor module"
+	default y
+
+config DATA_ACCELEROMETER_BUFFER_STORE
+	bool "Store accelerometer data received from the sensor module"
+
+config DATA_DYNAMIC_MODEM_BUFFER_STORE
+	bool "Store dynamic modem data received from the modem module"
+	default y
+
+config DATA_BATTERY_BUFFER_STORE
+	bool "Store battery data received from the modem module"
+	default y
+
+config DATA_UI_MODEM_BUFFER_STORE
+	bool "Store UI data received from the UI module"
+	default y
 
 endif # DATA_MODULE
 

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -66,14 +66,12 @@ static enum state_type {
  * Upon a LTE connection loss the device will keep sampling/storing data in
  * the buffers, and empty the buffers in batches upon a reconnect.
  */
-static struct cloud_data_gps gps_buf[CONFIG_GPS_BUFFER_MAX];
-static struct cloud_data_sensors sensors_buf[CONFIG_SENSOR_BUFFER_MAX];
-static struct cloud_data_ui ui_buf[CONFIG_UI_BUFFER_MAX];
-static struct cloud_data_accelerometer accel_buf[CONFIG_ACCEL_BUFFER_MAX];
-static struct cloud_data_battery bat_buf[CONFIG_BAT_BUFFER_MAX];
-
-static struct cloud_data_modem_dynamic
-			modem_dyn_buf[CONFIG_MODEM_BUFFER_DYNAMIC_MAX];
+static struct cloud_data_gps gps_buf[CONFIG_DATA_GPS_BUFFER_COUNT];
+static struct cloud_data_sensors sensors_buf[CONFIG_DATA_SENSOR_BUFFER_COUNT];
+static struct cloud_data_ui ui_buf[CONFIG_DATA_UI_BUFFER_COUNT];
+static struct cloud_data_accelerometer accel_buf[CONFIG_DATA_ACCELEROMETER_BUFFER_COUNT];
+static struct cloud_data_battery bat_buf[CONFIG_DATA_BATTERY_BUFFER_COUNT];
+static struct cloud_data_modem_dynamic modem_dyn_buf[CONFIG_DATA_MODEM_DYNAMIC_BUFFER_COUNT];
 
 /* Static modem data does not change between firmware versions and does not
  * have to be buffered.


### PR DESCRIPTION
Add options that decide if data of the respective cloud data type
received from other modules should be stored to its respective
ringbuffer.

Disable storage of accelerometer data by default. The data that we
get from the accelerometer does not currently provide any value to the
end-user and should be removed for the time being. This is done for
power and data saving purposes.

There are plans to improve the way data from the accelerometer is
handled in the firmware and at that point storage of accelerometer data
will be reinstated in a different form than just single sample XYZ
coordinates.

Closes CIA-281