### PR TITLE
caf:  ble_adv: documentation update

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -868,6 +868,17 @@ NCSDK-10196: DFU fails for some configurations with the quick session resume fea
 
   **Workaround:** Use the quick session resume feature only for configurations with the cellular network backend.
 
+Common Application Framework (CAF)
+==================================
+
+.. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+
+NCSDK-13058: Directed advertising does not work
+  The directed advertising feature enabled with the :kconfig:`CONFIG_CAF_BLE_ADV_DIRECT_ADV` option does not work as intended.
+  Using directed advertising towards peers that enable privacy may result in connection establishing problems.
+
+  **Workaround** Manually cherry-pick and apply commit with fix from main (commit hash: ``c61c677872943bcf7905ddeec8b24b07ae50752e``).
+
 Subsystems
 **********
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -169,6 +169,7 @@ Common Application Framework (CAF)
     The array holding module reference objects is explicitly defined in linker script to avoid creating an orphan section.
     ``MODULE_ID`` macro and :c:func:`module_id_get` function now returns module reference from dedicated section instead of module name.
     The module name can not be obtained from reference object directly, a helper function (:c:func:`module_name_get`) should be used instead.
+  * Fixed the NCSDK-13058 known issue related to directed advertising in CAF.
 
 Bootloader libraries
 --------------------


### PR DESCRIPTION
This PR updates documentation, that has to be updated because of this PR: https://github.com/nrfconnect/sdk-nrf/pull/6503.
Fixes misspelling in word "CONFIG" in direct advertising.
This issue caused device to not work properly when direct advertising
option was turned on.

Jira: NCSDK-13058

Signed-off-by: Aleksander Strzebonski <aleksander.strzebonski@nordicsemi.no>