### PR TITLE
bluetooth: services: nus: Add nus-client context upon msg reception.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -343,8 +343,10 @@ Libraries
 
 This section provides detailed lists of changes by :ref:`library <libraries>`.
 
-Bluetooth libraries
--------------------
+Bluetooth libraries and services
+--------------------------------
+
+Updated:
 
 * :ref:`ble_rpc` library:
 
@@ -355,6 +357,10 @@ Bluetooth libraries
 
   * Aligned the Silvair EnOcean Proxy Server model implementation with rev 1.2 of the Silvair EnOcean Switch Mesh Proxy Server specification.
   * Fixed an issue where the Sensor Client API can be used as non-blocking by passing NULL to the arguments that are used to fill the response.
+
+* :ref:`nus_client_readme` library:
+
+  * Added context to functions :c:func:`bt_nus_client.received`, :c:func:`bt_nus_client.sent` and :c:func:`bt_nus_client.unsubscribed` to enable their use in a multi-client application.
 
   Added:
 

--- a/include/bluetooth/services/nus_client.h
+++ b/include/bluetooth/services/nus_client.h
@@ -43,6 +43,8 @@ struct bt_nus_client_handles {
 	uint16_t tx_ccc;
 };
 
+struct bt_nus_client;
+
 /** @brief NUS Client callback structure. */
 struct bt_nus_client_cb {
 	/** @brief Data received callback.
@@ -50,29 +52,33 @@ struct bt_nus_client_cb {
 	 * The data has been received as a notification of the NUS TX
 	 * Characteristic.
 	 *
+	 * @param[in] nus  NUS Client instance.
 	 * @param[in] data Received data.
 	 * @param[in] len Length of received data.
 	 *
 	 * @retval BT_GATT_ITER_CONTINUE To keep notifications enabled.
 	 * @retval BT_GATT_ITER_STOP To disable notifications.
 	 */
-	uint8_t (*received)(const uint8_t *data, uint16_t len);
+	uint8_t (*received)(struct bt_nus_client *nus, const uint8_t *data, uint16_t len);
 
 	/** @brief Data sent callback.
 	 *
 	 * The data has been sent and written to the NUS RX Characteristic.
 	 *
+	 * @param[in] nus  NUS Client instance.
 	 * @param[in] err ATT error code.
 	 * @param[in] data Transmitted data.
 	 * @param[in] len Length of transmitted data.
 	 */
-	void (*sent)(uint8_t err, const uint8_t *data, uint16_t len);
+	void (*sent)(struct bt_nus_client *nus, uint8_t err, const uint8_t *data, uint16_t len);
 
 	/** @brief TX notifications disabled callback.
 	 *
 	 * TX notifications have been disabled.
+	 *
+	 * @param[in] nus  NUS Client instance.
 	 */
-	void (*unsubscribed)(void);
+	void (*unsubscribed)(struct bt_nus_client *nus);
 };
 
 /** @brief NUS Client structure. */

--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -60,8 +60,11 @@ static K_FIFO_DEFINE(fifo_uart_rx_data);
 static struct bt_conn *default_conn;
 static struct bt_nus_client nus_client;
 
-static void ble_data_sent(uint8_t err, const uint8_t *const data, uint16_t len)
+static void ble_data_sent(struct bt_nus_client *nus, uint8_t err,
+					const uint8_t *const data, uint16_t len)
 {
+	ARG_UNUSED(nus);
+
 	struct uart_data_t *buf;
 
 	/* Retrieve buffer context. */
@@ -75,8 +78,11 @@ static void ble_data_sent(uint8_t err, const uint8_t *const data, uint16_t len)
 	}
 }
 
-static uint8_t ble_data_received(const uint8_t *const data, uint16_t len)
+static uint8_t ble_data_received(struct bt_nus_client *nus,
+						const uint8_t *data, uint16_t len)
 {
+	ARG_UNUSED(nus);
+
 	int err;
 
 	for (uint16_t pos = 0; pos != len;) {

--- a/subsys/bluetooth/services/nus_client.c
+++ b/subsys/bluetooth/services/nus_client.c
@@ -34,14 +34,14 @@ static uint8_t on_received(struct bt_conn *conn,
 		params->value_handle = 0;
 		atomic_clear_bit(&nus->state, NUS_C_TX_NOTIF_ENABLED);
 		if (nus->cb.unsubscribed) {
-			nus->cb.unsubscribed();
+			nus->cb.unsubscribed(nus);
 		}
 		return BT_GATT_ITER_STOP;
 	}
 
 	LOG_DBG("[NOTIFICATION] data %p length %u", data, length);
 	if (nus->cb.received) {
-		return nus->cb.received(data, length);
+		return nus->cb.received(nus, data, length);
 	}
 
 	return BT_GATT_ITER_CONTINUE;
@@ -63,7 +63,7 @@ static void on_sent(struct bt_conn *conn, uint8_t err,
 
 	atomic_clear_bit(&nus_c->state, NUS_C_RX_WRITE_PENDING);
 	if (nus_c->cb.sent) {
-		nus_c->cb.sent(err, data, length);
+		nus_c->cb.sent(nus_c, err, data, length);
 	}
 }
 


### PR DESCRIPTION
This PR attempts to provide context to received callbacks of NUS Client library. This change is done with the objective to enable multi-connection handling capabilities.

- Changed received callback to include nus instance, to allow the
module to work as a multi-client instance.
- Adapted nus-client sample to implement this feature.

Signed-off-by: Luis Ubieda <luisf@croxel.com>