### PR TITLE
applications: serial_lte_modem: Use NCS version as SLM version

### DIFF
--- a/applications/serial_lte_modem/prj.conf
+++ b/applications/serial_lte_modem/prj.conf
@@ -80,11 +80,10 @@ CONFIG_FCB=y
 #
 # SLM-specific configurations
 #
+CONFIG_SLM_CUSTOMIZED=n
 CONFIG_SLM_LOG_LEVEL_INF=y
-# Configure external XTAL for UART
 CONFIG_SLM_EXTERNAL_XTAL=n
-# Start up then enter sleep
-#CONFIG_SLM_START_SLEEP=y
+CONFIG_SLM_START_SLEEP=n
 # Use UART_0 (when working with PC terminal)
 CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
 CONFIG_SLM_DATAMODE_HWFC=n

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -15,6 +15,7 @@
 #include <modem/at_cmd.h>
 #include <modem/at_cmd_parser.h>
 #include <sys/reboot.h>
+#include "ncs_version.h"
 
 #include "slm_util.h"
 #include "slm_at_host.h"
@@ -74,12 +75,6 @@ void rsp_send(const uint8_t *str, size_t len);
 int poweroff_uart(void);
 bool verify_datamode_control(uint16_t time_limit, uint16_t *time_limit_min);
 
-#if defined(CONFIG_SLM_CUSTOMIZED)
-#define SLM_VERSION	"\r\n#XSLMVER: \"1.6-CUSTOMIZED\"\r\n"
-#else
-#define SLM_VERSION	"\r\n#XSLMVER: \"1.6\"\r\n"
-#endif
-
 static void modem_power_off(void)
 {
 	/*
@@ -105,7 +100,14 @@ static int handle_at_slmver(enum at_cmd_type type)
 	int ret = -EINVAL;
 
 	if (type == AT_CMD_TYPE_SET_COMMAND) {
-		rsp_send(SLM_VERSION, sizeof(SLM_VERSION) - 1);
+#if defined(CONFIG_SLM_CUSTOMIZED)
+		sprintf(rsp_buf, "\r\n#XSLMVER: %s-CUSTOMIZED\r\n",
+			STRINGIFY(NCS_VERSION_STRING));
+#else
+		sprintf(rsp_buf, "\r\n#XSLMVER: %s\r\n",
+			STRINGIFY(NCS_VERSION_STRING));
+#endif
+		rsp_send(rsp_buf, strlen(rsp_buf));
 		ret = 0;
 	}
 


### PR DESCRIPTION
Remove hardcoded version and use NCS official version instead.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>