### PR TITLE
lib: lte_link_control: Move cell ID check under roaming/home reg status

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -236,16 +236,17 @@ static void at_handler(const char *response)
 			return;
 		}
 
-		/* Set the network registration status to UNKNOWN if the cell ID is parsed to
-		 * UINT32_MAX (FFFFFFFF).
-		 */
-		if (!is_cellid_valid(cell.id)) {
-			reg_status = LTE_LC_NW_REG_UNKNOWN;
-		}
-
 		if ((reg_status == LTE_LC_NW_REG_REGISTERED_HOME) ||
 		    (reg_status == LTE_LC_NW_REG_REGISTERED_ROAMING)) {
-			k_sem_give(&link);
+			/* Set the network registration status to UNKNOWN if the cell ID is parsed
+			 * to UINT32_MAX (FFFFFFFF) when the registration status is either home or
+			 * roaming.
+			 */
+			if (!is_cellid_valid(cell.id)) {
+				reg_status = LTE_LC_NW_REG_UNKNOWN;
+			} else {
+				k_sem_give(&link);
+			}
 		}
 
 		switch (reg_status) {


### PR DESCRIPTION
Check if cell ID is invalid when registered to home or roaming network.
If invalid, the `LTE_LC_NW_REG_UNKNOWN` network registration status
is propagated. This is handled internally for modem firmware versions
1.3.0 +.

Under certain circumstances, an invalid cell ID is expected. The check
was moved to ensure that the correct registration status is notified
in those cases.