### PR TITLE
doc: requirements: force mistune < 2.0

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -10,3 +10,4 @@ pyyaml
 azure-storage-blob
 sphinx_markdown_tables
 markdown<3.3.5 # Workaround for ryanfox/sphinx-markdown-tables#34
+mistune<2.0 # Workaround for https://github.com/CrossNox/m2r2/issues/40


### PR DESCRIPTION
The m2r2 dependency is not ready yet for mistine 2.0, so force the
dependency to lower versions until m2r2 does this (or is upgraded).