### PR TITLE
manifest: nrf_modem v1.2.0

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -375,7 +375,7 @@ static int z_to_nrf_family(sa_family_t z_family)
 	case AF_PACKET:
 		return NRF_AF_PACKET;
 	case AF_UNSPEC:
-	/* No NRF_AF_UNSPEC defined. */
+		return NRF_AF_UNSPEC;
 	default:
 		return -EAFNOSUPPORT;
 	}
@@ -394,6 +394,8 @@ static int nrf_to_z_family(nrf_socket_family_t nrf_family)
 		return AF_LOCAL;
 	case NRF_AF_PACKET:
 		return AF_PACKET;
+	case NRF_AF_UNSPEC:
+		return AF_UNSPEC;
 	default:
 		return -EAFNOSUPPORT;
 	}

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -218,6 +218,9 @@ static int z_to_nrf_optname(int z_in_level, int z_in_optname,
 		case SO_IPV6_ECHO_REPLY:
 			*nrf_out_optname = NRF_SO_SILENCE_IPV6_ECHO_REPLY;
 			break;
+		case SO_TCP_SRV_SESSTIMEO:
+			*nrf_out_optname = NRF_SO_TCP_SRV_SESSTIMEO;
+			break;
 		case SO_RAI_LAST:
 			*nrf_out_optname = NRF_SO_RAI_LAST;
 			break;

--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 949333c181d41fff33c8a0e9081fb708e13ebf24
+      revision: e47d05deb577d45c3c2ea9d53958073f4246123c
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
This version deprecates the GNSS socket and adds a new GNSS interface.
See the changelog in nrfxlib for a complete list of changes.