### PR TITLE
openthread: samples: Add debug overlay to openthread sample

### DIFF
--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -121,6 +121,10 @@ To activate the optional extensions supported by this sample, modify :makevar:`O
 * For the minimal single protocol variant, set :file:`overlay-minimal_singleprotocol.conf`.
 * For the minimal multiprotocol variant, set :file:`overlay-minimal_multiprotocol.conf`.
 * For USB transport support, set :file:`overlay-usb.conf`. Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to :file:`usb.overlay`.
+* For turning on logging, set :file:`overlay-logging.conf`.
+* For redirecting logs to RTT, set :file:`overlay-rtt.conf`.
+  For more information about RTT please refer to :ref:`RTT logging <ug_logging>`.
+* For debbuging a Thread sample with GDB thread awareness, set :file:`overlay-debug.conf`.
 
 See :ref:`cmake_options` for instructions on how to add this option.
 For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.

--- a/samples/openthread/cli/overlay-debug.conf
+++ b/samples/openthread/cli/overlay-debug.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable multithread support in gdb
+CONFIG_DEBUG=y
+CONFIG_THREAD_MONITOR=y
+CONFIG_INIT_STACKS=y
+CONFIG_THREAD_STACK_INFO=y
+CONFIG_TIMESLICING=n
+CONFIG_OPENOCD_SUPPORT=y
+CONFIG_THREAD_NAME=y
+CONFIG_DEBUG_THREAD_INFO=y

--- a/samples/openthread/cli/overlay-rtt.conf
+++ b/samples/openthread/cli/overlay-rtt.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable RTT logging backend
+CONFIG_USE_SEGGER_RTT=y
+CONFIG_LOG_BACKEND_RTT=y
+
+CONFIG_LOG_BACKEND_UART=n
+CONFIG_SHELL_LOG_BACKEND=n


### PR DESCRIPTION
This commits ads overlays to enable rtt logging and thread awareness
on openthread cli sample.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>