### PR TITLE
caf: sensor_manager: Fix wake up event handling

### DIFF
--- a/subsys/caf/modules/sensor_manager.c
+++ b/subsys/caf/modules/sensor_manager.c
@@ -180,7 +180,9 @@ static bool is_sensor_active(const struct sensor_data *sd)
 static void sensor_wake_up_post(const struct sm_sensor_config *sc, struct sensor_data *sd)
 {
 	sd->sample_timeout = k_uptime_get();
-	reset_sensor_sleep_cnt(sc, sd);
+	if (sc->trigger) {
+		reset_sensor_sleep_cnt(sc, sd);
+	}
 	update_sensor_state(sc, sd, SENSOR_STATE_ACTIVE);
 }
 


### PR DESCRIPTION
The reset_sensor_sleep_cnt can be called only if trigger is configured for the sensor. Otherwise it leads to NULL dereferencing.

Jira: NCSDK-13247