### PR TITLE
net: openthread: increase `ot_radio_workq` stack size

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -52,7 +52,7 @@ config OPENTHREAD_MBEDTLS_LIB_NAME
 config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	int "OpenThread radio transmit workqueue stack size"
 	default 640 if NRF_802154_SER_HOST
-	default 512
+	default 544
 
 choice CC3XX_LOCK_VARIANT
 	default CC3XX_ATOMIC_LOCK if SOC_NRF52840


### PR DESCRIPTION
Increase `ot_radio_workq` stack size to avoid stack overflow in situations with intense traffic.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-9628