### PR TITLE
Bluetooth: Mesh: Store hue and sat scene data.

### DIFF
--- a/include/bluetooth/mesh/scene_srv.rst
+++ b/include/bluetooth/mesh/scene_srv.rst
@@ -44,6 +44,8 @@ The following models will automatically register scene entries:
 * :ref:`bt_mesh_light_temp_srv_readme`
 * :ref:`bt_mesh_light_xyl_srv_readme`
 * :ref:`bt_mesh_light_hsl_srv_readme`
+* :ref:`bt_mesh_light_hue_srv_readme`
+* :ref:`bt_mesh_light_sat_srv_readme`
 * :ref:`bt_mesh_light_ctl_srv_readme`
 * :ref:`bt_mesh_light_ctrl_srv_readme`
 

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -418,35 +418,17 @@ const struct bt_mesh_model_op _bt_mesh_light_hsl_setup_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-struct __packed scene_data {
-	uint16_t h;
-	uint16_t s;
-	uint16_t l;
-};
-
 static ssize_t scene_store(struct bt_mesh_model *model, uint8_t data[])
 {
 	struct bt_mesh_light_hsl_srv *srv = model->user_data;
-	struct bt_mesh_light_hue_status hue = { 0 };
-	struct bt_mesh_light_sat_status sat = { 0 };
-	struct bt_mesh_lightness_status light = { 0 };
-	struct scene_data *scene = (struct scene_data *)&data[0];
+	struct bt_mesh_lightness_status status = { 0 };
 
-	srv->hue.handlers->get(&srv->hue, NULL, &hue);
-	srv->sat.handlers->get(&srv->sat, NULL, &sat);
-	srv->lightness.handlers->light_get(&srv->lightness, NULL, &light);
+	srv->lightness.handlers->light_get(&srv->lightness, NULL, &status);
+	sys_put_le16(status.remaining_time ? repr_to_light(status.target, ACTUAL) :
+					     status.current,
+		     &data[0]);
 
-	if (hue.remaining_time || sat.remaining_time || light.remaining_time) {
-		scene->h = hue.target;
-		scene->s = sat.target;
-		scene->l = repr_to_light(light.target, ACTUAL);
-	} else {
-		scene->h = hue.current;
-		scene->s = sat.current;
-		scene->l = light.current;
-	}
-
-	return sizeof(struct scene_data);
+	return 2;
 }
 
 static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
@@ -454,25 +436,16 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 			 struct bt_mesh_model_transition *transition)
 {
 	struct bt_mesh_light_hsl_srv *srv = model->user_data;
-	struct scene_data *scene = (struct scene_data *)&data[0];
 	struct bt_mesh_lightness_status light_status = { 0 };
 	struct bt_mesh_light_hue_status hue_status = { 0 };
 	struct bt_mesh_light_sat_status sat_status = { 0 };
 	struct bt_mesh_lightness_set light_set = {
-		.lvl = repr_to_light(scene->l, ACTUAL),
-		.transition = transition,
-	};
-	struct bt_mesh_light_hue hue_set = {
-		.lvl = scene->h,
-		.transition = transition,
-	};
-	struct bt_mesh_light_sat sat_set = {
-		.lvl = scene->s,
+		.lvl = repr_to_light(sys_get_le16(data), ACTUAL),
 		.transition = transition,
 	};
 
-	bt_mesh_light_hue_srv_set(&srv->hue, NULL, &hue_set, &hue_status);
-	bt_mesh_light_sat_srv_set(&srv->sat, NULL, &sat_set, &sat_status);
+	srv->hue.handlers->get(&srv->hue, NULL, &hue_status);
+	srv->sat.handlers->get(&srv->sat, NULL, &sat_status);
 
 	if (!atomic_test_bit(&srv->lightness.flags, LIGHTNESS_SRV_FLAG_EXTENDED_BY_LIGHT_CTRL)) {
 		lightness_srv_change_lvl(&srv->lightness, NULL, &light_set, &light_status);
@@ -488,7 +461,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 
 BT_MESH_SCENE_ENTRY_SIG(light_hsl) = {
 	.id.sig = BT_MESH_MODEL_ID_LIGHT_HSL_SRV,
-	.maxlen = sizeof(struct scene_data),
+	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
 };

--- a/subsys/bluetooth/mesh/light_hue_srv.c
+++ b/subsys/bluetooth/mesh/light_hue_srv.c
@@ -298,6 +298,40 @@ const struct bt_mesh_lvl_srv_handlers _bt_mesh_light_hue_srv_lvl_handlers = {
 	.move_set = lvl_move_set,
 };
 
+static ssize_t scene_store(struct bt_mesh_model *model, uint8_t data[])
+{
+	struct bt_mesh_light_hue_srv *srv = model->user_data;
+	struct bt_mesh_light_hue_status status = { 0 };
+
+	srv->handlers->get(srv, NULL, &status);
+	sys_put_le16(status.remaining_time ? status.target : status.current,
+		     &data[0]);
+
+	return 2;
+}
+
+static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
+			 size_t len,
+			 struct bt_mesh_model_transition *transition)
+{
+	struct bt_mesh_light_hue_srv *srv = model->user_data;
+	struct bt_mesh_light_hue_status status = { 0 };
+	struct bt_mesh_light_hue set = {
+		.lvl = sys_get_le16(data),
+		.transition = transition,
+	};
+	bt_mesh_light_hue_srv_set(srv, NULL, &set, &status);
+
+	(void)bt_mesh_light_hue_srv_pub(srv, NULL, &status);
+}
+
+BT_MESH_SCENE_ENTRY_SIG(light_hue) = {
+	.id.sig = BT_MESH_MODEL_ID_LIGHT_HSL_HUE_SRV,
+	.maxlen = 2,
+	.store = scene_store,
+	.recall = scene_recall,
+};
+
 static int hue_srv_pub_update(struct bt_mesh_model *model)
 {
 	struct bt_mesh_light_hue_srv *srv = model->user_data;


### PR DESCRIPTION
The Hue and Saturation servers does not store their own scene data,
and relay on the HSL server to do it for them. As these models can be
used independently, they should store their own scene data.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>