### PR TITLE
doc: update nRF Cloud product name

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -10,14 +10,14 @@ nRF9160: Asset Tracker
 .. note::
    The Asset Tracker application is deprecated and succeeded by the :ref:`asset_tracker_v2` application.
 
-The Asset Tracker demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160-based kit to the `nRF Connect for Cloud`_ via LTE, transmit GPS and sensor data, and retrieve information about the device.
+The Asset Tracker demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160-based kit to the `nRF Cloud`_ via LTE, transmit GPS and sensor data, and retrieve information about the device.
 
 Overview
 ********
 
 The application uses the LTE link control driver to establish a network connection.
-It then collects various data locally, and transmits the data to Nordic Semiconductor's cloud solution, `nRF Connect for Cloud`_.
-The data is visualized in nRF Connect for Cloud's web interface.
+It then collects various data locally, and transmits the data to Nordic Semiconductor's cloud solution, `nRF Cloud`_.
+The data is visualized in nRF Cloud's web interface.
 
 The collected data includes the GPS position, accelerometer readings (the device's physical orientation), and data from various environment sensors.
 
@@ -52,10 +52,10 @@ On the Thingy:91, onboard sensors are used by default.
 GPS is enabled by default on both the kits.
 
 In addition to the sensor data, the application retrieves information from the LTE modem, such as the signal strength, battery voltage, and current operator.
-This information is available in nRF Connect for Cloud under the section **Cellular Link Monitor**.
+This information is available in nRF Cloud under the section **Cellular Link Monitor**.
 
 The `LTE Link Monitor`_ application, implemented as part of `nRF Connect for Desktop`_  can be used to send AT commands to the device and receive the responses.
-You can also send AT commands from the **Terminal** card on nRF Connect for Cloud when the device is connected.
+You can also send AT commands from the **Terminal** card on nRF Cloud when the device is connected.
 
 By default, the Asset Tracker supports firmware updates through :ref:`lib_aws_fota`.
 
@@ -112,7 +112,7 @@ User interface
 The buttons and switches have the following functions when the connection is established:
 
 Button 1 (SW3 on Thingy:91):
-    * Send a BUTTON event to the nRF Connect for Cloud.
+    * Send a BUTTON event to nRF Cloud.
     * Enable or disable GPS operation (long press the button for a minimum of 10 seconds).
 
 Switch 1 (only on nRF9160 DK):
@@ -126,8 +126,8 @@ On the nRF9160 DK, the application state is indicated by the LEDs.
 LED 3 and LED 4:
     * LED 3 blinking: The device is connecting to the LTE network.
     * LED 3 ON: The device is connected to the LTE network.
-    * LED 4 blinking: The device is connecting to nRF Connect for Cloud.
-    * LED 3 and LED 4 blinking: The MQTT connection has been established and the user association procedure with nRF Connect for Cloud has been initiated.
+    * LED 4 blinking: The device is connecting to nRF Cloud.
+    * LED 3 and LED 4 blinking: The MQTT connection has been established and the user association procedure with nRF Cloud has been initiated.
     * LED 4 ON: The device is connected and ready for sensor data transfer.
 
     .. figure:: /images/nrf_cloud_led_states.svg
@@ -137,7 +137,7 @@ LED 3 and LED 4:
 
 All LEDs (1-4):
     * Blinking in groups of two (LED 1 and 3, LED 2 and 4): Recoverable error in the Modem library.
-    * Blinking in cross pattern (LED 1 and 4, LED 2 and 3): Communication error with the nRF Connect for Cloud.
+    * Blinking in cross pattern (LED 1 and 4, LED 2 and 3): Communication error with nRF Cloud.
 
 On the Thingy:91, the application state is indicated by a single RGB LED as follows:
 
@@ -152,7 +152,7 @@ On the Thingy:91, the application state is indicated by a single RGB LED as foll
    * - White
      - Connecting to network
    * - Cyan
-     - Connecting to nRF Connect for Cloud
+     - Connecting to nRF Cloud
    * - Yellow
      - Waiting for user association
    * - Blue
@@ -182,7 +182,7 @@ Alternatively, you can manually set the configuration options to match the conte
 Using nRF Cloud A-GPS or P-GPS
 ******************************
 By default, this application enables :ref:`lib_nrf_cloud_agps` (Assisted GPS) support.
-Each time the GPS unit attempts to get a location fix, it may require additional information from  `nRF Connect for Cloud`_ to speed up the time to get that fix.
+Each time the GPS unit attempts to get a location fix, it may require additional information from  `nRF Cloud`_ to speed up the time to get that fix.
 
 Alternatively, :ref:`lib_nrf_cloud_pgps` (Predicted GPS) downloads and stores assistance predictions in Flash for one or two weeks, and does not require the cloud to help with each fix.
 
@@ -195,7 +195,7 @@ In order to use A-GPS and P-GPS at the same time, use the following instead:
 Using nRF Cloud FOTA
 ********************
 
-You can add the nRF Cloud FOTA update functionality to the application through the :ref:`lib_nrf_cloud` library.
+You can add nRF Cloud FOTA update functionality to the application through the :ref:`lib_nrf_cloud` library.
 The FOTA functionality is automatically enabled when you include the nRF Cloud library.
 For more information, see :ref:`lib_nrf_cloud_fota`.
 
@@ -254,20 +254,20 @@ After programming the application and all prerequisites to your kit, test the As
       ***** Booting Zephyr OS v1.13.99 *****
       Application started
 
-#. Observe in the terminal window that the connection to nRF Connect for Cloud is established. This may take several minutes.
+#. Observe in the terminal window that the connection to nRF Cloud is established. This may take several minutes.
 #. Open a web browser and navigate to https://nrfcloud.com/.
    Follow the instructions to set up your account and add an LTE device.
 #. The first time you start the application, add the device to your account:
 
    a. Observe that the LED(s) indicate that the device is waiting for user association.
-   #. Follow the instructions on `nRF Connect for Cloud`_ to add your device.
-   #. If association is successful, the device reconnects to nRF Connect for Cloud.
+   #. Follow the instructions on `nRF Cloud`_ to add your device.
+   #. If association is successful, the device reconnects to nRF Cloud.
       If the LED(s) indicate an error, check the details of the error in the terminal window.
       The device must be power-cycled to restart the association procedure.
 #. Observe that the LED(s) indicate that the connection is established.
-#. Observe that the device count on your nRF Connect for Cloud dashboard is incremented by one.
-#. Select the device from your device list on nRF Connect for Cloud, and observe that sensor data and modem information is received from the kit.
-#. Press Button 1 (SW3 on Thingy:91) to send BUTTON data to nRF Connect for Cloud.
+#. Observe that the device count on your nRF Cloud dashboard is incremented by one.
+#. Select the device from your device list on nRF Cloud, and observe that sensor data and modem information is received from the kit.
+#. Press Button 1 (SW3 on Thingy:91) to send BUTTON data to nRF Cloud.
 #. Press Button 1 (SW3 on Thingy:91) for a minimum of 10 seconds to enable GPS tracking.
    The kit must be outdoors in clear space for a few minutes to get the first position fix.
 #. Optionally send AT commands from the terminal, and observe that the response is received.

--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -298,10 +298,10 @@ Glossary
    Non-volatile Memory Controller (NVMC)
       A controller used for writing and erasing the internal flash memory and the User Information Configuration Registers (UICR).
 
-   nRF Connect for Cloud
+   nRF Cloud
       Nordic Semiconductor's platform for connecting IoT devices to the cloud, viewing and analyzing device message data, prototyping ideas that use Nordic Semiconductor chips, and more.
       It includes a public REST API that can be used for building IoT solutions.
-      See `nRF Connect for Cloud`_.
+      See `nRF Cloud`_.
 
    nRF repository
       An |NCS| repository, hosted in the `nrfconnect GitHub organization`_, that does not have an externally maintained, open-source upstream.

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -95,10 +95,10 @@ Sending data before connecting to nRF Cloud
 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0
 
-IRIS-2676: Missing support for FOTA on nRF Connect for Cloud
-  The :ref:`asset_tracker` application does not support the nRF Connect for Cloud FOTA_v2 protocol.
+IRIS-2676: Missing support for FOTA on nRF Cloud
+  The :ref:`asset_tracker` application does not support the nRF Cloud FOTA_v2 protocol.
 
-  **Workaround:** The implementation for supporting the nRF Connect for Cloud FOTA_v2 can be found in the following commits:
+  **Workaround:** The implementation for supporting the nRF Cloud FOTA_v2 can be found in the following commits:
 
 					* cef289b559b92186cc54f0257b8c9adc0997f334
 					* 156d4cf3a568869adca445d43a786d819ae10250

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -89,8 +89,8 @@ NCSDK-6689: High current consumption in Asset Tracker
 
 .. rst-class:: v1-0-0 v0-4-0 v0-3-0
 
-Sending data before connecting to nRF Connect for Cloud
-  The :ref:`asset_tracker` application does not wait for connection to nRF Connect for Cloud before trying to send data.
+Sending data before connecting to nRF Cloud
+  The :ref:`asset_tracker` application does not wait for connection to nRF Cloud before trying to send data.
   This causes the application to crash if the user toggles one of the switches before the kit is connected to the cloud.
 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0 v0-4-0 v0-3-0

--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -7,7 +7,7 @@ nRF Cloud
    :local:
    :depth: 2
 
-The nRF Cloud library enables applications to connect to Nordic Semiconductor's `nRF Connect for Cloud`_.
+The nRF Cloud library enables applications to connect to Nordic Semiconductor's `nRF Cloud`_.
 It abstracts and hides the details of the transport and the encoding scheme that is used for the payload and provides a simplified API interface for sending data from supported sensor types to the cloud.
 The current implementation supports the following technologies:
 
@@ -45,7 +45,7 @@ This procedure involves a TLS handshake that might take up to three seconds.
 The API blocks for the duration of the handshake.
 
 The cloud uses the certificates of the device for authentication.
-See `Updating the nRF Connect for Cloud certificate`_ and the :ref:`modem_key_mgmt` library for more information on modem credentials.
+See `Updating the nRF Cloud certificate`_ and the :ref:`modem_key_mgmt` library for more information on modem credentials.
 The certificates are generated using the device ID and PIN or HWID.
 The device ID is also the MQTT client ID.
 There are multiple configuration options for the device or client ID.
@@ -53,9 +53,9 @@ See :ref:`config_device_id` for more information.
 
 As the next step, the API subscribes to an MQTT topic to start receiving user association requests from the cloud.
 
-Every time nRF Connect for Cloud starts a communication session with a device, it verifies whether the device is uniquely associated with a user.
+Every time nRF Cloud starts a communication session with a device, it verifies whether the device is uniquely associated with a user.
 If not, the user association procedure is triggered.
-When adding the device to an nRF Connect for Cloud account, the user must provide the correct device ID and PIN (for Thingy:91 and custom hardware) or HWID (for nRF9160 DK) to nRF Cloud.
+When adding the device to an nRF Cloud account, the user must provide the correct device ID and PIN (for Thingy:91 and custom hardware) or HWID (for nRF9160 DK) to nRF Cloud.
 
 The following message sequence chart shows the flow of events and the expected application responses to each event during the user association procedure:
 
@@ -78,7 +78,7 @@ The chart shows the sequence of successful user association of an unassociated d
 
 .. note::
 
-   Currently, nRF Connect for Cloud requires that communication is re-established to update the device's permission to send user data.
+   Currently, nRF Cloud requires that communication is re-established to update the device's permission to send user data.
    The application must disconnect using :c:func:`nrf_cloud_disconnect` and then reconnect using :c:func:`nrf_cloud_connect`.
 
 When the device is successfully associated with a user on the cloud, subsequent connections to the cloud (also across power cycles) occur in the following sequence:
@@ -113,7 +113,7 @@ Firmware over-the-air (FOTA) updates
 The nRF Cloud library supports FOTA updates for your nRF9160-based device.
 When the library is included by the application, the :kconfig:`CONFIG_NRF_CLOUD_FOTA` option is enabled by default, and the FOTA functionality is made available to the application.
 
-For FOTA updates to work, the device must provide the information about the supported FOTA types to nRF Connect for Cloud.
+For FOTA updates to work, the device must provide the information about the supported FOTA types to nRF Cloud.
 The device passes this information by writing a ``fota_v2`` field containing an array of FOTA types into the ``serviceInfo`` field in the device's shadow.
 :c:func:`nrf_cloud_service_info_json_encode` can be used to generate the proper JSON data to enable FOTA.
 Additionally, :c:func:`nrf_cloud_shadow_device_status_update` can be used to generate the JSON data and perform the shadow update.
@@ -140,7 +140,7 @@ For example, a device that supports all the FOTA types writes the following data
                ]
    }}}}}
 
-You can initiate FOTA updates through `nRF Connect for Cloud`_ or by using the `nRF Connect for Cloud Device API`_.
+You can initiate FOTA updates through `nRF Cloud`_ or by using the `nRF Cloud Device API`_.
 When the device receives the :c:enumerator:`NRF_CLOUD_EVT_FOTA_DONE` event, the application must perform any necessary cleanup, as a reboot will be initiated to complete the update.
 The message payload of the :c:enumerator:`NRF_CLOUD_EVT_FOTA_DONE` event contains the :c:enum:`nrf_cloud_fota_type` value.
 If the value equals :c:enumerator:`NRF_CLOUD_FOTA_MODEM`, the application can optionally avoid a reboot by performing reinitialization of the modem and calling the :c:func:`nrf_cloud_modem_fota_completed` function.
@@ -151,7 +151,7 @@ Sending sensor data
 *******************
 The library offers two APIs, :c:func:`nrf_cloud_sensor_data_send` and :c:func:`nrf_cloud_sensor_data_stream` (lowest QoS), for sending sensor data to the cloud.
 
-To view sensor data on nRF Connect for Cloud, the device must first inform the cloud what types of sensor data to display.
+To view sensor data on nRF Cloud, the device must first inform the cloud what types of sensor data to display.
 The device passes this information by writing a ``ui`` field, containing an array of sensor types, into the ``serviceInfo`` field in the device's shadow.
 :c:func:`nrf_cloud_service_info_json_encode` can be used to generate the proper JSON data to enable FOTA.
 Additionally, :c:func:`nrf_cloud_shadow_device_status_update` can be used to generate the JSON data and perform the shadow update.
@@ -170,7 +170,7 @@ Following are the supported UI types on nRF Cloud:
 Removing the link between device and user
 *****************************************
 
-If you want to remove the link between a device and an nRF Connect for Cloud user, you must do this from the nRF Connect for Cloud.
+If you want to remove the link between a device and an nRF Cloud user, you must do this from the nRF Cloud.
 It is not possible for a device to unlink itself.
 
 When a user disassociates a device, the library disallows any further sensor data to be sent to the cloud and generates an :c:enumerator:`NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST` event.
@@ -191,7 +191,7 @@ See the following message sequence chart:
 Using Cloud API with nRF Cloud library
 **************************************
 You can use this library in conjunction with :ref:`cloud_api_readme`.
-The following sections describe the various stages in the process of connection to the nRF Connect for Cloud.
+The following sections describe the various stages in the process of connection to the nRF Cloud.
 
 Initialization
 ==============
@@ -201,7 +201,7 @@ The nRF Cloud library defines the Cloud API backend as ``NRF_CLOUD`` via the :c:
 
 The backend must be initialized using the :c:func:`cloud_init` function, with the binding, and a function pointer to user-defined Cloud API event handler as parameters.
 If :c:func:`cloud_init` returns success, the backend is ready for use.
-The return values for a failure scenario of the :c:func:`cloud_init` function are described below for the nRF Connect for Cloud backend:
+The return values for a failure scenario of the :c:func:`cloud_init` function are described below for the nRF Cloud backend:
 
 *	-EACCES - Invalid state. Already initialized.
 *	-EINVAL - Invalid event handler provided.
@@ -232,7 +232,7 @@ The dual functionalities of the :c:func:`cloud_connect` function in the two scen
 
    * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NOT_INITD`.
    * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NETWORK` - Host cannot be found with the available network interfaces.
-   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_BACKEND` - A backend-specific error. In the case of nRF Connect for Cloud, this can indicate a FOTA initialization error.
+   * :c:enumerator:`CLOUD_CONNECT_RES_ERR_BACKEND` - A backend-specific error. In the case of nRF Cloud, this can indicate a FOTA initialization error.
    * :c:enumerator:`CLOUD_CONNECT_RES_ERR_MISC` -  Error cause cannot be determined.
    * :c:enumerator:`CLOUD_CONNECT_RES_ERR_NO_MEM` - MQTT RX/TX buffers were not initialized.
    * :c:enumerator:`CLOUD_CONNECT_RES_ERR_PRV_KEY` - Invalid private key.
@@ -240,7 +240,7 @@ The dual functionalities of the :c:func:`cloud_connect` function in the two scen
    * :c:enumerator:`CLOUD_CONNECT_RES_ERR_CERT_MISC` - Miscellaneous certificate error.
    * :c:enumerator:`CLOUD_CONNECT_RES_ERR_TIMEOUT_NO_DATA` - Timeout. Typically occurs when the inserted SIM card has no data.
 
-  For both connection methods, when a device with JITP certificates attempts to connect to nRF Connect for Cloud for the first time, the cloud rejects the connection attempt so that it can provision the device.
+  For both connection methods, when a device with JITP certificates attempts to connect to nRF Cloud for the first time, the cloud rejects the connection attempt so that it can provision the device.
   When this occurs, the Cloud API generates a :c:enumerator:`CLOUD_EVT_DISCONNECTED` event with the ``err`` field set to :c:enumerator:`CLOUD_DISCONNECT_INVALID_REQUEST`.
   The device must restart the connection process upon receipt of the :c:enumerator:`CLOUD_EVT_DISCONNECTED` event.
 
@@ -248,7 +248,7 @@ Connected to the Cloud
 ======================
 
 When the device connects to the cloud successfully, the Cloud API dispatches a :c:enumerator:`CLOUD_EVT_CONNECTED` event.
-If the device is not associated with an nRF Connect for Cloud account, a :c:enumerator:`CLOUD_EVT_PAIR_REQUEST` event is generated.
+If the device is not associated with an nRF Cloud account, a :c:enumerator:`CLOUD_EVT_PAIR_REQUEST` event is generated.
 The device must wait until it is added to an account, which is indicated by the :c:enumerator:`CLOUD_EVT_PAIR_DONE` event.
 If a device pair request is received, the device must disconnect and reconnect after receiving the :c:enumerator:`CLOUD_EVT_PAIR_DONE` event.
 This is necessary because the updated policy of the cloud becomes effective only on a new connection.

--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -170,7 +170,7 @@ Following are the supported UI types on nRF Cloud:
 Removing the link between device and user
 *****************************************
 
-If you want to remove the link between a device and an nRF Cloud user, you must do this from the nRF Cloud.
+If you want to remove the link between a device and an nRF Cloud user, you must do this from nRF Cloud.
 It is not possible for a device to unlink itself.
 
 When a user disassociates a device, the library disallows any further sensor data to be sent to the cloud and generates an :c:enumerator:`NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST` event.
@@ -191,7 +191,7 @@ See the following message sequence chart:
 Using Cloud API with nRF Cloud library
 **************************************
 You can use this library in conjunction with :ref:`cloud_api_readme`.
-The following sections describe the various stages in the process of connection to the nRF Cloud.
+The following sections describe the various stages in the process of connection to nRF Cloud.
 
 Initialization
 ==============

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -204,6 +204,7 @@
 
 .. _`nRF9160 DK Getting Started`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/intro.html
 .. _`Updating the nRF9160 DK cellular modem`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/updating_modem_firmware.html
+.. _`Updating the nRF Cloud certificate`:
 .. _`Updating the nRF Connect for Cloud certificate`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/updating_certificates.html
 
 .. _`nRF9160 DK Hardware`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/intro.html
@@ -289,9 +290,11 @@
 
 .. _`nRF9160 Hardware Verification Guidelines - UART interface`: https://infocenter.nordicsemi.com/topic/nwp_034/WP/nwp_034/nwp_034_uart_if.html
 
-.. _`Creating an nRF Cloud account`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/common/create_nrfcloud_account.html
+.. _`Creating an nRF Cloud account`:
+.. _`Creating an nRF Connect for Cloud account`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/common/create_nrfcloud_account.html
 
-.. _`Connecting your device to nRF Cloud`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/connecting_nrf_cloud.html
+.. _`Connecting your device to nRF Cloud`:
+.. _`Connecting your device to nRF Connect for Cloud`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/connecting_nrf_cloud.html
 
 .. ### Source: devzone.nordicsemi.com
 
@@ -554,22 +557,16 @@
 
 .. _`nRF Cloud`:
 .. _`nRF Connect for Cloud`: https://nrfcloud.com/
-
 .. _`nRF Cloud documentation`:
 .. _`nRF Connect for Cloud documentation`: https://docs.nrfcloud.com/
-
-.. _`nRF Cloud Patch Device State`: https://api.nrfcloud.com/v1#operation/UpdateDeviceState
-
-.. _`nRF Connect for Cloud Device API`: https://api.nrfcloud.com/v1
-
-.. _`nRF Cloud REST API`: https://nrfcloud.com/#/docs/guides/restapi
-
+.. _`nRF Cloud Patch Device State`:
+.. _`nRF Connect for Cloud Patch Device State`: https://api.nrfcloud.com/v1#operation/UpdateDeviceState
+.. _`nRF Cloud Device API`: https://api.nrfcloud.com/v1
+.. _`nRF Cloud REST API`:
+.. _`nRF Connect for Cloud REST API`: https://docs.nrfcloud.com/Reference/Interacting/REST#the-nrf-cloud-rest-api
 .. _`nRF Cloud Location Services`: https://api.nrfcloud.com/v1#tag/Location-Services
-
 .. _`nRF Cloud Location Services documentation`: https://docs.nrfcloud.com/Reference/LocationServices
-
 .. _`Nordic Semiconductor's IoT cloud platform`: https://www.nordicsemi.com/Products/Cloud-services
-
 .. _`Securely Generating Credentials on the nRF9160`: https://docs.nrfcloud.com/Guides/GettingStarted/Devices#securely-generating-credentials-on-the-nrf9160
 
 .. ### Source: other

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -51,7 +51,7 @@ The firmware of Thingy:91 has been developed using the nRF Connect SDK.
 It is open source, and can be modified according to specific needs.
 The :ref:`asset_tracker` application firmware, which is preprogrammed in the Thingy:91, enables the device to use the environment sensors and provides an option of tracking the device using GPS.
 
-The data, along with information about the device, is transmitted to Nordic Semiconductor's cloud solution, `nRF Connect for Cloud`_, where it can be visualized.
+The data, along with information about the device, is transmitted to Nordic Semiconductor's cloud solution, `nRF Cloud`_, where it can be visualized.
 See :ref:`asset_tracker` for more information on the asset tracker application.
 
 Operating modes

--- a/samples/nrf9160/agps/README.rst
+++ b/samples/nrf9160/agps/README.rst
@@ -7,9 +7,9 @@ nRF9160: A-GPS
    :local:
    :depth: 2
 
-The A-GPS sample demonstrates how the `nRF Connect for Cloud`_ Assisted GPS (`A-GPS`_) feature or an external :ref:`SUPL client <supl_client>` can be used to implement A-GPS in your application.
+The A-GPS sample demonstrates how the `nRF Cloud`_ Assisted GPS (`A-GPS`_) feature or an external :ref:`SUPL client <supl_client>` can be used to implement A-GPS in your application.
 The sample uses the generic A-GPS library, which allows the selection of different A-GPS sources via the :kconfig:`CONFIG_AGPS_SRC_SUPL` configurable option.
-By default, `nRF Connect for Cloud`_ is used for A-GPS and cloud communication.
+By default, `nRF Cloud`_ is used for A-GPS and cloud communication.
 
 Requirements
 ************
@@ -20,7 +20,7 @@ The sample supports the following development kits:
    :header: heading
    :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
 
-The sample also requires an nRF Connect for Cloud account.
+The sample also requires an nRF Cloud account.
 
 .. include:: /includes/spm.txt
 
@@ -68,18 +68,18 @@ You can enable or disable these features by using the :kconfig:`CONFIG_LTE_POWER
 User interface
 **************
 
-You can send a predefined message to nRF Connect for Cloud by pressing button 1.
+You can send a predefined message to nRF Cloud by pressing button 1.
 The message can be changed by setting the :kconfig:`CONFIG_CLOUD_MESSAGE` to a new message.
 
 To ease outdoors and remote testing of A-GPS feature, two methods for resetting the kit are provided, if the default A-GPS source is used.
 Both are equivalent to pressing the reset button on the nRF9160 DK, or power-cycling the nRF9160 DK or Thingy:91.
 
 Button 1:
-   Press the button to send a predefined message to nRF Connect for Cloud (the default A-GPS source).
+   Press the button to send a predefined message to nRF Cloud (the default A-GPS source).
    Press the button for a minimum of 3 seconds to reset the nRF9160-based device.
 
-nRF Connect for Cloud:
-   Use the terminal pane in the device view for a particular device in nRF Connect for Cloud and send the ``"{"reboot":true}"`` command to reset the nRF9160-based device.
+nRF Cloud:
+   Use the terminal pane in the device view for a particular device in nRF Cloud and send the ``"{"reboot":true}"`` command to reset the nRF9160-based device.
 
 Configuration
 *************
@@ -141,13 +141,13 @@ Testing
 #. Optionally, connect the nRF9160-based device to a PC with a USB cable. The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. Optionally, connect to the kit with a terminal emulator (for example, PuTTY) to see log output. See How to connect with PuTTY for the required settings.
    You can also use the Bluetooth® LE service of Thingy:91 to see log output on a mobile device.
-#. Log into your nRF Connect for Cloud account and select your device.
+#. Log into your nRF Cloud account and select your device.
 #. Power on the nRF9160-based device.
 
    .. note::
-      The sample outputs shown in the subsequent steps correspond to the scenario when nRF Connect for Cloud is used as the A-GPS source.
+      The sample outputs shown in the subsequent steps correspond to the scenario when nRF Cloud is used as the A-GPS source.
 
-#. The device connects to the LTE network and nRF Connect for Cloud as shown below:
+#. The device connects to the LTE network and nRF Cloud as shown below:
 
    .. code-block:: console
 
@@ -161,7 +161,7 @@ Testing
 	  I: Network registration status: Connected - home network
 
    .. note::
-      If the credentials on the device are used to connect to nRF Connect for Cloud for the first time, the device will be disconnected, and a :cpp:enumerator:`CLOUD_EVT_DISCONNECTED <cloud_api::CLOUD_EVT_DISCONNECTED>` event will be logged on the terminal.
+      If the credentials on the device are used to connect to nRF Cloud for the first time, the device will be disconnected, and a :cpp:enumerator:`CLOUD_EVT_DISCONNECTED <cloud_api::CLOUD_EVT_DISCONNECTED>` event will be logged on the terminal.
       This happens due to the configuring of the device on the cloud by `AWS IoT Just-in-time-provisioning`_ and the subsequent termination of the connection.
       In general, the devices reconnect automatically.
       However, for the simplicity of the sample, reconnection is not implemented.
@@ -334,7 +334,7 @@ Testing
 	  D: PVT: Position fix
 	  D: Stopping GPS
 
-#. Observe that the current position of the device shows up on the GPS position map in nRF Connect for Cloud, after acquiring the GPS position fix.
+#. Observe that the current position of the device shows up on the GPS position map in nRF Cloud, after acquiring the GPS position fix.
    The position details are also displayed on the terminal as shown below:
 
    .. code-block:: console
@@ -361,7 +361,7 @@ Testing
 	  I: GPS position sent to cloud
 
 
-#. Optionally, press Button 1 and observe that the predefined message is sent from the device to nRF Connect for Cloud.
+#. Optionally, press Button 1 and observe that the predefined message is sent from the device to nRF Cloud.
    Note that this interrupts the GPS search for a period of time since LTE requires the use of the radio resources of the device.
 
 Dependencies

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -89,7 +89,7 @@ After programming the sample to your development kit, test the sample by perform
    #. Enter the command: :command:`AT%CMNG=1`
 
       This command displays a list of all certificates that are stored on your device.
-      If the device has been added to nRF Connect for Cloud, a CA certificate, a client certificate, and a private key with security tag 16842753 (which is the security tag for nRF Connect for Cloud credentials) are displayed.
+      If the device has been added to nRF Cloud, a CA certificate, a client certificate, and a private key with security tag 16842753 (which is the security tag for nRF Cloud credentials) are displayed.
 
 
 Sample output

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -132,13 +132,13 @@ Before you build the sample, check and update the following configuration option
 
 .. option:: CONFIG_CERT_SEC_TAG - Security tag for TLS credentials
 
-   By default, the sample uses the certificates that are stored with the security tag for nRF Connect for Cloud.
+   By default, the sample uses the certificates that are stored with the security tag for nRF Cloud.
    To use different certificates, configure a different security tag.
    If you used LTE Link Monitor to store the certificates, make sure to configure the security tag to the same that you used to store them.
 
 .. option:: CONFIG_MQTT_BROKER_HOSTNAME - AWT IoT MQTT broker hostname
 
-   By default, the sample uses nRF Connect for Cloud's MQTT broker.
+   By default, the sample uses nRF Cloud's MQTT broker.
    Change this value to AWS IoT's MQTT broker.
    To find the address of the AWS IoT MQTT broker, open the AWS IoT console, go to :guilabel:`Test` and select :guilabel:`View endpoint` from the :guilabel:`Connected as XXX` drop-down menu.
 

--- a/samples/nrf9160/cloud_client/README.rst
+++ b/samples/nrf9160/cloud_client/README.rst
@@ -29,7 +29,7 @@ The identification strings for the different cloud backends are listed in the fo
 
    * - Cloud Backend
      - Configuration String
-   * - nRF Connect for Cloud
+   * - nRF Cloud
      - "NRF_CLOUD"
    * - AWS IoT
      - "AWS_IOT"
@@ -52,8 +52,8 @@ For configuring the different cloud backends, refer to the documentation on :ref
 Each cloud backend has specific setup steps that must be executed before it can be used.
 
 .. note::
-   The nRF9160 DK and Thingy:91 come preprogrammed with the certificates required for a connection to `nRF Connect for Cloud`_.
-   No extra steps are required to use the Cloud client sample with nRF Connect for Cloud.
+   The nRF9160 DK and Thingy:91 come preprogrammed with the certificates required for a connection to `nRF Cloud`_.
+   No extra steps are required to use the Cloud client sample with nRF Cloud.
 
 
 Configurations
@@ -68,7 +68,7 @@ The configurations used in the sample are listed below. They can be added to ``c
    :only-visible:
 
 .. note::
-   To output data in the terminal window located in the `nRF Connect for Cloud`_ web interface, the data format must be in JSON format.
+   To output data in the terminal window located in the `nRF Cloud`_ web interface, the data format must be in JSON format.
 
 .. note::
    The sample sets the option :kconfig:`CONFIG_MQTT_KEEPALIVE` to the maximum allowed value that is specified by the configured cloud backend.
@@ -131,10 +131,10 @@ Building and running
 Testing
 =======
 
-Before testing, ensure that your device is already set up with your nRF Connect for Cloud account.
+Before testing, ensure that your device is already set up with your nRF Cloud account.
 After programming the sample to your device, test it by performing the following steps:
 
-1. Open a web browser and navigate to the correct device in `nRF Connect for Cloud`_.
+1. Open a web browser and navigate to the correct device in `nRF Cloud`_.
 #. Connect the USB cable and power on or reset your device.
 #. Open a terminal emulator and observe that the sample has started.
    Wait until the "I: CLOUD_EVT_READY" status appears in the terminal.
@@ -155,7 +155,7 @@ After programming the sample to your device, test it by performing the following
       I: CLOUD_EVT_PAIR_DONE
       I: CLOUD_EVT_READY
 
-    The device is now connected to nRF Connect for Cloud.
+    The device is now connected to nRF Cloud.
 
 #. Press button 1 on the device and observe that the following output is displayed in the terminal:
 
@@ -164,7 +164,7 @@ After programming the sample to your device, test it by performing the following
       I: Publishing message: {"state":{"reported":{"message":"Hello Internet of Things!"}}}
       +CSCON: 1
 
-#. Observe that the following status appears in the terminal pane for the connected device in nRF Connect for Cloud:
+#. Observe that the following status appears in the terminal pane for the connected device in nRF Cloud:
 
    .. code-block:: console
 

--- a/samples/nrf9160/http_update/application_update/README.rst
+++ b/samples/nrf9160/http_update/application_update/README.rst
@@ -82,7 +82,7 @@ After programming the sample to your development kit, test it by performing the 
    To do so, either change ``CONFIG_APPLICATION_VERSION`` to 2 in the :file:`prj.conf` file, or select :guilabel:`Project` > :guilabel:`Configure nRF Connect SDK Project` > :guilabel:`HTTP application update sample` in |SES| and change the value for :guilabel:`Application version`.
    Then rebuild the application.
 #. Upload the file :file:`update.bin` to the server you have chosen.
-   To upload the file on nRF Connect for Cloud, click :guilabel:`Upload` for the firmware URL that you generated earlier.
+   To upload the file on nRF Cloud, click :guilabel:`Upload` for the firmware URL that you generated earlier.
    Then select the file :file:`update.bin` and upload it.
 #. Reset your nRF9160 DK to start the application.
 #. Open a terminal emulator and observe that an output similar to this is printed:

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -7,10 +7,10 @@ nRF9160: LTE Sensor Gateway
    :local:
    :depth: 2
 
-The LTE Sensor Gateway sample demonstrates how to transmit sensor data from an nRF9160 development kit to the `nRF Connect for Cloud`_.
+The LTE Sensor Gateway sample demonstrates how to transmit sensor data from an nRF9160 development kit to the `nRF Cloud`_.
 
 The sensor data is collected via Bluetooth® Low Energy, unlike the :ref:`asset_tracker` sample.
-Therefore, this sample acts as a gateway between the Bluetooth LE and the LTE connections to nRF Connect for Cloud.
+Therefore, this sample acts as a gateway between the Bluetooth LE and the LTE connections to nRF Cloud.
 
 Overview
 *********
@@ -22,7 +22,7 @@ When the connection is established, it starts collecting data from two sensors:
 * The simulated GPS position data
 
 The sample aggregates the data from both sensors in memory.
-You can then trigger an alarm that sends the aggregated data over LTE to `nRF Connect for Cloud`_ by flipping the Thingy:52, which causes a change in the flip state to ``UPSIDE_DOWN``.
+You can then trigger an alarm that sends the aggregated data over LTE to `nRF Cloud`_ by flipping the Thingy:52, which causes a change in the flip state to ``UPSIDE_DOWN``.
 
 Requirements
 ************
@@ -40,9 +40,9 @@ The sample also requires a `Nordic Thingy:52`_.
 User interface
 **************
 
-Two buttons and two switches are used to enter a pairing pattern to associate a specific development kit with an nRF Connect for Cloud user account.
+Two buttons and two switches are used to enter a pairing pattern to associate a specific development kit with an nRF Cloud user account.
 
-When the connection is established, set switch 2 to **N.C.** to send simulated GPS data to nRF Connect for Cloud once every 2 seconds.
+When the connection is established, set switch 2 to **N.C.** to send simulated GPS data to nRF Cloud once every 2 seconds.
 
 See the :ref:`asset_tracker_user_interface` in the :ref:`asset_tracker` documentation for detailed information about the different LED states used by the sample.
 
@@ -102,24 +102,24 @@ After programming the main controller with the sample, you can test it as follow
 
 #. Observe that the message ``Application started`` is shown in the terminal window after the LTE link is established, to ensure that the application started.
    This might take several minutes.
-#. Observe that LED 3 starts blinking as the connection to nRF Connect for Cloud is established.
+#. Observe that LED 3 starts blinking as the connection to nRF Cloud is established.
 #. The first time you start the sample, pair the device to your account:
 
    a. Observe that both LED 3 and 4 start blinking, indicating that the pairing procedure has been initiated.
-   #. Follow the instructions on `nRF Connect for Cloud`_ and enter the displayed pattern.
+   #. Follow the instructions on `nRF Cloud`_ and enter the displayed pattern.
       In the terminal window, you can see the pattern that you have entered.
-   #. If the pattern is entered correctly, the kit and your nRF Connect for Cloud account are paired and the device reboots.
+   #. If the pattern is entered correctly, the kit and your nRF Cloud account are paired and the device reboots.
       If the LEDs start blinking in pairs, check in the terminal window which error occurred.
       The device must be power-cycled to restart the pairing procedure.
-   #. After reboot, the kit connects to nRF Connect for Cloud, and the pattern disappears from the web page.
+   #. After reboot, the kit connects to nRF Cloud, and the pattern disappears from the web page.
 #. Observe that LED 4 is turned on to indicate that the connection is established.
-#. Observe that the device count on your nRF Connect for Cloud dashboard is incremented by one.
-#. Set switch 2 in the position marked as **N.C.** and observe that simulated GPS data is sent to nRF Connect for Cloud.
+#. Observe that the device count on your nRF Cloud dashboard is incremented by one.
+#. Set switch 2 in the position marked as **N.C.** and observe that simulated GPS data is sent to nRF Cloud.
 #. Make sure that the Thingy:52 has established a connection to the application.
    This is indicated by its led blinking green.
-#. Flip the Thingy:52, with the USB port pointing upward, to trigger the sending of the sensor data to nRF Connect for Cloud.
-#. Select the device from your device list on nRF Connect for Cloud, and observe that the sensor data is received from the kit.
-#. Observe that the data is updated in nRF Connect for Cloud.
+#. Flip the Thingy:52, with the USB port pointing upward, to trigger the sending of the sensor data to nRF Cloud.
+#. Select the device from your device list on nRF Cloud, and observe that the sensor data is received from the kit.
+#. Observe that the data is updated in nRF Cloud.
 
 
 Dependencies


### PR DESCRIPTION
This commit changes nRF Connect for Cloud to nRF Cloud in all NCS docs but release notes.

Signed-off-by: Mel Weed <mel.weed@nordicsemi.no>