### PR TITLE
doc: add support for nRF21540 FEM to Profiler sample doc

### DIFF
--- a/samples/profiler/README.rst
+++ b/samples/profiler/README.rst
@@ -31,7 +31,12 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832
+   :rows: nrf9160dk_nrf9160_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf21540dk_nrf52840
+
+Configuration
+*************
+
+|config|
 
 Building and running
 ********************

--- a/samples/profiler/sample.yaml
+++ b/samples/profiler/sample.yaml
@@ -9,4 +9,5 @@ tests:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160_ns
+      - nrf21540dk_nrf52840
     tags: ci_build


### PR DESCRIPTION
This commit adds support for nRF21540 Front-End Module to
the Profiler sample doc.
Ref NCSDK-10897

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>