### PR TITLE
lib: bin: lwm2m_carrier: lwm2m_os_storage_delete() should ignore certain IDs

### DIFF
--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -146,6 +146,12 @@ int lwm2m_os_storage_delete(uint16_t id)
 	__ASSERT((id >= LWM2M_OS_STORAGE_BASE) || (id <= LWM2M_OS_STORAGE_END),
 		 "Storage ID out of range");
 
+	if ((id == LWM2M_OS_STORAGE_END - 16) ||
+	    (id == LWM2M_OS_STORAGE_END - 18) ||
+	    (id == LWM2M_OS_STORAGE_END - 19)) {
+		return 0;
+	}
+
 	return nvs_delete(&fs, id);
 }
 


### PR DESCRIPTION
Edited lwm2m_os_storage_delete() to ignore certain records.
These records should be retained in LwM2M carrier library.

Signed-off-by: Håvard Vermeer <havard.vermeer@nordicsemi.no>