### PR TITLE
manifest: update nrfxlib to include nRF Security fix for SES-NE

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.7.0-rc1
+      revision: d32edb96e40ac44c5e31e687abefa5c8a73b7b16
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
This commit updates the manifest file to point to nrfxlib revision:
pull/550/head

This update work around a SES-NE issue on the windows platform where a
long post build command results in the generation of a post-build.bat
file with a following SHA.
This results in build failure in SES-NE when trying to invoke the SHA
as part of the command.

This is fixed by updating nrfxlib to a version that instead uses a
cmake file for passing the script arguments.

Fixes: NCSDK-10510

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>