### PR TITLE
Bluetooth: Mesh: Fix light representation in periodic publication

### DIFF
--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -832,7 +832,7 @@ static int update_handler(struct bt_mesh_model *model)
 	srv->handlers->light_get(srv, NULL, &status);
 	BT_DBG("Republishing: %u -> %u [%u ms]", status.current, status.target,
 	       status.remaining_time);
-	lvl_status_encode(model->pub->msg, &status, LIGHT_USER_REPR);
+	lvl_status_encode(model->pub->msg, &status, ACTUAL);
 	return 0;
 }
 


### PR DESCRIPTION
According to the mesh model specification, Lightness Server should
always publish in Actual representation. This also applies to periodic
publication.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>