### PR TITLE
docs: state that 4MB ext flash is requiref for FOTA FMFU

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -76,3 +76,5 @@
    If you are updating from the |NCS| version earlier than v1.5.0, see :ref:`gs_installing_tools` for installation instructions.
 
 .. |NSIB| replace:: nRF Secure Immutable Bootloader
+
+.. |external_flash_size| replace:: external flash memory with minimum 4MB

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -248,7 +248,7 @@ To perform a FOTA upgrade, complete the following steps:
       * |fota_upgrades_req_mcuboot|
       * If you want to upgrade the upgradable bootloader, the :ref:`bootloader` must be used (:option:`CONFIG_SECURE_BOOT`).
       * If you want to upgrade the modem firmware through modem delta updates, neither MCUboot nor the immutable bootloader are required, because the modem firmware upgrade is handled by the modem itself.
-      * If you want to perform a full modem firmware upgrade, an external flash memory with minimum 2MB is required.
+      * If you want to perform a full modem firmware upgrade, an |external_flash_size| is required.
 
 #. Create a binary file that contains the new image.
       This step does not apply for upgrades of the modem firmware.

--- a/include/dfu/dfu_target.rst
+++ b/include/dfu/dfu_target.rst
@@ -68,7 +68,7 @@ Full modem upgrades
 ===================
 
 .. note::
-   An external flash memory device of minimum 2MB is required for this target.
+   An |external_flash_size| is required for this target.
 
 This type of firmware upgrade supports updating the modem firmware using the serialized firmware bundled in the zip file of the modem firmware release.
 This DFU target will download the serialized modem firmware to an external flash memory, which is required for this type of upgrade.

--- a/samples/nrf9160/http_update/full_modem_update/README.rst
+++ b/samples/nrf9160/http_update/full_modem_update/README.rst
@@ -13,7 +13,7 @@ The sample downloads a modem firmware signed by Nordic and performs the firmware
 Overview
 ********
 
-An external flash memory with a minimum of 2MB of free space is required to perform a full modem update.
+An |external_flash_size| of free space is required to perform a full modem update.
 Hence, only versions 0.14.0 and later of the nrf9160 DK support this sample as the prior versions do not have any external flash memory.
 
 The sample connects to a remote HTTP server to download a signed version of the modem firmware, using the :ref:`lib_fota_download` library.


### PR DESCRIPTION
Ref: NCSDK-9506
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>