### PR TITLE
connectedhomeip: change pigweed location

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -111,7 +111,7 @@ manifest:
     - name: connectedhomeip
       repo-path: sdk-connectedhomeip
       path: modules/lib/connectedhomeip
-      revision: v1.5.0
+      revision: f998c5c49824b9b7f60b8bbbe8eddd0c1c2e5880
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Pigweed, one of Project CHIP submodules, is hosted on googlesource.com and that location is blocked for users in some locations. A pigweed fork has been created on github to workaround that, so switch Project CHIP to use that fork.