### PR TITLE
TF-M: Use secure services from TF-M

### DIFF
--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -30,6 +30,7 @@ config MPSL_FEM_PIN_FORWARDER
 	bool "Forward pin control for front-end module (FEM) to the radio core"
 	depends on SOC_NRF5340_CPUAPP
 	depends on MPSL_FEM_NRF21540_GPIO_SUPPORT
+	depends on !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
 	default y
 
 if MPSL_FEM || MPSL_FEM_PIN_FORWARDER

--- a/subsys/mpsl/fem/mpsl_fem_host.c
+++ b/subsys/mpsl/fem/mpsl_fem_host.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <sys/__assert.h>
 #include <hal/nrf_gpio.h>
+#include <soc_secure.h>
 
 static void fem_pin_num_correction(uint8_t *p_gpio_pin, const char *gpio_lbl)
 {
@@ -49,28 +50,28 @@ static int fem_nrf21540_gpio_pins_forward(void)
 	uint8_t tx_en_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), tx_en_gpios);
 
 	fem_pin_num_correction(&tx_en_pin, DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem), tx_en_gpios));
-	nrf_gpio_pin_mcu_select(tx_en_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(tx_en_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), rx_en_gpios)
 	uint8_t rx_en_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), rx_en_gpios);
 
 	fem_pin_num_correction(&rx_en_pin, DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem), rx_en_gpios));
-	nrf_gpio_pin_mcu_select(rx_en_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(rx_en_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
 	uint8_t pdn_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), pdn_gpios);
 
 	fem_pin_num_correction(&pdn_pin, DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem), pdn_gpios));
-	nrf_gpio_pin_mcu_select(pdn_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(pdn_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), mode_gpios)
 	uint8_t mode_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), mode_gpios);
 
 	fem_pin_num_correction(&mode_pin, DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem), mode_gpios));
-	nrf_gpio_pin_mcu_select(mode_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(mode_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios)
@@ -78,7 +79,7 @@ static int fem_nrf21540_gpio_pins_forward(void)
 
 	fem_pin_num_correction(&ant_sel_pin,
 			       DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios));
-	nrf_gpio_pin_mcu_select(ant_sel_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(ant_sel_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_STATUS(MPSL_FEM_SPI_IF, okay)
@@ -88,10 +89,10 @@ static int fem_nrf21540_gpio_pins_forward(void)
 	uint8_t mosi_pin = DT_PROP(DT_BUS(DT_NODELABEL(nrf_radio_fem_spi)), mosi_pin);
 
 	fem_pin_num_correction(&cs_pin, DT_SPI_DEV_CS_GPIOS_LABEL(MPSL_FEM_SPI_IF));
-	nrf_gpio_pin_mcu_select(cs_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
-	nrf_gpio_pin_mcu_select(sck_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
-	nrf_gpio_pin_mcu_select(miso_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
-	nrf_gpio_pin_mcu_select(mosi_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(cs_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(sck_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(miso_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(mosi_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
 	return 0;
@@ -107,14 +108,14 @@ static int fem_simple_gpio_pins_forward(void)
 	uint8_t ctx_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), ctx_gpios);
 
 	fem_pin_num_correction(&ctx_pin, DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem), ctx_gpios));
-	nrf_gpio_pin_mcu_select(ctx_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(ctx_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), crx_gpios)
 	uint8_t crx_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), crx_gpios);
 
 	fem_pin_num_correction(&crx_pin, DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem), crx_gpios));
-	nrf_gpio_pin_mcu_select(crx_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(crx_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
 	return 0;

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d143ae93cabf2979b4bc3d049145e108a7d7adcf
+      revision: 84381aa76dbc58cc8b6ae4b11be00bd8cce0179f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -112,7 +112,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: b599a2e3b93b256ccb886d3368ab9948845ebac4
+      revision: 6fa4f64be90bffb7354363c550235513f9bb7527
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Remove downstream platform secure services for GPIO MCU select and secure read.
Since upstream board and SoC init code depended on these they are moved to TF-M platform so that they don't rely on out-of-tree platform services.

Set as draft until upstream PR has its dependencies resolved and can be cherry-picked.
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/40725
TF-M review: https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/12685