### PR TITLE
net: lib: nrf_cloud: cleanup MQTT msg ids

### DIFF
--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -18,16 +18,27 @@ extern "C" {
  * @{
  */
 
-#define DEFAULT_REPORT_ID		1
-#define NCT_CC_SUBSCRIBE_ID		1234
-#define CLOUD_STATE_REQ_ID		5678
-#define PAIRING_STATUS_REPORT_ID	7890
-#define NCT_DC_SUBSCRIBE_ID		8765
-#define NRF_CLOUD_FOTA_SUBSCRIBE_ID	8766
-#define NRF_CLOUD_FOTA_REQUEST_ID	8767
-#define NRF_CLOUD_FOTA_UPDATE_ID	8768
-#define NRF_CLOUD_FOTA_BLE_REQUEST_ID	8769
-#define NRF_CLOUD_FOTA_BLE_UPDATE_ID	8770
+/** @defgroup nrf_cloud_mqtt_msg_ids MQTT message IDs for nRF Cloud.
+ * @{
+ */
+#define NCT_MSG_ID_CC_SUB               100
+#define NCT_MSG_ID_DC_SUB               101
+#define NCT_MSG_ID_CG_SUB               102
+#define NCT_MSG_ID_FOTA_SUB             103
+#define NCT_MSG_ID_CC_UNSUB             150
+#define NCT_MSG_ID_DC_UNSUB             151
+#define NCT_MSG_ID_CG_UNSUB             152
+#define NCT_MSG_ID_FOTA_UNSUB           153
+#define NCT_MSG_ID_STATE_REQUEST        200
+#define NCT_MSG_ID_FOTA_REQUEST         201
+#define NCT_MSG_ID_FOTA_BLE_REQUEST     202
+#define NCT_MSG_ID_STATE_REPORT         300
+#define NCT_MSG_ID_PAIR_STATUS_REPORT   301
+#define NCT_MSG_ID_FOTA_REPORT          302
+#define NCT_MSG_ID_FOTA_BLE_REPORT      303
+#define NCT_MSG_ID_INCREMENT_BEGIN     1000
+#define NCT_MSG_ID_INCREMENT_END       0xFFFF /* MQTT message IDs are uint16_t */
+/** @} */
 
 #define NRF_CLOUD_SETTINGS_NAME "nrf_cloud"
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -516,7 +516,7 @@ int nrf_cloud_fota_subscribe(void)
 	struct mqtt_subscription_list sub_list = {
 		.list = sub_topics,
 		.list_count = ARRAY_SIZE(sub_topics),
-		.message_id = NRF_CLOUD_FOTA_SUBSCRIBE_ID
+		.message_id = NCT_MSG_ID_FOTA_SUB
 	};
 
 	for (int i = 0; i < sub_list.list_count; ++i) {
@@ -536,7 +536,7 @@ int nrf_cloud_fota_unsubscribe(void)
 	struct mqtt_subscription_list sub_list = {
 		.list = sub_topics,
 		.list_count = ARRAY_SIZE(sub_topics),
-		.message_id = NRF_CLOUD_FOTA_SUBSCRIBE_ID
+		.message_id = NCT_MSG_ID_FOTA_UNSUB
 	};
 
 	for (int i = 0; i < sub_list.list_count; ++i) {
@@ -1024,7 +1024,7 @@ static int send_job_update(struct nrf_cloud_fota_job *const job)
 
 	int ret;
 	struct mqtt_publish_param param = {
-		.message_id = NRF_CLOUD_FOTA_UPDATE_ID,
+		.message_id = NCT_MSG_ID_FOTA_REPORT,
 		.dup_flag = 0,
 		.retain_flag = 0,
 	};
@@ -1068,7 +1068,7 @@ int nrf_cloud_fota_update_check(void)
 	}
 
 	struct mqtt_publish_param param = {
-		.message_id = NRF_CLOUD_FOTA_REQUEST_ID,
+		.message_id = NCT_MSG_ID_FOTA_REQUEST,
 		.dup_flag = 0,
 		.retain_flag = 0,
 	};
@@ -1200,8 +1200,7 @@ int nrf_cloud_fota_mqtt_evt_handler(const struct mqtt_evt *evt)
 	}
 	case MQTT_EVT_SUBACK:
 	{
-		if (evt->param.suback.message_id !=
-		    NRF_CLOUD_FOTA_SUBSCRIBE_ID) {
+		if (evt->param.suback.message_id != NCT_MSG_ID_FOTA_SUB) {
 			return 1;
 		}
 		LOG_DBG("MQTT_EVT_SUBACK");
@@ -1212,8 +1211,7 @@ int nrf_cloud_fota_mqtt_evt_handler(const struct mqtt_evt *evt)
 	}
 	case MQTT_EVT_UNSUBACK:
 	{
-		if (evt->param.unsuback.message_id !=
-		    NRF_CLOUD_FOTA_SUBSCRIBE_ID) {
+		if (evt->param.unsuback.message_id != NCT_MSG_ID_FOTA_UNSUB) {
 			return 1;
 		}
 		LOG_DBG("MQTT_EVT_UNSUBACK");
@@ -1224,11 +1222,11 @@ int nrf_cloud_fota_mqtt_evt_handler(const struct mqtt_evt *evt)
 		bool do_update_check = false;
 
 		switch (evt->param.puback.message_id) {
-		case NRF_CLOUD_FOTA_UPDATE_ID:
+		case NCT_MSG_ID_FOTA_REPORT:
 			do_update_check = true;
-		case NRF_CLOUD_FOTA_REQUEST_ID:
-		case NRF_CLOUD_FOTA_BLE_UPDATE_ID:
-		case NRF_CLOUD_FOTA_BLE_REQUEST_ID:
+		case NCT_MSG_ID_FOTA_REQUEST:
+		case NCT_MSG_ID_FOTA_BLE_REPORT:
+		case NCT_MSG_ID_FOTA_BLE_REQUEST:
 			break;
 		default:
 			return 1;
@@ -1300,7 +1298,7 @@ int nrf_cloud_fota_ble_update_check(const bt_addr_t *const ble_id)
 	cJSON *array;
 	char ble_id_str[BT_ADDR_LE_STR_LEN];
 	struct mqtt_publish_param param = {
-		.message_id = NRF_CLOUD_FOTA_BLE_REQUEST_ID,
+		.message_id = NCT_MSG_ID_FOTA_BLE_REQUEST,
 		.dup_flag = 0,
 		.retain_flag = 0,
 	};
@@ -1339,7 +1337,7 @@ int nrf_cloud_fota_ble_job_update(const struct nrf_cloud_fota_ble_job
 	cJSON *array;
 	char ble_id_str[BT_ADDR_LE_STR_LEN];
 	struct mqtt_publish_param param = {
-		.message_id = NRF_CLOUD_FOTA_BLE_UPDATE_ID,
+		.message_id = NCT_MSG_ID_FOTA_BLE_REPORT,
 		.dup_flag = 0,
 		.retain_flag = 0,
 	};

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -139,7 +139,7 @@ static int state_ua_pin_wait(void)
 	int err;
 	struct nct_cc_data msg = {
 		.opcode = NCT_CC_OPCODE_UPDATE_REQ,
-		.id = DEFAULT_REPORT_ID,
+		.id = NCT_MSG_ID_STATE_REPORT,
 	};
 
 	/* Publish report to the cloud on current status. */
@@ -173,7 +173,7 @@ static int handle_device_config_update(const struct nct_evt *const evt,
 	int err;
 	struct nct_cc_data msg = {
 		.opcode = NCT_CC_OPCODE_UPDATE_REQ,
-		.id = DEFAULT_REPORT_ID,
+		.id = NCT_MSG_ID_STATE_REPORT,
 	};
 
 	struct nrf_cloud_evt cloud_evt = {
@@ -221,7 +221,7 @@ static int state_ua_pin_complete(void)
 	int err;
 	struct nct_cc_data msg = {
 		.opcode = NCT_CC_OPCODE_UPDATE_REQ,
-		.id = PAIRING_STATUS_REPORT_ID,
+		.id = NCT_MSG_ID_PAIR_STATUS_REPORT,
 	};
 
 	err = nrf_cloud_encode_state(STATE_UA_PIN_COMPLETE, &msg.data);
@@ -321,7 +321,7 @@ static int cc_connection_handler(const struct nct_evt *nct_evt)
 	 */
 	static const struct nct_cc_data get_request = {
 		.opcode = NCT_CC_OPCODE_GET_REQ,
-		.id = CLOUD_STATE_REQ_ID,
+		.id = NCT_MSG_ID_STATE_REQUEST,
 	};
 
 	int err;
@@ -422,13 +422,13 @@ static int cc_tx_ack_handler(const struct nct_evt *nct_evt)
 {
 	int err;
 
-	if (nct_evt->param.data_id == CLOUD_STATE_REQ_ID) {
+	if (nct_evt->param.data_id == NCT_MSG_ID_STATE_REQUEST) {
 		nfsm_set_current_state_and_notify(STATE_CLOUD_STATE_REQUESTED,
 						  NULL);
 		return 0;
 	}
 
-	if (nct_evt->param.data_id == PAIRING_STATUS_REPORT_ID) {
+	if (nct_evt->param.data_id == NCT_MSG_ID_PAIR_STATUS_REPORT) {
 		if (!persistent_session) {
 			err = nct_dc_connect();
 			if (err) {
@@ -452,7 +452,7 @@ static int cc_tx_ack_handler(const struct nct_evt *nct_evt)
 
 static int cc_tx_ack_in_state_requested_handler(const struct nct_evt *nct_evt)
 {
-	if (nct_evt->param.data_id == CLOUD_STATE_REQ_ID) {
+	if (nct_evt->param.data_id == NCT_MSG_ID_STATE_REQUEST) {
 		nfsm_set_current_state_and_notify(STATE_CLOUD_STATE_REQUESTED,
 						  NULL);
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -115,7 +115,6 @@ static struct nct {
 	struct mqtt_utf8 dc_tx_endp;
 	struct mqtt_utf8 dc_rx_endp;
 	struct mqtt_utf8 dc_m_endp;
-	struct mqtt_utf8 job_status_endp;
 	uint16_t message_id;
 	uint8_t rx_buf[CONFIG_NRF_CLOUD_MQTT_MESSAGE_BUFFER_LEN];
 	uint8_t tx_buf[CONFIG_NRF_CLOUD_MQTT_MESSAGE_BUFFER_LEN];
@@ -144,9 +143,6 @@ static void dc_endpoint_reset(void)
 
 	nct.dc_m_endp.utf8 = NULL;
 	nct.dc_m_endp.size = 0;
-
-	nct.job_status_endp.utf8 = NULL;
-	nct.job_status_endp.size = 0;
 }
 
 /* Get the next unused message id. */
@@ -168,9 +164,6 @@ static uint16_t get_next_message_id(void)
  * nct_dc_endpoint_set() caller gets the buffers from
  * json_decode_and_alloc(), which uses nrf_cloud_malloc() to call
  * k_malloc().
- *
- * The job_status_endp.utf8 buffer is allocated in this file as
- * non-const, so casting away const here is safe.
  */
 static void dc_endpoint_free(void)
 {
@@ -182,9 +175,6 @@ static void dc_endpoint_free(void)
 	}
 	if (nct.dc_m_endp.utf8 != NULL) {
 		nrf_cloud_free((void *)nct.dc_m_endp.utf8);
-	}
-	if (nct.job_status_endp.utf8 != NULL) {
-		nrf_cloud_free((void *)nct.job_status_endp.utf8);
 	}
 	dc_endpoint_reset();
 #if defined(CONFIG_NRF_CLOUD_FOTA)


### PR DESCRIPTION
cleaned up messy msg id names/values.
also MQTT msg ids are uint16_t.

more cleanup: removed  unused variable `job_status_endp`

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>