### PR TITLE
applications: nrf_desktop: Move Fn key ID related macros

### DIFF
--- a/applications/nrf_desktop/configuration/common/fn_key_id.h
+++ b/applications/nrf_desktop/configuration/common/fn_key_id.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _FN_KEY_ID_H_
+#define _FN_KEY_ID_H_
+
+#include <sys/util.h>
+#include <caf/key_id.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define _FN_POS		(_COL_POS + _COL_SIZE)
+#define _FN_BIT		BIT(_FN_POS)
+
+#define FN_KEY_ID(_col, _row)	(KEY_ID(_col, _row) | _FN_BIT)
+#define IS_FN_KEY(_keyid)	((_FN_BIT & _keyid) != 0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FN_KEY_ID_H_ */

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/hid_keymap_def.h
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/hid_keymap_def.h
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "hid_keymap.h"
 #include <caf/key_id.h>
+
+#include "hid_keymap.h"
+#include "fn_key_id.h"
 
 /* This configuration file is included only once from hid_state module and holds
  * information about mapping between buttons and generated reports.

--- a/applications/nrf_desktop/doc/hid_state.rst
+++ b/applications/nrf_desktop/doc/hid_state.rst
@@ -48,8 +48,10 @@ For example, the file contents should look like the following:
 
 .. code-block:: c
 
-	#include "hid_keymap.h"
 	#include <caf/key_id.h>
+
+	#include "hid_keymap.h"
+	#inclue "fn_key_id.h"
 
 	static const struct hid_keymap hid_keymap[] = {
 		{ KEY_ID(0x00, 0x01), 0x0014, REPORT_ID_KEYBOARD_KEYS }, /* Q */

--- a/applications/nrf_desktop/src/modules/fn_keys.c
+++ b/applications/nrf_desktop/src/modules/fn_keys.c
@@ -15,6 +15,7 @@
 
 #include <caf/key_id.h>
 
+#include "fn_key_id.h"
 #include "fn_keys_def.h"
 
 #include <logging/log.h>

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -93,6 +93,7 @@ nRF Desktop
 * Updated:
 
    * Documentation and diagrams for the Bluetooth LE bond internal module.
+   * Moved Fn key related macros to an application specific header file (:file:`configuration/common/fn_key_id.h`).
 
 Samples
 =======

--- a/include/caf/key_id.h
+++ b/include/caf/key_id.h
@@ -18,9 +18,7 @@ extern "C" {
 #define _ROW_SIZE 7ul
 #define _COL_POS  (_ROW_POS + _ROW_SIZE)
 #define _COL_SIZE 7ul
-#define _FN_POS   (_COL_POS + _COL_SIZE)
 
-#define _FN_BIT         BIT(_FN_POS)
 #define _COL_BITS(_col) ((_col & BIT_MASK(_COL_SIZE)) << _COL_POS)
 #define _ROW_BITS(_row) ((_row & BIT_MASK(_ROW_SIZE)) << _ROW_POS)
 
@@ -29,11 +27,6 @@ extern "C" {
 
 #define KEY_COL(_keyid) ((_keyid >> _COL_POS) & BIT_MASK(_COL_SIZE))
 #define KEY_ROW(_keyid) ((_keyid >> _ROW_POS) & BIT_MASK(_ROW_SIZE))
-
-#if defined(CONFIG_DESKTOP_FN_KEYS_ENABLE)
-#define FN_KEY_ID(_col, _row) (KEY_ID(_col, _row) | _FN_BIT)
-#define IS_FN_KEY(_keyid) ((_FN_BIT & _keyid) != 0)
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The Fn key ID related macros are specific to nRF Desktop and should be introduced by application specific header.

Jira: NCSDK-13155