### PR TITLE
zigbee: osif: Flush logs before kernel panic

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_platform.c
+++ b/subsys/zigbee/osif/zb_nrf_platform.c
@@ -512,6 +512,8 @@ void zb_osif_init(void)
 void zb_osif_abort(void)
 {
 	LOG_ERR("Fatal error occurred");
+	ZB_OSIF_SERIAL_FLUSH();
+
 	k_fatal_halt(K_ERR_KERNEL_PANIC);
 }
 


### PR DESCRIPTION
Flush logs, including the file ID and line number, that caused the ZBOSS assertion before raising kernel panic error.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>