### PR TITLE
lib: pdn: PDN connection authentication fix

### DIFF
--- a/lib/pdn/Kconfig
+++ b/lib/pdn/Kconfig
@@ -48,6 +48,7 @@ config PDN_DEFAULT_APN
 
 choice
 	prompt "Family"
+	default PDN_DEFAULT_FAM_IPV4V6
 
 config PDN_DEFAULT_FAM_IPV4
 	bool "IPV4"
@@ -69,6 +70,7 @@ config PDN_DEFAULT_FAM
 
 choice
 	prompt "Authentication method"
+	default PDN_DEFAULT_AUTH_NONE
 
 config PDN_DEFAULT_AUTH_NONE
 	bool "None"
@@ -86,9 +88,11 @@ config PDN_DEFAULT_AUTH
 
 config PDN_DEFAULT_USERNAME
 	string "Username"
+	depends on !PDN_DEFAULT_AUTH_NONE
 
 config PDN_DEFAULT_PASSWORD
 	string "Password"
+	depends on !PDN_DEFAULT_AUTH_NONE
 
 endif # PDN_DEFAULTS_OVERRIDE
 endif # PDN_SYS_INIT

--- a/lib/pdn/pdn.c
+++ b/lib/pdn/pdn.c
@@ -281,7 +281,7 @@ int pdn_ctx_auth_set(uint8_t cid, enum pdn_auth method,
 	}
 
 	err = snprintf(at_buf, sizeof(at_buf),
-		       "AT+CGAUTH=%u,%s,%s", cid, user, password);
+		       "AT+CGAUTH=%u,%d,%s,%s", cid, method, user, password);
 
 	if (err < 0 || err >= sizeof(at_buf)) {
 		return -ENOBUFS;
@@ -452,6 +452,10 @@ static int pdn_sys_init(const struct device *unused)
 		return -1;
 	}
 
+#if defined(CONFIG_PDN_DEFAULT_AUTH_PAP) || defined(CONFIG_PDN_DEFAULT_AUTH_CHAP)
+	/* +CGAUTH=<cid>[,<auth_prot>[,<userid>[,<password>]]] */
+	BUILD_ASSERT(sizeof(CONFIG_PDN_DEFAULT_USERNAME) > 1, "Username not defined");
+
 	err = pdn_ctx_auth_set(0, CONFIG_PDN_DEFAULT_AUTH,
 			       CONFIG_PDN_DEFAULT_USERNAME,
 			       CONFIG_PDN_DEFAULT_PASSWORD);
@@ -460,6 +464,7 @@ static int pdn_sys_init(const struct device *unused)
 			err);
 		return -1;
 	}
+#endif /* CONFIG_PDN_DEFAULT_AUTH_PAP || CONFIG_PDN_DEFAULT_AUTH_CHAP */
 #endif /* CONFIG_PDN_DEFAULTS_OVERRIDE */
 
 	err = pdn_init();


### PR DESCRIPTION
Add the missing authentication protocol in AT command;
Set default CONFIG_PDN_DEFAULT_FAM_IPV4V6=y;
Set default CONFIG_PDN_DEFAULT_AUTH_NONE=y;
Make authentication optional in case of CONFIG_PDN_SYS_INIT=y;

Related to #4283 

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no> 