### PR TITLE
Bluetooth: Mesh: Add ETIMEDOUT as a return code in mesh blocking API

### DIFF
--- a/include/bluetooth/mesh/gen_battery_cli.h
+++ b/include/bluetooth/mesh/gen_battery_cli.h
@@ -92,8 +92,8 @@ struct bt_mesh_battery_cli {
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_battery_cli_get(struct bt_mesh_battery_cli *cli,
 			    struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/gen_dtt_cli.h
+++ b/include/bluetooth/mesh/gen_dtt_cli.h
@@ -95,8 +95,7 @@ struct bt_mesh_dtt_cli {
  *
  * @retval 0 Successfully retrieved the status of the bound srv.
  * @retval -EALREADY A blocking operation is already in progress in this model.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The request timed out.
  */
 int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 		    int32_t *rsp_transition_time);
@@ -121,8 +120,7 @@ int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
  * @p rsp_transition_time buffer.
  * @retval -EINVAL The given transition time is invalid.
  * @retval -EALREADY A blocking operation is already in progress in this model.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The request timed out.
  */
 int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 		    uint32_t transition_time, int32_t *rsp_transition_time);

--- a/include/bluetooth/mesh/gen_dtt_cli.h
+++ b/include/bluetooth/mesh/gen_dtt_cli.h
@@ -95,7 +95,9 @@ struct bt_mesh_dtt_cli {
  *
  * @retval 0 Successfully retrieved the status of the bound srv.
  * @retval -EALREADY A blocking operation is already in progress in this model.
- * @retval -EAGAIN The request timed out.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+
  */
 int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 		    int32_t *rsp_transition_time);
@@ -120,7 +122,8 @@ int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
  * @p rsp_transition_time buffer.
  * @retval -EINVAL The given transition time is invalid.
  * @retval -EALREADY A blocking operation is already in progress in this model.
- * @retval -EAGAIN The request timed out.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 		    uint32_t transition_time, int32_t *rsp_transition_time);

--- a/include/bluetooth/mesh/gen_loc_cli.h
+++ b/include/bluetooth/mesh/gen_loc_cli.h
@@ -110,8 +110,8 @@ struct bt_mesh_loc_cli {
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_loc_cli_global_get(struct bt_mesh_loc_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
@@ -133,8 +133,8 @@ int bt_mesh_loc_cli_global_get(struct bt_mesh_loc_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_loc_cli_global_set(struct bt_mesh_loc_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
@@ -173,8 +173,8 @@ int bt_mesh_loc_cli_global_set_unack(struct bt_mesh_loc_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_loc_cli_local_get(struct bt_mesh_loc_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -196,8 +196,8 @@ int bt_mesh_loc_cli_local_get(struct bt_mesh_loc_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_loc_cli_local_set(struct bt_mesh_loc_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/gen_lvl_cli.h
+++ b/include/bluetooth/mesh/gen_lvl_cli.h
@@ -91,8 +91,8 @@ struct bt_mesh_lvl_cli {
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lvl_cli_get(struct bt_mesh_lvl_cli *cli,
 			struct bt_mesh_msg_ctx *ctx,
@@ -115,8 +115,8 @@ int bt_mesh_lvl_cli_get(struct bt_mesh_lvl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
 			struct bt_mesh_msg_ctx *ctx,
@@ -163,8 +163,8 @@ int bt_mesh_lvl_cli_set_unack(struct bt_mesh_lvl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -223,8 +223,8 @@ int bt_mesh_lvl_cli_delta_set_unack(
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
 			     struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/gen_onoff_cli.h
+++ b/include/bluetooth/mesh/gen_onoff_cli.h
@@ -92,8 +92,8 @@ struct bt_mesh_onoff_cli {
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_onoff_cli_get(struct bt_mesh_onoff_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -117,8 +117,8 @@ int bt_mesh_onoff_cli_get(struct bt_mesh_onoff_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_onoff_cli_set(struct bt_mesh_onoff_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/gen_plvl_cli.h
+++ b/include/bluetooth/mesh/gen_plvl_cli.h
@@ -127,8 +127,8 @@ struct bt_mesh_plvl_cli {
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_plvl_cli_power_get(struct bt_mesh_plvl_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
@@ -151,8 +151,8 @@ int bt_mesh_plvl_cli_power_get(struct bt_mesh_plvl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_plvl_cli_power_set(struct bt_mesh_plvl_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
@@ -191,8 +191,8 @@ int bt_mesh_plvl_cli_power_set_unack(struct bt_mesh_plvl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_plvl_cli_range_get(struct bt_mesh_plvl_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
@@ -214,8 +214,8 @@ int bt_mesh_plvl_cli_range_get(struct bt_mesh_plvl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_plvl_cli_range_set(struct bt_mesh_plvl_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
@@ -254,8 +254,8 @@ int bt_mesh_plvl_cli_range_set_unack(struct bt_mesh_plvl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
 				 struct bt_mesh_msg_ctx *ctx, uint16_t *rsp);
@@ -276,8 +276,8 @@ int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_plvl_cli_default_set(struct bt_mesh_plvl_cli *cli,
 				 struct bt_mesh_msg_ctx *ctx,
@@ -296,6 +296,7 @@ int bt_mesh_plvl_cli_default_set(struct bt_mesh_plvl_cli *cli,
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_plvl_cli_default_set_unack(struct bt_mesh_plvl_cli *cli,
 				 struct bt_mesh_msg_ctx *ctx,
@@ -319,8 +320,8 @@ int bt_mesh_plvl_cli_default_set_unack(struct bt_mesh_plvl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_plvl_cli_last_get(struct bt_mesh_plvl_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx, uint16_t *rsp);

--- a/include/bluetooth/mesh/gen_ponoff_cli.h
+++ b/include/bluetooth/mesh/gen_ponoff_cli.h
@@ -92,8 +92,8 @@ struct bt_mesh_ponoff_cli {
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_ponoff_cli_on_power_up_get(struct bt_mesh_ponoff_cli *cli,
 				       struct bt_mesh_msg_ctx *ctx,
@@ -117,8 +117,8 @@ int bt_mesh_ponoff_cli_on_power_up_get(struct bt_mesh_ponoff_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_ponoff_cli_on_power_up_set(struct bt_mesh_ponoff_cli *cli,
 				       struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/gen_prop_cli.h
+++ b/include/bluetooth/mesh/gen_prop_cli.h
@@ -125,8 +125,8 @@ struct bt_mesh_prop_cli {
  * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_prop_cli_client_props_get(struct bt_mesh_prop_cli *cli,
 				      struct bt_mesh_msg_ctx *ctx, uint16_t id,
@@ -155,8 +155,8 @@ int bt_mesh_prop_cli_client_props_get(struct bt_mesh_prop_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_prop_cli_props_get(struct bt_mesh_prop_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
@@ -185,8 +185,8 @@ int bt_mesh_prop_cli_props_get(struct bt_mesh_prop_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -216,8 +216,8 @@ int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_prop_cli_user_prop_set(struct bt_mesh_prop_cli *cli,
 				   struct bt_mesh_msg_ctx *ctx,
@@ -264,8 +264,8 @@ int bt_mesh_prop_cli_user_prop_set_unack(struct bt_mesh_prop_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -305,8 +305,8 @@ int bt_mesh_prop_cli_admin_prop_set_unack(struct bt_mesh_prop_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
 				  struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/light_ctl_cli.h
+++ b/include/bluetooth/mesh/light_ctl_cli.h
@@ -126,8 +126,8 @@ struct bt_mesh_light_ctl_cli {
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_ctl_get(struct bt_mesh_light_ctl_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -148,8 +148,8 @@ int bt_mesh_light_ctl_get(struct bt_mesh_light_ctl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_ctl_set(struct bt_mesh_light_ctl_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -191,8 +191,8 @@ int bt_mesh_light_ctl_set_unack(struct bt_mesh_light_ctl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_temp_get(struct bt_mesh_light_ctl_cli *cli,
 			   struct bt_mesh_msg_ctx *ctx,
@@ -218,8 +218,8 @@ int bt_mesh_light_temp_get(struct bt_mesh_light_ctl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_temp_set(struct bt_mesh_light_ctl_cli *cli,
 			   struct bt_mesh_msg_ctx *ctx,
@@ -262,8 +262,8 @@ int bt_mesh_light_temp_set_unack(
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_ctl_default_get(struct bt_mesh_light_ctl_cli *cli,
 				  struct bt_mesh_msg_ctx *ctx,
@@ -284,8 +284,8 @@ int bt_mesh_light_ctl_default_get(struct bt_mesh_light_ctl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_ctl_default_set(struct bt_mesh_light_ctl_cli *cli,
 				  struct bt_mesh_msg_ctx *ctx,
@@ -323,8 +323,8 @@ int bt_mesh_light_ctl_default_set_unack(
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_temp_range_get(
 	struct bt_mesh_light_ctl_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -345,8 +345,8 @@ int bt_mesh_light_temp_range_get(
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request timed out
- * without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_temp_range_set(
 	struct bt_mesh_light_ctl_cli *cli, struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/light_ctrl_cli.h
+++ b/include/bluetooth/mesh/light_ctrl_cli.h
@@ -168,8 +168,8 @@ struct bt_mesh_light_ctrl_cli {
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_mode_get(struct bt_mesh_light_ctrl_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx, bool *rsp);
@@ -195,8 +195,8 @@ int bt_mesh_light_ctrl_cli_mode_get(struct bt_mesh_light_ctrl_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_mode_set(struct bt_mesh_light_ctrl_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx, bool enabled,
@@ -243,8 +243,8 @@ int bt_mesh_light_ctrl_cli_mode_set_unack(struct bt_mesh_light_ctrl_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_occupancy_enabled_get(
 	struct bt_mesh_light_ctrl_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -272,8 +272,8 @@ int bt_mesh_light_ctrl_cli_occupancy_enabled_get(
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_occupancy_enabled_set(
 	struct bt_mesh_light_ctrl_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -319,8 +319,8 @@ int bt_mesh_light_ctrl_cli_occupancy_enabled_set_unack(
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_light_onoff_get(struct bt_mesh_light_ctrl_cli *cli,
 					   struct bt_mesh_msg_ctx *ctx,
@@ -349,8 +349,8 @@ int bt_mesh_light_ctrl_cli_light_onoff_get(struct bt_mesh_light_ctrl_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_light_onoff_set(struct bt_mesh_light_ctrl_cli *cli,
 					   struct bt_mesh_msg_ctx *ctx,
@@ -400,8 +400,8 @@ int bt_mesh_light_ctrl_cli_light_onoff_set_unack(
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_prop_get(struct bt_mesh_light_ctrl_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -430,8 +430,8 @@ int bt_mesh_light_ctrl_cli_prop_get(struct bt_mesh_light_ctrl_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -478,8 +478,8 @@ int bt_mesh_light_ctrl_cli_prop_set_unack(struct bt_mesh_light_ctrl_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_coeff_get(struct bt_mesh_light_ctrl_cli *cli,
 				     struct bt_mesh_msg_ctx *ctx,
@@ -504,8 +504,8 @@ int bt_mesh_light_ctrl_cli_coeff_get(struct bt_mesh_light_ctrl_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_light_ctrl_cli_coeff_set(struct bt_mesh_light_ctrl_cli *cli,
 				     struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/light_hsl_cli.h
+++ b/include/bluetooth/mesh/light_hsl_cli.h
@@ -139,8 +139,8 @@ struct bt_mesh_light_hsl_cli {
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_hsl_get(struct bt_mesh_light_hsl_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -161,8 +161,8 @@ int bt_mesh_light_hsl_get(struct bt_mesh_light_hsl_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_hsl_set(struct bt_mesh_light_hsl_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -199,8 +199,8 @@ int bt_mesh_light_hsl_set_unack(struct bt_mesh_light_hsl_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_hsl_target_get(struct bt_mesh_light_hsl_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -220,8 +220,8 @@ int bt_mesh_light_hsl_target_get(struct bt_mesh_light_hsl_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_hsl_default_get(struct bt_mesh_light_hsl_cli *cli,
 				  struct bt_mesh_msg_ctx *ctx,
@@ -242,8 +242,8 @@ int bt_mesh_light_hsl_default_get(struct bt_mesh_light_hsl_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_hsl_default_set(struct bt_mesh_light_hsl_cli *cli,
 				  struct bt_mesh_msg_ctx *ctx,
@@ -281,8 +281,8 @@ int bt_mesh_light_hsl_default_set_unack(
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_hsl_range_get(
 	struct bt_mesh_light_hsl_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -303,8 +303,8 @@ int bt_mesh_light_hsl_range_get(
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_hsl_range_set(
 	struct bt_mesh_light_hsl_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -342,8 +342,8 @@ int bt_mesh_light_hsl_range_set_unack(
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_hue_get(struct bt_mesh_light_hsl_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -364,8 +364,8 @@ int bt_mesh_light_hue_get(struct bt_mesh_light_hsl_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_hue_set(struct bt_mesh_light_hsl_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -402,8 +402,8 @@ int bt_mesh_light_hue_set_unack(struct bt_mesh_light_hsl_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_saturation_get(struct bt_mesh_light_hsl_cli *cli,
 				 struct bt_mesh_msg_ctx *ctx,
@@ -424,8 +424,8 @@ int bt_mesh_light_saturation_get(struct bt_mesh_light_hsl_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *                  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_saturation_set(struct bt_mesh_light_hsl_cli *cli,
 				 struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/light_xyl_cli.h
+++ b/include/bluetooth/mesh/light_xyl_cli.h
@@ -115,8 +115,8 @@ struct bt_mesh_light_xyl_cli {
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_xyl_get(struct bt_mesh_light_xyl_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -137,8 +137,8 @@ int bt_mesh_light_xyl_get(struct bt_mesh_light_xyl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_xyl_set(struct bt_mesh_light_xyl_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -175,8 +175,8 @@ int bt_mesh_light_xyl_set_unack(struct bt_mesh_light_xyl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_xyl_target_get(struct bt_mesh_light_xyl_cli *cli,
 				 struct bt_mesh_msg_ctx *ctx,
@@ -196,8 +196,8 @@ int bt_mesh_light_xyl_target_get(struct bt_mesh_light_xyl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_xyl_default_get(struct bt_mesh_light_xyl_cli *cli,
 				  struct bt_mesh_msg_ctx *ctx,
@@ -218,8 +218,8 @@ int bt_mesh_light_xyl_default_get(struct bt_mesh_light_xyl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_xyl_default_set(struct bt_mesh_light_xyl_cli *cli,
 				  struct bt_mesh_msg_ctx *ctx,
@@ -257,8 +257,8 @@ int bt_mesh_light_xyl_default_set_unack(struct bt_mesh_light_xyl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_light_xyl_range_get(struct bt_mesh_light_xyl_cli *cli,
 				struct bt_mesh_msg_ctx *ctx,
@@ -279,8 +279,8 @@ int bt_mesh_light_xyl_range_get(struct bt_mesh_light_xyl_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  * @retval -EFAULT Invalid input range.
  */
 

--- a/include/bluetooth/mesh/lightness_cli.h
+++ b/include/bluetooth/mesh/lightness_cli.h
@@ -132,8 +132,8 @@ struct bt_mesh_lightness_cli {
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -159,8 +159,8 @@ int bt_mesh_lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lightness_cli_light_set(struct bt_mesh_lightness_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -202,8 +202,8 @@ int bt_mesh_lightness_cli_light_set_unack(
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lightness_cli_range_get(struct bt_mesh_lightness_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -225,8 +225,8 @@ int bt_mesh_lightness_cli_range_get(struct bt_mesh_lightness_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lightness_cli_range_set(struct bt_mesh_lightness_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -265,8 +265,8 @@ int bt_mesh_lightness_cli_range_set_unack(
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lightness_cli_default_get(struct bt_mesh_lightness_cli *cli,
 				      struct bt_mesh_msg_ctx *ctx, uint16_t *rsp);
@@ -287,8 +287,8 @@ int bt_mesh_lightness_cli_default_get(struct bt_mesh_lightness_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lightness_cli_default_set(struct bt_mesh_lightness_cli *cli,
 				      struct bt_mesh_msg_ctx *ctx,
@@ -307,6 +307,7 @@ int bt_mesh_lightness_cli_default_set(struct bt_mesh_lightness_cli *cli,
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lightness_cli_default_set_unack(struct bt_mesh_lightness_cli *cli,
 					    struct bt_mesh_msg_ctx *ctx,
@@ -330,8 +331,8 @@ int bt_mesh_lightness_cli_default_set_unack(struct bt_mesh_lightness_cli *cli,
  * @retval -EALREADY A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
- * @retval -EAGAIN The device has not been provisioned or the request
- * timed out without a response.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_lightness_cli_last_get(struct bt_mesh_lightness_cli *cli,
 				   struct bt_mesh_msg_ctx *ctx, uint16_t *rsp);

--- a/include/bluetooth/mesh/scene_cli.h
+++ b/include/bluetooth/mesh/scene_cli.h
@@ -98,8 +98,8 @@ struct bt_mesh_scene_cli {
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *  not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_scene_cli_get(struct bt_mesh_scene_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
@@ -123,8 +123,8 @@ int bt_mesh_scene_cli_get(struct bt_mesh_scene_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *  not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_scene_cli_register_get(struct bt_mesh_scene_cli *cli,
 				   struct bt_mesh_msg_ctx *ctx,
@@ -150,8 +150,8 @@ int bt_mesh_scene_cli_register_get(struct bt_mesh_scene_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *  not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_scene_cli_store(struct bt_mesh_scene_cli *cli,
 			    struct bt_mesh_msg_ctx *ctx, uint16_t scene,
@@ -193,8 +193,8 @@ int bt_mesh_scene_cli_store_unack(struct bt_mesh_scene_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *  not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_scene_cli_delete(struct bt_mesh_scene_cli *cli,
 			     struct bt_mesh_msg_ctx *ctx, uint16_t scene,
@@ -237,8 +237,8 @@ int bt_mesh_scene_cli_delete_unack(struct bt_mesh_scene_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *  not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_scene_cli_recall(struct bt_mesh_scene_cli *cli,
 			     struct bt_mesh_msg_ctx *ctx, uint16_t scene,

--- a/include/bluetooth/mesh/scheduler_cli.h
+++ b/include/bluetooth/mesh/scheduler_cli.h
@@ -90,8 +90,8 @@ struct bt_mesh_scheduler_cli {
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *  not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_scheduler_cli_get(struct bt_mesh_scheduler_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -113,8 +113,8 @@ int bt_mesh_scheduler_cli_get(struct bt_mesh_scheduler_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *  not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_scheduler_cli_action_get(struct bt_mesh_scheduler_cli *cli,
 				struct bt_mesh_msg_ctx *ctx,
@@ -138,8 +138,8 @@ int bt_mesh_scheduler_cli_action_get(struct bt_mesh_scheduler_cli *cli,
  *  @retval -EALREADY A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *  not configured.
- *  @retval -EAGAIN The device has not been provisioned or the request
- *  timed out without a response.
+ *  @retval -EAGAIN The device has not been provisioned.
+ *  @retval -ETIMEDOUT The request timed out without a response.
  */
 int bt_mesh_scheduler_cli_action_set(struct bt_mesh_scheduler_cli *cli,
 				struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/sensor_cli.h
+++ b/include/bluetooth/mesh/sensor_cli.h
@@ -289,8 +289,7 @@ struct bt_mesh_sensor_cli_handlers {
  *                         response.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_desc_all_get(struct bt_mesh_sensor_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -316,8 +315,7 @@ int bt_mesh_sensor_cli_desc_all_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_desc_get(struct bt_mesh_sensor_cli *cli,
 				struct bt_mesh_msg_ctx *ctx,
@@ -343,8 +341,7 @@ int bt_mesh_sensor_cli_desc_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_cadence_get(struct bt_mesh_sensor_cli *cli,
 				   struct bt_mesh_msg_ctx *ctx,
@@ -373,8 +370,7 @@ int bt_mesh_sensor_cli_cadence_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_cadence_set(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -434,8 +430,7 @@ int bt_mesh_sensor_cli_cadence_set_unack(
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -462,8 +457,7 @@ int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_setting_get(struct bt_mesh_sensor_cli *cli,
 				   struct bt_mesh_msg_ctx *ctx,
@@ -494,8 +488,7 @@ int bt_mesh_sensor_cli_setting_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EALREADY      A blocking request is already in progress.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_setting_set(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -544,8 +537,7 @@ int bt_mesh_sensor_cli_setting_set_unack(
  *  @retval -ENODEV        The sensor server doesn't have the given sensor.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_all_get(struct bt_mesh_sensor_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
@@ -570,8 +562,7 @@ int bt_mesh_sensor_cli_all_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -ENODEV        The sensor server doesn't have the given sensor.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_get(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -601,8 +592,7 @@ int bt_mesh_sensor_cli_get(
  *  @retval -ENOENT        The sensor doesn't have the given column.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_series_entry_get(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -649,8 +639,7 @@ int bt_mesh_sensor_cli_series_entry_get(
  *  @retval -ENOTSUP       The sensor doesn't support series data.
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
- *  @retval -EAGAIN        The device has not been provisioned or the request
- *                         timed out without a response.
+ *  @retval -EAGAIN        The device has not been provisioned.
  */
 int bt_mesh_sensor_cli_series_entries_get(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/sensor_cli.h
+++ b/include/bluetooth/mesh/sensor_cli.h
@@ -290,6 +290,7 @@ struct bt_mesh_sensor_cli_handlers {
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_desc_all_get(struct bt_mesh_sensor_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -316,6 +317,7 @@ int bt_mesh_sensor_cli_desc_all_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_desc_get(struct bt_mesh_sensor_cli *cli,
 				struct bt_mesh_msg_ctx *ctx,
@@ -342,6 +344,7 @@ int bt_mesh_sensor_cli_desc_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_cadence_get(struct bt_mesh_sensor_cli *cli,
 				   struct bt_mesh_msg_ctx *ctx,
@@ -371,6 +374,7 @@ int bt_mesh_sensor_cli_cadence_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_cadence_set(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -431,6 +435,7 @@ int bt_mesh_sensor_cli_cadence_set_unack(
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
 				    struct bt_mesh_msg_ctx *ctx,
@@ -458,6 +463,7 @@ int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_setting_get(struct bt_mesh_sensor_cli *cli,
 				   struct bt_mesh_msg_ctx *ctx,
@@ -489,6 +495,7 @@ int bt_mesh_sensor_cli_setting_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_setting_set(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -538,6 +545,7 @@ int bt_mesh_sensor_cli_setting_set_unack(
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_all_get(struct bt_mesh_sensor_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
@@ -563,6 +571,7 @@ int bt_mesh_sensor_cli_all_get(struct bt_mesh_sensor_cli *cli,
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_get(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -593,6 +602,7 @@ int bt_mesh_sensor_cli_get(
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_series_entry_get(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -640,6 +650,7 @@ int bt_mesh_sensor_cli_series_entry_get(
  *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                         not configured.
  *  @retval -EAGAIN        The device has not been provisioned.
+ *  @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_sensor_cli_series_entries_get(
 	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,

--- a/include/bluetooth/mesh/time_cli.h
+++ b/include/bluetooth/mesh/time_cli.h
@@ -149,8 +149,8 @@ struct bt_mesh_time_cli {
  * @retval -EALREADY      A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
- * @retval -EAGAIN        The device has not been provisioned or the request
- *                        timed out without a response.
+ * @retval -EAGAIN        The device has not been provisioned.
+ * @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_time_cli_time_get(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -170,8 +170,8 @@ int bt_mesh_time_cli_time_get(struct bt_mesh_time_cli *cli,
  * @retval -EALREADY      A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
- * @retval -EAGAIN        The device has not been provisioned or the request
- *                        timed out without a response.
+ * @retval -EAGAIN        The device has not been provisioned.
+ * @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_time_cli_time_set(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -191,8 +191,8 @@ int bt_mesh_time_cli_time_set(struct bt_mesh_time_cli *cli,
  * @retval -EALREADY      A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
- * @retval -EAGAIN        The device has not been provisioned or the request
- *                        timed out without a response.
+ * @retval -EAGAIN        The device has not been provisioned.
+ * @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_time_cli_zone_get(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -215,8 +215,8 @@ int bt_mesh_time_cli_zone_get(struct bt_mesh_time_cli *cli,
  * @retval -EALREADY      A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
- * @retval -EAGAIN        The device has not been provisioned or the request
- *                        timed out without a response.
+ * @retval -EAGAIN        The device has not been provisioned.
+ * @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_time_cli_zone_set(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
@@ -236,8 +236,8 @@ int bt_mesh_time_cli_zone_set(struct bt_mesh_time_cli *cli,
  * @retval -EALREADY      A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
- * @retval -EAGAIN        The device has not been provisioned or the request
- *                        timed out without a response.
+ * @retval -EAGAIN        The device has not been provisioned.
+ * @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_time_cli_tai_utc_delta_get(
 	struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -260,8 +260,8 @@ int bt_mesh_time_cli_tai_utc_delta_get(
  * @retval -EALREADY      A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
- * @retval -EAGAIN        The device has not been provisioned or the request
- *                        timed out without a response.
+ * @retval -EAGAIN        The device has not been provisioned.
+ * @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_time_cli_tai_utc_delta_set(
 	struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -281,8 +281,8 @@ int bt_mesh_time_cli_tai_utc_delta_set(
  * @retval -EALREADY      A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
- * @retval -EAGAIN        The device has not been provisioned or the request
- *                        timed out without a response.
+ * @retval -EAGAIN        The device has not been provisioned.
+ * @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_time_cli_role_get(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx, uint8_t *rsp);
@@ -301,8 +301,8 @@ int bt_mesh_time_cli_role_get(struct bt_mesh_time_cli *cli,
  * @retval -EALREADY      A blocking request is already in progress.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing
  *                        is not configured.
- * @retval -EAGAIN        The device has not been provisioned or the request
- *                        timed out without a response.
+ * @retval -EAGAIN        The device has not been provisioned.
+ * @retval -ETIMEDOUT     The request timed out without a response.
  */
 int bt_mesh_time_cli_role_set(struct bt_mesh_time_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx, const uint8_t *set,


### PR DESCRIPTION
This commit reverts change added in https://github.com/nrfconnect/sdk-nrf/pull/5543 and adds ETIMEDOUT as a return code in mesh blocking API. The corresponding API fix is here: https://github.com/zephyrproject-rtos/zephyr/pull/38816

Reference: https://github.com/nrfconnect/sdk-nrf/pull/5543#pullrequestreview-747635646