### PR TITLE
manifest: nrf_modem: version 1.4.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 2be3a9c539b86bf7496ac09202ec4df557e17fd6
+      revision: fd79b800bddf63b0a212a70007a6b612226e134c
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
Update manifest for libmodem v1.4.1 release.

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>
Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>