### PR TITLE
net: lib: nrf_cloud: Fix sensor data ack event

### DIFF
--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -149,10 +149,7 @@ If the value equals :c:enumerator:`NRF_CLOUD_FOTA_MODEM`, the application can op
 
 Sending sensor data
 *******************
-The library offers two APIs, :c:func:`nrf_cloud_sensor_data_send` and :c:func:`nrf_cloud_sensor_data_stream`, for sending sensor data to the cloud.
-Currently, the supported sensor types are GPS and FLIP (see :c:enum:`nrf_cloud_sensor`).
-
-Use :c:func:`nrf_cloud_sensor_data_stream` to send sensor data with best quality.
+The library offers two APIs, :c:func:`nrf_cloud_sensor_data_send` and :c:func:`nrf_cloud_sensor_data_stream` (lowest QoS), for sending sensor data to the cloud.
 
 To view sensor data on nRF Connect for Cloud, the device must first inform the cloud what types of sensor data to display.
 The device passes this information by writing a ``ui`` field, containing an array of sensor types, into the ``serviceInfo`` field in the device's shadow.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -55,6 +55,7 @@ nRF9160
     * Removed function ``nrf_cloud_sensor_attach()``, the associated structure ``nrf_cloud_sa_param``, and event ``NRF_CLOUD_EVT_SENSOR_ATTACHED``. These items provided no useful functionality.
     * Added the option to use the P-GPS API independent of nRF Cloud MQTT transport.
     * Implemented functionality for the :c:enumerator:`NRF_CLOUD_EVT_SENSOR_DATA_ACK` event. The event is now generated when a valid tag value (NCT_MSG_ID_USER_TAG_BEGIN through NCT_MSG_ID_USER_TAG_END) is provided with the sensor data when calling either :c:func:`nrf_cloud_sensor_data_send` or :c:func:`nrf_cloud_shadow_update`.
+    * Updated :c:func:`nrf_cloud_shadow_update` to expect that ``param->data.ptr`` points to a JSON string. Previously, a cJSON object was expected.
 
   * :ref:`serial_lte_modem` application:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -54,6 +54,7 @@ nRF9160
     * Added Kconfig option :kconfig:`CONFIG_NRF_CLOUD_GATEWAY`, which enables functionality to behave as an nRF Cloud gateway.
     * Removed function ``nrf_cloud_sensor_attach()``, the associated structure ``nrf_cloud_sa_param``, and event ``NRF_CLOUD_EVT_SENSOR_ATTACHED``. These items provided no useful functionality.
     * Added the option to use the P-GPS API independent of nRF Cloud MQTT transport.
+    * Implemented functionality for the :c:enumerator:`NRF_CLOUD_EVT_SENSOR_DATA_ACK` event. The event is now generated when a valid tag value (NCT_MSG_ID_USER_TAG_BEGIN through NCT_MSG_ID_USER_TAG_END) is provided with the sensor data when calling either :c:func:`nrf_cloud_sensor_data_send` or :c:func:`nrf_cloud_shadow_update`.
 
   * :ref:`serial_lte_modem` application:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -395,7 +395,8 @@ int nrf_cloud_connect(const struct nrf_cloud_connect_param *param);
  * @ref NRF_CLOUD_EVT_SENSOR_DATA_ACK event for data sent with
  * a valid tag value.
  *
- * @param[in] param Sensor data.
+ * @param[in] param Sensor data; the data pointed to by param->data.ptr
+ *                  must be a string.
  *
  * @retval 0       If successful.
  * @retval -EACCES Cloud connection is not established; wait for @ref NRF_CLOUD_EVT_READY.
@@ -406,7 +407,8 @@ int nrf_cloud_sensor_data_send(const struct nrf_cloud_sensor_data *param);
 /**
  * @brief Update the device shadow with sensor data.
  *
- * @param[in] param Sensor data.
+ * @param[in] param Sensor data; the data pointed to by param->data.ptr must be a
+ *                  valid JSON string.
  *
  * @retval 0       If successful.
  * @retval -EACCES Cloud connection is not established; wait for @ref NRF_CLOUD_EVT_READY.

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -38,13 +38,13 @@ enum nct_cc_opcode {
 struct nct_dc_data {
 	struct nrf_cloud_data data;
 	struct nrf_cloud_topic topic;
-	uint32_t id;
+	uint16_t message_id;
 };
 
 struct nct_cc_data {
 	struct nrf_cloud_data data;
 	struct nrf_cloud_topic topic;
-	uint32_t id;
+	uint16_t message_id;
 	enum nct_cc_opcode opcode;
 };
 
@@ -53,7 +53,7 @@ struct nct_evt {
 	union {
 		struct nct_cc_data *cc;
 		struct nct_dc_data *dc;
-		uint32_t data_id;
+		uint16_t message_id;
 		uint8_t flag;
 	} param;
 	enum nct_evt_type type;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -49,6 +49,7 @@ static const char *const sensor_type_str[] = {
 	[NRF_CLOUD_DEVICE_INFO] = "DEVICE",
 	[NRF_CLOUD_SENSOR_LIGHT] = "LIGHT",
 };
+#define SENSOR_TYPE_ARRAY_SIZE (sizeof(sensor_type_str) / sizeof(*sensor_type_str))
 #endif
 
 #define MSGTYPE_VAL_DATA	"DATA"
@@ -286,16 +287,19 @@ int nrf_cloud_encode_shadow_data(const struct nrf_cloud_sensor_data *sensor,
 	__ASSERT_NO_MSG(sensor->data.ptr != NULL);
 	__ASSERT_NO_MSG(sensor->data.len != 0);
 	__ASSERT_NO_MSG(output != NULL);
+	__ASSERT_NO_MSG(sensor->type < SENSOR_TYPE_ARRAY_SIZE);
 
 	cJSON *root_obj = cJSON_CreateObject();
 	cJSON *state_obj = cJSON_AddObjectToObjectCS(root_obj, JSON_KEY_STATE);
 	cJSON *reported_obj = cJSON_AddObjectToObjectCS(state_obj, JSON_KEY_REP);
+	cJSON *input_obj = cJSON_ParseWithLength(sensor->data.ptr, sensor->data.len);
 
-	ret = json_add_obj_cs(reported_obj, sensor_type_str[sensor->type],
-			   (cJSON *)sensor->data.ptr);
+	ret = json_add_obj_cs(reported_obj, sensor_type_str[sensor->type], input_obj);
 
 	if (ret == 0) {
 		buffer = cJSON_PrintUnformatted(root_obj);
+	} else {
+		cJSON_Delete(input_obj);
 	}
 
 	if (buffer) {
@@ -318,6 +322,7 @@ int nrf_cloud_encode_sensor_data(const struct nrf_cloud_sensor_data *sensor,
 	__ASSERT_NO_MSG(sensor->data.ptr != NULL);
 	__ASSERT_NO_MSG(sensor->data.len != 0);
 	__ASSERT_NO_MSG(output != NULL);
+	__ASSERT_NO_MSG(sensor->type < SENSOR_TYPE_ARRAY_SIZE);
 
 	cJSON *root_obj = cJSON_CreateObject();
 


### PR DESCRIPTION
The event NRF_CLOUD_EVT_SENSOR_DATA_ACK was previously not
implemented.  It has been implemented using a tag field
in the `nrf_cloud_sensor_data` struct.
This also cleans up handling of MQTT message ids in the
nrf_cloud library
