### PR TITLE
cmake: Apply child image DTS overlay automatically

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -158,19 +158,24 @@ function(add_child_image_from_source)
   # | - prj.conf
   # | - prj_<desc>.conf
   # | - child_image DIRECTORY
-  #     |-- <ACI_NAME>.conf (I)             Fragment, used together with (A) and (C)
-  #     |-- <ACI_NAME>_<desc>.conf (J)      Fragment, used together with (B) and (D)
+  #     |-- <ACI_NAME>.conf (I)                 Fragment, used together with (A) and (C)
+  #     |-- <ACI_NAME>_<desc>.conf (J)          Fragment, used together with (B) and (D)
+  #     |-- <ACI_NAME>.overlay                  If present, will be merged with BOARD.dts
   #     |-- <ACI_NAME> DIRECTORY
   #         |-- boards DIRECTORY
-  #         |   |-- <board>.conf (E)        If present, use instead of (C), requires (G).
-  #         |   |-- <board>_<desc>.conf (F) If present, use instead of (D), requires (H).
-  #         |-- prj.conf (G)                If present, use instead of (A)
-  #         |                               Note that (C) is ignored if this is present.
-  #         |                               Use (E) instead.
-  #         |-- prj_<desc>.conf (H)         If present, used instead of (B) when user
-  #                                         specify `-DCONF_FILE=prj_<desc>.conf for
-  #                                         parent image. Note that any (C) is ignored
-  #                                         if this is present. Use (F) instead.
+  #         |   |-- <board>.conf (E)            If present, use instead of (C), requires (G).
+  #         |   |-- <board>_<desc>.conf (F)     If present, use instead of (D), requires (H).
+  #         |   |-- <board>.overlay             If present, will be merged with BOARD.dts
+  #         |   |-- <board>_<revision>.overlay  If present, will be merged with BOARD.dts
+  #         |-- prj.conf (G)                    If present, use instead of (A)
+  #         |                                   Note that (C) is ignored if this is present.
+  #         |                                   Use (E) instead.
+  #         |-- prj_<desc>.conf (H)             If present, used instead of (B) when user
+  #         |                                   specify `-DCONF_FILE=prj_<desc>.conf for
+  #         |                                   parent image. Note that any (C) is ignored
+  #         |                                   if this is present. Use (F) instead.
+  #         |-- <board>.overlay                 If present, will be merged with BOARD.dts
+  #         |-- <board>_<revision>.overlay      If present, will be merged with BOARD.dts
   #
   # Note: The folder `child_image/<ACI_NAME>` is only need when configurations
   #       files must be used instead of the child image default configs.
@@ -184,6 +189,7 @@ function(add_child_image_from_source)
              # Child image always uses the same revision as parent board.
              BOARD_REVISION ${BOARD_REVISION}
              KCONF ${ACI_NAME}_CONF_FILE
+             DTS ${ACI_NAME}_DTC_OVERLAY_FILE
              BUILD ${CONF_FILE_BUILD_TYPE}
     )
 
@@ -198,8 +204,13 @@ function(add_child_image_from_source)
     if (EXISTS ${child_image_conf_fragment})
       add_overlay_config(${ACI_NAME} ${child_image_conf_fragment})
     endif()
-  endif()
 
+    # Check for overlay named <ACI_NAME>.overlay.
+    set(child_image_dts_overlay ${ACI_CONF_DIR}/${ACI_NAME}.overlay)
+    if (EXISTS ${child_image_dts_overlay})
+      add_overlay_dts(${ACI_NAME} ${child_image_dts_overlay})
+    endif()
+  endif()
   # Construct a list of variables that, when present in the root
   # image, should be passed on to all child images as well.
   list(APPEND

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -187,7 +187,7 @@ With ``west``, you can pass these configuration variables into CMake by using th
    -Dmcuboot_CONF_FILE=prj_a.conf \
    -DCONF_FILE=app_prj.conf
 
-You can make a project pass Kconfig configuration files and fragments to child images by placing them in the :file:`child_image` folder in the application source directory.
+You can make a project pass Kconfig configuration files, fragments, and device tree overlays to child images by placing them in the :file:`child_image` folder in the application source directory.
 The listing below describes how to leverage this functionality, where ``ACI_NAME`` is the name of the child image to which the configuration will be applied.
 
 .. literalinclude:: ../../cmake/multi_image.cmake
@@ -259,6 +259,31 @@ When the build system finds the fragment, it outputs their merge during the CMak
    Merged configuration '*extrafragment.conf*'
    Merged configuration '*abc.conf*'
    ...
+
+Child image devicetree overlays
+===============================
+
+You can provide devicetree overlays for a child image using ``*.overlay`` files.
+
+The following example sets the devicetree overlay ``extra.overlay`` to ``childimageone``:
+
+.. parsed-literal::
+   :class: highlight
+
+   cmake -D\ *childimageone*\_DTC_OVERLAY_FILE='\ *extra.overlay*\'
+
+The build system does also automatically apply any devicetree overlay located in the ``child_image`` folder and named as follows (where ``ACI_NAME`` is the name of the child image):
+
+* ``child_image/<ACI_NAME>.overlay``
+* ``child_image/<ACI_NAME>/<board>.overlay``
+* ``child_image/<ACI_NAME>/<board>_<revision>.overlay``
+* ``child_image/<ACI_NAME>/boards/<board>.overlay``
+* ``child_image/<ACI_NAME>/boards/<board>_<revision>.overlay``
+
+.. note::
+
+   The build system grabs the devicetree overlay files specified in a CMake argument relative to that image's application directory.
+   For example, the build system uses ``nrf/samples/bootloader/my-dts.overlay`` when building with the ``-Db0_DTC_OVERLAY_FILE=my-dts.overlay`` option, whereas ``-DDTC_OVERLAY_FILE=my-dts.overlay`` grabs the fragment from the main application's directory, such as ``zephyr/samples/hello_world/my-dts.overlay``.
 
 Child image targets
 ===================

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -174,7 +174,7 @@ For example, to change the ``VARIABLEONE`` variable for the ``childimageone`` ch
   .. parsed-literal::
     :class: highlight
 
-     cmake -D*childimageone*_*VARIABLEONE*=value -D*VARIABLEONE*=value
+     cmake -D\ *childimageone*\_\ *VARIABLEONE*\=value -D\ *VARIABLEONE*\=value
 
 You can extend the CMake command used to create the child images by adding flags to the CMake variable ``EXTRA_MULTI_IMAGE_CMAKE_ARGS``.
 For example, add ``--trace-expand`` to that variable to output more debug information.
@@ -206,7 +206,7 @@ The following example sets the configuration option ``CONFIG_VARIABLEONE=val`` i
   .. parsed-literal::
     :class: highlight
 
-     cmake -D*childimageone*_*CONFIG_VARIABLEONE=val* [...]
+     cmake -D\ *childimageone*\_\ *CONFIG_VARIABLEONE=val*\ [...]
 
 You can add a Kconfig fragment to the child image default configuration in a similar way.
 The following example adds an extra Kconfig fragment ``extrafragment.conf`` to ``childimageone``:
@@ -214,7 +214,7 @@ The following example adds an extra Kconfig fragment ``extrafragment.conf`` to `
   .. parsed-literal::
     :class: highlight
 
-     cmake -D*childimageone*_OVERLAY_CONFIG=*extrafragment.conf* [...]
+     cmake -D\ *childimageone*\_OVERLAY_CONFIG=\ *extrafragment.conf*\ [...]
 
 It is also possible to provide a custom configuration file as a replacement for the default Kconfig file for the child image.
 The following example uses the custom configuration file ``myfile.conf`` when building ``childimageone``:
@@ -222,7 +222,7 @@ The following example uses the custom configuration file ``myfile.conf`` when bu
   .. parsed-literal::
     :class: highlight
 
-     cmake -D*childimageone*_CONF_FILE=*myfile.conf* [...]
+     cmake -D\ *childimageone*\_CONF_FILE=\ *myfile.conf*\ [...]
 
 If your application includes multiple child images, then you can combine all the above as follows:
 
@@ -233,7 +233,7 @@ If your application includes multiple child images, then you can combine all the
   .. parsed-literal::
     :class: highlight
 
-     cmake -DCONFIG_VARIABLEONE=val -D*childimageone*_OVERLAY_CONFIG=*extrafragment.conf* -Dquz_CONF_FILE=*myfile.conf* [...]
+     cmake -DCONFIG_VARIABLEONE=val -D\ *childimageone*\_OVERLAY_CONFIG=\ *extrafragment.conf*\ -Dquz_CONF_FILE=\ *myfile.conf*\ [...]
 
 See :ref:`ug_bootloader` for more details.
 
@@ -248,7 +248,7 @@ The following example shows how to combine ``abc.conf``, Kconfig fragment of the
   .. parsed-literal::
     :class: highlight
 
-     cmake -D*childimageone*_OVERLAY_CONFIG='*extrafragment.conf*;*abc.conf*'
+     cmake -D\ *childimageone*\_OVERLAY_CONFIG='\ *extrafragment.conf*\;\ *abc.conf*\'
 
 When the build system finds the fragment, it outputs their merge during the CMake build output as follows:
 
@@ -256,8 +256,8 @@ When the build system finds the fragment, it outputs their merge during the CMak
    :class: highlight
 
    ...
-   Merged configuration '*extrafragment.conf*'
-   Merged configuration '*abc.conf*'
+   Merged configuration '\ *extrafragment.conf*\'
+   Merged configuration '\ *abc.conf*\'
    ...
 
 Child image devicetree overlays


### PR DESCRIPTION
Allow projects to define child image DTS overlay files in
a specific folder. Also support per board  child image
DTS overlay files.

Check if the folder 'child_image/<ACI_NAME>' exists, and apply all
relevant DTS overlay sources.

It is possible for a sample to use a custom set of DTS overlays for
a child image.

```
<child-sample> DIRECTORY
| - boards DIRECTORY
| | - <board>.overlay             If present, will be merged with BOARD.dts
| | - <board>_<revision>.overlay  If present, will be merged with BOARD.dts

<current-sample> DIRECTORY
| - child_image DIRECTORY
    |-- <ACI_NAME>.overlay    If present, will be merged with BOARD.dts
    |-- <ACI_NAME> DIRECTORY
        |-- boards DIRECTORY
        |   |-- <board>.overlay            If present, will be merged with
        |   |                              BOARD.dts
        |   |-- <board>_<revision>.overlay If present, will be merged with
        |                                  BOARD.dts
        |-- <board>.overlay            If present, will be merged with
        |                              BOARD.dts
        |-- <board>_<revision>.overlay If present, will be merged with
                                       BOARD.dts
```

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>