### PR TITLE
net: lib: nrf_cloud: fix A-GPS data processing with GNSS API

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
@@ -705,13 +705,12 @@ int nrf_cloud_agps_process(const char *buf, size_t buf_len, const int *socket)
 
 		gps_dev = NULL;
 		fd = *socket;
-	} else if (gps_dev == NULL) {
+	} else {
 		gps_dev = device_get_binding("NRF9160_GPS");
-		if (gps_dev == NULL) {
-			LOG_ERR("GPS is not enabled, A-GPS response unhandled");
-			LOG_DBG("A-GPS_inject_active UNLOCKED");
-			k_sem_give(&agps_injection_active);
-			return -ENODEV;
+		if (gps_dev != NULL) {
+			LOG_DBG("Using GPS driver to input assistance data");
+		} else {
+			LOG_DBG("Using GNSS API to input assistance data");
 		}
 	}
 


### PR DESCRIPTION
Support for GNSS API was still missing from one place. Changed
code to allow A-GPS data processing also when no socket has
been provided and GPS driver is not enabled.

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>