### PR TITLE
applications: nrf_desktop: Do not broadcast kbd LEDs on read

### DIFF
--- a/applications/nrf_desktop/src/modules/hids.c
+++ b/applications/nrf_desktop/src/modules/hids.c
@@ -216,6 +216,11 @@ static void consumer_ctrl_notif_handler(enum bt_hids_notify_evt evt)
 
 static void broadcast_kbd_leds_report(struct bt_hids_rep *rep, struct bt_conn *conn, bool write)
 {
+	/* Ignore HID keyboard LEDs report read. */
+	if (!write) {
+		return;
+	}
+
 	struct hid_report_event *event = new_hid_report_event(rep->size + 1);
 
 	event->source = conn;


### PR DESCRIPTION
There is no need to broadcast HID keyboard LED state on HID report read. In that case the state does not change.