### PR TITLE
net: lib: aws_fota: Reset fota_state variable upon download failure

### DIFF
--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -261,6 +261,8 @@ static int job_update_accepted(struct mqtt_client *const client,
 			LOG_ERR("Error (%d) when trying to start firmware "
 				"download", err);
 			execution_state = AWS_JOBS_FAILED;
+			aws_fota_evt.id = AWS_FOTA_EVT_ERROR;
+			fota_state = NONE;
 			err = update_job_execution(client, job_id,
 						   execution_state, "");
 			if (err) {


### PR DESCRIPTION
Reset fota_state to NONE if fota_download_start() fails. If this
variable is not reset, subsequent jobs received on the notify-next topic
is not handled.

Set callback event ID to AWS_FOTA_EVT_ERROR when fota_download_start()
fails. Previously, AWS_FOTA_EVT_START was propagated, which gave a false
impression that AWS FOTA started successfully.