### PR TITLE
lib: date_time: Check that uptime is not negative.

### DIFF
--- a/include/date_time.h
+++ b/include/date_time.h
@@ -62,7 +62,8 @@ int date_time_set(const struct tm *new_date_time);
 
 /** @brief Get the date time UTC when the passing variable uptime was set.
  *         This function requires that k_uptime_get() has been called on the
- *         passing variable uptime prior to the function call.
+ *         passing variable uptime prior to the function call. In that case the uptime
+ *         will not be too large or negative.
  *
  *  @warning If the function fails, the passed in variable retains its
  *           old value.
@@ -72,7 +73,7 @@ int date_time_set(const struct tm *new_date_time);
  *  @return 0        If the operation was successful.
  *  @return -ENODATA If the library does not have a valid date time UTC.
  *  @return -EINVAL  If the passed in pointer is NULL, dereferenced value is too large,
- *		     or already converted.
+ *		     already converted or if uptime is negative.
  */
 int date_time_uptime_to_unix_time_ms(int64_t *uptime);
 

--- a/lib/date_time/date_time.c
+++ b/lib/date_time/date_time.c
@@ -418,6 +418,11 @@ int date_time_uptime_to_unix_time_ms(int64_t *uptime)
 		return -EINVAL;
 	}
 
+	if (*uptime < 0) {
+		LOG_ERR("Uptime cannot be negative");
+		return -EINVAL;
+	}
+
 	uptime_prev = *uptime;
 
 	if (!initial_valid_time) {

--- a/tests/lib/date_time/src/main.c
+++ b/tests/lib/date_time/src/main.c
@@ -18,8 +18,6 @@ static void reset_to_valid_time(struct tm *time)
 	time->tm_hour = 15;
 	time->tm_min = 11;
 	time->tm_sec = 30;
-	time->tm_wday = 5;
-	time->tm_yday = 200;
 }
 
 static void test_date_time_invalid_input(void)
@@ -163,6 +161,17 @@ static void test_date_time_already_converted(void)
 		      "ts_unix_ms should equal ts_unix_ms_prev");
 }
 
+static void test_date_time_negative_uptime(void)
+{
+	int ret;
+
+	int64_t ts_unix_ms = -1000;
+
+	ret = date_time_uptime_to_unix_time_ms(&ts_unix_ms);
+	zassert_equal(-EINVAL, ret,
+		      "date_time_uptime_to_unix_time_ms should return -EINVAL");
+}
+
 static void test_date_time_clear(void)
 {
 	int ret;
@@ -280,6 +289,10 @@ void test_main(void)
 					test_date_time_teardown),
 		ztest_unit_test_setup_teardown(
 					test_date_time_clear,
+					test_date_time_setup,
+					test_date_time_teardown),
+		ztest_unit_test_setup_teardown(
+					test_date_time_negative_uptime,
 					test_date_time_setup,
 					test_date_time_teardown),
 		ztest_unit_test_setup_teardown(


### PR DESCRIPTION
Adding check to confirm that passed in uptime pointer to date_time_uptime_to_unix_time_ms is not negative.
This is primarily to ensure that k_uptime_get have been run on the passed in pointer.

Signed-off-by: David Dilner <david.dilner@nordicsemi.no>