### PR TITLE
[backport-v1.6-branch] lib: bin: lwm2m_carrier: cancel work in lwm2m_os_timer_release()

### DIFF
--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -239,7 +239,10 @@ void lwm2m_os_timer_release(lwm2m_os_timer_t *timer)
 		return;
 	}
 
-	work->handler = NULL;
+	/* Workaround. The work is being reused by the library without ever reassigning
+	 * the handler, hence the timer cannot be released. Instead, only cancel the work.
+	 */
+	k_work_cancel_delayable_sync(&work->work_item, &work->work_sync);
 }
 
 int lwm2m_os_timer_start(lwm2m_os_timer_t *timer, int64_t msec)


### PR DESCRIPTION
Backport of [#5283](https://github.com/nrfconnect/sdk-nrf/pull/5283).