### PR TITLE
TFM: Add secure GPIO service

### DIFF
--- a/include/tfm/tfm_ioctl_api.h
+++ b/include/tfm/tfm_ioctl_api.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <tfm_api.h>
 #include <tfm_platform_api.h>
+#include <hal/nrf_gpio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,7 +31,8 @@ extern "C" {
 /** @brief Supported request types.
  */
 enum tfm_platform_ioctl_reqest_types_t {
-	TFM_PLATFORM_IOCTL_READ_SERVICE
+	TFM_PLATFORM_IOCTL_READ_SERVICE,
+	TFM_PLATFORM_IOCTL_GPIO_SERVICE,
 };
 
 /** @brief Argument list for each platform read service.
@@ -45,6 +47,31 @@ struct tfm_read_service_args_t {
 /** @brief Output list for each read platform service
  */
 struct tfm_read_service_out_t {
+	uint32_t result;
+};
+
+enum tfm_gpio_service_type {
+	/** Select which MCU / Subsystem controls the pin */
+	TFM_GPIO_SERVICE_TYPE_PIN_MCU_SELECT = 0,
+};
+
+/** @brief Arguments for selecting the MCU to control a GPIO pin. */
+struct tfm_gpio_service_args_mcu_select {
+	uint32_t pin_number;
+	uint32_t mcu;
+};
+
+/** @brief Argument list for each platform GPIO service */
+struct tfm_gpio_service_args {
+	uint32_t type;
+	union {
+		struct tfm_gpio_service_args_mcu_select mcu_select;
+	};
+};
+
+/** @brief Output list for each GPIO platform service
+ */
+struct tfm_gpio_service_out {
 	uint32_t result;
 };
 
@@ -67,6 +94,20 @@ struct tfm_read_service_range {
 	uint32_t start;
 	size_t size;
 };
+
+/**
+ * @brief Perform a GPIO MCU select operation.
+ *
+ * @param pin_number         Pin_number.
+ * @param mcu                MCU to control the pin, use nrf_gpio_pin_mcusel_t values.
+
+ * @param[out] result        Result of operation
+ *
+ * @return Returns values as specified by the tfm_platform_err_t
+ */
+enum tfm_platform_err_t tfm_platform_gpio_pin_mcu_select(uint32_t pin_number, uint32_t mcu,
+							 uint32_t *result);
+
 
 #ifdef __cplusplus
 }

--- a/modules/tfm/tfm/boards/src/tfm_ioctl_ns_api.c
+++ b/modules/tfm/tfm/boards/src/tfm_ioctl_ns_api.c
@@ -34,3 +34,34 @@ enum tfm_platform_err_t tfm_platform_mem_read(void *destination, uint32_t addr,
 
 	return ret;
 }
+
+enum tfm_platform_err_t tfm_platform_gpio_pin_mcu_select(uint32_t pin_number, uint32_t mcu,
+							 uint32_t *result)
+{
+#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
+	enum tfm_platform_err_t ret;
+	psa_invec in_vec;
+	psa_outvec out_vec;
+	struct tfm_gpio_service_args args;
+	struct tfm_gpio_service_out out;
+
+	args.type = TFM_GPIO_SERVICE_TYPE_PIN_MCU_SELECT;
+	args.mcu_select.pin_number = pin_number;
+	args.mcu_select.mcu = mcu;
+
+	in_vec.base = (const void *)&args;
+	in_vec.len = sizeof(args);
+
+	out_vec.base = (void *)&out;
+	out_vec.len = sizeof(out);
+
+	ret = tfm_platform_ioctl(TFM_PLATFORM_IOCTL_GPIO_SERVICE, &in_vec,
+				 &out_vec);
+
+	*result = out.result;
+
+	return ret;
+#else
+	return TFM_PLATFORM_ERR_NOT_SUPPORTED;
+#endif
+}

--- a/modules/tfm/tfm/boards/src/tfm_ioctl_s_api.c
+++ b/modules/tfm/tfm/boards/src/tfm_ioctl_s_api.c
@@ -34,3 +34,35 @@ enum tfm_platform_err_t tfm_platform_mem_read(void *destination, uint32_t addr,
 
 	return (enum tfm_platform_err_t) ret;
 }
+
+__attribute__((section("SFN")))
+enum tfm_platform_err_t tfm_platform_gpio_pin_mcu_select(uint32_t pin_number, uint32_t mcu,
+							 uint32_t *result)
+{
+#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
+	enum tfm_platform_err_t ret;
+	psa_invec in_vec;
+	psa_outvec out_vec;
+	struct tfm_gpio_service_args args;
+	struct tfm_gpio_service_out out;
+
+	args.type = TFM_GPIO_SERVICE_TYPE_PIN_MCU_SELECT;
+	args.mcu_select.pin_number = pin_number;
+	args.mcu_select.mcu = mcu;
+
+	in_vec.base = (const void *)&args;
+	in_vec.len = sizeof(args);
+
+	out_vec.base = (void *)&out;
+	out_vec.len = sizeof(out);
+
+	ret = tfm_platform_ioctl(TFM_PLATFORM_IOCTL_GPIO_SERVICE, &in_vec,
+				 &out_vec);
+
+	*result = out.result;
+
+	return ret;
+#else
+	return TFM_PLATFORM_ERR_NOT_SUPPORTED;
+#endif
+}

--- a/modules/tfm/tfm/boards/src/tfm_platform_system.c
+++ b/modules/tfm/tfm/boards/src/tfm_platform_system.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <sys/util.h>
+
 #include <platform/include/tfm_platform_system.h>
 #include <cmsis.h>
 #include <stdio.h>
@@ -14,8 +16,6 @@
 
 /* This contains the user provided allowed ranges */
 #include <tfm_read_ranges.h>
-
-#define ARRAY_SIZE(arr) (sizeof(arr)/sizeof(arr[0]))
 
 static bool ptr_in_secure_area(intptr_t ptr)
 {

--- a/samples/tfm/tfm_hello_world/README.rst
+++ b/samples/tfm/tfm_hello_world/README.rst
@@ -47,6 +47,7 @@ After programming the sample, the following output is displayed in the console:
     Hashing 'Hello World! nrf5340dk_nrf5340_cpuapp'
     SHA256 digest:
     0x12f0c84eecba8497cc0bec1ebc5a785df2ae027a2545921d6cdc0920c5aaefd7
+    Configuring MCU selection for LFXO
 
 Dependencies
 *************

--- a/samples/tfm/tfm_hello_world/sample.yaml
+++ b/samples/tfm/tfm_hello_world/sample.yaml
@@ -21,6 +21,7 @@ common:
         - "Hashing 'Hello World! .*'"
         - "SHA256 digest:"
         - "0x[0-9a-f]{64}"
+        - "(Configuring MCU selection for LFXO)?"
 tests:
   sample.tfm.helloworld:
     tags: tfm ci_build


### PR DESCRIPTION
Add secure GPIO service in order allow non-secure to configure the MCUSEL field of PIN_CNF[i].