### PR TITLE
doc: release-notes: rename Asset Tracker section

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -48,8 +48,8 @@ Applications
 
 This section provides detailed lists of changes by :ref:`application <applications>`.
 
-nRF9160: Asset Tracker
-----------------------
+nRF9160: Asset Tracker v2
+-------------------------
 
 * Updated the application to start sending batch messages to the new bulk endpoint topic supported in nRF Cloud.
 * Updated the application to use nRF Cloud A-GPS directly without the A-GPS library. SUPL is no longer supported.


### PR DESCRIPTION
The changes actually apply to asset_tracker_v2