### PR TITLE
lib: nrf_modem: increase default heap size and range

### DIFF
--- a/lib/nrf_modem_lib/Kconfig
+++ b/lib/nrf_modem_lib/Kconfig
@@ -61,7 +61,7 @@ comment "Heap and buffers"
 config NRF_MODEM_LIB_HEAP_SIZE
 	int "Library heap size"
 	default 512
-	range 512 2048
+	range 512 4096
 	help
 	  Size of the heap buffer used by the library.
 	  This heap is allocated in the application's RAM.

--- a/lib/nrf_modem_lib/Kconfig
+++ b/lib/nrf_modem_lib/Kconfig
@@ -60,7 +60,7 @@ comment "Heap and buffers"
 
 config NRF_MODEM_LIB_HEAP_SIZE
 	int "Library heap size"
-	default 512
+	default 1024
 	range 512 4096
 	help
 	  Size of the heap buffer used by the library.


### PR DESCRIPTION
Increase default heap size to `1024` and range to `4096`