### PR TITLE
matter: bring in various fixes from the upstream and fix CI

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -90,8 +90,8 @@
 
 .. _`SMP over Bluetooth`: https://github.com/apache/mynewt-mcumgr/blob/master/transport/smp-bluetooth.md
 
-.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/43e5173/src/android/CHIPTool
-.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/43e5173/src/controller
+.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/2d5daa9/src/android/CHIPTool
+.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/2d5daa9/src/controller
 .. _`ZCL Advanced Platform`: https://github.com/project-chip/zap
 .. _`Matter nRF Connect releases`: https://github.com/nrfconnect/sdk-connectedhomeip/releases
 

--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 43e5173c5762d85275869fddb7fa7eb9ded03e9b
+      revision: 2d5daa9e002fa98ab7335268661b03a635068572
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
1. Bring in a fix for Android CHIPTool build failure, and
   an enhancement to exit to the main screen after
   commissioning a device.
2. Bring in documentation changes.
3. Try to fix failing CI jobs due to conflicting Python
   requirements.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>