### PR TITLE
manifest: Update zephyr revision to fix doc build

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -35,8 +35,7 @@ jobs:
       - name: Install base dependencies
         working-directory: ncs
         run: |
-          pip3 install -U pip
-          pip3 install -U setuptools
+          sudo pip3 install -U setuptools wheel pip
           export PATH="$HOME/.local/bin:$PATH"
           pip3 install -r nrf/scripts/requirements-base.txt
 

--- a/doc/nrf/gs_recommended_versions.rst
+++ b/doc/nrf/gs_recommended_versions.rst
@@ -196,8 +196,6 @@ Building documentation
      - |sphinxcontrib-mscgen_ver|
    * - breathe
      - |breathe_ver|
-   * - docutils
-     - |docutils_ver|
    * - sphinx
      - |sphinx_ver|
    * - sphinx_rtd_theme

--- a/doc/nrf/gs_recommended_versions.rst
+++ b/doc/nrf/gs_recommended_versions.rst
@@ -198,8 +198,8 @@ Building documentation
      - |breathe_ver|
    * - sphinx
      - |sphinx_ver|
-   * - sphinx_rtd_theme
-     - |sphinx_rtd_theme_ver|
+   * - sphinx-ncs-theme
+     - |sphinx-ncs-theme_ver|
    * - sphinx-tabs
      - |sphinx-tabs_ver|
    * - sphinxcontrib-svg2pdfconverter

--- a/doc/nrf/versions.txt.in
+++ b/doc/nrf/versions.txt.in
@@ -68,7 +68,6 @@
 .. |windows-curses_ver| replace:: @WINDOWS-CURSES_VERSION@
 
 .. |breathe_ver| replace:: @BREATHE_VERSION@
-.. |docutils_ver| replace:: @DOCUTILS_VERSION@
 .. |recommonmark_ver| replace:: @RECOMMONMARK_VERSION@
 .. |sphinx_ver| replace:: @SPHINX_VERSION@
 .. |sphinx-tabs_ver| replace:: @SPHINX-TABS_VERSION@

--- a/doc/nrf/versions.txt.in
+++ b/doc/nrf/versions.txt.in
@@ -71,6 +71,6 @@
 .. |recommonmark_ver| replace:: @RECOMMONMARK_VERSION@
 .. |sphinx_ver| replace:: @SPHINX_VERSION@
 .. |sphinx-tabs_ver| replace:: @SPHINX-TABS_VERSION@
-.. |sphinx_rtd_theme_ver| replace:: @SPHINX_RTD_THEME_VERSION@
+.. |sphinx-ncs-theme_ver| replace:: @SPHINX-NCS-THEME_VERSION@
 .. |sphinxcontrib-mscgen_ver| replace:: @SPHINXCONTRIB-MSCGEN_VERSION@
 .. |sphinxcontrib-svg2pdfconverter_ver| replace:: @SPHINXCONTRIB-SVG2PDFCONVERTER_VERSION@

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d5fe6f2e7f5ba28c9637297368ab1d3ecce7183c
+      revision: ca2b2af6b699bdb3834bbbe90d8b15bae3d2ff39
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pins the breathe revision and removes the docutils requirement, since it
comes with sphinx.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>