### PR TITLE
Update Memfault sample and intergration layer

### DIFF
--- a/modules/memfault/Kconfig
+++ b/modules/memfault/Kconfig
@@ -89,6 +89,13 @@ config MEMFAULT_NCS_FW_VERSION_PREFIX
 	  If the build version string is "a1b2c3d", the full firmware version
 	  will become "<prefix>a1b2c3d".
 
+config MEMFAULT_NCS_FW_VERSION
+	string "Static firmware version to use"
+	depends on MEMFAULT_NCS_FW_VERSION_STATIC
+	help
+	 When using a statically configured firmware version, this value
+	 will be reported to Memfault
+
 config MEMFAULT_NCS_INIT_PRIORITY
 	int "Memfault initialization priority"
 	range AT_CMD_INIT_PRIORITY 99 if MEMFAULT_NCS_DEVICE_ID_IMEI

--- a/modules/memfault/memfault_integration.c
+++ b/modules/memfault/memfault_integration.c
@@ -43,9 +43,6 @@ BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC) > 1,
 	     "Firmware version must be configured");
 #endif
 
-static char fw_version[sizeof(CONFIG_MEMFAULT_NCS_FW_VERSION_PREFIX) + 8] =
-	CONFIG_MEMFAULT_NCS_FW_VERSION_PREFIX;
-
 #if defined(CONFIG_MEMFAULT_NCS_DEVICE_ID_IMEI)
 	static char device_serial[IMEI_LEN + 1];
 #elif defined(CONFIG_MEMFAULT_NCS_DEVICE_ID_STATIC)
@@ -64,7 +61,11 @@ sMfltHttpClientConfig g_mflt_http_client_config = {
 
 void memfault_platform_get_device_info(sMemfaultDeviceInfo *info)
 {
+#if defined(CONFIG_MEMFAULT_NCS_FW_VERSION_AUTO)
 	static bool is_init;
+
+	static char fw_version[sizeof(CONFIG_MEMFAULT_NCS_FW_VERSION_PREFIX) + 8] =
+	    CONFIG_MEMFAULT_NCS_FW_VERSION_PREFIX;
 
 	if (!is_init) {
 		const size_t version_len = strlen(fw_version);
@@ -75,6 +76,9 @@ void memfault_platform_get_device_info(sMemfaultDeviceInfo *info)
 		memfault_build_id_get_string(&fw_version[version_len], build_id_num_chars);
 		is_init = true;
 	}
+#else
+	static const char *fw_version = CONFIG_MEMFAULT_NCS_FW_VERSION;
+#endif /* defined(CONFIG_MEMFAULT_NCS_FW_VERSION_AUTO) */
 
 	*info = (sMemfaultDeviceInfo) {
 		.device_serial = device_serial,


### PR DESCRIPTION
- Add Kconfig option, `MEMFAULT_NCS_FW_VERSION` which is used as the
  firmware version when `CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y` is
  used
- Updated Memfault sample app to always send data when LTE
  re-connects. This allows for new data to show up faster for demo
  purposes when in an environment with weak signal or a roaming
  network