### PR TITLE
applications: pelion_client: Add module for pelion tracing

### DIFF
--- a/applications/pelion_client/src/modules/CMakeLists.txt
+++ b/applications/pelion_client/src/modules/CMakeLists.txt
@@ -30,3 +30,6 @@ target_sources_ifdef(CONFIG_NET_L2_OPENTHREAD
 
 target_sources_ifdef(CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/factory_reset_request.c)
+
+target_sources_ifdef(CONFIG_PELION_DEBUG_TRACE
+		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/pelion_trace.c)

--- a/applications/pelion_client/src/modules/pelion_trace.c
+++ b/applications/pelion_client/src/modules/pelion_trace.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include "mbed-trace/mbed_trace.h"
+#include "mbed-trace-helper.h"
+
+#define MODULE pelion_trace
+#include <caf/events/module_state_event.h>
+
+
+static void init_pelion_trace(void)
+{
+	bool ret;
+	/* Create mutex for tracing to avoid broken lines in logs */
+	ret = mbed_trace_helper_create_mutex();
+	__ASSERT_NO_MSG(ret);
+	(void) mbed_trace_init();
+	/*
+	 * If you want, you can filter out the trace set.
+	 * For example  mbed_trace_include_filters_set("COAP");
+	 * would enable only the COAP level traces.
+	 * Or           mbed_trace_exclude_filters_set("COAP");
+	 * would leave them out.
+	 * More details on mbed_trace.h file.
+	 */
+	mbed_trace_mutex_wait_function_set(mbed_trace_helper_mutex_wait);
+	mbed_trace_mutex_release_function_set(mbed_trace_helper_mutex_release);
+}
+
+
+static bool event_handler(const struct event_header *eh)
+{
+	if (is_module_state_event(eh)) {
+		const struct module_state_event *event = cast_module_state_event(eh);
+
+		if (check_state(event, MODULE_ID(main), MODULE_STATE_READY)) {
+			init_pelion_trace();
+			return false;
+		}
+		return false;
+	}
+
+	/* Event not handled but subscribed. */
+	__ASSERT_NO_MSG(false);
+
+	return false;
+}
+
+EVENT_LISTENER(MODULE, event_handler);
+EVENT_SUBSCRIBE(MODULE, module_state_event);


### PR DESCRIPTION
This commit adds module that simplifies enabling of tracing from the pelion code.
