### PR TITLE
doc: enable Algolia search

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -55,7 +55,7 @@ jobs:
         working-directory: ncs/nrf
         run: |
           cmake -GNinja -Bdoc/_build -Sdoc -DSPHINXOPTS_EXTRA="-W"
-          ninja -C doc/_build
+          NCS_USE_ALGOLIA=1 ninja -C doc/_build
 
       - name: Build cache
         working-directory: ncs/nrf

--- a/doc/_static/css/algolia.css
+++ b/doc/_static/css/algolia.css
@@ -1,0 +1,6 @@
+/* Copyright (c) 2021 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.wy-nav-side { overflow: visible; }
+.wy-side-scroll { overflow: inherit; }

--- a/doc/_utils/utils.py
+++ b/doc/_utils/utils.py
@@ -1,7 +1,10 @@
+import os
 from os import PathLike
 from pathlib import Path
+import textwrap
 from typing import Dict, Tuple, Optional
 
+from sphinx.application import Sphinx
 from sphinx.cmd.build import get_parser
 from west.manifest import Manifest
 
@@ -114,3 +117,40 @@ def get_intersphinx_mapping(docset: str) -> Optional[Tuple[str, str]]:
         return
 
     return (str(Path("..") / docset), str(inventory))
+
+
+def configure_algolia(app: Sphinx) -> None:
+    """Configure algolia search on the given Sphinx instance.
+
+    Notes:
+        This function will not do anything unless ``NCS_USE_ALGOLIA``
+        environment variable is set.
+
+    Args:
+        app: Sphinx instance.
+    """
+
+    if not os.environ.get("NCS_USE_ALGOLIA"):
+        return
+
+    app.add_js_file(
+        "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js",
+        defer="defer",
+        onload=textwrap.dedent(
+            f"""
+            docsearch({{
+                apiKey: 'fee2fbd62a3aa11ae2f30777a328b19f',
+                indexName: 'nrf_connect_sdk',
+                inputSelector: '#rtd-search-form input[type=text]',
+                algoliaOptions: {{
+                    hitsPerPage: 10,
+                }},
+            }});
+            """
+        ),
+    )
+
+    app.add_css_file(
+        "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
+    )
+    app.add_css_file("css/algolia.css")

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -48,3 +48,4 @@ ncs_cache_manifest = NRF_BASE / "west.yml"
 def setup(app):
     app.add_css_file("css/common.css")
     app.add_css_file("css/kconfig.css")
+    utils.configure_algolia(app)

--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -71,3 +71,4 @@ ncs_cache_manifest = NRF_BASE / "west.yml"
 def setup(app):
     app.add_css_file("css/common.css")
     app.add_css_file("css/mcuboot.css")
+    utils.configure_algolia(app)

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -172,3 +172,4 @@ ncs_cache_manifest = NRF_BASE / "west.yml"
 def setup(app):
     app.add_css_file("css/common.css")
     app.add_css_file("css/nrf.css")
+    utils.configure_algolia(app)

--- a/doc/nrfx/conf.py
+++ b/doc/nrfx/conf.py
@@ -70,3 +70,4 @@ ncs_cache_manifest = NRF_BASE / "west.yml"
 def setup(app):
     app.add_css_file("css/common.css")
     app.add_css_file("css/nrfx.css")
+    utils.configure_algolia(app)

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -121,3 +121,4 @@ ncs_cache_manifest = NRF_BASE / "west.yml"
 def setup(app):
     app.add_css_file("css/common.css")
     app.add_css_file("css/nrfxlib.css")
+    utils.configure_algolia(app)

--- a/doc/tfm/conf.py
+++ b/doc/tfm/conf.py
@@ -76,3 +76,4 @@ ncs_cache_manifest = NRF_BASE / "west.yml"
 def setup(app):
     app.add_css_file("css/common.css")
     app.add_css_file("css/tfm.css")
+    utils.configure_algolia(app)

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -74,3 +74,4 @@ ncs_cache_manifest = NRF_BASE / "west.yml"
 def setup(app):
     app.add_css_file("css/common.css")
     app.add_css_file("css/zephyr.css")
+    utils.configure_algolia(app)


### PR DESCRIPTION
Enable Algolia search on all docsets. Algolia offers cross-search
functionality.

Note: indexer can be configured if needed, see https://github.com/algolia/docsearch-configs/blob/master/configs/nrf_connect_sdk.json