### PR TITLE
zigbee: Align Zigbee FOTA buffer address to 4 bytes

### DIFF
--- a/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
+++ b/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
@@ -73,7 +73,7 @@ union zb_ota_app_ver {
 	};
 };
 
-static uint8_t zb_ota_buf[CONFIG_ZIGBEE_FOTA_DATA_BLOCK_SIZE];
+static uint8_t zb_ota_buf[CONFIG_ZIGBEE_FOTA_DATA_BLOCK_SIZE] __aligned(4);
 static struct zb_ota_dfu_context ota_ctx;
 static struct zb_ota_client_ctx dev_ctx;
 static zigbee_fota_callback_t callback;


### PR DESCRIPTION
This commit aligns Zigbee FOTA library buffer address to 4 bytes