### PR TITLE
boards: thingy53: ensure network core is started before 802.15.4

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.6.0-rc1-ncs1
+      revision: pull/573/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull the change to the Thingy:53 board files decreasing the
board init priority level (which includes starting the
network core) in order to guarantee that the initialization
happens before the 802.15.4 driver initialization. It is
necessary, because the latter involves establishing a rpmsg
channel with the network core.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>