### PR TITLE
applications: nrf_desktop: nachine_learning: Remove workaround in USB state handling

### DIFF
--- a/applications/machine_learning/src/modules/usb_state.c
+++ b/applications/machine_learning/src/modules/usb_state.c
@@ -64,15 +64,7 @@ static void device_status(enum usb_dc_status_code status, const uint8_t *param)
 		new_state = USB_STATE_DISCONNECTED;
 		break;
 	case USB_DC_SUSPEND:
-		if (current_state == USB_STATE_DISCONNECTED) {
-			/* Due to the way USB driver and stack are written
-			 * some events may be issued before application
-			 * connect its callback.
-			 * We assume that device was powered.
-			 */
-			current_state = USB_STATE_POWERED;
-			LOG_WRN("USB suspended while disconnected");
-		}
+		__ASSERT_NO_MSG(current_state != USB_STATE_DISCONNECTED);
 		before_suspend = current_state;
 		new_state = USB_STATE_SUSPENDED;
 		LOG_WRN("USB suspend");

--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -473,15 +473,7 @@ static void device_status(enum usb_dc_status_code cb_status, const uint8_t *para
 		break;
 
 	case USB_DC_SUSPEND:
-		if (state == USB_STATE_DISCONNECTED) {
-			/* Due to the way USB driver and stack are written
-			 * some events may be issued before application
-			 * connect its callback.
-			 * We assume that device was powered.
-			 */
-			state = USB_STATE_POWERED;
-			LOG_WRN("USB suspended while disconnected");
-		}
+		__ASSERT_NO_MSG(state != USB_STATE_DISCONNECTED);
 		before_suspend = state;
 		new_state = USB_STATE_SUSPENDED;
 		LOG_WRN("USB suspend");


### PR DESCRIPTION
Problem with missing USB callback had been fixed
 so the workaround is no longer needed.

Jira: NCSDK-11652

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>