### PR TITLE
cmake: bump minimal NCS Toolchain version to 1.7.0

### DIFF
--- a/share/ncs-package/cmake/NcsConfig.cmake
+++ b/share/ncs-package/cmake/NcsConfig.cmake
@@ -2,7 +2,7 @@
 set(NRF_RELATIVE_DIR "../../..")
 set(NCS_RELATIVE_DIR "../../../..")
 
-set(NCS_TOOLCHAIN_MINIMUM_REQUIRED 1.5.99)
+set(NCS_TOOLCHAIN_MINIMUM_REQUIRED 1.7.0)
 
 # Set the current NRF_DIR
 # The use of get_filename_component ensures that the final path variable will not contain `../..`.


### PR DESCRIPTION
With nRF Connect SDK 1.7.0 the CMake minimum required version increased
to 3.20. This means that only the latest NCS Toolchain will now work.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>