### PR TITLE
Bluetooth: Mesh: make qemu_cortex_m3 main ble mesh ut platform

### DIFF
--- a/tests/subsys/bluetooth/mesh/light_ctrl/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/light_ctrl/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   bluetooth.mesh.light_ctrl_subsys:
-    platform_allow: native_posix
+    platform_allow: native_posix qemu_cortex_m3
     tags: bluetooth ci_build
     integration_platforms:
-        - native_posix
+        - qemu_cortex_m3

--- a/tests/subsys/bluetooth/mesh/sensor_subsys/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/sensor_subsys/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   bluetooth.mesh.sensor_subsys:
-    platform_allow: native_posix
-    tags: bluetooth mesh models sensor
+    platform_allow: native_posix qemu_cortex_m3
+    tags: bluetooth ci_build
     integration_platforms:
-        - native_posix
+        - qemu_cortex_m3

--- a/tests/subsys/bluetooth/mesh/silvair_enocean_model/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/silvair_enocean_model/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   bluetooth.mesh.silvair_enocean_model:
     platform_allow: native_posix qemu_cortex_m3
-    tags: bluetooth mesh models
+    tags: bluetooth ci_build
     integration_platforms:
-        - native_posix
+        - qemu_cortex_m3


### PR DESCRIPTION
native_posix cannot be used as reference platform to run unit tests by CI
since CI uses only GNU ARM toolchain. Init test platform should be able to
be built for arm target and run posix host. qemu_cortex_m3 seems suitable
for this purpose.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>