### PR TITLE
applications: machine_learning: Fix ml_state Kconfig dependency

### DIFF
--- a/applications/machine_learning/src/modules/Kconfig.ml_state
+++ b/applications/machine_learning/src/modules/Kconfig.ml_state
@@ -7,7 +7,7 @@
 menuconfig ML_APP_ML_STATE
 	bool "Machine learning state"
 	depends on ML_APP_ML_RUNNER || ML_APP_EI_DATA_FORWARDER
-	depends on CAF_BUTTON_EVENTS
+	depends on CAF_CLICK_EVENTS
 	select ML_APP_ML_STATE_EVENTS
 
 if ML_APP_ML_STATE


### PR DESCRIPTION
The ml_state no longer subscribes for button_event. In current implementation, the module uses click_event.