### PR TITLE
samples: nrf9160: gps: introduce GPS_SAMPLE_AT_{MAGPIO,COEX0} options

### DIFF
--- a/samples/nrf9160/gps/Kconfig
+++ b/samples/nrf9160/gps/Kconfig
@@ -23,6 +23,22 @@ config GPS_SAMPLE_ANTENNA_EXTERNAL
 
 endchoice
 
+config GPS_SAMPLE_AT_MAGPIO
+	string "AT%XMAGPIO command"
+	default "AT\%XMAGPIO=1,0,0,1,1,1574,1577" if BOARD_NRF9160DK_NRF9160NS
+	default "AT\%XMAGPIO=1,1,1,7,1,746,803,2,698,748,2,1710,2200,3,824,894,4,880,960,5,791,849,7,1565,1586" if BOARD_THINGY91_NRF9160NS
+	help
+	  Defines what is the AT%XMAGPIO command to be sent to GPS module. Leave
+	  empty if this command should not be sent.
+
+config GPS_SAMPLE_AT_COEX0
+	string "AT%XCOEX0 command"
+	default "AT\%XCOEX0=1,1,1565,1586" if (BOARD_NRF9160DK_NRF9160NS || BOARD_THINGY91_NRF9160NS) && GPS_SAMPLE_ANTENNA_ONBOARD
+	default "AT\%XCOEX0" if (BOARD_NRF9160DK_NRF9160NS || BOARD_THINGY91_NRF9160NS) && GPS_SAMPLE_ANTENNA_EXTERNAL
+	help
+	  Defines what is the AT%XCOEX0 command to be sent to GPS module. Leave
+	  empty if this command should not be sent.
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/samples/nrf9160/gps/src/main.c
+++ b/samples/nrf9160/gps/src/main.c
@@ -21,35 +21,13 @@
 
 #define AT_CMD_SIZE(x) (sizeof(x) - 1)
 
-#ifdef CONFIG_BOARD_NRF9160DK_NRF9160NS
-#define AT_MAGPIO      "AT\%XMAGPIO=1,0,0,1,1,1574,1577"
-#ifdef CONFIG_GPS_SAMPLE_ANTENNA_ONBOARD
-#define AT_COEX0       "AT\%XCOEX0=1,1,1565,1586"
-#elif CONFIG_GPS_SAMPLE_ANTENNA_EXTERNAL
-#define AT_COEX0       "AT\%XCOEX0"
-#endif
-#endif /* CONFIG_BOARD_NRF9160DK_NRF9160NS */
-
-#ifdef CONFIG_BOARD_THINGY91_NRF9160NS
-#define AT_MAGPIO      "AT\%XMAGPIO=1,1,1,7,1,746,803,2,698,748,2,1710,2200," \
-			"3,824,894,4,880,960,5,791,849,7,1565,1586"
-#ifdef CONFIG_GPS_SAMPLE_ANTENNA_ONBOARD
-#define AT_COEX0       "AT\%XCOEX0=1,1,1565,1586"
-#elif CONFIG_GPS_SAMPLE_ANTENNA_EXTERNAL
-#define AT_COEX0       "AT\%XCOEX0"
-#endif
-#endif /* CONFIG_BOARD_THINGY91_NRF9160NS */
-
 static const char update_indicator[] = {'\\', '|', '/', '-'};
 static const char *const at_commands[] = {
 #if !defined(CONFIG_SUPL_CLIENT_LIB)
 	AT_XSYSTEMMODE,
 #endif
-#if defined(CONFIG_BOARD_NRF9160DK_NRF9160NS) || \
-	defined(CONFIG_BOARD_THINGY91_NRF9160NS)
-	AT_MAGPIO,
-	AT_COEX0,
-#endif
+	CONFIG_GPS_SAMPLE_AT_MAGPIO,
+	CONFIG_GPS_SAMPLE_AT_COEX0,
 	AT_ACTIVATE_GPS
 };
 
@@ -88,6 +66,9 @@ void nrf_modem_recoverable_error_handler(uint32_t error)
 static int setup_modem(void)
 {
 	for (int i = 0; i < ARRAY_SIZE(at_commands); i++) {
+		if (at_commands[i][0] == '\0') {
+			continue;
+		}
 
 		if (at_cmd_write(at_commands[i], NULL, 0, NULL) != 0) {
 			return -1;


### PR DESCRIPTION
Those Kconfig options define if and what AT commands should be sent
during GPS modem setup. Those are usually hardware specific, so assign
default values for nrf9160dk_nrf9160ns and thingy91_nrf9160ns boards.

For simplicity reasons update setup_modem() to ignore empty AT commands,
as there is no easy way of checking at compile time (by preprocessor) if
AT command is empty or not.

This is subset of changes from #4985.