### PR TITLE
samples: Bluetooth: Add Direction Finding connectionless Rx sample

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -86,6 +86,7 @@ Kconfig*                                  @tejlmand
 /samples/sensor/bh1749/                   @wlgrd
 /samples/bluetooth/                       @joerchan @carlescufi @KAGA164
 /samples/bluetooth/mesh/                  @trond-snekvik @joerchan
+/samples/bluetooth/direction_finding_connectionless_rx/ @ppryga @joerchan
 /samples/bluetooth/direction_finding_connectionless_tx/ @ppryga @joerchan
 /samples/bootloader/                      @hakonfam @ioannisg
 /samples/connectedhomeip/                 @Damian-Nordic @kkasperczyk-no

--- a/samples/bluetooth/direction_finding_connectionless_rx/CMakeLists.txt
+++ b/samples/bluetooth/direction_finding_connectionless_rx/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(direction_finding_connectionless)
+
+# NORDIC SDK APP START
+target_sources(app PRIVATE
+  src/main.c
+)
+# NORDIC SDK APP END

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -1,0 +1,163 @@
+.. _direction_finding_connectionless_rx:
+
+Bluetooth: Direction finding connectionless locator
+###################################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The direction finding connectionless locator sample application demonstrates Bluetooth LE direction finding reception.
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52833dk_nrf52833
+
+The sample also requires an antenna matrix when operating in angle of arrival mode.
+It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.
+
+Overview
+********
+
+The direction finding connectionless locator sample application uses Constant Tone Extension (CTE), that is received and sampled with periodic advertising PDUs.
+
+The sample supports two direction finding modes:
+
+* angle of arrival (AoA)
+* angle of departure (AoD)
+
+By default, both modes are available in the sample.
+
+Configuration
+*************
+
+|config|
+
+Angle of departure mode
+=======================
+
+To build this sample with angle of departure mode only, set ``OVERLAY_CONFIG`` to :file:`overlay-aod.conf`.
+
+See :ref:`cmake_options` for instructions on how to add this option.
+For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
+Antenna matrix configuration for angle of arrival mode
+======================================================
+
+To use this sample when angle of arrival mode is enabled, additional configuration of GPIOs is required to control the antenna array.
+Example of such configuration is provided in a devicetree overlay file :file:`nrf52833dk_nrf52833.overlay`.
+
+The overlay file provides the information about which GPIOs should be used by the Radio peripheral to switch between antenna patches during the CTE reception in the AoA mode.
+At least two GPIOs must be provided to enable antenna switching.
+
+The GPIOs are used by the Radio peripheral in order given by the ``dfegpio#-gpios`` properties.
+The order is important because it affects mapping of the antenna switching patterns to GPIOs (see `Antenna patterns`_).
+
+To successfully use the direction finding locator when the AoA mode is enabled, provide the following data related to antenna matrix design:
+
+* Provide the GPIO pins to ``dfegpio#-gpios`` properties in :file:`nrf52833dk_nrf52833.overlay` file
+* Provide the default antenna that will be used to receive PDU ``dfe-pdu-antenna`` property in :file:`nrf52833dk_nrf52833.overlay` file
+* Update the antenna switching patterns in :c:member:`ant_patterns` array in :file:`main.c`.
+
+Antenna patterns
+================
+
+The antenna switching pattern is a binary number where each bit is applied to a particular antenna GPIO pin.
+For example, the pattern 0x3 means that antenna GPIOs at index 0,1 will be set, while the following are left unset.
+
+This also means that, for example, when using four GPIOs, the pattern count cannot be greater than 16 and maximum allowed value is 15.
+
+If the number of switch-sample periods is greater than the number of stored switching patterns, then the radio loops back to the first pattern.
+
+The following table presents the patterns that you can use to switch antennas on the Nordic-designed antenna matrix:
+
++--------+--------------+
+|Antenna | PATTERN[3:0] |
++========+==============+
+| ANT_12 |  0 (0b0000)  |
++--------+--------------+
+| ANT_10 |  1 (0b0001)  |
++--------+--------------+
+| ANT_11 |  2 (0b0010)  |
++--------+--------------+
+| RFU    |  3 (0b0011)  |
++--------+--------------+
+| ANT_3  |  4 (0b0100)  |
++--------+--------------+
+| ANT_1  |  5 (0b0101)  |
++--------+--------------+
+| ANT_2  |  6 (0b0110)  |
++--------+--------------+
+| RFU    |  7 (0b0111)  |
++--------+--------------+
+| ANT_6  |  8 (0b1000)  |
++--------+--------------+
+| ANT_4  |  9 (0b1001)  |
++--------+--------------+
+| ANT_5  | 10 (0b1010)  |
++--------+--------------+
+| RFU    | 11 (0b1011)  |
++--------+--------------+
+| ANT_9  | 12 (0b1100)  |
++--------+--------------+
+| ANT_7  | 13 (0b1101)  |
++--------+--------------+
+| ANT_8  | 14 (0b1110)  |
++--------+--------------+
+| RFU    | 15 (0b1111)  |
++--------+--------------+
+
+Building and Running
+********************
+.. |sample path| replace:: :file:`samples/bluetooth/direction_finding_connectionless_rx`
+
+.. include:: /includes/build_and_run.txt
+
+Testing
+=======
+
+After programming the sample to your development kit, test it by performing the following steps:
+
+1. |connect_terminal_specific|
+#. In the terminal window, check for information similar to the following::
+
+
+      Starting Connectionless Locator Demo
+      Bluetooth initialization...success
+      Scan callbacks register...success.
+      Periodic Advertising callbacks register...success.
+      Start scanning...success
+      Waiting for periodic advertising...
+      [DEVICE]: XX:XX:XX:XX:XX:XX, AD evt type X, Tx Pwr: XXX, RSSI XXX C:X S:X D:X SR:X E:1 Prim: XXX, Secn: XXX, Interval: XXX (XXX ms), SID: X
+      success. Found periodic advertising.
+      Creating Periodic Advertising Sync...success.
+      Waiting for periodic sync...
+      PER_ADV_SYNC[0]: [DEVICE]: XX:XX:XX:XX:XX:XX synced, Interval XXX (XXX ms), PHY XXX
+      success. Periodic sync established.
+      Enable receiving of CTE...
+      success. CTE receive enabled.
+      Scan disable...Success.
+      Waiting for periodic sync lost...
+      PER_ADV_SYNC[X]: [DEVICE]: XX:XX:XX:XX:XX:XX, tx_power XXX, RSSI XX, CTE XXX, data length X, data: XXX
+      CTE[X]: samples count XX, cte type XXX, slot durations: X [us], packet status XXX, RSSI XXX
+
+
+Dependencies
+************
+
+This sample uses the following Zephyr libraries:
+
+* ``include/zephyr/types.h``
+* ``lib/libc/minimal/include/errno.h``
+* ``include/sys/printk.h``
+* ``include/sys/byteorder.h``
+* ``include/sys/util.h``
+* :ref:`zephyr:bluetooth_api`:
+
+  * ``include/bluetooth/bluetooth.h``
+  * ``include/bluetooth/direction.h``

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52833.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is a number of antennas that are available on antenna matrix
+	 * designed by Nordic. For more information see README.rst.
+	 */
+	dfe-antenna-num = < 12 >;
+	/* This is a setting that enables antenna 12 (in antenna matrix designed
+	 * by Nordic) for Rx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoA is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
+};

--- a/samples/bluetooth/direction_finding_connectionless_rx/overlay-aod.conf
+++ b/samples/bluetooth/direction_finding_connectionless_rx/overlay-aod.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable AoA Feature (antenna switching) in Rx mode
+CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=n

--- a/samples/bluetooth/direction_finding_connectionless_rx/prj.conf
+++ b/samples/bluetooth/direction_finding_connectionless_rx/prj.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT=y
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+CONFIG_BT_DEVICE_NAME="DF Connectionless Locator App"
+
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_PER_ADV_SYNC=y
+CONFIG_BT_OBSERVER=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_DF=y
+CONFIG_BT_DF_CONNECTIONLESS_CTE_RX=y
+
+CONFIG_BT_CTLR_ADV_EXT=y
+CONFIG_BT_CTLR_SYNC_PERIODIC=y
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
+
+# Disable Direction Finding Tx mode
+CONFIG_BT_CTLR_DF_ADV_CTE_TX=n

--- a/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
@@ -1,0 +1,17 @@
+sample:
+  name: Direction Finding Connectionless Locator
+  description: Sample application showing connectionless Direction Finding reception
+tests:
+  sample.bluetooth.direction_finding_connectionless_rx:
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833
+  sample.bluetooth.direction_finding_connectionless_rx.aod:
+    extra_args: OVERLAY_CONFIG="overlay-aod.conf"
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stddef.h>
+#include <errno.h>
+#include <zephyr.h>
+
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/direction.h>
+
+#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
+#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
+#define PEER_NAME_LEN_MAX 30
+#define TIMEOUT_SYNC_CREATE K_SECONDS(10)
+
+static struct bt_le_per_adv_sync *sync;
+static bt_addr_le_t per_addr;
+static volatile bool per_adv_found;
+static bool scan_enabled;
+static uint8_t per_sid;
+
+static K_SEM_DEFINE(sem_per_adv, 0, 1);
+static K_SEM_DEFINE(sem_per_sync, 0, 1);
+static K_SEM_DEFINE(sem_per_sync_lost, 0, 1);
+
+#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
+/* Example sequence of antenna switch patterns for antenna matrix designed by
+ * Nordic. For more information about antenna switch patterns see README.rst.
+ */
+static const uint8_t ant_patterns[] = { 0x2, 0x0, 0x5, 0x6, 0x1, 0x4,
+					0xC, 0x9, 0xE, 0xD, 0x8, 0xA };
+#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
+
+static inline uint32_t adv_interval_to_ms(uint16_t interval)
+{
+	return interval * 5 / 4;
+}
+
+static const char *phy2str(uint8_t phy)
+{
+	switch (phy) {
+	case 0: return "No packets";
+	case BT_GAP_LE_PHY_1M: return "LE 1M";
+	case BT_GAP_LE_PHY_2M: return "LE 2M";
+	case BT_GAP_LE_PHY_CODED: return "LE Coded";
+	default: return "Unknown";
+	}
+}
+
+static const char *cte_type2str(uint8_t type)
+{
+	switch (type) {
+	case BT_DF_CTE_TYPE_AOA: return "AOA";
+	case BT_DF_CTE_TYPE_AOD_1US: return "AOD 1 [us]";
+	case BT_DF_CTE_TYPE_AOD_2US: return "AOD 2 [us]";
+	case BT_DF_CTE_TYPE_NONE: return "";
+	default: return "Unknown";
+	}
+}
+
+static const char *packet_status2str(uint8_t status)
+{
+	switch (status) {
+	case BT_DF_CTE_CRC_OK: return "CRC OK";
+	case BT_DF_CTE_CRC_ERR_CTE_BASED_TIME: return "CRC not OK, CTE Info OK";
+	case BT_DF_CTE_CRC_ERR_CTE_BASED_OTHER: return "CRC not OK, Sampled other way";
+	case BT_DF_CTE_INSUFFICIENT_RESOURCES: return "No resources";
+	default: return "Unknown";
+	}
+}
+
+static bool data_cb(struct bt_data *data, void *user_data)
+{
+	char *name = user_data;
+	uint8_t len;
+
+	switch (data->type) {
+	case BT_DATA_NAME_SHORTENED:
+	case BT_DATA_NAME_COMPLETE:
+		len = MIN(data->data_len, PEER_NAME_LEN_MAX - 1);
+		memcpy(name, data->data, len);
+		name[len] = '\0';
+		return false;
+	default:
+		return true;
+	}
+}
+
+static void sync_cb(struct bt_le_per_adv_sync *sync,
+		    struct bt_le_per_adv_sync_synced_info *info)
+{
+	char le_addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+
+	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
+	       "Interval 0x%04x (%u ms), PHY %s\n",
+	       bt_le_per_adv_sync_get_index(sync), le_addr, info->interval,
+	       adv_interval_to_ms(info->interval), phy2str(info->phy));
+
+	k_sem_give(&sem_per_sync);
+}
+
+static void term_cb(struct bt_le_per_adv_sync *sync,
+		    const struct bt_le_per_adv_sync_term_info *info)
+{
+	char le_addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+
+	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated\n",
+	       bt_le_per_adv_sync_get_index(sync), le_addr);
+
+	k_sem_give(&sem_per_sync_lost);
+}
+
+static void recv_cb(struct bt_le_per_adv_sync *sync,
+		    const struct bt_le_per_adv_sync_recv_info *info,
+		    struct net_buf_simple *buf)
+{
+	char le_addr[BT_ADDR_LE_STR_LEN];
+	char data_str[BT_GAP_ADV_MAX_EXT_ADV_DATA_LEN];
+
+	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	bin2hex(buf->data, buf->len, data_str, sizeof(data_str));
+
+	printk("PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
+	       "RSSI %i, CTE %s, data length %u, data: %s\n",
+	       bt_le_per_adv_sync_get_index(sync), le_addr, info->tx_power,
+	       info->rssi, cte_type2str(info->cte_type), buf->len, data_str);
+}
+
+static void cte_recv_cb(struct bt_le_per_adv_sync *sync,
+			struct bt_df_per_adv_sync_iq_samples_report const *report)
+{
+	printk("CTE[%u]: samples count %d, cte type %s, slot durations: %u [us], "
+	       "packet status %s, RSSI %i\n",
+	       bt_le_per_adv_sync_get_index(sync), report->sample_count,
+	       cte_type2str(report->cte_type), report->slot_durations,
+	       packet_status2str(report->packet_status), report->rssi);
+}
+
+static struct bt_le_per_adv_sync_cb sync_callbacks = {
+	.synced = sync_cb,
+	.term = term_cb,
+	.recv = recv_cb,
+	.cte_report_cb = cte_recv_cb,
+};
+
+static void scan_recv(const struct bt_le_scan_recv_info *info,
+		      struct net_buf_simple *buf)
+{
+	char le_addr[BT_ADDR_LE_STR_LEN];
+	char name[PEER_NAME_LEN_MAX];
+
+	(void)memset(name, 0, sizeof(name));
+
+	bt_data_parse(buf, data_cb, name);
+
+	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+
+	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i %s C:%u S:%u "
+	       "D:%u SR:%u E:%u Prim: %s, Secn: %s, Interval: 0x%04x (%u ms), "
+	       "SID: %u\n",
+	       le_addr, info->adv_type, info->tx_power, info->rssi, name,
+	       (info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_SCANNABLE) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_DIRECTED) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_SCAN_RESPONSE) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0, phy2str(info->primary_phy),
+	       phy2str(info->secondary_phy), info->interval, adv_interval_to_ms(info->interval),
+	       info->sid);
+
+	if (!per_adv_found && info->interval) {
+		per_adv_found = true;
+		per_sid = info->sid;
+		bt_addr_le_copy(&per_addr, info->addr);
+
+		k_sem_give(&sem_per_adv);
+	}
+}
+
+static struct bt_le_scan_cb scan_callbacks = {
+	.recv = scan_recv,
+};
+
+static void create_sync(void)
+{
+	struct bt_le_per_adv_sync_param sync_create_param;
+	int err;
+
+	printk("Creating Periodic Advertising Sync...");
+	bt_addr_le_copy(&sync_create_param.addr, &per_addr);
+	sync_create_param.options = 0;
+	sync_create_param.sid = per_sid;
+	sync_create_param.skip = 0;
+	sync_create_param.timeout = 0xa;
+	err = bt_le_per_adv_sync_create(&sync_create_param, &sync);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success.\n");
+}
+
+static int delete_sync(void)
+{
+	int err;
+
+	printk("Deleting Periodic Advertising Sync...");
+	err = bt_le_per_adv_sync_delete(sync);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return err;
+	}
+	printk("success\n");
+
+	return 0;
+}
+
+static void enable_cte_rx(void)
+{
+	int err;
+
+	const struct bt_df_per_adv_sync_cte_rx_param cte_rx_params = {
+		.max_cte_count = 5,
+#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
+		.cte_type = BT_DF_CTE_TYPE_ALL,
+		.slot_durations = 0x2,
+		.num_ant_ids = ARRAY_SIZE(ant_patterns),
+		.ant_ids = ant_patterns,
+#else
+		.cte_type = BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US,
+#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
+	};
+
+	printk("Enable receiving of CTE...\n");
+	err = bt_df_per_adv_sync_cte_rx_enable(sync, &cte_rx_params);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success. CTE receive enabled.\n");
+}
+
+static int scan_init(void)
+{
+	printk("Scan callbacks register...");
+	bt_le_scan_cb_register(&scan_callbacks);
+	printk("success.\n");
+
+	printk("Periodic Advertising callbacks register...");
+	bt_le_per_adv_sync_cb_register(&sync_callbacks);
+	printk("success.\n");
+
+	return 0;
+}
+
+static int scan_enable(void)
+{
+	struct bt_le_scan_param param = {
+		.type = BT_LE_SCAN_TYPE_ACTIVE,
+		.options = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+		.interval = BT_GAP_SCAN_FAST_INTERVAL,
+		.window = BT_GAP_SCAN_FAST_WINDOW,
+		.timeout = 0U,
+	};
+
+	int err;
+
+	if (!scan_enabled) {
+		printk("Start scanning...");
+		err = bt_le_scan_start(&param, NULL);
+		if (err) {
+			printk("failed (err %d)\n", err);
+			return err;
+		}
+		printk("success\n");
+		scan_enabled = true;
+	}
+
+	return 0;
+}
+
+static void scan_disable(void)
+{
+	int err;
+
+	printk("Scan disable...");
+	err = bt_le_scan_stop();
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("Success.\n");
+
+	scan_enabled = false;
+}
+
+void main(void)
+{
+	int err;
+
+	printk("Starting Connectionless Locator Demo\n");
+
+	printk("Bluetooth initialization...");
+	err = bt_enable(NULL);
+	if (err) {
+		printk("failed (err %d)\n", err);
+	}
+	printk("success\n");
+
+	scan_init();
+
+	scan_enabled = false;
+
+	while (true) {
+		per_adv_found = false;
+		scan_enable();
+
+		printk("Waiting for periodic advertising...\n");
+		err = k_sem_take(&sem_per_adv, K_FOREVER);
+		if (err) {
+			printk("failed (err %d)\n", err);
+			return;
+		}
+		printk("success. Found periodic advertising.\n");
+
+		create_sync();
+
+		printk("Waiting for periodic sync...\n");
+		err = k_sem_take(&sem_per_sync, TIMEOUT_SYNC_CREATE);
+		if (err) {
+			printk("failed (err %d)\n", err);
+			err = delete_sync();
+			if (err) {
+				return;
+			}
+			continue;
+		}
+		printk("success. Periodic sync established.\n");
+
+		enable_cte_rx();
+
+		/* Disable scan to cleanup output */
+		scan_disable();
+
+		printk("Waiting for periodic sync lost...\n");
+		err = k_sem_take(&sem_per_sync_lost, K_FOREVER);
+		if (err) {
+			printk("failed (err %d)\n", err);
+			return;
+		}
+		printk("Periodic sync lost.\n");
+	}
+}


### PR DESCRIPTION
Add sample of Direction Finding connectionless locator application.
The sample provides configuration for DF extension for Nordic
Radio peripheral that allows to use it with Nordic design 12 patches
antenna matrix.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>