### PR TITLE
doc: Added links to RST files in header files

### DIFF
--- a/include/app_event_manager.h
+++ b/include/app_event_manager.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/others/app_event_manager.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/app_event_manager.html.
+ */
+
 /** @file
  * @brief Application Event Manager header.
  */

--- a/include/app_event_manager_profiler_tracer.h
+++ b/include/app_event_manager_profiler_tracer.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/others/app_event_manager_profiler_tracer.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/app_event_manager_profiler_tracer.html.
+ */
+
 /** @file
  * @brief Application Event Manager profiler tracer header.
  */

--- a/include/bl_crypto.h
+++ b/include/bl_crypto.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/bootloader/bl_crypto.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bootloader/bl_crypto.html.
+ */
+
 #ifndef BOOTLOADER_CRYPTO_H__
 #define BOOTLOADER_CRYPTO_H__
 

--- a/include/bl_storage.h
+++ b/include/bl_storage.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/bootloader/bl_storage.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bootloader/bl_storage.html.
+ */
+
 #ifndef BL_STORAGE_H_
 #define BL_STORAGE_H_
 

--- a/include/bl_validation.h
+++ b/include/bl_validation.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/bootloader/bl_validation.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bootloader/bl_validation.html.
+ */
+
 #ifndef BL_VALIDATION_H__
 #define BL_VALIDATION_H__
 

--- a/include/date_time.h
+++ b/include/date_time.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/date_time.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/date_time.html.
+ */
+
 #ifndef DATE_TIME_H__
 #define DATE_TIME_H__
 

--- a/include/dk_buttons_and_leds.h
+++ b/include/dk_buttons_and_leds.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/dk_buttons_and_leds.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/dk_buttons_and_leds.html.
+ */
+
 #ifndef DK_BUTTON_AND_LEDS_H__
 #define DK_BUTTON_AND_LEDS_H__
 

--- a/include/dm.h
+++ b/include/dm.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/dm.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/dm.html.
+ */
+
 #ifndef DM_H_
 #define DM_H_
 

--- a/include/ei_wrapper.h
+++ b/include/ei_wrapper.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/ei_wrapper.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/ei_wrapper.html.
+ */
+
 /** @file
  * @brief Edge Impulse wrapper header.
  */

--- a/include/esb.h
+++ b/include/esb.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/esb.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/esb.html.
+ */
+
 #ifndef __ESB_H
 #define __ESB_H
 

--- a/include/event_manager_proxy.h
+++ b/include/event_manager_proxy.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/others/event_manager_proxy.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/event_manager_proxy.html.
+ */
+
 /**
  * @file
  * @brief Event manager proxy header.

--- a/include/fprotect.h
+++ b/include/fprotect.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/fprotect.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/fprotect.html.
+ */
+
 #ifndef FPROTECT_H_
 #define FPROTECT_H_
 

--- a/include/fw_info.h
+++ b/include/fw_info.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/fw_info.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/fw_info.html.
+ */
+
 #ifndef FW_INFO_H__
 #define FW_INFO_H__
 

--- a/include/gzll_glue.h
+++ b/include/gzll_glue.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/gazell/gzll_glue.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/gazell/gzll_glue.html.
+ */
+
 #ifndef __GZLL_GLUE_H
 #define __GZLL_GLUE_H
 

--- a/include/gzp.h
+++ b/include/gzp.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/gazell/gzp.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/gazell/gzp.html.
+ */
+
 /**
  * @file
  * @brief Gazell Pairing API

--- a/include/hw_unique_key.h
+++ b/include/hw_unique_key.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/hw_unique_key.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/hw_unique_key.html.
+ */
+
 #ifndef HW_UNIQUE_KEY_H_
 #define HW_UNIQUE_KEY_H_
 

--- a/include/memfault_ncs.h
+++ b/include/memfault_ncs.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/memfault_ncs.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/memfault_ncs.html.
+ */
+
 /** @file
  *  @brief Memfault NCS integration
  */

--- a/include/qos.h
+++ b/include/qos.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/qos.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/qos.html.
+ */
+
 /**
  * @defgroup qos Quality of Service library
  * @{

--- a/include/ram_pwrdn.h
+++ b/include/ram_pwrdn.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/ram_pwrdn.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/ram_pwrdn.html.
+ */
+
 /** @file
  * @brief RAM section power down header.
  */

--- a/include/secure_services.h
+++ b/include/secure_services.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/secure_services.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/secure_services.html.
+ */
+
 /** @file
  * @brief Secure Services header.
  */

--- a/include/spm.h
+++ b/include/spm.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/spm.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/spm.html.
+ */
+
 /** @file
  * @brief Secure Partition Manager header.
  */

--- a/include/st25r3911b_nfca.h
+++ b/include/st25r3911b_nfca.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/st25r3911b_nfc.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/st25r3911b_nfc.html.
+ */
+
 #ifndef ST25R3911B_NFCA_H_
 #define ST25R3911B_NFCA_H_
 

--- a/include/supl_os_client.h
+++ b/include/supl_os_client.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/supl_os_client.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/supl_os_client.html.
+ */
+
 #ifndef SUPL_OS_CLIENT_H_
 #define SUPL_OS_CLIENT_H_
 

--- a/include/wave_gen.h
+++ b/include/wave_gen.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/others/wave_gen.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/wave_gen.html.
+ */
+
 /** @file
  * @brief Wave generator header.
  */


### PR DESCRIPTION
Provided comments in the header files about the location of corresponding RST files
 and rendered documentation for the particular library.

Ref: NCSDK-11624

Signed-off-by: Richa Pandey <richa.pandey@nordicsemi.no>