### PR TITLE
modules: TF-M: Update out-of-tree boards to set PLATFORM_PATH variable

### DIFF
--- a/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
+++ b/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
@@ -5,7 +5,8 @@
 #
 #-------------------------------------------------------------------------------
 
-include(platform/ext/target/nordic_nrf/common/nrf5340/config.cmake)
+set(PLATFORM_PATH platform/ext/target/nordic_nrf/)
+include(${PLATFORM_PATH}/common/nrf5340/config.cmake)
 
 # Override the AEAD algorithm configuration
 set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_GCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")

--- a/modules/tfm/tfm/boards/nrf9160/config.cmake
+++ b/modules/tfm/tfm/boards/nrf9160/config.cmake
@@ -5,7 +5,8 @@
 #
 #-------------------------------------------------------------------------------
 
-include(platform/ext/target/nordic_nrf/common/nrf9160/config.cmake)
+set(PLATFORM_PATH platform/ext/target/nordic_nrf/)
+include(${PLATFORM_PATH}/common/nrf9160/config.cmake)
 
 # Override the AEAD algorithm configuration since nRF9160 supports only AES_CCM
 set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_CCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")


### PR DESCRIPTION
Update out-of-tree boards to set the PLATFORM_PATH variable to be used
for setting configurations.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>