### PR TITLE
applications: asset_tracker_v2: Do not reboot on sensor init failure.

### DIFF
--- a/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.h
+++ b/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.h
@@ -28,6 +28,11 @@ extern "C" {
 /** @brief Enum containing callback events from library. */
 enum ext_sensor_evt_type {
 	EXT_SENSOR_EVT_ACCELEROMETER_TRIGGER,
+
+	/** Events propagated when an error associated with a sensor device occurs. */
+	EXT_SENSOR_EVT_ACCELEROMETER_ERROR,
+	EXT_SENSOR_EVT_TEMPERATURE_ERROR,
+	EXT_SENSOR_EVT_HUMIDITY_ERROR
 };
 
 /** @brief Structure containing external sensor data. */


### PR DESCRIPTION
Failing to initialize external sensors should not be considered a
irrecoverable error that should be rebooted on.

This patch removes functionality that returns error upon sensor
initialization errors and adds callbacks to the ext_sensors library to
signal the sensor module which sensor that failed initialization.
Future improvement is to send a message to cloud in case issues with
external sensors occurs.

Closes CIA-324