### PR TITLE
Bluetooth: Mesh: Change rem_time type to uint32_t

### DIFF
--- a/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
@@ -18,7 +18,7 @@ struct lightness_ctx {
 	uint16_t target_lvl;
 	uint16_t current_lvl;
 	uint32_t time_per;
-	uint16_t rem_time;
+	uint32_t rem_time;
 };
 
 /* Set up a repeating delayed work to blink the DK's LEDs when attention is


### PR DESCRIPTION
rem_time type should be equal to struct bt_mesh_model_transition->time
type.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>