### PR TITLE
matter: android CHIPTool usability fixes

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -90,8 +90,8 @@
 
 .. _`SMP over Bluetooth`: https://github.com/apache/mynewt-mcumgr/blob/master/transport/smp-bluetooth.md
 
-.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/2d5daa9/src/android/CHIPTool
-.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/2d5daa9/src/controller
+.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/a68983a3/src/android/CHIPTool
+.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/a68983a3/src/controller
 .. _`ZCL Advanced Platform`: https://github.com/project-chip/zap
 .. _`Matter nRF Connect releases`: https://github.com/nrfconnect/sdk-connectedhomeip/releases
 

--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v1.7.0-rc1
+      revision: a68983a302979eaf59d5ca75006a1fc8b471df12
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This commit only modifies Android CHIPTool, a Matter controller for Android, and does not impact Matter core nor Matter samples.

1. Bring in a fix for the sensor time series graph rendering from the upstream.
2. Update device address using DNS-SD automatically upon entering the SENSOR CLUSTERS screen instead of forcing a user to use another screen just to resolve the address.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>