### PR TITLE
lib: dfu: Revert MCUBOOT FOTA image delimiter change

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -136,6 +136,20 @@ static int do_fota_start(int op, const char *file_uri, int sec_tag,
 		return -EINVAL;
 	}
 
+#if defined(CONFIG_SECURE_BOOT)
+	/* When download MCUBOOT bootloader, S0 and S1 must be separated by "+"
+	 * Convert "+" to " " SPACE as this is required in fota_download
+	 */
+	char *delimiter = strstr(path, "+");
+
+	if (delimiter == NULL) {
+		LOG_ERR("Invalid S0/S1 string");
+		return -EINVAL;
+	}
+
+	*delimiter = ' ';
+#endif
+
 	memset(hostname, 0x00, URI_HOST_MAX);
 	strncpy(hostname, file_uri, strlen(file_uri) - parser.field_data[UF_PATH].len);
 

--- a/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
@@ -56,7 +56,7 @@ int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active,
 	}
 
 	/* We have verified that there is a null-terminator, so this is safe */
-	char *delimiter = strstr(file, "+");
+	char *delimiter = strstr(file, " ");
 
 	if (delimiter == NULL) {
 		/* Could not find delimiter in input */

--- a/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
@@ -17,7 +17,7 @@
  */
 char buf[1024];
 
-#define S0_S1 "s0+s1"
+#define S0_S1 "s0 s1"
 #define NO_SPACE "s0s1"
 
 const char *flash_ptr = S0_S1;


### PR DESCRIPTION
In PR#5223 the delimiter was changed from SPAPCE to PLUS.
Revert this change as it causes issue in other modules.

application: serial_lte_modem

Define the delimiter to be PLUS, which is required for parsing
HTTP URL string, convert to SPACE before call fota_download.

testing: dfu

Restore SPACE delimiter in URL string definition, see PR#5319


Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>