### PR TITLE
manifest: Update ZBOSS libraries to v3.8.0.1

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -133,24 +133,24 @@
 .. _`known issues for nRF Connect SDK v1.4.0`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html?v=v1-4-0
 
 .. _`API documentation`:
-.. _`external ZBOSS development guide and API documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zigbee_devguide.html
-.. _`Stack commissioning start sequence`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/using_zigbee__z_c_l.html#stack_start_initiation
+.. _`external ZBOSS development guide and API documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/zigbee_devguide.html
+.. _`Stack commissioning start sequence`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/using_zigbee__z_c_l.html#stack_start_initiation
 .. _`ZBOSS NCP Host`: https://developer.nordicsemi.com/Zigbee/ncp_sdk_for_host/ncp_host_v1.0.0.zip
-.. _`NCP Host documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zboss_ncp_host_intro.html
-.. _`Rebuilding the ZBOSS libraries for host`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zboss_ncp_host.html#rebuilding_libs
-.. _`process the frame`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/using_zigbee__z_c_l.html#process_zcl_cmd
-.. _`declaring custom cluster`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/using_zigbee__z_c_l.html#cluster_declaration_custom
-.. _`Configuring sleepy behavior for end devices`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zigbee_prog_principles.html#zigbee_power_optimization_sleepy
-.. _`zboss_signal_handler()`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/group__zb__comm__signals.html#gae05c0ff285cfd03e0997fe438e8047fc
+.. _`NCP Host documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/zboss_ncp_host_intro.html
+.. _`Rebuilding the ZBOSS libraries for host`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/zboss_ncp_host.html#rebuilding_libs
+.. _`process the frame`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/using_zigbee__z_c_l.html#process_zcl_cmd
+.. _`declaring custom cluster`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/using_zigbee__z_c_l.html#cluster_declaration_custom
+.. _`Configuring sleepy behavior for end devices`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/zigbee_prog_principles.html#zigbee_power_optimization_sleepy
+.. _`zboss_signal_handler()`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/group__zb__comm__signals.html#gae05c0ff285cfd03e0997fe438e8047fc
 
-.. _`ZB_BDB_SIGNAL_FINDING_AND_BINDING_INITIATOR_FINISHED`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/group__zb__comm__signals.html#ga18f5e7ddfefb7d01ef98f696a9694d79
-.. _`ZB_ZDO_SIGNAL_PRODUCTION_CONFIG_READY`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/group__zgp__sink.html#ga3eb4631c12c345991be2461566c150e9
-.. _`ZB_ZDO_SIGNAL_SKIP_STARTUP`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/group__zb__comm__signals.html#gab2b9e7a13fd471d7bb642655d825a04e
-.. _`ZB_BDB_SIGNAL_DEVICE_FIRST_START`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/group__zb__comm__signals.html#gab55565980ef0580712f8dc160b01ea06
-.. _`ZB_BDB_SIGNAL_DEVICE_REBOOT`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/group__zb__comm__signals.html#ga3e9d86f42d2c6c27240f423a40fb152b
-.. _`ZB_BDB_SIGNAL_FORMATION`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/group__zb__comm__signals.html#ga342d4176c8932ff8ab0d8d6f997fa603
-.. _`ZB_BDB_SIGNAL_STEERING`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/group__zb__comm__signals.html#ga25a801841c95d6daddb9c60b39542b13
-.. _`ZB_ZDO_SIGNAL_LEAVE`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/group__zb__comm__signals.html#ga7942f336484c4fbb85626951480b2bba
+.. _`ZB_BDB_SIGNAL_FINDING_AND_BINDING_INITIATOR_FINISHED`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/group__zb__comm__signals.html#ga18f5e7ddfefb7d01ef98f696a9694d79
+.. _`ZB_ZDO_SIGNAL_PRODUCTION_CONFIG_READY`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/group__zgp__sink.html#ga3eb4631c12c345991be2461566c150e9
+.. _`ZB_ZDO_SIGNAL_SKIP_STARTUP`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/group__zb__comm__signals.html#gab2b9e7a13fd471d7bb642655d825a04e
+.. _`ZB_BDB_SIGNAL_DEVICE_FIRST_START`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/group__zb__comm__signals.html#gab55565980ef0580712f8dc160b01ea06
+.. _`ZB_BDB_SIGNAL_DEVICE_REBOOT`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/group__zb__comm__signals.html#ga3e9d86f42d2c6c27240f423a40fb152b
+.. _`ZB_BDB_SIGNAL_FORMATION`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/group__zb__comm__signals.html#ga342d4176c8932ff8ab0d8d6f997fa603
+.. _`ZB_BDB_SIGNAL_STEERING`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/group__zb__comm__signals.html#ga25a801841c95d6daddb9c60b39542b13
+.. _`ZB_ZDO_SIGNAL_LEAVE`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.8.0.1/group__zb__comm__signals.html#ga7942f336484c4fbb85626951480b2bba
 
 .. ### Source: www.nordicsemi.com
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -193,6 +193,8 @@ Zigbee
 
   * :ref:`zigbee_ug_logging_stack_logs` - Improved printing ZBOSS stack logs.
     Added new backend options to print ZBOSS stack logs with option for using binary format.
+  * ZBOSS Zigbee stack to version 3.8.0.1+4.0.0.
+    See the :ref:`nrfxlib:zboss_changelog` in the nrfxlib documentation for detailed information.
 
 nRF IEEE 802.15.4 radio driver
 ------------------------------

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -53,7 +53,7 @@
    When enabled, it allows devices to manage transmission by informing each other about their current state, and ensures more reliable connection in high-speed communication scenarios.
 
 .. |zigbee_version| replace:: Zigbee 3.0
-.. |zboss_version| replace:: 3.6.0.0
+.. |zboss_version| replace:: 3.8.0.1
 .. |zigbee_ncp_package_version| replace:: 1.0.0
 .. |zigbee_description| replace:: Zigbee is a portable, low-power software networking protocol that provides connectivity over an 802.15.4-based mesh network.
 .. |enable_zigbee_before_testing| replace:: Make sure to configure the Zigbee stack before building and testing this sample.

--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: f8c4cbb42dbacd2a8b2ac62d7a26b42d0dc32b7c
+      revision: 6a8dc21a9019af2d6495c8a7006b6816f5830b35
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Change manifest file to use sdk-nrfxlib revision with the newest ZBOSS libraries.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>