### PR TITLE
applications: serial_lte_modem: Add CONFIG_SLM_CUSTOMIZED flag

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -8,6 +8,11 @@ source "Kconfig.zephyr"
 
 menu "Nordic Serial LTE Modem"
 
+config SLM_CUSTOMIZED
+	bool "Flag for customized functionality"
+	help
+	  Enable this flag to include customized logic.
+
 config SLM_AT_MODE
 	bool "Serial LTE Modem by raw AT mode"
 	default y

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -114,7 +114,12 @@ Configuration options
 
 Check and configure the following configuration options for the sample:
 
-.. option:: CONFIG_SLM_NATIVE_TLS
+.. option:: CONFIG_SLM_CUSTOMIZED - Flag for customized functionality
+
+    This flag can be used to enable customized functionality.
+    To add your own custom logic, enclose the code by ``#if defined(CONFIG_SLM_CUSTOMIZED)`` and enable this flag.
+
+.. option:: CONFIG_SLM_NATIVE_TLS - Use Zephyr mbedTLS
 
    This option enables using Zephyr's mbedTLS.
    It requires additional configuration.

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -72,7 +72,11 @@ void rsp_send(const uint8_t *str, size_t len);
 int poweroff_uart(void);
 bool verify_datamode_control(uint16_t size_limit, uint16_t time_limit);
 
+#if defined(CONFIG_SLM_CUSTOMIZED)
+#define SLM_VERSION	"\r\n#XSLMVER: \"1.6-CUSTOMIZED\"\r\n"
+#else
 #define SLM_VERSION	"\r\n#XSLMVER: \"1.6\"\r\n"
+#endif
 
 static void modem_power_off(void)
 {


### PR DESCRIPTION
This allows customer to customize SLM under this flag.
  #if defined(CONFIG_SLM_CUSTOMIZED)
  < customized logic >
  #endif  /* CONFIG_SLM_CUSTOMIZED */
SLM version string will be changed to "< NCS ver >-CUSTOMIZED"

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>