### PR TITLE
Bluetooth: Mesh: Fix Scene Server srv_elem_end

### DIFF
--- a/subsys/bluetooth/mesh/scene_srv.c
+++ b/subsys/bluetooth/mesh/scene_srv.c
@@ -409,7 +409,7 @@ static uint16_t srv_elem_end(const struct bt_mesh_scene_srv *srv)
 			break;
 		}
 
-		end = srv->model->elem_idx;
+		end = it->model->elem_idx;
 	}
 
 	return end;


### PR DESCRIPTION
The procedure used wrong pointer to get end index. Srv pointer is a
parameter of the function and it is not updated with each iteration.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>