### PR TITLE
lib: agps: add own API, add support for GNSS API and refactor SUPL socket handling

### DIFF
--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -10,6 +10,9 @@
 #include <dfu/mcuboot.h>
 #include <math.h>
 #include <event_manager.h>
+#if defined(CONFIG_AGPS)
+#include <modem/agps.h>
+#endif
 
 #if defined(CONFIG_NRF_CLOUD_AGPS)
 #include <net/nrf_cloud_agps.h>
@@ -224,7 +227,7 @@ static void agps_data_handle(const uint8_t *buf, size_t len)
 	int err;
 
 #if defined(CONFIG_AGPS)
-	err = gps_process_agps_data(buf, len);
+	err = agps_cloud_data_process(buf, len);
 	if (err) {
 		LOG_WRN("Unable to process agps data, error: %d", err);
 #if defined(CONFIG_NRF_CLOUD_PGPS)
@@ -259,6 +262,36 @@ static void agps_data_handle(const uint8_t *buf, size_t len)
 	(void)err;
 }
 
+#if defined(CONFIG_AGPS)
+/* Converts the A-GPS data request from GPS driver to GNSS API format. */
+static void agps_request_convert(
+	struct nrf_modem_gnss_agps_data_frame *dest,
+	const struct gps_agps_request *src)
+{
+	dest->sv_mask_ephe = src->sv_mask_ephe;
+	dest->sv_mask_alm = src->sv_mask_alm;
+	dest->data_flags = 0;
+	if (src->utc) {
+		dest->data_flags |= NRF_MODEM_GNSS_AGPS_GPS_UTC_REQUEST;
+	}
+	if (src->klobuchar) {
+		dest->data_flags |= NRF_MODEM_GNSS_AGPS_KLOBUCHAR_REQUEST;
+	}
+	if (src->nequick) {
+		dest->data_flags |= NRF_MODEM_GNSS_AGPS_NEQUICK_REQUEST;
+	}
+	if (src->system_time_tow) {
+		dest->data_flags |= NRF_MODEM_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST;
+	}
+	if (src->position) {
+		dest->data_flags |= NRF_MODEM_GNSS_AGPS_POSITION_REQUEST;
+	}
+	if (src->integrity) {
+		dest->data_flags |= NRF_MODEM_GNSS_AGPS_INTEGRITY_REQUEST;
+	}
+}
+#endif
+
 static void agps_data_request_handle(struct gps_agps_request *incoming_request)
 {
 	int err;
@@ -269,7 +302,11 @@ static void agps_data_request_handle(struct gps_agps_request *incoming_request)
 	memcpy(&agps_request, incoming_request, sizeof(agps_request));
 
 #if defined(CONFIG_AGPS)
-	err = gps_agps_request_send(agps_request, GPS_SOCKET_NOT_PROVIDED);
+	struct nrf_modem_gnss_agps_data_frame request;
+
+	agps_request_convert(&request, &agps_request);
+
+	err = agps_request_send(request, AGPS_SOCKET_NOT_PROVIDED);
 	if (err) {
 		LOG_WRN("Failed to request A-GPS data, error: %d", err);
 		LOG_WRN("This is expected to fail if we are not in a connected state");

--- a/include/drivers/gps.h
+++ b/include/drivers/gps.h
@@ -27,7 +27,6 @@ extern "C" {
 
 #define GPS_NMEA_SENTENCE_MAX_LENGTH	83
 #define GPS_PVT_MAX_SV_COUNT		12
-#define GPS_SOCKET_NOT_PROVIDED		0
 
 struct gps_nmea {
 	char buf[GPS_NMEA_SENTENCE_MAX_LENGTH];
@@ -452,30 +451,6 @@ static inline int gps_deinit(const struct device *dev)
 
 	return api->deinit(dev);
 }
-
-/**
- * @brief Function to send a request for A-GPS data to the configured A-GPS
- *	  data source. See the A-GPS Library Kconfig documentation for alternatives.
- *
- * @param request Assistance data to request from A-GPS service.
- * @param socket GPS socket to which assistance data will be written
- *               when it's received from the selected A-GPS service.
- *               If zero the GPS driver will be used to write the data instead
- *               of directly to the provided socket.
- *
- * @return Zero on success or (negative) error code otherwise.
- */
-int gps_agps_request_send(struct gps_agps_request request, int socket);
-
-/**
- * @brief Processes A-GPS data.
- *
- * @param buf Pointer to A-GPS data.
- * @param len Buffer size of data to be processed.
- *
- * @return Zero on success or (negative) error code otherwise.
- */
-int gps_process_agps_data(const uint8_t *buf, size_t len);
 
 /** @} */
 

--- a/include/modem/agps.h
+++ b/include/modem/agps.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file agps.h
+ * @brief Public APIs for the A-GPS library.
+ * @defgroup agps A-GPS library
+ * @{
+ */
+
+#ifndef AGPS_H_
+#define AGPS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <nrf_modem_gnss.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define AGPS_SOCKET_NOT_PROVIDED 0
+
+/**
+ * @brief Function to send a request for A-GPS data to the configured A-GPS data source. See the
+ *        A-GPS library Kconfig documentation for alternatives.
+ *
+ * @param request Assistance data to request from the A-GPS service.
+ * @param socket GNSS socket to which assistance data will be written when it's received from the
+ *               selected A-GPS service. If socket argument is set to AGPS_SOCKET_NOT_PROVIDED,
+ *               the data will be written using the GPS driver or GNSS API.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int agps_request_send(struct nrf_modem_gnss_agps_data_frame request, int socket);
+
+/**
+ * @brief Processes A-GPS data from the cloud.
+ *
+ * @param buf Pointer to A-GPS data from the cloud.
+ * @param len Buffer size of data to be processed.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int agps_cloud_data_process(const uint8_t *buf, size_t len);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AGPS_H_ */

--- a/lib/agps/Kconfig
+++ b/lib/agps/Kconfig
@@ -6,6 +6,7 @@
 
 config AGPS
 	bool "A-GPS library"
+	depends on NRF_MODEM_LIB
 	help
 	  A library to simplify switching between A-GPS data sources.
 
@@ -28,7 +29,6 @@ config AGPS_SRC_NRF_CLOUD
 
 config AGPS_SRC_SUPL
 	bool "Use SUPL as data source"
-	depends on NRF_MODEM_LIB
 	imply SUPL_CLIENT_LIB
 	help
 	  Note that a request for A-GPS data using SUPL service will block until


### PR DESCRIPTION
This PR combines a few changes to the A-GPS library:

- Removes A-GPS library API from gps.h and adds an own header file for it (modem/agps.h). Also renames the functions accordingly and removes dependency to the GPS driver from the API.
- Adds support for writing SUPL A-GPS data using the GNSS API.
- Refactors the SUPL socket handling and adds support for IPv6 usage.