### PR TITLE
spm: Kconfig: Remove statement that was commented out

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -35,7 +35,6 @@ menuconfig IS_SPM
 	bool "Current app is SPM"
 	default n
 	select TRUSTED_EXECUTION_SECURE
-	# depends on !FPU
 
 if IS_SPM
 


### PR DESCRIPTION
Left by mistake.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>