### PR TITLE
doc: add missing word in doc_build sentence

### DIFF
--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -139,7 +139,7 @@ That means that if you do not have local modifications to a documentation set, y
 Downloading is usually quicker than building the documentation from scratch, however, this might depend on your Internet connection speed.
 
 .. note::
-   Using cached builds is currently in experimental state.
+   Using cached builds is currently in an experimental state.
 
 To enable the online cache, set the ``NCS_CACHE_ENABLE`` environment variable.
 For example, on Windows, enter the following command::


### PR DESCRIPTION
ref: NCSDK-10657

The sentence requires 'an' to be grammatically correct.

Signed-off-by: Deidre Casey <deidre.casey@nordicsemi.no>