### PR TITLE
applications: serial_lte_modem: fix AT#XSLEEP command

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -195,7 +195,7 @@ int poweroff_uart(void)
 
 	uart_rx_disable(uart_dev);
 	k_sleep(K_MSEC(100));
-	err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_OFF);
+	err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_SUSPENDED);
 	if (err) {
 		LOG_ERR("Can't power off uart: %d", err);
 	}
@@ -799,10 +799,10 @@ void slm_at_host_uninit(void)
 
 	slm_at_uninit();
 
-	/* Power off UART module */
+	/* Suspend UART module */
 	uart_rx_disable(uart_dev);
 	k_sleep(K_MSEC(100));
-	err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_OFF);
+	err = pm_device_state_set(uart_dev, PM_DEVICE_STATE_SUSPENDED);
 	if (err) {
 		LOG_WRN("Can't power off uart: %d", err);
 	}


### PR DESCRIPTION
slm_at_host_uninit and poweroff_uart were broken.
UART driver implementation has been
changed so that PM_DEVICE_STATE_OFF is not supported anymore.
The "AT#XSLEEP" command implementation was changed to use
PM_DEVICE_STATE_SUSPENDED instead.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>