### PR TITLE
Direction finding connectionless beacon sample app: add support for nRF5340

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -87,6 +87,7 @@ Bluetooth LE
 * Updated:
 
   * :ref:`ble_samples` - Changed the Bluetooth® sample Central DFU SMP name to :ref:`Central SMP Client <bluetooth_central_dfu_smp>`.
+  * :ref:`direction_finding_connectionless_rx` and :ref:`direction_finding_connectionless_tx` samples - Added default configuration for ``nrf52833dk_nrf52820`` and ``nrf5340dk_nrf5340_cpuapp_and_cpuappns`` boards.
 
 Matter
 ------

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -16,7 +16,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52833dk_nrf52833, nrf52833dk_nrf52820
+   :rows: nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp_and_cpuappns
 
 The sample also requires an antenna matrix when operating in angle of departure mode.
 It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.
@@ -38,6 +38,15 @@ Configuration
 
 |config|
 
+This sample configuration is split into the following two files:
+
+* generic configuration is available in :file:`prj.conf` file
+* board specific configuration is available in :file:`boards/<BOARD>.conf` file
+
+Board specific configuration involves configuring the Bluetooth LE controller.
+For :ref:`nRF5340 DK <ug_nrf5340>`, the Bluetooth LE controller is part of a ``child image`` aimed to run on the network core.
+Configuration for the child image is stored in :file:`child_image/` subdirectory.
+
 Angle of arrival mode
 =====================
 
@@ -45,6 +54,8 @@ To build this sample with angle of arrival mode only, set ``OVERLAY_CONFIG`` to 
 
 See :ref:`cmake_options` for instructions on how to add this option.
 For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
+To build this sample for :ref:`nRF5340 DK <ug_nrf5340>`, with angle of arrival mode only, add content of :file:`overlay-aoa.conf` file to :file:`child_image/hci_rpmsg.conf` file.
 
 Antenna matrix configuration for angle of departure mode
 ========================================================

--- a/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.conf
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+CONFIG_BT_CTLR_ADV_EXT=y
+CONFIG_BT_CTLR_ADV_PERIODIC=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+# Disable Direction Finding Rx mode
+CONFIG_BT_CTLR_DF_SCAN_CTE_RX=n
+BT_CTLR_DF_ANT_SWITCH_RX=n

--- a/samples/bluetooth/direction_finding_connectionless_tx/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/child_image/hci_rpmsg.conf
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Reguired to enable BT_BUF_CMD_TX_SIZE for LE Set Extended Advertising Data command
+CONFIG_BT_EXT_ADV=y
+
 CONFIG_BT_CTLR=y
 CONFIG_BT_LL_SW_SPLIT=y
 
@@ -13,6 +16,6 @@ CONFIG_BT_CTLR_ADV_PERIODIC=y
 # Enable Direction Finding Feature including AoA and AoD
 CONFIG_BT_CTLR_DF=y
 
-# Disable Direction Finding RX mode
+# Disable Direction Finding Rx mode
 CONFIG_BT_CTLR_DF_SCAN_CTE_RX=n
 CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=n

--- a/samples/bluetooth/direction_finding_connectionless_tx/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_tx/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is a number of antennas that are available on antenna matrix
+	 * designed by Nordic. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 12 (in antenna matrix designed
+	 * by Nordic) for Tx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoD is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 4 0>;
+	dfegpio1-gpios = <&gpio0 5 0>;
+	dfegpio2-gpios = <&gpio0 6 0>;
+	dfegpio3-gpios = <&gpio0 7 0>;
+};


### PR DESCRIPTION
Update configuration to allow build of the sample application with nRF5340.
Add information about nRF5340 support in README.rst.

This PR requires following other PRs to be merged:
- ~~https://github.com/zephyrproject-rtos/zephyr/pull/36047 to be merged in upstream and cherry-picked into sdk-zephyr repository.~~
- ~~https://github.com/nrfconnect/sdk-nrf/pull/4763 to be merged into main.~~
- ~~Upmerge of sdk-zephyr repository has to be finished.~~