### PR TITLE
nrf_802154: Disambiguate configurator enablement in Kconfig

### DIFF
--- a/subsys/ieee802154/Kconfig
+++ b/subsys/ieee802154/Kconfig
@@ -9,12 +9,14 @@ menu "Nordic IEEE 802.15.4"
 config NRF_802154_RADIO_CONFIG
 	bool "nRF52 IEEE 802.15.4 configurator"
 	default NRF_802154_SER_RADIO || IEEE802154_NRF5
+	depends on NRF_802154_RADIO_DRIVER
 	help
 	  Enable the nRF IEEE 802.15.4 configurator module.
 
 config NRF_802154_RADIO_CONFIG_PRIO
 	int "nRF52 IEEE 802.15.4 configuration priority"
 	default 91
+	depends on NRF_802154_RADIO_CONFIG
 	help
 	  Set the nRF IEEE 802.15.4 configuration priority number. Must be
 	  greater than nRF IEEE 802.15.4 Radio initialization priority.


### PR DESCRIPTION
It was not obvious in which variant of nRF 802.15.4 solution the
configuration module is added. This commit adds a redundant Kconfig
dependency which allows to fully reason when the module is enabled,
based solely on Kconfig symbol definition.

This PR implements review comments from @jciupis (https://github.com/nrfconnect/sdk-nrf/pull/5277), which were not added due to an express merge.