### PR TITLE
lib: bin: lwm2m_carrier: Document lwm2m_carrier_run exit

### DIFF
--- a/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h
@@ -251,7 +251,7 @@ int lwm2m_carrier_init(const lwm2m_carrier_config_t *config);
 /**
  * @brief LwM2M carrier library main function.
  *
- * This is a non-return function, intended to run on a separate thread.
+ * Intended to run on a separate thread. The function will exit only on non-recoverable errors.
  */
 void lwm2m_carrier_run(void);
 


### PR DESCRIPTION
Document that lwm2m_carrier_run() will exit on non-recoverable
errors.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>