### PR TITLE
drivers: sensor: Convert to use the new k_work API

### DIFF
--- a/drivers/sensor/pmw3360/pmw3360.c
+++ b/drivers/sensor/pmw3360/pmw3360.c
@@ -134,11 +134,11 @@ struct pmw3360_data {
 	const struct device          *spi_dev;
 	struct gpio_callback         irq_gpio_cb;
 	struct k_spinlock            lock;
-	int16_t                        x;
-	int16_t                        y;
+	int16_t                      x;
+	int16_t                      y;
 	sensor_trigger_handler_t     data_ready_handler;
 	struct k_work                trigger_handler_work;
-	struct k_delayed_work        init_work;
+	struct k_work_delayable      init_work;
 	enum async_init_step         async_init_step;
 	int                          err;
 	bool                         ready;
@@ -777,8 +777,8 @@ static void pmw3360_async_init(struct k_work *work)
 			dev_data->ready = true;
 			LOG_INF("PMW3360 initialized");
 		} else {
-			k_delayed_work_submit(&dev_data->init_work,
-					      K_MSEC(async_init_delay[
+			k_work_schedule(&dev_data->init_work,
+					K_MSEC(async_init_delay[
 						dev_data->async_init_step]));
 		}
 	}
@@ -871,11 +871,10 @@ static int pmw3360_init(const struct device *dev)
 		return err;
 	}
 
-	k_delayed_work_init(&dev_data->init_work, pmw3360_async_init);
+	k_work_init_delayable(&dev_data->init_work, pmw3360_async_init);
 
-	k_delayed_work_submit(&dev_data->init_work,
-			      K_MSEC(async_init_delay[
-				dev_data->async_init_step]));
+	k_work_schedule(&dev_data->init_work,
+			K_MSEC(async_init_delay[dev_data->async_init_step]));
 
 	return err;
 }


### PR DESCRIPTION
Convert the BH1749, PAW3212, and PMW3360 sensor drivers
to use the new k_work API.

Ref: NCSDK-9416

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>