### PR TITLE
samples:nrf_cloud_rest_fota: Remove use of at_cmd and at_notif library

### DIFF
--- a/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
@@ -6,8 +6,6 @@
 
 #include <zephyr.h>
 #include <modem/nrf_modem_lib.h>
-#include <modem/at_cmd.h>
-#include <modem/at_notif.h>
 #include <nrf_modem_at.h>
 #include <modem/modem_info.h>
 #include <dfu/mcuboot.h>
@@ -462,18 +460,6 @@ int init(void)
 	if (modem_lib_init_result) {
 		LOG_ERR("Failed to initialize modem library: 0x%X", modem_lib_init_result);
 		return -EFAULT;
-	}
-
-	err = at_cmd_init();
-	if (err) {
-		LOG_ERR("Failed to initialize AT commands, error: %d", err);
-		return err;
-	}
-
-	err = at_notif_init();
-	if (err) {
-		LOG_ERR("Failed to initialize AT notifications, error: %d", err);
-		return err;
 	}
 
 	err = fota_download_init(http_fota_dl_handler);


### PR DESCRIPTION
Remove use of at_cmd and at_notif libraries as they use the old AT
interface.