### PR TITLE
applications: asset_tracker: initialize structs

### DIFF
--- a/applications/asset_tracker/src/env_sensors/env_sensors.c
+++ b/applications/asset_tracker/src/env_sensors/env_sensors.c
@@ -82,7 +82,7 @@ int env_sensors_poll(void)
 static void env_sensors_poll_fn(struct k_work *work)
 {
 	int num_sensors = ARRAY_SIZE(env_sensors);
-	struct sensor_value data[num_sensors];
+	struct sensor_value data[num_sensors] = {0};
 
 	int err;
 

--- a/applications/asset_tracker/src/motion/motion.c
+++ b/applications/asset_tracker/src/motion/motion.c
@@ -28,7 +28,7 @@ static int accelerometer_poll(motion_acceleration_data_t *sensor_data)
 
 	int err;
 
-	struct sensor_value accel_data[3];
+	struct sensor_value accel_data[3] = {0};
 
 	/* If using the ADXL362 driver, all channels must be fetched */
 	if (IS_ENABLED(CONFIG_ADXL362)) {


### PR DESCRIPTION
Initialize unitialized structs found by static code analysis.

CIA-336

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>