### PR TITLE
samples: peripheral: lpuart: Fix pin conflicts for nrf21540 DK

### DIFF
--- a/samples/peripheral/lpuart/README.rst
+++ b/samples/peripheral/lpuart/README.rst
@@ -26,8 +26,8 @@ The sample supports the following development kits:
 
 The sample also requires the following pins to be shorted:
 
-* TX (Arduino Digital Pin 10) with RX (Arduino Digital Pin 11)
-* Request Pin (Arduino Digital Pin 12) with Response Pin (Arduino Digital Pin 13)
+* TX (Arduino Digital Pin 10 (4 on nRF21540 DK)) with RX (Arduino Digital Pin 11 (5 on nRF21540 DK))
+* Request Pin (Arduino Digital Pin 12 (6 on nRF21540 DK)) with Response Pin (Arduino Digital Pin 13 (7 on nRF21540 DK))
 
 Additionally, it requires a logic analyzer.
 

--- a/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/peripheral/lpuart/boards/nrf21540dk_nrf52840.overlay
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
 
 &uart1 {
-	rx-pin = <44>;
-	tx-pin = <45>;
+	rx-pin = <37>;
+	tx-pin = <38>;
 	/delete-property/ rts-pin;
 	/delete-property/ cts-pin;
 
@@ -10,8 +10,8 @@
 		compatible = "nordic,nrf-sw-lpuart";
 		status = "okay";
 		label = "LPUART";
-		req-pin = <46>;
-		rdy-pin = <47>;
+		req-pin = <39>;
+		rdy-pin = <40>;
 	};
 };
 


### PR DESCRIPTION
Pins used for LPUART overlapped with SPI for FEM. Updated sample
to use different pins.

Ref. NCSDK-11309

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>