### PR TITLE
Fixes t3324 lookup entry '010'

### DIFF
--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -327,7 +327,7 @@ int parse_psm(struct at_param_list *at_params,
 	/* Lookup table for T3324 timer used for PSM active time in seconds.
 	 * Ref: GPRS Timer 2 IE in 3GPP TS 24.008 Table 10.5.163/3GPP TS 24.008.
 	 */
-	static const uint32_t t3324_lookup[8] = {2, 60, 600, 60, 60, 60, 60, 0};
+	static const uint32_t t3324_lookup[8] = {2, 60, 360, 60, 60, 60, 60, 0};
 
 	/* Lookup table for T3412 timer used for periodic TAU. Unit is seconds.
 	 * Ref: GPRS Timer 3 in 3GPP TS 24.008 Table 10.5.163a/3GPP TS 24.008.


### PR DESCRIPTION
According to the specifications, the T3324 unit for the value '010' is 0.1h = 6m = 360s. It is not 10m = 600s.

This issue has been present in some form from at least v1.2.0.