### PR TITLE
net: lib: nrf_cloud: Increase internal payload buffer size

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -136,6 +136,7 @@ config NRF_CLOUD_MQTT_MESSAGE_BUFFER_LEN
 
 config NRF_CLOUD_MQTT_PAYLOAD_BUFFER_LEN
 	int "Size of the buffer for MQTT PUBLISH payload."
+	default 2144 if NRF_CLOUD_AGPS
 	default 2048
 
 menuconfig NRF_CLOUD_FOTA


### PR DESCRIPTION
When receiving AGPS data from nRF Cloud the total size of the received
data can sometimes exceed the internal payload buffer in
`nrf_cloud_transport`. This patch increases the internal buffer in case
nRF Cloud AGPS is configured.

CIA-335