### PR TITLE
LTE link control: Fixes for eDRX and CEREG parsing

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -169,8 +169,12 @@ struct lte_lc_psm_cfg {
 };
 
 struct lte_lc_edrx_cfg {
-	float edrx;	/* eDRX interval value [s] */
-	float ptw;	/* Paging time window [s] */
+	/* LTE mode for which the configuration is valid. */
+	enum lte_lc_lte_mode mode;
+	/* eDRX interval value [s] */
+	float edrx;
+	/* Paging time window [s] */
+	float ptw;
 };
 
 struct lte_lc_cell {

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -853,7 +853,7 @@ int lte_lc_edrx_req(bool enable)
 
 		/* PTW must be requested after eDRX is enabled */
 		if (strlen(ptw_param) != 4) {
-			return 0;
+			continue;
 		}
 
 		snprintk(req, sizeof(req), "AT%%XPTW=%d,\"%s\"", actt[i], ptw_param);

--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -445,9 +445,10 @@ int parse_cereg(const char *at_response,
 
 	if (reg_status) {
 		*reg_status = status;
+
+		LOG_DBG("Network registration status: %d", *reg_status);
 	}
 
-	LOG_DBG("Network registration status: %d", *reg_status);
 
 	if (cell && (status != LTE_LC_NW_REG_UICC_FAIL) &&
 	    (at_params_valid_count_get(&resp_list) > AT_CEREG_CELL_ID_INDEX)) {

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -28,21 +28,25 @@ static void test_parse_edrx(void)
 	zassert_equal(0, err, "parse_edrx failed, error: %d", err);
 	zassert_within(cfg.edrx, 81.92, 0.1, "Wrong eDRX value");
 	zassert_within(cfg.ptw, 15.36,  0.1, "Wrong PTW value");
+	zassert_equal(cfg.mode, LTE_LC_LTE_MODE_LTEM, "Wrong LTE mode");
 
 	err = parse_edrx(at_response_ltem_2, &cfg);
 	zassert_equal(0, err, "parse_edrx failed, error: %d", err);
 	zassert_within(cfg.edrx, 20.48, 0.1, "Wrong eDRX value");
 	zassert_within(cfg.ptw, 19.2, 0.1, "Wrong PTW value");
+	zassert_equal(cfg.mode, LTE_LC_LTE_MODE_LTEM, "Wrong LTE mode");
 
 	err = parse_edrx(at_response_nbiot, &cfg);
 	zassert_equal(0, err, "parse_edrx failed, error: %d", err);
 	zassert_within(cfg.edrx, 2621.44, 0.1, "Wrong eDRX value");
 	zassert_within(cfg.ptw, 20.48, 0.1, "Wrong PTW value");
+	zassert_equal(cfg.mode, LTE_LC_LTE_MODE_NBIOT, "Wrong LTE mode");
 
 	err = parse_edrx(at_response_nbiot_2, &cfg);
 	zassert_equal(0, err, "parse_edrx failed, error: %d", err);
 	zassert_within(cfg.edrx, 2621.44, 0.1, "Wrong eDRX value");
 	zassert_within(cfg.ptw, 15.36, 0.1, "Wrong PTW value");
+	zassert_equal(cfg.mode, LTE_LC_LTE_MODE_NBIOT, "Wrong LTE mode");
 }
 
 void test_parse_cereg(void)


### PR DESCRIPTION
The PR contains three fixes:

- NULL check before printing registration status
- Bug where eDRX parameters for NB-IoT were not set if PTW was not configured for LTE-M
- Add LTE mode to eDRX update event