### PR TITLE
doc: nrf9160: add note on control signal that enables ext flash

### DIFF
--- a/samples/nrf9160/http_update/full_modem_update/README.rst
+++ b/samples/nrf9160/http_update/full_modem_update/README.rst
@@ -37,7 +37,9 @@ The sample supports the following development kit, version 0.14.0 or higher:
 
 .. include:: /includes/spm.txt
 
-
+On the nRF9160 DK, you must set the control signal from the nRF52840 board controller MCU (**P0.19**) to *high* to let the nRF9160 communicate with the external flash memory.
+To do so, enable the ``external_flash_pins_routing`` node in devicetree.
+See :ref:`zephyr:nrf9160dk_board_controller_firmware` for details on building the firmware for the nRF52840 board controller MCU.
 
 Configuration options
 *********************


### PR DESCRIPTION
Add note to the nrf9160 user guide about control signal from the
nRF52840 board controller MCU that needs to be set high in order
for the nRF9160 to be able to communicate with the external flash
over SPI.

Ref: NCSDK-11798

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>