### PR TITLE
manifest: sdk-zephyr fixes for ieee802154

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 975e3710736e56770f5acd84b87cfd2c46dd0020
+      revision: pull/606/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The manifest update brings a fix for setting enhanced-ack
data.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>