### PR TITLE
samples: openthread: fix power consumption increase

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -195,7 +195,7 @@ int poweroff_uart(void)
 
 	uart_rx_disable(uart_dev);
 	k_sleep(K_MSEC(100));
-	err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_OFF);
+	err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_SUSPENDED);
 	if (err) {
 		LOG_ERR("Can't power off uart: %d", err);
 	}
@@ -802,7 +802,7 @@ void slm_at_host_uninit(void)
 	/* Power off UART module */
 	uart_rx_disable(uart_dev);
 	k_sleep(K_MSEC(100));
-	err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_OFF);
+	err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_SUSPENDED);
 	if (err) {
 		LOG_WRN("Can't power off uart: %d", err);
 	}

--- a/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
@@ -716,7 +716,7 @@ int nrf21540_tx_gain_set(uint8_t gain)
 	}
 
 	if (uart_ready) {
-		err = pm_device_state_set(uart, PM_DEVICE_STATE_OFF);
+		err = pm_device_state_set(uart, PM_DEVICE_STATE_SUSPENDED);
 		if (err) {
 			goto error;
 		}

--- a/samples/openthread/coap_client/src/coap_client.c
+++ b/samples/openthread/coap_client/src/coap_client.c
@@ -100,7 +100,7 @@ static void on_mtd_mode_toggle(uint32_t med)
 	if (med) {
 		pm_device_state_set(cons, PM_DEVICE_STATE_ACTIVE);
 	} else {
-		pm_device_state_set(cons, PM_DEVICE_STATE_OFF);
+		pm_device_state_set(cons, PM_DEVICE_STATE_SUSPENDED);
 	}
 #endif
 	dk_set_led(MTD_SED_LED, med);


### PR DESCRIPTION
STATE_OFF is no longer supported in uart driver. changed to SUSPENDED

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>