### PR TITLE
Samples: bluetooth: Remove support for nrf5340

### DIFF
--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -83,7 +83,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuappns,nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832, nrf52840dongle_nrf52840
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832, nrf52840dongle_nrf52840
 
 The sample also supports other development kits running SoftDevice Controller variants that support LLPM (see :ref:`nrfxlib:softdevice_controller` Proprietary feature support).
 You can use any two of the development kits mentioned above and mix different development kits.

--- a/samples/bluetooth/llpm/sample.yaml
+++ b/samples/bluetooth/llpm/sample.yaml
@@ -6,6 +6,5 @@ tests:
     build_only: true
     build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
       nrf52840dongle_nrf52840
     tags: bluetooth ci_build


### PR DESCRIPTION
LLPM is not supported on nrf5340 and this sample does not run on
nrf5340. Remove support for it.

Signed-off-by: Jan Müller <jan.mueller@nordicsemi.no>