### PR TITLE
manifest: homekit: added coredump

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
       path: modules/lib/cddl-gen
     - name: homekit
       repo-path: sdk-homekit
-      revision: 40ae4b9225f051a3e02b8d73ce80389b462fee01
+      revision: 978a278bda30ea69402a8c1b464505cd9ec0dcde
       groups:
       - homekit
     - name: find-my


### PR DESCRIPTION
[KRKNWK-9898]
in case of error generate coredump for post mortem debugging

Signed-off-by: Robert Gałat <robert.galat@nordicsemi.no>

Depends on:
- [x] https://github.com/nrfconnect/sdk-homekit/pull/124