### PR TITLE
lib: at_monitor: remove AT_MONITOR_SYS_INIT

### DIFF
--- a/doc/nrf/libraries/modem/at_monitor.rst
+++ b/doc/nrf/libraries/modem/at_monitor.rst
@@ -29,11 +29,7 @@ The AT monitor library facilitates the integration of the Modem library in |NCS|
 Initialization
 ==============
 
-The application can initialize the AT monitor library in the following ways:
-
-* Manually by using the :c:func:`at_monitor_init` function.
-* Automatically by using the ``SYS_INIT`` macro and by enabling :kconfig:`CONFIG_AT_MONITOR_SYS_INIT`.
-
+The AT monitor library initializes automatically when enabled using :kconfig:`CONFIG_AT_MONITOR`.
 Upon initialization, the AT monitor library registers itself as the receiver of AT notifications from the Modem library (using :c:func:`nrf_modem_at_notif_handler_set`).
 
 .. note::

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -187,6 +187,7 @@ Modem libraries
 * :ref:`at_monitor_readme` library:
 
   * Introduced AT_MONITOR_ISR macro to monitor AT notifications in an interrupt service routine.
+  * Removed :c:func:`at_monitor_init` function and :kconfig:`CONFIG_AT_MONITOR_SYS_INIT` option. The library now initializes automatically when enabled.
 
 * :ref:`at_cmd_parser_readme` library:
 

--- a/include/modem/at_monitor.h
+++ b/include/modem/at_monitor.h
@@ -57,11 +57,6 @@ struct at_monitor_isr_entry {
 	bool paused;
 };
 
-/**
- * @brief Ready to dispatch notifications to monitors.
- */
-void at_monitor_init(void);
-
 /** Wildcard. Match any notifications. */
 #define ANY NULL
 /** Monitor is paused. */

--- a/lib/at_monitor/Kconfig
+++ b/lib/at_monitor/Kconfig
@@ -9,11 +9,6 @@ menuconfig AT_MONITOR
 
 if AT_MONITOR
 
-config AT_MONITOR_SYS_INIT
-	bool "Initialize during SYS_INIT"
-	depends on NRF_MODEM_LIB_SYS_INIT
-	default y
-
 config AT_MONITOR_HEAP_SIZE
 	int "Heap size for notifications"
 	range 64 2048

--- a/lib/at_monitor/at_monitor.c
+++ b/lib/at_monitor/at_monitor.c
@@ -100,12 +100,5 @@ static int at_monitor_sys_init(const struct device *unused)
 	return 0;
 }
 
-#if defined(CONFIG_AT_MONITOR_SYS_INIT)
 /* Initialize during SYS_INIT */
 SYS_INIT(at_monitor_sys_init, APPLICATION, 0);
-#endif
-
-void at_monitor_init(void)
-{
-	at_monitor_sys_init(NULL);
-}

--- a/lib/at_shell/at_shell.c
+++ b/lib/at_shell/at_shell.c
@@ -48,10 +48,6 @@ int at_shell(const struct shell *shell, size_t argc, char **argv)
 	char *command = argv[1];
 
 	if (!strcmp(command, "events_enable")) {
-		if (!IS_ENABLED(CONFIG_AT_MONITOR_SYS_INIT)) {
-			at_monitor_init();
-		}
-
 		at_monitor_resume(at_shell_monitor);
 		shell_print(shell, "AT command event handler enabled");
 	} else if (!strcmp(command, "events_disable")) {

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -384,8 +384,6 @@ int lwm2m_os_at_init(void)
 		return -EIO;
 	}
 
-	at_monitor_init();
-
 	return 0;
 }
 

--- a/lib/date_time/date_time_core.c
+++ b/lib/date_time/date_time_core.c
@@ -141,11 +141,6 @@ void date_time_lte_ind_handler(const struct lte_lc_evt *const evt)
 
 void date_time_core_init(void)
 {
-	if (IS_ENABLED(CONFIG_DATE_TIME_MODEM) && IS_ENABLED(CONFIG_DATE_TIME_AUTO_UPDATE) &&
-	    !IS_ENABLED(CONFIG_AT_MONITOR_SYS_INIT)) {
-		at_monitor_init();
-	}
-
 	if (IS_ENABLED(CONFIG_DATE_TIME_AUTO_UPDATE) && IS_ENABLED(CONFIG_LTE_LINK_CONTROL)) {
 		lte_lc_register_handler(date_time_lte_ind_handler);
 	}

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -559,10 +559,6 @@ static int init_and_config(void)
 {
 	int err;
 
-	if (!IS_ENABLED(CONFIG_AT_MONITOR_SYS_INIT)) {
-		at_monitor_init();
-	}
-
 	if (is_initialized) {
 		return -EALREADY;
 	}

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -148,9 +148,6 @@ void main(void)
 #if !defined(CONFIG_AT_NOTIF_SYS_INIT)
 	at_notif_init();
 #endif
-#if !defined(CONFIG_AT_MONITOR_SYS_INIT)
-	at_monitor_init();
-#endif
 	lte_lc_init();
 #else
 	/* Wait until modemlib has been initialized. */


### PR DESCRIPTION
Library shall always initialize automatically when enabled.
There was no reason not to, this simplifies things a bit.