### PR TITLE
manifest: update mcuboot to reserve area for swapping

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -89,6 +89,13 @@ config NORDIC_QSPI_NOR
 
 DT_ZEPHYR_FLASH := zephyr,flash
 DT_CHOSEN_ZEPHYR_FLASH := $(dt_chosen_path,$(DT_ZEPHYR_FLASH))
+
+config FLASH_LAYOUT_PAGE_SIZE
+	hex
+	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
+	help
+	  Hidden option used to expose page size of chosen flash.
+
 config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
 	help

--- a/west.yml
+++ b/west.yml
@@ -107,7 +107,7 @@ manifest:
       revision: 5ee5972d527ede375f982fcedaeea26f2fb03f10
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 2da20eb0f92974ce1dbcc700a25c43dcddc72b29
+      revision: pull/185/head
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Moving using swap requires one page to work.
Currently there is nothing stopping an image from using all pages
in its partition, which would break the swapping mechanism.

Fix this by introducing a placeholder partition with the size
of a page.

Ref: NCSDK-7203
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>