### PR TITLE
applications: pelion_client: Remove dead code

### DIFF
--- a/applications/pelion_client/src/modules/power_manager.c
+++ b/applications/pelion_client/src/modules/power_manager.c
@@ -116,11 +116,6 @@ struct pm_state_info pm_policy_next_state(int32_t ticks)
 	return (struct pm_state_info){PM_STATE_ACTIVE, 0, 0};
 }
 
-bool pm_policy_low_power_devices(enum pm_state pm_state)
-{
-	return pm_is_sleep_state(pm_state);
-}
-
 static void error(struct k_work *work)
 {
 	struct power_down_event *event = new_power_down_event();


### PR DESCRIPTION
Remove a function that become a dead code after zephyr's
upmerge.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>