### PR TITLE
lib: lte_link_control: Add support for %XMODEMSLEEP AT notifications

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -76,6 +76,7 @@ nRF9160
 
     * Added support for %XT3412 AT command notifications, which allows the application to get prewarnings before Tracking Area Updates.
     * Added support for neighbor cell measurements.
+    * Added support for %XMODEMSLEEP AT command notifications which allows the application to get notifications related to modem sleep.
 
   * :ref:`serial_lte_modem` application:
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -166,6 +166,21 @@ enum lte_lc_evt_type {
 
 	/** Event containing results from neighbor cell measurements. */
 	LTE_LC_EVT_NEIGHBOR_CELL_MEAS,
+
+	/** Modem sleep pre-warning
+	 *  This event will be received a configurable amount of time before the modem exits sleep.
+	 *  The time parameter associated with this event signifies the time until modem exits
+	 *  sleep.
+	 */
+	LTE_LC_EVT_MODEM_SLEEP_EXIT_PRE_WARNING,
+
+	/** This event will be received when the modem exits sleep. */
+	LTE_LC_EVT_MODEM_SLEEP_EXIT,
+
+	/** This event will be received when the modem enters sleep.
+	 *  The time parameter associated with this event signifies the duration of the sleep.
+	 */
+	LTE_LC_EVT_MODEM_SLEEP_ENTER,
 };
 
 enum lte_lc_rrc_mode {
@@ -291,6 +306,19 @@ struct lte_lc_cells_info {
 	struct lte_lc_ncell *neighbor_cells;
 };
 
+enum lte_lc_modem_sleep_type {
+	LTE_LC_MODEM_SLEEP_PSM			= 1,
+	LTE_LC_MODEM_SLEEP_RF_INACTIVITY	= 2,	/* For example eDRX */
+	LTE_LC_MODEM_SLEEP_FLIGHT_MODE		= 4,
+};
+
+struct lte_lc_modem_sleep {
+	enum lte_lc_modem_sleep_type type;
+
+	/* If this value is set to -1. Sleep is considered infinite. */
+	int64_t time;
+};
+
 struct lte_lc_evt {
 	enum lte_lc_evt_type type;
 	union {
@@ -300,6 +328,7 @@ struct lte_lc_evt {
 		struct lte_lc_edrx_cfg edrx_cfg;
 		struct lte_lc_cell cell;
 		enum lte_lc_lte_mode lte_mode;
+		struct lte_lc_modem_sleep modem_sleep;
 
 		/* Time until next Tracking Area Update in milliseconds. */
 		uint64_t time;

--- a/lib/at_cmd/Kconfig
+++ b/lib/at_cmd/Kconfig
@@ -32,6 +32,7 @@ config AT_CMD_THREAD_PRIO
 
 config AT_CMD_THREAD_STACK_SIZE
 	int "AT thread stack size"
+	default 1472 if LTE_LINK_CONTROL
 	default 1344
 
 config AT_CMD_QUEUE_LEN

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -283,6 +283,28 @@ config LTE_NEIGHBOR_CELLS_MAX
 		cells, so there's a trade-off between heap requirements and
 		the risk of not being able to parse all neighbor cell information.
 
+config LTE_LC_MODEM_SLEEP_NOTIFICATIONS
+	bool "Modem sleep notifications"
+	help
+		If this option is enabled the application will get notifications when the modem
+		enters and exits sleep. The application will also get pre-warning notifications
+		prior to when the modem exits sleep depending on the configured pre-warning time.
+
+config LTE_LC_MODEM_SLEEP_PRE_WARNING_TIME_MS
+	int "Modem sleep pre-warning time"
+	range 500 3600000
+	default 5000
+	help
+		Time before modem exits sleep that a pre-warning is to be received.
+
+config LTE_LC_MODEM_SLEEP_NOTIFICATIONS_THRESHOLD_MS
+	int "Modem sleep notifications threshold"
+	range 10240 3456000000
+	default 1200000
+	help
+		Minimum value of the duration of the scheduled modem sleep that triggers a
+		notification.
+
 module = LTE_LINK_CONTROL
 module-dep = LOG
 module-str = LTE link control library

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -108,6 +108,12 @@
 	(AT_NCELLMEAS_PRE_NCELLS_PARAMS_COUNT +				\
 	 AT_NCELLMEAS_N_PARAMS_COUNT * CONFIG_LTE_NEIGHBOR_CELLS_MAX)
 
+/* XMODEMSLEEP command parameters. */
+#define AT_XMODEMSLEEP_SUB			"AT%%XMODEMSLEEP=1,%d,%d"
+#define AT_XMODEMSLEEP_PARAMS_COUNT_MAX		4
+#define AT_XMODEMSLEEP_TYPE_INDEX		1
+#define AT_XMODEMSLEEP_TIME_INDEX		2
+
 /* @brief Helper function to check if a response is what was expected.
  *
  * @param response Pointer to response prefix
@@ -203,3 +209,14 @@ uint32_t neighborcell_count_get(const char *at_response);
  * @return Zero on success or (negative) error code otherwise.
  */
 int parse_ncellmeas(const char *at_response, struct lte_lc_cells_info *cells);
+
+/* @brief Parses an XMODEMSLEEP response and extracts the sleep type and time.
+ *
+ * @note If the time parameter -1 after this API call, time shall be considered infinite.
+ *
+ * @param at_response Pointer to buffer with AT response.
+ * @param modem_sleep Pointer to a structure holding modem sleep data.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int parse_xmodemsleep(const char *at_response, struct lte_lc_modem_sleep *modem_sleep);

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -231,6 +231,48 @@ void test_parse_xt3412(void)
 	zassert_equal(-EINVAL, err, "parse_xt3412 failed, error: %d", err);
 }
 
+void test_parse_xmodemsleep(void)
+{
+	int err;
+	struct lte_lc_modem_sleep modem_sleep;
+	char *at_response_0 = "%XMODEMSLEEP: 1,36000";
+	char *at_response_1 = "%XMODEMSLEEP: 1,35712000000";
+	char *at_response_2 = "%XMODEMSLEEP: 2,100400";
+	char *at_response_3 = "%XMODEMSLEEP: 4";
+	char *at_response_4 = "%XMODEMSLEEP: 4,0";
+
+	err = parse_xmodemsleep(at_response_0, &modem_sleep);
+	zassert_equal(0, err, "parse_xmodemsleep failed, error: %d", err);
+	zassert_equal(modem_sleep.type, 1, "Wrong modem sleep type parameter");
+	zassert_equal(modem_sleep.time, 36000, "Wrong modem sleep time parameter");
+
+	err = parse_xmodemsleep(at_response_1, &modem_sleep);
+	zassert_equal(0, err, "parse_xmodemsleep failed, error: %d", err);
+	zassert_equal(modem_sleep.type, 1, "Wrong modem sleep type parameter");
+	zassert_equal(modem_sleep.time, 35712000000, "Wrong modem sleep time parameter");
+
+	err = parse_xmodemsleep(at_response_2, &modem_sleep);
+	zassert_equal(0, err, "parse_xmodemsleep failed, error: %d", err);
+	zassert_equal(modem_sleep.type, 2, "Wrong modem sleep type parameter");
+	zassert_equal(modem_sleep.time, 100400, "Wrong modem sleep time parameter");
+
+	err = parse_xmodemsleep(at_response_3, &modem_sleep);
+	zassert_equal(0, err, "parse_xmodemsleep failed, error: %d", err);
+	zassert_equal(modem_sleep.type, 4, "Wrong modem sleep type parameter");
+	zassert_equal(modem_sleep.time, -1, "Wrong modem sleep time parameter");
+
+	err = parse_xmodemsleep(at_response_4, &modem_sleep);
+	zassert_equal(0, err, "parse_xmodemsleep failed, error: %d", err);
+	zassert_equal(modem_sleep.type, 4, "Wrong modem sleep type parameter");
+	zassert_equal(modem_sleep.time, 0, "Wrong modem sleep time parameter");
+
+	err = parse_xmodemsleep(NULL, &modem_sleep);
+	zassert_equal(-EINVAL, err, "parse_xmodemsleep failed, error: %d", err);
+
+	err = parse_xmodemsleep(at_response_0, NULL);
+	zassert_equal(-EINVAL, err, "parse_xmodemsleep failed, error: %d", err);
+}
+
 static void test_parse_rrc_mode(void)
 {
 	int err;
@@ -327,6 +369,7 @@ void test_main(void)
 		ztest_unit_test(test_parse_edrx),
 		ztest_unit_test(test_parse_cereg),
 		ztest_unit_test(test_parse_xt3412),
+		ztest_unit_test(test_parse_xmodemsleep),
 		ztest_unit_test(test_parse_rrc_mode),
 		ztest_unit_test(test_response_is_valid),
 		ztest_unit_test(test_parse_ncellmeas),


### PR DESCRIPTION
Add support for %XMODEMSLEEP AT notifications which allows the
application to get updates related to modem sleep.

Closes CIA-101