### PR TITLE
application: asset_tracker_v2: Change `time` to `ts`

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/json_protocol_names_nrf_cloud.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/json_protocol_names_nrf_cloud.h
@@ -30,7 +30,7 @@
 #define DATA_GROUP     "messageType"
 #define DATA_ID	       "appId"
 #define DATA_TYPE      "data"
-#define DATA_TIMESTAMP "time"
+#define DATA_TIMESTAMP "ts"
 #define DATA_VALUE     "data"
 
 #define MESSAGE_TYPE_DATA "DATA"


### PR DESCRIPTION
Use `ts` instead of `time` as parameter name for timestamp values
sent to nRF Cloud.

Closes CIA-461