### PR TITLE
doc: simplify paths handling

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -179,43 +179,9 @@ function(add_doc_target name)
 endfunction()
 
 #-------------------------------------------------------------------------------
-# Environment & Paths
-
-# Set various *_BASE variables pointing to the nrf/, zephyr/, etc.,
-# directories. Derive them automatically if they're not set in the environment,
-# by assuming that e.g. nrfxlib can be found at ../../nrfxlib/. Also add them
-# to the environment if they're not there.
-#
+# Paths
 
 get_filename_component(NRF_BASE ${CMAKE_CURRENT_LIST_DIR}../ DIRECTORY)
-set(ENV{NRF_BASE} ${NRF_BASE})
-
-if(NOT DEFINED ENV{MCUBOOT_BASE})
-  get_filename_component(MCUBOOT_BASE ${CMAKE_CURRENT_LIST_DIR}/../../bootloader/mcuboot/ REALPATH)
-  set(ENV{MCUBOOT_BASE} ${MCUBOOT_BASE})
-endif()
-
-if(NOT DEFINED ENV{NRFXLIB_BASE})
-  get_filename_component(NRFXLIB_BASE ${CMAKE_CURRENT_LIST_DIR}/../../nrfxlib/ REALPATH)
-  set(ENV{NRFXLIB_BASE} ${NRFXLIB_BASE})
-endif()
-
-if(NOT DEFINED ENV{NRFX_BASE})
-  get_filename_component(NRFX_BASE ${CMAKE_CURRENT_LIST_DIR}/../../modules/hal/nordic/nrfx/ REALPATH)
-  set(ENV{NRFX_BASE} ${NRFX_BASE})
-endif()
-
-if(NOT DEFINED ENV{TFM_BASE})
-  get_filename_component(TFM_BASE ${CMAKE_CURRENT_LIST_DIR}/../../modules/tee/tfm/trusted-firmware-m/ REALPATH)
-  set(ENV{TFM_BASE} ${TFM_BASE})
-endif()
-
-message(STATUS "ZEPHYR_BASE: ${ZEPHYR_BASE}")
-message(STATUS "NRF_BASE: $ENV{NRF_BASE}")
-message(STATUS "MCUBOOT_BASE: $ENV{MCUBOOT_BASE}")
-message(STATUS "NRFXLIB_BASE: $ENV{NRFXLIB_BASE}")
-message(STATUS "NRFX_BASE: $ENV{NRFX_BASE}")
-message(STATUS "TFM_BASE: $ENV{TFM_BASE}")
 
 set(NRF_BINARY_DIR ${CMAKE_BINARY_DIR}/nrf)
 set(ZEPHYR_BINARY_DIR ${CMAKE_BINARY_DIR}/zephyr)
@@ -258,7 +224,7 @@ set(tools_version_files
 set(pip_requirements_files
     ${ZEPHYR_BASE}/scripts/requirements-base.txt
     ${ZEPHYR_BASE}/scripts/requirements-doc.txt
-    ${MCUBOOT_BASE}/scripts/requirements.txt
+    ${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/requirements.txt
     ${NRF_BASE}/scripts/requirements-base.txt
     ${NRF_BASE}/scripts/requirements-doc.txt
     ${NRF_BASE}/scripts/requirements-build.txt
@@ -371,9 +337,9 @@ add_custom_target(
         --separate-all-index
         --modules Zephyr,zephyr,${ZEPHYR_BASE}
                   nRF,nrf,${NRF_BASE}
-                  nrfxlib,nrfxlib,${NRFXLIB_BASE}
+                  nrfxlib,nrfxlib,${ZEPHYR_NRFXLIB_MODULE_DIR}
         --no-index-modules BuildDir,${CMAKE_BINARY_DIR}
-                           MCUboot,${MCUBOOT_BASE}
+                           MCUboot,${ZEPHYR_MCUBOOT_MODULE_DIR}
   VERBATIM
 )
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -217,12 +217,8 @@ message(STATUS "NRFXLIB_BASE: $ENV{NRFXLIB_BASE}")
 message(STATUS "NRFX_BASE: $ENV{NRFX_BASE}")
 message(STATUS "TFM_BASE: $ENV{TFM_BASE}")
 
-set(ZEPHYR_BINARY_DIR ${CMAKE_BINARY_DIR}/zephyr)
 set(NRF_BINARY_DIR ${CMAKE_BINARY_DIR}/nrf)
-set(NRFXLIB_BINARY_DIR ${CMAKE_BINARY_DIR}/nrfxlib)
-set(NRFX_BINARY_DIR ${CMAKE_BINARY_DIR}/nrfx)
-set(TFM_BINARY_DIR ${CMAKE_BINARY_DIR}/tfm)
-set(MCUBOOT_BINARY_DIR ${CMAKE_BINARY_DIR}/mcuboot)
+set(ZEPHYR_BINARY_DIR ${CMAKE_BINARY_DIR}/zephyr)
 
 # HTML output directory
 set(HTML_DIR ${CMAKE_BINARY_DIR}/html)
@@ -246,8 +242,6 @@ add_custom_target(
 )
 
 set(zephyr_env
-  ZEPHYR_BASE=${ZEPHYR_BASE}
-  ZEPHYR_BUILD=${ZEPHYR_BINARY_DIR}
   DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
 )
 
@@ -294,9 +288,6 @@ add_custom_command(
 )
 
 set(nrf_env
-  ZEPHYR_BASE=${ZEPHYR_BASE}
-  NRF_BASE=${NRF_BASE}
-  NRF_BUILD=${NRF_BINARY_DIR}
   DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
 )
 
@@ -313,21 +304,13 @@ add_dependencies(nrf-html-all nrf-versions)
 #-------------------------------------------------------------------------------
 # docset: mcuboot
 
-set(mcuboot_env
-  NRF_BASE=${NRF_BASE}
-  MCUBOOT_BUILD=${MCUBOOT_BINARY_DIR}
-  MCUBOOT_BASE=${MCUBOOT_BASE}
-)
-
-add_docset(mcuboot "${mcuboot_env}")
+add_docset(mcuboot "")
 
 #-------------------------------------------------------------------------------
 # docset: nrfx
 
 set(nrfx_env
-  NRF_BASE=${NRF_BASE}
-  NRFX_BASE=${NRFX_BASE}
-  NRFX_BUILD=${NRFX_BINARY_DIR}
+  DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
 )
 
 add_docset(nrfx "${nrfx_env}")
@@ -335,22 +318,12 @@ add_docset(nrfx "${nrfx_env}")
 #-------------------------------------------------------------------------------
 # docset: tfm
 
-set(tfm_env
-  NRF_BASE=${NRF_BASE}
-  ZEPHYR_BASE=${ZEPHYR_BASE}
-  TFM_BASE=${TFM_BASE}
-  TFM_BUILD=${TFM_BINARY_DIR}
-)
-
-add_docset(tfm "${tfm_env}" DODGY)
+add_docset(tfm "" DODGY)
 
 #-------------------------------------------------------------------------------
 # docset: nrfxlib
 
 set(nrfxlib_env
-  NRF_BASE=${NRF_BASE}
-  NRFXLIB_BASE=${NRFXLIB_BASE}
-  NRFXLIB_BUILD=${NRFXLIB_BINARY_DIR}
   DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
 )
 
@@ -420,10 +393,7 @@ add_custom_target(
   VERBATIM
 )
 
-set(kconfig_env
-  KCONFIG_BUILD=${KCONFIG_BINARY_DIR}
-)
-add_docset(kconfig "${kconfig_env}")
+add_docset(kconfig "")
 add_dependencies(kconfig-html kconfig-content)
 add_dependencies(kconfig-html-all kconfig-content)
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -55,7 +55,6 @@ include(${ZEPHYR_BASE}/cmake/zephyr_module.cmake)
 #
 # Args:
 # - name: Docset name.
-# - env: Environment passed to the Sphinx build.
 # - DODGY: Enable/disable "dodgy" mode. If enabled, the ${SPHINXOPTS_EXTRA}
 #   option (used to enable things like -W) will not be passed to Sphinx. It can
 #   be useful for external docsets that are likely to generate build warnings.
@@ -76,7 +75,7 @@ include(${ZEPHYR_BASE}/cmake/zephyr_module.cmake)
 # - ${name}-linkcheck: Run Sphinx "linkcheck" target.
 # - ${name}-clean: Clean build artifacts.
 #
-function(add_docset name env)
+function(add_docset name)
   cmake_parse_arguments(DOCSET "DODGY" "" "" ${ARGN})
 
   set(DOCSET_CFG_DIR ${CMAKE_CURRENT_LIST_DIR}/${name})
@@ -85,6 +84,7 @@ function(add_docset name env)
   set(DOCSET_HTML_DIR ${CMAKE_BINARY_DIR}/html/${name})
   set(DOCSET_MAKE_DIRS ${DOCSET_BUILD_DIR};${DOCSET_SRC_DIR})
   set(DOCSET_CLEAN_DIRS ${DOCSET_BUILD_DIR};${DOCSET_HTML_DIR})
+  set(DOCSET_ENV DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE})
 
   if(NOT ${DOCSET_DODGY})
     set(EXTRA_ARGS ${SPHINXOPTS_EXTRA})
@@ -93,7 +93,7 @@ function(add_docset name env)
   add_doc_target(
     ${name}-inventory
     COMMAND ${CMAKE_COMMAND} -E make_directory ${DOCSET_MAKE_DIRS}
-    COMMAND ${CMAKE_COMMAND} -E env ${env}
+    COMMAND ${CMAKE_COMMAND} -E env ${DOCSET_ENV}
     ${SPHINXBUILD}
       -b inventory
       -c ${DOCSET_CFG_DIR}
@@ -107,7 +107,7 @@ function(add_docset name env)
   add_doc_target(
     ${name}-html
     COMMAND ${CMAKE_COMMAND} -E make_directory ${DOCSET_MAKE_DIRS}
-    COMMAND ${CMAKE_COMMAND} -E env ${env}
+    COMMAND ${CMAKE_COMMAND} -E env ${DOCSET_ENV}
     ${SPHINXBUILD}
       -b html
       -c ${DOCSET_CFG_DIR}
@@ -122,7 +122,7 @@ function(add_docset name env)
   add_custom_target(
     ${name}-linkcheck
     COMMAND ${CMAKE_COMMAND} -E make_directory ${DOCSET_MAKE_DIRS}
-    COMMAND ${CMAKE_COMMAND} -E env ${env}
+    COMMAND ${CMAKE_COMMAND} -E env ${DOCSET_ENV}
     ${SPHINXBUILD}
       -b linkcheck
       -c ${DOCSET_CFG_DIR}
@@ -241,11 +241,7 @@ add_custom_target(
   USES_TERMINAL
 )
 
-set(zephyr_env
-  DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
-)
-
-add_docset(zephyr "${zephyr_env}")
+add_docset(zephyr)
 add_dependencies(zephyr-html zephyr-devicetree)
 add_dependencies(zephyr-html-all zephyr-devicetree)
 
@@ -287,47 +283,35 @@ add_custom_command(
     ${pip_requirements_files}
 )
 
-set(nrf_env
-  DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
-)
-
 add_custom_target(
   nrf-versions
   DEPENDS
     ${NRF_BINARY_DIR}/src/versions.txt
 )
 
-add_docset(nrf "${nrf_env}")
+add_docset(nrf)
 add_dependencies(nrf-html nrf-versions)
 add_dependencies(nrf-html-all nrf-versions)
 
 #-------------------------------------------------------------------------------
 # docset: mcuboot
 
-add_docset(mcuboot "")
+add_docset(mcuboot)
 
 #-------------------------------------------------------------------------------
 # docset: nrfx
 
-set(nrfx_env
-  DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
-)
-
-add_docset(nrfx "${nrfx_env}")
+add_docset(nrfx)
 
 #-------------------------------------------------------------------------------
 # docset: tfm
 
-add_docset(tfm "" DODGY)
+add_docset(tfm DODGY)
 
 #-------------------------------------------------------------------------------
 # docset: nrfxlib
 
-set(nrfxlib_env
-  DOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
-)
-
-add_docset(nrfxlib "${nrfxlib_env}")
+add_docset(nrfxlib)
 
 #-------------------------------------------------------------------------------
 # docset: kconfig
@@ -393,7 +377,7 @@ add_custom_target(
   VERBATIM
 )
 
-add_docset(kconfig "")
+add_docset(kconfig)
 add_dependencies(kconfig-html kconfig-content)
 add_dependencies(kconfig-html-all kconfig-content)
 

--- a/doc/_extensions/options_from_kconfig.py
+++ b/doc/_extensions/options_from_kconfig.py
@@ -46,9 +46,6 @@ class OptionsFromKconfig(SphinxDirective):
         )
 
     def run(self):
-        if 'ZEPHYR_BASE' not in os.environ:
-            raise self.severe("ZEPHYR_BASE is not in the environment")
-
         if len(self.arguments) > 0:
             _, path = self.env.relfn2path(self.arguments[0])
         else:
@@ -57,8 +54,14 @@ class OptionsFromKconfig(SphinxDirective):
             source_dir = os.path.dirname(os.path.abspath(source))
             path = self._get_kconfig_path(source_dir)
 
-        sys.path.append(os.path.join(os.environ['ZEPHYR_BASE'],
-                                     'scripts', 'kconfig'))
+        sys.path.append(
+            os.path.join(
+                self.config.options_from_kconfig_zephyr_dir,
+                'scripts',
+                'kconfig'
+            )
+        )
+        os.environ["ZEPHYR_BASE"] = str(self.config.options_from_kconfig_zephyr_dir)
         import kconfiglib
         self._monkey_patch_kconfiglib(kconfiglib)
 
@@ -112,6 +115,7 @@ class OptionsFromKconfig(SphinxDirective):
 
 def setup(app: Sphinx):
     app.add_config_value("options_from_kconfig_base_dir", None, "env")
+    app.add_config_value("options_from_kconfig_zephyr_dir", None, "env")
 
     directives.register_directive('options-from-kconfig', OptionsFromKconfig)
 

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -1,18 +1,12 @@
 # Kconfig documentation build configuration file
 
-import os
 from pathlib import Path
 import sys
 
 
 # Paths ------------------------------------------------------------------------
 
-NRF_BASE = Path(__file__).absolute().parent / ".." / ".."
-
-KCONFIG_BUILD = os.environ.get("KCONFIG_BUILD")
-if not KCONFIG_BUILD:
-    raise FileNotFoundError("KCONFIG_BUILD not defined")
-KCONFIG_BUILD = Path(KCONFIG_BUILD)
+NRF_BASE = Path(__file__).absolute().parents[2]
 
 sys.path.insert(0, str(NRF_BASE / "doc" / "_utils"))
 import utils
@@ -43,7 +37,7 @@ html_theme_options = {"docsets": utils.get_docsets("kconfig")}
 # Options for ncs_cache --------------------------------------------------------
 
 ncs_cache_docset = "kconfig"
-ncs_cache_build_dir = KCONFIG_BUILD / ".."
+ncs_cache_build_dir = utils.get_builddir()
 ncs_cache_config = NRF_BASE / "doc" / "cache.yml"
 ncs_cache_manifest = NRF_BASE / "west.yml"
 

--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -1,29 +1,17 @@
 # MCUboot documentation build configuration file
 
-import os
 from pathlib import Path
 import sys
 
 
 # Paths ------------------------------------------------------------------------
 
-NRF_BASE = os.environ.get("NRF_BASE")
-if not NRF_BASE:
-    raise FileNotFoundError("NRF_BASE not defined")
-NRF_BASE = Path(NRF_BASE)
-
-MCUBOOT_BASE = os.environ.get("MCUBOOT_BASE")
-if not MCUBOOT_BASE:
-    raise FileNotFoundError("MCUBOOT_BASE not defined")
-MCUBOOT_BASE = Path(MCUBOOT_BASE)
-
-MCUBOOT_BUILD = os.environ.get("MCUBOOT_BUILD")
-if not MCUBOOT_BUILD:
-    raise FileNotFoundError("MCUBOOT_BUILD not defined")
-MCUBOOT_BUILD = Path(MCUBOOT_BUILD)
+NRF_BASE = Path(__file__).absolute().parents[2]
 
 sys.path.insert(0, str(NRF_BASE / "doc" / "_utils"))
 import utils
+
+MCUBOOT_BASE = utils.get_projdir("mcuboot")
 
 # General configuration --------------------------------------------------------
 
@@ -67,7 +55,7 @@ external_content_contents = [
 # Options for ncs_cache --------------------------------------------------------
 
 ncs_cache_docset = "mcuboot"
-ncs_cache_build_dir = MCUBOOT_BUILD / ".."
+ncs_cache_build_dir = utils.get_builddir()
 ncs_cache_config = NRF_BASE / "doc" / "cache.yml"
 ncs_cache_manifest = NRF_BASE / "west.yml"
 

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -171,6 +171,7 @@ table_from_rows_base_dir = NRF_BASE
 # Options for options_from_kconfig ---------------------------------------------
 
 options_from_kconfig_base_dir = NRF_BASE
+options_from_kconfig_zephyr_dir = ZEPHYR_BASE
 
 # Options for ncs_cache --------------------------------------------------------
 

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -7,23 +7,12 @@ import sys
 
 # Paths ------------------------------------------------------------------------
 
-NRF_BASE = os.environ.get("NRF_BASE")
-if not NRF_BASE:
-    raise FileNotFoundError("NRF_BASE not defined")
-NRF_BASE = Path(NRF_BASE)
-
-NRF_BUILD = os.environ.get("NRF_BUILD")
-if not NRF_BUILD:
-    raise FileNotFoundError("NRF_BUILD not defined")
-NRF_BUILD = Path(NRF_BUILD)
-
-ZEPHYR_BASE = os.environ.get("ZEPHYR_BASE")
-if not ZEPHYR_BASE:
-    raise FileNotFoundError("ZEPHYR_BASE not defined")
-ZEPHYR_BASE = Path(ZEPHYR_BASE)
+NRF_BASE = Path(__file__).absolute().parents[2]
 
 sys.path.insert(0, str(NRF_BASE / "doc" / "_utils"))
 import utils
+
+ZEPHYR_BASE = utils.get_projdir("zephyr")
 
 # General configuration --------------------------------------------------------
 
@@ -114,11 +103,11 @@ if nrfx_mapping:
 
 doxyrunner_doxygen = os.environ.get("DOXYGEN_EXECUTABLE", "doxygen")
 doxyrunner_doxyfile = NRF_BASE / "doc" / "nrf" / "nrf.doxyfile.in"
-doxyrunner_outdir = NRF_BUILD / "doxygen"
+doxyrunner_outdir = utils.get_builddir() / "nrf" / "doxygen"
 doxyrunner_fmt = True
 doxyrunner_fmt_vars = {
     "NRF_BASE": str(NRF_BASE),
-    "NRF_BINARY_DIR": str(NRF_BUILD),
+    "NRF_BINARY_DIR": str(utils.get_builddir() / "nrf"),
 }
 
 # Options for breathe ----------------------------------------------------------
@@ -176,7 +165,7 @@ options_from_kconfig_zephyr_dir = ZEPHYR_BASE
 # Options for ncs_cache --------------------------------------------------------
 
 ncs_cache_docset = "nrf"
-ncs_cache_build_dir = NRF_BUILD / ".."
+ncs_cache_build_dir = utils.get_builddir()
 ncs_cache_config = NRF_BASE / "doc" / "cache.yml"
 ncs_cache_manifest = NRF_BASE / "west.yml"
 

--- a/doc/nrfx/conf.py
+++ b/doc/nrfx/conf.py
@@ -8,20 +8,12 @@ from sphinx.config import eval_config_file
 
 # Paths ------------------------------------------------------------------------
 
-NRF_BASE = Path(__file__).absolute().parent / ".." / ".."
-
-NRFX_BASE = os.environ.get("NRFX_BASE")
-if not NRFX_BASE:
-    raise FileNotFoundError("NRFX_BASE not defined")
-NRFX_BASE = Path(NRFX_BASE)
-
-NRFX_BUILD = os.environ.get("NRFX_BUILD")
-if not NRFX_BUILD:
-    raise FileNotFoundError("NRFX_BUILD not defined")
-NRFX_BUILD = Path(NRFX_BUILD)
+NRF_BASE = Path(__file__).absolute().parents[2]
 
 sys.path.insert(0, str(NRF_BASE / "doc" / "_utils"))
 import utils
+
+NRFX_BASE = utils.get_projdir("nrfx") / "nrfx"
 
 # pylint: disable=undefined-variable
 
@@ -43,7 +35,7 @@ html_theme_options = {"docsets": utils.get_docsets("nrfx")}
 
 doxyrunner_doxygen = os.environ.get("DOXYGEN_EXECUTABLE", "doxygen")
 doxyrunner_doxyfile = NRF_BASE / "doc" / "nrfx" / "nrfx.doxyfile.in"
-doxyrunner_outdir = NRFX_BUILD / "doxygen"
+doxyrunner_outdir = utils.get_builddir() / "nrfx" / "doxygen"
 doxyrunner_fmt = True
 doxyrunner_fmt_vars = {
     "NRFX_BASE": str(NRFX_BASE),
@@ -57,7 +49,8 @@ breathe_projects = {"nrfx": str(doxyrunner_outdir / "xml")}
 # Options for external_content -------------------------------------------------
 
 from external_content import DEFAULT_DIRECTIVES
-directives = DEFAULT_DIRECTIVES + ("mdinclude", )
+
+directives = DEFAULT_DIRECTIVES + ("mdinclude",)
 
 external_content_directives = directives
 external_content_contents = [
@@ -67,7 +60,7 @@ external_content_contents = [
 # Options for ncs_cache --------------------------------------------------------
 
 ncs_cache_docset = "nrfx"
-ncs_cache_build_dir = NRFX_BUILD / ".."
+ncs_cache_build_dir = utils.get_builddir()
 ncs_cache_config = NRF_BASE / "doc" / "cache.yml"
 ncs_cache_manifest = NRF_BASE / "west.yml"
 

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -8,23 +8,12 @@ import sys
 
 # Paths ------------------------------------------------------------------------
 
-NRF_BASE = os.environ.get("NRF_BASE")
-if not NRF_BASE:
-    raise FileNotFoundError("NRF_BASE not defined")
-NRF_BASE = Path(NRF_BASE)
-
-NRFXLIB_BASE = os.environ.get("NRFXLIB_BASE")
-if not NRFXLIB_BASE:
-    raise FileNotFoundError("NRFXLIB_BASE not defined")
-NRFXLIB_BASE = Path(NRFXLIB_BASE)
-
-NRFXLIB_BUILD = os.environ.get("NRFXLIB_BUILD")
-if not NRFXLIB_BUILD:
-    raise FileNotFoundError("NRFXLIB_BUILD not defined")
-NRFXLIB_BUILD = Path(NRFXLIB_BUILD)
+NRF_BASE = Path(__file__).absolute().parents[2]
 
 sys.path.insert(0, str(NRF_BASE / "doc" / "_utils"))
 import utils
+
+NRFXLIB_BASE = utils.get_projdir("nrfxlib")
 
 # General configuration --------------------------------------------------------
 
@@ -78,7 +67,7 @@ if nrf_mapping:
 
 doxyrunner_doxygen = os.environ.get("DOXYGEN_EXECUTABLE", "doxygen")
 doxyrunner_doxyfile = NRF_BASE / "doc" / "nrfxlib" / "nrfxlib.doxyfile.in"
-doxyrunner_outdir = NRFXLIB_BUILD / "doxygen"
+doxyrunner_outdir = utils.get_builddir() / "nrfxlib" / "doxygen"
 doxyrunner_fmt = True
 doxyrunner_fmt_vars = {
     "NRFXLIB_BASE": str(NRFXLIB_BASE),
@@ -121,7 +110,7 @@ external_content_contents = [(NRFXLIB_BASE, "**/*.rst"), (NRFXLIB_BASE, "**/doc/
 # Options for ncs_cache --------------------------------------------------------
 
 ncs_cache_docset = "nrfxlib"
-ncs_cache_build_dir = NRFXLIB_BUILD / ".."
+ncs_cache_build_dir = utils.get_builddir()
 ncs_cache_config = NRF_BASE / "doc" / "cache.yml"
 ncs_cache_manifest = NRF_BASE / "west.yml"
 

--- a/doc/tfm/conf.py
+++ b/doc/tfm/conf.py
@@ -1,6 +1,5 @@
 # TFM documentation build configuration file
 
-import os
 from pathlib import Path
 import re
 import sys
@@ -8,23 +7,12 @@ import sys
 
 # Paths ------------------------------------------------------------------------
 
-NRF_BASE = os.environ.get("NRF_BASE")
-if not NRF_BASE:
-    raise FileNotFoundError("NRF_BASE not defined")
-NRF_BASE = Path(NRF_BASE)
-
-TFM_BASE = os.environ.get("TFM_BASE")
-if not TFM_BASE:
-    raise FileNotFoundError("TFM_BASE not defined")
-TFM_BASE = Path(TFM_BASE)
-
-TFM_BUILD = os.environ.get("TFM_BUILD")
-if not TFM_BUILD:
-    raise FileNotFoundError("TFM_BUILD not defined")
-TFM_BUILD = Path(TFM_BUILD)
+NRF_BASE = Path(__file__).absolute().parents[2]
 
 sys.path.insert(0, str(NRF_BASE / "doc" / "_utils"))
 import utils
+
+TFM_BASE = utils.get_projdir("tfm") / "trusted-firmware-m"
 
 # General configuration --------------------------------------------------------
 
@@ -80,7 +68,7 @@ external_content_contents = [
 # Options for ncs_cache --------------------------------------------------------
 
 ncs_cache_docset = "tfm"
-ncs_cache_build_dir = TFM_BUILD / ".."
+ncs_cache_build_dir = utils.get_builddir()
 ncs_cache_config = NRF_BASE / "doc" / "cache.yml"
 ncs_cache_manifest = NRF_BASE / "west.yml"
 

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -1,33 +1,28 @@
 # Zephyr documentation build configuration file
 
+import os
 from pathlib import Path
 import sys
-import os
 from sphinx.config import eval_config_file
 
 
 # Paths ------------------------------------------------------------------------
 
-NRF_BASE = Path(__file__).absolute().parent / ".." / ".."
-
-ZEPHYR_BASE = os.environ.get("ZEPHYR_BASE")
-if not ZEPHYR_BASE:
-    raise FileNotFoundError("ZEPHYR_BASE not defined")
-ZEPHYR_BASE = Path(ZEPHYR_BASE)
-
-ZEPHYR_BUILD = os.environ.get("ZEPHYR_BUILD")
-if not ZEPHYR_BUILD:
-    raise FileNotFoundError("ZEPHYR_BUILD not defined")
-ZEPHYR_BUILD = Path(ZEPHYR_BUILD)
+NRF_BASE = Path(__file__).absolute().parents[2]
 
 sys.path.insert(0, str(NRF_BASE / "doc" / "_utils"))
 import utils
+
+ZEPHYR_BASE = utils.get_projdir("zephyr")
 
 # pylint: disable=undefined-variable,used-before-assignment
 
 # General ----------------------------------------------------------------------
 
 # Import all Zephyr configuration, override as needed later
+os.environ["ZEPHYR_BASE"] = str(ZEPHYR_BASE)
+os.environ["ZEPHYR_BUILD"] = str(utils.get_builddir() / "zephyr")
+
 conf = eval_config_file(str(ZEPHYR_BASE / "doc" / "conf.py"), tags)
 locals().update(conf)
 
@@ -85,7 +80,7 @@ external_content_keep = [
 # Options for ncs_cache --------------------------------------------------------
 
 ncs_cache_docset = "zephyr"
-ncs_cache_build_dir = ZEPHYR_BUILD / ".."
+ncs_cache_build_dir = utils.get_builddir()
 ncs_cache_config = NRF_BASE / "doc" / "cache.yml"
 ncs_cache_manifest = NRF_BASE / "west.yml"
 


### PR DESCRIPTION
```
doc: extensions: options_from_kconfig: do not require env vars

The required paths are now passed via an extension option. The
ZEPHYR_BASE is still set internally by the extension because kconfiglib
requires it.
```
```
doc: utils: add utility to obtain west project directory

Add a new API call to obtain the west project directory for a given
docset.
```
```
doc: simplify path handling

Stop relying on environment variables for paths. Use the recently
introduced get_projdir() API instead. The ultimate goal is to rely less
on CMake to the point it will only be used to invoke Sphinx in the right
order.
```
```
doc: simplify docset environment

Remove the environment argument from add_docset and handle its content
internally.
```
```
doc: simplify module paths handling

The modules path is already available via the ZEPHYR_${NAME}_MODULE_DIR
CMake variables, set by zephyr_module. The environment variables were
not needed.
```