### PR TITLE
tests: thread_swap: Enable FPU to be compatible with SPM

### DIFF
--- a/tests/subsys/spm/thread_swap/prj.conf
+++ b/tests/subsys/spm/thread_swap/prj.conf
@@ -6,3 +6,5 @@
 
 CONFIG_ZTEST=y
 CONFIG_ZTEST_THREAD_PRIORITY=0
+
+CONFIG_FPU=y # For compatibility with SPM.

--- a/tests/subsys/spm/thread_swap/src/main.c
+++ b/tests/subsys/spm/thread_swap/src/main.c
@@ -33,7 +33,7 @@ void test_spm_service_thread_swap1(void)
 	 */
 	k_work_init_delayable(&interrupting_work, work_func);
 	err = k_work_reschedule(&interrupting_work, K_MSEC(10));
-	zassert_equal(0, err, "k_delayed_work failed: %d\n", err);
+	zassert_true(err >= 0, "k_work_reschedule failed: %d\n", err);
 
 	/* Call into the secure service which will be interrupted. If the
 	 * scheduler is locked before entering secure services, it will prevent


### PR DESCRIPTION
The SPM assumes FPU to be enabled.
Without this, the test (NS) faults.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>