### PR TITLE
applications: nrf_desktop: Forward boot report doc

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -205,7 +205,7 @@ Every of these reports uses predefined report format and provides the given info
 For example, the mouse motion is forwarded as HID mouse report.
 
 An nRF Desktop device supports the selected subset of the HID input reports.
-For example, the nRF Desktop keyboard reference desing (nrf52kbd_nrf52832) supports HID keyboard report, HID consumer control report and HID system control report.
+For example, the nRF Desktop keyboard reference design (nrf52kbd_nrf52832) supports HID keyboard report, HID consumer control report and HID system control report.
 
 As an example, the following section describes handling HID mouse report data.
 
@@ -296,6 +296,18 @@ The report is used by the :ref:`nrf_desktop_config_channel`.
    The nRF Desktop also uses a dedicated HID output report to forward the :ref:`nrf_desktop_config_channel` data through the nRF Desktop dongle.
    This report is handled using the configuration channel's infrastructure and it can be enabled using :kconfig:`CONFIG_DESKTOP_CONFIG_CHANNEL_OUT_REPORT`.
    See the Kconfig option's help for details about the report.
+
+HID protocols
+-------------
+
+The following HID protocols are supported by nRF Desktop for HID input reports and HID output reports:
+
+* Report protocol - Most widely used in HID devices.
+  When establishing connection, host reads a HID descriptor from the HID device.
+  HID descriptor describes format of HID reports and is used by the host to interpret data exchanged between HID device and host.
+* Boot protocol - Only available for mice and keyboards data.
+  No HID descriptor is used for this HID protocol.
+  Instead, fixed data packet formats must be used to send data between the HID device and the host.
 
 Requirements
 ************

--- a/applications/nrf_desktop/doc/hid_state.rst
+++ b/applications/nrf_desktop/doc/hid_state.rst
@@ -12,7 +12,7 @@ It is responsible for the following operations:
 
 * Aggregating data from user input sources.
 * Tracking state of the HID report subscriptions.
-* Forming the HID reports.
+* Forming the HID reports in either report or boot protocol.
 * Transmitting the HID reports to the right subscriber.
 * Sending :c:struct:`led_event` based on the HID keyboard LED output reports.
 
@@ -31,6 +31,11 @@ Configuration
 
 The |hid_state| is enabled by selecting :kconfig:`CONFIG_DESKTOP_HID_STATE_ENABLE`.
 This module is optional and turned off by default.
+
+To send boot reports, enable the respective Kconfig option:
+
+* :kconfig:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD` - This option enables sending keyboard boot reports.
+* :kconfig:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE` - This option enables sending mouse boot reports.
 
 HID keymap
 ==========

--- a/applications/nrf_desktop/doc/usb_state.rst
+++ b/applications/nrf_desktop/doc/usb_state.rst
@@ -46,7 +46,10 @@ Boot protocol configuration
 If the device is meant to support the boot protocol, set the following options:
 
 #. Enable :kconfig:`CONFIG_USB_HID_BOOT_PROTOCOL`.
-#. Make sure :kconfig:`CONFIG_USB_HID_PROTOCOL_CODE` is set to either the mouse or the keyboard code.
+#. Set the :kconfig:`CONFIG_USB_HID_PROTOCOL_CODE` Kconfig option to one of the following values to use the device for forwarding either the HID boot keyboard or the HID boot mouse reports, respectively:
+
+* If you want to forward HID boot keyboard reports, set the option to ``1``.
+* If you want to forward HID boot mouse reports, set the option to ``2``.
 
 USB device instance configuration
 =================================

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -76,6 +76,8 @@ nRF Desktop
 
   * Updated information about custom build types.
   * Updated documentation for :ref:`nrf_desktop_usb_state`.
+  * Updated documentation with information about forwarding boot reports.
+    See the documenation page of nRF Desktop's :ref:`nrf_desktop_hid_forward` for details.
 
 Zigbee
 ------


### PR DESCRIPTION
Add documentation to Forward HID boot reports in NRF Desktop

Jira: NCSDK-10268

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>