### PR TITLE
lib: lte_lc: Return 0 if library is already initialized

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -282,6 +282,10 @@ Modem libraries
 
   * The modem trace handling is moved from :file:`nrf_modem_os.c` to a new file :file:`nrf_modem_lib_trace.c`, which also provides the API for starting a trace session for a given time interval or until a given size of trace data is received.
 
+* :ref:`lte_lc_readme` library:
+
+  * API calls that initialize the library will now return ``0`` if the library has already been initialized.
+
 * Removed the ``at_cmd`` library.
 
 * Removed the ``at_notif`` library.

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -792,11 +792,10 @@ int lte_lc_deregister_handler(lte_lc_evt_handler_t handler);
  *
  * @note a follow-up call to lte_lc_connect() or lte_lc_connect_async() must be
  *	 made to establish an LTE connection. The module can be initialized
- *	 only once, and subsequent calls will return -EALREADY.
+ *	 only once, and subsequent calls will return 0.
  *
  * @retval 0 if successful.
  * @retval -EFAULT if an AT command failed.
- * @retval -EALREADY if the library has already been initialized.
  */
 int lte_lc_init(void);
 
@@ -821,11 +820,10 @@ int lte_lc_connect(void);
  *	   the connection attempt times out.
  *
  * @note The module can be initialized only once, and repeated calls will
- *	 return -EALREADY. lte_lc_connect_async() should be used on subsequent
+ *	 return 0. lte_lc_connect_async() should be used on subsequent
  *	 calls.
  *
  * @retval 0 if successful.
- * @retval -EALREADY if the library has already been initialized.
  * @retval -EFAULT if an AT command failed.
  * @retval -ETIMEDOUT if a connection attempt timed out before the device was
  *	   registered to a network.
@@ -849,13 +847,12 @@ int lte_lc_connect_async(lte_lc_evt_handler_t handler);
  *	   network. Non-blocking.
  *
  * @note The module can be initialized only once, and repeated calls will
- *	 return -EALREADY. lte_lc_connect() should be used on subsequent calls.
+ *	 return 0. lte_lc_connect() should be used on subsequent calls.
  *
  * @param handler Event handler for receiving LTE events. The parameter can be
  *		  NULL if an event handler is already registered.
  *
  * @retval 0 if successful.
- * @retval -EALREADY if the library has already been initialized.
  * @retval -EFAULT if an AT command failed.
  * @retval -EINVAL if no event handler was registered.
  */

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -538,7 +538,8 @@ static int init_and_config(void)
 	int err;
 
 	if (is_initialized) {
-		return -EALREADY;
+		LOG_DBG("The library is already initialized and configured");
+		return 0;
 	}
 
 	k_sem_init(&link, 0, 1);
@@ -709,11 +710,7 @@ int lte_lc_init(void)
 {
 	int err = init_and_config();
 
-	if ((err == 0) || (err == -EALREADY)) {
-		return err;
-	}
-
-	return -EFAULT;
+	return err ? -EFAULT : 0;
 }
 
 void lte_lc_register_handler(lte_lc_evt_handler_t handler)
@@ -771,7 +768,7 @@ int lte_lc_init_and_connect_async(lte_lc_evt_handler_t handler)
 
 	err = init_and_config();
 	if (err) {
-		return err;
+		return -EFAULT;
 	}
 
 	return lte_lc_connect_async(handler);

--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -606,9 +606,6 @@ int link_func_mode_set(enum lte_lc_func_mode fun, bool rel14_used)
 			 * subscribed there also nowadays?
 			 */
 			return_value = lte_lc_init_and_connect_async(link_ind_handler);
-			if (return_value == -EALREADY) {
-				return_value = lte_lc_connect_async(link_ind_handler);
-			}
 		}
 		break;
 	case LTE_LC_FUNC_MODE_DEACTIVATE_LTE:


### PR DESCRIPTION
The library has returned -EALREADY if it was already initialized.
This patch changes the return value to 0 in this case, which
simplifies the use of the library, as there would be no practical
difference with regards to how to treat the different returned
values previously.