### PR TITLE
Bluetooth: Mesh: Remove nRF51 from sample.yaml

### DIFF
--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -4,13 +4,12 @@ sample:
 tests:
   samples.bluetooth.mesh.light:
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
-      - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -4,13 +4,12 @@ sample:
 tests:
   samples.bluetooth.mesh.light_switch:
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
-      - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp

--- a/samples/bluetooth/mesh/silvair_enocean/sample.yaml
+++ b/samples/bluetooth/mesh/silvair_enocean/sample.yaml
@@ -9,7 +9,7 @@ tests:
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
     tags: bluetooth ci_build
     integration_platforms:
-        - rf52dk_nrf52832
+        - nrf52dk_nrf52832
         - nrf52840dk_nrf52840
         - nrf5340dk_nrf5340_cpuapp
         - nrf5340dk_nrf5340_cpuapp_ns


### PR DESCRIPTION
Removes nRF51 from sample.yaml for all Bluetooth mesh samples. nRF51 is
not officially supported, and has started overflowing SRAM in some build
configurations.

Additionally fixes a typo in the Silvar EnOcean sample.yaml's integration_platforms,
which made it skip builds for nrf52dk.