### PR TITLE
samples: bluetooth: central_dfu_smp: flush stdout after decoding CBOR

### DIFF
--- a/samples/bluetooth/central_dfu_smp/src/main.c
+++ b/samples/bluetooth/central_dfu_smp/src/main.c
@@ -303,8 +303,8 @@ static void smp_echo_rsp_proc(struct bt_dfu_smp *dfu_smp)
 		}
 
 		cbor_error = cbor_value_to_pretty_advance(stdout, &value);
+		fprintf(stdout, "\n");  /* Add newline and flush the stdout buffer */
 
-		printk("\n");
 		if (cbor_error != CborNoError) {
 			printk("Cannot print received CBOR stream (err: %d)\n",
 			       cbor_error);


### PR DESCRIPTION
Added a flush of stdout buffer after the cbor_value_to_pretty_advance
function in order to print the decoded message.

Ref: NCSDK-8510

Signed-off-by: Marcin Jeliński <marcin.jelinski@nordicsemi.no>