### PR TITLE
doc: requirements: relax allowed versions

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -5,7 +5,7 @@ sphinx-ncs-theme>=0.6.4
 pygments>=2.7.0
 m2r2
 sphinxcontrib-plantuml
-pygit2~=1.5
-pyyaml~=5.4
-azure-storage-blob~=12.8
+pygit2
+pyyaml
+azure-storage-blob
 sphinx_markdown_tables


### PR DESCRIPTION
Relax the allowed versions for dependencies that are not used
extensively. This allows other packages that have stronger requirements
on these dependencies to evolve without docs interfering.