### PR TITLE
manifest: Update Zephyr to add trace port kconfig setting

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 0d103dd7318d6103b2c3ebe5bb3b5f342e85ae2a
+      revision: 702a872264faaed717159efd8d6b003e77d8fc05
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: f22f0b6582636247db4228ba9f2179bb51535e4b
+      revision: 6c54910691e13f5f3627943111559b0dff712e49
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Add Kconfig option to enable the hardware trace port in the SystemInit()
function.

manifest: Update SoftDevice Controller:
Brings in bugfixes and changes required to pass conformance tests.
See CHANGELOG for additional details.

Signed-off-by: Gregers Gram Rygg <gregers.gram.rygg@nordicsemi.no>