### PR TITLE
samples: multiprotocol_rpmsg: Increased BT_BUF_CMF_TX_COUNT

### DIFF
--- a/samples/nrf5340/multiprotocol_rpmsg/prj.conf
+++ b/samples/nrf5340/multiprotocol_rpmsg/prj.conf
@@ -14,6 +14,10 @@ CONFIG_BT_MAX_CONN=16
 CONFIG_BT_CTLR_ASSERT_HANDLER=y
 CONFIG_BT_HCI_RAW_RESERVE=1
 
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10
+
 CONFIG_ASSERT=y
 CONFIG_DEBUG_INFO=y
 CONFIG_EXCEPTION_STACK_TRACE=y


### PR DESCRIPTION
It was spotted that at the end of Device Firmware Upgrade
over BLE process appears warning related to the
HCI_ACL_FLOW_CONTROL and results with breaking further
BLE communication. Increased BT_BUF_CMD_TX_COUNT that
was introduced also for hci_rpmsg image as a workaround
for this problem.

Fixes: KRKNWK-11608

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>