### PR TITLE
doc: zigbee: changes for NCS v1.5.1

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -11,12 +11,10 @@ Changes in |NCS| v1.4.99
 
 The most relevant changes that are present on the master branch of the |NCS|, as compared to the latest release, are tracked in this file.
 
-
-
 Highlights
 **********
 
-
+* Updated ZBOSS Zigbee stack to version 3_3_0_7+03_22_2021.
 
 Changelog
 *********
@@ -26,7 +24,13 @@ The following sections provide detailed lists of changes by component.
 nRF5
 ====
 
+Zigbee
+------
 
+* Updated:
+
+  * ZBOSS Zigbee stack to version 3_3_0_7+03_22_2021.
+    See :ref:`zboss_configuration` for detailed information.
 
 nRF9160
 =======


### PR DESCRIPTION
Added v1.5.1 release notes file with an entry for Zigbee.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>