### PR TITLE
doc: samples: peripheral: radio_test: clarify units in commands.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -378,3 +378,7 @@ In addition to documentation related to the changes listed above, the following 
 * Libraries:
 
   * Added the documentation page for :ref:`lib_fatal_error`.
+
+* Samples
+
+  * :ref:`radio_test` - clarified units for numerical parameters in shell commands.

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -81,7 +81,7 @@ User interface
      - Set the data rate.
    * - end_channel
      - <channel>
-     - End the channel for the sweep.
+     - End channel for the sweep (in MHz, as difference from 2400 MHz).
    * - nRF21540
      - <sub_cmd>
      - Set nRF21540 Front-End-Module parameters.
@@ -96,7 +96,7 @@ User interface
      - Print the received RX payload.
    * - start_channel
      - <channel>
-     - Start the channel for the sweep or the channel for the constant carrier.
+     - Start channel for the sweep or the channel for the constant carrier (in MHz, as difference from 2400 MHz).
    * - start_duty_cycle_modulated_tx
      - <duty_cycle>
      - Duty cycle in percent (two decimal digits, between 01 and 99).
@@ -117,7 +117,7 @@ User interface
      - Start the TX sweep.
    * - time_on_channel
      - <time>
-     - Time on each channel (between 1 ms and 99 ms).
+     - Time on each channel in ms (between 1 and 99).
    * - toggle_dcdc_state
      - <state>
      - Toggle DC/DC converter state.

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -1282,14 +1282,14 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_nrf21540,
 #endif /* CONFIG_NRF21540_FEM */
 
 SHELL_CMD_REGISTER(start_channel, NULL,
-		   "Start the channel for the sweep or the channel for"
-		   " the constant carrier <channel>",
+		   "Start channel for the sweep or the channel for"
+		   " the constant carrier (in MHz as difference from 2400 MHz) <channel>",
 		    cmd_start_channel_set);
 SHELL_CMD_REGISTER(end_channel, NULL,
-		   "End the channel for the sweep <channel>",
+		   "End channel for the sweep (in MHz as difference from 2400 MHz) <channel>",
 		   cmd_end_channel_set);
 SHELL_CMD_REGISTER(time_on_channel, NULL,
-		   "Time on each channel (between 1 ms and 99 ms) <time>",
+		   "Time on each channel in ms (between 1 and 99) <time>",
 		   cmd_time_set);
 SHELL_CMD_REGISTER(cancel, NULL, "Cancel the sweep or the carrier",
 		   cmd_cancel);


### PR DESCRIPTION
Clarify units for numerical values in some commands.

Technically, there are also source code changes, but only in constant strings describing some shell commands, so maybe it still classifies as a doc update.