### PR TITLE
lib: agps: Replace deprecated typedef to avoid build warning

### DIFF
--- a/lib/agps/agps.c
+++ b/lib/agps/agps.c
@@ -286,7 +286,7 @@ static int init_supl(int socket)
 static int supl_start(const struct gps_agps_request request)
 {
 	int err;
-	nrf_gnss_agps_data_frame_t req = {
+	struct nrf_modem_gnss_agps_data_frame req = {
 		.sv_mask_ephe = request.sv_mask_ephe,
 		.sv_mask_alm = request.sv_mask_alm,
 		.data_flags =


### PR DESCRIPTION
Use new `struct nrf_gnss_agps_data_frame` instead of
`nrf_gnss_agps_data_frame_t`.

NCSDK-10046