### PR TITLE
doc: Unifying terminology in HID configurator script document

### DIFF
--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -16,8 +16,8 @@ It can be used for the following purposes:
 * `Configuring device runtime options`_
 * `Performing DFU`_
 * `Rebooting the device`_
-* `Getting information about the FW version`_
-* `Playing LEDstream`_
+* `Getting information about the firmware version`_
+* `Playing LED stream`_
 
 Overview
 ********
@@ -26,7 +26,7 @@ The script looks for nRF Desktop devices connected to the host through USB, Blue
 The devices are identified based on Vendor ID.
 
 The script exchanges data with the device using :ref:`nrf_desktop_config_channel`.
-The data is sent using HID feature reports and targets a specific FW module of the nRF Desktop application.
+The data is sent using HID feature reports and targets a specific firmware module of the nRF Desktop application.
 
 For more information about the architecture of the nRF Desktop configuration channel, see :ref:`nrf_desktop_config_channel`.
 The configuration channel uses a cross-platform HIDAPI library to communicate with HID devices attached to the operating system.
@@ -62,7 +62,7 @@ Complete the following steps:
 
       py -3 -m pip install -r requirements_music_led_stream.txt
 
-For more detailed information about LED stream functionality, see the `Playing LEDstream`_ section.
+For more detailed information about LED stream functionality, see the `Playing LED stream`_ section.
 
 Debian/Ubuntu/Linux Mint
 ========================
@@ -91,7 +91,7 @@ Complete the following steps:
       sudo apt-get install portaudio19-dev python3-pyaudio
       pip3 install --user -r requirements_music_led_stream.txt
 
-For more detailed information about LED stream functionality, see the `Playing LEDstream`_ section.
+For more detailed information about LED stream functionality, see the `Playing LED stream`_ section.
 
 Using the script
 ****************
@@ -137,7 +137,7 @@ Use the following syntax to show the modules and options:
 Configuring device runtime options
 ==================================
 
-The script can pass the configuration values to the linked FW module using the ``config`` command.
+The script can pass the configuration values to the linked firmware module using the ``config`` command.
 Use the following syntax to display the list of modules that can have device runtime options configured:
 
 .. parsed-literal::
@@ -185,7 +185,7 @@ To write a new value for the selected option, pass the value as the fifth argume
 
 .. important::
    If the module that is a configuration channel listener specifies its variant, you must refer to the module using the following syntax: ``module_name/variant``.
-   For example, the :ref:`nrf_desktop_motion` variant that depends on the motion sensor model will require the following naming convention:
+   For example, the :ref:`nrf_desktop_motion` variant that depends on the motion sensor model requires the following naming convention:
 
    * ``motion/paw3212``
    * ``motion/pmw3360``
@@ -203,13 +203,13 @@ After the device reboots, the process always starts from the beginning.
 For more information, see nRF Desktop's :ref:`nrf_desktop_dfu`.
 The DFU functionality on the host computer is implemented in the :file:`nrf/scripts/hid_configurator/modules/dfu.py` file.
 
-The ``dfu`` command will read the version of the firmware running on the device and compare it with the firmware version in the update image at the provided path.
-If the process is to be continued, the script will upload the image data to the device.
-When the upload is completed, the script will reboot the device.
+The ``dfu`` command reads the version of the firmware running on the device and compares it with the firmware version in the update image at the provided path.
+If the process is to be continued, the script uploads the image data to the device.
+When the upload is completed, the script reboots the device.
 
-Customize the command with the following variables:
+Customize the command with the following variable:
 
-* ``UPDATE_IMAGE_PATH`` - Path to the DFU update file.
+``UPDATE_IMAGE_PATH`` - Path to the DFU update file.
 
 To perform a DFU operation, run the following command:
 
@@ -234,8 +234,8 @@ To perform a device reboot operation, run the following command:
 .. note::
   Only devices with :ref:`nrf_desktop_dfu` support the ``fwreboot`` command.
 
-Getting information about the FW version
-========================================
+Getting information about the firmware version
+==============================================
 
 To obtain information about the firmware running on the device, run the following command:
 
@@ -247,17 +247,17 @@ To obtain information about the firmware running on the device, run the followin
 .. note::
   Only devices with :ref:`nrf_desktop_dfu` support the ``fwinfo`` command.
 
-Playing LEDstream
-=================
+Playing LED stream
+==================
 
-The LEDstream is a feature of nRF Desktop that allows you to send a stream of color data to be replayed on the device LED.
+The LED stream is a feature of nRF Desktop that allows you to send a stream of color data to be replayed on the device LED.
 For more information about its implementation, see nRF Desktop's :ref:`nrf_desktop_led_stream`.
-The LEDstream functionality on the host computer is implemented by the following files:
+The LED stream functionality on the host computer is implemented by the following files:
 
 * :file:`nrf/scripts/hid_configurator/modules/led_stream.py`
 * :file:`nrf/scripts/hid_configurator/modules/music_led_stream.py`.
 
-HID configurator's ``led_stream`` command will start the LEDstream playback on the device.
+HID configurator's ``led_stream`` command starts the LED stream playback on the device.
 
 Customize the command with the following variables:
 
@@ -266,7 +266,7 @@ Customize the command with the following variables:
   The higher the frequency, the more often the colors change.
 * ``--file WAVE_FILE`` - Optional argument for opening a wave file and using it to generate the stream of colors based on the sound data.
 
-To start the LEDstream payback, run the following command:
+To start the LED stream payback, run the following command:
 
 .. parsed-literal::
     :class: highlight
@@ -286,12 +286,12 @@ For details about options available within each module, see the module documenta
 
 From the user perspective, the nRF Desktop device is handled in the same way, regardless of it being connected to the host directly or through the nRF Desktop dongle.
 During the device discovery, the script asks for the nRF Desktop peripherals connected through Bluetooth.
-In case the currently discovered device has connected peripherals, these peripherals are discovered, readying them for configuration.
+If the currently discovered device has connected peripherals, they are discovered and prepared for configuration.
 
 Dependencies
 ************
 
-The configuration channel uses the following dependencies:
+The configuration channel has the following dependencies:
 
 * `HIDAPI library`_
 * `pyhidapi Python wrapper`_


### PR DESCRIPTION
Changing LEDstream to LED stream.
Also FW to firmware.
Ref: NCSDK-10719

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>