### PR TITLE
drivers: entropy_cc310: Initialize at PRE_KERNEL_1

### DIFF
--- a/drivers/entropy/entropy_cc310.c
+++ b/drivers/entropy/entropy_cc310.c
@@ -103,5 +103,5 @@ static const struct entropy_driver_api entropy_cc3xx_rng_api = {
 #endif
 
 DEVICE_DT_DEFINE(CRYPTOCELL_NODE_ID, entropy_cc3xx_rng_init,
-		 device_pm_control_nop, NULL, NULL, PRE_KERNEL_2,
+		 device_pm_control_nop, NULL, NULL, PRE_KERNEL_1,
 		 CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &entropy_cc3xx_rng_api);

--- a/drivers/hw_cc310/hw_cc310.c
+++ b/drivers/hw_cc310/hw_cc310.c
@@ -49,7 +49,7 @@ static int hw_cc3xx_init(const struct device *dev)
 }
 
 /* Driver initalization done when mutex is not usable (pre kernel) */
-SYS_INIT(hw_cc3xx_init_internal, PRE_KERNEL_2,
+SYS_INIT(hw_cc3xx_init_internal, PRE_KERNEL_1,
 	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 /* Driver initialization when mutex is usable (post kernel) */


### PR DESCRIPTION
This is a follow-up to commit 9e2ac5bafb9602d135f152fb298bf88bf8bd9cee.

Initialize the driver at the PRE_KERNEL_1 level, like Zephyr in-tree
entropy drivers, so that other modules that need an entropy driver can
initialize at PRE_KERNEL_2 (see e.g. rand32_xoroshiro128).

Ref: NCSIDB-420

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>