### PR TITLE
applications: pelion_client: Convert to new work API

### DIFF
--- a/applications/pelion_client/src/modules/Kconfig.net
+++ b/applications/pelion_client/src/modules/Kconfig.net
@@ -6,6 +6,33 @@
 
 menu "Networking"
 
+config PELION_CLIENT_LOG_WAITING_ON_CONNECTION
+	bool "Log waiting on connection"
+	depends on LOG
+	default y
+	help
+	  If enabled periodic message informing about connection in progress
+	  will be emitted.
+
+if PELION_CLIENT_LOG_WAITING_ON_CONNECTION
+
+config PELION_CLIENT_WAITING_ON_CONNECTION_LOG_PERIOD
+	int "Waiting on connection log period [s]"
+	range 1 3600
+	default 5
+	help
+	  Time in seconds at which waiting on connection log is emitted.
+
+endif
+
+if !PELION_CLIENT_LOG_WAITING_ON_CONNECTION
+
+config PELION_CLIENT_WAITING_ON_CONNECTION_LOG_PERIOD
+	int
+	default 0
+
+endif
+
 module = PELION_CLIENT_NET
 module-str = Networking module
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/pelion_client/src/modules/oma_stopwatch.cpp
+++ b/applications/pelion_client/src/modules/oma_stopwatch.cpp
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_PELION_CLIENT_OMA_STOPWATCH_LOG_LEVEL);
 
 
 static M2MResource *resource;
-static struct k_delayed_work resource_work;
+static struct k_work_delayable resource_work;
 
 static bool updated;
 static bool update_pending;
@@ -57,7 +57,7 @@ static void resource_work_handler(struct k_work *work)
 	updated = true;
 	update_stopwatch();
 
-	k_delayed_work_submit(&resource_work, K_SECONDS(CONFIG_PELION_CLIENT_OMA_STOPWATCH_TIMEOUT));
+	k_work_reschedule(&resource_work, K_SECONDS(CONFIG_PELION_CLIENT_OMA_STOPWATCH_TIMEOUT));
 }
 
 static void on_value_updated(const char *arg)
@@ -173,8 +173,8 @@ static bool event_handler(const struct event_header *eh)
 			__ASSERT_NO_MSG(!initialized);
 			initialized = true;
 
-			k_delayed_work_init(&resource_work, resource_work_handler);
-			k_delayed_work_submit(&resource_work, K_NO_WAIT);
+			k_work_init_delayable(&resource_work, resource_work_handler);
+			k_work_reschedule(&resource_work, K_NO_WAIT);
 
 			module_set_state(MODULE_STATE_READY);
 		}

--- a/applications/pelion_client/src/modules/power_manager.c
+++ b/applications/pelion_client/src/modules/power_manager.c
@@ -44,8 +44,8 @@ enum power_state {
 };
 
 static enum power_state power_state = POWER_STATE_IDLE;
-static struct k_delayed_work power_down_trigger;
-static struct k_delayed_work error_trigger;
+static struct k_work_delayable power_down_trigger;
+static struct k_work_delayable error_trigger;
 static atomic_t power_down_count;
 
 
@@ -88,7 +88,7 @@ static void power_down(struct k_work *work)
 			/* Stay suspended. */
 		}
 	} else {
-		k_delayed_work_submit(&power_down_trigger,
+		k_work_reschedule(&power_down_trigger,
 				      K_MSEC(POWER_DOWN_CHECK_MS));
 	}
 }
@@ -137,7 +137,7 @@ static bool event_handler(const struct event_header *eh)
 	if (is_power_down_event(eh)) {
 		switch (power_state) {
 		case POWER_STATE_ERROR:
-			k_delayed_work_submit(&error_trigger,
+			k_work_reschedule(&error_trigger,
 					      POWER_DOWN_ERROR_TIMEOUT);
 			break;
 
@@ -183,7 +183,7 @@ static bool event_handler(const struct event_header *eh)
 
 		power_state = POWER_STATE_IDLE;
 		power_down_counter_reset();
-		k_delayed_work_submit(&power_down_trigger,
+		k_work_reschedule(&power_down_trigger,
 				      K_MSEC(POWER_DOWN_CHECK_MS));
 
 		return false;
@@ -220,13 +220,14 @@ static bool event_handler(const struct event_header *eh)
 
 			pm_power_state_force((struct pm_state_info){PM_STATE_ACTIVE, 0, 0});
 
-			k_delayed_work_init(&error_trigger, error);
-			k_delayed_work_init(&power_down_trigger, power_down);
-			k_delayed_work_submit(&power_down_trigger,
+			k_work_init_delayable(&error_trigger, error);
+			k_work_init_delayable(&power_down_trigger, power_down);
+			k_work_reschedule(&power_down_trigger,
 					      K_MSEC(POWER_DOWN_CHECK_MS));
 		} else if (event->state == MODULE_STATE_ERROR) {
 			power_state = POWER_STATE_ERROR;
-			k_delayed_work_cancel(&power_down_trigger);
+			/* Cancel cannot fail if executed from another work's context. */
+			(void)k_work_cancel_delayable(&power_down_trigger);
 
 			struct power_down_event *event = new_power_down_event();
 


### PR DESCRIPTION
Move net state logging to ensure proper synchronization.
Also don't create work if net state logging is disabled.

Jira:NCSDK-9742

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>