### PR TITLE
caf: power_manager: Add missing state to wake up handler

### DIFF
--- a/subsys/caf/modules/power_manager.c
+++ b/subsys/caf/modules/power_manager.c
@@ -296,7 +296,8 @@ static bool event_handler(const struct event_header *eh)
 			return true;
 		}
 
-		if (power_state == POWER_STATE_OFF) {
+		if ((power_state == POWER_STATE_OFF) ||
+		    (power_state == POWER_STATE_ERROR_OFF)) {
 			LOG_INF("Wake up when going into sleep - rebooting");
 			sys_reboot(SYS_REBOOT_WARM);
 		}


### PR DESCRIPTION
Change adds missing state to wake up handler to ensure correct behavior after an error.

Jira: NCSDK-11871