### PR TITLE
samples: peripheral_uart: Build sample for Thingy53

### DIFF
--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -6,7 +6,7 @@ tests:
     build_only: true
     build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns thingy53_nrf5340_cpuapp
     tags: bluetooth ci_build
 tests:
   samples.bluetooth.peripheral_lbs_minimal:


### PR DESCRIPTION
Allow CI to build sample for Thingy53 target.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>