### PR TITLE
net: lib: download_client: Disable hostname verification on IP addr

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -178,6 +178,11 @@ Bootloader libraries
 
 * Added a separate section for :ref:`lib_bootloader`.
 
+Libraries for networking
+------------------------
+* :ref:`lib_fota_download` library:
+  * Skipping host name check when connecting to TLS service using just IP address.
+
 Modem libraries
 ---------------
 

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -132,6 +132,11 @@ int dfu_ctx_mcuboot_set_b1_file(char *file, bool s0_active, char **update)
 	return 0;
 }
 
+int z_impl_zsock_inet_pton(sa_family_t family, const char *src, void *dst)
+{
+	return 0;
+}
+
 /* END stubs and mocks */
 
 #ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE


### PR DESCRIPTION
This change checks whether given host name is just numberic IP
address, and if so, does not automatically enable host name
verification of the TLS.