### PR TITLE
manifest: update zephyr to pull in smp_svr fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.6.99-ncs1
+      revision: pull/630/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Increase stack size to avoid stack overflow on
certain boards.

Ref: NCSDK-11336
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>