### PR TITLE
[DNM] matter: rebase sdk-connectedhomeip fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 43e5173c5762d85275869fddb7fa7eb9ded03e9b
+      revision: pull/29/head
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Since we had to create a pre-release tag on the
sdk-connectedhomeip fork, use the opportunity to rebase
the master branch on the fork so that all downstream
patches are moved to the top.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>