### PR TITLE
samples: nrf9160: modem_shell: Print BRANCH_NAME

### DIFF
--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -69,7 +69,11 @@ static void mosh_print_version_info(void)
 #endif
 
 #if defined(BUILD_VARIANT)
+#if defined(BRANCH_NAME)
+	printk("\nMOSH build variant: %s/%s\n\n", STRINGIFY(BRANCH_NAME), STRINGIFY(BUILD_VARIANT));
+#else
 	printk("\nMOSH build variant: %s\n\n", STRINGIFY(BUILD_VARIANT));
+#endif
 #else
 	printk("\nMOSH build variant: dev\n\n");
 #endif


### PR DESCRIPTION
Print BRANCH_NAME in startup as part of mosh version info.