### PR TITLE
manifest: Update ble-controller/MPSL revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 59179ff80cee01c4feb8b747e0ff9caecb55c92d
+      revision: pull/516/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Includes updates:

- Fix for nrf53 assert during legacy scanning
- Fix for nrf53 corrupted adv reports
- Fix for channel map not always being applied to secondary adv channels
- Fixed scanner not checking that window < interval

ble-controller revision: 9a04211932895310efb6a894304c08a18793eccd
mpsl revision: eaef98baf09040590d4c739a37a081bca4d99150

Signed-off-by: Olivier Lesage <olivier.lesage@nordicsemi.no>