### PR TITLE
doc: document multithread locking library

### DIFF
--- a/doc/nrf/libraries/mpsl/mpsl_multithread_lock.rst
+++ b/doc/nrf/libraries/mpsl/mpsl_multithread_lock.rst
@@ -1,0 +1,27 @@
+.. _lib_mpsl_multithreading_lock:
+
+MPSL: Multithreading lock
+#########################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Multiprotocol Service Layer (MPSL) multithreading lock library is used to ensure the threadsafe operation of MPSL and stacks using MPSL.
+
+Library files
+*************
+
+.. |library path| replace:: :file:`lib/multithreading_lock`
+
+This library is found under |library path| in the |NCS| folder structure.
+
+API documentation
+*****************
+
+| Header file: :file:`lib/multithreading_lock/multithreading_lock.h`
+| Source file: :file:`lib/multithreading_lock/multithreading_lock.c`
+
+.. doxygengroup::
+   :project: nrf
+   :members:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -409,6 +409,7 @@ In addition to documentation related to the changes listed above, the following 
 * Libraries:
 
   * Added the documentation page for :ref:`lib_fatal_error`.
+  * Added the documentation page for :ref:`lib_mpsl_multithreading_lock`
 
 * Samples
 


### PR DESCRIPTION
Adds documentation for the MPSL multithread locking library.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>