### PR TITLE
homekit: add release notes for 1.5.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -153,7 +153,7 @@ manifest:
       path: modules/lib/cddl-gen
     - name: homekit
       repo-path: sdk-homekit
-      revision: 6f257f34b84e494bc18202e8c6411e6be4cc81aa
+      revision: 37d35c1ac77240d71a82ee4ed8ae686bc1030692
       groups:
       - homekit
 


### PR DESCRIPTION
KRKNWK:9675
added release notes to HomeKit documentation

Signed-off-by: Robert Gałat <robert.galat@nordicsemi.no>