### PR TITLE
ext: curl: removed custom trace for POLLHUP

### DIFF
--- a/ext/curl/lib/select.c
+++ b/ext/curl/lib/select.c
@@ -403,9 +403,6 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
     if(ufds[i].fd == CURL_SOCKET_BAD)
       continue;
     if (ufds[i].revents & POLLHUP) {
-#if defined(CONFIG_NRF_CURL_INTEGRATION)
-	    printk("\npoll() returned: POLLHUP - connection closed\n");
-#endif
 	    ufds[i].revents |= POLLIN;
     }
     if (ufds[i].revents & POLLERR) {


### PR DESCRIPTION
Removed nrf specific trace print for POLLHUP in Curl_poll().
It was find out that this is seen also in OK cases where TCP FIN
contained the last payload http data. Happened especially with NB-IoT.
Jira: MOSH-217

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>