### PR TITLE
net: lib: aws_iot: clarify use of topic type

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -280,6 +280,10 @@ Libraries for networking
 
     * Validation of bootloader FOTA updates.
 
+* :ref:`lib_aws_iot` library:
+
+  * Renamed ``aws_iot_topic_type`` to ``aws_iot_shadow_topic_type`` and removed ``AWS_IOT_SHADOW_TOPIC_UNKNOWN``.
+
 Modem libraries
 ---------------
 

--- a/include/net/aws_iot.h
+++ b/include/net/aws_iot.h
@@ -27,9 +27,9 @@ extern "C" {
 /** @brief AWS IoT shadow topics, used in messages to specify which shadow
  *         topic that will be published to.
  */
-enum aws_iot_topic_type {
-	/** Unknown device shadow topic. */
-	AWS_IOT_SHADOW_TOPIC_UNKNOWN = 0x0,
+enum aws_iot_shadow_topic_type {
+	/** Unused default value. */
+	AWS_IOT_SHADOW_TOPIC_NONE,
 	/** This topic type corresponds to
 	 *  $aws/things/<thing-name>/shadow/get, publishing an empty message
 	 *  to this topic requests the device shadow document.
@@ -109,8 +109,11 @@ enum aws_iot_evt_type {
 
 /** @brief AWS IoT topic data. */
 struct aws_iot_topic_data {
-	/** Type of shadow topic that will be published to. */
-	enum aws_iot_topic_type type;
+	/** Optional: type of shadow topic that will be published to.
+	 *  When publishing to a shadow topic this can be set instead of the
+	 *  application specific topic below.
+	 */
+	enum aws_iot_shadow_topic_type type;
 	/** Pointer to string of application specific topic. */
 	const char *str;
 	/** Length of application specific topic. */

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -751,7 +751,6 @@ static void mqtt_evt_handler(struct mqtt_client *const c,
 		aws_iot_evt.type = AWS_IOT_EVT_DATA_RECEIVED;
 		aws_iot_evt.data.msg.ptr = payload_buf;
 		aws_iot_evt.data.msg.len = p->message.payload.len;
-		aws_iot_evt.data.msg.topic.type = AWS_IOT_SHADOW_TOPIC_UNKNOWN;
 		aws_iot_evt.data.msg.topic.str = p->message.topic.topic.utf8;
 		aws_iot_evt.data.msg.topic.len = p->message.topic.topic.size;
 


### PR DESCRIPTION
This clarifies the use of the `type` property when defining
a topic.
