### PR TITLE
applications: asset_tracker_v2: fix Doxygen issues

### DIFF
--- a/applications/asset_tracker_v2/src/events/led_state_event.h
+++ b/applications/asset_tracker_v2/src/events/led_state_event.h
@@ -39,4 +39,6 @@ struct led_state_event {
 
 EVENT_TYPE_DECLARE(led_state_event);
 
+/** @} */
+
 #endif /* _LED_STATE_EVENT_H_ */

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.h
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.h
@@ -7,7 +7,7 @@
 #ifndef SLM_AT_FTP_
 #define SLM_AT_FTP_
 
-/**@file slm_at_tcpip.h
+/**@file
  *
  * @brief Vendor-specific AT command for FTP service.
  * @{


### PR DESCRIPTION
The declared group was not closed on the same file, leading to a Doxygen error.