### PR TITLE
manifest: Bump zephyr version to bring new openthread upmerge.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0d103dd7318d6103b2c3ebe5bb3b5f342e85ae2a
+      revision: 0cb9125c9c736b1b19af9809a495da83344efc50
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit will bring new version of openthread to NCS and resolve
decreased baudrate issue.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>