### PR TITLE
manifest: Update zephyr to use DWT null-pointer detection on nrf5340net

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a64e96d17cc741937a8f5ff01a824ef0df22f662
+      revision: 3ef7602a2f1a4c5655425d9cec7072dc2a2313b5
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This update changes the default null-pointer dereference detection
mechanism to be used for the network core on nRF5340 to DWT-based,
as the MPU-based one cannot be used on this core and causes the
zephyr/tests/arch/arm/arm_interrupt test to fail.

Ref. NCSDK-11348

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>