### PR TITLE
doc: zigbee: add error handler library page

### DIFF
--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -1988,7 +1988,8 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_LWM2M_CLIENT_UTILS_DEVICE_OBJ_SUPPORT=y" \
                          "CONFIG_LWM2M_CLIENT_UTILS_SECURITY_OBJ_SUPPORT=y"\
                          "ATOMIC_DEFINE(x, y)=atomic_t x[ATOMIC_BITMAP_SIZE(y)]" \
-                         "CONFIG_ZIGBEE_DEBUG_FUNCTIONS=y"
+                         "CONFIG_ZIGBEE_DEBUG_FUNCTIONS=y" \
+                         "CONFIG_ZBOSS_ERROR_PRINT_TO_LOG=y"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/zigbee/zigbee_error_handler.h
+++ b/include/zigbee/zigbee_error_handler.h
@@ -5,13 +5,10 @@
  */
 
 /**
+ * @file
  *  @defgroup zb_error ZBOSS error handling utilities
  *  @{
- */
-
-/**
- * @file
- * @brief This file defines the error handler for ZBOSS error codes.
+ * @brief This file defines the error handler utilities for ZBOSS error codes.
  */
 
 #ifndef ZIGBEE_ERROR_HANDLER_H__
@@ -22,15 +19,18 @@
 #include <zboss_api.h>
 #include <zb_errors.h>
 
-#define ZB_ERROR_BASE_NUM 20000 /*< ZBOSS stack error codes base. */
+/**@brief ZBOSS stack error code base.
+ *
+ */
+#define ZB_ERROR_BASE_NUM 20000
 
 #ifdef CONFIG_ZBOSS_ERROR_PRINT_TO_LOG
 #include "zb_error_to_string.h"
 #include <logging/log.h>
 
 
-/**@brief Macro for calling error handler function if supplied
- *        error code any other than RET_OK.
+/**@brief Macro for calling the error handler function if the supplied
+ *        ZBOSS return code is different than RET_OK.
  *
  * @param[in] ERR_CODE Error code supplied to the error handler.
  */
@@ -47,11 +47,11 @@
 		}							\
 	} while (0)
 
-/**@brief Macro for calling error handler function
- *        if bdb_start_top_level_commissioning return code
- *        indicates that it BDB procedure did not succeed.
+/**@brief Macro for calling the error handler function
+ *        if the return code for bdb_start_top_level_commissioning
+ *        indicates that the BDB procedure did not succeed.
  *
- * @param[in] COMM_STATUS Value returned by
+ * @param[in] COMM_STATUS Value returned by the
  *            bdb_start_top_level_commissioning function.
  */
 #define ZB_COMM_STATUS_CHECK(COMM_STATUS)				      \

--- a/include/zigbee/zigbee_error_handler.rst
+++ b/include/zigbee/zigbee_error_handler.rst
@@ -1,0 +1,36 @@
+.. _lib_zigbee_error_handler:
+
+Zigbee error handler
+####################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Zigbee error handler library provides a set of macros that can be used to assert on nrfxlib's :ref:`nrfxlib:zboss` API return codes.
+The assertion is implemented by a call to the :c:func:`k_fatal_halt` function.
+Additionally, you can enable the library to log the error code name before the assertion.
+
+Functions that resolve the numeric error code to printable string are defined in the :file:`zb_error_to_string.c` source file in nrfxlib.
+
+.. _lib_zigbee_error_handler_options:
+
+Configuration
+*************
+
+To use this library, include its header in your application and pass the error code that should be checked using its macros.
+
+Additionally, if you want the error code to be printed to log, enable the :option:`CONFIG_LOG` and :option:`CONFIG_ZBOSS_ERROR_PRINT_TO_LOG` Kconfig options.
+The :option:`CONFIG_ZBOSS_ERROR_PRINT_TO_LOG` option automatically enables the :option:`CONFIG_ZIGBEE_ERROR_TO_STRING_ENABLED` Kconfig option, which obtains the ZBOSS error code name.
+
+The library also provides a macro for checking the value returned by the :c:func:`bdb_start_top_level_commissioning` function.
+
+API documentation
+*****************
+
+| Header file: :file:`include/zigbee/zigbee_error_handler.h`
+| Source file: :file:`../nrfxlib/zboss/src/zb_error/zb_error_to_string.c`
+
+.. doxygengroup:: zb_error
+   :project: nrf
+   :members:


### PR DESCRIPTION
Added documentation page for Zigbee error handler lib.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>