### PR TITLE
doc: zigbee: update links to NCP Host

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -111,7 +111,7 @@
 .. _`known issues for nRF Connect SDK v1.4.0`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html?v=v1-4-0
 
 .. _`Stack commissioning start sequence`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss_api_doc/using_zigbee__z_c_l.html#stack_start_initiation
-.. _`NCP Host for Zigbee`: https://developer.nordicsemi.com/Zigbee/ncp_sdk_for_host/ncp_sdk_v0.9.3.zip
+.. _`ZBOSS NCP Host`: https://developer.nordicsemi.com/Zigbee/ncp_sdk_for_host/ncp_host_v0.9.4.zip
 .. _`process the frame`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.3.0.6/using_zigbee__z_c_l.html#process_zcl_cmd
 
 .. ### Source: www.nordicsemi.com

--- a/doc/nrf/ug_zigbee_architectures.rst
+++ b/doc/nrf/ug_zigbee_architectures.rst
@@ -88,7 +88,7 @@ The host processor communicates with the NCP through a serial interface (USB or 
 
    Split Zigbee architecture
 
-The |NCS|'s :ref:`ug_zigbee_tools` include the `NCP Host for Zigbee`_ based on ZBOSS and available for download as a standalone :file:`zip` package.
+The |NCS|'s :ref:`ug_zigbee_tools` include the `ZBOSS NCP Host`_ and available for download as a standalone :file:`zip` package.
 |zigbee_ncp_package|
 
 The NCP design has the following advantages:
@@ -102,4 +102,4 @@ The NCP design has the following advantages:
 It also has the following disadvantages:
 
 * The host part of the stack must be built and run for every individual host processor in use.
-  However, Nordic Semiconductor provides reference implementation for Linux-based platforms in the NCP Host for Zigbee package.
+  However, Nordic Semiconductor provides reference implementation for Linux-based platforms in the ZBOSS NCP Host package.

--- a/doc/nrf/ug_zigbee_tools.rst
+++ b/doc/nrf/ug_zigbee_tools.rst
@@ -6,7 +6,7 @@ Zigbee tools
 When working with Zigbee in |NCS|, you can use the following tools during Zigbee application development:
 
 * `nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`_ - Tool for analyzing network traffic during development.
-* `NCP Host for Zigbee`_ - ZBOSS-based tool for running the host side of the :ref:`ug_zigbee_platform_design_ncp_details` design, distributed as a standalone :file:`zip` package.
+* `ZBOSS NCP Host`_ - ZBOSS-based tool for running the host side of the :ref:`ug_zigbee_platform_design_ncp_details` design, distributed as a standalone :file:`zip` package.
   |zigbee_ncp_package|
 
 Using Zigbee tools is optional.

--- a/samples/zigbee/ncp/README.rst
+++ b/samples/zigbee/ncp/README.rst
@@ -9,7 +9,7 @@ Zigbee: NCP
 
 The :ref:`Zigbee <ug_zigbee>` NCP sample demonstrates the usage of Zigbee's :ref:`ug_zigbee_platform_design_ncp_details` architecture.
 
-Together with the source code from `NCP Host for Zigbee`_, you can use this sample to create a complete and functional Zigbee device.
+Together with the source code from `ZBOSS NCP Host`_, you can use this sample to create a complete and functional Zigbee device.
 For example, as shown in the `Testing`_ scenario, you can program a development kit with the NCP sample and bundle it with the light control application on the NCP host processor.
 
 You can then use this sample together with the :ref:`Zigbee network coordinator <zigbee_network_coordinator_sample>` and the :ref:`Zigbee light bulb <zigbee_light_bulb_sample>` to set up a basic Zigbee network.
@@ -30,10 +30,10 @@ You can use any of the development kits listed above.
 
 For this sample to work, you also need the following:
 
-* `NCP Host for Zigbee`_ tool, which is based on the ZBOSS stack and available for download as a standalone :file:`zip` package as one of :ref:`ug_zigbee_tools`.
+* `ZBOSS NCP Host`_ tool, which is based on the ZBOSS stack and available for download as a standalone :file:`zip` package as one of :ref:`ug_zigbee_tools`.
   It contains the source code for all parts of the ZBOSS library for the NCP host.
   This allows you to recompile the library for the designated hardware platform.
-  Running the NCP Host for Zigbee requires a PC with an operating system compatible with the 64-bit Ubuntu 18.04 Linux.
+  Running the ZBOSS NCP Host requires a PC with an operating system compatible with the 64-bit Ubuntu 18.04 Linux.
 * The :ref:`Zigbee network coordinator <zigbee_network_coordinator_sample>` sample programmed on one separate device.
 * The :ref:`zigbee_light_bulb_sample` sample programmed on one separate device.
 
@@ -174,10 +174,10 @@ Testing
 
 After building the sample and programming it to your development kit, test it by performing the following steps:
 
-1. Download and extract the `NCP Host for Zigbee`_ package.
+1. Download and extract the `ZBOSS NCP Host`_ package.
 
    .. note::
-      If you are using an Linux distribution different than the 64-bit Ubuntu 18.04, make sure to rebuild the package libraries and applications by following the instructions described in the :file:`README.rst`  file in the NCP Host for Zigbee package.
+      If you are using an Linux distribution different than the 64-bit Ubuntu 18.04, make sure to rebuild the package libraries and applications by following the instructions described in the :file:`README.rst`  file in the ZBOSS NCP Host package.
 
 #. If you are using `Communication through USB`_, connect the nRF USB port of the NCP sample's development kit to the PC USB port with an USB cable.
 #. Get the kit’s serial port name (for example, /dev/ttyACM0).


### PR DESCRIPTION
Updated links to NCP Host v0.9.4.
Renamed NCP Host to match the name in the package.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>