### PR TITLE
lib: supl: remove dependency to FPU

### DIFF
--- a/lib/supl/Kconfig
+++ b/lib/supl/Kconfig
@@ -6,6 +6,5 @@
 
 config SUPL_CLIENT_LIB
 	bool "SUPL Client library"
-	select FPU
 	help
 	  A library for accessing AGPS data using the SUPL protocol


### PR DESCRIPTION
The next version of the SUPL library will have support for soft-float,
so there should be no dependency to FPU.

NCSDK-10148

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>