### PR TITLE
samples: nrf9160: modem_shell: link: unsuccessful reactivations removed from PDN lst

### DIFF
--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -76,7 +76,7 @@ static void link_continuous_ncellmeas(struct k_work *work)
 static void link_api_activate_mosh_contexts(
 	struct pdn_activation_status_info pdn_act_status_arr[], int size)
 {
-	int i, esm;
+	int i, esm, ret;
 
 	/* Check that all context created by mosh link connect are active and if not,
 	 * then activate:
@@ -84,7 +84,14 @@ static void link_api_activate_mosh_contexts(
 	for (i = 0; i < size; i++) {
 		if (pdn_act_status_arr[i].activated == false &&
 		    link_shell_pdn_info_is_in_list(pdn_act_status_arr[i].cid)) {
-			(void)pdn_activate(pdn_act_status_arr[i].cid, &esm);
+			ret = pdn_activate(pdn_act_status_arr[i].cid, &esm);
+			if (ret) {
+				mosh_warn(
+					"Cannot reactivate ctx with CID #%d, err: %d, removing from the list",
+						pdn_act_status_arr[i].cid,
+						ret);
+				link_shell_pdn_info_list_remove(pdn_act_status_arr[i].cid);
+			}
 		}
 	}
 }

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
@@ -211,7 +211,7 @@ static struct link_shell_pdn_info *link_shell_pdn_info_list_find(uint8_t cid)
 	return iterator;
 }
 
-static void link_shell_pdn_info_list_remove(uint8_t cid)
+void link_shell_pdn_info_list_remove(uint8_t cid)
 {
 	struct link_shell_pdn_info *found;
 

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.h
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.h
@@ -26,7 +26,10 @@ int link_shell_pdn_activate(int pdn_cid);
 
 int link_family_str_to_pdn_lib_family(enum pdn_fam *ret_fam, const char *family);
 const char *link_pdn_lib_family_to_string(enum pdn_fam pdn_family, char *out_fam_str);
+
 bool link_shell_pdn_info_is_in_list(uint8_t cid);
+void link_shell_pdn_info_list_remove(uint8_t cid);
+
 int link_shell_pdn_auth_prot_to_pdn_lib_method_map(int auth_proto, enum pdn_auth *method);
 
 #endif /* MOSH_LINK_SHELL_PDN_H */


### PR DESCRIPTION
When going to normal mode and if reactivation of the contexts, that were
created by using "link connect", is unsuccessful, those will be removed
from the internal pdn context list to avoid further failure attempts.

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>