### PR TITLE
boards: Posix socket support for thingy91.

### DIFF
--- a/boards/arm/thingy91_nrf9160/board_nonsecure.c
+++ b/boards/arm/thingy91_nrf9160/board_nonsecure.c
@@ -7,7 +7,12 @@
 #include <init.h>
 
 #if defined(CONFIG_NRF_MODEM_LIB) && defined(CONFIG_NET_SOCKETS_OFFLOAD)
+#if defined(CONFIG_POSIX_API)
+#include <posix/unistd.h>
+#include <posix/sys/socket.h>
+#else
 #include <net/socket.h>
+#endif
 #endif
 
 #include <logging/log.h>


### PR DESCRIPTION
Posix socket use requires different headers than using net sockets. Added posix headers for thingy91.

Signed-off-by: Tommi Rantanen <Tommi.Rantanen@nordicsemi.no>