### PR TITLE
drivers: gps: nrf9160_gps: Fix functional mode check

### DIFF
--- a/drivers/gps/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/gps/nrf9160_gps/nrf9160_gps.c
@@ -512,7 +512,8 @@ static int enable_gps(const struct device *dev)
 		return err;
 	}
 
-	if (functional_mode != LTE_LC_FUNC_MODE_NORMAL) {
+	if ((functional_mode != LTE_LC_FUNC_MODE_NORMAL) &&
+	    (functional_mode != LTE_LC_FUNC_MODE_ACTIVATE_GNSS)) {
 		LOG_ERR("GPS is not supported in current functional mode");
 		return -EIO;
 	}


### PR DESCRIPTION
Add LTE_LC_FUNC_MODE_ACTIVATE_GNSS to functional mode check when
enabling the GNSS. This mode may be reported from the modem when
GNSS is enabled and LTE is disabled.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>