### PR TITLE
Bluetooth: Mesh: Fix publishing composite state on scene recall

### DIFF
--- a/include/bluetooth/mesh/scene_srv.h
+++ b/include/bluetooth/mesh/scene_srv.h
@@ -150,6 +150,21 @@ struct bt_mesh_scene_entry {
 	 */
 	void (*recall)(struct bt_mesh_model *model, const uint8_t data[],
 		       size_t len, struct bt_mesh_model_transition *transition);
+
+	/** @brief Recall a scene is completed
+	 *
+	 * This callback is called for each model that has a scene entry when
+	 * recalling a scene data is done and @ref bt_mesh_scene_entry::recall
+	 * callback has been called for all models. The model can use this
+	 * callback when it needs to publish its state, which is a composite
+	 * state and requires all corresponding models to recall their scene
+	 * data first.
+	 *
+	 * Can be NULL.
+	 *
+	 *  @param[in] model      Model to restore the scene of.
+	 */
+	void (*recall_complete)(struct bt_mesh_model *model);
 };
 
 /** @brief Notify the Scene Server that a Scene entry has changed.

--- a/include/bluetooth/mesh/scene_srv.rst
+++ b/include/bluetooth/mesh/scene_srv.rst
@@ -80,6 +80,9 @@ If a scene store operation is requested in the middle of a transition between tw
 
 The ``recall`` callback contains a transition time pointer, which should be taken into account when implementing the model behavior.
 
+The ``recall_complete`` callback is called to notify that recalling scene data is finished.
+A model can use this callback when it needs to publish its state, which is a composite state and requires all corresponding models to recall their scene data first.
+
 Invalidating scene data
 ***********************
 

--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -260,6 +260,14 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	};
 
 	srv->handlers->set(srv, NULL, &set, &status);
+}
+
+static void scene_recall_complete(struct bt_mesh_model *model)
+{
+	struct bt_mesh_lvl_srv *srv = model->user_data;
+	struct bt_mesh_lvl_status status = { 0 };
+
+	srv->handlers->get(srv, NULL, &status);
 
 	(void)bt_mesh_lvl_srv_pub(srv, NULL, &status);
 }
@@ -269,6 +277,7 @@ BT_MESH_SCENE_ENTRY_SIG(lvl) = {
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
+	.recall_complete = scene_recall_complete,
 };
 
 static int update_handler(struct bt_mesh_model *model)

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -160,6 +160,14 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	};
 
 	srv->handlers->set(srv, NULL, &set, &status);
+}
+
+static void scene_recall_complete(struct bt_mesh_model *model)
+{
+	struct bt_mesh_onoff_srv *srv = model->user_data;
+	struct bt_mesh_onoff_status status = { 0 };
+
+	srv->handlers->get(srv, NULL, &status);
 
 	(void)bt_mesh_onoff_srv_pub(srv, NULL, &status);
 }
@@ -169,6 +177,7 @@ BT_MESH_SCENE_ENTRY_SIG(onoff) = {
 	.maxlen = 1,
 	.store = scene_store,
 	.recall = scene_recall,
+	.recall_complete = scene_recall_complete,
 };
 /* .. include_endpoint_scene_srv_rst_1 */
 

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -248,6 +248,14 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	};
 
 	srv->onoff_handlers->set(&srv->onoff, NULL, &set, &status);
+}
+
+static void scene_recall_complete(struct bt_mesh_model *model)
+{
+	struct bt_mesh_ponoff_srv *srv = model->user_data;
+	struct bt_mesh_onoff_status status = { 0 };
+
+	srv->onoff_handlers->get(&srv->onoff, NULL, &status);
 
 	(void)bt_mesh_onoff_srv_pub(&srv->onoff, NULL, &status);
 }
@@ -257,6 +265,7 @@ BT_MESH_SCENE_ENTRY_SIG(ponoff) = {
 	.maxlen = 1,
 	.store = scene_store,
 	.recall = scene_recall,
+	.recall_complete = scene_recall_complete,
 };
 
 static int update_handler(struct bt_mesh_model *model)

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -182,7 +182,7 @@ static void light_set(struct bt_mesh_light_ctrl_srv *srv, uint16_t lvl,
 	};
 	struct bt_mesh_lightness_status dummy;
 
-	lightness_srv_change_lvl(srv->lightness, NULL, &set, &dummy);
+	lightness_srv_change_lvl(srv->lightness, NULL, &set, &dummy, true);
 }
 
 static uint32_t remaining_fade_time(struct bt_mesh_light_ctrl_srv *srv)
@@ -1436,7 +1436,7 @@ static ssize_t scene_store(struct bt_mesh_model *model, uint8_t data[])
 #endif
 
 	srv->lightness->handlers->light_get(srv->lightness, NULL, &light);
-	scene->lightness = repr_to_light(light.remaining_time ? light.target : light.current,
+	scene->lightness = light_to_repr(light.remaining_time ? light.target : light.current,
 					 ACTUAL);
 
 	return sizeof(struct scene_data);
@@ -1465,13 +1465,13 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	} else {
 		struct bt_mesh_lightness_status status;
 		struct bt_mesh_lightness_set set = {
-			.lvl = scene->lightness,
+			.lvl = repr_to_light(scene->lightness, ACTUAL),
 			.transition = transition,
 		};
 
 		ctrl_disable(srv);
 		schedule_resume_timer(srv);
-		lightness_srv_change_lvl(srv->lightness, NULL, &set, &status);
+		lightness_srv_change_lvl(srv->lightness, NULL, &set, &status, true);
 	}
 }
 

--- a/subsys/bluetooth/mesh/light_hue_srv.c
+++ b/subsys/bluetooth/mesh/light_hue_srv.c
@@ -65,17 +65,6 @@ static void encode_status(struct net_buf_simple *buf,
 	}
 }
 
-static void rsp_status(struct bt_mesh_model *model,
-		       struct bt_mesh_msg_ctx *rx_ctx,
-		       struct bt_mesh_light_hue_status *status)
-{
-	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_HUE_OP_STATUS,
-				 BT_MESH_LIGHT_HSL_MSG_MAXLEN_HUE_STATUS);
-	encode_status(&msg, status);
-
-	(void)bt_mesh_model_send(model, rx_ctx, &msg, NULL, NULL);
-}
-
 static void hue_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		    struct net_buf_simple *buf, bool ack)
 {
@@ -105,7 +94,7 @@ static void hue_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		 * to the app, but we still have to respond with a status.
 		 */
 		srv->handlers->get(srv, NULL, &status);
-		rsp_status(model, ctx, &status);
+		(void)bt_mesh_light_hue_srv_pub(srv, ctx, &status);
 		return;
 	}
 
@@ -135,7 +124,7 @@ static void hue_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	};
 
 	if (ack) {
-		rsp_status(model, ctx, &status);
+		(void)bt_mesh_light_hue_srv_pub(srv, ctx, &status);
 	}
 
 	(void)bt_mesh_light_hue_srv_pub(srv, NULL, &status);
@@ -158,7 +147,7 @@ static void hue_get_handle(struct bt_mesh_model *model,
 	struct bt_mesh_light_hue_status status = { 0 };
 
 	srv->handlers->get(srv, ctx, &status);
-	rsp_status(model, ctx, &status);
+	(void)bt_mesh_light_hue_srv_pub(srv, ctx, &status);
 }
 
 static void hue_set_handle(struct bt_mesh_model *model,
@@ -320,7 +309,16 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 		.lvl = sys_get_le16(data),
 		.transition = transition,
 	};
+
 	bt_mesh_light_hue_srv_set(srv, NULL, &set, &status);
+}
+
+static void scene_recall_complete(struct bt_mesh_model *model)
+{
+	struct bt_mesh_light_hue_srv *srv = model->user_data;
+	struct bt_mesh_light_hue_status status = { 0 };
+
+	srv->handlers->get(srv, NULL, &status);
 
 	(void)bt_mesh_light_hue_srv_pub(srv, NULL, &status);
 }
@@ -330,6 +328,7 @@ BT_MESH_SCENE_ENTRY_SIG(light_hue) = {
 	.maxlen = 2,
 	.store = scene_store,
 	.recall = scene_recall,
+	.recall_complete = scene_recall_complete,
 };
 
 static int hue_srv_pub_update(struct bt_mesh_model *model)

--- a/subsys/bluetooth/mesh/lightness_internal.h
+++ b/subsys/bluetooth/mesh/lightness_internal.h
@@ -146,7 +146,8 @@ void lightness_srv_disable_control(struct bt_mesh_lightness_srv *srv);
 void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct bt_mesh_lightness_set *set,
-			      struct bt_mesh_lightness_status *status);
+			      struct bt_mesh_lightness_status *status,
+			      bool publish);
 
 /* For testing purposes */
 int lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,


### PR DESCRIPTION
Some models, like HSL, xyL or CTL have a composite state that
consist of states from corresponding models. Since such models are
not extended by the main model, this creates a corner case for
current scene store/recall mechanism as those models should store
their scene data by themselves instead of relying on the main model.
Since they are also instantiated after the main model, it becomes
impossible for the main model to publish its composite state upon
recall callback, because not all scene data is restored at this
moment.

This commit adds a callback that will be called after all scene
data has been restored so that all models can then pushes their states
with an actual value.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>