### PR TITLE
tests: lib: lte_lc: Fix buffer overrun

### DIFF
--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -366,7 +366,7 @@ static void test_response_is_valid(void)
 	zassert_true(response_is_valid(xsystemmode, strlen(xsystemmode), "+%XSYSTEMMODE"),
 		     "response_is_valid failed");
 
-	zassert_false(response_is_valid(cscon, strlen(xsystemmode), "+%XSYSTEMMODE"),
+	zassert_false(response_is_valid(cscon, strlen(cscon), "+%XSYSTEMMODE"),
 		     "response_is_valid should have failed");
 }
 


### PR DESCRIPTION
Fix buffer overrun discovered by static code analysis.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>