### PR TITLE
spm: Fix size calculation of NSC region

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1014,15 +1014,6 @@ NCSIDB-114: Default logging causes crash
 
   **Workaround:** Do not enable logging and add a breakpoint in the fault handling, or try a different logging backend.
 
-.. rst-class:: v1-7-0 v1-6-1 v1-6-0 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
-
-NCSDK-5156: Size of the non-secure callable area is wrong when the number of secure services exceeds 63
-  If the number of services is between 64 and 255, the number is too large, resulting in up to 4096 B of wasted space.
-  If the number of services exceeds 255, the hardware configuration becomes invalid.
-  The default number of services is much smaller than 64.
-
-  **Workaround:** Keep the number of services below 256.
-
 .. rst-class:: v1-6-1 v1-6-0 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
 
 NCSDK-8232: Secure Partition Manager and application building together

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -146,6 +146,12 @@ Bugfixes:
 
 * Fixed ``hw_unique_key_is_written()`` which would previously trigger a fault under certain circumstances.
 
+Secure partition manager (SPM)
+------------------------------
+
+Bug fixes:
+
+* NCSDK-5156: Fixed the size calculation for the non-secure callable region, which prevented users from adding a large number of custom secure services.
 
 MCUboot
 =======

--- a/subsys/spm/spm_internal.h
+++ b/subsys/spm/spm_internal.h
@@ -141,10 +141,6 @@ extern "C" {
 	((SPU_FLASHNSC_REGION_LOCK_Locked << SPU_FLASHNSC_REGION_LOCK_Pos) &   \
 	SPU_FLASHNSC_REGION_LOCK_Msk)
 
-#define FLASH_NSC_SIZE(reg_size)                                               \
-	(((reg_size) << SPU_FLASHNSC_SIZE_SIZE_Pos) &                          \
-	SPU_FLASHNSC_SIZE_SIZE_Msk)
-
 #define FLASH_NSC_SIZE_LOCK                                                    \
 	((SPU_FLASHNSC_SIZE_LOCK_Locked << SPU_FLASHNSC_SIZE_LOCK_Pos) &       \
 	SPU_FLASHNSC_SIZE_LOCK_Msk)
@@ -152,7 +148,22 @@ extern "C" {
 #define FLASH_NSC_SIZE_FROM_ADDR(addr) FLASH_SECURE_ATTRIBUTION_REGION_SIZE    \
 	- (((uint32_t)(addr)) % FLASH_SECURE_ATTRIBUTION_REGION_SIZE)
 
-#define FLASH_NSC_SIZE_REG(size) FLASH_NSC_SIZE((size) / FLASH_NSC_MIN_SIZE)
+
+/* (31 - __builtin_clzl(size)) is the same as log2 for powers of 2.
+ * Subtract 4 because the NSC region sizes start at 32 and are 1-indexed.
+ * Note that this macro needs size to one of the valid sizes, it cannot be
+ * any value in between, so the size has have been rounded up beforehand.
+ */
+#define FLASH_NSC_SIZE_REG(size) ((31 - __builtin_clzl(size)) - 4)
+
+BUILD_ASSERT(FLASH_NSC_SIZE_REG(32) == 1);
+BUILD_ASSERT(FLASH_NSC_SIZE_REG(64) == 2);
+BUILD_ASSERT(FLASH_NSC_SIZE_REG(128) == 3);
+BUILD_ASSERT(FLASH_NSC_SIZE_REG(256) == 4);
+BUILD_ASSERT(FLASH_NSC_SIZE_REG(512) == 5);
+BUILD_ASSERT(FLASH_NSC_SIZE_REG(1024) == 6);
+BUILD_ASSERT(FLASH_NSC_SIZE_REG(2048) == 7);
+BUILD_ASSERT(FLASH_NSC_SIZE_REG(4096) == 8);
 
 
 /** Initialze secure services.


### PR DESCRIPTION
The existing calculation is only correct for 32 and 64 bytes.
The calculation was doing division instead of log2.
Our secure services are below 32 bytes, so this hasn't affected us.
From 64 bytes to 256 bytes, the size configured in HW will be larger
than needed, and above 256 bytes, the HW configuration will be invalid.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>