### PR TITLE
matter: fix Android CHIPTool service resolution

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v1.7.0-rc2
+      revision: a523f2f88a9c51c9503ea4854a2f41a84f861cef
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
The UI could generate two DNS-SD queries at the same time
which on some Android SDK versions results in a failure,
preventing the application to find an IP address of the
controlled device.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>