### PR TITLE
samples: matter: Disabled BT central for multiprotocol builds

### DIFF
--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/multiprotocol_rpmsg.conf
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/multiprotocol_rpmsg.conf
@@ -8,6 +8,7 @@
 # Refer to samples/nrf5340/multiprotocol_rpmsg/prj.conf
 
 # Reduce number of Bluetooth connections to limit memory usage.
+CONFIG_BT_CENTRAL=n
 CONFIG_BT_MAX_CONN=2
 
 # Increase maximum data length of PDU supported in the Controller

--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/multiprotocol_rpmsg_release.conf
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/multiprotocol_rpmsg_release.conf
@@ -8,6 +8,7 @@
 # Refer to samples/nrf5340/multiprotocol_rpmsg/prj.conf
 
 # Reduce number of Bluetooth connections to limit memory usage.
+CONFIG_BT_CENTRAL=n
 CONFIG_BT_MAX_CONN=2
 
 # Increase maximum data length of PDU supported in the Controller

--- a/samples/matter/light_bulb/child_image/multiprotocol_rpmsg.conf
+++ b/samples/matter/light_bulb/child_image/multiprotocol_rpmsg.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Reduce number of Bluetooth connections to limit memory usage.
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_MAX_CONN=1

--- a/samples/matter/lock/child_image/multiprotocol_rpmsg.conf
+++ b/samples/matter/lock/child_image/multiprotocol_rpmsg.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Reduce number of Bluetooth connections to limit memory usage.
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_MAX_CONN=1

--- a/samples/matter/template/child_image/multiprotocol_rpmsg.conf
+++ b/samples/matter/template/child_image/multiprotocol_rpmsg.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Reduce number of Bluetooth connections to limit memory usage.
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=n
+CONFIG_BT_MAX_CONN=1


### PR DESCRIPTION
On nRF5340 we are running out of net core FLASH and multiprotocol
image starts to not fit within it. Disabled BLE central for those
builds, as it's not used by the Matter samples anyway and saves
over 30k of memory.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>