### PR TITLE
samples: Bluetooth: Fix Direction Finding build issues

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_rx/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/direction_finding_connectionless_rx/child_image/hci_rpmsg.conf
@@ -23,3 +23,6 @@ CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
 
 # Disable Direction Finding TX mode
 CONFIG_BT_CTLR_DF_ADV_CTE_TX=n
+
+# Limit number of connections to avoid memory overflow
+CONFIG_BT_MAX_CONN=1

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -228,12 +228,12 @@ static void enable_cte_rx(void)
 	const struct bt_df_per_adv_sync_cte_rx_param cte_rx_params = {
 		.max_cte_count = 5,
 #if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
-		.cte_type = BT_DF_CTE_TYPE_ALL,
+		.cte_types = BT_DF_CTE_TYPE_ALL,
 		.slot_durations = 0x2,
 		.num_ant_ids = ARRAY_SIZE(ant_patterns),
 		.ant_ids = ant_patterns,
 #else
-		.cte_type = BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US,
+		.cte_types = BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US,
 #endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
 	};
 

--- a/samples/bluetooth/direction_finding_connectionless_tx/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/child_image/hci_rpmsg.conf
@@ -7,15 +7,22 @@
 # Reguired to enable BT_BUF_CMD_TX_SIZE for LE Set Extended Advertising Data command
 CONFIG_BT_EXT_ADV=y
 
+CONFIG_BT_PER_ADV_SYNC=y
+
 CONFIG_BT_CTLR=y
 CONFIG_BT_LL_SW_SPLIT=y
 
 CONFIG_BT_CTLR_ADV_EXT=y
 CONFIG_BT_CTLR_ADV_PERIODIC=y
+CONFIG_BT_CTLR_SYNC_PERIODIC=y
 
 # Enable Direction Finding Feature including AoA and AoD
 CONFIG_BT_CTLR_DF=y
 
-# Disable Direction Finding Rx mode
-CONFIG_BT_CTLR_DF_SCAN_CTE_RX=n
+# Required to correctly setup number of PDUs in periodic advertising chain
+CONFIG_BT_CTLR_DF_SCAN_CTE_RX=y
+# Disable antenna switching in receiver mode
 CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=n
+
+# Limit number of connections to avoid memory overflow
+CONFIG_BT_MAX_CONN=1

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f295fb7c67ca6895a98bc33c1cf0a837d2f5383e
+      revision: pull/683/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Due to changes in upstream Zephyr implementation of direction
finding, samples source code and configuration for nRF53 SOCs
had to be corrected.

Corrections required:
- change of name of a member in bt_df_per_adv_sync_cte_rx_param
- configuration related with number of PDUs allowed in periodic
  advertising chains.

Regarding the configuration of number of PDUs in periodic advertising
chains, the change is temporary until the upsream implementation is
changed from worst case scenario (allocate memory for maxium nubmer of
PDUs in a chain for every periodic sync) to average one (smaller memory
amount for peridoic advertising chains shared between all periodic
syncs).

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>