### PR TITLE
lib: fota_download: fixed fota update fail after link timeout

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -284,7 +284,8 @@ Libraries for networking
 * :ref:`lib_fota_download` library:
 
   * Fixed an issue where the application would not be notified of errors originating from inside :c:func:`download_with_offset`. In the http_update samples, this would result in the dfu start button interrupt being disabled after a connect error in :c:func:`download_with_offset` after a disconnect during firmware download.
-
+  * Fixed an issue that :ref:`lib_fota_download`, after a link-connection timeout, restarted the firmware image download from an incorrect offset.
+    This resulted in an invalid image and required a restart of the firmware update process.
 * :ref:`lib_dfu_target` library:
 
   * Updated the implementation of modem delta upgrades in the DFU target library to use the new socketless interface provided by the :ref:`nrf_modem`.


### PR DESCRIPTION
fota_download would in some cases fail to restart the download from
the right offset after a link connection timeout. This would result
in an invalid image, and the whole fota update would have to be
restarted.

Reason for failure:
When an amount of data that is not a multiple of
CONFIG_FOTA_DOWNLOAD_MCUBOOT_FLASH_BUF_SZ is written with
stream_flash_buffered_write() this leaves data in the stream flash buffer
between calls.
Stream_flash_bytes_written() only reports number of bytes written to
flash (in multiples of CONFIG_FOTA_DOWNLOAD_MCUBOOT_FLASH_BUF_SZ) and
does not account for bytes written to the internal stream flash buffer.

When fota_download uses dfu_target_mcuboot_offset_get() to get download offset
for download_client, it can result in a series of bytes being duplicated
and consecutive bytes being offseted in flash. Resulting in a wrong firmware
image.

Fix:
In dfu_target_mcuboot, keep a counter of bytes in the stream flash buffer in
order to correct the offset returned by dfu_target_mcuboot_offset_get().

NCSDK-12930

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>