### PR TITLE
Bluetooth: Mesh: Add a note about end of transition publication

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/mesh/model_types.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/model_types.rst
@@ -43,6 +43,20 @@ See :ref:`configure_application` for more information.
 
 The options related to each model configuration are listed in the respective documentation pages.
 
+.. _bt_mesh_models_transition:
+
+Transition
+**********
+
+States may support non-instantaneous changes.
+Such states make use of :c:struct:`bt_mesh_model_transition` to specify the time it should take a server to change a state to a new value.
+
+The transition to a new value can be postponed by the time defined in :c:member:`bt_mesh_model_transition.delay`, and the current value of a state remains unchanged until the transition starts.
+The delay should not be taken into account when calculating the remaining transition time.
+
+Server models are taking care of publishing of status messages, when receiving a state changing message, as well as sending a response back to a client, when an acknowledged message is received.
+If a state change is non-instantaneous, for example when :c:func:`bt_mesh_model_transition_time` returns a nonzero value, the application is responsible for publishing a new value of the state at the end of the transition.
+
 .. _bt_mesh_models_common_types:
 
 Common types for all models

--- a/include/bluetooth/mesh/gen_lvl_srv.h
+++ b/include/bluetooth/mesh/gen_lvl_srv.h
@@ -65,6 +65,12 @@ struct bt_mesh_lvl_srv_handlers {
 
 	/** @brief Set the level state.
 	 *
+	 * When a set message is received, the model publishes a status message, with the response
+	 * set to @c rsp. When an acknowledged set message is received, the model also sends a
+	 * response back to a client. If a state change is non-instantaneous, for example when
+	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
+	 * responsible for publishing a value of the level state at the end of the transition.
+	 *
 	 * @note This handler is mandatory.
 	 *
 	 * @param[in] srv Level server to set the state of.

--- a/include/bluetooth/mesh/gen_lvl_srv.h
+++ b/include/bluetooth/mesh/gen_lvl_srv.h
@@ -48,9 +48,9 @@ struct bt_mesh_lvl_srv;
 						 _srv),                        \
 			 &_bt_mesh_lvl_srv_cb)
 
-/** Handler functions for the generic level server. */
+/** Handler functions for the Generic Level Server. */
 struct bt_mesh_lvl_srv_handlers {
-	/** @brief Get the current level state.
+	/** @brief Get the current Level state.
 	 *
 	 * @note This handler is mandatory.
 	 *
@@ -63,13 +63,13 @@ struct bt_mesh_lvl_srv_handlers {
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct bt_mesh_lvl_status *rsp);
 
-	/** @brief Set the level state.
+	/** @brief Set the Level state.
 	 *
 	 * When a set message is received, the model publishes a status message, with the response
 	 * set to @c rsp. When an acknowledged set message is received, the model also sends a
 	 * response back to a client. If a state change is non-instantaneous, for example when
 	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
-	 * responsible for publishing a value of the level state at the end of the transition.
+	 * responsible for publishing a value of the Level state at the end of the transition.
 	 *
 	 * @note This handler is mandatory.
 	 *
@@ -86,7 +86,7 @@ struct bt_mesh_lvl_srv_handlers {
 			  struct bt_mesh_lvl_status *rsp);
 
 	/**
-	 * @brief Change the level state relative to its current value.
+	 * @brief Change the Level state relative to its current value.
 	 *
 	 * If @c delta_set::new_transaction is false, the state transition
 	 * should use the same start point as the previous delta_set message,
@@ -108,9 +108,9 @@ struct bt_mesh_lvl_srv_handlers {
 				const struct bt_mesh_lvl_delta_set *delta_set,
 				struct bt_mesh_lvl_status *rsp);
 
-	/** @brief Move the level state continuously at a given rate.
+	/** @brief Move the Level state continuously at a given rate.
 	 *
-	 * The level state should move @c move_set::delta units for every
+	 * The Level state should move @c move_set::delta units for every
 	 * @c move_set::transition::time milliseconds. For instance, if
 	 * delta is 5 and the transition time is 100ms, the state should move
 	 * at a rate of 50 per second.
@@ -156,9 +156,9 @@ struct bt_mesh_lvl_srv {
 	struct bt_mesh_tid_ctx tid;
 };
 
-/** @brief Publish the generic level state.
+/** @brief Publish the current Level state.
  *
- * @param[in] srv Server whose level state should be published.
+ * @param[in] srv Server whose Level state should be published.
  * @param[in] ctx Message context to publish with, or NULL to publish on the
  * configured publish parameters.
  * @param[in] status Current status.

--- a/include/bluetooth/mesh/gen_onoff_srv.h
+++ b/include/bluetooth/mesh/gen_onoff_srv.h
@@ -52,6 +52,12 @@ struct bt_mesh_onoff_srv;
 struct bt_mesh_onoff_srv_handlers {
 	/** @brief Set the OnOff state.
 	 *
+	 * When a set message is received, the model publishes a status message, with the response
+	 * set to @c rsp. When an acknowledged set message is received, the model also sends a
+	 * response back to a client. If a state change is non-instantaneous, for example when
+	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
+	 * responsible for publishing a value of the OnOff state at the end of the transition.
+	 *
 	 * @note This handler is mandatory.
 	 *
 	 * @param[in] srv Server instance to set the state of.

--- a/include/bluetooth/mesh/gen_plvl_srv.h
+++ b/include/bluetooth/mesh/gen_plvl_srv.h
@@ -65,6 +65,12 @@ struct bt_mesh_plvl_srv;
 struct bt_mesh_plvl_srv_handlers {
 	/** @brief Set the Power state.
 	 *
+	 * When a set message is received, the model publishes a status message, with the response
+	 * set to @c rsp. When an acknowledged set message is received, the model also sends a
+	 * response back to a client. If a state change is non-instantaneous, for example when
+	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
+	 * responsible for publishing a value of the Power state at the end of the transition.
+	 *
 	 * @note This handler is mandatory.
 	 *
 	 * @param[in] srv Server to set the Power state of.

--- a/include/bluetooth/mesh/light_hue_srv.h
+++ b/include/bluetooth/mesh/light_hue_srv.h
@@ -57,6 +57,12 @@ struct bt_mesh_light_hue_srv;
 struct bt_mesh_light_hue_srv_handlers {
 	/** @brief Set the Hue state.
 	 *
+	 * When a set message is received, the model publishes a status message, with the response
+	 * set to @c rsp. When an acknowledged set message is received, the model also sends a
+	 * response back to a client. If a state change is non-instantaneous, for example when
+	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
+	 * responsible for publishing a value of the Hue state at the end of the transition.
+	 *
 	 *  @note This handler is mandatory.
 	 *
 	 *  @param[in] srv Server to set the Hue state of.

--- a/include/bluetooth/mesh/light_sat_srv.h
+++ b/include/bluetooth/mesh/light_sat_srv.h
@@ -57,6 +57,12 @@ struct bt_mesh_light_sat_srv;
 struct bt_mesh_light_sat_srv_handlers {
 	/** @brief Set the Saturation state.
 	 *
+	 * When a set message is received, the model publishes a status message, with the response
+	 * set to @c rsp. When an acknowledged set message is received, the model also sends a
+	 * response back to a client. If a state change is non-instantaneous, for example when
+	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
+	 * responsible for publishing a value of the Saturation state at the end of the transition.
+	 *
 	 *  @note This handler is mandatory.
 	 *
 	 *  @param[in]  srv Light Saturation server.

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -59,6 +59,13 @@ struct bt_mesh_light_temp_srv;
 struct bt_mesh_light_temp_srv_handlers {
 	/** @brief Set the Light Temperature state.
 	 *
+	 * When a set message is received, the model publishes a status message, with the response
+	 * set to @c rsp. When an acknowledged set message is received, the model also sends a
+	 * response back to a client. If a state change is non-instantaneous, for example when
+	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
+	 * responsible for publishing a value of the Light Temperature state at the end of the
+	 * transition.
+	 *
 	 * @note This handler is mandatory.
 	 *
 	 * @param[in] srv Server to set the CTL Temperature state of.

--- a/include/bluetooth/mesh/light_xyl_srv.h
+++ b/include/bluetooth/mesh/light_xyl_srv.h
@@ -87,6 +87,12 @@ struct bt_mesh_light_xy_status {
 struct bt_mesh_light_xyl_srv_handlers {
 	/** @brief Set the xy state.
 	 *
+	 * When a set message is received, the model publishes a status message, with the response
+	 * set to @c rsp. When an acknowledged set message is received, the model also sends a
+	 * response back to a client. If a state change is non-instantaneous, for example when
+	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
+	 * responsible for publishing a value of the xy state at the end of the transition.
+	 *
 	 * @note This handler is mandatory.
 	 *
 	 * @param[in] srv Server to set the xy state of.

--- a/include/bluetooth/mesh/lightness_srv.h
+++ b/include/bluetooth/mesh/lightness_srv.h
@@ -66,6 +66,12 @@ struct bt_mesh_lightness_srv;
 struct bt_mesh_lightness_srv_handlers {
 	/** @brief Set the Light state.
 	 *
+	 * When a set message is received, the model publishes a status message, with the response
+	 * set to @c rsp. When an acknowledged set message is received, the model also sends a
+	 * response back to a client. If a state change is non-instantaneous, for example when
+	 * @ref bt_mesh_model_transition_time returns a nonzero value, the application is
+	 * responsible for publishing a value of the Light state at the end of the transition.
+	 *
 	 * @note This handler is mandatory.
 	 *
 	 * @param[in] srv Server to set the Light state of.

--- a/include/bluetooth/mesh/scene_srv.h
+++ b/include/bluetooth/mesh/scene_srv.h
@@ -141,7 +141,9 @@ struct bt_mesh_scene_entry {
 	 *  When a scene is recalled, the Scene Server calls this callback for
 	 *  every scene entry that has data for the recalled scene. The handler
 	 *  shall start transitioning to the given scene with the given
-	 *  transition parameters.
+	 *  transition parameters. If the transition is non-instantaneious, for example
+	 *  when @ref bt_mesh_model_transition_time returns a nonzero value, the
+	 *  handler shall publish a status message at the end of the transition.
 	 *
 	 *  @param[in] model      Model to restore the scene of.
 	 *  @param[in] data       Scene data to restore.


### PR DESCRIPTION
According to MshPRFv1.0.1, section 3.7.6.1.2, when publishing is enabled
for a model, unless specified otherwise, by a higher layer
specification, a corresponding status message shall be published
immediately after the state transition ends.

This behaviour is not implemented in the stack. The models only publish
at the start of transition. An application is responsible for publishing
a status message at the end of transition.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>