### PR TITLE
applications: asset_tracker_v2: Use correct Kconfig option name.

### DIFF
--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -90,7 +90,7 @@ config DATA_BATTERY_BUFFER_STORE
 	bool "Store battery data received from the modem module"
 	default y
 
-config DATA_UI_MODEM_BUFFER_STORE
+config DATA_UI_BUFFER_STORE
 	bool "Store UI data received from the UI module"
 	default y
 


### PR DESCRIPTION
Update data module kconfig description to use correct naming for
DATA_UI_BUFFER_STORE.