### PR TITLE
applications: serial_lte_modem: Support nRF52 serial DFU

### DIFF
--- a/applications/serial_lte_modem/CMakeLists.txt
+++ b/applications/serial_lte_modem/CMakeLists.txt
@@ -29,5 +29,6 @@ add_subdirectory_ifdef(CONFIG_SLM_FTPC src/ftp_c)
 add_subdirectory_ifdef(CONFIG_SLM_MQTTC src/mqtt_c)
 add_subdirectory_ifdef(CONFIG_SLM_HTTPC src/http_c)
 add_subdirectory_ifdef(CONFIG_SLM_TWI src/twi)
+add_subdirectory_ifdef(CONFIG_SLM_NRF52_DFU src/nrf52_dfu)
 
 zephyr_include_directories(src)

--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -146,6 +146,7 @@ rsource "src/ftp_c/Kconfig"
 rsource "src/mqtt_c/Kconfig"
 rsource "src/http_c/Kconfig"
 rsource "src/twi/Kconfig"
+rsource "src/nrf52_dfu/Kconfig"
 
 module = SLM
 module-str = serial modem

--- a/applications/serial_lte_modem/src/nrf52_dfu/CMakeLists.txt
+++ b/applications/serial_lte_modem/src/nrf52_dfu/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_include_directories(.)
+if(CONFIG_SLM_NRF52_DFU)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/slm_at_dfu.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/dfu_target_nrf52.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/dfu_host.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/slip.c)
+endif()

--- a/applications/serial_lte_modem/src/nrf52_dfu/Kconfig
+++ b/applications/serial_lte_modem/src/nrf52_dfu/Kconfig
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+config SLM_NRF52_DFU
+	bool "NRF52 DFU support in SLM"
+	select DOWNLOAD_CLIENT
+
+if (SLM_NRF52_DFU)
+
+config SLM_DFU_SOCKET_RETRIES
+	int "Number of retries for socket-related download issues"
+	default 2
+
+config SLM_DFU_INIT_PACKET_SZ
+	int "Size of buffer used for store init packet"
+	default 512
+
+config SLM_DFU_FLASH_BUF_SZ
+	int "Size of buffer used for flash write operations"
+	default 512
+	help
+	  Buffer size must be aligned to the minimal flash write block size
+
+endif # SLM_NRF52_DFU

--- a/applications/serial_lte_modem/src/nrf52_dfu/dfu_host.c
+++ b/applications/serial_lte_modem/src/nrf52_dfu/dfu_host.c
@@ -1,0 +1,593 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <zephyr.h>
+#include <sys/crc.h>
+#include <sys/byteorder.h>
+#include <sys/util.h>
+#include <logging/log.h>
+LOG_MODULE_REGISTER(dfu_req, CONFIG_SLM_LOG_LEVEL);
+
+#include "dfu_host.h"
+#include "slip.h"
+
+#define REQ_DATA_SIZE_MAX		SLIP_SIZE_MAX
+#define RSP_DATA_SIZE_MAX		SLIP_SIZE_MAX
+
+/**
+ * @brief DFU protocol operation.
+ */
+enum nrf_dfu_op {
+	NRF_DFU_OP_PROTOCOL_VERSION  = 0x00,     /* Retrieve protocol version */
+	NRF_DFU_OP_OBJECT_CREATE     = 0x01,     /* Create selected object */
+	NRF_DFU_OP_RECEIPT_NOTIF_SET = 0x02,     /* Set receipt notification */
+	NRF_DFU_OP_CRC_GET           = 0x03,     /* Request CRC of selected object */
+	NRF_DFU_OP_OBJECT_EXECUTE    = 0x04,     /* Execute selected object */
+	NRF_DFU_OP_OBJECT_SELECT     = 0x06,     /* Select object */
+	NRF_DFU_OP_MTU_GET           = 0x07,     /* Retrieve MTU size */
+	NRF_DFU_OP_OBJECT_WRITE      = 0x08,     /* Write selected object */
+	NRF_DFU_OP_PING              = 0x09,     /* Ping */
+	NRF_DFU_OP_HARDWARE_VERSION  = 0x0A,     /* Retrieve hardware version */
+	NRF_DFU_OP_FIRMWARE_VERSION  = 0x0B,     /* Retrieve firmware version */
+	NRF_DFU_OP_ABORT             = 0x0C,     /* Abort the DFU procedure */
+	NRF_DFU_OP_RESPONSE          = 0x60,     /* Response */
+	NRF_DFU_OP_INVALID           = 0xFF
+};
+
+/**
+ * @brief DFU operation result code.
+ */
+enum nrf_dfu_result {
+	/* Invalid opcode */
+	NRF_DFU_RES_CODE_INVALID                 = 0x00,
+	/* Operation successful */
+	NRF_DFU_RES_CODE_SUCCESS                 = 0x01,
+	/* Opcode not supported */
+	NRF_DFU_RES_CODE_OP_CODE_NOT_SUPPORTED   = 0x02,
+	/* Missing/invalid parameter value */
+	NRF_DFU_RES_CODE_INVALID_PARAMETER       = 0x03,
+	/* Not enough memory for the data object */
+	NRF_DFU_RES_CODE_INSUFFICIENT_RESOURCES  = 0x04,
+	/* Data object does not match the firmware and hardware requirements,
+	 * the signature is wrong, or parsing the command failed
+	 */
+	NRF_DFU_RES_CODE_INVALID_OBJECT          = 0x05,
+	/* Not a valid object type for a Create request */
+	NRF_DFU_RES_CODE_UNSUPPORTED_TYPE        = 0x07,
+	/* The state of the DFU process does not allow this operation */
+	NRF_DFU_RES_CODE_OPERATION_NOT_PERMITTED = 0x08,
+	/* Operation failed */
+	NRF_DFU_RES_CODE_OPERATION_FAILED        = 0x0A,
+	/* Extended error. The next byte of the response contains the error
+	 * code of the extended error (see @ref nrf_dfu_ext_error_code_t
+	 */
+	NRF_DFU_RES_CODE_EXT_ERROR               = 0x0B,
+};
+
+/**
+ * @brief @ref NRF_DFU_OP_OBJECT_SELECT response details.
+ */
+struct nrf_dfu_response_select {
+	uint32_t offset;                    /* Current offset */
+	uint32_t crc;                       /* Current CRC */
+	uint32_t max_size;                  /* Maximum size of selected object */
+};
+
+/**
+ * @brief @ref NRF_DFU_OP_CRC_GET response details.
+ */
+struct nrf_dfu_response_crc {
+	uint32_t offset;                    /* Current offset */
+	uint32_t crc;                       /* Current CRC */
+};
+
+static uint8_t  ping_id;
+static uint16_t prn;
+static uint16_t mtu;
+
+static uint8_t send_data[REQ_DATA_SIZE_MAX];
+static uint8_t receive_data[RSP_DATA_SIZE_MAX];
+
+/* global functions defined in different resources */
+int dfu_drv_tx(const uint8_t *data, uint16_t length);
+int dfu_drv_rx(uint8_t *data, uint32_t max_len, uint32_t *real_len);
+
+static int send_raw(const uint8_t *pData, uint32_t nSize)
+{
+	return dfu_drv_tx(pData, nSize);
+}
+
+static int get_rsp(enum nrf_dfu_op oper, uint32_t *data_cnt)
+{
+	int rc;
+
+	LOG_DBG("%s", __func__);
+
+	rc = dfu_drv_rx(receive_data, sizeof(receive_data), data_cnt);
+	if (!rc) {
+		if (*data_cnt >= 3 &&
+		    receive_data[0] == NRF_DFU_OP_RESPONSE &&
+		    receive_data[1] == oper) {
+			if (receive_data[2] != NRF_DFU_RES_CODE_SUCCESS) {
+				uint16_t rsp_error = receive_data[2];
+
+				/* get 2-byte error code, if applicable */
+				if (*data_cnt >= 4) {
+					rsp_error = (rsp_error << 8) + receive_data[3];
+				}
+				LOG_ERR("Bad result code (0x%X)!", rsp_error);
+				rc = 1;
+			}
+		} else {
+			LOG_ERR("Invalid response!");
+			rc = 1;
+		}
+	}
+
+	return rc;
+}
+
+static int req_ping(uint8_t id)
+{
+	int rc;
+	uint8_t send_data[2] = { NRF_DFU_OP_PING };
+
+	LOG_DBG("%s", __func__);
+
+	send_data[1] = id;
+	rc = send_raw(send_data, sizeof(send_data));
+
+	if (!rc) {
+		uint32_t data_cnt;
+
+		rc = get_rsp(NRF_DFU_OP_PING, &data_cnt);
+		if (!rc) {
+			if (data_cnt != 4 || receive_data[3] != id) {
+				LOG_ERR("Bad ping id!");
+				rc = 1;
+			}
+		}
+	}
+
+	return rc;
+}
+
+static int req_set_prn(uint16_t prn)
+{
+	int rc;
+	uint8_t send_data[3] = { NRF_DFU_OP_RECEIPT_NOTIF_SET };
+
+	LOG_DBG("%s", __func__);
+	LOG_INF("Set Packet Receipt Notification %u", prn);
+
+	sys_put_le16(prn, send_data + 1);
+	rc = send_raw(send_data, sizeof(send_data));
+
+	if (!rc) {
+		uint32_t data_cnt;
+
+		rc = get_rsp(NRF_DFU_OP_RECEIPT_NOTIF_SET, &data_cnt);
+	}
+
+	return rc;
+}
+
+static int req_get_mtu(uint16_t *mtu)
+{
+
+	int rc;
+	uint8_t send_data[1] = { NRF_DFU_OP_MTU_GET };
+
+	LOG_DBG("%s", __func__);
+
+	rc = send_raw(send_data, sizeof(send_data));
+	if (!rc) {
+		uint32_t data_cnt;
+
+		rc = get_rsp(NRF_DFU_OP_MTU_GET, &data_cnt);
+		if (!rc) {
+			if (data_cnt == 5) {
+				uint16_t mtu_value = sys_get_le16(receive_data + 3);
+
+				*mtu = mtu_value;
+				LOG_INF("MTU: %d", mtu_value);
+			} else {
+				LOG_ERR("Invalid MTU!");
+				rc = 1;
+			}
+		}
+	}
+
+	return rc;
+}
+
+static int req_obj_select(uint8_t obj_type, struct nrf_dfu_response_select *select_rsp)
+{
+	int rc;
+	uint8_t send_data[2] = { NRF_DFU_OP_OBJECT_SELECT };
+
+	LOG_DBG("%s", __func__);
+	LOG_DBG("Selecting Object: type:%u", obj_type);
+
+	send_data[1] = obj_type;
+	rc = send_raw(send_data, sizeof(send_data));
+
+	if (!rc) {
+		uint32_t data_cnt;
+
+		rc = get_rsp(NRF_DFU_OP_OBJECT_SELECT, &data_cnt);
+		if (!rc) {
+			if (data_cnt == 15) {
+				select_rsp->max_size = sys_get_le32(receive_data + 3);
+				select_rsp->offset   = sys_get_le32(receive_data + 7);
+				select_rsp->crc      = sys_get_le32(receive_data + 11);
+
+				LOG_DBG("Object selected:  max_size:%u offset:%u crc:0x%08X",
+					select_rsp->max_size,
+					select_rsp->offset,
+					select_rsp->crc);
+			} else {
+				LOG_ERR("Invalid object response!");
+				rc = 1;
+			}
+		}
+	}
+
+	return rc;
+}
+
+static int req_obj_create(uint8_t obj_type, uint32_t obj_size)
+{
+	int rc;
+	uint8_t send_data[6] = { NRF_DFU_OP_OBJECT_CREATE };
+
+	LOG_DBG("%s", __func__);
+
+	send_data[1] = obj_type;
+	sys_put_le32(obj_size, send_data + 2);
+	rc = send_raw(send_data, sizeof(send_data));
+
+	if (!rc) {
+		uint32_t data_cnt;
+
+		rc = get_rsp(NRF_DFU_OP_OBJECT_CREATE, &data_cnt);
+	}
+
+	return rc;
+}
+
+static int stream_data(const uint8_t *data, uint32_t data_size)
+{
+	int rc = 0;
+	uint32_t pos, stp;
+	uint32_t stp_max = 5;
+
+	LOG_DBG("%s", __func__);
+
+	if (data == NULL || !data_size) {
+		rc = 1;
+	}
+
+	if (!rc) {
+		if (mtu >= 5) {
+			stp_max = (mtu - 1) / 2 - 1;
+		} else {
+			LOG_ERR("MTU is too small to send data!");
+			rc = 1;
+			return 1;
+		}
+	}
+
+	for (pos = 0; !rc && pos < data_size; pos += stp) {
+		send_data[0] = NRF_DFU_OP_OBJECT_WRITE;
+		stp = MIN((data_size - pos), stp_max);
+		memcpy(send_data + 1, data + pos, stp);
+		rc = send_raw(send_data, stp + 1);
+	}
+
+	return rc;
+}
+
+static int req_get_crc(struct nrf_dfu_response_crc *crc_rsp)
+{
+	int rc;
+	uint8_t send_data[1] = { NRF_DFU_OP_CRC_GET };
+
+	LOG_DBG("%s", __func__);
+
+	rc = send_raw(send_data, sizeof(send_data));
+	if (!rc) {
+		uint32_t data_cnt;
+
+		rc = get_rsp(NRF_DFU_OP_CRC_GET, &data_cnt);
+		if (!rc) {
+			if (data_cnt == 11) {
+				crc_rsp->offset = sys_get_le32(receive_data + 3);
+				crc_rsp->crc    = sys_get_le32(receive_data + 7);
+			} else {
+				LOG_ERR("Invalid CRC response!");
+				rc = 1;
+			}
+		}
+	}
+
+	return rc;
+}
+
+static int req_obj_execute(void)
+{
+	int rc;
+	uint8_t send_data[1] = { NRF_DFU_OP_OBJECT_EXECUTE };
+
+	LOG_DBG("%s", __func__);
+
+	rc = send_raw(send_data, sizeof(send_data));
+	if (!rc) {
+		uint32_t data_cnt;
+
+		rc = get_rsp(NRF_DFU_OP_OBJECT_EXECUTE, &data_cnt);
+	}
+
+	return rc;
+}
+
+static int stream_data_crc(const uint8_t *data, uint32_t data_size,
+			   uint32_t pos, uint32_t *crc)
+{
+	int rc;
+	struct nrf_dfu_response_crc rsp_crc;
+
+	LOG_DBG("%s", __func__);
+	LOG_DBG("Streaming Data: len:%u offset:%u crc:0x%08X", data_size, pos, *crc);
+
+	rc = stream_data(data, data_size);
+
+	if (!rc) {
+		*crc = crc32_ieee_update(*crc, data, data_size);
+		rc = req_get_crc(&rsp_crc);
+	}
+
+	if (!rc) {
+		if (rsp_crc.offset != pos + data_size) {
+			LOG_ERR("Invalid offset (%u -> %u)!", pos + data_size, rsp_crc.offset);
+			rc = 2;
+		}
+		if (rsp_crc.crc != *crc) {
+			LOG_ERR("Invalid CRC (0x%08X -> 0x%08X)!", *crc, rsp_crc.crc);
+			rc = 2;
+		}
+	}
+
+	return rc;
+}
+
+static int try_recover_ip(const uint8_t *data, uint32_t data_size,
+			  struct nrf_dfu_response_select *rsp_recover,
+			  const struct nrf_dfu_response_select *rsp_select)
+{
+	int rc = 0;
+	uint32_t pos_start, len_remain;
+	uint32_t crc_32;
+
+	LOG_DBG("%s", __func__);
+
+	*rsp_recover = *rsp_select;
+	pos_start = rsp_recover->offset;
+
+	if (pos_start > 0 && pos_start <= data_size) {
+		crc_32 = crc32_ieee(data, pos_start);
+		if (rsp_select->crc != crc_32) {
+			pos_start = 0;
+		}
+	} else {
+		pos_start = 0;
+	}
+
+	if (pos_start > 0 && pos_start < data_size) {
+		len_remain = data_size - pos_start;
+		rc = stream_data_crc(data + pos_start, len_remain, pos_start, &crc_32);
+		if (!rc) {
+			pos_start += len_remain;
+		} else if (rc == 2) {
+			/* when there is a CRC error, discard previous init packet */
+			rc = 0;
+			pos_start = 0;
+		}
+	}
+
+	if (!rc && pos_start == data_size) {
+		rc = req_obj_execute();
+	}
+
+	rsp_recover->offset = pos_start;
+
+	return rc;
+}
+
+static int try_recover_fw(const uint8_t *data, uint32_t data_size,
+			  struct nrf_dfu_response_select *rsp_recover,
+			  const struct nrf_dfu_response_select *rsp_select)
+{
+	int rc = 0;
+	uint32_t max_size, stp_size;
+	uint32_t pos_start, len_remain;
+	uint32_t crc_32;
+	int obj_exec = 1;
+
+	LOG_DBG("%s", __func__);
+
+	*rsp_recover = *rsp_select;
+	pos_start = rsp_recover->offset;
+
+	if (pos_start > data_size) {
+		LOG_ERR("Invalid firmware offset reported!");
+		rc = 1;
+	} else if (pos_start > 0) {
+		max_size = rsp_select->max_size;
+		crc_32 = crc32_ieee(data, pos_start);
+		len_remain = pos_start % max_size;
+
+		if (rsp_select->crc != crc_32) {
+			pos_start -= ((len_remain > 0) ? len_remain : max_size);
+			rsp_recover->offset = pos_start;
+
+			return rc;
+		}
+
+		if (len_remain > 0) {
+			stp_size = max_size - len_remain;
+
+			rc = stream_data_crc(data + pos_start, stp_size, pos_start, &crc_32);
+			if (!rc) {
+				pos_start += stp_size;
+			} else if (rc == 2) {
+				rc = 0;
+				pos_start -= len_remain;
+				obj_exec = 0;
+			}
+
+			rsp_recover->offset = pos_start;
+		}
+
+		if (!rc && obj_exec) {
+			rc = req_obj_execute();
+		}
+	}
+
+	return rc;
+}
+
+bool dfu_host_bl_mode_check(void)
+{
+	int rc = 0;
+	int cnt = 3;	/* Try 3 times */
+
+	while (cnt--) {
+		rc = req_ping(ping_id++);
+		if (!rc) {
+			break;
+		}
+	}
+
+	return rc == 0;
+}
+
+int dfu_host_setup(void)
+{
+	int rc;
+
+	ping_id++;
+
+	rc = req_ping(ping_id);
+
+	if (!rc) {
+		rc = req_set_prn(prn);
+	}
+
+	if (!rc) {
+		rc = req_get_mtu(&mtu);
+	}
+
+	return rc;
+}
+
+int dfu_host_send_ip(const uint8_t *data, uint32_t data_size)
+{
+	int rc = 0;
+	uint32_t crc_32 = 0;
+	struct nrf_dfu_response_select rsp_select;
+	struct nrf_dfu_response_select rsp_recover;
+
+	LOG_INF("Sending init packet...");
+
+	if (data == NULL || !data_size) {
+		LOG_ERR("Invalid init packet!");
+		rc = 1;
+	}
+
+	if (!rc) {
+		rc = req_obj_select(0x01, &rsp_select);
+	}
+
+	if (!rc) {
+		rc = try_recover_ip(data, data_size, &rsp_recover, &rsp_select);
+		if (!rc && rsp_recover.offset == data_size) {
+			return rc;
+		}
+	}
+
+	if (!rc) {
+		if (data_size > rsp_select.max_size) {
+			LOG_ERR("Init packet too big!");
+			rc = 1;
+		}
+	}
+
+	if (!rc) {
+		rc = req_obj_create(0x01, data_size);
+	}
+
+	if (!rc) {
+		rc = stream_data_crc(data, data_size, 0, &crc_32);
+	}
+
+	if (!rc) {
+		rc = req_obj_execute();
+	}
+
+	return rc;
+}
+
+int dfu_host_send_fw(const uint8_t *data, uint32_t data_size)
+{
+	int rc = 0;
+	uint32_t max_size, stp_size, pos;
+	uint32_t crc_32 = 0;
+	struct nrf_dfu_response_select rsp_select;
+	struct nrf_dfu_response_select rsp_recover;
+	uint32_t pos_start;
+
+	LOG_INF("Sending firmware file...");
+
+	if (data == NULL || !data_size) {
+		LOG_ERR("Invalid firmware data!");
+		rc = 1;
+	}
+
+	if (!rc) {
+		rc = req_obj_select(0x02, &rsp_select);
+	}
+
+	if (!rc) {
+		rc = try_recover_fw(data, data_size, &rsp_recover, &rsp_select);
+	}
+
+	if (!rc) {
+		max_size = rsp_select.max_size;
+		pos_start = rsp_recover.offset;
+		crc_32 = crc32_ieee_update(crc_32, data, pos_start);
+
+		for (pos = pos_start; pos < data_size; pos += stp_size) {
+			stp_size = MIN((data_size - pos), max_size);
+			rc = req_obj_create(0x02, stp_size);
+			if (!rc) {
+				rc = stream_data_crc(data + pos, stp_size, pos, &crc_32);
+			}
+
+			if (!rc) {
+				rc = req_obj_execute();
+			}
+
+			if (rc) {
+				break;
+			}
+		}
+	}
+
+	return rc;
+}

--- a/applications/serial_lte_modem/src/nrf52_dfu/dfu_host.h
+++ b/applications/serial_lte_modem/src/nrf52_dfu/dfu_host.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#ifndef DFU_HOST_H__
+#define DFU_HOST_H__
+
+#include <zephyr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+/**@brief Set up a DFU procedure */
+int dfu_host_setup(void);
+
+/**@brief Start to send init packet */
+int dfu_host_send_ip(const uint8_t *data, uint32_t data_size);
+
+/**@brief Start to send firmware bin */
+int dfu_host_send_fw(const uint8_t *data, uint32_t data_size);
+
+/**@brief Check if it's in bootloader mode */
+bool dfu_host_bl_mode_check(void);
+
+#ifdef __cplusplus
+}   /* ... extern "C" */
+#endif  /* __cplusplus */
+
+
+#endif /* _INC_DFU_SERIAL */

--- a/applications/serial_lte_modem/src/nrf52_dfu/dfu_target_nrf52.c
+++ b/applications/serial_lte_modem/src/nrf52_dfu/dfu_target_nrf52.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/*
+ * Ensure 'strnlen' is available even with -std=c99. If
+ * _POSIX_C_SOURCE was defined we will get a warning when referencing
+ * 'strnlen'. If this proves to cause trouble we could easily
+ * re-implement strnlen instead, perhaps with a different name, as it
+ * is such a simple function.
+ */
+#if !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200809L
+#endif
+#include <string.h>
+
+#include <zephyr.h>
+#include <pm_config.h>
+#include <logging/log.h>
+#include <nrfx.h>
+#include <dfu/mcuboot.h>
+#include <dfu/dfu_target.h>
+#include <dfu/dfu_target_stream.h>
+
+LOG_MODULE_REGISTER(target_dfu, CONFIG_SLM_LOG_LEVEL);
+
+#define MAX_FILE_SEARCH_LEN 500
+#define MCUBOOT_SECONDARY_LAST_PAGE_ADDR                                       \
+	(PM_MCUBOOT_SECONDARY_ADDRESS + PM_MCUBOOT_SECONDARY_SIZE - 1)
+
+static uint8_t *stream_buf;
+static size_t stream_buf_len;
+
+int dfu_target_nrf52_set_buf(uint8_t *buf, size_t len)
+{
+	if (buf == NULL) {
+		return -EINVAL;
+	}
+
+	stream_buf = buf;
+	stream_buf_len = len;
+
+	return 0;
+}
+
+int dfu_target_nrf52_init(size_t file_size, dfu_target_callback_t cb)
+{
+	ARG_UNUSED(cb);
+	const struct device *flash_dev;
+	int err;
+
+	if (stream_buf == NULL) {
+		LOG_ERR("Missing stream_buf, call '..set_buf' before '..init");
+		return -ENODEV;
+	}
+
+	if (file_size > PM_MCUBOOT_SECONDARY_SIZE) {
+		LOG_ERR("Requested file too big to fit in flash %zu > 0x%x",
+			file_size, PM_MCUBOOT_SECONDARY_SIZE);
+		return -EFBIG;
+	}
+
+	flash_dev = device_get_binding(PM_MCUBOOT_SECONDARY_DEV_NAME);
+	if (flash_dev == NULL) {
+		LOG_ERR("Failed to get device '%s'",
+			PM_MCUBOOT_SECONDARY_DEV_NAME);
+		return -EFAULT;
+	}
+
+	err = dfu_target_stream_init(&(struct dfu_target_stream_init){
+		.id = "NRF52",
+		.fdev = flash_dev,
+		.buf = stream_buf,
+		.len = stream_buf_len,
+		.offset = PM_MCUBOOT_SECONDARY_ADDRESS,
+		.size = PM_MCUBOOT_SECONDARY_SIZE,
+		.cb = NULL });
+	if (err < 0) {
+		LOG_ERR("dfu_target_stream_init failed %d", err);
+		return err;
+	}
+
+	return 0;
+}
+
+int dfu_target_nrf52_offset_get(size_t *out)
+{
+	return dfu_target_stream_offset_get(out);
+}
+
+int dfu_target_nrf52_write(const void *const buf, size_t len)
+{
+	return dfu_target_stream_write(buf, len);
+}
+
+int dfu_target_nrf52_done(bool successful)
+{
+	int err = 0;
+
+	err = dfu_target_stream_done(successful);
+	if (err != 0) {
+		LOG_ERR("dfu_target_stream_done error %d", err);
+		return err;
+	}
+
+	if (successful) {
+		err = stream_flash_erase_page(dfu_target_stream_get_stream(),
+					      MCUBOOT_SECONDARY_LAST_PAGE_ADDR);
+		if (err != 0) {
+			LOG_ERR("Unable to delete last page: %d", err);
+			return err;
+		}
+
+		LOG_INF("DFU image upgrade scheduled");
+	} else {
+		LOG_ERR("DFU image upgrade aborted.");
+	}
+
+	return err;
+}

--- a/applications/serial_lte_modem/src/nrf52_dfu/dfu_target_nrf52.h
+++ b/applications/serial_lte_modem/src/nrf52_dfu/dfu_target_nrf52.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file dfu_target_nrf52.h
+ *
+ * @defgroup dfu_target_nrf52 NRF52 DFU Target
+ * @{
+ * @brief DFU Target for upgrades performed by NRF52 Serial DFU
+ */
+
+#ifndef DFU_TARGET_NRF52_H__
+#define DFU_TARGET_NRF52_H__
+
+#include <stddef.h>
+#include <dfu/dfu_target.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Set buffer to use for flash write operations.
+ *
+ * @retval Non-negative value if successful, negative errno otherwise.
+ */
+int dfu_target_nrf52_set_buf(uint8_t *buf, size_t len);
+
+/**
+ * @brief Initialize dfu target, perform steps necessary to receive firmware.
+ *
+ * @param[in] file_size Size of the current file being downloaded.
+ *
+ * @retval 0 If successful, negative errno otherwise.
+ */
+int dfu_target_nrf52_init(size_t file_size);
+
+/**
+ * @brief Get offset of firmware
+ *
+ * @param[out] offset Returns the offset of the firmware upgrade.
+ *
+ * @return 0 if success, otherwise negative value if unable to get the offset
+ */
+int dfu_target_nrf52_offset_get(size_t *offset);
+
+/**
+ * @brief Write firmware data.
+ *
+ * @param[in] buf Pointer to data that should be written.
+ * @param[in] len Length of data to write.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int dfu_target_nrf52_write(const void *const buf, size_t len);
+
+/**
+ * @brief Deinitialize resources and finalize firmware upgrade if successful.
+
+ * @param[in] successful Indicate whether the firmware was successfully recived.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int dfu_target_nrf52_done(bool successful);
+
+#endif /* DFU_TARGET_NRF52_H__ */
+
+/**@} */

--- a/applications/serial_lte_modem/src/nrf52_dfu/slip.c
+++ b/applications/serial_lte_modem/src/nrf52_dfu/slip.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <stdbool.h>
+#include "slip.h"
+
+void encode_slip(uint8_t *dest_data, uint32_t *dest_size,
+		 const uint8_t *src_data, uint32_t src_size)
+{
+	uint32_t n, n_dest_size;
+
+	n_dest_size = 0;
+	for (n = 0; n < src_size; n++) {
+		uint8_t n_src_byte = *(src_data + n);
+
+		if (n_src_byte == SLIP_END) {
+			*dest_data++ = SLIP_ESC;
+			*dest_data++ = SLIP_ESC_END;
+			n_dest_size += 2;
+		} else if (n_src_byte == SLIP_ESC) {
+			*dest_data++ = SLIP_ESC;
+			*dest_data++ = SLIP_ESC_ESC;
+			n_dest_size += 2;
+		} else {
+			*dest_data++ = n_src_byte;
+			n_dest_size++;
+		}
+	}
+
+	*dest_data = SLIP_END;
+	n_dest_size++;
+
+	*dest_size = n_dest_size;
+}
+
+int decode_slip(uint8_t *dest_data, uint32_t *dest_size,
+		const uint8_t *src_data, uint32_t src_size)
+{
+	int err_code = 1;
+	uint32_t n, n_dest_size = 0;
+	bool is_escaped = false;
+
+	for (n = 0; n < src_size; n++) {
+		uint8_t n_src_byte = *(src_data + n);
+
+		if (n_src_byte == SLIP_END) {
+			if (!is_escaped) {
+				err_code = 0;  /* Done. OK */
+			}
+			break;
+		} else if (n_src_byte == SLIP_ESC) {
+			if (is_escaped) {
+				/* should not get SLIP_ESC twice */
+				err_code = 1;
+				break;
+			}
+			is_escaped = true;
+		} else if (n_src_byte == SLIP_ESC_END) {
+			if (is_escaped) {
+				is_escaped = false;
+				*dest_data++ = SLIP_END;
+			} else {
+				*dest_data++ = n_src_byte;
+			}
+			n_dest_size++;
+		} else if (n_src_byte == SLIP_ESC_ESC) {
+			if (is_escaped) {
+				is_escaped = false;
+				*dest_data++ = SLIP_ESC;
+			} else {
+				*dest_data++ = n_src_byte;
+			}
+			n_dest_size++;
+		} else {
+			*dest_data++ = n_src_byte;
+			n_dest_size++;
+		}
+	}
+
+	*dest_size = n_dest_size;
+
+	return err_code;
+}

--- a/applications/serial_lte_modem/src/nrf52_dfu/slip.h
+++ b/applications/serial_lte_modem/src/nrf52_dfu/slip.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#ifndef SLIP_H__
+#define SLIP_H__
+
+#include <zephyr.h>
+
+#define SLIP_SIZE_MAX 128
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+#define	SLIP_END	0300
+#define	SLIP_ESC	0333
+#define	SLIP_ESC_END	0334
+#define	SLIP_ESC_ESC	0335
+
+void encode_slip(uint8_t *dest_data, uint32_t *dest_size,
+		 const uint8_t *src_data, uint32_t src_size);
+
+int  decode_slip(uint8_t *dest_data, uint32_t *dest_size,
+		 const uint8_t *src_data, uint32_t src_size);
+
+#ifdef __cplusplus
+}   /* ... extern "C" */
+#endif  /* __cplusplus */
+
+
+#endif /* SLIP_H__ */

--- a/applications/serial_lte_modem/src/nrf52_dfu/slm_at_dfu.c
+++ b/applications/serial_lte_modem/src/nrf52_dfu/slm_at_dfu.c
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <logging/log.h>
+#include <zephyr.h>
+#include <stdio.h>
+#include <pm_config.h>
+#include <dfu/mcuboot.h>
+#include <net/socket.h>
+#include <net/tls_credentials.h>
+#include <net/http_parser_url.h>
+#include <net/download_client.h>
+#include <nrf_socket.h>
+#include "slm_at_host.h"
+#include "slm_at_dfu.h"
+#include "dfu_target_nrf52.h"
+#include "dfu_host.h"
+#include "slm_util.h"
+
+LOG_MODULE_REGISTER(dfu, CONFIG_SLM_LOG_LEVEL);
+
+/* file_uri: scheme://hostname[:port]path */
+#define FILE_URI_MAX	256
+#define SCHEMA_HTTP	"http"
+#define SCHEMA_HTTPS	"https"
+#define URI_HOST_MAX	64
+#define URI_PATH_MAX	128
+#define APN_MAX		32
+
+#define FILE_BUF_LEN (CONFIG_DOWNLOAD_CLIENT_MAX_FILENAME_SIZE)
+
+static enum slm_dfu_operation {
+	DFU_INIT_PACKET_DOWNLOAD,
+	DFU_FILE_IMAGE_DOWNLOAD,
+	DFU_MODE_CHECK,
+	DFU_INITIALIZE,
+	DFU_INIT_PACKET_TRANSFER,
+	DFU_FILE_IMAGE_TRANSFER
+} dfu_operation;
+
+static K_SEM_DEFINE(sem_init_packet, 0, 1);
+static K_SEM_DEFINE(sem_file_image, 0, 1);
+
+static struct k_work_delayable dfu_work;
+static uint8_t dfu_buf[CONFIG_SLM_DFU_FLASH_BUF_SZ];
+static uint8_t init_packet[CONFIG_SLM_DFU_INIT_PACKET_SZ];
+static uint16_t init_packet_size;
+static uint32_t file_image_size;
+
+static char hostname[URI_HOST_MAX];
+static char filepath[URI_PATH_MAX];
+static struct download_client dlc;
+static int socket_retries_left;
+static bool first_fragment;
+
+/* global functions defined in different resources */
+void rsp_send(const uint8_t *str, size_t len);
+void enter_dfumode(void);
+void exit_dfumode(void);
+int poweroff_uart(void);
+int poweron_uart(void);
+
+/* global variable defined in different resources */
+extern struct at_param_list at_param_list;
+extern char rsp_buf[CONFIG_SLM_SOCKET_RX_MAX * 2];
+extern struct k_work_q slm_work_q;
+
+static void dfu_wk(struct k_work *work)
+{
+	int ret = 0;
+	uint32_t file_image = PM_MCUBOOT_SECONDARY_ADDRESS;
+
+	ARG_UNUSED(work);
+
+	enter_dfumode();
+	rsp_buf[0] = '\0';
+
+	dfu_operation = DFU_MODE_CHECK;
+	if (!dfu_host_bl_mode_check()) {
+		ret = -ENOEXEC;
+		LOG_ERR("bootloader mode check fails");
+		sprintf(rsp_buf, "\r\n#XDFU: %d,-1\r\n", dfu_operation);
+		goto done;
+	}
+
+	dfu_operation = DFU_INITIALIZE;
+	ret = dfu_host_setup();
+	if (ret) {
+		LOG_ERR("#XDFU: DFU initialize fails");
+		sprintf(rsp_buf, "\r\n#XDFU: %d,-1\r\n", dfu_operation);
+		goto done;
+	}
+
+	dfu_operation = DFU_INIT_PACKET_TRANSFER;
+	ret = dfu_host_send_ip(init_packet, init_packet_size);
+	if (ret) {
+		LOG_ERR("DFU transfer init packet fails: %d\r\n", ret);
+		sprintf(rsp_buf, "\r\n#XDFU: %d,%d\r\n", dfu_operation, ret);
+		goto done;
+	}
+
+	dfu_operation = DFU_FILE_IMAGE_TRANSFER;
+	ret = dfu_host_send_fw((const uint8_t *)file_image, file_image_size);
+	if (ret) {
+		LOG_ERR("\r\n#XDFU: DFU transfer file image fails: %d\r\n", ret);
+		sprintf(rsp_buf, "\r\n#XDFU: %d,%d\r\n", dfu_operation, ret);
+		goto done;
+	}
+
+	LOG_INF("DFU done successfully");
+
+done:
+	exit_dfumode();
+	if (ret) {
+		rsp_send(rsp_buf, strlen(rsp_buf));
+	}
+}
+
+static int download_client_callback(const struct download_client_evt *event)
+{
+	static size_t download_size;
+	int err;
+
+	if (event == NULL) {
+		return -EINVAL;
+	}
+
+	switch (event->id) {
+	case DOWNLOAD_CLIENT_EVT_FRAGMENT: {
+		LOG_DBG("EVT_FRAGMENT");
+		if (first_fragment) {
+			err = download_client_file_size_get(&dlc, &file_image_size);
+			if (err != 0) {
+				LOG_ERR("download_client_file_size_get err: %d", err);
+				return err;
+			}
+			/* Init Packet is small and should be received in first fragment */
+			if (dfu_operation == DFU_INIT_PACKET_DOWNLOAD) {
+				init_packet_size = event->fragment.len;
+				memcpy(init_packet, event->fragment.buf, init_packet_size);
+				first_fragment = true;
+				return 0;
+			}
+			/* File image download */
+			err = dfu_target_nrf52_init(file_image_size);
+			if ((err < 0) && (err != -EBUSY)) {
+				LOG_ERR("dfu_target_init error %d", err);
+				(void)download_client_disconnect(&dlc);
+				first_fragment = true;
+				return err;
+			}
+			first_fragment = false;
+			download_size = event->fragment.len;
+		} else {
+			download_size += event->fragment.len;
+		}
+
+		err = dfu_target_nrf52_write(event->fragment.buf, event->fragment.len);
+		if (err != 0) {
+			LOG_ERR("dfu_target_write error %d", err);
+			int res = dfu_target_nrf52_done(false);
+
+			if (res != 0) {
+				LOG_ERR("Unable to free DFU target resources");
+			}
+			first_fragment = true;
+			(void)download_client_disconnect(&dlc);
+			return err;
+		}
+
+		break;
+	}
+
+	case DOWNLOAD_CLIENT_EVT_DONE:
+		LOG_DBG("EVT_DONE");
+		if (dfu_operation == DFU_FILE_IMAGE_DOWNLOAD) {
+			err = dfu_target_nrf52_done(true);
+			if (err != 0) {
+				LOG_ERR("dfu_target_done error: %d", err);
+				return err;
+			}
+		}
+
+		err = download_client_disconnect(&dlc);
+		if (err != 0) {
+			LOG_ERR("download_client_disconnect error: %d", err);
+			return err;
+		}
+		first_fragment = true;
+		if (dfu_operation == DFU_INIT_PACKET_DOWNLOAD) {
+			LOG_INF("Init Packet downloaded");
+			k_sem_give(&sem_init_packet);
+		} else {
+			LOG_INF("File Image downloaded");
+			k_sem_give(&sem_file_image);
+		}
+		break;
+
+	case DOWNLOAD_CLIENT_EVT_ERROR:
+		LOG_INF("EVT_ERROR");
+		/* In case of socket errors we can return 0 to retry/continue,
+		 * or non-zero to stop
+		 */
+		if ((socket_retries_left) && ((event->error == -ENOTCONN) ||
+					      (event->error == -ECONNRESET))) {
+			LOG_WRN("Download socket error. %d retries left...", socket_retries_left);
+			socket_retries_left--;
+			/* Fall through and return 0 below to tell download_client to retry */
+		} else {
+			download_client_disconnect(&dlc);
+			LOG_ERR("Download client error");
+			if (dfu_operation == DFU_FILE_IMAGE_DOWNLOAD) {
+				err = dfu_target_nrf52_done(false);
+				if (err == -EACCES) {
+					LOG_DBG("No DFU target was initialized");
+				} else if (err != 0) {
+					LOG_ERR("Unable to deinitialze resources");
+				}
+			}
+			first_fragment = true;
+			/* Return non-zero to tell download_client to stop */
+			return event->error;
+		}
+
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static int dfu_download_init(void)
+{
+	int err;
+
+	err = download_client_init(&dlc, download_client_callback);
+	if (err != 0) {
+		LOG_ERR("download_client_init error: %d", err);
+		return err;
+	}
+
+	first_fragment = true;
+	return 0;
+}
+
+static  int dfu_download_start(const char *host, const char *file, int sec_tag,
+			const char *apn, size_t fragment_size)
+{
+	/* We need a static file buffer since the download client structure
+	 * only keeps a pointer to the file buffer. This is problematic when
+	 * a download needs to be restarted for some reason (e.g. if
+	 * continuing a download operation from an offset).
+	 */
+	static char file_buf[FILE_BUF_LEN];
+	const char *file_buf_ptr = file_buf;
+	int err = -1;
+
+	struct download_client_cfg config = {
+		.sec_tag = sec_tag,
+		.apn = apn,
+		.frag_size_override = fragment_size,
+		.set_tls_hostname = (sec_tag != -1),
+	};
+
+	if (host == NULL || file == NULL) {
+		return -EINVAL;
+	}
+
+	socket_retries_left = CONFIG_SLM_DFU_SOCKET_RETRIES;
+	strncpy(file_buf, file, sizeof(file_buf));
+	err = download_client_connect(&dlc, host, &config);
+	if (err != 0) {
+		return err;
+	}
+
+	err = download_client_start(&dlc, file_buf_ptr, 0);
+	if (err != 0) {
+		download_client_disconnect(&dlc);
+		return err;
+	}
+
+	return 0;
+}
+
+static int do_dfu_download(const char *host, const char *path, int sec_tag, const char *apn)
+{
+	int ret;
+	struct http_parser_url parser = {
+		/* UNINIT checker fix, assumed UF_SCHEMA existence */
+		.field_set = 0
+	};
+	char schema[8];
+
+	http_parser_url_init(&parser);
+	ret = http_parser_parse_url(host, strlen(host), 0, &parser);
+	if (ret) {
+		LOG_ERR("Parse URL error");
+		return -EINVAL;
+	}
+	memset(schema, 0x00, 8);
+	if (parser.field_set & (1 << UF_SCHEMA)) {
+		strncpy(schema, host + parser.field_data[UF_SCHEMA].off,
+			parser.field_data[UF_SCHEMA].len);
+	} else {
+		LOG_ERR("Parse schema error");
+		return -EINVAL;
+	}
+	memset(filepath, 0x00, URI_PATH_MAX);
+	strcpy(filepath, path);
+	memset(hostname, 0x00, URI_HOST_MAX);
+	strcpy(hostname, host);
+
+	/* start HTTP(S) FOTA */
+	if (slm_util_cmd_casecmp(schema, SCHEMA_HTTPS)) {
+		if (sec_tag == INVALID_SEC_TAG) {
+			LOG_ERR("Missing sec_tag");
+			return -EINVAL;
+		}
+		ret = dfu_download_start(hostname, filepath, sec_tag, apn, 0);
+	} else if (slm_util_cmd_casecmp(schema, SCHEMA_HTTP)) {
+		ret = dfu_download_start(hostname, filepath, -1, apn, 0);
+	} else {
+		ret = -EINVAL;
+	}
+	if (ret) {
+		LOG_ERR("Failed to start download: %d", ret);
+	}
+
+	return ret;
+}
+
+/**@brief handle AT#XDFUDOWNLOAD commands
+ *  AT#XDFUDOWNLOAD=<host>,<init_packet>,<file_image>[,<sec_tag>[,<apn>]]
+ *  AT#XDFUDOWNLOAD? READ command not supported
+ *  AT#XDFUDOWNLOAD=?
+ */
+int handle_at_dfu_download(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	char host[URI_HOST_MAX];
+	char ip_file[FILE_URI_MAX];
+	char fw_file[FILE_URI_MAX];
+	char apn_str[APN_MAX];
+	char *apn_ptr = NULL;
+	int size;
+	sec_tag_t sec_tag = INVALID_SEC_TAG;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		size = URI_HOST_MAX;
+		err = util_string_get(&at_param_list, 1, host, &size);
+		if (err) {
+			return err;
+		}
+		size = FILE_URI_MAX;
+		err = util_string_get(&at_param_list, 2, ip_file, &size);
+		if (err) {
+			return err;
+		}
+		size = FILE_URI_MAX;
+		err = util_string_get(&at_param_list, 3, fw_file, &size);
+		if (err) {
+			return err;
+		}
+		if (at_params_valid_count_get(&at_param_list) > 4) {
+			at_params_unsigned_int_get(&at_param_list, 4, &sec_tag);
+		}
+		if (at_params_valid_count_get(&at_param_list) > 5) {
+			size = APN_MAX;
+			err = util_string_get(&at_param_list, 5, apn_str, &size);
+			if (err) {
+				return err;
+			}
+			apn_ptr = apn_str;
+		}
+
+		/* Download DFU files */
+		dfu_operation = DFU_INIT_PACKET_DOWNLOAD;
+		err = do_dfu_download(host, ip_file, sec_tag, apn_ptr);
+		if (err) {
+			sprintf(rsp_buf, "\r\n#XDFU: %d,%d\r\n", dfu_operation, err);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+			return err;
+		}
+		k_sem_take(&sem_init_packet, K_FOREVER);
+
+		dfu_operation = DFU_FILE_IMAGE_DOWNLOAD;
+		err = do_dfu_download(host, fw_file, sec_tag, apn_ptr);
+		if (err) {
+			sprintf(rsp_buf, "\r\n#XDFU: %d,%d\r\n", dfu_operation, err);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+			return err;
+		}
+		k_sem_take(&sem_file_image, K_FOREVER);
+		break;
+
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf,
+			"\r\n#XDFUDOWNLOAD=<host>,<init_packet>,<file_image>,<sec_tag>,<apn>\r\n");
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief handle AT#XDFUSTART commands
+ *  AT#XDFUSTART=<delay>
+ *  AT#XDFUSTART? READ command not supported
+ *  AT#XDFUSTART=?
+ */
+int handle_at_dfu_start(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	uint16_t delay = 0;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		err = at_params_unsigned_short_get(&at_param_list, 1, &delay);
+		if (err < 0) {
+			return err;
+		}
+		if (delay > 0) {
+			k_work_schedule(&dfu_work, K_SECONDS(delay));
+		} else {
+			k_work_schedule(&dfu_work, K_NO_WAIT);
+		}
+		break;
+
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf, "\r\n#XDFUSTART=<delay>");
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+int slm_at_dfu_init(void)
+{
+	k_work_init_delayable(&dfu_work, dfu_wk);
+	(void)dfu_target_nrf52_set_buf(dfu_buf, sizeof(dfu_buf));
+	(void)dfu_download_init();
+
+	return 0;
+}
+
+int slm_at_dfu_uninit(void)
+{
+	return 0;
+}

--- a/applications/serial_lte_modem/src/nrf52_dfu/slm_at_dfu.h
+++ b/applications/serial_lte_modem/src/nrf52_dfu/slm_at_dfu.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef SLM_AT_DFU_
+#define SLM_AT_DFU_
+
+/**@file slm_at_dfu.h
+ *
+ * @brief Vendor-specific AT command for nRF52 DFU service.
+ * @{
+ */
+/**
+ * @brief Initialize DFU AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_dfu_init(void);
+
+/**
+ * @brief Uninitialize DFU AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_dfu_uninit(void);
+
+/** @} */
+
+#endif /* SLM_AT_DFU_ */

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -41,6 +41,9 @@
 #if defined(CONFIG_SLM_TWI)
 #include "slm_at_twi.h"
 #endif
+#if defined(CONFIG_SLM_NRF52_DFU)
+#include "slm_at_dfu.h"
+#endif
 
 LOG_MODULE_REGISTER(slm_at, CONFIG_SLM_LOG_LEVEL);
 
@@ -359,6 +362,11 @@ int handle_at_twi_read(enum at_cmd_type cmd_type);
 int handle_at_twi_write_read(enum at_cmd_type cmd_type);
 #endif
 
+#if defined(CONFIG_SLM_NRF52_DFU)
+int handle_at_dfu_download(enum at_cmd_type cmd_type);
+int handle_at_dfu_start(enum at_cmd_type cmd_type);
+#endif
+
 static struct slm_at_cmd {
 	char *string;
 	slm_at_handler_t handler;
@@ -433,6 +441,11 @@ static struct slm_at_cmd {
 	{"AT#XTWIW", handle_at_twi_write},
 	{"AT#XTWIR", handle_at_twi_read},
 	{"AT#XTWIWR", handle_at_twi_write_read},
+#endif
+
+#if defined(CONFIG_SLM_NRF52_DFU)
+	{"AT#XDFUDOWNLOAD", handle_at_dfu_download},
+	{"AT#XDFUSTART", handle_at_dfu_start},
 #endif
 };
 
@@ -548,6 +561,13 @@ int slm_at_init(void)
 		return -EFAULT;
 	}
 #endif
+#if defined(CONFIG_SLM_NRF52_DFU)
+	err = slm_at_dfu_init();
+	if (err) {
+		LOG_ERR("DFU could not be initialized: %d", err);
+		return -EFAULT;
+	}
+#endif
 
 	return err;
 }
@@ -610,6 +630,12 @@ void slm_at_uninit(void)
 	err = slm_at_twi_uninit();
 	if (err) {
 		LOG_ERR("TWI could not be uninit: %d", err);
+	}
+#endif
+#if defined(CONFIG_SLM_NRF52_DFU)
+	err = slm_at_dfu_uninit();
+	if (err) {
+		LOG_ERR("DFU could not be uninitialized: %d", err);
 	}
 #endif
 }


### PR DESCRIPTION
SLM act as Serial DFU Controller by two new AT commands:
AT#XDFUDOWNLOAD=< host >,< init_packet >,< file_image >[,< sec_tag >[,< apn >]]
AT#XDFUSTART=< delay >
SLM enters DFU mode after second AT command, and return to AT command
mode after serial DFU protocol is completed.
Requires to use UART_2 in SLM and disable its hardware flow control.
A sample client in nRF5 SDK17.0.2 is available in the JIRA ticket.

JIRA Reference: NCSIDB-460

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>