### PR TITLE
application: serial_lte_modem: Add option CONFIG_SLM_CONFIRM_XSLEEP

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -27,6 +27,9 @@ config SLM_AT_MAX_PARAM
 config SLM_NATIVE_TLS
 	bool "Use Zephyr mbedTLS"
 
+config SLM_CONFIRM_XSLEEP
+	bool "Send OK confirmation after the AT#XSLEEP=... command"
+
 #
 # external XTAL for UART
 #

--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -149,7 +149,7 @@ The default value is 0.
 Response syntax
 ~~~~~~~~~~~~~~~
 
-There is no response:
+There is no ``OK`` response on this command, unless the :option:`CONFIG_SLM_CONFIRM_XSLEEP` option is enabled:
 
 * In case of Idle, it will exit by GPIO.
 * In case of Sleep, it will wake up by GPIO.

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -147,6 +147,12 @@ Check and configure the following configuration options for the sample:
 
    This option is selected by default.
 
+.. option:: CONFIG_SLM_CONFIRM_XSLEEP - Send response on sleep command
+
+   This option makes nRF9160 respond with the `OK` message to the `AT#XSLEEP=...` command.
+
+   This option is not selected by default.
+
 .. option:: CONFIG_SLM_START_SLEEP - Enter sleep on startup
 
    This option makes nRF9160 enter deep sleep after startup.

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -149,7 +149,7 @@ Check and configure the following configuration options for the sample:
 
 .. option:: CONFIG_SLM_CONFIRM_XSLEEP - Send response on sleep command
 
-   This option makes nRF9160 respond with the `OK` message to the `AT#XSLEEP=...` command.
+   This option makes nRF9160 respond with the ``OK`` message to the ``AT#XSLEEP=...`` command.
 
    This option is not selected by default.
 

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -122,6 +122,9 @@ static int handle_at_slmver(enum at_cmd_type type)
 static int handle_at_sleep(enum at_cmd_type type)
 {
 	int ret = -EINVAL;
+#if defined(CONFIG_SLM_CONFIRM_XSLEEP)
+	char ok_str[] = "\r\nOK\r\n";
+#endif
 
 	if (type == AT_CMD_TYPE_SET_COMMAND) {
 		uint16_t shutdown_mode = SHUTDOWN_MODE_IDLE;
@@ -133,10 +136,18 @@ static int handle_at_sleep(enum at_cmd_type type)
 			}
 		}
 		if (shutdown_mode == SHUTDOWN_MODE_IDLE) {
+#if defined(CONFIG_SLM_CONFIRM_XSLEEP)
+			rsp_send(ok_str, strlen(ok_str));
+			k_sleep(K_MSEC(50));
+#endif
 			slm_at_host_uninit();
 			enter_idle(true);
-			ret = -ESHUTDOWN; /*Will send no "OK"*/
+			ret = -ESHUTDOWN;
 		} else if (shutdown_mode == SHUTDOWN_MODE_SLEEP) {
+#if defined(CONFIG_SLM_CONFIRM_XSLEEP)
+			rsp_send(ok_str, strlen(ok_str));
+			k_sleep(K_MSEC(50));
+#endif
 #if defined(CONFIG_SLM_GPIO_WAKEUP)
 			slm_at_host_uninit();
 			modem_power_off();
@@ -147,10 +158,14 @@ static int handle_at_sleep(enum at_cmd_type type)
 			ret = -EINVAL;
 #endif
 		} else if (shutdown_mode == SHUTDOWN_MODE_UART) {
+#if defined(CONFIG_SLM_CONFIRM_XSLEEP)
+			rsp_send(ok_str, strlen(ok_str));
+			k_sleep(K_MSEC(50));
+#endif
 			ret = poweroff_uart();
 			if (ret == 0) {
 				enter_idle(false);
-				ret = -ESHUTDOWN; /*Will send no "OK"*/
+				ret = -ESHUTDOWN;
 			}
 		} else {
 			LOG_ERR("AT parameter error");


### PR DESCRIPTION
This Kconfig option enables `OK` response on the `AT#XSLEEP` command.