### PR TITLE
caf: Rework returned address of module_id_get and MODULE_ID

### DIFF
--- a/applications/machine_learning/src/events/ml_result_event.c
+++ b/applications/machine_learning/src/events/ml_result_event.c
@@ -20,12 +20,10 @@ static int log_ml_result_event(const struct event_header *eh, char *buf, size_t 
 static int log_ml_result_signin_event(const struct event_header *eh, char *buf, size_t buf_len)
 {
 	const struct ml_result_signin_event *event = cast_ml_result_signin_event(eh);
-	const char *mid = module_id_get(event->module_idx);
-
-	__ASSERT_NO_MSG(mid);
 
 	return snprintf(buf, buf_len, "module: \"%s\" %s ml_result_event",
-		mid, event->state ? "signs in to" : "signs off from");
+			module_name_get(module_id_get(event->module_idx)),
+			event->state ? "signs in to" : "signs off from");
 }
 
 static void profile_ml_result_event(struct log_event_buf *buf, const struct event_header *eh)

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -104,6 +104,16 @@ Bluetooth libraries and services
 
 * |no_changes_yet_note|
 
+Common Application Framework (CAF)
+----------------------------------
+
+* Updated:
+
+  * Unify module id reference location.
+    The array holding module reference objects is explicitly defined in linker script to avoid creating an orphan section.
+    ``MODULE_ID`` macro and :c:func:`module_id_get` function now returns module reference from dedicated section instead of module name.
+    The module name can not be obtained from reference object directly, a helper function (:c:func:`module_name_get`) should be used instead.
+
 Modem libraries
 ---------------
 

--- a/subsys/caf/events/module_state_event.c
+++ b/subsys/caf/events/module_state_event.c
@@ -30,7 +30,7 @@ static int log_module_state_event(const struct event_header *eh, char *buf,
 	__ASSERT_NO_MSG(state_name[event->state] != NULL);
 
 	return snprintf(buf, buf_len, "module:%s state:%s",
-		      (const char *)event->module_id, state_name[event->state]);
+			module_name_get(event->module_id), state_name[event->state]);
 }
 
 EVENT_TYPE_DEFINE(module_state_event,

--- a/subsys/caf/events/power_manager_event.c
+++ b/subsys/caf/events/power_manager_event.c
@@ -43,8 +43,8 @@ static int log_event(const struct event_header *eh,
 	}
 
 	return snprintf(buf, buf_len, "module \"%s\" restricts to %s",
-		(const char *)module_id_get(event->module_idx),
-		power_state_str);
+			module_name_get(module_id_get(event->module_idx)),
+			power_state_str);
 }
 
 static void profile_event(struct log_event_buf *buf,


### PR DESCRIPTION
Macro and function name suggest it returns pointer to
the memory rather that value of that pointer.

This change fixes returned value by module_id_get function
and MODULE_ID macro. Module id is an address from the
module_id_list section rather than value to which this
pointer points.

Rework the returned address to be more understandable
and predictable.

Add module_name_get function to properly return module
name when needed for logging.

Added entry in changelog.

Jira:NCSDK-13029

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>