### PR TITLE
tree-wide: Fix license identifiers

### DIFF
--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/app_ZDebug.conf
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/app_ZDebug.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 ################################################################################
 # Application configuration

--- a/applications/machine_learning/configuration/thingy52_nrf52832/app_ZDebug.conf
+++ b/applications/machine_learning/configuration/thingy52_nrf52832/app_ZDebug.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 ################################################################################
 # Application configuration

--- a/applications/machine_learning/src/events/CMakeLists.txt
+++ b/applications/machine_learning/src/events/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 target_sources_ifdef(CONFIG_ML_APP_ML_RESULT_EVENTS app PRIVATE

--- a/applications/machine_learning/src/events/ml_result_event.c
+++ b/applications/machine_learning/src/events/ml_result_event.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <stdio.h>

--- a/applications/machine_learning/src/events/ml_result_event.h
+++ b/applications/machine_learning/src/events/ml_result_event.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #ifndef _ML_RESULT_EVENT_H_

--- a/applications/machine_learning/src/events/ml_state_event.c
+++ b/applications/machine_learning/src/events/ml_state_event.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <stdio.h>

--- a/applications/machine_learning/src/events/ml_state_event.h
+++ b/applications/machine_learning/src/events/ml_state_event.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #ifndef _ML_STATE_EVENT_H_

--- a/applications/machine_learning/src/events/sensor_sim_event.c
+++ b/applications/machine_learning/src/events/sensor_sim_event.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <stdio.h>

--- a/applications/machine_learning/src/events/sensor_sim_event.h
+++ b/applications/machine_learning/src/events/sensor_sim_event.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #ifndef _SENSOR_SIM_EVENT_H_

--- a/applications/machine_learning/src/main.c
+++ b/applications/machine_learning/src/main.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <event_manager.h>

--- a/applications/machine_learning/src/modules/CMakeLists.txt
+++ b/applications/machine_learning/src/modules/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 target_sources_ifdef(CONFIG_ML_APP_EI_DATA_FORWARDER

--- a/applications/machine_learning/src/modules/ei_data_forwarder.c
+++ b/applications/machine_learning/src/modules/ei_data_forwarder.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr.h>

--- a/applications/machine_learning/src/modules/led_state.c
+++ b/applications/machine_learning/src/modules/led_state.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr.h>

--- a/applications/machine_learning/src/modules/ml_runner.c
+++ b/applications/machine_learning/src/modules/ml_runner.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr.h>

--- a/applications/machine_learning/src/modules/ml_state.c
+++ b/applications/machine_learning/src/modules/ml_state.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr.h>

--- a/applications/machine_learning/src/modules/sensor_sim_ctrl.c
+++ b/applications/machine_learning/src/modules/sensor_sim_ctrl.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr.h>

--- a/include/caf/events/sensor_event.h
+++ b/include/caf/events/sensor_event.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #ifndef _SENSOR_EVENT_H_

--- a/subsys/caf/events/sensor_event.c
+++ b/subsys/caf/events/sensor_event.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <stdio.h>

--- a/subsys/caf/modules/sensor_sampler.c
+++ b/subsys/caf/modules/sensor_sampler.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr.h>


### PR DESCRIPTION
Change updates SPDX-License-Identifier in CAF and machine learning application.