### PR TITLE
lib: lte_lc: Fix missing ncellmeas notification

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1511,10 +1511,13 @@ int lte_lc_neighbor_cell_measurement(enum lte_lc_neighbor_search_type type)
 	 * command without parameters to avoid error messages for older firmware version.
 	 */
 
-	if (type == LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT) {
-		err = nrf_modem_at_printf("AT%%NCELLMEAS");
+	if (type == LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT) {
+		err = at_cmd_write("AT%NCELLMEAS=1",  NULL, 0, NULL);
+	} else if (type == LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE) {
+		err = at_cmd_write("AT%NCELLMEAS=2",  NULL, 0, NULL);
 	} else {
-		err = nrf_modem_at_printf("AT%%NCELLMEAS=%d", type);
+		/* Defaulting to use LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT */
+		err = at_cmd_write("AT%NCELLMEAS",  NULL, 0, NULL);
 	}
 
 	return err ? -EFAULT : 0;


### PR DESCRIPTION
Change neighbor cell searches to use at_cmd for AT commands,
in order to receive notifications about neighbor cells.

This change is needed because lte_lc_neighbor_cell_measurement()
was mistakenly set up to use nrf_modem_at for AT commands before
the rest of the link controller was ready for it (see PR #5741).
Commands issued using nrf_modem_at must use at_monitor to receive
notifications, but this work is notyet completed in lte_lc.
Therefore this commit reverts to using at_cmd.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>