### PR TITLE
manifest: update nrf_modem docs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1f3ad531bf48d4241b6c60f5c521364a0785bfa7
+      revision: 59179ff80cee01c4feb8b747e0ff9caecb55c92d
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
This commit updates the manifest pointing to an update
to nrfxlib that addresses some remarks n the `nrf_modem` documentation
regarding support of the `nrf_select` function.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>