### PR TITLE
manifest: pull Zephyr fix for IEEE802154

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d94780be5b6bf4faf979fda1815c9c183d101de1
+      revision: pull/554/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The Zephyr revision update fixes small bug which results
in unintentionall fall-through.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>