### PR TITLE
manifest: Pull in Bluetooth Mesh feature freeze patches

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: pull/669/head
+      revision: c13b3fe1b20bbb07e705d240437e222f5ac41f1b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This is replay of previous commit which was merged accidentally
witch the PR reference.

Updates sdk-zephyr to include Bluetooth Mesh patches required for the
v1.8 feature freeze.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

replay of https://github.com/nrfconnect/sdk-nrf/pull/6205