### PR TITLE
NFC: Added length header to ndef message when using tag type 4

### DIFF
--- a/subsys/nfc/ndef/msg.c
+++ b/subsys/nfc/ndef/msg.c
@@ -38,6 +38,10 @@ int nfc_ndef_msg_encode(struct nfc_ndef_msg_desc const *ndef_msg_desc,
 {
 	uint32_t sum_of_len = 0;
 
+#if NFC_NDEF_MSG_TAG_TYPE == TYPE_4_TAG
+	sum_of_len += NLEN_FIELD_SIZE;
+#endif
+
 	if (!ndef_msg_desc || !msg_len) {
 		return -EINVAL;
 	}
@@ -73,6 +77,10 @@ int nfc_ndef_msg_encode(struct nfc_ndef_msg_desc const *ndef_msg_desc,
 		/* next record */
 		pp_record_rec_desc++;
 	}
+
+#if NFC_NDEF_MSG_TAG_TYPE == TYPE_4_TAG
+	sys_put_be16(sum_of_len-NLEN_FIELD_SIZE, msg_buffer);
+#endif
 
 	*msg_len = sum_of_len;
 


### PR DESCRIPTION
`nfc_ndef_msg_encode` is not correctly encoding ndef messages for tag type 4. Tag type 4 requires a 2 byte length prepended to the message body.

Apologies for the other PR. It was in the  `v1.5-branch`.