### PR TITLE
tests: tfm: secure services: fix bug and add test case for secure read service

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -56,6 +56,7 @@
   - "samples/tfm/**/*"
   - "subsys/bootloader/**/*"
   - "subsys/partition_manager/**/*"
+  - "tests/modules/tfm"
   - "tests/subsys/spm/secure_services/**/*"
 
 "CI-ble-test":

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -157,6 +157,7 @@ Kconfig*                                  @tejlmand
 /tests/bluetooth/tester/                  @joerchan @carlescufi @trond-snekvik
 /tests/lib/hw_unique_key*/                @oyvindronningstad @Vge0rge
 /tests/lib/modem_jwt/                     @SeppoTakalo
+/tests/modules/tfm/                       @hakonfam
 /tests/subsys/profiler/                   @pdunaj @MarekPieta
 /tests/subsys/zigbee/                     @tomchy @sebastiandraus
 /tests/subsys/bluetooth/mesh/             @joerchan @trond-snekvik

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -146,6 +146,12 @@ Modem library
 * The AT socket API is now deprecated.
 * The DFU socket API is now deprecated.
 
+Trusted Firmware-M
+------------------
+
+* Updated :file:`tfm_platform_system.c` to fix a bug that returned ``TFM_PLATFORM_ERR_SUCCESS`` instead of ``TFM_PLATFORM_ERR_INVALID_PARAM`` when the address passed is outside of the accepted read range.
+* Added a test case for the secure read service that verifies that only addresses within the accepted range can be read.
+
 Pelion
 ------
 

--- a/modules/tfm/tfm/boards/src/tfm_platform_system.c
+++ b/modules/tfm/tfm/boards/src/tfm_platform_system.c
@@ -28,6 +28,8 @@ tfm_platform_hal_read_service(const psa_invec  *in_vec,
 {
 	struct tfm_read_service_args_t *args;
 	struct tfm_read_service_out_t *out;
+	enum tfm_platform_err_t err;
+
 
 	if (in_vec->len != sizeof(struct tfm_read_service_args_t) ||
 	    out_vec->len != sizeof(struct tfm_read_service_out_t)) {
@@ -39,6 +41,7 @@ tfm_platform_hal_read_service(const psa_invec  *in_vec,
 
 	/* Assume failure, unless valid region is hit in the loop */
 	out->result = -1;
+	err = TFM_PLATFORM_ERR_INVALID_PARAM;
 
 	if (args->destination == NULL || args->len <= 0) {
 		return TFM_PLATFORM_ERR_INVALID_PARAM;
@@ -58,6 +61,7 @@ tfm_platform_hal_read_service(const psa_invec  *in_vec,
 			       (const void *)args->addr,
 			       args->len);
 			out->result = 0;
+			err = TFM_PLATFORM_ERR_SUCCESS;
 			break;
 		}
 	}
@@ -65,7 +69,7 @@ tfm_platform_hal_read_service(const psa_invec  *in_vec,
 	in_vec++;
 	out_vec++;
 
-	return TFM_PLATFORM_ERR_SUCCESS;
+	return err;
 }
 
 

--- a/tests/modules/tfm/secure_services/CMakeLists.txt
+++ b/tests/modules/tfm/secure_services/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(NONE)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_include_directories(app PRIVATE
+  ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/trusted-firmware-m/interface/include)

--- a/tests/modules/tfm/secure_services/prj.conf
+++ b/tests/modules/tfm/secure_services/prj.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_ZTEST=y
+CONFIG_BUILD_WITH_TFM=y

--- a/tests/modules/tfm/secure_services/src/main.c
+++ b/tests/modules/tfm/secure_services/src/main.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+ #include <ztest.h>
+ #include <tfm_ns_interface.h>
+ #include <tfm/tfm_ioctl_api.h>
+ #include <pm_config.h>
+
+static bool is_secure(intptr_t ptr)
+{
+	/* We can not use 'arm_cmse_addr_is_secure here since this firmware
+	 * is built as non secure.
+	 */
+	if (ptr >= CONFIG_PM_SRAM_BASE) {
+		/* Check if RAM address is secure */
+		return ptr < PM_SRAM_ADDRESS;
+	}
+
+	/* Check if flash address is secure */
+	return ptr < PM_ADDRESS;
+}
+
+void test_tfm_read_service(void)
+{
+	const uint32_t ficr_start = (NRF_FICR_S_BASE + 0x204);
+	const uint32_t ficr_end = ficr_start + 0xA1C;
+
+	uint8_t output[4];
+	uint8_t data_length = sizeof(output);
+	void *secure_ptr = (size_t *)PM_TFM_SRAM_ADDRESS;
+
+	uint32_t err = 0;
+	enum tfm_platform_err_t plt_err;
+
+	/* Verify that test objects is stored in non-secure addresses. */
+	zassert_true(!is_secure((intptr_t)output),
+			 "Test object is not non-secure");
+
+	/* Verify that secure test objects is stored in secure addresses. */
+	zassert_true(is_secure((intptr_t)secure_ptr),
+						"Test object is not secure");
+
+	/* Verify that the function fails if it is passed secure pointers */
+	plt_err = tfm_platform_mem_read(secure_ptr, ficr_start, data_length, &err);
+	zassert_equal(plt_err, TFM_PLATFORM_ERR_INVALID_PARAM,
+						"Did not fail for secure pointer");
+	zassert_equal(err, -1, "Did not fail for secure pointer");
+
+	/* Verify that edge addresses in FICR will return expected values */
+	/* Normal execution */
+	plt_err = tfm_platform_mem_read(output, ficr_start, data_length, &err);
+	zassert_equal(plt_err, TFM_PLATFORM_ERR_SUCCESS, "Valid address returned an error!");
+	zassert_equal(err, 0, "Valid address returned an error!");
+
+	plt_err = tfm_platform_mem_read(output, ficr_end - data_length, data_length, &err);
+	zassert_equal(plt_err, TFM_PLATFORM_ERR_SUCCESS, "Valid address returned an error!");
+	zassert_equal(err, 0, "Valid address returned an error!");
+
+	/* Expect invalid addresses to finish with result -1 */
+	plt_err = tfm_platform_mem_read(output, ficr_start - 1, data_length, &err);
+	zassert_equal(plt_err, TFM_PLATFORM_ERR_INVALID_PARAM,
+							"Invalid address returned an unexpected error");
+	zassert_equal(err, -1, "Invalid address did not return expected address");
+
+	plt_err = tfm_platform_mem_read(output, ficr_end - data_length + 1, data_length, &err);
+	zassert_equal(plt_err, TFM_PLATFORM_ERR_INVALID_PARAM,
+							"Invalid address returned an unexpected error");
+	zassert_equal(err, -1, "Invalid address did not return expected address");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(test_secure_service,
+		ztest_unit_test(test_tfm_read_service));
+	ztest_run_test_suite(test_secure_service);
+}

--- a/tests/modules/tfm/secure_services/testcase.yaml
+++ b/tests/modules/tfm/secure_services/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  tfm.secure_services:
+    platform_allow: nrf9160dk_nrf9160_ns nrf5340dk_nrf5340_cpuapp_ns
+    tags: tfm secure_services


### PR DESCRIPTION
Verifies only addresses within expected range can be read
