### PR TITLE
applications: asset_tracker: Convert ot new k_work API

### DIFF
--- a/applications/asset_tracker/src/env_sensors/bsec.c
+++ b/applications/asset_tracker/src/env_sensors/bsec.c
@@ -74,7 +74,7 @@ static struct k_thread thread;
 static uint8_t s_state_buffer[BSEC_MAX_STATE_BLOB_SIZE];
 static int32_t s_state_buffer_len;
 
-static struct k_delayed_work env_sensors_poller;
+static struct k_work_delayable env_sensors_poller;
 static env_sensors_data_ready_cb data_ready_cb;
 static uint32_t data_send_interval_s = CONFIG_ENVIRONMENT_DATA_SEND_INTERVAL;
 static bool backoff_enabled;
@@ -272,7 +272,7 @@ int env_sensors_get_air_quality(env_sensor_data_t *sensor_data)
 
 static inline int submit_poll_work(const uint32_t delay_s)
 {
-	return k_delayed_work_submit_to_queue(env_sensors_work_q,
+	return k_work_reschedule_for_queue(env_sensors_work_q,
 					      &env_sensors_poller,
 					      K_SECONDS((uint32_t)delay_s));
 }
@@ -345,7 +345,7 @@ int env_sensors_init_and_start(struct k_work_q *work_q,
 
 	env_sensors_work_q = work_q;
 
-	k_delayed_work_init(&env_sensors_poller, env_sensors_poll_fn);
+	k_work_init_delayable(&env_sensors_poller, env_sensors_poll_fn);
 
 	initialized = true;
 
@@ -368,8 +368,9 @@ void env_sensors_set_send_interval(const uint32_t interval_s)
 	if (data_send_interval_s) {
 		/* restart work for new interval to take effect */
 		env_sensors_poll();
-	} else if (k_delayed_work_remaining_get(&env_sensors_poller) > 0) {
-		k_delayed_work_cancel(&env_sensors_poller);
+	} else {
+		/* If cancel fails poller will return early when checking data_send_interval_s */
+		k_work_cancel_delayable(&env_sensors_poller);
 	}
 }
 

--- a/applications/asset_tracker/src/env_sensors/env_sensors.c
+++ b/applications/asset_tracker/src/env_sensors/env_sensors.c
@@ -61,7 +61,7 @@ static struct env_sensor *env_sensors[] = {
 	&pressure_sensor
 };
 
-static struct k_delayed_work env_sensors_poller;
+static struct k_work_delayable env_sensors_poller;
 static env_sensors_data_ready_cb data_ready_cb;
 static uint32_t data_send_interval_s = CONFIG_ENVIRONMENT_DATA_SEND_INTERVAL;
 static bool backoff_enabled;
@@ -69,7 +69,7 @@ static bool initialized;
 
 static inline int submit_poll_work(const uint32_t delay_s)
 {
-	return k_delayed_work_submit_to_queue(env_sensors_work_q,
+	return k_work_reschedule_for_queue(env_sensors_work_q,
 					      &env_sensors_poller,
 					      K_SECONDS((uint32_t)delay_s));
 }
@@ -148,7 +148,7 @@ int env_sensors_init_and_start(struct k_work_q *work_q,
 
 	data_ready_cb = cb;
 
-	k_delayed_work_init(&env_sensors_poller, env_sensors_poll_fn);
+	k_work_init_delayable(&env_sensors_poller, env_sensors_poll_fn);
 
 	initialized = true;
 
@@ -214,8 +214,9 @@ void env_sensors_set_send_interval(const uint32_t interval_s)
 	if (data_send_interval_s) {
 		/* restart work for new interval to take effect */
 		env_sensors_poll();
-	} else if (k_delayed_work_remaining_get(&env_sensors_poller) > 0) {
-		k_delayed_work_cancel(&env_sensors_poller);
+	} else {
+		/* If cancel fails poller will return early when checking data_send_interval_s */
+		k_work_cancel_delayable(&env_sensors_poller);
 	}
 }
 

--- a/applications/asset_tracker/src/gps_controller/gps_controller.c
+++ b/applications/asset_tracker/src/gps_controller/gps_controller.c
@@ -20,8 +20,8 @@ static const struct device *gps_dev;
 static atomic_t gps_is_enabled;
 static atomic_t gps_is_active;
 static struct k_work_q *app_work_q;
-static struct k_delayed_work start_work;
-static struct k_delayed_work stop_work;
+static struct k_work_delayable start_work;
+static struct k_work_delayable stop_work;
 static int gps_reporting_interval_seconds;
 
 static void start(struct k_work *work)
@@ -102,7 +102,8 @@ static void stop(struct k_work *work)
 		LOG_ERR("Failed to disable GPS, error: %d", err);
 		return;
 	}
-	k_delayed_work_cancel(&start_work);
+	/* start work runs on same queue. This should be safe */
+	k_work_cancel_delayable(&start_work);
 	atomic_set(&gps_is_enabled, 0);
 	gps_control_set_active(false);
 	LOG_INF("GPS operation was stopped");
@@ -125,13 +126,13 @@ bool gps_control_set_active(bool active)
 
 void gps_control_start(uint32_t delay_ms)
 {
-	k_delayed_work_submit_to_queue(app_work_q, &start_work,
+	k_work_reschedule_for_queue(app_work_q, &start_work,
 				       K_MSEC(delay_ms));
 }
 
 void gps_control_stop(uint32_t delay_ms)
 {
-	k_delayed_work_submit_to_queue(app_work_q, &stop_work,
+	k_work_reschedule_for_queue(app_work_q, &stop_work,
 				       K_MSEC(delay_ms));
 }
 
@@ -174,8 +175,8 @@ int gps_control_init(struct k_work_q *work_q, gps_event_handler_t handler)
 		return err;
 	}
 
-	k_delayed_work_init(&start_work, start);
-	k_delayed_work_init(&stop_work, stop);
+	k_work_init_delayable(&start_work, start);
+	k_work_init_delayable(&stop_work, stop);
 
 #if !defined(CONFIG_GPS_SIM)
 	gps_reporting_interval_seconds =

--- a/applications/asset_tracker/src/light_sensor/light_sensor.c
+++ b/applications/asset_tracker/src/light_sensor/light_sensor.c
@@ -43,7 +43,7 @@ static struct ls_ch_data *ls_data[LS_CH__END] = { [LS_CH_RED] = &ls_ch_red,
 						  [LS_CH_BLUE] = &ls_ch_blue,
 						  [LS_CH_IR] = &ls_ch_ir };
 static light_sensor_data_ready_cb ls_cb;
-static struct k_delayed_work ls_poller;
+static struct k_work_delayable ls_poller;
 static struct k_work_q *ls_work_q;
 static uint32_t data_send_interval_s = CONFIG_LIGHT_SENSOR_DATA_SEND_INTERVAL;
 static bool initialized;
@@ -52,7 +52,7 @@ static void light_sensor_poll_fn(struct k_work *work);
 
 static inline int submit_poll_work(const uint32_t delay_s)
 {
-	return k_delayed_work_submit_to_queue(ls_work_q, &ls_poller,
+	return k_work_reschedule_for_queue(ls_work_q, &ls_poller,
 					      K_SECONDS((uint32_t)delay_s));
 }
 
@@ -81,7 +81,7 @@ int light_sensor_init_and_start(struct k_work_q *work_q,
 	ls_work_q = work_q;
 	ls_cb = cb;
 
-	k_delayed_work_init(&ls_poller, light_sensor_poll_fn);
+	k_work_init_delayable(&ls_poller, light_sensor_poll_fn);
 
 	initialized = true;
 
@@ -161,8 +161,8 @@ void light_sensor_set_send_interval(const uint32_t interval_s)
 	if (data_send_interval_s) {
 		/* restart work for new interval to take effect */
 		submit_poll_work(0);
-	} else if (k_delayed_work_remaining_get(&ls_poller) > 0) {
-		k_delayed_work_cancel(&ls_poller);
+	} else  {
+		k_work_cancel_delayable(&ls_poller);
 	}
 }
 

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -150,13 +150,13 @@ static struct k_work sensors_start_work;
 static struct k_work send_gps_data_work;
 static struct k_work send_button_data_work;
 static struct k_work send_modem_at_cmd_work;
-static struct k_delayed_work long_press_button_work;
-static struct k_delayed_work cloud_reboot_work;
-static struct k_delayed_work cycle_cloud_connection_work;
-static struct k_delayed_work device_config_work;
-static struct k_delayed_work cloud_connect_work;
+static struct k_work_delayable long_press_button_work;
+static struct k_work_delayable cloud_reboot_work;
+static struct k_work_delayable cycle_cloud_connection_work;
+static struct k_work_delayable device_config_work;
+static struct k_work_delayable cloud_connect_work;
 static struct k_work device_status_work;
-static struct k_delayed_work send_agps_request_work;
+static struct k_work_delayable send_agps_request_work;
 #if defined(CONFIG_MOTION)
 static struct k_work motion_data_send_work;
 #endif
@@ -181,7 +181,7 @@ static K_SEM_DEFINE(cloud_ready_to_connect, 0, 1);
 #endif
 
 #if CONFIG_MODEM_INFO
-static struct k_delayed_work rsrp_work;
+static struct k_work_delayable rsrp_work;
 #endif /* CONFIG_MODEM_INFO */
 
 enum error_type {
@@ -485,7 +485,7 @@ void cloud_connect_error_handler(enum cloud_connect_result err)
 	if (reboot) {
 		LOG_ERR("Device will reboot in %d seconds",
 				CONFIG_CLOUD_CONNECT_ERR_REBOOT_S);
-		k_delayed_work_submit_to_queue(
+		k_work_reschedule_for_queue(
 			&application_work_q, &cloud_reboot_work,
 			K_SECONDS(CONFIG_CLOUD_CONNECT_ERR_REBOOT_S));
 	}
@@ -540,12 +540,12 @@ void connect_to_cloud(const int32_t connect_delay_s)
 	if (!initial_connect) {
 		LOG_INF("Attempting reconnect in %d seconds...",
 			connect_delay_s);
-		k_delayed_work_cancel(&cloud_reboot_work);
+		k_work_cancel_delayable(&cloud_reboot_work);
 	} else {
 		initial_connect = false;
 	}
 
-	k_delayed_work_submit_to_queue(&application_work_q,
+	k_work_reschedule_for_queue(&application_work_q,
 				       &cloud_connect_work,
 				       K_SECONDS(connect_delay_s));
 }
@@ -558,7 +558,7 @@ static void cloud_connect_work_fn(struct k_work *work)
 	       atomic_get(&cloud_connect_attempts),
 		   CONFIG_CLOUD_CONNECT_COUNT_MAX);
 
-	k_delayed_work_submit_to_queue(&application_work_q,
+	k_work_reschedule_for_queue(&application_work_q,
 			&cloud_reboot_work,
 			K_MSEC(CLOUD_CONNACK_WAIT_DURATION));
 
@@ -567,7 +567,7 @@ static void cloud_connect_work_fn(struct k_work *work)
 	/* Attempt cloud connection */
 	ret = cloud_connect(cloud_backend);
 	if (ret != CLOUD_CONNECT_RES_SUCCESS) {
-		k_delayed_work_cancel(&cloud_reboot_work);
+		k_work_cancel_delayable(&cloud_reboot_work);
 		/* Will not return from this function.
 		 * If the connect fails here, it is likely
 		 * that user intervention is required.
@@ -577,7 +577,7 @@ static void cloud_connect_work_fn(struct k_work *work)
 		LOG_INF("Cloud connection request sent.");
 		LOG_INF("Connection response timeout is set to %d seconds.",
 		       CLOUD_CONNACK_WAIT_DURATION / MSEC_PER_SEC);
-		k_delayed_work_submit_to_queue(&application_work_q,
+		k_work_reschedule_for_queue(&application_work_q,
 					&cloud_reboot_work,
 					K_MSEC(CLOUD_CONNACK_WAIT_DURATION));
 	}
@@ -734,7 +734,7 @@ static void gps_handler(const struct device *dev, struct gps_event *evt)
 		 * dependent corner-case where the request would not be sent.
 		 */
 		memcpy(&agps_request, &evt->agps_request, sizeof(agps_request));
-		k_delayed_work_submit_to_queue(&application_work_q,
+		k_work_reschedule_for_queue(&application_work_q,
 					       &send_agps_request_work,
 					       K_SECONDS(1));
 		break;
@@ -954,7 +954,7 @@ static void cloud_cmd_handler(struct cloud_command *cmd)
 					       &device_status_work);
 		} else if (cmd->channel == CLOUD_CHANNEL_LTE_LINK_RSRP) {
 #if CONFIG_MODEM_INFO
-			k_delayed_work_submit_to_queue(&application_work_q,
+			k_work_reschedule_for_queue(&application_work_q,
 						       &rsrp_work,
 						       K_NO_WAIT);
 #endif
@@ -984,14 +984,8 @@ static void modem_rsrp_handler(char rsrp_value)
 
 	rsrp.value = rsrp_value;
 
-	/* Only send the RSRP if transmission is not already scheduled.
-	 * Checking CONFIG_HOLD_TIME_RSRP gives the compiler a shortcut.
-	 */
-	if (CONFIG_HOLD_TIME_RSRP == 0 ||
-	    k_delayed_work_remaining_get(&rsrp_work) == 0) {
-		k_delayed_work_submit_to_queue(&application_work_q, &rsrp_work,
+	k_work_schedule_for_queue(&application_work_q, &rsrp_work,
 					       K_NO_WAIT);
-	}
 }
 
 /**@brief Publish RSRP data to the cloud. */
@@ -1028,7 +1022,7 @@ static void modem_rsrp_data_send(struct k_work *work)
 	rsrp_prev = rsrp_current;
 
 	if (CONFIG_HOLD_TIME_RSRP > 0) {
-		k_delayed_work_submit_to_queue(&application_work_q, &rsrp_work,
+		k_work_reschedule_for_queue(&application_work_q, &rsrp_work,
 					      K_SECONDS(CONFIG_HOLD_TIME_RSRP));
 	}
 }
@@ -1122,7 +1116,7 @@ static void device_config_send(struct k_work *work)
 
 	if (gps_control_is_active() && gps_cfg_state == CLOUD_CMD_STATE_FALSE) {
 		/* GPS hasn't been stopped yet, reschedule this work */
-		k_delayed_work_submit_to_queue(&application_work_q,
+		k_work_reschedule_for_queue(&application_work_q,
 			&device_config_work, K_SECONDS(5));
 		return;
 	}
@@ -1348,7 +1342,7 @@ static void on_user_pairing_req(const struct cloud_event *evt)
 		/* If the association is not done soon enough (< ~5 min?)
 		 * a connection cycle is needed... TBD why.
 		 */
-		k_delayed_work_submit_to_queue(&application_work_q,
+		k_work_reschedule_for_queue(&application_work_q,
 					       &cycle_cloud_connection_work,
 					       CONN_CYCLE_AFTER_ASSOCIATION_REQ_MS);
 	}
@@ -1367,7 +1361,7 @@ static void cycle_cloud_connection(struct k_work *work)
 	}
 
 	/* Reboot fail-safe on disconnect */
-	k_delayed_work_submit_to_queue(&application_work_q, &cloud_reboot_work,
+	k_work_reschedule_for_queue(&application_work_q, &cloud_reboot_work,
 				       K_MSEC(reboot_wait_ms));
 }
 
@@ -1376,7 +1370,7 @@ void on_pairing_done(void)
 {
 	if (atomic_get(&cloud_association) ==
 			CLOUD_ASSOCIATION_STATE_REQUESTED) {
-		k_delayed_work_cancel(&cycle_cloud_connection_work);
+		k_work_cancel_delayable(&cycle_cloud_connection_work);
 
 		/* After successful association, the device must
 		 * reconnect to the cloud.
@@ -1385,7 +1379,7 @@ void on_pairing_done(void)
 		LOG_INF("Reconnecting for cloud policy to take effect.");
 		atomic_set(&cloud_association,
 				   CLOUD_ASSOCIATION_STATE_RECONNECT);
-		k_delayed_work_submit_to_queue(&application_work_q,
+		k_work_reschedule_for_queue(&application_work_q,
 					       &cycle_cloud_connection_work,
 					       K_NO_WAIT);
 	} else {
@@ -1501,7 +1495,7 @@ void connection_evt_handler(const struct cloud_event *const evt)
 	if (evt->type == CLOUD_EVT_CONNECTING) {
 		LOG_INF("CLOUD_EVT_CONNECTING");
 		ui_led_set_pattern(UI_CLOUD_CONNECTING);
-		k_delayed_work_cancel(&cloud_reboot_work);
+		k_work_cancel_delayable(&cloud_reboot_work);
 
 		if (evt->data.err != CLOUD_CONNECT_RES_SUCCESS) {
 			cloud_connect_error_handler(evt->data.err);
@@ -1509,7 +1503,7 @@ void connection_evt_handler(const struct cloud_event *const evt)
 		return;
 	} else if (evt->type == CLOUD_EVT_CONNECTED) {
 		LOG_INF("CLOUD_EVT_CONNECTED");
-		k_delayed_work_cancel(&cloud_reboot_work);
+		k_work_cancel_delayable(&cloud_reboot_work);
 		k_sem_take(&cloud_disconnected, K_NO_WAIT);
 		atomic_set(&cloud_connect_attempts, 0);
 #if !IS_ENABLED(CONFIG_MQTT_CLEAN_SESSION)
@@ -1601,7 +1595,7 @@ static void set_gps_enable(const bool enable)
 	}
 
 	/* Update config state in cloud */
-	k_delayed_work_submit_to_queue(&application_work_q,
+	k_work_reschedule_for_queue(&application_work_q,
 			&device_config_work, K_MSEC(delay_ms));
 }
 
@@ -1624,20 +1618,20 @@ static void work_init(void)
 	k_work_init(&send_gps_data_work, send_gps_data_work_fn);
 	k_work_init(&send_button_data_work, send_button_data_work_fn);
 	k_work_init(&send_modem_at_cmd_work, send_modem_at_cmd_work_fn);
-	k_delayed_work_init(&send_agps_request_work, send_agps_request);
-	k_delayed_work_init(&long_press_button_work, long_press_handler);
-	k_delayed_work_init(&cloud_reboot_work, cloud_reboot_handler);
-	k_delayed_work_init(&cycle_cloud_connection_work,
+	k_work_init_delayable(&send_agps_request_work, send_agps_request);
+	k_work_init_delayable(&long_press_button_work, long_press_handler);
+	k_work_init_delayable(&cloud_reboot_work, cloud_reboot_handler);
+	k_work_init_delayable(&cycle_cloud_connection_work,
 			    cycle_cloud_connection);
-	k_delayed_work_init(&device_config_work, device_config_send);
-	k_delayed_work_init(&cloud_connect_work, cloud_connect_work_fn);
+	k_work_init_delayable(&device_config_work, device_config_send);
+	k_work_init_delayable(&cloud_connect_work, cloud_connect_work_fn);
 	k_work_init(&device_status_work, device_status_send);
 #if defined(CONFIG_MOTION)
 	k_work_init(&motion_data_send_work, motion_data_send);
 #endif
 	k_work_init(&no_sim_go_offline_work, no_sim_go_offline);
 #if CONFIG_MODEM_INFO
-	k_delayed_work_init(&rsrp_work, modem_rsrp_data_send);
+	k_work_init_delayable(&rsrp_work, modem_rsrp_data_send);
 #endif /* CONFIG_MODEM_INFO */
 }
 
@@ -1737,7 +1731,7 @@ static void sensors_init(void)
 #endif
 #if defined(CONFIG_ENVIRONMENT_SENSORS)
 	err = env_sensors_init_and_start(&application_work_q, env_data_send);
-	if (err) {
+	if (err < 0) {
 		LOG_ERR("Environmental sensors init failed, error: %d", err);
 #if CONFIG_USE_BME680_BSEC
 		if (err == -34) {
@@ -1751,7 +1745,7 @@ static void sensors_init(void)
 #if CONFIG_LIGHT_SENSOR
 	err = light_sensor_init_and_start(&application_work_q,
 					  light_sensor_data_send);
-	if (err) {
+	if (err < 0) {
 		LOG_ERR("Light sensor init failed, error: %d", err);
 	}
 #endif /* CONFIG_LIGHT_SENSOR */
@@ -1772,7 +1766,7 @@ static void sensors_init(void)
 	}
 #if defined(CONFIG_AGPS_SINGLE_CELL_ONLY)
 	/* Make initial cell-based location request */
-	k_delayed_work_submit_to_queue(&application_work_q,
+	k_work_reschedule_for_queue(&application_work_q,
 					&send_agps_request_work,
 					K_SECONDS(1));
 #endif
@@ -1797,11 +1791,11 @@ static void ui_evt_handler(struct ui_evt evt)
 	if (IS_ENABLED(CONFIG_GPS_CONTROL_ON_LONG_PRESS) &&
 	   (evt.button == UI_BUTTON_1)) {
 		if (evt.type == UI_EVT_BUTTON_ACTIVE) {
-			k_delayed_work_submit_to_queue(&application_work_q,
+			k_work_reschedule_for_queue(&application_work_q,
 						       &long_press_button_work,
 						       K_SECONDS(5));
 		} else {
-			k_delayed_work_cancel(&long_press_button_work);
+			k_work_cancel_delayable(&long_press_button_work);
 		}
 	}
 
@@ -1925,7 +1919,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 #if defined(CONFIG_AGPS_SINGLE_CELL_ONLY)
 		/* Request location based on new network info */
 		if (data_send_enabled() && evt->cell.id != -1) {
-			k_delayed_work_submit_to_queue(&application_work_q,
+			k_work_reschedule_for_queue(&application_work_q,
 						       &send_agps_request_work,
 						       K_SECONDS(1));
 		}
@@ -1960,9 +1954,9 @@ static void date_time_event_handler(const struct date_time_evt *evt)
 void main(void)
 {
 	LOG_INF("Asset tracker started");
-	k_work_q_start(&application_work_q, application_stack_area,
+	k_work_queue_start(&application_work_q, application_stack_area,
 		       K_THREAD_STACK_SIZEOF(application_stack_area),
-		       CONFIG_APPLICATION_WORKQUEUE_PRIORITY);
+		       CONFIG_APPLICATION_WORKQUEUE_PRIORITY, NULL);
 	if (IS_ENABLED(CONFIG_WATCHDOG)) {
 		watchdog_init_and_start(&application_work_q);
 	}

--- a/applications/asset_tracker/src/motion/motion.c
+++ b/applications/asset_tracker/src/motion/motion.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(motion, CONFIG_ASSET_TRACKER_LOG_LEVEL);
 motion_handler_t handler;
 static const struct device *accel_dev;
 static struct k_work_q *motion_work_q;
-static struct k_delayed_work motion_work;
+static struct k_work_delayable motion_work;
 
 #define FLIP_ACCELERATION_THRESHOLD	5.0
 
@@ -101,7 +101,7 @@ static void sensor_trigger_handler(const struct device *dev,
 	ARG_UNUSED(dev);
 	ARG_UNUSED(trigger);
 
-	k_delayed_work_submit_to_queue(motion_work_q, &motion_work, K_NO_WAIT);
+	k_work_reschedule_for_queue(motion_work_q, &motion_work, K_NO_WAIT);
 }
 
 /**@brief Workqueue handler that runs the callback provided by application.*/
@@ -164,7 +164,7 @@ int motion_init_and_start(struct k_work_q *work_q,
 	motion_work_q = work_q;
 	handler = motion_handler;
 
-	k_delayed_work_init(&motion_work, motion_work_q_handler);
+	k_work_init_delayable(&motion_work, motion_work_q_handler);
 	err = accelerometer_init();
 
 	if (err) {

--- a/applications/asset_tracker/src/ui/led_pwm.c
+++ b/applications/asset_tracker/src/ui/led_pwm.c
@@ -24,7 +24,8 @@ struct led {
 	uint16_t effect_step;
 	uint16_t effect_substep;
 
-	struct k_delayed_work work;
+	struct k_work_delayable work;
+	struct k_work_sync work_sync;
 };
 
 static const struct led_effect effect[] = {
@@ -136,13 +137,13 @@ static void work_handler(struct k_work *work)
 		int32_t next_delay =
 			leds.effect->steps[leds.effect_step].substep_time;
 
-		k_delayed_work_submit(&leds.work, K_MSEC(next_delay));
+		k_work_schedule(&leds.work, K_MSEC(next_delay));
 	}
 }
 
 static void led_update(struct led *led)
 {
-	k_delayed_work_cancel(&led->work);
+	k_work_cancel_delayable_sync(&led->work, &led->work_sync);
 
 	led->effect_step = 0;
 	led->effect_substep = 0;
@@ -158,7 +159,7 @@ static void led_update(struct led *led)
 		int32_t next_delay =
 			led->effect->steps[led->effect_step].substep_time;
 
-		k_delayed_work_submit(&led->work, K_MSEC(next_delay));
+		k_work_reschedule(&led->work, K_MSEC(next_delay));
 	} else {
 		LOG_DBG("LED effect with no effect");
 	}
@@ -178,7 +179,7 @@ int ui_leds_init(void)
 		return -ENODEV;
 	}
 
-	k_delayed_work_init(&leds.work, work_handler);
+	k_work_init_delayable(&leds.work, work_handler);
 	led_update(&leds);
 
 	return err;
@@ -199,7 +200,7 @@ void ui_leds_start(void)
 
 void ui_leds_stop(void)
 {
-	k_delayed_work_cancel(&leds.work);
+	k_work_cancel_delayable_sync(&leds.work, &leds.work_sync);
 #ifdef CONFIG_PM_DEVICE
 	int err = device_set_power_state(leds.pwm_dev,
 					 DEVICE_PM_SUSPEND_STATE,

--- a/applications/asset_tracker/src/ui/ui.c
+++ b/applications/asset_tracker/src/ui/ui.c
@@ -17,7 +17,7 @@ static enum ui_led_pattern current_led_state;
 static ui_callback_t callback;
 
 #if !defined(CONFIG_UI_LED_USE_PWM)
-static struct k_delayed_work leds_update_work;
+static struct k_work_delayable leds_update_work;
 
 /**@brief Update LEDs state. */
 static void leds_update(struct k_work *work)
@@ -44,10 +44,10 @@ static void leds_update(struct k_work *work)
 
 	if (work) {
 		if (led_on) {
-			k_delayed_work_submit(&leds_update_work,
+			k_work_reschedule(&leds_update_work,
 					      K_MSEC(UI_LED_ON_PERIOD_NORMAL));
 		} else {
-			k_delayed_work_submit(&leds_update_work,
+			k_work_reschedule(&leds_update_work,
 					      K_MSEC(UI_LED_OFF_PERIOD_NORMAL));
 		}
 	}
@@ -141,8 +141,8 @@ int ui_init(ui_callback_t cb)
 		return err;
 	}
 
-	k_delayed_work_init(&leds_update_work, leds_update);
-	k_delayed_work_submit(&leds_update_work, K_NO_WAIT);
+	k_work_init_delayable(&leds_update_work, leds_update);
+	k_work_reschedule(&leds_update_work, K_NO_WAIT);
 #endif /* CONFIG_UI_LED_USE_PWM */
 
 	if (cb) {

--- a/applications/asset_tracker/src/watchdog/watchdog.c
+++ b/applications/asset_tracker/src/watchdog/watchdog.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(watchdog, CONFIG_ASSET_TRACKER_LOG_LEVEL);
 struct wdt_data_storage {
 	const struct device *wdt_drv;
 	int wdt_channel_id;
-	struct k_delayed_work system_workqueue_work;
+	struct k_work_delayable system_workqueue_work;
 	struct k_work second_workqueue_work;
 };
 static struct wdt_data_storage wdt_data;
@@ -36,7 +36,7 @@ static void secondary_feed_worker(struct k_work *work_desc)
 	if (err) {
 		LOG_ERR("Cannot feed watchdog. Error code: %d", err);
 	} else {
-		k_delayed_work_submit(&wdt_data.system_workqueue_work,
+		k_work_reschedule(&wdt_data.system_workqueue_work,
 				      K_MSEC(WDT_FEED_WORKER_DELAY_MS));
 	}
 }
@@ -85,7 +85,7 @@ static int watchdog_feed_enable(struct wdt_data_storage *data)
 {
 	__ASSERT_NO_MSG(data != NULL);
 
-	k_delayed_work_init(&data->system_workqueue_work, primary_feed_worker);
+	k_work_init_delayable(&data->system_workqueue_work, primary_feed_worker);
 	k_work_init(&data->second_workqueue_work, secondary_feed_worker);
 
 	int err = wdt_feed(data->wdt_drv, data->wdt_channel_id);
@@ -95,15 +95,10 @@ static int watchdog_feed_enable(struct wdt_data_storage *data)
 		return err;
 	}
 
-	err = k_delayed_work_submit(&data->system_workqueue_work,
-				    K_MSEC(WDT_FEED_WORKER_DELAY_MS));
-	if (err) {
-		LOG_ERR("Cannot start watchdog feed worker!"
-				" Error code: %d", err);
-	} else {
-		LOG_INF("Watchdog feed enabled. Timeout: %d",
-			WDT_FEED_WORKER_DELAY_MS);
-	}
+	k_work_schedule(&data->system_workqueue_work,
+				K_MSEC(WDT_FEED_WORKER_DELAY_MS));
+	LOG_DBG("Watchdog feed enabled. Timeout: %d", WDT_FEED_WORKER_DELAY_MS);
+
 	return err;
 }
 

--- a/applications/asset_tracker_v2/src/led/led.c
+++ b/applications/asset_tracker_v2/src/led/led.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(led, CONFIG_LED_CONTROL_LOG_LEVEL);
 static enum led_pattern current_led_state;
 
 #if !defined(CONFIG_LED_USE_PWM)
-static struct k_delayed_work leds_update_work;
+static struct k_work_delayable leds_update_work;
 
 /**@brief Update LEDs state. */
 static void leds_update(struct k_work *work)
@@ -49,15 +49,15 @@ static void leds_update(struct k_work *work)
 
 	if (work) {
 		if (led_on) {
-			k_delayed_work_submit(&leds_update_work,
+			k_work_schedule(&leds_update_work,
 					      K_MSEC(LED_ON_PERIOD_NORMAL));
 		} else {
 			if (passive_mode) {
-				k_delayed_work_submit(
+				k_work_schedule(
 					&leds_update_work,
 					K_MSEC(LED_OFF_PERIOD_LONG));
 			} else {
-				k_delayed_work_submit(
+				k_work_schedule(
 					&leds_update_work,
 					K_MSEC(LED_OFF_PERIOD_NORMAL));
 			}
@@ -102,8 +102,8 @@ int led_init(void)
 		return err;
 	}
 
-	k_delayed_work_init(&leds_update_work, leds_update);
-	k_delayed_work_submit(&leds_update_work, K_NO_WAIT);
+	k_work_init_delayable(&leds_update_work, leds_update);
+	k_work_schedule(&leds_update_work, K_NO_WAIT);
 #endif /* CONFIG_LED_USE_PWM */
 
 	return 0;

--- a/applications/asset_tracker_v2/src/led/led_pwm.c
+++ b/applications/asset_tracker_v2/src/led/led_pwm.c
@@ -21,7 +21,8 @@ struct led {
 	uint16_t effect_step;
 	uint16_t effect_substep;
 
-	struct k_delayed_work work;
+	struct k_work_delayable work;
+	struct k_work_sync work_sync;
 };
 
 static const struct led_effect effect[] = {
@@ -114,13 +115,13 @@ static void work_handler(struct k_work *work)
 		int32_t next_delay =
 			leds.effect->steps[leds.effect_step].substep_time;
 
-		k_delayed_work_submit(&leds.work, K_MSEC(next_delay));
+		k_work_reschedule(&leds.work, K_MSEC(next_delay));
 	}
 }
 
 static void led_update(struct led *led)
 {
-	k_delayed_work_cancel(&led->work);
+	k_work_cancel_delayable_sync(&led->work, &led->work_sync);
 
 	led->effect_step = 0;
 	led->effect_substep = 0;
@@ -136,7 +137,7 @@ static void led_update(struct led *led)
 		int32_t next_delay =
 			led->effect->steps[led->effect_step].substep_time;
 
-		k_delayed_work_submit(&led->work, K_MSEC(next_delay));
+		k_work_schedule(&led->work, K_MSEC(next_delay));
 	} else {
 		printk("LED effect with no effect");
 	}
@@ -153,7 +154,7 @@ int led_pwm_init(void)
 		return -ENODEV;
 	}
 
-	k_delayed_work_init(&leds.work, work_handler);
+	k_work_init_delayable(&leds.work, work_handler);
 
 	return 0;
 }
@@ -172,7 +173,7 @@ void led_pwm_start(void)
 
 void led_pwm_stop(void)
 {
-	k_delayed_work_cancel(&leds.work);
+	k_work_cancel_delayable_sync(&leds.work, &leds.work_sync);
 #if defined(CONFIG_PM_DEVICE)
 	int err = device_set_power_state(leds.pwm_dev, DEVICE_PM_SUSPEND_STATE,
 					 NULL, NULL);

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -96,7 +96,7 @@ static struct cloud_data_cfg current_cfg = {
 	.accelerometer_threshold = DEFAULT_ACCELEROMETER_THRESHOLD
 };
 
-static struct k_delayed_work data_send_work;
+static struct k_work_delayable data_send_work;
 
 /* List used to keep track of responses from other modules with data that is
  * requested to be sampled/published.
@@ -662,7 +662,7 @@ static void data_send_work_fn(struct k_work *work)
 	SEND_EVENT(data, DATA_EVT_DATA_READY);
 
 	requested_data_clear();
-	k_delayed_work_cancel(&data_send_work);
+	k_work_cancel_delayable(&data_send_work);
 }
 
 static void requested_data_status_set(enum app_module_data_type data_type)
@@ -888,7 +888,7 @@ static void on_all_states(struct data_msg_data *msg)
 		/* Start countdown until data must have been received by the
 		 * Data module in order to be sent to cloud
 		 */
-		k_delayed_work_submit(&data_send_work,
+		k_work_reschedule(&data_send_work,
 				      K_SECONDS(msg->module.app.timeout));
 
 		return;
@@ -1074,7 +1074,7 @@ static void module_thread_fn(void)
 
 	state_set(STATE_CLOUD_DISCONNECTED);
 
-	k_delayed_work_init(&data_send_work, data_send_work_fn);
+	k_work_init_delayable(&data_send_work, data_send_work_fn);
 
 	err = setup();
 	if (err) {

--- a/applications/asset_tracker_v2/src/modules/ui_module.c
+++ b/applications/asset_tracker_v2/src/modules/ui_module.c
@@ -56,9 +56,9 @@ static void led_pat_gps_work_fn(struct k_work *work);
 /* Delayed works that is used to make sure the device always reverts back to the
  * device mode or GPS search LED pattern.
  */
-static K_DELAYED_WORK_DEFINE(led_pat_active_work, led_pat_active_work_fn);
-static K_DELAYED_WORK_DEFINE(led_pat_passive_work, led_pat_passive_work_fn);
-static K_DELAYED_WORK_DEFINE(led_pat_gps_work, led_pat_gps_work_fn);
+static K_WORK_DELAYABLE_DEFINE(led_pat_active_work, led_pat_active_work_fn);
+static K_WORK_DELAYABLE_DEFINE(led_pat_passive_work, led_pat_passive_work_fn);
+static K_WORK_DELAYABLE_DEFINE(led_pat_gps_work, led_pat_gps_work_fn);
 
 /* UI module message queue. */
 #define UI_QUEUE_ENTRY_COUNT		10
@@ -268,13 +268,13 @@ static void on_state_active_sub_state_gps_active(struct ui_msg_data *msg)
 	if ((IS_EVENT(msg, data, DATA_EVT_DATA_SEND)) ||
 	    (IS_EVENT(msg, data, DATA_EVT_UI_DATA_SEND))) {
 		update_led_pattern(LED_CLOUD_PUBLISHING);
-		k_delayed_work_submit(&led_pat_gps_work, K_SECONDS(5));
+		k_work_reschedule(&led_pat_gps_work, K_SECONDS(5));
 	}
 
 	if (IS_EVENT(msg, data, DATA_EVT_CONFIG_READY)) {
 		if (!msg->module.data.data.cfg.active_mode) {
 			state_set(STATE_PASSIVE);
-			k_delayed_work_submit(&led_pat_gps_work,
+			k_work_reschedule(&led_pat_gps_work,
 					      K_SECONDS(5));
 		}
 	}
@@ -291,13 +291,13 @@ static void on_state_active_sub_state_gps_inactive(struct ui_msg_data *msg)
 	if ((IS_EVENT(msg, data, DATA_EVT_DATA_SEND)) ||
 	    (IS_EVENT(msg, data, DATA_EVT_UI_DATA_SEND))) {
 		update_led_pattern(LED_CLOUD_PUBLISHING);
-		k_delayed_work_submit(&led_pat_active_work, K_SECONDS(5));
+		k_work_reschedule(&led_pat_active_work, K_SECONDS(5));
 	}
 
 	if (IS_EVENT(msg, data, DATA_EVT_CONFIG_READY)) {
 		if (!msg->module.data.data.cfg.active_mode) {
 			state_set(STATE_PASSIVE);
-			k_delayed_work_submit(&led_pat_passive_work,
+			k_work_reschedule(&led_pat_passive_work,
 					      K_SECONDS(5));
 		}
 	}
@@ -314,13 +314,13 @@ static void on_state_passive_sub_state_gps_active(struct ui_msg_data *msg)
 	if ((IS_EVENT(msg, data, DATA_EVT_DATA_SEND)) ||
 	    (IS_EVENT(msg, data, DATA_EVT_UI_DATA_SEND))) {
 		update_led_pattern(LED_CLOUD_PUBLISHING);
-		k_delayed_work_submit(&led_pat_gps_work, K_SECONDS(5));
+		k_work_reschedule(&led_pat_gps_work, K_SECONDS(5));
 	}
 
 	if (IS_EVENT(msg, data, DATA_EVT_CONFIG_READY)) {
 		if (msg->module.data.data.cfg.active_mode) {
 			state_set(STATE_ACTIVE);
-			k_delayed_work_submit(&led_pat_gps_work,
+			k_work_reschedule(&led_pat_gps_work,
 					      K_SECONDS(5));
 		}
 	}
@@ -337,13 +337,13 @@ static void on_state_passive_sub_state_gps_inactive(struct ui_msg_data *msg)
 	if ((IS_EVENT(msg, data, DATA_EVT_DATA_SEND)) ||
 	    (IS_EVENT(msg, data, DATA_EVT_UI_DATA_SEND))) {
 		update_led_pattern(LED_CLOUD_PUBLISHING);
-		k_delayed_work_submit(&led_pat_passive_work, K_SECONDS(5));
+		k_work_reschedule(&led_pat_passive_work, K_SECONDS(5));
 	}
 
 	if (IS_EVENT(msg, data, DATA_EVT_CONFIG_READY)) {
 		if (msg->module.data.data.cfg.active_mode) {
 			state_set(STATE_ACTIVE);
-			k_delayed_work_submit(&led_pat_active_work,
+			k_work_reschedule(&led_pat_active_work,
 					      K_SECONDS(5));
 		}
 	}

--- a/applications/asset_tracker_v2/src/modules/util_module.c
+++ b/applications/asset_tracker_v2/src/modules/util_module.c
@@ -47,7 +47,7 @@ static void message_handler(struct util_msg_data *msg);
 static void send_reboot_request(enum shutdown_reason reason);
 
 /* Delayed work that is used to trigger a reboot. */
-static K_DELAYED_WORK_DEFINE(reboot_work, reboot_work_fn);
+static K_WORK_DELAYABLE_DEFINE(reboot_work, reboot_work_fn);
 
 static struct module_data self = {
 	.name = "util",
@@ -197,7 +197,7 @@ static void send_reboot_request(enum shutdown_reason reason)
 		util_module_event->type = UTIL_EVT_SHUTDOWN_REQUEST;
 		util_module_event->reason = reason;
 
-		k_delayed_work_submit(&reboot_work,
+		k_work_reschedule(&reboot_work,
 				      K_SECONDS(CONFIG_REBOOT_TIMEOUT));
 
 		EVENT_SUBMIT(util_module_event);
@@ -222,7 +222,7 @@ static void reboot_ack_check(uint32_t module_id)
 	if (modules_shutdown_register(module_id)) {
 		LOG_WRN("All modules have ACKed the reboot request.");
 		LOG_WRN("Reboot in 5 seconds.");
-		k_delayed_work_submit(&reboot_work, K_SECONDS(5));
+		k_work_reschedule(&reboot_work, K_SECONDS(5));
 	}
 }
 


### PR DESCRIPTION
Convert to new k_work API due to deprecation.

Jira: NCSDK-9409

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>


link to best practices: https://github.com/zephyrproject-rtos/zephyr/issues/33104