### PR TITLE
Bluetooth: Mesh: default resume delay after reset

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1658,6 +1658,7 @@ static void light_ctrl_srv_reset(struct bt_mesh_model *model)
 
 	ctrl_disable(srv);
 	net_buf_simple_reset(srv->pub.msg);
+	srv->resume = CONFIG_BT_MESH_LIGHT_CTRL_SRV_RESUME_DELAY;
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		(void)bt_mesh_model_data_store(srv->setup_srv, false, NULL,


### PR DESCRIPTION
Resume delay can be changed by an application.
This makes sure that resume delay value
will return to its default value after
mesh reset.

Signed-off-by: Antonio Sousa <antonio.sousa@tridonic.com>