### PR TITLE
lib: date_time: Use correct variable type for `last_date_time_update`

### DIFF
--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -67,7 +67,7 @@ static struct k_work_delayable time_work;
 
 static struct time_aux {
 	int64_t date_time_utc;
-	int last_date_time_update;
+	int64_t last_date_time_update;
 } time_aux;
 
 static bool initial_valid_time;


### PR DESCRIPTION
Change the type of `last_date_time_update` to `int64_t`.

The variable `last_date_time_update` is used to calculate timestamps
returned by the library and is continously updated everytime the
library updates its internal UTC time reference. This happens with
`k_uptime_get()` which returns an int64 bit value. Previously the
variable would overflow after a quite limited amount of days, which
would cause inaccurate timestamps returned by the library.