### PR TITLE
manifest:nrfxlib can now build with TF-M and FPU

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 6a8dc21a9019af2d6495c8a7006b6816f5830b35
+      revision: ed9a0bfdfa223a2c476f0b66da8a829381a0ee96
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-This points to the nrfxlib PR which solves an issue
 when building with TF-M and enabled the FPU.

Nrfxlib PR: [pull/537](https://github.com/nrfconnect/sdk-nrfxlib/pull/537)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>