### PR TITLE
ci: Add ENOSYS to ignored checkpatch rules

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -8,6 +8,7 @@
 --typedefsfile=scripts/checkpatch/typedefsfile
 
 --ignore BRACES
+--ignore ENOSYS
 --ignore PRINTK_WITHOUT_KERN_LEVEL
 --ignore SPLIT_STRING
 --ignore VOLATILE


### PR DESCRIPTION
In zephyr it was decided to expand the meaning
of ENOSYS error to all not implemented callbacks.
This rule would not allow us to properly
handle all the values returned by drivers APIs.