### PR TITLE
tfm: mcuboot: Configure MCUBoot to use 32kb of flash

### DIFF
--- a/modules/mcuboot/tfm.conf
+++ b/modules/mcuboot/tfm.conf
@@ -10,3 +10,11 @@ CONFIG_MCUBOOT_CLEANUP_ARM_CORE=y
 # are required to be privileged. But in an IPC application there exist
 # both privileged and unprivileged accesses.
 CONFIG_ARM_MPU=n
+
+# The MCUBoot max size is usually 48kb, but is reduced to 32kb with
+# this option. TF-M is placed after MCUBoot and it's end must be
+# aligned to 32kb due to placement requirements of the veneers. A
+# result of these requirements is that TF-M will consume an excessive
+# amount of flash if it is placed after a 48kb MCUBoot, so we default
+# to allocating 32kb to MCUBoot instead.
+CONFIG_PM_PARTITION_SIZE_MCUBOOT=0x8000


### PR DESCRIPTION
Configure MCUBoot to use 32kb of flash when TFM is enabled. Otherwise
TF-M will exceed it's 32kb flash region. See the comment and
NCSDK-11467 for details.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>