### PR TITLE
codeowners: Update at_notif owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,7 +63,7 @@ Kconfig*                                  @tejlmand
 /lib/at_cmd_parser/                       @rlubos
 /lib/at_cmd/                              @rlubos
 /lib/at_host/                             @rlubos
-/lib/at_notif/                            @pkchan
+/lib/at_notif/                            @rlubos
 /lib/agps/                                @jtguggedal @simensrostad
 /lib/nrf_modem_lib/                       @rlubos
 /lib/edge_impulse/                        @pdunaj


### PR DESCRIPTION
Set myself as an at_notif library owner, as pkchan is no longer working
at Nordic.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>