### PR TITLE
partition manager: added all input files as dependencies for merging

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -379,6 +379,7 @@ if (is_dynamic_partition_in_domain)
   share("set(${DOMAIN}_PM_DOTCONF_FILES ${pm_out_dotconf_file})")
   share("set(${DOMAIN}_PM_APP_HEX ${PROJECT_BINARY_DIR}/app.hex)")
   share("set(${DOMAIN}_PM_SIGNED_APP_HEX ${PROJECT_BINARY_DIR}/signed_by_b0_app.hex)")
+  share("list(APPEND ${IMAGE_NAME}BUILD_BYPRODUCTS ${PROJECT_BINARY_DIR}/${merged}.hex)")
 else()
   # This is the root image, generate the global pm_config.h
   # First, include the shared_vars.cmake file for all child images.
@@ -501,6 +502,7 @@ else()
       -o ${final_merged}
       ${domain_hex_files}
       DEPENDS
+      ${domain_hex_files}
       ${global_hex_depends}
       )
 


### PR DESCRIPTION
This commit adds ${domain_hex_files} as dependencies to mergehex.py
having merged_domains.hex as output.

merged_domains.hex is constructed from ${domain_hex_files} and thus all
files in that list should also be a dependency.

Jira: NCSIDB-275

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>