### PR TITLE
Bluetooth: Mesh: Added nRF21540 support to samples

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -112,6 +112,7 @@ Bluetooth mesh samples
 * Added:
 
   * :ref:`bluetooth_ble_peripheral_lbs_coex` sample, demonstrating how to combine Bluetooth mesh and Bluetooth Low Energy features in a single application.
+  * Support for :ref:`zephyr:nrf21540dk_nrf52840`.
 
 * Updated:
 

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/README.rst
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/README.rst
@@ -16,7 +16,7 @@ The mesh and peripheral coexistence sample supports the following development ki
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820
+   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf21540dk_nrf52840
 
 The sample also requires a smartphone with the following apps:
 
@@ -113,6 +113,11 @@ This sample is split into the following source files:
 * :file:`main.c` used to handle initialization.
 * :file:`model_handler.c` used to handle mesh models.
 * :file:`lb_service_handler.c` used to handle the LBS interaction.
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
@@ -4,8 +4,9 @@ sample:
 tests:
   samples.bluetooth.mesh.ble_and_mesh:
     build_only: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf21540dk_nrf52840

--- a/samples/bluetooth/mesh/chat/README.rst
+++ b/samples/bluetooth/mesh/chat/README.rst
@@ -100,6 +100,11 @@ This sample is split into the following source files:
 * A file for handling the Chat Client model, :file:`chat_cli.c`.
 * A file for handling Bluetooth mesh models and communication with the :ref:`shell module <shell_api>`, :file:`model_handler.c`.
 
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
+
 Building and running
 ********************
 

--- a/samples/bluetooth/mesh/chat/sample.yaml
+++ b/samples/bluetooth/mesh/chat/sample.yaml
@@ -4,8 +4,9 @@ sample:
 tests:
   samples.bluetooth.mesh.chat:
     build_only: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf21540dk_nrf52840

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -20,7 +20,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, thingy53_nrf5340_cpuapp_and_cpuapp_ns
+   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, thingy53_nrf5340_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 
@@ -108,6 +108,11 @@ This sample is split into the following source files:
 * :file:`model_handler.c` used to handle mesh models.
 * :file:`thingy53.c` used to handle preinitialization of the :ref:`zephyr:thingy53_nrf5340` board.
   Only compiled when the sample is built for :ref:`zephyr:thingy53_nrf5340` board.
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -6,6 +6,7 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf21540dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832
@@ -14,3 +15,4 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
       - thingy53_nrf5340_cpuapp_ns
+      - nrf21540dk_nrf52840

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -16,7 +16,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832
+   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf21540dk_nrf52840
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 
@@ -124,6 +124,11 @@ This sample is split into the following source files:
 * A :file:`main.c` file to handle initialization.
 * A file for handling mesh models, :file:`model_handler.c`.
 * A file for handling PWM driven control of the dimmable LED, :file:`lc_pwm_led.c`.
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -4,8 +4,9 @@ sample:
 tests:
   samples.bluetooth.mesh.light_ctrl:
     build_only: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf21540dk_nrf52840

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -19,7 +19,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, thingy53_nrf5340_cpuapp_and_cpuapp_ns
+   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, thingy53_nrf5340_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
 
 You need at least two development kits:
 
@@ -124,6 +124,11 @@ The light switch sample is split into the following source files:
 * :file:`model_handler.c` used to handle mesh models.
 * :file:`thingy53.c` used to handle preinitialization of the :ref:`zephyr:thingy53_nrf5340` board.
   Only compiled when the sample is built for :ref:`zephyr:thingy53_nrf5340` board.
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -6,6 +6,7 @@ tests:
     build_only: true
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf21540dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832
@@ -14,3 +15,4 @@ tests:
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
       - thingy53_nrf5340_cpuapp_ns
+      - nrf21540dk_nrf52840

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -99,6 +99,10 @@ This sample is split into the following source files:
 * A :file:`main.c` file to handle initialization.
 * One additional file for handling Bluetooth mesh models, :file:`model_handler.c`.
 
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************

--- a/samples/bluetooth/mesh/sensor_client/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_client/sample.yaml
@@ -4,8 +4,9 @@ sample:
 tests:
   samples.bluetooth.mesh.sensor_client:
     build_only: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf21540dk_nrf52840

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -99,6 +99,11 @@ This sample is split into the following source files:
 * A :file:`main.c` file to handle initialization.
 * One additional file for handling Bluetooth mesh models, :file:`model_handler.c`.
 
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
+
 Building and running
 ********************
 

--- a/samples/bluetooth/mesh/sensor_server/sample.yaml
+++ b/samples/bluetooth/mesh/sensor_server/sample.yaml
@@ -4,8 +4,9 @@ sample:
 tests:
   samples.bluetooth.mesh.sensor_server:
     build_only: true
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf21540dk_nrf52840

--- a/samples/bluetooth/mesh/silvair_enocean/README.rst
+++ b/samples/bluetooth/mesh/silvair_enocean/README.rst
@@ -19,7 +19,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833
+   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf21540dk_nrf52840
 
 You need at least two development kits:
 
@@ -117,6 +117,11 @@ The Silvair EnOcean sample is split into the following source files:
 
 * A :file:`main.c` file to handle initialization.
 * One additional file for handling mesh models, :file:`model_handler.c`.
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************

--- a/samples/bluetooth/mesh/silvair_enocean/sample.yaml
+++ b/samples/bluetooth/mesh/silvair_enocean/sample.yaml
@@ -6,10 +6,11 @@ tests:
     build_only: true
     build_on_all: false
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf21540dk_nrf52840
     tags: bluetooth ci_build
     integration_platforms:
         - nrf52dk_nrf52832
         - nrf52840dk_nrf52840
         - nrf5340dk_nrf5340_cpuapp
         - nrf5340dk_nrf5340_cpuapp_ns
+        - nrf21540dk_nrf52840


### PR DESCRIPTION
Added sample support for the nRF21540 to samples.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>