### PR TITLE
lib: fota_download: Button re-enable after err in download_with_offset

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -103,6 +103,13 @@ Modem libraries
 * :ref:`at_cmd_parser_readme` library:
   * Can now parse AT command responses containing the response result, for example, ``OK`` or ``ERROR``.
 
+Libraries for networking
+========================
+
+* :ref:`lib_fota_download` library:
+
+  * Fixed an issue where the application would not be notified of errors originating from inside :c:func:`download_with_offset`. In the http_update samples, this would result in the dfu start button interrupt being disabled after a connect error in :c:func:`download_with_offset` after a disconnect during firmware download.
+
 sdk-nrfxlib
 -----------
 

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -256,12 +256,14 @@ static void download_with_offset(struct k_work *unused)
 	int err = dfu_target_offset_get(&offset);
 	if (err != 0) {
 		LOG_ERR("%s failed to get offset with error %d", __func__, err);
+		send_error_evt(FOTA_DOWNLOAD_ERROR_CAUSE_DOWNLOAD_FAILED);
 		return;
 	}
 
 	err = download_client_connect(&dlc, dlc.host, &dlc.config);
 	if (err != 0) {
 		LOG_ERR("%s failed to connect with error %d", __func__, err);
+		send_error_evt(FOTA_DOWNLOAD_ERROR_CAUSE_DOWNLOAD_FAILED);
 		return;
 	}
 
@@ -269,6 +271,7 @@ static void download_with_offset(struct k_work *unused)
 	if (err != 0) {
 		LOG_ERR("%s failed to start download  with error %d", __func__,
 			err);
+		send_error_evt(FOTA_DOWNLOAD_ERROR_CAUSE_DOWNLOAD_FAILED);
 		return;
 	}
 	LOG_INF("Downloading from offset: 0x%x", offset);


### PR DESCRIPTION
After disconnecting from the net in the middle of a download,
fota_download have the ability to restart from the point it left off
when dfu is re-started. In this case, the download_with_offset()
function will be called.

If an error happens in the download_with_offset() function,
the dfu is stopped and the button used in the http_update samples for
starting the dfu will not have been re-enabled. This makes it
impossible to restart dfu without resetting the board, in case of
an error in download_with_offset().

fota_download will now send error event to application so application
can re-enable the button.

NRF91-1287

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>