### PR TITLE
lib: bin: lwm2m_carrier: fix library event definitions

### DIFF
--- a/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst
@@ -42,7 +42,7 @@ Changes
   * Application is now expected to store CA certificates into the modem security tags.
   * Added a new event :c:macro:`LWM2M_CARRIER_EVENT_CERTS_INIT` that instructs the application to provide the CA certificate security tags to the LwM2M carrier library.
 * Renamed the event :c:macro:`LWM2M_CARRIER_BSDLIB_INIT` to :c:macro:`LWM2M_CARRIER_EVENT_MODEM_INIT`.
-* Added a new error code :c:macro:`LWM2M_CARRIER_ERROR_SERVICE_UNAVAILABLE` which indicates that the LwM2M server is unavailable due to maintenance.
+* Added a new deferred event reason :c:macro:`LWM2M_CARRIER_DEFERRED_SERVICE_UNAVAILABLE`, which indicates that the LwM2M server is unavailable due to maintenance.
 * Added a new error code :c:macro:`LWM2M_CARRIER_ERROR_CONFIGURATION` which indicates that an illegal object configuration was detected.
 * Added new Kconfig options :c:kconfig:`CONFIG_LWM2M_CARRIER_USE_CUSTOM_APN` and :c:kconfig:`CONFIG_LWM2M_CARRIER_CUSTOM_APN` to set the ``apn`` member of :c:type:`lwm2m_carrier_config_t`.
 * It is now possible to configure a custom bootstrap URI using :c:kconfig:`CONFIG_LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI` regardless of operator SIM.

--- a/doc/nrf/libraries/bin/lwm2m_carrier/app_integration.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/app_integration.rst
@@ -142,6 +142,8 @@ Following are the various LwM2M carrier library events:
 
     * :c:macro:`LWM2M_CARRIER_DEFERRED_SERVER_REGISTRATION` - The server registration has not completed, and the server does not recognize the connecting device. If this event persists, contact the carrier.
 
+    * :c:macro:`LWM2M_CARRIER_DEFERRED_SERVICE_UNAVAILABLE` - The server is unavailable due to maintenance.
+
 * :c:macro:`LWM2M_CARRIER_EVENT_FOTA_START`:
 
   * This event indicates that the modem update has started.
@@ -174,8 +176,6 @@ Following are the various LwM2M carrier library events:
     * :c:macro:`LWM2M_CARRIER_ERROR_FOTA_CONN_LOST` - This error indicates a loss of connection, or an unexpected closure of connection by the server.
 
     * :c:macro:`LWM2M_CARRIER_ERROR_FOTA_FAIL` - This error indicates a failure in applying a valid update. If this error persists, create a ticket in `DevZone`_ with the modem trace.
-
-    * :c:macro:`LWM2M_CARRIER_ERROR_SERVICE_UNAVAILABLE` - This error indicates that the LWM2M Server in maintenance mode.
 
     * :c:macro:`LWM2M_CARRIER_ERROR_CONFIGURATION` - This error indicates that an illegal object configuration was detected.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -78,6 +78,15 @@ nRF9160
 
     * The library has been deprecated in favor of the :ref:`at_monitor_readme` library.
 
+  * :ref:`liblwm2m_carrier_readme` library:
+
+    * Added deferred event reason :c:macro:`LWM2M_CARRIER_DEFERRED_SERVICE_UNAVAILABLE`, which indicates that the LwM2M server is unavailable due to maintenance.
+    * Removed error code :c:macro:`LWM2M_CARRIER_ERROR_SERVICE_UNAVAILABLE`, which was used incorrectly to indicate a deferred event reason.
+
+  * :ref:`lwm2m_carrier` sample:
+
+    * Adjusted the messages printed in :c:func:`lwm2m_carrier_event_handler` to reflect the updated event definitions in the :ref:`liblwm2m_carrier_readme` library.
+
   * Board names:
 
     * The ``nrf9160dk_nrf9160ns`` and the ``nrf5340dk_nrf5340_cpuappns`` boards have been renamed respectively to ``nrf9160dk_nrf9160_ns`` and ``nrf5340dk_nrf5340_cpuapp_ns``, in a change inherited from upstream Zephyr.

--- a/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
@@ -83,6 +83,8 @@ typedef struct {
 #define LWM2M_CARRIER_DEFERRED_SERVER_CONNECT	   6
 /** Server registration sequence not completed. */
 #define LWM2M_CARRIER_DEFERRED_SERVER_REGISTRATION 7
+/** Server in maintenance mode. */
+#define LWM2M_CARRIER_DEFERRED_SERVICE_UNAVAILABLE 9
 /** @} */
 
 /*
@@ -117,8 +119,6 @@ typedef struct {
 #define LWM2M_CARRIER_ERROR_FOTA_CONN_LOST	7
 /**< Update failed. */
 #define LWM2M_CARRIER_ERROR_FOTA_FAIL		8
-/**< LWM2M server in maintenance mode. */
-#define LWM2M_CARRIER_ERROR_SERVICE_UNAVAILABLE 9
 /**< Illegal object configuration detected. */
 #define LWM2M_CARRIER_ERROR_CONFIGURATION      10
 /** @} */

--- a/samples/nrf9160/lwm2m_carrier/src/main.c
+++ b/samples/nrf9160/lwm2m_carrier/src/main.c
@@ -41,8 +41,8 @@ void print_err(const lwm2m_carrier_event_t *evt)
 			"Connection to remote server lost",
 		[LWM2M_CARRIER_ERROR_FOTA_FAIL] =
 			"Modem firmware update failed",
-		[LWM2M_CARRIER_ERROR_SERVICE_UNAVAILABLE] =
-			"LWM2M server in maintenance mode",
+		[LWM2M_CARRIER_ERROR_CONFIGURATION] =
+			"Illegal object configuration detected",
 	};
 
 	__ASSERT(PART_OF_ARRAY(strerr[err->code]),
@@ -73,6 +73,8 @@ void print_deferred(const lwm2m_carrier_event_t *evt)
 			"Failed to connect to server",
 		[LWM2M_CARRIER_DEFERRED_SERVER_REGISTRATION] =
 			"Server registration sequence not completed",
+		[LWM2M_CARRIER_DEFERRED_SERVICE_UNAVAILABLE] =
+			"Server in maintenance mode",
 	};
 
 	__ASSERT(PART_OF_ARRAY(strdef[def->reason]),


### PR DESCRIPTION
Added LWM2M_CARRIER_DEFERRED_SERVICE_UNAVAILABLE definition to the list
of library event deferred reasons, as the library event error code
LWM2M_CARRIER_ERROR_SERVICE_UNAVAILABLE was instead used incorrectly
to indicate the deferred event due to the server being in maintenance
mode. Added missing error message in the sample for
LWM2M_CARRIER_ERROR_CONFIGURATION to avoid an out-of-bound access.

Signed-off-by: Kacper Radoszewski <kacper.radoszewski@nordicsemi.no>