### PR TITLE
mpsl: Generic radio coexistence implementation according to Thread Recommendations

### DIFF
--- a/include/mpsl/mpsl_cx_config_thread.h
+++ b/include/mpsl/mpsl_cx_config_thread.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file mpsl_cx_config_thread.h
+ *
+ * @defgroup mpsl_cx_thread MPSL Coexistence configuration according to Thread Radio Coexistence
+ * @ingroup  mpsl_cx
+ *
+ * @{
+ */
+
+#ifndef MPSL_CX_CONFIG_THREAD_H__
+#define MPSL_CX_CONFIG_THREAD_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/** @brief Configuration parameters for the Thread Radio Coexistence variant. */
+struct mpsl_cx_thread_interface_config {
+	/** GPIO pin number of REQUEST pin. */
+	uint8_t request_pin;
+	/** GPIO pin number of PRIORITY pin. */
+	uint8_t priority_pin;
+	/** GPIO pin number of GRANTED pin. */
+	uint8_t granted_pin;
+};
+
+/** @brief Configures the Thread Radio Coexistence interface.
+ *
+ * This function sets device interface parameters for the Coexistence module.
+ * The module is used to control PTA interface through the given pins and resources.
+ *
+ * @param[in] config Pointer to the interface parameters.
+ *
+ * @retval   0             Coexistence interface successfully configured.
+ * @retval   -NRF_EPERM    Coexistence interface is not available.
+ *
+ */
+int32_t mpsl_cx_thread_interface_config_set(
+		struct mpsl_cx_thread_interface_config const * const config);
+
+#endif // MPSL_CX_CONFIG_THREAD_H__
+
+/**@} */

--- a/subsys/mpsl/CMakeLists.txt
+++ b/subsys/mpsl/CMakeLists.txt
@@ -10,4 +10,6 @@ zephyr_library_sources(
   mpsl_init.c
   )
 
+zephyr_library_sources_ifdef(CONFIG_MPSL_CX mpsl_cx.c)
+zephyr_library_sources_ifdef(CONFIG_MPSL_CX_THREAD cx/thread/mpsl_cx_thread.c)
 zephyr_library_sources_ifdef(CONFIG_MPSL_FEM mpsl_fem.c)

--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -34,6 +34,7 @@ config MPSL_ASSERT_HANDLER
 	  MPSL code encounters an unrecoverable error.
 
 rsource "Kconfig.fem"
+rsource "Kconfig.cx"
 
 module=MPSL
 module-str=MPSL

--- a/subsys/mpsl/Kconfig.cx
+++ b/subsys/mpsl/Kconfig.cx
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config MPSL_CX
+	bool "Radio Coexistence interface support [EXPERIMENTAL]"
+# Generic coexistence is not yet supported by Bluetooth
+	depends on !BT
+	help
+	  Controls if Radio Coexistence interface is to be configured and enabled
+	  when MPSL is initialized.
+
+	  Radio Coexistence interface connects nRF5 radio protocols with external
+	  Packet Traffic Arbiter (PTA) which denies or grants access to RF.
+
+if MPSL_CX
+
+choice MPSL_CX_CHOICE
+	prompt "Radio Coexistence interface implementation"
+
+config MPSL_CX_THREAD
+	select NRFX_GPIOTE
+	select GPIO
+	bool "Thread Radio Coexistence"
+	help
+	  Radio Coexistence interface implementation according to Thread Radio
+	  Coexistence Practical recommendations for using a 3-wire PTA
+	  implementation for co-located 2.4 GHz radios.
+
+endchoice	# MPSL_CX_CHOICE
+
+if MPSL_CX_THREAD
+
+config MPSL_CX_THREAD_PIN_REQUEST
+	int "GPIO pin id used as coexistence Request signal"
+	default 13
+	help
+	  For port 0 simply use pin number. For port 1 add value 32 to pin number:
+	  P0.04 is 4; P1.04 is 36.
+
+	  Note: This configuration will be moved to device tree.
+
+config MPSL_CX_THREAD_PIN_PRIORITY
+	int "GPIO pin id used as coexistence Priority signal"
+	default 14
+	help
+	  For port 0 simply use pin number. For port 1 add value 32 to pin number:
+	  P0.04 is 4; P1.04 is 36.
+
+	  Note: This configuration will be moved to device tree.
+
+config MPSL_CX_THREAD_PIN_GRANT
+	int "GPIO pin id used as coexistence Grant signal"
+	default 12
+	help
+	  For port 0 simply use pin number. For port 1 add value 32 to pin number:
+	  P0.04 is 4; P1.04 is 36.
+
+	  Note: This configuration will be moved to device tree.
+
+endif
+
+endif	# MPSL_CX

--- a/subsys/mpsl/cx/thread/mpsl_cx_thread.c
+++ b/subsys/mpsl/cx/thread/mpsl_cx_thread.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ *   This file implements generic Coexistence interface according to
+ *   Thread Radio Coexistence whitepaper.
+ *
+ */
+
+#include <mpsl_cx_abstract_interface.h>
+#include <mpsl/mpsl_cx_config_thread.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <device.h>
+#include <drivers/gpio.h>
+
+#include "hal/nrf_gpio.h"
+
+/* Value from chapter 7. Logic Timing from Thread Radio Coexistence */
+#define REQUEST_TO_GRANT_US 50U
+
+static struct mpsl_cx_thread_interface_config config;
+static mpsl_cx_cb_t callback;
+
+static const struct device *req_dev;
+static const struct device *pri_dev;
+static const struct device *gra_dev;
+static gpio_port_value_t    req_pin_mask;
+static gpio_port_value_t    pri_pin_mask;
+static gpio_port_value_t    gra_pin_mask;
+static struct gpio_callback grant_cb;
+
+static int32_t grant_pin_is_asserted(bool *is_asserted)
+{
+	int ret;
+	gpio_port_value_t port_val;
+
+	ret = gpio_port_get_raw(gra_dev, &port_val);
+
+	if (ret != 0) {
+		return -NRF_EPERM;
+	}
+
+	*is_asserted = (port_val & gra_pin_mask) ? true : false;
+	return 0;
+}
+
+static mpsl_cx_op_map_t granted_ops_map(bool grant_is_asserted)
+{
+	mpsl_cx_op_map_t granted_ops = MPSL_CX_OP_IDLE_LISTEN | MPSL_CX_OP_RX;
+
+	if (grant_is_asserted) {
+		granted_ops |= MPSL_CX_OP_TX;
+	}
+
+	return granted_ops;
+}
+
+static int32_t granted_ops_get(mpsl_cx_op_map_t *granted_ops)
+{
+	int  ret;
+	bool grant_is_asserted;
+
+	ret = grant_pin_is_asserted(&grant_is_asserted);
+	if (ret < 0) {
+		return ret;
+	}
+
+	*granted_ops = granted_ops_map(grant_is_asserted);
+	return 0;
+}
+
+static void gpiote_irq_handler(const struct device *gpiob, struct gpio_callback *cb, uint32_t pins)
+{
+	(void)gpiob;
+	(void)cb;
+	(void)pins;
+
+	static mpsl_cx_op_map_t last_notified;
+	int32_t ret;
+	mpsl_cx_op_map_t granted_ops;
+
+	if (callback != NULL) {
+		ret = granted_ops_get(&granted_ops);
+
+		__ASSERT(ret == 0, "Getting grant pin state returned unexpected result: %d", ret);
+		if (ret != 0) {
+			/* nrfx gpio implementation cannot return failure for this call
+			 * This condition is handled for fail-safe approach. It is assumed
+			 * GRANT is not given, if cannot read its value
+			 */
+			granted_ops = granted_ops_map(false);
+		}
+
+		if (granted_ops != last_notified) {
+			last_notified = granted_ops;
+			callback(granted_ops);
+		}
+	}
+}
+
+static int32_t gpio_init(uint8_t pin_no, bool input, const struct device **port,
+		gpio_port_value_t *pin_mask)
+{
+	gpio_flags_t flags;
+	bool use_port_1 = (pin_no > P0_PIN_NUM);
+
+	pin_no = use_port_1 ? pin_no - P0_PIN_NUM : pin_no;
+	*port = device_get_binding(use_port_1 ? "GPIO_1" : "GPIO_0");
+
+	if (*port == NULL) {
+		return -NRF_EINVAL;
+	}
+
+	*pin_mask = 1U << pin_no;
+
+	if (input) {
+		flags = GPIO_INPUT | GPIO_PULL_UP;
+	} else {
+		flags = GPIO_OUTPUT_LOW;
+	}
+
+	gpio_pin_configure(*port, pin_no, flags);
+
+	return 0;
+}
+
+static int32_t gpiote_init(void)
+{
+	int32_t ret;
+	gpio_flags_t flags = GPIO_INT_ENABLE | GPIO_INT_EDGE | GPIO_INT_EDGE_BOTH;
+
+	ret = gpio_init(config.granted_pin, true, &gra_dev, &gra_pin_mask);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = gpio_pin_interrupt_configure(gra_dev, config.granted_pin, flags);
+	if (ret < 0) {
+		return ret;
+	}
+
+	gpio_init_callback(&grant_cb, gpiote_irq_handler, gra_pin_mask);
+	gpio_add_callback(gra_dev, &grant_cb);
+
+	return 0;
+}
+
+static int32_t request(const mpsl_cx_request_t *req_params)
+{
+	int ret;
+
+	if (req_params == NULL) {
+		return -NRF_EINVAL;
+	}
+
+	if (req_params->prio > (UINT8_MAX / 2)) {
+		ret = gpio_port_set_clr_bits_raw(pri_dev, pri_pin_mask, 0);
+	} else {
+		ret = gpio_port_set_clr_bits_raw(pri_dev, 0, pri_pin_mask);
+	}
+
+	if (ret < 0) {
+		return -NRF_EPERM;
+	}
+
+	if (req_params->ops & (MPSL_CX_OP_RX | MPSL_CX_OP_TX)) {
+		ret = gpio_port_set_clr_bits_raw(req_dev, req_pin_mask, 0);
+	} else {
+		ret = gpio_port_set_clr_bits_raw(req_dev, 0, req_pin_mask);
+	}
+
+	if (ret < 0) {
+		return -NRF_EPERM;
+	}
+
+	return 0;
+}
+
+static int32_t release(void)
+{
+	int ret;
+
+	ret = gpio_port_set_clr_bits_raw(req_dev, 0, req_pin_mask);
+	if (ret < 0) {
+		return -NRF_EPERM;
+	}
+
+	ret = gpio_port_set_clr_bits_raw(pri_dev, 0, pri_pin_mask);
+	if (ret < 0) {
+		return -NRF_EPERM;
+	}
+
+	return 0;
+}
+
+static uint32_t req_grant_delay_get(void)
+{
+	return REQUEST_TO_GRANT_US;
+}
+
+static int32_t register_callback(mpsl_cx_cb_t cb)
+{
+	callback = cb;
+
+	return 0;
+}
+
+static const mpsl_cx_interface_t m_mpsl_cx_methods = {
+	.p_request             = request,
+	.p_release             = release,
+	.p_granted_ops_get     = granted_ops_get,
+	.p_req_grant_delay_get = req_grant_delay_get,
+	.p_register_callback   = register_callback,
+};
+
+int32_t mpsl_cx_thread_interface_config_set(
+		struct mpsl_cx_thread_interface_config const * const new_config)
+{
+	int32_t ret_code;
+
+	config = *new_config;
+	callback = NULL;
+
+	ret_code = mpsl_cx_interface_set(&m_mpsl_cx_methods);
+	if (ret_code != 0) {
+		return ret_code;
+	}
+
+	ret_code = gpio_init(config.request_pin, false, &req_dev, &req_pin_mask);
+	if (ret_code != 0) {
+		return ret_code;
+	}
+
+	ret_code = gpio_init(config.priority_pin, false, &pri_dev, &pri_pin_mask);
+	if (ret_code != 0) {
+		return ret_code;
+	}
+
+	ret_code = gpiote_init();
+	if (ret_code != 0) {
+		return ret_code;
+	}
+
+	return 0;
+}

--- a/subsys/mpsl/mpsl_cx.c
+++ b/subsys/mpsl/mpsl_cx.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "mpsl_cx_internal.h"
+
+#include <mpsl/mpsl_cx_config_thread.h>
+#include <sys/util.h>
+
+#if IS_ENABLED(CONFIG_MPSL_CX_THREAD)
+static int cx_thread_configure(void)
+{
+	struct mpsl_cx_thread_interface_config cfg = {
+		.request_pin  = CONFIG_MPSL_CX_THREAD_PIN_REQUEST,
+		.priority_pin = CONFIG_MPSL_CX_THREAD_PIN_PRIORITY,
+		.granted_pin  = CONFIG_MPSL_CX_THREAD_PIN_GRANT,
+	};
+
+	return mpsl_cx_thread_interface_config_set(&cfg);
+}
+#endif
+
+int mpsl_cx_configure(void)
+{
+	int err = 0;
+
+#if IS_ENABLED(CONFIG_MPSL_CX_THREAD)
+	err = cx_thread_configure();
+#else
+#error Incomplete CONFIG_MPSL_CX configuration. No supported coexistence protocol found.
+#endif
+
+	return err;
+}

--- a/subsys/mpsl/mpsl_cx_internal.h
+++ b/subsys/mpsl/mpsl_cx_internal.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ * @brief Internal MPSL Coexistence initialization
+ */
+
+#ifndef MPSL_CX_INTERNAL__
+#define MPSL_CX_INTERNAL__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int mpsl_cx_configure(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MPSL_CX_INTERNAL__ */

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -12,6 +12,7 @@
 #include <mpsl.h>
 #include <mpsl_timeslot.h>
 #include <mpsl/mpsl_assert.h>
+#include "mpsl_cx_internal.h"
 #include "mpsl_fem_config_common.h"
 #include "mpsl_fem_internal.h"
 #include "multithreading_lock.h"
@@ -221,7 +222,19 @@ static int mpsl_fem_init(const struct device *dev)
 #endif
 }
 
+static int mpsl_cx_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+#if IS_ENABLED(CONFIG_MPSL_CX)
+	return mpsl_cx_configure();
+#else
+	return 0;
+#endif
+}
+
 SYS_INIT(mpsl_lib_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 SYS_INIT(mpsl_signal_thread_init, POST_KERNEL,
 	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(mpsl_cx_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);


### PR DESCRIPTION
Generic coexistence implementation according to Thread Recommendations.
This implementation is presenting how to implement PTA client
aligned with given PTA interface. It is disabled in Kconfig by default.
It can be easily replaced with other implementations added by Nordic
to NCS or created by an application developer.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>