### PR TITLE
modules: tfm: disable unsupported crypto regression tests

### DIFF
--- a/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
+++ b/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
@@ -10,3 +10,6 @@ include(platform/ext/target/nordic_nrf/common/nrf5340/config.cmake)
 # Override the AEAD algorithm configuration
 set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_GCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")
 set(PLATFORM_DUMMY_CRYPTO_KEYS          FALSE      CACHE BOOL      "Use dummy crypto keys. Should not be used in production.")
+
+# Disable crypto regression tests that are not supported
+set(TFM_CRYPTO_TEST_ALG_CFB             OFF          CACHE BOOL      "Test CFB cryptography mode")

--- a/modules/tfm/tfm/boards/nrf9160/config.cmake
+++ b/modules/tfm/tfm/boards/nrf9160/config.cmake
@@ -10,3 +10,7 @@ include(platform/ext/target/nordic_nrf/common/nrf9160/config.cmake)
 # Override the AEAD algorithm configuration since nRF9160 supports only AES_CCM
 set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_CCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")
 set(PLATFORM_DUMMY_CRYPTO_KEYS          FALSE      CACHE BOOL      "Use dummy crypto keys. Should not be used in production.")
+
+# Disable crypto regression tests that are not supported
+set(TFM_CRYPTO_TEST_ALG_CFB             OFF         CACHE BOOL      "Test CFB cryptography mode")
+set(TFM_CRYPTO_TEST_ALG_GCM             OFF         CACHE BOOL      "Test GCM cryptography mode")


### PR DESCRIPTION
Disable tests for unsupported crypto regression tests in board configurations. 