### PR TITLE
samples: matter: Fixed unable to allocate TX context BT error

### DIFF
--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/prj_ZDebug.conf
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/prj_ZDebug.conf
@@ -176,5 +176,8 @@ CONFIG_BT_L2CAP_TX_MTU=498
 CONFIG_BT_BUF_ACL_TX_SIZE=251
 CONFIG_BT_BUF_ACL_RX_SIZE=502
 
+# Increase max number of pending GATT notification callbacks
+CONFIG_BT_CONN_TX_MAX=6
+
 # Increase system workqueue size, as SMP is processed within it
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2800

--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/prj_ZRelease.conf
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/prj_ZRelease.conf
@@ -156,5 +156,8 @@ CONFIG_BT_L2CAP_TX_MTU=498
 CONFIG_BT_BUF_ACL_TX_SIZE=251
 CONFIG_BT_BUF_ACL_RX_SIZE=502
 
+# Increase max number of pending GATT notification callbacks
+CONFIG_BT_CONN_TX_MAX=6
+
 # Increase system workqueue size, as SMP is processed within it
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2800

--- a/samples/matter/light_bulb/prj_multi_image_dfu.conf
+++ b/samples/matter/light_bulb/prj_multi_image_dfu.conf
@@ -135,6 +135,9 @@ CONFIG_BT_L2CAP_TX_MTU=498
 CONFIG_BT_BUF_ACL_TX_SIZE=251
 CONFIG_BT_BUF_ACL_RX_SIZE=502
 
+# Increase max number of pending GATT notification callbacks
+CONFIG_BT_CONN_TX_MAX=6
+
 # Increase system workqueue size, as SMP is processed within it
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2800
 

--- a/samples/matter/light_bulb/prj_single_image_dfu.conf
+++ b/samples/matter/light_bulb/prj_single_image_dfu.conf
@@ -134,6 +134,9 @@ CONFIG_BT_L2CAP_TX_MTU=498
 CONFIG_BT_BUF_ACL_TX_SIZE=251
 CONFIG_BT_BUF_ACL_RX_SIZE=502
 
+# Increase max number of pending GATT notification callbacks
+CONFIG_BT_CONN_TX_MAX=6
+
 # Increase MCUMGR_BUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
 CONFIG_MCUMGR_BUF_SIZE=1024
 

--- a/samples/matter/lock/prj_multi_image_dfu.conf
+++ b/samples/matter/lock/prj_multi_image_dfu.conf
@@ -131,6 +131,9 @@ CONFIG_BT_L2CAP_TX_MTU=498
 CONFIG_BT_BUF_ACL_TX_SIZE=251
 CONFIG_BT_BUF_ACL_RX_SIZE=502
 
+# Increase max number of pending GATT notification callbacks
+CONFIG_BT_CONN_TX_MAX=6
+
 # Increase system workqueue size, as SMP is processed within it
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2800
 

--- a/samples/matter/lock/prj_single_image_dfu.conf
+++ b/samples/matter/lock/prj_single_image_dfu.conf
@@ -130,6 +130,9 @@ CONFIG_BT_L2CAP_TX_MTU=498
 CONFIG_BT_BUF_ACL_TX_SIZE=251
 CONFIG_BT_BUF_ACL_RX_SIZE=502
 
+# Increase max number of pending GATT notification callbacks
+CONFIG_BT_CONN_TX_MAX=6
+
 # Increase MCUMGR_BUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
 CONFIG_MCUMGR_BUF_SIZE=1024
 


### PR DESCRIPTION
When performing DFU over BLE with SMP sometimes BT error
"Unable to allocate TX context" was visible. Investigated
that it is a result of too small BT_CONN_TX_MAX value
to handle all pending GATT notification callbacks.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>