### PR TITLE
application: serial_lte_modem: Support Non-JITP provisioned device

### DIFF
--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -137,15 +137,19 @@ Syntax
 
 The ``<op>`` parameter accepts the following integer values:
 
-* ``0`` - Disconnect from the nRF Cloud service
-* ``1`` - Connect to the nRF Cloud service
+* ``0`` - Disconnect from the nRF Cloud service.
+* ``1`` - Connect to the nRF Cloud service.
+* ``2`` - Send a message in the JSON format to the nRF Cloud service.
 
-The ``<signify>`` parameter accepts the following integer values:
+When ``<op>`` is ``2``, SLM enters ``slm_data_mode``.
 
-* ``0`` - It does not signify the location info to nRF Cloud
-* ``1`` - It does signify the location info to nRF Cloud
+The ``<signify>`` parameter is used only when the ``<op>`` value is ``1``
+It accepts the following integer values:
 
-When not specified, it does not signify the location info to nRF Cloud.
+* ``0`` - It does not signify the location info to nRF Cloud.
+* ``1`` - It does signify the location info to nRF Cloud.
+
+When the ``<signify>`` parameter is not specified, it does not signify the location info to nRF Cloud.
 
 Unsolicited notification
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -157,6 +161,12 @@ Unsolicited notification
 * The ``<ready>`` value indicates whether the nRF Cloud connection is ready or not.
 * The ``<signify>`` value indicates whether the location info will be signified to nRF Cloud or not.
 
+::
+
+   #XNRFCLOUD: <message>
+
+* The ``<message>`` value indicates the nRF Cloud data received when A-GPS, P-GPS, and Cell_Pos are not active.
+
 Example
 ~~~~~~~
 
@@ -166,6 +176,13 @@ Example
 
   OK
   #XNRFCLOUD: 1,0
+
+  AT#XNRFCLOUD=2
+  {"msg":"Hello, nRF Cloud"}
+  OK
+
+  #XNRFCLOUD: {"msg":"Hello"}
+
   AT#XNRFCLOUD=0
 
   AT#XNRFCLOUD: 0,0
@@ -198,10 +215,12 @@ Response syntax
 
 ::
 
-   #XNRFCLOUD: <ready>,<signify>
+   #XNRFCLOUD: <ready>,<signify>,<sec_tag>,<device_id>
 
 * The ``<ready>`` value indicates whether the nRF Cloud connection is ready or not.
 * The ``<signify>`` value indicates whether the location info will be signified to nRF Cloud or not.
+* The ``<sec_tag>`` value indicates the ``sec_tag`` used for accessing nRF Cloud.
+* The ``<device_id>`` value indicates the device ID used for accessing nRF Cloud.
 
 Example
 ~~~~~~~
@@ -210,7 +229,15 @@ Example
 
   AT#XNRFCLOUD?
 
-  #XNRFCLOUD: 1,0
+  #XNRFCLOUD: 1,0,16842753,"nrf-352656106443792"
+
+  OK
+
+::
+
+  AT#XNRFCLOUD?
+
+  #XNRFCLOUD: 1,0,8888,"50503041-3633-4261-803d-1e2b8f70111a"
 
   OK
 
@@ -232,9 +259,9 @@ Example
 
 ::
 
-  AT#XNRFSIGNIFY=?
+  AT#XXNRFCLOUD=?
 
-  #XNRFCLOUD: (1,0),<signify>
+  #XNRFCLOUD: (0,1,2),<signify>
 
   OK
 

--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -300,3 +300,51 @@ Example
 
    AT#XSLMUART=?
    #XSLMUART: (1200,2400,4800,9600,14400,19200,38400,57600,115200,230400,460800,921600,1000000)
+
+
+Device UUID #XUUID
+==================
+
+The ``#XUUID`` command requests the device UUID.
+
+Set command
+-----------
+
+The set command returns the device UUID.
+
+Syntax
+~~~~~~
+
+::
+
+   #XUUID
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XUUID: <device-uuid>
+
+The ``<device-uuid>`` value returns a string indicating the UUID of the device.
+
+Example
+~~~~~~~
+
+::
+
+  AT#XUUID
+
+  #XUUID: 50503041-3633-4261-803d-1e2b8f70111a
+
+  OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.

--- a/applications/serial_lte_modem/doc/slm_data_mode.rst
+++ b/applications/serial_lte_modem/doc/slm_data_mode.rst
@@ -26,6 +26,7 @@ However, the SLM data mode is applied automatically while using the following mo
 * FTP put, uput and mput
 * MQTT publish
 * HTTP request
+* GNSS nRF Cloud send message
 
 Entering data mode
 ==================
@@ -44,6 +45,7 @@ Other examples:
 * ``AT#XFTP="uput"``
 * ``AT#XFTP="mput",<file>``
 * ``AT#XMQTTPUB=<topic>,"",<qos>,<retain>``
+* ``AT#XNRFCLOUD=2``
 
 The SLM application does not send an *OK* response when it enters data mode.
 

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -308,7 +308,17 @@ This application uses the following |NCS| libraries:
 
 * :ref:`at_cmd_parser_readme`
 * :ref:`at_monitor_readme`
+* :ref:`nrf_modem_lib_readme`
+* :ref:`lib_modem_jwt`
 * :ref:`lib_ftp_client`
+* :ref:`sms_readme`
+* :ref:`lib_fota_download`
+* :ref:`lib_download_client`
+* :ref:`cloud_api_readme`
+* :ref:`lib_nrf_cloud`
+* :ref:`lib_nrf_cloud_agps`
+* :ref:`lib_nrf_cloud_pgps`
+* :ref:`lib_nrf_cloud_cell_pos`
 
 It uses the following `sdk-nrfxlib`_ libraries:
 

--- a/applications/serial_lte_modem/prj.conf
+++ b/applications/serial_lte_modem/prj.conf
@@ -85,6 +85,10 @@ CONFIG_DATE_TIME=y
 CONFIG_MODEM_INFO=y
 CONFIG_MODEM_INFO_ADD_DATE_TIME=n
 CONFIG_AT_MONITOR=y
+CONFIG_MODEM_JWT=y
+# Use "nrf-<IMEI>" as the default device_id format
+# Use "<device_uuid>" as the device_id format by below
+#CONFIG_NRF_CLOUD_CLIENT_ID_SRC_INTERNAL_UUID=y
 
 #
 # SLM-specific configurations

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -66,6 +66,13 @@ nRF9160
 
     * Added a possibility to use TF-M and Zephyr Mbed TLS instead of using the offloaded TLS stack in modem.
 
+  * :ref:`serial_lte_modem` application:
+
+    * Added the ``#XUUID`` command to read out the device UUID from the modem.
+    * Added to the ``XNRFCLOUD`` command the following features:
+      * The possibility to send to and receive from nRF Cloud JSON messages in data mode.
+      * The ability to read out the ``sec_tag`` and the UUID of the device.
+
 nRF5
 ====
 


### PR DESCRIPTION
Add #XUUID to read out the device UUID from modem (MFWv1.3.0~)
Add to support those devices provisioned to nRF Cloud by Non-JITP.
Improve #XNRFCONNECT for access testing
.Send JSON message to nrf cloud in datamode
.Receive JSON message from cloud and send URC for it
.In READ command, read out the <sec_tag> and the device_id used
 in accessing nRF Cloud

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>