### PR TITLE
applications: nrf_desktop: Fix Kconfig option in settings_loader

### DIFF
--- a/applications/nrf_desktop/src/modules/settings_loader.c
+++ b/applications/nrf_desktop/src/modules/settings_loader.c
@@ -74,7 +74,7 @@ static bool module_event_handler(const struct module_state_event *event)
 #if CONFIG_DESKTOP_BAS_ENABLE
 		MODULE_ID(bas),
 #endif
-#if CONFIG_DESKTOP_BLE_ADVERTISING_ENABLE
+#if CONFIG_CAF_BLE_ADV
 		MODULE_ID(ble_adv),
 #endif
 #if CONFIG_DESKTOP_MOTION_SENSOR_ENABLE


### PR DESCRIPTION
Change updates Kconfig option name in settings_loader.
The option name was changed when ble_adv was moved to CAF.