### PR TITLE
HomeKit: update west manifest - HAP heap optimize

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
       path: modules/lib/cddl-gen
     - name: homekit
       repo-path: sdk-homekit
-      revision: 40ae4b9225f051a3e02b8d73ce80389b462fee01
+      revision: pull/132/head
       groups:
       - homekit
     - name: find-my


### PR DESCRIPTION
[KRKNWK-10087]
restore size of the heap for messages in HAP.
This size caused an issue with missing memory for new message in stress test.
Timout has been added in case where there is not enought memory.

Signed-off-by: Robert Gałat <robert.galat@nordicsemi.no>

- [ ] https://github.com/nrfconnect/sdk-homekit/pull/132