### PR TITLE
dts: Add ant-sel-gpios property for SKY66112-11

### DIFF
--- a/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
+++ b/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
@@ -61,3 +61,9 @@ properties:
             can be changed if, instead of SKY66112-11, another device with
             different gain, but compatible with the control interface via the
             CTX, CRX pins is used.
+
+    ant-sel-gpios:
+        type: phandle-array
+        required: false
+        description: |
+            Gpio of the SOC controlling ANT-SEL pin of the SKY66112-11 device.


### PR DESCRIPTION
GPIO interface for SKY66112-11 can now include ant-sel-gpios property
which allows for convenient control of antenna selection.