### PR TITLE
doc: updating the copyright in conf.py files

### DIFF
--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -16,7 +16,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 # General configuration --------------------------------------------------------
 
 project = "Kconfig reference"
-copyright = "2019-2021, Nordic Semiconductor"
+copyright = "2019-2022, Nordic Semiconductor"
 author = "Nordic Semiconductor"
 # NOTE: use blank space as version to preserve space
 version = "&nbsp;"

--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -17,7 +17,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 # General configuration --------------------------------------------------------
 
 project = "MCUboot"
-copyright = "2019-2021"
+copyright = "2019-2022, Nordic Semiconductor"
 version = release = "1.7.99"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -17,7 +17,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 # General configuration --------------------------------------------------------
 
 project = "nRF Connect SDK"
-copyright = "2019-2021, Nordic Semiconductor"
+copyright = "2019-2022, Nordic Semiconductor"
 author = "Nordic Semiconductor"
 version = release = "1.8.99"
 

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -19,7 +19,7 @@ NRFXLIB_BASE = utils.get_projdir("nrfxlib")
 # General configuration --------------------------------------------------------
 
 project = "nrfxlib"
-copyright = "2019-2021, Nordic Semiconductor"
+copyright = "2019-2022, Nordic Semiconductor"
 author = "Nordic Semiconductor"
 version = release = "1.8.99"
 


### PR DESCRIPTION
Updated the copyright line to 2019-2022 in the
conf.py files of nrf, nrfxlib, kconfig and mcuboot.

Ref: NCSDK-13404

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>