### PR TITLE
samples: bluetooth: align BLE samples with new features

### DIFF
--- a/samples/bluetooth/alexa_gadget/src/main.c
+++ b/samples/bluetooth/alexa_gadget/src/main.c
@@ -98,7 +98,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed,
@@ -343,8 +343,6 @@ void main(void)
 	configure_gpio();
 
 	uint32_t buttons = dk_get_buttons();
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/samples/bluetooth/central_and_peripheral_hr/src/main.c
+++ b/samples/bluetooth/central_and_peripheral_hr/src/main.c
@@ -294,7 +294,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed
@@ -381,7 +381,6 @@ void main(void)
 		return;
 	}
 
-	bt_conn_cb_register(&conn_callbacks);
 	bt_conn_auth_cb_register(&auth_callbacks);
 
 	err = bt_enable(NULL);

--- a/samples/bluetooth/central_bas/src/main.c
+++ b/samples/bluetooth/central_bas/src/main.c
@@ -236,7 +236,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	gatt_discover(conn);
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed
@@ -379,7 +379,6 @@ void main(void)
 	}
 
 	scan_init();
-	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -258,7 +258,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	gatt_discover(conn);
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected        = connected,
 	.disconnected     = disconnected,
 	.security_changed = security_changed
@@ -639,8 +639,6 @@ void main(void)
 	printk("Starting Bluetooth Central HIDS example\n");
 
 	bt_hogp_init(&hogp, &hogp_init_params);
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {

--- a/samples/bluetooth/central_hr_coded/src/main.c
+++ b/samples/bluetooth/central_hr_coded/src/main.c
@@ -247,7 +247,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 };
@@ -263,8 +263,6 @@ void main(void)
 	}
 
 	printk("Bluetooth initialized\n");
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_hrs_client_init(&hrs_c);
 	if (err) {

--- a/samples/bluetooth/central_nfc_pairing/src/main.c
+++ b/samples/bluetooth/central_nfc_pairing/src/main.c
@@ -206,7 +206,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed
@@ -591,7 +591,6 @@ void main(void)
 		printk("Cannot init buttons (err %d\n", err);
 	}
 
-
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
@@ -605,7 +604,6 @@ void main(void)
 	}
 
 	scan_init();
-	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {

--- a/samples/bluetooth/central_smp_client/src/main.c
+++ b/samples/bluetooth/central_smp_client/src/main.c
@@ -204,7 +204,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed
@@ -389,7 +389,6 @@ void main(void)
 	printk("Bluetooth initialized\n");
 
 	scan_init();
-	bt_conn_cb_register(&conn_callbacks);
 
 	err = dk_buttons_init(button_handler);
 	if (err) {

--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -432,7 +432,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	gatt_discover(conn);
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed
@@ -568,8 +568,6 @@ void main(void)
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
 	}
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	int (*module_init[])(void) = {uart_init, scan_init, nus_client_init};
 	for (size_t i = 0; i < ARRAY_SIZE(module_init); i++) {

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -411,14 +411,15 @@ static void test_run(void)
 	}
 }
 
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+	.le_param_updated = le_param_updated,
+};
+
 void main(void)
 {
 	int err;
-	static struct bt_conn_cb conn_callbacks = {
-		.connected = connected,
-		.disconnected = disconnected,
-		.le_param_updated = le_param_updated,
-	};
 
 #if defined(CONFIG_USB_DEVICE_STACK)
 	const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
@@ -438,8 +439,6 @@ void main(void)
 	console_init();
 
 	printk("Starting Bluetooth LLPM example\n");
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/src/lb_service_handler.c
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/src/lb_service_handler.c
@@ -59,7 +59,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected (reason %u)\n", reason);
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 };
@@ -108,7 +108,6 @@ static void lbs_init(void)
 	};
 
 	dk_button_handler_add(&button_handler);
-	bt_conn_cb_register(&conn_callbacks);
 
 	int err = bt_lbs_init(&lbs_callbacs);
 

--- a/samples/bluetooth/peripheral_ancs_client/src/main.c
+++ b/samples/bluetooth/peripheral_ancs_client/src/main.c
@@ -361,7 +361,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed,
@@ -704,12 +704,6 @@ void main(void)
 
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
-	}
-
-	bt_conn_cb_register(&conn_callbacks);
-	if (err) {
-		printk("Failed to register connection callbacks\n");
-		return;
 	}
 
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);

--- a/samples/bluetooth/peripheral_bms/src/main.c
+++ b/samples/bluetooth/peripheral_bms/src/main.c
@@ -45,7 +45,7 @@ static const struct bt_data ad[] = {
 };
 
 static const struct bt_data sd[] = {
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL, 0x1e, 0x18),
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_BMS_VAL)),
 };
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -82,7 +82,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected        = connected,
 	.disconnected     = disconnected,
 	.security_changed = security_changed,
@@ -183,7 +183,6 @@ void main(void)
 		return;
 	}
 
-	bt_conn_cb_register(&conn_callbacks);
 	bt_conn_auth_cb_register(&conn_auth_callbacks);
 
 	err = bt_enable(NULL);

--- a/samples/bluetooth/peripheral_cts_client/src/main.c
+++ b/samples/bluetooth/peripheral_cts_client/src/main.c
@@ -37,7 +37,7 @@ static const struct bt_data ad[] = {
 		      (CONFIG_BT_DEVICE_APPEARANCE >> 0) & 0xff,
 		      (CONFIG_BT_DEVICE_APPEARANCE >> 8) & 0xff),
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_LIMITED | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_SOLICIT16, 0x05, 0x18),
+	BT_DATA_BYTES(BT_DATA_SOLICIT16, BT_UUID_16_ENCODE(BT_UUID_CTS_VAL)),
 	BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
 };
 
@@ -210,7 +210,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed,
@@ -327,12 +327,6 @@ void main(void)
 
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
-	}
-
-	bt_conn_cb_register(&conn_callbacks);
-	if (err) {
-		printk("Failed to register connection callbacks\n");
-		return;
 	}
 
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);

--- a/samples/bluetooth/peripheral_gatt_dm/src/main.c
+++ b/samples/bluetooth/peripheral_gatt_dm/src/main.c
@@ -115,7 +115,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected        = connected,
 	.disconnected     = disconnected,
 	.security_changed = security_changed,
@@ -226,12 +226,6 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("BLE init failed with error code %d\n", err);
-		return;
-	}
-
-	bt_conn_cb_register(&conn_callbacks);
-	if (err) {
-		printk("Failed to register connection callbacks.\n");
 		return;
 	}
 

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -120,10 +120,8 @@ static const struct bt_data ad[] = {
 		      (CONFIG_BT_DEVICE_APPEARANCE >> 0) & 0xff,
 		      (CONFIG_BT_DEVICE_APPEARANCE >> 8) & 0xff),
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL,
-		      0x12, 0x18,       /* HID Service */
-		      0x0f, 0x18),      /* Battery Service */
-
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_HIDS_VAL),
+					  BT_UUID_16_ENCODE(BT_UUID_BAS_VAL)),
 };
 
 static const struct bt_data sd[] = {
@@ -341,7 +339,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 }
 
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed,
@@ -939,7 +937,6 @@ void main(void)
 
 	configure_gpio();
 
-	bt_conn_cb_register(&conn_callbacks);
 	bt_conn_auth_cb_register(&conn_auth_callbacks);
 
 	err = bt_enable(NULL);

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -103,9 +103,8 @@ static const struct bt_data ad[] = {
 		      (CONFIG_BT_DEVICE_APPEARANCE >> 0) & 0xff,
 		      (CONFIG_BT_DEVICE_APPEARANCE >> 8) & 0xff),
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL,
-		      0x12, 0x18,       /* HID Service */
-		      0x0f, 0x18),      /* Battery Service */
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_HIDS_VAL),
+					  BT_UUID_16_ENCODE(BT_UUID_BAS_VAL)),
 };
 
 static const struct bt_data sd[] = {
@@ -333,7 +332,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 #endif
 
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 #ifdef CONFIG_BT_HIDS_SECURITY_ENABLED
@@ -755,8 +754,6 @@ void main(void)
 	int err;
 
 	printk("Starting Bluetooth Peripheral HIDS mouse example\n");
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	if (IS_ENABLED(CONFIG_BT_HIDS_SECURITY_ENABLED)) {
 		bt_conn_auth_cb_register(&conn_auth_callbacks);

--- a/samples/bluetooth/peripheral_hr_coded/src/main.c
+++ b/samples/bluetooth/peripheral_hr_coded/src/main.c
@@ -28,7 +28,9 @@ static struct bt_le_ext_adv *adv;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL, 0x0d, 0x18, 0x0f, 0x18, 0x0a, 0x18),
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_HRS_VAL),
+					  BT_UUID_16_ENCODE(BT_UUID_BAS_VAL),
+					  BT_UUID_16_ENCODE(BT_UUID_DIS_VAL)),
 };
 
 static void connected(struct bt_conn *conn, uint8_t conn_err)
@@ -64,7 +66,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	k_work_submit(&start_advertising_worker);
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 };
@@ -164,8 +166,6 @@ void main(void)
 	}
 
 	bt_ready();
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	/* Implement notification. At the moment there is no suitable way
 	 * of starting delayed work so we do it here

--- a/samples/bluetooth/peripheral_lbs/src/main.c
+++ b/samples/bluetooth/peripheral_lbs/src/main.c
@@ -85,7 +85,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 }
 #endif
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected        = connected,
 	.disconnected     = disconnected,
 #ifdef CONFIG_BT_LBS_SECURITY_ENABLED
@@ -196,7 +196,6 @@ void main(void)
 		return;
 	}
 
-	bt_conn_cb_register(&conn_callbacks);
 	if (IS_ENABLED(CONFIG_BT_LBS_SECURITY_ENABLED)) {
 		bt_conn_auth_cb_register(&conn_auth_callbacks);
 	}

--- a/samples/bluetooth/peripheral_nfc_pairing/src/main.c
+++ b/samples/bluetooth/peripheral_nfc_pairing/src/main.c
@@ -414,7 +414,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed,
@@ -723,7 +723,6 @@ void main(void)
 		printk("Cannot init buttons (err %d\n", err);
 	}
 
-	bt_conn_cb_register(&conn_callbacks);
 	bt_conn_auth_cb_register(&conn_auth_callbacks);
 
 	err = bt_enable(NULL);

--- a/samples/bluetooth/peripheral_rscs/src/main.c
+++ b/samples/bluetooth/peripheral_rscs/src/main.c
@@ -119,7 +119,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	dk_set_led_off(CON_STATUS_LED);
 }
 
-#ifdef CONFIG_BT_LBS_SECURITY_ENABLED
+#ifdef CONFIG_BT_RSCS_SECURITY_ENABLED
 static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -135,15 +135,15 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 }
 #endif
 
-static struct bt_conn_cb conn_callbacks = {
-	.connected    = connected,
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
 	.disconnected = disconnected,
-#ifdef CONFIG_BT_LBS_SECURITY_ENABLED
+#ifdef CONFIG_BT_RSCS_SECURITY_ENABLED
 	.security_changed = security_changed,
 #endif
 };
 
-#if defined(CONFIG_BT_LBS_SECURITY_ENABLED)
+#if defined(CONFIG_BT_RSCS_SECURITY_ENABLED)
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -209,7 +209,6 @@ void main(void)
 		return;
 	}
 
-	bt_conn_cb_register(&conn_callbacks);
 	if (IS_ENABLED(CONFIG_BT_RSCS_SECURITY_ENABLED)) {
 		bt_conn_auth_cb_register(&conn_auth_callbacks);
 	}

--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -374,7 +374,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 }
 #endif
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected    = connected,
 	.disconnected = disconnected,
 #ifdef CONFIG_BT_NUS_SECURITY_ENABLED
@@ -567,8 +567,6 @@ void main(void)
 	if (err) {
 		error();
 	}
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	if (IS_ENABLED(CONFIG_BT_NUS_SECURITY_ENABLED)) {
 		bt_conn_auth_cb_register(&conn_auth_callbacks);

--- a/samples/bluetooth/shell_bt_nus/src/main.c
+++ b/samples/bluetooth/shell_bt_nus/src/main.c
@@ -81,7 +81,7 @@ static void __attribute__((unused)) security_changed(struct bt_conn *conn,
 	}
 }
 
-static struct bt_conn_cb conn_callbacks = {
+BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected    = connected,
 	.disconnected = disconnected,
 	COND_CODE_1(CONFIG_BT_SMP,
@@ -121,7 +121,6 @@ void main(void)
 
 	printk("Starting Bluetooth NUS shell transport example\n");
 
-	bt_conn_cb_register(&conn_callbacks);
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
 		bt_conn_auth_cb_register(&conn_auth_callbacks);
 	}

--- a/samples/bluetooth/throughput/src/main.c
+++ b/samples/bluetooth/throughput/src/main.c
@@ -582,22 +582,20 @@ int test_run(const struct shell *shell,
 	return 0;
 }
 
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+	.le_param_req = le_param_req,
+	.le_param_updated = le_param_updated,
+	.le_phy_updated = le_phy_updated,
+	.le_data_len_updated = le_data_length_updated
+};
+
 void main(void)
 {
 	int err;
 
-	static struct bt_conn_cb conn_callbacks = {
-	    .connected = connected,
-	    .disconnected = disconnected,
-	    .le_param_req = le_param_req,
-	    .le_param_updated = le_param_updated,
-	    .le_phy_updated = le_phy_updated,
-	    .le_data_len_updated = le_data_length_updated
-	};
-
 	printk("Starting Bluetooth Throughput example\n");
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_enable(NULL);
 	if (err) {


### PR DESCRIPTION
The following macros were used in the samples.
- BT_UUID_16_ENCODE for encoding UUID in advertising data
- BT_CONN_CB_DEFINE for static connection callbacks

Ref: NCSDK-12960

Signed-off-by: Marcin Jeliński <marcin.jelinski@nordicsemi.no>