### PR TITLE
applications: asset_tracker_v2: Add new Kconfigs to convert RSRP/RSRQ

### DIFF
--- a/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
@@ -29,11 +29,40 @@ config MODEM_AUTO_REQUEST_POWER_SAVING_FEATURES
 	default y
 
 config MODEM_CONVERT_RSRP_AND_RSPQ_TO_DB
-	bool "Convert RSRP and RSRQ values to dBm and dB, respectively"
-	default y if AWS_IOT || AZURE_IOT_HUB
+	bool "Convert RSRP and RSRQ values to dBm and dB, respectively [DEPRECATED]"
+	select MODEM_DYNAMIC_DATA_CONVERT_RSRP_TO_DBM
+	select MODEM_NEIGHBOR_CELLS_DATA_CONVERT_RSRP_TO_DBM
+	select MODEM_NEIGHBOR_CELLS_DATA_CONVERT_RSRQ_TO_DB
 	help
 	  If this option is enabled, RSRP and RSRQ values are converted to dBm and dB before being
-	  sent out by the module.
+	  sent out by the module. This option is deprecated,
+	  use MODEM_DYNAMIC_DATA_CONVERT_RSRP_TO_DBM, MODEM_NEIGHBOR_CELLS_DATA_CONVERT_RSRP_TO_DBM
+	  and MODEM_NEIGHBOR_CELLS_DATA_CONVERT_RSRQ_TO_DB instead.
+
+config MODEM_DYNAMIC_DATA_CONVERT_RSRP_TO_DBM
+	bool "Convert RSRP values to dBm for dynamic modem data"
+	default y
+	help
+	  If this option is enabled, RSRP values are converted to dBm before being
+	  sent out by the module with the MODEM_EVT_MODEM_DYNAMIC_DATA_READY event.
+
+config MODEM_NEIGHBOR_CELLS_DATA_CONVERT_RSRP_TO_DBM
+	bool "Convert RSRP values to dBm for neighbor cell measurements"
+	default y if AWS_IOT || AZURE_IOT_HUB
+	help
+	  If this option is enabled, RSRP values are converted to dBm before being
+	  sent out by the module with the MODEM_EVT_NEIGHBOR_CELLS_DATA_READY event.
+	  Don't convert RSRP to dBm when building for nRF Cloud, this is handled during encoding
+	  using the nRF Cloud cellular positioning library.
+
+config MODEM_NEIGHBOR_CELLS_DATA_CONVERT_RSRQ_TO_DB
+	bool "Convert RSRQ values to dB for neighbor cell measurements"
+	default y if AWS_IOT || AZURE_IOT_HUB
+	help
+	  If this option is enabled, RSRQ values are converted to dB before being
+	  sent out by the module with the MODEM_EVT_NEIGHBOR_CELLS_DATA_READY event.
+	  Don't convert RSRQ to dB when building for nRF Cloud, this is handled during encoding
+	  using the nRF Cloud cellular positioning library.
 
 endif # MODEM_MODULE
 


### PR DESCRIPTION
Depending on the integration, RSRP and RSRQ values need to be provided
unconverted or in dB/dBm in the various sample events sent out by
the modem module. This is due to the application using different
encoding libraries depending on the data that is sent and
the configured cloud configuration.