### PR TITLE
Bluetooth: Mesh: Move scene entries to flash

### DIFF
--- a/include/bluetooth/mesh/gen_lvl_srv.h
+++ b/include/bluetooth/mesh/gen_lvl_srv.h
@@ -148,8 +148,6 @@ struct bt_mesh_lvl_srv {
 					       BT_MESH_LVL_MSG_MAXLEN_STATUS)];
 	/** Transaction ID tracking. */
 	struct bt_mesh_tid_ctx tid;
-	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Publish the generic level state.

--- a/include/bluetooth/mesh/gen_onoff_srv.h
+++ b/include/bluetooth/mesh/gen_onoff_srv.h
@@ -97,8 +97,6 @@ struct bt_mesh_onoff_srv {
 	/* Publication data */
 	uint8_t pub_data[BT_MESH_MODEL_BUF_LEN(
 		BT_MESH_ONOFF_OP_STATUS, BT_MESH_ONOFF_MSG_MAXLEN_STATUS)];
-	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
 	/** Internal flag state. */
 	atomic_t flags;
 };

--- a/include/bluetooth/mesh/gen_plvl_srv.h
+++ b/include/bluetooth/mesh/gen_plvl_srv.h
@@ -160,8 +160,6 @@ struct bt_mesh_plvl_srv {
 	uint16_t last;
 	/** Whether the Power is on. */
 	bool is_on;
-	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Publish the current Power state.

--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -104,8 +104,6 @@ struct bt_mesh_ponoff_srv {
 
 	/** Current OnPowerUp state. */
 	enum bt_mesh_on_power_up on_power_up;
-	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Set the OnPowerUp state of a Power OnOff server.

--- a/include/bluetooth/mesh/light_ctl_srv.h
+++ b/include/bluetooth/mesh/light_ctl_srv.h
@@ -78,8 +78,6 @@ struct bt_mesh_light_ctl_srv {
 		BT_MESH_LIGHT_CTL_STATUS, BT_MESH_LIGHT_CTL_MSG_MAXLEN_STATUS)];
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
-	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Publish the current CTL status.

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -186,8 +186,6 @@ struct bt_mesh_light_ctrl_srv {
 	struct bt_mesh_model *model;
 	/** Composition data setup server model instance */
 	struct bt_mesh_model *setup_srv;
-	/** Scene entry */
-	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Turn the light on.

--- a/include/bluetooth/mesh/light_hsl_srv.h
+++ b/include/bluetooth/mesh/light_hsl_srv.h
@@ -89,8 +89,6 @@ struct bt_mesh_light_hsl_srv {
 	bool pub_pending;
 	/** Transaction ID tracker for the set messages. */
 	struct bt_mesh_tid_ctx prev_transaction;
-	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Publish the current HSL status.

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -130,8 +130,6 @@ struct bt_mesh_light_temp_srv {
 	struct bt_mesh_light_temp_range range;
 	/** The last known color temperature. */
 	struct bt_mesh_light_temp last;
-	/** Scene data entry */
-	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Publish the current CTL Temperature status.

--- a/include/bluetooth/mesh/light_xyl_srv.h
+++ b/include/bluetooth/mesh/light_xyl_srv.h
@@ -155,8 +155,6 @@ struct bt_mesh_light_xyl_srv {
 	struct bt_mesh_light_xy_range range;
 	/** Handler function structure. */
 	const struct bt_mesh_light_xyl_srv_handlers *handlers;
-	/** Scene entry */
-	struct bt_mesh_scene_entry scene;
 
 	/** The last known xy Level. */
 	struct bt_mesh_light_xy xy_last;

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -166,8 +166,6 @@ struct bt_mesh_lightness_srv {
 	/** Acting controller, if enabled. */
 	struct bt_mesh_light_ctrl_srv *ctrl;
 #endif
-	/* Scene entry */
-	struct bt_mesh_scene_entry scene;
 };
 
 /** @brief Publish the current Light state.

--- a/include/bluetooth/mesh/scene_srv.h
+++ b/include/bluetooth/mesh/scene_srv.h
@@ -16,6 +16,7 @@
 
 #include <bluetooth/mesh/scene.h>
 #include <settings/settings.h>
+#include <toolchain/common.h>
 #include <sys/slist.h>
 
 #ifdef __cplusplus
@@ -25,6 +26,26 @@ extern "C" {
 #ifndef CONFIG_BT_MESH_SCENES_MAX
 #define CONFIG_BT_MESH_SCENES_MAX 0
 #endif
+
+/** @def BT_MESH_SCENE_ENTRY_SIG
+ *
+ *  @brief Scene entry type definition for SIG models
+ *
+ *  @param[in] _name Name of the scene entry type
+ */
+#define BT_MESH_SCENE_ENTRY_SIG(_name)                                         \
+	static const Z_STRUCT_SECTION_ITERABLE(                                \
+		bt_mesh_scene_entry, bt_mesh_scene_entry_sig_##_name)
+
+/** @def BT_MESH_SCENE_ENTRY_VND
+ *
+ *  @brief Scene entry type definition for vendor models
+ *
+ *  @param[in] _name Name of the scene entry type
+ */
+#define BT_MESH_SCENE_ENTRY_VND(_name)                                         \
+	static const Z_STRUCT_SECTION_ITERABLE(                                \
+		bt_mesh_scene_entry, bt_mesh_scene_entry_vnd_##_name)
 
 struct bt_mesh_scene_srv;
 
@@ -65,10 +86,8 @@ struct bt_mesh_scene_srv {
 	/** Largest number of pages used to store SIG model scene data. */
 	uint8_t sigpages;
 
-	/** SIG model scene entries. */
-	sys_slist_t sig;
-	/** Vendor model scene entries. */
-	sys_slist_t vnd;
+	/** Linked list node for Scene Server list */
+	sys_snode_t n;
 
 	/** Timestamp when the transition ends. */
 	uint64_t transition_end;
@@ -92,7 +111,14 @@ struct bt_mesh_scene_srv {
 };
 
 /** Scene entry type. */
-struct bt_mesh_scene_entry_type {
+struct bt_mesh_scene_entry {
+	/** Model ID */
+	union {
+		/** SIG model ID */
+		uint16_t sig;
+		/** Vendor model ID */
+		struct bt_mesh_mod_id_vnd vnd;
+	} id;
 	/** Longest scene data */
 	size_t maxlen;
 
@@ -126,61 +152,15 @@ struct bt_mesh_scene_entry_type {
 		       size_t len, struct bt_mesh_model_transition *transition);
 };
 
-/** @brief Scene entry.
- *
- *  Every model that stores data in scenes must own a unique scene entry, and
- *  register it with a Scene Server through @ref bt_mesh_scene_entry_add.
- *
- *  Parameters in this structure will be filled by @ref bt_mesh_scene_entry_add,
- *  and should not be manipulated directly.
- */
-struct bt_mesh_scene_entry {
-#if defined(CONFIG_BT_MESH_SCENE_SRV)
-	/** Scene Server this entry got registered to. */
-	struct bt_mesh_scene_srv *srv;
-	/** Model this scene entry belongs to. */
-	struct bt_mesh_model *model;
-	/** Scene entry callbacks */
-	const struct bt_mesh_scene_entry_type *type;
-	/** Scene entry list node */
-	sys_snode_t n;
-#endif
-};
-
-/** @brief Register a scene entry.
- *
- *  This function fills all fields of the supplied @ref bt_mesh_scene_entry
- *  structure, and registers it to the correct Scene Server.
- *
- *  Scene Servers store scene data for all models in their own element, and
- *  every subsequent element until the next Scene Server. If a Scene Server is
- *  found for this entry, the @c srv parameter will point to it when this
- *  function returns. If @c srv is NULL, this means no Scene Server was found,
- *  and Scene data will not be stored for this entry.
- *
- *  @note This function must be called as part of the model initialization
- *        procedure to correctly recover a scene on startup. The initial Scene
- *        is recovered as part of the model start procedure.
- *
- *  @param[in] model Model this scene entry represents.
- *  @param[in] entry Scene entry.
- *  @param[in] type  Scene entry type.
- *  @param[in] vnd   Whether this is a vendor model.
- */
-void bt_mesh_scene_entry_add(struct bt_mesh_model *model,
-			     struct bt_mesh_scene_entry *entry,
-			     const struct bt_mesh_scene_entry_type *type,
-			     bool vnd);
-
 /** @brief Notify the Scene Server that a Scene entry has changed.
  *
  *  Whenever some state in the Scene has changed outside of Scene recall
  *  procedure, this function must be called to notify the Scene Server that
  *  the current Scene is no longer active.
  *
- *  @param[in] entry Scene entry that was invalidated.
+ *  @param[in] mod Model that invalidated the scene.
  */
-void bt_mesh_scene_invalidate(struct bt_mesh_scene_entry *entry);
+void bt_mesh_scene_invalidate(struct bt_mesh_model *mod);
 
 /** @brief Set the current Scene.
  *

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -72,3 +72,4 @@ zephyr_library_sources_ifdef(CONFIG_BT_MESH_SCHEDULER_CLI scheduler_cli.c)
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_SCHEDULER_SRV scheduler_srv.c)
 
 zephyr_linker_sources(SECTIONS sensor_types.ld)
+zephyr_linker_sources(SECTIONS scene_types.ld)

--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -84,7 +84,7 @@ static void set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	srv->handlers->set(srv, ctx, &set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	if (ack) {
@@ -116,7 +116,7 @@ static void delta_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	srv->handlers->delta_set(srv, ctx, &delta_set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	if (ack) {
@@ -156,7 +156,7 @@ static void move_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	srv->handlers->move_set(srv, ctx, &move_set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	if (ack) {
@@ -277,7 +277,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_lvl_srv_pub(srv, NULL, &status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(lvl) = {
+	.id.sig = BT_MESH_MODEL_ID_GEN_LEVEL_SRV,
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -303,10 +304,6 @@ static int bt_mesh_lvl_srv_init(struct bt_mesh_model *model)
 	srv->pub.update = update_handler;
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
 				      sizeof(srv->pub_data));
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -90,7 +90,7 @@ static void onoff_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	srv->handlers->set(srv, ctx, &set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	(void)bt_mesh_onoff_srv_pub(srv, NULL, &status);
@@ -162,7 +162,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_onoff_srv_pub(srv, NULL, &status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(onoff) = {
+	.id.sig = BT_MESH_MODEL_ID_GEN_ONOFF_SRV,
 	.maxlen = 1,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -189,10 +190,6 @@ static int bt_mesh_onoff_srv_init(struct bt_mesh_model *model)
 	srv->pub.update = update_handler;
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
 				      sizeof(srv->pub_data));
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -172,7 +172,7 @@ static void plvl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		change_lvl(srv, ctx, &set, &status);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->plvl_model);
 		}
 	} else if (ack) {
 		srv->handlers->power_get(srv, NULL, &status);
@@ -629,7 +629,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	change_lvl(srv, NULL, &set, &status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(plvl) = {
+	.id.sig = BT_MESH_MODEL_ID_GEN_POWER_LEVEL_SRV,
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -694,10 +695,6 @@ static int bt_mesh_plvl_srv_init(struct bt_mesh_model *model)
 		bt_mesh_model_find(
 			bt_mesh_model_elem(model),
 			BT_MESH_MODEL_ID_GEN_POWER_LEVEL_SETUP_SRV));
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -224,7 +224,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_onoff_srv_pub(&srv->onoff, NULL, &status);
 }
 
-const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(ponoff) = {
+	.id.sig = BT_MESH_MODEL_ID_GEN_POWER_ONOFF_SRV,
 	.maxlen = 1,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -266,10 +267,6 @@ static int bt_mesh_ponoff_srv_init(struct bt_mesh_model *model)
 		bt_mesh_model_find(
 			bt_mesh_model_elem(model),
 			BT_MESH_MODEL_ID_GEN_POWER_ONOFF_SETUP_SRV));
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -118,7 +118,7 @@ respond:
 	}
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 }
 
@@ -382,7 +382,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	}
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(light_ctl) = {
+	.id.sig = BT_MESH_MODEL_ID_LIGHT_CTL_SRV,
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -423,10 +424,6 @@ static int bt_mesh_light_ctl_srv_init(struct bt_mesh_model *model)
 		model, bt_mesh_model_find(
 			       bt_mesh_model_elem(model),
 			       BT_MESH_MODEL_ID_LIGHT_CTL_SETUP_SRV));
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -825,7 +825,7 @@ static int om_set(struct bt_mesh_light_ctrl_srv *srv,
 	store(srv, FLAG_STORE_STATE);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	return 0;
@@ -911,7 +911,7 @@ static void light_onoff_set(struct bt_mesh_light_ctrl_srv *srv,
 		}
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->model);
 		}
 	}
 
@@ -1311,7 +1311,7 @@ static void handle_prop_set(struct bt_mesh_model *model,
 		prop_tx(srv, NULL, id);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->model);
 		}
 	}
 
@@ -1332,7 +1332,7 @@ static void handle_prop_set_unack(struct bt_mesh_model *model,
 		prop_tx(srv, NULL, id);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->model);
 		}
 	}
 
@@ -1453,7 +1453,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	}
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(light_ctrl) = {
+	.id.sig = BT_MESH_MODEL_ID_LIGHT_LC_SRV,
 	.maxlen = sizeof(struct scene_data),
 	.store = scene_store,
 	.recall = scene_recall,
@@ -1509,10 +1510,6 @@ static int light_ctrl_srv_init(struct bt_mesh_model *model)
 	atomic_set_bit(&srv->lightness->flags, LIGHTNESS_SRV_FLAG_EXTENDED_BY_LIGHT_CTRL);
 
 	atomic_set_bit(&srv->onoff.flags, GEN_ONOFF_SRV_NO_DTT);
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }
@@ -1698,7 +1695,7 @@ int bt_mesh_light_ctrl_srv_on(struct bt_mesh_light_ctrl_srv *srv)
 
 	err = turn_on(srv, NULL, true);
 	if (!err && IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	return err;
@@ -1710,7 +1707,7 @@ int bt_mesh_light_ctrl_srv_off(struct bt_mesh_light_ctrl_srv *srv)
 
 	err = turn_off(srv, NULL, true);
 	if (!err && IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	return err;
@@ -1727,7 +1724,7 @@ int bt_mesh_light_ctrl_srv_enable(struct bt_mesh_light_ctrl_srv *srv)
 		ctrl_enable(srv);
 		store(srv, FLAG_STORE_STATE);
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->model);
 		}
 	}
 
@@ -1744,7 +1741,7 @@ int bt_mesh_light_ctrl_srv_disable(struct bt_mesh_light_ctrl_srv *srv)
 	ctrl_disable(srv);
 	store(srv, FLAG_STORE_STATE);
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	return 0;

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -160,7 +160,7 @@ static void hsl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	(void)bt_mesh_light_hsl_srv_pub(srv, NULL, &hsl);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 }
 
@@ -492,7 +492,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_light_hsl_srv_pub(srv, NULL, &hsl);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(light_hsl) = {
+	.id.sig = BT_MESH_MODEL_ID_LIGHT_HSL_SRV,
 	.maxlen = sizeof(struct scene_data),
 	.store = scene_store,
 	.recall = scene_recall,
@@ -536,10 +537,6 @@ static int bt_mesh_light_hsl_srv_init(struct bt_mesh_model *model)
 		model, bt_mesh_model_find(
 			       bt_mesh_model_elem(model),
 			       BT_MESH_MODEL_ID_LIGHT_HSL_SETUP_SRV));
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/light_hue_srv.c
+++ b/subsys/bluetooth/mesh/light_hue_srv.c
@@ -131,7 +131,7 @@ static void hue_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	(void)bt_mesh_lvl_srv_pub(&srv->lvl, NULL, &lvl_status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->lvl.scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 }
 

--- a/subsys/bluetooth/mesh/light_sat_srv.c
+++ b/subsys/bluetooth/mesh/light_sat_srv.c
@@ -130,7 +130,7 @@ static void sat_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	(void)bt_mesh_lvl_srv_pub(&srv->lvl, NULL, &lvl_status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->lvl.scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 }
 

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -99,7 +99,7 @@ static void temp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	bt_mesh_light_temp_srv_set(srv, ctx, &set, &status);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 respond:
@@ -337,7 +337,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	bt_mesh_light_temp_srv_set(srv, NULL, &set, NULL);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(light_temp) = {
+	.id.sig = BT_MESH_MODEL_ID_LIGHT_CTL_TEMP_SRV,
 	.store = scene_store,
 	.recall = scene_recall,
 	.maxlen = sizeof(struct scene_data),
@@ -362,10 +363,6 @@ static int bt_mesh_light_temp_srv_init(struct bt_mesh_model *model)
 	net_buf_simple_init(srv->pub.msg, 0);
 
 	bt_mesh_model_extend(model, srv->lvl.model);
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -137,7 +137,7 @@ static void xyl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	store_state(srv);
 
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_invalidate(&srv->scene);
+		bt_mesh_scene_invalidate(srv->model);
 	}
 
 	(void)bt_mesh_light_xyl_srv_pub(srv, NULL, &xyl_status);
@@ -491,7 +491,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	(void)bt_mesh_light_xyl_srv_pub(srv, NULL, &xyl_status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(light_xyl) = {
+	.id.sig = BT_MESH_MODEL_ID_LIGHT_XYL_SRV,
 	.maxlen = sizeof(struct scene_data),
 	.store = scene_store,
 	.recall = scene_recall,
@@ -532,10 +533,6 @@ static int bt_mesh_light_xyl_srv_init(struct bt_mesh_model *model)
 		model, bt_mesh_model_find(
 			       bt_mesh_model_elem(model),
 			       BT_MESH_MODEL_ID_LIGHT_XYL_SETUP_SRV));
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -241,7 +241,7 @@ static void lightness_set(struct bt_mesh_model *model,
 		lightness_srv_change_lvl(srv, ctx, &set, &status);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-			bt_mesh_scene_invalidate(&srv->scene);
+			bt_mesh_scene_invalidate(srv->lightness_model);
 		}
 	} else if (ack) {
 		srv->handlers->light_get(srv, NULL, &status);
@@ -803,7 +803,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	lightness_srv_change_lvl(srv, NULL, &set, &dummy_status);
 }
 
-static const struct bt_mesh_scene_entry_type scene_type = {
+BT_MESH_SCENE_ENTRY_SIG(lightness) = {
+	.id.sig = BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SRV,
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
@@ -849,10 +850,6 @@ static int bt_mesh_lightness_srv_init(struct bt_mesh_model *model)
 		bt_mesh_model_find(
 			bt_mesh_model_elem(model),
 			BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_SETUP_SRV));
-
-	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
-		bt_mesh_scene_entry_add(model, &srv->scene, &scene_type, false);
-	}
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/scene_srv.c
+++ b/subsys/bluetooth/mesh/scene_srv.c
@@ -27,6 +27,8 @@ struct __packed scene_data {
 	uint8_t data[];
 };
 
+static sys_slist_t scene_servers;
+
 static char *scene_path(char *buf, uint16_t scene, bool vnd, uint8_t page)
 {
 	sprintf(buf, "%x/%c%x", scene, vnd ? 'v' : 's', page);
@@ -41,6 +43,58 @@ static inline void update_page_count(struct bt_mesh_scene_srv *srv, bool vnd,
 	} else {
 		srv->sigpages = MAX(page + 1, srv->sigpages);
 	}
+}
+
+static const struct bt_mesh_scene_entry *
+entry_find(const struct bt_mesh_model *mod, bool vnd)
+{
+	const struct bt_mesh_scene_entry *it;
+
+	if (vnd) {
+		extern const struct bt_mesh_scene_entry
+			_bt_mesh_scene_entry_vnd_list_start[];
+		extern const struct bt_mesh_scene_entry
+			_bt_mesh_scene_entry_vnd_list_end[];
+
+		for (it = _bt_mesh_scene_entry_vnd_list_start;
+		     it != _bt_mesh_scene_entry_vnd_list_end; it++) {
+			if (it->id.vnd.id == mod->vnd.id &&
+			    it->id.vnd.company == mod->vnd.company) {
+				return it;
+			}
+		}
+	} else {
+		extern const struct bt_mesh_scene_entry
+			_bt_mesh_scene_entry_sig_list_start[];
+		extern const struct bt_mesh_scene_entry
+			_bt_mesh_scene_entry_sig_list_end[];
+
+		for (it = _bt_mesh_scene_entry_sig_list_start;
+		     it != _bt_mesh_scene_entry_sig_list_end; it++) {
+			if (it->id.sig == mod->id) {
+				return it;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+static struct bt_mesh_scene_srv *srv_find(uint16_t elem_idx)
+{
+	struct bt_mesh_scene_srv *srv;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&scene_servers, srv, n) {
+		/* Scene servers are added to the link list in reverse
+		 * composition data order. The first scene server that isn't
+		 * after this element will be the right one:
+		 */
+		if (srv->model->elem_idx <= elem_idx) {
+			return srv;
+		}
+	}
+
+	return NULL;
 }
 
 static uint16_t current_scene(const struct bt_mesh_scene_srv *srv, int64_t now)
@@ -231,51 +285,38 @@ static uint16_t *scene_find(struct bt_mesh_scene_srv *srv, uint16_t scene)
 static void entry_recover(struct bt_mesh_scene_srv *srv, bool vnd,
 			  const struct scene_data *data)
 {
-	sys_slist_t *list = vnd ? &srv->vnd : &srv->sig;
-	struct bt_mesh_scene_entry *entry;
+	const struct bt_mesh_elem *elem = &bt_mesh_comp_get()->elem[data->elem_idx];
+	const size_t overhead = vnd ? VND_MODEL_SCENE_DATA_OVERHEAD : 0;
+	const struct bt_mesh_scene_entry *entry;
+	struct bt_mesh_model *mod;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(list, entry, n) {
-		if (data->elem_idx != entry->model->elem_idx) {
-			continue;
-		}
+	if (vnd) {
+		mod = bt_mesh_model_find_vnd(elem, sys_get_le16(data->data), data->id);
+	} else {
+		mod = bt_mesh_model_find(elem, data->id);
+	}
 
-		/* MeshMDL1.0.1, section 5.1.3.1.1:
-		 * If a model is extending another model, the extending model shall determine
-		 * the Stored with Scene behavior of that model.
-		 */
-		if (bt_mesh_model_is_extended(entry->model)) {
-			continue;
-		}
-
-		if (vnd) {
-			uint16_t company_id = sys_get_le16(data->data);
-
-			if (entry->model->vnd.id != data->id) {
-				continue;
-			}
-
-			if (entry->model->vnd.company != company_id) {
-				continue;
-			}
-
-			entry->type->recall(
-				entry->model,
-				&data->data[VND_MODEL_SCENE_DATA_OVERHEAD],
-				data->len - VND_MODEL_SCENE_DATA_OVERHEAD,
-				&srv->transition);
-		} else {
-			if (entry->model->id != data->id) {
-				continue;
-			}
-
-			entry->type->recall(entry->model, &data->data[0],
-					    data->len, &srv->transition);
-		}
-
+	if (!mod) {
+		BT_WARN("No model @%s", bt_hex(&data->elem_idx, vnd ? 5 : 3));
 		return;
 	}
 
-	BT_WARN("Missing entry for %s", bt_hex(&data->elem_idx, vnd ? 5 : 3));
+	/* MeshMDL1.0.1, section 5.1.3.1.1:
+	 * If a model is extending another model, the extending model shall determine
+	 * the Stored with Scene behavior of that model.
+	 */
+	if (bt_mesh_model_is_extended(mod)) {
+		return;
+	}
+
+	entry = entry_find(mod, vnd);
+	if (!entry) {
+		BT_WARN("No scene entry for %s", bt_hex(&data->elem_idx, vnd ? 5 : 3));
+		return;
+	}
+
+	entry->recall(mod, &data->data[overhead], data->len - overhead,
+		      &srv->transition);
 }
 
 static void page_recover(struct bt_mesh_scene_srv *srv, bool vnd,
@@ -288,37 +329,42 @@ static void page_recover(struct bt_mesh_scene_srv *srv, bool vnd,
 	}
 }
 
-static ssize_t entry_store(const struct bt_mesh_scene_entry *entry, bool vnd,
+static ssize_t entry_store(struct bt_mesh_model *mod,
+			   const struct bt_mesh_scene_entry *entry, bool vnd,
 			   uint8_t buf[])
 {
 	struct scene_data *data = (struct scene_data *)buf;
 	ssize_t size;
 
-	data->elem_idx = entry->model->elem_idx;
+	data->elem_idx = mod->elem_idx;
 
 	if (vnd) {
-		data->id = entry->model->vnd.id;
-		sys_put_le16(entry->model->vnd.company, data->data);
-		size = entry->type->store(
-			entry->model, &data->data[VND_MODEL_SCENE_DATA_OVERHEAD]);
+		data->id = mod->vnd.id;
+		sys_put_le16(mod->vnd.company, data->data);
+		size = entry->store(mod,
+				    &data->data[VND_MODEL_SCENE_DATA_OVERHEAD]);
 		data->len = size + VND_MODEL_SCENE_DATA_OVERHEAD;
 	} else {
-		data->id = entry->model->id;
-		size = entry->type->store(entry->model, &data->data[0]);
+		data->id = mod->id;
+		size = entry->store(mod, &data->data[0]);
 		data->len = size;
 	}
 
-	if (size > entry->type->maxlen) {
+	if (size > entry->maxlen) {
 		BT_ERR("Entry %s:%u:%u: data too large (%u bytes)",
-		       vnd ? "vnd" : "sig", entry->model->elem_idx,
-		       entry->model->mod_idx, size);
+		       vnd ? "vnd" : "sig", mod->elem_idx, mod->mod_idx, size);
 		return -EINVAL;
 	}
 
-	if (size <= 0) {
+	if (size < 0) {
 		BT_WARN("Failed storing %s:%u:%u (%d)", vnd ? "vnd" : "sig",
-			entry->model->elem_idx, entry->model->mod_idx, size);
+			mod->elem_idx, mod->mod_idx, size);
 		return size;
+	}
+
+	if (size == 0) {
+		/* Silently ignore this entry */
+		return 0;
 	}
 
 	return sizeof(struct scene_data) + data->len;
@@ -344,88 +390,106 @@ static void page_store(struct bt_mesh_scene_srv *srv, uint16_t scene,
 	}
 }
 
-static enum bt_mesh_scene_status scene_store(struct bt_mesh_scene_srv *srv,
-					     uint16_t scene)
+/** @brief Get the end of the Scene server's controlled elements.
+ *
+ *  A Scene Server controls all elements whose index is equal to or larger than
+ *  its own, and smaller than the return value of this function.
+ *
+ *  @param[in] srv Scene Server to find control boundary of.
+ *
+ *  @return The element index of the next Scene Server, or the total element
+ *          count.
+ */
+static uint16_t srv_elem_end(const struct bt_mesh_scene_srv *srv)
 {
-	struct bt_mesh_scene_entry *entry;
-	uint16_t *existing;
+	uint16_t end = bt_mesh_elem_count();
+	struct bt_mesh_scene_srv *it;
+
+	/* As Scene Servers are added to the list in reverse order, we'll break
+	 * when we find our scene server. When this happens, end will be the
+	 * index of the previously checked Scene Server, which is the next Scene
+	 * Server in the composition data.
+	 */
+	SYS_SLIST_FOR_EACH_CONTAINER(&scene_servers, it, n) {
+		if (it == srv) {
+			break;
+		}
+
+		end = srv->model->elem_idx;
+	}
+
+	return end;
+}
+
+static void scene_store_mod(struct bt_mesh_scene_srv *srv, uint16_t scene,
+			    bool vnd)
+{
+	const size_t data_overhead = sizeof(struct scene_data) + (vnd ? 2 : 0);
+	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
+	uint16_t elem_end = srv_elem_end(srv);
 	uint8_t buf[SCENE_PAGE_SIZE];
 	uint8_t page = 0;
 	size_t len = 0;
 
-	existing = scene_find(srv, scene);
-	if (!existing && srv->count == ARRAY_SIZE(srv->all)) {
-		BT_ERR("Out of space");
-		return BT_MESH_SCENE_REGISTER_FULL;
-	}
+	for (int i = srv->model->elem_idx; i < elem_end; i++) {
+		const struct bt_mesh_elem *elem = &comp->elem[i];
+		struct bt_mesh_model *models = vnd ? elem->vnd_models : elem->models;
+		int model_count = vnd ? elem->vnd_model_count : elem->model_count;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&srv->sig, entry, n) {
-		ssize_t size;
+		for (int j = 0; j < model_count; j++) {
+			const struct bt_mesh_scene_entry *entry;
+			struct bt_mesh_model *mod = &models[j];
+			ssize_t size;
 
-		/* MeshMDL1.0.1, section 5.1.3.1.1:
-		 * If a model is extending another model, the extending model shall determine
-		 * the Stored with Scene behavior of that model.
-		 */
-		if (bt_mesh_model_is_extended(entry->model)) {
-			continue;
+			if (mod == srv->model) {
+				continue;
+			}
+
+			/* MeshMDL1.0.1, section 5.1.3.1.1:
+			 * If a model is extending another model, the extending
+			 * model shall determine the Stored with Scene behavior
+			 * of that model.
+			 */
+			if (bt_mesh_model_is_extended(mod)) {
+				continue;
+			}
+
+			entry = entry_find(mod, vnd);
+			if (!entry) {
+				continue;
+			}
+
+			if (len + data_overhead + entry->maxlen >= SCENE_PAGE_SIZE) {
+				page_store(srv, scene, page++, vnd, buf, len);
+				len = 0;
+			}
+
+			size = entry_store(mod, entry, vnd, &buf[len]);
+			len += MAX(0, size);
 		}
-
-		if (len + sizeof(struct scene_data) + entry->type->maxlen >=
-		    sizeof(buf)) {
-			page_store(srv, scene, page++, false, buf, len);
-			len = 0;
-		}
-
-		size = entry_store(entry, false, &buf[len]);
-		if (size < 0) {
-			continue;
-		}
-
-		len += size;
-	}
-
-	if (len) {
-		page_store(srv, scene, page, false, buf, len);
-		len = 0;
-	}
-
-	page = 0;
-
-	SYS_SLIST_FOR_EACH_CONTAINER(&srv->vnd, entry, n) {
-		ssize_t size;
-
-		/* MeshMDL1.0.1, section 5.1.3.1.1:
-		 * If a model is extending another model, the extending model shall determine
-		 * the Stored with Scene behavior of that model.
-		 */
-		if (bt_mesh_model_is_extended(entry->model)) {
-			continue;
-		}
-
-		/* Account for Company ID: */
-		if (len + sizeof(struct scene_data) +
-			    VND_MODEL_SCENE_DATA_OVERHEAD +
-			    entry->type->maxlen >=
-		    sizeof(buf)) {
-			page_store(srv, scene, page++, true, buf, len);
-			len = 0;
-		}
-
-		size = entry_store(entry, true, &buf[len]);
-		if (size < 0) {
-			continue;
-		}
-
-		len += size;
 	}
 
 	if (len) {
-		page_store(srv, scene, page, true, buf, len);
+		page_store(srv, scene, page, vnd, buf, len);
 	}
+}
+
+static enum bt_mesh_scene_status scene_store(struct bt_mesh_scene_srv *srv,
+					     uint16_t scene)
+{
+	uint16_t *existing = scene_find(srv, scene);
 
 	if (!existing) {
+		if (srv->count == ARRAY_SIZE(srv->all)) {
+			BT_ERR("Out of space");
+			return BT_MESH_SCENE_REGISTER_FULL;
+		}
+
 		srv->all[srv->count++] = scene;
 	}
+
+	scene_store_mod(srv, scene, false);
+	scene_store_mod(srv, scene, true);
 
 	srv->next = scene;
 	return BT_MESH_SCENE_SUCCESS;
@@ -561,10 +625,7 @@ static int scene_srv_init(struct bt_mesh_model *model)
 {
 	struct bt_mesh_scene_srv *srv = model->user_data;
 
-	if (model->id == BT_MESH_MODEL_ID_SCENE_SETUP_SRV) {
-		srv->setup_mod = model;
-		return 0;
-	}
+	sys_slist_prepend(&scene_servers, &srv->n);
 
 	srv->model = model;
 	net_buf_simple_init_with_data(&srv->pub_msg, srv->buf,
@@ -688,59 +749,17 @@ const struct bt_mesh_model_cb _bt_mesh_scene_setup_srv_cb = {
 	.init = scene_setup_srv_init,
 };
 
-void bt_mesh_scene_entry_add(struct bt_mesh_model *model,
-			     struct bt_mesh_scene_entry *entry,
-			     const struct bt_mesh_scene_entry_type *type,
-			     bool vnd)
+void bt_mesh_scene_invalidate(struct bt_mesh_model *mod)
 {
-	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
+	struct bt_mesh_scene_srv *srv = srv_find(mod->elem_idx);
 
-	if (sizeof(struct scene_data) +
-		    (vnd ? VND_MODEL_SCENE_DATA_OVERHEAD : 0) + type->maxlen >
-	    SCENE_PAGE_SIZE) {
-		BT_ERR("Scene entry maxlen too large");
+	if (!srv) {
 		return;
 	}
 
-	entry->model = model;
-	entry->type = type;
-	entry->srv = NULL;
-
-	/* A scene server covers all elements from its own until the next scene
-	 * server. Find the last scene server before this model:
-	 */
-	for (int elem_idx = model->elem_idx; elem_idx >= 0; elem_idx--) {
-		struct bt_mesh_model *srv_model;
-
-		srv_model = bt_mesh_model_find(&comp->elem[elem_idx],
-					     BT_MESH_MODEL_ID_SCENE_SRV);
-		if (srv_model) {
-			entry->srv = srv_model->user_data;
-			break;
-		}
-	}
-
-	if (!entry->srv) {
-		BT_WARN("No Scene server for elem %u", model->elem_idx);
-		return;
-	}
-
-	if (vnd) {
-		sys_slist_append(&entry->srv->vnd, &entry->n);
-	} else {
-		sys_slist_append(&entry->srv->sig, &entry->n);
-	}
-}
-
-void bt_mesh_scene_invalidate(struct bt_mesh_scene_entry *entry)
-{
-	if (!entry->srv) {
-		return;
-	}
-
-	entry->srv->prev = BT_MESH_SCENE_NONE;
-	entry->srv->transition_end = 0U;
-	entry->srv->next = BT_MESH_SCENE_NONE;
+	srv->prev = BT_MESH_SCENE_NONE;
+	srv->transition_end = 0U;
+	srv->next = BT_MESH_SCENE_NONE;
 }
 
 int bt_mesh_scene_srv_set(struct bt_mesh_scene_srv *srv, uint16_t scene,

--- a/subsys/bluetooth/mesh/scene_types.ld
+++ b/subsys/bluetooth/mesh/scene_types.ld
@@ -1,0 +1,16 @@
+SECTION_DATA_PROLOGUE(bt_mesh_scene_entries_sections,,SUBALIGN(4))
+{
+#ifdef CONFIG_BT_MESH_SCENE_SRV
+	_bt_mesh_scene_entry_sig_list_start = .;
+	KEEP(*(SORT_BY_NAME("._bt_mesh_scene_entry.static.bt_mesh_scene_entry_sig_*")));
+	_bt_mesh_scene_entry_sig_list_end = .;
+	_bt_mesh_scene_entry_vnd_list_start = .;
+	KEEP(*(SORT_BY_NAME("._bt_mesh_scene_entry.static.bt_mesh_scene_entry_vnd_*")));
+	_bt_mesh_scene_entry_vnd_list_end = .;
+#else
+	/* Will be discarded by linker, unless they're explicitly referenced by
+	 * some other module:
+	 */
+	*(SORT_BY_NAME("._bt_mesh_scene_entry.static.*"));
+#endif
+} GROUP_LINK_IN(ROMABLE_REGION)


### PR DESCRIPTION
Redesign of the scene entry feature.

Instead of keeping a separate linked list of scene entry objects in the
model contexts, we'll trade RAM for CPU, and perform a lookup in
ROM-allocated scene entries for each model in the composition data when
storing and restoring.

This removes all RAM usage for scene entries, saving 16 bytes per model,
for all models with scene data. As there'll only be one entry for each
model type, we'll have to search through at most 10 entries per model.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>