### PR TITLE
manifest: extend 802.15.4 retransmission support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0944459b5b622048a08ad1f8cf8a044c135fd0d3
+      revision: pull/582/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: fa5a790a287954915b4e3e48a4ff3cf614d04a2a
+      revision: pull/519/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
@@ -127,7 +127,7 @@ manifest:
     - name: nrf-802154
       repo-path: sdk-nrf-802154
       path: nrf-802154
-      revision: v1.6.0
+      revision: de32c3e638b82880686d5d88eac79fb0ae2cdab7
       groups:
       - nrf-802154
     - name: cjson


### PR DESCRIPTION
This commit combines changes in sdk-zephyr and sdk-nrfxlib to bring in
the latest changes in the nRF IEEE 802.15.4 radio driver.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>