### PR TITLE
Bluetooth: Mesh: Cleaner light representation conversion

### DIFF
--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -19,13 +19,11 @@ static void ctl_encode_status(struct net_buf_simple *buf,
 			      struct bt_mesh_light_ctl_status *status)
 {
 	bt_mesh_model_msg_init(buf, BT_MESH_LIGHT_CTL_STATUS);
-	net_buf_simple_add_le16(buf,
-				light_to_repr(status->current_light, ACTUAL));
+	net_buf_simple_add_le16(buf, to_actual(status->current_light));
 	net_buf_simple_add_le16(buf, status->current_temp);
 
 	if (status->remaining_time) {
-		net_buf_simple_add_le16(buf, light_to_repr(status->target_light,
-							   ACTUAL));
+		net_buf_simple_add_le16(buf, to_actual(status->target_light));
 		net_buf_simple_add_le16(buf, status->target_temp);
 		net_buf_simple_add_u8(
 			buf, model_transition_encode(status->remaining_time));
@@ -67,7 +65,7 @@ static int ctl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_light_temp_set temp;
 	uint8_t tid;
 
-	light.lvl = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	light.lvl = from_actual(net_buf_simple_pull_le16(buf));
 	temp.params.temp = net_buf_simple_pull_le16(buf);
 	temp.params.delta_uv = net_buf_simple_pull_le16(buf);
 	tid = net_buf_simple_pull_u8(buf);
@@ -215,8 +213,7 @@ static void default_encode_status(struct net_buf_simple *buf,
 				  struct bt_mesh_light_ctl_srv *srv)
 {
 	bt_mesh_model_msg_init(buf, BT_MESH_LIGHT_CTL_DEFAULT_STATUS);
-	net_buf_simple_add_le16(
-		buf, light_to_repr(srv->lightness_srv.default_light, ACTUAL));
+	net_buf_simple_add_le16(buf, to_actual(srv->lightness_srv.default_light));
 	net_buf_simple_add_le16(buf, srv->temp_srv.dflt.temp);
 	net_buf_simple_add_le16(buf, srv->temp_srv.dflt.delta_uv);
 }
@@ -239,7 +236,7 @@ static int default_set(struct bt_mesh_model *model,
 	struct bt_mesh_light_temp temp;
 	uint16_t light;
 
-	light = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	light = from_actual(net_buf_simple_pull_le16(buf));
 	temp.temp = net_buf_simple_pull_le16(buf);
 	temp.delta_uv = net_buf_simple_pull_le16(buf);
 
@@ -344,8 +341,7 @@ static ssize_t scene_store(struct bt_mesh_model *model, uint8_t data[])
 	}
 
 	srv->lightness_srv.handlers->light_get(&srv->lightness_srv, NULL, &light);
-	sys_put_le16(light_to_repr(light.remaining_time ? light.target : light.current, ACTUAL),
-		     &data[0]);
+	sys_put_le16(to_actual(light.remaining_time ? light.target : light.current), &data[0]);
 
 	return 2;
 }
@@ -363,7 +359,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 
 	struct bt_mesh_lightness_status dummy_light_status;
 	struct bt_mesh_lightness_set light = {
-		.lvl = repr_to_light(sys_get_le16(data), ACTUAL),
+		.lvl = from_actual(sys_get_le16(data)),
 		.transition = transition,
 	};
 

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -560,7 +560,7 @@ static void reg_step(struct k_work *work)
 	/* The regulator output is always in linear format, so we need the
 	 * target value to be linear as well for the comparison.
 	 */
-	uint16_t lvl = light_to_repr(light_get(srv), LINEAR);
+	uint16_t lvl = to_linear(light_get(srv));
 
 	/* Output value is max out of regulator and configured level. */
 	if (output > lvl) {
@@ -580,7 +580,7 @@ static void reg_step(struct k_work *work)
 	struct bt_mesh_lightness_set set = {
 		/* Regulator output is linear, but lightness works in the configured representation.
 		 */
-		.lvl = repr_to_light(output, LINEAR),
+		.lvl = from_linear(output),
 	};
 
 	bt_mesh_lightness_srv_set(srv->lightness, NULL, &set,
@@ -1122,13 +1122,13 @@ static int prop_get(struct net_buf_simple *buf,
 		break; /* Prevent returning -ENOENT */
 #endif
 	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_ON:
-		val.val1 = light_to_repr(srv->cfg.light[LIGHT_CTRL_STATE_ON], ACTUAL);
+		val.val1 = to_actual(srv->cfg.light[LIGHT_CTRL_STATE_ON]);
 		break;
 	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_PROLONG:
-		val.val1 = light_to_repr(srv->cfg.light[LIGHT_CTRL_STATE_PROLONG], ACTUAL);
+		val.val1 = to_actual(srv->cfg.light[LIGHT_CTRL_STATE_PROLONG]);
 		break;
 	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_STANDBY:
-		val.val1 = light_to_repr(srv->cfg.light[LIGHT_CTRL_STATE_STANDBY], ACTUAL);
+		val.val1 = to_actual(srv->cfg.light[LIGHT_CTRL_STATE_STANDBY]);
 		break;
 	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_PROLONG:
 		to_prop_time(srv->cfg.fade_prolong, &val);
@@ -1231,13 +1231,13 @@ static int prop_set(struct net_buf_simple *buf,
 #endif
 	/* Properties are always set in light actual representation: */
 	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_ON:
-		srv->cfg.light[LIGHT_CTRL_STATE_ON] = repr_to_light(val.val1, ACTUAL);
+		srv->cfg.light[LIGHT_CTRL_STATE_ON] = from_actual(val.val1);
 		break;
 	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_PROLONG:
-		srv->cfg.light[LIGHT_CTRL_STATE_PROLONG] = repr_to_light(val.val1, ACTUAL);
+		srv->cfg.light[LIGHT_CTRL_STATE_PROLONG] = from_actual(val.val1);
 		break;
 	case BT_MESH_LIGHT_CTRL_PROP_LIGHTNESS_STANDBY:
-		srv->cfg.light[LIGHT_CTRL_STATE_STANDBY] = repr_to_light(val.val1, ACTUAL);
+		srv->cfg.light[LIGHT_CTRL_STATE_STANDBY] = from_actual(val.val1);
 		break;
 	case BT_MESH_LIGHT_CTRL_PROP_TIME_FADE_PROLONG:
 		srv->cfg.fade_prolong = from_prop_time(&val);
@@ -1435,8 +1435,7 @@ static ssize_t scene_store(struct bt_mesh_model *model, uint8_t data[])
 #endif
 
 	srv->lightness->handlers->light_get(srv->lightness, NULL, &light);
-	scene->lightness = light_to_repr(light.remaining_time ? light.target : light.current,
-					 ACTUAL);
+	scene->lightness = to_actual(light.remaining_time ? light.target : light.current);
 
 	return sizeof(struct scene_data);
 }
@@ -1464,7 +1463,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	} else {
 		struct bt_mesh_lightness_status status;
 		struct bt_mesh_lightness_set set = {
-			.lvl = repr_to_light(scene->lightness, ACTUAL),
+			.lvl = from_actual(scene->lightness),
 			.transition = transition,
 		};
 

--- a/subsys/bluetooth/mesh/light_hsl.c
+++ b/subsys/bluetooth/mesh/light_hsl.c
@@ -61,7 +61,7 @@ uint16_t bt_mesh_light_hsl_to_rgb(const struct bt_mesh_light_hsl *hsl,
 {
 	uint16_t lightness, min, max;
 
-	lightness = light_to_repr(hsl->lightness, ACTUAL);
+	lightness = to_actual(hsl->lightness);
 
 	/* When the color is monochromatic, it's equivalent to lightness: */
 	if (!hsl->saturation) {

--- a/subsys/bluetooth/mesh/light_hsl_internal.h
+++ b/subsys/bluetooth/mesh/light_hsl_internal.h
@@ -18,7 +18,7 @@
 static inline void light_hsl_buf_push(struct net_buf_simple *buf,
 				      const struct bt_mesh_light_hsl *hsl)
 {
-	net_buf_simple_add_le16(buf, light_to_repr(hsl->lightness, ACTUAL));
+	net_buf_simple_add_le16(buf, to_actual(hsl->lightness));
 	net_buf_simple_add_le16(buf, hsl->hue);
 	net_buf_simple_add_le16(buf, hsl->saturation);
 }
@@ -36,7 +36,7 @@ light_hue_sat_range_buf_push(struct net_buf_simple *buf,
 static inline void light_hsl_buf_pull(struct net_buf_simple *buf,
 				      struct bt_mesh_light_hsl *hsl)
 {
-	hsl->lightness = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	hsl->lightness = from_actual(net_buf_simple_pull_le16(buf));
 	hsl->hue = net_buf_simple_pull_le16(buf);
 	hsl->saturation = net_buf_simple_pull_le16(buf);
 }

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -94,7 +94,7 @@ static int hsl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		return -EMSGSIZE;
 	}
 
-	set.l.lvl = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	set.l.lvl = from_actual(net_buf_simple_pull_le16(buf));
 	set.h.lvl = net_buf_simple_pull_le16(buf);
 	set.s.lvl = net_buf_simple_pull_le16(buf);
 
@@ -411,9 +411,7 @@ static ssize_t scene_store(struct bt_mesh_model *model, uint8_t data[])
 	}
 
 	srv->lightness->handlers->light_get(srv->lightness, NULL, &status);
-	sys_put_le16(status.remaining_time ? light_to_repr(status.target, ACTUAL) :
-					     status.current,
-		     &data[0]);
+	sys_put_le16(status.remaining_time ? to_actual(status.target) : status.current, &data[0]);
 
 	return 2;
 }
@@ -430,7 +428,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 
 	struct bt_mesh_lightness_status light_status = { 0 };
 	struct bt_mesh_lightness_set light_set = {
-		.lvl = repr_to_light(sys_get_le16(data), ACTUAL),
+		.lvl = from_actual(sys_get_le16(data)),
 		.transition = transition,
 	};
 

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -103,7 +103,7 @@ static int xyl_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	struct bt_mesh_lightness_set light;
 	struct bt_mesh_light_xyl_status xyl_status;
 
-	light.lvl = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	light.lvl = from_actual(net_buf_simple_pull_le16(buf));
 	set.params.x = net_buf_simple_pull_le16(buf);
 	set.params.y = net_buf_simple_pull_le16(buf);
 	uint8_t tid = net_buf_simple_pull_u8(buf);
@@ -225,7 +225,7 @@ static int default_set(struct bt_mesh_model *model,
 {
 	struct bt_mesh_light_xyl_srv *srv = model->user_data;
 	struct bt_mesh_light_xy old_default = srv->xy_default;
-	uint16_t light = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	uint16_t light = from_actual(net_buf_simple_pull_le16(buf));
 
 	srv->xy_default.x = net_buf_simple_pull_le16(buf);
 	srv->xy_default.y = net_buf_simple_pull_le16(buf);
@@ -434,9 +434,9 @@ static ssize_t scene_store(struct bt_mesh_model *model, uint8_t data[])
 	}
 
 	if (light.remaining_time) {
-		scene->light = light_to_repr(light.target, ACTUAL);
+		scene->light = to_actual(light.target);
 	} else {
-		scene->light = light_to_repr(light.current, ACTUAL);
+		scene->light = to_actual(light.current);
 	}
 
 	return sizeof(struct scene_data);
@@ -467,7 +467,7 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 
 	struct bt_mesh_lightness_status light_status = { 0 };
 	struct bt_mesh_lightness_set light = {
-		.lvl = repr_to_light(scene->light, ACTUAL),
+		.lvl = from_actual(scene->light),
 		.transition = transition,
 	};
 

--- a/subsys/bluetooth/mesh/lightness_cli.c
+++ b/subsys/bluetooth/mesh/lightness_cli.c
@@ -59,7 +59,7 @@ static int handle_last_status(struct bt_mesh_model *model, struct bt_mesh_msg_ct
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_lightness_cli *cli = model->user_data;
-	uint16_t last = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	uint16_t last = from_actual(net_buf_simple_pull_le16(buf));
 	uint16_t *rsp;
 
 	if (bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, BT_MESH_LIGHTNESS_OP_LAST_STATUS, ctx->addr,
@@ -79,8 +79,7 @@ static int handle_default_status(struct bt_mesh_model *model, struct bt_mesh_msg
 				 struct net_buf_simple *buf)
 {
 	struct bt_mesh_lightness_cli *cli = model->user_data;
-	uint16_t default_lvl =
-		repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	uint16_t default_lvl = from_actual(net_buf_simple_pull_le16(buf));
 	uint16_t *rsp;
 
 	if (bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, BT_MESH_LIGHTNESS_OP_DEFAULT_STATUS,
@@ -104,8 +103,8 @@ static int handle_range_status(struct bt_mesh_model *model, struct bt_mesh_msg_c
 	struct bt_mesh_lightness_range_status *rsp;
 
 	status.status = net_buf_simple_pull_u8(buf);
-	status.range.min = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
-	status.range.max = repr_to_light(net_buf_simple_pull_le16(buf), ACTUAL);
+	status.range.min = from_actual(net_buf_simple_pull_le16(buf));
+	status.range.max = from_actual(net_buf_simple_pull_le16(buf));
 
 	if (bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, BT_MESH_LIGHTNESS_OP_RANGE_STATUS, ctx->addr,
 				      (void **)&rsp)) {
@@ -269,8 +268,8 @@ int bt_mesh_lightness_cli_range_set(struct bt_mesh_lightness_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHTNESS_OP_RANGE_SET,
 				 BT_MESH_LIGHTNESS_MSG_LEN_RANGE_SET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHTNESS_OP_RANGE_SET);
-	net_buf_simple_add_le16(&buf, light_to_repr(range->min, ACTUAL));
-	net_buf_simple_add_le16(&buf, light_to_repr(range->max, ACTUAL));
+	net_buf_simple_add_le16(&buf, to_actual(range->min));
+	net_buf_simple_add_le16(&buf, to_actual(range->max));
 
 	return model_ackd_send(cli->model, ctx, &buf,
 			       rsp ? &cli->ack_ctx : NULL,
@@ -284,8 +283,8 @@ int bt_mesh_lightness_cli_range_set_unack(
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHTNESS_OP_RANGE_SET_UNACK,
 				 BT_MESH_LIGHTNESS_MSG_LEN_RANGE_SET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHTNESS_OP_RANGE_SET_UNACK);
-	net_buf_simple_add_le16(&buf, light_to_repr(range->min, ACTUAL));
-	net_buf_simple_add_le16(&buf, light_to_repr(range->max, ACTUAL));
+	net_buf_simple_add_le16(&buf, to_actual(range->min));
+	net_buf_simple_add_le16(&buf, to_actual(range->max));
 
 	return model_send(cli->model, ctx, &buf);
 }
@@ -309,7 +308,7 @@ int bt_mesh_lightness_cli_default_set(struct bt_mesh_lightness_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHTNESS_OP_DEFAULT_SET,
 				 BT_MESH_LIGHTNESS_MSG_LEN_DEFAULT_SET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHTNESS_OP_DEFAULT_SET);
-	net_buf_simple_add_le16(&buf, light_to_repr(default_light, ACTUAL));
+	net_buf_simple_add_le16(&buf, to_actual(default_light));
 
 	return model_ackd_send(cli->model, ctx, &buf,
 			       rsp ? &cli->ack_ctx : NULL,
@@ -323,7 +322,7 @@ int bt_mesh_lightness_cli_default_set_unack(struct bt_mesh_lightness_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHTNESS_OP_DEFAULT_SET_UNACK,
 				 BT_MESH_LIGHTNESS_MSG_LEN_DEFAULT_SET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHTNESS_OP_DEFAULT_SET_UNACK);
-	net_buf_simple_add_le16(&buf, light_to_repr(default_light, ACTUAL));
+	net_buf_simple_add_le16(&buf, to_actual(default_light));
 
 	return model_send(cli->model, ctx, &buf);
 }

--- a/subsys/bluetooth/mesh/lightness_internal.h
+++ b/subsys/bluetooth/mesh/lightness_internal.h
@@ -118,6 +118,36 @@ static inline uint16_t repr_to_light(uint16_t val, enum light_repr repr)
 	return val;
 }
 
+/** @brief Convert light from linear representation to the configured.
+ *
+ *  @param light Light value in linear representation.
+ *
+ *  @return The light value in the configured representation.
+ */
+static inline uint16_t from_linear(uint16_t val)
+{
+	if (IS_ENABLED(CONFIG_BT_MESH_LIGHTNESS_ACTUAL)) {
+		return linear_to_actual(val);
+	}
+
+	return val;
+}
+
+/** @brief Convert light from actual representation to the configured.
+ *
+ *  @param light Light value in actual representation.
+ *
+ *  @return The light value in the configured representation.
+ */
+static inline uint16_t from_actual(uint16_t val)
+{
+	if (IS_ENABLED(CONFIG_BT_MESH_LIGHTNESS_LINEAR)) {
+		return actual_to_linear(val);
+	}
+
+	return val;
+}
+
 /** @brief Convert light from the configured representation to the specified.
  *
  *  @param light Light value in the configured representation.
@@ -136,6 +166,36 @@ static inline uint16_t light_to_repr(uint16_t light, enum light_repr repr)
 	}
 
 	return light;
+}
+
+/** @brief Convert light from the configured representation to linear.
+ *
+ *  @param light Light value in the configured representation.
+ *
+ *  @return The light value in linear representation.
+ */
+static inline uint16_t to_linear(uint16_t val)
+{
+	if (IS_ENABLED(CONFIG_BT_MESH_LIGHTNESS_ACTUAL)) {
+		return actual_to_linear(val);
+	}
+
+	return val;
+}
+
+/** @brief Convert light from the configured representation to actual.
+ *
+ *  @param light Light value in the configured representation.
+ *
+ *  @return The light value in actual representation.
+ */
+static inline uint16_t to_actual(uint16_t val)
+{
+	if (IS_ENABLED(CONFIG_BT_MESH_LIGHTNESS_LINEAR)) {
+		return linear_to_actual(val);
+	}
+
+	return val;
 }
 
 struct bt_mesh_lightness_srv;

--- a/tests/bluetooth/tester/src/mmdl.c
+++ b/tests/bluetooth/tester/src/mmdl.c
@@ -2616,8 +2616,8 @@ static void light_lightness_linear_get(uint8_t *data, uint16_t len)
 		goto fail;
 	}
 
-	current = light_to_repr(status.current, LINEAR);
-	target = light_to_repr(status.target, LINEAR);
+	current = to_linear(status.current);
+	target = to_linear(status.target);
 
 	net_buf_simple_init(buf, 0);
 	net_buf_simple_add_le16(buf, current);
@@ -2676,8 +2676,8 @@ static void light_lightness_linear_set(uint8_t *data, uint16_t len)
 		err = lightness_cli_light_set(&lightness_cli, &ctx, LINEAR,
 					      &set, &status);
 
-		current = light_to_repr(status.current, LINEAR);
-		target = light_to_repr(status.target, LINEAR);
+		current = to_linear(status.current);
+		target = to_linear(status.target);
 
 		net_buf_simple_init(buf, 0);
 		net_buf_simple_add_le16(buf, current);


### PR DESCRIPTION
The light representation conversion functions light_to_repr and
repr_to_light have caused a couple of bugs (like #5890), as they're hard
to tell apart.

Instead of these two general conversion functions, use specific to/from
linear/actual function to reduce the risk of any double-conversion.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>