### PR TITLE
Multicell location: Increase sample's main stack and add socket timeouts

### DIFF
--- a/lib/multicell_location/Kconfig
+++ b/lib/multicell_location/Kconfig
@@ -154,6 +154,20 @@ config MULTICELL_LOCATION_TLS_SEC_TAG
 	  service will be stored. This sec tag will also be used to provision
 	  certificates when multicell_location_provision_certificate() is called.
 
+config MULTICELL_LOCATION_SEND_TIMEOUT
+	int "Send timeout, in seconds"
+	default 60
+	help
+	  Sets the timeout duration in seconds to use when sending data.
+	  To disable, set the timeout duration to -1.
+
+config MULTICELL_LOCATION_RECV_TIMEOUT
+	int "Receive timeout, in seconds"
+	default 60
+	help
+	  Sets the timeout duration in seconds to use when receiving data.
+	  To disable, set the timeout duration to -1.
+
 config MULTICELL_LOCATION_SEND_BUF_SIZE
 	int "Send buffer size"
 	default 2048 if MULTICELL_LOCATION_SERVICE_SKYHOOK

--- a/samples/nrf9160/multicell_location/prj.conf
+++ b/samples/nrf9160/multicell_location/prj.conf
@@ -58,6 +58,7 @@ CONFIG_MODEM_INFO=y
 CONFIG_DK_LIBRARY=y
 
 # Heap and stacks
+CONFIG_MAIN_STACK_SIZE=4096
 # The AT parser and link controller libraries use the heap
 CONFIG_HEAP_MEM_POOL_SIZE=2048
 


### PR DESCRIPTION
lib: multicell_location: Add options for socket timeouts …

Add Kconfig options to set timeouts for sending and receiving.
This addresses isses that have been observed where the connection
is not closed and the library never starts to parse the received
data.
Now the library will attempt to parse the data in the case of
timeout, as it may have received all the required payload even
though a timout occurs.

CIA-333

---

Increase main stack size to avoid stack overflow.

Fixes CIA-332
