### PR TITLE
applications: nrf_desktop: dfu: Config chan backward compatibility

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -192,7 +192,7 @@ HID Configurator
 * Added:
 
   * HID Configurator now recognizes the bootloader variant as a DFU module variant for the configuration channel communication.
-    The new implementation is not backward compatible, since new version of script checks for variant it expects firmware to support this request.
+    The new implementation is backward compatible: the new version of the script checks for module name and acts accordingly.
 
 MCUboot
 =======

--- a/scripts/hid_configurator/NrfHidDevice.py
+++ b/scripts/hid_configurator/NrfHidDevice.py
@@ -489,6 +489,8 @@ class NrfHidDevice():
     def get_complete_module_name(self, name):
         """complete module name consist of module name + '/' + variant name."""
         for key in self.dev_config:
-            if '{}/'.format(name) in key:
+            if key.startswith('{}/'.format(name)):
+                return key
+            if name == key:
                 return key
         return None

--- a/scripts/hid_configurator/configurator_cli.py
+++ b/scripts/hid_configurator/configurator_cli.py
@@ -45,7 +45,16 @@ def perform_dfu(dev, args):
         return
     img_ver_dev = info.get_fw_version()
 
-    img_file = DfuImage(args.dfu_image, info, dev.get_board_name(), dev.get_complete_module_name('dfu')[len('{}/'.format('dfu')):])
+    complete_dfu_module_name = dev.get_complete_module_name('dfu')
+
+    if complete_dfu_module_name is None:
+        print('Dfu module not found')
+        return
+    if complete_dfu_module_name == 'dfu':
+        bootloader_variant = None
+    else:
+        bootloader_variant = complete_dfu_module_name[len('{}/'.format('dfu')):]
+    img_file = DfuImage(args.dfu_image, info, dev.get_board_name(), bootloader_variant)
 
     img_file_bin = img_file.get_dfu_image_bin_path()
     if img_file_bin is None:
@@ -59,9 +68,10 @@ def perform_dfu(dev, args):
         print('Cannot read image version from file')
         return
 
-    if dev.get_complete_module_name('dfu')[len('{}/'.format('dfu')):] != img_file.get_dfu_image_bootloader_var():
-        print('Bootloader types does not match')
-        return
+    if bootloader_variant:
+        if bootloader_variant != img_file.get_dfu_image_bootloader_var():
+            print('Bootloader types does not match')
+            return
 
     print('Current FW version from device: ' +
           '.'.join([str(i) for i in img_ver_dev]))
@@ -137,7 +147,12 @@ def perform_fwinfo(dev, args):
 
     if info:
         print(info)
-        print('  Bootloader variant: ' + dev.get_complete_module_name('dfu')[len('{}/'.format('dfu')):])
+        complete_dfu_module_name = dev.get_complete_module_name('dfu')
+        if complete_dfu_module_name is None:
+            print('Dfu module not found')
+            return
+        if complete_dfu_module_name != 'dfu':
+            print('  Bootloader variant: ' + complete_dfu_module_name[len('{}/'.format('dfu')):])
     else:
         print('FW info request failed')
 

--- a/scripts/hid_configurator/modules/dfu.py
+++ b/scripts/hid_configurator/modules/dfu.py
@@ -337,7 +337,7 @@ class DfuImage:
             if not bootloader_api['is_dfu_file_correct'](dfu_bin_path):
                 continue
 
-            if dev_bootloader_variant != bootloader_api['get_dfu_image_bootloader_var']():
+            if (dev_bootloader_variant != bootloader_api['get_dfu_image_bootloader_var']()) and (dev_bootloader_variant is not None):
                 continue
 
             return dfu_bin_path


### PR DESCRIPTION
After changes introduced in
https://projecttools.nordicsemi.no/jira/browse/NCSDK-12781

change hid_configurator script to work with old version of firmware.

Jira: NCSDK-13087

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>