### PR TITLE
application: serial_lte_modem: Add IPv6 support to HTTP client

### DIFF
--- a/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
@@ -29,7 +29,8 @@ Syntax
 * The ``<op>`` parameter can accept one of the following values:
 
   * ``0`` - Disconnect from the HTTP server
-  * ``1`` - Connect to the HTTP server
+  * ``1`` - Connect to the HTTP server for IP protocol family version 4
+  * ``2`` - Connect to the HTTP server for IP protocol family version 6
 
 * The ``<host>`` parameter is a string.
   It represents the HTTP server hostname.

--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -35,8 +35,8 @@ Syntax
 * The ``<op>`` parameter can accept one of the following values:
 
   * ``0`` - Stop the server.
-  * ``1`` - Start the server for IP protocol family version 4.
-  * ``2`` - Start the server for IP protocol family version 6.
+  * ``1`` - Start the server using IP protocol family version 4.
+  * ``2`` - Start the server using IP protocol family version 6.
 
 * The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the TCP service port.

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -344,10 +344,10 @@ static void silence_timer_handler(struct k_timer *timer)
 	/* quit datamode */
 	if (datamode_handler) {
 		(void)datamode_handler(DATAMODE_EXIT, NULL, 0);
-		(void)exit_datamode(true);
 	} else {
 		LOG_WRN("missing datamode handler");
 	}
+	(void)exit_datamode(true);
 	datamode_off_pending = false;
 }
 

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -286,36 +286,24 @@ static int do_tcp_client_connect(const char *url, uint16_t port)
 		}
 	}
 
+	/* Connect to remote host */
 	struct addrinfo *res;
+	struct addrinfo hints = {
+		.ai_family = proxy.family,
+		.ai_socktype = SOCK_STREAM
+	};
 
+	ret = getaddrinfo(url, NULL, &hints, &res);
+	if (ret) {
+		LOG_ERR("getaddrinfo() failed: %d", ret);
+		goto exit_cli;
+	}
 	if (proxy.family == AF_INET) {
-		struct addrinfo hints = {
-			.ai_family = AF_INET,
-			.ai_socktype = SOCK_STREAM
-		};
-
-		ret = getaddrinfo(url, NULL, &hints, &res);
-		if (ret) {
-			LOG_ERR("getaddrinfo() failed: %d", ret);
-			goto exit_cli;
-		}
-		/* Connect to remote host */
 		struct sockaddr_in *host = (struct sockaddr_in *)res->ai_addr;
 
 		host->sin_port = htons(port);
 		ret = connect(proxy.sock, (struct sockaddr *)host, sizeof(struct sockaddr_in));
 	} else {
-		struct addrinfo hints = {
-			.ai_family = AF_INET6,
-			.ai_socktype = SOCK_STREAM
-		};
-
-		ret = getaddrinfo(url, NULL, &hints, &res);
-		if (ret) {
-			LOG_ERR("getaddrinfo() failed: %d", ret);
-			goto exit_cli;
-		}
-		/* Connect to remote host */
 		struct sockaddr_in6 *host = (struct sockaddr_in6 *)res->ai_addr;
 
 		host->sin6_port = htons(port);

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -196,36 +196,24 @@ static int do_udp_client_connect(const char *url, uint16_t port)
 		}
 	}
 
+	/* Connect to remote host */
 	struct addrinfo *res;
+	struct addrinfo hints = {
+		.ai_family = proxy.family,
+		.ai_socktype = SOCK_DGRAM
+	};
 
+	ret = getaddrinfo(url, NULL, &hints, &res);
+	if (ret) {
+		LOG_ERR("getaddrinfo() failed: %d", ret);
+		goto cli_exit;
+	}
 	if (proxy.family == AF_INET) {
-		struct addrinfo hints = {
-			.ai_family = AF_INET,
-			.ai_socktype = SOCK_DGRAM
-		};
-
-		ret = getaddrinfo(url, NULL, &hints, &res);
-		if (ret) {
-			LOG_ERR("getaddrinfo() failed: %d", ret);
-			goto cli_exit;
-		}
-		/* Connect to remote host */
 		struct sockaddr_in *host = (struct sockaddr_in *)res->ai_addr;
 
 		host->sin_port = htons(port);
 		ret = connect(proxy.sock, (struct sockaddr *)host, sizeof(struct sockaddr_in));
 	} else {
-		struct addrinfo hints = {
-			.ai_family = AF_INET6,
-			.ai_socktype = SOCK_DGRAM
-		};
-
-		ret = getaddrinfo(url, NULL, &hints, &res);
-		if (ret) {
-			LOG_ERR("getaddrinfo() failed: %d", ret);
-			goto cli_exit;
-		}
-		/* Connect to remote host */
 		struct sockaddr_in6 *host = (struct sockaddr_in6 *)res->ai_addr;
 
 		host->sin6_port = htons(port);


### PR DESCRIPTION
Reworked the #XHTTPCCON implementation to add IPv6 support
Piggyback: code optimization in at_host and TCPIP proxy

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>