### PR TITLE
manifest: updating Zephyr for the PPP update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c928652a6a56644ded4c02bd033cd061a987341c
+      revision: f80aea343f37aa4d5e3fb707ce2dcf842bf0e06a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updating Zephyr to get the needed PPP updates for the MoSh: https://github.com/nrfconnect/sdk-zephyr/pull/656