### PR TITLE
manifest: Pull in Bluetooth Mesh bugfixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.6.99-ncs1-rc2
+      revision: ebddd97c4d395bddc381a2a8edcc8f1a66dbeb4a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pulls in nrfconnect/sdk-zephyr#616 to fix upstream mesh bugs related to
qualification.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>