### PR TITLE
application: serial_lte_modem: Adapt to new AT command interface

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -16,8 +16,6 @@ config SLM_CUSTOMIZED
 config SLM_AT_MODE
 	bool "Serial LTE Modem by raw AT mode"
 	default y
-	select AT_CMD
-	select AT_NOTIF
 	select AT_CMD_PARSER
 
 config SLM_AT_MAX_PARAM

--- a/applications/serial_lte_modem/README.rst
+++ b/applications/serial_lte_modem/README.rst
@@ -12,6 +12,7 @@ See the subpages for how to use the application, how to extend it, and informati
    :maxdepth: 2
    :caption: Subpages:
 
+   doc/CHANGELOG
    doc/slm_description
    doc/slm_testing
    doc/slm_extending

--- a/applications/serial_lte_modem/doc/CHANGELOG.rst
+++ b/applications/serial_lte_modem/doc/CHANGELOG.rst
@@ -1,0 +1,23 @@
+.. _serial_lte_modem_changelog:
+
+Changelog
+#########
+
+.. contents::
+   :local:
+   :depth: 2
+
+All notable changes to this project after NCSv1.7.0 are documented in this file.
+
+SLM 1.7.99
+**********
+
+* Adapted new AT interface for AT commands by libmodem, remove at_cmd and at_notify.
+
+Limitations
+###########
+
+SLM 1.7.99
+**********
+
+* No <CR><LF> before AT command final result due to no support by modem.

--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -492,9 +492,10 @@ Syntax
 
 The ``<op>`` parameter accepts the following integer values:
 
-* ``0`` - Stop cellular positioning
-* ``1`` - Start cellular positioning in single-cell mode
-* ``2`` - Start cellular positioning in multi-cell mode
+* ``0`` - Stop cellular positioning.
+* ``1`` - Start cellular positioning in single-cell mode.
+* ``2`` - Start cellular positioning in multi-cell mode.
+  To use ``2``, you must issue the ``AT%NCELLMEAS`` command first.
 
 Unsolicited notification
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -532,11 +533,18 @@ Example
   OK
 
   #XCELLPOS: 0,35.455833,139.626111,1094
+
+  AT%NCELLMEAS
+
+  OK
+
+  %NCELLMEAS: 0,"0199F10A","44020","107E",65535,3750,5,49,27,107504,3750,251,33,4,0,475,107,26,14,25,475,58,26,17,25,475,277,24,9,25,475,51,18,1,25
+
   AT#XCELLPOS=2
 
   OK
 
-  #XCELLPOS: 0,35.455833,139.626111,25000
+  #XCELLPOS: 1,35.534999,139.722362,1801
   AT#XCELLPOS=0
 
   OK

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -306,11 +306,9 @@ Dependencies
 
 This application uses the following |NCS| libraries:
 
-* :ref:`at_cmd_readme`
 * :ref:`at_cmd_parser_readme`
-* :ref:`at_notif_readme`
+* :ref:`at_monitor_readme`
 * :ref:`lib_ftp_client`
-* :ref:`supl_client`
 
 It uses the following `sdk-nrfxlib`_ libraries:
 

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -109,7 +109,7 @@ RING_BUF_DECLARE(ftp_data_buf, SLM_MAX_PAYLOAD);
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 void ftp_ctrl_callback(const uint8_t *msg, uint16_t len)
 {

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -62,7 +62,7 @@ static struct slm_httpc_ctx {
 
 /* global variable defined in different resources */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 static struct k_thread httpc_thread;
 #define HTTPC_THREAD_STACK_SIZE       KB(2)

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -61,7 +61,7 @@ static uint8_t pub_msg[MQTT_MESSAGE_BUFFER_LEN];
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 #define THREAD_STACK_SIZE	KB(2)
 #define THREAD_PRIORITY		K_LOWEST_APPLICATION_THREAD_PRIO

--- a/applications/serial_lte_modem/src/slm_at_cmng.c
+++ b/applications/serial_lte_modem/src/slm_at_cmng.c
@@ -36,7 +36,7 @@ enum slm_cmng_type {
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 /**@brief handle AT#XCMNG commands
  *  AT#XCMNG=<opcode>[,<sec_tag>[,<type>[,<content>]]]
@@ -49,7 +49,7 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 	uint16_t op, type;
 	nrf_sec_tag_t sec_tag;
 	uint8_t *content;
-	size_t len = CONFIG_AT_CMD_RESPONSE_MAX_LEN;
+	size_t len = SLM_AT_CMD_RESPONSE_MAX_LEN;
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
@@ -96,7 +96,7 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 				LOG_ERR("Parameter missed");
 				return -EINVAL;
 			}
-			content = k_malloc(CONFIG_AT_CMD_RESPONSE_MAX_LEN);
+			content = k_malloc(SLM_AT_CMD_RESPONSE_MAX_LEN);
 			err = util_string_get(&at_param_list, 4, content,
 						   &len);
 			if (err != 0) {
@@ -120,7 +120,7 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 				LOG_ERR("Not support READ for type: %d", type);
 				return -EPERM;
 			}
-			content = k_malloc(CONFIG_AT_CMD_RESPONSE_MAX_LEN);
+			content = k_malloc(SLM_AT_CMD_RESPONSE_MAX_LEN);
 			err = modem_key_mgmt_read(
 				slm_tls_map_sectag(sec_tag, type),
 				0, content, &len);

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -12,7 +12,6 @@
 #include <drivers/uart.h>
 #include <string.h>
 #include <init.h>
-#include <modem/at_cmd.h>
 #include <modem/at_cmd_parser.h>
 #include <sys/reboot.h>
 #include "ncs_version.h"
@@ -65,7 +64,7 @@ static struct slm_work_info {
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 extern uint16_t datamode_time_limit;
 extern struct uart_config slm_uart;
 
@@ -87,7 +86,7 @@ static void modem_power_off(void)
 	 * Refer to https://infocenter.nordicsemi.com/topic/ps_nrf9160/
 	 * pmu.html?cp=2_0_0_4_0_0_1#system_off_mode
 	 */
-	(void)at_cmd_write("AT+CFUN=0", NULL, 0, NULL);
+	(void)nrf_modem_at_printf("AT+CFUN=0");
 	k_sleep(K_SECONDS(1));
 }
 

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -47,7 +47,7 @@ int slm_setting_fota_init(void);
 int slm_setting_fota_save(void);
 
 /* global variable defined in different files */
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 extern struct at_param_list at_param_list;
 extern uint8_t fota_stage;
 extern uint8_t fota_status;

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -15,8 +15,9 @@
 
 #include <zephyr/types.h>
 #include <ctype.h>
+#include <nrf_modem_at.h>
+#include <modem/at_monitor.h>
 #include <modem/at_cmd_parser.h>
-#include <modem/at_cmd.h>
 #include "slm_defines.h"
 
 /**@brief Operations in datamode. */

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -45,7 +45,7 @@ static struct k_work ping_work;
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 static inline void setip(uint8_t *buffer, uint32_t ipaddr)
 {

--- a/applications/serial_lte_modem/src/slm_at_sms.c
+++ b/applications/serial_lte_modem/src/slm_at_sms.c
@@ -26,7 +26,7 @@ static int sms_handle;
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 static void sms_callback(struct sms_data *const data, void *context)
 {

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -58,7 +58,7 @@ static struct {
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 /* forward declarations */
 #define SOCKET_SEND_TMO_SEC      30

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -50,7 +50,7 @@ static struct tcp_proxy {
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 /** forward declaration of thread function **/
 static void tcpcli_thread_func(void *p1, void *p2, void *p3);

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -56,7 +56,7 @@ static struct udp_proxy {
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 /** forward declaration of thread function **/
 static void udp_thread_func(void *p1, void *p2, void *p3);

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -13,6 +13,8 @@
 #define INVALID_SEC_TAG      -1
 #define INVALID_ROLE         -1
 
+#define SLM_AT_CMD_RESPONSE_MAX_LEN 2100 /** re-define CONFIG_AT_CMD_RESPONSE_MAX_LEN */
+
 #define SLM_MAX_URL          128  /** max size of URL string */
 #define SLM_MAX_USERNAME     32   /** max size of username in login */
 #define SLM_MAX_PASSWORD     32   /** max size of password in login */

--- a/applications/serial_lte_modem/src/slm_util.c
+++ b/applications/serial_lte_modem/src/slm_util.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <net/socket.h>
 #include <modem/at_cmd_parser.h>
+#include "slm_at_host.h"
 #include "slm_util.h"
 
 /* global variable defined in different files */
@@ -157,54 +158,36 @@ int util_string_get(const struct at_param_list *list, size_t index, char *value,
  */
 void util_get_ip_addr(int cid, char *addr4, char *addr6)
 {
-	int err;
-	char buf[128];
+	int ret;
+	char cmd[128];
 	char tmp[sizeof(struct in6_addr)];
-	char addr[NET_IPV6_ADDR_LEN];
-	size_t addr_len;
+	char addr1[NET_IPV6_ADDR_LEN] = { 0 };
+	char addr2[NET_IPV6_ADDR_LEN] = { 0 };
 
-	sprintf(buf, "AT+CGPADDR=%d", cid);
-	err = at_cmd_write(buf, buf, sizeof(buf), NULL);
-	if (err) {
-		return;
-	}
-
+	sprintf(cmd, "AT+CGPADDR=%d", cid);
 	/** parse +CGPADDR: <cid>,<PDP_addr_1>,<PDP_addr_2>
-	 * PDN type "IP": PDP_addr_1 is <IPv4>
-	 * PDN type "IPV6": PDP_addr_1 is <IPv6>
+	 * PDN type "IP": PDP_addr_1 is <IPv4>, max 16(INET_ADDRSTRLEN), '.' and digits
+	 * PDN type "IPV6": PDP_addr_1 is <IPv6>, max 46(INET6_ADDRSTRLEN),':', digits, 'A'~'F'
 	 * PDN type "IPV4V6": <IPv4>,<IPv6> or <IPV4> or <IPv6>
 	 */
-	at_params_list_clear(&at_param_list);
-	err = at_parser_params_from_str(buf, NULL, &at_param_list);
-	if (err) {
+	ret = nrf_modem_at_scanf(cmd, "+CGPADDR: %*d,\"%46[.:0-9A-F]\",\"%46[:0-9A-F]\"",
+				 addr1, addr2);
+	if (ret <= 0) {
 		return;
 	}
-
-	/* parse first IP string, could be IPv4 or IPv6 */
-	addr_len = NET_IPV6_ADDR_LEN;
-	err = util_string_get(&at_param_list, 2, addr, &addr_len);
-	if (err) {
-		return;
-	}
-	if (addr4 != NULL && inet_pton(AF_INET, addr, tmp) == 1) {
-		strcpy(addr4, addr);
-	} else if (addr6 != NULL && inet_pton(AF_INET6, addr, tmp) == 1) {
-		strcpy(addr6, addr);
+	if (addr4 != NULL && inet_pton(AF_INET, addr1, tmp) == 1) {
+		strcpy(addr4, addr1);
+	} else if (addr6 != NULL && inet_pton(AF_INET6, addr1, tmp) == 1) {
+		strcpy(addr6, addr1);
 		return;
 	}
 	/* parse second IP string, IPv6 only */
 	if (addr6 == NULL) {
 		return;
 	}
-	addr_len = NET_IPV6_ADDR_LEN;
-	err = util_string_get(&at_param_list, 3, addr, &addr_len);
-	if (err) {
-		return;
+	if (ret > 1 && inet_pton(AF_INET6, addr2, tmp) == 1) {
+		strcpy(addr6, addr2);
 	}
-	if (inet_pton(AF_INET6, addr, tmp) == 1) {
-		strcpy(addr6, addr);
-	}
-	/* only parse addresses from primary PDN */
 }
 
 int util_str_to_int(const char *str_buf, int base, int *output)

--- a/applications/serial_lte_modem/src/slm_util.h
+++ b/applications/serial_lte_modem/src/slm_util.h
@@ -16,7 +16,6 @@
 #include <zephyr/types.h>
 #include <ctype.h>
 #include <stdbool.h>
-#include <modem/at_cmd.h>
 #include <modem/at_cmd_parser.h>
 
 /**

--- a/applications/serial_lte_modem/src/twi/slm_at_twi.c
+++ b/applications/serial_lte_modem/src/twi/slm_at_twi.c
@@ -35,7 +35,7 @@ static uint8_t twi_data[TWI_DATA_LEN * 2 + 1];
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 static void do_twi_list(void)
 {


### PR DESCRIPTION
From libmodem v1.3.0 libmodem has a new AT command interface.
Remove the usage of lib_at_cmd and lib_at_notify.
Use at_monitor to receive modem AT notifications.

Impact on GNSS/MCELL service:
- Requires MCU to issue %NCELLMEAS instead of by SLM now
- at_monitor for %NCELLMEAS start/stop with nRF Cloud connect
Added CHANGELOG.rst to record updates from now on

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>