### PR TITLE
lib: supl: change ID from IMSI to IP address

### DIFF
--- a/lib/supl/include/lte_params.h
+++ b/lib/supl/include/lte_params.h
@@ -20,9 +20,9 @@ void lte_params_init(struct lte_params *params);
  * @brief Handler for XMONITOR AT command
  *
  * @param[in,out] session_ctx   session context to fill
- * @param[in]     col_number      column number
+ * @param[in]     col_number    column number
  * @param[in]     buf           input buffer
- * @param[in]     buf_len         input buffer length
+ * @param[in]     buf_len       input buffer length
  *
  * @return 0 for success, -1 otherwise
  */
@@ -30,5 +30,27 @@ int handler_at_xmonitor(struct supl_session_ctx *session_ctx,
 			int col_number,
 			const char *buf,
 			int buf_len);
+
+/**
+ * @brief Initialize the device ID
+ *
+ * @param[in,out]   session_ctx  The session context
+ */
+void device_id_init(struct supl_session_ctx *session_ctx);
+
+/**
+ * @brief Handler for +CGDCONT AT response
+ *
+ * @param[in,out] session_ctx   session context to fill
+ * @param[in]     col_number    column number
+ * @param[in]     buf           input buffer
+ * @param[in]     buf_len       input buffer length
+ *
+ * @return 0 for success, -1 otherwise
+ */
+int handler_at_cgdcont(struct supl_session_ctx *session_ctx,
+		       int col_number,
+		       const char *buf,
+		       int buf_len);
 
 #endif /* SUPL_LTE_PARAMS_H_ */


### PR DESCRIPTION
Change the used device ID from IMSI to the device IP address. It's better not to send the IMSI to the network if not mandatory, especially unencrypted.