### PR TITLE
lib: lte_lc: Add support for period search configuration

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -212,6 +212,7 @@ Modem libraries
   * Added neighbor cell measurement search type parameter in :c:func:`lte_lc_neighbor_cell_measurement`.
   * Added timing advance measurement time to current cell data in :c:enum:`LTE_LC_EVT_NEIGHBOR_CELL_MEAS` event.
   * Updated the library to use the :ref:`nrfxlib:nrf_modem_at` API and the :ref:`at_monitor_readme` library for AT commands.
+  * Added support for periodic search configuration. API functions have been added to set, read and clear the configuration, and to request extra searches.
 
 * :ref:`nrf_modem_lib_readme` library:
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -625,6 +625,130 @@ enum lte_lc_neighbor_search_type {
 	LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE = 2,
 };
 
+/** @brief Periodic search pattern.
+ *	   A search pattern may be of either 'range' or 'table' type.
+ */
+struct lte_lc_periodic_search_pattern {
+	enum lte_lc_periodic_search_pattern_type {
+		LTE_LC_PERIODIC_SEARCH_PATTERN_RANGE = 0,
+		LTE_LC_PERIODIC_SEARCH_PATTERN_TABLE = 1,
+	} type;
+
+	union {
+		/** Configuration for periodic search of type LTE_LC_PERIODIC_SEARCH_PATTERN_RANGE.
+		 */
+		struct lte_lc_periodic_search_range_cfg {
+			/** Sleep time in seconds between searches in the beginning of the range.
+			 *  Allowed values: 0 - 65535 seconds.
+			 */
+			uint16_t initial_sleep;
+
+			/** Sleep time in seconds between searches in the end of the range.
+			 *  Allowed values: 0 - 65535 seconds.
+			 */
+			uint16_t final_sleep;
+
+			/** Optional target time in minutes for achieving the @c final_sleep value.
+			 *  This can be used to determine angle factor between
+			 *  the initial and final sleep times. The timeline for the
+			 *  @c time_to_final_sleep starts from the beginning of the search pattern.
+			 *  If given, the value cannot be greater than the value of
+			 *  the @c pattern_end_point value in the same search pattern.
+			 *  If not given, the angle factor is calculated by using the
+			 *  @c pattern_end_point value so that the @c final_sleep value is reached
+			 *  at the point of @c pattern_end_point.
+			 *
+			 *  Allowed values:
+			 *  -1: Not used
+			 *   0 - 1080 minutes
+			 */
+			int16_t time_to_final_sleep;
+
+			/** Time in minutes that must elapse before entering
+			 *  the next search pattern. The timeline for @c pattern_end_point
+			 *  starts from the beginning of the limited service starting point,
+			 *  which is the moment when the first sleep period started.
+			 *
+			 *  Allowed values: 0 - 1080 minutes.
+			 */
+			int16_t pattern_end_point;
+		} range;
+
+		/** Configuration for periodic search of type LTE_LC_PERIODIC_SEARCH_PATTERN_TABLE.
+		 *  1 to 5 sleep time values for sleep between searches can be configured.
+		 *  It's mandatory to provide @c val_1, while the rest are optional.
+		 *  Unused values must be set to -1.
+		 *  After going through all values, the last value of the last search pattern
+		 *  is repeated, if not configured differently by the @c loop or
+		 *  @c return_to_pattern parameters.
+		 *
+		 *  Allowed values:
+		 *  -1: Value unused.
+		 *   0 - 65535 seconds.
+		 */
+		struct lte_lc_periodic_search_table_cfg {
+			/** Mandatory when LTE_LC_PERIODIC_SEARCH_PATTERN_TABLE is used. */
+			int val_1;
+
+			/** Optional sleep time.
+			 *  Must be set to -1 if not used.
+			 */
+			int val_2;
+
+			/** Optional sleep time. @c val_2 must be configured for
+			 *  this parameter to have effect.
+			 *  Must be set to -1 if not used.
+			 */
+			int val_3;
+
+			/** Optional sleep time. @c val_3 must be configured for
+			 *  this parameter to have effect.
+			 *  Must be set to -1 if not used.
+			 */
+			int val_4;
+
+			/** Optional sleep time. @c val_4 must be configured for
+			 *  this parameter to have effect.
+			 *  Must be set to -1 if not used.
+			 */
+			int val_5;
+		} table;
+	};
+};
+
+/** @brief Periodic search configuration. */
+struct lte_lc_periodic_search_cfg {
+	/** Indicates if the last given pattern is looped from the beginning
+	 *  when the pattern has ended.
+	 *  If several patterns are configured, this impacts only the last pattern.
+	 */
+	bool loop;
+
+	/** Indicates if the modem can return to a given search pattern with shorter sleeps, for
+	 *  example, when radio conditions change and the given pattern index has already
+	 *  been exceeded.
+	 *
+	 *  Allowed values:
+	 *  0: No return pattern.
+	 *  1 - 4: Return to search pattern index 1..4.
+	 */
+	uint8_t return_to_pattern;
+
+	/** 0: No optimization. Every periodic search shall be all band search.
+	 *  1: Use default optimizations predefined by modem. Predefinition depends on
+	 *     the active data profile.
+	 *     See "nRF91 AT Commands - Command Reference Guide" for more information.
+	 *  2 - 20: Every n periodic search must be an all band search.
+	 */
+	uint8_t band_optimization;
+
+	/** The number of valid patterns. Range 1 - 4. */
+	size_t pattern_count;
+
+	/** Array of periodic search patterns. */
+	struct lte_lc_periodic_search_pattern patterns[4];
+};
+
 struct lte_lc_evt {
 	enum lte_lc_evt_type type;
 	union {
@@ -1009,6 +1133,47 @@ int lte_lc_modem_events_enable(void);
  * @retval -EFAULT if AT command failed.
  */
 int lte_lc_modem_events_disable(void);
+
+/** @brief Configure periodic searches. This configuration affects the periodic searches
+ *	   that the modem performs in limited service state to obtain normal service.
+ *	   See @c struct lte_lc_periodic_search_cfg and
+ *	   "nRF91 AT Commands - Command Reference Guide" for more information and
+ *	   in-depth explanations of periodic search configuration.
+ *
+ * @retval 0 if the configuration was successfully sent to the modem.
+ * @retval -EINVAL if an input parameter was NULL or contained an invalid pattern count.
+ * @retval -EFAULT if an AT command could not be sent to the modem.
+ * @retval -EBADMSG if the modem responded with an error to an AT command.
+ */
+int lte_lc_periodic_search_set(const struct lte_lc_periodic_search_cfg *const cfg);
+
+/** @brief Get the configured periodic search parameters.
+ *
+ * @retval 0 if a configuration was found and populated to the provided pointer.
+ * @retval -EINVAL if input parameter was NULL.
+ * @retval -ENOENT if no periodic search was not configured.
+ * @retval -EFAULT if an AT command failed.
+ * @retval -EBADMSG if the modem responded with an error to an AT command or the
+ *		    response could not be parsed.
+ */
+int lte_lc_periodic_search_get(struct lte_lc_periodic_search_cfg *const cfg);
+
+/** @brief Clear the configured periodic search parameters.
+ *
+ * @retval 0 if the configuration was cleared.
+ * @retval -EFAULT if an AT command could not be sent to the modem.
+ * @retval -EBADMSG if the modem responded with an error to an AT command.
+ */
+int lte_lc_periodic_search_clear(void);
+
+/** @brief Request an extra search. This can be used for example when modem is in
+ *	   sleep state between periodic searches. The search is performed only when
+ *	   the modem is in sleep state between periodic searches.
+ *
+ * @retval 0 if the search request was successfully delivered to the modem.
+ * @retval -EFAULT if an AT command could not be sent to the modem.
+ */
+int lte_lc_periodic_search_request(void);
 
 /** @} */
 

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -330,3 +330,28 @@ bool event_handler_list_is_empty(void);
  * @retval -ENODATA if conversion failed.
  */
 int string_to_int(const char *str_buf, int base, int *output);
+
+/* @brief Get periodic search pattern string to be used in AT%PERIODICSEARCHCONF from
+ *	  a pattern struct.
+ *
+ * @param buf Buffer to store the string.
+ * @param buf_size Size of the provided buffer.
+ * @param pattern Pointer to pattern struct.
+ *
+ * @return Pointer to the buffer where the pattern string is stored.
+ */
+char *periodic_search_pattern_get(char *const buf, size_t buf_size,
+				  const struct lte_lc_periodic_search_pattern *const pattern);
+
+/* @brief Parse a periodic search pattern from an AT%PERIODICSEARCHCONF response
+ *	  and populate a pattern struct with the result.
+ *	  The pattern string is expected to be without quotation marks and null-terminated.
+ *
+ * @param pattern_str Pointer to pattern string.
+ * @param pattern Pointer to storage for the parsed pattern.
+ *
+ * @retval 0 if parsing was successful.
+ * @retval -EBADMSG if pattern could not be parsed.
+ */
+int parse_periodic_search_pattern(const char *const pattern_str,
+				  struct lte_lc_periodic_search_pattern *pattern);


### PR DESCRIPTION
Add support for the modem firmware v1.3.1 command to configure
periodic search, AT%PERIODICSEARCHCONF.
A new family of API functions are added to expose the command's
functionality:
	lte_lc_periodic_search_set()
	lte_lc_periodic_search_get()
	lte_lc_periodic_search_clear()
	lte_lc_periodic_search_request()

Tests are added for helper functions that are used to compile and
parse the AT commands that are utilized under the hood.


Note that this PR uses the nrf_modem_at interface, which the rest of the link controller is converted to use in #5741.

The PR is marked as DNM, as there is still testing to be done.