### PR TITLE
crypto: tests: Fixed unsafe hex2bin calls in crypto test

### DIFF
--- a/tests/crypto/src/common_test.c
+++ b/tests/crypto/src/common_test.c
@@ -127,6 +127,11 @@ uint32_t get_vector_count(const test_case_t *tc)
 	       test_vector_sizes[tc->vector_type];
 }
 
+size_t hex2bin_safe(const char *hex, uint8_t *buf, size_t buflen)
+{
+	return hex == NULL ? 0 : hex2bin(hex, strlen(hex), buf, buflen);
+}
+
 /* Weak definition, user overridable */
 __weak void start_time_measurement(void)
 {

--- a/tests/crypto/src/common_test.h
+++ b/tests/crypto/src/common_test.h
@@ -50,6 +50,18 @@ extern int (*drbg_random)(void *, unsigned char *, size_t);
  */
 int init_drbg(const unsigned char *p_optional_seed, size_t len);
 
+/**@brief Wrapper function for hex2bin that makes sure that the input pointer is valid.
+ *
+ * @details Will return 0 if given param hex is NULL.
+ *
+ * @param hex     The hexadecimal string to convert
+ * @param buf     Address of where to store the binary data
+ * @param buflen  Size of the storage area for binary data
+ *
+ * @return     The length of the binary array, or 0 if an error occurred.
+ */
+size_t hex2bin_safe(const char *hex, uint8_t *buf, size_t buflen);
+
 #if defined(MBEDTLS_CTR_DRBG_C)
 
 #include <mbedtls/ctr_drbg.h>

--- a/tests/crypto/test_cases/test_aead.c
+++ b/tests/crypto/test_cases/test_aead.c
@@ -155,44 +155,40 @@ __attribute__((noinline)) void unhexify_aead(void)
 	bool encrypt =
 		(p_test_vector->direction == MBEDTLS_ENCRYPT) && g_encrypt;
 
-	key_len = hex2bin(p_test_vector->p_key, strlen(p_test_vector->p_key),
-			  m_aead_key_buf, strlen(p_test_vector->p_key));
-	mac_len =
-		hex2bin(p_test_vector->p_mac, strlen(p_test_vector->p_mac),
-			m_aead_expected_mac_buf, strlen(p_test_vector->p_mac));
-	ad_len = hex2bin(p_test_vector->p_ad, strlen(p_test_vector->p_ad),
-			 m_aead_ad_buf, strlen(p_test_vector->p_ad));
-	nonce_len =
-		hex2bin(p_test_vector->p_nonce, strlen(p_test_vector->p_nonce),
-			m_aead_nonce_buf, strlen(p_test_vector->p_nonce));
+	key_len = hex2bin_safe(p_test_vector->p_key,
+			       m_aead_key_buf,
+			       sizeof(m_aead_key_buf));
+	mac_len = hex2bin_safe(p_test_vector->p_mac,
+			       m_aead_expected_mac_buf,
+			       sizeof(m_aead_expected_mac_buf));
+	ad_len = hex2bin_safe(p_test_vector->p_ad,
+			      m_aead_ad_buf,
+			      sizeof(m_aead_ad_buf));
+	nonce_len = hex2bin_safe(p_test_vector->p_nonce,
+				 m_aead_nonce_buf,
+				 sizeof(m_aead_nonce_buf));
 
 	/* Fetch and unhexify plaintext and ciphertext for encryption. */
 	if (encrypt) {
-		input_len = hex2bin(p_test_vector->p_plaintext,
-				    strlen(p_test_vector->p_plaintext),
-				    m_aead_input_buf,
-				    strlen(p_test_vector->p_plaintext));
-		output_len = hex2bin(p_test_vector->p_ciphertext,
-				     strlen(p_test_vector->p_ciphertext),
-				     m_aead_expected_output_buf,
-				     strlen(p_test_vector->p_ciphertext));
-		mac_len = hex2bin(p_test_vector->p_mac,
-				  strlen(p_test_vector->p_mac),
-				  m_aead_expected_mac_buf,
-				  strlen(p_test_vector->p_mac));
+		input_len = hex2bin_safe(p_test_vector->p_plaintext,
+					 m_aead_input_buf,
+					 sizeof(m_aead_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					  m_aead_expected_output_buf,
+					  sizeof(m_aead_expected_output_buf));
+		mac_len = hex2bin_safe(p_test_vector->p_mac,
+				       m_aead_expected_mac_buf,
+				       sizeof(m_aead_expected_mac_buf));
 	} else {
-		input_len = hex2bin(p_test_vector->p_ciphertext,
-				    strlen(p_test_vector->p_ciphertext),
-				    m_aead_input_buf,
-				    strlen(p_test_vector->p_ciphertext));
-		output_len = hex2bin(p_test_vector->p_plaintext,
-				     strlen(p_test_vector->p_plaintext),
-				     m_aead_expected_output_buf,
-				     strlen(p_test_vector->p_plaintext));
-		mac_len = hex2bin(p_test_vector->p_mac,
-				  strlen(p_test_vector->p_mac),
-				  m_aead_output_mac_buf,
-				  strlen(p_test_vector->p_mac));
+		input_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					 m_aead_input_buf,
+					 sizeof(m_aead_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_plaintext,
+					  m_aead_expected_output_buf,
+					  sizeof(m_aead_expected_output_buf));
+		mac_len = hex2bin_safe(p_test_vector->p_mac,
+				       m_aead_output_mac_buf,
+				       sizeof(m_aead_output_mac_buf));
 	}
 }
 

--- a/tests/crypto/test_cases/test_aes_cbc.c
+++ b/tests/crypto/test_cases/test_aes_cbc.c
@@ -147,31 +147,30 @@ __attribute__((noinline)) void unhexify_aes_cbc(void)
 	bool encrypt =
 		(p_test_vector->direction == MBEDTLS_ENCRYPT) && g_encrypt;
 
-	key_len = hex2bin(p_test_vector->p_key, strlen(p_test_vector->p_key),
-			  m_aes_key_buf, strlen(p_test_vector->p_key));
-	iv_len = hex2bin(p_test_vector->p_iv, strlen(p_test_vector->p_iv),
-			 m_aes_iv_buf, strlen(p_test_vector->p_iv));
-	ad_len = hex2bin(p_test_vector->p_ad, strlen(p_test_vector->p_ad),
-			 m_aes_temp_buf, strlen(p_test_vector->p_ad));
+	key_len = hex2bin_safe(p_test_vector->p_key,
+			       m_aes_key_buf,
+			       sizeof(m_aes_key_buf));
+	iv_len = hex2bin_safe(p_test_vector->p_iv,
+			      m_aes_iv_buf,
+			      sizeof(m_aes_iv_buf));
+	ad_len = hex2bin_safe(p_test_vector->p_ad,
+			      m_aes_temp_buf,
+			      sizeof(m_aes_temp_buf));
 
 	if (encrypt) {
-		input_len = hex2bin(p_test_vector->p_plaintext,
-				    strlen(p_test_vector->p_plaintext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_plaintext));
-		output_len = hex2bin(p_test_vector->p_ciphertext,
-				     strlen(p_test_vector->p_ciphertext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_ciphertext));
+		input_len = hex2bin_safe(p_test_vector->p_plaintext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	} else {
-		input_len = hex2bin(p_test_vector->p_ciphertext,
-				    strlen(p_test_vector->p_ciphertext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_ciphertext));
-		output_len = hex2bin(p_test_vector->p_plaintext,
-				     strlen(p_test_vector->p_plaintext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_plaintext));
+		input_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_plaintext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	}
 }
 

--- a/tests/crypto/test_cases/test_aes_cbc_mac.c
+++ b/tests/crypto/test_cases/test_aes_cbc_mac.c
@@ -139,31 +139,30 @@ __attribute__((noinline)) void unhexify_aes_cbc_mac(void)
 {
 	bool encrypt = (p_test_vector->direction == MBEDTLS_ENCRYPT);
 
-	key_len = hex2bin(p_test_vector->p_key, strlen(p_test_vector->p_key),
-			  m_aes_key_buf, strlen(p_test_vector->p_key));
-	iv_len = hex2bin(p_test_vector->p_iv, strlen(p_test_vector->p_iv),
-			 m_aes_iv_buf, strlen(p_test_vector->p_iv));
-	ad_len = hex2bin(p_test_vector->p_ad, strlen(p_test_vector->p_ad),
-			 m_aes_temp_buf, strlen(p_test_vector->p_ad));
+	key_len = hex2bin_safe(p_test_vector->p_key,
+			       m_aes_key_buf,
+			       sizeof(m_aes_key_buf));
+	iv_len = hex2bin_safe(p_test_vector->p_iv,
+			      m_aes_iv_buf,
+			      sizeof(m_aes_iv_buf));
+	ad_len = hex2bin_safe(p_test_vector->p_ad,
+			      m_aes_temp_buf,
+			      sizeof(m_aes_temp_buf));
 
 	if (encrypt) {
-		input_len = hex2bin(p_test_vector->p_plaintext,
-				    strlen(p_test_vector->p_plaintext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_plaintext));
-		output_len = hex2bin(p_test_vector->p_ciphertext,
-				     strlen(p_test_vector->p_ciphertext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_ciphertext));
+		input_len = hex2bin_safe(p_test_vector->p_plaintext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	} else {
-		input_len = hex2bin(p_test_vector->p_ciphertext,
-				    strlen(p_test_vector->p_ciphertext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_ciphertext));
-		output_len = hex2bin(p_test_vector->p_plaintext,
-				     strlen(p_test_vector->p_plaintext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_plaintext));
+		input_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_plaintext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	}
 }
 

--- a/tests/crypto/test_cases/test_aes_ctr.c
+++ b/tests/crypto/test_cases/test_aes_ctr.c
@@ -139,31 +139,30 @@ __attribute__((noinline)) void unhexify_aes_ctr(void)
 {
 	bool encrypt = p_test_vector->direction == MBEDTLS_ENCRYPT;
 
-	key_len = hex2bin(p_test_vector->p_key, strlen(p_test_vector->p_key),
-			  m_aes_key_buf, strlen(p_test_vector->p_key));
-	iv_len = hex2bin(p_test_vector->p_iv, strlen(p_test_vector->p_iv),
-			 m_aes_iv_buf, strlen(p_test_vector->p_iv));
-	ad_len = hex2bin(p_test_vector->p_ad, strlen(p_test_vector->p_ad),
-			 m_aes_temp_buf, strlen(p_test_vector->p_ad));
+	key_len = hex2bin_safe(p_test_vector->p_key,
+			       m_aes_key_buf,
+			       sizeof(m_aes_key_buf));
+	iv_len = hex2bin_safe(p_test_vector->p_iv,
+			      m_aes_iv_buf,
+			      sizeof(m_aes_iv_buf));
+	ad_len = hex2bin_safe(p_test_vector->p_ad,
+			      m_aes_temp_buf,
+			      sizeof(m_aes_temp_buf));
 
 	if (encrypt) {
-		input_len = hex2bin(p_test_vector->p_plaintext,
-				    strlen(p_test_vector->p_plaintext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_plaintext));
-		output_len = hex2bin(p_test_vector->p_ciphertext,
-				     strlen(p_test_vector->p_ciphertext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_ciphertext));
+		input_len = hex2bin_safe(p_test_vector->p_plaintext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	} else {
-		input_len = hex2bin(p_test_vector->p_ciphertext,
-				    strlen(p_test_vector->p_ciphertext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_ciphertext));
-		output_len = hex2bin(p_test_vector->p_plaintext,
-				     strlen(p_test_vector->p_plaintext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_plaintext));
+		input_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_plaintext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	}
 }
 

--- a/tests/crypto/test_cases/test_aes_ecb.c
+++ b/tests/crypto/test_cases/test_aes_ecb.c
@@ -156,31 +156,30 @@ __attribute__((noinline)) void unhexify_aes_ecb(void)
 	bool encrypt =
 		(p_test_vector->direction == MBEDTLS_ENCRYPT) && g_encrypt;
 
-	key_len = hex2bin(p_test_vector->p_key, strlen(p_test_vector->p_key),
-			  m_aes_key_buf, strlen(p_test_vector->p_key));
-	iv_len = hex2bin(p_test_vector->p_iv, strlen(p_test_vector->p_iv),
-			 m_aes_iv_buf, strlen(p_test_vector->p_iv));
-	ad_len = hex2bin(p_test_vector->p_ad, strlen(p_test_vector->p_ad),
-			 m_aes_temp_buf, strlen(p_test_vector->p_ad));
+	key_len = hex2bin_safe(p_test_vector->p_key,
+			       m_aes_key_buf,
+			       sizeof(m_aes_key_buf));
+	iv_len = hex2bin_safe(p_test_vector->p_iv,
+			      m_aes_iv_buf,
+			      sizeof(m_aes_iv_buf));
+	ad_len = hex2bin_safe(p_test_vector->p_ad,
+			      m_aes_temp_buf,
+			      sizeof(m_aes_temp_buf));
 
 	if (encrypt) {
-		input_len = hex2bin(p_test_vector->p_plaintext,
-				    strlen(p_test_vector->p_plaintext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_plaintext));
-		output_len = hex2bin(p_test_vector->p_ciphertext,
-				     strlen(p_test_vector->p_ciphertext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_ciphertext));
+		input_len = hex2bin_safe(p_test_vector->p_plaintext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	} else {
-		input_len = hex2bin(p_test_vector->p_ciphertext,
-				    strlen(p_test_vector->p_ciphertext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_ciphertext));
-		output_len = hex2bin(p_test_vector->p_plaintext,
-				     strlen(p_test_vector->p_plaintext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_plaintext));
+		input_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_plaintext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	}
 }
 

--- a/tests/crypto/test_cases/test_aes_ecb_mac.c
+++ b/tests/crypto/test_cases/test_aes_ecb_mac.c
@@ -116,31 +116,30 @@ __attribute__((noinline)) void unhexify_aes_ecb_mac(void)
 {
 	bool encrypt = p_test_vector->direction == MBEDTLS_ENCRYPT;
 
-	key_len = hex2bin(p_test_vector->p_key, strlen(p_test_vector->p_key),
-			  m_aes_key_buf, strlen(p_test_vector->p_key));
-	iv_len = hex2bin(p_test_vector->p_iv, strlen(p_test_vector->p_iv),
-			 m_aes_iv_buf, strlen(p_test_vector->p_iv));
-	ad_len = hex2bin(p_test_vector->p_ad, strlen(p_test_vector->p_ad),
-			 m_aes_temp_buf, strlen(p_test_vector->p_ad));
+	key_len = hex2bin_safe(p_test_vector->p_key,
+			       m_aes_key_buf,
+			       sizeof(m_aes_key_buf));
+	iv_len = hex2bin_safe(p_test_vector->p_iv,
+			      m_aes_iv_buf,
+			      sizeof(m_aes_iv_buf));
+	ad_len = hex2bin_safe(p_test_vector->p_ad,
+			      m_aes_temp_buf,
+			      sizeof(m_aes_temp_buf));
 
 	if (encrypt) {
-		input_len = hex2bin(p_test_vector->p_plaintext,
-				    strlen(p_test_vector->p_plaintext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_plaintext));
-		output_len = hex2bin(p_test_vector->p_ciphertext,
-				     strlen(p_test_vector->p_ciphertext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_ciphertext));
+		input_len = hex2bin_safe(p_test_vector->p_plaintext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	} else {
-		input_len = hex2bin(p_test_vector->p_ciphertext,
-				    strlen(p_test_vector->p_ciphertext),
-				    m_aes_input_buf,
-				    strlen(p_test_vector->p_ciphertext));
-		output_len = hex2bin(p_test_vector->p_plaintext,
-				     strlen(p_test_vector->p_plaintext),
-				     m_aes_expected_output_buf,
-				     strlen(p_test_vector->p_plaintext));
+		input_len = hex2bin_safe(p_test_vector->p_ciphertext,
+					 m_aes_input_buf,
+					 sizeof(m_aes_input_buf));
+		output_len = hex2bin_safe(p_test_vector->p_plaintext,
+					  m_aes_expected_output_buf,
+					  sizeof(m_aes_expected_output_buf));
 	}
 }
 

--- a/tests/crypto/test_cases/test_ecdh.c
+++ b/tests/crypto/test_cases/test_ecdh.c
@@ -107,11 +107,11 @@ void ecdh_clear_buffers(void)
 
 __attribute__((noinline)) void unhexify_ecdh(void)
 {
-	expected_ss_len =
-		hex2bin(p_test_vector->p_expected_shared_secret,
-			strlen(p_test_vector->p_expected_shared_secret),
-			m_ecdh_expected_ss_buf,
-			strlen(p_test_vector->p_expected_shared_secret));
+
+	expected_ss_len = hex2bin_safe(p_test_vector->p_expected_shared_secret,
+				       m_ecdh_expected_ss_buf,
+				       sizeof(m_ecdh_expected_ss_buf));
+
 }
 
 /**@brief Function for executing ECDH for initiator and repsonder by
@@ -267,10 +267,9 @@ void exec_test_case_ecdh_deterministic_full(void)
 	}
 
 	expected_ss_len =
-		hex2bin(p_test_vector->p_expected_shared_secret,
-			strlen(p_test_vector->p_expected_shared_secret),
-			m_ecdh_expected_ss_buf,
-			strlen(p_test_vector->p_expected_shared_secret));
+		hex2bin_safe(p_test_vector->p_expected_shared_secret,
+			     m_ecdh_expected_ss_buf,
+			     sizeof(m_ecdh_expected_ss_buf));
 
 	/* Execute ECDH on initiator side. */
 	start_time_measurement();

--- a/tests/crypto/test_cases/test_ecdsa.c
+++ b/tests/crypto/test_cases/test_ecdsa.c
@@ -73,26 +73,23 @@ static void ecdsa_setup_random(void)
 
 __attribute__((noinline)) void unhexify_ecdsa_verify(void)
 {
-	hash_len = hex2bin(p_test_vector_verify->p_input,
-			   strlen(p_test_vector_verify->p_input),
-			   m_ecdsa_input_buf,
-			   strlen(p_test_vector_verify->p_input));
+	hash_len = hex2bin_safe(p_test_vector_verify->p_input,
+				m_ecdsa_input_buf,
+				sizeof(m_ecdsa_input_buf));
 }
 
 __attribute__((noinline)) void unhexify_ecdsa_sign(void)
 {
-	hash_len =
-		hex2bin(p_test_vector_sign->p_input,
-			strlen(p_test_vector_sign->p_input), m_ecdsa_input_buf,
-			strlen(p_test_vector_sign->p_input));
+	hash_len = hex2bin_safe(p_test_vector_sign->p_input,
+				m_ecdsa_input_buf,
+				sizeof(m_ecdsa_input_buf));
 }
 
 __attribute__((noinline)) void unhexify_ecdsa_random(void)
 {
-	hash_len = hex2bin(p_test_vector_random->p_input,
-			   strlen(p_test_vector_random->p_input),
-			   m_ecdsa_input_buf,
-			   strlen(p_test_vector_random->p_input));
+	hash_len = hex2bin_safe(p_test_vector_random->p_input,
+				m_ecdsa_input_buf,
+				sizeof(m_ecdsa_input_buf));
 }
 
 void ecdsa_clear_buffers(void)

--- a/tests/crypto/test_cases/test_ecjpake.c
+++ b/tests/crypto/test_cases/test_ecjpake.c
@@ -87,55 +87,38 @@ void ecjpake_clear_buffers(void)
 
 __attribute__((noinline)) void unhexify_ecjpake(void)
 {
-	secret_len = hex2bin(p_test_vector->p_expected_shared_secret,
-			     strlen(p_test_vector->p_expected_shared_secret),
-			     m_expected_secret,
-			     strlen(p_test_vector->p_expected_shared_secret));
-	password_len = hex2bin(p_test_vector->p_password,
-			       strlen(p_test_vector->p_password), m_password,
-			       strlen(p_test_vector->p_password));
+	secret_len = hex2bin_safe(p_test_vector->p_expected_shared_secret,
+				  m_expected_secret,
+				  sizeof(m_expected_secret));
+	password_len = hex2bin_safe(p_test_vector->p_password,
+				    m_password,
+				    sizeof(m_password));
 
-	priv_key_cli_1_len =
-		hex2bin(p_test_vector->p_priv_key_client_1,
-			strlen(p_test_vector->p_priv_key_client_1),
-			m_priv_key_cli_1,
-			strlen(p_test_vector->p_priv_key_client_1));
-	priv_key_cli_2_len =
-		hex2bin(p_test_vector->p_priv_key_client_2,
-			strlen(p_test_vector->p_priv_key_client_2),
-			m_priv_key_cli_2,
-			strlen(p_test_vector->p_priv_key_client_2));
-	priv_key_srv_1_len =
-		hex2bin(p_test_vector->p_priv_key_server_1,
-			strlen(p_test_vector->p_priv_key_server_1),
-			m_priv_key_srv_1,
-			strlen(p_test_vector->p_priv_key_server_1));
-	priv_key_srv_2_len =
-		hex2bin(p_test_vector->p_priv_key_server_2,
-			strlen(p_test_vector->p_priv_key_server_2),
-			m_priv_key_srv_2,
-			strlen(p_test_vector->p_priv_key_server_2));
+	priv_key_cli_1_len = hex2bin_safe(p_test_vector->p_priv_key_client_1,
+					  m_priv_key_cli_1,
+					  sizeof(m_priv_key_cli_1));
+	priv_key_cli_2_len = hex2bin_safe(p_test_vector->p_priv_key_client_2,
+					  m_priv_key_cli_2,
+					  sizeof(m_priv_key_cli_2));
+	priv_key_srv_1_len = hex2bin_safe(p_test_vector->p_priv_key_server_1,
+					  m_priv_key_srv_1,
+					  sizeof(m_priv_key_srv_1));
+	priv_key_srv_2_len = hex2bin_safe(p_test_vector->p_priv_key_server_2,
+					  m_priv_key_srv_2,
+					  sizeof(m_priv_key_srv_2));
 
-	msg_cli_1_len =
-		hex2bin(p_test_vector->p_round_message_client_1,
-			strlen(p_test_vector->p_round_message_client_1),
-			m_msg_cli_1,
-			strlen(p_test_vector->p_round_message_client_1));
-	msg_cli_2_len =
-		hex2bin(p_test_vector->p_round_message_client_2,
-			strlen(p_test_vector->p_round_message_client_2),
-			m_msg_cli_2,
-			strlen(p_test_vector->p_round_message_client_2));
-	msg_srv_1_len =
-		hex2bin(p_test_vector->p_round_message_server_1,
-			strlen(p_test_vector->p_round_message_server_1),
-			m_msg_srv_1,
-			strlen(p_test_vector->p_round_message_server_1));
-	msg_srv_2_len =
-		hex2bin(p_test_vector->p_round_message_server_2,
-			strlen(p_test_vector->p_round_message_server_2),
-			m_msg_srv_2,
-			strlen(p_test_vector->p_round_message_server_2));
+	msg_cli_1_len = hex2bin_safe(p_test_vector->p_round_message_client_1,
+				     m_msg_cli_1,
+				     sizeof(m_msg_cli_1));
+	msg_cli_2_len = hex2bin_safe(p_test_vector->p_round_message_client_2,
+				     m_msg_cli_2,
+				     sizeof(m_msg_cli_2));
+	msg_srv_1_len = hex2bin_safe(p_test_vector->p_round_message_server_1,
+				     m_msg_srv_1,
+				     sizeof(m_msg_srv_1));
+	msg_srv_2_len = hex2bin_safe(p_test_vector->p_round_message_server_2,
+				     m_msg_srv_2,
+				     sizeof(m_msg_srv_2));
 }
 
 /*

--- a/tests/crypto/test_cases/test_hkdf.c
+++ b/tests/crypto/test_cases/test_hkdf.c
@@ -57,17 +57,21 @@ void hkdf_clear_buffers(void)
 __attribute__((noinline)) void unhexify_hkdf(void)
 {
 	/* Fetch and unhexify test vectors. */
-	ikm_len = hex2bin(p_test_vector->p_ikm, strlen(p_test_vector->p_ikm),
-			  m_hkdf_ikm_buf, strlen(p_test_vector->p_ikm));
-	prk_len = hex2bin(p_test_vector->p_prk, strlen(p_test_vector->p_prk),
-			  m_hkdf_prk_buf, strlen(p_test_vector->p_prk));
-	salt_len = hex2bin(p_test_vector->p_salt, strlen(p_test_vector->p_salt),
-			   m_hkdf_salt_buf, strlen(p_test_vector->p_salt));
-	info_len = hex2bin(p_test_vector->p_info, strlen(p_test_vector->p_info),
-			   m_hkdf_info_buf, strlen(p_test_vector->p_info));
-	expected_okm_len =
-		hex2bin(p_test_vector->p_okm, strlen(p_test_vector->p_okm),
-			m_hkdf_expected_okm_buf, strlen(p_test_vector->p_okm));
+	ikm_len = hex2bin_safe(p_test_vector->p_ikm,
+			       m_hkdf_ikm_buf,
+			       sizeof(m_hkdf_ikm_buf));
+	prk_len = hex2bin_safe(p_test_vector->p_prk,
+			       m_hkdf_prk_buf,
+			       sizeof(m_hkdf_prk_buf));
+	salt_len = hex2bin_safe(p_test_vector->p_salt,
+				m_hkdf_salt_buf,
+				sizeof(m_hkdf_salt_buf));
+	info_len = hex2bin_safe(p_test_vector->p_info,
+				m_hkdf_info_buf,
+				sizeof(m_hkdf_info_buf));
+	expected_okm_len = hex2bin_safe(p_test_vector->p_okm,
+					m_hkdf_expected_okm_buf,
+					sizeof(m_hkdf_expected_okm_buf));
 	okm_len = expected_okm_len;
 
 	p_hkdp_salt = (salt_len == 0) ? NULL : m_hkdf_salt_buf;

--- a/tests/crypto/test_cases/test_hmac.c
+++ b/tests/crypto/test_cases/test_hmac.c
@@ -72,15 +72,15 @@ void hmac_clear_buffers(void)
 __attribute__((noinline)) void unhexify_hmac(void)
 {
 	/* Fetch and unhexify test vectors. */
-	key_len = hex2bin(p_test_vector->p_key, strlen(p_test_vector->p_key),
-			  m_hmac_key_buf, strlen(p_test_vector->p_key));
-	in_len = hex2bin(p_test_vector->p_input, strlen(p_test_vector->p_input),
-			 m_hmac_input_buf, strlen(p_test_vector->p_input));
-	expected_hmac_len = hex2bin(p_test_vector->p_expected_output,
-				    strlen(p_test_vector->p_expected_output),
-				    m_hmac_expected_output_buf,
-				    strlen(p_test_vector->p_expected_output));
-
+	key_len = hex2bin_safe(p_test_vector->p_key,
+			       m_hmac_key_buf,
+			       sizeof(m_hmac_key_buf));
+	in_len = hex2bin_safe(p_test_vector->p_input,
+			      m_hmac_input_buf,
+			      sizeof(m_hmac_input_buf));
+	expected_hmac_len = hex2bin_safe(p_test_vector->p_expected_output,
+					 m_hmac_expected_output_buf,
+					 sizeof(m_hmac_expected_output_buf));
 	hmac_len = expected_hmac_len;
 }
 

--- a/tests/crypto/test_cases/test_sha_256.c
+++ b/tests/crypto/test_cases/test_sha_256.c
@@ -86,12 +86,12 @@ static void sha_256_long_teardown(void)
 __attribute__((noinline)) void unhexify_sha_256(void)
 {
 	/* Fetch and unhexify test vectors. */
-	in_len = hex2bin(p_test_vector->p_input, strlen(p_test_vector->p_input),
-			 m_sha_input_buf, strlen(p_test_vector->p_input));
-	expected_out_len = hex2bin(p_test_vector->p_expected_output,
-				   strlen(p_test_vector->p_expected_output),
-				   m_sha_expected_output_buf,
-				   strlen(p_test_vector->p_expected_output));
+	in_len = hex2bin_safe(p_test_vector->p_input,
+			      m_sha_input_buf,
+			      sizeof(m_sha_input_buf));
+	expected_out_len = hex2bin_safe(p_test_vector->p_expected_output,
+					m_sha_expected_output_buf,
+					sizeof(m_sha_expected_output_buf));
 	out_len = expected_out_len;
 }
 
@@ -99,10 +99,9 @@ __attribute__((noinline)) void unhexify_sha_256_long(void)
 {
 	/* Fetch and unhexify test vectors. */
 	in_len = p_test_vector->chunk_length;
-	expected_out_len = hex2bin(p_test_vector->p_expected_output,
-				   strlen(p_test_vector->p_expected_output),
-				   m_sha_expected_output_buf,
-				   strlen(p_test_vector->p_expected_output));
+	expected_out_len = hex2bin_safe(p_test_vector->p_expected_output,
+					m_sha_expected_output_buf,
+					sizeof(m_sha_expected_output_buf));
 	out_len = expected_out_len;
 	memcpy(m_sha_input_buf, p_test_vector->p_input, in_len);
 }

--- a/tests/crypto/test_cases/test_sha_512.c
+++ b/tests/crypto/test_cases/test_sha_512.c
@@ -86,12 +86,12 @@ void sha_512_clear_buffers(void)
 __attribute__((noinline)) void unhexify_sha_512(void)
 {
 	/* Fetch and unhexify test vectors. */
-	in_len = hex2bin(p_test_vector->p_input, strlen(p_test_vector->p_input),
-			 m_sha_input_buf, strlen(p_test_vector->p_input));
-	expected_out_len = hex2bin(p_test_vector->p_expected_output,
-				   strlen(p_test_vector->p_expected_output),
-				   m_sha_expected_output_buf,
-				   strlen(p_test_vector->p_expected_output));
+	in_len = hex2bin_safe(p_test_vector->p_input,
+			      m_sha_input_buf,
+			      sizeof(m_sha_input_buf));
+	expected_out_len = hex2bin_safe(p_test_vector->p_expected_output,
+					m_sha_expected_output_buf,
+					sizeof(m_sha_expected_output_buf));
 	out_len = expected_out_len;
 }
 
@@ -99,10 +99,9 @@ __attribute__((noinline)) void unhexify_sha_512_long(void)
 {
 	/* Fetch and unhexify test vectors. */
 	in_len = p_test_vector->chunk_length;
-	expected_out_len = hex2bin(p_test_vector->p_expected_output,
-				   strlen(p_test_vector->p_expected_output),
-				   m_sha_expected_output_buf,
-				   strlen(p_test_vector->p_expected_output));
+	expected_out_len = hex2bin_safe(p_test_vector->p_expected_output,
+					m_sha_expected_output_buf,
+					sizeof(m_sha_expected_output_buf));
 	out_len = expected_out_len;
 	memcpy(m_sha_input_buf, p_test_vector->p_input, in_len);
 }

--- a/tests/crypto/testcase.yaml
+++ b/tests/crypto/testcase.yaml
@@ -12,7 +12,7 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
     build_on_all: True
     tags: crypto ci_build
-    timeout: 100
+    timeout: 200
   crypto.multi:
     extra_args: OVERLAY_CONFIG=overlay-multi.conf
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
Wrapped the hex2bin function to make sure the hex input pointer is valid
before calling strlen on it.

Signed-off-by: Magne Værnes <magne.varnes@nordicsemi.no>