### PR TITLE
cmake: adding missing file extension, .c to zephyr_sources filename

### DIFF
--- a/subsys/nfc/t4t/CMakeLists.txt
+++ b/subsys/nfc/t4t/CMakeLists.txt
@@ -10,4 +10,4 @@ zephyr_sources_ifdef(CONFIG_NFC_T4T_APDU apdu.c)
 zephyr_sources_ifdef(CONFIG_NFC_T4T_CC_FILE
 		     cc_file.c
 		     tlv_block.c)
-zephyr_sources_ifdef(CONFIG_NFC_T4T_HL_PROCEDURE hl_procedure)
+zephyr_sources_ifdef(CONFIG_NFC_T4T_HL_PROCEDURE hl_procedure.c)


### PR DESCRIPTION
CMake >= 3.20 requires file extensions explicitly added to source files.

See CMP0115:
> Starting in CMake 3.20, CMake prefers all source files to have their
> extensions explicitly listed:

The zephyr_sources_ifdef() added a file without extension causing CMake
to fail.

The line:
zephyr_sources_ifdef(CONFIG_NFC_T4T_HL_PROCEDURE hl_procedure)

has been updated to:
zephyr_sources_ifdef(CONFIG_NFC_T4T_HL_PROCEDURE hl_procedure.c)

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>