### PR TITLE
manifest: Post-upmerge Bluetooth changes

### DIFF
--- a/subsys/bluetooth/mesh/model_utils.h
+++ b/subsys/bluetooth/mesh/model_utils.h
@@ -134,15 +134,6 @@ model_transition_is_invalid(const struct bt_mesh_model_transition *transition)
 		 transition->delay > BT_MESH_MODEL_DELAY_TIME_MAX_MS));
 }
 
-static inline bool bt_mesh_model_is_extended(struct bt_mesh_model *model)
-{
-#ifdef CONFIG_BT_MESH_MODEL_EXTENSIONS
-	return model->next != NULL;
-#else
-	return false;
-#endif
-}
-
 #endif /* MODEL_UTILS_H__ */
 
 /** @} */

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 975e3710736e56770f5acd84b87cfd2c46dd0020
+      revision: 2716fad989a4de8f2f13bfa6626250572a081a80
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls in critical changes to the Bluetooth subsystem that came in after
upmerge.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>