### PR TITLE
Bluetooth: Mesh: Extract regulator from light ctrl srv

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl.rst
@@ -23,6 +23,8 @@ For types common to all models, see :ref:`bt_mesh_models`.
 
    light_ctrl_srv.rst
    light_ctrl_cli.rst
+   light_ctrl_reg.rst
+   light_ctrl_reg_spec.rst
 
 
 

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg.rst
@@ -1,0 +1,20 @@
+.. _bt_mesh_light_ctrl_reg_readme:
+
+Light Lightness Control regulator
+#################################
+
+This module is an abstract proportional integral (PI) regulator.
+Regulator implementations should declare a :c:struct:`bt_mesh_light_ctrl_reg` struct and supply implementations for ``init``, ``start``, and ``stop``.
+
+For an example of a regulator implementation, see :ref:`bt_mesh_light_ctrl_reg_spec_readme`.
+
+
+API documentation
+*****************
+
+| Header file: :file:`include/bluetooth/mesh/light_ctrl_reg.h`
+| Source file: :file:`subsys/bluetooth/mesh/light_ctrl_reg.c`
+
+.. doxygengroup:: bt_mesh_light_ctrl_reg
+   :project: nrf
+   :members:

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg_spec.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg_spec.rst
@@ -1,0 +1,17 @@
+.. _bt_mesh_light_ctrl_reg_spec_readme:
+
+Light Lightness Control spec regulator
+######################################
+
+This module implements the PI lightness regulator specified in the Bluetooth® mesh model specification.
+Initialize using :c:macro:`BT_MESH_LIGHT_CTRL_REG_SPEC_INIT`.
+
+API documentation
+*****************
+
+| Header file: :file:`include/bluetooth/mesh/light_ctrl_reg_spec.h`
+| Source file: :file:`subsys/bluetooth/mesh/light_ctrl_reg_spec.c`
+
+.. doxygengroup:: bt_mesh_light_ctrl_reg_spec
+   :project: nrf
+   :members:

--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -1991,6 +1991,7 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "ATOMIC_DEFINE(x, y)=atomic_t x[ATOMIC_BITMAP_SIZE(y)]" \
                          "CONFIG_ZIGBEE_DEBUG_FUNCTIONS=y" \
                          "CONFIG_ZBOSS_ERROR_PRINT_TO_LOG=y" \
+                         "CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG=y" \
                          "MODULE="
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this

--- a/include/bluetooth/mesh/light_ctrl.h
+++ b/include/bluetooth/mesh/light_ctrl.h
@@ -218,21 +218,21 @@ enum bt_mesh_light_ctrl_coeff {
 #if CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG
 #define BT_MESH_LIGHT_CTRL_SRV_REG_CFG_INIT                                    \
 	{                                                                      \
-		.lux = { { CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_STANDBY },    \
-			 { CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_ON },         \
-			 { CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_PROLONG } },  \
-		.kiu = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KIU,                  \
-		.kid = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KID,                  \
-		.kpu = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KPU,                  \
-		.kpd = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KPD,                  \
+		.ki.up = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KIU,                  \
+		.ki.down = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KID,                  \
+		.kp.up = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KPU,                  \
+		.kp.down = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KPD,                  \
 		.accuracy = CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_ACCURACY,        \
 	}
 
-#define BT_MESH_LIGHT_CTRL_SRV_REG_INIT .reg = {                               \
-		.cfg = BT_MESH_LIGHT_CTRL_SRV_REG_CFG_INIT                     \
+#define BT_MESH_LIGHT_CTRL_SRV_LUX_INIT                                        \
+	.lux = {                                                               \
+		{ CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_STANDBY },             \
+		{ CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_ON },                  \
+		{ CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_LUX_PROLONG }              \
 	}
 #else
-#define BT_MESH_LIGHT_CTRL_SRV_REG_INIT
+#define BT_MESH_LIGHT_CTRL_SRV_LUX_INIT
 #endif
 
 #define BT_MESH_LIGHT_CTRL_SRV_CFG_INIT                                        \
@@ -254,7 +254,8 @@ enum bt_mesh_light_ctrl_coeff {
 			CONFIG_BT_MESH_LIGHT_CTRL_SRV_LVL_STANDBY,             \
 			CONFIG_BT_MESH_LIGHT_CTRL_SRV_LVL_ON,                  \
 			CONFIG_BT_MESH_LIGHT_CTRL_SRV_LVL_PROLONG,             \
-		}                                                              \
+		},                                                             \
+		BT_MESH_LIGHT_CTRL_SRV_LUX_INIT                                \
 	}
 /** @endcond */
 

--- a/include/bluetooth/mesh/light_ctrl_reg.h
+++ b/include/bluetooth/mesh/light_ctrl_reg.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *  @defgroup bt_mesh_light_ctrl_reg Light Lightness Control Regulator
+ *  @ingroup bt_mesh_light_ctrl
+ *  @{
+ *  @brief Light Lightness Control regulator API
+ */
+
+#ifndef BT_MESH_LIGHT_CTRL_REG_H__
+#define BT_MESH_LIGHT_CTRL_REG_H__
+
+#include <bluetooth/mesh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_light_ctrl_reg_coeff {
+	/** Upwards coefficient. */
+	float up;
+	/** Downwards coefficient. */
+	float down;
+};
+
+/** Light Lightness Control regulator configuration. */
+struct bt_mesh_light_ctrl_reg_cfg {
+	/** Regulator integral coefficient. */
+	struct bt_mesh_light_ctrl_reg_coeff ki;
+	/** Regulator proportional coefficient. */
+	struct bt_mesh_light_ctrl_reg_coeff kp;
+	/** Regulator dead zone (in percentage). */
+	float accuracy;
+};
+
+/** Common regulator context */
+struct bt_mesh_light_ctrl_reg {
+	/** Initialize the regulator. */
+	void (*init)(struct bt_mesh_light_ctrl_reg *reg);
+	/** Start the regulator. */
+	void (*start)(struct bt_mesh_light_ctrl_reg *reg);
+	/** Stop the regulator. */
+	void (*stop)(struct bt_mesh_light_ctrl_reg *reg);
+	/** Regulator configuration. */
+	struct bt_mesh_light_ctrl_reg_cfg cfg;
+	/** Measured value. */
+	float measured;
+	/** Regulator output update callback. */
+	void (*updated)(struct bt_mesh_light_ctrl_reg *reg, float output);
+	/** User data, available in update callback. */
+	void *user_data;
+/** @cond INTERNAL_HIDDEN */
+	float target;
+	float prev_target;
+	int32_t transition_time;
+	int64_t transition_start;
+/** @endcond */
+};
+
+/** @brief Set the target lightness for the regulator.
+ *
+ *  Sets the target lightness, also known as the setpoint, for the regulator.
+ *  Transition time is optional.
+ *
+ *  @param[in] reg      Lightness regulator instance.
+ *
+ *  @param[in] target   Target lightness (setpoint).
+ *
+ *  @param[in] transition_time  Transition time until the target lightness
+ *                              should reach the specified value. Pass 0
+ *                              to change immediately.
+ */
+void bt_mesh_light_ctrl_reg_target_set(struct bt_mesh_light_ctrl_reg *reg,
+				       float target,
+				       int32_t transition_time);
+
+/** @brief Get the target lightness for the regulator.
+ *
+ *  Returns the target lightness, taking the requested transition time into
+ *  account, for use in regulator implementations.
+ *
+ *  @param[in] reg      Lightness regulator instance.
+ *
+ *  @returns    The current target lightness, interpolated during transition
+ *              time.
+ */
+float bt_mesh_light_ctrl_reg_target_get(struct bt_mesh_light_ctrl_reg *reg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_LIGHT_CTRL_REG_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/light_ctrl_reg_spec.h
+++ b/include/bluetooth/mesh/light_ctrl_reg_spec.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ *  @defgroup bt_mesh_light_ctrl_reg_spec Light Lightness Control Spec Regulator
+ *  @ingroup bt_mesh_light_ctrl
+ *  @{
+ *  @brief Light Lightness Control spec regulator
+ */
+
+#ifndef BT_MESH_LIGHT_CTRL_REG_SPEC_H__
+#define BT_MESH_LIGHT_CTRL_REG_SPEC_H__
+
+#include <bluetooth/mesh/light_ctrl_reg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**  @def BT_MESH_LIGHT_CTRL_REG_SPEC_INIT
+ *
+ *   @brief Initialization macro for @ref bt_mesh_light_ctrl_reg_spec.
+ */
+#define BT_MESH_LIGHT_CTRL_REG_SPEC_INIT                                       \
+	{                                                                      \
+		.reg = {                                                       \
+			.init = bt_mesh_light_ctrl_reg_spec_init,              \
+			.start = bt_mesh_light_ctrl_reg_spec_start,            \
+			.stop = bt_mesh_light_ctrl_reg_spec_stop               \
+		}                                                              \
+	}
+
+/** Light Lightness Control spec regulator context. */
+struct bt_mesh_light_ctrl_reg_spec {
+	/** Common regulator context. */
+	struct bt_mesh_light_ctrl_reg reg;
+	/** Regulator step timer. */
+	struct k_work_delayable timer;
+	/** Internal integral sum. */
+	float i;
+	/** Regulator enabled flag. */
+	bool enabled;
+};
+
+/** @cond INTERNAL_HIDDEN */
+void bt_mesh_light_ctrl_reg_spec_init(struct bt_mesh_light_ctrl_reg *reg);
+void bt_mesh_light_ctrl_reg_spec_start(struct bt_mesh_light_ctrl_reg *reg);
+void bt_mesh_light_ctrl_reg_spec_stop(struct bt_mesh_light_ctrl_reg *reg);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_LIGHT_CTRL_REG_SPEC_H__ */
+
+/** @} */

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -36,6 +36,8 @@ zephyr_library_sources_ifdef(CONFIG_BT_MESH_LIGHTNESS_SRV lightness_srv.c)
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_LIGHTNESS_CLI lightness_cli.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_LIGHT_CTRL_SRV light_ctrl_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_LIGHT_CTRL_REG light_ctrl_reg.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC light_ctrl_reg_spec.c)
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_LIGHT_CTRL_CLI light_ctrl_cli.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_DK_PROV dk_prov.c)

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -277,6 +277,32 @@ endchoice
 endmenu
 endif
 
+menuconfig BT_MESH_LIGHT_CTRL_REG
+	bool "Lightness PI Regulator"
+	help
+	  Enable the lightness PI regulator module
+
+if BT_MESH_LIGHT_CTRL_REG
+
+config BT_MESH_LIGHT_CTRL_REG_SPEC
+	bool "Spec Lightness PI Regulator"
+	depends on FPU
+	default y
+	help
+	  Enable specification-defined lightness PI regulator implementation.
+
+if BT_MESH_LIGHT_CTRL_REG_SPEC
+
+config BT_MESH_LIGHT_CTRL_REG_SPEC_INTERVAL
+	int "Update interval"
+	default 100
+	range 10 100
+	help
+	  Update interval of the specification PI regulator (in milliseconds).
+
+endif #BT_MESH_LIGHT_CTRL_REG_SPEC
+endif #BT_MESH_LIGHT_CTRL_REG
+
 menuconfig BT_MESH_LIGHT_CTRL_SRV
 	bool "Light Lightness Control (LC) Server"
 	select BT_MESH_NRF_MODELS
@@ -290,21 +316,13 @@ if BT_MESH_LIGHT_CTRL_SRV
 
 menuconfig BT_MESH_LIGHT_CTRL_SRV_REG
 	bool "Lightness Regulator"
-	depends on FPU
+	select BT_MESH_LIGHT_CTRL_REG
 	default y
 	help
-	  Enable the Lightness PI Regulator for controlling the lightness level
+	  Enable the use of a PI regulator for controlling the lightness level
 	  through an illuminance sensor feedback loop.
 
 if BT_MESH_LIGHT_CTRL_SRV_REG
-
-config BT_MESH_LIGHT_CTRL_SRV_REG_INTERVAL
-	int "Update interval"
-	default 100
-	range 10 100
-	help
-	  Update interval of the Light LC Server model's internal PI regulator
-	  (in milliseconds).
 
 config BT_MESH_LIGHT_CTRL_SRV_REG_KIU
 	int "Default Kiu coefficient"

--- a/subsys/bluetooth/mesh/light_ctrl_reg.c
+++ b/subsys/bluetooth/mesh/light_ctrl_reg.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <bluetooth/mesh/light_ctrl_reg.h>
+
+void bt_mesh_light_ctrl_reg_target_set(struct bt_mesh_light_ctrl_reg *reg,
+				       float value,
+				       int32_t transition_time)
+{
+	reg->prev_target = reg->target;
+	reg->target = value;
+	if (reg->target == reg->prev_target) {
+		reg->transition_time = 0;
+		return;
+	}
+	reg->transition_start = k_uptime_get();
+	reg->transition_time = transition_time;
+}
+
+float bt_mesh_light_ctrl_reg_target_get(struct bt_mesh_light_ctrl_reg *reg)
+{
+	if (reg->transition_time == 0) {
+		return reg->target;
+	}
+
+	int32_t elapsed = k_uptime_get() - reg->transition_start;
+
+	if (elapsed >= reg->transition_time) {
+		reg->transition_time = 0;
+		return reg->target;
+	}
+	return reg->prev_target +
+		(elapsed * (reg->target - reg->prev_target)) / reg->transition_time;
+}

--- a/subsys/bluetooth/mesh/light_ctrl_reg_spec.c
+++ b/subsys/bluetooth/mesh/light_ctrl_reg_spec.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <bluetooth/mesh/light_ctrl_reg_spec.h>
+
+#define REG_INT CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC_INTERVAL
+
+static void reg_step(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_mesh_light_ctrl_reg_spec *spec_reg = CONTAINER_OF(
+		dwork, struct bt_mesh_light_ctrl_reg_spec, timer);
+
+	if (!spec_reg->enabled) {
+		/* The regulator might be disabled asynchronously. */
+		return;
+	}
+
+	k_work_reschedule(&spec_reg->timer, K_MSEC(REG_INT));
+
+	float target = bt_mesh_light_ctrl_reg_target_get(&spec_reg->reg);
+	float error = target - spec_reg->reg.measured;
+	/* Accuracy should be in percent and both up and down: */
+	float accuracy = (spec_reg->reg.cfg.accuracy * target) / (2 * 100.0f);
+	float input;
+
+	if (error > accuracy) {
+		input = error - accuracy;
+	} else if (error < -accuracy) {
+		input = error + accuracy;
+	} else {
+		input = 0.0f;
+	}
+
+	float kp, ki;
+
+	if (input >= 0) {
+		kp = spec_reg->reg.cfg.kp.up;
+		ki = spec_reg->reg.cfg.ki.up;
+	} else {
+		kp = spec_reg->reg.cfg.kp.down;
+		ki = spec_reg->reg.cfg.ki.down;
+	}
+
+	spec_reg->i += (input * ki) * ((float)REG_INT / (float)MSEC_PER_SEC);
+	spec_reg->i = CLAMP(spec_reg->i, 0, UINT16_MAX);
+
+	float p = input * kp;
+	float output = spec_reg->i + p;
+
+	spec_reg->reg.updated(&spec_reg->reg, output);
+}
+
+void bt_mesh_light_ctrl_reg_spec_start(struct bt_mesh_light_ctrl_reg *reg)
+{
+	struct bt_mesh_light_ctrl_reg_spec *spec_reg = CONTAINER_OF(
+		reg, struct bt_mesh_light_ctrl_reg_spec, reg);
+	spec_reg->enabled = true;
+	k_work_schedule(&spec_reg->timer, K_MSEC(REG_INT));
+}
+
+void bt_mesh_light_ctrl_reg_spec_stop(struct bt_mesh_light_ctrl_reg *reg)
+{
+	struct bt_mesh_light_ctrl_reg_spec *spec_reg = CONTAINER_OF(
+		reg, struct bt_mesh_light_ctrl_reg_spec, reg);
+	spec_reg->i = 0;
+	spec_reg->enabled = false;
+	k_work_cancel_delayable(&spec_reg->timer);
+}
+
+void bt_mesh_light_ctrl_reg_spec_init(struct bt_mesh_light_ctrl_reg *reg)
+{
+	struct bt_mesh_light_ctrl_reg_spec *spec_reg = CONTAINER_OF(
+		reg, struct bt_mesh_light_ctrl_reg_spec, reg);
+	k_work_init_delayable(&spec_reg->timer, reg_step);
+}

--- a/tests/subsys/bluetooth/mesh/light_ctrl/CMakeLists.txt
+++ b/tests/subsys/bluetooth/mesh/light_ctrl/CMakeLists.txt
@@ -14,6 +14,8 @@ target_sources(app
   PRIVATE
   ${app_sources}
   ${NRF_DIR}/subsys/bluetooth/mesh/light_ctrl_srv.c
+  ${NRF_DIR}/subsys/bluetooth/mesh/light_ctrl_reg.c
+  ${NRF_DIR}/subsys/bluetooth/mesh/light_ctrl_reg_spec.c
   ${NRF_DIR}/subsys/bluetooth/mesh/sensor_types.c
   ${NRF_DIR}/subsys/bluetooth/mesh/sensor.c
   ${ZEPHYR_BASE}/subsys/net/buf.c
@@ -45,7 +47,9 @@ target_compile_options(app
   -DCONFIG_BT_MESH_LIGHT_CTRL_SRV_LVL_ON=20000
   -DCONFIG_BT_MESH_LIGHT_CTRL_SRV_LVL_PROLONG=10000
   -DCONFIG_BT_MESH_LIGHT_CTRL_SRV_REG=1
-  -DCONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_INTERVAL=100
+  -DCONFIG_BT_MESH_LIGHT_CTRL_REG=1
+  -DCONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC=1
+  -DCONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC_INTERVAL=100
   -DCONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KIU=250
   -DCONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KID=25
   -DCONFIG_BT_MESH_LIGHT_CTRL_SRV_REG_KPU=80


### PR DESCRIPTION
This makes it possible to use an application-defined regulator instead
of using the spec-defined one. The config option
BT_MESH_LIGHT_CTRL_SRV_REG now controls compilation of the default
regulator, but all helper functions are compiled either way, to
facilitate creation of custom regulators.

Signed-off-by: Ludvig Samuelsen Jordet <ludvig.jordet@nordicsemi.no>