### PR TITLE
doc: openthread: align with upstream changes

### DIFF
--- a/doc/nrf/includes/thread_configure_network.txt
+++ b/doc/nrf/includes/thread_configure_network.txt
@@ -1,4 +1,4 @@
-Configure the required Thread network parameters with the ``ot channel``, ``ot panid``, and ``ot masterkey`` commands.
+Configure the required Thread network parameters with the ``ot channel``, ``ot panid``, and ``ot networkkey`` commands.
 Make sure to use the same parameters for all nodes that you add to the network.
 The following example uses the default OpenThread parameters:
 
@@ -8,5 +8,5 @@ The following example uses the default OpenThread parameters:
    Done
    uart:~$ ot panid 0xabcd
    Done
-   uart:~$ ot masterkey 00112233445566778899aabbccddeeff
+   uart:~$ ot networkkey 00112233445566778899aabbccddeeff
    Done


### PR DESCRIPTION
"networkkey" replaces "masterkey" command
