### PR TITLE
LTE link control: Add support for neighbor cell measurements

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -74,7 +74,8 @@ nRF9160
 
   * :ref:`lte_lc_readme` library:
 
-    * Add support for %XT3412 AT command notifications which allows the application to get pre-warnings prior to Tracking Area Updates.
+    * Added support for %XT3412 AT command notifications, which allows the application to get prewarnings before Tracking Area Updates.
+    * Added support for neighbor cell measurements.
 
   * :ref:`serial_lte_modem` application:
 

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -270,6 +270,19 @@ config LTE_LC_TAU_PRE_WARNING_THRESHOLD_MS
 	help
 		Minimum value of the given T3412 timer that will trigger TAU pre-warnings.
 
+config LTE_NEIGHBOR_CELLS_MAX
+	int "Max number of neighbor cells"
+	range 1 17
+	default 10
+	help
+		Maximum number of neighbor cells to allocate space for when
+		performing neighbor cell measurements.
+		Increasing the maximum number of neighbor cells requires
+		more heap space.
+		The modem can deliver information for a maximum of 17 neighbor
+		cells, so there's a trade-off between heap requirements and
+		the risk of not being able to parse all neighbor cell information.
+
 module = LTE_LINK_CONTROL
 module-dep = LOG
 module-str = LTE link control library

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -76,6 +76,38 @@
 #define AT_XT3412_TIME_INDEX			2
 #define T3412_MAX				35712000000
 
+/* NCELLMEAS notification parameters */
+#define AT_NCELLMEAS_RESPONSE_PREFIX		"%NCELLMEAS"
+#define AT_NCELLMEAS_START			"AT%NCELLMEAS"
+#define AT_NCELLMEAS_STOP			"AT%NCELLMEASSTOP"
+#define AT_NCELLMEAS_STATUS_INDEX		1
+#define AT_NCELLMEAS_STATUS_VALUE_SUCCESS	0
+#define AT_NCELLMEAS_STATUS_VALUE_FAIL		1
+#define AT_NCELLMEAS_CELL_ID_INDEX		2
+#define AT_NCELLMEAS_PLMN_INDEX			3
+#define AT_NCELLMEAS_TAC_INDEX			4
+#define AT_NCELLMEAS_TIMING_ADV_INDEX		5
+#define AT_NCELLMEAS_EARFCN_INDEX		6
+#define AT_NCELLMEAS_PHYS_CELL_ID_INDEX		7
+#define AT_NCELLMEAS_RSRP_INDEX			8
+#define AT_NCELLMEAS_RSRQ_INDEX			9
+#define AT_NCELLMEAS_MEASUREMENT_TIME_INDEX	10
+#define AT_NCELLMEAS_PRE_NCELLS_PARAMS_COUNT	11
+/* The rest of the parameters are in repeating arrays per neighboring cell.
+ * The indices below refer to their index within such a repeating array.
+ */
+#define AT_NCELLMEAS_N_EARFCN_INDEX		0
+#define AT_NCELLMEAS_N_PHYS_CELL_ID_INDEX	1
+#define AT_NCELLMEAS_N_RSRP_INDEX		2
+#define AT_NCELLMEAS_N_RSRQ_INDEX		3
+#define AT_NCELLMEAS_N_TIME_DIFF_INDEX		4
+#define AT_NCELLMEAS_N_PARAMS_COUNT		5
+#define AT_NCELLMEAS_N_MAX_ARRAY_SIZE		CONFIG_LTE_NEIGHBOR_CELLS_MAX
+
+#define AT_NCELLMEAS_PARAMS_COUNT_MAX					\
+	(AT_NCELLMEAS_PRE_NCELLS_PARAMS_COUNT +				\
+	 AT_NCELLMEAS_N_PARAMS_COUNT * CONFIG_LTE_NEIGHBOR_CELLS_MAX)
+
 /* @brief Helper function to check if a response is what was expected.
  *
  * @param response Pointer to response prefix
@@ -153,3 +185,21 @@ int parse_cereg(const char *at_response,
  * @return Zero on success or (negative) error code otherwise.
  */
 int parse_xt3412(const char *at_response, uint64_t *time);
+
+/* @brief Get the number of neighboring cells reported in an NCELLMEAS response.
+ *
+ * @param at_response Pointer to buffer with AT response to parse.
+ *
+ * @return The number of neighbor cells found in the response.
+ */
+uint32_t neighborcell_count_get(const char *at_response);
+
+/* @brief Parses an NCELLMEAS notification and stores neighboring cell
+ *	  information in a struct.
+ *
+ * @param at_response Pointer to buffer with AT response.
+ * @param ncell Pointer to ncell structure.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int parse_ncellmeas(const char *at_response, struct lte_lc_cells_info *cells);


### PR DESCRIPTION
Adds support and test for neighbor cell measurements:

- APIs to start and stop measurements
- Events to indicate successful or failed measurements
- Test for neighbor cell measurement response parsing