### PR TITLE
Modem shell: minor shell improvements

### DIFF
--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -27,8 +27,6 @@ CONFIG_SHELL=y
 CONFIG_SHELL_WILDCARD=n
 CONFIG_SHELL_PROMPT_UART="mosh:~$ "
 CONFIG_SHELL_ARGC_MAX=16
-CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=160
-CONFIG_SHELL_DEFAULT_TERMINAL_HEIGHT=48
 # Command line buffer is set this large to enable writing of certificates.
 CONFIG_SHELL_CMD_BUFF_SIZE=3072
 # Shell stack has impact for modem shell application, not CONFIG_MAIN_STACK_SIZE

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -161,4 +161,9 @@ void main(void)
 #if defined(CONFIG_BOOTLOADER_MCUBOOT)
 	boot_write_img_confirmed();
 #endif
+
+	/* Resize terminal width and height of the shell to have proper command editing. */
+	shell_execute_cmd(shell_global, "resize");
+	/* Run empty command because otherwise "resize" would be set to the command line. */
+	shell_execute_cmd(shell_global, "");
 }


### PR DESCRIPTION
Two changes to shell behavior:
- Use default shell width and height. We used to have larger width specified and there shouldn't be a reason for that.
- Shell size is resized at startup so shell works properly if the terminal window is not standard size.