### PR TITLE
samples: nrf9160: modem_shell: fix uart disable command

### DIFF
--- a/samples/nrf9160/modem_shell/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/nrf9160/modem_shell/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Enable uart1. Note: cannot be used with T-FM.
+ * See: https://github.com/zephyrproject-rtos/zephyr/commit/0856e4ba518d32576ed1800a4b70a33617196474
+ */
+&uart1 {
+	status = "okay";
+};

--- a/samples/nrf9160/modem_shell/src/uart/uart.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart.c
@@ -16,12 +16,12 @@ void disable_uarts(void)
 
 	uart_dev = device_get_binding(DT_LABEL(DT_NODELABEL(uart0)));
 	if (uart_dev) {
-		pm_device_state_set(uart_dev, PM_DEVICE_STATE_LOW_POWER);
+		pm_device_state_set(uart_dev, PM_DEVICE_STATE_SUSPENDED);
 	}
 
 	uart_dev = device_get_binding(DT_LABEL(DT_NODELABEL(uart1)));
 	if (uart_dev) {
-		pm_device_state_set(uart_dev, PM_DEVICE_STATE_LOW_POWER);
+		pm_device_state_set(uart_dev, PM_DEVICE_STATE_SUSPENDED);
 	}
 }
 

--- a/samples/nrf9160/modem_shell/src/uart/uart_shell.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart_shell.c
@@ -99,13 +99,13 @@ void uart_toggle_power_state(void)
 			/* allow little time for printing the notification */
 			k_sleep(K_MSEC(500));
 
-			/* set uart0 to low power state */
-			err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_LOW_POWER);
+			/* set uart0 to suspended state */
+			err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_SUSPENDED);
 
-			/* set uart1 to low power state */
+			/* set uart1 to suspended state */
 			uart_dev = device_get_binding(DT_LABEL(DT_NODELABEL(uart1)));
 			if (uart_dev) {
-				pm_device_state_set(uart_dev, PM_DEVICE_STATE_LOW_POWER);
+				pm_device_state_set(uart_dev, PM_DEVICE_STATE_SUSPENDED);
 			}
 		} else {
 			/* set uart0 to active state */


### PR DESCRIPTION
"uart disable" command was broken. UART driver implementation has been
changed so that PM_DEVICE_STATE_LOW_POWER is not supported anymore.
The "uart disable" command implementation was changed to use
PM_DEVICE_STATE_SUSPENDED instead. Also brought back a deleted
overlay file to enable UART1 in modem shell.

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>