### PR TITLE
doc: include doc installation instructions from Zephyr

### DIFF
--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -16,16 +16,31 @@ See :ref:`zephyr:documentation-overview` in the Zephyr developer guide for infor
 Before you start
 ****************
 
-Before you can build the documentation, install the |NCS| as described in :ref:`gs_installing`.
-Make sure that you have installed the required :ref:`Python dependencies <additional_deps>`.
+Before you can build the documentation, you must install the required tools.
+The following tool versions have been tested to work:
 
-See :ref:`zephyr:documentation-processors` in the Zephyr developer guide for information about installing the required tools to build the documentation and their supported versions.
-In addition to these tools, you must install `mscgen`_ and make sure the ``mscgen`` executable is in your ``PATH``.
+.. ncs-include:: README.rst
+   :docset: zephyr
+   :auto-dedent:
+   :start-after: tested to run with:
+   :end-before: * All Python dependencies
 
-.. note::
-   On Windows, the Sphinx executable ``sphinx-build.exe`` is placed in the :file:`Scripts` folder of your Python installation path.
-   Depending on how you have installed Python, you might need to add this folder to your ``PATH`` environment variable.
-   Follow the instructions in `Windows Python Path`_ if needed.
+* Mscgen 0.20
+* Python dependencies as listed in :ref:`python_req_documentation`
+
+Complete the following steps to install the required tools:
+
+1. If you have not done so already, install the |NCS| as described in :ref:`gs_installing`.
+#. Install or update all required :ref:`Python dependencies <additional_deps>`.
+#. Install the additional documentation tools required by Zephyr:
+
+   .. ncs-include:: README.rst
+      :docset: zephyr
+      :auto-dedent:
+      :start-after: .. doc_processors_installation_start
+      :end-before: .. doc_processors_installation_end
+
+#. Install `mscgen`_ and make sure that the ``mscgen`` executable is in your ``PATH``.
 
 
 Documentation structure

--- a/doc/nrf/gs_recommended_versions.rst
+++ b/doc/nrf/gs_recommended_versions.rst
@@ -182,6 +182,8 @@ Building and running applications, samples, and tests
    * - windows-curses (only Windows)
      - |windows-curses_ver|
 
+.. _python_req_documentation:
+
 Building documentation
 ======================
 

--- a/doc/nrf/templates/cheat_sheet.rst
+++ b/doc/nrf/templates/cheat_sheet.rst
@@ -243,6 +243,10 @@ Include 5 (similar to include 2, but improved indentation):
 
 See https://github.com/nrfconnect/sdk-nrf/commit/fa5bd7330538f6a12e059c9d60fa2696e48fcf3a for implementation and usage.
 
+.. tip::
+   If you need a "start-after" text that occurs more than once inside a document, you can combine ``:start-after:`` with ``:start-line:``.
+   Sphinx will then use the first occurrence of the "start-after" text after the specified start line.
+
 Including text inside a nested list
 ===================================
 


### PR DESCRIPTION
Include the instructions for installing the documentation tools
from Zephyr instead of linking.

Ref. NCSDK-7821

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>