### PR TITLE
bluetooth: Convert to new k_work_delayable API

### DIFF
--- a/include/bluetooth/services/bas_client.h
+++ b/include/bluetooth/services/bas_client.h
@@ -71,13 +71,11 @@ typedef void (*bt_bas_read_cb)(struct bt_bas_client *bas,
 /* @brief Battery Service Client characteristic periodic read. */
 struct bt_bas_periodic_read {
 	/** Work queue used to measure the read interval. */
-	struct k_delayed_work read_work;
+	struct k_work_delayable read_work;
 	/** Read parameters. */
 	struct bt_gatt_read_params params;
 	/** Read value interval. */
 	atomic_t interval;
-	/** Active processing flag. */
-	atomic_t process;
 };
 
 /** @brief Battery Service Client instance. */

--- a/samples/bluetooth/central_nfc_pairing/src/nfc_poller.c
+++ b/samples/bluetooth/central_nfc_pairing/src/nfc_poller.c
@@ -69,7 +69,7 @@
 static uint8_t tx_data[NFC_TX_DATA_LEN];
 static uint8_t rx_data[NFC_RX_DATA_LEN];
 
-static struct k_delayed_work transmit_work;
+static struct k_work_delayable transmit_work;
 static ndef_recv_cb_t ndef_cb;
 
 NFC_T4T_CC_DESC_DEF(t4t_cc, MAX_TLV_BLOCKS);
@@ -639,7 +639,7 @@ static void t4t_hl_selected(enum nfc_t4t_hl_procedure_select type)
 	if (err) {
 		st25r3911b_nfca_tag_sleep();
 
-		k_delayed_work_submit(&transmit_work, K_MSEC(TRANSMIT_DELAY));
+		k_work_reschedule(&transmit_work, K_MSEC(TRANSMIT_DELAY));
 	}
 }
 
@@ -790,7 +790,7 @@ int nfc_poller_init(struct k_poll_event *events, ndef_recv_cb_t ndef_recv_cb)
 	ndef_cb = ndef_recv_cb;
 
 	nfc_t4t_hl_procedure_cb_register(&t4t_hl_procedure_cb);
-	k_delayed_work_init(&transmit_work, transfer_handler);
+	k_work_init_delayable(&transmit_work, transfer_handler);
 	nfc_tnep_poller_cb_register(&tnep_cb);
 
 	err = nfc_tnep_poller_init(&tnep_tx_buf);

--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define UART_RX_TIMEOUT 50
 
 static const struct device *uart;
-static struct k_delayed_work uart_work;
+static struct k_work_delayable uart_work;
 
 K_SEM_DEFINE(nus_write_sem, 0, 1);
 
@@ -181,8 +181,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 			buf->len = 0;
 		} else {
 			LOG_WRN("Not able to allocate UART receive buffer");
-			k_delayed_work_submit(&uart_work,
-					      UART_WAIT_FOR_BUF_DELAY);
+			k_work_reschedule(&uart_work, UART_WAIT_FOR_BUF_DELAY);
 			return;
 		}
 
@@ -241,7 +240,7 @@ static void uart_work_handler(struct k_work *item)
 		buf->len = 0;
 	} else {
 		LOG_WRN("Not able to allocate UART receive buffer");
-		k_delayed_work_submit(&uart_work, UART_WAIT_FOR_BUF_DELAY);
+		k_work_reschedule(&uart_work, UART_WAIT_FOR_BUF_DELAY);
 		return;
 	}
 
@@ -266,7 +265,7 @@ static int uart_init(void)
 		return -ENOMEM;
 	}
 
-	k_delayed_work_init(&uart_work, uart_work_handler);
+	k_work_init_delayable(&uart_work, uart_work_handler);
 
 	err = uart_callback_set(uart, uart_cb, NULL);
 	if (err) {

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -78,7 +78,7 @@ BT_HIDS_DEF(hids_obj,
 	    INPUT_REP_MOVEMENT_LEN,
 	    INPUT_REP_MEDIA_PLAYER_LEN);
 
-static struct k_delayed_work hids_work;
+static struct k_work hids_work;
 struct mouse_pos {
 	int16_t x_val;
 	int16_t y_val;
@@ -295,7 +295,6 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-	k_delayed_work_cancel(&hids_work);
 
 	printk("Disconnected from %s (reason %u)\n", addr, reason);
 
@@ -733,7 +732,7 @@ void button_changed(uint32_t button_state, uint32_t has_changed)
 			return;
 		}
 		if (k_msgq_num_used_get(&hids_queue) == 1) {
-			k_delayed_work_submit(&hids_work, K_NO_WAIT);
+			k_work_submit(&hids_work);
 		}
 	}
 }
@@ -787,7 +786,7 @@ void main(void)
 	/* DIS initialized at system boot with SYS_INIT macro. */
 	hid_init();
 
-	k_delayed_work_init(&hids_work, mouse_handler);
+	k_work_init(&hids_work, mouse_handler);
 	k_work_init(&pairing_work, pairing_process);
 	k_work_init(&adv_work, advertising_process);
 

--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -57,7 +57,7 @@ static struct bt_conn *current_conn;
 static struct bt_conn *auth_conn;
 
 static const struct device *uart;
-static struct k_delayed_work uart_work;
+static struct k_work_delayable uart_work;
 
 struct uart_data_t {
 	void *fifo_reserved;
@@ -140,8 +140,7 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 			buf->len = 0;
 		} else {
 			LOG_WRN("Not able to allocate UART receive buffer");
-			k_delayed_work_submit(&uart_work,
-					      UART_WAIT_FOR_BUF_DELAY);
+			k_work_reschedule(&uart_work, UART_WAIT_FOR_BUF_DELAY);
 			return;
 		}
 
@@ -200,7 +199,7 @@ static void uart_work_handler(struct k_work *item)
 		buf->len = 0;
 	} else {
 		LOG_WRN("Not able to allocate UART receive buffer");
-		k_delayed_work_submit(&uart_work, UART_WAIT_FOR_BUF_DELAY);
+		k_work_reschedule(&uart_work, UART_WAIT_FOR_BUF_DELAY);
 		return;
 	}
 
@@ -224,7 +223,7 @@ static int uart_init(void)
 		return -ENOMEM;
 	}
 
-	k_delayed_work_init(&uart_work, uart_work_handler);
+	k_work_init_delayable(&uart_work, uart_work_handler);
 
 	err = uart_callback_set(uart, uart_cb, NULL);
 	if (err) {

--- a/subsys/bluetooth/enocean.c
+++ b/subsys/bluetooth/enocean.c
@@ -47,7 +47,7 @@ enum entry_tag {
 
 static struct bt_enocean_device devices[CONFIG_BT_ENOCEAN_DEVICES_MAX];
 static const struct bt_enocean_callbacks *cb;
-static struct k_delayed_work work;
+static struct k_work_delayable work;
 static bool commissioning;
 
 static struct bt_enocean_device *device_find(const bt_addr_le_t *addr)
@@ -88,10 +88,8 @@ static void encode_tag(char buf[SETTINGS_TAG_SIZE], uint8_t index,
 static void schedule_store(void)
 {
 #if CONFIG_BT_ENOCEAN_STORE_SEQ
-	if (!k_delayed_work_remaining_get(&work)) {
-		k_delayed_work_submit(
-			&work, K_SECONDS(CONFIG_BT_ENOCEAN_STORE_TIMEOUT));
-	}
+	/* Only start timer if it's not already running */
+	k_work_schedule(&work, K_SECONDS(CONFIG_BT_ENOCEAN_STORE_TIMEOUT));
 #endif
 }
 
@@ -532,7 +530,7 @@ SETTINGS_STATIC_HANDLER_DEFINE(bt_enocean, "bt/enocean", NULL, settings_set,
 void bt_enocean_init(const struct bt_enocean_callbacks *callbacks)
 {
 	if (IS_ENABLED(CONFIG_BT_ENOCEAN_STORE_SEQ)) {
-		k_delayed_work_init(&work, store_dirty);
+		k_work_init_delayable(&work, store_dirty);
 	}
 
 	cb = callbacks;


### PR DESCRIPTION
Converts the entire Bluetooth subsystem, its tests and samples to the new k_work_delayable API. 

This also resolves a couple instances of questionable usage of the k_work API, which needs some additional scrutiny from the code owners. In particular, see:
- The peripheral_hids_mouse: Uses k_work instead of delayable
- bas_client: Restructures the approach for the periodic value read slightly to account for failing cancel calls
- gatt_dm: Moves k_work_init to the mock setup
See commit messages for each change for details.