### PR TITLE
manifest: Point to the nrfxlib with v.0.9.11 cc3xx

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 6a8dc21a9019af2d6495c8a7006b6816f5830b35
+      revision: f7522e51e6a1024955ad35949b8a18188464e655
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
-This points to the nrfxlib which includes the new
 version (v.0.9.11) of the cc3xx runtime library

Nrfxlib PR: [pull/542](https://github.com/nrfconnect/sdk-nrfxlib/pull/542)

Ref:NCSDK-9752

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>