### PR TITLE
VS Code: Add extension recommendation file

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+        "recommendations": [
+                "nordic-semiconductor.nrf-connect-extension-pack"
+        ]
+}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,6 +18,9 @@
 /.github/labeler.yml                      @thst-nordic @guwa @mariusz-nordicsemi @tomaszkob89 @totyz @doublemis1 @wiminordic @jorgenmk @maciekrozanski @ns-tolu @miha-nordic @maciejpietras @piwe-nordic @nordic-babu @fredaas @torsteingrindvik @mswarowsky @shantha-14 @ardo-nordic
 /.github/workflows/manifest.yml           @thst-nordic @guwa @mariusz-nordicsemi @tomaszkob89 @totyz @doublemis1 @wiminordic @jorgenmk @maciekrozanski @ns-tolu @miha-nordic @maciejpietras @piwe-nordic @nordic-babu @fredaas @torsteingrindvik @mswarowsky @shantha-14 @ardo-nordic
 
+# VS Code Configuration files
+/.vscode/                                 @trond-snekvik
+
 # Applications
 /applications/asset_tracker/              @jhn-nordic @jtguggedal @rlubos
 /applications/asset_tracker_v2/           @simensrostad @jtguggedal @jhn-nordic @coderbyheart


### PR DESCRIPTION
Adds VS Code extension recommendations for the nRF Connect SDK, that
will cause VS Code to prompt users to install the official nRF Connect
extension pack:

![image](https://user-images.githubusercontent.com/7857838/140326413-8f60d490-dce2-4276-82c8-d5e18e6a36a3.png)

The prompt can be permanently dismissed by pressing the cogwheel: 
![image](https://user-images.githubusercontent.com/7857838/140327278-9b0699b5-f067-4b37-b56d-ece90cac29a4.png)

The prompt will pop up if the extensions.json file exists at any place in the user's workspace. They do not have to open the nrf folder as a root folder.

I added myself as the code owner for this folder, but I have no intention of adding more content in there. 

This PR was prompted by @ihansse spotting someone in today's internal v1.7.0 showcase running raw VS Code without the extension 🙂 
I seem to recall that we have rejected editor configs in the past, but I wanted to make this PR to start a discussion, as I believe it would help increase adoption and awareness without causing any major annoyance.
