### PR TITLE
modules: tfm: Fix tfm_hal_platform_init handling

### DIFF
--- a/modules/tfm/tfm/boards/CMakeLists.txt
+++ b/modules/tfm/tfm/boards/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(platform_s
 
 target_sources(platform_s
   PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/common/plat_init.c
+  ${CMAKE_CURRENT_LIST_DIR}/common/tfm_hal_platform.c
   )
 
 if (${TFM_PARTITION_CRYPTO}

--- a/modules/tfm/tfm/boards/common/tfm_hal_platform.c
+++ b/modules/tfm/tfm/boards/common/tfm_hal_platform.c
@@ -15,12 +15,12 @@
 
 enum tfm_hal_status_t tfm_hal_platform_init(void)
 {
-	__enable_irq();
+	tfm_hal_status_t status;
 
-	/* Only if UART1 is used by TF-M do we initialize it. */
-#ifdef SECURE_UART1
-	stdio_init();
-#endif
+	status = tfm_hal_platform_common_init();
+	if (status != TFM_HAL_SUCCESS) {
+		return status;
+	}
 
 #if defined(TFM_PARTITION_CRYPTO) && \
     !defined(TFM_CRYPTO_KEY_DERIVATION_MODULE_DISABLED) && \


### PR DESCRIPTION
Fix tfm_hal_platformi_init handling. Use the common board support init
handling from TF-M and maintain the out-of-tree init code in the same
place.

NCSDK-12821

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>