### PR TITLE
caf: power_manager: Clear RESETREAS

### DIFF
--- a/subsys/caf/modules/power_manager.c
+++ b/subsys/caf/modules/power_manager.c
@@ -10,6 +10,7 @@
 #include <device.h>
 #include <drivers/gpio.h>
 #include <hal/nrf_power.h>
+#include <helpers/nrfx_reset_reason.h>
 
 #include <event_manager.h>
 #include <profiler.h>
@@ -132,6 +133,10 @@ static void system_off(void)
 		set_power_state(POWER_STATE_OFF);
 		LOG_WRN("System turned off");
 		LOG_PANIC();
+		/* Clear RESETREAS to avoid starting serial recovery if nobody
+		 * has cleared it already.
+		 */
+		nrfx_reset_reason_clear(nrfx_reset_reason_get());
 		pm_power_state_force((struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
 	} else {
 		LOG_WRN("System suspended");

--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 45ba885ca0cb3312a01e6781049229645e6ea79b
+      revision: 800d4756702f07364f32538a6f0263c16be3eafc
       path: bootloader/mcuboot
     - name: nrfxlib
       repo-path: sdk-nrfxlib


### PR DESCRIPTION
This commit clears reset reason just before system OFF.
This way we avoid the situation where waking up the system
by the button that is assigned to serial recovery
would enter mcuboot and wait a command here.
