### PR TITLE
AT monitor: Increase upper limit of heap size

### DIFF
--- a/applications/asset_tracker_v2/prj.conf
+++ b/applications/asset_tracker_v2/prj.conf
@@ -17,6 +17,9 @@ CONFIG_HEAP_MEM_POOL_SIZE=32768
 CONFIG_MAIN_STACK_SIZE=1280
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 CONFIG_HW_STACK_PROTECTION=y
+# Increase AT monitor heap size to be able to fit both neighbor cell measurement
+# and other AT notifications that may come in rapid succession.
+CONFIG_AT_MONITOR_HEAP_SIZE=1024
 
 # Logging
 CONFIG_LOG=y

--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -35,6 +35,13 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_MODEM_MODULE_LOG_LEVEL);
 BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
 		"The Modem module does not support this configuration");
 
+#ifdef CONFIG_APP_REQUEST_NEIGHBOR_CELLS_DATA
+BUILD_ASSERT(CONFIG_AT_MONITOR_HEAP_SIZE >= 1024,
+	    "CONFIG_AT_MONITOR_HEAP_SIZE must be >= 1024 to fit neighbor cell measurements "
+	    "and other notifications at the same time");
+#endif
+
+
 struct modem_msg_data {
 	union {
 		struct app_module_event app;

--- a/lib/at_monitor/Kconfig
+++ b/lib/at_monitor/Kconfig
@@ -16,7 +16,7 @@ config AT_MONITOR_SYS_INIT
 
 config AT_MONITOR_HEAP_SIZE
 	int "Heap size for notifications"
-	range 64 768
+	range 64 2048
 	default 256
 
 module=AT_MONITOR


### PR DESCRIPTION
lib: at_monitor: Increase maximum allowed AT monitor heap size 

In some cases, several AT notifications can come in rapid succession
and require more than the previously allowed maximum heap size.
The issue is more easily triggered if one or more of the notifications
are large, like for instance an %NCELLMEAS notification with many
cells.

This patch increases the upper limit of the heap size range to let
applications set a higher value if required for their use-case.

---

applications: asset_tracker_v2: Assert large enough AT monitor heap 

A larger heap may be required to fit all the cells in the response,
and in particular if other notifications come in rapid succession.
Add an assert for AT monitor heap size when neighbor cell
measurements are enabled.