### PR TITLE
applications: asset_tracker_v2: use GPS_MODULE in Kconfig.app_module

### DIFF
--- a/applications/asset_tracker_v2/src/modules/Kconfig.app_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.app_module
@@ -8,7 +8,7 @@ menu "Application control module"
 
 config APP_REQUEST_GNSS_ON_INITIAL_SAMPLING
 	bool "Request GNSS on initial data sampling after connection"
-	default y if GPS_MODULE
+	default y if GNSS_MODULE
 
 config APP_REQUEST_NEIGHBOR_CELLS_DATA
 	bool "Request neighbor cells data"


### PR DESCRIPTION
This renames the dependency `GPS_MODULE` to `GNSS_MODULE` which was renamed in #6392.