### PR TITLE
samples: openthread: Add missing conversion to the THCI file

### DIFF
--- a/samples/openthread/cli/harness/nRF_Connect_SDK.py
+++ b/samples/openthread/cli/harness/nRF_Connect_SDK.py
@@ -1794,7 +1794,7 @@ class OpenThreadTHCI(object):
             P_Prefix = '%016x' % P_Prefix
         else:
             # TestHarness 1.1 converts 2001000000000000 to "2001000000000000" (it's wrong, but not fixed yet.)
-            P_Prefix = '%016x' % P_Prefix
+            P_Prefix = str(P_Prefix)
 
         prefix = self.__convertIp6PrefixStringToIp6Address(P_Prefix)
         print(prefix)


### PR DESCRIPTION
One additional conversion was missing to make THCI work correctly for
NCS.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>