### PR TITLE
net: lib: Introduce socket timeouts in AWS IoT and Azure IoT backends

### DIFF
--- a/subsys/net/lib/aws_iot/Kconfig
+++ b/subsys/net/lib/aws_iot/Kconfig
@@ -11,6 +11,25 @@ menuconfig AWS_IOT
 
 if AWS_IOT
 
+config AWS_IOT_SEND_TIMEOUT
+	bool "Send data with socket timeout"
+	default y
+	help
+	  Configures a timeout on the AWS IoT socket to ensure that a call to the send function will
+	  not block indefinitely. To configure the length of the timeout,
+	  use AWS_IOT_SEND_TIMEOUT_SEC.
+
+if AWS_IOT_SEND_TIMEOUT
+
+config AWS_IOT_SEND_TIMEOUT_SEC
+	int "Send timeout"
+	default 60
+	help
+	  Timeout in seconds to use when the AWS IoT socket is configured to
+	  send with a timeout by enabling AWS_IOT_SEND_TIMEOUT.
+
+endif
+
 config AWS_IOT_STATIC_IPV4
 	bool "Enable use of static IPv4"
 

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -1002,6 +1002,27 @@ static int connect_client(struct aws_iot_config *const config)
 		return err;
 	}
 
+	if (IS_ENABLED(CONFIG_AWS_IOT_SEND_TIMEOUT)) {
+		struct timeval timeout = {
+			.tv_sec = CONFIG_AWS_IOT_SEND_TIMEOUT_SEC
+		};
+
+		err = setsockopt(client.transport.tls.sock,
+				 SOL_SOCKET,
+				 SO_SNDTIMEO,
+				 &timeout,
+				 sizeof(timeout));
+		if (err == -1) {
+			LOG_WRN("Failed to set timeout, errno: %d", errno);
+
+			/* Don't propagate this as an error. */
+			err = 0;
+		} else {
+			LOG_DBG("Using send socket timeout of %d seconds",
+				CONFIG_AWS_IOT_SEND_TIMEOUT_SEC);
+		}
+	}
+
 	if (config != NULL) {
 		config->socket = client.transport.tls.sock;
 	}

--- a/subsys/net/lib/azure_iot_hub/Kconfig
+++ b/subsys/net/lib/azure_iot_hub/Kconfig
@@ -11,6 +11,25 @@ menuconfig AZURE_IOT_HUB
 
 if AZURE_IOT_HUB
 
+config AZURE_IOT_HUB_SEND_TIMEOUT
+	bool "Send data with socket timeout"
+	default y
+	help
+	  Configures a timeout on the Azure IoT Hub socket to ensure that a call to the send
+	  function will not block indefinitely. To configure the length of the timeout,
+	  use AZURE_IOT_HUB_SEND_TIMEOUT_SEC.
+
+if AZURE_IOT_HUB_SEND_TIMEOUT
+
+config AZURE_IOT_HUB_SEND_TIMEOUT_SEC
+	int "Send timeout"
+	default 60
+	help
+	  Timeout in seconds to use when the Azure IoT Hub socket is configured to
+	  send with a timeout by enabling AZURE_IOT_HUB_SEND_TIMEOUT.
+
+endif
+
 config AZURE_IOT_HUB_HOSTNAME
 	string "Azure IoT Hub hostname"
 

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -942,6 +942,27 @@ static int connect_client(struct azure_iot_hub_config *cfg)
 	/* Set the current socket and start reading from it in polling thread */
 	conn_config.socket = client.transport.tls.sock;
 
+	if (IS_ENABLED(CONFIG_AZURE_IOT_HUB_SEND_TIMEOUT)) {
+		struct timeval timeout = {
+			.tv_sec = CONFIG_AZURE_IOT_HUB_SEND_TIMEOUT_SEC
+		};
+
+		err = setsockopt(conn_config.socket,
+				 SOL_SOCKET,
+				 SO_SNDTIMEO,
+				 &timeout,
+				 sizeof(timeout));
+		if (err == -1) {
+			LOG_WRN("Failed to set timeout, errno: %d", errno);
+
+			/* Don't propagate this as an error. */
+			err = 0;
+		} else {
+			LOG_DBG("Using send socket timeout of %d seconds",
+				CONFIG_AZURE_IOT_HUB_SEND_TIMEOUT_SEC);
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Prevent send from blocking indefinitely by introducing Kconfig options
to set socket timeouts in AWS IoT and Azure IoT Hub cloud backends.

Closes CIA-323