### PR TITLE
west.yml: pull in fix for nrf52805

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5585355dde0c59eac3f344b38c76803182f8a223
+      revision: pull/505/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a backport of the upstream fix in:

https://github.com/zephyrproject-rtos/zephyr/pull/34433/

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>