### PR TITLE
manifest: nrf_modem v1.2.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 4012879d964319cf6ceba745522b911bd47d7546
+      revision: pull/481/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Update nrf_modem library to bring in a fix for `getaddrinfo()`