### PR TITLE
net: lib: coap_utils: argument "addr" in coap_init() had no effect

### DIFF
--- a/subsys/net/lib/coap_utils/coap_utils.c
+++ b/subsys/net/lib/coap_utils/coap_utils.c
@@ -203,14 +203,13 @@ static void coap_set_response_callback(struct coap_packet *request,
 void coap_init(int ip_family, struct sockaddr *addr)
 {
 	proto_family = ip_family;
+	if (addr) {
+		bind_addr = addr;
+	}
 
 	fds.events = POLLIN;
 	fds.revents = 0;
 	fds.fd = coap_open_socket();
-
-	if (addr) {
-		bind_addr = addr;
-	}
 
 	/* start sock receive thread */
 	k_thread_create(&receive_thread_data, receive_stack_area,


### PR DESCRIPTION
static struct bind_addr was being set after coap_open_socket() therefore socket would be opened with uninitialized variable bind_addr.