### PR TITLE
include: date_time: Use correct function name in documentation

### DIFF
--- a/include/date_time.rst
+++ b/include/date_time.rst
@@ -28,7 +28,7 @@ See the API documentation for more information on these functions.
 .. note::
 
    The first date-time update cycle (after boot) does not occur until the time set by the :option:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS` has elapsed.
-   It is recommended to call the :c:func:`date_time_update` function after the device has connected to LTE, to get the initial date-time information.
+   It is recommended to call the :c:func:`date_time_update_async` function after the device has connected to LTE, to get the initial date-time information.
 
 Configuration
 *************


### PR DESCRIPTION
`date_time_update` is now called `date_time_update_async`. Update docs
to reflect this.