### PR TITLE
treewide: finish 'ns' -> '_ns' rename

### DIFF
--- a/applications/machine_learning/sample.yaml
+++ b/applications/machine_learning/sample.yaml
@@ -5,7 +5,7 @@ tests:
   applications.machine_learning.zdebug:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 thingy52_nrf52832 thingy53_nrf5340_cpuapp
-    platform_exclude: thingy53_nrf5340_cpuappns
+    platform_exclude: thingy53_nrf5340_cpuapp_ns
     integration_platforms:
       - nrf52840dk_nrf52840
       - thingy52_nrf52832
@@ -21,7 +21,7 @@ tests:
   applications.machine_learning.zdebug_rtt:
     build_only: true
     platform_allow: thingy53_nrf5340_cpuapp
-    platform_exclude: thingy53_nrf5340_cpuappns
+    platform_exclude: thingy53_nrf5340_cpuapp_ns
     integration_platforms:
       - thingy53_nrf5340_cpuapp
     tags: ci_build
@@ -29,7 +29,7 @@ tests:
   applications.machine_learning.zrelease:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 thingy52_nrf52832 thingy53_nrf5340_cpuapp
-    platform_exclude: thingy53_nrf5340_cpuappns
+    platform_exclude: thingy53_nrf5340_cpuapp_ns
     integration_platforms:
       - nrf52840dk_nrf52840
       - thingy52_nrf52832

--- a/applications/matter_weather_station/sample.yaml
+++ b/applications/matter_weather_station/sample.yaml
@@ -5,7 +5,7 @@ tests:
   applications.matter_weather_station:
     build_only: true
     platform_allow: thingy53_nrf5340_cpuapp
-    platform_exclude: thingy53_nrf5340_cpuappns
+    platform_exclude: thingy53_nrf5340_cpuapp_ns
     integration_platforms:
       - thingy53_nrf5340_cpuapp
     tags: ci_build

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -6,7 +6,7 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-    platform_exclude: thingy53_nrf5340_cpuappns
+    platform_exclude: thingy53_nrf5340_cpuapp_ns
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -6,7 +6,7 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-    platform_exclude: thingy53_nrf5340_cpuappns
+    platform_exclude: thingy53_nrf5340_cpuapp_ns
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -14,7 +14,7 @@ tests:
     tags: bluetooth ci_build
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
-    platform_exclude: thingy53_nrf5340_cpuappns
+    platform_exclude: thingy53_nrf5340_cpuapp_ns
   samples.bluetooth.peripheral_lbs_minimal:
     extra_args: OVERLAY_CONFIG=prj_minimal.conf
     build_only: true

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -7,7 +7,7 @@ tests:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       nrf21540dk_nrf52840
-    platform_exclude: thingy53_nrf5340_cpuappns
+    platform_exclude: thingy53_nrf5340_cpuapp_ns
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5bfea3862a45ed9beda1fa1a4f5cd2c594ab7c48
+      revision: pull/627/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This particularly applies to Thingy:53, but we caught various
non-secure board configurations that were not kept consistent with the
pattern of ending in '_ns'. Fix the remaining boards with this issue.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>