### PR TITLE
lib: date_time: Automatically setting time to Zephyr and modem

### DIFF
--- a/doc/nrf/libraries/others/date_time.rst
+++ b/doc/nrf/libraries/others/date_time.rst
@@ -7,7 +7,7 @@ Date-Time
    :local:
    :depth: 2
 
-The date-time library maintains the current date-time information in UTC format.
+The date-time library maintains the current date-time information in UTC format and stores it as Zephyr time and modem time.
 The option :kconfig:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS` determines the frequency with which the library updates the date-time information.
 
 The information is fetched in the following prioritized order:
@@ -22,13 +22,21 @@ The information is fetched in the following prioritized order:
 The :c:func:`date_time_set` function can be used to obtain the current date-time information from external sources independent of the internal date-time update routine.
 Time from GPS can be such an external source.
 
+The option :kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE` determines whether date-time update is triggered automatically when the LTE network becomes available.
+Libraries that require date-time information can just enable this library to get updated time information.
+Applications do not need to do anything to trigger time update when they start because this library handles it automatically.
+
+Current date-time information is stored as Zephyr time when it has been retrieved and hence applications can also get the time using the POSIX function ``clock_gettime``.
+It is also stored as modem time if the modem does not have valid time.
+
 To get date-time information from the library, either call the :c:func:`date_time_uptime_to_unix_time_ms` function or the :c:func:`date_time_now` function.
 See the API documentation for more information on these functions.
 
 .. note::
 
-   The first date-time update cycle (after boot) does not occur until the time set by the :kconfig:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS` has elapsed.
-   It is recommended to call the :c:func:`date_time_update_async` function after the device has connected to LTE, to get the initial date-time information.
+   It is recommended to set the :kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE` option to trigger a time update when the device has connected to LTE.
+   If an application has time-dependent operations immediately after connecting to LTE network, it should wait for a confirmation telling that time has been updated.
+   If the :kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE` option is not set, the first date-time update cycle (after boot) does not occur until the time set by the :kconfig:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS` option has elapsed.
 
 Configuration
 *************
@@ -36,6 +44,11 @@ Configuration
 :kconfig:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS`
 
    Configure this option to control the frequency with which the library fetches the time information.
+
+:kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE`
+
+CONFIG_DATE_TIME_AUTO_UPDATE - Trigger date-time update when LTE is connected
+   Configure this option to determine whether date-time update is triggered automatically when the device has connected to LTE.
 
 API documentation
 *****************

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -521,6 +521,11 @@ Other libraries
 
   * Added PSM and eDRX configuration metrics that are collected when :kconfig:`MEMFAULT_NCS_LTE_METRICS` is enabled.
 
+* :ref:`lib_date_time` library:
+
+  * The library now stores the received date-time information as Zephyr and modem time.
+    Also modem XTIME notifications are used as time source.
+    Added the :kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE` option to trigger a time update when device has connected to LTE.
 
 Libraries for Zigbee
 --------------------

--- a/include/date_time.h
+++ b/include/date_time.h
@@ -8,8 +8,8 @@
 #define DATE_TIME_H__
 
 #include <zephyr/types.h>
-#include <time.h>
 #include <stdbool.h>
+#include <time.h>
 
 /**
  * @defgroup date_time Date Time Library

--- a/lib/date_time/Kconfig
+++ b/lib/date_time/Kconfig
@@ -6,14 +6,22 @@
 
 menuconfig DATE_TIME
 	bool "Date time library"
+	select POSIX_CLOCK
 
 if DATE_TIME
+
+config DATE_TIME_AUTO_UPDATE
+	bool "Trigger date-time update when LTE is connected"
+	select AT_MONITOR if DATE_TIME_MODEM
+	default y if (DATE_TIME_MODEM || DATE_TIME_NTP)
+	help
+	  Date-time update is triggered automatically when the LTE network becomes available.
 
 config DATE_TIME_UPDATE_INTERVAL_SECONDS
 	int "Date time update interval, in seconds"
 	default 3600
 	help
-		Setting this option to 0 disables sequential date time updates.
+	  Setting this option to 0 disables sequential date time updates.
 
 config DATE_TIME_MODEM
 	bool "Get date time from the nRF9160 onboard modem"

--- a/samples/nrf9160/location/overlay-pgps.conf
+++ b/samples/nrf9160/location/overlay-pgps.conf
@@ -29,8 +29,5 @@ CONFIG_BOOTLOADER_MCUBOOT=y
 CONFIG_IMG_MANAGER=y
 CONFIG_MCUBOOT_IMG_MANAGER=y
 
-# Library that maintains the current date time UTC.
-CONFIG_DATE_TIME=y
-
 # Download client library stack size needs to be increased with P-GPS
 CONFIG_DOWNLOAD_CLIENT_STACK_SIZE=1280

--- a/samples/nrf9160/location/prj.conf
+++ b/samples/nrf9160/location/prj.conf
@@ -44,6 +44,9 @@ CONFIG_NRF_CLOUD_AGPS=y
 CONFIG_MODEM_INFO=y # required by CONFIG_NRF_CLOUD_AGPS
 CONFIG_MODEM_INFO_ADD_NETWORK=y # required by CONFIG_NRF_CLOUD_AGPS
 
+# Library that maintains the current date time UTC for A-GPS and P-GPS purposes
+CONFIG_DATE_TIME=y
+
 # Modem JWT
 CONFIG_MODEM_JWT=y
 


### PR DESCRIPTION
This PR adds the following functionality to date_time library:

- When date_time library receives time, it sets the time to Zephyr with `clock_settime()` and to modem with AT command AT%CCLK if we haven't received time from modem (meaning we have time from NTP but not from modem).
- Added `CONFIG_DATE_AUTO_UPDATE` to enable setting of system time automatically after the time is available. This is when LTE registration has occurred. This means application doesn't need to request time update from the library with `date_time_update_async()` but this library handles it automatically. Applications and libraries can just request time whenever they need it. This is particularly handy if there is a library that needs time so the application doesn't need code to request time update with `date_time_update_async()` but it just needs to enable date_time library which sets `CONFIG_DATE_AUTO_UPDATE=y` automatically.
- In addition to earlier requests for modem and NTP time, implemented also support for modem time notifications `AT%XTIME` as a source to retrieve time whenever modem gets an update time from the network.
- It's possible for application to continue to request time with `date_time_now()` or start using OS function `clock_gettime()`.