### PR TITLE
tests: crypto: Address coverity issues

### DIFF
--- a/tests/crypto/src/common_test.h
+++ b/tests/crypto/src/common_test.h
@@ -559,6 +559,11 @@ void stop_time_measurement(void);
 			  (-actual))
 #endif
 
+#ifndef TEST_VECTOR_ASSERT_NOT_NULL
+#define TEST_VECTOR_ASSERT_NOT_NULL(ptr) \
+	zassert_not_null((ptr), "\tUnexpected null")
+#endif
+
 /**@brief Macro for checking buffer overflow for a given buffer. Requires that the two following
  *  bytes after the buffer are set to 0xFF.
  *

--- a/tests/crypto/test_cases/test_aead.c
+++ b/tests/crypto/test_cases/test_aead.c
@@ -195,7 +195,7 @@ __attribute__((noinline)) void unhexify_aead(void)
 #if defined(MBEDTLS_CCM_C)
 void exec_test_case_aead_ccm_star_simple(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	/* Initialize AEAD. */
 	key_bits = key_len * 8;
@@ -249,7 +249,7 @@ void exec_test_case_aead_ccm_star_simple(void)
 
 void exec_test_case_aead_ccm_star(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	/* Initialize AEAD. */
 	key_bits = key_len * 8;
@@ -331,7 +331,7 @@ void exec_test_case_aead_ccm_star(void)
  */
 void exec_test_case_aead(void)
 {
-	int err_code = -1;
+	int err_code;
 
 #if defined(MBEDTLS_CCM_C)
 	if (p_test_vector->mode == MBEDTLS_MODE_CCM &&
@@ -435,7 +435,7 @@ void exec_test_case_aead(void)
  */
 void exec_test_case_aead_simple(void)
 {
-	int err_code = -1;
+	int err_code;
 
 #if defined(MBEDTLS_CCM_C)
 	if (p_test_vector->mode == MBEDTLS_MODE_CCM &&

--- a/tests/crypto/test_cases/test_aes_cbc.c
+++ b/tests/crypto/test_cases/test_aes_cbc.c
@@ -42,7 +42,6 @@ static uint8_t m_aes_expected_output_buf[AES_PLAINTEXT_BUF_SIZE_PLUS];
 static uint8_t m_prev_aes_output_buf[AES_PLAINTEXT_BUF_SIZE_PLUS];
 static uint8_t m_aes_key_buf[AES_MAX_KEY_SIZE];
 static uint8_t m_aes_iv_buf[AES_IV_MAX_SIZE + NUM_BUFFER_OVERFLOW_TEST_BYTES];
-static uint8_t m_aes_temp_buf[AES_MAX_KEY_SIZE];
 
 static test_vector_aes_t *p_test_vector;
 /* Some tests require overriding the test vector crypt direction.
@@ -54,7 +53,6 @@ static size_t input_len;
 static size_t output_len;
 static size_t key_len;
 static size_t iv_len;
-static size_t ad_len;
 
 void aes_cbc_clear_buffers(void);
 void unhexify_aes_cbc(void);
@@ -139,7 +137,6 @@ void aes_cbc_clear_buffers(void)
 	memset(m_prev_aes_output_buf, 0x00, sizeof(m_prev_aes_output_buf));
 	memset(m_aes_key_buf, 0x00, sizeof(m_aes_key_buf));
 	memset(m_aes_iv_buf, 0xFF, sizeof(m_aes_iv_buf));
-	memset(m_aes_temp_buf, 0x00, sizeof(m_aes_temp_buf));
 }
 
 __attribute__((noinline)) void unhexify_aes_cbc(void)
@@ -153,9 +150,6 @@ __attribute__((noinline)) void unhexify_aes_cbc(void)
 	iv_len = hex2bin_safe(p_test_vector->p_iv,
 			      m_aes_iv_buf,
 			      sizeof(m_aes_iv_buf));
-	ad_len = hex2bin_safe(p_test_vector->p_ad,
-			      m_aes_temp_buf,
-			      sizeof(m_aes_temp_buf));
 
 	if (encrypt) {
 		input_len = hex2bin_safe(p_test_vector->p_plaintext,
@@ -178,12 +172,13 @@ __attribute__((noinline)) void unhexify_aes_cbc(void)
  */
 void exec_test_case_aes_cbc_functional(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_cipher_context_t ctx;
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, MBEDTLS_ENCRYPT);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
@@ -216,6 +211,7 @@ void exec_test_case_aes_cbc_functional(void)
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, MBEDTLS_DECRYPT);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
@@ -247,12 +243,13 @@ void exec_test_case_aes_cbc_functional(void)
  */
 void exec_test_case_aes_cbc(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_cipher_context_t ctx;
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, p_test_vector->direction);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
@@ -282,19 +279,19 @@ void monte_carlo_cbc_update_key(size_t key_len, size_t ciphertext_len)
 		LOG_HEXDUMP_DBG(m_aes_key_buf, key_len,
 				"m_aes_key_buf before update");
 	}
-	uint8_t divider;
+	size_t divider;
 
 	divider = key_len - ciphertext_len;
 
 	/* Xor previous cipher with key if key_len > cipher_len. */
-	for (uint8_t xor_start = 0; xor_start < divider; xor_start++) {
+	for (size_t xor_start = 0; xor_start < divider; xor_start++) {
 		m_aes_key_buf[xor_start] ^=
 			m_prev_aes_output_buf[ciphertext_len - divider +
 					      xor_start];
 	}
 
 	/* Xor cipher with last 16 bytes of key. */
-	for (uint8_t xor_start = 0; xor_start < ciphertext_len; xor_start++) {
+	for (size_t xor_start = 0; xor_start < ciphertext_len; xor_start++) {
 		m_aes_key_buf[divider + xor_start] ^=
 			m_aes_output_buf[xor_start];
 	}
@@ -309,7 +306,7 @@ int monte_carlo_cbc(test_vector_aes_t *p_test_vector,
 		    mbedtls_cipher_context_t *p_ctx, size_t key_len,
 		    size_t iv_len, size_t input_len, size_t output_len)
 {
-	uint16_t j;
+	size_t j;
 	int err_code;
 
 	/* Execution of encryption or decryption 1000 times with same AES key. */
@@ -325,8 +322,9 @@ int monte_carlo_cbc(test_vector_aes_t *p_test_vector,
 		err_code =
 			mbedtls_cipher_update(p_ctx, m_aes_input_buf, input_len,
 					      m_aes_output_buf, &output_len);
-		TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code,
-					 err_code);
+		if (err_code != p_test_vector->expected_err_code) {
+			return err_code;
+		}
 
 		if (j == 0) {
 			memcpy(m_aes_input_buf, m_aes_iv_buf, input_len);
@@ -345,13 +343,13 @@ int monte_carlo_cbc(test_vector_aes_t *p_test_vector,
 	monte_carlo_cbc_update_key(key_len, output_len);
 
 	err_code = cipher_set_key(p_ctx, key_len, p_test_vector->direction);
-	TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code, err_code);
+	if (err_code != p_test_vector->expected_err_code)
+		return err_code;
+
 
 	memcpy(m_aes_iv_buf, m_aes_output_buf, iv_len);
-	err_code = mbedtls_cipher_set_iv(p_ctx, m_aes_iv_buf, input_len);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
-	return err_code;
+	return mbedtls_cipher_set_iv(p_ctx, m_aes_iv_buf, input_len);
 }
 
 /**@brief Function for the AES Monte Carlo test execution.
@@ -365,6 +363,7 @@ void exec_test_case_aes_cbc_monte_carlo(void)
 	mbedtls_cipher_context_t ctx;
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, p_test_vector->direction);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);

--- a/tests/crypto/test_cases/test_aes_cbc_mac.c
+++ b/tests/crypto/test_cases/test_aes_cbc_mac.c
@@ -39,15 +39,12 @@ static uint8_t m_aes_output_buf[AES_PLAINTEXT_BUF_SIZE_PLUS];
 static uint8_t m_aes_expected_output_buf[AES_PLAINTEXT_BUF_SIZE_PLUS];
 static uint8_t m_aes_key_buf[AES_MAX_KEY_SIZE];
 static uint8_t m_aes_iv_buf[AES_IV_MAX_SIZE + NUM_BUFFER_OVERFLOW_TEST_BYTES];
-static uint8_t m_aes_temp_buf[AES_MAX_KEY_SIZE];
 
 static test_vector_aes_t *p_test_vector;
 
 static size_t input_len;
-static size_t output_len;
 static size_t key_len;
 static size_t iv_len;
-static size_t ad_len;
 
 void aes_cbc_mac_clear_buffers(void);
 void unhexify_aes_cbc_mac(void);
@@ -132,7 +129,6 @@ void aes_cbc_mac_clear_buffers(void)
 	       sizeof(m_aes_expected_output_buf));
 	memset(m_aes_key_buf, 0x00, sizeof(m_aes_key_buf));
 	memset(m_aes_iv_buf, 0xFF, sizeof(m_aes_iv_buf));
-	memset(m_aes_temp_buf, 0x00, sizeof(m_aes_temp_buf));
 }
 
 __attribute__((noinline)) void unhexify_aes_cbc_mac(void)
@@ -145,24 +141,15 @@ __attribute__((noinline)) void unhexify_aes_cbc_mac(void)
 	iv_len = hex2bin_safe(p_test_vector->p_iv,
 			      m_aes_iv_buf,
 			      sizeof(m_aes_iv_buf));
-	ad_len = hex2bin_safe(p_test_vector->p_ad,
-			      m_aes_temp_buf,
-			      sizeof(m_aes_temp_buf));
 
 	if (encrypt) {
 		input_len = hex2bin_safe(p_test_vector->p_plaintext,
 					 m_aes_input_buf,
 					 sizeof(m_aes_input_buf));
-		output_len = hex2bin_safe(p_test_vector->p_ciphertext,
-					  m_aes_expected_output_buf,
-					  sizeof(m_aes_expected_output_buf));
 	} else {
 		input_len = hex2bin_safe(p_test_vector->p_ciphertext,
 					 m_aes_input_buf,
 					 sizeof(m_aes_input_buf));
-		output_len = hex2bin_safe(p_test_vector->p_plaintext,
-					  m_aes_expected_output_buf,
-					  sizeof(m_aes_expected_output_buf));
 	}
 }
 
@@ -170,12 +157,13 @@ __attribute__((noinline)) void unhexify_aes_cbc_mac(void)
  */
 void exec_test_case_aes_cbc_mac(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_cipher_context_t ctx;
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, MBEDTLS_ENCRYPT);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
@@ -202,6 +190,7 @@ void exec_test_case_aes_cbc_mac(void)
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, MBEDTLS_ENCRYPT);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);

--- a/tests/crypto/test_cases/test_aes_ctr.c
+++ b/tests/crypto/test_cases/test_aes_ctr.c
@@ -170,12 +170,13 @@ __attribute__((noinline)) void unhexify_aes_ctr(void)
  */
 void exec_test_case_aes_ctr_functional(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_cipher_context_t ctx;
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, MBEDTLS_ENCRYPT);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
@@ -237,12 +238,13 @@ void exec_test_case_aes_ctr_functional(void)
  */
 void exec_test_case_aes_ctr(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_cipher_context_t ctx;
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, p_test_vector->direction);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
@@ -254,7 +256,6 @@ void exec_test_case_aes_ctr(void)
 	start_time_measurement();
 	err_code = cipher_crypt(&ctx, iv_len, input_len);
 	stop_time_measurement();
-
 	TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code, err_code);
 
 	/* Verify the generated AES ciphertext. */
@@ -280,14 +281,14 @@ void monte_carlo_update_key(size_t key_len, size_t ciphertext_len)
 	divider = key_len - ciphertext_len;
 
 	/* Xor previous cipher with key if key_len > cipher_len. */
-	for (uint8_t xor_start = 0; xor_start < divider; xor_start++) {
+	for (size_t xor_start = 0; xor_start < divider; xor_start++) {
 		m_aes_key_buf[xor_start] ^=
 			m_prev_aes_output_buf[ciphertext_len - divider +
 					      xor_start];
 	}
 
 	/* Xor cipher with last 16 bytes of key. */
-	for (uint8_t xor_start = 0; xor_start < ciphertext_len; xor_start++) {
+	for (size_t xor_start = 0; xor_start < ciphertext_len; xor_start++) {
 		m_aes_key_buf[divider + xor_start] ^=
 			m_aes_output_buf[xor_start];
 	}
@@ -302,7 +303,7 @@ int monte_carlo(test_vector_aes_t *p_test_vector,
 		mbedtls_cipher_context_t *p_ctx, size_t key_len, size_t iv_len,
 		size_t input_len, size_t output_len)
 {
-	uint16_t j;
+	size_t j;
 	int err_code;
 
 	/* Execution of encryption or decryption 1000 times with same AES key. */
@@ -317,8 +318,9 @@ int monte_carlo(test_vector_aes_t *p_test_vector,
 		err_code =
 			mbedtls_cipher_update(p_ctx, m_aes_input_buf, input_len,
 					      m_aes_output_buf, &output_len);
-		TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code,
-					 err_code);
+		if (err_code != p_test_vector->expected_err_code)
+			return err_code;
+
 
 		if (j < 5 && dbg_hexdump_on) {
 			LOG_HEXDUMP_DBG(m_aes_output_buf, input_len,
@@ -329,10 +331,7 @@ int monte_carlo(test_vector_aes_t *p_test_vector,
 	/* Update the AES key. */
 	monte_carlo_update_key(key_len, output_len);
 
-	err_code = cipher_set_key(p_ctx, key_len, p_test_vector->direction);
-	TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code, err_code);
-
-	return err_code;
+	return cipher_set_key(p_ctx, key_len, p_test_vector->direction);
 }
 
 /**@brief Function for the AES Monte Carlo test execution.
@@ -346,6 +345,7 @@ void exec_test_case_aes_monte_carlo(void)
 	mbedtls_cipher_context_t ctx;
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, p_test_vector->direction);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);

--- a/tests/crypto/test_cases/test_aes_ecb.c
+++ b/tests/crypto/test_cases/test_aes_ecb.c
@@ -42,7 +42,6 @@ static uint8_t m_aes_expected_output_buf[AES_PLAINTEXT_BUF_SIZE_PLUS];
 static uint8_t m_prev_aes_output_buf[AES_PLAINTEXT_BUF_SIZE_PLUS];
 static uint8_t m_aes_key_buf[AES_MAX_KEY_SIZE];
 static uint8_t m_aes_iv_buf[AES_IV_MAX_SIZE + NUM_BUFFER_OVERFLOW_TEST_BYTES];
-static uint8_t m_aes_temp_buf[AES_MAX_KEY_SIZE];
 
 static test_vector_aes_t *p_test_vector;
 /* Some tests require overriding the test vector crypt direction.
@@ -54,7 +53,6 @@ static size_t input_len;
 static size_t output_len;
 static size_t key_len;
 static size_t iv_len;
-static size_t ad_len;
 
 void aes_ecb_clear_buffers(void);
 void unhexify_aes_ecb(void);
@@ -148,7 +146,6 @@ void aes_ecb_clear_buffers(void)
 	memset(m_prev_aes_output_buf, 0x00, sizeof(m_prev_aes_output_buf));
 	memset(m_aes_key_buf, 0x00, sizeof(m_aes_key_buf));
 	memset(m_aes_iv_buf, 0xFF, sizeof(m_aes_iv_buf));
-	memset(m_aes_temp_buf, 0x00, sizeof(m_aes_temp_buf));
 }
 
 __attribute__((noinline)) void unhexify_aes_ecb(void)
@@ -162,9 +159,6 @@ __attribute__((noinline)) void unhexify_aes_ecb(void)
 	iv_len = hex2bin_safe(p_test_vector->p_iv,
 			      m_aes_iv_buf,
 			      sizeof(m_aes_iv_buf));
-	ad_len = hex2bin_safe(p_test_vector->p_ad,
-			      m_aes_temp_buf,
-			      sizeof(m_aes_temp_buf));
 
 	if (encrypt) {
 		input_len = hex2bin_safe(p_test_vector->p_plaintext,
@@ -187,12 +181,13 @@ __attribute__((noinline)) void unhexify_aes_ecb(void)
  */
 void exec_test_case_aes_ecb_functional(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_cipher_context_t ctx;
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, MBEDTLS_ENCRYPT);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
@@ -225,6 +220,7 @@ void exec_test_case_aes_ecb_functional(void)
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, MBEDTLS_DECRYPT);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
@@ -257,12 +253,13 @@ void exec_test_case_aes_ecb_functional(void)
  */
 void exec_test_case_aes_ecb(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_cipher_context_t ctx;
 
 	err_code = cipher_init(&ctx, key_len, p_test_vector->mode);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	TEST_VECTOR_ASSERT_NOT_NULL(ctx.cipher_ctx);
 
 	err_code = cipher_set_key(&ctx, key_len, p_test_vector->direction);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
@@ -297,14 +294,14 @@ void monte_carlo_ecb_update_key(size_t key_len, size_t ciphertext_len)
 	divider = key_len - ciphertext_len;
 
 	/* Xor previous cipher with key if key_len > cipher_len. */
-	for (uint8_t xor_start = 0; xor_start < divider; xor_start++) {
+	for (size_t xor_start = 0; xor_start < divider; xor_start++) {
 		m_aes_key_buf[xor_start] ^=
 			m_prev_aes_output_buf[ciphertext_len - divider +
 					      xor_start];
 	}
 
 	/* Xor cipher with last 16 bytes of key. */
-	for (uint8_t xor_start = 0; xor_start < ciphertext_len; xor_start++) {
+	for (size_t xor_start = 0; xor_start < ciphertext_len; xor_start++) {
 		m_aes_key_buf[divider + xor_start] ^=
 			m_aes_output_buf[xor_start];
 	}
@@ -334,8 +331,9 @@ int monte_carlo_ecb(test_vector_aes_t *p_test_vector,
 		err_code =
 			mbedtls_cipher_update(p_ctx, m_aes_input_buf, input_len,
 					      m_aes_output_buf, &output_len);
-		TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code,
-					 err_code);
+		if (err_code != p_test_vector->expected_err_code)
+			return err_code;
+
 		memcpy(m_aes_input_buf, m_aes_output_buf, input_len);
 
 		if (j < 5 && dbg_hexdump_on) {
@@ -347,10 +345,7 @@ int monte_carlo_ecb(test_vector_aes_t *p_test_vector,
 	/* Update the AES key. */
 	monte_carlo_ecb_update_key(key_len, output_len);
 
-	err_code = cipher_set_key(p_ctx, key_len, p_test_vector->direction);
-	TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code, err_code);
-
-	return err_code;
+	return cipher_set_key(p_ctx, key_len, p_test_vector->direction);
 }
 
 /**@brief Function for the AES Monte Carlo test execution.

--- a/tests/crypto/test_cases/test_aes_ecb_mac.c
+++ b/tests/crypto/test_cases/test_aes_ecb_mac.c
@@ -33,16 +33,11 @@ static uint8_t m_aes_input_buf[AES_PLAINTEXT_BUF_SIZE_PLUS];
 static uint8_t m_aes_output_buf[AES_PLAINTEXT_BUF_SIZE_PLUS];
 static uint8_t m_aes_expected_output_buf[AES_PLAINTEXT_BUF_SIZE_PLUS];
 static uint8_t m_aes_key_buf[AES_MAX_KEY_SIZE];
-static uint8_t m_aes_iv_buf[AES_IV_MAX_SIZE + NUM_BUFFER_OVERFLOW_TEST_BYTES];
-static uint8_t m_aes_temp_buf[AES_MAX_KEY_SIZE];
 
 static test_vector_aes_t *p_test_vector;
 
 static size_t input_len;
-static size_t output_len;
 static size_t key_len;
-static size_t iv_len;
-static size_t ad_len;
 
 void aes_ecb_mac_clear_buffers(void);
 void unhexify_aes_ecb_mac(void);
@@ -108,8 +103,6 @@ void aes_ecb_mac_clear_buffers(void)
 	memset(m_aes_expected_output_buf, 0xFF,
 	       sizeof(m_aes_expected_output_buf));
 	memset(m_aes_key_buf, 0x00, sizeof(m_aes_key_buf));
-	memset(m_aes_iv_buf, 0xFF, sizeof(m_aes_iv_buf));
-	memset(m_aes_temp_buf, 0x00, sizeof(m_aes_temp_buf));
 }
 
 __attribute__((noinline)) void unhexify_aes_ecb_mac(void)
@@ -119,27 +112,15 @@ __attribute__((noinline)) void unhexify_aes_ecb_mac(void)
 	key_len = hex2bin_safe(p_test_vector->p_key,
 			       m_aes_key_buf,
 			       sizeof(m_aes_key_buf));
-	iv_len = hex2bin_safe(p_test_vector->p_iv,
-			      m_aes_iv_buf,
-			      sizeof(m_aes_iv_buf));
-	ad_len = hex2bin_safe(p_test_vector->p_ad,
-			      m_aes_temp_buf,
-			      sizeof(m_aes_temp_buf));
 
 	if (encrypt) {
 		input_len = hex2bin_safe(p_test_vector->p_plaintext,
 					 m_aes_input_buf,
 					 sizeof(m_aes_input_buf));
-		output_len = hex2bin_safe(p_test_vector->p_ciphertext,
-					  m_aes_expected_output_buf,
-					  sizeof(m_aes_expected_output_buf));
 	} else {
 		input_len = hex2bin_safe(p_test_vector->p_ciphertext,
 					 m_aes_input_buf,
 					 sizeof(m_aes_input_buf));
-		output_len = hex2bin_safe(p_test_vector->p_plaintext,
-					  m_aes_expected_output_buf,
-					  sizeof(m_aes_expected_output_buf));
 	}
 }
 
@@ -147,7 +128,7 @@ __attribute__((noinline)) void unhexify_aes_ecb_mac(void)
  */
 void exec_test_case_aes_ecb_mac(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_cipher_context_t ctx;
 

--- a/tests/crypto/test_cases/test_ecdh.c
+++ b/tests/crypto/test_cases/test_ecdh.c
@@ -48,17 +48,11 @@ static int curve25519_ctx_fixup(mbedtls_ecdh_context *ctx)
 	/* Set certain bits to predefined values */
 	int err_code = mbedtls_mpi_set_bit(&ctx->d, 0, 0);
 
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 	err_code |= mbedtls_mpi_set_bit(&ctx->d, 1, 0);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 	err_code |= mbedtls_mpi_set_bit(&ctx->d, 2, 0);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 	err_code |= mbedtls_mpi_set_bit(&ctx->d, 254, 1);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 	err_code |= mbedtls_mpi_set_bit(&ctx->d, 255, 0);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
-
-	mbedtls_mpi_lset(&ctx->Q.Z, 1);
+	err_code |= mbedtls_mpi_lset(&ctx->Q.Z, 1);
 
 	return err_code;
 }
@@ -119,8 +113,8 @@ __attribute__((noinline)) void unhexify_ecdh(void)
  */
 void exec_test_case_ecdh_random(void)
 {
-	int err_code_initiator = -1;
-	int err_code_responder = -1;
+	int err_code_initiator;
+	int err_code_responder;
 
 	mbedtls_ecdh_context initiator_ctx;
 	mbedtls_ecdh_context responder_ctx;
@@ -129,11 +123,11 @@ void exec_test_case_ecdh_random(void)
 	mbedtls_ecdh_init(&responder_ctx);
 
 	err_code_initiator = mbedtls_ecp_group_load(&initiator_ctx.grp,
-						    p_test_vector->curve_type);
+		(mbedtls_ecp_group_id)p_test_vector->curve_type);
 	TEST_VECTOR_ASSERT_EQUAL(err_code_initiator, 0);
 
 	err_code_responder = mbedtls_ecp_group_load(&responder_ctx.grp,
-						    p_test_vector->curve_type);
+		(mbedtls_ecp_group_id)p_test_vector->curve_type);
 	TEST_VECTOR_ASSERT_EQUAL(err_code_responder, 0);
 
 	err_code_initiator =
@@ -180,7 +174,7 @@ void exec_test_case_ecdh_random(void)
  */
 void exec_test_case_ecdh_deterministic_full(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	size_t initiator_ss_len;
 	size_t responder_ss_len;
@@ -194,11 +188,11 @@ void exec_test_case_ecdh_deterministic_full(void)
 	mbedtls_ecdh_init(&responder_ctx);
 
 	err_code = mbedtls_ecp_group_load(&initiator_ctx.grp,
-					  p_test_vector->curve_type);
+			(mbedtls_ecp_group_id)p_test_vector->curve_type);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
 	err_code = mbedtls_ecp_group_load(&responder_ctx.grp,
-					  p_test_vector->curve_type);
+			(mbedtls_ecp_group_id)p_test_vector->curve_type);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
 	const char *initiator_publ_y;
@@ -340,7 +334,7 @@ void exec_test_case_ecdh_deterministic_full(void)
  */
 void exec_test_case_ecdh_deterministic(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_ecdh_context initiator_ctx;
 	mbedtls_ecdh_context responder_ctx;
@@ -349,11 +343,11 @@ void exec_test_case_ecdh_deterministic(void)
 	mbedtls_ecdh_init(&responder_ctx);
 
 	err_code = mbedtls_ecp_group_load(&initiator_ctx.grp,
-					  p_test_vector->curve_type);
+		(mbedtls_ecp_group_id)p_test_vector->curve_type);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
 	err_code = mbedtls_ecp_group_load(&responder_ctx.grp,
-					  p_test_vector->curve_type);
+		(mbedtls_ecp_group_id)p_test_vector->curve_type);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
 	/* Prepare initiator public key. */

--- a/tests/crypto/test_cases/test_ecdsa.c
+++ b/tests/crypto/test_cases/test_ecdsa.c
@@ -101,14 +101,14 @@ void ecdsa_clear_buffers(void)
  */
 void exec_test_case_ecdsa_sign(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	/* Prepare signer context. */
 	mbedtls_ecdsa_context ctx_sign;
 	mbedtls_ecdsa_init(&ctx_sign);
 
 	err_code = mbedtls_ecp_group_load(&ctx_sign.grp,
-					  p_test_vector_sign->curve_type);
+			(mbedtls_ecp_group_id)p_test_vector_sign->curve_type);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
 	/* Get public key. */
@@ -179,13 +179,13 @@ void exec_test_case_ecdsa_sign(void)
  */
 void exec_test_case_ecdsa_verify(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	mbedtls_ecdsa_context ctx_verify;
 	mbedtls_ecdsa_init(&ctx_verify);
 
 	err_code = mbedtls_ecp_group_load(&ctx_verify.grp,
-					  p_test_vector_verify->curve_type);
+			(mbedtls_ecp_group_id)p_test_vector_verify->curve_type);
 	if (err_code != 0) {
 		LOG_WRN("ecp group load error code: -0x%02X, curve type: %d",
 			-err_code, p_test_vector_verify->curve_type);
@@ -240,7 +240,7 @@ void exec_test_case_ecdsa_verify(void)
  */
 void exec_test_case_ecdsa_random(void)
 {
-	int err_code = -1;
+	int err_code;
 
 
 	/* Prepare signer context. */
@@ -249,8 +249,8 @@ void exec_test_case_ecdsa_random(void)
 
 	/* Create a ECDSA key pair */
 	err_code = mbedtls_ecdsa_genkey(&ctx_sign,
-					p_test_vector_random->curve_type,
-					drbg_random, &drbg_ctx);
+			(mbedtls_ecp_group_id)p_test_vector_random->curve_type,
+			drbg_random, &drbg_ctx);
 	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
 	/* Verify keys. */
@@ -274,6 +274,7 @@ void exec_test_case_ecdsa_random(void)
 				      m_ecdsa_input_buf, hash_len,
 				      drbg_random, &drbg_ctx);
 	stop_time_measurement();
+	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
 	/* Prepare verification context. */
 	mbedtls_ecdsa_context ctx_verify;

--- a/tests/crypto/test_cases/test_ecjpake.c
+++ b/tests/crypto/test_cases/test_ecjpake.c
@@ -134,20 +134,20 @@ static int ecjpake_test_load(mbedtls_ecjpake_context *ctx,
 	int err_code;
 
 	err_code = mbedtls_mpi_read_binary(&ctx->xm1, xm1, len1);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	if (err_code != 0)
+		return err_code;
 
 	err_code = mbedtls_mpi_read_binary(&ctx->xm2, xm2, len2);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	if (err_code != 0)
+		return err_code;
 
-	mbedtls_ecp_mul(&ctx->grp, &ctx->Xm1, &ctx->xm1, &ctx->grp.G, NULL,
-			NULL);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	err_code = mbedtls_ecp_mul(&ctx->grp, &ctx->Xm1, &ctx->xm1, &ctx->grp.G,
+		NULL, NULL);
+	if (err_code != 0)
+		return err_code;
 
-	mbedtls_ecp_mul(&ctx->grp, &ctx->Xm2, &ctx->xm2, &ctx->grp.G, NULL,
-			NULL);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
-
-	return err_code;
+	return mbedtls_ecp_mul(&ctx->grp, &ctx->Xm2, &ctx->xm2, &ctx->grp.G,
+		NULL, NULL);
 }
 #else
 extern int ecjpake_test_load(mbedtls_ecjpake_context *ctx,
@@ -175,7 +175,7 @@ static void ecjpake_random_setup(void)
 	unhexify_ecjpake();
 }
 
-static void ecjpake_ctx_init(mbedtls_ecjpake_context *ctx,
+static int ecjpake_ctx_init(mbedtls_ecjpake_context *ctx,
 				 mbedtls_ecjpake_role role)
 {
 	int err_code;
@@ -184,10 +184,10 @@ static void ecjpake_ctx_init(mbedtls_ecjpake_context *ctx,
 	err_code = mbedtls_ecjpake_setup(ctx, role, MBEDTLS_MD_SHA256,
 					 MBEDTLS_ECP_DP_SECP256R1, m_password,
 					 password_len);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	if (err_code != 0)
+		return err_code;
 
-	err_code = mbedtls_ecjpake_check(ctx);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	return mbedtls_ecjpake_check(ctx);
 }
 
 void exec_test_case_ecjpake_given(void)
@@ -199,8 +199,10 @@ void exec_test_case_ecjpake_given(void)
 	mbedtls_ecjpake_context ctx_client;
 	mbedtls_ecjpake_context ctx_server;
 
-	ecjpake_ctx_init(&ctx_client, MBEDTLS_ECJPAKE_CLIENT);
-	ecjpake_ctx_init(&ctx_server, MBEDTLS_ECJPAKE_SERVER);
+	err_code = ecjpake_ctx_init(&ctx_client, MBEDTLS_ECJPAKE_CLIENT);
+	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	err_code = ecjpake_ctx_init(&ctx_server, MBEDTLS_ECJPAKE_SERVER);
+	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
 
 	err_code = ecjpake_test_load(&ctx_client, m_priv_key_cli_1,
 				     priv_key_cli_1_len, m_priv_key_cli_2,

--- a/tests/crypto/test_cases/test_hkdf.c
+++ b/tests/crypto/test_cases/test_hkdf.c
@@ -32,9 +32,6 @@ static uint8_t m_hkdf_salt_buf[HKDF_BUF_SIZE];
 static uint8_t m_hkdf_info_buf[HKDF_BUF_SIZE];
 static uint8_t m_hkdf_expected_okm_buf[HKDF_BUF_SIZE];
 
-static uint8_t *p_hkdp_salt;
-static uint8_t *p_hkdp_info;
-
 static test_vector_hkdf_t *p_test_vector;
 
 static size_t ikm_len;
@@ -73,9 +70,6 @@ __attribute__((noinline)) void unhexify_hkdf(void)
 					m_hkdf_expected_okm_buf,
 					sizeof(m_hkdf_expected_okm_buf));
 	okm_len = expected_okm_len;
-
-	p_hkdp_salt = (salt_len == 0) ? NULL : m_hkdf_salt_buf;
-	p_hkdp_info = (info_len == 0) ? NULL : m_hkdf_info_buf;
 }
 
 void hkdf_setup(void)
@@ -92,14 +86,15 @@ void hkdf_setup(void)
  */
 void exec_test_case_hkdf(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	/* Calculation of the HKDF extract and expand. */
 	start_time_measurement();
 
 	const mbedtls_md_info_t *p_md_info =
-		mbedtls_md_info_from_type(p_test_vector->digest_type);
-	err_code = mbedtls_hkdf(p_md_info, p_hkdp_salt, salt_len,
+		mbedtls_md_info_from_type(
+			(mbedtls_md_type_t)p_test_vector->digest_type);
+	err_code = mbedtls_hkdf(p_md_info, m_hkdf_salt_buf, salt_len,
 				m_hkdf_ikm_buf, ikm_len, m_hkdf_info_buf,
 				info_len, m_hkdf_okm_buf, okm_len);
 	stop_time_measurement();

--- a/tests/crypto/test_cases/test_hmac.c
+++ b/tests/crypto/test_cases/test_hmac.c
@@ -88,13 +88,14 @@ __attribute__((noinline)) void unhexify_hmac(void)
  */
 void exec_test_case_hmac(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	/* Initialize the HMAC module. */
 	mbedtls_md_init(&md_context);
 
 	const mbedtls_md_info_t *p_md_info =
-		mbedtls_md_info_from_type(p_test_vector->digest_type);
+		mbedtls_md_info_from_type(
+			(mbedtls_md_type_t)p_test_vector->digest_type);
 	err_code = mbedtls_md_setup(&md_context, p_md_info, 1);
 	if (err_code != 0) {
 		LOG_WRN("mb setup ec: -0x%02X", -err_code);
@@ -129,11 +130,12 @@ void exec_test_case_hmac(void)
  */
 void exec_test_case_hmac_combined(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	/* Generate the HMAC using the combined method. */
 	const mbedtls_md_info_t *p_md_info =
-		mbedtls_md_info_from_type(p_test_vector->digest_type);
+		mbedtls_md_info_from_type(
+			(mbedtls_md_type_t)p_test_vector->digest_type);
 	start_time_measurement();
 	err_code = mbedtls_md_hmac(p_md_info, m_hmac_key_buf, key_len,
 				   m_hmac_input_buf, in_len, m_hmac_output_buf);

--- a/tests/crypto/test_cases/test_sha_256.c
+++ b/tests/crypto/test_cases/test_sha_256.c
@@ -12,7 +12,6 @@
 
 #include "common_test.h"
 #include <sha256.h>
-#include <mbedtls/md.h>
 
 /* Setting LOG_LEVEL_DBG might affect time measurements! */
 LOG_MODULE_REGISTER(test_sha_256, LOG_LEVEL_INF);
@@ -114,7 +113,9 @@ static int exec_sha256(test_vector_hash_t *p_test_vector, int in_len,
 {
 	mbedtls_sha256_init(&sha256_context);
 	int err_code = mbedtls_sha256_starts_ret(&sha256_context, false);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	if (err_code != 0) {
+		return err_code;
+	}
 
 	/* Update the hash. */
 	if (!is_long) {
@@ -131,12 +132,13 @@ static int exec_sha256(test_vector_hash_t *p_test_vector, int in_len,
 
 			err_code = mbedtls_sha256_update_ret(
 				&sha256_context, m_sha_input_buf, in_len);
-			TEST_VECTOR_ASSERT_EQUAL(
-				p_test_vector->expected_err_code, err_code);
+			if (err_code != 0)
+				return err_code;
 		}
 	}
 
-	TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code, err_code);
+	if (err_code != p_test_vector->expected_err_code)
+		return err_code;
 
 	/* Finalize the hash. */
 	return mbedtls_sha256_finish_ret(&sha256_context, m_sha_output_buf);
@@ -146,7 +148,7 @@ static int exec_sha256(test_vector_hash_t *p_test_vector, int in_len,
  */
 void exec_test_case_sha_256(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	start_time_measurement();
 	err_code = exec_sha256(p_test_vector, in_len, false);
@@ -182,7 +184,7 @@ void exec_test_case_sha_256(void)
  */
 void exec_test_case_sha_256_long(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	start_time_measurement();
 	err_code = exec_sha256(p_test_vector, in_len, true);

--- a/tests/crypto/test_cases/test_sha_512.c
+++ b/tests/crypto/test_cases/test_sha_512.c
@@ -11,7 +11,6 @@
 #include <logging/log.h>
 
 #include "common_test.h"
-#include <mbedtls/md.h>
 #include <sha512.h>
 
 /* Setting LOG_LEVEL_DBG might affect time measurements! */
@@ -114,7 +113,8 @@ static int exec_sha_512(test_vector_hash_t *p_test_vector, int in_len,
 {
 	mbedtls_sha512_init(&sha512_context);
 	int err_code = mbedtls_sha512_starts_ret(&sha512_context, false);
-	TEST_VECTOR_ASSERT_EQUAL(0, err_code);
+	if (err_code != 0)
+		return err_code;
 
 	/* Update the hash. */
 	if (!is_long) {
@@ -131,12 +131,13 @@ static int exec_sha_512(test_vector_hash_t *p_test_vector, int in_len,
 
 			err_code = mbedtls_sha512_update_ret(
 				&sha512_context, m_sha_input_buf, in_len);
-			TEST_VECTOR_ASSERT_EQUAL(
-				p_test_vector->expected_err_code, err_code);
+			if (err_code != 0)
+				return err_code;
 		}
 	}
 
-	TEST_VECTOR_ASSERT_EQUAL(p_test_vector->expected_err_code, err_code);
+	if (err_code != p_test_vector->expected_err_code)
+		return err_code;
 
 	/* Finalize the hash. */
 	return mbedtls_sha512_finish_ret(&sha512_context, m_sha_output_buf);
@@ -146,7 +147,7 @@ static int exec_sha_512(test_vector_hash_t *p_test_vector, int in_len,
  */
 void exec_test_case_sha_512(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	start_time_measurement();
 	err_code = exec_sha_512(p_test_vector, in_len, false);
@@ -182,7 +183,7 @@ void exec_test_case_sha_512(void)
  */
 void exec_test_case_sha_512_long(void)
 {
-	int err_code = -1;
+	int err_code;
 
 	start_time_measurement();
 	err_code = exec_sha_512(p_test_vector, in_len, true);

--- a/tests/crypto/test_cases/test_vectors_ecjpake.c
+++ b/tests/crypto/test_cases/test_vectors_ecjpake.c
@@ -5,23 +5,22 @@
  */
 
 #include "common_test.h"
-#include <mbedtls/ecjpake.h>
 
 /*
  * Test data as used by ARMmbed: https://github.com/ARMmbed/mbed-crypto/blob/master/library/ecjpake.c
  */
 
-static const unsigned char ecjpake_password[] =
+static const char ecjpake_password[] =
 	"7468726561646a70616b6574657374";
-static const unsigned char ecjpake_x1[] =
+static const char ecjpake_x1[] =
 	"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f21";
-static const unsigned char ecjpake_x2[] =
+static const char ecjpake_x2[] =
 	"6162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f81";
-static const unsigned char ecjpake_x3[] =
+static const char ecjpake_x3[] =
 	"6162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f81";
-static const unsigned char ecjpake_x4[] =
+static const char ecjpake_x4[] =
 	"c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe1";
-static const unsigned char ecjpake_round_msg_cli_1[] =
+static const char ecjpake_round_msg_cli_1[] =
 	"4104accf0106ef858fa2d919331346805a78b58bbad0b844e5c7892879146187dd2666ada7"
 	"81bb7f111372251a8910621f634df128ac48e381fd6ef9060731f694a441041dd0bd5d4566"
 	"c9bed9ce7de701b5e82e08e84b730466018ab903c79eb982172236c0c1728ae4bf73610d34"
@@ -31,13 +30,13 @@ static const unsigned char ecjpake_round_msg_cli_1[] =
 	"ec91b7e32bb013bb2b4104a49558d32ed1ebfc1816af4ff09b55fcb4ca47b2a02d1e7caf11"
 	"79ea3fe1395b22b861964016fabaf72c975695d93d4df0e5197fe9f040634ed59764937787"
 	"be20bc4deebbf9b8d60a335f046ca3aa941e45864c7cadef9cf75b3d8b010e443ef0";
-static const unsigned char ecjpake_round_msg_cli_2[] =
+static const char ecjpake_round_msg_cli_2[] =
 	"410469d54ee85e90ce3f1246742de507e939e81d1dc1c5cb988b58c310c9fdd9524d93720b"
 	"45541c83ee8841191da7ced86e3312d43623c1d63e74989aba4affd1ee4104077e8c31e20e"
 	"6bedb760c13593e69f15be85c27d68cd09ccb8c4183608917c5c3d409fac39fefee82f7292"
 	"d36f0d23e055913f45a52b85dd8a2052e9e129bb4d200f011f19483535a6e89a580c9b0003"
 	"baf21462ece91a82cc38dbdcae60d9c54c";
-static const unsigned char ecjpake_round_msg_srv_1[] =
+static const char ecjpake_round_msg_srv_1[] =
 	"41047ea6e3a4487037a9e0dbd79262b2cc273e779930fc18409ac5361c5fe669d702e14779"
 	"0aeb4ce7fd6575ab0f6c7fd1c335939aa863ba37ec91b7e32bb013bb2b410409f85b3d20eb"
 	"d7885ce464c08d056d6428fe4dd9287aa365f131f4360ff386d846898bc4b41583c2a5197f"
@@ -47,13 +46,13 @@ static const unsigned char ecjpake_round_msg_srv_1[] =
 	"2b41ccd41ac56a56124104360a1cea33fce641156458e0a4eac219e96831e6aebc88b3f375"
 	"2f93a0281d1bf1fb106051db9694a8d6e862a5ef1324a3d9e27894f1ee4f7c59199965a8dd"
 	"4a2091847d2d22df3ee55faa2a3fb33fd2d1e055a07a7c61ecfb8d80ec00c2c9eb12";
-static const unsigned char ecjpake_round_msg_srv_2[] =
+static const char ecjpake_round_msg_srv_2[] =
 	"03001741040fb22b1d5d1123e0ef9feb9d8a2e590a1f4d7ced2c2b06586e8f2a16d4eb2fda"
 	"4328a20b07d8fd667654ca18c54e32a333a0845451e926ee8804fd7af0aaa7a641045516ea"
 	"3e54a0d5d8b2ce786b38d383370029a5dbe4459c9dd601b408a24ae6465c8ac905b9eb03b5"
 	"d3691c139ef83f1cd4200f6c9cd4ec392218a59ed243d3c820ff724a9a70b88cb86f20b434"
 	"c6865aa1cd7906dd7c9bce3525f508276f26836c";
-static const unsigned char ecjpake_ss[] =
+static const char ecjpake_ss[] =
 	"f3d47f599844db92a569bbe7981e39d931fd743bf22e98f9b438f719d3c4f351";
 
 /*


### PR DESCRIPTION
Some more "cosmetic" issues, others of a more legitimate nature.
Summary:

* Variables overwritten before initial value used
* Unused variables
* False negatives
    - Coverity doesn't understand cipher ctx has been checked to be
        non-null, so add explicit checks
* Possible infinite loops
    - When doing a for loop comparing a u8 to a size_t
* Implicit casts of numericals to enums
* Mixed unsigned char and char
* Unchecked return values
* Unused headers

Signed-off-by: Torstein Grindvik <torstein.grindvik@nordicsemi.no>