### PR TITLE
application: serial_lte_modem: Add IPv6 support to MQTT client

### DIFF
--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -30,7 +30,8 @@ Syntax
   It can accept one of the following values:
 
   * ``0`` - Disconnect from the MQTT broker.
-  * ``1`` - Connect to the MQTT broker.
+  * ``1`` - Connect to the MQTT broker using IP protocol family version 4.
+  * ``2`` - Connect to the MQTT broker using IP protocol family version 6.
 
 * The ``<client_id>`` parameter is a string.
   It indicates the MQTT Client ID.
@@ -93,14 +94,10 @@ Response syntax
 
 ::
 
-   #XMQTTCON: <cid>,<username>,<password>,<url>,<port>[,<sec_tag>]]
+   #XMQTTCON: <client_id>,<url>,<port>[,<sec_tag>]]
 
-* The ``<cid>`` value is a string.
+* The ``<client_id>`` value is a string.
   It indicates the MQTT client ID.
-* The ``<username>`` value is a string.
-  It indicates the MQTT Client username.
-* The ``<password>`` value is a string.
-  It indicates the MQTT Client password in cleartext.
 * The ``<url>`` value is a string.
   It indicates the MQTT broker hostname.
 * The ``<port>`` value is an unsigned 16-bit integer (0 - 65535).

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -516,6 +516,8 @@ static void httpc_thread_fn(void *arg1, void *arg2, void *arg3)
 			LOG_ERR("Fail to disconnect. Error: %d", err);
 		}
 	}
+
+	LOG_INF("HTTP thread terminated");
 }
 
 /**@brief handle AT#XHTTPCREQ commands

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -18,18 +18,16 @@
 LOG_MODULE_REGISTER(slm_mqtt, CONFIG_SLM_LOG_LEVEL);
 
 #define MQTT_MAX_TOPIC_LEN	128
-#define MQTT_MAX_URL_LEN	128
 #define MQTT_MAX_CID_LEN	64
-#define MQTT_MAX_USERNAME_LEN	64
-#define MQTT_MAX_PASSWORD_LEN	64
 #define MQTT_MESSAGE_BUFFER_LEN	NET_IPV4_MTU
 
 #define INVALID_FDS -1
 
-/**@brief MQTT connect operations. */
+/**@brief MQTT client operations. */
 enum slm_mqttcon_operation {
-	AT_MQTTCON_DISCONNECT,
-	AT_MQTTCON_CONNECT
+	MQTTC_DISCONNECT,
+	MQTTC_CONNECT,
+	MQTTC_CONNECT6,
 };
 
 /**@brief MQTT subscribe operations. */
@@ -39,17 +37,23 @@ enum slm_mqttsub_operation {
 };
 
 static struct slm_mqtt_ctx {
+	int family; /* Socket address family */
 	bool connected;
-	bool sec_transport;
-	uint8_t cid[MQTT_MAX_CID_LEN + 1];
+	struct mqtt_utf8 client_id;
 	struct mqtt_utf8 username;
-	uint8_t uname[MQTT_MAX_USERNAME_LEN + 1];
 	struct mqtt_utf8 password;
-	uint8_t pword[MQTT_MAX_PASSWORD_LEN + 1];
-	char url[MQTT_MAX_URL_LEN + 1];
-	uint16_t port;
 	sec_tag_t sec_tag;
+	union {
+		struct sockaddr_in  broker;
+		struct sockaddr_in6 broker6;
+	};
 } ctx;
+
+static char mqtt_broker_url[SLM_MAX_URL + 1];
+static uint16_t mqtt_broker_port;
+static char mqtt_clientid[MQTT_MAX_CID_LEN + 1];
+static char mqtt_username[SLM_MAX_USERNAME + 1];
+static char mqtt_password[SLM_MAX_PASSWORD + 1];
 
 static struct mqtt_publish_param pub_param;
 static uint8_t pub_topic[MQTT_MAX_TOPIC_LEN];
@@ -62,6 +66,7 @@ extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
 #define THREAD_STACK_SIZE	KB(2)
 #define THREAD_PRIORITY		K_LOWEST_APPLICATION_THREAD_PRIO
 
+static struct k_thread mqtt_thread;
 static K_THREAD_STACK_DEFINE(mqtt_thread_stack, THREAD_STACK_SIZE);
 
 /* Buffers for MQTT client. */
@@ -71,19 +76,6 @@ static uint8_t payload_buf[MQTT_MESSAGE_BUFFER_LEN];
 
 /* The mqtt client struct */
 static struct mqtt_client client;
-
-/* MQTT Broker details. */
-static struct sockaddr_storage broker;
-
-/* Connected flag */
-static K_SEM_DEFINE(mqtt_connected, 0, 1);
-
-/* File descriptor */
-static struct pollfd fds = {
-	.fd = INVALID_FDS,
-};
-
-static int do_mqtt_disconnect(void);
 
 /**@brief Function to read the published payload.
  */
@@ -209,52 +201,58 @@ void mqtt_evt_handler(struct mqtt_client *const c, const struct mqtt_evt *evt)
 static void mqtt_thread_fn(void *arg1, void *arg2, void *arg3)
 {
 	int err = 0;
+	struct pollfd fds;
 
-	while (1) {
-		/* Don't go any further until MQTT is connected */
-		k_sem_take(&mqtt_connected, K_FOREVER);
-		while (ctx.connected) {
-			err = poll(&fds, 1, mqtt_keepalive_time_left(&client));
-			if (err < 0) {
-				LOG_ERR("ERROR: poll %d", errno);
-				break;
-			}
-			err = mqtt_live(&client);
-			if ((err != 0) && (err != -EAGAIN)) {
-				LOG_ERR("ERROR: mqtt_live %d", err);
-				break;
-			}
-			if ((fds.revents & POLLIN) == POLLIN) {
-				err = mqtt_input(&client);
-				if (err != 0) {
-					LOG_ERR("ERROR: mqtt_input %d", err);
-					mqtt_abort(&client);
-					break;
-				}
-			}
-			if ((fds.revents & POLLERR) == POLLERR) {
-				LOG_ERR("POLLERR");
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+
+	fds.fd = client.transport.tcp.sock;
+#if defined(CONFIG_MQTT_LIB_TLS)
+	if (client.transport.type == MQTT_TRANSPORT_SECURE) {
+		fds.fd = client.transport.tls.sock;
+	}
+#endif
+	fds.events = POLLIN;
+	while (true) {
+		if (!ctx.connected) {
+			LOG_WRN("MQTT disconnected");
+			break;
+		}
+		err = poll(&fds, 1, mqtt_keepalive_time_left(&client));
+		if (err < 0) {
+			LOG_ERR("ERROR: poll %d", errno);
+			break;
+		}
+		/* timeout or revent, send KEEPALIVE */
+		(void)mqtt_live(&client);
+
+		if ((fds.revents & POLLIN) == POLLIN) {
+			err = mqtt_input(&client);
+			if (err != 0) {
+				LOG_ERR("ERROR: mqtt_input %d", err);
 				mqtt_abort(&client);
-				err = -EIO;
-				break;
-			}
-			if ((fds.revents & POLLHUP) == POLLHUP) {
-				LOG_ERR("POLLHUP");
-				mqtt_abort(&client);
-				err = -ECONNRESET;
-				break;
-			}
-			if ((fds.revents & POLLNVAL) == POLLNVAL) {
-				LOG_ERR("POLLNVAL");
-				mqtt_abort(&client);
-				err = -ECONNABORTED;
 				break;
 			}
 		}
-		if (err) {
+		if ((fds.revents & POLLERR) == POLLERR) {
+			LOG_ERR("POLLERR");
+			mqtt_abort(&client);
+			break;
+		}
+		if ((fds.revents & POLLHUP) == POLLHUP) {
+			LOG_ERR("POLLHUP");
+			mqtt_abort(&client);
+			break;
+		}
+		if ((fds.revents & POLLNVAL) == POLLNVAL) {
+			LOG_ERR("POLLNVAL");
+			mqtt_abort(&client);
 			break;
 		}
 	}
+
+	LOG_INF("MQTT thread terminated");
 }
 
 /**@brief Resolves the configured hostname and
@@ -263,96 +261,56 @@ static void mqtt_thread_fn(void *arg1, void *arg2, void *arg3)
 static int broker_init(void)
 {
 	int err;
-	char addr_str[INET6_ADDRSTRLEN];
 	struct addrinfo *result;
-	struct addrinfo *addr;
 	struct addrinfo hints = {
-		.ai_family = AF_INET,
+		.ai_family = ctx.family,
 		.ai_socktype = SOCK_STREAM
 	};
 
-	err = getaddrinfo(ctx.url, NULL, &hints, &result);
-	if (err != 0) {
+	err = getaddrinfo(mqtt_broker_url, NULL, &hints, &result);
+	if (err) {
 		LOG_ERR("ERROR: getaddrinfo failed %d", err);
 		return err;
 	}
-	addr = result;
 
-	while (addr != NULL) {
-		/* IPv4 Address. */
-		if (addr->ai_addrlen == sizeof(struct sockaddr_in)) {
-			struct sockaddr_in *broker4 = ((struct sockaddr_in *)&broker);
-
-			broker4->sin_addr.s_addr =
-				((struct sockaddr_in *)addr->ai_addr)->sin_addr.s_addr;
-			broker4->sin_family = AF_INET;
-			broker4->sin_port = htons(ctx.port);
-
-			inet_ntop(AF_INET, &broker4->sin_addr, addr_str, sizeof(addr_str));
-			LOG_INF("IPv4 Address %s", log_strdup(addr_str));
-			err = 0;
-			break;
-		} else if (addr->ai_addrlen == sizeof(struct sockaddr_in6)) {
-			/* IPv6 Address. */
-			struct sockaddr_in6 *broker6 = ((struct sockaddr_in6 *)&broker);
-
-			memcpy(broker6->sin6_addr.s6_addr,
-				((struct sockaddr_in6 *)addr->ai_addr)->sin6_addr.s6_addr,
-				sizeof(struct in6_addr));
-			broker6->sin6_family = AF_INET6;
-			broker6->sin6_port = htons(ctx.port);
-
-			inet_ntop(AF_INET6, &broker6->sin6_addr, addr_str, sizeof(addr_str));
-			LOG_INF("IPv6 Address %s", log_strdup(addr_str));
-			err = 0;
-			break;
-		} else {
-			LOG_ERR("error: ai_addrlen = %u should be %u or %u",
-				(unsigned int)addr->ai_addrlen,
-				(unsigned int)sizeof(struct sockaddr_in),
-				(unsigned int)sizeof(struct sockaddr_in6));
-			err = -EINVAL;
-		}
-
-		addr = addr->ai_next;
+	if (ctx.family == AF_INET) {
+		ctx.broker = *(struct sockaddr_in *)result->ai_addr;
+		ctx.broker.sin_port = htons(mqtt_broker_port);
+	} else {
+		ctx.broker6 = *(struct sockaddr_in6 *)result->ai_addr;
+		ctx.broker6.sin6_port = htons(mqtt_broker_port);
 	}
 
 	/* Free the address. */
 	freeaddrinfo(result);
-	return err;
+	return 0;
 }
 
 /**@brief Initialize the MQTT client structure
  */
-static int client_init(void)
+static void client_init(void)
 {
-	int err;
-
 	/* Init MQTT client */
 	mqtt_client_init(&client);
 
-	/* Init MQTT broker */
-	err = broker_init();
-	if (err != 0) {
-		return err;
-	}
-
 	/* MQTT client configuration */
-	client.broker = &broker;
+	if (ctx.family == AF_INET) {
+		client.broker = &ctx.broker;
+	} else {
+		client.broker = &ctx.broker6;
+	}
 	client.evt_cb = mqtt_evt_handler;
-	client.client_id.utf8 = ctx.cid;
-	client.client_id.size = strlen(ctx.cid);
-	client.user_name = NULL;
+	client.client_id.utf8 = mqtt_clientid;
+	client.client_id.size = strlen(mqtt_clientid);
 	client.password = NULL;
-	if (strlen(ctx.uname) > 0) {
-		ctx.username.utf8 = ctx.uname;
-		ctx.username.size = strlen(ctx.uname);
+	if (ctx.username.size > 0) {
 		client.user_name = &ctx.username;
-		if (strlen(ctx.pword) > 0) {
-			ctx.password.utf8 = ctx.pword;
-			ctx.password.size = strlen(ctx.pword);
+		if (ctx.password.size > 0) {
 			client.password = &ctx.password;
 		}
+	} else {
+		client.user_name = NULL;
+		/* ignore password if no user_name */
 	}
 	client.protocol_version = MQTT_VERSION_3_1_1;
 
@@ -362,42 +320,25 @@ static int client_init(void)
 	client.tx_buf = tx_buffer;
 	client.tx_buf_size = sizeof(tx_buffer);
 
+#if defined(CONFIG_MQTT_LIB_TLS)
 	/* MQTT transport configuration */
-	if (ctx.sec_transport == true) {
+	if (ctx.sec_tag != INVALID_SEC_TAG) {
 		struct mqtt_sec_config *tls_config;
 
 		tls_config = &(client.transport).tls.config;
-		tls_config->peer_verify = TLS_PEER_VERIFY_REQUIRED;
-		tls_config->cipher_list = NULL;
-		tls_config->cipher_count = 0;
+		tls_config->peer_verify   = TLS_PEER_VERIFY_REQUIRED;
+		tls_config->cipher_list   = NULL;
+		tls_config->cipher_count  = 0;
 		tls_config->sec_tag_count = 1;
-		tls_config->sec_tag_list = (int *)&ctx.sec_tag;
-		tls_config->hostname = ctx.url;
-		client.transport.type = MQTT_TRANSPORT_SECURE;
+		tls_config->sec_tag_list  = (int *)&ctx.sec_tag;
+		tls_config->hostname      = mqtt_broker_url;
+		client.transport.type     = MQTT_TRANSPORT_SECURE;
 	} else {
-		client.transport.type = MQTT_TRANSPORT_NON_SECURE;
+		client.transport.type     = MQTT_TRANSPORT_NON_SECURE;
 	}
-
-	return err;
-}
-
-/**@brief Initialize the file descriptor structure used by poll.
- */
-static int fds_init(struct mqtt_client *c)
-{
-	if (c->transport.type == MQTT_TRANSPORT_NON_SECURE) {
-		fds.fd = c->transport.tcp.sock;
-	} else {
-#if defined(CONFIG_MQTT_LIB_TLS)
-		fds.fd = c->transport.tls.sock;
 #else
-		return -ENOTSUP;
+	client.transport.type = MQTT_TRANSPORT_NON_SECURE;
 #endif
-	}
-
-	fds.events = POLLIN;
-
-	return 0;
 }
 
 static int do_mqtt_connect(void)
@@ -405,48 +346,29 @@ static int do_mqtt_connect(void)
 	int err;
 
 	if (ctx.connected) {
-		return -EINPROGRESS;
+		return -EISCONN;
 	}
 
-	err = client_init();
-	if (err != 0) {
+	/* Init MQTT broker */
+	err = broker_init();
+	if (err) {
 		return err;
 	}
 
-#if defined(CONFIG_SLM_NATIVE_TLS)
-	if (ctx.sec_tag != INVALID_SEC_TAG) {
-		err = slm_tls_loadcrdl(ctx.sec_tag);
-		if (err < 0) {
-			LOG_ERR("Fail to load credential: %d", err);
-			return err;
-		}
-	}
-#endif
-
+	/* Connect to MQTT broker */
+	client_init();
 	err = mqtt_connect(&client);
 	if (err != 0) {
 		LOG_ERR("ERROR: mqtt_connect %d", err);
-#if defined(CONFIG_SLM_NATIVE_TLS)
-		if (ctx.sec_tag != INVALID_SEC_TAG) {
-			if (slm_tls_unloadcrdl(ctx.sec_tag) != 0) {
-				LOG_ERR("Fail to load credential: %d", err);
-			}
-		}
-#endif
 		return err;
 	}
 
-	err = fds_init(&client);
-	if (err != 0) {
-		LOG_ERR("ERROR: fds_init %d", err);
-		do_mqtt_disconnect();
-		return err;
-	}
+	k_thread_create(&mqtt_thread, mqtt_thread_stack,
+			K_THREAD_STACK_SIZEOF(mqtt_thread_stack),
+			mqtt_thread_fn, NULL, NULL, NULL,
+			THREAD_PRIORITY, K_USER, K_NO_WAIT);
 
-	/** start polling now for CONNACK */
 	ctx.connected = true;
-	k_sem_give(&mqtt_connected);
-
 	return 0;
 }
 
@@ -454,19 +376,20 @@ static int do_mqtt_disconnect(void)
 {
 	int err;
 
+	if (!ctx.connected) {
+		return -ENOTCONN;
+	}
+
 	err = mqtt_disconnect(&client);
 	if (err) {
 		LOG_ERR("ERROR: mqtt_disconnect %d", err);
+		return err;
 	}
-#if defined(CONFIG_SLM_NATIVE_TLS)
-	if (ctx.sec_tag != INVALID_SEC_TAG) {
-		err = slm_tls_unloadcrdl(ctx.sec_tag);
-		if (err < 0) {
-			LOG_ERR("Fail to load credential: %d", err);
-			return err;
-		}
+
+	if (k_thread_join(&mqtt_thread, K_SECONDS(CONFIG_MQTT_KEEPALIVE)) != 0) {
+		LOG_WRN("Wait for thread terminate failed");
 	}
-#endif
+
 	slm_at_mqtt_uninit();
 
 	return err;
@@ -525,100 +448,78 @@ static int do_mqtt_subscribe(uint16_t op,
 int handle_at_mqtt_connect(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
-
 	uint16_t op;
-	size_t url_sz = MQTT_MAX_URL_LEN;
-	size_t cid_sz = MQTT_MAX_CID_LEN;
-	size_t username_sz = MQTT_MAX_USERNAME_LEN;
-	size_t password_sz = MQTT_MAX_PASSWORD_LEN;
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
-		if (at_params_valid_count_get(&at_param_list) <= 1) {
-			return -EINVAL;
-		}
 		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
-		if (err < 0) {
+		if (err) {
 			return err;
 		}
-		if (op == AT_MQTTCON_CONNECT) {
-			uint16_t port;
+		if (op == MQTTC_CONNECT || op == MQTTC_CONNECT6)  {
+			size_t clientid_sz = sizeof(mqtt_clientid);
+			size_t username_sz = sizeof(mqtt_username);
+			size_t password_sz = sizeof(mqtt_password);
+			size_t url_sz = sizeof(mqtt_broker_url);
 
-			if (at_params_valid_count_get(&at_param_list) <= 6) {
-				return -EINVAL;
+			err = util_string_get(&at_param_list, 2, mqtt_clientid, &clientid_sz);
+			if (err) {
+				return err;
 			}
-			if (ctx.connected) {
-				return -EISCONN;
+			err = util_string_get(&at_param_list, 3, mqtt_username, &username_sz);
+			if (err) {
+				return err;
+			} else {
+				ctx.username.utf8 = mqtt_username;
+				ctx.username.size = strlen(mqtt_username);
 			}
-
-			memset(&ctx, 0, sizeof(ctx));
+			err = util_string_get(&at_param_list, 4, mqtt_password, &password_sz);
+			if (err) {
+				return err;
+			} else {
+				ctx.password.utf8 = mqtt_password;
+				ctx.password.size = strlen(mqtt_password);
+			}
+			err = util_string_get(&at_param_list, 5, mqtt_broker_url, &url_sz);
+			if (err) {
+				return err;
+			}
+			err = at_params_unsigned_short_get(&at_param_list, 6, &mqtt_broker_port);
+			if (err) {
+				return err;
+			}
 			ctx.sec_tag = INVALID_SEC_TAG;
-
-			err = util_string_get(&at_param_list, 2, ctx.cid, &cid_sz);
-			if (err < 0) {
-				return err;
-			}
-			err = util_string_get(&at_param_list, 3, ctx.uname, &username_sz);
-			if (err < 0) {
-				return err;
-			}
-			err = util_string_get(&at_param_list, 4, ctx.pword, &password_sz);
-			if (err < 0) {
-				return err;
-			}
-			if ((username_sz == 0) && (password_sz > 0)) {
-				/* Password without username is invalid. */
-				return -EINVAL;
-			}
-			err = util_string_get(&at_param_list, 5, ctx.url, &url_sz);
-			if (err < 0) {
-				return err;
-			}
-			err = at_params_unsigned_short_get(&at_param_list, 6, &port);
-			if (err < 0) {
-				return err;
-			}
-			ctx.port = (uint16_t)port;
-			if (at_params_valid_count_get(&at_param_list) == 8) {
+			if (at_params_valid_count_get(&at_param_list) > 7) {
 				err = at_params_unsigned_int_get(&at_param_list, 7, &ctx.sec_tag);
-				if (err < 0) {
+				if (err) {
 					return err;
 				}
-				ctx.sec_transport = true;
 			}
+			ctx.family = (op == MQTTC_CONNECT) ? AF_INET : AF_INET6;
 			err = do_mqtt_connect();
-			break;
-		} else if (op == AT_MQTTCON_DISCONNECT) {
-			if (!ctx.connected) {
-				return -ENOTCONN;
-			}
-			LOG_DBG("Disconnect from broker");
+		} else if (op == MQTTC_DISCONNECT) {
 			err = do_mqtt_disconnect();
-			if (err) {
-				LOG_ERR("Fail to disconnect. Error: %d", err);
-			}
-		} break;
+		} else {
+			err = -EINVAL;
+		}
+		break;
 
 	case AT_CMD_TYPE_READ_COMMAND:
-		if (ctx.sec_transport) {
-			sprintf(rsp_buf,
-				"\r\n#XMQTTCON: %d,\"%s\",\"%s\",\"%s\",\"%s\",%d,%d\r\n",
-				ctx.connected, log_strdup(ctx.cid), log_strdup(ctx.uname),
-				log_strdup(ctx.pword), log_strdup(ctx.url), ctx.port, ctx.sec_tag);
+		if (ctx.sec_tag != INVALID_SEC_TAG) {
+			sprintf(rsp_buf, "\r\n#XMQTTCON: %d,\"%s\",\"%s\",%d,%d\r\n",
+				ctx.connected, mqtt_clientid, mqtt_broker_url, mqtt_broker_port,
+				ctx.sec_tag);
 		} else {
-			sprintf(rsp_buf,
-				"\r\n#XMQTTCON: %d,\"%s\",\"%s\",\"%s\","
-				"\"%s\",%d\r\n",
-				ctx.connected, log_strdup(ctx.cid), log_strdup(ctx.uname),
-				log_strdup(ctx.pword), log_strdup(ctx.url), ctx.port);
+			sprintf(rsp_buf, "\r\n#XMQTTCON: %d,\"%s\",\"%s\",%d\r\n",
+				ctx.connected, mqtt_clientid, mqtt_broker_url, mqtt_broker_port);
 		}
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "\r\n#XMQTTCON: (0,1),<cid>,<username>,"
-			"<password>,<url>,<port>,<sec_tag>\r\n");
+		sprintf(rsp_buf, "\r\n#XMQTTCON: (0,1,2),<cid>,<username>,"
+				 "<password>,<url>,<port>,<sec_tag>\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;
@@ -819,6 +720,8 @@ int handle_at_mqtt_unsubscribe(enum at_cmd_type cmd_type)
 int slm_at_mqtt_init(void)
 {
 	pub_param.message_id = 0;
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.sec_tag = INVALID_SEC_TAG;
 
 	return 0;
 }
@@ -826,11 +729,6 @@ int slm_at_mqtt_init(void)
 int slm_at_mqtt_uninit(void)
 {
 	client.broker = NULL;
-	fds.fd = INVALID_FDS;
 
 	return 0;
 }
-
-K_THREAD_DEFINE(mqtt_thread, K_THREAD_STACK_SIZEOF(mqtt_thread_stack),
-		mqtt_thread_fn, NULL, NULL, NULL,
-		THREAD_PRIORITY, 0, 0);

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -14,6 +14,8 @@
 #define INVALID_ROLE         -1
 
 #define SLM_MAX_URL          128  /** max size of URL string */
+#define SLM_MAX_USERNAME     32   /** max size of username in login */
+#define SLM_MAX_PASSWORD     32   /** max size of password in login */
 
 #define MODEM_MSS            708
 #define MODEM_MTU            1280


### PR DESCRIPTION
Rework of #XMQTTCON implementation:
.Add IPv6 support to MQTT broker connection
.Start MQTT thread dynamically so as to support re-connection
.Use no native TLS, but TLS on modem side only
.Code clean-up
Unifying the way of waiting for thread quit
.Align the implementation in TCPIP proxy, MQTT
Bug-fix, stopping UDP Server has a bug

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>