### PR TITLE
Bluetooth: Mesh: Fix schedule resume on ctrl disable

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1777,14 +1777,14 @@ int bt_mesh_light_ctrl_srv_disable(struct bt_mesh_light_ctrl_srv *srv)
 {
 	atomic_clear_bit(&srv->flags, FLAG_CTRL_SRV_MANUALLY_ENABLED);
 
-	/* Restart resume timer even if the server has already been disabled: */
-	schedule_resume_timer(srv);
-
 	if (!is_enabled(srv)) {
+		/* Restart resume timer even if the server has already been disabled: */
+		schedule_resume_timer(srv);
 		return -EALREADY;
 	}
 
 	ctrl_disable(srv);
+	schedule_resume_timer(srv);
 	store(srv, FLAG_STORE_STATE);
 	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
 		bt_mesh_scene_invalidate(srv->model);


### PR DESCRIPTION
Currently if a model (like Lightness server) disable light ctrl, resume timer will not run because function ctrl_disable() is called after schedule_resume_timer() and is cancelling resume work.

This fix maintains the same sequence to call schedule_resume_timer() that can be found in the same file:
- scene_recall()
- light_ctrl_srv_start()