### PR TITLE
lib: lte_link_control: multiple registered LTE event handlers and better testability

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -61,6 +61,7 @@ nRF9160
   * :ref:`lte_lc_readme` library:
 
     * Changed the value of an invalid E-UTRAN cell ID from zero to UINT32_MAX for the LTE_LC_EVT_NEIGHBOR_CELL_MEAS event.
+    * Added support for multiple LTE event handlers. Thus, deregistration is not possible by using lte_lc_register_handler(NULL) anymore and it is done by the :c:func:`lte_lc_deregister_handler` function in the API.
 
   * :ref:`https_client` sample:
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -605,10 +605,21 @@ typedef void(*lte_lc_evt_handler_t)(const struct lte_lc_evt *const evt);
 
 /** @brief Register event handler for LTE events.
  *
- *  @param handler Event handler. Handler is de-registered if parameter is
- *		   NULL.
+ *  @param handler Event handler.
  */
+
 void lte_lc_register_handler(lte_lc_evt_handler_t handler);
+
+/**
+ * @brief Function to de-register event handler for LTE events.
+ *
+ *  @param handler Event handler.
+ *
+ * @retval 0            If command execution was successful.
+ * @retval -ENXIO       If handler cannot be found.
+ * @retval -EINVAL      If handler is a NULL pointer.
+ */
+int lte_lc_deregister_handler(lte_lc_evt_handler_t handler);
 
 /** @brief Initializes the module and configures the modem.
  *

--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -22,6 +22,112 @@
 
 LOG_MODULE_REGISTER(lte_lc_helpers, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
+static K_MUTEX_DEFINE(list_mtx);
+
+/**@brief List element for event handler list. */
+struct event_handler {
+	sys_snode_t          node;
+	lte_lc_evt_handler_t handler;
+};
+
+static sys_slist_t handler_list;
+
+/**
+ * @brief Find the handler from the event handler list.
+ *
+ * @return The node or NULL if not found and its previous node in @p prev_out.
+ */
+static struct event_handler *event_handler_list_find_node(struct event_handler **prev_out,
+							  lte_lc_evt_handler_t handler)
+{
+	struct event_handler *prev = NULL, *curr;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&handler_list, curr, node) {
+		if (curr->handler == handler) {
+			*prev_out = prev;
+			return curr;
+		}
+		prev = curr;
+	}
+	return NULL;
+}
+
+/**@brief Test if the handler list is empty. */
+bool event_handler_list_is_empty(void)
+{
+	return sys_slist_is_empty(&handler_list);
+}
+
+/**@brief Add the handler in the event handler list if not already present. */
+int event_handler_list_append_handler(lte_lc_evt_handler_t handler)
+{
+	struct event_handler *to_ins;
+
+	k_mutex_lock(&list_mtx, K_FOREVER);
+
+	/* Check if handler is already registered. */
+	if (event_handler_list_find_node(&to_ins, handler) != NULL) {
+		LOG_DBG("Handler already registered. Nothing to do");
+		k_mutex_unlock(&list_mtx);
+		return 0;
+	}
+
+	/* Allocate memory and fill. */
+	to_ins = (struct event_handler *)k_malloc(sizeof(struct event_handler));
+	if (to_ins == NULL) {
+		k_mutex_unlock(&list_mtx);
+		return -ENOBUFS;
+	}
+	memset(to_ins, 0, sizeof(struct event_handler));
+	to_ins->handler = handler;
+
+	/* Insert handler in the list. */
+	sys_slist_append(&handler_list, &to_ins->node);
+	k_mutex_unlock(&list_mtx);
+	return 0;
+}
+
+/**@brief Remove the handler from the event handler list if registered. */
+int event_handler_list_remove_event_handler(lte_lc_evt_handler_t handler)
+{
+	struct event_handler *curr, *prev = NULL;
+
+	k_mutex_lock(&list_mtx, K_FOREVER);
+
+	/* Check if the handler is registered before removing it. */
+	curr = event_handler_list_find_node(&prev, handler);
+	if (curr == NULL) {
+		LOG_WRN("Handler not registered. Nothing to do");
+		k_mutex_unlock(&list_mtx);
+		return 0;
+	}
+
+	/* Remove the handler from the list. */
+	sys_slist_remove(&handler_list, &prev->node, &curr->node);
+	k_free(curr);
+
+	k_mutex_unlock(&list_mtx);
+	return 0;
+}
+
+/**@brief dispatch events. */
+void event_handler_list_dispatch(const struct lte_lc_evt *const evt)
+{
+	struct event_handler *curr, *tmp;
+
+	k_mutex_lock(&list_mtx, K_FOREVER);
+
+	/* Dispatch events to all registered handlers */
+	LOG_DBG("Dispatching events:");
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&handler_list, curr, tmp, node) {
+		LOG_DBG(" - handler=0x%08X", (uint32_t)curr->handler);
+		curr->handler(evt);
+	}
+	LOG_DBG("Done");
+
+	k_mutex_unlock(&list_mtx);
+}
+
 static int string_to_int(const char *str_buf, int base, int *output)
 {
 	int temp;
@@ -684,7 +790,7 @@ int parse_ncellmeas(const char *at_response, struct lte_lc_cells_info *cells)
 					NULL,
 					&resp_list);
 	if (err && err != -E2BIG) {
-		LOG_ERR("Could not parse AT%%XNCELLMEAS  response, error: %d", err);
+		LOG_ERR("Could not parse AT%%NCELLMEAS response, error: %d", err);
 		goto clean_exit;
 	} else if (err == -E2BIG) {
 		incomplete = true;

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -289,3 +289,33 @@ int parse_coneval(const char *at_response, struct lte_lc_conn_eval_params *param
  * @retval -ENODATA If no modem event type was found in the AT response.
  */
 int parse_mdmev(const char *at_response, enum lte_lc_modem_evt *modem_evt);
+
+/* @brief Add the handler in the event handler list if not already present.
+ *
+ *  @param handler Event handler.
+ *
+ * @return Zero on success, negative errno code if the API call fails.
+ */
+int event_handler_list_append_handler(lte_lc_evt_handler_t handler);
+
+/* @brief Remove the handler from the event handler list if present.
+ *
+ *  @param handler Event handler.
+ *
+ * @return Zero on success, negative errno code if the API call fails.
+ */
+int event_handler_list_remove_notif_handler(lte_lc_evt_handler_t handler);
+
+/* @brief Dispatch events for the registered event handlers.
+ *
+ *  @param evt Event.
+ *
+ * @return Zero on success, negative errno code if the API call fails.
+ */
+void event_handler_list_dispatch(const struct lte_lc_evt *const evt);
+
+/* @brief Test if the handler list is empty.
+ *
+ * @return a boolean, true if it's empty, false otherwise
+ */
+bool event_handler_list_is_empty(void);


### PR DESCRIPTION
This PR adds for lib/lte_link_control:
- a support for multiple registered LTE event handlers
- changes to improve testability.