### PR TITLE
doc: nrf: Update known issues that B0 and MCUBoot is broken

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -663,9 +663,15 @@ Immutable bootloader board restrictions
 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
 
-Immutable bootloader and netboot can overwrite non-OTP provisioning data
+nRF Secure Immutable Bootloader and netboot can overwrite non-OTP provisioning data
   In architectures that do not have OTP regions, b0 and b0n images incorrectly linked to the size of their container can overwrite provisioning partition data from their image sizes.
   Issue related to NCSDK-7982.
+
+.. rst-class:: v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+
+The combination of nRF Secure Immutable Bootloader and MCUBoot fails to upgrade both the application and MCUBoot.
+  Due to a change in dependency handling in MCUBoot, MCUBoot does not read any update as a valid update.
+  Issue related to NCSDK-8681.
 
 Build system
 ============


### PR DESCRIPTION
B0 and MCUBoot cannot upgrade application or bootloader MCUBoot after
the upmerge 56a7dc8339fdcad8d53dad5a1691a1f0ac4c4ac7 which was in
august.

This has been broken for versions 1.4 to 1.5.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>