### PR TITLE
labeler.yml: Fix rule for changelog-entry-required

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -214,4 +214,4 @@
   - "samples/nrf_rpc/**/*"
 
 "changelog-entry-required":
-  - "!doc/nrf/releases/release-notes-changelog.rst"
+  - all: ["!doc/nrf/releases/release-notes-changelog.rst"]


### PR DESCRIPTION
Change
  - "!doc/nrf/releases/release-notes-changelog.rst"
which is equivalent to
  - any: ["!doc/nrf/releases/release-notes-changelog.rst"]
to
  - all: ["!doc/nrf/releases/release-notes-changelog.rst"]

'any' means that the label is applied if _any_ changed file matches the
glob, which means the label is applied as long as any other files than
the changelog are changed.
'all' means that the label is applied only if _all_ changed files match
the glob, i.e. when the changelog is not among the changed files.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>