### PR TITLE
west.yml: remove tensorflow from zephyr allowlist

### DIFF
--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -487,4 +487,5 @@ _BLOCKED_PROJECTS = set(
      'modules/hal/stm32',
      'modules/hal/ti',
      'modules/hal/xtensa',
+     'modules/lib/tensorflow',
      ])

--- a/west.yml
+++ b/west.yml
@@ -87,7 +87,6 @@ manifest:
           - open-amp
           - openthread
           - segger
-          - tensorflow
           - tinycbor
           - tinycrypt
           - TraceRecorderSource


### PR DESCRIPTION
This was left in the manifest, but we did not mean to include it in
the last upmerge. It's a large download that is not relevant to our
distribution, so remove it from the allowlist and add it to the
blocklist in ncs_commands.py.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>