### PR TITLE
Bluetooth: Mesh: test ambient temp sensors

### DIFF
--- a/subsys/bluetooth/mesh/sensor.c
+++ b/subsys/bluetooth/mesh/sensor.c
@@ -372,7 +372,7 @@ uint8_t sensor_powtime_encode(uint64_t raw)
 		return 1;
 	}
 
-	const uint64_t *seed = &powtime_lookup[0];
+	const uint64_t *seed = &powtime_lookup[ARRAY_SIZE(powtime_lookup) - 1];
 
 	for (int i = 1; i < ARRAY_SIZE(powtime_lookup); ++i) {
 		if (raw_us < powtime_lookup[i]) {
@@ -388,7 +388,9 @@ uint8_t sensor_powtime_encode(uint64_t raw)
 	     i++) {
 	}
 
-	return ARRAY_SIZE(powtime_mul) * (seed - &powtime_lookup[0]) + i;
+	uint8_t encoded = ARRAY_SIZE(powtime_mul) * (seed - &powtime_lookup[0]) + i;
+
+	return MIN(encoded, 253);
 }
 
 uint64_t sensor_powtime_decode_us(uint8_t val)

--- a/tests/subsys/bluetooth/mesh/sensor_subsys/prj.conf
+++ b/tests/subsys/bluetooth/mesh/sensor_subsys/prj.conf
@@ -6,3 +6,4 @@
 
 # Ztest configuration
 CONFIG_ZTEST=y
+CONFIG_CBPRINTF_FP_SUPPORT=y


### PR DESCRIPTION
This adds tests for ambient temperature sensors
Also includes fixes for bugs found during testing, mainly:
 - Non-conflicting value (0xffffffff and 0xfffffffe) returned
   for special 0xfe and 0xff value in time 8 exponential
 - Fix for handling (SIGNED | HAS_UNDEFINED)

Signed-off-by: Ludvig Samuelsen Jordet <ludvig.jordet@nordicsemi.no>