### PR TITLE
west.yml: Bring back the sdk-mcumgr fork to manifest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -82,7 +82,6 @@ manifest:
           - lvgl
           - lz4
           - mbedtls
-          - mcumgr
           - mipi-sys-t
           - nanopb
           - net-tools
@@ -101,6 +100,10 @@ manifest:
       repo-path: sdk-mcuboot
       revision: 10254a9e8799f9500d5b9b2366f5ea5d28067255
       path: bootloader/mcuboot
+    - name: mcumgr
+      repo-path: sdk-mcumgr
+      revision: pull/15/head
+      path: modules/lib/mcumgr
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib


### PR DESCRIPTION
The mcumgr fork has been brought back to the manifest to support
commits that are not visible in upstream.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>