### PR TITLE
samples: zigbee: Change application log level

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -56,6 +56,7 @@ Zigbee
 * Added new version of the :ref:`ug_zigbee_tools_ncp_host` (v2.0.0).
 * Added :ref:`ug_zigee_qsg`.
 * Removed experimental support for Green Power Combo Basic functionality.
+* Changed the default logging level in Zigbee applications to ``INF`` from Zephyr's :ref:`zephyr:logging_api` default level, which is set to ``ERR`` by default.
 
 Applications
 ============

--- a/doc/nrf/ug_zigbee_configuring.rst
+++ b/doc/nrf/ug_zigbee_configuring.rst
@@ -135,6 +135,14 @@ Custom logging per module
 Logging is handled with the :kconfig:`CONFIG_LOG` option.
 This option enables logging for both the stack and Zephyr's :ref:`zephyr:logging_api` API.
 
+.. _zigbee_ug_logging_application_logs:
+
+Default Zigbee application logging
+----------------------------------
+
+The Zigbee application uses the ``INF`` logging level by default.
+This level can be changed only by modifying the sample code.
+
 .. _zigbee_ug_logging_stack_logs:
 
 Stack logs
@@ -179,9 +187,6 @@ If NCP transport channel is used, stack logs are stored in the buffer used for N
 
 Zephyr's logger options
 -----------------------
-
-Zephyr's :ref:`zephyr:logging_api` starts with the default ``ERR`` logging level (only errors reported).
-This level is used by default by the application.
 
 You can configure custom logger options for each Zigbee and ZBOSS module.
 To do this, configure the related Kconfig option for one or more modules:

--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -106,7 +106,7 @@
 #error Define ZB_ROUTER_ROLE to compile router source code.
 #endif
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
 /* Main application customizable context.
  * Stores all settings and static values.

--- a/samples/zigbee/light_switch/src/main.c
+++ b/samples/zigbee/light_switch/src/main.c
@@ -88,7 +88,7 @@
 #error Define ZB_ED_ROLE to compile light switch (End Device) source code.
 #endif
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
 struct bulb_context {
 	zb_uint8_t     endpoint;

--- a/samples/zigbee/ncp/src/main.c
+++ b/samples/zigbee/ncp/src/main.c
@@ -24,7 +24,7 @@
 #include <dfu/mcuboot.h>
 #endif
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
 #if DT_NODE_EXISTS(DT_ALIAS(rst0))
 #define RST_PIN_PORT DT_GPIO_LABEL(DT_ALIAS(rst0), gpios)

--- a/samples/zigbee/network_coordinator/src/main.c
+++ b/samples/zigbee/network_coordinator/src/main.c
@@ -41,7 +41,7 @@
 #error Define ZB_COORDINATOR_ROLE to compile coordinator source code.
 #endif
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
 
 /**@brief Callback used in order to visualise network steering period.

--- a/samples/zigbee/shell/src/main.c
+++ b/samples/zigbee/shell/src/main.c
@@ -37,7 +37,7 @@
 #define IDENTIFY_MODE_BUTTON            DK_BTN4_MSK
 
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
 /* Main application customizable context.
  * Stores all settings and static values.

--- a/samples/zigbee/template/src/main.c
+++ b/samples/zigbee/template/src/main.c
@@ -37,7 +37,7 @@
 #define IDENTIFY_MODE_BUTTON            DK_BTN4_MSK
 
 
-LOG_MODULE_REGISTER(app);
+LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
 /* Main application customizable context.
  * Stores all settings and static values.


### PR DESCRIPTION
Change default Zigbee  application log level to info.
It is expected that the log from the main entry point, showing which sample is being executed, will be visible on the console.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordcisemi.no>