### PR TITLE
samples: nrf9160: pdn: subscribe to AT notif using nrf_modem_at APIs

### DIFF
--- a/samples/nrf9160/pdn/src/main.c
+++ b/samples/nrf9160/pdn/src/main.c
@@ -8,10 +8,8 @@
 #include <stdint.h>
 #include <zephyr.h>
 #include <modem/pdn.h>
-#include <modem/at_cmd.h>
-#include <modem/at_notif.h>
 #include <modem/lte_lc.h>
-#include <modem/nrf_modem_lib.h>
+#include <nrf_modem_at.h>
 
 extern const char *esm_strerr(int reason);
 
@@ -51,13 +49,13 @@ void main(void)
 	printk("PDN sample started\n");
 
 	/* Register to the necessary packet domain AT notifications */
-	err = at_cmd_write("AT+CNEC=16", NULL, 0, NULL);
+	err = nrf_modem_at_printf("AT+CNEC=16");
 	if (err) {
 		printk("AT+CNEC=16 failed, err %d\n", err);
 		return;
 	}
 
-	err = at_cmd_write("AT+CGEREP=1", NULL, 0, NULL);
+	err = nrf_modem_at_printf("AT+CGEREP=1");
 	if (err) {
 		printk("AT+CGEREP=1 failed, err %d\n", err);
 		return;


### PR DESCRIPTION
Subscribe to PDN-related AT notifications using the nrf_modem_at APIs.

If notifications are registered via the at_cmd library,
they will be sent out from the AT socket through the
at_notif library, which is no longer used by the sample.

Should have been done in e212f6869.