### PR TITLE
manifest: Update sdk-zephyr revision to a SHA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: pull/627/head
+      revision: f19ebe4b50405b2eb174199b3635f24d741c9bf4
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
A commit with a PR reference was mistakenly merged, fix this by pointing
to the right SHA.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>