### PR TITLE
nrf_desktop: Fix race condition in usb_state and hids

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -552,6 +552,10 @@ NCSDK-8304: HID configurator issues for peripherals connected over Bluetooth® L
 
   **Workaround:** Connect the nRF Desktop peripheral through USB or using the nRF Desktop dongle.
 
+.. rst-class:: v1-6-1 v1-6-0 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
+
+NCSDK-10907: :ref:`nrf_desktop_usb_state` and :ref:`nrf_desktop_hids` modules may (there is a race) forward HID input reports related to an old protocol after protocol mode change.
+
 Pelion
 ======
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -134,6 +134,7 @@ Updated:
 * Changed settings backend from FCB to NVS.
 * Switched to using :ref:`caf_power_manager`.
 * Fixed an issue with generating motion in :ref:`nrf_desktop_motion` (``motion_buttons`` and ``motion_simulated``) while the HID boot protocol was in use.
+* Fixed an issue with :ref:`nrf_desktop_usb_state` and :ref:`nrf_desktop_hids` modules forwarding the HID input reports related to an old protocol after protocol mode change.
 
 Added:
 


### PR DESCRIPTION
Ensures that report with incompatible mode is not forwarded.
This issue could earlier occur after protocol mode change.

Jira: NCSDK-10907