### PR TITLE
samples: tfm: add rng to tfm_hello_world sample

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm_minimal.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.tfm_minimal.defconfig
@@ -7,6 +7,10 @@ config TFM_CRYPTO_HASH_MODULE_ENABLED
 	bool
 	default y
 
+config TFM_CRYPTO_RNG_MODULE_ENABLED
+	bool
+	default y
+
 config TFM_PARTITION_CRYPTO
 	bool
 	default y

--- a/samples/tfm/tfm_hello_world/README.rst
+++ b/samples/tfm/tfm_hello_world/README.rst
@@ -39,13 +39,14 @@ After programming the sample, the following output is displayed in the console:
 .. code-block:: console
 
     Hello World! nrf5340dk_nrf5340_cpuapp
+    Generating random number
+    0x8aefe6b7473f2e2c170bbd3eb39aa7679bc1e7693a11030b0a4c1c8ba41eb457
     Reading some secure memory that NS is allowed to read
     FICR->INFO.PART: 0x00005340
     FICR->INFO.VARIANT: 0x514b4141
     Hashing 'Hello World! nrf5340dk_nrf5340_cpuapp'
     SHA256 digest:
-    12f0c84eecba8497cc0bec1ebc5a785d
-    f2ae027a2545921d6cdc0920c5aaefd7
+    0x12f0c84eecba8497cc0bec1ebc5a785df2ae027a2545921d6cdc0920c5aaefd7
 
 Dependencies
 *************

--- a/samples/tfm/tfm_hello_world/sample.yaml
+++ b/samples/tfm/tfm_hello_world/sample.yaml
@@ -13,13 +13,14 @@ common:
       type: multi_line
       regex:
         - "Hello World! .*"
+        - "Generating random number"
+        - "0x[0-9a-f]{64}"
         - "Reading some secure memory that NS is allowed to read"
         - "FICR->INFO.PART: 0x[0-9a-f]{8}"
         - "FICR->INFO.VARIANT: 0x[0-9a-f]{8}"
         - "Hashing 'Hello World! .*'"
         - "SHA256 digest:"
-        - "[0-9a-f]{32}"
-        - "[0-9a-f]{32}"
+        - "0x[0-9a-f]{64}"
 tests:
   sample.tfm.helloworld:
     tags: tfm ci_build

--- a/samples/tfm/tfm_hello_world/src/main.c
+++ b/samples/tfm/tfm_hello_world/src/main.c
@@ -31,10 +31,20 @@ static uint32_t secure_read_word(intptr_t ptr)
 	return val;
 }
 
+static void print_hex_number(uint8_t *num, size_t len)
+{
+	printk("0x");
+	for (int i = 0; i < len; i++) {
+		printk("%02x", num[i]);
+	}
+	printk("\n");
+}
+
 void main(void)
 {
 	char hello_string[sizeof(HELLO_PATTERN) + sizeof(CONFIG_BOARD)];
 	char hello_digest[32];
+	uint8_t random_bytes[32];
 	size_t len;
 	psa_status_t status;
 
@@ -42,6 +52,14 @@ void main(void)
 		HELLO_PATTERN, CONFIG_BOARD);
 
 	printk("%s\n", hello_string);
+
+	printk("Generating random number\n");
+	status = psa_generate_random(random_bytes, sizeof(random_bytes));
+	if (status != PSA_SUCCESS) {
+		printk("psa_generate_random failed with status %d\n", status);
+	} else {
+		print_hex_number(random_bytes, sizeof(random_bytes));
+	}
 
 	printk("Reading some secure memory that NS is allowed to read\n");
 	printk("FICR->INFO.PART: 0x%08x\n",
@@ -62,9 +80,6 @@ void main(void)
 		printk("psa_hash_compute failed with status %d\n", status);
 	} else {
 		printk("SHA256 digest:\n");
-		for (int i = 0; i < len; i++) {
-			printk("%02x%s", hello_digest[i],
-					i % 16 == 15 ? "\n" : "");
-		}
+		print_hex_number(hello_digest, 32);
 	}
 }

--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 384ff0c232aad2a929aea35d67411c24d34c540c
+      revision: 02f76ba0e91ba0fe5bb58f38bb787cd652d818b8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -107,7 +107,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
-      revision: v1.3.99-ncs1-rc1
+      revision: cb1e6c2f070e68c950cd861d1bbd76b296be78b9
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Rng functionality should be available with TFM_MINIMAL.
Use psa_generate_random from tfm_hello_world to show this

Ref: NCSDK-10031
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>