### PR TITLE
doc: Update sphinx nrfxlib config for Mathjax

### DIFF
--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -37,6 +37,7 @@ sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))
 
 extensions = [
     "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
     "breathe",
     "sphinxcontrib.mscgen",
     "inventory_builder",


### PR DESCRIPTION
Adds the ability to use the Mathjax library for latex expressions in the :math: tag in rst files in nrfxlib documentation.

Signed-off-by: Timothy Keys <timothy.keys@nordicsemi.no>