### PR TITLE
Ncsidb 416 esb fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v1.8-branch") _
 
 def pipeline = new ncs.sdk_nrf.Main()
 

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -695,9 +695,6 @@ static void on_radio_disabled_tx(void)
 	ESB_SYS_TIMER->EVENTS_COMPARE[0] = 0;
 	ESB_SYS_TIMER->EVENTS_COMPARE[1] = 0;
 
-	/* Remove */
-	ESB_SYS_TIMER->TASKS_START = 1;
-
 	nrfx_gppi_channels_enable(ppi_all_channels_mask);
 	nrfx_gppi_channels_disable(1 << ppi_ch_timer_compare1_radio_txen);
 
@@ -943,7 +940,6 @@ static void radio_irq_handler(void)
 	if (NRF_RADIO->EVENTS_READY &&
 	    (NRF_RADIO->INTENSET & RADIO_INTENSET_READY_Msk)) {
 		NRF_RADIO->EVENTS_READY = 0;
-		ESB_SYS_TIMER->TASKS_START;
 	}
 
 	if (NRF_RADIO->EVENTS_END &&


### PR DESCRIPTION
Fixes requested by [NCSIDB-416](https://projecttools.nordicsemi.no/jira/browse/NCSIDB-416):

The ESB contain the following two lines of code the customer asks can be removed or not:
https://github.com/nrfconnect/sdk-nrf/blame/3a66b06f79128643416eb2a161b29314b363e56c/subsys/esb/esb.c#L699
https://github.com/nrfconnect/sdk-nrf/blame/3a66b06f79128643416eb2a161b29314b363e56c/subsys/esb/esb.c#L946 

The first link the comment says /* Remove */, the second line of code will have no effect.