### PR TITLE
doc: Bluetooth state power manager documentation

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -1675,6 +1675,7 @@ These are valid for events that have many listeners or sources, and are gathered
    doc/ble_passkey.rst
    doc/ble_qos.rst
    doc/ble_scan.rst
+   doc/ble_state_pm.rst
    doc/ble_state.rst
    doc/board.rst
    doc/buttons.rst

--- a/applications/nrf_desktop/doc/ble_state_pm.rst
+++ b/applications/nrf_desktop/doc/ble_state_pm.rst
@@ -1,0 +1,18 @@
+.. _nrf_desktop_ble_state_pm:
+
+Bluetooth state power manager module
+####################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+In nRF Desktop, the |ble_state_pm| is responsible for blocking power off when there is at least one active Bluetooth® connection.
+
+Implementation details
+**********************
+
+nRF Desktop uses the |ble_state_pm| from :ref:`lib_caf` (CAF).
+See the :ref:`CAF Bluetooth state power manager module <caf_ble_state_pm>` page for implementation details.
+
+.. |ble_state_pm| replace:: Bluetooth state power manager module

--- a/doc/nrf/libraries/caf/ble_state_pm.rst
+++ b/doc/nrf/libraries/caf/ble_state_pm.rst
@@ -1,0 +1,32 @@
+.. _caf_ble_state_pm:
+
+CAF: Bluetooth state power manager module
+#########################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The |ble_state_pm| is a minor module that counts the number of active Bluetooth® connections and imposes a :ref:`power manager module <caf_power_manager>` power level restriction if there is at least one active connection.
+
+Configuration
+*************
+
+The module is enabled by selecting :kconfig:`CONFIG_CAF_BLE_STATE_PM`.
+It depends on :kconfig:`CONFIG_CAF_BLE_STATE` and :kconfig:`CONFIG_CAF_POWER_MANAGER`.
+
+Implementation details
+**********************
+
+The module reacts only to :c:struct:`ble_peer_event`.
+Upon the reception of the event, the module checks if the Bluetooth® peer is connected or disconnected.
+It then counts the active connections.
+
+Depending on the count result:
+
+* If there is at least one active connection, the power level is limited to :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED`.
+* If there is no active connection, the limitation on power level is removed.
+
+For more information about the CAF power levels, see the :ref:`caf_power_manager` documentation page.
+
+.. |ble_state_pm| replace:: Bluetooth state power manager module

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -88,6 +88,7 @@ nRF Desktop
 * Added:
 
   * Added documentation for :ref:`nrf_desktop_usb_state_pm`.
+  * Added :ref:`nrf_desktop_ble_state_pm`.
 
 * Updated:
 
@@ -125,6 +126,7 @@ Common Application Framework (CAF)
 Added:
 
 * :ref:`caf_preview_sample` sample.
+* :ref:`caf_ble_state_pm` CAF module.
 
 Updated:
 


### PR DESCRIPTION
Add documentation for the Bluetooth state power manager module.

JIRA: NCSDK-10556

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>