### PR TITLE
manifest: Nrfxlib with SHA1 as opt in with TFM

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1c0ba974a1db404110f36976ac942645fedc4a36
+      revision: d048f584bb79997e1f60e3539b4520026ebb7745
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-Point to the PR with the SHA1 as opt in for
 TFM builds

nrfxlib PR: [pull/531](https://github.com/nrfconnect/sdk-nrfxlib/pull/531)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>