### PR TITLE
samples: nrf9160: fmfu_smp_svr: Remove use of deprecated at_cmd library 

### DIFF
--- a/samples/nrf9160/fmfu_smp_svr/src/main.c
+++ b/samples/nrf9160/fmfu_smp_svr/src/main.c
@@ -9,7 +9,6 @@
 #include <mgmt/fmfu_mgmt_stat.h>
 #include <modem/modem_info.h>
 #include <modem/nrf_modem_lib.h>
-#include <modem/at_cmd.h>
 #include "os_mgmt/os_mgmt.h"
 #include "img_mgmt/img_mgmt.h"
 #include <dfu/mcuboot.h>
@@ -21,22 +20,16 @@ void main(void)
 	if (err == 0) {
 		char modem_version[MODEM_INFO_MAX_RESPONSE_SIZE];
 
-		err = at_cmd_init();
+		err = modem_info_init();
 		if (err != 0) {
-			printk("AT CMD Init error: %d\n\r", err);
+			printk("Modem info Init error: %d\n\r", err);
 		} else {
-			err = modem_info_init();
-			if (err != 0) {
-				printk("Modem info Init error: %d\n\r", err);
-			} else {
-				modem_info_string_get(MODEM_INFO_FW_VERSION,
-						modem_version,
-						MODEM_INFO_MAX_RESPONSE_SIZE);
-				printk("Starting modem mgmt sample\n\r");
-				printk("Modem version: %s\n\r", modem_version);
-			}
+			modem_info_string_get(MODEM_INFO_FW_VERSION,
+					modem_version,
+					MODEM_INFO_MAX_RESPONSE_SIZE);
+			printk("Starting modem mgmt sample\n\r");
+			printk("Modem version: %s\n\r", modem_version);
 		}
-
 	}
 	/* Shutdown modem to prepare for DFU */
 	nrf_modem_lib_shutdown();


### PR DESCRIPTION
Remove use of at_cmd library to prepare for removing deprecated AT socket interface.
