### PR TITLE
LTE link control: Extract helper functions, add tests and add API to set functional mode

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -99,18 +99,48 @@ enum lte_lc_system_mode_preference {
 	LTE_LC_SYSTEM_MODE_PREFER_NBIOT_PLMN_PRIO
 };
 
-/* NOTE: enum lte_lc_func_mode maps directly to the functional mode
- *	 as returned by the AT command "AT+CFUN?" as specified in
- *	 "nRF91 AT Commands - Command Reference Guide v1.1"
+/** @brief Functional modes, used to contol RF functionality in the modem.
+ *
+ *  @note The functional modes map directly to the functional modes as described
+ *	  in "nRF91 AT Commands - Command Reference Guide". Please refer to the
+ *	  AT command guide to verify if a functional mode is supported by a
+ *	  given modem firmware version.
  */
 enum lte_lc_func_mode {
+	/* Sets the device to minimum functionality. Disables both transmit and
+	 * receive RF circuits and deactivates LTE and GNSS.
+	 */
 	LTE_LC_FUNC_MODE_POWER_OFF		= 0,
+
+	/* Sets the device to full functionality. Both LTE and GNSS will become
+	 * active if the respective system modes are enabled.
+	 */
 	LTE_LC_FUNC_MODE_NORMAL			= 1,
+
+	/* Sets the device to flight mode. Disables both transmit and receive RF
+	 * circuits and deactivates LTE and GNSS services.
+	 */
 	LTE_LC_FUNC_MODE_OFFLINE		= 4,
+
+	/* Deactivates LTE without shutting down GNSS services. */
 	LTE_LC_FUNC_MODE_DEACTIVATE_LTE		= 20,
+
+	/* Activates LTE without changing GNSS. */
 	LTE_LC_FUNC_MODE_ACTIVATE_LTE		= 21,
+
+	/* Deactivates GNSS without shutting down LTE services. */
 	LTE_LC_FUNC_MODE_DEACTIVATE_GNSS	= 30,
+
+	/* Activates GNSS without changing LTE. */
 	LTE_LC_FUNC_MODE_ACTIVATE_GNSS		= 31,
+
+	/* Deactivates UICC. */
+	LTE_LC_FUNC_MODE_DEACTIVATE_UICC	= 40,
+
+	/* Activates UICC. */
+	LTE_LC_FUNC_MODE_ACTIVATE_UICC		= 41,
+
+	/* Sets the device to flight mode without shutting down UICC. */
 	LTE_LC_FUNC_MODE_OFFLINE_UICC_ON	= 44,
 };
 
@@ -415,6 +445,14 @@ int lte_lc_system_mode_set(enum lte_lc_system_mode mode,
  */
 int lte_lc_system_mode_get(enum lte_lc_system_mode *mode,
 			   enum lte_lc_system_mode_preference *preference);
+
+/**@brief Set the modem's functional mode.
+ *
+ * @param mode Functional mode to set.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_func_mode_set(enum lte_lc_func_mode mode);
 
 /**@brief Get the modem's functional mode.
  *

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -99,7 +99,7 @@ enum lte_lc_system_mode_preference {
 	LTE_LC_SYSTEM_MODE_PREFER_NBIOT_PLMN_PRIO
 };
 
-/** @brief Functional modes, used to contol RF functionality in the modem.
+/** @brief Functional modes, used to control RF functionality in the modem.
  *
  *  @note The functional modes map directly to the functional modes as described
  *	  in "nRF91 AT Commands - Command Reference Guide". Please refer to the

--- a/lib/lte_link_control/CMakeLists.txt
+++ b/lib/lte_link_control/CMakeLists.txt
@@ -5,4 +5,5 @@
 #
 
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_LTE_LINK_CONTROL lte_lc.c)
+zephyr_library_sources(lte_lc.c)
+zephyr_library_sources(lte_lc_helpers.c)

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1808,6 +1808,33 @@ clean_exit:
 	return err;
 }
 
+int lte_lc_func_mode_set(enum lte_lc_func_mode mode)
+{
+	switch (mode) {
+	case LTE_LC_FUNC_MODE_POWER_OFF:
+	case LTE_LC_FUNC_MODE_NORMAL:
+	case LTE_LC_FUNC_MODE_OFFLINE:
+	case LTE_LC_FUNC_MODE_DEACTIVATE_LTE:
+	case LTE_LC_FUNC_MODE_ACTIVATE_LTE:
+	case LTE_LC_FUNC_MODE_DEACTIVATE_GNSS:
+	case LTE_LC_FUNC_MODE_ACTIVATE_GNSS:
+	case LTE_LC_FUNC_MODE_OFFLINE_UICC_ON: {
+		char buf[12];
+		int ret = snprintk(buf, sizeof(buf), "AT+CFUN=%d", mode);
+
+		if ((ret < 0) || (ret >= sizeof(buf))) {
+			LOG_ERR("Failed to create functional mode command");
+			return -EFAULT;
+		}
+
+		return at_cmd_write(buf, NULL, 0, NULL);
+	}
+	default:
+		LOG_ERR("Invalid functional mode: %d", mode);
+		return -EINVAL;
+	}
+}
+
 int lte_lc_func_mode_get(enum lte_lc_func_mode *mode)
 {
 	int err, resp_mode;

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -18,58 +18,9 @@
 #include <modem/at_notif.h>
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
+#include "lte_lc_helpers.h"
 
-#define LC_MAX_READ_LENGTH			128
-#define AT_CMD_SIZE(x)				(sizeof(x) - 1)
-#define AT_RESPONSE_PREFIX_INDEX		0
-#define AT_CFUN_READ				"AT+CFUN?"
-#define AT_CFUN_RESPONSE_PREFIX			"+CFUN"
-#define AT_CFUN_MODE_INDEX			1
-#define AT_CFUN_PARAMS_COUNT			2
-#define AT_CFUN_RESPONSE_MAX_LEN		20
-#define AT_CEREG_5				"AT+CEREG=5"
-#define AT_CEREG_READ				"AT+CEREG?"
-#define AT_CEREG_RESPONSE_PREFIX		"+CEREG"
-#define AT_CEREG_PARAMS_COUNT_MAX		10
-#define AT_CEREG_REG_STATUS_INDEX		1
-#define AT_CEREG_READ_REG_STATUS_INDEX		2
-#define AT_CEREG_TAC_INDEX			2
-#define AT_CEREG_READ_TAC_INDEX			3
-#define AT_CEREG_CELL_ID_INDEX			3
-#define AT_CEREG_ACT_INDEX			4
-#define AT_CEREG_READ_CELL_ID_INDEX		4
-#define AT_CEREG_READ_ACT_INDEX			5
-#define AT_CEREG_ACTIVE_TIME_INDEX		7
-#define AT_CEREG_READ_ACTIVE_TIME_INDEX		8
-#define AT_CEREG_TAU_INDEX			8
-#define AT_CEREG_READ_TAU_INDEX			9
-#define AT_CEREG_RESPONSE_MAX_LEN		80
-#define AT_XSYSTEMMODE_READ			"AT%XSYSTEMMODE?"
-#define AT_XSYSTEMMODE_RESPONSE_PREFIX		"%XSYSTEMMODE"
-#define AT_XSYSTEMMODE_PROTO			"AT%%XSYSTEMMODE=%d,%d,%d,%d"
-/* The indices are for the set command. Add 1 for the read command indices. */
-#define AT_XSYSTEMMODE_READ_LTEM_INDEX		1
-#define AT_XSYSTEMMODE_READ_NBIOT_INDEX		2
-#define AT_XSYSTEMMODE_READ_GPS_INDEX		3
-#define AT_XSYSTEMMODE_READ_PREFERENCE_INDEX	4
-#define AT_XSYSTEMMODE_PARAMS_COUNT		5
-#define AT_XSYSTEMMODE_RESPONSE_MAX_LEN		30
-/* CEDRXS command parameters */
-#define AT_CEDRXS_MODE_INDEX
-#define AT_CEDRXS_ACTT_WB			4
-#define AT_CEDRXS_ACTT_NB			5
-/* CEDRXP notification parameters */
-#define AT_CEDRXP_PARAMS_COUNT_MAX		5
-#define AT_CEDRXP_ACTT_INDEX			1
-#define AT_CEDRXP_REQ_EDRX_INDEX		2
-#define AT_CEDRXP_NW_EDRX_INDEX			3
-#define AT_CEDRXP_NW_PTW_INDEX			4
-/* CSCON command parameters */
-#define AT_CSCON_RESPONSE_PREFIX		"+CSCON"
-#define AT_CSCON_PARAMS_COUNT_MAX		4
-#define AT_CSCON_RRC_MODE_INDEX			1
-#define AT_CSCON_READ_RRC_MODE_INDEX		2
+LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
 #define SYS_MODE_PREFERRED \
 	(IS_ENABLED(CONFIG_LTE_NETWORK_MODE_LTE_M)		? \
@@ -86,20 +37,15 @@ LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 		LTE_LC_SYSTEM_MODE_LTEM_NBIOT_GPS		: \
 	LTE_LC_SYSTEM_MODE_NONE)
 
-/* Forward declarations */
-static int parse_nw_reg_status(const char *at_response,
-			       enum lte_lc_nw_reg_status *status,
-			       size_t reg_status_index);
-static int parse_rrc_mode(const char *at_response,
-			  enum lte_lc_rrc_mode *mode,
-			  size_t mode_index);
-static int parse_edrx(const char *at_response,
-		      struct lte_lc_edrx_cfg *cfg);
-static bool response_is_valid(const char *response, size_t response_len,
-			      const char *check);
-static int parse_psm_cfg(struct at_param_list *at_params,
-			 bool is_notif,
-			 struct lte_lc_psm_cfg *psm_cfg);
+enum lte_lc_notif_type {
+	LTE_LC_NOTIF_CEREG,
+	LTE_LC_NOTIF_CSCON,
+	LTE_LC_NOTIF_CEDRXP,
+
+	LTE_LC_NOTIF_COUNT,
+};
+
+/* Static variables */
 
 static lte_lc_evt_handler_t evt_handler;
 static bool is_initialized;
@@ -108,6 +54,7 @@ static bool is_initialized;
 /* Enable modem trace */
 static const char mdm_trace[] = "AT%XMODEMTRACE=1,2";
 #endif
+
 /* Subscribes to notifications with level 5 */
 static const char cereg_5_subscribe[] = AT_CEREG_5;
 
@@ -136,12 +83,6 @@ static char psm_param_rat[9] = CONFIG_LTE_PSM_REQ_RAT;
 static char psm_param_rptau[9] = CONFIG_LTE_PSM_REQ_RPTAU;
 /* Request PSM to be disabled */
 static const char psm_disable[] = "AT+CPSMS=";
-/* Set the modem to power off mode */
-static const char power_off[] = "AT+CFUN=0";
-/* Set the modem to Normal mode */
-static const char normal[] = "AT+CFUN=1";
-/* Set the modem to Offline mode */
-static const char offline[] = "AT+CFUN=4";
 /* Enable CSCON (RRC mode) notifications */
 static const char cscon[] = "AT+CSCON=1";
 /* Disable RAI */
@@ -226,14 +167,6 @@ static char cgauth[19 + CONFIG_LTE_PDN_AUTH_LEN] =
 static const char legacy_pco[] = "AT%XEPCO=0";
 #endif
 
-enum lte_lc_notif_type {
-	LTE_LC_NOTIF_CEREG,
-	LTE_LC_NOTIF_CSCON,
-	LTE_LC_NOTIF_CEDRXP,
-
-	LTE_LC_NOTIF_COUNT,
-};
-
 static const char *const at_notifs[] = {
 	[LTE_LC_NOTIF_CEREG] = "+CEREG",
 	[LTE_LC_NOTIF_CSCON] = "+CSCON",
@@ -255,124 +188,6 @@ static bool is_relevant_notif(const char *notif, enum lte_lc_notif_type *type)
 	}
 
 	return false;
-}
-
-static int parse_cereg(bool is_notification,
-		       const char *at_buf,
-		       enum lte_lc_nw_reg_status *reg_status,
-		       struct lte_lc_cell *cell,
-		       enum lte_lc_lte_mode *lte_mode,
-		       struct lte_lc_psm_cfg *psm_cfg)
-{
-	int err, status;
-	struct at_param_list resp_list;
-	char str_buf[10];
-	size_t len = sizeof(str_buf) - 1;
-
-	err = at_params_list_init(&resp_list, AT_CEREG_PARAMS_COUNT_MAX);
-	if (err) {
-		LOG_ERR("Could not init AT params list, error: %d", err);
-		return err;
-	}
-
-	/* Parse CEREG response and populate AT parameter list */
-	err = at_parser_params_from_str(at_buf,
-					NULL,
-					&resp_list);
-	if (err) {
-		LOG_ERR("Could not parse AT+CEREG response, error: %d", err);
-		goto clean_exit;
-	}
-
-	if (reg_status) {
-		/* Parse network registration status */
-		err = at_params_int_get(&resp_list,
-				is_notification ? AT_CEREG_REG_STATUS_INDEX :
-						AT_CEREG_READ_REG_STATUS_INDEX,
-				&status);
-		if (err) {
-			LOG_ERR("Could not get registration status, error: %d", err);
-			goto clean_exit;
-		}
-
-		*reg_status = status;
-	}
-
-	if (cell && (*reg_status != LTE_LC_NW_REG_UICC_FAIL) &&
-	    (at_params_valid_count_get(&resp_list) > AT_CEREG_CELL_ID_INDEX)) {
-		/* Parse tracking area code */
-		err = at_params_string_get(
-				&resp_list,
-				is_notification ? AT_CEREG_TAC_INDEX :
-						  AT_CEREG_READ_TAC_INDEX,
-				str_buf, &len);
-		if (err) {
-			LOG_ERR("Could not get tracking area code, error: %d", err);
-			goto clean_exit;
-		}
-
-		str_buf[len] = '\0';
-		cell->tac = strtoul(str_buf, NULL, 16);
-
-		/* Parse cell ID */
-		len = sizeof(str_buf) - 1;
-
-		err = at_params_string_get(&resp_list,
-				is_notification ? AT_CEREG_CELL_ID_INDEX :
-						  AT_CEREG_READ_CELL_ID_INDEX,
-				str_buf, &len);
-		if (err) {
-			LOG_ERR("Could not get cell ID, error: %d", err);
-			goto clean_exit;
-		}
-
-		str_buf[len] = '\0';
-		cell->id = strtoul(str_buf, NULL, 16);
-	} else if (cell) {
-		cell->tac = UINT32_MAX;
-		cell->id = UINT32_MAX;
-	}
-
-	if (lte_mode) {
-		/* Get currently active LTE mode. */
-		err = at_params_int_get(&resp_list,
-				is_notification ? AT_CEREG_ACT_INDEX :
-						  AT_CEREG_READ_ACT_INDEX,
-				(int *)lte_mode);
-		if (err) {
-			LOG_DBG("LTE mode not found, error code: %d", err);
-			*lte_mode = LTE_LC_LTE_MODE_NONE;
-
-			/* This is not an error that should be returned, as it's
-			 * expected in some situations that LTE mode is not
-			 * available.
-			 */
-			err = 0;
-		} else {
-			LOG_DBG("LTE mode: %d", *lte_mode);
-		}
-	}
-
-	/* Parse PSM configuration only when registered */
-	if (psm_cfg && ((*reg_status == LTE_LC_NW_REG_REGISTERED_HOME) ||
-	    (*reg_status == LTE_LC_NW_REG_REGISTERED_ROAMING)) &&
-	     (at_params_valid_count_get(&resp_list) > AT_CEREG_TAU_INDEX)) {
-		err = parse_psm_cfg(&resp_list, is_notification, psm_cfg);
-		if (err) {
-			LOG_ERR("Failed to parse PSM configuration, error: %d",
-				err);
-			goto clean_exit;
-		}
-	} else {
-		/* When device is not registered, PSM valies are invalid */
-		psm_cfg->tau = -1;
-		psm_cfg->active_time = -1;
-	}
-
-clean_exit:
-	at_params_list_free(&resp_list);
-
-	return err;
 }
 
 static void at_handler(void *context, const char *response)
@@ -408,7 +223,7 @@ static void at_handler(void *context, const char *response)
 
 		LOG_DBG("+CEREG notification: %s", log_strdup(response));
 
-		err = parse_cereg(true, response, &reg_status, &cell, &lte_mode, &psm_cfg);
+		err = parse_cereg(response, true, &reg_status, &cell, &lte_mode, &psm_cfg);
 		if (err) {
 			LOG_ERR("Failed to parse notification (error %d): %s",
 				err, log_strdup(response));
@@ -507,85 +322,6 @@ static void at_handler(void *context, const char *response)
 	}
 }
 
-static int parse_psm_cfg(struct at_param_list *at_params,
-			 bool is_notif,
-			 struct lte_lc_psm_cfg *psm_cfg)
-{
-	int err;
-	size_t tau_idx = is_notif ? AT_CEREG_TAU_INDEX :
-				    AT_CEREG_READ_TAU_INDEX;
-	size_t active_time_idx = is_notif ? AT_CEREG_ACTIVE_TIME_INDEX :
-					    AT_CEREG_READ_ACTIVE_TIME_INDEX;
-	char timer_str[9] = {0};
-	char unit_str[4] = {0};
-	size_t timer_str_len = sizeof(timer_str) - 1;
-	size_t unit_str_len = sizeof(unit_str) - 1;
-	size_t lut_idx;
-	uint32_t timer_unit, timer_value;
-
-	/* Lookup table for T3324 timer used for PSM active time in seconds.
-	 * Ref: GPRS Timer 2 IE in 3GPP TS 24.008 Table 10.5.163/3GPP TS 24.008.
-	 */
-	static const uint32_t t3324_lookup[8] = {2, 60, 600, 60, 60, 60, 60, 0};
-
-	/* Lookup table for T3412 timer used for periodic TAU. Unit is seconds.
-	 * Ref: GPRS Timer 3 in 3GPP TS 24.008 Table 10.5.163a/3GPP TS 24.008.
-	 */
-	static const uint32_t t3412_lookup[8] = {600, 3600, 36000, 2, 30, 60,
-					      1152000, 0};
-
-	/* Parse periodic TAU string */
-	err = at_params_string_get(at_params,
-				   tau_idx,
-				   timer_str,
-				   &timer_str_len);
-	if (err) {
-		LOG_ERR("Could not get TAU, error: %d", err);
-		return err;
-	}
-
-	memcpy(unit_str, timer_str, unit_str_len);
-
-	lut_idx = strtoul(unit_str, NULL, 2);
-	if (lut_idx > (ARRAY_SIZE(t3412_lookup) - 1)) {
-		LOG_ERR("Unable to parse periodic TAU string");
-		err = -EINVAL;
-		return err;
-	}
-
-	timer_unit = t3412_lookup[lut_idx];
-	timer_value = strtoul(timer_str + unit_str_len, NULL, 2);
-	psm_cfg->tau = timer_unit ? timer_unit * timer_value : -1;
-
-	/* Parse active time string */
-	err = at_params_string_get(at_params,
-				   active_time_idx,
-				   timer_str,
-				   &timer_str_len);
-	if (err) {
-		LOG_ERR("Could not get TAU, error: %d", err);
-		return err;
-	}
-
-	memcpy(unit_str, timer_str, unit_str_len);
-
-	lut_idx = strtoul(unit_str, NULL, 2);
-	if (lut_idx > (ARRAY_SIZE(t3324_lookup) - 1)) {
-		LOG_ERR("Unable to parse active time string");
-		err = -EINVAL;
-		return err;
-	}
-
-	timer_unit = t3324_lookup[lut_idx];
-	timer_value = strtoul(timer_str + unit_str_len, NULL, 2);
-	psm_cfg->active_time = timer_unit ? timer_unit * timer_value : -1;
-
-	LOG_DBG("TAU: %d sec, active time: %d sec\n",
-		psm_cfg->tau, psm_cfg->active_time);
-
-	return 0;
-}
-
 static int enable_notifications(void)
 {
 	int err;
@@ -622,7 +358,7 @@ static int enable_notifications(void)
 	return 0;
 }
 
-static int w_lte_lc_init(void)
+static int init_and_config(void)
 {
 	int err;
 
@@ -739,7 +475,7 @@ static int w_lte_lc_init(void)
 	return 0;
 }
 
-static int w_lte_lc_connect(bool blocking)
+static int connect_lte(bool blocking)
 {
 	int err;
 	bool retry;
@@ -761,7 +497,7 @@ static int w_lte_lc_connect(bool blocking)
 			}
 		}
 
-		err = lte_lc_normal();
+		err = lte_lc_func_mode_set(LTE_LC_FUNC_MODE_NORMAL);
 		if (err || !blocking) {
 			return err;
 		}
@@ -775,7 +511,7 @@ static int w_lte_lc_connect(bool blocking)
 				sys_mode_target = sys_mode_fallback;
 				retry = true;
 
-				err = lte_lc_offline();
+				err = lte_lc_func_mode_set(LTE_LC_FUNC_MODE_OFFLINE);
 				if (err) {
 					return err;
 				}
@@ -790,22 +526,23 @@ static int w_lte_lc_connect(bool blocking)
 	return err;
 }
 
-static int w_lte_lc_init_and_connect(const struct device *unused)
+static int init_and_connect(const struct device *unused)
 {
 	int ret;
 
-	ret = w_lte_lc_init();
+	ret = init_and_config();
 	if (ret) {
 		return ret;
 	}
 
-	return w_lte_lc_connect(true);
+	return connect_lte(true);
 }
 
-/* lte lc Init wrapper */
+/* Public API */
+
 int lte_lc_init(void)
 {
-	return w_lte_lc_init();
+	return init_and_config();
 }
 
 void lte_lc_register_handler(lte_lc_evt_handler_t handler)
@@ -829,18 +566,16 @@ void lte_lc_register_handler(lte_lc_evt_handler_t handler)
 	return;
 }
 
-/* lte lc Connect wrapper */
 int lte_lc_connect(void)
 {
-	return w_lte_lc_connect(true);
+	return connect_lte(true);
 }
 
-/* lte lc Init and connect wrapper */
 int lte_lc_init_and_connect(void)
 {
 	const struct device *x = 0;
 
-	int err = w_lte_lc_init_and_connect(x);
+	int err = init_and_connect(x);
 
 	return err;
 }
@@ -854,14 +589,14 @@ int lte_lc_connect_async(lte_lc_evt_handler_t handler)
 		return -EINVAL;
 	}
 
-	return w_lte_lc_connect(false);
+	return connect_lte(false);
 }
 
 int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler)
 {
 	int err;
 
-	err = w_lte_lc_init();
+	err = init_and_config();
 	if (err) {
 		return err;
 	}
@@ -869,30 +604,12 @@ int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler)
 	return lte_lc_connect_async(handler);
 }
 
-int lte_lc_offline(void)
-{
-	if (at_cmd_write(offline, NULL, 0, NULL) != 0) {
-		return -EIO;
-	}
-
-	return 0;
-}
-
-int lte_lc_power_off(void)
-{
-	if (at_cmd_write(power_off, NULL, 0, NULL) != 0) {
-		return -EIO;
-	}
-
-	return 0;
-}
-
 int lte_lc_deinit(void)
 {
 	if (is_initialized) {
 		is_initialized = false;
 		at_notif_deregister_handler(NULL, at_handler);
-		return lte_lc_power_off();
+		return lte_lc_func_mode_set(LTE_LC_FUNC_MODE_POWER_OFF);
 	}
 
 	return 0;
@@ -908,13 +625,17 @@ int lte_lc_normal(void)
 		return err;
 	}
 
-	err = at_cmd_write(normal, NULL, 0, NULL);
-	if (err) {
-		LOG_ERR("Failed to set normal mode, error: %d", err);
-		return err;
-	}
+	return lte_lc_func_mode_set(LTE_LC_FUNC_MODE_NORMAL);
+}
 
-	return 0;
+int lte_lc_offline(void)
+{
+	return lte_lc_func_mode_set(LTE_LC_FUNC_MODE_OFFLINE);
+}
+
+int lte_lc_power_off(void)
+{
+	return lte_lc_func_mode_set(LTE_LC_FUNC_MODE_POWER_OFF);
 }
 
 int lte_lc_psm_param_set(const char *rptau, const char *rat)
@@ -1019,7 +740,7 @@ int lte_lc_psm_get(int *tau, int *active_time)
 		goto parse_psm_clean_exit;
 	}
 
-	err = parse_psm_cfg(&at_resp_list, false, &psm_cfg);
+	err = parse_psm(&at_resp_list, false, &psm_cfg);
 	if (err) {
 		LOG_ERR("Could not obtain PSM configuration");
 		goto parse_psm_clean_exit;
@@ -1226,347 +947,6 @@ int lte_lc_pdn_auth_set(enum lte_lc_pdn_auth_type auth_prot,
 #endif
 }
 
-/**@brief Helper function to check if a response is what was expected
- *
- * @param response Pointer to response prefix
- * @param response_len Length of the response to be checked
- * @param check The buffer with "truth" to verify the response against,
- *		for example "+CEREG"
- *
- * @return True if the provided buffer and check are equal, false otherwise.
- */
-static bool response_is_valid(const char *response, size_t response_len,
-			      const char *check)
-{
-	if ((response == NULL) || (check == NULL)) {
-		LOG_ERR("Invalid pointer provided");
-		return false;
-	}
-
-	if ((response_len < strlen(check)) ||
-	    (memcmp(response, check, response_len) != 0)) {
-		return false;
-	}
-
-	return true;
-}
-
-/**@brief Parses an AT command response, and returns the current network
- *	  registration status if it's available in the string.
- *
- * @param at_response Pointer to buffer with AT response.
- * @param status Pointer to where the registration status is stored.
- *
- * @return Zero on success or (negative) error code otherwise.
- */
-static int parse_nw_reg_status(const char *at_response,
-			       enum lte_lc_nw_reg_status *status,
-			       size_t reg_status_index)
-{
-	int err, reg_status;
-	struct at_param_list resp_list = {0};
-	char  response_prefix[sizeof(AT_CEREG_RESPONSE_PREFIX)] = {0};
-	size_t response_prefix_len = sizeof(response_prefix);
-
-	if ((at_response == NULL) || (status == NULL)) {
-		return -EINVAL;
-	}
-
-	err = at_params_list_init(&resp_list, AT_CEREG_PARAMS_COUNT_MAX);
-	if (err) {
-		LOG_ERR("Could not init AT params list, error: %d", err);
-		return err;
-	}
-
-	/* Parse CEREG response and populate AT parameter list */
-	err = at_parser_max_params_from_str(at_response,
-					    NULL,
-					    &resp_list,
-					    AT_CEREG_PARAMS_COUNT_MAX);
-	if (err) {
-		LOG_ERR("Could not parse AT+CEREG response, error: %d", err);
-		goto clean_exit;
-	}
-
-	/* Check if AT command response starts with +CEREG */
-	err = at_params_string_get(&resp_list,
-				   AT_RESPONSE_PREFIX_INDEX,
-				   response_prefix,
-				   &response_prefix_len);
-	if (err) {
-		LOG_ERR("Could not get response prefix, error: %d", err);
-		goto clean_exit;
-	}
-
-	if (!response_is_valid(response_prefix, response_prefix_len,
-			       AT_CEREG_RESPONSE_PREFIX)) {
-		/* The unsolicited response is not a CEREG response, ignore it.
-		 */
-		goto clean_exit;
-	}
-
-	/* Get the network registration status parameter from the response */
-	err = at_params_int_get(&resp_list, reg_status_index,
-				&reg_status);
-	if (err) {
-		LOG_ERR("Could not get registration status, error: %d", err);
-		goto clean_exit;
-	}
-
-	/* Check if the parsed value maps to a valid registration status */
-	switch (reg_status) {
-	case LTE_LC_NW_REG_NOT_REGISTERED:
-	case LTE_LC_NW_REG_REGISTERED_HOME:
-	case LTE_LC_NW_REG_SEARCHING:
-	case LTE_LC_NW_REG_REGISTRATION_DENIED:
-	case LTE_LC_NW_REG_UNKNOWN:
-	case LTE_LC_NW_REG_REGISTERED_ROAMING:
-	case LTE_LC_NW_REG_REGISTERED_EMERGENCY:
-	case LTE_LC_NW_REG_UICC_FAIL:
-		*status = reg_status;
-		LOG_DBG("Network registration status: %d", reg_status);
-		break;
-	default:
-		LOG_ERR("Invalid network registration status: %d", reg_status);
-		err = -EIO;
-	}
-
-clean_exit:
-	at_params_list_free(&resp_list);
-
-	return err;
-}
-
-/**@brief Parses an AT command response, and returns the current RRC mode.
- *
- * @param at_response Pointer to buffer with AT response.
- * @param mode Pointer to where the RRC mode is stored.
- * @param mode_index Parameter index for mode.
- *
- * @return Zero on success or (negative) error code otherwise.
- */
-static int parse_rrc_mode(const char *at_response,
-			  enum lte_lc_rrc_mode *mode,
-			  size_t mode_index)
-{
-	int err, temp_mode;
-	struct at_param_list resp_list = {0};
-
-	err = at_params_list_init(&resp_list, AT_CSCON_PARAMS_COUNT_MAX);
-	if (err) {
-		LOG_ERR("Could not init AT params list, error: %d", err);
-		return err;
-	}
-
-	/* Parse CSCON response and populate AT parameter list */
-	err = at_parser_params_from_str(at_response,
-					NULL,
-					&resp_list);
-	if (err) {
-		LOG_ERR("Could not parse +CSCON response, error: %d", err);
-		goto clean_exit;
-	}
-
-	/* Get the RRC mode from the response */
-	err = at_params_int_get(&resp_list, mode_index, &temp_mode);
-	if (err) {
-		LOG_ERR("Could not get signalling mode, error: %d", err);
-		goto clean_exit;
-	}
-
-	/* Check if the parsed value maps to a valid registration status */
-	if (temp_mode == 0) {
-		*mode = LTE_LC_RRC_MODE_IDLE;
-	} else if (temp_mode == 1) {
-		*mode = LTE_LC_RRC_MODE_CONNECTED;
-	} else {
-		LOG_ERR("Invalid signalling mode: %d", temp_mode);
-		err = -EINVAL;
-	}
-
-clean_exit:
-	at_params_list_free(&resp_list);
-
-	return err;
-}
-
-/* Confirm valid system mode and set Paging Time Window multiplier.
- * Multiplier is 1.28 s for LTE-M, and 2.56 s for NB-IoT, derived from
- * Figure 10.5.5.32/3GPP TS 24.008.
- */
-static int get_ptw_multiplier(float *ptw_multiplier)
-{
-	switch (sys_mode_current) {
-	case LTE_LC_SYSTEM_MODE_LTEM: /* Fall through */
-	case LTE_LC_SYSTEM_MODE_LTEM_GPS:
-		*ptw_multiplier = 1.28;
-		break;
-	case LTE_LC_SYSTEM_MODE_NBIOT: /* Fall through */
-	case LTE_LC_SYSTEM_MODE_NBIOT_GPS:
-		*ptw_multiplier = 2.56;
-		break;
-	case LTE_LC_SYSTEM_MODE_GPS: /* Fall through */
-	case LTE_LC_SYSTEM_MODE_NONE: /* Fall through */
-	default:
-		LOG_ERR("No LTE connection available in this system mode");
-		return -ENOTCONN;
-	}
-
-	return 0;
-}
-
-static int get_edrx_value(uint8_t idx, float *edrx_value)
-{
-	uint16_t multiplier = 0;
-
-	/* Lookup table to eDRX multiplier values, based on T_eDRX values found
-	 * in Table 10.5.5.32/3GPP TS 24.008. The actual value is
-	 * (multiplier * 10.24 s), except for the first entry which is handled
-	 * as a special case per note 3 in the specification.
-	 */
-	static const uint16_t edrx_lookup_ltem[16] = {
-		0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 32, 64, 128, 256, 256, 256
-	};
-	static const uint16_t edrx_lookup_nbiot[16] = {
-		2, 2, 2, 4, 2, 8, 2, 2, 2, 16, 32, 64, 128, 256, 512, 1024
-	};
-
-	if ((edrx_value == NULL) || (idx > ARRAY_SIZE(edrx_lookup_ltem) - 1)) {
-		return -EINVAL;
-	}
-
-	switch (sys_mode_current) {
-	case LTE_LC_SYSTEM_MODE_LTEM: /* Fall through */
-	case LTE_LC_SYSTEM_MODE_LTEM_GPS:
-		multiplier = edrx_lookup_ltem[idx];
-		break;
-	case LTE_LC_SYSTEM_MODE_NBIOT: /* Fall through */
-	case LTE_LC_SYSTEM_MODE_NBIOT_GPS:
-		multiplier = edrx_lookup_nbiot[idx];
-		break;
-	case LTE_LC_SYSTEM_MODE_GPS: /* Fall through */
-	case LTE_LC_SYSTEM_MODE_NONE: /* Fall through */
-	default:
-		LOG_ERR("No LTE connection available in this system mode");
-		return -ENOTCONN;
-	}
-
-	*edrx_value = multiplier == 0 ? 5.12 : multiplier * 10.24;
-
-	return 0;
-}
-
-/**@brief Parses an AT command response, and returns the current eDRX settings.
- *
- * @note It's assumed that the network only reports valid eDRX values when
- *	 in each mode (LTE-M and NB1). There's no sanity-check of these values.
- *
- * @param at_response Pointer to buffer with AT response.
- * @param cfg Pointer to where the eDRX configuration is stored.
- *
- * @return Zero on success or (negative) error code otherwise.
- */
-static int parse_edrx(const char *at_response,
-		      struct lte_lc_edrx_cfg *cfg)
-{
-	int err;
-	uint8_t idx;
-	struct at_param_list resp_list = {0};
-	char tmp_buf[5];
-	size_t len = sizeof(tmp_buf) - 1;
-	float ptw_multiplier;
-
-	if ((at_response == NULL) || (cfg == NULL)) {
-		return -EINVAL;
-	}
-
-	/* Confirm valid system mode and set Paging Time Window multiplier.
-	 * Multiplier is 1.28 s for LTE-M, and 2.56 s for NB-IoT, derived from
-	 * figure 10.5.5.32/3GPP TS 24.008.
-	 */
-	err = get_ptw_multiplier(&ptw_multiplier);
-	if (err) {
-		return err;
-	}
-
-	err = at_params_list_init(&resp_list, AT_CEDRXP_PARAMS_COUNT_MAX);
-	if (err) {
-		LOG_ERR("Could not init AT params list, error: %d", err);
-		return err;
-	}
-
-	/* Parse CEDRXP response and populate AT parameter list */
-	err = at_parser_params_from_str(at_response,
-					NULL,
-					&resp_list);
-	if (err) {
-		LOG_ERR("Could not parse +CEDRXP response, error: %d", err);
-		goto clean_exit;
-	}
-
-	err = at_params_string_get(&resp_list, AT_CEDRXP_NW_EDRX_INDEX,
-				   tmp_buf, &len);
-	if (err) {
-		LOG_ERR("Failed to get eDRX configuration, error: %d", err);
-		goto clean_exit;
-	}
-
-	tmp_buf[len] = '\0';
-
-	/* The eDRX value is a multiple of 10.24 seconds, except for the
-	 * special case of idx == 0 for LTE-M, where the value is 5.12 seconds.
-	 * The variable idx is used to map to the entry of index idx in
-	 * Figure 10.5.5.32/3GPP TS 24.008, table for eDRX in S1 mode, and
-	 * note 4 and 5 are taken into account.
-	 */
-	idx = strtoul(tmp_buf, NULL, 2);
-
-	err = get_edrx_value(idx, &cfg->edrx);
-	if (err) {
-		LOG_ERR("Failed to get eDRX value, error; %d", err);
-		goto clean_exit;
-	}
-
-	len = sizeof(tmp_buf) - 1;
-
-	err = at_params_string_get(&resp_list, AT_CEDRXP_NW_PTW_INDEX,
-				   tmp_buf, &len);
-	if (err) {
-		LOG_ERR("Failed to get PTW configuration, error: %d", err);
-		goto clean_exit;
-	}
-
-	tmp_buf[len] = '\0';
-
-	/* Value can be a maximum of 15, as there are 16 entries in the table
-	 * for paging time window (both for LTE-M and NB1).
-	 */
-	idx = strtoul(tmp_buf, NULL, 2);
-	if (idx > 15) {
-		LOG_ERR("Invalid PTW lookup index: %d", idx);
-		err = -EINVAL;
-		goto clean_exit;
-	}
-
-	/* The Paging Time Window is different for LTE-M and NB-IoT:
-	 *	- LTE-M: (idx + 1) * 1.28 s
-	 *	- NB-IoT (idx + 1) * 2.56 s
-	 */
-	idx += 1;
-	cfg->ptw = idx * ptw_multiplier;
-
-	LOG_DBG("eDRX value: %d.%02d, PTW: %d.%02d",
-		(int)cfg->edrx,
-		(int)(100 * (cfg->edrx - (int)cfg->edrx)),
-		(int)cfg->ptw,
-		(int)(100 * (cfg->ptw - (int)cfg->ptw)));
-
-clean_exit:
-	at_params_list_free(&resp_list);
-
-	return err;
-}
-
 int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status)
 {
 	int err;
@@ -1590,7 +970,7 @@ int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status)
 		return err;
 	}
 
-	err = parse_nw_reg_status(buf, status, AT_CEREG_READ_REG_STATUS_INDEX);
+	err = parse_cereg(buf, false, status, NULL, NULL, NULL);
 	if (err) {
 		LOG_ERR("Could not parse registration status, err: %d", err);
 		return err;
@@ -1808,33 +1188,6 @@ clean_exit:
 	return err;
 }
 
-int lte_lc_func_mode_set(enum lte_lc_func_mode mode)
-{
-	switch (mode) {
-	case LTE_LC_FUNC_MODE_POWER_OFF:
-	case LTE_LC_FUNC_MODE_NORMAL:
-	case LTE_LC_FUNC_MODE_OFFLINE:
-	case LTE_LC_FUNC_MODE_DEACTIVATE_LTE:
-	case LTE_LC_FUNC_MODE_ACTIVATE_LTE:
-	case LTE_LC_FUNC_MODE_DEACTIVATE_GNSS:
-	case LTE_LC_FUNC_MODE_ACTIVATE_GNSS:
-	case LTE_LC_FUNC_MODE_OFFLINE_UICC_ON: {
-		char buf[12];
-		int ret = snprintk(buf, sizeof(buf), "AT+CFUN=%d", mode);
-
-		if ((ret < 0) || (ret >= sizeof(buf))) {
-			LOG_ERR("Failed to create functional mode command");
-			return -EFAULT;
-		}
-
-		return at_cmd_write(buf, NULL, 0, NULL);
-	}
-	default:
-		LOG_ERR("Invalid functional mode: %d", mode);
-		return -EINVAL;
-	}
-}
-
 int lte_lc_func_mode_get(enum lte_lc_func_mode *mode)
 {
 	int err, resp_mode;
@@ -1897,6 +1250,33 @@ clean_exit:
 	return err;
 }
 
+int lte_lc_func_mode_set(enum lte_lc_func_mode mode)
+{
+	switch (mode) {
+	case LTE_LC_FUNC_MODE_POWER_OFF:
+	case LTE_LC_FUNC_MODE_NORMAL:
+	case LTE_LC_FUNC_MODE_OFFLINE:
+	case LTE_LC_FUNC_MODE_DEACTIVATE_LTE:
+	case LTE_LC_FUNC_MODE_ACTIVATE_LTE:
+	case LTE_LC_FUNC_MODE_DEACTIVATE_GNSS:
+	case LTE_LC_FUNC_MODE_ACTIVATE_GNSS:
+	case LTE_LC_FUNC_MODE_OFFLINE_UICC_ON: {
+		char buf[12];
+		int ret = snprintk(buf, sizeof(buf), "AT+CFUN=%d", mode);
+
+		if ((ret < 0) || (ret >= sizeof(buf))) {
+			LOG_ERR("Failed to create functional mode command");
+			return -EFAULT;
+		}
+
+		return at_cmd_write(buf, NULL, 0, NULL);
+	}
+	default:
+		LOG_ERR("Invalid functional mode: %d", mode);
+		return -EINVAL;
+	}
+}
+
 int lte_lc_lte_mode_get(enum lte_lc_lte_mode *mode)
 {
 	int err;
@@ -1909,7 +1289,7 @@ int lte_lc_lte_mode_get(enum lte_lc_lte_mode *mode)
 		return err;
 	}
 
-	err = parse_cereg(false, buf, NULL, NULL, mode, NULL);
+	err = parse_cereg(buf, false, NULL, NULL, mode, NULL);
 	if (err) {
 		LOG_ERR("Could not parse registration status, err: %d", err);
 		return err;
@@ -1919,7 +1299,7 @@ int lte_lc_lte_mode_get(enum lte_lc_lte_mode *mode)
 }
 
 #if defined(CONFIG_LTE_AUTO_INIT_AND_CONNECT)
-SYS_DEVICE_DEFINE("LTE_LINK_CONTROL", w_lte_lc_init_and_connect,
+SYS_DEVICE_DEFINE("LTE_LINK_CONTROL", init_and_connect,
 		  device_pm_control_nop,
 		  APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
 #endif /* CONFIG_LTE_AUTO_INIT_AND_CONNECT */

--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <zephyr/types.h>
+#include <errno.h>
+#include <net/socket.h>
+#include <string.h>
+#include <stdio.h>
+#include <device.h>
+#include <modem/lte_lc.h>
+#include <modem/at_cmd.h>
+#include <modem/at_cmd_parser.h>
+#include <modem/at_params.h>
+#include <modem/at_notif.h>
+#include <logging/log.h>
+
+#include "lte_lc_helpers.h"
+
+LOG_MODULE_REGISTER(lte_lc_helpers, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
+
+/* Confirm valid system mode and set Paging Time Window multiplier.
+ * Multiplier is 1.28 s for LTE-M, and 2.56 s for NB-IoT, derived from
+ * Figure 10.5.5.32/3GPP TS 24.008.
+ */
+static int get_ptw_multiplier(enum lte_lc_lte_mode lte_mode, float *ptw_multiplier)
+{
+	switch (lte_mode) {
+	case LTE_LC_LTE_MODE_LTEM:
+		*ptw_multiplier = 1.28;
+		break;
+	case LTE_LC_LTE_MODE_NBIOT:
+		*ptw_multiplier = 2.56;
+		break;
+	default:
+		return -ENOTCONN;
+	}
+
+	return 0;
+}
+
+
+static int get_edrx_value(enum lte_lc_lte_mode lte_mode, uint8_t idx, float *edrx_value)
+{
+	uint16_t multiplier = 0;
+
+	/* Lookup table to eDRX multiplier values, based on T_eDRX values found
+	 * in Table 10.5.5.32/3GPP TS 24.008. The actual value is
+	 * (multiplier * 10.24 s), except for the first entry which is handled
+	 * as a special case per note 3 in the specification.
+	 */
+	static const uint16_t edrx_lookup_ltem[16] = {
+		0, 1, 2, 4, 6, 8, 10, 12, 14, 16, 32, 64, 128, 256, 256, 256
+	};
+	static const uint16_t edrx_lookup_nbiot[16] = {
+		2, 2, 2, 4, 2, 8, 2, 2, 2, 16, 32, 64, 128, 256, 512, 1024
+	};
+
+	if ((edrx_value == NULL) || (idx > ARRAY_SIZE(edrx_lookup_ltem) - 1)) {
+		return -EINVAL;
+	}
+
+	switch (lte_mode) {
+	case LTE_LC_LTE_MODE_LTEM:
+		multiplier = edrx_lookup_ltem[idx];
+		break;
+	case LTE_LC_LTE_MODE_NBIOT:
+		multiplier = edrx_lookup_nbiot[idx];
+		break;
+	default:
+		return -ENOTCONN;
+	}
+
+	*edrx_value = multiplier == 0 ? 5.12 : multiplier * 10.24;
+
+	return 0;
+}
+
+/**@brief Helper function to check if a response is what was expected
+ *
+ * @param response Pointer to response prefix
+ * @param response_len Length of the response to be checked
+ * @param check The buffer with "truth" to verify the response against,
+ *		for example "+CEREG"
+ *
+ * @return True if the provided buffer and check are equal, false otherwise.
+ */
+bool response_is_valid(const char *response, size_t response_len,
+			      const char *check)
+{
+	if ((response == NULL) || (check == NULL)) {
+		LOG_ERR("Invalid pointer provided");
+		return false;
+	}
+
+	if ((response_len < strlen(check)) ||
+	    (memcmp(response, check, response_len) != 0)) {
+		return false;
+	}
+
+	return true;
+}
+
+/* Get network registration status from CEREG response list.
+ * Returns the (positive) registration value if it's found, otherwise a negative
+ * error code.
+ */
+static int get_nw_reg_status(struct at_param_list *list, bool is_notif)
+{
+	int err, reg_status;
+	size_t reg_status_index = is_notif ? AT_CEREG_REG_STATUS_INDEX :
+					     AT_CEREG_READ_REG_STATUS_INDEX;
+
+	err = at_params_int_get(list, reg_status_index, &reg_status);
+	if (err) {
+		return err;
+	}
+
+	/* Check if the parsed value maps to a valid registration status */
+	switch (reg_status) {
+	case LTE_LC_NW_REG_NOT_REGISTERED:
+	case LTE_LC_NW_REG_REGISTERED_HOME:
+	case LTE_LC_NW_REG_SEARCHING:
+	case LTE_LC_NW_REG_REGISTRATION_DENIED:
+	case LTE_LC_NW_REG_UNKNOWN:
+	case LTE_LC_NW_REG_REGISTERED_ROAMING:
+	case LTE_LC_NW_REG_REGISTERED_EMERGENCY:
+	case LTE_LC_NW_REG_UICC_FAIL:
+		break;
+	default:
+		LOG_ERR("Invalid network registration status: %d", reg_status);
+		return -EINVAL;
+	}
+
+	return reg_status;
+}
+
+int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg)
+{
+	int err, tmp_int;
+	uint8_t idx;
+	struct at_param_list resp_list = {0};
+	char tmp_buf[5];
+	size_t len = sizeof(tmp_buf) - 1;
+	float ptw_multiplier;
+	enum lte_lc_lte_mode lte_mode = LTE_LC_LTE_MODE_NONE;
+
+	if ((at_response == NULL) || (cfg == NULL)) {
+		return -EINVAL;
+	}
+
+	err = at_params_list_init(&resp_list, AT_CEDRXP_PARAMS_COUNT_MAX);
+	if (err) {
+		LOG_ERR("Could not init AT params list, error: %d", err);
+		return err;
+	}
+
+	/* Parse CEDRXP response and populate AT parameter list */
+	err = at_parser_params_from_str(at_response,
+					NULL,
+					&resp_list);
+	if (err) {
+		LOG_ERR("Could not parse +CEDRXP response, error: %d", err);
+		goto clean_exit;
+	}
+
+	err = at_params_string_get(&resp_list, AT_CEDRXP_NW_EDRX_INDEX,
+				   tmp_buf, &len);
+	if (err) {
+		LOG_ERR("Failed to get eDRX configuration, error: %d", err);
+		goto clean_exit;
+	}
+
+	tmp_buf[len] = '\0';
+
+	/* The eDRX value is a multiple of 10.24 seconds, except for the
+	 * special case of idx == 0 for LTE-M, where the value is 5.12 seconds.
+	 * The variable idx is used to map to the entry of index idx in
+	 * Figure 10.5.5.32/3GPP TS 24.008, table for eDRX in S1 mode, and
+	 * note 4 and 5 are taken into account.
+	 */
+	idx = strtoul(tmp_buf, NULL, 2);
+
+	err = at_params_int_get(&resp_list, AT_CEDRXP_ACTT_INDEX, &tmp_int);
+	if (err) {
+		LOG_ERR("Failed to get LTE mode, error: %d", err);
+		goto clean_exit;
+	}
+
+	/* The acces technology indicators 4 for LTE-M and 5 for NB-IoT are
+	 * specified in 3GPP 27.007 Ch. 7.41.
+	 */
+	lte_mode = tmp_int == 4 ? LTE_LC_LTE_MODE_LTEM :
+		   tmp_int == 5 ? LTE_LC_LTE_MODE_NBIOT :
+				  LTE_LC_LTE_MODE_NONE;
+
+	/* Confirm valid system mode and set Paging Time Window multiplier.
+	 * Multiplier is 1.28 s for LTE-M, and 2.56 s for NB-IoT, derived from
+	 * figure 10.5.5.32/3GPP TS 24.008.
+	 */
+	err = get_ptw_multiplier(lte_mode, &ptw_multiplier);
+	if (err) {
+		LOG_WRN("Active LTE mode could not be determined");
+		goto clean_exit;
+	}
+
+	err = get_edrx_value(lte_mode, idx, &cfg->edrx);
+	if (err) {
+		LOG_ERR("Failed to get eDRX value, error; %d", err);
+		goto clean_exit;
+	}
+
+	len = sizeof(tmp_buf) - 1;
+
+	err = at_params_string_get(&resp_list, AT_CEDRXP_NW_PTW_INDEX,
+				   tmp_buf, &len);
+	if (err) {
+		LOG_ERR("Failed to get PTW configuration, error: %d", err);
+		goto clean_exit;
+	}
+
+	tmp_buf[len] = '\0';
+
+	/* Value can be a maximum of 15, as there are 16 entries in the table
+	 * for paging time window (both for LTE-M and NB1).
+	 */
+	idx = strtoul(tmp_buf, NULL, 2);
+	if (idx > 15) {
+		LOG_ERR("Invalid PTW lookup index: %d", idx);
+		err = -EINVAL;
+		goto clean_exit;
+	}
+
+	/* The Paging Time Window is different for LTE-M and NB-IoT:
+	 *	- LTE-M: (idx + 1) * 1.28 s
+	 *	- NB-IoT (idx + 1) * 2.56 s
+	 */
+	idx += 1;
+	cfg->ptw = idx * ptw_multiplier;
+
+	LOG_DBG("eDRX value: %d.%02d, PTW: %d.%02d",
+		(int)cfg->edrx,
+		(int)(100 * (cfg->edrx - (int)cfg->edrx)),
+		(int)cfg->ptw,
+		(int)(100 * (cfg->ptw - (int)cfg->ptw)));
+
+clean_exit:
+	at_params_list_free(&resp_list);
+
+	return err;
+}
+
+
+
+int parse_psm(struct at_param_list *at_params,
+			 bool is_notif,
+			 struct lte_lc_psm_cfg *psm_cfg)
+{
+	int err;
+	size_t tau_idx = is_notif ? AT_CEREG_TAU_INDEX :
+				    AT_CEREG_READ_TAU_INDEX;
+	size_t active_time_idx = is_notif ? AT_CEREG_ACTIVE_TIME_INDEX :
+					    AT_CEREG_READ_ACTIVE_TIME_INDEX;
+	char timer_str[9] = {0};
+	char unit_str[4] = {0};
+	size_t timer_str_len = sizeof(timer_str) - 1;
+	size_t unit_str_len = sizeof(unit_str) - 1;
+	size_t lut_idx;
+	uint32_t timer_unit, timer_value;
+
+	/* Lookup table for T3324 timer used for PSM active time in seconds.
+	 * Ref: GPRS Timer 2 IE in 3GPP TS 24.008 Table 10.5.163/3GPP TS 24.008.
+	 */
+	static const uint32_t t3324_lookup[8] = {2, 60, 600, 60, 60, 60, 60, 0};
+
+	/* Lookup table for T3412 timer used for periodic TAU. Unit is seconds.
+	 * Ref: GPRS Timer 3 in 3GPP TS 24.008 Table 10.5.163a/3GPP TS 24.008.
+	 */
+	static const uint32_t t3412_lookup[8] = {600, 3600, 36000, 2, 30, 60,
+					      1152000, 0};
+
+	/* Parse periodic TAU string */
+	err = at_params_string_get(at_params,
+				   tau_idx,
+				   timer_str,
+				   &timer_str_len);
+	if (err) {
+		LOG_ERR("Could not get TAU, error: %d", err);
+		return err;
+	}
+
+	memcpy(unit_str, timer_str, unit_str_len);
+
+	lut_idx = strtoul(unit_str, NULL, 2);
+	if (lut_idx > (ARRAY_SIZE(t3412_lookup) - 1)) {
+		LOG_ERR("Unable to parse periodic TAU string");
+		err = -EINVAL;
+		return err;
+	}
+
+	timer_unit = t3412_lookup[lut_idx];
+	timer_value = strtoul(timer_str + unit_str_len, NULL, 2);
+	psm_cfg->tau = timer_unit ? timer_unit * timer_value : -1;
+
+	/* Parse active time string */
+	err = at_params_string_get(at_params,
+				   active_time_idx,
+				   timer_str,
+				   &timer_str_len);
+	if (err) {
+		LOG_ERR("Could not get TAU, error: %d", err);
+		return err;
+	}
+
+	memcpy(unit_str, timer_str, unit_str_len);
+
+	lut_idx = strtoul(unit_str, NULL, 2);
+	if (lut_idx > (ARRAY_SIZE(t3324_lookup) - 1)) {
+		LOG_ERR("Unable to parse active time string");
+		err = -EINVAL;
+		return err;
+	}
+
+	timer_unit = t3324_lookup[lut_idx];
+	timer_value = strtoul(timer_str + unit_str_len, NULL, 2);
+	psm_cfg->active_time = timer_unit ? timer_unit * timer_value : -1;
+
+	LOG_DBG("TAU: %d sec, active time: %d sec\n",
+		psm_cfg->tau, psm_cfg->active_time);
+
+	return 0;
+}
+
+
+/**@brief Parses an AT command response, and returns the current RRC mode.
+ *
+ * @param at_response Pointer to buffer with AT response.
+ * @param mode Pointer to where the RRC mode is stored.
+ * @param mode_index Parameter index for mode.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int parse_rrc_mode(const char *at_response,
+		   enum lte_lc_rrc_mode *mode,
+		   size_t mode_index)
+{
+	int err, temp_mode;
+	struct at_param_list resp_list = {0};
+
+	err = at_params_list_init(&resp_list, AT_CSCON_PARAMS_COUNT_MAX);
+	if (err) {
+		LOG_ERR("Could not init AT params list, error: %d", err);
+		return err;
+	}
+
+	/* Parse CSCON response and populate AT parameter list */
+	err = at_parser_params_from_str(at_response,
+					NULL,
+					&resp_list);
+	if (err) {
+		LOG_ERR("Could not parse +CSCON response, error: %d", err);
+		goto clean_exit;
+	}
+
+	/* Get the RRC mode from the response */
+	err = at_params_int_get(&resp_list, mode_index, &temp_mode);
+	if (err) {
+		LOG_ERR("Could not get signalling mode, error: %d", err);
+		goto clean_exit;
+	}
+
+	/* Check if the parsed value maps to a valid registration status */
+	if (temp_mode == 0) {
+		*mode = LTE_LC_RRC_MODE_IDLE;
+	} else if (temp_mode == 1) {
+		*mode = LTE_LC_RRC_MODE_CONNECTED;
+	} else {
+		LOG_ERR("Invalid signalling mode: %d", temp_mode);
+		err = -EINVAL;
+	}
+
+clean_exit:
+	at_params_list_free(&resp_list);
+
+	return err;
+}
+
+int parse_cereg(const char *at_response,
+		bool is_notif,
+		enum lte_lc_nw_reg_status *reg_status,
+		struct lte_lc_cell *cell,
+		enum lte_lc_lte_mode *lte_mode,
+		struct lte_lc_psm_cfg *psm_cfg)
+{
+	int err, status;
+	struct at_param_list resp_list;
+	char str_buf[10];
+	char  response_prefix[sizeof(AT_CEREG_RESPONSE_PREFIX)] = {0};
+	size_t response_prefix_len = sizeof(response_prefix);
+	size_t len = sizeof(str_buf) - 1;
+
+	err = at_params_list_init(&resp_list, AT_CEREG_PARAMS_COUNT_MAX);
+	if (err) {
+		LOG_ERR("Could not init AT params list, error: %d", err);
+		return err;
+	}
+
+	/* Parse CEREG response and populate AT parameter list */
+	err = at_parser_params_from_str(at_response,
+					NULL,
+					&resp_list);
+	if (err) {
+		LOG_ERR("Could not parse AT+CEREG response, error: %d", err);
+		goto clean_exit;
+	}
+
+	/* Check if AT command response starts with +CEREG */
+	err = at_params_string_get(&resp_list,
+				   AT_RESPONSE_PREFIX_INDEX,
+				   response_prefix,
+				   &response_prefix_len);
+	if (err) {
+		LOG_ERR("Could not get response prefix, error: %d", err);
+		goto clean_exit;
+	}
+
+	if (!response_is_valid(response_prefix, response_prefix_len,
+			       AT_CEREG_RESPONSE_PREFIX)) {
+		/* The unsolicited response is not a CEREG response, ignore it.
+		 */
+		LOG_DBG("Not a valid CEREG response");
+		goto clean_exit;
+	}
+
+	/* Get network registration status */
+	status = get_nw_reg_status(&resp_list, is_notif);
+	if (status < 0) {
+		LOG_ERR("Could not get registration status, error: %d", status);
+		err = status;
+		goto clean_exit;
+	}
+
+	if (reg_status) {
+		*reg_status = status;
+	}
+
+	LOG_DBG("Network registration status: %d", *reg_status);
+
+	if (cell && (status != LTE_LC_NW_REG_UICC_FAIL) &&
+	    (at_params_valid_count_get(&resp_list) > AT_CEREG_CELL_ID_INDEX)) {
+		/* Parse tracking area code */
+		err = at_params_string_get(
+				&resp_list,
+				is_notif ? AT_CEREG_TAC_INDEX :
+					   AT_CEREG_READ_TAC_INDEX,
+				str_buf, &len);
+		if (err) {
+			LOG_ERR("Could not get tracking area code, error: %d", err);
+			goto clean_exit;
+		}
+
+		str_buf[len] = '\0';
+		cell->tac = strtoul(str_buf, NULL, 16);
+
+		/* Parse cell ID */
+		len = sizeof(str_buf) - 1;
+
+		err = at_params_string_get(&resp_list,
+				is_notif ? AT_CEREG_CELL_ID_INDEX :
+					   AT_CEREG_READ_CELL_ID_INDEX,
+				str_buf, &len);
+		if (err) {
+			LOG_ERR("Could not get cell ID, error: %d", err);
+			goto clean_exit;
+		}
+
+		str_buf[len] = '\0';
+		cell->id = strtoul(str_buf, NULL, 16);
+	} else if (cell) {
+		cell->tac = UINT32_MAX;
+		cell->id = UINT32_MAX;
+	}
+
+	if (lte_mode) {
+		int mode;
+
+		/* Get currently active LTE mode. */
+		err = at_params_int_get(&resp_list,
+				is_notif ? AT_CEREG_ACT_INDEX :
+					   AT_CEREG_READ_ACT_INDEX,
+				&mode);
+		if (err) {
+			LOG_DBG("LTE mode not found, error code: %d", err);
+			*lte_mode = LTE_LC_LTE_MODE_NONE;
+
+			/* This is not an error that should be returned, as it's
+			 * expected in some situations that LTE mode is not
+			 * available.
+			 */
+			err = 0;
+		} else {
+			*lte_mode = mode;
+
+			LOG_DBG("LTE mode: %d", *lte_mode);
+		}
+	}
+
+	/* Parse PSM configuration only when registered */
+	if (psm_cfg && ((status == LTE_LC_NW_REG_REGISTERED_HOME) ||
+	    (status == LTE_LC_NW_REG_REGISTERED_ROAMING)) &&
+	     (at_params_valid_count_get(&resp_list) > AT_CEREG_TAU_INDEX)) {
+		err = parse_psm(&resp_list, is_notif, psm_cfg);
+		if (err) {
+			LOG_ERR("Failed to parse PSM configuration, error: %d",
+				err);
+			goto clean_exit;
+		}
+	} else if (psm_cfg) {
+		/* When device is not registered, PSM valies are invalid */
+		psm_cfg->tau = -1;
+		psm_cfg->active_time = -1;
+	}
+
+clean_exit:
+	at_params_list_free(&resp_list);
+
+	return err;
+}

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <zephyr/types.h>
+#include <string.h>
+#include <stdio.h>
+#include <modem/lte_lc.h>
+#include <modem/at_cmd.h>
+#include <modem/at_cmd_parser.h>
+#include <modem/at_params.h>
+#include <logging/log.h>
+
+#define LC_MAX_READ_LENGTH			128
+
+#define AT_CMD_SIZE(x)				(sizeof(x) - 1)
+#define AT_RESPONSE_PREFIX_INDEX		0
+#define AT_CFUN_READ				"AT+CFUN?"
+#define AT_CFUN_RESPONSE_PREFIX			"+CFUN"
+#define AT_CFUN_MODE_INDEX			1
+#define AT_CFUN_PARAMS_COUNT			2
+#define AT_CFUN_RESPONSE_MAX_LEN		20
+#define AT_CEREG_5				"AT+CEREG=5"
+#define AT_CEREG_READ				"AT+CEREG?"
+#define AT_CEREG_RESPONSE_PREFIX		"+CEREG"
+#define AT_CEREG_PARAMS_COUNT_MAX		11
+#define AT_CEREG_REG_STATUS_INDEX		1
+#define AT_CEREG_READ_REG_STATUS_INDEX		2
+#define AT_CEREG_TAC_INDEX			2
+#define AT_CEREG_READ_TAC_INDEX			3
+#define AT_CEREG_CELL_ID_INDEX			3
+#define AT_CEREG_READ_CELL_ID_INDEX		4
+#define AT_CEREG_ACT_INDEX			4
+#define AT_CEREG_READ_ACT_INDEX			5
+#define AT_CEREG_ACTIVE_TIME_INDEX		7
+#define AT_CEREG_READ_ACTIVE_TIME_INDEX		8
+#define AT_CEREG_TAU_INDEX			8
+#define AT_CEREG_READ_TAU_INDEX			9
+#define AT_CEREG_RESPONSE_MAX_LEN		80
+#define AT_XSYSTEMMODE_READ			"AT%XSYSTEMMODE?"
+#define AT_XSYSTEMMODE_RESPONSE_PREFIX		"%XSYSTEMMODE"
+#define AT_XSYSTEMMODE_PROTO			"AT%%XSYSTEMMODE=%d,%d,%d,%d"
+
+/* The indices are for the set command. Add 1 for the read command indices. */
+#define AT_XSYSTEMMODE_READ_LTEM_INDEX		1
+#define AT_XSYSTEMMODE_READ_NBIOT_INDEX		2
+#define AT_XSYSTEMMODE_READ_GPS_INDEX		3
+#define AT_XSYSTEMMODE_READ_PREFERENCE_INDEX	4
+#define AT_XSYSTEMMODE_PARAMS_COUNT		5
+#define AT_XSYSTEMMODE_RESPONSE_MAX_LEN		30
+
+/* CEDRXS command parameters */
+#define AT_CEDRXS_MODE_INDEX
+#define AT_CEDRXS_ACTT_WB			4
+#define AT_CEDRXS_ACTT_NB			5
+
+/* CEDRXP notification parameters */
+#define AT_CEDRXP_PARAMS_COUNT_MAX		6
+#define AT_CEDRXP_ACTT_INDEX			1
+#define AT_CEDRXP_REQ_EDRX_INDEX		2
+#define AT_CEDRXP_NW_EDRX_INDEX			3
+#define AT_CEDRXP_NW_PTW_INDEX			4
+
+/* CSCON command parameters */
+#define AT_CSCON_RESPONSE_PREFIX		"+CSCON"
+#define AT_CSCON_PARAMS_COUNT_MAX		4
+#define AT_CSCON_RRC_MODE_INDEX			1
+#define AT_CSCON_READ_RRC_MODE_INDEX		2
+
+/* @brief Helper function to check if a response is what was expected.
+ *
+ * @param response Pointer to response prefix
+ * @param response_len Length of the response to be checked
+ * @param check The buffer with "truth" to verify the response against,
+ *		for example "+CEREG"
+ *
+ * @return True if the provided buffer and check are equal, false otherwise.
+ */
+bool response_is_valid(const char *response, size_t response_len,
+		       const char *check);
+
+/* @brief Parses an AT command response, and returns the current RRC mode.
+ *
+ * @param at_response Pointer to buffer with AT response.
+ * @param mode Pointer to where the RRC mode is stored.
+ * @param mode_index Parameter index for mode.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int parse_rrc_mode(const char *at_response,
+		   enum lte_lc_rrc_mode *mode,
+		   size_t mode_index);
+
+/* @brief Parses an AT command response and returns the current eDRX configuration.
+ *
+ * @note It's assumed that the network only reports valid eDRX values when
+ *	 in each mode (LTE-M and NB1). There's no sanity-check of these values.
+ *
+ * @param at_response Pointer to buffer with AT response.
+ * @param cfg Pointer to where the eDRX configuration is stored.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int parse_edrx(const char *at_response, struct lte_lc_edrx_cfg *cfg);
+
+/* @brief Parses an AT+CEREG response parameter list and extracts the PSM
+ *	  configuration.
+ *
+ * @param at_params Pointer to AT parameter list.
+ * @param is_notif Indicates if the AT list is for a notification.
+ * @param psm_cfg Pointer to where the PSM configuration is stored.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int parse_psm(struct at_param_list *at_params,
+		  bool is_notif,
+		  struct lte_lc_psm_cfg *psm_cfg);
+
+/* @brief Parses an CEREG response and returns network registration status,
+ *	  cell information, LTE mode and pSM configuration.
+ *
+ * @param at_response Pointer to buffer with AT response.
+ * @param is_notif The buffer in at_response is a notification.
+ * @param reg_status Pointer to where the registration status is stored.
+ *		     Can be NULL.
+ * @param cell Pointer to cell information struct. Can be NULL.
+ * @param lte_mode Pointer to LTE mode struct. Can be NULL.
+ * @param psm_cfg Pointer to PSM configuration struct. Can be NULL.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int parse_cereg(const char *at_response,
+		bool is_notif,
+		enum lte_lc_nw_reg_status *reg_status,
+		struct lte_lc_cell *cell,
+		enum lte_lc_lte_mode *lte_mode,
+		struct lte_lc_psm_cfg *psm_cfg);

--- a/tests/lib/lte_lc/CMakeLists.txt
+++ b/tests/lib/lte_lc/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(lte_lc)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_sources(app
+  PRIVATE
+  ${ZEPHYR_BASE}/../nrf/lib/lte_link_control/lte_lc_helpers.c
+)
+
+target_include_directories(app
+  PRIVATE
+  ${ZEPHYR_BASE}/../nrf/lib/lte_link_control/
+)
+
+target_compile_options(app
+  PRIVATE
+  -DCONFIG_LTE_LINK_CONTROL_LOG_LEVEL=0
+)

--- a/tests/lib/lte_lc/boards/nrf9160dk_nrf9160.conf
+++ b/tests/lib/lte_lc/boards/nrf9160dk_nrf9160.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NEWLIB_LIBC=y

--- a/tests/lib/lte_lc/boards/nrf9160dk_nrf9160ns.conf
+++ b/tests/lib/lte_lc/boards/nrf9160dk_nrf9160ns.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NEWLIB_LIBC=y

--- a/tests/lib/lte_lc/boards/qemu_x86.conf
+++ b/tests/lib/lte_lc/boards/qemu_x86.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_NEWLIB_LIBC=y
+CONFIG_FPU=y
+CONFIG_SSE=y

--- a/tests/lib/lte_lc/prj.conf
+++ b/tests/lib/lte_lc/prj.conf
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# ZTEST
+CONFIG_ZTEST=y
+
+# Heap is used by the AT command parser
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+
+# AT command parser library
+CONFIG_AT_CMD_PARSER=y

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <ztest.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "lte_lc_helpers.h"
+
+static void test_parse_edrx(void)
+{
+	int err;
+	struct lte_lc_edrx_cfg cfg;
+	char *at_response_none = "+CEDRXP: 1,\"1000\",\"0101\",\"1011\"";
+	char *at_response_ltem = "+CEDRXP: 4,\"1000\",\"0101\",\"1011\"";
+	char *at_response_ltem_2 = "+CEDRXP: 4,\"1000\",\"0010\",\"1110\"";
+	char *at_response_nbiot = "+CEDRXP: 5,\"1000\",\"1101\",\"0111\"";
+	char *at_response_nbiot_2 = "+CEDRXP: 5,\"1000\",\"1101\",\"0101\"";
+
+	err = parse_edrx(at_response_none, &cfg);
+	zassert_not_equal(0, err, "parse_edrx should have failed");
+
+	err = parse_edrx(at_response_ltem, &cfg);
+	zassert_equal(0, err, "parse_edrx failed, error: %d", err);
+	zassert_within(cfg.edrx, 81.92, 0.1, "Wrong eDRX value");
+	zassert_within(cfg.ptw, 15.36,  0.1, "Wrong PTW value");
+
+	err = parse_edrx(at_response_ltem_2, &cfg);
+	zassert_equal(0, err, "parse_edrx failed, error: %d", err);
+	zassert_within(cfg.edrx, 20.48, 0.1, "Wrong eDRX value");
+	zassert_within(cfg.ptw, 19.2, 0.1, "Wrong PTW value");
+
+	err = parse_edrx(at_response_nbiot, &cfg);
+	zassert_equal(0, err, "parse_edrx failed, error: %d", err);
+	zassert_within(cfg.edrx, 2621.44, 0.1, "Wrong eDRX value");
+	zassert_within(cfg.ptw, 20.48, 0.1, "Wrong PTW value");
+
+	err = parse_edrx(at_response_nbiot_2, &cfg);
+	zassert_equal(0, err, "parse_edrx failed, error: %d", err);
+	zassert_within(cfg.edrx, 2621.44, 0.1, "Wrong eDRX value");
+	zassert_within(cfg.ptw, 15.36, 0.1, "Wrong PTW value");
+}
+
+void test_parse_cereg(void)
+{
+	int err;
+	enum lte_lc_nw_reg_status status;
+	enum lte_lc_lte_mode mode;
+	struct lte_lc_cell cell;
+	struct lte_lc_psm_cfg psm_cfg;
+	char *at_response_0 = "+CEREG: 5,0,,,9,0,0,,";
+	char *at_response_1 = "+CEREG: 5,1,\"0A0B\",\"01020304\",9,0,0,\"00100110\",\"01011111\"";
+	char *at_response_2 = "+CEREG: 5,2,\"0A0B\",\"01020304\",9,0,0,\"11100000\",\"11100000\"";
+	char *at_response_3 = "+CEREG: 5,3,\"0A0B\",\"01020304\",9,0,0,,";
+	char *at_response_4 = "+CEREG: 5,4,\"0A0B\",\"FFFFFFFF\",9,0,0,,";
+	char *at_response_5 = "+CEREG: 5,5,\"0A0B\",\"01020304\",9,0,0,\"11100000\",\"11100000\"";
+	char *at_response_8 = "+CEREG: 5,8,\"0A0B\",\"01020304\",9,0,0,,";
+	char *at_response_90 = "+CEREG: 5,90,,\"FFFFFFFF\",,,,,";
+	char *at_response_wrong = "+CEREG: 5,10,,\"FFFFFFFF\",,,,,";
+	char *at_notif_0 = "+CEREG: 0,\"FFFF\",\"FFFFFFFF\",9,0,0,,";
+	char *at_notif_1 = "+CEREG: 1,\"0A0B\",\"01020304\",9,0,0,\"00100110\",\"01011111\"";
+	char *at_notif_2 = "+CEREG: 2,\"0A0B\",\"01020304\",9,0,0,,";
+	char *at_notif_3 = "+CEREG: 3,\"0A0B\",\"01020304\",9,0,0,,";
+	char *at_notif_4 = "+CEREG: 4,\"FFFF\",\"FFFFFFFF\",9,0,0,,";
+	char *at_notif_5 = "+CEREG: 5,\"0A0B\",\"01020304\",9,0,0,\"11100000\",\"00011111\"";
+	char *at_notif_8 = "+CEREG: 8,\"0A0B\",\"01020304\",9,0,0,,";
+	char *at_notif_90 = "+CEREG: 90,,\"FFFFFFFF\",,,,,";
+	char *at_notif_wrong = "+CEREG: 10,,\"FFFFFFFF\",,,,,";
+
+	/* For CEREG reads, we only check the network status, as that's the only
+	 * functionality that is exposed.
+	 */
+	err = parse_cereg(at_response_0, false, &status, NULL, NULL, NULL);
+	zassert_equal(0, err, "parse_cereg failed, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_NOT_REGISTERED,
+		      "Wrong network registation status");
+
+	err = parse_cereg(at_response_1, false, &status, &cell, &mode, &psm_cfg);
+	zassert_equal(0, err, "parse_cereg failed, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_REGISTERED_HOME,
+		      "Wrong network registation status: %d", status);
+	zassert_equal(cell.id, 0x01020304, "Wrong cell ID (0x%08x)", cell.id);
+	zassert_equal(cell.tac, 0x0A0B, "Wrong area code");
+	zassert_equal(mode, 9, "Wrong LTE mode");
+	zassert_equal(psm_cfg.tau, 1116000, "Wrong PSM TAU");
+	zassert_equal(psm_cfg.active_time, 360, "Wrong PSM active time");
+
+	err = parse_cereg(at_response_2, false, &status, NULL, NULL, NULL);
+	zassert_equal(0, err, "parse_cereg failed, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_SEARCHING,
+		      "Wrong network registation status");
+
+	err = parse_cereg(at_response_3, false, &status, NULL, NULL, NULL);
+	zassert_equal(0, err, "parse_cereg failed, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_REGISTRATION_DENIED,
+		      "Wrong network registation status");
+
+	err = parse_cereg(at_response_4, false, &status, NULL, NULL, NULL);
+	zassert_equal(0, err, "parse_cereg failed, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_UNKNOWN,
+		      "Wrong network registation status");
+
+	err = parse_cereg(at_response_5, false, &status, NULL, NULL, NULL);
+	zassert_equal(0, err, "parse_cereg failed, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_REGISTERED_ROAMING,
+		      "Wrong network registation status");
+
+	err = parse_cereg(at_response_8, false, &status, NULL, NULL, NULL);
+	zassert_equal(0, err, "parse_cereg failed, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_REGISTERED_EMERGENCY,
+		      "Wrong network registation status");
+
+	err = parse_cereg(at_response_90, false, &status, NULL, NULL, NULL);
+	zassert_equal(0, err, "parse_cereg failed, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_UICC_FAIL,
+		      "Wrong network registation status");
+
+	err = parse_cereg(at_response_wrong, false, &status, NULL, NULL, NULL);
+	zassert_not_equal(0, err, "parse_cereg should have failed");
+
+	/* For CEREG notifications, we test the parser function, which
+	 * implicitly also tests parse_nw_reg_status() for notifications.
+	 */
+	err = parse_cereg(at_notif_0, true, &status, &cell, &mode, &psm_cfg);
+	zassert_equal(0, err, "parse_cereg failed, true, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_NOT_REGISTERED,
+		      "Wrong network registation status");
+
+	err = parse_cereg(at_notif_1, true, &status, &cell, &mode, &psm_cfg);
+	zassert_equal(0, err, "parse_cereg failed, true, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_REGISTERED_HOME,
+		      "Wrong network registation status");
+	zassert_equal(cell.id, 0x01020304, "Wrong cell ID (0x%08x)", cell.id);
+	zassert_equal(cell.tac, 0x0A0B, "Wrong area code");
+	zassert_equal(mode, 9, "Wrong LTE mode");
+	zassert_equal(psm_cfg.tau, 1116000, "Wrong PSM TAU");
+	zassert_equal(psm_cfg.active_time, 360, "Wrong PSM active time");
+
+	err = parse_cereg(at_notif_2, true, &status, &cell, &mode, &psm_cfg);
+	zassert_equal(0, err, "parse_cereg failed, true, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_SEARCHING,
+		      "Wrong network registation status");
+	zassert_equal(cell.id, 0x01020304, "Wrong cell ID");
+	zassert_equal(cell.tac, 0x0A0B, "Wrong area code");
+	zassert_equal(mode, 9, "Wrong LTE mode");
+
+	err = parse_cereg(at_notif_3, true, &status, &cell, &mode, &psm_cfg);
+	zassert_equal(0, err, "parse_cereg failed, true, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_REGISTRATION_DENIED,
+		      "Wrong network registation status");
+	zassert_equal(cell.id, 0x01020304, "Wrong cell ID");
+	zassert_equal(cell.tac, 0x0A0B, "Wrong area code");
+	zassert_equal(mode, 9, "Wrong LTE mode");
+
+	err = parse_cereg(at_notif_4, true, &status, &cell, &mode, &psm_cfg);
+	zassert_equal(0, err, "parse_cereg failed, true, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_UNKNOWN,
+		      "Wrong network registation status");
+	zassert_equal(cell.id, 0xFFFFFFFF, "Wrong cell ID");
+	zassert_equal(cell.tac, 0xFFFF, "Wrong area code");
+	zassert_equal(mode, 9, "Wrong LTE mode");
+
+	err = parse_cereg(at_notif_5, true, &status, &cell, &mode, &psm_cfg);
+	zassert_equal(0, err, "parse_cereg failed, true, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_REGISTERED_ROAMING,
+		      "Wrong network registation status");
+	zassert_equal(cell.id, 0x01020304, "Wrong cell ID");
+	zassert_equal(cell.tac, 0x0A0B, "Wrong area code");
+	zassert_equal(mode, 9, "Wrong LTE mode");
+	zassert_equal(psm_cfg.tau, 18600, "Wrong PSM TAU: %d", psm_cfg.tau);
+	zassert_equal(psm_cfg.active_time, -1, "Wrong PSM active time: %d",
+		      psm_cfg.active_time);
+
+	err = parse_cereg(at_notif_8, true, &status, &cell, &mode, &psm_cfg);
+	zassert_equal(0, err, "parse_cereg failed, true, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_REGISTERED_EMERGENCY,
+		      "Wrong network registation status");
+	zassert_equal(cell.id, 0x01020304, "Wrong cell ID");
+	zassert_equal(cell.tac, 0x0A0B, "Wrong area code");
+	zassert_equal(mode, 9, "Wrong LTE mode");
+
+	err = parse_cereg(at_notif_90, true, &status, &cell, &mode, &psm_cfg);
+	zassert_equal(0, err, "parse_cereg failed, true, error: %d", err);
+	zassert_equal(status, LTE_LC_NW_REG_UICC_FAIL,
+		      "Wrong network registation status");
+
+	err = parse_cereg(at_notif_wrong, true, &status, &cell, &mode, &psm_cfg);
+	zassert_not_equal(0, err, "parse_cereg should have true, failed");
+}
+
+static void test_parse_rrc_mode(void)
+{
+	int err;
+	enum lte_lc_rrc_mode mode;
+	char *at_response_0 = "+CSCON: 0";
+	char *at_response_1 = "+CSCON: 1";
+
+	err = parse_rrc_mode(at_response_0, &mode, AT_CSCON_RRC_MODE_INDEX);
+	zassert_equal(0, err, "parse_rrc_mode failed, error: %d", err);
+	zassert_equal(mode, LTE_LC_RRC_MODE_IDLE, "Wrong RRC mode");
+
+	err = parse_rrc_mode(at_response_1, &mode, AT_CSCON_RRC_MODE_INDEX);
+	zassert_equal(0, err, "parse_rrc_mode failed, error: %d", err);
+	zassert_equal(mode, LTE_LC_RRC_MODE_CONNECTED, "Wrong RRC mode");
+
+}
+
+static void test_response_is_valid(void)
+{
+	char *cscon = "+CSCON";
+	char *xsystemmode = "+%XSYSTEMMODE";
+
+	zassert_true(response_is_valid(cscon, strlen(cscon), "+CSCON"),
+		     "response_is_valid failed");
+
+	zassert_true(response_is_valid(xsystemmode, strlen(xsystemmode), "+%XSYSTEMMODE"),
+		     "response_is_valid failed");
+
+	zassert_false(response_is_valid(cscon, strlen(xsystemmode), "+%XSYSTEMMODE"),
+		     "response_is_valid should have failed");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(test_lte_lc,
+		ztest_unit_test(test_parse_edrx),
+		ztest_unit_test(test_parse_cereg),
+		ztest_unit_test(test_parse_rrc_mode),
+		ztest_unit_test(test_response_is_valid)
+	);
+
+	ztest_run_test_suite(test_lte_lc);
+}

--- a/tests/lib/lte_lc/testcase.yaml
+++ b/tests/lib/lte_lc/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  lte_lc.functionality_test:
+    platform_allow: nrf9160dk_nrf9160 qemu_x86 native_posix
+    tags: lte_lc


### PR DESCRIPTION
This PR contains the following changes:

- Adds an API to set the modem's functional mode. Currently this
functionality is covered by wrapper functions like lte_lc_normal()
and lte_lc_offline(). By adding the new API along with expanding
the existing lte_lc_func_mode enumerator, it's now possible to use
all functional modes supported by the modem.

- Extract and refactor helper functions. 
Helper functions, mostly for parsing, in the link controller are
abstraced and moved to a separate file.
This makes them easier to maintain and test.

- Add tests for LTE link controller helper functions.