### PR TITLE
doc: update SES programming instructions

### DIFF
--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -47,7 +47,7 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
        Open nRF Connect SDK Project menu
 
-#. To import a project into SES, you must specify the following information:
+#. To add a project to SES, you must specify the following information:
 
    * :guilabel:`nRF Connect SDK Release` - Select the |NCS| version that you want to work with.
 
@@ -86,8 +86,8 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
    .. build_SES_projimport_start
 
-4. Click :guilabel:`OK` to import the project into SES. You can now work with the
-   project in the IDE.
+4. Click :guilabel:`OK` to add the project to SES.
+   You can now work with the project in the IDE.
 
    .. build_SES_projimport_note_start
 
@@ -122,21 +122,29 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
    To build and program an application:
 
-      a. Select your project in the Project Explorer.
-      #. From the menu, select :guilabel:`Build` > :guilabel:`Build Solution`.
-      #. When the build completes, you can program the application to a connected development kit:
+   a. Select your project in the Project Explorer.
+      The project name displays in bold when it is selected.
+   #. From the menu, select :guilabel:`Build` > :guilabel:`Build Solution`.
+      Alternatively, if you are working with a single-image application, you can choose the :guilabel:`Build and Debug` option that builds the application and programs it to a connected development kit when the build has completed.
+   #. When the build completes, you can program the application to a connected development kit:
 
-         * For a single-image application, select :guilabel:`Target` > :guilabel:`Download zephyr/zephyr.elf`.
-         * For a multi-image application, select :guilabel:`Target` > :guilabel:`Download zephyr/merged.hex`.
+      * For a single-image application, select :guilabel:`Target` > :guilabel:`Download zephyr/zephyr.elf`.
+      * For a multi-image application, depending on your build target:
 
-      .. warning::
-	   For nRF53 family SoC, programming :file:`merged.hex` file updates only the application core.
-	   If you need to update also the network core, you must follow additional steps described in :ref:`ug_nrf5340`.
+        * If you are programming a SoC from the nRF53 Series and you also need to update the network core, you must add the network core project in |SES| and complete the additional steps, as described in the :ref:`ug_nrf5340_ses_multi_image` section of :ref:`ug_nrf5340`.
+          This is because programming the :file:`merged.hex` file at this stage updates only the application core.
+        * If you are not programming an nRF53 Series SoC or you do not need to update the network core, select :guilabel:`Target` > :guilabel:`Download zephyr/merged.hex`.
 
-      .. note::
-	   Alternatively, choose the :guilabel:`Build and Debug` option.
-	   :guilabel:`Build and Debug` will build the application and program it when
-	   the build completes.
+   If a "Project out-of-date" warning appears, click :guilabel:`No` to ignore it and leave the option to show the dialog again selected:
+
+   .. figure:: images/ses_nrf5340_netcore_download.png
+      :alt: Ignore any 'Project out-of-date' warnings
+
+      Ignore any 'Project out-of-date' warnings
+
+   .. caution::
+      If you click :guilabel:`Yes` and disable the option to show the dialog again, you will enter a loop because of a "no input files" error.
+      To restore the default settings, select :guilabel:`Tools` > :guilabel:`Options` > :guilabel:`Building` and set :guilabel:`Confirm Automatically Build Before Debug` to ``Yes``.
 
 #. To inspect the details of the code that was programmed and the memory usage, click :guilabel:`Debug` > :guilabel:`Go`.
 

--- a/doc/nrf/gs_updating.rst
+++ b/doc/nrf/gs_updating.rst
@@ -123,6 +123,20 @@ Whenever you update to a newer release of the |NCS|, check the :ref:`gs_recommen
       Then, :ref:`set up the build environment in SES <setting_up_SES>` again.
 ..
 
+.. _gs_updating_ses_packages:
+
+Updating SES packages
+=====================
+
+Updating SES Nordic Edition will not update already installed packages.
+You might need to manually update the CPU support package when you cannot select a CPU as :guilabel:`Target Processor` when configuring a new project.
+
+To update the nRF CPU Support Package after a SES update:
+
+1. In SES, select :guilabel:`Tools` > :guilabel:`Package Manager...`.
+#. Search for "nRF CPU Support Package".
+#. Update the package to the latest version.
+
 .. _repo_move:
 
 Pointing the repositories to the right remotes after they were moved

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -298,7 +298,7 @@ Other libraries
 
 * :ref:`lib_spm`:
 
-  * : Fixed the NCSDK-5156 issue with the size calculation for the non-secure callable region, which prevented users from adding a large number of custom secure services.
+  * Fixed the NCSDK-5156 issue with the size calculation for the non-secure callable region, which prevented users from adding a large number of custom secure services.
   * All EGU peripherals, instead of just EGU1 and EGU2, are now configurable to be non-secure and are configured as non-secure by default.
 
 Libraries for Zigbee
@@ -389,9 +389,12 @@ In addition to documentation related to the changes listed above, the following 
     * Added a section describing the Git tool.
     * Expanded the existing section about the West tool.
 
+  * :ref:`gs_programming` - Updated the :ref:`gs_programming_ses` with a warning about a "no input files" error.
+  * :ref:`gs_updating` - Added a section about :ref:`gs_updating_ses_packages`.
   * :ref:`glossary` - Added new terms related to :ref:`ug_matter` and :ref:`ug_zigbee`.
   * :ref:`library_template` - added a template for documenting libraries.
   * :ref:`ug_nrf5340` - Added a note about varying folder names of the network core child image when programming with nrfjprog.
+  * :ref:`ug_nrf5340` - Updated the :ref:`ug_nrf5340_ses_multi_image` to better match the programming procedure.
 
 * Libraries:
 

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -356,116 +356,122 @@ You must manually add a network core project to the application core project to 
    You must reprogram the network core sample only when changes are made to it.
    You can modify and program the application core sample without reprogramming the network core.
 
-
 Follow these steps to build and program a multi-image build to the nRF5340 application core and network core:
 
-1. Follow the instructions in :ref:`gs_programming_ses` and open the application core sample (for example, :ref:`peripheral_lbs`) in |SES|.
-   Use ``nrf5340dk_nrf5340_cpuapp`` or ``nrf5340dk_nrf5340_cpuapp_ns`` as the build target.
-#. Build the sample as described in :ref:`gs_programming_ses`.
+1. Follow the initial steps in :ref:`gs_programming_ses` to add the application core sample project in |SES| using ``nrf5340dk_nrf5340_cpuapp`` or ``nrf5340dk_nrf5340_cpuapp_ns`` as the build target.
+   For example, select the :ref:`peripheral_lbs` sample.
+#. Build the sample as described in :ref:`gs_programming_ses` in the step about building and programming the project.
    This creates both the application core image and the network core image.
-#. Select :guilabel:`File` > :guilabel:`New Project`.
+   When the build completes, return to this guide.
+#. Add the network core project to the application core project:
 
-    .. figure:: images/ses_nrf5340_netcore_new_project.png
-       :alt: Create New Project menu
+   a. Select :guilabel:`File` > :guilabel:`New Project`.
 
-       Create New Project menu
+      .. figure:: images/ses_nrf5340_netcore_new_project.png
+         :alt: Create New Project menu
 
-#. Select :guilabel:`Add the project to the current solution`.
+         Create New Project menu
 
-    .. figure:: images/ses_nrf5340_netcore_add_project.png
-       :alt: Adding a project target for programming the network core
+   #. Select :guilabel:`Add the project to the current solution`.
 
-       Adding a project target for programming the network core
+      .. figure:: images/ses_nrf5340_netcore_add_project.png
+         :alt: Adding a project target for programming the network core
 
-#. Select the project template, project name, and project location.
+         Adding a project target for programming the network core
 
-   * :guilabel:`An externally built executable for Nordic Semiconductor nRF`:
-     This template allows you to specify the network core HEX file to be programmed.
-     The HEX file is created by the build system.
+   #. Select the project template, project name, and project location.
 
-   * :guilabel:`Name`: Specify the name of the project as it will appear in SES.
-     This example uses ``hci_rpmsg_nrf5340_netcore``.
+      * :guilabel:`An externally built executable for Nordic Semiconductor nRF`:
+        This template allows you to specify the network core hexadecimal file to be programmed.
+        The hexadecimal file is created by the build system.
+      * :guilabel:`Name`: Specify the name of the project as it will appear in SES.
+        For example, for the :ref:`peripheral_lbs` sample you can use ``hci_rpmsg_nrf5340_netcore``.
+      * :guilabel:`Location`: Specify the location of the project.
+        This must be the same build target's folder as the current project.
+        Click :guilabel:`Browse` to open a dialog where you can navigate to the current project's build target folder and click :guilabel:`Select Folder`.
 
-   * :guilabel:`Location`: Specify the location of the project.
-     This must be the same location as the current project/build folder.
-     Click :guilabel:`Browse` to open a dialog where you can navigate to the current project/build folder and click :guilabel:`Select Folder`.
+      .. figure:: images/ses_nrf5340_netcore_project_template.png
+         :alt: Creating a new project for programming the network core
 
-    .. figure:: images/ses_nrf5340_netcore_project_template.png
-       :alt: Creating a new project for programming the network core
+         Creating a new project for programming the network core
 
-       Creating a new project for programming the network core
+   #. Click :guilabel:`Next`.
 
-#. Click :guilabel:`Next`.
+   #. Configure the project settings.
 
-#. Configure the project settings.
+      * :guilabel:`Target Processor`: Select ``nRF5340_xxAA_Network``.
+        If it is not on the list, see :ref:`gs_updating_ses_packages`.
 
-   * :guilabel:`Target Processor`: Select ``nRF5340_xxAA_Network``.
+      * :guilabel:`Load File`: Specify the file name of the merged HEX file for the network core that should be programmed.
+         For example, specify :file:`$(ProjectDir)/hci_rpmsg/zephyr/merged_CPUNET.hex` for the :ref:`zephyr:bluetooth-hci-rpmsg-sample` sample.
 
-   * :guilabel:`Load File`: Specify the file name of the merged HEX file for the network core that should be programmed.
-     For example, specify :file:`$(ProjectDir)/hci_rpmsg/zephyr/merged_CPUNET.hex` for the :ref:`zephyr:bluetooth-hci-rpmsg-sample` sample.
+      .. figure:: images/ses_nrf5340_netcore_project_settings.png
+         :alt: Project settings for programming the network core
 
-    .. figure:: images/ses_nrf5340_netcore_project_settings.png
-       :alt: Project settings for programming the network core
+         Project settings for programming the network core
 
-       Project settings for programming the network core
+   #. Click :guilabel:`Next`.
 
-#. Click :guilabel:`Next`.
+   #. Add the project files.
+      This project will only be used for programming the network core, so you must only add the default :guilabel:`Script Files`.
 
-#. Add the project files.
-   This project will only be used for programming the network core so you must only add the default :guilabel:`Script Files`.
+      .. figure:: images/ses_nrf5340_netcore_files.png
+         :alt: Adding script files for programming the network core
 
-   .. figure:: images/ses_nrf5340_netcore_files.png
-       :alt: Adding script files for programming the network core
+         Adding script files for programming the network core
 
-       Adding script files for programming the network core
+   #. Click :guilabel:`Next`.
 
-#. Click :guilabel:`Next`.
+   #. Add the project configurations.
+      This project will only be used for programming the network core, so no build configurations are needed.
 
-#. Add the project configurations.
-   This project will only be used for programming the network core so no build configurations are needed.
+      Deselect :guilabel:`Debug` and :guilabel:`Release`.
 
-   Deselect :guilabel:`Debug` and :guilabel:`Release`.
+      .. figure:: images/ses_nrf5340_netcore_conf.png
+         :alt: Deselecting configurations and finishing the configuration
 
-    .. figure:: images/ses_nrf5340_netcore_conf.png
-       :alt: Deselecting configurations and finishing the configuration
+         Deselecting configurations and finishing the configuration
 
-       Deselecting configurations and finishing the configuration
+   #. Click :guilabel:`Finish`.
 
-#. Click :guilabel:`Finish`.
-
-   This creates a new project for programming the network core with the HEX file of the network sample.
+      This creates a new project for programming the network core with the HEX file of the network sample.
 
 #. Set the new network core project as the active project using :guilabel:`Project` > :guilabel:`Set Active Project`.
    For example, select :guilabel:`hci_rpmsg_nrf5340_netcore`.
 
    .. figure:: images/ses_nrf5340_netcore_set_active.png
-     :alt: Set the hci_rpmsg_nrf5340_netcore programming target as active
+      :alt: Set the hci_rpmsg_nrf5340_netcore programming target as active
 
-     Set the hci_rpmsg_nrf5340_netcore programming target as active
+      Set the hci_rpmsg_nrf5340_netcore programming target as active
 
 #. Program the network sample using :guilabel:`Target` > :guilabel:`Download XXX` (for example, :guilabel:`Download hci_rpmsg_nrf5340_netcore`).
 
    .. figure:: images/ses_nrf5340_netcore_flash_active.png
-     :alt: Program the network sample hci_rpmsg_nrf5340_netcore
+      :alt: Program the network sample hci_rpmsg_nrf5340_netcore
 
-     Program the network sample hci_rpmsg_nrf5340_netcore
+      Program the network sample hci_rpmsg_nrf5340_netcore
 
-   Ignore any warnings regarding the project being out of date.
+   Ignore any project out-of-date warning by clicking :guilabel:`No` when they appear.
    The network core project is a pure programming target, so it cannot be built.
 
    .. figure:: images/ses_nrf5340_netcore_download.png
-     :alt: Ignore any 'Project out of date' warning
+      :alt: Ignore any "Project out-of-date" warnings
 
-     Ignore any 'Project out of date' warning
+      Ignore any "Project out-of-date" warnings
 
-   .. note:: Programming the network core erases the application.
+   .. caution::
+      If you click :guilabel:`Yes` and disable the option to show the dialog again, you will enter a loop because of a "no input files" error.
+      To restore the default settings, select :guilabel:`Tools` > :guilabel:`Options` > :guilabel:`Building` and set :guilabel:`Confirm Automatically Build Before Debug` to ``Yes``.
 
+   Programming the network core erases the application.
+   If you encounter an error with programming the network core, try disabling :ref:`readback_protection_error`.
 #. After the network core is programmed, make the application target active again by selecting :guilabel:`Project` > :guilabel:`Set Active Project` > :guilabel:`zephyr/merged.hex`.
 
    .. figure:: images/ses_nrf5340_appcore_set_active.png
      :alt: Set the zephyr/merged.hex target as active
 
      Set the zephyr/merged.hex target as active
+
 #. Program the application sample using :guilabel:`Target` > :guilabel:`Download zephyr/merged.hex`.
 
 


### PR DESCRIPTION
Added several updates to SES programming instructions.
Clarified what to do with no input files error.
Added information about updating SES packages.
Reorganized multi-image programming instructions for nRF5340.
NCSDK-10552.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>