### PR TITLE
tests: dfu_target: fix warning

### DIFF
--- a/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
@@ -145,7 +145,7 @@ static void test_done(void)
 static void test_offset_get(void)
 {
 	int err;
-	size_t offset;
+	size_t offset = 0;
 
 	init();
 


### PR DESCRIPTION
Fix for a coverity warning for an uninitialized variable in dfu tests

Signed-off-by: Markus Swarowsky markus.swarowsky@nordicsemi.no