### PR TITLE
samples: profiler: Add qemu_cortex_m3 to excluded platforms

### DIFF
--- a/samples/profiler/sample.yaml
+++ b/samples/profiler/sample.yaml
@@ -5,7 +5,7 @@ tests:
   samples.profiler:
     build_only: true
     build_on_all: true
-    platform_exclude: native_posix qemu_x86
+    platform_exclude: native_posix qemu_x86 qemu_cortex_m3
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840


### PR DESCRIPTION
This is a follow-up to commit 75f093bce97f0e1d7f658934a67f0ceefdfc5625.

This sample uses the Nordic profiler subsystem which bases on RTT,
so it cannot be built on any platform not selecting HAS_SEGGER_RTT
(unfortunately, unsupported platforms cannot be filtered out by
using the filter property, because the Kconfig dependency error occurs
when the sample is configured in cmake).