### PR TITLE
partition manager: configure MBR partition for nRF5280 dongle

### DIFF
--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -49,6 +49,10 @@ endfunction()
 # Add all pm.yml files for subsystems
 # Store the preprocessed output in the binary dir of the subsystems
 # to avoid overwriting pm.yml files.
+if (CONFIG_BOARD_HAS_NRF5_BOOTLOADER)
+  ncs_add_partition_manager_config(pm.yml.nrf5_mbr)
+endif()
+
 if (CONFIG_SETTINGS_FCB OR CONFIG_SETTINGS_NVS)
   ncs_add_partition_manager_config(pm.yml.settings)
 endif()

--- a/subsys/partition_manager/pm.yml.nrf5_mbr
+++ b/subsys/partition_manager/pm.yml.nrf5_mbr
@@ -1,0 +1,3 @@
+nrf5_mbr:
+  placement: {after: [start]}
+  size: 0x1000


### PR DESCRIPTION
nRF52840 dongle reserves the first 4KiB of flash for the
MBR. Partition manager does not reflect this fact and
MCUBoot is built with a wrong base address - 0. As a result,
any sample built with CONFIG_BOOTLOADER_MCUBOOT=y does not
run correctly on the dongle.

Add a new "mbr" partition when an application is built for
the nrf52840dnogle_nrf52840 target.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>