### PR TITLE
doc: add support for nRF21540 FEM to PPI Trace sample doc

### DIFF
--- a/samples/debug/ppi_trace/README.rst
+++ b/samples/debug/ppi_trace/README.rst
@@ -36,10 +36,19 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52dk_nrf52832, nrf52840dk_nrf52840, nrf9160dk_nrf9160
+   :rows: nrf52dk_nrf52832, nrf52840dk_nrf52840, nrf9160dk_nrf9160, nrf21540dk_nrf52840
 
 The sample also requires a logic analyzer.
 
+Configuration
+*************
+
+|config|
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************

--- a/samples/debug/ppi_trace/boards/nrf21540dk_nrf52840.conf
+++ b/samples/debug/ppi_trace/boards/nrf21540dk_nrf52840.conf
@@ -1,0 +1,6 @@
+CONFIG_BT_LL_SW_SPLIT=y
+
+# CC310 is disabled to speed up bootup time
+CONFIG_HW_CC3XX=n
+CONFIG_ENTROPY_CC3XX=n
+CONFIG_ENTROPY_NRF5_RNG=y

--- a/samples/debug/ppi_trace/sample.yaml
+++ b/samples/debug/ppi_trace/sample.yaml
@@ -4,7 +4,8 @@ sample:
 tests:
   samples.debug.ppi_trace:
     build_only: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160
+    build_on_all: true
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf21540_nrf52840
     tags: ci_build
     integration_platforms:
       - nrf52840dk_nrf52840


### PR DESCRIPTION
This commit adds support for nRF21540 Front-End Module to
the PPI Trace sample doc.
Ref NCSDK-10897

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>