### PR TITLE
applications: nrf_desktop: provide missing help for Kconfig options

### DIFF
--- a/applications/nrf_desktop/src/events/Kconfig
+++ b/applications/nrf_desktop/src/events/Kconfig
@@ -11,72 +11,104 @@ menu "Event options"
 comment "Initially logged events"
 
 config DESKTOP_INIT_LOG_BATTERY_STATE_EVENT
-	bool "Battery state event"
+	bool "Log battery state events"
 	default y
+	help
+	  Log battery state events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_BATTERY_LEVEL_EVENT
-	bool "Battery level event"
+	bool "Log battery level events"
 	default y
+	help
+	  Log battery level events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_BLE_DISC_COMPLETE_EVENT
-	bool "BLE discovery complete event"
+	bool "Log Bluetooth LE discovery complete events"
 	default y
 
 config DESKTOP_INIT_LOG_BLE_QOS_EVENT
-	bool "BLE QOS event"
+	bool "Log Bluetooth LE QoS events"
 	default y
+	help
+	  Log Bluetooth LE QoS events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_CPU_LOAD_EVENT
-	bool "CPU load event"
+	bool "Log CPU load events"
 	default y
+	help
+	  Log CPU load events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_SELECTOR_EVENT
-	bool "Selector event"
+	bool "Log selector events"
 	default y
+	help
+	  Log selector events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_PASSKEY_EVENT
-	bool "Passkey event"
+	bool "Log passkey events"
 	default y
+	help
+	  Log passkey events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_CONFIG_EVENT
-	bool "Config event"
+	bool "Log config events"
 	default y
+	help
+	  Log config events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_HID_SUBSCRIBER_EVENT
-	bool "HID report subscriber event"
+	bool "Log HID report subscriber events"
 	default y
+	help
+	  Log HID report subscriber events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_HID_SUBSCRIPTION_EVENT
-	bool "HID report subscription event"
+	bool "Log HID report subscription events"
 	default y
+	help
+	  Log HID report subscription events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_HID_REPORT_EVENT
-	bool "HID report event"
+	bool "Log HID report events"
 	default y
+	help
+	  Log HID report events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_HID_REPORT_SENT_EVENT
-	bool "HID report sent event"
+	bool "Log HID report sent events"
 	default y
+	help
+	  Log HID report sent events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_MOTION_EVENT
-	bool "Motion event"
+	bool "Log motion events"
 	default y
+	help
+	  Log motion events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_USB_STATE_EVENT
-	bool "USB state event"
+	bool "Log USB state events"
 	default y
+	help
+	  Log USB state events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_USB_HID_EVENT
-	bool "USB HID event"
+	bool "Log USB HID events"
 	default y
+	help
+	  Log USB HID events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_WHEEL_EVENT
-	bool "Wheel event"
+	bool "Log wheel events"
 	default y
+	help
+	  Log wheel events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_HID_NOTIFICATION_EVENT
-	bool "HID notification event"
+	bool "Log HID notification events"
 	default y
+	help
+	  Log HID notification events in nRF Desktop application.
 
 endmenu
 

--- a/applications/nrf_desktop/src/events/Kconfig
+++ b/applications/nrf_desktop/src/events/Kconfig
@@ -25,6 +25,8 @@ config DESKTOP_INIT_LOG_BATTERY_LEVEL_EVENT
 config DESKTOP_INIT_LOG_BLE_DISC_COMPLETE_EVENT
 	bool "Log Bluetooth LE discovery complete events"
 	default y
+	help
+	  Log Bluetooth LE discovery complete events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_BLE_QOS_EVENT
 	bool "Log Bluetooth LE QoS events"
@@ -34,6 +36,7 @@ config DESKTOP_INIT_LOG_BLE_QOS_EVENT
 
 config DESKTOP_INIT_LOG_CPU_LOAD_EVENT
 	bool "Log CPU load events"
+	depends on DESKTOP_CPU_MEAS_ENABLE
 	default y
 	help
 	  Log CPU load events in nRF Desktop application.
@@ -52,6 +55,7 @@ config DESKTOP_INIT_LOG_PASSKEY_EVENT
 
 config DESKTOP_INIT_LOG_CONFIG_EVENT
 	bool "Log config events"
+	depends on DESKTOP_CONFIG_CHANNEL_ENABLE
 	default y
 	help
 	  Log config events in nRF Desktop application.
@@ -88,12 +92,14 @@ config DESKTOP_INIT_LOG_MOTION_EVENT
 
 config DESKTOP_INIT_LOG_USB_STATE_EVENT
 	bool "Log USB state events"
+	depends on DESKTOP_USB_ENABLE
 	default y
 	help
 	  Log USB state events in nRF Desktop application.
 
 config DESKTOP_INIT_LOG_USB_HID_EVENT
 	bool "Log USB HID events"
+	depends on DESKTOP_USB_ENABLE
 	default y
 	help
 	  Log USB HID events in nRF Desktop application.
@@ -106,6 +112,7 @@ config DESKTOP_INIT_LOG_WHEEL_EVENT
 
 config DESKTOP_INIT_LOG_HID_NOTIFICATION_EVENT
 	bool "Log HID notification events"
+	depends on DESKTOP_HIDS_ENABLE
 	default y
 	help
 	  Log HID notification events in nRF Desktop application.

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.battery_charger
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.battery_charger
@@ -12,9 +12,13 @@ choice
 
 config DESKTOP_BATTERY_CHARGER_NONE
 	bool "No battery charging"
+	help
+	  If selected, battery charging is disabled.
 
 config DESKTOP_BATTERY_CHARGER_DISCRETE
 	bool "Discrete battery charger"
+	help
+	  If selected, battery charging is enabled.
 
 endchoice
 
@@ -31,12 +35,18 @@ choice
 
 config DESKTOP_BATTERY_CHARGER_CSO_PULL_NONE
 	bool "Disable CSO pin pull"
+	help
+	  If selected, CSO pin pull is disabled.
 
 config DESKTOP_BATTERY_CHARGER_CSO_PULL_UP
 	bool "Enable CPO pin pull up"
+	help
+	  If selected, CSO pin is pulled up.
 
 config DESKTOP_BATTERY_CHARGER_CSO_PULL_DOWN
 	bool "Enable CSO pin pull down"
+	help
+	  If selected, CSO pin is pulled down.
 
 endchoice
 

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.battery_meas
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.battery_meas
@@ -12,9 +12,13 @@ choice
 
 config DESKTOP_BATTERY_MEAS_NONE
 	bool "No battery measurement"
+	help
+	  If selected, battery measurement is disabled.
 
 config DESKTOP_BATTERY_MEAS
 	bool "Enable battery measurement circuit"
+	help
+	  If selected, battery measurement is enabled.
 
 endchoice
 
@@ -22,27 +26,33 @@ config DESKTOP_BATTERY_MEAS_MIN_LEVEL
 	int "Minimum battery voltage [mV] that corresponds to 0% level"
 	depends on DESKTOP_BATTERY_MEAS
 	default 3100
+	help
+	  This option specifies battery voltage [mV] that corresponds to 0% battery level.
 
 config DESKTOP_BATTERY_MEAS_MAX_LEVEL
 	int "Maximum battery voltage [mV] that corresponds to 100% level"
 	depends on DESKTOP_BATTERY_MEAS
 	default 4180
+	help
+	  This option specifies battery voltage [mV] that corresponds to 100% battery level.
 
 config DESKTOP_BATTERY_MEAS_HAS_VOLTAGE_DIVIDER
 	bool "Use voltage divider for battery measurement"
 	depends on DESKTOP_BATTERY_MEAS
+	help
+	  Enable if voltage divider is used for battery measurement.
 
 config DESKTOP_BATTERY_MEAS_VOLTAGE_DIVIDER_UPPER
 	int "Upper resistor in battery measurement voltage divider [kOhm]"
 	depends on DESKTOP_BATTERY_MEAS_HAS_VOLTAGE_DIVIDER
 	help
-	  Output voltage is measured on the lower resistor.
+	  Upper resistor value [kOhm]. Output voltage is measured on the lower resistor.
 
 config DESKTOP_BATTERY_MEAS_VOLTAGE_DIVIDER_LOWER
 	int "Lower resistor in battery measurement voltage divider [kOhm]"
 	depends on DESKTOP_BATTERY_MEAS_HAS_VOLTAGE_DIVIDER
 	help
-	  Output voltage is measured on the lower resistor.
+	  Lower resistor value [kOhm]. Output voltage is measured on the lower resistor.
 
 config DESKTOP_VOLTAGE_TO_SOC_DELTA
 	int "Difference between adjacent elements in conversion LUT [mV]"
@@ -57,10 +67,15 @@ config DESKTOP_BATTERY_MEAS_POLL_INTERVAL_MS
 	depends on DESKTOP_BATTERY_MEAS
 	default 10000
 	range 500 120000
+	help
+	  Time interval between the subsequent battery measurements [ms].
 
 config DESKTOP_BATTERY_MEAS_HAS_ENABLE_PIN
 	bool "Use pin for enabling battery measurement"
 	depends on DESKTOP_BATTERY_MEAS
+	help
+	  Enable if dedicated gpio0 pin is used for enabling battery measurement circuit.
+	  Pin number is configurable by CONFIG_DESKTOP_BATTERY_MEAS_ENABLE_PIN
 
 config DESKTOP_BATTERY_MEAS_ENABLE_PIN
 	int "Battery monitoring enable pin"

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.buttons_sim
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.buttons_sim
@@ -9,6 +9,9 @@ menu "Buttons simulation configuration"
 config DESKTOP_BUTTONS_SIM_ENABLE
 	bool "Enable simulated button presses generator"
 	depends on CAF_BUTTON_EVENTS
+	help
+	  This option enables simulated button presses in nRF Desktop application.
+	  Could be used for debugging purposes.
 
 if DESKTOP_BUTTONS_SIM_ENABLE
 
@@ -16,6 +19,8 @@ config DESKTOP_BUTTONS_SIM_INTERVAL
 	int "Interval between subsequent simulated button presses [ms]"
 	default 1000
 	range 1 60000
+	help
+	  Time interval between the subsequent simulated button presses [ms].
 
 config DESKTOP_BUTTONS_SIM_LOOP_FOREVER
 	bool "Generate buttons in infinite loop"
@@ -27,6 +32,9 @@ config DESKTOP_BUTTONS_SIM_LOOP_FOREVER
 config DESKTOP_BUTTONS_SIM_TRIGGER_KEY_ID
 	hex "Button used to start/stop generating button presses"
 	default 0x0000
+	help
+	  This option defines KEY ID of the button used to start/stop generation of simulated
+	  button presses in the nRF Desktop application.
 
 module = DESKTOP_BUTTONS_SIM
 module-str = buttons sim module

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.motion
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.motion
@@ -12,23 +12,33 @@ choice
 
 config DESKTOP_MOTION_NONE
 	bool "Disable motion"
+	help
+	  If selected, no motion source if defined for the interface.
 
 config DESKTOP_MOTION_SENSOR_PMW3360_ENABLE
 	bool "Motion from optical sensor PMW3360"
 	select DESKTOP_MOTION_SENSOR_ENABLE
 	depends on PMW3360
+	help
+	  If selected, movement data it obtained from PMW3360 optical sensor.
 
 config DESKTOP_MOTION_SENSOR_PAW3212_ENABLE
 	bool "Motion from optical sensor PAW3212"
 	select DESKTOP_MOTION_SENSOR_ENABLE
 	depends on PAW3212
+	help
+	  If selected, movement data it obtained from PAW3212 optical sensor.
 
 config DESKTOP_MOTION_BUTTONS_ENABLE
 	bool "Motion from buttons"
 	depends on CAF_BUTTON_EVENTS
+	help
+	  If selected, movement data it obtained from buttons.
 
 config DESKTOP_MOTION_SIMULATED_ENABLE
 	bool "Simulated motion"
+	help
+	  If selected, movement data is simulated.
 
 endchoice
 
@@ -75,6 +85,7 @@ config DESKTOP_MOTION_SIMULATED_EDGE_TIME
 	range 8 1000000
 	default 16
 	help
+	  The simulated movement data will be tracing predefined path, an eight-sided polygon.
 	  Must be power of two (calculations speedup).
 
 config DESKTOP_MOTION_SIMULATED_SCALE_FACTOR
@@ -82,6 +93,9 @@ config DESKTOP_MOTION_SIMULATED_SCALE_FACTOR
 	depends on DESKTOP_MOTION_SIMULATED_ENABLE
 	range 1 5
 	default 2
+	help
+	  The simulated movement data will be tracing predefined path, an eight-sided polygon.
+	  This option defines scale factor for tracked polygon size.
 
 config DESKTOP_MOTION_SENSOR_THREAD_STACK_SIZE
 	int "Motion module thread stack size"

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.passkey
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.passkey
@@ -12,10 +12,15 @@ choice
 
 config DESKTOP_PASSKEY_NONE
 	bool "Disable passkey"
+	help
+	  If selected, passkey is disabled.
 
 config DESKTOP_PASSKEY_BUTTONS
 	bool "Passkey based on button presses"
 	depends on CAF_BUTTON_EVENTS
+	help
+	  If selected, the passkey module is used to handle numeric passkey input.
+	  The input handling is based on button presses.
 
 endchoice
 
@@ -24,6 +29,8 @@ config DESKTOP_PASSKEY_MAX_LEN
 	range 0 9
 	default 0
 	depends on !DESKTOP_PASSKEY_NONE
+	help
+	  Maximum number of digits in a passkey.
 
 if !DESKTOP_PASSKEY_NONE
 

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.selector
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.selector
@@ -9,6 +9,9 @@ menu "Selector configuration"
 config DESKTOP_SELECTOR_HW_ENABLE
 	depends on CAF
 	bool "Enable HW based selector"
+	help
+	  This option enables hardware based selector for nRF Desktop application.
+	  If selector state changes, selector_event is send.
 
 if DESKTOP_SELECTOR_HW_ENABLE
 

--- a/applications/nrf_desktop/src/hw_interface/Kconfig.wheel
+++ b/applications/nrf_desktop/src/hw_interface/Kconfig.wheel
@@ -10,6 +10,10 @@ menu "Wheel configuration"
 config DESKTOP_WHEEL_ENABLE
 	bool "Enable wheel hardware interface"
 	depends on QDEC_NRFX
+	help
+	  This option enables wheel hardware interface for nRF Desktop application.
+	  Wheel hardware interface is responsible for generating events related to rotation of the
+	  mouse wheel.
 
 config DESKTOP_WHEEL_SENSOR_VALUE_DIVIDER
 	int "Wheel sensor value divider"

--- a/applications/nrf_desktop/src/modules/Kconfig.config_channel
+++ b/applications/nrf_desktop/src/modules/Kconfig.config_channel
@@ -34,6 +34,8 @@ config DESKTOP_CONFIG_CHANNEL_TIMEOUT
 	int "Transaction timeout on configuration channel in seconds"
 	depends on DESKTOP_CONFIG_CHANNEL_ENABLE
 	default 10
+	help
+	  Timeout in [s] after which config channel transaction is dropped.
 
 if DESKTOP_CONFIG_CHANNEL_ENABLE
 

--- a/applications/nrf_desktop/src/modules/Kconfig.config_channel
+++ b/applications/nrf_desktop/src/modules/Kconfig.config_channel
@@ -35,7 +35,7 @@ config DESKTOP_CONFIG_CHANNEL_TIMEOUT
 	depends on DESKTOP_CONFIG_CHANNEL_ENABLE
 	default 10
 	help
-	  Timeout in [s] after which config channel transaction is dropped.
+	  Timeout [s] after which config channel transaction is dropped.
 
 if DESKTOP_CONFIG_CHANNEL_ENABLE
 

--- a/applications/nrf_desktop/src/modules/Kconfig.hid_state
+++ b/applications/nrf_desktop/src/modules/Kconfig.hid_state
@@ -25,6 +25,8 @@ config DESKTOP_HID_EVENT_QUEUE_SIZE
 	int "HID event queue size"
 	default 12
 	range 2 255
+	help
+	  Size of the HID event queue.
 
 module = DESKTOP_HID_STATE
 module-str = HID state

--- a/applications/nrf_desktop/src/modules/Kconfig.led_stream
+++ b/applications/nrf_desktop/src/modules/Kconfig.led_stream
@@ -17,6 +17,8 @@ config DESKTOP_LED_STREAM_QUEUE_SIZE
 	depends on DESKTOP_LED_STREAM_ENABLE
 	default 15
 	range 2 254
+	help
+	  Size of the LED stream event queue.
 
 if DESKTOP_LED_STREAM_ENABLE
 

--- a/applications/nrf_desktop/src/modules/Kconfig.profiler_sync
+++ b/applications/nrf_desktop/src/modules/Kconfig.profiler_sync
@@ -30,9 +30,13 @@ choice
 
 config DESKTOP_PROFILER_SYNC_CENTRAL
 	bool "Central"
+	help
+	  This is the default option, the device is central.
 
 config DESKTOP_PROFILER_SYNC_PERIPHERAL
 	bool "Peripheral"
+	help
+	  If selected, the device is peripheral.
 
 endchoice
 
@@ -40,11 +44,17 @@ config DESKTOP_PROFILER_SYNC_GPIO_PORT
 	int "Sync GPIO port"
 	range 0 1
 	default 0
+	help
+	  This option defines which gpio port is to be used to synchronize
+	  timestamps between two different devices.
 
 config DESKTOP_PROFILER_SYNC_GPIO_PIN
 	int "Sync GPIO pin"
 	range 0 31
 	default 0
+	help
+	  This option defines which gpio pin is to be used to synchronize
+	  timestamps between two different devices.
 
 module = DESKTOP_PROFILER_SYNC
 module-str = profiler_sync

--- a/applications/nrf_desktop/src/modules/Kconfig.profiler_sync
+++ b/applications/nrf_desktop/src/modules/Kconfig.profiler_sync
@@ -45,16 +45,18 @@ config DESKTOP_PROFILER_SYNC_GPIO_PORT
 	range 0 1
 	default 0
 	help
-	  This option defines which gpio port is to be used to synchronize
-	  timestamps between two different devices.
+	  This option defines which gpio port is to be used to generate/receive
+	  synchronization signal. The signal is used to synchronize timestamps
+	  between two different devices.
 
 config DESKTOP_PROFILER_SYNC_GPIO_PIN
 	int "Sync GPIO pin"
 	range 0 31
 	default 0
 	help
-	  This option defines which gpio pin is to be used to synchronize
-	  timestamps between two different devices.
+	  This option defines which gpio pin is to be used to generate/receive
+	  synchronization signal. The signal is used to synchronize timestamps
+	  between two different devices.
 
 module = DESKTOP_PROFILER_SYNC
 module-str = profiler_sync


### PR DESCRIPTION
As suggested in [comment](https://github.com/nrfconnect/sdk-nrf/pull/4951#discussion_r655268181) this PR fills missing help descriptions for Kconfig options in nrf_desktop application.

Jira: NCSDK-10210