### PR TITLE
doc: add information about ncs-include to cheat sheet

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -113,6 +113,7 @@ breathe_separate_member_pages = True
 
 ncs_include_mapping = {
     "nrf": utils.get_rstdir("nrf"),
+    "nrfxlib": utils.get_rstdir("nrfxlib"),
     "zephyr": utils.get_rstdir("zephyr"),
 }
 

--- a/doc/nrf/templates/cheat_sheet.rst
+++ b/doc/nrf/templates/cheat_sheet.rst
@@ -202,6 +202,47 @@ Curabitur nisl |sapien|, posuere auctor metus et, convallis varius turpis. Sed e
 
 .. |sapien| replace:: some Latin word
 
+Reuse
+*****
+
+To reuse text from the same or another file in the same doc set:
+
+Include 1:
+  .. include:: cheat_sheet.rst
+     :start-line: 19
+     :end-line: 27
+
+Include 2:
+  .. include:: ../gs_installing.rst
+     :start-after: west-error-start
+     :end-before: west-error-end
+
+To reuse text from another doc set:
+
+Include 3:
+  .. ncs-include:: getting_started/installation_win.rst
+     :docset: zephyr
+     :auto-dedent:
+     :start-line: 10
+     :end-line: 18
+
+Include 4:
+  .. ncs-include:: ../nfc/doc/type_2_tag.rst
+     :docset: nrfxlib
+     :auto-dedent:
+     :start-after: Version 1.0*.
+     :end-before: If you use the supplied library,
+
+You can also use ncs-include if you want to use the indentation options inside the nrf doc set:
+
+Include 5 (similar to include 2, but improved indentation):
+  .. ncs-include:: ../gs_installing.rst
+     :start-after: west-error-start
+     :end-before: west-error-end
+     :auto-dedent:
+
+See https://github.com/nrfconnect/sdk-nrf/commit/fa5bd7330538f6a12e059c9d60fa2696e48fcf3a for implementation and usage.
+
 Including text inside a nested list
 ===================================
 
@@ -235,6 +276,7 @@ Another list which includes the steps from the previous list:
 
    d. substepB4
    #. substepB5
+
 
 Including code snippets in RST
 ******************************


### PR DESCRIPTION
We have an ncs-include directive that allows to reuse text from
another doc set. Add it to the cheat sheet so we can easily see
how to use it.

Ref. NCSDK-8091

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>