### PR TITLE
applications: asset_tracker_v2: Request GNSS after A-GPS is processed

### DIFF
--- a/applications/asset_tracker_v2/src/events/app_module_event.c
+++ b/applications/asset_tracker_v2/src/events/app_module_event.c
@@ -41,6 +41,8 @@ static char *get_evt_type_str(enum app_module_event_type type)
 		return "APP_EVT_ACTIVITY_DETECTION_ENABLE";
 	case APP_EVT_ACTIVITY_DETECTION_DISABLE:
 		return "APP_EVT_ACTIVITY_DETECTION_DISABLE";
+	case APP_EVT_AGPS_NEEDED:
+		return "APP_EVT_AGPS_NEEDED";
 	case APP_EVT_DATA_GET_ALL:
 		return "APP_EVT_DATA_GET_ALL";
 	case APP_EVT_START:

--- a/applications/asset_tracker_v2/src/events/app_module_event.h
+++ b/applications/asset_tracker_v2/src/events/app_module_event.h
@@ -58,6 +58,9 @@ enum app_module_event_type {
 	 */
 	APP_EVT_ACTIVITY_DETECTION_DISABLE,
 
+	/** The application module needs A-GPS to be processed before it requests GNSS. */
+	APP_EVT_AGPS_NEEDED,
+
 	/** The application module has performed all procedures to prepare for
 	 *  a shutdown of the system.
 	 */

--- a/applications/asset_tracker_v2/src/modules/Kconfig.app_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.app_module
@@ -10,6 +10,25 @@ config APP_REQUEST_GNSS_ON_INITIAL_SAMPLING
 	bool "Request GNSS on initial data sampling after connection"
 	default y if GNSS_MODULE
 
+config APP_REQUEST_GNSS_WAIT_FOR_AGPS
+	bool "Wait for A-GPS data before requesting sampling of GNSS data"
+	default y
+	select DATA_AGPS_REQUEST_ALL_UPON_CONNECTION
+	depends on NRF_CLOUD_AGPS || NRF_CLOUD_PGPS
+	help
+	  If this option is enabled, the application module will wait a configured amount of
+	  seconds set by APP_REQUEST_GNSS_WAIT_FOR_AGPS_THRESHOLD_SEC before requesting GNSS data,
+	  unless A-GPS data has been processed.
+
+config APP_REQUEST_GNSS_WAIT_FOR_AGPS_THRESHOLD_SEC
+	int "Number of seconds to wait for A-GPS data"
+	default 300
+	range -1 2147483647
+	help
+	  Number of seconds that the application module will wait for A-GPS data to be processed
+	  before requesting GNSS data. If set to -1, the application module will wait
+	  until A-GPS data has been processed.
+
 config APP_REQUEST_NEIGHBOR_CELLS_DATA
 	bool "Request neighbor cells data"
 	depends on AWS_IOT || NRF_CLOUD_MQTT || AZURE_IOT_HUB

--- a/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
@@ -17,7 +17,7 @@ CLOUD_SERVICE_SELECTOR := choice
 # A-GPS takes precedence if both A-GPS and P-GPS are enabled at the same time. Therefore, A-GPS is
 # disabled when enabling P-GPS.
 config NRF_CLOUD_AGPS
-	default y if !NRF_CLOUD_PGPS
+	default y
 
 # Enable MQTT clean session by default. This is to ensure that the configured cloud MQTT service
 # client library always subscribes to the necessary topics.

--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -11,6 +11,10 @@ menuconfig DATA_MODULE
 
 if DATA_MODULE
 
+config DATA_AGPS_REQUEST_ALL_UPON_CONNECTION
+	bool "Request all A-GPS data upon a connection"
+	depends on NRF_CLOUD_AGPS || NRF_CLOUD_PGPS
+
 config PENDING_DATA_COUNT
 	int "Number of entries in pending data list"
 	default 10

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -83,6 +83,7 @@ nRF9160: Asset Tracker v2
 * Added support for A-GPS filtered ephemerides.
 * Added new documentation for :ref:`asset_tracker_v2_util_module` and :ref:`api_modules_common`.
 * Updated support for P-GPS preemptive updates and P-GPS coexistence with A-GPS.
+* Added functionality that allows the application to wait for A-GPS data to be processed before starting GNSS positioning.
 
 nRF9160: Asset Tracker
 ----------------------


### PR DESCRIPTION
Add functionality that allows the user to specify a time after boot
that the application will wait for A-GPS to be processed before GNSS
is requested. This includes:

- `CONFIG_APP_REQUEST_GNSS_WAIT_FOR_AGPS` option to enable/disable
   this feature.

- `CONFIG_APP_REQUEST_GNSS_WAIT_FOR_AGPS_THRESHOLD_SEC` option to
   specify the aforementioned timeout.

- Add auto-requesting of all A-GPS data types upon a connection if
  `CONFIG_APP_REQUEST_GNSS_WAIT_FOR_AGPS` is enabled.

Fixes CIA-506, CIA-507