### PR TITLE
caf: sensor_manager: Correct initialization behaviour

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -343,6 +343,8 @@ Updated:
 * The :ref:`caf_power_manager` now has a dependency on :kconfig:`CONFIG_PM_POLICY_APP`, which is required by the application that is using the :ref:`caf_power_manager` to link.
 * Sensor sampler renamed to sensor manager. All references updated.
 * Extended the functionality of the :ref:`caf_sensor_manager` with passive and active power management.
+* Aligned initialization of the :ref:`caf_sensor_manager` with the documentation.
+  The module now reports error state at init, only if all sensors fail to initialize.
 
 
 Modem libraries


### PR DESCRIPTION
During the initialization of sensors, if any fails to initialize,
the module reports error and disallows to sample remaining sensors.

This behaviour is rather an inconvinience; plus it was not aligned
with module documentation.

Fix this by allowing sensor_manager to continue sampling remaining
sensors in case some of them fail to initialize.

Jira: NCSDK-11645

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>