### PR TITLE
samples: openthread: enable PSA crypto API in non-secure builds

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -216,6 +216,14 @@ nRF9160 samples
   * The sample has been removed.
     nRF Cloud A-GPS and P-GPS are demonstrated in the :ref:`gnss_sample` sample.
 
+OpenThread samples
+------------------
+
+* Added:
+
+  * Support for ``nrf5340dk_nrf5340_cpuapp_ns`` build target for :ref:`zephyr:nrf5340dk_nrf5340`.
+    This allows to build the OpenThread samples with Trusted Firmware-M and the PSA crypto API support.
+
 Zigbee samples
 --------------
 

--- a/samples/openthread/cli/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/openthread/cli/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -6,3 +6,4 @@
 
 # Enable Trusted Firmware M
 CONFIG_BUILD_WITH_TFM=y
+CONFIG_OPENTHREAD_CRYPTO_PSA=y

--- a/samples/openthread/coap_client/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/openthread/coap_client/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -6,3 +6,4 @@
 
 # Enable Trusted Firmware M
 CONFIG_BUILD_WITH_TFM=y
+CONFIG_OPENTHREAD_CRYPTO_PSA=y

--- a/samples/openthread/coap_server/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/openthread/coap_server/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -6,3 +6,4 @@
 
 # Enable Trusted Firmware M
 CONFIG_BUILD_WITH_TFM=y
+CONFIG_OPENTHREAD_CRYPTO_PSA=y


### PR DESCRIPTION
We've recently added support for OpenThread crypto backend based on PSA crypto API to Zephyr. Let's make use of it in
our OpenThread samples.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>