### PR TITLE
clang-format: Update line length to 100 characters

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,7 +52,7 @@ BreakConstructorInitializersBeforeComma: false
 #BreakConstructorInitializers: BeforeComma # Unknown to clang-format-4.0
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
-ColumnLimit: 80
+ColumnLimit: 100
 CommentPragmas: '^ IWYU pragma:'
 #CompactNamespaces: false # Unknown to clang-format-4.0
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
@@ -136,6 +136,7 @@ SpaceBeforeAssignmentOperators: true
 #SpaceBeforeInheritanceColon: true # Unknown to clang-format-5.0
 SpaceBeforeParens: ControlStatements
 #SpaceBeforeRangeBasedForLoopColon: true # Unknown to clang-format-5.0
+#BitFieldColonSpacing: BFCS_None # Supported from clang-format-12.0
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles: false


### PR DESCRIPTION
Extend line length to 100 characters to align with Zephyr Coding Style.
Add new option (currently commented out) to alternate clang-format
behavior for bit fields.

Without the BitFieldColonSpacing clang-format output for bit field is
following (this is also default behavior):
```
struct foo {
         uint8_t bar1 : 1;
         uint8_t bar2 : 2;
};
```

When the option is enabled output will be following:
```
struct foo {
        uint8_t bar1:1;
        uint8_t bar2:2;
};
```

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>