### PR TITLE
applications: asset_tracker_v2: Use new API for sending service info to nRF Cloud

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -12,29 +12,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(MODULE, CONFIG_CLOUD_INTEGRATION_LOG_LEVEL);
 
-#define NRF_CLOUD_SERVICE_INFO "{"								\
-					"\"state\":{"						\
-						"\"reported\":{"				\
-							"\"device\":{"				\
-								"\"serviceInfo\":{"		\
-									"\"ui\":["		\
-										"\"GPS\","	\
-										"\"HUMID\","	\
-										"\"RSRP\","	\
-										"\"BUTTON\","	\
-										"\"TEMP\""	\
-									"],"			\
-									"\"fota_v2\":["		\
-										"\"APP\","	\
-										"\"MODEM\","	\
-										"\"BOOT\""	\
-									"]"			\
-								"}"				\
-							"}"					\
-						"}"						\
-					"}"							\
-				"}"
-
 #define REQUEST_DEVICE_STATE_STRING ""
 
 static cloud_wrap_evt_handler_t wrapper_evt_handler;
@@ -51,20 +28,35 @@ static void cloud_wrapper_notify_event(const struct cloud_wrap_event *evt)
 static int send_service_info(void)
 {
 	int err;
-	struct nrf_cloud_tx_data msg = {
-		.data.ptr = NRF_CLOUD_SERVICE_INFO,
-		.data.len = sizeof(NRF_CLOUD_SERVICE_INFO) - 1,
-		.qos = MQTT_QOS_0_AT_MOST_ONCE,
-		.topic_type = NRF_CLOUD_TOPIC_STATE,
+	struct nrf_cloud_svc_info_fota fota_info = {
+		.application = true,
+		.bootloader = true,
+		.modem = true
+	};
+	struct nrf_cloud_svc_info_ui ui_info = {
+		.gps = true,
+		.humidity = true,
+		.rsrp = true,
+		.temperature = true,
+		.button = true
+	};
+	struct nrf_cloud_svc_info service_info = {
+		.fota = &fota_info,
+		.ui = &ui_info
+	};
+	struct nrf_cloud_device_status device_status = {
+		.modem = NULL,
+		.svc = &service_info
+
 	};
 
-	err = nrf_cloud_send(&msg);
+	err = nrf_cloud_shadow_device_status_update(&device_status);
 	if (err) {
-		LOG_ERR("nrf_cloud_send, error: %d", err);
+		LOG_ERR("nrf_cloud_shadow_device_status_update, error: %d", err);
 		return err;
 	}
 
-	LOG_DBG("nRF Cloud service info sent: %s", NRF_CLOUD_SERVICE_INFO);
+	LOG_DBG("nRF Cloud service info sent");
 
 	return 0;
 }

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -740,7 +740,7 @@ static int nrf_cloud_encode_service_info_ui(const struct nrf_cloud_svc_info_ui *
 				cJSON_CreateString(sensor_type_str[NRF_CLOUD_SENSOR_AIR_PRESS]));
 			++item_cnt;
 		}
-		if (ui->air_pressure) {
+		if (ui->gps) {
 			cJSON_AddItemToArray(array,
 				cJSON_CreateString(sensor_type_str[NRF_CLOUD_SENSOR_GPS]));
 			++item_cnt;


### PR DESCRIPTION
Use new API in nRF Cloud library for encoding and sending of
service info to nRF Cloud. Previously this information
was hard-coded in the application. Service info contains information
about the application that enables certain features in the Web UI.

CIA-387