### PR TITLE
samples: ppi_trace: Add integration_platforms to sample.yaml

### DIFF
--- a/samples/debug/ppi_trace/sample.yaml
+++ b/samples/debug/ppi_trace/sample.yaml
@@ -7,3 +7,6 @@ tests:
     build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160
     tags: ci_build
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160


### PR DESCRIPTION
Add required integration platforms (one with PPI and one with DPPI).

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>