### PR TITLE
nrf_802154: Add subsys for nRF 802.15.4 Radio Driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -131,6 +131,7 @@ Kconfig*                                  @tejlmand
 /subsys/caf/                              @pdunaj
 /subsys/debug/                            @nordic-krch @anangl
 /subsys/dfu/                              @hakonfam @sigvartmh
+/subsys/ieee802154/                       @rlubos @czeslawmakarski
 /subsys/mgmt/                             @hakonfam @sigvartmh
 /subsys/esb/                              @Raane @lemrey
 /subsys/event_manager/                    @pdunaj

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -49,3 +49,4 @@ add_subdirectory(debug)
 add_subdirectory(partition_manager)
 
 add_subdirectory_ifdef(CONFIG_NRF_RPC nrf_rpc)
+add_subdirectory_ifdef(CONFIG_NRF_802154_RADIO_DRIVER ieee802154)

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -42,3 +42,5 @@ rsource "zigbee/Kconfig"
 rsource "mgmt/fmfu/Kconfig"
 
 rsource "caf/Kconfig"
+
+rsource "ieee802154/Kconfig"

--- a/subsys/ieee802154/CMakeLists.txt
+++ b/subsys/ieee802154/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+
+zephyr_library_sources(
+  nrf_802154_configurator.c
+  )

--- a/subsys/ieee802154/Kconfig
+++ b/subsys/ieee802154/Kconfig
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menu "Nordic IEEE 802.15.4"
+
+config NRF_802154_RADIO_CONFIG_PRIO
+	int "nRF52 IEEE 802.15.4 configuration priority"
+	default 91
+	help
+	  Set the nRF IEEE 802.15.4 configuration priority number. Must be
+	  greater than nRF IEEE 802.15.4 Radio initialization priority.
+
+endmenu

--- a/subsys/ieee802154/nrf_802154_configurator.c
+++ b/subsys/ieee802154/nrf_802154_configurator.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <init.h>
+#include <logging/log.h>
+#include <sys/__assert.h>
+#include <devicetree.h>
+#include <nrf_802154.h>
+#include <nrf_802154_config.h>
+
+LOG_MODULE_REGISTER(nrf_802154_configure);
+
+/* NRF21540 FEM */
+#if IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_GPIO)
+#define LNA_GAIN CONFIG_MPSL_FEM_NRF21540_RX_GAIN_DB
+/* Simple GPIO FEM */
+#elif IS_ENABLED(CONFIG_MPSL_FEM_SIMPLE_GPIO)
+#if !DT_NODE_EXISTS(DT_NODELABEL(nrf_radio_fem))
+#error Node with label 'nrf_radio_fem' not found in the devicetree.
+#endif
+#define LNA_GAIN DT_PROP(DT_NODELABEL(nrf_radio_fem), rx_gain_db)
+/* No FEM */
+#else
+#define LNA_GAIN 0U
+#endif
+
+static void ccaed_threshold_configure(void)
+{
+	nrf_802154_cca_cfg_t cca_cfg;
+
+	nrf_802154_cca_cfg_get(&cca_cfg);
+
+	/* Overwrite thresholds accounting for RX track gain. */
+	cca_cfg.ed_threshold = NRF_802154_CCA_ED_THRESHOLD_DEFAULT + LNA_GAIN;
+	cca_cfg.corr_threshold = NRF_802154_CCA_CORR_THRESHOLD_DEFAULT + LNA_GAIN;
+
+	nrf_802154_cca_cfg_set(&cca_cfg);
+}
+
+static int nrf_802154_configure(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	ccaed_threshold_configure();
+
+	return 0;
+}
+
+#if IS_ENABLED(CONFIG_NRF_802154_SER_RADIO)
+#define INIT_PRIO CONFIG_NRF_802154_SER_RADIO_INIT_PRIO
+#else
+#define INIT_PRIO CONFIG_IEEE802154_NRF5_INIT_PRIO
+#endif
+
+BUILD_ASSERT(INIT_PRIO < CONFIG_NRF_802154_RADIO_CONFIG_PRIO,
+	     "nRF 802.15.4 driver configuration would not be performed after its initialization");
+
+SYS_INIT(nrf_802154_configure, POST_KERNEL, CONFIG_NRF_802154_RADIO_CONFIG_PRIO);


### PR DESCRIPTION
This commit adds a subsys for nRF 802.15.4 Radio Driver. The goal of
this subsys is to perform operations on initialized Radio Driver.
This commit adds an automatic adjustment of CCA energy detection
threshold in case a FEM is present.