### PR TITLE
[manifest] bring uart deadlock fix ncs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 540567aae240ec80501743ddea354029dca831a4
+      revision: pull/537/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Cherry-picked uart fix by krch-nordic to fix Thread CoAP sample SED mode
deadlock issue.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>