### PR TITLE
doc: open NCS abbreviations

### DIFF
--- a/doc/nrf/app_bootloaders.rst
+++ b/doc/nrf/app_bootloaders.rst
@@ -40,7 +40,7 @@ You can find an overview of currently supported bootloaders in the table below:
      - SMP updates
      - Downgrade protection
      - Versioning
-     - Update methods (supported by NCS)
+     - Update methods (supported by |NCS|)
    * - :ref:`bootloader`
      - Yes
      - No

--- a/doc/nrf/app_power_opt.rst
+++ b/doc/nrf/app_power_opt.rst
@@ -170,7 +170,7 @@ To simulate the use case with Online Power Profiler, complete the following step
 #. Export the settings from the Online Power Profiler tool and compare them with the measurements in real networks. Complete the following sub-steps to export the settings from Online Power Profiler:
 
    a. Click :guilabel:`Export settings` to store current Online Power Profiler settings to a :file:`.json` file.
-   #. Click :guilabel:`Export NCS project config` to export the configuration parameters in a :file:`opp.conf` file that you can use when building the firmware.
+   #. Click :guilabel:`Export project config` to export the configuration parameters in a :file:`opp.conf` file that you can use when building the firmware.
 
 Real-time power measurement using Power Profiler Kit II
 -------------------------------------------------------

--- a/doc/nrf/dm_adding_code.rst
+++ b/doc/nrf/dm_adding_code.rst
@@ -109,7 +109,7 @@ For example:
 .. code-block:: yaml
 
    # Example your-application/west.yml, using manifest imports, with
-   # an NCS fork and a separate module
+   # an nRF Connect SDK fork and a separate module
    manifest:
      remotes:
        - name: ncs
@@ -121,11 +121,11 @@ For example:
          remote: ncs
          revision: v1.5.1
          import: true
-       # Example for how to override a repository in the NCS with your own:
+       # Example for how to override a repository in the nRF Connect SDK with your own:
        - name: mcuboot
          remote: your-remote
          revision: your-mcuboot-fork-SHA-or-branch
-       # Example for how to add a repository not in NCS:
+       # Example for how to add a repository not in nRF Connect SDK:
        - name: your-custom-library
          remote: your-remote
          revision: your-library-SHA-or-branch

--- a/doc/nrf/dm_managing_code.rst
+++ b/doc/nrf/dm_managing_code.rst
@@ -36,7 +36,7 @@ Replace ``{revision}`` with any revision you wish to obtain.
 This can be ``master`` if you want the latest state, or any released version (e.g. |release_tt|).
 If you omit the ``--mr`` parameter, west defaults to ``master``.
 
-This is the procedure used for :ref:`getting the |NCS| code <cloning_the_repositories>` when :ref:`gs_installing`.
+This is the procedure used for :ref:`getting the nRF Connect SDK code <cloning_the_repositories>` when :ref:`gs_installing`.
 
 .. _dm-wf-update-ncs:
 

--- a/doc/nrf/gs_assistant.rst
+++ b/doc/nrf/gs_assistant.rst
@@ -62,16 +62,16 @@ The |NCS| version of your choice is installed on your machine, and the :guilabel
 This button lets you start SEGGER Embedded Studio if you want to start :ref:`gs_programming_ses`.
 
 .. figure:: images/gs-assistant_tm_installed.png
-   :alt: The Toolchain manager options after installing the NCS version, cropped
+   :alt: The Toolchain manager options after installing the nRF Connect SDK version, cropped
 
-   The Toolchain Manager options after installing the NCS version
+   The Toolchain Manager options after installing the |NCS| version
 
 Additionally, the dropdown menu becomes available.
 Among other options, this menu lets you open bash and command prompt that use the installed Toolchain manager tools.
 You can use the :guilabel:`Open bash` option from this menu when you start :ref:`gs_programming_cmd`.
 
 .. figure:: images/gs-assistant_tm_dropdown.png
-   :alt: The Toolchain manager dropdown menu for the installed NCS version, cropped
+   :alt: The Toolchain manager dropdown menu for the installed nRF Connect SDK version, cropped
 
    The Toolchain manager dropdown menu options
 

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -31,9 +31,9 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
    If you have installed SES manually, run :file:`bin/emStudio`.
 
    .. figure:: images/gs-assistant_tm_installed.png
-      :alt: The Toolchain Manager options after installing the NCS version, cropped
+      :alt: The Toolchain Manager options after installing the nRF Connect SDK version, cropped
 
-      The Toolchain Manager options after installing the NCS version
+      The Toolchain Manager options after installing the |NCS| version
 
 #. Select :guilabel:`File` > :guilabel:`Open nRF Connect SDK Project`.
 
@@ -149,7 +149,7 @@ Complete the following steps to build |NCS| projects on the command line after c
       If you have installed the |NCS| using the :ref:`gs_app_tcm`, click the down arrow next to the version you installed and select :guilabel:`Open bash`.
 
       .. figure:: images/gs-assistant_tm_dropdown.png
-         :alt: The Toolchain Manager dropdown menu for the installed NCS version, cropped
+         :alt: The Toolchain Manager dropdown menu for the installed nRF Connect SDK version, cropped
 
          The Toolchain Manager dropdown menu options
 


### PR DESCRIPTION
Some instances of the NCS abbreviation instead of the full nRF Connect SDK have slipped into the documentation.
This corrects those errors.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>