### PR TITLE
partition manager: let sram_nonsecure span rpmsg_nrf53_sram partition

### DIFF
--- a/subsys/partition_manager/pm.yml.bt_rpmsg_nrf53
+++ b/subsys/partition_manager/pm.yml.bt_rpmsg_nrf53
@@ -5,3 +5,6 @@ rpmsg_nrf53_sram:
   placement: {before: end}
   size: CONFIG_RPMSG_NRF53_SRAM_SIZE
   region: sram_primary
+#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
+  inside: sram_nonsecure
+#endif


### PR DESCRIPTION
In the case of nRF5340, Bluetooth subystem creates
rpmsg_nrf53_sram partition in SRAM for the HCI transport
between the two cores. If the partition is present,
sram_primary and sram_nonsecure partitions are reduced and
the rpmsg_nrf53_sram is not accessible from the non-secure
firmware - an application built with CONFIG_BT=y causes
the secure fault.

Make sram_nonsecure partition, which defines the non-secure
SRAM, span rpmsg_nrf53_sram as well.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>