### PR TITLE
tests: lib: at_cmd_parser: Add extra checks for string lengths

### DIFF
--- a/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
@@ -161,6 +161,7 @@ static void test_params_string_parsing(void)
 	zassert_equal(0, at_params_string_get(&test_list2, 0,
 					      tmpbuf, &tmpbuf_len),
 		      "Get string should not fail");
+	zassert_equal(strlen("+TEST"), tmpbuf_len, "String length mismatch");
 	zassert_equal(0, memcmp("+TEST", tmpbuf, tmpbuf_len),
 		      "The string in tmpbuf should equal to +TEST");
 
@@ -172,6 +173,7 @@ static void test_params_string_parsing(void)
 	zassert_equal(0, at_params_string_get(&test_list2, 2,
 					      tmpbuf, &tmpbuf_len),
 		      "Get string should not fail");
+	zassert_equal(strlen("Hello World!"), tmpbuf_len, "String length mismatch");
 	zassert_equal(0, memcmp("Hello World!", tmpbuf, tmpbuf_len),
 		      "The string in tmpbuf should equal to Hello World!");
 
@@ -192,6 +194,7 @@ static void test_params_string_parsing(void)
 	zassert_equal(0, at_params_string_get(&test_list2, 0,
 					      tmpbuf, &tmpbuf_len),
 		      "Get string should not fail");
+	zassert_equal(strlen("%TEST"), tmpbuf_len, "String length mismatch");
 	zassert_equal(0, memcmp("%TEST", tmpbuf, tmpbuf_len),
 		      "The string in tmpbuf should equal to %TEST");
 
@@ -203,6 +206,7 @@ static void test_params_string_parsing(void)
 	zassert_equal(0, at_params_string_get(&test_list2, 2,
 					      tmpbuf, &tmpbuf_len),
 		      "Get string should not fail");
+	zassert_equal(strlen("Hello World!"), tmpbuf_len, "String length mismatch");
 	zassert_equal(0, memcmp("Hello World!", tmpbuf, tmpbuf_len),
 		      "The string in tmpbuf should equal to Hello World!");
 
@@ -217,6 +221,7 @@ static void test_params_string_parsing(void)
 	zassert_equal(0, at_params_string_get(&test_list2, 0,
 					      tmpbuf, &tmpbuf_len),
 		      "Get string should not fail");
+	zassert_equal(strlen("%TEST"), tmpbuf_len, "String length mismatch");
 	zassert_equal(0, memcmp("%TEST", tmpbuf, tmpbuf_len),
 		      "The string in tmpbuf should equal to %TEST");
 
@@ -229,6 +234,7 @@ static void test_params_string_parsing(void)
 	zassert_equal(0, at_params_string_get(&test_list2, 2,
 					      tmpbuf, &tmpbuf_len),
 		      "Get string should not fail");
+	zassert_equal(strlen("Hello World!"), tmpbuf_len, "String length mismatch");
 	zassert_equal(0, memcmp("Hello World!", tmpbuf, tmpbuf_len),
 		      "The string in tmpbuf should "
 		      "equal to Hello World!");
@@ -244,6 +250,7 @@ static void test_params_string_parsing(void)
 	zassert_equal(0, at_params_string_get(&test_list2, 0,
 					      tmpbuf, &tmpbuf_len),
 		      "Get string should not fail");
+	zassert_equal(strlen("+TEST"), tmpbuf_len, "String length mismatch");
 	zassert_equal(0, memcmp("+TEST", tmpbuf, tmpbuf_len),
 		      "The string in tmpbuf should equal to +TEST");
 
@@ -256,6 +263,7 @@ static void test_params_string_parsing(void)
 	zassert_equal(0, at_params_string_get(&test_list2, 2,
 					      tmpbuf, &tmpbuf_len),
 		      "Get string should not fail");
+	zassert_equal(strlen("FOOBAR"), tmpbuf_len, "String length mismatch");
 	zassert_equal(0, memcmp("FOOBAR", tmpbuf, tmpbuf_len),
 		      "The string in tmpbuf should "
 		      "equal to FOOBAR");


### PR DESCRIPTION
Static analysis tool detected that the buffer length to compare might
exceed the provided string length, which is not correct as the
at_params_string_get() should overwrite the tmpbuf_len value with the
actual string length read.
    
Make sure that the result string length matches the expected one before
doing memcmp to prevent such reports in the future.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>