### PR TITLE
doc/release-note: flash API & MCUboot notes

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -125,13 +125,18 @@ There are no entries for this section yet.
 MCUboot
 =======
 
-The MCUboot fork in |NCS| (``sdk-mcuboot``) contains all commits from the upstream MCUboot repository up to and including ``3fc59410b6``, plus some |NCS| specific additions.
+The MCUboot fork in |NCS| (``sdk-mcuboot``) contains all commits from the upstream MCUboot repository up to and including ``5f004461f9``, plus some |NCS| specific additions.
 
 The code for integrating MCUboot into |NCS| is located in :file:`ncs/nrf/modules/mcuboot`.
 
 The following list summarizes the most important changes inherited from upstream MCUboot:
 
-* No changes yet
+* Added support for indicating serial recovery through LED.
+* Made the debounce delay of the serial detect pin state configurable.
+* Added support for mbed TLS ECDSA for signatures.
+* Added an option to use GPIO PIN to enter to USB DFU class recovery.
+* Added an optional check that prevents attempting to boot an image built for a different ROM address than the slot it currently resides in.
+  The check is enabled if the image was signed with the ``IMAGE_F_ROM_FIXED`` flag.
 
 Mcumgr
 ======
@@ -192,7 +197,9 @@ The following list summarizes the most important changes inherited from upstream
 
     * Implemented workaround for nRF52 anomaly 242 in the nRF SoC flash driver.
     * Added automatic selection of :option:`CONFIG_MPU_ALLOW_FLASH_WRITE` when the MPU is enabled for Arm based SoCs.
-    * Deprecated the :c:func:`flash_write_protection_set` API function.
+    * Deprecated :c:func:`flash_write_protection_set()`.
+      The function will be removed in Zephyr v2.8.
+      Responsibility for write/erase protection management has been moved to the driver-specific implementation of the :c:func:`flash_write()` and :c:func:`flash_erase()` API calls.
     * Improved the SPI NOR flash driver to support devices that power up with block protect bits set.
 
   * GPIO:


### PR DESCRIPTION
Added record on MCUboot changes and flash API
changes which was inherited within the last upmerge
#4370.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>