### PR TITLE
Bug-fix allow digits in AT command name

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -392,7 +392,7 @@ static int raw_rx_handler(const uint8_t *data, int datalen)
  *  AT<separator><body>=<parameters><NULL>
  * In which
  * <separator>: +, %, #
- * <body>: alphabetic char only, size > 0
+ * <body>: alphanumeric char only, size > 0
  * <parameters>: arbitrary, size > 0
  */
 static int cmd_grammar_check(const uint8_t *cmd, uint16_t length)
@@ -419,10 +419,8 @@ static int cmd_grammar_check(const uint8_t *cmd, uint16_t length)
 	cmd += 1;
 	body = cmd;
 	while (true) {
-		char ch = toupper((int)*cmd);
-
-		/* check body is alphabetic */
-		if (ch < 'A' || ch > 'Z') {
+		/* check body is alphanumeric */
+		if (!isalpha((int)*cmd) && !isdigit((int)*cmd)) {
 			break;
 		}
 		cmd++;

--- a/lib/at_cmd_parser/at_cmd_parser.c
+++ b/lib/at_cmd_parser/at_cmd_parser.c
@@ -180,7 +180,7 @@ static int at_parse_process_element(const char **str, int index,
 
 		skip_command_prefix(&tmpstr);
 
-		while (is_valid_notification_char(*tmpstr)) {
+		while (is_valid_command_char(*tmpstr)) {
 			tmpstr++;
 		}
 

--- a/lib/at_cmd_parser/at_utils.h
+++ b/lib/at_cmd_parser/at_utils.h
@@ -54,6 +54,25 @@ static inline bool is_notification(char chr)
 /**
  * @brief Verify that the character is a valid character
  *
+ * Command strings can only contain alphanemuric characters.
+ *
+ * @param[in] chr Character that should be examined
+ *
+ * @retval true  If character is valid
+ * @retval false If character is not valid
+ */
+static inline bool is_valid_command_char(char chr)
+{
+	if (isalpha((int)chr) || isdigit((int)chr)) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * @brief Verify that the character is a valid character
+ *
  * Notification ID strings can only contain upper case letters 'A' through 'Z'
  *
  * @param[in] chr Character that should be examined


### PR DESCRIPTION
For example, %XCOEX0, %REL14FEAT, %XT3412
Affecting at_cmd_parser library as well as serial_lte_modem app.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>
