### PR TITLE
kconfig: hw_cc3c310: Don't enable driver by default

### DIFF
--- a/drivers/hw_cc310/Kconfig
+++ b/drivers/hw_cc310/Kconfig
@@ -24,7 +24,6 @@ config HW_CC3XX
 	depends on HAS_HW_NRF_CC310 || HAS_HW_NRF_CC312
 	depends on !TRUSTED_EXECUTION_NONSECURE
 	select NRF_CC3XX_PLATFORM
-	default y
 	help
 	  This option enables the Arm CC3xx hw devices in nRF52840, nRF53, and nRF9160 devices.
 


### PR DESCRIPTION
Drivers, subsystems, and in general, most features, should be disabled
by default and then enabled when needed.

Stop enabling the cryptocell driver by default.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>