### PR TITLE
applications: asset_tracker: Fix regression in ui_module_event

### DIFF
--- a/applications/asset_tracker_v2/src/events/ui_module_event.h
+++ b/applications/asset_tracker_v2/src/events/ui_module_event.h
@@ -27,15 +27,15 @@ enum ui_module_event_type {
 	 */
 	UI_EVT_BUTTON_DATA_READY,
 
-	/** The sensor module has performed all procedures to prepare for
+	/** The UI module has performed all procedures to prepare for
 	 *  a shutdown of the system. The event carries the ID (id) of the module.
 	 */
-	SENSOR_EVT_SHUTDOWN_READY,
+	UI_EVT_SHUTDOWN_READY,
 
 	/** An irrecoverable error has occurred in the cloud module. Error details are
 	 *  attached in the event structure.
 	 */
-	SENSOR_EVT_ERROR
+	UI_EVT_ERROR
 };
 
 /** @brief Structure used to provide button data. */


### PR DESCRIPTION
Two events were recently accidentally renamed to use the SENSOR prefix
which caused a multiple definition error.

Revert this change.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>