### PR TITLE
doc: Add missing release notes related to profiler

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -181,6 +181,11 @@ Updated:
 * The power management support in modules is now enabled by default when the :kconfig:`CONFIG_CAF_PM_EVENTS` Kconfig option is enabled.
 * The :ref:`caf_power_manager` now has a dependency on :kconfig:`CONFIG_PM_POLICY_APP`, which is required by the application that is using the :ref:`caf_power_manager` to link.
 
+Profiler
+--------
+
+* Updated Python scripts to use multiple processes that communicate over sockets.
+
 Hardware unique key
 -------------------
 


### PR DESCRIPTION
Change adds missing release notes related to profiler scripts.
The change in scripts is significant and should be mentioned.