### PR TITLE
application: serial_lte_modem: Bug-fix memory leak

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -476,6 +476,7 @@ int slm_at_parse(const char *at_cmd)
 		if (slm_util_cmd_casecmp(at_cmd, slm_at_cmd_list[i].string)) {
 			enum at_cmd_type type = at_parser_cmd_type_get(at_cmd);
 
+			at_params_list_clear(&at_param_list);
 			ret = at_parser_params_from_str(at_cmd, NULL, &at_param_list);
 			if (ret) {
 				LOG_ERR("Failed to parse AT command %d", ret);

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -832,5 +832,8 @@ void slm_at_host_uninit(void)
 		LOG_WRN("Can't power off uart: %d", err);
 	}
 
+	/* Un-initialize AT Parser */
+	at_params_list_free(&at_param_list);
+
 	LOG_DBG("at_host uninit done");
 }

--- a/applications/serial_lte_modem/src/slm_util.c
+++ b/applications/serial_lte_modem/src/slm_util.c
@@ -172,6 +172,7 @@ void util_get_ip_addr(char *addr4, char *addr6)
 	 * PDN type "IPV6": PDP_addr_1 is <IPv6>
 	 * PDN type "IPV4V6": <IPv4>,<IPv6> or <IPV4> or <IPv6>
 	 */
+	at_params_list_clear(&at_param_list);
 	err = at_parser_params_from_str(rsp, NULL, &at_param_list);
 	if (err) {
 		return;


### PR DESCRIPTION
In at_host un-init, must free memory allocated in lib_at_parser.
Also add to clear AT param list before parsing any AT command.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>