### PR TITLE
.github: manifest.yml: Add CI labels based on modules in west.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -46,7 +46,6 @@
   - "tests/subsys/net/**/*"
 
 "CI-all-test":
-  - "west.yml"
   - "**/*partition_manager*/**/*"
   - "**/*partition_manager*"
 

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -29,5 +29,19 @@ jobs:
           checkout-path: 'ncs/nrf'
           label-prefix: 'manifest-'
           verbosity-level: '1'
-          labels: 'manifest'
+
+          # Add one label per line. 'manifest' always adds the label 'manifest'.
+          # 'CI-all-test:zephyr;nrfxlib,' adds the 'CI-all-test' label when the
+          # zephyr module or the nrfxlib module is changed. Each line is comma-
+          # separated.
+          labels: >
+            manifest,
+            CI-all-test:zephyr;nrfxlib,
+            CI-tfm-test:trusted-firmware-m;tfm-mcuboot,
+            CI-boot-dfu-test:mcuboot;mcumgr,
+            CI-matter-test:matter,
+            CI-find-my-test:find-my,
+            CI-homekit-test:homekit,
+            CI-thread-test:openthread,
+            CI-crypto-test:mbedtls;mbedtls-nrf
           dnm-labels: 'DNM'

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Manifest
-        uses: zephyrproject-rtos/action-manifest@v1.1.0
+        uses: oyvindronningstad/action-manifest@module-labels
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           manifest-path: 'west.yml'


### PR DESCRIPTION
Add CI labels only when relevant modules are changed.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

Needs this PR in action-manifest: https://github.com/zephyrproject-rtos/action-manifest/pull/2
I'll update the commit sha in the `uses: zephyrproject-rtos/action-manifest@` line after that is merged

The label list is incomplete, need input on this.

The labelling can be tested by opening a PR to this branch, where you change west.yml.