### PR TITLE
doc: reorganize Applications nav items

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -164,6 +164,17 @@ Newly sampled data is always published prior to the old, buffered data.
 The application has LTE and cloud connection awareness.
 Upon a disconnect from the cloud service, the application keeps the sensor data that has been buffered and empty the buffers in batch messages when the application reconnects to the cloud service.
 
+Requirements
+************
+
+The application supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+
+.. include:: /includes/spm.txt
+
 User interface
 **************
 
@@ -221,17 +232,6 @@ In |SES|, select :guilabel:`Tools` > :guilabel:`Options` > :guilabel:`nRF Connec
 See :ref:`cmake_options` for more information.
 
 Alternatively, you can manually set the configuration options to match the contents of the overlay configuration file.
-
-Requirements
-************
-
-The application supports the following development kits:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
-
-.. include:: /includes/spm.txt
 
 Configuration
 *************
@@ -539,35 +539,6 @@ Following are the current limitations in the nRF Cloud implementation of the Ass
 		}
 	}
 
-
-Dependencies
-************
-
-This application uses the following |NCS| libraries and drivers:
-
-* :ref:`event_manager`
-* :ref:`lib_aws_iot`
-* :ref:`lib_aws_fota`
-* :ref:`lib_azure_iot_hub`
-* :ref:`lib_azure_fota`
-* :ref:`lib_nrf_cloud`
-* :ref:`lib_nrf_cloud_fota`
-* :ref:`lib_nrf_cloud_agps`
-* :ref:`lib_date_time`
-* :ref:`lte_lc_readme`
-* :ref:`modem_info_readme`
-* :ref:`lib_download_client`
-* :ref:`lib_fota_download`
-* :ref:`caf_leds`
-
-It uses the following `sdk-nrfxlib`_ library:
-
-* :ref:`nrfxlib:nrf_modem`
-
-In addition, it uses the following sample:
-
-* :ref:`secure_partition_manager`
-
 .. _asset_tracker_v2_internal_modules:
 
 Internal modules
@@ -671,3 +642,31 @@ You can configure the heap memory by using the :kconfig:`CONFIG_HEAP_MEM_POOL_SI
 The data management module that encodes data destined for cloud is the biggest consumer of heap memory.
 Therefore, when adjusting buffer sizes in the data management module, you must also adjust the heap accordingly.
 This avoids the problem of running out of heap memory in worst-case scenarios.
+
+Dependencies
+************
+
+This application uses the following |NCS| libraries and drivers:
+
+* :ref:`event_manager`
+* :ref:`lib_aws_iot`
+* :ref:`lib_aws_fota`
+* :ref:`lib_azure_iot_hub`
+* :ref:`lib_azure_fota`
+* :ref:`lib_nrf_cloud`
+* :ref:`lib_nrf_cloud_fota`
+* :ref:`lib_nrf_cloud_agps`
+* :ref:`lib_date_time`
+* :ref:`lte_lc_readme`
+* :ref:`modem_info_readme`
+* :ref:`lib_download_client`
+* :ref:`lib_fota_download`
+* :ref:`caf_leds`
+
+It uses the following `sdk-nrfxlib`_ library:
+
+* :ref:`nrfxlib:nrf_modem`
+
+In addition, it uses the following sample:
+
+* :ref:`secure_partition_manager`

--- a/applications/machine_learning/README.rst
+++ b/applications/machine_learning/README.rst
@@ -96,6 +96,76 @@ For example, the :ref:`caf_ble_state` and :ref:`caf_ble_adv` modules are not ena
 
 See :ref:`nrf_machine_learning_app_internal_modules` for detailed information about every module used by the nRF Machine Learning application.
 
+Requirements
+************
+
+The application supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy52_nrf52832, thingy53_nrf5340_cpuapp, nrf52840dk_nrf52840
+
+The available configurations use only built-in sensors or the simulated sensor signal.
+There is no need to connect any additional components to the board.
+
+Programming Thingy:52
+=====================
+
+The Thingy:52 does not have the J-Link debug IC and the application configuration does not use a bootloader.
+Use an external debugger to program the firmware.
+See :ref:`zephyr:thingy52_nrf52832` documentation for details.
+
+Programming Thingy:53
+=====================
+
+|thingy53_sample_note|
+
+Custom model requirements
+=========================
+
+The default application configurations rely on pretrained machine learning models that can be automatically downloaded during the application build.
+If you want to train and deploy a custom machine learning model using `Edge Impulse Studio`_, you need a user account for the Edge Impulse Studio web-based tool.
+The user account is not needed to perform predictions using the pretrained models.
+
+Data forwarding requirements
+============================
+
+To forward the collected data using `Edge Impulse's data forwarder`_, you must install the Edge Impulse CLI.
+See `Edge Impulse CLI installation guide`_ for instructions.
+
+Nordic UART Service requirements
+--------------------------------
+
+If you want to forward data over Nordic UART Service (NUS), you need an additional development kit that is able to run the :ref:`central_uart` sample.
+Check the sample Requirements section for the list of supported development kits.
+The sample is used to receive data over NUS and forward it to the host computer over UART.
+See `Testing with Thingy devices`_ for how to test this solution.
+
+.. _nrf_machine_learning_app_requirements_build_types:
+
+nRF Machine Learning build types
+================================
+
+The nRF Machine Learning application does not use a single :file:`prj.conf` file.
+Configuration files are provided for different build types for each supported board.
+
+.. include:: /gs_modifying.rst
+   :start-after: build_types_overview_start
+   :end-before: build_types_overview_end
+
+Before you start testing the application, you can select one of the build types supported by nRF Machine Learning application, depending on your development kit and the building method.
+The application supports the following build types:
+
+* ``ZDebug`` -- Debug version of the application - can be used to verify if the application works correctly.
+* ``ZRelease`` -- Release version of the application - can be used to achieve better performance and reduce memory consumption.
+
+The given board can also support some additional configurations of the nRF Machine Learning application.
+For example, the nRF52840 Development Kit supports ``ZDebugNUS`` configuration that uses :ref:`nus_service_readme` instead of :ref:`zephyr:uart_api` for data forwarding.
+
+.. note::
+    `Selecting a build type`_ is optional.
+    The ``ZDebug`` build type is used by default if no build type is explicitly selected.
+
 User interface
 **************
 
@@ -174,77 +244,6 @@ By default, the application uses the following LED effects:
     * LED blinks slowly if it is not connected.
     * LED blinks with an average frequency if it is connected, but is not actively forwarding data.
     * LED blinks rapidly if it is connected and is actively forwarding data.
-
-Requirements
-************
-
-The application supports the following development kits:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy52_nrf52832, thingy53_nrf5340_cpuapp, nrf52840dk_nrf52840
-
-The available configurations use only built-in sensors or the simulated sensor signal.
-There is no need to connect any additional components to the board.
-
-Programming Thingy:52
-=====================
-
-The Thingy:52 does not have the J-Link debug IC and the application configuration does not use a bootloader.
-Use an external debugger to program the firmware.
-See :ref:`zephyr:thingy52_nrf52832` documentation for details.
-
-Programming Thingy:53
-=====================
-
-|thingy53_sample_note|
-
-Custom model requirements
-=========================
-
-The default application configurations rely on pretrained machine learning models that can be automatically downloaded during the application build.
-If you want to train and deploy a custom machine learning model using `Edge Impulse Studio`_, you need a user account for the Edge Impulse Studio web-based tool.
-The user account is not needed to perform predictions using the pretrained models.
-
-Data forwarding requirements
-============================
-
-To forward the collected data using `Edge Impulse's data forwarder`_, you must install the Edge Impulse CLI.
-See `Edge Impulse CLI installation guide`_ for instructions.
-
-Nordic UART Service requirements
---------------------------------
-
-If you want to forward data over Nordic UART Service (NUS), you need an additional development kit that is able to run the :ref:`central_uart` sample.
-Check the sample Requirements section for the list of supported development kits.
-The sample is used to receive data over NUS and forward it to the host computer over UART.
-See `Testing with Thingy devices`_ for how to test this solution.
-
-.. _nrf_machine_learning_app_requirements_build_types:
-
-nRF Machine Learning build types
-================================
-
-The nRF Machine Learning application does not use a single :file:`prj.conf` file.
-Instead, it comes with configuration files for different build types for each supported board.
-
-.. include:: /gs_modifying.rst
-   :start-after: build_types_overview_start
-   :end-before: build_types_overview_end
-
-Before you start testing the application, you can select one of the build types supported by nRF Machine Learning application, depending on your development kit and the building method.
-The application supports the following build types:
-
-* ``ZDebug`` -- Debug version of the application - can be used to verify if the application works correctly.
-* ``ZRelease`` -- Release version of the application - can be used to achieve better performance and reduce memory consumption.
-
-|nrf_desktop_build_type_conf|
-For example, the nRF52840 Development Kit supports the ``ZDebugNUS`` configuration, which is defined in the :file:`app_ZDebugNUS.conf` file in the :file:`configuration/nrf52840dk_nrf52840` directory.
-This configuration uses :ref:`nus_service_readme` instead of :ref:`zephyr:uart_api` for data forwarding.
-
-.. note::
-    `Selecting a build type`_ is optional.
-    The ``ZDebug`` build type is used by default if no build type is explicitly selected.
 
 .. _nrf_machine_learning_app_configuration:
 
@@ -460,24 +459,6 @@ You can port the nRF Machine Learning application to any board available in the 
 To do so, create the board-specific directory in :file:`applications/machine_learning/configuration/` and add the application configuration files there.
 See the :ref:`nrf_machine_learning_app_configuration` for detailed information about the nRF Machine Learning application configuration.
 
-Dependencies
-************
-
-The application uses the following Zephyr drivers and libraries:
-
-* :ref:`zephyr:sensor_api`
-* :ref:`zephyr:uart_api`
-
-The application uses the following |NCS| libraries and drivers:
-
-* :ref:`event_manager`
-* :ref:`lib_caf`
-* :ref:`ei_wrapper`
-* :ref:`nus_service_readme`
-
-In addition, you can use the :ref:`central_uart` sample together with the application.
-The sample is used to receive data over NUS and forward it to the host over UART.
-
 .. _nrf_machine_learning_app_internal_modules:
 
 Application internal modules
@@ -531,3 +512,21 @@ The nRF Machine Learning application also uses the following dedicated applicati
    This could happen, for example, if the selected sensor sampling frequency is too high for the used implementation of the Edge Impulse data forwarder.
    Data forwarding is stopped to make sure that dropping samples is noticed by the user.
    If you switch to running the machine learning model and then switch back to data forwarding, the data will be again forwarded to the host.
+
+Dependencies
+************
+
+The application uses the following Zephyr drivers and libraries:
+
+* :ref:`zephyr:sensor_api`
+* :ref:`zephyr:uart_api`
+
+The application uses the following |NCS| libraries and drivers:
+
+* :ref:`event_manager`
+* :ref:`lib_caf`
+* :ref:`ei_wrapper`
+* :ref:`nus_service_readme`
+
+In addition, you can use the :ref:`central_uart` sample together with the application.
+The sample is used to receive data over NUS and forward it to the host over UART.

--- a/applications/matter_weather_station/README.rst
+++ b/applications/matter_weather_station/README.rst
@@ -15,27 +15,6 @@ You can use this application as a reference for creating your own application.
 .. note::
     The Matter protocol is in an early development stage and must be treated as an experimental feature.
 
-Requirements
-************
-
-The application supports the following development kits:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy53_nrf5340_cpuapp
-
-To commission the weather station device and control it remotely through a Thread network, you also need a Matter controller device :ref:`configured on PC or smartphone <ug_matter_configuring>` (which requires additional hardware depending on which setup you choose).
-The recommended way of getting measurement values is using the mobile Matter controller application that comes with a neat graphical interface, performs measurements automatically and visualizes the data.
-
-To program a Thingy:53 device where the preprogrammed MCUboot bootloader has been erased, you need the external J-Link programmer.
-If you own an nRF5340 DK that has an onboard J-Link programmer, you can also use it for this purpose.
-
-If the Thingy:53 is programmed with Thingy:53-compatible sample or application, then you can also update the firmware using MCUboot's serial recovery or DFU over Bluetooth LE.
-See :ref:`thingy53_app_guide` for details.
-
-.. note::
-    |matter_gn_required_note|
-
 Overview
 ********
 
@@ -84,10 +63,26 @@ This application supports the following build types:
     `Selecting a build type`_ is optional.
     The ``ZDebug`` build type is used by default if no build type is explicitly selected.
 
-Configuration
-*************
+Requirements
+************
 
-|config|
+The application supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy53_nrf5340_cpuapp
+
+To commission the weather station device and control it remotely through a Thread network, you also need a Matter controller device :ref:`configured on PC or smartphone <ug_matter_configuring>` (which requires additional hardware depending on which setup you choose).
+The recommended way of getting measurement values is using the mobile Matter controller application that comes with a neat graphical interface, performs measurements automatically and visualizes the data.
+
+To program a Thingy:53 device where the preprogrammed MCUboot bootloader has been erased, you need the external J-Link programmer.
+If you own an nRF5340 DK that has an onboard J-Link programmer, you can also use it for this purpose.
+
+If the Thingy:53 is programmed with Thingy:53-compatible sample or application, then you can also update the firmware using MCUboot's serial recovery or DFU over Bluetooth LE.
+See :ref:`thingy53_app_guide` for details.
+
+.. note::
+    |matter_gn_required_note|
 
 User interface
 **************
@@ -116,6 +111,11 @@ USB port:
 
 NFC port with antenna attached:
     Used for obtaining the commissioning information from the Matter accessory device to start the commissioning procedure.
+
+Configuration
+*************
+
+|config|
 
 Building and running
 ********************

--- a/applications/pelion_client/README.rst
+++ b/applications/pelion_client/README.rst
@@ -301,6 +301,47 @@ The internal procedures refer to situations where both connection types interact
 
 The state transitions are related to the LED behavior, as described in `User interface`_.
 
+Requirements
+************
+
+The application supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160_ns, nrf5340dk_nrf5340_cpuapp, nrf5340dk_nrf5340_cpuapp_ns, nrf52840dk_nrf52840
+
+The nRF Pelion Client application is configured to compile and run as a non-secure application on nRF91's and nRF5340's Cortex-M33.
+Therefore, it automatically includes the :ref:`secure_partition_manager` that prepares the required peripherals to be available for the application.
+
+Pelion Device Management requirements
+=====================================
+
+You need a developer account on `Pelion Device Management Portal`_.
+
+.. _pelion_client_reqs_build_types:
+
+nRF Pelion Client build types
+=============================
+
+The nRF Pelion Client application does not use a single :file:`prj.conf` file.
+Configuration files are provided for different build types for each supported board.
+
+.. include:: /gs_modifying.rst
+   :start-after: build_types_overview_start
+   :end-before: build_types_overview_end
+
+Before you start testing the application, you can select one of the build types supported by nRF Pelion Client application, depending on your development kit and the building method.
+The application supports the following build types:
+
+* ``ZDebug`` -- Debug version of the application - can be used to verify if the application works correctly.
+* ``ZRelease`` -- Release version of the application - can be used to achieve better performance and reduce memory consumption.
+
+.. note::
+    `Selecting a build type`_ is optional.
+    The ``ZDebug`` build type is used by default if no build type is explicitly selected.
+
+For more information, see the `Configuration files`_ section.
+
 User interface
 **************
 
@@ -346,47 +387,6 @@ The following table shows the LED behavior demonstrated by the application:
 +-------------------------------+------------------------------------+--------------------------------------------------------------------------------+
 
 See `Application states`_ for an overview of the application state transitions.
-
-Requirements
-************
-
-The application supports the following development kits:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf5340dk_nrf5340_cpuapp, nrf5340dk_nrf5340_cpuapp_ns, nrf52840dk_nrf52840
-
-The nRF Pelion Client application is configured to compile and run as a non-secure application on nRF91's and nRF5340's Cortex-M33.
-Therefore, it automatically includes the :ref:`secure_partition_manager` that prepares the required peripherals to be available for the application.
-
-Pelion Device Management requirements
-=====================================
-
-You need a developer account on `Pelion Device Management Portal`_.
-
-.. _pelion_client_reqs_build_types:
-
-nRF Pelion Client build types
-=============================
-
-The nRF Pelion Client application does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types for each supported board.
-
-.. include:: /gs_modifying.rst
-   :start-after: build_types_overview_start
-   :end-before: build_types_overview_end
-
-Before you start testing the application, you can select one of the build types supported by nRF Pelion Client application, depending on your development kit and the building method.
-The application supports the following build types:
-
-* ``ZDebug`` -- Debug version of the application - can be used to verify if the application works correctly.
-* ``ZRelease`` -- Release version of the application - can be used to achieve better performance and reduce memory consumption.
-
-.. note::
-    `Selecting a build type`_ is optional.
-    The ``ZDebug`` build type is used by default if no build type is explicitly selected.
-
-For more information, see the `Configuration files`_ section.
 
 Configuration
 *************

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -11,17 +11,6 @@ The Serial LTE Modem (SLM) application demonstrates how to use the nRF9160 as a 
 
 The application accepts both the modem-specific AT commands documented in the `nRF91 AT Commands Reference Guide <AT Commands Reference Guide_>`_ and proprietary AT commands documented in :ref:`SLM_AT_intro`.
 
-Requirements
-************
-
-The application supports the following development kit:
-
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
-
-.. include:: /includes/spm.txt
-
 Overview
 ********
 
@@ -101,6 +90,17 @@ UART configuration:
    The GPIO output level on the nRF9160 side must be 3 V.
    You can set the VDD voltage with the **VDD IO** switch (**SW9**).
    See the `VDD supply rail section in the nRF9160 DK User Guide`_ for more information.
+
+Requirements
+************
+
+The application supports the following development kit:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf9160dk_nrf9160_ns
+
+.. include:: /includes/spm.txt
 
 Configuration
 *************


### PR DESCRIPTION
ref: NCSDK-11278

Reorganize the navigation items under the Applications so that they
have a similar order across applications.

Signed-off-by: Deidre Casey <deidre.casey@nordicsemi.no>