### PR TITLE
applications: pelion_client: Fix assertion failed issue

### DIFF
--- a/applications/pelion_client/configuration/nrf9160dk_nrf9160_ns/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
+++ b/applications/pelion_client/configuration/nrf9160dk_nrf9160_ns/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
@@ -7,4 +7,31 @@
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
+
+	pwmleds1 {
+		compatible = "pwm-leds";
+		status = "okay";
+
+		pwm_led1: led_pwm_1 {
+			status = "okay";
+			pwms = <&pwm1 3>;
+			label = "LED Pelion State";
+		};
+	};
+};
+
+&pwm0 {
+	status = "okay";
+	ch0-pin = <2>;
+};
+
+&pwm1 {
+	status = "okay";
+	ch0-pin = <3>;
+};
+
+&pwm_led0 {
+	status = "okay";
+	pwms = <&pwm0 2>;
+	label = "LED Net State";
 };


### PR DESCRIPTION
This change fixes an assertion fail for caf/leds module.
Assertion happens due to missing configuration in DT file.

If exists, board revision specific *.overlay takes precedence over
app.overlay and app.overlay is skipped when application is build.

pelion_client specifies board and version specific overlay file for
nrf9160dk_nrf9160_ns@0.14.0. Because of that contains of app.overlay
must be mirrored in board specific file.

Jira: NCSDK-12497

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>