### PR TITLE
unit_test: gps_module: Add setup and tearDown functions

### DIFF
--- a/applications/asset_tracker_v2/tests/gps_module/src/gps_module_test.c
+++ b/applications/asset_tracker_v2/tests/gps_module/src/gps_module_test.c
@@ -68,6 +68,20 @@ int test_suiteTearDown(int num_failures)
 	return generic_suiteTearDown(num_failures);
 }
 
+void setUp(void)
+{
+	mock_gps_Init();
+	mock_modules_common_Init();
+	mock_event_manager_Init();
+}
+
+void tearDown(void)
+{
+	mock_gps_Verify();
+	mock_modules_common_Verify();
+	mock_event_manager_Verify();
+}
+
 static int gps_init_callback(const struct device *dev,
 			     gps_event_handler_t handler, int number_of_calls)
 {


### PR DESCRIPTION
The setup and tearDown functions thus added will be invoked for every
test case. They initialize the mocks and verify that all expected
functions are called the correct number of times by the unit under
test (in this case, the gps_module).

If this is not done, the test case will pass even if the the gps_module
does not call make an expected function call.

This is needed because we are using custom scripts to generate test
runners in ncs.

See https://github.com/ThrowTheSwitch/CMock/issues/202

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>