### PR TITLE
applications: serial_lte_modem: Parse UINT16 & UINT32 params

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -208,7 +208,7 @@ static int do_ftp_open(void)
 	int sz_password = FTP_MAX_PASSWORD;
 	char hostname[FTP_MAX_HOSTNAME];
 	int sz_hostname = FTP_MAX_HOSTNAME;
-	int32_t port = CONFIG_SLM_FTP_SERVER_PORT;
+	uint16_t port = CONFIG_SLM_FTP_SERVER_PORT;
 	sec_tag_t sec_tag = INVALID_SEC_TAG;
 	int param_count = at_params_valid_count_get(&at_param_list);
 
@@ -228,17 +228,13 @@ static int do_ftp_open(void)
 		return ret;
 	}
 	if (param_count > 5) {
-		ret = at_params_int_get(&at_param_list, 5, &port);
+		ret = at_params_unsigned_short_get(&at_param_list, 5, &port);
 		if (ret) {
 			return ret;
 		}
 	}
-	if (!check_port_range(port)) {
-		LOG_ERR("Invalid port");
-		return -EINVAL;
-	}
 	if (param_count > 6) {
-		ret = at_params_int_get(&at_param_list, 6, &sec_tag);
+		ret = at_params_unsigned_int_get(&at_param_list, 6, &sec_tag);
 		if (ret) {
 			return ret;
 		}
@@ -509,7 +505,7 @@ static int do_ftp_put(void)
 		return ret;
 	}
 
-	ret = at_params_short_get(&at_param_list, 3, &datatype);
+	ret = at_params_unsigned_short_get(&at_param_list, 3, &datatype);
 	if (ret) {
 		return ret;
 	}
@@ -583,7 +579,7 @@ static int do_ftp_uput(void)
 	uint16_t datatype;
 	int param_count = at_params_valid_count_get(&at_param_list);
 
-	ret = at_params_short_get(&at_param_list, 2, &datatype);
+	ret = at_params_unsigned_short_get(&at_param_list, 2, &datatype);
 	if (ret) {
 		return ret;
 	}
@@ -657,7 +653,7 @@ static int do_ftp_mput(void)
 		return ret;
 	}
 
-	ret = at_params_short_get(&at_param_list, 3, &datatype);
+	ret = at_params_unsigned_short_get(&at_param_list, 3, &datatype);
 	if (ret) {
 		return ret;
 	}

--- a/applications/serial_lte_modem/src/gps/slm_at_gps.c
+++ b/applications/serial_lte_modem/src/gps/slm_at_gps.c
@@ -413,13 +413,13 @@ int handle_at_gps(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
 		if (err < 0) {
 			return err;
 		}
 		if (op == 1) {
 			if (at_params_valid_count_get(&at_param_list) > 2) {
-				err = at_params_short_get(&at_param_list, 2,
+				err = at_params_unsigned_short_get(&at_param_list, 2,
 							&client.mask);
 				if (err < 0) {
 					return err;

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -540,14 +540,14 @@ int handle_at_httpc_connect(enum at_cmd_type cmd_type)
 		if (at_params_valid_count_get(&at_param_list) == 0) {
 			return -EINVAL;
 		}
-		err = at_params_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
 		if (err < 0) {
 			LOG_ERR("Fail to get op: %d", err);
 			return err;
 		}
 
 		if (op == AT_HTTPCCON_CONNECT) {
-			int32_t port;
+			uint16_t port;
 
 			if (at_params_valid_count_get(&at_param_list) <= 3) {
 				return -EINVAL;
@@ -561,18 +561,14 @@ int handle_at_httpc_connect(enum at_cmd_type cmd_type)
 				return err;
 			}
 
-			err = at_params_int_get(&at_param_list, 3, &port);
+			err = at_params_unsigned_short_get(&at_param_list, 3, &port);
 			if (err < 0) {
 				LOG_ERR("Fail to get port: %d", err);
 				return err;
 			}
-			if (!check_port_range(port)) {
-				LOG_ERR("Invalid port");
-				return -EINVAL;
-			}
 			httpc.port = (uint16_t)port;
 			if (at_params_valid_count_get(&at_param_list) == 5) {
-				err = at_params_int_get(&at_param_list, 4,
+				err = at_params_unsigned_int_get(&at_param_list, 4,
 							&httpc.sec_tag);
 				if (err < 0) {
 					LOG_ERR("Fail to get sec_tag: %d", err);
@@ -689,7 +685,7 @@ int handle_at_httpc_request(enum at_cmd_type cmd_type)
 		}
 		httpc.headers = (char *)(data_buf + offset);
 		if (param_count >= 5) {
-			err = at_params_int_get(&at_param_list, 4, &httpc.pl_len);
+			err = at_params_unsigned_int_get(&at_param_list, 4, &httpc.pl_len);
 			if (err != 0) {
 				return err;
 			}

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -591,12 +591,12 @@ int handle_at_mqtt_connect(enum at_cmd_type cmd_type)
 		if (at_params_valid_count_get(&at_param_list) <= 1) {
 			return -EINVAL;
 		}
-		err = at_params_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
 		if (err < 0) {
 			return err;
 		}
 		if (op == AT_MQTTCON_CONNECT) {
-			int32_t port;
+			uint16_t port;
 
 			if (at_params_valid_count_get(&at_param_list) <= 6) {
 				return -EINVAL;
@@ -632,17 +632,13 @@ int handle_at_mqtt_connect(enum at_cmd_type cmd_type)
 			if (err < 0) {
 				return err;
 			}
-			err = at_params_int_get(&at_param_list, 6, &port);
+			err = at_params_unsigned_short_get(&at_param_list, 6, &port);
 			if (err < 0) {
 				return err;
 			}
-			if (!check_port_range(port)) {
-				LOG_ERR("Invalid port");
-				return -EINVAL;
-			}
 			ctx.port = (uint16_t)port;
 			if (at_params_valid_count_get(&at_param_list) == 8) {
-				err = at_params_int_get(&at_param_list, 7,
+				err = at_params_unsigned_int_get(&at_param_list, 7,
 							&ctx.sec_tag);
 				if (err < 0) {
 					return err;
@@ -719,7 +715,7 @@ int handle_at_mqtt_publish(enum at_cmd_type cmd_type)
 		if (err < 0) {
 			return err;
 		}
-		err = at_params_short_get(&at_param_list, 2, &datatype);
+		err = at_params_unsigned_short_get(&at_param_list, 2, &datatype);
 		if (err < 0) {
 			return err;
 		}
@@ -727,11 +723,11 @@ int handle_at_mqtt_publish(enum at_cmd_type cmd_type)
 		if (err < 0) {
 			return err;
 		}
-		err = at_params_short_get(&at_param_list, 4, &qos);
+		err = at_params_unsigned_short_get(&at_param_list, 4, &qos);
 		if (err < 0) {
 			return err;
 		}
-		err = at_params_short_get(&at_param_list, 5, &retain);
+		err = at_params_unsigned_short_get(&at_param_list, 5, &retain);
 		if (err < 0) {
 			return err;
 		}
@@ -790,7 +786,7 @@ int handle_at_mqtt_subscribe(enum at_cmd_type cmd_type)
 			if (err < 0) {
 				return err;
 			}
-			err = at_params_short_get(&at_param_list, 2, &qos);
+			err = at_params_unsigned_short_get(&at_param_list, 2, &qos);
 			if (err < 0) {
 				return err;
 			}

--- a/applications/serial_lte_modem/src/slm_at_cmng.c
+++ b/applications/serial_lte_modem/src/slm_at_cmng.c
@@ -59,7 +59,7 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 			LOG_ERR("Parameter missed");
 			return -EINVAL;
 		}
-		err = at_params_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
 		if (err < 0) {
 			LOG_ERR("Fail to get op parameter: %d", err);
 			return err;
@@ -78,7 +78,7 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 			LOG_ERR("Parameter missed");
 			return -EINVAL;
 		}
-		err = at_params_int_get(&at_param_list, 2, &sec_tag);
+		err = at_params_unsigned_int_get(&at_param_list, 2, &sec_tag);
 		if (err < 0) {
 			LOG_ERR("Fail to get sec_tag parameter: %d", err);
 			return err;
@@ -87,7 +87,7 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 			LOG_ERR("Invalid security tag: %d", sec_tag);
 			return -EINVAL;
 		}
-		err = at_params_short_get(&at_param_list, 3, &type);
+		err = at_params_unsigned_short_get(&at_param_list, 3, &type);
 		if (err < 0) {
 			LOG_ERR("Fail to get type parameter: %d", err);
 			return err;

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -119,7 +119,7 @@ static int handle_at_sleep(enum at_cmd_type type)
 		uint16_t shutdown_mode = SHUTDOWN_MODE_IDLE;
 
 		if (at_params_valid_count_get(&at_param_list) > 1) {
-			ret = at_params_short_get(&at_param_list, 1, &shutdown_mode);
+			ret = at_params_unsigned_short_get(&at_param_list, 1, &shutdown_mode);
 			if (ret < 0) {
 				return -EINVAL;
 			}
@@ -197,7 +197,7 @@ static int handle_at_slmuart(enum at_cmd_type type)
 		uint32_t baudrate = 115200;
 
 		if (at_params_valid_count_get(&at_param_list) > 1) {
-			ret = at_params_int_get(&at_param_list, 1, &baudrate);
+			ret = at_params_unsigned_int_get(&at_param_list, 1, &baudrate);
 			if (ret) {
 				LOG_ERR("AT parameter error");
 				return -EINVAL;
@@ -256,11 +256,11 @@ static int handle_at_datactrl(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		ret = at_params_short_get(&at_param_list, 1, &size_limit);
+		ret = at_params_unsigned_short_get(&at_param_list, 1, &size_limit);
 		if (ret) {
 			return ret;
 		}
-		ret = at_params_short_get(&at_param_list, 2, &time_limit);
+		ret = at_params_unsigned_short_get(&at_param_list, 2, &time_limit);
 		if (ret) {
 			return ret;
 		}

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -91,7 +91,10 @@ static int do_fota_start(int op, const char *file_uri, int sec_tag,
 			const char *apn)
 {
 	int ret;
-	struct http_parser_url parser;
+	struct http_parser_url parser = {
+		/* UNINIT checker fix, assumed UF_SCHEMA existence */
+		.field_set = 0
+	};
 	char schema[8];
 
 	http_parser_url_init(&parser);
@@ -209,7 +212,7 @@ int handle_at_fota(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
 		if (err < 0) {
 			return err;
 		}
@@ -226,7 +229,7 @@ int handle_at_fota(enum at_cmd_type cmd_type)
 				return err;
 			}
 			if (at_params_valid_count_get(&at_param_list) > 3) {
-				at_params_int_get(&at_param_list, 3, &sec_tag);
+				at_params_unsigned_int_get(&at_param_list, 3, &sec_tag);
 			}
 			if (at_params_valid_count_get(&at_param_list) > 4) {
 				size = APN_MAX;

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -369,16 +369,16 @@ int handle_at_icmp_ping(enum at_cmd_type cmd_type)
 		if (err < 0) {
 			return err;
 		}
-		err = at_params_short_get(&at_param_list, 2, &length);
+		err = at_params_unsigned_short_get(&at_param_list, 2, &length);
 		if (err < 0) {
 			return err;
 		}
-		err = at_params_short_get(&at_param_list, 3, &timeout);
+		err = at_params_unsigned_short_get(&at_param_list, 3, &timeout);
 		if (err < 0) {
 			return err;
 		}
 		if (at_params_valid_count_get(&at_param_list) > 4) {
-			err = at_params_short_get(&at_param_list, 4, &count);
+			err = at_params_unsigned_short_get(&at_param_list, 4, &count);
 			if (err < 0) {
 				return err;
 			};
@@ -386,7 +386,7 @@ int handle_at_icmp_ping(enum at_cmd_type cmd_type)
 			count = 0;
 		}
 		if (at_params_valid_count_get(&at_param_list) > 5) {
-			err = at_params_short_get(&at_param_list, 5, &interval);
+			err = at_params_unsigned_short_get(&at_param_list, 5, &interval);
 			if (err < 0) {
 				return err;
 			};

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -418,23 +418,18 @@ int handle_at_udp_server(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
 	uint16_t op;
+	uint16_t port;
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
 		if (err) {
 			return err;
 		}
 		if (op == AT_SERVER_START || op == AT_SERVER_START_WITH_DATAMODE) {
-			int32_t port;
-
-			err = at_params_int_get(&at_param_list, 2, &port);
+			err = at_params_unsigned_short_get(&at_param_list, 2, &port);
 			if (err) {
 				return err;
-			}
-			if (!check_port_range(port)) {
-				LOG_ERR("Invalid port");
-				return -EINVAL;
 			}
 			if (udp_sock > 0) {
 				LOG_WRN("Server is running");
@@ -491,12 +486,12 @@ int handle_at_udp_client(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_short_get(&at_param_list, 1, &op);
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
 		if (err) {
 			return err;
 		}
 		if (op == AT_CLIENT_CONNECT || op == AT_CLIENT_CONNECT_WITH_DATAMODE) {
-			int32_t port;
+			uint16_t port;
 			char url[TCPIP_MAX_URL];
 			int size = TCPIP_MAX_URL;
 			sec_tag_t sec_tag = INVALID_SEC_TAG;
@@ -505,16 +500,12 @@ int handle_at_udp_client(enum at_cmd_type cmd_type)
 			if (err) {
 				return err;
 			}
-			err = at_params_int_get(&at_param_list, 3, &port);
+			err = at_params_unsigned_short_get(&at_param_list, 3, &port);
 			if (err) {
 				return err;
 			}
-			if (!check_port_range(port)) {
-				LOG_ERR("Invalid port");
-				return -EINVAL;
-			}
 			if (at_params_valid_count_get(&at_param_list) > 4) {
-				at_params_int_get(&at_param_list, 4, &sec_tag);
+				at_params_unsigned_int_get(&at_param_list, 4, &sec_tag);
 			}
 #if defined(CONFIG_SLM_DATAMODE_HWFC)
 			if (op == AT_CLIENT_CONNECT_WITH_DATAMODE && !check_uart_flowcontrol()) {
@@ -573,7 +564,7 @@ int handle_at_udp_send(enum at_cmd_type cmd_type)
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		err = at_params_short_get(&at_param_list, 1, &datatype);
+		err = at_params_unsigned_short_get(&at_param_list, 1, &datatype);
 		if (err) {
 			return err;
 		}

--- a/applications/serial_lte_modem/src/slm_util.c
+++ b/applications/serial_lte_modem/src/slm_util.c
@@ -164,17 +164,6 @@ bool check_for_ipv4(const char *address, uint8_t length)
 	return true;
 }
 
-/**@brief Check whether an integer value is in valid port range
- */
-bool check_port_range(int32_t port)
-{
-	if (port > 65535 || port < 0) {
-		return false;
-	}
-
-	return true;
-}
-
 /**brief use AT command to get IPv4 address
  */
 bool util_get_ipv4_addr(char *address)

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -103,14 +103,6 @@ int slm_util_atoh(const char *ascii, uint16_t ascii_len,
  */
 bool check_for_ipv4(const char *address, uint8_t length);
 
-/**@brief Check whether an integer value is in valid port range
- *
- * @param port value to be checked
- *
- * @return true if integer value is in valid port range, false otherwise
- */
-bool check_port_range(int32_t port);
-
 /**brief use AT command to get IPv4 address
  *
  * @param[in] address buffer to hold the IPv4 address


### PR DESCRIPTION
Call new API to parse UINT16/UINT32 params in AT command.

Also included fix for static code analysis issues:
.Uninitialized scalar variable (UNINIT)
.Unused value (UNUSED_VALUE)

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>