### PR TITLE
doc: requirements: update NCS Sphinx theme

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,7 +1,7 @@
 recommonmark==0.6.0
 CommonMark>=0.9.1
 sphinxcontrib-mscgen>=0.6
-sphinx-ncs-theme>=0.6.3
+sphinx-ncs-theme>=0.6.4
 pygments>=2.7.0
 m2r2
 sphinxcontrib-plantuml


### PR DESCRIPTION
Update the sphinx-ncs-theme to 0.6.4 so that search tips are included.