### PR TITLE
bluetooth: Remove unused prj.overlay files

### DIFF
--- a/samples/bluetooth/central_uart/prj.overlay
+++ b/samples/bluetooth/central_uart/prj.overlay
@@ -1,3 +1,0 @@
-&uart0 {
-	compatible = "nordic,nrf-uarte";
-};

--- a/samples/bluetooth/peripheral_uart/prj.overlay
+++ b/samples/bluetooth/peripheral_uart/prj.overlay
@@ -1,3 +1,0 @@
-&uart0 {
-	compatible = "nordic,nrf-uarte";
-};


### PR DESCRIPTION
Remove unused prj.overlay files for peripheral_uart and central_uart sample.