### PR TITLE
doc: known_issues: Add section about FMFU and newest J-Link

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -177,6 +177,13 @@ Modem FW reset on debugger connection through SWD
   If a debugger (for example, J-Link) is connected via SWD to the nRF9160, the modem firmware will reset.
   Therefore, the LTE modem cannot be operational during debug sessions.
 
+  .. rst-class:: v1-6-0 v1-5-1 v1-5-0
+
+NCSDK-9441: Fmfu SMP server sample is unstable with the newest J-Link version
+  Full modem serial update does not work on development kit with debugger chip version delivered with J-Link software > 6.88a
+
+  **Workaround:** Downgrade the debugger chip to the firmware released with J-Link 6.88a or use another way of transferring serial data to the chip.
+
 nRF5
 ****
 


### PR DESCRIPTION
There is an issue with the newer J-Link versions which causes the UART
communication to break when sending the modem firmware data using the
SMP protocol.

This affects every version of the FMFU SMP Server sample. Using J-Link
firmware on the debugger chip from 6.88a fixes this issue.

Ref. NCSDK-9441

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>