### PR TITLE
drivers: bh1749: Fix after k_work API update

### DIFF
--- a/drivers/sensor/bh1749/bh1749.c
+++ b/drivers/sensor/bh1749/bh1749.c
@@ -291,8 +291,8 @@ static int bh1749_init(const struct device *dev)
 		return -EINVAL;
 	}
 	k_work_init_delayable(&bh1749_init_work, bh1749_async_init);
-	return k_work_schedule(&bh1749_init_work,
-			       K_MSEC(async_init_delay[data->async_init_step]));
+	k_work_schedule(&bh1749_init_work, K_MSEC(async_init_delay[data->async_init_step]));
+	return 0;
 };
 
 static const struct sensor_driver_api bh1749_driver_api = {


### PR DESCRIPTION
Driver init function was returning 1 from k_work_schedule(),
causing the driver to fail init.

Changed to always return 0 from init function.

Signed-off-by: Jorgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>