### PR TITLE
CODEOWNERS: Remove myself from tests owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -136,8 +136,7 @@ Kconfig*                                  @tejlmand
 /modules/                                 @tejlmand
 /modules/tfm/                             @oyvindronningstad @ioannisg @hakonfam
 /subsys/zigbee/                           @maciekfabia @mariuszpos
-/tests/                                   @rakons
 /tests/bluetooth/tester/                  @joerchan @carlescufi @trond-snekvik
-/tests/subsys/zigbee/                     @rakons @maciekfabia @mariuszpos
+/tests/subsys/zigbee/                     @maciekfabia @mariuszpos
 /tests/subsys/bluetooth/mesh/             @joerchan @trond-snekvik
 /zephyr/                                  @carlescufi


### PR DESCRIPTION
Removing myself from tests owner.
I have appeared here because I was the first to create any test.
Being the generic test owner does not make many sense from my perspective.
Already discussed with @carlescufi 