### PR TITLE
caf: sensor_sampler: Add sensor state event.

### DIFF
--- a/include/caf/events/sensor_event.h
+++ b/include/caf/events/sensor_event.h
@@ -19,6 +19,12 @@
 extern "C" {
 #endif
 
+enum sensor_state {
+	SENSOR_STATE_DISABLED,
+	SENSOR_STATE_SLEEP,
+	SENSOR_STATE_ACTIVE,
+	SENSOR_STATE_ERROR,
+};
 
 /** @brief Sensor event. */
 struct sensor_event {

--- a/include/caf/events/sensor_event.h
+++ b/include/caf/events/sensor_event.h
@@ -19,12 +19,32 @@
 extern "C" {
 #endif
 
+/** Sensor state list. */
+#define SENSOR_STATE_LIST	\
+	UTIL_EXPAND(		\
+	X(DISABLED)		\
+	X(SLEEP)		\
+	X(ACTIVE)		\
+	X(ERROR))		\
+
+/** Sensor states. */
 enum sensor_state {
-	SENSOR_STATE_DISABLED,
-	SENSOR_STATE_SLEEP,
-	SENSOR_STATE_ACTIVE,
-	SENSOR_STATE_ERROR,
+#define X(name) _CONCAT(SENSOR_STATE_, name),
+	SENSOR_STATE_LIST
+#undef X
+
+	SENSOR_STATE_COUNT
 };
+
+/** @brief Sensor state event. */
+struct sensor_state_event {
+	struct event_header header; /**< Event header. */
+
+	const char *descr; /**< Description of the sensor event. */
+	enum sensor_state state; /**< Sensor satate. */
+};
+
+EVENT_TYPE_DECLARE(sensor_state_event);
 
 /** @brief Sensor event. */
 struct sensor_event {

--- a/subsys/caf/events/Kconfig
+++ b/subsys/caf/events/Kconfig
@@ -118,5 +118,15 @@ config CAF_INIT_LOG_SENSOR_EVENTS
 	depends on CAF_SENSOR_EVENTS
 	depends on LOG
 	default y
+	help
+	  Log sensor events, used to notify about sensor measured data.
+
+config CAF_INIT_LOG_SENSOR_STATE_EVENTS
+	bool "Log sensor state events"
+	depends on CAF_SENSOR_EVENTS
+	depends on LOG
+	default y
+	help
+	  Log sensor state events, used to notify about sensor state change.
 
 endmenu

--- a/subsys/caf/events/sensor_event.c
+++ b/subsys/caf/events/sensor_event.c
@@ -9,6 +9,12 @@
 #include <caf/events/sensor_event.h>
 
 
+static const char * const sensor_state_name[] = {
+#define X(name) STRINGIFY(name),
+	SENSOR_STATE_LIST
+#undef X
+};
+
 static int log_sensor_event(const struct event_header *eh, char *buf, size_t buf_len)
 {
 	const struct sensor_event *event = cast_sensor_event(eh);
@@ -29,3 +35,22 @@ EVENT_TYPE_DEFINE(sensor_event,
 		  IS_ENABLED(CONFIG_CAF_INIT_LOG_SENSOR_EVENTS),
 		  log_sensor_event,
 		  &sensor_event_info);
+
+
+static int log_sensor_state_event(const struct event_header *eh, char *buf, size_t buf_len)
+{
+	const struct sensor_state_event *event = cast_sensor_state_event(eh);
+
+	BUILD_ASSERT(ARRAY_SIZE(sensor_state_name) == SENSOR_STATE_COUNT,
+			 "Invalid number of elements");
+
+	__ASSERT_NO_MSG(event->state < SENSOR_STATE_COUNT);
+
+	return snprintf(buf, buf_len, "sensor:%s state:%s",
+			event->descr, sensor_state_name[event->state]);
+}
+
+EVENT_TYPE_DEFINE(sensor_state_event,
+		  IS_ENABLED(CONFIG_CAF_INIT_LOG_SENSOR_STATE_EVENTS),
+		  log_sensor_state_event,
+		  NULL);

--- a/subsys/caf/modules/sensor_sampler.c
+++ b/subsys/caf/modules/sensor_sampler.c
@@ -32,25 +32,23 @@ struct sensor_data {
 	unsigned int sleep_cnt;
 };
 
-enum state {
-	STATE_DISABLED,
-	STATE_ACTIVE,
-	STATE_ERROR
-};
-
 static struct sensor_data sensor_data[ARRAY_SIZE(sensor_configs)];
-
-static enum state state;
 
 static K_THREAD_STACK_DEFINE(sample_thread_stack, SAMPLE_THREAD_STACK_SIZE);
 static struct k_thread sample_thread;
 static struct k_sem can_sample;
 
 
-static void report_error(void)
+static void update_sensor_state(const struct sensor_config *sc, struct sensor_data *sd,
+				const enum sensor_state state)
 {
-	state = STATE_ERROR;
-	module_set_state(MODULE_STATE_ERROR);
+	struct sensor_state_event *event = new_sensor_state_event();
+
+	event->descr = sc->event_descr;
+	event->state = state;
+
+	atomic_set(&sd->state, state);
+	EVENT_SUBMIT(event);
 }
 
 static void send_sensor_event(const char *descr, const float *data, const size_t data_cnt)
@@ -74,6 +72,27 @@ static struct sensor_data *get_sensor_data(const struct device *dev)
 		}
 	}
 
+	__ASSERT_NO_MSG(false);
+
+	return NULL;
+}
+
+static const struct sensor_config *get_sensor_config(const struct device *dev)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(sensor_configs); i++) {
+		if (dev->name == sensor_configs[i].dev_name) {
+			return &sensor_configs[i];
+		}
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(sensor_configs); i++) {
+		if (strcmp(dev->name, sensor_configs[i].dev_name) == 0) {
+			return &sensor_configs[i];
+		}
+	}
+
+	__ASSERT_NO_MSG(false);
+
 	return NULL;
 }
 
@@ -88,7 +107,8 @@ static size_t get_sensor_data_cnt(const struct sensor_config *sc)
 	return data_cnt;
 }
 
-static bool is_active(const struct sensor_config *sc, const float curr, const float prev)
+static bool is_active(const struct sensor_config *sc, struct sensor_data *sd,
+		      const float curr, const float prev)
 {
 	enum act_type type = sc->trigger->activation.type;
 	float thresh = sc->trigger->activation.thresh;
@@ -103,7 +123,8 @@ static bool is_active(const struct sensor_config *sc, const float curr, const fl
 		is_active = fabs(curr - prev) > fabs(thresh);
 		break;
 	default:
-		report_error();
+		__ASSERT(false, "Invalid configuration");
+		update_sensor_state(sc, sd, SENSOR_STATE_ERROR);
 		break;
 	}
 
@@ -118,7 +139,7 @@ static bool can_sensor_sleep(const struct sensor_config *sc,
 	bool sleep = true;
 
 	for (size_t i = 0; i < data_cnt; i++) {
-		if (is_active(sc, curr[i], sd->prev[i])) {
+		if (is_active(sc, sd, curr[i], sd->prev[i])) {
 			sleep = false;
 			break;
 		}
@@ -145,50 +166,48 @@ static void trigger_handler(const struct device *dev, struct sensor_trigger *tri
 {
 	sensor_trigger_set(dev, trigger, NULL);
 
+	const struct sensor_config *sc = get_sensor_config(dev);
 	struct sensor_data *sd = get_sensor_data(dev);
 
 	sd->sample_timeout = k_uptime_get();
 
-	if (!atomic_cas(&sd->state, SENSOR_STATE_SLEEP, SENSOR_STATE_ACTIVE)) {
+	if (atomic_get(&sd->state) != SENSOR_STATE_SLEEP) {
 		__ASSERT_NO_MSG(false);
-		report_error();
+		update_sensor_state(sc, sd, SENSOR_STATE_ERROR);
 		return;
 	}
 
-	LOG_DBG("%s sensor woken up", dev->name);
+	update_sensor_state(sc, sd, SENSOR_STATE_ACTIVE);
 	k_sem_give(&can_sample);
 }
 
-static int try_enter_sleep(const struct sensor_config *sc,
+static void try_enter_sleep(const struct sensor_config *sc,
 			   struct sensor_data *sd,
 			   const float *curr)
 {
-	int err = 0;
-
 	if (can_sensor_sleep(sc, sd, curr)) {
-		atomic_set(&sd->state, SENSOR_STATE_SLEEP);
-		err = sensor_trigger_set(sd->dev, &sc->trigger->cfg, trigger_handler);
+		k_sched_lock();
+		int err = sensor_trigger_set(sd->dev, &sc->trigger->cfg, trigger_handler);
+
 		if (err) {
 			LOG_ERR("Error setting trigger (err:%d)", err);
-			atomic_set(&sd->state, SENSOR_STATE_ERROR);
-			return err;
+			update_sensor_state(sc, sd, SENSOR_STATE_ERROR);
+		} else {
+			update_sensor_state(sc, sd, SENSOR_STATE_SLEEP);
 		}
-
-		LOG_DBG("%s sensor put to sleep", sc->dev_name);
+		k_sched_unlock();
 	}
-
-	return err;
 }
 
-static int sample_sensor(struct sensor_data *sd, const struct sensor_config *sc)
+static void sample_sensor(struct sensor_data *sd, const struct sensor_config *sc)
 {
-	int err = 0;
 	size_t data_idx = 0;
 	size_t data_cnt = get_sensor_data_cnt(sc);
 	struct sensor_value data[data_cnt];
 	float curr[data_cnt];
 
-	err = sensor_sample_fetch(sd->dev);
+	int err = sensor_sample_fetch(sd->dev);
+
 	for (size_t i = 0; !err && (i < sc->chan_cnt); i++) {
 		const struct sampled_channel *sampled_chan = &sc->chans[i];
 
@@ -200,33 +219,31 @@ static int sample_sensor(struct sensor_data *sd, const struct sensor_config *sc)
 		curr[i] = sensor_value_to_double(&data[i]);
 	}
 
-	if (sc->trigger) {
-		err = try_enter_sleep(sc, sd, curr);
-	}
-
 	if (err) {
 		LOG_ERR("Sensor sampling error (err %d)", err);
+		update_sensor_state(sc, sd, SENSOR_STATE_ERROR);
 	} else {
 		send_sensor_event(sc->event_descr, curr, ARRAY_SIZE(curr));
+		if (sc->trigger) {
+			try_enter_sleep(sc, sd, curr);
+		}
 	}
-
-	return err;
 }
 
-static int sample_sensors(int64_t *next_timeout)
+static size_t sample_sensors(int64_t *next_timeout)
 {
-	int err = 0;
+	size_t alive_sensors = 0;
 	int64_t cur_uptime = k_uptime_get();
 
 	*next_timeout = INT64_MAX;
 
-	for (size_t i = 0; !err && (i < ARRAY_SIZE(sensor_data)); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(sensor_data); i++) {
 		struct sensor_data *sd = &sensor_data[i];
 		const struct sensor_config *sc = &sensor_configs[i];
 
 		if (atomic_get(&sd->state) == SENSOR_STATE_ACTIVE) {
 			if (sd->sample_timeout <= cur_uptime) {
-				err = sample_sensor(sd, sc);
+				sample_sensor(sd, sc);
 			}
 
 			int drops = -1;
@@ -240,14 +257,17 @@ static int sample_sensors(int64_t *next_timeout)
 			}
 		}
 
-		if (atomic_get(&sd->state) == SENSOR_STATE_ACTIVE) {
-			if (*next_timeout > sd->sample_timeout) {
-				*next_timeout = sd->sample_timeout;
+		if (atomic_get(&sd->state) != SENSOR_STATE_ERROR) {
+			alive_sensors++;
+			if (atomic_get(&sd->state) == SENSOR_STATE_ACTIVE) {
+				if (*next_timeout > sd->sample_timeout) {
+					*next_timeout = sd->sample_timeout;
+				}
 			}
 		}
 	}
 
-	return err;
+	return alive_sensors;
 }
 
 static int sensor_trigger_init(const struct sensor_config *sc, struct sensor_data *sd)
@@ -294,12 +314,12 @@ static int sensor_init(void)
 		if (sc->trigger) {
 			err = sensor_trigger_init(sc, sd);
 			if (err) {
-				atomic_set(&sd->state, SENSOR_STATE_ERROR);
+				update_sensor_state(sc, sd, SENSOR_STATE_ERROR);
 				break;
 			}
 		}
 
-		atomic_set(&sd->state, SENSOR_STATE_ACTIVE);
+		update_sensor_state(sc, sd, SENSOR_STATE_ACTIVE);
 	}
 
 	return err;
@@ -307,25 +327,26 @@ static int sensor_init(void)
 
 static void sample_thread_fn(void)
 {
-	int err = 0;
+	size_t alive_sensors = ARRAY_SIZE(sensor_data);
 	int64_t next_timeout = 0;
+	int err = 0;
 
 	k_sem_init(&can_sample, 0, 1);
 
 	err = sensor_init();
 
 	if (!err) {
-		state = STATE_ACTIVE;
 		module_set_state(MODULE_STATE_READY);
+		return;
 	}
 
-	while (!err) {
+	while (alive_sensors > 0) {
 		k_sem_take(&can_sample, K_TIMEOUT_ABS_MS(next_timeout));
 
-		err = sample_sensors(&next_timeout);
+		alive_sensors = sample_sensors(&next_timeout);
 	}
 
-	report_error();
+	module_set_state(MODULE_STATE_ERROR);
 }
 
 static void init(void)


### PR DESCRIPTION
This change adds sensor_state event.
In case of an error, each sensor reports its state.
Single sensor state does not affect sensor sampler module as a whole
and other sensor can still work.