### PR TITLE
applications: asset_tracket_v2: Correct config for tests

### DIFF
--- a/applications/asset_tracker_v2/tests/debug_module/boards/nrf9160dk_nrf9160_ns.conf
+++ b/applications/asset_tracker_v2/tests/debug_module/boards/nrf9160dk_nrf9160_ns.conf
@@ -1,3 +1,0 @@
-# The following option is required to silence the linker warning about orphan
-# sections. The event manager header files uses orphan sections.
-CONFIG_LINKER_ORPHAN_SECTION_PLACE=y

--- a/applications/asset_tracker_v2/tests/debug_module/boards/qemu_cortex_m3.conf
+++ b/applications/asset_tracker_v2/tests/debug_module/boards/qemu_cortex_m3.conf
@@ -1,3 +1,0 @@
-# The following option is required to silence the linker warning about orphan
-# sections. The event manager header files uses orphan sections.
-CONFIG_LINKER_ORPHAN_SECTION_PLACE=y

--- a/applications/asset_tracker_v2/tests/debug_module/prj.conf
+++ b/applications/asset_tracker_v2/tests/debug_module/prj.conf
@@ -12,3 +12,6 @@ CONFIG_EVENT_MANAGER=y
 
 # Event manager requires sys_reboot()
 CONFIG_REBOOT=y
+# The following option is required to silence the linker warning about orphan
+# sections. The event manager header files uses orphan sections.
+CONFIG_LINKER_ORPHAN_SECTION_PLACE=y

--- a/applications/asset_tracker_v2/tests/gps_module/boards/nrf9160dk_nrf9160_ns.conf
+++ b/applications/asset_tracker_v2/tests/gps_module/boards/nrf9160dk_nrf9160_ns.conf
@@ -1,3 +1,0 @@
-# The following option is required to silence the linker warning about orphan
-# sections. The event manager header files uses orphan sections.
-CONFIG_LINKER_ORPHAN_SECTION_PLACE=y

--- a/applications/asset_tracker_v2/tests/gps_module/boards/qemu_cortex_m3.conf
+++ b/applications/asset_tracker_v2/tests/gps_module/boards/qemu_cortex_m3.conf
@@ -1,3 +1,0 @@
-# The following option is required to silence the linker warning about orphan
-# sections. The event manager header files uses orphan sections.
-CONFIG_LINKER_ORPHAN_SECTION_PLACE=y

--- a/applications/asset_tracker_v2/tests/gps_module/prj.conf
+++ b/applications/asset_tracker_v2/tests/gps_module/prj.conf
@@ -19,3 +19,6 @@ CONFIG_EVENT_MANAGER=y
 
 # Event manager requires sys_reboot()
 CONFIG_REBOOT=y
+# The following option is required to silence the linker warning about orphan
+# sections. The event manager header files uses orphan sections.
+CONFIG_LINKER_ORPHAN_SECTION_PLACE=y


### PR DESCRIPTION
Adding CONFIG_LINKER_ORPHAN_SECTION_PLACE to all platforms.

Signed-off-by: David Dilner <david.dilner@nordicsemi.no>