### PR TITLE
samples: http_application_update: align buffer

### DIFF
--- a/samples/nrf9160/http_update/application_update/src/main.c
+++ b/samples/nrf9160/http_update/application_update/src/main.c
@@ -17,7 +17,7 @@
 #define NUM_LEDS 1
 #endif
 
-static uint8_t fota_buf[512];
+static __aligned(4) uint8_t fota_buf[512];
 
 static void fota_dl_handler(const struct fota_download_evt *evt)
 {


### PR DESCRIPTION
This buffer needs to be 32 bit aligned

Ref: NCSDK-9801
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>