### PR TITLE
download_client: Don't parse header past end of accumulated buffer

### DIFF
--- a/subsys/net/lib/download_client/src/http.c
+++ b/subsys/net/lib/download_client/src/http.c
@@ -112,7 +112,7 @@ static int http_header_parse(struct download_client *client, size_t *hdr_len)
 	char *p;
 
 	p = strstr(client->buf, "\r\n\r\n");
-	if (!p) {
+	if (!p || p > client->buf + client->offset) {
 		/* Waiting full HTTP header */
 		LOG_DBG("Waiting full header in response");
 		return 1;


### PR DESCRIPTION
## Description

When a block of data is received in the download thread from the server, `http_parse()` is called, to parse the header and retrieve any image data available.

`http_header_parse()` looks for the end of the header, indicated by the string `"\r\n\r\n"`.  If it has only received part of the header, it returns 1, indicating that more data needs to be downloaded before it can parse the full header.

However, `http_header_parse()` doesn't verify where in the `client->buf` the `"\r\n\r\n"` string is contained.  It's possible that only part of the header has been received in this transaction, and the data in the remaining part of the buffer is from a previous transaction.  The `download_thread` never clears this buffer before calling `recv()` between transactions - it's usually overwritten by image data, but this is not guaranteed.

This change simply makes sure `http_header_parse()` isn't attempting to parse past the end of the data received so far, which is kept track with `client->offset`.  Another way to solve this would be to 0 the buffer between each partial response of the range request; or, use `strnstr()` to limit the search to `client->offset` bytes (unfortunately, `strnstr()` is not available as part of Zephyr's minimal libc library).

## Example of Bug

I hit this bug when attempting a FOTA from a Google Cloud Storage bucket.  the FOTA would consistently make it to 96%, and then crash with the following debug message:

```
[00:04:09.484,558] <dbg> download_client.http_parse: Copying 4294967281 payload bytes
```

The payload was computed to be 4294967281 `(client->offset - hdr_len)`, because the number of bytes received was _less_ than the header size computed by looking for `"\r\n\r\n"`, because there was old data past the end of the buffer:

```
[00:07:12.734,985] <dbg> download_client.HTTP response
                                         48 54 54 50 2f 31 2e 31  20 32 30 36 20 50 61 72 |HTTP/1.1  206 Par
                                         74 69 61 6c 20 43 6f 6e  74 65 6e 74 0d 0a 58 2d |tial Con tent..X-
                                         47 55 70 6c 6f 61 64 65  72 2d 55 70 6c 6f 61 64 |GUploade r-Upload
                                         49 44 3a 20 41 42 67 35  2d 55 7a 61 4a 35 35 34 |ID: ABg5 -UzaJ554
                                         69 6e 76 6f 6d 45 67 53  6a 37 30 34 45 55 45 4d |invomEgS j704EUEM
                                         70 77 42 4f 64 48 69 42  75 7a 34 79 41 76 67 33 |pwBOdHiB uz4yAvg3
                                         59 4a 6c 65 6f 57 5f 4e  66 65 75 79 31 71 71 53 |YJleoW_N feuy1qqS
                                         4e 73 76 32 72 53 64 46  35 41 6a 76 4a 2d 64 6f |Nsv2rSdF 5AjvJ-do
                                         44 5f 50 33 5f 78 2d 66  50 44 4a 6a 47 75 30 5f |D_P3_x-f PDJjGu0_
                                         6a 41 6e 36 67 51 0d 0a  45 78 70 69 72 65 73 3a |jAn6gQ.. Expires:
                                         20 54 75 65 2c 20 31 31  20 4d 61 79 20 32 30 32 | Tue, 11  May 202
                                         31 20 32 32 3a 30 36 3a  32 35 20 47 4d 54 0d 0a |1 22:06: 25 GMT..
                                         44 61 74 65 3a 20 54 75  65 2c 20 31 31 20 4d 61 |Date: Tu e, 11 Ma
                                         79 20 32 30 32 31 20 32  31 3a 30 36 3a 32 35 20 |y 2021 2 1:06:25 
                                         47 4d 54 0d 0a 43 61 63  68 65 2d 43 6f 6e 74 72 |GMT..Cac he-Contr
                                         6f 6c 3a 20 70 75 62 6c  69 63 2c 20 6d 61 78 2d |ol: publ ic, max-
                                         61 67 65 3d 33 36 30 30  0d 0a 4c 61 73 74 2d 4d |age=3600 ..Last-M
                                         6f 64 69 66 69 65 64 3a  20 4d 6f 6e 2c 20 31 30 |odified:  Mon, 10
                                         20 4d 61 79 20 32 30 32  31 20 32 33 3a 30 39 3a | May 202 1 23:09:
                                         33 39 20 47 4d 54 0d 0a  45 54 61 67 3a 20 22 39 |39 GMT.. ETag: "9
                                         36 61 34 37 65 30 36 63  30 66 65 65 62 65 35 35 |6a47e06c 0feebe55
                                         61 65 39 62 33 65 64 30  65 37 38 39 63 62 36 22 |ae9b3ed0 e789cb6"
                                         0d 0a 78 2d 67 6f 6f 67  2d 67 65 6e 65 72 61 74 |..x-goog -generat
                                         69 6f 6e 3a 20 31 36 32  30 36 38 38 31 37 39 35 |ion: 162 06881795
                                         35 34 31 39 33 0d 0a 78  2d 67 6f 6f 67 2d 6d 65 |54193..x -goog-me
                                         74 61 67 65 6e 65 72 61  74 69 6f 6e 3a 20 31 0d |tagenera tion: 1.
                                         0a 78 2d 67 6f 6f 67 2d  73 74 6f 72 65 64 2d 63 |.x-goog- stored-c
                                         6f 6e 74 65 6e 74 2d 65  6e 63 6f 64 69 6e 67 3a |ontent-e ncoding:
                                         20 69 64 65 6e 74 69 74  79 0d 0a 78 2d 67 6f 6f | identit y..x-goo
                                         67 2d 73 74 6f 72 65 64  2d 63 6f 6e 74 65 6e 74 |g-stored -content
                                         2d 6c 65 6e 67 74 68 3a  20 33 37 30 35 34 34 0d |-length:  370544.
                                         0a 43 6f 6e 74 65 6e 74  2d 54 79 70 65 3a 20 61 |.Content -Type: a
                                         70 70 6c 69 63 61 74 69  6f 6e 2f 6d 61 63 62 69 |pplicati on/macbi
                                         6e 61 72 79 0d 0a 78 2d  67 6f 6f 67 2d 68 61 73 |nary..x- goog-has
                                         68 3a 20 63 72 63 33 32  63 3d 7a 30 33 7a 6b 51 |h: crc32 c=z03zkQ
                                         3d 3d 0d 0a 78 2d 67 6f  6f 67 2d 68 61 73 68 3a |==..x-go og-hash:
                                         20 6d 64 35 3d 6c 71 52  2b 42 73 44 2b 36 2b 56 | md5=lqR +BsD+6+V
                                         61 36 62 50 74 44 6e 69  63 74 67 3d 3d 0d 0a 78 |a6bPtDni ctg==..x
                                         2d 67 6f 6f 67 2d 73 74  6f 72 61 67 65 2d 63 6c |-goog-st orage-cl
                                         61 73 73 3a 20 53 54 41  4e 44 41 52 44 0d 0a 41 |ass: STA NDARD..A
                                         63 63 65 70 74 2d 52 61  6e 67 65 73 3a 20 62 79 |ccept-Ra nges: by
                                         74 65 73 0d 0a 43 6f 6e  74 65 6e 74 2d 52 61 6e |tes..Con tent-Ran
                                         67 65 3a 20 62 79 74 65  73 20 33 35 37 33 37 36 |ge: byte s 357376
                                         2d 33 35 38 33 39 39 2f  33 37 30 35 34 34 0d 0a |-358399/ 370544..
                                         43 6f 6e 74 20 6b 65 65  70 2d 61 6c 69 76 65 0d |Cont kee p-alive.
                                         0a 0d 0a                                         |...              
```

We only received 708 bytes (i.e., `recv()` return 708), but `http_header_parse()` thought the header was 723 bytes - because the last 15 bytes were from old data not received in the most recent response (the string ` keep-alive\r\n\r\n`)
