### PR TITLE
lib: bin: lwm2m_carrier: Non-blocking connect to LTE network

### DIFF
--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -732,6 +732,11 @@ int lwm2m_os_download_file_size_get(size_t *size)
 
 /* LTE LC module abstractions. */
 
+static void lwm2m_os_lte_event_handler(const struct lte_lc_evt *const evt)
+{
+	/* This event handler is not in use by LwM2M carrier library. */
+}
+
 int lwm2m_os_lte_link_up(void)
 {
 	int err;
@@ -746,7 +751,7 @@ int lwm2m_os_lte_link_up(void)
 		}
 	}
 
-	return lte_lc_connect();
+	return lte_lc_connect_async(lwm2m_os_lte_event_handler);
 }
 
 int lwm2m_os_lte_link_down(void)


### PR DESCRIPTION
Use non-blocking connect to LTE network to avoid an error condition
in lwm2m_carrier_init() and lwm2m_carrier_run() when a device boot
in an area without LTE coverage or bad reception conditions.

The event handler is not in use by the LwM2M carrier library and
can be utilized by the application if needed.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>