### PR TITLE
lib: date_time: Remove unnecessary time structure checks

### DIFF
--- a/include/date_time.h
+++ b/include/date_time.h
@@ -49,7 +49,8 @@ typedef void (*date_time_evt_handler_t)(const struct date_time_evt *evt);
 /** @brief Set the current date time.
  *
  *  @note See http://www.cplusplus.com/reference/ctime/tm/ for accepted input
- *        format.
+ *        format. Members wday and yday have no impact on the date time UTC and are thus
+ *        does not need to be set.
  *
  *  @param[in] new_date_time Pointer to a tm structure.
  *

--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -395,18 +395,6 @@ int date_time_set(const struct tm *new_date_time)
 		err = -EINVAL;
 	}
 
-	/** Days since Sunday. */
-	if (new_date_time->tm_wday < 0 || new_date_time->tm_wday > 6) {
-		LOG_ERR("Week day in time structure not in correct format");
-		err = -EINVAL;
-	}
-
-	/** Days since January 1. */
-	if (new_date_time->tm_yday < 0 || new_date_time->tm_yday > 365) {
-		LOG_ERR("Year day in time structure not in correct format");
-		err = -EINVAL;
-	}
-
 	if (err) {
 		return err;
 	}

--- a/tests/lib/date_time/src/main.c
+++ b/tests/lib/date_time/src/main.c
@@ -117,34 +117,6 @@ static void test_date_time_invalid_input(void)
 
 	reset_to_valid_time(&date_time_dummy);
 
-	/**********************************************************************/
-
-	/** Invalid week day. */
-	date_time_dummy.tm_wday = -1;
-
-	ret = date_time_set(&date_time_dummy);
-	zassert_equal(-EINVAL, ret, "date_time_set should equal -EINVAL");
-
-	date_time_dummy.tm_wday = 7;
-
-	ret = date_time_set(&date_time_dummy);
-	zassert_equal(-EINVAL, ret, "date_time_set should equal -EINVAL");
-
-	reset_to_valid_time(&date_time_dummy);
-
-	/**********************************************************************/
-
-	/** Invalid year day. */
-	date_time_dummy.tm_yday = -1;
-
-	ret = date_time_set(&date_time_dummy);
-	zassert_equal(-EINVAL, ret, "date_time_set should equal -EINVAL");
-
-	date_time_dummy.tm_yday = 366;
-
-	ret = date_time_set(&date_time_dummy);
-	zassert_equal(-EINVAL, ret, "date_time_set should equal -EINVAL");
-
 }
 
 static void test_date_time_premature_request(void)


### PR DESCRIPTION
Removing check that time structure contains weekday and yearday
in date_time_set().
Signed-off-by: David Dilner <david.dilner@nordicsemi.no>