### PR TITLE
Bluetooth: Mesh: Remove configuration data publication in Light LC

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -767,7 +767,6 @@ static void handle_mode_set(struct bt_mesh_model *model,
 	}
 
 	mode_rsp(srv, ctx);
-	mode_rsp(srv, NULL); /* publish */
 }
 
 static void handle_mode_set_unack(struct bt_mesh_model *model,
@@ -781,8 +780,6 @@ static void handle_mode_set_unack(struct bt_mesh_model *model,
 	if (err) {
 		return;
 	}
-
-	mode_rsp(srv, NULL); /* publish */
 }
 
 static void om_rsp(struct bt_mesh_light_ctrl_srv *srv,
@@ -847,7 +844,6 @@ static void handle_om_set(struct bt_mesh_model *model,
 	}
 
 	om_rsp(srv, ctx);
-	om_rsp(srv, NULL); /* publish */
 }
 
 static void handle_om_set_unack(struct bt_mesh_model *model,
@@ -861,8 +857,6 @@ static void handle_om_set_unack(struct bt_mesh_model *model,
 	if (err) {
 		return;
 	}
-
-	om_rsp(srv, NULL); /* publish */
 }
 
 static void handle_light_onoff_get(struct bt_mesh_model *model,


### PR DESCRIPTION
When Light LC Mode Set message is sent with the value Off,
2 messages are published: Light LC Light OnOff Status and
Light LC Mode Status.

After publication has been moved from the caller thread to
work queue in zephyrproject-rtos/zephyr#34310
it became impossible to publish 2 messages consecutively.

However, according to the changes in the model spec,
section 6.5.1.1 (see Errata ID 11372), Light LC Server should not
use publication for configuration data:
Changes in the Light LC Mode state, or in the Light LC Occupancy
Mode state, or in the Light LC Light OnOff state shall not
trigger publication of the Light LC Mode Status, or Light LC
OM Status, or Light LC Light OnOff Status messages.

This change removes publication of Mode and Occupancy Mode states
upon reception of corresponding Set messages. Light OnOff state
is published according to state machine's state changes.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>