### PR TITLE
Add CI-libmodem-test label to labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,10 @@
   - "doc/**/*"
   - "**/*.rst"
 
+"CI-libmodem-test":
+  - "samples/nrf9160/**/*"
+  - "lib/nrf_modem_lib/*"
+
 "CI-boot-dfu-test":
   - "include/bl*"
   - "include/fprotect.h"


### PR DESCRIPTION
This commit adds glob patterns for the CI-libmodem-test label.

Signed-off-by: Fredrik Ås <fredrik.aas@nordicsemi.no>