### PR TITLE
Bluetooth: Mesh: Check Light LC Server Property Set message length

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1197,6 +1197,11 @@ static int prop_set(struct net_buf_simple *buf,
 		return err;
 	}
 
+	if (buf->len > 0) {
+		BT_ERR("Invalid message size");
+		return -EMSGSIZE;
+	}
+
 	BT_DBG("0x%04x: %s", id, bt_mesh_sensor_ch_str(&val));
 
 	switch (id) {


### PR DESCRIPTION
In MMDL/SR/LLCS/BI-01-C PTS sends too long Light LC property value and expects
IUT to ignore it.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>