### PR TITLE
doc: extensions: external_content: handle deleted content

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -158,6 +158,7 @@ external_content_contents = [
     (NRF_BASE, "scripts/**/*.rst"),
     (NRF_BASE, "tests/**/*.rst"),
 ]
+external_content_keep = ["versions.txt"]
 
 # Options for table_from_rows --------------------------------------------------
 


### PR DESCRIPTION
In order to fully support incremental builds we also need to handle the
case when origin files are deleted. They also need to be deleted in the
destination folder, otherwise Sphinx will find a file that is likely not
referenced in any toctree and so it will produce a warning/error.

A new option to mark some files to be kept has been added to cover cases
where the output folder contains files not handled by Sphinx (e.g.
auto-generated content).