### PR TITLE
samples: dtm: Fix UART baudrate for nRF5340

### DIFF
--- a/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,3 +1,8 @@
+&uart0 {
+	status = "okay";
+	current-speed = <19200>;
+};
+
 &spi0 {
 	status = "disabled";
 };


### PR DESCRIPTION
The generic app.overlay file with UART configuration
is not applied if board has it own overlay file.