### PR TITLE
Bluetooth: Mesh: Refactor Light XYL and HSL Server models

### DIFF
--- a/include/bluetooth/mesh/light_hsl_srv.h
+++ b/include/bluetooth/mesh/light_hsl_srv.h
@@ -30,16 +30,15 @@ struct bt_mesh_light_hsl_srv;
  *
  *  @brief Initialization parameters for a @ref bt_mesh_light_hsl_srv instance.
  *
+ *  @param[in] _lightness_srv Pointer to the Lightness Server instance.
  *  @param[in] _hue_handlers Hue Server model handlers.
  *  @param[in] _sat_handlers Saturation Server model handlers.
- *  @param[in] _light_handlers Lightness Server model handlers.
  */
-#define BT_MESH_LIGHT_HSL_SRV_INIT(_hue_handlers, _sat_handlers,               \
-				   _light_handlers)                            \
-	{                                                                      \
-		.hue = BT_MESH_LIGHT_HUE_SRV_INIT(_hue_handlers),              \
-		.sat = BT_MESH_LIGHT_SAT_SRV_INIT(_sat_handlers),              \
-		.lightness = BT_MESH_LIGHTNESS_SRV_INIT(_light_handlers),      \
+#define BT_MESH_LIGHT_HSL_SRV_INIT(_lightness_srv, _hue_handlers, _sat_handlers)                 \
+	{                                                                                          \
+		.lightness = _lightness_srv,                          \
+		.hue = BT_MESH_LIGHT_HUE_SRV_INIT(_hue_handlers),                                  \
+		.sat = BT_MESH_LIGHT_SAT_SRV_INIT(_sat_handlers),                                  \
 	}
 
 /** @def BT_MESH_MODEL_LIGHT_HSL_SRV
@@ -49,7 +48,6 @@ struct bt_mesh_light_hsl_srv;
  *  @param[in] _srv Pointer to a @ref bt_mesh_light_hsl_srv instance.
  */
 #define BT_MESH_MODEL_LIGHT_HSL_SRV(_srv)                                      \
-	BT_MESH_MODEL_LIGHTNESS_SRV(&(_srv)->lightness),                       \
 	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_LIGHT_HSL_SRV,                       \
 			 _bt_mesh_light_hsl_srv_op, &(_srv)->pub,              \
 			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_light_hsl_srv, \
@@ -69,8 +67,8 @@ struct bt_mesh_light_hsl_srv {
 	struct bt_mesh_light_hue_srv hue;
 	/** Light Saturation Server instance. */
 	struct bt_mesh_light_sat_srv sat;
-	/** Lightness Server instance. */
-	struct bt_mesh_lightness_srv lightness;
+	/** Pointer to Lightness Server instance. */
+	struct bt_mesh_lightness_srv *lightness;
 
 	/** Model entry. */
 	struct bt_mesh_model *model;

--- a/include/bluetooth/mesh/light_hsl_srv.rst
+++ b/include/bluetooth/mesh/light_hsl_srv.rst
@@ -12,7 +12,7 @@ It should be instantiated in the light fixture node.
 
 The Light HSL Server provides functionality for working on the individual hue, saturation and lightness channels in a combined message interface, controlled by a :ref:`bt_mesh_light_hsl_cli_readme`.
 
-The Light HSL Server adds the following new model instances in the composition data, in addition to the extended :ref:`bt_mesh_lightness_srv_readme` model:
+The Light HSL Server adds the following new model instances in the composition data:
 
 * Light HSL Server
 * Light HSL Setup Server
@@ -23,6 +23,8 @@ This allows for a fine-grained control of the access rights for the Light HSL st
 * The Light HSL Server only provides write access to the HSL state for the user, in addition to read access to all the meta states.
 * The Light HSL Setup Server provides write access to the corresponding :ref:`bt_mesh_light_hue_srv_readme` and :ref:`bt_mesh_light_sat_srv_readme` models' meta states.
   This allows the configurator devices to set up the range and the default value for the various HSL states.
+
+The extended :ref:`bt_mesh_lightness_srv_readme` model should be defined and initialized separately, and the pointer to this model should be passed to the Light HSL Server initialization macro.
 
 Model composition
 *****************
@@ -46,12 +48,17 @@ In the application code, this would look like this:
 
 .. code-block:: c
 
+   static struct bt_mesh_lightness_srv lightess_srv =
+      BT_MESH_LIGHTNESS_SRV_INIT(&lightness_cb);
+
    static struct bt_mesh_light_hsl_srv hsl_srv =
-   	BT_MESH_LIGHT_HSL_SRV_INIT(&hue_cb, &sat_cb, &light_cb);
+   	BT_MESH_LIGHT_HSL_SRV_INIT(&lightness_srv, &hue_cb, &sat_cb);
 
    static struct bt_mesh_elem elements[] = {
    	BT_MESH_ELEM(
-   		1, BT_MESH_MODEL_LIST(BT_MESH_MODEL_LIGHT_HSL_SRV(&hsl_srv)),
+   		1, BT_MESH_MODEL_LIST(
+            BT_MESH_MODEL_LIGHTNESS_SRV(&lightness_srv),
+            BT_MESH_MODEL_LIGHT_HSL_SRV(&hsl_srv)),
    		BT_MESH_MODEL_NONE),
    	BT_MESH_ELEM(
    		2, BT_MESH_MODEL_LIST(BT_MESH_MODEL_LIGHT_HUE_SRV(&hsl_srv.hue)),
@@ -64,6 +71,8 @@ In the application code, this would look like this:
 .. note::
    The :c:struct:`bt_mesh_light_hsl_srv` contains the memory for its corresponding Light Hue Server and Light Saturation Server.
    When instantiating these models in the composition data, the model entries must point to these substructures.
+   The :c:struct:`bt_mesh_light_hsl_srv` also contains a pointer to the Light Lightness Server model.
+   Pointer to this model should be passed to the Light HSL Server initialization macro.
 
 The Light HSL Server does not contain any states on its own, but instead operates on the underlying Hue, Saturation and Lightness Server model's states.
 Because of this, the Light HSL Server does not have a message handler structure, but will instead defer its messages to the individual submodels' handler callbacks.

--- a/include/bluetooth/mesh/light_xyl_srv.h
+++ b/include/bluetooth/mesh/light_xyl_srv.h
@@ -28,14 +28,13 @@ struct bt_mesh_light_xyl_srv;
  *
  * @brief initialization parameters for a @ref bt_mesh_light_xyl_srv instance.
  *
- * @param[in] _lightness_handlers Lightness server callbacks.
+ * @param[in] _lightness_srv Pointer to Lightness server instance.
  * @param[in] _light_xyl_handlers Light xyL server callbacks.
  */
-#define BT_MESH_LIGHT_XYL_SRV_INIT(_lightness_handlers, _light_xyl_handlers)   \
+#define BT_MESH_LIGHT_XYL_SRV_INIT(_lightness_srv, _light_xyl_handlers)   \
 	{                                                                      \
 		.handlers = _light_xyl_handlers,                               \
-		.lightness_srv =                                               \
-			BT_MESH_LIGHTNESS_SRV_INIT(_lightness_handlers),       \
+		.lightness_srv = _lightness_srv,				\
 		.range = {                                                     \
 			.min = { .x = 0, .y = 0 },                             \
 			.max = { .x = UINT16_MAX, .y = UINT16_MAX }            \
@@ -49,7 +48,6 @@ struct bt_mesh_light_xyl_srv;
  * @param[in] _srv Pointer to a @ref bt_mesh_light_xyl_srv instance.
  */
 #define BT_MESH_MODEL_LIGHT_XYL_SRV(_srv)                                      \
-	BT_MESH_MODEL_LIGHTNESS_SRV(&(_srv)->lightness_srv),                   \
 		BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_LIGHT_XYL_SRV,               \
 				 _bt_mesh_light_xyl_srv_op, &(_srv)->pub,      \
 				 BT_MESH_MODEL_USER_DATA(                      \
@@ -145,8 +143,8 @@ struct bt_mesh_light_xyl_srv_handlers {
 struct bt_mesh_light_xyl_srv {
 	/** Model entry. */
 	struct bt_mesh_model *model;
-	/** Lightness Server instance. */
-	struct bt_mesh_lightness_srv lightness_srv;
+	/** Pointer to Lightness Server instance. */
+	struct bt_mesh_lightness_srv *lightness_srv;
 	/** Publish parameters. */
 	struct bt_mesh_model_pub pub;
 	/* Publication buffer */


### PR DESCRIPTION
When a node implements Light HSL Server and Light xyL Server located on
the same element, the Light xyL state and the Light HSL state are bound
indirectly via the Light Lightness Actual state.

The user has to add Lightness Server model to the composition data
separately and pass a pointer to HSL and XYL Server init macros.

Signed-off-by: Michał Narajowski <michal.narajowski@codecoup.pl>