### PR TITLE
samples: Added grant deny status log in 1wire coex sample

### DIFF
--- a/samples/bluetooth/radio_coex_1wire/src/main.c
+++ b/samples/bluetooth/radio_coex_1wire/src/main.c
@@ -78,8 +78,10 @@ static void check_input(void)
 
 	if ((input_char == 'g') ^ APP_GRANT_ACTIVE_LOW) {
 		nrf_gpio_pin_set(APP_GRANT_GPIO_PIN);
+		printk("Current state is: Grant every request\n");
 	} else if ((input_char == 'd') ^ APP_GRANT_ACTIVE_LOW) {
 		nrf_gpio_pin_clear(APP_GRANT_GPIO_PIN);
+		printk("Current state is: Deny every request\n");
 	} else {
 		return;
 	}


### PR DESCRIPTION
sample: radio_coex_1wire -To work with sample more effectively, added logging grant deny status.