### PR TITLE
applications: asset_tracker_v2: disable AT host in low power mode

### DIFF
--- a/applications/asset_tracker_v2/overlay-low-power.conf
+++ b/applications/asset_tracker_v2/overlay-low-power.conf
@@ -18,3 +18,6 @@ CONFIG_UART_CONSOLE=n
 
 # Disable event logging.
 CONFIG_EVENT_MANAGER_SHOW_EVENTS=n
+
+# Disable AT host library.
+CONFIG_AT_HOST_LIBRARY=n


### PR DESCRIPTION
Disable AT host in lower power overlay to avoid boot loop.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>