### PR TITLE
applications: asset_tracker_v2: improve P-GPS support

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -73,11 +73,13 @@ nRF9160: Asset Tracker v2
 * Added new documentation for Asset Tracker v2 :ref:`asset_tracker_v2_modem_module`.
 * Added support for A-GPS filtered ephemerides.
 * Added new documentation for :ref:`asset_tracker_v2_util_module` and :ref:`api_modules_common`.
+* Updated support for P-GPS preemptive updates and P-GPS coexistence with A-GPS.
 
 nRF9160: Asset Tracker
 ----------------------
 
-* The application is removed.Hence, it is recommended to upgrade to the :ref:`asset_tracker_v2_modem_module` application.
+* The application is removed.
+  Hence, it is recommended to upgrade to the :ref:`asset_tracker_v2` application.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
Add missing handling of preemptive updates after injecting data.

Add missing request for prediction notifications when A-GPS download is in progress.

Add missing request for prediction notifications when A-GPS download is processed correctly.

Make A-GPS work along with P-GPS if both enabled.  A-GPS is be used for everything but ephemeris data, while P-GPS is used for only that.

Jira: CIA-460

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>