### PR TITLE
kconfig: Set TEST_EXTRA_STACKSIZE for nRF devices

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -18,8 +18,8 @@ config MAIN_STACK_SIZE
 	default 2048 if ZTEST
 	default 2048 if ENTROPY_CC3XX
 
-config ZTEST_STACKSIZE
-	default 2048 if ZTEST
+config TEST_EXTRA_STACKSIZE
+	default 1024 if ZTEST
 
 config PRIVILEGED_STACK_SIZE
 	default 2048 if ZTEST


### PR DESCRIPTION
Instead of modifying the default value of ZTEST_STACKSIZE config for nRF
devices, set TEST_EXTRA_STACKSIZE config. This allows to use a larger
stack size for the ztest thread also for tests that modify
CONFIG_ZTEST_STACKSIZE explicity in their config file.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>