### PR TITLE
ci: oss-history: run on pull_request 

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,8 +1,13 @@
 name: Manifest
+
 on:
   pull_request_target:
     paths:
       - 'west.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   contribs:

--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -1,5 +1,5 @@
 name: OSS history check
-on: pull_request_target
+on: pull_request
 
 jobs:
   contribs:
@@ -10,7 +10,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ncs/nrf
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Install extra python dependencies


### PR DESCRIPTION
Run action on pull_request instead of pull_request_target. This way
token is read-only and secrets are not exposed when PRs are opened from
forks.