### PR TITLE
samples: nrf9160: modem_shell: Fix crash after getaddrinfo

### DIFF
--- a/samples/nrf9160/modem_shell/src/sock/sock.c
+++ b/samples/nrf9160/modem_shell/src/sock/sock.c
@@ -331,12 +331,19 @@ static int sock_getaddrinfo(
 		};
 		err = getaddrinfo(address, NULL, &hints, &socket_info->addrinfo);
 		if (err) {
-			shell_error(
-				shell_global,
-				"getaddrinfo() failed, err %d errno %d",
-				err,
-				errno);
-			err = errno;
+			if (err == DNS_EAI_SYSTEM) {
+				shell_error(
+					shell_global,
+					"getaddrinfo() failed, err %d errno %d",
+					err,
+					errno);
+			} else {
+				shell_error(
+					shell_global,
+					"getaddrinfo() failed, err %d",
+					err);
+			}
+			err = -EADDRNOTAVAIL;
 			return err;
 		}
 


### PR DESCRIPTION
Modem shell crashes if getaddrinfo returns error code because
errno is used instead of return value of getaddrinfo.
Signed-off-by: Tommi Rantanen <tommi.rantanen@nordicsemi.no>