### PR TITLE
tests: bump size of provision to ensure page alignment of s1

### DIFF
--- a/tests/subsys/bootloader/bl_validation_neg/child_image/b0.conf
+++ b/tests/subsys/bootloader/bl_validation_neg/child_image/b0.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_PM_PARTITION_SIZE_PROVISION=0x2000

--- a/tests/subsys/fw_info/child_image/b0.conf
+++ b/tests/subsys/fw_info/child_image/b0.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_PM_PARTITION_SIZE_PROVISION=0x2000


### PR DESCRIPTION
If S1 is not page aligned it can not be erased.
This triggers an unexpected error when running the
bl_validation_neg test for nrf52.

Fix this by bumping the size of the provision partition
so that the start of the s1 partition becomes page aligned.

Ref: NCSDK-9062
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>