### PR TITLE
applications: serial_lte_modem: Enhance FOTA function

### DIFF
--- a/applications/serial_lte_modem/doc/AT_commands_intro.rst
+++ b/applications/serial_lte_modem/doc/AT_commands_intro.rst
@@ -38,6 +38,7 @@ The modem-specific AT commands are documented in the `nRF91 AT Commands Referenc
    FTP_AT_commands
    GPS_AT_commands
    ICMP_AT_commands
+   FOTA_AT_commands
    SMS_AT_commands
    MQTT_AT_commands
    TCPIP_AT_commands

--- a/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
@@ -1,0 +1,155 @@
+.. _SLM_AT_FOTA:
+
+FOTA AT commands
+****************
+
+.. contents::
+   :local:
+   :depth: 2
+
+The following commands list contains AT commands related to firmware-over-the-air updates (FOTA) requests.
+
+FOTA request #XFOTA
+===================
+
+The ``#XFOTA`` command sends various types of FOTA requests, based on specific operation codes.
+
+Set command
+-----------
+
+The set command allows you to send a FOTA request.
+
+Syntax
+~~~~~~
+
+::
+
+   AT#XFOTA=<op>,<file_url>[,<sec_tag>[,<apn>]]
+
+* The ``<op>`` parameter can accept one of the following values:
+
+  * ``0`` - Cancel FOTA (during download only).
+  * ``1`` - Start FOTA for application update.
+  * ``2`` - Start FOTA for modem delta update.
+  * ``8`` - Erase mcuboot secondary slot (optional for application FOTA).
+  * ``9`` - Erase modem scratch space (optional for modem FOTA).
+
+* The ``<file url>`` parameter is a string.
+  It represents the full HTTP or HTTPS path of the target image to download.
+* The ``<sec_tag>`` parameter is an integer.
+  It indicates to the modem the credential of the security tag used for establishing a secure connection for downloading the image.
+  It is associated with the certificate or PSK.
+  Specifying the ``<sec_tag>`` is mandatory when using HTTPS.
+* The ``<apn>`` parameter is a string.
+  It represents an alternative access point name (APN), other than the default primary APN, to use for downloading.
+
+Example
+~~~~~~~
+
+::
+
+   Application download and activate
+   AT#XFOTA=1,"http://remote.host/fota/slm_app_update.bin"
+   AT#XRESET
+
+   Abnormal download the same image twice, REVERT error
+   AT#XFOTA=1,"http://remote.host/fota/slm_app_update.bin"
+
+   Erase previous image after FOTA
+   AT#XFOTA=8
+
+   Erase modem scratch space before FOTA
+   AT#XFOTA=9
+
+   Modem download and activate
+   AT#XFOTA=2,"http://remote.host/fota/mfw_nrf9160_update_from_1.3.0_to_1.3.0-FOTA-TEST.bin"
+   AT#XRESET
+
+Unsolicited notification
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+   #XFOTA: <fota_stage>,<fota_status>[,<fota_info>]
+
+* The ``<fota_stage>`` value is an integer and can assume one of the following values:
+
+  * ``0`` - Init
+  * ``1`` - Download
+  * ``2`` - Download, erase pending (modem FOTA only)
+  * ``3`` - Download, erased (modem FOTA only)
+  * ``4`` - Downloaded, to be activated
+  * ``5`` - Complete
+
+* The ``<fota_status>`` value is an integer and can assume one of the following values:
+
+  * ``0`` - OK
+  * ``1`` - Error
+  * ``2`` - Cancelled
+  * ``3`` - Reverted (application FOTA only)
+
+* The ``<fota_info>`` value is an integer.
+  Its value can have different meanings based on the values assumed by ``<fota_stage>`` and ``<fota_status>``.
+  See the following table:
+
+  +-------------------------+----------------------------+-------------------------------------------------------------------------------+
+  |``<fota_stage>`` value   |``<fota_status>`` value     | ``<fota_info>`` value                                                         |
+  +=========================+============================+===============================================================================+
+  |``1`` (namely *Download*)| ``0`` (namely *OK*)        | Percentage of the download                                                    |
+  +-------------------------+----------------------------+-------------------------------------------------------------------------------+
+  |``1`` (namely *Download*)| ``1`` (namely *ERROR*)     | Error Code                                                                    |
+  +-------------------------+----------------------------+-------------------------------------------------------------------------------+
+  |``5`` (namely *Complete*)| ``1`` (namely *ERROR*)     | Error Code                                                                    |
+  +-------------------------+----------------------------+-------------------------------------------------------------------------------+
+  |``1`` (namely *Download*)| ``2`` (namely *CANCELLED*) | ``0`` - Downloading is cancelled before completion                            |
+  +-------------------------+------------------------+---+-------------------------------------------------------------------------------+
+  |``5`` (namely *Complete*)| ``3`` (namely *REVERTED*)  | ``0`` - New application image has problem and MCUBOOT revert to current image |
+  +-------------------------+----------------------------+-------------------------------------------------------------------------------+
+
+  The error codes can be the following:
+
+  * ``1`` - Download failed
+  * ``2`` - Update image rejected (for example modem firmware version error)
+  * ``3`` - Update image mismatch (for example ``<op>`` is ``1`` but ``<file_url>`` points to a modem image)
+
+  For modem FOTA, the error codes can be the following:
+
+  * ``0x4400001u`` - The modem encountered a fatal internal error during firmware update.
+  * ``0x4400002u`` - The modem encountered a fatal hardware error during firmware update.
+  * ``0x4400003u`` - Modem firmware update failed, due to an authentication error.
+  * ``0x4400004u`` - Modem firmware update failed, due to UUID mismatch.
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command tests the existence of the command and provides information about the type of its subparameters.
+
+Syntax
+~~~~~~
+
+::
+
+   #XFOTA=?
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XFOTA: <list of op value>,<file_url>,<sec_tag>,<apn>
+
+Examples
+~~~~~~~~
+
+::
+
+   AT#XFOTA=?
+
+   #XFOTA: (0,1,2,8,9),<file_url>,<sec_tag>,<apn>
+
+   OK

--- a/applications/serial_lte_modem/src/slm_at_fota.h
+++ b/applications/serial_lte_modem/src/slm_at_fota.h
@@ -24,7 +24,8 @@ enum fota_stages {
 enum fota_status {
 	FOTA_STATUS_OK,
 	FOTA_STATUS_ERROR,
-	FOTA_STATUS_CANCELLED
+	FOTA_STATUS_CANCELLED,
+	FOTA_STATUS_REVERTED
 };
 
 /**

--- a/applications/serial_lte_modem/src/slm_settings.c
+++ b/applications/serial_lte_modem/src/slm_settings.c
@@ -16,7 +16,6 @@ LOG_MODULE_REGISTER(slm_config, CONFIG_SLM_LOG_LEVEL);
 /**
  * Serial LTE Modem setting page for persistent data
  */
-uint8_t fota_type;		/* FOTA: image type */
 uint8_t fota_stage;		/* FOTA: stage of FOTA process */
 uint8_t fota_status;		/* FOTA: OK/Error status */
 int32_t fota_info;		/* FOTA: failure cause in case of error or download percentage*/
@@ -26,12 +25,7 @@ struct uart_config slm_uart;	/* UART: config */
 
 static int settings_set(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg)
 {
-	if (!strcmp(name, "fota_type")) {
-		if (len != sizeof(fota_type))
-			return -EINVAL;
-		if (read_cb(cb_arg, &fota_type, len) > 0)
-			return 0;
-	} else if (!strcmp(name, "fota_stage")) {
+	if (!strcmp(name, "fota_stage")) {
 		if (len != sizeof(fota_stage))
 			return -EINVAL;
 		if (read_cb(cb_arg, &fota_stage, len) > 0)
@@ -113,11 +107,6 @@ int slm_setting_fota_save(void)
 	int ret;
 
 	/* Write a single serialized value to persisted storage (if it has changed value). */
-	ret = settings_save_one("slm/fota_type", &(fota_type), sizeof(fota_type));
-	if (ret) {
-		LOG_ERR("save slm/fota_type failed: %d", ret);
-		return ret;
-	}
 	ret = settings_save_one("slm/fota_stage", &(fota_stage), sizeof(fota_stage));
 	if (ret) {
 		LOG_ERR("save slm/fota_stage failed: %d", ret);
@@ -139,7 +128,6 @@ int slm_setting_fota_save(void)
 
 void slm_setting_fota_init(void)
 {
-	fota_type = 0; /* see enum dfu_target_image_type */
 	fota_stage = FOTA_STAGE_INIT;
 	fota_status = FOTA_STATUS_OK;
 	fota_info = 0;

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -41,6 +41,7 @@ nRF9160
 
     * Added a separate document page to explain data mode mechanism and how it works.
     * Removed datatype in all sending AT commands. If no sending data is specified, switch data mode to receive and send any arbitrary data.
+    * Added a separate document page to describe the FOTA service.
 
 nRF5
 ====


### PR DESCRIPTION
Use different OP code for APP and MFW FOTA
Remove FOTA image_type in URC notification.
Add to support erasing of MCUBOOT secondary.
After APP FOTA, check the swap type from MCUBOOT.
Confirm new image only if the swap type is TEST image.
Add SLM FOTA service document.

JIRA reference: NCSIDB-500

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>