### PR TITLE
net: lib: nrf_cloud: fix addr of packed warning

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -371,9 +371,15 @@ static void discard_oldest_predictions(int num)
 	npgps_print_blocks();
 
 	/* update index and header for new first stored prediction */
+	uint16_t gps_day;
+	uint32_t gps_time_of_day;
+
 	get_prediction_day_time(last, &index.start_sec,
-				&index.header.gps_day,
-				&index.header.gps_time_of_day);
+				&gps_day,
+				&gps_time_of_day);
+	index.header.gps_day = gps_day;
+	index.header.gps_time_of_day = gps_time_of_day;
+
 	LOG_DBG("updated index to gps_sec:%d, day:%u, time:%u",
 		(int32_t)index.start_sec, index.header.gps_day,
 		index.header.gps_time_of_day);


### PR DESCRIPTION
Fix a new warning related to taking the address of
a packed structure member, which could result in an
unaligned pointer.

Jira: NCSDK-13343

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>