### PR TITLE
test: lib: dfu_target fix B1 upgrade url

### DIFF
--- a/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
@@ -17,7 +17,7 @@
  */
 char buf[1024];
 
-#define S0_S1 "s0 s1"
+#define S0_S1 "s0+s1"
 #define NO_SPACE "s0s1"
 
 const char *flash_ptr = S0_S1;


### PR DESCRIPTION
In PR-5223 the way how the B1 upgrade image for the S0 and the S1
partition got changed. From SPACE " " to "+".
Therefore it was also needed to change the corresponding twister test,
which was missed in the original PR.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>