### PR TITLE
kconfig: partition_manager: set size of mcuboot secondary automatically

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -165,7 +165,8 @@ Kconfig*                                  @tejlmand
 /tests/lib/hw_unique_key*/                @oyvindronningstad @Vge0rge
 /tests/lib/modem_jwt/                     @SeppoTakalo
 /tests/modules/tfm/                       @hakonfam
-/tests/modules/mcuboot/external_flash/     @hakonfam @sigvartmh
+/tests/modules/mcuboot/external_flash/    @hakonfam @sigvartmh
+/tests/subsys/pcd/                        @hakonfam @sigvartmh
 /tests/subsys/profiler/                   @pdunaj @MarekPieta
 /tests/subsys/zigbee/                     @tomchy @sebastiandraus
 /tests/subsys/bluetooth/mesh/             @trond-snekvik

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -637,25 +637,6 @@ to the external flash")
 
 endif()
 
-# Ensure that the size of the second slot matches the primary slot when
-# external flash is used. This check must be here since the size of
-# the primary slot is not known during the configure stage of the mcuboot
-# child image.
-if (CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY)
-  if (NOT ${PM_MCUBOOT_SECONDARY_SIZE} EQUAL ${PM_MCUBOOT_PRIMARY_SIZE})
-    if (DEFINED static_configuration)
-      set(last_part "If the size of 'mcuboot_secondary' is set in your static \
-configuration you need to update the value there. Otherwise, this is done by \
-setting CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY")
-    else()
-      set(last_part "This is done by setting CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY")
-    endif()
-    message(WARNING "\
-The size of the 'mcuboot_secondary' partition is incorrect (${PM_MCUBOOT_SECONDARY_SIZE}).
-Its size must be ${PM_MCUBOOT_PRIMARY_SIZE} to match the  primary partition. ${last_part}")
-  endif()
-endif()
-
 # We need to tell the flash runner use the merged hex file instead of
 # 'zephyr.hex'This is typically done by setting the 'hex_file' property of the
 # 'runners_yaml_props_target' target. However, since the CMakeLists.txt file

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -115,7 +115,7 @@ The code for integrating MCUboot into |NCS| is located in :file:`ncs/nrf/modules
 
 The following list summarizes the most important changes inherited from upstream MCUboot:
 
-* No changes yet
+* The value of the :kconfig:`CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY` Kconfig option does not have to be specified manually as it automatically shares the value with the primary partition.
 
 Mcumgr
 ======

--- a/doc/nrf/ug_bootloader_external_flash.rst
+++ b/doc/nrf/ug_bootloader_external_flash.rst
@@ -14,12 +14,5 @@ See :ref:`pm_external_flash` for general information about how to set up partiti
 
    Currently, only MCUboot supports booting images stored in the external memory partition.
 
-To use the external flash memory as storage for the secondary partition, you must manually specify the size of the secondary partition by setting the value of the :kconfig:`CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY` configuration option to match the value of the automatically deduced size of the primary partition.
-CMake gives a warning when the values do not match, and it also provides the correct value.
-
-.. note::
-
-   Currently, you must manually synchronize the value of :kconfig:`CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY` by setting it for both the parent image and the MCUboot child image.
-
 Both the nRF52840 DK and nRF5340 DK come with an external flash memory that can be used for the secondary slot and can be accessed using the QSPI NOR flash memory driver.
 See the test in :file:`tests/modules/mcuboot/external_flash` for an example on how to enable this.

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -169,14 +169,6 @@ config PM_EXTERNAL_FLASH_BASE
 	hex "External flash base address"
 	default 0
 
-config PM_PARTITION_SIZE_MCUBOOT_SECONDARY
-	hex "Size of MCUboot secondary partition"
-	default 0
-	depends on PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
-	depends on BOOTLOADER_MCUBOOT || MCUBOOT
-	help
-	  Must be set to the same size as the 'MCUBOOT_PRIMARY' partition.
-
 config PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 	bool "Place MCUboot secondary in external flash"
 	depends on BOOTLOADER_MCUBOOT || MCUBOOT

--- a/tests/modules/mcuboot/external_flash/child_image/mcuboot/prj.conf
+++ b/tests/modules/mcuboot/external_flash/child_image/mcuboot/prj.conf
@@ -20,9 +20,6 @@ CONFIG_DEBUG_OPTIMIZATIONS=y
 # Enable flash operations
 CONFIG_FLASH=y
 
-# This value must match the size of the MCUboot primary partition.
-CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY=0xe0000
-
 # This must be increased to accommodate the bigger images.
 CONFIG_BOOT_MAX_IMG_SECTORS=256
 

--- a/tests/subsys/pcd/child_image/hello_world.conf
+++ b/tests/subsys/pcd/child_image/hello_world.conf
@@ -4,6 +4,5 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-CONFIG_ZTEST=y
-
-CONFIG_BOOTLOADER_MCUBOOT=y
+# Enable B0N on the network core
+CONFIG_SECURE_BOOT=y

--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.7.99-ncs3
+      revision: 7606d9cad32c95a0d6fb7e872b070c71e85f931d
       path: bootloader/mcuboot
     - name: nrfxlib
       repo-path: sdk-nrfxlib


### PR DESCRIPTION
kconfig: partition_manager: set size of mcuboot secondary automatically

Fix bug in partition manager where 'share_size' could not be used for
sharing size between a partition in a region with non-complex placement
strategy and a partition in a region with complex placement strategy.

Also leverage this functionality to avoid having to manually set the
size of the mcuboot secondary slot when it is stored in external flash.

Ref: NCSDK-10375
