### PR TITLE
lib: edge_impulse: Add "waiting for data" state

### DIFF
--- a/include/ei_wrapper.h
+++ b/include/ei_wrapper.h
@@ -73,6 +73,10 @@ int ei_wrapper_add_data(const float *data, size_t data_size);
 
 /** Clear all buffered data.
  *
+ * The buffer cannot be cleared if the prediction was already started and the
+ * wrapper is not waiting for data. In that case, user must wait until the
+ * prediction is finished.
+ *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */


### PR DESCRIPTION
The prediction can still be cancelled if the wrapper is waiting for data. That could be more convenient for user.

Jira: NCSDK-8456