### PR TITLE
scripts: keygen: re-generate key if digest contains 0xffff

### DIFF
--- a/scripts/bootloader/keygen.py
+++ b/scripts/bootloader/keygen.py
@@ -7,8 +7,24 @@
 
 from ecdsa import SigningKey
 from ecdsa.curves import NIST256p
+from hashlib import sha256
 import argparse
 import sys
+
+
+def generate_legal_key():
+    """
+    Ensure that we don't have 0xFFFF in the hash of the public key of
+    the generated keypair.
+
+    :return: A key who's SHA256 digest does not contain 0xFFFF
+    """
+    while True:
+        key = SigningKey.generate(curve=NIST256p)
+        digest = sha256(key.get_verifying_key().to_string()).digest()[:16]
+        if not (any([digest[n:n + 2] == b'\xff\xff'
+                     for n in range(0, len(digest), 2)])):
+            return key
 
 
 if __name__ == '__main__':
@@ -26,11 +42,13 @@ if __name__ == '__main__':
                         help='Output to specified file instead of stdout.')
     parser.add_argument('--in', '-in', '-i', required=False, dest='infile',
                         type=argparse.FileType('rb'),
-                        help='Read private key from specified PEM file instead of generating it.')
+                        help='Read private key from specified PEM file instead '
+                             'of generating it.')
 
     args = parser.parse_args()
 
-    sk = SigningKey.from_pem(args.infile.read()) if args.infile else SigningKey.generate(curve=NIST256p)
+    sk = (SigningKey.from_pem(args.infile.read())
+          if args.infile else generate_legal_key())
 
     if args.private:
         args.out.write(sk.to_pem())


### PR DESCRIPTION
It is not possible provision digests with 0xffff since this
value can be used to trigger a write to the OTP region, which
breaks the security of the B0 bootloader.

This PR adds a check to the generated key to ensure that it
can be successfully provisioned.

Ref: NCSDK-10060
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>