### PR TITLE
Bluetooth: Mesh: Timer for model data storage.

### DIFF
--- a/include/bluetooth/mesh/gen_plvl_srv.h
+++ b/include/bluetooth/mesh/gen_plvl_srv.h
@@ -152,6 +152,10 @@ struct bt_mesh_plvl_srv {
 	/** User handler functions. */
 	const struct bt_mesh_plvl_srv_handlers *const handlers;
 
+#if CONFIG_BT_SETTINGS
+	/** Storage timer */
+	struct k_work_delayable store_timer;
+#endif
 	/** Current Power Range. */
 	struct bt_mesh_plvl_range range;
 	/** Current Default Power. */

--- a/include/bluetooth/mesh/gen_plvl_srv.rst
+++ b/include/bluetooth/mesh/gen_plvl_srv.rst
@@ -85,6 +85,9 @@ Persistent storage
 The Generic Power Level Server stores any changes to the Default Power and Power Range states, as well as the last known non-zero Generic Power Level and whether the Generic Power Level is on or off.
 This information is used to reestablish the correct Generic Power Level when the device powers up.
 
+If :option:`CONFIG_BT_SETTINGS` is enabled, the Generic Power Level Server stores all its states persistently using a configurable storage delay to stagger storing.
+See :option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+
 API documentation
 ==================
 

--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -102,6 +102,10 @@ struct bt_mesh_ponoff_srv {
 			     enum bt_mesh_on_power_up old_on_power_up,
 			     enum bt_mesh_on_power_up new_on_power_up);
 
+#if CONFIG_BT_SETTINGS
+	/** Storage timer */
+	struct k_work_delayable store_timer;
+#endif
 	/** Current OnPowerUp state. */
 	enum bt_mesh_on_power_up on_power_up;
 	/* Scene entry */

--- a/include/bluetooth/mesh/gen_ponoff_srv.rst
+++ b/include/bluetooth/mesh/gen_ponoff_srv.rst
@@ -61,6 +61,9 @@ Persistent storage
 
 The Generic On Power Up state is stored persistently, along with the current Generic OnOff state of the extended :ref:`bt_mesh_onoff_srv_readme`.
 
+If :option:`CONFIG_BT_SETTINGS` is enabled, the Generic Power OnOff Server stores all its states persistently using a configurable storage delay to stagger storing.
+See :option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+
 API documentation
 =================
 

--- a/include/bluetooth/mesh/gen_prop_srv.h
+++ b/include/bluetooth/mesh/gen_prop_srv.h
@@ -163,6 +163,10 @@ struct bt_mesh_prop_srv {
 	/** Which state is currently being published. */
 	enum bt_mesh_prop_srv_state pub_state;
 
+#if CONFIG_BT_SETTINGS
+	/** Storage timer */
+	struct k_work_delayable store_timer;
+#endif
 	/** List of properties supported by the server. */
 	struct bt_mesh_prop *const properties;
 	/** Number of properties supported by the server. */

--- a/include/bluetooth/mesh/gen_prop_srv.rst
+++ b/include/bluetooth/mesh/gen_prop_srv.rst
@@ -60,6 +60,9 @@ Persistent storage
 The Generic Manufacturer Property Server and Generic Admin Property Server models will store changes to the user access rights of their properties.
 Any permanent changes to the property values themselves should be stored manually by the application.
 
+If :option:`CONFIG_BT_SETTINGS` is enabled, the Generic Admin Property Server stores all its states persistently using a configurable storage delay to stagger storing.
+See :option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+
 API documentation
 =================
 

--- a/include/bluetooth/mesh/light_ctrl_srv.rst
+++ b/include/bluetooth/mesh/light_ctrl_srv.rst
@@ -428,7 +428,7 @@ Persistent Storage
 ******************
 
 If :option:`CONFIG_BT_SETTINGS` is enabled, the Light LC Server stores all its states persistently using a configurable storage delay to stagger storing.
-See :option:`CONFIG_BT_MESH_LIGHT_CTRL_SRV_STORE_TIMEOUT`.
+See :option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
 
 Changes to the configuration properties are stored and restored on power-up, so the compile time configuration is only valid the first time the device powers up, until the configuration is changed.
 

--- a/include/bluetooth/mesh/light_hue_srv.h
+++ b/include/bluetooth/mesh/light_hue_srv.h
@@ -190,6 +190,11 @@ struct bt_mesh_light_hue_srv {
 		BT_MESH_LIGHT_HSL_MSG_MAXLEN_HUE_STATUS)];
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
+
+#if CONFIG_BT_SETTINGS
+	/** Storage timer */
+	struct k_work_delayable store_timer;
+#endif
 	/** Hue range */
 	struct bt_mesh_light_hsl_range range;
 	/** Last known Hue level */

--- a/include/bluetooth/mesh/light_hue_srv.rst
+++ b/include/bluetooth/mesh/light_hue_srv.rst
@@ -71,6 +71,9 @@ The Light Hue Server stores the following information:
 
 This information is used to reestablish the correct Hue level when the device powers up.
 
+If :option:`CONFIG_BT_SETTINGS` is enabled, the Light Hue Server stores all its states persistently using a configurable storage delay to stagger storing.
+See :option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+
 API documentation
 ******************
 

--- a/include/bluetooth/mesh/light_sat_srv.h
+++ b/include/bluetooth/mesh/light_sat_srv.h
@@ -137,6 +137,11 @@ struct bt_mesh_light_sat_srv {
 		BT_MESH_LIGHT_HSL_MSG_MAXLEN_SAT_STATUS)];
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
+
+#if CONFIG_BT_SETTINGS
+	/** Storage timer */
+	struct k_work_delayable store_timer;
+#endif
 	/** Saturation range */
 	struct bt_mesh_light_hsl_range range;
 	/** Last known Saturation level */

--- a/include/bluetooth/mesh/light_sat_srv.rst
+++ b/include/bluetooth/mesh/light_sat_srv.rst
@@ -64,6 +64,9 @@ The Light Saturation Server stores the following information:
 
 This information is used to reestablish the correct Saturation level when the device powers up.
 
+If :option:`CONFIG_BT_SETTINGS` is enabled, the Light Saturation Server stores all its states persistently using a configurable storage delay to stagger storing.
+See :option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+
 API documentation
 ******************
 

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -124,6 +124,11 @@ struct bt_mesh_light_temp_srv {
 	struct bt_mesh_tid_ctx prev_transaction;
 	/** Handler function structure. */
 	const struct bt_mesh_light_temp_srv_handlers *handlers;
+
+#if CONFIG_BT_SETTINGS
+	/** Storage timer */
+	struct k_work_delayable store_timer;
+#endif
 	/** Default light temperature and delta UV */
 	struct bt_mesh_light_temp dflt;
 	/** Current Temperature range. */

--- a/include/bluetooth/mesh/light_xyl_srv.h
+++ b/include/bluetooth/mesh/light_xyl_srv.h
@@ -151,6 +151,11 @@ struct bt_mesh_light_xyl_srv {
 		BT_MESH_LIGHT_XYL_MSG_LEN_RANGE_STATUS)];
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
+
+#if CONFIG_BT_SETTINGS
+	/** Storage timer */
+	struct k_work_delayable store_timer;
+#endif
 	/** Current range parameters */
 	struct bt_mesh_light_xy_range range;
 	/** Handler function structure. */

--- a/include/bluetooth/mesh/light_xyl_srv.rst
+++ b/include/bluetooth/mesh/light_xyl_srv.rst
@@ -110,6 +110,9 @@ In addition, the model takes over the persistent storage responsibility of the :
 
 This information is used to reestablish the correct light configuration when the device powers up.
 
+If :option:`CONFIG_BT_SETTINGS` is enabled, the Light xyL Server stores all its states persistently using a configurable storage delay to stagger storing.
+See :option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+
 API documentation
 *****************
 

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -153,6 +153,10 @@ struct bt_mesh_lightness_srv {
 	/** User handler functions. */
 	const struct bt_mesh_lightness_srv_handlers *const handlers;
 
+#if CONFIG_BT_SETTINGS
+	/** Storage timer */
+	struct k_work_delayable store_timer;
+#endif
 	/** Current Light Level Range. */
 	struct bt_mesh_lightness_range range;
 	/** Current Default Light Level. */

--- a/include/bluetooth/mesh/lightness_srv.rst
+++ b/include/bluetooth/mesh/lightness_srv.rst
@@ -100,6 +100,9 @@ The Light Lightness Server stores the following information:
 
 This information is used to reestablish the correct Light level when the device powers up.
 
+If :option:`CONFIG_BT_SETTINGS` is enabled, the Light Lightness Server stores all its states persistently using a configurable storage delay to stagger storing.
+See :option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+
 API documentation
 ==================
 

--- a/include/bluetooth/mesh/sensor_srv.h
+++ b/include/bluetooth/mesh/sensor_srv.h
@@ -68,6 +68,10 @@ struct bt_mesh_sensor_srv {
 	/** Number of sensors. */
 	uint8_t sensor_count;
 
+#if CONFIG_BT_SETTINGS
+	/** Storage timer */
+	struct k_work_delayable store_timer;
+#endif
 	/** Publish parameters. */
 	struct bt_mesh_model_pub pub;
 	/* Publication buffer */

--- a/include/bluetooth/mesh/sensor_srv.rst
+++ b/include/bluetooth/mesh/sensor_srv.rst
@@ -77,6 +77,9 @@ The Sensor Server stores the cadence state of each sensor instance persistently,
 Any other data is managed by the application and must be stored separately.
 This applies for example to sensor settings or sample data.
 
+If :option:`CONFIG_BT_SETTINGS` is enabled, the Sensor Server stores all its states persistently using a configurable storage delay to stagger storing.
+See :option:`CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT`.
+
 API documentation
 =================
 

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -31,6 +31,18 @@ config BT_MESH_MOD_ACKD_TIMEOUT_PER_HOP
 
 endmenu
 
+if BT_SETTINGS
+
+config BT_MESH_MODEL_SRV_STORE_TIMEOUT
+	int "Delay (in seconds) before storing changes to mesh model servers"
+	range 0 1000000
+	default 0
+	help
+	  Time to wait before storing changes to the mesh model servers.
+	  Effectively the minimum interval of changes.
+
+endif
+
 config BT_MESH_ONOFF_SRV
 	bool "Generic OnOff Server"
 	select BT_MESH_NRF_MODELS
@@ -366,15 +378,6 @@ config BT_MESH_LIGHT_CTRL_SRV_REG_LUX_STANDBY
 	  Target ambient illuminance for the Standby state (in lux). May be
 	  reconfigured at runtime by other models in the mesh network.
 endif # BT_MESH_LIGHT_CTRL_SRV_REG
-
-config BT_MESH_LIGHT_CTRL_SRV_STORE_TIMEOUT
-	int "Delay (in seconds) before storing changes to the Light LC Server"
-	range 0 1000000
-	default 5
-	help
-	  Time to wait before storing changes to the Light LC Server's
-	  configuration and state. Effectively the minimum interval of changes.
-
 
 config BT_MESH_LIGHT_CTRL_SRV_OCCUPANCY_DELAY
 	int "Default occupancy delay"

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -8,6 +8,10 @@
 #include <bluetooth/mesh/gen_plvl_srv.h>
 #include "model_utils.h"
 
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_MODEL)
+#define LOG_MODULE_NAME bt_mesh_gen_lvl_srv
+#include "common/log.h"
+
 #define LVL_TO_POWER(_lvl) ((_lvl) + 32768)
 #define POWER_TO_LVL(_power) ((_power)-32768)
 
@@ -19,11 +23,12 @@ struct bt_mesh_plvl_srv_settings_data {
 	bool is_on;
 } __packed;
 
-static int store_state(struct bt_mesh_plvl_srv *srv)
+#if CONFIG_BT_SETTINGS
+static void store_timeout(struct k_work *work)
 {
-	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		return 0;
-	}
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_mesh_plvl_srv *srv = CONTAINER_OF(
+		dwork, struct bt_mesh_plvl_srv, store_timer);
 
 	struct bt_mesh_plvl_srv_settings_data data = {
 		.default_power = srv->default_power,
@@ -32,8 +37,18 @@ static int store_state(struct bt_mesh_plvl_srv *srv)
 		.range = srv->range,
 	};
 
-	return bt_mesh_model_data_store(srv->plvl_model, false, NULL, &data,
-					sizeof(data));
+	(void)bt_mesh_model_data_store(srv->plvl_model, false, NULL, &data,
+				       sizeof(data));
+}
+#endif
+
+static void store_state(struct bt_mesh_plvl_srv *srv)
+{
+#if CONFIG_BT_SETTINGS
+	k_work_schedule(
+		&srv->store_timer,
+		K_SECONDS(CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT));
+#endif
 }
 
 static void lvl_status_encode(struct net_buf_simple *buf,
@@ -677,6 +692,10 @@ static int bt_mesh_plvl_srv_init(struct bt_mesh_model *model)
 	srv->pub.update = update_handler;
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
 				      sizeof(srv->pub_data));
+
+#if CONFIG_BT_SETTINGS
+	k_work_init_delayable(&srv->store_timer, store_timeout);
+#endif
 
 	/* Model extensions:
 	 * To simplify the model extension tree, we're flipping the

--- a/subsys/bluetooth/mesh/light_hue_srv.c
+++ b/subsys/bluetooth/mesh/light_hue_srv.c
@@ -25,11 +25,12 @@ struct settings_data {
 	uint16_t dflt;
 } __packed;
 
-static int store(struct bt_mesh_light_hue_srv *srv)
+#if CONFIG_BT_SETTINGS
+static void store_timeout(struct k_work *work)
 {
-	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		return 0;
-	}
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_mesh_light_hue_srv *srv = CONTAINER_OF(
+		dwork, struct bt_mesh_light_hue_srv, store_timer);
 
 	struct settings_data data = {
 		.range = srv->range,
@@ -37,8 +38,18 @@ static int store(struct bt_mesh_light_hue_srv *srv)
 		.dflt = srv->dflt,
 	};
 
-	return bt_mesh_model_data_store(srv->model, false, NULL, &data,
-					sizeof(data));
+	(void)bt_mesh_model_data_store(srv->model, false, NULL, &data,
+				       sizeof(data));
+}
+#endif
+
+static void store(struct bt_mesh_light_hue_srv *srv)
+{
+#if CONFIG_BT_SETTINGS
+	k_work_schedule(
+		&srv->store_timer,
+		K_SECONDS(CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT));
+#endif
 }
 
 static void encode_status(struct net_buf_simple *buf,
@@ -308,6 +319,10 @@ static int hue_srv_init(struct bt_mesh_model *model)
 	srv->pub.msg = &srv->buf;
 	net_buf_simple_init_with_data(&srv->buf, srv->pub_data,
 				      ARRAY_SIZE(srv->pub_data));
+
+#if CONFIG_BT_SETTINGS
+	k_work_init_delayable(&srv->store_timer, store_timeout);
+#endif
 
 	bt_mesh_model_extend(model, srv->lvl.model);
 


### PR DESCRIPTION
Extended storage timeout made for the Light LC to apply to
more of the models. This so it is possible to reduce the
amount of writes done to flash.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>