### PR TITLE
 Extending Kconfig in external projects.

### DIFF
--- a/modules/memfault/Kconfig
+++ b/modules/memfault/Kconfig
@@ -4,6 +4,22 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Symbols guarded inside `if 0`.
+# Those symbols are defined in memfault upstream Kconfig but added and guarded
+# here to avoid Kconfig errors when this module is not available.
+if 0
+config MEMFAULT_HTTP_PERIODIC_UPLOAD
+	bool
+
+choice MEMFAULT_HTTP_PERIODIC_UPLOAD_CONTEXT
+	prompt ""
+
+config MEMFAULT_HTTP_PERIODIC_UPLOAD_USE_DEDICATED_WORKQUEUE
+	bool ""
+
+endchoice
+endif
+
 if MEMFAULT
 
 config MEMFAULT_NCS_PROJECT_KEY


### PR DESCRIPTION
nRF Connect SDK may be extending Kconfig and referring Kconfig symbols specified in external projects.
This creates a artificially hard dependency to a project that users in principle should be able to disable in their downstream manifest file, as that module is not crucial to nRF Connect SDK.

See: https://devzone.nordicsemi.com/f/nordic-q-a/81109/ncs-does-not-build-correctly-if-memfault-module-sources-are-not-present

This PR presents a principle that allows us to mark such extension, and thus avoiding to load the Kconfig if the module is not available.

An alternative approach is seen here: #6080 