### PR TITLE
manifest: Updating Zephyr for avoiding warning in bt_enable

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0d103dd7318d6103b2c3ebe5bb3b5f342e85ae2a
+      revision: 18d166b07955aa3b882a795e43738837973e541e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updating Zephyr to avoid warning in bt_enable
when calling bt_set_name.

Signed-off-by: Martin Tverdal <martin.tverdal@nordicsemi.no>