### PR TITLE
net: lib: azure_iot_hub: Add API to reset DPS information

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -427,6 +427,7 @@ Libraries for networking
 
   * Added handling of MQTT ping failures and MQTT input failures.
   * Updated the API version used in MQTT connection to Azure IoT Hub to 2020-09-30.
+  * Added the :c:func:`azure_iot_hub_dps_reset` function for resetting the DPS information.
 
 * :ref:`lib_download_client` library:
 

--- a/include/net/azure_iot_hub.h
+++ b/include/net/azure_iot_hub.h
@@ -306,6 +306,15 @@ int azure_iot_hub_method_respond(struct azure_iot_hub_result *result);
  */
 int azure_iot_hub_keepalive_time_left(void);
 
+/** @brief Reset the stored Azure IoT Hub device provisioning data. This can be used to trigger
+ *	   a new provisioning of the device upon next time the device initiates connection
+ *	   to an IoT Hub.
+ *
+ *  @retval 0 If successful.
+ *            Otherwise, a (negative) error code is returned.
+ */
+int azure_iot_hub_dps_reset(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/azure_iot_hub/include/azure_iot_hub_dps.h
+++ b/subsys/net/lib/azure_iot_hub/include/azure_iot_hub_dps.h
@@ -104,6 +104,13 @@ enum dps_reg_state dps_get_reg_state(void);
  */
 bool dps_reg_in_progress(void);
 
+/* @brief Reset DPS information. This will trigger a new device provisioning
+ *	  upon the next connection establishment to Azure IoT Hub.
+ *
+ * @retval 0 if successul, otherwise a negative error code.
+ */
+int dps_reset(void);
+
 /**
  *@}
  */

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -1353,6 +1353,11 @@ int azure_iot_hub_method_respond(struct azure_iot_hub_result *result)
 	return mqtt_publish(&client, &param);
 }
 
+int azure_iot_hub_dps_reset(void)
+{
+	return dps_reset();
+}
+
 static void azure_iot_hub_run(void)
 {
 	int ret;


### PR DESCRIPTION
Add API to reset the stored information received during the
initial device provisioning using DPS.
This can be used to trigger re-provisioning upon the next connection
establishment to Azure IoT Hub.