### PR TITLE
doc impovement: clarify Thread Harness link

### DIFF
--- a/doc/nrf/ug_thread_certification.rst
+++ b/doc/nrf/ug_thread_certification.rst
@@ -54,6 +54,7 @@ Thread Test Harness integration
 To certify a Thread product, all certification test cases must be run on the Thread Test Harness software.
 
 A detailed description of how to assemble and configure a Thread Test Bed and run the Thread Test Harness can be found on the `Thread Group's Confluence wiki page`_.
+Access to this information is only available to members of the Thread Group, and access to the Thread Test Harness depends on the membership tier.
 
 .. note::
    The following procedure references the nRF52840 Development Kit.


### PR DESCRIPTION
Added a note to a link that access is limited to Thread Group
members.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>