### PR TITLE
lib: nrf_modem: Clear the address structure on recvfrom

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -183,6 +183,10 @@ Libraries for networking
 Modem libraries
 ---------------
 
+* :ref:`nrf_modem_lib_readme` library:
+
+  * Fixed a bug in the socket offloading component, where the :c:func:`recvfrom` wrapper could do an out-of-bounds copy of the sender's address, when the application is compiled without IPv6 support. In some cases, the out of bounds copy could indefinitely block the :c:func:`send` and other socket API calls.
+
 * :ref:`at_monitor_readme` library:
 
   * Introduced AT_MONITOR_ISR macro to monitor AT notifications in an interrupt service routine.


### PR DESCRIPTION
When DTLS is used, libmodem does not set the address field in the
`nrf_recvfrom()` structure, which may lead to erronous behaviour as the
structure will contain rubbish on output. Therefore we need to clear the
structure before calling the function to prevent the erronous behaviour.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>