### PR TITLE
doc: Add nRF21540 DK to the Working with nRF52 user guide

### DIFF
--- a/doc/nrf/ug_nrf52.rst
+++ b/doc/nrf/ug_nrf52.rst
@@ -68,7 +68,12 @@ Devices in the nRF52 Series are supported by these boards in the Zephyr open sou
      - ``nrf52840dongle_nrf52840``
      - | `Product Specification <nRF52840 Product Specification_>`_
        | `User Guide <nRF52840 Dongle User Guide_>`_
+   * - :ref:`zephyr:nrf21540dk_nrf52840`
+     - PCA10112
+     - ``nrf21540dk_nrf52840``
+     - `Product Specification <nRF21540 Product Specification_>`_
 
+See :ref:`ug_radio_fem_nrf21540_ek` to learn how to use this RF front-end module (FEM) with the nRF52 Series devices.
 
 nRF Desktop
 ===========


### PR DESCRIPTION
This commit adds nRF21540 DK and EK to the
supported boards table in the Working with nRF52
Series user guide.
Ref NCSDK-10897

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>