### PR TITLE
Fix profiler on Windows

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -529,7 +529,7 @@ Other libraries
 
 * :ref:`profiler` library:
 
-  * Updated Python scripts to use multiple processes that communicate over sockets.
+  * Updated Python scripts to use multiple processes that communicate over pipes.
   * Increase the number of supported profiler events.
   * Added a special profiler event for indicating a situation where the profiler's data buffer has overflowed and some events have been dropped, which causes the device to stop sending events.
 

--- a/scripts/profiler/data_collector.py
+++ b/scripts/profiler/data_collector.py
@@ -5,36 +5,45 @@
 
 from multiprocessing import Process, Event, active_children
 import argparse
-import signal
 import time
 import logging
-import os
+import signal
 from stream import Stream
 from rtt2stream import Rtt2Stream
 from model_creator import ModelCreator
 
-def rtt2stream(stream, event, log_lvl_number):
+is_waiting = True
+def signal_handler(sig, frame):
+    global is_waiting
+    is_waiting = False
+
+def rtt2stream(stream, event, event_close, log_lvl_number):
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        rtt2s = Rtt2Stream(stream, log_lvl=log_lvl_number)
+        rtt2s = Rtt2Stream(stream, event_close, log_lvl=log_lvl_number)
         event.wait()
         rtt2s.read_and_transmit_data()
-    except KeyboardInterrupt:
-        rtt2s.close()
+    except Exception as e:
+        print("[ERROR] Unhandled exception in Profiler Rtt to stream module: {}".format(e))
 
-def model_creator(stream, event, dataset_name, log_lvl_number):
+def model_creator(stream, event, event_close, dataset_name, log_lvl_number):
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
         mc = ModelCreator(stream,
+                          event_close,
                           sending_events=False,
                           event_filename=dataset_name + ".csv",
                           event_types_filename=dataset_name + ".json",
                           log_lvl=log_lvl_number)
         event.set()
         mc.start()
-    except KeyboardInterrupt:
-        mc.close()
+    except Exception as e:
+        print("[ERROR] Unhandled exception in Profiler model creator module: {}".format(e))
 
 
 def main():
+    signal.signal(signal.SIGINT, signal_handler)
+
     parser = argparse.ArgumentParser(
         description='Collecting data from Nordic profiler for given time and saving to files.')
     parser.add_argument('time', type=int, help='Time of collecting data [s]')
@@ -47,46 +56,47 @@ def main():
     else:
         log_lvl_number = logging.INFO
 
-    # event is made to ensure that ModelCreator class is initialized before Rtt2Stream starts sending data
+    # Event is made to ensure that ModelCreator class is initialized before Rtt2Stream starts sending data
     event = Event()
+    # Setting these events results in closing corresponding modules.
+    event_close_rtt2stream = Event()
+    event_close_model_creator = Event()
 
     streams = Stream.create_stream(2)
 
-    try:
-        processes = []
-        processes.append(Process(target=rtt2stream,
-                                 args=(streams[0], event, log_lvl_number),
-                                 daemon=True))
-        processes.append(Process(target=model_creator,
-                                 args=(streams[1], event, args.dataset_name, log_lvl_number),
-                                 daemon=True))
+    processes = []
+    processes.append((Process(target=rtt2stream,
+                                args=(streams[0], event, event_close_rtt2stream, log_lvl_number),
+                                daemon=True),
+                        event_close_rtt2stream))
+    processes.append((Process(target=model_creator,
+                                args=(streams[1], event, event_close_model_creator,
+                                    args.dataset_name, log_lvl_number),
+                                daemon=True),
+                        event_close_model_creator))
 
-        for p in processes:
-            p.start()
+    for p, _ in processes:
+        p.start()
 
-        start_time = time.time()
-        is_waiting = True
-        while is_waiting:
-            for p in processes:
-                p.join(timeout=0.5)
-                # Terminate other processes if one of the processes is not active.
-                if len(processes) > len(active_children()):
-                    is_waiting = False
-                    break
+    start_time = time.time()
+    global is_waiting
+    while is_waiting:
+        for p, _ in processes:
+            p.join(timeout=0.5)
+            # Terminate other processes if one of the processes is not active.
+            if len(processes) > len(active_children()):
+                is_waiting = False
+                break
 
-                # Terminate every process on timeout.
-                if (time.time() - start_time) >= args.time:
-                    is_waiting = False
-                    break
+            # Terminate every process on timeout.
+            if (time.time() - start_time) >= args.time:
+                is_waiting = False
+                break
 
-        for p in processes:
-            if p.is_alive():
-                os.kill(p.pid, signal.SIGINT)
-                # Ensure that we stop processes in order to prevent profiler data drop.
-                p.join()
-
-    except KeyboardInterrupt:
-        for p in processes:
+    for p, event_close in processes:
+        if p.is_alive():
+            event_close.set()
+            # Ensure that we stop processes in order to prevent profiler data drop.
             p.join()
 
 if __name__ == "__main__":

--- a/scripts/profiler/model_creator.py
+++ b/scripts/profiler/model_creator.py
@@ -24,6 +24,7 @@ PROFILER_FATAL_ERROR_EVENT_NAME = "_profiler_fatal_error_event_"
 class ModelCreator:
 
     def __init__(self, stream,
+                 event_close,
                  sending_events=False,
                  config=RttNordicConfig,
                  event_filename=None,
@@ -35,9 +36,11 @@ class ModelCreator:
         self.event_types_filename = event_types_filename
         self.csvfile = None
 
+        self.event_close = event_close
+
         timeouts = {
-            'descriptions': None,
-            'events': None
+            'descriptions': 1,
+            'events': 1
         }
         self.stream = stream
         self.stream.set_timeouts(timeouts)
@@ -92,6 +95,10 @@ class ModelCreator:
             try:
                 buf = self.stream.recv_ev()
             except StreamError as err:
+                if err.args[1] == StreamError.TIMEOUT_MSG:
+                    if self.event_close.is_set():
+                        self.close()
+                    continue
                 self.logger.error("Receiving error: {}".format(err))
                 self.close()
             if len(buf) > 0:
@@ -112,7 +119,12 @@ class ModelCreator:
                 bytes = self.stream.recv_desc()
                 break
             except StreamError as err:
-                self.logger.error("Receiving error: {}. Exiting.".format(err))
+                if err.args[1] == StreamError.TIMEOUT_MSG:
+                    if self.event_close.is_set():
+                        self.logger.info("Module closed before receiving event descriptions.")
+                        sys.exit()
+                    continue
+                self.logger.error("Receiving error: {}. Exiting".format(err))
                 sys.exit()
         desc_buf = bytes.decode()
         f = StringIO(desc_buf)
@@ -142,6 +154,7 @@ class ModelCreator:
                 self.stream.send_desc(json_et_string.encode())
             except StreamError as err:
                 self.logger.error("Sending error: {}. Cannot send descriptions.".format(err))
+                sys.exit()
 
     def _read_single_event(self):
         id = int.from_bytes(
@@ -224,6 +237,7 @@ class ModelCreator:
             self.stream.send_ev(event_string.encode())
         except StreamError as err:
             self.logger.error("Sending error: {}. Cannot send event.".format(err))
+            self.close()
 
     def _write_event_to_file(self, csvfile, tracked_event):
         try:

--- a/scripts/profiler/plot_nordic.py
+++ b/scripts/profiler/plot_nordic.py
@@ -18,7 +18,7 @@ import json
 
 from processed_events import ProcessedEvents, EM_MEM_ADDRESS_DATA_DESC
 from events import TrackedEvent, EventType
-from stream import Stream, StreamError
+from stream import StreamError
 from plot_nordic_config import PlotNordicConfig
 
 class MouseButton(Enum):
@@ -61,7 +61,7 @@ class DrawState():
 
 class PlotNordic():
 
-    def __init__(self, own_recv_socket_dict=None, log_lvl=logging.WARNING):
+    def __init__(self, stream=None, log_lvl=logging.WARNING):
         plt.rcParams['toolbar'] = 'None'
         plt.ioff()
         self.plot_config = PlotNordicConfig
@@ -73,12 +73,13 @@ class PlotNordic():
         self.close_event_flag = False
         self.processed_events = ProcessedEvents()
 
-        if own_recv_socket_dict is not None:
+        if stream is not None:
             timeouts = {
                 'descriptions': None,
                 'events': 0
             }
-            self.in_stream = Stream(own_recv_socket_dict, timeouts)
+            self.in_stream = stream
+            self.in_stream.set_timeouts(timeouts)
 
         self.logger = logging.getLogger('Plot Nordic')
         self.logger_console = logging.StreamHandler()
@@ -393,7 +394,7 @@ class PlotNordic():
             try:
                 data = self.in_stream.recv_ev()
             except StreamError as err:
-                if err.args[1] == 'timeout':
+                if err.args[1] == StreamError.TIMEOUT_MSG:
                     break
                 self.logger.error("Receiving error: {}. Exiting".format(err))
                 self.close_event(None)

--- a/scripts/profiler/real_time_plot.py
+++ b/scripts/profiler/real_time_plot.py
@@ -6,43 +6,52 @@
 from multiprocessing import Process, Event, active_children
 import argparse
 import logging
-import os
 import signal
 from stream import Stream
 from rtt2stream import Rtt2Stream
 from model_creator import ModelCreator
 from plot_nordic import PlotNordic
 
-def rtt2stream(stream, event_plot, event_model_creator, log_lvl_number):
+is_waiting = True
+def signal_handler(sig, frame):
+    global is_waiting
+    is_waiting = False
+
+def rtt2stream(stream, event_plot, event_model_creator, event_close, log_lvl_number):
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        rtt2s = Rtt2Stream(stream, log_lvl=log_lvl_number)
+        rtt2s = Rtt2Stream(stream, event_close, log_lvl=log_lvl_number)
         event_plot.wait()
         event_model_creator.wait()
         rtt2s.read_and_transmit_data()
-    except KeyboardInterrupt:
-        rtt2s.close()
+    except Exception as e:
+        print("[ERROR] Unhandled exception in Profiler Rtt to stream module: {}".format(e))
 
-def model_creator(stream, event, dataset_name, log_lvl_number):
+def model_creator(stream, event, event_close, dataset_name, log_lvl_number):
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        mc = ModelCreator(stream,
-                          sending_events=True,
+        mc = ModelCreator(stream, event_close, sending_events=True,
                           event_filename=dataset_name + ".csv",
                           event_types_filename=dataset_name + ".json",
                           log_lvl=log_lvl_number)
         event.set()
         mc.start()
-    except KeyboardInterrupt:
-        mc.close()
+    except Exception as e:
+        print("[ERROR] Unhandled exception in Profiler model creator module: {}".format(e))
 
-def dynamic_plot(stream, event, log_lvl_number):
+def dynamic_plot(stream, event, event_close, log_lvl_number):
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        pn = PlotNordic(stream=stream, log_lvl=log_lvl_number)
+        pn = PlotNordic(stream=stream, event_close=event_close, log_lvl=log_lvl_number)
         event.set()
         pn.plot_events_real_time()
-    except KeyboardInterrupt:
-        pn.close_event(None)
+    except Exception as e:
+        print("[ERROR] Unhandled exception in Plot Nordic module: {}".format(e))
+
 
 def main():
+    signal.signal(signal.SIGINT, signal_handler)
+
     parser = argparse.ArgumentParser(
         description='Collecting data from Nordic profiler for given time, plotting and saving to files.')
     parser.add_argument('dataset_name', help='Name of dataset')
@@ -54,46 +63,48 @@ def main():
     else:
         log_lvl_number = logging.INFO
 
-    # events are made to ensure that PlotNordic and ModelCreator classes are initialized before Rtt2Stream starts sending data
+    # Events are made to ensure that PlotNordic and ModelCreator classes are initialized before Rtt2Stream starts sending data.
     event_plot = Event()
     event_model_creator = Event()
+    # Setting these events results in closing corresponding modules.
+    event_close_rtt2stream = Event()
+    event_close_model_creator = Event()
+    event_close_plot = Event()
 
     streams = Stream.create_stream(3)
 
-    try:
-        processes = []
-        processes.append(Process(target=rtt2stream,
-                                 args=(streams[0], event_plot, event_model_creator,
-                                       log_lvl_number),
-                                 daemon=True))
-        processes.append(Process(target=model_creator,
-                                 args=(streams[1], event_model_creator,
-                                       args.dataset_name, log_lvl_number),
-                                 daemon=True))
-        processes.append(Process(target=dynamic_plot,
-                                 args=(streams[2], event_plot, log_lvl_number),
-                                 daemon=True))
+    processes = []
+    processes.append((Process(target=rtt2stream,
+                              args=(streams[0], event_plot, event_model_creator,
+                                    event_close_rtt2stream, log_lvl_number),
+                              daemon=True),
+                      event_close_rtt2stream))
+    processes.append((Process(target=model_creator,
+                              args=(streams[1], event_model_creator, event_close_model_creator,
+                                    args.dataset_name, log_lvl_number),
+                              daemon=True),
+                      event_close_model_creator))
+    processes.append((Process(target=dynamic_plot,
+                              args=(streams[2], event_plot, event_close_plot, log_lvl_number),
+                              daemon=True),
+                      event_close_plot))
 
-        for p in processes:
-            p.start()
+    for p, _ in processes:
+        p.start()
 
-        is_waiting = True
-        while is_waiting:
-            for p in processes:
-                p.join(timeout=0.5)
-                # Terminate other processes if one of the processes is not active.
-                if len(processes) > len(active_children()):
-                    is_waiting = False
-                    break
+    global is_waiting
+    while is_waiting:
+        for p, _ in processes:
+            p.join(timeout=0.5)
+            # Terminate other processes if one of the processes is not active.
+            if len(processes) > len(active_children()):
+                is_waiting = False
+                break
 
-        for p in processes:
-            if p.is_alive():
-                os.kill(p.pid, signal.SIGINT)
-                # Ensure that we stop processes in order to prevent profiler data drop.
-                p.join()
-
-    except KeyboardInterrupt:
-        for p in processes:
+    for p, event_close in processes:
+        if p.is_alive():
+            event_close.set()
+            # Ensure that we stop processes in order to prevent profiler data drop.
             p.join()
 
 if __name__ == "__main__":

--- a/scripts/profiler/rtt2stream.py
+++ b/scripts/profiler/rtt2stream.py
@@ -10,24 +10,20 @@ import time
 from pynrfjprog.LowLevel import API
 from pynrfjprog.APIError import APIError
 from enum import Enum
-from stream import Stream, StreamError
+from stream import StreamError
 
 class Command(Enum):
     START = 1
     STOP = 2
     INFO = 3
 
-class Rtt2Socket:
-    def __init__(self, own_send_socket_dict, remote_socket_dict, config=RttNordicConfig, log_lvl=logging.INFO):
+class Rtt2Stream:
+    def __init__(self, out_stream, config=RttNordicConfig, log_lvl=logging.INFO):
         self.config = config
 
-        timeouts = {
-            'descriptions': None,
-            'events': None
-        }
-        self.out_stream = Stream(own_send_socket_dict, timeouts, remote_socket_dict=remote_socket_dict)
+        self.out_stream = out_stream
 
-        self.logger = logging.getLogger('Profiler Rtt to socket')
+        self.logger = logging.getLogger('Profiler Rtt to stream')
         self.logger_console = logging.StreamHandler()
         self.logger.setLevel(log_lvl)
         self.log_format = logging.Formatter('[%(levelname)s] %(name)s: %(message)s')
@@ -57,7 +53,7 @@ class Rtt2Socket:
 
     def _connect_rtt(self):
         snr = self.config['device_snr']
-        device_family = Rtt2Socket._rtt_get_device_family(snr)
+        device_family = Rtt2Stream._rtt_get_device_family(snr)
         self.logger.info('Recognized device family: ' + device_family)
         self.jlink = API(device_family)
         self.jlink.open()
@@ -121,11 +117,8 @@ class Rtt2Socket:
             try:
                 self.out_stream.send_ev(buf)
             except StreamError as err:
-                if err.args[1] != 'closed':
-                    self.logger.error("Error. Unable to send data: {}".format(err))
-                # Cannot send more data over socket.
+                self.logger.error("Error: {}. Unable to send remaining data".format(err))
                 break
-
             buf = self._read_bytes()
 
     def _disconnect_rtt(self):
@@ -156,7 +149,7 @@ class Rtt2Socket:
     def _read_all_events_descriptions(self):
         self._send_command(Command.INFO)
         desc_buf = bytearray()
-        # Empty field is send after last event description
+        # Empty field is sent after last event description
         while True:
             try:
                 buf_temp = self.jlink.rtt_read(self.rtt_up_channels['info'],
@@ -177,7 +170,7 @@ class Rtt2Socket:
         try:
             self.out_stream.send_desc(desc_buf)
         except StreamError as err:
-            self.logger.error("Error. Unable to send data: {}".format(err))
+            self.logger.error("Error: {}. Unable to send data".format(err))
             self._disconnect_rtt()
             sys.exit()
 
@@ -189,9 +182,7 @@ class Rtt2Socket:
                 try:
                     self.out_stream.send_ev(buf)
                 except StreamError as err:
-                    if err.args[1] != 'closed':
-                        self.logger.error("Error. Unable to send data: {}".format(err))
-                    # Receiver has been closed.
+                    self.logger.error("Error: {}. Unable to send data".format(err))
                     self._disconnect_rtt()
                     sys.exit()
 


### PR DESCRIPTION
This PR fixes two issues with profiler on Windows:
1. It changes using sockets for communicating between modules to using Python Multiprocessing Pipes - Unix Domain Sockets are not supported on Windows.
2. It changes using OS signals for closing modules to using Python Multiprocessing Events - OS signals are handled differently on Linux and Windows.

Jira: NCSDK-11933