### PR TITLE
west.yml: Update mcumgr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.6.99-ncs1-rc1
+      revision: pull/587/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The commit updates mcumgr revision to includ efollowing commits
that affect Zephyr, from newest to oldest:

-  1e0f283 zephyr: Make direct image upload configurable [BUGFIX]
-  4fa8691 zephyr: Allow to select slot for DFU as image
-  d8802de samples/smp_svr/zephyr: Update stack size
-  e71063a zephyr: Improve and rename img_mgmt_find_best_area_id
-  e215d26 zephyr: Check area id in erase slot processing
-  71c76f5 zephyr: Upload should use g_img_mgmt_state
-  afa95ba cmd/img_mgmt: Call dfu stop cb on erase
-  6a10fa6 img_mgmt: Add interpretation of "image" parameter
-  757965c samples: smp_svr: zephyr: Update MTU Kconfig values

It also includes Zephyr side commits that support the mcumgr changes.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>