### PR TITLE
doc: add support for nRF21540 FEM to nRF Secure Immutable Bootloader sample doc

### DIFF
--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -221,7 +221,17 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832
+   :rows: nrf9160dk_nrf9160_ns, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf21540dk_nrf52840
+
+Configuration
+*************
+
+|config|
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 .. _bootloader_build_and_run:
 

--- a/samples/bootloader/sample.yaml
+++ b/samples/bootloader/sample.yaml
@@ -4,11 +4,12 @@ tests:
   samples.bootloader:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840
-           nrf52dk_nrf52832 nrf51dk_nrf51422
+           nrf52dk_nrf52832 nrf51dk_nrf51422 nrf21540dk_nrf52840
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf9160dk_nrf9160
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
       - nrf51dk_nrf51422
+      - nrf21540dk_nrf52840
     tags: ci_build


### PR DESCRIPTION
This commit adds support for nRF21540 Front-End Module into the nRF Secure Immutable Bootloader sample doc.
Ref NCSDK-10897

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>