### PR TITLE
doc improvement: fix style and typos in sdk-nrf

### DIFF
--- a/applications/matter_weather_station/README.rst
+++ b/applications/matter_weather_station/README.rst
@@ -47,7 +47,7 @@ Matter weather station build types
 ==================================
 
 The Matter weather station application does not use a single :file:`prj.conf` file.
-Configuration files are provided for different build types and they are located in the `configuration/thingy53_nrf5340_cpuapp` directory.
+Configuration files are provided for different build types and they are located in the :file:`configuration/thingy53_nrf5340_cpuapp` directory.
 
 The :file:`prj.conf` file represents a ``debug`` build type.
 Other build types are covered by dedicated files with the build type added as a suffix to the ``prj`` part, as per the following list.

--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -489,7 +489,7 @@ No additional software or drivers are required.
       .. figure:: /images/nrf_desktop_dongle_usb.svg
          :alt: nRF Desktop dongle
 
-      The dongle has an USB connector located at one end of the board.
+      The dongle has a USB connector located at one end of the board.
       It should be inserted to the USB slot located on the host.
 
 ..
@@ -1083,9 +1083,9 @@ First, create a new motion sensor driver that will provide code for communicatio
 Use the two existing |NCS| sensor drivers as an example.
 
 The communication between the application and the sensor is done through a sensor driver API (see :ref:`sensor_api`).
-For motion module to work correctly, the driver must support a trigger (see ``sensor_trigger_set``) on a new data (see ``SENSOR_TRIG_DATA_READY`` trigger type).
+For the motion module to work correctly, the driver must support a trigger (see ``sensor_trigger_set``) on a new data (see ``SENSOR_TRIG_DATA_READY`` trigger type).
 
-When motion data is ready, the driver calls a registered callback.
+When the motion data is ready, the driver calls a registered callback.
 The application starts a process of retrieving a motion data sample.
 The motion module calls ``sensor_sample_fetch`` and then ``sensor_channel_get`` on two sensor channels, ``SENSOR_CHAN_POS_DX`` and ``SENSOR_CHAN_POS_DY``.
 The driver must support these two channels.
@@ -1145,7 +1145,7 @@ The following options are inherited from the ``spi-device`` binding and are comm
 
   .. note::
       To achieve the full speed, data must be propagated through the application and reach Bluetooth LE a few hundred microseconds before the subsequent connection event.
-      If you aim for the lowest latency through the LLPM (a 1-ms interval), the sensor data readout should take no more than 250 us.
+      If you aim for the lowest latency through the LLPM (an interval of 1 ms), the sensor data readout should take no more than 250 us.
       The bus and the sensor configuration must ensure that communication speed is fast enough.
 
 The remaining option ``irq-gpios`` is specific to ``pixart,pmw3360`` binding.
@@ -1189,14 +1189,14 @@ Changing interrupt priority
 You can edit the DTS files to change the priority of the peripheral's interrupt.
 This can be useful when :ref:`adding a new custom board <porting_guide_adding_board>` or whenever you need to change the interrupt priority.
 
-The ``interrupts`` property is an array, where meaning of each element is defined by the specification of the interrupt controller.
+The ``interrupts`` property is an array, where the meaning of each element is defined by the specification of the interrupt controller.
 These specification files are located at :file:`zephyr/dts/bindings/interrupt-controller/` DTS binding file directory.
 
 For example, for nRF52840 the file is :file:`arm,v7m-nvic.yaml`.
 This file defines ``interrupts`` property in the ``interrupt-cells`` list.
-In case of nRF52840, it contains two elements: ``irq`` and ``priority``.
+For nRF52840, it contains two elements: ``irq`` and ``priority``.
 The default values for these elements for the given peripheral can be found in the :file:`dtsi` file specific for the device.
-In case of nRF52840, this is :file:`zephyr/dts/arm/nordic/nrf52840.dtsi`, which has the following ``interrupts`` property for nRF52840:
+In the case of nRF52840, this is :file:`zephyr/dts/arm/nordic/nrf52840.dtsi`, which has the following ``interrupts``:
 
 .. code-block::
 
@@ -1519,7 +1519,7 @@ To enable the MCUboot bootloader, select the :kconfig:`CONFIG_BOOTLOADER_MCUBOOT
 
 Configure the MCUboot bootloader with the following options:
 
-* ``CONFIG_BOOT_SIGNATURE_KEY_FILE`` - This option defines the path to the private key that is used to sign the application and that is used by the bootloader to verify the application signature.
+* :kconfig:`CONFIG_BOOT_SIGNATURE_KEY_FILE` - This option defines the path to the private key that is used to sign the application and that is used by the bootloader to verify the application signature.
   The key must be defined only in the MCUboot bootloader configuration file.
 * :kconfig:`CONFIG_IMG_MANAGER` and :kconfig:`CONFIG_MCUBOOT_IMG_MANAGER` - These options allow the application to manage the DFU image.
   Enable both of them only for configurations that support :ref:`background DFU <nrf_desktop_bootloader_background_dfu>`.

--- a/applications/nrf_desktop/doc/battery_charger.rst
+++ b/applications/nrf_desktop/doc/battery_charger.rst
@@ -30,15 +30,15 @@ Set the option :kconfig:`CONFIG_DESKTOP_BATTERY_CHARGER_DISCRETE` to enable the 
 
 The following module configuration options are available:
 
-* :kconfig:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PIN` - Configures the pin to which the charge status output (CSO) from the charger is connected.
+* ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PIN`` - Configures the pin to which the charge status output (CSO) from the charger is connected.
 
-  * :kconfig:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_NONE` - CSO pin pull disabled (default setting).
-  * :kconfig:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_UP` - CSO pin pull up.
-  * :kconfig:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_DOWN` - CSO pin pull down.
+  * ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_NONE`` - CSO pin pull disabled (default setting).
+  * ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_UP`` - CSO pin pull up.
+  * ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_DOWN`` - CSO pin pull down.
 
-* :kconfig:`CONFIG_DESKTOP_BATTERY_CHARGER_ENABLE_PIN` - Configures the pin that enables the battery charging.
-* :kconfig:`CONFIG_DESKTOP_BATTERY_CHARGER_ENABLE_INVERSED` - Option for inversing the charging enable signal.
-* :kconfig:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_FREQ` - Set this Kconfig option to the CSO pin state switching frequency (in Hz) for when a charging error occurs.
+* ``CONFIG_DESKTOP_BATTERY_CHARGER_ENABLE_PIN`` - Configures the pin that enables the battery charging.
+* ``CONFIG_DESKTOP_BATTERY_CHARGER_ENABLE_INVERSED`` - Option for inversing the charging enable signal.
+* ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_FREQ`` - Set this Kconfig option to the CSO pin state switching frequency (in Hz) for when a charging error occurs.
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/doc/ble_bond.rst
+++ b/applications/nrf_desktop/doc/ble_bond.rst
@@ -40,20 +40,18 @@ Both IDs related to the given Bluetooth peer operation are propagated in ``ble_p
 
 The identity usage depends on the device type:
 
-* nRF Desktop central
-  The nRF Desktop central uses only one application local identity and only one Bluetooth local identity (the default ones).
-* nRF Desktop peripheral
-  The nRF Desktop peripheral uses multiple local identities.
+  * nRF Desktop central uses only one application local identity and only one Bluetooth local identity (the default ones).
+  * nRF Desktop peripheral uses multiple local identities.
 
-  Every application local identity is associated with exactly one Bluetooth local identity.
-  The |ble_bond| stores the mapping from the application local identities to the Bluetooth local identities in the ``bt_stack_id_lut`` array.
-  The mapping changes only after a successful erase advertising.
+Every application local identity is associated with exactly one Bluetooth local identity.
+The |ble_bond| stores the mapping from the application local identities to the Bluetooth local identities in the ``bt_stack_id_lut`` array.
+The mapping changes only after a successful erase advertising.
 
-  Only one Bluetooth peer can be bonded with a given local identity.
+Only one Bluetooth peer can be bonded with a given local identity.
 
-  Also, only one of the application local identities is selected at a time.
-  When the device changes the selected Bluetooth peer, it actually switches its own local identity.
-  The old peer is disconnected by the application, Bluetooth advertising is started, and the new peer connects.
+Also, only one of the application local identities is selected at a time.
+When the device changes the selected Bluetooth peer, it actually switches its own local identity.
+The old peer is disconnected by the application, Bluetooth advertising is started, and the new peer connects.
 
 Module states
 *************
@@ -68,7 +66,7 @@ The following diagram shows states and transitions between these states after th
 .. figure:: /images/nrf_desktop_ble_bond.svg
    :alt: nRF Desktop Bluetooth LE bond module state diagram
 
-   nRF Desktop Bluetooth LE bond module state diagram (click to enlarge)
+   nRF Desktop Bluetooth LE bond module state diagram
 
 .. note::
   The diagram does not present the states related to module going into standby (:c:enum:`STATE_STANDBY`, :c:enum:`STATE_DISABLED_STANDBY`, :c:enum:`STATE_DONGLE_CONN_STANDBY`).
@@ -211,7 +209,7 @@ The module provides the following :ref:`nrf_desktop_config_channel` options:
 
 Perform :ref:`nrf_desktop_config_channel` set operation on selected option to trigger the operation.
 The options can be used only if the module is in :c:enumerator:`STATE_IDLE`.
-Because of this, they cannot be used when device is suspended by :ref:`nrf_desktop_power_manager`.
+Because of this, they cannot be used when the device is suspended by :ref:`nrf_desktop_power_manager`.
 The device must be woken up from suspended state before the operation is started.
 
 Shell integration

--- a/applications/nrf_desktop/doc/ble_discovery.rst
+++ b/applications/nrf_desktop/doc/ble_discovery.rst
@@ -66,8 +66,8 @@ The peripheral discovery consists of the following steps:
 a. Reading device description.
    The central checks if the connected peripheral supports the LLPM (Low Latency Packet Mode).
    The device description is a GATT Characteristic that is specific for nRF Desktop peripherals and is implemented by :ref:`nrf_desktop_dev_descr`.
-#. Reading HW ID (hardware ID).
-   The hardware ID is unique per device and it is used to identify the device while forwarding the :ref:`nrf_desktop_config_channel` data.
+#. Reading Hardware ID (HW ID).
+   The HW ID is unique per device and it is used to identify the device while forwarding the :ref:`nrf_desktop_config_channel` data.
    The HW ID is a read from a GATT Characteristic that is specific for nRF Desktop peripherals and is implemented by :ref:`nrf_desktop_dev_descr`.
 #. Reading DIS (Device Information Service).
    The central reads VID and PID of the connected peripheral.

--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -52,7 +52,7 @@ The module listens for the following events related to data transfer initiated b
 * ``ble_smp_transfer_event`` - This event is received when the firmware update is received by :ref:`nrf_desktop_ble_smp`.
 
 When these events are received, the module sets the connection latency to low.
-When the :ref:`nrf_desktop_config_channel` is no longer in use and firmware update is not received by :ref:`nrf_desktop_ble_smp` (no mentioned events for ``LOW_LATENCY_CHECK_PERIOD_MS``), the module sets the connection latency to :kconfig:`CONFIG_BT_PERIPHERAL_PREF_LATENCY`  to reduce the power consumption.
+When the :ref:`nrf_desktop_config_channel` is no longer in use and the firmware update is not received by :ref:`nrf_desktop_ble_smp` (no mentioned events for ``LOW_LATENCY_CHECK_PERIOD_MS``), the module sets the connection latency to :kconfig:`CONFIG_BT_PERIPHERAL_PREF_LATENCY`  to reduce the power consumption.
 
   .. note::
      If the option :kconfig:`CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK` is enabled, the LLPM connection latency is not increased unless the device is in the low power mode.

--- a/applications/nrf_desktop/doc/board.rst
+++ b/applications/nrf_desktop/doc/board.rst
@@ -8,7 +8,7 @@ Board module
    :depth: 2
 
 The board module is used to ensure the proper state of GPIO pins that are not configured by other modules in the application.
-Ensuring the proper state is done by setting the state of the mentioned pins on the system start and wake-up, and when the system enters the low-power mode.
+Ensuring the proper state is done by setting the state of the mentioned pins on the system start and wakeup, and when the system enters the low-power mode.
 
 Module events
 *************
@@ -30,7 +30,7 @@ For every configuration, you must define the :file:`port_state_def.h` file in th
 
 The :file:`port_state_def.h` file defines the states set to the GPIO ports by the following arrays:
 
-* ``port_state_on`` - State set on the system start and wake-up.
+* ``port_state_on`` - State set on the system start and wakeup.
 * ``port_state_off`` - State set when the system enters the low-power mode.
 
 Every :c:struct:`port_state` refers to a single GPIO port and contains the following information:

--- a/applications/nrf_desktop/doc/config_channel.rst
+++ b/applications/nrf_desktop/doc/config_channel.rst
@@ -32,12 +32,12 @@ The host initiates all data exchange.
 
 .. note::
    If the device supports multiple USB or Bluetooth® LE HID instances, only one USB HID instance and only one Bluetooth® LE HID instance can be used to configure the device.
-   Other HID instances ignore the HID report set method and respond with the disconnected status on the HID report get method to indicate that the HID instance is not used for configuration channel.
+   Other HID instances ignore the HID report set method and respond with the disconnected status on the HID report get method to indicate that the HID instance is not used for the configuration channel.
 
 Transaction request and response
 ********************************
 
-To maintain the communication pace between the host and the device, configuration channel uses transactions.
+To maintain the communication pace between the host and the device, the configuration channel uses transactions.
 Each transaction consists of a single request send from the host to the device, followed by a single response that provides the completion status of the requested activity.
 
 * A request from the host to the device is a single HID feature report set operation.
@@ -50,7 +50,7 @@ Since the device works asynchronously from the host, it might happen that an act
 
 .. note::
    There can be only one pending configuration channel request.
-   The host can send the following request only after it received response for the previous request.
+   The host can send the following request only after it has received a response for the previous request.
 
 Transaction types
 *****************
@@ -60,7 +60,7 @@ The configuration channel has the following transaction types:
 * set - Used to write configurable options.
 * fetch - Used to read the values of options from the device.
 
-Both transactions can be used to trigger a device to perform an activity, but fetch transaction can ensure that such activity is completed.
+Both transactions can be used to trigger a device to perform an activity, but the fetch transaction can ensure that such activity is completed.
 
 Transaction forwarding
 **********************
@@ -119,7 +119,7 @@ Both request and response share the same data format, which is described in the 
 |           |           | Option ID | Module ID |        |             |         |
 +-----------+-----------+-----------+-----------+--------+-------------+---------+
 
-See the following sections for detailed description of each HID feature report component.
+See the following sections for a detailed description of each HID feature report component.
 
 Report ID
 =========
@@ -130,7 +130,7 @@ The configuration channel uses a predefined HID feature report.
 
 .. note::
    Bluetooth® LE HID Service removes the leading report ID byte.
-   As a result, firmware obtains a data frame shorter by one byte.
+   As a result, the firmware obtains a data frame shorter by one byte.
 
    The USB HID class transmits the whole report, including the report ID byte.
 
@@ -139,17 +139,17 @@ Recipient
 
 This is the identifier of the device to which the request is addressed.
 
-This field is used to route requests in a multi-device setup.
+This field is used to route requests in a multidevice setup.
 The field can have the following values:
 
 * ``0`` - The transaction is intended for a directly connected device.
-* Other values - The transaction should be forwarded by :ref:`nrf_desktop_hid_forward` to the peripheral connected over Bluetooth® LE.
+* Other values - The transaction should be forwarded by the :ref:`nrf_desktop_hid_forward` to the peripheral connected over Bluetooth® LE.
   The recipients connected over Bluetooth® LE are discovered during the :ref:`device discovery <nrf_desktop_config_channel_device_discovery>`.
 
 Event ID
 ========
 
-This is the identifier of both module and option for set or fetch operation.
+This is the identifier for both module and option for the set or fetch operation.
 
 The field is composed of the following subfields:
 
@@ -158,7 +158,7 @@ The field is composed of the following subfields:
 
 The values of Module ID and Option ID are assigned during the application build time.
 These values are obtained during the :ref:`device discovery <nrf_desktop_config_channel_device_discovery>` performed by the host.
-The same application module can have different ID value, when it was compiled at different configuration.
+The same application module can have different ID values, when it is compiled at a different configuration.
 
 Status
 ======
@@ -168,7 +168,7 @@ The usage of the Status field is different for request and response operations.
 Request
 -------
 
-In case of request, the value of Status field denotes requested operation.
+In the case of a request, the value of Status field denotes a requested operation.
 The request operations can be grouped as follows:
 
 Generic operations
@@ -198,7 +198,7 @@ Module discovery operations
 
   .. note::
     Using :ref:`nrf_desktop_info` is mandatory for every device that is configurable with the configuration channel.
-    The module provides information that are necessary to identify the device.
+    The module provides information that is necessary to identify the device.
 
 Recipient discovery operations
   The :ref:`nrf_desktop_hid_forward` handles recipients discovery operations.
@@ -210,7 +210,7 @@ Recipient discovery operations
 
   * ``CONFIG_STATUS_INDEX_PEERS`` - Request Recipient ID re-evaluation.
     Response to this request returns no data.
-    When performed device will map each connected Bluetooth® LE Peripheral to an integer.
+    When performed, the device will map each connected Bluetooth® LE Peripheral to an integer.
   * ``CONFIG_STATUS_GET_PEER`` - Obtain Recipient ID of Bluetooth® LE Peripheral.
     Response to this request contains the following information:
 
@@ -223,12 +223,12 @@ Recipient discovery operations
 Response
 --------
 
-In case of response, the value of the Status field indicates the state of the earlier request.
+In the case of a response, the value of the Status field indicates the state of the earlier request.
 The following values are possible:
 
-* ``CONFIG_STATUS_PENDING`` - The operation is not yet completed.
+* ``CONFIG_STATUS_PENDING`` - The operation has not completed.
   The response is not ready and the data field should not be interpreted.
-  The host should not sent new requests before the operation completes.
+  The host should not send new requests before the operation completes.
 * ``CONFIG_STATUS_SUCCESS`` - The operation was successful.
   The host tool can access data returned by the response.
   The host can send a new request.
@@ -304,12 +304,12 @@ Device identification
 
 The following requests provide the information about the device hardware:
 
-* ``CONFIG_STATUS_GET_BOARD_NAME`` - For reading board name.
-* ``CONFIG_STATUS_GET_HWID`` - For Hardware ID.
+* ``CONFIG_STATUS_GET_BOARD_NAME`` - For reading the board name.
+* ``CONFIG_STATUS_GET_HWID`` - For the Hardware ID.
   The Hardware ID allows to differentiate devices of the same type (that have the same board name).
 
 If you are developing a custom host tool, use the Recipient ID linked with the device that is being discovered.
-Your tool should note which Recipient ID and HID instance on the host is associated with the board name and Hardware ID.
+Your tool should note which Recipient ID and HID instance on the host is associated with the board name and the Hardware ID.
 
 .. _nrf_desktop_config_channel_module_discovery:
 
@@ -339,14 +339,14 @@ For reading the module descriptor, the following conditions must be met:
 * The end line character (``\n``) indicates the end of the descriptor.
   After the end line character is fetched, following requests should loop around and repeat descriptor strings.
 * The module descriptor strings are provided in a predefined order, but the host should make no assumption about the descriptor string that will be provided by the device as the first one.
-* The duplicated string is fetched after the host received all of the strings related to given module.
-  The host can stop option discovery procedure when a duplicated string is fetched.
+* The duplicated string is fetched after the host has received all of the strings related to the given module.
+  The host can stop the option discovery procedure when a duplicated string is fetched.
 * The module name should be provided as the first string in the module descriptor.
 * The following strings should indicate the module option names.
   The first option on the descriptor must be identified with Option ID equal to ``1``.
   The following options will be identified by monotonically increasing Option ID values (second option by ``2``, third by ``3``, and so on).
 * Once the descriptor is read, the module options can be accessed.
-  When performing set or fetch request on the option, the Event ID contains Option ID and Module ID of module that owns the option.
+  When performing a set or fetch request on the option, the Event ID contains the Option ID and the Module ID of the module that owns the option.
 
 The module descriptor can contain an optional ``module_variant`` option.
 The nRF Desktop application modules come in various variants with different characteristics.
@@ -392,7 +392,7 @@ Depending on the connection method:
    Disabling this option reduces the memory consumption.
 
 The :c:struct:`config_event` is used to propagate the configuration channel data.
-The configuration channel request received from host is propagated using the mentioned event with :c:member:`config_event.is_request` set to ``true``.
+The configuration channel request received from the host is propagated using the mentioned event with :c:member:`config_event.is_request` set to ``true``.
 The application module that handles the request consumes the event and provides the response.
 The response is provided as :c:struct:`config_event` with :c:member:`config_event.is_request` set to ``false``.
 In case a request is not handled by any application module, the configuration channel transport will eventually receive it and generate an error response.
@@ -401,10 +401,10 @@ Listener configuration
 ======================
 
 The configuration channel listener is an application module that provides a set of options that are accessible through the configuration channel.
-For example, depending on listener, it can provide the CPI option from :ref:`nrf_desktop_motion` or the option for searching for new peer from :ref:`nrf_desktop_ble_bond`.
+For example, depending on the listener, it can provide the CPI option from :ref:`nrf_desktop_motion` or the option for searching for a new peer from :ref:`nrf_desktop_ble_bond`.
 The host computer can use set or fetch request to access these options.
 
-On the firmware side, the configuration channel listener and its options are referenced with numbers, respectively module ID and option IDs.
+On the firmware side, the configuration channel listener and its options are referenced with module ID and option ID numbers, respectively.
 
 On the host side, these IDs are translated to strings based on the registered listener and option names.
 Details are described in the :ref:`nrf_desktop_config_channel_script`.

--- a/applications/nrf_desktop/doc/cpu_meas.rst
+++ b/applications/nrf_desktop/doc/cpu_meas.rst
@@ -33,4 +33,4 @@ Implementation details
 
 The module periodically submits the measured CPU load as :c:struct:`cpu_load_event` and resets the measurement.
 The event can be displayed in the logs or using the :ref:`profiler`.
-The :c:member:`cpu_load_event.load` presents the CPU load in 0,001% units.
+The :c:member:`cpu_load_event.load` presents the CPU load in 0.001% units.

--- a/applications/nrf_desktop/doc/dev_descr.rst
+++ b/applications/nrf_desktop/doc/dev_descr.rst
@@ -38,4 +38,4 @@ Implementation details
 **********************
 
 The module uses :c:macro:`BT_GATT_SERVICE_DEFINE` to define the custom GATT Service.
-More detailed information regarding GATT are available in Zephyr's :ref:`zephyr:bt_gatt` documentation.
+More detailed information regarding GATT is available in Zephyr's :ref:`zephyr:bt_gatt` documentation.

--- a/applications/nrf_desktop/doc/dfu.rst
+++ b/applications/nrf_desktop/doc/dfu.rst
@@ -40,7 +40,7 @@ It requires the transport option :kconfig:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE`
 
 Set the value of :kconfig:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_SYNC_BUFFER_SIZE` to specify the size of the sync buffer (in words).
 During the DFU, the data is initially stored in the buffer and then it is moved to flash.
-The buffer is located in RAM, so increasing the buffer size increases the RAM usage.
+The buffer is located in the RAM, so increasing the buffer size increases the RAM usage.
 If the buffer is small, the host must perform the DFU progress synchronization more often.
 
 .. important::
@@ -68,7 +68,7 @@ The module provides a simple protocol that allows the update tool on the host to
 
 .. note::
    All the described :ref:`nrf_desktop_config_channel` options are used by the :ref:`nrf_desktop_config_channel_script` during the DFU.
-   You can trigger DFU using a single command in CLI.
+   You can trigger DFU using a single command in the CLI.
 
 The following :ref:`nrf_desktop_config_channel` options are available to perform the firmware update:
 
@@ -152,7 +152,7 @@ sync
 Writing data to flash
 =====================
 
-The image data that is received from the host is initially buffered in RAM.
+The image data that is received from the host is initially buffered in the RAM.
 Writing the data to flash is triggered when the host performs the fetch operation on the ``sync`` option.
 At that point, the :ref:`nrf_desktop_config_channel_script` waits until the data is written to flash before providing more image data chunks.
 

--- a/applications/nrf_desktop/doc/hfclk_lock.rst
+++ b/applications/nrf_desktop/doc/hfclk_lock.rst
@@ -9,7 +9,7 @@ High frequency clock lock hotfix module
 
 Use the high frequency clock lock hotfix module to keep the high frequency clock enabled.
 This reduces the latency before the first packet in a row is transmitted over Bluetooth®, but it also increases the power consumption.
-If this module is disabled, a start-up delay of around 1.5 ms will be added to the overall latency of the first packet.
+If this module is disabled, a startup delay of around 1.5 ms will be added to the overall latency of the first packet.
 
 Module events
 *************

--- a/applications/nrf_desktop/doc/hid_forward.rst
+++ b/applications/nrf_desktop/doc/hid_forward.rst
@@ -106,7 +106,7 @@ Enqueuing incoming HID input reports
 The |hid_forward| forwards only one HID input report to the HID-class USB device at a time.
 Another HID input report may be received from a peripheral connected over Bluetooth before the previous one was sent.
 In that case, ``hid_report_event`` is enqueued and submitted later.
-Up to :kconfig:`CONFIG_DESKTOP_HID_FORWARD_MAX_ENQUEUED_REPORTS` reports can be enqueued at a time for each report type and for each connected peripheral.
+Up to the number of reports specified in :kconfig:`CONFIG_DESKTOP_HID_FORWARD_MAX_ENQUEUED_REPORTS` reports can be enqueued at a time for each report type and for each connected peripheral.
 If there is not enough space to enqueue a new event, the module drops the oldest enqueued event that was received from this peripheral (of the same type).
 
 Upon receiving the ``hid_report_sent_event``, the |hid_forward| submits the ``hid_report_event`` enqueued for the peripheral that is associated with the HID-class USB device.
@@ -119,18 +119,18 @@ Forwarding HID output reports
 =============================
 
 When the |hid_forward| receives a ``hid_report_event`` that contains an output report from a :ref:`nrf_desktop_usb_state`, it tries to forward the output report.
-The HID output report is forwarded to all of the Bluetooth connected peripherals that forward the HID data to HID subscriber that is source of the HID output report.
+The HID output report is forwarded to all of the Bluetooth connected peripherals that forward the HID data to the HID subscriber that is source of the HID output report.
 The HID output report is never forwarded to peripheral that does not support it.
 
-If the GATT write without response operation is in progress for given HID output report ID and connected peripheral, the report is placed in a queue and sent later.
+If the GATT write without response operation is in progress for the given HID output report ID and connected peripheral, the report is placed in a queue and sent later.
 The |hid_forward| sends information only about the last received HID output report with given ID.
-If changes of state related to HID output report with given ID are frequent, some intermediate states can be omitted by the |hid_forward|.
+If changes of state related to the HID output report with the given ID are frequent, some intermediate states can be omitted by the |hid_forward|.
 
 Bluetooth Peripheral disconnection
 ==================================
 
 On a peripheral disconnection, nRF Desktop central informs the host that all the pressed keys reported by the peripheral are released.
-This is done to make sure that user will not observe a problem with a key stuck on peripheral disconnection.
+This is done to make sure that the user will not observe a problem with a key stuck on peripheral disconnection.
 
 Configuration channel data forwarding
 =====================================
@@ -139,7 +139,7 @@ The |hid_forward| forwards the :ref:`nrf_desktop_config_channel` data between th
 The data is exchanged with the peripheral connected over Bluetooth using HID feature report or HID output report.
 
 In contrast to :ref:`nrf_desktop_config_channel_script`, the |hid_forward| does not use configuration channel request to get hardware ID (HW ID) of the peripheral.
-The peripheral identification on nRF Desktop central is based on HW ID that is received from :ref:`nrf_desktop_ble_discovery` when peripheral discovery is completed.
+The peripheral identification on nRF Desktop central is based on the HW ID that is received from :ref:`nrf_desktop_ble_discovery` when peripheral discovery is completed.
 The peripheral uses :ref:`nrf_desktop_dev_descr` to provide the HW ID to the nRF Desktop central.
 
 The |hid_forward| only forwards the configuration channel requests that come from the USB connected host, it does not generate its own requests.

--- a/applications/nrf_desktop/doc/hid_state.rst
+++ b/applications/nrf_desktop/doc/hid_state.rst
@@ -44,7 +44,7 @@ You must define mapping between button IDs and usage IDs in generated HID report
 For that purpose you must create a configuration file with ``hid_keymap`` array.
 Every element of the array contains mapping from a single hardware key ID to HID report ID and usage ID.
 
-For example, the file contents should look like follows:
+For example, the file contents should look like the following:
 
 .. code-block:: c
 
@@ -170,7 +170,7 @@ The ``button_event`` is the source of this type of data.
 
 To indicate a change to this input data, overwrite the value that is already stored.
 
-Since keys on the board can be associated to a usage ID, and thus be part of different HID reports, the first step is to identify to which report the key belongs and what usage it represents.
+Since keys on the board can be associated to a usage ID, and thus be part of different HID reports, the first step is to identify which report the key belongs to and what usage it represents.
 This is done by obtaining the key mapping from the :c:struct:`hid_keymap` structure.
 This structure is part of the application configuration files for the specific board and is defined in :file:`hid_keymap_def.h`.
 

--- a/applications/nrf_desktop/doc/hids.rst
+++ b/applications/nrf_desktop/doc/hids.rst
@@ -74,7 +74,7 @@ The module can receive an HID output report setting state of the keyboard LEDs, 
 The report is received from the Bluetooth connected host.
 The module forwards the report using ``hid_report_event``, that is handled either by |HID_state| (for peripheral) or :ref:`nrf_desktop_hid_forward` (for central).
 
-Right now, the only board that displays information received in the HID output report using hardware LEDs is :ref:`nrf52840dk_nrf52840 <nrf52840dk_nrf52840>` in ``keyboard`` build type configuration.
+Right now, the only board that displays information received in the HID output report using hardware LEDs is the :ref:`nrf52840dk_nrf52840 <nrf52840dk_nrf52840>` in ``keyboard`` build type configuration.
 The keyboard reference design (nrf52kbd_nrf52832) has only one LED that is used to display the Bluetooth LE peer state.
 Detailed information about the usage of LEDs to display information about Bluetooth LE peer state and system state to the user is available in the :ref:`nrf_desktop_led_state` documentation.
 Detailed information about displaying state of the HID keyboard LEDs using hardware LEDs is available in :ref:`nrf_desktop_hid_state` documentation.

--- a/applications/nrf_desktop/doc/led_state.rst
+++ b/applications/nrf_desktop/doc/led_state.rst
@@ -47,7 +47,7 @@ Configuration
 *************
 
 The |led_state| is enabled when you set the :kconfig:`CONFIG_CAF_LEDS` option.
-You must also configure :ref:`caf_leds`, which is used as sink module for ``led_state``.
+You must also configure :ref:`caf_leds`, which is used as a sink module for ``led_state``.
 
 For every board that has this option enabled, you must define the module configuration.
 Do this in the :file:`led_state_def.h` file located in the board-specific directory in the application configuration directory.

--- a/applications/nrf_desktop/doc/led_stream.rst
+++ b/applications/nrf_desktop/doc/led_stream.rst
@@ -29,7 +29,7 @@ For this reason, make sure that :kconfig:`CONFIG_CAF_LEDS` and :kconfig:`CONFIG_
 To enable the module, use the :kconfig:`CONFIG_DESKTOP_LED_STREAM_ENABLE` Kconfig option.
 
 You can also define the stream LED event queue size (:kconfig:`CONFIG_DESKTOP_LED_STREAM_QUEUE_SIZE`).
-The queue is used by the module as data buffer for the data received from the host computer.
+The queue is used by the module as a data buffer for the data received from the host computer.
 
 Configuration channel
 *********************

--- a/applications/nrf_desktop/doc/leds.rst
+++ b/applications/nrf_desktop/doc/leds.rst
@@ -7,7 +7,7 @@ LEDs module
    :local:
    :depth: 2
 
-The LEDs module is responsible for controlling LEDs in response to LED effect set by a ``led_event``.
+The LEDs module is responsible for controlling LEDs in response to the LED effect set by a ``led_event``.
 The source of events could be any other module.
 
 Module events

--- a/applications/nrf_desktop/doc/motion.rst
+++ b/applications/nrf_desktop/doc/motion.rst
@@ -35,7 +35,7 @@ The motion module selects the source of movement based on the following configur
 
 See the following sections for more information.
 
-Depending on the selected configuration option, different implementation file is used during the build process.
+Depending on the selected configuration option, a different implementation file is used during the build process.
 
 Movement data from motion sensors
 =================================
@@ -64,8 +64,8 @@ Simulated movement data
 
 Selecting the :kconfig:`CONFIG_DESKTOP_MOTION_SIMULATED_ENABLE` option adds the :file:`src/hw_interface/motion_simulated.c` file to the compilation.
 
-If shell is available (:kconfig:`CONFIG_SHELL` option is set) the motion module registers a shell module ``motion_sim`` and links to it two commands: ``start`` and ``stop``.
-If shell is not available motion generation starts automatically when the device is connected to the USB or Bluetooth®.
+If the shell is available (the :kconfig:`CONFIG_SHELL` option is set), the motion module registers a shell module ``motion_sim`` and links to it two commands: ``start`` and ``stop``.
+If the shell is not available, motion generation starts automatically when the device is connected to USB or Bluetooth®.
 
 When started, the module will generate simulated motion events.
 The movement data in each event will be tracing the predefined path, an eight-sided polygon.
@@ -93,7 +93,7 @@ In these configurations, the module is a configuration channel listener and it p
     The motion sensor CPI.
 * ``downshift``, ``rest1``, ``rest2``
     These firmware option names correspond to switch times of motion sensor modes, namely the sleep modes of ``PAW3212`` and the rest modes of ``PMW3360``.
-    This kind of modes is used by a motion sensor to reduce the power consumption, but it also increases the sensor's response time when a motion is detected after a period of inactivity.
+    These modes are used by a motion sensor to reduce the power consumption, but they also increase the sensor's response time when a motion is detected after a period of inactivity.
 
     The :ref:`nrf_desktop_config_channel_script` refers to these mode options using names that depend on the sensor variant:
 

--- a/applications/nrf_desktop/doc/passkey.rst
+++ b/applications/nrf_desktop/doc/passkey.rst
@@ -29,7 +29,7 @@ To configure the passkey module, complete the following steps:
 
 1. Enable and configure the :ref:`caf_buttons`.
 #. Enable the passkey module by using the :kconfig:`CONFIG_DESKTOP_PASSKEY_BUTTONS` Kconfig option.
-#. Define the maximum number of digits in the passkey by using :kconfig:`CONFIG_DESKTOP_PASSKEY_MAX_LEN` option.
+#. Define the maximum number of digits in the passkey by using the :kconfig:`CONFIG_DESKTOP_PASSKEY_MAX_LEN` option.
 #. Define the IDs of the keys used by the passkey module in the :file:`passkey_buttons_def.h` file located in the board-specific directory in the :file:`configuration` directory.
    You must define the IDs of the following keys:
 
@@ -39,7 +39,7 @@ To configure the passkey module, complete the following steps:
 
    You can define multiple sets of keys used to input the digits, but every set should contain keys used to input every digit.
    This is to ensure that the user will be able to input the passkey.
-   The index of key ID in the input configuration array represents the digit.
+   The index of the key ID in the input configuration array represents the digit.
 
 The example configuration of the module can be found in the :file:`configuration/nrf52kbd_nrf52832/passkey_buttons_def.h` file.
 

--- a/applications/nrf_desktop/doc/qos.rst
+++ b/applications/nrf_desktop/doc/qos.rst
@@ -10,7 +10,7 @@ Quality of Service module
 The Quality of Service (QoS) module provides the QoS information through the Bluetooth® GATT service.
 The module can be used only by nRF Desktop peripheral with the SoftDevice Link Layer (:kconfig:`CONFIG_BT_LL_SOFTDEVICE`).
 
-The module is made available in case the peripheral is meant to be paired with a third party dongle.
+The module is made available in case the peripheral is meant to be paired with a third-party dongle.
 In such case, the vendor can use the Quality of Service data provided by the nRF Desktop peripheral to improve the link quality.
 
 .. note::

--- a/applications/nrf_desktop/doc/selector.rst
+++ b/applications/nrf_desktop/doc/selector.rst
@@ -44,7 +44,7 @@ Implementation details
 
 The ``selector_event`` that the module sends to inform about the current hardware selector state is sent on the following occasions:
 
-* System start or wake-up (for every defined selector).
+* System start or wakeup (for every defined selector).
 * Selector state change when the application is running (only for the selector that changed state).
 
 When the application goes to sleep, selectors are not informing about the state change (interrupts are disabled).

--- a/applications/nrf_desktop/doc/settings_loader.rst
+++ b/applications/nrf_desktop/doc/settings_loader.rst
@@ -39,7 +39,7 @@ This will prevent blocking the system workqueue, but it requires creating an add
 The stack size for the background thread is defined as :kconfig:`CONFIG_DESKTOP_SETTINGS_LOADER_THREAD_STACK_SIZE`.
 
 .. tip::
-   Using separate thread is recommended for nRF Desktop keyboards.
+   Using a separate thread is recommended for nRF Desktop keyboards.
    The :ref:`caf_buttons` uses the system workqueue to scan the keyboard matrix.
    Loading the settings in the system workqueue context could block the workqueue and result in missing key presses on system reboot.
    For this reason, :kconfig:`CONFIG_DESKTOP_SETTINGS_LOADER_USE_THREAD` is enabled for keyboard reference design (nRF52832 Desktop Keyboard)

--- a/applications/nrf_desktop/doc/usb_state.rst
+++ b/applications/nrf_desktop/doc/usb_state.rst
@@ -64,19 +64,19 @@ On the Bluetooth Central device, if only one instance is used, reports from all 
 In other cases, reports from each of the bonded peripherals will be forwarded to a dedicated HID-class USB device instance.
 The same instance is used after reconnection.
 
-USB wake-up configuration
-=========================
+USB wakeup configuration
+========================
 
-The nRF Desktop device can work as a source of wake-up events for the host device if connected through the USB.
+The nRF Desktop device can work as a source of wakeup events for the host device if connected through the USB.
 
 To use the feature, select :kconfig:`CONFIG_USB_DEVICE_REMOTE_WAKEUP`.
 
 When host enters the suspended state, the USB will be suspended as well.
 With this feature enabled, this state change is used to suspend the nRF Desktop device (see :ref:`nrf_desktop_power_manager`).
-When the nRF Desktop device wakes up from standby, the |usb_state| will issue a wake-up request on the USB.
+When the nRF Desktop device wakes up from standby, the |usb_state| will issue a wakeup request on the USB.
 
 .. note::
-    The USB wake-up request is transmitted to the host only if the host enables this request before suspending the USB.
+    The USB wakeup request is transmitted to the host only if the host enables this request before suspending the USB.
 
 
 Implementation details

--- a/applications/pelion_client/README.rst
+++ b/applications/pelion_client/README.rst
@@ -154,7 +154,7 @@ The following table lists modules that are part of the application.
 
 All modules react to ``module_state_event``.
 
-On top of these modules, the application uses the following modules from :ref:`lib_caf` (CAF), a set of generic modules based on the Event Manager and available to all applications in the |NCS|:
+On top of these modules, the application uses the following modules of the :ref:`lib_caf` (CAF) libraries, a set of generic modules based on the Event Manager and available to all applications in the |NCS|:
 
 * :ref:`caf_buttons`
 * :ref:`caf_leds`
@@ -433,9 +433,9 @@ Along with the bootloader, you must also enable an image manager with the :kconf
 When MCUboot is enabled the |NCS| build system generates the update image that can be uploaded to the secondary (update) slot.
 The resulting signed file named :file:`app_update.bin` can be found in the build directory.
 For more information refer to :ref:`mcuboot_ncs`.
-This image is signed with MCUboot private key.
-By default, if private key is present at :file:`applications/pelion_client/configuration/${BOARD_NAME}/mcuboot_private.pem` it will be used for signing process.
-If key is not present and configuration does not point to any specific key path, the default sample MCUBoot key will be used.
+This image is signed with the MCUboot private key.
+By default, if a private key is present at :file:`applications/pelion_client/configuration/${BOARD_NAME}/mcuboot_private.pem` it will be used for the signing process.
+If a key is not present and configuration does not point to any specific key path, the default sample MCUBoot key will be used.
 
 Additionally, if the application image is large, you may need to store the update image on an external flash device.
 In such case, enable the external flash support and correctly configure the partition layout.
@@ -443,7 +443,7 @@ In such case, enable the external flash support and correctly configure the part
 The Pelion Device Management library's update manager is enabled when you select the :kconfig:`CONFIG_PELION_UPDATE` Kconfig option.
 This option enables components required for image transport and storage.
 
-For the update campaign to be recognized and the image be accepted, you need to provision the device with the valid update resources (device unique identifiers and certificate used for update process validation).
+For the update campaign to be recognized and the image to be accepted, you need to provision the device with the valid update resources (device unique identifiers and certificate used for update process validation).
 These resources are normally stored on device at production time.
 To simplify the development process, you can have the update resources created by the update manifest generation tool (see `Pelion Manifest Tool for version 4.7`_ in the Pelion documentation).
 The generated C file must be stored to the :file:`update_default_resources.c` file, located in the :file:`applications/pelion_client/configuration/common` directory.
@@ -458,7 +458,7 @@ You can find the configuration files in the :file:`applications/pelion_client/co
 For each supported build target, you can find a subdirectory that contains all configuration files for the given target.
 Configuration files are provided for different `nRF Pelion Client build types`_ for each supported build target.
 
-The build types names are replacing the *${CMAKE_BUILD_TYPE}* variable in the configuration file names (for example, :file:`pm_static_ZDebug.yml`).
+The build type names are replacing the *${CMAKE_BUILD_TYPE}* variable in the configuration file names (for example, :file:`pm_static_ZDebug.yml`).
 If the given build type is not supported on the selected build target, an error message appears when `Building and running`_.
 In addition to the build types mentioned above, some build targets can provide more build types, which can be used to generate an application in a specific variant.
 The selected build type impacts the configuration of all system elements that are enabled (application, bootloader, partition layout).

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -176,6 +176,7 @@
 .. _`zb_zcl_device_callback_param_t`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.9.0.1/group___z_b___z_c_l___i_n_i_t_i_a_l_i_z_a_t_i_o_n.html#ga0dfcc989252b93252f8bb1d27d2639fa
 .. _`zb_zcl_device_callback_id_t`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.9.0.1/group___z_b___z_c_l___i_n_i_t_i_a_l_i_z_a_t_i_o_n.html#gad27454b213ce8a00540ebc75288966ad
 .. _`ZB_ZCL_OTA_UPGRADE_VALUE_CB_ID`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.9.0.1/group___z_b___z_c_l___i_n_i_t_i_a_l_i_z_a_t_i_o_n.html#gga35caa2e3a9ef37535b1f75e0fe919266a8a87688c465e80b46ad821741a60fe84
+.. _`zb_bdb_set_legacy_device_support`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.9.0.1/group__zboss__bdb__comm__params.html#ga8bf3b3beef192c00bcdca17ad1240921
 
 .. _`TF-M documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/tfm/index.html
 
@@ -505,7 +506,7 @@
 .. _`Thread Commissioning on OpenThread portal`: https://openthread.io/guides/build/commissioning
 .. _`OpenThread logging`: https://openthread.io/guides/build/logs
 
-.. _`Openthread acting as a new reference platform`: https://openthread.io/certification/automation-setup#acting_as_a_new_reference_platform
+.. _`OpenThread acting as a new reference platform`: https://openthread.io/certification/automation-setup#acting_as_a_new_reference_platform
 .. _`OpenThread Border Router`: https://openthread.io/guides/border-router
 .. _`OpenThread Border Router Codelab tutorial`: https://openthread.io/codelabs/openthread-border-router
 .. _`OpenThread Border Router Codelab tutorial step 3`: https://openthread.io/codelabs/openthread-border-router#2

--- a/doc/nrf/ug_matter_configuring_protocol.rst
+++ b/doc/nrf/ug_matter_configuring_protocol.rst
@@ -35,7 +35,7 @@ OpenThread configuration
 
 Enabling :kconfig:`CONFIG_CHIP` automatically enables the following options related to OpenThread:
 
-* :kconfig:`CONFIG_OPENTHREAD_ECDSA` and :kconfig:`OPENTHREAD_SRP_CLIENT` - enabled through :kconfig:`CHIP_ENABLE_DNSSD_SRP`
+* :kconfig:`CONFIG_OPENTHREAD_ECDSA` and :kconfig:`CONFIG_OPENTHREAD_SRP_CLIENT` - enabled through :kconfig:`CONFIG_CHIP_ENABLE_DNSSD_SRP`
 * :kconfig:`CONFIG_OPENTHREAD_DNS_CLIENT` - enabled through :kconfig:`CONFIG_CHIP_ENABLE_DNS_CLIENT`
 
 Additionally, you can enable the support for Thread :ref:`Sleepy End Device <thread_ot_device_types>` in Matter by using the :kconfig:`CONFIG_CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT` Kconfig option.

--- a/doc/nrf/ug_matter_creating_accessory.rst
+++ b/doc/nrf/ug_matter_creating_accessory.rst
@@ -8,7 +8,7 @@ Creating Matter accessory device
    :depth: 2
 
 The Matter accessory device is a basic node of the `Matter`_ network.
-The accessory is formed by the development kit and the application that is running the Matter stack and that is programmed on the development kit.
+The accessory is formed by the development kit and the application that is running the Matter stack, which is programmed on the development kit.
 
 Once you are familiar with Matter in the |NCS| and you have tested some of the available :ref:`matter_samples`, you can use the :ref:`Matter template <matter_template_sample>` sample to create your own custom accessory device application.
 For example, you can create a sensor application that uses a temperature sensor with an on/off switch, with the sensor periodically updating its measured value when it is active.
@@ -21,7 +21,7 @@ Each cluster contains attributes that are stored in the device's memory and comm
 Clusters appropriate for a single device type such as a sensor or a light bulb are organized into an addressable container that is called an endpoint.
 
 An application can implement appropriate callback functions to be informed about specific cluster state changes.
-These functions can be used to alter device's behavior when the state of a cluster is changing as a result of some external event.
+These functions can be used to alter the device's behavior when the state of a cluster is changing as a result of some external event.
 
 Read the following sections for detailed steps about how to expand the Matter template sample.
 
@@ -122,7 +122,7 @@ Complete the steps in the following subsections to modify the main loop.
 Edit the event queue
 ====================
 
-The main application loop is based on an queue on which the events are posted by ZCL callbacks, the application itself or by other entities, such as Zephyr timers.
+The main application loop is based on a queue on which the events are posted by ZCL callbacks, the application itself or by other entities, such as Zephyr timers.
 In each iteration, the event is dequeued and a corresponding event handler is called.
 
 Add new events
@@ -153,7 +153,7 @@ You need to make sure that the sensor is making measurements at the required tim
 For this purpose, use a Zephyr timer to post :c:struct:`SensorMeasure` events.
 In the template sample, such a timer is being used to count down 6 seconds when **Button 1** is being pressed to initiate the factory reset.
 
-To add a new timer for the measurement event, edit the :file:`src/app_task.cpp` file like follows:
+To add a new timer for the measurement event, edit the :file:`src/app_task.cpp` file as follows:
 
 .. code-block:: C++
 
@@ -305,7 +305,7 @@ Add new targets to CMakelists
 
 To allow a proper build, you must update the :file:`CMakelists.txt` file by adding the following targets:
 
-* :file:`${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/on-off-server/on-off-server.cpp` - for OnOff cluster callbacks.
+* :file:`${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/on-off-server/on-off-server.cpp` - for On/Off cluster callbacks.
 * :file:`${ZEPHYR_CONNECTEDHOMEIP_MODULE_DIR}/src/app/clusters/temperature-measurement-server/temperature-measurement-server.cpp` - for TemperatureMeasurement cluster callbacks.
 * :file:`src/zcl_callbacks.cpp` - to include the callback implementation.
 

--- a/doc/nrf/ug_thread_certification.rst
+++ b/doc/nrf/ug_thread_certification.rst
@@ -102,7 +102,7 @@ Complete the following steps to prepare for the certification tests:
 See the following links for more information on OpenThread:
 
 - `OpenThread THCI`_
-- `Openthread acting as a new reference platform`_
+- `OpenThread acting as a new reference platform`_
 
 Thread Test Harness with nRF52840 DK
 ====================================

--- a/doc/nrf/ug_thread_commissioning.rst
+++ b/doc/nrf/ug_thread_commissioning.rst
@@ -197,10 +197,10 @@ The commissioning uses the following passwords and credentials:
   .. note::
         The Commissioning Credential has 6 bytes minimum and 255 bytes maximum and is composed in the UTF-8 format, without character exclusions.
 
-* *Commissioning Key (PSKc)* - Pre-shared key for the Commissioner based on the Commissioning Credential, which is used to establish the Commissioner Session between the Commissioner and Border Agent.
+* *Commissioning Key (PSKc)* - Preshared key for the Commissioner based on the Commissioning Credential, which is used to establish the Commissioner Session between the Commissioner and Border Agent.
   All devices in the Thread network store the PSKc.
 * *Joining Device Credential (PSKd)* - Passphrase for authenticating a new Joiner device, used to establish a secure session between the Commissioner and the Joiner.
-  When encoded in binary, this passphrase is referred to as pre-shared key for the device.
+  When encoded in binary, this passphrase is referred to as preshared key for the device.
 
   .. note::
         The Joining Device Credential is composed of at least 6 and no more than 32 uppercase alphanumeric ASCII characters (base32-thread, 0 to 9 and A to Y, with the exclusion of I, O, Q, and Z).
@@ -249,7 +249,7 @@ Programming the DKs
 Program both development kits with the :ref:`ot_cli_sample` sample or program both of them with the :ref:`ot_coprocessor_sample` sample.
 See the sample's page for details.
 
-After programming the DKs and turning them on, both devices will be pre-commissioned and will form a Thread network.
+After programming the DKs and turning them on, both devices will be precommissioned and will form a Thread network.
 This network needs to be manually disabled.
 
 .. _thread_ot_commissioning_configuring_on-mesh_disabling:
@@ -394,7 +394,7 @@ Complete the following steps for the sample of your choice:
             wpanctl:leader_if> commissioner start
             Commissioner started
 
-#. Set up a pre-shared key for the Joiner device by running the following command:
+#. Set up a preshared key for the Joiner device by running the following command:
 
    .. tabs::
 

--- a/doc/nrf/ug_zigbee_adding_clusters.rst
+++ b/doc/nrf/ug_zigbee_adding_clusters.rst
@@ -7,10 +7,10 @@ Adding ZCL clusters to application
    :local:
    :depth: 2
 
-Once you are familiar with Zigbee in the |NCS| and you have tested some of the available :ref:`zigbee_samples`, you can use the :ref:`Zigbee template <zigbee_template_sample>` sample to create your own application with custom set of ZCL clusters.
+Once you are familiar with Zigbee in the |NCS| and you have tested some of the available :ref:`zigbee_samples`, you can use the :ref:`Zigbee template <zigbee_template_sample>` sample to create your own application with a custom set of ZCL clusters.
 For example, you can create a sensor application that uses a temperature sensor with an on/off switch, with the sensor periodically updating its measured value when it is active.
 
-Adding ZCL clusters to application consists of expanding the Zigbee template sample with new application clusters.
+Adding ZCL clusters to an application consists of expanding the Zigbee template sample with new application clusters.
 By default, the template sample includes only mandatory Zigbee clusters, that is the Basic and Identify clusters, required to identify a device within a Zigbee network.
 
 Cluster is a representation of a single functionality within a Zigbee node.
@@ -19,7 +19,7 @@ Clusters appropriate for a single device type such as a sensor or a light bulb a
 For more information about the ZCL terminology, see `Common ZCL terms and definitions`_ in the ZBOSS stack user guide.
 
 An application can implement appropriate callback functions to be informed about specific cluster state changes.
-These functions can be used to alter device's behavior when the state of a cluster is changing as a result of some external event.
+These functions can be used to alter the device's behavior when the state of a cluster is changing as a result of some external event.
 
 Read the following sections for detailed steps about how to expand the Zigbee template sample.
 

--- a/doc/nrf/ug_zigbee_configuring.rst
+++ b/doc/nrf/ug_zigbee_configuring.rst
@@ -97,7 +97,7 @@ IEEE 802.15.4 EUI-64 configuration
 The Zigbee stack uses the EUI-64 address that is configured in the IEEE 802.15.4 shim layer.
 By default, it uses an address from Nordic Semiconductor's pool.
 
-If your devices should use different address, you can change the address according to your company's addressing scheme.
+If your devices should use a different address, you can change the address according to your company's addressing scheme.
 
 .. include:: /includes/ieee802154_eui64_conf.txt
 

--- a/doc/nrf/ug_zigbee_configuring_libraries.rst
+++ b/doc/nrf/ug_zigbee_configuring_libraries.rst
@@ -36,7 +36,7 @@ Default signal handler
 The default signal handler provides the default logic for handling ZBOSS stack signals.
 For more information, see :ref:`lib_zigbee_signal_handler`.
 
-Afer enabling the Zigbee application utilities library, you can use this component by calling the :c:func:`zigbee_default_signal_handler` in the application's :c:func:`zboss_signal_handler` implementation.
+After enabling the Zigbee application utilities library, you can use this component by calling the :c:func:`zigbee_default_signal_handler` in the application's :c:func:`zboss_signal_handler` implementation.
 
 .. _ug_zigbee_configuring_components_error_handler:
 

--- a/doc/nrf/ug_zigbee_other_ecosystems.rst
+++ b/doc/nrf/ug_zigbee_other_ecosystems.rst
@@ -67,4 +67,4 @@ The following instructions can help you troubleshoot the connection problem:
 #. Make sure that the device is scanning through all channels to find the Zigbee network.
    For example, verify that the :kconfig:`CONFIG_ZIGBEE_CHANNEL_SELECTION_MODE_MULTI` Kconfig option is correctly set.
 #. Check if the device is compatible with Zigbee 3.0.
-   If it *not* compatible, enable the legacy mode by including a call to :c:func:`zb_bdb_set_legacy_device_support`.
+   If it is *not* compatible, enable the legacy mode by including a call to `zb_bdb_set_legacy_device_support`_.

--- a/doc/nrf/ug_zigbee_supported_features.rst
+++ b/doc/nrf/ug_zigbee_supported_features.rst
@@ -8,7 +8,7 @@ Supported Zigbee features
    :depth: 2
 
 The |NCS|'s Zigbee protocol uses the ZBOSS library, a third-party precompiled Zigbee stack.
-It includes all mandatory features of the |zigbee_version| specification and provides an Application Programming Interface to access different services.
+It includes all mandatory features of the |zigbee_version| specification and provides an Application Programming Interface (API) to access different services.
 The stack comes with the following features:
 
 * Complete implementation of the Zigbee core specification and Zigbee Pro feature set


### PR DESCRIPTION
Fixed various typos and style errors within nRF Protocols and Applications.
Will add comments regarding some possible style/code-link errors shortly after creating the PR. Please check these.
Jira ticket: NCSDK-12637.

Signed-off-by: Katherine Depa <katherine.depa@nordicsemi.no>