### PR TITLE
manifest: update homekit revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -136,7 +136,7 @@ manifest:
       revision: c6af068b7f05207b28d68880740e4b9ec1e4b50a
     - name: homekit
       repo-path: sdk-homekit
-      revision: v1.8.0-rc2
+      revision: c09a4539359da983f41d6195733464772662e1d0
       groups:
       - homekit
     - name: find-my


### PR DESCRIPTION
This commit updates sdk-homekit revisions to bring in
the latest changes in the homekit component.

- [x] fix: samples: multi-image support for nRF5340
- [x] BLE: fix bus fault
- [x] BLE: fix advertising interval

Signed-off-by: Mariusz Poslinski <mariusz.poslinski@nordicsemi.no>