### PR TITLE
doc: applications: SLM adding links to AT manual

### DIFF
--- a/applications/serial_lte_modem/README.rst
+++ b/applications/serial_lte_modem/README.rst
@@ -4,6 +4,7 @@ nRF9160: Serial LTE modem
 #########################
 
 The Serial LTE Modem (SLM) application can be used to emulate a stand-alone LTE modem on the nRF9160.
+The application accepts both the modem-specific AT commands documented in the `nRF91 AT Commands Reference Guide <AT Commands Reference Guide_>`_ and proprietary AT commands documented in :ref:`SLM_AT_intro`.
 
 See the subpages for how to use the application, how to extend it, and information on the supported AT commands.
 

--- a/applications/serial_lte_modem/doc/AT_commands_intro.rst
+++ b/applications/serial_lte_modem/doc/AT_commands_intro.rst
@@ -1,7 +1,7 @@
 .. _SLM_AT_intro:
 
-AT commands
-###########
+SLM-specific AT commands
+########################
 
 The application sample uses a series of proprietary AT commands to let the nRF91 development kit operate as a Serial LTE Modem (SLM).
 
@@ -26,6 +26,9 @@ There are 3 types of AT commands:
   Some test commands can also have other functionality.
 
 AT responds to all commands with a final response.
+
+See the following subpages for documentation of the proprietary AT commands.
+The modem-specific AT commands are documented in the `nRF91 AT Commands Reference Guide <AT Commands Reference Guide_>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -7,7 +7,9 @@ Application description
    :local:
    :depth: 3
 
-The Serial LTE Modem (SLM) application demonstrates how to use the nRF9160 as a stand-alone LTE modem that can be controlled by proprietary AT commands.
+The Serial LTE Modem (SLM) application demonstrates how to use the nRF9160 as a stand-alone LTE modem that can be controlled by AT commands.
+
+The application accepts both the modem-specific AT commands documented in the `nRF91 AT Commands Reference Guide <AT Commands Reference Guide_>`_ and proprietary AT commands documented in :ref:`SLM_AT_intro`.
 
 Requirements
 ************


### PR DESCRIPTION
Adding some additional description that SLM adds proprietary
AT Commands and links to the default AT command reference manual.

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>
Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>

Replaces https://github.com/nrfconnect/sdk-nrf/pull/4474/