### PR TITLE
gps_sim: Fix validation of timeout configuration

### DIFF
--- a/drivers/gps/gps_sim/gps_sim.c
+++ b/drivers/gps/gps_sim/gps_sim.c
@@ -317,7 +317,8 @@ static int start(const struct device *dev, struct gps_config *cfg)
 		return -EALREADY;
 	}
 
-	if (cfg->timeout >= cfg->interval) {
+	if ((drv_data->cfg.nav_mode != GPS_NAV_MODE_SINGLE_FIX) &&
+	    (cfg->timeout >= cfg->interval)) {
 		LOG_ERR("The timeout must be less than the interval");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Make gps_sim validate timeout only for navigation modes other than
GPS_NAV_MODE_SINGLE_FIX. This is because when in the navigation mode is
GPS_NAV_MODE_SINGLE_FIX, the value of interval is irrelevant.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>