### PR TITLE
net: lib: azure_iot_hub: add content-type and encoding to messages

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/azure_iot_hub_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/azure_iot_hub_integration.c
@@ -15,15 +15,31 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_CLOUD_INTEGRATION_LOG_LEVEL);
 #define CLIENT_ID_LEN (sizeof(CONFIG_CLOUD_CLIENT_ID) - 1)
 #endif
 
-#define PROP_BAG_COUNT 1
+#define PROP_BAG_CONTENT_TYPE_KEY "$.ct"
+#define PROP_BAG_CONTENT_TYPE_VALUE "application/json"
+#define PROP_BAG_CONTENT_ENCODING_KEY "$.ce"
+#define PROP_BAG_CONTENT_ENCODING_VALUE "utf-8"
+#define PROP_BAG_MESSAGE_ENCODING_COUNT 2
+#define PROP_BAG_BATCH_COUNT 3
 #define PROP_BAG_BATCH "batch"
 
 #define REQUEST_DEVICE_TWIN_STRING ""
 
-static struct azure_iot_hub_prop_bag prop_bag_batch[PROP_BAG_COUNT] = {
-		[0].key = PROP_BAG_BATCH,
-		[0].value = NULL
+static struct azure_iot_hub_prop_bag prop_bag_message_encoding[PROP_BAG_MESSAGE_ENCODING_COUNT] = {
+		[0].key = PROP_BAG_CONTENT_TYPE_KEY,
+		[0].value = PROP_BAG_CONTENT_TYPE_VALUE,
+		[1].key = PROP_BAG_CONTENT_ENCODING_KEY,
+		[1].value = PROP_BAG_CONTENT_ENCODING_VALUE
 };
+static struct azure_iot_hub_prop_bag prop_bag_batch[PROP_BAG_BATCH_COUNT] = {
+		[0].key = PROP_BAG_CONTENT_TYPE_KEY,
+		[0].value = PROP_BAG_CONTENT_TYPE_VALUE,
+		[1].key = PROP_BAG_CONTENT_ENCODING_KEY,
+		[1].value = PROP_BAG_CONTENT_ENCODING_VALUE,
+		[2].key = PROP_BAG_BATCH,
+		[2].value = NULL
+};
+
 static char client_id_buf[CLIENT_ID_LEN + 1];
 static struct azure_iot_hub_config config;
 static cloud_wrap_evt_handler_t wrapper_evt_handler;
@@ -308,7 +324,9 @@ int cloud_wrap_ui_send(char *buf, size_t len)
 		.ptr = buf,
 		.len = len,
 		.qos = MQTT_QOS_0_AT_MOST_ONCE,
-		.topic.type = AZURE_IOT_HUB_TOPIC_EVENT
+		.topic.type = AZURE_IOT_HUB_TOPIC_EVENT,
+		.topic.prop_bag = prop_bag_message_encoding,
+		.topic.prop_bag_count = ARRAY_SIZE(prop_bag_message_encoding)
 	};
 
 	err = azure_iot_hub_send(&msg);


### PR DESCRIPTION
This adds the content-type and encoding to the messages sent by the device.

This is needed to enable message based routing on the cloud side.

See https://azure.microsoft.com/es-es/blog/iot-hub-message-routing-now-with-routing-on-message-body/

Signed-off-by: Markus Tacker <Markus.Tacker@NordicSemi.no>