### PR TITLE
tf-m: sourcing Kconfig.mbedtls.defconfig when not using minimal config

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -30,6 +30,7 @@ config TFM_MINIMAL
 	  and reproduce the desired configuration through kconfig fragments.
 
 if !TFM_MINIMAL
+rsource "Kconfig.mbedtls.defconfig"
 source "$(ZEPHYR_BASE)/modules/trusted-firmware-m/Kconfig"
 endif
 

--- a/modules/trusted-firmware-m/Kconfig.mbedtls.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.mbedtls.defconfig
@@ -4,55 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Upstream regression test are not compatible with SHA1, so default to n for
+# regression tests.
 config MBEDTLS_SHA1_C
-	default n
-
-config MBEDTLS_SHA512_C
-	default n
-
-# SHA256 is enabled since we don't override its default
-
-config MBEDTLS_TLS_LIBRARY
-	default n
-
-config MBEDTLS_X509_LIBRARY
-	default n
-
-config MBEDTLS_ENABLE_HEAP
-	default n
-
-config MBEDTLS_DHM_C
-	default n
-
-config MBEDTLS_ECP_C
-	default n
-
-config MBEDTLS_HMAC_DRBG_C
-	default n
-
-config MBEDTLS_CIPHER_MODE_CBC
-	default n
-
-config MBEDTLS_CIPHER_MODE_CTR
-	default n
-
-config MBEDTLS_CMAC_C
-	default n
-
-config MBEDTLS_CCM_C
-	default n
-
-config MBEDTLS_GCM_C
-	default n
-
-config MBEDTLS_CHACHA20_C
-	default n
-
-config MBEDTLS_POLY1305_C
-	default n
-
-config MBEDTLS_PK_WRITE_C
-	default n
-
-config MBEDTLS_PSA_CRYPTO_STORAGE_C
-	default n
+	default n if TFM_REGRESSION_NS || TFM_REGRESSION_S


### PR DESCRIPTION
Fixes: NCSDK-9954

The file Kconfig.mbedtls.defconfig was introduced in #4745.
However, only sourcing of Kconfig.mbedtls_minimal.defconfig was done
when TFM_MINIMAL=y.

This commit sources the corresponding Kconfig.mbedtls.defconfig when
not using the minimal config.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>