### PR TITLE
doc: update versions for NCS 1.8.0 release

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -19,7 +19,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 project = "nRF Connect SDK"
 copyright = "2019-2021, Nordic Semiconductor"
 author = "Nordic Semiconductor"
-version = release = "1.7.99"
+version = release = "1.8.0"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/nrf/dm_adding_code.rst
+++ b/doc/nrf/dm_adding_code.rst
@@ -92,7 +92,7 @@ This is demonstrated by the following code:
        - name: nrf
          repo-path: sdk-nrf
          remote: ncs
-         revision: v1.7.1
+         revision: v1.8.0
          import: true
      self:
        path: application
@@ -119,7 +119,7 @@ For example:
      projects:
        - name: nrf
          remote: ncs
-         revision: v1.7.1
+         revision: v1.8.0
          import: true
        # Example for how to override a repository in the nRF Connect SDK with your own:
        - name: mcuboot

--- a/doc/nrf/libraries/gazell/gzll_glue.rst
+++ b/doc/nrf/libraries/gazell/gzll_glue.rst
@@ -7,7 +7,7 @@ Gazell Link Layer glue
    :local:
    :depth: 2
 
-The Gazell Link Layer glue module provides the necessary hardware resources to the :ref:`nrfxlib:gzll_glue_layer` in :ref:`nrfxlib:gzll`.
+The Gazell Link Layer glue module provides the necessary hardware resources to the Gazell glue layer in :ref:`nrfxlib:gzll`.
 
 This module is used in the :ref:`gazell_samples`.
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -349,11 +349,11 @@
 
 .. ### Source: www.segger.com
 
-.. _`SEGGER Embedded Studio (Nordic Edition) - Windows x86`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_win_x86
-.. _`SEGGER Embedded Studio (Nordic Edition) - Windows x64`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_win_x64
-.. _`SEGGER Embedded Studio (Nordic Edition) - Mac OS x64`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_macos
-.. _`SEGGER Embedded Studio (Nordic Edition) - Linux x86`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_linux_x86
-.. _`SEGGER Embedded Studio (Nordic Edition) - Linux x64`: https://www.segger.com/downloads/embedded-studio/embeddedstudio_arm_nordic_linux_x64
+.. _`SEGGER Embedded Studio (Nordic Edition) - Windows x86`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v568_win_x86.zip
+.. _`SEGGER Embedded Studio (Nordic Edition) - Windows x64`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v568_win_x64.zip
+.. _`SEGGER Embedded Studio (Nordic Edition) - Mac OS x64`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v568_macos_x64.dmg
+.. _`SEGGER Embedded Studio (Nordic Edition) - Linux x86`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v568_linux_x86.tar.gz
+.. _`SEGGER Embedded Studio (Nordic Edition) - Linux x64`: https://www.segger.com/downloads/embedded-studio/EmbeddedStudio_ARM_Nordic_v568_linux_x64.tar.gz
 
 .. _`J-Link Software and Documentation Pack`: https://www.segger.com/downloads/jlink
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -1,8 +1,8 @@
 .. |NCS| replace:: nRF Connect SDK
 
-.. |release| replace:: v1.7.1
-.. |release_tt| replace:: ``v1.7.1``
-.. |release_number_tt| replace:: ``1.7.1``
+.. |release| replace:: v1.8.0
+.. |release_tt| replace:: ``v1.8.0``
+.. |release_number_tt| replace:: ``1.8.0``
 
 .. |plusminus| unicode:: U+000B1 .. PLUS-MINUS SIGN
    :rtrim:

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -21,7 +21,7 @@ NRFXLIB_BASE = utils.get_projdir("nrfxlib")
 project = "nrfxlib"
 copyright = "2019-2021, Nordic Semiconductor"
 author = "Nordic Semiconductor"
-version = release = "1.7.99"
+version = release = "1.8.0"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/versions.json
+++ b/doc/versions.json
@@ -1,6 +1,7 @@
 {
   "VERSIONS": [
     "latest",
+    "1.8.0",
     "1.7.1",
     "1.7.0",
     "1.6.1",
@@ -22,9 +23,18 @@
   ],
   "COMPONENTS_BY_VERSION": {
     "latest": {
-      "ncs": "1.7.99",
-      "nrfxlib": "1.7.99",
-      "zephyr": "2.6.99",
+      "ncs": "1.8.0",
+      "nrfxlib": "1.8.0",
+      "zephyr": "2.7.99",
+      "mcuboot": "1.7.99",
+      "nrfx": "2.5",
+      "tfm": "1.3.99",
+      "matter": ""
+    },
+    "1.8.0": {
+      "ncs": "1.8.0",
+      "nrfxlib": "1.8.0",
+      "zephyr": "2.7.0",
       "mcuboot": "1.7.99",
       "nrfx": "2.5",
       "tfm": "1.3.99",

--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.8.0-rc2
+      revision: 4fd082590c20abac209f83f6adcd28a21849929e
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Updated files except for VERSION for doc NCS 1.8.0 release.
VERSION to be handled by Vestavind.
NCSDK-12642.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>

-----

- [x] This PR to nrfxlib needs to go in before this one: https://github.com/nrfconnect/sdk-nrfxlib/pull/595
- [x] These PRs to sdk-nrf need to go in before this one: https://github.com/nrfconnect/sdk-nrf/pull/6237 and https://github.com/nrfconnect/sdk-nrf/pull/6340
- [x] Check versions
- [x] Check production statement (update from @umapraseeda ) -- This is updated in https://github.com/nrfconnect/sdk-nrf/pull/6340