### PR TITLE
doc: Change used mfw version to 1.3.0/1

### DIFF
--- a/samples/nrf9160/http_update/full_modem_update/README.rst
+++ b/samples/nrf9160/http_update/full_modem_update/README.rst
@@ -23,7 +23,7 @@ The sample proceeds as follows:
 #. It prevalidates the update if the firmware supports the prevalidation process.
 #. It then programs the update to the modem, using the :ref:`lib_fmfu_fdev` library.
 
-The current version of this sample downloads two different versions of the firmware, namely 1.2.1 and 1.2.2.
+The current version of this sample downloads two different versions of the firmware, namely 1.3.0 and 1.3.1.
 The sample then selects the version which is currently not installed.
 
 Requirements


### PR DESCRIPTION
The code used now the official packages from modem firmware version 1.3.0
and 1.3.1, so the documentation should say so too.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>