### PR TITLE
doc: deprecating Asset Tracker v1 in docs

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -8,8 +8,7 @@ nRF9160: Asset Tracker
    :depth: 2
 
 .. note::
-   The Asset Tracker application is succeeded by the :ref:`asset_tracker_v2` application.
-   It will be phased out in future releases.
+   The Asset Tracker application is deprecated and succeeded by the :ref:`asset_tracker_v2` application.
 
 The Asset Tracker demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160-based kit to the `nRF Connect for Cloud`_ via LTE, transmit GPS and sensor data, and retrieve information about the device.
 

--- a/doc/nrf/libraries/networking/nrf_cloud_pgps.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_pgps.rst
@@ -127,7 +127,7 @@ P-GPS data can be requested from the cloud using one of the following methods:
 
    * N/A
 
-The indirect methods are used in the :ref:`agps_sample` sample and in the :ref:`asset_tracker` application.
+The indirect methods are used in the :ref:`agps_sample` sample and in the :ref:`asset_tracker_v2` application.
 They are simpler to use than the direct methods.
 
 When nRF Cloud responds with the requested P-GPS data, the application's :c:func:`cloud_evt_handler_t` function must call the :c:func:`nrf_cloud_pgps_process` function when it receives the :c:enum:`CLOUD_EVT_DATA_RECEIVED` event.
@@ -141,7 +141,7 @@ A P-GPS prediction for the current date and time can be retrieved using one of t
 * Directly, by calling the function :c:func:`nrf_cloud_pgps_find_prediction`
 * Indirectly, by calling the function :c:func:`nrf_cloud_pgps_notify_prediction`
 
-The indirect method is used in the :ref:`agps_sample` sample and in the :ref:`asset_tracker` application.
+The indirect method is used in the :ref:`agps_sample` sample and in the :ref:`asset_tracker_v2` application.
 
 The application can inject the data contained in the prediction to the GPS unit in the modem by calling the :c:func:`nrf_cloud_pgps_inject` function.
 This must be done when the GPS driver callback indicates that assistance is needed.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -94,6 +94,10 @@ nRF9160
     * The ``nrf9160dk_nrf9160ns`` and the ``nrf5340dk_nrf5340_cpuappns`` boards have been renamed respectively to ``nrf9160dk_nrf9160_ns`` and ``nrf5340dk_nrf5340_cpuapp_ns``, in a change inherited from upstream Zephyr.
     * The ``thingy91_nrf9160ns`` board has been renamed to ``thingy91_nrf9160_ns`` for consistency with the changes inherited from upstream Zephyr.
 
+* Deprecated:
+
+  * :ref:`asset_tracker` has been deprecated in favor of :ref`asset_tracker_v2`.
+
 nRF5
 ====
 


### PR DESCRIPTION
Asset Tracker v2 replaces now the version 1.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>