### PR TITLE
Bugfix/slm httpc

### DIFF
--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -128,17 +128,18 @@ static void response_cb(struct http_response *rsp,
 static int headers_cb(int sock, struct http_request *req, void *user_data)
 {
 	size_t len;
-	int ret = 0;
+	int ret = 0, offset = 0;
 
 	len = strlen(httpc.headers);
 	while (len > 0) {
-		ret = send(sock, httpc.headers + ret, len, 0);
+		ret = send(sock, httpc.headers + offset, len, 0);
 		if (ret < 0) {
 			LOG_ERR("send header fail: %d", ret);
 			return ret;
 		}
 		LOG_DBG("send header: %d bytes", ret);
 		len -= ret;
+		offset += ret;
 	}
 
 	return len;
@@ -198,16 +199,6 @@ int httpc_datamode_callback(uint8_t op, const uint8_t *data, int len)
 	}
 	if (op == DATAMODE_SEND) {
 		ret = do_send_payload(data, len);
-		LOG_INF("datamode send: %d", ret);
-		if (ret == 0) {
-			/* Payload sent successfully */
-			sprintf(rsp_buf, "\r\nOK\r\n");
-			rsp_send(rsp_buf, strlen(rsp_buf));
-		} else {
-			/* Payload sent fail */
-			sprintf(rsp_buf, "\r\nERROR\r\n");
-			rsp_send(rsp_buf, strlen(rsp_buf));
-		}
 	} else if (op == DATAMODE_EXIT) {
 		k_sem_give(&http_req_sem);
 	}


### PR DESCRIPTION
This PR contains 2 fixes related to SLM HTTPC:

1. Fix incorrect HTTP header sending:
https://devzone.nordicsemi.com/support/280323
https://projecttools.nordicsemi.no/jira/browse/NRF91-1313

2. Fix URC in datamode  to align datamode behavior with other module

Signed-off-by: Larry Tsai <larry.tsai@nordicsemi.no>