### PR TITLE
samples: nrf9160: modem_shell: improve GNSS LNA configuration

### DIFF
--- a/samples/nrf9160/modem_shell/Kconfig
+++ b/samples/nrf9160/modem_shell/Kconfig
@@ -111,10 +111,31 @@ config MOSH_GNSS_GPS_DRIVER
 
 endchoice
 
-config MOSH_GNSS_ENABLE_LNA
-	bool "LNA for GNSS during startup"
+choice MOSH_GNSS_ANTENNA
 	depends on MOSH_GNSS
+	default MOSH_GNSS_ANTENNA_ONBOARD
+	prompt "Select which antenna to use for GNSS"
+config MOSH_GNSS_ANTENNA_ONBOARD
+	bool "Use onboard antenna"
+config MOSH_GNSS_ANTENNA_EXTERNAL
+	bool "Use external antenna"
+
+endchoice
+
+config MOSH_AT_MAGPIO
+	string
+	default "AT\%XMAGPIO=1,0,0,1,1,1574,1577" if BOARD_NRF9160DK_NRF9160_NS
+	default "AT\%XMAGPIO=1,1,1,7,1,746,803,2,698,748,2,1710,2200,3,824,894,4,880,960,5,791,849,7,1565,1586" if BOARD_THINGY91_NRF9160_NS
 	help
-	  Enable Low Noise Amplifier (LNA) for GNSS during startup
+	  Defines what is the AT%XMAGPIO command to be sent to GNSS module. Leave
+	  empty if this command should not be sent.
+
+config MOSH_AT_COEX0
+	string
+	default "AT\%XCOEX0=1,1,1565,1586" if (BOARD_NRF9160DK_NRF9160_NS || BOARD_THINGY91_NRF9160_NS) && MOSH_GNSS_ANTENNA_ONBOARD
+	default "AT\%XCOEX0" if (BOARD_NRF9160DK_NRF9160_NS || BOARD_THINGY91_NRF9160_NS) && MOSH_GNSS_ANTENNA_EXTERNAL
+	help
+	  Defines what is the AT%XCOEX0 command to be sent to GNSS module. Leave
+	  empty if this command should not be sent.
 
 endmenu # Modem Shell

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -294,10 +294,6 @@ Enable LTE PSM, only NMEA output, automatic A-GPS data fetching and start period
    gnss mode periodic 300 120
    gnss start
 
-Enable Low Noise Amplifier (LNA) for use with the on-board GPS antenna::
-
-   gnss lna enable
-
 FOTA
 ====
 

--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -12,9 +12,9 @@ CONFIG_MOSH_CURL=y
 CONFIG_MOSH_LINK=y
 CONFIG_MOSH_SMS=y
 CONFIG_MOSH_GNSS=y
-# By default Low Noise Amplifier (LNA) is not enabled, generally this should be enabled if the
-# on board GPS antenna is used. The LNA can also be controlled using shell commands.
-#CONFIG_MOSH_GNSS_ENABLE_LNA=y
+
+# Uncomment to use external antenna for GNSS
+#CONFIG_MOSH_GNSS_ANTENNA_EXTERNAL=y
 
 # Stacks and heaps
 CONFIG_MAIN_STACK_SIZE=4096
@@ -110,7 +110,7 @@ CONFIG_SUPL_CLIENT_LIB=n
 # Enable this to use GNSS socket API instead of the GNSS interface.
 #CONFIG_MOSH_GNSS_SOCKET=y
 
-# Configurations for the GPS driver, enable these to use GPS driver instead of the GNSS interface.
+# Configurations for the GPS driver, uncomment all to use GPS driver instead of the GNSS interface.
 #CONFIG_MOSH_GNSS_GPS_DRIVER=y
 #CONFIG_NRF9160_GPS=y
 #CONFIG_NRF9160_GPS_NMEA_GSV=y
@@ -118,8 +118,7 @@ CONFIG_SUPL_CLIENT_LIB=n
 #CONFIG_NRF9160_GPS_NMEA_GLL=y
 #CONFIG_NRF9160_GPS_NMEA_GGA=y
 #CONFIG_NRF9160_GPS_NMEA_RMC=y
-# Enable if an external GPS antenna is used with the GPS driver.
-#CONFIG_NRF9160_GPS_ANTENNA_EXTERNAL=y
+#CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION=n
 
 # Library for buttons and LEDs
 CONFIG_DK_LIBRARY=y

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.h
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.h
@@ -64,7 +64,7 @@ struct gnss_1pps_mode {
 
 /* Common functions */
 
-int gnss_set_lna_enabled(bool enabled);
+int gnss_configure_lna(void);
 
 /* Functions implemented by different API implementations */
 

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_common.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_common.c
@@ -11,46 +11,32 @@
 #include <shell/shell.h>
 #include <modem/at_cmd.h>
 
-#include "gnss.h"
-
-#ifdef CONFIG_BOARD_THINGY91_NRF9160_NS
-#define GNSS_LNA_ENABLE_XMAGPIO "AT\%XMAGPIO=1,1,1,7,1,746,803,2,698,748," \
-"2,1710,2200,3,824,894,4,880,960,5,791,849," \
-"7,1565,1586"
-#else
-#define GNSS_LNA_ENABLE_XMAGPIO "AT\%XMAGPIO=1,0,0,1,1,1574,1577"
-#endif
-
-#define GNSS_LNA_DISABLE_XMAGPIO "AT\%XMAGPIO"
-#define GNSS_LNA_ENABLE_XCOEX0 "AT\%XCOEX0=1,1,1565,1586"
-#define GNSS_LNA_DISABLE_XCOEX0 "AT\%XCOEX0"
-
 extern const struct shell *shell_global;
 
-int gnss_set_lna_enabled(bool enabled)
+int gnss_configure_lna(void)
 {
 	int err;
 	const char *xmagpio_command;
 	const char *xcoex0_command;
 
-	if (enabled) {
-		xmagpio_command = GNSS_LNA_ENABLE_XMAGPIO;
-		xcoex0_command = GNSS_LNA_ENABLE_XCOEX0;
-	} else {
-		xmagpio_command = GNSS_LNA_DISABLE_XMAGPIO;
-		xcoex0_command = GNSS_LNA_DISABLE_XCOEX0;
+	xmagpio_command = CONFIG_MOSH_AT_MAGPIO;
+	xcoex0_command = CONFIG_MOSH_AT_COEX0;
+
+	/* Make sure the AT command is not empty */
+	if (xmagpio_command[0] != '\0') {
+		err = at_cmd_write(xmagpio_command, NULL, 0, NULL);
+		if (err) {
+			shell_error(shell_global, "Failed to send XMAGPIO command");
+			return err;
+		}
 	}
 
-	err = at_cmd_write(xmagpio_command, NULL, 0, NULL);
-	if (err) {
-		shell_error(shell_global, "Failed to send XMAGPIO command");
-		return err;
-	}
-
-	err = at_cmd_write(xcoex0_command, NULL, 0, NULL);
-	if (err) {
-		shell_error(shell_global, "Failed to send XCOEX0 command");
-		return err;
+	if (xcoex0_command[0] != '\0') {
+		err = at_cmd_write(xcoex0_command, NULL, 0, NULL);
+		if (err) {
+			shell_error(shell_global, "Failed to send XCOEX0 command");
+			return err;
+		}
 	}
 
 	return 0;

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
@@ -788,21 +788,6 @@ static int cmd_gnss_1pps_disable(const struct shell *shell, size_t argc, char **
 	return gnss_set_1pps_mode(&mode);
 }
 
-static int cmd_gnss_lna(const struct shell *shell, size_t argc, char **argv)
-{
-	return print_help(shell, argc, argv);
-}
-
-static int cmd_gnss_lna_enable(const struct shell *shell, size_t argc, char **argv)
-{
-	return gnss_set_lna_enabled(true);
-}
-
-static int cmd_gnss_lna_disable(const struct shell *shell, size_t argc, char **argv)
-{
-	return gnss_set_lna_enabled(false);
-}
-
 static int cmd_gnss_output(const struct shell *shell, size_t argc, char **argv)
 {
 	int err;
@@ -981,13 +966,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_gnss_lna,
-	SHELL_CMD_ARG(enable, NULL, "Enable LNA.", cmd_gnss_lna_enable, 1, 0),
-	SHELL_CMD_ARG(disable, NULL, "Disable LNA.", cmd_gnss_lna_disable, 1, 0),
-	SHELL_SUBCMD_SET_END
-);
-
-SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_gnss,
 	SHELL_CMD_ARG(start, NULL, "Start GNSS.", cmd_gnss_start, 1, 0),
 	SHELL_CMD_ARG(stop, NULL, "Stop GNSS.", cmd_gnss_stop, 1, 0),
@@ -999,7 +977,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		  cmd_gnss_priority),
 	SHELL_CMD(agps, &sub_gnss_agps, "AGPS configuration and commands.", cmd_gnss_agps),
 	SHELL_CMD(1pps, &sub_gnss_1pps, "1PPS control.", cmd_gnss_1pps),
-	SHELL_CMD(lna, &sub_gnss_lna, "Enable or disable LNA.", cmd_gnss_lna),
 	SHELL_CMD(output, NULL, "<pvt level> <nmea level> <event level>\nSet output levels.",
 		  cmd_gnss_output),
 	SHELL_SUBCMD_SET_END

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -161,10 +161,9 @@ void main(void)
 #if defined(CONFIG_MOSH_WORKER_THREADS)
 	th_ctrl_init();
 #endif
-#if defined(CONFIG_MOSH_GNSS_ENABLE_LNA)
-	gnss_set_lna_enabled(true);
+#if defined(CONFIG_MOSH_GNSS)
+	gnss_configure_lna();
 #endif
-
 #if defined(CONFIG_MOSH_FOTA)
 	err = fota_init();
 	if (err) {


### PR DESCRIPTION
MAPGIO/COEX0 configuration which switches GNSS LNA on/off only takes
effect before any modem activity has occurred. Modem shell had a
command 'gnss lna', but it has not been working properly if given
before RF has been started. Thus the whole command was removed and
essentially replaced with Kconfig item MOSH_GNSS_ANTENNA. Now it
is enough that the user knows if she's using onboard or external
antenna and the LNA will be configured accordingly.

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>