### PR TITLE
gitignore: ignore common Python venv paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ build-*
 build_*
 cscope.*
 .dir
+venv
+.venv
 
 /*.patch
 


### PR DESCRIPTION
Ignore commonly used Python venv paths (venv, .venv). Useful for
developers using Python virtual environments.