### PR TITLE
applications: serial_lte_modem: fix HTTPC host name resolving

### DIFF
--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -134,7 +134,6 @@ static int resolve_and_connect(int family, const char *host, int sec_tag)
 	struct addrinfo hints = {
 		.ai_family = family,
 		.ai_socktype = SOCK_STREAM,
-		.ai_protocol = proto,
 	};
 
 	err = getaddrinfo(host, NULL, &hints, &info);


### PR DESCRIPTION
When HTTPC resolves host name for a TLS connection, resolving
protocol is incorrectly set to TLS 1.2. After modem_lib v1.1.0, such
behavior results to host name resolving failure.

This commit fix the issue by removing the incorrect protocol hint.

Signed-off-by: Larry Tsai <larry.tsai@nordicsemi.no>