### PR TITLE
Cast pointers passed to the LOG macro

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_conn_params.c
+++ b/applications/nrf_desktop/src/modules/ble_conn_params.c
@@ -124,7 +124,7 @@ static void update_peer_conn_params(const struct connected_peer *peer)
 
 	if (err) {
 		LOG_WRN("Cannot update conn parameters for peer %p (err:%d)",
-			peer, err);
+			(void *)peer, err);
 		/* Retry to update the connection parameters after an error. */
 		k_delayed_work_submit(&conn_params_update,
 				      CONN_PARAMS_ERROR_TIMEOUT);

--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -485,8 +485,8 @@ static int register_peripheral(struct bt_gatt_dm *dm, const uint8_t *hwid,
 	__ASSERT_NO_MSG(hwid_len == HWID_LEN);
 	memcpy(per->hwid, hwid, hwid_len);
 
-	LOG_INF("Peripheral %p registered and linked to %p", per,
-		get_subscriber(per));
+	LOG_INF("Peripheral %p registered and linked to %p", (void *)per,
+		(void *)get_subscriber(per));
 
 	return err;
 }
@@ -854,7 +854,7 @@ static bool handle_config_event(struct config_event *event)
 
 static void disconnect_peripheral(struct hids_peripheral *per)
 {
-	LOG_INF("Peripheral %p disconnected", per);
+	LOG_INF("Peripheral %p disconnected", (void *)per);
 
 	struct bt_hogp_rep_info *rep = NULL;
 

--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -423,7 +423,7 @@ static void clear_axes(struct axis_data *axes)
 
 static void clear_report_data(struct report_data *rd)
 {
-	LOG_INF("Clear report data (%p)", rd);
+	LOG_INF("Clear report data (%p)", (void *)rd);
 
 	clear_axes(&rd->axes);
 	clear_items(&rd->items);

--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -389,7 +389,8 @@ static void broadcast_subscription_change(struct usb_hid_device *usb_hid)
 		usb_hid->report_enabled[REPORT_ID_BOOT_KEYBOARD] = new_boot_enabled;
 	}
 
-	LOG_INF("USB HID %p %sabled", usb_hid, (state == USB_STATE_ACTIVE) ? ("en"):("dis"));
+	LOG_INF("USB HID %p %sabled", (void *)usb_hid,
+		(state == USB_STATE_ACTIVE) ? ("en"):("dis"));
 	if (state == USB_STATE_ACTIVE) {
 		LOG_INF("%s_PROTOCOL active", usb_hid->hid_protocol ? "REPORT" : "BOOT");
 	}

--- a/applications/nrf_desktop/src/util/config_channel_transport.c
+++ b/applications/nrf_desktop/src/util/config_channel_transport.c
@@ -205,13 +205,13 @@ int config_channel_transport_set(struct config_channel_transport *transport,
 	__ASSERT_NO_MSG(transport->state != CONFIG_CHANNEL_TRANSPORT_DISABLED);
 
 	if (transport->state == CONFIG_CHANNEL_TRANSPORT_WAIT_RSP) {
-		LOG_WRN("Transport %p busy", transport);
+		LOG_WRN("Transport %p busy", (void *)transport);
 		return -EBUSY;
 	}
 
 	if (transport->state == CONFIG_CHANNEL_TRANSPORT_RSP_READY) {
 		LOG_WRN("Host ignored previous response (transport: %p)",
-			transport);
+			(void *)transport);
 	}
 
 	struct config_event *event =

--- a/samples/nrf5340/multiprotocol_rpmsg/src/main.c
+++ b/samples/nrf5340/multiprotocol_rpmsg/src/main.c
@@ -161,7 +161,7 @@ static int hci_rpmsg_send(struct net_buf *buf)
 {
 	uint8_t pkt_indicator;
 
-	LOG_DBG("buf %p type %u len %u", buf, bt_buf_get_type(buf),
+	LOG_DBG("buf %p type %u len %u", (void *)buf, bt_buf_get_type(buf),
 		buf->len);
 
 	LOG_HEXDUMP_DBG(buf->data, buf->len, "Controller buffer:");

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -325,7 +325,7 @@ static void model_bound_cb(uint16_t addr, struct bt_mesh_model *model,
 	int i;
 
 	LOG_DBG("remote addr 0x%04x key_idx 0x%04x model %p",
-		addr, key_idx, model);
+		addr, key_idx, (void *)model);
 
 	for (i = 0; i < ARRAY_SIZE(model_bound); i++) {
 		if (!model_bound[i].model) {
@@ -346,7 +346,7 @@ static void model_unbound_cb(uint16_t addr, struct bt_mesh_model *model,
 	int i;
 
 	LOG_DBG("remote addr 0x%04x key_idx 0x%04x model %p",
-		addr, key_idx, model);
+		addr, key_idx, (void *)model);
 
 	for (i = 0; i < ARRAY_SIZE(model_bound); i++) {
 		if (model_bound[i].model == model) {


### PR DESCRIPTION
Cast the pointer to (void*) before passing it to LOG macro.