### PR TITLE
Bluetooth ANCS client SPDX license fix

### DIFF
--- a/samples/bluetooth/peripheral_ancs_client/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_ancs_client/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 cmake_minimum_required(VERSION 3.13.1)
 

--- a/subsys/bluetooth/services/Kconfig.ancs_client
+++ b/subsys/bluetooth/services/Kconfig.ancs_client
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 menuconfig BT_ANCS_CLIENT


### PR DESCRIPTION
In Bluetooth ANCS client, fix SPDX tags to Nordic-5-Clause.