### PR TITLE
samples: connectedhomeip: fix hangs on sys_rand32_get()

### DIFF
--- a/samples/matter/light_bulb/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/matter/light_bulb/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Generate random numbers using Xoroshiro algorithm instead of direct calls
+# to the cryptocell library to workaround firmware hangs.
+CONFIG_XOROSHIRO_RANDOM_GENERATOR=y

--- a/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Generate random numbers using Xoroshiro algorithm instead of direct calls
+# to the cryptocell library to workaround firmware hangs.
+CONFIG_XOROSHIRO_RANDOM_GENERATOR=y

--- a/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Generate random numbers using Xoroshiro algorithm instead of direct calls
+# to the cryptocell library to workaround firmware hangs.
+CONFIG_XOROSHIRO_RANDOM_GENERATOR=y


### PR DESCRIPTION
There is a known issue in the cryptocell library causing
that an application may hang on a call to sys_rand32_get()
or underlying functions. The issue is supposed to be fixed
in the next cryptocell library version, but for now provide
a workaround using the non-cryptographically secure
Xoroshiro algorithm for random number generation.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>