### PR TITLE
doc: zigbee: add OSIF library page

### DIFF
--- a/doc/nrf/libraries/lib_zigbee.rst
+++ b/doc/nrf/libraries/lib_zigbee.rst
@@ -16,5 +16,6 @@ For information on how to use the supplied libraries, see :ref:`ug_zigbee_config
    :glob:
    :caption: Subpages:
 
+   zigbee/lib_zigbee_osif
    ../../include/zigbee/*
    zigbee/lib_zigbee_shell

--- a/doc/nrf/libraries/zigbee/lib_zigbee_osif.rst
+++ b/doc/nrf/libraries/zigbee/lib_zigbee_osif.rst
@@ -1,0 +1,51 @@
+﻿.. _lib_zigbee_osif:
+
+Zigbee ZBOSS OSIF
+#################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Zigbee ZBOSS OSIF layer subsystem acts as the linking layer between the :ref:`nrfxlib:zboss` and the |NCS|.
+
+.. _zigbee_osif_configuration:
+
+Configuration
+*************
+
+The ZBOSS OSIF layer implements a series of functions used by ZBOSS and is included in the |NCS|'s Zigbee subsystem.
+
+The ZBOSS OSIF layer is automatically enabled when you enable the ZBOSS library with the :option:`CONFIG_ZIGBEE` Kconfig option.
+
+You can also configure the following OSIF-related Kconfig options:
+
+* :option:`CONFIG_ZIGBEE_APP_CB_QUEUE_LENGTH` - Defines the length of the application callback and alarm queue.
+  This queue is used to pass application callbacks and alarms from other threads or interrupts to the ZBOSS main loop context.
+* :option:`CONFIG_ZIGBEE_DEBUG_FUNCTIONS` - Includes functions to suspend and resume the ZBOSS thread.
+
+  .. note::
+      These functions are useful for debugging, but they can cause instability of the device.
+
+* :option:`CONFIG_ZIGBEE_HAVE_SERIAL` - Enables the UART serial abstract for the ZBOSS OSIF layer and allows to configure the serial glue layer.
+* :option:`CONFIG_ZIGBEE_USE_BUTTONS` - Enables the buttons abstract for the ZBOSS OSIF layer.
+  You can use this option if you want to test ZBOSS examples directly in the |NCS|.
+* :option:`CONFIG_ZIGBEE_USE_DIMMABLE_LED` - Dimmable LED (PWM) abstract for the ZBOSS OSIF layer.
+  You can use this option if you want to test ZBOSS examples directly in the |NCS|.
+* :option:`CONFIG_ZIGBEE_USE_LEDS` - LEDs abstract for the ZBOSS OSIF layer.
+  You can use this option if you want to test ZBOSS examples directly in the |NCS|.
+* :option:`CONFIG_ZIGBEE_USE_SOFTWARE_AES` - Configures the ZBOSS OSIF layer to use the software encryption.
+
+Additionally, the following Kconfig option is available when setting :ref:`zigbee_ug_logging_logger_options`:
+
+* :option:`CONFIG_ZBOSS_OSIF_LOG_LEVEL` - Configures the custom logger options for the ZBOSS OSIF layer.
+
+API documentation
+*****************
+
+| Header files: :file:`subsys/zigbee/osif/zb_nrf_platform.h`
+| Source files: :file:`subsys/zigbee/osif/`
+
+.. doxygengroup:: zigbee_zboss_osif
+   :project: nrf
+   :members:

--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -754,7 +754,8 @@ WARN_LOGFILE           =
 
 INPUT                  = @NRF_BASE@/applications \
                          @NRF_BASE@/lib \
-                         @NRF_BASE@/include
+                         @NRF_BASE@/include \
+                         @NRF_BASE@/subsys/zigbee/osif/zb_nrf_platform.h
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1971,23 +1972,23 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "__attribute__(x)=" \
                          "__syscall=" \
                          "__syscall_inline=" \
-			 "__attribute(x)= DOXYGEN=1" \
-			 "CONFIG_BT_SCAN_FILTER_ENABLE:=1" \
-			 "CONFIG_BT_SCAN_UUID_CNT:=1" \
-			 "CONFIG_BT_SCAN_NAME_CNT:=1" \
-			 "CONFIG_BT_SCAN_SHORT_NAME_CNT:=1" \
-			 "CONFIG_BT_SCAN_ADDRESS_CNT:=1" \
-			 "CONFIG_BT_SCAN_APPEARANCE_CNT:=1" \
+                         "__attribute(x)= DOXYGEN=1" \
+                         "CONFIG_BT_SCAN_FILTER_ENABLE:=1" \
+                         "CONFIG_BT_SCAN_UUID_CNT:=1" \
+                         "CONFIG_BT_SCAN_NAME_CNT:=1" \
+                         "CONFIG_BT_SCAN_SHORT_NAME_CNT:=1" \
+                         "CONFIG_BT_SCAN_ADDRESS_CNT:=1" \
+                         "CONFIG_BT_SCAN_APPEARANCE_CNT:=1" \
                          "CONFIG_PROFILER=y" \
-			 "CONFIG_NFC_TNEP_TAG=y" \
-			 "EVENT_TYPE_DECLARE(x)=" \
-			 "CONFIG_LWM2M_CLIENT_UTILS_LOCATION_OBJ_SUPPORT=y" \
-			 "CONFIG_LWM2M_CLIENT_UTILS_FIRMWARE_UPDATE_OBJ_SUPPORT=y" \
-			 "CONFIG_LWM2M_CLIENT_UTILS_CONN_MON_OBJ_SUPPORT=y" \
-			 "CONFIG_LWM2M_CLIENT_UTILS_DEVICE_OBJ_SUPPORT=y" \
-			 "CONFIG_LWM2M_CLIENT_UTILS_SECURITY_OBJ_SUPPORT=y"\
-                         "ATOMIC_DEFINE(x, y)=atomic_t x[ATOMIC_BITMAP_SIZE(y)]"
-
+                         "CONFIG_NFC_TNEP_TAG=y" \
+                         "EVENT_TYPE_DECLARE(x)=" \
+                         "CONFIG_LWM2M_CLIENT_UTILS_LOCATION_OBJ_SUPPORT=y" \
+                         "CONFIG_LWM2M_CLIENT_UTILS_FIRMWARE_UPDATE_OBJ_SUPPORT=y" \
+                         "CONFIG_LWM2M_CLIENT_UTILS_CONN_MON_OBJ_SUPPORT=y" \
+                         "CONFIG_LWM2M_CLIENT_UTILS_DEVICE_OBJ_SUPPORT=y" \
+                         "CONFIG_LWM2M_CLIENT_UTILS_SECURITY_OBJ_SUPPORT=y"\
+                         "ATOMIC_DEFINE(x, y)=atomic_t x[ATOMIC_BITMAP_SIZE(y)]" \
+                         "CONFIG_ZIGBEE_DEBUG_FUNCTIONS=y"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/nrf/ug_zigbee_configuring.rst
+++ b/doc/nrf/ug_zigbee_configuring.rst
@@ -7,18 +7,16 @@ Configuring Zigbee in |NCS|
    :local:
    :depth: 2
 
-This page describes what is needed to start working with Zigbee in |NCS|.
+This page describes what is needed to start working with Zigbee in the |NCS|.
 
 .. _zigbee_ug_libs:
 
 Required libraries and drivers
 ******************************
 
-Zigbee requires the following modules to properly operate in |NCS|:
+Zigbee requires the following modules to properly operate in the |NCS|:
 
-* :ref:`nrfxlib:zboss` available in nrfxlib, with the OSIF subsystem acting as the linking layer between the ZBOSS stack and |NCS|.
-  OSIF implements a series of functions used by ZBOSS and is included in the |NCS|'s Zigbee subsystem.
-  The files that handle the OSIF integration are located in :file:`nrf/subsys/zigbee/osif`.
+* :ref:`nrfxlib:zboss` available in nrfxlib, with the :ref:`lib_zigbee_osif` subsystem acting as the linking layer between the ZBOSS stack and the |NCS|.
   The ZBOSS library is enabled by the :option:`CONFIG_ZIGBEE` Kconfig option.
   For more information about the ZBOSS stack, see also the `external ZBOSS development guide and API documentation`_.
 * :ref:`zephyr:ieee802154_interface` radio driver - This library is automatically enabled when working with Zigbee on Nordic Semiconductor's development kits.
@@ -57,7 +55,7 @@ This allows the stack to enter the sleep state during these periods, which also 
 When the Zigbee stack thread goes to sleep, the Zigbee thread can enter the suspend state for the same amount of time as the stack's sleep.
 The thread will be automatically resumed after the sleep period is over or on an event.
 
-In the Zigbee samples in |NCS|, the sleepy behavior can be triggered by pressing a predefined button when the device is booting.
+In the Zigbee samples in the |NCS|, the sleepy behavior can be triggered by pressing a predefined button when the device is booting.
 This action results in calling the ZBOSS API that activates this feature.
 See the :ref:`light switch sample <zigbee_light_switch_sample>` for a demonstration.
 
@@ -149,6 +147,7 @@ To customize them, use the following options:
 
 * :option:`CONFIG_ZBOSS_ERROR_PRINT_TO_LOG` - Allows the application to log ZBOSS error names; enabled by default.
 * :option:`CONFIG_ZBOSS_TRACE_MASK` - Sets the modules from which ZBOSS will log the debug messages with :option:`CONFIG_ZBOSS_TRACE_LOG_LEVEL`; no module is set by default.
+* :option:`CONFIG_ZBOSS_TRAF_DUMP` - Enables logging of the received 802.15.4 frames over ZBOSS trace log if :option:`CONFIG_ZBOSS_TRACE_LOG_LEVEL` is set; disabled by default.
 
 The stack logs are provided in a binary format (hex dump).
 

--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -208,12 +208,12 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 # Configure ZBOSS_OSIF_LOG_LEVEL
 module = ZBOSS_OSIF
-module-str = ZBOSS osif layer
+module-str = ZBOSS OSIF layer
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 endmenu #menu "Zigbee Log configuration"
 
-menu "ZBOSS osif configuration"
+menu "ZBOSS OSIF configuration"
 
 menuconfig ZIGBEE_HAVE_SERIAL
 	bool "UART serial abstract for ZBOSS OSIF"

--- a/subsys/zigbee/osif/zb_nrf_platform.h
+++ b/subsys/zigbee/osif/zb_nrf_platform.h
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/** @file
+ * @brief Zigbee ZBOSS OSIF layer API header.
+ */
+
 #ifndef ZB_NRF_PLATFORM_H__
 #define ZB_NRF_PLATFORM_H__
 
@@ -17,31 +21,11 @@ typedef enum {
 	ZIGBEE_EVENT_APP,
 } zigbee_event_t;
 
-#ifdef CONFIG_ZIGBEE_DEBUG_FUNCTIONS
-/**@brief Function for suspending zboss thread.
- */
-void zigbee_debug_suspend_zboss_thread(void);
-
-/**@brief Function for resuming zboss thread.
- */
-void zigbee_debug_resume_zboss_thread(void);
-
-/**@brief Function for getting the state of the Zigbee stack thread
- *        processing suspension.
+/**
+ * @defgroup zigbee_zboss_osif Zigbee ZBOSS OSIF API
+ * @{
  *
- * @retval true   Scheduler processing is suspended or zboss thread
- *                is not yet created.
- * @retval false  Scheduler processing is not suspended and zboss thread
- *                is created.
  */
-bool zigbee_is_zboss_thread_suspended(void);
-#endif /* defined(CONFIG_ZIGBEE_DEBUG_FUNCTIONS) */
-
-/**@brief Function for Zigbee stack initialization
- *
- * @return    0 if success
- */
-int zigbee_init(void);
 
 /**@brief Function for checking if the Zigbee stack has been started.
  *
@@ -50,10 +34,40 @@ int zigbee_init(void);
  */
 bool zigbee_is_stack_started(void);
 
-/* Function for starting Zigbee thread. */
+/**@brief Function for starting the Zigbee thread. */
 void zigbee_enable(void);
 
-/**@brief Notify ZBOSS thread about a new event.
+#ifdef CONFIG_ZIGBEE_DEBUG_FUNCTIONS
+/**@brief Function for suspending the ZBOSS thread.
+ */
+void zigbee_debug_suspend_zboss_thread(void);
+
+/**@brief Function for resuming the ZBOSS thread.
+ */
+void zigbee_debug_resume_zboss_thread(void);
+
+/**@brief Function for getting the state of the Zigbee stack thread
+ *        processing suspension.
+ *
+ * @retval true   Scheduler processing is suspended or the ZBOSS thread
+ *                is not yet created.
+ * @retval false  Scheduler processing is not suspended and the ZBOSS thread
+ *                is created.
+ */
+bool zigbee_is_zboss_thread_suspended(void);
+#endif /* defined(CONFIG_ZIGBEE_DEBUG_FUNCTIONS) */
+
+/**
+ * @}
+ */
+
+/**@brief Function for Zigbee stack initialization
+ *
+ * @return    0 if success
+ */
+int zigbee_init(void);
+
+/**@brief Notify the ZBOSS thread about a new event.
  *
  * @param[in] event  Event to notify.
  */


### PR DESCRIPTION
Added library page for the Zigbee OSIF subsystem.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>