### PR TITLE
applications: asset_tracker_v2: Use deferred logging v2

### DIFF
--- a/applications/asset_tracker_v2/overlay-debug.conf
+++ b/applications/asset_tracker_v2/overlay-debug.conf
@@ -17,8 +17,7 @@
 CONFIG_LOG_MAX_LEVEL=4
 
 # Increase the logging thread capacity so that the debug logs are not lost
-CONFIG_LOG_STRDUP_BUF_COUNT=12
-CONFIG_LOG_BUFFER_SIZE=2048
+CONFIG_LOG_BUFFER_SIZE=1280
 
 # Module debug configurations.
 CONFIG_APPLICATION_MODULE_LOG_LEVEL_DBG=y

--- a/applications/asset_tracker_v2/prj.conf
+++ b/applications/asset_tracker_v2/prj.conf
@@ -20,9 +20,7 @@ CONFIG_HW_STACK_PROTECTION=y
 
 # Logging
 CONFIG_LOG=y
-# Set CONFIG_LOG_STRDUP_BUF_COUNT to a value higher the default value (4) to avoid
-# missing logs due to "log_strdup alloc failed" error.
-CONFIG_LOG_STRDUP_BUF_COUNT=8
+CONFIG_LOG2_MODE_DEFERRED=y
 
 # DK - Used for buttons and LEDs in UI module.
 CONFIG_DK_LIBRARY_INVERT_LEDS=n


### PR DESCRIPTION
Use deferred logging v2.

After the change to deferred logging, floats were not properly printed
anymore. This patch fixes this issue by using version 2 of deferred
logging.

Fix suggested in https://github.com/zephyrproject-rtos/zephyr/issues/18351 and
documented in https://docs.zephyrproject.org/latest/reference/logging/index.html