### PR TITLE
[rfc] lib: at_cmd: printf and scanf

### DIFF
--- a/include/modem/at_cmd.h
+++ b/include/modem/at_cmd.h
@@ -133,6 +133,27 @@ int at_cmd_write(const char *const cmd,
 		 enum at_cmd_state *state);
 
 /**
+ * @brief Send a formatted AT command.
+ *
+ * @param fmt Command format.
+ * @param ... Format parameters.
+ * @return int Zero on success, a negative errno otherwise.
+ */
+int at_cmd_printf(const char *fmt, ...);
+
+/**
+ * @brief Send an AT command and parse the response.
+ *
+ * Send an AT command and parse the response using sscanf.
+ *
+ * @param cmd The AT command.
+ * @param fmt Response format.
+ * @param ... Format parameters.
+ * @return int Zero on success, a negative errno otherwise.
+ */
+int at_cmd_scanf(const char *cmd, const char *fmt, ...);
+
+/**
  * @brief Function to set AT command global notification handler
  *
  * @param handler Pointer to a received notification handler function of type


### PR DESCRIPTION
This PR has two purposes, first I introduce two new functions to `at_cmd` which I think will simplify the most common operations we do with AT commands. Second, although this might not be the best place to discuss it in-depth, it kick-starts some discussion around the AT parser.

The implementation is preliminary and the changes to the Link Controller are purely demonstrative.

I noticed that very often, what we do is
1) `snprintf` an AT command and send it, usually not interested in the response
2) send an AT command, and use the AT parser to parse the results

---

Example of 1)
```
int err;
char buf[32];
err = snprintf(buf, sizeof(buf),
	       "AT+CGAUTH=%u,%s,%s", cid, user, password);

if (err < 0 || err >= sizeof(buf)) {
	return -ENOBUFS;
}

err = at_cmd_write(buf, NULL, 0, NULL);
if (err) {
	return err;
}
```
`at_cmd_printf` addresses this pattern and removes the need of allocating a buffer on the stack every time, or the need to have a static buffer for this purpose in each library. There is only one static buffer in the `at_cmd` library, which is also the only place where we'll need error checking for `snprintf`. Pattern 1) can be replaced (entirely) by:
```
in err; 
err = at_cmd_printf("AT+CGAUTH=%u,%s,%s", cid, user, password);
if (err) {
	return err;
}
```

---

A condensed example of 2)
```
char response[];
at_cmd_write(cmd, response)
at_params_list_init()
at_parser_max_params_from_str()
at_params_xxxx_get()
at_params_list_free()
```

I see several issues with this pattern, all related to the AT parser. Perhaps this PR is not the best place to discuss those in-depth, but `at_cmd_scanf` would be used like this;
```
int err, status;
err = at_cmd_scanf("AT+CREG?", "+CEREG: %*d,%d", status);
if (err) {
	return err;
}
```
which has several advantages compared to using the AT parser:
- the response parameters are not copied on the heap
- all parameters are retrieved at once, instead of one function call per parameter (`at_params_xxx_get()`)
- instead of having one buffer for AT responses in each library, we could have one buffer in `at_cmd`

