### PR TITLE
manifest: Update SoftDevice Controller

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 389b60a7399b51d54d7b815224b73ec3621ffcd0
+      revision: 76469a054694708a5f79b5e0eefa52a7b3a8ff9a
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Imports required fix for handling AUX_CHAIN_IND PDUs.
The fix is required in order to pass conformance tests
after TCRL 2021-1.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>