### PR TITLE
Peripheral LBS  fix button release notification

### DIFF
--- a/samples/bluetooth/peripheral_lbs/src/main.c
+++ b/samples/bluetooth/peripheral_lbs/src/main.c
@@ -170,8 +170,10 @@ static struct bt_lbs_cb lbs_callbacs = {
 static void button_changed(uint32_t button_state, uint32_t has_changed)
 {
 	if (has_changed & USER_BUTTON) {
-		bt_lbs_send_button_state(button_state);
-		app_button_state = button_state ? true : false;
+		uint32_t user_button_state = button_state & USER_BUTTON;
+
+		bt_lbs_send_button_state(user_button_state);
+		app_button_state = user_button_state ? true : false;
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug in the peripheral_lbs sample where if button 1 pushed and released while
holding one of the other buttons, the notification for release is
the same as for press (0x01).