### PR TITLE
samples: nrf9160: lwm2m_client: Fix build command in Readme

### DIFF
--- a/samples/nrf9160/lwm2m_client/README.rst
+++ b/samples/nrf9160/lwm2m_client/README.rst
@@ -485,7 +485,7 @@ To use the LwM2M Client with LwM2M Queue Mode support, build it with the ``-DOVE
 
 .. code-block:: console
 
-   west build -b nrf9160dk_nrf9160_ns -- -DOVERLAY_CONFIG=-DOVERLAY_CONFIG=overlay-queue.conf
+   west build -b nrf9160dk_nrf9160_ns -- -DOVERLAY_CONFIG=overlay-queue.conf
 
 Bootstrap support
 =================
@@ -497,7 +497,7 @@ To build the LwM2M Client with LwM2M bootstrap support, build it with the ``-DOV
 
 .. code-block:: console
 
-   west build -b nrf9160dk_nrf9160_ns -- -DOVERLAY_CONFIG=-DOVERLAY_CONFIG=overlay-bootstrap.conf
+   west build -b nrf9160dk_nrf9160_ns -- -DOVERLAY_CONFIG=overlay-bootstrap.conf
 
 See :ref:`cmake_options` for instructions on how to add this option.
 Keep in mind that the used bootstrap port is set in the aforementioned configuration file.


### PR DESCRIPTION
The commands for building the sample listed in the readme contain an
extra -DOVERLAY_CONFIG. This commit removes them so that the listed
commands will work.

Signed-off-by: Markus Rekdal <markus.rekdal@nordicsemi.no>