### PR TITLE
manifest: Add nrf security Kconfig for SOME_PSK

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: fa5a790a287954915b4e3e48a4ff3cf614d04a2a
+      revision: pull/511/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-This points to the nrfxlib with an added
 Kconfig option for MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED

Nrfxlib PR: [pull/511](https://github.com/nrfconnect/sdk-nrfxlib/pull/511)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>