### PR TITLE
AT monitor list alignment fix

### DIFF
--- a/lib/at_monitor/at_monitor.ld
+++ b/lib/at_monitor/at_monitor.ld
@@ -1,3 +1,4 @@
+. = ALIGN(4);
 _at_monitor_entry_list_start = .;
 KEEP(*(SORT_BY_NAME("._at_monitor_entry.*")));
 _at_monitor_entry_list_end = .;


### PR DESCRIPTION
`struct at_monitor_entry` is always aligned on word boundary. Hence, when _at_monitor_entry_list_start is placed at unaligned address, it will point to aligning bytes and AT monitor would not find entries to send notifications to. This is somewhat hard to reproduce, as it only comes up in some builds (i. e. depends on previous section size).