### PR TITLE
manifest: updating manifest to nRF security / TF-M CMake fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a8f3c1dabb2a2b16c45b10f53118ef91247c0311
+      revision: pull/558/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d7795a15f59fed58f1e044a642fbae0786b51a4f
+      revision: pull/493/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Fixes: NCSDK-10008

This updates nrfxlib and sdk-zephyr to include fixes regarding CMake.

This commit includes project updates for the following fixes:
- nrfxlib
  - Rework TF-M mbedTLS header copy into a CMake script file on windows
  - Extracting of imported libraries is now performed as independent
    custom target using the extraction in a custom command instead of
    being a post build command
  - Using archiving script when archiving all objects in a folder to
    avoid issues where `*` would be treated as filename instead of a
    wild card
- sdk-zephyr
  - Limit number of parallel jobs to 1 when building TF-M on Windows

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>