### PR TITLE
samples: tests: apps: remove build_on_all:true from test yamls

### DIFF
--- a/applications/asset_tracker/sample.yaml
+++ b/applications/asset_tracker/sample.yaml
@@ -3,6 +3,5 @@ sample:
 tests:
   applications.asset_tracker:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns qemu_x86
     tags: ci_build

--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -3,12 +3,10 @@ sample:
 tests:
   applications.asset_tracker_v2.nrf_cloud:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
     tags: ci_build
   applications.asset_tracker_v2.aws:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
     extra_configs:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
@@ -33,7 +31,6 @@ tests:
     tags: ci_build
   applications.asset_tracker_v2.azure:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
     extra_configs:
       - CONFIG_AZURE_IOT_HUB_DPS_HOSTNAME="global.azure-devices-provisioning.net"

--- a/applications/connectivity_bridge/sample.yaml
+++ b/applications/connectivity_bridge/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   applications.connectivity_bridge:
     build_only: true
-    build_on_all: true
     platform_allow: thingy91_nrf52840
     tags: ci_build

--- a/applications/machine_learning/sample.yaml
+++ b/applications/machine_learning/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   applications.machine_learning.zdebug:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 thingy52_nrf52832 thingy53_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
@@ -13,7 +12,6 @@ tests:
     tags: ci_build
   applications.machine_learning.zdebug_nus:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
@@ -21,7 +19,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebugNUS"
   applications.machine_learning.zrelease:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 thingy52_nrf52832 thingy53_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840

--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   applications.nrf_desktop.zdebug:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dmouse_nrf52832 nrf52kbd_nrf52832 nrf52810dmouse_nrf52810 nrf52820dongle_nrf52820 nrf52833dk_nrf52833 nrf52833dongle_nrf52833 nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52dmouse_nrf52832
@@ -20,7 +19,6 @@ tests:
     tags: bluetooth ci_build
   applications.nrf_desktop.zdebug_b0:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52kbd_nrf52832 nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52kbd_nrf52832
@@ -32,7 +30,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebugB0"
   applications.nrf_desktop.zdebug_mcuboot:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52833dongle_nrf52833
     integration_platforms:
       - nrf52833dongle_nrf52833
@@ -40,7 +37,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebugMCUBoot"
   applications.nrf_desktop.zdebug_mcuboot_qspi:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
@@ -48,7 +44,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebugMCUBootQSPI"
   applications.nrf_desktop.zdebug_mcuboot_smp:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
@@ -56,7 +51,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebugMCUBootSMP"
   applications.nrf_desktop.zdebug_splitll:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52kbd_nrf52832 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840
     integration_platforms:
       - nrf52kbd_nrf52832
@@ -66,7 +60,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebugSplitLL"
   applications.nrf_desktop.zdebugwithshell:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52kbd_nrf52832 nrf52833dk_nrf52833 nrf52833dongle_nrf52833 nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840
     integration_platforms:
       - nrf52kbd_nrf52832
@@ -79,7 +72,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebugWithShell"
   applications.nrf_desktop.zdebug_3bleconn:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dongle_nrf52840
     integration_platforms:
       - nrf52840dongle_nrf52840
@@ -87,7 +79,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebug3BLEconn"
   applications.nrf_desktop.zdebug_4llpmconn:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dongle_nrf52840
     integration_platforms:
       - nrf52840dongle_nrf52840
@@ -95,7 +86,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebug4LLPMconn"
   applications.nrf_desktop.zdebug_dongle:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
@@ -103,7 +93,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebug_dongle"
   applications.nrf_desktop.zdebug_keyboard:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
@@ -111,7 +100,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZDebug_keyboard"
   applications.nrf_desktop.zrelease:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dmouse_nrf52832 nrf52kbd_nrf52832 nrf52810dmouse_nrf52810 nrf52820dongle_nrf52820 nrf52833dk_nrf52833 nrf52833dongle_nrf52833 nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52dmouse_nrf52832
@@ -128,7 +116,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZRelease"
   applications.nrf_desktop.zrelease_b0:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52kbd_nrf52832 nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52kbd_nrf52832
@@ -140,7 +127,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZReleaseB0"
   applications.nrf_desktop.zrelease_mcuboot:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52820dongle_nrf52820 nrf52833dongle_nrf52833
     integration_platforms:
       - nrf52820dongle_nrf52820
@@ -149,7 +135,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZReleaseMCUBoot"
   applications.nrf_desktop.zrelease_splitll:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52kbd_nrf52832 nrf52840dongle_nrf52840 nrf52840gmouse_nrf52840
     integration_platforms:
       - nrf52kbd_nrf52832
@@ -159,7 +144,6 @@ tests:
     extra_args: "CMAKE_BUILD_TYPE=ZReleaseSplitLL"
   applications.nrf_desktop.zrelease_4llpmconn:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dongle_nrf52840
     integration_platforms:
       - nrf52840dongle_nrf52840

--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -3,12 +3,10 @@ sample:
 tests:
   samples.nrf9160.serial_lte_modem:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     tags: ci_build
   samples.nrf9160.serial_lte_modem.native_tls:
     build_only: true
-    build_on_all: true
     extra_args: OVERLAY_CONFIG=overlay-native_tls.conf
     platform_allow: nrf9160dk_nrf9160ns
     tags: ci_build

--- a/samples/bluetooth/alexa_gadget/sample.yaml
+++ b/samples/bluetooth/alexa_gadget/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.alexa_gadget:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52810
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -8,7 +8,6 @@ tests:
     tags: bluetooth
   samples.bluetooth.central_bas.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -8,7 +8,6 @@ tests:
     tags: bluetooth
   samples.bluetooth.central_hids.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hr_coded/sample.yaml
+++ b/samples/bluetooth/central_hr_coded/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.central_hr_coded:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/central_nfc_pairing/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.central_nfc_pairing:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_smp_client/sample.yaml
+++ b/samples/bluetooth/central_smp_client/sample.yaml
@@ -8,7 +8,6 @@ tests:
     tags: bluetooth
   samples.bluetooth.central_dfu_smp.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.central_uart:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.direct_test_mode:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpunet nrf21540dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/enocean/sample.yaml
+++ b/samples/bluetooth/enocean/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.enocean:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/llpm/sample.yaml
+++ b/samples/bluetooth/llpm/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.llpm:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf52840dongle_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/chat/sample.yaml
+++ b/samples/bluetooth/mesh/chat/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.mesh.chat:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.mesh.light:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns thingy53_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.mesh.light_ctrl:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.mesh.light_switch:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns thingy53_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/sensor_client/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_client/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.mesh.sensor_client:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:

--- a/samples/bluetooth/mesh/sensor_server/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_server/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.mesh.sensor_server:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:

--- a/samples/bluetooth/peripheral_ancs_client/sample.yaml
+++ b/samples/bluetooth/peripheral_ancs_client/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.peripheral_ancs_client.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_bms/sample.yaml
+++ b/samples/bluetooth/peripheral_bms/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.peripheral_bms:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_cts_client/sample.yaml
+++ b/samples/bluetooth/peripheral_cts_client/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.peripheral_cts_client.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_gatt_dm/sample.yaml
+++ b/samples/bluetooth/peripheral_gatt_dm/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.peripheral_gatt_dm:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -8,7 +8,6 @@ tests:
     tags: bluetooth
   samples.bluetooth.peripheral_hids_keyboard.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -8,7 +8,6 @@ tests:
     tags: bluetooth
   samples.bluetooth.peripheral_hids_mouse.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hr_coded/sample.yaml
+++ b/samples/bluetooth/peripheral_hr_coded/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.peripheral_hr_coded:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.peripheral_lbs:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns thingy53_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
+++ b/samples/bluetooth/peripheral_nfc_pairing/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.peripheral_nfc_pairing:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.peripheral_uart:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns thingy53_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/rpc_host/sample.yaml
+++ b/samples/bluetooth/rpc_host/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.bluetooth.rpc_host:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpunet
     tags: bluetooth ci_build

--- a/samples/bluetooth/shell_bt_nus/sample.yaml
+++ b/samples/bluetooth/shell_bt_nus/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.shell_bt_nus:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bluetooth/throughput/sample.yaml
+++ b/samples/bluetooth/throughput/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.throughput:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: bluetooth ci_build

--- a/samples/bootloader/sample.yaml
+++ b/samples/bootloader/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.bootloader:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840
            nrf52dk_nrf52832 nrf51dk_nrf51422
     integration_platforms:

--- a/samples/crypto/psa_tls/sample.yaml
+++ b/samples/crypto/psa_tls/sample.yaml
@@ -5,6 +5,5 @@ sample:
 tests:
     samples.psa_tls:
         build_only: true
-        build_on_all: true
         platform_allow: nrf5340dk_nrf5340_cpuappns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         tags: ci_build

--- a/samples/debug/ppi_trace/sample.yaml
+++ b/samples/debug/ppi_trace/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.debug.ppi_trace:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160
     tags: ci_build
     integration_platforms:

--- a/samples/edge_impulse/data_forwarder/sample.yaml
+++ b/samples/edge_impulse/data_forwarder/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.ei_data_forwarder:
     build_only: true
-    build_on_all: true
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840

--- a/samples/edge_impulse/wrapper/sample.yaml
+++ b/samples/edge_impulse/wrapper/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.edge_impulse.wrapper:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf52dk_nrf52832

--- a/samples/esb/prx/sample.yaml
+++ b/samples/esb/prx/sample.yaml
@@ -8,6 +8,5 @@ tests:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
   samples.esb.prx.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/esb/ptx/sample.yaml
+++ b/samples/esb/ptx/sample.yaml
@@ -8,6 +8,5 @@ tests:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
   samples.esb.ptx.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/event_manager/sample.yaml
+++ b/samples/event_manager/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.event_manager:
     build_only: true
-    build_on_all: true
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840

--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   matter.light_bulb:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   matter.light_switch:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   matter.lock:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   matter.template:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840

--- a/samples/matter/weather_station/sample.yaml
+++ b/samples/matter/weather_station/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   matter.weather_station:
     build_only: true
-    build_on_all: true
     platform_allow: thingy53_nrf5340_cpuapp
     integration_platforms:
       - thingy53_nrf5340_cpuapp

--- a/samples/mpsl/timeslot/sample.yaml
+++ b/samples/mpsl/timeslot/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.mpsl.timeslot:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/nfc/record_text/sample.yaml
+++ b/samples/nfc/record_text/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.nfc.record_text:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: ci_build

--- a/samples/nfc/system_off/sample.yaml
+++ b/samples/nfc/system_off/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.nfc.system_off:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: ci_build

--- a/samples/nfc/tag_reader/sample.yaml
+++ b/samples/nfc/tag_reader/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.nfc.tag_reader:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/nfc/tnep_poller/sample.yaml
+++ b/samples/nfc/tnep_poller/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.nfc.tnep_poller:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/nfc/tnep_tag/sample.yaml
+++ b/samples/nfc/tnep_tag/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.nfc.tnep_tag:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: ci_build

--- a/samples/nfc/writable_ndef_msg/sample.yaml
+++ b/samples/nfc/writable_ndef_msg/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.nfc.writable_ndef_msg:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuappns
     tags: ci_build

--- a/samples/nrf5340/empty_app_core/sample.yaml
+++ b/samples/nrf5340/empty_app_core/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.nrf5340.empty_app_core.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/nrf5340/multiprotocol_rpmsg/sample.yaml
+++ b/samples/nrf5340/multiprotocol_rpmsg/sample.yaml
@@ -5,7 +5,6 @@ sample:
 tests:
   samples.nrf5340.multiprotocol_rpmsg.build:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet

--- a/samples/nrf5340/netboot/sample.yaml
+++ b/samples/nrf5340/netboot/sample.yaml
@@ -3,14 +3,12 @@ sample:
 tests:
   samples.nrf5340.netboot:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet
     tags: ci_build
   samples.nrf5340.netboot.minimal_size:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpunet
     integration_platforms:
       - nrf5340dk_nrf5340_cpunet

--- a/samples/nrf9160/agps/sample.yaml
+++ b/samples/nrf9160/agps/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.agps:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/at_client/sample.yaml
+++ b/samples/nrf9160/at_client/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.at_client:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/aws_fota/sample.yaml
+++ b/samples/nrf9160/aws_fota/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.aws_fota:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/aws_iot/sample.yaml
+++ b/samples/nrf9160/aws_iot/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.aws_iot:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/azure_fota/sample.yaml
+++ b/samples/nrf9160/azure_fota/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.azure_fota:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/azure_iot_hub/sample.yaml
+++ b/samples/nrf9160/azure_iot_hub/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.azure_iot_hub:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/cloud_client/sample.yaml
+++ b/samples/nrf9160/cloud_client/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.cloud_client:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/coap_client/sample.yaml
+++ b/samples/nrf9160/coap_client/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.coap_client:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/download/sample.yaml
+++ b/samples/nrf9160/download/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.download_client:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns
@@ -14,7 +13,6 @@ tests:
       - CONFIG_DOWNLOAD_CLIENT_SHELL=y
   samples.nrf9160.download.tfm:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/fmfu_smp_svr/sample.yaml
+++ b/samples/nrf9160/fmfu_smp_svr/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.nrf9160.fmfu_smp_svr:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/gps/sample.yaml
+++ b/samples/nrf9160/gps/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.gps:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/https_client/sample.yaml
+++ b/samples/nrf9160/https_client/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.https_client:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/lte_ble_gateway/sample.yaml
+++ b/samples/nrf9160/lte_ble_gateway/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.lte_ble_gateway:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/lwm2m_carrier/sample.yaml
+++ b/samples/nrf9160/lwm2m_carrier/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.lwm2m_carrier:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/lwm2m_client/sample.yaml
+++ b/samples/nrf9160/lwm2m_client/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.lwm2m_client:
     build_only: true
-    build_on_all: true
     extra_args: OVERLAY_CONFIG=overlay-ci.conf
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:

--- a/samples/nrf9160/memfault/sample.yaml
+++ b/samples/nrf9160/memfault/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.memfault:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
     tags: ci_build
     extra_configs:

--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.modem_shell:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/mqtt_simple/sample.yaml
+++ b/samples/nrf9160/mqtt_simple/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.mqtt_simple:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/multicell_location/sample.yaml
+++ b/samples/nrf9160/multicell_location/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.multicell_location:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/pdn/sample.yaml
+++ b/samples/nrf9160/pdn/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.pdn:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/secure_services/sample.yaml
+++ b/samples/nrf9160/secure_services/sample.yaml
@@ -78,5 +78,4 @@ tests:
       - nrf9160dk_nrf9160ns
     extra_args: OVERLAY_CONFIG="b0_mcuboot_overlay.conf"
     build_only: true
-    build_on_all: true
     tags: ci_build

--- a/samples/nrf9160/sms/sample.yaml
+++ b/samples/nrf9160/sms/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.sms:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf9160/udp/sample.yaml
+++ b/samples/nrf9160/udp/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.nrf9160.udp:
     build_only: true
-    build_on_all: true
     platform_allow: nrf9160dk_nrf9160ns thingy91_nrf9160ns
     integration_platforms:
       - nrf9160dk_nrf9160ns

--- a/samples/nrf_rpc/entropy_nrf53/cpuapp/sample.yaml
+++ b/samples/nrf_rpc/entropy_nrf53/cpuapp/sample.yaml
@@ -4,5 +4,4 @@ sample:
 tests:
   samples.nrf_rpc.entropy_cpuapp:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/samples/nrf_rpc/entropy_nrf53/cpunet/sample.yaml
+++ b/samples/nrf_rpc/entropy_nrf53/cpunet/sample.yaml
@@ -4,5 +4,4 @@ sample:
 tests:
   samples.nrf_rpc.entropy_cpunet:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpunet

--- a/samples/openthread/coap_server/sample.yaml
+++ b/samples/openthread/coap_server/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.openthread.coap_server:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
     tags: ci_build
     integration_platforms:

--- a/samples/peripheral/lpuart/sample.yaml
+++ b/samples/peripheral/lpuart/sample.yaml
@@ -4,14 +4,12 @@ sample:
 tests:
   samples.peripheral.lpuart:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf9160dk_nrf9160
                     nrf5340dk_nrf5340_cpuapp
     tags: ci_build
 
   samples.peripheral.lpuart_int_driven:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf9160dk_nrf9160
                     nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -4,6 +4,5 @@ sample:
 tests:
   samples.peripheral.radio_test:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/profiler/sample.yaml
+++ b/samples/profiler/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.profiler:
     build_only: true
-    build_on_all: true
     platform_exclude: native_posix qemu_x86 qemu_cortex_m3
     integration_platforms:
       - nrf52dk_nrf52832

--- a/samples/spm/sample.yaml
+++ b/samples/spm/sample.yaml
@@ -3,7 +3,6 @@ sample:
 tests:
   samples.spm:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
@@ -12,7 +11,6 @@ tests:
 
   samples.spm_shared_uart:
     build_only: true
-    build_on_all: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
This patch removes "build_on_all:true" from all test yamls.
An option "build_on_all: true" can be set in sample/testcase.yaml.
It tells Twister to add all existing zephyr platforms (~400) to
the test scope. This option is abused in a lot of Nordic samples
and tests. It is pointless as "platform_allow" is also used there
limiting the building/executing scope to selected platforms. Hovewer,
this causes huge mess in the genereted results reports, where ~400
platforms are added with all test statuses "skipped".

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>