### PR TITLE
west.yml: Update Zephyr to bring in fix for TF-M/BL2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 52c88d4525626fe3fc35272e20fc52ce7bb95778
+      revision: pull/547/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Set CONFIG_TFM_BL2 to n when building with nrf_security.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>