### PR TITLE
doc: add support for nRF21540 FEM to Event Manager sample doc

### DIFF
--- a/samples/event_manager/README.rst
+++ b/samples/event_manager/README.rst
@@ -38,8 +38,12 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf52dk_nrf52832, nrf52840dk_nrf52840
+   :rows: nrf9160dk_nrf9160_ns, nrf52dk_nrf52832, nrf52840dk_nrf52840, nrf21540dk_nrf52840
 
+Configuration
+*************
+
+|config|
 
 Building and running
 ********************

--- a/samples/event_manager/sample.yaml
+++ b/samples/event_manager/sample.yaml
@@ -8,4 +8,5 @@ tests:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160_ns
+      - nrf21540dk_nrf52840
     tags: ci_build


### PR DESCRIPTION
This commit adds support for nRF21540 Front-End Module to
the Event Manager sample doc.
Ref NCSDK-10897

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>