### PR TITLE
Fix docstring build

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Install packages
         run: |
+          sudo apt update
           sudo apt-get install -y ninja-build mscgen plantuml libclang1-9 libclang-cpp9
           wget -q https://www.doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
           tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz


### PR DESCRIPTION
Docbuild fails due to:
Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-lts/openjdk-11-jre-headless_11.0.11+9-0ubuntu2~20.04_amd64.deb  404  Not Found
Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>