### PR TITLE
lib: bin: lwm2m_carrier: Add AT+CNUM failure handling

### DIFF
--- a/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
@@ -208,7 +208,7 @@ int lwm2m_carrier_init(const lwm2m_carrier_config_t *config);
 /**
  * @brief LWM2M carrier library main function.
  *
- * This is a non-return function, intended to run on a separate thread.
+ * Intended to run on a separate thread. The function will exit only on non-recoverable errors.
  */
 void lwm2m_carrier_run(void);
 

--- a/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
@@ -42,7 +42,6 @@ void lwm2m_carrier_thread_run(void)
 	}
 
 	lwm2m_carrier_run();
-	CODE_UNREACHABLE;
 }
 
 K_THREAD_DEFINE(lwm2m_carrier_thread, LWM2M_CARRIER_THREAD_STACK_SIZE,

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -359,7 +359,17 @@ int lwm2m_os_at_notif_register_handler(void *context,
 
 int lwm2m_os_at_cmd_write(const char *const cmd, char *buf, size_t buf_len)
 {
-	return at_cmd_write(cmd, buf, buf_len, (enum at_cmd_state *)NULL);
+	enum at_cmd_state state = AT_CMD_OK;
+	int err = at_cmd_write(cmd, buf, buf_len, &state);
+
+	if ((err == 0) && (state != AT_CMD_OK)) {
+		/* Application has enabled AT+CMEE=1 and state indicates an error.
+		 * Report this as if the modem returned ERROR.
+		 */
+		err = -ENOEXEC;
+	}
+
+	return err;
 }
 
 static void at_params_list_get(struct at_param_list *dst,


### PR DESCRIPTION
Handle a situation when SIM does not have subscriber MSISDN.

This happens on new a SIM which have not been registered on the
network yet. Handle this by retry every 10 seconds for up to
10 minutes to let the registration happen.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>