### PR TITLE
doc: Replace note on non-upgradable bootloaders

### DIFF
--- a/doc/nrf/ug_nrf52.rst
+++ b/doc/nrf/ug_nrf52.rst
@@ -197,7 +197,7 @@ See the :ref:`ug_multiprotocol_support` user guide for instructions on how to en
 The :ref:`nrfxlib:mpsl` library provides services for multiprotocol applications.
 
 
-.. |note| replace:: There is currently no support for upgrading the bootloader (:doc:`mcuboot:index`) on nRF52 Series devices.
+.. |note| replace:: For posibility of introducing upgradable bootloader, please refer to :ref:`ug_bootloader_adding`.
 
 .. fota_upgrades_start
 


### PR DESCRIPTION
Replace the note with link to article describing bootloader
chain-loading.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>