### PR TITLE
Bluetooth: Mesh: Fixed setting of last light level

### DIFF
--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -163,6 +163,8 @@ struct bt_mesh_lightness_srv {
 	uint16_t default_light;
 	/** The last known Light Level. */
 	uint16_t last;
+	/** The delta start Light Level */
+	uint16_t delta_start;
 	/** Internal flag state. */
 	atomic_t flags;
 


### PR DESCRIPTION
Fixes an issue where when setting the delta set level in the lightness server
makes the last light level be the previous lightness level, and not the
last one set. This can make the last level end up as zero that is a
pohibeted value.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>