### PR TITLE
doc: Document problem with menuconfig and multi-image

### DIFF
--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -86,6 +86,9 @@ You can enable existing child images in the |NCS| by enabling the respective mod
 To turn an application that you have implemented into a child image that can be included in a parent image, you must update the build scripts to enable the child image and add the required configuration options.
 You should also know how image-specific variables are disambiguated and what targets of the child images are available.
 
+Enabling an existing image through Kconfig can not be done through menuconfig, but must instead be done by modifying Kconfig fragments, such as :file:`prj.conf`.
+This is due to image configuration being interdependent.
+
 Updating the build scripts
 ==========================
 


### PR DESCRIPTION
Enabling a child image requires the Kconfig of the parent to be
re-generated due to interdependencies, so we can't enable them through
menuconfig.

This is now documented.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>