### PR TITLE
boards: Fix CS pin for nrf21540 EK shield

### DIFF
--- a/boards/shields/nrf21540_ek/nrf21540_ek.overlay
+++ b/boards/shields/nrf21540_ek/nrf21540_ek.overlay
@@ -17,7 +17,7 @@
 
 fem_spi: &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 0>; /* D10 */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 
 	nrf_radio_fem_spi: nrf21540_fem_spi@0 {
 		compatible = "nordic,nrf21540-fem-spi";


### PR DESCRIPTION
Fix CS GPIO active state for nrf21540 EK. This fixes
issue with output power selection.

NCSDK-11436

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>