### PR TITLE
samples: nrf9160: modem_shell: link: cell event changes and possibility to bypass REL14 feature setting

### DIFF
--- a/samples/nrf9160/modem_shell/overlay-app_fota.conf
+++ b/samples/nrf9160/modem_shell/overlay-app_fota.conf
@@ -4,8 +4,11 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Curl needs to be switched off to free enough flash
+# Some of the MoSh features need to be switched off to free enough flash
 CONFIG_MOSH_CURL=n
+CONFIG_MOSH_REST=n
+CONFIG_MOSH_WORKER_THREADS=n
+CONFIG_MOSH_LOCATION=n
 
 CONFIG_BOOTLOADER_MCUBOOT=y
 CONFIG_IMG_MANAGER=y

--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -30,3 +30,17 @@ tests:
       - nrf9160dk_nrf9160_ns
     extra_args: OVERLAY_CONFIG=overlay-pgps.conf
     tags: ci_build
+  samples.nrf9160.modem_shell.fota:
+    build_only: true
+    platform_allow: nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+    extra_args: OVERLAY_CONFIG=overlay-app_fota.conf
+    tags: ci_build
+  samples.nrf9160.modem_shell.lwm2m:
+    build_only: true
+    platform_allow: nrf9160dk_nrf9160_ns
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+    extra_args: OVERLAY_CONFIG=overlay-lwm2m_carrier.conf
+    tags: ci_build

--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -282,7 +282,8 @@ void link_init(void)
  */
 #if !defined(CONFIG_LWM2M_CARRIER)
 	if (link_sett_is_normal_mode_autoconn_enabled() == true) {
-		link_func_mode_set(LTE_LC_FUNC_MODE_NORMAL);
+		link_func_mode_set(LTE_LC_FUNC_MODE_NORMAL,
+				   link_sett_is_normal_mode_autoconn_rel14_used());
 	}
 #endif
 }
@@ -587,7 +588,7 @@ void link_modem_tau_notifications_unsubscribe(void)
 	}
 }
 
-int link_func_mode_set(enum lte_lc_func_mode fun)
+int link_func_mode_set(enum lte_lc_func_mode fun, bool rel14_used)
 {
 	int return_value = 0;
 	int sysmode;
@@ -604,8 +605,10 @@ int link_func_mode_set(enum lte_lc_func_mode fun)
 		return_value = lte_lc_offline();
 		break;
 	case LTE_LC_FUNC_MODE_NORMAL:
-		/* Enable Rel14 features before going to normal mode */
-		link_enable_rel14_features();
+		if (rel14_used) {
+			/* Enable Rel14 features before going to normal mode */
+			link_enable_rel14_features();
+		}
 
 		/* (Re)register for PDN lib notifications */
 		link_shell_pdn_events_subscribe();

--- a/samples/nrf9160/modem_shell/src/link/link.h
+++ b/samples/nrf9160/modem_shell/src/link/link.h
@@ -27,7 +27,7 @@ void link_modem_sleep_notifications_subscribe(uint32_t warn_time_ms, uint32_t th
 void link_modem_sleep_notifications_unsubscribe(void);
 void link_modem_tau_notifications_subscribe(uint32_t warn_time_ms, uint32_t threshold_ms);
 void link_modem_tau_notifications_unsubscribe(void);
-int link_func_mode_set(enum lte_lc_func_mode fun);
+int link_func_mode_set(enum lte_lc_func_mode fun, bool rel14_used);
 int link_func_mode_get(void);
 void link_rai_read(void);
 int link_rai_enable(bool enable);

--- a/samples/nrf9160/modem_shell/src/link/link_api.h
+++ b/samples/nrf9160/modem_shell/src/link/link_api.h
@@ -13,6 +13,9 @@
 
 #include "mosh_defines.h"
 
+/** SNR offset value that is used when mapping to dBs  */
+#define LINK_SNR_OFFSET_VALUE 24
+
 #define PDP_TYPE_UNKNOWN 0x00
 #define PDP_TYPE_IPV4    0x01
 #define PDP_TYPE_IPV6    0x02
@@ -45,9 +48,31 @@ struct pdp_context_info_array {
 	size_t size;
 };
 
+#define OP_FULL_NAME_STR_MAX_LEN 128
+#define OP_SHORT_NAME_STR_MAX_LEN 64
+#define OP_CELL_ID_STR_MAX_LEN 32
+#define OP_PLMN_STR_MAX_LEN 32
+#define OP_TAC_STR_MAX_LEN 8
+
+struct lte_xmonitor_resp_t {
+	int32_t pci;
+	int32_t rsrp;
+	int32_t snr;
+	int32_t cell_id;
+	uint32_t band;
+	int32_t tac;
+
+	char full_name_str[OP_FULL_NAME_STR_MAX_LEN + 1];
+	char short_name_str[OP_SHORT_NAME_STR_MAX_LEN + 1];
+	char plmn_str[OP_PLMN_STR_MAX_LEN + 1];
+	char cell_id_str[OP_CELL_ID_STR_MAX_LEN + 1];
+	char tac_str[OP_TAC_STR_MAX_LEN + 1];
+};
+
 void link_api_modem_info_get_for_shell(bool connected);
 
-#if defined(CONFIG_AT_CMD)
+int link_api_xmonitor_read(struct lte_xmonitor_resp_t *resp);
+
 void link_api_coneval_read_for_shell(void);
 
 int link_api_pdp_contexts_read(struct pdp_context_info_array *pdp_info);
@@ -71,6 +96,5 @@ struct pdp_context_info *link_api_get_pdp_context_info_by_pdn_cid(int pdn_cid);
  * @return 0 if operation was successful, otherwise an error code.
  */
 int link_api_rai_status(bool *rai_status);
-#endif
 
 #endif /* MOSH_LINK_API_H */

--- a/samples/nrf9160/modem_shell/src/link/link_settings.h
+++ b/samples/nrf9160/modem_shell/src/link/link_settings.h
@@ -51,8 +51,9 @@ int link_sett_save_normal_mode_at_cmd_str(const char *at_str, uint8_t mem_slot);
 int link_sett_clear_normal_mode_at_cmd_str(uint8_t mem_slot);
 void link_sett_normal_mode_at_cmds_shell_print(void);
 
-int link_sett_save_normal_mode_autoconn_enabled(bool enabled);
+int link_sett_save_normal_mode_autoconn_enabled(bool enabled, bool use_rel14);
 bool link_sett_is_normal_mode_autoconn_enabled(void);
+bool link_sett_is_normal_mode_autoconn_rel14_used(void);
 void link_sett_normal_mode_autoconn_shell_print(void);
 
 void link_sett_modem_factory_reset(enum link_sett_modem_reset_type type);


### PR DESCRIPTION
This PR adds following functionalities to mosh `link`  command:
- possibility to bypass the setting of Release 14 features when going to normal mode:
`link nmodeauto --enable_no_rel14`
`link funmode --normal_no_rel14`
- started to use XMONITOR (if not returning error) as a source for printing operator parameters in case of cell change event, otherwise printing the event data as earlier.

Additionally added missing configurations for CI to sample.yaml.