### PR TITLE
lib: increase `COAP_RECEIVE_STACK_SIZE`

### DIFF
--- a/subsys/net/lib/coap_utils/coap_utils.c
+++ b/subsys/net/lib/coap_utils/coap_utils.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(coap_utils, CONFIG_COAP_UTILS_LOG_LEVEL);
 #if defined(CONFIG_NRF_MODEM_LIB)
 #define COAP_RECEIVE_STACK_SIZE 1000
 #else
-#define COAP_RECEIVE_STACK_SIZE 500
+#define COAP_RECEIVE_STACK_SIZE 900
 #endif
 
 const static int nfds = 1;

--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -51,8 +51,7 @@ config OPENTHREAD_MBEDTLS_LIB_NAME
 
 config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	int "OpenThread radio transmit workqueue stack size"
-	default 640 if NRF_802154_SER_HOST
-	default 512
+	default 640
 
 choice CC3XX_LOCK_VARIANT
 	default CC3XX_ATOMIC_LOCK if SOC_NRF52840


### PR DESCRIPTION
Increase `COAP_RECEIVE_STACK_SIZE` in order to avoid stack overflow for the OpenThread CoAP client sample.

Increase `ot_radio_workq` stack size to avoid stack overflow in situations with intense traffic.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-9627
KRKNWK-9628