### PR TITLE
requirements-fixed.txt: bump babel to 2.9.1

### DIFF
--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -15,7 +15,7 @@ appdirs==1.4.4
 arrow==0.17.0
 astroid==2.4.2
 attrs==20.3.0
-Babel==2.9.0
+Babel==2.9.1
 breathe==4.26.1
 canopen==1.2.0
 cbor==1.0.0


### PR DESCRIPTION
build(deps): bump babel from 2.9.0 to 2.9.1 in /scripts

Bumps [babel](https://github.com/python-babel/babel) from 2.9.0 to 2.9.1.
- [Release notes](https://github.com/python-babel/babel/releases)
- [Changelog](https://github.com/python-babel/babel/blob/master/CHANGES)
- [Commits](https://github.com/python-babel/babel/compare/v2.9.0...v2.9.1)

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

replacement of #5903 for get CI pass