### PR TITLE
net: nrf_cloud: Separate cellular positioning from A-GPS

### DIFF
--- a/applications/asset_tracker/src/gps_controller/gps_controller.c
+++ b/applications/asset_tracker/src/gps_controller/gps_controller.c
@@ -155,8 +155,8 @@ int gps_control_init(struct k_work_q *work_q, gps_event_handler_t handler)
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_AGPS_SINGLE_CELL_ONLY)) {
-		LOG_INF("Cell-based location enabled, skipping GPS init");
+	if (!IS_ENABLED(CONFIG_NRF9160_GPS) && !IS_ENABLED(CONFIG_GPS_SIM)) {
+		LOG_INF("GPS not enabled, skipping GPS init");
 		return 0;
 	}
 

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -38,8 +38,8 @@ nRF9160
 
   * :ref:`lib_nrf_cloud` library:
 
-    * Added cell-based location support to :ref:`lib_nrf_cloud_agps`.
-    * Added Kconfig option :option:`CONFIG_NRF_CLOUD_AGPS_SINGLE_CELL_ONLY` to obtain cell-based location from nRF Connect for Cloud instead of using the modem's GPS.
+    * Added cellular positioning support to :ref:`lib_nrf_cloud_cell_pos`.
+    * Added Kconfig option :option:`CONFIG_NRF_CLOUD_CELL_POS` to obtain cell-based location from nRF Cloud instead of using the modem's GPS.
     * Added function :c:func:`nrf_cloud_modem_fota_completed` which is to be called by the application after it re-initializes the modem (instead of rebooting) after a modem FOTA update.
     * Updated to include the FOTA type value in the :c:enumerator:`NRF_CLOUD_EVT_FOTA_DONE` event.
     * Updated configuration options for setting the source of the MQTT client ID (nRF Cloud device ID).
@@ -48,12 +48,7 @@ nRF9160
 
     * Updated to handle new Kconfig options:
 
-      * :option:`CONFIG_NRF_CLOUD_AGPS_SINGLE_CELL_ONLY`
-      * :option:`CONFIG_NRF_CLOUD_AGPS_REQ_CELL_BASED_LOC`
-
-  * A-GPS library:
-
-    * Added the Kconfig option :option:`CONFIG_AGPS_SINGLE_CELL_ONLY` to support cell-based location instead of using the modem's GPS.
+      * :option:`CONFIG_NRF_CLOUD_CELL_POS`
 
   * :ref:`modem_info_readme` library:
 

--- a/include/net/nrf_cloud_agps.h
+++ b/include/net/nrf_cloud_agps.h
@@ -22,13 +22,6 @@ extern "C" {
  * @{
  */
 
-/** @brief Cell-based location request type */
-enum cell_based_location_type {
-	CELL_LOC_TYPE_INVALID = -1,
-	CELL_LOC_TYPE_SINGLE,
-	CELL_LOC_TYPE_MULTI /* Not yet supported */
-};
-
 /**@brief Requests specified A-GPS data from nRF Cloud.
  *
  * @param request Structure containing specified A-GPS data to be requested.
@@ -42,25 +35,6 @@ int nrf_cloud_agps_request(const struct gps_agps_request request);
  * @return 0 if successful, otherwise a (negative) error code.
  */
 int nrf_cloud_agps_request_all(void);
-
-/**@brief Request a cell-based location query from nRF Cloud.
- *
- * @param type        Type of cell-based location to request.
- * @param request_loc If true, cloud will send location to the device.
- *                    If false, cloud will not send location to the device.
- * @return 0 if successful, otherwise a (negative) error code.
- */
-int nrf_cloud_agps_request_cell_location(enum cell_based_location_type type,
-					 const bool request_loc);
-
-/**@brief Gets most recent location from single-cell request.
- *
- * @param lat Pointer where last single cell latitude is to be copied.
- * @param lon Pointer where last single cell longitude is to be copied.
- * @return 0 if successful, otherwise a (negative) error code.
- */
-int nrf_cloud_agps_get_last_cell_location(double *const lat,
-					  double *const lon);
 
 /**@brief Processes binary A-GPS data received from nRF Cloud.
  *

--- a/include/net/nrf_cloud_cell_pos.h
+++ b/include/net/nrf_cloud_cell_pos.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef NRF_CLOUD_CELL_POS_H_
+#define NRF_CLOUD_CELL_POS_H_
+
+/** @file nrf_cloud_cell_pos.h
+ * @brief Module to provide nRF Cloud cellular positioning support to nRF9160 SiP.
+ */
+
+#include <zephyr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup nrf_cloud_cell_pos nRF Cloud cellular positioning
+ * @{
+ */
+
+/** @brief Cellular positioning request type */
+enum nrf_cloud_cell_pos_type {
+	CELL_POS_TYPE_SINGLE,
+	CELL_POS_TYPE_MULTI /* Not yet supported */
+};
+
+/** @brief Cellular positioning request result */
+struct nrf_cloud_cell_pos_result {
+	enum nrf_cloud_cell_pos_type type;
+	double lat;
+	double lon;
+	uint32_t unc;
+};
+
+/**@brief Request a cellular positioning query from nRF Cloud.
+ *
+ * @param type        Type of cellular positioning request.
+ * @param request_loc If true, cloud will send location to the device.
+ *                    If false, cloud will not send location to the device.
+ * @return 0 if successful, otherwise a (negative) error code.
+ */
+int nrf_cloud_cell_pos_request(enum nrf_cloud_cell_pos_type type, const bool request_loc);
+
+/**@brief Processes cellular positioning data received from nRF Cloud.
+ *
+ * @param buf Pointer to data received from nRF Cloud.
+ * @param result Pointer to buffer for parsing result.
+ *
+ * @return 0 if processed successfully and cell-based location found.
+ *         1 if processed successfully but no cell-based location found.
+ *         otherwise a (negative) error code.
+ */
+int nrf_cloud_cell_pos_process(const char *buf, struct nrf_cloud_cell_pos_result *result);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_CLOUD_CELL_POS_H_ */

--- a/include/net/nrf_cloud_cell_pos.rst
+++ b/include/net/nrf_cloud_cell_pos.rst
@@ -1,0 +1,41 @@
+.. _lib_nrf_cloud_cell_pos:
+
+nRF Cloud cellular positioning
+##############################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The nRF Cloud cellular positioning library enables applications to request cellular positioning data from `nRF Cloud`_ to be used with the nRF9160 SiP.
+This library is an enhancement to the :ref:`lib_nrf_cloud` library.
+
+.. note::
+   To use the nRF Cloud cellular positioning service, an nRF Cloud account is needed, and the device needs to be associated with a user's account.
+
+Configuration
+*************
+
+Configure the following options to enable or disable the use of this library:
+
+* :option:`CONFIG_NRF_CLOUD`
+* :option:`CONFIG_NRF_CLOUD_CELL_POS`
+
+
+Request and process cellular positioning data
+*********************************************
+
+The :c:func:`nrf_cloud_cell_pos_request` function is used to request the cellular location of the device by type.
+
+When nRF Cloud responds with the requested cellular positioning data, the :c:func:`nrf_cloud_cell_pos_process` function processes the received data.
+The function parses the data and returns the location information if it is found.
+
+API documentation
+*****************
+
+| Header file: :file:`include/net/nrf_cloud_cell_pos.h`
+| Source files: :file:`subsys/net/lib/nrf_cloud/src/`
+
+.. doxygengroup:: nrf_cloud_cell_pos
+   :project: nrf
+   :members:

--- a/lib/agps/Kconfig
+++ b/lib/agps/Kconfig
@@ -37,12 +37,6 @@ config AGPS_SRC_SUPL
 
 endchoice
 
-config AGPS_SINGLE_CELL_ONLY
-	bool "Obtain approximate location using a single cell tower instead of GPS"
-	depends on AGPS_SRC_NRF_CLOUD
-	depends on NRF_CLOUD_AGPS
-	select NRF_CLOUD_AGPS_SINGLE_CELL_ONLY
-
 if AGPS_SRC_SUPL
 
 config AGPS_SUPL_HOST_NAME

--- a/lib/agps/agps.c
+++ b/lib/agps/agps.c
@@ -351,12 +351,7 @@ int gps_agps_request_send(struct gps_agps_request request, int socket)
 	}
 
 #elif defined(CONFIG_AGPS_SRC_NRF_CLOUD)
-#if defined(CONFIG_AGPS_SINGLE_CELL_ONLY)
-	err = nrf_cloud_agps_request_cell_location(CELL_LOC_TYPE_SINGLE,
-		(bool)IS_ENABLED(CONFIG_NRF_CLOUD_AGPS_REQ_CELL_BASED_LOC));
-#else
 	err = nrf_cloud_agps_request(request);
-#endif
 	if (err) {
 		LOG_ERR("nRF Cloud A-GPS request failed, error: %d", err);
 		return err;
@@ -381,12 +376,4 @@ int gps_process_agps_data(const uint8_t *buf, size_t len)
 #endif /* CONFIG_AGPS_SRC_NRF_CLOUD && CONFIG_NRF_CLOUD_AGPS */
 
 	return err;
-}
-
-int gps_get_last_cell_location(double *const lat, double *const lon)
-{
-#if defined(CONFIG_AGPS_SRC_NRF_CLOUD) && defined(CONFIG_NRF_CLOUD_AGPS)
-	return nrf_cloud_agps_get_last_cell_location(lat, lon);
-#endif
-	return -ESRCH;
 }

--- a/subsys/net/lib/nrf_cloud/CMakeLists.txt
+++ b/subsys/net/lib/nrf_cloud/CMakeLists.txt
@@ -22,6 +22,9 @@ zephyr_library_sources_ifdef(
 	src/nrf_cloud_pgps.c
 	src/nrf_cloud_pgps_utils.c)
 zephyr_library_sources_ifdef(
+	CONFIG_NRF_CLOUD_CELL_POS
+	src/nrf_cloud_cell_pos.c)
+zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_FOTA
 	src/nrf_cloud_fota.c)
 zephyr_include_directories(./include)

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -208,20 +208,22 @@ if NRF_CLOUD_AGPS
 config NRF_CLOUD_AGPS_AUTO
 	bool "Automatically request A-GPS on bootup"
 
-config NRF_CLOUD_AGPS_SINGLE_CELL_ONLY
-	bool "Obtain approximate location using a single cell tower instead of GPS"
-
-config NRF_CLOUD_AGPS_REQ_CELL_BASED_LOC
-	bool "Request the cell-based location from nRF Cloud"
-	depends on NRF_CLOUD_AGPS_SINGLE_CELL_ONLY
-	default y
-	help
-	  When disabled, nRF Cloud will obtain and store the approximate
-	  cell-based location but will not send it to the device.
-	  When enabled, nRF Cloud will also send the location to the
-	  device.
+module = NRF_CLOUD_AGPS
+module-str = nRF Cloud A-GPS
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # NRF_CLOUD_AGPS
+
+endmenu
+
+menu "nRF Cloud Cellular Positioning"
+
+config NRF_CLOUD_CELL_POS
+	bool "Enable nRF Cloud Cellular Positioning"
+	imply FPU
+	depends on MODEM_INFO
+	depends on MODEM_INFO_ADD_NETWORK
+
 endmenu
 
 menu "nRF Cloud P-GPS"

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_cell_pos.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_cell_pos.c
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <device.h>
+#include <net/socket.h>
+#include <nrf_socket.h>
+
+#include <cJSON.h>
+#include <cJSON_os.h>
+#include <modem/modem_info.h>
+#include <net/nrf_cloud_cell_pos.h>
+
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(nrf_cloud_cell_pos, CONFIG_NRF_CLOUD_LOG_LEVEL);
+
+#include "nrf_cloud_transport.h"
+#include "nrf_cloud_agps_schema_v1.h"
+
+#define CELL_POS_JSON_MSG_TYPE_KEY		"messageType"
+#define CELL_POS_JSON_MSG_TYPE_VAL_DATA		"DATA"
+
+#define CELL_POS_JSON_DATA_KEY			"data"
+#define CELL_POS_JSON_MCC_KEY			"mcc"
+#define CELL_POS_JSON_MNC_KEY			"mnc"
+#define CELL_POS_JSON_AREA_CODE_KEY		"tac"
+#define CELL_POS_JSON_CELL_ID_KEY		"eci"
+#define CELL_POS_JSON_PHYCID_KEY		"phycid"
+#define CELL_POS_JSON_TYPES_KEY			"types"
+#define CELL_POS_JSON_CELL_LOC_KEY_DOREPLY	"doReply"
+
+#define CELL_POS_JSON_APPID_KEY			"appId"
+#define CELL_POS_JSON_APPID_VAL_SINGLE_CELL	"SCELL"
+#define CELL_POS_JSON_APPID_VAL_MULTI_CELL	"MCELL"
+#define CELL_POS_JSON_CELL_LOC_KEY_LAT		"lat"
+#define CELL_POS_JSON_CELL_LOC_KEY_LON		"lon"
+#define CELL_POS_JSON_CELL_LOC_KEY_UNCERT	"uncertainty"
+
+static bool json_initialized;
+
+static int get_modem_info(struct modem_param_info *const modem_info)
+{
+	__ASSERT_NO_MSG(modem_info != NULL);
+
+	int err = modem_info_init();
+
+	if (err) {
+		LOG_ERR("Could not initialize modem info module");
+		return err;
+	}
+
+	err = modem_info_params_init(modem_info);
+	if (err) {
+		LOG_ERR("Could not initialize modem info parameters");
+		return err;
+	}
+
+	err = modem_info_params_get(modem_info);
+	if (err) {
+		LOG_ERR("Could not obtain cell information");
+		return err;
+	}
+
+	return 0;
+}
+
+static cJSON *json_create_req_obj(const char *const app_id, const char *const msg_type)
+{
+	__ASSERT_NO_MSG(app_id != NULL);
+	__ASSERT_NO_MSG(msg_type != NULL);
+
+	if (!json_initialized) {
+		cJSON_Init();
+		json_initialized = true;
+	}
+
+	cJSON *resp_obj = cJSON_CreateObject();
+
+	if (!cJSON_AddStringToObject(resp_obj, CELL_POS_JSON_APPID_KEY, app_id) ||
+	    !cJSON_AddStringToObject(resp_obj, CELL_POS_JSON_MSG_TYPE_KEY, msg_type)) {
+		cJSON_Delete(resp_obj);
+		resp_obj = NULL;
+	}
+
+	return resp_obj;
+}
+
+static int json_format_data_obj(cJSON *const data_obj,
+				const struct modem_param_info *const modem_info)
+{
+	__ASSERT_NO_MSG(data_obj != NULL);
+	__ASSERT_NO_MSG(modem_info != NULL);
+
+	if (!cJSON_AddNumberToObject(data_obj, CELL_POS_JSON_MCC_KEY,
+		modem_info->network.mcc.value) ||
+	    !cJSON_AddNumberToObject(data_obj, CELL_POS_JSON_MNC_KEY,
+		modem_info->network.mnc.value) ||
+	    !cJSON_AddNumberToObject(data_obj, CELL_POS_JSON_AREA_CODE_KEY,
+		modem_info->network.area_code.value) ||
+	    !cJSON_AddNumberToObject(data_obj, CELL_POS_JSON_CELL_ID_KEY,
+		(uint32_t)modem_info->network.cellid_dec) ||
+	    !cJSON_AddNumberToObject(data_obj, CELL_POS_JSON_PHYCID_KEY, 0)) {
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+static int json_add_modem_info(cJSON *const data_obj)
+{
+	__ASSERT_NO_MSG(data_obj != NULL);
+
+	struct modem_param_info modem_info = {0};
+	int err;
+
+	err = get_modem_info(&modem_info);
+	if (err) {
+		return err;
+	}
+
+	return json_format_data_obj(data_obj, &modem_info);
+}
+
+static int json_send_to_cloud(cJSON *const cell_pos_request)
+{
+	__ASSERT_NO_MSG(cell_pos_request != NULL);
+
+	char *msg_string;
+	int err;
+
+	msg_string = cJSON_PrintUnformatted(cell_pos_request);
+	if (!msg_string) {
+		LOG_ERR("Could not allocate memory for Cell Pos request message");
+		return -ENOMEM;
+	}
+
+	LOG_DBG("Created Cell Pos request: %s", log_strdup(msg_string));
+
+	struct nct_dc_data msg = {
+		.data.ptr = msg_string,
+		.data.len = strlen(msg_string)
+	};
+
+	err = nct_dc_send(&msg);
+	if (err) {
+		LOG_ERR("Failed to send Cell Pos request, error: %d", err);
+	} else {
+		LOG_DBG("Cell Pos request sent");
+	}
+
+	k_free(msg_string);
+
+	return err;
+}
+
+bool json_item_string_exists(const cJSON *const obj, const char *const key, const char *const val)
+{
+	__ASSERT_NO_MSG(obj != NULL);
+	__ASSERT_NO_MSG(key != NULL);
+
+	char *str_val;
+	cJSON *item = cJSON_GetObjectItem(obj, key);
+
+	if (!item) {
+		return false;
+	}
+
+	if (!val) {
+		return cJSON_IsNull(item);
+	}
+
+	str_val = cJSON_GetStringValue(item);
+	if (!str_val) {
+		return false;
+	}
+
+	return (strcmp(str_val, val) == 0);
+}
+
+static int json_parse_cell_location(const cJSON *const cell_pos_obj,
+				    struct nrf_cloud_cell_pos_result *result)
+{
+	__ASSERT_NO_MSG(cell_pos_obj);
+
+	cJSON *lat, *lon, *unc;
+
+	lat = cJSON_GetObjectItem(cell_pos_obj, CELL_POS_JSON_CELL_LOC_KEY_LAT);
+	lon = cJSON_GetObjectItem(cell_pos_obj, CELL_POS_JSON_CELL_LOC_KEY_LON);
+	unc = cJSON_GetObjectItem(cell_pos_obj, CELL_POS_JSON_CELL_LOC_KEY_UNCERT);
+
+	if (!cJSON_IsNumber(lat) || !cJSON_IsNumber(lon) || !cJSON_IsNumber(unc)) {
+		LOG_DBG("Expected items not found in cell-based location msg");
+		return -EBADMSG;
+	}
+
+	result->lat = lat->valuedouble;
+	result->lon = lon->valuedouble;
+	result->unc = unc->valueint;
+
+	LOG_DBG("Cell location: (%lf, %lf), unc: %d, type: %d",
+		result->lat, result->lon, result->unc, result->type);
+
+	return 0;  /* 0: cell-based location found */
+}
+
+static int parse_cell_location_response(const char *const buf,
+					struct nrf_cloud_cell_pos_result *result)
+{
+	int ret = 1; /* 1: cell-based location not found */
+	cJSON *cell_pos_obj;
+	cJSON *data_obj;
+
+	if (buf == NULL) {
+		return -EINVAL;
+	}
+
+	cell_pos_obj = cJSON_Parse(buf);
+	if (!cell_pos_obj) {
+		LOG_DBG("No JSON found for cell location");
+		return 1;
+	}
+
+	/* Check for valid appId and msgType */
+	if (!json_item_string_exists(cell_pos_obj, CELL_POS_JSON_MSG_TYPE_KEY,
+				     CELL_POS_JSON_MSG_TYPE_VAL_DATA)) {
+		LOG_DBG("Wrong msg type for cell location");
+		goto cleanup;
+	}
+
+	if (json_item_string_exists(cell_pos_obj, CELL_POS_JSON_APPID_KEY,
+				    CELL_POS_JSON_APPID_VAL_SINGLE_CELL)) {
+		result->type = CELL_POS_TYPE_SINGLE;
+	} else if (json_item_string_exists(cell_pos_obj, CELL_POS_JSON_APPID_KEY,
+					   CELL_POS_JSON_APPID_VAL_MULTI_CELL)) {
+		result->type = CELL_POS_TYPE_MULTI;
+	} else {
+		LOG_DBG("Wrong app id for cell location");
+		goto cleanup;
+	}
+
+	data_obj = cJSON_GetObjectItem(cell_pos_obj, CELL_POS_JSON_DATA_KEY);
+	if (!data_obj) {
+		LOG_DBG("Data object not found in cell-based location msg.");
+		goto cleanup;
+	}
+
+	ret = json_parse_cell_location(data_obj, result);
+
+cleanup:
+	cJSON_Delete(cell_pos_obj);
+	return ret;
+}
+
+int nrf_cloud_cell_pos_request(enum nrf_cloud_cell_pos_type type, const bool request_loc)
+{
+	int err;
+	cJSON *data_obj;
+	cJSON *cell_pos_req_obj;
+
+	/* TODO: currently single cell only */
+	ARG_UNUSED(type);
+	cell_pos_req_obj = json_create_req_obj(CELL_POS_JSON_APPID_VAL_SINGLE_CELL,
+					   CELL_POS_JSON_MSG_TYPE_VAL_DATA);
+	data_obj = cJSON_AddObjectToObject(cell_pos_req_obj, CELL_POS_JSON_DATA_KEY);
+
+	if (!cell_pos_req_obj || !data_obj) {
+		err = -ENOMEM;
+		goto cleanup;
+	}
+
+	/* Add modem info to the data object */
+	err = json_add_modem_info(data_obj);
+	if (err) {
+		LOG_ERR("Failed to add modem info to cell loc req: %d", err);
+		goto cleanup;
+	}
+
+	/* By default, nRF Cloud will send the location to the device */
+	if (!request_loc) {
+		/* Specify that location should not be sent to the device */
+		cJSON_AddNumberToObject(data_obj, CELL_POS_JSON_CELL_LOC_KEY_DOREPLY, 0);
+	}
+
+	err = json_send_to_cloud(cell_pos_req_obj);
+
+cleanup:
+	cJSON_Delete(cell_pos_req_obj);
+
+	return err;
+}
+
+int nrf_cloud_cell_pos_process(const char *buf, struct nrf_cloud_cell_pos_result *result)
+{
+	int err;
+
+	if (!result) {
+		return -EINVAL;
+	}
+
+	err = parse_cell_location_response(buf, result);
+	if (err < 0) {
+		LOG_ERR("Error processing cell-based location: %d", err);
+	}
+
+	return err;
+}


### PR DESCRIPTION
Cellular positioning does not requires GPS on modem side.
 In nrf\subsys\net\lib\nrf_cloud, separate APIs for cellular
positioning and A-GPS; In nrf\lib\agps, remove anything related
to cellular positioning.

Applications and samples
.adapted nrf\applications\asset_tracker

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>