### PR TITLE
applications: nrf_desktop: Force power down immediately

### DIFF
--- a/applications/nrf_desktop/doc/usb_state_pm.rst
+++ b/applications/nrf_desktop/doc/usb_state_pm.rst
@@ -27,7 +27,7 @@ Upon reception of the event and depending on the current USB state, the module r
 * If the USB state is set to :c:enum:`USB_STATE_POWERED` or :c:enum:`USB_STATE_ACTIVE`, the :c:enum:`POWER_MANAGER_LEVEL_ALIVE` is required.
 * If the USB state is set to :c:enum:`USB_STATE_DISCONNECTED`, any power level is allowed.
 * If the USB state is set to :c:enum:`USB_STATE_SUSPENDED`, the :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED` is imposed.
-  The module restricts the power down level to the :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED` and generates ``force_power_down_event`` after 1 second.
+  The module restricts the power down level to the :c:enum:`POWER_MANAGER_LEVEL_SUSPENDED` and generates ``force_power_down_event``.
 
 For more information about the USB states in nRF Desktop, see the :ref:`nrf_desktop_usb_state`.
 


### PR DESCRIPTION
According to USB specification (7.1.7.6 Suspending):

"The device must actually be suspended, drawing only suspend
current from the bus after no more than 10 ms of bus inactivity (...)"

This PR changes current 1 sec to 3 ms to reduce time the
application waits before forcing power down event.

Jira: NCSDK-12006

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>