### PR TITLE
net: lib: nrf_cloud: obtain UUID from JWT instead of attestation tok

### DIFF
--- a/lib/modem_attest_token/modem_attest_token.c
+++ b/lib/modem_attest_token/modem_attest_token.c
@@ -15,7 +15,6 @@
 #include <tinycbor/cbor_buf_reader.h>
 #include <modem/modem_attest_token.h>
 
-#define GET_BASE64_LEN(n) (((4 * n / 3) + 3) & ~3)
 #define BASE64_PAD_CHAR '='
 #define AT_ATTEST_CMD "AT%ATTESTTOKEN"
 

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -51,8 +51,7 @@ config NRF_CLOUD_CLIENT_ID_SRC_COMPILE_TIME
 
 config NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID
 	bool "Modem internal UUID value"
-	select MODEM_ATTEST_TOKEN
-	select MODEM_ATTEST_TOKEN_PARSING
+	depends on MODEM_JWT
 	help
 	  Requires modem firmware version 1.3 or later.
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -24,7 +24,7 @@
 #include <nrf_socket.h>
 #endif
 #if defined(CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID)
-#include "modem/modem_attest_token.h"
+#include "modem/modem_jwt.h"
 #endif
 
 LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
@@ -325,7 +325,7 @@ static int nct_client_id_set(const char * const client_id)
 #elif defined(CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID)
 	struct nrf_device_uuid dev_id;
 
-	err = modem_attest_token_get_uuids(&dev_id, NULL);
+	err = modem_jwt_get_uuids(&dev_id, NULL);
 	if (err) {
 		LOG_ERR("Failed to get device UUID: %d", err);
 		return err;


### PR DESCRIPTION
Use the new method for obtaining the UUID from a JWT instead of
an attestation token.
The JWT method does not require the CBOR library.
Ref: CIA-352

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>