### PR TITLE
doc: applications: SLM adding links to AT manual

### DIFF
--- a/applications/serial_lte_modem/README.rst
+++ b/applications/serial_lte_modem/README.rst
@@ -5,6 +5,9 @@ nRF9160: Serial LTE modem
 
 The Serial LTE Modem (SLM) application can be used to emulate a stand-alone LTE modem on the nRF9160.
 
+The SLM application adds proprietary AT commands running on the application processor so they are 
+complementary to the AT Commands found in nRF91 `AT Commands Reference Guide`_ which are modem specific.
+
 See the subpages for how to use the application, how to extend it, and information on the supported AT commands.
 
 .. toctree::

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -9,6 +9,9 @@ Application description
 
 The Serial LTE Modem (SLM) application demonstrates how to use the nRF9160 as a stand-alone LTE modem that can be controlled by proprietary AT commands.
 
+The SLM application adds proprietary AT commands running on the application processor so they are 
+complementary to the AT Commands found in nRF91 `AT Commands Reference Guide`_ which are modem specific.
+
 Requirements
 ************
 


### PR DESCRIPTION
Adding some additional description that SLM adds proprietary
AT Commands and links to the default AT command reference manual.

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>