### PR TITLE
manifest: point to latest sdc and mpsl versions.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 4012879d964319cf6ceba745522b911bd47d7546
+      revision: pull/478/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
See the changelog for more details.

Signed-off-by: Bernhard Wimmer <bernhard.wimmer@nordicsemi.no>