### PR TITLE
labeler: Remove invalid Thread entries

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -139,14 +139,10 @@
   - "modules/mcuboot/**/*"
 
 "CI-thread-test":
-  - "include/openthread/**/*"
-  - "include/modem/**/*"
-  - "lib/**/*"
   - "samples/openthread/**/*"
   - "subsys/mpsl/**/*"
   - "subsys/net/lib/coap_utils/**/*"
   - "subsys/net/openthread/**/*"
-  - "subsys/net/l2/openthread/**/*"
 
 "CI-nfc-test":
   - "subsys/nfc/**/*"


### PR DESCRIPTION
Remove invalid entries for CI-thread-test:
 * include/openthread does not exist
 * subsys/net/l2/openthread does not exist
 * include/modem is not related to Thread at all
 * lib is too generic, and to my knowledge does not have any library
   used by Thread

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>