### PR TITLE
Add integration platforms

### DIFF
--- a/samples/bluetooth/mesh/silvair_enocean/sample.yaml
+++ b/samples/bluetooth/mesh/silvair_enocean/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.mesh.silvair_enocean:
     build_only: true
-    build_on_all: false
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf21540dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_rscs/sample.yaml
+++ b/samples/bluetooth/peripheral_rscs/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.bluetooth.peripheral_rscs:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52833dk_nrf52833
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
     integration_platforms:

--- a/samples/debug/ppi_trace/sample.yaml
+++ b/samples/debug/ppi_trace/sample.yaml
@@ -4,7 +4,6 @@ sample:
 tests:
   samples.debug.ppi_trace:
     build_only: true
-    build_on_all: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf21540_nrf52840
     tags: ci_build
     integration_platforms:

--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -8,3 +8,5 @@ tests:
     build_only: true
     platform_allow: nrf52840dk_nrf52840
     tags: bluetooth ci_build
+    integration_platforms:
+      - nrf52840dk_nrf52840

--- a/tests/crypto/testcase.yaml
+++ b/tests/crypto/testcase.yaml
@@ -4,48 +4,68 @@ tests:
   crypto.vanilla:
     extra_args: OVERLAY_CONFIG=overlay-vanilla.conf
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
-    build_on_all: True
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp
     tags: crypto ci_build
     timeout: 600
   crypto.cc3xx:
     extra_args: OVERLAY_CONFIG=overlay-cc3xx.conf
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
-    build_on_all: True
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp
     tags: crypto ci_build
     timeout: 200
   crypto.multi:
     extra_args: OVERLAY_CONFIG=overlay-multi.conf
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
-    build_on_all: True
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp
     tags: crypto ci_build
     timeout: 200
   crypto.oberon:
     extra_args: OVERLAY_CONFIG=overlay-oberon.conf
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
-    build_on_all: True
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp
     tags: crypto ci_build
     timeout: 200
   crypto.cc3xx_oberon:
     extra_args: OVERLAY_CONFIG=overlay-cc3xx-oberon.conf
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
-    build_on_all: True
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
     tags: crypto ci_build
     timeout: 200
   crypto.small.hash:
     extra_args: OVERLAY_CONFIG="overlay-small-devices/overlay-small.conf;overlay-small-devices/overlay-small-hash.conf"
     platform_allow: nrf52840dk_nrf52811 nrf52dk_nrf52810
-    build_on_all: True
+    integration_platforms:
+      - nrf52840dk_nrf52811
+      - nrf52dk_nrf52810
     tags: crypto ci_build
     timeout: 200
   crypto.small.aes:
     extra_args: OVERLAY_CONFIG="overlay-small-devices/overlay-small.conf;overlay-small-devices/overlay-small-aes.conf"
     platform_allow: nrf52840dk_nrf52811 nrf52dk_nrf52810
-    build_on_all: True
+    integration_platforms:
+      - nrf52840dk_nrf52811
+      - nrf52dk_nrf52810
     tags: crypto ci_build
     timeout: 200
   crypto.small.ecc:
     extra_args: OVERLAY_CONFIG="overlay-small-devices/overlay-small.conf;overlay-small-devices/overlay-small-ecc.conf"
     platform_allow: nrf52840dk_nrf52811 nrf52dk_nrf52810
-    build_on_all: True
+    integration_platforms:
+      - nrf52840dk_nrf52811
+      - nrf52dk_nrf52810
     tags: crypto ci_build
     timeout: 200

--- a/tests/drivers/clock_control/clock_control_mpsl/testcase.yaml
+++ b/tests/drivers/clock_control/clock_control_mpsl/testcase.yaml
@@ -3,3 +3,8 @@ tests:
     tags: drivers
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
                         nrf9160dk_nrf9160
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160

--- a/tests/drivers/flash_patch/testcase.yaml
+++ b/tests/drivers/flash_patch/testcase.yaml
@@ -1,8 +1,12 @@
 tests:
   flash_patch.flash_patch_off:
     platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: flash_patch
     extra_args: CONFIG_DISABLE_FLASH_PATCH=n
   flash_patch.flash_patch_on:
     platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: flash_patch

--- a/tests/drivers/fprotect/negative/testcase.yaml
+++ b/tests/drivers/fprotect/negative/testcase.yaml
@@ -2,4 +2,11 @@ tests:
   drivers.fprotect.negative:
     platform_allow: nrf9160dk_nrf9160 nrf52dk_nrf52832
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf51dk_nrf51422
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf52840dk_nrf52840
+      - nrf51dk_nrf51422
     tags: b0 fprotect ignore_faults

--- a/tests/drivers/fprotect/positive/testcase.yaml
+++ b/tests/drivers/fprotect/positive/testcase.yaml
@@ -2,4 +2,11 @@ tests:
   drivers.fprotect.positive:
     platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf51dk_nrf51422
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0 fprotect

--- a/tests/drivers/nrfx_integration_test/testcase.yaml
+++ b/tests/drivers/nrfx_integration_test/testcase.yaml
@@ -3,15 +3,30 @@ tests:
     build_only: true
     filter: CONFIG_HAS_NRFX
     tags: drivers ci_build
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf9160dk_nrf9160_ns
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf5340dk_nrf5340_cpunet
   nrfx_integration_test.build.bt.softdevice:
     build_only: true
     filter: CONFIG_HAS_NRFX and CONFIG_BT_LL_SOFTDEVICE
     tags: drivers ci_build
     extra_configs:
       - CONFIG_NRFX_AND_BT_LL_SOFTDEVICE=y
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpunet
   nrfx_integration_test.build.bt.sw_split:
     build_only: true
     filter: CONFIG_HAS_NRFX and CONFIG_BT_LL_SW_SPLIT
     tags: drivers ci_build
     extra_configs:
       - CONFIG_NRFX_AND_BT_LL_SW_SPLIT=y
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpunet

--- a/tests/lib/at_cmd_parser/at_cmd_parser/testcase.yaml
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/testcase.yaml
@@ -1,5 +1,7 @@
 tests:
   at_cmd_parser.at_cmd_parser:
     platform_allow: qemu_cortex_m3 native_posix
+    integration_platforms:
+      - qemu_cortex_m3
+      - native_posix
     tags: at_cmd_parser
-    skip: true

--- a/tests/lib/at_cmd_parser/at_params/testcase.yaml
+++ b/tests/lib/at_cmd_parser/at_params/testcase.yaml
@@ -1,4 +1,7 @@
 tests:
   at_cmd_parser.at_params:
     platform_allow: qemu_cortex_m3 native_posix
+    integration_platforms:
+      - qemu_cortex_m3
+      - native_posix
     tags: at_cmd_parser

--- a/tests/lib/at_cmd_parser/at_utils/testcase.yaml
+++ b/tests/lib/at_cmd_parser/at_utils/testcase.yaml
@@ -1,4 +1,7 @@
 tests:
   at_cmd_parser.at_utils:
     platform_allow: qemu_cortex_m3 native_posix
+    integration_platforms:
+      - qemu_cortex_m3
+      - native_posix
     tags: at_cmd_parser

--- a/tests/lib/hw_unique_key/testcase.yaml
+++ b/tests/lib/hw_unique_key/testcase.yaml
@@ -1,4 +1,8 @@
 tests:
   lib.hw_unique_key:
     platform_allow: nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf52840dk_nrf52840
     tags: hw_unique_key

--- a/tests/lib/hw_unique_key_tfm/testcase.yaml
+++ b/tests/lib/hw_unique_key_tfm/testcase.yaml
@@ -1,5 +1,8 @@
 tests:
   lib.hw_unique_key_tfm:
     platform_allow: nrf9160dk_nrf9160_ns nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: hw_unique_key
     build_only: true

--- a/tests/lib/modem_jwt/testcase.yaml
+++ b/tests/lib/modem_jwt/testcase.yaml
@@ -1,4 +1,7 @@
 tests:
   unity.modem_jwt:
     platform_allow: qemu_cortex_m3 native_posix
+    integration_platforms:
+      - qemu_cortex_m3
+      - native_posix
     tags: jwt

--- a/tests/lib/sms/sample.yaml
+++ b/tests/lib/sms/sample.yaml
@@ -1,3 +1,0 @@
-sample:
-  description: SMS Library Unity/Cmock test
-  name: sms_lib_unity_test

--- a/tests/lib/sms/testcase.yaml
+++ b/tests/lib/sms/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   unity.sms_test:
     tags: sms
+    integration_platforms:
+      - native_posix

--- a/tests/modules/lib/cddl-gen/testcase.yaml
+++ b/tests/modules/lib/cddl-gen/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   modules.lib.cddl_gen:
-    build_only: true
     tags: cddl-gen
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/bluetooth/gatt_dm/testcase.yaml
+++ b/tests/subsys/bluetooth/gatt_dm/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.gatt_dm:
     platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
     tags: discovery_manager

--- a/tests/subsys/bootloader/bl_storage/testcase.yaml
+++ b/tests/subsys/bootloader/bl_storage/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   bootloader.bl_storage:
-    platform_allow: nrf9160dk_nrf9160 nrf9160dk_nrf9160ns
+    platform_allow: nrf9160dk_nrf9160 nrf9160dk_nrf9160_ns
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
     integration_platforms:
       - nrf9160dk_nrf9160

--- a/tests/subsys/debug/cpu_load/testcase.yaml
+++ b/tests/subsys/debug/cpu_load/testcase.yaml
@@ -1,10 +1,15 @@
 tests:
   debug.cpu_load:
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
     build_only: true
     tags: ci_build debug
   debug.cpu_load.shared_dppi:
     platform_allow: nrf9160dk_nrf9160
+    integration_platforms:
+      - nrf9160dk_nrf9160
     build_only: true
     tags: ci_build debug
     extra_configs:

--- a/tests/subsys/dfu/dfu_target_stream/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_stream/testcase.yaml
@@ -3,6 +3,10 @@ tests:
   dfu.target_stream:
     tags: target_stream
     platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160
+      - nrf5340dk_nrf5340_cpuapp
   dfu.target_stream.store_progress:
     tags: target_stream
     extra_args: OVERLAY_CONFIG=overlay-store-progress.conf

--- a/tests/subsys/net/lib/fota_download/testcase.yaml
+++ b/tests/subsys/net/lib/fota_download/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   net.lib.fota_download:
     tags: aws fota
     platform_allow: nrf9160dk_nrf9160 nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf9160dk_nrf9160_ns

--- a/tests/subsys/spm/secure_services/testcase.yaml
+++ b/tests/subsys/spm/secure_services/testcase.yaml
@@ -1,4 +1,7 @@
 tests:
   spm.secure_services:
     platform_allow: nrf9160dk_nrf9160_ns nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: spm secure_services

--- a/tests/subsys/spm/thread_swap/testcase.yaml
+++ b/tests/subsys/spm/thread_swap/testcase.yaml
@@ -1,4 +1,7 @@
 tests:
   spm.secure_services.thread_swap:
     platform_allow: nrf9160dk_nrf9160_ns nrf5340dk_nrf5340_cpuapp_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+      - nrf5340dk_nrf5340_cpuapp_ns
     tags: spm secure_services thread_swap

--- a/tests/unity/example_test/sample.yaml
+++ b/tests/unity/example_test/sample.yaml
@@ -1,3 +1,0 @@
-sample:
-  description: Example Unity/Cmock test
-  name: example_unity_test

--- a/tests/unity/example_test/testcase.yaml
+++ b/tests/unity/example_test/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   unity.example_test:
     tags: example
+    integration_platforms:
+      - native_posix


### PR DESCRIPTION
Add integration_platforms for tests' yaml. Required for
transparency and reliability of on-commit CI.
Fixes incorrect yaml for tests and removes `build_on_all` entries