### PR TITLE
doc: openthread: State there are no libraries for cpuapp_ns

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -295,6 +295,7 @@ OpenThread samples
 
   * Support for ``nrf5340dk_nrf5340_cpuapp_ns`` build target for :ref:`zephyr:nrf5340dk_nrf5340`.
     This allows to build the OpenThread samples with Trusted Firmware-M and the PSA crypto API support.
+    This platform is experimental, so :ref:`nrfxlib:ot_libs` will not be generated for it.
 
 Zigbee samples
 --------------


### PR DESCRIPTION
board nrf5340dk_nrf5340_cpuapp_ns is experimental in Thread samples and
no pre-built libraries are generated for it. We need to indicate this in
the release notes.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>