### PR TITLE
zigbee: osif: Fix checks in NVRAM read routines

### DIFF
--- a/subsys/zigbee/osif/zb_nrf_nvram.c
+++ b/subsys/zigbee/osif/zb_nrf_nvram.c
@@ -73,7 +73,7 @@ zb_ret_t zb_osif_nvram_read(zb_uint8_t page, zb_uint32_t pos, zb_uint8_t *buf,
 		return RET_PAGE_NOT_FOUND;
 	}
 
-	if (pos + len >= zb_get_nvram_page_length()) {
+	if (pos + len > zb_get_nvram_page_length()) {
 		return RET_INVALID_PARAMETER;
 	}
 


### PR DESCRIPTION
It is allowed to read the whole page (including the last byte), so the comparison should not fail in case of the last read on the  NVRAM page.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>