### PR TITLE
ext: port to nrf_modem_at APIs

### DIFF
--- a/ext/curl/tool/tool_getparam.c
+++ b/ext/curl/tool/tool_getparam.c
@@ -798,7 +798,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           return PARAM_BAD_NUMERIC;
         }
         break;
-#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED) && defined (CONFIG_AT_CMD)
+#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
       case 'T': /* --curr-mdm-traces */
         global->curr_mdm_traces = toggle;
       break;

--- a/ext/curl/tool/tool_help.c
+++ b/ext/curl/tool/tool_help.c
@@ -200,7 +200,7 @@ static const struct helptxt helptext[] = {
   {"    --upload-buff-size #<size of the upload buffer>",
    "NRF curl tool hook for the CURLOPT_UPLOAD_BUFFERSIZE curl lib option impacting upload sending",
    CURLHELP_IMPORTANT | CURLHELP_HTTP | CURLHELP_POST | CURLHELP_UPLOAD},
-#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED) && defined (CONFIG_AT_CMD)   
+#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
   {"    --curr-mdm-traces",
    "Use currently configured modem traces",
    CURLHELP_IMPORTANT | CURLHELP_HTTP},

--- a/ext/curl/tool/tool_main.c
+++ b/ext/curl/tool/tool_main.c
@@ -33,9 +33,9 @@
 #endif
 
 #if defined(CONFIG_NRF_CURL_INTEGRATION)
-#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED) && defined (CONFIG_AT_CMD)
+#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
 /* NRF_IPERF3_INTEGRATION_CHANGE: added */
-#include <modem/at_cmd.h>
+#include <nrf_modem_at.h>
 #endif
 #endif
 
@@ -213,12 +213,12 @@ static void free_globalconfig(struct GlobalConfig *config)
 static void main_free(struct GlobalConfig *config)
 {
 #if defined(CONFIG_NRF_CURL_INTEGRATION)
-#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED) && defined (CONFIG_AT_CMD)
+#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
   if (!config->curr_mdm_traces) {
-    static const char default_mdm_trace[] = "AT%XMODEMTRACE=1,2";
+    static const char default_mdm_trace[] = "AT%%XMODEMTRACE=1,2";
 
     /* We cannot know what was set before the tests, thus setting "default": */
-    if (at_cmd_write(default_mdm_trace, NULL, 0, NULL) != 0) {
+    if (nrf_modem_at_printf(default_mdm_trace) != 0) {
       printk("error when setting default modem traces \"%s\"\n", default_mdm_trace);
     }
     else {
@@ -348,7 +348,7 @@ int curl_tool_main(int argc, char *argv[], struct k_poll_signal *kill_signal)
 #if defined(CONFIG_NRF_CURL_INTEGRATION)
     global.kill_signal = kill_signal;
 #endif
-      
+
     /* Start our curl operation */
     result = operate(&global, argc, argv);
 

--- a/ext/curl/tool/tool_operate.c
+++ b/ext/curl/tool/tool_operate.c
@@ -86,9 +86,9 @@
 #include "memdebug.h" /* keep this as LAST include */
 
 #if defined(CONFIG_NRF_CURL_INTEGRATION)
-#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED) && defined (CONFIG_AT_CMD)
+#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
 /* NRF_IPERF3_INTEGRATION_CHANGE: added */
-#include <modem/at_cmd.h>
+#include <nrf_modem_at.h>
 #endif
 #endif
 
@@ -343,7 +343,7 @@ static CURLcode pre_transfer(struct GlobalConfig *global,
 #if defined(CONFIG_NRF_CURL_INTEGRATION)
   curl_easy_nrf_set_kill_signal(per->curl, global->kill_signal);
 #endif
-  
+
   return result;
 }
 
@@ -894,7 +894,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
         /* Single header file for all URLs */
         if(config->headerfile) {
-          /* open file for output: */          
+          /* open file for output: */
           if(strcmp(config->headerfile, "-")) {
             FILE *newfile;
 #if !defined(CONFIG_NRF_CURL_INTEGRATION)
@@ -981,11 +981,11 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->etag_save_file) {
           /* open file for output: */
           if(strcmp(config->etag_save_file, "-")) {
-#if !defined(CONFIG_NRF_CURL_INTEGRATION)            
+#if !defined(CONFIG_NRF_CURL_INTEGRATION)
             FILE *newfile = fopen(config->etag_save_file, "wb");
 #else
             FILE *newfile = NULL;
-#endif            
+#endif
             if(!newfile) {
               warnf(
                 config->global,
@@ -1120,7 +1120,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
               /* set offset to current file size: */
               config->resume_from = fileinfo.st_size;
             else
-#endif            
+#endif
               /* let offset be 0 */
               config->resume_from = 0;
           }
@@ -1211,7 +1211,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           /* we send the output to a tty, therefore we switch off the progress
              meter */
           per->noprogress = global->noprogress = global->isatty = TRUE;
-        else 
+        else
 #endif
 
         {
@@ -1813,16 +1813,16 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if (config->upload_buffsize) {
           my_setopt(curl, CURLOPT_UPLOAD_BUFFERSIZE, config->upload_buffsize);
         }
-#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED) && defined (CONFIG_AT_CMD)
+#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
         if (!global->curr_mdm_traces) {
           /* Let's set more lightweight traces for getting better perf: */
-          static const char lightweight_mdm_trace[] = "AT%XMODEMTRACE=1,5";
-              
-          if (at_cmd_write(lightweight_mdm_trace, NULL, 0, NULL) != 0) {
+          static const char lightweight_mdm_trace[] = "AT%%XMODEMTRACE=1,5";
+
+          if (nrf_modem_at_printf(lightweight_mdm_trace) != 0) {
             printk("error when setting lightweight modem traces\n");
           }
           else {
-            printk("note: custom traces \"%s\" was set for testing\n", 
+            printk("note: custom traces \"%s\" was set for testing\n",
               lightweight_mdm_trace);
         	printk("note: use --curr-mdm-traces hook for the current ones\n\n");
           }
@@ -2630,7 +2630,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
       else if(res == PARAM_MANUAL_REQUESTED)
         hugehelp();
       /* Check if we were asked for the version information */
-#endif      
+#endif
       else if(res == PARAM_VERSION_INFO_REQUESTED)
         tool_version_info();
       /* Check if we were asked to list the SSL engines */

--- a/ext/iperf3/iperf.h
+++ b/ext/iperf3/iperf.h
@@ -319,7 +319,7 @@ struct iperf_test
     char     *timestamp_format;
 #if defined(CONFIG_NRF_IPERF3_INTEGRATION)
     char     *pdn_id_str;			/* --pdn_id option */
-#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED) && defined (CONFIG_AT_CMD)
+#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
     bool     curr_mdm_traces;        /* --curr-mdm-traces option */
 #endif
 #endif

--- a/ext/iperf3/iperf_locale.c
+++ b/ext/iperf3/iperf_locale.c
@@ -118,7 +118,7 @@ const char nrf_iperf3_usage_support_str[] =
                            "  -c, --client    <host>    run in client mode, connecting to <host>\n"
                            "  -u, --udp                 use UDP rather than TCP\n"
                            "  --connect-timeout #       timeout for control connection setup (ms)\n"
-#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED) && defined (CONFIG_AT_CMD)
+#if defined (CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
                            "  --curr-mdm-traces         use currently configured modem traces\n"
 #endif
                            "  -b, --bitrate #[KMG][/#]  target bitrate in bits/sec (0 for unlimited)\n"


### PR DESCRIPTION
My editor automatically removed trailing whitespaces. You can disable that in the diff by clicking on the gear symbol.