### PR TITLE
actions: labeler: Exclude Bluetooth Mesh from CI-find-my-test

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -181,19 +181,24 @@
   - "samples/matter/**/*"
 
 "CI-find-my-test":
-  - "include/bluetooth/**/*"
-  - "include/dfu/**/*"
-  - "include/nfc/**/*"
-  - "include/dk_buttons_and_leds.h"
-  - "include/event_manager.h"
-  - "lib/dk_buttons_and_leds/**/*"
-  - "subsys/bootloader/**/*"
-  - "subsys/bluetooth/**/*"
-  - "subsys/dfu/dfu_target/**/*"
-  - "subsys/event_manager/**/*"
-  - "subsys/nfc/**/*"
-  - "subsys/partition_manager/**/*"
-  - "modules/mcuboot/**/*"
+  - any:
+    - "include/dfu/**/*"
+    - "include/nfc/**/*"
+    - "include/dk_buttons_and_leds.h"
+    - "include/event_manager.h"
+    - "lib/dk_buttons_and_leds/**/*"
+    - "subsys/bootloader/**/*"
+    - "subsys/dfu/dfu_target/**/*"
+    - "subsys/event_manager/**/*"
+    - "subsys/nfc/**/*"
+    - "subsys/partition_manager/**/*"
+    - "modules/mcuboot/**/*"
+  - any:
+    - "include/bluetooth/**/*"
+    - "!include/bluetooth/mesh/**/*"
+  - any:
+    - "subsys/bluetooth/**/*"
+    - "!subsys/bluetooth/mesh/**/*"
 
 "no-changelog":
   - "!doc/nrf/releases/release-notes-latest.rst"


### PR DESCRIPTION
Adds filter for excluding find-my CI label from pure Bluetooth Mesh
changes, just like the other high level protocols that do not depend on
Bluetooth Mesh.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>