### PR TITLE
samples: nrf9160: mqtt_simple: increase payload buffer size

### DIFF
--- a/samples/nrf9160/mqtt_simple/Kconfig
+++ b/samples/nrf9160/mqtt_simple/Kconfig
@@ -35,7 +35,7 @@ config MQTT_MESSAGE_BUFFER_SIZE
 
 config MQTT_PAYLOAD_BUFFER_SIZE
 	int "MQTT payload buffer size"
-	default 128
+	default 400
 
 config BUTTON_EVENT_PUBLISH_MSG
 	string "The message to publish on a button event"


### PR DESCRIPTION
Increased the MQTT_PAYLOAD_BUFFER_SIZE, the sample tries to retrieve a long message from the broker (size 350) and fails (error 122). The payload buffer size needs to be increased for it to work.
NCSDK-12520

Signed-off-by: Paul Fleury <paul.fleury@nordicsemi.no>