### PR TITLE
west.yml: Update nrfxlib and zephyr to include TF-M variable changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f80aea343f37aa4d5e3fb707ce2dcf842bf0e06a
+      revision: 56899c3147f6758e0856d5d7c27c97a9227973c4
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: c1fe5a41c45f41adcfc008fe0ae2a4265e148d81
+      revision: 864380f7c193213a39565acf533beb40bd1153fc
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Update nrfxlib and zephyr to include TF-M variable changes.
Zephyr contains build updates for crypto configuration.
nrfxlib just removes a build warning.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>