### PR TITLE
FEM user guide update

### DIFF
--- a/doc/nrf/includes/sample_dtm_radio_test_fem.txt
+++ b/doc/nrf/includes/sample_dtm_radio_test_fem.txt
@@ -15,3 +15,10 @@ For example, to build the sample from the command line for an nRF5340 DK with an
    To configure the nRF21540 front-end module gain, write the gain value over the SPI.
    In samples, UART is used as a control interface or shell transport.
    To send the gain value UART is temporary disabled and restarted after the SPI transfer.
+
+For more details refer to the following documentation:
+
+* :ref:`ug_radio_fem`
+* :ref:`ug_radio_fem_direct_support`
+* :ref:`ug_radio_fem_nrf21540_spi_gpio`
+* :ref:`ug_radio_fem_nrf21540_ek`

--- a/doc/nrf/includes/sample_dtm_radio_test_skyworks.txt
+++ b/doc/nrf/includes/sample_dtm_radio_test_skyworks.txt
@@ -1,61 +1,7 @@
 The Skyworks SKY66114 and SKY66403 are front-end module (FEM) devices that support the 2-pin PA/LNA interface.
 You can also use other Skyworks FEM devices that provide the same hardware interface.
 
-.. note::
-   The functionalities designated as ``PA`` and ``LNA`` apply to the ``ctx-gpios`` and ``crx-gpios`` pins listed below, respectively.
-
-To use the generic FEM implementation with SKY66114, complete the following steps:
-
-1. Add the following node in the devicetree file:
-
-   .. code-block::
-
-      / {
-         nrf_radio_fem: name_of_fem_node {
-            compatible = "skyworks,sky66114-11", "generic-fem-two-ctrl-pins";
-            ctx-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-            crx-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
-         };
-      };
-
-#. Replace the pin numbers provided for each of the required properties:
-
-   * ``ctx-gpios`` - GPIO characteristic of the device that controls the ``CTX`` signal of SKY66114-11.
-   * ``crx-gpios`` - GPIO characteristic of the device that controls the ``CRX`` signal of SKY66114-11.
-
-   These properties correspond to the ``CTX`` and ``CRX`` pins of SKY66114-11 supported by software FEM.
-
-   The type ``phandle-array`` is used in Zephyr's devicetree to describe GPIO signals.
-   The first element ``&gpio0`` refers to the GPIO port ("port 0" is selected in the example).
-   The second element is the pin number of that port.
-   The last element must be ``GPIO_ACTIVE_HIGH`` for SKY66114-11, but for a different FEM module you can use ``GPIO_ACTIVE_LOW``.
-
-   Set the state of the other control pins according to the SKY66114-11 documentation.
-   See the official `SKY66114-11 page`_ for more information.
-
-Optional properties
--------------------
-
-The following properties are optional and you can add them to the devicetree node if needed:
-
-* Properties that control the other pins:
-   * ``csd-gpios`` - GPIO characteristic of the device that controls the ``CSD`` signal of SKY66114-11.
-   * ``cps-gpios`` - GPIO characteristic of the device that controls the ``CPS`` signal of SKY66114-11.
-   * ``chl-gpios`` - GPIO characteristic of the device that controls the ``CHL`` signal of SKY66114-11.
-   * ``ant-sel-gpios`` - GPIO characteristic of the device that controls the ``ANT_SEL`` signal of devices that support antenna diversity, for example SKY66403-11.
-
-* Properties that control the timing of interface signals:
-
-  * ``ctx-settle-time-us`` - Minimal time interval between asserting the ``CTX`` signal and starting the radio transmission, in microseconds.
-  * ``crx-settle-time-us`` - Minimal time interval between asserting the ``CRX`` signal and starting the radio reception, in microseconds.
-
-  The default values of these properties are appropriate for default hardware and most use cases.
-  You can override them if you need additional capacitors, for example when using custom hardware.
-  In such cases, add the property name under the required properties in the devicetree node and set a new custom value.
-
-  .. note::
-    These values have some constraints.
-    For details, see the official documentation at the `SKY66114-11 page`_.
+To use the generic FEM implementation with Skyworks front-end modules refer to :ref:`ug_radio_fem_skyworks` for details.
 
 Use case of incomplete physical connections to the FEM module
 -------------------------------------------------------------

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -412,5 +412,10 @@ In addition to documentation related to the changes listed above, the following 
 
   * Reduced the ToC levels of the subpages.
 
+* Reorganized the contents of the :ref:`ug_radio_fem` section:
+
+  * Added new section :ref: `ug_radio_fem_nrf21540_spi_gpio`.
+  * Added new section :ref: `ug_radio_fem_direct_support`.
+  * Added more information about supported protocols and hardware.
 
 .. |no_changes_yet_note| replace:: No changes since the latest |NCS| release.

--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -24,7 +24,7 @@ Software support
 
 If your application uses radio protocols and requires FEM, you can enable :ref:`nrfxlib:mpsl_fem` in the :ref:`nrfxlib:mpsl` (MPSL) library.
 The test samples in |NCS|: :ref:`radio_test` and :ref:`direct_test_mode` also support FEM control.
-You can use as well your own FEM driver when required.
+You can also use your own FEM driver when required.
 
 Using MPSL
 ==========
@@ -155,7 +155,7 @@ To use nRF21540 in GPIO mode, complete the following steps:
 SPI/GPIO mode
 -------------
 
-The nRF21540 has also an SPI interface.
+The nRF21540 features an SPI interface.
 You can use it to fully control your front-end module or you can use a combination of SPI and GPIO interface.
 The SPI interface enables you, for example, to set the output power of the nRF21540.
 
@@ -357,22 +357,23 @@ Two nRF21540 boards are available, showcasing the possibilities of the nRF21540 
 * :ref:`nRF21540 DK <nrf21540dk_nrf52840>`
 * :ref:`ug_radio_fem_nrf21540_ek`
 
-For example SKY66112-11EK also has a 2-pin PA/LNA interface.
+Also various Skyworks front-end modules are supported.
+For example, SKY66112-11EK has a 2-pin PA/LNA interface.
 
 The front-end module feature is supported on the nRF52 and nRF53 Series devices.
 
 nRF21540 DK
 ===========
 
-The nRF21540 DK is a development kit that has the nRF52840 device combined with the additional nRF21540 front-end module.
-You can use it the same way as :ref:`zephyr:nrf52840dk_nrf52840`
+The nRF21540 DK is a development kit that features the nRF52840 device combined with the additional nRF21540 front-end module.
+You can use it the same way as :ref:`zephyr:nrf52840dk_nrf52840`.
 It is an easy way to start testing front-end modules.
-For more details see :ref:`nRF21540 DK <nrf21540dk_nrf52840>`
+For more details, see :ref:`nRF21540 DK <nrf21540dk_nrf52840>`.
 
 Shields
 =======
 
-Shields are adds on that you can attach to the development kit to extend its feature and functionalities.
+Shields are add-ons that you can attach to the development kit to extend its feature and functionalities.
 
 .. _ug_radio_fem_nrf21540_ek:
 


### PR DESCRIPTION
This PR updates the FEM user guide to be more generic. It adds an information about direct support in samples and also shows how to configure the SPI for nRF21540 FEM.