### PR TITLE
caf: sensor_manager: Add known issue (NULL dereferencing on wakeup)

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -871,6 +871,14 @@ NCSDK-10196: DFU fails for some configurations with the quick session resume fea
 Common Application Framework (CAF)
 ==================================
 
+.. rst-class:: v1-8-0
+
+NCSDK-13247: Sensor manager dereferences NULL pointer on wake up for sensors without trigger
+  :ref:`caf_sensor_manager` dereferences NULL pointer while handling a :c:struct:`wake_up_event` if a configured sensor does not use trigger.
+  This leads to undefined behaviour.
+
+  **Workaround** Manually cherry-pick and apply commit with fix from main (commit hash: ``3db6da76206d379c223afe2de646218e60e4f339``).
+
 .. rst-class:: v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
 NCSDK-13058: Directed advertising does not work

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -195,6 +195,7 @@ Common Application Framework (CAF)
     ``MODULE_ID`` macro and :c:func:`module_id_get` function now returns module reference from dedicated section instead of module name.
     The module name can not be obtained from reference object directly, a helper function (:c:func:`module_name_get`) should be used instead.
   * Fixed the NCSDK-13058 known issue related to directed advertising in CAF.
+  * Fixed NULL dereferencing in :ref:`caf_sensor_manager` during :c:struct:`wake_up_event` handling for sensors that do not support trigger.
 
 Bootloader libraries
 --------------------


### PR DESCRIPTION
Describe known issue related to possible NULL dereferencing while handling wake_up_event if a sensor does not support trigger.

Jira: NCSDK-13247