### PR TITLE
event_manager: Add subscribe first to event

### DIFF
--- a/doc/nrf/libraries/others/event_manager.rst
+++ b/doc/nrf/libraries/others/event_manager.rst
@@ -230,6 +230,7 @@ To turn a module into a listener for specific event types, complete the followin
 For subscribing to an event type, the Event Manager provides three types of subscriptions, differing in priority.
 They can be registered with the following macros:
 
+* :c:macro:`EVENT_SUBSCRIBE_FIRST` - notification as the first subscriber
 * :c:macro:`EVENT_SUBSCRIBE_EARLY` - notification before other listeners
 * :c:macro:`EVENT_SUBSCRIBE` - standard notification
 * :c:macro:`EVENT_SUBSCRIBE_FINAL` - notification as the last, final subscriber

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -208,6 +208,10 @@ Modem libraries
 Event manager
 -------------
 
+* Added:
+
+  * ``EVENT_SUBSCRIBE_FIRST`` subscriber priority.
+
 * Updated:
 
   * Modified the sections used by the event manager. Stopped using orphaned sections. Removed forced alignment for x86. Reworked priorities.

--- a/include/event_manager.h
+++ b/include/event_manager.h
@@ -119,6 +119,17 @@ extern struct event_type _event_type_list_end[];
 #define EVENT_LISTENER(lname, cb_fn) _EVENT_LISTENER(lname, cb_fn)
 
 
+/** Subscribe a listener to an event type as first module that is
+ *  being notified.
+ *
+ * @param lname  Name of the listener.
+ * @param ename  Name of the event.
+ */
+#define EVENT_SUBSCRIBE_FIRST(lname, ename)							\
+	_EVENT_SUBSCRIBE(lname, ename, _EM_MARKER_FIRST_ELEMENT);				\
+	const struct {} _CONCAT(_CONCAT(__event_subscriber_, ename), first_sub_redefined) = {}
+
+
 /** Subscribe a listener to the early notification list for an
  *  event type.
  *

--- a/tests/subsys/event_manager/src/modules/test_subs.c
+++ b/tests/subsys/event_manager/src/modules/test_subs.c
@@ -15,10 +15,11 @@
 
 static enum test_id cur_test_id;
 
+static int first_cnt;
 static int early_cnt;
 static int normal_cnt;
 
-static bool event_handler_early(const struct event_header *eh)
+static bool event_handler_first(const struct event_header *eh)
 {
 	if (is_test_start_event(eh)) {
 		struct test_start_event *event = cast_test_start_event(eh);
@@ -30,6 +31,28 @@ static bool event_handler_early(const struct event_header *eh)
 
 	if (is_order_event(eh)) {
 		if (cur_test_id == TEST_SUBSCRIBER_ORDER) {
+			first_cnt++;
+		}
+
+		return false;
+	}
+
+	zassert_true(false, "Event unhandled");
+	return false;
+}
+
+/* Create one first listener. */
+EVENT_LISTENER(first, event_handler_first);
+EVENT_SUBSCRIBE_FIRST(first, order_event);
+EVENT_SUBSCRIBE_EARLY(first, test_start_event);
+
+
+static bool event_handler_early(const struct event_header *eh)
+{
+	if (is_order_event(eh)) {
+		if (cur_test_id == TEST_SUBSCRIBER_ORDER) {
+			zassert_equal(first_cnt, 1, "Incorrect subscriber order"
+				      " - early before first");
 			early_cnt++;
 		}
 
@@ -43,21 +66,20 @@ static bool event_handler_early(const struct event_header *eh)
 /* Create 3 early listeners. */
 EVENT_LISTENER(early1, event_handler_early);
 EVENT_SUBSCRIBE_EARLY(early1, order_event);
-EVENT_SUBSCRIBE_EARLY(early1, test_start_event);
 
 EVENT_LISTENER(early2, event_handler_early);
 EVENT_SUBSCRIBE_EARLY(early2, order_event);
-EVENT_SUBSCRIBE_EARLY(early2, test_start_event);
 
 EVENT_LISTENER(early3, event_handler_early);
 EVENT_SUBSCRIBE_EARLY(early3, order_event);
-EVENT_SUBSCRIBE_EARLY(early3, test_start_event);
 
 
 static bool event_handler_normal(const struct event_header *eh)
 {
 	if (is_order_event(eh)) {
 		if (cur_test_id == TEST_SUBSCRIBER_ORDER) {
+			zassert_equal(first_cnt, 1, "Incorrect subscriber order"
+				      " - normal before first");
 			zassert_equal(early_cnt, 3, "Incorrect subscriber order"
 				      " - normal before early");
 			normal_cnt++;
@@ -83,16 +105,10 @@ EVENT_SUBSCRIBE(listener3, order_event);
 
 static bool event_handler_final(const struct event_header *eh)
 {
-	if (is_test_start_event(eh)) {
-		struct test_start_event *event = cast_test_start_event(eh);
-
-		cur_test_id = event->test_id;
-
-		return false;
-	}
-
 	if (is_order_event(eh)) {
 		if (cur_test_id == TEST_SUBSCRIBER_ORDER) {
+			zassert_equal(first_cnt, 1, "Incorrect subscriber order"
+				      " - late before first");
 			zassert_equal(early_cnt, 3, "Incorrect subscriber order"
 				      " - late before early");
 			zassert_equal(normal_cnt, 3,


### PR DESCRIPTION
Add first subscriber to event functionality to event manager.

Jira: NCSDK-9067

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>