### PR TITLE
modules: memfault: Fix use of wrong macro

### DIFF
--- a/modules/memfault/memfault_ncs_metrics.c
+++ b/modules/memfault/memfault_ncs_metrics.c
@@ -14,10 +14,10 @@
 
 LOG_MODULE_REGISTER(memfault_ncs_metrics, CONFIG_MEMFAULT_NCS_LOG_LEVEL);
 
-#ifdef CONFIG_MEMFAULT_NCS_STACK_METRICS
+#ifdef CONFIG_MEMFAULT_NCS_LTE_METRICS
 static bool connected;
 static bool connect_timer_started;
-#endif /* CONFIG_MEMFAULT_NCS_STACK_METRICS */
+#endif /* CONFIG_MEMFAULT_NCS_LTE_METRICS */
 
 static void stack_check(const struct k_thread *cthread, void *user_data)
 {


### PR DESCRIPTION
Change the guard for two static variables to the correct one,
CONFIG_MEMFAULT_NCS_LTE_METRICS.

This fixes an issue where compilation fails of stack metrics
are disabled and LTE metrics are enabled.

Fixes CIA-479

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>