### PR TITLE
drivers: sensor: Align used trigger handlers to API changes

### DIFF
--- a/applications/asset_tracker/src/motion/motion.c
+++ b/applications/asset_tracker/src/motion/motion.c
@@ -96,7 +96,7 @@ static int get_orientation(motion_orientation_state_t *orientation,
 
 /**@brief Callback for sensor trigger events */
 static void sensor_trigger_handler(const struct device *dev,
-			struct sensor_trigger *trigger)
+				   const struct sensor_trigger *trigger)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(trigger);

--- a/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.c
+++ b/applications/asset_tracker_v2/src/ext_sensors/ext_sensors.c
@@ -56,7 +56,7 @@ static ext_sensor_handler_t evt_handler;
 static bool initial_trigger;
 
 static void accelerometer_trigger_handler(const struct device *dev,
-					  struct sensor_trigger *trig)
+					  const struct sensor_trigger *trig)
 {
 	int err = 0;
 	struct sensor_value data[ACCELEROMETER_CHANNELS];

--- a/applications/nrf_desktop/src/hw_interface/motion_sensor.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_sensor.c
@@ -181,7 +181,7 @@ static int disable_trigger(void)
 	return err;
 }
 
-static void data_ready_handler(const struct device *dev, struct sensor_trigger *trig)
+static void data_ready_handler(const struct device *dev, const struct sensor_trigger *trig)
 {
 	k_spinlock_key_t key = k_spin_lock(&state.lock);
 

--- a/applications/nrf_desktop/src/hw_interface/wheel.c
+++ b/applications/nrf_desktop/src/hw_interface/wheel.c
@@ -56,7 +56,7 @@ static enum state state;
 static int enable_qdec(enum state next_state);
 
 
-static void data_ready_handler(const struct device *dev, struct sensor_trigger *trig)
+static void data_ready_handler(const struct device *dev, const struct sensor_trigger *trig)
 {
 	if (IS_ENABLED(CONFIG_ASSERT)) {
 		k_spinlock_key_t key = k_spin_lock(&lock);

--- a/samples/sensor/bh1749/src/main.c
+++ b/samples/sensor/bh1749/src/main.c
@@ -18,7 +18,7 @@
 static K_SEM_DEFINE(sem, 0, 1);
 
 static void trigger_handler(const struct device *dev,
-			    struct sensor_trigger *trigger)
+			    const struct sensor_trigger *trigger)
 {
 	ARG_UNUSED(dev);
 	switch (trigger->type) {

--- a/subsys/caf/modules/sensor_sampler.c
+++ b/subsys/caf/modules/sensor_sampler.c
@@ -165,7 +165,7 @@ static bool can_sensor_sleep(const struct sensor_config *sc,
 	return false;
 }
 
-static void trigger_handler(const struct device *dev, struct sensor_trigger *trigger)
+static void trigger_handler(const struct device *dev, const struct sensor_trigger *trigger)
 {
 	sensor_trigger_set(dev, trigger, NULL);
 


### PR DESCRIPTION
This commit aligns our usage of the sensor API
to match changes i Zephyr.

Jira: NCSDK-11602