### PR TITLE
ESB samples nRF52833 DK support

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -191,6 +191,15 @@ Libraries for networking
 
     * An issue where downloads of COAP URIs would fail when they contained multiple path elements.
 
+Other libraries
+---------------
+
+* Updated:
+
+  * :ref:`esb_readme`:
+
+    * Fixed a compilation error for nRF52833.
+
 sdk-nrfxlib
 -----------
 

--- a/include/esb.h
+++ b/include/esb.h
@@ -116,8 +116,7 @@ enum esb_bitrate {
 	ESB_BITRATE_1MBPS = RADIO_MODE_MODE_Nrf_1Mbit,
 	/** 2 Mb radio mode. */
 	ESB_BITRATE_2MBPS = RADIO_MODE_MODE_Nrf_2Mbit,
-#if !(defined(CONFIG_SOC_NRF52840) || defined(CONFIG_SOC_NRF52810) ||          \
-      defined(CONFIG_SOC_NRF52811) || defined(CONFIG_SOC_NRF5340_CPUNET))
+#if defined(RADIO_MODE_MODE_Nrf_250Kbit)
 	/** 250 Kb radio mode. */
 	ESB_BITRATE_250KBPS = RADIO_MODE_MODE_Nrf_250Kbit,
 #endif

--- a/samples/esb/README.rst
+++ b/samples/esb/README.rst
@@ -37,7 +37,7 @@ The sample supports the following development kits:
 
 .. table-from-rows:: /includes/sample_board_rows.txt
    :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf21540dk_nrf52840
+   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832, nrf21540dk_nrf52840
 
 You can use any two of the development kits listed above and mix different development kits.
 

--- a/samples/esb/prx/sample.yaml
+++ b/samples/esb/prx/sample.yaml
@@ -13,10 +13,11 @@ tests:
       - nrf52dk_nrf52810
   samples.esb.prx.build:
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
+      - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52810
       - nrf5340dk_nrf5340_cpunet

--- a/samples/esb/ptx/sample.yaml
+++ b/samples/esb/ptx/sample.yaml
@@ -13,10 +13,11 @@ tests:
       - nrf52dk_nrf52810
   samples.esb.ptx.build:
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
+      - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52810
       - nrf5340dk_nrf5340_cpunet


### PR DESCRIPTION
Add nRF52833 DK support to ESB samples.

JIRA: NCSIDB-640