### PR TITLE
multithreading_lock: Change lock to mutex

### DIFF
--- a/lib/multithreading_lock/multithreading_lock.c
+++ b/lib/multithreading_lock/multithreading_lock.c
@@ -6,14 +6,14 @@
 
 #include "multithreading_lock.h"
 
-static K_SEM_DEFINE(mpsl_lock, 1, 1);
+static K_MUTEX_DEFINE(mpsl_lock);
 
 int multithreading_lock_acquire(k_timeout_t timeout)
 {
-	return k_sem_take(&mpsl_lock, timeout);
+	return k_mutex_lock(&mpsl_lock, timeout);
 }
 
 void multithreading_lock_release(void)
 {
-	k_sem_give(&mpsl_lock);
+	k_mutex_unlock(&mpsl_lock);
 }

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -17,6 +17,10 @@
 
 #include "hci_internal.h"
 
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
+#define LOG_MODULE_NAME sdc_hci_internal
+#include "common/log.h"
+
 #define CMD_COMPLETE_MIN_SIZE (BT_HCI_EVT_HDR_SIZE \
 				+ sizeof(struct bt_hci_evt_cmd_complete) \
 				+ sizeof(struct bt_hci_evt_cc_status))


### PR DESCRIPTION
Change the multithreading lock to a mutex.
This allows the thread to acquire the lock multiple times.
A mutex handles priority inversion as opposed to a semaphore.

Add logging macros to HCI internal so that Bluetooth logging can
be used in this file.