### PR TITLE
cmake: fw_zip: Fix dependencies in dfu zip generation

### DIFF
--- a/cmake/fw_zip.cmake
+++ b/cmake/fw_zip.cmake
@@ -13,8 +13,7 @@ function(generate_dfu_zip)
     GENZIP_BIN_FILES AND
     GENZIP_SCRIPT_PARAMS AND
     GENZIP_OUTPUT AND
-    GENZIP_TYPE AND
-    GENZIP_TARGET
+    GENZIP_TYPE
     ))
     message(FATAL_ERROR "Missing required param")
   endif()
@@ -30,7 +29,7 @@ function(generate_dfu_zip)
     "type=${GENZIP_TYPE}"
     "board=${CONFIG_BOARD}"
     "soc=${CONFIG_SOC}"
-    DEPENDS ${GENZIP_TARGET}
+    DEPENDS ${GENZIP_BIN_FILES}
     )
 
   get_filename_component(TARGET_NAME ${GENZIP_OUTPUT} NAME)

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -797,6 +797,13 @@ Build system
 
 .. rst-class:: v1-6-1 v1-6-0 v1-5-1 v1-5-0
 
+NCSDK-10672: :file:`dfu_application.zip` is not updated during build
+  In the configuration with MCUboot, the :file:`dfu_application.zip` might not be properly updated after code or configuration changes, because of missing dependencies.
+
+  **Workaround:** Clear the build if :file:`dfu_application.zip` is going to be released to make sure that it is up to date.
+
+.. rst-class:: v1-6-1 v1-6-0 v1-5-1 v1-5-0
+
 Missing files or permissions when building on Windows
   Because of the Windows path length limitations, the build can fail with errors related to permissions or missing files if some paths in the build are too long.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -168,7 +168,7 @@ Bluetooth LE
   * :ref:`lbs_readme` library - added write request data validation in the LED characteristic.
 
 Bluetooth mesh
----------------
+--------------
 
 * Added:
 
@@ -343,6 +343,13 @@ The mcumgr library contains all commits from the upstream mcumgr repository up t
 The following list summarizes the most important changes inherited from upstream mcumgr:
 
 * No changes yet
+
+Build system
+============
+
+* Bugfixes:
+
+  * Fixed a bug where :file:`dfu_application.zip` would not be updated after rebuilding the code with changes.
 
 Zephyr
 ======

--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -341,7 +341,6 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     endif()
 
     generate_dfu_zip(
-      TARGET mcuboot_sign_target
       OUTPUT ${PROJECT_BINARY_DIR}/dfu_application.zip
       BIN_FILES ${generate_bin_files}
       TYPE application
@@ -412,7 +411,6 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
         )
 
       generate_dfu_zip(
-        TARGET signed_s1_target
         OUTPUT ${PROJECT_BINARY_DIR}/dfu_mcuboot.zip
         BIN_FILES ${s0_bin_path} ${s1_bin_path}
         TYPE mcuboot

--- a/subsys/bootloader/cmake/sign.cmake
+++ b/subsys/bootloader/cmake/sign.cmake
@@ -227,7 +227,6 @@ if (CONFIG_BUILD_S1_VARIANT AND NOT CONFIG_BOOTLOADER_MCUBOOT)
   set(s1_bin_path ${PROJECT_BINARY_DIR}/${s1_name})
 
   generate_dfu_zip(
-    TARGET s1_image_signed_kernel_hex_target
     OUTPUT ${PROJECT_BINARY_DIR}/dfu_application.zip
     BIN_FILES ${s0_bin_path} ${s1_bin_path}
     TYPE application

--- a/subsys/bootloader/cmake/sign.cmake
+++ b/subsys/bootloader/cmake/sign.cmake
@@ -175,6 +175,7 @@ foreach (slot ${slots})
     ${SIGN_KEY_FILE_DEPENDS}
     ${signature_file}
     ${slot}_signature_file_target
+    ${SIGNATURE_PUBLIC_KEY_FILE}
     WORKING_DIRECTORY
     ${PROJECT_BINARY_DIR}
     COMMENT

--- a/subsys/bootloader/cmake/sign.cmake
+++ b/subsys/bootloader/cmake/sign.cmake
@@ -160,6 +160,7 @@ foreach (slot ${slots})
   add_custom_command(
     OUTPUT
     ${signed_hex}
+    ${signed_bin}
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${NRF_BOOTLOADER_SCRIPTS}/validation_data.py


### PR DESCRIPTION
Adds compilled binnary files, used to create zip file
as a dependency for zip files generation custom command.
This fixes the issue where the zip file is outdated.

Relates to: NCSDK-10672