### PR TITLE
applications: serial_lte_modem Remove TCP inactivity timer

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -115,10 +115,6 @@ config SLM_UDP_POLL_TIME
 	int "Poll time-out in seconds for UDP connection"
 	default 10
 
-config SLM_TCP_CONN_TIME
-	int "Connection time-out in seconds for TCP server"
-	default 60
-
 config SLM_DATAMODE_HWFC
 	bool "UART HWFC for data mode"
 	default y

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -183,10 +183,6 @@ Check and configure the following configuration options for the sample:
 
    This option specifies the poll timeout for the TCP connection, in seconds.
 
-.. option:: CONFIG_SLM_TCP_CONN_TIME - Connection timeout in seconds for TCP server
-
-   This option specifies the connection timeout for the TCP connection, in seconds.
-
 .. option:: CONFIG_SLM_DATAMODE_HWFC - UART HWFC for data mode
 
    This option specifies whether UART hardware flow control is required for data mode.

--- a/applications/serial_lte_modem/doc/slm_testing.rst
+++ b/applications/serial_lte_modem/doc/slm_testing.rst
@@ -922,18 +922,13 @@ To act as a TCP server, |global_private_address|
          TCP3/4/5 received
          Closing connection
 
-   #. Read information about the current state and observe that the client disconnects.
+   #. Read information about the current state.
 
       .. parsed-literal::
          :class: highlight
 
          **AT#XTCPSVR?**
          #XTCPSVR: 1,2,0
-         OK
-         #XTCPSVR: "timeout"
-
-         **AT#XTCPSVR?**
-         #XTCPSVR: 1,-1,0
          OK
 
    #. Stop the server.


### PR DESCRIPTION
Inactivity timeout is a problem for TCP server in case of
- eDRX wakeup test by MT data
- PSM wakeup test by MT data

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>