### PR TITLE
manifest: Bump the docker image

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f295fb7c67ca6895a98bc33c1cf0a837d2f5383e
+      revision: pull/684/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Bump the docker image to get a new west version that is hoped to
resolve CI issues.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>