### PR TITLE
doc: requirements: Reject markdown >=3.3.5

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -9,3 +9,4 @@ pygit2
 pyyaml
 azure-storage-blob
 sphinx_markdown_tables
+markdown<3.3.5 # Workaround for ryanfox/sphinx-markdown-tables#34


### PR DESCRIPTION
markdown-3.3.5 is included through sphinx_markdown_tables, but fails for
our python version because of ryanfox/sphinx-markdown-tables#34.

Stick with a markdown version lower than 3.3.5 until the issue can be
resolved, so the doc build can start working again.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>