### PR TITLE
Bluetooth: Mesh: Add undefined value for delta trigger format

### DIFF
--- a/subsys/bluetooth/mesh/sensor_types.c
+++ b/subsys/bluetooth/mesh/sensor_types.c
@@ -496,7 +496,7 @@ FORMAT(percentage_16) = SCALAR_FORMAT_MAX(2,
 					  SCALAR(1e-2, 0),
 					  10000);
 FORMAT(percentage_delta_trigger) = SCALAR_FORMAT(2,
-					  (UNSIGNED),
+					  (UNSIGNED | HAS_UNDEFINED),
 					  percent,
 					  SCALAR(1e-2, 0));
 


### PR DESCRIPTION
This allows to use 0xFFFF as value is not known.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>