### PR TITLE
Bluetooth: Mesh: Reinitialize PI Regulator config on reset

### DIFF
--- a/include/bluetooth/mesh/light_ctrl.h
+++ b/include/bluetooth/mesh/light_ctrl.h
@@ -203,8 +203,8 @@ enum bt_mesh_light_ctrl_coeff {
 #define BT_MESH_LIGHT_CTRL_OP_PROP_STATUS BT_MESH_MODEL_OP_1(0x64)
 
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
-#define BT_MESH_LIGHT_CTRL_SRV_REG_INIT .reg = {                               \
-	.cfg = {                                                               \
+#define BT_MESH_LIGHT_CTRL_SRV_REG_CFG_INIT                                    \
+	{                                                                      \
 		.lux = { { CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_STANDBY },    \
 			 { CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_ON },         \
 			 { CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_PROLONG } },  \
@@ -213,7 +213,11 @@ enum bt_mesh_light_ctrl_coeff {
 		.kpu = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KPU,                  \
 		.kpd = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KPD,                  \
 		.accuracy = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_ACCURACY,        \
-	} }
+	}
+
+#define BT_MESH_LIGHT_CTRL_SRV_REG_INIT .reg = {                               \
+		.cfg = BT_MESH_LIGHT_CTRL_SRV_REG_CFG_INIT                     \
+	}
 #else
 #define BT_MESH_LIGHT_CTRL_SRV_REG_INIT
 #endif

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1633,8 +1633,15 @@ static void light_ctrl_srv_reset(struct bt_mesh_model *model)
 {
 	struct bt_mesh_light_ctrl_srv *srv = model->user_data;
 	struct bt_mesh_light_ctrl_srv_cfg cfg = BT_MESH_LIGHT_CTRL_SRV_CFG_INIT;
+#if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
+	struct bt_mesh_light_ctrl_srv_reg_cfg reg_cfg = BT_MESH_LIGHT_CTRL_SRV_REG_CFG_INIT;
+#endif
 
 	srv->cfg = cfg;
+#if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
+	srv->reg.cfg = reg_cfg;
+#endif
+
 	ctrl_disable(srv);
 	net_buf_simple_reset(srv->pub.msg);
 


### PR DESCRIPTION
PI Regulator configuration must be reinitialized on reset.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>