### PR TITLE
debug: cpu_load: Convert to use the new k_work API

### DIFF
--- a/subsys/debug/cpu_load/cpu_load.c
+++ b/subsys/debug/cpu_load/cpu_load.c
@@ -34,7 +34,7 @@ LOG_MODULE_REGISTER(cpu_load, CONFIG_CPU_LOAD_LOG_LEVEL);
 
 static nrfx_timer_t timer = NRFX_TIMER_INSTANCE(CONFIG_CPU_LOAD_TIMER_INSTANCE);
 static bool ready;
-static struct k_delayed_work cpu_load_log;
+static struct k_work_delayable cpu_load_log;
 static uint32_t cycle_ref;
 static uint32_t shared_ch_mask;
 
@@ -111,13 +111,13 @@ static void cpu_load_log_fn(struct k_work *item)
 
 	cpu_load_reset();
 	LOG_INF("Load:%d,%03d%%", percent, fraction);
-	k_delayed_work_submit(&cpu_load_log, K_MSEC(CPU_LOAD_LOG_INTERVAL));
+	k_work_schedule(&cpu_load_log, K_MSEC(CPU_LOAD_LOG_INTERVAL));
 }
 
 static int cpu_load_log_init(void)
 {
-	k_delayed_work_init(&cpu_load_log, cpu_load_log_fn);
-	return k_delayed_work_submit(&cpu_load_log, K_MSEC(CPU_LOAD_LOG_INTERVAL));
+	k_work_init_delayable(&cpu_load_log, cpu_load_log_fn);
+	return k_work_schedule(&cpu_load_log, K_MSEC(CPU_LOAD_LOG_INTERVAL));
 }
 
 static void timer_handler(nrf_timer_event_t event_type, void *context)


### PR DESCRIPTION
Convert the cpu_load module to use the new k_work API.

Ref: NCSDK-9419

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>