### PR TITLE
treewide: Rename master to main

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 # https://github.com/actions/labeler/blob/main/README.md
 
 # When extending this, remember that in the PR, the labeler will run against
-# the labeler.yml in master, more info:
+# the labeler.yml in main, more info:
 # https://github.com/actions/labeler/issues/12
 # This means your changes won't be tested. To test your branch, make a second
 # branch with dummy changes, and open a PR on your own fork, against the

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - master
+      - main
       - 'v*-branch'
   push:
     branches:
-      - master
+      - main
       - 'v*-branch'
 
 env:
@@ -86,7 +86,7 @@ jobs:
           else
             # basename will work for both branches and tags
             branch=$(basename "${{ github.ref }}")
-            if [[ $branch == "master" ]]; then
+            if [[ $branch == "main" ]]; then
               echo "publish2 main latest __FILE__" > monitor.txt
             else
               echo "publish2 main ${branch} __FILE__" > monitor.txt

--- a/.github/workflows/docremove.yml
+++ b/.github/workflows/docremove.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [closed]
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/doc/nrf/dm_adding_code.rst
+++ b/doc/nrf/dm_adding_code.rst
@@ -54,7 +54,7 @@ If you choose to have your application outside of the folder hierarchy of the |N
 More information about application development and the |NCS| build and configuration system can be found in the :ref:`app_build_system` documentation section.
 
 The drawback with this approach is that any changes you make to the set of |NCS| repositories are not directly trackable using Git, since you do not have any of the |NCS| repositories forked.
-If you are tracking the master branch of the |NCS|, you can instead send the changes you require to the official repositories as Pull Requests, so that they are incorporated into the codebase.
+If you are tracking the main branch of the |NCS|, you can instead send the changes you require to the official repositories as Pull Requests, so that they are incorporated into the codebase.
 
 Workflow 3: Application in a fork of `sdk-nrf`_
 ===============================================

--- a/doc/nrf/dm_code_base.rst
+++ b/doc/nrf/dm_code_base.rst
@@ -63,7 +63,7 @@ repositories (i.e. the west projects).
 This means that the linear Git history of this manifest repository also determines the history of the repository set in its entirety, thanks to the :file:`west.yml` `west manifest file`_ being part of the manifest repository.
 West reads the contents of the manifest file to find out which revisions of the project repositories are to be checked out every time ``west update`` is run.
 In this way, you can decide to work with a specific |NCS| release either by initializing a new west installation at a particular tag or by checking out the corresponding tag for a release in an existing installation and then updating your project repositories to the corresponding state with ``west update``.
-Alternatively, you can work with the latest state of development by using the master branch of the `sdk-nrf`_ repository, updating it with Git regularly and using ``west update`` to update the project repositories every time the manifest repository changes.
+Alternatively, you can work with the latest state of development by using the main branch of the `sdk-nrf`_ repository, updating it with Git regularly and using ``west update`` to update the project repositories every time the manifest repository changes.
 More information about manifests can be found in the :ref:`west manifest section <zephyr:west-manifests>` of the Zephyr documentation.
 
 Revisions
@@ -71,12 +71,12 @@ Revisions
 
 There are two fundamental revisions that are relevant to most |NCS| users:
 
-* The ``master`` branch of the `sdk-nrf`_ repository
+* The ``main`` branch of the `sdk-nrf`_ repository
 * Any Git tag (i.e. release) of the `sdk-nrf`_ repository
 
 As discussed above, the revision of the manifest repository, `sdk-nrf`_, uniquely determines the revisions of all other repositories, so a discussion about |NCS| revisions can be essentially limited to the manifest repository revision.
 
-The ``master`` branch of the `sdk-nrf`_ repository always contains the latest development state of the |NCS|.
+The ``main`` branch of the `sdk-nrf`_ repository always contains the latest development state of the |NCS|.
 Since all development is done openly, you can use it if you are not particularly concerned about stability and want to track the latest changes that are being merged continuously into the different repositories.
 
 The Git tags correspond to official releases tested and signed by the Nordic engineers.

--- a/doc/nrf/dm_managing_code.rst
+++ b/doc/nrf/dm_managing_code.rst
@@ -33,8 +33,8 @@ To obtain a fresh copy of the |NCS| at revision ``{revision}`` and place it in a
   west update
 
 Replace ``{revision}`` with any revision you wish to obtain.
-This can be ``master`` if you want the latest state, or any released version (e.g. |release_tt|).
-If you omit the ``--mr`` parameter, west defaults to ``master``.
+This can be ``main`` if you want the latest state, or any released version (e.g. |release_tt|).
+If you omit the ``--mr`` parameter, west defaults to ``main``.
 
 This is the procedure used for :ref:`getting the nRF Connect SDK code <cloning_the_repositories>` when :ref:`gs_installing`.
 
@@ -47,8 +47,8 @@ If you already have a copy of the |NCS| and wish to update it or switch to a new
 
   cd ncs/nrf
   git fetch {remote}
-  # Check out the latest master branch
-  git checkout {remote}/master
+  # Check out the latest main branch
+  git checkout {remote}/main
   # or check out a release
   git checkout {revision}
   west update
@@ -63,10 +63,10 @@ Git offers several commands and mechanisms to set the current working copy of a 
 Depending on how you manage the branches of your local clone of the `sdk-nrf`_ repository, you can also replace the use of ``git checkout`` with, among many others::
 
   # If you have no changes of your own
-  git reset --hard {remote}/master
+  git reset --hard {remote}/main
   git reset --hard {revision}
   # If you have changes of your own
-  git rebase {remote}/master
+  git rebase {remote}/main
   git rebase {revision}
 
 Describing the exact differences between the commands above is outside the scope of this section.
@@ -137,4 +137,4 @@ Also, since a GitHub fork automatically initializes the forked repository with t
   # Rename the default remote from 'origin' to 'ncs'
   git remote rename origin ncs
   git remote add origin https://github.com/{username}/{repo}.git
-  git push origin master
+  git push origin main

--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -233,7 +233,7 @@ Every |NCS| release consists of a combination of :ref:`Git repositories <ncs_int
 The revision of each of those repositories is determined by the current revision of the main (or manifest) repository, `sdk-nrf`_.
 
 .. note::
-   The latest state of development is on the ``master`` branch of the `sdk-nrf`_ repository.
+   The latest state of development is on the ``main`` branch of the `sdk-nrf`_ repository.
    To ensure a usable state, the `sdk-nrf`_ repository defines the compatible states of the other repositories.
    However, this state is not necessarily tested.
    For a higher degree of quality assurance, check out a tagged release.
@@ -252,7 +252,7 @@ To clone the repositories, complete the following steps:
    * To work with a specific release, the identifier is the corresponding tag (for example, |release_tt|).
      You can find the tag in the :ref:`release_notes` of the release.
    * To work with a development tag, the identifier is the corresponding tag (for example, ``v1.2.99-dev1``)
-   * To work with a branch, the identifier is the branch name (for example, ``master`` to work with the latest state of development).
+   * To work with a branch, the identifier is the branch name (for example, ``main`` to work with the latest state of development).
    * To work with a specific state, the identifier is the SHA (for example, ``224bee9055d986fe2677149b8cbda0ff10650a6e``).
 
 #. From the command line, initialize west with the revision of the |NCS| that you want to check out, replacing *NCS_revision* with the identifier:
@@ -271,7 +271,7 @@ To clone the repositories, complete the following steps:
 
    To check out the latest state of development, enter the following command::
 
-     west init -m https://github.com/nrfconnect/sdk-nrf --mr master
+     west init -m https://github.com/nrfconnect/sdk-nrf --mr main
 
    .. west-error-start
 

--- a/doc/nrf/gs_updating.rst
+++ b/doc/nrf/gs_updating.rst
@@ -83,7 +83,7 @@ To update to a particular revision (SHA), make sure that you have that particula
 To switch to the latest state of development, enter the following commands::
 
    git fetch origin
-   git checkout origin/master
+   git checkout origin/main
    west update
 
 .. note::

--- a/doc/nrf/includes/filter.js
+++ b/doc/nrf/includes/filter.js
@@ -38,9 +38,9 @@
           var versionName = className.replace(/v(\d+)-(\d+)-(\d+)/i, 'v$1.$2.$3');
           thisDl.children("dt").append('<a href="' + URL + '?v=' + className + '"><span class="versiontag" version="' + className + '">' + versionName + '</span></a>');
 
-        } else if (className === 'master') {
+        } else if (className === 'main') {
 
-          thisDl.children("dt").append('<a href="' + URL + '?v=master"><span class="versiontag" version="master">master</span></a>');
+          thisDl.children("dt").append('<a href="' + URL + '?v=main"><span class="versiontag" version="main">main</span></a>');
 
         };
 
@@ -78,7 +78,7 @@
         Otherwise, switch to the version that is selected in the dropdown.    **/
     var v = getUrlParameter('v');
 
-    if ((RegExp('v\\d+-\\d+-\\d+').test(v)) || v === 'master') {
+    if ((RegExp('v\\d+-\\d+-\\d+').test(v)) || v === 'main') {
 
       displayVersion(v);
 

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -13,7 +13,7 @@ The |NCS| includes the Zephyr™ real-time operating system (RTOS), which is bui
 
 To access different versions of the |NCS| documentation, use the version drop-down in the top left corner.
 To view the documentation from the different repositories that are part of |NCS|, click the arrow in the bottom left corner and select the desired document set.
-A "99" at the end of the version number of this documentation indicates continuous updates on the master branch since the previous major.minor release.
+A "99" at the end of the version number of this documentation indicates continuous updates on the main branch since the previous major.minor release.
 
 In addition to the |NCS| documentation, information is available in the following locations:
 

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1033,7 +1033,7 @@ NCSDK-8232: Secure Partition Manager and application building together
 CIA-248: Samples with default SPM config fails to build for ``thingy91_nrf9160_ns``
    All samples using the default SPM config fails to build for the ``thingy91_nrf9160_ns``  build target if the sample is not set up with MCUboot.
 
-   **Workaround:** Use the master branch.
+   **Workaround:** Use the main branch.
 
 MCUboot
 *******
@@ -1357,7 +1357,7 @@ DRGN-15475: Samples might not initialize the SoftDevice Controller HCI driver co
 DRGN-15382: The SoftDevice Controller cannot be qualified on nRF52832
   The SoftDevice Controller cannot be qualified on nRF52832.
 
-  **Workaround:** Upgrade to v1.5.1 or use the master branch.
+  **Workaround:** Upgrade to v1.5.1 or use the main branch.
 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -52,13 +52,13 @@
 
 .. _`Alexa Gadgets Github color cycler`: https://github.com/alexa/Alexa-Gadgets-Raspberry-Pi-Samples/tree/v2.0.0/src/examples/color_cycler#user-content-step-4-create-your-custom-skill
 
-.. _`nrf9160dk_nrf9160_partition_conf.dts`: https://github.com/nrfconnect/sdk-zephyr/blob/master/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
+.. _`nrf9160dk_nrf9160_partition_conf.dts`: https://github.com/nrfconnect/sdk-zephyr/blob/main/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
 
-.. _`west manifest file`: https://github.com/nrfconnect/sdk-nrf/blob/master/west.yml
+.. _`west manifest file`: https://github.com/nrfconnect/sdk-nrf/blob/main/west.yml
 
-.. _`tests/unity/example_test/CMakeLists.txt`: https://github.com/nrfconnect/sdk-nrf/blob/master/tests/unity/example_test/CMakeLists.txt
+.. _`tests/unity/example_test/CMakeLists.txt`: https://github.com/nrfconnect/sdk-nrf/blob/main/tests/unity/example_test/CMakeLists.txt
 
-.. _`nRF52820 CMakeLists.txt`: https://github.com/zephyrproject-rtos/zephyr/blob/master/boards/arm/nrf52833dk_nrf52820/CMakeLists.txt
+.. _`nRF52820 CMakeLists.txt`: https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/arm/nrf52833dk_nrf52820/CMakeLists.txt
 
 .. _`OpenThread CLI Reference`: https://github.com/openthread/openthread/blob/main/src/cli/README.md
 .. _`Commissioner CLI commands`: https://github.com/openthread/openthread/blob/main/src/cli/README_COMMISSIONER.md
@@ -132,7 +132,7 @@
 .. _`nRF Connect SDK v0.3.0 documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/0.3.0/nrf/index.html
 .. _`nRF Connect SDK latest documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/index.html
 
-.. _`known issues page on the master branch`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html
+.. _`known issues page on the main branch`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html
 .. _`known issues for nRF Connect SDK v1.7.0`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html?v=v1-7-0
 .. _`known issues for nRF Connect SDK v1.6.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html?v=v1-6-1
 .. _`known issues for nRF Connect SDK v1.6.0`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html?v=v1-6-0

--- a/doc/nrf/release_notes.rst
+++ b/doc/nrf/release_notes.rst
@@ -5,14 +5,14 @@ Release notes
 
 See the release notes for information about specific |NCS| releases.
 
-Known issues for each release are listed on the `known issues page on the master branch`_.
+Known issues for each release are listed on the `known issues page on the main branch`_.
 This page is included only in the latest documentation, because it might contain issues that are discovered after a release is tagged.
 
 .. note::
-   A "99" at the end of the version number of this documentation indicates continuous updates on the master branch since the previous major.minor release.
+   A "99" at the end of the version number of this documentation indicates continuous updates on the main branch since the previous major.minor release.
    When looking at this latest documentation, be aware of the following aspects:
 
-   * Changes between releases are tracked on the :ref:`ncs_release_notes_changelog` page, but the master branch might contain additional changes that are not listed on that page.
+   * Changes between releases are tracked on the :ref:`ncs_release_notes_changelog` page, but the main branch might contain additional changes that are not listed on that page.
    * The release note pages that are available in the latest documentation might differ slightly from the release notes that were included in the respective |NCS| release at its release date.
      Therefore, to see the official version of the release notes for a specific |NCS| release, switch to the documentation for the corresponding |NCS| version using the selector in the upper left-hand corner.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -7,7 +7,7 @@ Changelog for |NCS| v1.7.99
    :local:
    :depth: 2
 
-The most relevant changes that are present on the master branch of the |NCS|, as compared to the latest official release, are tracked in this file.
+The most relevant changes that are present on the main branch of the |NCS|, as compared to the latest official release, are tracked in this file.
 
 .. note::
    This file is a work in progress and might not cover all relevant changes.
@@ -342,7 +342,7 @@ For a complete list of |NCS| specific commits, run:
 
    git log --oneline manifest-rev ^14f09a3b00
 
-The current |NCS| master branch is based on the Zephyr v2.7 development branch.
+The current |NCS| main branch is based on the Zephyr v2.7 development branch.
 
 Matter (Project CHIP)
 =====================

--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 3561c830a4cad2736113123bf17a9f5c14fd112f
+      revision: 8c79698bd1d6362b4c779a1f646a1a3e99a1ea00
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Remove any references to the master branch now that it will be renamed
to main. This mostly affects scripting and documentation.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>