### PR TITLE
Zigbee: Extend CI-zigbee-test label scope

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -75,6 +75,7 @@
   - "subsys/dfu/**/*"
   - "subsys/mpsl/**/*"
   - "subsys/zigbee/**/*"
+  - "tests/subsys/zigbee/**/*"
 
 "CI-thingy91-test":
   - "applications/asset_tracker/**/*"


### PR DESCRIPTION
Add CI-zigbee-test label to PRs changing Zigbee tests.
Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>