### PR TITLE
drivers: sensor_sim: Fetch all channels

### DIFF
--- a/drivers/sensor/sensor_sim/sensor_sim.c
+++ b/drivers/sensor/sensor_sim/sensor_sim.c
@@ -444,6 +444,13 @@ static int sensor_sim_generate_data(enum sensor_channel chan)
 	int err = 0;
 
 	switch (chan) {
+	case SENSOR_CHAN_ALL:
+		generate_temp_data();
+		generate_humidity_data();
+		generate_pressure_data();
+		err = generate_accel_data(SENSOR_CHAN_ACCEL_XYZ);
+		break;
+
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
 	case SENSOR_CHAN_ACCEL_Z:


### PR DESCRIPTION
Change adds support for fetching all available channels. It is used by the CAF sensor sampler module.

Jira: NCSDK-9013