### PR TITLE
release-notes-changelog.rst: remove duplicate Event Manager section

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -187,13 +187,6 @@ Modem libraries
 
   * Can now parse AT command responses containing the response result, for example, ``OK`` or ``ERROR``.
 
-Event manager
--------------
-
-* Updated:
-
-  * Modified the sections used by the event manager. Stopped using orphaned sections. Removed forced alignment for x86. Reworked priorities.
-
 Libraries for networking
 ------------------------
 


### PR DESCRIPTION
It was added a second time in 602cd6cb91e68e60f5c3c6b25dc3f71dc696b9af, but not removed from this location.