### PR TITLE
cmake: partition manager: re-adding lost dependency to domain_hex_files

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -624,6 +624,7 @@ to the external flash")
       -o ${final_merged}
       ${domain_hex_files}
       DEPENDS
+      ${domain_hex_files}
       ${global_hex_depends}
       )
 


### PR DESCRIPTION
The dependency to `domain_hex_files` was lost in sdk-nrf:#4529.

This commit re-introduces the needed dependency on domain_hex_files
which is also used as input to the mergehex script.

Jira: NCSDK-10993

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>