### PR TITLE
samples: bluetooth: Add information to documentation.

### DIFF
--- a/samples/bluetooth/central_hr_coded/README.rst
+++ b/samples/bluetooth/central_hr_coded/README.rst
@@ -13,7 +13,7 @@ However, this sample specifically looks for heart rate monitors using LE Coded P
 Overview
 ********
 
-The sample demonstrates a Bluetooth LE Central role functionality by scanning for other Bluetooth LE devices that run a Heart Rate Server with LE Coded PHY support.
+The sample demonstrates a Bluetooth LE Central role functionality by scanning for other Bluetooth LE devices that run a Heart Rate Server with LE Coded PHY support which not available in Zephyr Bluetooth LE Controller (See :ref:`ug_ble_controller` for more information).
 It then establishes a connection to the first Peripheral device in range.
 It can be used together with the :ref:`peripheral_hr_coded` sample.
 

--- a/samples/bluetooth/peripheral_hr_coded/README.rst
+++ b/samples/bluetooth/peripheral_hr_coded/README.rst
@@ -13,7 +13,7 @@ However, this sample supports LE Coded PHY.
 Overview
 ********
 
-The sample demonstrates a basic Bluetooth LE Peripheral role functionality that exposes the Heart Rate GATT Service with LE Coded PHY support.
+The sample demonstrates a basic Bluetooth LE Peripheral role functionality that exposes the Heart Rate GATT Service with LE Coded PHY support which not available in Zephyr Bluetooth LE Controller (See :ref:`ug_ble_controller` for more information).
 Once it connects to a Central device, it generates dummy heart rate values.
 It can be used together with the :ref:`bluetooth_central_hr_coded` sample.
 


### PR DESCRIPTION
In central_hr_coded and peripheral_hr_coded documention
added information that these samples doesn't support ZephyrLL

Ref: NCSDK-8743

Signed-off-by: Marcin Jeliński <marcin.jelinski@nordicsemi.no>