### PR TITLE
applications: asset_tracker_v2: Always report all configs back to cloud

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
@@ -109,15 +109,6 @@ struct cloud_data_cfg {
 	double accelerometer_threshold;
 	/** Variable used to govern what data types are requested by the application. */
 	struct cloud_data_no_data no_data;
-
-	/** Flags to signify if the corresponding data value is fresh and can be used. */
-	bool active_mode_fresh		   : 1;
-	bool gps_timeout_fresh		   : 1;
-	bool active_wait_timeout_fresh	   : 1;
-	bool movement_resolution_fresh	   : 1;
-	bool movement_timeout_fresh	   : 1;
-	bool accelerometer_threshold_fresh : 1;
-	bool nod_list_fresh		   : 1;
 };
 
 struct cloud_data_accelerometer {

--- a/applications/asset_tracker_v2/tests/json_common/src/main.c
+++ b/applications/asset_tracker_v2/tests/json_common/src/main.c
@@ -726,14 +726,7 @@ static void test_encode_configuration_data_object(void)
 		.gps_timeout = 60,
 		.accelerometer_threshold = 2,
 		.no_data.gnss = true,
-		.no_data.neighbor_cell = true,
-		.active_mode_fresh = true,
-		.gps_timeout_fresh = true,
-		.active_wait_timeout_fresh = true,
-		.movement_resolution_fresh = true,
-		.movement_timeout_fresh = true,
-		.accelerometer_threshold_fresh = true,
-		.nod_list_fresh = true,
+		.no_data.neighbor_cell = true
 	};
 
 	ret = json_common_config_add(dummy.root_obj, &data, DATA_CONFIG);
@@ -1148,8 +1141,7 @@ static void test_floating_point_encoding_configuration(void)
 	cJSON *decoded_config_obj;
 	struct cloud_data_cfg decoded_values = {0};
 	struct cloud_data_cfg data = {
-		.accelerometer_threshold = 2.22,
-		.accelerometer_threshold_fresh = true
+		.accelerometer_threshold = 2.22
 	};
 
 	ret = json_common_config_add(dummy.root_obj, &data, DATA_CONFIG);


### PR DESCRIPTION
Always report the entire device configuration set to cloud for
incoming configuration updates. Configuration updates received from
cloud should always take precedence and should be reported back to cloud
in its entirety to remove the `delta` between `reported` and `desired`.

This is to prevent a potential mismatch between the reported and
applied config values. This can potentially occur in
poor network conditions, after flash-erases, and upon corruption of
persistent storage.