### PR TITLE
applications: asset_tracker_v2: Set `supports_shutdown` to false

### DIFF
--- a/applications/asset_tracker_v2/src/modules/debug_module.c
+++ b/applications/asset_tracker_v2/src/modules/debug_module.c
@@ -70,7 +70,7 @@ K_THREAD_DEFINE(mflt_send_thread, CONFIG_DEBUG_MODULE_MEMFAULT_THREAD_STACK_SIZE
 static struct module_data self = {
 	.name = "debug",
 	.msg_q = NULL,
-	.supports_shutdown = true,
+	.supports_shutdown = false,
 };
 
 /* Handlers */

--- a/applications/asset_tracker_v2/tests/debug_module/src/debug_module_test.c
+++ b/applications/asset_tracker_v2/tests/debug_module/src/debug_module_test.c
@@ -97,7 +97,7 @@ void setup_debug_module_in_init_state(void)
 	static struct module_data expected_module_data = {
 		.name = "debug",
 		.msg_q = NULL,
-		.supports_shutdown = true,
+		.supports_shutdown = false,
 	};
 
 	__wrap_watchdog_register_handler_ExpectAnyArgs();


### PR DESCRIPTION
Set `supports_shutdown` flag to false for the debug module.
The debug module does not support acking of shutdown events sent from
the util module. Without this change the util module expects an
`SHUTDOWN_READY` from the debug module. This prevents the util module
from rebooting the application fast when all supported module has
ACKed the shutdown request.