### PR TITLE
applications: pelion_client: OpenThread factory reset

### DIFF
--- a/applications/pelion_client/configuration/nrf52840dk_nrf52840/app_ZDebug.conf
+++ b/applications/pelion_client/configuration/nrf52840dk_nrf52840/app_ZDebug.conf
@@ -12,6 +12,8 @@ CONFIG_PELION_CLIENT=y
 CONFIG_PELION_NRF_SECURITY=y
 CONFIG_PELION_UPDATE_DEVELOPER=y
 
+CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE=y
+
 ################################################################################
 
 CONFIG_DEBUG=y

--- a/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuapp/app_ZDebug.conf
+++ b/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuapp/app_ZDebug.conf
@@ -12,6 +12,8 @@ CONFIG_PELION_CLIENT=y
 CONFIG_PELION_NRF_SECURITY=y
 CONFIG_PELION_UPDATE_DEVELOPER=y
 
+CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE=y
+
 ################################################################################
 
 CONFIG_DEBUG=y

--- a/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuappns/app_ZDebug.conf
+++ b/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuappns/app_ZDebug.conf
@@ -12,6 +12,8 @@ CONFIG_PELION_CLIENT=y
 CONFIG_PELION_NRF_SECURITY=y
 CONFIG_PELION_UPDATE_DEVELOPER=y
 
+CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE=y
+
 ################################################################################
 
 CONFIG_FPU=y

--- a/applications/pelion_client/configuration/nrf9160dk_nrf9160ns/app_ZDebug.conf
+++ b/applications/pelion_client/configuration/nrf9160dk_nrf9160ns/app_ZDebug.conf
@@ -12,6 +12,8 @@ CONFIG_PELION_CLIENT=y
 CONFIG_PELION_NRF_SECURITY=y
 CONFIG_PELION_UPDATE_DEVELOPER=y
 
+CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE=y
+
 ################################################################################
 
 CONFIG_FPU=y

--- a/applications/pelion_client/configuration/nrf9160dk_nrf9160ns@1.0.0/app_ZDebug.conf
+++ b/applications/pelion_client/configuration/nrf9160dk_nrf9160ns@1.0.0/app_ZDebug.conf
@@ -12,6 +12,8 @@ CONFIG_PELION_CLIENT=y
 CONFIG_PELION_NRF_SECURITY=y
 CONFIG_PELION_UPDATE_DEVELOPER=y
 
+CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE=y
+
 ################################################################################
 
 CONFIG_FPU=y

--- a/applications/pelion_client/src/events/CMakeLists.txt
+++ b/applications/pelion_client/src/events/CMakeLists.txt
@@ -11,3 +11,6 @@ target_sources(app PRIVATE
 
 target_sources_ifdef(CONFIG_PELION_CLIENT_KEEP_ALIVE_EVENTS
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/keep_alive_event.c)
+
+target_sources_ifdef(CONFIG_PELION_CLIENT_FACTORY_RESET_EVENTS
+		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/factory_reset_event.c)

--- a/applications/pelion_client/src/events/Kconfig
+++ b/applications/pelion_client/src/events/Kconfig
@@ -24,5 +24,6 @@ config PELION_INIT_LOG_PELION_CREATE_OBJECTS_EVENTS
 	default y
 
 rsource "Kconfig.keep_alive_event"
+rsource "Kconfig.factory_reset_event"
 
 endmenu

--- a/applications/pelion_client/src/events/Kconfig.factory_reset_event
+++ b/applications/pelion_client/src/events/Kconfig.factory_reset_event
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config PELION_CLIENT_FACTORY_RESET_EVENTS
+	bool "Enable factory reset events"
+	help
+	  Enable the event that informs the system that factory reset was requested.
+
+config PELION_CLIENT_INIT_LOG_FACTORY_RESET_EVENTS
+	bool "Log factory reset events"
+	depends on LOG
+	depends on PELION_CLIENT_FACTORY_RESET_EVENTS
+	default y
+	help
+	  Log the factory reset events.

--- a/applications/pelion_client/src/events/factory_reset_event.c
+++ b/applications/pelion_client/src/events/factory_reset_event.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include "factory_reset_event.h"
+
+
+static void profile_factory_reset_event(struct log_event_buf *buf,
+					const struct event_header *eh)
+{
+	(void)buf;
+	(void)eh;
+}
+
+EVENT_INFO_DEFINE(factory_reset_event,
+		  ENCODE(),
+		  ENCODE(),
+		  profile_factory_reset_event);
+
+EVENT_TYPE_DEFINE(factory_reset_event,
+		  IS_ENABLED(CONFIG_PELION_CLIENT_INIT_LOG_FACTORY_RESET_EVENTS),
+		  NULL,
+		  &factory_reset_event_info);

--- a/applications/pelion_client/src/events/factory_reset_event.h
+++ b/applications/pelion_client/src/events/factory_reset_event.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#ifndef _FACTORY_RESET_EVENT_H_
+#define _FACTORY_RESET_EVENT_H_
+
+#include <event_manager.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Factory reset event
+ *
+ * The event that informs that factory reset was requested.
+ */
+struct factory_reset_event {
+	struct event_header header;
+};
+
+EVENT_TYPE_DECLARE(factory_reset_event);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FACTORY_RESET_EVENT_H_ */

--- a/applications/pelion_client/src/modules/CMakeLists.txt
+++ b/applications/pelion_client/src/modules/CMakeLists.txt
@@ -27,3 +27,6 @@ target_sources_ifdef(CONFIG_LTE_LINK_CONTROL
 
 target_sources_ifdef(CONFIG_NET_L2_OPENTHREAD
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/net_ot.c)
+
+target_sources_ifdef(CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE
+		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/factory_reset_request.c)

--- a/applications/pelion_client/src/modules/Kconfig
+++ b/applications/pelion_client/src/modules/Kconfig
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-rsource "Kconfig.pelion"
+rsource "Kconfig.dfu"
+rsource "Kconfig.factory_reset_request"
+rsource "Kconfig.led_state"
 rsource "Kconfig.net"
 rsource "Kconfig.oma_objects"
-rsource "Kconfig.led_state"
-rsource "Kconfig.dfu"
+rsource "Kconfig.pelion"
 rsource "Kconfig.power_manager"

--- a/applications/pelion_client/src/modules/Kconfig.factory_reset_request
+++ b/applications/pelion_client/src/modules/Kconfig.factory_reset_request
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "Factory reset request"
+
+config PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE
+	bool "Enable factory reset request module"
+	select PELION_CLIENT_FACTORY_RESET_EVENTS
+	help
+	  Enable module that generates initialization event with
+	  factory reset request.
+
+config PELION_CLIENT_FACTORY_RESET_REQUEST_DELAY
+	int "Time in miliseconds to wait for button event at initialization"
+	default 50
+	help
+	  The time to wait for button event when the module is initialized.
+	  The time should be long enough for the button module to react
+	  for the button that is pressed during initialization.
+
+endmenu

--- a/applications/pelion_client/src/modules/factory_reset_request.c
+++ b/applications/pelion_client/src/modules/factory_reset_request.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <zephyr.h>
+#include <event_manager.h>
+
+#include <caf/events/button_event.h>
+#include "factory_reset_event.h"
+
+#define MODULE factory_reset_request
+#include <caf/events/module_state_event.h>
+
+
+static struct k_work_delayable init_work;
+
+
+static void init_work_handler(struct k_work *work)
+{
+	module_set_state(MODULE_STATE_READY);
+}
+
+static bool event_handler(const struct event_header *eh)
+{
+	if (is_button_event(eh)) {
+		struct button_event *event = cast_button_event(eh);
+
+		if (k_work_delayable_is_pending(&init_work) &&  event->pressed) {
+			EVENT_SUBMIT(new_factory_reset_event());
+		}
+		return false;
+	}
+
+	if (is_module_state_event(eh)) {
+		struct module_state_event *event = cast_module_state_event(eh);
+
+		if (check_state(event, MODULE_ID(buttons), MODULE_STATE_READY)) {
+			k_work_init_delayable(&init_work, init_work_handler);
+			k_work_schedule(&init_work,
+					K_MSEC(CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_DELAY));
+		}
+		return false;
+	}
+	/* Event not handled but subscribed. */
+	__ASSERT_NO_MSG(false);
+
+	return false;
+}
+
+EVENT_LISTENER(MODULE, event_handler);
+EVENT_SUBSCRIBE(MODULE, module_state_event);
+EVENT_SUBSCRIBE(MODULE, button_event);

--- a/applications/pelion_client/src/modules/net_ot.c
+++ b/applications/pelion_client/src/modules/net_ot.c
@@ -9,8 +9,9 @@
 #include <net/openthread.h>
 #include <openthread/thread.h>
 #include <openthread/netdata.h>
-
+#include "factory_reset_event.h"
 #include "net_event.h"
+
 
 #define MODULE net
 #include <caf/events/module_state_event.h>
@@ -19,8 +20,14 @@
 LOG_MODULE_REGISTER(MODULE, CONFIG_PELION_CLIENT_NET_LOG_LEVEL);
 
 
+#define NET_MODULE_ID_STATE_READY_WAIT_FOR                               \
+	(IS_ENABLED(CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE) ? \
+		MODULE_ID(factory_reset_request) : MODULE_ID(main))
+
+
 static struct k_delayed_work connecting_work;
 static enum net_state net_state;
+static bool initialized;
 
 
 static void format_address(char *buffer, size_t buffer_size, const uint8_t *addr_m8,
@@ -181,27 +188,55 @@ static void connect_ot(void)
 	LOG_INF("OT connection requested");
 }
 
+static bool handle_state_event(const struct module_state_event *event)
+{
+	if (!check_state(event, NET_MODULE_ID_STATE_READY_WAIT_FOR, MODULE_STATE_READY)) {
+		return false;
+	}
+	__ASSERT_NO_MSG(!initialized);
+	initialized = true;
+
+	k_delayed_work_init(&connecting_work, connecting_work_handler);
+
+	set_net_state_event(NET_STATE_DISCONNECTED);
+
+	connect_ot();
+	module_set_state(MODULE_STATE_READY);
+	k_delayed_work_submit(&connecting_work, K_NO_WAIT);
+
+	return false;
+}
+
+static bool handle_reset_event(void)
+{
+	struct openthread_context *ot_context = openthread_get_default_context();
+	otError err;
+
+	/* This event has to apear before initialization */
+	__ASSERT_NO_MSG(!initialized);
+
+	LOG_WRN("Storage reset requested");
+	openthread_api_mutex_lock(ot_context);
+	err = otInstanceErasePersistentInfo(ot_context->instance);
+	openthread_api_mutex_unlock(ot_context);
+	/* It can fail only if called with OpenThread stack enabled.
+	 * This event should not appear after the OpenThread is started.
+	 * If it does - there is some huge coding error.
+	 */
+	__ASSERT_NO_MSG(err == OT_ERROR_NONE);
+
+	return false;
+}
+
 static bool event_handler(const struct event_header *eh)
 {
 	if (is_module_state_event(eh)) {
-		struct module_state_event *event = cast_module_state_event(eh);
+		return handle_state_event(cast_module_state_event(eh));
+	}
 
-		if (check_state(event, MODULE_ID(main), MODULE_STATE_READY)) {
-			static bool initialized;
-
-			__ASSERT_NO_MSG(!initialized);
-			initialized = true;
-
-			k_delayed_work_init(&connecting_work, connecting_work_handler);
-
-			set_net_state_event(NET_STATE_DISCONNECTED);
-
-			connect_ot();
-			module_set_state(MODULE_STATE_READY);
-			k_delayed_work_submit(&connecting_work, K_NO_WAIT);
-		}
-
-		return false;
+	if (IS_ENABLED(CONFIG_PELION_CLIENT_FACTORY_RESET_EVENTS) &&
+	    is_factory_reset_event(eh)) {
+		return handle_reset_event();
 	}
 
 	/* Event not handled but subscribed. */
@@ -212,3 +247,6 @@ static bool event_handler(const struct event_header *eh)
 
 EVENT_LISTENER(MODULE, event_handler);
 EVENT_SUBSCRIBE(MODULE, module_state_event);
+#if IS_ENABLED(CONFIG_PELION_CLIENT_FACTORY_RESET_EVENTS)
+	EVENT_SUBSCRIBE(MODULE, factory_reset_event);
+#endif


### PR DESCRIPTION
This commit adds common way to add factory reset functionality.
The factory reset is implemented in OpenThread port.
The factory reset functionality is rewritten for pelion_fcc.