### PR TITLE
zigbee: Remove ZB_ERROR_BASE_NUM define

### DIFF
--- a/include/zigbee/zigbee_error_handler.h
+++ b/include/zigbee/zigbee_error_handler.h
@@ -19,11 +19,6 @@
 #include <zboss_api.h>
 #include <zb_errors.h>
 
-/**@brief ZBOSS stack error code base.
- *
- */
-#define ZB_ERROR_BASE_NUM 20000
-
 #ifdef CONFIG_ZBOSS_ERROR_PRINT_TO_LOG
 #include "zb_error_to_string.h"
 #include <logging/log.h>


### PR DESCRIPTION
The ZB_ERROR_BASE_NUM define is no longer used by the Zigbee error handler library.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>