### PR TITLE
Bluetooth: Mesh: scheduler setup server pointer has been removed

### DIFF
--- a/include/bluetooth/mesh/scheduler_srv.h
+++ b/include/bluetooth/mesh/scheduler_srv.h
@@ -84,8 +84,6 @@ struct bt_mesh_scheduler_srv {
 	};
 	/** Composition data model pointer. */
 	struct bt_mesh_model *model;
-	/** Composition data setup model pointer. */
-	struct bt_mesh_model *setup_mod;
 	/** Publication state. */
 	struct bt_mesh_model_pub pub;
 	/* Publication buffer */

--- a/subsys/bluetooth/mesh/scheduler_srv.c
+++ b/subsys/bluetooth/mesh/scheduler_srv.c
@@ -693,7 +693,9 @@ static int scheduler_srv_init(struct bt_mesh_model *model)
 		 * the mesh stack, but it makes it a lot easier to extend
 		 * this model, as we won't have to support multiple extenders.
 		 */
-		bt_mesh_model_extend(model, srv->setup_mod);
+		bt_mesh_model_extend(model, bt_mesh_model_find(
+				bt_mesh_model_elem(model),
+				BT_MESH_MODEL_ID_SCHEDULER_SETUP_SRV));
 	}
 
 	srv->idx = BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT;


### PR DESCRIPTION
The scheduler setup server pointer within scheduler server structure
has not been initialized. Actually, scheduler server structure
is not required in it. The scheduler setup server is possible
to find via Access layer element related API.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>