### PR TITLE
tfm: mcuboot: Don't enable the MPU from the bootloader

### DIFF
--- a/modules/mcuboot/tfm.conf
+++ b/modules/mcuboot/tfm.conf
@@ -4,3 +4,9 @@
 
 # Cleaning up the core's state as TF-M assumes a clean core.
 CONFIG_MCUBOOT_CLEANUP_ARM_CORE=y
+
+# Don't configure the MPU in the bootloader. Configuring the MPU from
+# the bootloader results in a configuration where all memory accesses
+# are required to be privileged. But in an IPC application there exist
+# both privileged and unprivileged accesses.
+CONFIG_ARM_MPU=n


### PR DESCRIPTION
Prevent the bootloader from enabling and configuring the MPU.

Configuring the MPU from the bootloader results in a configuration
where all memory accesses are required to be privileged. But in an IPC
application there exist both privileged and unprivileged accesses.

NCSDK-10736

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>