### PR TITLE
application: serial_lte_modem: Adapt new zephyr http_client API

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -417,9 +417,9 @@ static void udp_thread_func(void *p1, void *p2, void *p3)
 		(void)close(proxy.sock);
 		proxy.sock = INVALID_SOCKET;
 		if (proxy.role == UDP_ROLE_CLIENT) {
-			sprintf(rsp_buf, "\r\n#XTCPCLI: %d,\"disconnected\"\r\n", ret);
+			sprintf(rsp_buf, "\r\n#XUDPCLI: %d,\"disconnected\"\r\n", ret);
 		} else {
-			sprintf(rsp_buf, "\r\n#XTCPSVR: %d,\"stopped\"\r\n", ret);
+			sprintf(rsp_buf, "\r\n#XUDPSVR: %d,\"stopped\"\r\n", ret);
 		}
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	}


### PR DESCRIPTION
HTTP_DATA_FINAL notification has been fixed.
https://github.com/nrfconnect/sdk-zephyr/commit/
be7faf7c0826544382165e47d8d33e716fd12622

Adapt Zephyr 2.7 http_client behavior.
.HTTP message might come along with HTTP_DATA_FINAL, process it
before return.
.http_response->body_start only works on HTTP header ends.
After that, every HTTP body message starts with begin of recv_buf.

Piggyback fix typo of udp proxy client.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>