### PR TITLE
doc: update versions for NCS 1.7 release

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -282,7 +282,7 @@ This enables the cloud to indirectly fetch A-GPS and P-GPS data from `nRF Cloud`
 This approach saves data and energy costs related to maintaining multiple connections.
 
 .. note::
-   For more information on the various trade-offs of using A-GPS compared to using P-GPS, see the `nRF Cloud Location Services documentation`_.
+   |gps_tradeoffs|
 
 By default, the application is configured to communicate with `nRF Cloud`_ using the factory-provisioned certificates on Thingy:91 and nRF9160 DK.
 This enables the application to function out-of-the-box with nRF Cloud.

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -19,7 +19,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 project = "nRF Connect SDK"
 copyright = "2019-2021, Nordic Semiconductor"
 author = "Nordic Semiconductor"
-version = release = "1.6.99"
+version = release = "1.7.0"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/nrf/dm_adding_code.rst
+++ b/doc/nrf/dm_adding_code.rst
@@ -92,7 +92,7 @@ This is demonstrated by the following code:
        - name: nrf
          repo-path: sdk-nrf
          remote: ncs
-         revision: v1.6.1
+         revision: v1.7.0
          import: true
      self:
        path: application
@@ -119,7 +119,7 @@ For example:
      projects:
        - name: nrf
          remote: ncs
-         revision: v1.6.1
+         revision: v1.7.0
          import: true
        # Example for how to override a repository in the nRF Connect SDK with your own:
        - name: mcuboot

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -10,7 +10,8 @@ The |NCS| includes the Zephyr™ real-time operating system (RTOS), which is bui
 
 .. note::
 
-   This version of the |NCS| supports prototyping and evaluation, but should not be used for production and deployment in end products.
+   nRF53 Series devices are supported for production.
+   Wireless protocol stacks and libraries may indicate support for development or support for production for different series of devices based on verification and certification status.
 
 To access different versions of the |NCS| documentation, use the version drop-down in the top left corner.
 To view the documentation from the different repositories that are part of |NCS|, click the arrow in the bottom left corner and select the desired document set.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -342,11 +342,11 @@
 
 .. ### Source: www.segger.com
 
-.. _`SEGGER Embedded Studio (Nordic Edition) - Windows x86`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_win_x86
-.. _`SEGGER Embedded Studio (Nordic Edition) - Windows x64`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_win_x64
-.. _`SEGGER Embedded Studio (Nordic Edition) - Mac OS x64`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_macos
-.. _`SEGGER Embedded Studio (Nordic Edition) - Linux x86`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_linux_x86
-.. _`SEGGER Embedded Studio (Nordic Edition) - Linux x64`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_linux_x64
+.. _`SEGGER Embedded Studio (Nordic Edition) - Windows x86`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v560_win_x86.zip
+.. _`SEGGER Embedded Studio (Nordic Edition) - Windows x64`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v560_win_x64.zip
+.. _`SEGGER Embedded Studio (Nordic Edition) - Mac OS x64`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v560_macos_x64.dmg
+.. _`SEGGER Embedded Studio (Nordic Edition) - Linux x86`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v560_linux_x86.tar.gz
+.. _`SEGGER Embedded Studio (Nordic Edition) - Linux x64`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v560_linux_x64.tar.gz
 
 .. _`J-Link Software and Documentation Pack`: https://www.segger.com/downloads/jlink
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -1,8 +1,8 @@
 .. |NCS| replace:: nRF Connect SDK
 
-.. |release| replace:: v1.6.1
-.. |release_tt| replace:: ``v1.6.1``
-.. |release_number_tt| replace:: ``1.6.1``
+.. |release| replace:: v1.7.0
+.. |release_tt| replace:: ``v1.7.0``
+.. |release_number_tt| replace:: ``1.7.0``
 
 .. |SES| replace:: SEGGER Embedded Studio
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -83,6 +83,8 @@
 
 .. |application_sample_definition| replace:: For simplicity, this guide will refer to both :ref:`samples<samples>` and :ref:`applications<applications>` as "applications".
 
+.. |gps_tradeoffs| replace:: For more information on the various trade-offs of using A-GPS compared to using P-GPS, see the `nRF Cloud Location Services documentation`_.
+
 .. |vsc_extension_instructions| replace:: The `nRF Connect for Visual Studio Code`_ extension is a complete IDE for developing applications for nRF91, nRF53 and nRF52 Series devices. This includes an interface to the compiler and linker, an RTOS-aware debugger, a seamless interface to the nRF Connect SDK, and a serial terminal.
 
 .. |VSC| replace:: nRF Connect for Visual Studio Code

--- a/doc/nrf/ug_nrf91_features.rst
+++ b/doc/nrf/ug_nrf91_features.rst
@@ -321,6 +321,9 @@ Also, note that due to satellite clock inaccuracies, not all functional satellit
 This means that the number of satellites having valid predicted Ephemerides reduces in number roughly after ten days.
 Hence, the GNSS module needs to download the Ephemeris data from the satellite broadcast if no predicted Ephemeris is found for that satellite to be able to use the satellite.
 
+.. note::
+   |gps_tradeoffs|
+
 nRF Cloud A-GPS compared with SUPL library
 ------------------------------------------
 

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -21,7 +21,7 @@ NRFXLIB_BASE = utils.get_projdir("nrfxlib")
 project = "nrfxlib"
 copyright = "2019-2021, Nordic Semiconductor"
 author = "Nordic Semiconductor"
-version = release = "1.6.99"
+version = release = "1.7.0"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/tfm/conf.py
+++ b/doc/tfm/conf.py
@@ -19,7 +19,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 project = "Trusted Firmware-M"
 copyright = "2017-2019, ARM CE-OSS"
 author = "ARM CE-OSS"
-version = "1.3.0"
+version = "1.3.99"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/versions.json
+++ b/doc/versions.json
@@ -1,6 +1,7 @@
 {
   "VERSIONS": [
     "latest",
+    "1.7.0",
     "1.6.1",
     "1.6.0",
     "1.5.1",
@@ -20,8 +21,17 @@
   ],
   "COMPONENTS_BY_VERSION": {
     "latest": {
-      "ncs": "1.6.99",
-      "nrfxlib": "1.6.99",
+      "ncs": "1.7.0",
+      "nrfxlib": "1.7.0",
+      "zephyr": "2.6.99",
+      "mcuboot": "1.7.99",
+      "nrfx": "2.5",
+      "tfm": "1.3.99",
+      "matter": ""
+    },
+    "1.7.0": {
+      "ncs": "1.7.0",
+      "nrfxlib": "1.7.0",
       "zephyr": "2.6.99",
       "mcuboot": "1.7.99",
       "nrfx": "2.5",

--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 580e325c9f686432b8c55baed8a4b03249cc12cd
+      revision: a79fdc3dc432e40a13d9c631582aa5f83ea93635
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Updated files except VERSION for documentation NCS 1.7.0 release.
VERSION to be handled by Vestavind.
NCSDK-11022.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>

-----

- [x] This PR to nrfxlib needs to go in before this one: https://github.com/nrfconnect/sdk-nrfxlib/pull/549
- [x] These PRs to sdk-nrf need to go in before this one: https://github.com/nrfconnect/sdk-nrf/pull/5534 and https://github.com/nrfconnect/sdk-nrf/pull/5475
- [x] Check TFM version with @SebastianBoe  -- updated to 1.3.99
- [x] Check MCUboot version with @carlescufi 