### PR TITLE
lib: date_time: refactor NTP server usage

### DIFF
--- a/doc/nrf/libraries/others/date_time.rst
+++ b/doc/nrf/libraries/others/date_time.rst
@@ -7,17 +7,34 @@ Date-Time
    :local:
    :depth: 2
 
-The date-time library maintains the current date-time information in UTC format and stores it as Zephyr time and modem time.
-The option :kconfig:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS` determines the frequency with which the library updates the date-time information.
+The date-time library retrieves the date-time information and stores it as Zephyr time and modem time.
 
-The information is fetched in the following prioritized order:
+
+Overview
+********
+
+Date-time information update can be triggered to this library by the following means:
+
+* Periodic date-time updates with the frequency determined by the option :kconfig:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS`.
+* By the client using the :c:func:`date_time_update_async` function.
+* External date-time source from which the date-time information is set to this library with the :c:func:`date_time_set` function.
+* Automatic update when connecting to LTE network if the option :kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE` is set.
+* Notification about date-time information coming from the modem through AT%XTIME notification.
+
+When this library retrieves the date-time information, it is fetched in the following prioritized order:
 
 1. The library checks if the current date-time information is valid and relatively new.
-   If the date-time information currently set in the library was obtained sometime during the interval set by CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS, the library does not fetch new date-time information.
+   If the date-time information currently set in the library was obtained sometime during the interval set by the :kconfig:`CONFIG_DATE_TIME_TOO_OLD_SECONDS` option, the library does not fetch new date-time information.
    In this way, unnecessary update cycles are avoided.
-#. If the aforementioned check fails, the library requests time from the onboard modem of nRF9160.
-#. If the time information obtained from the onboard modem of nRF9160 is not valid, the library requests time from NTP servers.
-#. If the NTP time request does not succeed, the library tries to request time information from several other NTP servers, before it fails.
+#. If the check fails and the :kconfig:`CONFIG_DATE_TIME_MODEM` option is set, the library requests time from the onboard modem of nRF9160.
+#. If the time information obtained from the onboard modem of nRF9160 is not valid and the :kconfig:`CONFIG_DATE_TIME_NTP` option is set, the library requests time from an NTP server.
+#. If the NTP time request does not succeed, the library tries to request time information from a different NTP server, before it fails.
+
+The current date-time information is stored as Zephyr time when it has been retrieved and hence, applications can also get the time using the POSIX function ``clock_gettime``.
+It is also stored as modem time if the modem does not have valid time.
+
+Implementation
+==============
 
 The :c:func:`date_time_set` function can be used to obtain the current date-time information from external sources independent of the internal date-time update routine.
 Time from GNSS can be such an external source.
@@ -26,10 +43,8 @@ The option :kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE` determines whether date-time 
 Libraries that require date-time information can just enable this library to get updated time information.
 Applications do not need to do anything to trigger time update when they start because this library handles it automatically.
 
-Current date-time information is stored as Zephyr time when it has been retrieved and hence applications can also get the time using the POSIX function ``clock_gettime``.
-It is also stored as modem time if the modem does not have valid time.
-
-To get date-time information from the library, either call the :c:func:`date_time_uptime_to_unix_time_ms` function or the :c:func:`date_time_now` function.
+Retrieving date-time information using the POSIX function ``clock_gettime`` is encouraged when feasible.
+You can obtain the information also from the library by calling either the :c:func:`date_time_uptime_to_unix_time_ms` function or the :c:func:`date_time_now` function.
 See the API documentation for more information on these functions.
 
 .. note::
@@ -41,14 +56,46 @@ See the API documentation for more information on these functions.
 Configuration
 *************
 
-:kconfig:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS`
+Configure the following Kconfig options to enable this library and its main functionalities:
 
-   Configure this option to control the frequency with which the library fetches the time information.
+* :kconfig:`CONFIG_DATE_TIME` - Enables this library.
+* :kconfig:`CONFIG_DATE_TIME_MODEM` - Enables use of modem time.
+* :kconfig:`CONFIG_DATE_TIME_NTP` - Enables use of NTP (Network Time Protocol) time.
+* :kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE` - Trigger date-time update automatically when LTE is connected.
 
-:kconfig:`CONFIG_DATE_TIME_AUTO_UPDATE`
+Configure the following options to fine-tune the behavior of the library:
 
-CONFIG_DATE_TIME_AUTO_UPDATE - Trigger date-time update when LTE is connected
-   Configure this option to determine whether date-time update is triggered automatically when the device has connected to LTE.
+* :kconfig:`CONFIG_DATE_TIME_UPDATE_INTERVAL_SECONDS` - Control the frequency with which the library fetches the time information.
+* :kconfig:`CONFIG_DATE_TIME_TOO_OLD_SECONDS` - Control the time when date-time update is applied if previous update was done earlier.
+* :kconfig:`CONFIG_DATE_TIME_NTP_QUERY_TIME_SECONDS` - Timeout for a single NTP query.
+* :kconfig:`CONFIG_DATE_TIME_THREAD_STACK_SIZE` - Configure the stack size of the date-time update thread.
+
+Samples using the library
+*************************
+
+The following |NCS| samples and applications use this library:
+
+* :ref:`asset_tracker_v2`
+* :ref:`serial_lte_modem`
+* :ref:`location_sample`
+* :ref:`gnss_sample`
+* :ref:`modem_shell_application`
+* :ref:`aws_iot`
+* :ref:`lwm2m_client`
+
+Limitations
+***********
+
+The date-time library can only have one application registered at a time.
+If there is already an application handler registered, another registration will override the existing handler.
+Also, using the :c:func:`date_time_update_async` function will override the existing handler.
+
+Dependencies
+************
+
+* :ref:`nrf_modem_lib_readme`
+* :ref:`lte_lc_readme`
+* :ref:`sntp_interface`
 
 API documentation
 *****************

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -171,6 +171,11 @@ Other libraries
 
 * Moved :ref:`lib_bootloader` to a section of their own.
 
+* :ref:`lib_date_time` library:
+
+  * Removed the :kconfig:`CONFIG_DATE_TIME_IPV6` Kconfig option.
+    The library now automatically uses IPv6 for NTP when available.
+
 Modem library
 +++++++++++++
 

--- a/lib/date_time/Kconfig
+++ b/lib/date_time/Kconfig
@@ -51,9 +51,6 @@ config DATE_TIME_NTP_QUERY_TIME_SECONDS
 	int "Duration in which the library will query for NTP time, in seconds"
 	default 5
 
-config DATE_TIME_IPV6
-	bool "Use IPv6"
-
 module=DATE_TIME
 module-dep=LOG
 module-str=Date time module

--- a/lib/date_time/date_time_core.c
+++ b/lib/date_time/date_time_core.c
@@ -101,6 +101,7 @@ static void date_time_update_thread(void)
 #endif
 		LOG_DBG("Did not get time from any time source");
 
+		date_time_core_schedule_update();
 		date_time_core_notify_event(DATE_TIME_NOT_OBTAINED);
 	}
 }

--- a/lib/date_time/date_time_ntp.c
+++ b/lib/date_time/date_time_ntp.c
@@ -15,69 +15,36 @@
 
 LOG_MODULE_DECLARE(date_time, CONFIG_DATE_TIME_LOG_LEVEL);
 
-#define UIO_IP      "ntp.uio.no"
-#define GOOGLE_IP_1 "time1.google.com"
-#define GOOGLE_IP_2 "time2.google.com"
-#define GOOGLE_IP_3 "time3.google.com"
-#define GOOGLE_IP_4 "time4.google.com"
+#define UIO_NTP    "ntp.uio.no"
+#define GOOGLE_NTP "time.google.com"
 
-#define NTP_PORT "123"
+#define NTP_PORT 123
 
-struct ntp_servers {
-	const char *server_str;
-	struct sockaddr addr;
-	socklen_t addrlen;
-};
-
-struct ntp_servers servers[] = {
-	{.server_str = UIO_IP},
-	{.server_str = GOOGLE_IP_1},
-	{.server_str = GOOGLE_IP_2},
-	{.server_str = GOOGLE_IP_3},
-	{.server_str = GOOGLE_IP_4}
+static const char * const servers[] = {
+	UIO_NTP,
+	GOOGLE_NTP
 };
 
 static struct sntp_time sntp_time;
 
-static int sntp_time_request(struct ntp_servers *server, uint32_t timeout,
-			     struct sntp_time *time)
+static int sntp_time_request(const char *server, uint32_t timeout, struct sntp_time *time)
 {
 	int err;
-	static struct addrinfo hints;
 	struct addrinfo *addrinfo;
 	struct sntp_ctx sntp_ctx;
 
-	if (server->addrlen == 0) {
-		if (IS_ENABLED(CONFIG_DATE_TIME_IPV6)) {
-			hints.ai_family = AF_INET6;
-		} else {
-			hints.ai_family = AF_INET;
-		}
-		hints.ai_socktype = SOCK_DGRAM;
-		hints.ai_protocol = 0;
+	struct addrinfo hints = {
+		.ai_flags = AI_NUMERICSERV,
+		.ai_family = AF_UNSPEC /* Allow both IPv4 and IPv6 addresses */
+	};
 
-		err = getaddrinfo(server->server_str, NTP_PORT, &hints,
-				  &addrinfo);
-		if (err) {
-			LOG_WRN("getaddrinfo, error: %d", err);
-			return err;
-		}
-
-		if (addrinfo->ai_addrlen > sizeof(server->addr)) {
-			LOG_WRN("getaddrinfo, addrlen: %d > %d",
-				addrinfo->ai_addrlen, sizeof(server->addr));
-			freeaddrinfo(addrinfo);
-			return -ENOMEM;
-		}
-
-		memcpy(&server->addr, addrinfo->ai_addr, addrinfo->ai_addrlen);
-		server->addrlen = addrinfo->ai_addrlen;
-		freeaddrinfo(addrinfo);
-	} else {
-		LOG_DBG("Server address already obtained, skipping DNS lookup");
+	err = getaddrinfo(server, STRINGIFY(NTP_PORT), &hints, &addrinfo);
+	if (err) {
+		LOG_WRN("getaddrinfo, error: %d", err);
+		return err;
 	}
 
-	err = sntp_init(&sntp_ctx, &server->addr, server->addrlen);
+	err = sntp_init(&sntp_ctx, addrinfo->ai_addr, addrinfo->ai_addrlen);
 	if (err) {
 		LOG_WRN("sntp_init, error: %d", err);
 		goto socket_close;
@@ -89,7 +56,10 @@ static int sntp_time_request(struct ntp_servers *server, uint32_t timeout,
 	}
 
 socket_close:
+	freeaddrinfo(addrinfo);
+
 	sntp_close(&sntp_ctx);
+
 	return err;
 }
 
@@ -129,17 +99,14 @@ int date_time_ntp_get(int64_t *date_time_ms)
 #endif
 
 	for (int i = 0; i < ARRAY_SIZE(servers); i++) {
-		err =  sntp_time_request(&servers[i],
+		err =  sntp_time_request(servers[i],
 			MSEC_PER_SEC * CONFIG_DATE_TIME_NTP_QUERY_TIME_SECONDS,
 			&sntp_time);
 		if (err) {
-			LOG_DBG("Did not get time from NTP server %s, error %d",
-				log_strdup(servers[i].server_str), err);
-			LOG_DBG("Trying another address...");
+			LOG_DBG("Did not get time from NTP server %s, error %d", servers[i], err);
 			continue;
 		}
-		LOG_DBG("Time obtained from NTP server %s",
-			log_strdup(servers[i].server_str));
+		LOG_DBG("Time obtained from NTP server %s", servers[i]);
 		*date_time_ms = (int64_t)sntp_time.seconds * 1000;
 		return 0;
 	}


### PR DESCRIPTION
Refactored NTP server selection logic. Instead of doing a DNS query only once and using the same IP address for all furure connections, address resolution is done every time to take advantage of server load balancing. The change also saves some flash and SRAM, because the implementation is simpler and no space needs to be reserved for storing the IP address for each server.

Removed the CONFIG_DATE_TIME_IPV6 Kconfig option. The library now automatically uses IPv6 for NTP when available.