### PR TITLE
samples: nrf9160: modem_shell: Thingy config due to flash shortage

### DIFF
--- a/samples/nrf9160/modem_shell/boards/thingy91_nrf9160ns.conf
+++ b/samples/nrf9160/modem_shell/boards/thingy91_nrf9160ns.conf
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Configuration file for Thingy:91.
+# This file is merged with prj.conf in the application folder, and options
+# set here will take precedence if they are present in both files.
+
+# Disabling CURL by default to fit MOSH into the flash
+CONFIG_MOSH_CURL=n
+
+# For APP FOTA
+CONFIG_BOOTLOADER_MCUBOOT=y
+CONFIG_IMG_MANAGER=y
+CONFIG_IMG_ERASE_PROGRESSIVELY=y


### PR DESCRIPTION
MCUBOOT has been enabled for all applications for Thingy (CIA-259).
This reduces the available flash from ~950kB to ~380kB and hence
MOSH doesn't fit into the flash anymore as it requires ~480kB
with its default configuration.
Solution is to disable CURL by default for thingy. At the same time,
as MCUBOOT is enabled, application FOTA can also be enabled without
any significant further penalty in memory consumption.
Signed-off-by: Tommi Rantanen <tommi.rantanen@nordicsemi.no>