### PR TITLE
Zigbee: Add integration platforms to unit tests

### DIFF
--- a/tests/subsys/zigbee/osif/crypto/testcase.yaml
+++ b/tests/subsys/zigbee/osif/crypto/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   zigbee.osif.logger:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: osif_crypto
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833

--- a/tests/subsys/zigbee/osif/nvram/testcase.yaml
+++ b/tests/subsys/zigbee/osif/nvram/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   zigbee.osif.nvram:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: zigbee_nvram
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833

--- a/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
@@ -2,3 +2,7 @@ tests:
   zigbee.osif.serial.async:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: osif_serial
+    harness_config:
+      fixture: shorted_uart_1
+    integration_platforms:
+      - null # No integration platforms because test requires shorted UART 1 pins

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
@@ -2,3 +2,7 @@ tests:
   zigbee.osif.serial.basic:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: osif_serial
+    harness_config:
+      fixture: shorted_uart_1
+    integration_platforms:
+      - null # No integration platforms because test requires shorted UART 1 pins

--- a/tests/subsys/zigbee/osif/serial/serial_via_logger/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_via_logger/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   zigbee.osif.logger:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: osif_logger
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833

--- a/tests/subsys/zigbee/osif/timer/testcase.yaml
+++ b/tests/subsys/zigbee/osif/timer/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   zigbee.osif.timer:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: zigbee_osif
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833

--- a/tests/subsys/zigbee/zboss_api/alarm_api/testcase.yaml
+++ b/tests/subsys/zigbee/zboss_api/alarm_api/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   zigbee.zboss_api.alarm_api:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: zboss_api_alarm
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833

--- a/tests/subsys/zigbee/zboss_api/callback_api/testcase.yaml
+++ b/tests/subsys/zigbee/zboss_api/callback_api/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   zigbee.zboss_api.callback_api:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: zboss_api_callback
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833


### PR DESCRIPTION
Specify platforms on which unit tests are run periodically.
Some tests are excluded from integration suite, because it require special hardware,
Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>