### PR TITLE
applications: serial_lte_modem: Datamode enter and exit

### DIFF
--- a/applications/serial_lte_modem/doc/slm_data_mode.rst
+++ b/applications/serial_lte_modem/doc/slm_data_mode.rst
@@ -30,11 +30,13 @@ However, the SLM data mode is applied automatically while using the following mo
 Entering data mode
 ==================
 
-SLM enters data mode when an AT command to send data out does not carry the payload.
+The SLM application enters data mode when an AT command to send data out does not carry the payload.
 See the following examples:
 
 * ``AT#XSEND`` makes SLM enter data mode to receive arbitrary data to transmit.
 * ``AT#XSEND="data"`` makes SLM transmit data in normal AT Command mode.
+
+The SLM application does not send an *OK* response when it enters data mode.
 
 TCP and UDP proxies must explicitly specify data mode support using their respective AT commands.
 Also, the following conditions apply:
@@ -49,16 +51,20 @@ Exiting data mode
 
 To exit data mode, the MCU sends the termination command set by the ``CONFIG_SLM_DATAMODE_TERMINATOR`` configuration option over UART and also applies the silence period set by the ``CONFIG_SLM_DATAMODE_SILENCE`` option, both before and after the termination command.
 
+When instructed to exit data mode, the SLM application returns the AT-command response ``OK``.
+
 The SLM application also exits data mode automatically in the following scenarios:
 
-* The TCP Server is stopped
+* The TCP Server is stopped.
 * The remote server disconnects the TCP client.
-* The TCP Client disconnects from the remote server due to an error
-* The UDP Client disconnects from the remote server due to an error
+* The TCP Client disconnects from the remote server due to an error.
+* The UDP Client disconnects from the remote server due to an error.
 * FTP unique or single put operations are completed.
 * An HTTP request is sent.
 
-After exiting data mode, the Serial LTE Modem application returns to the AT-command mode.
+When exiting data mode automatically, the SLM application sends ``#XDATAMODE: 0`` as an unsolicited notification.
+
+After exiting data mode, the SLM application returns to the AT-command mode.
 
 Triggering the transmission
 ===========================

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -141,9 +141,7 @@ void ftp_ctrl_callback(const uint8_t *msg, uint16_t len)
 			break;
 		}
 		rsp_send(rsp_buf, strlen(rsp_buf));
-		if (ftp_data_mode_handler && exit_datamode()) {
-			sprintf(rsp_buf, "\r\n#XFTP: 0,\"datamode\"\r\n");
-			rsp_send(rsp_buf, strlen(rsp_buf));
+		if (ftp_data_mode_handler && exit_datamode(false)) {
 			ftp_data_mode_handler = NULL;
 		}
 	}
@@ -466,9 +464,7 @@ static int ftp_put_handler(const uint8_t *data, int len)
 		ret = ftp_put(filepath, data, len, FTP_PUT_NORMAL);
 	}
 
-	if (exit_datamode()) {
-		sprintf(rsp_buf, "\r\n#XFTP: 0,\"datamode\"\r\n");
-		rsp_send(rsp_buf, strlen(rsp_buf));
+	if (exit_datamode(false)) {
 		ftp_data_mode_handler = NULL;
 	}
 
@@ -519,9 +515,7 @@ static int ftp_uput_handler(const uint8_t *data, int len)
 		ret = ftp_put(NULL, data, len, FTP_PUT_UNIQUE);
 	}
 
-	if (exit_datamode()) {
-		sprintf(rsp_buf, "\r\n#XFTP: 0,\"datamode\"\r\n");
-		rsp_send(rsp_buf, strlen(rsp_buf));
+	if (exit_datamode(false)) {
 		ftp_data_mode_handler = NULL;
 	}
 

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -619,7 +619,7 @@ static void httpc_thread_fn(void *arg1, void *arg2, void *arg3)
 	int err;
 
 	err = do_http_request();
-	(void)exit_datamode();
+	(void)exit_datamode(false);
 	if (err < 0) {
 		LOG_ERR("do_http_request fail:%d", err);
 		/* Disconnect from server */

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -53,20 +53,31 @@ void rsp_send(const uint8_t *str, size_t len);
 /**
  * @brief Request SLM AT host to enter data mode
  *
+ * No AT unsolicited message or command response allowed in data mode.
+ *
  * @param handler Data mode handler provided by requesting module
  *
  * @retval 0 If the operation was successful.
- *           Otherwise, a (negative) error code is returned.
+ *         Otherwise, a (negative) error code is returned.
  */
 int enter_datamode(slm_datamode_handler_t handler);
 
 /**
+ * @brief Check whether SLM AT host is in data mode
+ *
+ * @retval true if yes, false if no.
+ */
+bool in_datamode(void);
+
+/**
  * @brief Request SLM AT host to exit data mode
+ *
+ * @param response Whether to send "OK" response or not
  *
  * @retval true If normal exit from data mode.
  *         false If not in data mode.
  */
-bool exit_datamode(void);
+bool exit_datamode(bool response);
 /** @} */
 
 #endif /* SLM_AT_HOST_ */

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -419,7 +419,7 @@ static void tcp_data_handle(uint8_t *data, uint32_t length)
 static void tcp_terminate_connection(int cause)
 {
 	if (proxy.datamode) {
-		(void)exit_datamode();
+		(void)exit_datamode(false);
 	}
 	close(proxy.sock_peer);
 	proxy.sock_peer = INVALID_SOCKET;
@@ -610,10 +610,7 @@ exit:
 	sprintf(rsp_buf, "\r\n#XTCPSVR: %d,\"stopped\"\r\n", ret);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 	if (in_datamode) {
-		if (exit_datamode()) {
-			sprintf(rsp_buf, "\r\n#XTCPSVR: 0,\"datamode\"\r\n");
-			rsp_send(rsp_buf, strlen(rsp_buf));
-		}
+		(void)exit_datamode(false);
 	}
 }
 
@@ -679,10 +676,7 @@ exit:
 	sprintf(rsp_buf, "\r\n#XTCPCLI: %d,\"disconnected\"\r\n", ret);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 	if (in_datamode) {
-		if (exit_datamode()) {
-			sprintf(rsp_buf, "\r\n#XTCPCLI: 0,\"datamode\"\r\n");
-			rsp_send(rsp_buf, strlen(rsp_buf));
-		}
+		(void)exit_datamode(false);
 	}
 }
 

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -301,7 +301,7 @@ static int do_udp_send_datamode(const uint8_t *data, int datalen)
 		if (ret < 0) {
 			LOG_ERR("send() failed: %d", -errno);
 			if (errno != EAGAIN && errno != ETIMEDOUT) {
-				(void)exit_datamode();
+				(void)exit_datamode(false);
 				if (udp_server_role) {
 					do_udp_server_stop(-errno);
 				} else {


### PR DESCRIPTION
For AT command of sending data, if it enters data mode, the
response of command is sent after quitting data mode.

If SLM quit data mode by itself, URC "#XDATAMODE: 0" is sent.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>