### PR TITLE
labeler.yml: Remove invalid "zigbee" words

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -88,7 +88,7 @@
 
 "CI-desktop-test":
   - "applications/nrf_desktop/**/*"
-  - "boards/arm/*dmouse*/**/*" zigbee
+  - "boards/arm/*dmouse*/**/*"
   - "boards/arm/*kbd*/**/*"
   - "boards/arm/*dongle*/**/*"
   - "boards/arm/*gmouse*/**/*"
@@ -111,7 +111,7 @@
 
 "CI-crypto-test":
   - "cmake/*"
-  - "drivers/entropy/*" zigbee
+  - "drivers/entropy/*"
   - "drivers/hw_cc310/*"
   - "drivers/net/*"
   - "samples/crypto/**/*"


### PR DESCRIPTION
The word "zigbee" was added at random places inside labeler.yml. Remove
them, they are not valid yaml.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>