### PR TITLE
dk_buttons_and_leds: fix off-by-one

### DIFF
--- a/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
+++ b/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
@@ -381,7 +381,7 @@ int dk_set_led(uint8_t led_idx, uint32_t val)
 {
 	int err;
 
-	if (led_idx > ARRAY_SIZE(led_pins)) {
+	if (led_idx >= ARRAY_SIZE(led_pins)) {
 		LOG_ERR("LED index out of the range");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The error handling for invalid LEDs is off by one.
Caught by static analysis.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>