### PR TITLE
samples: edge_impulse: Add nRF53 DK to supported platforms

### DIFF
--- a/samples/edge_impulse/data_forwarder/README.rst
+++ b/samples/edge_impulse/data_forwarder/README.rst
@@ -17,7 +17,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf52dk_nrf52832, nrf52840dk_nrf52840
+   :rows: nrf9160dk_nrf9160_ns, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52dk_nrf52832, nrf52840dk_nrf52840
 
 Overview
 ********

--- a/samples/edge_impulse/data_forwarder/sample.yaml
+++ b/samples/edge_impulse/data_forwarder/sample.yaml
@@ -7,5 +7,7 @@ tests:
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
       - nrf9160dk_nrf9160_ns
     tags: ci_build

--- a/samples/edge_impulse/wrapper/README.rst
+++ b/samples/edge_impulse/wrapper/README.rst
@@ -17,7 +17,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832
+   :rows: nrf9160dk_nrf9160_ns, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832
 
 Overview
 ********

--- a/samples/edge_impulse/wrapper/sample.yaml
+++ b/samples/edge_impulse/wrapper/sample.yaml
@@ -4,9 +4,11 @@ sample:
 tests:
   samples.edge_impulse.wrapper:
     build_only: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160_ns
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160_ns nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
       - nrf9160dk_nrf9160_ns
     tags: ci_build


### PR DESCRIPTION
Change adds nRF53 DK to supported platforms.

Jira: NCSDK-11603