### PR TITLE
doc: Use the term application instead of sample

### DIFF
--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -1,13 +1,15 @@
 .. _gs_modifying:
 
-Modifying a sample application
-##############################
+Modifying an application
+########################
 
 .. contents::
    :local:
    :depth: 2
 
-After programming and testing a sample application, you probably want to make some modifications to the application, for example, add your own files with additional functionality, change compilation options, or update the default configuration.
+|application_sample_definition|
+
+After programming and testing an application, you probably want to make some modifications to the application, for example, add your own files with additional functionality, change compilation options, or update the default configuration.
 
 
 Adding files and changing compiler settings
@@ -75,7 +77,7 @@ The following CMake commands can be managed by SES, if they target the ``app`` l
 * ``target_include_directories``
 * ``target_compile_options``
 
-The :file:`CMakeLists.txt` files for the sample applications in the |NCS| are tagged as required.
+The :file:`CMakeLists.txt` files for the applications in the |NCS| are tagged as required.
 Therefore, if you always use SES to maintain them, you do not need to worry about tagging.
 Typically, the :file:`CMakeLists.txt` files include at least the :file:`main.c` file as source::
 

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -1,14 +1,15 @@
 .. _gs_programming:
 
-Building and programming a sample application
-#############################################
+Building and programming an application
+#######################################
 
 .. contents::
    :local:
    :depth: 2
 
-The recommended way of building and programming an |NCS| sample is to use the Nordic Edition of the |SES| (SES) IDE.
+The recommended way of building and programming an |NCS| application is to use the Nordic Edition of the |SES| (SES) IDE.
 
+|application_sample_definition|
 
 .. note::
 
@@ -56,8 +57,8 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
    * :guilabel:`Projects` - Select the project that you want to work with.
 
-     The drop-down list contains a selection of samples and applications from the sdk-nrf and sdk-zephyr repositories.
-     Select any of the checkboxes underneath to add the samples from that area to the drop-down list.
+     The drop-down list contains a selection of applications from the sdk-nrf and sdk-zephyr repositories.
+     Select any of the checkboxes underneath to add the applications from that area to the drop-down list.
      To add projects to the drop-down list, for example, your own custom projects, click :guilabel:`...` and select the folder that contains the projects that you want to add.
    * :guilabel:`Board Name` - Select the board that you want to work with.
 
@@ -119,7 +120,7 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
       a. Select your project in the Project Explorer.
       #. From the menu, select :guilabel:`Build` > :guilabel:`Build Solution`.
-      #. When the build completes, you can program the sample to a connected development kit:
+      #. When the build completes, you can program the application to a connected development kit:
 
          * For a single-image application, select :guilabel:`Target` > :guilabel:`Download zephyr/zephyr.elf`.
          * For a multi-image application, select :guilabel:`Target` > :guilabel:`Download zephyr/merged.hex`.
@@ -153,15 +154,15 @@ Complete the following steps to build |NCS| projects on the command line after c
 
          The Toolchain Manager dropdown menu options
 
-#.    Go to the specific sample or application directory.
-      For example, to build the :ref:`at_client_sample` sample, run the following command to navigate to the sample directory:
+#.    Go to the specific application directory.
+      For example, to build the :ref:`at_client_sample` sample, run the following command to navigate to its directory:
 
       .. code-block:: console
 
          cd nrf/samples/nRF9160/at_client
 
 
-#.    Build the sample or application using the west command.
+#.    Build the application using the west command.
       The build target is specified by the parameter *build_target* in the west command as follows:
 
       .. parsed-literal::
@@ -197,7 +198,7 @@ Complete the following steps to build |NCS| projects on the command line after c
          To program the nRF52840 Dongle instead of a development kit, skip the following instructions and follow the programming instructions in :ref:`zephyr:nrf52840dongle_nrf52840`.
 
 #.    Power on the development kit.
-#.    Program the sample or application to the kit using the following command:
+#.    Program the application to the kit using the following command:
 
       .. code-block:: console
 

--- a/doc/nrf/gs_testing.rst
+++ b/doc/nrf/gs_testing.rst
@@ -1,16 +1,18 @@
 .. _gs_testing:
 
-Testing a sample application
+Testing an application
 ############################
 
 .. contents::
    :local:
    :depth: 2
 
-Follow the instructions in the testing section of the sample documentation to ensure that the application runs as expected.
+|application_sample_definition|
+
+Follow the instructions in the testing section of the application documentation to ensure that the application runs as expected.
 
 Information about the current state of the application is usually provided through the LEDs or through UART, or through both.
-See the user interface section of the sample documentation for description of the LED states or available UART commands.
+See the user interface section of the application documentation for description of the LED states or available UART commands.
 
 .. _putty:
 
@@ -39,7 +41,7 @@ UART can also be used for logging purposes as one of the :ref:`logging backends 
 How to use RTT
 **************
 
-To view the logging output using Real Time Transfer (RTT), modify the configuration settings of the sample to override the default UART console:
+To view the logging output using Real Time Transfer (RTT), modify the configuration settings of the application to override the default UART console:
 
  .. code-block:: none
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -80,3 +80,5 @@
 .. |NSIB| replace:: nRF Secure Immutable Bootloader
 
 .. |external_flash_size| replace:: external flash memory with minimum 4MB
+
+.. |application_sample_definition| replace:: For simplicity, this guide will refer to both :ref:`samples<samples>` and :ref:`applications<applications>` as "applications".


### PR DESCRIPTION
ref: NCSDK-10594

For the Getting Started sections, use "application" to refer to both
samples and applications for a more unified use of terminology.

Signed-off-by: Deidre Casey <deidre.casey@nordicsemi.no>