### PR TITLE
Bluetooth: Mesh: Get rid of unused scene entries

### DIFF
--- a/include/bluetooth/mesh/gen_lvl.h
+++ b/include/bluetooth/mesh/gen_lvl.h
@@ -108,6 +108,12 @@ struct bt_mesh_lvl_status {
 #define BT_MESH_LVL_MSG_MAXLEN_DELTA_SET 7
 #define BT_MESH_LVL_MSG_MINLEN_MOVE_SET 3
 #define BT_MESH_LVL_MSG_MAXLEN_MOVE_SET 5
+
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+#define BT_MESH_LVL_SCENE_ENTRY_INIT .scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_lvl_srv_scene_type),
+#else
+#define BT_MESH_LVL_SCENE_ENTRY_INIT
+#endif
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/gen_lvl_srv.h
+++ b/include/bluetooth/mesh/gen_lvl_srv.h
@@ -33,6 +33,7 @@ struct bt_mesh_lvl_srv;
 #define BT_MESH_LVL_SRV_INIT(_handlers)                                        \
 	{                                                                      \
 		.handlers = _handlers,                                         \
+		BT_MESH_LVL_SCENE_ENTRY_INIT                                   \
 	}
 
 /** @def BT_MESH_MODEL_LVL_SRV
@@ -148,8 +149,10 @@ struct bt_mesh_lvl_srv {
 					       BT_MESH_LVL_MSG_MAXLEN_STATUS)];
 	/** Transaction ID tracking. */
 	struct bt_mesh_tid_ctx tid;
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 };
 
 /** @brief Publish the generic level state.
@@ -171,6 +174,7 @@ int bt_mesh_lvl_srv_pub(struct bt_mesh_lvl_srv *srv,
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_lvl_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_lvl_srv_cb;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_lvl_srv_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/gen_onoff.h
+++ b/include/bluetooth/mesh/gen_onoff.h
@@ -49,6 +49,12 @@ struct bt_mesh_onoff_status {
 #define BT_MESH_ONOFF_MSG_MAXLEN_SET 4
 #define BT_MESH_ONOFF_MSG_MINLEN_STATUS 1
 #define BT_MESH_ONOFF_MSG_MAXLEN_STATUS 3
+
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+#define BT_MESH_ONOFF_SCENE_ENTRY_INIT .scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_onoff_scene_type),
+#else
+#define BT_MESH_ONOFF_SCENE_ENTRY_INIT
+#endif
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/gen_onoff_srv.h
+++ b/include/bluetooth/mesh/gen_onoff_srv.h
@@ -33,6 +33,7 @@ struct bt_mesh_onoff_srv;
 #define BT_MESH_ONOFF_SRV_INIT(_handlers)                                      \
 	{                                                                      \
 		.handlers = _handlers,                                         \
+		BT_MESH_ONOFF_SCENE_ENTRY_INIT                                 \
 	}
 
 /** @def BT_MESH_MODEL_ONOFF_SRV
@@ -97,8 +98,10 @@ struct bt_mesh_onoff_srv {
 	/* Publication data */
 	uint8_t pub_data[BT_MESH_MODEL_BUF_LEN(
 		BT_MESH_ONOFF_OP_STATUS, BT_MESH_ONOFF_MSG_MAXLEN_STATUS)];
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 	/** Internal flag state. */
 	atomic_t flags;
 };
@@ -128,6 +131,7 @@ int bt_mesh_onoff_srv_pub(struct bt_mesh_onoff_srv *srv,
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_onoff_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_onoff_srv_cb;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_onoff_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/gen_plvl.h
+++ b/include/bluetooth/mesh/gen_plvl.h
@@ -113,6 +113,12 @@ static inline uint16_t bt_mesh_plvl_from_percent(uint8_t plvl_percent)
 #define BT_MESH_PLVL_MSG_LEN_RANGE_STATUS 5
 #define BT_MESH_PLVL_MSG_LEN_DEFAULT_SET 2
 #define BT_MESH_PLVL_MSG_LEN_RANGE_SET 4
+
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+#define BT_MESH_PLVL_SCENE_ENTRY_INIT .scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_plvl_srv_scene_type),
+#else
+#define BT_MESH_PLVL_SCENE_ENTRY_INIT
+#endif
 /** @endcond */
 
 

--- a/include/bluetooth/mesh/gen_plvl_srv.h
+++ b/include/bluetooth/mesh/gen_plvl_srv.h
@@ -35,10 +35,16 @@ struct bt_mesh_plvl_srv;
  */
 #define BT_MESH_PLVL_SRV_INIT(_handlers)                                       \
 	{                                                                      \
-		.lvl = BT_MESH_LVL_SRV_INIT(&bt_mesh_plvl_srv_lvl_handlers),   \
-		.ponoff = BT_MESH_PONOFF_SRV_INIT(                             \
-			&bt_mesh_plvl_srv_onoff_handlers, NULL, NULL),         \
+		.lvl = {                                                       \
+			.handlers = &bt_mesh_plvl_srv_lvl_handlers,            \
+		},                                                             \
+		.ponoff = {                                                    \
+			.onoff = {                                             \
+				.handlers = &bt_mesh_plvl_srv_onoff_handlers,  \
+			},                                                     \
+		},                                                             \
 		.handlers = _handlers,                                         \
+		BT_MESH_PLVL_SCENE_ENTRY_INIT                                  \
 	}
 
 /** @def BT_MESH_MODEL_PLVL_SRV
@@ -160,8 +166,10 @@ struct bt_mesh_plvl_srv {
 	uint16_t last;
 	/** Whether the Power is on. */
 	bool is_on;
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 };
 
 /** @brief Publish the current Power state.
@@ -192,6 +200,7 @@ extern const struct bt_mesh_model_op _bt_mesh_plvl_srv_op[];
 extern const struct bt_mesh_model_op _bt_mesh_plvl_setup_srv_op[];
 extern const struct bt_mesh_lvl_srv_handlers bt_mesh_plvl_srv_lvl_handlers;
 extern const struct bt_mesh_onoff_srv_handlers bt_mesh_plvl_srv_onoff_handlers;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_plvl_srv_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/gen_ponoff.h
+++ b/include/bluetooth/mesh/gen_ponoff.h
@@ -40,6 +40,13 @@ enum bt_mesh_on_power_up {
 #define BT_MESH_PONOFF_MSG_LEN_GET 0
 #define BT_MESH_PONOFF_MSG_LEN_STATUS 1
 #define BT_MESH_PONOFF_MSG_LEN_SET 1
+
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+#define BT_MESH_PONOFF_SCENE_ENTRY_INIT \
+	.scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_ponoff_srv_scene_type),
+#else
+#define BT_MESH_PONOFF_SCENE_ENTRY_INIT
+#endif
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -38,11 +38,13 @@ struct bt_mesh_ponoff_srv;
 #define BT_MESH_PONOFF_SRV_INIT(_onoff_handlers, _dtt_change_handler,          \
 				_on_power_up_change_handler)                   \
 	{                                                                      \
-		.onoff = BT_MESH_ONOFF_SRV_INIT(                               \
-			&_bt_mesh_ponoff_onoff_intercept),                     \
+		.onoff = {                                                     \
+			.handlers = &_bt_mesh_ponoff_onoff_intercept,          \
+		},                                                             \
 		.dtt = BT_MESH_DTT_SRV_INIT(_dtt_change_handler),              \
 		.onoff_handlers = _onoff_handlers,                             \
 		.update = _on_power_up_change_handler,                         \
+		BT_MESH_PONOFF_SCENE_ENTRY_INIT                                \
 	}
 
 /** @def BT_MESH_MODEL_PONOFF_SRV
@@ -104,8 +106,10 @@ struct bt_mesh_ponoff_srv {
 
 	/** Current OnPowerUp state. */
 	enum bt_mesh_on_power_up on_power_up;
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 };
 
 /** @brief Set the OnPowerUp state of a Power OnOff server.
@@ -145,6 +149,7 @@ extern const struct bt_mesh_model_cb _bt_mesh_ponoff_srv_cb;
 extern const struct bt_mesh_model_op _bt_mesh_ponoff_srv_op[];
 extern const struct bt_mesh_model_op _bt_mesh_ponoff_setup_srv_op[];
 extern const struct bt_mesh_onoff_srv_handlers _bt_mesh_ponoff_onoff_intercept;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_ponoff_srv_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_ctl.h
+++ b/include/bluetooth/mesh/light_ctl.h
@@ -133,6 +133,16 @@ struct bt_mesh_light_temp_range_status {
 #define BT_MESH_LIGHT_CTL_MSG_MAXLEN_TEMP_STATUS 9
 #define BT_MESH_LIGHT_CTL_MSG_LEN_DEFAULT_MSG 6
 #define BT_MESH_LIGHT_CTL_MSG_LEN_TEMP_RANGE_SET 4
+
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+#define BT_MESH_LIGHT_CTL_SCENE_ENTRY_INIT \
+	.scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_light_ctl_scene_type),
+#define BT_MESH_LIGHT_TEMP_SCENE_ENTRY_INIT \
+	.scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_light_temp_scene_type),
+#else
+#define BT_MESH_LIGHT_CTL_SCENE_ENTRY_INIT
+#define BT_MESH_LIGHT_TEMP_SCENE_ENTRY_INIT
+#endif
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_ctl_srv.h
+++ b/include/bluetooth/mesh/light_ctl_srv.h
@@ -34,9 +34,21 @@ struct bt_mesh_light_ctl_srv;
  */
 #define BT_MESH_LIGHT_CTL_SRV_INIT(_lightness_handlers, _light_temp_handlers)  \
 	{                                                                      \
-		.lightness_srv =                                               \
-			BT_MESH_LIGHTNESS_SRV_INIT(_lightness_handlers),       \
+		.lightness_srv = {                                             \
+			.lvl = {                                               \
+				.handlers =                                    \
+					&_bt_mesh_lightness_srv_lvl_handlers,  \
+			},                                                     \
+			.ponoff = {                                            \
+				.onoff = {                                     \
+					.handlers =                            \
+				       &_bt_mesh_lightness_srv_onoff_handlers, \
+				},                                             \
+			},                                                     \
+			.handlers = _lightness_handlers,                       \
+		},                                                             \
 		.temp_srv = BT_MESH_LIGHT_TEMP_SRV_INIT(_light_temp_handlers), \
+		BT_MESH_LIGHT_CTL_SCENE_ENTRY_INIT                             \
 	}
 
 /** @def BT_MESH_MODEL_LIGHT_CTL_SRV
@@ -78,8 +90,10 @@ struct bt_mesh_light_ctl_srv {
 		BT_MESH_LIGHT_CTL_STATUS, BT_MESH_LIGHT_CTL_MSG_MAXLEN_STATUS)];
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 };
 
 /** @brief Publish the current CTL status.
@@ -150,6 +164,7 @@ int bt_mesh_light_ctl_default_pub(struct bt_mesh_light_ctl_srv *srv,
 extern const struct bt_mesh_model_op _bt_mesh_light_ctl_srv_op[];
 extern const struct bt_mesh_model_op _bt_mesh_light_ctl_setup_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_light_ctl_srv_cb;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_light_ctl_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_ctrl.h
+++ b/include/bluetooth/mesh/light_ctrl.h
@@ -239,6 +239,13 @@ enum bt_mesh_light_ctrl_coeff {
 			CONFIG_BT_MESH_LIGHT_CTRL_SRV_LVL_PROLONG,             \
 		}                                                              \
 	}
+
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+#define BT_MESH_LIGHT_CTRL_SCENE_ENTRY_INIT \
+	.scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_light_ctrl_scene_type),
+#else
+#define BT_MESH_LIGHT_CTRL_SCENE_ENTRY_INIT
+#endif
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -37,9 +37,11 @@ struct bt_mesh_light_ctrl_srv;
 #define BT_MESH_LIGHT_CTRL_SRV_INIT(_lightness_srv)                            \
 	{                                                                      \
 		.cfg = BT_MESH_LIGHT_CTRL_SRV_CFG_INIT,                        \
-		.onoff = BT_MESH_ONOFF_SRV_INIT(                               \
-			&_bt_mesh_light_ctrl_srv_onoff),                       \
+		.onoff = {                                                     \
+			.handlers = &_bt_mesh_light_ctrl_srv_onoff,            \
+		},                                                             \
 		.lightness = _lightness_srv,                                   \
+		BT_MESH_LIGHT_CTRL_SCENE_ENTRY_INIT                            \
 		BT_MESH_LIGHT_CTRL_SRV_REG_INIT                                \
 	}
 
@@ -186,8 +188,10 @@ struct bt_mesh_light_ctrl_srv {
 	struct bt_mesh_model *model;
 	/** Composition data setup server model instance */
 	struct bt_mesh_model *setup_srv;
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/** Scene entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 };
 
 /** @brief Turn the light on.
@@ -275,6 +279,7 @@ extern const struct bt_mesh_model_op _bt_mesh_light_ctrl_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_light_ctrl_setup_srv_cb;
 extern const struct bt_mesh_model_op _bt_mesh_light_ctrl_setup_srv_op[];
 extern const struct bt_mesh_onoff_srv_handlers _bt_mesh_light_ctrl_srv_onoff;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_light_ctrl_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_hsl.h
+++ b/include/bluetooth/mesh/light_hsl.h
@@ -203,6 +203,12 @@ uint16_t bt_mesh_light_hsl_to_rgb(const struct bt_mesh_light_hsl *hsl,
 #define BT_MESH_LIGHT_HSL_MSG_LEN_RANGE_SET 8
 #define BT_MESH_LIGHT_HSL_MSG_LEN_RANGE_STATUS 9
 
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+#define BT_MESH_LIGHT_HSL_SCENE_ENTRY_INIT \
+	.scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_light_hsl_scene_type),
+#else
+#define BT_MESH_LIGHT_HSL_SCENE_ENTRY_INIT
+#endif
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_hsl_srv.h
+++ b/include/bluetooth/mesh/light_hsl_srv.h
@@ -39,7 +39,20 @@ struct bt_mesh_light_hsl_srv;
 	{                                                                      \
 		.hue = BT_MESH_LIGHT_HUE_SRV_INIT(_hue_handlers),              \
 		.sat = BT_MESH_LIGHT_SAT_SRV_INIT(_sat_handlers),              \
-		.lightness = BT_MESH_LIGHTNESS_SRV_INIT(_light_handlers),      \
+		.lightness = {                                                 \
+			.lvl = {                                               \
+				.handlers =                                    \
+					&_bt_mesh_lightness_srv_lvl_handlers,  \
+			},                                                     \
+			.ponoff = {                                            \
+				.onoff = {                                     \
+					.handlers =                            \
+				       &_bt_mesh_lightness_srv_onoff_handlers, \
+				},                                             \
+			},                                                     \
+			.handlers = _light_handlers,                           \
+		},                                                             \
+		BT_MESH_LIGHT_HSL_SCENE_ENTRY_INIT                             \
 	}
 
 /** @def BT_MESH_MODEL_LIGHT_HSL_SRV
@@ -89,8 +102,10 @@ struct bt_mesh_light_hsl_srv {
 	bool pub_pending;
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 };
 
 /** @brief Publish the current HSL status.
@@ -119,6 +134,7 @@ int bt_mesh_light_hsl_srv_pub(struct bt_mesh_light_hsl_srv *srv,
 extern const struct bt_mesh_model_op _bt_mesh_light_hsl_srv_op[];
 extern const struct bt_mesh_model_op _bt_mesh_light_hsl_setup_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_light_hsl_srv_cb;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_light_hsl_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_hue_srv.h
+++ b/include/bluetooth/mesh/light_hue_srv.h
@@ -34,8 +34,9 @@ struct bt_mesh_light_hue_srv;
 #define BT_MESH_LIGHT_HUE_SRV_INIT(_handlers)                                  \
 	{                                                                      \
 		.handlers = _handlers,                                         \
-		.lvl = BT_MESH_LVL_SRV_INIT(                                   \
-			&_bt_mesh_light_hue_srv_lvl_handlers),                 \
+		.lvl = {                                                       \
+			.handlers = &_bt_mesh_light_hue_srv_lvl_handlers,      \
+		},                                                             \
 		.range = BT_MESH_LIGHT_HSL_OP_RANGE_DEFAULT,                   \
 	}
 

--- a/include/bluetooth/mesh/light_sat_srv.h
+++ b/include/bluetooth/mesh/light_sat_srv.h
@@ -34,8 +34,9 @@ struct bt_mesh_light_sat_srv;
 #define BT_MESH_LIGHT_SAT_SRV_INIT(_handlers)                                  \
 	{                                                                      \
 		.handlers = _handlers,                                         \
-		.lvl = BT_MESH_LVL_SRV_INIT(                                   \
-			&_bt_mesh_light_sat_srv_lvl_handlers),                 \
+		.lvl = {                                                       \
+			.handlers = &_bt_mesh_light_sat_srv_lvl_handlers,      \
+		},                                                             \
 		.range = BT_MESH_LIGHT_HSL_OP_RANGE_DEFAULT,                   \
 	}
 

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -33,12 +33,11 @@ struct bt_mesh_light_temp_srv;
  */
 #define BT_MESH_LIGHT_TEMP_SRV_INIT(_handlers)                                 \
 	{                                                                      \
-		.lvl = BT_MESH_LVL_SRV_INIT(                                   \
-			&_bt_mesh_light_temp_srv_lvl_handlers),                \
-		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
-				 BT_MESH_LIGHT_TEMP_STATUS,                    \
-				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_TEMP_STATUS)) }, \
+		.lvl = {                                                       \
+			.handlers = &_bt_mesh_light_temp_srv_lvl_handlers,     \
+		},                                                             \
 		.handlers = _handlers,                                         \
+		BT_MESH_LIGHT_TEMP_SCENE_ENTRY_INIT                            \
 	}
 
 /** @def BT_MESH_MODEL_LIGHT_TEMP_SRV
@@ -120,6 +119,12 @@ struct bt_mesh_light_temp_srv {
 	struct bt_mesh_model *model;
 	/** Publish parameters. */
 	struct bt_mesh_model_pub pub;
+	/* Publication buffer */
+	struct net_buf_simple pub_buf;
+	/* Publication data */
+	uint8_t pub_data[BT_MESH_MODEL_BUF_LEN(
+		BT_MESH_LIGHT_TEMP_STATUS,
+		BT_MESH_LIGHT_CTL_MSG_MAXLEN_TEMP_STATUS)];
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
 	/** Handler function structure. */
@@ -130,8 +135,10 @@ struct bt_mesh_light_temp_srv {
 	struct bt_mesh_light_temp_range range;
 	/** The last known color temperature. */
 	struct bt_mesh_light_temp last;
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/** Scene data entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 };
 
 /** @brief Publish the current CTL Temperature status.
@@ -161,6 +168,7 @@ extern const struct bt_mesh_model_op _bt_mesh_light_temp_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_light_temp_srv_cb;
 extern const struct bt_mesh_lvl_srv_handlers
 	_bt_mesh_light_temp_srv_lvl_handlers;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_light_temp_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_xyl.h
+++ b/include/bluetooth/mesh/light_xyl.h
@@ -104,6 +104,12 @@ struct bt_mesh_light_xyl_range_status {
 #define BT_MESH_LIGHT_XYL_MSG_MINLEN_SET 7
 #define BT_MESH_LIGHT_XYL_MSG_MAXLEN_SET 9
 
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+#define BT_MESH_LIGHT_XYL_SCENE_ENTRY_INIT \
+	.scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_light_xyl_scene_type),
+#else
+#define BT_MESH_LIGHT_XYL_SCENE_ENTRY_INIT
+#endif
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/light_xyl_srv.h
+++ b/include/bluetooth/mesh/light_xyl_srv.h
@@ -34,12 +34,24 @@ struct bt_mesh_light_xyl_srv;
 #define BT_MESH_LIGHT_XYL_SRV_INIT(_lightness_handlers, _light_xyl_handlers)   \
 	{                                                                      \
 		.handlers = _light_xyl_handlers,                               \
-		.lightness_srv =                                               \
-			BT_MESH_LIGHTNESS_SRV_INIT(_lightness_handlers),       \
+		.lightness_srv = {                                             \
+			.lvl = {                                               \
+				.handlers =                                    \
+					&_bt_mesh_lightness_srv_lvl_handlers,  \
+			},                                                     \
+			.ponoff = {                                            \
+				.onoff = {                                     \
+					.handlers =                            \
+				       &_bt_mesh_lightness_srv_onoff_handlers, \
+				},                                             \
+			},                                                     \
+			.handlers = _lightness_handlers,                       \
+		},                                                             \
 		.range = {                                                     \
 			.min = { .x = 0, .y = 0 },                             \
 			.max = { .x = UINT16_MAX, .y = UINT16_MAX }            \
-		}                                                              \
+		},                                                             \
+		BT_MESH_LIGHT_XYL_SCENE_ENTRY_INIT                             \
 	}
 
 /** @def BT_MESH_MODEL_LIGHT_XYL_SRV
@@ -155,8 +167,10 @@ struct bt_mesh_light_xyl_srv {
 	struct bt_mesh_light_xy_range range;
 	/** Handler function structure. */
 	const struct bt_mesh_light_xyl_srv_handlers *handlers;
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/** Scene entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 
 	/** The last known xy Level. */
 	struct bt_mesh_light_xy xy_last;
@@ -254,6 +268,7 @@ int bt_mesh_light_xyl_srv_default_pub(struct bt_mesh_light_xyl_srv *srv,
 extern const struct bt_mesh_model_op _bt_mesh_light_xyl_srv_op[];
 extern const struct bt_mesh_model_op _bt_mesh_light_xyl_setup_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_light_xyl_srv_cb;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_light_xyl_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/lightness.h
+++ b/include/bluetooth/mesh/lightness.h
@@ -99,6 +99,13 @@ struct bt_mesh_lightness_range_status {
 #define BT_MESH_LIGHTNESS_MSG_LEN_RANGE_STATUS 5
 #define BT_MESH_LIGHTNESS_MSG_LEN_DEFAULT_SET 2
 #define BT_MESH_LIGHTNESS_MSG_LEN_RANGE_SET 4
+
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+#define BT_MESH_LIGHTNESS_SCENE_ENTRY_INIT \
+	.scene = BT_MESH_SCENE_ENTRY(&_bt_mesh_lightness_scene_type),
+#else
+#define BT_MESH_LIGHTNESS_SCENE_ENTRY_INIT
+#endif
 /** @endcond */
 
 #ifdef __cplusplus

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -35,11 +35,17 @@ struct bt_mesh_lightness_srv;
  */
 #define BT_MESH_LIGHTNESS_SRV_INIT(_handlers)                                  \
 	{                                                                      \
-		.lvl = BT_MESH_LVL_SRV_INIT(                                   \
-			&_bt_mesh_lightness_srv_lvl_handlers),                 \
-		.ponoff = BT_MESH_PONOFF_SRV_INIT(                             \
-			&_bt_mesh_lightness_srv_onoff_handlers, NULL, NULL),   \
+		.lvl = {                                                       \
+			.handlers = &_bt_mesh_lightness_srv_lvl_handlers,      \
+		},                                                             \
+		.ponoff = {                                                    \
+			.onoff = {                                             \
+				.handlers =                                    \
+				      &_bt_mesh_lightness_srv_onoff_handlers,  \
+			},                                                     \
+		},                                                             \
 		.handlers = _handlers,                                         \
+		BT_MESH_LIGHTNESS_SCENE_ENTRY_INIT                             \
 	}
 
 /** @def BT_MESH_MODEL_LIGHTNESS_SRV
@@ -166,8 +172,11 @@ struct bt_mesh_lightness_srv {
 	/** Acting controller, if enabled. */
 	struct bt_mesh_light_ctrl_srv *ctrl;
 #endif
+
+#if defined(CONFIG_BT_MESH_SCENE_SRV)
 	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
+	struct bt_mesh_scene_entry *scene;
+#endif
 };
 
 /** @brief Publish the current Light state.
@@ -200,6 +209,7 @@ extern const struct bt_mesh_lvl_srv_handlers
 	_bt_mesh_lightness_srv_lvl_handlers;
 extern const struct bt_mesh_onoff_srv_handlers
 	_bt_mesh_lightness_srv_onoff_handlers;
+extern const struct bt_mesh_scene_entry_type _bt_mesh_lightness_scene_type;
 /** @endcond */
 
 #ifdef __cplusplus

--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -84,7 +84,7 @@ static void set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	srv->handlers->set(srv, ctx, &set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	if (ack) {
@@ -116,7 +116,7 @@ static void delta_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	srv->handlers->delta_set(srv, ctx, &delta_set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	if (ack) {
@@ -156,7 +156,7 @@ static void move_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	srv->handlers->move_set(srv, ctx, &move_set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	if (ack) {
@@ -277,7 +277,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_lvl_srv_pub(srv, NULL, &status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+const struct bt_mesh_scene_entry_type _bt_mesh_lvl_srv_scene_type = {
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -304,9 +304,9 @@ static int bt_mesh_lvl_srv_init(struct bt_mesh_model *model)
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
 				      sizeof(srv->pub_data));
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	(void)bt_mesh_scene_entry_add(model, srv->scene, false);
+#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -90,7 +90,7 @@ static void onoff_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	srv->handlers->set(srv, ctx, &set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	(void)bt_mesh_onoff_srv_pub(srv, NULL, &status);
@@ -162,7 +162,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_onoff_srv_pub(srv, NULL, &status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+const struct bt_mesh_scene_entry_type _bt_mesh_onoff_scene_type = {
 	.maxlen = 1,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -190,9 +190,9 @@ static int bt_mesh_onoff_srv_init(struct bt_mesh_model *model)
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
 				      sizeof(srv->pub_data));
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	(void)bt_mesh_scene_entry_add(model, srv->scene, false);
+#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -172,7 +172,7 @@ static void plvl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		change_lvl(srv, ctx, &set, &status);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->plvl_model);
 		}
 	} else if (ack) {
 		srv->handlers->power_get(srv, NULL, &status);
@@ -629,7 +629,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	change_lvl(srv, NULL, &set, &status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+const struct bt_mesh_scene_entry_type _bt_mesh_plvl_srv_scene_type = {
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -695,9 +695,9 @@ static int bt_mesh_plvl_srv_init(struct bt_mesh_model *model)
 			bt_mesh_model_elem(model),
 			BT_MESH_MODEL_ID_GEN_POWER_LEVEL_SETUP_SRV));
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	(void)bt_mesh_scene_entry_add(model, srv->scene, false);
+#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -224,7 +224,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_onoff_srv_pub(&srv->onoff, NULL, &status);
 }
 
-const struct bt_mesh_scene_entry_type scene_type = {
+const struct bt_mesh_scene_entry_type _bt_mesh_ponoff_srv_scene_type = {
 	.maxlen = 1,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -267,9 +267,9 @@ static int bt_mesh_ponoff_srv_init(struct bt_mesh_model *model)
 			bt_mesh_model_elem(model),
 			BT_MESH_MODEL_ID_GEN_POWER_ONOFF_SETUP_SRV));
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	(void)bt_mesh_scene_entry_add(model, srv->scene, false);
+#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -118,7 +118,7 @@ respond:
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 }
 
@@ -382,7 +382,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	}
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+const struct bt_mesh_scene_entry_type _bt_mesh_light_ctl_scene_type = {
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -424,9 +424,9 @@ static int bt_mesh_light_ctl_srv_init(struct bt_mesh_model *model)
 			       bt_mesh_model_elem(model),
 			       BT_MESH_MODEL_ID_LIGHT_CTL_SETUP_SRV));
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	(void)bt_mesh_scene_entry_add(model, srv->scene, false);
+#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -828,7 +828,7 @@ static int om_set(struct bt_mesh_light_ctrl_srv *srv,
 	store(srv, FLAG_STORE_STATE);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	return 0;
@@ -917,7 +917,7 @@ static void light_onoff_set(struct bt_mesh_light_ctrl_srv *srv,
 		}
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->model);
 		}
 	}
 
@@ -1317,7 +1317,7 @@ static void handle_prop_set(struct bt_mesh_model *model,
 		prop_tx(srv, NULL, id);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->model);
 		}
 	}
 
@@ -1338,7 +1338,7 @@ static void handle_prop_set_unack(struct bt_mesh_model *model,
 		prop_tx(srv, NULL, id);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->model);
 		}
 	}
 
@@ -1459,7 +1459,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	}
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+const struct bt_mesh_scene_entry_type _bt_mesh_light_ctrl_scene_type = {
 	.maxlen = sizeof(struct scene_data),
 	.store = scene_store,
 	.recall = scene_recall,
@@ -1516,9 +1516,9 @@ static int light_ctrl_srv_init(struct bt_mesh_model *model)
 
 	atomic_set_bit(&srv->onoff.flags, GEN_ONOFF_SRV_NO_DTT);
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	(void)bt_mesh_scene_entry_add(model, srv->scene, false);
+#endif
 
 	return 0;
 }
@@ -1704,7 +1704,7 @@ int bt_mesh_light_ctrl_srv_on(struct bt_mesh_light_ctrl_srv *srv)
 
 	err = turn_on(srv, NULL, true);
 	if (!err && IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	return err;
@@ -1716,7 +1716,7 @@ int bt_mesh_light_ctrl_srv_off(struct bt_mesh_light_ctrl_srv *srv)
 
 	err = turn_off(srv, NULL, true);
 	if (!err && IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	return err;
@@ -1733,7 +1733,7 @@ int bt_mesh_light_ctrl_srv_enable(struct bt_mesh_light_ctrl_srv *srv)
 		ctrl_enable(srv);
 		store(srv, FLAG_STORE_STATE);
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->model);
 		}
 	}
 
@@ -1750,7 +1750,7 @@ int bt_mesh_light_ctrl_srv_disable(struct bt_mesh_light_ctrl_srv *srv)
 	ctrl_disable(srv);
 	store(srv, FLAG_STORE_STATE);
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	return 0;

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -160,7 +160,7 @@ static void hsl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	(void)bt_mesh_light_hsl_srv_pub(srv, NULL, &hsl);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 }
 
@@ -492,7 +492,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_light_hsl_srv_pub(srv, NULL, &hsl);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+const struct bt_mesh_scene_entry_type _bt_mesh_light_hsl_scene_type = {
 	.maxlen = sizeof(struct scene_data),
 	.store = scene_store,
 	.recall = scene_recall,
@@ -537,9 +537,9 @@ static int bt_mesh_light_hsl_srv_init(struct bt_mesh_model *model)
 			       bt_mesh_model_elem(model),
 			       BT_MESH_MODEL_ID_LIGHT_HSL_SETUP_SRV));
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	(void)bt_mesh_scene_entry_add(model, srv->scene, false);
+#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/light_hue_srv.c
+++ b/subsys/bluetooth/mesh/light_hue_srv.c
@@ -131,7 +131,7 @@ static void hue_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	(void)bt_mesh_lvl_srv_pub(&srv->lvl, NULL, &lvl_status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->lvl.scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 }
 

--- a/subsys/bluetooth/mesh/light_sat_srv.c
+++ b/subsys/bluetooth/mesh/light_sat_srv.c
@@ -130,7 +130,7 @@ static void sat_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	(void)bt_mesh_lvl_srv_pub(&srv->lvl, NULL, &lvl_status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->lvl.scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 }
 

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -137,7 +137,7 @@ static void xyl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	store_state(srv);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	(void)bt_mesh_light_xyl_srv_pub(srv, NULL, &xyl_status);
@@ -491,7 +491,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_light_xyl_srv_pub(srv, NULL, &xyl_status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+const struct bt_mesh_scene_entry_type _bt_mesh_light_xyl_scene_type = {
 	.maxlen = sizeof(struct scene_data),
 	.store = scene_store,
 	.recall = scene_recall,
@@ -533,9 +533,9 @@ static int bt_mesh_light_xyl_srv_init(struct bt_mesh_model *model)
 			       bt_mesh_model_elem(model),
 			       BT_MESH_MODEL_ID_LIGHT_XYL_SETUP_SRV));
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	(void)bt_mesh_scene_entry_add(model, srv->scene, false);
+#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -241,7 +241,7 @@ static void lightness_set(struct bt_mesh_model *model,
 		lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->lightness_model);
 		}
 	} else if (ack) {
 		srv->handlers->light_get(srv, NULL, &status);
@@ -803,7 +803,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	lightness_srv_change_lvl(srv, NULL, &set, &dummy_status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+const struct bt_mesh_scene_entry_type _bt_mesh_lightness_scene_type = {
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -850,9 +850,9 @@ static int bt_mesh_lightness_srv_init(struct bt_mesh_model *model)
 			bt_mesh_model_elem(model),
 			BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SETUP_SRV));
 
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	(void)bt_mesh_scene_entry_add(model, srv->scene, false);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Scene entry is defined and initialized by every model that has a state
stored with scene. However, when a model is extended by another model,
the Scene Store and Scene Recall behaviours are controled by the
extending model. Thus, scene_store and scene_recall will never be called
for the extended model. This change makes possible for the compiler to
get rid of unused code.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>