### PR TITLE
doc: update VSC doc site link

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -115,10 +115,10 @@
 .. _`Getting started guide for nRF Asset Tracker for AWS`: https://nordicsemiconductor.github.io/asset-tracker-cloud-docs/v1.6.x/docs/aws/GettingStarted/Index.html
 .. _`Getting started guide for nRF Asset Tracker for Azure`: https://nordicsemiconductor.github.io/asset-tracker-cloud-docs/v1.6.x/docs/azure/GettingStarted/Index.html
 
-.. _`nRF Connect for Visual Studio Code`: https://nordicplayground.github.io/vscode-nrf-connect/
-.. _`Creating an application`: https://nordicplayground.github.io/vscode-nrf-connect/#creating-an-application
-.. _`Building an application`: https://nordicplayground.github.io/vscode-nrf-connect/#building-an-application
-.. _`Testing an application`: https://nordicplayground.github.io/vscode-nrf-connect/#testing-an-application
+.. _`nRF Connect for Visual Studio Code`: https://nrfconnect.github.io/vscode-nrf-connect
+.. _`Creating an application`: https://nrfconnect.github.io/vscode-nrf-connect/create_app.html
+.. _`Building an application`: https://nrfconnect.github.io/vscode-nrf-connect/build_app.html
+.. _`Testing an application`: https://nrfconnect.github.io/vscode-nrf-connect/test_app.html
 
 .. ### Source: developer.nordicsemi.com
 


### PR DESCRIPTION
Update the VSC doc site link to point to the new url.
Remove unused page-specific links.

Signed-off-by: Deidre Casey <deidre.casey@nordicsemi.no>