### PR TITLE
Introduce device configuration 254 handling

### DIFF
--- a/subsys/mpsl/Kconfig.fem
+++ b/subsys/mpsl/Kconfig.fem
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 - 2020 Nordic Semiconductor ASA
+# Copyright (c) 2019 - 2021 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -73,3 +73,13 @@ config MPSL_FEM_NRF21540_RX_GAIN_DB
 endif
 
 endif	# MPSL_FEM
+
+config MPSL_FEM_DEVICE_CONFIG_254
+	bool "Apply device configuration 254"
+	default MPSL_FEM
+	help
+	  Device configuration 254 may be required to conform to the requirements
+	  in section TP/154/PHY24/TRANSMIT-05 of the ZigBee IEEE 802.15.4 Test
+	  Specification, especially when an external PA is present.
+	  Device configuration 254 may be required to improve RX blocking,
+	  especially when an external LNA is present.

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -12,6 +12,7 @@
 #include <mpsl.h>
 #include <mpsl_timeslot.h>
 #include <mpsl/mpsl_assert.h>
+#include "mpsl_fem_config_common.h"
 #include "mpsl_fem_internal.h"
 #include "multithreading_lock.h"
 #if defined(CONFIG_NRFX_DPPI)
@@ -170,6 +171,9 @@ static int mpsl_lib_init(const struct device *dev)
 	if (err) {
 		return err;
 	}
+
+	mpsl_fem_device_config_254_apply_set(
+		IS_ENABLED(CONFIG_MPSL_FEM_DEVICE_CONFIG_254));
 
 #if MPSL_TIMESLOT_SESSION_COUNT > 0
 	err = mpsl_timeslot_session_count_set((void *) timeslot_context,

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: e47d05deb577d45c3c2ea9d53958073f4246123c
+      revision: 9c07ac14d4666030ad70d88ea8f830bbb3f0d99d
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Device configuration 254 is required to conform to the requirements in section TP/154/PHY24/TRANSMIT-05 of the ZigBee IEEE 802.15.4 Test Specification. This configuration shall be applied by default, unless overridden by the user.