### PR TITLE
samples: nrf9160: modem_shell: Timestamp fixes

### DIFF
--- a/samples/nrf9160/modem_shell/src/utils/mosh_print.c
+++ b/samples/nrf9160/modem_shell/src/utils/mosh_print.c
@@ -51,7 +51,9 @@ static const char *create_timestamp_string(void)
 	mins = ltm.tm_min;
 	hours = ltm.tm_hour;
 	day = ltm.tm_mday;
-	month = ltm.tm_mon;
+	/* Range is 0-11, as per POSIX */
+	month = ltm.tm_mon + 1;
+	/* Relative to 1900, as per POSIX */
 	year = 1900 + ltm.tm_year;
 
 	sprintf(timestamp_str,


### PR DESCRIPTION
Fixes two things:
* Delay date time request to increase the probability of finding modem time, i.e., have modem time available after network registration
* Fix month handling in timestamp. POSIX structure has month range between 0-11, not 1-12.

Date time library update also ongoing to change some of the behavior in there: https://github.com/nrfconnect/sdk-nrf/pull/5687 