### PR TITLE
doc: RSC service total distance correction and units

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -85,7 +85,13 @@ For lists of protocol-specific changes, see `Protocols`_.
 Bluetooth samples
 -----------------
 
-* Added :ref:`multiple_adv_sets` sample.
+* Added:
+
+  * :ref:`multiple_adv_sets` sample.
+
+* Updated:
+
+  * :ref:`peripheral_rscs` - Corrected the number of bytes for setting the Total Distance Value and specified the data units.
 
 nRF9160 samples
 ---------------
@@ -113,7 +119,11 @@ This section provides detailed lists of changes by :ref:`library <libraries>`.
 Bluetooth libraries and services
 --------------------------------
 
-* |no_changes_yet_note|
+Updated:
+
+* :ref:`rscs_readme` library:
+
+  * Added units for :c:struct:`bt_rscs_measurement` members.
 
 Common Application Framework (CAF)
 ----------------------------------

--- a/include/bluetooth/services/rscs.h
+++ b/include/bluetooth/services/rscs.h
@@ -147,16 +147,16 @@ struct bt_rscs_measurement {
 	/** True if running, False if walking. */
 	bool is_running;
 
-	/** Instantaneous Speed. */
+	/** Instantaneous Speed. 256 units = 1 meter/second */
 	uint16_t inst_speed;
 
-	/** Instantaneous Cadence. */
+	/** Instantaneous Cadence. 1 unit = 1 stride/minute */
 	uint8_t inst_cadence;
 
-	/** Instantaneous Stride Length. */
+	/** Instantaneous Stride Length. 100 units = 1 meter */
 	uint16_t inst_stride_length;
 
-	/** Total Distance. */
+	/** Total Distance. 1 unit = 1 meter */
 	uint32_t total_distance;
 };
 

--- a/samples/bluetooth/peripheral_rscs/README.rst
+++ b/samples/bluetooth/peripheral_rscs/README.rst
@@ -62,7 +62,7 @@ After programming the sample to your development kit, test it by performing the 
 #. In :guilabel:`SC Control Point`, tap the :guilabel:`Indicate` button to control the sensor.
 #. The following Op Codes (with data if required) can be written into :guilabel:`SC Control Point`:
 
-   * ``01 xx xx xx`` to set the Total Distance Value to the entered value (if the server supports the Total Distance Measurement feature).
+   * ``01 xx xx xx xx`` to set the Total Distance Value to the entered value in meters. (if the server supports the Total Distance Measurement feature).
    * ``02`` to start the sensor calibration process (if the server supports the Sensor Calibration feature).
    * ``03 xx`` to update the sensor location (if the server supports the Multiple Sensor Locations feature).
    * ``04`` to get a list of supported localizations (if the server supports the Multiple Sensor Locations feature).


### PR DESCRIPTION
Corrected:
number of bytes for set Total Distance service 3->4 (uint32)

Specified units (rscs.h) for:
-Instantenous speed,
-Instantenous Cadence,
-Instantenous Stride Length,
-Total Distance

Signed-off-by: Dominik Chat <dominik.chat@nordicsemi.no>