### PR TITLE
applications: asset_tracker_v2: Improve module shutdown handling

### DIFF
--- a/applications/asset_tracker_v2/src/events/app_module_event.h
+++ b/applications/asset_tracker_v2/src/events/app_module_event.h
@@ -90,6 +90,8 @@ struct app_module_event {
 
 	union {
 		int err;
+		/* Module ID, used when acknowledging shutdown requests. */
+		uint32_t id;
 	} data;
 
 	size_t count;

--- a/applications/asset_tracker_v2/src/events/cloud_module_event.h
+++ b/applications/asset_tracker_v2/src/events/cloud_module_event.h
@@ -54,6 +54,8 @@ struct cloud_module_event {
 	union {
 		struct cloud_data_cfg config;
 		struct cloud_module_data_ack ack;
+		/* Module ID, used when acknowledging shutdown requests. */
+		uint32_t id;
 		int err;
 	} data;
 };

--- a/applications/asset_tracker_v2/src/events/data_module_event.h
+++ b/applications/asset_tracker_v2/src/events/data_module_event.h
@@ -51,6 +51,8 @@ struct data_module_event {
 		struct data_module_data_buffers buffer;
 		struct cloud_data_cfg cfg;
 		struct cloud_data_ui ui;
+		/* Module ID, used when acknowledging shutdown requests. */
+		uint32_t id;
 		int err;
 	} data;
 };

--- a/applications/asset_tracker_v2/src/events/gps_module_event.h
+++ b/applications/asset_tracker_v2/src/events/gps_module_event.h
@@ -50,6 +50,8 @@ struct gps_module_event {
 	union {
 		struct gps_module_data gps;
 		struct gps_agps_request agps_request;
+		/* Module ID, used when acknowledging shutdown requests. */
+		uint32_t id;
 		int err;
 	} data;
 };

--- a/applications/asset_tracker_v2/src/events/modem_module_event.h
+++ b/applications/asset_tracker_v2/src/events/modem_module_event.h
@@ -107,6 +107,8 @@ struct modem_module_event {
 		struct modem_module_cell cell;
 		struct modem_module_psm psm;
 		struct modem_module_edrx edrx;
+		/* Module ID, used when acknowledging shutdown requests. */
+		uint32_t id;
 		int err;
 	} data;
 };

--- a/applications/asset_tracker_v2/src/events/sensor_module_event.h
+++ b/applications/asset_tracker_v2/src/events/sensor_module_event.h
@@ -48,6 +48,8 @@ struct sensor_module_event {
 	union {
 		struct sensor_module_data sensors;
 		struct sensor_module_accel_data accel;
+		/* Module ID, used when acknowledging shutdown requests. */
+		uint32_t id;
 		int err;
 	} data;
 };

--- a/applications/asset_tracker_v2/src/events/ui_module_event.h
+++ b/applications/asset_tracker_v2/src/events/ui_module_event.h
@@ -38,6 +38,8 @@ struct ui_module_event {
 
 	union {
 		struct ui_module_data ui;
+		/* Module ID, used when acknowledging shutdown requests. */
+		uint32_t id;
 		int err;
 	} data;
 };

--- a/applications/asset_tracker_v2/src/modules/gps_module.c
+++ b/applications/asset_tracker_v2/src/modules/gps_module.c
@@ -62,6 +62,7 @@ static struct gps_config gps_cfg = {
 static struct module_data self = {
 	.name = "gps",
 	.msg_q = NULL,
+	.supports_shutdown = true,
 };
 
 /* Forward declarations. */
@@ -370,7 +371,12 @@ static void on_all_states(struct gps_msg_data *msg)
 	if (IS_EVENT(msg, app, APP_EVT_START)) {
 		int err;
 
-		module_start(&self);
+		err = module_start(&self);
+		if (err) {
+			LOG_ERR("Failed starting module, error: %d", err);
+			SEND_ERROR(gps, GPS_EVT_ERROR, err);
+		}
+
 		state_set(STATE_INIT);
 
 		err = setup();
@@ -384,7 +390,7 @@ static void on_all_states(struct gps_msg_data *msg)
 		/* The module doesn't have anything to shut down and can
 		 * report back immediately.
 		 */
-		SEND_EVENT(gps, GPS_EVT_SHUTDOWN_READY);
+		SEND_SHUTDOWN_ACK(gps, GPS_EVT_SHUTDOWN_READY, self.id);
 		state_set(STATE_SHUTDOWN);
 	}
 }

--- a/applications/asset_tracker_v2/src/modules/modules_common.c
+++ b/applications/asset_tracker_v2/src/modules/modules_common.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr.h>
+#include <zephyr/types.h>
 #include <event_manager.h>
 #include "modules_common.h"
 
@@ -17,8 +18,19 @@ struct event_prototype {
 	uint8_t event_id;
 };
 
-static atomic_t active_module_count;
+/* List containing metadata on active modules in the application. */
+static sys_slist_t module_list = SYS_SLIST_STATIC_INIT(&module_list);
+static K_MUTEX_DEFINE(module_list_lock);
 
+/* Structure containing general information about the modules in the application. */
+static struct modules_info {
+	/* Modules that support shutdown. */
+	atomic_t shutdown_supported_count;
+	/* Number of active modules in the application. */
+	atomic_t active_modules_count;
+} modules_info;
+
+/* Public interface */
 void module_purge_queue(struct module_data *module)
 {
 	k_msgq_purge(module->msg_q);
@@ -81,18 +93,80 @@ int module_enqueue_msg(struct module_data *module, void *msg)
 	return 0;
 }
 
-void module_start(struct module_data *module)
+bool modules_shutdown_register(uint32_t id_reg)
 {
-	atomic_inc(&active_module_count);
+	bool retval = false;
+	struct module_data *module, *next_module = NULL;
 
-	if (module->name) {
-		LOG_DBG("Module \"%s\" started", module->name);
-	} else if (module->thread_id) {
-		LOG_DBG("Module with thread ID %p started", module->thread_id);
+	if (id_reg == 0) {
+		LOG_WRN("Passed in module ID cannot be 0");
+		return false;
 	}
+
+	k_mutex_lock(&module_list_lock, K_FOREVER);
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&module_list, module, next_module, header) {
+		if (module->id == id_reg) {
+			if (module->supports_shutdown) {
+				/* A module shutdown has been registered. Decrease the number of
+				 * active modules in the application and delete the list entry for
+				 * the corresponding module.
+				 */
+				sys_slist_find_and_remove(&module_list, &module->header);
+				atomic_dec(&modules_info.active_modules_count);
+				atomic_dec(&modules_info.shutdown_supported_count);
+
+				LOG_WRN("Module \"%s\" shutdown registered", module->name);
+			} else {
+				goto exit;
+			}
+			break;
+		}
+	};
+
+	if (modules_info.shutdown_supported_count == 0) {
+		/* All modules in the application have reported a shutdown. */
+		retval = true;
+	}
+
+exit:
+	k_mutex_unlock(&module_list_lock);
+	return retval;
+}
+
+int module_start(struct module_data *module)
+{
+	if (module == NULL) {
+		LOG_ERR("Module metadata is NULL");
+		return -EINVAL;
+	}
+
+	if (module->name == NULL) {
+		LOG_ERR("Module name is NULL");
+		return -EINVAL;
+	}
+
+	module->id = k_cycle_get_32();
+	atomic_inc(&modules_info.active_modules_count);
+
+	if (module->supports_shutdown) {
+		atomic_inc(&modules_info.shutdown_supported_count);
+	}
+
+	/* Append passed in module metadata to linked list. */
+	k_mutex_lock(&module_list_lock, K_FOREVER);
+	sys_slist_append(&module_list, &module->header);
+	k_mutex_unlock(&module_list_lock);
+
+	if (module->thread_id) {
+		LOG_DBG("Module \"%s\" with thread ID %p started", module->name, module->thread_id);
+	} else {
+		LOG_DBG("Module \"%s\" started", module->name);
+	}
+
+	return 0;
 }
 
 uint32_t module_active_count_get(void)
 {
-	return atomic_get(&active_module_count);
+	return atomic_get(&modules_info.active_modules_count);
 }

--- a/applications/asset_tracker_v2/src/modules/modules_common.h
+++ b/applications/asset_tracker_v2/src/modules/modules_common.h
@@ -7,34 +7,40 @@
 #ifndef _MODULES_COMMON_H_
 #define _MODULES_COMMON_H_
 
+#include <zephyr.h>
+
 #define IS_EVENT(_ptr, _mod, _evt) \
-		is_ ## _mod ## _module_event(&_ptr->module._mod.header) &&     \
+		is_ ## _mod ## _module_event(&_ptr->module._mod.header) &&		\
 		_ptr->module._mod.type == _evt
 
-#define SEND_EVENT(_mod, _type)						       \
-	struct _mod ## _module_event *event = new_ ## _mod ## _module_event(); \
-	event->type = _type;						       \
+#define SEND_EVENT(_mod, _type)								\
+	struct _mod ## _module_event *event = new_ ## _mod ## _module_event();		\
+	event->type = _type;								\
 	EVENT_SUBMIT(event)
 
-#define SEND_ERROR(_mod, _type, _error_code)				      \
-	struct _mod ## _module_event *event = new_ ## _mod ## _module_event(); \
-	event->type = _type;						      \
-	event->data.err = _error_code;					      \
+#define SEND_ERROR(_mod, _type, _error_code)						\
+	struct _mod ## _module_event *event = new_ ## _mod ## _module_event();		\
+	event->type = _type;								\
+	event->data.err = _error_code;							\
+	EVENT_SUBMIT(event)
+
+#define SEND_SHUTDOWN_ACK(_mod, _type, _id)						\
+	struct _mod ## _module_event *event = new_ ## _mod ## _module_event();		\
+	event->type = _type;								\
+	event->data.id = _id;								\
 	EVENT_SUBMIT(event)
 
 struct module_data {
+	/* Variable used to construct a linked list of module metadata. */
+	sys_snode_t header;
+	/* ID specific to each module. Internally assigned when calling module_start(). */
+	uint32_t id;
 	k_tid_t thread_id;
 	char *name;
 	struct k_msgq *msg_q;
+	/* Flag signifying if the module supports shutdown. */
+	bool supports_shutdown;
 };
-
-void module_register(struct module_data *module);
-
-void module_set_thread(struct module_data *module, const k_tid_t thread_id);
-
-void module_set_name(struct module_data *module, char *name);
-
-void module_set_queue(struct module_data *module,  struct k_msgq *msg_q);
 
 void module_purge_queue(struct module_data *module);
 
@@ -46,7 +52,22 @@ int module_get_next_msg(struct module_data *module, void *msg);
  */
 int module_enqueue_msg(struct module_data *module, void *msg);
 
-void module_start(struct module_data *module);
+/** @brief Register that a module has performed a graceful shutdown.
+ *
+ *  @param id_reg Identifier of module.
+ *
+ *  @return true If this API has been called for all modules supporting graceful shutdown in the
+ *	    application.
+ */
+bool modules_shutdown_register(uint32_t id_reg);
+
+/** @brief Register and start a module.
+ *
+ *  @param module Pointer to a structure containing module metadata.
+ *
+ *  @return 0 if successful, otherwise a negative error code.
+ */
+int module_start(struct module_data *module);
 
 uint32_t module_active_count_get(void);
 

--- a/applications/asset_tracker_v2/src/modules/util_module.c
+++ b/applications/asset_tracker_v2/src/modules/util_module.c
@@ -211,16 +211,14 @@ static void send_reboot_request(void)
  * modules in the application. When this API has been called a set number of times equal to the
  * number of active modules, a reboot will be scheduled.
  */
-static void reboot_ack_check(void)
+static void reboot_ack_check(uint32_t module_id)
 {
-	static uint8_t reboot_ack_count;
-
-	reboot_ack_count++;
-
 	/* Reboot after a shorter timeout if all modules have acknowledged that they are ready
-	 * to reboot, ensuring a graceful shutdown.
+	 * to reboot, ensuring a graceful shutdown. If not all modules respond to the shutdown
+	 * request, the application will be shut down after a longer duration scheduled upon the
+	 * initial error event.
 	 */
-	if (reboot_ack_count >= module_active_count_get() - 1) {
+	if (modules_shutdown_register(module_id)) {
 		LOG_WRN("All modules have ACKed the reboot request.");
 		LOG_WRN("Reboot in 5 seconds.");
 		k_delayed_work_submit(&reboot_work, K_SECONDS(5));
@@ -247,37 +245,37 @@ static void on_state_init(struct util_msg_data *msg)
 static void on_state_reboot_pending(struct util_msg_data *msg)
 {
 	if (IS_EVENT(msg, cloud, CLOUD_EVT_SHUTDOWN_READY)) {
-		reboot_ack_check();
+		reboot_ack_check(msg->module.cloud.data.id);
 		return;
 	}
 
 	if (IS_EVENT(msg, modem, MODEM_EVT_SHUTDOWN_READY)) {
-		reboot_ack_check();
+		reboot_ack_check(msg->module.modem.data.id);
 		return;
 	}
 
 	if (IS_EVENT(msg, sensor, SENSOR_EVT_SHUTDOWN_READY)) {
-		reboot_ack_check();
+		reboot_ack_check(msg->module.sensor.data.id);
 		return;
 	}
 
 	if (IS_EVENT(msg, gps, GPS_EVT_SHUTDOWN_READY)) {
-		reboot_ack_check();
+		reboot_ack_check(msg->module.gps.data.id);
 		return;
 	}
 
 	if (IS_EVENT(msg, data, DATA_EVT_SHUTDOWN_READY)) {
-		reboot_ack_check();
+		reboot_ack_check(msg->module.data.data.id);
 		return;
 	}
 
 	if (IS_EVENT(msg, app, APP_EVT_SHUTDOWN_READY)) {
-		reboot_ack_check();
+		reboot_ack_check(msg->module.app.data.id);
 		return;
 	}
 
 	if (IS_EVENT(msg, ui, UI_EVT_SHUTDOWN_READY)) {
-		reboot_ack_check();
+		reboot_ack_check(msg->module.ui.data.id);
 		return;
 	}
 }
@@ -286,7 +284,13 @@ static void on_state_reboot_pending(struct util_msg_data *msg)
 static void on_all_states(struct util_msg_data *msg)
 {
 	if (IS_EVENT(msg, app, APP_EVT_START)) {
-		module_start(&self);
+		int err = module_start(&self);
+
+		if (err) {
+			LOG_ERR("Failed starting module, error: %d", err);
+			send_reboot_request();
+		}
+
 		state_set(STATE_INIT);
 	}
 }


### PR DESCRIPTION
This patch suggests functionality to the application that enables it to
keep track of what modules that supports shutdown.

This is done by maintaining a list in the modules common library of
modules that supports this feature. This is done by passing in a flag
when starting the module. Modules will acknowledge that they have shut
down by sending an event to the utility module including
their module ID. The utility module will then register that the
respective module has shut down and when all modules have acknowledged
the shutdown, the application reboots.

This patch includes:
- Add new macro to lib modules common to send shutdown ACK events.
- Introduce module ID that is used to identify modules.
- Keep track of an internal list of modules that support shutdown.
- Add new API to lib modules common to register modules that have performed a shutdown.

Closes CIA-244

Signed-off-by: Simen S. Røstad <simen.rostad@nordicsemi.no>