### PR TITLE
caf: events: Add documentation for module state event

### DIFF
--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -789,7 +789,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = @NRF_BASE@/applications/connectivity_bridge/src/events/module_state_event.h
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -1985,7 +1985,9 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
 			 "CONFIG_LWM2M_CLIENT_UTILS_FIRMWARE_UPDATE_OBJ_SUPPORT=y" \
 			 "CONFIG_LWM2M_CLIENT_UTILS_CONN_MON_OBJ_SUPPORT=y" \
 			 "CONFIG_LWM2M_CLIENT_UTILS_DEVICE_OBJ_SUPPORT=y" \
-			 "CONFIG_LWM2M_CLIENT_UTILS_SECURITY_OBJ_SUPPORT=y"
+			 "CONFIG_LWM2M_CLIENT_UTILS_SECURITY_OBJ_SUPPORT=y"\
+                         "ATOMIC_DEFINE(x, y)=atomic_t x[ATOMIC_BITMAP_SIZE(y)]"
+
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/caf/caf_overview.rst
+++ b/include/caf/caf_overview.rst
@@ -156,6 +156,10 @@ CAF module state events
 | Header file: :file:`include/caf/events/module_state_event.h`
 | Source file: :file:`subsys/caf/events/module_state_event.c`
 
+.. doxygengroup:: caf_module_state_event
+   :project: nrf
+   :members:
+
 CAF power events
 ================
 

--- a/include/caf/events/module_state_event.h
+++ b/include/caf/events/module_state_event.h
@@ -8,9 +8,10 @@
 #define _MODULE_STATE_EVENT_H_
 
 /**
- * @brief Module Event
- * @defgroup module_state_event Module State Event
+ * @file
+ * @defgroup caf_module_state_event CAF Module State Event
  * @{
+ * @brief CAF Module State Event.
  */
 
 #include <sys/atomic.h>
@@ -33,11 +34,23 @@ extern const void * const MODULE_ID_LIST_START;
 extern const void * const MODULE_ID_LIST_STOP;
 
 
+/**
+ * @brief Get number of modules.
+ *
+ * @return Number of modules.
+ */
 static inline size_t module_count(void)
 {
 	return (&MODULE_ID_LIST_STOP - &MODULE_ID_LIST_START);
 }
 
+/**
+ * @brief Get ID of module with given index.
+ *
+ * @param[in] idx Index of the module.
+ *
+ * @return Module ID.
+ */
 static inline const void * const module_id_get(size_t idx)
 {
 	if (idx >= module_count()) {
@@ -46,24 +59,33 @@ static inline const void * const module_id_get(size_t idx)
 	return *((&MODULE_ID_LIST_START) + idx);
 }
 
+/** @brief Get index of module.
+ *
+ * For example, the MODULE_IDX(buttons) can be used to get module index of module named buttons.
+ *
+ * @param[in] mname Name of the module.
+ *
+ * @return Index of the module.
+ */
 #define MODULE_IDX(mname) ({                                        \
 		MODULE_ID_PTR_VAR_EXTERN_DEC(mname);                \
 		&MODULE_ID_PTR_VAR(mname) - &MODULE_ID_LIST_START;  \
 	})
 
 /**
- * @brief Structure that provides a flag for every module
+ * @brief Structure that provides a flag for every module available in application.
  */
 struct module_flags {
 	ATOMIC_DEFINE(f, CONFIG_CAF_MODULES_FLAGS_COUNT);
 };
 
 /**
- * @brief Check if given module index is valid
+ * @brief Check if given module index is valid.
  *
- * @param module_idx The index to check
- * @retval true index is valid
- * @retval false index is out of valid range
+ * @param[in] module_idx The index to check.
+ *
+ * @retval true  Index is valid.
+ * @retval false Index is out of valid range.
  */
 static inline bool module_check_id_valid(size_t module_idx)
 {
@@ -73,9 +95,10 @@ static inline bool module_check_id_valid(size_t module_idx)
 /**
  * @brief Check if there is 0 in all the flags
  *
- * @param mf     Pointer to modules flags variable
- * @retval true  All the flags have value of 0
- * @retval false Any of the flags is not 0
+ * @param[in] mf Pointer to module flags variable.
+ *
+ * @retval true  All the flags have value of 0.
+ * @retval false Any of the flags is not 0.
  */
 static inline bool module_flags_check_zero(const struct module_flags *mf)
 {
@@ -90,12 +113,13 @@ static inline bool module_flags_check_zero(const struct module_flags *mf)
 }
 
 /**
- * @brief Test single module bit
+ * @brief Test single module bit.
  *
- * @param mf         Pointer to modules flags variable
- * @param module_idx The index of the module whose bit should be tested
- * @retval true  The module bit in flags is set
- * @retval false The module bit in flags is cleared
+ * @param[in] mf         Pointer to module flags variable.
+ * @param[in] module_idx The index of the selected module.
+ *
+ * @retval true  The module bit in flags is set.
+ * @retval false The module bit in flags is cleared.
  */
 static inline bool module_flags_test_bit(const struct module_flags *mf, size_t module_idx)
 {
@@ -105,8 +129,8 @@ static inline bool module_flags_test_bit(const struct module_flags *mf, size_t m
 /**
  * @brief Clear single module bit
  *
- * @param mf         Pointer to modules flags variable
- * @param module_idx The index of the module whose bit should be cleared
+ * @param[in,out] mf		Pointer to module flags variable.
+ * @param[in] module_idx	The index of the selected module.
  */
 static inline void module_flags_clear_bit(struct module_flags *mf, size_t module_idx)
 {
@@ -114,10 +138,10 @@ static inline void module_flags_clear_bit(struct module_flags *mf, size_t module
 }
 
 /**
- * @brief Set single module bit
+ * @brief Set single module bit.
  *
- * @param mf         Pointer to modules flags variable
- * @param module_idx The index of the module whose bit should be set
+ * @param[in,out] mf		Pointer to module flags variable.
+ * @param[in] module_idx	The index of the selected module.
  */
 static inline void module_flags_set_bit(struct module_flags *mf, size_t module_idx)
 {
@@ -127,42 +151,83 @@ static inline void module_flags_set_bit(struct module_flags *mf, size_t module_i
 /**
  * @brief Set single module bit to specified value
  *
- * @param mf         Pointer to module flags variable
- * @param module_idx The index of the module whose bit should be set
- * @param val        The value whose should be set in a specified modules bit
+ * @param[in,out] mf		Pointer to module flags variable.
+ * @param[in] module_idx	The index of the selected module.
+ * @param[in] val		The value to be set in a specified module's bit.
  */
 static inline void module_flags_set_bit_to(struct module_flags *mf, size_t module_idx, bool val)
 {
 	atomic_set_bit_to(mf->f, module_idx, val);
 }
 
-/** Module state list. */
-#define MODULE_STATE_LIST	\
-	X(READY)		\
-	X(OFF)			\
-	X(STANDBY)		\
-	X(ERROR)
-
 /** Module states. */
 enum module_state {
-#define X(name) _CONCAT(MODULE_STATE_, name),
-	MODULE_STATE_LIST
-#undef X
+	/** Module is active. This state is reported when the module is initialized or woken up
+	 *  after suspending.
+	 */
+	MODULE_STATE_READY,
 
+	/** Module is suspended in reaction to @ref power_down_event. The module cannot submit
+	 *  @ref wake_up_event.
+	 */
+	MODULE_STATE_OFF,
+
+	/** Module is suspended in reaction to @ref power_down_event. The module can submit
+	 *  @ref wake_up_event.
+	 */
+	MODULE_STATE_STANDBY,
+
+	/** Module reported fatal error. */
+	MODULE_STATE_ERROR,
+
+	/** Number of module states. */
 	MODULE_STATE_COUNT
 };
 
-/** Module event. */
+/** @brief Module state event.
+ *
+ * The module state event is submitted by a module to inform that state of the module changed.
+ * The @ref module_set_state can be used to submit the module state event for a module.
+ * The @ref check_state can be used in event_handler to check if the event carries information that
+ * selected module reported selected state. See @ref module_state for details about available
+ * module states.
+ *
+ * Name of the module must be defined as MODULE before including the module_state_event.h header.
+ * For example, "#define MODULE buttons" defines name of the module as buttons. The module name is
+ * used to identify a module.
+ *
+ * Every application module must register for module state event and submit this event when state
+ * of the module changes. An application module can initialize itself when all the required
+ * application modules are initialized (report MODULE_STATE_READY). This ensures proper
+ * initialization order of the application modules.
+ */
 struct module_state_event {
+	/** Event header. */
 	struct event_header header;
 
+	/** ID of the module. */
 	const void *module_id;
+
+	/** New state of the module. */
 	enum module_state state;
 };
 
 EVENT_TYPE_DECLARE(module_state_event);
 
 
+/** @brief Check if the selected module reported the selected state.
+ *
+ * The function can be used in event handler to verify if received module state event informs that
+ * selected module reported selected state. The @ref MODULE_ID can be used to get module ID of
+ * module with selected name.
+ *
+ * @param[in] event		Poitner to handled module state event.
+ * @param[in] module_id		ID of the selected module.
+ * @param[in] state		Selected module state.
+ *
+ * @retval true  The module state event informs that selected module reported selected state.
+ *		 Otherwise, false is returned.
+ */
 static inline bool check_state(const struct module_state_event *event,
 		const void *module_id, enum module_state state)
 {
@@ -173,6 +238,14 @@ static inline bool check_state(const struct module_state_event *event,
 }
 
 
+/** @brief Get module ID.
+ *
+ * For example, the MODULE_ID(buttons) can be used to get module ID of module named buttons.
+ *
+ * @param[in] mname Name of the module.
+ *
+ * @return ID of the module.
+ */
 #define MODULE_ID(mname) ({                                  \
 			MODULE_ID_PTR_VAR_EXTERN_DEC(mname); \
 			MODULE_ID_PTR_VAR(mname);            \
@@ -183,9 +256,6 @@ static inline bool check_state(const struct module_state_event *event,
 }
 #endif
 
-/**
- * @}
- */
 #endif /* _MODULE_STATE_EVENT_H_ */
 
 /* Declare elements required in the module C file,
@@ -205,6 +275,12 @@ const void * const MODULE_ID_PTR_VAR(MODULE)
 	= MODULE_NAME;
 
 
+/** @brief Submit module state event to inform that state of the module changed.
+ *
+ * ID of the module is automatically assigned based on name that is defined as MODULE.
+ *
+ * @param[in] state New state of the module.
+ */
 static inline void module_set_state(enum module_state state)
 {
 	__ASSERT_NO_MSG(state < MODULE_STATE_COUNT);
@@ -221,3 +297,7 @@ static inline void module_set_state(enum module_state state)
 #endif
 
 #endif /* defined(MODULE) && !defined(MODULE_NAME) */
+
+/**
+ * @}
+ */

--- a/subsys/caf/events/module_state_event.c
+++ b/subsys/caf/events/module_state_event.c
@@ -12,9 +12,10 @@
 
 
 static const char * const state_name[] = {
-#define X(name) STRINGIFY(name),
-	MODULE_STATE_LIST
-#undef X
+	[MODULE_STATE_READY] = "READY",
+	[MODULE_STATE_OFF] = "OFF",
+	[MODULE_STATE_STANDBY] = "STANDBY",
+	[MODULE_STATE_ERROR] = "ERROR",
 };
 
 static int log_module_state_event(const struct event_header *eh, char *buf,
@@ -23,9 +24,10 @@ static int log_module_state_event(const struct event_header *eh, char *buf,
 	const struct module_state_event *event = cast_module_state_event(eh);
 
 	BUILD_ASSERT(ARRAY_SIZE(state_name) == MODULE_STATE_COUNT,
-			 "Invalid number of elements");
+		     "Invalid number of elements");
 
 	__ASSERT_NO_MSG(event->state < MODULE_STATE_COUNT);
+	__ASSERT_NO_MSG(state_name[event->state] != NULL);
 
 	return snprintf(buf, buf_len, "module:%s state:%s",
 		      (const char *)event->module_id, state_name[event->state]);


### PR DESCRIPTION
Change adds doxygen documentation for module state event.

Jira: NCSDK-9551