### PR TITLE
lib: ram_pwrdn: allow to power up/down address ranges

### DIFF
--- a/include/ram_pwrdn.h
+++ b/include/ram_pwrdn.h
@@ -14,7 +14,7 @@
 /**
  * @defgroup ram_pwrdn RAM Power Down
  * @{
- * @brief Module for disabling unused sections of RAM.
+ * @brief Module for powering on and off RAM sections.
  *
  */
 
@@ -22,9 +22,29 @@
 extern "C" {
 #endif
 
-/** Request powering down unused RAM sections.
+/**
+ * @brief Request powering down RAM sections for the given address range.
  *
- * Not all devices support this feature.
+ * Power down RAM sections which fully fall within the given address range.
+ */
+void power_down_ram(uintptr_t start_address, uintptr_t end_address);
+
+/**
+ * @brief Request powering up RAM sections for the given address range.
+ *
+ * Power up RAM sections which overlap with the given address range.
+ */
+void power_up_ram(uintptr_t start_address, uintptr_t end_address);
+
+/**
+ * @brief Request powering down unused RAM sections.
+ *
+ * Power down RAM sections which are not used by the application image.
+ *
+ * @note
+ * Some libc implementations use the memory area following the application
+ * image for heap. If this is the case and the application relies on dynamic
+ * memory allocations, this function should not be used.
  */
 void power_down_unused_ram(void);
 

--- a/lib/ram_pwrdn/Kconfig
+++ b/lib/ram_pwrdn/Kconfig
@@ -6,6 +6,7 @@
 
 menuconfig RAM_POWER_DOWN_LIBRARY
 	bool "Enable API for turning off unused RAM segments"
+	depends on SOC_NRF52840 || SOC_NRF52833
 	help
 	  This allows application to call API for disabling unused RAM segments
 	  in the System ON mode. Effectively the application looses possibility

--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -3,118 +3,150 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include <zephyr.h>
-#include <logging/log.h>
 
+#include <hal/nrf_power.h>
+#include <logging/log.h>
+#include <sys/util.h>
+#include <zephyr.h>
+
+#include <stdint.h>
 
 LOG_MODULE_REGISTER(ram_pwrdn, CONFIG_RAM_POWERDOWN_LOG_LEVEL);
 
-#if defined CONFIG_BOARD_NRF52840DK_NRF52840 || \
-	defined CONFIG_BOARD_NRF52833DK_NRF52833
-
-#include <hal/nrf_power.h>
-
-/* Start address of RAM. */
-#define RAM_START_ADDR              0x20000000UL
-/* Size of RAM section for banks 0-7. */
-#define RAM_BANK_0_7_SECTION_SIZE   0x1000
-/* Number of sections in banks 0-7. */
-#define RAM_BANK_0_7_SECTIONS_NBR   2
-/* Size of RAM section for bank 8. */
-#define RAM_BANK_8_SECTION_SIZE     0x8000
-/* Number of sections in bank 8. */
-#define RAM_BANK_8_SECTIONS_NBR     6
-/* Number of RAM banks available at the SoC. */
-#define RAM_BANKS_NBR               8
-/* End of RAM used by the application. */
-#define RAM_END_ADDR                ((uint32_t)&_image_ram_end)
-extern char _image_ram_end;
-#else
-#define UNUSED_RAM_POWER_OFF_UNSUPPORTED
+#if !defined(CONFIG_SOC_NRF52840) && !defined(CONFIG_SOC_NRF52833)
+#error "RAM power-down module is not supported on the current platform"
 #endif
 
-#ifndef UNUSED_RAM_POWER_OFF_UNSUPPORTED
+#define RAM_IMAGE_END_ADDR ((uintptr_t)_image_ram_end)
+#define RAM_BANK_COUNT ARRAY_SIZE(banks)
 
-/**@brief Calculate bottom address of RAM bank with given ID.
- *
- * @param[in] bank_id  ID of RAM bank to get start address of.
- *
- * @return    Start address of RAM bank.
+struct ram_bank {
+	uintptr_t start;
+	uint8_t section_count;
+	uint16_t section_size;
+};
+
+extern char _image_ram_end[];
+
+static const struct ram_bank banks[] = {
+	{ .start = 0x20000000UL, .section_count = 2, .section_size = 0x1000 },
+	{ .start = 0x20002000UL, .section_count = 2, .section_size = 0x1000 },
+	{ .start = 0x20004000UL, .section_count = 2, .section_size = 0x1000 },
+	{ .start = 0x20006000UL, .section_count = 2, .section_size = 0x1000 },
+	{ .start = 0x20008000UL, .section_count = 2, .section_size = 0x1000 },
+	{ .start = 0x2000A000UL, .section_count = 2, .section_size = 0x1000 },
+	{ .start = 0x2000C000UL, .section_count = 2, .section_size = 0x1000 },
+	{ .start = 0x2000E000UL, .section_count = 2, .section_size = 0x1000 },
+#if CONFIG_SOC_NRF52833
+	{ .start = 0x20010000UL, .section_count = 2, .section_size = 0x8000 },
+#else
+	{ .start = 0x20010000UL, .section_count = 6, .section_size = 0x8000 },
+#endif
+};
+
+/*
+ * Power down selected RAM sections of the given bank.
  */
-static inline uint32_t ram_bank_bottom_addr(uint8_t bank_id)
+static void ram_bank_power_down(uint8_t bank_id, uint8_t first_section_id, uint8_t last_section_id)
 {
-	uint32_t bank_addr = RAM_START_ADDR + bank_id
-			  * RAM_BANK_0_7_SECTION_SIZE
-			  * RAM_BANK_0_7_SECTIONS_NBR;
-	return bank_addr;
+	uint32_t mask = GENMASK(NRF_POWER_RAMPOWER_S0POWER + last_section_id,
+				NRF_POWER_RAMPOWER_S0POWER + first_section_id);
+	nrf_power_rampower_mask_off(NRF_POWER, bank_id, mask);
 }
 
-/**@brief Calculate bottom address of section of RAM bank with given bank
- *        and section IDs.
- *
- * @param[in] bank_id     ID of RAM bank section is placed in.
- * @param[in] section_id  ID of section of RAM bank to get start address of.
- *
- * @return    Start address of section of RAM bank.
+/*
+ * Power up selected RAM sections of the given bank.
  */
-static uint32_t ram_sect_bank_bottom_addr(uint8_t bank_id, uint8_t section_id)
+static void ram_bank_power_up(uint8_t bank_id, uint8_t first_section_id, uint8_t last_section_id)
 {
-	/* Get base address of given RAM bank. */
-	uint32_t section_addr = ram_bank_bottom_addr(bank_id);
+	uint32_t mask = GENMASK(NRF_POWER_RAMPOWER_S0POWER + last_section_id,
+				NRF_POWER_RAMPOWER_S0POWER + first_section_id);
+	nrf_power_rampower_mask_on(NRF_POWER, bank_id, mask);
+}
 
-	/* Calculate section address offset. */
-	if (bank_id == 8) {
-		section_addr += section_id * RAM_BANK_8_SECTION_SIZE;
-	} else {
-		section_addr += section_id * RAM_BANK_0_7_SECTION_SIZE;
+/*
+ * Calculate size of the RAM bank.
+ */
+static uintptr_t ram_bank_size(const struct ram_bank *bank)
+{
+	return (uintptr_t)bank->section_count * (uintptr_t)bank->section_size;
+}
+
+/*
+ * Return ID of the nearest RAM section with start address less or equal to the given address.
+ *
+ * If the address points before or after the RAM bank then 0 or the number of bank sections
+ * is returned, respectively.
+ */
+static uint8_t ram_bank_section_id_floor(uintptr_t address, const struct ram_bank *bank)
+{
+	if (address < bank->start) {
+		return 0;
 	}
 
-	return section_addr;
+	if (address >= bank->start + ram_bank_size(bank)) {
+		return bank->section_count;
+	}
+
+	return (uint8_t)((address - bank->start) / bank->section_size);
 }
-#endif /* ifndef UNUSED_RAM_POWER_OFF_UNSUPPORTED */
+
+/*
+ * Returns ID of the nearest RAM section with start address greater or equal to the given address.
+ *
+ * If the address points before or after the RAM bank then 0 or the number of bank sections
+ * is returned, respectively.
+ */
+static uint8_t ram_bank_section_id_ceil(uintptr_t address, const struct ram_bank *bank)
+{
+	if (address < bank->start) {
+		return 0;
+	}
+
+	if (address >= bank->start + ram_bank_size(bank)) {
+		return bank->section_count;
+	}
+
+	return (uint8_t)(ROUND_UP(address - bank->start, bank->section_size) / bank->section_size);
+}
+
+void power_down_ram(uintptr_t start_address, uintptr_t end_address)
+{
+	for (uint8_t bank_id = 0; bank_id < RAM_BANK_COUNT; ++bank_id) {
+		const struct ram_bank *bank = &banks[bank_id];
+
+		/* Determine bank sections which fully fall within the input address range */
+		uint8_t section_begin = ram_bank_section_id_ceil(start_address, bank);
+		uint8_t section_end = ram_bank_section_id_floor(end_address, bank);
+
+		if (section_begin < section_end) {
+			LOG_DBG("Powering down sections %u-%u of bank %u", section_begin,
+				section_end - 1, bank_id);
+			ram_bank_power_down(bank_id, section_begin, section_end - 1);
+		}
+	}
+}
+
+void power_up_ram(uintptr_t start_address, uintptr_t end_address)
+{
+	for (uint8_t bank_id = 0; bank_id < RAM_BANK_COUNT; ++bank_id) {
+		const struct ram_bank *bank = &banks[bank_id];
+
+		/* Determine bank sections which overlap with the input address range */
+		uint8_t section_begin = ram_bank_section_id_floor(start_address, bank);
+		uint8_t section_end = ram_bank_section_id_ceil(end_address, bank);
+
+		if (section_begin < section_end) {
+			LOG_DBG("Powering up sections %u-%u of bank %u", section_begin,
+				section_end - 1, bank_id);
+			ram_bank_power_up(bank_id, section_begin, section_end - 1);
+		}
+	}
+}
 
 void power_down_unused_ram(void)
 {
-#ifndef UNUSED_RAM_POWER_OFF_UNSUPPORTED
-	/* ID of top RAM bank. Depends of amount of RAM available at SoC. */
-	uint8_t     bank_id                 = RAM_BANKS_NBR;
-	uint8_t     section_id              = 5;
-	uint32_t    section_size            = 0;
-	/* Mask to power down whole RAM bank. */
-	uint32_t    ram_bank_power_off_mask = 0x0000FFFF;
-	/* Mask to select sections of RAM bank to power off. */
-	uint32_t    mask_off;
+	const struct ram_bank *last_bank = &banks[RAM_BANK_COUNT - 1];
 
-	/* Power off banks with unused RAM only. */
-	while (ram_bank_bottom_addr(bank_id) >= RAM_END_ADDR) {
-		LOG_DBG("Powering off bank: %d.", bank_id);
-		nrf_power_rampower_mask_off(NRF_POWER,
-					    bank_id,
-					    ram_bank_power_off_mask);
-		bank_id--;
-	}
-
-	/* Set ID of top section and section size for given bank. */
-	if (bank_id == 8) {
-		section_id = RAM_BANK_8_SECTIONS_NBR - 1;
-		section_size = RAM_BANK_8_SECTION_SIZE;
-	} else {
-		section_id = RAM_BANK_0_7_SECTIONS_NBR - 1;
-		section_size = RAM_BANK_0_7_SECTION_SIZE;
-	}
-
-	/* Power off remaining sections of unused RAM. */
-	while (ram_sect_bank_bottom_addr(bank_id, section_id) >= RAM_END_ADDR) {
-		LOG_DBG("Powering off section %d of bank %d.",
-			section_id,
-			bank_id);
-
-		mask_off = ((1 << section_id) << NRF_POWER_RAMPOWER_S0POWER);
-
-		nrf_power_rampower_mask_off(NRF_POWER, bank_id, mask_off);
-		section_id--;
-	}
-#else
-	LOG_INF("RAM power off unsupported.");
-#endif /* UNUSED_RAM_POWER_OFF_UNSUPPORTED */
+	power_down_ram(RAM_IMAGE_END_ADDR, last_bank->start + ram_bank_size(last_bank));
 }

--- a/tests/lib/ram_pwrdn/CMakeLists.txt
+++ b/tests/lib/ram_pwrdn/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(ram_pwrdn)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/ram_pwrdn/prj.conf
+++ b/tests/lib/ram_pwrdn/prj.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_ZTEST=y
+CONFIG_NEWLIB_LIBC=y
+CONFIG_NEWLIB_LIBC_NANO=n
+CONFIG_RAM_POWER_DOWN_LIBRARY=y

--- a/tests/lib/ram_pwrdn/testcase.yaml
+++ b/tests/lib/ram_pwrdn/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  ram_pwrdn.functionality_test:
+    platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
+    tags: ram_pwrdn


### PR DESCRIPTION
Existing RAM Power Down library only allows to disable RAM after the image till the RAM end. We need a greater flexibility to be able to implement dynamic RAM power up/down for applications using heap memory allocations. This change is a prerequisite for the dynamic RAM power control which will be provided after the upmerge.

1. Extend RAM Power Down library with two functions for powering up and down RAM sections for the given address range. Refactor the code so that it will be easier to add support for nRF53 and other SOCs.
2. Enable the library for nRF52840 and nRF52833 SOCs instead of just corresponding development kits.
3. Add an integration test.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>