### PR TITLE
west.yml: zephyr: pull in fix for corrupted network poll timeout

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2716fad989a4de8f2f13bfa6626250572a081a80
+      revision: 9807bcf4e21610727f551e0a4f149fe4dc7a4289
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls in upstream zephyr commit
dab4616e4537eba1122654bd92fa8d85cedeccf9.

JIRA: NCSDK-10973

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>