### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: af79106e4a0aa4396909a20a1bc245533e258676
+      revision: pull/548/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr with fixes for watchdog and timer tests failures

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>