### PR TITLE
doc: known issue: add NCSDK-10106 to nrf9160 known issues

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -178,7 +178,7 @@ Modem FW reset on debugger connection through SWD
   If a debugger (for example, J-Link) is connected via SWD to the nRF9160, the modem firmware will reset.
   Therefore, the LTE modem cannot be operational during debug sessions.
 
-  .. rst-class:: v1-6-0 v1-5-1 v1-5-0
+.. rst-class:: v1-6-0 v1-5-1 v1-5-0
 
 NCSDK-9441: Fmfu SMP server sample is unstable with the newest J-Link version
   Full modem serial update does not work on development kit with debugger chip version delivered with J-Link software > 6.88a
@@ -190,7 +190,7 @@ NCSDK-9441: Fmfu SMP server sample is unstable with the newest J-Link version
 NCSDK-10106: Elevated current consumption when using applications without :ref:`nrfxlib:nrf_modem` on nRF9160
   When running applications that do not enable :ref:`nrfxlib:nrf_modem` on nRF9160 with build code B1A, current consumption will stay at 3 mA when in sleep.
 
- **Workaround:** Enable :ref:`nrfxlib:nrf_modem`.
+  **Workaround:** Enable :ref:`nrfxlib:nrf_modem`.
 
 nRF5
 ****

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -185,6 +185,13 @@ NCSDK-9441: Fmfu SMP server sample is unstable with the newest J-Link version
 
   **Workaround:** Downgrade the debugger chip to the firmware released with J-Link 6.88a or use another way of transferring serial data to the chip.
 
+.. rst-class:: v1-6-0 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+
+NCSDK-10106: Elevated current consumption when using applications without :ref:`nrfxlib:nrf_modem` on nRF9160
+  When running applications that do not enable :ref:`nrfxlib:nrf_modem` on nRF9160 with build code B1A, current consumption will stay at 3 mA when in sleep.
+
+ **Workaround:** Enable :ref:`nrfxlib:nrf_modem`.
+
 nRF5
 ****
 


### PR DESCRIPTION
Elevated current consumption on nrf9160 when not using modem.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>