### PR TITLE
manifest: Update to nrfxlib PR-494

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d7795a15f59fed58f1e044a642fbae0786b51a4f
+      revision: pull/494/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-Fixes bug with enabling AES GCM in TF-M for 9160 devices

ref: NCSDK-10023

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>