### PR TITLE
doc: nrfx: fix Doxygen warnings

### DIFF
--- a/doc/nrfx/nrfx.doxyfile.in
+++ b/doc/nrfx/nrfx.doxyfile.in
@@ -2089,29 +2089,13 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = SUPPRESS_INLINE_IMPLEMENTATION \
                          __NRFX_DOXYGEN__ \
                          CONFIG_PURGE_ENABLED \
-                         == \
-                         1 \
                          CONFIG_DISASSOCIATE_ENABLED \
-                         == \
-                         1 \
                          CONFIG_GTS_ENABLED \
-                         == \
-                         1 \
                          CONFIG_ORPHAN_ENABLED \
-                         == \
-                         1 \
                          CONFIG_RXE_ENABLED \
-                         == \
-                         1 \
                          CONFIG_START_ENABLED \
-                         == \
-                         1 \
                          CONFIG_SYNC_ENABLED \
-                         == \
-                         1 \
                          CONFIG_PANID_CONFLICT_ENABLED \
-                         == \
-                         1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2180,12 +2164,6 @@ EXTERNAL_GROUPS        = NO
 
 #EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2198,15 +2176,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The


### PR DESCRIPTION
- Remove deprecated fields in Doxyfile
- Remove wrong PREDEFINED fields

Tested with Doxygen 1.8.17