### PR TITLE
manifest: tf-m: update to enable non-static key labels

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -105,7 +105,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
-      revision: b9a9ba684026c9bab73ae7ddfb50daacc1138324
+      revision: bd5f6687241c5a82f52efbc51ad15e95a1f21e30
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Update TF-M module to enable non-static key labels.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>