### PR TITLE
samples: matter: lock: enable GPIO1 for nRF21540DK

### DIFF
--- a/samples/matter/lock/boards/nrf21540dk_nrf52840.overlay
+++ b/samples/matter/lock/boards/nrf21540dk_nrf52840.overlay
@@ -22,9 +22,6 @@
 &uart1 {
 	status = "disabled";
 };
-&gpio1 {
-	status = "disabled";
-};
 &i2c0 {
 	status = "disabled";
 };


### PR DESCRIPTION
Do not turn off GPIO1 used between nRF52840 SoC and nRF21540 FEM.

Signed-off-by: Lukasz Duda <lukasz.duda@nordicsemi.no>