### PR TITLE
manifest: update sdk-zephyr for TF-M CMake integration / nRF Security

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4d068de3f50f6a2de2be0c0b98670e33d28ff493
+      revision: a409bc732b62ce659462114ccf2870ada1724e1c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -105,7 +105,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
-      revision: 7b935d15868e4d4dd443fe04f103fef25bb34d2d
+      revision: a3fe611fd0507285421557e3d19b569af7c29672
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Update manifest to included TF-M CMake changes required for
TF-M / nRF Security integration.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>