### PR TITLE
applications: asset_tracker_v2: add CONFIG_FPU=y to SUPL config

### DIFF
--- a/applications/asset_tracker_v2/prj.conf
+++ b/applications/asset_tracker_v2/prj.conf
@@ -98,6 +98,8 @@ CONFIG_WATCHDOG_APPLICATION=y
 # client library documentation in NCS.
 # CONFIG_AGPS=y
 # CONFIG_AGPS_SRC_SUPL=y
+# The SUPL library depends on FPU being enabled.
+# CONFIG_FPU=y
 
 # Event Manager
 CONFIG_EVENT_MANAGER=y


### PR DESCRIPTION
The SUPL library depends on FPU being enabled.

Signed-off-by: Markus Tacker <Markus.Tacker@NordicSemi.no>