### PR TITLE
net: lib: nrf_cloud: Add support for new bulk topic

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -539,8 +539,6 @@ Following are the current limitations in the nRF Cloud implementation of the Ass
 		}
 	}
 
-* nRF Cloud does not support a separate endpoint for *batch* data updates. To temporarily circumvent this, batched data updates are sent to the message endpoint.
-
 
 Dependencies
 ************

--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -314,7 +314,7 @@ int cloud_wrap_batch_send(char *buf, size_t len)
 		.data.ptr = buf,
 		.data.len = len,
 		.qos = MQTT_QOS_0_AT_MOST_ONCE,
-		.topic_type = NRF_CLOUD_TOPIC_MESSAGE,
+		.topic_type = NRF_CLOUD_TOPIC_BULK,
 	};
 
 	err = nrf_cloud_send(&msg);

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -47,6 +47,8 @@ nRF9160
   * :ref:`lib_nrf_cloud` library:
 
     * Removed GNSS socket API support from A-GPS and P-GPS.
+    * Added support for sending data to a new bulk endpoint topic that is supported in nRF Cloud.
+      A message published to the bulk topic is typically a combination of multiple messages.
 
   * :ref:`multicell_location` sample:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -50,6 +50,10 @@ nRF9160
     * Added support for sending data to a new bulk endpoint topic that is supported in nRF Cloud.
       A message published to the bulk topic is typically a combination of multiple messages.
 
+  * :ref:`asset_tracker_v2` application:
+
+    * Updated the application to start sending batch messages to the new bulk endpoint topic supported in nRF Cloud.
+
   * :ref:`multicell_location` sample:
 
     * Updated to only request neighbor cell measurements when connected and to only copy neighbor cell measurements if they exist.

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -145,6 +145,11 @@ enum nrf_cloud_topic_type {
 	NRF_CLOUD_TOPIC_STATE = 0x1,
 	/** Endpoint used to directly message the nRF Cloud Web UI. */
 	NRF_CLOUD_TOPIC_MESSAGE,
+	/** Endpoint used to publish bulk messages to nRF Cloud. Bulk messages combine multiple
+	 *  messages into a single message that will be unwrapped and re-published to the
+	 *  message topic in the nRF Cloud backend.
+	 */
+	NRF_CLOUD_TOPIC_BULK
 };
 
 /**@brief FOTA status reported to nRF Cloud. */

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
@@ -89,6 +89,7 @@ int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *payload,
 int nrf_cloud_decode_data_endpoint(const struct nrf_cloud_data *input,
 				   struct nrf_cloud_data *tx_endpoint,
 				   struct nrf_cloud_data *rx_endpoint,
+				   struct nrf_cloud_data *bulk_endpoint,
 				   struct nrf_cloud_data *m_endpoint);
 
 /** @brief Encodes state information. */

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -90,6 +90,16 @@ int nct_dc_send(const struct nct_dc_data *dc);
  */
 int nct_dc_stream(const struct nct_dc_data *dc);
 
+/** @brief Publish data on the bulk endpoint topic.
+ *
+ *  @param[in] dc_data Pointer to structure containing the data to be published.
+ *  @param[in] qos MQTT Quality of Service level of the publication.
+ *
+ *  @return 0 If successful. Otherwise, a negative error code is returned.
+ *  @retval -EINVAL if one or several of the passed in arguments are invalid.
+ */
+int nct_dc_bulk_send(const struct nct_dc_data *dc_data, enum mqtt_qos qos);
+
 /**@brief Disconnects the logical control channel. */
 int nct_cc_disconnect(void);
 
@@ -106,6 +116,7 @@ int nct_disconnect(void);
  */
 void nct_dc_endpoint_set(const struct nrf_cloud_data *tx_endpoint,
 			 const struct nrf_cloud_data *rx_endpoint,
+			 const struct nrf_cloud_data *bulk_endpoint,
 			 const struct nrf_cloud_data *m_endpoint);
 
 /**
@@ -113,6 +124,7 @@ void nct_dc_endpoint_set(const struct nrf_cloud_data *tx_endpoint,
  */
 void nct_dc_endpoint_get(struct nrf_cloud_data *tx_endpoint,
 			 struct nrf_cloud_data *rx_endpoint,
+			 struct nrf_cloud_data *bulk_endpoint,
 			 struct nrf_cloud_data *m_endpoint);
 
 /**@brief Needed for keep alive. */

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -386,6 +386,21 @@ int nrf_cloud_send(const struct nrf_cloud_tx_data *msg)
 
 		break;
 	}
+	case NRF_CLOUD_TOPIC_BULK: {
+		const struct nct_dc_data buf = {
+			.data.ptr = msg->data.ptr,
+			.data.len = msg->data.len,
+			.message_id = NCT_MSG_ID_USE_NEXT_INCREMENT
+		};
+
+		err = nct_dc_bulk_send(&buf, msg->qos);
+		if (err) {
+			LOG_ERR("nct_dc_bulk_send failed, error: %d", err);
+			return err;
+		}
+
+		break;
+	}
 	default:
 		LOG_ERR("Unknown topic type");
 		return -ENODATA;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -356,16 +356,17 @@ static int handle_pin_complete(const struct nct_evt *nct_evt)
 	const struct nrf_cloud_data *payload = &nct_evt->param.cc->data;
 	struct nrf_cloud_data rx;
 	struct nrf_cloud_data tx;
+	struct nrf_cloud_data bulk;
 	struct nrf_cloud_data endpoint;
 
-	err = nrf_cloud_decode_data_endpoint(payload, &tx, &rx, &endpoint);
+	err = nrf_cloud_decode_data_endpoint(payload, &tx, &rx, &bulk, &endpoint);
 	if (err) {
 		LOG_ERR("nrf_cloud_decode_data_endpoint failed %d", err);
 		return err;
 	}
 
 	/* Set the endpoint information. */
-	nct_dc_endpoint_set(&tx, &rx, &endpoint);
+	nct_dc_endpoint_set(&tx, &rx, &bulk, &endpoint);
 
 	return state_ua_pin_complete();
 }


### PR DESCRIPTION
Add support for the new d2c/bulk topic in nRF Cloud.
This topic can be used to publish arrays of data objects that will be
unpacked and re-published to the message topic in the nRF Cloud backed.

CIA-389