### PR TITLE
lib: agps: deprecate the A-GPS library

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -259,6 +259,10 @@ Modem libraries
   * Added logging on modem errors.
   * Changed the return values on modem errors to -ENOEXEC to avoid conflicts with return of other positive values.
 
+* A-GPS library:
+
+  * The A-GPS library has been deprecated in favor of using the :ref:`lib_nrf_cloud_agps` library directly.
+
 Libraries for networking
 ------------------------
 

--- a/include/modem/agps.h
+++ b/include/modem/agps.h
@@ -7,6 +7,9 @@
 /**
  * @file agps.h
  * @brief Public APIs for the A-GPS library.
+ *
+ * @deprecated since v1.8.0.
+ *
  * @defgroup agps A-GPS library
  * @{
  */


### PR DESCRIPTION
Marked the A-GPS library deprecated since nRF Connect SDK v1.8.0. A-GPS should be used directly for example from the nRF Cloud library.

After the A-GPS sample has been removed (PR #6048), only the already deprecated Asset Tracker is still using the library.