### PR TITLE
samples: bluetooth: dtm: isolate anomaly timer code for nrf52840 soc

### DIFF
--- a/samples/bluetooth/direct_test_mode/Kconfig
+++ b/samples/bluetooth/direct_test_mode/Kconfig
@@ -28,6 +28,7 @@ config DTM_TIMER_IRQ_PRIORITY
 
 config ANOMALY_172_TIMER_IRQ_PRIORITY
 	int "Anomaly 172 timer interrupt priority"
+	depends on SOC_NRF52840
 	range 0 5 if ZERO_LATENCY_IRQS
 	range 0 6
 	default 2

--- a/samples/bluetooth/direct_test_mode/boards/nrf21540dk_nrf52840.conf
+++ b/samples/bluetooth/direct_test_mode/boards/nrf21540dk_nrf52840.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Use an additional timer for Anomaly 172
+CONFIG_NRFX_TIMER3=y

--- a/samples/bluetooth/direct_test_mode/boards/nrf52840dk_nrf52840.conf
+++ b/samples/bluetooth/direct_test_mode/boards/nrf52840dk_nrf52840.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Use an additional timer for Anomaly 172
+CONFIG_NRFX_TIMER3=y


### PR DESCRIPTION
Isolated the Anomaly 172 Timer code which should only be activated for
the nRF52840 SoC. Changed the instance of the Anomaly Timer which was
in conflict with the FEM driver.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>