### PR TITLE
TF-M: Add SECURE_UART1 Kconfig option

### DIFF
--- a/modules/tfm/tfm/boards/CMakeLists.txt
+++ b/modules/tfm/tfm/boards/CMakeLists.txt
@@ -23,9 +23,19 @@ set(board_includes
 
 target_include_directories(platform_region_defs INTERFACE ${partition_includes})
 
+target_compile_definitions(platform_s
+  PRIVATE
+  $<$<BOOL:${PLATFORM_DUMMY_CRYPTO_KEYS}>:PLATFORM_DUMMY_CRYPTO_KEYS>
+  )
+
 target_include_directories(platform_s
   PUBLIC ${partition_includes} ${board_includes}
   ${NRF_DIR}/include
+  )
+
+target_sources(platform_s
+  PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/common/plat_init.c
   )
 
 if (${TFM_PARTITION_CRYPTO}
@@ -36,7 +46,6 @@ if (${TFM_PARTITION_CRYPTO}
       ${NRF_DIR}/lib/hw_unique_key/hw_unique_key.c
       ${NRF_DIR}/lib/hw_unique_key/hw_unique_key_kmu.c
       ${CMAKE_CURRENT_LIST_DIR}/common/crypto_keys.c
-      ${CMAKE_CURRENT_LIST_DIR}/common/plat_init.c
   )
 endif()
 

--- a/modules/tfm/tfm/boards/common/plat_init.c
+++ b/modules/tfm/tfm/boards/common/plat_init.c
@@ -16,8 +16,15 @@
 enum tfm_hal_status_t tfm_hal_platform_init(void)
 {
 	__enable_irq();
-	stdio_init();
 
+	/* Only if UART1 is used by TF-M do we initialize it. */
+#ifdef SECURE_UART1
+	stdio_init();
+#endif
+
+#if defined(TFM_PARTITION_CRYPTO) && \
+    !defined(TFM_CRYPTO_KEY_DERIVATION_MODULE_DISABLED) && \
+    !defined(PLATFORM_DUMMY_CRYPTO_KEYS)
 	/* Initialize the nrf_cc3xx runtime */
 	int result = nrf_cc3xx_platform_init();
 	if (result != NRF_CC3XX_PLATFORM_SUCCESS) {
@@ -29,6 +36,7 @@ enum tfm_hal_status_t tfm_hal_platform_init(void)
 		hw_unique_key_write_random();
 		SPMLOG_INFMSG("Success\r\n");
 	}
+#endif
 
 	return TFM_HAL_SUCCESS;
 }

--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -37,6 +37,16 @@ if (CONFIG_SETTINGS_FCB OR CONFIG_SETTINGS_NVS)
   )
 endif()
 
+if (CONFIG_TFM_SECURE_UART1)
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS -DSECURE_UART1=ON
+    )
+else()
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS -DSECURE_UART1=OFF
+    )
+endif()
+
 set_property(GLOBAL PROPERTY
   tfm_PM_HEX_FILE $<TARGET_PROPERTY:tfm,TFM_S_HEX_FILE>
   )
@@ -48,6 +58,7 @@ set_property(TARGET zephyr_property_target
 set_property(TARGET zephyr_property_target
   APPEND PROPERTY TFM_CMAKE_OPTIONS -DZEPHYR_BASE=${ZEPHYR_BASE}
   )
+
 
 if (CONFIG_TFM_MINIMAL)
   set_property(TARGET zephyr_property_target

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -20,6 +20,18 @@ config TFM_BL2
 	bool
 	default n
 
+config TFM_SECURE_UART1
+	bool "TF-M logging on UART1"
+	default y
+	depends on !UART_1_NRF_UARTE
+	depends on !"$(dt_nodelabel_enabled,uart1)"
+	depends on SOC_NRF5340_CPUAPP || SOC_NRF9160
+	help
+	  Reserve the UART1 port for TF-M logging. This makes the UART1
+	  peripheral unavailable to the non-secure application. When this
+	  option is selected the device tree node for UART1 needs to be
+	  disabled for the non-secure application.
+
 config TFM_MINIMAL
 	bool "Use minimal TF-M build"
 	help

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -71,15 +71,6 @@ if (CONFIG_SPM)
   endif()
 endif()
 
-if (CONFIG_BUILD_WITH_TFM AND CONFIG_UART_1_NRF_UARTE)
-  message(FATAL_ERROR "
-    Non-secure applications built with TF-M cannot use UART1, because this
-    instance is used by the TF-M secure application. Disable the uart1 node
-    in devicetree. See the following file:
-    nrf/samples/tfm/tfm_hello_world/boards/nrf9160dk_nrf9160_ns.overlay
-    for an example how to do it.")
-endif()
-
 if (CONFIG_SECURE_BOOT)
   if (CONFIG_SOC_NRF5340_CPUNET)
     # Share some information which is used when generating the zip file

--- a/west.yml
+++ b/west.yml
@@ -103,11 +103,11 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: b236d8c96fcd648f3c1c3654c9348e385343b645
+      revision: 8103747515ab31a554fa95c755e52d0d6af833f7
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm
-      revision: ca81d4a7c1dff40f214df7b8d99b6ac78e330049
+      revision: d2e93153863e7add9fae3849faf7de430258c0de
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
-This adds a Kconfig configuration option for SECURE_UART1
 option of TF-M

Ref: NCSIDB-551
    
Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>