### PR TITLE
west.yml: Update Zephyr revision that enables swap type for multi-image

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.6.99-ncs1-rc1
+      revision: pull/602/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The commit advances sdk-zephyr revision to include changes, to DFU
subsystem, that enable swap type for multi-image.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>