### PR TITLE
scripts: profiler: Pin version of pynrfjprog

### DIFF
--- a/scripts/profiler/requirements.txt
+++ b/scripts/profiler/requirements.txt
@@ -1,3 +1,3 @@
-pynrfjprog
+pynrfjprog<=10.12.2
 matplotlib
 numpy


### PR DESCRIPTION
Change pins used version of pynrfjprog. Newer versions of this Python library introduce issues related to closing scripts with
Ctrl+C combination. The SIGINT stops underlying worker process of the pynrfjprog library and causes error when scripts read the remaining data.

Jira: NCSDK-12784