### PR TITLE
manifest: mcuboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -99,7 +99,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.7.99-ncs4
+      revision: 4e4e979c1998e6dad7e47011e6e076b861921645
       path: bootloader/mcuboot
     - name: nrfxlib
       repo-path: sdk-nrfxlib


### PR DESCRIPTION
Include mcuboot_config.h from sign_key.h to fix MCUBOOT_HW_KEY
compilation.

needed for NCSIDB-659

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>