### PR TITLE
tests: enable native posix board for dfu_target_stream

### DIFF
--- a/tests/subsys/dfu/dfu_target_stream/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_stream/testcase.yaml
@@ -2,18 +2,20 @@
 tests:
   dfu.target_stream:
     tags: target_stream
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp native_posix
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
+      - native_posix
   dfu.target_stream.store_progress:
     tags: target_stream
     extra_args: OVERLAY_CONFIG=overlay-store-progress.conf
     # Since we need the storage partition (and hence PM) allow some nRF devices
     # only.
-    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp native_posix
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
+      - native_posix


### PR DESCRIPTION
The test passes on native posix, we should run it there as well.

Ref: NCSDK-12232
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>