### PR TITLE
net: lib: nrf_cloud: remove GNSS socket support

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -431,7 +431,7 @@ static void manage_pgps(struct k_work *work)
 	int err;
 
 	LOG_INF("Sending prediction to modem...");
-	err = nrf_cloud_pgps_inject(prediction, &agps_request, NULL);
+	err = nrf_cloud_pgps_inject(prediction, &agps_request);
 	if (err) {
 		LOG_ERR("Unable to send prediction to modem: %d", err);
 	}

--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -623,7 +623,7 @@ void pgps_handler(struct nrf_cloud_pgps_event *event)
 	case PGPS_EVT_AVAILABLE:
 		LOG_DBG("PGPS_EVT_AVAILABLE");
 
-		err = nrf_cloud_pgps_inject(event->prediction, &agps_request, NULL);
+		err = nrf_cloud_pgps_inject(event->prediction, &agps_request);
 		if (err) {
 			LOG_ERR("Unable to send prediction to modem: %d", err);
 		}

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -354,10 +354,10 @@ static void pgps_event_handler(struct nrf_cloud_pgps_event *event)
 		err = read_agps_req(&req);
 		if (err) {
 			/* All assistance elements as requested */
-			err = nrf_cloud_pgps_inject(event->prediction, &req, NULL);
+			err = nrf_cloud_pgps_inject(event->prediction, &req);
 		} else {
 			/* ephemerides assistance only */
-			err = nrf_cloud_pgps_inject(event->prediction, NULL, NULL);
+			err = nrf_cloud_pgps_inject(event->prediction, NULL);
 		}
 		if (err) {
 			LOG_ERR("Unable to send prediction to modem: %d", err);
@@ -543,7 +543,7 @@ static void on_cloud_evt_data_received(const struct cloud_event *const evt)
 	int err = 0;
 
 	if (run_type == RUN_TYPE_AGPS) {
-		err = nrf_cloud_agps_process(evt->data.msg.buf, evt->data.msg.len, NULL);
+		err = nrf_cloud_agps_process(evt->data.msg.buf, evt->data.msg.len);
 		if (err) {
 			LOG_INF("Unable to process A-GPS data, error: %d", err);
 		}

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -44,6 +44,10 @@ nRF9160
 
     * Removed GNSS socket API support.
 
+  * :ref:`lib_nrf_cloud` library:
+
+    * Removed GNSS socket API support from A-GPS and P-GPS.
+
 nRF5
 ====
 

--- a/include/net/nrf_cloud_agps.h
+++ b/include/net/nrf_cloud_agps.h
@@ -43,12 +43,10 @@ int nrf_cloud_agps_request_all(void);
  *
  * @param buf Pointer to data received from nRF Cloud.
  * @param buf_len Buffer size of data to be processed.
- * @param socket Pointer to GNSS socket to which A-GPS data will be injected.
- *		 If NULL, the nRF9160 GPS driver is used to inject the data.
  *
  * @return 0 if successful, otherwise a (negative) error code.
  */
-int nrf_cloud_agps_process(const char *buf, size_t buf_len, const int *socket);
+int nrf_cloud_agps_process(const char *buf, size_t buf_len);
 
 /**@brief Query which A-GPS elements were actually received
  *

--- a/include/net/nrf_cloud_pgps.h
+++ b/include/net/nrf_cloud_pgps.h
@@ -250,14 +250,11 @@ int nrf_cloud_pgps_process(const char *buf, size_t buf_len);
  *
  * @param p Pointer to a prediction.
  * @param request Which assistance elements the modem needs. May be NULL.
- * @param socket Pointer to GNSS socket to which P-GPS data will be injected.
- * If NULL, the nRF9160 GPS driver is used to inject the data.
  *
  * @return 0 if successful, otherwise a (negative) error code.
  */
 int nrf_cloud_pgps_inject(struct nrf_cloud_pgps_prediction *p,
-			  const struct gps_agps_request *request,
-			  const int *socket);
+			  const struct gps_agps_request *request);
 
 /**@brief Find out if P-GPS update is in progress
  *

--- a/lib/agps/agps.c
+++ b/lib/agps/agps.c
@@ -294,7 +294,7 @@ int agps_cloud_data_process(const uint8_t *buf, size_t len)
 	int err = 0;
 
 #if defined(CONFIG_AGPS_SRC_NRF_CLOUD) && defined(CONFIG_NRF_CLOUD_AGPS)
-	err = nrf_cloud_agps_process(buf, len, NULL);
+	err = nrf_cloud_agps_process(buf, len);
 	if (err) {
 		LOG_ERR("A-GPS failed, error: %d", err);
 		return err;

--- a/samples/nrf9160/agps/src/main.c
+++ b/samples/nrf9160/agps/src/main.c
@@ -62,7 +62,7 @@ static void manage_pgps(struct k_work *work)
 	int err;
 
 	LOG_INF("Sending prediction to modem...");
-	err = nrf_cloud_pgps_inject(prediction, &agps_request, NULL);
+	err = nrf_cloud_pgps_inject(prediction, &agps_request);
 	if (err) {
 		LOG_ERR("Unable to send prediction to modem: %d", err);
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps_utils.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps_utils.c
@@ -7,9 +7,9 @@
 #include <zephyr.h>
 
 #include <net/nrf_cloud_agps.h>
-#include <nrf_socket.h>
+#include <nrf_modem_gnss.h>
 
-static void print_utc(nrf_gnss_agps_data_utc_t *data)
+static void print_utc(struct nrf_modem_gnss_agps_data_utc *data)
 {
 	printk("utc:\n");
 	printk("\ta1: %d\n", data->a1);
@@ -22,7 +22,7 @@ static void print_utc(nrf_gnss_agps_data_utc_t *data)
 	printk("\tdelta_tlsf: %d\n", data->delta_tlsf);
 }
 
-static void print_ephemeris(nrf_gnss_agps_data_ephemeris_t *data)
+static void print_ephemeris(struct nrf_modem_gnss_agps_data_ephemeris *data)
 {
 	printk("ephemeris:\n");
 	printk("\tsv_id: %d\n", data->sv_id);
@@ -53,7 +53,7 @@ static void print_ephemeris(nrf_gnss_agps_data_ephemeris_t *data)
 	printk("\tcuc: %d\n", data->cuc);
 }
 
-static void print_almanac(nrf_gnss_agps_data_almanac_t *data)
+static void print_almanac(struct nrf_modem_gnss_agps_data_almanac *data)
 {
 	printk("almanac\n");
 	printk("\tsv_id: %d\n", data->sv_id);
@@ -72,7 +72,7 @@ static void print_almanac(nrf_gnss_agps_data_almanac_t *data)
 	printk("\taf1: %d\n", data->af1);
 }
 
-static void print_klobuchar(nrf_gnss_agps_data_klobuchar_t *data)
+static void print_klobuchar(struct nrf_modem_gnss_agps_data_klobuchar *data)
 {
 	printk("klobuchar\n");
 	printk("\talpha0: %d\n", data->alpha0);
@@ -85,8 +85,7 @@ static void print_klobuchar(nrf_gnss_agps_data_klobuchar_t *data)
 	printk("\tbeta3: %d\n", data->beta3);
 }
 
-static void print_clock_and_tows(
-	nrf_gnss_agps_data_system_time_and_sv_tow_t *data)
+static void print_clock_and_tows(struct nrf_modem_gnss_agps_data_system_time_and_sv_tow *data)
 {
 	printk("clock_and_tows\n");
 	printk("\tdate_day: %d\n", data->date_day);
@@ -95,14 +94,14 @@ static void print_clock_and_tows(
 	printk("\tsv_mask: 0x%08x\n", data->sv_mask);
 	printk("\tsv_tow\n");
 
-	for (size_t i = 0; i < NRF_GNSS_AGPS_MAX_SV_TOW; i++) {
+	for (size_t i = 0; i < NRF_MODEM_GNSS_AGPS_MAX_SV_TOW; i++) {
 		printk("\t\tsv_tow[%d]\n", i);
 		printk("\t\t\ttlm: %d\n", data->sv_tow[i].tlm);
 		printk("\t\t\tflags: 0x%02x\n", data->sv_tow[i].flags);
 	}
 }
 
-static void print_location(nrf_gnss_agps_data_location_t *data)
+static void print_location(struct nrf_modem_gnss_agps_data_location *data)
 {
 	printk("location\n");
 	printk("\tlatitude: %d\n", data->latitude);
@@ -115,47 +114,47 @@ static void print_location(nrf_gnss_agps_data_location_t *data)
 	printk("\tconfidence: %d\n", data->confidence);
 }
 
-static void print_integrity(nrf_gnss_agps_data_integrity_t *data)
+static void print_integrity(struct nrf_modem_gnss_agps_data_integrity *data)
 {
 	printk("integrity\n");
 	printk("\tintegrity_mask: %d\n", data->integrity_mask);
 }
 
-void agps_print(nrf_gnss_agps_data_type_t type, void *data)
+void agps_print(uint16_t type, void *data)
 {
 
 	switch (type) {
-	case NRF_GNSS_AGPS_UTC_PARAMETERS: {
-		print_utc((nrf_gnss_agps_data_utc_t *)data);
+	case NRF_MODEM_GNSS_AGPS_UTC_PARAMETERS: {
+		print_utc((struct nrf_modem_gnss_agps_data_utc *)data);
 		break;
 	}
-	case NRF_GNSS_AGPS_EPHEMERIDES: {
-		print_ephemeris((nrf_gnss_agps_data_ephemeris_t *)data);
+	case NRF_MODEM_GNSS_AGPS_EPHEMERIDES: {
+		print_ephemeris((struct nrf_modem_gnss_agps_data_ephemeris *)data);
 		break;
 	}
-	case NRF_GNSS_AGPS_ALMANAC: {
-		print_almanac((nrf_gnss_agps_data_almanac_t *)data);
+	case NRF_MODEM_GNSS_AGPS_ALMANAC: {
+		print_almanac((struct nrf_modem_gnss_agps_data_almanac *)data);
 		break;
 	}
-	case NRF_GNSS_AGPS_KLOBUCHAR_IONOSPHERIC_CORRECTION: {
-		print_klobuchar((nrf_gnss_agps_data_klobuchar_t *)data);
+	case NRF_MODEM_GNSS_AGPS_KLOBUCHAR_IONOSPHERIC_CORRECTION: {
+		print_klobuchar((struct nrf_modem_gnss_agps_data_klobuchar *)data);
 		break;
 	}
-	case NRF_GNSS_AGPS_NEQUICK_IONOSPHERIC_CORRECTION: {
+	case NRF_MODEM_GNSS_AGPS_NEQUICK_IONOSPHERIC_CORRECTION: {
 		printk("nequick unhandled\n");
 		break;
 	}
-	case NRF_GNSS_AGPS_GPS_SYSTEM_CLOCK_AND_TOWS: {
+	case NRF_MODEM_GNSS_AGPS_GPS_SYSTEM_CLOCK_AND_TOWS: {
 		print_clock_and_tows(
-			(nrf_gnss_agps_data_system_time_and_sv_tow_t *)data);
+			(struct nrf_modem_gnss_agps_data_system_time_and_sv_tow *)data);
 		break;
 	}
-	case NRF_GNSS_AGPS_LOCATION: {
-		print_location((nrf_gnss_agps_data_location_t *)data);
+	case NRF_MODEM_GNSS_AGPS_LOCATION: {
+		print_location((struct nrf_modem_gnss_agps_data_location *)data);
 		break;
 	}
-	case NRF_GNSS_AGPS_INTEGRITY: {
-		print_integrity((nrf_gnss_agps_data_integrity_t *)data);
+	case NRF_MODEM_GNSS_AGPS_INTEGRITY: {
+		print_integrity((struct nrf_modem_gnss_agps_data_integrity *)data);
 		break;
 	}
 	default:

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -9,8 +9,6 @@
 #include <device.h>
 #include <drivers/gps.h>
 #include <storage/stream_flash.h>
-#include <net/socket.h>
-#include <nrf_socket.h>
 
 #include <cJSON.h>
 #include <cJSON_os.h>
@@ -433,7 +431,7 @@ static void prediction_work_handler(struct k_work *work)
 	ret = nrf_cloud_pgps_find_prediction(&p);
 	if (ret >= 0) {
 		LOG_DBG("found prediction %d; injecting to modem", ret);
-		ret = nrf_cloud_pgps_inject(p, NULL, NULL);
+		ret = nrf_cloud_pgps_inject(p, NULL);
 		if (ret) {
 			LOG_ERR("Error injecting prediction:%d", ret);
 		} else {
@@ -789,8 +787,7 @@ int nrf_cloud_pgps_preemptive_updates(void)
 }
 
 int nrf_cloud_pgps_inject(struct nrf_cloud_pgps_prediction *p,
-			  const struct gps_agps_request *request,
-			  const int *socket)
+			  const struct gps_agps_request *request)
 {
 	int err;
 	int ret = 0;
@@ -848,8 +845,7 @@ int nrf_cloud_pgps_inject(struct nrf_cloud_pgps_prediction *p,
 			/* send time */
 			err = nrf_cloud_agps_process((const char *)&sys_time,
 						     sizeof(sys_time) -
-						     sizeof(sys_time.time.sv_tow),
-						     socket);
+						     sizeof(sys_time.time.sv_tow));
 			if (err) {
 				LOG_ERR("Error injecting P-GPS sys_time (%u, %u): %d",
 					sys_time.time.date_day, sys_time.time.time_full_s,
@@ -886,8 +882,7 @@ int nrf_cloud_pgps_inject(struct nrf_cloud_pgps_prediction *p,
 			saved_location->longitude);
 		/* send location */
 
-		err = nrf_cloud_agps_process((const char *)&location, sizeof(location),
-					     socket);
+		err = nrf_cloud_agps_process((const char *)&location, sizeof(location));
 		if (err) {
 			LOG_ERR("Error injecting P-GPS location (%d, %d): %d",
 				location.location.latitude, location.location.longitude,
@@ -908,7 +903,7 @@ int nrf_cloud_pgps_inject(struct nrf_cloud_pgps_prediction *p,
 					     sizeof(p->schema_version) +
 					     sizeof(p->ephemeris_type) +
 					     sizeof(p->ephemeris_count) +
-					     sizeof(p->ephemerii), socket);
+					     sizeof(p->ephemerii));
 		if (err) {
 			LOG_ERR("Error injecting ephermerii:%d", err);
 			ret = err;


### PR DESCRIPTION
Removed GNSS socket support from nRF Cloud A-GPS and P-GPS. Also there's no need anymore to write A-GPS data using the GPS driver, the data can always be written directly using the GNSS API.

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>