### PR TITLE
doc: add crosslinks to Board Porting Guide

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -811,8 +811,10 @@ The nRF Desktop application uses the following files as configuration sources:
 * Kconfig files - These reflect the software configuration.
   See :ref:`kconfig_tips_and_tricks` for information about how to configure them.
 
-You must modify these configuration sources when `Adding a new board`_.
+You must modify these configuration sources when `Adding a new board`_, as described below.
+
 For information about differences between DTS and Kconfig, see :ref:`zephyr:dt_vs_kconfig`.
+For detailed instructions for adding Zephyr support to a custom board, see Zephyr's :ref:`zephyr:board_porting_guide`.
 
 .. _nrf_desktop_board_configuration:
 
@@ -901,7 +903,8 @@ When adding a new board for the first time, focus on a single configuration.
 Moreover, keep the default ``ZDebug`` build type that the application is built with, and do not add any additional build type parameters.
 
 .. note::
-    The following procedure uses the gaming mouse configuration as an example.
+    * The following procedure uses the gaming mouse configuration as an example.
+    * The first three steps of the configuration procedure are identical to the steps described in Zephyr's :ref:`zephyr:board_porting_guide`.
 
 To use the nRF Desktop application with your custom board:
 

--- a/doc/nrf/app_boards.rst
+++ b/doc/nrf/app_boards.rst
@@ -102,3 +102,6 @@ To define your own board, you can use the following Zephyr guides as reference, 
 
 * :ref:`custom_board_definition` is a guide to adding your own custom board to the Zephyr build system.
 * :ref:`board_porting_guide` is a complete guide to porting Zephyr to your own board.
+
+One of the |NCS| applications that lets you add custom boards is :ref:`nrf_desktop`.
+See :ref:`nrf_desktop_porting_guide` in the application documentation for details.

--- a/doc/nrf/app_build_system.rst
+++ b/doc/nrf/app_build_system.rst
@@ -25,6 +25,7 @@ See the following links for information about the different building blocks ment
 * :ref:`zephyr:cmake-details` describes in-depth the usage of CMake for Zephyr-based applications.
 * :ref:`zephyr:application-kconfig` contains a guide for Kconfig usage in applications.
 * :ref:`zephyr:set-devicetree-overlays` explains how to use devicetree and its overlays to customize an application's devicetree.
+* :ref:`board_porting_guide` is a complete guide to porting Zephyr to your own board.
 
 |NCS| additions
 ***************


### PR DESCRIPTION
Added links to Zephyr's Board Porting Guide to sdk-nrf.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>