### PR TITLE
doc: JIRA 8949 add link to how to add cmake opt

### DIFF
--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -94,8 +94,10 @@ Building and running
 Minimal build
 =============
 
-The sample can be built with a minimum configuration as a demonstration of how to reduce code size and RAM usage.
-To build the minimum configuration, use the following command:
+You can build the sample with a minimum configuration as a demonstration of how to reduce code size and RAM usage, using the ``-DCONF_FILE='prj_minimal.conf'`` flag in your build.
+
+See :ref:`cmake_options` for instructions on how to add this option to your build.
+For example, when building on the command line, you can do so as follows:
 
 .. code-block:: console
 

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -95,8 +95,10 @@ Building and running
 Minimal build
 =============
 
-You can build the sample with a minimum configuration as a demonstration of how to reduce code size and RAM usage.
-To build the minimum configuration, use the following command:
+You can build the sample with a minimum configuration as a demonstration of how to reduce code size and RAM usage, using the ``-DCONF_FILE='prj_minimal.conf'`` flag in your build.
+
+See :ref:`cmake_options` for instructions on how to add this option to your build.
+For example, when building on the command line, you can do so as follows:
 
 .. code-block:: console
 

--- a/samples/bluetooth/rpc_host/README.rst
+++ b/samples/bluetooth/rpc_host/README.rst
@@ -31,6 +31,8 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/rpc_host`
 
+You must program this sample to the nRF5340 network core.
+
 .. include:: /includes/build_and_run.txt
 
 .. _rpc_host_debug:
@@ -38,7 +40,10 @@ Building and running
 Debug build
 ===========
 
-To build the sample with a debugging configuration, use the following command:
+You can build the sample with a debugging configuration using the ``-DCONFIG_OVERLAY=overlay-debugging.conf'`` flag in your build.
+
+See :ref:`cmake_options` for instructions on how to add this option to your build.
+For example, when building on the command line, you can do so as follows:
 
 .. code-block:: console
 
@@ -46,20 +51,24 @@ To build the sample with a debugging configuration, use the following command:
 
 .. _rpc_host_testing:
 
-Testing
-=======
+Example build
+=============
 
-Build the sample with the same Bluetooth configuration as the application core sample.
-For more details, see: :ref:`ble_rpc`.
-Build the :ref:`zephyr:bluetooth-beacon-sample` on the application core.
-This sample works out of the box and does not require configuration changes.
-In the Beacon sample directory, invoke:
+The recommended way of building the nRF RPC Host sample is to use the multi-image feature of the build system, building the sample with the same Bluetooth configuration as the application core sample.
+In this way, the sample is built automatically as a child image when :option:`CONFIG_BT_RPC` is enabled.
 
-   .. code-block:: console
+See :ref:`configure_application` for information about how to configure a sample.
+
+For example, building the :ref:`zephyr:bluetooth-beacon-sample` sample for the nRF5340 application core with the :option:`CONFIG_BT_RPC` configuration option will include the nRF RPC Host sample in the build.
+
+To do so on the command line, run the following command in the beacon sample directory:
 
       west build -b nrf5340dk_nrf5340_cpuapp -- -DCONFIG_BT_RPC=y
 
-After programming the sample for your development kit, test it by performing the following steps:
+Testing
+=======
+
+After programming the example build to your development kit, test it by performing the following steps:
 
 1. Connect the dual core development kit to the computer using a USB cable.
    The development kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -77,10 +77,14 @@ Device Firmware Upgrade support
 
 .. matter_door_lock_sample_build_with_dfu_start
 
-You can configure the sample to use the secure bootloader for performing over-the-air Device Firmware Upgrade through Bluetooth LE, adding to your build a configuration that enables the DFU using the ``-DBUILD_WITH_DFU=1`` flag in your build.
+You can configure the sample to use the secure bootloader for performing over-the-air Device Firmware Upgrade using Bluetooth LE, using the following build flags during the build process:
 
-See :ref:`cmake_options` for instructions on how to add this option to your build.
-For example, when building on the command line, you can run the following command with *build_target* replaced with the build target name of the hardware platform you are using (see `Requirements`_):
+* ``-DOVERLAY_CONFIG=../common/config/overlay-dfu_support.conf``
+* ``-DPM_STATIC_YML_FILE="configuration/build-target/pm_static.yml``
+
+See :ref:`cmake_options` for instructions on how to add these options to your build.
+
+For example, when building on the command line, run the following command with *build_target* replaced with the build target name of the hardware platform you are using (see `Requirements`_):
 
 .. parsed-literal::
    :class: highlight

--- a/samples/matter/weather_station/README.rst
+++ b/samples/matter/weather_station/README.rst
@@ -73,10 +73,13 @@ This sample supports the following build types:
 
 You can find configuration options for both build types in the corresponding :file:`prj_debug.conf` and :file:`prj_release.conf` files.
 By default, the sample selects the release configuration.
-To build the target with the debug configuration, you can use the ``-DCMAKE_BUILD_TYPE=debug`` flag in your build.
 
-See :ref:`cmake_options` for instructions on how to add this option to your build.
-For example, when building on the command line, you can do so as follows:
+If you want to build the target with the debug configuration, you can set the following flag when building the sample:
+
+* ``-DCMAKE_BUILD_TYPE=debug``
+
+See :ref:`cmake_options` for instructions on how to add these options to your build.
+For example, when building on the command line, you can build the target with the debug configuration running the following command:
 
 .. parsed-literal::
    :class: highlight

--- a/samples/nrf5340/multiprotocol_rpmsg/README.rst
+++ b/samples/nrf5340/multiprotocol_rpmsg/README.rst
@@ -49,6 +49,21 @@ You must program this sample to the nRF5340 network core.
 The recommended way of building the sample is to use the multi-image feature of the build system.
 In this way, the sample is built automatically as a child image when both :option:`CONFIG_BT_RPMSG_NRF53` and :option:`CONFIG_NRF_802154_SER_HOST` are enabled.
 
+See :ref:`configure_application` for information about how to configure the sample.
+
+For example, you can include the Multiprotocol RPMsg sample in a multi-image build by building the :ref:`sockets-echo-server-sample` sample for the nRF5340 application core and adding the following configuration files to your build as CMake options:
+
+* ``overlay-802154.conf``
+* ``overlay-bt.conf``
+
+See :ref:`cmake_options` for instructions on how to add these options to your build.
+To see an example of this multi-image build on the command line, run the following command:
+
+.. parsed-literal::
+   :class: highlight
+
+   west build -b nrf5340dk_nrf5340_cpuapp -p -- -DOVERLAY_CONFIG="overlay-802154.conf;overlay-bt.conf"
+
 However, it is also possible to build the sample as a stand-alone image.
 
 .. include:: /includes/build_and_run.txt
@@ -56,24 +71,12 @@ However, it is also possible to build the sample as a stand-alone image.
 Testing
 *******
 
-|test_sample|
+The testing methods for this sample depend on how it was built and programmed to the device.
+For example, if you built the sample in a multi-image build containing also the :ref:`sockets-echo-server-sample` sample mentioned before, you can test it as follows:
 
-1. Go to the :file:`samples/net/sockets/echo_server` path in the Zephyr's sample directory
-#. Run the following command:
-
-   .. code-block:: console
-
-      west build -b nrf5340dk_nrf5340_cpuapp -p -- -DOVERLAY_CONFIG="overlay-802154.conf;overlay-bt.conf"
-
-   During the build, the :ref:`multiprotocol-rpmsg-sample` image will be automatically included.
-#. Run this command to program both the application and network core firmwares to the nRF5340 SoC:
-
-   .. code-block:: console
-
-      west flash
-#. Run the IEEE 802.15.4 variant of the :ref:`sockets-echo-client-sample` on a second development kit that supports IEEE 802.15.4.
+1. Run the IEEE 802.15.4 variant of the :ref:`sockets-echo-client-sample` on a second development kit that supports IEEE 802.15.4.
 #. |connect_terminal|
-   As the nRF5340 DK has multiple UART instances, the correct port must be identified.
+   As the nRF5340 DK has multiple UART instances, you must identify the correct port.
 #. Observe that IPv6 packets are exchanged between the echo client and server over the IEEE 802.15.4 interface.
    You can use a smartphone to see that the nRF5340 device advertises over Bluetooth LE in parallel to the echo exchanges.
 

--- a/samples/nrf9160/mqtt_simple/README.rst
+++ b/samples/nrf9160/mqtt_simple/README.rst
@@ -93,8 +93,10 @@ In addition, the sample provides overlay configuration files, which are used to 
 They are located in ``samples/nrf9160/mqtt_simple`` folder.
 
 
-To add a specific overlay configuration file to the build, add the ``-- -DOVERLAY_CONFIG=<overlay_config_file>`` parameter to the ``west build`` command.
-The following command builds the sample with the TLS configuration for nRF9160 DK:
+To add a specific overlay configuration file to the build, add the ``-- -DOVERLAY_CONFIG=<overlay_config_file>`` flag to your build.
+
+See :ref:`cmake_options` for instructions on how to add this option to your build.
+For example, when building on the command line, you can build the sample with the TLS configuration for nRF9160 DK as follows:
 
   .. code-block:: console
 
@@ -102,9 +104,6 @@ The following command builds the sample with the TLS configuration for nRF9160 D
 
 .. note::
    The CA certificate for the default MQTT broker is included in the project and automatically provisioned after boot if the sample is built with the TLS configuration.
-
-
-
 
 Building and running
 ********************

--- a/samples/zigbee/ncp/README.rst
+++ b/samples/zigbee/ncp/README.rst
@@ -80,9 +80,10 @@ The ``UART0`` pins are configured by Devicetree :file:`overlay` files for each s
 Communication through USB
 -------------------------
 
-You can change the communication channel from the default UART to nRF USB by using the :file:`prj_usb.conf` configuration file.
-This configuration file is not applied automatically and can be passed into CMake by using the ``--`` separator when building the sample.
-For example:
+You can change the communication channel from the default UART to nRF USB by using the :file:`prj_usb.conf` configuration file, adding the ``-DCONF_FILE='prj_usb.conf'`` flag to your build.
+
+See :ref:`cmake_options` for instructions on how to add this flag to your build.
+For example, when building on the command line, you can do so as follows:
 
 .. code-block:: console
 
@@ -117,8 +118,10 @@ See :ref:`ug_multi_image_variables` for how to set the required options.
 
 MCUboot with the USB DFU requires a larger partition.
 To increase the partition, define the ``PM_STATIC_YML_FILE`` variable that provides the path to the :file:`pm_static.yml` static configuration file in the :file:`configuration` directory for the build target of your choice.
-These additional options and configuration file can be passed into CMake by using the ``--`` separator when building the sample.
-For example:
+
+For instructions on how to set these additional options and configuration at build time, see :ref:`cmake_options` and :ref:`configure_application`.
+
+See the following command-line instruction for an example:
 
 .. code-block:: console
 


### PR DESCRIPTION
Related to JIRA 8949
Added mention to docs on how to add CMake flag
in the following nrf samples doc
- multiprotocol-rpmsg-sample
- mqtt_simple_sample
- matter_lock_sample
- matter_weather_station_sample
- peripheral_lbs
- peripheral_uart
- zigbee_ncp_sample
- ble_rpc_host

Signed-off-by: Francesco Servidio <francesco.servidio@nordicsemi.no>