### PR TITLE
subsys/dfu_target: support for multiple mcuboot's image collection

### DIFF
--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -41,6 +41,7 @@ struct dfu_target {
 	int (*offset_get)(size_t *offset);
 	int (*write)(const void *const buf, size_t len);
 	int (*done)(bool successful);
+	int (*schedule_update)(int img_num);
 };
 
 /**
@@ -122,6 +123,20 @@ int dfu_target_done(bool successful);
  *	   code identicating reason of failure.
  **/
 int dfu_target_reset(void);
+
+/**
+ * @brief Schedule update of one or more images.
+ *
+ * This call requests images update. Time of update depends on image type.
+ *
+ * @param[in] img_num For DFU_TARGET_IMAGE_TYPE_MCUBOOT
+ *		      image type: given image pair index or -1 for all
+ *		      of image pair indexes. Disregard otherwise.
+ *
+ * @return 0 for a successful request or a negative error
+ *	   code identicating reason of failure.
+ **/
+int dfu_target_schedule_update(int img_num);
 
 #ifdef __cplusplus
 }

--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -37,7 +37,7 @@ typedef void (*dfu_target_callback_t)(enum dfu_target_evt_id evt_id);
 /** @brief Functions which needs to be supported by all DFU targets.
  */
 struct dfu_target {
-	int (*init)(size_t file_size, dfu_target_callback_t cb);
+	int (*init)(size_t file_size, int img_num, dfu_target_callback_t cb);
 	int (*offset_get)(size_t *offset);
 	int (*write)(const void *const buf, size_t len);
 	int (*done)(bool successful);
@@ -68,6 +68,9 @@ int dfu_target_img_type(const void *const buf, size_t len);
  *	  'dfu_target_offset_get' function after invoking this function.
  *
  * @param[in] img_type Image type identifier.
+ * @param[in] img_num Image pair index. Value different than 0 are supported
+ *		      only for DFU_TARGET_IMAGE_TYPE_MCUBOOT image type
+ *		      currently.
  * @param[in] file_size Size of the current file being downloaded.
  * @param[in] cb Callback function in case the DFU operation requires additional
  *		 proceedures to be called.
@@ -76,7 +79,7 @@ int dfu_target_img_type(const void *const buf, size_t len);
  *	   code identicating reason of failure.
  *
  **/
-int dfu_target_init(int img_type, size_t file_size, dfu_target_callback_t cb);
+int dfu_target_init(int img_type, int img_num, size_t file_size, dfu_target_callback_t cb);
 
 /**
  * @brief Get offset of the firmware upgrade

--- a/include/dfu/dfu_target_full_modem.h
+++ b/include/dfu/dfu_target_full_modem.h
@@ -108,6 +108,17 @@ int dfu_target_full_modem_write(const void *const buf, size_t len);
  */
 int dfu_target_full_modem_done(bool successful);
 
+/**
+ * @brief Schedule update of the image.
+ *
+ * This call does nothing fot this target type.
+ *
+ * @param[in] img_num This parameter is unused by this target type.
+ *
+ * @return 0, it is always successful.
+ **/
+int dfu_target_full_modem_schedule_update(int img_num);
+
 #endif /* DFU_TARGET_FULL_MODEM_H__ */
 
 /**@} */

--- a/include/dfu/dfu_target_full_modem.h
+++ b/include/dfu/dfu_target_full_modem.h
@@ -70,12 +70,13 @@ bool dfu_target_full_modem_identify(const void *const buf);
  * @brief Initialize dfu target, perform steps necessary to receive firmware.
  *
  * @param[in] file_size Size of the current file being downloaded.
+ * @param[in] img_num Image pair index. The value is not used currently.
  * @param[in] callback  Not in use. In place to be compatible with DFU target
  *                      API.
  *
  * @retval 0 If successful, negative errno otherwise.
  */
-int dfu_target_full_modem_init(size_t file_size,
+int dfu_target_full_modem_init(size_t file_size, int img_num,
 			       dfu_target_callback_t callback);
 
 /**

--- a/include/dfu/dfu_target_mcuboot.h
+++ b/include/dfu/dfu_target_mcuboot.h
@@ -95,6 +95,20 @@ int dfu_target_mcuboot_write(const void *const buf, size_t len);
  */
 int dfu_target_mcuboot_done(bool successful);
 
+/**
+ * @brief Schedule update of one or more images.
+ *
+ * This call requests images update. The update will be performed after
+ * the device reset.
+ *
+ * @param[in] img_num Given image pair index or -1 for all
+ *		      of image pair indexes.
+ *
+ * @return 0 for a successful request or a negative error
+ *	   code identicating reason of failure.
+ **/
+int dfu_target_mcuboot_schedule_update(int img_num);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dfu/dfu_target_mcuboot.h
+++ b/include/dfu/dfu_target_mcuboot.h
@@ -60,11 +60,12 @@ bool dfu_target_mcuboot_identify(const void *const buf);
  * @brief Initialize dfu target, perform steps necessary to receive firmware.
  *
  * @param[in] file_size Size of the current file being downloaded.
+ * @param[in] img_num Image pair index.
  * @param[in] cb Callback for signaling events(unused).
  *
  * @retval 0 If successful, negative errno otherwise.
  */
-int dfu_target_mcuboot_init(size_t file_size, dfu_target_callback_t cb);
+int dfu_target_mcuboot_init(size_t file_size, int img_num, dfu_target_callback_t cb);
 
 /**
  * @brief Get offset of firmware

--- a/include/dfu/dfu_target_modem_delta.h
+++ b/include/dfu/dfu_target_modem_delta.h
@@ -68,6 +68,19 @@ int dfu_target_modem_delta_write(const void *const buf, size_t len);
  */
 int dfu_target_modem_delta_done(bool successful);
 
+/**
+ * @brief Schedule update of the image.
+ *
+ * This call requests image update. The update will be performed after
+ * the device reset.
+ *
+ * @param[in] img_num This parameter is unused by this target type.
+ *
+ * @return 0 for a successful request or a negative error
+ *	   code identicating reason of failure.
+ **/
+int dfu_target_modem_delta_schedule_update(int img_num);
+
 #endif /* DFU_TARGET_MODEM_H__ */
 
 /**@} */

--- a/include/dfu/dfu_target_modem_delta.h
+++ b/include/dfu/dfu_target_modem_delta.h
@@ -31,12 +31,13 @@ bool dfu_target_modem_delta_identify(const void *const buf);
  * @brief Initialize dfu target, perform steps necessary to receive firmware.
  *
  * @param[in] file_size Size of the current file being downloaded.
+ * @param[in] img_num Image pair index. The value is not used currently.
  * @param[in] callback Callback function for signaling if the modem is not able
  *		       to service the erase request.
  *
  * @retval 0 If successful, negative errno otherwise.
  */
-int dfu_target_modem_delta_init(size_t file_size,
+int dfu_target_modem_delta_init(size_t file_size, int img_num,
 				dfu_target_callback_t callback);
 
 /**

--- a/subsys/dfu/dfu_target/src/dfu_target.c
+++ b/subsys/dfu/dfu_target/src/dfu_target.c
@@ -14,6 +14,7 @@ static const struct dfu_target dfu_target_ ## name  = { \
 	.offset_get = dfu_target_## name ##_offset_get, \
 	.write = dfu_target_ ## name ## _write, \
 	.done = dfu_target_ ## name ## _done, \
+	.schedule_update = dfu_target_ ## name ## _schedule_update, \
 }
 
 #ifdef CONFIG_DFU_TARGET_MODEM_DELTA
@@ -131,10 +132,6 @@ int dfu_target_done(bool successful)
 		return err;
 	}
 
-	if (successful) {
-		current_target = NULL;
-	}
-
 	return 0;
 }
 
@@ -150,4 +147,18 @@ int dfu_target_reset(void)
 	}
 	current_target = NULL;
 	return 0;
+}
+
+int dfu_target_schedule_update(int img_num)
+{
+	int err = 0;
+
+	if (current_target == NULL) {
+		return -EACCES;
+	}
+
+	err = current_target->schedule_update(img_num);
+	current_target = NULL;
+
+	return err;
 }

--- a/subsys/dfu/dfu_target/src/dfu_target.c
+++ b/subsys/dfu/dfu_target/src/dfu_target.c
@@ -59,7 +59,7 @@ int dfu_target_img_type(const void *const buf, size_t len)
 	return -ENOTSUP;
 }
 
-int dfu_target_init(int img_type, size_t file_size, dfu_target_callback_t cb)
+int dfu_target_init(int img_type, int img_num, size_t file_size, dfu_target_callback_t cb)
 {
 	const struct dfu_target *new_target = NULL;
 
@@ -96,7 +96,7 @@ int dfu_target_init(int img_type, size_t file_size, dfu_target_callback_t cb)
 
 	current_target = new_target;
 
-	return current_target->init(file_size, cb);
+	return current_target->init(file_size, img_num, cb);
 }
 
 int dfu_target_offset_get(size_t *offset)

--- a/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
@@ -78,3 +78,10 @@ int dfu_target_full_modem_done(bool successful)
 
 	return dfu_target_stream_done(successful);
 }
+
+int dfu_target_full_modem_schedule_update(int img_num)
+{
+	ARG_UNUSED(img_num);
+
+	return 0;
+}

--- a/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
@@ -48,7 +48,7 @@ int dfu_target_full_modem_cfg(const struct dfu_target_full_modem_params *params)
 	return 0;
 }
 
-int dfu_target_full_modem_init(size_t file_size,
+int dfu_target_full_modem_init(size_t file_size, int img_num,
 			       dfu_target_callback_t callback)
 {
 	if (!configured) {

--- a/subsys/dfu/dfu_target/src/dfu_target_modem_delta.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_modem_delta.c
@@ -169,22 +169,30 @@ int dfu_target_modem_delta_done(bool successful)
 {
 	int err;
 
+	ARG_UNUSED(successful);
+
 	err = nrf_modem_delta_dfu_write_done();
 	if (err != 0) {
 		LOG_ERR("Failed to stop MFU and release resources, error %d", err);
 		return -EFAULT;
 	}
 
-	if (successful) {
-		err = nrf_modem_delta_dfu_update();
-		if (err != 0) {
-			LOG_ERR("Modem firmware upgrade scheduling failed, error %d", err);
-			return -EFAULT;
-		}
-		LOG_INF("Scheduling modem firmware upgrade at next boot");
-	} else {
-		LOG_INF("Modem upgrade stopped.");
-	}
-
 	return 0;
+}
+
+int dfu_target_modem_delta_schedule_update(int img_num)
+{
+	int err;
+
+	ARG_UNUSED(img_num);
+
+	err = nrf_modem_delta_dfu_update();
+
+	if (err != 0) {
+		LOG_ERR("Modem firmware upgrade scheduling failed, error %d", err);
+		return -EFAULT;
+	}
+	LOG_INF("Scheduling modem firmware upgrade at next boot");
+
+	return err;
 }

--- a/subsys/dfu/dfu_target/src/dfu_target_modem_delta.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_modem_delta.c
@@ -66,7 +66,7 @@ bool dfu_target_modem_delta_identify(const void *const buf)
 	return ((const struct modem_delta_header *)buf)->magic == MODEM_MAGIC;
 }
 
-int dfu_target_modem_delta_init(size_t file_size, dfu_target_callback_t cb)
+int dfu_target_modem_delta_init(size_t file_size, int img_num, dfu_target_callback_t cb)
 {
 	int err;
 	int offset;

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -200,6 +200,10 @@ static int download_client_callback(const struct download_client_evt *event)
 
 	case DOWNLOAD_CLIENT_EVT_DONE:
 		err = dfu_target_done(true);
+		if (err == 0) {
+			err = dfu_target_schedule_update(0);
+		}
+
 		if (err != 0) {
 			LOG_ERR("dfu_target_done error: %d", err);
 			send_error_evt(FOTA_DOWNLOAD_ERROR_CAUSE_DOWNLOAD_FAILED);

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -120,7 +120,7 @@ static int download_client_callback(const struct download_client_evt *event)
 				err_cause = FOTA_DOWNLOAD_ERROR_CAUSE_TYPE_MISMATCH;
 				err = -EPROTOTYPE;
 			} else {
-				err = dfu_target_init(img_type, file_size,
+				err = dfu_target_init(img_type, 0, file_size,
 						      dfu_target_callback_handler);
 				if ((err < 0) && (err != -EBUSY)) {
 					LOG_ERR("dfu_target_init error %d", err);

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -287,6 +287,10 @@ static int firmware_block_received_cb(uint16_t obj_inst_id,
 	if (last_block) {
 		/* Last write to flash should be flush write */
 		ret = dfu_target_done(true);
+		if (ret == 0) {
+			ret = dfu_target_schedule_update(0);
+		}
+
 		if (ret < 0) {
 			LOG_ERR("dfu_target_done error, err %d", ret);
 			goto cleanup;

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -228,7 +228,7 @@ static int firmware_block_received_cb(uint16_t obj_inst_id,
 			configure_full_modem_update();
 		}
 #endif
-		ret = dfu_target_init(image_type, total_size, dfu_target_cb);
+		ret = dfu_target_init(image_type, 0, total_size, dfu_target_cb);
 		if (ret < 0) {
 			LOG_ERR("Failed to init DFU target, err: %d", ret);
 			goto cleanup;

--- a/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
+++ b/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
@@ -202,7 +202,7 @@ static uint8_t ota_dfu_target_init(const uint8_t *magic_word_buf)
 		return err;
 	}
 
-	err = dfu_target_init(img_type, ota_ctx.bin_size,
+	err = dfu_target_init(img_type, 0, ota_ctx.bin_size,
 			      ota_dfu_target_callback_handler);
 	if (err < 0) {
 		LOG_ERR("dfu_target_init err %d", err);

--- a/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
@@ -61,7 +61,7 @@ static void init(void)
 
 	zassert_true(ret > 0, "Valid type not recognized");
 
-	err = dfu_target_init(ret, FILE_SIZE, NULL);
+	err = dfu_target_init(ret, 0, FILE_SIZE, NULL);
 	zassert_equal(err, 0, NULL);
 }
 
@@ -84,10 +84,10 @@ static void test_init(void)
 	ret = dfu_target_img_type(buf, sizeof(buf));
 	zassert_true(ret > 0, "Valid type not recognized");
 
-	err = dfu_target_init(ret, FILE_SIZE, NULL);
+	err = dfu_target_init(ret, 0, FILE_SIZE, NULL);
 	zassert_equal(err, 0, NULL);
 
-	err = dfu_target_init(ret, FILE_SIZE, NULL);
+	err = dfu_target_init(ret, 0, FILE_SIZE, NULL);
 	zassert_equal(err, 0, "Re-initialization should pass");
 
 	err = dfu_target_done(true);
@@ -96,17 +96,17 @@ static void test_init(void)
 	/* Now clean up and try invalid types */
 	done();
 
-	err = dfu_target_init(0, FILE_SIZE, NULL);
+	err = dfu_target_init(0, 0, FILE_SIZE, NULL);
 	zassert_true(err < 0, "Did not fail when invalid type is used");
 
 	done();
 
-	err = dfu_target_init(2, FILE_SIZE, NULL);
+	err = dfu_target_init(2, 0, FILE_SIZE, NULL);
 	zassert_true(err < 0, "Did not fail when invalid type is used");
 
 	init_retval = -42;
 
-	err = dfu_target_init(ret, FILE_SIZE, NULL);
+	err = dfu_target_init(ret, 0, FILE_SIZE, NULL);
 	zassert_equal(err, -42, "Did not return error code from target");
 
 	done();

--- a/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
@@ -25,7 +25,7 @@ bool dfu_target_mcuboot_identify(const void *const buf)
 	return identify_retval;
 }
 
-int dfu_target_mcuboot_init(size_t file_size, dfu_target_callback_t cb)
+int dfu_target_mcuboot_init(size_t file_size, int img_num, dfu_target_callback_t cb)
 {
 	return init_retval;
 }
@@ -48,6 +48,11 @@ int dfu_target_mcuboot_done(bool successful)
 	return done_retval;
 }
 
+int dfu_target_mcuboot_schedule_update(int img_num)
+{
+	return 0;
+}
+
 static void init(void)
 {
 	int err;
@@ -68,6 +73,7 @@ static void init(void)
 static void done(void)
 {
 	(void)dfu_target_done(true);
+	(void)dfu_target_schedule_update(0);
 }
 
 static void test_init(void)

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -86,6 +86,11 @@ int dfu_target_reset(void)
 	return 0;
 }
 
+int dfu_target_schedule_update(int img_num)
+{
+	return 0;
+}
+
 int download_client_start(struct download_client *client, const char *file,
 			  size_t from)
 {

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -41,7 +41,7 @@ static bool fail_on_start;
 static bool download_with_offset_success;
 static download_client_callback_t download_client_event_handler;
 
-int dfu_target_init(int img_type, size_t file_size, dfu_target_callback_t cb)
+int dfu_target_init(int img_type, int img_num, size_t file_size, dfu_target_callback_t cb)
 {
 	return 0;
 }

--- a/west.yml
+++ b/west.yml
@@ -120,7 +120,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 4231c6e38f613d23da92e9e8b093005b478eaf71
+      revision: a82a009ed2612c27c107af80fe80d012293ed51e
       submodules:
         - name: nlio
           path: third_party/nlio/repo
@@ -145,7 +145,7 @@ manifest:
       - homekit
     - name: find-my
       repo-path: sdk-find-my
-      revision: 5f376e7fdc717439b95a549b80bacfdb12820097
+      revision: e045d152e765bf8d91db9d346e3d0d8a10077c22
       groups:
       - find-my
     # Other third-party repositories.


### PR DESCRIPTION
nRF53 bootloader supports simultaneous update of the application and the networking core images.
This patch objective is to introduce support for collecting both images by the application.

This patch makes possible to collect image for multiple images.
dfu_target is kept as one instance entity - so it is able to
collect one image at the time but now its API allow to switch to
other image once previous image collection was finished.

ToDo:
- [x] rework dfu_target_done() and add dfu_target_schedule_update()
 Reason for this change is the preference for schedule updates
 of both images at once in simultaneous multi-image DFU scheme
 where images are likely dependent each other.

~~- [ ] rework progress load to settings subtree load.~~ (will do in another PR)

ref.: NCSDK-12460