### PR TITLE
labeler.yml: Exclude mesh from CI-ble-test and CI-homekit-test rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -61,8 +61,11 @@
 
 "CI-ble-test":
   - "subsys/bluetooth/**/*"
+  - "!subsys/bluetooth/mesh/**/*"
   - "include/bluetooth/**/*"
+  - "!include/bluetooth/mesh/**/*"
   - "samples/bluetooth/**/*"
+  - "!samples/bluetooth/mesh/**/*"
 
 "CI-mesh-test":
   - "subsys/bluetooth/mesh/**/*"
@@ -133,8 +136,11 @@
   - "modules/nrfxlib/nrf_802154/**/*"
   - "drivers/hw_cc310/*"
   - "subsys/bluetooth/**/*"
+  - "!subsys/bluetooth/mesh/**/*"
   - "include/bluetooth/**/*"
+  - "!include/bluetooth/mesh/**/*"
   - "samples/bluetooth/**/*"
+  - "!samples/bluetooth/mesh/**/*"
   - "subsys/bootloader/**/*"
   - "subsys/partition_manager/**/*"
   - "modules/mcuboot/**/*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -139,8 +139,6 @@
   - "!subsys/bluetooth/mesh/**/*"
   - "include/bluetooth/**/*"
   - "!include/bluetooth/mesh/**/*"
-  - "samples/bluetooth/**/*"
-  - "!samples/bluetooth/mesh/**/*"
   - "subsys/bootloader/**/*"
   - "subsys/partition_manager/**/*"
   - "modules/mcuboot/**/*"


### PR DESCRIPTION
The CI-ble-test and CI-homekit-test labels do not trigger any tests that
import Bluetooth Mesh modules. Exclude the mesh paths from these labels.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>