### PR TITLE
net: lib: rest_client: fix for the case where no Content-Length HTTP response

### DIFF
--- a/include/net/rest_client.h
+++ b/include/net/rest_client.h
@@ -17,6 +17,7 @@
 #ifndef REST_CLIENT_H__
 #define REST_CLIENT_H__
 
+#include <zephyr.h>
 #include <net/http_parser.h>
 
 /** @brief TLS is not used. */

--- a/subsys/net/lib/rest_client/src/rest_client.c
+++ b/subsys/net/lib/rest_client/src/rest_client.c
@@ -60,10 +60,10 @@ static void rest_client_http_response_cb(struct http_response *rsp,
 			return;
 		}
 		resp_ctx->http_status_code = rsp->http_status_code;
-		resp_ctx->response_len = rsp->content_length;
+		resp_ctx->response_len = rsp->processed;
 
 		LOG_DBG("HTTP: All data received (content/total: %d/%d), status: %u %s",
-			rsp->content_length,
+			resp_ctx->response_len,
 			resp_ctx->total_response_len,
 			rsp->http_status_code,
 			log_strdup(rsp->http_status));


### PR DESCRIPTION
Now on when processing http response, counting on process field of the http client lib response for
indicating a content length. This fixes a situation when a response does
not have actual Content-Length field at all.

Additionally, adding a commit to fix a compilation with native_posix -target.