### PR TITLE
manifest: Point to TF-M with CCM for protected storage

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -105,7 +105,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
-      revision: 7b935d15868e4d4dd443fe04f103fef25bb34d2d
+      revision: pull/17/head
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
-Point to the PR that selects the AES CCM algorithm
 as the default for the Protected Storage service of TF-M
 for the nRF9160

TF-M PR: [pull/17](https://github.com/nrfconnect/sdk-trusted-firmware-m/pull/17)
Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>