### PR TITLE
softdevice_controller: Update library selection

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -831,6 +831,14 @@ SoftDevice Controller
 
 .. rst-class:: v1-5-0
 
+DRGN-15475: Samples might not initialize the SoftDevice Controller HCI driver correctly
+  Samples using both the advertising and the scanning state, but not the connected state, fail to initialize the SoftDevice Controller HCI driver.
+  As a result, the function :c:func:`bt_enable()` returns an error code.
+
+  **Workaround:** Manually enable :option:`CONFIG_SOFTDEVICE_CONTROLLER_MULTIROLE` for the project configuration.
+
+.. rst-class:: v1-5-0
+
 DRGN-15382: The SoftDevice Controller cannot be qualified on nRF52832
   The SoftDevice Controller cannot be qualified on nRF52832.
 

--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ff8f407384afb230a73a102303683377bd7fc0d9
+      revision: 138cfa3984d0a63c2da2fd40bf122e258ccc051a
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Fixes an issue where the sample zephyr/samples/bluetooth/adv_scan
failed to initialize the Bluetooth driver.
