### PR TITLE
lib: lte_link_control: Update conversion specifier when passing in enums

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1108,7 +1108,7 @@ int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status)
 	}
 
 	/* Read network registration status */
-	err = nrf_modem_at_scanf("AT%XMONITOR", "%%XMONITOR: %u", status);
+	err = nrf_modem_at_scanf("AT%XMONITOR", "%%XMONITOR: %hhu", status);
 	if (err != 1) {
 		LOG_ERR("Could not get registration status, error: %d", err);
 		return -EFAULT;
@@ -1267,7 +1267,7 @@ int lte_lc_func_mode_get(enum lte_lc_func_mode *mode)
 	}
 
 	/* Exactly one parameter is expected to match. */
-	err = nrf_modem_at_scanf(AT_CFUN_READ, "+CFUN: %u", mode);
+	err = nrf_modem_at_scanf(AT_CFUN_READ, "+CFUN: %hhu", mode);
 	if (err != 1) {
 		LOG_ERR("AT command failed, nrf_modem_at_scanf() returned error: %d", err);
 		return -EFAULT;
@@ -1350,7 +1350,7 @@ int lte_lc_lte_mode_get(enum lte_lc_lte_mode *mode)
 		"%*u,"		/* <stat> */
 		"%*[^,],"	/* <tac> */
 		"%*[^,],"	/* <ci> */
-		"%u",		/* <AcT> */
+		"%hhu",		/* <AcT> */
 		mode);
 	if (err == -NRF_EBADMSG) {
 		/* The AT command was successful, but there were no matches.


### PR DESCRIPTION
Update conversion specifier to `%hhu` when passing in enums to
`nrf_modem_at_scanf`.

This is to avoid memory alignment issues when passing enums directly
into `nrf_modem_at_scanf`. `nrf_modem_at_scanf` expects the input
variable to be 32 bits alligned on a 4 byte boundrary.

Fixes NCSDK-12282