### PR TITLE
tfm: pull 802.15.4 driver adaptation

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: afc8e063c8ba5950bd43a94155ef538e89524ba8
+      revision: pull/524/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull a fix for the 802.15.4 driver to read EUI64 from the non-secure world.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>