### PR TITLE
application: serial_lte_modem: Datamode error handling

### DIFF
--- a/applications/serial_lte_modem/doc/slm_data_mode.rst
+++ b/applications/serial_lte_modem/doc/slm_data_mode.rst
@@ -54,6 +54,8 @@ To exit data mode, the MCU sends the termination command set by the ``CONFIG_SLM
 
 When instructed to exit data mode, the SLM application returns the AT command response ``OK``.
 
+If the current sending function fails, the SLM application exits data mode and returns the AT command response ``ERROR``.
+
 The SLM application also exits data mode automatically in the following scenarios:
 
 * The TCP server is stopped.

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -139,7 +139,7 @@ void ftp_ctrl_callback(const uint8_t *msg, uint16_t len)
 			sprintf(rsp_buf, "\r\n#XFTP: %d,\"disconnected\"\r\n", -ENOEXEC);
 			break;
 		}
-		if (ftp_data_mode_handler && exit_datamode(false)) {
+		if (ftp_data_mode_handler && exit_datamode(DATAMODE_EXIT_URC)) {
 			ftp_data_mode_handler = NULL;
 		}
 		if (ftp_verbose_on) {
@@ -466,7 +466,7 @@ static int ftp_put_handler(const uint8_t *data, int len)
 		ret = ftp_put(filepath, data, len, FTP_PUT_NORMAL);
 	}
 
-	if (exit_datamode(false)) {
+	if (exit_datamode(DATAMODE_EXIT_URC)) {
 		ftp_data_mode_handler = NULL;
 	}
 
@@ -518,7 +518,7 @@ static int ftp_uput_handler(const uint8_t *data, int len)
 		ret = ftp_put(NULL, data, len, FTP_PUT_UNIQUE);
 	}
 
-	if (exit_datamode(false)) {
+	if (exit_datamode(DATAMODE_EXIT_URC)) {
 		ftp_data_mode_handler = NULL;
 	}
 

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -640,7 +640,6 @@ int handle_at_agps(enum at_cmd_type cmd_type)
 			 */
 			run_type = RUN_TYPE_AGPS;
 			err = nrf_modem_gnss_start();
-			LOG_INF("[JUZO] nrf_modem_gnss_start %d", err);
 			if (err) {
 				LOG_ERR("Failed to start GNSS, error: %d", err);
 				run_type = RUN_TYPE_NONE;

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -507,7 +507,7 @@ static void httpc_thread_fn(void *arg1, void *arg2, void *arg3)
 	int err;
 
 	err = do_http_request();
-	(void)exit_datamode(false);
+	(void)exit_datamode(DATAMODE_EXIT_URC);
 	if (err < 0) {
 		LOG_ERR("do_http_request fail:%d", err);
 		/* Disconnect from server */

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -20,9 +20,16 @@
 #include "slm_defines.h"
 
 /**@brief Operations in datamode. */
-enum slm_datamode_operation_t {
+enum slm_datamode_operation {
 	DATAMODE_SEND,  /* Send data in datamode */
 	DATAMODE_EXIT   /* Exit data mode */
+};
+
+/**@brief Exit modes in datamode. */
+enum slm_datamode_exit_mode {
+	DATAMODE_EXIT_OK,      /* Exit datamode, send OK response */
+	DATAMODE_EXIT_ERROR,   /* Exit datamode, send ERROR response */
+	DATAMODE_EXIT_URC      /* Exit datamode, send URC notification */
 };
 
 /**@brief Data mode sending handler type.
@@ -87,12 +94,12 @@ bool in_datamode(void);
 /**
  * @brief Request SLM AT host to exit data mode
  *
- * @param response Whether to send "OK" response or not
+ * @param exit_mode Response type. Refer to enum slm_datamode_exit_mode.
  *
  * @retval true If normal exit from data mode.
  *         false If not in data mode.
  */
-bool exit_datamode(bool response);
+bool exit_datamode(int exit_mode);
 /** @} */
 
 #endif /* SLM_AT_HOST_ */

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -757,11 +757,11 @@ static int do_sendto(const char *url, uint16_t port, const uint8_t *data, int da
 	sprintf(rsp_buf, "\r\n#XSENDTO: %d\r\n", offset);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 
+	freeaddrinfo(res);
 	if (ret >= 0) {
 		return 0;
 	}
 
-	freeaddrinfo(res);
 	return ret;
 }
 

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -431,7 +431,7 @@ static int tcp_datamode_callback(uint8_t op, const uint8_t *data, int len)
 static void tcpsvr_terminate_connection(int cause)
 {
 	if (in_datamode()) {
-		(void)exit_datamode(false);
+		(void)exit_datamode(DATAMODE_EXIT_URC);
 	}
 	if (proxy.sock_peer != INVALID_SOCKET) {
 		close(proxy.sock_peer);
@@ -520,7 +520,7 @@ static void tcpsvr_thread_func(void *p1, void *p2, void *p3)
 				(void)inet_ntop(AF_INET6, &client.sin6_addr, peer_addr,
 					sizeof(peer_addr));
 			}
-			if (fds[1].fd != INVALID_SOCKET) {
+			if (fds[1].fd >= 0) {
 				LOG_WRN("Full. Close connection.");
 				close(ret);
 				goto client_events;
@@ -657,7 +657,7 @@ static void tcpcli_thread_func(void *p1, void *p2, void *p3)
 	}
 
 	if (in_datamode()) {
-		(void)exit_datamode(false);
+		(void)exit_datamode(DATAMODE_EXIT_URC);
 	}
 	if (proxy.sock != INVALID_SOCKET) {
 		(void)close(proxy.sock);


### PR DESCRIPTION
Based on customer project experience, needs to quit datamode as
soon as sending function fails in order for upper-layer protocol
to re-act on the failure.

Add to support "ERROR" response for sending function in datamode.
No more re-transmit by datamode and all buffered data is dropped.

Piggyback: static code analysis check handling

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>