### PR TITLE
samples: Fix bug in hkdf crypto sample

### DIFF
--- a/samples/crypto/hkdf/src/main.c
+++ b/samples/crypto/hkdf/src/main.c
@@ -114,7 +114,7 @@ int export_derived_key(void)
 
 	PRINT_MESSAGE("Compare derived key with expected value...");
 	cmp_status = memcmp(m_expected_output_key, m_output_key, sizeof(m_output_key));
-	if (status != 0) {
+	if (cmp_status != 0) {
 		PRINT_MESSAGE("Error, the derived key doesn't match the expected value!");
 		return APP_ERROR;
 	}


### PR DESCRIPTION
-The example uses a wrong variable to compare
 the resul of the hkdf operation with the
 expected value

Ref: NCSIDB-488

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>