### PR TITLE
manifest: update reference for sdk-zephyr: adding NCS path for mbedcrypto in TF-M

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 540567aae240ec80501743ddea354029dca831a4
+      revision: 625b8b0bd247496f1f75868c907c0adb1e0db661
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update manifest pointer for sdk-zephyr, to
incorporate adding the custom (NCS) variant
of mbedtls into the builds with TF-M.

This only affects TF-M builds.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>