### PR TITLE
applications: asset_tracker_v2: Enable debug module when using memfault

### DIFF
--- a/applications/asset_tracker_v2/configuration/memfault/memfault_platform_config.h
+++ b/applications/asset_tracker_v2/configuration/memfault/memfault_platform_config.h
@@ -6,6 +6,8 @@
  * "<NCS folder>/modules/lib/memfault-firmware-sdk/components/include/memfault/default_config.h"
  */
 
+#if defined(CONFIG_DEBUG_MODULE)
  /* Prepare captured metric data for upload to Memfault cloud every configured interval. */
 #define MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS CONFIG_DEBUG_MODULE_MEMFAULT_HEARTBEAT_INTERVAL_SEC
 #define MEMFAULT_DATA_EXPORT_CHUNK_MAX_LEN CONFIG_DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX
+#endif /* defined(CONFIG_DEBUG_MODULE) */

--- a/applications/asset_tracker_v2/overlay-memfault.conf
+++ b/applications/asset_tracker_v2/overlay-memfault.conf
@@ -21,3 +21,4 @@ CONFIG_PM_PARTITION_SIZE_MEMFAULT_STORAGE=0x10000
 # is configured to forward Memfault data via an external transport the data will be carried on
 # the system workqueue using event manager events.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=3584
+CONFIG_DEBUG_MODULE=y


### PR DESCRIPTION
The memfault integration in Asset Tracker v2 depends on the
debug module to work properly. Add `CONFIG_DEBUG_MODULE=y` to
`overlay-memfault.conf` to ensure this.

NCSDK-11445