### PR TITLE
doc: tfm: add missing sphinx tabs extension

### DIFF
--- a/doc/tfm/conf.py
+++ b/doc/tfm/conf.py
@@ -28,6 +28,7 @@ extensions = [
     "m2r2",
     "sphinx.ext.autosectionlabel",
     "sphinxcontrib.plantuml",
+    "sphinx_tabs.tabs",
     "ncs_cache",
     "zephyr.external_content",
 ]


### PR DESCRIPTION
Recent version of TF-M docs require this extension to be rendered
correctly.