### PR TITLE
CODEOWNERS: Add code owner for bluetooth gatt_dm

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -203,6 +203,7 @@ Kconfig*                                  @tejlmand
 /tests/modules/lib/cddl-gen/              @oyvindronningstad
 /tests/modules/mcuboot/external_flash/    @hakonfam @sigvartmh
 /tests/modules/tfm/                       @SebastianBoe @joerchan @torsteingrindvik @magnev
+/tests/subsys/bluetooth/gatt_dm/          @doki-nordic
 /tests/subsys/bluetooth/mesh/             @trond-snekvik
 /tests/subsys/bootloader/                 @hakonfam
 /tests/subsys/debug/cpu_load/             @nordic-krch


### PR DESCRIPTION
After consults with bluetooth team, the test of gatt_dm should be
assigned as following:

/tests/subsys/bluetooth/gatt_dm/          @doki-nordic

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>