### PR TITLE
applications: asset_tracker_v2: Send neighbor cell data to nRF Cloud

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/Kconfig
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/Kconfig
@@ -18,6 +18,10 @@ choice
 
 config CLOUD_CODEC_NRF_CLOUD
 	bool "Enable nRF Cloud codec backend"
+	select NRF_CLOUD_CELL_POS
+	help
+	  The nRF Cloud codec backend uses the nRF Cloud cell position library to
+	  generate a JSON cell position request based on neighbor cell measurements.
 
 config CLOUD_CODEC_AWS_IOT
 	bool "Enable AWS IoT codec backend"

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/json_protocol_names_nrf_cloud.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/json_protocol_names_nrf_cloud.h
@@ -40,6 +40,7 @@
 #define APP_ID_HUMIDITY	   "HUMID"
 #define APP_ID_TEMPERATURE "TEMP"
 #define APP_ID_RSRP	   "RSRP"
+#define APP_ID_CELL_POS    "CELL_POS"
 
 #define MODEM_CURRENT_BAND     "currentBand"
 #define MODEM_NETWORK_MODE     "networkMode"
@@ -53,16 +54,17 @@
 #define MODEM_CELL_ID	       "cellID"
 #define MODEM_IP_ADDRESS       "ipAddress"
 
+#define DATA_NEIGHBOR_CELLS_LTE           "lte"
 #define DATA_NEIGHBOR_CELLS_MCC		  "mcc"
 #define DATA_NEIGHBOR_CELLS_MNC		  "mnc"
-#define DATA_NEIGHBOR_CELLS_CID		  "cell"
-#define DATA_NEIGHBOR_CELLS_TAC		  "area"
+#define DATA_NEIGHBOR_CELLS_CID		  "eci"
+#define DATA_NEIGHBOR_CELLS_TAC		  "tac"
 #define DATA_NEIGHBOR_CELLS_EARFCN	  "earfcn"
 #define DATA_NEIGHBOR_CELLS_TIMING	  "adv"
 #define DATA_NEIGHBOR_CELLS_RSRP	  "rsrp"
 #define DATA_NEIGHBOR_CELLS_RSRQ	  "rsrq"
 #define DATA_NEIGHBOR_CELLS_NEIGHBOR_MEAS "nmr"
-#define DATA_NEIGHBOR_CELLS_PCI		  "cell"
+#define DATA_NEIGHBOR_CELLS_PCI		  "pci"
 
 #define CONFIG_DEVICE_MODE		  "activeMode"
 #define CONFIG_ACTIVE_TIMEOUT		  "activeWaitTime"

--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -339,8 +339,21 @@ int cloud_wrap_ui_send(char *buf, size_t len)
 
 int cloud_wrap_neighbor_cells_send(char *buf, size_t len)
 {
-	/* Not supported */
-	return -ENOTSUP;
+	int err;
+	struct nrf_cloud_tx_data msg = {
+		.data.ptr = buf,
+		.data.len = len,
+		.qos = MQTT_QOS_0_AT_MOST_ONCE,
+		.topic_type = NRF_CLOUD_TOPIC_MESSAGE,
+	};
+
+	err = nrf_cloud_send(&msg);
+	if (err) {
+		LOG_ERR("nrf_cloud_send, error: %d", err);
+		return err;
+	}
+
+	return 0;
 }
 
 int cloud_wrap_agps_request_send(char *buf, size_t len)

--- a/applications/asset_tracker_v2/src/modules/Kconfig.app_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.app_module
@@ -12,7 +12,7 @@ config APP_REQUEST_GPS_ON_INITIAL_SAMPLING
 
 config APP_REQUEST_NEIGHBOR_CELLS_DATA
 	bool "Request neighbor cells data"
-	depends on AWS_IOT
+	depends on AWS_IOT || NRF_CLOUD_MQTT
 	default y
 	help
 	  Include LTE neighbor cell measurement data in regular sampling requests.

--- a/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
@@ -28,6 +28,13 @@ config MODEM_AUTO_REQUEST_POWER_SAVING_FEATURES
 	bool "Auto request power saving features"
 	default y
 
+config MODEM_CONVERT_RSRP_AND_RSPQ_TO_DB
+	bool "Convert RSRP and RSRQ values to dBm and dB, respectively"
+	default y if AWS_IOT || AZURE_IOT_HUB
+	help
+	  If this option is enabled, RSRP and RSRQ values are converted to dBm and dB before being
+	  sent out by the module.
+
 endif # MODEM_MODULE
 
 module = MODEM_MODULE

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -48,11 +48,12 @@ Applications
 
 This section provides detailed lists of changes by :ref:`application <applications>`.
 
-nRF9160: Asset Tracker
-----------------------
+nRF9160: Asset Tracker v2
+-------------------------
 
 * Updated the application to start sending batch messages to the new bulk endpoint topic supported in nRF Cloud.
 * Updated the application to use nRF Cloud A-GPS directly without the A-GPS library. SUPL is no longer supported.
+* Updated the application to start sending neighbor cell measurement data to nRF Cloud.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------

--- a/include/net/nrf_cloud_cell_pos.h
+++ b/include/net/nrf_cloud_cell_pos.h
@@ -13,6 +13,7 @@
 
 #include <zephyr.h>
 #include <modem/lte_lc.h>
+#include <cJSON.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,6 +69,19 @@ struct nrf_cloud_cell_pos_result {
 int nrf_cloud_cell_pos_request(const struct lte_lc_cells_info * const cells_inf,
 			       const bool request_loc);
 #endif /* CONFIG_NRF_CLOUD_MQTT */
+
+/**@brief Get the reference to a cJSON object containing a cell position request.
+ *
+ * @param cells_inf Pointer to cell info.
+ * @param request_loc If true, cloud will send location to the device.
+ *                    If false, cloud will not send location to the device.
+ * @param req_obj_out Pointer used to get the reference to the generated cJSON object.
+ *
+ * @retval 0 If successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int nrf_cloud_cell_pos_request_json_get(const struct lte_lc_cells_info *const cells_inf,
+					const bool request_loc, cJSON **req_obj_out);
 
 /**@brief Processes cellular positioning data received from nRF Cloud via MQTT or REST.
  *

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_cell_pos.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_cell_pos.c
@@ -17,19 +17,39 @@
 
 LOG_MODULE_REGISTER(nrf_cloud_cell_pos, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
+/* Forward declarations */
+int nrf_cloud_cell_pos_request_json_get(const struct lte_lc_cells_info *const cells_inf,
+					const bool request_loc, cJSON **req_obj_out);
+
 #include "nrf_cloud_codec.h"
 #if defined(CONFIG_NRF_CLOUD_MQTT)
 #include "nrf_cloud_transport.h"
 
 #define CELL_POS_JSON_CELL_LOC_KEY_DOREPLY	"doReply"
 
-int nrf_cloud_cell_pos_request(const struct lte_lc_cells_info * const cells_inf,
+int nrf_cloud_cell_pos_request(const struct lte_lc_cells_info *const cells_inf,
 			       const bool request_loc)
 {
 	int err = 0;
-	cJSON *cell_pos_req_obj = json_create_req_obj(NRF_CLOUD_JSON_APPID_VAL_CELL_POS,
+	cJSON *cell_pos_req_obj = NULL;
+
+	err = nrf_cloud_cell_pos_request_json_get(cells_inf, request_loc, &cell_pos_req_obj);
+	if (!err) {
+		err = json_send_to_cloud(cell_pos_req_obj);
+	}
+
+	cJSON_Delete(cell_pos_req_obj);
+	return err;
+}
+#endif /* CONFIG_NRF_CLOUD_MQTT */
+
+int nrf_cloud_cell_pos_request_json_get(const struct lte_lc_cells_info *const cells_inf,
+					const bool request_loc, cJSON **req_obj_out)
+{
+	int err = 0;
+	*req_obj_out = json_create_req_obj(NRF_CLOUD_JSON_APPID_VAL_CELL_POS,
 						      NRF_CLOUD_JSON_MSG_TYPE_VAL_DATA);
-	cJSON *data_obj = cJSON_AddObjectToObject(cell_pos_req_obj, NRF_CLOUD_JSON_DATA_KEY);
+	cJSON *data_obj = cJSON_AddObjectToObject(*req_obj_out, NRF_CLOUD_JSON_DATA_KEY);
 
 	if (!data_obj) {
 		err = -ENOMEM;
@@ -55,13 +75,12 @@ int nrf_cloud_cell_pos_request(const struct lte_lc_cells_info * const cells_inf,
 		goto cleanup;
 	}
 
-	err = json_send_to_cloud(cell_pos_req_obj);
+	return 0;
 
 cleanup:
-	cJSON_Delete(cell_pos_req_obj);
+	cJSON_Delete(*req_obj_out);
 	return err;
 }
-#endif /* CONFIG_NRF_CLOUD_MQTT */
 
 int nrf_cloud_cell_pos_process(const char *buf, struct nrf_cloud_cell_pos_result *result)
 {


### PR DESCRIPTION
Start sending neighbor cell data in the nRF Cloud integration. The data
is formattet according to the schema for `APP_ID` : `CELL_POS`
documented in this PR:

https://github.com/nRFCloud/application-protocols/pull/27

Closes CIA-445