### PR TITLE
caf: Fix coverity issue

### DIFF
--- a/include/caf/events/module_state_event.h
+++ b/include/caf/events/module_state_event.h
@@ -51,7 +51,7 @@ static inline size_t module_count(void)
  *
  * @return Module ID.
  */
-static inline const void * const module_id_get(size_t idx)
+static inline const void *module_id_get(size_t idx)
 {
 	if (idx >= module_count()) {
 		return NULL;


### PR DESCRIPTION
Solved coverity issue by removing const in return type

Jira: NCSDK-11371

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>