### PR TITLE
labeler: add ieee802154 subsys to 802154-based protocols

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -81,6 +81,7 @@
   - "subsys/zigbee/**/*"
   - "tests/subsys/zigbee/**/*"
   - "subsys/mpsl/**/*"
+  - "subsys/ieee802154/**/*"
   - "drivers/mpsl/**/*"
   - "dts/bindings/radio_fem/**/*"
   - "samples/nrf5340/multiprotocol_rpmsg/**/*"
@@ -136,6 +137,7 @@
 
 "CI-rs-test":
   - "subsys/mpsl/**/*"
+  - "subsys/ieee802154/**/*"
   - "drivers/mpsl/**/*"
   - "dts/bindings/radio_fem/**/*"
   - "samples/nrf5340/multiprotocol_rpmsg/**/*"
@@ -145,6 +147,7 @@
 "CI-homekit-test":
   - any:
     - "subsys/mpsl/**/*"
+    - "subsys/ieee802154/**/*"
     - "drivers/mpsl/**/*"
     - "dts/bindings/radio_fem/**/*"
     - "modules/nrfxlib/nrf_802154/**/*"
@@ -162,6 +165,7 @@
 "CI-thread-test":
   - "samples/openthread/**/*"
   - "subsys/mpsl/**/*"
+  - "subsys/ieee802154/**/*"
   - "subsys/net/lib/coap_utils/**/*"
   - "subsys/net/openthread/**/*"
 
@@ -179,6 +183,7 @@
   - "drivers/hw_cc310/*"
   - "drivers/net/*"
   - "subsys/mpsl/**/*"
+  - "subsys/ieee802154/**/*"
   - "subsys/bootloader/**/*"
   - "subsys/partition_manager/**/*"
   - "subsys/nfc/**/*"


### PR DESCRIPTION
This commit adds ieee802154 subsys to the 802.15.4 based protocol
CIs.

Signed-off-by: Czeslaw Makarski <czeslaw.makarski@nordicsemi.no>