### PR TITLE
samples: matter: Fixed bug with handling events in the main loop

### DIFF
--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -156,9 +156,7 @@ int AppTask::StartApp()
 
 	while (true) {
 		k_msgq_get(&sAppEventQueue, &event, K_FOREVER);
-
 		DispatchEvent(event);
-		k_msgq_get(&sAppEventQueue, &event, K_NO_WAIT);
 	}
 }
 

--- a/samples/matter/common/src/led_widget.h
+++ b/samples/matter/common/src/led_widget.h
@@ -24,7 +24,6 @@ public:
 	void UpdateState();
 
 private:
-	int64_t mLastChangeTimeMS;
 	uint32_t mBlinkOnTimeMS;
 	uint32_t mBlinkOffTimeMS;
 	uint32_t mGPIONum;

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -124,9 +124,7 @@ int AppTask::StartApp()
 
 	while (true) {
 		k_msgq_get(&sAppEventQueue, &event, K_FOREVER);
-
 		DispatchEvent(event);
-		k_msgq_get(&sAppEventQueue, &event, K_NO_WAIT);
 	}
 }
 

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -97,9 +97,7 @@ CHIP_ERROR AppTask::StartApp()
 
 	while (true) {
 		k_msgq_get(&sAppEventQueue, &event, K_FOREVER);
-
 		DispatchEvent(event);
-		k_msgq_get(&sAppEventQueue, &event, K_NO_WAIT);
 	}
 
 	return CHIP_NO_ERROR;

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -114,9 +114,7 @@ int AppTask::StartApp()
 
 	while (true) {
 		k_msgq_get(&sAppEventQueue, &event, K_FOREVER);
-
 		DispatchEvent(event);
-		k_msgq_get(&sAppEventQueue, &event, K_NO_WAIT);
 	}
 }
 

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -91,9 +91,7 @@ int AppTask::StartApp()
 
 	while (true) {
 		k_msgq_get(&sAppEventQueue, &event, K_FOREVER);
-
 		DispatchEvent(event);
-		k_msgq_get(&sAppEventQueue, &event, K_NO_WAIT);
 	}
 }
 


### PR DESCRIPTION
During last main loop optimization the bug occurred that resulted
in getting pending events from the queue and not handling them,
so in result they were lost. It was fixed by removing this get
operation.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>