### PR TITLE
dfu/pcd: made pcd_network_core_update() optinaly non-blocking

### DIFF
--- a/include/dfu/pcd.h
+++ b/include/dfu/pcd.h
@@ -67,7 +67,7 @@ enum pcd_status {
  *
  * @retval 0 on success, -1 on failure.
  */
-int pcd_network_core_update(const void *src_addr, size_t len);
+int pcd_network_core_update(const void *src_addr, size_t len, bool wait);
 
 /** @brief Lock the RAM section used for IPC with the network core bootloader.
  */

--- a/modules/mcuboot/hooks/nrf53_hooks.c
+++ b/modules/mcuboot/hooks/nrf53_hooks.c
@@ -65,7 +65,7 @@ int boot_read_swap_state_primary_slot_hook(int image_index,
 	return BOOT_HOOK_REGULAR;
 }
 
-int network_core_update(void)
+int network_core_update(bool wait)
 {
 	struct image_header *hdr;
 	static const struct device *mock_flash_dev;
@@ -86,7 +86,7 @@ int network_core_update(void)
 		uint32_t reset_addr = vtable[1];
 
 		if (reset_addr > PM_CPUNET_B0N_ADDRESS) {
-			int rc = pcd_network_core_update(vtable, fw_size);
+			int rc = pcd_network_core_update(vtable, fw_size, wait);
 			return rc;
 		}
 	}
@@ -99,7 +99,7 @@ int boot_copy_region_post_hook(int img_index, const struct flash_area *area,
 		size_t size)
 {
 	if (img_index == NET_CORE_SECONDARY_SLOT) {
-		return network_core_update();
+		return true);
 	}
 
 	return 0;
@@ -109,7 +109,7 @@ int boot_serial_uploaded_hook(int img_index, const struct flash_area *area,
 		size_t size)
 {
 	if (img_index == NET_CORE_VIRTUAL_PRIMARY_SLOT) {
-		return network_core_update();
+		return network_core_update(false);
 	}
 
 	return 0;

--- a/subsys/pcd/src/pcd.c
+++ b/subsys/pcd/src/pcd.c
@@ -131,7 +131,7 @@ static int pcd_cmd_write(const void *data, size_t len, off_t offset)
 	return 0;
 }
 
-int pcd_network_core_update(const void *src_addr, size_t len)
+int pcd_network_core_update(const void *src_addr, size_t len, bool wait)
 {
 	int err;
 
@@ -161,6 +161,13 @@ int pcd_network_core_update(const void *src_addr, size_t len)
 		k_busy_wait(1 * USEC_PER_SEC);
 
 		err = pcd_fw_copy_status_get();
+		if (!wait) {
+			if (err == PCD_STATUS_COPY_FAILED) {
+				return err;
+			}
+
+			return 0;
+		}
 	} while (err == PCD_STATUS_COPY);
 
 	if (err == PCD_STATUS_COPY_FAILED) {

--- a/tests/subsys/pcd/src/main.c
+++ b/tests/subsys/pcd/src/main.c
@@ -22,7 +22,7 @@ static void test_pcd_network_core_update(void)
 	enum pcd_status status;
 	int err;
 
-	err = pcd_network_core_update(&data, sizeof(data));
+	err = pcd_network_core_update(&data, sizeof(data), true);
 	zassert_equal(err, 0, "Unexpected failure");
 
 	status = pcd_fw_copy_status_get();


### PR DESCRIPTION
The function is busy-waiting on network core update finish.
This patch makes wait run-time optional and disables it for MCUboot's
serial recovery hook function.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>