### PR TITLE
applications: asset_tracker_v2: Fix opcode handling in lib json_common.

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/aws_iot_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/aws_iot_codec.c
@@ -173,7 +173,8 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 
 	err = json_common_ui_data_add(rep_obj, ui_buf,
 				      JSON_COMMON_ADD_DATA_TO_OBJECT,
-				      DATA_BUTTON);
+				      DATA_BUTTON,
+				      NULL);
 	if (err == 0) {
 		object_added = true;
 	} else if (err != -ENODATA) {
@@ -182,7 +183,8 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 
 	err = json_common_modem_static_data_add(rep_obj, modem_stat_buf,
 						JSON_COMMON_ADD_DATA_TO_OBJECT,
-						DATA_MODEM_STATIC);
+						DATA_MODEM_STATIC,
+						NULL);
 	if (err == 0) {
 		object_added = true;
 	} else if (err != -ENODATA) {
@@ -191,7 +193,8 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 
 	err = json_common_modem_dynamic_data_add(rep_obj, modem_dyn_buf,
 						 JSON_COMMON_ADD_DATA_TO_OBJECT,
-						 DATA_MODEM_DYNAMIC);
+						 DATA_MODEM_DYNAMIC,
+						 NULL);
 	if (err == 0) {
 		object_added = true;
 	} else if (err != -ENODATA) {
@@ -200,7 +203,8 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 
 	err = json_common_gps_data_add(rep_obj, gps_buf,
 				       JSON_COMMON_ADD_DATA_TO_OBJECT,
-				       DATA_GPS);
+				       DATA_GPS,
+				       NULL);
 	if (err == 0) {
 		object_added = true;
 	} else if (err != -ENODATA) {
@@ -209,7 +213,8 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 
 	err = json_common_sensor_data_add(rep_obj, sensor_buf,
 					  JSON_COMMON_ADD_DATA_TO_OBJECT,
-					  DATA_ENVIRONMENTALS);
+					  DATA_ENVIRONMENTALS,
+					  NULL);
 	if (err == 0) {
 		object_added = true;
 	} else if (err != -ENODATA) {
@@ -218,7 +223,8 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 
 	err = json_common_accel_data_add(rep_obj, accel_buf,
 					 JSON_COMMON_ADD_DATA_TO_OBJECT,
-					 DATA_MOVEMENT);
+					 DATA_MOVEMENT,
+					 NULL);
 	if (err == 0) {
 		object_added = true;
 	} else if (err != -ENODATA) {
@@ -227,7 +233,8 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 
 	err = json_common_battery_data_add(rep_obj, bat_buf,
 					   JSON_COMMON_ADD_DATA_TO_OBJECT,
-					   DATA_BATTERY);
+					   DATA_BATTERY,
+					   NULL);
 	if (err == 0) {
 		object_added = true;
 	} else if (err != -ENODATA) {
@@ -292,7 +299,8 @@ int cloud_codec_encode_ui_data(struct cloud_codec_data *output,
 
 	err = json_common_ui_data_add(root_obj, ui_buf,
 				      JSON_COMMON_ADD_DATA_TO_OBJECT,
-				      DATA_BUTTON);
+				      DATA_BUTTON,
+				      NULL);
 	if (err) {
 		goto exit;
 	}

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/json_common.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/json_common.h
@@ -63,6 +63,10 @@ enum json_common_op_code {
  * @param[in] data Pointer to data that is to be encoded.
  * @param[in] op Operation that is to be carried out.
  * @param[in] object_label Name of the encoded object.
+ * @param[out] parent_ref Reference to an unallocated parent object pointer. Used when getting the
+ *			  pointer to the encoded data object when setting
+ *			  JSON_COMMON_GET_POINTER_TO_OBJECT as the opcode. The cJSON object pointed
+ *			  to after this function call must be manually freed after use.
  *
  * @return 0 on success. -ENODATA if the passed in data is not valid. Otherwise a negative error
  *         code is returned.
@@ -70,7 +74,8 @@ enum json_common_op_code {
 int json_common_modem_static_data_add(cJSON *parent,
 				      struct cloud_data_modem_static *data,
 				      enum json_common_op_code op,
-				      const char *object_label);
+				      const char *object_label,
+				      cJSON **parent_ref);
 
 /**
  * @brief Encode and add dynamic modem data to the parent object.
@@ -79,6 +84,10 @@ int json_common_modem_static_data_add(cJSON *parent,
  * @param[in] data Pointer to data that is to be encoded.
  * @param[in] op Operation that is to be carried out.
  * @param[in] object_label Name of the encoded object.
+ * @param[out] parent_ref Reference to an unallocated parent object pointer. Used when getting the
+ *			  pointer to the encoded data object when setting
+ *			  JSON_COMMON_GET_POINTER_TO_OBJECT as the opcode. The cJSON object pointed
+ *			  to after this function call must be manually freed after use.
  *
  * @return 0 on success. -ENODATA if the passed in data is not valid. Otherwise a negative error
  *         code is returned.
@@ -86,7 +95,8 @@ int json_common_modem_static_data_add(cJSON *parent,
 int json_common_modem_dynamic_data_add(cJSON *parent,
 				       struct cloud_data_modem_dynamic *data,
 				       enum json_common_op_code op,
-				       const char *object_label);
+				       const char *object_label,
+				       cJSON **parent_ref);
 
 /**
  * @brief Encode and add environmental sensor data to the parent object.
@@ -95,6 +105,10 @@ int json_common_modem_dynamic_data_add(cJSON *parent,
  * @param[in] data Pointer to data that is to be encoded.
  * @param[in] op Operation that is to be carried out.
  * @param[in] object_label Name of the encoded object.
+ * @param[out] parent_ref Reference to an unallocated parent object pointer. Used when getting the
+ *			  pointer to the encoded data object when setting
+ *			  JSON_COMMON_GET_POINTER_TO_OBJECT as the opcode. The cJSON object pointed
+ *			  to after this function call must be manually freed after use.
  *
  * @return 0 on success. -ENODATA if the passed in data is not valid. Otherwise a negative error
  *         code is returned.
@@ -102,7 +116,8 @@ int json_common_modem_dynamic_data_add(cJSON *parent,
 int json_common_sensor_data_add(cJSON *parent,
 				struct cloud_data_sensors *data,
 				enum json_common_op_code op,
-				const char *object_label);
+				const char *object_label,
+				cJSON **parent_ref);
 
 /**
  * @brief Encode and add GPS data to the parent object.
@@ -111,6 +126,10 @@ int json_common_sensor_data_add(cJSON *parent,
  * @param[in] data Pointer to data that is to be encoded.
  * @param[in] op Operation that is to be carried out.
  * @param[in] object_label Name of the encoded object.
+ * @param[out] parent_ref Reference to an unallocated parent object pointer. Used when getting the
+ *			  pointer to the encoded data object when setting
+ *			  JSON_COMMON_GET_POINTER_TO_OBJECT as the opcode. The cJSON object pointed
+ *			  to after this function call must be manually freed after use.
  *
  * @return 0 on success. -ENODATA if the passed in data is not valid. Otherwise a negative error
  *         code is returned.
@@ -118,7 +137,8 @@ int json_common_sensor_data_add(cJSON *parent,
 int json_common_gps_data_add(cJSON *parent,
 			     struct cloud_data_gps *data,
 			     enum json_common_op_code op,
-			     const char *object_label);
+			     const char *object_label,
+			     cJSON **parent_ref);
 
 /**
  * @brief Encode and add accelerometer data to the parent object.
@@ -127,6 +147,10 @@ int json_common_gps_data_add(cJSON *parent,
  * @param[in] data Pointer to data that is to be encoded.
  * @param[in] op Operation that is to be carried out.
  * @param[in] object_label Name of the encoded object.
+ * @param[out] parent_ref Reference to an unallocated parent object pointer. Used when getting the
+ *			  pointer to the encoded data object when setting
+ *			  JSON_COMMON_GET_POINTER_TO_OBJECT as the opcode. The cJSON object pointed
+ *			  to after this function call must be manually freed after use.
  *
  * @return 0 on success. -ENODATA if the passed in data is not valid. Otherwise a negative error
  *         code is returned.
@@ -134,7 +158,8 @@ int json_common_gps_data_add(cJSON *parent,
 int json_common_accel_data_add(cJSON *parent,
 			       struct cloud_data_accelerometer *data,
 			       enum json_common_op_code op,
-			       const char *object_label);
+			       const char *object_label,
+			       cJSON **parent_ref);
 
 /**
  * @brief Encode and add User Interface data to the parent object.
@@ -143,6 +168,10 @@ int json_common_accel_data_add(cJSON *parent,
  * @param[in] data Pointer to data that is to be encoded.
  * @param[in] op Operation that is to be carried out.
  * @param[in] object_label Name of the encoded object.
+ * @param[out] parent_ref Reference to an unallocated parent object pointer. Used when getting the
+ *			  pointer to the encoded data object when setting
+ *			  JSON_COMMON_GET_POINTER_TO_OBJECT as the opcode. The cJSON object pointed
+ *			  to after this function call must be manually freed after use.
  *
  * @return 0 on success. -ENODATA if the passed in data is not valid. Otherwise a negative error
  *         code is returned.
@@ -150,7 +179,8 @@ int json_common_accel_data_add(cJSON *parent,
 int json_common_ui_data_add(cJSON *parent,
 			    struct cloud_data_ui *data,
 			    enum json_common_op_code op,
-			    const char *object_label);
+			    const char *object_label,
+			    cJSON **parent_ref);
 
 /**
  * @brief Encode and add battery data to the parent object.
@@ -159,6 +189,10 @@ int json_common_ui_data_add(cJSON *parent,
  * @param[in] data Pointer to data that is to be encoded.
  * @param[in] op Operation that is to be carried out.
  * @param[in] object_label Name of the encoded object.
+ * @param[out] parent_ref Reference to an unallocated parent object pointer. Used when getting the
+ *			  pointer to the encoded data object when setting
+ *			  JSON_COMMON_GET_POINTER_TO_OBJECT as the opcode. The cJSON object pointed
+ *			  to after this function call must be manually freed after use.
  *
  * @return 0 on success. -ENODATA if the passed in data is not valid. Otherwise a negative error
  *         code is returned.
@@ -166,7 +200,8 @@ int json_common_ui_data_add(cJSON *parent,
 int json_common_battery_data_add(cJSON *parent,
 				 struct cloud_data_battery *data,
 				 enum json_common_op_code op,
-				 const char *object_label);
+				 const char *object_label,
+				 cJSON **parent_ref);
 
 /**
  * @brief Encode and add configuration data to the parent object.


### PR DESCRIPTION
Add proper handling of the JSON_COMMON_GET_POINTER_TO_OBJECT opcode.

This patch includes:
- Update API for JSON common functions that encode data to include a
  double-pointer of type cJSON.
- Handle this new input variable in op_code_handle() to properly
  retrieve the encoded JSON object.
- Update the AWS IoT codec to handle the API changes.

Closes CIA-274 and CIA-292