### PR TITLE
lib: at_host: Convert to a new k_work API

### DIFF
--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -306,9 +306,9 @@ static int at_host_init(const struct device *arg)
 	}
 
 	k_work_init(&cmd_send_work, cmd_send);
-	k_work_q_start(&at_host_work_q, at_host_stack_area,
-		       K_THREAD_STACK_SIZEOF(at_host_stack_area),
-		       CONFIG_AT_HOST_THREAD_PRIO);
+	k_work_queue_start(&at_host_work_q, at_host_stack_area,
+			   K_THREAD_STACK_SIZEOF(at_host_stack_area),
+			   CONFIG_AT_HOST_THREAD_PRIO, NULL);
 	uart_irq_rx_enable(uart_dev);
 
 	return err;


### PR DESCRIPTION
Convert the at_host library to a new k_work API.

Jira: NCSDK-9410

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>