### PR TITLE
samples: nrf9160: mqtt_simple: add CONFIG_FPU=y

### DIFF
--- a/samples/nrf9160/mqtt_simple/prj.conf
+++ b/samples/nrf9160/mqtt_simple/prj.conf
@@ -47,3 +47,6 @@ CONFIG_HEAP_MEM_POOL_SIZE=2048
 
 # NewLib C
 CONFIG_NEWLIB_LIBC=y
+
+# Enable FPU to coexsist with secure services
+CONFIG_FPU=y


### PR DESCRIPTION
Add CONFIG_FPU=y to coexist with secure services

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>