### PR TITLE
scripts: Add ruby as requirement to all tools-versions files

### DIFF
--- a/scripts/tools-versions-darwin.txt
+++ b/scripts/tools-versions-darwin.txt
@@ -10,3 +10,4 @@ ses=5.68
 west=0.12.0
 gn=1880
 doxygen=1.9.2
+ruby=2.7.0

--- a/scripts/tools-versions-linux.txt
+++ b/scripts/tools-versions-linux.txt
@@ -12,3 +12,4 @@ dfu_util=0.9-1
 west=0.12.0
 gn=1880
 doxygen=1.9.2
+ruby=2.7.0

--- a/scripts/tools-versions-minimum.txt
+++ b/scripts/tools-versions-minimum.txt
@@ -9,3 +9,4 @@ ses=5.68
 west=0.12.0
 gn=1851
 doxygen=1.8.18
+ruby=2.7.0

--- a/scripts/tools-versions-win10.txt
+++ b/scripts/tools-versions-win10.txt
@@ -10,3 +10,4 @@ ses=5.68
 west=0.12.0
 gn=1880
 doxygen=1.9.2
+ruby=2.7.0


### PR DESCRIPTION
Adding Ruby as a requirement because it is required for application tests