### PR TITLE
Bluetooth: Mesh: Add runtime state for resume delay

### DIFF
--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -162,6 +162,8 @@ struct bt_mesh_light_ctrl_srv {
 	/* Publication data */
 	uint8_t pub_data[BT_MESH_MODEL_BUF_LEN(
 		BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_STATUS, 3)];
+	/** Resume control timeout (in seconds) */
+	uint16_t resume;
 	/** Setup model publish parameters */
 	struct bt_mesh_model_pub setup_pub;
 	/* Publication buffer */


### PR DESCRIPTION
Adds a resume delay parameter to the Light Control Server structure,
allowing the resume delay to be changed at runtime.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>