### PR TITLE
caf: events: Add documentation for hardware-related events

### DIFF
--- a/include/caf/events/button_event.h
+++ b/include/caf/events/button_event.h
@@ -8,9 +8,10 @@
 #define _BUTTON_EVENT_H_
 
 /**
- * @brief CAF Button Event
+ * @file
  * @defgroup caf_button_event CAF Button Event
  * @{
+ * @brief CAF Button Event.
  */
 
 #include "event_manager.h"
@@ -19,10 +20,18 @@
 extern "C" {
 #endif
 
+/** @brief Button event.
+ *
+ * The button event is submitted when a button is pressed or released.
+ */
 struct button_event {
+	/** Event header. */
 	struct event_header header;
 
+	/** ID of the button. */
 	uint16_t key_id;
+
+	/** Information if the button was pressed or released. */
 	bool pressed;
 };
 

--- a/include/caf/events/click_event.h
+++ b/include/caf/events/click_event.h
@@ -8,9 +8,10 @@
 #define _CLICK_EVENT_H_
 
 /**
- * @brief CAF Click Event
+ * @file
  * @defgroup caf_click_event CAF Click Event
  * @{
+ * @brief CAF Click Event.
  */
 
 #include "event_manager.h"
@@ -19,20 +20,41 @@
 extern "C" {
 #endif
 
-/** @brief Click types. */
+/** @brief Click types.
+ *
+ * The click type refers to the way a button can be pressed.
+ */
 enum click {
+	/** Button pressed and held for a period of time that is too long for CLICK_SHORT,
+	 * but too short for CLICK_LONG.
+	 */
 	CLICK_NONE,
+
+	/** Button pressed and released after a short time. */
 	CLICK_SHORT,
+
+	/** Button pressed and held for a long period of time. */
 	CLICK_LONG,
+
+	/** Two sequences of the button press and release in a short time interval. */
 	CLICK_DOUBLE,
 
+	/** Number of click types. */
 	CLICK_COUNT
 };
 
+/** @brief Click event.
+ *
+ * The click event is submitted when a click type is recorded for one of the monitored buttons.
+ */
 struct click_event {
+	/** Event header. */
 	struct event_header header;
 
+	/** ID of the button - matching the key_id used by the @ref button_event. */
 	uint16_t key_id;
+
+	/** Detected click type. */
 	enum click click;
 };
 

--- a/include/caf/events/led_event.h
+++ b/include/caf/events/led_event.h
@@ -8,9 +8,10 @@
 #define _LED_EVENT_H_
 
 /**
- * @brief CAF LED Event
+ * @file
  * @defgroup caf_led_event CAF LED Event
  * @{
+ * @brief CAF LED Event.
  */
 
 #include "event_manager.h"
@@ -20,22 +21,40 @@
 extern "C" {
 #endif
 
-/** @brief LED event used to change LED operating mode and color. */
+/** @brief LED event.
+ *
+ * The LED event is submitted to change effect displayed by the selected LED. The LED effect affects
+ * operating mode and color of the LED. The LED effect displayed by the given LED is overridden
+ * if LED receives a new LED event. For more information about LED effects see  @ref led_effect_CAF.
+ */
 struct led_event {
+	/** Event header. */
 	struct event_header header;
 
+	/** ID of the LED. */
 	size_t led_id;
+
+	/** Pointer to LED effect to be displayed. */
 	const struct led_effect *led_effect;
 };
 
 
-/** @brief LED ready event used to notify that leds are ready for next
- * LED stream effect.
+/** @brief LED ready event.
+ *
+ * The LED ready event is submitted to inform that a LED has finished displaying a LED effect.
+ * The event is used to notify that the LED is ready to display next effect.
+ *
+ * If the displayed LED effect has loop_forever set to true, the effect never ends and the LED ready
+ * event should not be submitted.
  */
 struct led_ready_event {
+	/** Event header. */
 	struct event_header header;
 
+	/** ID of the LED. */
 	size_t led_id;
+
+	/** Pointer to the LED effect that was displayed. */
 	const struct led_effect *led_effect;
 };
 


### PR DESCRIPTION
Change adds doxygen documentation for button_event, click_event and led_event.

Jira: NCSDK-9551