### PR TITLE
manifest: update zephyr for get flash simulator upgrade

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 2716fad989a4de8f2f13bfa6626250572a081a80
+      revision: 66ef6a7e125d53b5d650effcce101ab901627100
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Upgraded sdk-zephyr zephyr version has flash simulator
patches which allows to:
- get RAM buffer address and to
- disable statistic usage

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>