### PR TITLE
manifest: Point to the tf-m with EITS

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -64,6 +64,13 @@ config TFM_CRYPTO_ENGINE_BUF_SIZE
 		PSA_CRYPTO_DRIVER_ALG_RSA_PSS_CC3XX
 	default 8320
 
+config TFM_ITS_ENCRYPTED
+	bool
+	prompt "PSA Internal Trusted Storage with encryption"
+	select PSA_ITS_ENCRYPTED
+	help
+	  Enables authenticated encryption for PSA Internal Trusted Storage files
+
 endif # BUILD_WITH_TFM
 
 source "$(ZEPHYR_BASE)/modules/trusted-firmware-m/Kconfig.tfm"

--- a/west.yml
+++ b/west.yml
@@ -113,7 +113,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v1.5.0-ncs2-rc1
+      revision: dcc75ee27b34ea9d57c548d7d8d4e943e4fbae30
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot

--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 95156cc9adc6b604e962296220f568eabbab6508
+      revision: 9d8264a9f9c491084767999f5ad567c1a07d6704
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
-This points to the TF-M which supports
 encryption for the ITS objects.

Ref: NCSDK-7563

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>

test-sdk-nrf: sdk-nrf-PR-6139