### PR TITLE
scripts: bump pillow from 8.1.2 to 8.3.2

### DIFF
--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -56,7 +56,7 @@ mypy==0.800
 mypy-extensions==0.4.3
 naturalsort==1.5.1
 packaging==20.8
-Pillow==8.1.2
+Pillow==8.3.2
 pluggy==0.13.1
 ply==3.11
 prettytable==2.0.0


### PR DESCRIPTION
from dependabot: https://github.com/nrfconnect/sdk-nrf/pull/5552

pillow is not used in test toolchain, only github-actions doc building. 

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>
