### PR TITLE
zigbee: Fix static analysis issues

### DIFF
--- a/subsys/zigbee/lib/zigbee_app_utils/zigbee_app_utils.c
+++ b/subsys/zigbee/lib/zigbee_app_utils/zigbee_app_utils.c
@@ -116,7 +116,7 @@ bool parse_hex_str(char const *in_str, uint8_t in_str_len, uint8_t *out_buff,
 	memset(out_buff, 0, out_buff_size);
 
 	while (i < in_str_len) {
-		uint8_t nibble;
+		uint8_t nibble = 0;
 
 		if (char2hex(*in_str, &nibble)) {
 			break;

--- a/subsys/zigbee/osif/zb_nrf_nvram.c
+++ b/subsys/zigbee/osif/zb_nrf_nvram.c
@@ -172,7 +172,7 @@ zb_bool_t zb_osif_prod_cfg_check_presence(void)
 {
 	zb_uint8_t hdr[ZB_OSIF_PRODUCTION_CONFIG_MAGIC_SIZE] =
 		ZB_OSIF_PRODUCTION_CONFIG_MAGIC;
-	zb_uint8_t buffer[ZB_OSIF_PRODUCTION_CONFIG_MAGIC_SIZE];
+	zb_uint8_t buffer[ZB_OSIF_PRODUCTION_CONFIG_MAGIC_SIZE] = {0};
 
 	int err = flash_area_read(fa_pc, 0, buffer,
 				  ZB_OSIF_PRODUCTION_CONFIG_MAGIC_SIZE);

--- a/subsys/zigbee/osif/zb_nrf_platform.c
+++ b/subsys/zigbee/osif/zb_nrf_platform.c
@@ -549,7 +549,7 @@ uint32_t zigbee_event_poll(uint32_t timeout_us)
 					 &zigbee_sig),
 	};
 
-	unsigned int signaled;
+	unsigned int signaled = 0;
 	int result;
 	/* Store timestamp of event polling start. */
 	int64_t timestamp_poll_start = k_uptime_ticks();

--- a/subsys/zigbee/osif/zb_nrf_serial.c
+++ b/subsys/zigbee/osif/zb_nrf_serial.c
@@ -110,7 +110,7 @@ static void uart_rx_timeout(struct k_timer *dummy)
 static void handle_rx_ready_evt(const struct device *dev)
 {
 	int recv_len = 0;
-	uint8_t buffer[CONFIG_ZIGBEE_UART_RX_BUF_LEN];
+	uint8_t buffer[CONFIG_ZIGBEE_UART_RX_BUF_LEN] = {0};
 
 	/* Copy data to the user's buffer. */
 	if (uart_rx_buf && (uart_rx_buf_offset < uart_rx_buf_len)) {

--- a/subsys/zigbee/osif/zb_nrf_timer.c
+++ b/subsys/zigbee/osif/zb_nrf_timer.c
@@ -113,7 +113,7 @@ zb_uint32_t zb_osif_timer_get(void)
 	zb_uint32_t time_cur;
 
 	if (zb_osif_timer_is_on() == ZB_TRUE) {
-		uint32_t ticks;
+		uint32_t ticks = 0;
 		(void)counter_get_value(zb_timer.device, &ticks);
 		time_cur = (zb_uint32_t)counter_ticks_to_us(zb_timer.device,
 							    ticks);


### PR DESCRIPTION
Add initial values for uninitialized variables in zigbee subsys.

Signed-off-by: Filip Zajdel <filip.zajdel@nordicsemi.no>