### PR TITLE
Bluetooth: Mesh: Make BT_MESH_MODEL_USER_DATA macro public

### DIFF
--- a/include/bluetooth/mesh/model_types.h
+++ b/include/bluetooth/mesh/model_types.h
@@ -87,10 +87,9 @@ bt_mesh_model_transition_time(const struct bt_mesh_model_transition *trans)
 	return trans->delay + trans->time;
 }
 
-/** @cond INTERNAL_HIDDEN
- * @def BT_MESH_MODEL_USER_DATA
+/** @def BT_MESH_MODEL_USER_DATA
  *
- * @brief Internal utility macro for type checking model user data.
+ * @brief Utility macro for type checking of model user data.
  *
  * Produces a "Comparison of distinct pointer types" warning if @p _user_data
  * is of the wrong type.
@@ -99,7 +98,7 @@ bt_mesh_model_transition_time(const struct bt_mesh_model_transition *trans)
  * @c BT_MESH_MODEL_ macros, it generates a compiler warning for a bug that is
  * otherwise very hard to detect, and relatively easy to make:
  *
- * As the @ref bt_mesh_model::user_data is a void pointer, it does not have
+ * As the @em bt_mesh_model::user_data is a void pointer, it does not have
  * any type checking. The mesh model implementations wrap this macro, often
  * taking a pointer parameter to a context structure, passing it to the model
  * user data. As the @c BT_MESH_MODEL_ macros are used in listing of models,
@@ -112,7 +111,6 @@ bt_mesh_model_transition_time(const struct bt_mesh_model_transition *trans)
  */
 #define BT_MESH_MODEL_USER_DATA(_type, _user_data)                             \
 	(((_user_data) == (_type *)0) ? NULL : (_user_data))
-/** @endcond */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This fixes a reference to this macro in Chat sample walk-through guide.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>