### PR TITLE
scripts: unity: func_name_list: Improve function name search

### DIFF
--- a/scripts/unity/func_name_list.py
+++ b/scripts/unity/func_name_list.py
@@ -14,7 +14,7 @@ def func_names_from_header(in_file, out_file):
 
     with open(out_file, 'w') as f_out:
         # Regex match all function names in the header file
-        x = re.findall(r"^\s*(?:\w+[*\s]+)+(\w+?)\(.*?\);",
+        x = re.findall(r"^\s*(?:\w+[*\s]+)+(\w+?)\([^\\]*?\);",
                        content, re.M | re.S)
         for item in x:
             f_out.write(item + "\n")

--- a/tests/unity/example_test/src/foo/foo.h
+++ b/tests/unity/example_test/src/foo/foo.h
@@ -21,6 +21,11 @@ int foo_init(void *handle);
 
 static const char test_string[] = "test string";
 
+#define TEST_MACRO(xx) do { \
+	const Z_STRUCT_SECTION_ITERABLE(settings_handler_static, \
+			name) \
+} while (0)
+
 static inline int foo_execute(void)
 {
 	foo_t val = 0;


### PR DESCRIPTION
Improve search to take into account macro content which resembles function declaration.

Fixes NCSDK-10918

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>