### PR TITLE
Bluetooth: Mesh: clarification the time spreading between time servers

### DIFF
--- a/include/bluetooth/mesh/time_srv.rst
+++ b/include/bluetooth/mesh/time_srv.rst
@@ -25,9 +25,9 @@ To ensure consistent synchronization, the Time Server model should be configured
 
 .. note::
 
-   To ensure a high level of accuracy, Time Status messages are always transmitted one hop at a time.
-   This means that every mesh node that needs access to the common time reference must be within radio range of at least one other node with the Time Server model.
-   Time Server nodes that have no neighboring Time Servers need to get this information in some other way.
+   To ensure a high level of accuracy, Time Status messages are always transmitted one hop at a time if it is sent as an unsolicited message.
+   Every mesh node without access to the Time Authority that needs access to the common time reference must be within the radio range of at least one other node with the Time Server model.
+   Time Server nodes that have no neighboring Time Servers need to get this information in some other way (e.g. getting time from the Time Authority).
 
 Roles
 *****


### PR DESCRIPTION
Clarification of the time server documentation about time spreading
between time servers. The current description confuses customers in that
they cannot get time on the node if it is out of one-hop distance from
the time server.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>