### PR TITLE
manifest: Update ble-controller/MPSL revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: fa5a790a287954915b4e3e48a4ff3cf614d04a2a
+      revision: 1a894638c438ce738c101b2c35894c9ffa2beb95
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Includes updates:

- The scanner is now scheduling cooperatively when window = interval. 
Performance for BLE Mesh is improved.

- Start signal jitter for the MPSL timeslot API has been 
reduced to 1us.

ble-controller revision: 9d2d547e6f8c9284f687e751e6e2fa84d08a2ee6
mpsl revision: 7b1d08624c9d2d1b4dacabab9ab3898478c6245b

Signed-off-by: Olivier Lesage <olivier.lesage@nordicsemi.no>