### PR TITLE
doc: add support for nRF21540 FEM to PHY Test Tool sample doc

### DIFF
--- a/samples/peripheral/802154_phy_test/README.rst
+++ b/samples/peripheral/802154_phy_test/README.rst
@@ -23,7 +23,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpunet, nrf52840dk_nrf52840
+   :rows: nrf5340dk_nrf5340_cpunet, nrf52840dk_nrf52840, nrf21540dk_nrf52840
 
 Conducting tests using the sample also requires a testing device, like another development kit running the same sample, set into DUT mode.
 For more information, see :ref:`802154_phy_test_testing`.
@@ -904,6 +904,16 @@ See the following example:
       :class: highlight
 
       custom lreboot
+
+Configuration
+*************
+
+|config|
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************


### PR DESCRIPTION
This commit adds support for nRF21540 Front-End Module to
the IEEE 802.15.4 PHY Test Tool sample doc.
Ref NCSDK-10897

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>