### PR TITLE
application: asset_tracker_v2: Add function to filter duplicate messages

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/json_protocol_names.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/json_protocol_names.h
@@ -34,6 +34,7 @@
 #define DATA_ENVIRONMENTALS	"env"
 #define DATA_BUTTON		"btn"
 #define DATA_CONFIG		"cfg"
+#define DATA_VERSION		"version"
 
 #define DATA_MOVEMENT		"acc"
 #define DATA_MOVEMENT_X		"x"

--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -234,7 +234,6 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 		 * before it is sent to the Data module. This way we avoid
 		 * sending uninitialized variables to the Data module.
 		 */
-
 		err = cloud_codec_decode_config(evt->data.buf, &copy_cfg);
 		if (err == 0) {
 			LOG_DBG("Device configuration encoded");
@@ -243,9 +242,10 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 		} else if (err == -ENODATA) {
 			LOG_WRN("Device configuration empty!");
 			SEND_EVENT(cloud, CLOUD_EVT_CONFIG_EMPTY);
+		} else if (err == -ECANCELED) {
+			/* Incoming message already handled, ignored. */
 		} else {
-			LOG_ERR("Decoding of device configuration, error: %d",
-				err);
+			LOG_ERR("Decoding of device configuration, error: %d", err);
 			SEND_ERROR(cloud, CLOUD_EVT_ERROR, err);
 			break;
 		}


### PR DESCRIPTION
Add function that keeps track of the version number of incoming
message from the AWS IoT broker. If a message has already been handled
by the application, it is ignored.

Messages from the AWS IoT shadow contain a version number that
increments for each new message published to the device.

Closes CIA-288

**Note**
An alternative would be to handle this at MQTT level, filtering packets
based on the MQTT packet ID and take advantage of the MQTT duplicate
flag set for messages that are in fact duplicates of the original
message. However, AWS IoT does not support the MQTT duplicate flag and
will actually reuse packet IDs for MQTT PUBLISH messages once they have been
ACKed.

This essentially means that filtering based on the last received packet
ID wont work. Because there is a probability that two *new* packets
received in succession have the same packet ID.