### PR TITLE
net: lib: nrf_cloud: fix P-GPS error handling

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -233,13 +233,20 @@ Libraries for networking
   * Changed REST API for A-GPS to use GNSS interface structure instead of GPS driver structure.
     Also changed from GPS driver ``GPS_AGPS_`` request types to ``NRF_CLOUD_AGPS_`` request types.
   * Added function :c:func:`nrf_cloud_jwt_generate` that generates a JWT using the :ref:`lib_nrf_cloud` library's configured values.
-  * Fixed an issue with :kconfig:`CONFIG_NRF_CLOUD_PGPS_TRANSPORT_NONE` to ensure predictions are properly stored.
-  * Added :c:func:`nrf_cloud_pgps_request_reset` so P-GPS application request handler can indicate failure to process the request.
-    This ensures the P-GPS library tries the request again.
 
 * :ref:`lib_nrf_cloud_agps` library:
 
   * Removed GNSS socket API support.
+
+* :ref:`lib_nrf_cloud_pgps` library:
+
+  * Fixed an issue with :kconfig:`CONFIG_NRF_CLOUD_PGPS_TRANSPORT_NONE` to ensure predictions are properly stored.
+  * Fixed error handling associated with :kconfig:`CONFIG_NRF_CLOUD_PGPS_TRANSPORT_NONE`.
+  * Added :c:func:`nrf_cloud_pgps_request_reset` so P-GPS application request handler can indicate failure to process the request.
+    This ensures the P-GPS library tries the request again.
+  * Added :kconfig:`CONFIG_NRF_CLOUD_PGPS_SOCKET_RETRIES`.
+  * Changed :c:func:`nrf_cloud_pgps_init` to limit allowable :kconfig:`CONFIG_NRF_CLOUD_PGPS_NUM_PREDICTIONS` to an even number,
+    and limited :kconfig:`CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD` to this value minus 2.
 
 * :ref:`lib_rest_client` library:
 

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
@@ -33,22 +33,23 @@ config NRF_CLOUD_PGPS_PREDICTION_PERIOD
 
 config NRF_CLOUD_PGPS_NUM_PREDICTIONS
 	int "Desired number of predictions."
-	range 1 84
+	range 2 84
 	default 42
 	help
 	  This value, together with the prediction period, determines the
 	  overall timespan that the GPS predictions will cover. The
-	  default values allows for one week of predictions.
+	  default values allows for one week of predictions. Odd numbers
+	  are not allowed.
 
 config NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD
 	int "Number of predictions remaining before fetching more."
-	range 0 84
+	range 0 82
 	default 0
 	help
 	  When set to 0, no attempt will be made to update the prediction
 	  set from the cloud until all predictions have expired. When set
 	  to an even number less than or equal to
-	  NRF_CLOUD_PGPS_NUM_PREDICTIONS, any expired predictions will be
+	  NRF_CLOUD_PGPS_NUM_PREDICTIONS - 2, any expired predictions will be
 	  replaced with predictions following the last remaining valid
 	  prediction. Odd numbers are not allowed.
 
@@ -81,5 +82,11 @@ config NRF_CLOUD_PGPS_TRANSPORT_MQTT
 	  data and receive responses.
 
 endchoice # NRF_CLOUD_PGPS_TRANSPORT
+
+config NRF_CLOUD_PGPS_SOCKET_RETRIES
+	int "Number of times to retry a P-GPS download"
+	default 2
+	help
+	  This sets the maximum number of times to retry a download.
 
 endif # NRF_CLOUD_PGPS

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -40,6 +40,13 @@ LOG_MODULE_REGISTER(nrf_cloud_pgps, CONFIG_NRF_CLOUD_GPS_LOG_LEVEL);
 #define LOCATION_UNC_SEMIMINOR_K	89U
 #define LOCATION_CONFIDENCE_PERCENT	68U
 
+BUILD_ASSERT(((NUM_PREDICTIONS & 1) == 0),
+	 "NUM_PREDICTIONS must be even");
+BUILD_ASSERT(((REPLACEMENT_THRESHOLD & 1) == 0),
+	 "REPLACEMENT_THRESHOLD must be even");
+BUILD_ASSERT((NUM_PREDICTIONS != REPLACEMENT_THRESHOLD),
+	 "NUM_PREDICTIONS and REPLACEMENT_THRESHOLD cannot be equal");
+
 enum pgps_state {
 	PGPS_NONE,
 	PGPS_INITIALIZING,
@@ -473,10 +480,11 @@ static void print_time_details(const char *info,
 {
 	uint32_t tow = (day % DAYS_PER_WEEK) * SEC_PER_DAY + time_of_day;
 
-	LOG_INF("%s GPS sec:%llu, day:%u, time of day:%u, week:%lu, "
-		"day of week:%lu, time of week:%u, toe:%u",
-		info ? info : "", sec, day, time_of_day,
-		day / DAYS_PER_WEEK, day % DAYS_PER_WEEK, tow, tow / 16);
+	LOG_INF("%s GPS sec:%u, day:%u, time of day:%u, week:%u, "
+		"day of week:%u, time of week:%u, toe:%u",
+		info ? info : "", (uint32_t)sec, day, time_of_day,
+		(uint32_t)(day / DAYS_PER_WEEK), (uint32_t)(day % DAYS_PER_WEEK),
+		tow, tow / 16);
 }
 
 int nrf_cloud_pgps_find_prediction(struct nrf_cloud_pgps_prediction **prediction)
@@ -527,6 +535,9 @@ int nrf_cloud_pgps_find_prediction(struct nrf_cloud_pgps_prediction **prediction
 			LOG_WRN("Predictions not loaded yet");
 			return -ELOADING;
 		}
+		index.cur_pnum = 0xff;
+		state = PGPS_EXPIRED;
+		pgps_need_assistance = false; /* make sure we request it */
 		LOG_WRN("No data stored");
 		return -ENODATA;
 	}
@@ -582,7 +593,10 @@ int nrf_cloud_pgps_find_prediction(struct nrf_cloud_pgps_prediction **prediction
 
 bool nrf_cloud_pgps_loading(void)
 {
-	return ((state == PGPS_REQUESTING) || (state == PGPS_LOADING));
+	LOG_DBG("Checking state:%d", state);
+	return ((state == PGPS_REQUEST_NEEDED) ||
+		(state == PGPS_REQUESTING) ||
+		(state == PGPS_LOADING));
 }
 
 #if defined(CONFIG_NRF_CLOUD_MQTT)
@@ -615,6 +629,7 @@ static int pgps_request(const struct gps_pgps_request *request)
 	}
 
 	if (nrf_cloud_pgps_loading()) {
+		LOG_DBG("Already loading; skipping request");
 		return 0;
 	}
 
@@ -765,6 +780,9 @@ int nrf_cloud_pgps_preemptive_updates(void)
 	if (state == PGPS_NONE) {
 		LOG_ERR("P-GPS subsystem is not initialized.");
 		return -EINVAL;
+	} else if (nrf_cloud_pgps_loading()) {
+		LOG_DBG("Still loading; no need to preemptively update");
+		return 0;
 	}
 
 	if (current == 0xff) {
@@ -1443,8 +1461,6 @@ int nrf_cloud_pgps_init(struct nrf_cloud_pgps_init_param *param)
 		.type = PGPS_EVT_INIT,
 	};
 
-	__ASSERT(((REPLACEMENT_THRESHOLD & 1) == 0),
-		 "REPLACEMENT_THRESHOLD must be even");
 	__ASSERT(param != NULL, "param must be provided");
 	__ASSERT(param->storage_base != 0, "storage must be provided");
 	__ASSERT((param->storage_size >= (NUM_BLOCKS * BLOCK_SIZE)),
@@ -1551,6 +1567,8 @@ int nrf_cloud_pgps_init(struct nrf_cloud_pgps_init_param *param)
 
 		if (IS_ENABLED(CONFIG_NRF_CLOUD_PGPS_REQUEST_ALL_UPON_INIT)) {
 			err = pgps_request_all();
+		} else {
+			err = 0;
 		}
 	} else if (num_valid < count) {
 		/* read missing predictions at end */

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
@@ -21,6 +21,7 @@
 
 LOG_MODULE_DECLARE(nrf_cloud_pgps, CONFIG_NRF_CLOUD_GPS_LOG_LEVEL);
 
+#define SOCKET_RETRIES				CONFIG_NRF_CLOUD_PGPS_SOCKET_RETRIES
 #define SETTINGS_NAME				"nrf_cloud_pgps"
 #define SETTINGS_KEY_PGPS_HEADER		"pgps_header"
 #define SETTINGS_FULL_PGPS_HEADER		SETTINGS_NAME "/" SETTINGS_KEY_PGPS_HEADER
@@ -453,7 +454,7 @@ int npgps_download_start(const char *host, const char *file, int sec_tag,
 	}
 	LOG_DBG("pgps_active LOCKED");
 
-	socket_retries_left = CONFIG_FOTA_SOCKET_RETRIES;
+	socket_retries_left = SOCKET_RETRIES;
 
 	struct download_client_cfg config = {
 		.sec_tag = sec_tag,
@@ -518,10 +519,12 @@ static int download_client_callback(const struct download_client_evt *event)
 		return 0;
 	}
 
-	err = download_client_disconnect(&dlc);
-	if (err) {
+	int ret = download_client_disconnect(&dlc);
+
+	if (ret) {
 		LOG_ERR("Error disconnecting from "
-			"download client:%d", err);
+			"download client:%d", ret);
+		err = ret;
 	}
 	k_sem_give(&pgps_active);
 	LOG_DBG("pgps_active UNLOCKED");


### PR DESCRIPTION
Return 0 from nrf_cloud_pgps_init() if there are no valid predictions stored and CONFIG_NRF_CLOUD_PGPS_REQUEST_ALL_UPON_INIT is false.

If process_buffer() rejects some P-GPS data, make sure error code returned from that is also returned from download_client_callback() so the downloads stop with the correct error message ("fragment refused, download stopped").

Fix state checks for loading when using REST.

Enforce NUM_PREDICTIONS != REPLACEMENT_THRESHOLD and even numbers of predictions. Storage must be done two predictions at a time.

Also fix one more location was was using %llu for GPS seconds.

Update release notes.

Jira: NCSDK-12101