### PR TITLE
event_manager: Add memory related weak func

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -362,6 +362,7 @@ Other libraries
 
   * Increased number of supported Event Manager events.
   * Moved the Event Manager features responsible for profiling events into the new ``event_manager_profiler`` module.
+  * Added a weak function to allow overriding the allocation in Event Manager.
 
 * :ref:`ei_wrapper` library:
 

--- a/include/event_manager.h
+++ b/include/event_manager.h
@@ -258,7 +258,7 @@ int event_manager_init(void);
 /** Trace event execution.
  * The behavior of this function depends on the actual implementation.
  * The default implementation of this function is no-operation.
- * It is annotated as weak and is meant to be overloaded by layer
+ * It is annotated as weak and is meant to be overridden by layer
  * adding support for profiling mechanism.
  **/
 void event_manager_trace_event_execution(const struct event_header *eh,
@@ -268,7 +268,7 @@ void event_manager_trace_event_execution(const struct event_header *eh,
 /** Trace event submission.
  * The behavior of this function depends on the actual implementation.
  * The default implementation of this function is no-operation.
- * It is annotated as weak and is meant to be overloaded by layer
+ * It is annotated as weak and is meant to be overridden by layer
  * adding support for profiling mechanism.
  **/
 void event_manager_trace_event_submission(const struct event_header *eh,
@@ -278,10 +278,30 @@ void event_manager_trace_event_submission(const struct event_header *eh,
 /** Initialize tracing in the Event Manager.
  * The behavior of this function depends on the actual implementation.
  * The default implementation of this function is no-operation.
- * It is annotated as weak and is meant to be overloaded by layer
+ * It is annotated as weak and is meant to be overridden by layer
  * adding support for profiling mechanism.
  **/
 int event_manager_trace_event_init(void);
+
+/** Allocate event.
+ * The behavior of this function depends on the actual implementation.
+ * The default implementation of this function is same as k_malloc.
+ * It is annotated as weak and can be overridden by user.
+ *
+ * @param size  Amount of memory requested (in bytes).
+ * @retval Address of the allocated memory if successful, otherwise NULL.
+ **/
+void *event_manager_alloc(size_t size);
+
+
+/** Free memory occupied by the event.
+ * The behavior of this function depends on the actual implementation.
+ * The default implementation of this function is same as k_free.
+ * It is annotated as weak and can be overridden by user.
+ *
+ * @param addr  Pointer to previously allocated memory.
+ **/
+void event_manager_free(void *addr);
 
 
 #ifdef __cplusplus

--- a/subsys/event_manager/event_manager.c
+++ b/subsys/event_manager/event_manager.c
@@ -116,6 +116,26 @@ void __weak event_manager_trace_event_submission(const struct event_header *eh,
 {
 }
 
+void * __weak event_manager_alloc(size_t size)
+{
+	void *event = k_malloc(size);
+
+	if (unlikely(!event)) {
+		printk("Event Manager OOM error\n");
+		LOG_PANIC();
+		__ASSERT_NO_MSG(false);
+		sys_reboot(SYS_REBOOT_WARM);
+		return NULL;
+	}
+
+	return event;
+}
+
+void __weak event_manager_free(void *addr)
+{
+	k_free(addr);
+}
+
 int __weak event_manager_trace_event_init(void)
 {
 	return 0;
@@ -182,7 +202,7 @@ static void event_processor_fn(struct k_work *work)
 
 		event_manager_trace_event_execution(eh, false);
 
-		k_free(eh);
+		event_manager_free(eh);
 	}
 }
 

--- a/subsys/event_manager/event_manager_priv.h
+++ b/subsys/event_manager/event_manager_priv.h
@@ -93,21 +93,15 @@ extern "C" {
  * an argument. Allocator function is used to create an event of the given
  * ename type.
  */
-#define _EVENT_ALLOCATOR_FN(ename)					\
-	static inline struct ename *_CONCAT(new_, ename)(void)		\
-	{								\
-		struct ename *event = (struct ename *)k_malloc(sizeof(*event));\
-		BUILD_ASSERT(offsetof(struct ename, header) == 0,	\
-				 "");					\
-		if (unlikely(!event)) {					\
-			printk("Event Manager OOM error\n");		\
-			LOG_PANIC();					\
-			__ASSERT_NO_MSG(false);				\
-			sys_reboot(SYS_REBOOT_WARM);			\
-			return NULL;					\
-		}							\
-		event->header.type_id = _EVENT_ID(ename);		\
-		return event;						\
+#define _EVENT_ALLOCATOR_FN(ename)						\
+	static inline struct ename *_CONCAT(new_, ename)(void)			\
+	{									\
+		struct ename *event =						\
+			(struct ename *)event_manager_alloc(sizeof(*event));	\
+		BUILD_ASSERT(offsetof(struct ename, header) == 0,		\
+				 "");						\
+		event->header.type_id = _EVENT_ID(ename);			\
+		return event;							\
 	}
 
 
@@ -115,25 +109,19 @@ extern "C" {
  * an argument. Allocator function is used to create an event of the given
  * ename type.
  */
-#define _EVENT_ALLOCATOR_DYNDATA_FN(ename)				\
-	static inline struct ename *_CONCAT(new_, ename)(size_t size)	\
-	{								\
-		struct ename *event = (struct ename *)k_malloc(sizeof(*event) + size);\
-		BUILD_ASSERT((offsetof(struct ename, dyndata) +		\
-				  sizeof(event->dyndata.size)) ==	\
-				 sizeof(*event), "");			\
-		BUILD_ASSERT(offsetof(struct ename, header) == 0,	\
-				 "");					\
-		if (unlikely(!event)) {					\
-			printk("Event Manager OOM error\n");		\
-			LOG_PANIC();					\
-			__ASSERT_NO_MSG(false);				\
-			sys_reboot(SYS_REBOOT_WARM);			\
-			return NULL;					\
-		}							\
-		event->header.type_id = _EVENT_ID(ename);		\
-		event->dyndata.size = size;				\
-		return event;						\
+#define _EVENT_ALLOCATOR_DYNDATA_FN(ename)						\
+	static inline struct ename *_CONCAT(new_, ename)(size_t size)			\
+	{										\
+		struct ename *event =							\
+			(struct ename *)event_manager_alloc(sizeof(*event) + size);	\
+		BUILD_ASSERT((offsetof(struct ename, dyndata) +				\
+				  sizeof(event->dyndata.size)) ==			\
+				 sizeof(*event), "");					\
+		BUILD_ASSERT(offsetof(struct ename, header) == 0,			\
+				 "");							\
+		event->header.type_id = _EVENT_ID(ename);				\
+		event->dyndata.size = size;						\
+		return event;								\
 	}
 
 


### PR DESCRIPTION
Definine two weak function event_manager_alloc and event_manager_free.

Jira: NCSDK-12458

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>