### PR TITLE
lib: agps: Close SUPL socket if `supl_session()` fails

### DIFF
--- a/lib/agps/agps.c
+++ b/lib/agps/agps.c
@@ -315,11 +315,12 @@ static int supl_start(const struct gps_agps_request request)
 	err = supl_session(&req);
 	if (err) {
 		LOG_ERR("SUPL session failed, error: %d", err);
-		return err;
+		goto cleanup;
 	}
 
 	LOG_INF("SUPL session finished successfully");
 
+cleanup:
 	close_supl_socket();
 
 	return err;


### PR DESCRIPTION
Close socket used for SUPL if `supl_session()` fails.

Closes CIA-343