### PR TITLE
partition_manager: add offset from region start

### DIFF
--- a/include/flash_map_pm.h
+++ b/include/flash_map_pm.h
@@ -37,7 +37,7 @@
 #define FLASH_AREA_ID(label) PM_ID(label)
 
 #define FLASH_AREA_OFFSET(label) \
-	UTIL_CAT(PM_, UTIL_CAT(UTIL_CAT(PM_, UTIL_CAT(PM_ID(label), _LABEL)), _ADDRESS))
+	UTIL_CAT(PM_, UTIL_CAT(UTIL_CAT(PM_, UTIL_CAT(PM_ID(label), _LABEL)), _OFFSET))
 
 #define FLASH_AREA_SIZE(label) \
 	UTIL_CAT(PM_, UTIL_CAT(UTIL_CAT(PM_, UTIL_CAT(PM_ID(label), _LABEL)), _SIZE))

--- a/scripts/partition_manager_output.py
+++ b/scripts/partition_manager_output.py
@@ -53,7 +53,9 @@ def get_config_lines(gpm_config, greg_config, head, split, dest, current_domain=
 
             name_upper = name.upper()
             name_lower = name.lower()
-
+            region = reg_config[partition['region']]
+            offset = partition['address'] - region['base_address']
+            add_line(f'{name_upper}_OFFSET', hex(offset))
             add_line(f'{name_upper}_ADDRESS', hex(partition['address']))
             # The end address facilitates using PM values via Cmake generator expressions.
             add_line(f'{name_upper}_END_ADDRESS', hex(partition['end_address']))
@@ -75,7 +77,7 @@ def get_config_lines(gpm_config, greg_config, head, split, dest, current_domain=
 
             if dest is DEST_HEADER:
                 if partition_has_device(partition):
-                    add_line(f'{name_upper}_DEV_NAME', f"\"{reg_config[partition['region']]['device']}\"")
+                    add_line(f'{name_upper}_DEV_NAME', f"\"{region['device']}\"")
             elif dest is DEST_KCONFIG:
                 if 'span' in partition.keys():
                     add_line(f'{name_upper}_SPAN', string_of_strings(partition['span']))


### PR DESCRIPTION
A region has a base address and currently partition manager
only outputs the absolute address to the partitions, not
any offsets from the base of the region it is located in.

This is problematic for several APIs that operate on offsets.
Working with offsets also mimics the devicetree model
more closely.

To work better with these APIs, and to be more aligned with
devicetree we add the _OFFSET define in the output of
partition manager.

In addition we change flash_map_pm.h to provide this value
to the 'FLASH_AREA_OFFSET' macro, which is what users
would expect in the first place.

Ref: NCSDK-9797
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>