### PR TITLE
scripts: west_commands: prepare for upmerge

### DIFF
--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -133,6 +133,7 @@ class NcsWestCommand(WestCommand):
         z_west_yml = cp.stdout.decode('utf-8')
         try:
             return Manifest.from_data(source_data=yaml.safe_load(z_west_yml),
+                                      import_flags=ImportFlag.IGNORE,
                                       topdir=self.topdir)
         except MalformedManifest:
             log.die(f"can't load zephyr manifest; file {z_west_yml} "


### PR DESCRIPTION
The following upstream Zephyr commit adds an import into the zephyr
manifest itself:

https://github.com/zephyrproject-rtos/zephyr/commit/51f8588fb8978e6be4708ca414832df57dd5e73a

This will break our NCS scripts when we want to upmerge anything
including this revision, because we try to parse this manifest data
without any import hooks installed. Handle it by instructing west to
ignore the import; the imported submanifests directory is empty
upstream (it is intended for external users to more easily add
submodules), so this is correct.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>