### PR TITLE
applications: serial_lte_modem: add GPIO AT command

### DIFF
--- a/applications/serial_lte_modem/CMakeLists.txt
+++ b/applications/serial_lte_modem/CMakeLists.txt
@@ -30,5 +30,6 @@ add_subdirectory_ifdef(CONFIG_SLM_FTPC src/ftp_c)
 add_subdirectory_ifdef(CONFIG_SLM_MQTTC src/mqtt_c)
 add_subdirectory_ifdef(CONFIG_SLM_HTTPC src/http_c)
 add_subdirectory_ifdef(CONFIG_SLM_TWI src/twi)
+add_subdirectory_ifdef(CONFIG_SLM_GPIO src/gpio)
 
 zephyr_include_directories(src)

--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -133,6 +133,7 @@ rsource "src/ftp_c/Kconfig"
 rsource "src/mqtt_c/Kconfig"
 rsource "src/http_c/Kconfig"
 rsource "src/twi/Kconfig"
+rsource "src/gpio/Kconfig"
 
 module = SLM
 module-str = serial modem

--- a/applications/serial_lte_modem/doc/AT_commands_intro.rst
+++ b/applications/serial_lte_modem/doc/AT_commands_intro.rst
@@ -45,3 +45,4 @@ The modem-specific AT commands are documented in the `nRF91 AT Commands Referenc
    MQTT_AT_commands
    HTTPC_AT_commands
    TWI_AT_commands
+   GPIO_AT_commands

--- a/applications/serial_lte_modem/doc/GPIO_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GPIO_AT_commands.rst
@@ -1,0 +1,164 @@
+.. _SLM_AT_GPIO:
+
+GPIO AT commands
+****************
+
+.. contents::
+   :local:
+   :depth: 2
+
+The following commands list contains AT commands related to the General Purpose Input/Output (GPIO).
+
+Configure GPIO pins function #XGPIOCFG
+======================================
+
+The ``#XGPIOCFG`` command configures the specified GPIO function.
+
+Set command
+-----------
+
+The set command allows you to list all available GPIO instances.
+
+Syntax
+~~~~~~
+
+::
+
+   #XGPIOCFG=<op>,<pin>
+
+The ``<op>`` parameter indicates the function to be configured.
+It accepts the following integer values:
+
+   * ``0`` - Disable GPIO.
+   * ``1`` - Output.
+   * ``21`` - Input using internal pull up register.
+   * ``22`` - Input using internal pull down register.
+
+The ``<pin>`` parameter indicates the GPIO pin to be configured.
+It ranges between ``0`` and ``31``.
+
+Example
+~~~~~~~
+
+Configure GPIO pin 2 as output:
+
+::
+
+   AT#XGPIOCFG=1,2
+   OK
+
+Configure GPIO pin 6 as input pull up:
+
+::
+
+   AT#XGPIOCFG=21,6
+   OK
+
+Read command
+------------
+
+The read command lists any GPIOs configured by the #XGPIOCFG command.
+
+Example
+~~~~~~~
+
+::
+
+    AT#XGPIOCFG?
+
+    #XGPIOCFG
+
+    1,2
+
+    21,6
+    OK
+
+Test command
+------------
+
+The test command is not supported.
+
+
+Access GPIO pins #XGPIO
+=======================
+
+The ``#XGPIO`` command writes, reads, or toggles GPIO pins state.
+
+Set command
+-----------
+
+The set command allows you to write, read, or toggle GPIO pins state.
+
+Syntax
+~~~~~~
+
+::
+
+   #XGPIO=<op>,<pin>[,<value>]
+
+* The ``<op>`` parameter accepts the following integer values:
+
+  * ``0`` - Write output GPIO state.
+  * ``1`` - Read input GPIO state.
+  * ``2`` - Toggle output GPIO state.
+
+* The ``<pin>`` parameter indicates the GPIO pin to be accessed.
+  It ranges between ``0`` and ``31``.
+
+* The ``<value>`` parameter indicates the value to be written to the GPIO pin.
+  It can assume one of the following values:
+
+  * ``0`` - Logic low
+  * ``1`` - Logic high
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+Response example when ``<op>`` values are write and toggle:
+
+::
+
+   OK
+
+Response example when the ``<op>`` value is read:
+
+::
+
+   #XGPIO: <pin>,<value>
+
+Example
+~~~~~~~
+
+Example of a write operation:
+
+::
+
+   AT#XGPIO=0,2,1
+   OK
+
+Example of a read operation:
+
+::
+
+   AT#XGPIO=1,2
+
+   #XGPIO: 2,1
+
+   OK
+
+Example of a toggle operation:
+
+::
+
+   AT#XGPIO=2,2
+   OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.

--- a/applications/serial_lte_modem/src/gpio/CMakeLists.txt
+++ b/applications/serial_lte_modem/src/gpio/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_include_directories(.)
+target_sources_ifdef(CONFIG_SLM_GPIO app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/slm_at_gpio.c)

--- a/applications/serial_lte_modem/src/gpio/Kconfig
+++ b/applications/serial_lte_modem/src/gpio/Kconfig
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+config SLM_GPIO
+	bool "GPIO support in SLM"
+	default y
+	depends on GPIO

--- a/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
+++ b/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <logging/log.h>
+#include <zephyr.h>
+#include <stdio.h>
+#include <drivers/gpio.h>
+#include "slm_util.h"
+#include "slm_at_gpio.h"
+#include "slm_at_host.h"
+
+LOG_MODULE_REGISTER(slm_gpio, CONFIG_SLM_LOG_LEVEL);
+
+/* global variable defined in different resources */
+extern struct at_param_list at_param_list;
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
+
+static const struct device *gpio_dev;
+static sys_slist_t slm_gpios = SYS_SLIST_STATIC_INIT(&slm_gpios);
+
+/* global variable defined in different files */
+extern struct k_work_q slm_work_q;
+
+struct slm_gpio_pin_node {
+	sys_snode_t node;
+	gpio_pin_t pin;
+	uint16_t op;
+};
+
+#define MAX_GPIO_PIN 31
+
+/* Regular GPIO */
+#define SLM_GPIOC_OP_DISABLE 0     /* Disables pin for both input and output. */
+#define SLM_GPIOC_OP_OUT     1     /* Enables pin as output. */
+#define SLM_GPIOC_OP_IN_PU   21    /* Enables pin as input. Use internal pull up resistor. */
+#define SLM_GPIOC_OP_IN_PD   22    /* Enables pin as input. Use internal pull down resistor. */
+
+/**@brief GPIO operations. */
+enum slm_gpio_operations {
+	SLM_GPIO_OP_WRITE,
+	SLM_GPIO_OP_READ,
+	SLM_GPIO_OP_TOGGLE
+};
+
+static gpio_flags_t convert_flags(uint16_t op)
+{
+	gpio_flags_t gpio_flags = UINT32_MAX;
+
+	switch (op) {
+	case SLM_GPIOC_OP_DISABLE:
+		gpio_flags = GPIO_DISCONNECTED;
+		break;
+	case SLM_GPIOC_OP_OUT:
+		gpio_flags = GPIO_OUTPUT;
+		break;
+	case SLM_GPIOC_OP_IN_PU:
+		gpio_flags = GPIO_INPUT | GPIO_PULL_UP;
+		break;
+	case SLM_GPIOC_OP_IN_PD:
+		gpio_flags = GPIO_INPUT | GPIO_PULL_DOWN;
+		break;
+	default:
+		LOG_ERR("Fail to convert gpio flag");
+		break;
+	}
+
+	return gpio_flags;
+}
+
+static int do_gpio_pin_configure_set(uint16_t op, gpio_pin_t pin)
+{
+	int err = 0;
+	gpio_flags_t gpio_flags = 0;
+	struct slm_gpio_pin_node *slm_gpio_pin = NULL, *cur = NULL, *next = NULL;
+	gpio_port_pins_t pin_mask = 0;
+
+	LOG_DBG("op:%hu pin:%hu", op, pin);
+
+	/* Verify pin correctness */
+	if (pin > MAX_GPIO_PIN) {
+		LOG_ERR("Incorrect <pin>: %d", pin);
+		return -EINVAL;
+	}
+
+	/* Convert SLM GPIO flag to zephyr gpio pin configuration flag */
+	gpio_flags = convert_flags(op);
+	if (gpio_flags == UINT32_MAX) {
+		LOG_ERR("Fail to configure pin.");
+		return -EINVAL;
+	}
+
+	err = gpio_pin_configure(gpio_dev, pin, gpio_flags);
+	if (err) {
+		LOG_ERR("GPIO_0 config error: %d", err);
+		return err;
+	}
+
+	/* Trace gpio list */
+	if (sys_slist_peek_head(&slm_gpios) != NULL) {
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&slm_gpios, cur, next, node) {
+			if (cur->pin == pin) {
+				slm_gpio_pin = cur;
+			}
+		}
+	}
+
+	/* Add GPIO node if node does not exist */
+	if (slm_gpio_pin == NULL) {
+		slm_gpio_pin = (struct slm_gpio_pin_node *)
+							k_malloc(sizeof(struct slm_gpio_pin_node));
+		if (slm_gpio_pin == NULL) {
+			return -ENOBUFS;
+		}
+		memset(slm_gpio_pin, 0, sizeof(struct slm_gpio_pin_node));
+		sys_slist_append(&slm_gpios, &slm_gpio_pin->node);
+	}
+
+	slm_gpio_pin->pin = pin;
+	slm_gpio_pin->op = op;
+
+	if (op == SLM_GPIOC_OP_DISABLE) {
+		/* Disable interrupt */
+		err = gpio_pin_interrupt_configure(gpio_dev, pin, GPIO_INT_DISABLE);
+		if (err) {
+			LOG_ERR("Interface pin interrupt config error: %d", err);
+			return err;
+		}
+		/* Remove callback */
+		pin_mask &= ~BIT(pin);
+		/* Remove node in list */
+		sys_slist_find_and_remove(&slm_gpios, &slm_gpio_pin->node);
+		k_free(slm_gpio_pin);
+	}
+
+	return err;
+}
+
+static int do_gpio_pin_configure_read(void)
+{
+	int err = 0;
+	struct slm_gpio_pin_node *cur = NULL, *next = NULL;
+
+	sprintf(rsp_buf, "\r\n#XGPIOCFG\r\n");
+	rsp_send(rsp_buf, strlen(rsp_buf));
+
+	if (sys_slist_peek_head(&slm_gpios) != NULL) {
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&slm_gpios, cur,
+						  next, node) {
+			if (cur) {
+				LOG_DBG("%hu,%hu", cur->op, cur->pin);
+				sprintf(rsp_buf, "%hu,%hu\r\n", cur->op, cur->pin);
+				rsp_send(rsp_buf, strlen(rsp_buf));
+			}
+		}
+	}
+
+	return err;
+}
+
+static int do_gpio_pin_operate(uint16_t op, gpio_pin_t pin, uint16_t value)
+{
+	int ret = 0;
+	struct slm_gpio_pin_node *cur = NULL, *next = NULL;
+
+	if (sys_slist_peek_head(&slm_gpios) != NULL) {
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&slm_gpios, cur, next, node) {
+			if (cur) {
+				if (cur->pin != pin) {
+					continue;
+				}
+				if (op == SLM_GPIO_OP_WRITE) {
+					LOG_DBG("Write pin: %d with value: %d", cur->pin, value);
+					ret = gpio_pin_set(gpio_dev, pin, value);
+					if (ret < 0) {
+						LOG_ERR("Cannot write gpio");
+						return ret;
+					}
+				} else if (op == SLM_GPIO_OP_READ) {
+					ret = gpio_pin_get(gpio_dev, pin);
+					if (ret < 0) {
+						LOG_ERR("Cannot read gpio high");
+						return ret;
+					}
+					LOG_DBG("Read value: %d", ret);
+					sprintf(rsp_buf, "\r\n#XGPIO: %d,%d\r\n", pin, ret);
+					rsp_send(rsp_buf, strlen(rsp_buf));
+				} else if (op == SLM_GPIO_OP_TOGGLE) {
+					LOG_DBG("Toggle pin: %d", cur->pin);
+					ret = gpio_pin_toggle(gpio_dev, pin);
+					if (ret < 0) {
+						LOG_ERR("Cannot toggle gpio");
+						return ret;
+					}
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
+/**@brief handle AT#XGPIOCFG commands
+ *  AT#XGPIOCFG=<op>,<pin>
+ *  AT#XGPIOCFG?
+ *  AT#XGPIOCFG=? Test command not supported
+ */
+int handle_at_gpio_configure(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	uint16_t pin = 0xff, op = 0xff;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		if (err < 0) {
+			LOG_ERR("Fail to get op: %d", err);
+			return err;
+		}
+		err = at_params_unsigned_short_get(&at_param_list, 2, &pin);
+		if (err < 0) {
+			LOG_ERR("Fail to get pin: %d", err);
+			return err;
+		}
+		err = do_gpio_pin_configure_set(op, (gpio_pin_t)pin);
+		break;
+	case AT_CMD_TYPE_READ_COMMAND:
+		err = do_gpio_pin_configure_read();
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief handle AT#XGPIO commands
+ *  AT#XGPIO=<pin>,<op>[,<value>]
+ *  AT#XGPIO? READ command not supported
+ *  AT#XGPIO=? TEST command not supported
+ */
+int handle_at_gpio_operate(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	uint16_t pin = 0xff, op = 0xff, value = 0xff;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		if (err < 0) {
+			LOG_ERR("Fail to get OP code: %d", err);
+			return err;
+		}
+		if (op > SLM_GPIO_OP_TOGGLE) {
+			LOG_ERR("GPIO OP code is out of range: %d", op);
+			return -EINVAL;
+		}
+		err = at_params_unsigned_short_get(&at_param_list, 2, &pin);
+		if (err < 0) {
+			LOG_ERR("Fail to get pin: %d", err);
+			return err;
+		}
+		if (pin > MAX_GPIO_PIN) {
+			LOG_ERR("Incorrect <pin>: %d", pin);
+			return -EINVAL;
+		}
+		if (op == SLM_GPIO_OP_WRITE) {
+			err = at_params_unsigned_short_get(&at_param_list, 3, &value);
+			if (err < 0) {
+				LOG_ERR("Fail to get value: %d", err);
+				return err;
+			}
+			if (value != 1 && value != 0) {
+				LOG_ERR("Fail to set gpio value: %d", value);
+				return -EINVAL;
+			}
+		}
+		err = do_gpio_pin_operate(op, (gpio_pin_t)pin, value);
+		break;
+
+	default:
+		break;
+	}
+	return err;
+}
+
+int slm_at_gpio_init(void)
+{
+	int err = 0;
+
+	gpio_dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
+	if (gpio_dev == NULL) {
+		LOG_ERR("GPIO_0 bind error");
+		err = -EIO;
+	}
+	return err;
+}
+
+int slm_at_gpio_uninit(void)
+{
+	return 0;
+}

--- a/applications/serial_lte_modem/src/gpio/slm_at_gpio.h
+++ b/applications/serial_lte_modem/src/gpio/slm_at_gpio.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef SLM_AT_GPIO_
+#define SLM_AT_GPIO_
+
+/**@file slm_at_gpio.h
+ *
+ * @brief Vendor-specific AT command for GPIO service.
+ * @{
+ */
+
+/**
+ * @brief Initialize GPIO AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_gpio_init(void);
+
+/**
+ * @brief Uninitialize GPIO AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_gpio_uninit(void);
+
+/** @} */
+
+#endif /* SLM_AT_GPIO_ */

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -43,6 +43,9 @@
 #if defined(CONFIG_SLM_TWI)
 #include "slm_at_twi.h"
 #endif
+#if defined(CONFIG_SLM_GPIO)
+#include "slm_at_gpio.h"
+#endif
 
 LOG_MODULE_REGISTER(slm_at, CONFIG_SLM_LOG_LEVEL);
 
@@ -397,6 +400,11 @@ int handle_at_twi_read(enum at_cmd_type cmd_type);
 int handle_at_twi_write_read(enum at_cmd_type cmd_type);
 #endif
 
+#if defined(CONFIG_SLM_GPIO)
+int handle_at_gpio_configure(enum at_cmd_type cmd_type);
+int handle_at_gpio_operate(enum at_cmd_type cmd_type);
+#endif
+
 static struct slm_at_cmd {
 	char *string;
 	slm_at_handler_t handler;
@@ -489,6 +497,12 @@ static struct slm_at_cmd {
 	{"AT#XTWIR", handle_at_twi_read},
 	{"AT#XTWIWR", handle_at_twi_write_read},
 #endif
+
+#if defined(CONFIG_SLM_GPIO)
+	{"AT#XGPIOCFG", handle_at_gpio_configure},
+	{"AT#XGPIO", handle_at_gpio_operate},
+#endif
+
 };
 
 int handle_at_clac(enum at_cmd_type cmd_type)
@@ -605,6 +619,13 @@ int slm_at_init(void)
 		return -EFAULT;
 	}
 #endif
+#if defined(CONFIG_SLM_GPIO)
+	err = slm_at_gpio_init();
+	if (err) {
+		LOG_ERR("GPIO could not be initialized: %d", err);
+		return -EFAULT;
+	}
+#endif
 #if defined(CONFIG_SLM_TWI)
 	err = slm_at_twi_init();
 	if (err) {
@@ -680,6 +701,12 @@ void slm_at_uninit(void)
 	err = slm_at_twi_uninit();
 	if (err) {
 		LOG_ERR("TWI could not be uninit: %d", err);
+	}
+#endif
+#if defined(CONFIG_SLM_GPIO)
+	err = slm_at_gpio_uninit();
+	if (err) {
+		LOG_ERR("GPIO could not be uninit: %d", err);
 	}
 #endif
 }

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -33,6 +33,10 @@ nRF9160
 
 * Updated:
 
+  * :ref:`serial_lte_modem` application:
+
+    * Added new AT commands related to the General Purpose Input/Output (GPIO).
+
   * :ref:`lwm2m_client` sample:
 
     * Added support for Thingy:91.


### PR DESCRIPTION
The GPIO AT commands support configure/read/write/toggle GPIO.
Currently the supported commands are:

AT#XGPIOCFG: Configure GPIO pins as input pin, output pin or custom functions.
AT#XGPIO: Access GPIO pins.

Signed-off-by: Lee <pirun.lee@nordicsemi.no>