### PR TITLE
doc: relnotes: Remove a statement from the 1.7 release notes

### DIFF
--- a/doc/nrf/releases/release-notes-1.7.0.rst
+++ b/doc/nrf/releases/release-notes-1.7.0.rst
@@ -442,8 +442,6 @@ For a complete list of |NCS| specific commits, run:
 
    git log --oneline manifest-rev ^14f09a3b00
 
-The current |NCS| master branch is based on the Zephyr v2.7 development branch.
-
 Matter (Project CHIP)
 =====================
 


### PR DESCRIPTION
Remove this sentence from the release notes because:

1. "current" is meaningless in the context of a release and its release
   notes
2. "v2.7 development branch" is not a term that Zephyr upstream uses
3. The sentence did not add useful information for the user

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>