### PR TITLE
samples: nrf9160: mosh: toggle uart power state when pressing button 2

### DIFF
--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -123,6 +123,9 @@ CONFIG_SUPL_CLIENT_LIB=n
 # Enable if an external GPS antenna is used with the GPS driver.
 #CONFIG_NRF9160_GPS_ANTENNA_EXTERNAL=y
 
+# Library for buttons and LEDs
+CONFIG_DK_LIBRARY=y
+
 # FOTA
 CONFIG_FLASH=y
 CONFIG_REBOOT=y

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -25,6 +25,9 @@
 #include <modem/modem_info.h>
 #include <modem/lte_lc.h>
 
+#include <dk_buttons_and_leds.h>
+#include "uart/uart_shell.h"
+
 #if defined(CONFIG_MOSH_PPP)
 #include <shell/shell.h>
 #include "ppp_ctrl.h"
@@ -77,6 +80,14 @@ static void mosh_print_version_info(void)
 #else
 	printk("\nMOSH build variant: dev\n\n");
 #endif
+}
+
+static void button_handler(uint32_t button_states, uint32_t has_changed)
+{
+	if (has_changed & button_states & DK_BTN2_MSK) {
+		shell_print(shell_global, "Button 2 pressed, toggling UART power state");
+		uart_toggle_power_state(shell_global);
+	}
 }
 
 void main(void)
@@ -154,6 +165,11 @@ void main(void)
 	}
 	modem_info_params_init(&modem_param);
 #endif
+
+	err = dk_buttons_init(button_handler);
+	if (err) {
+		printk("Failed to initialize DK buttons library, error: %d", err);
+	}
 
 	/* Application started successfully, mark image as OK to prevent
 	 * revert at next reboot.

--- a/samples/nrf9160/modem_shell/src/uart/uart.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart.c
@@ -28,8 +28,22 @@ void disable_uarts(void)
 void enable_uarts(void)
 {
 	const struct device *uart_dev;
+	uint32_t current_state;
 
 	uart_dev = device_get_binding(DT_LABEL(DT_NODELABEL(uart0)));
+
+	int err = pm_device_state_get(uart_dev, &current_state);
+
+	if (err) {
+		printk("Failed to assess UART power state, pm_device_state_get: %d", err);
+		return;
+	}
+
+	/* If UARTs are already enabled, do nothing */
+	if (current_state == PM_DEVICE_STATE_ACTIVE) {
+		return;
+	}
+
 	if (uart_dev) {
 		pm_device_state_set(uart_dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
 	}
@@ -38,4 +52,6 @@ void enable_uarts(void)
 	if (uart_dev) {
 		pm_device_state_set(uart_dev, PM_DEVICE_STATE_ACTIVE, NULL, NULL);
 	}
+
+	printk("UARTs enabled\n");
 }

--- a/samples/nrf9160/modem_shell/src/uart/uart_shell.h
+++ b/samples/nrf9160/modem_shell/src/uart/uart_shell.h
@@ -10,4 +10,15 @@
 void uart_toggle_power_state_at_event(const struct shell *shell,
 				       const struct lte_lc_evt *const evt);
 
+/**
+ * @brief Toggles UART0 and UART1 power states.
+ *
+ * @details Checks the current power state of UART0. If UART0 is currently in
+ * PM_DEVICE_STATE_ACTIVE, both UART0 and UART1 are set to PM_DEVICE_STATE_LOW_POWER. If UART0 is
+ * currently in any other state than PM_DEVICE_STATE_ACTIVE, both UARTs are set to active state.
+ *
+ * @param[in] shell Pointer to shell instance.
+ */
+void uart_toggle_power_state(const struct shell *shell);
+
 #endif /* MOSH_UART_SHELL_H */


### PR DESCRIPTION
Added handler and a function to toggle uart power state if button 2 is
pressed. Changed the implementation of 'uart disable' command to use a
timer instead of k_sleep in order to enable waking up uarts by
pressing button 2.

Jira: MOSH-136

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>