### PR TITLE
samples: nrf9160: http_update: graceful shutdown of modem fw

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -105,6 +105,10 @@ nRF9160 samples
 
   * Added support for minimal assistance using factory almanac, time and location.
 
+* nRF9160: HTTP update samples:
+
+  * HTTP update samples now set the modem in the power off mode after the firmware image download completes. This avoids ungraceful disconnects from the network upon pressing the reset button on the kit.
+
 Other samples
 -------------
 

--- a/samples/nrf9160/http_update/application_update/src/main.c
+++ b/samples/nrf9160/http_update/application_update/src/main.c
@@ -22,9 +22,12 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 	switch (evt->id) {
 	case FOTA_DOWNLOAD_EVT_ERROR:
 		printk("Received error from fota_download\n");
-		/* Fallthrough */
+		update_sample_stop();
+		break;
+
 	case FOTA_DOWNLOAD_EVT_FINISHED:
 		update_sample_done();
+		printk("Reset device to apply new firmware\n");
 		break;
 
 	default:
@@ -39,7 +42,7 @@ static void update_start(void)
 	err = fota_download_start(CONFIG_DOWNLOAD_HOST, CONFIG_DOWNLOAD_FILE,
 				  SEC_TAG, 0, 0);
 	if (err != 0) {
-		update_sample_done();
+		update_sample_stop();
 		printk("fota_download_start() failed, err %d\n", err);
 	}
 }

--- a/samples/nrf9160/http_update/common/include/update.h
+++ b/samples/nrf9160/http_update/common/include/update.h
@@ -44,7 +44,18 @@ struct update_sample_init_params {
  */
 int update_sample_init(struct update_sample_init_params *params);
 
-/** Notify the library that the update has been completed. */
+/** Notify the library that the update has been stopped.
+ *
+ * This will re-enable the button. Making it possible to
+ * restart or continue the update.
+ */
+void update_sample_stop(void);
+
+/** Notify the library that the update has been completed.
+ *
+ * This will send the modem to power off mode, while waiting
+ * for a reset.
+ */
 void update_sample_done(void);
 
 #endif /* UPDATE_H__ */

--- a/samples/nrf9160/http_update/common/src/update.c
+++ b/samples/nrf9160/http_update/common/src/update.c
@@ -200,7 +200,12 @@ int update_sample_init(struct update_sample_init_params *params)
 	return 0;
 }
 
-void update_sample_done(void)
+void update_sample_stop(void)
 {
 	button_irq_enable();
+}
+
+void update_sample_done(void)
+{
+	lte_lc_deinit();
 }

--- a/samples/nrf9160/http_update/full_modem_update/src/main.c
+++ b/samples/nrf9160/http_update/full_modem_update/src/main.c
@@ -168,7 +168,7 @@ void update_start(void)
 	err = fota_download_start(CONFIG_DOWNLOAD_HOST, get_file(), SEC_TAG,
 				  0, 0);
 	if (err != 0) {
-		update_sample_done();
+		update_sample_stop();
 		printk("fota_download_start() failed, err %d\n", err);
 	}
 }

--- a/samples/nrf9160/http_update/modem_delta_update/src/main.c
+++ b/samples/nrf9160/http_update/modem_delta_update/src/main.c
@@ -55,9 +55,12 @@ void fota_dl_handler(const struct fota_download_evt *evt)
 	switch (evt->id) {
 	case FOTA_DOWNLOAD_EVT_ERROR:
 		printk("Received error from fota_download\n");
-		/* Fallthrough */
+		update_sample_stop();
+		break;
+
 	case FOTA_DOWNLOAD_EVT_FINISHED:
 		update_sample_done();
+		printk("Reset device to apply new modem firmware\n");
 		break;
 
 	default:
@@ -73,7 +76,7 @@ void update_start(void)
 	err = fota_download_start(CONFIG_DOWNLOAD_HOST, get_file(), SEC_TAG,
 				  0, 0);
 	if (err != 0) {
-		update_sample_done();
+		update_sample_stop();
 		printk("fota_download_start() failed, err %d\n", err);
 	}
 }


### PR DESCRIPTION
When updating firmware with http_update sample(s), one or more resets
must happen in order to apply the new image. These resets are causing
ungraceful disconnects/reconnects from the network, and the modem
will after a number of reconnects like these, refuse all
subsequent reconnection attempts for a set amount of time.

To avoid this, the sample(s) now gracefully disconnect from the
network by setting the modem in the power off mode when the
firmware image download is complete.

NCSDK-12416

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>