### PR TITLE
ci: pip: Pillow==8.1.1 and Jinja2==2.11.3

### DIFF
--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -42,12 +42,12 @@ iniconfig==1.1.1
 intelhex==2.3.0
 intervaltree==3.1.0
 isort==5.7.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 junit2html==30.0.4
 junitparser==1.6.3
 lazy-object-proxy==1.4.3
 lpc-checksum==2.2.0
-lxml==4.6.2
+lxml==4.6.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
 milksnake==0.1.5
@@ -56,7 +56,7 @@ mypy==0.800
 mypy-extensions==0.4.3
 naturalsort==1.5.1
 packaging==20.8
-Pillow==8.1.0
+Pillow==8.1.2
 pluggy==0.13.1
 ply==3.11
 prettytable==2.0.0
@@ -103,7 +103,7 @@ tabulate==0.8.7
 toml==0.10.2
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
-urllib3==1.26.3
+urllib3==1.26.4
 wcwidth==0.2.5
 west==0.10.0
 wrapt==1.12.1


### PR DESCRIPTION
in scripts/requirements-fixed.txt
recommended by Github dependebot alerts
* https://github.com/nrfconnect/sdk-nrf/security/dependabot/scripts/requirements-fixed.txt/Pillow/closed
* https://github.com/nrfconnect/sdk-nrf/security/dependabot/scripts/requirements-fixed.txt/jinja2/closed
* https://github.com/nrfconnect/sdk-nrf/security/dependabot/scripts/requirements-fixed.txt/urllib3/closed
* https://github.com/nrfconnect/sdk-nrf/security/dependabot/scripts/requirements-fixed.txt/lxml/closed

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>