### PR TITLE
Update invalid cell id handling for LTE_LC_EVT_NEIGHBOR_CELL_MEAS

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -215,8 +215,12 @@ static void lte_evt_handler(const struct lte_lc_evt *const evt)
 		send_cell_update(evt->cell.id, evt->cell.tac);
 		break;
 	case LTE_LC_EVT_NEIGHBOR_CELL_MEAS:
-		LOG_DBG("Neighbor cell measurements received");
-		send_neighbor_cell_update((struct lte_lc_cells_info *)&evt->cells_info);
+		if (evt->cells_info.current_cell.id != LTE_LC_CELL_EUTRAN_ID_INVALID) {
+			LOG_DBG("Neighbor cell measurements received");
+			send_neighbor_cell_update((struct lte_lc_cells_info *)&evt->cells_info);
+		} else {
+			LOG_DBG("Neighbor cell measurement was not successful");
+		}
 		break;
 	default:
 		break;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -52,6 +52,10 @@ nRF9160
 
     * Updated to only request neighbor cell measurements when connected and to only copy neighbor cell measurements if they exist.
 
+  * :ref:`lte_lc_readme` library:
+
+    * Changed the value of an invalid E-UTRAN cell ID from zero to UINT32_MAX for the LTE_LC_EVT_NEIGHBOR_CELL_MEAS event.
+
 nRF5
 ====
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -48,6 +48,10 @@ nRF9160
 
     * Removed GNSS socket API support from A-GPS and P-GPS.
 
+  * :ref:`multicell_location` sample:
+
+    * Updated to only request neighbor cell measurements when connected and to only copy neighbor cell measurements if they exist.
+
 nRF5
 ====
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -262,6 +262,8 @@ struct lte_lc_edrx_cfg {
 #define LTE_LC_CELL_EARFCN_MAX			262143
 #define LTE_LC_CELL_RSRP_INVALID		255
 #define LTE_LC_CELL_RSRQ_INVALID		255
+#define LTE_LC_CELL_EUTRAN_ID_INVALID		UINT32_MAX
+#define LTE_LC_CELL_EUTRAN_ID_MAX		268435455
 
 struct lte_lc_cell {
 	/** Mobile Country Code. */
@@ -270,7 +272,7 @@ struct lte_lc_cell {
 	/** Mobile Network Code. */
 	int mnc;
 
-	/** E-UTRAN cell ID. */
+	/** E-UTRAN cell ID, range 0 - LTE_LC_CELL_EUTRAN_ID_MAX */
 	uint32_t id;
 
 	/** Tracking area code. */
@@ -357,7 +359,8 @@ struct lte_lc_ncell {
 };
 
 /** @brief Structure containing results of neighbor cell measurements.
- *	   The current cell information is valid if the current cell ID is non-zero.
+ *	   The current cell information is valid if the current cell ID is not
+ *	   set to LTE_LC_CELL_EUTRAN_ID_INVALID.
  *	   The ncells_count member indicates whether or not the structure contains
  *	   valid neighbor cell information. If it is zero, no cells were found, and
  *	   the information in the rest of structure members do not contain valid data.

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -192,7 +192,7 @@ static bool is_relevant_notif(const char *notif, enum lte_lc_notif_type *type)
 
 static bool is_cellid_valid(uint32_t cellid)
 {
-	if (cellid == UINT32_MAX) {
+	if (cellid == LTE_LC_CELL_EUTRAN_ID_INVALID) {
 		return false;
 	}
 
@@ -423,7 +423,7 @@ static void at_handler(void *context, const char *response)
 			evt_handler(&evt);
 			break;
 		default:
-			LOG_ERR("Parsing of neighbour cells failed, err: %d", err);
+			LOG_ERR("Parsing of neighbor cells failed, err: %d", err);
 			break;
 		}
 

--- a/lib/multicell_location/multicell_location.c
+++ b/lib/multicell_location/multicell_location.c
@@ -216,6 +216,11 @@ int multicell_location_get(const struct lte_lc_cells_info *cell_data,
 		return -EINVAL;
 	}
 
+	if (cell_data->current_cell.id == LTE_LC_CELL_EUTRAN_ID_INVALID) {
+		LOG_WRN("Invalid cell ID, device may not be connected to a network");
+		return -ENOENT;
+	}
+
 	if (cell_data->ncells_count > CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS) {
 		LOG_WRN("Found %d neighbor cells, but %d cells will be used in location request",
 			cell_data->ncells_count, CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS);

--- a/lib/multicell_location/services/here_integration.c
+++ b/lib/multicell_location/services/here_integration.c
@@ -145,11 +145,6 @@ int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
 		return -EINVAL;
 	}
 
-	if (cell_data->current_cell.id == 0) {
-		LOG_WRN("No cells were found");
-		return -ENOENT;
-	}
-
 	if (neighbors_to_use == 0) {
 		len = snprintk(body, sizeof(body), HTTP_REQUEST_BODY_NO_NEIGHBORS,
 			       cell_data->current_cell.mcc,

--- a/lib/multicell_location/services/skyhook_integration.c
+++ b/lib/multicell_location/services/skyhook_integration.c
@@ -164,11 +164,6 @@ int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
 		return -EINVAL;
 	}
 
-	if (cell_data->current_cell.id == 0) {
-		LOG_WRN("No cells were found");
-		return -ENOENT;
-	}
-
 	err = modem_info_init();
 	if (err) {
 		LOG_ERR("modem_info_init failed, error: %d", err);

--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -226,10 +226,10 @@ void link_ind_handler(const struct lte_lc_evt *const evt)
 		shell_print(shell_global, "Neighbor cell measurement results:");
 
 		/* Current cell: */
-		if (cur_cell.id) {
+		if (cur_cell.id != LTE_LC_CELL_EUTRAN_ID_INVALID) {
 			char tmp_ta_str[12];
 
-			if (cur_cell.timing_advance == 65535) {
+			if (cur_cell.timing_advance == LTE_LC_CELL_TIMING_ADVANCE_INVALID) {
 				sprintf(tmp_ta_str, "\"not valid\"");
 			} else {
 				sprintf(tmp_ta_str, "%d", cur_cell.timing_advance);

--- a/samples/nrf9160/multicell_location/src/main.c
+++ b/samples/nrf9160/multicell_location/src/main.c
@@ -84,7 +84,10 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 			evt->cell.id, evt->cell.tac);
 
 		if (evt->cell.id != prev_cell_id) {
-			k_work_submit(&cell_change_search_work);
+			if (evt->cell.id != LTE_LC_CELL_EUTRAN_ID_INVALID) {
+				k_work_submit(&cell_change_search_work);
+			}
+
 			prev_cell_id = evt->cell.id;
 		}
 		break;
@@ -99,7 +102,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 	case LTE_LC_EVT_NEIGHBOR_CELL_MEAS:
 		LOG_INF("Neighbor cell measurements received");
 
-		if (evt->cells_info.current_cell.id == 0) {
+		if (evt->cells_info.current_cell.id == LTE_LC_CELL_EUTRAN_ID_INVALID) {
 			LOG_DBG("Cell ID not valid.");
 			break;
 		}
@@ -222,7 +225,7 @@ static void periodic_search_work_fn(struct k_work *work)
 
 static void print_cell_data(void)
 {
-	if (cell_data.current_cell.id == 0) {
+	if (cell_data.current_cell.id == LTE_LC_CELL_EUTRAN_ID_INVALID) {
 		LOG_WRN("No cells were found");
 		return;
 	}

--- a/tests/lib/lte_lc/CMakeLists.txt
+++ b/tests/lib/lte_lc/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(app
 target_include_directories(app
   PRIVATE
   ${ZEPHYR_BASE}/../nrf/lib/lte_link_control/
+  ${ZEPHYR_BASE}/../nrf/include/modem/
 )
 
 target_compile_options(app

--- a/tests/lib/lte_lc/src/main.c
+++ b/tests/lib/lte_lc/src/main.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "lte_lc_helpers.h"
+#include "lte_lc.h"
 
 static void test_parse_edrx(void)
 {
@@ -408,6 +409,8 @@ static void test_parse_ncellmeas(void)
 
 	err = parse_ncellmeas(resp2, &cells);
 	zassert_equal(err, 1, "parse_ncellmeas was expected to return 1, but returned %d", err);
+	zassert_equal(cells.current_cell.id, LTE_LC_CELL_EUTRAN_ID_INVALID, "Wrong cell ID");
+	zassert_equal(cells.ncells_count, 0, "Wrong neighbor cell count");
 
 	memset(&cells, 0, sizeof(cells));
 


### PR DESCRIPTION
Updated to use UINT32_MAX instead of zero as the indicator of an invalid cell id for the LTE_LC_EVT_NEIGHBOR_CELL_MEAS event.
Updated related samples/applications.

Updated multicell location sample:
Wait for connection to request ncell measurements.
Only process if cell id is valid.
Only process ncells if ncell count is > zero.

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>