### PR TITLE
samples: dtm: Set default baudrate for all devices

### DIFF
--- a/samples/bluetooth/direct_test_mode/app.overlay
+++ b/samples/bluetooth/direct_test_mode/app.overlay
@@ -1,0 +1,4 @@
+&uart0 {
+	status = "okay";
+	current-speed = <19200>;
+};


### PR DESCRIPTION
The defacto baud rate for direct test mode is
19k2 baud rate. With this commit, it will be set
as default on the application level, regardless of
which board is being selected.