### PR TITLE
net: lib: download_client: remove APN support

### DIFF
--- a/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
@@ -24,7 +24,7 @@ Syntax
 
 ::
 
-   AT#XFOTA=<op>,<file_url>[,<sec_tag>[,<apn>]]
+   AT#XFOTA=<op>,<file_url>[,<sec_tag>[,<pdn_id>]]
 
 * The ``<op>`` parameter can accept one of the following values:
 
@@ -42,8 +42,8 @@ Syntax
   It indicates to the modem the credential of the security tag used for establishing a secure connection for downloading the image.
   It is associated with the certificate or PSK.
   Specifying the ``<sec_tag>`` is mandatory when using HTTPS.
-* The ``<apn>`` parameter is a string.
-  It represents an alternative access point name (APN), other than the default primary APN, to use for downloading.
+* The ``<pdn_id>`` parameter is an integer.
+  It represents the Packet Data Network (PDN) ID that can be used instead of the default PDN for downloading.
 
 Response syntax
 ~~~~~~~~~~~~~~~

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -88,6 +88,7 @@ nRF Desktop
 nRF9160: Serial LTE modem
 -------------------------
 
+* Updated the ``#XFOTA`` command to accept an integer parameter to specify the PDN ID to be used for the download, instead of the APN name.
 * Added new AT commands related to the General Purpose Input/Output (GPIO).
 * Added the ``#XUUID`` command to read out the device UUID from the modem.
 * Added to the ``XNRFCLOUD`` command the following features:
@@ -268,6 +269,7 @@ Libraries for networking
   * Added :kconfig:`CONFIG_NRF_CLOUD_PGPS_SOCKET_RETRIES`.
   * Changed :c:func:`nrf_cloud_pgps_init` to limit allowable :kconfig:`CONFIG_NRF_CLOUD_PGPS_NUM_PREDICTIONS` to an even number,
     and limited :kconfig:`CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD` to this value minus 2.
+  * Updated the signature of :c:func:`npgps_download_start` to accept an integer parameter specifying the PDN ID, which replaces the parameter used to specify the APN.
 
 * :ref:`lib_rest_client` library:
 
@@ -276,6 +278,14 @@ Libraries for networking
 * :ref:`lib_azure_iot_hub` library:
 
   * Updated the API version used in MQTT connection to Azure IoT Hub to 2020-09-30.
+
+* :ref:`lib_download_client` library:
+
+  * Removed the ``apn`` field in the ``download_client_cfg`` configuration structure.
+
+* :ref:`lib_fota_download` library:
+
+  * Updated the signature of :c:func:`fota_download_start_with_image_type` to accept an integer parameter specifying the PDN ID, which replaces the parameter used to specify the APN.
 
 Libraries for NFC
 -----------------

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -91,12 +91,6 @@ struct download_client_cfg {
 	 *  Pass -1 to disable TLS.
 	 */
 	int sec_tag;
-	/** Access point name identifying a packet data network.
-	 *  Pass a null-terminated string with the APN
-	 *  or NULL to use the default APN.
-	 *  @deprecated Specify a PDN ID instead.
-	 */
-	const char *apn;
 	/**
 	 * PDN ID to be used for the download.
 	 * Zero is the default PDN.

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -99,7 +99,7 @@ int fota_download_init(fota_download_callback_t client_callback);
  *             and port number, e.g. https://google.com:443
  * @param file Filepath to the file you wish to download.
  * @param sec_tag Security tag you want to use with HTTPS set to -1 to Disable.
- * @param apn Access Point Name to use or NULL to use the default APN.
+ * @param pdn_id Packet Data Network ID to use for the download, or 0 to use the default.
  * @param fragment_size Fragment size to be used for the download.
  *			If 0, @kconfig{CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE} is used.
  *
@@ -108,7 +108,7 @@ int fota_download_init(fota_download_callback_t client_callback);
  *                   Otherwise, a negative value is returned.
  */
 int fota_download_start(const char *host, const char *file, int sec_tag,
-			const char *apn, size_t fragment_size);
+			uint8_t pdn_id, size_t fragment_size);
 
 /**@brief Start downloading the given file from the given host. Validate that the
  * file type matches the expected type before starting the installation.
@@ -120,7 +120,7 @@ int fota_download_start(const char *host, const char *file, int sec_tag,
  *             and port number, e.g. https://google.com:443
  * @param file Filepath to the file you wish to download.
  * @param sec_tag Security tag you want to use with HTTPS set to -1 to Disable.
- * @param apn Access Point Name to use or NULL to use the default APN.
+ * @param pdn_id Packet Data Network ID to use for the download, or 0 to use the default.
  * @param fragment_size Fragment size to be used for the download.
  *			If 0, @kconfig{CONFIG_DOWNLOAD_CLIENT_HTTP_FRAG_SIZE} is used.
  * @param expected_type Type of firmware file to be downloaded and installed.
@@ -130,7 +130,7 @@ int fota_download_start(const char *host, const char *file, int sec_tag,
  *                   Otherwise, a negative value is returned.
  */
 int fota_download_start_with_image_type(const char *host, const char *file,
-			int sec_tag, const char *apn, size_t fragment_size,
+			int sec_tag, uint8_t pdn_id, size_t fragment_size,
 			const enum dfu_target_image_type expected_type);
 
 /**@brief Cancel FOTA image downloading.

--- a/samples/nrf9160/http_update/application_update/src/main.c
+++ b/samples/nrf9160/http_update/application_update/src/main.c
@@ -35,10 +35,9 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 static void update_start(void)
 {
 	int err;
-	char *apn = NULL;
 
 	err = fota_download_start(CONFIG_DOWNLOAD_HOST, CONFIG_DOWNLOAD_FILE,
-				  SEC_TAG, apn, 0);
+				  SEC_TAG, 0, 0);
 	if (err != 0) {
 		update_sample_done();
 		printk("fota_download_start() failed, err %d\n", err);

--- a/samples/nrf9160/http_update/full_modem_update/src/main.c
+++ b/samples/nrf9160/http_update/full_modem_update/src/main.c
@@ -166,7 +166,7 @@ void update_start(void)
 
 	/* Functions for getting the host and file */
 	err = fota_download_start(CONFIG_DOWNLOAD_HOST, get_file(), SEC_TAG,
-				  NULL, 0);
+				  0, 0);
 	if (err != 0) {
 		update_sample_done();
 		printk("fota_download_start() failed, err %d\n", err);

--- a/samples/nrf9160/http_update/modem_delta_update/src/main.c
+++ b/samples/nrf9160/http_update/modem_delta_update/src/main.c
@@ -68,11 +68,10 @@ void fota_dl_handler(const struct fota_download_evt *evt)
 void update_start(void)
 {
 	int err;
-	char *apn = NULL;
 
 	/* Functions for getting the host and file */
 	err = fota_download_start(CONFIG_DOWNLOAD_HOST, get_file(), SEC_TAG,
-				  apn, 0);
+				  0, 0);
 	if (err != 0) {
 		update_sample_done();
 		printk("fota_download_start() failed, err %d\n", err);

--- a/samples/nrf9160/modem_shell/src/fota/fota.c
+++ b/samples/nrf9160/modem_shell/src/fota/fota.c
@@ -103,5 +103,5 @@ int fota_init(void)
 
 int fota_start(const char *host, const char *file)
 {
-	return fota_download_start(host, file, MOSH_FOTA_TLS_SECURITY_TAG, NULL, 0);
+	return fota_download_start(host, file, MOSH_FOTA_TLS_SECURITY_TAG, 0, 0);
 }

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -302,7 +302,6 @@ static int job_update_accepted(struct mqtt_client *const client,
 {
 	int err;
 	int sec_tag = -1;
-	char *apn = NULL;
 
 	err = get_published_payload(client, payload_buf, payload_len);
 	if (err) {
@@ -331,7 +330,7 @@ static int job_update_accepted(struct mqtt_client *const client,
 		sec_tag = CONFIG_AWS_FOTA_DOWNLOAD_SECURITY_TAG;
 #endif
 
-		err = fota_download_start(hostname, file_path, sec_tag, apn, 0);
+		err = fota_download_start(hostname, file_path, sec_tag, 0, 0);
 		if (err) {
 			LOG_ERR("Error (%d) when trying to start firmware download", err);
 			aws_fota_evt.id = AWS_FOTA_EVT_ERROR;

--- a/subsys/net/lib/azure_fota/azure_fota.c
+++ b/subsys/net/lib/azure_fota/azure_fota.c
@@ -728,7 +728,7 @@ int azure_fota_msg_process(const char *const buf, size_t size)
 
 	err = fota_download_start(fota_object.host, fota_object.path,
 				  CONFIG_AZURE_FOTA_SEC_TAG,
-				  NULL, fota_object.fragment_size);
+				  0, fota_object.fragment_size);
 	if (err) {
 		LOG_ERR("Error (%d) when trying to start firmware download",
 			err);

--- a/subsys/net/lib/download_client/src/shell.c
+++ b/subsys/net/lib/download_client/src/shell.c
@@ -13,13 +13,11 @@
 
 LOG_MODULE_DECLARE(download_client);
 
-static char apn[32];
 static char host[CONFIG_DOWNLOAD_CLIENT_MAX_HOSTNAME_SIZE];
 static char file[CONFIG_DOWNLOAD_CLIENT_MAX_FILENAME_SIZE];
 
 static struct download_client downloader;
 static struct download_client_cfg config = {
-	.apn = apn,
 	.sec_tag = -1,
 };
 
@@ -66,21 +64,21 @@ static int download_shell_init(const struct device *d)
 
 static int cmd_dc_config(const struct shell *shell, size_t argc, char **argv)
 {
-	shell_warn(shell, "usage: dc config <apn>|<sec_tag>\n");
+	shell_warn(shell, "usage: dc config <pdn_id>|<sec_tag>\n");
 	return 0;
 }
 
-static int cmd_dc_config_apn(const struct shell *shell, size_t argc,
+static int cmd_dc_config_pdn_id(const struct shell *shell, size_t argc,
 			     char **argv)
 {
 	if (argc != 2) {
-		shell_warn(shell, "usage: dc config apn <apn_name>\n");
+		shell_warn(shell, "usage: dc config pdn <pdn_id>\n");
 		return 0;
 	}
 
-	memcpy(apn, argv[1], MIN(strlen(argv[1]) + 1, sizeof(apn)));
+	config.pdn_id = atoi(argv[1]);
 
-	shell_print(shell, "APN set: %s\n", apn);
+	shell_print(shell, "PDN ID set: %d\n", config.pdn_id);
 	return 0;
 }
 
@@ -176,7 +174,7 @@ static int cmd_dc_disconnect(const struct shell *shell, size_t argc,
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_config,
-	SHELL_CMD(apn, NULL, "Set APN", cmd_dc_config_apn),
+	SHELL_CMD(pdn_id, NULL, "Set PDN ID", cmd_dc_config_pdn_id),
 	SHELL_CMD(sec_tag, NULL, "Set security tag", cmd_dc_config_sec_tag),
 	SHELL_SUBCMD_SET_END
 );

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -277,14 +277,14 @@ static void download_with_offset(struct k_work *unused)
 }
 
 int fota_download_start(const char *host, const char *file, int sec_tag,
-	const char *apn, size_t fragment_size)
+	uint8_t pdn_id, size_t fragment_size)
 {
-	return fota_download_start_with_image_type(host, file, sec_tag, apn,
+	return fota_download_start_with_image_type(host, file, sec_tag, pdn_id,
 		fragment_size, DFU_TARGET_IMAGE_TYPE_ANY);
 }
 
 int fota_download_start_with_image_type(const char *host, const char *file,
-	int sec_tag, const char *apn, size_t fragment_size,
+	int sec_tag, uint8_t pdn_id, size_t fragment_size,
 	const enum dfu_target_image_type expected_type)
 {
 	/* We need a static file buffer since the download client structure
@@ -298,7 +298,7 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 
 	struct download_client_cfg config = {
 		.sec_tag = sec_tag,
-		.apn = apn,
+		.pdn_id = pdn_id,
 		.frag_size_override = fragment_size,
 		.set_tls_hostname = (sec_tag != -1),
 	};

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -331,7 +331,7 @@ static void start_fota_download(struct k_work *work)
 	 */
 	configure_full_modem_update();
 #endif
-	int ret = fota_download_start(fota_host, fota_path, fota_sec_tag, NULL, 0);
+	int ret = fota_download_start(fota_host, fota_path, fota_sec_tag, 0, 0);
 
 	if (ret < 0) {
 		LOG_ERR("fota_download_start() failed, return code %d", ret);

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_pgps_utils.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_pgps_utils.h
@@ -77,7 +77,7 @@ void *npgps_block_to_pointer(int block);
 /* download functions */
 int npgps_download_init(npgps_buffer_handler_t handler);
 int npgps_download_start(const char *host, const char *file, int sec_tag,
-			 const char *apn, size_t fragment_size);
+			 uint8_t pdn_id, size_t fragment_size);
 
 
 #ifdef __cplusplus

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -882,7 +882,7 @@ static int start_job(struct nrf_cloud_fota_job *const job)
 	}
 
 	ret = fota_download_start_with_image_type(job->info.host,
-		job->info.path, CONFIG_NRF_CLOUD_SEC_TAG, NULL,
+		job->info.path, CONFIG_NRF_CLOUD_SEC_TAG, 0,
 		CONFIG_NRF_CLOUD_FOTA_DOWNLOAD_FRAGMENT_SIZE,
 		img_type);
 	if (ret) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -1451,7 +1451,7 @@ int nrf_cloud_pgps_process(const char *buf, size_t buf_len)
 	}
 
 	return npgps_download_start(pgps_dl.host, pgps_dl.path, sec_tag,
-				    NULL, FRAGMENT_SIZE);
+				    0, FRAGMENT_SIZE);
 }
 
 int nrf_cloud_pgps_init(struct nrf_cloud_pgps_init_param *param)

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps_utils.c
@@ -439,7 +439,7 @@ int npgps_download_init(npgps_buffer_handler_t handler)
 }
 
 int npgps_download_start(const char *host, const char *file, int sec_tag,
-			 const char *apn, size_t fragment_size)
+			 uint8_t pdn_id, size_t fragment_size)
 {
 	if (host == NULL || file == NULL) {
 		return -EINVAL;
@@ -458,7 +458,7 @@ int npgps_download_start(const char *host, const char *file, int sec_tag,
 
 	struct download_client_cfg config = {
 		.sec_tag = sec_tag,
-		.apn = apn,
+		.pdn_id = pdn_id,
 		.frag_size_override = fragment_size,
 		.set_tls_hostname = (sec_tag != -1),
 	};

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -24,7 +24,6 @@ char buf[1024];
 #define S1 "s1"
 #define NO_SPACE "s0s1"
 #define NO_TLS -1
-#define DEFAULT_APN NULL
 
 /* Stubs and mocks */
 bool dfu_ctx_mcuboot_set_b1_file__s0_active;
@@ -186,7 +185,7 @@ static void test_fota_download_start(void)
 	/* Verify that correct argument for s0_active is given */
 	set_s0_active(false);
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	err = fota_download_start("something.com", buf, NO_TLS, 0, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active,
 		      spm_s0_active_retval, "Incorrect param for s0_active");
@@ -194,7 +193,7 @@ static void test_fota_download_start(void)
 	err = fota_download_cancel();
 	zassert_equal(err, 0, NULL);
 	set_s0_active(true);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	err = fota_download_start("something.com", buf, NO_TLS, 0, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active,
 		      spm_s0_active_retval, "Incorrect param for s0_active");
@@ -208,7 +207,7 @@ static void test_fota_download_start(void)
 	/* update set to null indicates to use original file param */
 	dfu_ctx_mcuboot_set_b1_file__update = NULL;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	err = fota_download_start("something.com", buf, NO_TLS, 0, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S0_S1) == 0, NULL);
 	err = fota_download_cancel();
@@ -217,12 +216,12 @@ static void test_fota_download_start(void)
 	/* update set to not null indicates to use update for file param */
 	dfu_ctx_mcuboot_set_b1_file__update = S1;
 	strcpy(buf, S0_S1);
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	err = fota_download_start("something.com", buf, NO_TLS, 0, 0);
 	zassert_equal(err, 0, NULL);
 	zassert_true(strcmp(download_client_start_file, S1) == 0, NULL);
 
 	/* Check if double call returns EALREADY */
-	err = fota_download_start("something.com", buf, NO_TLS, DEFAULT_APN, 0);
+	err = fota_download_start("something.com", buf, NO_TLS, 0, 0);
 	zassert_equal(err, -EALREADY, "No failure for double call");
 }
 


### PR DESCRIPTION
Starting from modem library v1.4.0, the support for configuring
network sockets and DNS queries to use a given APN has been removed.

This patch removes the `apn` field from the configuration structure.