### PR TITLE
samples: zigbee: moved target_sources_ifdef() outside NORDIC SDK tags

### DIFF
--- a/samples/zigbee/light_switch/CMakeLists.txt
+++ b/samples/zigbee/light_switch/CMakeLists.txt
@@ -15,9 +15,9 @@ target_sources(app PRIVATE
   src/main.c
 )
 
+target_include_directories(app PRIVATE include)
+# NORDIC SDK APP END
+
 target_sources_ifdef(CONFIG_BT_NUS app PRIVATE
   src/nus_cmd.c
 )
-
-target_include_directories(app PRIVATE include)
-# NORDIC SDK APP END


### PR DESCRIPTION
Only native CMake functions are allowed inside the
NORDIC SDK APP START / END tags.

Custom CMake functions, such as zephyr specific CMake functions are not
supported and thus they are wrapped incorrectly when file is written
back by SES-NE.

This has been fixed by moving the target_sources_ifdef() outside of the
tags.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>