### PR TITLE
applications: caf: Add limit to sensor events

### DIFF
--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/sensor_sampler_def.h
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/sensor_sampler_def.h
@@ -38,5 +38,6 @@ static const struct sensor_config sensor_configs[] = {
 		.chans = accel_chan,
 		.chan_cnt = ARRAY_SIZE(accel_chan),
 		.sampling_period_ms = 20,
+		.active_events_limit = 3,
 	},
 };

--- a/applications/machine_learning/configuration/thingy52_nrf52832/sensor_sampler_def.h
+++ b/applications/machine_learning/configuration/thingy52_nrf52832/sensor_sampler_def.h
@@ -30,5 +30,6 @@ static const struct sensor_config sensor_configs[] = {
 		.chans = accel_chan,
 		.chan_cnt = ARRAY_SIZE(accel_chan),
 		.sampling_period_ms = 20,
+		.active_events_limit = 3,
 	},
 };

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/sensor_sampler_def.h
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/sensor_sampler_def.h
@@ -30,5 +30,6 @@ static const struct sensor_config sensor_configs[] = {
 		.chans = accel_chan,
 		.chan_cnt = ARRAY_SIZE(accel_chan),
 		.sampling_period_ms = 20,
+		.active_events_limit = 3,
 	},
 };

--- a/include/caf/sensor_sampler.h
+++ b/include/caf/sensor_sampler.h
@@ -39,6 +39,7 @@ struct sensor_config {
 	const char *event_descr;
 	const struct sampled_channel *chans;
 	uint8_t chan_cnt;
+	uint8_t active_events_limit;
 	unsigned int sampling_period_ms;
 	struct trigger *trigger;
 };


### PR DESCRIPTION
Nof unprocessed  sensor_event is limited in order not
to fall in oom.

Jira: NCSDK-10569

Signed-off-by: Jan Zyczkowski <Jan.Zyczkowski@nordicsemi.no>