### PR TITLE
modules: tfm: use TFM NS binary in regression testing

### DIFF
--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -10,12 +10,24 @@ if (CONFIG_TFM_BL2)
   set_property(GLOBAL PROPERTY
     bl2_PM_HEX_FILE ${CMAKE_BINARY_DIR}/tfm/bin/bl2.hex
     )
-  set_property(GLOBAL PROPERTY
-    app_primary_PM_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr_ns_signed.hex
-    )
+  if (CONFIG_TFM_REGRESSION_NS)
+    set_property(GLOBAL PROPERTY
+      app_primary_PM_HEX_FILE ${CMAKE_BINARY_DIR}/tfm_ns_signed.hex
+      )
+  else()
+    set_property(GLOBAL PROPERTY
+      app_primary_PM_HEX_FILE ${CMAKE_BINARY_DIR}/zephyr_ns_signed.hex
+      )
+  endif()
   set_property(GLOBAL PROPERTY
     tfm_primary_PM_HEX_FILE ${CMAKE_BINARY_DIR}/tfm_s_signed.hex
     )
+else()
+  if (CONFIG_TFM_REGRESSION_NS)
+    set_property(GLOBAL PROPERTY
+      app_primary_PM_HEX_FILE $<TARGET_PROPERTY:tfm,TFM_NS_HEX_FILE>
+      )
+  endif()
 endif()
 set_property(GLOBAL PROPERTY
   tfm_PM_HEX_FILE $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>


### PR DESCRIPTION
When running regression tests for TFM in NCS,
use the TFM generated NS binary.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>