### PR TITLE
mcuboot: hooks: Add version number 0.0.0+0 to ram flash image header

### DIFF
--- a/modules/mcuboot/hooks/nrf53_hooks.c
+++ b/modules/mcuboot/hooks/nrf53_hooks.c
@@ -23,6 +23,15 @@ int boot_read_image_header_hook(int img_index, int slot,
 {
 	if (img_index == 1 && slot == 0) {
 		img_head->ih_magic = IMAGE_MAGIC;
+		img_head->ih_hdr_size = IMAGE_HEADER_SIZE;
+		img_head->ih_load_addr = PM_MCUBOOT_PRIMARY_1_ADDRESS;
+		img_head->ih_img_size = PM_MCUBOOT_PRIMARY_1_SIZE - IMAGE_HEADER_SIZE;
+		img_head->ih_flags = 0;
+		img_head->ih_ver.iv_major = 0;
+		img_head->ih_ver.iv_minor = 0;
+		img_head->ih_ver.iv_revision = 0;
+		img_head->ih_ver.iv_build_num = 0;
+		img_head->_pad1 = 0;
 		return 0;
 	}
 


### PR DESCRIPTION
Since we don't have this information available in the application core
we fake the data returned. So instead of it being uninitialized, we just
set everything to 0. So that it looks more intuitive for the user when
fetching the image version number.

This is mainly to be used for MCUBoot Serial Recovery as I would
expect that the `smp_svr` based samples could at some point use a custom
HCI command to fetch the image version number, build number or hash from
the running network core image.

Ref. NCSDK-11270

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>