### PR TITLE
manifest: Point to mcuboot PR for signature validation

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.7.0-ncs1-rc1
+      revision: db700bfa11e8272a04c034ae9659973c4057eee6
       path: bootloader/mcuboot
     - name: nrfxlib
       repo-path: sdk-nrfxlib


### PR DESCRIPTION
-Points to mcuboot PR which fixed signature validation
 issue when used with external crypto.

mcuboot PR: [pull/154](https://github.com/nrfconnect/sdk-mcuboot/pull/154)
Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>