### PR TITLE
edge_impulse: Fix external library headers dependencies

### DIFF
--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -28,6 +28,10 @@ if(NOT ${EI_URI} MATCHES "^[a-z]+://")
   endif()
 endif()
 
+
+file(GLOB_RECURSE  edge_impulse_all_headers CONFIGURE_DEPENDS "${EDGE_IMPULSE_SOURCE_DIR}/*.h")
+
+
 include(ExternalProject)
 ExternalProject_Add(edge_impulse_project
     URL              ${EI_URI}
@@ -39,6 +43,7 @@ ExternalProject_Add(edge_impulse_project
     STAMP_DIR        ${EDGE_IMPULSE_STAMP_DIR}
     DOWNLOAD_NAME    edge_impulse_src.zip
     BUILD_BYPRODUCTS ${EDGE_IMPULSE_LIBRARY}
+                     ${edge_impulse_all_headers}
     PATCH_COMMAND    ${CMAKE_COMMAND} -E copy
                      ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.ei.template
                      ${EDGE_IMPULSE_SOURCE_DIR}/CMakeLists.txt


### PR DESCRIPTION
This commit adds all the header files from edge_impulse
external project to the product.
This informs the CMake that any of this files can change
if the external project zip file changes.
This way the issue with the ei_wrapper being rebuilt
after second build rerun is solved.