### PR TITLE
lib: location: add support for GNSS high accuracy

### DIFF
--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -40,6 +40,7 @@ Each location method has its own implementation for the location retrieval:
      precedence as the transport method of GNSS assistance data.
    * Note that acquiring GNSS fix only starts when LTE connection, more specifically Radio Resource Control (RRC) connection, is idle.
      Also, if A-GPS is not used and Power Saving Mode (PSM) is enabled, Location library will wait for the modem to enter PSM.
+   * Selectable location accuracy (low/normal/high).
 * Cellular positioning
    * :ref:`lte_lc_readme` for getting visible cellular base stations.
    * :ref:`lib_multicell_location` for sending cell information to the selected location service and getting the calculated location back to the device.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -261,6 +261,10 @@ Other libraries
   * Removed the :kconfig:`CONFIG_DATE_TIME_IPV6` Kconfig option.
     The library now automatically uses IPv6 for NTP when available.
 
+* :ref:`lib_location` library:
+
+  * Added support for GNSS high accuracy.
+
 Event Manager
 +++++++++++++
 

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -56,6 +56,8 @@ enum location_accuracy {
 	LOCATION_ACCURACY_LOW,
 	/** Normal accuracy. */
 	LOCATION_ACCURACY_NORMAL,
+	/** Try to improve accuracy. Increases power consumption. */
+	LOCATION_ACCURACY_HIGH,
 };
 
 /** Location service. */
@@ -145,8 +147,24 @@ struct location_gnss_config {
 	 */
 	uint16_t timeout;
 
-	/** Desired accuracy level. */
+	/** @brief Desired accuracy level.
+	 *
+	 * @details If accuracy is set to LOCATION_ACCURACY_LOW, GNSS relaxes the
+	 * criteria for a qualifying fix and may produce fixes using only three satellites.
+	 *
+	 * If accuracy is set to LOCATION_ACCURACY_HIGH, instead of using the first fix, GNSS is
+	 * allowed to run for a longer time. This typically improves the location accuracy.
+	 */
 	enum location_accuracy accuracy;
+
+	/**
+	 * @brief The number of fixes GNSS is allowed to produce before the library outputs the
+	 * current location when accuracy is set to LOCATION_ACCURACY_HIGH.
+	 *
+	 * @details If accuracy is set to LOCATION_ACCURACY_NORMAL or LOCATION_ACCURACY_LOW this
+	 * parameter has no effect.
+	 */
+	uint8_t num_consecutive_fixes;
 };
 
 /** LTE cellular positioning configuration. */

--- a/lib/location/location.c
+++ b/lib/location/location.c
@@ -128,6 +128,7 @@ static void location_config_method_defaults_set(
 	if (method_type == LOCATION_METHOD_GNSS) {
 		method->gnss.timeout = 120;
 		method->gnss.accuracy = LOCATION_ACCURACY_NORMAL;
+		method->gnss.num_consecutive_fixes = 3;
 	} else if (method_type == LOCATION_METHOD_CELLULAR) {
 		method->cellular.timeout = 30;
 		method->cellular.service = LOCATION_SERVICE_ANY;

--- a/lib/location/location_core.c
+++ b/lib/location/location_core.c
@@ -135,6 +135,7 @@ static const struct location_method_api *location_method_api_get(enum location_m
 
 static const char LOCATION_ACCURACY_LOW_STR[] = "low";
 static const char LOCATION_ACCURACY_NORMAL_STR[] = "normal";
+static const char LOCATION_ACCURACY_HIGH_STR[] = "high";
 
 static const char *location_core_gnss_accuracy_str(enum location_accuracy accuracy)
 {
@@ -146,6 +147,9 @@ static const char *location_core_gnss_accuracy_str(enum location_accuracy accura
 		break;
 	case LOCATION_ACCURACY_NORMAL:
 		accuracy_str = LOCATION_ACCURACY_NORMAL_STR;
+		break;
+	case LOCATION_ACCURACY_HIGH:
+		accuracy_str = LOCATION_ACCURACY_HIGH_STR;
 		break;
 	default:
 		__ASSERT_NO_MSG(0);

--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -92,6 +92,8 @@ static struct k_work method_gnss_agps_ext_work;
 static void method_gnss_agps_ext_work_fn(struct k_work *item);
 #endif
 
+static int fixes_remaining;
+
 #if defined(CONFIG_NRF_CLOUD_PGPS)
 static void method_gnss_manage_pgps(struct k_work *work)
 {
@@ -582,6 +584,8 @@ static void method_gnss_pvt_work_fn(struct k_work *item)
 	 * in memory and it is not overwritten in case we get an invalid fix.
 	 */
 	if (pvt_data.flags & NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID) {
+		fixes_remaining--;
+
 		location_result.method = LOCATION_METHOD_GNSS;
 		location_result.latitude = pvt_data.latitude;
 		location_result.longitude = pvt_data.longitude;
@@ -595,9 +599,11 @@ static void method_gnss_pvt_work_fn(struct k_work *item)
 		location_result.datetime.second = pvt_data.datetime.seconds;
 		location_result.datetime.ms = pvt_data.datetime.ms;
 
-		/* We are done, stop GNSS and publish the fix. */
-		method_gnss_cancel();
-		location_core_event_cb(&location_result);
+		if (fixes_remaining <= 0) {
+			/* We are done, stop GNSS and publish the fix. */
+			method_gnss_cancel();
+			location_core_event_cb(&location_result);
+		}
 	}
 }
 
@@ -626,21 +632,26 @@ static void method_gnss_positioning_work_fn(struct k_work *work)
 #if defined(CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK)
 	err |= nrf_modem_gnss_elevation_threshold_set(CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK);
 #endif
+	/* By default we take the first fix. */
+	fixes_remaining = 1;
 
-	uint8_t use_case;
+	uint8_t use_case = NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START;
 
 	switch (gnss_config.accuracy) {
 	case LOCATION_ACCURACY_LOW:
-		use_case = NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START |
-			   NRF_MODEM_GNSS_USE_CASE_LOW_ACCURACY;
-		err |= nrf_modem_gnss_use_case_set(use_case);
+		use_case |= NRF_MODEM_GNSS_USE_CASE_LOW_ACCURACY;
 		break;
 
 	case LOCATION_ACCURACY_NORMAL:
-		use_case = NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START;
-		err |= nrf_modem_gnss_use_case_set(use_case);
+		break;
+
+	case LOCATION_ACCURACY_HIGH:
+		/* In high accuracy mode, use the configured fix count. */
+		fixes_remaining = gnss_config.num_consecutive_fixes;
 		break;
 	}
+
+	err |= nrf_modem_gnss_use_case_set(use_case);
 
 	if (err) {
 		LOG_ERR("Failed to configure GNSS");

--- a/samples/nrf9160/location/src/main.c
+++ b/samples/nrf9160/location/src/main.c
@@ -160,6 +160,29 @@ static void location_gnss_low_accuracy_get(void)
 	location_event_wait();
 }
 
+/**
+ * @brief Retrieve location with GNSS high accuracy.
+ */
+static void location_gnss_high_accuracy_get(void)
+{
+	int err;
+	struct location_config config;
+	enum location_method methods[] = {LOCATION_METHOD_GNSS};
+
+	location_config_defaults_set(&config, sizeof(methods), methods);
+	config.methods[0].gnss.accuracy = LOCATION_ACCURACY_HIGH;
+
+	printk("Requesting high accuracy GNSS location...\n");
+
+	err = location_request(&config);
+	if (err) {
+		printk("Requesting location failed, error: %d\n", err);
+		return;
+	}
+
+	location_event_wait();
+}
+
 #if defined(CONFIG_LOCATION_METHOD_WIFI)
 /**
  * @brief Retrieve location with Wi-Fi positioning as first priority, GNSS as second
@@ -259,6 +282,8 @@ int main(void)
 	location_default_get();
 
 	location_gnss_low_accuracy_get();
+
+	location_gnss_high_accuracy_get();
 
 #if defined(CONFIG_LOCATION_METHOD_WIFI)
 	location_wifi_get();


### PR DESCRIPTION
Added support for GNSS high accuracy fixes. In high accuracy mode, GNSS is allowed to produce several fixes before the library outputs the location. This typically improves location accuracy, at the expense of increased power consumption.

Added a new test example to the Location sample and support for GNSS high accuracy to modem_shell "location" command.