### PR TITLE
Bluetooth: Mesh: initialize sched_time to fix Coverity warning

### DIFF
--- a/subsys/bluetooth/mesh/scheduler_srv.c
+++ b/subsys/bluetooth/mesh/scheduler_srv.c
@@ -416,7 +416,7 @@ static void run_scheduler(struct bt_mesh_scheduler_srv *srv)
 static void schedule_action(struct bt_mesh_scheduler_srv *srv,
 			    uint8_t idx)
 {
-	struct tm sched_time;
+	struct tm sched_time = {0};
 	struct bt_mesh_schedule_entry *entry = &srv->sch_reg[idx];
 
 	int64_t current_uptime = k_uptime_get();


### PR DESCRIPTION
Coverity throws warning about usage of not initialized
local variable. PR fixes that.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>