### PR TITLE
applications: asset_tracker_v2: pass length to config decode function

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/aws_iot_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/aws_iot_codec.c
@@ -91,7 +91,8 @@ exit:
 	return err;
 }
 
-int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
+int cloud_codec_decode_config(char *input, size_t input_len,
+			      struct cloud_data_cfg *data)
 {
 	int err = 0;
 	cJSON *root_obj = NULL;
@@ -102,7 +103,7 @@ int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 		return -EINVAL;
 	}
 
-	root_obj = cJSON_Parse(input);
+	root_obj = cJSON_ParseWithLength(input, input_len);
 	if (root_obj == NULL) {
 		return -ENOENT;
 	}

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/azure_iot_hub_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/azure_iot_hub_codec.c
@@ -30,7 +30,8 @@ int cloud_codec_encode_neighbor_cells(struct cloud_codec_data *output,
 	return -ENOTSUP;
 }
 
-int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
+int cloud_codec_decode_config(char *input, size_t input_len,
+			      struct cloud_data_cfg *data)
 {
 	int err = 0;
 	cJSON *root_obj = NULL;
@@ -41,7 +42,7 @@ int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 		return -EINVAL;
 	}
 
-	root_obj = cJSON_Parse(input);
+	root_obj = cJSON_ParseWithLength(input, input_len);
 	if (root_obj == NULL) {
 		return -ENOENT;
 	}

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
@@ -217,7 +217,8 @@ static inline void cloud_codec_init(void)
 int cloud_codec_encode_neighbor_cells(struct cloud_codec_data *output,
 				      struct cloud_data_neighbor_cells *neighbor_cells);
 
-int cloud_codec_decode_config(char *input, struct cloud_data_cfg *cfg);
+int cloud_codec_decode_config(char *input, size_t input_len,
+			      struct cloud_data_cfg *cfg);
 
 int cloud_codec_encode_config(struct cloud_codec_data *output,
 			      struct cloud_data_cfg *cfg);

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud_codec.c
@@ -122,7 +122,8 @@ int cloud_codec_encode_neighbor_cells(struct cloud_codec_data *output,
 	return -ENOTSUP;
 }
 
-int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
+int cloud_codec_decode_config(char *input, size_t input_len,
+			      struct cloud_data_cfg *data)
 {
 	int err = 0;
 	cJSON *root_obj = NULL;
@@ -133,7 +134,7 @@ int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 		return -EINVAL;
 	}
 
-	root_obj = cJSON_Parse(input);
+	root_obj = cJSON_ParseWithLength(input, input_len);
 	if (root_obj == NULL) {
 		return -ENOENT;
 	}

--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -324,7 +324,8 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 		 * before it is sent to the Data module. This way we avoid
 		 * sending uninitialized variables to the Data module.
 		 */
-		err = cloud_codec_decode_config(evt->data.buf, &copy_cfg);
+		err = cloud_codec_decode_config(evt->data.buf, evt->data.len,
+						&copy_cfg);
 		if (err == 0) {
 			LOG_DBG("Device configuration encoded");
 			send_config_received();


### PR DESCRIPTION
So far it was assumed that NULL terminated string (e.g. JSON) is passed
to cloud_codec_decode_config(), so length parameter was not needed. This
however does not work for other content formats, like CBOR.

Pass length to cloud_codec_decode_config() function to be able to handle
codecs that do not produce NULL terminated strings, like CBOR.

With current JSON codecs switch from cJSON_Parse() to
cJSON_ParseWithLength(), so that there is one less strlen() invocation
underneath in cJSON library.