### PR TITLE
scripts: unity: Fix whitespace not handled correctly

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -200,6 +200,11 @@ Scripts
 
 This section provides detailed lists of changes by :ref:`script <scripts>`.
 
+Unity
+-----
+
+* Fixed bug that resulted in the mocks for some functions not having the __wrap_ prefix. This happened for functions declared with whitespaces between identifier and parameter list.
+
 HID Configurator
 ----------------
 

--- a/scripts/unity/func_name_list.py
+++ b/scripts/unity/func_name_list.py
@@ -14,7 +14,7 @@ def func_names_from_header(in_file, out_file):
 
     with open(out_file, 'w') as f_out:
         # Regex match all function names in the header file
-        x = re.findall(r"^\s*(?:\w+[*\s]+)+(\w+?)\([^\\]*?\);",
+        x = re.findall(r"^\s*(?:\w+[*\s]+)+(\w+?)\s*\([^\\]*?\)\s*;",
                        content, re.M | re.S)
         for item in x:
             f_out.write(item + "\n")

--- a/scripts/unity/header_prepare.py
+++ b/scripts/unity/header_prepare.py
@@ -63,7 +63,7 @@ def header_prepare(in_file, out_file, out_wrap_file):
     # Prepare file with functions prefixed with __wrap_ that will be used for
     # mock generation.
     func_pattern = re.compile(
-        r"^\s*((?:\w+[*\s]+)+)(\w+?\([^\\{}#]*?\);)", re.M | re.S)
+        r"^\s*((?:\w+[*\s]+)+)(\w+?\s*\([^\\{}#]*?\)\s*;)", re.M)
     content2 = func_pattern.sub(r"\n\1__wrap_\2", content)
 
     with open(out_wrap_file, 'w') as f_wrap:


### PR DESCRIPTION
The header parsing scripts used for test mocks does not handle whitespace between function identifier and the parameter list. This results in some functions not being wrapped correctly.

The fix updates the regexes to allow whitespace.

This is a breaking change if you use a strict interpretation of what is considered a breaking change. Tests that doesn't use the `__wrap_` prefix in the tests because of this bug will break after this change. So the tests would need to be updated with the prefix.

Signed-off-by: Gregers Gram Rygg <gregers.gram.rygg@nordicsemi.no>