### PR TITLE
doc: nrf: doxygen: add EVENT_TYPE_DECLARE

### DIFF
--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -1979,7 +1979,8 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
 			 "CONFIG_BT_SCAN_ADDRESS_CNT:=1" \
 			 "CONFIG_BT_SCAN_APPEARANCE_CNT:=1" \
                          "CONFIG_PROFILER=y" \
-			 "CONFIG_NFC_TNEP_TAG=y"
+			 "CONFIG_NFC_TNEP_TAG=y" \
+			 "EVENT_TYPE_DECLARE(x)=" \
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
Headers using this construction generate wrong Doxygen output leading
to Sphinx parsing errors. It is common to pre-define such kind of
constructions in the Doxygen predefined fields.

Fixes build issues introduced by the merge of https://github.com/nrfconnect/sdk-nrf/pull/4343