### PR TITLE
applications: asset_tracker_v2: Fix memory leak in `json_helpers`

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/json_helpers.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/json_helpers.c
@@ -16,12 +16,18 @@ LOG_MODULE_REGISTER(json_helpers, CONFIG_CLOUD_CODEC_LOG_LEVEL);
 
 void json_add_obj(cJSON *parent, const char *str, cJSON *item)
 {
-	cJSON_AddItemToObject(parent, str, item);
+	if (!cJSON_AddItemToObject(parent, str, item)) {
+		LOG_ERR("Failed adding object");
+		cJSON_Delete(item);
+	}
 }
 
 void json_add_obj_array(cJSON *parent, cJSON *item)
 {
-	cJSON_AddItemToArray(parent, item);
+	if (!cJSON_AddItemToArray(parent, item)) {
+		LOG_ERR("Failed adding array item");
+		cJSON_Delete(item);
+	}
 }
 
 int json_add_number(cJSON *parent, const char *str, double item)

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/json_helpers.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/json_helpers.h
@@ -6,8 +6,31 @@
 
 #include "cJSON.h"
 
+/**
+ * @brief Associate a child object with a parent.
+ *
+ * This API is expected to be called after data has been added to the child item. If this API
+ * fails to add the child item to the parent it will free the child item. Due to this its not
+ * guaranteed that subsequent accesses to the child item will succeed after this API call.
+ *
+ * @param[inout] parent	Pointer to a parent object.
+ * @param[in]	 str	Name of the added child object.
+ * @param[in]	 item	Pointer to child object.
+ *
+ */
 void json_add_obj(cJSON *parent, const char *str, cJSON *item);
 
+/**
+ * @brief Add item to array object
+ *
+ * This API is expected to be called after data has been added to the child item. If this API
+ * fails to add the child item to the parent it will free the child item. Due to this its not
+ * guaranteed that subsequent accesses to the child item will succeed after this API call.
+ *
+ * @param[inout] parent	Pointer to a parent array object.
+ * @param[in]    item	Pointer to item to be added.
+ *
+ */
 void json_add_obj_array(cJSON *parent, cJSON *item);
 
 int json_add_number(cJSON *parent, const char *str, double item);


### PR DESCRIPTION
Due to an API change in CJSON, `cJSON_AddItem...` functions now returns
a boolean value depending on if the child item was added to the parent.

If these API fails, the child item is now freed in `json_helpers`.