### PR TITLE
codeowners: update bh1749 owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -89,7 +89,7 @@ Kconfig*                                  @tejlmand
 /modules/                                 @tejlmand
 /modules/mcuboot/                         @nvlsianpu
 /modules/cjson/                           @simensrostad @plskeggs @sigvartmh
-/samples/sensor/bh1749/                   @wlgrd
+/samples/sensor/bh1749/                   @jfischer-no
 /samples/bluetooth/                       @joerchan @carlescufi @KAGA164
 /samples/bluetooth/mesh/                  @trond-snekvik @joerchan
 /samples/bluetooth/direction_finding_connectionless_rx/ @ppryga @joerchan


### PR DESCRIPTION
Updates code owner of BH1749 library.
    
Signed-off-by: Christian Wilgaard <christian.wilgaard@nordicsemi.no>