### PR TITLE
Bluetooth: Mesh: Permit transition time = NULL

### DIFF
--- a/include/bluetooth/mesh/gen_lvl.h
+++ b/include/bluetooth/mesh/gen_lvl.h
@@ -32,9 +32,11 @@ struct bt_mesh_lvl_set {
 	/** Whether this is a new action. */
 	bool new_transaction;
 	/**
-	 * Transition time parameters for the state change. Setting the
-	 * transition to NULL makes the server use its default transition time
-	 * parameters.
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
 	 */
 	const struct bt_mesh_model_transition *transition;
 };
@@ -50,9 +52,11 @@ struct bt_mesh_lvl_delta_set {
 	 */
 	bool new_transaction;
 	/**
-	 * Transition time parameters for the state change. Setting the
-	 * transition to NULL makes the server use its default transition time
-	 * parameters.
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
 	 */
 	const struct bt_mesh_model_transition *transition;
 };
@@ -64,10 +68,13 @@ struct bt_mesh_lvl_move_set {
 	/** Whether this is a new action. */
 	bool new_transaction;
 	/**
-	 * Transition parameters. @c delay indicates time until the move
-	 * should start, @c transition indicates the amount of time each
-	 * @c delta step should take. Setting the transition to NULL makes the
-	 * server use its default transition time parameters.
+	 * Transition parameters, or NULL. @c delay indicates time until the
+	 * move should start, @c time indicates the amount of time each @c delta
+	 * step should take.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
 	 */
 	const struct bt_mesh_model_transition *transition;
 };

--- a/include/bluetooth/mesh/gen_onoff.h
+++ b/include/bluetooth/mesh/gen_onoff.h
@@ -24,7 +24,13 @@ extern "C" {
 struct bt_mesh_onoff_set {
 	/** State to set. */
 	bool on_off;
-	/** Transition parameters. */
+	/**
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
+	 */
 	const struct bt_mesh_model_transition *transition;
 };
 

--- a/include/bluetooth/mesh/gen_plvl.h
+++ b/include/bluetooth/mesh/gen_plvl.h
@@ -25,9 +25,11 @@ struct bt_mesh_plvl_set {
 	/** Power Level. */
 	uint16_t power_lvl;
 	/**
-	 * Transition time parameters for the state change. Setting the
-	 * transition to NULL makes the server use its default transition time
-	 * parameters.
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
 	 */
 	const struct bt_mesh_model_transition *transition;
 };

--- a/include/bluetooth/mesh/light_ctl.h
+++ b/include/bluetooth/mesh/light_ctl.h
@@ -47,8 +47,12 @@ struct bt_mesh_light_temp {
 struct bt_mesh_light_ctl_set {
 	/** CTL set parameters. */
 	struct bt_mesh_light_ctl params;
-	/** Transition time parameters for the state change, or NULL to use the
-	 *  default transition time.
+	/**
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
 	 */
 	const struct bt_mesh_model_transition *transition;
 };
@@ -71,8 +75,12 @@ struct bt_mesh_light_ctl_status {
 struct bt_mesh_light_temp_set {
 	/** New light temperature. */
 	struct bt_mesh_light_temp params;
-	/** Transition time parameters for the state change, or NULL to use the
-	 *  default transition time.
+	/**
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
 	 */
 	const struct bt_mesh_model_transition *transition;
 };

--- a/include/bluetooth/mesh/light_hsl.h
+++ b/include/bluetooth/mesh/light_hsl.h
@@ -49,7 +49,13 @@ struct bt_mesh_light_hue_sat {
 struct bt_mesh_light_hsl_params {
 	/** HSL set parameters */
 	struct bt_mesh_light_hsl params;
-	/** Transition time parameters for the state change. */
+	/**
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
+	 */
 	const struct bt_mesh_model_transition *transition;
 };
 
@@ -63,7 +69,13 @@ struct bt_mesh_light_hue_delta {
 	 * relative to the original value in the previous delta_set command.
 	 */
 	bool new_transaction;
-	/** Transition time parameters for the state change. */
+	/**
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
+	 */
 	const struct bt_mesh_model_transition *transition;
 };
 
@@ -75,6 +87,10 @@ struct bt_mesh_light_hue_move {
 	 * Transition parameters. @c delay indicates time until the move
 	 * should start, @c time indicates the amount of time each
 	 * @c delta step should take.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
 	 */
 	const struct bt_mesh_model_transition *transition;
 };
@@ -91,7 +107,13 @@ struct bt_mesh_light_hsl_status {
 struct bt_mesh_light_hue {
 	/** Level to set */
 	uint16_t lvl;
-	/** Transition time parameters for the state change. */
+	/**
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
+	 */
 	const struct bt_mesh_model_transition *transition;
 };
 
@@ -99,7 +121,13 @@ struct bt_mesh_light_hue {
 struct bt_mesh_light_sat {
 	/** Level to set */
 	uint16_t lvl;
-	/** Transition time parameters for the state change. */
+	/**
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
+	 */
 	const struct bt_mesh_model_transition *transition;
 };
 

--- a/include/bluetooth/mesh/light_xyl.h
+++ b/include/bluetooth/mesh/light_xyl.h
@@ -40,7 +40,13 @@ struct bt_mesh_light_xyl {
 struct bt_mesh_light_xyl_set_params {
 	/** xyL set parameters */
 	struct bt_mesh_light_xyl params;
-	/** Transition time parameters for the state change. */
+	/**
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
+	 */
 	struct bt_mesh_model_transition *transition;
 };
 

--- a/include/bluetooth/mesh/light_xyl_srv.h
+++ b/include/bluetooth/mesh/light_xyl_srv.h
@@ -65,7 +65,13 @@ struct bt_mesh_light_xyl_srv;
 struct bt_mesh_light_xy_set {
 	/** xy set parameters */
 	struct bt_mesh_light_xy params;
-	/** Transition time parameters for the state change. */
+	/**
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
+	 */
 	struct bt_mesh_model_transition *transition;
 };
 

--- a/include/bluetooth/mesh/lightness.h
+++ b/include/bluetooth/mesh/lightness.h
@@ -31,9 +31,11 @@ struct bt_mesh_lightness_set {
 	/** Lightness level. */
 	uint16_t lvl;
 	/**
-	 * Transition time parameters for the state change. Setting the
-	 * transition to NULL makes the server use its default transition time
-	 * parameters.
+	 * Transition time parameters for the state change, or NULL.
+	 *
+	 * When sending, setting the transition to NULL makes the receiver use
+	 * its default transition time parameters, or 0 if no default transition
+	 * time is set.
 	 */
 	const struct bt_mesh_model_transition *transition;
 };

--- a/include/bluetooth/mesh/model_types.h
+++ b/include/bluetooth/mesh/model_types.h
@@ -81,6 +81,23 @@ enum bt_mesh_rgb_ch {
 	BT_MESH_RGB_CHANNELS,
 };
 
+/** @brief Get the total transition time
+ *
+ *  @param[in] trans Transition time, or NULL.
+ *
+ *  @return Total time of the given transition, in milliseconds, or 0 if
+ *          @p trans is NULL.
+ */
+static inline int32_t
+bt_mesh_model_transition_time(const struct bt_mesh_model_transition *trans)
+{
+	if (!trans) {
+		return 0;
+	}
+
+	return trans->delay + trans->time;
+}
+
 /** @cond INTERNAL_HIDDEN
  * @def BT_MESH_MODEL_USER_DATA
  *

--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -26,17 +26,6 @@ static void encode_status(const struct bt_mesh_lvl_status *status,
 			      model_transition_encode(status->remaining_time));
 }
 
-static void transition_get(struct bt_mesh_lvl_srv *srv,
-			   struct bt_mesh_model_transition *transition,
-			   struct net_buf_simple *buf)
-{
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->model, transition);
-	}
-}
-
 static void rsp_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       const struct bt_mesh_lvl_status *status)
 {
@@ -71,15 +60,14 @@ static void set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	}
 
 	struct bt_mesh_lvl_srv *srv = model->user_data;
-	struct bt_mesh_lvl_status status = { 0 };
 	struct bt_mesh_model_transition transition;
+	struct bt_mesh_lvl_status status = { 0 };
 	struct bt_mesh_lvl_set set;
 
 	set.lvl = net_buf_simple_pull_le16(buf);
 	set.new_transaction = !tid_check_and_update(
 		&srv->tid, net_buf_simple_pull_u8(buf), ctx);
-	transition_get(srv, &transition, buf);
-	set.transition = &transition;
+	set.transition = model_transition_get(srv->model, &transition, buf);
 
 	srv->handlers->set(srv, ctx, &set, &status);
 
@@ -110,8 +98,7 @@ static void delta_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	delta_set.delta = net_buf_simple_pull_le32(buf);
 	delta_set.new_transaction = !tid_check_and_update(
 		&srv->tid, net_buf_simple_pull_u8(buf), ctx);
-	transition_get(srv, &transition, buf);
-	delta_set.transition = &transition;
+	delta_set.transition = model_transition_get(srv->model, &transition, buf);
 
 	srv->handlers->delta_set(srv, ctx, &delta_set, &status);
 
@@ -142,15 +129,15 @@ static void move_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	move_set.delta = net_buf_simple_pull_le16(buf);
 	move_set.new_transaction = !tid_check_and_update(
 		&srv->tid, net_buf_simple_pull_u8(buf), ctx);
-	transition_get(srv, &transition, buf);
-	move_set.transition = &transition;
+	move_set.transition = model_transition_get(srv->model, &transition, buf);
 
 	/* If transition.time is 0, we shouldn't move. Align these two
 	 * parameters to simplify application logic for this case:
 	 */
-	if (move_set.transition->time == 0 || move_set.delta == 0) {
+	if ((!move_set.transition || move_set.transition->time == 0) ||
+	    move_set.delta == 0) {
 		move_set.delta = 0;
-		transition.time = 0;
+		move_set.transition = NULL;
 	}
 
 	srv->handlers->move_set(srv, ctx, &move_set, &status);

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -60,7 +60,7 @@ static void onoff_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_onoff_srv *srv = model->user_data;
 	struct bt_mesh_onoff_status status = { 0 };
 	struct bt_mesh_model_transition transition;
-	struct bt_mesh_onoff_set set = { .transition = &transition };
+	struct bt_mesh_onoff_set set;
 
 	uint8_t on_off = net_buf_simple_pull_u8(buf);
 	uint8_t tid = net_buf_simple_pull_u8(buf);
@@ -81,8 +81,10 @@ static void onoff_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 
 	if (buf->len == 2) {
 		model_transition_buf_pull(buf, &transition);
+		set.transition = &transition;
 	} else if (!atomic_test_bit(&srv->flags, GEN_ONOFF_SRV_NO_DTT)) {
 		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
+		set.transition = &transition;
 	} else {
 		set.transition = NULL;
 	}

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -85,17 +85,6 @@ static int pub(struct bt_mesh_plvl_srv *srv, struct bt_mesh_msg_ctx *ctx,
 	return model_send(srv->plvl_model, ctx, &msg);
 }
 
-static void transition_get(struct bt_mesh_plvl_srv *srv,
-			   struct bt_mesh_model_transition *transition,
-			   struct net_buf_simple *buf)
-{
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->plvl_model, transition);
-	}
-}
-
 static void rsp_plvl_status(struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct bt_mesh_plvl_status *status)
@@ -169,8 +158,7 @@ static void plvl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 
 	set.power_lvl = net_buf_simple_pull_le16(buf);
 	tid = net_buf_simple_pull_u8(buf);
-	transition_get(srv, &transition, buf);
-	set.transition = &transition;
+	set.transition = model_transition_get(srv->plvl_model, &transition, buf);
 
 	if (!tid_check_and_update(&srv->tid, tid, ctx)) {
 		change_lvl(srv, ctx, &set, &status);
@@ -521,10 +509,10 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 		target = status.current;
 	}
 
-	struct bt_mesh_model_transition transition = { 0 };
+	struct bt_mesh_model_transition transition;
 	struct bt_mesh_plvl_set set = {
 		.power_lvl = target,
-		.transition = &transition,
+		.transition = NULL,
 	};
 
 	if (move_set->delta != 0 && move_set->transition) {
@@ -537,6 +525,7 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 		if (time_to_edge > 0) {
 			transition.delay = move_set->transition->delay;
 			transition.time = time_to_edge;
+			set.transition = &transition;
 		}
 	}
 

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -282,8 +282,7 @@ static int bt_mesh_ponoff_srv_settings_set(struct bt_mesh_model *model,
 		return 0;
 	}
 
-	struct bt_mesh_model_transition transition = { 0 };
-	struct bt_mesh_onoff_set onoff_set = { .transition = &transition };
+	struct bt_mesh_onoff_set onoff_set = { .transition = NULL };
 
 	switch (data.on_power_up) {
 	case BT_MESH_ON_POWER_UP_OFF:

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -62,12 +62,8 @@ static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_lightness_status light_rsp;
 	struct bt_mesh_light_temp_status temp_rsp;
 	struct bt_mesh_light_ctl_status status;
-	struct bt_mesh_lightness_set light = {
-		.transition = &transition,
-	};
-	struct bt_mesh_light_temp_set temp = {
-		.transition = &transition,
-	};
+	struct bt_mesh_lightness_set light;
+	struct bt_mesh_light_temp_set temp;
 	uint8_t tid;
 
 	light.lvl = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
@@ -93,11 +89,8 @@ static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		goto respond;
 	}
 
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, &transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
-	}
+	light.transition = model_transition_get(srv->model, &transition, buf);
+	temp.transition = light.transition;
 
 	lightness_srv_disable_control(&srv->lightness_srv);
 	lightness_srv_change_lvl(&srv->lightness_srv, ctx, &light, &light_rsp);

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -892,14 +892,8 @@ static void light_onoff_set(struct bt_mesh_light_ctrl_srv *srv,
 
 	uint8_t tid = net_buf_simple_pull_u8(buf);
 
-	bool has_trans = (buf->len == 2);
 	struct bt_mesh_model_transition transition;
-
-	if (has_trans) {
-		model_transition_buf_pull(buf, &transition);
-	} else if (buf->len != 0) {
-		return;
-	}
+	bool has_trans = !!model_transition_get(srv->model, &transition, buf);
 
 	enum bt_mesh_light_ctrl_srv_state prev_state = srv->state;
 

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -99,11 +99,7 @@ static void hsl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		struct bt_mesh_light_hue h;
 		struct bt_mesh_light_sat s;
 		struct bt_mesh_lightness_set l;
-	} set = {
-		.h = { .transition = &transition },
-		.s = { .transition = &transition },
-		.l = { .transition = &transition },
-	};
+	} set;
 	uint8_t tid;
 
 	if (buf->len != BT_MESH_LIGHT_HSL_MSG_MINLEN_SET &&
@@ -127,11 +123,9 @@ static void hsl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		return;
 	}
 
-	if (buf->len) {
-		model_transition_buf_pull(buf, &transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(model, &transition);
-	}
+	set.h.transition = model_transition_get(srv->model, &transition, buf);
+	set.s.transition = set.h.transition;
+	set.l.transition = set.h.transition;
 
 	/* In the documentation for the Hue, Saturation and Lightness Servers,
 	 * the user is instructed to publish an HSL status message whenever

--- a/subsys/bluetooth/mesh/light_sat_srv.c
+++ b/subsys/bluetooth/mesh/light_sat_srv.c
@@ -275,9 +275,8 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 		target = status.current;
 	}
 
-	struct bt_mesh_model_transition transition = { 0 };
-	struct bt_mesh_light_sat set = { .lvl = target,
-					     .transition = &transition };
+	struct bt_mesh_light_sat set = { .lvl = target, .transition = NULL };
+	struct bt_mesh_model_transition transition;
 
 	if (move_set->delta != 0 && move_set->transition) {
 		uint32_t distance = abs(target - status.current);
@@ -299,6 +298,7 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 		if (time_to_edge > 0) {
 			transition.delay = move_set->transition->delay;
 			transition.time = time_to_edge;
+			set.transition = &transition;
 		}
 	}
 

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -69,9 +69,7 @@ static void temp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_light_temp_srv *srv = model->user_data;
 	struct bt_mesh_light_temp_status status = { 0 };
 	struct bt_mesh_model_transition transition;
-	struct bt_mesh_light_temp_set set = {
-		.transition = &transition,
-	};
+	struct bt_mesh_light_temp_set set;
 
 	set.params.temp = net_buf_simple_pull_le16(buf);
 	set.params.delta_uv = net_buf_simple_pull_le16(buf);
@@ -90,11 +88,7 @@ static void temp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		goto respond;
 	}
 
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, &transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
-	}
+	set.transition = model_transition_get(srv->model, &transition, buf);
 
 	bt_mesh_light_temp_srv_set(srv, ctx, &set, &status);
 
@@ -254,12 +248,10 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 	struct bt_mesh_light_temp_srv *srv =
 		CONTAINER_OF(lvl_srv, struct bt_mesh_light_temp_srv, lvl);
 	struct bt_mesh_light_temp_status status = { 0 };
-	struct bt_mesh_model_transition transition = {
-		.delay = move_set->transition->delay,
-	};
+	struct bt_mesh_model_transition transition;
 	struct bt_mesh_light_temp_set set = {
 		.params = srv->last,
-		.transition = &transition,
+		.transition = NULL,
 	};
 
 	srv->handlers->get(srv, NULL, &status);
@@ -274,10 +266,15 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 
 	if (move_set->delta != 0 && move_set->transition) {
 		uint64_t distance = abs(set.params.temp - status.current.temp);
-
-		transition.time =
+		uint32_t time_to_edge =
 			(distance * (uint64_t)move_set->transition->time) /
 			abs(move_set->delta);
+
+		if (time_to_edge > 0) {
+			transition.time = time_to_edge;
+			transition.delay = move_set->transition->delay;
+			set.transition = &transition;
+		}
 	}
 
 	bt_mesh_light_temp_srv_set(srv, ctx, &set, &status);

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -85,9 +85,7 @@ static void xyl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_light_xy_set set;
 	struct bt_mesh_light_xy_status status = { 0 };
 	struct bt_mesh_lightness_status light_rsp = { 0 };
-	struct bt_mesh_lightness_set light = {
-		.transition = &transition,
-	};
+	struct bt_mesh_lightness_set light;
 	struct bt_mesh_light_xyl_status xyl_status;
 
 	light.lvl = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
@@ -119,13 +117,9 @@ static void xyl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		}
 	}
 
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, &transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
-	}
+	set.transition = model_transition_get(srv->model, &transition, buf);
+	light.transition = set.transition;
 
-	set.transition = &transition;
 	lightness_srv_disable_control(&srv->lightness_srv);
 	lightness_srv_change_lvl(&srv->lightness_srv, ctx, &light, &light_rsp);
 	srv->handlers->xy_set(srv, ctx, &set, &status);

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -105,18 +105,6 @@ static int pub(struct bt_mesh_lightness_srv *srv, struct bt_mesh_msg_ctx *ctx,
 	return model_send(srv->lightness_model, ctx, &msg);
 }
 
-static void transition_get(struct bt_mesh_lightness_srv *srv,
-			   struct bt_mesh_model_transition *transition,
-			   struct net_buf_simple *buf)
-{
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, transition);
-	} else {
-		bt_mesh_dtt_srv_transition_get(srv->lightness_model,
-					       transition);
-	}
-}
-
 static void rsp_lightness_status(struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct bt_mesh_lightness_status *status,
@@ -192,8 +180,12 @@ void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
 
 	atomic_set_bit_to(&srv->flags, LIGHTNESS_SRV_FLAG_IS_ON, set->lvl > 0);
 
-	BT_DBG("%u [%u + %u ms]", set->lvl, set->transition->delay,
-	       set->transition->time);
+	if (bt_mesh_model_transition_time(set->transition)) {
+		BT_DBG("%u [%u + %u ms]", set->lvl, set->transition->delay,
+		       set->transition->time);
+	} else {
+		BT_DBG("%u", set->lvl);
+	}
 
 	if (state_change) {
 		store_state(srv);
@@ -227,11 +219,14 @@ static void lightness_set(struct bt_mesh_model *model,
 
 	set.lvl = repr_to_light(net_buf_simple_pull_le16(buf), repr);
 	tid = net_buf_simple_pull_u8(buf);
-	transition_get(srv, &transition, buf);
-	set.transition = &transition;
+	set.transition = model_transition_get(model, &transition, buf);
 
-	BT_DBG("Light set %s: %u [%u + %u ms]", repr_str[repr], set.lvl,
-	       set.transition->delay, set.transition->time);
+	if (bt_mesh_model_transition_time(set.transition)) {
+		BT_DBG("Light set %s: %u [%u + %u ms]", repr_str[repr], set.lvl,
+		set.transition->delay, set.transition->time);
+	} else {
+		BT_DBG("Light set %s: %u", repr_str[repr], set.lvl);
+	}
 
 	if (!tid_check_and_update(&srv->tid, tid, ctx)) {
 		/* According to the Mesh Model Specification section 6.2.3.1,
@@ -655,9 +650,11 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 		target = status.current;
 	}
 
-	struct bt_mesh_model_transition transition = { 0 };
-	struct bt_mesh_lightness_set set = { .lvl = target,
-					     .transition = &transition };
+	struct bt_mesh_model_transition transition;
+	struct bt_mesh_lightness_set set = {
+		.lvl = target,
+		.transition = NULL,
+	};
 
 	if (move_set->delta != 0 && move_set->transition) {
 		uint32_t distance = abs(target - status.current);
@@ -679,6 +676,7 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 		if (time_to_edge > 0) {
 			transition.delay = move_set->transition->delay;
 			transition.time = time_to_edge;
+			set.transition = &transition;
 		}
 	}
 

--- a/subsys/bluetooth/mesh/model_utils.h
+++ b/subsys/bluetooth/mesh/model_utils.h
@@ -14,6 +14,7 @@
 
 #include <string.h>
 #include <bluetooth/mesh/model_types.h>
+#include <bluetooth/mesh/gen_dtt_srv.h>
 
 /**
  * @brief Returns rounded division of @p A divided by @p B.
@@ -162,10 +163,21 @@ model_transition_buf_pull(struct net_buf_simple *buf,
 	transition->delay = model_delay_decode(net_buf_simple_pull_u8(buf));
 }
 
-static inline bool
-model_transition_is_active(const struct bt_mesh_model_transition *transition)
+static inline struct bt_mesh_model_transition *
+model_transition_get(struct bt_mesh_model *model,
+		     struct bt_mesh_model_transition *transition,
+		     struct net_buf_simple *buf)
 {
-	return (transition->time > 0 || transition->delay > 0);
+	if (buf->len == 2) {
+		model_transition_buf_pull(buf, transition);
+		return transition;
+	}
+
+	if (bt_mesh_dtt_srv_transition_get(model, transition)) {
+		return transition;
+	}
+
+	return NULL;
 }
 
 static inline bool

--- a/subsys/bluetooth/mesh/scene_srv.c
+++ b/subsys/bluetooth/mesh/scene_srv.c
@@ -46,7 +46,7 @@ static inline void update_page_count(struct bt_mesh_scene_srv *srv, bool vnd,
 
 static uint16_t current_scene(const struct bt_mesh_scene_srv *srv, int64_t now)
 {
-	if (model_transition_is_active(&srv->transition) &&
+	if (bt_mesh_model_transition_time(&srv->transition) &&
 	    srv->prev != srv->next && now < srv->transition_end) {
 		if (now < srv->transition_end - srv->transition.time) {
 			return srv->prev;
@@ -60,7 +60,7 @@ static uint16_t current_scene(const struct bt_mesh_scene_srv *srv, int64_t now)
 
 static uint16_t target_scene(const struct bt_mesh_scene_srv *srv, int64_t now)
 {
-	if (model_transition_is_active(&srv->transition) &&
+	if (bt_mesh_model_transition_time(&srv->transition) &&
 	    srv->prev != srv->next && now < srv->transition_end) {
 		return srv->next;
 	}
@@ -131,23 +131,17 @@ static void scene_recall(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ct
 	struct bt_mesh_model_transition transition;
 	enum bt_mesh_scene_status status;
 	uint16_t scene;
+	bool has_trans;
 	uint8_t tid;
 	int err;
 
 	scene = net_buf_simple_pull_le16(buf);
-	tid = net_buf_simple_pull_u8(buf);
-	if (buf->len == 2) {
-		model_transition_buf_pull(buf, &transition);
-	} else if (!buf->len) {
-		bt_mesh_dtt_srv_transition_get(model, &transition);
-	} else {
-		return;
-	}
-
-	if (scene == BT_MESH_SCENE_NONE ||
-	    model_transition_is_invalid(&transition)) {
+	if (scene == BT_MESH_SCENE_NONE) {
 		return; /* Prohibited */
 	}
+
+	tid = net_buf_simple_pull_u8(buf);
+	has_trans = !!model_transition_get(srv->model, &transition, buf);
 
 	if (tid_check_and_update(&srv->tid, tid, ctx)) {
 		BT_DBG("Duplicate TID");
@@ -155,7 +149,7 @@ static void scene_recall(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ct
 		return;
 	}
 
-	err = bt_mesh_scene_srv_set(srv, scene, &transition);
+	err = bt_mesh_scene_srv_set(srv, scene, has_trans ? &transition : NULL);
 	status = ((err == -ENOENT) ? BT_MESH_SCENE_NOT_FOUND :
 				     BT_MESH_SCENE_SUCCESS);
 
@@ -769,6 +763,7 @@ void bt_mesh_scene_invalidate(struct bt_mesh_scene_entry *entry)
 int bt_mesh_scene_srv_set(struct bt_mesh_scene_srv *srv, uint16_t scene,
 			  struct bt_mesh_model_transition *transition)
 {
+	int32_t transition_time;
 	char path[25];
 
 	if (scene == BT_MESH_SCENE_NONE ||
@@ -782,10 +777,10 @@ int bt_mesh_scene_srv_set(struct bt_mesh_scene_srv *srv, uint16_t scene,
 	}
 
 	srv->prev = current_scene(srv, k_uptime_get());
-	if (transition && model_transition_is_active(transition)) {
-		srv->transition_end =
-			k_uptime_get() + transition->delay + transition->time;
 
+	transition_time = bt_mesh_model_transition_time(transition);
+	if (transition_time) {
+		srv->transition_end = k_uptime_get() + transition_time;
 		srv->transition = *transition;
 	} else {
 		srv->transition_end = 0U;

--- a/subsys/bluetooth/mesh/scheduler_srv.c
+++ b/subsys/bluetooth/mesh/scheduler_srv.c
@@ -781,7 +781,7 @@ static int scheduler_srv_settings_set(struct bt_mesh_model *model,
 				      void *cb_data)
 {
 	struct bt_mesh_scheduler_srv *srv = model->user_data;
-	struct bt_mesh_schedule_entry data;
+	struct bt_mesh_schedule_entry data = { 0 };
 	ssize_t len = read_cb(cb_data, &data, sizeof(data));
 	uint8_t idx = strtol(name, NULL, 16);
 

--- a/subsys/bluetooth/mesh/sensor_cli.c
+++ b/subsys/bluetooth/mesh/sensor_cli.c
@@ -433,11 +433,10 @@ static void handle_setting_status(struct bt_mesh_model *model,
 
 	uint16_t id = net_buf_simple_pull_le16(buf);
 	uint16_t setting_id = net_buf_simple_pull_le16(buf);
-	struct bt_mesh_sensor_setting_status setting;
+	struct bt_mesh_sensor_setting_status setting = { 0 };
 	uint8_t access;
 
 	if (buf->len == 0) {
-		setting.type = NULL;
 		goto yield_ack;
 	}
 


### PR DESCRIPTION
Pull request #3827 changed the Generic OnOff's set message transition
time parameter to NULL for certain scenarios. This change is propagated
to higher level models, which forward the OnOff set message in some way.

To make this behavior consistent, this change makes the transition
pointer NULLable in all APIs, and makes all server models follow the
same pattern as the Generic OnOff model, so that when no transition time
parameters are provided (either in the message, or through DTT), the
transition pointer is NULL.

Updates documentation and samples, and replaces some code that jumps
through hoops to ensure that transition isn't NULL. See handling of
Generic Level's Move set in higher level models, in particular.

Replaces model_transition_is_active with a public function that returns
the total transition time.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>