### PR TITLE
event_manager: Optimize memory usage

### DIFF
--- a/subsys/event_manager/event_manager_priv.h
+++ b/subsys/event_manager/event_manager_priv.h
@@ -192,9 +192,9 @@ extern "C" {
 
 /* Declarations and definitions - for more details refer to public API. */
 #define _EVENT_INFO_DEFINE(ename, types, labels, profile_func)							\
-	const static char *_CONCAT(ename, _log_arg_labels[]) __used = _ARG_LABELS_DEFINE(labels);		\
-	const static enum profiler_arg _CONCAT(ename, _log_arg_types[]) __used = _ARG_TYPES_DEFINE(types);	\
-	const static struct event_info _CONCAT(ename, _info) __used _EM_FORCED_ALIGNMENT			\
+	const static char *_CONCAT(ename, _log_arg_labels[]) = _ARG_LABELS_DEFINE(labels);			\
+	const static enum profiler_arg _CONCAT(ename, _log_arg_types[]) = _ARG_TYPES_DEFINE(types);		\
+	const static struct event_info _CONCAT(ename, _info) _EM_FORCED_ALIGNMENT				\
 	__attribute__((__section__("event_infos"))) = {								\
 				.profile_fn	= profile_func,							\
 				.log_arg_cnt	= ARRAY_SIZE(_CONCAT(ename, _log_arg_labels)),			\
@@ -246,8 +246,9 @@ extern "C" {
 			[_SUBS_PRIO_FINAL]	= _EVENT_SUBSCRIBERS_STOP(ename, _SUBS_PRIO_ID(_SUBS_PRIO_FINAL)),	\
 		},													\
 		.init_log_enable		= init_log_en,								\
-		.log_event			= log_fn,								\
-		.ev_info			= ev_info_struct,							\
+		.log_event			= (IS_ENABLED(CONFIG_LOG) ? (log_fn) : (NULL)),				\
+		.ev_info			= (IS_ENABLED(CONFIG_EVENT_MANAGER_PROFILER_ENABLED) ?			\
+							    (ev_info_struct) : (NULL)),					\
 	}
 
 


### PR DESCRIPTION
Change allows optimizing out log_event function and ev_info struct if they are not used.

Jira: NCSDK-12091