### PR TITLE
lib: modem_jwt: Add integration platform for JWT unittest

### DIFF
--- a/tests/lib/modem_jwt/testcase.yaml
+++ b/tests/lib/modem_jwt/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   unity.modem_jwt:
     platform_allow: qemu_cortex_m3 native_posix
     tags: jwt
+    integration_platforms: native_posix


### PR DESCRIPTION
This is requested in #5742

Signed-off-by: Seppo Takalo <seppo.takalo@nordicsemi.no>