### PR TITLE
doc: correcting -DCONFIG_OVERLAY to -DOVERLAY_CONFIG

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/rpc.rst
+++ b/doc/nrf/libraries/bluetooth_services/rpc.rst
@@ -76,7 +76,7 @@ Then, you can invoke build command like this:
 .. parsed-literal::
    :class: highlight
 
-   west build -b *board* -- -DCONFIG_OVERLAY=my_overlay_file.conf
+   west build -b *board* -- -DOVERLAY_CONFIG=my_overlay_file.conf
 
 API documentation
 *****************

--- a/samples/bluetooth/rpc_host/README.rst
+++ b/samples/bluetooth/rpc_host/README.rst
@@ -44,14 +44,14 @@ You must program this sample to the nRF5340 network core.
 Debug build
 ===========
 
-You can build the sample with a debugging configuration using the ``-DCONFIG_OVERLAY=overlay-debugging.conf'`` flag in your build.
+You can build the sample with a debugging configuration using the ``-DOVERLAY_CONFIG=overlay-debugging.conf'`` flag in your build.
 
 See :ref:`cmake_options` for instructions on how to add this option to your build.
 For example, when building on the command line, you can do so as follows:
 
 .. code-block:: console
 
-   west build samples/bluetooth/rpc_host -- -DCONFIG_OVERLAY=overlay-debugging.conf
+   west build samples/bluetooth/rpc_host -- -DOVERLAY_CONFIG=overlay-debugging.conf
 
 .. _rpc_host_testing:
 


### PR DESCRIPTION
Host for nRF RPC Bluetooth LE sample and
Bluetooth LE RPC Call library had an incorrect
-DCONFIG_OVERLAY parameter as pointed out
by Bui Hung.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>