### PR TITLE
net: lib: aws_iot: Cleanup error logging

### DIFF
--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -1281,9 +1281,11 @@ start:
 
 		if ((fds[0].revents & POLLIN) == POLLIN) {
 			err = aws_iot_input();
-			LOG_ERR("Cloud MQTT input error: %d", err);
-			if (err == -ENOTCONN) {
-				break;
+			if (err) {
+				LOG_ERR("Cloud MQTT input error: %d", err);
+				if (err == -ENOTCONN) {
+					break;
+				}
 			}
 
 			if (atomic_get(&aws_iot_disconnected) == 1) {


### PR DESCRIPTION
Move log to avoid error being printed for every call to
`aws_iot_input()`.