### PR TITLE
Bluetooth: Mesh: splitting between active and define states for scheduled register

### DIFF
--- a/include/bluetooth/mesh/scheduler_srv.h
+++ b/include/bluetooth/mesh/scheduler_srv.h
@@ -72,10 +72,10 @@ struct bt_mesh_scheduler_srv {
 		sched_tai[BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT];
 		/* Index of the ongoing action. */
 		uint8_t idx;
-		/* Bit field indicating defined Actions
+		/* Bit field indicating active entries
 		 * in the Schedule Register.
 		 */
-		uint16_t status_bitmap;
+		uint16_t active_bitmap;
 		/* The Schedule Register state is a 16-entry,
 		 * zero-based, indexed array
 		 */


### PR DESCRIPTION
After clarification in Bluetooth model specification,
the defined scheduled register is an entry where the action is not equal
to 'Inactive'.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>