### PR TITLE
manifest: mcuboot: Manifest update for multi image fix in MCUBoot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -96,7 +96,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: bbca448b64fc7e0e10122dab6909649068c22a0e
+      revision: c1688c6127646b26f2fcb4839ccc3f1099d84f4a
       path: bootloader/mcuboot
     - name: nrfxlib
       repo-path: sdk-nrfxlib


### PR DESCRIPTION
Manifest which points to the PR with the fix for multi-image variant
build for MCUBoot.

Ref. NCSDK-8681

PR Link: https://github.com/nrfconnect/sdk-mcuboot/pull/146

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>