### PR TITLE
workflows: contribs: Allow external contributions

### DIFF
--- a/.github/workflows/contribs.yml
+++ b/.github/workflows/contribs.yml
@@ -15,9 +15,14 @@ jobs:
           command: 'external'
           messages: |
                     Thank you for your contribution!
-                    It seems you are not a member of the nrfconnect GitHub organization.
-                    At this time we are not accepting external contributions, but this may change soon.
-                    Please visit https://devzone.nordicsemi.com/ to raise any issues you found or ask for help.
+                    It seems you are not a member of the nrfconnect GitHub organization. External contributions are handled as follows:
+                    Large contributions, affecting multiple subsystems for example, may be rejected if they are complex, may introduce regressions due to lack of test coverage, or if they are not consistent with the architecture of nRF Connect SDK.
+                    PRs will be run in our continuous integration (CI) test system.
+                    If CI passes, PRs will be tagged for review and merged on successful completion of review. You may be asked to make some modifications to your contribution during review.
+                    If CI fails, PRs may be rejected or may be tagged for review and rework.
+                    PRs that become outdated due to other changes in the repository may be rejected or rework requested.
+                    External contributions will be prioritized for review based on the relevance to current development efforts in nRF Connect SDK.  Bug fix PRs will be prioritized.
+                    You may raise issues or ask for help from our Technical Support team by visiting https://devzone.nordicsemi.com/.
                     |
                     The author of this pull request has now been added to the nrfconnect GitHub organization.
           labels: 'external'


### PR DESCRIPTION
Update the text automatically added to PRs by external contributors to
begin allowing external contributions, with some caveats.

NCSDK-10067.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>