### PR TITLE
subsys: net: lib: rest_client: Add new REST client library

### DIFF
--- a/doc/nrf/libraries/networking/rest_client.rst
+++ b/doc/nrf/libraries/networking/rest_client.rst
@@ -1,0 +1,47 @@
+.. _lib_rest_client:
+
+REST client
+###########
+
+.. contents::
+   :local:
+   :depth: 2
+
+The REST client library provides means for performing REST requests.
+
+Overview
+********
+
+This library creates a socket with TLS when requested.
+It uses Zephyr's HTTP client library to send HTTP requests and receive HTTP responses.
+When using this library, the :c:struct:`rest_client_req_resp_context` structure is populated and passed to the :c:func:`rest_client_request` function.
+The same structure will contain the response data.
+
+Configuration
+*************
+
+To use the REST client library, enable the :kconfig:`CONFIG_REST_CLIENT` Kconfig option.
+
+You can configure the following options to adjust the behavior of the library:
+
+*  :kconfig:`CONFIG_REST_CLIENT_REQUEST_TIMEOUT`
+*  :kconfig:`CONFIG_REST_CLIENT_SCKT_SEND_TIMEOUT`
+*  :kconfig:`CONFIG_REST_CLIENT_SCKT_RECV_TIMEOUT`
+*  :kconfig:`CONFIG_REST_CLIENT_SCKT_TLS_SESSION_CACHE_IN_USE`
+
+Limitations
+***********
+
+* Executing REST request is a blocking operation. The calling thread is blocked until the request has completed.
+* REST client only works in the default PDP context.
+* REST client do not allow selection of IPV4 or IPV6 but it works on what DNS returns for name query.
+
+API documentation
+*****************
+
+| Header file: :file:`include/net/rest_client.h`
+| Source files: :file:`subsys/net/lib/rest_client`
+
+.. doxygengroup:: rest_client
+   :project: nrf
+   :members:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -31,6 +31,12 @@ The following sections provide detailed lists of changes by component.
 nRF9160
 =======
 
+* Added:
+
+  * :ref:`lib_rest_client` library:
+
+    * Added REST client library for sending REST requests and receiving their responses.
+
 * Updated:
 
   * :ref:`serial_lte_modem` application:

--- a/include/net/rest_client.h
+++ b/include/net/rest_client.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file rest_client.h
+ *
+ * @defgroup rest_client REST client library
+ * @{
+ * @brief REST client.
+ *
+ * @details Provide REST client functionality.
+ */
+
+#ifndef REST_CLIENT_H__
+#define REST_CLIENT_H__
+
+#include <net/http_parser.h>
+
+/** @brief TLS is not used. */
+#define REST_CLIENT_SEC_TAG_NO_SEC -1
+
+/** @brief Use the default TLS peer verification; TLS_PEER_VERIFY_REQUIRED. */
+#define REST_CLIENT_TLS_DEFAULT_PEER_VERIFY -1
+
+/** @brief REST client opens a socket connection. */
+#define REST_CLIENT_SCKT_CONNECT -1
+
+/** @brief Common HTTP status codes */
+enum rest_client_http_status {
+	REST_CLIENT_HTTP_STATUS_OK = 200,
+	REST_CLIENT_HTTP_STATUS_BAD_REQ = 400,
+	REST_CLIENT_HTTP_STATUS_UNAUTH = 401,
+	REST_CLIENT_HTTP_STATUS_FORBIDDEN = 403,
+	REST_CLIENT_HTTP_STATUS_NOT_FOUND = 404,
+};
+
+/**
+ * @brief REST client request context.
+ *
+ * @details Input parameters for using the REST client API should be filled into
+ *          this structure before calling @ref rest_client_request.
+ */
+struct rest_client_req_context {
+	/** Socket identifier for the connection. When using the default value,
+	 *  the library will open a new socket connection. Default: REST_CLIENT_SCKT_CONNECT.
+	 */
+	int connect_socket;
+
+	/** Defines whether the connection should remain after API call. Default: false. */
+	bool keep_alive;
+
+	/** Security tag. Default: REST_CLIENT_SEC_TAG_NO_SEC. */
+	int sec_tag;
+
+	/** Indicates the preference for peer verification.
+	 *  Initialize to REST_CLIENT_TLS_DEFAULT_PEER_VERIFY
+	 *  and the default (TLS_PEER_VERIFY_REQUIRED) is used.
+	 */
+	int tls_peer_verify;
+
+	/** Used HTTP method. */
+	enum http_method http_method;
+
+	/** Hostname or IP address to be used in the request. */
+	const char *host;
+
+	/** Port number to be used in the request. */
+	uint16_t port;
+
+	/** The URL for this request, for example: /index.html */
+	const char *url;
+
+	/** The HTTP header fields. Similar to the Zephyr HTTP client.
+	 *  This is a NULL-terminated list of header fields. May be NULL.
+	 */
+	const char **header_fields;
+
+	/** Payload/body, may be NULL. */
+	const char *body;
+
+	/** User-defined timeout value for receiving response data.
+	 *  Default: CONFIG_REST_CLIENT_REST_REQUEST_TIMEOUT.
+	 */
+	int32_t timeout_ms;
+
+	/** User-allocated buffer for receiving API response. */
+	char *resp_buff;
+
+	/** User-defined size of resp_buff. */
+	size_t resp_buff_len;
+};
+
+/**
+ * @brief REST client response context.
+ *
+ * @details When @ref rest_client_request returns, response-related data can be read from
+ *          this structure.
+ */
+struct rest_client_resp_context {
+	/** Length of HTTP headers + response body/content data. */
+	size_t total_response_len;
+
+	/** Length of response body/content data. */
+	size_t response_len;
+
+	/** Start of response data (the body/content) in resp_buff.*/
+	char *response;
+
+	/** Numeric HTTP status code. */
+	uint16_t http_status_code;
+
+	/** Used socket identifier. Use this for keepalive connections as
+	 *  connect_socket for upcoming requests.
+	 */
+	int used_socket_id;
+
+	/** True if used_socket_id was kept alive and was not closed after the REST request. */
+	int used_socket_is_alive;
+};
+
+/**
+ * @brief REST client request.
+ *
+ * @details This function will block the calling thread until the request completes.
+ *
+ * @param[in] req_ctx Request context containing input parameters to REST request
+ * @param[out] resp_ctx Response context for returning the response data.
+ *
+ * @retval 0, if the REST response was received successfully. If response_len > 0,
+ *            there is also body/content data in a response. http_status_code contains the actual
+ *            HTTP status code.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int rest_client_request(struct rest_client_req_context *req_ctx,
+			struct rest_client_resp_context *resp_ctx);
+
+/**
+ * @brief Sets the default values into a given request context.
+ *
+ * @details Intended to be used before calling rest_client_request().
+ *
+ * @param[in,out] req_ctx Request context for communicating with REST client API.
+ */
+void rest_client_request_defaults_set(struct rest_client_req_context *req_ctx);
+
+/** @} */
+
+#endif /* REST_CLIENT_H__ */

--- a/lib/multicell_location/Kconfig
+++ b/lib/multicell_location/Kconfig
@@ -38,11 +38,13 @@ config MULTICELL_LOCATION_SERVICE_NRF_CLOUD
 
 config MULTICELL_LOCATION_SERVICE_HERE
 	bool "HERE location service"
+	select REST_CLIENT
 	help
 	  Use HERE location service
 
 config MULTICELL_LOCATION_SERVICE_SKYHOOK
 	bool "Skyhook location service"
+	select REST_CLIENT
 	help
 	  Use Skyhook location service. If a device ID is not provided for
 	  a location request, the device's IMEI will be used.

--- a/lib/multicell_location/multicell_location.c
+++ b/lib/multicell_location/multicell_location.c
@@ -17,201 +17,19 @@
 #include <logging/log.h>
 
 #define TLS_SEC_TAG	CONFIG_MULTICELL_LOCATION_TLS_SEC_TAG
-#define HTTPS_PORT	CONFIG_MULTICELL_LOCATION_HTTPS_PORT
-#define HOSTNAME	CONFIG_MULTICELL_LOCATION_HOSTNAME
 
 LOG_MODULE_REGISTER(multicell_location, CONFIG_MULTICELL_LOCATION_LOG_LEVEL);
 
 BUILD_ASSERT(!IS_ENABLED(CONFIG_MULTICELL_LOCATION_SERVICE_NONE),
 	     "A location service must be enabled");
 
-static char http_request[CONFIG_MULTICELL_LOCATION_SEND_BUF_SIZE];
 static char recv_buf[CONFIG_MULTICELL_LOCATION_RECV_BUF_SIZE];
 
-static int tls_setup(int fd)
-{
-	int err;
-	int verify = TLS_PEER_VERIFY_REQUIRED;
-	/* Security tag that we have provisioned the certificate to */
-	const sec_tag_t tls_sec_tag[] = {
-		CONFIG_MULTICELL_LOCATION_TLS_SEC_TAG,
-	};
-
-	err = setsockopt(fd, SOL_TLS, TLS_PEER_VERIFY, &verify, sizeof(verify));
-	if (err) {
-		LOG_ERR("Failed to setup peer verification, err %d", errno);
-		return -errno;
-	}
-
-	/* Associate the socket with the security tag
-	 * we have provisioned the certificate with.
-	 */
-	err = setsockopt(fd, SOL_TLS, TLS_SEC_TAG_LIST, tls_sec_tag,
-			 sizeof(tls_sec_tag));
-	if (err) {
-		LOG_ERR("Failed to setup TLS sec tag, error: %d", errno);
-		return -errno;
-	}
-
-	err = setsockopt(fd, SOL_TLS, TLS_HOSTNAME, HOSTNAME, sizeof(HOSTNAME) - 1);
-	if (err < 0) {
-		LOG_ERR("Failed to set hostname option, errno: %d", errno);
-		return -errno;
-	}
-
-	return 0;
-}
-
-static int execute_http_request(const char *request, size_t request_len)
-{
-	int err, fd, bytes;
-	size_t offset = 0;
-	struct addrinfo *res;
-	struct addrinfo hints = {
-		.ai_family = AF_INET,
-		.ai_socktype = SOCK_STREAM,
-	};
-
-	err = getaddrinfo(location_service_get_hostname(), NULL, &hints, &res);
-	if (err) {
-		LOG_ERR("getaddrinfo() failed, error: %d", err);
-		return err;
-	}
-
-	if (IS_ENABLED(CONFIG_MULTICELL_LOCATION_LOG_LEVEL_DBG)) {
-		char ip[INET6_ADDRSTRLEN];
-
-		inet_ntop(AF_INET, &((struct sockaddr_in *)res->ai_addr)->sin_addr,
-			  ip, sizeof(ip));
-		LOG_DBG("IP address: %s", log_strdup(ip));
-	}
-
-	((struct sockaddr_in *)res->ai_addr)->sin_port = htons(HTTPS_PORT);
-
-	fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TLS_1_2);
-	if (fd == -1) {
-		LOG_ERR("Failed to open socket, errno: %d", errno);
-		err = -errno;
-		goto clean_up;
-	}
-
-	/* Setup TLS socket options */
-	err = tls_setup(fd);
-	if (err) {
-		goto clean_up;
-	}
-
-	if (CONFIG_MULTICELL_LOCATION_SEND_TIMEOUT > 0) {
-		struct timeval timeout = {
-			.tv_sec = CONFIG_MULTICELL_LOCATION_SEND_TIMEOUT,
-		};
-
-		err = setsockopt(fd,
-				 SOL_SOCKET,
-				 SO_SNDTIMEO,
-				 &timeout,
-				 sizeof(timeout));
-		if (err) {
-			LOG_ERR("Failed to setup socket send timeout, errno %d", errno);
-			err = -errno;
-			goto clean_up;
-		}
-	}
-
-	if (CONFIG_MULTICELL_LOCATION_RECV_TIMEOUT > 0) {
-		struct timeval timeout = {
-			.tv_sec = CONFIG_MULTICELL_LOCATION_RECV_TIMEOUT,
-		};
-
-		err = setsockopt(fd,
-				 SOL_SOCKET,
-				 SO_RCVTIMEO,
-				 &timeout,
-				 sizeof(timeout));
-		if (err) {
-			LOG_ERR("Failed to setup socket receive timeout, errno %d", errno);
-			err = -errno;
-			goto clean_up;
-		}
-	}
-
-	err = connect(fd, res->ai_addr, sizeof(struct sockaddr_in));
-	if (err) {
-		LOG_ERR("connect() failed, errno: %d", errno);
-		err = -errno;
-		goto clean_up;
-	}
-
-	do {
-		bytes = send(fd, &request[offset], request_len - offset, 0);
-		if (bytes < 0) {
-			LOG_ERR("send() failed, errno: %d", errno);
-			err = -errno;
-			goto clean_up;
-		}
-
-		offset += bytes;
-	} while (offset < request_len);
-
-	LOG_DBG("Sent %d bytes", offset);
-
-	offset = 0;
-
-	do {
-		bytes = recv(fd, &recv_buf[offset], sizeof(recv_buf) - offset - 1, 0);
-		if (bytes < 0) {
-			if ((errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == ETIMEDOUT)) {
-				LOG_WRN("Receive timeout, possibly incomplete data received");
-
-				/* It's been observed that some services seemingly doesn't
-				 * close the connection as expected, causing recv() to never
-				 * return 0. In these cases we may have received all data,
-				 * so we choose to break here to continue parsing while
-				 * propagating the timeout information.
-				 */
-				err = -ETIMEDOUT;
-				break;
-			}
-
-			LOG_ERR("recv() failed, errno: %d", errno);
-
-			err = -errno;
-			goto clean_up;
-		} else {
-			LOG_DBG("Received HTTP response chunk of %d bytes", bytes);
-		}
-
-		offset += bytes;
-	} while (bytes != 0);
-
-	recv_buf[offset] = '\0';
-
-	LOG_DBG("Received %d bytes", offset);
-
-	if (offset > 0) {
-		LOG_DBG("HTTP response:\n%s\n", log_strdup(recv_buf));
-	}
-
-	LOG_DBG("Closing socket");
-
-	/* Propagate timeout information */
-	if (err != -ETIMEDOUT) {
-		err = 0;
-	}
-
-clean_up:
-	freeaddrinfo(res);
-	(void)close(fd);
-
-	return err;
-}
 
 int multicell_location_get(const struct lte_lc_cells_info *cell_data,
 			   const char * const device_id,
 			   struct multicell_location *location)
 {
-	int err;
-
 	if ((cell_data == NULL) || (location == NULL)) {
 		return -EINVAL;
 	}
@@ -227,35 +45,8 @@ int multicell_location_get(const struct lte_lc_cells_info *cell_data,
 		LOG_WRN("Increase CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS to use more cells");
 	}
 
-	if (IS_ENABLED(CONFIG_MULTICELL_LOCATION_SERVICE_NRF_CLOUD)) {
-		return location_service_get_cell_location(cell_data, device_id, recv_buf,
-							  sizeof(recv_buf), location);
-	} else {
-		err = location_service_generate_request(cell_data, device_id,
-							http_request, sizeof(http_request));
-		if (err) {
-			LOG_ERR("Failed to generate HTTP request, error: %d", err);
-			return err;
-		}
-
-		LOG_DBG("Generated request:\n%s", log_strdup(http_request));
-
-		err = execute_http_request(http_request, strlen(http_request));
-		if (err == -ETIMEDOUT) {
-			LOG_WRN("Data reception timed out, parsing potentially incomplete data");
-		} else if (err) {
-			LOG_ERR("HTTP request failed, error: %d", err);
-			return err;
-		}
-
-		err = location_service_parse_response(recv_buf, location);
-		if (err) {
-			LOG_ERR("Failed to parse HTTP response");
-			return -ENOMSG;
-		}
-	}
-
-	return 0;
+	return location_service_get_cell_location(
+		cell_data, device_id, recv_buf, sizeof(recv_buf), location);
 }
 
 int multicell_location_provision_certificate(bool overwrite)

--- a/lib/multicell_location/services/here_integration.c
+++ b/lib/multicell_location/services/here_integration.c
@@ -6,6 +6,7 @@
 
 #include <zephyr.h>
 #include <modem/lte_lc.h>
+#include <net/rest_client.h>
 #include <cJSON.h>
 #include <cJSON_os.h>
 
@@ -25,13 +26,13 @@ LOG_MODULE_REGISTER(multicell_location_here, CONFIG_MULTICELL_LOCATION_LOG_LEVEL
 #define NEIGHBOR_ELEMENT_SIZE	36
 /* Neighbor buffer size that will hold all neighbor cell objects */
 #define NEIGHBOR_BUFFER_SIZE	(CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS * NEIGHBOR_ELEMENT_SIZE)
-/* Estiamted size for HTTP request body */
+/* Estimated size for HTTP request body */
 #define HTTP_BODY_SIZE		(CURRENT_CELL_SIZE + NEIGHBOR_BUFFER_SIZE)
 
 #if IS_ENABLED(CONFIG_MULTICELL_LOCATION_HERE_V1)
-#define PATH		"/positioning/v1/locate"
+#define API_LOCATE_PATH		"/positioning/v1/locate"
 #elif IS_ENABLED(CONFIG_MULTICELL_LOCATION_HERE_V2)
-#define PATH		"/v2/locate"
+#define API_LOCATE_PATH		"/v2/locate"
 #endif
 
 #if IS_ENABLED(CONFIG_MULTICELL_LOCATION_HERE_USE_API_KEY)
@@ -45,12 +46,10 @@ BUILD_ASSERT(sizeof(API_APP_ID) > 1, "App ID must be configured");
 	"&app_id="CONFIG_MULTICELL_LOCATION_HERE_APP_ID
 #endif
 
-#define HTTP_REQUEST_HEADER						\
-	"POST "PATH"?"AUTHENTICATION" HTTP/1.1\r\n"			\
-	"Host: "HOSTNAME"\r\n"					        \
-	"Content-Type: application/json\r\n"				\
-	"Connection: close\r\n"						\
-	"Content-Length: %d\r\n\r\n"
+#define REQUEST_URL		API_LOCATE_PATH"?"AUTHENTICATION
+
+#define HEADER_CONTENT_TYPE    "Content-Type: application/json\r\n"
+#define HEADER_CONNECTION      "Connection: close\r\n"
 
 #define HTTP_REQUEST_BODY						\
 	"{"								\
@@ -83,7 +82,7 @@ BUILD_ASSERT(sizeof(API_APP_ID) > 1, "App ID must be configured");
 		"\"pci\": %d"						\
 	"}"
 
-BUILD_ASSERT(sizeof(HOSTNAME) > 1, "Hostname must be configured");
+BUILD_ASSERT(sizeof(CONFIG_MULTICELL_LOCATION_HOSTNAME) > 1, "Hostname must be configured");
 
 static char body[HTTP_BODY_SIZE];
 static char neighbors[NEIGHBOR_BUFFER_SIZE];
@@ -121,19 +120,16 @@ static const char tls_certificate[] =
 	"WD9f\n"
 	"-----END CERTIFICATE-----\n";
 
-const char *location_service_get_hostname(void)
-{
-	return HOSTNAME;
-}
-
 const char *location_service_get_certificate(void)
 {
 	return tls_certificate;
 }
 
-int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
-				      const char *const device_id,
-				      char *buf, size_t buf_len)
+static int location_service_generate_request(
+	const struct lte_lc_cells_info *cell_data,
+	const char *const device_id,
+	char *buf,
+	size_t buf_len)
 {
 	ARG_UNUSED(device_id);
 
@@ -146,18 +142,12 @@ int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
 	}
 
 	if (neighbors_to_use == 0) {
-		len = snprintk(body, sizeof(body), HTTP_REQUEST_BODY_NO_NEIGHBORS,
+		len = snprintk(buf, buf_len, HTTP_REQUEST_BODY_NO_NEIGHBORS,
 			       cell_data->current_cell.mcc,
 			       cell_data->current_cell.mnc,
 			       cell_data->current_cell.id);
-		if ((len < 0) || (len >= sizeof(body))) {
-			LOG_ERR("Too small buffer for HTTP request body");
-			return -ENOMEM;
-		}
-
-		len = snprintk(buf, buf_len, HTTP_REQUEST_HEADER "%s", strlen(body), body);
 		if ((len < 0) || (len >= buf_len)) {
-			LOG_ERR("Too small buffer for HTTP request");
+			LOG_ERR("Too small buffer for HTTP request body");
 			return -ENOMEM;
 		}
 
@@ -193,30 +183,24 @@ int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
 		strncat(neighbors, element, sizeof(neighbors) - strlen(neighbors));
 	}
 
-	len = snprintk(body, sizeof(body), HTTP_REQUEST_BODY,
+	len = snprintk(buf, buf_len, HTTP_REQUEST_BODY,
 		       cell_data->current_cell.mcc,
 		       cell_data->current_cell.mnc,
 		       cell_data->current_cell.id,
 		       neighbors);
-	if ((len < 0) || (len >= sizeof(body))) {
-		LOG_ERR("Too small buffer for HTTP request body");
-		return -ENOMEM;
-	}
-
-	len = snprintk(buf, buf_len, HTTP_REQUEST_HEADER "%s", strlen(body), body);
 	if ((len < 0) || (len >= buf_len)) {
-		LOG_ERR("Too small buffer for HTTP request buffer");
+		LOG_ERR("Too small buffer for HTTP request body");
 		return -ENOMEM;
 	}
 
 	return 0;
 }
 
-int location_service_parse_response(const char *response, struct multicell_location *location)
+static int location_service_parse_response(const char *response,
+					   struct multicell_location *location)
 {
 	int err;
 	struct cJSON *root_obj, *location_obj, *lat_obj, *lng_obj, *accuracy_obj;
-	char *json_start, *http_status;
 	static bool cjson_is_init;
 
 	if ((response == NULL) || (location == NULL)) {
@@ -229,28 +213,12 @@ int location_service_parse_response(const char *response, struct multicell_locat
 		cjson_is_init = true;
 	}
 
-
-	/* The expected response format is the following:
+	/* The expected body format of the response is the following:
 	 *
-	 * HTTP/1.1 <HTTP status, 200 OK if successful>
-	 * <Additional HTTP header elements>
-	 * <\r\n\r\n>
 	 * {"location":{"lat":<latitude>,"lng":<longitude>,"accuracy":<accuracy>}}
 	 */
 
-	http_status = strstr(response, "HTTP/1.1 200");
-	if (http_status == NULL) {
-		LOG_ERR("HTTP status was not \"200\"");
-		return -1;
-	}
-
-	json_start = strstr(response, "\r\n\r\n");
-	if (json_start == NULL) {
-		LOG_ERR("No payload found");
-		return -1;
-	}
-
-	root_obj = cJSON_Parse(json_start);
+	root_obj = cJSON_Parse(response);
 	if (root_obj == NULL) {
 		LOG_ERR("Could not parse JSON in payload");
 		return -1;
@@ -297,5 +265,63 @@ int location_service_parse_response(const char *response, struct multicell_locat
 clean_exit:
 	cJSON_Delete(root_obj);
 
+	return err;
+}
+
+int location_service_get_cell_location(const struct lte_lc_cells_info *cell_data,
+				       const char * const device_id,
+				       char * const rcv_buf, const size_t rcv_buf_len,
+				       struct multicell_location *const location)
+{
+	int err;
+	struct rest_client_req_context req_ctx = { 0 };
+	struct rest_client_resp_context resp_ctx = { 0 };
+	char *const headers[] = {
+		HEADER_CONTENT_TYPE,
+		HEADER_CONNECTION,
+		/* Note: Content-length set according to payload in HTTP library */
+		NULL
+	};
+
+	err = location_service_generate_request(cell_data, device_id, body, sizeof(body));
+	if (err) {
+		LOG_ERR("Failed to generate HTTP request, error: %d", err);
+		return err;
+	}
+
+	LOG_DBG("Generated request body:\r\n%s", log_strdup(body));
+
+	/* Set the defaults: */
+	rest_client_request_defaults_set(&req_ctx);
+	req_ctx.http_method = HTTP_POST;
+	req_ctx.url = REQUEST_URL;
+	req_ctx.sec_tag = CONFIG_MULTICELL_LOCATION_TLS_SEC_TAG;
+	req_ctx.port = CONFIG_MULTICELL_LOCATION_HTTPS_PORT;
+	req_ctx.host = CONFIG_MULTICELL_LOCATION_HOSTNAME;
+	req_ctx.header_fields = (const char **)headers;
+	req_ctx.resp_buff = rcv_buf;
+	req_ctx.resp_buff_len = rcv_buf_len;
+
+	/* Get the body/payload to request: */
+	req_ctx.body = body;
+
+	err = rest_client_request(&req_ctx, &resp_ctx);
+	if (err) {
+		LOG_ERR("Error from rest client lib, err: %d", err);
+		return err;
+	}
+
+	if (resp_ctx.http_status_code != REST_CLIENT_HTTP_STATUS_OK) {
+		LOG_ERR("HTTP status: %d", resp_ctx.http_status_code);
+		/* Let it fail in parsing */
+	}
+
+	LOG_DBG("Received response body:\r\n%s", log_strdup(resp_ctx.response));
+
+	err = location_service_parse_response(resp_ctx.response, location);
+	if (err) {
+		LOG_ERR("Failed to parse HTTP response");
+		return -ENOMSG;
+	}
 	return err;
 }

--- a/lib/multicell_location/services/location_service.h
+++ b/lib/multicell_location/services/location_service.h
@@ -15,44 +15,16 @@
 extern "C" {
 #endif
 
-/* @brief Generate an HTTPS request in the format the location service expects.
- *
- * @param cell_data Pointer to neighbor cell data.
- * @param device_id Unique device identifier.
- * @param buf Buffer for storing the HTTP request.
- * @param buf_len Length of the provided buffer.
- *
- * @return 0 on success, or negative error code on failure.
- */
-int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
-				      const char *const device_id,
-				      char *buf, size_t buf_len);
-
-/* @brief Get pointer to the location service's null-terminated hostname.
- *
- * @return A pointer to null-terminated hostname in case of success,
- *	   or NULL in case of failure.
- */
-const char *location_service_get_hostname(void);
-
-/* @brief Get pointer to certificate to location service.
+/**
+ * @brief Get pointer to certificate to location service.
  *
  * @return A pointer to null-terminated root CA certificate in case of success,
- *	   or NULL in case of failure.
+ *         or NULL in case of failure.
  */
 const char *location_service_get_certificate(void);
 
-/* @brief Parse a response from a location service, and populate the provided
- *	  location structure.
- *
- * @param response Response from location service.
- * @param location Storage for the result from response parsing.
- *
- * @return 0 on success, or -1 on failure.
- */
-int location_service_parse_response(const char *response, struct multicell_location *location);
-
-/* @brief Generate location request, send, and parse response.
+/**
+ * @brief Generate location request, send, and parse response.
  *
  * @param cell_data Pointer to neighbor cell data.
  * @param device_id Unique device identifier.

--- a/lib/multicell_location/services/nrf_cloud_integration.c
+++ b/lib/multicell_location/services/nrf_cloud_integration.c
@@ -13,8 +13,6 @@
 
 LOG_MODULE_REGISTER(multicell_location_nrf_cloud, CONFIG_MULTICELL_LOCATION_LOG_LEVEL);
 
-#define HOSTNAME CONFIG_NRF_CLOUD_REST_HOST_NAME
-
 /* TLS certificate:
  *	CN=Starfield Services Root Certificate Authority - G2
  *	O=Starfield Technologies, Inc.
@@ -51,11 +49,6 @@ static const char tls_certificate[] =
 	"59vPr5KW7ySaNRB6nJHGDn2Z9j8Z3/VyVOEVqQdZe4O/Ui5GjLIAZHYcSNPYeehu\n"
 	"VsyuLAOQ1xk4meTKCRlb/weWsKh/NEnfVqn3sF/tM+2MR7cwA130A4w=\n"
 	"-----END CERTIFICATE-----\n";
-
-const char *location_service_get_hostname(void)
-{
-	return HOSTNAME;
-}
 
 const char *location_service_get_certificate(void)
 {

--- a/lib/multicell_location/services/skyhook_integration.c
+++ b/lib/multicell_location/services/skyhook_integration.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <modem/lte_lc.h>
 #include <modem/modem_info.h>
+#include <net/rest_client.h>
 #include <cJSON.h>
 #include <cJSON_os.h>
 
@@ -18,27 +19,31 @@
 LOG_MODULE_REGISTER(multicell_location_skyhook, CONFIG_MULTICELL_LOCATION_LOG_LEVEL);
 
 #define API_KEY		CONFIG_MULTICELL_LOCATION_SKYHOOK_API_KEY
-#define HOSTNAME	CONFIG_MULTICELL_LOCATION_HOSTNAME
 
 /* The timing advance returned by the nRF9160 modem must be divided by 16
  * to have the range expected by Skyhook.
  */
 #define TA_DIVIDER		16
+/* Estimated size for current cell information */
+#define CURRENT_CELL_SIZE	250
 /* Buffer size for neighbor element objects */
-#define NEIGHBOR_ELEMENT_SIZE	100
+#define NEIGHBOR_ELEMENT_SIZE	120
 /* Neighbor buffer size that will hold all neighbor cell objects */
 #define NEIGHBOR_BUFFER_SIZE	(CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS * NEIGHBOR_ELEMENT_SIZE)
+/* Estimated size for HTTP request body */
+#define HTTP_BODY_SIZE		(CURRENT_CELL_SIZE + NEIGHBOR_BUFFER_SIZE)
 
 /* URL and query string format:
  * https://global.skyhookwireless.com/wps2/json/location?key=<API KEY>&user=<DEVICE ID>
  */
 
-#define HTTP_REQUEST_HEADER						\
-	"POST /wps2/json/location?key="API_KEY"&user=%s HTTP/1.1\r\n"	\
-	"Host: "HOSTNAME"\r\n"					        \
-	"Content-Type: application/json\r\n"				\
-	"Connection: close\r\n"						\
-	"Content-Length: %d\r\n\r\n"
+#define API_LOCATE_PATH		"/wps2/json/location"
+#define API_KEY_PARAM		"key="API_KEY
+#define REQUEST_URL		API_LOCATE_PATH"?"API_KEY_PARAM"&user=%s"
+
+#define HEADER_CONTENT_TYPE    "Content-Type: application/json\r\n"
+#define HEADER_CONNECTION      "Connection: close\r\n"
+
 
 #define HTTP_REQUEST_BODY                                               \
 	"{"								\
@@ -88,6 +93,12 @@ LOG_MODULE_REGISTER(multicell_location_skyhook, CONFIG_MULTICELL_LOCATION_LOG_LE
 		"\"serving\": false"					\
 	"}"
 
+BUILD_ASSERT(sizeof(API_KEY) > 1, "API key must be configured");
+BUILD_ASSERT(sizeof(CONFIG_MULTICELL_LOCATION_HOSTNAME) > 1, "Hostname must be configured");
+
+static char body[HTTP_BODY_SIZE];
+static char neighbors[NEIGHBOR_BUFFER_SIZE];
+
 /* TLS certificate:
  *	DigiCert Global Root CA
  *	CN=DigiCert Global Root CA
@@ -122,17 +133,6 @@ static const char tls_certificate[] =
 	"CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=\n"
 	"-----END CERTIFICATE-----\n";
 
-BUILD_ASSERT(sizeof(API_KEY) > 1, "API key must be configured");
-BUILD_ASSERT(sizeof(HOSTNAME) > 1, "Hostname must be configured");
-
-static char body[1536];
-static char neighbors[NEIGHBOR_BUFFER_SIZE];
-
-const char *location_service_get_hostname(void)
-{
-	return HOSTNAME;
-}
-
 const char *location_service_get_certificate(void)
 {
 	return tls_certificate;
@@ -147,16 +147,14 @@ static int adjust_rsrp(int input)
 	return input - 141;
 }
 
-int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
-				      const char *const device_id,
-				      char *buf, size_t buf_len)
+static int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
+					     const char *const device_id,
+					     char *buf, size_t buf_len)
 {
 	int len;
 	enum lte_lc_lte_mode mode;
 	int err;
-	char imei[20];
 	char timing_advance[30];
-	char *dev_id = device_id ? (char *)device_id : imei;
 	size_t neighbors_to_use =
 		MIN(CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS, cell_data->ncells_count);
 
@@ -164,28 +162,9 @@ int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
 		return -EINVAL;
 	}
 
-	err = modem_info_init();
-	if (err) {
-		LOG_ERR("modem_info_init failed, error: %d", err);
-		return err;
-	}
-
-	if (device_id == NULL) {
-		err = modem_info_string_get(MODEM_INFO_IMEI, imei, sizeof(imei));
-		if (err < 0) {
-			LOG_ERR("Failed to get IMEI, error: %d", err);
-			LOG_WRN("Falling back to uptime as user ID");
-
-			len = snprintk(imei, sizeof(imei), "%d", k_cycle_get_32());
-			if ((len < 0) || (len >= sizeof(imei))) {
-				LOG_ERR("Too small buffer for IMEI buffer");
-				return -ENOMEM;
-			}
-
-		} else {
-			/* Null-terminate the IMEI. */
-			imei[15] = '\0';
-		}
+	if (cell_data->current_cell.id == 0) {
+		LOG_WRN("No cells were found");
+		return -ENOENT;
 	}
 
 	err = lte_lc_lte_mode_get(&mode);
@@ -207,7 +186,7 @@ int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
 	}
 
 	if (neighbors_to_use == 0) {
-		len = snprintk(body, sizeof(body), HTTP_REQUEST_BODY_NO_NEIGHBORS,
+		len = snprintk(buf, buf_len, HTTP_REQUEST_BODY_NO_NEIGHBORS,
 			 mode == LTE_LC_LTE_MODE_LTEM ? "lte" : "nbiot",
 			 cell_data->current_cell.mcc,
 			 cell_data->current_cell.mnc,
@@ -217,12 +196,6 @@ int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
 			 timing_advance,
 			 adjust_rsrp(cell_data->current_cell.rsrp),
 			 cell_data->current_cell.earfcn);
-		if ((len < 0) || (len >= sizeof(body))) {
-			LOG_ERR("Too small buffer for HTTP request body");
-			return -ENOMEM;
-		}
-
-		len = snprintk(buf, buf_len, HTTP_REQUEST_HEADER "%s", dev_id, strlen(body), body);
 		if ((len < 0) || (len >= buf_len)) {
 			LOG_ERR("Too small buffer for HTTP request body");
 			return -ENOMEM;
@@ -262,7 +235,7 @@ int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
 		strncat(neighbors, element, sizeof(neighbors) - strlen(neighbors));
 	}
 
-	len = snprintk(body, sizeof(body), HTTP_REQUEST_BODY,
+	len = snprintk(buf, buf_len, HTTP_REQUEST_BODY,
 		 mode == LTE_LC_LTE_MODE_LTEM ? "lte" : "nbiot",
 		 cell_data->current_cell.mcc,
 		 cell_data->current_cell.mnc,
@@ -273,25 +246,19 @@ int location_service_generate_request(const struct lte_lc_cells_info *cell_data,
 		 adjust_rsrp(cell_data->current_cell.rsrp),
 		 cell_data->current_cell.earfcn,
 		 neighbors);
-	if ((len < 0) || (len >= sizeof(body))) {
-		LOG_ERR("Too small buffer for HTTP request body");
-		return -ENOMEM;
-	}
-
-	len = snprintk(buf, buf_len, HTTP_REQUEST_HEADER "%s", dev_id, strlen(body), body);
 	if ((len < 0) || (len >= buf_len)) {
-		LOG_ERR("Too small buffer for HTTP request");
+		LOG_ERR("Too small buffer for HTTP request body");
 		return -ENOMEM;
 	}
 
 	return 0;
 }
 
-int location_service_parse_response(const char *response, struct multicell_location *location)
+static int location_service_parse_response(const char *response,
+					   struct multicell_location *location)
 {
 	int err;
 	struct cJSON *root_obj, *location_obj, *lat_obj, *lng_obj, *accuracy_obj;
-	char *json_start, *http_status;
 	static bool cjson_is_init;
 
 	if ((response == NULL) || (location == NULL)) {
@@ -304,27 +271,12 @@ int location_service_parse_response(const char *response, struct multicell_locat
 		cjson_is_init = true;
 	}
 
-	/* The expected response format is the following:
+	/* The expected body format of the response is the following:
 	 *
-	 * HTTP/1.1 <HTTP status, 200 OK if successful>
-	 * <Additional HTTP header elements>
-	 * <\r\n\r\n>
 	 * {"location":{"lat":<double>,"lng":<double>},"accuracy":<double>}
 	 */
 
-	http_status = strstr(response, "HTTP/1.1 200");
-	if (http_status == NULL) {
-		LOG_ERR("HTTP status was not 200");
-		return -1;
-	}
-
-	json_start = strstr(response, "\r\n\r\n");
-	if (json_start == NULL) {
-		LOG_ERR("No payload found");
-		return -1;
-	}
-
-	root_obj = cJSON_Parse(json_start);
+	root_obj = cJSON_Parse(response);
 	if (root_obj == NULL) {
 		LOG_ERR("Could not parse JSON in payload");
 		return -1;
@@ -371,5 +323,110 @@ int location_service_parse_response(const char *response, struct multicell_locat
 clean_exit:
 	cJSON_Delete(root_obj);
 
+	return err;
+}
+
+static int location_service_generate_url(
+	const char * const device_id, char * const request_url, const size_t request_url_len)
+{
+	int err;
+	char imei[20];
+	int len;
+	char *dev_id = device_id ? (char *)device_id : imei;
+
+	if (device_id == NULL) {
+		err = modem_info_init();
+		if (err) {
+			LOG_ERR("modem_info_init failed, error: %d", err);
+			return err;
+		}
+		err = modem_info_string_get(MODEM_INFO_IMEI, imei, sizeof(imei));
+		if (err < 0) {
+			LOG_ERR("Failed to get IMEI, error: %d", err);
+			LOG_WRN("Falling back to uptime as user ID");
+
+			len = snprintk(imei, sizeof(imei), "%d", k_cycle_get_32());
+			if ((len < 0) || (len >= sizeof(imei))) {
+				LOG_ERR("Too small buffer for IMEI buffer");
+				return -ENOMEM;
+			}
+		} else {
+			/* Null-terminate the IMEI. */
+			imei[15] = '\0';
+		}
+	}
+
+	len = snprintk(request_url, request_url_len, REQUEST_URL, dev_id);
+	if ((len < 0) || (len >= request_url_len)) {
+		LOG_ERR("Too small buffer for HTTP request URL");
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+int location_service_get_cell_location(const struct lte_lc_cells_info *cell_data,
+				       const char * const device_id,
+				       char * const rcv_buf, const size_t rcv_buf_len,
+				       struct multicell_location *const location)
+{
+	int err;
+	/* Reserving 30 bytes for device ID */
+	char request_url[sizeof(REQUEST_URL) + 30];
+	struct rest_client_req_context req_ctx = { 0 };
+	struct rest_client_resp_context resp_ctx = { 0 };
+	char *const headers[] = {
+		HEADER_CONTENT_TYPE,
+		HEADER_CONNECTION,
+		/* Note: Content-length set according to payload in HTTP library */
+		NULL
+	};
+
+	err = location_service_generate_url(device_id, request_url, sizeof(request_url));
+	if (err) {
+		LOG_ERR("modem_info_init failed, error: %d", err);
+		return err;
+	}
+
+	err = location_service_generate_request(cell_data, device_id, body, sizeof(body));
+	if (err) {
+		LOG_ERR("Failed to generate HTTP request, error: %d", err);
+		return err;
+	}
+
+	LOG_DBG("Generated request body:\r\n%s", log_strdup(body));
+
+	/* Set the defaults: */
+	rest_client_request_defaults_set(&req_ctx);
+	req_ctx.http_method = HTTP_POST;
+	req_ctx.url = request_url;
+	req_ctx.sec_tag = CONFIG_MULTICELL_LOCATION_TLS_SEC_TAG;
+	req_ctx.port = CONFIG_MULTICELL_LOCATION_HTTPS_PORT;
+	req_ctx.host = CONFIG_MULTICELL_LOCATION_HOSTNAME;
+	req_ctx.header_fields = (const char **)headers;
+	req_ctx.resp_buff = rcv_buf;
+	req_ctx.resp_buff_len = rcv_buf_len;
+
+	/* Get the body/payload to request: */
+	req_ctx.body = body;
+
+	err = rest_client_request(&req_ctx, &resp_ctx);
+	if (err) {
+		LOG_ERR("Error from rest client lib, err: %d", err);
+		return err;
+	}
+
+	if (resp_ctx.http_status_code != REST_CLIENT_HTTP_STATUS_OK) {
+		LOG_ERR("HTTP status: %d", resp_ctx.http_status_code);
+		/* Let it fail in parsing */
+	}
+
+	LOG_DBG("Received response body:\r\n%s", log_strdup(resp_ctx.response));
+
+	err = location_service_parse_response(resp_ctx.response, location);
+	if (err) {
+		LOG_ERR("Failed to parse HTTP response");
+		return -ENOMSG;
+	}
 	return err;
 }

--- a/subsys/net/lib/CMakeLists.txt
+++ b/subsys/net/lib/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 add_subdirectory_ifdef(CONFIG_CLOUD_API cloud)
 add_subdirectory_ifdef(CONFIG_NRF_CLOUD nrf_cloud)
+add_subdirectory_ifdef(CONFIG_REST_CLIENT rest_client)
 add_subdirectory_ifdef(CONFIG_DOWNLOAD_CLIENT download_client)
 add_subdirectory_ifdef(CONFIG_FOTA_DOWNLOAD fota_download)
 add_subdirectory_ifdef(CONFIG_AWS_JOBS aws_jobs)

--- a/subsys/net/lib/Kconfig
+++ b/subsys/net/lib/Kconfig
@@ -6,6 +6,7 @@
 menu "Application protocols"
 
 rsource "nrf_cloud/Kconfig"
+rsource "rest_client/Kconfig"
 rsource "download_client/Kconfig"
 rsource "fota_download/Kconfig"
 rsource "aws_iot/Kconfig"

--- a/subsys/net/lib/rest_client/CMakeLists.txt
+++ b/subsys/net/lib/rest_client/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+zephyr_library()
+zephyr_library_sources(src/rest_client.c)

--- a/subsys/net/lib/rest_client/Kconfig
+++ b/subsys/net/lib/rest_client/Kconfig
@@ -1,0 +1,44 @@
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menuconfig REST_CLIENT
+	bool "REST client library"
+	select HTTP_CLIENT
+
+if REST_CLIENT
+
+config REST_CLIENT_REQUEST_TIMEOUT
+	int "Rest request timeout, in seconds"
+	default 65
+	help
+	  Sets the timeout duration in seconds to wait for the response data.
+
+config REST_CLIENT_SCKT_SEND_TIMEOUT
+	int "Socket send timeout, in seconds"
+	default 60
+	help
+	  Sets the timeout duration in seconds to use when sending data.
+	  To disable, set the timeout duration to 0.
+
+config REST_CLIENT_SCKT_RECV_TIMEOUT
+	int "Socket receive timeout, in seconds"
+	default 60
+	help
+	  Sets the timeout duration in seconds to use when receiving data.
+	  To disable, set the timeout duration to 0.
+
+config REST_CLIENT_SCKT_TLS_SESSION_CACHE_IN_USE
+	bool "TLS session cache usage"
+	default y
+	help
+	  TLS session cache, disable or enable.
+
+module=REST_CLIENT
+module-dep=LOG
+module-str=Log level for REST Client lib
+module-help=Enables REST Client log messages.
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif # REST_CLIENT

--- a/subsys/net/lib/rest_client/src/rest_client.c
+++ b/subsys/net/lib/rest_client/src/rest_client.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <string.h>
+#include <zephyr.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+
+#if defined(CONFIG_POSIX_API)
+#include <posix/arpa/inet.h>
+#include <posix/unistd.h>
+#include <posix/netdb.h>
+#include <posix/sys/socket.h>
+#else
+#include <net/socket.h>
+#endif
+#include <net/tls_credentials.h>
+#include <net/http_client.h>
+#include <net/http_parser.h>
+
+#include <logging/log.h>
+
+#include <net/rest_client.h>
+
+LOG_MODULE_REGISTER(rest_client, CONFIG_REST_CLIENT_LOG_LEVEL);
+
+#define HTTP_PROTOCOL "HTTP/1.1"
+
+static void rest_client_http_response_cb(struct http_response *rsp,
+					  enum http_final_call final_data,
+					  void *user_data)
+{
+	struct rest_client_resp_context *resp_ctx = NULL;
+
+	if (user_data) {
+		resp_ctx = (struct rest_client_resp_context *)user_data;
+	}
+
+	/* If the entire HTTP response is not received in a single "recv" call
+	 * then this could be called multiple times, with a different value in
+	 * rsp->body_start. Only set rest_ctx->response once, the first time,
+	 * which will be the start of the body.
+	 */
+	if (resp_ctx) {
+		if (!resp_ctx->response && rsp->body_found && rsp->body_start) {
+			resp_ctx->response = rsp->body_start;
+		}
+		resp_ctx->total_response_len += rsp->data_len;
+	}
+
+	if (final_data == HTTP_DATA_MORE) {
+		LOG_DBG("Partial data received(%zd bytes)", rsp->data_len);
+	} else if (final_data == HTTP_DATA_FINAL) {
+		if (!resp_ctx) {
+			LOG_WRN("REST response context not provided");
+			return;
+		}
+		resp_ctx->http_status_code = rsp->http_status_code;
+		resp_ctx->response_len = rsp->content_length;
+
+		LOG_DBG("HTTP: All data received (content/total: %d/%d), status: %u %s",
+			rsp->content_length,
+			resp_ctx->total_response_len,
+			rsp->http_status_code,
+			log_strdup(rsp->http_status));
+	}
+}
+
+static int rest_client_sckt_tls_setup(int fd, const char *const tls_hostname,
+				      const sec_tag_t sec_tag, int tls_peer_verify)
+{
+	int err;
+	int verify = TLS_PEER_VERIFY_REQUIRED;
+	const sec_tag_t tls_sec_tag[] = {
+		sec_tag,
+	};
+	uint8_t cache;
+
+	if (tls_peer_verify == TLS_PEER_VERIFY_REQUIRED ||
+	    tls_peer_verify == TLS_PEER_VERIFY_OPTIONAL ||
+	    tls_peer_verify == TLS_PEER_VERIFY_NONE) {
+		verify = tls_peer_verify;
+	}
+
+	err = setsockopt(fd, SOL_TLS, TLS_PEER_VERIFY, &verify, sizeof(verify));
+	if (err) {
+		LOG_ERR("Failed to setup peer verification, error: %d", errno);
+		return err;
+	}
+
+	err = setsockopt(fd, SOL_TLS, TLS_SEC_TAG_LIST, tls_sec_tag, sizeof(tls_sec_tag));
+	if (err) {
+		LOG_ERR("Failed to setup TLS sec tag, error: %d", errno);
+		return err;
+	}
+
+	if (IS_ENABLED(CONFIG_REST_CLIENT_SCKT_TLS_SESSION_CACHE_IN_USE)) {
+		cache = TLS_SESSION_CACHE_ENABLED;
+	} else {
+		cache = TLS_SESSION_CACHE_DISABLED;
+	}
+
+	err = setsockopt(fd, SOL_TLS, TLS_SESSION_CACHE, &cache, sizeof(cache));
+	if (err) {
+		LOG_ERR("Unable to set session cache, errno %d", errno);
+		return err;
+	}
+
+	if (tls_hostname) {
+		err = setsockopt(fd, SOL_TLS, TLS_HOSTNAME, tls_hostname, strlen(tls_hostname));
+		if (err) {
+			LOG_ERR("Failed to setup TLS hostname, error: %d", errno);
+			return err;
+		}
+	}
+	return 0;
+}
+
+static int rest_client_sckt_timeouts_set(int fd)
+{
+	int err;
+	struct timeval timeout = { 0 };
+
+	if (CONFIG_REST_CLIENT_SCKT_SEND_TIMEOUT > 0) {
+		/* Send TO also affects TCP connect */
+		timeout.tv_sec = CONFIG_REST_CLIENT_SCKT_SEND_TIMEOUT;
+		err = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+		if (err) {
+			LOG_ERR("Failed to set socket send timeout, error: %d", errno);
+			return err;
+		}
+	}
+
+	if (CONFIG_REST_CLIENT_SCKT_RECV_TIMEOUT > 0) {
+		timeout.tv_sec = CONFIG_REST_CLIENT_SCKT_RECV_TIMEOUT;
+		err = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+		if (err) {
+			LOG_ERR("Failed to set socket recv timeout, error: %d", errno);
+			return err;
+		}
+	}
+	return 0;
+}
+
+static int rest_client_sckt_connect(int *const fd, const char *const hostname,
+				     const uint16_t port_num,
+				     const sec_tag_t sec_tag,
+				     int tls_peer_verify)
+{
+	int ret;
+	struct addrinfo *addr_info;
+	char peer_addr[INET6_ADDRSTRLEN];
+	char portstr[6] = { 0 };
+	struct addrinfo hints = {
+		.ai_flags = AI_NUMERICSERV, /* Let getaddrinfo() set port to addrinfo */
+		.ai_family = AF_UNSPEC, /* Both IPv4 and IPv6 addresses accepted */
+		.ai_socktype = SOCK_STREAM,
+		.ai_next = NULL,
+	};
+	struct sockaddr *sa;
+	int proto = 0;
+
+	/* Make sure fd is always initialized when this function is called */
+	*fd = -1;
+
+	snprintf(portstr, 6, "%d", port_num);
+
+	LOG_DBG("Doing getaddrinfo() with connect addr %s port %s",
+		log_strdup(hostname),
+		log_strdup(portstr));
+
+	ret = getaddrinfo(hostname, portstr, &hints, &addr_info);
+	if (ret) {
+		LOG_ERR("getaddrinfo() failed, error: %d", ret);
+		return -EFAULT;
+	}
+
+	sa = addr_info->ai_addr;
+	inet_ntop(sa->sa_family,
+		  (void *)&((struct sockaddr_in *)sa)->sin_addr,
+		  peer_addr,
+		  INET6_ADDRSTRLEN);
+	LOG_DBG("getaddrinfo() %s", log_strdup(peer_addr));
+
+	proto = (sec_tag == REST_CLIENT_SEC_TAG_NO_SEC) ? IPPROTO_TCP : IPPROTO_TLS_1_2;
+	*fd = socket(addr_info->ai_family, SOCK_STREAM, proto);
+	if (*fd == -1) {
+		LOG_ERR("Failed to open socket, error: %d", errno);
+		ret = -ENOTCONN;
+		goto clean_up;
+	}
+
+	if (sec_tag >= 0) {
+		ret = rest_client_sckt_tls_setup(*fd, hostname, sec_tag, tls_peer_verify);
+		if (ret) {
+			ret = -EACCES;
+			goto clean_up;
+		}
+	}
+
+	ret = rest_client_sckt_timeouts_set(*fd);
+	if (ret) {
+		LOG_ERR("Failed to set socket timeouts, error: %d", errno);
+		ret = -EINVAL;
+		goto clean_up;
+	}
+
+	LOG_DBG("Connecting to %s port %s",
+		log_strdup(hostname),
+		log_strdup(portstr));
+
+	ret = connect(*fd, addr_info->ai_addr, addr_info->ai_addrlen);
+	if (ret) {
+		LOG_ERR("Failed to connect socket, error: %d", errno);
+		ret = -ECONNREFUSED;
+		goto clean_up;
+	}
+
+clean_up:
+
+	freeaddrinfo(addr_info);
+	if (ret) {
+		if (*fd > -1) {
+			(void)close(*fd);
+			*fd = -1;
+		}
+	}
+
+	return ret;
+}
+
+static void rest_client_close_connection(struct rest_client_req_context *const req_ctx,
+					 struct rest_client_resp_context *const resp_ctx)
+{
+	int ret;
+
+	if (!req_ctx->keep_alive) {
+		ret = close(req_ctx->connect_socket);
+		if (ret) {
+			LOG_WRN("Failed to close socket, error: %d", errno);
+		}
+		req_ctx->connect_socket = REST_CLIENT_SCKT_CONNECT;
+	} else {
+		resp_ctx->used_socket_is_alive = true;
+		LOG_INF("Socket with id: %d was kept alive and wasn't closed",
+			req_ctx->connect_socket);
+	}
+}
+
+static void rest_client_init_request(struct rest_client_req_context *const req_ctx,
+				      struct http_request *const req)
+{
+	memset(req, 0, sizeof(struct http_request));
+
+	req->host = req_ctx->host;
+	req->protocol = HTTP_PROTOCOL;
+
+	req->response = rest_client_http_response_cb;
+	req->method = req_ctx->http_method;
+}
+
+static int rest_client_do_api_call(struct http_request *http_req,
+				   struct rest_client_req_context *const req_ctx,
+				   struct rest_client_resp_context *const resp_ctx)
+{
+	int err = 0;
+
+	if (req_ctx->connect_socket < 0) {
+		err = rest_client_sckt_connect(&req_ctx->connect_socket,
+						http_req->host,
+						req_ctx->port,
+						req_ctx->sec_tag, req_ctx->tls_peer_verify);
+		if (err) {
+			return err;
+		}
+	}
+
+	/* Assign the user provided receive buffer into the http request */
+	http_req->recv_buf = req_ctx->resp_buff;
+	http_req->recv_buf_len = req_ctx->resp_buff_len;
+
+	memset(http_req->recv_buf, 0, http_req->recv_buf_len);
+
+	/* Ensure receive buffer stays NULL terminated */
+	--http_req->recv_buf_len;
+
+	resp_ctx->response = NULL;
+	resp_ctx->response_len = 0;
+	resp_ctx->total_response_len = 0;
+	resp_ctx->used_socket_id = req_ctx->connect_socket;
+
+	err = http_client_req(req_ctx->connect_socket, http_req, req_ctx->timeout_ms, resp_ctx);
+	if (err < 0) {
+		LOG_ERR("http_client_req() error: %d", err);
+	} else if (resp_ctx->total_response_len >= req_ctx->resp_buff_len) {
+		/* 1 byte is reserved to NULL terminate the response */
+		LOG_ERR("Receive buffer too small, %d bytes are required",
+			resp_ctx->total_response_len + 1);
+		err = -ENOBUFS;
+	} else {
+		err = 0;
+	}
+
+	return err;
+}
+
+void rest_client_request_defaults_set(struct rest_client_req_context *req_ctx)
+{
+	__ASSERT_NO_MSG(req_ctx != NULL);
+
+	req_ctx->connect_socket = REST_CLIENT_SCKT_CONNECT;
+	req_ctx->keep_alive = false;
+	req_ctx->sec_tag = REST_CLIENT_SEC_TAG_NO_SEC;
+	req_ctx->tls_peer_verify = REST_CLIENT_TLS_DEFAULT_PEER_VERIFY;
+	req_ctx->http_method = HTTP_GET;
+	req_ctx->timeout_ms = CONFIG_REST_CLIENT_REQUEST_TIMEOUT * 1000;
+}
+
+int rest_client_request(struct rest_client_req_context *req_ctx,
+			struct rest_client_resp_context *resp_ctx)
+{
+	__ASSERT_NO_MSG(req_ctx != NULL);
+	__ASSERT_NO_MSG(req_ctx->host != NULL);
+	__ASSERT_NO_MSG(req_ctx->url != NULL);
+	__ASSERT_NO_MSG(req_ctx->resp_buff != NULL);
+	__ASSERT_NO_MSG(req_ctx->resp_buff_len > 0);
+
+	struct http_request http_req;
+	int ret;
+
+	rest_client_init_request(req_ctx, &http_req);
+
+	http_req.url = req_ctx->url;
+
+	LOG_DBG("Requesting destination HOST: %s at port %d, URL: %s",
+		log_strdup(req_ctx->host), req_ctx->port, log_strdup(http_req.url));
+
+	http_req.header_fields = req_ctx->header_fields;
+
+	if (req_ctx->body != NULL) {
+		http_req.payload = req_ctx->body;
+		http_req.payload_len = strlen(http_req.payload);
+		LOG_DBG("Payload: %s", log_strdup(http_req.payload));
+	}
+
+	ret = rest_client_do_api_call(&http_req, req_ctx, resp_ctx);
+	if (ret) {
+		LOG_ERR("rest_client_do_api_call() failed, err %d", ret);
+		goto clean_up;
+	}
+
+	if (!resp_ctx->response || !resp_ctx->response_len) {
+		LOG_WRN("No data in a response body");
+		/* Make it as zero length string */
+		*req_ctx->resp_buff = '\0';
+		resp_ctx->response = req_ctx->resp_buff;
+		resp_ctx->response_len = 0;
+	}
+	LOG_DBG("API call response len: http status: %d, %u bytes", resp_ctx->http_status_code,
+		resp_ctx->response_len);
+
+clean_up:
+	if (req_ctx->connect_socket != REST_CLIENT_SCKT_CONNECT) {
+		/* Socket was not closed yet: */
+		rest_client_close_connection(req_ctx, resp_ctx);
+	}
+	return ret;
+}


### PR DESCRIPTION
Adds a new `rest_client` library, which uses Zephyr's `http_client`.
This PR also adds a user for the library as `multicell_location` library is modified to use `rest_client`.
In `multicell_location` library, `nrf_cloud_jwt_generate()` is also taken into use instead of `modem_jwt_generate()`.

There are some more users of this library coming as part of new Location API/library work which can be seen in draft state in PR https://github.com/nrfconnect/sdk-nrf/pull/5341.