### PR TITLE
doc: MCUboot Wrapper update

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,6 +49,7 @@ Kconfig*                                  @tejlmand
 /doc/nrf/images/                          @Avalei
 /doc/nrfx/                                @gmarull
 /doc/matter/                              @gmarull
+/doc/mcuboot/                             @carlescufi
 /doc/nrfxlib/                             @gmarull
 /doc/update_versions.cmake                @carlescufi
 /doc/versions.json                        @carlescufi

--- a/doc/mcuboot/index-ncs.rst
+++ b/doc/mcuboot/index-ncs.rst
@@ -1,0 +1,72 @@
+.. _mcuboot_index_ncs:
+
+MCUboot
+#######
+
+.. contents::
+   :local:
+   :depth: 2
+
+MCUboot is a secure bootloader for 32-bit microcontrollers.
+
+Overview
+********
+
+MCUboot defines a common infrastructure for the bootloader and the system flash layout on microcontroller systems, and provides a secure bootloader that enables easy software upgrade.
+
+MCUboot is not dependent on any specific operating system and hardware and relies on hardware porting layers from the operating system it works with.
+Currently MCUboot works with the various operating systems and SDKs, such as Zephyr and the nRF Connect SDK.
+
+MCUboot is an open governance project.
+See the `membership list <https://github.com/mcu-tools/mcuboot/wiki/Members>`_ for current members, and the `project charter <https://github.com/mcu-tools/mcuboot/wiki/MCUboot-Project-Charter>`_ for more details.
+
+Documentation
+*************
+
+The MCUboot documentation is composed of the following pages:
+
+.. toctree::
+   :maxdepth: 1
+
+   release-notes.md
+   design.md
+   encrypted_images.md
+   imgtool.md
+   ecdsa.md
+   readme-zephyr.md
+   readme-ncs.rst
+   testplan-zephyr.md
+   release.md
+   SECURITY.md
+   SubmittingPatches.md
+
+Roadmap
+*******
+
+The issues being planned and worked on are tracked using GitHub issues.
+To give your input, visit `MCUboot GitHub Issues <https://github.com/mcu-tools/mcuboot/issues>`_.
+
+Source files
+************
+
+You can find additional documentation on the bootloader in the source files.
+For more information, use the following links:
+
+* `boot/bootutil <https://github.com/mcu-tools/mcuboot/tree/main/boot/bootutil>`_ - The core of the bootloader itself.
+* `boot/boot_serial <https://github.com/mcu-tools/mcuboot/tree/main/boot/boot_serial>`_ - Support for serial upgrade within the bootloader itself.
+* `boot/zephyr <https://github.com/mcu-tools/mcuboot/tree/main/boot/zephyr>`_ - Port of the bootloader to Zephyr.
+* `imgtool <https://github.com/mcu-tools/mcuboot/tree/main/scripts/imgtool.py>`_ - A tool to securely sign firmware images for booting by MCUboot.
+* `sim <https://github.com/mcu-tools/mcuboot/tree/main/sim>`_ - A bootloader simulator for testing and regression.
+
+Joining the project
+*******************
+
+Developers are welcome!
+
+Use the following links to join or see more about the project:
+
+* `MCUboot official developer mailing list <https://groups.io/g/MCUBoot>`_
+* `MCUboot official Slack channel <https://mcuboot.slack.com/>`_
+  Get `your invite <https://join.slack.com/t/mcuboot/shared_invite/MjE2NDcwMTQ2MTYyLTE1MDA4MTIzNTAtYzgyZTU0NjFkMg>`_
+* `Current members <https://github.com/mcu-tools/mcuboot/wiki/Members>`_
+* `Project charter <https://github.com/mcu-tools/mcuboot/wiki/MCUboot-Project-Charter>`_

--- a/doc/mcuboot/readme-ncs.rst
+++ b/doc/mcuboot/readme-ncs.rst
@@ -5,7 +5,7 @@ Using MCUboot in nRF Connect SDK
 
 See :doc:`readme-zephyr` for general information on how to integrate MCUboot with Zephyr.
 
-nRF Connect SDK provides additional functionality that is available when MCUboot is included.
+The nRF Connect SDK provides additional functionality that is available when MCUboot is included.
 This functionality is implemented in the files in the ``modules/mcuboot`` subfolder in the `sdk-nrf`_ repository.
 
 To include MCUboot in your nRF Connect SDK application, enable :kconfig:`CONFIG_BOOTLOADER_MCUBOOT`.

--- a/doc/mcuboot/unused_files.rst
+++ b/doc/mcuboot/unused_files.rst
@@ -3,6 +3,7 @@
 .. toctree::
    :maxdepth: 1
 
+   index.md
    PORTING.md
    readme-mbed.md
    readme-mynewt.md

--- a/doc/mcuboot/wrapper.rst
+++ b/doc/mcuboot/wrapper.rst
@@ -1,30 +1,29 @@
 .. _mcuboot_wrapper:
 
-MCUboot documentation
-#####################
+MCUboot documentation in the nRF Connect SDK
+############################################
 
-This documentation is based on the official `MCUboot <https://mcuboot.com>`_ documentation, but focuses on the use of MCUboot in nRF Connect SDK.
+This documentation is based on the official `MCUboot <https://mcuboot.com>`_ documentation, but focuses on the use of MCUboot in the nRF Connect SDK.
 
 The documentation includes documentation files from the upstream `MCUboot repository <https://github.com/mcu-tools/mcuboot>`_.
 Topics that are not relevant for the integration of MCUboot in the nRF Connect SDK are excluded from the navigation.
 
-:ref:`mcuboot_ncs` contains information that is relevant for nRF Connect SDK's `fork of MCUboot <https://github.com/nrfconnect/sdk-mcuboot>`_ but not for the upstream MCUboot repository.
+:ref:`mcuboot_ncs` contains information that is relevant for the `fork of MCUboot <https://github.com/nrfconnect/sdk-mcuboot>`_ included in the nRF Connect SDK but not for the upstream MCUboot repository.
 
 
 .. toctree::
    :maxdepth: 1
    :caption: Contents:
 
-
-   index.md
+   index-ncs.rst
    release-notes.md
    design.md
-   ecdsa.md
    encrypted_images.md
    imgtool.md
+   ecdsa.md
    readme-zephyr.md
    readme-ncs.rst
-   SubmittingPatches.md
    testplan-zephyr.md
    release.md
    SECURITY.md
+   SubmittingPatches.md


### PR DESCRIPTION
Updated the text in the MCUboot wrapper homepage
Ported index.md to RST removing info unrelated to NCS.
Updated list of unused doc files from the mcuboot repo.

Signed-off-by: Francesco Servidio <francesco.servidio@nordicsemi.no>