### PR TITLE
Bluetooth: Tester: Fix Scheduler Action set

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -621,7 +621,7 @@ struct mesh_scheduler_action_set {
 	uint8_t ack;
 	uint8_t index;
 	uint8_t year;
-	uint8_t month;
+	uint16_t month;
 	uint8_t day;
 	uint8_t hour;
 	uint8_t minute;

--- a/tests/bluetooth/tester/src/mmdl.c
+++ b/tests/bluetooth/tester/src/mmdl.c
@@ -5159,7 +5159,7 @@ static void scheduler_action_set(uint8_t *data, uint16_t len)
 	if (cmd->ack) {
 		net_buf_simple_init(buf, 0);
 		net_buf_simple_add_u8(buf, status.year);
-		net_buf_simple_add_u8(buf, status.month);
+		net_buf_simple_add_le16(buf, status.month);
 		net_buf_simple_add_u8(buf, status.day);
 		net_buf_simple_add_u8(buf, status.hour);
 		net_buf_simple_add_u8(buf, status.minute);


### PR DESCRIPTION
Fix inncorrectly declared month parameter in the Scheduler Action Set
struct in the bttester.h.

Signed-off-by: Agata Ponitka <agata.ponitka@codecoup.pl>