### PR TITLE
samples: openthread: Added DFU support overlay to CoAP client.

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -607,6 +607,8 @@
 
 .. _`Git`: https://git-scm.com/
 
+.. _`Go language package`: https://golang.org/doc/install
+
 .. _`reStructuredText Primer`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 
 .. _`mscgen`: http://www.mcternan.me.uk/mscgen/

--- a/samples/openthread/coap_client/overlay-dfu_support.conf
+++ b/samples/openthread/coap_client/overlay-dfu_support.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable MCUboot bootloader
+CONFIG_BOOTLOADER_MCUBOOT=y
+
+# MCU Manager and SMP configuration
+CONFIG_MCUMGR=y
+CONFIG_MCUMGR_CMD_IMG_MGMT=y
+CONFIG_MCUMGR_CMD_OS_MGMT=y
+CONFIG_MCUMGR_SMP_BT=y
+CONFIG_MCUMGR_SMP_BT_AUTHEN=n
+CONFIG_MCUMGR_BUF_COUNT=6
+
+# Increase BT MTU and RX buffer for big size DFU messages
+CONFIG_BT_L2CAP_TX_MTU=260
+CONFIG_BT_BUF_ACL_RX_SIZE=264
+
+# Reduce GAP event length to avoid heavy BLE traffic generated during DFU
+CONFIG_SDC_MAX_CONN_EVENT_LEN_DEFAULT=3000

--- a/samples/openthread/coap_client/sample.yaml
+++ b/samples/openthread/coap_client/sample.yaml
@@ -19,3 +19,10 @@ tests:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
+  samples.openthread.coap_client.multiprotocol_ble.dfu_support:
+    build_only: true
+    platform_allow: nrf52840dk_nrf52840
+    tags: ci_build
+    extra_args: OVERLAY_CONFIG=overlay-multiprotocol_ble.conf;overlay-dfu_support.conf
+    integration_platforms:
+      - nrf52840dk_nrf52840

--- a/samples/openthread/coap_client/src/ble_utils.c
+++ b/samples/openthread/coap_client/src/ble_utils.c
@@ -13,6 +13,17 @@
 
 #include "ble_utils.h"
 
+/* MCUMgr BT FOTA includes */
+#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+#include "os_mgmt/os_mgmt.h"
+#endif
+#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
+#include "img_mgmt/img_mgmt.h"
+#endif
+#ifdef CONFIG_MCUMGR_SMP_BT
+#include <mgmt/mcumgr/smp_bt.h>
+#endif
+
 LOG_MODULE_REGISTER(ble_utils, CONFIG_BLE_UTILS_LOG_LEVEL);
 
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
@@ -143,8 +154,20 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 	LOG_INF("Pairing failed conn: %s, reason %d", log_strdup(addr), reason);
 }
 
-int ble_utils_init(struct bt_nus_cb *nus_clbs,
-		   ble_connection_cb_t on_connect,
+#if defined(CONFIG_MCUMGR_SMP_BT)
+static int software_update_confirmation_handler(uint32_t offset, uint32_t size,
+						void *arg)
+{
+	/* For now just print update progress and confirm data chunk without any additional
+	 * checks.
+	 */
+	LOG_INF("Device firmware upgrade progress %d B / %d B", offset, size);
+
+	return 0;
+}
+#endif
+
+int ble_utils_init(struct bt_nus_cb *nus_clbs, ble_connection_cb_t on_connect,
 		   ble_disconnection_cb_t on_disconnect)
 {
 	int ret;
@@ -175,6 +198,14 @@ int ble_utils_init(struct bt_nus_cb *nus_clbs,
 		LOG_ERR("Failed to initialize UART service (error: %d)", ret);
 		goto end;
 	}
+
+#if defined(CONFIG_MCUMGR_SMP_BT) && defined(CONFIG_MCUMGR_CMD_IMG_MGMT) &&    \
+	defined(CONFIG_MCUMGR_CMD_OS_MGMT)
+	os_mgmt_register_group();
+	img_mgmt_register_group();
+	img_mgmt_set_upload_cb(software_update_confirmation_handler, NULL);
+	smp_bt_register();
+#endif
 
 	ret = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd,
 			      ARRAY_SIZE(sd));

--- a/samples/openthread/coap_client/src/coap_client.c
+++ b/samples/openthread/coap_client/src/coap_client.c
@@ -16,6 +16,10 @@
 #include "ble_utils.h"
 #endif
 
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+#include <dfu/mcuboot.h>
+#endif
+
 LOG_MODULE_REGISTER(coap_client, CONFIG_COAP_CLIENT_LOG_LEVEL);
 
 #define CONSOLE_LABEL DT_LABEL(DT_CHOSEN(zephyr_console))
@@ -132,6 +136,20 @@ void main(void)
 	if (IS_ENABLED(CONFIG_RAM_POWER_DOWN_LIBRARY)) {
 		power_down_unused_ram();
 	}
+
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+	/* Check if the image is run in the REVERT mode and eventually
+	 * confirm it to prevent reverting on the next boot.
+	 */
+	if (mcuboot_swap_type() == BOOT_SWAP_TYPE_REVERT) {
+		if (boot_write_img_confirmed()) {
+			LOG_ERR("Confirming firmware image failed, it will be reverted on the next "
+				"boot.");
+		} else {
+			LOG_INF("New device firmware image confirmed.");
+		}
+	}
+#endif
 
 	ret = dk_buttons_init(on_button_changed);
 	if (ret) {


### PR DESCRIPTION
* Added an overlay that enables performing Device Firmware Upgrade over Bluetooth LE using SMP protocol.
* Extended documentation to describe how to perform DFU.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>