### PR TITLE
doc: Update pages to mention the VSC extension

### DIFF
--- a/doc/nrf/getting_started.rst
+++ b/doc/nrf/getting_started.rst
@@ -6,7 +6,12 @@ Getting started
 To quickly get started with the |NCS|, use :ref:`nRF Connect for Desktop <gs_assistant>` to set up your development environment.
 Alternatively, check the :ref:`gs_installing` section for instructions on setting up your environment manually.
 
-We recommend using SEGGER Embedded Studio for building your applications. See :ref:`gs_programming` for the download links and instructions.
+We recommend using the `nRF Connect for Visual Studio Code`_ extension or |SES| to build applications.
+See the |VSC| README file for more information about the extension.
+See :ref:`gs_programming` for the |SES| instructions.
+
+.. note::
+   Some samples in the |NCS| are currently not designed to work out-of-tree. You may need to manually configure your sample to work correctly in the |VSC|.
 
 Once you are set up, check out the :ref:`samples`.
 If this is the first time you are working with embedded devices, it is probably a good idea to program an unchanged sample to your development kit first and test if it works as expected.

--- a/doc/nrf/gs_assistant.rst
+++ b/doc/nrf/gs_assistant.rst
@@ -23,8 +23,8 @@ See :ref:`gs_recommended_versions` for information on the supported operating sy
 Toolchain Manager
 *****************
 
-The Toolchain Manager app is available for Windows and macOS.
-It installs the full toolchain that you need to work with the |NCS|, including SEGGER Embedded Studio and the |NCS| source code.
+The Toolchain manager app is available for Windows and macOS.
+It installs the full toolchain that you need to work with the |NCS|, including the |VSC| extension, |SES|, and the |NCS| source code.
 
 
 Installing the Toolchain Manager
@@ -54,12 +54,15 @@ Once you have installed the Toolchain Manager, open it in nRF Connect for Deskto
 
 Click :guilabel:`Settings` in the navigation bar to specify where you want to install the |NCS|.
 Then, in :guilabel:`SDK Environments`, click the :guilabel:`Install` button next to the |NCS| version that you want to install.
-The |NCS| version of your choice is installed on your machine, and the :guilabel:`Install` button changes to :guilabel:`Open IDE`.
+The |NCS| version of your choice is installed on your machine.
 
-There are two ways you can build an application:
+There are several ways you can build an application:
 
-1. To :ref:`build with SES <gs_programming_ses>`, click on the :guilabel:`Open IDE` button.
-#. To build on the command line, use the following steps:
+* To build with |VSC|, click on the :guilabel:`Open VS Code` button.
+
+* To build with |SES|, click on the :guilabel:`Open Segger Embedded Studio` button.
+
+* To build on the command line, use the following steps:
 
    1. With admin permissions enabled, download and install the `nRF Command Line Tools`_.
    #. Restart the Toolchain Manager application.

--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -448,16 +448,27 @@ To set up the toolchain, complete the following steps:
           Define the environment variables in the :file:`~/.zephyrrc` file as described in :ref:`build_environment_cli`.
           This lets you avoid setting them every time you open a terminal window.
 
+.. rst-class:: numbered-step
+
+Install a build IDE
+*******************
+
+You can install either the |VSC| extension or the |SES| (SES) Nordic Edition to open and compile projects in the |NCS|:
+
+.. _installing_vsc:
+
+Visual Studio Code extension
+============================
+
+|vsc_extension_instructions|
+For detailed instructions see the `nRF Connect for Visual Studio Code`_ README file.
 
 .. _installing_ses:
 
-.. rst-class:: numbered-step
+|SES| Nordic Edition
+====================
 
-Install the |SES| Nordic Edition
-********************************
-
-You must install the |SES| (SES) Nordic Edition to be able to open and compile projects in the |NCS|.
-
+You can install the |SES| (SES) Nordic Edition to open and compile projects in the |NCS|.
 SES is free of charge for use with Nordic Semiconductor devices.
 
 To install the Nordic Edition, complete the following steps:
@@ -516,12 +527,10 @@ To install the Nordic Edition, complete the following steps:
 .. _build_environment:
 .. _setting_up_SES:
 
-.. rst-class:: numbered-step
-
 Set up the build environment in SES
 ***********************************
 
-Before you start :ref:`building and programming a sample application <gs_programming>`, you must set up your build environment.
+If you chose to use |SES| for :ref:`building and programming a sample application <gs_programming>`, you must first set up your build environment.
 
 1. Set up the SES environment.
    If you plan to :ref:`build with SEGGER Embedded Studio <gs_programming_ses>`, the first time you import an |NCS| project, SES might prompt you to set the paths to the Zephyr Base directory and the GNU ARM Embedded Toolchain.
@@ -604,8 +613,7 @@ If you want to configure tools that are not listed in the SES options, add them 
 Set up the command-line build environment
 *****************************************
 
-The default build environment for the |NCS| is SES.
-However, you can also build and program your application from the command line.
+In addition to |VSC| and |SES|, you can also build and program your application from the command line.
 You have to set up your build environment by defining the required environment variables every time you open a new command-line or terminal window.
 
 See :ref:`zephyr:important-build-vars` for more information about the various relevant environment variables.

--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -11,7 +11,6 @@ Modifying an application
 
 After programming and testing an application, you probably want to make some modifications to the application, for example, add your own files with additional functionality, change compilation options, or update the default configuration.
 
-
 Adding files and changing compiler settings
 *******************************************
 
@@ -104,6 +103,14 @@ Similarly, the default configuration for a board is specified in its :file:`*_de
 The configuration for your application, which might override some default options of the libraries or the board, is specified in a :file:`prj.conf` file in the application directory.
 
 For detailed information about configuration options, see :ref:`zephyr:application-kconfig` in the Zephyr documentation.
+
+.. _configuring_vsc:
+
+Configuring in the VS Code extension
+====================================
+
+The `nRF Connect for Visual Studio Code`_ extension lets you modify your build configuration for custom boards, add additional CMake build arguments, select Kconfig fragments, and more.
+For detailed instructions on how to configure your application, see `Building an application`_ in the extension's README file.
 
 Changing the configuration permanently
 ======================================

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -7,15 +7,21 @@ Building and programming an application
    :local:
    :depth: 2
 
-The recommended way of building and programming an |NCS| application is to use the Nordic Edition of the |SES| (SES) IDE.
-
 |application_sample_definition|
 
-.. note::
+For additional information, check the user guide for the hardware platform that you are using.
+These user guides contain platform-specific instructions for building and programming.
+For additional information, check the user guide for the hardware platform that you are using.
+For example, see :ref:`ug_nrf5340_building` in the :ref:`ug_nrf5340` user guide for information about programming an nRF5340 DK, or :ref:`precompiled_fw` and :ref:`building_pgming` for information about programming a Thingy:91.
 
-   For additional information, check the user guide for the hardware platform that you are using.
-   These user guides contain platform-specific instructions for building and programming.
-   For example, see :ref:`ug_nrf5340_building` in the :ref:`ug_nrf5340` user guide for information about programming an nRF5340 DK, or :ref:`precompiled_fw` and :ref:`building_pgming` for information about programming a Thingy:91.
+.. _gs_programming_vsc:
+
+Building with the VS Code extension
+***********************************
+
+|vsc_extension_instructions|
+For detailed instructions on how to set up your build configuration, see `Creating an application`_ in the extension's README file.
+
 
 .. _gs_programming_ses:
 
@@ -28,7 +34,7 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
 1. Start SEGGER Embedded Studio.
 
-   If you have installed the |NCS| using the :ref:`gs_app_tcm`, click :guilabel:`Open IDE` next to the version you installed to start SES.
+   If you have installed the |NCS| using the :ref:`gs_app_tcm`, click the :guilabel:`Open Segger Embedded Studio` button next to the version you installed to start SES.
    If you have installed SES manually, run the :file:`emStudio` executable file from the :file:`bin` directory.
 
    .. figure:: images/gs-assistant_tm_installed.png

--- a/doc/nrf/gs_testing.rst
+++ b/doc/nrf/gs_testing.rst
@@ -14,6 +14,15 @@ Follow the instructions in the testing section of the application's documentatio
 Information about the current state of the application is usually provided through the LEDs or through UART, or through both.
 See the user interface section of the application's documentation for description of the LED states or available UART commands.
 
+.. _testing_vscode:
+
+How to connect with the VS Code extension
+*****************************************
+
+The `nRF Connect for Visual Studio Code`_ extension is a complete IDE for developing applications for nRF91, nRF53 and nRF52 Series devices.
+It includes nRF Terminal, which is an integrated serial port and RTT terminal to connect to your board.
+For detailed instructions, see `Testing an application`_ in the extension's README file.
+
 .. _putty:
 
 How to connect with PuTTY

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -111,6 +111,11 @@
 .. _`Getting started guide for nRF Asset Tracker for AWS`: https://nordicsemiconductor.github.io/asset-tracker-cloud-docs/v1.6.x/docs/aws/GettingStarted/Index.html
 .. _`Getting started guide for nRF Asset Tracker for Azure`: https://nordicsemiconductor.github.io/asset-tracker-cloud-docs/v1.6.x/docs/azure/GettingStarted/Index.html
 
+.. _`nRF Connect for Visual Studio Code`: https://nordicplayground.github.io/vscode-nrf-connect/
+.. _`Creating an application`: https://nordicplayground.github.io/vscode-nrf-connect/#creating-an-application
+.. _`Building an application`: https://nordicplayground.github.io/vscode-nrf-connect/#building-an-application
+.. _`Testing an application`: https://nordicplayground.github.io/vscode-nrf-connect/#testing-an-application
+
 .. ### Source: developer.nordicsemi.com
 
 .. _`nRF Connect SDK v1.4.0 documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.4.0/nrf/index.html

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -395,3 +395,4 @@ Documentation
 
   * Renamed :ref:`ncs_release_notes_changelog` (this page).
   * :ref:`gs_installing` - added information about the version folder created when extracting the GNU Arm Embedded Toolchain.
+  * Updated the Getting Started section with information to support the new Visual Studio Code extension.

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -82,3 +82,7 @@
 .. |external_flash_size| replace:: external flash memory with minimum 4MB
 
 .. |application_sample_definition| replace:: For simplicity, this guide will refer to both :ref:`samples<samples>` and :ref:`applications<applications>` as "applications".
+
+.. |vsc_extension_instructions| replace:: The `nRF Connect for Visual Studio Code`_ extension is a complete IDE for developing applications for nRF91, nRF53 and nRF52 Series devices. This includes an interface to the compiler and linker, an RTOS-aware debugger, a seamless interface to the nRF Connect SDK, and a serial terminal.
+
+.. |VSC| replace:: nRF Connect for Visual Studio Code


### PR DESCRIPTION
ref: NCSDK-10911

Getting started pages now recommend that customers use the new VSC extension to build applications.
Any section that mentions SES also includes a VSC section.