### PR TITLE
lib: pdn: Fix pdn_init() condition

### DIFF
--- a/lib/pdn/Kconfig
+++ b/lib/pdn/Kconfig
@@ -40,6 +40,8 @@ config PDN_INIT_PRIORITY
 	int "Initialization priority"
 	default APPLICATION_INIT_PRIORITY
 
+endif # PDN_SYS_INIT
+
 config PDN_DEFAULTS_OVERRIDE
 	bool "Override defaults for PDP context 0"
 
@@ -97,7 +99,6 @@ config PDN_DEFAULT_PASSWORD
 	depends on !PDN_DEFAULT_AUTH_NONE
 
 endif # PDN_DEFAULTS_OVERRIDE
-endif # PDN_SYS_INIT
 
 module=PDN
 module-dep=LOG


### PR DESCRIPTION
For application that inits libmodem by itself, the flag of
`NRF_MODEM_LIB_SYS_INIT` is not defined, which in turn cause
`PDN_SYS_INIT` not defined.

Then when the app calls pdn_init() to define primary pdn with
 PDN_DEFAULTS_OVERRIDE=y
 PDN_DEFAULT_APN="xxx"
 PDN_DEFAULT_AUTH=y
 etc.
it becomes impossible as they need `PDN_SYS_INIT` be defined.

Solution is to decouple `PDN_SYS_INIT` from PDN_DEFAULT flags.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>