### PR TITLE
bluetooth: rpc: Modification of bt_conn_auth_cb_register function

### DIFF
--- a/subsys/bluetooth/rpc/client/bt_rpc_conn_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_conn_client.c
@@ -1333,7 +1333,7 @@ static void bt_rpc_auth_cb_pairing_accept_rpc_handler(CborValue *value, void *ha
 		goto decoding_error;
 	}
 
-	if (auth_cb->pairing_accept) {
+	if (auth_cb && auth_cb->pairing_accept) {
 		result = auth_cb->pairing_accept(conn, &feat);
 	} else {
 		result = BT_SECURITY_ERR_INVALID_PARAM;
@@ -1369,7 +1369,7 @@ static void bt_rpc_auth_cb_passkey_display_rpc_handler(CborValue *value, void *h
 		goto decoding_error;
 	}
 
-	if (auth_cb->passkey_display) {
+	if (auth_cb && auth_cb->passkey_display) {
 		auth_cb->passkey_display(conn, passkey);
 	}
 
@@ -1394,7 +1394,7 @@ static void bt_rpc_auth_cb_passkey_entry_rpc_handler(CborValue *value, void *han
 		goto decoding_error;
 	}
 
-	if (auth_cb->passkey_entry) {
+	if (auth_cb && auth_cb->passkey_entry) {
 		auth_cb->passkey_entry(conn);
 	}
 
@@ -1421,7 +1421,7 @@ static void bt_rpc_auth_cb_passkey_confirm_rpc_handler(CborValue *value, void *h
 		goto decoding_error;
 	}
 
-	if (auth_cb->passkey_confirm) {
+	if (auth_cb && auth_cb->passkey_confirm) {
 		auth_cb->passkey_confirm(conn, passkey);
 	}
 
@@ -1449,7 +1449,7 @@ static void bt_rpc_auth_cb_oob_data_request_rpc_handler(CborValue *value, void *
 		goto decoding_error;
 	}
 
-	if (auth_cb->oob_data_request) {
+	if (auth_cb && auth_cb->oob_data_request) {
 		auth_cb->oob_data_request(conn, info);
 	}
 
@@ -1474,7 +1474,7 @@ static void bt_rpc_auth_cb_cancel_rpc_handler(CborValue *value, void *handler_da
 		goto decoding_error;
 	}
 
-	if (auth_cb->cancel) {
+	if (auth_cb && auth_cb->cancel) {
 		auth_cb->cancel(conn);
 	}
 
@@ -1498,7 +1498,7 @@ static void bt_rpc_auth_cb_pairing_confirm_rpc_handler(CborValue *value, void *h
 		goto decoding_error;
 	}
 
-	if (auth_cb->pairing_confirm) {
+	if (auth_cb && auth_cb->pairing_confirm) {
 		auth_cb->pairing_confirm(conn);
 	}
 
@@ -1525,7 +1525,7 @@ static void bt_rpc_auth_cb_pairing_complete_rpc_handler(CborValue *value, void *
 		goto decoding_error;
 	}
 
-	if (auth_cb->pairing_complete) {
+	if (auth_cb && auth_cb->pairing_complete) {
 		auth_cb->pairing_complete(conn, bonded);
 	}
 
@@ -1552,7 +1552,7 @@ static void bt_rpc_auth_cb_pairing_failed_rpc_handler(CborValue *value, void *ha
 		goto decoding_error;
 	}
 
-	if (auth_cb->pairing_failed) {
+	if (auth_cb && auth_cb->pairing_failed) {
 		auth_cb->pairing_failed(conn, reason);
 	}
 
@@ -1588,17 +1588,21 @@ int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)
 	int res;
 	uint16_t flags = 0;
 
+	if (cb != NULL) {
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
-	flags |= cb->pairing_accept ? FLAG_PAIRING_ACCEPT_PRESENT : 0;
+		flags |= cb->pairing_accept ? FLAG_PAIRING_ACCEPT_PRESENT : 0;
 #endif /* CONFIG_BT_SMP_APP_PAIRING_ACCEPT */
-	flags |= cb->passkey_display ? FLAG_PASSKEY_DISPLAY_PRESENT : 0;
-	flags |= cb->passkey_entry ? FLAG_PASSKEY_ENTRY_PRESENT : 0;
-	flags |= cb->passkey_confirm ? FLAG_PASSKEY_CONFIRM_PRESENT : 0;
-	flags |= cb->oob_data_request ? FLAG_OOB_DATA_REQUEST_PRESENT : 0;
-	flags |= cb->cancel ? FLAG_CANCEL_PRESENT : 0;
-	flags |= cb->pairing_confirm ? FLAG_PAIRING_CONFIRM_PRESENT : 0;
-	flags |= cb->pairing_complete ? FLAG_PAIRING_COMPLETE_PRESENT : 0;
-	flags |= cb->pairing_failed ? FLAG_PAIRING_FAILED_PRESENT : 0;
+		flags |= cb->passkey_display ? FLAG_PASSKEY_DISPLAY_PRESENT : 0;
+		flags |= cb->passkey_entry ? FLAG_PASSKEY_ENTRY_PRESENT : 0;
+		flags |= cb->passkey_confirm ? FLAG_PASSKEY_CONFIRM_PRESENT : 0;
+		flags |= cb->oob_data_request ? FLAG_OOB_DATA_REQUEST_PRESENT : 0;
+		flags |= cb->cancel ? FLAG_CANCEL_PRESENT : 0;
+		flags |= cb->pairing_confirm ? FLAG_PAIRING_CONFIRM_PRESENT : 0;
+		flags |= cb->pairing_complete ? FLAG_PAIRING_COMPLETE_PRESENT : 0;
+		flags |= cb->pairing_failed ? FLAG_PAIRING_FAILED_PRESENT : 0;
+	} else {
+		flags = FLAG_AUTH_CB_IS_NULL;
+	}
 
 	res = bt_conn_auth_cb_register_on_remote(flags);
 

--- a/subsys/bluetooth/rpc/common/bt_rpc_common.h
+++ b/subsys/bluetooth/rpc/common/bt_rpc_common.h
@@ -210,6 +210,7 @@ enum {
 	FLAG_PAIRING_CONFIRM_PRESENT  = BIT(6),
 	FLAG_PAIRING_COMPLETE_PRESENT = BIT(7),
 	FLAG_PAIRING_FAILED_PRESENT   = BIT(8),
+	FLAG_AUTH_CB_IS_NULL          = BIT(15),
 };
 
 /* Helper callback definitions for connection API and Extended Advertising.

--- a/subsys/bluetooth/rpc/host/bt_rpc_conn_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_conn_host.c
@@ -1287,6 +1287,10 @@ void bt_rpc_auth_cb_pairing_failed(struct bt_conn *conn, enum bt_security_err re
 
 static int bt_conn_auth_cb_register_on_remote(uint16_t flags)
 {
+	if (flags & FLAG_AUTH_CB_IS_NULL) {
+		return bt_conn_auth_cb_register(NULL);
+	}
+
 #if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
 	remote_auth_cb.pairing_accept = (flags & FLAG_PAIRING_ACCEPT_PRESENT) ?
 					bt_rpc_auth_cb_pairing_accept : NULL;


### PR DESCRIPTION
Serialization of the structure of callbacks when it is different
from NULL.

Signed-off-by: Marcin Jeliński <marcin.jelinski@nordicsemi.no>