### PR TITLE
samples: nrf9160: modem_shell: Use vsnprintfcb() in mosh_print

### DIFF
--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -31,6 +31,8 @@ CONFIG_SHELL_ARGC_MAX=16
 CONFIG_SHELL_CMD_BUFF_SIZE=3072
 # Shell stack has impact for modem shell application, not CONFIG_MAIN_STACK_SIZE
 CONFIG_SHELL_STACK_SIZE=16384
+# Enable use of vsnprintfcb() for extending mosh_print() format
+CONFIG_CBPRINTF_LIBC_SUBSTS=y
 
 CONFIG_MINIMAL_LIBC=n
 CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
vsnprintf() doesn't support %lld properly. shell_print() did support that and changing to mosh_print, which used vsnprintf() caused some crashes because %lld was handled incorrectly and next %s specifier accessed wrong memory area for the string.

The issue can be seen in the output of `link ncellmeas --single` command.
Before the change:
```
    ID 1805086, phy ID 110, MCC 244 MNC 12, RSRP 58 : -83dBm, RSRQ 24, TAC 322, earfcn 6200, meas time ld, TA ▒i▒▒#▒
```

After the change:
```
    ID 1805086, phy ID 110, MCC 244 MNC 12, RSRP 58 : -83dBm, RSRQ 26, TAC 322, earfcn 6200, meas time 38230, TA 48
```