### PR TITLE
manifest: Nrfxlib with encrypted EITS

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.6.0-rc3
+      revision: pull/508/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-Point to the nrfxlib which has encrypted ITS
 support with the zephyr settings backend

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>