### PR TITLE
tfm: Set default AEAD alg for nRF9160 and nRF5340 

### DIFF
--- a/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
+++ b/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
@@ -6,3 +6,6 @@
 #-------------------------------------------------------------------------------
 
 include(platform/ext/target/nordic_nrf/common/nrf5340/config.cmake)
+
+# Override the AEAD algorithm configuration
+set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_GCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")

--- a/modules/tfm/tfm/boards/nrf9160/config.cmake
+++ b/modules/tfm/tfm/boards/nrf9160/config.cmake
@@ -6,3 +6,6 @@
 #-------------------------------------------------------------------------------
 
 include(platform/ext/target/nordic_nrf/common/nrf9160/config.cmake)
+
+# Override the AEAD algorithm configuration since nRF9160 supports only AES_CCM
+set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_CCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")


### PR DESCRIPTION
-Enables AES-CCM as the default AEAD algorithm
 for protected storage on nRF9160
-Enables AES-GCM as the default AEAD algorithm
 for protected storage on nRF5340

Ref: NCSDK-9006

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>