### PR TITLE
manifest: update softdevice controller and mpsl

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1c0ba974a1db404110f36976ac942645fedc4a36
+      revision: 7d93adccdf04686f5910b22362c816a54b921bc5
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Added support for nRF21540 GPIO Front-End Module for nRF53 Series.

Corresponding PR in nrf: nrfconnect/sdk-nrfxlib#534

Signed-off-by: Ryan Chu <ryan.chu@nordicsemi.no>