### PR TITLE
doc: zigbee: add NCP Host links and versions

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -135,6 +135,7 @@
 .. _`Stack commissioning start sequence`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/using_zigbee__z_c_l.html#stack_start_initiation
 .. _`ZBOSS NCP Host`: https://developer.nordicsemi.com/Zigbee/ncp_sdk_for_host/ncp_host_v0.9.5.zip
 .. _`NCP Host documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zboss_ncp_host_intro.html
+.. _`Rebuilding the ZBOSS libraries for host`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zboss_ncp_host.html#rebuilding_libs
 .. _`process the frame`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/using_zigbee__z_c_l.html#process_zcl_cmd
 .. _`declaring custom cluster`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/using_zigbee__z_c_l.html#cluster_declaration_custom
 .. _`Configuring sleepy behavior for end devices`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zigbee_prog_principles.html#zigbee_power_optimization_sleepy

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -53,6 +53,8 @@
    When enabled, it allows devices to manage transmission by informing each other about their current state, and ensures more reliable connection in high-speed communication scenarios.
 
 .. |zigbee_version| replace:: Zigbee 3.0
+.. |zboss_version| replace:: 3.6.0.0
+.. |zigbee_ncp_package_version| replace:: 0.9.5
 .. |zigbee_description| replace:: Zigbee is a portable, low-power software networking protocol that provides connectivity over an 802.15.4-based mesh network.
 .. |enable_zigbee_before_testing| replace:: Make sure to configure the Zigbee stack before building and testing this sample.
    See :ref:`ug_zigbee_configuring` for more information.
@@ -60,7 +62,7 @@
    See :ref:`ug_zigbee_configuring_libraries` for information about how to configure it for you Zigbee application.
 .. |zigbee_ncp_package| replace:: It contains the full development-ready source code for host and evaluation-ready firmware for the nRF52840 DK, the nRF52833 DK, and the nRF52840 Dongle.
    The package comes with prebuilt libraries compatible with 64-bit Ubuntu 18.04 Linux.
-.. |zigbee_ncp_package_more_info| replace:: For information about how to recompile the library for different host architecture or operating system, see the `NCP Host documentation`_.
+.. |zigbee_ncp_package_more_info| replace:: For information about how to recompile the package libraries for a different host architecture or operating system, see the `NCP Host documentation`_.
    For information about how to use NCP Host for Zigbee in the |NCS| or build the firmware using the NCP sample, see the :ref:`NCP sample <zigbee_ncp_sample>`.
 .. |zigbee_shell_config| replace:: You can add support for Zigbee shell commands to any of the available :ref:`Zigbee samples <zigbee_samples>`, except for the :ref`NCP sample <zigbee_ncp_sample>`.
    Some of the commands use an endpoint for sending packets, so no endpoint handler is allowed to be registered for this endpoint.

--- a/doc/nrf/ug_zigbee.rst
+++ b/doc/nrf/ug_zigbee.rst
@@ -9,7 +9,7 @@ Zigbee is a portable, low-power software networking protocol that provides conne
 It also defines an application layer that provides interoperability among all Zigbee devices.
 
 The |NCS| provides support for developing Zigbee applications based on the third-party precompiled ZBOSS stack.
-This stack is included as the :ref:`nrfxlib:zboss` library in nrfxlib.
+This stack is included as the :ref:`nrfxlib:zboss` library in nrfxlib (version |zboss_version|).
 In combination with the integrated Zephyr RTOS, Zigbee in |NCS| allows for development of low-power connected solutions.
 
 .. zigbee_ug_intro_end

--- a/doc/nrf/ug_zigbee_architectures.rst
+++ b/doc/nrf/ug_zigbee_architectures.rst
@@ -125,8 +125,12 @@ It also has the following disadvantages:
 
    Split Zigbee architecture
 
-The |NCS|'s :ref:`ug_zigbee_tools` include the `ZBOSS NCP Host`_, which is available for download as a standalone :file:`zip` package.
+The |NCS| includes the :ref:`ug_zigbee_tools_ncp_host` tool.
 |zigbee_ncp_package|
+
+The tool is available for download as a standalone :file:`zip` package using the following link:
+
+* `ZBOSS NCP Host`_ (|zigbee_ncp_package_version|)
 
 |zigbee_ncp_package_more_info|
 

--- a/doc/nrf/ug_zigbee_tools.rst
+++ b/doc/nrf/ug_zigbee_tools.rst
@@ -24,8 +24,12 @@ See `nRF Sniffer for 802.15.4`_ for documentation.
 ZBOSS NCP Host
 **************
 
-The NCP Host is a ZBOSS-based tool for running the host side of the :ref:`ug_zigbee_platform_design_ncp_details` design, distributed as a standalone :file:`zip` package.
+The NCP Host is a ZBOSS-based tool for running the host side of the :ref:`ug_zigbee_platform_design_ncp_details` design.
 |zigbee_ncp_package|
+
+The tool is available for download as a standalone :file:`zip` package using the following link:
+
+* `ZBOSS NCP Host`_ (|zigbee_ncp_package_version|)
 
 |zigbee_ncp_package_more_info|
 

--- a/samples/zigbee/light_bulb/README.rst
+++ b/samples/zigbee/light_bulb/README.rst
@@ -105,7 +105,7 @@ This sample uses the following |NCS| libraries:
 
 This sample uses the following `sdk-nrfxlib`_ libraries:
 
-* :ref:`nrfxlib:zboss` (`API documentation`_)
+* :ref:`nrfxlib:zboss` |zboss_version| (`API documentation`_)
 
 In addition, it uses the following Zephyr libraries:
 

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -287,7 +287,7 @@ This sample uses the following |NCS| libraries:
 
 This sample uses the following `sdk-nrfxlib`_ libraries:
 
-* :ref:`nrfxlib:zboss` (`API documentation`_)
+* :ref:`nrfxlib:zboss` |zboss_version| (`API documentation`_)
 
 In addition, it uses the following Zephyr libraries:
 

--- a/samples/zigbee/ncp/README.rst
+++ b/samples/zigbee/ncp/README.rst
@@ -9,7 +9,7 @@ Zigbee: NCP
 
 The :ref:`Zigbee <ug_zigbee>` NCP sample demonstrates the usage of Zigbee's :ref:`ug_zigbee_platform_design_ncp_details` architecture.
 
-Together with the source code from `ZBOSS NCP Host`_, you can use this sample to create a complete and functional Zigbee device.
+Together with the source code from :ref:`ug_zigbee_tools_ncp_host`, you can use this sample to create a complete and functional Zigbee device.
 For example, as shown in the `Testing`_ scenario, you can program a development kit with the NCP sample and bundle it with the simple gateway application on the NCP host processor.
 
 You can then use this sample together with the :ref:`Zigbee light bulb <zigbee_light_bulb_sample>` to set up a basic Zigbee network.
@@ -30,10 +30,12 @@ You can use any of the development kits listed above.
 
 For this sample to work, you also need the following:
 
-* `ZBOSS NCP Host`_ tool, which is based on the ZBOSS stack and available for download as a standalone :file:`zip` package as one of :ref:`ug_zigbee_tools`.
-  It contains the source code for all parts of the ZBOSS library for the NCP host.
-  This allows you to recompile the library for the designated hardware platform.
-  Running the ZBOSS NCP Host requires a PC with an operating system compatible with the 64-bit Ubuntu 18.04 Linux.
+* :ref:`ug_zigbee_tools_ncp_host` tool, which is based on the ZBOSS stack and requires a PC with an operating system compatible with the 64-bit Ubuntu 18.04 Linux.
+  The tool is available for download as a standalone :file:`zip` package using the following link:
+
+  * `ZBOSS NCP Host`_ (|zigbee_ncp_package_version|)
+
+  For more information, see also the `NCP Host documentation`_.
 * The :ref:`zigbee_light_bulb_sample` sample programmed on one separate device.
 
 This means that you need at least two development kits for testing this sample.
@@ -183,7 +185,7 @@ After building the sample and programming it to your development kit, test it by
 1. Download and extract the `ZBOSS NCP Host`_ package.
 
    .. note::
-      If you are using an Linux distribution different than the 64-bit Ubuntu 18.04, make sure to rebuild the package libraries and applications by following the instructions described in the :file:`README.rst` file in the ZBOSS NCP Host package.
+      If you are using an Linux distribution different than the 64-bit Ubuntu 18.04, make sure to rebuild the package libraries and applications by following the instructions described in the `Rebuilding the ZBOSS libraries for host`_ section in the `NCP Host documentation`_.
 
 #. If you are using `Communication through USB`_, connect the nRF USB port of the NCP sample's development kit to the PC USB port with an USB cable.
 #. Get the kit’s serial port name (for example, /dev/ttyACM0).
@@ -212,7 +214,7 @@ This sample uses the following |NCS| libraries:
 
 This sample uses the following `sdk-nrfxlib`_ libraries:
 
-* :ref:`nrfxlib:zboss` (`API documentation`_)
+* :ref:`nrfxlib:zboss` |zboss_version| (`API documentation`_)
 
 In addition, it uses the following Zephyr libraries:
 

--- a/samples/zigbee/network_coordinator/README.rst
+++ b/samples/zigbee/network_coordinator/README.rst
@@ -111,7 +111,7 @@ This sample uses the following |NCS| libraries:
 
 This sample uses the following `sdk-nrfxlib`_ libraries:
 
-* :ref:`nrfxlib:zboss` (`API documentation`_)
+* :ref:`nrfxlib:zboss` |zboss_version| (`API documentation`_)
 
 In addition, it uses the following Zephyr libraries:
 


### PR DESCRIPTION
Added prominent links for downloading NCP Host.
Rewrote NCP host description.
Added version shortcuts for ZBOSS and NCP Host.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>