### PR TITLE
manifest: Point to nrfxlib fixing ecdsa deterministic

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: c6fe05f9fd5e65fdfdab281549832a767e255004
+      revision: pull/504/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-This points to the nrfxlib which populates the
 ECDSA deterministic cmake option early

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>