### PR TITLE
manifest: udpate nrfxlib and sdk-zephyr revisions

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.6.0-rc1-ncs1
+      revision: pull/571/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.6.0
+      revision: pull/474/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Update nrfxlib and sdk-zephyr revisions to introduce temperature
platform for IEEE 802.15.4 Radio Driver.

Signed-off-by: Pawel Kwiek <pawel.kwiek@nordicsemi.no>