### PR TITLE
samples: spm: Avoid using feature that allocates PPI channel

### DIFF
--- a/samples/spm/prj.conf
+++ b/samples/spm/prj.conf
@@ -15,3 +15,7 @@ CONFIG_MAIN_STACK_SIZE=4096
 # being built by a parent image. Hence we set it here to ensure that SPM
 # cleans up the core during boot.
 CONFIG_INIT_ARCH_HW_AT_BOOT=y
+
+# Avoid using feature that allocates PPI channels
+CONFIG_UART_0_ENHANCED_POLL_OUT=n
+CONFIG_UART_1_ENHANCED_POLL_OUT=n


### PR DESCRIPTION
Currently, there is no mechanism to synchronize between S and NS. When S allocates a PPI channel and then starts NS. NS application may allocate same channel which is not functional. It is fixed by disabling a feature which is using PPI channel allocation in spm.

Additional fix in uarte driver was needed.