### PR TITLE
samples: nrf9160: shutdown when finished

### DIFF
--- a/samples/nrf9160/download/src/main.c
+++ b/samples/nrf9160/download/src/main.c
@@ -174,13 +174,13 @@ static int callback(const struct download_client_evt *event)
 #endif /* CONFIG_SAMPLE_COMPARE_HASH */
 #endif /* CONFIG_SAMPLE_COMPUTE_HASH */
 
+		lte_lc_power_off();
 		printk("Bye\n");
-		downloaded = 0;
 		return 0;
 
 	case DOWNLOAD_CLIENT_EVT_ERROR:
 		printk("Error %d during download\n", event->error);
-		downloaded = 0;
+		lte_lc_power_off();
 		/* Stop download */
 		return -1;
 	}

--- a/samples/nrf9160/https_client/src/main.c
+++ b/samples/nrf9160/https_client/src/main.c
@@ -252,4 +252,6 @@ void main(void)
 clean_up:
 	freeaddrinfo(res);
 	(void)close(fd);
+
+	lte_lc_power_off();
 }

--- a/samples/nrf9160/pdn/src/main.c
+++ b/samples/nrf9160/pdn/src/main.c
@@ -121,5 +121,6 @@ void main(void)
 	printk("PDP Context %d, PDN ID %d\n", 0, pdn_id_get(0));
 	printk("PDP Context %d, PDN ID %d\n", cid, pdn_id_get(cid));
 
+	lte_lc_power_off();
 	printk("Bye\n");
 }


### PR DESCRIPTION
Shutdown the modem library to put the modem in CFUN0.
There might be other samples that "finish", haven't looked too closely; can add more commits.