### PR TITLE
applications: pelion: Use mutex lock for cc3xx backend.

### DIFF
--- a/applications/pelion_client/configuration/nrf52840dk_nrf52840/app_ZDebug.conf
+++ b/applications/pelion_client/configuration/nrf52840dk_nrf52840/app_ZDebug.conf
@@ -72,6 +72,9 @@ CONFIG_DNS_SERVER2="64:ff9b::8.8.4.4"
 CONFIG_MBEDTLS_HEAP_SIZE=32768
 CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES=2
 
+# Switching to mutex lock to avoid warm resets when accessing CC3XX resources from many contexts
+CONFIG_CC3XX_MUTEX_LOCK=y
+
 # OpenThread related configuration
 CONFIG_OPENTHREAD_THREAD_STACK_SIZE=10240
 CONFIG_OPENTHREAD_DEBUG=y

--- a/applications/pelion_client/configuration/nrf52840dk_nrf52840/app_ZRelease.conf
+++ b/applications/pelion_client/configuration/nrf52840dk_nrf52840/app_ZRelease.conf
@@ -71,6 +71,9 @@ CONFIG_DNS_SERVER2="64:ff9b::8.8.4.4"
 CONFIG_MBEDTLS_HEAP_SIZE=32768
 CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES=2
 
+# Switching to mutex lock to avoid warm resets when accessing CC3XX resources from many contexts
+CONFIG_CC3XX_MUTEX_LOCK=y
+
 # OpenThread related configuration
 CONFIG_OPENTHREAD_THREAD_STACK_SIZE=10240
 

--- a/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuapp/app_ZDebug.conf
+++ b/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuapp/app_ZDebug.conf
@@ -72,6 +72,9 @@ CONFIG_DNS_SERVER2="64:ff9b::8.8.4.4"
 CONFIG_MBEDTLS_HEAP_SIZE=32768
 CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES=2
 
+# Switching to mutex lock to avoid warm resets when accessing CC3XX resources from many contexts
+CONFIG_CC3XX_MUTEX_LOCK=y
+
 # OpenThread related configuration
 CONFIG_OPENTHREAD_THREAD_STACK_SIZE=10240
 CONFIG_OPENTHREAD_DEBUG=y

--- a/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuapp/app_ZRelease.conf
+++ b/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuapp/app_ZRelease.conf
@@ -71,6 +71,9 @@ CONFIG_DNS_SERVER2="64:ff9b::8.8.4.4"
 CONFIG_MBEDTLS_HEAP_SIZE=32768
 CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES=2
 
+# Switching to mutex lock to avoid warm resets when accessing CC3XX resources from many contexts
+CONFIG_CC3XX_MUTEX_LOCK=y
+
 # OpenThread related configuration
 CONFIG_OPENTHREAD_THREAD_STACK_SIZE=10240
 

--- a/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuappns/app_ZDebug.conf
+++ b/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuappns/app_ZDebug.conf
@@ -73,6 +73,9 @@ CONFIG_DNS_SERVER2="64:ff9b::8.8.4.4"
 CONFIG_MBEDTLS_HEAP_SIZE=32768
 CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES=2
 
+# Switching to mutex lock to avoid warm resets when accessing CC3XX resources from many contexts
+CONFIG_CC3XX_MUTEX_LOCK=y
+
 # OpenThread related configuration
 CONFIG_OPENTHREAD_THREAD_STACK_SIZE=10240
 CONFIG_OPENTHREAD_DEBUG=y

--- a/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuappns/app_ZRelease.conf
+++ b/applications/pelion_client/configuration/nrf5340dk_nrf5340_cpuappns/app_ZRelease.conf
@@ -72,6 +72,9 @@ CONFIG_DNS_SERVER2="64:ff9b::8.8.4.4"
 CONFIG_MBEDTLS_HEAP_SIZE=32768
 CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES=2
 
+# Switching to mutex lock to avoid warm resets when accessing CC3XX resources from many contexts
+CONFIG_CC3XX_MUTEX_LOCK=y
+
 # OpenThread related configuration
 CONFIG_OPENTHREAD_THREAD_STACK_SIZE=10240
 

--- a/lib/pelion/Kconfig
+++ b/lib/pelion/Kconfig
@@ -87,6 +87,8 @@ config PELION_QUICK_SESSION_RESUME
 	select PELION_PAL_SUPPORT_SSL_CONNECTION_ID
 	select MBEDTLS_SSL_CONTEXT_SERIALIZATION
 	select MBEDTLS_SSL_DTLS_CONNECTION_ID
+	depends on CC3XX_MUTEX_LOCK
+	default y
 	help
 	  This option allows to enable quick session resume functionality by avoiding DTLS
 	  handshake when performing pause, resume for pelion client.


### PR DESCRIPTION
The default option selected for CC3XX_LOCK_VARIANT
is different for nRF52 and nRF53 series. Both implementations
chosen does not ensure 'real' mutual exclusion for crypto
resources. By default nRF52 series uses atomic mutexes, for
nRF53 series HW mutex is default option. This requries
crypto backend to be called from single thread to avoid
concurency. We can not ensure that for Pelion application
with QUICK_SESSION_RESUME enabled. As an outcome depend
QUICK_SESSION_RESUME on having CC3XX_MUTEX_LOCK chosen.

Enable CC3XX_MUTEX_LOCK for all configurations in nRF52/53
series in pelion client application.

Jira: NCSDK-10196.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>