### PR TITLE
doc: treewide: Convert all references to the old k_work API in docs

### DIFF
--- a/applications/nrf_desktop/doc/battery_charger.rst
+++ b/applications/nrf_desktop/doc/battery_charger.rst
@@ -51,7 +51,7 @@ The module enables charging when USB is powered or active.
     Make sure that the hardware configuration enables charging by default (for example, when the pin to enable charging is not configured).
     Otherwise it will be impossible to enable charging when the battery is empty.
 
-The module checks the battery state using :c:struct:`k_delayed_work`.
+The module checks the battery state using :c:struct:`k_work_delayable`.
 The check is based on the edge interrupt count on the CSO pin in a period of time defined in ``ERROR_CHECK_TIMEOUT_MS``, and on the CSO pin state while the work is processed.
 
 On a battery state change, the new state is sent using ``battery_state_event``.

--- a/applications/nrf_desktop/doc/battery_meas.rst
+++ b/applications/nrf_desktop/doc/battery_meas.rst
@@ -57,7 +57,7 @@ Because Zephyr's :ref:`zephyr:gpio_api` driver is used to control this pin, also
 Implementation details
 **********************
 
-:c:struct:`k_delayed_work` starts the asynchronous voltage measurement and resubmits itself.
+:c:struct:`k_work_delayable` starts the asynchronous voltage measurement and resubmits itself.
 When it is processed the next time, it reads the measured voltage.
 This read sequence is repeated periodically.
 When the system goes to the low-power state, the work is canceled.

--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -40,7 +40,7 @@ Enabling this option increases the power consumption - the connection latency is
 Implementation details
 **********************
 
-The |ble_latency| uses delayed works (:c:struct:`k_delayed_work`) to control the connection latency and trigger the security timeout.
+The |ble_latency| uses delayed works (:c:struct:`k_work_delayable`) to control the connection latency and trigger the security timeout.
 
 .. note::
    The module does not request an increase in the connection latency until the connection is secured.

--- a/applications/nrf_desktop/doc/buttons_sim.rst
+++ b/applications/nrf_desktop/doc/buttons_sim.rst
@@ -40,7 +40,7 @@ By default, the sequence is generated only once.
 Implementation details
 **********************
 
-The |button_sim| generates button sequence using :c:struct:`k_delayed_work`, which resubmits itself.
+The |button_sim| generates button sequence using :c:struct:`k_work_delayable`, which resubmits itself.
 The work handler submits the press and the release of a single button from the sequence.
 
 Receiving ``button_event`` with the key ID set to :option:`CONFIG_DESKTOP_BUTTONS_SIM_TRIGGER_KEY_ID` either stops generating the sequence (in case it is already being generated) or starts generating it.

--- a/applications/nrf_desktop/doc/dfu.rst
+++ b/applications/nrf_desktop/doc/dfu.rst
@@ -160,7 +160,7 @@ The image data that is received from the host is initially buffered in RAM.
 Writing the data to flash is triggered when the host performs the fetch operation on the ``sync`` option.
 At that point, the :ref:`nrf_desktop_config_channel_script` waits until the data is written to flash before providing more image data chunks.
 
-The data is stored in a secondary image flash partition using a dedicated work (:c:struct:`k_delayed_work`).
+The data is stored in a secondary image flash partition using a dedicated work (:c:struct:`k_work_delayable`).
 The work stores a single chunk of data and resubmits itself.
 
 To ensure that the flash write will not interfere with the device usability, the stored data is split into small chunks and written only if there are no HID reports transmitted and the Bluetooth connection state does not change.

--- a/applications/nrf_desktop/doc/selector.rst
+++ b/applications/nrf_desktop/doc/selector.rst
@@ -51,6 +51,6 @@ When the application goes to sleep, selectors are not informing about the state 
 
 If a selector is placed between states, it is in unknown state and ``selector_event`` is not sent.
 
-Recording of selector state changes is implemented using GPIO callbacks (:c:struct:`gpio_callback`) and work (:c:struct:`k_delayed_work`).
+Recording of selector state changes is implemented using GPIO callbacks (:c:struct:`gpio_callback`) and work (:c:struct:`k_work_delayable`).
 Each state change triggers an interrupt (GPIO interrupt for pin level high).
 Callback of an interrupt submits work, which sends ``selector_event``.

--- a/applications/nrf_desktop/doc/watchdog.rst
+++ b/applications/nrf_desktop/doc/watchdog.rst
@@ -41,6 +41,6 @@ Implementation details
 **********************
 
 The watchdog timer is started when the :ref:`nrf_desktop_main` is ready (which is reported using ``module_state_event``).
-The module periodically resets the watchdog timer using :c:struct:`k_delayed_work`.
+The module periodically resets the watchdog timer using :c:struct:`k_work_delayable`.
 The work resubmits itself with delay equal to ``CONFIG_DESKTOP_WATCHDOG_TIMEOUT / 3``.
 In case of the system hang, the work will not be processed, the watchdog timer will not be reset on time, and the system will be restarted.

--- a/include/caf/click_detector.rst
+++ b/include/caf/click_detector.rst
@@ -60,7 +60,7 @@ To do so, complete the following steps:
 Implementation details
 **********************
 
-Tracing of key states is implemented using a periodically submitted work (:c:struct:`k_delayed_work`).
+Tracing of key states is implemented using a periodically submitted work (:c:struct:`k_work_delayable`).
 The work updates the states of traced keys and sends ``click_event`` when one of the `Click types`_ is recorded.
 The work is not submitted if there is no key for which the state should be updated.
 

--- a/include/caf/leds.rst
+++ b/include/caf/leds.rst
@@ -167,7 +167,7 @@ An example may be an LED that is blinking or breathing with a given color.
 Such LED behavior is referred to as *LED effect*.
 
 The LED color is achieved by setting the proper pulse widths for the PWM signals.
-To achieve the desired LED effect, colors for the given LED are periodically updated using work (:c:struct:`k_delayed_work`).
+To achieve the desired LED effect, colors for the given LED are periodically updated using work (:c:struct:`k_work_delayable`).
 One work automatically updates the color of a single LED.
 
 If the application goes to the error state, the LEDs are used to indicate error.

--- a/tests/subsys/spm/thread_swap/src/main.c
+++ b/tests/subsys/spm/thread_swap/src/main.c
@@ -33,7 +33,7 @@ void test_spm_service_thread_swap1(void)
 	 */
 	k_work_init_delayable(&interrupting_work, work_func);
 	err = k_work_reschedule(&interrupting_work, K_MSEC(10));
-	zassert_equal(0, err, "k_delayed_work failed: %d\n", err);
+	zassert_equal(0, err, "k_work_reschedule failed: %d\n", err);
 
 	/* Call into the secure service which will be interrupted. If the
 	 * scheduler is locked before entering secure services, it will prevent


### PR DESCRIPTION
Converts all references to the old API in documentation files where the
documented behavior has been converted to the new k_work API.

Includes one change to a log string that references the old API as well.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>