### PR TITLE
Bluetooth ANCS client app attribute request fixes

### DIFF
--- a/subsys/bluetooth/services/ancs_app_attr_get.c
+++ b/subsys/bluetooth/services/ancs_app_attr_get.c
@@ -181,12 +181,7 @@ int bt_ancs_app_attr_request(struct bt_ancs_client *ancs_c,
 			     const uint8_t *app_id, uint32_t len,
 			     bt_ancs_write_cb func)
 {
-	/* App ID to be requested must be null-terminated. */
 	if (!len) {
-		return -EINVAL;
-	}
-	if (app_id[len] !=
-	    '\0') {
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/services/ancs_attr_parser.c
+++ b/subsys/bluetooth/services/ancs_attr_parser.c
@@ -63,6 +63,7 @@ static enum bt_ancs_parse_state command_id_parse(struct bt_ancs_client *ancs_c,
 		ancs_c->attr_response.command_id = BT_ANCS_COMMAND_ID_GET_APP_ATTRIBUTES;
 		ancs_c->parse_info.attr_list = ancs_c->ancs_app_attr_list;
 		ancs_c->parse_info.attr_count = BT_ANCS_APP_ATTR_COUNT;
+		ancs_c->parse_info.current_app_id_index = 0;
 		parse_state = BT_ANCS_PARSE_STATE_APP_ID;
 		break;
 
@@ -88,6 +89,11 @@ static enum bt_ancs_parse_state app_id_parse(struct bt_ancs_client *ancs_c,
 					     const uint8_t *data_src,
 					     uint32_t *index)
 {
+	if (ancs_c->parse_info.current_app_id_index >= sizeof(ancs_c->attr_response.app_id)) {
+		LOG_WRN("App ID cannot be stored in response buffer.");
+		return BT_ANCS_PARSE_STATE_DONE;
+	}
+
 	ancs_c->attr_response.app_id[ancs_c->parse_info.current_app_id_index] =
 		data_src[(*index)++];
 


### PR DESCRIPTION
ANCS client clears an array index in the app attribute response parser. It prevents a buffer overflow when multiple requests are made.

Besides, remove a null termination check that is redundant.