### PR TITLE
samples: nrf9160: aws_iot: Update `README` to reference root `Kconfig`

### DIFF
--- a/samples/nrf9160/aws_iot/README.rst
+++ b/samples/nrf9160/aws_iot/README.rst
@@ -56,8 +56,8 @@ For FOTA DFU related documentation, see :ref:`aws_fota_sample`.
 Configuration
 *************
 
-The configurations used in the sample are listed below.
-They are located in :file:`aws_iot/src/prj.conf`.
+The application specific configurations used in the sample are listed below.
+They are located in :file:`samples/nrf9160/aws_iot/Kconfig`.
 
 .. option:: CONFIG_APP_VERSION
 
@@ -66,6 +66,10 @@ Publishes the application version number to the AWS IoT message broker.
 .. option:: CONFIG_PUBLICATION_INTERVAL_SECONDS
 
 Configures the time interval between each publishing of the message.
+
+.. option:: CONFIG_CONNECTION_RETRY_TIMEOUT_SECONDS
+
+Configures the number of seconds between each AWS IoT connection retry.
 
 .. note::
 


### PR DESCRIPTION
- Update the `README` to reference the correct placement of the sample root `Kconfig` file.
- Add missing documentation for `CONFIG_CONNECTION_RETRY_TIMEOUT_SECONDS` in `README`.