### PR TITLE
doc: fix path to entropy_cc310 implementation

### DIFF
--- a/doc/nrf/drivers/entropy_cc310.rst
+++ b/doc/nrf/drivers/entropy_cc310.rst
@@ -25,6 +25,6 @@ API documentation
 *****************
 
 | Header file: :file:`zephyr/include/drivers/entropy.h` (in the |NCS| project)
-| Source file: :file:`drivers/entropy_cc310/entropy_cc310.c`
+| Source file: :file:`drivers/entropy/entropy_cc310.c`
 
 The entropy_cc3xx driver implements the Zephyr :ref:`zephyr:entropy_api` API.


### PR DESCRIPTION
Fix the path to the driver implementation in the docs.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>