### PR TITLE
net: lib: nrf_cloud: Remove dependency from `NRF_CLOUD_PGPS`

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
@@ -5,7 +5,6 @@
 
 menuconfig NRF_CLOUD_PGPS
 	bool "Enable nRF Cloud Predicted GPS (P-GPS)"
-	depends on NRF_CLOUD_REST || NRF_CLOUD_MQTT
 	depends on MODEM_INFO
 	depends on MODEM_INFO_ADD_NETWORK
 	depends on DATE_TIME


### PR DESCRIPTION
Remove the `NRF_CLOUD_REST` and `NRF_CLOUD_MQTT` dependency from
the `NRF_CLOUD_PGPS` option.

The nRF Cloud P-GPS library can be used without
depending on the nRF Cloud REST / MQTT transport libraries to
request/receive P-GPS data. The library can be used transport agnostic,
as it is done in Asset Tracker v2.