### PR TITLE
cmake: target_compile_options_final function implemented

### DIFF
--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -28,3 +28,6 @@ if(DEFINED NRF_SUPPORTED_BUILD_TYPES)
                 message(FATAL_ERROR "${CMAKE_BUILD_TYPE} variant is not supported")
         endif()
 endif()
+
+add_library(compile_options_final INTERFACE)
+target_compile_options(compile_options_final INTERFACE $<TARGET_PROPERTY:COMPILE_OPTIONS_FINAL>)


### PR DESCRIPTION
CMake offers target_compile_options.
However, those compile options are placed first on compiler invocation
and afterwards inherited options from linked libraries are placed.

This means that if you do:
```
  add_library(bar INTERFACE)
  target_compile_options(bar INTERFACE -Os)

  add_library(foo STATIC foo.c)
  target_link_libraries(foo PRIVATE bar)
  target_compile_options(foo PRIVATE -O0)
```
then the result will be:

      <compiler> -O0 -Os -o foo.o -c foo.c

which means that foo.c is being compiled with -Os and not -O0.

The new function target_compile_options_final() will use a dedicated
property and generator expression to allow users to get library compile
options placed at the end, so that a user may do:
```
  add_library(bar INTERFACE)
  target_compile_options(bar INTERFACE -Os)

  add_library(foo STATIC foo.c)
  target_link_libraries(foo PRIVATE bar)
  target_compile_options_final(foo PRIVATE -O0)
```
then the result will be:
```
  <compiler> -Os -O0 -o foo.o -c foo.c
```
which is want the user intended.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>