### PR TITLE
doc: Update AWS IoT docs

### DIFF
--- a/doc/nrf/libraries/networking/aws_iot.rst
+++ b/doc/nrf/libraries/networking/aws_iot.rst
@@ -62,8 +62,8 @@ To establish a connection to the AWS IoT message broker, set the following optio
 
 To configure the required library options, complete the following steps:
 
-1. In the `AWS IoT console`_, navigate to :guilabel:`IoT core` > :guilabel:`Manage` > :guilabel:`things` and click on the entry for the *thing* created during the steps of :ref:`creating_a_thing_in_AWS_IoT`.
-#. Navigate to :guilabel:`interact`, find the ``Rest API Endpoint`` and set the configurable option :kconfig:`CONFIG_AWS_IOT_BROKER_HOST_NAME` to this address string.
+1. In the `AWS IoT console`_, navigate to :guilabel:`IoT core` > :guilabel:`Settings`.
+#. Find the ``Endpoint`` address and set the configurable option :kconfig:`CONFIG_AWS_IOT_BROKER_HOST_NAME` to this address string.
 #. Set the option :kconfig:`CONFIG_AWS_IOT_CLIENT_ID_STATIC` to the name of the *thing* created during the aforementioned steps.
 #. Set the security tag configuration :kconfig:`CONFIG_AWS_IOT_SEC_TAG` to the security tag, chosen while `Programming the certificates to the on-board modem of the nRF9160-based kit`_.
 


### PR DESCRIPTION
Where to find the AWS IoT endpoint hostname has changed in the AWS user interface.
Update the AWS library docs accordingly.

Signed-off-by: Gregers Gram Rygg <gregers.gram.rygg@nordicsemi.no>

## Where the current docs (before PR) point to
![The tab which the current docs refer to](https://user-images.githubusercontent.com/149725/144247832-ad482a5a-8eba-473a-bce0-9ca43b43e109.png)

## The new location to find endpoint hostname
![AWS IoT > Settings](https://user-images.githubusercontent.com/149725/144247877-9d7a606a-e249-4709-8e15-cbb047ec7d16.png)


