### PR TITLE
net: lib: nrf_cloud: update nrf_cloud_rest to use rest_client

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -216,6 +216,10 @@ Libraries for networking
   * Added A-GPS filtered ephemerides support, with ability to set matching threshold mask angle.
   * When filtered ephemerides is enabled, A-GPS assistance requests to cloud are limited to no more than once every two hours.
 
+* :ref:`lib_nrf_cloud_rest` library:
+
+  * Updated to use the :ref:`lib_rest_client` library for REST API calls.
+
 Other libraries
 ---------------
 

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -68,7 +68,7 @@ struct nrf_cloud_rest_context {
 	 * Minimum timeout value specified by NRF_CLOUD_REST_TIMEOUT_MINIMUM.
 	 * For no timeout, set to NRF_CLOUD_REST_TIMEOUT_NONE.
 	 * @note This parameter is currently not used; set
-	 * CONFIG_NRF_CLOUD_REST_RECV_TIMEOUT instead.
+	 * CONFIG_REST_CLIENT_SCKT_RECV_TIMEOUT instead.
 	 */
 	int32_t timeout_ms;
 	/** Authentication string: JWT @ref modem_jwt.

--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -198,7 +198,7 @@ static void method_gnss_agps_request_work_fn(struct k_work *item)
 	struct nrf_cloud_rest_context rest_ctx = {
 		.connect_socket = -1,
 		.keep_alive = false,
-		.timeout_ms = CONFIG_NRF_CLOUD_REST_RECV_TIMEOUT * MSEC_PER_SEC,
+		.timeout_ms = NRF_CLOUD_REST_TIMEOUT_NONE,
 		.rx_buf = rest_api_recv_buf,
 		.rx_buf_len = sizeof(rest_api_recv_buf),
 		.fragment_size = 0
@@ -263,7 +263,7 @@ static void method_gnss_pgps_request_work_fn(struct k_work *item)
 	struct nrf_cloud_rest_context rest_ctx = {
 		.connect_socket = -1,
 		.keep_alive = false,
-		.timeout_ms = CONFIG_NRF_CLOUD_REST_RECV_TIMEOUT * MSEC_PER_SEC,
+		.timeout_ms = NRF_CLOUD_REST_TIMEOUT_NONE,
 		.rx_buf = rest_api_recv_buf,
 		.rx_buf_len = sizeof(rest_api_recv_buf),
 		.fragment_size = 0

--- a/lib/multicell_location/services/nrf_cloud_integration.c
+++ b/lib/multicell_location/services/nrf_cloud_integration.c
@@ -144,7 +144,7 @@ int location_service_get_cell_location_nrf_cloud(
 		.auth = jwt_buf,
 		.connect_socket = -1,
 		.keep_alive = false,
-		.timeout_ms = CONFIG_NRF_CLOUD_REST_RECV_TIMEOUT * MSEC_PER_SEC,
+		.timeout_ms = NRF_CLOUD_REST_TIMEOUT_NONE,
 		.rx_buf = rcv_buf,
 		.rx_buf_len = rcv_buf_len,
 		.fragment_size = 0

--- a/samples/nrf9160/gnss/src/assistance.c
+++ b/samples/nrf9160/gnss/src/assistance.c
@@ -108,7 +108,7 @@ static void get_pgps_data_work_fn(struct k_work *work)
 	struct nrf_cloud_rest_context rest_ctx = {
 		.connect_socket = -1,
 		.keep_alive = false,
-		.timeout_ms = CONFIG_NRF_CLOUD_REST_RECV_TIMEOUT * MSEC_PER_SEC,
+		.timeout_ms = NRF_CLOUD_REST_TIMEOUT_NONE,
 		.auth = jwt_buf,
 		.rx_buf = rx_buf,
 		.rx_buf_len = sizeof(rx_buf),
@@ -260,7 +260,7 @@ int assistance_request(struct nrf_modem_gnss_agps_data_frame *agps_request)
 	struct nrf_cloud_rest_context rest_ctx = {
 		.connect_socket = -1,
 		.keep_alive = false,
-		.timeout_ms = CONFIG_NRF_CLOUD_REST_RECV_TIMEOUT * MSEC_PER_SEC,
+		.timeout_ms = NRF_CLOUD_REST_TIMEOUT_NONE,
 		.auth = jwt_buf,
 		.rx_buf = rx_buf,
 		.rx_buf_len = sizeof(rx_buf),

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_interface.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_interface.c
@@ -576,7 +576,7 @@ static void get_agps_data(struct k_work *item)
 	struct nrf_cloud_rest_context rest_ctx = {
 		.connect_socket = -1,
 		.keep_alive = false,
-		.timeout_ms = CONFIG_NRF_CLOUD_REST_RECV_TIMEOUT * MSEC_PER_SEC,
+		.timeout_ms = NRF_CLOUD_REST_TIMEOUT_NONE,
 		.auth = jwt_buf,
 		.rx_buf = rx_buf,
 		.rx_buf_len = sizeof(rx_buf),
@@ -760,7 +760,7 @@ static void get_pgps_data_work_fn(struct k_work *work)
 	struct nrf_cloud_rest_context rest_ctx = {
 		.connect_socket = -1,
 		.keep_alive = false,
-		.timeout_ms = CONFIG_NRF_CLOUD_REST_RECV_TIMEOUT * MSEC_PER_SEC,
+		.timeout_ms = NRF_CLOUD_REST_TIMEOUT_NONE,
 		.auth = jwt_buf,
 		.rx_buf = rx_buf,
 		.rx_buf_len = sizeof(rx_buf),

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_rest
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_rest
@@ -5,8 +5,8 @@
 
 menuconfig NRF_CLOUD_REST
 	bool "nRF Cloud REST"
-	select HTTP_CLIENT
 	select CJSON_LIB
+	select REST_CLIENT
 
 if NRF_CLOUD_REST
 
@@ -18,20 +18,6 @@ config NRF_CLOUD_REST_FRAGMENT_SIZE
 	int "Fragment size for REST API downloads"
 	range 128 1700
 	default 1700
-
-config NRF_CLOUD_REST_SEND_TIMEOUT
-	int "Socket send timeout, in seconds"
-	default 60
-	help
-	  Sets the timeout duration in seconds to use when sending data.
-	  To disable, set the timeout duration to -1.
-
-config NRF_CLOUD_REST_RECV_TIMEOUT
-	int "Socket receive timeout, in seconds"
-	default 60
-	help
-	  Sets the timeout duration in seconds to use when receiving data.
-	  To disable, set the timeout duration to -1.
 
 module = NRF_CLOUD_REST
 module-str = nRF Cloud REST


### PR DESCRIPTION
Updated the nrf_cloud_rest library to use the rest_client
library for making REST API calls.
Removed socket timeout kconfig options from nrf_cloud_rest kconfig.
REST_CLIENT_SCKT_SEND_TIMEOUT and REST_CLIENT_SCKT_RECV_TIMEOUT
should be used instead.
CIA-473

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>