### PR TITLE
samples: Fix samples with missing integration_platforms

### DIFF
--- a/samples/bluetooth/alexa_gadget/sample.yaml
+++ b/samples/bluetooth/alexa_gadget/sample.yaml
@@ -5,4 +5,7 @@ tests:
   samples.bluetooth.alexa_gadget:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52810
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52810
     tags: bluetooth ci_build

--- a/samples/bluetooth/enocean/sample.yaml
+++ b/samples/bluetooth/enocean/sample.yaml
@@ -5,4 +5,8 @@ tests:
   samples.bluetooth.enocean:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/hci_lpuart/sample.yaml
+++ b/samples/bluetooth/hci_lpuart/sample.yaml
@@ -4,4 +4,6 @@ sample:
 tests:
   sample.bluetooth.hci_lpuart:
     platform_allow: nrf9160dk_nrf52840
+    integration_platforms:
+      - nrf9160dk_nrf52840
     tags: uart bluetooth

--- a/samples/bluetooth/llpm/sample.yaml
+++ b/samples/bluetooth/llpm/sample.yaml
@@ -6,4 +6,8 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf52840dongle_nrf52840
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf52840dongle_nrf52840
     tags: bluetooth ci_build

--- a/samples/crypto/psa_tls/sample.yaml
+++ b/samples/crypto/psa_tls/sample.yaml
@@ -6,4 +6,10 @@ tests:
     samples.psa_tls:
         build_only: true
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
+        integration_platforms:
+            - nrf5340dk_nrf5340_cpuapp_ns
+            - nrf5340dk_nrf5340_cpuapp
+            - nrf9160dk_nrf9160_ns
+            - nrf9160dk_nrf9160
+            - nrf52840dk_nrf52840
         tags: ci_build

--- a/samples/esb/prx/sample.yaml
+++ b/samples/esb/prx/sample.yaml
@@ -6,7 +6,18 @@ tests:
     tags: samples console
     harness: keyboard
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52810
   samples.esb.prx.build:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52810
+      - nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/esb/ptx/sample.yaml
+++ b/samples/esb/ptx/sample.yaml
@@ -6,7 +6,18 @@ tests:
     tags: samples console
     harness: keyboard
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52810
   samples.esb.ptx.build:
     build_only: true
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52810
+      - nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/mpsl/timeslot/sample.yaml
+++ b/samples/mpsl/timeslot/sample.yaml
@@ -5,4 +5,8 @@ tests:
   samples.mpsl.timeslot:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/nfc/record_text/sample.yaml
+++ b/samples/nfc/record_text/sample.yaml
@@ -5,4 +5,9 @@ tests:
   samples.nfc.record_text:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: ci_build

--- a/samples/nfc/system_off/sample.yaml
+++ b/samples/nfc/system_off/sample.yaml
@@ -5,4 +5,9 @@ tests:
   samples.nfc.system_off:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: ci_build

--- a/samples/nfc/tag_reader/sample.yaml
+++ b/samples/nfc/tag_reader/sample.yaml
@@ -5,4 +5,8 @@ tests:
   samples.nfc.tag_reader:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/nfc/tnep_poller/sample.yaml
+++ b/samples/nfc/tnep_poller/sample.yaml
@@ -5,4 +5,8 @@ tests:
   samples.nfc.tnep_poller:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/nfc/tnep_tag/sample.yaml
+++ b/samples/nfc/tnep_tag/sample.yaml
@@ -5,4 +5,9 @@ tests:
   samples.nfc.tnep_tag:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: ci_build

--- a/samples/nfc/writable_ndef_msg/sample.yaml
+++ b/samples/nfc/writable_ndef_msg/sample.yaml
@@ -5,4 +5,9 @@ tests:
   samples.nfc.writable_ndef_msg:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: ci_build

--- a/samples/nrf5340/empty_app_core/sample.yaml
+++ b/samples/nrf5340/empty_app_core/sample.yaml
@@ -5,4 +5,6 @@ tests:
   samples.nrf5340.empty_app_core.build:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/nrf9160/memfault/sample.yaml
+++ b/samples/nrf9160/memfault/sample.yaml
@@ -4,6 +4,9 @@ tests:
   samples.nrf9160.memfault:
     build_only: true
     platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+      - thingy91_nrf9160_ns
     tags: ci_build
     extra_configs:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="dummy-key"

--- a/samples/nrf_rpc/entropy_nrf53/cpuapp/sample.yaml
+++ b/samples/nrf_rpc/entropy_nrf53/cpuapp/sample.yaml
@@ -5,3 +5,5 @@ tests:
   samples.nrf_rpc.entropy_cpuapp:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp

--- a/samples/nrf_rpc/entropy_nrf53/cpunet/sample.yaml
+++ b/samples/nrf_rpc/entropy_nrf53/cpunet/sample.yaml
@@ -5,3 +5,5 @@ tests:
   samples.nrf_rpc.entropy_cpunet:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet

--- a/samples/peripheral/lpuart/sample.yaml
+++ b/samples/peripheral/lpuart/sample.yaml
@@ -6,12 +6,26 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf9160dk_nrf9160
                     nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52833dk_nrf52833
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
     tags: ci_build
 
   samples.peripheral.lpuart_int_driven:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf9160dk_nrf9160
                     nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52833dk_nrf52833
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
     tags: ci_build
     extra_configs:
       - CONFIG_NRF_SW_LPUART_INT_DRIVEN=y

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -5,4 +5,8 @@ tests:
   samples.peripheral.radio_test:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/sensor/bh1749/sample.yaml
+++ b/samples/sensor/bh1749/sample.yaml
@@ -5,4 +5,6 @@ tests:
     harness: sensor
     tags: sensors
     platform_allow: thingy91_nrf9160
+    integration_platforms:
+      - thingy91_nrf9160
     depends_on: i2c


### PR DESCRIPTION
Add a list of integration_platfoms to samples that are still
missing it. This is an important fix for proper and complying with
the workflow operation of the sdk-nrf CI. Samples without this list
leave a lot of noise in the result reports as Twister sets the
scope for them to all Zephyr's platforms (~400) and then filters
the vast majority of them resulting in a huge amount of skips in
the results. It is also crucial to assure that the listed
platforms will not get skipped.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>