### PR TITLE
manifest: update TF-M module for ChachaPoly

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -107,7 +107,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
-      revision: 974a728ecafba94db804dc146c5e38afab51ccf4
+      revision: b53b5d53b6f0b9004ebc27d1997c1a7608e321d5
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Update the pointer to the NCS TF-M module repository.
This enabled by default Chacha20, Poly1305 and ChachaPoly
configuration options in TF-M (default and profile
configurations).

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>