### PR TITLE
application: asset_tracker_v2: Enable doreply flag in cell pos request

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
@@ -245,7 +245,13 @@ int cloud_codec_encode_neighbor_cells(struct cloud_codec_data *output,
 		return -ENODATA;
 	}
 
-	err = nrf_cloud_cell_pos_request_json_get(&info, false, &root_obj);
+	/* Set the request location flag when encoding the cellular position request.
+	 * In general, the application does not care about
+	 * getting the location back from cellular position requests. However, this is
+	 * needed to ensure that the cellular location of the application
+	 * is visualized in the nRF Cloud web UI.
+	 */
+	err = nrf_cloud_cell_pos_request_json_get(&info, true, &root_obj);
 	if (err) {
 		LOG_ERR("nrf_cloud_cell_pos_request_json_get, error: %d", err);
 		return -ENOMEM;


### PR DESCRIPTION
Enable `doreply` flag in cell position requests and filter (ignore) the
corresponding responses carrying the approximate location of the
device.

Due to ongoing changes in nRF Cloud regarding visualization of location
based on cellular measurements, it might be necessary to request
the response to cellular position request. If this is not needed anymore
this commit will be reverted in the future.

In general, the application does not care about getting the location
back from cellular position requests. However, this commit is
needed to ensure that the cellular location of the application on
tag v1.8.0 will be visualized in the nRF Cloud web UI, regardless.

Fixes CIA-477