### PR TITLE
cmake: fix bug when creating s1 variant

### DIFF
--- a/cmake/s1.cmake
+++ b/cmake/s1.cmake
@@ -69,7 +69,7 @@ if (CONFIG_BUILD_S1_VARIANT AND
       DEPENDS ${${link_variant}prebuilt}
       )
 
-    set(${link_variant}generated_kernel_files ${link_variant}isr_tables.c)
+    list(APPEND ${link_variant}generated_kernel_files ${link_variant}isr_tables.c)
   endif()
 
   add_custom_command(
@@ -82,7 +82,7 @@ if (CONFIG_BUILD_S1_VARIANT AND
     --zephyr-base ${ZEPHYR_BASE}
     DEPENDS $<TARGET_FILE:${${link_variant}prebuilt}>
     )
-  set(${link_variant}generated_kernel_files ${link_variant}dev_handles.c)
+  list(APPEND ${link_variant}generated_kernel_files ${link_variant}dev_handles.c)
 
   configure_linker_script(
     ${link_variant}linker.cmd


### PR DESCRIPTION
The problem was that we were using a variable for
generated kernel files instead of a list.

After the dev_handles.c was added to the
generated kernel files this replaced the
isr_tables entry.

Update to use a list explicitly to avoid this
issue.

Ref: NCSDK-9243
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>