### PR TITLE
applications: nrf_desktop: Fix HID boot reports (USB)

### DIFF
--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -261,8 +261,8 @@ static void send_hid_report(const struct hid_report_event *event)
 		usb_hid->sent_report_id = event->dyndata.data[0];
 	}
 
-	int err = hid_int_ep_write(usb_hid->dev, event->dyndata.data,
-				   event->dyndata.size, NULL);
+	int err = hid_int_ep_write(usb_hid->dev, report_buffer,
+				   report_size, NULL);
 
 	if (err) {
 		LOG_ERR("Cannot send report (%d)", err);


### PR DESCRIPTION
Change fixes sending HID boot reports over USB. The report ID should not be sent in that case.

Jira: NCSDK-9257