### PR TITLE
doc: update link to nRF Sniffer for 802.15.4

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -248,7 +248,7 @@
 .. _`DFU over Zigbee`: https://infocenter.nordicsemi.com/topic/ug_nrfutil/UG/nrfutil/nrfutil_dfu_zigbee.html
 
 .. _`nRF Thread Topology Monitor`: https://infocenter.nordicsemi.com/topic/ug_nrf_ttm/UG/nrf_ttm/ttm_introduction.html
-.. _`nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`: https://infocenter.nordicsemi.com/topic/sdk_tz_v4.1.0/nrf802154_sniffer.html
+.. _`nRF Sniffer for 802.15.4`: https://infocenter.nordicsemi.com/topic/ug_sniffer_802154/UG/sniffer_802154/intro_802154.html
 
 .. _`Power Profiler Kit II (PPK2)`: https://infocenter.nordicsemi.com/topic/ug_ppk2/UG/ppk/PPK_user_guide_Intro.html
 

--- a/doc/nrf/ug_thread_tools.rst
+++ b/doc/nrf/ug_thread_tools.rst
@@ -17,7 +17,7 @@ nRF Sniffer for 802.15.4
 The nRF Sniffer for 802.15.4 is a tool for learning about and debugging applications that are using protocols based on IEEE 802.15.4, like Thread or Zigbee.
 It provides a near real-time display of 802.15.4 packets that are sent back and forth between devices, even when the link is encrypted.
 
-See `nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`_ for documentation.
+See `nRF Sniffer for 802.15.4`_ for documentation.
 
 .. _ug_thread_tools_ttm:
 

--- a/doc/nrf/ug_zigbee_tools.rst
+++ b/doc/nrf/ug_zigbee_tools.rst
@@ -5,7 +5,7 @@ Zigbee tools
 
 When working with Zigbee in |NCS|, you can use the following tools during Zigbee application development:
 
-* `nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`_ - Tool for analyzing network traffic during development.
+* `nRF Sniffer for 802.15.4`_ - Tool for analyzing network traffic during development.
 * `ZBOSS NCP Host`_ - ZBOSS-based tool for running the host side of the :ref:`ug_zigbee_platform_design_ncp_details` design, distributed as a standalone :file:`zip` package.
   |zigbee_ncp_package|
 

--- a/include/zigbee/zigbee_logger_eprxzcl.rst
+++ b/include/zigbee/zigbee_logger_eprxzcl.rst
@@ -10,7 +10,7 @@ Zigbee endpoint logger
 The Zigbee endpoint logger library provides the :c:func:`zigbee_logger_eprxzcl_ep_handler` function.
 You can use this endpoint handler function for parsing incoming ZCL frames and logging their fields and command payload.
 
-The library can work as a partial replacement of `nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`_ for debugging and testing purposes.
+The library can work as a partial replacement of `nRF Sniffer for 802.15.4`_ for debugging and testing purposes.
 Unlike the sniffer, it provides logging information only for incoming ZCL frames on a specific device.
 
 .. _lib_zigbee_logger_endpoint_parsing:

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -86,7 +86,7 @@ Optionally, you can use one or more compatible development kits programmed with 
 Thread 1.2 extension requirements
 =================================
 
-If you enable the :ref:`ot_cli_sample_thread_v12`, you will need `nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`_ to observe messages sent from the router to the leader kit when :ref:`ot_cli_sample_testing_multiple_v12`.
+If you enable the :ref:`ot_cli_sample_thread_v12`, you will need `nRF Sniffer for 802.15.4`_ to observe messages sent from the router to the leader kit when :ref:`ot_cli_sample_testing_multiple_v12`.
 
 User interface
 **************
@@ -334,7 +334,7 @@ To test the Thread 1.2 features, complete the following steps:
       Done
 
    The router kit will send an ``MLR.req`` message to the leader kit (Backbone Router).
-   This can be observed using the `nRF Sniffer for 802.15.4 based on nRF52840 with Wireshark`_.
+   This can be observed using the `nRF Sniffer for 802.15.4`_.
 
    .. note::
         The DUA registration with the Backbone Router is not yet supported.


### PR DESCRIPTION
Update the link to the nRF Sniffer for 802.15.4 user guide.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>