### PR TITLE
tests: add integration platforms to various tests

### DIFF
--- a/tests/modules/mcuboot/external_flash/testcase.yaml
+++ b/tests/modules/mcuboot/external_flash/testcase.yaml
@@ -2,3 +2,7 @@ tests:
   mcuboot.external_flash:
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp thingy53_nrf5340_cpuapp
     tags: mcuboot external_flash
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - thingy53_nrf5340_cpuapp

--- a/tests/modules/tfm/secure_services/testcase.yaml
+++ b/tests/modules/tfm/secure_services/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   tfm.secure_services:
     platform_allow: nrf9160dk_nrf9160_ns nrf5340dk_nrf5340_cpuapp_ns
     tags: tfm secure_services
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+      - nrf5340dk_nrf5340_cpuapp_ns

--- a/tests/subsys/bootloader/bl_crypto/testcase.yaml
+++ b/tests/subsys/bootloader/bl_crypto/testcase.yaml
@@ -1,5 +1,13 @@
 tests:
   bootloader.bl_crypto:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf9160dk_nrf9160 nrf51dk_nrf51422
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf9160dk_nrf9160
+      - nrf9160dk_nrf9160_ns
+      - nrf51dk_nrf51422
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0

--- a/tests/subsys/bootloader/bl_storage/testcase.yaml
+++ b/tests/subsys/bootloader/bl_storage/testcase.yaml
@@ -1,7 +1,12 @@
 tests:
   bootloader.bl_storage:
-    platform_allow: nrf9160dk_nrf9160
+    platform_allow: nrf9160dk_nrf9160 nrf9160dk_nrf9160ns
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf9160dk_nrf9160_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0
     harness: console
     harness_config:

--- a/tests/subsys/bootloader/bl_validation/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation/testcase.yaml
@@ -2,4 +2,11 @@ tests:
   bootloader.bl_validation:
     platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0 bl_validation

--- a/tests/subsys/bootloader/bl_validation_ff_key/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_ff_key/testcase.yaml
@@ -2,6 +2,11 @@ tests:
   bootloader.bl_validation.ff_key:
     platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
     tags: b0 bl_validation ff_key
     harness: console
     harness_config:

--- a/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
@@ -2,6 +2,10 @@ tests:
   bootloader.bl_validation.negative:
     platform_allow: nrf9160dk_nrf9160
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0 bl_validation negative bl_validation_negative
     harness: console
     harness_config:
@@ -25,6 +29,9 @@ tests:
         - "No bootable image found. Aborting boot."
   bootloader.bl_validation.negative.nrf52:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
     tags: b0 bl_validation negative bl_validation_negative
     harness: console
     harness_config:

--- a/tests/subsys/bootloader/bl_validation_unittest/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_unittest/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bootloader.bl_validation.unittest:
     platform_allow: native_posix
+    integration_platforms:
+      - native_posix
     tags: b0 bl_validation unittest

--- a/tests/subsys/dfu/dfu_target/mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target/mcuboot/testcase.yaml
@@ -1,4 +1,11 @@
 tests:
   dfu.dfu_target.mcuboot:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422 nrf9160dk_nrf9160 native_posix qemu_cortex_m3
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
+      - nrf9160dk_nrf9160
+      - native_posix
+      - qemu_cortex_m3
     tags: dfu mcuboot

--- a/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
@@ -4,3 +4,9 @@ tests:
     # nrfx is used to ensure that variables are stored in RAM, so no qemu
     # or native posix
     platform_exclude: qemu_cortex_m3 qemu_x86 native_posix
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340

--- a/tests/subsys/dfu/dfu_target_stream/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_stream/testcase.yaml
@@ -9,3 +9,7 @@ tests:
     # Since we need the storage partition (and hence PM) allow some nRF devices
     # only.
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp

--- a/tests/subsys/fw_info/testcase.yaml
+++ b/tests/subsys/fw_info/testcase.yaml
@@ -2,4 +2,11 @@ tests:
   fw_info.core:
     platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0 fw_info

--- a/tests/subsys/pcd/testcase.yaml
+++ b/tests/subsys/pcd/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   dfu.pcd:
     platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
     tags: pcd


### PR DESCRIPTION
Add integration platform which matches 'platform_allow'.

Ref: NCSDK-11857
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>