### PR TITLE
net: lib: azure_iot_hub: Fix too small property bag buffer

### DIFF
--- a/subsys/net/lib/azure_iot_hub/Kconfig
+++ b/subsys/net/lib/azure_iot_hub/Kconfig
@@ -96,7 +96,7 @@ config AZURE_IOT_HUB_TOPIC_MAX_LEN
 
 config AZURE_IOT_HUB_TOPIC_ELEMENT_MAX_LEN
 	int "Maximum length of topic element strings"
-	default 22
+	default 40
 	help
 	  Azure IoT Hub uses dynamically constructed topics to transfer
 	  information elements such as response codes, direct method names and

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_dps.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_dps.c
@@ -65,6 +65,16 @@ static char dps_topic_reg_pub[sizeof(DPS_TOPIC_REG_PUB) +
 BUILD_ASSERT(sizeof(CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE) - 1 > 0,
 	     "The DPS ID scope must be defined");
 
+/* The device ID is used as DPS registration ID, and will be received back
+ * in response to registration request. Therefore the size of a property bag
+ * must be at least as large as the maximum device ID.
+ */
+BUILD_ASSERT(CONFIG_AZURE_IOT_HUB_TOPIC_ELEMENT_MAX_LEN >=
+	     CONFIG_AZURE_IOT_HUB_DEVICE_ID_MAX_LEN,
+	     "CONFIG_AZURE_IOT_HUB_TOPIC_ELEMENT_MAX_LEN must be at least as "
+	     "large as CONFIG_AZURE_IOT_HUB_DEVICE_ID_MAX_LEN "
+	     "when DPS is enabled");
+
 /* Forward declarations */
 static int dps_on_settings_loaded(void);
 static int dps_settings_handler(const char *key, size_t len,


### PR DESCRIPTION
When DPS is enabled, the device ID is used as the DPS registration
ID. The registration ID is passed back to the device as a property
bag, which means that a property bag value can be as long as the
device ID in the worst case.

This patch asserts that the property bag buffer is at least as
large as the device ID buffer.

In addition, the default value of the property bag element size
is increased.

NCSDK-10175

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>