### PR TITLE
doc: peripheral_hids_keyboard,mouse encryption notice

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/hids.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/hids.rst
@@ -22,6 +22,11 @@ The HIDS module must be notified about the incoming connect and
 disconnect events using the dedicated API. This is done to synchronize
 the connection state of HIDS with the top module that uses it.
 
+.. note::
+
+   Some systems require security to use the HID service.
+   To ensure interoperability, enable the :kconfig:`CONFIG_BT_HIDS_DEFAULT_PERM_RW_ENCRYPT` option.
+
 The HID Service is used in the following samples:
 
  * :ref:`peripheral_hids_mouse`

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -92,7 +92,10 @@ Bluetooth samples
 * Updated:
 
   * :ref:`peripheral_rscs` - Corrected the number of bytes for setting the Total Distance Value and specified the data units.
-  * :ref`direct_test_mode` - Added support for front-end module devices that support 2-pin PA/LNA interface with additional support for the Skyworks SKY66114-11 and the Skyworks SKY66403-11.
+  * :ref:`direct_test_mode` - Added support for front-end module devices that support 2-pin PA/LNA interface with additional support for the Skyworks SKY66114-11 and the Skyworks SKY66403-11.
+  * :ref:`peripheral_hids_mouse` - Added a notice about encryption requirement.
+  * :ref:`peripheral_hids_keyboard` - Added a notice about encryption requirement.
+
 
 nRF9160 samples
 ---------------

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -80,6 +80,15 @@ Button 4:
 LED 4:
    Indicates if an NFC field is present.
 
+Configuration
+*************
+
+|config|
+
+Setup
+=====
+
+The HID service specification does not require encryption (:kconfig:`CONFIG_BT_HIDS_DEFAULT_PERM_RW_ENCRYPT`), but some systems disconnect from the HID devices that do not support security.
 
 Building and running
 ********************

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -56,7 +56,15 @@ Button 3:
 Button 4:
    Simulate moving the mouse pointer 5 pixels downward.
 
+Configuration
+*************
 
+|config|
+
+Setup
+=====
+
+The HID service specification does not require encryption (:kconfig:`CONFIG_BT_HIDS_DEFAULT_PERM_RW_ENCRYPT`), but some systems disconnect from the HID devices that do not support security.
 
 Building and running
 ********************


### PR DESCRIPTION
Added info about encryption config in:
-peripheral_hids_mouse
-peripheral_hids_keyboard
samples.

NCSDK-11784

Signed-off-by: Dominik Chat <dominik.chat@nordicsemi.no>