### PR TITLE
ci: use v1.7-branch fork of CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v1.7-branch") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 


### PR DESCRIPTION
Loads the exact CI when sdk-nrf:v1.7.0 was tagged

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>