### PR TITLE
samples: Bluetooth: df: Add integration_platforms to sample.yaml

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -6,8 +6,12 @@ tests:
     harness: bluetooth
     platform_allow: nrf52833dk_nrf52833
     tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833
   sample.bluetooth.direction_finding_connectionless.aoa:
     extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
     harness: bluetooth
     platform_allow: nrf52833dk_nrf52833
     tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833


### PR DESCRIPTION
Add integration_plaforms to the direction_finding_connectionless_tx
sample application.

Adding the similar update at it was already added and then reverted due to use of `filter` option in sample.yaml.
To fix that issue `platform_allow` is left unchanged. Now sample will build only for nRF52833 board.

Change request PR: https://github.com/nrfconnect/sdk-nrf/pull/4444
First time added as PR: https://github.com/nrfconnect/sdk-nrf/pull/4477
Revert PR: https://github.com/nrfconnect/sdk-nrf/pull/4590

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>