### PR TITLE
doc improvement: use acronym GNSS instead of GPS where appropriate

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -10,7 +10,7 @@ nRF9160: Asset Tracker
 .. note::
    The Asset Tracker application is deprecated and succeeded by the :ref:`asset_tracker_v2` application.
 
-The Asset Tracker demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160-based kit to the `nRF Cloud`_ through LTE, transmit GPS and sensor data, and retrieve information about the device.
+The Asset Tracker demonstrates how to use the :ref:`lib_nrf_cloud` to connect an nRF9160-based kit to the `nRF Cloud`_ through LTE, transmit GNSS and sensor data, and retrieve information about the device.
 
 Overview
 ********
@@ -19,7 +19,7 @@ The application uses the LTE link control driver to establish a network connecti
 It then collects various data locally, and transmits the data to Nordic Semiconductor's cloud solution, `nRF Cloud`_.
 The data is visualized in nRF Cloud's web interface.
 
-The collected data includes the GPS position, accelerometer readings (the device's physical orientation), and data from various environment sensors.
+The collected data includes the GNSS position, accelerometer readings (the device's physical orientation), and data from various environment sensors.
 
 .. list-table::
    :header-rows: 1
@@ -28,8 +28,8 @@ The collected data includes the GPS position, accelerometer readings (the device
    * - Sensor data
      - nRF Cloud sensor type
      - Data unit
-   * - GPS coordinates
-     - GPS
+   * - GNSS coordinates
+     - GNSS
      - NMEA Gxxx string
    * - Accelerometer data
      - FLIP
@@ -49,7 +49,7 @@ The collected data includes the GPS position, accelerometer readings (the device
 
 On the nRF9160 DK, the application uses simulated sensor data by default, but it can be configured with Kconfig options to use real sensors to collect data.
 On the Thingy:91, onboard sensors are used by default.
-GPS is enabled by default on both the kits.
+GNSS is enabled by default on both the kits.
 
 In addition to the sensor data, the application retrieves information from the LTE modem, such as the signal strength, battery voltage, and current operator.
 This information is available in nRF Cloud under the section **Cellular Link Monitor**.
@@ -113,7 +113,7 @@ The buttons and switches have the following functions when the connection is est
 
 Button 1 (SW3 on Thingy:91):
     * Send a BUTTON event to nRF Cloud.
-    * Enable or disable GPS operation (long press the button for a minimum of 10 seconds).
+    * Enable or disable GNSS operation (long press the button for a minimum of 10 seconds).
 
 Switch 1 (only on nRF9160 DK):
     * Toggle to simulate orientation change (flipping) of the kit.
@@ -158,13 +158,13 @@ On the Thingy:91, the application state is indicated by a single RGB LED as foll
    * - Blue
      - Connected, sending environment data
    * - Purple
-     - Searching for GPS
+     - Acquiring GNSS position
    * - Green
-     - GPS has fix, sending GPS and environment data
+     - GNSS has fix, sending GNSS and environment data
    * - Red
      - Error
 
-If multicell location services are used and GPS is not enabled, the LED colors change depending on the number of neighboring cell towers reported by the modem as follows:
+If multicell location services are used and GNSS is not enabled, the LED colors change depending on the number of neighboring cell towers reported by the modem as follows:
 
    * Blue = one cell tower
    * Purple = two cell towers
@@ -189,7 +189,7 @@ Alternatively, you can manually set the configuration options to match the conte
 Using nRF Cloud A-GPS or P-GPS
 ******************************
 By default, this application enables :ref:`lib_nrf_cloud_agps` (Assisted GPS) support.
-Each time the GPS unit attempts to get a location fix, it may require additional information from  `nRF Cloud`_ to speed up the time to get that fix.
+Each time the GNSS unit attempts to get a location fix, it may require additional information from  `nRF Cloud`_ to speed up the time to get that fix.
 
 Alternatively, :ref:`lib_nrf_cloud_pgps` (Predicted GPS) downloads and stores assistance predictions in Flash for one or two weeks, and does not require the cloud to help with each fix.
 
@@ -201,7 +201,7 @@ In order to use A-GPS and P-GPS at the same time, use the following instead:
 
 Using nRF Cloud Cellular Positioning
 ************************************
-If the accuracy of GPS is not required, battery life is very important, and reporting an approximate location is desired, cellular positioning is an option.
+If the accuracy of GNSS is not required, battery life is very important, and reporting an approximate location is desired, cellular positioning is an option.
 
 With cellular positioning:
 
@@ -279,7 +279,7 @@ After programming the application and all prerequisites to your kit, test the As
 #. Observe that the device count on your nRF Cloud dashboard is incremented by one.
 #. Select the device from your device list on nRF Cloud, and observe that sensor data and modem information is received from the kit.
 #. Press Button 1 (SW3 on Thingy:91) to send BUTTON data to nRF Cloud.
-#. Press Button 1 (SW3 on Thingy:91) for a minimum of 10 seconds to enable GPS tracking.
+#. Press Button 1 (SW3 on Thingy:91) for a minimum of 10 seconds to enable GNSS tracking.
    The kit must be outdoors in clear space for a few minutes to get the first position fix.
 #. Optionally send AT commands from the terminal, and observe that the response is received.
 

--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -13,7 +13,7 @@ The Asset Tracker v2 application introduces a set of new features, which are not
 * Offline first - Highly-mobile cellular IoT products need to handle unreliable connections gracefully by implementing mechanisms to retry the failed sending of data.
 * Timestamping on the device - Sensor data is timestamped on the device using multiple time sources. When the device is offline (planned or unplanned), the timestamping does not rely on the cloud side.
 * Batching of data - Data can be batched to reduce the number of messages transmitted, and to be able to retain collected data while the device is offline.
-* Configurable at run time - The application behavior (for example, accelerometer sensitivity or GPS timeout) can be configured at run time. This improves the development experience with individual devices or when debugging the device behavior in specific areas and situations. It also reduces the cost for transmitting data to the devices by reducing the frequency of sending firmware updates to the devices.
+* Configurable at run time - The application behavior (for example, accelerometer sensitivity or GNSS timeout) can be configured at run time. This improves the development experience with individual devices or when debugging the device behavior in specific areas and situations. It also reduces the cost for transmitting data to the devices by reducing the frequency of sending firmware updates to the devices.
 
 Implementation of the above features required a rework of the existing application.
 Hence, this application is not backward compatible to the :ref:`asset_tracker` application.
@@ -105,7 +105,7 @@ The device modes and their descriptions are listed in the following table:
 |          +---------------------+--------------------------------------------------------------------------------------------------------------------------------------+----------------+
 |          | Movement timeout    | Sample and publish data at a minimum of the time interval specified by the parameter. Not dependent on movement.                     | 3600 seconds   |
 +----------+---------------------+--------------------------------------------------------------------------------------------------------------------------------------+----------------+
-| GPS timeout                    | Timeout for acquiring a GPS fix during sampling of the data.                                                                         | 60 seconds     |
+| GPS timeout                    | Timeout for acquiring a GNSS fix during sampling of the data.                                                                        | 60 seconds     |
 +--------------------------------+--------------------------------------------------------------------------------------------------------------------------------------+----------------+
 | Accelerometer threshold        | Accelerometer threshold in m/s². Minimal absolute value in m/s² for the accelerometer readings to be considered as a valid movement. | 10 m/s²        |
 +--------------------------------+--------------------------------------------------------------------------------------------------------------------------------------+----------------+
@@ -203,7 +203,7 @@ The following table shows the LED behavior demonstrated by the application:
 +===========================+=========================+=======================+
 | LTE connection search     | Yellow, blinking        | LED1 blinking         |
 +---------------------------+-------------------------+-----------------------+
-| GPS fix search            | Purple, blinking        | LED2 blinking         |
+| GNSS fix search           | Purple, blinking        | LED2 blinking         |
 +---------------------------+-------------------------+-----------------------+
 | Publishing data           | Green, blinking         | LED3 blinking         |
 +---------------------------+-------------------------+-----------------------+
@@ -351,9 +351,9 @@ The default values for the device configuration parameters can be set by manipul
 
    This configuration sets the Accelerometer threshold value.
 
-.. option:: CONFIG_DATA_GPS_TIMEOUT_SECONDS - Configuration for GPS timeout
+.. option:: CONFIG_DATA_GPS_TIMEOUT_SECONDS - Configuration for GNSS timeout
 
-   This configuration sets the GPS timeout value.
+   This configuration sets the GNSS timeout value.
 
 
 .. _mandatory_config:

--- a/applications/asset_tracker_v2/doc/debug_module.rst
+++ b/applications/asset_tracker_v2/doc/debug_module.rst
@@ -28,9 +28,9 @@ Information that is collected from the device can be sent to Memfault's cloud so
 The debug module uses `Memfault SDK`_ to track |NCS| specific metrics such as LTE and stack metrics.
 In addition, the following types of custom Memfault metrics are defined and tracked when compiling in the debug module:
 
- * ``GpsTimeToFix`` - Time duration between the start of a GPS search and obtaining a fix.
- * ``GpsTimeoutSearchTime`` - Time duration between the start of a GPS search and a search timeout.
- * ``GpsSatellitesTracked`` - Number of satellites tracked during a GPS search window.
+ * ``GpsTimeToFix`` - Time duration between the start of a GNSS search and obtaining a fix.
+ * ``GpsTimeoutSearchTime`` - Time duration between the start of a GNSS search and a search timeout.
+ * ``GpsSatellitesTracked`` - Number of satellites tracked during a GNSS search window.
 
 The debug module also implements `Memfault SDK`_ software watchdog, which is designed to trigger an assert before an actual watchdog timeout.
 This enables the application to be able to collect coredump data before a reboot occurs.

--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -9,15 +9,15 @@ GNSS AT commands
 
 The following commands list contains GNSS-related AT commands.
 
-Run GPS
-=======
+Run GNSS
+========
 
-The ``#XGPS`` command controls the GPS.
+The ``#XGPS`` command controls the GNSS.
 
 Set command
 -----------
 
-The set command allows you to start and stop the GPS.
+The set command allows you to start and stop the GNSS.
 
 Syntax
 ~~~~~~
@@ -28,11 +28,11 @@ Syntax
 
 The ``<op>`` parameter accepts the following integer values:
 
-* ``0`` - Stop GPS
-* ``1`` - Start GPS
+* ``0`` - Stop GNSS
+* ``1`` - Start GNSS
 
 The ``<interval>`` parameter represents the GNSS fix interval in seconds.
-It must be set when starting the GPS.
+It must be set when starting the GNSS.
 It accepts the following integer values:
 
 * ``0`` - Single-fix navigation mode.
@@ -265,16 +265,16 @@ Example
 
   OK
 
-Run GPS with nRF Cloud A-GPS
-============================
+Run GNSS with nRF Cloud A-GPS
+=============================
 
-The ``#XAGPS`` command runs the GPS together with the nRF Cloud A-GPS service.
+The ``#XAGPS`` command runs the GNSS together with the nRF Cloud A-GPS service.
 This requires access to nRF Cloud through the LTE network for receiving A-GPS data.
 
 Set command
 -----------
 
-The set command allows you to start and stop the GPS together with the nRF Cloud A-GPS service.
+The set command allows you to start and stop the GNSS together with the nRF Cloud A-GPS service.
 
 Syntax
 ~~~~~~
@@ -285,11 +285,11 @@ Syntax
 
 The ``<op>`` parameter accepts the following integer values:
 
-* ``0`` - Stop GPS with A-GPS
-* ``1`` - Start GPS with A-GPS
+* ``0`` - Stop GNSS with A-GPS
+* ``1`` - Start GNSS with A-GPS
 
 The ``<interval>`` parameter represents the GNSS fix interval in seconds.
-It must be set when starting the GPS.
+It must be set when starting the GNSS.
 It accepts the following integer values:
 
 * ``0`` - Single-fix navigation mode.
@@ -384,16 +384,16 @@ Example
   OK
 
 
-Run GPS with nRF Cloud P-GPS
-============================
+Run GNSS with nRF Cloud P-GPS
+=============================
 
-The ``#XPGPS`` command runs the GPS together with the nRF Cloud P-GPS service.
+The ``#XPGPS`` command runs the GNSS together with the nRF Cloud P-GPS service.
 This requires access to nRF Cloud through the LTE network for receiving P-GPS data.
 
 Set command
 -----------
 
-The set command allows you to start and stop the GPS together with the nRF Cloud P-GPS service.
+The set command allows you to start and stop the GNSS together with the nRF Cloud P-GPS service.
 
 Syntax
 ~~~~~~
@@ -404,11 +404,11 @@ Syntax
 
 The ``<op>`` parameter accepts the following integer values:
 
-* ``0`` - Stop GPS with P-GPS
-* ``1`` - Start GPS with P-GPS
+* ``0`` - Stop GNSS with P-GPS
+* ``1`` - Start GNSS with P-GPS
 
 The ``<interval>`` parameter represents the GNSS fix interval in seconds.
-It must be set when starting the GPS.
+It must be set when starting the GNSS.
 It accepts the following integer values:
 
 * Ranging from ``10`` to ``1800`` - Periodic navigation mode.

--- a/doc/nrf/libraries/modem/lte_lc.rst
+++ b/doc/nrf/libraries/modem/lte_lc.rst
@@ -9,7 +9,7 @@ LTE link controller
 
 The LTE link controller library provides functionality to control the LTE link on an nRF9160 SiP.
 
-The LTE link can be controlled through library configurations and API calls to enable a range of features such as specifying the Access Point Name (APN), switching between LTE network modes (NB-IoT or LTE-M), enabling GPS support and power saving features such as Power Saving Mode (PSM) and enhanced Discontinuous Reception (eDRX).
+The LTE link can be controlled through library configurations and API calls to enable a range of features such as specifying the Access Point Name (APN), switching between LTE network modes (NB-IoT or LTE-M), enabling GNSS support and power saving features such as Power Saving Mode (PSM) and enhanced Discontinuous Reception (eDRX).
 
 The library also provides functionality that enables the application to receive notifications regarding LTE link health parameters such as Radio Resource Control (RRC) mode, cell information, and the provided PSM or eDRX timer values.
 

--- a/doc/nrf/libraries/modem/modem_info.rst
+++ b/doc/nrf/libraries/modem/modem_info.rst
@@ -19,7 +19,7 @@ It issues AT commands to retrieve the following data:
 * The battery voltage and temperature level, measured by the modem
 * The modem firmware version
 * The modem serial number
-* The LTE-M, NB-IoT, and GPS support mode
+* The LTE-M, NB-IoT, and GNSS support mode
 * Mobile network time and date
 
 The modem information library uses the :ref:`at_cmd_parser_readme`.

--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -11,7 +11,7 @@ The nRF Cloud library enables applications to connect to Nordic Semiconductor's 
 It abstracts and hides the details of the transport and the encoding scheme that is used for the payload and provides a simplified API interface for sending data from supported sensor types to the cloud.
 The current implementation supports the following technologies:
 
-* GPS and FLIP sensor data
+* GNSS and FLIP sensor data
 * TLS secured MQTT as the communication protocol
 * JSON as the data format
 

--- a/doc/nrf/libraries/networking/nrf_cloud_agps.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_agps.rst
@@ -10,8 +10,8 @@ nRF Cloud A-GPS
 The nRF Cloud A-GPS library enables applications to request and process Assisted GPS (`A-GPS`_) data from `nRF Cloud`_ to be used with the nRF9160 SiP.
 This library is an enhancement to the :ref:`lib_nrf_cloud` library.
 
-The use of A-GPS reduces the time for a GPS device to estimate its position, which is also called Time to First Fix (TTFF).
-To get a position fix, a GPS needs information such as the satellite orbital data, exact timing data, and a rough position estimate.
+The use of A-GPS reduces the time for a GNSS module to estimate its position, which is also called Time to First Fix (TTFF).
+To get a position fix, a GNSS module needs information such as the satellite orbital data, exact timing data, and a rough position estimate.
 GPS satellites broadcast this information in a pattern, which repeats every 12.5 minutes.
 If nRF Cloud A-GPS service is used, the broadcasted information can be downloaded at a faster rate from nRF Cloud.
 
@@ -50,13 +50,13 @@ Since the library requests only partial data, data traffic reduction and battery
 The duration for which a particular type of assistance data is valid is different for each type of assistance data.
 As an example, `Almanac`_ data has a far longer validity (several months) than `Ephemeris`_ data (2 to 4 hours).
 
-Since the library receives a partial assistance data set, it may cause GPS to download the missing data from satellites.
+Since the library receives a partial assistance data set, it may cause GNSS to download the missing data from satellites.
 
 When A-GPS data is downloaded using LTE network, the LTE link is in `RRC connected mode <RRC idle mode_>`_.
-The GPS can only operate only when the device is in RRC idle mode.
+The GNSS module can only operate when the device is in RRC idle mode or `Power Saving Mode (PSM)`_.
 The time to go from RRC connected mode to RRC idle mode is network-dependent.
 This time is usually not controlled by the device and is typically in the range of 5 to 70 seconds.
-If the GPS service has already started before the device enters the RRC idle mode, this RRC inactivity may make TTFF appear longer than the actual time spent searching for the GPS satellite signals.
+If the GNSS module has already started before the device enters the RRC idle mode, this RRC inactivity may make TTFF appear longer than the actual time spent searching for the GNSS satellite signals.
 
 Limitation
 **********

--- a/doc/nrf/libraries/others/date_time.rst
+++ b/doc/nrf/libraries/others/date_time.rst
@@ -20,7 +20,7 @@ The information is fetched in the following prioritized order:
 #. If the NTP time request does not succeed, the library tries to request time information from several other NTP servers, before it fails.
 
 The :c:func:`date_time_set` function can be used to obtain the current date-time information from external sources independent of the internal date-time update routine.
-Time from GPS can be such an external source.
+Time from GNSS can be such an external source.
 
 The option :kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE` determines whether date-time update is triggered automatically when the LTE network becomes available.
 Libraries that require date-time information can just enable this library to get updated time information.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -667,6 +667,7 @@ In addition to documentation related to the changes listed above, the following 
   * :ref:`library_template` - added a template for documenting libraries.
   * :ref:`ug_nrf5340` - Added a note about varying folder names of the network core child image when programming with nrfjprog.
   * :ref:`ug_nrf5340` - Updated the :ref:`ug_nrf5340_ses_multi_image` to better match the programming procedure.
+  * Updated documentation to use the acronym GNSS instead of GPS when not talking explicitly about the GPS system.
 
 * Libraries:
 

--- a/doc/nrf/ug_nrf91_features.rst
+++ b/doc/nrf/ug_nrf91_features.rst
@@ -267,25 +267,25 @@ See `GPS interface and antenna`_ for more details on GNSS interface and antenna.
 Obtaining a fix
 ===============
 
-GPS provides lots of useful information including 3D location (latitude, longitude, altitude), time, and velocity.
+GNSS provides lots of useful information including 3D location (latitude, longitude, altitude), time, and velocity.
 
-The time to obtain a fix (also referred to as Time to First Fix (TTFF)) will depend on the time when the GPS receiver was last turned on and used.
+The time to obtain a fix (also referred to as Time to First Fix (TTFF)) will depend on the time when the GNSS receiver was last turned on and used.
 
-Following are the various GPS start modes:
+Following are the various GNSS start modes:
 
-* Cold start - GPS starts after being powered off for a long time with zero knowledge of the time, current location, or the satellite orbits.
-* Warm start - GPS has some coarse knowledge of the time, location, or satellite orbits from a previous fix that is more than around 37 minutes old.
-* Hot start - GPS fix is requested within an interval of around 37 minutes from the last successful fix.
+* Cold start - GNSS starts after being powered off for a long time with zero knowledge of the time, current location, or the satellite orbits.
+* Warm start - GNSS has some coarse knowledge of the time, location, or satellite orbits from a previous fix that is more than around 37 minutes old.
+* Hot start - GNSS fix is requested within an interval of around 37 minutes from the last successful fix.
 
-Each GPS satellite transmits its own `Ephemeris`_ data and common `Almanac`_ data:
+Each satellite transmits its own `Ephemeris`_ data and common `Almanac`_ data:
 
-* Ephemeris data - Provides information about the orbit of the GPS satellite transmitting it. This data is valid for four hours and becomes inaccurate after that.
+* Ephemeris data - Provides information about the orbit of the satellite transmitting it. This data is valid for four hours and becomes inaccurate after that.
 * Almanac data - Provides coarse orbit and status information for each satellite in the constellation. Each satellite broadcasts Almanac data for all satellites.
 
 The data transmission occurs at a slow data rate of 50 bps.
 The orbital data can be received faster using A-GPS.
 
-Due to the clock bias on the receiver, there are four unknowns when looking for a GPS fix - latitude, longitude, altitude, and clock bias.
+Due to the clock bias on the receiver, there are four unknowns when looking for a GNSS fix - latitude, longitude, altitude, and clock bias.
 This results in solving an equation system with four unknowns, and therefore a minimum of four satellites must be tracked to acquire a fix.
 
 Enhancements to GNSS
@@ -317,7 +317,7 @@ Normally, devices connect to the cellular network approximately every two hours 
 P-GPS enables devices to determine the exact orbital location of the satellite without connecting to the network every two hours with a trade-off of reduced accuracy of the calculated position over time.
 Note that P-GPS requires more memory compared to regular A-GPS.
 
-Also, note that due to satellite clock inaccuracies, not all functional satellites will have Ephemerides data valid for two weeks in the downloaded PGPS package.
+Also, note that due to satellite clock inaccuracies, not all functional satellites will have Ephemerides data valid for two weeks in the downloaded P-GPS package.
 This means that the number of satellites having valid predicted Ephemerides reduces in number roughly after ten days.
 Hence, the GNSS module needs to download the Ephemeris data from the satellite broadcast if no predicted Ephemeris is found for that satellite to be able to use the satellite.
 

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -14,7 +14,7 @@ Nordic Thingy:91 is a battery-operated prototyping platform for cellular IoT sys
 
 Thingy:91 integrates the following components:
 
-* nRF9160 SiP - supporting LTE-M, NB-IoT, and Global Positioning System (GPS)
+* nRF9160 SiP - supporting LTE-M, NB-IoT, and Global Navigation Satellite System (GNSS)
 * nRF52840 SoC - supporting Bluetooth® Low Energy and Near Field Communication (NFC)
 
 You can find more information on the product in the `Thingy:91 product page`_ and in the `Nordic Thingy:91 User Guide`_.
@@ -49,7 +49,7 @@ Firmware
 
 The firmware of Thingy:91 has been developed using the |NCS|.
 It is open source, and can be modified according to specific needs.
-The :ref:`asset_tracker` application firmware, which is preprogrammed in the Thingy:91, enables the device to use the environment sensors and provides an option of tracking the device using GPS.
+The :ref:`asset_tracker` application firmware, which is preprogrammed in the Thingy:91, enables the device to use the environment sensors and provides an option of tracking the device using GNSS.
 
 The data, along with information about the device, is transmitted to Nordic Semiconductor's cloud solution, `nRF Cloud`_, where it can be visualized.
 See :ref:`asset_tracker` for more information on the asset tracker application.
@@ -59,11 +59,11 @@ Operating modes
 
 Thingy:91 contains RGB indicator LEDs, which indicate the operating state of the device as described in :ref:`operating states of Thingy:91<thingy91_operating_states>`.
 
-GPS
-===
+GNSS
+====
 
-Thingy:91 has GPS, which, if activated, allows the device to be located globally using GPS signals.
-To activate GPS, long-press the SW3 button.
+Thingy:91 has a GNSS receiver, which, if activated, allows the device to be located globally using GNSS signals.
+To activate GNSS, long-press the SW3 button.
 See :ref:`Button SW3 on Thingy:91<asset_tracker_user_interface>` for information.
 
 LTE Band Lock
@@ -166,7 +166,7 @@ You must use the build target ``thingy91_nrf9160`` or ``thingy91_nrf9160_ns`` wh
 
 .. note::
 
-   LTE/GPS features can only be used with non-secure target.
+   LTE/GNSS features can only be used with non-secure target.
 
 The table below shows the different types of build files that are generated and the different scenarios in which they are used:
 

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -19,7 +19,7 @@ The sample connects using Bluetooth LE to a Thingy:52 running the factory pre-lo
 When the connection is established, it starts collecting data from two sensors:
 
 * The flip state of the Thingy:52
-* The simulated GPS position data
+* The simulated GNSS position data
 
 The sample aggregates the data from both sensors in memory.
 You can then trigger an alarm that sends the aggregated data over LTE to `nRF Cloud`_ by flipping the Thingy:52, which causes a change in the flip state to ``UPSIDE_DOWN``.
@@ -42,7 +42,7 @@ User interface
 
 Two buttons and two switches are used to enter a pairing pattern to associate a specific development kit with an nRF Cloud user account.
 
-When the connection is established, set switch 2 to **N.C.** to send simulated GPS data to nRF Cloud once every 2 seconds.
+When the connection is established, set switch 2 to **N.C.** to send simulated GNSS data to nRF Cloud once every 2 seconds.
 
 See the :ref:`asset_tracker_user_interface` in the :ref:`asset_tracker` documentation for detailed information about the different LED states used by the sample.
 
@@ -114,7 +114,7 @@ After programming the main controller with the sample, you can test it as follow
    #. After reboot, the kit connects to nRF Cloud, and the pattern disappears from the web page.
 #. Observe that LED 4 is turned on to indicate that the connection is established.
 #. Observe that the device count on your nRF Cloud dashboard is incremented by one.
-#. Set switch 2 in the position marked as **N.C.** and observe that simulated GPS data is sent to nRF Cloud.
+#. Set switch 2 in the position marked as **N.C.** and observe that simulated GNSS data is sent to nRF Cloud.
 #. Make sure that the Thingy:52 has established a connection to the application.
    This is indicated by its led blinking green.
 #. Flip the Thingy:52, with the USB port pointing upward, to trigger the sending of the sensor data to nRF Cloud.

--- a/samples/nrf9160/lwm2m_client/README.rst
+++ b/samples/nrf9160/lwm2m_client/README.rst
@@ -28,13 +28,13 @@ Overview
 
 LwM2M is an application layer protocol based on CoAP over UDP.
 It is designed to expose various resources for reading, writing, and executing through an LwM2M server in a very lightweight environment.
-The client sends data such as button and switch states, accelerometer data, temperature, and GPS position to the LwM2M server.
+The client sends data such as button and switch states, accelerometer data, temperature, and GNSS position to the LwM2M server.
 It can also receive activation commands such as buzzer activation and light control.
 
 .. note::
-   The GPS module interferes with the LTE connection.
-   If GPS is not needed or if the device is in an area with poor connection, disable the GPS module.
-   You can disable the GPS module by setting the configuration option :kconfig:`CONFIG_APP_GPS` to ``n``.
+   The GNSS module interferes with the LTE connection.
+   If GNSS is not needed or if the device is in an area with poor connection, disable the GNSS module.
+   You can disable the GNSS module by setting the configuration option :kconfig:`CONFIG_APP_GPS` to ``n``.
 
 
 The following LwM2M objects are implemented in this sample:
@@ -356,16 +356,16 @@ LwM2M objects options
    Disabled objects will not be visible in the server.
    This configuration option can be used for other LwM2M objects also by modifying the option accordingly.
 
-.. option:: CONFIG_APP_GPS - Configuration for enabling GPS functionality
+.. option:: CONFIG_APP_GPS - Configuration for enabling GNSS functionality
 
-   The sample configuration is used to enable the GPS.
-   This configuration might interfere with LTE if the GPS conditions are not optimal.
-   Disable this option if GPS is not needed.
+   The sample configuration is used to enable the GNSS.
+   This configuration might interfere with LTE if the GNSS conditions are not optimal.
+   Disable this option if GNSS is not needed.
 
-.. option::  CONFIG_GPS_PRIORITY_ON_FIRST_FIX - Configuration for prioritizing GPS
+.. option::  CONFIG_GPS_PRIORITY_ON_FIRST_FIX - Configuration for prioritizing GNSS
 
-   The configuration is used to prioritize GPS over LTE during the search for first fix.
-   Enabling this option makes it significantly easier for the GPS module to find a position but will also affect performance for the rest of the application during the search for first fix.
+   The configuration is used to prioritize GNSS over LTE during the search for first fix.
+   Enabling this option makes it significantly easier for the GNSS module to find a position but will also affect performance for the rest of the application during the search for first fix.
 
 .. option:: CONFIG_ENV_SENSOR_USE_SIM - Configuration to enable simulated sensor data
 
@@ -509,11 +509,11 @@ Testing
    #. Press **Button 1** on nRF9160 DK or **SW3** on Thingy:91 and confirm that the button event appears in the terminal.
    #. Check that the button press event has been registered on the LwM2M server by confirming that the press count has been updated.
    #. Retrieve sensor data from various sensors and check if values are reasonable.
-   #. Test GPS module:
+   #. Test GNSS module:
 
       a. Ensure that :kconfig:`CONFIG_GPS_PRIORITY_ON_FIRST_FIX` is enabled.
-      #. Ensure that you are in a location with good GPS signal, preferably outside.
-      #. Wait for the GPS to receive a fix, which will be displayed in the terminal.
+      #. Ensure that you are in a location with good GNSS signal, preferably outside.
+      #. Wait for the GNSS to receive a fix, which will be displayed in the terminal.
          It might take several minutes for the first fix.
 
    #. Try to enable or disable some sensors in menuconfig and check if the sensors


### PR DESCRIPTION
nRF9160 satellite navigation supports also QZSS satellites, so the acronym GNSS should used instead of GPS when not talking explicitly about the GPS system.