### PR TITLE
net: lib: nrf_cloud: set response pointer only once

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -121,7 +121,12 @@ static void http_response_cb(struct http_response *rsp,
 		rest_ctx = (struct nrf_cloud_rest_context *)user_data;
 	}
 
-	if (rest_ctx && rsp->body_found && rsp->body_start) {
+	/* If the entire HTTP response is not received in a single "recv" call
+	 * then this could be called multiple times, with a different value in
+	 * rsp->body_start. Only set rest_ctx->response once, the first time,
+	 * which will be the start of the body.
+	 */
+	if (rest_ctx && !rest_ctx->response && rsp->body_found && rsp->body_start) {
 		rest_ctx->response = rsp->body_start;
 	}
 


### PR DESCRIPTION
Sometimes the http_response_cb is called multiple times with
a different value for rsp->body_start. Only set the response
pointer the first time, which is the proper start of the body.
NCSDK-11328

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>