### PR TITLE
DTM and radio test build empty_app_core sample by default as child image.

### DIFF
--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -210,6 +210,8 @@ Building and running
    It does not require any counterpart application sample.
    However, you must still program the application core to boot up the network core.
    You can use any sample for this, for example, the :ref:`nrf5340_empty_app_core`.
+   The :ref:`nrf5340_empty_app_core` is built and programmed automatically by default.
+   If you want to program another sample for the application core, unset the :option:'CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE' option.
 
 .. _dtm_testing:
 

--- a/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.conf
+++ b/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.conf
@@ -4,3 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 CONFIG_PM_DEVICE=y
+
+# Build Empty APP Core sample for the application core
+CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE=y

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -137,6 +137,8 @@ Building and running
    On the |nRF5340DKnoref|, the Radio test sample is a standalone network sample that does not require any counterpart application sample.
    However, you must still program the application core to boot up the network core.
    You can use any sample for this, for example :ref:`nrf5340_empty_app_core`.
+   The :ref:`nrf5340_empty_app_core` is built and programmed automatically by default.
+   If you want to program another sample for the application core, unset the :option:'CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE' option.
 
 .. _radio_test_testing:
 

--- a/samples/peripheral/radio_test/boards/nrf5340dk_nrf5340_cpunet.conf
+++ b/samples/peripheral/radio_test/boards/nrf5340dk_nrf5340_cpunet.conf
@@ -4,3 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 CONFIG_PM_DEVICE=y
+
+# Build Empty APP Core sample for the application core
+CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE=y


### PR DESCRIPTION
This PR adds possibility to build empty_app_core by default for the Direct Test Mode sample and the Radio Test sample