### PR TITLE
ci: use v1.6 fork of CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v1.6-branch") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 


### PR DESCRIPTION
Loads the exact CI when NRF:v1.6 was tagged

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>