### PR TITLE
doc: fixing typo from nrf5840 to nrf52840

### DIFF
--- a/doc/nrf/ug_bootloader_adding.rst
+++ b/doc/nrf/ug_bootloader_adding.rst
@@ -53,7 +53,7 @@ To ensure that the immutable bootloader occupies as little flash memory as possi
 
 .. code-block:: console
 
-   west build -b nrf52840dk_nrf5840 zephyr/samples/hello_world -- \
+   west build -b nrf52840dk_nrf52840 zephyr/samples/hello_world -- \
    -DCONFIG_SECURE_BOOT=y \
    -Db0_CONF_FILE=prj_minimal.conf
 
@@ -181,7 +181,7 @@ To use a custom signing command with this bootloader, set the following options 
 
       .. code-block:: console
 
-         west build -b nrf52840dk_nrf5840 zephyr/samples/hello_world -- \
+         west build -b nrf52840dk_nrf52840 zephyr/samples/hello_world -- \
          -DCONFIG_SECURE_BOOT=y \
          -DCONFIG_SB_SIGNING_CUSTOM=y \
          -DCONFIG_SB_SIGNING_PUBLIC_KEY=\"/path/to/pub.pem\" \
@@ -302,7 +302,7 @@ To enable this configuration, apply the :file:`overlay-minimal-external-crypto.c
 
 .. code-block::
 
-   west build -b nrf52840dk_nrf5840 zephyr/samples/hello_world -- \
+   west build -b nrf52840dk_nrf52840 zephyr/samples/hello_world -- \
    -DCONFIG_BOOTLOADER_MCUBOOT=y \
    -Dmcuboot_OVERLAY_CONFIG=overlay-minimal-external-crypto.conf
 

--- a/doc/nrf/ug_bootloader_config.rst
+++ b/doc/nrf/ug_bootloader_config.rst
@@ -40,7 +40,7 @@ For example, you can assign the :file:`my-custom-fragment.conf` fragment to the 
 
 .. code-block:: console
 
-   west build -b nrf52840dk_nrf5840 zephyr/samples/hello_world -- \
+   west build -b nrf52840dk_nrf52840 zephyr/samples/hello_world -- \
    -DCONFIG_SECURE_BOOT=y \
    -DCONFIG_BOOTLOADER_MCUBOOT=y \
    -Db0_OVERLAY_CONFIG=my-custom-fragment.conf
@@ -49,7 +49,7 @@ In the same way, you can replace ``b0`` with ``mcuboot`` to apply the :file:`my-
 
 .. code-block:: console
 
-   west build -b nrf52840dk_nrf5840 zephyr/samples/hello_world -- \
+   west build -b nrf52840dk_nrf52840 zephyr/samples/hello_world -- \
    -DCONFIG_SECURE_BOOT=y \
    -DCONFIG_BOOTLOADER_MCUBOOT=y \
    -Dmcuboot_OVERLAY_CONFIG=my-custom-fragment.conf

--- a/doc/nrf/ug_matter_configuring.rst
+++ b/doc/nrf/ug_matter_configuring.rst
@@ -80,7 +80,7 @@ To use this setup, you need the following hardware:
 * 1x PC with Ubuntu (20.04 or newer) or 1x smartphone with Android 8+
 * 1x Raspberry Pi Model 3B+ or newer (along with a SD card with at least 8 GB of memory)
 * 1x Wi-Fi Access Point supporting IPv6 (without the IPv6 Router Advertisement Guard enabled on the router)
-* 1x nRF52840 DK or nRF5840 Dongle - for the Radio Co-Processor (RCP) device
+* 1x nRF52840 DK or nRF52840 Dongle - for the Radio Co-Processor (RCP) device
 * 1x nRF52840 DK or nRF5340 DK - for the Matter accessory device (programmed with one of :ref:`matter_samples`)
 
 For information about how to configure and use the required components, complete steps from the following user guides:
@@ -107,7 +107,7 @@ To use this setup, you need the following hardware:
 
 * 1x PC with Ubuntu (20.04 or newer) or Raspberry Pi Model 3B+ or newer with Ubuntu (20.04 or newer) instead of Raspbian OS
 * 1x Bluetooth LE dongle (can be embedded inside the PC, like it is on Raspberry Pi)
-* 1x nRF52840 DK or nRF5840 Dongle - for the Radio Co-Processor (RCP) device
+* 1x nRF52840 DK or nRF52840 Dongle - for the Radio Co-Processor (RCP) device
 * 1x nRF52840 DK or nRF5340 DK - for the Matter accessory device (programmed with one of :ref:`matter_samples`)
 
 For information about how to configure and use the required components, see the following user guides:


### PR DESCRIPTION
Documentation references to nrf5840 or nRF5840 have been changed to nrf52840 or nRF52840 respectively

Signed-off-by: Akash Patel <akash.patel@nordicsemi.no>