### PR TITLE
matter: bring fixes for Android CHIPTool

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -86,14 +86,13 @@
 
 .. _`SMP over Bluetooth`: https://github.com/apache/mynewt-mcumgr/blob/master/transport/smp-bluetooth.md
 
-.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/430b49/src/android/CHIPTool
-.. _`Working with Android Controller`:
-.. _`Commissioning nRF Connect Accessory using Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/430b49/docs/guides/nrfconnect_android_commissioning.md
-.. _`Working with Python Controller`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/430b49/src/controller/python/README.md
-.. _`Performing Device Firmware Upgrade in Matter device`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/430b49/docs/guides/nrfconnect_examples_software_update.md
-.. _`Matter Protocol Overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/430b49/README.md
-.. _`nRF Connect platform overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/430b49/docs/guides/nrfconnect_platform_overview.md
-.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/430b49/src/controller
+.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/933fb4/src/android/CHIPTool
+.. _`Commissioning nRF Connect Accessory using Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/933fb4/docs/guides/nrfconnect_android_commissioning.md
+.. _`Working with Python Controller`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/933fb4/src/controller/python/README.md
+.. _`Performing Device Firmware Upgrade in Matter device`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/933fb4/docs/guides/nrfconnect_examples_software_update.md
+.. _`Matter Protocol Overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/933fb4/README.md
+.. _`nRF Connect platform overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/933fb4/docs/guides/nrfconnect_platform_overview.md
+.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/933fb4/src/controller
 
 .. _`Azure support for Asset Tracker v2`: https://github.com/nrfconnect/sdk-nrf/pull/3950
 .. _`nRF Cloud JSON protocol schemas`: https://github.com/nRFCloud/application-protocols

--- a/doc/nrf/ug_matter_configuring.rst
+++ b/doc/nrf/ug_matter_configuring.rst
@@ -89,7 +89,7 @@ For information about how to configure and use the required components, complete
 * Depending on the Matter controller type:
 
   * Testing with the Python Matter Controller - see `Working with Python Controller`_ in the Matter documentation
-  * Testing with the Android Mobile Controller - see `Working with Android Controller`_ in the Matter documentation
+  * Testing with the Android Mobile Controller - see `Commissioning nRF Connect Accessory using Android CHIPTool`_ in the Matter documentation
 
 Running Thread Border Router and Matter controller on the same device
 =====================================================================

--- a/west.yml
+++ b/west.yml
@@ -119,7 +119,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: e73ee78cfa6b8d57952a380eac43de6ba0bb27f9
+      revision: 933fb42b2522ee06fde77ef4b01fd2b297c0b064
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
* Re-add the possibility to send ZCL messages using Android
  CHIPTool.
* Update the documentation about commissioning a nRF Connect
  accessory device using Android CHIPTool.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>