### PR TITLE
samples: nrf9160: modem_shell: add support for nRF Cloud A-GPS and P-GPS

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -201,6 +201,8 @@ nRF9160 samples
   * Added a new shell command ``rest`` for sending simple REST requests and receiving responses to them.
   * Added a new shell command ``location`` for using the Location library to retrieve device's location with different methods.
   * Updated some samples to use DTS overlays instead of KConfig configuration files for setting up external flash memory.
+  * Added support for nRF Cloud A-GPS and P-GPS.
+    A-GPS support is enabled by default.
 
 * :ref:`gnss_sample` sample:
 

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -541,6 +541,8 @@ Building and running
 
 .. include:: /includes/build_and_run_nrf9160.txt
 
+See :ref:`cmake_options` for instructions on how to provide CMake options, for example to use a configuration overlay.
+
 DK buttons
 ==========
 
@@ -608,8 +610,6 @@ For example:
 
    west build -p -b nrf9160dk_nrf9160_ns -d build -- -DOVERLAY_CONFIG=overlay-ppp.conf
 
-See :ref:`cmake_options` for more instructions on how to add this option.
-
 Application FOTA support
 ========================
 
@@ -619,8 +619,6 @@ For example:
 .. code-block:: console
 
    west build -p -b nrf9160dk_nrf9160_ns -d build -- -DOVERLAY_CONFIG=overlay-app_fota.conf
-
-See :ref:`cmake_options` for more instructions on how to add this option.
 
 LwM2M carrier library support
 =============================
@@ -632,7 +630,15 @@ For example:
 
    west build -p -b nrf9160dk_nrf9160_ns -d build -- -DOVERLAY_CONFIG=overlay-lwm2m_carrier.conf
 
-See :ref:`cmake_options` for more instructions on how to add this option.
+P-GPS support
+=============
+
+To build the MoSh sample with P-GPS support, use the ``-DOVERLAY_CONFIG=overlay-pgps.conf`` option.
+For example:
+
+.. code-block:: console
+
+   west build -p -b nrf9160dk_nrf9160_ns -d build -- -DOVERLAY_CONFIG=overlay-pgps.conf
 
 Dependencies
 ************

--- a/samples/nrf9160/modem_shell/overlay-pgps.conf
+++ b/samples/nrf9160/modem_shell/overlay-pgps.conf
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# P-GPS overlay configuration
+
+# P-GPS
+CONFIG_NRF_CLOUD=y
+CONFIG_NRF_CLOUD_REST=y
+CONFIG_NRF_CLOUD_PGPS=y
+CONFIG_NRF_CLOUD_PGPS_NUM_PREDICTIONS=42
+CONFIG_NRF_CLOUD_PGPS_REPLACEMENT_THRESHOLD=4
+CONFIG_NRF_CLOUD_PGPS_REQUEST_ALL_UPON_INIT=y
+
+# Storage for P-GPS
+CONFIG_STREAM_FLASH=y
+CONFIG_FLASH=y
+CONFIG_FLASH_PAGE_LAYOUT=y
+CONFIG_FLASH_MAP=y
+CONFIG_FCB=y
+CONFIG_SETTINGS=y
+CONFIG_SETTINGS_FCB=y
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
+
+# MCUBOOT - for partition containing PM_MCUBOOT_SECONDARY_ADDRESS
+CONFIG_BOOTLOADER_MCUBOOT=y
+CONFIG_IMG_MANAGER=y
+CONFIG_MCUBOOT_IMG_MANAGER=y
+
+# Library that maintains the current date and UTC time
+CONFIG_DATE_TIME=y
+
+# Modem JWT library
+CONFIG_MODEM_JWT=y
+
+# Download client library stack size needs to be increased with P-GPS
+CONFIG_DOWNLOAD_CLIENT_STACK_SIZE=1280
+
+# Disable other features to make the application fit onto flash
+CONFIG_MOSH_IPERF3=n
+CONFIG_MOSH_CURL=n

--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -115,9 +115,13 @@ CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS=0
 
 # nRF Cloud
 CONFIG_NRF_CLOUD=y
+# nRF Cloud A-GPS, disable this in case you want to enable SUPL below
 CONFIG_NRF_CLOUD_AGPS=y
 CONFIG_NRF_CLOUD_REST=y
 CONFIG_MODEM_JWT=y
+
+# SUPL A-GPS support, needs the nRF9160 SiP SUPL client library from nRF9160 DK product page
+#CONFIG_SUPL_CLIENT_LIB=y
 
 # Cellular positioning
 CONFIG_MULTICELL_LOCATION=y
@@ -135,10 +139,6 @@ CONFIG_MULTICELL_LOCATION_SERVICE_NRF_CLOUD=y
 #CONFIG_MULTICELL_LOCATION_SERVICE_POLTE=y
 #CONFIG_MULTICELL_LOCATION_POLTE_CUSTOMER_ID="customer id"
 #CONFIG_MULTICELL_LOCATION_POLTE_API_TOKEN="api token"
-
-
-# GNSS SUPL (AGPS) support, needs the nRF9160 SiP SUPL client library from nRF9160 DK product page
-CONFIG_SUPL_CLIENT_LIB=n
 
 # Configurations for the GPS driver, uncomment all to use GPS driver instead of the GNSS interface.
 #CONFIG_MOSH_GNSS_GPS_DRIVER=y

--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -23,3 +23,10 @@ tests:
     extra_args: OVERLAY_CONFIG=overlay-esp-wifi.conf
                 DTC_OVERLAY_FILE="esp_8266_nrf9160ns.overlay"
     tags: ci_build
+  samples.nrf9160.modem_shell.pgps:
+    build_only: true
+    platform_allow: nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+    extra_args: OVERLAY_CONFIG=overlay-pgps.conf
+    tags: ci_build

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.h
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.h
@@ -319,6 +319,14 @@ int gnss_set_agps_automatic(bool value);
 int gnss_inject_agps_data(void);
 
 /**
+ * @brief Enables P-GPS. Once enabled, P-GPS remains enabled until reboot.
+ *
+ * @retval 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int gnss_enable_pgps(void);
+
+/**
  * @brief Configures how much PVT information is printed out.
  *
  * @param level 0 = PVT output disabled

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_gps_driver.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_gps_driver.c
@@ -354,6 +354,12 @@ int gnss_inject_agps_data(void)
 	return -EOPNOTSUPP;
 }
 
+int gnss_enable_pgps(void)
+{
+	mosh_error("GNSS: Operation not supported in GPS driver mode");
+	return -EOPNOTSUPP;
+}
+
 int gnss_set_pvt_output_level(uint8_t level)
 {
 	if (level < 0 || level > 2) {

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
@@ -499,6 +499,16 @@ static int cmd_gnss_agps_inject(const struct shell *shell, size_t argc, char **a
 	return gnss_inject_agps_data();
 }
 
+static int cmd_gnss_pgps(const struct shell *shell, size_t argc, char **argv)
+{
+	return print_help(shell, argc, argv);
+}
+
+static int cmd_gnss_pgps_enable(const struct shell *shell, size_t argc, char **argv)
+{
+	return gnss_enable_pgps();
+}
+
 static int cmd_gnss_agps_filter(const struct shell *shell, size_t argc, char **argv)
 {
 	bool ephe_enabled;
@@ -938,6 +948,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_gnss_pgps,
+	SHELL_CMD_ARG(enable, NULL, "Enable P-GPS.",
+		      cmd_gnss_pgps_enable, 1, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_gnss_1pps,
 	SHELL_CMD_ARG(enable, NULL, "<interval (s)> <pulse length (ms)>\nEnable 1PPS.",
 		      cmd_gnss_1pps_enable, 3, 0),
@@ -958,7 +975,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(config, &sub_gnss_config, "Set GNSS configuration.", cmd_gnss_config),
 	SHELL_CMD(priority, &sub_gnss_priority, "Enable/disable priority time window requests.",
 		  cmd_gnss_priority),
-	SHELL_CMD(agps, &sub_gnss_agps, "AGPS configuration and commands.", cmd_gnss_agps),
+	SHELL_CMD(agps, &sub_gnss_agps, "A-GPS configuration and commands.", cmd_gnss_agps),
+	SHELL_CMD(pgps, &sub_gnss_pgps, "P-GPS commands.", cmd_gnss_pgps),
 	SHELL_CMD(1pps, &sub_gnss_1pps, "1PPS control.", cmd_gnss_1pps),
 	SHELL_CMD(output, NULL, "<pvt level> <nmea level> <event level>\nSet output levels.",
 		  cmd_gnss_output),


### PR DESCRIPTION
Added support for nRF Cloud A-GPS and P-GPS using REST API. A-GPS support is now enabled by default.