### PR TITLE
samples: nrf9160: lwm2m_client: Add Object ID next to Object name in docs

### DIFF
--- a/samples/nrf9160/lwm2m_client/README.rst
+++ b/samples/nrf9160/lwm2m_client/README.rst
@@ -43,51 +43,67 @@ The following LwM2M objects are implemented in this sample:
    :header-rows: 1
 
    *  - LwM2M objects
+      - Object ID
       - Thingy:91
       - nRF9160 DK
    *  - LwM2M Server
+      - 1
       - Yes
       - Yes
    *  - Device
+      - 3
       - Yes
       - Yes
    *  - Connectivity Monitoring
+      - 4
       - Yes
       - Yes
    *  - FOTA
+      - 5
       - Yes
       - Yes
    *  - Location
+      - 6
       - Yes
       - Yes
    *  - Accelerometer
+      - 3313
       - Yes
       - Simulated
    *  - Color
+      - 3335
       - Yes
       - Simulated
    *  - Temperature
+      - 3303
       - Yes
       - Simulated
    *  - Pressure
+      - 3323
       - Yes
       - Simulated
    *  - Humidity
+      - 3304
       - Yes
       - Simulated
    *  - Generic Sensor
+      - 3300
       - Yes
       - Simulated
    *  - Light Control
+      - 3311
       - Yes
       - Yes
    *  - Push Button
+      - 3347
       - Yes
       - Yes
    *  - Buzzer
+      - 3338
       - Yes
       - No
    *  - On/Off Switch
+      - 3342
       - No
       - Yes
 


### PR DESCRIPTION
It was requested to add Object ID column next to Object name in the
table of supported objects, for clarity.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>