### PR TITLE
doc: Mesh samples template adjustment

### DIFF
--- a/samples/bluetooth/mesh/chat/README.rst
+++ b/samples/bluetooth/mesh/chat/README.rst
@@ -8,10 +8,6 @@ Bluetooth: Mesh chat
    :depth: 2
 
 The Bluetooth mesh chat sample demonstrates how the mesh network can be used to facilitate communication between nodes by text, using the :ref:`bt_mesh_chat_client_model`.
-By means of the mesh network, the clients as mesh nodes can communicate with each other without the need of a server.
-The sample is mainly designed for group communication, but it also supports one-on-one communication, as well as sharing the nodes presence.
-
-This sample is used in :ref:`ug_bt_mesh_vendor_model` as an example of how to implement a vendor model for the Bluetooth mesh in |NCS|.
 
 .. toctree::
    :maxdepth: 1
@@ -20,14 +16,32 @@ This sample is used in :ref:`ug_bt_mesh_vendor_model` as an example of how to im
 
    chat_cli.rst
 
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :sample-yaml-rows:
+
+The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+
+* `nRF Mesh mobile app for Android`_
+* `nRF Mesh mobile app for iOS`_
+
 Overview
 ********
 
-This sample is split into four source files:
+By means of the mesh network, the clients as mesh nodes can communicate with each other without the need of a server.
+The mesh chat sample is mainly designed for group communication, but it also supports one-on-one communication, as well as sharing the nodes presence.
 
-* A :file:`main.c` file to handle initialization.
-* A file for handling the Chat Client model, :file:`chat_cli.c`.
-* A file for handling Bluetooth mesh models and communication with the :ref:`shell module <shell_api>`, :file:`model_handler.c`.
+This sample is used in :ref:`ug_bt_mesh_vendor_model` as an example of how to implement a vendor model for the Bluetooth mesh in |NCS|.
+
+The clients are nodes with a provisionee role in a mesh network.
+Provisioning is performed using the `nRF Mesh mobile app`_.
+This mobile application is also used to configure key bindings, and publication and subscription settings of the Bluetooth mesh model instances in the sample.
+After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, you can control the dimmable LED on the development kit from the app.
 
 After provisioning and configuring the Bluetooth mesh models supported by the sample in the `nRF Mesh mobile app`_, you can communicate with other mesh nodes by sending text messages and obtaining their presence using the :ref:`shell module <shell_api>`.
 
@@ -35,6 +49,7 @@ Provisioning
 ============
 
 The provisioning is handled by the :ref:`bt_mesh_dk_prov`.
+It supports four types of out-of-band (OOB) authentication methods, and uses the Hardware Information driver to generate a deterministic UUID to uniquely represent the device.
 
 Models
 ======
@@ -60,20 +75,6 @@ The models are used for the following purposes:
 
 The model handling is implemented in :file:`src/model_handler.c`.
 
-Requirements
-************
-
-The sample supports the following development kits:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :sample-yaml-rows:
-
-The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
-
-* `nRF Mesh mobile app for Android`_
-* `nRF Mesh mobile app for iOS`_
-
 User interface
 **************
 
@@ -85,7 +86,21 @@ LEDs:
    Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
 
 Terminal emulator:
-   Used for the interraction with the sample.
+   Used for the interaction with the sample.
+
+Configuration
+*************
+
+|config|
+
+Source file setup
+=================
+
+This sample is split into the following source files:
+
+* A :file:`main.c` file to handle initialization.
+* A file for handling the Chat Client model, :file:`chat_cli.c`.
+* A file for handling Bluetooth mesh models and communication with the :ref:`shell module <shell_api>`, :file:`model_handler.c`.
 
 Building and running
 ********************
@@ -132,8 +147,8 @@ Make sure to configure the parameters for each mesh node in the mesh network.
 Interacting with the sample
 ---------------------------
 
-1. Connect the kit to the computer using a USB cable.
-   The kit is assigned a COM port (Windows), ttyACM device (Linux) or tty.usbmodem (MacOS).
+1. Connect the development kit to the computer using a USB cable.
+   The development kit is assigned a COM port (Windows), ttyACM device (Linux) or tty.usbmodem (MacOS).
 #. |connect_terminal_specific|
 #. Enable local echo in the terminal to see the text you are typing.
 

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -7,26 +7,44 @@ Bluetooth: Mesh light
    :local:
    :depth: 2
 
-The Bluetooth mesh light sample demonstrates how to set up a basic mesh server model application, and control LEDs with the Bluetooth mesh using the :ref:`bt_mesh_onoff_readme`.
+The Bluetooth mesh light sample demonstrates how to set up a mesh server model application, and control LEDs with Bluetooth mesh using the :ref:`bt_mesh_onoff_readme`.
 
 .. note::
    This sample is self-contained, and can be tested on its own.
    However, it is required when testing the :ref:`bluetooth_mesh_light_switch` sample.
 
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuappns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820
+
+
+The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+
+  * `nRF Mesh mobile app for Android`_
+  * `nRF Mesh mobile app for iOS`_
+
 Overview
 ********
 
-This sample is split into two source files:
+The mesh light sample is a Generic OnOff Server with a provisionee role in a mesh network.
+There can be one or more servers in the network, for example light bulbs.
 
-* A :file:`main.c` file to handle initialization.
-* One additional file for handling mesh models, :file:`model_handler.c`.
+The sample instantiates four instances of the Generic OnOff Server model for controlling LEDs.
 
+Provisioning is performed using the `nRF Mesh mobile app`_.
+This mobile application is also used to configure key bindings, and publication and subscription settings of the Bluetooth mesh model instances in the sample.
 After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, you can control the LEDs on the development kit from the app.
 
 Provisioning
 ============
 
 The provisioning is handled by the :ref:`bt_mesh_dk_prov`.
+It supports four types of out-of-band (OOB) authentication methods, and uses the Hardware Information driver to generate a deterministic UUID to uniquely represent the device.
 
 Models
 ======
@@ -53,21 +71,6 @@ The models are used for the following purposes:
 
 The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library to control each LED on the development kit according to the matching received messages of Generic OnOff Server.
 
-Requirements
-************
-
-The sample supports the following development kits:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuappns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820
-
-
-The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
-
-  * `nRF Mesh mobile app for Android`_
-  * `nRF Mesh mobile app for iOS`_
-
 User interface
 **************
 
@@ -79,6 +82,18 @@ LEDs:
    Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
    Show the OnOff state of the Generic OnOff Server of the corresponding element.
 
+Configuration
+*************
+
+|config|
+
+Source file setup
+=================
+
+This sample is split into the following source files:
+
+* A :file:`main.c` file to handle initialization.
+* One additional file for handling mesh models, :file:`model_handler.c`.
 
 Building and running
 ********************
@@ -92,7 +107,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with `nRF Mesh mobile app`_ installed.
 Testing consists of provisioning the device and configuring it for communication with the mesh models.
 
 Provisioning the device

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -9,21 +9,40 @@ Bluetooth: Mesh light fixture
 
 The Bluetooth mesh light fixture sample demonstrates how to set up a light control mesh server model application, and control a dimmable LED with Bluetooth mesh using the :ref:`bt_mesh_onoff_readme`.
 
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832
+
+The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+
+  * `nRF Mesh mobile app for Android`_
+  * `nRF Mesh mobile app for iOS`_
+
 Overview
 ********
 
-This sample is split into three source files:
+This sample can be used to control the state of light sources.
+In addition to generic on and off functions, it allows changing the light level (brightness) of a LED light.
 
-* A :file:`main.c` file to handle initialization.
-* A file for handling mesh models, :file:`model_handler.c`.
-* A file for handling PWM driven control of the dimmable LED, :file:`lc_pwm_led.c`.
+The sample instantiates the :ref:`bt_mesh_lightness_srv_readme` model and the :ref:`bt_mesh_light_ctrl_srv_readme` model.
+As both Light Lightness Server and the Light LC Server extend the Generic OnOff Server, the two models need to be instantiated on separate elements.
+For more information, see documentation on :ref:`bt_mesh_light_ctrl_srv_readme`.
 
+Devices are nodes with a provisionee role in a mesh network.
+Provisioning is performed using the `nRF Mesh mobile app`_.
+This mobile application is also used to configure key bindings, and publication and subscription settings of the Bluetooth mesh model instances in the sample.
 After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, you can control the dimmable LED on the development kit from the app.
 
 Provisioning
 ============
 
 The provisioning is handled by the :ref:`bt_mesh_dk_prov`.
+It supports four types of out-of-band (OOB) authentication methods, and uses the Hardware Information driver to generate a deterministic UUID to uniquely represent the device.
 
 Models
 ======
@@ -57,13 +76,13 @@ The following table shows the mesh light fixture composition data for this sampl
 
 The models are used for the following purposes:
 
-- The first element contains a Config Server and a Health Server.
+* The first element contains a Config Server and a Health Server.
   The Config Server allows configurator devices to configure the node remotely.
   The Health Server provides ``attention`` callbacks that are used during provisioning to call your attention to the device.
   These callbacks trigger blinking of the LEDs.
-- The seven other models in the first element are the product of a single instance of the Light Lightness Server.
+* The seven other models in the first element are the product of a single instance of the Light Lightness Server.
   The application implements callbacks for the Light Lightness Server to control the first LED on the device using the PWM (pulse width modulation) driver.
-- The three models in the second element are the product of a single instance of the Light Lightness Control (LC) Server.
+* The three models in the second element are the product of a single instance of the Light Lightness Control (LC) Server.
   The Light LC Server controls the Light Lightness Server in the first element, deciding on parameters such as fade time, lighting levels for different states, and inactivity timing.
   In this sample, the Light LC Server is enabled by default on startup.
 
@@ -76,20 +95,6 @@ For more details, see :ref:`bt_mesh_lightness_srv_readme` and :ref:`bt_mesh_ligh
 
 The model handling is implemented in :file:`src/model_handler.c`, which uses the :ref:`dk_buttons_and_leds_readme` library and the :ref:`zephyr:pwm_api` API to control the LEDs on the development kit.
 
-Requirements
-************
-
-The sample supports the following development kits:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832
-
-The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
-
-  * `nRF Mesh mobile app for Android`_
-  * `nRF Mesh mobile app for iOS`_
-
 User interface
 **************
 
@@ -101,6 +106,19 @@ LEDs:
    Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
    First LED outputs the current light level of the Light Lightness Server in the first element.
 
+Configuration
+*************
+
+|config|
+
+Source file setup
+=================
+
+This sample is split into the following source files:
+
+* A :file:`main.c` file to handle initialization.
+* A file for handling mesh models, :file:`model_handler.c`.
+* A file for handling PWM driven control of the dimmable LED, :file:`lc_pwm_led.c`.
 
 Building and running
 ********************
@@ -114,7 +132,7 @@ Building and running
 Testing
 =======
 
-After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor's nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with `nRF Mesh mobile app`_ installed.
 Testing consists of provisioning the device and configuring it for communication with the mesh models.
 
 Provisioning the device

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -107,7 +107,7 @@ Configuration
 Source file setup
 =================
 
-The light switch sample is split into two source files:
+The light switch sample is split into the following source files:
 
 * A :file:`main.c` file to handle initialization.
 * One additional file for handling mesh models, :file:`model_handler.c`.

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -15,13 +15,24 @@ In addition, the samples demonstrate usage of both :ref:`single-channel sensor t
    This sample must be paired with :ref:`bluetooth_mesh_sensor_server` to show any functionality.
    The observer has no sensor data, and is dependent on a mesh sensor to provide it.
 
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :sample-yaml-rows:
+
+The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+
+* `nRF Mesh mobile app for Android`_
+* `nRF Mesh mobile app for iOS`_
+
+Additionally, the sample requires the :ref:`bluetooth_mesh_sensor_server` sample application, programmed on a separate development kit and configured according to mesh sensor sample's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>`.
+
 Overview
 ********
-
-This sample is split into the following source files:
-
-* A :file:`main.c` file to handle initialization.
-* One additional file for handling Bluetooth mesh models, :file:`model_handler.c`.
 
 The following Bluetooth mesh sensor types are used in this sample:
 
@@ -35,6 +46,8 @@ Provisioning
 ============
 
 The provisioning is handled by the :ref:`bt_mesh_dk_prov`.
+It supports four types of out-of-band (OOB) authentication methods, and uses the Hardware Information driver to generate a deterministic UUID to uniquely represent the device.
+
 Use `nRF Mesh mobile app`_ for provisioning and configuring of models supported by the sample.
 
 Models
@@ -62,22 +75,6 @@ The models are used for the following purposes:
 The model handling is implemented in :file:`src/model_handler.c`.
 A :c:struct:`k_work_delayable` item is submitted recursively to periodically request sensor data.
 
-Requirements
-************
-
-The sample supports the following development kits:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :sample-yaml-rows:
-
-The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
-
-* `nRF Mesh mobile app for Android`_
-* `nRF Mesh mobile app for iOS`_
-
-Additionally, the sample requires the :ref:`bluetooth_mesh_sensor_server` sample application, programmed on a separate development kit and configured according to mesh sensor sample's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>`.
-
 User interface
 **************
 
@@ -88,6 +85,20 @@ Buttons:
 Terminal:
    All sensor values gathered from the server are printed over UART.
    For more details, see :ref:`gs_testing`.
+
+Configuration
+*************
+
+|config|
+
+Source file setup
+=================
+
+This sample is split into the following source files:
+
+* A :file:`main.c` file to handle initialization.
+* One additional file for handling Bluetooth mesh models, :file:`model_handler.c`.
+
 
 Building and running
 ********************
@@ -103,9 +114,9 @@ Testing
 
 .. note::
    The mesh sensor observer sample cannot demonstrate any functionality on its own, and needs a device with the :ref:`bluetooth_mesh_sensor_server` sample running in the same mesh network.
-   Before testing the mesh sensor observer, go through the mesh sensor's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>` with a different kit.
+   Before testing the mesh sensor observer, go through the mesh sensor's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>` with a different development kit.
 
-After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor’s nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with `nRF Mesh mobile app`_ installed.
 Testing consists of provisioning the device and configuring it for communication with the mesh models.
 
 All sensor values gathered from the server are printed over UART.

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -15,13 +15,25 @@ In addition, the sample demonstrates usage of both :ref:`single-channel sensor t
    This sample must be paired with the :ref:`bluetooth_mesh_sensor_client` sample to show any functionality.
    The mesh sensor provides the sensor data used by the observer.
 
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :sample-yaml-rows:
+
+For provisioning and configuring of the mesh model instances, the sample requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
+
+* `nRF Mesh mobile app for Android`_
+* `nRF Mesh mobile app for iOS`_
+
+Additionally, the sample requires the :ref:`bluetooth_mesh_sensor_client` sample application.
+The application needs to be programmed on a separate device, and configured according to the sensor observer sample's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>`.
+
 Overview
 ********
-
-This sample is split into the following source files:
-
-* A :file:`main.c` file to handle initialization.
-* One additional file for handling Bluetooth mesh models, :file:`model_handler.c`.
 
 The following Bluetooth mesh sensor types are used in this sample:
 
@@ -36,6 +48,8 @@ Provisioning
 ============
 
 The provisioning is handled by the :ref:`bt_mesh_dk_prov`.
+It supports four types of out-of-band (OOB) authentication methods, and uses the Hardware Information driver to generate a deterministic UUID to uniquely represent the device.
+
 Use `nRF Mesh mobile app`_ for provisioning and configuring of models supported by the sample.
 
 Models
@@ -62,23 +76,6 @@ The models are used for the following purposes:
 
 The model handling is implemented in :file:`src/model_handler.c`, which uses the ``TEMP_NRF5`` temperature sensor, and the :ref:`dk_buttons_and_leds_readme` library to detect button presses.
 
-Requirements
-************
-
-The sample supports the following development kits:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :sample-yaml-rows:
-
-The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
-
-* `nRF Mesh mobile app for Android`_
-* `nRF Mesh mobile app for iOS`_
-
-Additionally, the sample requires the :ref:`bluetooth_mesh_sensor_client` sample application.
-The application needs to be programmed on a separate device, and configured according to the sensor observer sample's :ref:`testing guide <bluetooth_mesh_sensor_server_testing>`.
-
 User interface
 **************
 
@@ -87,8 +84,20 @@ Buttons:
    All buttons have the same functionality during the provisioning procedure.
 
 Button 1:
-   Simulate presence detected (after the provisioning procedure is finished).
+   Simulates presence detected (after the provisioning procedure is finished).
 
+Configuration
+*************
+
+|config|
+
+Source file setup
+=================
+
+This sample is split into the following source files:
+
+* A :file:`main.c` file to handle initialization.
+* One additional file for handling Bluetooth mesh models, :file:`model_handler.c`.
 
 Building and running
 ********************
@@ -104,9 +113,9 @@ Testing
 
 .. note::
    The Bluetooth mesh sensor sample cannot demonstrate any functionality on its own, and needs a device with the :ref:`bluetooth_mesh_sensor_client` sample running in the same mesh network.
-   Before testing the sensor sample, go through the sensor observer sample's :ref:`testing guide <bluetooth_mesh_sensor_client_testing>` with a different kit.
+   Before testing the sensor sample, go through the sensor observer sample's :ref:`testing guide <bluetooth_mesh_sensor_client_testing>` with a different development kit.
 
-After programming the sample to your development kit, you can test it by using a smartphone with Nordic Semiconductor’s nRF Mesh app installed.
+After programming the sample to your development kit, you can test it by using a smartphone with `nRF Mesh mobile app`_ installed.
 Testing consists of provisioning the device, and configuring it for communication with the mesh models.
 
 Provisioning the device


### PR DESCRIPTION
NCSDK-9362
Re-shuffling the structure a bit to fit sample template

When it comes to mesh chat sample, we have a subpage structure adding Chat Client model to it.
The agreement is not to introduce that structure level to samples, so it is removed.
I would consider moving the Chat Client model to https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_bt_mesh_vendor_model.html, where it is used as an example. Other alternatives? Don't remember why not in the list of other mesh models... 

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>