### PR TITLE
doc: add VSC instructions for Thread Test Harness integration

### DIFF
--- a/doc/nrf/ug_thread_certification.rst
+++ b/doc/nrf/ug_thread_certification.rst
@@ -66,10 +66,17 @@ Complete the following steps to prepare for the certification tests:
 
    The :ref:`ot_cli_sample` sample is used as a base, modified with the :file:`harness/overlay-cert.conf` overlay file.
 
-   .. code-block::
+   * If building on the command line, use the following command:
 
-         cd ncs/nrf/samples/openthread/cli/
-         west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG=harness/overlay-cert.conf -DCONFIG_OPENTHREAD_LIBRARY_1_1=y
+     .. code-block::
+
+        cd ncs/nrf/samples/openthread/cli/
+        west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG=harness/overlay-cert.conf -DCONFIG_OPENTHREAD_LIBRARY_1_1=y
+
+   * If building using Visual Studio Code, you must first `create the application <Creating an application_>`_ using the CLI sample, and then `build the application <Building an application_>`_.
+     Select the :file:`harness/overlay-cert.conf` overlay file in the :guilabel:`Kconfig fragment` drop-down menu and add ``CONFIG_OPENTHREAD_LIBRARY_1_1=y`` to the :guilabel:`Additional CMake arguments` text field.
+
+     If the overlay file is not visible in the drop-down menu, navigate to :file:`ncs/nrf/samples/openthread/cli/harness/` and copy the :file:`overlay-cert.conf` file to :file:`ncs/nrf/samples/openthread/cli/` and try again.
 
    .. note::
       The configuration option selects the precompiled OpenThread libraries.


### PR DESCRIPTION
Added instructions for using VSC as an alternative to
command line when building the CLI sample for
Thread certification using the Thread Test Harness.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>