### PR TITLE
Parse modem UUID from JWT token 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,7 +83,7 @@ Kconfig*                                  @tejlmand
 /lib/date_time/                           @simensrostad
 /lib/wave_gen/                            @MarekPieta
 /lib/hw_unique_key/                       @oyvindronningstad @Vge0rge
-/lib/modem_jwt/                           @jayteemo
+/lib/modem_jwt/                           @jayteemo @SeppoTakalo
 /lib/modem_attest_token/                  @jayteemo
 /modules/                                 @tejlmand
 /modules/mcuboot/                         @nvlsianpu
@@ -151,6 +151,7 @@ Kconfig*                                  @tejlmand
 /subsys/zigbee/                           @maciekfabia @mariuszpos
 /tests/bluetooth/tester/                  @joerchan @carlescufi @trond-snekvik
 /tests/lib/hw_unique_key*/                @oyvindronningstad @Vge0rge
+/tests/lib/modem_jwt/                     @SeppoTakalo
 /tests/subsys/zigbee/                     @maciekfabia @mariuszpos
 /tests/subsys/bluetooth/mesh/             @joerchan @trond-snekvik
 /zephyr/                                  @carlescufi

--- a/include/modem/modem_jwt.h
+++ b/include/modem/modem_jwt.h
@@ -16,6 +16,7 @@
 #define MODEM_JWT_H__
 
 #include <zephyr/types.h>
+#include <modem/modem_attest_token.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,12 +70,36 @@ struct jwt_data {
  * provide a buffer.  In that case, the user is responsible for freeing
  * the memory by calling @ref modem_jwt_free.
  *
+ * Subject and audience fields may be NULL in which case those fields are left out
+ * from generated JWT token.
+ *
+ * If sec_tag value is given as zero, JWT is signed with Nordic's own keys that
+ * already exist in the modem.
+ *
  * @param[in,out] jwt Pointer to struct containing JWT parameters and result.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
 int modem_jwt_generate(struct jwt_data *const jwt);
+
+/**
+ * @brief Gets the device and/or modem firmware UUID from the modem
+ * and returns it as a NULL terminated string in the supplied struct(s).
+ *
+ * Uses internally @ref modem_jwt_generate and parses JWT token for "iss"
+ * "jti" fields which contains given UUID values.
+ *
+ * @param[out] dev Pointer to struct containing device UUID string.
+ *                 Can be NULL if UUID is not wanted.
+ * @param[out] mfw Pointer to struct containing modem fw UUID string.
+ *                 Can be NULL if UUID is not wanted.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int modem_jwt_get_uuids(struct nrf_device_uuid *dev,
+			struct nrf_modem_fw_uuid *mfw);
 
 /**
  * @brief Frees the JWT buffer allocated by @ref modem_jwt_generate.

--- a/include/modem/modem_jwt.h
+++ b/include/modem/modem_jwt.h
@@ -48,9 +48,9 @@ struct jwt_data {
 	uint32_t exp_delta_s;
 
 	/**  NULL terminated 'sub' claim; the principal that is the subject of the JWT */
-	char *subject;
+	const char *subject;
 	/**  NULL terminated 'aud' claim; intended recipient of the JWT */
-	char *audience;
+	const char *audience;
 
 	/** Buffer to which the NULL terminated JWT will be copied.
 	 * If a buffer is provided by the user, the size must also be set.

--- a/include/modem/modem_jwt.rst
+++ b/include/modem/modem_jwt.rst
@@ -17,12 +17,12 @@ To use the library to request a JWT, complete the following steps:
 
 You can configure the following values in the :c:struct:`jwt_data` structure:
 
-* :c:member:`jwt_data.sec_tag` - Required. The sec tag must contain a valid signing key.
-* :c:member:`jwt_data.key` - Required. Defines the type of key in the sec tag.
-* :c:member:`jwt_data.alg` - Required. Defines the JWT signing algorithm. Currently, only ECDSA 256 is supported.
+* :c:member:`jwt_data.sec_tag` - Optional. The sec tag must contain a valid signing key. If zero is given, modem uses its own key for signing.
+* :c:member:`jwt_data.key` - Required if sec_tag is not zero. Defines the type of key in the sec tag.
+* :c:member:`jwt_data.alg` - Required if sec_tag is not zero. Defines the JWT signing algorithm. Currently, only ECDSA 256 is supported.
 * :c:member:`jwt_data.exp_delta_s` - Optional. If set, and if the modem has a valid date and time, the ``iat`` and ``exp`` claims are populated.
-* :c:member:`jwt_data.subject` - Optional. Corresponds to ``sub`` claim.
-* :c:member:`jwt_data.audience` - Optional. Corresponds to ``aud`` claim.
+* :c:member:`jwt_data.subject` - Optional. Corresponds to ``sub`` claim. Use NULL if you want to leave out this field.
+* :c:member:`jwt_data.audience` - Optional. Corresponds to ``aud`` claim. Use NULL if you want to leave out this field.
 * :c:member:`jwt_data.jwt_buf` - Optional. Buffer for the generated, null-terminated, JWT string. If a buffer is not provided, the library will allocate memory.
 * :c:member:`jwt_data.jwt_sz` - Size of JWT buffer. Required if :c:member:`jwt_data.jwt_buf` is set.
 

--- a/lib/modem_jwt/Kconfig
+++ b/lib/modem_jwt/Kconfig
@@ -7,6 +7,7 @@
 menuconfig MODEM_JWT
 	bool "Modem JWT Library"
 	select NRF_MODEM_LIB
+	select BASE64
 	help
 	  Functionality requires modem firmware version 1.3 or greater.
 

--- a/lib/modem_jwt/modem_jwt.c
+++ b/lib/modem_jwt/modem_jwt.c
@@ -10,11 +10,13 @@
 #include <stdio.h>
 #include <modem/at_cmd.h>
 #include <modem/modem_jwt.h>
+#include <sys/base64.h>
 
 #define JWT_CMD_TEMPLATE "AT%%JWT=%d,%u,\"%s\",\"%s\""
 #define JWT_CMD_TEMPLATE_SEC_TAG "AT%%JWT=%d,%u,\"%s\",\"%s\",%d,%d"
 #define MAX_INT_PRINT_SZ 11
 #define JWT_CMD_PRINT_INT_SZ (MAX_INT_PRINT_SZ * 4)
+#define GET_BASE64_DECODED_LEN(n) (3 * n / 4)
 
 /* Minimum JWT response is ~420 bytes.
  * With very long (128 bytes) values for sub and aud claims
@@ -155,6 +157,86 @@ cleanup:
 	}
 
 	return ret;
+}
+
+static int copy_uuid_str(char *dst, const char *src, const char *field)
+{
+	char *tag;
+	char *end;
+	char *dot;
+	char *uuid;
+	size_t len;
+
+	/* nRF modem generated tokens have two fixed fields that contain what we are looking for
+	 * "iss":"<chip>.<UUID>"  This is device UUID
+	 * "jti":"<chip>.<UUID>.<JTI data>" This is FW UUID
+	 * So I need to seek a first dot after the correct tag is found.
+	 */
+	tag = strstr(src, field);
+	if (!tag) {
+		return -EINVAL;
+	}
+
+	tag += strlen(field);
+	end = strchr(tag, '"');
+	dot = strchr(tag, '.');
+	if (!end || !dot || dot > end) {
+		return -EINVAL;
+	}
+
+	uuid = dot + 1;
+	len = end - uuid;
+	if (len < NRF_UUID_V4_STR_LEN) {
+		return -EINVAL;
+	}
+
+	strncpy(dst, uuid, NRF_UUID_V4_STR_LEN);
+	dst[NRF_UUID_V4_STR_LEN] = 0;
+	return 0;
+}
+
+int modem_jwt_get_uuids(struct nrf_device_uuid *dev,
+			struct nrf_modem_fw_uuid *mfw)
+{
+	struct jwt_data jwt = {0};
+	char *payload = NULL;
+	char *start, *end;
+	size_t slen, len;
+
+	int rc = modem_jwt_generate(&jwt);
+
+	if (rc) {
+		goto end;
+	}
+
+	start = strchr(jwt.jwt_buf, '.') + 1;
+	end = strrchr(jwt.jwt_buf, '.');
+	slen = end - start;
+	payload =  k_calloc(1, GET_BASE64_DECODED_LEN(slen));
+	if (!payload) {
+		rc = -ENOMEM;
+		goto end;
+	}
+
+	rc = base64_decode(payload, GET_BASE64_DECODED_LEN(slen), &len, start, slen);
+	if (rc) {
+		goto end;
+	} else if (len == 0 || len > GET_BASE64_DECODED_LEN(slen)) {
+		rc = -EINVAL;
+		goto end;
+	}
+
+	if (dev && !rc) {
+		rc = copy_uuid_str(dev->str, payload, "iss\":\"");
+	}
+	if (mfw && !rc) {
+		rc = copy_uuid_str(mfw->str, payload, "jti\":\"");
+	}
+
+end:
+	k_free(payload);
+	modem_jwt_free(jwt.jwt_buf);
+	return rc;
 }
 
 void modem_jwt_free(char *const jwt_buf)

--- a/tests/lib/modem_jwt/CMakeLists.txt
+++ b/tests/lib/modem_jwt/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(jwt_test)
+
+# generate runner for the test
+test_runner_generate(src/jwt_test.c)
+
+target_include_directories(app PRIVATE src)
+
+cmock_handle(../../../include/modem/at_cmd.h)
+
+# add test file
+target_sources(app PRIVATE src/jwt_test.c)
+target_sources(app PRIVATE ../../../lib/modem_jwt/modem_jwt.c)
+add_definitions(-DCONFIG_MODEM_JWT_MAX_LEN=850)
+add_definitions(-DCONFIG_AT_CMD_RESPONSE_MAX_LEN=850)

--- a/tests/lib/modem_jwt/prj.conf
+++ b/tests/lib/modem_jwt/prj.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_UNITY=y
+CONFIG_HEAP_MEM_POOL_SIZE=16384
+CONFIG_BASE64=y

--- a/tests/lib/modem_jwt/src/jwt_test.c
+++ b/tests/lib/modem_jwt/src/jwt_test.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <unity.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <kernel.h>
+#include <modem/modem_jwt.h>
+#include <mock_at_cmd.h>
+
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+/* Our sample token:
+ * {
+ *   "typ": "JWT",
+ *   "alg": "ES256",
+ *   "kid": "e6c35cea1f541a4be485ff8db21f51dfe7242e7ca7b9456c90f69815e77ea61f"
+ * } .
+ * {
+ *   "iss": "nRF9160.50363154-3930-4d96-80f9-13121cf35adc",
+ *   "jti": "nRF9160.f72d9789-2e73-4780-9248-b3952f89b872.942d99b903aca2c3dd649b5d612322dc",
+ *   "sub": "50363154-3930-4d96-80f9-13121cf35adc"
+ * }
+ */
+static const char jwt_token[] =
+	"%JWT: \""
+	"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6ImU2YzM1Y2VhMWY1NDFhNGJlNDg1ZmY4ZGIyMWY1MWRmZTcyNDJlN2NhN2I5NDU2YzkwZjY5ODE1ZTc3ZWE2MWYifSAg.eyJpc3MiOiJuUkY5MTYwLjUwMzYzMTU0LTM5MzAtNGQ5Ni04MGY5LTEzMTIxY2YzNWFkYyIsImp0aSI6Im5SRjkxNjAuZjcyZDk3ODktMmU3My00NzgwLTkyNDgtYjM5NTJmODliODcyLjk0MmQ5OWI5MDNhY2EyYzNkZDY0OWI1ZDYxMjMyMmRjIiwic3ViIjoiNTAzNjMxNTQtMzkzMC00ZDk2LTgwZjktMTMxMjFjZjM1YWRjIn0g.tW2wG-sSE01jtrcT9JmFvPVIvEB99jUGGHIUCCH65fG5HtBrisOD1cl0L49cuyo2OE6XXvI9wdKSASxDQPJ8lw"
+	"\"";
+
+int cmd_cb(const char * const cmd, char *buf, size_t buf_len, enum at_cmd_state *state,
+	   int cmock_num_calls)
+{
+	if (cmock_num_calls == 0) {
+		/* Fail first call */
+		return AT_CMD_ERROR;
+	} else if (cmock_num_calls == 1) {
+		TEST_ASSERT_EQUAL_STRING("AT%JWT=0,0,\"\",\"\"", cmd);
+	} else if (cmock_num_calls == 2) {
+		TEST_ASSERT_EQUAL_STRING("AT%JWT=0,100,\"sub\",\"aud\",10,2", cmd);
+	}
+	strncpy(buf, jwt_token, buf_len - 1);
+	buf[buf_len-1] = 0;
+	return 0;
+}
+
+void test_modem_jwt_generate(void)
+{
+	struct jwt_data jwt = {0};
+	int rc;
+
+	/* Few failure cases */
+
+	rc = modem_jwt_generate(NULL);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, rc);
+
+	jwt.jwt_buf = (char *) 0xDEADEEF;
+	jwt.jwt_sz = 0;
+	rc = modem_jwt_generate(&jwt);
+	TEST_ASSERT_EQUAL_INT(-EMSGSIZE, rc);
+
+	jwt.jwt_buf = NULL;
+
+	__wrap_at_cmd_init_ExpectAndReturn(-1);
+	rc = modem_jwt_generate(&jwt);
+	TEST_ASSERT_EQUAL_INT(-EPIPE, rc);
+
+	__wrap_at_cmd_init_ExpectAndReturn(0);
+	__wrap_at_cmd_write_Stub(cmd_cb);
+	rc = modem_jwt_generate(&jwt);
+	TEST_ASSERT_EQUAL_INT(-EBADMSG, rc);
+
+	/* Success case, default parameters */
+	__wrap_at_cmd_init_ExpectAndReturn(0);
+	rc = modem_jwt_generate(&jwt);
+	TEST_ASSERT_EQUAL_INT(0, rc);
+
+	modem_jwt_free(jwt.jwt_buf);
+	jwt.jwt_buf = NULL;
+
+	/* Success case */
+	jwt.subject = "sub";
+	jwt.audience = "aud";
+	jwt.exp_delta_s = 100;
+	jwt.sec_tag = 10;
+	jwt.key = 2;
+	__wrap_at_cmd_init_ExpectAndReturn(0);
+	rc = modem_jwt_generate(&jwt);
+	TEST_ASSERT_EQUAL_INT(0, rc);
+}
+
+void test_modem_jwt_get_uuids(void)
+{
+	struct nrf_device_uuid dev = {0};
+	struct nrf_modem_fw_uuid mfw = {0};
+	int rc;
+
+	__wrap_at_cmd_init_IgnoreAndReturn(0);
+	rc = modem_jwt_get_uuids(&dev, &mfw);
+	TEST_ASSERT_EQUAL_INT(0, rc);
+	TEST_ASSERT_EQUAL_STRING("50363154-3930-4d96-80f9-13121cf35adc", dev.str);
+	TEST_ASSERT_EQUAL_STRING("f72d9789-2e73-4780-9248-b3952f89b872", mfw.str);
+}
+
+extern int unity_main(void);
+
+void main(void)
+{
+	(void)unity_main();
+}

--- a/tests/lib/modem_jwt/testcase.yaml
+++ b/tests/lib/modem_jwt/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  unity.modem_jwt:
+    platform_allow: qemu_cortex_m3 native_posix
+    tags: jwt


### PR DESCRIPTION
Default JWT tokens contain modem UUID in "iss" field.
For example:
{
  "iss": "nRF9160.50363154-3930-4d96-80f9-13121cf35adc",
  "jti": "..."
}
This is easiest way to fetch it.

But in order to issue default AT%JWT command, I needed some small fixes for the existing library as well:
JWT library should allow user to leave out sec_tag and expiration times.

AT%JWT and AT%JWT=0 and AT%JWT=0,0 and AT%JWT=,, AT%JWT=0,0,"" AT%JWT=0,0,"",""
returns only "iss" and "jti" fields and signed with device identity key

So numerical values can be zero or missing. Strings can be zero length or missing.

Sec_tag cannot be zero, it must be a valid tag, or missing in the parameter field.
When sec_tag is given, it key type must be given as well. When sec_tag is given as zero, I thread it as a missing field.
