### PR TITLE
drivers: hw_cc310: demote menuconfig w/o children

### DIFF
--- a/drivers/hw_cc310/Kconfig
+++ b/drivers/hw_cc310/Kconfig
@@ -19,7 +19,7 @@ config HW_CC3XX_FORCE_ALT
 
 if !HW_CC3XX_FORCE_ALT
 
-menuconfig HW_CC3XX
+config HW_CC3XX
 	bool "Arm CC3xx hw driver for Nordic devices"
 	depends on HAS_HW_NRF_CC310 || HAS_HW_NRF_CC312
 	depends on !TRUSTED_EXECUTION_NONSECURE


### PR DESCRIPTION
This commit addresses a compliance issue highlighted by
'zephyr/scripts/ci/check_compliance.py'.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>