### PR TITLE
Make CAF zephyr library

### DIFF
--- a/subsys/caf/modules/CMakeLists.txt
+++ b/subsys/caf/modules/CMakeLists.txt
@@ -4,17 +4,19 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-zephyr_sources_ifdef(CONFIG_CAF_BLE_ADV ble_adv.c)
+zephyr_library()
 
-zephyr_sources_ifdef(CONFIG_CAF_BLE_STATE ble_state.c)
+zephyr_library_sources_ifdef(CONFIG_CAF_BLE_ADV ble_adv.c)
 
-zephyr_sources_ifdef(CONFIG_CAF_BUTTONS buttons.c)
+zephyr_library_sources_ifdef(CONFIG_CAF_BLE_STATE ble_state.c)
 
-zephyr_sources_ifdef(CONFIG_CAF_CLICK_DETECTOR click_detector.c)
+zephyr_library_sources_ifdef(CONFIG_CAF_BUTTONS buttons.c)
 
-zephyr_sources_ifdef(CONFIG_CAF_LEDS leds.c)
+zephyr_library_sources_ifdef(CONFIG_CAF_CLICK_DETECTOR click_detector.c)
 
-zephyr_sources_ifdef(CONFIG_CAF_SENSOR_SAMPLER sensor_sampler.c)
+zephyr_library_sources_ifdef(CONFIG_CAF_LEDS leds.c)
 
-zephyr_sources_ifdef(CONFIG_CAF_BLE_SMP ble_smp.c)
-zephyr_link_libraries_ifdef(CONFIG_CAF_BLE_SMP MCUMGR)
+zephyr_library_sources_ifdef(CONFIG_CAF_SENSOR_SAMPLER sensor_sampler.c)
+
+zephyr_library_sources_ifdef(CONFIG_CAF_BLE_SMP ble_smp.c)
+zephyr_library_link_libraries_ifdef(CONFIG_MCUMGR MCUMGR)


### PR DESCRIPTION
Make CAF zephyr library similarly as its already done for other subsystems.

Jira: NCSDK-9863

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>