### PR TITLE
fota_download: mcuboot_buf must be word aligned

### DIFF
--- a/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
@@ -31,6 +31,8 @@ LOG_MODULE_REGISTER(dfu_target_mcuboot, CONFIG_DFU_TARGET_LOG_LEVEL);
 #define MCUBOOT_SECONDARY_LAST_PAGE_ADDR                                       \
 	(PM_MCUBOOT_SECONDARY_ADDRESS + PM_MCUBOOT_SECONDARY_SIZE - 1)
 
+#define IS_ALIGNED_32(POINTER) (((uintptr_t)(const void *)(POINTER)) % 4 == 0)
+
 static uint8_t *stream_buf;
 static size_t stream_buf_len;
 
@@ -85,6 +87,10 @@ bool dfu_target_mcuboot_identify(const void *const buf)
 int dfu_target_mcuboot_set_buf(uint8_t *buf, size_t len)
 {
 	if (buf == NULL) {
+		return -EINVAL;
+	}
+
+	if (!IS_ALIGNED_32(buf)) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -35,7 +35,7 @@ static struct download_client   dlc;
 static struct k_work_delayable  dlc_with_offset_work;
 static int socket_retries_left;
 #ifdef CONFIG_DFU_TARGET_MCUBOOT
-static uint8_t mcuboot_buf[CONFIG_FOTA_DOWNLOAD_MCUBOOT_FLASH_BUF_SZ];
+static uint8_t mcuboot_buf[CONFIG_FOTA_DOWNLOAD_MCUBOOT_FLASH_BUF_SZ] __aligned(4);
 #endif
 static enum dfu_target_image_type img_type;
 static bool first_fragment;


### PR DESCRIPTION
mcuboot_buf must be word aligned to be compatible
with the nordic nrf_qspi_nor driver.

This fix was tested with slot1 partition in QSPI flash. This change was needed for FOTA to work properly.