### PR TITLE
manifest: Update zephyr to add missing HAS_HW_NRF_* entries for nRF5340

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.6.99-ncs1
+      revision: e0448d102b8e3174b57b94b167e0180f3df9bd9a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This update adds a few missing selections of HAS_HW_NRF_* Kconfig
options for peripherals available in nRF5340.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>