### PR TITLE
tests: Add integration_platforms to ..yaml for applications and tests

### DIFF
--- a/applications/asset_tracker/sample.yaml
+++ b/applications/asset_tracker/sample.yaml
@@ -4,4 +4,7 @@ tests:
   applications.asset_tracker:
     build_only: true
     platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns qemu_x86
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+      - thingy91_nrf9160_ns
     tags: ci_build

--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -1,5 +1,9 @@
 sample:
   name: Asset Tracker v2 Application
+common:
+  integration_platforms:
+    - nrf9160dk_nrf9160_ns
+    - thingy91_nrf9160_ns
 tests:
   applications.asset_tracker_v2.nrf_cloud:
     build_only: true

--- a/applications/asset_tracker_v2/tests/debug_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/debug_module/testcase.yaml
@@ -1,4 +1,8 @@
 tests:
   asset_tracker_v2.debug_module_test.tester:
-    platform_allow: native_posix qemu_cortex_m3 nrf9160dk_nrf9160ns
+    platform_allow: native_posix qemu_cortex_m3 nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - native_posix
+      - qemu_cortex_m3
+      - nrf9160dk_nrf9160_ns
     tags: debug_module

--- a/applications/asset_tracker_v2/tests/gps_module/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/gps_module/testcase.yaml
@@ -1,4 +1,8 @@
 tests:
   asset_tracker_v2.gps_module_test.tester:
     platform_allow: native_posix qemu_cortex_m3 nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - native_posix
+      - qemu_cortex_m3
+      - nrf9160dk_nrf9160_ns
     tags: gps_module

--- a/applications/asset_tracker_v2/tests/json_common/testcase.yaml
+++ b/applications/asset_tracker_v2/tests/json_common/testcase.yaml
@@ -1,4 +1,8 @@
 tests:
   applications.asset_tracker_v2.cloud.cloud_codec.json_common:
     platform_allow: nrf9160dk_nrf9160 native_posix qemu_cortex_m3
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - native_posix
+      - qemu_cortex_m3
     tags: json_common_test

--- a/applications/connectivity_bridge/sample.yaml
+++ b/applications/connectivity_bridge/sample.yaml
@@ -5,4 +5,6 @@ tests:
   applications.connectivity_bridge:
     build_only: true
     platform_allow: thingy91_nrf52840
+    integration_platforms:
+      - thingy91_nrf52840
     tags: ci_build

--- a/tests/lib/date_time/testcase.yaml
+++ b/tests/lib/date_time/testcase.yaml
@@ -1,4 +1,8 @@
 tests:
   date_time.functionality_test:
     platform_allow: nrf9160dk_nrf9160 qemu_x86 native_posix qemu_cortex_m3
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - native_posix
+      - qemu_cortex_m3
     tags: date_time

--- a/tests/lib/lte_lc/testcase.yaml
+++ b/tests/lib/lte_lc/testcase.yaml
@@ -1,4 +1,8 @@
 tests:
   lte_lc.functionality_test:
     platform_allow: nrf9160dk_nrf9160 qemu_x86 native_posix qemu_cortex_m3
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - native_posix
+      - qemu_cortex_m3
     tags: lte_lc

--- a/tests/subsys/net/lib/aws_fota/aws_fota_json/testcase.yaml
+++ b/tests/subsys/net/lib/aws_fota/aws_fota_json/testcase.yaml
@@ -1,4 +1,9 @@
 tests:
   net.lib.aws_fota.aws_fota_json:
     platform_allow: native_posix nrf52840dk_nrf52840 nrf9160dk_nrf9160 qemu_cortex_m3
+    integration_platforms:
+      - native_posix
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - qemu_cortex_m3
     tags: aws fota json

--- a/tests/subsys/net/lib/aws_jobs/testcase.yaml
+++ b/tests/subsys/net/lib/aws_jobs/testcase.yaml
@@ -1,4 +1,7 @@
 tests:
   net.lib.aws_jobs:
     platform_allow: native_posix qemu_cortex_m3
+    integration_platforms:
+      - native_posix
+      - qemu_cortex_m3
     tags: aws

--- a/tests/subsys/net/lib/azure_iot_hub/testcase.yaml
+++ b/tests/subsys/net/lib/azure_iot_hub/testcase.yaml
@@ -1,4 +1,8 @@
 tests:
   net.lib.azure_iot_hub:
     platform_allow: nrf9160dk_nrf9160 qemu_x86 native_posix qemu_cortex_m3
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - native_posix
+      - qemu_cortex_m3
     tags: azure_iot_hub


### PR DESCRIPTION
Add `integration_platforms` to `..yaml` for applications and tests.
Requested in https://github.com/nrfconnect/sdk-nrf/pull/5742.