### PR TITLE
scripts: unity: Handle attributes used for structs and functions

### DIFF
--- a/scripts/unity/func_name_list.py
+++ b/scripts/unity/func_name_list.py
@@ -13,6 +13,11 @@ def func_names_from_header(in_file, out_file):
         content = f_in.read()
 
     with open(out_file, 'w') as f_out:
+        # remove attributes, attributes can be followed by semicolon (e.g. after struct)
+        # or by space when it's added before struct, variable or function.
+        attribute_pattern = re.compile(r'__attribute__\(\(.+?(?=(\s|;))', re.M | re.S)
+        content = attribute_pattern.sub(r"", content)
+
         # Regex match all function names in the header file
         x = re.findall(r"^\s*(?:\w+[*\s]+)+(\w+?)\([^\\]*?\);",
                        content, re.M | re.S)

--- a/scripts/unity/header_prepare.py
+++ b/scripts/unity/header_prepare.py
@@ -27,6 +27,14 @@ def header_prepare(in_file, out_file, out_wrap_file):
 
     content = cpp_comments_pattern.sub(r"", content)
 
+    # remove weak used attribute if any api function has it
+    weak_pattern = re.compile(r'__attribute__\(\((weak|used)\)\)', re.M | re.S)
+    content = weak_pattern.sub(r"", content)
+
+    # remove __aligned
+    aligned_pattern = re.compile(r'__aligned\(.+?\)', re.M | re.S)
+    content = aligned_pattern.sub(r"", content)
+
     # remove inline syscalls
     static_inline_pattern = re.compile(
         r'(?:__deprecated\s+)?(?:static\s+inline\s+|inline\s+static\s+|static\s+ALWAYS_INLINE\s+|__STATIC_INLINE\s+)'

--- a/tests/unity/example_test/src/foo/foo.h
+++ b/tests/unity/example_test/src/foo/foo.h
@@ -7,7 +7,7 @@
 #ifndef __FOO_H
 #define __FOO_H
 
-#include <toolchain/common.h>
+#include <toolchain/gcc.h>
 
 #include "foo_internal.h"
 // c++ comment
@@ -33,10 +33,26 @@ static inline int foo_execute(void)
 	return (int)val;
 }
 
+struct foobar_struct {
+	int x;
+} __attribute__((packed, aligned(4)));
+
+struct foobar_struct2 {
+	int x;
+} __aligned(4);
+
+struct foobar_struct3 {
+	int x;
+} __packed;
+
 static ALWAYS_INLINE int foo_execute2(void)
 {
 	return 0;
 }
+
+struct __attribute__((packed)) foobar_struct4 {
+	int x;
+};
 
 inline static int foo_execute3(void)
 {


### PR DESCRIPTION
Remove typical attributes used for function declarations.
Handle attributes added to structures.