### PR TITLE
lib: nrf_modem: only lock ctx mutex if socket context was not released

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -871,7 +871,12 @@ static ssize_t nrf91_socket_offload_recvfrom(void *obj, void *buf, size_t len,
 	}
 
 exit:
-	k_mutex_lock(ctx->lock, K_FOREVER);
+	if (ctx->lock) {
+		/* don't touch this if the context has been released
+		 * as a consequence of the socket being closed
+		 */
+		k_mutex_lock(ctx->lock, K_FOREVER);
+	}
 
 	return retval;
 }


### PR DESCRIPTION
If close() is called while a recv() call is ongoing,
the offloading code would release the ctx->lock mutex at
the end of recv() and crash due to the context
itself being released after close().