### PR TITLE
west: Update pelion manifest

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -84,7 +84,12 @@ Zigbee
 Common
 ======
 
-There are no entries for this section yet.
+The following changes are relevant for all device families.
+
+Pelion
+------
+
+* Updated Pelion Device Management Client library version to 4.10.0.
 
 MCUboot
 =======

--- a/west.yml
+++ b/west.yml
@@ -158,7 +158,7 @@ manifest:
       remote: alexa
     - name: mbed-cloud-client
       path: modules/lib/pelion-dm
-      revision: 4.9.1
+      revision: 4.10.0
       remote: pelioniot
     - name: cddl-gen
       remote: nordicsemi


### PR DESCRIPTION
Update pelion manifest to 4.10.0 version.
For Pelion release notes, refer to: https://developer.pelion.com/docs/device-management/current/release-notes/device-management-client.html

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>