### PR TITLE
Bluetooth: Mesh: Use correct define to enable settings in Sensor

### DIFF
--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -55,7 +55,7 @@ static void cadence_store(const struct bt_mesh_sensor_srv *srv)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_SETTINGS) &&
+	if (IS_ENABLED(CONFIG_BT_SETTINGS) &&
 	    bt_mesh_model_data_store(srv->model, false, NULL, buf.data,
 				     buf.len)) {
 		BT_ERR("Sensor server data store failed");
@@ -876,7 +876,7 @@ static void sensor_srv_reset(struct bt_mesh_model *model)
 		memset(&s->state.threshold, 0, sizeof(s->state.threshold));
 	}
 
-	if (IS_ENABLED(CONFIG_SETTINGS)) {
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		(void)bt_mesh_model_data_store(srv->model, false, NULL, NULL,
 					       0);
 	}


### PR DESCRIPTION
Mesh settings are only enabled if CONFIG_BT_SETTINGS is enabled.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>