### PR TITLE
manifest: Cherry-pick OpenThread stack overflow fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4d068de3f50f6a2de2be0c0b98670e33d28ff493
+      revision: pull/512/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Some stack overflows were fixed in upstream zephyr.
Porting related changes.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>