### PR TITLE
manifest: Integrate TF-M secure read service in flash driver

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d4b3ba831af022dbf1729db869306b262534b79e
+      revision: 9cad422b7e3765f77ce1e4e82b2fda3f32e4c794
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Adds the secure read service to the soc flash driver. So that it can be
used if the non-secure application is trying to access memory configured
to be secure but readable from non-secure.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>