### PR TITLE
net: openthread: increase ot_radio_workq stack size

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -60,8 +60,8 @@ config OPENTHREAD_THREAD_STACK_SIZE
 
 config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	int "OpenThread radio transmit workqueue stack size"
-	default 796 if SOC_NRF5340_CPUAPP
-	default 736
+	default 1084 if SOC_NRF5340_CPUAPP
+	default 1024
 
 endmenu
 


### PR DESCRIPTION
This commit increases ot_radio_workq stack size since the current value
is not enought for working in stress environment.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>

KRKNWK-11263