### PR TITLE
Bluetooth: Mesh: Fix light fixture sample behavior

### DIFF
--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -43,11 +43,6 @@ Provisioning is performed using the `nRF Mesh mobile app`_.
 This mobile application is also used to configure key bindings, and publication and subscription settings of the Bluetooth mesh model instances in the sample.
 After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, you can control the LEDs on the development kit from the app.
 
-.. note::
-   The Bluetooth mesh specification recommends that a status message is published at the end of transitions.
-   This behavior is not reflected in the light sample.
-   Make sure to implement the end-of-transition publication for your application.
-
 Provisioning
 ============
 

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -84,7 +84,7 @@ The models are used for the following purposes:
   The application implements callbacks for the Light Lightness Server to control the first LED on the device using the PWM (pulse width modulation) driver.
 * The three models in the second element are the product of a single instance of the Light Lightness Control (LC) Server.
   The Light LC Server controls the Light Lightness Server in the first element, deciding on parameters such as fade time, lighting levels for different states, and inactivity timing.
-  In this sample, the Light LC Server is enabled by default on startup.
+  In this sample, the Light LC Server is enabled by default at first boot.
 
 Other nodes can control the Light Lightness Server through the Light LC Server, by sending On/Off messages to the Light LC Server or to the Generic OnOff Server in the second element.
 

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -38,11 +38,6 @@ Provisioning is performed using the `nRF Mesh mobile app`_.
 This mobile application is also used to configure key bindings, and publication and subscription settings of the Bluetooth mesh model instances in the sample.
 After provisioning and configuring the mesh models supported by the sample in the `nRF Mesh mobile app`_, you can control the dimmable LED on the development kit from the app.
 
-.. note::
-   The Bluetooth mesh specification recommends that a status message is published at the end of transitions.
-   This behavior is not reflected in the light fixture sample.
-   Make sure to implement the end-of-transition publication for your application.
-
 Provisioning
 ============
 

--- a/samples/bluetooth/mesh/light_ctrl/include/model_handler.h
+++ b/samples/bluetooth/mesh/light_ctrl/include/model_handler.h
@@ -19,6 +19,7 @@ extern "C" {
 #endif
 
 const struct bt_mesh_comp *model_handler_init(void);
+void model_handler_start(void);
 
 #ifdef __cplusplus
 }

--- a/samples/bluetooth/mesh/light_ctrl/src/main.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/main.c
@@ -40,6 +40,8 @@ static void bt_ready(int err)
 	bt_mesh_prov_enable(BT_MESH_PROV_ADV | BT_MESH_PROV_GATT);
 
 	printk("Mesh initialized\n");
+
+	model_handler_start();
 }
 
 void main(void)

--- a/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
@@ -92,8 +92,16 @@ static void periodic_led_work(struct k_work *work)
 
 	if ((l_ctx->rem_time <= l_ctx->time_per) ||
 	    (abs(l_ctx->target_lvl - l_ctx->current_lvl) <= PWM_SIZE_STEP)) {
+		struct bt_mesh_lightness_status status = {
+			.current = l_ctx->target_lvl,
+			.target = l_ctx->target_lvl,
+		};
+
 		l_ctx->current_lvl = l_ctx->target_lvl;
 		l_ctx->rem_time = 0;
+
+		bt_mesh_lightness_srv_pub(&l_ctx->lightness_srv, NULL, &status);
+
 		goto apply_and_print;
 	} else if (l_ctx->target_lvl > l_ctx->current_lvl) {
 		l_ctx->current_lvl += PWM_SIZE_STEP;

--- a/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
@@ -77,7 +77,7 @@ static void start_new_light_trans(const struct bt_mesh_lightness_set *set,
 
 	ctx->target_lvl = set->lvl;
 	ctx->time_per = (step_cnt ? time / step_cnt : 0);
-	ctx->rem_time = bt_mesh_model_transition_time(set->transition);
+	ctx->rem_time = time;
 	k_work_reschedule(&ctx->per_work, K_MSEC(delay));
 
 	printk("New light transition-> Lvl: %d, Time: %d, Delay: %d\n",
@@ -126,7 +126,7 @@ static void light_set(struct bt_mesh_lightness_srv *srv,
 	start_new_light_trans(set, l_ctx);
 	rsp->current = l_ctx->current_lvl;
 	rsp->target = l_ctx->target_lvl;
-	rsp->remaining_time = bt_mesh_model_transition_time(set->transition);
+	rsp->remaining_time = set->transition ? set->transition->time : 0;
 }
 
 static void light_get(struct bt_mesh_lightness_srv *srv,

--- a/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
@@ -176,15 +176,22 @@ static const struct bt_mesh_comp comp = {
 
 const struct bt_mesh_comp *model_handler_init(void)
 {
-	int err;
-
 	k_work_init_delayable(&attention_blink_work, attention_blink);
 	k_work_init_delayable(&my_ctx.per_work, periodic_led_work);
+
+	return &comp;
+}
+
+void model_handler_start(void)
+{
+	int err;
+
+	if (bt_mesh_is_provisioned()) {
+		return;
+	}
 
 	err = bt_mesh_light_ctrl_srv_enable(&light_ctrl_srv);
 	if (!err) {
 		printk("Successfully enabled LC server\n");
 	}
-
-	return &comp;
 }


### PR DESCRIPTION
This PR fixes 3 issues:
- End of transition publication in the light_ctrl sample. Publication at the end of a transition is not implemented in models, thus the app should do this.
- Stops enforcing the light ctrl state at boot up. This fixes Generic OnPowerUp state behavior in the sample.
- Delay is excluded from the remaining time computation.