### PR TITLE
samples: nrf9160: mosh: Fix LWM2M_CARRIER_EVENT_BSDLIB_INIT define

### DIFF
--- a/samples/nrf9160/modem_shell/src/shell.c
+++ b/samples/nrf9160/modem_shell/src/shell.c
@@ -114,7 +114,7 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 	shell_global = shell_backend_uart_get_ptr();
 
 	switch (event->type) {
-	case LWM2M_CARRIER_EVENT_BSDLIB_INIT:
+	case LWM2M_CARRIER_EVENT_MODEM_INIT:
 		shell_print(shell_global, "LwM2M carrier event: modem lib initialized");
 		break;
 	case LWM2M_CARRIER_EVENT_CONNECTING:


### PR DESCRIPTION
Change LWM2M_CARRIER_EVENT_BSDLIB_INIT to LWM2M_CARRIER_EVENT_MODEM_INIT according to lwm2m_carrier library change in commit: https://github.com/nrfconnect/sdk-nrf/commit/9af8184e52c5a30c33726ddb959645bfe777b184

Jira: NCSDK-10042