### PR TITLE
samples: bluetooth: add integration platforms to sample.yaml

### DIFF
--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -4,10 +4,20 @@ sample:
 tests:
   samples.bluetooth.central_bas:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
     harness: bluetooth
     tags: bluetooth
   samples.bluetooth.central_bas.build:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -4,10 +4,20 @@ sample:
 tests:
   samples.bluetooth.central_hids:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
     harness: bluetooth
     tags: bluetooth
   samples.bluetooth.central_hids.build:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hr_coded/sample.yaml
+++ b/samples/bluetooth/central_hr_coded/sample.yaml
@@ -5,4 +5,7 @@ tests:
   samples.bluetooth.central_hr_coded:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/central_nfc_pairing/sample.yaml
@@ -5,4 +5,8 @@ tests:
   samples.bluetooth.central_nfc_pairing:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_smp_client/sample.yaml
+++ b/samples/bluetooth/central_smp_client/sample.yaml
@@ -4,10 +4,20 @@ sample:
 tests:
   samples.bluetooth.central_dfu_smp:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
     harness: bluetooth
     tags: bluetooth
   samples.bluetooth.central_dfu_smp.build:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -4,6 +4,12 @@ sample:
 tests:
   samples.bluetooth.central_uart:
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -5,4 +5,7 @@ tests:
   samples.bluetooth.direct_test_mode:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpunet nrf21540dk_nrf52840
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+      - nrf21540dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_ancs_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ancs_client/sample.yaml
@@ -5,4 +5,9 @@ tests:
   samples.bluetooth.peripheral_ancs_client.build:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_bms/sample.yaml
+++ b/samples/bluetooth/peripheral_bms/sample.yaml
@@ -4,5 +4,9 @@ sample:
 tests:
   samples.bluetooth.peripheral_bms:
     build_only: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_cts_client/sample.yaml
+++ b/samples/bluetooth/peripheral_cts_client/sample.yaml
@@ -5,4 +5,9 @@ tests:
   samples.bluetooth.peripheral_cts_client.build:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_gatt_dm/sample.yaml
+++ b/samples/bluetooth/peripheral_gatt_dm/sample.yaml
@@ -6,4 +6,10 @@ tests:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -5,9 +5,17 @@ tests:
   samples.bluetooth.peripheral_hids_keyboard:
     harness: bluetooth
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
     tags: bluetooth
   samples.bluetooth.peripheral_hids_keyboard.build:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -5,9 +5,19 @@ tests:
   samples.bluetooth.peripheral_hids_mouse:
     harness: bluetooth
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
     tags: bluetooth
   samples.bluetooth.peripheral_hids_mouse.build:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hr_coded/sample.yaml
+++ b/samples/bluetooth/peripheral_hr_coded/sample.yaml
@@ -5,4 +5,7 @@ tests:
   samples.bluetooth.peripheral_hr_coded:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -4,12 +4,23 @@ sample:
 tests:
   samples.bluetooth.peripheral_lbs:
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns thingy53_nrf5340_cpuapp
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
+      - thingy53_nrf5340_cpuapp
     tags: bluetooth ci_build
-tests:
   samples.bluetooth.peripheral_lbs_minimal:
-    extra_args: OVERLAY_CONFIG=minimal.conf
+    extra_args: OVERLAY_CONFIG=prj_minimal.conf
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52810
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52810 nrf52840dk_nrf52811 nrf52833dk_nrf52820
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52810
+      - nrf52840dk_nrf52811
+      - nrf52833dk_nrf52820
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
@@ -5,4 +5,9 @@ tests:
   samples.bluetooth.peripheral_nfc_pairing:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -6,4 +6,20 @@ tests:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns thingy53_nrf5340_cpuapp
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
+      - thingy53_nrf5340_cpuapp
+    tags: bluetooth ci_build
+  samples.bluetooth.peripheral_uart_minimal:
+    extra_args: OVERLAY_CONFIG=prj_minimal.conf
+    build_only: true
+    platform_allow: nrf52dk_nrf52810 nrf52840dk_nrf52811 nrf52833dk_nrf52820
+    integration_platforms:
+      - nrf52dk_nrf52810
+      - nrf52840dk_nrf52811
+      - nrf52833dk_nrf52820
     tags: bluetooth ci_build

--- a/samples/bluetooth/rpc_host/sample.yaml
+++ b/samples/bluetooth/rpc_host/sample.yaml
@@ -5,4 +5,6 @@ tests:
   samples.bluetooth.rpc_host:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
     tags: bluetooth ci_build

--- a/samples/bluetooth/shell_bt_nus/sample.yaml
+++ b/samples/bluetooth/shell_bt_nus/sample.yaml
@@ -6,4 +6,10 @@ tests:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/throughput/sample.yaml
+++ b/samples/bluetooth/throughput/sample.yaml
@@ -4,6 +4,11 @@ sample:
 tests:
   samples.bluetooth.throughput:
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build


### PR DESCRIPTION
Adds integration_plaforms listings to bluetooth samples.
Updated list of platforms.

Ref: NCSDK-8508

Signed-off-by: Marcin Jeliński <marcin.jelinski@nordicsemi.no>