### PR TITLE
Convert nRF9160 samples to use the new k_work API

### DIFF
--- a/samples/nrf9160/agps/src/main.c
+++ b/samples/nrf9160/agps/src/main.c
@@ -24,8 +24,8 @@ static struct cloud_backend *cloud_backend;
 static const struct device *gps_dev;
 static uint64_t start_search_timestamp;
 static uint64_t fix_timestamp;
-static struct k_delayed_work gps_start_work;
-static struct k_delayed_work reboot_work;
+static struct k_work gps_start_work;
+static struct k_work_delayable reboot_work;
 
 static void gps_start_work_fn(struct k_work *work);
 
@@ -120,7 +120,7 @@ static void cloud_event_handler(const struct cloud_backend *const backend,
 		/* Update nRF Cloud with GPS service info signifying that it
 		 * has GPS capabilities. */
 		send_service_info();
-		k_delayed_work_submit(&gps_start_work, K_NO_WAIT);
+		k_work_submit(&gps_start_work);
 		break;
 	case CLOUD_EVT_DISCONNECTED:
 		LOG_INF("CLOUD_EVT_DISCONNECTED");
@@ -145,7 +145,12 @@ static void cloud_event_handler(const struct cloud_backend *const backend,
 				      strlen("{\"reboot\":true}"));
 
 			if (ret == 0) {
-				k_delayed_work_submit(&reboot_work, K_NO_WAIT);
+				/* The work item may already be scheduled
+				 * because of the button being pressed,
+				 * so use rescheduling here to get the work
+				 * submitted with no delay.
+				 */
+				k_work_reschedule(&reboot_work, K_NO_WAIT);
 			}
 			break;
 		}
@@ -329,8 +334,8 @@ static void reboot_work_fn(struct k_work *work)
 
 static void work_init(void)
 {
-	k_delayed_work_init(&gps_start_work, gps_start_work_fn);
-	k_delayed_work_init(&reboot_work, reboot_work_fn);
+	k_work_init(&gps_start_work, gps_start_work_fn);
+	k_work_init_delayable(&reboot_work, reboot_work_fn);
 }
 
 static int modem_configure(void)
@@ -371,9 +376,9 @@ static void button_handler(uint32_t button_states, uint32_t has_changed)
 {
 	if (has_changed & button_states & DK_BTN1_MSK) {
 		cloud_send_msg();
-		k_delayed_work_submit(&reboot_work, K_SECONDS(3));
+		k_work_schedule(&reboot_work, K_SECONDS(3));
 	} else if (has_changed & ~button_states & DK_BTN1_MSK) {
-		k_delayed_work_cancel(&reboot_work);
+		k_work_cancel_delayable(&reboot_work);
 	}
 }
 

--- a/samples/nrf9160/azure_fota/src/main.c
+++ b/samples/nrf9160/azure_fota/src/main.c
@@ -20,7 +20,7 @@
 static K_SEM_DEFINE(network_connected_sem, 0, 1);
 static K_SEM_DEFINE(cloud_connected_sem, 0, 1);
 static bool network_connected;
-static struct k_delayed_work reboot_work;
+static struct k_work_delayable reboot_work;
 
 BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
 			 "This sample does not support auto init and connect");
@@ -93,7 +93,7 @@ static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 	case AZURE_IOT_HUB_EVT_FOTA_DONE:
 		printk("AZURE_IOT_HUB_EVT_FOTA_DONE\n");
 		printk("The device will reboot in 5 seconds to apply update\n");
-		k_delayed_work_submit(&reboot_work, K_SECONDS(5));
+		k_work_schedule(&reboot_work, K_SECONDS(5));
 		break;
 	case AZURE_IOT_HUB_EVT_FOTA_ERASE_PENDING:
 		printk("AZURE_IOT_HUB_EVT_FOTA_ERASE_PENDING\n");
@@ -231,7 +231,7 @@ void main(void)
 
 	printk("Modem library initialized\n");
 
-	k_delayed_work_init(&reboot_work, reboot_work_fn);
+	k_work_init_delayable(&reboot_work, reboot_work_fn);
 	at_configure();
 
 	err = azure_iot_hub_init(NULL, azure_event_handler);

--- a/samples/nrf9160/azure_iot_hub/src/main.c
+++ b/samples/nrf9160/azure_iot_hub/src/main.c
@@ -25,13 +25,13 @@
 #define APP_WORK_Q_STACK_SIZE	KB(2)
 
 struct method_data {
-	struct k_delayed_work work;
+	struct k_work work;
 	char request_id[8];
 	char name[32];
 	char payload[200];
 } method_data;
-struct k_delayed_work twin_report_work;
-struct k_delayed_work send_event_work;
+struct k_work twin_report_work;
+struct k_work_delayable send_event_work;
 
 static char recv_buf[RECV_BUF_SIZE];
 static void direct_method_handler(struct k_work *work);
@@ -102,8 +102,8 @@ static void event_interval_apply(int interval)
 	}
 
 	atomic_set(&event_interval, interval);
-	k_delayed_work_submit_to_queue(&application_work_q, &send_event_work,
-				       K_NO_WAIT);
+	k_work_reschedule_for_queue(&application_work_q, &send_event_work,
+				    K_NO_WAIT);
 }
 
 static void on_evt_twin_desired(char *buf, size_t len)
@@ -116,9 +116,7 @@ static void on_evt_twin_desired(char *buf, size_t len)
 
 		memcpy(recv_buf, buf, len);
 		recv_buf[len] = '\0';
-			k_delayed_work_submit_to_queue(&application_work_q,
-						       &twin_report_work,
-						       K_NO_WAIT);
+		k_work_submit_to_queue(&application_work_q, &twin_report_work);
 	} else {
 		printk("Recv buffer is busy, data was not copied\n");
 	}
@@ -136,8 +134,7 @@ static void on_evt_direct_method(struct azure_iot_hub_method *method)
 	snprintf(method_data.payload, sizeof(method_data.payload),
 		 "%.*s", method->payload_len, method->payload);
 
-	k_delayed_work_submit_to_queue(&application_work_q,
-				       &method_data.work, K_NO_WAIT);
+	k_work_submit_to_queue(&application_work_q, &method_data.work);
 }
 
 static void azure_event_handler(struct azure_iot_hub_evt *const evt)
@@ -167,8 +164,8 @@ static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 		 * The below work submission will cause send_event() to be
 		 * call after 3 seconds.
 		 */
-		k_delayed_work_submit_to_queue(&application_work_q,
-					       &send_event_work, K_NO_WAIT);
+		k_work_reschedule_for_queue(&application_work_q,
+					    &send_event_work, K_NO_WAIT);
 		break;
 	case AZURE_IOT_HUB_EVT_DATA_RECEIVED:
 		printk("AZURE_IOT_HUB_EVT_DATA_RECEIVED\n");
@@ -257,8 +254,8 @@ exit:
 	}
 
 	printk("Next event will be sent in %d seconds\n", event_interval);
-	k_delayed_work_submit_to_queue(&application_work_q, &send_event_work,
-				       K_SECONDS(event_interval));
+	k_work_reschedule_for_queue(&application_work_q, &send_event_work,
+				    K_SECONDS(event_interval));
 }
 
 static void direct_method_handler(struct k_work *work)
@@ -414,12 +411,12 @@ static void modem_configure(void)
 
 static void work_init(void)
 {
-	k_delayed_work_init(&method_data.work, direct_method_handler);
-	k_delayed_work_init(&twin_report_work, twin_report_work_fn);
-	k_delayed_work_init(&send_event_work, send_event);
-	k_work_q_start(&application_work_q, application_stack_area,
+	k_work_init(&method_data.work, direct_method_handler);
+	k_work_init(&twin_report_work, twin_report_work_fn);
+	k_work_init_delayable(&send_event_work, send_event);
+	k_work_queue_start(&application_work_q, application_stack_area,
 		       K_THREAD_STACK_SIZEOF(application_stack_area),
-		       K_HIGHEST_APPLICATION_THREAD_PRIO);
+		       K_HIGHEST_APPLICATION_THREAD_PRIO, NULL);
 }
 
 void main(void)

--- a/samples/nrf9160/cloud_client/src/main.c
+++ b/samples/nrf9160/cloud_client/src/main.c
@@ -16,8 +16,8 @@
 LOG_MODULE_REGISTER(cloud_client, CONFIG_CLOUD_CLIENT_LOG_LEVEL);
 
 static struct cloud_backend *cloud_backend;
-static struct k_delayed_work cloud_update_work;
-static struct k_delayed_work connect_work;
+static struct k_work_delayable cloud_update_work;
+static struct k_work_delayable connect_work;
 
 static K_SEM_DEFINE(lte_connected, 0, 1);
 
@@ -30,6 +30,10 @@ static void connect_work_fn(struct k_work *work)
 {
 	int err;
 
+	if (cloud_connected) {
+		return;
+	}
+
 	err = cloud_connect(cloud_backend);
 	if (err) {
 		LOG_ERR("cloud_connect, error: %d", err);
@@ -38,7 +42,7 @@ static void connect_work_fn(struct k_work *work)
 	LOG_INF("Next connection retry in %d seconds",
 	       CONFIG_CLOUD_CONNECTION_RETRY_TIMEOUT_SECONDS);
 
-	k_delayed_work_submit(&connect_work,
+	k_work_schedule(&connect_work,
 		K_SECONDS(CONFIG_CLOUD_CONNECTION_RETRY_TIMEOUT_SECONDS));
 }
 
@@ -76,8 +80,7 @@ static void cloud_update_work_fn(struct k_work *work)
 	}
 
 #if defined(CONFIG_CLOUD_PUBLICATION_SEQUENTIAL)
-	k_delayed_work_submit(
-			&cloud_update_work,
+	k_work_schedule(&cloud_update_work,
 			K_SECONDS(CONFIG_CLOUD_MESSAGE_PUBLICATION_INTERVAL));
 #endif
 }
@@ -96,26 +99,23 @@ void cloud_event_handler(const struct cloud_backend *const backend,
 	case CLOUD_EVT_CONNECTED:
 		LOG_INF("CLOUD_EVT_CONNECTED");
 		cloud_connected = true;
+		/* This may fail if the work item is already being processed,
+		 * but in such case, the next time the work handler is executed,
+		 * it will exit after checking the above flag and the work will
+		 * not be scheduled again.
+		 */
+		(void)k_work_cancel_delayable(&connect_work);
 		break;
 	case CLOUD_EVT_READY:
 		LOG_INF("CLOUD_EVT_READY");
-
-		k_delayed_work_cancel(&connect_work);
-
 #if defined(CONFIG_CLOUD_PUBLICATION_SEQUENTIAL)
-		k_delayed_work_submit(&cloud_update_work, K_NO_WAIT);
+		k_work_reschedule(&cloud_update_work, K_NO_WAIT);
 #endif
 		break;
 	case CLOUD_EVT_DISCONNECTED:
 		LOG_INF("CLOUD_EVT_DISCONNECTED");
-
 		cloud_connected = false;
-
-		if (k_delayed_work_pending(&connect_work)) {
-			break;
-		}
-
-		k_delayed_work_submit(&connect_work, K_NO_WAIT);
+		k_work_reschedule(&connect_work, K_NO_WAIT);
 		break;
 	case CLOUD_EVT_ERROR:
 		LOG_INF("CLOUD_EVT_ERROR");
@@ -149,8 +149,8 @@ void cloud_event_handler(const struct cloud_backend *const backend,
 
 static void work_init(void)
 {
-	k_delayed_work_init(&cloud_update_work, cloud_update_work_fn);
-	k_delayed_work_init(&connect_work, connect_work_fn);
+	k_work_init_delayable(&cloud_update_work, cloud_update_work_fn);
+	k_work_init_delayable(&connect_work, connect_work_fn);
 }
 
 static void lte_handler(const struct lte_lc_evt *const evt)
@@ -245,7 +245,7 @@ static void modem_configure(void)
 static void button_handler(uint32_t button_states, uint32_t has_changed)
 {
 	if (has_changed & button_states & DK_BTN1_MSK) {
-		k_delayed_work_submit(&cloud_update_work, K_NO_WAIT);
+		k_work_reschedule(&cloud_update_work, K_NO_WAIT);
 	}
 }
 #endif
@@ -282,5 +282,5 @@ void main(void)
 	LOG_INF("Connected to LTE network");
 	LOG_INF("Connecting to cloud");
 
-	k_delayed_work_submit(&connect_work, K_NO_WAIT);
+	k_work_schedule(&connect_work, K_NO_WAIT);
 }

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_accelerometer.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_accelerometer.c
@@ -56,7 +56,7 @@ struct orientation_detector_sensor_data {
 
 static const struct device *accel_dev;
 static double accel_offset[3];
-static struct k_delayed_work flip_poll_work;
+static struct k_work_delayable flip_poll_work;
 static uint32_t timestamp;
 
 int orientation_detector_poll(
@@ -169,7 +169,7 @@ static void flip_work(struct k_work *work)
 
 exit:
 	if (work) {
-		k_delayed_work_submit(&flip_poll_work, FLIP_POLL_INTERVAL);
+		k_work_schedule(&flip_poll_work, FLIP_POLL_INTERVAL);
 	}
 }
 
@@ -232,7 +232,7 @@ int lwm2m_init_accel(void)
 	int ret;
 
 	if (IS_ENABLED(CONFIG_FLIP_POLL)) {
-		k_delayed_work_init(&flip_poll_work, flip_work);
+		k_work_init_delayable(&flip_poll_work, flip_work);
 	}
 
 	accel_dev = device_get_binding(CONFIG_ACCEL_DEV_NAME);
@@ -259,7 +259,7 @@ int lwm2m_init_accel(void)
 				  &timestamp, sizeof(timestamp), 0);
 
 	if (IS_ENABLED(CONFIG_FLIP_POLL)) {
-		k_delayed_work_submit(&flip_poll_work, K_NO_WAIT);
+		k_work_schedule(&flip_poll_work, K_NO_WAIT);
 	}
 
 	if (IS_ENABLED(CONFIG_ACCEL_USE_SIM)) {

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_device.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_device.c
@@ -31,7 +31,7 @@ static int usb_ma = 900;
 static uint8_t bat_status = LWM2M_DEVICE_BATTERY_STATUS_CHARGING;
 static int mem_total = (CLIENT_FLASH_SIZE / 1024);
 
-static struct k_delayed_work reboot_work;
+static struct k_work_delayable reboot_work;
 
 static void reboot_work_handler(struct k_work *work)
 {
@@ -47,7 +47,7 @@ static int device_reboot_cb(uint16_t obj_inst_id, uint8_t *args,
 
 	LOG_INF("DEVICE: Reboot in progress");
 
-	k_delayed_work_submit(&reboot_work, REBOOT_DELAY);
+	k_work_schedule(&reboot_work, REBOOT_DELAY);
 
 	return 0;
 }
@@ -65,7 +65,7 @@ static int device_factory_default_cb(uint16_t obj_inst_id, uint8_t *args,
 
 int lwm2m_init_device(char *serial_num)
 {
-	k_delayed_work_init(&reboot_work, reboot_work_handler);
+	k_work_init_delayable(&reboot_work, reboot_work_handler);
 
 	lwm2m_engine_set_res_data("3/0/0", CLIENT_MANUFACTURER,
 				  sizeof(CLIENT_MANUFACTURER),

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
@@ -34,7 +34,7 @@ static uint8_t mcuboot_buf[CONFIG_APP_MCUBOOT_FLASH_BUF_SZ];
 
 static int image_type;
 
-static struct k_delayed_work reboot_work;
+static struct k_work_delayable reboot_work;
 
 void client_acknowledge(void);
 
@@ -82,7 +82,7 @@ static int firmware_update_cb(uint16_t obj_inst_id, uint8_t *args,
 
 	LOG_INF("Rebooting device");
 
-	k_delayed_work_submit(&reboot_work, REBOOT_DELAY);
+	k_work_schedule(&reboot_work, REBOOT_DELAY);
 
 	return 0;
 
@@ -210,7 +210,7 @@ cleanup:
 
 int lwm2m_init_firmware(void)
 {
-	k_delayed_work_init(&reboot_work, reboot_work_handler);
+	k_work_init_delayable(&reboot_work, reboot_work_handler);
 
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT)
 	lwm2m_firmware_set_update_cb(firmware_update_cb);

--- a/samples/nrf9160/lwm2m_client/src/ui/led_pwm.c
+++ b/samples/nrf9160/lwm2m_client/src/ui/led_pwm.c
@@ -27,7 +27,8 @@ struct led {
 	uint16_t effect_step;
 	uint16_t effect_substep;
 
-	struct k_delayed_work work;
+	struct k_work_delayable work;
+	struct k_work_sync work_sync;
 };
 
 static const struct led_effect effect[] = {
@@ -130,13 +131,13 @@ static void work_handler(struct k_work *work)
 		int32_t next_delay =
 			leds.effect->steps[leds.effect_step].substep_time;
 
-		k_delayed_work_submit(&leds.work, K_MSEC(next_delay));
+		k_work_schedule(&leds.work, K_MSEC(next_delay));
 	}
 }
 
 static void led_update(struct led *led)
 {
-	k_delayed_work_cancel(&led->work);
+	k_work_cancel_delayable_sync(&led->work, &led->work_sync);
 
 	led->effect_step = 0;
 	led->effect_substep = 0;
@@ -152,7 +153,7 @@ static void led_update(struct led *led)
 		int32_t next_delay =
 			led->effect->steps[led->effect_step].substep_time;
 
-		k_delayed_work_submit(&led->work, K_MSEC(next_delay));
+		k_work_schedule(&led->work, K_MSEC(next_delay));
 	} else {
 		LOG_DBG("LED effect with no effect");
 	}
@@ -172,7 +173,7 @@ int ui_leds_init(void)
 		return -ENODEV;
 	}
 
-	k_delayed_work_init(&leds.work, work_handler);
+	k_work_init_delayable(&leds.work, work_handler);
 	led_update(&leds);
 
 	return err;
@@ -193,7 +194,7 @@ void ui_leds_start(void)
 
 void ui_leds_stop(void)
 {
-	k_delayed_work_cancel(&leds.work);
+	k_work_cancel_delayable_sync(&leds.work, &leds.work_sync);
 #ifdef CONFIG_PM_DEVICE
 	int err = device_set_power_state(leds.pwm_dev,
 					 DEVICE_PM_SUSPEND_STATE,

--- a/samples/nrf9160/lwm2m_client/src/ui/ui.c
+++ b/samples/nrf9160/lwm2m_client/src/ui/ui.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(ui, CONFIG_UI_LOG_LEVEL);
 static enum ui_led_pattern current_led_state;
 
 #if !defined(CONFIG_UI_LED_USE_PWM)
-static struct k_delayed_work leds_update_work;
+static struct k_work_delayable leds_update_work;
 
 /**@brief Update LEDs state. */
 static void leds_update(struct k_work *work)
@@ -43,11 +43,11 @@ static void leds_update(struct k_work *work)
 
 	if (work) {
 		if (led_on) {
-			k_delayed_work_submit(&leds_update_work,
-					      K_MSEC(UI_LED_ON_PERIOD_NORMAL));
+			k_work_schedule(&leds_update_work,
+					K_MSEC(UI_LED_ON_PERIOD_NORMAL));
 		} else {
-			k_delayed_work_submit(&leds_update_work,
-					      K_MSEC(UI_LED_OFF_PERIOD_NORMAL));
+			k_work_schedule(&leds_update_work,
+					K_MSEC(UI_LED_OFF_PERIOD_NORMAL));
 		}
 	}
 }
@@ -111,8 +111,8 @@ int ui_init(ui_callback_t cb)
 		return err;
 	}
 
-	k_delayed_work_init(&leds_update_work, leds_update);
-	k_delayed_work_submit(&leds_update_work, K_NO_WAIT);
+	k_work_init_delayable(&leds_update_work, leds_update);
+	k_work_schedule(&leds_update_work, K_NO_WAIT);
 #endif /* CONFIG_UI_LED_USE_PWM */
 
 #ifdef CONFIG_UI_BUTTON

--- a/samples/nrf9160/udp/src/main.c
+++ b/samples/nrf9160/udp/src/main.c
@@ -13,7 +13,7 @@
 
 static int client_fd;
 static struct sockaddr_storage host_addr;
-static struct k_delayed_work server_transmission_work;
+static struct k_work_delayable server_transmission_work;
 
 K_SEM_DEFINE(lte_connected, 0, 1);
 
@@ -34,15 +34,14 @@ static void server_transmission_work_fn(struct k_work *work)
 		return;
 	}
 
-	k_delayed_work_submit(
-			&server_transmission_work,
+	k_work_schedule(&server_transmission_work,
 			K_SECONDS(CONFIG_UDP_DATA_UPLOAD_FREQUENCY_SECONDS));
 }
 
 static void work_init(void)
 {
-	k_delayed_work_init(&server_transmission_work,
-			    server_transmission_work_fn);
+	k_work_init_delayable(&server_transmission_work,
+			      server_transmission_work_fn);
 }
 
 #if defined(CONFIG_NRF_MODEM_LIB)
@@ -245,5 +244,5 @@ void main(void)
 		return;
 	}
 
-	k_delayed_work_submit(&server_transmission_work, K_NO_WAIT);
+	k_work_schedule(&server_transmission_work, K_NO_WAIT);
 }


### PR DESCRIPTION
Convert the following nRF9160 samples to use the new k_work API:
- A-GPS
- UDP
- LTE Sensor Gateway
- Cloud client
- AWS IoT
- Azure FOTA
- Azure IoT Hub
- LwM2M Client

Ref: NCSDK-9417