### PR TITLE
zigbee: Change severity level log in serial logger

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_serial_logger.c
+++ b/subsys/zigbee/osif/zb_nrf_serial_logger.c
@@ -107,7 +107,7 @@ void zb_osif_serial_logger_put_bytes(const zb_uint8_t *buf, zb_short_t len)
 	}
 
 	if (k_sem_take(&ringbuf_sem, K_FOREVER)) {
-		LOG_ERR("Couldn't take semaphore, dropping %u bytes", len);
+		LOG_DBG("Couldn't take semaphore, dropping %u bytes", len);
 		return;
 	}
 


### PR DESCRIPTION
Change log severity level for log message that happens when semaphor could not be taken.