### PR TITLE
doc: Remove latin from nrf connect sdk docs

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -10,7 +10,7 @@ nRF9160: Asset Tracker
 .. note::
    The Asset Tracker application is deprecated and succeeded by the :ref:`asset_tracker_v2` application.
 
-The Asset Tracker demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160-based kit to the `nRF Cloud`_ via LTE, transmit GPS and sensor data, and retrieve information about the device.
+The Asset Tracker demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160-based kit to the `nRF Cloud`_ through LTE, transmit GPS and sensor data, and retrieve information about the device.
 
 Overview
 ********
@@ -297,7 +297,7 @@ This application uses the following |NCS| libraries and drivers:
 * ``drivers/sensor/sensor_sim``
 * :ref:`dk_buttons_and_leds_readme`
 * :ref:`lte_lc_readme`
-* |NCS| modules abstracted via the LwM2M carrier OS abstraction layer (:file:`lwm2m_os.h`)
+* |NCS| modules abstracted by the LwM2M carrier OS abstraction layer (:file:`lwm2m_os.h`)
 
 .. include:: /libraries/bin/lwm2m_carrier/app_integration.rst
   :start-after: lwm2m_osal_mod_list_start

--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -24,7 +24,7 @@ Hence, this application is not backward compatible to the :ref:`asset_tracker` a
 Overview
 ********
 
-The application samples sensor data and publishes the data to a connected cloud service over TCP/IP via LTE.
+The application samples sensor data and publishes the data to a connected cloud service over TCP/IP through LTE.
 As of now, the application supports the following cloud services and the corresponding cloud-side instances:
 
 +---------------------------+---------------------------------------------------------------------------------------+

--- a/applications/connectivity_bridge/README.rst
+++ b/applications/connectivity_bridge/README.rst
@@ -71,7 +71,7 @@ Testing
 
 After programming the sample to your kit, test it by performing the following steps:
 
-1. Connect the kit to the host via a USB cable.
+1. Connect the kit to the host using a USB cable.
 #. Observe that the CDC ACM devices enumerate on the USB host (COM ports on Windows, /dev/tty* on Linux).
 #. Use a serial client on the USB host to communicate over the kit's UART pins.
 

--- a/applications/machine_learning/README.rst
+++ b/applications/machine_learning/README.rst
@@ -132,12 +132,12 @@ If you build this application for the nRF53 DK, it enables additional features s
 
 * MCUboot bootloader with serial recovery and multi-image update.
 * Static configuration of :ref:`partition_manager`.
-* DFU over-the-air via Simple Management Protocol over Bluetooth.
+* DFU over-the-air using Simple Management Protocol over Bluetooth.
 
 See :ref:`ug_thingy53` for detailed information about the mentioned features.
 
 The nRF53 DK has a J-Link debug IC that can be used to program the firmware.
-Alternatively, firmware can be updated over MCUBoot serial recovery or DFU over-ther-air via Simple Management Protocol over Bluetooth.
+Alternatively, firmware can be updated over MCUBoot serial recovery or DFU over-ther-air using Simple Management Protocol over Bluetooth.
 Keep in mind that if you use bootloader to update firmware, the new firmware must be compatible with used bootloader and partition map.
 
 The nRF53 Development Kit uses RTT as logger's backend.

--- a/applications/nrf_desktop/doc/ble_qos.rst
+++ b/applications/nrf_desktop/doc/ble_qos.rst
@@ -126,7 +126,7 @@ The thread is used to periodically perform the following operations:
 If the :kconfig:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE` Kconfig option is set, the module prints the following information through the virtual COM port:
 
 * HID report rate
-   The module counts the number of HID input reports received via Bluetoooth LE and prints the report rate through the virtual COM port every 100 packets.
+   The module counts the number of HID input reports received through Bluetoooth LE and prints the report rate through the virtual COM port every 100 packets.
    The report rate is printed with a timestamp.
 
    Example output:

--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -219,7 +219,7 @@ Syntax
 
 * The ``<sec_tag>`` parameter is an integer.
   It indicates to the modem the credential of the security tag to be used for establishing a secure connection.
-  It is associated with a credential, i.e. certificate or PSK. The credential should be stored on the modem side beforehand.
+  It is associated with a credential, that is, a certificate or PSK. The credential should be stored on the modem side beforehand.
 
 * The ``<peer_verify>`` parameter can accept one of the following values:
 

--- a/doc/nrf/dm_code_base.rst
+++ b/doc/nrf/dm_code_base.rst
@@ -128,4 +128,4 @@ The empty diff means you can always use:
 
 Additionally, both the old and new histories are committed sequentially into the ``revision`` fields for these projects in the :file:`nrf/west.yml` west
 manifest file.
-This means you can always combine ``git bisect`` in the ``nrf`` repository with ``west update`` at each bisection point to diagnose regressions, etc.
+This means you can always combine ``git bisect`` in the ``nrf`` repository with ``west update`` at each bisection point to diagnose regressions and the rest.

--- a/doc/nrf/dm_managing_code.rst
+++ b/doc/nrf/dm_managing_code.rst
@@ -33,7 +33,7 @@ To obtain a fresh copy of the |NCS| at revision ``{revision}`` and place it in a
   west update
 
 Replace ``{revision}`` with any revision you wish to obtain.
-This can be ``main`` if you want the latest state, or any released version (e.g. |release_tt|).
+This can be ``main`` if you want the latest state, or any released version (for example, |release_tt|).
 If you omit the ``--mr`` parameter, west defaults to ``main``.
 
 This is the procedure used for :ref:`getting the nRF Connect SDK code <cloning_the_repositories>` when :ref:`gs_installing`.

--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -278,7 +278,7 @@ Glossary
       A machine-to-machine (M2M) connectivity protocol used by some IoT devices.
       It is designed as an extremely lightweight publish/subscribe messaging transport.
       It is useful for connections with remote locations where a small code footprint is required and/or network bandwidth is at a premium.
-      For example, it has been used in sensors communicating to a broker via satellite link, over occasional dial-up connections with healthcare providers, and in a range of home automation and small device scenarios.
+      For example, it has been used in sensors communicating to a broker through a satellite link, over occasional dial-up connections with healthcare providers, and in a range of home automation and small device scenarios.
 
    Microcontroller Unit (MCU)
       A small computer on an integrated circuit.

--- a/doc/nrf/gs_testing.rst
+++ b/doc/nrf/gs_testing.rst
@@ -38,10 +38,10 @@ Connect with the following settings:
  * No parity
  * HW flow control: None
 
-If you want to send commands via UART, make sure to configure the required line endings and turn on local echo and local line editing:
+If you want to send commands through UART, make sure to configure the required line endings and turn on local echo and local line editing:
 
 .. figure:: /images/putty.svg
-   :alt: PuTTY configuration for sending commands via UART
+   :alt: PuTTY configuration for sending commands through UART
 
 UART can also be used for logging purposes as one of the :ref:`logging backends <ug_logging_backends>`.
 
@@ -67,8 +67,8 @@ SEGGER's J-Link RTT can also be used for logging purposes as one of the :ref:`lo
 
 .. _testing_rtt_connect:
 
-Connecting via RTT
-==================
+Connecting using RTT
+====================
 
 To run RTT on your platform, complete the following steps:
 

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -199,7 +199,7 @@ Receive error with large packets
 .. rst-class:: v1-0-0 v0-4-0 v0-3-0
 
 Modem FW reset on debugger connection through SWD
-  If a debugger (for example, J-Link) is connected via SWD to the nRF9160, the modem firmware will reset.
+  If a debugger (for example, J-Link) is connected through SWD to the nRF9160, the modem firmware will reset.
   Therefore, the LTE modem cannot be operational during debug sessions.
 
 .. rst-class:: v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-1 v1-5-0

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_sat_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_sat_srv.rst
@@ -18,7 +18,7 @@ States
 
 Saturation: ``uint16_t``
     The Saturation controls the light's color saturation.
-    If the Saturation of a light is ``0``, the light's color is a completely gray scale, i.e. white light.
+    If the Saturation of a light is ``0``, the light's color is a completely gray scale, that is, white light.
     If the Saturation of a light is the maximum value of ``65535``, the color should be fully saturated.
 
     The Saturation state power-up behavior is determined by the On Power Up state of the extended :ref:`bt_mesh_ponoff_srv_readme`:

--- a/doc/nrf/libraries/bluetooth_services/mesh/scene_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/scene_srv.rst
@@ -56,7 +56,7 @@ Adding scene data for a model
 *****************************
 
 Every model that needs to store its state in scenes must register a :c:type:`bt_mesh_scene_entry` structure containing callbacks for storing and recalling the scene data.
-The scene entry must be declared using :c:macro:`BT_MESH_SCENE_ENTRY_SIG` for SIG defined models (e.g. from the model specification), or :c:macro:`BT_MESH_SCENE_ENTRY_VND` for vendor-specific models.
+The scene entry must be declared using :c:macro:`BT_MESH_SCENE_ENTRY_SIG` for SIG defined models (for example, from the model specification), or :c:macro:`BT_MESH_SCENE_ENTRY_VND` for vendor-specific models.
 These macros will allocate the structure in flash, and make them known to the Scene Server model.
 
 For instance, the Generic OnOff Server model defines its scene entry by declaring a :c:type:`bt_mesh_scene_entry` structure with the Generic OnOff Server model ID and a set of callbacks:

--- a/doc/nrf/libraries/bluetooth_services/mesh/time_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/time_srv.rst
@@ -27,7 +27,7 @@ To ensure consistent synchronization, the Time Server model should be configured
 
    To ensure a high level of accuracy, Time Status messages are always transmitted one hop at a time if it is sent as an unsolicited message.
    Every mesh node without access to the Time Authority that needs access to the common time reference must be within the radio range of at least one other node with the Time Server model.
-   Time Server nodes that have no neighboring Time Servers need to get this information in some other way (e.g. getting time from the Time Authority).
+   Time Server nodes that have no neighboring Time Servers need to get this information in some other way (for example, getting time from the Time Authority).
 
 Roles
 *****

--- a/doc/nrf/libraries/caf/leds.rst
+++ b/doc/nrf/libraries/caf/leds.rst
@@ -13,7 +13,7 @@ The source of such events could be any other module in |NCS|.
 The module uses Zephyr's :ref:`zephyr:led_api` driver for setting the LED color, either RGB or monochromatic.
 Zephyr's LED driver can use the implementation based on either GPIO or PWM.
 Use the PWM-based implementation to achieve smooth changes of brightness.
-Use the GPIO-based implementation if your board does not support PWM or if you want to control LEDs connected via GPIO expander.
+Use the GPIO-based implementation if your board does not support PWM or if you want to control LEDs connected using the GPIO expander.
 
 Configuration
 *************
@@ -192,7 +192,7 @@ Enabling the GPIOs
 ~~~~~~~~~~~~~~~~~~
 
 In general, boards in Zephyr configure and enable the GPIO drivers by default, so no additional configuration is needed.
-You can also use the LED GPIO driver to control LEDs connected via a GPIO expander supported by Zephyr.
+You can also use the LED GPIO driver to control LEDs connected using a GPIO expander supported by Zephyr.
 For example, the DTS configuration of the ``thingy52_nrf52832`` board supports ``sx1509b`` GPIO expander, which is used to control lightwell RGB LEDs.
 
 Enabling the LED GPIO nodes
@@ -205,7 +205,7 @@ There is no limit to the number of node instances you can create.
 The LED GPIO is configured as a node that is compatible with ``gpio-leds``.
 The following code snippets show examples of DTS nodes:
 
-* Example 1 - RGB LED controlled via GPIO expander (``sx1509b``)
+* Example 1 - RGB LED controlled using GPIO expander (``sx1509b``)
 
   .. code-block:: none
 

--- a/doc/nrf/libraries/networking/download_client.rst
+++ b/doc/nrf/libraries/networking/download_client.rst
@@ -21,11 +21,11 @@ The library supports HTTP, HTTPS (TLS 1.2), CoAP, and CoAPS (DTLS 1.2) over IPv4
 HTTP and HTTPS (TLS 1.2)
 ========================
 
-In the case of download via HTTP, the library sends only one HTTP request to the server and receives only one HTTP response.
+In the case of download using HTTP, the library sends only one HTTP request to the server and receives only one HTTP response.
 
 .. _download_client_https:
 
-In the case of download via HTTPS, it is carried out through `Content-Range requests (IETF RFC 7233)`_ due to memory constraints that limit the maximum HTTPS message size to 2 kilobytes.
+In the case of download using HTTPS, it is carried out through `Content-Range requests (IETF RFC 7233)`_ due to memory constraints that limit the maximum HTTPS message size to 2 kilobytes.
 The library thus sends and receives as many requests and responses as the number of fragments that constitutes the download.
 For example, to download a file of size 47 kilobytes file with a fragment size of 2 kilobytes, a total of 24 HTTP GET requests are sent.
 It is therefore recommended to use the largest fragment size to minimize the network usage.

--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -197,7 +197,7 @@ Initialization
 ==============
 
 To use a defined Cloud API backend, a binding must be obtained using the Cloud API function :c:func:`cloud_get_binding`, to which you can pass the name of the desired backend.
-The nRF Cloud library defines the Cloud API backend as ``NRF_CLOUD`` via the :c:macro:`CLOUD_BACKEND_DEFINE` macro.
+The nRF Cloud library defines the Cloud API backend as ``NRF_CLOUD`` using the :c:macro:`CLOUD_BACKEND_DEFINE` macro.
 
 The backend must be initialized using the :c:func:`cloud_init` function, with the binding, and a function pointer to user-defined Cloud API event handler as parameters.
 If :c:func:`cloud_init` returns success, the backend is ready for use.

--- a/doc/nrf/libraries/others/bl_crypto.rst
+++ b/doc/nrf/libraries/others/bl_crypto.rst
@@ -9,7 +9,7 @@ Bootloader crypto
 
 The bootloader crypto library is the cryptography library that is used by the :ref:`bootloader`.
 
-The API is public because applications that are booted by the immutable bootloader can call functions from this library via the bootloader's code, through external APIs.
+The API is public because applications that are booted by the immutable bootloader can call functions from this library using the bootloader's code, through external APIs.
 See :ref:`doc_fw_info_ext_api` for more information.
 
 The library provides the following functionality:
@@ -28,7 +28,7 @@ When using the library, you can choose between the following backends:
 
 * Hardware backend :ref:`nrf_cc310_bl_readme` (can only be used if Arm CryptoCell CC310 is available)
 * Software backend :ref:`nrf_oberon_readme`
-* Another image's instance of the bootloader crypto library, called via external APIs.
+* Another image's instance of the bootloader crypto library, called through external APIs.
   The other image chooses its own backend.
 
 To configure which backend is used for hashing, set one of the following configuration options:

--- a/doc/nrf/libraries/others/bl_validation.rst
+++ b/doc/nrf/libraries/others/bl_validation.rst
@@ -9,7 +9,7 @@ Bootloader firmware validation
 
 The bootloader firmware validation library provides the function that the :ref:`bootloader` uses to validate a firmware image before booting it.
 
-The API is public because applications that are booted by the immutable bootloader can call the function from this library via the bootloader's code, through external APIs.
+The API is public because applications that are booted by the immutable bootloader can call the function from this library using the bootloader's code, through external APIs.
 See :ref:`doc_fw_info_ext_api` for more information.
 Using this mechanism can be useful when the application receives a DFU package and wants to determine whether it will be accepted by the bootloader.
 

--- a/doc/nrf/libraries/others/hw_unique_key.rst
+++ b/doc/nrf/libraries/others/hw_unique_key.rst
@@ -77,7 +77,7 @@ Additionally, you can enable the :kconfig:`CONFIG_HW_UNIQUE_KEY_RANDOM` option t
 
 See :ref:`configure_application` for information on how to enable the required configuration options.
 
-You can then use the HUKs via the APIs in the :ref:`CC3xx platform libraries<nrf_cc3xx_platform_readme>`.
+You can then use the HUKs through the APIs in the :ref:`CC3xx platform libraries<nrf_cc3xx_platform_readme>`.
 You can also derive a key using :c:func:`hw_unique_key_derive_key`.
 
 .. caution::

--- a/doc/nrf/libraries/others/profiler.rst
+++ b/doc/nrf/libraries/others/profiler.rst
@@ -9,7 +9,7 @@ Profiler
 
 The Profiler provides an interface for logging and visualizing data for performance measurements, while the system is running.
 You can use the module to profile :ref:`event_manager` events or custom events.
-The output is provided via RTT and can be visualized in a custom Python backend.
+The output is provided using RTT and can be visualized in a custom Python backend.
 
 See the :ref:`profiler_sample` sample for an example of how to use the Profiler.
 
@@ -99,7 +99,7 @@ To use the tools, run the scripts on the command line:
 
 * ``python3 data_collector.py 5 test1``
 
-  Connects to the device via RTT, receives profiling data, and saves it to files.
+  Connects to the device using RTT, receives profiling data, and saves it to files.
   As command-line arguments, provide the time for collecting data (in seconds) and a dataset name.
 
 * ``python3 plot_from_files.py test1``
@@ -108,7 +108,7 @@ To use the tools, run the scripts on the command line:
 
 * ``python3 real_time_plot.py test1``
 
-  Connects to the device via RTT, plots data in real-time, and saves the data.
+  Connects to the device using RTT, plots data in real-time, and saves the data.
   As command line arguments, provide a dataset name.
 
 * ``python3 merge_data.py test_p sync_event_p test_c sync_event_c test_merged``

--- a/doc/nrf/libraries/others/supl_os_client.rst
+++ b/doc/nrf/libraries/others/supl_os_client.rst
@@ -46,7 +46,7 @@ A SET is a logical part of a device that supports communication with a SUPL netw
 SUPL session and transaction type
 =================================
 
-A typical SUPL client session is SET-based, i.e. the position is calculated based on SET.
+A typical SUPL client session is SET-based, that is, the position is calculated based on SET.
 See `SET-initiated SUPL collaboration`_ for more information.
 
 Each LPP session consists of one or more LPP transactions.

--- a/doc/nrf/libraries/zigbee/shell.rst
+++ b/doc/nrf/libraries/zigbee/shell.rst
@@ -436,7 +436,7 @@ Example:
 bdb factory_reset
 =================
 
-Perform a factory reset via local action.
+Perform a factory reset using local action.
 See Base Device Behavior specification chapter 9.5 for details.
 
 .. code-block::

--- a/doc/nrf/ug_bt_mesh_vendor_model_dev_overview.rst
+++ b/doc/nrf/ug_bt_mesh_vendor_model_dev_overview.rst
@@ -234,7 +234,7 @@ Either by using the :c:macro:`NET_BUF_SIMPLE` macro:
                                                     MESSAGE_SET_MAXLEN)),
     }
 
-Or e.g. in the :c:member:`bt_mesh_model_cb.init` callback, using :c:func:`net_buf_simple_init_with_data`:
+Or, for example, in the :c:member:`bt_mesh_model_cb.init` callback, using :c:func:`net_buf_simple_init_with_data`:
 
 .. code-block:: c
 
@@ -258,7 +258,7 @@ Or e.g. in the :c:member:`bt_mesh_model_cb.init` callback, using :c:func:`net_bu
 How to initialize :c:member:`bt_mesh_model_cb.init` is described later in this guide.
 
 When the model supports the model publication, configure the model to send messages at certain periods, regardless of the current model state, using the Configuration Client.
-This is useful for periodic data publication, e.g. if it changes over time.
+This is useful for periodic data publication, for example, if it changes over time.
 To support the model publication, initialize the :c:member:`bt_mesh_model_pub.update` callback.
 
 If the periodic publication is configured by the Configuration Client, the access layer calls the :c:member:`bt_mesh_model_pub.update` callback in the beginning of each publication period.
@@ -306,7 +306,7 @@ These callbacks are defined in :c:struct:`bt_mesh_model_cb`.
 
 :c:member:`bt_mesh_model_cb.init`
    This handler is called on every model instance during the mesh initialization.
-   Implement it if you need to do additional model initialization before the mesh stack starts, e.g. to initialize the model publication context.
+   Implement it if you need to do additional model initialization before the mesh stack starts, for example, to initialize the model publication context.
    If any of the model init callbacks return an error, the mesh subsystem initialization is aborted, and the error is returned to the caller of :c:func:`bt_mesh_init`.
 
 :c:member:`bt_mesh_model_cb.reset`

--- a/doc/nrf/ug_fw_update.rst
+++ b/doc/nrf/ug_fw_update.rst
@@ -74,7 +74,7 @@ Using Imgtool to generate keys
 
 :doc:`mcuboot:imgtool` is a Python tool maintained by MCUboot that handles public/private key pairs.
 
-It is also available as a PyPI package that you can install via ``pip``.
+It is also available as a PyPI package that you can install using ``pip``.
 However, when working within the |NCS| framework, it is recommended to use the script that is included in the fork of MCUboot used by the |NCS|.
 
 See below for examples of imgtool used to create some commonly used key types:

--- a/doc/nrf/ug_multiprotocol_support.rst
+++ b/doc/nrf/ug_multiprotocol_support.rst
@@ -15,7 +15,7 @@ For more information about how the SoftDevice Controller and MPSL work together,
 
 The multiprotocol solution available for Thread and Zigbee is dynamic.
 This means that it allows for running several radio protocols simultaneously without the time-expensive uninitialization and initialization in-between the switching.
-Switching between protocols requires only a reinitialization of the radio peripheral, since protocols may operate on different frequencies, modulations, etc.
+Switching between protocols requires only a reinitialization of the radio peripheral, since protocols may operate on different frequencies and modulations.
 
 Multiprotocol limitations in application development
 ****************************************************

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -261,8 +261,8 @@ If you want to enable the network core anyway, set the :kconfig:`CONFIG_BOARD_EN
 
 .. _ug_nrf5340_multi_image:
 
-Single image vs. multi-image build
-**********************************
+Multi-image builds
+*******************
 
 If a sample consists of several images (in this case, different images for the application core and for the network core), you can build these images separately or combined as a :ref:`multi-image build <ug_multi_image>`, depending on the sample configuration.
 

--- a/doc/nrf/ug_nrf91_features.rst
+++ b/doc/nrf/ug_nrf91_features.rst
@@ -155,7 +155,7 @@ Modem library
 =============
 
 The |NCS| applications for the nRF9160-based devices that communicate with the nRF9160 modem firmware must include the :ref:`nrfxlib:nrf_modem`.
-The :ref:`nrfxlib:nrf_modem` is released as an OS-independent binary library in the :ref:`nrfxlib` repository and it is integrated into |NCS| via an integration layer, ``nrf_modem_lib``.
+The :ref:`nrfxlib:nrf_modem` is released as an OS-independent binary library in the :ref:`nrfxlib` repository and it is integrated into |NCS| through an integration layer, ``nrf_modem_lib``.
 
 The Modem library integration layer fulfills the integration requirements of the Modem library in |NCS|.
 For more information on the integration, see :ref:`nrf_modem_lib_readme`.
@@ -234,7 +234,7 @@ Samples and applications implementing FOTA
 * :ref:`http_full_modem_update_sample` sample - performs a full firmware OTA update of the modem.
 * :ref:`http_modem_delta_update_sample` sample - performs a delta OTA update of the modem firmware.
 * :ref:`http_application_update_sample` sample - performs a basic application FOTA update.
-* :ref:`aws_fota_sample` sample - performs a FOTA update via MQTT and HTTP, where the firmware download is triggered through an AWS IoT job.
+* :ref:`aws_fota_sample` sample - performs a FOTA update using MQTT and HTTP, where the firmware download is triggered through an AWS IoT job.
 * :ref:`azure_fota_sample` sample - performs a FOTA update from the Azure IoT Hub.
 * :ref:`asset_tracker_v2` application - performs FOTA updates of the application, modem (delta), and boot (if enabled). It also supports nRF Cloud FOTA as well as AWS or Azure FOTA. Only one must be configured at a time.
 

--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -227,7 +227,7 @@ This enables connecting an SoC or a signal generator to the input.
 It also enables connecting the outputs to measurement tools or to antennas directly.
 The FEM can be configured through the pins available on the Arduino headers.
 
-The nRF21540's gain control, antenna switching, and modes are controlled via GPIO or SPI, or a combination of both.
+The nRF21540's gain control, antenna switching, and modes are controlled using GPIO or SPI, or a combination of both.
 GPIO and SPI are accessible through the Arduino Uno Rev3 compatible headers.
 The shield also features two additional SMA connectors hooked to the dual antenna ports from the RF FEM, to monitor the performance of the RF FEM using any equipment desired.
 The FEM SMA input can be connected to the nRF52 or nRF53 Series SoC RF output with a coaxial RF cable with SMA\SWF connectors.

--- a/doc/nrf/ug_tfm.rst
+++ b/doc/nrf/ug_tfm.rst
@@ -16,7 +16,7 @@ TF-M is the reference implementation of `Platform Security Architecture (PSA)`_.
 
 It provides a highly configurable set of software components to create a Trusted Execution Environment.
 This is achieved by a set of secure run time services such as Secure Storage, Cryptography, Audit Logs, and Attestation.
-Additionally, secure boot via MCUboot in TF-M ensures integrity of run time software and supports firmware upgrade.
+Additionally, secure boot through MCUboot in TF-M ensures integrity of run time software and supports firmware upgrade.
 
 Support for TF-M in |NCS| is currently experimental.
 TF-M is a framework which will be extended for new functions and use cases beyond the scope of SPM.

--- a/doc/nrf/ug_thingy53.rst
+++ b/doc/nrf/ug_thingy53.rst
@@ -329,14 +329,14 @@ MCUboot bootloader
 In addition to the configurations mentioned above, an application compatible with Thingy:53 is expected to enable the following features:
 
 * USB CDC ACM as backend for logger.
-  The logs are provided via USB CDC ACM to allow accessing them without additional hardware.
+  The logs are provided using USB CDC ACM to allow accessing them without additional hardware.
 
   Most of the Thingy:53-compatible applications and samples use only a single instance of USB CDC ACM that works as logger's backend.
   No other USB classes are used.
   These samples can share common USB product name, vendor ID, and product ID.
   If a sample supports additional USB classes or more than one instance of USB CDC ACM, it must use dedicated product name, vendor ID, and product ID.
 
-* DFU over-the-air via Simple Management Protocol over Bluetooth.
+* DFU over-the-air through Simple Management Protocol over Bluetooth.
   The application acts as GATT server and allows the connected Bluetooth Central to perform the firmware update for both application and network core.
   The Bluetooth configuration is updated to allow quick DFU data transfer.
   The application supports Simple Management Protocol (SMP) handlers related to:

--- a/doc/nrf/ug_thread_commissioning.rst
+++ b/doc/nrf/ug_thread_commissioning.rst
@@ -31,8 +31,9 @@ During the commissioning process, the devices involved are assigned one of the f
 * *Joiner Router* - Role for a router device that is one hop away from the Joiner device in the Thread network and is the sole device connected with the Joiner.
   Responds to the Discovery Request of the Joiner.
   Moreover, when chosen by the Joiner, it passes subsequent communication in a secure manner.
-* *Border Router* - Role for a device equipped with at least two interfaces (for example Thread and Wi-Fi, Ethernet, LTE etc.) that forwards data between a Thread network and a non-Thread network.
-  It can also be an interface for the Commissioner.
+* *Border Router* - Role for a device that forwards data between a Thread network and a non-Thread network. For this purpose, it is equipped with at least two interfaces, for example Wi-Fi, Ethernet, LTE, or other interface in addition to Thread.
+  The Border Router can also be an interface for the Commissioner.
+
 
   The Border Router role is usually combined with the *Border Agent* function, which accepts :ref:`petitions <thread_ot_commissioning_phases>` from the Commissioner candidate.
   It also relays commissioning messages between Thread Network and a Commissioner.

--- a/samples/bluetooth/alexa_gadget/README.rst
+++ b/samples/bluetooth/alexa_gadget/README.rst
@@ -48,7 +48,7 @@ The following table shows the mapping between capability configuration and suppo
 
 Gadget Custom Directives and Events
 ***********************************
-Custom directives sent from the peer to the Gadget are propagated via the ``BT_GADGETS_EVT_CUSTOM`` event.
+Custom directives sent from the peer to the Gadget are propagated using the ``BT_GADGETS_EVT_CUSTOM`` event.
 Custom directives do not require defining any additional data format.
 
 This sample includes a rudimentary custom event type that lets you send a JSON-formatted string with your chosen custom event name and namespace, using the function ``bt_gadgets_profile_custom_event_json_send``.
@@ -87,7 +87,7 @@ This sample depends on an external protobuf compiler tool - `Nanopb`_.
 
 This tool must be downloaded manually.
 
-Download Nanopb version **0.4.2** for your platform from the `Nanopb Downloads`_ site and extract the downloaded file to either this sample directory, the |NCS| installation directory, the tools folder in the |NCS| installation directory, or any other location where CMake can find it via a standard system PATH.
+Download Nanopb version **0.4.2** for your platform from the `Nanopb Downloads`_ site and extract the downloaded file to either this sample directory, the |NCS| installation directory, the tools folder in the |NCS| installation directory, or any other location where CMake can find it through a standard system PATH.
 Note that this sample directory is searched automatically for the presence of Nanopb.
 For example, if you are using Windows, download and extract **nanopb-0.4.2-windows-x86.zip** to this sample directory.
 

--- a/samples/nrf9160/agps/README.rst
+++ b/samples/nrf9160/agps/README.rst
@@ -8,7 +8,7 @@ nRF9160: A-GPS
    :depth: 2
 
 The A-GPS sample demonstrates how the `nRF Cloud`_ Assisted GPS (`A-GPS`_) feature or an external :ref:`SUPL client <supl_client>` can be used to implement A-GPS in your application.
-The sample uses the generic A-GPS library, which allows the selection of different A-GPS sources via the :kconfig:`CONFIG_AGPS_SRC_SUPL` configurable option.
+The sample uses the generic A-GPS library, which allows the selection of different A-GPS sources using the :kconfig:`CONFIG_AGPS_SRC_SUPL` configurable option.
 By default, `nRF Cloud`_ is used for A-GPS and cloud communication.
 
 Requirements

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -13,7 +13,7 @@ The sample enables you to use an external computer or MCU to send AT commands to
 Overview
 ********
 
-The AT Client sample acts as a proxy for sending directives to the nRF9160 modem via AT commands.
+The AT Client sample acts as a proxy for sending directives to the nRF9160 modem using AT commands.
 This facilitates the reading of responses or analyzing of events related to the nRF9160 modem.
 The commands can be initiated from a terminal or the `LTE Link Monitor`_, which is an application implemented as part of `nRF Connect for Desktop`_.
 

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -7,7 +7,7 @@ nRF9160: AWS FOTA
    :local:
    :depth: 2
 
-The Amazon Web Services firmware over-the-air (AWS FOTA) sample shows how to perform an over-the-air firmware update of an nRF9160 device via MQTT and HTTP. It is similar to the :ref:`http_application_update_sample`, except that the firmware download is triggered through an AWS IoT job.
+The Amazon Web Services firmware over-the-air (AWS FOTA) sample shows how to perform an over-the-air firmware update of an nRF9160 device using MQTT and HTTP. It is similar to the :ref:`http_application_update_sample`, except that the firmware download is triggered through an AWS IoT job.
 
 Overview
 *********

--- a/samples/nrf9160/cloud_client/README.rst
+++ b/samples/nrf9160/cloud_client/README.rst
@@ -8,7 +8,7 @@ nRF9160: Cloud client
    :depth: 2
 
 This sample connects to, and communicates with a compatible cloud service using the respective cloud backend firmware library.
-The sample connects via cellular network (LTE) and publishes a custom string in intervals or upon a button trigger, to the cloud service.
+The sample connects to the cloud service using cellular network (LTE) and publishes a custom string in intervals or upon a button trigger.
 
 Overview
 ********

--- a/samples/nrf9160/download/README.rst
+++ b/samples/nrf9160/download/README.rst
@@ -28,7 +28,7 @@ Overview
 The sample first initializes the :ref:`nrfxlib:nrf_modem` and AT communications.
 Next, it provisions a certificate to the modem using the :ref:`modem_key_mgmt` library if the :kconfig:`CONFIG_SAMPLE_SECURE_SOCKET` option is set.
 The provisioning of the certificates must be done before connecting to the LTE network since the certificates can only be provisioned when the device is not connected.
-The certificate file name and security tag can be configured via the :kconfig:`CONFIG_SAMPLE_SEC_TAG` and the :kconfig:`CONFIG_SAMPLE_CERT_FILE` options, respectively.
+The certificate file name and security tag can be configured using the :kconfig:`CONFIG_SAMPLE_SEC_TAG` and the :kconfig:`CONFIG_SAMPLE_CERT_FILE` options, respectively.
 
 The sample then performs the following actions:
 
@@ -40,7 +40,7 @@ The sample then performs the following actions:
 Downloading from a CoAP server
 ==============================
 
-To enable CoAP block-wise transfer, it is necessary to enable :ref:`Zephyr's CoAP stack <zephyr:coap_sock_interface>` via the :kconfig:`CONFIG_COAP` option.
+To enable CoAP block-wise transfer, it is necessary to enable :ref:`Zephyr's CoAP stack <zephyr:coap_sock_interface>` using the :kconfig:`CONFIG_COAP` option.
 
 Using TLS and DTLS
 ==================

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -9,13 +9,13 @@ nRF9160: LTE Sensor Gateway
 
 The LTE Sensor Gateway sample demonstrates how to transmit sensor data from an nRF9160 development kit to the `nRF Cloud`_.
 
-The sensor data is collected via Bluetooth® Low Energy, unlike the :ref:`asset_tracker` sample.
+The sensor data is collected using Bluetooth® Low Energy, unlike the :ref:`asset_tracker` sample.
 Therefore, this sample acts as a gateway between the Bluetooth LE and the LTE connections to nRF Cloud.
 
 Overview
 *********
 
-The sample connects via Bluetooth LE to a Thingy:52 running the factory pre-loaded application.
+The sample connects using Bluetooth LE to a Thingy:52 running the factory pre-loaded application.
 When the connection is established, it starts collecting data from two sensors:
 
 * The flip state of the Thingy:52

--- a/samples/nrf9160/lwm2m_carrier/README.rst
+++ b/samples/nrf9160/lwm2m_carrier/README.rst
@@ -36,7 +36,7 @@ After programming the sample and all prerequisites to the development kit, test 
 #. Open a terminal emulator and observe that the kit prints the following information::
 
         LWM2M Carrier library sample.
-#. Observe that the application receives events from the **LwM2M carrier** library via the registered event handler.
+#. Observe that the application receives events from the **LwM2M carrier** library using the registered event handler.
 
 
 Troubleshooting
@@ -56,7 +56,7 @@ Dependencies
 
 This sample uses the following |NCS| libraries:
 
-* |NCS| modules abstracted via the LwM2M carrier OS abstraction layer (:file:`lwm2m_os.h`)
+* |NCS| modules abstracted by the LwM2M carrier OS abstraction layer (:file:`lwm2m_os.h`)
 
   .. include:: /libraries/bin/lwm2m_carrier/app_integration.rst
     :start-after: lwm2m_osal_mod_list_start

--- a/samples/nrf9160/udp/README.rst
+++ b/samples/nrf9160/udp/README.rst
@@ -81,7 +81,7 @@ This configuration option, if set, allows the sample to request eDRX from the mo
 This configuration option, if set, allows the sample to request RAI for transmitted messages.
 
 .. note::
-   PSM, eDRX and RAI value or timers are set via the configurable options for the :ref:`lte_lc_readme` library.
+   PSM, eDRX and RAI value or timers are set using the configurable options for the :ref:`lte_lc_readme` library.
 
 
 Additional configuration

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -464,7 +464,7 @@ To test the Thread 1.2 features, complete the following steps:
          Done
 
       Observe that the reply latency is reduced to a value below 500 ms.
-      The reduction occurs because the transmission from the leader is performed via CSL, based on the CSL Information Elements sent by the CSL Receiver.
+      The reduction occurs because the transmission from the leader is performed using CSL, based on the CSL Information Elements sent by the CSL Receiver.
 
 Dependencies
 ************

--- a/samples/spm/README.rst
+++ b/samples/spm/README.rst
@@ -33,21 +33,21 @@ Secure Services
 
 The SPM can provide access to secure services to the application firmware.
 See the :ref:`lib_spm` library for information about the available services.
-See the :ref:`secure_services` for example code for using the secure services.
+For an example code using the secure services, see :ref:`secure_services`.
 
 Requirements for the application firmware
 =========================================
 
 * The application firmware must be located in the slot_ns flash partition.
-  For more details, see the partition configuration file for the chosen board (e.g. `nrf9160dk_nrf9160_partition_conf.dts`_ for the nRF9160 DK).
+  For more details, see the partition configuration file for the chosen board (for example, `nrf9160dk_nrf9160_partition_conf.dts`_ for the nRF9160 DK).
   Note that if you build your application firmware with the |NCS|, this requirement is automatically fulfilled.
 
-* The application firmware must be built as a non-secure firmware for the build target (e.g. nrf9160dk_nrf9160_ns for the nRF9160 DK).
+* The application firmware must be built as a non-secure firmware for the build target (for example, nrf9160dk_nrf9160_ns for the nRF9160 DK).
 
 Automatic building of SPM
 =========================
 
-The sample is automatically built by the non-secure applications when the non-secure build target is used (e.g. nrf9160dk_nrf9160_ns).
+The sample is automatically built by the non-secure applications when the non-secure build target is used (for example, nrf9160dk_nrf9160_ns).
 However, it is not a part of the non-secure application.
 
 Instead of programming SPM and the non-secure application at the same time, you might want to program them individually.

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -55,7 +55,7 @@ RAM partition types
 Default image RAM partition
    The default image RAM partition consists of all the RAM that is not defined as a permanent image RAM partition or placeholder RAM partition.
    It is the default RAM partition associated with an image and is set as the RAM region when linking the image.
-   If an image must reserve its RAM area permanently (i.e. at the same time as other images are running), it must use a permanent image RAM partition, described below.
+   If an image must reserve its RAM area permanently (that is, at the same time as other images are running), it must use a permanent image RAM partition, described below.
 
 .. _pm_permanent_image_ram_partition:
 
@@ -576,7 +576,7 @@ HEX files
 
 The Partition Manager may implicitly or explicitly assign a HEX file to a partition.
 
-Image partitions are implicitly assigned the compiled HEX file, i.e. the HEX file that is generated when building the corresponding image.
+Image partitions are implicitly assigned the compiled HEX file, that is, the HEX file that is generated when building the corresponding image.
 Container partitions are implicitly assigned the result of merging the HEX files that are assigned to the underlying partitions.
 Placeholder partitions are not implicitly assigned a HEX file.
 


### PR DESCRIPTION
NCSDK-12222
Remove Latin abbreviations from the
nrf connect sdk documents.

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>