### PR TITLE
lib: pdn: Report IP family change in pdn_activate()

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -194,6 +194,10 @@ Modem libraries
 
   * Added a possibility to create native sockets when nRF91 socket offloading is enabled.
 
+* :ref:`pdn_readme` library:
+
+  * Added an optional ``family`` parameter to :c:func:`pdn_activate`, which is used to report when the IP family of a PDN changes after activation.
+
 Libraries for networking
 ------------------------
 

--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -149,11 +149,13 @@ int pdn_ctx_destroy(uint8_t cid);
  * @brief Activate a Packet Data Network (PDN) connection.
  *
  * @param cid The PDP context ID to activate a connection for.
- * @param[out] esm If provided, the function will block to return
- *		   the ESM error reason.
+ * @param[out] esm If provided, the function will block to return the ESM error reason.
+ * @param[out] family If provided, the function will block to return PDN_FAM_IPV4 if only IPv4 is
+ *		      supported, or PDN_FAM_IPV6 if only IPv6 is supported. Otherwise, this value
+ *		      will remain unchanged.
  * @return int Zero on success or a negative errno otherwise.
  */
-int pdn_activate(uint8_t cid, int *esm);
+int pdn_activate(uint8_t cid, int *esm, enum pdn_fam *family);
 
 /**
  * @brief Deactivate a Packet Data Network (PDN) connection.

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -845,7 +845,7 @@ int lwm2m_os_pdn_ctx_destroy(uint8_t cid)
 
 int lwm2m_os_pdn_activate(uint8_t cid, int *esm)
 {
-	return pdn_activate(cid, esm);
+	return pdn_activate(cid, esm, NULL);
 }
 
 int lwm2m_os_pdn_deactivate(uint8_t cid)

--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -84,7 +84,7 @@ static void link_api_activate_mosh_contexts(
 	for (i = 0; i < size; i++) {
 		if (pdn_act_status_arr[i].activated == false &&
 		    link_shell_pdn_info_is_in_list(pdn_act_status_arr[i].cid)) {
-			ret = pdn_activate(pdn_act_status_arr[i].cid, &esm);
+			ret = pdn_activate(pdn_act_status_arr[i].cid, &esm, NULL);
 			if (ret) {
 				mosh_warn(
 					"Cannot reactivate ctx with CID #%d, err: %d, removing from the list",

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
@@ -328,7 +328,7 @@ int link_shell_pdn_activate(int pdn_cid)
 	int esm;
 
 	/* Activate a PDN connection */
-	ret = pdn_activate(pdn_cid, &esm);
+	ret = pdn_activate(pdn_cid, &esm, NULL);
 	if (ret) {
 		mosh_error(
 			"pdn_activate() failed, err %d esm %d %s\n",

--- a/samples/nrf9160/pdn/src/main.c
+++ b/samples/nrf9160/pdn/src/main.c
@@ -109,7 +109,7 @@ void main(void)
 	       cid, apn, fam_str[PDN_FAM_IPV4V6]);
 
 	/* Activate a PDN connection */
-	err = pdn_activate(cid, &esm);
+	err = pdn_activate(cid, &esm, NULL);
 	if (err) {
 		printk("pdn_activate() failed, err %d esm %d %s\n",
 			err, esm, esm_strerr(esm));


### PR DESCRIPTION
Add an output parameter to pdn_activate() which reports if the newly
activated PDN supports only IPv4 or only IPv6, according to the reason
code given by the +CGEV ME PDN ACT notification. Additionally, improve
synchronization between pdn_activate() and AT notifications in order to
avoid possibilities for returning incorrect values.

Signed-off-by: Grzegorz Swiderski <grzegorz.swiderski@nordicsemi.no>