### PR TITLE
caf: leds: Add GPIO LED documentation

### DIFF
--- a/include/caf/leds.rst
+++ b/include/caf/leds.rst
@@ -10,27 +10,70 @@ CAF: LEDs module
 The LEDs module of the :ref:`lib_caf` (CAF) is responsible for controlling LEDs in response to LED effect set by a ``led_event``.
 The source of such events could be any other module in |NCS|.
 
-The module uses its own variant of Zephyr's :ref:`zephyr:pwm_api` driver for setting the LED color, either RGB or monochromatic.
-For this reason, it requires a manual configuration of the PWM ports and LEDs.
+The module uses Zephyr's :ref:`zephyr:led_api` driver for setting the LED color, either RGB or monochromatic.
+Zephyr's LED driver can use the implementation based on either GPIO or PWM.
+Use the PWM-based implementation to achieve smooth changes of brightness.
+Use the GPIO-based implementation if your board does not support PWM or if you want to control LEDs connected via GPIO expander.
 
 Configuration
 *************
 
-To use the module, you must enable the following Kconfig options:
+To use the module, you must conplete the following requirements:
 
-* :option:`CONFIG_CAF_LEDS` - This option enables the LEDs module.
-* :option:`CONFIG_PWM` - This option enables Zephyr's :ref:`zephyr:pwm_api` driver, which is used for setting the LED color (that is, the brightness of the diodes).
-* :option:`CONFIG_LED` - This option enables the LED driver API.
-* :option:`CONFIG_LED_PWM` - This option enabled the LED PWM driver.
+1. Enable the following Kconfig options:
 
-Additionally, you need to complete the steps described in `Configuring PWM ports and LEDs`_.
+   * :option:`CONFIG_CAF_LEDS` - This option enables the LEDs module.
+   * :option:`CONFIG_LED` - This option enables the LED driver API.
+
+#. Complete one of the following steps to choose and configure the LED driver implementation:
+
+   a. For the PWM-based implementation, Zephyr's :ref:`zephyr:pwm_api` driver is used for setting the LED color (that is, the brightness of the diodes).
+      For this reason, set the following options:
+
+      * :option:`CONFIG_CAF_LEDS_PWM`
+      * :option:`CONFIG_LED_PWM`
+      * :option:`CONFIG_PWM`
+
+   b. For the GPIO-based implementation, Zephyr's :ref:`zephyr:gpio_api` driver is used for setting the LED color (that is, the brightness of the diodes).
+      For this reason, set the following options:
+
+      * :option:`CONFIG_CAF_LEDS_GPIO`
+      * :option:`CONFIG_LED_GPIO`
+      * :option:`CONFIG_GPIO`
+
+#. Configure LEDs in DTS.
+   See `Configuring LEDs in DTS`_ for details.
 
 The following Kconfig options are also available for this module:
 
 * :option:`CONFIG_CAF_LEDS_PM_EVENTS` - This option enables the reaction to `Power management events`_.
 
-Configuring PWM ports and LEDs
-==============================
+.. note::
+   The GPIO-based LED driver implementation supports only turning LED on or off.
+   Smooth changes of brightness are not supported, because of hardware limitations.
+   Therefore, the LED effects that use smooth changes of LED brightness are not properly displayed by this implementation.
+
+Configuring LEDs in DTS
+=======================
+
+Zephyr's LEDs are configured using compatible DTS nodes.
+You must enable or create DTS nodes for the configuration to work.
+You can do this in the devicetree file, either in the board-specific :file:`dts` file or in a DTS overlay file.
+Using the option with the overlay file merges the settings to configuration.
+For more help, see :ref:`zephyr:dt-guide`.
+
+The value of the ``compatible`` property of the DTS node depends on the selected LED driver implementation.
+For example, you can use a node that is compatible with ``pwm-leds`` to configure LEDs controlled with PWM.
+See the following subsections for more detailed information about configuring LED driver implementations supported by CAF LEDs.
+
+The LEDs module assumes that a single DTS node is a separate and complete logical LED.
+The LEDs module expects that the node will hold configuration of HW LEDs responsible for reproducing all required color channels.
+The number of HW LEDs configured to reproduce color channels can be either one or three (either monochromatic or following the RGB order, with the red channel defined first, then the green one, then the blue one).
+If only one HW LED is used for a monochromatic setting, the module converts the tri-channel color to a single value of brightness and passes it to this single HW LED.
+The LED color channels are represented as child nodes of the compatible DTS node.
+
+Configuring PWM LEDs
+--------------------
 
 To properly use the LEDs module and have LEDs driven by PWM, you must configure the PWM driver and the LED PWM driver.
 
@@ -39,22 +82,14 @@ Configuring the LED PWM driver defines which PWM port is to be used for each LED
 In case of the LED PWM driver, the GPIO pin must match the one passed to the PWM driver.
 
 The configuration process requires enabling the PWM ports and enabling or creating the LED PWM nodes.
-Both these steps are to be done in the devicetree file, either in the board-specific :file:`dts` file or in the :file:`dts.overlay` file.
-Using the option with the :file:`dts.overlay` file will merge the settings to configuration.
-
 Make sure to configure all PWM ports and channels that are used by the application.
-For more help, see :ref:`zephyr:dt-guide`.
 
 Enabling the PWM ports
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 To enable the PWM ports, you must set the PWM port status to ``"okay"`` in the devicetree file and specify the PWM channel in relation to the GPIO pin number.
-This can be done using one of the following options:
 
-* Enabling relevant PWM ports in the board-specific :file:`dts` file.
-* Enabling relevant PWM ports in the :file:`dts.overlay` file, which are to be merged to configuration.
-
-The following code snippets show examples of how the file contents could look in either :file:`dts` or :file:`dts.overlay` files:
+The following code snippets show examples of the DTS nodes:
 
 * Example 1 (enabling an existing port node):
 
@@ -86,27 +121,17 @@ The following code snippets show examples of how the file contents could look in
 	};
 
 Enabling the LED PWM nodes
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To enable the LED PWM nodes in the devicetree file, you must set their status to ``"okay"`` in the devicetree file and specify to which PWM node they are related to.
 You can also decide to create these nodes from scratch.
 There is no limit to the number of node instances you can create.
 
-The LEDs module assumes that a single LED PWM node is a separate and complete logical LED.
-The LEDs module expects that a single LED PWM node will hold configuration of HW LEDs responsible for reproducing all required color channels.
-The number of HW LEDs configured to reproduce color channels can be either one or three (either monochromatic or following the RGB order, with the red channel defined first, then the green one, then the blue one).
-If only one HW LED is used for a monochromatic setting, the module will convert the tri-channel color to a single value of brightness and pass it to this single HW LED.
-
-The configuration can be done using one of the following options:
-
-* Enabling or creating relevant nodes in a board-specific :file:`dts` file.
-* Enabling or creating relevant nodes in :file:`dts.overlay` file, which are to be merged to configuration.
-
 For the LEDs to be configured correctly, make sure that LED PWM node pin numbers in the :file:`dts` file are matching the PWM nodes set when `Enabling the PWM ports`_.
 
-The following code snippets show examples of how the file contents could look in either :file:`dts` or :file:`dts.overlay` files:
+The following code snippets show examples of the DTS nodes:
 
-* Example 1 (enabling existing LED node):
+* Example 1 (enabling existing LED PWM node):
 
   .. code-block:: none
 
@@ -117,7 +142,7 @@ The following code snippets show examples of how the file contents could look in
 	};
 
   In this example, the ``pwms`` property is pointing to the ``pwm0`` PWM node set in Example 1 in `Enabling the PWM ports`_, with the respective channel GPIO pin number (``8``).
-* Example 2 (creating new LED nodes):
+* Example 2 (creating new LED PWM nodes):
 
   .. code-block:: none
 
@@ -158,10 +183,77 @@ The following code snippets show examples of how the file contents could look in
      In this example, ``pwmleds0`` is a tri-channel color LED node, while ``pwmleds1`` is a monochromatic LED node.
      Both ``pwmleds`` nodes are pointing to the ``pwms`` properties corresponding to PWM nodes set in Example 2 in `Enabling the PWM ports`_, with the respective channel GPIO pin numbers.
 
+Configuring GPIO LEDs
+---------------------
+
+To properly use the LEDs module and have LEDs driven by GPIO, you must configure the GPIO driver and the LED GPIO driver.
+
+Enabling the GPIOs
+~~~~~~~~~~~~~~~~~~
+
+In general, boards in Zephyr configure and enable the GPIO drivers by default, so no additional configuration is needed.
+You can also use the LED GPIO driver to control LEDs connected via a GPIO expander supported by Zephyr.
+For example, the DTS configuration of the ``thingy52_nrf52832`` board supports ``sx1509b`` GPIO expander, which is used to control lightwell RGB LEDs.
+
+Enabling the LED GPIO nodes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To enable the LED GPIO nodes in the devicetree file, you must set their status to ``"okay"`` and specify to which GPIO nodes they are related to.
+You can also decide to create these nodes from scratch.
+There is no limit to the number of node instances you can create.
+
+The LED GPIO is configured as a node that is compatible with ``gpio-leds``.
+The following code snippets show examples of DTS nodes:
+
+* Example 1 - RGB LED controlled via GPIO expander (``sx1509b``)
+
+  .. code-block:: none
+
+	leds0 {
+		compatible = "gpio-leds";
+		label = "Lightwell RGB";
+		status = "okay";
+
+		led0: led_0 {
+			gpios = <&sx1509b 7 GPIO_ACTIVE_LOW>;
+			label = "Red LED";
+		};
+		led1: led_1 {
+			gpios = <&sx1509b 5 GPIO_ACTIVE_LOW>;
+			label = "Green LED";
+		};
+		led2: led_2 {
+			gpios = <&sx1509b 6 GPIO_ACTIVE_LOW>;
+			label = "Blue LED";
+		};
+	};
+
+* Example 2 - Monochromatic LED connected directly to the GPIO of an MCU
+
+  .. code-block:: none
+
+	leds1 {
+		compatible = "gpio-leds";
+		label = "Green LED";
+		status = "okay";
+
+		led0: led_0 {
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			label = "Green LED 0";
+		};
+	};
+
+Make sure to configure all the LED GPIO nodes that are used by the application.
+
+.. note::
+   In general, boards defined by Zephyr define a ``leds`` node that is compatible with ``gpio-leds``.
+   The node can also be used by the module.
+   Before enabling the node, make sure it meets the requirements of the CAF LEDs module.
+
 Implementation details
 **********************
 
-The LED effect defines the LED behavior over time for the LED diodes by setting their brightness level periodically.
+The LED effect defines the LED behavior over time for the LEDs by setting their brightness level periodically.
 This allows for different RGB or monochromatic colors.
 An example may be an LED that is blinking or breathing with a given color.
 Such LED behavior is referred to as *LED effect*.
@@ -169,6 +261,9 @@ Such LED behavior is referred to as *LED effect*.
 The LED color is achieved by setting the proper pulse widths for the PWM signals.
 To achieve the desired LED effect, colors for the given LED are periodically updated using work (:c:struct:`k_work_delayable`).
 One work automatically updates the color of a single LED.
+
+.. note::
+   If you use the GPIO-based implementation, the signal's duty cycle can be either 0% or 100% and the LED can be either turned on or off.
 
 If the application goes to the error state, the LEDs are used to indicate error.
 


### PR DESCRIPTION
Change adds information about GPIO based implementation.

Jira: NCSDK-9548