### PR TITLE
applications: serial_lte_modem: MQTT event for PINGRESP and UNSUBACK

### DIFF
--- a/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
@@ -205,7 +205,7 @@ The ``#XHTTPCRSP`` is an unsolicited notification that indicates that a part of 
 Unsolicited notification
 ------------------------
 
-The set command allows you to connect to and disconnect from an HTTP server.
+It indicates that a part of the HTTP response has been received.
 
 Syntax
 ~~~~~~

--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -9,6 +9,45 @@ MQTT AT commands
 
 The following commands list contains the AT commands used to operate the MQTT client.
 
+MQTT event #XMQTTEVT
+====================
+
+The ``#XMQTTEVT`` is an unsolicited notification that indicates the event of the MQTT client.
+
+Unsolicited notification
+------------------------
+
+It indicates the event of the MQTT client.
+
+Syntax
+~~~~~~
+
+::
+
+   #XMQTTEVT=<evt_type>,<result>
+
+* The ``<evt_type>`` value is an integer indicating the type of the event.
+  It can assume the following values:
+
+  * ``0`` - Connection request.
+  * ``1`` - Disconnection.
+    The MQTT client is disconnected from the MQTT broker once this event is notified.
+  * ``2`` - Message received on a topic the client is subscribed to.
+  * ``3`` - Acknowledgment for the published message with QoS 1.
+  * ``4`` - Confirmation of the reception for the published message with QoS 2.
+  * ``5`` - Release of the published message with QoS 2.
+  * ``6`` - Confirmation to a publish release message with QoS 2.
+  * ``7`` - Reception of the subscribe request.
+  * ``8`` - Reception of the unsubscription request.
+  * ``9`` - Ping response from the MQTT broker.
+
+* The ``<result>`` value is an integer indicating the result of the event.
+  It can assume the following values:
+
+  * ``0`` - Success.
+  * *Negative value* - Failure.
+    It is the error code indicating the reason for the failure.
+
 MQTT connect #XMQTTCON
 ======================
 

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -188,6 +188,18 @@ void mqtt_evt_handler(struct mqtt_client *const c, const struct mqtt_evt *evt)
 		}
 		break;
 
+	case MQTT_EVT_UNSUBACK:
+		if (evt->result == 0) {
+			LOG_DBG("UNSUBACK packet id: %u", evt->param.unsuback.message_id);
+		}
+		break;
+
+	case MQTT_EVT_PINGRESP:
+		if (evt->result == 0) {
+			LOG_DBG("PINGRESP packet");
+		}
+		break;
+
 	default:
 		LOG_DBG("default: %d", evt->type);
 		break;


### PR DESCRIPTION
The PINGRESP and UNSUBACK events are not handled in SLM MQTT client.
This commit includes below changes to handle missing events:
 - add MQTT event for PINGRESP.
 - add MQTT event for UNSUBACK
 - add description for MQTT events

Below document fix is also included:
 - minor document fix for SLM HTTP client

Signed-off-by: Larry Tsai <larry.tsai@nordicsemi.no>