### PR TITLE
lib: at_monitor: Fix missing log_strdup on LOG_DBG

### DIFF
--- a/lib/at_monitor/at_monitor.c
+++ b/lib/at_monitor/at_monitor.c
@@ -52,7 +52,7 @@ static void at_monitor_task(struct k_work *work)
 
 	while ((at_notif = k_fifo_get(&at_monitor_fifo, K_NO_WAIT))) {
 		/* Match notification with all monitors */
-		LOG_DBG("AT notif: %s", at_notif->data);
+		LOG_DBG("AT notif: %s", log_strdup(at_notif->data));
 		STRUCT_SECTION_FOREACH(at_monitor_entry, e) {
 			if (!e->paused &&
 			   (e->filter == ANY || strstr(at_notif->data, e->filter))) {


### PR DESCRIPTION
Fix argument 1 in at_monitor_task log dbg message "AT notif: %s"
missing log_strdup().

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>