### PR TITLE
cmake: use CACHE STRING FORCE for add_overlay function

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -93,7 +93,9 @@ function(add_overlay image overlay_file overlay_type)
   set(old_overlays ${${image}_${overlay_type}})
   string(FIND "${old_overlays}" "${overlay_file}" found)
   if (${found} EQUAL -1)
-    set(${image}_${overlay_type} "${old_overlays} ${overlay_file}" CACHE INTERNAL "")
+    set(${image}_${overlay_type} "${old_overlays};${overlay_file}" CACHE STRING
+      "Extra config fragments for ${image} child image" FORCE
+    )
   endif()
 endfunction()
 


### PR DESCRIPTION
The use of
> `set(${image}_${overlay_type} "<val>" CACHE INTERNAL "")`

has been modified to use
> `set({image}_${overlay_type} "<val>" CACHE STRING "" FORCE)`

instead.

According to CMake documentation, the INTERNAL flag implies FORCE.
However, as NCDIDB-608 reveals, there seems to be an edge case
when the user initializes the cache variable and the build system later
updates it using INTERNAL.
This behavior appears to be scope dependent as it works as expected in
most cases.

Specifically setting the cache variable to type `STRING` and specify
`FORCE` works as expected and updates the CMake cache correctly in all
cases.

This has been filed as an official CMake bug here:
https://gitlab.kitware.com/cmake/cmake/-/issues/22734

Fixes: NCSIDB-608

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>