### PR TITLE
net: lib: nrf_cloud: Fix flagging for cellular positioning callback

### DIFF
--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_fsm.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_fsm.h
@@ -64,10 +64,12 @@ void nfsm_disconnect(void);
  */
 bool nfsm_get_disconnect_requested(void);
 
+#if defined(CONFIG_NRF_CLOUD_CELL_POS) && defined(CONFIG_NRF_CLOUD_MQTT)
 /**@brief Sets a callback from the nrf_cloud_cell_pos module to
  * handle the cellular positioning response data from the cloud.
  */
 void nfsm_set_cell_pos_response_cb(nrf_cloud_cell_pos_response_t cb);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
PR https://github.com/nrfconnect/sdk-nrf/pull/5986 added callback for cellular positioning. Flagging with CONFIG_NRF_CLOUD_CELL_POS and CONFIG_NRF_CLOUD_MQTT were added except to nrf_cloud_fsm.h.
