### PR TITLE
actions: labeler: Ignore changes to Bluetooth Mesh in ble and homekit

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -60,9 +60,15 @@
   - "tests/subsys/spm/secure_services/**/*"
 
 "CI-ble-test":
-  - "subsys/bluetooth/**/*"
-  - "include/bluetooth/**/*"
-  - "samples/bluetooth/**/*"
+  - any:
+    - "subsys/bluetooth/**/*"
+    - "!subsys/bluetooth/mesh/**/*"
+  - any:
+    - "include/bluetooth/**/*"
+    - "!include/bluetooth/mesh/**/*"
+  - any:
+    - "samples/bluetooth/**/*"
+    - "!samples/bluetooth/mesh/**/*"
 
 "CI-mesh-test":
   - "subsys/bluetooth/mesh/**/*"
@@ -127,16 +133,21 @@
   - "samples/CMakeLists.txt"
 
 "CI-homekit-test":
-  - "subsys/mpsl/**/*"
-  - "drivers/mpsl/**/*"
-  - "dts/bindings/radio_fem/**/*"
-  - "modules/nrfxlib/nrf_802154/**/*"
-  - "drivers/hw_cc310/*"
-  - "subsys/bluetooth/**/*"
-  - "include/bluetooth/**/*"
-  - "subsys/bootloader/**/*"
-  - "subsys/partition_manager/**/*"
-  - "modules/mcuboot/**/*"
+  - any:
+    - "subsys/mpsl/**/*"
+    - "drivers/mpsl/**/*"
+    - "dts/bindings/radio_fem/**/*"
+    - "modules/nrfxlib/nrf_802154/**/*"
+    - "drivers/hw_cc310/*"
+    - "subsys/bootloader/**/*"
+    - "subsys/partition_manager/**/*"
+    - "modules/mcuboot/**/*"
+  - any:
+    - "subsys/bluetooth/**/*"
+    - "!subsys/bluetooth/mesh/**/*"
+  - any:
+    - "include/bluetooth/**/*"
+    - "!include/bluetooth/mesh/**/*"
 
 "CI-thread-test":
   - "samples/openthread/**/*"


### PR DESCRIPTION
Don't add labels CI-homekit-test and CI-bluetooth-test when changes only
apply to the Bluetooth Mesh subsystem.

--- 
This finally solves this labeling headache for Bluetooth Mesh, where people keep fighting the bot to avoid running homekit and ble tests on something that isn't relevant to these test plans (see for instance #4504).

This configuration is tested here:
- changes to mesh should only trigger mesh label: https://github.com/trond-snekvik/fw-nrfconnect-nrf/pull/3
- changes to mesh and bluetooth should add `CI-ble-test`, `CI-homekit-test` and `CI-mesh-test`: https://github.com/trond-snekvik/fw-nrfconnect-nrf/pull/4
- changes only to bluetooth should just add `CI-ble-test` and `CI-homekit-test`, and not mesh: https://github.com/trond-snekvik/fw-nrfconnect-nrf/pull/6
- changes outside bluetooth should not add any of the affected labels: https://github.com/trond-snekvik/fw-nrfconnect-nrf/pull/5

The `CI-desktop-test` labels  are also added to some of these tests, but that does not have a recursive pattern, and won't pick up mesh files anyway, so it's not causing any issues.