### PR TITLE
Bluetooth: Controller: Define periodic sync buffer count KConfig

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -112,6 +112,14 @@ config BT_CTLR_SDC_SCAN_BUFFER_COUNT
 	  It is recommended to support at least three buffers,
 	  otherwise the scan response report will likely not be generated.
 
+config BT_CTLR_SDC_PERIODIC_SYNC_BUFFER_COUNT
+	int "Number of periodic synchronization receive buffers"
+	default 2
+	range 2 10
+	help
+	  The buffers are used for processing incoming packets
+	  and storing periodic advertising reports.
+
 config BT_CTLR_SDC_RX_PRIO
 	# Hidden option to set the priority of the controller receive thread
 	int

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -112,7 +112,7 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_PERIPHERAL) ||
 	#define SDC_PERIODIC_ADV_SYNC_COUNT CONFIG_BT_PER_ADV_SYNC_MAX
 	#define SDC_PERIODIC_SYNC_MEM_SIZE \
 		(SDC_PERIODIC_ADV_SYNC_COUNT * \
-		 SDC_MEM_PER_PERIODIC_SYNC(SDC_DEFAULT_PERIODIC_SYNC_BUFFER_COUNT))
+		 SDC_MEM_PER_PERIODIC_SYNC(CONFIG_BT_CTLR_SDC_PERIODIC_SYNC_BUFFER_COUNT))
 #else
 	#define SDC_PERIODIC_ADV_SYNC_COUNT 0
 	#define SDC_PERIODIC_SYNC_MEM_SIZE 0
@@ -640,9 +640,20 @@ static int configure_memory_usage(void)
 
 	if (IS_ENABLED(CONFIG_BT_PER_ADV_SYNC)) {
 		cfg.periodic_sync_count.count = SDC_PERIODIC_ADV_SYNC_COUNT;
+
 		required_memory =
 		sdc_cfg_set(SDC_DEFAULT_RESOURCE_CFG_TAG,
 			    SDC_CFG_TYPE_PERIODIC_SYNC_COUNT,
+			    &cfg);
+		if (required_memory < 0) {
+			return required_memory;
+		}
+
+		cfg.periodic_sync_buffer_cfg.count = CONFIG_BT_CTLR_SDC_PERIODIC_SYNC_BUFFER_COUNT;
+
+		required_memory =
+		sdc_cfg_set(SDC_DEFAULT_RESOURCE_CFG_TAG,
+			    SDC_CFG_TYPE_PERIODIC_SYNC_BUFFER_CFG,
 			    &cfg);
 		if (required_memory < 0) {
 			return required_memory;


### PR DESCRIPTION
Able to set the number of periodic synchronization receive buffers

Signed-off-by: Aytürk Düzen <ayturk.duzen@nordicsemi.no>