### PR TITLE
samples: Bluetooth: df: Add integration_platforms to sample.yaml

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -4,10 +4,14 @@ sample:
 tests:
   sample.bluetooth.direction_finding_connectionless:
     harness: bluetooth
-    platform_allow: nrf52833dk_nrf52833
+    filter: CONFIG_HAS_HW_NRF_RADIO_BLE_DF
     tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833
   sample.bluetooth.direction_finding_connectionless.aoa:
     extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
     harness: bluetooth
-    platform_allow: nrf52833dk_nrf52833
+    filter: CONFIG_HAS_HW_NRF_RADIO_BLE_DF
     tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833


### PR DESCRIPTION
Add integration_plaforms to the direction_finding_connectionless_tx
sample application.

Change done regarding the PR: #4444 

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>