### PR TITLE
lib: at_monitor: introduce AT_MONITOR_ISR

### DIFF
--- a/doc/nrf/libraries/modem/at_monitor.rst
+++ b/doc/nrf/libraries/modem/at_monitor.rst
@@ -8,7 +8,7 @@ AT monitor
    :depth: 2
 
 The AT monitor library is used to define AT monitors, which consist of a handler function that receives AT notifications from the :ref:`nrfxlib:nrf_modem`, based on a filter.
-The handler is executed from the system workqueue.
+The handler is executed from the system workqueue or from an ISR, depending on the type of monitor.
 
 Overview
 ========
@@ -42,11 +42,16 @@ Upon initialization, the AT monitor library registers itself as the receiver of 
 Usage
 =====
 
-The application can define an AT monitor to receive notifications through the :c:macro:`AT_MONITOR` macro.
+The application can define an AT monitor to receive notifications through the :c:macro:`AT_MONITOR` and :c:macro:`AT_MONITOR_ISR` macros.
 An AT monitor has a name, a filter string, and a callback function.
 In addition, it can be paused or activated (using :c:macro:`PAUSED` and :c:macro:`ACTIVE` respectively).
-When the AT monitor library receives an AT notification from the Modem library, the notification is copied on the AT monitor library heap and is dispatched using the system workqueue to all monitors whose filter matches (even partially) the contents of the notification.
 Multiple parts of the application can define their own AT monitor with the same filter as another AT monitor, and thus receive the same notifications, if desired.
+
+Deferred dispatching
+********************
+
+The application can define an AT monitor to receive AT notifications in the system workqueue using the :c:macro:`AT_MONITOR` macro.
+When the AT monitor library receives an AT notification from the Modem library, the notification is copied on the AT monitor library heap and is dispatched using the system workqueue to all monitors whose filter matches (even partially) the contents of the notification.
 
 The following code snippet shows how to register a handler that receives ``+CEREG`` notifications from the Modem library:
 
@@ -58,6 +63,27 @@ The following code snippet shows how to register a handler that receives ``+CERE
 	int cereg_mon(const char *notif)
 	{
 		printf("Received +CEREG notification: %s", notif);
+	}
+
+The size of the AT monitor library heap can be configured using the :kconfig:`CONFIG_AT_MONITOR_HEAP_SIZE` option.
+
+Direct dispatching
+******************
+
+The AT monitor library supports defining a particular type of monitor that receives the AT notifications in an interrupt service routine.
+Because notifications dispatched to AT monitors in an ISR are not copied onto the AT monitor library heap, the application is guaranteed that the library will not be out of memory to copy the notification.
+This can be useful for some particularly large AT notifications or AT notifications that the application must reply to, for example, SMS notifications.
+
+The following code snippet shows how to register a handler that receives ``+CEREG`` notifications from the Modem library:
+
+.. code-block:: c
+
+	/* AT monitor for +CEREG notifications, dispatched in ISR */
+	AT_MONITOR_ISR(network_registration, "+CEREG", cereg_mon);
+
+	int cereg_mon(const char *notif)
+	{
+		printf("Received +CEREG notification in ISR");
 	}
 
 Pausing and resuming

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -159,6 +159,10 @@ Bootloader libraries
 Modem libraries
 ---------------
 
+* :ref:`at_monitor_readme` library:
+
+  * Introduced AT_MONITOR_ISR macro to monitor AT notifications in an interrupt service routine.
+
 * :ref:`at_cmd_parser_readme` library:
 
   * Can now parse AT command responses containing the response result, for example, ``OK`` or ``ERROR``.

--- a/include/modem/at_monitor.h
+++ b/include/modem/at_monitor.h
@@ -46,6 +46,18 @@ struct at_monitor_entry {
 };
 
 /**
+ * @brief AT monitor entry (ISR).
+ */
+struct at_monitor_isr_entry {
+	/** The filter for this monitor. */
+	const char *filter;
+	/** Monitor callback. */
+	const at_monitor_handler_t handler;
+	/** Whether monitor is paused. */
+	bool paused;
+};
+
+/**
  * @brief Ready to dispatch notifications to monitors.
  */
 void at_monitor_init(void);
@@ -58,7 +70,7 @@ void at_monitor_init(void);
 #define ACTIVE 0
 
 /**
- * @brief Define an AT monitor.
+ * @brief Define an AT monitor to receive notifications in the system workqueue thread.
  *
  * @param name The monitor name.
  * @param _filter The filter for AT notification the monitor should receive,
@@ -67,12 +79,30 @@ void at_monitor_init(void);
  * @param ... Optional monitor initial state (@c PAUSED or @c ACTIVE).
  *	      The default initial state of a monitor is active.
  */
-#define AT_MONITOR(name, _filter, _handler, ...)                               \
-	static void _handler(const char *);                                    \
-	STRUCT_SECTION_ITERABLE(at_monitor_entry, at_monitor_##name) = {       \
-		.filter = _filter,                                             \
-		.handler = _handler,                                           \
-		COND_CODE_1(__VA_ARGS__, (.paused = __VA_ARGS__,), ())         \
+#define AT_MONITOR(name, _filter, _handler, ...)                                                   \
+	static void _handler(const char *);                                                        \
+	STRUCT_SECTION_ITERABLE(at_monitor_entry, at_monitor_##name) = {                           \
+		.filter = _filter,                                                                 \
+		.handler = _handler,                                                               \
+		COND_CODE_1(__VA_ARGS__, (.paused = __VA_ARGS__,), ())                             \
+	}
+
+/**
+ * @brief Define an AT monitor to receive AT notifications in an ISR.
+ *
+ * @param name The monitor name.
+ * @param _filter The filter for AT notification the monitor should receive,
+ *		  or @c ANY to receive all notifications.
+ * @param _handler The monitor callback.
+ * @param ... Optional monitor initial state (@c PAUSED or @c ACTIVE).
+ *	      The default initial state of a monitor is active.
+ */
+#define AT_MONITOR_ISR(name, _filter, _handler, ...)                                               \
+	static void _handler(const char *);                                                        \
+	STRUCT_SECTION_ITERABLE(at_monitor_isr_entry, at_monitor_##name) = {                       \
+		.filter = _filter,                                                                 \
+		.handler = _handler,                                                               \
+		COND_CODE_1(__VA_ARGS__, (.paused = __VA_ARGS__,), ())                             \
 	}
 
 /**

--- a/lib/at_monitor/at_monitor.ld
+++ b/lib/at_monitor/at_monitor.ld
@@ -1,4 +1,10 @@
+/* AT monitors, to run in a thread */
 . = ALIGN(4);
 _at_monitor_entry_list_start = .;
 KEEP(*(SORT_BY_NAME("._at_monitor_entry.*")));
 _at_monitor_entry_list_end = .;
+/* AT monitors, to run in ISR */
+. = ALIGN(4);
+_at_monitor_isr_entry_list_start = .;
+KEEP(*(SORT_BY_NAME("._at_monitor_isr_entry.*")));
+_at_monitor_isr_entry_list_end = .;


### PR DESCRIPTION
Introduce `AT_MONITOR_ISR` macro to define monitors that receive
notifications directly, that is, in the same ISR they are sent
from by libmodem.

These monitors avoid the situation where there is no memory to copy
the notification on the library heap. This is useful for applications
that must ensure to ack certain notifications (SMS-related) and
need a guarantee that they can always be received.

Importantly, the application may not call other nrf_modem_at
APIs in the ISR context where notifications are received.
The application must ensure to defer acking any notifications
received in the ISR outside of the ISR.

Tested manually by modifying the AT monitor sample.

A few questions for the reviewers:
1) `at_monitor` copies _all_ notifications on the heap, regardless of whether they have a monitor. This is based on the assumption that the application manually registers to notifications, and thus if a notification is received, there is a monitor. This avoids any loops in the ISR. If that assumption is wrong, we could reduce heap use by copying the notification only if there is a monitor for it. This has the drawback of having to loop the monitors in the ISR (and then again- in the workqueue).
Is this assumption reasonable?
2) It is not possible to make `nrf_modem_at_` calls in the notification interrupt. Is this an acceptable limitation?