### PR TITLE
net: fota_download: Add state variable to check if it is downloading

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -39,6 +39,7 @@ static uint8_t mcuboot_buf[CONFIG_FOTA_DOWNLOAD_MCUBOOT_FLASH_BUF_SZ] __aligned(
 static enum dfu_target_image_type img_type;
 static enum dfu_target_image_type img_type_expected = DFU_TARGET_IMAGE_TYPE_ANY;
 static bool first_fragment;
+static bool downloading;
 
 static void send_evt(enum fota_download_evt_id id)
 {
@@ -57,6 +58,7 @@ static void send_error_evt(enum fota_download_error_cause cause)
 		.id = FOTA_DOWNLOAD_EVT_ERROR,
 		.cause = cause
 	};
+	downloading = false;
 	callback(&evt);
 }
 
@@ -190,6 +192,7 @@ static int download_client_callback(const struct download_client_evt *event)
 			}
 
 			send_progress((offset * 100) / file_size);
+			downloading = false;
 			LOG_DBG("Progress: %d/%d bytes", offset, file_size);
 		}
 	break;
@@ -210,6 +213,7 @@ static int download_client_callback(const struct download_client_evt *event)
 		}
 		send_evt(FOTA_DOWNLOAD_EVT_FINISHED);
 		first_fragment = true;
+		downloading = false;
 		break;
 
 	case DOWNLOAD_CLIENT_EVT_ERROR: {
@@ -269,6 +273,7 @@ static void download_with_offset(struct k_work *unused)
 		return;
 	}
 	LOG_INF("Downloading from offset: 0x%x", offset);
+	downloading = true;
 	return;
 }
 
@@ -301,6 +306,10 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 
 	if (host == NULL || file == NULL || callback == NULL) {
 		return -EINVAL;
+	}
+
+	if (downloading) {
+		return -EALREADY;
 	}
 
 	socket_retries_left = CONFIG_FOTA_SOCKET_RETRIES;
@@ -364,6 +373,8 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 		return err;
 	}
 
+	downloading = true;
+
 	return 0;
 }
 
@@ -401,6 +412,8 @@ int fota_download_init(fota_download_callback_t client_callback)
 int fota_download_cancel(void)
 {
 	int err;
+
+	downloading = false;
 
 	if (dlc.fd == -1) {
 		/* Download not started, aborted or completed */

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -191,11 +191,15 @@ static void test_fota_download_start(void)
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active,
 		      spm_s0_active_retval, "Incorrect param for s0_active");
 
+	err = fota_download_cancel();
+	zassert_equal(err, 0, NULL);
 	set_s0_active(true);
 	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active,
 		      spm_s0_active_retval, "Incorrect param for s0_active");
+	err = fota_download_cancel();
+	zassert_equal(err, 0, NULL);
 
 	/* Next, verify that the update path given by mcuboot_set_b1_file
 	 * is used correctly.
@@ -207,6 +211,8 @@ static void test_fota_download_start(void)
 	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S0_S1) == 0, NULL);
+	err = fota_download_cancel();
+	zassert_equal(err, 0, NULL);
 
 	/* update set to not null indicates to use update for file param */
 	dfu_ctx_mcuboot_set_b1_file__update = S1;
@@ -214,6 +220,10 @@ static void test_fota_download_start(void)
 	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S1) == 0, NULL);
+
+	/* Check if double call returns EALREADY */
+	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	zassert_equal(err, -EALREADY, "No failure for double call");
 }
 
 void test_main(void)


### PR DESCRIPTION
Due to the callback nature of download client and the delayed scheduling
of a restart from offset it is possible to call `fota_download_start`
while something else is downloading which causes an error.

This commit adds a state variable which we can check to make sure that
we don't start a new download while another download is still in
progress.

Ref. NCSDK-8541

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>