### PR TITLE
Bluetooth: Mesh: Use fast cadence when value exceedes delta

### DIFF
--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -391,6 +391,9 @@ struct bt_mesh_sensor {
 		/** Flag indicating whether the sensor is in fast cadence mode.
 		 */
 		uint8_t fast_pub : 1;
+
+		/** Flag indicating whether the sensor cadence state has been configured. */
+		uint8_t configured : 1;
 	} state;
 };
 

--- a/subsys/bluetooth/mesh/sensor.c
+++ b/subsys/bluetooth/mesh/sensor.c
@@ -554,6 +554,14 @@ void sensor_cadence_update(struct bt_mesh_sensor *sensor,
 
 	new = sensor_cadence(&sensor->state.threshold, value);
 
+	/** Use Fast Cadence Period Divisor when publishing when the change exceeds the delta,
+	 * section 4.3.1.2.4.3, E15551 and E15886.
+	 */
+	if (new == BT_MESH_SENSOR_CADENCE_NORMAL) {
+		new = bt_mesh_sensor_delta_threshold(sensor, value) ?
+			BT_MESH_SENSOR_CADENCE_FAST : BT_MESH_SENSOR_CADENCE_NORMAL;
+	}
+
 	if (sensor->state.fast_pub != new) {
 		BT_DBG("0x%04x new cadence: %s", sensor->type->id,
 		       (new == BT_MESH_SENSOR_CADENCE_FAST) ? "fast" :


### PR DESCRIPTION
Section 4.3.1.2.4.3 of E15886 and E15551 makes Sensor server use Fast
Cadence Period Divisor to publish sensor values if the change exceeds
delta defined by Status Trigger Delta Up/Down and Type states:

The message shall be published more frequently when the value
of the measured quantity is lower than the previously published
value decremented by the value of the Status Trigger Delta Down
state (see Section 4.1.3.3) or when it is higher than the previously
published value incremented by the value of the Status Trigger Delta
Up state (see Section 4.1.3.4). When the message is to be published
more frequently, the Publish Period value is divided by the value of
the Fast Cadence Period Divisor state as described in Section 3.1.3.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>