### PR TITLE
spm: support for POWER peripheral in non-secure applications

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -289,6 +289,10 @@ config SPM_NRF_PDM_NS
 config SPM_NRF_I2S_NS
 	bool "I2S is Non-Secure"
 	default y
+
+config SPM_NRF_POWER_NS
+	bool "Power is Non-Secure"
+	default y
 endif #SOC_NRF9160
 
 if SOC_NRF5340_CPUAPP

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -451,6 +451,9 @@ static void spm_config_peripherals(void)
 #ifdef NRF_RESET
 		PERIPH("NRF_RESET", NRF_RESET, CONFIG_SPM_NRF_RESET_NS),
 #endif
+#ifdef NRF_POWER
+		PERIPH("NRF_POWER", NRF_POWER, CONFIG_SPM_NRF_POWER_NS),
+#endif
 
 		/* There is no DTS node for the peripherals below,
 		 * so address them using nrfx macros directly.


### PR DESCRIPTION
It's currently not possible to configure the POWER peripheral
of the nRF9160 for use in non-secure applications. This PR adds
support for this in the SPM.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>