### PR TITLE
manifest: include TFM crypto module kconfig

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 625b8b0bd247496f1f75868c907c0adb1e0db661
+      revision: 4e63ea417176a6ba11dabb8a88b7b82b7779573f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr to include TFM crypto module kconfig options.

Ref: NCSDK-9749
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>