### PR TITLE
applications: asset_tracker_v2: Use correct input arg in `memcpy`

### DIFF
--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -266,7 +266,7 @@ static void agps_data_request_handle(struct gps_agps_request *incoming_request)
 	/* Keep a local copy of the incoming request. Used when injecting PGPS data into the
 	 * modem.
 	 */
-	memcpy(&agps_request, &incoming_request, sizeof(agps_request));
+	memcpy(&agps_request, incoming_request, sizeof(agps_request));
 
 #if defined(CONFIG_AGPS)
 	err = gps_agps_request_send(agps_request, GPS_SOCKET_NOT_PROVIDED);


### PR DESCRIPTION
Directly pass in pointer to `incoming_request` in `src` argument for
`memcpy`. Previously the incoming agps data request was not properly
copied into the `cloud_module` local copy. This would cause the
`cloud_module` to not request AGPS data that was actually
specified by the modem.

Addresses CIA-370