### PR TITLE
tfm: Initialize nrf_cc3xx_platform when TF-M boots

### DIFF
--- a/modules/tfm/tfm/boards/common/boot_hal.c
+++ b/modules/tfm/tfm/boards/common/boot_hal.c
@@ -56,7 +56,7 @@ int32_t boot_platform_init(void)
     }
 
     /* Initialize the nrf_cc3xx runtime */
-    result = nrf_cc3xx_platform_init();
+    result = nrf_cc3xx_platform_init_no_rng();
     if (result != NRF_CC3XX_PLATFORM_SUCCESS) {
         return 1;
     }

--- a/modules/tfm/tfm/boards/common/plat_init.c
+++ b/modules/tfm/tfm/boards/common/plat_init.c
@@ -11,11 +11,18 @@
 #include "uart_stdout.h"
 #include "tfm_spm_log.h"
 #include "hw_unique_key.h"
+#include <nrf_cc3xx_platform.h>
 
 enum tfm_hal_status_t tfm_hal_platform_init(void)
 {
 	__enable_irq();
 	stdio_init();
+
+	/* Initialize the nrf_cc3xx runtime */
+	int result = nrf_cc3xx_platform_init();
+	if (result != NRF_CC3XX_PLATFORM_SUCCESS) {
+		return TFM_HAL_ERROR_BAD_STATE;
+	}
 
 	if (!hw_unique_key_are_any_written()) {
 		SPMLOG_INFMSG("Writing random Hardware Unique Keys to the KMU.\r\n");


### PR DESCRIPTION
Before checking for HUKs.
Change initialization in boot_hal.c (BL2) to _init_no_rng() so that
initialization with RNG only happens once, in TF-M.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>