### PR TITLE
net: lib: nrf_cloud: do FOTA init first to complete pending updates

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -61,6 +61,7 @@ nRF9160
     * Added the option to use the P-GPS API independent of nRF Cloud MQTT transport.
     * Implemented functionality for the :c:enumerator:`NRF_CLOUD_EVT_SENSOR_DATA_ACK` event. The event is now generated when a valid tag value (NCT_MSG_ID_USER_TAG_BEGIN through NCT_MSG_ID_USER_TAG_END) is provided with the sensor data when calling either :c:func:`nrf_cloud_sensor_data_send` or :c:func:`nrf_cloud_shadow_update`.
     * Updated :c:func:`nrf_cloud_shadow_update` to expect that ``param->data.ptr`` points to a JSON string. Previously, a cJSON object was expected.
+    * Updated :c:func:`nct_init` to perform FOTA initialization before setting the client ID. This fixes an issue that prevented an expected reboot during a modem FOTA update.
 
   * :ref:`serial_lte_modem` application:
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -994,11 +994,9 @@ int nct_init(const char * const client_id)
 {
 	int err;
 
-	err = nct_client_id_set(client_id);
-	if (err) {
-		return err;
-	}
-
+	/* Perform settings and FOTA init first so that pending updates
+	 * can be completed
+	 */
 	err = nct_settings_init();
 	if (err) {
 		return err;
@@ -1013,6 +1011,10 @@ int nct_init(const char * const client_id)
 		nct_save_session_state(0);
 	}
 #endif
+	err = nct_client_id_set(client_id);
+	if (err) {
+		return err;
+	}
 
 	dc_endpoint_reset();
 


### PR DESCRIPTION
FOTA should be initialized first so that pending updates can be completed.
NCSDK-11236

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>