### PR TITLE
cmake: support for nRF Connect SDK (Ncs) CMake package

### DIFF
--- a/share/ncs-package/cmake/NcsConfig.cmake
+++ b/share/ncs-package/cmake/NcsConfig.cmake
@@ -60,3 +60,8 @@ if(NOT NO_BOILERPLATE)
 
   include(${NRF_DIR}/cmake/boilerplate.cmake NO_POLICY_SCOPE)
 endif()
+
+if("${CMAKE_FIND_PACKAGE_NAME}" STREQUAL Ncs)
+  # nRF Connect SDK has been included using `find_package(NCS)` so let's find Zephyr.
+  find_package(Zephyr REQUIRED)
+endif()

--- a/share/ncs-package/cmake/NcsConfigVersion.cmake
+++ b/share/ncs-package/cmake/NcsConfigVersion.cmake
@@ -1,0 +1,32 @@
+# This file provides rRF Connect SDK config package version information.
+#
+# The purpose of the version file is to ensure that CMake find_package can
+# correctly locate the nRF Connect SDK installation for building of applications.
+
+# Relative directory of NRF dir as seen from ZephyrExtension package file
+set(NRF_RELATIVE_DIR "../../..")
+set(NCS_RELATIVE_DIR "../../../..")
+
+# Set the current NRF_DIR
+# The use of get_filename_component ensures that the final path variable will not contain `../..`.
+get_filename_component(NRF_DIR ${CMAKE_CURRENT_LIST_DIR}/${NRF_RELATIVE_DIR} ABSOLUTE)
+get_filename_component(NCS_DIR ${CMAKE_CURRENT_LIST_DIR}/${NCS_RELATIVE_DIR} ABSOLUTE)
+
+file(STRINGS ${NRF_DIR}/VERSION NCS_VERSION LIMIT_COUNT 1 LENGTH_MINIMUM 5)
+string(REGEX MATCH "([^\.]*)\.([^\.]*)\.([^-]*)[-]?(.*)" OUT_VAR ${NCS_VERSION})
+
+set(NCS_VERSION_MAJOR ${CMAKE_MATCH_1})
+set(NCS_VERSION_MINOR ${CMAKE_MATCH_2})
+set(NCS_VERSION_PATCH ${CMAKE_MATCH_3})
+set(NCS_VERSION_EXTRA ${CMAKE_MATCH_4})
+
+set(PACKAGE_VERSION ${NCS_VERSION})
+
+if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+    set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif() 

--- a/share/ncs-package/cmake/ncs_export.cmake
+++ b/share/ncs-package/cmake/ncs_export.cmake
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Purpose of this CMake file is to install a NcsConfig package reference in:
+# Unix/Linux/MacOS: ~/.cmake/packages/Ncs
+# Windows         : HKEY_CURRENT_USER
+#
+# Having NcsConfig package allows for find_package(NCS) for out of tree projects.
+#
+# Create the reference by running `cmake -P ncs_export.cmake` in this directory.
+
+set(MD5_INFILE "current_path.txt")
+
+# We write CMAKE_CURRENT_LIST_DIR into MD5_INFILE, as the content of that file will be used for MD5 calculation.
+# This means we effectively get the MD5 of CMAKE_CURRENT_LIST_DIR which must be used for CMake user package registry.
+file(WRITE ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE} ${CMAKE_CURRENT_LIST_DIR})
+execute_process(COMMAND ${CMAKE_COMMAND} -E md5sum ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE}
+                OUTPUT_VARIABLE MD5_SUM
+)
+string(SUBSTRING ${MD5_SUM} 0 32 MD5_SUM)
+if(WIN32)
+  execute_process(COMMAND ${CMAKE_COMMAND}
+                  -E  write_regv
+                 "HKEY_CURRENT_USER\\Software\\Kitware\\CMake\\Packages\\Ncs\;${MD5_SUM}" "${CMAKE_CURRENT_LIST_DIR}"
+)
+else()
+  file(WRITE $ENV{HOME}/.cmake/packages/Ncs/${MD5_SUM} ${CMAKE_CURRENT_LIST_DIR})
+endif()
+
+message("nRF Connect SDK (NCS) (${CMAKE_CURRENT_LIST_DIR})")
+message("has been added to the user package registry in:")
+if(WIN32)
+  message("HKEY_CURRENT_USER\\Software\\Kitware\\CMake\\Packages\\Ncs\n")
+else()
+  message("~/.cmake/packages/Ncs\n")
+endif()
+
+file(REMOVE ${CMAKE_CURRENT_LIST_DIR}/${MD5_INFILE})

--- a/share/zephyrbuild-package/cmake/ZephyrBuildConfig.cmake
+++ b/share/zephyrbuild-package/cmake/ZephyrBuildConfig.cmake
@@ -1,3 +1,7 @@
 # The ZephyrBuildConfig is simply including NCS package.
 # The NCS package can be used to precisely identify an NCS installation, in case there are multiple Zephyr derivatives installed.
-include(${CMAKE_CURRENT_LIST_DIR}/../../ncs-package/cmake/NcsConfig.cmake)
+
+# Only source the NcsConfig file when `find_package(Ncs)` has not been used.
+if(NOT DEFINED Ncs_DIR)
+  include(${CMAKE_CURRENT_LIST_DIR}/../../ncs-package/cmake/NcsConfig.cmake)
+endif()


### PR DESCRIPTION
This commit introduces a real nRF Connect SDK CMake package that can be
used to lookup an nRF Connect SDK release in an out of workspace
environment.

This further allows users to match a specific nRF Connect SDK
installation when multiple releases are available in the system.

This can be done as:
> `find_package(Ncs 1.7.0 EXACT REQUIRED)`

The Ncs CMake package will chain load the Zephyr package into the build
system.

This means that doing:
> `find_package(Zephyr)`

or
> `find_package(Ncs)`

will have identical behavior, but with the possibility for the user to
ensure an exact version of nRF Connect SDK is used.

To use the nRF Connect SDK CMake package it must first be exported which
can be done by invoking:
> `cmake -P <ncs>/nrf/share/ncs-package/cmake/ncs_export.cmake`

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>