### PR TITLE
caf: Fix typo in net_state module

### DIFF
--- a/subsys/caf/events/net_state_event.c
+++ b/subsys/caf/events/net_state_event.c
@@ -46,6 +46,6 @@ EVENT_INFO_DEFINE(net_state_event,
 		  profile_net_state_event);
 
 EVENT_TYPE_DEFINE(net_state_event,
-		  IS_ENABLED(CONFIG_CAF_INIT_LOG_NET_EVENTS),
+		  IS_ENABLED(CONFIG_CAF_INIT_LOG_NET_STATE_EVENTS),
 		  log_net_state_event,
 		  &net_state_event_info);


### PR DESCRIPTION
Fix typo that made it unable to see net_state events.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>