### PR TITLE
west.yml: Update Zephyr revision to bring FLASH_AREA_DEVICE macro

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 15be5e615498377e9326cb2eb5819c7c62005299
+      revision: pull/649/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The commit updates west.yml to bring Zephyr commit:
  1455c8d361 [nrf fromtree] storage/flash_map: Add FLASH_AREA_DEVICE macro

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>