### PR TITLE
west.yml: update zephyr sha

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 01a38e7fa55913350c647df1f51715fea5d80daa
+      revision: d5f350a4c4759f4a420663973af0f31e459d6f70
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Bring in a fix for a failing workflow inherited from upstream zephyr,
which ensures it is only run on the mainline zephyr repository. This
avoids failures when it is run in downstream repositories.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>