### PR TITLE
Bluetooth: Mesh: fix move_set int32 overflow

### DIFF
--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -273,7 +273,7 @@ static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
 	if (move_set->delta != 0 && move_set->transition) {
 		/* Calculate the transition time to edge in the Generic Level space: */
 		int32_t lvl_target = (move_set->delta > 0 ? INT16_MAX : INT16_MIN);
-		int32_t lvl_delta = lvl_target - temp_to_lvl(srv, status.current.temp);
+		int64_t lvl_delta = lvl_target - temp_to_lvl(srv, status.current.temp);
 		uint32_t time_to_edge = (move_set->transition->time * lvl_delta) / move_set->delta;
 
 		if (time_to_edge > 0) {


### PR DESCRIPTION
The calculation of the transition time within
move_set can cause int32_t overflow.
PR fixes the issue.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>