### PR TITLE
zigbee: use log_strdup in logger ep handler

### DIFF
--- a/subsys/zigbee/lib/zigbee_logger_ep/zigbee_logger_eprxzcl.c
+++ b/subsys/zigbee/lib/zigbee_logger_ep/zigbee_logger_eprxzcl.c
@@ -248,7 +248,7 @@ zb_uint8_t zigbee_logger_eprxzcl_ep_handler(zb_bufid_t bufid)
 
 		*log_message_curr = '\0';
 
-		LOG_INST_INF(logger.inst, "%s", log_message);
+		LOG_INST_INF(logger.inst, "%s", log_strdup(log_message));
 	}
 
 	return ZB_FALSE;


### PR DESCRIPTION
Call log_strdup in zigbee_logger_eprxzcl_ep_handler.
This will duplicate a log message before passing to zephyr's
logger. Fixes an assertion in log_core which occurs when:
* LOG_MODE_DEFERRED is used
* LOG_MINIMAL is not used.

Signed-off-by: Filip Zajdel <filip.zajdel@nordicsemi.no>