### PR TITLE
fprotect: add sys init to protect image

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -173,6 +173,7 @@ Other libraries
 ---------------
 
 * Moved :ref:`lib_bootloader` to a section of their own.
+  * Added write protection by default for the image partition.
 
 Modem library
 +++++++++++++

--- a/lib/fprotect/CMakeLists.txt
+++ b/lib/fprotect/CMakeLists.txt
@@ -17,3 +17,4 @@ endif()
 
 zephyr_library()
 zephyr_library_sources(${FPROTECT_SRC})
+zephyr_library_sources_ifdef(CONFIG_FPROTECT_APP sys_init_fprotect.c)

--- a/lib/fprotect/Kconfig
+++ b/lib/fprotect/Kconfig
@@ -65,3 +65,22 @@ config FPROTECT_ENABLE_IS_PROTECTED
 	depends on FPROTECT && HAS_HW_NRF_ACL
 	help
 	  Enable API to query if an address has been protected.
+
+config FPROTECT_APP
+	bool "Lock image partition using FPROTECT"
+	depends on PARTITION_MANAGER_ENABLED && FPROTECT
+	help
+	  The flash partition which contains the image hex file should never be
+	  written to. Set this option to enable a module which will perform
+	  a 'fprotect_area' operation during system initialization before
+	  the kernel is initialized. This will ensure that the appropriate
+	  locking mechanism is configured to not allow write operations to the
+	  memory partition which contains the image hex file. Note that this
+	  imposes a requirement to the start address and size of the image
+	  hex file: they must both be aligned with the locking granularity
+	  of the locking mechanism available for the current hardware. See
+	  'FPROTECT_BLOCK_SIZE' and set the partition sizes in the system so
+	  that this is aligned with the 'app' partition. The start and size
+	  of the 'app' partition can be found by either inspecting the file
+	  'pm_config.h' in your build directory, or by invoking the
+	  'partition_manager_report' target.

--- a/lib/fprotect/sys_init_fprotect.c
+++ b/lib/fprotect/sys_init_fprotect.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+#include <init.h>
+#include <pm_config.h>
+#include <fprotect.h>
+
+#define PRIORITY_LEVEL 0 /* Locking should be performed as soon as possible */
+
+BUILD_ASSERT(PM_ADDRESS % CONFIG_FPROTECT_BLOCK_SIZE == 0,
+	     "Unable to protect app image since its start address does not "
+	     "align with the locking granularity of fprotect.");
+
+BUILD_ASSERT(PM_SIZE % CONFIG_FPROTECT_BLOCK_SIZE == 0,
+	     "Unable to protect app image since its size does not align with "
+	     "the locking granularity of fprotect.");
+
+static int fprotect_self(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	int err;
+
+	err = fprotect_area(PM_ADDRESS, PM_SIZE);
+	if (err != 0) {
+		__ASSERT(0,
+			 "Unable to lock required area. Check address and "
+			 "size against locking granularity.");
+	}
+
+	return 0;
+}
+
+SYS_INIT(fprotect_self, PRE_KERNEL_1, PRIORITY_LEVEL);

--- a/tests/drivers/fprotect/app/CMakeLists.txt
+++ b/tests/drivers/fprotect/app/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(NONE)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+target_include_directories(app PRIVATE .)

--- a/tests/drivers/fprotect/app/prj.conf
+++ b/tests/drivers/fprotect/app/prj.conf
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_ZTEST=y
+CONFIG_FPROTECT=y
+CONFIG_FPROTECT_APP=y
+
+CONFIG_PM_SINGLE_IMAGE=y
+CONFIG_DEBUG_OPTIMIZATIONS=y
+# Ensure that flash writes are allowed
+CONFIG_FLASH=y
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
+
+# Ensure that 'storage' partition is defined, so that we have somewhere legal
+# to write.
+CONFIG_FLASH_MAP=y
+CONFIG_SETTINGS=y
+CONFIG_NVS=y
+
+# Set the size of the 'storage' partition so that the 'app' partition is 32kB
+# aligned, this should be sufficient for all HW supported by this test.
+CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE=0x8000

--- a/tests/drivers/fprotect/app/src/main.c
+++ b/tests/drivers/fprotect/app/src/main.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <ztest.h>
+#include <pm_config.h>
+#include <device.h>
+#include <string.h>
+#include <drivers/flash.h>
+
+#define STORAGE_LAST_WORD (PM_SETTINGS_STORAGE_END_ADDRESS - 4)
+#define IMAGE_LAST_WORD (PM_APP_END_ADDRESS - 4)
+
+static uint32_t expected_fatal;
+static uint32_t actual_fatal;
+
+void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
+{
+	printk("Caught system error -- reason %d\n", reason);
+	actual_fatal++;
+}
+
+static void test_writing_to_app_image(void)
+{
+	/* Prepare for flash writes */
+	int err;
+	const struct device *flash_dev;
+	static uint8_t val[] = {0xba, 0x53, 0xba, 0x11};
+
+	flash_dev = device_get_binding(PM_APP_DEV_NAME);
+	zassert_not_null(flash_dev, "Could not load flash driver");
+
+	printf("Perform a legal flash write to show that it is supported\n");
+	err = flash_write(flash_dev, STORAGE_LAST_WORD, val, sizeof(val));
+	zassert_equal(err, 0, "Failed when writing to legal flash area");
+
+	zassert_equal(expected_fatal, actual_fatal, "An unexpected fatal error has occurred.\n");
+	expected_fatal++;
+
+	printf("Next we write inside the image and expect a failure\n");
+	printf("The next lines should be a BUS FAULT\n");
+	flash_write(flash_dev, IMAGE_LAST_WORD, val, sizeof(val));
+	zassert_unreachable("Should have BUS FAULTed before coming here.");
+}
+
+static void test_fatal(void)
+{
+	zassert_equal(expected_fatal, actual_fatal,
+			"The wrong number of fatal error has occurred (e:%d != a:%d).\n",
+			expected_fatal, actual_fatal);
+}
+
+void test_main(void)
+{
+	ztest_test_suite(fprotect_test,
+			 ztest_unit_test(test_writing_to_app_image),
+			 ztest_unit_test(test_fatal)
+			 );
+
+	ztest_run_test_suite(fprotect_test);
+}

--- a/tests/drivers/fprotect/app/testcase.yaml
+++ b/tests/drivers/fprotect/app/testcase.yaml
@@ -1,0 +1,10 @@
+tests:
+  lib.fprotect.sys_init_fprotect:
+    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
+      nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf9160dk_nrf9160
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+      - nrf5340dk_nrf5340_cpuapp
+    tags: b0 fprotect


### PR DESCRIPTION
There is no reason not to protect the image partition.
All areas that should be written to are stored in separate
partitions (storage, settings etc.)

Reopening of https://github.com/nrfconnect/sdk-nrf/pull/3264

Ref: NCSDK-6933
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>