### PR TITLE
manifest: Pull in Bluetooth Mesh feature freeze patches

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 928e4587c957fc74073996392c0b743ae52afd78
+      revision: pull/669/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updates sdk-zephyr to include Bluetooth Mesh patches required for the
v1.8 feature freeze.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>