### PR TITLE
samples: nrf9160: modem_shell: Fix RAI doc example

### DIFF
--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -306,7 +306,7 @@ Examples
   .. code-block:: console
 
      link funmode -4
-     sock rai --rai_enable
+     link rai -e
      link funmode -1
      sock connect -a 111.222.111.222 -p 20000
      sock rai -i 0 --rai_last


### PR DESCRIPTION
Documentation was not updated when RAI enable was moved from sock to link command.
JIRA: NCSIDB-612
Mentioned in https://devzone.nordicsemi.com/f/nordic-q-a/80467/lte-m-release-assistance-indication-rai