### PR TITLE
lib: lte_link_control: Fix NCELLMEAS at command

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1387,12 +1387,12 @@ int lte_lc_neighbor_cell_measurement(enum lte_lc_neighbor_search_type type)
 	 */
 
 	if (type == LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT) {
-		err = at_cmd_write("AT%NCELLMEAS=1",  NULL, 0, NULL);
+		err = nrf_modem_at_printf("AT%%NCELLMEAS=1");
 	} else if (type == LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE) {
-		err = at_cmd_write("AT%NCELLMEAS=2",  NULL, 0, NULL);
+		err = nrf_modem_at_printf("AT%%NCELLMEAS=2");
 	} else {
 		/* Defaulting to use LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT */
-		err = at_cmd_write("AT%NCELLMEAS",  NULL, 0, NULL);
+		err = nrf_modem_at_printf("AT%%NCELLMEAS");
 	}
 
 	return err ? -EFAULT : 0;

--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -12,10 +12,8 @@
 #include <stdio.h>
 #include <device.h>
 #include <modem/lte_lc.h>
-#include <modem/at_cmd.h>
 #include <modem/at_cmd_parser.h>
 #include <modem/at_params.h>
-#include <modem/at_notif.h>
 #include <logging/log.h>
 
 #include "lte_lc_helpers.h"

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <modem/lte_lc.h>
-#include <modem/at_cmd.h>
 #include <modem/at_cmd_parser.h>
 #include <modem/at_params.h>
 #include <logging/log.h>


### PR DESCRIPTION
NCELLMEAS AT command still used `at_cmd_write`. Changed this to `nrf_modem_at_printf`.
This caused issues as client never get NCELLMEAS event because `lte_link_control` doesn't have old `at_notif_handler` registered where the response was sent.