### PR TITLE
Manifest: Bluetooth changes for v1.6

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2a96c190d98c79577dc45a9ef05c5d256f06cd4d
+      revision: pull/544/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updates manifest for sdk-zephyr to pull in Bluetooth changes for v1.6

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>