### PR TITLE
applications: nrf_desktop: Inform that config channel is disabled

### DIFF
--- a/applications/nrf_desktop/doc/config_channel.rst
+++ b/applications/nrf_desktop/doc/config_channel.rst
@@ -30,6 +30,10 @@ The library supports both Bluetooth® LE and USB.
 On the HID feature report level, the host can set or get report, either to or from the connected device.
 The host initiates all data exchange.
 
+.. note::
+   If the device supports multiple USB or Bluetooth® LE HID instances, only one USB HID instance and only one Bluetooth® LE HID instance can be used to configure the device.
+   Other HID instances ignore the HID report set method and respond with the disconnected status on the HID report get method to indicate that the HID instance is not used for configuration channel.
+
 Transaction request and response
 ********************************
 

--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -110,13 +110,12 @@ static int get_report(const struct device *dev,
 				err = config_channel_transport_get(&cfg_chan_transport,
 								   &buffer[1],
 								   length - 1);
-
-				if (err) {
-					LOG_WRN("Failed to process report get");
-				}
 			} else {
-				/* Configuration channel does not use this USB HID instance. */
-				memset(&buffer[1], 0, length - 1);
+				err = config_channel_transport_get_disabled(&buffer[1], length - 1);
+			}
+
+			if (err) {
+				LOG_WRN("Failed to process report get (err: %d)", err);
 			}
 
 			*len_to_set = length;

--- a/applications/nrf_desktop/src/util/config_channel_transport.c
+++ b/applications/nrf_desktop/src/util/config_channel_transport.c
@@ -240,6 +240,21 @@ int config_channel_transport_set(struct config_channel_transport *transport,
 	return 0;
 }
 
+int config_channel_transport_get_disabled(uint8_t *buffer, size_t length)
+{
+	int err = frame_length_check(length);
+
+	if (err) {
+		return err;
+	}
+
+	/* Recipient ID and Event ID are both set to zero. */
+	memset(buffer, 0, length);
+	buffer[CONFIG_STATUS_POS] = CONFIG_STATUS_DISCONNECTED;
+
+	return 0;
+}
+
 bool config_channel_transport_rsp_receive(struct config_channel_transport *transport,
 					  struct config_event *event)
 {

--- a/applications/nrf_desktop/src/util/config_channel_transport.h
+++ b/applications/nrf_desktop/src/util/config_channel_transport.h
@@ -96,6 +96,22 @@ int config_channel_transport_set(struct config_channel_transport *transport,
 				 const uint8_t *buffer, size_t length);
 
 /**
+ * @brief Handle a get operation and inform that the transport is disabled.
+ *
+ * Fills the buffer with response informing that the transport is disabled and cannot be used to
+ * configure device. If a given transport is disabled, set operation should be ignored and get
+ * operation should use this function to prepare response for host.
+ *
+ * The disabled transport returns disconnected status.
+ *
+ * @param buffer    Pointer to the buffer to be filled.
+ * @param length    Length of the data to be filled.
+ *
+ * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
+ */
+int config_channel_transport_get_disabled(uint8_t *buffer, size_t length);
+
+/**
  * @brief Handle the response received from higher layer.
  *
  * @param transport Pointer to the configuration channel transport instance.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -86,6 +86,7 @@ nRF Desktop
   * Updated information about custom build types.
   * Updated documentation for :ref:`nrf_desktop_usb_state`.
   * Updated documentation for :ref:`nrf_desktop_config_channel` and added more detailed protocol description.
+  * Updated :ref:`nrf_desktop_config_channel` to respond with the disconnected status to explicitly inform the host tools that the given HID instance cannot be used to configure device.
   * Updated documentation with information about forwarding boot reports.
     See the documenation page of nRF Desktop's :ref:`nrf_desktop_hid_forward` for details.
   * Fixed an issue that was causing the HID keyboard LEDs to remain turned on after host disconnection while no other hosts were connected.

--- a/scripts/hid_configurator/NrfHidDevice.py
+++ b/scripts/hid_configurator/NrfHidDevice.py
@@ -95,7 +95,6 @@ class NrfHidTransport():
             logging.error('Response too short')
             return None
 
-        # Report ID is not included in the feature report from device
         fmt = '{}{}s'.format(NrfHidTransport.HEADER_FORMAT, data_field_len)
 
         (report_id, rcpt, event_id, status, data_len, data) = struct.unpack(fmt, response_raw)
@@ -201,12 +200,6 @@ class NrfHidDevice():
 
         try:
             devlist = hid.enumerate(vid=vid)
-            # Config channel can use only first HID interface of nrf_desktop
-            # device. Other HID interfaces do not provide proper config channel
-            # response.
-            devlist = list(filter(lambda x: x['interface_number'] in (-1, 0),
-                                  devlist))
-
             for d in devlist:
                 dev = hid.Device(path=d['path'])
                 dev_active = False


### PR DESCRIPTION
Change adds explicit information that given HID instance cannot be used to configure device. Discovering hardware ID, board name or connected peers using this instance results in receiving disconnected status.

Jira: NCSDK-12276