### PR TITLE
net: lib: azure_fota: Fix version string comparison

### DIFF
--- a/subsys/net/lib/azure_fota/azure_fota.c
+++ b/subsys/net/lib/azure_fota/azure_fota.c
@@ -209,7 +209,8 @@ static char *get_current_version(void)
 static bool is_update(void)
 {
 	return strncmp(get_current_version(), fota_object.version,
-		       strlen(get_current_version())) != 0;
+		       MAX(strlen(get_current_version()),
+			   strlen(fota_object.version))) != 0;
 }
 
 static bool is_new_job(void)


### PR DESCRIPTION
Fixes string comparison of current firmware version and incoming
FOTA job firmware version.
Previously, the comparison could give the wrong result if the
current version was shorter than the incoming version.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>