### PR TITLE
applications: serial_lte_modem: implement Watchdog timer

### DIFF
--- a/applications/serial_lte_modem/CMakeLists.txt
+++ b/applications/serial_lte_modem/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(app PRIVATE src/slm_at_fota.c)
 target_sources_ifdef(CONFIG_SLM_SMS app PRIVATE src/slm_at_sms.c)
 target_sources_ifdef(CONFIG_SLM_NATIVE_TLS app PRIVATE src/slm_native_tls.c)
 target_sources_ifdef(CONFIG_SLM_NATIVE_TLS app PRIVATE src/slm_at_cmng.c)
+target_sources_ifdef(CONFIG_SLM_WATCHDOG app PRIVATE src/slm_watchdog.c)
 
 add_subdirectory_ifdef(CONFIG_SLM_GNSS src/gnss)
 add_subdirectory_ifdef(CONFIG_SLM_FTPC src/ftp_c)

--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -27,6 +27,15 @@ config SLM_AT_MAX_PARAM
 config SLM_NATIVE_TLS
 	bool "Use Zephyr mbedTLS"
 
+config SLM_WATCHDOG
+	bool "Watchdog support in SLM"
+	default y
+	select WATCHDOG
+
+config SLM_WATCHDOG_TIMEOUT_MSEC
+	int "Watchdog timeout in milliseconds"
+	default 60000
+
 #
 # external XTAL for UART
 #

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -213,6 +213,14 @@ Check and configure the following configuration options for the sample:
 
    This option enables additional AT commands for using the TWI service.
 
+.. option:: CONFIG_SLM_WATCHDOG - Watchdog support in SLM
+
+   This option enables Watchdog feature.
+
+.. option:: CONFIG_SLM_WATCHDOG_TIMEOUT_MSEC - Watchdog timeout in milliseconds
+
+   This option specifies Watchdog timeout. If watchdog expired , SLM will reboot and send URC (Unsolicited Result Code) message #WDRESET.
+
 Additional configuration
 ========================
 

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -23,6 +23,9 @@
 #include <drivers/clock_control/nrf_clock_control.h>
 #include "slm_at_host.h"
 #include "slm_at_fota.h"
+#if defined(CONFIG_SLM_WATCHDOG)
+#include "slm_watchdog.h"
+#endif
 
 LOG_MODULE_REGISTER(slm, CONFIG_SLM_LOG_LEVEL);
 
@@ -286,6 +289,10 @@ void start_execute(void)
 	k_work_queue_start(&slm_work_q, slm_wq_stack_area,
 			   K_THREAD_STACK_SIZEOF(slm_wq_stack_area),
 			   SLM_WQ_PRIORITY, NULL);
+#if defined(CONFIG_SLM_WATCHDOG)
+	slm_watchdog_init_and_start();
+#endif
+
 	k_work_init(&exit_idle_work, exit_idle);
 }
 

--- a/applications/serial_lte_modem/src/slm_watchdog.c
+++ b/applications/serial_lte_modem/src/slm_watchdog.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <device.h>
+#include <drivers/watchdog.h>
+#if defined(CONFIG_SLM_WATCHDOG)
+#include "slm_watchdog.h"
+#endif
+#include <logging/log.h>
+#include "slm_util.h"
+
+LOG_MODULE_REGISTER(watchdog, CONFIG_SLM_LOG_LEVEL);
+
+#define WDT_FEED_WORKER_DELAY_MS \
+	((CONFIG_SLM_WATCHDOG_TIMEOUT_MSEC) / 2)
+
+#define WDT_STACK_SIZE       KB(1)
+#define WDT_PRIORITY      K_LOWEST_APPLICATION_THREAD_PRIO
+static K_THREAD_STACK_DEFINE(wdt_stack_area, WDT_STACK_SIZE);
+
+static struct k_work_q wdt_work_q;
+
+struct wdt_data_storage {
+	const struct device *wdt_drv;
+	int wdt_channel_id;
+	struct k_work_delayable workqueue_work;
+};
+static struct wdt_data_storage wdt_data;
+
+static void primary_feed_worker(struct k_work *work_desc)
+{
+	int err = wdt_feed(wdt_data.wdt_drv, wdt_data.wdt_channel_id);
+
+	LOG_DBG("Feeding watchdog");
+
+	if (err) {
+		LOG_ERR("Cannot feed watchdog. Error code: %d", err);
+	} else {
+		k_work_reschedule_for_queue(&wdt_work_q, &wdt_data.workqueue_work,
+			K_MSEC(WDT_FEED_WORKER_DELAY_MS));
+	}
+}
+static int watchdog_timeout_install(struct wdt_data_storage *data)
+{
+	static const struct wdt_timeout_cfg wdt_settings = {
+		.window = {
+			.min = 0,
+			.max = CONFIG_SLM_WATCHDOG_TIMEOUT_MSEC,
+		},
+		.callback = NULL,
+		.flags = WDT_FLAG_RESET_SOC
+	};
+
+	__ASSERT_NO_MSG(data != NULL);
+
+	data->wdt_channel_id = wdt_install_timeout(
+		data->wdt_drv, &wdt_settings);
+	if (data->wdt_channel_id < 0) {
+		LOG_ERR("Cannot install watchdog timer! Error code: %d",
+			data->wdt_channel_id);
+		return -EFAULT;
+	}
+
+	LOG_DBG("Watchdog timeout installed. Timeout: %d",
+		CONFIG_SLM_WATCHDOG_TIMEOUT_MSEC);
+	return 0;
+}
+
+static int watchdog_start(struct wdt_data_storage *data)
+{
+	__ASSERT_NO_MSG(data != NULL);
+
+	int err = wdt_setup(data->wdt_drv, WDT_OPT_PAUSE_HALTED_BY_DBG);
+
+	if (err) {
+		LOG_ERR("Cannot start watchdog! Error code: %d", err);
+	} else {
+		LOG_DBG("Watchdog started");
+	}
+	return err;
+}
+
+static int watchdog_feed_enable(struct wdt_data_storage *data)
+{
+	__ASSERT_NO_MSG(data != NULL);
+
+	k_work_init_delayable(&data->workqueue_work, primary_feed_worker);
+
+	int err = wdt_feed(data->wdt_drv, data->wdt_channel_id);
+
+	if (err) {
+		LOG_ERR("Cannot feed watchdog. Error code: %d", err);
+		return err;
+	}
+	k_work_reschedule_for_queue(&wdt_work_q, &data->workqueue_work,
+				K_MSEC(WDT_FEED_WORKER_DELAY_MS));
+
+	if (err) {
+		LOG_ERR("Cannot start watchdog feed worker!"
+			" Error code: %d", err);
+	} else {
+		LOG_DBG("Watchdog feed enabled. Timeout: %d",
+			WDT_FEED_WORKER_DELAY_MS);
+	}
+	return err;
+}
+
+static int watchdog_enable(struct wdt_data_storage *data)
+{
+	__ASSERT_NO_MSG(data != NULL);
+
+	int err = -ENXIO;
+
+	data->wdt_drv = device_get_binding(DT_LABEL(DT_NODELABEL(wdt)));
+	if (data->wdt_drv == NULL) {
+		LOG_ERR("Cannot bind watchdog driver");
+		return err;
+	}
+
+	err = watchdog_timeout_install(data);
+	if (err) {
+		return err;
+	}
+
+	err = watchdog_start(data);
+	if (err) {
+		return err;
+	}
+
+	err = watchdog_feed_enable(data);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}
+
+int slm_watchdog_init_and_start(void)
+{
+	/* start wdt wq */
+	k_work_queue_start(&wdt_work_q, wdt_stack_area,
+			   K_THREAD_STACK_SIZEOF(wdt_stack_area),
+			   WDT_PRIORITY, NULL);
+	return watchdog_enable(&wdt_data);
+}

--- a/applications/serial_lte_modem/src/slm_watchdog.h
+++ b/applications/serial_lte_modem/src/slm_watchdog.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**@file
+ *
+ * @brief   Watchdog module for serial LTE modem
+ */
+
+#ifndef SLM_WATCHDOG_H__
+#define SLM_WATCHDOG_H__
+
+#include <zephyr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int slm_watchdog_init_and_start(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SLM_WATCHDOG_H__ */


### PR DESCRIPTION
Implement watchdog timer with default 60 seconds. If watchdog timer
expires, RI pin will be toggled in the next boot. Then SLM will
send URC #WDRESET to MCU.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>