### PR TITLE
samples: matter: Aligned handling BLE advertising to the upstream

### DIFF
--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -109,7 +109,7 @@ int AppTask::Init()
 	ConfigurationMgr().LogDeviceConfig();
 	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
 
-#if defined(CONFIG_CHIP_NFC_COMMISSIONING) || defined(CONFIG_MCUMGR_SMP_BT)
+#if defined(CONFIG_CHIP_NFC_COMMISSIONING)
 	PlatformMgr().AddEventHandler(AppTask::ChipEventHandler, 0);
 #endif
 
@@ -382,31 +382,26 @@ void AppTask::UpdateLedState()
 	sRedLED.Animate();
 }
 
+#ifdef CONFIG_CHIP_NFC_COMMISSIONING
 void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 {
 	if (event->Type != DeviceEventType::kCHIPoBLEAdvertisingChange)
 		return;
 
-	if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped) {
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-		NFCMgr().StopTagEmulation();
-#endif
-#ifdef CONFIG_MCUMGR_SMP_BT
-		/* After CHIPoBLE advertising stop, start advertising SMP in case Thread is enabled or there are no
-		 * active CHIPoBLE connections (exclude the case when CHIPoBLE advertising is stopped on the connection
-		 * time) */
-		if (GetDFUOverSMP().IsEnabled() &&
-		    (ConnectivityMgr().IsThreadProvisioned() || ConnectivityMgr().NumBLEConnections() == 0))
-			sAppTask.RequestSMPAdvertisingStart();
-#endif
-	}
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-	else if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Started) {
-		if (NFCMgr().IsTagEmulationStarted()) {
-			LOG_INF("NFC Tag emulation is already started");
-		} else {
-			ShareQRCodeOverNFC(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-		}
-	}
-#endif
+    if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Started)
+    {
+        if (NFCMgr().IsTagEmulationStarted())
+        {
+            LOG_INF("NFC Tag emulation is already started");
+        }
+        else
+        {
+            ShareQRCodeOverNFC(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+        }
+    }
+    else if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped)
+    {
+        NFCMgr().StopTagEmulation();
+    }
 }
+#endif

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -90,16 +90,16 @@
 
 .. _`SMP over Bluetooth`: https://github.com/apache/mynewt-mcumgr/blob/master/transport/smp-bluetooth.md
 
-.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/27bce6d/src/android/CHIPTool
-.. _`Commissioning nRF Connect Accessory using Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/27bce6d/docs/guides/nrfconnect_android_commissioning.md
-.. _`Working with Python Controller`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/27bce6d/docs/guides/python_chip_controller_building.md
-.. _`Performing Device Firmware Upgrade in Matter device`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/27bce6d/docs/guides/nrfconnect_examples_software_update.md
-.. _`Matter Protocol Overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/27bce6d/README.md
-.. _`nRF Connect platform overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/27bce6d/docs/guides/nrfconnect_platform_overview.md
-.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/27bce6d/src/controller
+.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/ee7ed2a/src/android/CHIPTool
+.. _`Commissioning nRF Connect Accessory using Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/ee7ed2a/docs/guides/nrfconnect_android_commissioning.md
+.. _`Working with Python Controller`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/ee7ed2a/docs/guides/python_chip_controller_building.md
+.. _`Performing Device Firmware Upgrade in Matter device`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/ee7ed2a/docs/guides/nrfconnect_examples_software_update.md
+.. _`Matter Protocol Overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/ee7ed2a/README.md
+.. _`nRF Connect platform overview`: https://github.com/nrfconnect/sdk-connectedhomeip/blob/ee7ed2a/docs/guides/nrfconnect_platform_overview.md
+.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/ee7ed2a/src/controller
 .. _`ZCL Advanced Platform`: https://github.com/project-chip/zap
 .. _`Matter nRF Connect releases`: https://github.com/nrfconnect/sdk-connectedhomeip/releases
-.. _`Building Android CHIPTool`: https://github.com/project-chip/connectedhomeip/blob/27bce6d/docs/guides/android_chiptool_building.md
+.. _`Building Android CHIPTool`: https://github.com/project-chip/connectedhomeip/blob/ee7ed2a/docs/guides/android_chiptool_building.md
 
 .. _`nRF Cloud JSON protocol schemas`: https://github.com/nRFCloud/application-protocols
 

--- a/samples/matter/common/src/dfu_over_smp.cpp
+++ b/samples/matter/common/src/dfu_over_smp.cpp
@@ -19,6 +19,8 @@
 
 #include <support/logging/CHIPLogging.h>
 
+using namespace ::chip::DeviceLayer;
+
 DFUOverSMP DFUOverSMP::sDFUOverSMP;
 
 void DFUOverSMP::Init(DFUOverSMPRestartAdvertisingHandler startAdvertisingCb)
@@ -33,6 +35,8 @@ void DFUOverSMP::Init(DFUOverSMPRestartAdvertisingHandler startAdvertisingCb)
 	bt_conn_cb_register(&mBleConnCallbacks);
 
 	restartAdvertisingCallback = startAdvertisingCb;
+
+	PlatformMgr().AddEventHandler(ChipEventHandler, 0);
 }
 
 void DFUOverSMP::ConfirmNewImage()
@@ -66,7 +70,7 @@ void DFUOverSMP::StartServer()
 		ChipLogProgress(DeviceLayer, "Enabled software update");
 
 		/* Start SMP advertising only in case CHIPoBLE advertising is not working. */
-		if (!chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled())
+		if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
 			StartBLEAdvertising();
 	} else {
 		ChipLogProgress(DeviceLayer, "Software update is already enabled");
@@ -75,7 +79,7 @@ void DFUOverSMP::StartServer()
 
 void DFUOverSMP::StartBLEAdvertising()
 {
-	if (!mIsEnabled)
+	if (!mIsEnabled && !mIsAdvertisingEnabled)
 		return;
 
 	const char *deviceName = bt_get_name();
@@ -98,20 +102,45 @@ void DFUOverSMP::StartBLEAdvertising()
 		ChipLogError(DeviceLayer, "SMP advertising start failed (rc %d)", rc);
 	} else {
 		ChipLogProgress(DeviceLayer, "Started SMP service BLE advertising");
+		mIsAdvertisingEnabled = true;
 	}
 }
 
 void DFUOverSMP::OnBleDisconnect(struct bt_conn *conId, uint8_t reason)
 {
-	chip::DeviceLayer::PlatformMgr().LockChipStack();
+	PlatformMgr().LockChipStack();
 
 	/* After BLE disconnect SMP advertising needs to be restarted. Before making it ensure that BLE disconnect was
 	 * not triggered by closing CHIPoBLE service connection (in that case CHIPoBLE advertising needs to be
 	 * restarted). */
-	if (!chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled() &&
-	    chip::DeviceLayer::ConnectivityMgr().NumBLEConnections() == 0) {
+	if (!ConnectivityMgr().IsBLEAdvertisingEnabled() && (ConnectivityMgr().NumBLEConnections() == 0)) {
 		sDFUOverSMP.restartAdvertisingCallback();
 	}
 
-	chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+	PlatformMgr().UnlockChipStack();
+}
+
+void DFUOverSMP::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
+{
+	if (!GetDFUOverSMP().IsEnabled())
+		return;
+
+	switch (event->Type) {
+	case DeviceEventType::kCHIPoBLEAdvertisingChange:
+		if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped) {
+			/* Check if CHIPoBLE advertising was stopped permanently or it just a matter of opened BLE
+			 * connection. */
+			if (ConnectivityMgr().NumBLEConnections() == 0)
+				sDFUOverSMP.restartAdvertisingCallback();
+		}
+		break;
+	case DeviceEventType::kCHIPoBLEConnectionClosed:
+		/* Check if after closing CHIPoBLE connection advertising is working, if no start SMP advertising. */
+		if (!ConnectivityMgr().IsBLEAdvertisingEnabled()) {
+			sDFUOverSMP.restartAdvertisingCallback();
+		}
+		break;
+	default:
+		break;
+	}
 }

--- a/samples/matter/common/src/dfu_over_smp.h
+++ b/samples/matter/common/src/dfu_over_smp.h
@@ -25,8 +25,10 @@ private:
 
 	static int UploadConfirmHandler(uint32_t offset, uint32_t size, void *arg);
 	static void OnBleDisconnect(bt_conn *conn, uint8_t reason);
+	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 
 	bool mIsEnabled;
+	bool mIsAdvertisingEnabled;
 	bt_conn_cb mBleConnCallbacks;
 	DFUOverSMPRestartAdvertisingHandler restartAdvertisingCallback;
 

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -86,7 +86,7 @@ int AppTask::Init()
 	ConfigurationMgr().LogDeviceConfig();
 	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
 
-#if defined(CONFIG_CHIP_NFC_COMMISSIONING) || defined(CONFIG_MCUMGR_SMP_BT)
+#if defined(CONFIG_CHIP_NFC_COMMISSIONING)
 	PlatformMgr().AddEventHandler(AppTask::ChipEventHandler, 0);
 #endif
 
@@ -338,34 +338,29 @@ void AppTask::StartBLEAdvertisingHandler()
 	}
 }
 
+#ifdef CONFIG_CHIP_NFC_COMMISSIONING
 void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 {
 	if (event->Type != DeviceEventType::kCHIPoBLEAdvertisingChange)
 		return;
 
-	if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped) {
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-		NFCMgr().StopTagEmulation();
-#endif
-#ifdef CONFIG_MCUMGR_SMP_BT
-		/* After CHIPoBLE advertising stop, start advertising SMP in case Thread is enabled or there are no
-		 * active CHIPoBLE connections (exclude the case when CHIPoBLE advertising is stopped on the connection
-		 * time) */
-		if (GetDFUOverSMP().IsEnabled() &&
-		    (ConnectivityMgr().IsThreadProvisioned() || ConnectivityMgr().NumBLEConnections() == 0))
-			sAppTask.RequestSMPAdvertisingStart();
-#endif
-	}
-#ifdef CONFIG_CHIP_NFC_COMMISSIONING
-	else if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Started) {
-		if (NFCMgr().IsTagEmulationStarted()) {
-			LOG_INF("NFC Tag emulation is already started");
-		} else {
-			ShareQRCodeOverNFC(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-		}
-	}
-#endif
+    if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Started)
+    {
+        if (NFCMgr().IsTagEmulationStarted())
+        {
+            LOG_INF("NFC Tag emulation is already started");
+        }
+        else
+        {
+            ShareQRCodeOverNFC(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+        }
+    }
+    else if (event->CHIPoBLEAdvertisingChange.Result == kActivity_Stopped)
+    {
+        NFCMgr().StopTagEmulation();
+    }
 }
+#endif
 
 void AppTask::ButtonEventHandler(uint32_t buttonState, uint32_t hasChanged)
 {

--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 27bce6d82a1227b1f9fb442c16ea74e4930acd6c
+      revision: ee7ed2ad92f8d2ff218ea085e5586ad2843b8658
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
In the connectedhomeip handling BLE advertising and switching
between CHIPoBLE and SMP advertising changed, so following changes
were needed to align Matter samples.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>