### PR TITLE
nfc: ndef: enable encoding of long uri messages

### DIFF
--- a/include/nfc/ndef/uri_msg.h
+++ b/include/nfc/ndef/uri_msg.h
@@ -47,7 +47,7 @@ extern "C" {
  */
 int nfc_ndef_uri_msg_encode(enum nfc_ndef_uri_rec_id uri_id_code,
 			    uint8_t const *const uri_data,
-			    uint8_t uri_data_len,
+			    uint16_t uri_data_len,
 			    uint8_t *buf,
 			    uint32_t *len);
 

--- a/include/nfc/ndef/uri_rec.h
+++ b/include/nfc/ndef/uri_rec.h
@@ -80,7 +80,7 @@ struct nfc_ndef_uri_rec_payload {
 	/** Pointer to a URI string. */
 	uint8_t const *uri_data;
 	/** Length of the URI string. */
-	uint8_t uri_data_len;
+	uint16_t uri_data_len;
 };
 
 /**

--- a/subsys/nfc/ndef/uri_msg.c
+++ b/subsys/nfc/ndef/uri_msg.c
@@ -9,7 +9,7 @@
 
 int nfc_ndef_uri_msg_encode(enum nfc_ndef_uri_rec_id uri_id_code,
 			    uint8_t const *const uri_data,
-			    uint8_t uri_data_len,
+			    uint16_t uri_data_len,
 			    uint8_t *buf,
 			    uint32_t *len)
 {


### PR DESCRIPTION
The NDEF URI Message module now supports long URI payload encoding.
It is possible to encode URIs longer than 255 bytes.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>