### PR TITLE
samples: Bluetooth: marked nRF21540 DK as supported in the UART samples.

### DIFF
--- a/samples/bluetooth/central_uart/README.rst
+++ b/samples/bluetooth/central_uart/README.rst
@@ -30,6 +30,11 @@ Debug messages are not displayed in the UART console, but are printed by the RTT
 
 If you want to view the debug messages, follow the procedure in :ref:`testing_rtt_connect`.
 
+FEM support
+***********
+
+.. include:: /includes/sample_fem_support.txt
+
 Requirements
 ************
 
@@ -37,7 +42,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820
+   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf21540dk_nrf52840
 
 The sample also requires another development kit running a compatible application (see :ref:`peripheral_uart`).
 

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -5,11 +5,12 @@ tests:
   samples.bluetooth.central_uart:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf21540dk_nrf52840
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf21540dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -32,6 +32,11 @@ If you want to view the debug messages, follow the procedure in :ref:`testing_rt
 .. note::
    On Thingy:53 debug logs are provided over the USB CDC ACM class serial port, instead of using RTT.
 
+FEM support
+***********
+
+.. include:: /includes/sample_fem_support.txt
+
 Requirements
 ************
 
@@ -39,7 +44,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52840dk_nrf52811, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52833dk_nrf52820, nrf52dk_nrf52832, nrf52dk_nrf52810, thingy53_nrf5340_cpuapp
+   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52840dk_nrf52811, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52833dk_nrf52820, nrf52dk_nrf52832, nrf52dk_nrf52810, thingy53_nrf5340_cpuapp, nrf21540dk_nrf52840
 
 .. note::
    * To build this sample for ``nrf52dk_nrf52810``, ``nrf52840dk_nrf52811`` or ``nrf52833dk_nrf52820``, use the `Minimal build`_ approach.

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -6,6 +6,7 @@ tests:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
+      nrf21540dk_nrf52840
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
@@ -13,6 +14,7 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
     tags: bluetooth ci_build
   samples.bluetooth.peripheral_uart_minimal:
     extra_args: OVERLAY_CONFIG=prj_minimal.conf


### PR DESCRIPTION
Declare explicit support for the nRF21540 DK in the peripheral_ and central_uart samples.