### PR TITLE
manifest: Update ble-controller/MPSL revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d048f584bb79997e1f60e3539b4520026ebb7745
+      revision: pull/543/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Includes updates:
- Fixed an issue where the mpsl_tx_power_channel_map_set() API would not work on peripheral-only or central-only configurations (DRGN-16091)

ble-controller revision: TBA
mpsl revision: 88fa7bb5cec8e2223c18c1d8ebeda20422b52440

Signed-off-by: Olivier Lesage <olivier.lesage@nordicsemi.no>