### PR TITLE
net: lib: nrf_cloud: Remove sensor attach function and event

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -103,9 +103,6 @@ static void nrf_cloud_event_handler(const struct nrf_cloud_evt *evt)
 		cloud_wrap_evt.type = CLOUD_WRAP_EVT_ERROR;
 		notify = true;
 		break;
-	case NRF_CLOUD_EVT_SENSOR_ATTACHED:
-		LOG_DBG("NRF_CLOUD_EVT_SENSOR_ATTACHED");
-		break;
 	case NRF_CLOUD_EVT_SENSOR_DATA_ACK:
 		LOG_DBG("NRF_CLOUD_EVT_SENSOR_DATA_ACK");
 		break;

--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -39,6 +39,7 @@ nRF9160
     * Added function :c:func:`nrf_cloud_shadow_device_status_update`, which sets the device status in the device's shadow.
     * Added function :c:func:`nrf_cloud_modem_info_json_encode`, which encodes modem information into a cJSON object formatted for use with nRF Cloud.
     * Added function :c:func:`nrf_cloud_service_info_json_encode`, which encodes service information into a cJSON object formatted for use with nRF Cloud.
+    * Removed function ``nrf_cloud_sensor_attach()``, the associated structure ``nrf_cloud_sa_param``, and event ``NRF_CLOUD_EVT_SENSOR_ATTACHED``. These items provided no useful functionality.
 
   * :ref:`serial_lte_modem` application:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -66,10 +66,6 @@ enum nrf_cloud_evt_type {
 	NRF_CLOUD_EVT_USER_ASSOCIATED,
 	/** The device can now start sending sensor data to the cloud. */
 	NRF_CLOUD_EVT_READY,
-	/** A sensor was successfully attached to the cloud.
-	 * Supported sensor types are defined in @ref nrf_cloud_sensor.
-	 */
-	NRF_CLOUD_EVT_SENSOR_ATTACHED,
 	/** The device received data from the cloud. */
 	NRF_CLOUD_EVT_RX_DATA,
 	/** The data sent to the cloud was acknowledged. */
@@ -185,12 +181,6 @@ struct nrf_cloud_sensor_list {
 struct nrf_cloud_connect_param {
 	/** Supported sensor types. May be NULL. */
 	const struct nrf_cloud_sensor_list *sensor;
-};
-
-/**@brief Parameters of attached sensors. */
-struct nrf_cloud_sa_param {
-	/** The sensor that is being attached. */
-	enum nrf_cloud_sensor sensor_type;
 };
 
 /**@brief Sensor data transmission parameters. */
@@ -357,26 +347,10 @@ int nrf_cloud_uninit(void);
 int nrf_cloud_connect(const struct nrf_cloud_connect_param *param);
 
 /**
- * @brief Attach a sensor to the cloud.
- *
- * This API should only be called after receiving an
- * @ref NRF_CLOUD_EVT_READY event.
- * If the API succeeds, wait for the @ref NRF_CLOUD_EVT_SENSOR_ATTACHED
- * event before sending the sensor data.
- *
- * @param[in] param	Sensor information.
- *
- * @retval 0       If successful.
- * @retval -EACCES Cloud connection is not established; wait for @ref NRF_CLOUD_EVT_READY.
- *                 Otherwise, a (negative) error code is returned.
- */
-int nrf_cloud_sensor_attach(const struct nrf_cloud_sa_param *param);
-
-/**
  * @brief Send sensor data reliably.
  *
  * This API should only be called after receiving an
- * @ref NRF_CLOUD_EVT_SENSOR_ATTACHED event.
+ * @ref NRF_CLOUD_EVT_READY event.
  * If the API succeeds, you can expect the
  * @ref NRF_CLOUD_EVT_SENSOR_DATA_ACK event.
  *
@@ -414,7 +388,7 @@ int nrf_cloud_shadow_device_status_update(const struct nrf_cloud_device_status *
  * @brief Stream sensor data.
  *
  * This API should only be called after receiving an
- * @ref NRF_CLOUD_EVT_SENSOR_ATTACHED event.
+ * @ref NRF_CLOUD_EVT_READY event.
  *
  * @param[in] param Sensor data.
  *

--- a/include/net/nrf_cloud.rst
+++ b/include/net/nrf_cloud.rst
@@ -154,10 +154,6 @@ Currently, the supported sensor types are GPS and FLIP (see :c:enum:`nrf_cloud_s
 
 Use :c:func:`nrf_cloud_sensor_data_stream` to send sensor data with best quality.
 
-Before sending any sensor data, call the function :c:func:`nrf_cloud_sensor_attach` with the type of the sensor.
-Note that this function must be called after receiving the event :c:enumerator:`NRF_CLOUD_EVT_READY`.
-It triggers the event :c:enumerator:`NRF_CLOUD_EVT_SENSOR_ATTACHED` if the function executes successfully.
-
 To view sensor data on nRF Connect for Cloud, the device must first inform the cloud what types of sensor data to display.
 The device passes this information by writing a ``ui`` field, containing an array of sensor types, into the ``serviceInfo`` field in the device's shadow.
 :c:func:`nrf_cloud_service_info_json_encode` can be used to generate the proper JSON data to enable FOTA.

--- a/samples/nrf9160/lte_ble_gateway/src/main.c
+++ b/samples/nrf9160/lte_ble_gateway/src/main.c
@@ -288,8 +288,6 @@ static void on_cloud_evt_user_associated(void)
 /**@brief Callback for nRF Cloud events. */
 static void cloud_event_handler(const struct nrf_cloud_evt *evt)
 {
-	int err;
-
 	switch (evt->type) {
 	case NRF_CLOUD_EVT_TRANSPORT_CONNECTED:
 		printk("NRF_CLOUD_EVT_TRANSPORT_CONNECTED\n");
@@ -313,30 +311,8 @@ static void cloud_event_handler(const struct nrf_cloud_evt *evt)
 	case NRF_CLOUD_EVT_READY:
 		printk("NRF_CLOUD_EVT_READY\n");
 		display_state = LEDS_CLOUD_CONNECTED;
-		struct nrf_cloud_sa_param param = {
-			.sensor_type = NRF_CLOUD_SENSOR_FLIP,
-		};
-
-		err = nrf_cloud_sensor_attach(&param);
-
-		if (err) {
-			printk("nrf_cloud_sensor_attach failed: %d\n", err);
-			nrf_cloud_error_handler(err);
-		}
-
-		param.sensor_type = NRF_CLOUD_SENSOR_GPS;
-		err = nrf_cloud_sensor_attach(&param);
-
-		if (err) {
-			printk("nrf_cloud_sensor_attach failed: %d\n", err);
-			nrf_cloud_error_handler(err);
-		}
-
 		sensors_init();
 		atomic_set(&send_data_enable, 1);
-		break;
-	case NRF_CLOUD_EVT_SENSOR_ATTACHED:
-		printk("NRF_CLOUD_EVT_SENSOR_ATTACHED\n");
 		break;
 	case NRF_CLOUD_EVT_SENSOR_DATA_ACK:
 		printk("NRF_CLOUD_EVT_SENSOR_DATA_ACK\n");

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -283,21 +283,6 @@ int nrf_cloud_shadow_device_status_update(const struct nrf_cloud_device_status *
 	return err;
 }
 
-int nrf_cloud_sensor_attach(const struct nrf_cloud_sa_param *param)
-{
-	if (current_state != STATE_DC_CONNECTED) {
-		return -EACCES;
-	}
-
-	const struct nrf_cloud_evt evt = {
-		.type = NRF_CLOUD_EVT_SENSOR_ATTACHED
-	};
-
-	nfsm_set_current_state_and_notify(STATE_DC_CONNECTED, &evt);
-
-	return 0;
-}
-
 int nrf_cloud_sensor_data_send(const struct nrf_cloud_sensor_data *param)
 {
 	int err;
@@ -629,10 +614,6 @@ static void api_event_handler(const struct nrf_cloud_evt *nrf_cloud_evt)
 		evt.type = CLOUD_EVT_READY;
 
 		cloud_notify_event(nrf_cloud_backend, &evt, config->user_data);
-		break;
-	case NRF_CLOUD_EVT_SENSOR_ATTACHED:
-		LOG_DBG("NRF_CLOUD_EVT_SENSOR_ATTACHED");
-
 		break;
 	case NRF_CLOUD_EVT_SENSOR_DATA_ACK:
 		LOG_DBG("NRF_CLOUD_EVT_SENSOR_DATA_ACK");


### PR DESCRIPTION
Remove the unnecessary function `nrf_cloud_sensor_attach` and
related event `NRF_CLOUD_EVT_SENSOR_ATTACHED`. This function and
event provided no actual functionality.

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>