### PR TITLE
applications: pelion_client: Init before callbacks

### DIFF
--- a/applications/pelion_client/src/modules/pelion.cpp
+++ b/applications/pelion_client/src/modules/pelion.cpp
@@ -140,6 +140,8 @@ static void complete_objects_creation(void)
 
 static int pelion_init(void)
 {
+	cloud_client.init();
+
 	cloud_client.on_error(on_client_error);
 	cloud_client.on_registered(on_client_registered);
 	cloud_client.on_unregistered(on_client_unregistered);
@@ -149,8 +151,6 @@ static int pelion_init(void)
 	cloud_client.set_update_authorize_priority_handler(on_update_authorize_priority);
 	cloud_client.set_update_progress_handler(on_update_progress);
 #endif
-
-	cloud_client.init();
 
 	set_pelion_state(PELION_STATE_INITIALIZED);
 


### PR DESCRIPTION
Initialize before registering callbacks to ensure resource presence.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>