### PR TITLE
samples: nrf9160: modem_shell: add comment about SUPL server license

### DIFF
--- a/samples/nrf9160/modem_shell/src/gnss/gnss_supl_support.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_supl_support.c
@@ -20,6 +20,7 @@
 
 #include "mosh_print.h"
 
+/* This sample uses Google SUPL server by default. For commercial use, a license is required. */
 #define SUPL_SERVER "supl.google.com"
 #define SUPL_SERVER_PORT 7276
 


### PR DESCRIPTION
Added a comment that a license is required for Google SUPL server commercial usage.