### PR TITLE
caf: leds: Fix error log when power state of LED driver is set

### DIFF
--- a/subsys/caf/modules/leds.c
+++ b/subsys/caf/modules/leds.c
@@ -200,11 +200,14 @@ static int leds_init(void)
 static void leds_start(void)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(leds); i++) {
-#ifdef CONFIG_PM_DEVICE
-		int err = pm_device_state_set(leds[i].dev,
-					      PM_DEVICE_STATE_ACTIVE);
+#if defined(CONFIG_PM_DEVICE) && !defined(CONFIG_CAF_LEDS_GPIO)
+		/* Zephyr power management API is not implemented for GPIO LEDs.
+		 * LEDs are turned off by CAF LEDs module.
+		 */
+		int err = pm_device_state_set(leds[i].dev, PM_DEVICE_STATE_ACTIVE);
+
 		if (err) {
-			LOG_ERR("PWM enable failed");
+			LOG_ERR("Failed to set LED driver into active state (err: %d)", err);
 		}
 #endif
 		led_update(&leds[i]);
@@ -218,11 +221,14 @@ static void leds_stop(void)
 
 		set_off(&leds[i]);
 
-#ifdef CONFIG_PM_DEVICE
-		int err = pm_device_state_set(leds[i].dev,
-					      PM_DEVICE_STATE_SUSPEND);
+#if defined(CONFIG_PM_DEVICE) && !defined(CONFIG_CAF_LEDS_GPIO)
+		/* Zephyr power management API is not implemented for GPIO LEDs.
+		 * LEDs are turned off by CAF LEDs module.
+		 */
+		int err = pm_device_state_set(leds[i].dev, PM_DEVICE_STATE_SUSPEND);
+
 		if (err) {
-			LOG_ERR("PWM disable failed");
+			LOG_ERR("Failed to set LED driver into suspend state (err: %d)", err);
 		}
 #endif
 	}


### PR DESCRIPTION
LEDs GPIO driver does not implement Zephyr power management API. LEDs are turned off by the CAF LEDs module.

Jira: NCSDK-11658