### PR TITLE
manifest: nrf_modem: version 1.1.0

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -94,8 +94,14 @@ struct download_client_cfg {
 	/** Access point name identifying a packet data network.
 	 *  Pass a null-terminated string with the APN
 	 *  or NULL to use the default APN.
+	 *  @deprecated Specify a PDN ID instead.
 	 */
 	const char *apn;
+	/**
+	 * PDN ID to be used for the download.
+	 * Zero is the default PDN.
+	 */
+	uint8_t pdn_id;
 	/** Maximum fragment size to download. 0 indicates that Kconfigured
 	 *  values shall be used.
 	 */

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -320,9 +320,17 @@ static int z_to_nrf_flags(int z_flags)
 
 static int z_to_nrf_addrinfo_flags(int flags)
 {
-	/* Flags not implemented.*/
-	ARG_UNUSED(flags);
-	return 0;
+	int nrf_flags = 0;
+
+	if (flags & AI_NUMERICSERV) {
+		nrf_flags |= NRF_AI_NUMERICSERV;
+	}
+
+	if (flags & AI_PDNSERV) {
+		nrf_flags |= NRF_AI_PDNSERV;
+	}
+
+	return nrf_flags;
 }
 
 static int nrf_to_z_addrinfo_flags(int flags)

--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -307,6 +307,9 @@ void nrf_modem_os_errno_set(int err_code)
 	case NRF_ETIMEDOUT:
 		errno = ETIMEDOUT;
 		break;
+	case NRF_ECONNREFUSED:
+		errno = ECONNREFUSED;
+		break;
 	case NRF_ENOBUFS:
 		errno = ENOBUFS;
 		break;

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -141,6 +141,24 @@ static int socket_tls_hostname_set(int fd, const char * const hostname)
 	return 0;
 }
 
+static int socket_pdn_id_set(int fd, uint8_t pdn_id)
+{
+	int err;
+	char buf[8] = {0};
+
+	(void) snprintf(buf, sizeof(buf), "pdn%d", pdn_id);
+
+	LOG_INF("Binding to PDN ID: %s", log_strdup(buf));
+	err = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, &buf, strlen(buf));
+	if (err) {
+		LOG_ERR("Failed to bind socket to PDN ID %d, err %d",
+			pdn_id, errno);
+		return -ENETDOWN;
+	}
+
+	return 0;
+}
+
 static int socket_apn_set(int fd, const char *apn)
 {
 	int err;
@@ -166,22 +184,16 @@ static int socket_apn_set(int fd, const char *apn)
 	return 0;
 }
 
-static int host_lookup(const char *host, int family, const char *apn,
-		       struct sockaddr *sa)
+static int host_lookup(const char *host, int family, uint8_t pdn_id,
+		       const char *apn, struct sockaddr *sa)
 {
 	int err;
-	struct addrinfo *ai;
+	char pdnserv[4];
 	char hostname[HOSTNAME_SIZE];
+	struct addrinfo *ai;
 
 	struct addrinfo hints = {
 		.ai_family = family,
-		.ai_next = apn ?
-			&(struct addrinfo) {
-				.ai_family    = AF_LTE,
-				.ai_socktype  = SOCK_MGMT,
-				.ai_protocol  = NPROTO_PDN,
-				.ai_canonname = (char *)apn
-			} : NULL,
 	};
 
 	/* Extract the hostname, without protocol or port */
@@ -190,7 +202,23 @@ static int host_lookup(const char *host, int family, const char *apn,
 		return err;
 	}
 
-	err = getaddrinfo(hostname, NULL, &hints, &ai);
+	if (pdn_id) {
+		hints.ai_flags = AI_PDNSERV;
+		(void)snprintf(pdnserv, sizeof(pdnserv), "%d", pdn_id);
+
+		err = getaddrinfo(hostname, pdnserv, &hints, &ai);
+	} else {
+		if (apn) {
+			hints.ai_next = &(struct addrinfo) {
+				.ai_family    = AF_LTE,
+				.ai_socktype  = SOCK_MGMT,
+				.ai_protocol  = NPROTO_PDN,
+				.ai_canonname = (char *)apn
+			};
+		}
+		err = getaddrinfo(hostname, NULL, &hints, &ai);
+	}
+
 	if (err) {
 		LOG_WRN("Failed to resolve hostname %s on %s",
 			log_strdup(hostname), str_family(family));
@@ -283,6 +311,11 @@ static int client_connect(struct download_client *dl, const char *host,
 
 	if (dl->config.apn != NULL && strlen(dl->config.apn)) {
 		err = socket_apn_set(*fd, dl->config.apn);
+		if (err) {
+			goto cleanup;
+		}
+	} else if (dl->config.pdn_id) {
+		err = socket_pdn_id_set(*fd, dl->config.pdn_id);
 		if (err) {
 			goto cleanup;
 		}
@@ -621,10 +654,10 @@ int download_client_connect(struct download_client *client, const char *host,
 	err = 0;
 	/* Attempt IPv6 connection if configured, fallback to IPv4 */
 	if (IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_IPV6)) {
-		err = host_lookup(host, AF_INET6, config->apn, &sa);
+		err = host_lookup(host, AF_INET6, config->pdn_id, config->apn, &sa);
 	}
 	if (err || !IS_ENABLED(CONFIG_DOWNLOAD_CLIENT_IPV6)) {
-		err = host_lookup(host, AF_INET, config->apn, &sa);
+		err = host_lookup(host, AF_INET, config->pdn_id, config->apn, &sa);
 	}
 
 	if (err) {

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -160,7 +160,7 @@ static int socket_apn_set(int fd, const char *apn)
 	if (err) {
 		LOG_ERR("Failed to bind socket to network \"%s\", err %d",
 			log_strdup(apn), errno);
-		return -ENETUNREACH;
+		return -ENETDOWN;
 	}
 
 	return 0;

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7de47f00d4e40491abb483a9dc2d67a5d4a685d0
+      revision: f725ac7a6dfb9d329c1e9f97e88ecfcd1a020acd
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 11fb8c5e5ecdd25c1e15efbd94b07dea14b621db
+      revision: c9cf6f74c618581794cda73063f93e77123dadbc
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
This version deprecates the PDN socket, re-introduces the `nrf_gai_error.h` and related `nrf_getaddrinfo()` fixes, and adds a couple of secure socket options. See the changelog for a complete list of changes.