### PR TITLE
lib: zigbee_shell: Use correct LOG_LEVEL

### DIFF
--- a/subsys/zigbee/cli/zigbee_cli_cmd_zdo.c
+++ b/subsys/zigbee/cli/zigbee_cli_cmd_zdo.c
@@ -77,7 +77,7 @@
 /* Defines how long to wait, in seconds, for mgmt_leave response. */
 #define ZIGBEE_CLI_MGMT_LEAVE_RESP_TIMEOUT 5
 
-LOG_MODULE_DECLARE(cli);
+LOG_MODULE_DECLARE(cli, CONFIG_ZIGBEE_SHELL_LOG_LEVEL);
 
 
 /* Forward declarations. */


### PR DESCRIPTION
This commit changes log level used in zigbee_cli_cmd_zdo.c to CONFIG_ZIGBEE_SHELL_LOG_LEVEL

Signed-off-by: Sebastian Draus <sebastian.draus@nordicsemi.no>