### PR TITLE
test-commit: update manifest revision to test ci-libmodem-test label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,6 +41,11 @@
   - "**/*partition_manager*/**/*"
   - "**/*partition_manager*"
 
+"CI-libmodem-test":
+  - "west.yml"
+  - "**/*partition_manager*/**/*"
+  - "**/*partition_manager*"
+
 "CI-tfm-test":
   - "modules/tfm/**/*"
   - "samples/tfm/**/*"

--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: fb936182435a1ae90fafbb8840e70a45d6f99a4e
+      revision: 1031df6166a6e7f9a714607ffb78b5bfaf123b85
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Ignore this PR. I am using it to test the ci-libmodem-test label which will trigger an integration test run in jenkins to test a specified version of the libmodem.a binary from nrfxlib with some samples.