### PR TITLE
matter: bring in fixes for Matter CI

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -126,7 +126,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v1.6.0
+      revision: pull/15/head
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Merged changes which fix github workflows run on the
sdk-connectedhomeip fork. The workflows were configured
specifically for the upstream, so they required some
adjustments to pass on the fork as well.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>