### PR TITLE
net: lib: nrf_cloud: remove GPS driver dependency

### DIFF
--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -92,7 +92,7 @@ const k_tid_t cloud_module_thread;
 
 #if defined(CONFIG_NRF_CLOUD_PGPS)
 /* Local copy of the last requested AGPS request from the modem. */
-static struct gps_agps_request agps_request;
+static struct nrf_modem_gnss_agps_data_frame agps_request;
 #endif
 
 /* Cloud module message queue. */
@@ -582,27 +582,6 @@ static void disconnect_cloud(void)
 }
 
 #if defined(CONFIG_NRF_CLOUD_PGPS)
-/* Converts the A-GPS data request from GNSS API to GPS driver format. */
-static void agps_request_convert(
-	struct gps_agps_request *dest,
-	const struct nrf_modem_gnss_agps_data_frame *src)
-{
-	dest->sv_mask_ephe = src->sv_mask_ephe;
-	dest->sv_mask_alm = src->sv_mask_alm;
-	dest->utc = src->data_flags &
-		NRF_MODEM_GNSS_AGPS_GPS_UTC_REQUEST ? 1 : 0;
-	dest->klobuchar = src->data_flags &
-		NRF_MODEM_GNSS_AGPS_KLOBUCHAR_REQUEST ? 1 : 0;
-	dest->nequick = src->data_flags &
-		NRF_MODEM_GNSS_AGPS_NEQUICK_REQUEST ? 1 : 0;
-	dest->system_time_tow = src->data_flags &
-		NRF_MODEM_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST ? 1 : 0;
-	dest->position = src->data_flags &
-		NRF_MODEM_GNSS_AGPS_POSITION_REQUEST ? 1 : 0;
-	dest->integrity = src->data_flags &
-		NRF_MODEM_GNSS_AGPS_INTEGRITY_REQUEST ? 1 : 0;
-}
-
 void pgps_handler(struct nrf_cloud_pgps_event *event)
 {
 	int err;
@@ -860,7 +839,7 @@ static void on_all_states(struct cloud_msg_data *msg)
 		/* Keep a local copy of the incoming request. Used when injecting
 		 * P-GPS data into the modem.
 		 */
-		agps_request_convert(&agps_request, &msg->module.gps.data.agps_request);
+		memcpy(&agps_request, &msg->module.gps.data.agps_request, sizeof(agps_request));
 	}
 #endif
 }

--- a/include/net/nrf_cloud_agps.h
+++ b/include/net/nrf_cloud_agps.h
@@ -12,7 +12,7 @@
  */
 
 #include <zephyr.h>
-#include <drivers/gps.h>
+#include <nrf_modem_gnss.h>
 #include <net/nrf_cloud.h>
 
 #ifdef __cplusplus
@@ -30,7 +30,7 @@ extern "C" {
  *
  * @return 0 if successful, otherwise a (negative) error code.
  */
-int nrf_cloud_agps_request(const struct gps_agps_request request);
+int nrf_cloud_agps_request(const struct nrf_modem_gnss_agps_data_frame *request);
 
 /**@brief Requests all available A-GPS data from nRF Cloud via MQTT.
  *
@@ -53,7 +53,7 @@ int nrf_cloud_agps_process(const char *buf, size_t buf_len);
  * @param received_elements return copy of requested elements received
  * since agps request made
  */
-void nrf_cloud_agps_processed(struct gps_agps_request *received_elements);
+void nrf_cloud_agps_processed(struct nrf_modem_gnss_agps_data_frame *received_elements);
 
 /**@brief Query whether A-GPS data has been requested from cloud
  *

--- a/include/net/nrf_cloud_pgps.h
+++ b/include/net/nrf_cloud_pgps.h
@@ -12,7 +12,7 @@
  */
 
 #include <zephyr.h>
-#include <drivers/gps.h>
+#include <nrf_modem_gnss.h>
 #include "nrf_cloud_agps_schema_v1.h"
 
 #ifdef __cplusplus
@@ -254,7 +254,7 @@ int nrf_cloud_pgps_process(const char *buf, size_t buf_len);
  * @return 0 if successful, otherwise a (negative) error code.
  */
 int nrf_cloud_pgps_inject(struct nrf_cloud_pgps_prediction *p,
-			  const struct gps_agps_request *request);
+			  const struct nrf_modem_gnss_agps_data_frame *request);
 
 /**@brief Find out if P-GPS update is in progress
  *

--- a/lib/agps/agps.c
+++ b/lib/agps/agps.c
@@ -9,7 +9,6 @@
 #include <logging/log.h>
 #include <net/socket.h>
 #include <nrf_modem_gnss.h>
-#include <drivers/gps.h>
 
 #if defined(CONFIG_AGPS_SRC_SUPL)
 #include <supl_session.h>
@@ -257,25 +256,7 @@ int agps_request_send(struct nrf_modem_gnss_agps_data_frame request)
 	}
 
 #elif defined(CONFIG_AGPS_SRC_NRF_CLOUD) && defined(CONFIG_NRF_CLOUD_MQTT)
-	/* Convert GNSS API A-GPS request to GPS driver A-GPS request. */
-	struct gps_agps_request agps_request;
-
-	agps_request.sv_mask_ephe = request.sv_mask_ephe;
-	agps_request.sv_mask_alm = request.sv_mask_alm;
-	agps_request.utc =
-		request.data_flags & NRF_MODEM_GNSS_AGPS_GPS_UTC_REQUEST ? 1 : 0;
-	agps_request.klobuchar =
-		request.data_flags & NRF_MODEM_GNSS_AGPS_KLOBUCHAR_REQUEST ? 1 : 0;
-	agps_request.nequick =
-		request.data_flags & NRF_MODEM_GNSS_AGPS_NEQUICK_REQUEST ? 1 : 0;
-	agps_request.system_time_tow =
-		request.data_flags & NRF_MODEM_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST ? 1 : 0;
-	agps_request.position =
-		request.data_flags & NRF_MODEM_GNSS_AGPS_POSITION_REQUEST ? 1 : 0;
-	agps_request.integrity =
-		request.data_flags & NRF_MODEM_GNSS_AGPS_INTEGRITY_REQUEST ? 1 : 0;
-
-	err = nrf_cloud_agps_request(agps_request);
+	err = nrf_cloud_agps_request(&request);
 	if (err) {
 		LOG_ERR("nRF Cloud A-GPS request failed, error: %d", err);
 		return err;

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
@@ -11,8 +11,12 @@
 #include <modem/modem_info.h>
 #include <modem/lte_lc.h>
 #include <net/nrf_cloud.h>
+#if defined(CONFIG_NRF_CLOUD_PGPS)
 #include <net/nrf_cloud_pgps.h>
+#endif
+#if defined(CONFIG_NRF_CLOUD_AGPS) || defined(CONFIG_NRF_CLOUD_PGPS)
 #include <net/nrf_cloud_agps.h>
+#endif
 #include <net/nrf_cloud_cell_pos.h>
 #include "cJSON.h"
 #include "nrf_cloud_fsm.h"
@@ -117,9 +121,11 @@ void nrf_cloud_fota_job_free(struct nrf_cloud_fota_job_info *const job);
 int nrf_cloud_rest_fota_execution_parse(const char *const response,
 					struct nrf_cloud_fota_job_info *const job);
 
+#if defined(CONFIG_NRF_CLOUD_PGPS)
 /** @brief Parses the PGPS response (REST and MQTT) from nRF Cloud */
 int nrf_cloud_parse_pgps_response(const char *const response,
 				  struct nrf_cloud_pgps_result *const result);
+#endif
 
 /** @brief Adds common [network] modem info to the provided cJSON object */
 int nrf_cloud_json_add_modem_info(cJSON * const data_obj);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -1135,6 +1135,7 @@ err_cleanup:
 	return ret;
 }
 
+#if defined(CONFIG_NRF_CLOUD_PGPS)
 int nrf_cloud_parse_pgps_response(const char *const response,
 	struct nrf_cloud_pgps_result *const result)
 {
@@ -1193,6 +1194,7 @@ cleanup:
 	}
 	return err;
 }
+#endif /* CONFIG_NRF_CLOUD_PGPS */
 
 int get_string_from_array(const cJSON *const array, const int index,
 			  char **string_out)


### PR DESCRIPTION
Removed usage of the GPS driver API because the driver has been deprecated and will be removed.

Signed-off-by: Tommi Kangas <tommi.kangas@nordicsemi.no>