### PR TITLE
doc: nrf: changelog: Add info about nRF21540 support in BLE.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -94,6 +94,10 @@ nRF Desktop
 Bluetooth LE
 ------------
 
+* Added:
+
+  * Production support for :ref:`nRF21540 GPIO <ug_radio_fem_nrf21540_gpio>` for both nRF52 and nRF53 Series.
+
 * Updated:
 
   * :ref:`ble_samples` - Changed the Bluetooth® sample Central DFU SMP name to :ref:`Central SMP Client <bluetooth_central_dfu_smp>`.


### PR DESCRIPTION
Signed-off-by: Sondre Ravn <sondre.ravn@nordicsemi.no>