### PR TITLE
net: lib: nrf_cloud: Add missing break statement

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -869,6 +869,7 @@ static int start_job(struct nrf_cloud_fota_job *const job)
 		break;
 	case NRF_CLOUD_FOTA_MODEM:
 		img_type = DFU_TARGET_IMAGE_TYPE_MODEM_DELTA;
+		break;
 	default:
 		LOG_ERR("Unhandled FOTA type: %d", job->info.type);
 		return -EFTYPE;


### PR DESCRIPTION
Add missing break statement in FOTA type check.
This fixes an issue where modem FOTA would be wrongly terminated.

Fixes NCSDK-10140

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>