### PR TITLE
Bluetooth: Mesh: Fix magnetic flux density 2d declaration

### DIFF
--- a/subsys/bluetooth/mesh/sensor_types.c
+++ b/subsys/bluetooth/mesh/sensor_types.c
@@ -776,7 +776,7 @@ SENSOR_TYPE(magnetic_declination) = {
 	.id = BT_MESH_PROP_ID_MAGNETIC_DECLINATION,
 	CHANNELS(CHANNEL("Magnetic Declination", direction_16)),
 };
-SENSOR_TYPE(magnetic_flux_density) = {
+SENSOR_TYPE(magnetic_flux_density_2d) = {
 	.id = BT_MESH_PROP_ID_MAGNETIC_FLUX_DENSITY_2D,
 	CHANNELS(CHANNEL("X-axis", magnetic_flux_density),
 		 CHANNEL("Y-axis", magnetic_flux_density)),


### PR DESCRIPTION
The magnetic flux density 2D sensor type source file definition did not
match its header declaration. Correct this by aligning with header.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>