### PR TITLE
mpsl: Add nrf21540_gpio support to softdevice controller

### DIFF
--- a/subsys/mpsl/Kconfig.fem
+++ b/subsys/mpsl/Kconfig.fem
@@ -9,7 +9,7 @@ DT_COMPAT_GENERIC_FEM_2_CTRL_PIN := generic-fem-two-ctrl-pins
 
 config MPSL_FEM_NRF21540_GPIO_SUPPORT
 	bool
-	default $(dt_nodelabel_has_compat,nrf_radio_fem,$(DT_COMPAT_NORDIC_NRF21540_GPIO)) && !BT
+	default $(dt_nodelabel_has_compat,nrf_radio_fem,$(DT_COMPAT_NORDIC_NRF21540_GPIO))
 
 config MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT
 	bool

--- a/subsys/mpsl/mpsl_fem.c
+++ b/subsys/mpsl/mpsl_fem.c
@@ -62,7 +62,7 @@ static void fem_pin_num_correction(uint8_t *p_gpio_pin, const char *gpio_lbl)
 }
 
 #if IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_GPIO)
-static int inactive_pin_configure(uint8_t pin, const char *gpio_lbl,
+static inline int inactive_pin_configure(uint8_t pin, const char *gpio_lbl,
 				  gpio_flags_t flags)
 {
 	const struct device *port;


### PR DESCRIPTION
The softdevice controller uses mpsl_fem_disable of FEM protocol API to
disable front-end module (FEM) when no radio activity is expected.

Signed-off-by: Ryan Chu <ryan.chu@nordicsemi.no>