### PR TITLE
samples: nrf9160: modem_shell: Use new nrf_modem_at API

### DIFF
--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -575,6 +575,9 @@ int link_func_mode_set(enum lte_lc_func_mode fun)
 		/* Enable Rel14 features before going to normal mode */
 		link_enable_rel14_features();
 
+		/* (Re)register for PDN lib notifications */
+		link_shell_pdn_events_subscribe();
+
 		/* (Re)register for rsrp notifications: */
 		modem_info_rsrp_register(link_rsrp_signal_handler);
 

--- a/samples/nrf9160/modem_shell/src/link/link_shell.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell.c
@@ -11,7 +11,7 @@
 #include <unistd.h>
 #include <getopt.h>
 
-#include <modem/at_cmd.h>
+#include <nrf_modem_at.h>
 
 #include "mosh_print.h"
 #include "link.h"
@@ -868,15 +868,10 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 		} else if (link_cmd_args.common_option == LINK_COMMON_ENABLE) {
 			link_sett_save_defcont_enabled(true);
 		} else if (link_cmd_args.common_option == LINK_COMMON_DISABLE) {
-			static const char cgdcont[] = "AT+CGDCONT=0";
-
-			if (at_cmd_write(cgdcont, NULL, 0, NULL) != 0) {
+			if (nrf_modem_at_printf("AT+CGDCONT=0") != 0) {
 				mosh_warn(
 					"ERROR from modem. Getting the initial PDP context back "
 					"wasn't successful.");
-				mosh_warn(
-					"Please note: you might need to visit the pwroff state to "
-					"make an impact to modem.");
 			}
 			link_sett_save_defcont_enabled(false);
 			mosh_print("Custom default context config disabled.");
@@ -911,9 +906,7 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 			}
 		} else if (link_cmd_args.common_option ==
 			   LINK_COMMON_DISABLE) {
-			static const char cgauth[] = "AT+CGAUTH=0,0";
-
-			if (at_cmd_write(cgauth, NULL, 0, NULL) != 0) {
+			if (nrf_modem_at_printf("AT+CGAUTH=0,0") != 0) {
 				mosh_warn("Disabling of auth cannot be done to modem.");
 			}
 			link_sett_save_defcontauth_enabled(false);

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
@@ -8,8 +8,8 @@
 
 #include <shell/shell.h>
 
+#include <nrf_modem_at.h>
 #include <modem/pdn.h>
-#include <modem/at_cmd.h>
 
 #if defined(CONFIG_MOSH_PPP)
 #include "ppp_ctrl.h"
@@ -337,25 +337,30 @@ int link_shell_pdn_activate(int pdn_cid)
 	return ret;
 }
 
-void link_shell_pdn_init(void)
+void link_shell_pdn_events_subscribe(void)
 {
 	int err;
 
 	/* Register to the necessary packet domain AT notifications */
-	err = at_cmd_write("AT+CNEC=16", NULL, 0, NULL);
+	err = nrf_modem_at_printf("AT+CNEC=16");
 	if (err) {
 		mosh_error("AT+CNEC=16 failed, err %d\n", err);
 		return;
 	}
 
-	err = at_cmd_write("AT+CGEREP=1", NULL, 0, NULL);
+	err = nrf_modem_at_printf("AT+CGEREP=1");
 	if (err) {
 		mosh_error("AT+CGEREP=1 failed, err %d\n", err);
 		return;
 	}
+	pdn_default_callback_set(link_pdn_event_handler);
+}
+
+void link_shell_pdn_init(void)
+{
 
 	pdn_init();
-	pdn_default_callback_set(link_pdn_event_handler);
+	link_shell_pdn_events_subscribe();
 	sys_dlist_init(&pdn_info_list);
 }
 

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.h
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.h
@@ -17,6 +17,7 @@ struct link_shell_pdn_auth {
 };
 
 void link_shell_pdn_init(void);
+void link_shell_pdn_events_subscribe(void);
 
 int link_shell_pdn_connect(const char *apn_name,
 			   const char *family_str,

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -20,8 +20,11 @@
 #include <shell/shell_uart.h>
 
 #include <modem/nrf_modem_lib.h>
+
 #include <modem/at_cmd.h>
 #include <modem/at_notif.h>
+#include <modem/at_monitor.h>
+
 #include <modem/modem_info.h>
 #include <modem/lte_lc.h>
 
@@ -143,6 +146,9 @@ void main(void)
 	at_cmd_init();
 #if !defined(CONFIG_AT_NOTIF_SYS_INIT)
 	at_notif_init();
+#endif
+#if !defined(CONFIG_AT_MONITOR_SYS_INIT)
+	at_monitor_init();
 #endif
 	lte_lc_init();
 #else


### PR DESCRIPTION
Run AT commands using nrf_modem_at API instead of at_cmd library.
Notifications are handled via at_monitor library.