### PR TITLE
doc: unified GUI element sequence notation

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -175,7 +175,7 @@ To enable the LwM2M carrier library, add the following parameter to your build c
 
 ``-DOVERLAY_CONFIG=lwm2m_carrier_overlay.conf``
 
-In |SES|, select :guilabel:`Tools` -> :guilabel:`Options` -> :guilabel:`nRF Connect` to add the above CMake parameter.
+In |SES|, select :guilabel:`Tools` > :guilabel:`Options` > :guilabel:`nRF Connect` to add the above CMake parameter.
 See :ref:`cmake_options` for more information.
 
 Alternatively, you can manually set the configuration options to match the contents of the overlay config file.
@@ -197,7 +197,7 @@ Building and running
 
 The Kconfig file of the application contains options to configure the application.
 For example, configure ``CONFIG_POWER_OPTIMIZATION_ENABLE`` to enable power optimization or ``CONFIG_TEMP_USE_EXTERNAL`` to use an external temperature sensor instead of simulated temperature data.
-In |SES|, select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK project` to browse and configure these options.
+In |SES|, select :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK project` to browse and configure these options.
 Alternatively, use the command line tool ``menuconfig`` or configure the options directly in :file:`prj.conf`.
 
 .. external_antenna_note_start

--- a/doc/nrf/doc_styleguide.rst
+++ b/doc/nrf/doc_styleguide.rst
@@ -176,9 +176,8 @@ Pay attention to the following rules when highlighting content:
 
 * GUI
 
-  * When writing about a sequence of GUI elements, use -> between them.
-    Do not use > or other markup.
-    For example: "Select :guilabel:`File` -> :guilabel:`Save as...`".
+  * When writing about a sequence of GUI elements, use a > between them.
+    For example: "Select :guilabel:`File` > :guilabel:`Save as...`".
 
 * Filenames and titles
 

--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -492,7 +492,7 @@ Before you start :ref:`building and programming a sample application <gs_program
 
    a. Run the file :file:`bin/emStudio`.
 
-   #. Select :guilabel:`File` -> :guilabel:`Open nRF Connect SDK Project`.
+   #. Select :guilabel:`File` > :guilabel:`Open nRF Connect SDK Project`.
 
       .. figure:: images/ses_open.png
          :alt: Open nRF Connect SDK Project menu
@@ -526,7 +526,7 @@ Before you start :ref:`building and programming a sample application <gs_program
 
          If you start SES on macOS by running the file :file:`bin/emStudio`, make sure to complete the following steps:
 
-         1. Specify the path to all executables under :guilabel:`Tools` -> :guilabel:`Options` (in the :guilabel:`nRF Connect` tab).
+         1. Specify the path to all executables under :guilabel:`Tools` > :guilabel:`Options` (in the :guilabel:`nRF Connect` tab).
 
             .. figure:: images/ses_options.png
                :alt: nRF Connect SDK options in SES on Windows
@@ -552,7 +552,7 @@ Before you start :ref:`building and programming a sample application <gs_program
    ..
 
 #. Change the SES environment settings.
-   If you want to change the SES environment settings, click :guilabel:`Tools` -> :guilabel:`Options` and select the :guilabel:`nRF Connect` tab, as shown on the following screenshot from the Windows installation.
+   If you want to change the SES environment settings, click :guilabel:`Tools` > :guilabel:`Options` and select the :guilabel:`nRF Connect` tab, as shown on the following screenshot from the Windows installation.
 
 .. _ses_options_figure:
 

--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -62,7 +62,7 @@ In the window that is displayed, you can define compilation options for the proj
 
 .. note::
    These compilation options apply to the application project only.
-   To manage Zephyr and other subsystems, go to :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project`.
+   To manage Zephyr and other subsystems, go to :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK Project`.
 
 
 SES tags in :file:`CMakeLists.txt`
@@ -130,7 +130,7 @@ Changes are picked up immediately, and you do not need to re-open the project in
 While it is possible to edit the :file:`.config` file directly, you should use SES or a tool like menuconfig or guiconfig to update it.
 These tools present all available options and allow you to select the ones that you need.
 
-To edit the file in SES, select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project`.
+To edit the file in SES, select :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK Project`.
 If your application contains more than one image (see :ref:`ug_multi_image`), you must select the correct target.
 To configure the parent image (the main application), select :guilabel:`menuconfig`.
 The other options allow you to configure the child images.
@@ -220,7 +220,7 @@ To select the build type in SEGGER Embedded Studio:
 
 
 .. note::
-   You can also specify the build type in the :guilabel:`Additional CMake Options` field in :guilabel:`Tools` -> :guilabel:`Options` -> :guilabel:`nRF Connect`.
+   You can also specify the build type in the :guilabel:`Additional CMake Options` field in :guilabel:`Tools` > :guilabel:`Options` > :guilabel:`nRF Connect`.
    However, the changes will only be applied after re-opening the project.
    Reloading the project is not sufficient.
 

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -35,7 +35,7 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
       The Toolchain Manager options after installing the NCS version
 
-#. Select :guilabel:`File` -> :guilabel:`Open nRF Connect SDK Project`.
+#. Select :guilabel:`File` > :guilabel:`Open nRF Connect SDK Project`.
 
     .. figure:: images/ses_open.png
        :alt: Open nRF Connect SDK Project menu
@@ -118,18 +118,18 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
    To build and program an application:
 
       a. Select your project in the Project Explorer.
-      #. From the menu, select :guilabel:`Build` -> :guilabel:`Build Solution`.
+      #. From the menu, select :guilabel:`Build` > :guilabel:`Build Solution`.
       #. When the build completes, you can program the sample to a connected development kit:
 
-         * For a single-image application, select :guilabel:`Target` -> :guilabel:`Download zephyr/zephyr.elf`.
-         * For a multi-image application, select :guilabel:`Target` -> :guilabel:`Download zephyr/merged.hex`.
+         * For a single-image application, select :guilabel:`Target` > :guilabel:`Download zephyr/zephyr.elf`.
+         * For a multi-image application, select :guilabel:`Target` > :guilabel:`Download zephyr/merged.hex`.
 
       .. note::
 	   Alternatively, choose the :guilabel:`Build and Debug` option.
 	   :guilabel:`Build and Debug` will build the application and program it when
 	   the build completes.
 
-#. To inspect the details of the code that was programmed and the memory usage, click :guilabel:`Debug` -> :guilabel:`Go`.
+#. To inspect the details of the code that was programmed and the memory usage, click :guilabel:`Debug` > :guilabel:`Go`.
 
    .. note::
    	In a multi-image build, this allows you to debug the source code of your application only.

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -264,7 +264,7 @@ This also creates the network core image.
 
 Follow these steps to program the network sample :ref:`zephyr:bluetooth-hci-rpmsg-sample` to the network core when it is included as a child image:
 
-1. Select :guilabel:`File` -> :guilabel:`New Project...`.
+1. Select :guilabel:`File` > :guilabel:`New Project...`.
 
     .. figure:: images/ses_nrf5340_netcore_new_project.png
        :alt: Create New Project menu
@@ -338,14 +338,14 @@ Follow these steps to program the network sample :ref:`zephyr:bluetooth-hci-rpms
    A new project has been created for programming the network core with the network sample :ref:`zephyr:bluetooth-hci-rpmsg-sample`.
 
 #. To program the network sample, the ``hci_rpmsg_nrf5340_netcore`` project must be active.
-   If the ``hci_rpmsg_nrf5340_netcore`` project is not the current active project, then set it as active using :guilabel:`Project` -> :guilabel:`Set Active Project` -> :guilabel:`hci_rpmsg_nrf5340_netcore`.
+   If the ``hci_rpmsg_nrf5340_netcore`` project is not the current active project, then set it as active using :guilabel:`Project` > :guilabel:`Set Active Project` > :guilabel:`hci_rpmsg_nrf5340_netcore`.
 
    .. figure:: images/ses_nrf5340_netcore_set_active.png
      :alt: Set the hci_rpmsg_nrf5340_netcore programming target as active
 
      Set the hci_rpmsg_nrf5340_netcore programming target as active
 
-#. You can now program the network sample using :guilabel:`Target` -> :guilabel:`Download hci_rpmsg_nrf5340_netcore`.
+#. You can now program the network sample using :guilabel:`Target` > :guilabel:`Download hci_rpmsg_nrf5340_netcore`.
 
    .. figure:: images/ses_nrf5340_netcore_flash_active.png
      :alt: Program the network sample hci_rpmsg_nrf5340_netcore
@@ -362,7 +362,7 @@ Follow these steps to program the network sample :ref:`zephyr:bluetooth-hci-rpms
 
 #. After the network core is programmed, make sure to make the application target active again.
 
-   To do this, select :guilabel:`Project` -> :guilabel:`Set Active Project` -> :guilabel:`zephyr/merged.hex`.
+   To do this, select :guilabel:`Project` > :guilabel:`Set Active Project` > :guilabel:`zephyr/merged.hex`.
 
    .. figure:: images/ses_nrf5340_appcore_set_active.png
      :alt: Set the zephyr/merged.hex target as active

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -231,7 +231,7 @@ Building and programming using SEGGER Embedded Studio
 #. To build the sample or application:
 
    a. Select your project in the Project Explorer.
-   #. From the menu, select :guilabel:`Build` -> :guilabel:`Build Solution`.
+   #. From the menu, select :guilabel:`Build` > :guilabel:`Build Solution`.
       This builds the project.
 
    You can find the output of the build, which includes the merged HEX file containing both the application and the SPM, in the ``zephyr`` subfolder in the build directory.
@@ -253,8 +253,8 @@ Building and programming using SEGGER Embedded Studio
 .. prog_extdebugprobe_end
 ..
 
-   e. In SES, select :guilabel:`Target` -> :guilabel:`Connect J-Link`.
-   #. Select :guilabel:`Target` -> :guilabel:`Download zephyr/merged.hex` to program the sample or application onto Thingy:91.
+   e. In SES, select :guilabel:`Target` > :guilabel:`Connect J-Link`.
+   #. Select :guilabel:`Target` > :guilabel:`Download zephyr/merged.hex` to program the sample or application onto Thingy:91.
    #. The device will reset and run the programmed sample or application.
 
 .. _build_pgm_cmdline:

--- a/include/net/aws_iot.rst
+++ b/include/net/aws_iot.rst
@@ -62,7 +62,7 @@ To establish a connection to the AWS IoT message broker, set the following optio
 
 To configure the required library options, complete the following steps:
 
-1. In the `AWS IoT console`_, navigate to :guilabel:`IoT core` -> :guilabel:`Manage` -> :guilabel:`things` and click on the entry for the *thing* created during the steps of :ref:`creating_a_thing_in_AWS_IoT`.
+1. In the `AWS IoT console`_, navigate to :guilabel:`IoT core` > :guilabel:`Manage` > :guilabel:`things` and click on the entry for the *thing* created during the steps of :ref:`creating_a_thing_in_AWS_IoT`.
 #. Navigate to :guilabel:`interact`, find the ``Rest API Endpoint`` and set the configurable option :option:`CONFIG_AWS_IOT_BROKER_HOST_NAME` to this address string.
 #. Set the option :option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC` to the name of the *thing* created during the aforementioned steps.
 #. Set the security tag configuration :option:`CONFIG_AWS_IOT_SEC_TAG` to the security tag, chosen while `Programming the certificates to the on-board modem of the nRF9160-based kit`_.

--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -121,7 +121,7 @@ Testing with nRF Connect for Desktop
       Reading BAS value:
       [xx.xx.xx.xx.xx.xx (random)]: Battery read: 100%
 
-#. Change the value in :guilabel:`Battery Service` -> :guilabel:`Battery Level` to generate notifications.
+#. Change the value in :guilabel:`Battery Service` > :guilabel:`Battery Level` to generate notifications.
 #. Observe that the notification information is displayed::
 
       [xx.xx.xx.xx.xx.xx (random)]: Battery notification: 99%

--- a/samples/bluetooth/peripheral_ancs_client/README.rst
+++ b/samples/bluetooth/peripheral_ancs_client/README.rst
@@ -74,7 +74,7 @@ Testing with an iOS device
 
 #. |connect_terminal_specific|
 #. Reset the kit.
-#. Select the device in the iOS settings -> Bluetooth menu and connect.
+#. Select the device in the iOS settings Bluetooth menu and connect.
 #. Observe that notifications that are displayed in the iOS notification tab also show up on the UART from the sample.
 #. Press **Button 1** to retrieve the notification attributes and observe that you receive, among other information, the app identifier for the last received notification.
    For example, if you got a notification from the Calendar app and request the app identifier, it is "com.apple.mobilecal".

--- a/samples/bluetooth/peripheral_cts_client/README.rst
+++ b/samples/bluetooth/peripheral_cts_client/README.rst
@@ -60,7 +60,7 @@ After programming the sample to your development kit, you can test it with `nRF 
 #. Go to the :guilabel:`Connection Map` tab.
    Click the dongle configuration and select :guilabel:`Security parameters`.
    Check :guilabel:`Perform Bonding`, and click :guilabel:`Apply`.
-#. Set the value of :guilabel:`Current Time Service` -> :guilabel:`Current Time` to ``C2 07 0B 0F 0C 22 38 06 80 02`` and click Write.
+#. Set the value of :guilabel:`Current Time Service` > :guilabel:`Current Time` to ``C2 07 0B 0F 0C 22 38 06 80 02`` and click Write.
 #. Connect to the device from nRF Connect. The device is advertising as "Nordic_CTS".
 #. Wait until the bond is established. Verify that the UART data is received as follows::
 
@@ -92,7 +92,7 @@ After programming the sample to your development kit, you can test it with `nRF 
           External update  1
           Manual update    0
 
-#. Change the value of :guilabel:`Current Time Service` -> :guilabel:`Current Time` to ``C2 07 0B 0F 0D 25 2A 06 FE 08``. It generates a notification. Verify that the current time printed on the UART matches the time that was input::
+#. Change the value of :guilabel:`Current Time Service` > :guilabel:`Current Time` to ``C2 07 0B 0F 0D 25 2A 06 FE 08``. It generates a notification. Verify that the current time printed on the UART matches the time that was input::
 
       Current Time:
 

--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -102,7 +102,7 @@ If you choose to do so, use the Python scripts located in the :file:`scripts/boo
 
        This will erase the whole chip before programming the new image.
 
-     * In |SES|, choose :guilabel:`Target` -> :guilabel:`Connect J-Link` and then :guilabel:`Target` -> :guilabel:`Erase All` to erase the whole chip.
+     * In |SES|, choose :guilabel:`Target` > :guilabel:`Connect J-Link` and then :guilabel:`Target` > :guilabel:`Erase All` to erase the whole chip.
 
    * The public key hash cannot contain half-words with the value ``0xFFFF``, because half-words are writeable when they are ``0xFFFF``, so such hashes cannot be guaranteed to be immutable.
      The bootloader will refuse to boot if any hash contains a half-word with the value ``0xFFFF``.
@@ -153,8 +153,8 @@ Complete the following steps to add the bootloader sample as a child image to yo
 
 #. Enable Secure Boot by running ``menuconfig`` on your application:
 
-   a. Select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK project`.
-   #. Go to :guilabel:`Modules` -> :guilabel:`Nordic nRF Connect` -> :guilabel:`Bootloader` and set :guilabel:`Use Secure Bootloader` to enable :option:`CONFIG_SECURE_BOOT`.
+   a. Select :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK project`.
+   #. Go to :guilabel:`Modules` > :guilabel:`Nordic nRF Connect` > :guilabel:`Bootloader` and set :guilabel:`Use Secure Bootloader` to enable :option:`CONFIG_SECURE_BOOT`.
    #. Under :guilabel:`Private key PEM file` (:option:`CONFIG_SB_SIGNING_KEY_FILE`), enter the path to the private key that you created.
       If you choose to run the sample with default debug keys, you can skip this step.
 
@@ -168,9 +168,9 @@ Complete the following steps to add the bootloader sample as a child image to yo
 
    #. Click :guilabel:`Configure`.
 
-#. Select :guilabel:`Build` -> :guilabel:`Build Solution` to compile your application.
+#. Select :guilabel:`Build` > :guilabel:`Build Solution` to compile your application.
    The build process creates two images, one for the bootloader and one for the application, and merges them together.
-#. Select :guilabel:`Build` -> :guilabel:`Build and Run` to program the resulting image to your device.
+#. Select :guilabel:`Build` > :guilabel:`Build and Run` to program the resulting image to your device.
 
 Building on the command line
 ============================

--- a/samples/debug/ppi_trace/README.rst
+++ b/samples/debug/ppi_trace/README.rst
@@ -54,7 +54,7 @@ After programming the sample to your development kit, test it by performing the 
 
 1. Connect a logic analyzer to the pins that are used for tracing.
    Check the sample configuration for information about which pins are used.
-   To do so in |SES|, select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project` and navigate to :guilabel:`PPI trace pins configuration`.
+   To do so in |SES|, select :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK Project` and navigate to :guilabel:`PPI trace pins configuration`.
 #. Observe that:
 
    * The pin that is tracing the RTC Tick event is toggling with a frequency of approximately 32 kHz.

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -39,7 +39,7 @@ See `AWS IoT Developer Guide: Basic Policy Variables`_ and `AWS IoT Developer Gu
 To create a thing for your kit:
 
 1. Log on to the `AWS IoT console`_.
-#. Go to :guilabel:`Secure` -> :guilabel:`Policies` and select :guilabel:`Create a policy`.
+#. Go to :guilabel:`Secure` > :guilabel:`Policies` and select :guilabel:`Create a policy`.
 #. Enter a name and define your policy.
    For testing purposes, you can use the following policy (switch to :guilabel:`Advanced mode` to copy and paste it):
 
@@ -55,7 +55,7 @@ To create a thing for your kit:
              }
           ]
        }
-#. Go to :guilabel:`Manage` -> :guilabel:`Things` and select :guilabel:`Register a thing` or :guilabel:`Create` (depending on whether you already have a thing registered).
+#. Go to :guilabel:`Manage` > :guilabel:`Things` and select :guilabel:`Register a thing` or :guilabel:`Create` (depending on whether you already have a thing registered).
 #. Select :guilabel:`Create a single thing`.
 #. Enter a name.
    The default name used by the sample is ``nrf-IMEI``, where *IMEI* is the IMEI number of your kit.
@@ -198,7 +198,7 @@ After programming the sample to your development kit, test it by performing the 
       [mqtt_evt_handler:129] MQTT client connected!
       [00:00:14.106,140] <inf> aws_jobs: Subscribe: $aws/things/nrf-aws-fota/jobs/notify-next
 
-#. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` -> :guilabel:`Things`, and select your thing.
+#. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` > :guilabel:`Things`, and select your thing.
 #. Go to :guilabel:`Shadow` and confirm that the application version (``nrfcloud__dfu_v1__app_v``) is the one that you configured for the sample.
 #. In the :ref:`configuring`, change the application version.
    Then rebuild the application, but do not program it.
@@ -226,7 +226,7 @@ After programming the sample to your development kit, test it by performing the 
 #. Log on to the `AWS S3 console`_.
 #. Select the bucket, click :guilabel:`Upload`, and select your job document.
    Use the default settings when uploading the file.
-#. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` -> :guilabel:`Jobs`, and select :guilabel:`Create a job`.
+#. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` > :guilabel:`Jobs`, and select :guilabel:`Create a job`.
 #. Click :guilabel:`Create custom job` and enter a unique job ID.
    Select your device and the job file that you uploaded to AWS S3.
    Use the default settings for all other options.
@@ -249,7 +249,7 @@ After programming the sample to your development kit, test it by performing the 
 
 
 #. When the kit resets, observe that the sample prints the new application version.
-#. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` -> :guilabel:`Things`, and select your thing.
+#. Log on to the `AWS IoT console`_, go to :guilabel:`Manage` > :guilabel:`Things`, and select your thing.
 #. Go to :guilabel:`Shadow` and confirm that the application version has updated.
 
 

--- a/samples/nrf9160/http_update/application_update/README.rst
+++ b/samples/nrf9160/http_update/application_update/README.rst
@@ -54,7 +54,7 @@ See `Setting up an AWS S3 bucket`_ for instructions.
 
 To specify the location in |SES|:
 
-1. Select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project`.
+1. Select :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK Project`.
 #. Navigate to :guilabel:`HTTP application update sample` and specify the download hostname (``CONFIG_DOWNLOAD_HOST``) and the file to download (``CONFIG_DOWNLOAD_FILE``).
 #. Click :guilabel:`Configure` to save the configuration.
 
@@ -79,7 +79,7 @@ Testing
 After programming the sample to your development kit, test it by performing the following steps:
 
 1. Configure the application version to be 2.
-   To do so, either change ``CONFIG_APPLICATION_VERSION`` to 2 in the :file:`prj.conf` file, or select :guilabel:`Project` -> :guilabel:`Configure nRF Connect SDK Project` -> :guilabel:`HTTP application update sample` in |SES| and change the value for :guilabel:`Application version`.
+   To do so, either change ``CONFIG_APPLICATION_VERSION`` to 2 in the :file:`prj.conf` file, or select :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK Project` > :guilabel:`HTTP application update sample` in |SES| and change the value for :guilabel:`Application version`.
    Then rebuild the application.
 #. Upload the file :file:`update.bin` to the server you have chosen.
    To upload the file on nRF Connect for Cloud, click :guilabel:`Upload` for the firmware URL that you generated earlier.

--- a/scripts/shell/ble_console/README.rst
+++ b/scripts/shell/ble_console/README.rst
@@ -62,6 +62,6 @@ Pairing with the device
 ***********************
 
 After configuring the Bluetooth daemon, you can pair with the device using the Bluetooth tools provided by your Linux vendor.
-For example, in Ubuntu simply go to :guilabel:`Settings` -> :guilabel:`Bluetooth`.
+For example, in Ubuntu simply go to :guilabel:`Settings` > :guilabel:`Bluetooth`.
 
 After pairing successfully, you can start using Bluetooth LE Console.


### PR DESCRIPTION
JIRA ticket NCSDK-9709.

Unified notation on sequential GUI elements across documentation set.
Left the rule in place, to be handled as part of NCSDK-9708.

Documentation still contains arrows, but those are parts of code samples and other non-related instances.

Signed-off-by: Wille Backman wille.backman@nordicsemi.no