### PR TITLE
samples: openthread: update yaml files with nrf21540dk_nrf52840 support

### DIFF
--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -4,23 +4,25 @@ sample:
 tests:
   samples.openthread.cli:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
+      - nrf21540dk_nrf52840
   samples.openthread.cli.thread_1_2:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-thread_1_2.conf
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
+      - nrf21540dk_nrf52840
   samples.openthread.cli.usb:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52833dk_nrf52833
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-usb.conf
     integration_platforms:
@@ -28,21 +30,24 @@ tests:
       - nrf52840dk_nrf52840
       - nrf52840dongle_nrf52840
       - nrf52833dk_nrf52833
+      - nrf21540dk_nrf52840
   samples.openthread.cli.minimal_multiprotocol:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-minimal_multiprotocol.conf
     integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
-      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
   samples.openthread.cli.minimal_singleprotocol:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-minimal_singleprotocol.conf
     integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
-      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840

--- a/samples/openthread/coap_client/sample.yaml
+++ b/samples/openthread/coap_client/sample.yaml
@@ -4,21 +4,23 @@ sample:
 tests:
   samples.openthread.coap_client:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
-      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
   samples.openthread.coap_client.mtd.multiprotocol_ble:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-mtd.conf;overlay-multiprotocol_ble.conf
     integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
-      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
   samples.openthread.coap_client.multiprotocol_ble.dfu_support:
     build_only: true
     platform_allow: nrf52840dk_nrf52840

--- a/samples/openthread/coap_server/sample.yaml
+++ b/samples/openthread/coap_server/sample.yaml
@@ -4,9 +4,10 @@ sample:
 tests:
   samples.openthread.coap_server:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
-      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840

--- a/samples/openthread/coprocessor/sample.yaml
+++ b/samples/openthread/coprocessor/sample.yaml
@@ -4,26 +4,29 @@ sample:
 tests:
   samples.openthread.coprocessor:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-logging.conf;overlay-vendor_hook.conf
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
+      - nrf21540dk_nrf52840
   samples.openthread.coprocessor.rcp:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-rcp.conf;overlay-logging.conf;overlay-vendor_hook.conf
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
+      - nrf21540dk_nrf52840
   samples.openthread.coprocessor.usb:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52833dk_nrf52833
+    platform_allow: nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: OVERLAY_CONFIG=overlay-usb.conf;
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52840dongle_nrf52840
       - nrf52833dk_nrf52833
+      - nrf21540dk_nrf52840

--- a/subsys/mpsl/fem/mpsl_fem.c
+++ b/subsys/mpsl/fem/mpsl_fem.c
@@ -65,7 +65,7 @@ static void fem_pin_num_correction(uint8_t *p_gpio_pin, const char *gpio_lbl)
 static inline int inactive_pin_configure(uint8_t pin, const char *gpio_lbl,
 				  gpio_flags_t flags)
 {
-	const struct device *port;
+	const struct device *port = NULL;
 
 	if (gpio_lbl != NULL) {
 		port = device_get_binding(gpio_lbl);


### PR DESCRIPTION
The board nrf21540dk_nrf52840 is supported by Thread samples but hasn't
been checked by Twister builds so far. This commit fixes it.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>