### PR TITLE
Bluetooth: Mesh: Avoid types promotion in Sensor server

### DIFF
--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -799,14 +799,15 @@ static void pub_msg_add(struct bt_mesh_sensor_srv *srv,
 			uint32_t base_period)
 {
 	uint16_t min_int = min_int_get(s, period_div, base_period);
+	uint16_t delta = srv->seq - s->state.seq;
 	int err;
 
-	if (srv->seq - s->state.seq < min_int) {
+	if (delta < min_int) {
 		return;
 	}
 
 	if (!s->state.configured &&
-	    ((srv->seq - s->state.seq) < (1 << period_div))) {
+	    (delta < (1 << period_div))) {
 		/** Don't publish a sensor value with not configured sensor cadence state more
 		 * frequently than base periodic publication.
 		 */
@@ -824,7 +825,7 @@ static void pub_msg_add(struct bt_mesh_sensor_srv *srv,
 		bool delta_triggered = bt_mesh_sensor_delta_threshold(s, value);
 		uint16_t interval = pub_int_get(s, period_div);
 
-		if (!delta_triggered && srv->seq - s->state.seq < interval) {
+		if (!delta_triggered && delta < interval) {
 			return;
 		}
 	}


### PR DESCRIPTION
In the changed expressions C promotes types to signed int. This makes
the comparisons fail when seq wraps around. Cast the result of the
substractions back to uint16_t to get "correct" value even if seq wraps
around.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>