### PR TITLE
tfm: update read ranges for secure read service

### DIFF
--- a/include/tfm/tfm_read_ranges.h
+++ b/include/tfm/tfm_read_ranges.h
@@ -10,9 +10,19 @@
 #include <tfm_ioctl_api.h>
 #include <pm_config.h>
 
+#include "nrf.h"
+
 #define FICR_BASE               NRF_FICR_S_BASE
-#define FICR_PUBLIC_ADDR        (FICR_BASE + 0x204)
-#define FICR_PUBLIC_SIZE        0xA1C
+
+#define FICR_INFO_ADDR          (FICR_BASE + offsetof(NRF_FICR_Type, INFO))
+#define FICR_INFO_SIZE          (sizeof(FICR_INFO_Type))
+
+#if defined(FICR_NFC_TAGHEADER0_MFGID_Msk)
+#define FICR_NFC_ADDR           (FICR_BASE + offsetof(NRF_FICR_Type, NFC))
+#define FICR_NFC_SIZE           (sizeof(FICR_NFC_Type))
+#endif
+
+/* Used by nrf_erratas.h */
 #define FICR_RESTRICTED_ADDR    (FICR_BASE + 0x130)
 #define FICR_RESTRICTED_SIZE    0x8
 
@@ -22,8 +32,12 @@ static const struct tfm_read_service_range ranges[] = {
 	{.start = PM_MCUBOOT_PAD_ADDRESS,
 		.size = PM_MCUBOOT_PAD_SIZE},
 #endif
-	{.start = FICR_PUBLIC_ADDR,
-		.size = FICR_PUBLIC_SIZE},
+	{.start = FICR_INFO_ADDR,
+		.size = FICR_INFO_SIZE},
+#if defined(FICR_NFC_TAGHEADER0_MFGID_Msk)
+	{.start = FICR_NFC_ADDR,
+		.size = FICR_NFC_SIZE},
+#endif
 	{.start = FICR_RESTRICTED_ADDR,
 		.size = FICR_RESTRICTED_SIZE},
 };

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -56,8 +56,16 @@ int spm_secure_services_init(void)
 #ifdef CONFIG_SPM_SERVICE_READ
 
 #define FICR_BASE               NRF_FICR_S_BASE
-#define FICR_PUBLIC_ADDR        (FICR_BASE + 0x204)
-#define FICR_PUBLIC_SIZE        0xA1C
+
+#define FICR_INFO_ADDR          (FICR_BASE + offsetof(NRF_FICR_Type, INFO))
+#define FICR_INFO_SIZE          (sizeof(FICR_INFO_Type))
+
+#if defined(FICR_NFC_TAGHEADER0_MFGID_Msk)
+#define FICR_NFC_ADDR           (FICR_BASE + offsetof(NRF_FICR_Type, NFC))
+#define FICR_NFC_SIZE           (sizeof(FICR_NFC_Type))
+#endif
+
+/* Used by nrf_erratas.h */
 #define FICR_RESTRICTED_ADDR    (FICR_BASE + 0x130)
 #define FICR_RESTRICTED_SIZE    0x8
 
@@ -71,13 +79,18 @@ __TZ_NONSECURE_ENTRY_FUNC
 int spm_request_read_nse(void *destination, uint32_t addr, size_t len)
 {
 	static const struct read_range ranges[] = {
+
 #ifdef PM_MCUBOOT_ADDRESS
 		/* Allow reads of mcuboot metadata */
 		{.start = PM_MCUBOOT_PAD_ADDRESS,
 		 .size = PM_MCUBOOT_PAD_SIZE},
 #endif
-		{.start = FICR_PUBLIC_ADDR,
-		 .size = FICR_PUBLIC_SIZE},
+		{.start = FICR_INFO_ADDR,
+		 .size = FICR_INFO_SIZE},
+#if defined(FICR_NFC_TAGHEADER0_MFGID_Msk)
+		{.start = FICR_NFC_ADDR,
+		 .size = FICR_NFC_SIZE},
+#endif
 		{.start = FICR_RESTRICTED_ADDR,
 		 .size = FICR_RESTRICTED_SIZE},
 	};

--- a/tests/modules/tfm/secure_services/src/main.c
+++ b/tests/modules/tfm/secure_services/src/main.c
@@ -25,8 +25,8 @@ static bool is_secure(intptr_t ptr)
 
 void test_tfm_read_service(void)
 {
-	const uint32_t ficr_start = (NRF_FICR_S_BASE + 0x204);
-	const uint32_t ficr_end = ficr_start + 0xA1C;
+	const uint32_t ficr_info_start = NRF_FICR_S_BASE + offsetof(NRF_FICR_Type, INFO);
+	const uint32_t ficr_info_end   = ficr_info_start + sizeof(FICR_INFO_Type);
 
 	uint8_t output[4];
 	uint8_t data_length = sizeof(output);
@@ -44,31 +44,57 @@ void test_tfm_read_service(void)
 						"Test object is not secure");
 
 	/* Verify that the function fails if it is passed secure pointers */
-	plt_err = tfm_platform_mem_read(secure_ptr, ficr_start, data_length, &err);
+	plt_err = tfm_platform_mem_read(secure_ptr, ficr_info_start, data_length, &err);
 	zassert_equal(plt_err, TFM_PLATFORM_ERR_INVALID_PARAM,
 						"Did not fail for secure pointer");
 	zassert_equal(err, -1, "Did not fail for secure pointer");
 
-	/* Verify that edge addresses in FICR will return expected values */
+	/* Verify that edge addresses in FICR INFO will return expected values */
 	/* Normal execution */
-	plt_err = tfm_platform_mem_read(output, ficr_start, data_length, &err);
+	plt_err = tfm_platform_mem_read(output, ficr_info_start, data_length, &err);
 	zassert_equal(plt_err, TFM_PLATFORM_ERR_SUCCESS, "Valid address returned an error!");
 	zassert_equal(err, 0, "Valid address returned an error!");
 
-	plt_err = tfm_platform_mem_read(output, ficr_end - data_length, data_length, &err);
+	plt_err = tfm_platform_mem_read(output, ficr_info_end - data_length, data_length, &err);
 	zassert_equal(plt_err, TFM_PLATFORM_ERR_SUCCESS, "Valid address returned an error!");
 	zassert_equal(err, 0, "Valid address returned an error!");
 
 	/* Expect invalid addresses to finish with result -1 */
-	plt_err = tfm_platform_mem_read(output, ficr_start - 1, data_length, &err);
+	plt_err = tfm_platform_mem_read(output, ficr_info_start - 1, data_length, &err);
 	zassert_equal(plt_err, TFM_PLATFORM_ERR_INVALID_PARAM,
 							"Invalid address returned an unexpected error");
 	zassert_equal(err, -1, "Invalid address did not return expected address");
 
-	plt_err = tfm_platform_mem_read(output, ficr_end - data_length + 1, data_length, &err);
+	plt_err = tfm_platform_mem_read(output, ficr_info_end - data_length + 1, data_length, &err);
 	zassert_equal(plt_err, TFM_PLATFORM_ERR_INVALID_PARAM,
 							"Invalid address returned an unexpected error");
 	zassert_equal(err, -1, "Invalid address did not return expected address");
+
+#if defined(FICR_NFC_TAGHEADER0_MFGID_Msk)
+	const uint32_t ficr_nfc_start  = NRF_FICR_S_BASE + offsetof(NRF_FICR_Type, NFC);
+	const uint32_t ficr_nfc_end    = ficr_nfc_start + sizeof(FICR_NFC_Type);
+
+	/* Verify that edge addresses in FICR NFC will return expected values */
+	/* Normal execution */
+	plt_err = tfm_platform_mem_read(output, ficr_nfc_start, data_length, &err);
+	zassert_equal(plt_err, TFM_PLATFORM_ERR_SUCCESS, "Valid address returned an error!");
+	zassert_equal(err, 0, "Valid address returned an error!");
+
+	plt_err = tfm_platform_mem_read(output, ficr_nfc_end - data_length, data_length, &err);
+	zassert_equal(plt_err, TFM_PLATFORM_ERR_SUCCESS, "Valid address returned an error!");
+	zassert_equal(err, 0, "Valid address returned an error!");
+
+	/* Expect invalid addresses to finish with result -1 */
+	plt_err = tfm_platform_mem_read(output, ficr_nfc_start - 1, data_length, &err);
+	zassert_equal(plt_err, TFM_PLATFORM_ERR_INVALID_PARAM,
+							"Invalid address returned an unexpected error");
+	zassert_equal(err, -1, "Invalid address did not return expected address");
+
+	plt_err = tfm_platform_mem_read(output, ficr_nfc_end - data_length + 1, data_length, &err);
+	zassert_equal(plt_err, TFM_PLATFORM_ERR_INVALID_PARAM,
+							"Invalid address returned an unexpected error");
+	zassert_equal(err, -1, "Invalid address did not return expected address");
+#endif /* defined(FICR_NFC_TAGHEADER0_MFGID_Msk) */
 }
 
 void test_main(void)


### PR DESCRIPTION
Update read ranges for the secure read service to include the FICR INFO
and NFC range.
This fixes INFO.CONFIGID (FICR + 0x200) not being readable on nrf53.

NCSDK-11047