### PR TITLE
Bluetooth: coex: add support for setting role priorities and scan modes

### DIFF
--- a/doc/nrf/ug_bt_coex.rst
+++ b/doc/nrf/ug_bt_coex.rst
@@ -45,6 +45,22 @@ For more information about devicetree overlays, see :ref:`zephyr:use-dt-overlays
 A sample devicetree overlay is available at :file:`samples/bluetooth/radio_coex_3wire/boards/nrf52840dk_nrf52840.overlay`.
 The elements are described in the bindings: :file:`dts/bindings/radio_coex/sdc-radio-coex-three-wire.yaml`.
 
+Run-time configuration
+======================
+
+Per-state priorities
+--------------------
+
+It is possible to use a different priority when requesting a session, depending on the session's role: either advertising, scanning, in a connection as master or as a slave.
+To do so, use the HCI VS command :c:enum:`SDC_HCI_OPCODE_CMD_VS_CONFIG_COEX_PRIORITY`. Its parameters are described in  :c:type:`sdc_hci_cmd_vs_config_coex_priority_t`.
+
+Scanner request mode
+--------------------
+
+It is possible to configure the scanner's behavior when requesting sessions:
+Either request a coex session as soon as it has received a valid access address, or request only before transmitting.
+To do so, use the HCI VS command :c:enum:`SDC_HCI_OPCODE_CMD_VS_CONFIG_COEX_SCAN_MODE`. Its parameters are described in  :c:type:`sdc_hci_cmd_vs_config_coex_scan_mode_t`.
+
 .. _ug_bt_coex_sample:
 
 Sample application

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -903,6 +903,12 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 		return sdc_hci_cmd_vs_qos_conn_event_report_enable((void *)cmd_params);
 	case SDC_HCI_OPCODE_CMD_VS_EVENT_LENGTH_SET:
 		return sdc_hci_cmd_vs_event_length_set((void *)cmd_params);
+#ifdef CONFIG_MPSL_CX_BT
+	case SDC_HCI_OPCODE_CMD_VS_CONFIG_COEX_PRIORITY:
+		return sdc_hci_cmd_vs_config_coex_priority((void *)cmd_params);
+	case SDC_HCI_OPCODE_CMD_VS_CONFIG_COEX_SCAN_MODE:
+		return sdc_hci_cmd_vs_config_coex_scan_mode((void *)cmd_params);
+#endif	/* CONFIG_MPSL_CX_BT */
 
 	default:
 		return BT_HCI_ERR_UNKNOWN_CMD;


### PR DESCRIPTION
This adds support for two new HCI VS commands, allowing the application
to set the per-role priority and scan request mode.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>