### PR TITLE
application: serial_lte_modem: Support native TLS in parallel

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -1153,7 +1153,7 @@ int handle_at_secure_socketopt(enum at_cmd_type cmd_type)
 			if (type == AT_PARAM_TYPE_NUM_INT) {
 				err = do_secure_socketopt_set_int(name, value_int);
 			} else if (type == AT_PARAM_TYPE_STRING) {
-				if (size == 0) {
+				if (size != 0) {
 					err = do_secure_socketopt_set_str(name, value_str);
 				} else {
 					err = do_secure_socketopt_set_str(name, NULL);

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -83,7 +83,11 @@ static int do_tcp_server_start(uint16_t port)
 	if (proxy.sec_tag == INVALID_SEC_TAG) {
 		ret = socket(proxy.family, SOCK_STREAM, IPPROTO_TCP);
 	} else {
+#if defined(CONFIG_SLM_NATIVE_TLS)
+		ret = socket(proxy.family, SOCK_STREAM | SOCK_NATIVE_TLS, IPPROTO_TLS_1_2);
+#else
 		ret = socket(proxy.family, SOCK_STREAM, IPPROTO_TLS_1_2);
+#endif
 	}
 	if (ret < 0) {
 		LOG_ERR("socket() failed: %d", -errno);


### PR DESCRIPTION
When build with native TLS support, only apply native TLS to
TLS Server role, and keep using modem TLS for (D)TLS client.

BUG-FIX: secure socket option (string type) mistake

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>