### PR TITLE
doc: update NCP host version in docs

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -146,7 +146,7 @@
 .. _`API documentation`:
 .. _`external ZBOSS development guide and API documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.9.0.1/zigbee_devguide.html
 .. _`Stack commissioning start sequence`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.9.0.1/using_zigbee__z_c_l.html#stack_start_initiation
-.. _`ZBOSS NCP Host`: https://developer.nordicsemi.com/Zigbee/ncp_sdk_for_host/ncp_host_v1.0.0.zip
+.. _`ZBOSS NCP Host`: https://developer.nordicsemi.com/Zigbee/ncp_sdk_for_host/ncp_host_v2.0.0.zip
 .. _`NCP Host documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.9.0.1/zboss_ncp_host_intro.html
 .. _`Rebuilding the ZBOSS libraries for host`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.9.0.1/zboss_ncp_host.html#rebuilding_libs
 .. _`process the frame`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.9.0.1/using_zigbee__z_c_l.html#process_zcl_cmd

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -50,7 +50,11 @@ Matter
 Zigbee
 ------
 
+* Updated ZBOSS Zigbee stack to version ``v3.9.0.1+v4.1.0``.
+  See the :ref:`nrfxlib:zboss_changelog` in the nrfxlib documentation for detailed information.
+* Added new version of the :ref:`ug_zigbee_tools_ncp_host` (v2.0.0).
 * Added :ref:`ug_zigee_qsg`.
+* Removed experimental support for Green Power Combo Basic functionality.
 
 Applications
 ============
@@ -505,9 +509,6 @@ Libraries for Zigbee
 * Fixes and improvements in :ref:`Zigbee Shell  <lib_zigbee_shell>` library.
 * Added :ref:`BDB command for printing install codes <bdb_ic_list>` to the :ref:`Zigbee shell <lib_zigbee_shell>` library.
 * Improve logging in :ref:`ZBOSS OSIF <lib_zigbee_osif>` library and :ref:`Zigbee Shell <lib_zigbee_shell>` library.
-* Removed experimental support for Green Power Combo Basic functionality.
-* Updated ZBOSS Zigbee stack to version v3.9.0.1+v4.0.1.
-    See the :ref:`nrfxlib:zboss_changelog` in the nrfxlib documentation for detailed information.
 
 Scripts
 =======

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -57,7 +57,7 @@
 
 .. |zigbee_version| replace:: Zigbee 3.0
 .. |zboss_version| replace:: 3.9.0.1
-.. |zigbee_ncp_package_version| replace:: 1.0.0
+.. |zigbee_ncp_package_version| replace:: 2.0.0
 .. |zigbee_description| replace:: Zigbee is a portable, low-power software networking protocol that provides connectivity over an 802.15.4-based mesh network.
 .. |enable_zigbee_before_testing| replace:: Make sure to configure the Zigbee stack before building and testing this sample.
    See :ref:`ug_zigbee_configuring` for more information.


### PR DESCRIPTION
Bumped NCP host version and link in sdk-nrf.
NCSDK-12029.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>