### PR TITLE
nrf_802154: Allow to use subsys without IEEE802154_NRF5

### DIFF
--- a/subsys/ieee802154/CMakeLists.txt
+++ b/subsys/ieee802154/CMakeLists.txt
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-zephyr_library()
+if(CONFIG_NRF_802154_RADIO_CONFIG)
+  zephyr_library()
 
-zephyr_library_sources(
-  nrf_802154_configurator.c
-  )
+  zephyr_library_sources(
+    nrf_802154_configurator.c
+    )
+endif()

--- a/subsys/ieee802154/Kconfig
+++ b/subsys/ieee802154/Kconfig
@@ -6,6 +6,12 @@
 
 menu "Nordic IEEE 802.15.4"
 
+config NRF_802154_RADIO_CONFIG
+	bool "nRF52 IEEE 802.15.4 configurator"
+	default NRF_802154_SER_RADIO || IEEE802154_NRF5
+	help
+	  Enable the nRF IEEE 802.15.4 configurator module.
+
 config NRF_802154_RADIO_CONFIG_PRIO
 	int "nRF52 IEEE 802.15.4 configuration priority"
 	default 91

--- a/subsys/ieee802154/nrf_802154_configurator.c
+++ b/subsys/ieee802154/nrf_802154_configurator.c
@@ -51,11 +51,17 @@ static int nrf_802154_configure(const struct device *dev)
 
 #if IS_ENABLED(CONFIG_NRF_802154_SER_RADIO)
 #define INIT_PRIO CONFIG_NRF_802154_SER_RADIO_INIT_PRIO
-#else
+#elif IS_ENABLED(CONFIG_IEEE802154_NRF5)
 #define INIT_PRIO CONFIG_IEEE802154_NRF5_INIT_PRIO
+#else
+/* There is no defined priority of nRF 802.15.4 Radio Driver's initialization.
+ * No priority validation can be performed.
+ */
 #endif
 
+#if defined(INIT_PRIO)
 BUILD_ASSERT(INIT_PRIO < CONFIG_NRF_802154_RADIO_CONFIG_PRIO,
 	     "nRF 802.15.4 driver configuration would not be performed after its initialization");
+#endif
 
 SYS_INIT(nrf_802154_configure, POST_KERNEL, CONFIG_NRF_802154_RADIO_CONFIG_PRIO);


### PR DESCRIPTION
This commit removes direct dependency of the ieee802154 subsys on
IEEE802154_NRF5 symbols. This allows to use the subsys with applications
not using IEEE802154_NRF5, but rather using nRF 802.15.4 Radio Driver
directly.