### PR TITLE
Bluetooth: Mesh: LC Regulator: Set lightness without side effects

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -572,10 +572,18 @@ static void reg_step(struct k_work *work)
 
 		srv->reg.prev = output;
 		atomic_set_bit(&srv->flags, FLAG_REGULATOR);
-		light_set(srv, light_to_repr(output, LINEAR), 0);
 	} else if (atomic_test_and_clear_bit(&srv->flags, FLAG_REGULATOR)) {
-		light_set(srv, light_to_repr(lvl, LINEAR), 0);
+		output = lvl;
+	} else {
+		return;
 	}
+
+	struct bt_mesh_lightness_set set = {
+		.lvl = light_to_repr(output, LINEAR),
+	};
+
+	bt_mesh_lightness_srv_set(srv->lightness, NULL, &set,
+				  &(struct bt_mesh_lightness_status){});
 }
 #endif
 

--- a/subsys/bluetooth/mesh/lightness_internal.h
+++ b/subsys/bluetooth/mesh/lightness_internal.h
@@ -149,6 +149,19 @@ void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
 			      struct bt_mesh_lightness_status *status,
 			      bool publish);
 
+
+/** @brief Set the lightness without side effects such as storage or publication
+ *
+ *  @param[in] srv     Lightness server
+ *  @param[in] ctx     Message context or NULL
+ *  @param[in] set     Value to set
+ *  @param[out] status Status response
+ */
+void bt_mesh_lightness_srv_set(struct bt_mesh_lightness_srv *srv,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct bt_mesh_lightness_set *set,
+			       struct bt_mesh_lightness_status *status);
+
 /* For testing purposes */
 int lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
 			    struct bt_mesh_msg_ctx *ctx, enum light_repr repr,


### PR DESCRIPTION
The regulator runs on a sub-100ms interval, and each update to the
lightness level will trigger a publication and the staggered persistent
storage timer. This adds significant processing and flash wear.

Add a lightness_set function without these side effects, and call this
from the regulator step function.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>