### PR TITLE
zigbee: osif: Fix checks in NVRAM write routines

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_nvram.c
+++ b/subsys/zigbee/osif/zb_nrf_nvram.c
@@ -107,7 +107,7 @@ zb_ret_t zb_osif_nvram_write(zb_uint8_t page, zb_uint32_t pos, void *buf,
 		return RET_PAGE_NOT_FOUND;
 	}
 
-	if (pos + len >= zb_get_nvram_page_length()) {
+	if (pos + len > zb_get_nvram_page_length()) {
 		return RET_INVALID_PARAMETER;
 	}
 


### PR DESCRIPTION
It is allowed to write the whole page (including the last byte), so the comparison should not fail in case of the last write on the NVRAM page.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>