### PR TITLE
application: serial_lte_modem: Limit size for LOG_HEXDUMP_DBG

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -49,7 +49,16 @@ void slm_at_host_uninit(void);
  * @param len Length of response message
  *
  */
-void rsp_send(const uint8_t *str, size_t len);
+void rsp_send(const char *str, size_t len);
+
+/**
+ * @brief Send raw data received in data mode
+ *
+ * @param data Raw data received
+ * @param len Length of raw data
+ *
+ */
+void datamode_send(const uint8_t *data, size_t len);
 
 /**
  * @brief Request SLM AT host to enter data mode


### PR DESCRIPTION
In practice, when SLM is running in data mode, full dump of data
packets are too much for logging, causing message drop.

Define debug dump size to be 16 bytes or less.
Add new datamode_send() to dump received data following the limit.

Also include one improvement to flush ring-buffer if flow control
is imposed when operating in datamode.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>