### PR TITLE
JWT cleanup

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -110,6 +110,10 @@ nRF9160
     * The ``nrf9160dk_nrf9160ns`` and the ``nrf5340dk_nrf5340_cpuappns`` boards have been renamed respectively to ``nrf9160dk_nrf9160_ns`` and ``nrf5340dk_nrf5340_cpuapp_ns``, in a change inherited from upstream Zephyr.
     * The ``thingy91_nrf9160ns`` board has been renamed to ``thingy91_nrf9160_ns`` for consistency with the changes inherited from upstream Zephyr.
 
+  * :ref:`lib_modem_jwt` library:
+
+    * Updated :c:func:`modem_jwt_generate` to ensure the generated JWT has base64url encoding.
+
 * Deprecated:
 
   * :ref:`asset_tracker` has been deprecated in favor of :ref`asset_tracker_v2`.

--- a/lib/modem_jwt/modem_jwt.c
+++ b/lib/modem_jwt/modem_jwt.c
@@ -60,6 +60,31 @@ static int parse_jwt_at_cmd_resp(char *const jwt_resp)
 	return 0;
 }
 
+static void base64_url_format(char *const base64_string)
+{
+	if (base64_string == NULL) {
+		return;
+	}
+
+	char *found = NULL;
+
+	/* replace '+' with "-" */
+	for (found = base64_string; (found = strchr(found, '+'));) {
+		*found = '-';
+	}
+
+	/* replace '/' with "_" */
+	for (found = base64_string; (found = strchr(found, '/'));) {
+		*found = '_';
+	}
+
+	/* remove padding '=' */
+	found = strchr(base64_string, '=');
+	if (found) {
+		*found = '\0';
+	}
+}
+
 int modem_jwt_generate(struct jwt_data *const jwt)
 {
 	if (!jwt) {
@@ -148,6 +173,8 @@ cleanup:
 		}
 
 		if (ret == 0) {
+			/* Remove any non-base64url characters */
+			base64_url_format(cmd_resp);
 			memcpy(jwt->jwt_buf, cmd_resp, jwt_sz);
 		}
 	}

--- a/lib/multicell_location/services/nrf_cloud_integration.c
+++ b/lib/multicell_location/services/nrf_cloud_integration.c
@@ -75,7 +75,10 @@ int location_service_get_cell_location(const struct lte_lc_cells_info *cell_data
 		.exp_delta_s = (5 * 60),
 		.sec_tag = CONFIG_MULTICELL_LOCATION_NRF_CLOUD_JWT_SEC_TAG,
 		.key = JWT_KEY_TYPE_CLIENT_PRIV,
-		.alg = JWT_ALG_TYPE_ES256
+		.alg = JWT_ALG_TYPE_ES256,
+		/* Set to NULL so a properly sized buffer is allocated */
+		.jwt_buf = NULL,
+		.jwt_sz = 0
 	};
 	struct nrf_cloud_rest_context rest_ctx = {
 		.connect_socket = -1,
@@ -101,6 +104,7 @@ int location_service_get_cell_location(const struct lte_lc_cells_info *cell_data
 	err = nrf_cloud_rest_cell_pos_get(&rest_ctx, &loc_req, &result);
 
 	modem_jwt_free(jwt.jwt_buf);
+	jwt.jwt_buf = NULL;
 
 	if (!err) {
 		location->accuracy = (double)result.unc;


### PR DESCRIPTION
Initialize JWT buffer to NULL so that the library allocates a properly sized buffer for the JWT.
Ensure JWT has base64url format.
CIA-424 and CIA-425

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>