### PR TITLE
applications: serial_lte_modem: xsleep doc note

### DIFF
--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -118,6 +118,10 @@ Power saving #XSLEEP
 
 The ``#XSLEEP`` command makes the nRF91 development kit go into idle or sleep mode.
 
+If you are going to do power measurements on the nRF9160 DK while running the SLM application it is recommended to disable unused peripherals.
+By default UART2 is enabled in the :file:`nrf9160dk_nrf9160ns.overlay` file so disable the UART2 by switching the status.
+Change the line ``status = "okay"`` to ``status = "disabled"`` and then save the :file:`nrf9160dk_nrf9160ns.overlay`` file to make sure you will get the expected power consumption numbers when doing the measurements.
+
 Set command
 -----------
 


### PR DESCRIPTION
Adding a note to disable UART2 when doing power
measurements on the nRF9160.

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>