### PR TITLE
CI-lib PRD changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,10 @@
 /README.rst                               @carlescufi
 /Jenkinsfile                              @thst-nordic
 /west.yml                                 @carlescufi @tejlmand
+/west-test.yml                            @thst-nordic
+
+# CI specific west
+/test-manifests/99-default-test-nrf.yml     @thst-nordic
 
 # Github Actions
 /.github/                                 @thst-nordic
@@ -35,6 +39,8 @@
 # All cmake related files
 /cmake/                                   @tejlmand
 /CMakeLists.txt                           @tejlmand
+# CI labeler
+/ci/labeler.yaml                      @thst-nordic @guwa @mariusz-nordicsemi @tomaszkob89 @totyz @doublemis1 @wiminordic @jorgenmk @maciekrozanski @ns-tolu @miha-nordic @maciejpietras @piwe-nordic @nordic-babu @fredaas @torsteingrindvik @mswarowsky @shantha-14 @ardo-nordic
 # All Kconfig related files
 Kconfig*                                  @tejlmand
 # All doc related files

--- a/ci/labeler.yaml
+++ b/ci/labeler.yaml
@@ -1,0 +1,233 @@
+# This is the Jenkins ci variant of the .github/labler.yaml
+# Instead of folder based glob strings, this one uses regex strings
+# to compare against the files changes list from the PR
+
+manifest:
+  - 'west.yml'
+
+doc-required:
+  - 'doc/.*/?.*'
+  - '.*/?.*\.rst'
+
+CI-libmodem-test:
+  - 'samples/nrf9160/.*/?.*'
+  - 'lib/lte_link_control/.*/?.*'
+  - 'lib/nrf_modem_lib/.*'
+
+CI-lwm2m-test:
+  - 'samples/nrf9160/lwm2m_.*/?.*'
+  - 'lib/bin/.*'
+  - 'lib/lte_link_control/.*/?.*'
+  - 'lib/nrf_modem_lib/.*'
+
+CI-boot-dfu-test:
+  - 'include/bl.*'
+  - 'include/fprotect.h'
+  - 'include/fw_info\..*'
+  - 'include/mgmt/.*'
+  - 'include/spm.h'
+  - 'include/dfu/.*/?.*'
+  - 'include/net/.*/?.*'
+  - 'cmake/.*'
+  - 'lib/lte_link_control/.*/?.*'
+  - 'modules/mcuboot/.*/?.*'
+  - 'samples/nrf9160/.*fota/.*/?.*'
+  - 'samples/nrf9160/fmfu_smp_svr/.*/?.*'
+  - 'samples/nrf9160/http_update/.*/?.*'
+  - 'samples/nrf5340/netboot/.*'
+  - 'samples/bootloader/.*/?.*'
+  - 'scripts/bootloader/.*/?.*'
+  - 'subsys/bootloader/.*/?.*'
+  - 'subsys/nonsecure/.*'
+  - 'subsys/partition_manager/.*'
+  - 'subsys/dfu/.*'
+  - 'subsys/fw_info/.*/?.*'
+  - 'subsys/mgmt/.*/?.*'
+  - 'subsys/pcd/.*'
+  - 'subsys/spm/.*'
+  - 'subsys/net/lib/.*fota*/.*/?.*'
+  - 'subsys/net/lib/download_client/.*/?.*'
+  - 'tests/subsys/bootloader/.*/?.*'
+  - 'tests/subsys/dfu/.*/?.*'
+  - 'tests/subsys/fw_info/.*/?.*'
+  - 'tests/subsys/net/.*/?.*'
+
+CI-all-test:
+  - '.*/?.*partition_manager*/.*/?.*'
+  - '.*/?.*partition_manager*'
+
+CI-tfm-test:
+  - 'cmake/.*'
+  - 'modules/nrfxlib/.*/?.*'
+  - 'modules/tfm/.*/?.*'
+  - 'samples/tfm/.*/?.*'
+  - 'subsys/bootloader/.*/?.*'
+  - 'subsys/partition_manager/.*/?.*'
+  - 'tests/modules/tfm'
+  - 'tests/subsys/spm/secure_services/.*/?.*'
+
+CI-ble-test:
+  - any:
+    - 'subsys/bluetooth/.*/?.*'
+    - '!subsys/bluetooth/mesh/?.*'
+  - any:
+    - 'include/bluetooth/.*/?.*'
+    - '!include/bluetooth/mash/?.*'
+  - any:
+    - 'samples/bluetooth/.*/?.*'
+    - '!samples/bluetooth/mesh/?.*'
+  - 'subsys/nrf_rpc/.*/?.*'
+  - 'subsys/mpsl/.*/?.*'
+  - 'drivers/mpsl/.*/?.*'
+
+CI-mesh-test:
+  - 'subsys/bluetooth/mesh/.*/?.*'
+  - 'include/bluetooth/mesh/.*/?.*'
+  - 'tests/subsys/bluetooth/mesh/.*/?.*'
+
+CI-zigbee-test:
+  - 'include/zigbee/.*/?.*'
+  - 'samples/zigbee/.*/?.*'
+  - 'subsys/dfu/.*/?.*'
+  - 'subsys/zigbee/.*/?.*'
+  - 'tests/subsys/zigbee/.*/?.*'
+  - 'subsys/mpsl/.*/?.*'
+  - 'subsys/ieee802154/.*/?.*'
+  - 'drivers/mpsl/.*/?.*'
+  - 'dts/bindings/radio_fem/.*/?.*'
+  - 'samples/nrf5340/multiprotocol_rpmsg/.*/?.*'
+  - 'modules/nrfxlib/nrf_802154/.*/?.*'
+  - any:
+    - 'subsys/bluetooth/.*/?.*'
+    - '!subsys/bluetooth/mesh/?.*'
+  - any:
+    - 'include/bluetooth/.*/?.*'
+    - '!include/bluetooth/mesh/?.*'
+
+CI-thingy91-test:
+  - 'applications/asset_tracker/.*/?.*'
+  - 'ext/cjson/.*/?.*'
+  - 'drivers/gps/gps_sim/.*/?.*'
+  - 'subsys/net/lib/nrf_cloud/.*/?.*'
+  - 'subsys/net/lib/cloud/.*/?.*'
+  - 'lib/date_time/.*/?.*'
+  - 'drivers/sensor/sensor_sim/.*/?.*'
+  - 'samples/nrf9160/udp/.*/?.*'
+
+CI-desktop-test:
+  - 'applications/nrf_desktop/.*/?.*'
+  - 'boards/arm/.*dmouse*/.*/?.*'
+  - 'boards/arm/.*kbd*/.*/?.*'
+  - 'boards/arm/.*dongle*/.*/?.*'
+  - 'boards/arm/.*gmouse*/.*/?.*'
+  - 'cmake/.*'
+  - 'drivers/sensor/pmw3360/.*/?.*'
+  - 'drivers/sensor/paw3212/.*/?.*'
+  - 'dts/bindings/sensor/pixart*'
+  - 'include/bluetooth/services/.*/?.*'
+  - 'include/bluetooth/.*'
+  - 'include/caf/.*/?.*'
+  - 'include/sensor/.*'
+  - 'include/event_manager.h'
+  - 'include/profiler.h'
+  - 'scripts/hid_configurator/.*/?.*'
+  - 'subsys/bluetooth/services/.*/?.*'
+  - 'subsys/bluetooth/.*'
+  - 'subsys/caf/.*/?.*'
+  - 'subsys/event_manager/.*/?.*'
+  - 'subsys/partition_manager/.*/?.*'
+
+CI-crypto-test:
+  - 'cmake/.*'
+  - 'drivers/entropy/.*'
+  - 'drivers/hw_cc310/.*'
+  - 'drivers/net/.*'
+  - 'samples/crypto/.*/?.*'
+  - 'subsys/partition_manager/.*/?.*'
+  - 'tests/crypto/.*/?.*'
+
+CI-rs-test:
+  - 'subsys/mpsl/.*/?.*'
+  - 'subsys/ieee802154/.*/?.*'
+  - 'drivers/mpsl/.*/?.*'
+  - 'dts/bindings/radio_fem/.*/?.*'
+  - 'samples/nrf5340/multiprotocol_rpmsg/.*/?.*'
+  - 'modules/nrfxlib/nrf_802154/.*/?.*'
+  - 'samples/CMakeLists.txt'
+
+CI-homekit-test:
+  - 'subsys/mpsl/.*/?.*'
+  - 'subsys/ieee802154/.*/?.*'
+  - 'drivers/mpsl/.*/?.*'
+  - 'dts/bindings/radio_fem/.*/?.*'
+  - 'modules/nrfxlib/nrf_802154/.*/?.*'
+  - 'drivers/hw_cc310/.*'
+  - 'subsys/bootloader/.*/?.*'
+  - 'subsys/partition_manager/.*/?.*'
+  - 'modules/mcuboot/.*/?.*'
+  - any:
+    - 'subsys/bluetooth/.*/?.*'
+    - '!subsys/bluetooth/mesh/?.*'
+  - any:
+    - 'include/bluetooth/.*/?.*'
+    - '!include/bluetooth/mesh/?.*'
+
+CI-thread-test:
+  - 'samples/openthread/.*/?.*'
+  - 'subsys/mpsl/.*/?.*'
+  - 'subsys/ieee802154/.*/?.*'
+  - 'subsys/net/lib/coap_utils/.*/?.*'
+  - 'subsys/net/openthread/.*/?.*'
+  - 'drivers/mpsl/.*/?.*'
+  - 'drivers/hw_cc310/.*'
+  - 'modules/nrfxlib/nrf_802154/.*/?.*'
+
+CI-nfc-test:
+  - 'subsys/nfc/.*/?.*'
+  - 'include/nfc/.*/?.*'
+  - 'lib/st25r3911b/.*/?.*'
+  - 'samples/nfc/.*/?.*'
+  - 'samples/bluetooth/peripheral_nfc_pairing/.*/?.*'
+  - 'samples/bluetooth/central_nfc_pairing/.*/?.*'
+  - 'samples/bluetooth/peripheral_hids_keyboard/.*/?.*'
+
+CI-matter-test:
+  - 'drivers/mpsl/.*/?.*'
+  - 'drivers/hw_cc310/.*'
+  - 'drivers/net/.*'
+  - 'subsys/mpsl/.*/?.*'
+  - 'subsys/ieee802154/.*/?.*'
+  - 'subsys/bootloader/.*/?.*'
+  - 'subsys/partition_manager/.*/?.*'
+  - 'subsys/nfc/.*/?.*'
+  - 'subsys/nrf_rpc/.*/?.*'
+  - 'subsys/net/.*/?.*'
+  - 'modules/tfm/.*/?.*'
+  - 'modules/nrfxlib/nrf_802154/.*/?.*'
+  - 'modules/mcuboot/.*/?.*'
+  - 'samples/matter/.*/?.*'
+  - 'applications/matter_weather_station/.*/?.*'
+  - 'samples/nrf5340/multiprotocol_rpmsg/.*/?.*'
+
+CI-find-my-test:
+  - 'include/dfu/.*/?.*'
+  - 'include/nfc/.*/?.*'
+  - 'include/dk_buttons_and_leds.h'
+  - 'include/event_manager.h'
+  - 'lib/dk_buttons_and_leds/.*/?.*'
+  - 'subsys/bootloader/.*/?.*'
+  - 'subsys/dfu/dfu_target/.*/?.*'
+  - 'subsys/event_manager/.*/?.*'
+  - 'subsys/nfc/.*/?.*'
+  - 'subsys/partition_manager/.*/?.*'
+  - 'modules/mcuboot/.*/?.*'
+  - any:
+    - 'include/bluetooth/.*/?.*'
+    - '!include/bluetooth/mesh/?.*'
+  - any:
+    - 'subsys/bluetooth/.*/?.*'
+    - '!subsys/bluetooth/mesh/?.*'
+
+CI-rpc-test:
+  - 'subsys/nrf_rpc/.*/?.*'
+  - 'samples/nrf_rpc/.*/?.*'

--- a/test-manifests/99-default-test-nrf.yml
+++ b/test-manifests/99-default-test-nrf.yml
@@ -1,0 +1,18 @@
+manifest:
+
+  version: "0.12"
+  remotes:
+    - name: ncs-test
+      url-base: https://projecttools.nordicsemi.no/bitbucket/scm/NCS-TEST
+
+
+  projects:
+    # NRF test repositories
+    - name: test_nrf
+      remote: ncs-test
+      repo-path: test-fw-nrfconnect-nrf
+      revision: master
+      import:
+        name-blocklist: [sdk-nrf]
+      userdata:
+        run_downstream: always

--- a/west-test.yml
+++ b/west-test.yml
@@ -1,0 +1,8 @@
+manifest:
+  version: "0.12"
+
+  self:
+    west-commands: scripts/west-commands.yml
+    import:
+      - test-manifests
+      - west.yml

--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@
 # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/west/index.html
 
 manifest:
-  version: "0.10"
+  version: "0.12"
 
   # "remotes" is a list of locations where git repositories are cloned
   # and fetched from.


### PR DESCRIPTION
These changes are required to enable the upcoming PRD changes in the CI-LIB and will enable the following features.

* The downstream job for sdk-nrf will now be selected via west.
* The west-test.yml is only meant to be used by the ci / jenkins.
* ci/labeler.yaml is the replacement for the .github/labeler.yaml.

On it's own the changes will have no impact on the CI

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>