### PR TITLE
samples: nrf9160: modem_shell: sample.yaml fix

### DIFF
--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -44,7 +44,7 @@ tests:
       - nrf9160dk_nrf9160_ns
     extra_args: OVERLAY_CONFIG=overlay-lwm2m_carrier.conf
     tags: ci_build
-samples.nrf9160.modem_shell.thingy91:
+  samples.nrf9160.modem_shell.thingy91:
     build_only: true
     platform_allow: thingy91_nrf9160_ns
     integration_platforms:


### PR DESCRIPTION
Adding missing indentation for thingy91.
This mistake came in within [PR#6500](https://github.com/nrfconnect/sdk-nrf/pull/6500)
For some reason all checks were successful in that PR view.

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>