### PR TITLE
manifest: Update ble-controller/MPSL revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1706b3dfd3d3270d2ad6c988fd5f5a6e46451d02
+      revision: 1a2428def00b0a1f6501c8000eb856b29f0e21dd
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Includes updates:
- Updates documentation
- Fixes bug related to critical timing

ble-controller revision: 22035804c766c55afec09e55e85f0ea192f2db46
mpsl revision: dfffe7a007476b017dd6078a3aceb6d457d042c5

Related PR to nrfxlib: https://github.com/nrfconnect/sdk-nrfxlib/pull/496

Signed-off-by: Jan Müller <jan.mueller@nordicsemi.no>