### PR TITLE
zigbee: Set USB transport for NCP built on nRF52 dongle [KRKNWK-9100]

### DIFF
--- a/samples/zigbee/ncp/CMakeLists.txt
+++ b/samples/zigbee/ncp/CMakeLists.txt
@@ -20,6 +20,11 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static.yml"
   )
 endif()
 
+# Set USB as default transport when nRF52 Dongle board is selected
+if (${BOARD} STREQUAL "nrf52840dongle_nrf52840")
+  set(CONF_FILE "prj_usb.conf")
+endif()
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project("ZBOSS NCP SoC firmware")

--- a/samples/zigbee/ncp/README.rst
+++ b/samples/zigbee/ncp/README.rst
@@ -90,7 +90,7 @@ For example:
 The USB device VID and PID are configured by the sample's Kconfig file.
 
 .. note::
-    If you want to use the USB as the NCP communication channel when using the nRF52840 Dongle, building the sample with the :file:`prj_usb.conf` configuration file is mandatory.
+    The USB is used as the default NCP communication channel when using the nRF52840 Dongle.
 
 .. _zigbee_ncp_bootloader:
 


### PR DESCRIPTION
Set by default USB transport for NCP sample when built on nRF52 dongle