### PR TITLE
mgmt: settings: Add SMP command to erase settings

### DIFF
--- a/include/mgmt/settings_mgmt.h
+++ b/include/mgmt/settings_mgmt.h
@@ -1,0 +1,54 @@
+
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file settings_mgmt.h
+ * @defgroup settings_mgmt MCUMgr module for managing settings
+ * @{
+ * @brief MCUMgr based Settings management.
+ *
+ * Module for managing settings area with the SMP protocol.
+ *
+ * The command values are 6 for erase.
+ *
+ */
+
+
+#ifndef SETTINGS_MGMT_H__
+#define SETTINGS_MGMT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Setup and register the command handler for settings management
+ *  command handler group.
+ *
+ *  Since settings mgmt uses the same group ID as OS mgmt it needs to be
+ *  initialized before OS mgmt.
+ */
+
+void settings_mgmt_init(void);
+
+/** @brief Setup and register the command handler for settings management
+ *  command handler group.
+ *
+ *  Since settings mgmt uses the same group ID as OS mgmt it needs to be
+ *  initialized before OS mgmt.
+ */
+
+int storage_erase(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* SETTINGS_MGMT_H__ */

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -26,6 +26,7 @@ add_subdirectory_ifdef(CONFIG_TRUSTED_EXECUTION_NONSECURE nonsecure)
 add_subdirectory_ifdef(CONFIG_MPSL mpsl)
 add_subdirectory_ifdef(CONFIG_ZIGBEE zigbee)
 add_subdirectory_ifdef(CONFIG_MGMT_FMFU mgmt/fmfu)
+add_subdirectory_ifdef(CONFIG_MGMT_SETTINGS mgmt/settings)
 
 if (CONFIG_NFC_T2T_NRFXLIB OR
     CONFIG_NFC_T4T_NRFXLIB OR

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -39,6 +39,6 @@ rsource "nrf_rpc/Kconfig"
 
 rsource "zigbee/Kconfig"
 
-rsource "mgmt/fmfu/Kconfig"
+rsource "mgmt/*/Kconfig"
 
 rsource "caf/Kconfig"

--- a/subsys/mgmt/settings/CMakeLists.txt
+++ b/subsys/mgmt/settings/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+
+# This is needed to get the library paths for cbor attrs etc.
+# used by MCUMgr but also reused in this module
+if(NOT CONFIG_MCUBOOT)
+zephyr_library_link_libraries(MCUMGR)
+endif()
+
+zephyr_library_sources(
+  src/settings_mgmt.c
+  )

--- a/subsys/mgmt/settings/Kconfig
+++ b/subsys/mgmt/settings/Kconfig
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "Settings Management"
+
+if MCUBOOT
+config MGMT_SETTINGS
+	bool "Settings Management Module"
+endif
+
+if !MCUBOOT
+config MGMT_SETTINGS
+	bool "Settings Management Module"
+	depends on MCUMGR
+endif
+
+module=MGMT_SETTINGS
+module-dep=LOG
+module-str=SETTINGS
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+endmenu

--- a/subsys/mgmt/settings/src/settings_mgmt.c
+++ b/subsys/mgmt/settings/src/settings_mgmt.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <logging/log.h>
+#if !defined(CONFIG_MCUBOOT)
+#include <mgmt/mgmt.h>
+#endif
+#include <mgmt/settings_mgmt.h>
+#include <storage/flash_map.h>
+
+LOG_MODULE_REGISTER(mgmt_storage, CONFIG_MGMT_SETTINGS_LOG_LEVEL);
+
+#define STORAGE_MGMT_ID_ERASE 6
+
+int storage_erase(void)
+{
+	const struct flash_area *fa;
+
+
+	int rc = flash_area_open(FLASH_AREA_ID(storage), &fa);
+	if (rc < 0) {
+		LOG_ERR("failed to open flash area");
+		return rc;
+	}
+	rc = flash_area_erase(fa, 0, FLASH_AREA_SIZE(storage));
+	if (rc < 0) {
+		LOG_ERR("failed to erase flash area");
+		return rc;
+	}
+	flash_area_close(fa);
+
+	return rc;
+}
+
+#if !defined(CONFIG_MCUBOOT)
+static int storage_erase_handler(struct mgmt_ctxt *ctxt)
+{
+	CborError cbor_err = 0;
+
+	int rc = storage_erase();
+
+
+	cbor_err |= cbor_encode_text_stringz(&ctxt->encoder, "rc");
+	cbor_err |= cbor_encode_int(&ctxt->encoder, rc);
+	if (cbor_err != 0) {
+		return MGMT_ERR_ENOMEM;
+	}
+
+	return MGMT_ERR_EOK;
+}
+
+static const struct mgmt_handler mgmt_storage_handlers[] = {
+	[STORAGE_MGMT_ID_ERASE] = {
+		.mh_read  = storage_erase_handler,
+		.mh_write = storage_erase_handler,
+	},
+};
+
+static struct mgmt_group storage_mgmt_group = {
+	.mg_handlers = (struct mgmt_handler *)mgmt_storage_handlers,
+	.mg_handlers_count = ARRAY_SIZE(mgmt_storage_handlers),
+	.mg_group_id = (MGMT_GROUP_ID_OS),
+};
+
+void settings_mgmt_init(void)
+{
+	mgmt_register_group(&storage_mgmt_group);
+}
+#endif


### PR DESCRIPTION
Added a subsys which allows the user to send a command to erase the
settings page. So that if the user loads a new application the settings
are not already populated or contains invalid values.

Ref. TG53-97

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>