### PR TITLE
mpsl: enable simple gpio FEM for nRF5340

### DIFF
--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -19,8 +19,7 @@ config MPSL_FEM
 	bool "Radio front-end module (FEM) support"
 	# MPSL_FEM_GENERIC_TWO_CTRL_PINS is not supported on nRF53 yet
 	depends on MPSL
-	depends on MPSL_FEM_NRF21540_GPIO_SUPPORT || \
-		(MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT && !SOC_SERIES_NRF53X)
+	depends on MPSL_FEM_NRF21540_GPIO_SUPPORT || MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT
 	default y
 	help
 	  Controls if front-end module (FEM) is to be configured and enabled

--- a/subsys/mpsl/fem/mpsl_fem.c
+++ b/subsys/mpsl/fem/mpsl_fem.c
@@ -114,7 +114,7 @@ static int ppi_channel_alloc(uint8_t *ppi_channels, size_t size)
 	return 0;
 }
 
-#if defined(CONFIG_SOC_SERIES_NRF53X)
+#if defined(CONFIG_HAS_HW_NRF_DPPIC)
 static int egu_instance_alloc(uint8_t *p_egu_instance_no)
 {
 	/* Always return EGU0. */
@@ -245,13 +245,13 @@ static int fem_nrf21540_gpio_configure(void)
 		return err;
 	}
 
-	IF_ENABLED(CONFIG_SOC_SERIES_NRF53X,
+	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
 		   (err = egu_instance_alloc(&cfg.egu_instance_no);));
 	if (err) {
 		return err;
 	}
 
-	IF_ENABLED(CONFIG_SOC_SERIES_NRF53X,
+	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
 		   (err = egu_channel_alloc(cfg.egu_channels,
 					    ARRAY_SIZE(cfg.egu_channels),
 					    cfg.egu_instance_no);))

--- a/subsys/mpsl/fem/mpsl_fem.c
+++ b/subsys/mpsl/fem/mpsl_fem.c
@@ -409,7 +409,24 @@ static int fem_simple_gpio_configure(void)
 		}
 	};
 
-	err = ppi_channel_alloc(cfg.ppi_channels, ARRAY_SIZE(cfg.ppi_channels));
+	IF_ENABLED(CONFIG_HAS_HW_NRF_PPI,
+		   (err = ppi_channel_alloc(cfg.ppi_channels, ARRAY_SIZE(cfg.ppi_channels));));
+	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
+		   (err = ppi_channel_alloc(cfg.dppi_channels, ARRAY_SIZE(cfg.dppi_channels));));
+	if (err) {
+		return err;
+	}
+
+	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
+		   (err = egu_instance_alloc(&cfg.egu_instance_no);));
+	if (err) {
+		return err;
+	}
+
+	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
+		   (err = egu_channel_alloc(cfg.egu_channels,
+					    ARRAY_SIZE(cfg.egu_channels),
+					    cfg.egu_instance_no);))
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
This PR adds the necessary changes to enable support for simple gpio
Front-End Modules on nRF5340:
* Allocation of EGU channels to be used to control the simple gpio FEM
from the nRF5340 network core
* Kconfig modifications that make it possible to build nRF5340
applications with support for simple gpio FEM

Signed-off-by: Olav Thoresen <olav.thoresen@nordicsemi.no>