### PR TITLE
application: asset_tracker_v2: Increase thread stack sizes

### DIFF
--- a/applications/asset_tracker_v2/src/modules/Kconfig.debug_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.debug_module
@@ -36,7 +36,7 @@ config DEBUG_MODULE_MEMFAULT_WATCHDOG_DELTA_MS
 
 config DEBUG_MODULE_MEMFAULT_THREAD_STACK_SIZE
 	int "Debug module Memfault thread stack size"
-	default 1024
+	default 1152
 
 config DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX
 	int "Fragment size of data transmitted to memfault"

--- a/applications/asset_tracker_v2/src/modules/Kconfig.sensor_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.sensor_module
@@ -13,7 +13,7 @@ if SENSOR_MODULE
 
 config SENSOR_THREAD_STACK_SIZE
 	int "Sensor module thread stack size"
-	default 1024
+	default 1152
 
 rsource "../ext_sensors/Kconfig"
 


### PR DESCRIPTION
Increase thread stack sizes for `mflt_send_thread` and
`sensor_module_thread` to avoid a potential stack overflow.

After analyzing the stack usage of each thread in the application,
the memfault send thread and sensor module thread maxed
out at 96% and 99%, respectively.

Addresses CIA-475

Signed-off-by: Simen S. Røstad <simen.rostad@nordicsemi.no>