### PR TITLE
Memfault: Add information on how to change heartbeat interval and fix key reference

### DIFF
--- a/modules/memfault/memfault_integration.c
+++ b/modules/memfault/memfault_integration.c
@@ -30,9 +30,9 @@ LOG_MODULE_REGISTER(memfault_ncs, CONFIG_MEMFAULT_NCS_LOG_LEVEL);
 #define MEMFAULT_URL	"https://goto.memfault.com/create-key/nrf"
 #endif
 
-/* API key check */
+/* Project key check */
 BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_PROJECT_KEY) > 1,
-	"Memfault API Key not configured. Please visit " MEMFAULT_URL);
+	"Memfault Project Key not configured. Please visit " MEMFAULT_URL);
 
 /* Firmware type check */
 BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_FW_TYPE) > 1, "Firmware type must be configured");

--- a/samples/nrf9160/memfault/config/memfault_platform_config.h
+++ b/samples/nrf9160/memfault/config/memfault_platform_config.h
@@ -5,3 +5,11 @@
  * memfault-firmware-sdk. Default configuration settings can be found in
  * "<NCS folder>/modules/lib/memfault-firmware-sdk/components/include/memfault/default_config.h"
  */
+
+/* Uncomment the definition below to override the default setting for
+ * heartbeat interval. This will prepare the captured metric data for upload
+ * to Memfault cloud at the specified interval.
+ */
+/*
+ * #define MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS 1800
+ */

--- a/samples/nrf9160/memfault/prj.conf
+++ b/samples/nrf9160/memfault/prj.conf
@@ -38,8 +38,6 @@ CONFIG_MEMFAULT=y
 CONFIG_MEMFAULT_NCS_PROJECT_KEY=""
 CONFIG_MEMFAULT_SHELL=y
 CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD=y
-# Configure the option below to set the periodic data upload interval
-# CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD_INTERVAL_SECS=3600
 CONFIG_MEMFAULT_NCS_LTE_METRICS=y
 
 # Add to pick up support for sending Memfault data over HTTP

--- a/samples/nrf9160/memfault/src/main.c
+++ b/samples/nrf9160/memfault/src/main.c
@@ -141,6 +141,8 @@ static void button_handler(uint32_t button_states, uint32_t has_changed)
 		MEMFAULT_TRACE_EVENT_WITH_LOG(Switch2Toggled,
 					      "Switch state: %d",
 					      buttons_pressed & DK_BTN4_MSK ? 1 : 0);
+		LOG_INF("Switch2Toggled event has been traced, button state: %d",
+			buttons_pressed & DK_BTN4_MSK ? 1 : 0);
 	}
 }
 


### PR DESCRIPTION
samples: nrf9160: memfault: Add info on changing heartbeat interval

Add information on how to align the hearbeat interval with
the periodic upload interval.
Also add a missing log message.

---

modules: memfault: Fix reference to missing project key

The assert message refers to Memfault "API key", while "project key"
is used in our documentation and symbols.
Changing the message to refer to "project key".