### PR TITLE
applications: serial_lte_modem: UART at command improvement

### DIFF
--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -205,17 +205,18 @@ The ``#XSLMUART`` command manages the UART settings.
 Set command
 -----------
 
-The set command changes the UART settings.
+The set command changes the UART baud rate and hardware flow control settings.
+These settings are stored in the flash memory and applied during the application startup.
 
 Syntax
 ~~~~~~
 
 ::
 
-   #XSLMUART[=<baud_rate>]
+   #XSLMUART[=<baud_rate>,<hwfc>]
 
 The ``<baud_rate>`` parameter is an integer.
-It accepts only the following values:
+It accepts the following values:
 
 * ``1200`` - 1200 bps
 * ``2400`` - 2400 bps
@@ -231,7 +232,20 @@ It accepts only the following values:
 * ``921600`` - 921600 bps
 * ``1000000`` - 1000000 bps
 
-The default value is ``115200``.
+Its default value is ``115200``.
+When not specified, it is set to the last value set for the variable and stored in the flash memory.
+If there is no value stored for the variable, it is set to its default value.If not specified , will use previous value.
+
+The ``<hwfc>`` parameter accepts the following integer values:
+
+* ``0`` - Disable UART hardware flow control.
+
+* ``1`` - Enable UART hardware flow control.
+  In this mode, SLM configures both the RTS and the CTS pins according to the device-tree file.
+
+Its default value is ``1``.
+When not specified, it is set to the last value set for the variable and stored in the flash memory.
+If there is no value stored for the variable, it is set to its default value.
 
 Response syntax
 ~~~~~~~~~~~~~~~
@@ -243,7 +257,7 @@ Example
 
 ::
 
-   AT#XSLMUART=1000000
+   AT#XSLMUART=1000000,1
    OK
 
 Read command
@@ -263,7 +277,7 @@ Response syntax
 
 ::
 
-   #XSLMUART: <baud_rate>
+   #XSLMUART: <baud_rate>,<hwfc>
 
 Example
 ~~~~~~~
@@ -271,7 +285,7 @@ Example
 ::
 
    AT#XSLMUART?
-   #XSLMUART: 115200
+   #XSLMUART: 115200,1
    OK
 
 Test command
@@ -291,7 +305,7 @@ Response syntax
 
 ::
 
-   #XSLMUART: (list of the available baud rate options)
+   #XSLMUART: (list of the available baud rate options),(disable or enable hwfc)
 
 Example
 ~~~~~~~
@@ -299,7 +313,7 @@ Example
 ::
 
    AT#XSLMUART=?
-   #XSLMUART: (1200,2400,4800,9600,14400,19200,38400,57600,115200,230400,460800,921600,1000000)
+   #XSLMUART: (1200,2400,4800,9600,14400,19200,38400,57600,115200,230400,460800,921600,1000000),(0,1)
 
 
 Device UUID #XUUID

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -49,6 +49,9 @@
 
 LOG_MODULE_REGISTER(slm_at, CONFIG_SLM_LOG_LEVEL);
 
+/* This delay is necessary for at_host to send response message in low baud rate. */
+#define SLM_UART_RESPONSE_DELAY 50
+
 /**@brief Shutdown modes. */
 enum shutdown_modes {
 	SHUTDOWN_MODE_IDLE,
@@ -75,9 +78,10 @@ extern struct uart_config slm_uart;
 /* global functions defined in different files */
 void enter_idle(bool full_idle);
 void enter_sleep(void);
-int set_uart_baudrate(uint32_t baudrate);
+int slm_uart_configure(void);
 int poweroff_uart(void);
 bool verify_datamode_control(uint16_t time_limit, uint16_t *time_limit_min);
+extern int slm_setting_uart_save(void);
 
 static void modem_power_off(void)
 {
@@ -181,7 +185,7 @@ static int handle_at_reset(enum at_cmd_type type)
 
 	if (type == AT_CMD_TYPE_SET_COMMAND) {
 		rsp_send(ok_str, strlen(ok_str));
-		k_sleep(K_MSEC(50));
+		k_sleep(K_MSEC(SLM_UART_RESPONSE_DELAY));
 		slm_at_host_uninit();
 		modem_power_off();
 		sys_reboot(SYS_REBOOT_COLD);
@@ -218,11 +222,21 @@ static int handle_at_uuid(enum at_cmd_type type)
 
 static void set_uart_wk(struct k_work *work)
 {
-	set_uart_baudrate(slm_work.data);
+	int err;
+
+	err = slm_uart_configure();
+	if (err != 0) {
+		LOG_ERR("slm_uart_configure: %d", err);
+		return;
+	}
+	err = slm_setting_uart_save();
+	if (err != 0) {
+		LOG_ERR("uart_config_set: %d", err);
+	}
 }
 
 /**@brief handle AT#XSLMUART commands
- *  AT#XSLMUART[=<baud_rate>]
+ *  AT#XSLMUART[=<baud_rate>,<hwfc>]
  *  AT#XSLMUART?
  *  AT#XSLMUART=?
  */
@@ -231,52 +245,58 @@ static int handle_at_slmuart(enum at_cmd_type type)
 	int ret = -EINVAL;
 
 	if (type == AT_CMD_TYPE_SET_COMMAND) {
-		uint32_t baudrate = 115200;
+		uint32_t baudrate;
+		uint16_t hwfc;
 
-		if (at_params_valid_count_get(&at_param_list) > 1) {
-			ret = at_params_unsigned_int_get(&at_param_list, 1, &baudrate);
-			if (ret) {
-				LOG_ERR("AT parameter error");
+		ret = at_params_unsigned_int_get(&at_param_list, 1, &baudrate);
+
+		if (ret == 0) {
+			switch (baudrate) {
+			case 1200:
+			case 2400:
+			case 4800:
+			case 9600:
+			case 14400:
+			case 19200:
+			case 38400:
+			case 57600:
+			case 115200:
+			case 230400:
+			case 460800:
+			case 921600:
+			case 1000000:
+				slm_uart.baudrate = baudrate;
+				break;
+			default:
+				LOG_ERR("Invalid uart baud rate provided. %d", baudrate);
 				return -EINVAL;
 			}
 		}
-		switch (baudrate) {
-		case 1200:
-		case 2400:
-		case 4800:
-		case 9600:
-		case 14400:
-		case 19200:
-		case 38400:
-		case 57600:
-		case 115200:
-		case 230400:
-		case 460800:
-		case 921600:
-		case 1000000:
-			slm_work.data = baudrate;
-			k_work_reschedule(&slm_work.uart_work, K_MSEC(50));
+		ret = at_params_unsigned_short_get(&at_param_list, 2, &hwfc);
+		if (ret == 0) {
+			if ((hwfc != UART_CFG_FLOW_CTRL_RTS_CTS) &&
+				(hwfc != UART_CFG_FLOW_CTRL_NONE)) {
+				LOG_ERR("Invalid uart hwfc provided.");
+				return -EINVAL;
+			}
+			slm_uart.flow_ctrl = (uint8_t)hwfc;
+		}
+		ret = k_work_reschedule(&slm_work.uart_work, K_MSEC(SLM_UART_RESPONSE_DELAY));
+		if (ret > 0) {
 			ret = 0;
-			break;
-		default:
-			LOG_ERR("Invalid uart baud rate provided.");
-			return -EINVAL;
 		}
 	}
-
 	if (type == AT_CMD_TYPE_READ_COMMAND) {
-		sprintf(rsp_buf, "\r\n#XSLMUART: %d\r\n", slm_uart.baudrate);
+		sprintf(rsp_buf, "\r\n#XSLMUART: %d,%d\r\n", slm_uart.baudrate, slm_uart.flow_ctrl);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		ret = 0;
 	}
-
 	if (type == AT_CMD_TYPE_TEST_COMMAND) {
 		sprintf(rsp_buf, "\r\n#XSLMUART: (1200,2400,4800,9600,14400,19200,38400,57600,"
-				 "115200,230400,460800,921600,1000000)\r\n");
+				 "115200,230400,460800,921600,1000000),(0,1)\r\n");
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		ret = 0;
 	}
-
 	return ret;
 }
 

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -9,6 +9,8 @@
 #include <ctype.h>
 #include <logging/log.h>
 #include <drivers/uart.h>
+#include <hal/nrf_uarte.h>
+#include <hal/nrf_gpio.h>
 #include <sys/ring_buffer.h>
 #include <sys/util.h>
 #include <string.h>
@@ -227,18 +229,39 @@ int poweron_uart(void)
 	return err;
 }
 
-int set_uart_baudrate(uint32_t baudrate)
+int slm_uart_configure(void)
 {
 	int err;
 
-	LOG_DBG("Set uart baudrate to: %d", baudrate);
+	LOG_DBG("Set uart baudrate to: %d, hw flow control %d", slm_uart.baudrate,
+		slm_uart.flow_ctrl);
 
-	slm_uart.baudrate = baudrate;
 	err = uart_configure(uart_dev, &slm_uart);
 	if (err != 0) {
 		LOG_ERR("uart_configure: %d", err);
+		return err;
 	}
-
+/* Set HWFC dynamically */
+#if defined(CONFIG_UART_0_NRF_HW_ASYNC_TIMER)
+	if (slm_uart.flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
+		nrf_uarte_hwfc_pins_set(NRF_UARTE0,
+					DT_PROP(DT_NODELABEL(uart0), rts_pin),
+					DT_PROP(DT_NODELABEL(uart0), cts_pin));
+	} else {
+		nrf_uarte_hwfc_pins_disconnect(NRF_UARTE0);
+		nrf_gpio_pin_clear(DT_PROP(DT_NODELABEL(uart0), rts_pin));
+	}
+#endif
+#if defined(CONFIG_UART_2_NRF_HW_ASYNC_TIMER)
+	if (slm_uart.flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
+		nrf_uarte_hwfc_pins_set(NRF_UARTE2,
+					DT_PROP(DT_NODELABEL(uart2), rts_pin),
+					DT_PROP(DT_NODELABEL(uart2), cts_pin));
+	} else {
+		nrf_uarte_hwfc_pins_disconnect(NRF_UARTE2);
+		nrf_gpio_pin_clear(DT_PROP(DT_NODELABEL(uart2), rts_pin));
+	}
+#endif
 	return err;
 }
 
@@ -730,9 +753,17 @@ int slm_at_host_init(void)
 			return err;
 		}
 		uart_configured = true;
-	} /* else re-config UART based on setting page */
-	LOG_DBG("UART baud: %d d/p/s-bits: %d/%d/%d HWFC: %d", slm_uart.baudrate,
-		slm_uart.data_bits, slm_uart.parity, slm_uart.stop_bits, slm_uart.flow_ctrl);
+	} else {
+		/* else re-config UART based on setting page */
+		LOG_DBG("UART baud: %d d/p/s-bits: %d/%d/%d HWFC: %d",
+			slm_uart.baudrate, slm_uart.data_bits, slm_uart.parity,
+			slm_uart.stop_bits, slm_uart.flow_ctrl);
+		err = slm_uart_configure();
+		if (err != 0) {
+			LOG_ERR("Fail to set uart baudrate: %d", err);
+			return err;
+		}
+	}
 	/* Wait for the UART line to become valid */
 	start_time = k_uptime_get_32();
 	do {


### PR DESCRIPTION
The baudrate changed by AT#XSLMUART is saved to flash.
The baudrate setting saved in flash will be applied when SLM starts.
Add AT command option to AT#XSLMUART to configure HW flow control.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>