### PR TITLE
samples: matter: Added config to inform about experimental support

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -51,6 +51,11 @@ Bluetooth
 
 * |no_changes_yet_note|
 
+Matter
+------
+
+* Added ``EXPERIMENTAL`` select in Kconfig that informs that Matter support is experimental.
+
 Applications
 ============
 

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -37,6 +37,8 @@ rsource "shell/Kconfig"
 
 rsource "mpsl/Kconfig"
 
+rsource "matter/Kconfig"
+
 rsource "partition_manager/Kconfig"
 
 rsource "nrf_rpc/Kconfig"

--- a/subsys/matter/Kconfig
+++ b/subsys/matter/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Support for Matter (formerly Connected Home over IP) protocol in NCS is experimental
+config CHIP
+	bool
+	select EXPERIMENTAL


### PR DESCRIPTION
* Added Matter Kconfig to subsys
* Added CHIP config selecting EXPERIMENTAL support for Matter
that will be merged with existing CHIP upstream config.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>