### PR TITLE
lib: lte_link_control: Split ANY at_monitor

### DIFF
--- a/lib/lte_link_control/lte_lc_helpers.c
+++ b/lib/lte_link_control/lte_lc_helpers.c
@@ -113,6 +113,10 @@ void event_handler_list_dispatch(const struct lte_lc_evt *const evt)
 {
 	struct event_handler *curr, *tmp;
 
+	if (event_handler_list_is_empty()) {
+		return;
+	}
+
 	k_mutex_lock(&list_mtx, K_FOREVER);
 
 	/* Dispatch events to all registered handlers */


### PR DESCRIPTION
Having AT_MONITOR with ANY filter causes unnecessary heap allocations. And when heap runs out and there is AT_MONITOR_ISR's in other components, ANY monitors will cause unnecessary warning log which confuses users.