### PR TITLE
mpsl: Remove obsolete DPPI allocation check

### DIFF
--- a/subsys/mpsl/Kconfig.fem
+++ b/subsys/mpsl/Kconfig.fem
@@ -34,6 +34,7 @@ choice MPSL_FEM_CHOICE
 config MPSL_FEM_NRF21540_GPIO
 	depends on MPSL_FEM_NRF21540_GPIO_SUPPORT
 	select NRFX_GPIOTE
+	select NRFX_PPI
 	bool "nRF21540 front-end module in GPIO mode"
 	help
 	  FEM device is nRF21540 and its control mode is GPIO.
@@ -42,6 +43,7 @@ config MPSL_FEM_NRF21540_GPIO
 config MPSL_FEM_SIMPLE_GPIO
 	depends on MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT
 	select NRFX_GPIOTE
+	select NRFX_PPI
 	bool "Generic front-end module with two-pin control"
 	help
 	  FEM device has a generic two-pin control interface.

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -149,26 +149,6 @@ static int mpsl_lib_init(const struct device *dev)
 	int err = 0;
 	mpsl_clock_lfclk_cfg_t clock_cfg;
 
-#if !defined(CONFIG_BT_CTLR) && defined(CONFIG_NRFX_DPPI)
-	/* When the Bluetooth controller is used, it will include the DPPI
-	 * channels that MPSL uses in the mask that it provides for nrfx.
-	 * Otherwise, if additionaly the nrfx DPPI allocator is used (what
-	 * indicates that some other module will use some DPPI channels),
-	 * those channels needed by MPSL must be reserved in some other way.
-	 * Currently it is not possible to do it in nrfx_glue.h, so the below
-	 * code is used as a temporarily workaround.
-	 * Unfortunatelly, for PPI a similar workaround cannot be used.
-	 */
-	uint8_t channel;
-	nrfx_err_t err_code;
-	err_code = nrfx_dppi_channel_alloc(&channel);
-	__ASSERT_NO_MSG(err_code == NRFX_SUCCESS && channel == 0);
-	err_code = nrfx_dppi_channel_alloc(&channel);
-	__ASSERT_NO_MSG(err_code == NRFX_SUCCESS && channel == 1);
-	err_code = nrfx_dppi_channel_alloc(&channel);
-	__ASSERT_NO_MSG(err_code == NRFX_SUCCESS && channel == 2);
-#endif
-
 	clock_cfg.source = m_config_clock_source_get();
 	clock_cfg.accuracy_ppm = CONFIG_CLOCK_CONTROL_NRF_ACCURACY;
 	clock_cfg.skip_wait_lfclk_started =


### PR DESCRIPTION
Remove the obsolete DPPI allocation check, which is now replaced
by the proper nrfx_glue.h channel assignment.

Signed-off-by: Czeslaw Makarski <Czeslaw.Makarski@nordicsemi.no>