### PR TITLE
kconfig: default WARN_EXPERIMENTAL=y

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -25,6 +25,10 @@ config MBEDTLS_LIBRARY_NRF_SECURITY
 
 endchoice
 
+# nRF Connect SDK default experimental warnings to on.
+config WARN_EXPERIMENTAL
+	default y
+
 # This is a temporary solution to whitelist
 # BOARD_THINGY91_NRF9160_NS in compliance
 config BOARD_THINGY91_NRF9160_NS

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -35,7 +35,7 @@ Application development
 
   * Added an option to control the inclusion of RPMsg samples on the nRF53 network core :kconfig:`NCS_INCLUDE_RPMSG_CHILD_IMAGE`.
   * Fixed the NCSIDB-581 bug where application signing and file conversion for Device Firmware Update (DFU) could fail in SEGGER Embedded Studio during a build.
-  * Added possibility to enable build warning when experimental features are enabled, NCSDK-6336.
+  * Build warnings will be printed when experimental features are enabled, NCSDK-6336. Warnings can be disabled by disabling :kconfig:`CONFIG_WARN_EXPERIMENTAL`
   * Updated generation of the :file:`manifest.json` file in the :file:`dfu_application.zip` and :file:`dfu_mcuboot.zip` files to include nrf and zephyr revisions reported by the new build file :file:`zephyr.meta`.
 
 Protocols


### PR DESCRIPTION
This defaults WARN_EXPERIMENTAL=y so that users will see a warning
message when building nRF Connect SDK with experimental features.

Users may still disable this warning if they like.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>