### PR TITLE
mpsl: cx: initialize GPIO pin information

### DIFF
--- a/subsys/mpsl/cx/thread/mpsl_cx_thread.c
+++ b/subsys/mpsl/cx/thread/mpsl_cx_thread.c
@@ -34,9 +34,9 @@
 
 static mpsl_cx_cb_t callback;
 
-static const struct gpio_dt_spec req_spec;
-static const struct gpio_dt_spec pri_spec;
-static const struct gpio_dt_spec gra_spec;
+static const struct gpio_dt_spec req_spec = GPIO_DT_SPEC_GET(CX_NODE, req_gpios);
+static const struct gpio_dt_spec pri_spec = GPIO_DT_SPEC_GET(CX_NODE, pri_dir_gpios);
+static const struct gpio_dt_spec gra_spec = GPIO_DT_SPEC_GET(CX_NODE, grant_gpios);
 static struct gpio_callback grant_cb;
 
 static int32_t grant_pin_is_asserted(bool *is_asserted)


### PR DESCRIPTION
This commit fixes the initialization of GPIO pin information
of the MPSL CX Thread-compliant Coexistence interface.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>