### PR TITLE
doc improvement: add vsc instructions to updating page

### DIFF
--- a/doc/nrf/gs_updating.rst
+++ b/doc/nrf/gs_updating.rst
@@ -14,6 +14,24 @@ You might also want to switch to a newer release or check out the latest state o
 However, if you work with a specific release of the |NCS|, you do not need to update your repositories, because the release will not change.
 For an overview of changes in the latest releases, see :ref:`release_notes`.
 
+.. _gs_updating_vsc:
+
+Updating |VSC|
+**************
+
+Visual Studio Code checks for extension updates and automatically installs them when they are available.
+After an extension is updated, VS Code prompts you to reload the application.
+
+If you disabled automatic updates:
+
+1. Open the :guilabel:`Extensions` tab and locate the |VSC| extension.
+
+#. The :guilabel:`Update` button appears when an update is available.
+   Click on the button to install the update.
+
+The |VSC| extension lets you update west and the associated |NCS| repositories within its :guilabel:`Source Control` panel.
+For detailed instructions, see the `West integration`_ section of the extension's documentation.
+
 .. _west_update:
 
 Updating west

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -119,6 +119,7 @@
 .. _`Creating an application`: https://nrfconnect.github.io/vscode-nrf-connect/create_app.html
 .. _`Building an application`: https://nrfconnect.github.io/vscode-nrf-connect/build_app.html
 .. _`Testing an application`: https://nrfconnect.github.io/vscode-nrf-connect/test_app.html
+.. _`West integration`: https://nrfconnect.github.io/vscode-nrf-connect/west.html
 
 .. ### Source: developer.nordicsemi.com
 


### PR DESCRIPTION
Add information about how to update the VSC extension
Direct users to VSC doc site to update west and repos

Ref: NCSDK-12324

Signed-off-by: Deidre Casey <deidre.casey@nordicsemi.no>