### PR TITLE
applications: asset_tracker_v2: remove app-version token

### DIFF
--- a/applications/asset_tracker_v2/README.rst
+++ b/applications/asset_tracker_v2/README.rst
@@ -278,7 +278,7 @@ Check and configure the following configuration options for the application:
 
 .. option:: CONFIG_ASSET_TRACKER_V2_APP_VERSION - Configuration for providing the application version
 
-   The application publishes its version number as a part of the static device data. The default value for the application version is ``0.0.0-development``. To configure the application version, set :option:`CONFIG_ASSET_TRACKER_V2_APP_VERSION` to the desired ``app-version``.
+   The application publishes its version number as a part of the static device data. The default value for the application version is ``0.0.0-development``. To configure the application version, set :option:`CONFIG_ASSET_TRACKER_V2_APP_VERSION` to the desired version.
 
 .. option:: CONFIG_CLOUD_CLIENT_ID_USE_CUSTOM - Configuration for enabling the use of custom cloud client ID
 


### PR DESCRIPTION
The markup used is confusing, because there is no such thing as an `app-version` to be used with `CONFIG_ASSET_TRACKER_V2_APP_VERSION`.

It is a regular string.