### PR TITLE
net: fota_download: Remove bug which was merged

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -192,7 +192,6 @@ static int download_client_callback(const struct download_client_evt *event)
 			}
 
 			send_progress((offset * 100) / file_size);
-			downloading = false;
 			LOG_DBG("Progress: %d/%d bytes", offset, file_size);
 		}
 	break;


### PR DESCRIPTION
If you have progress enable the fix found in
acde6aea2b8c23f6deaf600fc1df5085ebde37a3 will not work as it sets
`downloading = false`. While the state of the program is that it is
still downloading.

Ref. NCSDK-8541

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>