### PR TITLE
cmake: add s1 variant of dev_handles.c

### DIFF
--- a/cmake/s1.cmake
+++ b/cmake/s1.cmake
@@ -72,6 +72,18 @@ if (CONFIG_BUILD_S1_VARIANT AND
     set(${link_variant}generated_kernel_files ${link_variant}isr_tables.c)
   endif()
 
+  add_custom_command(
+    OUTPUT ${link_variant}dev_handles.c
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${ZEPHYR_BASE}/scripts/gen_handles.py
+    --output-source ${link_variant}dev_handles.c
+    --kernel $<TARGET_FILE:${${link_variant}prebuilt}>
+    --zephyr-base ${ZEPHYR_BASE}
+    DEPENDS $<TARGET_FILE:${${link_variant}prebuilt}>
+    )
+  set(${link_variant}generated_kernel_files ${link_variant}dev_handles.c)
+
   configure_linker_script(
     ${link_variant}linker.cmd
     "-DLINK_INTO_${link_variant_name};-DLINKER_PASS2"


### PR DESCRIPTION
This fixes a bug where you would get orphan sections when
linking the S1 candidate.

All source code which is generated based on the first round
of linking needs to have the same handling in s1.cmake as
it does in zephyr/CMakeLists.txt.

This commit adds handling of generating 'dev_handles.c'
which was added in the latest upmerge.

Ref: NCSDK-9055
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>