### PR TITLE
Bluetooth: Mesh: check property counter on property server

### DIFF
--- a/subsys/bluetooth/mesh/gen_prop_srv.c
+++ b/subsys/bluetooth/mesh/gen_prop_srv.c
@@ -603,6 +603,11 @@ static int bt_mesh_prop_srv_init(struct bt_mesh_model *model)
 	net_buf_simple_init_with_data(&srv->pub_buf, srv->pub_data,
 				      sizeof(srv->pub_data));
 
+	if (srv->property_count > CONFIG_BT_MESH_PROP_MAXCOUNT) {
+		BT_ERR("Property counter is larger than max allowed value");
+		return -EINVAL;
+	}
+
 #if CONFIG_BT_SETTINGS
 	k_work_init_delayable(&srv->store_timer, store_timeout);
 #endif


### PR DESCRIPTION
The property counter cannot be larger than
configured value in Konfig file.
PR adds strict checking of this rule.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>