### PR TITLE
applications: pelion_client: Add connection status callback

### DIFF
--- a/applications/pelion_client/src/modules/Kconfig.pelion
+++ b/applications/pelion_client/src/modules/Kconfig.pelion
@@ -14,6 +14,23 @@ config PELION_CLIENT_PAUSE_ON_DISCONNECT
 	  it will be resumed. Note that to avoid TLS handshake on resume
 	  mbedtls must support SSL context serialization.
 
+config PELION_CLIENT_USE_APPLICATION_NETWORK_CALLBACK
+	bool "Register network callback by the application"
+	default y
+	select PELION_PAL_USE_APPLICATION_NETWORK_CALLBACK
+	help
+	  When this option is enabled, the application must provide definition
+	  of the setter function for registering network status callback.
+	  Application shall use the callback function to notify Pelion client
+	  about changes in network connectivity, allowing the client to stay
+	  dormant during network loss.
+
+	  Signature for setter C function:
+	  #include "pal.h"
+	  palStatus_t pal_plat_setConnectionStatusCallback(uint32_t interfaceIndex,
+							   connectionStatusCallback callback,
+							   void *client_arg)
+
 module = PELION_CLIENT_PELION
 module-str = Pelion module
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/pelion_client/src/modules/pelion.cpp
+++ b/applications/pelion_client/src/modules/pelion.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr.h>
+#include <pal.h>
 
 #include "mbed-cloud-client/MbedCloudClient.h"
 
@@ -26,6 +27,20 @@ static bool objects_created;
 
 static enum pelion_state pelion_state;
 
+static connectionStatusCallback net_status_cb;
+static void *net_cb_arg;
+
+#if defined(CONFIG_PELION_CLIENT_USE_APPLICATION_NETWORK_CALLBACK)
+extern "C" palStatus_t pal_plat_setConnectionStatusCallback(uint32_t interfaceIndex,
+							    connectionStatusCallback callback,
+							    void *arg)
+{
+	net_status_cb = callback;
+	net_cb_arg = arg;
+
+	return PAL_SUCCESS;
+}
+#endif /* CONFIG_PELION_CLIENT_USE_APPLICATION_NETWORK_CALLBACK */
 
 static void set_pelion_state(enum pelion_state state)
 {
@@ -162,6 +177,12 @@ static int pelion_init(void)
 static bool handle_net_state_event(const struct net_state_event *event)
 {
 	net_connected = (event->state == NET_STATE_CONNECTED);
+
+	if (IS_ENABLED(CONFIG_PELION_CLIENT_USE_APPLICATION_NETWORK_CALLBACK)
+	    && net_status_cb) {
+		net_status_cb(net_connected ? PAL_NETWORK_STATUS_CONNECTED :
+			      PAL_NETWORK_STATUS_DISCONNECTED, net_cb_arg);
+	}
 
 	switch (pelion_state) {
 	case PELION_STATE_INITIALIZED:


### PR DESCRIPTION
This change make use of PELION_PAL_USE_APPLICATION_NETWORK_CALLBACK.
Callback is registered for the application and cloud client
is notified about network state change.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>
