### PR TITLE
manifest: ipc: use highest coop priority for IPM workqueue

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 81e2be611e358bb1d6a8034b410a0da93fbda0a8
+      revision: pull/659/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This pulls in a fix to zephyr's rpmsg_backend

Signed-off-by: Andrzej Kuroś <andrzej.kuros@nordicsemi.no