### PR TITLE
lib: lte_lc: Always parse current cell when available

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -296,8 +296,9 @@ struct lte_lc_ncell {
 };
 
 /** @brief Structure containing results of neighbor cell measurements.
+ *	   The current cell information is valid if the current cell ID is non-zero.
  *	   The ncells_count member indicates whether or not the structure contains
- *	   any valid cell information. If it is zero, no cells were found, and
+ *	   valid neighbor cell information. If it is zero, no cells were found, and
  *	   the information in the rest of structure members do not contain valid data.
  */
 struct lte_lc_cells_info {

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -331,7 +331,7 @@ static void at_handler(void *context, const char *response)
 		break;
 	case LTE_LC_NOTIF_NCELLMEAS: {
 		int ncell_count = neighborcell_count_get(response);
-		struct lte_lc_ncell *neighbor_cells;
+		struct lte_lc_ncell *neighbor_cells = NULL;
 
 		LOG_DBG("%%NCELLMEAS notification");
 		LOG_DBG("Neighbor cell count: %d", ncell_count);
@@ -343,16 +343,12 @@ static void at_handler(void *context, const char *response)
 			return;
 		}
 
-		if (ncell_count == 0) {
-			evt.type = LTE_LC_EVT_NEIGHBOR_CELL_MEAS;
-			evt_handler(&evt);
-			return;
-		}
-
-		neighbor_cells = k_calloc(sizeof(struct lte_lc_ncell), ncell_count);
-		if (neighbor_cells == NULL) {
-			LOG_ERR("Failed to allocate memory for neighbor cells");
-			return;
+		if (ncell_count != 0) {
+			neighbor_cells = k_calloc(ncell_count, sizeof(struct lte_lc_ncell));
+			if (neighbor_cells == NULL) {
+				LOG_ERR("Failed to allocate memory for neighbor cells");
+				return;
+			}
 		}
 
 		evt.cells_info.neighbor_cells = neighbor_cells;
@@ -375,7 +371,9 @@ static void at_handler(void *context, const char *response)
 			break;
 		}
 
-		k_free(neighbor_cells);
+		if (neighbor_cells) {
+			k_free(neighbor_cells);
+		}
 
 		return;
 	}

--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -646,9 +646,13 @@ uint32_t neighborcell_count_get(const char *at_response)
 
 /* Parse NCELLMEAS notification and put information into struct lte_lc_cells_info.
  *
- * Returns 0 on successful cell measurements and population of struct, 1 on
- * measurement failure, -E2BIG if not all cells were parsed due to memory
- * limitations, otherwise negative error code.
+ * Returns 0 on successful cell measurements and population of struct.
+ *	     A non-zero current cell ID indicates that current cell information
+ *	     is valid. The ncells_count indicates for how many neighbor cells
+ *	     the data is valid.
+ * Returns 1 on measurement failure
+ * Returns -E2BIG if not all cells were parsed due to memory limitations
+ * Returns otherwise a negative error code.
  */
 int parse_ncellmeas(const char *at_response, struct lte_lc_cells_info *cells)
 {
@@ -802,8 +806,8 @@ int parse_ncellmeas(const char *at_response, struct lte_lc_cells_info *cells)
 
 	/* Neighbor cell count. */
 	cells->ncells_count = neighborcell_count_get(at_response);
-	if (cells->ncells_count == 0) {
-		return 0;
+	if ((cells->ncells_count == 0) || (cells->neighbor_cells == NULL)) {
+		goto clean_exit;
 	}
 
 	/* Neighboring cells. */

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -376,7 +376,7 @@ static void test_parse_ncellmeas(void)
 	char *resp1 = "%NCELLMEAS: 0,\"021D140C\",\"24201\",\"0821\",65535,5300,"
 			"449,50,15,10891,5300,194,46,8,0,1650,292,60,27,24";
 	char *resp2 = "%NCELLMEAS: 1,\"021D140C\",\"24201\",\"0821\",65535,5300";
-	char *resp3 = "%NCELLMEAS: 0,\"021D140C\",\"24201\",\"0821\",65535,5300,449,50,15,10891";
+	char *resp3 = "%NCELLMEAS: 0,\"071D340C\",\"24201\",\"0821\",65535,5300,449,50,15,10891";
 	struct lte_lc_ncell ncells[17];
 	struct lte_lc_cells_info cells = {
 		.neighbor_cells = ncells,
@@ -404,11 +404,24 @@ static void test_parse_ncellmeas(void)
 	zassert_equal(cells.neighbor_cells[1].rsrq, 27, "Wrong RSRQ");
 	zassert_equal(cells.neighbor_cells[1].time_diff, 24, "Wrong time difference");
 
+	memset(&cells, 0, sizeof(cells));
+
 	err = parse_ncellmeas(resp2, &cells);
 	zassert_equal(err, 1, "parse_ncellmeas was expected to return 1, but returned %d", err);
 
+	memset(&cells, 0, sizeof(cells));
+
 	err = parse_ncellmeas(resp3, &cells);
 	zassert_equal(err, 0, "parse_ncellmeas was expected to return 0, but returned %d", err);
+	zassert_equal(cells.current_cell.mcc, 242, "Wrong MCC");
+	zassert_equal(cells.current_cell.mnc, 1, "Wrong MNC");
+	zassert_equal(cells.current_cell.tac, 2081, "Wrong TAC");
+	zassert_equal(cells.current_cell.id, 119354380, "Wrong cell ID");
+	zassert_equal(cells.current_cell.earfcn, 5300, "Wrong EARFCN");
+	zassert_equal(cells.current_cell.timing_advance, 65535, "Wrong timing advance");
+	zassert_equal(cells.current_cell.measurement_time, 10891, "Wrong measurement time");
+	zassert_equal(cells.current_cell.phys_cell_id, 449, "Wrong physical cell ID");
+	zassert_equal(cells.ncells_count, 0, "Wrong neighbor cell count");
 }
 
 static void test_neighborcell_count_get(void)


### PR DESCRIPTION
Current cell information was only parsed if there was also neighbor
cell information present in the %NCELLMEAS response.
This change parses current cell information when it's available and
populates the event struct accordingly. The current cell ID can
be used to check if current cell information is valid in an event.

Test case is updated to verify the changed behavior.

Closes CIA-309

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>