### PR TITLE
cmake: bump minimal NCS Toolchain version to 1.5.99

### DIFF
--- a/share/ncs-package/cmake/NcsConfig.cmake
+++ b/share/ncs-package/cmake/NcsConfig.cmake
@@ -2,7 +2,7 @@
 set(NRF_RELATIVE_DIR "../../..")
 set(NCS_RELATIVE_DIR "../../../..")
 
-set(NCS_TOOLCHAIN_MINIMUM_REQUIRED 1.5.0)
+set(NCS_TOOLCHAIN_MINIMUM_REQUIRED 1.5.99)
 
 # Set the current NRF_DIR
 # The use of get_filename_component ensures that the final path variable will not contain `../..`.


### PR DESCRIPTION
Latest released NCS Toolchain is 1.5.0, which causes build failures as
newer versions of tools has been introduced since NCS Toolchain 1.5.0
has been released.

Updating minimal version to 1.5.99 ensures that 1.5.0 will not be used
and thus falling back to manual installed tools or a 1.5.99 toolchain.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>