### PR TITLE
doc: Remove introduction heading line in Gazell user guides

### DIFF
--- a/doc/nrf/ug_gzll.rst
+++ b/doc/nrf/ug_gzll.rst
@@ -7,9 +7,6 @@ Gazell Link Layer
    :local:
    :depth: 2
 
-Introduction
-************
-
 .. gzll_intro_start
 
 Gazell is a protocol for setting up a robust wireless link between a single Host and up to eight Devices in a star network topology.

--- a/doc/nrf/ug_gzp.rst
+++ b/doc/nrf/ug_gzp.rst
@@ -7,9 +7,6 @@ Gazell Pairing
    :local:
    :depth: 2
 
-Introduction
-************
-
 The Gazell Pairing library for the nRF5 Series enables applications to use the Gazell Link Layer to provide a secure wireless link between Gazell nodes.
 The library is customized for pairing a device (for example, a mouse, keyboard, or remote control) with a host (typically a USB dongle) using Gazell.
 


### PR DESCRIPTION
Remove the introduction heading in the Gazell user guides. The rendering adds a horizontal line that does not align with the style in other sections.