### PR TITLE
applications: serial_lte_modem: verify hex string before converting

### DIFF
--- a/applications/serial_lte_modem/src/slm_util.c
+++ b/applications/serial_lte_modem/src/slm_util.c
@@ -80,6 +80,24 @@ bool slm_util_hex_check(const uint8_t *data, uint16_t data_len)
 }
 
 /**
+ * @brief Detect hexdecimal string data type
+ */
+bool slm_util_hexstr_check(const uint8_t *data, uint16_t data_len)
+{
+	for (int i = 0; i < data_len; i++) {
+		char ch = *(data + i);
+
+		if ((ch < '0' || ch > '9') &&
+		    (ch < 'A' || ch > 'F') &&
+		    (ch < 'a' || ch > 'f')) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
  * @brief Encode hex array to hexdecimal string (ASCII text)
  */
 int slm_util_htoa(const uint8_t *hex, uint16_t hex_len,
@@ -114,6 +132,9 @@ int slm_util_atoh(const char *ascii, uint16_t ascii_len,
 		return -EINVAL;
 	}
 	if (ascii_len > (hex_len * 2)) {
+		return -EINVAL;
+	}
+	if (!slm_util_hexstr_check(ascii, ascii_len)) {
 		return -EINVAL;
 	}
 

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -48,12 +48,22 @@ bool slm_util_cmd_casecmp(const char *cmd, const char *slm_cmd);
 /**
  * @brief Detect hexdecimal data type
  *
- * @param[in] hex Hex arrary to be encoded
- * @param[in] hex_len Length of hex array
+ * @param[in] data Hex arrary to be encoded
+ * @param[in] data_len Length of hex array
  *
  * @return true if the input is hexdecimal array, otherwise false
  */
-bool slm_util_hex_check(const uint8_t *hex, uint16_t hex_len);
+bool slm_util_hex_check(const uint8_t *data, uint16_t data_len);
+
+/**
+ * @brief Detect hexdecimal string data type
+ *
+ * @param[in] data Hexdecimal string arrary to be checked
+ * @param[in] data_len Length of array
+ *
+ * @return true if the input is hexdecimal string array, otherwise false
+ */
+bool slm_util_hexstr_check(const uint8_t *data, uint16_t data_len);
 
 /**
  * @brief Encode hex array to hexdecimal string (ASCII text)


### PR DESCRIPTION
Verify hex string before converting to hex array. The valid character
in a hex string should be one of following:

A - Z
a - z
0 - 9

This change avoid converting non-hexadeimal string to 00 hex byte.

Signed-off-by: Larry Tsai <larry.tsai@nordicsemi.no>