### PR TITLE
CODEOWNERS: Add many reviewers for labeler.yml and manifest.yml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,8 @@
 
 # Github Actions
 /.github/                                 @thst-nordic
+/.github/labeler.yml                      @thst-nordic @guwa @mariusz-nordicsemi @tomaszkob89 @totyz @doublemis1 @wiminordic @jorgenmk @maciekrozanski @ns-tolu @miha-nordic @maciejpietras @piwe-nordic @nordic-babu @fredaas @torsteingrindvik @mswarowsky @shantha-14 @ardo-nordic
+/.github/workflows/manifest.yml           @thst-nordic @guwa @mariusz-nordicsemi @tomaszkob89 @totyz @doublemis1 @wiminordic @jorgenmk @maciekrozanski @ns-tolu @miha-nordic @maciejpietras @piwe-nordic @nordic-babu @fredaas @torsteingrindvik @mswarowsky @shantha-14 @ardo-nordic
 
 # Applications
 /applications/asset_tracker/              @jhn-nordic @jtguggedal @rlubos


### PR DESCRIPTION
This was requested by Test group because these files currently define each PRs test specification.
All the reviewers for this PR will be added as reviewers for PR's that touch labeler/manifest.yml. 

Notes:
 - Missing githubID for "Oksanen, Matti"
 - Couldn't add 'jpheikkinen' because not in nrfconnect Org