### PR TITLE
applications: serial_lte_modem: Add IPv6 support to ICMP Ping

### DIFF
--- a/applications/serial_lte_modem/doc/ICMP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/ICMP_AT_commands.rst
@@ -27,10 +27,9 @@ Syntax
    #XPING=<url>,<length>,<timeout>[,<count>[,<interval>]]
 
 * The ``<url>`` parameter is a string.
-  It represents the hostname or the IPv4 address of the target host.
+  It represents the hostname, the IPv4, or the IPv6 address of the target host.
 * The ``<length>`` parameter is an integer.
   It represents the length of the buffer size.
-  Its maximum value is ``548``.
 * The ``<timeout>`` parameter is an integer.
   It represents the time to wait for each reply, in milliseconds.
 * The ``<count>`` parameter is an integer.
@@ -40,23 +39,15 @@ Syntax
   It represents the time to wait for sending the next echo request, in milliseconds.
   Its default value is ``1000``.
 
-Response syntax
-~~~~~~~~~~~~~~~
-
-This is the response syntax when an echo reply is received:
+Unsolicited notification
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-   #XPING: <response time>
+   #XPING: <response time> seconds
 
 The ``<response time>`` value is a *float*.
 It represents the elapsed time, in seconds, between the echo requests and the echo replies.
-
-This is the response syntax when an echo reply is not received:
-
-::
-
-   #XPING: "timeout"
 
 Example
 ~~~~~~~
@@ -64,13 +55,13 @@ Example
 ::
 
    AT#XPING="5.189.130.26",45,5000,5,1000
-   #XPING: 0.386
-   #XPING: 0.341
-   #XPING: 0.353
-   #XPING: 0.313
-   #XPING: 0.313
-   #XPING: "average 0.341"
    OK
+   #XPING: 0.386 seconds
+   #XPING: 0.341 seconds
+   #XPING: 0.353 seconds
+   #XPING: 0.313 seconds
+   #XPING: 0.313 seconds
+   #XPING: average 0.341 seconds
 
 Read command
 ------------

--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -827,12 +827,12 @@ The test command is not supported.
 Resolve hostname #XGETADDRINFO
 ==============================
 
-The ``#XGETADDRINFO`` command allows you to resolve hostnames to IPv4 addresses.
+The ``#XGETADDRINFO`` command allows you to resolve hostnames to IPv4 and/or IPv6 addresses.
 
 Set command
 -----------
 
-The set command allows you to resolve hostnames to IPv4 addresses.
+The set command allows you to resolve hostnames to IPv4 and/or IPv6 addresses.
 
 Syntax
 ~~~~~~
@@ -842,7 +842,6 @@ Syntax
    #XGETADDRINFO=<hostname>
 
 The ``<hostname>`` parameter is a string.
-It cannot be an IPv4 address string.
 
 Response syntax
 ~~~~~~~~~~~~~~~
@@ -852,7 +851,7 @@ Response syntax
    #XGETADDRINFO: "<ip_addr>"
 
 * The ``<ip_addr>`` value is a string.
-  It indicates the IPv4 address of the resolved hostname.
+  It indicates the IPv4 and/or IPv6 address of the resolved hostname.
 
 Examples
 ~~~~~~~~

--- a/applications/serial_lte_modem/doc/slm_testing.rst
+++ b/applications/serial_lte_modem/doc/slm_testing.rst
@@ -1286,16 +1286,20 @@ DNS lookup
       :class: highlight
 
       **AT#XGETADDRINFO="www.google.com"**
-      #XGETADDRINFO: 172.217.174.100
+      #XGETADDRINFO: "172.217.174.100"
       OK
 
-#. Observe that you cannot look up the host name for an IP address.
-
-   .. parsed-literal::
-      :class: highlight
+      **AT#XGETADDRINFO="ipv6.google.com"**
+      #XGETADDRINFO: "2404:6800:4006:80e::200e"
+      OK
 
       **AT#XGETADDRINFO="172.217.174.100"**
-      ERROR
+      #XGETADDRINFO: "172.217.174.100"
+      OK
+
+      **AT#XGETADDRINFO="2404:6800:4006:80e::200e"**
+      #XGETADDRINFO: "2404:6800:4006:80e::200e"
+      OK
 
 Socket options
 ==============
@@ -1359,13 +1363,22 @@ Complete the following steps to test the functionality provided by the :ref:`SLM
       :class: highlight
 
       **AT#XPING="www.google.com",45,5000,5,1000**
-      #XPING: 0.637
-      #XPING: 0.585
-      #XPING: 0.598
-      #XPING: 0.598
-      #XPING: 0.599
-      #XPING: average 0.603
       OK
+      #XPING: 0.637 seconds
+      #XPING: 0.585 seconds
+      #XPING: 0.598 seconds
+      #XPING: 0.598 seconds
+      #XPING: 0.599 seconds
+      #XPING: average 0.603 seconds
+
+      **AT#XPING="ipv6.google.com",45,5000,5,1000**
+      OK
+      #XPING: 0.140 seconds
+      #XPING: 0.109 seconds
+      #XPING: 0.113 seconds
+      #XPING: 0.118 seconds
+      #XPING: 0.112 seconds
+      #XPING: average 0.118 seconds
 
 #. Ping a remote IP address, for example, 172.217.174.100.
 
@@ -1373,13 +1386,13 @@ Complete the following steps to test the functionality provided by the :ref:`SLM
       :class: highlight
 
       **AT#XPING="172.217.174.100",45,5000,5,1000**
-      #XPING: 0.873
-      #XPING: 0.576
-      #XPING: 0.599
-      #XPING: 0.623
-      #XPING: 0.577
-      #XPING: average 0.650
       OK
+      #XPING: 0.873 seconds
+      #XPING: 0.576 seconds
+      #XPING: 0.599 seconds
+      #XPING: 0.623 seconds
+      #XPING: 0.577 seconds
+      #XPING: average 0.650 seconds
 
 FTP AT commands
 ***************

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -80,7 +80,7 @@ static int do_tcp_server_start(uint16_t port)
 	int ret = 0;
 	struct sockaddr_in local;
 	int addr_len;
-	char ipv4_addr[NET_IPV4_ADDR_LEN];
+	char ipv4_addr[NET_IPV4_ADDR_LEN] = {0};
 #if SLM_TCP_PROXY_FUTURE_FEATURE
 	int addr_reuse = 1;
 #endif
@@ -138,7 +138,8 @@ static int do_tcp_server_start(uint16_t port)
 	/* Bind to local port */
 	local.sin_family = AF_INET;
 	local.sin_port = htons(port);
-	if (!util_get_ipv4_addr(ipv4_addr)) {
+	util_get_ip_addr(ipv4_addr, NULL);
+	if (strlen(ipv4_addr) == 0) {
 		LOG_ERR("Unable to obtain local IPv4 address");
 		ret = -ENETUNREACH;
 		goto exit;

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -63,7 +63,7 @@ static int do_udp_server_start(uint16_t port)
 	int ret = 0;
 	struct sockaddr_in local;
 	int addr_len;
-	char ipv4_addr[NET_IPV4_ADDR_LEN];
+	char ipv4_addr[NET_IPV4_ADDR_LEN] = {0};
 
 	/* Open socket */
 	udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -77,7 +77,8 @@ static int do_udp_server_start(uint16_t port)
 	/* Bind to local port */
 	local.sin_family = AF_INET;
 	local.sin_port = htons(port);
-	if (!util_get_ipv4_addr(ipv4_addr)) {
+	util_get_ip_addr(ipv4_addr, NULL);
+	if (strlen(ipv4_addr) == 0) {
 		LOG_ERR("Unable to obtain local IPv4 address");
 		close(udp_sock);
 		return ret;

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -103,14 +103,6 @@ int slm_util_atoh(const char *ascii, uint16_t ascii_len,
  */
 bool check_for_ipv4(const char *address, uint8_t length);
 
-/**brief use AT command to get IPv4 address
- *
- * @param[in] address buffer to hold the IPv4 address
- *
- * @return true if IPv4 address obtained, false otherwise
- */
-bool util_get_ipv4_addr(char *address);
-
 /**
  * @brief Get string value from AT command with length check.
  *
@@ -130,6 +122,13 @@ bool util_get_ipv4_addr(char *address);
 int util_string_get(const struct at_param_list *list, size_t index,
 			 char *value, size_t *len);
 
+/**
+ * @brief use AT command to get IPv4 and IPv6 addresses
+ *
+ * @param[in] addr4 buffer to hold the IPv4 address, size NET_IPV4_ADDR_LEN
+ * @param[in] addr6 buffer to hold the IPv6 address, size NET_IPV6_ADDR_LEN
+ */
+void util_get_ip_addr(char *addr4, char *addr6);
 /** @} */
 
 #endif /* SLM_UTIL_ */


### PR DESCRIPTION
Reworked Ping implementation to support IPv6 target, by hostname or
IPv6 address. Affect two SLM AT command:
  AT#XPING
  AT#XGETADDRINFO

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>