### PR TITLE
manifest: update sdk-zephyr to include docs on CMake 3.20.0 install

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ebddd97c4d395bddc381a2a8edcc8f1a66dbeb4a
+      revision: a64e96d17cc741937a8f5ff01a824ef0df22f662
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit updates the manifest file to point to sdk-zephyr revision
sdk-zephyr:pull/615/head

This update brings in the changes to Zephyr Getting started guide on how
to update CMake to version 3.20 or newer.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>