### PR TITLE
samples: Bluetooth: df: Fix stack overflow issue

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -18,6 +18,8 @@
  * synchronization establishment, hence timeout must be longer than that.
  */
 #define SYNC_CREATE_TIMEOUT_INTERVAL_NUM 7
+/* Maximum length of advertising data represented in hexadecimal format */
+#define ADV_DATA_HEX_STR_LEN_MAX (BT_GAP_ADV_MAX_EXT_ADV_DATA_LEN * 2 + 1)
 
 static struct bt_le_per_adv_sync *sync;
 static bt_addr_le_t per_addr;
@@ -125,8 +127,8 @@ static void recv_cb(struct bt_le_per_adv_sync *sync,
 		    const struct bt_le_per_adv_sync_recv_info *info,
 		    struct net_buf_simple *buf)
 {
+	static char data_str[ADV_DATA_HEX_STR_LEN_MAX];
 	char le_addr[BT_ADDR_LE_STR_LEN];
-	char data_str[BT_GAP_ADV_MAX_EXT_ADV_DATA_LEN];
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bin2hex(buf->data, buf->len, data_str, sizeof(data_str));


### PR DESCRIPTION
Host receive thread has small default stack size.
If periodic advertising is enabled max amount of advertising
data is set to 1650 bytes. Attempt to convert data from binany
to string requires large array. Allocation of such array on
stack caused stack overflow.

To limit the scope of the array and avoid stack overflow
the array is changed to be static local variable in a function.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>