### PR TITLE
labeler.yml: Don't apply CI-all-test for west.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -46,7 +46,6 @@
   - "tests/subsys/net/**/*"
 
 "CI-all-test":
-  - "west.yml"
   - "**/*partition_manager*/**/*"
   - "**/*partition_manager*"
 


### PR DESCRIPTION
The author should instead apply the right labels, since most updates
don't concern the whole tree.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>