### PR TITLE
lib: sms: Acknowledge unsupported/invalid SMS

### DIFF
--- a/lib/sms/sms_at.c
+++ b/lib/sms/sms_at.c
@@ -16,6 +16,7 @@
 
 #include "string_conversion.h"
 #include "parser.h"
+#include "sms_at.h"
 #include "sms_submit.h"
 #include "sms_deliver.h"
 #include "sms_internal.h"
@@ -105,7 +106,6 @@ int sms_at_parse(const char *at_notif, struct sms_data *sms_data_info,
 		}
 		err = sms_deliver_pdu_parse(sms_buf_tmp, sms_data_info);
 		if (err) {
-			LOG_ERR("sms_deliver_pdu_parse error: %d\n", err);
 			return err;
 		}
 	} else if (strncmp(at_notif, AT_SMS_STATUS_REPORT, AT_SMS_STATUS_REPORT_LEN) == 0) {
@@ -119,12 +119,11 @@ int sms_at_parse(const char *at_notif, struct sms_data *sms_data_info,
 		err = sms_notif_at_parse(at_notif, sms_buf_tmp, SMS_BUF_TMP_LEN,
 				AT_CDS_PARAMS_COUNT, AT_CDS_PDU_INDEX, temp_resp_list);
 		if (err != 0) {
-			LOG_ERR("sms_cds_at_parse error: %d", err);
 			return err;
 		}
 	} else {
 		/* Ignore all other notifications */
-		return -EINVAL;
+		return -ENOTSMSAT;
 	}
 
 	return 0;

--- a/lib/sms/sms_at.h
+++ b/lib/sms/sms_at.h
@@ -7,6 +7,9 @@
 #ifndef _SMS_AT_INCLUDE_H_
 #define _SMS_AT_INCLUDE_H_
 
+/** @brief Error code for AT command that is not SMS related. */
+#define ENOTSMSAT 0x0FFFFFFF
+
 /**
  * @brief Parse AT notifications finding relevant notifications for SMS and
  * dropping the rest.

--- a/lib/sms/sms_deliver.c
+++ b/lib/sms/sms_deliver.c
@@ -712,7 +712,11 @@ static int decode_pdu_deliver_message(struct parser *parser, uint8_t *buf)
 		return decode_pdu_ud_7bit(parser, buf);
 	case 1:
 		return decode_pdu_ud_8bit(parser, buf);
-	default:
+	case 2:
+		LOG_ERR("Unsupported data coding scheme: UCS2");
+		return -ENOTSUP;
+	default: /* case 3: is a reserved value */
+		LOG_ERR("Unsupported data coding scheme: Reserved");
 		return -ENOTSUP;
 	};
 
@@ -843,12 +847,11 @@ int sms_deliver_pdu_parse(const char *pdu, struct sms_data *data)
 	parser_get_header(&sms_deliver, header);
 
 	data->payload_len = parser_get_payload(&sms_deliver,
-					  data->payload,
-					  SMS_MAX_PAYLOAD_LEN_CHARS);
+					       data->payload,
+					       SMS_MAX_PAYLOAD_LEN_CHARS);
 
 	if (data->payload_len < 0) {
-		LOG_ERR("Getting sms deliver payload failed: %d\n",
-			data->payload_len);
+		LOG_ERR("Decoding SMS-DELIVER payload failed: %d", data->payload_len);
 		return data->payload_len;
 	}
 

--- a/tests/lib/sms/src/sms_test.c
+++ b/tests/lib/sms/src/sms_test.c
@@ -600,6 +600,7 @@ void test_send_cds_erroneous(void)
 	TEST_ASSERT_EQUAL(AT_CMD_OK, state);
 
 	/* Fail to receive SMS-STATUS-REPORT */
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	/* Removed length (24) from CDS */
 	sms_at_handler(NULL, "+CDS: \r\n06550A912143658709122022118314801220221183148000\r\n");
@@ -1124,6 +1125,7 @@ void test_recv_invalid_hex_characters(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+1234567890\",18\r\n"
 		"00040A91214365870900001220A00285438009123456KLAB\r\n");
@@ -1139,6 +1141,7 @@ void test_recv_invalid_header_too_short(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+1234567890\",18\r\n"
 		"00040A91214365870900001220A0028543800\r\n");
@@ -1151,6 +1154,7 @@ void test_recv_fail_number21(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+123456789012345678901\",32\r\n"
 		"0004169121436587092143658709F10000122090028543800831D98C56B3DD70\r\n");
@@ -1163,6 +1167,7 @@ void test_recv_cmt_erroneous(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	/* Size missing (22\r\n) */
 	sms_at_handler(NULL, "+CMT: \"+1234567890\","
@@ -1176,9 +1181,23 @@ void test_recv_fail_invalid_dcs_ucs2(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+1234567890\",22\r\n"
 		"004408812143658700081210032143652b1c0b05040b84000000037c0101010203040506070809\r\n");
+
+	sms_unreg_helper();
+}
+
+/** DCS not supported (reserved): 0x0C */
+void test_recv_fail_invalid_dcs_reserved_value(void)
+{
+	sms_reg_helper();
+
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
+	sms_callback_called_expected = false;
+	sms_at_handler(NULL, "+CMT: \"+1234567890\",22\r\n"
+		"0044088121436587000C1210032143652b1c0b05040b84000000037c0101010203040506070809\r\n");
 
 	sms_unreg_helper();
 }
@@ -1188,6 +1207,7 @@ void test_recv_fail_invalid_dcs_unsupported_format(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+1234567890\",22\r\n"
 		"004408812143658700801210032143652b1c0b05040b84000000037c0101010203040506070809\r\n");
@@ -1200,6 +1220,7 @@ void test_recv_fail_len161(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+1234567890\",22\r\n"
 		"00040A912143658709000012201232054480A131D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031\r\n");
@@ -1216,6 +1237,7 @@ void test_recv_fail_internal_pdu_buffer_too_short(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+1234567890\",22\r\n"
 		"00040A912143658709000012201232054480A031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E560\r\n");
@@ -1232,6 +1254,7 @@ void test_recv_fail_internal_payload_buffer_too_short(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+1234567890\",22\r\n"
 		"0B912143658709214365870904149121436587092143658709000012201232054480A031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E560313233343536\r\n");
@@ -1377,6 +1400,7 @@ void test_recv_fail_udhl_longer_than_udh(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+1234567890\",22\r\n"
 		"00440A912143658709000012201232054480050500037E0201AAAA\r\n");
@@ -1389,6 +1413,7 @@ void test_recv_fail_udhl_longer_than_ud(void)
 {
 	sms_reg_helper();
 
+	__wrap_at_cmd_write_ExpectAndReturn("AT+CNMA=1", NULL, 0, NULL, 0);
 	sms_callback_called_expected = false;
 	sms_at_handler(NULL, "+CMT: \"+1234567890\",22\r\n"
 		"00440A91214365870900001220123205448004030201\r\n");


### PR DESCRIPTION
When received SMS is malformed or using features that we don't support, it was not acknowledged with AT+CNMA=1. This caused SMS service between the device and LTE network to get stuck, i.e., no further messages could be sent or received.

An example is a message with UCS2 data encoding with an emoji or Asian characters. This was not supported and just ignored without acknowledging it. We'll continue to ignore the message content but will acknowledge it to keep SMS service working.

Improved error logging related to UCS2 encoded message.

JIRA: NCSDK-10152