### PR TITLE
drivers: gps: deprecate the GPS driver

### DIFF
--- a/doc/nrf/drivers/gps.rst
+++ b/doc/nrf/drivers/gps.rst
@@ -10,7 +10,9 @@ The API offers functionality to initialize and configure a device, to start and 
    :local:
    :depth: 2
 
+.. note::
 
+   The GPS driver is deprecated since v1.7.0. Use the :ref:`nrfxlib:gnss_interface` instead.
 
 API documentation
 *****************

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -89,6 +89,10 @@ nRF9160
 
     * Adjusted the messages printed in :c:func:`lwm2m_carrier_event_handler` to reflect the updated event definitions in the :ref:`liblwm2m_carrier_readme` library.
 
+  * :ref:`gps_api` driver:
+
+    * The driver has been deprecated in favor of the :ref:`nrfxlib:gnss_interface`.
+
   * Board names:
 
     * The ``nrf9160dk_nrf9160ns`` and the ``nrf5340dk_nrf5340_cpuappns`` boards have been renamed respectively to ``nrf9160dk_nrf9160_ns`` and ``nrf5340dk_nrf5340_cpuapp_ns``, in a change inherited from upstream Zephyr.

--- a/drivers/gps/nrf9160_gps/Kconfig
+++ b/drivers/gps/nrf9160_gps/Kconfig
@@ -6,7 +6,7 @@
 #
 
 menuconfig NRF9160_GPS
-	bool "nRF9160 GPS driver [experimental]"
+	bool "nRF9160 GPS driver [deprecated]"
 	depends on NRF_MODEM_LIB
 	# FPU_SHARING needs to be enabled if FPU is enabled, as other contexts
 	# might also use the FPU.

--- a/include/drivers/gps.h
+++ b/include/drivers/gps.h
@@ -10,6 +10,8 @@
  * @file gps.h
  *
  * @brief Public APIs for the GPS interface.
+ *
+ * @deprecated since v1.7.0.
  */
 
 #include <zephyr.h>


### PR DESCRIPTION
Marked the GPS driver deprecated since nRF Connect SDK v1.7.0.
The GNSS API should be used instead.

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>