### PR TITLE
bluetooth: dtm: Allows building with FEM for all phy

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/dtm.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm.c
@@ -1119,7 +1119,7 @@ static uint32_t dtm_packet_interval_calculate(uint32_t test_payload_length,
 		 * 24 CRC
 		 */
 		overhead_bits = 80; /* 10 bytes */
-#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 	} else if (mode == NRF_RADIO_MODE_BLE_LR125KBIT) {
 		/* 80     preamble
 		 * 32 * 8 sync word coding=8
@@ -1144,23 +1144,22 @@ static uint32_t dtm_packet_interval_calculate(uint32_t test_payload_length,
 		 *       assumption the radio will handle this
 		 */
 		overhead_bits = 462; /* 57.75 bytes */
-#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 	}
 
 	/* Add PDU payload test_payload length */
 	test_packet_length = (test_payload_length * 8); /* in bits */
 
 	/* Account for the encoding of PDU */
-#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 	if (mode == NRF_RADIO_MODE_BLE_LR125KBIT) {
 		test_packet_length *= 8; /* 1 to 8 encoding */
 	}
-#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
-#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
+
 	if (mode == NRF_RADIO_MODE_BLE_LR500KBIT) {
 		test_packet_length *= 2; /* 1 to 2 encoding */
 	}
-#endif /* defined(RADIO_MODE_MODE_Ble_LR500Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
 	/* Add overhead calculated above */
 	test_packet_length += overhead_bits;
@@ -1234,7 +1233,7 @@ static enum dtm_err_code phy_set(uint8_t phy)
 		return radio_init();
 	} else if ((phy >= LE_PHY_LE_CODED_S8_MIN_RANGE) &&
 		   (phy <= LE_PHY_LE_CODED_S8_MAX_RANGE)) {
-#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 		dtm_inst.radio_mode =
 			NRF_RADIO_MODE_BLE_LR125KBIT;
 		dtm_inst.packet_hdr_plen =
@@ -1255,10 +1254,10 @@ static enum dtm_err_code phy_set(uint8_t phy)
 #else
 		dtm_inst.event = LE_TEST_STATUS_EVENT_ERROR;
 		return DTM_ERROR_ILLEGAL_CONFIGURATION;
-#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 	} else if ((phy >= LE_PHY_LE_CODED_S2_MIN_RANGE) &&
 		   (phy <= LE_PHY_LE_CODED_S2_MAX_RANGE)) {
-#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 		dtm_inst.radio_mode =
 			NRF_RADIO_MODE_BLE_LR500KBIT;
 		dtm_inst.packet_hdr_plen =
@@ -1281,7 +1280,7 @@ static enum dtm_err_code phy_set(uint8_t phy)
 #else
 		dtm_inst.event = LE_TEST_STATUS_EVENT_ERROR;
 		return DTM_ERROR_ILLEGAL_CONFIGURATION;
-#endif /* defined(RADIO_MODE_MODE_Ble_LR500Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 	}
 
 	dtm_inst.event = LE_TEST_STATUS_EVENT_ERROR;

--- a/samples/bluetooth/direct_test_mode/src/dtm_hw.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm_hw.c
@@ -101,12 +101,10 @@ bool dtm_hw_radio_validate(nrf_radio_txpower_t tx_power,
 	 */
 
 	if (!(
-#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 		radio_mode == NRF_RADIO_MODE_BLE_LR125KBIT  ||
-#endif
-#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
 		radio_mode == NRF_RADIO_MODE_BLE_LR500KBIT  ||
-#endif
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 		radio_mode == NRF_RADIO_MODE_BLE_1MBIT      ||
 		radio_mode == NRF_RADIO_MODE_BLE_2MBIT
 		)
@@ -125,16 +123,15 @@ bool dtm_hw_radio_validate(nrf_radio_txpower_t tx_power,
 
 bool dtm_hw_radio_lr_check(nrf_radio_mode_t radio_mode)
 {
-#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 	if (radio_mode == NRF_RADIO_MODE_BLE_LR125KBIT) {
 		return true;
 	}
-#endif
-#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
+
 	if (radio_mode == NRF_RADIO_MODE_BLE_LR500KBIT) {
 		return true;
 	}
-#endif
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
 	return false;
 }

--- a/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
@@ -186,7 +186,7 @@ static uint32_t radio_tx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode)
 		ramp_up = fast ? RADIO_RAMP_UP_TX_2M_FAST_US :
 				 RADIO_RAMP_UP_TX_2M_US;
 		break;
-
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 	case NRF_RADIO_MODE_BLE_LR125KBIT:
 		ramp_up = fast ? RADIO_RAMP_UP_TX_S8_FAST_US :
 				 RADIO_RAMP_UP_TX_S8_US;
@@ -196,11 +196,14 @@ static uint32_t radio_tx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode)
 		ramp_up = fast ? RADIO_RAMP_UP_TX_S2_FAST_US :
 				 RADIO_RAMP_UP_TX_S2_US;
 		break;
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	case NRF_RADIO_MODE_IEEE802154_250KBIT:
 		ramp_up = fast ? RADIO_RAMP_UP_IEEE_FAST_US :
 				 RADIO_RAMP_UP_IEEE_US;
 		break;
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	default:
 		ramp_up = fast ? RADIO_RAMP_UP_DEFAULT_FAST_US :
@@ -226,6 +229,7 @@ static uint32_t radio_rx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode)
 				 RADIO_RAMP_UP_RX_2M_US;
 		break;
 
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 	case NRF_RADIO_MODE_BLE_LR125KBIT:
 		ramp_up = fast ? RADIO_RAMP_UP_RX_S8_FAST_US :
 				 RADIO_RAMP_UP_RX_S8_US;
@@ -235,11 +239,14 @@ static uint32_t radio_rx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode)
 		ramp_up = fast ? RADIO_RAMP_UP_RX_S2_FAST_US :
 				 RADIO_RAMP_UP_RX_S2_US;
 		break;
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	case NRF_RADIO_MODE_IEEE802154_250KBIT:
 		ramp_up = fast ? RADIO_RAMP_UP_IEEE_FAST_US :
 				 RADIO_RAMP_UP_IEEE_US;
 		break;
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	default:
 		ramp_up = fast ? RADIO_RAMP_UP_DEFAULT_FAST_US :
@@ -264,9 +271,12 @@ static uint32_t gpio_port_num_decode(NRF_GPIO_Type *reg)
 {
 	if (reg == NRF_P0) {
 		return 0;
-	} else if (reg == NRF_P1) {
+	}
+#if CONFIG_HAS_HW_NRF_GPIO1
+	else if (reg == NRF_P1) {
 		return 1;
 	}
+#endif /* CONFIG_HAS_HW_NRF_GPIO1 */
 
 	__ASSERT(false, "Unknown GPIO port");
 	return 0;

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -75,7 +75,7 @@ static struct radio_test_config test_config;
 /* If true, RX sweep, TX sweep or duty cycle test is performed. */
 static bool test_in_progress;
 
-#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 static void ieee_channel_check(const struct shell *shell, uint8_t channel)
 {
 	if (config.mode == NRF_RADIO_MODE_IEEE802154_250KBIT) {
@@ -93,7 +93,7 @@ static void ieee_channel_check(const struct shell *shell, uint8_t channel)
 
 	}
 }
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 static int cmd_start_channel_set(const struct shell *shell, size_t argc,
 				 char **argv)
@@ -213,9 +213,9 @@ static int cmd_tx_carrier_start(const struct shell *shell, size_t argc,
 		test_in_progress = false;
 	}
 
-#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	ieee_channel_check(shell, config.channel_start);
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	memset(&test_config, 0, sizeof(test_config));
 	test_config.type = UNMODULATED_TX;
@@ -246,9 +246,9 @@ static int cmd_tx_modulated_carrier_start(const struct shell *shell,
 		test_in_progress = false;
 	}
 
-#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	ieee_channel_check(shell, config.channel_start);
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	if (argc > 2) {
 		shell_error(shell, "%s: bad parameters count.", argv[0]);
@@ -301,9 +301,9 @@ static int cmd_duty_cycle_set(const struct shell *shell, size_t argc,
 
 	config.duty_cycle = duty_cycle;
 
-#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	ieee_channel_check(shell, config.channel_start);
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	memset(&test_config, 0, sizeof(test_config));
 	test_config.type = MODULATED_TX_DUTY_CYCLE;
@@ -446,29 +446,27 @@ static int cmd_print(const struct shell *shell, size_t argc, char **argv)
 			    STRINGIFY(NRF_RADIO_MODE_BLE_2MBIT));
 		break;
 
-#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 	case NRF_RADIO_MODE_BLE_LR125KBIT:
 		shell_print(shell,
 			    "Data rate: %s",
 			    STRINGIFY(NRF_RADIO_MODE_BLE_LR125KBIT));
 		break;
-#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
 
-#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
 	case NRF_RADIO_MODE_BLE_LR500KBIT:
 		shell_print(shell,
 			    "Data rate: %s",
 			    STRINGIFY(NRF_RADIO_MODE_BLE_LR500KBIT));
 		break;
-#endif /* defined(RADIO_MODE_MODE_Ble_LR500Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
-#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	case NRF_RADIO_MODE_IEEE802154_250KBIT:
 		shell_print(shell,
 			    "Data rate: %s",
 			    STRINGIFY(NRF_RADIO_MODE_IEEE802154_250KBIT));
 		break;
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	default:
 		shell_print(shell,
@@ -722,9 +720,9 @@ static int cmd_rx_start(const struct shell *shell, size_t argc, char **argv)
 		test_in_progress = false;
 	}
 
-#if defined(NRF_RADIO_MODE_IEEE802154_250KBIT)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	ieee_channel_check(shell, config.channel_start);
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	memset(&test_config, 0, sizeof(test_config));
 	test_config.type = RX;
@@ -963,7 +961,7 @@ static int cmd_ble_2mbit(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 static int cmd_ble_lr125kbit(const struct shell *shell, size_t argc,
 			     char **argv)
 {
@@ -973,9 +971,7 @@ static int cmd_ble_lr125kbit(const struct shell *shell, size_t argc,
 
 	return 0;
 }
-#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
 
-#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
 static int cmd_ble_lr500kbit(const struct shell *shell, size_t argc,
 			     char **argv)
 {
@@ -985,9 +981,9 @@ static int cmd_ble_lr500kbit(const struct shell *shell, size_t argc,
 
 	return 0;
 }
-#endif /* defined(RADIO_MODE_MODE_Ble_LR500Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
-#if defined(RADIO_MODE_MODE_Ieee802154_250Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 static int cmd_ble_ieee(const struct shell *shell, size_t argc, char **argv)
 {
 	config.mode = NRF_RADIO_MODE_IEEE802154_250KBIT;
@@ -996,7 +992,7 @@ static int cmd_ble_ieee(const struct shell *shell, size_t argc, char **argv)
 
 	return 0;
 }
-#endif /* RADIO_MODE_MODE_Ieee802154_250Kbit */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 static int cmd_pattern_random(const struct shell *shell, size_t argc,
 			      char **argv)
@@ -1048,22 +1044,20 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_data_rate,
 	SHELL_CMD(ble_2Mbit, NULL, "2 Mbit/s Bluetooth Low Energy",
 		  cmd_ble_2mbit),
 
-#if defined(RADIO_MODE_MODE_Ble_LR125Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 	SHELL_CMD(ble_lr125Kbit, NULL,
 		  "Long range 125 kbit/s TX, 125 kbit/s and 500 kbit/s RX",
 		  cmd_ble_lr125kbit),
-#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
 
-#if defined(RADIO_MODE_MODE_Ble_LR500Kbit)
 	SHELL_CMD(ble_lr500Kbit, NULL,
 		  "Long range 500 kbit/s TX, 125 kbit/s and 500 kbit/s RX",
 		  cmd_ble_lr500kbit),
-#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
-#if defined(RADIO_MODE_MODE_Ieee802154_250Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	SHELL_CMD(ieee802154_250Kbit, NULL, "IEEE 802.15.4-2006 250 kbit/s",
 		  cmd_ble_ieee),
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit)*/
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	SHELL_SUBCMD_SET_END
 );

--- a/samples/peripheral/radio_test/src/radio_test.c
+++ b/samples/peripheral/radio_test/src/radio_test.c
@@ -108,7 +108,7 @@ static uint8_t rnd8(void)
 
 static void radio_channel_set(nrf_radio_mode_t mode, uint8_t channel)
 {
-#if defined(RADIO_MODE_MODE_Ieee802154_250Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	if (mode == NRF_RADIO_MODE_IEEE802154_250KBIT) {
 		if ((channel >= IEEE_MIN_CHANNEL) &&
 			(channel <= IEEE_MAX_CHANNEL)) {
@@ -125,7 +125,7 @@ static void radio_channel_set(nrf_radio_mode_t mode, uint8_t channel)
 	}
 #else
 	nrf_radio_frequency_set(NRF_RADIO, CHAN_TO_FREQ(channel));
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 }
 
 static void radio_config(nrf_radio_mode_t mode, enum transmit_pattern pattern)
@@ -181,7 +181,7 @@ static void radio_config(nrf_radio_mode_t mode, enum transmit_pattern pattern)
 	packet_conf.whiteen = true;
 
 	switch (mode) {
-#if defined(RADIO_MODE_MODE_Ieee802154_250Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	case NRF_RADIO_MODE_IEEE802154_250KBIT:
 		/* Packet configuration:
 		 * S1 size = 0 bits,
@@ -198,11 +198,9 @@ static void radio_config(nrf_radio_mode_t mode, enum transmit_pattern pattern)
 		nrf_radio_modecnf0_set(NRF_RADIO, true,
 				       RADIO_MODECNF0_DTX_Center);
 		break;
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
-#if defined(RADIO_MODE_MODE_Ble_LR125Kbit) || \
-	defined(RADIO_MODE_MODE_Ble_LR500Kbit)
-
+#if CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 	case NRF_RADIO_MODE_BLE_LR500KBIT:
 	case NRF_RADIO_MODE_BLE_LR125KBIT:
 		/* Packet configuration:
@@ -228,9 +226,7 @@ static void radio_config(nrf_radio_mode_t mode, enum transmit_pattern pattern)
 					NRF_RADIO_CRC_ADDR_SKIP, 0);
 		break;
 
-#endif /* defined(RADIO_MODE_MODE_Ble_LR125Kbit) ||
-	* defined(RADIO_MODE_MODE_Ble_LR500Kbit)
-	*/
+#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
 	case NRF_RADIO_MODE_BLE_2MBIT:
 		/* Packet configuration:
@@ -260,7 +256,7 @@ static void generate_modulated_rf_packet(uint8_t mode,
 	radio_config(mode, pattern);
 
 	/* One byte used for size, actual size is SIZE-1 */
-#if defined(RADIO_MODE_MODE_Ieee802154_250Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	if (mode == NRF_RADIO_MODE_IEEE802154_250KBIT) {
 		tx_packet[0] = IEEE_MAX_PAYLOAD_LEN - 1;
 	} else {
@@ -268,7 +264,7 @@ static void generate_modulated_rf_packet(uint8_t mode,
 	}
 #else
 	tx_packet[0] = sizeof(tx_packet) - 1;
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	/* Fill payload with random data. */
 	for (uint8_t i = 0; i < sizeof(tx_packet) - 1; i++) {
@@ -332,10 +328,7 @@ static void radio_modulated_tx_carrier(uint8_t mode, uint8_t txpower, uint8_t ch
 	generate_modulated_rf_packet(mode, pattern);
 
 	switch (mode) {
-#if defined(RADIO_MODE_MODE_Ieee802154_250Kbit) || \
-	defined(RADIO_MODE_MODE_Ble_LR500Kbit) || \
-	defined(RADIO_MODE_MODE_Ble_LR125Kbit)
-
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154 || CONFIG_HAS_HW_NRF_RADIO_BLE_CODED
 	case NRF_RADIO_MODE_IEEE802154_250KBIT:
 	case NRF_RADIO_MODE_BLE_LR125KBIT:
 	case NRF_RADIO_MODE_BLE_LR500KBIT:
@@ -344,10 +337,7 @@ static void radio_modulated_tx_carrier(uint8_t mode, uint8_t txpower, uint8_t ch
 					NRF_RADIO_SHORT_PHYEND_START_MASK);
 		break;
 
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit) ||
-	* defined(RADIO_MODE_MODE_Ble_LR500Kbit) ||
-	* defined(RADIO_MODE_MODE_Ble_LR125Kbit)
-	*/
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 || CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
 	case NRF_RADIO_MODE_BLE_1MBIT:
 	case NRF_RADIO_MODE_BLE_2MBIT:
@@ -553,7 +543,7 @@ void radio_rx_stats_get(struct radio_rx_stats *rx_stats)
 {
 	size_t size;
 
-#if defined(RADIO_MODE_MODE_Ieee802154_250Kbit)
+#if CONFIG_HAS_HW_NRF_RADIO_IEEE802154
 	nrf_radio_mode_t radio_mode;
 
 	radio_mode = nrf_radio_mode_get(NRF_RADIO);
@@ -564,7 +554,7 @@ void radio_rx_stats_get(struct radio_rx_stats *rx_stats)
 	}
 #else
 	size = sizeof(rx_packet);
-#endif /* defined(RADIO_MODE_MODE_Ieee802154_250Kbit) */
+#endif /* CONFIG_HAS_HW_NRF_RADIO_IEEE802154 */
 
 	rx_stats->last_packet.buf = rx_packet;
 	rx_stats->last_packet.len = size;


### PR DESCRIPTION
Allows bulding the Direct Test Mode sample with
nRF21540 EK for targets which do not support
coded PHY or don't have more than 1 GPIO port.