### PR TITLE
subsys: dfu_target: use new modem delta dfu interface

### DIFF
--- a/doc/nrf/libraries/dfu/dfu_target.rst
+++ b/doc/nrf/libraries/dfu/dfu_target.rst
@@ -55,11 +55,11 @@ On the next reboot, the device will run the new firmware.
 Modem delta upgrades
 ====================
 
-This type of firmware upgrade opens a socket into the modem and passes the data given to the :c:func:`dfu_target_write` function through the socket.
-The modem stores the data in the memory location for firmware patches.
+This type of firmware upgrade is used for delta upgrades to the modem firmware (see: :ref:`nrf_modem_delta_dfu`).
+The modem stores the data in the memory location reserved for firmware patches.
 If there is already a firmware patch stored in the modem, the library requests the modem to delete the old firmware patch, to make space for the new patch.
 
-When the complete transfer is done, call the :c:func:`dfu_target_done` function to request the modem to apply the patch, and to close the socket.
+When the transfer is completed, call the :c:func:`dfu_target_done` function to request the modem to apply the patch.
 On the next reboot, the modem will try to apply the patch.
 
 .. _lib_dfu_target_full_modem_update:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -186,6 +186,10 @@ Libraries for networking
 
   * Fixed an issue where the application would not be notified of errors originating from inside :c:func:`download_with_offset`. In the http_update samples, this would result in the dfu start button interrupt being disabled after a connect error in :c:func:`download_with_offset` after a disconnect during firmware download.
 
+* :ref:`lib_dfu_target` library:
+
+  * Updated the implementation of modem delta upgrades in the DFU target library to use the new socketless interface provided by the :ref:`nrf_modem`.
+
 Other libraries
 ---------------
 


### PR DESCRIPTION
Modem DFU socket is to be removed from modem library and can
no longer be used in DFU target.

This change DFU target modem delta dfu to use the new
socketless interface.

Jira: NCSDK-10725

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>
Signed-off-by: Francesco Servidio <francesco.servidio@nordicsemi.no>