### PR TITLE
doc: rename release-notes-latest and other edits

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -199,5 +199,5 @@
     - "subsys/bluetooth/**/*"
     - "!subsys/bluetooth/mesh/**/*"
 
-"no-changelog":
+"changelog-entry-required":
   - "!doc/nrf/releases/release-notes-changelog.rst"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -200,4 +200,4 @@
     - "!subsys/bluetooth/mesh/**/*"
 
 "no-changelog":
-  - "!doc/nrf/releases/release-notes-latest.rst"
+  - "!doc/nrf/releases/release-notes-changelog.rst"

--- a/doc/nrf/release_notes.rst
+++ b/doc/nrf/release_notes.rst
@@ -12,7 +12,7 @@ This page is included only in the latest documentation, because it might contain
    A "99" at the end of the version number of this documentation indicates continuous updates on the master branch since the previous major.minor release.
    When looking at this latest documentation, be aware of the following aspects:
 
-   * Changes between releases are tracked on the :ref:`ncs_release_notes_latest` page, but the master branch might contain additional changes that are not listed on that page.
+   * Changes between releases are tracked on the :ref:`ncs_release_notes_changelog` page, but the master branch might contain additional changes that are not listed on that page.
    * The release note pages that are available in the latest documentation might differ slightly from the release notes that were included in the respective |NCS| release at its release date.
      Therefore, to see the official version of the release notes for a specific |NCS| release, switch to the documentation for the corresponding |NCS| version using the selector in the upper left-hand corner.
 
@@ -20,7 +20,7 @@ This page is included only in the latest documentation, because it might contain
    :maxdepth: 1
    :caption: Subpages:
 
-   releases/release-notes-latest
+   releases/release-notes-changelog
    releases/release-notes-1.6.1
    releases/release-notes-1.6.0
    releases/release-notes-1.5.1

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -1,21 +1,16 @@
-.. _ncs_release_notes_latest:
+.. _ncs_release_notes_changelog:
 
-Changes in |NCS| v1.6.99
-########################
+Changelog for |NCS| v1.6.99
+###########################
 
 .. contents::
    :local:
    :depth: 2
 
-The most relevant changes that are present on the master branch of the |NCS|, as compared to the latest release, are tracked in this file.
+The most relevant changes that are present on the master branch of the |NCS|, as compared to the latest official release, are tracked in this file.
 
 .. note::
    This file is a work in progress and might not cover all relevant changes.
-
-Highlights
-**********
-
-There are no entries for this section yet.
 
 Known issues
 ************
@@ -194,4 +189,6 @@ The following list summarizes the most important changes inherited from the upst
 Documentation
 =============
 
-There are no entries for this section yet.
+* Updated:
+
+  * Renamed :ref:`ncs_release_notes_changelog`.

--- a/doc/nrf/templates/sample_README.rst
+++ b/doc/nrf/templates/sample_README.rst
@@ -223,12 +223,6 @@ Troubleshooting*
 
 If the LEDs do not start blinking, check if the music is loud enough.
 
-
-Known issues and limitations*
-*****************************
-
-The sample only works with good music.
-
 References*
 ***********
 


### PR DESCRIPTION
Renamed release-notes-latest to -changelog.
Removed Highlights from changelog.
Removed KI section from sample template.
NCSDK-10540.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>