### PR TITLE
.github: oss-history: install pygit2 from wheel only

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Install extra python dependencies
         run: |
           pip3 install west
+          pip3 install --only-binary :all: pygit2
           pip3 install -r ncs/nrf/scripts/requirements-extra.txt
 
       - name: Set up the workspace


### PR DESCRIPTION
The CI environment does not have libgit2 development headers required
for building the pygit2 package from source. Make sure it's installed
via wheel by manually installing it with '--only-binary :all:'.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>