### PR TITLE
samples: openthread: CoAP client asserts at start on nrf21540dk

### DIFF
--- a/samples/openthread/coap_client/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/openthread/coap_client/boards/nrf21540dk_nrf52840.overlay
@@ -46,6 +46,3 @@
 &usbd {
 	status = "disabled";
 };
-&gpio1 {
-	status = "disabled";
-};


### PR DESCRIPTION
The issue is caused by disabling gpio port 1 by the device tree overlay
in the sample.
Jira: https://projecttools.nordicsemi.no/jira/browse/KRKNWK-11383

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>