### PR TITLE
doc: zigbee: update ncp host for release

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -141,7 +141,7 @@
 .. _`API documentation`:
 .. _`external ZBOSS development guide and API documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zigbee_devguide.html
 .. _`Stack commissioning start sequence`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/using_zigbee__z_c_l.html#stack_start_initiation
-.. _`ZBOSS NCP Host`: https://developer.nordicsemi.com/Zigbee/ncp_sdk_for_host/ncp_host_v0.9.5.zip
+.. _`ZBOSS NCP Host`: https://developer.nordicsemi.com/Zigbee/ncp_sdk_for_host/ncp_host_v1.0.0.zip
 .. _`NCP Host documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zboss_ncp_host_intro.html
 .. _`Rebuilding the ZBOSS libraries for host`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/zboss_ncp_host.html#rebuilding_libs
 .. _`process the frame`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.6.0.0/using_zigbee__z_c_l.html#process_zcl_cmd

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -162,6 +162,7 @@ Zigbee
 
 * Updated:
 
+  * :ref:`ug_zigbee_tools_ncp_host` to the production-ready v1.0.0.
   * Fixed the KRKNWK-9743 known issue where the timer could not be stopped in Zigbee routers and coordinators.
   * Fixed the KRKNWK-10490 known issue that would cause a deadlock in the NCP frame fragmentation logic.
   * Fixed the KRKNWK-6071 known issue with inaccurate ZBOSS alarms.

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -54,7 +54,7 @@
 
 .. |zigbee_version| replace:: Zigbee 3.0
 .. |zboss_version| replace:: 3.6.0.0
-.. |zigbee_ncp_package_version| replace:: 0.9.5
+.. |zigbee_ncp_package_version| replace:: 1.0.0
 .. |zigbee_description| replace:: Zigbee is a portable, low-power software networking protocol that provides connectivity over an 802.15.4-based mesh network.
 .. |enable_zigbee_before_testing| replace:: Make sure to configure the Zigbee stack before building and testing this sample.
    See :ref:`ug_zigbee_configuring` for more information.


### PR DESCRIPTION
Updated link and version tag for NCP Host.
KRKNWK-11189.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>