### PR TITLE
west.yml: Update zephyr for L2CAP disconnect for too much data sent

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 379117545b61f57d9263fc3f0048929c779524df
+      revision: pull/652/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updated zephyr for fix L2CAP channel disconnection if peer sent too much data.

Signed-off-by: Alexandru Carbuneanu alexandru.carbuneanu@nordicsemi.no
