### PR TITLE
lib: lte_lc: Enable notifications when LTE is activated 

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -619,14 +619,6 @@ int lte_lc_deinit(void)
 
 int lte_lc_normal(void)
 {
-	int err;
-
-	err = enable_notifications();
-	if (err) {
-		LOG_ERR("Failed to enabled notifications, error: %d", err);
-		return err;
-	}
-
 	return lte_lc_func_mode_set(LTE_LC_FUNC_MODE_NORMAL);
 }
 
@@ -1265,11 +1257,18 @@ clean_exit:
 int lte_lc_func_mode_set(enum lte_lc_func_mode mode)
 {
 	switch (mode) {
+	case LTE_LC_FUNC_MODE_ACTIVATE_LTE:
+	case LTE_LC_FUNC_MODE_NORMAL: {
+		int err = enable_notifications();
+
+		if (err) {
+			LOG_ERR("Failed to enabled notifications, error: %d", err);
+			return err;
+		}
+	}
 	case LTE_LC_FUNC_MODE_POWER_OFF:
-	case LTE_LC_FUNC_MODE_NORMAL:
 	case LTE_LC_FUNC_MODE_OFFLINE:
 	case LTE_LC_FUNC_MODE_DEACTIVATE_LTE:
-	case LTE_LC_FUNC_MODE_ACTIVATE_LTE:
 	case LTE_LC_FUNC_MODE_DEACTIVATE_GNSS:
 	case LTE_LC_FUNC_MODE_ACTIVATE_GNSS:
 	case LTE_LC_FUNC_MODE_OFFLINE_UICC_ON: {


### PR DESCRIPTION
Adds enabling of notifications when normal mode or
"activate LTE mode" is set.
This fixes an issue where notifications were not enabled after
mode was set to power off and then back to normal mode.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>