### PR TITLE
application: serial_lte_modem: Add IPv6 support to FTP client

### DIFF
--- a/applications/serial_lte_modem/doc/FTP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FTP_AT_commands.rst
@@ -47,6 +47,7 @@ The ``<cmd>`` command is a string, and can be used as follows:
 * ``AT#XFTP="mput",<file>[,<data>]``
 
 The values of the parameters depend on the command string used.
+When using the ``put``,``uput`` and ``mput`` commands, if the ``<data>`` attribute is not specified, SLM enters ``slm_data_mode``.
 
 Response syntax
 ~~~~~~~~~~~~~~~

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -195,18 +195,6 @@ Check and configure the following configuration options for the sample:
 
    This option enables additional AT commands for using the FTP client service.
 
-.. option:: CONFIG_SLM_FTP_SERVER_PORT - FTP service port on remote host
-
-   This option specifies the port to use when connecting to an FTP server.
-
-.. option:: CONFIG_SLM_FTP_USER_ANONYMOUS - FTP client anonymous login user
-
-   This option specifies the user name to use for anonymous login on an FTP server.
-
-.. option:: CONFIG_SLM_FTP_PASSWORD_ANONYMOUS - FTP client anonymous login password
-
-   This option specifies the password to use for anonymous login on an FTP server.
-
 .. option:: CONFIG_SLM_MQTTC - MQTT client support in SLM
 
    This option enables additional AT commands for using the MQTT client service.

--- a/applications/serial_lte_modem/src/ftp_c/Kconfig
+++ b/applications/serial_lte_modem/src/ftp_c/Kconfig
@@ -7,23 +7,3 @@ config SLM_FTPC
 	bool "FTP client support in SLM"
 	default y
 	select FTP_CLIENT
-
-if SLM_FTPC
-
-config SLM_FTP_SERVER_PORT
-	int "FTP service port on remote host"
-	default 21
-
-config SLM_FTP_USER_ANONYMOUS
-	string "FTP client anonymous login user"
-	default "anonymous"
-	help
-	  Define the user name for anonymous login.
-
-config SLM_FTP_PASSWORD_ANONYMOUS
-	string "FTP client anonymous login password"
-	default "anonymous@example.com"
-	help
-	  Define the password for anonymous login.
-
-endif


### PR DESCRIPTION
lib_ftp_client: 
Try IPv6 parsing first, if fails try IPv4 parsing next.
Adjust control and data socket based on address family.
Update QUIT command as some server does not reply.
Update KEEPALIVE to avoid unnecessary NOOP.

Code clean-up after adding IPv6 to lib_ftp_client.

 Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>