### PR TITLE
manifest: sdk-mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -96,7 +96,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 6402e996db829901dc715de41e3669e28fefb670
+      revision: d816ab0e281a8a60ded2db1dcad9012758b6c724
       path: bootloader/mcuboot
     - name: nrfxlib
       repo-path: sdk-nrfxlib


### PR DESCRIPTION
Updated to version which fix following issue:
Scratch area was declared for BOOT_UPGRADE_ONLY unnecessarily.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>