### PR TITLE
lib: edge_impulse: Allow relative path

### DIFF
--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -24,7 +24,8 @@ set(EI_URI ${CONFIG_EDGE_IMPULSE_URI})
 
 if(NOT ${EI_URI} MATCHES "^[a-z]+://")
   if(NOT IS_ABSOLUTE ${EI_URI})
-    message(FATAL_ERROR "CONFIG_EDGE_IMPULSE_URI cannot be a relative path")
+    # Using application source directory as base directory for relative path.
+    set(EI_URI ${APPLICATION_SOURCE_DIR}/${EI_URI})
   endif()
 endif()
 


### PR DESCRIPTION
Change allows using relative path for Edge Impulse URI. Application source directory is used as base directory for the relative path.

Jira: NCSDK-7344