### PR TITLE
tests: net: fota_download: Change invalid configuration

### DIFF
--- a/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160_ns.conf
+++ b/tests/subsys/net/lib/fota_download/boards/nrf9160dk_nrf9160_ns.conf
@@ -5,4 +5,5 @@
 #
 
 # Disable this since we write our own mock for 'spm_s0_active()'
-CONFIG_SPM_SECURE_SERVICES=n
+CONFIG_SPM_SERVICE_S0_ACTIVE=n
+CONFIG_SPM_SERVICE_BUSY_WAIT=n


### PR DESCRIPTION
Since fota download library depends on the random number generator
service we have to have secure services enabled. So for this we just
disable the s0_actice service so that everything work as intended.

Ref. NCSDK-11388

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>