### PR TITLE
manifest: update sdk-zephyr to disable TFM_BL2 for crypto

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4d068de3f50f6a2de2be0c0b98670e33d28ff493
+      revision: pull/522/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr, to take in a patch that disables
TFM_BL2 for TF-M builds together with Nordic
Security Backend.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>