### PR TITLE
net: openthread: increase `ot_radio_workq` stack size for nRF53

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -51,6 +51,7 @@ config OPENTHREAD_MBEDTLS_LIB_NAME
 
 config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	int "OpenThread radio transmit workqueue stack size"
+	default 700 if SOC_NRF5340_CPUAPP
 	default 640
 
 choice CC3XX_LOCK_VARIANT


### PR DESCRIPTION
Increase the OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE with nRF53.
It has been observed that spinel communication between
the requires higher stack size when used with the diag feature.

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>

KRKNWK-9804