### PR TITLE
manifest: Update Softdevice Controller

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.6.0
+      revision: 8f3ef0d73318150c9eb5843eb5bf9ad7772ce750
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Updates for:
Fixed an issue on the nRF53 Series where an assert could occur while scanning using legacy commands.
Fixed an issue on the nRF53 Series where the scanner could generate corrupted advertising reports.

Signed-off-by: Ilhan Ates <ilhan.ates@nordicsemi.no>