### PR TITLE
applications: asset_tracker_v2: Use correct macro when encoding GPS data

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/json_common.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/json_common.c
@@ -375,7 +375,7 @@ int json_common_gps_data_add(cJSON *parent,
 			goto exit;
 		}
 
-		err = json_add_number(gps_val_obj, DATA_MOVEMENT, data->pvt.acc);
+		err = json_add_number(gps_val_obj, DATA_GPS_ACCURACY, data->pvt.acc);
 		if (err) {
 			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
 			goto exit;

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/json_protocol_names.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/json_protocol_names.h
@@ -16,6 +16,7 @@
 #define DATA_GPS_ALTITUDE	"alt"
 #define DATA_GPS_SPEED		"spd"
 #define DATA_GPS_HEADING	"hdg"
+#define DATA_GPS_ACCURACY	"acc"
 
 #define DATA_MODEM_DYNAMIC	"networkInfo"
 #define DATA_MODEM_STATIC	"deviceInfo"
@@ -134,6 +135,7 @@
 #define DATA_GPS_ALTITUDE	"alt"
 #define DATA_GPS_SPEED		"spd"
 #define DATA_GPS_HEADING	"hdg"
+#define DATA_GPS_ACCURACY	"acc"
 #define DATA_GPS_NMEA		"nmea"
 
 #define DATA_NEIGHBOR_CELLS_MCC		  "mcc"


### PR DESCRIPTION
Use new `DATA_GPS_ACCURACY` macro when encoding GPS objects in
`json_common` instead of `DATA_MOVEMENT` which is used in
correlation with accelerometer data.

Closes CIA-276