### PR TITLE
modules: nrfxlib: nrf_802154: Increase IRQ priorities

### DIFF
--- a/modules/nrfxlib/nrf_802154/CMakeLists.txt
+++ b/modules/nrfxlib/nrf_802154/CMakeLists.txt
@@ -24,6 +24,11 @@ if (CONFIG_NRF_802154_RADIO_DRIVER OR CONFIG_NRF_802154_SERIALIZATION)
   add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR}/nrf_802154 nrf_802154)
   target_link_libraries(nrf-802154-driver-interface INTERFACE zephyr-802154-interface)
   target_link_libraries(nrf-802154-serialization-interface INTERFACE zephyr-802154-interface)
+
+  target_compile_definitions(nrf-802154-driver-interface INTERFACE NRF_802154_ECB_PRIORITY=0)
+  target_compile_definitions(nrf-802154-driver-interface INTERFACE NRF_802154_SWI_PRIORITY=1)
+  target_compile_definitions(nrf-802154-platform PUBLIC NRF_802154_SL_RTC_IRQ_PRIORITY=1)
+
   if (CONFIG_NRF_802154_ENCRYPTION)
     target_compile_definitions(nrf-802154-driver-interface INTERFACE NRF_802154_ENCRYPTION_ENABLED=1)
     target_compile_definitions(nrf-802154-driver-interface INTERFACE NRF_802154_SECURITY_WRITER_ENABLED=1)


### PR DESCRIPTION
This commit elevates priorities of interrupts specific for the nRF
802.15.4 driver, so that application interrupts are no longer capable of
preempting its code.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>