### PR TITLE
applications: asset_tracker_v2: Send memfault data on batch updates

### DIFF
--- a/applications/asset_tracker_v2/src/modules/debug_module.c
+++ b/applications/asset_tracker_v2/src/modules/debug_module.c
@@ -292,7 +292,8 @@ static void memfault_handle_event(struct debug_msg_data *msg)
 	 * compared to having Memfault SDK trigger regular updates independently. All data
 	 * should preferably be sent within the same LTE RRC connected window.
 	 */
-	if (IS_EVENT(msg, data, DATA_EVT_DATA_SEND)) {
+	if ((IS_EVENT(msg, data, DATA_EVT_DATA_SEND)) ||
+	    (IS_EVENT(msg, data, DATA_EVT_DATA_SEND_BATCH))) {
 		send_memfault_data(false);
 		return;
 	}


### PR DESCRIPTION
Update the debug module to trigger Memfault updates whenever a
batch update is sent to cloud. This is to accommodate the nRF Cloud
configuration, which exclusively uses batch updates for regularly
sampled data. Without this change, Memfault metric data is never
sent to Memfault when building for nRF Cloud.