### PR TITLE
debug: cpu_load: Fix warning

### DIFF
--- a/subsys/debug/cpu_load/cpu_load.c
+++ b/subsys/debug/cpu_load/cpu_load.c
@@ -273,7 +273,7 @@ static int cmd_cpu_load_reset(const struct shell *shell,
 
 	err = cpu_load_init();
 	if (err != 0) {
-		shell_error(shell, "Init failed (err:%d)");
+		shell_error(shell, "Init failed (err:%d)", err);
 		return 0;
 	}
 


### PR DESCRIPTION
Fix warning. format was missing err argument.

It is unclear how this was able to go through CI before.

/home/sebo/ncs/nrf/subsys/debug/cpu_load/cpu_load.c:276:22: warning:
format '%d' expects a matching 'int' argument [-Wformat=]

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>