### PR TITLE
MPSL: Always enable calibration when RC is used

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1000,6 +1000,11 @@ Closing sockets
 Multiprotocol Service Layer (MPSL)
 ==================================
 
+.. rst-class:: v1-6-1 v1-6-0 v1-5-1 v1-5-0
+
+DRGN-15979: :option:`CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION` must be set when :option:`CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC` is set.
+  MPSL requires RC clock calibration to be enabled when the RC clock is used as the Low Frequency clock source.
+
 .. rst-class:: v1-5-0 v1-4-2 v1-4-1
 
 DRGN-15223: `CONFIG_SYSTEM_CLOCK_NO_WAIT` is not supported for nRF5340

--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -155,7 +155,10 @@ static int mpsl_lib_init(const struct device *dev)
 	clock_cfg.skip_wait_lfclk_started =
 		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT);
 
-#ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
+#ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
+	BUILD_ASSERT(IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION),
+		    "MPSL requires clock calibration to be enabled when RC is used as LFCLK");
+
 	/* clock_cfg.rc_ctiv is given in 1/4 seconds units.
 	 * CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD is given in ms. */
 	clock_cfg.rc_ctiv = (CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_PERIOD * 4 / 1000);


### PR DESCRIPTION
MPSL requires RC clock calibration to be enabled when the RC clock is used as the Low Frequency clock source.

Ref: DRGN-15979