### PR TITLE
zigbee: Remove address shift in flash for MBR

### DIFF
--- a/samples/zigbee/ncp/configuration/nrf52840dongle_nrf52840/pm_static.yml
+++ b/samples/zigbee/ncp/configuration/nrf52840dongle_nrf52840/pm_static.yml
@@ -1,17 +1,10 @@
-# Flash reserved for MBR
 EMPTY_0:
-  address: 0x00000
-  end_address: 0x01000
-  region: flash_primary
-  size: 0x1000
-# Flash reserved for nRF5 Bootloader
-EMPTY_1:
   address: 0x0e0000
   end_address: 0x100000
   region: flash_primary
   size: 0x20000
 # SRAM reserved to be used by the nRF5 Bootloader
-EMPTY_2:
+EMPTY_1:
   address: 0x20000000
   end_address: 0x20000400
   region: sram_primary


### PR DESCRIPTION
In case of nrf52840dongle it is no longer required to move the start address by 0x1000.
The flash address adjustment is automatically handled after changes made in the following PR: https://github.com/nrfconnect/sdk-nrf/pull/5039

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>