### PR TITLE
Bluetooth: Mesh: Generic property ID can not be 0

### DIFF
--- a/subsys/bluetooth/mesh/gen_prop_cli.c
+++ b/subsys/bluetooth/mesh/gen_prop_cli.c
@@ -240,7 +240,7 @@ int bt_mesh_prop_cli_props_get(struct bt_mesh_prop_cli *cli,
 			       enum bt_mesh_prop_srv_kind kind,
 			       struct bt_mesh_prop_list *rsp)
 {
-	return props_get(cli, ctx, kind, 0x0000, rsp);
+	return props_get(cli, ctx, kind, 1, rsp);
 }
 
 int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,


### PR DESCRIPTION
PR makes;
 _srv_init fail if any of the property ID within the prop. server is 0
 makes sure that pub_list_build is called start_spop>=1

Signed-off-by: Alperen Sener <alperen.sener@nordicsemi.no>