### PR TITLE
Add missing .dts file for nrf52833 in openthread coap_sample

### DIFF
--- a/samples/openthread/coap_client/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/openthread/coap_client/boards/nrf52833dk_nrf52833.overlay
@@ -1,0 +1,36 @@
+/* Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+
+&adc {
+	status = "disabled";
+};
+&uart1 {
+	status = "disabled";
+};
+&pwm0 {
+	status = "disabled";
+};
+&i2c0 {
+	status = "disabled";
+};
+&spi0 {
+	status = "disabled";
+};
+&spi1 {
+	status = "disabled";
+};
+&spi2 {
+	status = "disabled";
+};
+&spi3 {
+	status = "disabled";
+};
+&usbd {
+	status = "disabled";
+};
+&gpio1 {
+	status = "disabled";
+};


### PR DESCRIPTION
Add missing .dts file for nrf52833 in openthread coap_sample. Without this file uart1 is enabled by default and power consumption of the board in idle state is too high