### PR TITLE
lib: at_host: Add missing at_notif_init

### DIFF
--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -292,6 +292,12 @@ static int at_host_init(const struct device *arg)
 		return -EINVAL;
 	}
 
+	err = at_notif_init();
+	if (err) {
+		LOG_ERR("Failed to initialize AT notifications, err %d", err);
+		return err;
+	}
+
 	err = at_notif_register_handler(NULL, response_handler);
 	if (err != 0) {
 		LOG_ERR("Can't register handler err=%d", err);


### PR DESCRIPTION
The library at_host calls at_notif_register_handler()
in at_host_init(), but that can only be called after
at_notif_init() has been. Because at_notif_init() is
idempotent, it's ok to add it here.

Also, at_host is initialized automatically by SYS_INIT,
so it's not possible to initialize at_notif earlier anywhere else.

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>