### PR TITLE
application: serial_lte_modem: Support HTTPS session resumption

### DIFF
--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -281,6 +281,7 @@ static int do_http_connect(void)
 	if (httpc.sec_tag != INVALID_SEC_TAG) {
 		sec_tag_t sec_tag_list[] = { httpc.sec_tag };
 		int peer_verify = TLS_PEER_VERIFY_REQUIRED;
+		int session_cache = TLS_SESSION_CACHE_ENABLED;
 
 		ret = setsockopt(httpc.fd, SOL_TLS, TLS_SEC_TAG_LIST, sec_tag_list,
 				 sizeof(sec_tag_t));
@@ -300,6 +301,13 @@ static int do_http_connect(void)
 				 strlen(httpc.host) + 1);
 		if (ret) {
 			LOG_ERR("setsockopt(TLS_HOSTNAME) error: %d", -errno);
+			ret = -errno;
+			goto exit_cli;
+		}
+		ret = setsockopt(httpc.fd, SOL_TLS, TLS_SESSION_CACHE, &session_cache,
+				       sizeof(session_cache));
+		if (ret < 0) {
+			LOG_ERR("setsockopt(TLS_SESSION_CACHE) error: %d", -errno);
 			ret = -errno;
 			goto exit_cli;
 		}


### PR DESCRIPTION
Enable TLS_SESSION_CACHE to support HTTP/TLS session resumption.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>