### PR TITLE
lib: dk_buttons_and_leds: Get button state during dk_buttons_init()

### DIFF
--- a/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
+++ b/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
@@ -299,6 +299,8 @@ int dk_buttons_init(button_handler_t button_handler)
 
 	dk_read_buttons(NULL, NULL);
 
+	atomic_set(&my_buttons, (atomic_val_t)get_buttons());
+
 	return 0;
 }
 


### PR DESCRIPTION
Currently failing usecase - when button is pressed and hold when device is starting, application don't get correct button state when `dk_get_buttons()` is called right after the `dk_buttons_init()`

This commit changes `dk_buttons_init()` so the button state can be read by the application immediately after the `dk_buttons_init()` is called. When changed this way, it allows to read the button state and doesn't change the `button_handler` behavior.