### PR TITLE
lib: lte_link_control: Fix wrong function call in deregistration.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,11 +16,13 @@
 
 "CI-libmodem-test":
   - "samples/nrf9160/**/*"
+  - "lib/lte_link_control/**/*"
   - "lib/nrf_modem_lib/*"
 
 "CI-lwm2m-test":
   - "samples/nrf9160/lwm2m_*/*"
   - "lib/bin/*"
+  - "lib/lte_link_control/**/*"
   - "lib/nrf_modem_lib/*"
 
 "CI-boot-dfu-test":
@@ -32,6 +34,7 @@
   - "include/dfu/**/*"
   - "include/net/**/*"
   - "cmake/*"
+  - "lib/lte_link_control/**/*"
   - "modules/mcuboot/**/*"
   - "samples/nrf9160/*fota/**/*"
   - "samples/nrf9160/fmfu_smp_svr/**/*"

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -763,7 +763,7 @@ int lte_lc_deregister_handler(lte_lc_evt_handler_t handler)
 		LOG_ERR("Invalid handler (handler=0x%08X)", (uint32_t)handler);
 		return -EINVAL;
 	}
-	return event_handler_list_remove_notif_handler(handler);
+	return event_handler_list_remove_handler(handler);
 }
 
 int lte_lc_connect(void)

--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -88,7 +88,7 @@ int event_handler_list_append_handler(lte_lc_evt_handler_t handler)
 }
 
 /**@brief Remove the handler from the event handler list if registered. */
-int event_handler_list_remove_event_handler(lte_lc_evt_handler_t handler)
+int event_handler_list_remove_handler(lte_lc_evt_handler_t handler)
 {
 	struct event_handler *curr, *prev = NULL;
 

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -304,7 +304,7 @@ int event_handler_list_append_handler(lte_lc_evt_handler_t handler);
  *
  * @return Zero on success, negative errno code if the API call fails.
  */
-int event_handler_list_remove_notif_handler(lte_lc_evt_handler_t handler);
+int event_handler_list_remove_handler(lte_lc_evt_handler_t handler);
 
 /* @brief Dispatch events for the registered event handlers.
  *


### PR DESCRIPTION
lte_lc_deregister_handler() is calling wrongly event_handler_list_remove_notif_handler(), which doesn't exist, while correct function is event_handler_list_remove_event_handler(). The mistake occured in PR https://github.com/nrfconnect/sdk-nrf/pull/5719.
Also, add more tests for lte_link_control PRs.
Signed-off-by: Tommi Rantanen <tommi.rantanen@nordicsemi.no>