### PR TITLE
subsys: adding event manager storage layer

### DIFF
--- a/include/event_manager.h
+++ b/include/event_manager.h
@@ -65,6 +65,11 @@ struct event_header {
 
 	/** Pointer to the event type object. */
 	const struct event_type *type_id;
+
+#if defined(CONFIG_EVENT_MANAGER_STORAGE)
+	/** Entry id used in one of the storage backend */
+	size_t entry_id;
+#endif
 };
 
 
@@ -144,6 +149,11 @@ struct event_type {
 
 	/** Logging and formatting information. */
 	const struct event_info *ev_info;
+
+#if defined(CONFIG_EVENT_MANAGER_STORAGE)
+	/** Size of the static payload used by the event */
+	const size_t event_size;
+#endif
 };
 
 
@@ -286,8 +296,13 @@ void _event_submit(struct event_header *eh);
  *
  * @param event  Pointer to the event object.
  */
+#if defined(CONFIG_EVENT_MANAGER_STORAGE)
+#include "event_manager_storage_priv.h"
+#define EVENT_SUBMIT(event)		event_store_add(&event->header); \
+					_event_submit(&event->header)
+#else
 #define EVENT_SUBMIT(event) _event_submit(&event->header)
-
+#endif
 
 /** Initialize the Event Manager.
  *

--- a/include/event_manager.h
+++ b/include/event_manager.h
@@ -298,11 +298,11 @@ void _event_submit(struct event_header *eh);
  */
 #if defined(CONFIG_EVENT_MANAGER_STORAGE)
 #include "event_manager_storage_priv.h"
-#define EVENT_SUBMIT(event)		event_store_add(&event->header); \
+#define EVENT_SUBMIT_IMPORTANT(event)	event_store_add(&event->header); \
 					_event_submit(&event->header)
-#else
-#define EVENT_SUBMIT(event) _event_submit(&event->header)
 #endif
+
+#define EVENT_SUBMIT(event) _event_submit(&event->header)
 
 /** Initialize the Event Manager.
  *
@@ -310,6 +310,11 @@ void _event_submit(struct event_header *eh);
  */
 int event_manager_init(void);
 
+/** Clears the underlying storage layer if configured
+ *
+ * @retval 0 If the operation was successful.
+ */
+int event_manager_clear_storage(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/event_manager/CMakeLists.txt
+++ b/subsys/event_manager/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2018 Nordic Semiconductor
+# Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -7,5 +8,12 @@
 zephyr_include_directories(.)
 zephyr_sources(event_manager.c)
 zephyr_sources_ifdef(CONFIG_SHELL event_manager_shell.c)
+zephyr_sources_ifdef(CONFIG_EVENT_MANAGER_STORAGE event_manager_storage.c)
+
+if (CONFIG_EVENT_MANAGER_STORAGE)
+    ncs_add_partition_manager_config(pm.events.yml)
+    zephyr_sources_ifdef(CONFIG_EVENT_MANAGER_STORAGE_BACKEND_NVS event_manager_storage_nvs.c)
+    zephyr_sources_ifdef(CONFIG_EVENT_MANAGER_STORAGE_BACKEND_LITTLEFS event_manager_storage_littlefs.c)
+endif ()
 
 zephyr_linker_sources(SECTIONS em.ld)

--- a/subsys/event_manager/Kconfig
+++ b/subsys/event_manager/Kconfig
@@ -61,4 +61,35 @@ config EVENT_MANAGER_PROFILE_EVENT_DATA
 
 endif # EVENT_MANAGER_PROFILER_ENABLED
 
+config EVENT_MANAGER_STORAGE
+	bool "Store event in non-volatile memory"
+	default n
+
+if EVENT_MANAGER_STORAGE
+
+partition=EVENTS_STORAGE
+partition-size=0x10000
+source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_size"
+
+choice EVENT_MANAGER_STORAGE_BACKEND
+	bool "Event storage backend"
+	default EVENT_MANAGER_STORAGE_BACKEND_LITTLEFS if FILE_SYSTEM_LITTLEFS
+	default EVENT_MANAGER_STORAGE_BACKEND_NVS if NVS
+
+config EVENT_MANAGER_STORAGE_BACKEND_LITTLEFS
+	bool "Littlefs backend"
+	depends on FILE_SYSTEM_LITTLEFS
+
+config EVENT_MANAGER_STORAGE_BACKEND_NVS
+	bool "NVS backend"
+	depends on NVS
+
+endchoice # EVENT_MANAGER_STORAGE_BACKEND
+
+endif # EVENT_MANAGER_STORAGE
+
+config EVENT_MANAGER_STORAGE_PAYLOAD_MAX_SIZE
+	int "Maximum size of event payload"
+	default 64
+
 endif # EVENT_MANAGER

--- a/subsys/event_manager/event_manager.c
+++ b/subsys/event_manager/event_manager.c
@@ -332,3 +332,17 @@ int event_manager_init(void)
 
 	return 0;
 }
+
+int event_manager_clear_storage(void)
+{
+#if defined(CONFIG_EVENT_MANAGER_STORAGE)
+	int err;
+
+	err = event_store_clear();
+	if (err) {
+		return err;
+	}
+#endif
+
+	return 0;
+}

--- a/subsys/event_manager/event_manager_priv.h
+++ b/subsys/event_manager/event_manager_priv.h
@@ -223,6 +223,8 @@ extern "C" {
 
 #define _EVENT_TYPE_DEFINE(ename, init_log_en, log_fn, ev_info_struct)							\
 	_EVENT_SUBSCRIBERS_DEFINE(ename);										\
+	BUILD_ASSERT(!(IS_ENABLED(CONFIG_EVENT_MANAGER_STORAGE) &&							\
+		sizeof(struct ename) > CONFIG_EVENT_MANAGER_STORAGE_PAYLOAD_MAX_SIZE));					\
 	const struct event_type _CONCAT(__event_type_, ename) __used							\
 	__attribute__((__section__("event_types"))) = {									\
 		.name				= STRINGIFY(ename),							\
@@ -239,8 +241,10 @@ extern "C" {
 		.init_log_enable		= init_log_en,								\
 		.log_event			= log_fn,								\
 		.ev_info			= ev_info_struct,							\
+		COND_CODE_1(IS_ENABLED(CONFIG_EVENT_MANAGER_STORAGE),							\
+			(.event_size = sizeof(struct ename)),								\
+			())												\
 	}
-
 
 #ifdef __cplusplus
 }

--- a/subsys/event_manager/event_manager_priv.h
+++ b/subsys/event_manager/event_manager_priv.h
@@ -100,6 +100,9 @@ extern "C" {
 			return NULL;					\
 		}							\
 		event->header.type_id = _EVENT_ID(ename);		\
+		COND_CODE_1(IS_ENABLED(CONFIG_EVENT_MANAGER_STORAGE),	\
+			(event->header.entry_id = 0;),			\
+			())						\
 		return event;						\
 	}
 

--- a/subsys/event_manager/event_manager_storage.c
+++ b/subsys/event_manager/event_manager_storage.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "event_manager_storage_priv.h"
+
+static struct event_storage_api *storage_api;
+
+int event_store_add(struct event_header *eh)
+{
+	return storage_api->write(eh);
+}
+
+int event_store_remove(struct event_header *eh)
+{
+	return storage_api->remove(eh);
+}
+
+static int event_store_play_all(void)
+{
+	int err;
+	bool first = true;
+
+	while (1) {
+		struct event_header *header;
+		err = storage_api->read(&header, first);
+		if (err == -ENOMEM) {
+			return -ENOMEM;
+		} else if (err < 0) {
+			/* No more data */
+			return 0;
+		}
+
+		first = false;
+		_event_submit(header);
+	}
+}
+
+int event_store_init(void)
+{
+	int err;
+
+	storage_api = event_store_backend_get_api();
+
+	err = storage_api->init();
+	if (err) {
+		return err;
+	}
+
+	return event_store_play_all();
+}

--- a/subsys/event_manager/event_manager_storage.c
+++ b/subsys/event_manager/event_manager_storage.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <event_manager.h>
 #include "event_manager_storage_priv.h"
 
 static struct event_storage_api *storage_api;
@@ -25,6 +26,7 @@ static int event_store_play_all(void)
 
 	while (1) {
 		struct event_header *header;
+
 		err = storage_api->read(&header, first);
 		if (err == -ENOMEM) {
 			return -ENOMEM;
@@ -50,4 +52,9 @@ int event_store_init(void)
 	}
 
 	return event_store_play_all();
+}
+
+int event_store_clear(void)
+{
+	return storage_api->clear();
 }

--- a/subsys/event_manager/event_manager_storage_littlefs.c
+++ b/subsys/event_manager/event_manager_storage_littlefs.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "event_manager_storage_priv.h"
+
+int event_storage_littlefs_init(void)
+{
+	/* TODO */
+	return -ENOTSUP;
+}
+
+int event_storage_littlefs_write(struct event_header *eh)
+{
+	/* TODO */
+	return -ENOTSUP;
+}
+
+int event_storage_littlefs_read(struct event_header **eh, bool from_start)
+{
+	/* TODO */
+	return -ENOTSUP;
+}
+
+int event_storage_littlefs_remove(struct event_header *eh)
+{
+	/* TODO */
+	return -ENOTSUP;
+}
+
+static struct event_storage_api api = {
+	.init = event_storage_littlefs_init,
+	.write = event_storage_littlefs_write,
+	.read = event_storage_littlefs_read,
+	.remove = event_storage_littlefs_remove
+};
+
+struct event_storage_api *event_store_backend_get_api(void)
+{
+	return &api;
+}

--- a/subsys/event_manager/event_manager_storage_littlefs.c
+++ b/subsys/event_manager/event_manager_storage_littlefs.c
@@ -30,11 +30,18 @@ int event_storage_littlefs_remove(struct event_header *eh)
 	return -ENOTSUP;
 }
 
+int event_storage_littlefs_clear(void)
+{
+	/* TODO */
+	return -ENOTSUP;
+}
+
 static struct event_storage_api api = {
 	.init = event_storage_littlefs_init,
 	.write = event_storage_littlefs_write,
 	.read = event_storage_littlefs_read,
-	.remove = event_storage_littlefs_remove
+	.remove = event_storage_littlefs_remove,
+	.clear = event_storage_littlefs_clear
 };
 
 struct event_storage_api *event_store_backend_get_api(void)

--- a/subsys/event_manager/event_manager_storage_nvs.c
+++ b/subsys/event_manager/event_manager_storage_nvs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "event_manager_storage_priv.h"
+#include <event_manager.h>
 #include <storage/flash_map.h>
 #include <fs/nvs.h>
 #include <logging/log.h>
@@ -139,6 +139,10 @@ int event_storage_nvs_remove(struct event_header *header)
 {
 	int err;
 
+	if (header->entry_id < FIRST_AVAILABLE_INDEX) {
+		return 0;
+	}
+
 	LOG_DBG("Removing event %d from nvs storage", header->entry_id);
 	err = nvs_delete(&event_nvs_cfg.cf_nvs, header->entry_id);
 	if (err < 0) {
@@ -206,11 +210,17 @@ int event_storage_nvs_read(struct event_header **eh, bool from_start)
 	return 0;
 }
 
+static int event_storage_nvs_clear(void)
+{
+	return nvs_clear(&event_nvs_cfg.cf_nvs);
+}
+
 static struct event_storage_api api = {
 	.init = event_storage_nvs_init,
 	.write = event_storage_nvs_write,
 	.read = event_storage_nvs_read,
-	.remove = event_storage_nvs_remove
+	.remove = event_storage_nvs_remove,
+	.clear = event_storage_nvs_clear,
 };
 
 struct event_storage_api *event_store_backend_get_api(void)

--- a/subsys/event_manager/event_manager_storage_nvs.c
+++ b/subsys/event_manager/event_manager_storage_nvs.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "event_manager_storage_priv.h"
+#include <storage/flash_map.h>
+#include <fs/nvs.h>
+#include <logging/log.h>
+LOG_MODULE_DECLARE(event_manager, CONFIG_EVENT_MANAGER_LOG_LEVEL);
+
+static const struct flash_area *events_area;
+
+#define LAST_EVENT_INDEX                                (0)
+#define LAST_EVENT_CONSUMED_INDEX                        (1)
+#define FIRST_AVAILABLE_INDEX                                (2)
+
+struct event_nvs {
+	struct nvs_fs cf_nvs;
+	uint16_t last_saved_event;
+	uint16_t last_consumed_event;
+	uint16_t read_cursor;
+	const char *flash_dev_name;
+};
+
+static struct event_nvs event_nvs_cfg;
+
+struct event_nvs_entry {
+	struct event_type *type;
+	size_t event_size;
+	uint8_t payload[CONFIG_EVENT_MANAGER_STORAGE_PAYLOAD_MAX_SIZE];
+};
+
+static int event_storage_nvs_backend_init(struct event_nvs *nvs)
+{
+	int rc;
+	uint16_t last_saved_event;
+
+	LOG_DBG("Initializing NVS backend");
+
+	rc = nvs_init(&nvs->cf_nvs, nvs->flash_dev_name);
+	if (rc) {
+		return rc;
+	}
+
+	rc = nvs_read(&nvs->cf_nvs, LAST_EVENT_INDEX, &last_saved_event,
+		sizeof(last_saved_event));
+	if (rc < 0) {
+		nvs->last_saved_event = FIRST_AVAILABLE_INDEX;
+	} else {
+		nvs->last_saved_event = last_saved_event;
+	}
+
+	LOG_DBG("Last NVS entry id = %d", nvs->last_saved_event);
+
+	rc = nvs_read(&nvs->cf_nvs, LAST_EVENT_CONSUMED_INDEX,
+		&last_saved_event,
+		sizeof(last_saved_event));
+	if (rc < 0) {
+		nvs->last_consumed_event = FIRST_AVAILABLE_INDEX;
+	} else {
+		nvs->last_consumed_event = last_saved_event;
+	}
+
+	LOG_DBG("Last consumed NVS entry id = %d", nvs->last_consumed_event);
+
+	return 0;
+}
+
+int event_storage_nvs_init(void)
+{
+	uint32_t sector_cnt = 1;
+	struct flash_sector hw_flash_sector;
+	int err;
+
+	err = flash_area_open(FLASH_AREA_ID(events_storage), &events_area);
+	if (err) {
+		return err;
+	}
+
+	err = flash_area_get_sectors(FLASH_AREA_ID(events_storage), &sector_cnt,
+		&hw_flash_sector);
+	if (err == -ENODEV) {
+		return err;
+	} else if (err != 0 && err != -ENOMEM) {
+		k_panic();
+	}
+
+	if (hw_flash_sector.fs_size > UINT16_MAX) {
+		return -EDOM;
+	}
+
+	event_nvs_cfg.cf_nvs.sector_size = hw_flash_sector.fs_size;
+	event_nvs_cfg.cf_nvs.sector_count = 2;
+	event_nvs_cfg.cf_nvs.offset = events_area->fa_off;
+	event_nvs_cfg.flash_dev_name = events_area->fa_dev_name;
+
+	return event_storage_nvs_backend_init(&event_nvs_cfg);
+}
+
+int event_storage_nvs_write(struct event_header *eh)
+{
+	int err;
+	size_t offset = WB_UP(sizeof(struct event_header));
+	struct event_nvs_entry entry = {
+		.type = (struct event_type *) eh->type_id,
+		.event_size = eh->type_id->event_size
+	};
+
+	memcpy(entry.payload, ((char *) eh) + offset,
+		entry.event_size - offset);
+	eh->entry_id = event_nvs_cfg.last_saved_event++;
+
+	LOG_DBG("Writing event %s of size %zd, type = %p,"
+		" payload size = %d, offset: %zd",
+		log_strdup(eh->type_id->name), entry.event_size,
+		entry.type, eh->type_id->event_size - offset, offset);
+
+	err = nvs_write(&event_nvs_cfg.cf_nvs, eh->entry_id,
+		&entry, sizeof(entry));
+	if (err < 0) {
+		LOG_ERR("Could not write event to nvs backend, err %d", err);
+		return err;
+	}
+
+	err = nvs_write(&event_nvs_cfg.cf_nvs, LAST_EVENT_INDEX,
+		&event_nvs_cfg.last_saved_event,
+		sizeof(event_nvs_cfg.last_saved_event));
+	if (err < 0) {
+		LOG_ERR("Could not write event to nvs backend, err %d", err);
+		return err;
+	}
+
+	return 0;
+}
+
+int event_storage_nvs_remove(struct event_header *header)
+{
+	int err;
+
+	LOG_DBG("Removing event %d from nvs storage", header->entry_id);
+	err = nvs_delete(&event_nvs_cfg.cf_nvs, header->entry_id);
+	if (err < 0) {
+		LOG_ERR("Could not remove event %d from nvs storage", err);
+		return err;
+	}
+
+	event_nvs_cfg.last_consumed_event = header->entry_id;
+	err = nvs_write(&event_nvs_cfg.cf_nvs, LAST_EVENT_CONSUMED_INDEX,
+		&event_nvs_cfg.last_consumed_event,
+		sizeof(event_nvs_cfg.last_consumed_event));
+	if (err < 0) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+int event_storage_nvs_read(struct event_header **eh, bool from_start)
+{
+	int err;
+	struct event_nvs_entry entry;
+
+	if (from_start || event_nvs_cfg.read_cursor == 0) {
+		event_nvs_cfg.read_cursor =
+			event_nvs_cfg.last_consumed_event + 1;
+	}
+
+	LOG_DBG("Reading event %d from nvs storage", event_nvs_cfg.read_cursor);
+
+	err = nvs_read(&event_nvs_cfg.cf_nvs, event_nvs_cfg.read_cursor,
+		&entry, sizeof(entry));
+	if (err < 0) {
+		LOG_DBG("No more event in nvs storage");
+		return err;
+	}
+
+	LOG_DBG("Allocating %zu bytes for event %d", entry.event_size,
+		event_nvs_cfg.read_cursor);
+	event_nvs_cfg.read_cursor++;
+
+	struct event_header *header =
+		(struct event_header *) k_malloc(entry.event_size);
+	if (!header) {
+		LOG_ERR("Could not allocate memory for event");
+		return -ENOMEM;
+	}
+
+	size_t offset = WB_UP(sizeof(struct event_header));
+
+	LOG_DBG("Event entry saved in NVS: type = %p, size= %zu",
+		entry.type, entry.event_size);
+	LOG_HEXDUMP_DBG(entry.payload, entry.event_size - offset, "Payload");
+	header->type_id = entry.type;
+	header->entry_id = event_nvs_cfg.read_cursor - 1;
+
+	/* We need to compute the address location of the
+	 * first field of the payload
+	 */
+	memcpy(((char *) header) + offset, entry.payload,
+		entry.event_size - offset);
+
+	*eh = header;
+
+	return 0;
+}
+
+static struct event_storage_api api = {
+	.init = event_storage_nvs_init,
+	.write = event_storage_nvs_write,
+	.read = event_storage_nvs_read,
+	.remove = event_storage_nvs_remove
+};
+
+struct event_storage_api *event_store_backend_get_api(void)
+{
+	return &api;
+}

--- a/subsys/event_manager/event_manager_storage_priv.h
+++ b/subsys/event_manager/event_manager_storage_priv.h
@@ -7,8 +7,9 @@
 #ifndef _EVENT_MANAGER_STORAGE_PRIV_H
 #define _EVENT_MANAGER_STORAGE_PRIV_H
 
-#include <event_manager.h>
 #include <device.h>
+
+struct event_header;
 
 typedef int (*event_storage_init_t)(void);
 
@@ -18,11 +19,14 @@ typedef int (*event_storage_read_t)(struct event_header **eh, bool from_start);
 
 typedef int (*event_storage_remove_t)(struct event_header *eh);
 
+typedef int (*event_storage_clear_t)(void);
+
 struct event_storage_api {
 	event_storage_init_t init;
 	event_storage_write_t write;
 	event_storage_read_t read;
 	event_storage_remove_t remove;
+	event_storage_clear_t clear;
 };
 
 int event_store_add(struct event_header *eh);
@@ -30,6 +34,8 @@ int event_store_add(struct event_header *eh);
 int event_store_remove(struct event_header *eh);
 
 int event_store_init(void);
+
+int event_store_clear(void);
 
 struct event_storage_api *event_store_backend_get_api(void);
 

--- a/subsys/event_manager/event_manager_storage_priv.h
+++ b/subsys/event_manager/event_manager_storage_priv.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _EVENT_MANAGER_STORAGE_PRIV_H
+#define _EVENT_MANAGER_STORAGE_PRIV_H
+
+#include <event_manager.h>
+#include <device.h>
+
+typedef int (*event_storage_init_t)(void);
+
+typedef int (*event_storage_write_t)(struct event_header *eh);
+
+typedef int (*event_storage_read_t)(struct event_header **eh, bool from_start);
+
+typedef int (*event_storage_remove_t)(struct event_header *eh);
+
+struct event_storage_api {
+	event_storage_init_t init;
+	event_storage_write_t write;
+	event_storage_read_t read;
+	event_storage_remove_t remove;
+};
+
+int event_store_add(struct event_header *eh);
+
+int event_store_remove(struct event_header *eh);
+
+int event_store_init(void);
+
+struct event_storage_api *event_store_backend_get_api(void);
+
+#endif /* _EVENT_MANAGER_STORAGE_PRIV_H */

--- a/subsys/event_manager/pm.events.yml
+++ b/subsys/event_manager/pm.events.yml
@@ -1,0 +1,5 @@
+#include <autoconf.h>
+
+events_storage:
+  placement: {before: [end]}
+  size: CONFIG_PM_PARTITION_SIZE_EVENTS_STORAGE


### PR DESCRIPTION
Depending on the application, it can be useful to store transient
event into a specified storage technology to be able to replay
events that were not consumed by the application.

This may happen if the board ran out of battery or if the application
crashed during the processing of the event (or any other reason).

This commit adds a new storage layer to the event manager, similar
to the storage layer of the Zephyr settings API.
For now, only NVS is supported, but littlefs is planned. The
configuration file + a basic source file are already added to
that commit.

Each time an event is submitted, it is first sent to the storage
layer. This layer will give a unique id to the event and will
store the event. Once the storage of the event is done (and
regardless of the result of that operation), the event is truly
sent to the manager which will then call all the subscribers.

Each time an event is consumed, the storage layer removes it from
the storage.

When the board boots (or when event_manager_init() is called to be
more precise), the event storage layer is initialized.
Once that initialization is done, it will load each non-consumed event
present in the storage.
Each of these events will then be automatically re-submitted to the
application.
If the event is properly consumed, it will be removed from the storage.

Know issues:
-----------------------------
- Dynamic sized event are not supported yet

Roadmap:
-----------------------------
- [ ] Documentation
- [ ] Adding more storage option
- [ ] Supporting dynamically sized events
- [x] To prevent reading/writing too frequently we may add a flag in the
event header that will tell the storage layer to ignore an event.
For example a "button_pressed_event" can be forgotten without much
risk. However, "machine_about_to_blow_event" must be stored and
replayed if need be.

Signed-off-by: Giuliano Franchetto <giuliano.franchetto@intellinium.com>