### PR TITLE
zigbee: Update ZBOSS libraries to v3.6.0.3+v3.0.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 59179ff80cee01c4feb8b747e0ff9caecb55c92d
+      revision: pull/513/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Update ZBOSS libraries to fix the bug in GPPB table and deadlock in NCP fragmentation logic.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>