### PR TITLE
Feature add fwversion to manifest json

### DIFF
--- a/cmake/fw_zip.cmake
+++ b/cmake/fw_zip.cmake
@@ -18,6 +18,12 @@ function(generate_dfu_zip)
     message(FATAL_ERROR "Missing required param")
   endif()
 
+  get_filename_component(APPNAME ${APPLICATION_SOURCE_DIR} NAME)
+  if(CONFIG_BUILD_OUTPUT_META)
+    set(meta_info_file ${PROJECT_BINARY_DIR}/${KERNEL_META_NAME})
+    set(meta_argument --meta-info-file ${meta_info_file})
+  endif()
+
   add_custom_command(
     OUTPUT ${GENZIP_OUTPUT}
     COMMAND
@@ -25,11 +31,13 @@ function(generate_dfu_zip)
     ${NRF_DIR}/scripts/bootloader/generate_zip.py
     --bin-files ${GENZIP_BIN_FILES}
     --output ${GENZIP_OUTPUT}
+    --name "${APPNAME}"
+    ${meta_argument}
     ${GENZIP_SCRIPT_PARAMS}
     "type=${GENZIP_TYPE}"
     "board=${CONFIG_BOARD}"
     "soc=${CONFIG_SOC}"
-    DEPENDS ${GENZIP_BIN_FILES}
+    DEPENDS ${GENZIP_BIN_FILES} ${meta_info_file}
     )
 
   get_filename_component(TARGET_NAME ${GENZIP_OUTPUT} NAME)

--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -145,6 +145,26 @@ When the device receives the :c:enumerator:`NRF_CLOUD_EVT_FOTA_DONE` event, the 
 The message payload of the :c:enumerator:`NRF_CLOUD_EVT_FOTA_DONE` event contains the :c:enum:`nrf_cloud_fota_type` value.
 If the value equals :c:enumerator:`NRF_CLOUD_FOTA_MODEM`, the application can optionally avoid a reboot by performing reinitialization of the modem and calling the :c:func:`nrf_cloud_modem_fota_completed` function.
 
+Building FOTA images
+====================
+The |NCS| build system places output images in the :file:`<build folder>/zephyr` folder.
+
+If :kconfig:`CONFIG_BOOTLOADER_MCUBOOT` is set, the build system creates the file :file:`dfu_application.zip` file containing files :file:`app_update.bin` and :file:`manifest.json`.
+Further, if :kconfig:`CONFIG_IMG_MANAGER` and :kconfig:`CONFIG_MCUBOOT_IMG_MANAGER` are also set, then the application will be able to process FOTA updates.
+
+The :file:`app_update.bin` file is a signed version of your application.
+The signature matches to what MCUboot expects, so it allows this file to be used as an update.
+The build system creates a :file:`manifest.json` file using information in the :file:`zephyr.meta` output file.
+This includes the Zephyr and |NCS| git hashes for the commits used to build the application.
+If your working tree contains uncommitted changes, the build system adds the suffix ``-dirty`` to the relevant version field.
+
+When you use the zip file to create an update bundle, the `nRF Cloud`_ UI populates the ``Name`` and ``Version`` fields from the :file:`manifest.json` file.
+However, you are free to change them as needed.
+The UI populates the ``Version`` field from only the |NCS| version field in the :file:`manifest.json` file.
+
+Alternatively, you can use the :file:`app_update.bin` file to create an update bundle, but you need to enter the ``Name`` and ``Version`` fields manually.
+See `nRF Cloud Getting Started FOTA documentation`_ to learn how to create an update bundle.
+
 .. _lib_nrf_cloud_data:
 
 Sending sensor data

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -36,6 +36,7 @@ Application development
   * Added an option to control the inclusion of RPMsg samples on the nRF53 network core :kconfig:`NCS_INCLUDE_RPMSG_CHILD_IMAGE`.
   * Fixed the NCSIDB-581 bug where application signing and file conversion for Device Firmware Update (DFU) could fail in SEGGER Embedded Studio during a build.
   * Added possibility to enable build warning when experimental features are enabled, NCSDK-6336.
+  * Updated generation of the :file:`manifest.json` file in the :file:`dfu_application.zip` and :file:`dfu_mcuboot.zip` files to include nrf and zephyr revisions reported by the new build file :file:`zephyr.meta`.
 
 Protocols
 =========

--- a/doc/nrf/ug_nrf_cloud.rst
+++ b/doc/nrf/ug_nrf_cloud.rst
@@ -33,6 +33,7 @@ For more information on the various services, see the following documentation:
 
 1. :ref:`lib_nrf_cloud_agps`
 #. :ref:`lib_nrf_cloud_cell_pos`
+#. :ref:`lib_nrf_cloud_fota`
 #. :ref:`lib_nrf_cloud_pgps`
 
 Applications and samples

--- a/modules/mcuboot/Kconfig
+++ b/modules/mcuboot/Kconfig
@@ -14,6 +14,7 @@ config BOOT_SIGNATURE_KEY_FILE
 config SIGN_IMAGES
 	bool "Sign images for MCUBoot"
 	default y
+	imply BUILD_OUTPUT_META
 	depends on MCUBOOT_BUILD_STRATEGY_FROM_SOURCE \
 		   || BOOT_SIGNATURE_KEY_FILE != ""
 	help


### PR DESCRIPTION
cmake: fw_zip: add fwversion
Use git to retrieve the version of the firmware image, then pass that to the  generate_zip.py script. Extract the name portion of the application source dir and pass that to the script as well.

scripts: generate_zip: add fwversion to manifest
Add a required option --fwversion.  Set the fwversion field in the manifest to the value.  This is required by nRF Cloud.

Set the name field in the manifest to a combination of the value of any --name value provided along with any key/value pair provided where key='type'.

Jira: NCSDK-11510
