### PR TITLE
Bluetooth: Mesh: Add integration_platforms to sample.yaml

### DIFF
--- a/samples/bluetooth/mesh/chat/sample.yaml
+++ b/samples/bluetooth/mesh/chat/sample.yaml
@@ -7,3 +7,6 @@ tests:
     build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -8,3 +8,9 @@ tests:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -7,3 +7,6 @@ tests:
     build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -8,3 +8,9 @@ tests:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns

--- a/samples/bluetooth/mesh/sensor_client/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_client/sample.yaml
@@ -7,3 +7,6 @@ tests:
     build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840

--- a/samples/bluetooth/mesh/sensor_server/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_server/sample.yaml
@@ -7,3 +7,6 @@ tests:
     build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840

--- a/tests/subsys/bluetooth/mesh/models/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/models/testcase.yaml
@@ -2,6 +2,8 @@ common:
   build_only: true
   platform_allow: nrf52840dk_nrf52840
   tags: bluetooth ci_build
+  integration_platforms:
+    - nrf52840dk_nrf52840
 tests:
   bluetooth.mesh.build_models:
     # Explicitly disabling settings to ensure they're not "imply"'d by anything:


### PR DESCRIPTION
Adds integration_plaforms listings to all Bluetooth Mesh tests and
samples.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>