### PR TITLE
samples: openthread: add dongle to the supported list

### DIFF
--- a/samples/openthread/coprocessor/README.rst
+++ b/samples/openthread/coprocessor/README.rst
@@ -66,7 +66,7 @@ The sample supports the following development kits for testing the network statu
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
+   :rows: nrf52840dk_nrf52840, nrf52840dongle_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
 
 To test the sample, you need at least one development kit.
 Additional development kits programmed with the Co-processor sample can be used for the :ref:`optional testing of network joining <ot_coprocessor_sample_testing_more_boards>`.


### PR DESCRIPTION
In the border router desription we point customers to use our rcp sample
on a dongle, however the sample documentation does not list this board
in supported list.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>