### PR TITLE
Bluetooth: Mesh: Pull k_work_delayable from k_work using API

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -506,8 +506,9 @@ static void ctrl_disable(struct bt_mesh_light_ctrl_srv *srv)
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
 static void reg_step(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct bt_mesh_light_ctrl_srv *srv = CONTAINER_OF(
-		work, struct bt_mesh_light_ctrl_srv, reg.timer.work);
+		dwork, struct bt_mesh_light_ctrl_srv, reg.timer);
 
 	if (!is_enabled(srv)) {
 		/* The server might be disabled asynchronously. */
@@ -574,8 +575,9 @@ static void reg_step(struct k_work *work)
 
 static void timeout(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct bt_mesh_light_ctrl_srv *srv =
-		CONTAINER_OF(work, struct bt_mesh_light_ctrl_srv, timer.work);
+		CONTAINER_OF(dwork, struct bt_mesh_light_ctrl_srv, timer);
 
 	if (!is_enabled(srv)) {
 		return;
@@ -639,8 +641,9 @@ static void timeout(struct k_work *work)
 
 static void delayed_action_timeout(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct bt_mesh_light_ctrl_srv *srv = CONTAINER_OF(
-		work, struct bt_mesh_light_ctrl_srv, action_delay.work);
+		dwork, struct bt_mesh_light_ctrl_srv, action_delay);
 	struct bt_mesh_model_transition transition = {
 		.time = srv->fade.duration
 	};
@@ -665,8 +668,9 @@ static void delayed_action_timeout(struct k_work *work)
 #if CONFIG_BT_SETTINGS
 static void store_timeout(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct bt_mesh_light_ctrl_srv *srv = CONTAINER_OF(
-		work, struct bt_mesh_light_ctrl_srv, store_timer.work);
+		dwork, struct bt_mesh_light_ctrl_srv, store_timer);
 	int err;
 
 	if (atomic_test_and_clear_bit(&srv->flags, FLAG_STORE_CFG)) {

--- a/subsys/bluetooth/mesh/scheduler_srv.c
+++ b/subsys/bluetooth/mesh/scheduler_srv.c
@@ -435,7 +435,8 @@ static void schedule_action(struct bt_mesh_scheduler_srv *srv,
 
 static void scheduled_action_handle(struct k_work *work)
 {
-	struct bt_mesh_scheduler_srv *srv = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_mesh_scheduler_srv *srv = CONTAINER_OF(dwork,
 				struct bt_mesh_scheduler_srv,
 				delayed_work);
 


### PR DESCRIPTION
Use k_work_delayable_from_work() to pull k_work_delayable from k_work.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>