### PR TITLE
doc: add a note about configuration to the multicell location sample

### DIFF
--- a/samples/nrf9160/multicell_location/README.rst
+++ b/samples/nrf9160/multicell_location/README.rst
@@ -126,6 +126,10 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nrf9160/multicell_location`
 
+.. note::
+
+   Before building the sample, you must configure a location provider and an API key as instructed in :ref:`lib_multicell_location`.
+
 .. include:: /includes/build_and_run_nrf9160.txt
 
 


### PR DESCRIPTION
As requested, added a note about the need for configuration.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>