### PR TITLE
samples: peripheral: 802154_phy_test: Parametrize PTT features

### DIFF
--- a/samples/peripheral/802154_phy_test/Kconfig
+++ b/samples/peripheral/802154_phy_test/Kconfig
@@ -52,6 +52,7 @@ config PTT_HW_VERSION
 
 config PTT_ANTENNA_DIVERSITY
 	depends on !SOC_SERIES_NRF53X
+	depends on NRFX_GPIOTE
 	bool "Enable Antenna Diversity [EXPERIMENTAL]"
 	select EXPERIMENTAL
 
@@ -89,5 +90,31 @@ config PTT_ANT_TOGGLE_TIME
 	  Time in microseconds between antenna switches in Auto Mode
 
 endif #PTT_ANTENNA_DIVERSITY
+
+config PTT_CLK_OUT
+	bool "Enable external clock signal generator"
+	default y
+	depends on NRFX_GPIOTE
+	help
+	  Output clock signal to an external pin
+
+config PTT_POWER_MGMT
+	bool "Enable power management commands"
+	default y
+	depends on NRFX_POWER
+	help
+	  Enable power management commands.
+
+config PTT_CACHE_MGMT
+	bool "Enable cache management commands"
+	default y
+	help
+	  Enable cache management commands.
+
+config PTT_RF_INIT_PRIORITY
+	int "PTT RF init priority"
+	default 50
+	help
+	  PTT RF module init priority
 
 endmenu

--- a/samples/peripheral/802154_phy_test/boards/nrf5340dk_nrf5340_cpunet.conf
+++ b/samples/peripheral/802154_phy_test/boards/nrf5340dk_nrf5340_cpunet.conf
@@ -1,0 +1,2 @@
+# Include empty image in the APP core
+CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE=y

--- a/samples/peripheral/802154_phy_test/include/rf_proc.h
+++ b/samples/peripheral/802154_phy_test/include/rf_proc.h
@@ -24,8 +24,6 @@
 /**< Start of PSDU payload */
 #define RF_PSDU_START (1u)
 
-#define PTT_RF_INIT_PRIORITY CONFIG_SENSOR_INIT_PRIORITY
-
 /** @brief NRF radio driver initialization
  *
  *  @param none

--- a/samples/peripheral/802154_phy_test/prj.conf
+++ b/samples/peripheral/802154_phy_test/prj.conf
@@ -38,9 +38,6 @@ CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT=2
 # Workaround for a bug in the MPSL Glue Layer (not required for nRF52840)
 CONFIG_BT=y
 
-# Include empty image in the APP core (not used for nRF52840)
-CONFIG_NCS_SAMPLE_EMPTY_APP_CORE_CHILD_IMAGE=y
-
 # Enable ring buffers
 CONFIG_RING_BUFFER=y
 

--- a/samples/peripheral/802154_phy_test/src/main.c
+++ b/samples/peripheral/802154_phy_test/src/main.c
@@ -54,7 +54,7 @@ static int setup(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(rf_setup, POST_KERNEL, PTT_RF_INIT_PRIORITY);
+SYS_INIT(rf_setup, POST_KERNEL, CONFIG_PTT_RF_INIT_PRIORITY);
 
 SYS_INIT(setup, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
 

--- a/samples/peripheral/802154_phy_test/src/rf_proc.c
+++ b/samples/peripheral/802154_phy_test/src/rf_proc.c
@@ -9,8 +9,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <kernel.h>
-#include <nrfx_gpiote.h>
 #include <nrfx.h>
+
+#if IS_ENABLED(CONFIG_PTT_ANTENNA_DIVERSITY)
+#include <nrfx_gpiote.h>
+#endif /* IS_ENABLED(CONFIG_PTT_ANTENNA_DIVERSITY) */
 
 #if defined(DPPI_PRESENT)
 #include <nrfx_dppi.h>


### PR DESCRIPTION
This commit parametrizes PHY test tool features to make it easier
to build and run on custom PCBs.

Change summary:
- PTT_CLK_OUT config to enable/disable external clock signal generation
- LED indication is optional (detected through devicetree)
- PTT_POWER_MGMT config to enable/disable power management commands
- PTT_CACHE_MGMT config to enable/disable cache management commands

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>