### PR TITLE
doc: release-notes-latest: summarize zephyr kernel changes

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -20,6 +20,7 @@
 .. _`Zephyr repository`: https://github.com/zephyrproject-rtos/zephyr
 .. _`Zephyr commit f12536`: https://github.com/zephyrproject-rtos/hal_nordic/commit/f12536cbfb27b7bb05b40b97bd8a8857f2bf23ec
 .. _`Zephyr commit 2db49c`: https://github.com/zephyrproject-rtos/zephyr/commit/2db49c4b99850b3e7a53667fe7bb9ba6fc2a5b7d
+.. _`kwork API changes`: https://github.com/zephyrproject-rtos/zephyr/pull/29618#issuecomment-738139695
 
 .. _`sdk-mcuboot`: https://github.com/nrfconnect/sdk-mcuboot
 .. _`MCUboot repository`: https://github.com/mcu-tools/mcuboot

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -188,6 +188,11 @@ The following list summarizes the most important changes inherited from upstream
     * Fixed handling of the OUT buffer in the Bluetooth class.
     * Fixed a possible deadlock in :c:func:`usb_transfer_sync`.
 
+* Kernel:
+
+  * Merged a new work queue implementation.
+    See `this comment <kwork API changes_>`_ for details on the API changes.
+
 * Networking:
 
   * General:


### PR DESCRIPTION
Update the changelog based on the Zephyr PR list from the recent
upmerge.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>