### PR TITLE
applications: pelion_client: Factory reset button

### DIFF
--- a/applications/pelion_client/src/modules/Kconfig.factory_reset_request
+++ b/applications/pelion_client/src/modules/Kconfig.factory_reset_request
@@ -13,6 +13,17 @@ config PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE
 	  Enable module that generates initialization event with
 	  factory reset request.
 
+if PELION_CLIENT_FACTORY_RESET_REQUEST_ENABLE
+
+config PELION_CLIENT_FACTORY_RESET_REQUEST_BUTTON
+	hex "Key ID of button used to request factory reset"
+	range 0x0000 0xffff
+	default 0x0000
+	help
+	  Button that will trigger a factory reset when held during the board
+	  boot-up. Factory reset will erase any stored Pelion and Network
+	  data. It will also re-provision the device.
+
 config PELION_CLIENT_FACTORY_RESET_REQUEST_DELAY
 	int "Time in miliseconds to wait for button event at initialization"
 	default 50
@@ -20,5 +31,7 @@ config PELION_CLIENT_FACTORY_RESET_REQUEST_DELAY
 	  The time to wait for button event when the module is initialized.
 	  The time should be long enough for the button module to react
 	  for the button that is pressed during initialization.
+
+endif
 
 endmenu

--- a/applications/pelion_client/src/modules/factory_reset_request.c
+++ b/applications/pelion_client/src/modules/factory_reset_request.c
@@ -26,7 +26,11 @@ static bool event_handler(const struct event_header *eh)
 	if (is_button_event(eh)) {
 		struct button_event *event = cast_button_event(eh);
 
-		if (k_work_delayable_is_pending(&init_work) &&  event->pressed) {
+		if (event->key_id != CONFIG_PELION_CLIENT_FACTORY_RESET_REQUEST_BUTTON) {
+			return false;
+		}
+
+		if (k_work_delayable_is_pending(&init_work) && event->pressed) {
 			EVENT_SUBMIT(new_factory_reset_event());
 		}
 		return false;


### PR DESCRIPTION
Assign factory reset request to a specific button.
This is to avoid nrf91 switches to trigger the reset.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>