### PR TITLE
Bluetooth: Mesh: Use instant transition time for the Light LC regulator

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -561,9 +561,9 @@ static void reg_step(struct k_work *work)
 
 		srv->reg.prev = output;
 		atomic_set_bit(&srv->flags, FLAG_REGULATOR);
-		light_set(srv, light_to_repr(output, LINEAR), REG_INT);
+		light_set(srv, light_to_repr(output, LINEAR), 0);
 	} else if (atomic_test_and_clear_bit(&srv->flags, FLAG_REGULATOR)) {
-		light_set(srv, light_to_repr(lvl, LINEAR), REG_INT);
+		light_set(srv, light_to_repr(lvl, LINEAR), 0);
 	}
 }
 #endif


### PR DESCRIPTION
When running the regulator, the light control server would attempt to
guess the interval until the next regulator step would be able to
execute, and use this as the transition time for the lightness
adjustments. This is not accurate, and generally introduces a lot of
overhead for applications that run their transitions using CPU timers.

Replace this behavior with instant transition time to relieve the
application of this overhead, as it's not accurate anyway.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>