### PR TITLE
Bluetooth: Mesh: Lightness: Add bt_mesh_ prefix to internal API

### DIFF
--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -93,8 +93,8 @@ static void ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	light.transition = model_transition_get(srv->model, &transition, buf);
 	temp.transition = light.transition;
 
-	lightness_srv_disable_control(&srv->lightness_srv);
-	lightness_srv_change_lvl(&srv->lightness_srv, ctx, &light, &light_rsp, true);
+	bt_mesh_lightness_srv_disable_control(&srv->lightness_srv);
+	bt_mesh_lightness_srv_change_lvl(&srv->lightness_srv, ctx, &light, &light_rsp, true);
 	bt_mesh_light_temp_srv_set(&srv->temp_srv, ctx, &temp, &temp_rsp);
 
 	status.current_temp = temp_rsp.current.temp;
@@ -256,7 +256,7 @@ static void default_set(struct bt_mesh_model *model,
 		return;
 	}
 
-	lightness_srv_default_set(&srv->lightness_srv, ctx, light);
+	bt_mesh_lightness_srv_default_set(&srv->lightness_srv, ctx, light);
 	bt_mesh_light_temp_srv_default_set(&srv->temp_srv, ctx, &temp);
 
 	(void)bt_mesh_light_ctl_default_pub(srv, NULL);
@@ -386,7 +386,8 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 		.transition = transition,
 	};
 
-	lightness_srv_change_lvl(&srv->lightness_srv, NULL, &light, &dummy_light_status, false);
+	bt_mesh_lightness_srv_change_lvl(&srv->lightness_srv, NULL, &light, &dummy_light_status,
+					 false);
 }
 
 static void scene_recall_complete(struct bt_mesh_model *model)

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -182,7 +182,7 @@ static void light_set(struct bt_mesh_light_ctrl_srv *srv, uint16_t lvl,
 	};
 	struct bt_mesh_lightness_status dummy;
 
-	lightness_srv_change_lvl(srv->lightness, NULL, &set, &dummy, true);
+	bt_mesh_lightness_srv_change_lvl(srv->lightness, NULL, &set, &dummy, true);
 }
 
 static uint32_t remaining_fade_time(struct bt_mesh_light_ctrl_srv *srv)
@@ -1472,7 +1472,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 
 		ctrl_disable(srv);
 		schedule_resume_timer(srv);
-		lightness_srv_change_lvl(srv->lightness, NULL, &set, &status, true);
+		bt_mesh_lightness_srv_change_lvl(srv->lightness, NULL, &set, &status, true);
 	}
 }
 
@@ -1585,7 +1585,7 @@ static int light_ctrl_srv_start(struct bt_mesh_model *model)
 				    FLAG_CTRL_SRV_MANUALLY_ENABLED)) {
 			ctrl_enable(srv);
 		} else {
-			lightness_on_power_up(srv->lightness);
+			bt_mesh_lightness_srv_on_power_up(srv->lightness);
 			ctrl_disable(srv);
 			schedule_resume_timer(srv);
 		}
@@ -1603,7 +1603,7 @@ static int light_ctrl_srv_start(struct bt_mesh_model *model)
 				    FLAG_CTRL_SRV_MANUALLY_ENABLED)) {
 			ctrl_enable(srv);
 		} else {
-			lightness_on_power_up(srv->lightness);
+			bt_mesh_lightness_srv_on_power_up(srv->lightness);
 			ctrl_disable(srv);
 			schedule_resume_timer(srv);
 		}
@@ -1619,7 +1619,7 @@ static int light_ctrl_srv_start(struct bt_mesh_model *model)
 			}
 		} else if (atomic_test_bit(&srv->lightness->flags,
 					   LIGHTNESS_SRV_FLAG_IS_ON)) {
-			lightness_on_power_up(srv->lightness);
+			bt_mesh_lightness_srv_on_power_up(srv->lightness);
 		}
 		break;
 	default:

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -128,8 +128,8 @@ static void hsl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 
 	bt_mesh_light_hue_srv_set(&srv->hue, ctx, &set.h, &hue);
 	bt_mesh_light_sat_srv_set(&srv->sat, ctx, &set.s, &sat);
-	lightness_srv_disable_control(&srv->lightness);
-	lightness_srv_change_lvl(&srv->lightness, ctx, &set.l, &lightness, true);
+	bt_mesh_lightness_srv_disable_control(&srv->lightness);
+	bt_mesh_lightness_srv_change_lvl(&srv->lightness, ctx, &set.l, &lightness, true);
 
 	srv->pub_pending = false;
 
@@ -215,7 +215,7 @@ static void default_set(struct bt_mesh_model *model,
 
 	light_hsl_buf_pull(buf, &val);
 
-	lightness_srv_default_set(&srv->lightness, ctx, val.lightness);
+	bt_mesh_lightness_srv_default_set(&srv->lightness, ctx, val.lightness);
 	bt_mesh_light_hue_srv_default_set(&srv->hue, ctx, val.hue);
 	bt_mesh_light_sat_srv_default_set(&srv->sat, ctx, val.saturation);
 }
@@ -441,7 +441,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 		.transition = transition,
 	};
 
-	lightness_srv_change_lvl(&srv->lightness, NULL, &light_set, &light_status, false);
+	bt_mesh_lightness_srv_change_lvl(&srv->lightness, NULL, &light_set, &light_status, false);
 }
 
 static void scene_recall_complete(struct bt_mesh_model *model)

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -135,8 +135,8 @@ static void xyl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	set.transition = model_transition_get(srv->model, &transition, buf);
 	light.transition = set.transition;
 
-	lightness_srv_disable_control(&srv->lightness_srv);
-	lightness_srv_change_lvl(&srv->lightness_srv, ctx, &light, &light_rsp, true);
+	bt_mesh_lightness_srv_disable_control(&srv->lightness_srv);
+	bt_mesh_lightness_srv_change_lvl(&srv->lightness_srv, ctx, &light, &light_rsp, true);
 	srv->handlers->xy_set(srv, ctx, &set, &status);
 	srv->xy_last.x = set.params.x;
 	srv->xy_last.y = set.params.y;
@@ -244,7 +244,7 @@ static void default_set(struct bt_mesh_model *model,
 
 	srv->xy_default.x = net_buf_simple_pull_le16(buf);
 	srv->xy_default.y = net_buf_simple_pull_le16(buf);
-	lightness_srv_default_set(&srv->lightness_srv, ctx, light);
+	bt_mesh_lightness_srv_default_set(&srv->lightness_srv, ctx, light);
 	store_state(srv);
 
 	if (srv->handlers->default_update) {
@@ -491,7 +491,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 		.transition = transition,
 	};
 
-	lightness_srv_change_lvl(&srv->lightness_srv, NULL, &light, &light_status, false);
+	bt_mesh_lightness_srv_change_lvl(&srv->lightness_srv, NULL, &light, &light_status, false);
 }
 
 static void scene_recall_complete(struct bt_mesh_model *model)

--- a/subsys/bluetooth/mesh/lightness_cli.c
+++ b/subsys/bluetooth/mesh/lightness_cli.c
@@ -184,9 +184,9 @@ const struct bt_mesh_model_cb _bt_mesh_lightness_cli_cb = {
 	.reset = bt_mesh_lvl_cli_reset,
 };
 
-int lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
-			    struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
-			    struct bt_mesh_lightness_status *rsp)
+int bt_mesh_lightness_cli_light_repr_get(struct bt_mesh_lightness_cli *cli,
+					 struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
+					 struct bt_mesh_lightness_status *rsp)
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHTNESS_OP_GET,
 				 BT_MESH_LIGHTNESS_MSG_LEN_GET);
@@ -197,10 +197,10 @@ int lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
 			       op_get(LIGHTNESS_OP_TYPE_STATUS, repr), rsp);
 }
 
-int lightness_cli_light_set(struct bt_mesh_lightness_cli *cli,
-			    struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
-			    const struct bt_mesh_lightness_set *set,
-			    struct bt_mesh_lightness_status *rsp)
+int bt_mesh_lightness_cli_light_repr_set(struct bt_mesh_lightness_cli *cli,
+					 struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
+					 const struct bt_mesh_lightness_set *set,
+					 struct bt_mesh_lightness_status *rsp)
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHTNESS_OP_SET,
 				 BT_MESH_LIGHTNESS_MSG_MAXLEN_SET);
@@ -217,10 +217,9 @@ int lightness_cli_light_set(struct bt_mesh_lightness_cli *cli,
 			       op_get(LIGHTNESS_OP_TYPE_STATUS, repr), rsp);
 }
 
-int lightness_cli_light_set_unack(struct bt_mesh_lightness_cli *cli,
-				  struct bt_mesh_msg_ctx *ctx,
-				  enum light_repr repr,
-				  const struct bt_mesh_lightness_set *set)
+int bt_mesh_lightness_cli_light_repr_set_unack(struct bt_mesh_lightness_cli *cli,
+					       struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
+					       const struct bt_mesh_lightness_set *set)
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHTNESS_OP_SET_UNACK,
 				 BT_MESH_LIGHTNESS_MSG_MAXLEN_SET);
@@ -239,7 +238,7 @@ int bt_mesh_lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct bt_mesh_lightness_status *rsp)
 {
-	return lightness_cli_light_get(cli, ctx, LIGHT_USER_REPR, rsp);
+	return bt_mesh_lightness_cli_light_repr_get(cli, ctx, LIGHT_USER_REPR, rsp);
 }
 
 int bt_mesh_lightness_cli_light_set(struct bt_mesh_lightness_cli *cli,
@@ -247,14 +246,14 @@ int bt_mesh_lightness_cli_light_set(struct bt_mesh_lightness_cli *cli,
 				    const struct bt_mesh_lightness_set *set,
 				    struct bt_mesh_lightness_status *rsp)
 {
-	return lightness_cli_light_set(cli, ctx, LIGHT_USER_REPR, set, rsp);
+	return bt_mesh_lightness_cli_light_repr_set(cli, ctx, LIGHT_USER_REPR, set, rsp);
 }
 
 int bt_mesh_lightness_cli_light_set_unack(
 	struct bt_mesh_lightness_cli *cli, struct bt_mesh_msg_ctx *ctx,
 	const struct bt_mesh_lightness_set *set)
 {
-	return lightness_cli_light_set_unack(cli, ctx, LIGHT_USER_REPR, set);
+	return bt_mesh_lightness_cli_light_repr_set_unack(cli, ctx, LIGHT_USER_REPR, set);
 }
 
 int bt_mesh_lightness_cli_range_get(struct bt_mesh_lightness_cli *cli,

--- a/subsys/bluetooth/mesh/lightness_internal.h
+++ b/subsys/bluetooth/mesh/lightness_internal.h
@@ -141,33 +141,31 @@ static inline uint16_t light_to_repr(uint16_t light, enum light_repr repr)
 struct bt_mesh_lightness_srv;
 struct bt_mesh_lightness_cli;
 
-void lightness_srv_disable_control(struct bt_mesh_lightness_srv *srv);
+void bt_mesh_lightness_srv_disable_control(struct bt_mesh_lightness_srv *srv);
 
-void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct bt_mesh_lightness_set *set,
-			      struct bt_mesh_lightness_status *status,
-			      bool publish);
+void bt_mesh_lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
+				      struct bt_mesh_msg_ctx *ctx,
+				      struct bt_mesh_lightness_set *set,
+				      struct bt_mesh_lightness_status *status, bool publish);
 
 /* For testing purposes */
-int lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
-			    struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
-			    struct bt_mesh_lightness_status *rsp);
+int bt_mesh_lightness_cli_light_repr_get(struct bt_mesh_lightness_cli *cli,
+					 struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
+					 struct bt_mesh_lightness_status *rsp);
 
-int lightness_cli_light_set(struct bt_mesh_lightness_cli *cli,
-			    struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
-			    const struct bt_mesh_lightness_set *set,
-			    struct bt_mesh_lightness_status *rsp);
+int bt_mesh_lightness_cli_light_repr_set(struct bt_mesh_lightness_cli *cli,
+					 struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
+					 const struct bt_mesh_lightness_set *set,
+					 struct bt_mesh_lightness_status *rsp);
 
-int lightness_cli_light_set_unack(struct bt_mesh_lightness_cli *cli,
-				  struct bt_mesh_msg_ctx *ctx,
-				  enum light_repr repr,
-				  const struct bt_mesh_lightness_set *set);
+int bt_mesh_lightness_cli_light_repr_set_unack(struct bt_mesh_lightness_cli *cli,
+					       struct bt_mesh_msg_ctx *ctx, enum light_repr repr,
+					       const struct bt_mesh_lightness_set *set);
 
-void lightness_srv_default_set(struct bt_mesh_lightness_srv *srv,
-			       struct bt_mesh_msg_ctx *ctx, uint16_t set);
+void bt_mesh_lightness_srv_default_set(struct bt_mesh_lightness_srv *srv,
+				       struct bt_mesh_msg_ctx *ctx, uint16_t set);
 
-int lightness_on_power_up(struct bt_mesh_lightness_srv *srv);
+int bt_mesh_lightness_srv_on_power_up(struct bt_mesh_lightness_srv *srv);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -165,7 +165,7 @@ static void handle_linear_get(struct bt_mesh_model *model,
 	handle_light_get(model, ctx, buf, LINEAR);
 }
 
-void lightness_srv_disable_control(struct bt_mesh_lightness_srv *srv)
+void bt_mesh_lightness_srv_disable_control(struct bt_mesh_lightness_srv *srv)
 {
 #if defined(CONFIG_BT_MESH_LIGHT_CTRL_SRV)
 	if (srv->ctrl) {
@@ -174,11 +174,10 @@ void lightness_srv_disable_control(struct bt_mesh_lightness_srv *srv)
 #endif
 }
 
-void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
-			      struct bt_mesh_msg_ctx *ctx,
-			      struct bt_mesh_lightness_set *set,
-			      struct bt_mesh_lightness_status *status,
-			      bool publish)
+void bt_mesh_lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
+				      struct bt_mesh_msg_ctx *ctx,
+				      struct bt_mesh_lightness_set *set,
+				      struct bt_mesh_lightness_status *status, bool publish)
 {
 	bool state_change =
 		(atomic_test_bit(&srv->flags, LIGHTNESS_SRV_FLAG_IS_ON) ==
@@ -245,8 +244,8 @@ static void lightness_set(struct bt_mesh_model *model,
 		/* According to the Mesh Model Specification section 6.2.3.1,
 		 * manual changes to the lightness should disable control.
 		 */
-		lightness_srv_disable_control(srv);
-		lightness_srv_change_lvl(srv, ctx, &set, &status, true);
+		bt_mesh_lightness_srv_disable_control(srv);
+		bt_mesh_lightness_srv_change_lvl(srv, ctx, &set, &status, true);
 
 		if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
 			bt_mesh_scene_invalidate(srv->lightness_model);
@@ -325,8 +324,8 @@ static void handle_default_get(struct bt_mesh_model *model,
 	bt_mesh_model_send(model, ctx, &rsp, NULL, NULL);
 }
 
-void lightness_srv_default_set(struct bt_mesh_lightness_srv *srv,
-			       struct bt_mesh_msg_ctx *ctx, uint16_t set)
+void bt_mesh_lightness_srv_default_set(struct bt_mesh_lightness_srv *srv,
+				       struct bt_mesh_msg_ctx *ctx, uint16_t set)
 {
 	uint16_t old = srv->default_light;
 
@@ -354,7 +353,7 @@ static void set_default(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx
 	struct bt_mesh_lightness_srv *srv = model->user_data;
 	uint16_t new = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
 
-	lightness_srv_default_set(srv, ctx, new);
+	bt_mesh_lightness_srv_default_set(srv, ctx, new);
 	if (!ack) {
 		return;
 	}
@@ -569,8 +568,8 @@ static void lvl_set(struct bt_mesh_lvl_srv *lvl_srv,
 		/* According to the Mesh Model Specification section 6.2.3.1,
 		 * manual changes to the lightness should disable control.
 		 */
-		lightness_srv_disable_control(srv);
-		lightness_srv_change_lvl(srv, ctx, &set, &status, true);
+		bt_mesh_lightness_srv_disable_control(srv);
+		bt_mesh_lightness_srv_change_lvl(srv, ctx, &set, &status, true);
 	} else if (rsp) {
 		srv->handlers->light_get(srv, NULL, &status);
 	}
@@ -623,8 +622,8 @@ static void lvl_delta_set(struct bt_mesh_lvl_srv *lvl_srv,
 	/* According to the Mesh Model Specification section 6.2.3.1,
 	 * manual changes to the lightness should disable control.
 	 */
-	lightness_srv_disable_control(srv);
-	lightness_srv_change_lvl(srv, ctx, &set, &status, true);
+	bt_mesh_lightness_srv_disable_control(srv);
+	bt_mesh_lightness_srv_change_lvl(srv, ctx, &set, &status, true);
 
 	/* Override "last" value to be able to make corrective deltas when
 	 * new_transaction is false. Note that the "last" value in persistent
@@ -696,8 +695,8 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 	/* According to the Mesh Model Specification section 6.2.3.1,
 	 * manual changes to the lightness should disable control.
 	 */
-	lightness_srv_disable_control(srv);
-	lightness_srv_change_lvl(srv, ctx, &set, &status, true);
+	bt_mesh_lightness_srv_disable_control(srv);
+	bt_mesh_lightness_srv_change_lvl(srv, ctx, &set, &status, true);
 
 	if (rsp) {
 		rsp->current = LIGHT_TO_LVL(status.current);
@@ -738,8 +737,8 @@ static void onoff_set(struct bt_mesh_onoff_srv *onoff_srv,
 	/* According to the Mesh Model Specification section 6.2.3.1,
 	 * manual changes to the lightness should disable control.
 	 */
-	lightness_srv_disable_control(srv);
-	lightness_srv_change_lvl(srv, ctx, &set, &status, true);
+	bt_mesh_lightness_srv_disable_control(srv);
+	bt_mesh_lightness_srv_change_lvl(srv, ctx, &set, &status, true);
 
 	if (rsp) {
 		rsp->present_on_off = (status.current > 0);
@@ -811,7 +810,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 		.transition = transition,
 	};
 
-	lightness_srv_change_lvl(srv, NULL, &set, &dummy_status, false);
+	bt_mesh_lightness_srv_change_lvl(srv, NULL, &set, &dummy_status, false);
 }
 
 static void scene_recall_complete(struct bt_mesh_model *model)
@@ -910,7 +909,7 @@ static int bt_mesh_lightness_srv_settings_set(struct bt_mesh_model *model,
 }
 #endif
 
-int lightness_on_power_up(struct bt_mesh_lightness_srv *srv)
+int bt_mesh_lightness_srv_on_power_up(struct bt_mesh_lightness_srv *srv)
 {
 	struct bt_mesh_lightness_status dummy = { 0 };
 	struct bt_mesh_model_transition transition = {
@@ -939,7 +938,7 @@ int lightness_on_power_up(struct bt_mesh_lightness_srv *srv)
 	BT_DBG("Loading POnOff: %u -> %u [%u ms]", srv->ponoff.on_power_up,
 	       set.lvl, transition.time);
 
-	lightness_srv_change_lvl(srv, NULL, &set, &dummy, true);
+	bt_mesh_lightness_srv_change_lvl(srv, NULL, &set, &dummy, true);
 	return 0;
 }
 
@@ -956,7 +955,7 @@ static int bt_mesh_lightness_srv_start(struct bt_mesh_model *model)
 		return 0;
 	}
 
-	return lightness_on_power_up(srv);
+	return bt_mesh_lightness_srv_on_power_up(srv);
 }
 #endif
 

--- a/tests/bluetooth/tester/src/mmdl.c
+++ b/tests/bluetooth/tester/src/mmdl.c
@@ -2610,7 +2610,7 @@ static void light_lightness_linear_get(uint8_t *data, uint16_t len)
 	ctx.addr = model_bound->addr;
 	ctx.app_idx = model_bound->appkey_idx;
 
-	err = lightness_cli_light_get(&lightness_cli, &ctx, LINEAR, &status);
+	err = bt_mesh_lightness_cli_light_get(&lightness_cli, &ctx, LINEAR, &status);
 	if (err) {
 		LOG_ERR("err=%d", err);
 		goto fail;
@@ -2673,7 +2673,7 @@ static void light_lightness_linear_set(uint8_t *data, uint16_t len)
 	}
 
 	if (cmd->ack) {
-		err = lightness_cli_light_set(&lightness_cli, &ctx, LINEAR,
+		err = bt_mesh_lightness_cli_light_set(&lightness_cli, &ctx, LINEAR,
 					      &set, &status);
 
 		current = light_to_repr(status.current, LINEAR);
@@ -2685,7 +2685,7 @@ static void light_lightness_linear_set(uint8_t *data, uint16_t len)
 		net_buf_simple_add_le32(buf, status.remaining_time);
 
 	} else {
-		err = lightness_cli_light_set_unack(&lightness_cli, &ctx,
+		err = bt_mesh_lightness_cli_light_set_unack(&lightness_cli, &ctx,
 						    LINEAR, &set);
 	}
 	if (err) {

--- a/tests/subsys/bluetooth/mesh/light_ctrl/src/main.c
+++ b/tests/subsys/bluetooth/mesh/light_ctrl/src/main.c
@@ -44,7 +44,7 @@ static struct bt_mesh_model mock_ligth_ctrl_model = {
 	.elem_idx = 1
 };
 
-void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
+void bt_mesh_lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct bt_mesh_lightness_set *set,
 			      struct bt_mesh_lightness_status *status,
@@ -59,7 +59,7 @@ void lightness_srv_change_lvl(struct bt_mesh_lightness_srv *srv,
 	zassert_true(publish, "Publication not done");
 }
 
-int lightness_on_power_up(struct bt_mesh_lightness_srv *srv)
+int bt_mesh_lightness_srv_on_power_up(struct bt_mesh_lightness_srv *srv)
 {
 	zassert_not_null(srv, "Context was null");
 	return 0;


### PR DESCRIPTION
Prefixes lightness internal functions with global linkage with bt_mesh_
to avoid breaking out of the mesh stack namespace.

Even though this header isn't exposed to the application, the linker
will still treat the non-static functions as global symbols, and they
may conflict with application functions of the same name.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>