### PR TITLE
samples: nrf9160: modem_shell: update GNSS use case configuration

### DIFF
--- a/samples/nrf9160/modem_shell/src/gnss/gnss.h
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.h
@@ -185,14 +185,15 @@ int gnss_set_duty_cycling_policy(enum gnss_duty_cycling_policy policy);
 int gnss_set_elevation_threshold(uint8_t elevation);
 
 /**
- * @brief Sets whether low accuracy fixes are allowed.
+ * @brief Sets the GNSS use case configuration.
  *
- * @param value True if low accuracy fixes are allowed, false if not.
+ * @param low_accuracy_enabled True if low accuracy fixes are allowed, false if not.
+ * @param scheduled_downloads_disabled True if scheduled downloads are disabled, false if not.
  *
  * @retval 0 if the operation was successful.
  *         Otherwise, a (negative) error code is returned.
  */
-int gnss_set_low_accuracy(bool value);
+int gnss_set_use_case(bool low_accuracy_enabled, bool scheduled_downloads_disabled);
 
 /**
  * @brief Sets the NMEA mask.

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_gps_driver.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_gps_driver.c
@@ -302,7 +302,7 @@ int gnss_set_elevation_threshold(uint8_t elevation)
 	return -EOPNOTSUPP;
 }
 
-int gnss_set_low_accuracy(bool value)
+int gnss_set_use_case(bool low_accuracy_enabled, bool scheduled_downloads_disabled)
 {
 	shell_error(shell_global,
 		    "GNSS: Operation not supported in GPS driver mode");

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_interface.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_interface.c
@@ -933,20 +933,23 @@ int gnss_set_elevation_threshold(uint8_t elevation)
 	return err;
 }
 
-int gnss_set_low_accuracy(bool value)
+int gnss_set_use_case(bool low_accuracy_enabled, bool scheduled_downloads_disabled)
 {
 	int err;
 	uint8_t use_case = NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START;
 
 	gnss_api_init();
 
-	if (value) {
+	if (low_accuracy_enabled) {
 		use_case |= NRF_MODEM_GNSS_USE_CASE_LOW_ACCURACY;
+	}
+	if (scheduled_downloads_disabled) {
+		use_case |= NRF_MODEM_GNSS_USE_CASE_SCHED_DOWNLOAD_DISABLE;
 	}
 
 	err = nrf_modem_gnss_use_case_set(use_case);
 	if (err) {
-		shell_error(shell_global, "GNSS: Failed to set use case");
+		shell_error(shell_global, "GNSS: Failed to set use case, check modem FW version");
 	}
 
 	return err;

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
@@ -297,29 +297,28 @@ static int cmd_gnss_config_elevation(const struct shell *shell, size_t argc, cha
 	return gnss_set_elevation_threshold(elevation);
 }
 
-static int cmd_gnss_config_accuracy(const struct shell *shell, size_t argc, char **argv)
-{
-	return print_help(shell, argc, argv);
-}
-
-static int cmd_gnss_config_accuracy_normal(const struct shell *shell, size_t argc, char **argv)
+static int cmd_gnss_config_use_case(const struct shell *shell, size_t argc, char **argv)
 {
 	if (gnss_running) {
 		shell_error(shell, "%s: stop GNSS to execute command", argv[0]);
 		return -ENOEXEC;
 	}
 
-	return gnss_set_low_accuracy(false);
-}
+	uint8_t value;
+	bool low_accuracy_enabled = false;
+	bool scheduled_downloads_disabled = false;
 
-static int cmd_gnss_config_accuracy_low(const struct shell *shell, size_t argc, char **argv)
-{
-	if (gnss_running) {
-		shell_error(shell, "%s: stop GNSS to execute command", argv[0]);
-		return -ENOEXEC;
+	value = atoi(argv[1]);
+	if (value == 1) {
+		low_accuracy_enabled = true;
 	}
 
-	return gnss_set_low_accuracy(true);
+	value = atoi(argv[2]);
+	if (value == 1) {
+		scheduled_downloads_disabled = true;
+	}
+
+	return gnss_set_use_case(low_accuracy_enabled, scheduled_downloads_disabled);
 }
 
 static int cmd_gnss_config_nmea(const struct shell *shell, size_t argc, char **argv)
@@ -878,14 +877,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_gnss_config_accuracy,
-	SHELL_CMD_ARG(normal, NULL, "Normal accuracy fixes (default).",
-		      cmd_gnss_config_accuracy_normal, 1, 0),
-	SHELL_CMD_ARG(low, NULL, "Low accuracy fixes allowed.", cmd_gnss_config_accuracy_low, 1, 0),
-	SHELL_SUBCMD_SET_END
-);
-
-SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_gnss_config_powersave,
 	SHELL_CMD_ARG(off, NULL, "Power saving off (default).",
 		      cmd_gnss_config_powersave_off, 1, 0),
@@ -930,7 +921,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      cmd_gnss_config_system, 2, 0),
 	SHELL_CMD(elevation, NULL, "<angle>\nElevation threshold angle.",
 		  cmd_gnss_config_elevation),
-	SHELL_CMD(accuracy, &sub_gnss_config_accuracy, "Fix accuracy.", cmd_gnss_config_accuracy),
+	SHELL_CMD_ARG(use_case, NULL,
+		      "<low accuracy allowed> <scheduled downloads disabled>\n"
+		      "Use case configuration. 0 = option disabled, 1 = option enabled "
+		      "(default all disabled).",
+		      cmd_gnss_config_use_case, 3, 0),
 	SHELL_CMD_ARG(nmea, NULL,
 		      "<GGA enabled> <GLL enabled> <GSA enabled> <GSV enabled> <RMC enabled>\n"
 		      "NMEA mask. 0 = disabled, 1 = enabled (default all enabled).",

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_socket.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_socket.c
@@ -781,9 +781,16 @@ int gnss_set_elevation_threshold(uint8_t elevation)
 	return 0;
 }
 
-int gnss_set_low_accuracy(bool value)
+int gnss_set_use_case(bool low_accuracy_enabled, bool scheduled_downloads_disabled)
 {
-	low_accuracy = value;
+	if (scheduled_downloads_disabled) {
+		shell_error(shell_global,
+			    "GNSS: Disabling scheduled downloads not supported in "
+			    "GNSS socket API mode");
+		return -EOPNOTSUPP;
+	}
+
+	low_accuracy = low_accuracy_enabled;
 
 	return 0;
 }


### PR DESCRIPTION
Changed how use case configuration is set using modem_shell commands.
Added support for disabling scheduled downloads in periodic tracking mode.

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>