### PR TITLE
net: lib: download_client: remove impossible case

### DIFF
--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -330,7 +330,7 @@ int socket_send(const struct download_client *client, size_t len)
 
 	while (len) {
 		sent = send(client->fd, client->buf + off, len, 0);
-		if (sent <= 0) {
+		if (sent < 0) {
 			return -errno;
 		}
 


### PR DESCRIPTION
This commit removes the check for the case of socket `send`
returning 0. `send` will always return either the non-zero
amount of data sent or a negative number in case of error.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>