### PR TITLE
mpsl: Make signaling semaphore binary

### DIFF
--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -33,7 +33,7 @@ const uint32_t z_mpsl_used_nrf_ppi_groups;
 #endif
 #define MPSL_LOW_PRIO (4)
 
-static K_SEM_DEFINE(sem_signal, 0, UINT_MAX);
+static K_SEM_DEFINE(sem_signal, 0, 1);
 static struct k_thread signal_thread_data;
 static K_THREAD_STACK_DEFINE(signal_thread_stack,
 			     CONFIG_MPSL_SIGNAL_STACK_SIZE);


### PR DESCRIPTION
Semaphore's count value can increase in an uncontrolled manner during
certain multiprotocol scenarios. As an example take Bluetooth scanning
and IEEE 802.15.4 RX. The IEEE 802.15.4 driver tries to request a
timeslot. The request is denied due to scanning activity. In the signal
handler the driver requests the timeslot again. This chain of events
creates a busy loop during which the best case scenario is one semaphore
taken and one semaphore given. Any more signal that shall be handled in
the low priority handler bumps the counter. The counting semaphore must
be then unwind to return control to other threads. This can introduce
performance issues and even block other threads entirely.
Changing the counting semaphore to binary resolves the issue as there is
no unwinding required.

Signed-off-by: Pawel Kwiek <pawel.kwiek@nordicsemi.no>