### PR TITLE
bluetooth: services: ancs_client: Use callback functions to report results in GATT operations

### DIFF
--- a/include/bluetooth/services/ancs_client.h
+++ b/include/bluetooth/services/ancs_client.h
@@ -355,7 +355,7 @@ struct bt_ancs_parse_sm {
 	uint32_t current_app_id_index;
 };
 
-/**@brief iOS notification structure, which contains various status information for the client. */
+/**@brief ANCS client instance, which contains various status information. */
 struct bt_ancs_client {
 	/** Connection object. */
 	struct bt_conn *conn;
@@ -426,9 +426,10 @@ struct bt_ancs_client {
 
 /**@brief Function for initializing the ANCS client.
  *
- * @param[out] ancs_c       ANCS client structure. This structure must be
- *                          supplied by the application. It is initialized by this function
- *                          and will later be used to identify this particular client instance.
+ * @param[out] ancs_c       ANCS client instance. This structure must be
+ *                          supplied by the application. It is initialized by
+ *                          this function and will later be used to identify
+ *                          this particular client instance.
  * @param[in]  evt_handler  Event handler for ANCS client events.
  *
  * @retval 0 If the client was initialized successfully.
@@ -440,8 +441,7 @@ int bt_ancs_client_init(struct bt_ancs_client *ancs_c,
 /**@brief Function for writing to the CCCD to enable notifications from
  *        the Apple Notification Service.
  *
- * @param[in] ancs_c  iOS notification structure. This structure must be supplied by
- *                    the application. It identifies the particular client instance to use.
+ * @param[in] ancs_c  ANCS client instance.
  *
  * @retval 0 If writing to the CCCD was successful.
  *           Otherwise, a (negative) error code is returned.
@@ -450,8 +450,7 @@ int bt_ancs_subscribe_notification_source(struct bt_ancs_client *ancs_c);
 
 /**@brief Function for writing to the CCCD to enable data source notifications from the ANCS.
  *
- * @param[in] ancs_c iOS notification structure. This structure must be supplied by
- *                   the application. It identifies the particular client instance to use.
+ * @param[in] ancs_c  ANCS client instance.
  *
  * @retval 0 If writing to the CCCD was successful.
  *           Otherwise, a (negative) error code is returned.
@@ -460,8 +459,7 @@ int bt_ancs_subscribe_data_source(struct bt_ancs_client *ancs_c);
 
 /**@brief Function for writing to the CCCD to disable notifications from the ANCS.
  *
- * @param[in] ancs_c  iOS notification structure. This structure must be supplied by
- *                    the application. It identifies the particular client instance to use.
+ * @param[in] ancs_c  ANCS client instance
  *
  * @retval 0 If writing to the CCCD was successful.
  *           Otherwise, a (negative) error code is returned.
@@ -470,8 +468,7 @@ int bt_ancs_unsubscribe_notification_source(struct bt_ancs_client *ancs_c);
 
 /**@brief Function for writing to the CCCD to disable data source notifications from the ANCS.
  *
- * @param[in] ancs_c  iOS notification structure. This structure must be supplied by
- *                    the application. It identifies the particular client instance to use.
+ * @param[in] ancs_c  ANCS client instance.
  *
  * @retval 0 If writing to the CCCD was successful.
  *           Otherwise, a (negative) error code is returned.
@@ -510,8 +507,7 @@ int bt_ancs_register_app_attr(struct bt_ancs_client *ancs_c,
 
 /**@brief Function for requesting attributes for a notification.
  *
- * @param[in] ancs_c   iOS notification structure. This structure must be supplied by
- *                     the application. It identifies the particular client instance to use.
+ * @param[in] ancs_c   ANCS client instance.
  * @param[in] notif    Pointer to the notification whose attributes will be requested from
  *                     the Notification Provider.
  *
@@ -523,8 +519,7 @@ int bt_ancs_request_attrs(struct bt_ancs_client *ancs_c,
 
 /**@brief Function for requesting attributes for a given app.
  *
- * @param[in] ancs_c   iOS notification structure. This structure must be supplied by
- *                     the application. It identifies the particular client instance to use.
+ * @param[in] ancs_c   ANCS client instance.
  * @param[in] app_id   App identifier of the app for which the app attributes are requested.
  * @param[in] len      Length of the app identifier.
  *
@@ -536,8 +531,7 @@ int bt_ancs_request_app_attr(struct bt_ancs_client *ancs_c,
 
 /**@brief Function for performing a notification action.
  *
- * @param[in] ancs_c    iOS notification structure. This structure must be supplied by
- *                      the application. It identifies the particular client instance to use.
+ * @param[in] ancs_c    ANCS client instance.
  * @param[in] uuid      The UUID of the notification for which to perform the action.
  * @param[in] action_id Perform a positive or negative action.
  *
@@ -547,7 +541,7 @@ int bt_ancs_request_app_attr(struct bt_ancs_client *ancs_c,
 int bt_ancs_notification_action(struct bt_ancs_client *ancs_c, uint32_t uuid,
 				enum bt_ancs_action_id_values action_id);
 
-/**@brief Function for assigning a handle to this instance of ancs_c.
+/**@brief Function for assigning handles to ANCS client instance.
  *
  * @details Call this function when a link has been established with a peer to
  *          associate the link to this instance of the module. This makes it
@@ -555,7 +549,7 @@ int bt_ancs_notification_action(struct bt_ancs_client *ancs_c, uint32_t uuid,
  *          instance of this module.
  *
  * @param[in]     dm     Discovery object.
- * @param[in,out] ancs_c Pointer to the ANCS client structure instance for associating the link.
+ * @param[in,out] ancs_c ANCS client instance for associating the link.
  *
  * @retval 0 If the operation is successful.
  *           Otherwise, a (negative) error code is returned.

--- a/include/bluetooth/services/ancs_client.rst
+++ b/include/bluetooth/services/ancs_client.rst
@@ -15,7 +15,7 @@ Apple Notification Center Service (ANCS) Client
 The ANCS Client module implements the Apple Notification Center Service (ANCS) client.
 This client can be used as a Notification Consumer (NC) that receives data notifications from a Notification Provider (NP).
 The NP is typically an iOS device that is acting as a server.
-For detailed information about the Apple Notification Center Service, see `Apple's iOS Developer Library <Apple Notification Center Service Specification_>`_.
+For detailed information about the Apple Notification Center Service, see `Apple Developer Documentation <Apple Notification Center Service Specification_>`_.
 
 The term "notification" is used in two different meanings:
 
@@ -37,32 +37,32 @@ Once a connection is established with a central device, the module needs a servi
 If this succeeds, the handles for the ANCS server must be assigned to an ANCS client instance using the :c:func:`bt_ancs_handles_assign` function.
 
 The application can now subscribe to iOS notifications with :c:func:`bt_ancs_subscribe_notification_source`.
-The notifications arrive in the :c:enumerator:`BT_ANCS_EVT_NOTIF` event.
+The notifications arrive through the callback function of the notification source subscription.
 Use :c:func:`bt_ancs_request_attrs` to request attributes for the notifications.
-The attributes arrive in the :c:enumerator:`BT_ANCS_EVT_NOTIF_ATTRIBUTE` event.
+The attributes arrive through the callback function of the data source subscription with a Command ID :c:enumerator:`BT_ANCS_COMMAND_ID_GET_NOTIF_ATTRIBUTES`.
 Use :c:func:`bt_ancs_request_app_attr` to request attributes of the app that issued the notifications.
-The app attributes arrive in the :c:enumerator:`BT_ANCS_EVT_APP_ATTRIBUTE` event.
+The app attributes arrive through the callback function of the data source subscription with a Command ID :c:enumerator:`BT_ANCS_COMMAND_ID_GET_APP_ATTRIBUTES`.
 Use :c:func:`bt_ancs_notification_action` to make the Notification Provider perform an action based on the provided notification.
 
 .. msc::
     hscale = "2.0";
     Application, ANCS_Client;
     |||;
-    Application=>ANCS_Client   [label = "bt_ancs_client_init(ancs_instance, event_handler)"];
+    Application=>ANCS_Client   [label = "bt_ancs_client_init(ancs_instance)"];
     Application=>ANCS_Client   [label = "bt_ancs_register_attr(attribute)"];
     ...;
     Application=>ANCS_Client   [label = "bt_ancs_handles_assign(dm, ancs_instance)"];
-    Application=>ANCS_Client   [label = "bt_ancs_subscribe_notification_source(ancs_instance)"];
-    Application=>ANCS_Client   [label = "bt_ancs_subscribe_data_source(ancs_instance)"];
+    Application=>ANCS_Client   [label = "bt_ancs_subscribe_notification_source(ancs_instance, callback)"];
+    Application=>ANCS_Client   [label = "bt_ancs_subscribe_data_source(ancs_instance, callback)"];
     |||;
     ...;
     |||;
-    Application<<=ANCS_Client  [label = "BT_ANCS_EVT_NOTIF"];
+    Application<<=ANCS_Client  [label = "notification_source callback(notif)"];
     |||;
     ...;
     |||;
     Application=>ANCS_Client   [label = "bt_ancs_request_attrs(notif)"];
-    Application<<=ANCS_Client  [label = "BT_ANCS_EVT_NOTIF_ATTRIBUTE"];
+    Application<<=ANCS_Client  [label = "data_source callback(attr_response)"];
     |||;
 
 API documentation

--- a/subsys/bluetooth/services/ancs_app_attr_get.c
+++ b/subsys/bluetooth/services/ancs_app_attr_get.c
@@ -130,7 +130,7 @@ static enum encode_app_attr app_attr_encode_attr_id(
  * @param[in] app_id_len Length of the app ID.
  */
 static int app_attr_get(struct bt_ancs_client *ancs_c, const uint8_t *app_id,
-			uint32_t app_id_len)
+			uint32_t app_id_len, bt_ancs_write_cb func)
 {
 	enum encode_app_attr state = APP_ATTR_COMMAND_ID;
 	int err;
@@ -166,7 +166,7 @@ static int app_attr_get(struct bt_ancs_client *ancs_c, const uint8_t *app_id,
 	}
 
 	if (state == APP_ATTR_DONE) {
-		err = bt_ancs_cp_write(ancs_c, buf.len);
+		err = bt_ancs_cp_write(ancs_c, buf.len, func);
 
 		ancs_c->parse_info.expected_number_of_attrs =
 			ancs_c->number_of_requested_attr;
@@ -178,7 +178,8 @@ static int app_attr_get(struct bt_ancs_client *ancs_c, const uint8_t *app_id,
 }
 
 int bt_ancs_app_attr_request(struct bt_ancs_client *ancs_c,
-			     const uint8_t *app_id, uint32_t len)
+			     const uint8_t *app_id, uint32_t len,
+			     bt_ancs_write_cb func)
 {
 	/* App ID to be requested must be null-terminated. */
 	if (!len) {
@@ -191,5 +192,5 @@ int bt_ancs_app_attr_request(struct bt_ancs_client *ancs_c,
 
 	ancs_c->parse_info.parse_state = BT_ANCS_PARSE_STATE_COMMAND_ID;
 
-	return app_attr_get(ancs_c, app_id, len);
+	return app_attr_get(ancs_c, app_id, len, func);
 }

--- a/subsys/bluetooth/services/ancs_app_attr_get.h
+++ b/subsys/bluetooth/services/ancs_app_attr_get.h
@@ -21,8 +21,7 @@ extern "C" {
 
 /**@brief Function for requesting attributes for an app.
  *
- * @param[in] ancs_c  iOS notification structure. This structure must be supplied by
- *                    the application. It identifies the particular client instance to use.
+ * @param[in] ancs_c  ANCS client instance.
  * @param[in] app_id  App identifier of the app for which to request app attributes.
  * @param[in] len     Length of the app identifier.
  *

--- a/subsys/bluetooth/services/ancs_app_attr_get.h
+++ b/subsys/bluetooth/services/ancs_app_attr_get.h
@@ -24,12 +24,14 @@ extern "C" {
  * @param[in] ancs_c  ANCS client instance.
  * @param[in] app_id  App identifier of the app for which to request app attributes.
  * @param[in] len     Length of the app identifier.
+ * @param[in] func    Callback function for handling NP write response.
  *
  * @retval 0 If all operations were successful.
  *           Otherwise, a (negative) error code is returned.
  */
 int bt_ancs_app_attr_request(struct bt_ancs_client *ancs_c,
-			     const uint8_t *app_id, uint32_t len);
+			     const uint8_t *app_id, uint32_t len,
+			     bt_ancs_write_cb func);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/services/ancs_attr_parser.h
+++ b/subsys/bluetooth/services/ancs_attr_parser.h
@@ -34,7 +34,7 @@ extern "C" {
  * --------|-------------|-------|--------|----------------|-------|--------|----------------
  * CMD_ID  |  NOTIF_UID  |ATTR_ID| LENGTH |    DATA        |ATTR_ID| LENGTH |    DATA
  *
- * @param[in] ancs_c     Pointer to an ANCS instance to which the event belongs.
+ * @param[in] ancs_c     ANCS client instance to which the event belongs.
  * @param[in] data_src   Pointer to data that was received from the Notification Provider.
  * @param[in] data_len   Length of the data that was received from the Notification Provider.
  */

--- a/subsys/bluetooth/services/ancs_client_internal.h
+++ b/subsys/bluetooth/services/ancs_client_internal.h
@@ -7,6 +7,8 @@
 #ifndef BT_ANCS_CLIENT_INTERNAL_H_
 #define BT_ANCS_CLIENT_INTERNAL_H_
 
+#include <bluetooth/services/ancs_client.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -17,7 +19,48 @@ enum {
 	ANCS_CP_WRITE_PENDING
 };
 
-int bt_ancs_cp_write(struct bt_ancs_client *ancs_c, uint16_t len);
+/**@brief Call Notification Source notification callback function.
+ *
+ * @param[in] ancs_c    ANCS client instance.
+ * @param[in] err       0 if the notification is valid.
+ *                      Otherwise, contains a (negative) error code.
+ * @param[in] notif     iOS notification structure.
+ */
+static inline void bt_ancs_do_ns_notif_cb(struct bt_ancs_client *ancs_c, int err,
+					  const struct bt_ancs_evt_notif *notif)
+{
+	if (ancs_c->ns_notif_cb) {
+		ancs_c->ns_notif_cb(ancs_c, err, notif);
+	}
+}
+
+/**@brief Call Data Source notification callback function.
+ *
+ * @param[in] ancs_c    ANCS client instance.
+ * @param[in] response  Attribute response structure.
+ */
+static inline void bt_ancs_do_ds_notif_cb(struct bt_ancs_client *ancs_c,
+					  const struct bt_ancs_attr_response *response)
+{
+	if (ancs_c->ds_notif_cb) {
+		ancs_c->ds_notif_cb(ancs_c, response);
+	}
+}
+
+/**@brief Internal function for writing to ANCS Control Point.
+ *
+ * The caller is expected to set the ANCS_CP_WRITE_PENDING and to set up
+ * the Control Point data buffer before calling this function.
+ *
+ * @param[in] ancs_c  ANCS client instance.
+ * @param[in] len     Length of data in Control Point data buffer.
+ * @param[in] func    Callback function for handling NP write response.
+ *
+ * @retval 0 If the operation is successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int bt_ancs_cp_write(struct bt_ancs_client *ancs_c, uint16_t len,
+		     bt_ancs_write_cb func);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Use callback functions to report results in GATT operations. The current ANCS client uses an event handler, which is ported from nRF5 SDK.