### PR TITLE
manifest: Update revision of the homekit project

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       path: modules/lib/cddl-gen
     - name: homekit
       repo-path: sdk-homekit
-      revision: 37869c22f29e5368a02f4a666c4ad1c2cfb58574
+      revision: 714dcca08a610e664861f0cf41c1ff0584cd6ac4
       groups:
       - homekit
     - name: find-my


### PR DESCRIPTION
[KRKNWK-10268] - Use certificated OpenThread libraries
[KRKNWK-10303] - Documentation
[KRKNWK-10489] - bugfix 1.6.0
[KRKNWK-10549] - ADK 5.3 Integration

Depends on:
- [x] nrfconnect/sdk-homekit#173
- [x] nrfconnect/sdk-homekit#177
- [x] nrfconnect/sdk-homekit#178
- [x] nrfconnect/sdk-homekit#179

Signed-off-by: Mariusz Poslinski <mariusz.poslinski@nordicsemi.no>