### PR TITLE
sample: store the default path of empty_app_core in Kconfig

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -160,7 +160,7 @@ if (CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE)
 
   add_child_image(
     NAME empty_app_core
-    SOURCE_DIR ${NRF_DIR}/samples/nrf5340/empty_app_core
+    SOURCE_DIR ${NRF_DIR}/${CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_PATH}
     DOMAIN CPUAPP
     BOARD ${CONFIG_DOMAIN_CPUAPP_BOARD})
 endif()

--- a/samples/Kconfig
+++ b/samples/Kconfig
@@ -25,6 +25,13 @@ config NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE
 	  Add the empty_app_core as a child image for the given sample.
 	  Used by samples that only require SOC_NRF5340_CPUNET.
 
+config NCS_SAMPLE_EMPTY_APP_CORE_PATH
+	string "Path of the empty_app_core as a child image"
+	default "samples/nrf5340/empty_app_core"
+	depends on NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE
+	help
+	  Set the source of the empty_app_core to be used.
+
 if LOG
 
 # LOG_DEFAULT_LEVEL is declared in Zephyr,


### PR DESCRIPTION
It allows setting source of empty_app_core for the given sample.

Signed-off-by: Chu, Ryan <ryan.chu@nordicsemi.no>