### PR TITLE
applications: nrf_desktop: Explicit check report id

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -918,8 +918,9 @@ static void disconnect_peripheral(struct hids_peripheral *per)
 			uint8_t report_id = bt_hogp_rep_id(rep);
 			size_t size = bt_hogp_rep_size(rep);
 
-			__ASSERT_NO_MSG((report_id != REPORT_ID_RESERVED) &&
-					(report_id < REPORT_ID_COUNT));
+			if ((report_id == REPORT_ID_RESERVED) || (report_id >= REPORT_ID_COUNT)) {
+				continue;
+			}
 
 			/* Release all pressed keys. */
 			uint8_t empty_data[size];


### PR DESCRIPTION
Check report id and skip if it goes out of bounds.
This can happen in case discovery is aborted before completion.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>