### PR TITLE
modules: tfm: avoid sourcing 'Kconfig.tfm' twice

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -29,19 +29,19 @@ config TFM_MINIMAL
 	  needs a different TF-M configuration you have to disable this option
 	  and reproduce the desired configuration through kconfig fragments.
 
+source "$(ZEPHYR_BASE)/modules/trusted-firmware-m/Kconfig.tfm"
+
 if !TFM_MINIMAL
 rsource "Kconfig.mbedtls.defconfig"
-source "$(ZEPHYR_BASE)/modules/trusted-firmware-m/Kconfig"
+
+# When enabling full TFM support, then partitions and crypto modules shall be available.
+source "$(ZEPHYR_BASE)/modules/trusted-firmware-m/Kconfig.tfm.partitions"
+source "$(ZEPHYR_BASE)/modules/trusted-firmware-m/Kconfig.tfm.crypto_modules"
 endif
 
 if TFM_MINIMAL
-
 rsource "Kconfig.mbedtls_minimal.defconfig"
-
 rsource "Kconfig.tfm_minimal.defconfig"
-
-source "$(ZEPHYR_BASE)/modules/trusted-firmware-m/Kconfig.tfm"
-
 endif # TFM_MINIMAL
 
 if BUILD_WITH_TFM


### PR DESCRIPTION
Kconfig.tfm was sourced both when TFM_MINIMAL was set
and when it was NOT set. This resultet in symbols having
both 'depends on TFM_MINIMAL' and 'depends on !TFM_MINIMAL'
in their definition.

Fix this by inlining parts of
 'zephyr/modules/trusted-firmware-m/Kconfig' so that 'Kconfig.tfm'
is sourced regardless of the value of 'TFM_MINIMAL'

Ref: NCSDK-10753

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>