### PR TITLE
dfu_target_mcuboot: fix cpp compatibility

### DIFF
--- a/include/dfu/dfu_target_mcuboot.h
+++ b/include/dfu/dfu_target_mcuboot.h
@@ -94,6 +94,10 @@ int dfu_target_mcuboot_write(const void *const buf, size_t len);
  */
 int dfu_target_mcuboot_done(bool successful);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* DFU_TARGET_MCUBOOT_H__ */
 
 /**@} */


### PR DESCRIPTION
Add missing extern block for CPP compatibility

Ref: NCSIDB-454

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>