### PR TITLE
Range Requests: Download Client Requesting Extra Byte

### DIFF
--- a/subsys/net/lib/download_client/src/http.c
+++ b/subsys/net/lib/download_client/src/http.c
@@ -66,7 +66,7 @@ int http_get_request_send(struct download_client *client)
 
 	if (client->file_size != 0) {
 		/* Don't request bytes past the end of file */
-		off = MIN(off, client->file_size);
+		off = MIN(off, client->file_size - 1);
 	}
 
 	/* We use range requests only for HTTPS, due to memory limitations.


### PR DESCRIPTION
Will use the following convention when talking about HTTP Range header: bytes =&lt;range-start>-&lt;range-end>

Download client appears to be requesting an extra byte on the last range request for a file. &lt;range-start> begins on 0, so the final &lt;range-end> should be ```file_size - 1``` instead of ```file_size```.

For a file of 619592 bytes the last range request is:
 - bytes =618496- 619592

When it should be: 
 - bytes =618496- 619591

I've attached a screenshot with the HTTP request below (blurred out host for privacy purposes):

![image](https://user-images.githubusercontent.com/14277350/125099312-e324d680-e0a5-11eb-9726-9b424778c05d.png)
