### PR TITLE
applications: pelion_client: Fix pelion tracing

### DIFF
--- a/applications/pelion_client/src/modules/pelion_trace.c
+++ b/applications/pelion_client/src/modules/pelion_trace.c
@@ -10,6 +10,14 @@
 #define MODULE pelion_trace
 #include <caf/events/module_state_event.h>
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(MODULE, CONFIG_PELION_CLIENT_PELION_LOG_LEVEL);
+
+
+static void trace_printer(const char *str)
+{
+	LOG_INF("%s", log_strdup(str));
+}
 
 static void init_pelion_trace(void)
 {
@@ -28,6 +36,8 @@ static void init_pelion_trace(void)
 	 */
 	mbed_trace_mutex_wait_function_set(mbed_trace_helper_mutex_wait);
 	mbed_trace_mutex_release_function_set(mbed_trace_helper_mutex_release);
+	mbed_trace_config_set(TRACE_MODE_COLOR | TRACE_ACTIVE_LEVEL_ALL);
+	mbed_trace_print_function_set(trace_printer);
 }
 
 


### PR DESCRIPTION
This commit fixes pelion traces by duplicating the strings that are
automatic variables inside pelion code.