### PR TITLE
drivers: flash_nop_device:  set target platform as native_posix

### DIFF
--- a/drivers/flash/flash_nop_device/flash_nop_device.c
+++ b/drivers/flash/flash_nop_device/flash_nop_device.c
@@ -13,7 +13,12 @@
 #include <string.h>
 #include <sys/util.h>
 
+/* configuration derived from DT */
+#ifdef CONFIG_ARCH_POSIX
+#define SOC_NV_FLASH_NODE DT_CHILD(DT_DRV_INST(0), flash_0)
+#else
 #define SOC_NV_FLASH_NODE DT_CHILD(DT_DRV_INST(0), flash_sim_0)
+#endif /* CONFIG_ARCH_POSIX */
 
 #define FLASH_NOP_DEVICE_BASE_OFFSET DT_REG_ADDR(SOC_NV_FLASH_NODE)
 #define FLASH_NOP_DEVICE_ERASE_UNIT DT_PROP(SOC_NV_FLASH_NODE, erase_block_size)

--- a/tests/drivers/flash_nop_device/boards/native_posix_ev_0x00.overlay
+++ b/tests/drivers/flash_nop_device/boards/native_posix_ev_0x00.overlay
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-&sim_flash {
+&flashcontroller0 {
 	erase-value = < 0x00 >;
 };

--- a/tests/drivers/flash_nop_device/src/main.c
+++ b/tests/drivers/flash_nop_device/src/main.c
@@ -8,8 +8,9 @@
 #include <drivers/flash.h>
 #include <device.h>
 
-/* configuration derived from DT */
-#define SOC_NV_FLASH_NODE DT_CHILD(DT_INST(0, zephyr_sim_flash), flash_sim_0)
+/* configuration derived from native_posix DT */
+#define SOC_NV_FLASH_NODE DT_CHILD(DT_INST(0, zephyr_sim_flash), flash_0)
+
 #define FLASH_NOP_DEVICE_BASE_OFFSET DT_REG_ADDR(SOC_NV_FLASH_NODE)
 #define FLASH_NOP_DEVICE_ERASE_UNIT DT_PROP(SOC_NV_FLASH_NODE, erase_block_size)
 #define FLASH_NOP_DEVICE_PROG_UNIT DT_PROP(SOC_NV_FLASH_NODE, write_block_size)

--- a/tests/drivers/flash_nop_device/testcase.yaml
+++ b/tests/drivers/flash_nop_device/testcase.yaml
@@ -5,9 +5,13 @@
 #
 tests:
   drivers.flash.flash_nop_device:
-    platform_allow: qemu_x86
+    platform_allow: native_posix
+    integration_platforms:
+      - native_posix
     tags: driver
-  drivers.flash.flash_nop_device.qemu_erase_value_0x00:
-    extra_args: DTC_OVERLAY_FILE=boards/qemu_x86_ev_0x00.overlay
-    platform_allow: qemu_x86
+  drivers.flash.flash_nop_device.posix_erase_value_0x00:
+    extra_args: DTC_OVERLAY_FILE=boards/native_posix_ev_0x00.overlay
+    platform_allow: native_posix
+    integration_platforms:
+      - native_posix
     tags: driver


### PR DESCRIPTION
Add changes into flash_nop_device driver, which allow to use this
device with native_posix. It is necessary due to the fact, that
native_posix's dts use different naming for flash node than qemu_x86
in dts file.

According to this, dirver's test was also changed - qemu_x86
platfrom was replaced by native_posix.

Testcase with erase value set to 0x00 for qemu_x86 was replaced by
analogous test on native_posix.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>