### PR TITLE
doc: crypto: Update boards and overlays in crypto tests

### DIFF
--- a/tests/crypto/README.rst
+++ b/tests/crypto/README.rst
@@ -129,7 +129,7 @@ The tests support the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf52840dk_nrf52840
+   :rows: nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160, nrf52840dk_nrf52840
 
 .. note::
    Nordic devices such as nRF51, nRF52810, or nRF52811 cannot run the full test suite because of limited flash capacity.
@@ -147,10 +147,15 @@ There are multiple ways to build the tests.
 See :ref:`nrf_security` for additional information about configuring the Nordic Security Module.
 You can use the following configuration files to build the test in a specific setup:
 
-* :file:`overlay-backend-sw.conf` - software only, except a hardware module to generate entropy for RNG
-* :file:`overlay-backend-hw.conf` - hardware-accelerated using the Arm CryptoCell accelerator (for cryptography and entropy for RNG)
-* :file:`overlay-backend-hw-sw.conf` - a combination of hardware acceleration using Arm CryptoCell and a software implementation that adds key sizes and algorithms not supported in CryptoCell (the setup uses hardware as much as possible)
-* :file:`overlay-backend-oberon.conf` - uses the Oberon software library only for all cryptographic operations
+* :file:`overlay-cc3xx.conf` - it uses hardware acceleration using the Arm CryptoCell accelerator (for cryptography and entropy for random number generation).
+* :file:`overlay-cc3xx-oberon.conf` - it uses a combination of hardware acceleration, using the Arm CryptoCell, and the Oberon software library, that adds key sizes and algorithms not supported in the CryptoCell.
+  This setup uses hardware acceleration as much as possible.
+* :file:`overlay-oberon.conf` - it uses only the Oberon software library for all cryptographic operations.
+* :file:`overlay-vanilla.conf` - it is software only, except for a hardware-accelerated module to generate entropy for random number generation.
+* :file:`overlay-multi.conf` - it uses a combination of hardware acceleration, using the Arm CryptoCell, and vanilla mbedtls and Oberon software implementations to support functionalities not supported by the CryptoCell.
+  This setup uses hardware acceleration as much as possible.
+
+You can use one of the listed overlay configurations by adding the ``-- -DOVERLAY_CONFIG=<overlay_config_file>`` flag to your build. Also see :ref:`cmake_options` for instructions on how to add this option.
 
 .. _crypto_test_ztest_custom:
 


### PR DESCRIPTION
Add nrf5340dk_nrf5340_cpuapp and change nrf9160dk_nrf9160_ns to nrf9160dk_nrf9160 in
suported boards.
Update description of overlay files.

Signed-off-by: Andreas Vibeto <andreas.vibeto@nordicsemi.no>