### PR TITLE
manifest: Bluetooth changes for v1.6.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 625b8b0bd247496f1f75868c907c0adb1e0db661
+      revision: ff72dde38d4215a10ce424bfe892001d54af4fc2
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls in changes to the upstream Bluetooth subsystem that need to be
included for nRF Connect SDK v1.6.0.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>