### PR TITLE
mpsl: Fix FEM compilation warning

### DIFF
--- a/subsys/mpsl/mpsl_fem.c
+++ b/subsys/mpsl/mpsl_fem.c
@@ -61,6 +61,7 @@ static void fem_pin_num_correction(uint8_t *p_gpio_pin, const char *gpio_lbl)
 	__ASSERT(false, "Unknown GPIO port DT label");
 }
 
+#if IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_GPIO)
 static int inactive_pin_configure(uint8_t pin, const char *gpio_lbl,
 				  gpio_flags_t flags)
 {
@@ -94,6 +95,7 @@ static int inactive_pin_configure(uint8_t pin, const char *gpio_lbl,
 			port, pin, GPIO_OUTPUT_INACTIVE | flags);
 	}
 }
+#endif
 
 static int ppi_channel_alloc(uint8_t *ppi_channels, size_t size)
 {


### PR DESCRIPTION
When using generic-fem-two-ctrl-pins,
inactive_pin_configure produces [-Werror=unused-function]

Signed-off-by: Konstantinos Sotiropoulos <koso@nordicsemi.no>