### PR TITLE
caf: Prevent linker from dropping modules from module_id_list

### DIFF
--- a/subsys/caf/events/CMakeLists.txt
+++ b/subsys/caf/events/CMakeLists.txt
@@ -55,3 +55,5 @@ zephyr_sources_ifdef(CONFIG_CAF_SENSOR_EVENTS
 zephyr_sources_ifdef(CONFIG_CAF_BLE_SMP_TRANSFER_EVENTS
 	ble_smp_event.c
 )
+
+zephyr_linker_sources(SECTIONS module_id_list.ld)

--- a/subsys/caf/events/module_id_list.ld
+++ b/subsys/caf/events/module_id_list.ld
@@ -1,0 +1,6 @@
+module_id_list_all :
+{
+	__start_module_id_list = .;
+	KEEP(*(module_id_list));
+	__stop_module_id_list = .;
+} > FLASH


### PR DESCRIPTION
This change fixes an issue that linker may drop off some
unreferenced elements of module_id_list.
Prevent this by adding explicit KEEP statement for
section elements.

JIRA: NCSDK-13031

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>