### PR TITLE
manifest: Allow RIPEMD Mbed TLS usage

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 03bf990a704df2438f4219344085505e19417736
+      revision: 353f527de89d83139883460140da79fb6e2191df
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Allow using RIPEMD160 hashing in nrfxlib.

Signed-off-by: Torstein Grindvik <torstein.grindvik@nordicsemi.no>