### PR TITLE
Updated asset tracker to use the v2 of the GNSS API

### DIFF
--- a/applications/asset_tracker/src/gps_controller/gps_controller.c
+++ b/applications/asset_tracker/src/gps_controller/gps_controller.c
@@ -31,9 +31,12 @@ static void start(struct k_work *work)
 	struct gps_config gps_cfg = {
 		.nav_mode = GPS_NAV_MODE_PERIODIC,
 		.power_mode = GPS_POWER_MODE_DISABLED,
+		.use_case = GPS_USE_CASE_MULTIPLE_HOT_START,
+		.accuracy = GPS_ACCURACY_NORMAL,
 		.timeout = CONFIG_GPS_CONTROL_FIX_TRY_TIME,
 		.interval = CONFIG_GPS_CONTROL_FIX_TRY_TIME +
 			gps_reporting_interval_seconds,
+		.delete_agps_data = 0,
 		.priority = true,
 	};
 

--- a/drivers/gps/nrf9160_gps/Kconfig
+++ b/drivers/gps/nrf9160_gps/Kconfig
@@ -16,6 +16,14 @@ menuconfig NRF9160_GPS
 
 if NRF9160_GPS
 
+config NRF9160_AGPS
+	bool "Enable A-GPS"
+	depends on AGPS
+	default y
+	help
+	  Disabling this will cause the GPS driver to not send AGPS data request
+	  events.
+
 config NRF9160_GPS_DEV_NAME
 	string "nRF9160 GPS device name"
 	default "NRF9160_GPS"

--- a/drivers/gps/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/gps/nrf9160_gps/nrf9160_gps.c
@@ -8,41 +8,32 @@
 #include <drivers/gpio.h>
 #include <drivers/gps.h>
 #include <init.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <logging/log.h>
-#include <nrf_socket.h>
-#include <net/socket.h>
-#ifdef CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
+#include <nrf_modem_gnss.h>
+#include <modem/nrf_modem_lib.h>
+
+#if defined(CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION) || \
+defined(CONFIG_NRF9160_GPS_SET_MAGPIO) || \
+defined(CONFIG_NRF9160_GPS_SET_COEX0)
 #include <modem/at_cmd.h>
-#include <modem/at_cmd_parser.h>
+#endif
+
+#if defined(CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION)
 #include <modem/lte_lc.h>
 #endif
-#include <modem/nrf_modem_lib.h>
+
 
 LOG_MODULE_REGISTER(nrf9160_gps, CONFIG_NRF9160_GPS_LOG_LEVEL);
 
-#ifdef CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
-#define AT_CMD_LEN(x)			(sizeof(x) - 1)
-#define AT_XSYSTEMMODE_REQUEST		"AT%XSYSTEMMODE?"
-#define AT_XSYSTEMMODE_RESPONSE		"%XSYSTEMMODE:"
-#define AT_XSYSTEMMODE_PROTO		"AT%%XSYSTEMMODE=%d,%d,%d,%d"
-#define AT_XSYSTEMMODE_PARAMS_COUNT	5
-#define AT_XSYSTEMMODE_GPS_PARAM_INDEX	3
-#define AT_CFUN_REQUEST			"AT+CFUN?"
-#define AT_CFUN_RESPONSE		"+CFUN:"
-#define AT_CFUN_0			"AT+CFUN=0"
-#define AT_CFUN_1			"AT+CFUN=1"
-#define FUNCTIONAL_MODE_ENABLED		1
-#endif
+K_MSGQ_DEFINE(nmea_q, sizeof(struct nrf_modem_gnss_nmea_data_frame *), 10, 4);
 
-/* Aligned strings describing sattelite states based on flags */
-#define sv_used_str(x) ((x)?"    used":"not used")
-#define sv_unhealthy_str(x) ((x)?"not healthy":"    healthy")
-
-#define GPS_BLOCKED_TIMEOUT CONFIG_NRF9160_GPS_PRIORITY_WINDOW_TIMEOUT_SEC
+#define GNSS_START 1
+#define GNSS_STOP 2
 
 struct gps_drv_data {
 	const struct device *dev;
@@ -52,47 +43,54 @@ struct gps_drv_data {
 	atomic_t is_active;
 	atomic_t is_shutdown;
 	atomic_t timeout_occurred;
-	int socket;
+	atomic_t has_fix;
+	int64_t  fix_timestamp;
+	int32_t  fix_interval;
+	atomic_t got_evt;
+	atomic_t nmea_nxt;
+	atomic_t nmea_fix_idx;
+	atomic_t blocked;
+	struct nrf_modem_gnss_pvt_data_frame  last_pvt;
+#ifdef CONFIG_NRF9160_AGPS
+	struct nrf_modem_gnss_agps_data_frame last_agps;
+#endif
+
 	K_THREAD_STACK_MEMBER(thread_stack,
 			      CONFIG_NRF9160_GPS_THREAD_STACK_SIZE);
 	struct k_thread thread;
 	k_tid_t thread_id;
 	struct k_sem thread_run_sem;
+	struct k_sem gps_evt_sem;
 	struct k_work stop_work;
 	struct k_work_delayable timeout_work;
-	struct k_work_delayable blocked_work;
+	struct k_work_delayable pvt_ntf_work;
+	struct k_work_delayable sat_stats_work;
+	struct k_work fix_ntf_work;
+	struct k_work_delayable blocked_ntf_work;
+	struct k_work_delayable unblocked_ntf_work;
+	struct k_work_delayable nmea_ntf_work;
+	struct k_work_delayable bump_priority_work;
 	struct k_work_sync work_sync;
+	struct k_work_sync nested_work_sync;
+#ifdef CONFIG_NRF9160_AGPS
+	struct k_work_delayable agps_ntf_work;
+#endif
 };
 
 struct nrf9160_gps_config {
-	nrf_gnss_fix_retry_t retry;
-	nrf_gnss_fix_interval_t interval;
-	nrf_gnss_nmea_mask_t nmea_mask;
-	nrf_gnss_delete_mask_t delete_mask;
-	nrf_gnss_power_save_mode_t power_mode;
-	nrf_gnss_use_case_t use_case;
+	uint16_t retry;
+	uint16_t interval;
+	uint16_t nmea_mask;
+	uint16_t delete_mask;
+	uint8_t power_mode;
+	uint8_t use_case;
 	bool priority;
 };
 
-static int stop_gps(const struct device *dev, bool is_timeout);
+/* To keep the GNSS event handler and the GPS thread in sync */
+static struct device *dev_hook;
 
-static uint64_t fix_timestamp;
-
-static nrf_gnss_agps_data_type_t type_lookup_gps2socket[] = {
-	[GPS_AGPS_UTC_PARAMETERS]	= NRF_GNSS_AGPS_UTC_PARAMETERS,
-	[GPS_AGPS_EPHEMERIDES]		= NRF_GNSS_AGPS_EPHEMERIDES,
-	[GPS_AGPS_ALMANAC]		= NRF_GNSS_AGPS_ALMANAC,
-	[GPS_AGPS_KLOBUCHAR_CORRECTION]
-		= NRF_GNSS_AGPS_KLOBUCHAR_IONOSPHERIC_CORRECTION,
-	[GPS_AGPS_NEQUICK_CORRECTION]
-		= NRF_GNSS_AGPS_NEQUICK_IONOSPHERIC_CORRECTION,
-	[GPS_AGPS_GPS_SYSTEM_CLOCK_AND_TOWS]
-		= NRF_GNSS_AGPS_GPS_SYSTEM_CLOCK_AND_TOWS,
-	[GPS_AGPS_LOCATION]		= NRF_GNSS_AGPS_LOCATION,
-	[GPS_AGPS_INTEGRITY]		= NRF_GNSS_AGPS_INTEGRITY,
-};
-
-static void copy_pvt(struct gps_pvt *dest, nrf_gnss_pvt_data_frame_t *src)
+static void copy_pvt(struct gps_pvt *dest, struct nrf_modem_gnss_pvt_data_frame *src)
 {
 	dest->latitude = src->latitude;
 	dest->longitude = src->longitude;
@@ -113,53 +111,40 @@ static void copy_pvt(struct gps_pvt *dest, nrf_gnss_pvt_data_frame_t *src)
 	dest->tdop = src->tdop;
 
 	for (size_t i = 0;
-	     i < MIN(NRF_GNSS_MAX_SATELLITES, GPS_PVT_MAX_SV_COUNT); i++) {
+	     i < MIN(NRF_MODEM_GNSS_MAX_SATELLITES, GPS_PVT_MAX_SV_COUNT); i++) {
 		dest->sv[i].sv = src->sv[i].sv;
 		dest->sv[i].cn0 = src->sv[i].cn0;
 		dest->sv[i].elevation = src->sv[i].elevation;
 		dest->sv[i].azimuth = src->sv[i].azimuth;
 		dest->sv[i].signal = src->sv[i].signal;
 		dest->sv[i].in_fix =
-			(src->sv[i].flags & NRF_GNSS_SV_FLAG_USED_IN_FIX) ==
-			NRF_GNSS_SV_FLAG_USED_IN_FIX;
+			(src->sv[i].flags & NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX) ==
+			NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX;
 		dest->sv[i].unhealthy =
-			(src->sv[i].flags & NRF_GNSS_SV_FLAG_UNHEALTHY) ==
-			NRF_GNSS_SV_FLAG_UNHEALTHY;
+			(src->sv[i].flags & NRF_MODEM_GNSS_SV_FLAG_UNHEALTHY) ==
+			NRF_MODEM_GNSS_SV_FLAG_UNHEALTHY;
 	}
 }
 
-static bool is_fix(nrf_gnss_pvt_data_frame_t *pvt)
+static bool is_fix(struct nrf_modem_gnss_pvt_data_frame *pvt)
 {
-	return ((pvt->flags & NRF_GNSS_PVT_FLAG_FIX_VALID_BIT)
-		== NRF_GNSS_PVT_FLAG_FIX_VALID_BIT);
+	return ((pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID)
+		== NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID);
 }
 
-/**@brief Checks if GPS operation is blocked due to insufficient time windows */
-static bool has_no_time_window(nrf_gnss_pvt_data_frame_t *pvt)
-{
-	return ((pvt->flags & NRF_GNSS_PVT_FLAG_NOT_ENOUGH_WINDOW_TIME)
-		== NRF_GNSS_PVT_FLAG_NOT_ENOUGH_WINDOW_TIME);
-}
-
-/**@brief Checks if PVT frame is invalid due to missed processing deadline */
-static bool pvt_deadline_missed(nrf_gnss_pvt_data_frame_t *pvt)
-{
-	return ((pvt->flags & NRF_GNSS_PVT_FLAG_DEADLINE_MISSED)
-		== NRF_GNSS_PVT_FLAG_DEADLINE_MISSED);
-}
-
-static void print_satellite_stats(nrf_gnss_data_frame_t *pvt_data)
+static void tracking_stats(struct nrf_modem_gnss_pvt_data_frame *pvt_data,
+				  int64_t fix_timestamp)
 {
 	uint8_t  n_tracked = 0;
 	uint8_t  n_used = 0;
 	uint8_t  n_unhealthy = 0;
 
-	for (int i = 0; i < NRF_GNSS_MAX_SATELLITES; ++i) {
-		uint8_t sv = pvt_data->pvt.sv[i].sv;
-		bool used = (pvt_data->pvt.sv[i].flags &
-			     NRF_GNSS_SV_FLAG_USED_IN_FIX) ? true : false;
-		bool unhealthy = (pvt_data->pvt.sv[i].flags &
-				  NRF_GNSS_SV_FLAG_UNHEALTHY) ? true : false;
+	for (int i = 0; i < NRF_MODEM_GNSS_MAX_SATELLITES; ++i) {
+		uint8_t sv = pvt_data->sv[i].sv;
+		bool used = (pvt_data->sv[i].flags &
+			     NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX) ? true : false;
+		bool unhealthy = (pvt_data->sv[i].flags &
+				  NRF_MODEM_GNSS_SV_FLAG_UNHEALTHY) ? true : false;
 
 		if (sv) { /* SV number 0 indicates no satellite */
 			n_tracked++;
@@ -169,18 +154,24 @@ static void print_satellite_stats(nrf_gnss_data_frame_t *pvt_data)
 			if (unhealthy) {
 				n_unhealthy++;
 			}
-
-			LOG_DBG("Tracking SV %2u: %s, %s", sv,
-				sv_used_str(used),
-				sv_unhealthy_str(unhealthy));
 		}
 	}
 
-	LOG_DBG("Tracking: %d Using: %d Unhealthy: %d", n_tracked,
-							n_used,
-							n_unhealthy);
-	LOG_DBG("Seconds since last fix %lld",
-			(k_uptime_get() - fix_timestamp) / 1000);
+	int64_t present = k_uptime_get();
+
+	if (fix_timestamp < present) {
+
+		LOG_DBG("%2u SVs:  %2u used, %2u unhealthy, %lld %s",
+			n_tracked, n_used, n_unhealthy,
+			((present - fix_timestamp) / MSEC_PER_SEC),
+			"secs since last fix");
+	} else {
+
+		LOG_DBG("%2u SVs:  %2u used, %2u unhealthy, %lld %s",
+			n_tracked, n_used, n_unhealthy,
+			(present / MSEC_PER_SEC),
+			"secs and no fix");
+	}
 }
 
 static void notify_event(const struct device *dev, struct gps_event *evt)
@@ -192,82 +183,107 @@ static void notify_event(const struct device *dev, struct gps_event *evt)
 	}
 }
 
-static int open_socket(struct gps_drv_data *drv_data)
-{
-	drv_data->socket = nrf_socket(NRF_AF_LOCAL, NRF_SOCK_DGRAM,
-				      NRF_PROTO_GNSS);
-
-	if (drv_data->socket >= 0) {
-		LOG_DBG("GPS socket created, fd: %d", drv_data->socket);
-	} else {
-		LOG_ERR("Could not initialize socket, error: %d)",
-			errno);
-		return -EIO;
-	}
-
-	return 0;
-}
-
 static void cancel_works(struct gps_drv_data *drv_data)
 {
-	k_work_cancel_delayable_sync(&drv_data->timeout_work,
-				     &drv_data->work_sync);
-	k_work_cancel_delayable_sync(&drv_data->blocked_work,
-				     &drv_data->work_sync);
+	k_work_cancel_delayable_sync(&drv_data->timeout_work, &drv_data->work_sync);
+	k_work_cancel_delayable_sync(&drv_data->bump_priority_work, &drv_data->work_sync);
+	k_work_cancel_delayable_sync(&drv_data->pvt_ntf_work, &drv_data->work_sync);
+	k_work_cancel_delayable_sync(&drv_data->sat_stats_work, &drv_data->work_sync);
+	k_work_cancel_delayable_sync(&drv_data->blocked_ntf_work, &drv_data->work_sync);
+	k_work_cancel_delayable_sync(&drv_data->unblocked_ntf_work, &drv_data->work_sync);
+	k_work_cancel_delayable_sync(&drv_data->nmea_ntf_work, &drv_data->work_sync);
+#ifdef CONFIG_NRF9160_AGPS
+	k_work_cancel_delayable_sync(&drv_data->agps_ntf_work, &drv_data->work_sync);
+#endif
+
+	struct nrf_modem_gnss_nmea_data_frame *data;
+
+	while (k_msgq_get(&nmea_q, &data, K_NO_WAIT) == 0) {
+		k_free(data);
+	}
 }
 
-static int gps_priority_set(struct gps_drv_data *drv_data, bool enable)
+static void nrf91_gnss_event_handler(int event)
 {
-	int retval;
-	nrf_gnss_delete_mask_t delete_mask = 0;
+	struct gps_drv_data *drv_data = dev_hook->data;
+	struct nrf_modem_gnss_nmea_data_frame *nmea_data;
 
-	if (enable) {
-		retval = nrf_setsockopt(drv_data->socket,
-					NRF_SOL_GNSS,
-					NRF_SO_GNSS_ENABLE_PRIORITY, NULL, 0);
-		if (retval != 0) {
-			return -EIO;
+	switch (event) {
+	case NRF_MODEM_GNSS_EVT_PVT:
+		atomic_clear(&drv_data->has_fix);
+
+		if (atomic_get(&drv_data->blocked)) {
+			/* Avoid spamming the logs and app. */
+			goto out;
 		}
 
-		LOG_DBG("GPS priority enabled");
-	} else {
-		retval = nrf_setsockopt(drv_data->socket,
-					NRF_SOL_GNSS,
-					NRF_SO_GNSS_DISABLE_PRIORITY, NULL, 0);
-		if (retval != 0) {
-			return -EIO;
+		k_work_schedule(&drv_data->pvt_ntf_work, K_NO_WAIT);
+		break;
+
+	case NRF_MODEM_GNSS_EVT_FIX:
+		atomic_set(&drv_data->has_fix, true);
+		drv_data->fix_timestamp = k_uptime_get();
+		k_work_submit(&drv_data->fix_ntf_work);
+		break;
+
+	case NRF_MODEM_GNSS_EVT_NMEA:
+		nmea_data = k_malloc(sizeof(struct nrf_modem_gnss_nmea_data_frame));
+
+		if (!nmea_data) {
+			return;
 		}
 
-		LOG_DBG("GPS priority disabled");
+		if (nrf_modem_gnss_read(
+			    nmea_data,
+			    sizeof(struct nrf_modem_gnss_nmea_data_frame),
+			    NRF_MODEM_GNSS_DATA_NMEA) != 0) {
+			k_free(nmea_data);
+			goto out;
+		}
+
+		if (k_msgq_put(&nmea_q, &nmea_data, K_NO_WAIT) != 0) {
+			k_free(nmea_data);
+			goto out;
+		}
+
+		k_work_reschedule(&drv_data->nmea_ntf_work, K_NO_WAIT);
+
+		break;
+
+	case NRF_MODEM_GNSS_EVT_AGPS_REQ:
+#ifdef CONFIG_NRF9160_AGPS
+		nrf_modem_gnss_read(&drv_data->last_agps,
+				sizeof(drv_data->last_agps),
+				event);
+
+		k_work_reschedule(&drv_data->agps_ntf_work, K_NO_WAIT);
+#endif /* CONFIG_NRF9160_AGPS */
+		break;
+	case NRF_MODEM_GNSS_EVT_BLOCKED:
+		atomic_set(&drv_data->blocked, true);
+		k_work_reschedule(&drv_data->blocked_ntf_work, K_NO_WAIT);
+		break;
+	case NRF_MODEM_GNSS_EVT_UNBLOCKED:
+		atomic_clear(&drv_data->blocked);
+		k_work_reschedule(&drv_data->unblocked_ntf_work, K_NO_WAIT);
+		break;
+	default:
+		return;
 	}
 
-	/* The GPS has to be started again here because setting the option
-	 * NRF_SO_GNSS_ENABLE_PRIORITY or NRF_SO_GNSS_DISABLE_PRIORITY
-	 * implicitly stops the GPS.
-	 */
-	retval = nrf_setsockopt(drv_data->socket,
-				NRF_SOL_GNSS,
-				NRF_SO_GNSS_START,
-				&delete_mask,
-				sizeof(delete_mask));
-	if (retval != 0) {
-		LOG_ERR("Failed to start GPS");
-		return -EIO;
-	}
-
-	return 0;
+out:
+	atomic_set(&drv_data->got_evt, true);
+	k_sem_give(&drv_data->gps_evt_sem);
 }
 
-static void gps_thread(int dev_ptr)
+static void nrf91_gnss_thread(int dev_ptr)
 {
 	struct device *dev = INT_TO_POINTER(dev_ptr);
 	struct gps_drv_data *drv_data = dev->data;
-	int len;
-	bool operation_blocked = false;
-	bool has_fix = false;
-	struct gps_event evt = {
-		.type = GPS_EVT_SEARCH_STARTED
-	};
+	struct gps_event evt = { .type = GPS_EVT_SEARCH_STARTED };
+	uint32_t timeout;
+
+	atomic_clear(&drv_data->has_fix);
 
 wait:
 	k_sem_take(&drv_data->thread_run_sem, K_FOREVER);
@@ -276,193 +292,34 @@ wait:
 	notify_event(dev, &evt);
 
 	while (true) {
-		nrf_gnss_data_frame_t raw_gps_data = {0};
-		struct gps_event evt = {0};
+		timeout = drv_data->fix_interval ? drv_data->fix_interval : 10;
 
-		/* There is no way of knowing if nrf_recv() blocks because the
-		 * GPS timeout/retry value has expired or the GPS has gotten a
-		 * fix. This check makes sure that a GPS_EVT_SEARCH_TIMEOUT is
-		 * not propagated upon a fix.
+		/** There is no way of knowing if an event has not been received
+		 *  or the GPS has gotten a fix. This check makes sure that
+		 *  a GPS_EVT_SEARCH_TIMEOUT is not propagated upon a fix.
 		 */
-		if (!has_fix) {
-			/* If nrf_recv() blocks for more than one second,
-			 * a fix has been obtained or the GPS has timed out.
-			 * Schedule a delayed timeout work to be executed after
-			 * five seconds to make sure the appropriate event is
-			 * propagated upon a block.
-			 */
-			k_work_schedule(&drv_data->timeout_work, K_SECONDS(5));
+		if (!atomic_get(&drv_data->has_fix)) {
+			k_work_schedule(&drv_data->timeout_work,
+					K_SECONDS(timeout));
 		}
 
-		len = nrf_recv(drv_data->socket, &raw_gps_data,
-			       sizeof(nrf_gnss_data_frame_t), 0);
+		k_sem_take(&drv_data->gps_evt_sem, K_SECONDS(timeout+1));
 
-		/* At this point, it may be too late to cancel this work,
-		 * as it may already be running. In such case, the search
-		 * timeout notification will be generated anyway.
-		 */
-		k_work_cancel_delayable_sync(&drv_data->timeout_work,
-					     &drv_data->work_sync);
+		/* No need for timeout if an event occurred early enough */
+		k_work_cancel_delayable_sync(&drv_data->timeout_work, &drv_data->work_sync);
 
-		if (len <= 0) {
-			/* Is the GPS stopped, causing this error? */
-			if (!atomic_get(&drv_data->is_active)) {
-				goto wait;
-			}
-
-			if (errno == EHOSTDOWN) {
-				LOG_DBG("GPS host is going down, sleeping");
-				cancel_works(drv_data);
-				atomic_clear(&drv_data->is_active);
-				atomic_set(&drv_data->is_shutdown, 1);
-				nrf_close(drv_data->socket);
-
-				nrf_modem_lib_shutdown_wait();
-				if (open_socket(drv_data) != 0) {
-					LOG_ERR("Failed to open socket after "
-						"shutdown sleep, killing thread");
-					return;
-				}
-
-				atomic_clear(&drv_data->is_shutdown);
-				LOG_DBG("GPS host available, going back to "
-					"initialized state");
-				goto wait;
-			} else {
-				LOG_ERR("recv() returned error: %d", len);
-			}
-
+		if (atomic_clear(&drv_data->got_evt)) {
 			continue;
 		}
 
-		switch (raw_gps_data.data_id) {
-		case NRF_GNSS_PVT_DATA_ID:
-			if (atomic_get(&drv_data->timeout_occurred) ||
-			    ((drv_data->current_cfg.nav_mode != GPS_NAV_MODE_CONTINUOUS) &&
-			    has_fix)) {
-				atomic_set(&drv_data->timeout_occurred, 0);
-				evt.type = GPS_EVT_SEARCH_STARTED;
-				notify_event(dev, &evt);
-			}
+		/* Is the GPS stopped, causing timeout? */
+		if (!atomic_get(&drv_data->is_active)) {
+			goto wait;
+		}
 
-			has_fix = false;
-
-			if (has_no_time_window(&raw_gps_data.pvt) ||
-			    pvt_deadline_missed(&raw_gps_data.pvt)) {
-				if (operation_blocked) {
-					/* Avoid spamming the logs and app. */
-					continue;
-				}
-
-				/* If LTE is used alongside GPS, PSM, eDRX or
-				 * DRX needs to be enabled for the GPS to
-				 * operate. If PSM is used, the GPS will
-				 * normally operate when active time expires.
-				 */
-				LOG_DBG("Waiting for time window to operate");
-
-				operation_blocked = true;
-				evt.type = GPS_EVT_OPERATION_BLOCKED;
-
-				notify_event(dev, &evt);
-
-				/* If GPS is blocked more than the specified
-				 * duration and GPS priority is set by the
-				 * application, GPS priority is requested.
-				 */
-				if (drv_data->current_cfg.priority) {
-					k_work_schedule(
-						&drv_data->blocked_work,
-						K_SECONDS(GPS_BLOCKED_TIMEOUT));
-				}
-
-				continue;
-			} else if (operation_blocked) {
-				/* GPS has been unblocked. */
-				LOG_DBG("GPS has time window to operate");
-
-				operation_blocked = false;
-				evt.type = GPS_EVT_OPERATION_UNBLOCKED;
-
-				notify_event(dev, &evt);
-
-				/* This may fail when the work has already
-				 * started, and the GPS priority will be
-				 * then requested anyway.
-				 */
-				k_work_cancel_delayable_sync(
-					&drv_data->blocked_work,
-					&drv_data->work_sync);
-			}
-
-			copy_pvt(&evt.pvt, &raw_gps_data.pvt);
-
-			if (is_fix(&raw_gps_data.pvt)) {
-				LOG_DBG("PVT: Position fix");
-
-				evt.type = GPS_EVT_PVT_FIX;
-				fix_timestamp = k_uptime_get();
-				has_fix = true;
-			} else {
-				evt.type = GPS_EVT_PVT;
-			}
-
-			notify_event(dev, &evt);
-			print_satellite_stats(&raw_gps_data);
-
-			break;
-		case NRF_GNSS_NMEA_DATA_ID:
-			if (operation_blocked) {
-				continue;
-			}
-
-			memcpy(evt.nmea.buf, raw_gps_data.nmea, len);
-
-			/* Don't count null terminator. */
-			evt.nmea.len = len - 1;
-
-			if (has_fix) {
-				LOG_DBG("NMEA: Position fix");
-
-				evt.type = GPS_EVT_NMEA_FIX;
-			} else {
-				evt.type = GPS_EVT_NMEA;
-			}
-
-			notify_event(dev, &evt);
-			break;
-		case NRF_GNSS_AGPS_DATA_ID:
-			LOG_DBG("A-GPS data update needed");
-
-			evt.type = GPS_EVT_AGPS_DATA_NEEDED;
-			evt.agps_request.sv_mask_ephe =
-				raw_gps_data.agps.sv_mask_ephe;
-			evt.agps_request.sv_mask_alm =
-				raw_gps_data.agps.sv_mask_alm;
-			evt.agps_request.utc =
-				raw_gps_data.agps.data_flags &
-				BIT(NRF_GNSS_AGPS_GPS_UTC_REQUEST) ? 1 : 0;
-			evt.agps_request.klobuchar =
-				raw_gps_data.agps.data_flags &
-				BIT(NRF_GNSS_AGPS_KLOBUCHAR_REQUEST) ? 1 : 0;
-			evt.agps_request.nequick =
-				raw_gps_data.agps.data_flags &
-				BIT(NRF_GNSS_AGPS_NEQUICK_REQUEST) ? 1 : 0;
-			evt.agps_request.system_time_tow =
-				raw_gps_data.agps.data_flags &
-				BIT(NRF_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST) ?
-				1 : 0;
-			evt.agps_request.position =
-				raw_gps_data.agps.data_flags &
-				BIT(NRF_GNSS_AGPS_POSITION_REQUEST) ? 1 : 0;
-			evt.agps_request.integrity =
-				raw_gps_data.agps.data_flags &
-				BIT(NRF_GNSS_AGPS_INTEGRITY_REQUEST) ? 1 : 0;
-
-			notify_event(dev, &evt);
-			continue;
-		default:
-			continue;
+		/* If blocked lets wait at least for one fix interval */
+		if (!atomic_get(&drv_data->blocked)) {
+			k_sleep(K_SECONDS(drv_data->fix_interval));
 		}
 	}
 }
@@ -474,7 +331,8 @@ static int init_thread(const struct device *dev)
 	drv_data->thread_id = k_thread_create(
 			&drv_data->thread, drv_data->thread_stack,
 			K_THREAD_STACK_SIZEOF(drv_data->thread_stack),
-			(k_thread_entry_t)gps_thread, (void *)dev, NULL, NULL,
+			(k_thread_entry_t)nrf91_gnss_thread, (void *)dev,
+			NULL, NULL,
 			K_PRIO_PREEMPT(CONFIG_NRF9160_GPS_THREAD_PRIORITY),
 			0, K_NO_WAIT);
 
@@ -535,30 +393,31 @@ static int enable_gps(const struct device *dev)
 }
 #endif
 
-static void set_nmea_mask(nrf_gnss_nmea_mask_t *nmea_mask)
+static void set_nmea_mask(uint16_t *nmea_mask)
 {
 	*nmea_mask = 0;
 
 #ifdef CONFIG_NRF9160_GPS_NMEA_GSV
-	*nmea_mask |= NRF_GNSS_NMEA_GSV_MASK;
+	*nmea_mask |= NRF_MODEM_GNSS_NMEA_GSV_MASK;
 #endif
 #ifdef CONFIG_NRF9160_GPS_NMEA_GSA
-	*nmea_mask |= NRF_GNSS_NMEA_GSA_MASK;
+	*nmea_mask |= NRF_MODEM_GNSS_NMEA_GSA_MASK;
 #endif
 #ifdef CONFIG_NRF9160_GPS_NMEA_GLL
-	*nmea_mask |= NRF_GNSS_NMEA_GLL_MASK;
+	*nmea_mask |= NRF_MODEM_GNSS_NMEA_GLL_MASK;
 #endif
 #ifdef CONFIG_NRF9160_GPS_NMEA_GGA
-	*nmea_mask |= NRF_GNSS_NMEA_GGA_MASK;
+	*nmea_mask |= NRF_MODEM_GNSS_NMEA_GGA_MASK;
 #endif
 #ifdef CONFIG_NRF9160_GPS_NMEA_RMC
-	*nmea_mask |= NRF_GNSS_NMEA_RMC_MASK;
+	*nmea_mask |= NRF_MODEM_GNSS_NMEA_RMC_MASK;
 #endif
 }
 
 static int parse_cfg(struct gps_config *cfg_src,
 		     struct nrf9160_gps_config *cfg_dst)
 {
+
 	switch (cfg_src->nav_mode) {
 	case GPS_NAV_MODE_SINGLE_FIX:
 		cfg_dst->interval = 0;
@@ -584,29 +443,78 @@ static int parse_cfg(struct gps_config *cfg_src,
 	}
 
 	if (cfg_src->delete_agps_data) {
-		cfg_dst->delete_mask = 0x7F;
+		/* TCXO frequency offset should not be cleared because it may have a big impact on
+		 * performance. It's not something which is downloaded from satellite broadcast or
+		 * an AGPS server, but something the device "learns" runtime.
+		 */
+		cfg_dst->delete_mask =
+				NRF_MODEM_GNSS_DELETE_EPHEMERIDES |
+				NRF_MODEM_GNSS_DELETE_ALMANACS |
+				NRF_MODEM_GNSS_DELETE_IONO_CORRECTION_DATA |
+				NRF_MODEM_GNSS_DELETE_LAST_GOOD_FIX |
+				NRF_MODEM_GNSS_DELETE_GPS_TOW |
+				NRF_MODEM_GNSS_DELETE_GPS_WEEK |
+				NRF_MODEM_GNSS_DELETE_UTC_DATA
+				/* NRF_MODEM_GNSS_DELETE_TCXO_OFFSET not set */
+				;
 	}
 
 	set_nmea_mask(&cfg_dst->nmea_mask);
 
 	if (cfg_src->power_mode == GPS_POWER_MODE_PERFORMANCE) {
-		cfg_dst->power_mode = NRF_GNSS_PSM_DUTY_CYCLING_PERFORMANCE;
+		cfg_dst->power_mode = NRF_MODEM_GNSS_PSM_DUTY_CYCLING_PERFORMANCE;
 	} else if (cfg_src->power_mode == GPS_POWER_MODE_SAVE) {
-		cfg_dst->power_mode = NRF_GNSS_PSM_DUTY_CYCLING_POWER;
+		cfg_dst->power_mode = NRF_MODEM_GNSS_PSM_DUTY_CYCLING_POWER;
 	}
 
 	cfg_dst->priority = cfg_src->priority;
 
-	if (cfg_src->use_case == GPS_USE_CASE_SINGLE_COLD_START) {
-		cfg_dst->use_case = NRF_GNSS_USE_CASE_SINGLE_COLD_START;
-	} else if (cfg_src->use_case == GPS_USE_CASE_MULTIPLE_HOT_START) {
-		cfg_dst->use_case = NRF_GNSS_USE_CASE_MULTIPLE_HOT_START;
+	/* Only supported mode currently */
+	cfg_dst->use_case = NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START;
+
+	if (cfg_src->accuracy == GPS_ACCURACY_LOW) {
+		cfg_dst->use_case |= NRF_MODEM_GNSS_USE_CASE_LOW_ACCURACY;
 	}
 
-	if (cfg_src->accuracy == GPS_ACCURACY_NORMAL) {
-		cfg_dst->use_case |= NRF_GNSS_USE_CASE_NORMAL_ACCURACY;
-	} else if (cfg_src->accuracy == GPS_ACCURACY_LOW) {
-		cfg_dst->use_case |= NRF_GNSS_USE_CASE_LOW_ACCURACY;
+	return 0;
+}
+
+static int nrf91_gnss_ctrl(uint32_t ctrl, struct nrf9160_gps_config *cfg)
+{
+	int retval;
+	static bool initialized; /* false by default */
+
+	if (ctrl == GNSS_START) {
+		if (initialized) {
+			goto START;
+		}
+
+		retval = nrf_modem_gnss_init();
+		retval |= nrf_modem_gnss_event_handler_set(nrf91_gnss_event_handler);
+
+		retval |= nrf_modem_gnss_nmea_mask_set(cfg->nmea_mask);
+		retval |= nrf_modem_gnss_fix_retry_set(cfg->retry);
+		retval |= nrf_modem_gnss_fix_interval_set(cfg->interval);
+		retval |= nrf_modem_gnss_power_mode_set(cfg->power_mode);
+		retval |= nrf_modem_gnss_use_case_set(cfg->use_case);
+
+		if (retval != 0) {
+			printk("Failed to initialize GNSS interface");
+			return -1;
+		}
+		initialized = true;
+START:
+		if (nrf_modem_gnss_start() != 0) {
+			printk("Failed to start GNSS\n");
+			return -1;
+		}
+	} else if (ctrl == GNSS_STOP) {
+		if (nrf_modem_gnss_stop() != 0) {
+			printk("Failed to stop GNSS\n");
+			return -1;
+		}
+	} else {
+		__ASSERT(false, "UNSUPPORTED command");
 	}
 
 	return 0;
@@ -614,27 +522,27 @@ static int parse_cfg(struct gps_config *cfg_src,
 
 static int start(const struct device *dev, struct gps_config *cfg)
 {
-	int retval, err;
+	int err;
 	struct gps_drv_data *drv_data = dev->data;
-	struct nrf9160_gps_config gps_cfg = { 0 };
+	struct nrf9160_gps_config gnss_cfg = { 0 };
 
 	if (atomic_get(&drv_data->is_shutdown) == 1) {
 		return -EHOSTDOWN;
 	}
 
 	if (atomic_get(&drv_data->is_active)) {
-		LOG_DBG("GPS is already active. Clean up before restart");
+		LOG_DBG("GNSS is already active. Clean up before restart");
 		cancel_works(drv_data);
 	}
 
 	if (atomic_get(&drv_data->is_init) != 1) {
-		LOG_WRN("GPS must be initialized first");
+		LOG_WRN("GNSS must be initialized first");
 		return -ENODEV;
 	}
 
-	err = parse_cfg(cfg, &gps_cfg);
+	err = parse_cfg(cfg, &gnss_cfg);
 	if (err) {
-		LOG_ERR("Invalid GPS configuration");
+		LOG_ERR("Invalid GNSS configuration");
 		return err;
 	}
 
@@ -646,119 +554,44 @@ static int start(const struct device *dev, struct gps_config *cfg)
 
 #ifdef CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
 	if (enable_gps(dev) != 0) {
-		LOG_ERR("Failed to enable GPS");
+		LOG_ERR("Failed to enable GNSS");
 		return -EIO;
 	}
 #endif
+	/* Needs to be set before the event handler is registered */
+	dev_hook = (struct device *)dev;
 
-set_configuration:
-	retval = nrf_setsockopt(drv_data->socket,
-				NRF_SOL_GNSS,
-				NRF_SO_GNSS_FIX_RETRY,
-				&gps_cfg.retry,
-				sizeof(gps_cfg.retry));
-
-	if ((retval == -1) && ((errno == EFAULT) || (errno == EBADF))) {
-		LOG_DBG("Failed to set fix retry value, "
-			"will try to re-init GPS service");
-
-		nrf_close(drv_data->socket);
-		if (open_socket(drv_data) != 0) {
-			LOG_ERR("Failed to re-init GPS service");
-			return -EIO;
-		}
-
-		goto set_configuration;
-	} else if (retval != 0) {
-		LOG_ERR("Failed to set fix retry value: %d", gps_cfg.retry);
-		return -EIO;
+	err = nrf91_gnss_ctrl(GNSS_START, &gnss_cfg);
+	if (err) {
+		return err;
 	}
 
-	retval = nrf_setsockopt(drv_data->socket,
-				NRF_SOL_GNSS,
-				NRF_SO_GNSS_FIX_INTERVAL,
-				&gps_cfg.interval,
-				sizeof(gps_cfg.interval));
-	if (retval != 0) {
-		LOG_ERR("Failed to set fix interval value");
-		return -EIO;
-	}
-
-	retval = nrf_setsockopt(drv_data->socket,
-				NRF_SOL_GNSS,
-				NRF_SO_GNSS_NMEA_MASK,
-				&gps_cfg.nmea_mask,
-				sizeof(gps_cfg.nmea_mask));
-	if (retval != 0) {
-		LOG_ERR("Failed to set nmea mask");
-		return -EIO;
-	}
-
-	if (gps_cfg.power_mode != NRF_GNSS_PSM_DISABLED) {
-		retval = nrf_setsockopt(drv_data->socket,
-					NRF_SOL_GNSS,
-					NRF_SO_GNSS_POWER_SAVE_MODE,
-					&gps_cfg.power_mode,
-					sizeof(gps_cfg.power_mode));
-		if (retval != 0) {
-			LOG_ERR("Failed to set GPS power mode");
-			return -EIO;
-		}
-	}
-
-	if (gps_cfg.use_case) {
-		retval = nrf_setsockopt(drv_data->socket,
-					NRF_SOL_GNSS,
-					NRF_SO_GNSS_USE_CASE,
-					&gps_cfg.use_case,
-					sizeof(gps_cfg.use_case));
-		if (retval) {
-			LOG_ERR("Failed to set use case and accuracy");
-			return -EIO;
-		}
-	}
-
-	/* The GPS is started before setting NRF_SO_GNSS_ENABLE_PRIORITY or
-	 * NRF_SO_GNSS_DISABLE_PRIORITY as that's currently a requirement
-	 * in Modem library.
-	 */
-	retval = nrf_setsockopt(drv_data->socket,
-				NRF_SOL_GNSS,
-				NRF_SO_GNSS_START,
-				&gps_cfg.delete_mask,
-				sizeof(gps_cfg.delete_mask));
-	if (retval != 0) {
-		LOG_ERR("Failed to start GPS");
-		return -EIO;
-	}
-
-	if (!gps_cfg.priority) {
-		retval = gps_priority_set(drv_data, false);
-		if (retval != 0) {
-			LOG_ERR("Failed to set GPS priority, error: %d",
-				retval);
-			return retval;
-		}
-	}
 
 	atomic_set(&drv_data->is_active, 1);
+	atomic_set(&drv_data->fix_interval, gnss_cfg.interval);
 	atomic_set(&drv_data->timeout_occurred, 0);
 	k_sem_give(&drv_data->thread_run_sem);
 
-	LOG_DBG("GPS operational");
+	LOG_DBG("GNSS operational");
 
-	return retval;
+	return 0;
 }
 
 static int setup(const struct device *dev)
 {
 	struct gps_drv_data *drv_data = dev->data;
 
-	drv_data->socket = -1;
 	drv_data->dev = dev;
 
 	atomic_set(&drv_data->is_active, 0);
 	atomic_set(&drv_data->timeout_occurred, 0);
+	drv_data->fix_timestamp = INT64_MAX; /* In the future -> no fix yet */
+	atomic_clear(&drv_data->got_evt);
+	atomic_clear(&drv_data->has_fix);
+	atomic_clear(&drv_data->nmea_nxt);
+	atomic_clear(&drv_data->nmea_fix_idx);
+	atomic_set(&drv_data->blocked, false);
+	memset(&drv_data->last_pvt, 0, sizeof(struct nrf_modem_gnss_pvt_data_frame));
 
 	return 0;
 }
@@ -794,54 +627,32 @@ static int configure_antenna(void)
 	return err;
 }
 
-static int stop_gps(const struct device *dev, bool is_timeout)
-{
-	struct gps_drv_data *drv_data = dev->data;
-	nrf_gnss_delete_mask_t delete_mask = 0;
-	int retval;
-
-	if (is_timeout) {
-		LOG_DBG("Stopping GPS due to timeout");
-	} else {
-		LOG_DBG("Stopping GPS");
-	}
-
-	atomic_set(&drv_data->is_active, 0);
-
-	retval = nrf_setsockopt(drv_data->socket,
-				NRF_SOL_GNSS,
-				NRF_SO_GNSS_STOP,
-				&delete_mask,
-				sizeof(nrf_gnss_delete_mask_t));
-	if (retval != 0) {
-		LOG_ERR("Failed to stop GPS");
-		return -EIO;
-	}
-
-	return 0;
-}
-
 static int stop(const struct device *dev)
 {
 	int err = 0;
 	struct gps_drv_data *drv_data = dev->data;
 
-	if (atomic_get(&drv_data->is_shutdown) == 1) {
+	k_sem_reset(&drv_data->thread_run_sem);
+
+	if (atomic_get(&drv_data->is_shutdown)) {
 		return -EHOSTDOWN;
 	}
 
 	cancel_works(drv_data);
 
-	if (atomic_get(&drv_data->is_active) == 0) {
+	if (!atomic_get(&drv_data->is_active)) {
 		/* The GPS is already stopped, attempting to stop it again would
 		 * result in an error. Instead, notify that it's stopped.
 		 */
 		goto notify;
 	}
 
-	err = stop_gps(dev, false);
+	atomic_clear(&drv_data->is_active);
+
+	err = nrf91_gnss_ctrl(GNSS_STOP, NULL);
 	if (err) {
-		return err;
+		LOG_ERR("Failed to stop GPS");
+		return -EIO;
 	}
 
 notify:
@@ -866,27 +677,172 @@ static void stop_work_fn(struct k_work *work)
 	notify_event(dev, &evt);
 }
 
+static void pvt_ntf_work_fn(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gps_drv_data *drv_data =
+		CONTAINER_OF(dwork, struct gps_drv_data, pvt_ntf_work);
+	const struct device *dev = drv_data->dev;
+	struct gps_event evt = {};
+
+	nrf_modem_gnss_read(&drv_data->last_pvt,
+		      sizeof(drv_data->last_pvt),
+		      NRF_MODEM_GNSS_EVT_PVT);
+
+	copy_pvt(&evt.pvt, &drv_data->last_pvt);
+
+	if (is_fix(&drv_data->last_pvt)) {
+		evt.type = GPS_EVT_PVT_FIX;
+		drv_data->fix_timestamp = k_uptime_get();
+		atomic_set(&drv_data->has_fix, true);
+	} else {
+		evt.type = GPS_EVT_PVT;
+	}
+
+	notify_event(dev, &evt);
+
+	k_work_schedule(&drv_data->sat_stats_work, K_SECONDS(1));
+}
+
+static void fix_ntf_work_fn(struct k_work *work)
+{
+	(void)work;
+
+	/* Fix obtained, no need for increased priority anymore */
+	if (nrf_modem_gnss_prio_mode_disable() != 0) {
+		LOG_ERR("Failed to restore normal GPS priority");
+	} else {
+		LOG_DBG("GPS priority normal");
+	}
+}
+
+#ifdef CONFIG_NRF9160_AGPS
+static void agps_ntf_work_fn(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gps_drv_data *drv_data =
+			CONTAINER_OF(dwork, struct gps_drv_data, agps_ntf_work);
+	const struct device *dev = drv_data->dev;
+	struct gps_event evt = {};
+
+	evt.type = GPS_EVT_AGPS_DATA_NEEDED;
+	evt.agps_request.sv_mask_ephe = drv_data->last_agps.sv_mask_ephe;
+	evt.agps_request.sv_mask_alm = drv_data->last_agps.sv_mask_alm;
+	evt.agps_request.utc =
+		drv_data->last_agps.data_flags & NRF_MODEM_GNSS_AGPS_GPS_UTC_REQUEST ? 1 : 0;
+	evt.agps_request.klobuchar =
+		drv_data->last_agps.data_flags & NRF_MODEM_GNSS_AGPS_KLOBUCHAR_REQUEST ? 1 : 0;
+	evt.agps_request.nequick =
+		drv_data->last_agps.data_flags & NRF_MODEM_GNSS_AGPS_NEQUICK_REQUEST ? 1 : 0;
+	evt.agps_request.system_time_tow =
+		drv_data->last_agps.data_flags & NRF_MODEM_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST ?
+		1 : 0;
+	evt.agps_request.position =
+		drv_data->last_agps.data_flags & NRF_MODEM_GNSS_AGPS_POSITION_REQUEST ? 1 : 0;
+	evt.agps_request.integrity =
+		drv_data->last_agps.data_flags & NRF_MODEM_GNSS_AGPS_INTEGRITY_REQUEST ? 1 : 0;
+
+	notify_event(dev, &evt);
+}
+#endif
+
+static void sat_stats_work_fn(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gps_drv_data *drv_data =
+		CONTAINER_OF(dwork, struct gps_drv_data, sat_stats_work);
+
+
+	tracking_stats(&drv_data->last_pvt, drv_data->fix_timestamp);
+}
+
+static void nmea_ntf_work_fn(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gps_drv_data *drv_data =
+		CONTAINER_OF(dwork, struct gps_drv_data, nmea_ntf_work);
+	const struct device *dev = drv_data->dev;
+	struct gps_event evt;
+	struct nrf_modem_gnss_nmea_data_frame *data;
+	int retval;
+
+	retval = k_msgq_get(&nmea_q, &data, K_NO_WAIT);
+
+	if (retval) {
+		return;
+	}
+
+	memcpy(evt.nmea.buf, data->nmea_str, GPS_NMEA_SENTENCE_MAX_LENGTH);
+	evt.nmea.len = strlen(evt.nmea.buf);
+	k_free(data);
+
+	if (atomic_get(&drv_data->has_fix)) {
+		LOG_DBG("NMEA fix data: %s", evt.nmea.buf);
+		evt.type = GPS_EVT_NMEA_FIX;
+	} else {
+		evt.type = GPS_EVT_NMEA;
+	}
+
+	notify_event(dev, &evt);
+}
+
+static void blocked_ntf_work_fn(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gps_drv_data *drv_data =
+		CONTAINER_OF(dwork, struct gps_drv_data, blocked_ntf_work);
+	const struct device *dev = drv_data->dev;
+	struct gps_event evt = { .type = GPS_EVT_OPERATION_BLOCKED};
+
+	/* Need to use another opaque item than what this work queue item is using itself */
+	k_work_cancel_delayable_sync(&drv_data->timeout_work, &drv_data->nested_work_sync);
+	k_work_cancel_delayable_sync(&drv_data->unblocked_ntf_work, &drv_data->nested_work_sync);
+
+	k_work_reschedule(
+		&drv_data->bump_priority_work,
+		K_SECONDS(CONFIG_NRF9160_GPS_PRIORITY_WINDOW_TIMEOUT_SEC));
+
+	notify_event(dev, &evt);
+}
+
+static void unblocked_ntf_work_fn(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gps_drv_data *drv_data =
+		CONTAINER_OF(dwork, struct gps_drv_data, unblocked_ntf_work);
+	const struct device *dev = drv_data->dev;
+	struct gps_event evt = { .type = GPS_EVT_OPERATION_UNBLOCKED};
+
+	/* Need to use another opaque item than what this work queue item is using itself */
+	k_work_cancel_delayable_sync(&drv_data->bump_priority_work, &drv_data->nested_work_sync);
+
+	notify_event(dev, &evt);
+}
+
 static void timeout_work_fn(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct gps_drv_data *drv_data =
-		CONTAINER_OF(work, struct gps_drv_data, timeout_work);
+		CONTAINER_OF(dwork, struct gps_drv_data, timeout_work);
 	const struct device *dev = drv_data->dev;
 	struct gps_event evt = {
 		.type = GPS_EVT_SEARCH_TIMEOUT
 	};
-	atomic_set(&drv_data->timeout_occurred, 1);
-	notify_event(dev, &evt);
+
+	if (!atomic_get(&drv_data->blocked)) {
+		atomic_set(&drv_data->timeout_occurred, 1);
+		notify_event(dev, &evt);
+	}
 }
 
-static void blocked_work_fn(struct k_work *work)
+static void bump_priority_work_fn(struct k_work *work)
 {
-	int retval;
-	struct gps_drv_data *drv_data =
-		CONTAINER_OF(work, struct gps_drv_data, blocked_work);
+	(void)work;
 
-	retval = gps_priority_set(drv_data, true);
-	if (retval != 0) {
-		LOG_ERR("Failed to set GPS priority, error: %d", retval);
+	if (nrf_modem_gnss_prio_mode_enable() != 0) {
+		LOG_ERR("Failed to set GPS priority");
+	} else {
+		LOG_DBG("GPS priority increased");
 	}
 }
 
@@ -894,11 +850,40 @@ static int agps_write(const struct device *dev, enum gps_agps_type type,
 		      void *data, size_t data_len)
 {
 	int err;
-	struct gps_drv_data *drv_data = dev->data;
-	nrf_gnss_agps_data_type_t data_type = type_lookup_gps2socket[type];
+	int nrf_type;
+	(void)dev->data; // Was used with GNSS API v1
 
-	err = nrf_sendto(drv_data->socket, data, data_len, 0, &data_type,
-			 sizeof(data_type));
+	switch (type) {
+	case GPS_AGPS_UTC_PARAMETERS:
+		nrf_type = NRF_MODEM_GNSS_AGPS_UTC_PARAMETERS;
+		break;
+	case GPS_AGPS_EPHEMERIDES:
+		nrf_type = NRF_MODEM_GNSS_AGPS_EPHEMERIDES;
+		break;
+	case GPS_AGPS_ALMANAC:
+		nrf_type = NRF_MODEM_GNSS_AGPS_ALMANAC;
+		break;
+	case GPS_AGPS_KLOBUCHAR_CORRECTION:
+		nrf_type = NRF_MODEM_GNSS_AGPS_KLOBUCHAR_IONOSPHERIC_CORRECTION;
+		break;
+	case GPS_AGPS_NEQUICK_CORRECTION:
+		nrf_type = NRF_MODEM_GNSS_AGPS_NEQUICK_IONOSPHERIC_CORRECTION;
+		break;
+	case GPS_AGPS_GPS_SYSTEM_CLOCK_AND_TOWS:
+		nrf_type = NRF_MODEM_GNSS_AGPS_GPS_SYSTEM_CLOCK_AND_TOWS;
+		break;
+	case GPS_AGPS_LOCATION:
+		nrf_type = NRF_MODEM_GNSS_AGPS_LOCATION;
+		break;
+	case GPS_AGPS_INTEGRITY:
+		nrf_type = NRF_MODEM_GNSS_AGPS_INTEGRITY;
+		break;
+	default:
+		LOG_ERR("Invalid argument");
+		return -EINVAL;
+	};
+
+	err = nrf_modem_gnss_agps_write(data, data_len, nrf_type);
 	if (err < 0) {
 		LOG_ERR("Failed to send A-GPS data to modem, errno: %d", errno);
 		return -errno;
@@ -932,18 +917,22 @@ static int init(const struct device *dev, gps_event_handler_t handler)
 		return err;
 	}
 
-	if (drv_data->socket < 0) {
-		int ret = open_socket(drv_data);
-
-		if (ret != 0) {
-			return ret;
-		}
-	}
-
 	k_work_init(&drv_data->stop_work, stop_work_fn);
+	k_work_init_delayable(&drv_data->bump_priority_work,
+			      bump_priority_work_fn);
 	k_work_init_delayable(&drv_data->timeout_work, timeout_work_fn);
-	k_work_init_delayable(&drv_data->blocked_work, blocked_work_fn);
+	k_work_init_delayable(&drv_data->pvt_ntf_work, pvt_ntf_work_fn);
+	k_work_init(&drv_data->fix_ntf_work, fix_ntf_work_fn);
+	k_work_init_delayable(&drv_data->sat_stats_work, sat_stats_work_fn);
+	k_work_init_delayable(&drv_data->nmea_ntf_work, nmea_ntf_work_fn);
+	k_work_init_delayable(&drv_data->blocked_ntf_work, blocked_ntf_work_fn);
+	k_work_init_delayable(&drv_data->unblocked_ntf_work,
+			      unblocked_ntf_work_fn);
+#ifdef CONFIG_NRF9160_AGPS
+	k_work_init_delayable(&drv_data->agps_ntf_work, agps_ntf_work_fn);
+#endif
 	k_sem_init(&drv_data->thread_run_sem, 0, 1);
+	k_sem_init(&drv_data->gps_evt_sem, 0, 1);
 
 	err = init_thread(dev);
 	if (err) {
@@ -957,9 +946,7 @@ static int init(const struct device *dev, gps_event_handler_t handler)
 	return 0;
 }
 
-static struct gps_drv_data gps_drv_data = {
-	.socket = -1,
-};
+static struct gps_drv_data gps_drv_data = {};
 
 static const struct gps_driver_api gps_api_funcs = {
 	.init = init,

--- a/include/supl_os_client.h
+++ b/include/supl_os_client.h
@@ -8,6 +8,7 @@
 #define SUPL_OS_CLIENT_H_
 
 #include <nrf_socket.h>
+#include <nrf_modem_gnss.h>
 #include <supl_session.h>
 
 /**
@@ -23,12 +24,12 @@
  * @brief Start a SUPL session
  *
  * @param[in] agps_request This contain the information about the AGPS data
- *                         that the GPS module is requesting from the server.
+ *                         that the GNSS module is requesting from the server.
  *
  * @return 0  SUPL session was successful.
  *         <0 SUPL session failed.
  */
-int supl_session(const nrf_gnss_agps_data_frame_t *const agps_request);
+int supl_session(const struct nrf_modem_gnss_agps_data_frame *const agps_request);
 
 /**
  * @brief Setup the API and the buffers required by

--- a/lib/supl/os/supl_os_client.c
+++ b/lib/supl/os/supl_os_client.c
@@ -115,7 +115,7 @@ static int create_device_id(void)
 	return 0;
 }
 
-int supl_session(const nrf_gnss_agps_data_frame_t *const agps_request)
+int supl_session(const struct nrf_modem_gnss_agps_data_frame *const agps_request)
 {
 	create_device_id();
 


### PR DESCRIPTION
Updates Asset Tracker to use the v2 of the GNSS API

**NOTE** This PR won't add support for the new nRF modem GNSS events - which got introduced by the new modem firmware v1.3.0 - but will gracefully discard all unsupported events.