### PR TITLE
application: serial_lte_modem: Add secure bootloader chain

### DIFF
--- a/applications/serial_lte_modem/prj_secure_bootloader.conf
+++ b/applications/serial_lte_modem/prj_secure_bootloader.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_SECURE_BOOT=y
+#CONFIG_SB_SIGNING_KEY_FILE="my_key_file.pem"
+CONFIG_BUILD_S1_VARIANT=y
+CONFIG_SPM_SERVICE_S0_ACTIVE=y

--- a/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
@@ -56,23 +56,31 @@ int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active,
 	}
 
 	/* We have verified that there is a null-terminator, so this is safe */
-	char *space = strstr(file, " ");
+	char *delimiter = strstr(file, "+");
 
-	if (space == NULL) {
-		/* Could not find space separator in input */
+	if (delimiter == NULL) {
+		/* Could not find delimiter in input */
 		*update = NULL;
 
 		return 0;
 	}
 
+	*update = file;
 	if (s0_active) {
-		/* Point after space to 'activate' second file path (S1) */
-		*update = space + 1;
-	} else {
-		*update = file;
+		char *tmp = strrchr(file, '/');
 
+		if (tmp == NULL) {
+			/* Point after delimiter to 'activate' second file path (S1) */
+			*update = delimiter + 1;
+		} else {
+			/* Copy after delimiter to 'activate' second file path (S1)
+			 * Copy one byte more to include the ending '\0' in original string
+			 */
+			memcpy(tmp + 1, delimiter + 1, strlen(delimiter));
+		}
+	} else {
 		/* Insert null-terminator to 'activate' first file path (S0) */
-		*space = '\0';
+		*delimiter = '\0';
 	}
 
 	return 0;


### PR DESCRIPTION
Add a new overlay file to support secure bootloader chain. If
applied, Nordic immutable bootloader is put in B0 and MCUBOOT is
put in B1, then "#XDFU=1.." can be used to update MCUBOOT by FOTA

BUG-FIX B1_s1 filepath in dfu_target:

Use '+' instead of ' ' to separate B1_s0 and B1_s1, due to SPACE
is not valid char in resource URI string. Fix a bug when B1_s1 image
is to be downloaded and it's under folder(s) in the resource path.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>