### PR TITLE
Testing a new label to trigger integration tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 nRF Connect SDK: sdk-nrf
 ########################
 
+test change
+
 .. contents::
    :local:
    :depth: 2

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6a1d340b632ec62f5abfb2e0c3e54838bbfd086e
+      revision: 1031df6166a6e7f9a714607ffb78b5bfaf123b85
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1031df6166a6e7f9a714607ffb78b5bfaf123b85
+      revision: 6a1d340b632ec62f5abfb2e0c3e54838bbfd086e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: fb936182435a1ae90fafbb8840e70a45d6f99a4e
+      revision: 1031df6166a6e7f9a714607ffb78b5bfaf123b85
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Ignore this PR. I am using it to test the ci-libmodem-test label which will trigger an integration test run in jenkins to test a specified version of the libmodem.a binary from nrfxlib with some samples.