### PR TITLE
manifest: Update Memfault SDK version to 0.27.3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       - find-my
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 0.27.1
+      revision: 0.27.3
       remote: memfault
 
   # West-related configuration for the nrf repository.


### PR DESCRIPTION
Bump the Memfault SDK version to version 0.27.3, which includes
fixes to work with version 2 of the logger.