### PR TITLE
samples: nrf9160: gps: Use LTE link controller when SUPL is enabled

### DIFF
--- a/samples/nrf9160/gps/prj.conf
+++ b/samples/nrf9160/gps/prj.conf
@@ -11,10 +11,14 @@ CONFIG_UART_INTERRUPT_DRIVEN=y
 CONFIG_NEWLIB_LIBC=y
 CONFIG_NEWLIB_LIBC_FLOAT_PRINTF=y
 CONFIG_AT_CMD=y
-CONFIG_AT_NOTIF=y
 
-# Enable SUPL client support
+# To use SUPL client library for assisted GPS, enable the options below
 CONFIG_SUPL_CLIENT_LIB=n
+CONFIG_LTE_LINK_CONTROL=n
+CONFIG_LTE_NETWORK_MODE_LTE_M_GPS=n
+
+# Auto-connect should be left off as we want the application to control LTE
+CONFIG_LTE_AUTO_INIT_AND_CONNECT=n
 
 # Networking
 CONFIG_NETWORKING=y


### PR DESCRIPTION
Use LTE link controller instead of AT commands directly when
SUPL is enabled.
This allows users more flexibility to configure the LTE setup
without having to use AT commands.