### PR TITLE
tests: zigbee: Fix path to ZBOSS include dir

### DIFF
--- a/tests/subsys/zigbee/osif/crypto/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/crypto/CMakeLists.txt
@@ -16,8 +16,8 @@ target_compile_definitions(app PRIVATE
 
 target_include_directories(app PRIVATE
   ${NRF_DIR}/subsys/zigbee/osif
-  ${NRFXLIB_DIR}/zboss/include
-  ${NRFXLIB_DIR}/zboss/include/osif
+  ${NRFXLIB_DIR}/zboss/production/include
+  ${NRFXLIB_DIR}/zboss/production/include/osif
 )
 
 project(osif_crypto)

--- a/tests/subsys/zigbee/osif/serial/serial_async_api/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/CMakeLists.txt
@@ -23,8 +23,8 @@ zephyr_compile_definitions(CONFIG_ZIGBEE_UART_RX_BUF_LEN=16)
 zephyr_compile_definitions(CONFIG_ZIGBEE_UART_TX_BUF_LEN=128)
 
 zephyr_include_directories(${ZEPHYR_BASE}/../nrf/subsys/zigbee/osif)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include/osif)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include/osif)
 
 
 target_sources(app PRIVATE

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/CMakeLists.txt
@@ -23,8 +23,8 @@ zephyr_compile_definitions(CONFIG_ZIGBEE_UART_RX_BUF_LEN=16)
 zephyr_compile_definitions(CONFIG_ZIGBEE_UART_TX_BUF_LEN=128)
 
 zephyr_include_directories(${ZEPHYR_BASE}/../nrf/subsys/zigbee/osif)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include/osif)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include/osif)
 
 
 target_sources(app PRIVATE

--- a/tests/subsys/zigbee/osif/serial/serial_via_logger/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/serial/serial_via_logger/CMakeLists.txt
@@ -11,8 +11,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(app)
 add_definitions(-Wno-packed-bitfield-compat)
 
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include/osif)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include/osif)
 target_include_directories(app BEFORE PRIVATE mock)
 
 target_sources(app PRIVATE

--- a/tests/subsys/zigbee/osif/timer/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/timer/CMakeLists.txt
@@ -22,5 +22,5 @@ target_include_directories(app
   PRIVATE
   ${NRF_DIR}/tests/subsys/zigbee/osif/timer/mock
   ${NRF_DIR}/tests/subsys/zigbee/osif/timer/stubs
-  ${NRFXLIB_DIR}/zboss/include/osif
+  ${NRFXLIB_DIR}/zboss/production/include/osif
 )


### PR DESCRIPTION
Fix the path to ZBOSS include and include/osif dirs in nrfxlib.
This fix is cherry-picked from PR https://github.com/nrfconnect/sdk-nrf/pull/4089

