### PR TITLE
bluetooth: mesh: disable ctrl on set msgs from ext. models

### DIFF
--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -99,6 +99,7 @@ static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
 	}
 
+	lightness_srv_disable_control(&srv->lightness_srv);
 	lightness_srv_change_lvl(&srv->lightness_srv, ctx, &light, &light_rsp);
 	bt_mesh_light_temp_srv_set(&srv->temp_srv, ctx, &temp, &temp_rsp);
 

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -145,6 +145,7 @@ static void hsl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 
 	bt_mesh_light_hue_srv_set(&srv->hue, ctx, &set.h, &hue);
 	bt_mesh_light_sat_srv_set(&srv->sat, ctx, &set.s, &sat);
+	lightness_srv_disable_control(&srv->lightness);
 	lightness_srv_change_lvl(&srv->lightness, ctx, &set.l, &lightness);
 
 	struct bt_mesh_light_hsl_status hsl =

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -126,6 +126,7 @@ static void xyl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	}
 
 	set.transition = &transition;
+	lightness_srv_disable_control(&srv->lightness_srv);
 	lightness_srv_change_lvl(&srv->lightness_srv, ctx, &light, &light_rsp);
 	srv->handlers->xy_set(srv, ctx, &set, &status);
 	srv->xy_last.x = set.params.x;

--- a/subsys/bluetooth/mesh/lightness_internal.h
+++ b/subsys/bluetooth/mesh/lightness_internal.h
@@ -141,6 +141,8 @@ static inline uint16_t light_to_repr(uint16_t light, enum light_repr repr)
 struct bt_mesh_lightness_srv;
 struct bt_mesh_lightness_cli;
 
+void lightness_srv_disable_control(struct bt_mesh_lightness_srv *srv);
+
 void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct bt_mesh_lightness_set *set,

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -50,15 +50,6 @@ static int store_state(struct bt_mesh_lightness_srv *srv)
 					&data, sizeof(data));
 }
 
-static void disable_control(struct bt_mesh_lightness_srv *srv)
-{
-#if defined(CONFIG_BT_MESH_LIGHT_CTRL_SRV)
-	if (srv->ctrl) {
-		bt_mesh_light_ctrl_srv_disable(srv->ctrl);
-	}
-#endif
-}
-
 static void lvl_status_encode(struct net_buf_simple *buf,
 			      const struct bt_mesh_lightness_status *status,
 			      enum light_repr repr)
@@ -175,6 +166,15 @@ static void handle_linear_get(struct bt_mesh_model *model,
 	handle_light_get(model, ctx, buf, LINEAR);
 }
 
+void lightness_srv_disable_control(struct bt_mesh_lightness_srv *srv)
+{
+#if defined(CONFIG_BT_MESH_LIGHT_CTRL_SRV)
+	if (srv->ctrl) {
+		bt_mesh_light_ctrl_srv_disable(srv->ctrl);
+	}
+#endif
+}
+
 void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct bt_mesh_lightness_set *set,
@@ -237,7 +237,7 @@ static void lightness_set(struct bt_mesh_model *model,
 		/* According to the Mesh Model Specification section 6.2.3.1,
 		 * manual changes to the lightness should disable control.
 		 */
-		disable_control(srv);
+		lightness_srv_disable_control(srv);
 		lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
@@ -561,7 +561,7 @@ static void lvl_set(struct bt_mesh_lvl_srv *lvl_srv,
 		/* According to the Mesh Model Specification section 6.2.3.1,
 		 * manual changes to the lightness should disable control.
 		 */
-		disable_control(srv);
+		lightness_srv_disable_control(srv);
 		lightness_srv_change_lvl(srv, ctx, &set, &status);
 	} else if (rsp) {
 		srv->handlers->light_get(srv, NULL, &status);
@@ -615,7 +615,7 @@ static void lvl_delta_set(struct bt_mesh_lvl_srv *lvl_srv,
 	/* According to the Mesh Model Specification section 6.2.3.1,
 	 * manual changes to the lightness should disable control.
 	 */
-	disable_control(srv);
+	lightness_srv_disable_control(srv);
 	lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 	/* Override "last" value to be able to make corrective deltas when
@@ -685,7 +685,7 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 	/* According to the Mesh Model Specification section 6.2.3.1,
 	 * manual changes to the lightness should disable control.
 	 */
-	disable_control(srv);
+	lightness_srv_disable_control(srv);
 	lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 	if (rsp) {
@@ -727,7 +727,7 @@ static void onoff_set(struct bt_mesh_onoff_srv *onoff_srv,
 	/* According to the Mesh Model Specification section 6.2.3.1,
 	 * manual changes to the lightness should disable control.
 	 */
-	disable_control(srv);
+	lightness_srv_disable_control(srv);
 	lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 	if (rsp) {


### PR DESCRIPTION
The Light Controller should disable control when the lightness is set
as a consquence of a message being received. This commit makes this work
also for messages received by any extending model of the lightness
server.

Signed-off-by: Ludvig Samuelsen Jordet <ludvig.jordet@nordicsemi.no>