### PR TITLE
scripts: hid_configurator: Inform about BlueZ issues

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -617,7 +617,7 @@ NCSDK-8304: HID configurator issues for peripherals connected over Bluetooth® L
   Using :ref:`nrf_desktop_config_channel_script` for peripherals connected to host directly over Bluetooth LE may result in receiving improper HID feature report ID.
   In such case, the device will provide HID input reports, but it cannot be configured with the HID configurator.
 
-  **Workaround:** Connect the nRF Desktop peripheral through USB or using the nRF Desktop dongle.
+  **Workaround:** Use BlueZ in version 5.56 or higher.
 
 .. rst-class:: v1-6-1 v1-6-0 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 

--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -78,8 +78,9 @@ Complete the following steps:
       pip3 install --user -r requirements.txt
 
    .. note::
-       When using the configuration channel for Bluetooth LE devices on Linux, use the BlueZ version 5.44 or higher.
-       In earlier versions, the HID device attached by BlueZ could obtain wrong VID and PID values (ignoring values in Device Information Service), which would stop HIDAPI from opening the device.
+       When using the configuration channel for Bluetooth LE devices on Linux, use the BlueZ version 5.56 or higher.
+       In versions earlier than 5.44, the HID device attached by BlueZ could obtain wrong VID and PID values (ignoring values in Device Information Service), which would stop HIDAPI from opening the device.
+       In versions earlier than 5.56, the HID device attached by BlueZ might provide incomplete HID feature report on get operation.
 
    Additionally, to call the Python script on Linux without root rights, install the provided udev rule :file:`99-hid.rules` file by copying it to :file:`/etc/udev/rules.d` and replugging the device.
 


### PR DESCRIPTION
Change updates known issues with BlueZ that could replicate when HID configurator configures device connected directly over Bluetooth on Linux.

Jira: NCSDK-8304