### PR TITLE
doc: USB state power manager documentation

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -1690,6 +1690,7 @@ These are valid for events that have many listeners or sources, and are gathered
    doc/selector.rst
    doc/smp.rst
    doc/settings_loader.rst
+   doc/usb_state_pm.rst
    doc/usb_state.rst
    doc/watchdog.rst
    doc/wheel.rst

--- a/applications/nrf_desktop/doc/usb_state.rst
+++ b/applications/nrf_desktop/doc/usb_state.rst
@@ -84,19 +84,19 @@ The |usb_state| registers the :kconfig:`CONFIG_USB_HID_DEVICE_COUNT` instances o
 The necessary callbacks are connected to the module to ensure that the state of the USB connection is tracked.
 From the application's viewpoint, USB can be in the following states:
 
-* USB_STATE_DISCONNECTED - USB cable is not connected.
-* USB_STATE_POWERED - The device is powered from USB but is not configured for the communication.
-* USB_STATE_ACTIVE - The device is ready to exchange data with the host.
-* USB_STATE_SUSPENDED - The host has requested the device to enter the suspended state.
+* :c:enum:`USB_STATE_DISCONNECTED` - USB cable is not connected.
+* :c:enum:`USB_STATE_POWERED` - The device is powered from USB but is not configured for the communication.
+* :c:enum:`USB_STATE_ACTIVE` - The device is ready to exchange data with the host.
+* :c:enum:`USB_STATE_SUSPENDED` - The host has requested the device to enter the suspended state.
 
-These states are broadcast by the |usb_state| with a ``usb_state_event``.
-When the device is connected to the host and configured for the communication, the module will broadcast the ``USB_STATE_ACTIVE`` state.
+These states are broadcast by the |usb_state| with a :c:struct:`usb_state_event`.
+When the device is connected to the host and configured for the communication, the module will broadcast the :c:enum:`USB_STATE_ACTIVE` state.
 The module will also subscribe to all HID reports available in the application for the selected protocol.
 
 When the device is disconnected from the host, the module will unsubscribe from receiving the HID reports.
 
-When the HID report data is transmitted through ``hid_report_event``, the module will pass it to the associated endpoint.
-Upon data delivery, ``hid_report_sent_event`` is submitted by the module.
+When the HID report data is transmitted through :c:struct:`hid_report_event`, the module will pass it to the associated endpoint.
+Upon data delivery, :c:struct:`hid_report_sent_event` is submitted by the module.
 
 .. note::
     Only one report can be transmitted by the module to a single instance of HID-class USB device at any given time.

--- a/applications/nrf_desktop/doc/usb_state_pm.rst
+++ b/applications/nrf_desktop/doc/usb_state_pm.rst
@@ -1,0 +1,34 @@
+.. _nrf_desktop_usb_state_pm:
+
+USB state power manager module
+##############################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The |usb_state_pm| is minor, stateless module that imposes an application power level restriction related to the USB state.
+The application power level is managed by the :ref:`power manager module <caf_power_manager>`.
+
+Configuration
+*************
+
+The module is enabled by selecting :kconfig:`CONFIG_DESKTOP_USB_PM_ENABLE`.
+It depends on :kconfig:`CONFIG_DESKTOP_USB_ENABLE` and :kconfig:`CONFIG_CAF_POWER_MANAGER`.
+
+The log level is inherited from the :ref:`nrf_desktop_usb_state`.
+
+Implementation details
+**********************
+
+For the change of the restricted power level, the module reacts to :c:struct:`usb_state_event`.
+Upon reception of the event and depending on the current USB state, the module requests different power restrictions:
+
+* If the USB state is set to :c:enum:`USB_STATE_POWERED` or :c:enum:`USB_STATE_ACTIVE`, the :c:enum:`POWER_MANAGER_LEVEL_ALIVE` is required.
+* If the USB state is set to :c:enum:`USB_STATE_DISCONNECTED`, any power level is allowed.
+* If the USB state is set to :c:enum:`USB_STATE_SUSPENDED`, the :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED` is imposed.
+  The module restricts the power down level to the :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED` and generates ``force_power_down_event`` after 1 second.
+
+For more information about the USB states in nRF Desktop, see the :ref:`nrf_desktop_usb_state`.
+
+.. |usb_state_pm| replace:: USB state power manager module

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -54,9 +54,14 @@ nRF5
 nRF Desktop
 -----------
 
+* Added:
+
+  * Added documentation for :ref:`nrf_desktop_usb_state_pm`.
+
 * Updated:
 
   * Updated information about custom build types.
+  * Updated documentation for :ref:`nrf_desktop_usb_state`.
 
 Common
 ======


### PR DESCRIPTION
Add documentation for the USB state power manager module.

JIRA: NCSDK-10557

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>