### PR TITLE
samples: nrf9160: modem_shell: kill button support

### DIFF
--- a/ext/curl/include/curl/easy.h
+++ b/ext/curl/include/curl/easy.h
@@ -38,6 +38,12 @@ struct curl_blob {
 
 CURL_EXTERN CURL *curl_easy_init(void);
 CURL_EXTERN CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...);
+
+#if defined(CONFIG_NRF_CURL_INTEGRATION)
+CURL_EXTERN void curl_easy_nrf_set_kill_signal(
+  CURL *curl, struct k_poll_signal *kill_signal);
+#endif
+
 CURL_EXTERN CURLcode curl_easy_perform(CURL *curl);
 CURL_EXTERN void curl_easy_cleanup(CURL *curl);
 

--- a/ext/curl/include/curl/nrf_curl.h
+++ b/ext/curl/include/curl/nrf_curl.h
@@ -6,5 +6,5 @@
 
 #ifndef NRF_CURL_H
 #define NRF_CURL_H
-int curl_tool_main(int argc, char *argv[]);
+int curl_tool_main(int argc, char *argv[], struct k_poll_signal *kill_signal);
 #endif

--- a/ext/curl/lib/multihandle.h
+++ b/ext/curl/lib/multihandle.h
@@ -151,6 +151,10 @@ struct Curl_multi {
   bool recheckstate; /* see Curl_multi_connchanged */
   bool in_callback;            /* true while executing a callback */
   bool ipv6_works;
+
+#if defined(CONFIG_NRF_CURL_INTEGRATION)
+struct k_poll_signal *kill_signal; 
+#endif
 };
 
 #endif /* HEADER_CURL_MULTIHANDLE_H */

--- a/ext/curl/lib/urldata.h
+++ b/ext/curl/lib/urldata.h
@@ -1920,6 +1920,9 @@ struct Curl_easy {
   iconv_t utf8_cd;             /* for translating to UTF8 */
 #endif /* CURL_DOES_CONVERSIONS && HAVE_ICONV */
   unsigned int magic;          /* set to a CURLEASY_MAGIC_NUMBER */
+#if defined(CONFIG_NRF_CURL_INTEGRATION)
+struct k_poll_signal *kill_signal; 
+#endif
 };
 
 #define LIBCURL_NAME "libcurl"

--- a/ext/curl/tool/tool_cfgable.h
+++ b/ext/curl/tool/tool_cfgable.h
@@ -319,6 +319,7 @@ struct GlobalConfig {
   char *help_category;            /* The help category, if set */
 #if defined(CONFIG_NRF_CURL_INTEGRATION)
   bool curr_mdm_traces;
+  struct k_poll_signal *kill_signal; 
 #endif
   struct OperationConfig *first;
   struct OperationConfig *current;

--- a/ext/curl/tool/tool_main.c
+++ b/ext/curl/tool/tool_main.c
@@ -301,7 +301,7 @@ static void restore_terminal(void)
 int wmain(int argc, wchar_t *argv[])
 #else
 #if defined(CONFIG_NRF_CURL_INTEGRATION)
-int curl_tool_main(int argc, char *argv[])
+int curl_tool_main(int argc, char *argv[], struct k_poll_signal *kill_signal)
 #endif
 #endif
 {
@@ -345,6 +345,10 @@ int curl_tool_main(int argc, char *argv[])
      this point */
   result = main_init(&global);
   if(!result) {
+#if defined(CONFIG_NRF_CURL_INTEGRATION)
+    global.kill_signal = kill_signal;
+#endif
+      
     /* Start our curl operation */
     result = operate(&global, argc, argv);
 

--- a/ext/curl/tool/tool_operate.c
+++ b/ext/curl/tool/tool_operate.c
@@ -343,6 +343,11 @@ static CURLcode pre_transfer(struct GlobalConfig *global,
     }
     per->input.fd = per->infd;
   }
+
+#if defined(CONFIG_NRF_CURL_INTEGRATION)
+  curl_easy_nrf_set_kill_signal(per->curl, global->kill_signal);
+#endif
+  
   return result;
 }
 

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -379,6 +379,17 @@ Building and running
 
 .. include:: /includes/build_and_run_nrf9160.txt
 
+DK buttons
+==========
+
+The buttons have the following functions:
+
+Button 1:
+   Raises a kill or abort signal. A long press of the button will kill or abort all supported running commands. You can abort commands ``iperf3`` (also with ``th``), ``curl``, ``ping`` and ``sock send``.
+
+Button 2:
+   Enables or disables the UARTs for power consumption measurements. Toggles between UARTs enabled and disabled.
+
 Testing
 =======
 

--- a/samples/nrf9160/modem_shell/src/mosh_defines.h
+++ b/samples/nrf9160/modem_shell/src/mosh_defines.h
@@ -17,4 +17,8 @@
 
 #define MOSH_AT_CMD_RESPONSE_MAX_LEN 2700
 
+enum mosh_signals {
+	MOSH_SIGNAL_KILL,
+};
+
 #endif /* MOSH_DEFINES_H */

--- a/samples/nrf9160/modem_shell/src/shell.c
+++ b/samples/nrf9160/modem_shell/src/shell.c
@@ -170,7 +170,7 @@ static int cmd_iperf3(const struct shell *shell, size_t argc, char **argv)
 #if defined(CONFIG_MOSH_CURL)
 static int cmd_curl(const struct shell *shell, size_t argc, char **argv)
 {
-	(void)curl_tool_main(argc, argv);
+	(void)curl_tool_main(argc, argv, &mosh_signal);
 	shell_print(shell, "\nDONE");
 	return 0;
 }

--- a/samples/nrf9160/modem_shell/src/shell.c
+++ b/samples/nrf9160/modem_shell/src/shell.c
@@ -44,7 +44,7 @@
 
 extern const struct shell *shell_global;
 extern struct k_sem nrf_modem_lib_initialized;
-
+extern struct k_poll_signal mosh_signal;
 /**
  * @brief Overriding modem library error handler.
  */
@@ -162,7 +162,7 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 #if defined(CONFIG_MOSH_IPERF3)
 static int cmd_iperf3(const struct shell *shell, size_t argc, char **argv)
 {
-	(void)iperf_main(argc, argv, NULL, 0, NULL);
+	(void)iperf_main(argc, argv, NULL, 0, &mosh_signal);
 	return 0;
 }
 #endif

--- a/samples/nrf9160/modem_shell/src/th/th_ctrl.c
+++ b/samples/nrf9160/modem_shell/src/th/th_ctrl.c
@@ -159,6 +159,16 @@ void th_ctrl_status_print(const struct shell *shell)
 	th_ctrl_data_status_print(shell, &th_work_data_2);
 }
 
+void th_ctrl_kill_em_all(void)
+{
+	if (k_work_is_pending(&(th_work_data_1.work))) {
+		k_poll_signal_raise(&th_work_data_1.kill_signal, 1);
+	}
+	if (k_work_is_pending(&(th_work_data_2.work))) {
+		k_poll_signal_raise(&th_work_data_2.kill_signal, 2);
+	}
+}
+
 void th_ctrl_kill(const struct shell *shell, int nbr)
 {
 	if (nbr == 1) {

--- a/samples/nrf9160/modem_shell/src/th/th_ctrl.h
+++ b/samples/nrf9160/modem_shell/src/th/th_ctrl.h
@@ -16,5 +16,6 @@ void th_ctrl_status_print(const struct shell *shell);
 void th_ctrl_start(const struct shell *shell, size_t argc, char **argv,
 		   bool bg_thread);
 void th_ctrl_kill(const struct shell *shell, int nbr);
+void th_ctrl_kill_em_all(void);
 
 #endif /* TH_CTRL_H */


### PR DESCRIPTION
By using MoSH, the DK button #1 can be used to kill/abort running instances of iperf3 (also instances started by th -command), ping, curl and sending of data by using sock send -command.