### PR TITLE
lib: lte_lc: Add parsing of timing advance measurement time

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -73,6 +73,7 @@ nRF9160
     * Changed the value of an invalid E-UTRAN cell ID from zero to UINT32_MAX for the LTE_LC_EVT_NEIGHBOR_CELL_MEAS event.
     * Added support for multiple LTE event handlers. Thus, deregistration is not possible by using lte_lc_register_handler(NULL) anymore and it is done by the :c:func:`lte_lc_deregister_handler` function in the API.
     * Added neighbor cell measurement search type parameter in :c:func:`lte_lc_neighbor_cell_measurement`.
+    * Added timing advance measurement time to current cell data in :c:enum:`LTE_LC_EVT_NEIGHBOR_CELL_MEAS` event.
 
   * :ref:`https_client` sample:
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -283,8 +283,24 @@ struct lte_lc_cell {
 
 	/** Timing advance decimal value.
 	 *  Range [0..20512, TIMING_ADVANCE_NOT_VALID = 65535].
+	 *
+	 * Note: Timing advance may be reported from past measurements.
+	 *	 The parameters @c timing_advance_meas_time and @c measurement_time
+	 *	 can be used to evaluate if the parameter is usable.
 	 */
 	uint16_t timing_advance;
+
+	/** Timing advance measurement time in milliseconds, calculated from modem
+	 *  boot time.
+	 *  Range 0 - 18 446 744 073 709 551 614 ms.
+	 *
+	 *  For modem firmware versions >= 1.3.1, timing advance measurement time may
+	 *  be reported from the modem. This means that timing advance data
+	 *  may now also be available in neighbor cell measurements done in
+	 *  RRC idle, even though the timing advance data was captured in RRC connected.
+	 *  If the value is not reported by the modem, it is set to 0.
+	 */
+	uint64_t timing_advance_meas_time;
 
 	/** Measurement time of serving cell in milliseconds.
 	 *  Range 0 - 18 446 744 073 709 551 614 ms.

--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -917,6 +917,23 @@ int parse_ncellmeas(const char *at_response, struct lte_lc_cells_info *cells)
 
 	/* Neighbor cell count. */
 	cells->ncells_count = neighborcell_count_get(at_response);
+
+	/* Starting from modem firmware v1.3.1, timing advance measurement time
+	 * information is added as the last parameter in the response.
+	 */
+	size_t ta_meas_time_index = AT_NCELLMEAS_PRE_NCELLS_PARAMS_COUNT +
+			cells->ncells_count * AT_NCELLMEAS_N_PARAMS_COUNT;
+
+	if (at_params_valid_count_get(&resp_list) > ta_meas_time_index) {
+		err = at_params_int64_get(&resp_list, ta_meas_time_index,
+					  &cells->current_cell.timing_advance_meas_time);
+		if (err) {
+			goto clean_exit;
+		}
+	} else {
+		cells->current_cell.timing_advance_meas_time = 0;
+	}
+
 	if ((cells->ncells_count == 0) || (cells->neighbor_cells == NULL)) {
 		goto clean_exit;
 	}


### PR DESCRIPTION
From modem firmware v1.3.1, timing advance measurement time may
be part of the ncellmeas reponse.
This commit adds parsing of the parameter and populates it to the
cell information struct. Test cases are also modified and added.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>