### PR TITLE
event manager: Make structs word aligned for x86

### DIFF
--- a/subsys/event_manager/event_manager_priv.h
+++ b/subsys/event_manager/event_manager_priv.h
@@ -16,6 +16,11 @@
 extern "C" {
 #endif
 
+#if !CONFIG_X86
+#define _EM_FORCED_ALIGNMENT
+#else
+#define _EM_FORCED_ALIGNMENT __aligned(4)
+#endif
 
 /* There are 3 levels of priorities defining an order at which event listeners
  * are notified about incoming events.
@@ -36,9 +41,10 @@ extern "C" {
 
 
 /* Declare a zero-length subscriber. */
-#define _EVENT_SUBSCRIBERS_EMPTY(ename, prio)								\
-	const struct {} _CONCAT(_EVENT_SUBSCRIBERS_SECTION_PREFIX(ename, prio), empty)			\
-	__attribute__((__section__(STRINGIFY(_EVENT_SUBSCRIBERS_SECTION_NAME(ename, prio))))) = {};
+#define _EVENT_SUBSCRIBERS_EMPTY(ename, prio)							\
+	const struct {} _CONCAT(_EVENT_SUBSCRIBERS_SECTION_PREFIX(ename, prio), empty)		\
+	__used _EM_FORCED_ALIGNMENT								\
+	__attribute__((__section__(_EVENT_SUBSCRIBERS_SECTION_NAME(ename, prio)))) = {};
 
 
 /* Convenience macros generating section start and stop markers. */
@@ -71,10 +77,11 @@ extern "C" {
 
 
 /* Subscribe a listener to an event. */
-#define _EVENT_SUBSCRIBE(lname, ename, prio)								\
-	const struct event_subscriber _CONCAT(_CONCAT(__event_subscriber_, ename), lname) __used	\
-	__attribute__((__section__(_EVENT_SUBSCRIBERS_SECTION_NAME(ename, prio)))) = {			\
-		.listener = &_CONCAT(__event_listener_, lname),						\
+#define _EVENT_SUBSCRIBE(lname, ename, prio)							\
+	const struct event_subscriber _CONCAT(_CONCAT(__event_subscriber_, ename), lname)	\
+	__used _EM_FORCED_ALIGNMENT								\
+	__attribute__((__section__(_EVENT_SUBSCRIBERS_SECTION_NAME(ename, prio)))) = {		\
+		.listener = &_CONCAT(__event_listener_, lname),					\
 	}
 
 
@@ -187,7 +194,7 @@ extern "C" {
 #define _EVENT_INFO_DEFINE(ename, types, labels, profile_func)							\
 	const static char *_CONCAT(ename, _log_arg_labels[]) __used = _ARG_LABELS_DEFINE(labels);		\
 	const static enum profiler_arg _CONCAT(ename, _log_arg_types[]) __used = _ARG_TYPES_DEFINE(types);	\
-	const static struct event_info _CONCAT(ename, _info) __used						\
+	const static struct event_info _CONCAT(ename, _info) __used _EM_FORCED_ALIGNMENT			\
 	__attribute__((__section__("event_infos"))) = {								\
 				.profile_fn	= profile_func,							\
 				.log_arg_cnt	= ARRAY_SIZE(_CONCAT(ename, _log_arg_labels)),			\
@@ -196,11 +203,13 @@ extern "C" {
 			}
 
 
-#define _EVENT_LISTENER(lname, notification_fn)					\
-	const struct event_listener _CONCAT(__event_listener_, lname) __used	\
-	__attribute__((__section__("event_listeners"))) = {			\
-		.name = STRINGIFY(lname),					\
-		.notification = (notification_fn),				\
+
+#define _EVENT_LISTENER(lname, notification_fn)						\
+	const struct event_listener _CONCAT(__event_listener_, lname)			\
+	__used _EM_FORCED_ALIGNMENT							\
+	__attribute__((__section__("event_listeners"))) = {				\
+		.name = STRINGIFY(lname),						\
+		.notification = (notification_fn),					\
 	}
 
 
@@ -223,7 +232,7 @@ extern "C" {
 
 #define _EVENT_TYPE_DEFINE(ename, init_log_en, log_fn, ev_info_struct)							\
 	_EVENT_SUBSCRIBERS_DEFINE(ename);										\
-	const struct event_type _CONCAT(__event_type_, ename) __used							\
+	const struct event_type _CONCAT(__event_type_, ename) __used _EM_FORCED_ALIGNMENT				\
 	__attribute__((__section__("event_types"))) = {									\
 		.name				= STRINGIFY(ename),							\
 		.subs_start	= {											\


### PR DESCRIPTION
Change align to cache line for structures in event manager so
it can work fine on x86
removed stringyfy so it could be build with clang

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>