### PR TITLE
application: serial_lte_modem: Extend RX buffer size for datamode

### DIFF
--- a/applications/serial_lte_modem/doc/slm_data_mode.rst
+++ b/applications/serial_lte_modem/doc/slm_data_mode.rst
@@ -79,8 +79,11 @@ Two triggers can initiate the transmission of the buffered data to the LTE netwo
 Flow control in data mode
 =========================
 
-The MCU must impose flow control to the SLM application over the UART interface when SLM has filled its receiving buffer.
-SLM disables UART receptions until there is buffer space available after the transmission of the data previously received.
+When SLM fills its receiving buffer, the MCU must impose flow control to the SLM over the UART interface to avoid any buffer overflow.
+Otherwise, if SLM imposes flow control, it disables the UART reception when it runs out of space in the buffer, potentially leading to data loss.
+
+SLM reenables UART receptions after the transmission of the data previously received has freed up buffer space.
+The buffer size is set to 3884 bytes by default.
 
 .. note:
    There is no unsolicited notification defined for this event.

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -25,7 +25,12 @@ enum slm_datamode_operation_t {
 	DATAMODE_EXIT   /* Exit data mode */
 };
 
-/**@brief Data mode sending handler type. */
+/**@brief Data mode sending handler type.
+ *
+ * @retval 0 means all data is sent successfully.
+ *         Positive value means the actual size of bytes that has been sent.
+ *         Negative value means error occurrs in sending.
+ */
 typedef int (*slm_datamode_handler_t)(uint8_t op, const uint8_t *data, int len);
 
 /**

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -650,7 +650,7 @@ static int do_send_datamode(const uint8_t *data, int datalen)
 		offset += ret;
 	}
 
-	return offset;
+	return (offset > 0) ? offset : -1;
 }
 
 static int do_recv(int timeout)
@@ -807,7 +807,7 @@ static int do_sendto_datamode(const uint8_t *data, int datalen)
 		offset += ret;
 	}
 
-	return offset;
+	return (offset > 0) ? offset : -1;
 }
 
 static int do_recvfrom(int timeout)


### PR DESCRIPTION
Use full size of at_buf for datamode UART RX. This is to reduce the
possibility of buffer overflow, for which HWFC is initiated by SLM
and could lead to byte loss.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>