### PR TITLE
doc: Fix subsection title in Working with nRF53 series

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -97,4 +97,4 @@
 
 .. |thingy53_sample_note| replace:: If you build this application for Thingy:53, it enables additional features. See :ref:`thingy53_app_guide` for details.
 
-.. |thingy53_unreleased| replace:: As of the |NCS| v1.7.0 release, Thingy:53 is an unreleased product that will be released in the near future.
+.. |thingy53_unreleased| replace:: As of the |NCS| |release| release, Thingy:53 is an unreleased product that will be released in the near future.

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -2,8 +2,8 @@
 
 .. _ug_nrf5340:
 
-Working with nRF53 Series
-#########################
+Working with nRF5340 DK
+#######################
 
 .. contents::
    :local:


### PR DESCRIPTION
Fixed title of subsection from "Working with nRF53 series" to
"Working with nRF5340 DK" to not duplicate the title of the whole section
that was added with the intrudoction of Nordic Thingy:53 documentation.

Also fixed release number to |release| in the Thingy:53 unreleased note.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>