### PR TITLE
lib: nrf_modem: apply default trace size when trace is enabled

### DIFF
--- a/lib/nrf_modem_lib/Kconfig
+++ b/lib/nrf_modem_lib/Kconfig
@@ -28,6 +28,8 @@ config NRF_MODEM_LIB_TRACE_ENABLED
 	# Modem tracing over UART use the UARTE1 as dedicated peripheral.
 	# This enable UARTE1 peripheral and includes nrfx UARTE driver.
 	select NRFX_UARTE1
+	help
+	  The default size of the Trace region is 16384 bytes.
 
 config NRF91_SOCKET_SEND_SPLIT_LARGE_BLOCKS
 	bool "Split large blocks passed to send() or sendto()"
@@ -93,8 +95,14 @@ config NRF_MODEM_LIB_SHMEM_RX_SIZE
 	  The minimum memory requirements stem from the size of the RPC lists (264 bytes = 8 + (32 * 8)),
 	  plus the RPC messages and data buffers (1280 bytes = 256 + 1024).
 
+config NRF_MODEM_LIB_SHMEM_TRACE_SIZE_OVERRIDE
+	bool "Custom Trace region size"
+	depends on NRF_MODEM_LIB_TRACE_ENABLED
+	help
+	  Override the default size of the Trace region (16384 bytes).
+
 config NRF_MODEM_LIB_SHMEM_TRACE_SIZE
-	int "Trace region size" if NRF_MODEM_LIB_TRACE_ENABLED
+	int "Trace region size" if NRF_MODEM_LIB_SHMEM_TRACE_SIZE_OVERRIDE
 	default 16384 if NRF_MODEM_LIB_TRACE_ENABLED
 	default 0
 	help


### PR DESCRIPTION
Apply the default for the Trace region size when the trace is enabled.

Followed this example from the Zephyr documentation:
```
If STACK_SIZE should usually be derived automatically,
but needs to be set to a custom value in rare circumstances,
then add another option for making STACK_SIZE user-configurable:

config CUSTOM_STACK_SIZE
   bool "Use a custom stack size"
   help
     Enable this if you need to use a custom stack size. When disabled, a
     suitable stack size is calculated automatically.

config STACK_SIZE
   hex "Stack size" if CUSTOM_STACK_SIZE
   default 0x200 if FOO
   default 0x100

As long as CUSTOM_STACK_SIZE is disabled,
STACK_SIZE will ignore the value from the saved configuration.
```