### PR TITLE
scripts: profiler: Fix race when host connects

### DIFF
--- a/scripts/profiler/rtt_nordic_config.py
+++ b/scripts/profiler/rtt_nordic_config.py
@@ -4,10 +4,14 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
 RttNordicConfig = {
-    'device_snr' : None,
-    'rtt_info_channel': 2,
-    'rtt_data_channel': 1,
-    'rtt_command_channel': 1,
+    'device_snr': None,
+    'rtt_up_channel_names':  {
+        'Nordic profiler info': 'info',
+        'Nordic profiler data': 'data',
+    },
+    'rtt_down_channel_names': {
+        'Nordic profiler command': 'command',
+    },
     'ms_per_timestamp_tick': 0.03125,
     'byteorder': 'little',
     'reset_on_start': True,


### PR DESCRIPTION
The RTT channels on device are configured during initialization of profiler. Script can start exchanging data only after all of the channels are configured. Using channels before they are configured leads to errors.

Jira: NCSDK-8302