### PR TITLE
doc: update HERE Positioning URL in link.txt

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -746,7 +746,7 @@
 
 .. _`mbedtls_memory_buffer_alloc_init`: https://tls.mbed.org/api/memory__buffer__alloc_8h.html#ac70d134be54133c272d8eab2cb85dfbf
 
-.. _`HERE Positioning`: https://www.here.com/platform/tracking-positioning-solutions/positioning
+.. _`HERE Positioning`: https://www.here.com/platform/positioning
 
 .. _`Skyhook Precision Location`: https://www.skyhook.com/precision-location
 


### PR DESCRIPTION
update the 'HERE Positioning' URL to the correct external
URL for the 'Multicell location' libraries.

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>