### PR TITLE
samples: matter: clean NFC code

### DIFF
--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -117,7 +117,7 @@ int AppTask::Init()
 	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
 
 #ifdef CONFIG_CHIP_NFC_COMMISSIONING
-	PlatformMgr().AddEventHandler(AppTask::ThreadProvisioningHandler, 0);
+	PlatformMgr().AddEventHandler(AppTask::ChipEventHandler, 0);
 #endif
 
 	sLightBulbPublishService.Init();
@@ -377,14 +377,6 @@ void AppTask::StartBLEAdvertisingHandler()
 		return;
 	}
 
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-	if (NFCMgr().IsTagEmulationStarted()) {
-		LOG_INF("NFC Tag emulation is already started");
-	} else {
-		ShareQRCodeOverNFC(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-	}
-#endif
-
 	if (ConnectivityMgr().IsBLEAdvertisingEnabled()) {
 		LOG_INF("BLE Advertisement is already enabled");
 		return;
@@ -398,11 +390,19 @@ void AppTask::StartBLEAdvertisingHandler()
 }
 
 #ifdef CONFIG_CHIP_NFC_COMMISSIONING
-void AppTask::ThreadProvisioningHandler(const ChipDeviceEvent *event, intptr_t)
+void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 {
-	if (event->Type == DeviceEventType::kCHIPoBLEAdvertisingChange &&
-	    event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped) {
-		NFCMgr().StopTagEmulation();
+	if (event->Type == DeviceEventType::kCHIPoBLEAdvertisingChange) {
+		if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Started) {
+			if (NFCMgr().IsTagEmulationStarted()) {
+				LOG_INF("NFC Tag emulation is already started");
+			} else {
+				ShareQRCodeOverNFC(
+					chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+			}
+		} else if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped) {
+			NFCMgr().StopTagEmulation();
+		}
 	}
 }
 #endif

--- a/samples/matter/light_bulb/src/app_task.h
+++ b/samples/matter/light_bulb/src/app_task.h
@@ -35,15 +35,11 @@ private:
 	void StartThreadHandler();
 	void StartBLEAdvertisingHandler();
 
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-	int StartNFCTag();
-#endif
-
 	static void ActionInitiated(LightingManager::Action aAction);
 	static void ActionCompleted(LightingManager::Action aAction);
 	static void ButtonEventHandler(uint32_t buttonState, uint32_t hasChanged);
 	static void TimerEventHandler(k_timer *timer);
-	static void ThreadProvisioningHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
+	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 	static int SoftwareUpdateConfirmationHandler(uint32_t offset, uint32_t size, void *arg);
 
 	friend AppTask &GetAppTask();

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -35,13 +35,9 @@ private:
 	void StartThreadHandler();
 	void StartBLEAdvertisingHandler();
 
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-	int StartNFCTag();
-#endif
-
 	static void ButtonEventHandler(uint32_t buttonState, uint32_t hasChanged);
 	static void TimerEventHandler(k_timer *timer);
-	static void ThreadProvisioningHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
+	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 	static int SoftwareUpdateConfirmationHandler(uint32_t offset, uint32_t size, void *arg);
 
 	friend AppTask &GetAppTask();


### PR DESCRIPTION
Formerly, the spec required that a programmable NFC Tag be
enabled only after a user physical action, such as a button
push. Now that the requirement has been removed, make NFC
start automatically when the BLE advertising starts.