### PR TITLE
doc: ug_nrf5340: fix P24 description

### DIFF
--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -630,14 +630,29 @@ This container package can be used by update tools to pass both images during th
 Getting logging output
 **********************
 
-When connected to a computer, the nRF5340 DK emulates three virtual COM ports.
+When connected to a computer, the nRF5340 DK emulates virtual COM ports.
+The number of COM ports depends on the DK version you are using.
+
+nRF5340 DK v2.0.0 COM ports
+===========================
+
+When connected to a computer, the nRF5340 DK v2.0.0 emulates two virtual COM ports.
+In the default configuration, they are set up as follows:
+
+* The first COM port outputs the log from the network core (if available).
+* The second COM port outputs the log from the application core.
+
+nRF5340 DK v1.0.0 COM ports
+===========================
+
+When connected to a computer, the nRF5340 DK v1.0.0 emulates three virtual COM ports.
 In the default configuration, they are set up as follows:
 
 * The first COM port outputs the log from the network core (if available).
 * The second (middle) COM port is routed to the **P24** connector of the nRF5340 DK.
-* The third (last) COM port outputs the log from the application core sample.
+* The third (last) COM port outputs the log from the application core.
 
-You can use the second COM port as follows:
+To use the middle COM port in the nRF5340 DK v1.0.0, complete the following steps:
 
 1. Map **rx-pin**, **tx-pin**, **rts-pin**, and **cts-pin** to four different pins on the development kit, using, for example, using :ref:`devicetree overlays<zephyr:devicetree-intro>`.
    See the following example, using the :ref:`zephyr:dtbinding_nordic_nrf_uarte` bindings.

--- a/doc/nrf/ug_tfm.rst
+++ b/doc/nrf/ug_tfm.rst
@@ -96,8 +96,12 @@ Logging
 TF-M employs two UART interfaces for logging: one for the secure part (MCUboot and TF-M), and one for the non-secure application.
 The logs arrive on different COM ports on the host PC.
 
-On the nRF5340 DK, you must connect specific wires on the kit to receive secure logs on the host PC.
-Specifically, wire the pins **P0.25** and **P0.26** of the **P2** connector respectively to **RxD** and **TxD**  of the **P24** connector.
+.. note::
+   * On the nRF5340 DK v1.0.0, you must connect specific wires on the kit to receive secure logs on the host PC.
+     Specifically, wire the pins **P0.25** and **P0.26** of the **P2** connector respectively to **RxD** and **TxD**  of the **P24** connector.
+     See :ref:`logging_cpunet` on the Working with nRF5340 DK page for more information.
+   * On the nRF5340 DK v2.0.0, there is one fewer COM port than on v1.0.0, so the secure and non-secure UART peripheral must be wired to the same pins.
+     Specifically, wire the pins **P0.25** and **P0.26** to **P0.20** and **P0.22**, respectively.
 
 Limitations
 ***********


### PR DESCRIPTION
Rewrote information about the P24 connector.
It is only available in nRF5340 v1.0.0.
TECHDOC-1890.
Related to https://github.com/nrfconnect/sdk-nrf/pull/6133

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>