### PR TITLE
application: serial_lte_modem: Handle "\r\n" in HTTP headers

### DIFF
--- a/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
@@ -118,15 +118,16 @@ Syntax
 
 ::
 
-   AT#XHTTPCREQ=<method>,<resource>,<header>[,<payload_length>]
+   AT#XHTTPCREQ=<method>,<resource>,<headers>[,<payload_length>]
 
 * The ``<method>`` is a string.
   It represents the request method string.
 * The ``<resource>`` is a string.
   It represents the target resource to apply the request.
-* The ``<header>`` is a string.
+* The ``<headers>`` is a string.
   It represents the header field of the request.
   Each header field should end with ``<CR><LF>``.
+  Any occurrence of "\\r\\n" (4 bytes) inside is replaced by ``<CR><LF>`` (2 bytes).
 * The ``<payload_length>`` is an integer.
   It represents the length of the payload.
   If ``payload_length`` is greater than ``0``, the SLM will enter data mode and expect the upcoming UART input data as payload.
@@ -177,6 +178,14 @@ The following example sends a GET request to retrieve data from the server witho
    #XHTTPCRSP:1,0
    }
    #XHTTPCRSP:0,1
+
+The following example sends a GET request with some headers that are delimited by "\\r\\n".
+
+::
+
+   AT#XHTTPCREQ="GET","/instruments/150771004/temperature-values/?page=1 HTTP/1.1","Host: demo.abc.com\r\nAccept: application/vnd.api+json\r\nAuthorization: Basic ZGVtbzpkZxxx\r\n"
+
+   OK
 
 Read command
 ------------


### PR DESCRIPTION
Add a pre-process function to replace "\r\n" (4 bytes) with the
delimiter of `<CR><LF>` (2 bytes) as in HTTP spec. Also add to
check the delimiter in the end of HTTP headers.

Jira Ticket: NCSIDB-567

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>