### PR TITLE
lib: date_time: Fix coverity issue and update library error handling.

### DIFF
--- a/include/date_time.h
+++ b/include/date_time.h
@@ -55,7 +55,7 @@ typedef void (*date_time_evt_handler_t)(const struct date_time_evt *evt);
  *
  *  @return 0        If the operation was successful.
  *  @return -EINVAL  If a member of the passing variable new_date_time does not
- *                   adhere to the tm structure format.
+ *                   adhere to the tm structure format, or pointer is passed in as NULL.
  */
 int date_time_set(const struct tm *new_date_time);
 
@@ -70,7 +70,8 @@ int date_time_set(const struct tm *new_date_time);
  *
  *  @return 0        If the operation was successful.
  *  @return -ENODATA If the library does not have a valid date time UTC.
- *  @return -EINVAL  If the passing variable is too large or already converted.
+ *  @return -EINVAL  If the passed in pointer is NULL, dereferenced value is too large,
+ *		     or already converted.
  */
 int date_time_uptime_to_unix_time_ms(int64_t *uptime);
 
@@ -84,6 +85,7 @@ int date_time_uptime_to_unix_time_ms(int64_t *uptime);
  *
  *  @return 0        If the operation was successful.
  *  @return -ENODATA If the library does not have a valid date time UTC.
+ *  @return -EINVAL  If the passed in pointer is NULL.
  */
 int date_time_now(int64_t *unix_time_ms);
 
@@ -135,7 +137,8 @@ int date_time_clear(void);
  *
  *  @param[in, out] unix_timestamp Pointer to a unix timestamp.
  *
- *  @return 0 If the operation was successful.
+ *  @return 0        If the operation was successful.
+ *  @return -EINVAL  If the passed in pointer is NULL.
  */
 int date_time_timestamp_clear(int64_t *unix_timestamp);
 

--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -320,6 +320,11 @@ int date_time_set(const struct tm *new_date_time)
 {
 	int err = 0;
 
+	if (new_date_time == NULL) {
+		LOG_ERR("The passed in pointer cannot be NULL");
+		return -EINVAL;
+	}
+
 	/** Seconds after the minute. tm_sec is generally 0-59.
 	 *  The extra range is to accommodate for leap seconds
 	 *  in certain systems.
@@ -387,7 +392,14 @@ int date_time_set(const struct tm *new_date_time)
 
 int date_time_uptime_to_unix_time_ms(int64_t *uptime)
 {
-	int64_t uptime_prev = *uptime;
+	int64_t uptime_prev;
+
+	if (uptime == NULL) {
+		LOG_ERR("The passed in pointer cannot be NULL");
+		return -EINVAL;
+	}
+
+	uptime_prev = *uptime;
 
 	if (!initial_valid_time) {
 		LOG_WRN("Valid time not currently available");
@@ -414,7 +426,14 @@ int date_time_uptime_to_unix_time_ms(int64_t *uptime)
 int date_time_now(int64_t *unix_time_ms)
 {
 	int err;
-	int64_t unix_time_ms_prev = *unix_time_ms;
+	int64_t unix_time_ms_prev;
+
+	if (unix_time_ms == NULL) {
+		LOG_ERR("The passed in pointer cannot be NULL");
+		return -EINVAL;
+	}
+
+	unix_time_ms_prev = *unix_time_ms;
 
 	*unix_time_ms = k_uptime_get();
 
@@ -473,6 +492,7 @@ int date_time_clear(void)
 int date_time_timestamp_clear(int64_t *unix_timestamp)
 {
 	if (unix_timestamp == NULL) {
+		LOG_ERR("The passed in pointer cannot be NULL");
 		return -EINVAL;
 	}
 

--- a/tests/lib/date_time/src/main.c
+++ b/tests/lib/date_time/src/main.c
@@ -225,8 +225,8 @@ static void test_date_time_conversion(void)
 	int64_t date_time_utc_unix = 1596813090000;
 	int64_t date_time_utc_unix_origin = k_uptime_get();
 	int64_t uptime = k_uptime_get();
-	int64_t ts_unix_ms;
-	int64_t ts_expect;
+	int64_t ts_unix_ms = 0;
+	int64_t ts_expect = 0;
 
 	ret = date_time_set(&date_time_dummy);
 	zassert_equal(0, ret, "date_time_set should equal 0");


### PR DESCRIPTION
Fix issue where the passed in variable was not initialized prior to
calling `test_date_time_conversion`.

Expland error checking in `date_time` library to get more verbose
feedback in case of erroneous API usage.