### PR TITLE
manifest: update sdk-zephyr to bring in the Kconfig experimental feature

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -35,6 +35,7 @@ Application development
 
   * Added an option to control the inclusion of RPMsg samples on the nRF53 network core :kconfig:`NCS_INCLUDE_RPMSG_CHILD_IMAGE`.
   * Fixed the NCSIDB-581 bug where application signing and file conversion for Device Firmware Update (DFU) could fail in SEGGER Embedded Studio during a build.
+  * Added possibility to enable build warning when experimental features are enabled, NCSDK-6336.
 
 Protocols
 =========

--- a/samples/peripheral/802154_phy_test/Kconfig
+++ b/samples/peripheral/802154_phy_test/Kconfig
@@ -53,6 +53,7 @@ config PTT_HW_VERSION
 config PTT_ANTENNA_DIVERSITY
 	depends on !SOC_SERIES_NRF53X
 	bool "Enable Antenna Diversity [EXPERIMENTAL]"
+	select EXPERIMENTAL
 
 if PTT_ANTENNA_DIVERSITY
 

--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -23,6 +23,7 @@ config MPSL_CX_THREAD
 	select GPIO
 	depends on !BT
 	bool "Thread Radio Coexistence [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  Radio Coexistence interface implementation according to Thread Radio
 	  Coexistence Practical recommendations for using a 3-wire PTA

--- a/subsys/net/lib/azure_fota/Kconfig
+++ b/subsys/net/lib/azure_fota/Kconfig
@@ -8,6 +8,7 @@ menuconfig AZURE_FOTA
 	bool "Azure FOTA library [EXPERIMENTAL]"
 	depends on FOTA_DOWNLOAD
 	depends on CJSON_LIB
+	select EXPERIMENTAL
 
 if AZURE_FOTA
 

--- a/subsys/net/lib/azure_iot_hub/Kconfig
+++ b/subsys/net/lib/azure_iot_hub/Kconfig
@@ -13,6 +13,7 @@ config $(module)
 	prompt "Azure IoT Hub [EXPERIMENTAL]" if !CLOUD_SERVICE_MUTUAL_EXCLUSIVE
 	select MQTT_LIB
 	select MQTT_LIB_TLS
+	select EXPERIMENTAL
 
 if AZURE_IOT_HUB
 

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 56899c3147f6758e0856d5d7c27c97a9227973c4
+      revision: 81e2be611e358bb1d6a8034b410a0da93fbda0a8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit updates sdk-zephyr to revision:
https://github.com/nrfconnect/sdk-zephyr/pull/643

This revision includes support for the new Zephyr Kconfig experimental
feature which allows users to enable `WARN_EXPERIMENTAL` which will
print a warning at CMake configure time if any experimental Zephyr
features has been enabled.

Jira: NCSDK-6336

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>