### PR TITLE
applications: serial_lte_modem: Add SMS support

### DIFF
--- a/applications/serial_lte_modem/CMakeLists.txt
+++ b/applications/serial_lte_modem/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(app PRIVATE src/slm_at_udp_proxy.c)
 target_sources(app PRIVATE src/slm_at_icmp.c)
 target_sources(app PRIVATE src/slm_at_fota.c)
 # NORDIC SDK APP END
+target_sources_ifdef(CONFIG_SLM_SMS app PRIVATE src/slm_at_sms.c)
 target_sources_ifdef(CONFIG_SLM_NATIVE_TLS app PRIVATE src/slm_native_tls.c)
 target_sources_ifdef(CONFIG_SLM_NATIVE_TLS app PRIVATE src/slm_at_cmng.c)
 

--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -141,6 +141,13 @@ config SLM_DATAMODE_SILENCE
 #
 # Configurable services
 #
+config SLM_SMS
+	bool "SMS support in SLM"
+	default y
+	select SMS
+	help
+	  Support SMS send/receive in plain text
+
 rsource "src/gps/Kconfig"
 rsource "src/ftp_c/Kconfig"
 rsource "src/mqtt_c/Kconfig"

--- a/applications/serial_lte_modem/doc/AT_commands_intro.rst
+++ b/applications/serial_lte_modem/doc/AT_commands_intro.rst
@@ -38,6 +38,7 @@ The modem-specific AT commands are documented in the `nRF91 AT Commands Referenc
    FTP_AT_commands
    GPS_AT_commands
    ICMP_AT_commands
+   SMS_AT_commands
    MQTT_AT_commands
    TCPIP_AT_commands
    HTTPC_AT_commands

--- a/applications/serial_lte_modem/doc/SMS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SMS_AT_commands.rst
@@ -1,0 +1,111 @@
+.. _SLM_AT_SMS:
+
+SMS AT commands
+****************
+
+.. contents::
+   :local:
+   :depth: 2
+
+The following commands list contains SMS-related AT commands.
+
+SMS support #XSMS
+=================
+
+The ``#XSMS`` command supports functionalities for sending and receiving SMS messages.
+
+Set command
+-----------
+
+The set command allows you to start or stop SMS, as well as send SMS text.
+Only GSM-7 encoding is supported, 8-bit and UCS2 encodings are not supported.
+
+Syntax
+~~~~~~
+
+::
+
+   #XSMS=<op>[,<number>,<text>]
+
+* The ``<op>`` parameter can accept one of the following values:
+
+  * ``0`` - Stop SMS
+  * ``1`` - Start SMS, ready to receive
+  * ``2`` - Send SMS
+
+* The ``<number>`` parameter is a string.
+  It represents the SMS recipient's phone number, including the country code (for example ``+81xxxxxxx``).
+* The ``<text>`` parameter is  a string.
+  It is the SMS text to be sent.
+
+Unsolicited notification
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is the notification syntax when an SMS message is received:
+
+  ::
+
+      #XSMS: <datetime>,<number>,<text>
+
+  * The ``<datetime>`` value is a string.
+    It represents the time when the SMS is received.
+    It has a format of "YY-MM-DD HH:MM:SS".
+  * The ``<number>`` value is a string.
+    It represents the SMS sender's phone number.
+  * The ``<text>`` value is a string.
+    It represents the SMS text that has been received.
+
+  When receiving concatenated SMS messages, there will be only one notification.
+
+Example
+~~~~~~~
+
+::
+
+  at#xsms=1
+
+  OK
+  at#xsms=2,"+8190xxxxxxxx","SLM test"
+
+  OK
+
+  #XSMS: "21-05-24 11:58:22","090xxxxxxxx","Tested OK"
+
+  at#xsms=2,"+8190xxxxxxxx","0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+  OK
+
+  #XSMS: "21-05-24 13:29:47","090xxxxxxxx","0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command tests the existence of the command and provides information about the type of its subparameters.
+
+Syntax
+~~~~~~
+
+::
+
+    #XSMS=?
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+    #XSMS: <list of op value>,<number>,<text>
+
+Examples
+~~~~~~~~
+
+::
+
+  at#xsms=?
+  #XSMS: (0,1,2),<number>,<text>
+  OK

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -205,6 +205,10 @@ Check and configure the following configuration options for the sample:
    This option specifies the time (in seconds) of UART silence before and after the pattern string that is used to exit data mode.
    The default value is 1 second.
 
+.. option:: CONFIG_SLM_SMS - SMS support in SLM
+
+   This option enables additional AT commands for using SMS service.
+
 .. option:: CONFIG_SLM_GPS - GPS support in SLM
 
    This option enables additional AT commands for using GPS service.

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -26,6 +26,7 @@
 #include "slm_at_cmng.h"
 #endif
 #include "slm_at_icmp.h"
+#include "slm_at_sms.h"
 #include "slm_at_fota.h"
 #if defined(CONFIG_SLM_GPS)
 #include "slm_at_gps.h"
@@ -331,6 +332,11 @@ int handle_at_xcmng(enum at_cmd_type cmd_type);
 /* ICMP commands */
 int handle_at_icmp_ping(enum at_cmd_type cmd_type);
 
+#if defined(CONFIG_SLM_SMS)
+/* SMS commands */
+int handle_at_sms(enum at_cmd_type cmd_type);
+#endif
+
 /* FOTA commands */
 int handle_at_fota(enum at_cmd_type cmd_type);
 
@@ -404,6 +410,11 @@ static struct slm_at_cmd {
 #endif
 	/* ICMP commands */
 	{"AT#XPING", handle_at_icmp_ping},
+
+#if defined(CONFIG_SLM_SMS)
+	/* SMS commands */
+	{"AT#XSMS", handle_at_sms},
+#endif
 
 	/* FOTA commands */
 	{"AT#XFOTA", handle_at_fota},
@@ -510,6 +521,13 @@ int slm_at_init(void)
 		LOG_ERR("ICMP could not be initialized: %d", err);
 		return -EFAULT;
 	}
+#if defined(CONFIG_SLM_GPS)
+	err = slm_at_sms_init();
+	if (err) {
+		LOG_ERR("SMS could not be initialized: %d", err);
+		return -EFAULT;
+	}
+#endif
 	err = slm_at_fota_init();
 	if (err) {
 		LOG_ERR("FOTA could not be initialized: %d", err);
@@ -580,6 +598,12 @@ void slm_at_uninit(void)
 	if (err) {
 		LOG_WRN("ICMP could not be uninitialized: %d", err);
 	}
+#if defined(CONFIG_SLM_GPS)
+	err = slm_at_sms_uninit();
+	if (err) {
+		LOG_WRN("SMS could not be uninitialized: %d", err);
+	}
+#endif
 	err = slm_at_fota_uninit();
 	if (err) {
 		LOG_WRN("FOTA could not be uninitialized: %d", err);

--- a/applications/serial_lte_modem/src/slm_at_sms.c
+++ b/applications/serial_lte_modem/src/slm_at_sms.c
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <logging/log.h>
+#include <zephyr.h>
+#include <stdio.h>
+#include <string.h>
+#include <modem/sms.h>
+#include "slm_util.h"
+
+LOG_MODULE_REGISTER(slm_sms, CONFIG_SLM_LOG_LEVEL);
+
+#define MAX_CONCATENATED_MESSAGE  3
+
+/**@brief SMS operations. */
+enum slm_sms_operation {
+	AT_SMS_STOP,
+	AT_SMS_START,
+	AT_SMS_SEND
+};
+
+static int sms_handle;
+
+/* global functions defined in different files */
+void rsp_send(const uint8_t *str, size_t len);
+
+/* global variable defined in different files */
+extern struct at_param_list at_param_list;
+extern char rsp_buf[CONFIG_SLM_SOCKET_RX_MAX * 2];
+
+static void sms_callback(struct sms_data *const data, void *context)
+{
+	static uint16_t ref_number;
+	static uint8_t total_msgs;
+	static uint8_t count;
+	static char messages[MAX_CONCATENATED_MESSAGE - 1][SMS_MAX_PAYLOAD_LEN_CHARS];
+
+	ARG_UNUSED(context);
+
+	if (data == NULL) {
+		LOG_WRN("NULL data");
+		return;
+	}
+
+	if (data->type == SMS_TYPE_DELIVER) {
+		struct sms_deliver_header *header = &data->header.deliver;
+
+		if (!header->concatenated.present) {
+			sprintf(rsp_buf, "\r\n#XSMS: \"%02d-%02d-%02d %02d:%02d:%02d\",\"",
+				header->time.year, header->time.month, header->time.day,
+				header->time.hour, header->time.minute, header->time.second);
+			strcat(rsp_buf, header->originating_address.address_str);
+			strcat(rsp_buf, "\",\"");
+			strcat(rsp_buf, data->payload);
+			strcat(rsp_buf, "\"\r\n");
+			rsp_send(rsp_buf, strlen(rsp_buf));
+		} else {
+			LOG_DBG("concatenated message %d, %d, %d",
+				header->concatenated.ref_number,
+				total_msgs = header->concatenated.total_msgs,
+				header->concatenated.seq_number);
+			/* ref_number and total_msgs should remain unchanged */
+			if (ref_number == 0) {
+				ref_number = header->concatenated.ref_number;
+			}
+			if (ref_number != header->concatenated.ref_number) {
+				LOG_ERR("SMS concatenated message ref_number error: %d, %d",
+					ref_number, header->concatenated.ref_number);
+				goto done;
+			}
+			if (total_msgs == 0) {
+				total_msgs = header->concatenated.total_msgs;
+			}
+			if (total_msgs != header->concatenated.total_msgs) {
+				LOG_ERR("SMS concatenated message total_msgs error: %d, %d",
+					total_msgs, header->concatenated.total_msgs);
+				goto done;
+			}
+			if (total_msgs > MAX_CONCATENATED_MESSAGE) {
+				LOG_ERR("SMS concatenated message no memory: %d", total_msgs);
+				goto done;
+			}
+			/* seq_number should start with 1 but could arrive in random order */
+			if (header->concatenated.seq_number == 0 ||
+			    header->concatenated.seq_number > total_msgs) {
+				LOG_ERR("SMS concatenated message seq_number error: %d, %d",
+					header->concatenated.seq_number, total_msgs);
+				goto done;
+			}
+			if (header->concatenated.seq_number == 1) {
+				sprintf(rsp_buf, "\r\n#XSMS: \"%02d-%02d-%02d %02d:%02d:%02d\",\"",
+					header->time.year, header->time.month, header->time.day,
+					header->time.hour, header->time.minute,
+					header->time.second);
+				strcat(rsp_buf, header->originating_address.address_str);
+				strcat(rsp_buf, "\",\"");
+				strcat(rsp_buf, data->payload);
+				count++;
+			} else {
+				strcpy(messages[header->concatenated.seq_number - 2],
+					data->payload);
+				count++;
+			}
+			if (count == total_msgs) {
+				for (int i = 0; i < (total_msgs - 1); i++) {
+					strcat(rsp_buf, messages[i]);
+				}
+				strcat(rsp_buf, "\"\r\n");
+				rsp_send(rsp_buf, strlen(rsp_buf));
+			} else {
+				return;
+			}
+done:
+			ref_number = 0;
+			total_msgs = 0;
+			count = 0;
+		}
+	} else if (data->type == SMS_TYPE_STATUS_REPORT) {
+		LOG_INF("Status report received");
+	} else {
+		LOG_WRN("Unknown type: %d", data->type);
+	}
+}
+
+static int do_sms_start(void)
+{
+	int err = 0;
+
+	if (sms_handle >= 0) {
+		/* already registered */
+		return -EINVAL;
+	}
+
+	sms_handle = sms_register_listener(sms_callback, NULL);
+	if (sms_handle < 0) {
+		err = sms_handle;
+		LOG_ERR("SMS start error: %d", err);
+		sms_handle = -1;
+	}
+
+	return err;
+}
+
+static int do_sms_stop(void)
+{
+	if (sms_handle < 0) {
+		/* not registered yet */
+		return -EINVAL;
+	}
+
+	sms_unregister_listener(sms_handle);
+	sms_handle = -1;
+
+	return 0;
+}
+
+static int do_sms_send(const char *number, const char *message)
+{
+	int err;
+
+	if (sms_handle < 0) {
+		/* not registered yet */
+		return -EINVAL;
+	}
+
+	err = sms_send_text(number, message);
+	if (err) {
+		LOG_ERR("SMS send error: %d", err);
+	}
+
+	return err;
+}
+
+
+/**@brief handle AT#XSMS commands
+ *  AT#XSMS=<op>,[<number>,<message>]
+ *  AT#XSMS? READ command not supported
+ *  AT#XSMS=?
+ */
+int handle_at_sms(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	uint16_t op;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		if (err) {
+			return err;
+		}
+		if (op == AT_SMS_STOP) {
+			err = do_sms_stop();
+		} else if (op == AT_SMS_START) {
+			err = do_sms_start();
+		} else if (op ==  AT_SMS_SEND) {
+			char number[SMS_MAX_ADDRESS_LEN_CHARS + 1];
+			char message[MAX_CONCATENATED_MESSAGE * SMS_MAX_PAYLOAD_LEN_CHARS];
+			int size;
+
+			size = SMS_MAX_ADDRESS_LEN_CHARS + 1;
+			err = util_string_get(&at_param_list, 2, number, &size);
+			if (err) {
+				return err;
+			}
+			size = MAX_CONCATENATED_MESSAGE * SMS_MAX_PAYLOAD_LEN_CHARS;
+			err = util_string_get(&at_param_list, 3, message, &size);
+			if (err) {
+				return err;
+			}
+			err = do_sms_send(number, message);
+		} else {
+			LOG_WRN("Unknown SMS operation: %d", op);
+		}
+		break;
+
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf, "\r\n#XSMS: (%d,%d,%d),<number>,<message>\r\n",
+			AT_SMS_STOP, AT_SMS_START, AT_SMS_SEND);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief API to initialize SMS AT commands handler
+ */
+int slm_at_sms_init(void)
+{
+	sms_handle = -1;
+
+	return 0;
+}
+
+/**@brief API to uninitialize SMS AT commands handler
+ */
+int slm_at_sms_uninit(void)
+{
+	if (sms_handle >= 0) {
+		sms_unregister_listener(sms_handle);
+	}
+
+	return 0;
+}

--- a/applications/serial_lte_modem/src/slm_at_sms.h
+++ b/applications/serial_lte_modem/src/slm_at_sms.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef SLM_AT_SMS_
+#define SLM_AT_SMS_
+
+/**@file slm_at_sms.h
+ *
+ * @brief Vendor-specific AT command for SMS service.
+ * @{
+ */
+/**
+ * @brief Initialize SMS AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_sms_init(void);
+
+/**
+ * @brief Uninitialize SMS AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_sms_uninit(void);
+/** @} */
+
+#endif /* SLM_AT_SMS_ */

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -93,6 +93,7 @@ nRF9160
     * Enabled all SLM services by default.
     * Updated the HTTP client service code to handle chunked HTTP responses.
     * Added data mode to the MQTT Publish service to support JSON-type payload.
+    * Added SMS support, to send/receive SMS in plain text.
 
   * :ref:`at_cmd_parser_readme`:
 


### PR DESCRIPTION
Use SMS lib functions to send/receive SMS by plain text.
 AT#XSMS=< op >,[< number >,< message >]
Limitations: support GSM-7 encoding scheme only

JIRA Reference: NCSIDB-433

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>