### PR TITLE
Direction finding connectionless locator sample app: add support for the nRF52820

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -16,7 +16,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp_and_cpuappns
+   :rows: nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp_and_cpuappns
 
 The sample also requires an antenna matrix when operating in angle of arrival mode.
 It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52820.conf
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52820.conf
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+CONFIG_BT_CTLR_ADV_EXT=y
+CONFIG_BT_CTLR_SYNC_PERIODIC=y
+
+# Enable Direction Finding RX Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+# Disable Direction Findnig TX mode
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
+CONFIG_BT_CTLR_DF_ADV_CTE_TX=n

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52820.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52820.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is a number of antennas that are available on antenna matrix
+	 * designed by Nordic. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 12 (in antenna matrix designed
+	 * by Nordic) for Rx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoA is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
+};


### PR DESCRIPTION
Add required configuration and DTS overlay for support the nRF52820 SOC.

This PR should be merged after: https://github.com/nrfconnect/sdk-nrf/pull/4773
Also upmerge of sdk-zephyr repository has to be finished.