### PR TITLE
doc improvement: Fix "Toolchain manager" capitalization

### DIFF
--- a/doc/nrf/gs_assistant.rst
+++ b/doc/nrf/gs_assistant.rst
@@ -20,23 +20,23 @@ See :ref:`gs_recommended_versions` for information on the supported operating sy
 
 .. _gs_app_tcm:
 
-Toolchain manager
+Toolchain Manager
 *****************
 
-The Toolchain manager app is available for Windows and macOS.
+The Toolchain Manager app is available for Windows and macOS.
 It installs the full toolchain that you need to work with the |NCS|, including SEGGER Embedded Studio and the |NCS| source code.
 
 
-Installing the Toolchain manager
+Installing the Toolchain Manager
 ================================
 
-To install the Toolchain manager app, complete the following steps:
+To install the Toolchain Manager app, complete the following steps:
 
 .. _tcm_setup:
 
 1. `Download nRF Connect for Desktop`_ for your operating system.
 #. Install and run the tool on your machine.
-#. In the APPS section, click :guilabel:`Install` next to Toolchain manager.
+#. In the APPS section, click :guilabel:`Install` next to Toolchain Manager.
 
 The app is installed on your machine, and the :guilabel:`Install` button changes to :guilabel:`Open`.
 
@@ -45,12 +45,12 @@ The app is installed on your machine, and the :guilabel:`Install` button changes
 Installing the |NCS|
 ====================
 
-Once you have installed the Toolchain manager, open it in nRF Connect for Desktop.
+Once you have installed the Toolchain Manager, open it in nRF Connect for Desktop.
 
 .. figure:: images/gs-assistant_tm.png
-   :alt: The Toolchain manager window
+   :alt: The Toolchain Manager window
 
-   The Toolchain manager window
+   The Toolchain Manager window
 
 Click :guilabel:`Settings` in the navigation bar to specify where you want to install the |NCS|.
 Then, in :guilabel:`SDK Environments`, click the :guilabel:`Install` button next to the |NCS| version that you want to install.
@@ -62,13 +62,13 @@ There are two ways you can build an application:
 #. To build on the command line, use the following steps:
 
    1. With admin permissions enabled, download and install the `nRF Command Line Tools`_.
-   #. Restart the Toolchain manager application.
+   #. Restart the Toolchain Manager application.
    #. Follow the instructions in :ref:`gs_programming_cmd`.
 
 .. figure:: images/gs-assistant_tm_dropdown.png
-   :alt: The Toolchain manager dropdown menu for the installed nRF Connect SDK version, cropped
+   :alt: The Toolchain Manager dropdown menu for the installed nRF Connect SDK version, cropped
 
-   The Toolchain manager dropdown menu options
+   The Toolchain Manager dropdown menu options
 
 .. _gs_app_gsa:
 

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -49,7 +49,7 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
      The drop-down list contains the current version of all |NCS| installation directories that SES knows about.
      To add a missing |NCS| installation directory to that list, run ``west zephyr-export`` in the installation repository or define the Zephyr base to point to the directory (see :ref:`setting_up_SES`).
-   * :guilabel:`nRF Connect Toolchain Version` - If you used the Toolchain manager to install the |NCS|, select the version of the toolchain that works with the selected |NCS| version.
+   * :guilabel:`nRF Connect Toolchain Version` - If you used the Toolchain Manager to install the |NCS|, select the version of the toolchain that works with the selected |NCS| version.
      Otherwise, select NONE and make sure that your SES environment is configured correctly (see :ref:`setting_up_SES`).
 
      .. note::

--- a/doc/nrf/gs_recommended_versions.rst
+++ b/doc/nrf/gs_recommended_versions.rst
@@ -35,7 +35,7 @@ It lists the minimum version that is required and the version that is installed 
 
          * - Tool
            - Minimum version
-           - Toolchain manager version
+           - Toolchain Manager version
          * - CMake
            - |cmake_min_ver|
            - |cmake_recommended_ver_win10|
@@ -119,7 +119,7 @@ It lists the minimum version that is required and the version that is installed 
 
          * - Tool
            - Minimum version
-           - Toolchain manager version
+           - Toolchain Manager version
          * - CMake
            - |cmake_min_ver|
            - |cmake_recommended_ver_darwin|
@@ -158,7 +158,7 @@ The following table shows the Python packages that are required for working with
 If no version is specified, the default version provided with pip is recommended.
 If a version is specified, it is important that the installed version matches the required version.
 
-The :ref:`gs_app_tcm` will install all Python dependencies into a local environment in the Toolchain manager app, not the system.
+The :ref:`gs_app_tcm` will install all Python dependencies into a local environment in the Toolchain Manager app, not the system.
 If you install manually, see :ref:`additional_deps` for instructions on how to install the Python dependencies and :ref:`gs_updating` for information about how to keep them updated.
 
 Building and running applications, samples, and tests

--- a/doc/nrf/gs_updating.rst
+++ b/doc/nrf/gs_updating.rst
@@ -107,7 +107,7 @@ Whenever you update to a newer release of the |NCS|, check the :ref:`gs_recommen
 
       To update to the latest version of the SES Nordic Edition, use one of the following options:
 
-      * Install the latest version of Toolchain manager as described in :ref:`gs_assistant`.
+      * Install the latest version of Toolchain Manager as described in :ref:`gs_assistant`.
       * Install the SES Nordic Edition manually as described in :ref:`installing_ses`.
 
       Then, :ref:`set up the build environment in SES <setting_up_SES>` again.


### PR DESCRIPTION
ref: NCSDK-11084

Correct the capitalization of "Toolchain manager" to "Toolchain Manager"

Signed-off-by: Deidre Casey <deidre.casey@nordicsemi.no>