### PR TITLE
cmake: Add support for variable offset and slot size

### DIFF
--- a/include/flash_map_pm.h
+++ b/include/flash_map_pm.h
@@ -15,6 +15,23 @@
 #define image_1 mcuboot_secondary
 #define image_0_nonsecure mcuboot_primary
 #define image_1_nonsecure mcuboot_secondary
+#if PM_mcuboot_primary_1_IS_ENABLED
+#define image_2 mcuboot_primary_1
+#if CONFIG_SOC_NRF5340_CPUAPP
+#if CONFIG_FLASH_SIMULATOR  /* TODO: Add special option for netcore update with RAM */
+#define PM_image_2_IS_ENABLED 1
+#define PM__image_2_IS_ENABLED 1
+#endif
+#else
+#define PM_image_2_IS_ENABLED 1
+#define PM__image_2_IS_ENABLED 1
+#endif /* CONFIG_SOC_NRF5340_CPUAPP */
+#endif
+#if PM_mcuboot_secondary_1_IS_ENABLED
+#define image_3 mcuboot_secondary_1
+#define PM_image_3_IS_ENABLED 1
+#define PM__image_3_IS_ENABLED 1
+#endif
 #define image_scratch mcuboot_scratch
 
 #if (CONFIG_SETTINGS_FCB || CONFIG_SETTINGS_NVS)

--- a/include/tfm/tfm_read_ranges.h
+++ b/include/tfm/tfm_read_ranges.h
@@ -21,6 +21,10 @@ static const struct tfm_read_service_range ranges[] = {
 	/* Allow reads of mcuboot metadata */
 	{.start = PM_MCUBOOT_PAD_ADDRESS,
 		.size = PM_MCUBOOT_PAD_SIZE},
+#ifdef PM_MCUBOOT_PAD_1_ADDRESS
+	{.start = PM_MCUBOOT_PAD_1_ADDRESS,
+		.size = PM_MCUBOOT_PAD_1_SIZE},
+#endif
 #endif
 	{.start = FICR_PUBLIC_ADDR,
 		.size = FICR_PUBLIC_SIZE},

--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -16,15 +16,16 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     # SIGNED_HEX_FILE_OUT - (required) Signed hex output image
     # DEPENDS - (optional) One or more dependencies for signing the hex image
 
-    set(oneValueArgs SIGNED_BIN_FILE_IN SIGNED_HEX_FILE_NAME_PREFIX START_ADDRESS_OFFSET SIGNED_HEX_FILE_OUT)
+    set(oneValueArgs SIGNED_BIN_FILE_IN SIGNED_HEX_FILE_NAME_PREFIX SLOT_SIZE START_ADDRESS_OFFSET SIGNED_HEX_FILE_OUT)
     set(multiValueArgs DEPENDS)
     cmake_parse_arguments(SIGN_ARG "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if (NOT DEFINED SIGN_ARG_SIGNED_BIN_FILE_IN
         OR NOT DEFINED SIGN_ARG_SIGNED_HEX_FILE_OUT
         OR NOT DEFINED SIGN_ARG_SIGNED_HEX_FILE_NAME_PREFIX
-        OR NOT DEFINED SIGN_ARG_START_ADDRESS_OFFSET)
-      message(FATAL_ERROR "Missing parameter, required: SIGNED_BIN_FILE_IN SIGNED_HEX_FILE_NAME_PREFIX START_ADDRESS_OFFSET SIGNED_HEX_FILE_OUT")
+        OR NOT DEFINED SIGN_ARG_START_ADDRESS_OFFSET
+        OR NOT DEFINED SIGN_ARG_SLOT_SIZE)
+      message(FATAL_ERROR "Missing parameter, required: SIGNED_BIN_FILE_IN SIGNED_HEX_FILE_NAME_PREFIX START_ADDRESS_OFFSET SIGNED_HEX_FILE_OUT SLOT_SIZE")
     endif()
 
     set(signed_hex ${SIGN_ARG_SIGNED_HEX_FILE_NAME_PREFIX}_signed.hex)
@@ -47,6 +48,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       # to be applied by mcuboot, the application is required to write the
       # IMAGE_MAGIC into the image trailer.
       ${sign_cmd}
+      --slot-size ${SIGN_ARG_SLOT_SIZE}
       ${SIGN_ARG_SIGNED_BIN_FILE_IN}
       ${signed_hex}
 
@@ -64,6 +66,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       COMMAND
       # Sign the binary version of the input hex file.
       ${sign_cmd}
+      --slot-size ${SIGN_ARG_SLOT_SIZE}
       ${to_sign_bin}
       ${update_bin}
 
@@ -75,7 +78,9 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       # as the input hex file, so in order for it to work as a test update,
       # it needs to be moved.
       ${sign_cmd}
+      --slot-size ${SIGN_ARG_SLOT_SIZE}
       --pad # Adds IMAGE_MAGIC to end of slot.
+      --hex-addr ${SIGN_ARG_START_ADDRESS_OFFSET}
       ${SIGN_ARG_SIGNED_BIN_FILE_IN}
       ${test_update_hex}
 
@@ -159,6 +164,8 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   endif()
 
   if(CONFIG_SIGN_IMAGES)
+    set(app_core_binary_name app_update.bin)
+
     execute_process(COMMAND
       ${PYTHON_EXECUTABLE}
       ${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py
@@ -175,6 +182,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       return()
     endif()
 
+
     set(sign_cmd
       ${PYTHON_EXECUTABLE}
       ${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py
@@ -183,7 +191,6 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       --header-size $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PAD_SIZE>
       --align       ${CONFIG_MCUBOOT_FLASH_WRITE_BLOCK_SIZE}
       --version     ${CONFIG_MCUBOOT_IMAGE_VERSION}
-      --slot-size   $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_SIZE>
       --pad-header
       )
 
@@ -191,7 +198,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       set(zb_add_ota_header_cmd
         ${PYTHON_EXECUTABLE}
         ${NRF_DIR}/scripts/bootloader/zb_add_ota_header.py
-        --application ${PROJECT_BINARY_DIR}/app_update.bin
+        --application ${PROJECT_BINARY_DIR}/${app_core_binary_name}
         --application-version-string ${CONFIG_MCUBOOT_IMAGE_VERSION}
         --zigbee-manufacturer-id ${CONFIG_ZIGBEE_FOTA_MANUFACTURER_ID}
         --zigbee-image-type ${CONFIG_ZIGBEE_FOTA_IMAGE_TYPE}
@@ -204,12 +211,11 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
         set(zb_add_ota_header_cmd "")
       endif(CONFIG_ZIGBEE AND CONFIG_ZIGBEE_FOTA)
 
-    set(app_offset $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_SIZE>)
-
     sign(
       SIGNED_BIN_FILE_IN ${app_to_sign_hex}
       SIGNED_HEX_FILE_NAME_PREFIX ${PROJECT_BINARY_DIR}/app
-      START_ADDRESS_OFFSET ${app_offset}
+      SLOT_SIZE $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_SIZE>
+      START_ADDRESS_OFFSET $<TARGET_PROPERTY:partition_manager,app_TO_SECONDARY>
       SIGNED_HEX_FILE_OUT app_signed_hex
       DEPENDS ${app_sign_depends}
       )
@@ -220,19 +226,10 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       mcuboot_primary_app_PM_HEX_FILE
       ${app_signed_hex}
       )
+
     set_property(GLOBAL PROPERTY
       mcuboot_primary_app_PM_TARGET
       mcuboot_sign_target
-      )
-
-    generate_dfu_zip(
-      TARGET mcuboot_sign_target
-      OUTPUT ${PROJECT_BINARY_DIR}/dfu_application.zip
-      BIN_FILES ${PROJECT_BINARY_DIR}/app_update.bin
-      TYPE application
-      SCRIPT_PARAMS
-      "load_address=$<TARGET_PROPERTY:partition_manager,PM_APP_ADDRESS>"
-      "version_MCUBOOT=${CONFIG_MCUBOOT_IMAGE_VERSION}"
       )
 
     get_shared(cpunet_signed_app_hex IMAGE CPUNET PROPERTY PM_SIGNED_APP_HEX)
@@ -256,9 +253,12 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
         endif()
       endforeach()
 
+      set(net_core_binary_name net_core_app_update.bin)
+
       sign(
         SIGNED_BIN_FILE_IN ${cpunet_signed_app_hex}
         SIGNED_HEX_FILE_NAME_PREFIX ${PROJECT_BINARY_DIR}/net_core_app
+        SLOT_SIZE $<TARGET_PROPERTY:partition_manager,net_app_slot_size>
         START_ADDRESS_OFFSET $<TARGET_PROPERTY:partition_manager,net_app_TO_SECONDARY>
         SIGNED_HEX_FILE_OUT net_core_app_signed_hex
         DEPENDS ${sign_depends}
@@ -274,6 +274,32 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
         net_core_app_sign_target
         )
 
+      generate_dfu_zip(
+        TARGET mcuboot_sign_target
+        OUTPUT ${PROJECT_BINARY_DIR}/dfu_application.zip
+        BIN_FILES ${PROJECT_BINARY_DIR}/${app_core_binary_name} ${PROJECT_BINARY_DIR}/${net_core_binary_name}
+        TYPE application
+        SCRIPT_PARAMS
+        "${app_core_binary_name}load_address=$<TARGET_PROPERTY:partition_manager,PM_APP_ADDRESS>"
+	"${net_core_binary_name}load_address=$<TARGET_PROPERTY:partition_manager,CPUNET_PM_APP_ADDRESS>"
+        "${app_core_binary_name}version_MCUBOOT=${CONFIG_MCUBOOT_IMAGE_VERSION}"
+        "${net_core_binary_name}version_BN0=${hci_rpmsg_fw_info}"
+	"${net_core_binary_name}board=${CONFIG_DOMAIN_CPUNET_BOARD}"
+	"${net_core_binary_name}soc=${hci_rpmsg_soc}"
+        "${app_core_binary_name}image_slot=2" # image_1
+        "${net_core_binary_name}image_slot=4" # image_3
+        )
+
+    else()
+      generate_dfu_zip(
+        TARGET mcuboot_sign_target
+        OUTPUT ${PROJECT_BINARY_DIR}/dfu_application.zip
+        BIN_FILES ${PROJECT_BINARY_DIR}/${app_core_binary_name}
+        TYPE application
+        SCRIPT_PARAMS
+        "load_address=$<TARGET_PROPERTY:partition_manager,PM_APP_ADDRESS>"
+        "version_MCUBOOT=${CONFIG_MCUBOOT_IMAGE_VERSION}"
+        )
     endif()
 
     if (CONFIG_BUILD_S1_VARIANT AND ("${CONFIG_S1_VARIANT_IMAGE_NAME}" STREQUAL "mcuboot"))
@@ -300,6 +326,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
         sign(
           SIGNED_BIN_FILE_IN ${${slot}_hex}
           SIGNED_HEX_FILE_NAME_PREFIX ${out_path}
+          SLOT_SIZE $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_SIZE>
           START_ADDRESS_OFFSET ${slot_offset}
           SIGNED_HEX_FILE_OUT signed_hex
           DEPENDS ${${slot}_target} ${${slot}_hex}

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -82,6 +82,8 @@ endif()
 
 if (CONFIG_SECURE_BOOT)
   if (CONFIG_SOC_NRF5340_CPUNET)
+    set_shared(IMAGE ${IMAGE_NAME} PROPERTY soc ${CONFIG_SOC})
+    set_shared(IMAGE ${IMAGE_NAME} PROPERTY fw_info ${CONFIG_SOC})
     add_child_image(
       NAME b0n
       SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/nrf5340/netboot

--- a/scripts/bootloader/generate_zip.py
+++ b/scripts/bootloader/generate_zip.py
@@ -63,8 +63,8 @@ if __name__ == '__main__':
         special_info[n]['file'] = n
         special_info[n]['modtime'] = int(path.getmtime(p))
         merged = dict()
-        merged.update(special_info[n])
         merged.update(shared_info)
+        merged.update(special_info[n])
         manifest['files'].append(merged)
 
     path_to_manifest = path.join(path.dirname(args.output.name), f'{path.basename(args.output.name)}_manifest.json')

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -76,6 +76,10 @@ int spm_request_read_nse(void *destination, uint32_t addr, size_t len)
 		{.start = PM_MCUBOOT_PAD_ADDRESS,
 		 .size = PM_MCUBOOT_PAD_SIZE},
 #endif
+#ifdef PM_MCUBOOT_PAD_1_ADDRESS
+		{.start = PM_MCUBOOT_PAD_1_ADDRESS,
+		 .size = PM_MCUBOOT_PAD_1_SIZE},
+#endif
 		{.start = FICR_PUBLIC_ADDR,
 		 .size = FICR_PUBLIC_SIZE},
 		{.start = FICR_RESTRICTED_ADDR,

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 01a38e7fa55913350c647df1f51715fea5d80daa
+      revision: pull/593/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -99,7 +99,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 274ff833dabea621483cafa3e5aede9a9bf11b9e
+      revision: pull/165/head
       path: bootloader/mcuboot
     - name: nrfxlib
       repo-path: sdk-nrfxlib


### PR DESCRIPTION
To support the use case of multi-image MCUBoot the slot size and offset
of the signing proceedure needs to be configurable. This commit will add
these as variables to be put into the signing command.

It also shares the variable `CONFIG_UPDATEABLE_IMAGE_NUMBER` from
mcuboot to other images so that it can be used for setting different
configurations and sizes.

This commit also adds the generation of a dfu zip file with manifest for
network and application core when building for nRF53.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>