### PR TITLE
manifest: Point to nrfxlib with nrf_cc3xx 0.9.10

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d7795a15f59fed58f1e044a642fbae0786b51a4f
+      revision: pull/492/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-Adding version 0.9.10 of CryptoCell runtime library

This version is needed to build apps against mbedtls 2.26.0. This is required to be compatible with 1.3.99 of TF-M.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>