### PR TITLE
net: lib: nrf_cloud: always add ephemerides and almanac to agps req

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -79,6 +79,7 @@ nrf9160: Asset Tracker
 ----------------------
 
 * Added timestamps to environment sensor data when compiled with :kconfig:`CONFIG_USE_BME680_BSEC`
+* Updated the application to clear the ephemeris and almanac flags from an A-GPS request when P-GPS is enabled.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------
@@ -409,6 +410,7 @@ Libraries for networking
 * :ref:`lib_nrf_cloud_agps` library:
 
   * Removed GNSS socket API support.
+  * Updated to always request ephemerides and almanacs. The application is now responsible for clearing the flags if P-GPS is enabled.
 
 * :ref:`lib_nrf_cloud_pgps` library:
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_agps.c
@@ -90,7 +90,6 @@ int nrf_cloud_agps_request(const struct nrf_modem_gnss_agps_data_frame *request)
 		types[type_count++] = NRF_CLOUD_AGPS_UTC_PARAMETERS;
 	}
 
-#if !defined(CONFIG_NRF_CLOUD_PGPS)
 	if (request->sv_mask_ephe) {
 		types[type_count++] = NRF_CLOUD_AGPS_EPHEMERIDES;
 	}
@@ -98,7 +97,6 @@ int nrf_cloud_agps_request(const struct nrf_modem_gnss_agps_data_frame *request)
 	if (request->sv_mask_alm) {
 		types[type_count++] = NRF_CLOUD_AGPS_ALMANAC;
 	}
-#endif
 
 	if (request->data_flags & NRF_MODEM_GNSS_AGPS_KLOBUCHAR_REQUEST) {
 		types[type_count++] = NRF_CLOUD_AGPS_KLOBUCHAR_CORRECTION;


### PR DESCRIPTION
If P-GPS is also enabled, it is up to the application to clear the
sv_mask_ephe and sv_mask_alm fields before making the request.
NRF91-1291

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>