### PR TITLE
doc: matter: samples: advertising time

### DIFF
--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -106,7 +106,7 @@ Button 3:
     If for some reason the light switch device is not able to receive messages during this predefined period of time, you can restart publishing service by pressing this button again.
 
 Button 4:
-    Starts the the NFC tag emulation, enables Bluetooth LE advertising for the predefined period of time, and makes the device discoverable over Bluetooth LE.
+    Starts the NFC tag emulation, enables Bluetooth LE advertising for the predefined period of time (15 minutes by default), and makes the device discoverable over Bluetooth LE.
     This button is used during the :ref:`commissioning procedure <matter_light_bulb_sample_remote_control_commissioning>`.
 
 .. include:: ../lock/README.rst

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -136,7 +136,7 @@ Button 3:
     Starts the Thread networking in the :ref:`test mode <matter_lock_sample_test_mode>` using the default configuration.
 
 Button 4:
-    Starts the the NFC tag emulation, enables Bluetooth LE advertising for the predefined period of time, and makes the device discoverable over Bluetooth LE.
+    Starts the the NFC tag emulation, enables Bluetooth LE advertising for the predefined period of time (15 minutes by default), and makes the device discoverable over Bluetooth LE.
     This button is used during the :ref:`commissioning procedure <matter_lock_sample_remote_control_commissioning>`.
 
 .. matter_door_lock_sample_jlink_start


### PR DESCRIPTION
Added the default advertising time information.
KRKNWK-10944.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>