### PR TITLE
thingy53: Add cpuappns to platform_exclude

### DIFF
--- a/applications/machine_learning/sample.yaml
+++ b/applications/machine_learning/sample.yaml
@@ -5,6 +5,7 @@ tests:
   applications.machine_learning.zdebug:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 thingy52_nrf52832 thingy53_nrf5340_cpuapp
+    platform_exclude: thingy53_nrf5340_cpuappns
     integration_platforms:
       - nrf52840dk_nrf52840
       - thingy52_nrf52832
@@ -20,6 +21,7 @@ tests:
   applications.machine_learning.zdebug_rtt:
     build_only: true
     platform_allow: thingy53_nrf5340_cpuapp
+    platform_exclude: thingy53_nrf5340_cpuappns
     integration_platforms:
       - thingy53_nrf5340_cpuapp
     tags: ci_build
@@ -27,6 +29,7 @@ tests:
   applications.machine_learning.zrelease:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 thingy52_nrf52832 thingy53_nrf5340_cpuapp
+    platform_exclude: thingy53_nrf5340_cpuappns
     integration_platforms:
       - nrf52840dk_nrf52840
       - thingy52_nrf52832

--- a/applications/machine_learning/sample.yaml
+++ b/applications/machine_learning/sample.yaml
@@ -17,6 +17,13 @@ tests:
       - nrf52840dk_nrf52840
     tags: ci_build
     extra_args: "CMAKE_BUILD_TYPE=ZDebugNUS"
+  applications.machine_learning.zdebug_rtt:
+    build_only: true
+    platform_allow: thingy53_nrf5340_cpuapp
+    integration_platforms:
+      - thingy53_nrf5340_cpuapp
+    tags: ci_build
+    extra_args: "CMAKE_BUILD_TYPE=ZDebugRTT"
   applications.machine_learning.zrelease:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 thingy52_nrf52832 thingy53_nrf5340_cpuapp

--- a/applications/matter_weather_station/sample.yaml
+++ b/applications/matter_weather_station/sample.yaml
@@ -5,6 +5,7 @@ tests:
   applications.matter_weather_station:
     build_only: true
     platform_allow: thingy53_nrf5340_cpuapp
+    platform_exclude: thingy53_nrf5340_cpuappns
     integration_platforms:
       - thingy53_nrf5340_cpuapp
     tags: ci_build

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -6,6 +6,7 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
+    platform_exclude: thingy53_nrf5340_cpuappns
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -6,6 +6,7 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
+    platform_exclude: thingy53_nrf5340_cpuappns
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -14,6 +14,7 @@ tests:
     tags: bluetooth ci_build
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
+    platform_exclude: thingy53_nrf5340_cpuappns
   samples.bluetooth.peripheral_lbs_minimal:
     extra_args: OVERLAY_CONFIG=prj_minimal.conf
     build_only: true

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -7,6 +7,7 @@ tests:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       nrf21540dk_nrf52840
+    platform_exclude: thingy53_nrf5340_cpuappns
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832


### PR DESCRIPTION
Change adds thingy53_nrf5340_cpuappns to platform_exclude for samples and applications that provide support for Thingy:53. The non-secure application core is not yet fully supported.
Change also introduces missing ZDebugRTT configuration to sample.yaml in machine_learning application.

Jira: NCSDK-11377