### PR TITLE
zigbee: Remove unused error() function from zigbee samples

### DIFF
--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -490,16 +490,6 @@ void zboss_signal_handler(zb_bufid_t bufid)
 	}
 }
 
-void error(void)
-{
-	dk_set_leds_state(DK_ALL_LEDS_MSK, DK_NO_LEDS_MSK);
-
-	while (true) {
-		/* Spin forever */
-		k_sleep(K_MSEC(1000));
-	}
-}
-
 void main(void)
 {
 	int blink_status = 0;

--- a/samples/zigbee/network_coordinator/src/main.c
+++ b/samples/zigbee/network_coordinator/src/main.c
@@ -198,16 +198,6 @@ void zboss_signal_handler(zb_bufid_t bufid)
 	}
 }
 
-void error(void)
-{
-	dk_set_leds_state(DK_ALL_LEDS_MSK, DK_NO_LEDS_MSK);
-
-	while (true) {
-		/* Spin for ever */
-		k_sleep(K_MSEC(1000));
-	}
-}
-
 void main(void)
 {
 	int blink_status = 0;

--- a/samples/zigbee/shell/src/main.c
+++ b/samples/zigbee/shell/src/main.c
@@ -219,16 +219,6 @@ void zboss_signal_handler(zb_bufid_t bufid)
 	}
 }
 
-void error(void)
-{
-	dk_set_leds_state(DK_ALL_LEDS_MSK, DK_NO_LEDS_MSK);
-
-	while (true) {
-		/* Spin forever */
-		k_sleep(K_MSEC(1000));
-	}
-}
-
 void main(void)
 {
 	LOG_INF("Starting Zigbee shell application");

--- a/samples/zigbee/template/src/main.c
+++ b/samples/zigbee/template/src/main.c
@@ -200,16 +200,6 @@ void zboss_signal_handler(zb_bufid_t bufid)
 	}
 }
 
-void error(void)
-{
-	dk_set_leds_state(DK_ALL_LEDS_MSK, DK_NO_LEDS_MSK);
-
-	while (true) {
-		/* Spin forever */
-		k_sleep(K_MSEC(1000));
-	}
-}
-
 void main(void)
 {
 	LOG_INF("Starting Zigbee application template example");


### PR DESCRIPTION
This commit removes unused error() function from zigbee samples.