### PR TITLE
doc: openhread: fix Thread 1.2 documentation

### DIFF
--- a/doc/nrf/ug_thread_configuring.rst
+++ b/doc/nrf/ug_thread_configuring.rst
@@ -129,9 +129,10 @@ You can change the stack version by using the following Kconfig options:
 
 By selecting support for Thread 1.2, you enable the following features in addition to the :ref:`Thread 1.1 features <thread_ug_supported_features>`:
 
-* Enhanced Frame Pending
-* Enhanced Keep Alive
-* Thread Domain Name
+* Enhanced Frame Pending.
+* Enhanced Keep Alive.
+* Thread Domain Name.
+* Coordinated Sampled Listening (CSL) Transmitter, for Full Thread Devices only.
 
 Moreover, Thread 1.2 also comes with the following features that are supported for development, but not production:
 
@@ -143,6 +144,7 @@ Moreover, Thread 1.2 also comes with the following features that are supported f
 
 .. note::
    The Link Metrics and Coordinated Sampled Listening features are not supported for nRF53 Series devices yet.
+   The Backbone Router feature enables the Thread Network side functionality, but not the Backbone side functionality.
 
 To test Thread 1.2 options, you can use the :ref:`ot_cli_sample` sample with the :ref:`ot_cli_sample_thread_v12`.
 

--- a/doc/nrf/ug_thread_supported_features.rst
+++ b/doc/nrf/ug_thread_supported_features.rst
@@ -35,6 +35,11 @@ In |NCS|, you can choose which version of the Thread protocol to use in your app
 By default, |NCS| supports Thread 1.1, but you can enable and configure Thread 1.2 by using :ref:`dedicated options <thread_ug_thread_1_2>`.
 
 .. note::
-    Not all Thread 1.2 functionalities are currently supported.
+    All Thread 1.2 mandatory functionalities are currently supported, execept for full Border Router support.
     See :ref:`thread_ug_thread_1_2` for the list of 1.2 features that are currently available in |NCS|, with information about how to enable them.
     Currently, the :ref:`ot_cli_sample` sample is the only sample that provides an :ref:`ot_cli_sample_thread_v12`.
+
+.. note::
+    Currently there is a limitation which prevents from sending secured retransmissions when Thread 1.2 is enabled.
+    Thus,retransmissions are disabled by default for Thread 1.2.
+    Users should enabled them at they own risk.


### PR DESCRIPTION
Fix statements about Thread 1.2 features support.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

Depends on:

- [ ] https://github.com/nrfconnect/sdk-nrf/pull/4880