### PR TITLE
Bluetooth: Mesh: Don't remove enocean model from the models list

### DIFF
--- a/subsys/bluetooth/mesh/vnd/silvair_enocean_srv.c
+++ b/subsys/bluetooth/mesh/vnd/silvair_enocean_srv.c
@@ -383,7 +383,9 @@ static void bt_mesh_silvair_enocean_srv_reset(struct bt_mesh_model *model)
 		decommission_device(srv);
 	}
 
+#if defined(CONFIG_ZTEST)
 	sys_slist_find_and_remove(&models_list, &srv->entry);
+#endif
 
 	for (int i = 0; i < BT_MESH_SILVAIR_ENOCEAN_PROXY_BUTTONS; i++) {
 		/* If cancel fails, the handler will do nothing because the


### PR DESCRIPTION
A model is added to the list at model's initialization callback,
which is called only once at runtime. If it's removed from the list, it
won't be added back until the next boot up.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>