### PR TITLE
application: serial_lte_modem: Add AT response for #XSLEEP

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -73,20 +73,10 @@ endchoice
 #
 # GPIO wakeup
 #
-config SLM_GPIO_WAKEUP
-	bool "Support of GPIO wakeup"
-	default y
-	help
-	  Enable GPIO wakeup on nRF9160 side.
-
-if SLM_GPIO_WAKEUP
-
 config SLM_START_SLEEP
 	bool "Enter sleep on startup"
 	help
 	  Put nRF9160 into deep sleep mode after startup.
-
-endif
 
 config SLM_INTERFACE_PIN
 	int "Interface GPIO to wake up or exit idle mode"

--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -125,59 +125,45 @@ Change the line ``status = "okay"`` to ``status = "disabled"`` and then save the
 Set command
 -----------
 
-The set command makes the nRF91 development kit go into idle or sleep mode.
+The set command makes the nRF91 development kit go into either idle or sleep mode, or it powers off the UART device.
 
 Syntax
 ~~~~~~
 
 ::
 
-   #XSLEEP[=<shutdown_mode>]
+   #XSLEEP=<shutdown_mode>
 
 The ``<shutdown_mode>`` parameter accepts only the following integer values:
 
 * ``0`` - Enter Idle.
   In this mode, the SLM service is terminated, but the LTE connection is maintained.
-  You can also use the syntax ``AT#XSLEEP``.
 * ``1`` - Enter Sleep.
   In this mode, both the SLM service and the LTE connection are terminated.
 * ``2`` - Power off UART.
   In this mode, both the SLM service and the LTE connection are maintained.
 
-The default value is 0.
-
-Response syntax
-~~~~~~~~~~~~~~~
-
-There is no response:
-
-* In case of Idle, it will exit by GPIO.
-* In case of Sleep, it will wake up by GPIO.
-* In case of UART power off, it will be powered on by GPIO or by SLM when needed.
+* In case of Idle, it will exit by interface GPIO.
+* In case of Sleep, it will wake up by interface GPIO.
+* In case of UART power off, UART will be powered on by interface GPIO or internally by SLM when needed.
 
 Examples
 ~~~~~~~~
 
 ::
 
-   AT#XSLEEP
-
-::
-
    AT#XSLEEP=0
+   OK
 
 ::
 
    AT#XSLEEP=1
+   OK
 
 ::
 
    AT#XSLEEP=2
-
-::
-
-   AT#XSLEEP?
-   ERROR
+   OK
 
 Read command
 ------------

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -25,13 +25,13 @@ The application supports the following development kit:
 Overview
 ********
 
-The nRF9160 SiP integrates both a full LTE modem and an application MCU, which enables you to run your LTE application directly on the nRF9160.
+The nRF9160 SiP integrates both a full LTE modem and an application MCU, enabling you to run your LTE application directly on the nRF9160.
 
 However, you might want to run your application on a different chip and use the nRF9160 only as a modem.
 For this use case, the serial LTE modem application provides an interface for controlling the LTE modem through AT commands.
 
-The proprietary AT commands that are specific to the serial LTE modem application are described in the :ref:`SLM_AT_intro` documentation.
-In addition to these proprietary AT commands, the application supports the nRF91 AT commands described in the `AT Commands Reference Guide`_.
+The proprietary AT commands specific to the serial LTE modem application are described in the :ref:`SLM_AT_intro` documentation.
+In addition to these, the application also supports the nRF91 AT commands described in the `AT Commands Reference Guide`_.
 
 Communicating with the modem
 ============================
@@ -53,7 +53,7 @@ Alternatively, you can use a terminal emulator like PuTTY to establish a termina
 See :ref:`putty` for instructions.
 
 .. note::
-   The default AT command terminator is carriage return and line feed (``\r\n``).
+   The default AT command terminator is a carriage return followed by a line feed (``\r\n``).
    LTE Link Monitor supports this format.
    When connecting with another terminal emulator, make sure that the configured AT command terminator corresponds to the line terminator of your terminal.
    You can change the termination mode in the :ref:`application configuration <slm_config>`.
@@ -98,7 +98,7 @@ UART configuration:
 * Operation mode: IRQ
 
 .. note::
-   The GPIO output level on nRF9160 side must be 3 V.
+   The GPIO output level on the nRF9160 side must be 3 V.
    You can set the VDD voltage with the **VDD IO** switch (**SW9**).
    See the `VDD supply rail section in the nRF9160 DK User Guide`_ for more information.
 
@@ -140,26 +140,16 @@ Check and configure the following configuration options for the sample:
    This option selects UART 2 for the UART connection.
    Select this option if you want to test the application with an external CPU.
 
-.. option:: CONFIG_SLM_GPIO_WAKEUP - Support of GPIO wakeup
-
-   This option enables using GPIO to wake up nRF9160 from deep sleep mode.
-   Select this option if you enable :option:`CONFIG_SLM_START_SLEEP` to put nRF9160 into deep sleep mode after startup.
-
-   This option is selected by default.
-
 .. option:: CONFIG_SLM_START_SLEEP - Enter sleep on startup
 
    This option makes nRF9160 enter deep sleep after startup.
 
    This option is not selected by default.
-   It requires :option:`CONFIG_SLM_GPIO_WAKEUP` to be selected.
 
-.. option:: CONFIG_SLM_INTERFACE_PIN - Interface GPIO to wake up or exit idle mode
+.. option:: CONFIG_SLM_INTERFACE_PIN - Interface GPIO to wake up from sleep or exit idle
 
    This option specifies which interface GPIO to use for exiting sleep or idle mode.
    By default, **P0.6** (Button 1 on the nRF9160 DK) is used when :option:`CONFIG_SLM_CONNECT_UART_0` is selected, and **P0.31** is used when when :option:`CONFIG_SLM_CONNECT_UART_2` is selected.
-
-   Note that when :option:`CONFIG_SLM_CONNECT_UART_0` is selected, Button 1 can be used to exit idle mode, but not to wake up from sleep mode.
 
 .. option:: CONFIG_SLM_SOCKET_RX_MAX - Maximum RX buffer size for receiving socket data
 
@@ -179,7 +169,7 @@ Check and configure the following configuration options for the sample:
 
 .. option:: CONFIG_SLM_CR_LF_TERMINATION - CR+LF termination
 
-   This option configures the application to accept AT commands ending with carriage return and line feed.
+   This option configures the application to accept AT commands ending with a carriage return followed by a line feed.
 
 .. option:: CONFIG_SLM_TCP_FILTER_SIZE - Size of IPv4 address allowlist
 
@@ -192,7 +182,7 @@ Check and configure the following configuration options for the sample:
 
 .. option:: CONFIG_SLM_SMS - SMS support in SLM
 
-   This option enables additional AT commands for using SMS service.
+   This option enables additional AT commands for using the SMS service.
 
 .. option:: CONFIG_SLM_GPS - GPS support in SLM
 
@@ -281,7 +271,7 @@ However, if you require customized TLS/DTLS features that are not supported by t
 The serial LTE modem application will then handle all secure sockets used in TCP/IP, TCP/IP proxy, and MQTT.
 
 If native TLS is enabled, the `Credential storage management %CMNG`_ command is overridden to map the :ref:`security tag <nrfxlib:security_tags>` from the serial LTE modem application to the modem.
-You must use the overridden AT%CMNG command to provision credentials to the modem.
+You must use the overridden AT%CMNG command to provision the credentials to the modem.
 Note that the serial LTE modem application supports security tags in the range of 0 - 214748364.
 
 The configuration options that are required to enable the native TLS socket are defined in the :file:`overlay-native_tls.conf` file.

--- a/applications/serial_lte_modem/doc/slm_testing.rst
+++ b/applications/serial_lte_modem/doc/slm_testing.rst
@@ -64,15 +64,16 @@ Complete the following steps to test the functionality provided by the :ref:`SLM
       #XSLEEP: (0,1,2)
       OK
 
-   ``AT#XSLEEP`` puts the kit in idle mode, and you can wake up by GPIO.
+   ``AT#XSLEEP=0`` puts the kit in idle mode.
+   You can exit idle by GPIO.
 
    Alternatively, you can use different modes for #XSLEEP:
 
    * ``AT#XSLEEP=1`` puts the kit in sleep mode.
-     If you are testing with :option:`CONFIG_SLM_GPIO_WAKEUP` enabled, you can wake up by GPIO.
+     You can wake it up by GPIO.
 
    * ``AT#XSLEEP=2`` powers off UART.
-     You can power on UART by GPIO.
+     You can power on UART again by GPIO.
 
 TCP/IP AT commands
 ******************
@@ -93,7 +94,7 @@ TCP client
          #XSOCKET: (0,1),(1,2),(0,1),<sec-tag>
          OK
 
-   #. Open a TCP socket, read information (handle, protocol, and role) about the open socket, and set the receive timeout of the open socket to 30 seconds.
+   #. Open a TCP socket, read the information (handle, protocol, and role) about the open socket, and set the receive timeout of the open socket to 30 seconds.
 
       .. parsed-literal::
          :class: highlight
@@ -110,7 +111,7 @@ TCP client
          OK
 
    #. Connect to a TCP server on a specified port.
-      Replace *example.com* with the host name or IPv4 address of a TCP server and *1234* with the corresponding port.
+      Replace *example.com* with the hostname or IPv4 address of a TCP server and *1234* with the corresponding port.
       Then read the connection status.
       ``1`` indicates that the connection is established.
 
@@ -135,7 +136,7 @@ TCP client
          OK
 
          **AT#XRECV**
-         PONG: b'Test TCP'
+         PONG: 'Test TCP'
          #XRECV: 17
          OK
 
@@ -185,7 +186,10 @@ TCP client
            Connection: close<CR><LF>
            <CR><LF>
 
-      Exit data mode.
+   #. Exit data mode.
+
+      .. parsed-literal::
+         :class: highlight
 
          +++
          OK
@@ -229,8 +233,8 @@ TCP client
          OK
 
    #. Create a TCP/TLS client and connect to a server.
-      Replace *example.com* with the host name or IPv4 address of a TCP server and *1234* with the corresponding port.
-      Then read information about the connection.
+      Replace *example.com* with the hostname or IPv4 address of a TCP server and *1234* with the corresponding port.
+      Then read the information about the connection.
 
       .. parsed-literal::
          :class: highlight
@@ -274,8 +278,8 @@ TCP client
 #. Test a TCP client with TCP proxy service in data mode:
 
    a. Create a TCP/TLS client and connect to a server with data mode support.
-      Replace ``*example.com*`` with the host name or IPv4 address of a TCP server and ``*1234*`` with the corresponding port.
-      Then read information about the connection.
+      Replace ``*example.com*`` with the hostname or IPv4 address of a TCP server and ``*1234*`` with the corresponding port.
+      Then read the information about the connection.
 
       .. parsed-literal::
          :class: highlight
@@ -310,7 +314,7 @@ UDP client
 
 1. Test a UDP client with connectionless UDP:
 
-   a. Open a UDP socket and read information (handle, protocol, and role) about the open socket.
+   a. Open a UDP socket and read the information (handle, protocol, and role) about the open socket.
 
       .. parsed-literal::
          :class: highlight
@@ -323,7 +327,7 @@ UDP client
          OK
 
    #. Send plain text data to a UDP server on a specified port.
-      Replace *example.com* with the host name or IPv4 address of a UDP server and *1234* with the corresponding port.
+      Replace *example.com* with the hostname or IPv4 address of a UDP server and *1234* with the corresponding port.
       Then retrieve the returned data.
 
       .. parsed-literal::
@@ -349,7 +353,7 @@ UDP client
 #. Test a UDP client with connection-based UDP:
 
    a. Open a UDP socket and connect to a UDP server on a specified port.
-      Replace *example.com* with the host name or IPv4 address of a UDP server and *1234* with the corresponding port.
+      Replace *example.com* with the hostname or IPv4 address of a UDP server and *1234* with the corresponding port.
 
       .. parsed-literal::
          :class: highlight
@@ -397,7 +401,7 @@ UDP client
          OK
 
    #. Create a UDP client and connect to a server.
-      Replace *example.com* with the host name or IPv4 address of a UDP server and *1234* with the corresponding port.
+      Replace *example.com* with the hostname or IPv4 address of a UDP server and *1234* with the corresponding port.
 
       .. parsed-literal::
          :class: highlight
@@ -428,8 +432,8 @@ UDP client
 #. Test a connection-based UDP client with UDP proxy service in data mode:
 
    a. Create a UDP client and connect to a server with data mode support.
-      Replace *example.com* with the host name or IPv4 address of a UDP server and *1234* with the corresponding port.
-      Then read information about the connection.
+      Replace *example.com* with the hostname or IPv4 address of a UDP server and *1234* with the corresponding port.
+      Then read the information about the connection.
 
       .. parsed-literal::
          :class: highlight
@@ -485,7 +489,7 @@ You must register the corresponding credentials on the server side.
          OK
 
    #. Open a TCP/TLS socket that uses the security tag 16842755 and connect to a TLS server on a specified port.
-      Replace *example.com* with the host name or IPv4 address of a TLS server and *1234* with the corresponding port.
+      Replace *example.com* with the hostname or IPv4 address of a TLS server and *1234* with the corresponding port.
 
       .. parsed-literal::
          :class: highlight
@@ -524,8 +528,8 @@ You must register the corresponding credentials on the server side.
 #. Test a TLS client with TCP proxy service:
 
    a. Create a TCP/TLS client and connect to a server.
-      Replace *example.com* with the host name or IPv4 address of a TLS server and *1234* with the corresponding port.
-      Then read information about the connection.
+      Replace *example.com* with the hostname or IPv4 address of a TLS server and *1234* with the corresponding port.
+      Then read the information about the connection.
 
       .. parsed-literal::
          :class: highlight
@@ -595,7 +599,7 @@ You must register the corresponding credentials on the server side.
 	     OK
 
        #. Open a TCP/DTLS socket that uses the security tag 16842756 and connect to a DTLS server on a specified port.
-	  Replace *example.com* with the host name or IPv4 address of a DTLS server and *1234* with the corresponding port.
+	  Replace *example.com* with the hostname or IPv4 address of a DTLS server and *1234* with the corresponding port.
 
 	 .. parsed-literal::
 	     :class: highlight
@@ -634,8 +638,8 @@ You must register the corresponding credentials on the server side.
     #. Test a DTLS client with UDP proxy service:
 
        a. Create a UDP/DTLS client and connect to a server.
-	  Replace *example.com* with the host name or IPv4 address of a DTLS server and *1234* with the corresponding port.
-	  Then read information about the connection.
+	  Replace *example.com* with the hostname or IPv4 address of a DTLS server and *1234* with the corresponding port.
+	  Then read the information about the connection.
 
 	  .. parsed-literal::
 	     :class: highlight
@@ -666,7 +670,7 @@ To act as a TCP server, |global_private_address|
 
 |global_private_address_check|
 
-1. Create a Python script :file:`client_tcp.py` that acts a TCP client.
+1. Create a Python script :file:`client_tcp.py` that acts as a TCP client.
    See the following sample code (make sure to use the correct IP address and port):
 
    .. code-block:: python
@@ -776,7 +780,7 @@ To act as a TCP server, |global_private_address|
 
 #. Test the TCP server with TCP proxy service:
 
-   a. Check the available values for the XTCPSVR command and read information about the current state.
+   a. Check the available values for the XTCPSVR command and read the information about the current state.
 
       .. parsed-literal::
          :class: highlight
@@ -789,7 +793,7 @@ To act as a TCP server, |global_private_address|
          #XTCPSVR: -1,-1
          OK
 
-   #. Create a TCP server and read information about the current state.
+   #. Create a TCP server and read the information about the current state.
       Replace *1234* with the correct port number.
 
       .. parsed-literal::
@@ -806,7 +810,7 @@ To act as a TCP server, |global_private_address|
    #. Run the :file:`client_tcp.py` script to start sending data to the server.
 
    #. Observe that the server accepts the connection from the client.
-      Read information about the current state again.
+      Read the information about the current state again.
 
       .. parsed-literal::
          :class: highlight
@@ -862,7 +866,7 @@ To act as a TCP server, |global_private_address|
          TCP3/4/5 received
          Closing connection
 
-   #. Read information about the current state.
+   #. Read the information about the current state.
 
       .. parsed-literal::
          :class: highlight
@@ -886,7 +890,7 @@ To act as a TCP server, |global_private_address|
 
 #. Test the TCP server with TCP proxy service in data mode:
 
-   a. Create a TCP server and read information about the current state.
+   a. Create a TCP server and read the information about the current state.
       Replace *1234* with the correct port number.
 
       .. parsed-literal::
@@ -941,7 +945,7 @@ To act as a UDP server, |global_private_address|
 
 |global_private_address_check|
 
-1. Create a Python script :file:`client_udp.py` that acts a UDP client.
+1. Create a Python script :file:`client_udp.py` that acts as a UDP client.
    See the following sample code (make sure to use the correct IP addresses and port):
 
    .. code-block:: python
@@ -999,7 +1003,7 @@ To act as a UDP server, |global_private_address|
    #. Run the :file:`client_udp.py` script to start sending data to the server.
 
    #. Start receiving and acknowledging the data.
-      Replace *example.com* with the host name or IPv4 address of the UDP client and *1234* with the corresponding port.
+      Replace *example.com* with the hostname or IPv4 address of the UDP client and *1234* with the corresponding port.
 
       .. parsed-literal::
          :class: highlight
@@ -1140,7 +1144,7 @@ To act as a UDP server, |global_private_address|
 
 #. Test the UDP server with UDP proxy service in data mode:
 
-   a. Create a UDP server and read information about the current state.
+   a. Create a UDP server and read the information about the current state.
       Replace *1234* with the correct port number.
 
       .. parsed-literal::
@@ -1220,7 +1224,7 @@ The DTLS server role is currently not supported (modem limitation).
 DNS lookup
 ==========
 
-1. Look up the IP address for a host name.
+1. Look up the IP address for a hostname.
 
    .. parsed-literal::
       :class: highlight
@@ -1846,7 +1850,7 @@ Complete the following steps to test the functionality provided by the :ref:`SLM
 
 ..
 
-   c. Enable power saving mode.
+   c. Enable power-saving mode.
       Then turn on the modem.
 
       .. parsed-literal::
@@ -1977,7 +1981,7 @@ Complete the following steps to test the functionality provided by the :ref:`SLM
          +CEREG: 1,"107E","00B02C03",7
 
    #. Start GPS with GPS fix data and geographic position latitude/longitude and time, and observe the output.
-      Note that the TTFF printed in the AT response is from then time when AT#XGPS was issued.
+      Note that the TTFF printed in the AT response is from the time when AT#XGPS was issued.
       For A-GPS, this includes the SUPL injection time.
 
       .. parsed-literal::

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -121,6 +121,8 @@ void enter_sleep(void)
 	nrf_gpio_cfg_input(CONFIG_SLM_INTERFACE_PIN, NRF_GPIO_PIN_PULLUP);
 	nrf_gpio_cfg_sense_set(CONFIG_SLM_INTERFACE_PIN, NRF_GPIO_PIN_SENSE_LOW);
 
+	k_sleep(K_MSEC(100));
+
 	nrf_regulators_system_off(NRF_REGULATORS_NS);
 }
 

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -512,9 +512,6 @@ static void cmd_send(struct k_work *work)
 			rsp_send(OK_STR, sizeof(OK_STR) - 1);
 		}
 		goto done;
-	} else if (err == -ESHUTDOWN) {
-		/*Entered IDLE or UART Power Off */
-		return;
 	} else if (err != -ENOENT) {
 		rsp_send(ERROR_STR, sizeof(ERROR_STR) - 1);
 		goto done;


### PR DESCRIPTION
Based on customer input, modify #XSLEEP as below
.<shutdown_mode> becomes mandatory, no default option
.#XSLEEP will now have OK or ERROR response
.Sleep is handled with 100ms delay after AT response
.CONFIG_SLM_GPIO_WAKEUP option is removed

Also include a bug-fix for deep sleep option.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>