### PR TITLE
lib: agps: remove GNSS socket support

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -532,7 +532,7 @@ static void send_agps_request(struct k_work *work)
 		agps_request_convert(&request, &agps_request);
 
 		LOG_INF("Sending A-GPS request");
-		err = agps_request_send(request, AGPS_SOCKET_NOT_PROVIDED);
+		err = agps_request_send(request);
 		if (err) {
 			LOG_ERR("Failed to request A-GPS data, error: %d", err);
 		} else {

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -1021,7 +1021,7 @@ static void agps_request_handle(struct nrf_modem_gnss_agps_data_frame *incoming_
 	 * selected as the A-GPS source via the CONFIG_AGPS_SRC_NRF_CLOUD option.
 	 */
 #if defined(CONFIG_AGPS) && (defined(CONFIG_NRF_CLOUD_MQTT) || defined(CONFIG_AGPS_SRC_SUPL))
-	err = agps_request_send(*incoming_request, AGPS_SOCKET_NOT_PROVIDED);
+	err = agps_request_send(*incoming_request);
 	if (err) {
 		LOG_WRN("Failed to request A-GPS data, error: %d", err);
 		LOG_WRN("This is expected to fail if we are not in a connected state");

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -31,12 +31,18 @@ The following sections provide detailed lists of changes by component.
 nRF9160
 =======
 
+* Updated:
+
   * :ref:`lwm2m_client` sample:
 
     * Added support for Thingy:91.
     * Added more LwM2M objects.
     * LwM2M sensor objects now uses the actual sensors available to the Thingy:91. If the nRF9160 DK is used, it uses simulated sensors instead.
     * Added possibility to poll sensors and notify the server if the measured changes are large enough.
+
+  * A-GPS library:
+
+    * Removed GNSS socket API support.
 
 nRF5
 ====

--- a/include/modem/agps.h
+++ b/include/modem/agps.h
@@ -23,20 +23,15 @@
 extern "C" {
 #endif
 
-#define AGPS_SOCKET_NOT_PROVIDED 0
-
 /**
  * @brief Function to send a request for A-GPS data to the configured A-GPS data source. See the
  *        A-GPS library Kconfig documentation for alternatives.
  *
  * @param request Assistance data to request from the A-GPS service.
- * @param socket GNSS socket to which assistance data will be written when it's received from the
- *               selected A-GPS service. If socket argument is set to AGPS_SOCKET_NOT_PROVIDED,
- *               the data will be written using the GPS driver or GNSS API.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
-int agps_request_send(struct nrf_modem_gnss_agps_data_frame request, int socket);
+int agps_request_send(struct nrf_modem_gnss_agps_data_frame request);
 
 /**
  * @brief Processes A-GPS data from the cloud.

--- a/samples/nrf9160/agps/src/main.c
+++ b/samples/nrf9160/agps/src/main.c
@@ -182,7 +182,7 @@ static void on_agps_needed(struct gps_agps_request request)
 
 	agps_request_convert(&agps_request, &request);
 
-	int err = agps_request_send(agps_request, AGPS_SOCKET_NOT_PROVIDED);
+	int err = agps_request_send(agps_request);
 
 	if (err) {
 		LOG_ERR("Failed to request A-GPS data, error: %d", err);


### PR DESCRIPTION
Removed GNSS socket support and updated samples which use the library. Also there's no need anymore to write A-GPS data using the GPS driver, the data can always be written directly using the GNSS API.

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>