### PR TITLE
applications: asset_tracker_v2: Remove unused config

### DIFF
--- a/applications/asset_tracker_v2/overlay-debug.conf
+++ b/applications/asset_tracker_v2/overlay-debug.conf
@@ -16,9 +16,6 @@
 # 4 DEBUG, maximal level set to LOG_LEVEL_DBG
 CONFIG_LOG_MAX_LEVEL=4
 
-# Increase the logging thread capacity so that the debug logs are not lost
-CONFIG_LOG_BUFFER_SIZE=1280
-
 # Module debug configurations.
 CONFIG_APPLICATION_MODULE_LOG_LEVEL_DBG=y
 CONFIG_CLOUD_MODULE_LOG_LEVEL_DBG=y


### PR DESCRIPTION
Remove `CONFIG_LOG_BUFFER_SIZE`. Since the application reverted back
to immediate logging, this config is no longer needed.