### PR TITLE
lib: nrf_modem: fix macro names

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -213,10 +213,10 @@ static int z_to_nrf_optname(int z_in_level, int z_in_optname,
 			*nrf_out_optname = NRF_SO_SILENCE_ALL;
 			break;
 		case SO_IP_ECHO_REPLY:
-			*nrf_out_optname = NRF_SO_SILENCE_IP_ECHO_REPLY;
+			*nrf_out_optname = NRF_SO_IP_ECHO_REPLY;
 			break;
 		case SO_IPV6_ECHO_REPLY:
-			*nrf_out_optname = NRF_SO_SILENCE_IPV6_ECHO_REPLY;
+			*nrf_out_optname = NRF_SO_IPV6_ECHO_REPLY;
 			break;
 		case SO_TCP_SRV_SESSTIMEO:
 			*nrf_out_optname = NRF_SO_TCP_SRV_SESSTIMEO;


### PR DESCRIPTION
Fixing calls to macros with recently changed names.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>