### PR TITLE
Bluetooth: Mesh: Light xyL Server composition data docs

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctl_srv.rst
@@ -25,7 +25,7 @@ The following two model instances are added:
 * Light CTL Server - Provides write access to Lightness, Temperature and Delta UV states for the user, in addition to read access to all meta states
 * Light CTL Setup Server - Provides write access to Default CTL state and Temperature Range meta states, allowing configurator devices to set up a temperature range and a default CTL state
 
-In addition to the extended Lightness Server model, the Light CTL Server also requires a :ref:`bt_mesh_light_temp_srv_readme` to be instantiated on a subsequent element.
+In addition to the extended Light Lightness Server model, the Light CTL Server also requires a :ref:`bt_mesh_light_temp_srv_readme` to be instantiated on a subsequent element.
 The Light Temperature Server should reference the :c:member:`bt_mesh_light_ctl_srv.temp_srv`.
 
 Conventionally, the Light Temperature Server model is instantiated on the very next element, and the composition data looks as presented below.
@@ -56,7 +56,7 @@ The Lightness and Light Temperature Server callbacks will pass pointers to :c:me
 States
 ======
 
-The Generic Power OnOff Server model (extended by the Lightness Server model) contains the following states:
+The Generic Power OnOff Server model (extended by the Light Lightness Server model) contains the following states:
 
 Lightness: ``uint16_t``
     The Lightness state represents the emitted light level of an element, and ranges from ``0`` to ``65535``.
@@ -126,10 +126,10 @@ The Light CTL Server extends the following model:
 
 * :ref:`bt_mesh_lightness_srv_readme`
 
-The state of the extended Lightness Server model is for the most part bound to states in the Light CTL Server.
+The state of the extended Light Lightness Server model is for the most part bound to states in the Light CTL Server.
 The only exception is the Lightness range state, which is exposed to the application through the :c:member:`bt_mesh_light_ctl_srv_handlers.lightness_range_update` callback of the Light CTL Server model.
 
-In addition to the extended Lightness Server model, the Light CTL Server model is associated with a Light Temperature model on a subsequent element.
+In addition to the extended Light Lightness Server model, the Light CTL Server model is associated with a Light Temperature model on a subsequent element.
 Unlike the extended models, the associated models do not share subscription lists, but still share states.
 
 Persistent storage

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_srv.rst
@@ -58,7 +58,7 @@ In the application, this composition data looks like this:
           BT_MESH_MODEL_NONE),
    };
 
-The Light LC Server will log an error during initialization if the controlled Lightness Server is on the same element.
+The Light LC Server will log an error during initialization if the controlled Light Lightness Server is on the same element.
 
 Relationship with other nodes
 =============================
@@ -68,8 +68,8 @@ When the Light LC Server model controls a Light Lightness Server, all nodes shou
 .. figure:: images/bt_mesh_light_ctrl_nodes.svg
    :alt: Light Lightness Control Server node organization
 
-The dimmer devices that want to override the light level of the Lightness Server can publish directly to the Lightness Server.
-This disengages the Light LC Server, and the Lightness Server operates independently until the Light LC Server is explicitly re-enabled.
+The dimmer devices that want to override the light level of the Light Lightness Server can publish directly to it.
+This disengages the Light LC Server, and the Light Lightness Server operates independently until the Light LC Server is explicitly re-enabled.
 
 .. _bt_mesh_light_ctrl_srv_composition_state_machine:
 
@@ -125,10 +125,10 @@ If the On event is triggered while in the On state, the timer is reset, and the 
 Resuming the state machine operation
 ------------------------------------
 
-Whenever something but the Light LC Server interacts with the controlled Lightness Server, the Light LC Server disables its state machine, and the Lightness Server starts running independently.
+Whenever something but the Light LC Server interacts with the controlled Light Lightness Server, the Light LC Server disables its state machine, and the Light Lightness Server starts running independently.
 To resume the state machine operation, the Light LC Server must be explicitly re-enabled.
 
-To avoid having a Lightness Server running independently forever, the Light LC Server implements a resume timer that lets the Light LC Server regain control after being disabled for a certain number of seconds.
+To avoid having a Light Lightness Server running independently forever, the Light LC Server implements a resume timer that lets the Light LC Server regain control after being disabled for a certain number of seconds.
 The resume timer can be configured with the :kconfig:`CONFIG_BT_MESH_LIGHT_CTRL_SRV_RESUME_DELAY` option, and is disabled by default.
 
 .. note::
@@ -298,7 +298,7 @@ Illuminance regulator
 =====================
 
 The illuminance regulator complements the light level state machine by adding an ambient illuminance sensor feedback loop.
-This allows the Lightness Server to adjust its output level that is based on the room's ambient light, and as a result conserve energy and achieve more consistent light levels.
+This allows the Light Lightness Server to adjust its output level that is based on the room's ambient light, and as a result conserve energy and achieve more consistent light levels.
 
 .. figure:: images/bt_mesh_light_ctrl_reg.svg
    :alt: Light Lightness Control Server illuminance regulator
@@ -335,7 +335,7 @@ This sensor data must come from an external :ref:`bt_mesh_sensor_srv_readme` mod
 The Sensor Server should publish its sensor readings to an address the Light LC Server is subscribed to, using a common application key.
 
 The Light LC Server will process all incoming sensor messages and use them in the next regulator step.
-The regulator depends on frequent readings from the sensor server to provide a stable output for the Lightness Server.
+The regulator depends on frequent readings from the sensor server to provide a stable output for the Light Lightness Server.
 If the sensor reports are too slow, the regulator might oscillate, as it attempts to compensate for outdated feedback.
 
 .. tip::
@@ -400,7 +400,7 @@ Not to be confused with the :ref:`state machine states <bt_mesh_light_ctrl_srv_c
 
 Mode: ``bool``
     Enables or disables the Light LC Server.
-    When disabled, the controlled Lightness Server operates independently.
+    When disabled, the controlled Light Lightness Server operates independently.
 
 Occupancy mode: ``bool``
     The occupancy mode controls whether sensor activity can turn the lights on.
@@ -435,15 +435,15 @@ Changes to the configuration properties are stored and restored on power-up, so 
 Power-up behavior
 =================
 
-When powering up, the Light LC Server behavior depends on the controlled Lightness Server's extended :ref:`bt_mesh_ponoff_srv_readme`'s state:
+When powering up, the Light LC Server behavior depends on the controlled Light Lightness Server's extended :ref:`bt_mesh_ponoff_srv_readme`'s state:
 
-* On Power Up is :c:enumerator:`BT_MESH_ON_POWER_UP_OFF` - The Light LC Server is disabled, and the Lightness Server remains off.
-* On Power Up is :c:enumerator:`BT_MESH_ON_POWER_UP_ON` - The Light LC Server is disabled, and the Lightness Server light level is set to its default value.
+* On Power Up is :c:enumerator:`BT_MESH_ON_POWER_UP_OFF` - The Light LC Server is disabled, and the Light Lightness Server remains off.
+* On Power Up is :c:enumerator:`BT_MESH_ON_POWER_UP_ON` - The Light LC Server is disabled, and the Light Lightness Server's Light level is set to its default value.
 * On Power Up is :c:enumerator:`BT_MESH_ON_POWER_UP_RESTORE` - The Light LC Server is enabled and takes control of the Lightness Server.
   If the last known value of the Light OnOff state was On, the Light LC Server triggers a transition to the On state.
 
 .. warning::
-    The Light LC Server is only re-enabled on startup if the Lightness Server's extended Generic Power OnOff Server is in the restore mode.
+    The Light LC Server is only re-enabled on startup if the Light Lightness Server's extended Generic Power OnOff Server is in the restore mode.
 
 API documentation
 *****************

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_hsl_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_hsl_srv.rst
@@ -30,19 +30,19 @@ Model composition
 *****************
 
 The Light HSL Server requires a :ref:`bt_mesh_light_hue_srv_readme` and a :ref:`bt_mesh_light_sat_srv_readme` model to be instantiated in any of the following elements.
-As each of the Hue, Saturation and Lightness Server models extend the :ref:`bt_mesh_lvl_srv_readme` model, they cannot be instantiated on the same element.
+As each of the Light Hue, Saturation and Lightness Server models extend the :ref:`bt_mesh_lvl_srv_readme` model, they cannot be instantiated on the same element.
 
-The recommended configuration for the Light HSL Server model is to instantiate the HSL Server (with its extended Lightness Server model) on one element, then instantiate the corresponding Light Hue Server model on the subsequent element, and the corresponding Light Saturation Server model on the next element after that:
+The recommended configuration for the Light HSL Server model is to instantiate the Light HSL Server (with its extended Light Lightness Server model) on one element, then instantiate the corresponding Light Hue Server model on the subsequent element, and the corresponding Light Saturation Server model on the next element after that:
 
 .. table::
    :align: center
 
-   =================  =================  =======================
-   Element N          Element N+1        Element N+2
-   =================  =================  =======================
-   Lightness Server   Light Hue Server   Light Saturation Server
+   =======================  =================  =======================
+   Element N                Element N+1        Element N+2
+   =======================  =================  =======================
+   Light Lightness Server   Light Hue Server   Light Saturation Server
    Light HSL Server
-   =================  =================  =======================
+   =======================  =================  =======================
 
 In the application code, this would look like this:
 
@@ -74,8 +74,11 @@ In the application code, this would look like this:
    The :c:struct:`bt_mesh_light_hsl_srv` also contains a pointer to the Light Lightness Server model.
    Pointer to this model should be passed to the Light HSL Server initialization macro.
 
-The Light HSL Server does not contain any states on its own, but instead operates on the underlying Hue, Saturation and Lightness Server model's states.
+The Light HSL Server does not contain any states on its own, but instead operates on the underlying Light Hue, Saturation and Lightness Server models' states.
 Because of this, the Light HSL Server does not have a message handler structure, but will instead defer its messages to the individual submodels' handler callbacks.
+
+It's also possible to combine the Light HSL Server model with a :ref:`bt_mesh_light_xyl_srv_readme`.
+See :ref:`bt_mesh_light_xyl_hsl_srv` for details.
 
 States
 ******


### PR DESCRIPTION
Removes text saying the Lightness Server is added to the composition
data, and adds a Model composition section explaing the required layout
for the Light xyL Server, both as a standalone model, and in combination
with the Light HSL Server.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>