### PR TITLE
samples: nrf9160: modem_shell: replace deprecated typedef

### DIFF
--- a/samples/nrf9160/modem_shell/src/gnss/gnss_socket.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_socket.c
@@ -36,7 +36,7 @@ static struct k_work_delayable gnss_timeout_work;
 #if defined(CONFIG_SUPL_CLIENT_LIB)
 static struct k_work get_agps_data_work;
 
-static nrf_gnss_agps_data_frame_t agps_data;
+static struct nrf_modem_gnss_agps_data_frame agps_data;
 #endif
 
 enum gnss_operation_mode {


### PR DESCRIPTION
Replaced deprecated typedef to remove a compilation warning when
building with SUPL support enabled.

NCSDK-10058

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>