### PR TITLE
Add nRF Cloud MQTT A-GPS filtered support

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -569,7 +569,8 @@ static void send_agps_request(struct k_work *work)
 /* Request A-GPS data no more often than every hour (time in milliseconds). */
 #define AGPS_UPDATE_PERIOD (60 * 60 * MSEC_PER_SEC)
 
-	if ((last_request_timestamp != 0) &&
+	if (!IS_ENABLED(CONFIG_NRF_CLOUD_AGPS_FILTERED) &&
+	    (last_request_timestamp != 0) &&
 	    (k_uptime_get() - last_request_timestamp) < AGPS_UPDATE_PERIOD) {
 		LOG_WRN("A-GPS request was sent less than 1 hour ago");
 	} else {

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
@@ -214,6 +214,11 @@ struct cloud_data_agps_request {
 	struct nrf_modem_gnss_agps_data_frame request;
 	/** Flag signifying that the data entry is to be encoded. */
 	bool queued : 1;
+	/** Flag indicating that the ephemerides will only include visible satellites */
+	bool filtered : 1;
+	/** Angle above the horizon to constrain the filtered set to. */
+	uint8_t mask_angle;
+
 };
 struct cloud_data_pgps_request {
 	/** Number of requested predictions. */

--- a/applications/asset_tracker_v2/src/modules/Kconfig.gnss_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.gnss_module
@@ -39,6 +39,16 @@ config GNSS_MODULE_PGPS_STORE_LOCATION
 	  modem upon boot.
 	  Note that this may also increase flash wear.
 
+config GNSS_MODULE_AGPS_FILTERED
+	bool "Request only visible satellite ephemerides"
+	default NRF_CLOUD_AGPS_FILTERED
+	depends on NRF_CLOUD_AGPS_FILTERED
+
+config GNSS_MODULE_ELEVATION_MASK
+	int "Minimum elevation angle for visible satellites"
+	default NRF_CLOUD_AGPS_ELEVATION_MASK
+	depends on NRF_CLOUD_AGPS_FILTERED
+
 choice GNSS_MODULE_ANTENNA
 	default GNSS_MODULE_ANTENNA_ONBOARD
 	prompt "Select which antenna to use for GNSS"

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -697,6 +697,12 @@ static int agps_request_encode(struct nrf_modem_gnss_agps_data_frame *incoming_r
 	cloud_agps_request.area = modem_info.network.area_code.value;
 	cloud_agps_request.request = *incoming_request;
 	cloud_agps_request.queued = true;
+#if defined(CONFIG_GNSS_MODULE_AGPS_FILTERED)
+	cloud_agps_request.filtered = CONFIG_GNSS_MODULE_AGPS_FILTERED;
+#endif
+#if defined(CONFIG_GNSS_MODULE_ELEVATION_MASK)
+	cloud_agps_request.mask_angle = CONFIG_GNSS_MODULE_ELEVATION_MASK;
+#endif
 
 	err = cloud_codec_encode_agps_request(&codec, &cloud_agps_request);
 	switch (err) {

--- a/applications/asset_tracker_v2/src/modules/gnss_module.c
+++ b/applications/asset_tracker_v2/src/modules/gnss_module.c
@@ -454,6 +454,16 @@ static void search_start(void)
 		}
 	}
 
+#if defined(CONFIG_GNSS_MODULE_ELEVATION_MASK)
+	err = nrf_modem_gnss_elevation_threshold_set(CONFIG_GNSS_MODULE_ELEVATION_MASK);
+	if (err) {
+		LOG_ERR("Failed to set elevation threshold to %d, error: %d",
+			CONFIG_GNSS_MODULE_ELEVATION_MASK, err);
+	} else {
+		LOG_DBG("Elevation threshold set to %d", CONFIG_GNSS_MODULE_ELEVATION_MASK);
+	}
+#endif
+
 	err = nrf_modem_gnss_start();
 	if (err) {
 		LOG_WRN("Failed to start GNSS, error: %d", err);

--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -114,6 +114,11 @@ The following options control the use of GNSS assistance data:
 * :kconfig:`CONFIG_LOCATION_METHOD_GNSS_AGPS_EXTERNAL` - Enables A-GPS data retrieval from an external source which the application implements separately. If enabled, Location library throws event :c:enum:`LOCATION_EVT_GNSS_ASSISTANCE_REQUEST` when assistance is needed. Once application has obtained the assistance data it should call :c:func:`location_agps_data_process` function to feed it into Location library.
 * :kconfig:`CONFIG_NRF_CLOUD_AGPS` - Enables A-GPS data retrieval from `nRF Cloud`_.
 * :kconfig:`CONFIG_NRF_CLOUD_PGPS` - Enables P-GPS data retrieval from `nRF Cloud`_.
+* :kconfig:`CONFIG_NRF_CLOUD_AGPS_FILTERED` - Reduces assistance size by only downloading ephemerides for visible satellites.
+
+The following option is useful when setting :kconfig:`CONFIG_NRF_CLOUD_AGPS_FILTERED`:
+
+* :kconfig:`CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK` - Sets elevation threshold angle.
 
 The following options control the transport method used with `nRF Cloud`_:
 

--- a/doc/nrf/libraries/networking/nrf_cloud_agps.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_agps.rst
@@ -42,6 +42,18 @@ If :kconfig:`CONFIG_NRF_CLOUD_REST` is enabled, the :c:func:`nrf_cloud_rest_agps
 When nRF Cloud responds with the requested A-GPS data, the :c:func:`nrf_cloud_agps_process` function processes the received data.
 The function parses the data and passes it on to the modem.
 
+Optimizing cloud data downloads
+*******************************
+
+When the application only requires a fast GNSS fix at most once per 2 hour period, it can reduce LTE data charges by enabling :kconfig:`CONFIG_NRF_CLOUD_AGPS_FILTERED` (A-GPS filtered mode).
+This option causes nRF Cloud to send ephemerides data for only those satellites whose elevation is at or above the :kconfig:`CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK` angle at the current moment.
+
+When using the A-GPS filtered mode with the GNSS unit in periodic tracking mode, applications should disable scheduled downloads in the GNSS unit.
+Applications do this when initializing the GNSS unit by bitwise ORing the :c:enumerator:`NRF_MODEM_GNSS_USE_CASE_SCHED_DOWNLOAD_DISABLE` bitmask with any other needed use case values, then passing the resulting value to the :c:func:`nrf_modem_gnss_use_case_set` function.
+This ensures the GNSS unit does not stay on longer than needed due to the lack of a full set of ephemerides.
+
+When the application requires fast GNSS fixes multiple times within a 2 hour period, it can avoid unnecessary A-GPS data downloads from nRF Cloud by keeping :kconfig:`CONFIG_NRF_CLOUD_AGPS_FILTERED` disabled.
+
 Practical considerations
 ************************
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -64,6 +64,11 @@ nRF9160: Asset Tracker v2
 
 * Updated the code and documentation to use the acronym GNSS instead of GPS when not referring explicitly to the GPS system.
 
+* Added:
+
+  * Support for A-GPS filtered ephemerides.
+
+
 nRF Desktop
 -----------
 
@@ -197,6 +202,15 @@ Libraries for networking
 * :ref:`lib_dfu_target` library:
 
   * Updated the implementation of modem delta upgrades in the DFU target library to use the new socketless interface provided by the :ref:`nrf_modem`.
+
+* :ref:`lib_location` library:
+
+  * Added A-GPS filtered ephemerides support.
+
+* :ref:`lib_nrf_cloud` library:
+
+  * Added A-GPS filtered ephemerides support, with ability to set matching threshold mask angle.
+  * When filtered ephemerides is enabled, A-GPS assistance requests to cloud are limited to no more than once every two hours.
 
 Other libraries
 ---------------

--- a/include/net/nrf_cloud_agps.h
+++ b/include/net/nrf_cloud_agps.h
@@ -63,7 +63,6 @@ void nrf_cloud_agps_processed(struct nrf_modem_gnss_agps_data_frame *received_el
  */
 bool nrf_cloud_agps_request_in_progress(void);
 
-
 /** @} */
 
 #ifdef __cplusplus

--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -623,6 +623,10 @@ static void method_gnss_positioning_work_fn(struct k_work *work)
 	/* Configure GNSS to continuous tracking mode */
 	err = nrf_modem_gnss_fix_interval_set(1);
 
+#if defined(CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK)
+	err |= nrf_modem_gnss_elevation_threshold_set(CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK);
+#endif
+
 	uint8_t use_case;
 
 	switch (gnss_config.accuracy) {

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_agps
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_agps
@@ -3,8 +3,28 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-config NRF_CLOUD_AGPS
+menuconfig NRF_CLOUD_AGPS
 	bool "nRF Cloud Assisted GPS (A-GPS)"
 	depends on MODEM_INFO
 	depends on MODEM_INFO_ADD_NETWORK
 	select CJSON_LIB
+
+if NRF_CLOUD_AGPS
+
+config NRF_CLOUD_AGPS_FILTERED
+	bool "Request only visible satellite ephemerides"
+	help
+	  Normally A-GPS requests ephemerides for all GPS constellation
+	  satellites. Setting this option reduces that set to only
+	  satellites at or above the threshold elevation angle.
+
+config NRF_CLOUD_AGPS_ELEVATION_MASK
+	int "Minimum elevation angle for visible satellites"
+	default 5
+	depends on NRF_CLOUD_AGPS_FILTERED
+	help
+	  This sets the threshold elevation angle in A-GPS cloud requests.
+	  It constrains which satellite ephemerides are included in the
+	  assistance data returned by the cloud.
+
+endif # NRF_CLOUD_AGPS

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
@@ -37,6 +37,9 @@ extern "C" {
 
 #define NRF_CLOUD_JSON_FULFILL_KEY		"fulfilledWith"
 
+#define NRF_CLOUD_JSON_FILTERED_KEY		"filtered"
+#define NRF_CLOUD_JSON_ELEVATION_MASK_KEY	"mask"
+
 /* Modem info key text */
 #define NRF_CLOUD_JSON_MCC_KEY			"mcc"
 #define NRF_CLOUD_JSON_MNC_KEY			"mnc"


### PR DESCRIPTION
Add support for filtered ephemerides:
- encode new parameters in JSON assistance request
- set GNSS elevation threshold to match configured value for filtered mode, and suppress scheduled downloads, in ATv2, location library, and nrf9160_gps driver (so ATv1 gets this too) -- but only for the apps and samples which use the GNSS periodic fix mode
- suppress redundant ephemerides assistance in filtered mode (limit to once every 2 hours)

To do: ensure ephemerides validity period is considered when deciding to suppress ephemerides assistance.