### PR TITLE
lib: fota_download, dfu_target: Support (only) explicit dual-binary FOTA paths

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -244,7 +244,10 @@ Bootloader libraries
 Libraries for networking
 ------------------------
 * :ref:`lib_fota_download` library:
+
   * Skipping host name check when connecting to TLS service using just IP address.
+  * Bootloader FOTA download standardized to accept only full dual path names (for example "path/to/s0.bin path/to/s1.bin").
+    Truncated dual path names ("path/to/s0.bin s1.bin") no longer supported.
 
 Modem libraries
 ---------------

--- a/include/dfu/dfu_target_mcuboot.h
+++ b/include/dfu/dfu_target_mcuboot.h
@@ -29,18 +29,18 @@ extern "C" {
  * This function is told what slot is active, and sets the update pointer to
  * point to the correct none active entry in the file path.
  *
- * @param[in, out] file      pointer to file path with space separator. Note
- *                           that the space separator can be replaced by a NULL
- *                           terminator.
- * @param[in]      s0_active bool indicating if S0 is the currently active slot.
- * @param[out]     update    pointer to correct file MCUBoot bootloader upgrade.
- *                           Will be set to NULL if no space separator is found.
+ * @param[in, out] file          pointer to file path with space separator. Note
+ *                               that the space separator will be replaced by a
+ *                               NULL terminator.
+ * @param[in]      s0_active     bool indicating if S0 is the currently active slot.
+ * @param[out]     selected_path pointer to correct file MCUBoot bootloader upgrade.
+ *                               Will be set to NULL if no space separator is found.
  *
  * @retval 0 If successful (note that this does not imply that a space
  *           separator was found) negative errno otherwise.
  */
-int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active,
-				const char **update);
+int dfu_ctx_mcuboot_set_b1_file(char * const file, bool s0_active,
+				const char **selected_path);
 
 /**
  * @brief Set buffer to use for flash write operations.

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -97,7 +97,17 @@ int fota_download_init(fota_download_callback_t client_callback);
  *
  * @param host Name of host to start downloading from. Can include scheme
  *             and port number, e.g. https://google.com:443
- * @param file Filepath to the file you wish to download.
+ * @param file Filepath to the file you wish to download. May be either a single
+ *              file path, relative to host (for example "path/to/binary.bin"),
+ *              or, if bootloader FOTA is enabled, can be two paths (both relative
+ *              to host), separated by a space (for example "path/to/s0.bin path/to/s1.bin").
+ *              If two paths are provided, the download will be assumed to be a bootloader
+ *              download, both paths will be treated as upgradable bootloader slot 0
+ *              and slot 1 binaries respectively, and only the binary corresponding to
+ *              the currently inactive bootloader slot will be selected and downloaded.
+ *              See <a href="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_bootloader.html">
+ *              Secure Bootloader Chain Docs</a> for details regarding the upgradable
+ *              bootloader slots.
  * @param sec_tag Security tag you want to use with HTTPS set to -1 to Disable.
  * @param pdn_id Packet Data Network ID to use for the download, or 0 to use the default.
  * @param fragment_size Fragment size to be used for the download.
@@ -117,8 +127,9 @@ int fota_download_start(const char *host, const char *file, int sec_tag,
  * valid firmware inside it. The completion is reported through an event.
  *
  * @param host Name of host to start downloading from. Can include scheme
- *             and port number, e.g. https://google.com:443
- * @param file Filepath to the file you wish to download.
+ *             and port number, for example https://google.com:443
+ * @param file Filepath to the file you wish to download. See fota_download_start()
+ *             for details on expected format.
  * @param sec_tag Security tag you want to use with HTTPS set to -1 to Disable.
  * @param pdn_id Packet Data Network ID to use for the download, or 0 to use the default.
  * @param fragment_size Fragment size to be used for the download.

--- a/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
@@ -37,10 +37,10 @@ static uint8_t *stream_buf;
 static size_t stream_buf_len;
 static size_t stream_buf_bytes;
 
-int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active,
-				const char **update)
+int dfu_ctx_mcuboot_set_b1_file(char *const file, bool s0_active,
+				const char **selected_path)
 {
-	if (file == NULL || update == NULL) {
+	if (file == NULL || selected_path == NULL) {
 		LOG_ERR("Got NULL pointer");
 		return -EINVAL;
 	}
@@ -61,29 +61,16 @@ int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active,
 
 	if (delimiter == NULL) {
 		/* Could not find delimiter in input */
-		*update = NULL;
-
+		*selected_path = NULL;
 		return 0;
 	}
 
-	*update = file;
-	if (s0_active) {
-		char *tmp = strrchr(file, '/');
+	/* Insert null-terminator to split the dual filepath into two separate filepaths */
+	*delimiter = '\0';
+	const char *s0_path = file;
+	const char *s1_path = delimiter + 1;
 
-		if (tmp == NULL) {
-			/* Point after delimiter to 'activate' second file path (S1) */
-			*update = delimiter + 1;
-		} else {
-			/* Copy after delimiter to 'activate' second file path (S1)
-			 * Copy one byte more to include the ending '\0' in original string
-			 */
-			memcpy(tmp + 1, delimiter + 1, strlen(delimiter));
-		}
-	} else {
-		/* Insert null-terminator to 'activate' first file path (S0) */
-		*delimiter = '\0';
-	}
-
+	*selected_path = s0_active ? s1_path : s0_path;
 	return 0;
 }
 

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -125,10 +125,11 @@ int download_client_connect(struct download_client *client, const char *host,
 	return 0;
 }
 
-int dfu_ctx_mcuboot_set_b1_file(char *file, bool s0_active, char **update)
+int dfu_ctx_mcuboot_set_b1_file(char * const file, bool s0_active,
+				const char **selected_path)
 {
 	dfu_ctx_mcuboot_set_b1_file__s0_active = s0_active;
-	*update = dfu_ctx_mcuboot_set_b1_file__update;
+	*selected_path = dfu_ctx_mcuboot_set_b1_file__update;
 	return 0;
 }
 


### PR DESCRIPTION
Altered dfu_ctx_mcuboot_set_b1_file within dfu_target_mcuboot to accept
(and only accept) dual path strings in the form "path/to/s0.bin
path/to/s1.bin" rather than in the form "path/to/s0.bin s1.bin".

While this function is within dfu_target, the forward-facing functions
it primarily affects are in fota_download. Added documentation to these
functions describing the correct format for a dual path string, and the
conditions under which they should be used.

Noted these changes in changelog.

Also changed file argument in dfu_ctx_mcuboot_set_b1_file to be a const
pointer to mutable cstring (rather than mutable pointer to const
cstring), since this function (even before this commit) freely modifies
the string passed to it.

Also renamed update argument to selected_path argument for clarity.

IRIS-3727

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>