### PR TITLE
caf: leds: Use warning log for set power state errors

### DIFF
--- a/subsys/caf/modules/leds.c
+++ b/subsys/caf/modules/leds.c
@@ -202,7 +202,7 @@ static void leds_start(void)
 						 DEVICE_PM_ACTIVE_STATE,
 						 NULL, NULL);
 		if (err) {
-			LOG_ERR("PWM enable failed");
+			LOG_WRN("PWM enable failed");
 		}
 #endif
 		led_update(&leds[i]);
@@ -221,7 +221,7 @@ static void leds_stop(void)
 						 DEVICE_PM_SUSPEND_STATE,
 						 NULL, NULL);
 		if (err) {
-			LOG_ERR("PWM disable failed");
+			LOG_WRN("PWM disable failed");
 		}
 #endif
 	}


### PR DESCRIPTION
LED PWM driver implementation in Zephyr does not support setting device power state. The support will be introduced by next Zephyr upmerge. For now, we should use warning instead of error logs to prevent CI fail when device is suspended during test.

Jira: NCSDK-9134