### PR TITLE
manifest: update nrfxlib and sdk-zephyr with combined manifest updates

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a8f3c1dabb2a2b16c45b10f53118ef91247c0311
+      revision: d94780be5b6bf4faf979fda1815c9c183d101de1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d7795a15f59fed58f1e044a642fbae0786b51a4f
+      revision: a6baa0748c486ce71918a97740ae105ba586092e
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
This manifest is a combined update for the following nrfxlib PRs:
https://github.com/nrfconnect/sdk-nrfxlib/pull/492
https://github.com/nrfconnect/sdk-nrfxlib/pull/493
https://github.com/nrfconnect/sdk-nrfxlib/pull/494

https://github.com/nrfconnect/sdk-zephyr/pull/548
https://github.com/nrfconnect/sdk-zephyr/pull/558
https://github.com/nrfconnect/sdk-zephyr/pull/560

-----------------------------------------------------------------------
manifest update commit message: nrfxlib:#492
manifest: Point to nrfxlib with nrf_cc3xx 0.9.10

-Adding CryptoCell runtime library version 0.9.10

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>

-----------------------------------------------------------------------
manifest update commit message: nrfxlib:#493, sdk-zephyr:#558
manifest: updating manifest to nRF security / TF-M CMake fixes

Fixes: NCSDK-10008

This updates nrfxlib and sdk-zephyr to include fixes regarding CMake.

This commit includes project updates for the following fixes:
- nrfxlib
  - Rework TF-M mbedTLS header copy into a CMake script file on windows
  - Extracting of imported libraries is now performed as independent
    custom target using the extraction in a custom command instead of
    being a post build command
  - Using archiving script when archiving all objects in a folder to
    avoid issues where `*` would be treated as filename instead of a
    wild card
- sdk-zephyr
  - Limit number of parallel jobs to 1 when building TF-M on Windows

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-----------------------------------------------------------------------
manifest update commit message: nrfxlib:#494
manifest: Update to nrfxlib PR-494

-Fixes bug with enabling AES GCM in TF-M for 9160 devices

ref: NCSDK-10023

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>

-----------------------------------------------------------------------
manifest update commit message: sdk-zephyr:#548
manifest: update sdk-zephyr

Update sdk-zephyr with fixes for watchdog and timer tests failures

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>