### PR TITLE
Integrate ZBOSS stack v3.11.0.0+v5.1.0 [KRKNWK-12145]

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -59,6 +59,15 @@ Thread
 
 * Changed how Thread 1.2 is enabled, refer to :ref:`thread_ug_thread_specification_options` and :ref:`thread_ug_feature_sets` for more information.
 
+Zigbee
+------
+
+* Updated ZBOSS Zigbee stack to version ``3.11.0.0+5.1.0``.
+  See the :ref:`nrfxlib:zboss_changelog` in the nrfxlib documentation for detailed information.
+* Added development ZBOSS stack library version based on the ZBOSS build v3.10.0.780+v5.1.0.
+  This library version is dedicated for testing ZCL v8 features.
+* Added ZBOSS libraries variant with ZBOSS Traces enabled.
+
 Applications
 ============
 

--- a/tests/subsys/zigbee/osif/crypto/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/crypto/CMakeLists.txt
@@ -16,8 +16,8 @@ target_compile_definitions(app PRIVATE
 
 target_include_directories(app PRIVATE
   ${NRF_DIR}/subsys/zigbee/osif
-  ${NRFXLIB_DIR}/zboss/include
-  ${NRFXLIB_DIR}/zboss/include/osif
+  ${NRFXLIB_DIR}/zboss/production/include
+  ${NRFXLIB_DIR}/zboss/production/include/osif
 )
 
 project(osif_crypto)

--- a/tests/subsys/zigbee/osif/serial/serial_async_api/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/CMakeLists.txt
@@ -24,8 +24,8 @@ zephyr_compile_definitions(CONFIG_ZIGBEE_UART_RX_BUF_LEN=16)
 zephyr_compile_definitions(CONFIG_ZIGBEE_UART_TX_BUF_LEN=128)
 
 zephyr_include_directories(${ZEPHYR_BASE}/../nrf/subsys/zigbee/osif)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include/osif)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include/osif)
 
 
 target_sources(app PRIVATE

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/CMakeLists.txt
@@ -25,8 +25,8 @@ zephyr_compile_definitions(CONFIG_ZIGBEE_UART_RX_BUF_LEN=16)
 zephyr_compile_definitions(CONFIG_ZIGBEE_UART_TX_BUF_LEN=128)
 
 zephyr_include_directories(${ZEPHYR_BASE}/../nrf/subsys/zigbee/osif)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include/osif)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include/osif)
 
 
 target_sources(app PRIVATE

--- a/tests/subsys/zigbee/osif/serial/serial_via_logger/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/serial/serial_via_logger/CMakeLists.txt
@@ -14,8 +14,8 @@ add_definitions(-Wno-packed-bitfield-compat)
 zephyr_compile_definitions(CONFIG_ZBOSS_TRACE_HEXDUMP_LOGGING)
 zephyr_compile_definitions(CONFIG_ZBOSS_TRACE_LOGGER_BUFFER_SIZE=1024)
 
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include)
-zephyr_include_directories(${NRFXLIB_DIR}/zboss/include/osif)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include)
+zephyr_include_directories(${NRFXLIB_DIR}/zboss/production/include/osif)
 target_include_directories(app BEFORE PRIVATE mock)
 
 target_sources(app PRIVATE

--- a/tests/subsys/zigbee/osif/timer/CMakeLists.txt
+++ b/tests/subsys/zigbee/osif/timer/CMakeLists.txt
@@ -22,5 +22,5 @@ target_include_directories(app
   PRIVATE
   ${NRF_DIR}/tests/subsys/zigbee/osif/timer/mock
   ${NRF_DIR}/tests/subsys/zigbee/osif/timer/stubs
-  ${NRFXLIB_DIR}/zboss/include/osif
+  ${NRFXLIB_DIR}/zboss/production/include/osif
 )

--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: bc0d20242fae2723f6ba973c49eab0506cb0fa05
+      revision: bf61b30136b01ebb355259cf299b6f5dbe2c5ff7
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
- Add development variant of ZBOSS libraries with support for ZCL v8
- Integrate ZBOSS stack v3.11.0.0+v5.1.0 (production libraries)
- Add ZBOSS libraries variant with ZBOSS Traces enabled

test-sdk-nrf: test-zigbee-only