### PR TITLE
manifest: Update Zephyr for HTTP POSIX

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 20ac60fb967003e1eb3f6d296721d076c814982a
+      revision: 15be5e615498377e9326cb2eb5819c7c62005299
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updating Zephyr to get POSIX support for HTTP client.
