### PR TITLE
caf: ble_smp: Introduce support for OS management

### DIFF
--- a/include/caf/ble_smp.rst
+++ b/include/caf/ble_smp.rst
@@ -22,6 +22,16 @@ To use the module, you must enable the following Kconfig options:
 * :option:`CONFIG_BOOTLOADER_MCUBOOT` - This option enables the MCUboot bootloader.
   The DFU over Simple Management Protocol in Zephyr is supported only with the MCUboot bootloader.
 
+Enabling remote OS management
+=============================
+
+The |smp| supports registering OS management handlers automatically, which you can enable using the following Kconfig option:
+
+* :option:`CONFIG_MCUMGR_CMD_OS_MGMT` - This option enables MCUmgr OS management handlers.
+  Use these handlers to remotely trigger the device reboot after the image transfer is completed.
+  After the reboot, the device starts using the new firmware.
+  One of the applications that support the remote reboot functionality is `nRF Connect for Mobile`_.
+
 Implementation details
 **********************
 

--- a/subsys/caf/modules/ble_smp.c
+++ b/subsys/caf/modules/ble_smp.c
@@ -6,6 +6,9 @@
 
 #include <mgmt/mcumgr/smp_bt.h>
 #include <img_mgmt/img_mgmt.h>
+#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+#include <os_mgmt/os_mgmt.h>
+#endif
 
 #define MODULE smp
 #include <caf/events/module_state_event.h>
@@ -37,6 +40,9 @@ static bool event_handler(const struct event_header *eh)
 		if (check_state(event, MODULE_ID(main), MODULE_STATE_READY)) {
 			img_mgmt_set_upload_cb(upload_confirm, NULL);
 			img_mgmt_register_group();
+#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+			os_mgmt_register_group();
+#endif
 		} else if (check_state(event, MODULE_ID(ble_state), MODULE_STATE_READY)) {
 			static bool initialized;
 


### PR DESCRIPTION
Change introduces support for OS management. This is needed to remotely trigger device reboot and firmware swap after image transfer is completed.

Jira: NCSDK-9972