### PR TITLE
Updated mpsl cx cmake file for bug fix

### DIFF
--- a/subsys/mpsl/cx/CMakeLists.txt
+++ b/subsys/mpsl/cx/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if (CONFIG_MPSL_CX_THREAD OR CONFIG_MPSL_CX_THREAD OR CONFIG_MPSL_CX_BT_3WIRE)
+if (CONFIG_MPSL_CX_THREAD OR CONFIG_MPSL_CX_BT_1WIRE OR CONFIG_MPSL_CX_BT_3WIRE)
     zephyr_library()
 
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_THREAD thread/mpsl_cx_thread.c)


### PR DESCRIPTION
Defined 1-wire coex flag

Signed-off-by: Dwivedi, Tanmay <tanmay.dwivedi@nordicsemi.no>