### PR TITLE
manifest: Update sdk-zephyr revision to fix TF-M Regression tests

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 02f76ba0e91ba0fe5bb58f38bb787cd652d818b8
+      revision: pull/565/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Disables SHA-1 in TF-M Regression test sample to fix failing tests

Ref.: NCSDK-9954