### PR TITLE
doc: samples: add msc to EM Profiler Tracer doc

### DIFF
--- a/doc/nrf/templates/cheat_sheet.rst
+++ b/doc/nrf/templates/cheat_sheet.rst
@@ -50,7 +50,8 @@ Lists
 Diagrams
 ========
 
-You can include Message Sequence Chart (MSC) diagrams in RST by using the ``.. msc::`` directive and including the MSC content, for example:
+You can include Message Sequence Chart (MSC) diagrams in RST by using the ``.. msc::`` directive and including the MSC content, using the syntax described for example here: http://www.mcternan.me.uk/mscgen/.
+Example:
 
 .. code-block:: none
 

--- a/samples/event_manager_profiler_tracer/README.rst
+++ b/samples/event_manager_profiler_tracer/README.rst
@@ -37,6 +37,26 @@ If it is equal to ``5``, Module B sends a :c:struct:`five_sec_event` to Module A
 
 When Module A receives a :c:struct:`five_sec_event` from Module B, it zeros the counter, sends a series of 50 :c:struct:`burst_event`, and simulates work for 100 ms by busy waiting.
 
+.. msc::
+   hscale = "1.3";
+   Main [label="main.c"],ModA [label="Module A"],ModB [label="Module B"];
+   Main>>ModA [label="Configuration event"];
+   ModA rbox ModA [label="Increases the counter"];
+   ModA>>ModB [label="One-second event, counter value 1"];
+   ModB rbox ModB [label="Checks the counter"];
+   ModA rbox ModA [label="Increases the counter"];
+   ModA>>ModB [label="One-second event, counter value 2"];
+   ModB rbox ModB [label="Checks the counter"];
+   |||;
+   ...;
+   ...;
+   |||;
+   ModA rbox ModA [label="Increases the counter"];
+   ModA>>ModB [label="One-second event, counter value 5"];
+   ModB rbox ModB [label="Checks the counter\nCounter value matches 5"];
+   ModA<<ModB [label="Five-second event"];
+   ModA rbox ModA [label="Zeroes the counter\nSends 50 burst events\nSimulates work for 100 ms"];
+
 Configuration
 *************
 


### PR DESCRIPTION
Added MSC diagram to Event Manager Profiler Tracer sample.
NCSDK-12668.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>