### PR TITLE
net: lib: nrf_cloud: add GNSS API support for nRFCloud A-GPS and P-GPS

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -200,7 +200,6 @@ menu "nRF Cloud A-GPS"
 
 config NRF_CLOUD_AGPS
 	bool "Enable nRF Cloud Assisted GPS"
-	depends on NRF9160_GPS
 	depends on MODEM_INFO
 	depends on MODEM_INFO_ADD_NETWORK
 
@@ -230,7 +229,6 @@ menu "nRF Cloud P-GPS"
 
 config NRF_CLOUD_PGPS
 	bool "Enable nRF Cloud Predicted GPS"
-	depends on NRF9160_GPS
 	depends on MODEM_INFO
 	depends on MODEM_INFO_ADD_NETWORK
 	select STREAM_FLASH_ERASE


### PR DESCRIPTION
Added support for writing assistance data to GNSS using the new GNSS
API. If GPS driver is not enabled and no GNSS socket descriptor has
been given, it's assumed that the GNSS API is used.

Removed Kconfig dependency to the GPS driver from both A-GPS and P-GPS.
It's should not be mandatory for the application to enable the GPS
driver. The library does use gps.h, but that's always present
regardless of the NRF9160_GPS configuration option.

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>