### PR TITLE
applications: serial_lte_modem: Add integration platforms 

### DIFF
--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -4,9 +4,13 @@ tests:
   samples.nrf9160.serial_lte_modem:
     build_only: true
     platform_allow: nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
     tags: ci_build
   samples.nrf9160.serial_lte_modem.native_tls:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-native_tls.conf
     platform_allow: nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
     tags: ci_build


### PR DESCRIPTION
Add integration_platforms section for Serial LTE Modem app.


Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>