### PR TITLE
manifest: update sdk-zephyr to bring SMP re-assembly

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c3208e7ff49d22d8271f305344382e9306fdde99
+      revision: pull/688/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The commit advances sdk-zephyr revision to bring in
SMP packet re-aseembly for Bluetooth;

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>