### PR TITLE
doc: release notes: add release notes for Central SMP Client sample

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -45,10 +45,19 @@ nRF9160
 nRF5
 ====
 
+The following changes are relevant for the nRF52 and nRF53 Series.
+
 nRF Desktop
 -----------
 
 * Settings backend changed from FCB to NVS.
+
+Bluetooth LE
+------------
+
+* Updated:
+
+  * :ref:`ble_samples` - Changed the Bluetooth sample Central DFU SMP name to :ref:`Central SMP Client <bluetooth_central_dfu_smp>`.
 
 Common
 ======


### PR DESCRIPTION
Added information about changing the sample name
from Central DFU SMP to Central SMP Client.

Relates to #5023.

Signed-off-by: Marcin Jeliński <marcin.jelinski@nordicsemi.no>