### PR TITLE
samples: nrf9160: modem_shell: link cmd updates

### DIFF
--- a/samples/nrf9160/modem_shell/Kconfig
+++ b/samples/nrf9160/modem_shell/Kconfig
@@ -32,6 +32,7 @@ config MOSH_PING
 config MOSH_LINK
 	bool "Link control"
 	depends on LTE_LINK_CONTROL
+	depends on MODEM_INFO
 	depends on SETTINGS
 	default y
 	help

--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -502,6 +502,9 @@ int link_func_mode_set(enum lte_lc_func_mode fun)
 		/* Enable Rel14 features before going to normal mode */
 		link_enable_rel14_features();
 
+		/* (Re)register for rsrp notifications: */
+		modem_info_rsrp_register(link_rsrp_signal_handler);
+
 		/* Run custom at cmds from settings (link nmodeat -mosh command): */
 		link_normal_mode_at_cmds_run();
 

--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -48,16 +48,18 @@ struct pdn_activation_status_info {
 	uint8_t cid;
 };
 
-/* System work queue for getting the modem info that ain't in lte connection ind: */
+/* Work for getting the modem info that ain't in lte connection ind: */
 static struct k_work registered_work;
 
-/* Work queue for signal info: */
+/* Work for a signal info: */
 static struct k_work modem_info_signal_work;
+
 #define LINK_RSRP_VALUE_NOT_KNOWN -999
 static int32_t modem_rsrp = LINK_RSRP_VALUE_NOT_KNOWN;
 
-/* Work queue for continuous neighbor cell measurements: */
+/* Work for continuous neighbor cell measurements: */
 static struct k_work continuous_ncellmeas_work;
+
 enum link_ncellmeas_modes ncellmeas_mode = LINK_NCELLMEAS_MODE_NONE;
 
 static void link_continuous_ncellmeas(struct k_work *work)

--- a/samples/nrf9160/modem_shell/src/link/link.h
+++ b/samples/nrf9160/modem_shell/src/link/link.h
@@ -8,6 +8,12 @@
 #define MOSH_LINK_H
 #include <modem/lte_lc.h>
 
+enum link_ncellmeas_modes {
+	LINK_NCELLMEAS_MODE_NONE = 0,
+	LINK_NCELLMEAS_MODE_SINGLE,
+	LINK_NCELLMEAS_MODE_CONTINUOUS,
+};
+
 #define LINK_APN_STR_MAX_LENGTH 100
 
 #define LINK_FUNMODE_NONE 99
@@ -15,7 +21,7 @@
 void link_init(void);
 void link_ind_handler(const struct lte_lc_evt *const evt);
 void link_rsrp_subscribe(bool subscribe);
-void link_ncellmeas_start(bool start);
+void link_ncellmeas_start(bool start, enum link_ncellmeas_modes mode);
 void link_modem_sleep_notifications_subscribe(uint32_t warn_time_ms, uint32_t threshold_ms);
 void link_modem_sleep_notifications_unsubscribe(void);
 void link_modem_tau_notifications_subscribe(uint32_t warn_time_ms, uint32_t threshold_ms);

--- a/samples/nrf9160/modem_shell/src/link/link_api.c
+++ b/samples/nrf9160/modem_shell/src/link/link_api.c
@@ -22,6 +22,7 @@
 
 #include "link_shell.h"
 #include "link_shell_print.h"
+#include "link_shell_pdn.h"
 #include "link_api.h"
 
 #if defined(CONFIG_AT_CMD)
@@ -49,6 +50,41 @@
 #define AT_CMD_PDP_CONTEXT_READ_RSP_DELIM "\r\n"
 
 extern const struct shell *shell_global;
+
+#define AT_CMD_PDP_CONTEXTS_ACT_READ "AT+CGACT?"
+
+static void link_api_context_info_fill_activation_status(
+	struct pdp_context_info_array *pdp_info)
+{
+	char buf[16] = { 0 };
+	const char *p;
+	char at_response_str[256];
+	int ret;
+	int ctx_cnt = pdp_info->size;
+	struct pdp_context_info *ctx_tbl = pdp_info->array;
+
+	ret = at_cmd_write(AT_CMD_PDP_CONTEXTS_ACT_READ, at_response_str,
+			   sizeof(at_response_str), NULL);
+	if (ret) {
+		shell_error(
+			shell_global,
+			"Cannot get PDP contexts activation states, err: %d",
+			ret);
+		return;
+	}
+
+	/* For each contexts: */
+	for (int i = 0; i < ctx_cnt; i++) {
+		/* Search for a string +CGACT: <cid>,<state> */
+		snprintf(buf, sizeof(buf), "+CGACT: %d,1", ctx_tbl[i].cid);
+		p = strstr(at_response_str, buf);
+		if (p) {
+			ctx_tbl[i].ctx_active = true;
+		}
+	}
+}
+
+/* ****************************************************************************/
 
 static int link_api_pdn_id_get(uint8_t cid)
 {
@@ -81,37 +117,7 @@ static int link_api_pdn_id_get(uint8_t cid)
 	return ret;
 }
 
-#define AT_CMD_PDP_CONTEXTS_ACT_READ "AT+CGACT?"
-
-static void link_api_get_pdn_states(struct pdp_context_info_array *pdp_info)
-{
-	char buf[16] = { 0 };
-	const char *p;
-	char at_response_str[256];
-	int ret;
-	int ctx_cnt = pdp_info->size;
-	struct pdp_context_info *ctx_tbl = pdp_info->array;
-
-	ret = at_cmd_write(AT_CMD_PDP_CONTEXTS_ACT_READ, at_response_str,
-			   sizeof(at_response_str), NULL);
-	if (ret) {
-		shell_error(
-			shell_global,
-			"Cannot get PDP contexts activation states, err: %d",
-			ret);
-		return;
-	}
-
-	/* For each contexts: */
-	for (int i = 0; i < ctx_cnt; i++) {
-		/* Search for a string +CGACT: <cid>,<state> */
-		snprintf(buf, sizeof(buf), "+CGACT: %d,1", ctx_tbl[i].cid);
-		p = strstr(at_response_str, buf);
-		if (p) {
-			ctx_tbl[i].ctx_active = true;
-		}
-	}
-}
+/* ****************************************************************************/
 
 struct pdp_context_info *link_api_get_pdp_context_info_by_pdn_cid(int pdn_cid)
 {
@@ -764,7 +770,7 @@ parse:
 	}
 
 	/* ...and finally, fill PDP context activation status for each: */
-	link_api_get_pdn_states(pdp_info);
+	link_api_context_info_fill_activation_status(pdp_info);
 
 clean_exit:
 	at_params_list_free(&param_list);
@@ -776,7 +782,6 @@ clean_exit:
 
 /* *****************************************************************************/
 
-#if defined(CONFIG_MODEM_INFO)
 void link_api_modem_info_get_for_shell(const struct shell *shell, bool connected)
 {
 	struct pdp_context_info_array pdp_context_info_tbl;
@@ -885,4 +890,3 @@ void link_api_modem_info_get_for_shell(const struct shell *shell, bool connected
 #endif /* CONFIG_AT_CMD */
 	}
 }
-#endif /* CONFIG_MODEM_INFO */

--- a/samples/nrf9160/modem_shell/src/link/link_api.h
+++ b/samples/nrf9160/modem_shell/src/link/link_api.h
@@ -44,10 +44,9 @@ struct pdp_context_info_array {
 	size_t size;
 };
 
-#if defined(CONFIG_MODEM_INFO)
 void link_api_modem_info_get_for_shell(const struct shell *shell,
 					bool connected);
-#endif
+
 #if defined(CONFIG_AT_CMD)
 void link_api_coneval_read_for_shell(const struct shell *shell);
 

--- a/samples/nrf9160/modem_shell/src/link/link_settings.c
+++ b/samples/nrf9160/modem_shell/src/link/link_settings.c
@@ -427,20 +427,16 @@ int link_sett_save_defcontauth_prot(int auth_prot)
 	int err;
 	const char *key =
 		LINK_SETT_KEY "/" LINK_SETT_DEFCONTAUTH_PROTOCOL_KEY;
-	enum pdn_auth prot;
+	enum pdn_auth method;
 
-	if (auth_prot == 0) {
-		prot = PDN_AUTH_NONE;
-	} else if (auth_prot == 1) {
-		prot = PDN_AUTH_PAP;
-	} else if (auth_prot == 2) {
-		prot = PDN_AUTH_CHAP;
-	} else {
+	err = link_shell_pdn_auth_prot_to_pdn_lib_method_map(auth_prot,
+							     &method);
+	if (err) {
 		shell_error(shell_global, "Uknown auth protocol %d", auth_prot);
 		return -EINVAL;
 	}
 
-	err = settings_save_one(key, &prot, sizeof(enum pdn_auth));
+	err = settings_save_one(key, &auth_prot, sizeof(enum pdn_auth));
 	if (err) {
 		shell_error(
 			shell_global,
@@ -448,10 +444,10 @@ int link_sett_save_defcontauth_prot(int auth_prot)
 			err);
 		return err;
 	}
-	link_settings.defcontauth_prot = prot;
+	link_settings.defcontauth_prot = method;
 
 	shell_print(shell_global, "Key \"%s\" with value \"%d\" saved", key,
-		    prot);
+		    method);
 
 	return 0;
 }

--- a/samples/nrf9160/modem_shell/src/link/link_shell.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell.c
@@ -86,7 +86,7 @@ static const char link_usage_str[] =
 	"  disconnect:   Disconnect from given apn by deactivating and destroying\n"
 	"                a PDP context\n"
 	"  rsrp:         Subscribe/unsubscribe for RSRP signal info\n"
-	"  ncellmeas:    Start/stop neighbor cell measurements\n"
+	"  ncellmeas:    Start/cancel neighbor cell measurements\n"
 	"  msleep:       Subscribe/unsubscribe for modem sleep notifications\n"
 	"  tau:          Subscribe/unsubscribe for modem TAU pre-warning notifications\n"
 	"  funmode:      Set/read functional modes of the modem\n"
@@ -405,6 +405,7 @@ static void link_shell_cmd_defaults_set(struct link_shell_cmd_args_t *link_cmd_a
 		LTE_LC_SYSTEM_MODE_PREFER_AUTO;
 	link_cmd_args->lte_mode = LTE_LC_LTE_MODE_NONE;
 	link_cmd_args->ncellmeasmode = LINK_NCELLMEAS_MODE_NONE;
+	link_cmd_args->common_option = LINK_COMMON_NONE;
 }
 
 /******************************************************************************/
@@ -554,6 +555,9 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 		ret = -EINVAL;
 		goto show_usage;
 	}
+
+	/* Reset getopt due to possible previous failures: */
+	optreset = 1;
 
 	/* We start from subcmd arguments */
 	optind = 2;
@@ -731,8 +735,7 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 					shell,
 					"APN string length %d exceeded. Maximum is %d.",
 					apn_len, LINK_APN_STR_MAX_LENGTH);
-				ret = -EINVAL;
-				goto show_usage;
+				return -EINVAL;
 			}
 			apn = optarg;
 			break;
@@ -1333,6 +1336,9 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 	return ret;
 
 show_usage:
+	/* Reset getopt for another users: */
+	optreset = 1;
+
 	link_shell_print_usage(shell, &link_cmd_args);
 	return ret;
 }

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
@@ -121,9 +121,7 @@ void link_pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)
 			    event_str[event]);
 #if defined(CONFIG_MOSH_PPP)
 		if (cid == 0) {
-			/* Notify PPP side about the default PDN activation
-			 * status:
-			 */
+			/* Notify PPP side about the default PDN activation status */
 			if (event == PDN_EVENT_ACTIVATED) {
 				ppp_ctrl_default_pdn_active(true);
 			} else if (event == PDN_EVENT_DEACTIVATED) {
@@ -182,14 +180,14 @@ static struct link_shell_pdn_info *link_shell_pdn_info_list_add(int pdn_id, uint
 	struct link_shell_pdn_info *new_pdn_info = NULL;
 	struct link_shell_pdn_info *iterator = NULL;
 
-	/* Check if already in list, if there; then return an existing one: */
+	/* Check if already in list, if there; then return an existing one */
 	SYS_DLIST_FOR_EACH_CONTAINER(&pdn_info_list, iterator, dnode) {
 		if (iterator->cid == cid) {
 			return iterator;
 		}
 	}
 
-	/* Not already at list, let's add it: */
+	/* Not already at list, let's add it */
 	new_pdn_info =
 		(struct link_shell_pdn_info *)k_calloc(1, sizeof(struct link_shell_pdn_info));
 	new_pdn_info->cid = cid;
@@ -265,14 +263,14 @@ int link_shell_pdn_connect(const struct shell *shell, const char *apn_name,
 		goto cleanup_and_fail;
 	}
 
-	/* Configure a PDP context with APN and Family */
+	/* Configure a PDP context with APN and family */
 	ret = pdn_ctx_configure(cid, apn_name, pdn_lib_family, NULL);
 	if (ret) {
 		shell_error(shell, "pdn_ctx_configure() failed, err %d\n", ret);
 		goto cleanup_and_fail;
 	}
 
-	/* Set authentication params if requested: */
+	/* Set authentication params if requested */
 	if (auth_params != NULL) {
 		ret = pdn_ctx_auth_set(cid, auth_params->method,
 				       auth_params->user,
@@ -294,7 +292,7 @@ int link_shell_pdn_connect(const struct shell *shell, const char *apn_name,
 
 	pdn_id = pdn_id_get(cid);
 
-	/* Add to PDN list: */
+	/* Add to PDN list */
 	new_pdn_info = link_shell_pdn_info_list_add(pdn_id, cid);
 	if (new_pdn_info == NULL) {
 		shell_error(

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.h
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.h
@@ -10,15 +10,24 @@
 #include <shell/shell.h>
 #include <modem/pdn.h>
 
+struct link_shell_pdn_auth {
+	enum pdn_auth method;
+	char *user;
+	char *password;
+};
+
 void link_shell_pdn_init(const struct shell *shell);
 
 int link_shell_pdn_connect(const struct shell *shell, const char *apn_name,
-			    const char *family_str);
+			   const char *family_str,
+			   const struct link_shell_pdn_auth *auth_params);
 int link_shell_pdn_disconnect(const struct shell *shell, int pdn_cid);
 int link_shell_pdn_activate(const struct shell *shell, int pdn_cid);
 
 int link_family_str_to_pdn_lib_family(enum pdn_fam *ret_fam, const char *family);
 const char *link_pdn_lib_family_to_string(enum pdn_fam pdn_family, char *out_fam_str);
 bool link_shell_pdn_info_is_in_list(uint8_t cid);
+int link_shell_pdn_auth_prot_to_pdn_lib_method_map(int auth_proto,
+						   enum pdn_auth *method);
 
 #endif /* MOSH_LINK_SHELL_PDN_H */

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.h
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.h
@@ -15,8 +15,10 @@ void link_shell_pdn_init(const struct shell *shell);
 int link_shell_pdn_connect(const struct shell *shell, const char *apn_name,
 			    const char *family_str);
 int link_shell_pdn_disconnect(const struct shell *shell, int pdn_cid);
+int link_shell_pdn_activate(const struct shell *shell, int pdn_cid);
 
 int link_family_str_to_pdn_lib_family(enum pdn_fam *ret_fam, const char *family);
 const char *link_pdn_lib_family_to_string(enum pdn_fam pdn_family, char *out_fam_str);
+bool link_shell_pdn_info_is_in_list(uint8_t cid);
 
 #endif /* MOSH_LINK_SHELL_PDN_H */


### PR DESCRIPTION
Following updates and fixes to link command:
- getopt usage fix
- link connect authentication support
- PDP contexts are reactivated when needed
- registering always to RSRP when going to normal mode
- link ncellmeas continuous mode.