### PR TITLE
doc: correct the COM port print text in BT Central UART sample

### DIFF
--- a/samples/bluetooth/central_uart/README.rst
+++ b/samples/bluetooth/central_uart/README.rst
@@ -63,7 +63,7 @@ After programming the sample to your development kit, test it by performing the 
 #. |connect_terminal_specific|
 #. Optionally, connect the RTT console to display debug messages. See :ref:`central_uart_debug`.
 #. Reset the kit.
-#. Observe that the text "Starting NUS Client example" is printed on the COM listener running on the computer and the device starts scanning for Peripherals with NUS.
+#. Observe that the text "Starting Bluetooth Central UART example" is printed on the COM listener running on the computer and the device starts scanning for Peripherals with NUS.
 #. Program the :ref:`peripheral_uart` sample to the second development kit.
    See the documentation for that sample for detailed instructions.
 #. Observe that the kits connect.


### PR DESCRIPTION
The doc incorrectly stated the COM port prints out
“Starting NUS Client example”. Corrected it to
“Starting Bluetooth Central UART example”.

Ref: NCSDK-12462

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>