### PR TITLE
doc: openthread: add documentation regarding Link Metrics and CSL

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -137,6 +137,16 @@ Matter (Project CHIP)
 
   * Renamed occurrences of Project CHIP to Matter.
 
+Thread
+------
+
+* Added support for the following Thread 1.2 features:
+
+  * Link Metrics
+  * Coordinated Sampled Listening (CSL)
+
+  These features are supported for nRF52 Series devices.
+
 Zigbee
 ------
 

--- a/doc/nrf/ug_thread_configuring.rst
+++ b/doc/nrf/ug_thread_configuring.rst
@@ -138,6 +138,7 @@ Moreover, Thread 1.2 also comes with the following features that are supported f
 * Domain Unicast Addresses - Set :option:`CONFIG_OPENTHREAD_DUA` to enable this feature.
 * Multicast Listener Registration - Set :option:`CONFIG_OPENTHREAD_MLR` to enable this feature.
 * Backbone Router - Set :option:`CONFIG_OPENTHREAD_BACKBONE_ROUTER` to enable this feature.
+* Link Metrics - Set :option:`CONFIG_OPENTHREAD_LINK_METRICS` to enable this feature.
 
 .. note::
     To test Thread 1.2 options, you can use the :ref:`ot_cli_sample` sample with the :ref:`ot_cli_sample_thread_v12`.

--- a/doc/nrf/ug_thread_configuring.rst
+++ b/doc/nrf/ug_thread_configuring.rst
@@ -139,9 +139,14 @@ Moreover, Thread 1.2 also comes with the following features that are supported f
 * Multicast Listener Registration - Set :option:`CONFIG_OPENTHREAD_MLR` to enable this feature.
 * Backbone Router - Set :option:`CONFIG_OPENTHREAD_BACKBONE_ROUTER` to enable this feature.
 * Link Metrics - Set :option:`CONFIG_OPENTHREAD_LINK_METRICS` to enable this feature.
+* Coordinated Sampled Listening (CSL) Receiver - Set :option:`CONFIG_OPENTHREAD_CSL_RECEIVER` to enable this feature.
 
 .. note::
-    To test Thread 1.2 options, you can use the :ref:`ot_cli_sample` sample with the :ref:`ot_cli_sample_thread_v12`.
+   The Link Metrics and Coordinated Sampled Listening features are not supported for nRF53 Series devices yet.
+
+To test Thread 1.2 options, you can use the :ref:`ot_cli_sample` sample with the :ref:`ot_cli_sample_thread_v12`.
+
+
 
 Thread commissioning options
 ============================

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -291,7 +291,7 @@ To test the Thread 1.2 features, complete the following steps:
 
       uart:~$ ot prefix add fd00:7d03:7d03:7d03::/64 prosD med
       Done
-      uart:~$ ot netdataregister
+      uart:~$ ot netdata register
       Done
       I: State changed! Flags: 0x00000200 Current role: 4
       I: State changed! Flags: 0x00001001 Current role: 4
@@ -338,6 +338,91 @@ To test the Thread 1.2 features, complete the following steps:
 
    .. note::
         The DUA registration with the Backbone Router is not yet supported.
+
+#. On the leader kit, list the IPv6 addresses:
+
+   .. code-block:: console
+
+      uart:~$ ot ipaddr
+      fd00:7d03:7d03:7d03:84c9:572d:be24:cbe
+      fdde:ad00:beef:0:0:ff:fe00:fc10
+      fdde:ad00:beef:0:0:ff:fe00:fc38
+      fdde:ad00:beef:0:0:ff:fe00:fc00
+      fdde:ad00:beef:0:0:ff:fe00:7000
+      fdde:ad00:beef:0:a318:bf4f:b9c6:5f7d
+      fe80:0:0:0:10b1:93ea:c0ee:eeb7
+
+#. Note down the link-local address.
+   You must use this address when running Link Metrics commands on the router kit.
+
+   The following steps use the address ``fe80:0:0:0:10b1:93ea:c0ee:eeb7``.
+   Replace it with the link-local address of your leader kit in all commands.
+
+#. Run the following commands on the router kit:
+
+   a. Reattach the router kit as SED:
+
+      .. code-block:: console
+
+         uart:~$ ot mode -
+         Done
+
+   #. Perform a Link Metrics query (Single Probe):
+
+      .. code-block:: console
+
+         uart:~$ ot linkmetrics query fe80:0:0:0:10b1:93ea:c0ee:eeb7 single qmr
+         Done
+         Received Link Metrics Report from: fe80:0:0:0:10b1:93ea:c0ee:eeb7
+         - LQI: 220 (Exponential Moving Average)
+         - Margin: 60 (dB) (Exponential Moving Average)
+         - RSSI: -40 (dBm) (Exponential Moving Average)
+
+   #. Send a Link Metrics Management Request to configure a Forward Tracking Series:
+
+      .. code-block:: console
+
+         uart:~$ ot linkmetrics mgmt fe80:0:0:0:10b1:93ea:c0ee:eeb7 forward 1 dra pqmr
+         Done
+         Received Link Metrics Management Response from: fe80:0:0:0:10b1:93ea:c0ee:eeb7
+         Status: Success
+
+   #. Send an MLE Link Probe message to the peer:
+
+      .. code-block:: console
+
+         uart:~$ ot linkmetrics probe fe80:0:0:0:10b1:93ea:c0ee:eeb7 1 10
+         Done
+
+   #. Perform a Link Metrics query (Forward Tracking Series):
+
+      .. code-block:: console
+
+         uart:~$ ot linkmetrics query fe80:0:0:0:10b1:93ea:c0ee:eeb7 forward 1
+         Done
+         Received Link Metrics Report from: fe80:0:0:0:10b1:93ea:c0ee:eeb7
+         - PDU Counter: 13 (Count/Summation)
+         - LQI: 212 (Exponential Moving Average)
+         - Margin: 60 (dB) (Exponential Moving Average)
+         - RSSI: -40 (dBm) (Exponential Moving Average)
+
+   #. Send a Link Metrics Management Request to register an Enhanced-ACK Based Probing:
+
+      .. code-block:: console
+
+         uart:~$ ot linkmetrics mgmt fe80:0:0:0:10b1:93ea:c0ee:eeb7 enhanced-ack register qm
+         Done
+         Received Link Metrics Management Response from: fe80:0:0:0:10b1:93ea:c0ee:eeb7
+         Status: Success
+
+   #. Send a Link Metrics Management Request to clear an Enhanced-ACK Based Probing:
+
+      .. code-block:: console
+
+         uart:~$ ot linkmetrics mgmt fe80:0:0:0:10b1:93ea:c0ee:eeb7 enhanced-ack clear
+         Done
+         Received Link Metrics Management Response from: fe80:0:0:0:10b1:93ea:c0ee:eeb7
+         Status: Success
 
 Dependencies
 ************

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -333,11 +333,8 @@ To test the Thread 1.2 features, complete the following steps:
       ff03:0:0:0:0:0:0:fc
       Done
 
-   The router kit will send an ``MLR.req`` message to the leader kit (Backbone Router).
+   The router kit will send an ``MLR.req`` message and a ``DUA.req`` message to the leader kit (Backbone Router).
    This can be observed using the `nRF Sniffer for 802.15.4`_.
-
-   .. note::
-        The DUA registration with the Backbone Router is not yet supported.
 
 #. On the leader kit, list the IPv6 addresses:
 
@@ -352,18 +349,20 @@ To test the Thread 1.2 features, complete the following steps:
       fdde:ad00:beef:0:a318:bf4f:b9c6:5f7d
       fe80:0:0:0:10b1:93ea:c0ee:eeb7
 
-#. Note down the link-local address.
-   You must use this address when running Link Metrics commands on the router kit.
+   Note down the link-local address.
+   You must use this address when sending Link Metrics commands from the router kit to the leader kit.
 
    The following steps use the address ``fe80:0:0:0:10b1:93ea:c0ee:eeb7``.
    Replace it with the link-local address of your leader kit in all commands.
 
 #. Run the following commands on the router kit:
 
-   a. Reattach the router kit as SED:
+   a. Reattach the router kit as SED with a polling period of 3 seconds:
 
       .. code-block:: console
 
+         uart:~$ ot pollperiod 3000
+         Done
          uart:~$ ot mode -
          Done
 
@@ -406,7 +405,7 @@ To test the Thread 1.2 features, complete the following steps:
          - Margin: 60 (dB) (Exponential Moving Average)
          - RSSI: -40 (dBm) (Exponential Moving Average)
 
-   #. Send a Link Metrics Management Request to register an Enhanced-ACK Based Probing:
+   #. Send a Link Metrics Management Request to register an Enhanced ACK-based Probing:
 
       .. code-block:: console
 
@@ -415,7 +414,7 @@ To test the Thread 1.2 features, complete the following steps:
          Received Link Metrics Management Response from: fe80:0:0:0:10b1:93ea:c0ee:eeb7
          Status: Success
 
-   #. Send a Link Metrics Management Request to clear an Enhanced-ACK Based Probing:
+   #. Send a Link Metrics Management Request to clear an Enhanced ACK-based Probing:
 
       .. code-block:: console
 
@@ -423,6 +422,43 @@ To test the Thread 1.2 features, complete the following steps:
          Done
          Received Link Metrics Management Response from: fe80:0:0:0:10b1:93ea:c0ee:eeb7
          Status: Success
+
+#. Verify the Coordinated Sampled Listening (CSL) functionality.
+
+   The following steps use the address ``fe80:0:0:0:acbd:53bf:1461:a861``.
+   Replace it with the link-local address of your router kit in all commands.
+
+   a. Send an ICMPv6 Echo Request from the leader kit to link-local address of the router kit:
+
+      .. code-block:: console
+
+         uart:~$ ot ping fe80:0:0:0:acbd:53bf:1461:a861
+         16 bytes from fe80:0:0:0:acbd:53bf:1461:a861: icmp_seq=2 hlim=64 time=2494ms
+         1 packets transmitted, 1 packets received. Packet loss = 0.0%. Round-trip min/a
+         Done
+
+      Observe that there is a long latency on the reply of up to 3000 ms.
+      This is due to the indirect transmission mechanism based on data polling.
+
+   #. Enable a CSL Receiver on the router kit (now SED) by configuring a CSL period of 0.5 seconds:
+
+      .. code-block:: console
+
+         uart:~$ ot csl period 3125
+         Done
+
+   #. Send an ICMPv6 Echo Request from the leader kit to the link-local address of the router kit:
+
+      .. code-block:: console
+
+         uart:~$ ot ping fe80:0:0:0:acbd:53bf:1461:a861
+         uart:~$ W: TX_STARTED event will be triggered without delay
+         16 bytes from fe80:0:0:0:acbd:53bf:1461:a861: icmp_seq=3 hlim=64 time=421ms
+         1 packets transmitted, 1 packets received. Packet loss = 0.0%. Round-trip min/a
+         Done
+
+      Observe that the reply latency is reduced to a value below 500 ms.
+      The reduction occurs because the transmission from the leader is performed via CSL, based on the CSL Information Elements sent by the CSL Receiver.
 
 Dependencies
 ************


### PR DESCRIPTION
Extend Thread 1.2 Specification options section and decsribe new use
cases for CLI sample.

It's bloked by:

- [x] https://github.com/nrfconnect/sdk-nrf/pull/4694