### PR TITLE
samples: nrf9160: nrf_cloud_rest_fota: Shutdown modem on reboot

### DIFF
--- a/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
@@ -730,6 +730,7 @@ static void error_reboot(void)
 {
 	LOG_INF("Rebooting in 30s..");
 	(void)nrf_cloud_rest_disconnect(&rest_ctx);
+	(void)lte_lc_deinit();
 	k_sleep(K_SECONDS(30));
 	sys_reboot(SYS_REBOOT_COLD);
 }
@@ -828,6 +829,7 @@ void main(void)
 		if (fota_status == NRF_CLOUD_FOTA_SUCCEEDED) {
 			save_settings();
 			(void)nrf_cloud_rest_disconnect(&rest_ctx);
+			(void)lte_lc_deinit();
 			LOG_INF("Rebooting in 10s to complete FOTA update..");
 			k_sleep(K_SECONDS(10));
 			sys_reboot(SYS_REBOOT_COLD);


### PR DESCRIPTION
After a number of ungraceful reconnects to the network, the modem will
refuse new connection attempts. To avoid this issue, the modem should
disconnect from the network before reboot.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>