### PR TITLE
doc: add support for nRF21540 FEM to Low power UART sample doc

### DIFF
--- a/samples/peripheral/lpuart/README.rst
+++ b/samples/peripheral/lpuart/README.rst
@@ -13,7 +13,7 @@ Overview
 ********
 
 The sample implements a simple loopback using a single UART instance.
-The sample has console and logging disabled by default, to demonstrate low power consumption while having UART active.
+It has console and logging disabled by default, to demonstrate low power consumption while having UART active.
 
 Requirements
 ************
@@ -22,7 +22,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf9160dk_nrf9160, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832, nrf5340dk_nrf5340_cpuapp
+   :rows: nrf9160dk_nrf9160, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
 
 The sample also requires the following pins to be shorted:
 
@@ -30,6 +30,16 @@ The sample also requires the following pins to be shorted:
 * Request Pin (Arduino Digital Pin 12) with Response Pin (Arduino Digital Pin 13)
 
 Additionally, it requires a logic analyzer.
+
+Configuration
+*************
+
+|config|
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************

--- a/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.conf
+++ b/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.conf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_UART_1_ASYNC=y
+CONFIG_UART_1_INTERRUPT_DRIVEN=n
+CONFIG_UART_1_NRF_HW_ASYNC=y
+CONFIG_UART_1_NRF_HW_ASYNC_TIMER=2
+CONFIG_NRFX_TIMER2=y

--- a/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.overlay
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
+
+&uart1 {
+	rx-pin = <44>;
+	tx-pin = <45>;
+	/delete-property/ rts-pin;
+	/delete-property/ cts-pin;
+
+	lpuart: nrf-sw-lpuart {
+		compatible = "nordic,nrf-sw-lpuart";
+		status = "okay";
+		label = "LPUART";
+		req-pin = <46>;
+		rdy-pin = <47>;
+	};
+};
+
+&uart0 {
+	status = "disabled";
+};
+
+&gpiote {
+	interrupts = <6 NRF_DEFAULT_IRQ_PRIORITY>;
+};

--- a/samples/peripheral/lpuart/sample.yaml
+++ b/samples/peripheral/lpuart/sample.yaml
@@ -5,13 +5,13 @@ tests:
   samples.peripheral.lpuart:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf9160dk_nrf9160
-                    nrf5340dk_nrf5340_cpuapp
+                    nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
     tags: ci_build
 
   samples.peripheral.lpuart_int_driven:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf9160dk_nrf9160
-                    nrf5340dk_nrf5340_cpuapp
+                    nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
     tags: ci_build
     extra_configs:
       - CONFIG_NRF_SW_LPUART_INT_DRIVEN=y


### PR DESCRIPTION
This commit adds support for nRF21540 Front-End Module to
the Low Power UART sample doc.
Ref NCSDK-10897

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>