### PR TITLE
tests: twister: quarantine: Add quarantine.yaml file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,6 +18,9 @@
 /.github/labeler.yml                      @thst-nordic @guwa @mariusz-nordicsemi @tomaszkob89 @totyz @doublemis1 @wiminordic @jorgenmk @maciekrozanski @ns-tolu @miha-nordic @maciejpietras @piwe-nordic @nordic-babu @fredaas @torsteingrindvik @mswarowsky @shantha-14 @ardo-nordic
 /.github/workflows/manifest.yml           @thst-nordic @guwa @mariusz-nordicsemi @tomaszkob89 @totyz @doublemis1 @wiminordic @jorgenmk @maciekrozanski @ns-tolu @miha-nordic @maciejpietras @piwe-nordic @nordic-babu @fredaas @torsteingrindvik @mswarowsky @shantha-14 @ardo-nordic
 
+# Quarantine for the CI and Twister
+/scripts/quarantine.yaml                  @ncs-test-leads @carlescufi @thst-nordic
+
 # VS Code Configuration files
 /.vscode/                                 @trond-snekvik
 

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -1,0 +1,18 @@
+# The configurations resulting as a product of scenarios and platforms
+# will be skipped if quarantine is used. More details here:
+# https://docs.zephyrproject.org/latest/guides/test/twister.html#quarantine
+# To have an empty list use:
+# - scenarios:
+#    - None
+#  platforms:
+#    - None
+
+- scenarios:
+    - samples.edge_impulse.wrapper
+    - applications.machine_learning.zdebug
+    - applications.machine_learning.zdebug_nus
+    - applications.machine_learning.zdebug_rtt
+    - applications.machine_learning.zrelease
+  platforms:
+    - all
+  comment: "Issues with edge impulse server"


### PR DESCRIPTION
Calling twister with --quarantine-list ./scripts/quarantine.yaml
tells twister to skip all the configurations from this list

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>