### PR TITLE
application: serial_lte_modem: Support datamode in MQTT Publish

### DIFF
--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -299,7 +299,7 @@ Syntax
 
 ::
 
-   AT#XMQTTPUB=<topic>,<datatype>,<msg>,<qos>,<retain>
+   AT#XMQTTPUB=<topic>,<datatype>[,<msg>[,<qos>[,<retain>]]]
 
 
 * The ``<topic>`` parameter is a string.
@@ -308,6 +308,7 @@ Syntax
 
   * ``0`` - hexadecimal string (e.g. "DEADBEEF" for 0xDEADBEEF)
   * ``1`` - plain text (default value)
+  * ``9`` - Arbitrary (enter data mode)
 
 * The ``<msg>`` parameter is a string.
   It contains the payload on the topic being published.
@@ -316,7 +317,7 @@ Syntax
   It indicates the MQTT Quality of Service types.
   It can accept the following values:
 
-  * ``0`` - Lowest Quality of Service.
+  * ``0`` - Lowest Quality of Service (default value).
     No acknowledgment of the reception is needed for the published message.
   * ``1`` - Medium Quality of Service.
     If the acknowledgment of the reception is expected for the published message, publishing duplicate messages is permitted.
@@ -324,6 +325,7 @@ Syntax
     The acknowledgment of the reception is expected and the message should be published only once.
 
 * The ``<retain>`` parameter is an integer.
+  Default value is  ``0``.
   When ``1``, it indicates that the broker should store the message persistently.
 
 Response syntax

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -297,9 +297,9 @@ static void silence_timer_handler(struct k_timer *timer)
 	at_buf_len = 0;
 
 	/* quit datamode */
-	(void)exit_datamode();
 	if (datamode_handler) {
 		(void)datamode_handler(DATAMODE_EXIT, NULL, 0);
+		(void)exit_datamode();
 	} else {
 		LOG_WRN("missing datamode handler");
 	}

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -91,6 +91,7 @@ nRF9160
     * Added URC (unsolicited response code) to the FOTA service.
     * Enabled all SLM services by default.
     * Updated the HTTP client service code to handle chunked HTTP responses.
+    * Added data mode to the MQTT Publish service to support JSON-type payload.
 
   * :ref:`at_cmd_parser_readme`:
 


### PR DESCRIPTION
JSON payload has double quotes and is not support by at_cmd_parser.
In order to publish JSON payload, add datamode to support it.
AT command format change from
  AT#XMQTTPUB=< topic >,< datatype >,< msg >,< qos >,< retain >
to
  AT#XMQTTPUB=< topic >,< datatype >[,< msg >[,< qos >[,< retain >]]]
When <datatype> is DATATYPE_ARBITRARY, enter datamode.
After publish, need to explicitly quit datamode by "+++".
Another update is to avoid random message ID due to RNG dependecy.
Also include a bug-fix in exitting datamode by "+++".

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>