### PR TITLE
applications: serial_lte_modem: fix UART AT command

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -35,6 +35,10 @@ config SLM_EXTERNAL_XTAL
 #
 # Inter-Connect
 #
+config SLM_UART_HWFC_RUNTIME
+	bool "Support of UART HWFC runtime configuration"
+	help
+		Selected if rts-pin/cts-pin are defined in devicetree
 choice
 	prompt "UART for interconnect"
 	help
@@ -43,8 +47,13 @@ choice
 		-  UART 2
 	config SLM_CONNECT_UART_0
 		bool "UART 0"
+		select SLM_UART_HWFC_RUNTIME if $(dt_node_has_prop,uart0,rts-pin) && \
+			$(dt_node_has_prop,uart0,cts-pin)
+
 	config SLM_CONNECT_UART_2
 		bool "UART 2"
+		select SLM_UART_HWFC_RUNTIME if $(dt_node_has_prop,uart2,rts-pin) && \
+			$(dt_node_has_prop,uart2,cts-pin)
 endchoice
 
 choice

--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -206,14 +206,21 @@ Set command
 -----------
 
 The set command changes the UART baud rate and hardware flow control settings.
+Hardware flow control settings can be changed only if :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is selected.
 These settings are stored in the flash memory and applied during the application startup.
 
 Syntax
 ~~~~~~
 
+The following is the syntax when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is selected:
 ::
 
    #XSLMUART[=<baud_rate>,<hwfc>]
+
+The following is the syntax when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is not selected:
+::
+
+   #XSLMUART[=<baud_rate>]
 
 The ``<baud_rate>`` parameter is an integer.
 It accepts the following values:
@@ -303,18 +310,34 @@ Syntax
 Response syntax
 ~~~~~~~~~~~~~~~
 
+The following is the syntax when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is selected:
+
 ::
 
    #XSLMUART: (list of the available baud rate options),(disable or enable hwfc)
 
+The following is the syntax when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` not selected:
+
+::
+
+   #XSLMUART: (list of the available baud rate options)
+
 Example
 ~~~~~~~
+
+The following is an example when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is selected:
 
 ::
 
    AT#XSLMUART=?
    #XSLMUART: (1200,2400,4800,9600,14400,19200,38400,57600,115200,230400,460800,921600,1000000),(0,1)
 
+The following is an example when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is not selected:
+
+::
+
+   AT#XSLMUART=?
+   #XSLMUART: (1200,2400,4800,9600,14400,19200,38400,57600,115200,230400,460800,921600,1000000)
 
 Device UUID #XUUID
 ==================

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -60,6 +60,12 @@ CONFIG_SLM_EXTERNAL_XTAL - Use external XTAL for UARTE
    This option configures the application to use an external XTAL for UARTE.
    See the `nRF9160 Product Specification`_ (section 6.19 UARTE) for more information.
 
+.. _CONFIG_SLM_UART_HWFC_RUNTIME:
+
+CONFIG_SLM_UART_HWFC_RUNTIME - Support of UART HWFC runtime configuration
+   This option let the application configure HWFC during runtime rather than while compiling by using ``#XSLMUART``.
+   This option is automatically selected when the **rts-pin** and **cts-pin** are defined in the DTS overlay.
+
 .. _CONFIG_SLM_CONNECT_UART_0:
 
 CONFIG_SLM_CONNECT_UART_0 - UART 0
@@ -84,7 +90,7 @@ CONFIG_SLM_START_SLEEP - Enter sleep on startup
 
 CONFIG_SLM_INTERFACE_PIN - Interface GPIO to wake up from sleep or exit idle
    This option specifies which interface GPIO to use for exiting sleep or idle mode.
-   By default, **P0.6** (Button 1 on the nRF9160 DK) is used when :ref:`CONFIG_SLM_CONNECT_   <CONFIG_SLM_CONNECT_UART_0>` is selected, and **P0.31** is used when :ref:`CONFIG_SLM_CONNECT_UART_2 <CONFIG_SLM_CONNECT_UART_2>` is selected.
+   By default, **P0.6** (Button 1 on the nRF9160 DK) is used when :ref:`CONFIG_SLM_CONNECT_UART_0 <CONFIG_SLM_CONNECT_UART_0>` is selected, and **P0.31** is used when :ref:`CONFIG_SLM_CONNECT_UART_2 <CONFIG_SLM_CONNECT_UART_2>` is selected.
 
    **P0.26** (Multi-function button on Thingy:91) is used when the target is Thingy:91.
 

--- a/applications/serial_lte_modem/doc/slm_testing.rst
+++ b/applications/serial_lte_modem/doc/slm_testing.rst
@@ -35,7 +35,7 @@ Complete the following steps to test the functionality provided by the :ref:`SLM
       :class: highlight
 
       **AT#XSLMUART?**
-      #XSLMUART: 115200
+      #XSLMUART: 115200,0
       OK
 
    You can change the used baud rate with the corresponding set command, but note that LTE Link Monitor requires 115200 bps for communication.
@@ -135,7 +135,7 @@ TCP client
          #XSEND: 8
          OK
 
-         **AT#XRECV**
+         **AT#XRECV=0**
          PONG: 'Test TCP'
          #XRECV: 17
          OK
@@ -199,14 +199,14 @@ TCP client
       .. parsed-literal::
          :class: highlight
 
-         **AT#XRECV**
+         **AT#XRECV=0**
          HTTP/1.1 200 OK
          Content-Type: text/html; charset=ISO-8859-1
          *[...]*
          #XRECV: 576
          OK
 
-         **AT#XRECV**
+         **AT#XRECV=0**
          *[...]*
          Connection: close
          #XRECV:147
@@ -336,7 +336,7 @@ UDP client
          **AT#XSENDTO="**\ *example.com*\ **",**\ *1234*\ **,"Test UDP"**
          #XSENDTO: 8
          OK
-         **AT#XRECVFROM**
+         **AT#XRECVFROM=0**
          PONG: Test UDP
          #XRECVFROM: 14
          OK
@@ -375,7 +375,7 @@ UDP client
          #XSEND: 8
          OK
 
-         **AT#XRECV**
+         **AT#XRECV=0**
          PONG: Test UDP
          #XRECV: 14
          OK
@@ -511,7 +511,7 @@ You must register the corresponding credentials on the server side.
          #XSEND: 15
          OK
 
-         **AT#XRECV**
+         **AT#XRECV=0**
          PONG: b'Test TLS client'
          #XRECV: 24
          OK
@@ -621,7 +621,7 @@ You must register the same PSK and PSK identity on the server side.
 		 #XSEND: 16
 		 OK
 
-		 **AT#XRECV**
+		 **AT#XRECV=0**
 		 PONG: b'Test DTLS client'
 		 #XRECV: 25
 		 OK
@@ -737,7 +737,7 @@ To act as a TCP server, |global_private_address|
          #XACCEPT: 3
          OK
 
-         **AT#XRECV**
+         **AT#XRECV=0**
          Hello, TCP#1!Hello, TCP#2!
          #XRECV: 26
          OK
@@ -746,7 +746,7 @@ To act as a TCP server, |global_private_address|
          #XSEND: 15
          OK
 
-         **AT#XRECV**
+         **AT#XRECV=0**
          Hello, TCP#3!Hello, TCP#4!Hello, TCP#5!
          #XRECV: 39
          OK
@@ -1008,12 +1008,12 @@ To act as a UDP server, |global_private_address|
       .. parsed-literal::
          :class: highlight
 
-         **AT#XRECVFROM**
+         **AT#XRECVFROM=0**
          Hello, UDP#1!
          #XRECVFROM: 13
          OK
 
-         **AT#XRECVFROM**
+         **AT#XRECVFROM=0**
          Hello, UDP#2!
          #XRECVFROM: 13
          OK
@@ -1022,17 +1022,17 @@ To act as a UDP server, |global_private_address|
          #XSENDTO: 15
          OK
 
-         **AT#XRECVFROM**
+         **AT#XRECVFROM=0**
          Hello, UDP#3!
          #XRECVFROM: 13
          OK
 
-         **AT#XRECVFROM**
+         **AT#XRECVFROM=0**
          Hello, UDP#4!
          #XRECVFROM: 13
          OK
 
-         **AT#XRECVFROM**
+         **AT#XRECVFROM=0**
          Hello, UDP#5!
          #XRECVFROM: 13
          OK
@@ -1047,7 +1047,7 @@ To act as a UDP server, |global_private_address|
       .. parsed-literal::
          :class: highlight
 
-         **AT#XRECVFROM**
+         **AT#XRECVFROM=0**
          #XSOCKET: -60
          ERROR
 


### PR DESCRIPTION
Fix #XSLMUART:
.Toggle hwfc should only work when rts-pin and rts-pin are defined
in selected UART.
.Not to disconnect rts/cts pin runtime. This would cause VCOM on DK
unable to receive data.
.In order to avoid write flash repeatly,save UART setting to flash
when #XSLMUART issued or first boot after SLM programmed.

Add overlay file for nRF9160 DK working with external MCU:
.Add nrf9160dk_external_mcu.conf to configure external MCU.
.Remove uncessary CONFIG in nrf9160dk_nrf9160_ns.conf.

Prevent exit_idle enter twice.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>