### PR TITLE
samples: openthread: mark TF-M support as experimental

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -63,6 +63,11 @@ config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	default 1084 if SOC_NRF5340_CPUAPP
 	default 1024
 
+# TF-M support in OpenThread is experimental
+config BUILD_WITH_TFM
+	bool
+	select EXPERIMENTAL
+
 endmenu
 
 endif


### PR DESCRIPTION
OpenThread samples can be built and run for the
nrf5340dk_nrf5340_cpuapp_ns built target, which enables
Trusted Firmware-M, however the support is still
experimental.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>