### PR TITLE
manifest: update zephyr before 1.6.0-RC1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 52c88d4525626fe3fc35272e20fc52ce7bb95778
+      revision: bfd1376a081d1f26fa7d4ba8606fd1cc77747ba4
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Introduce some last minute updates to
Zephyr before the RC1 cut.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>