### PR TITLE
LTE link control: Add modem domain events

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -94,6 +94,10 @@ nRF9160
 
     * The driver has been deprecated in favor of the :ref:`nrfxlib:gnss_interface`.
 
+  * :ref:`lte_lc_readme` library:
+
+    * Added API to enable modem domain events.
+
   * Board names:
 
     * The ``nrf9160dk_nrf9160ns`` and the ``nrf5340dk_nrf5340_cpuappns`` boards have been renamed respectively to ``nrf9160dk_nrf9160_ns`` and ``nrf5340dk_nrf5340_cpuapp_ns``, in a change inherited from upstream Zephyr.

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -214,6 +214,11 @@ enum lte_lc_evt_type {
 	 *         the duration of the sleep. Payload is of type @ref lte_lc_modem_sleep.
 	 */
 	LTE_LC_EVT_MODEM_SLEEP_ENTER,
+
+	/** @brief Modem domain event carrying information about modem operation.
+	 *	   Payload is of type @ref lte_lc_modem_evt.
+	 */
+	LTE_LC_EVT_MODEM_EVENT,
 };
 
 enum lte_lc_rrc_mode {
@@ -381,6 +386,45 @@ enum lte_lc_ce_level {
 	LTE_LC_CE_LEVEL_UNKNOWN			= UINT8_MAX,
 };
 
+/** @brief Modem domain events. */
+enum lte_lc_modem_evt {
+	/** Indicates that a light search has been performed. This event gives the
+	 *  application the chance to stop using more power when searching networks
+	 *  in possibly weaker radio conditions.
+	 *  Before sending this event, the modem searches for cells based on previous
+	 *  cell history, measures the radio conditions, and makes assumptions on
+	 *  where networks might be deployed. This event means that the modem has
+	 *  not found a network that it could select based on the 3GPP network
+	 *  selection rules from those locations. It does not mean that there are
+	 *  no networks to be found in the area. The modem continues more thorough
+	 *  searches automatically after sending this status.
+	 */
+	LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE,
+
+	/** Indicates that a network search has been performed. The modem has found
+	 *  a network that it can select according to the 3GPP network selection rules
+	 *  or all frequencies have been scanned and a suitable cell was not found.
+	 *  In the latter case, the modem enters normal limited service state
+	 *  functionality and performs scan for service periodically.
+	 */
+	LTE_LC_MODEM_EVT_SEARCH_DONE,
+	/** The modem has detected a reset loop. A reset loop indicates that
+	 *  the modem restricts network attach attempts for the next 30 minutes.
+	 *  The timer does not run when the modem has no power or while it stays
+	 *  in the reset loop. The modem counts all the resets where the modem
+	 *  is not gracefully deinitialized with +CFUN=0 or using an API
+	 *  performing the equivalent operation, such as setting the functional
+	 *  mode to LTE_LC_FUNC_MODE_POWER_OFF.
+	 */
+	LTE_LC_MODEM_EVT_RESET_LOOP,
+
+	/** Battery voltage is low and the modem is therefore deactivated. */
+	LTE_LC_MODEM_EVT_BATTERY_LOW,
+
+	/** The device is overheated and the modem is therefore deactivated. */
+	LTE_LC_MODEM_EVT_OVERHEATED,
+};
+
 /** @brief Connection evaluation parameters.
  *
  *  @note For more information on the various connection evaluation parameters, refer to the
@@ -522,6 +566,7 @@ struct lte_lc_evt {
 		struct lte_lc_cell cell;
 		enum lte_lc_lte_mode lte_mode;
 		struct lte_lc_modem_sleep modem_sleep;
+		enum lte_lc_modem_evt modem_evt;
 
 		/* Time until next Tracking Area Update in milliseconds. */
 		uint64_t time;
@@ -810,6 +855,25 @@ int lte_lc_neighbor_cell_measurement_cancel(void);
  * @retval 7 Evaluation failed, Unspecified.
  */
 int lte_lc_conn_eval_params_get(struct lte_lc_conn_eval_params *params);
+
+/** @brief Enable modem domain events. See @ref lte_lc_modem_evt for
+ *	   more information on what events may be received.
+ *
+ *  @note This feature is supported for nRF9160 modem firmware v1.3.0 and later
+ *	  versions. Attempting to use this API with older modem versions will
+ *	  result in an error being returned.
+ *
+ *  @note An event handler must be registered in order to receive events.
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_modem_events_enable(void);
+
+/** @brief Disable modem domain events.
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_modem_events_disable(void);
 
 /** @} */
 

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -138,6 +138,16 @@
 #define AT_CONEVAL_RX_REPETITIONS_INDEX		16
 #define AT_CONEVAL_DL_PATHLOSS_INDEX		17
 
+/* MDMEV command parameters */
+#define AT_MDMEV_ENABLE				"AT%MDMEV=1"
+#define AT_MDMEV_DISABLE			"AT%MDMEV=0"
+#define AT_MDMEV_RESPONSE_PREFIX		"%MDMEV: "
+#define AT_MDMEV_OVERHEATED			"ME OVERHEATED\r\n"
+#define AT_MDMEV_BATTERY_LOW			"ME BATTERY LOW\r\n"
+#define AT_MDMEV_SEARCH_STATUS_1		"SEARCH STATUS 1\r\n"
+#define AT_MDMEV_SEARCH_STATUS_2		"SEARCH STATUS 2\r\n"
+#define AT_MDMEV_RESET_LOOP			"RESET LOOP\r\n"
+
 /* @brief Helper function to check if a response is what was expected.
  *
  * @param response Pointer to response prefix
@@ -264,3 +274,18 @@ int parse_xmodemsleep(const char *at_response, struct lte_lc_modem_sleep *modem_
  * @retval 7 Evaluation failed, Unspecified.
  */
 int parse_coneval(const char *at_response, struct lte_lc_conn_eval_params *params);
+
+/* @brief Parses an MDMEV response and populates an enum with the corresponding
+ *	  modem event type.
+ *
+ * @param at_response Pointer to buffer with AT response.
+ * @param modem_evt Pointer to enum to hold modem event.
+ *
+ * @return Zero on success, negative errno code on failure.
+ *
+ * @retval 0 Parsing succeeded.
+ * @retval -EINVAL If invalid parameters are provided.
+ * @retval -EIO If the AT response is not a valid MDMEV response.
+ * @retval -ENODATA If no modem event type was found in the AT response.
+ */
+int parse_mdmev(const char *at_response, enum lte_lc_modem_evt *modem_evt);

--- a/samples/nrf9160/cloud_client/src/main.c
+++ b/samples/nrf9160/cloud_client/src/main.c
@@ -199,6 +199,20 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 			evt->lte_mode == LTE_LC_LTE_MODE_NBIOT ? "NB-IoT" :
 			"Unknown");
 		break;
+	case LTE_LC_EVT_MODEM_EVENT:
+		LOG_INF("Modem domain event, type: %s",
+			evt->modem_evt == LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE ?
+				"Light search done" :
+			evt->modem_evt == LTE_LC_MODEM_EVT_SEARCH_DONE ?
+				"Search done" :
+			evt->modem_evt == LTE_LC_MODEM_EVT_RESET_LOOP ?
+				"Reset loop detected" :
+			evt->modem_evt == LTE_LC_MODEM_EVT_BATTERY_LOW ?
+				"Low battery" :
+			evt->modem_evt == LTE_LC_MODEM_EVT_OVERHEATED ?
+				"Modem is overheated" :
+				"Unknown");
+		break;
 	default:
 		break;
 	}
@@ -227,6 +241,14 @@ static void modem_configure(void)
 
 		LOG_INF("PSM mode requested");
 #endif
+
+		err = lte_lc_modem_events_enable();
+		if (err) {
+			LOG_ERR("lte_lc_modem_events_enable failed, error: %d",
+				err);
+			return;
+		}
+
 		err = lte_lc_init_and_connect_async(lte_handler);
 		if (err) {
 			LOG_ERR("Modem could not be configured, error: %d",


### PR DESCRIPTION
lib: lte_lc: Add modem domain events 

Add API to enable modem domain events, parsing of unsolicited
MDMEV responses and tests.

--- 

samples: nrf9160: cloud_client: Enable modem domain events

Enable modem domain events and print the information when such
events are received.