### PR TITLE
doc: Added links to RST files in bluetooth header files

### DIFF
--- a/include/bluetooth/adv_prov.h
+++ b/include/bluetooth/adv_prov.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/bluetooth_services/adv_prov.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/adv_prov.html.
+ */
+
 /** @file
  * @brief Bluetooth LE advertising providers subsystem header.
  */

--- a/include/bluetooth/conn_ctx.h
+++ b/include/bluetooth/conn_ctx.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/bluetooth_services/conn_ctx.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/conn_ctx.html.
+ */
+
 /**
  * @file
  * @defgroup bt_conn_ctx Bluetooth connection context library API

--- a/include/bluetooth/enocean.h
+++ b/include/bluetooth/enocean.h
@@ -3,6 +3,12 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/bluetooth_services/enocean.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/enocean.html.
+ */
+
 /**
  * @file
  * @defgroup bt_enocean Bluetooth EnOcean library API

--- a/include/bluetooth/gatt_dm.h
+++ b/include/bluetooth/gatt_dm.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/bluetooth_services/gatt_dm.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/gatt_dm.html.
+ */
+
 #ifndef BT_GATT_DM_H_
 #define BT_GATT_DM_H_
 

--- a/include/bluetooth/gatt_pool.h
+++ b/include/bluetooth/gatt_pool.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/bluetooth_services/gatt_pool.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/gatt_pool.html.
+ */
+
 #ifndef BT_GATT_POOL_
 #define BT_GATT_POOL_
 

--- a/include/bluetooth/scan.h
+++ b/include/bluetooth/scan.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/bluetooth_services/scan.rst.
+ * Rendered documentation is available at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/scan.html.
+ */
+
 /**@file
  * @defgroup nrf_bt_scan BT Scanning module
  * @{

--- a/include/bluetooth/services/ams_client.h
+++ b/include/bluetooth/services/ams_client.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/ams_client.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/ams_client.html.
+ */
+
 #ifndef BT_AMS_CLIENT_H_
 #define BT_AMS_CLIENT_H_
 

--- a/include/bluetooth/services/ancs_client.h
+++ b/include/bluetooth/services/ancs_client.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/ancs_client.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/ancs_client.html.
+ */
+
 #ifndef BT_ANCS_CLIENT_H_
 #define BT_ANCS_CLIENT_H_
 

--- a/include/bluetooth/services/bas_client.h
+++ b/include/bluetooth/services/bas_client.h
@@ -3,6 +3,14 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/bas_client.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/bas_client.html.
+ */
+
 #ifndef __BAS_C_H
 #define __BAS_C_H
 

--- a/include/bluetooth/services/bms.h
+++ b/include/bluetooth/services/bms.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/bms.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/bms.html.
+ */
+
 #ifndef BT_BMS_H_
 #define BT_BMS_H_
 

--- a/include/bluetooth/services/cgms.h
+++ b/include/bluetooth/services/cgms.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/cgms.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/cgms.html.
+ */
+
 #ifndef BT_CGMS_H_
 #define BT_CGMS_H_
 

--- a/include/bluetooth/services/cts_client.h
+++ b/include/bluetooth/services/cts_client.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/cts_client.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/cts_client.html.
+ */
+
 #ifndef BT_CTS_CLIENT_H_
 #define BT_CTS_CLIENT_H_
 

--- a/include/bluetooth/services/ddfs.h
+++ b/include/bluetooth/services/ddfs.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/ddfs.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/ddfs.html.
+ */
+
 #ifndef BT_DDFS_H_
 #define BT_DDFS_H_
 

--- a/include/bluetooth/services/dfu_smp.h
+++ b/include/bluetooth/services/dfu_smp.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/dfu_smp.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/dfu_smp.html.
+ */
+
 #ifndef BT_DFU_SMP_H_
 #define BT_DFU_SMP_H_
 

--- a/include/bluetooth/services/fast_pair.h
+++ b/include/bluetooth/services/fast_pair.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/fast_pair.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/fast_pair.html.
+ */
+
 #ifndef BT_FAST_PAIR_H_
 #define BT_FAST_PAIR_H_
 

--- a/include/bluetooth/services/gattp.h
+++ b/include/bluetooth/services/gattp.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/gattp.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/gattp.html.
+ */
+
 #ifndef BT_GATTP_H_
 #define BT_GATTP_H_
 

--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/hids.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/hids.html.
+ */
+
 #ifndef BT_HIDS_H_
 #define BT_HIDS_H_
 

--- a/include/bluetooth/services/hogp.h
+++ b/include/bluetooth/services/hogp.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/hogp.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/hogp.html.
+ */
+
 #ifndef BT_HOGP_H_
 #define BT_HOGP_H_
 

--- a/include/bluetooth/services/hrs_client.h
+++ b/include/bluetooth/services/hrs_client.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/hrs_client.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/hrs_client.html.
+ */
+
 #ifndef BT_HRS_CLIENT_H_
 #define BT_HRS_CLIENT_H_
 

--- a/include/bluetooth/services/latency.h
+++ b/include/bluetooth/services/latency.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/latency.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/latency.html.
+ */
+
 /**
  * @file
  * @defgroup bt_latency Bluetooth LE GATT Latency Service API

--- a/include/bluetooth/services/latency_client.h
+++ b/include/bluetooth/services/latency_client.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/latency_client.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/latency_client.html.
+ */
+
 /**
  * @file
  * @defgroup bt_latency_c Bluetooth LE GATT Latency Client API

--- a/include/bluetooth/services/lbs.h
+++ b/include/bluetooth/services/lbs.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/lbs.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/lbs.html.
+ */
+
 #ifndef BT_LBS_H_
 #define BT_LBS_H_
 

--- a/include/bluetooth/services/mds.h
+++ b/include/bluetooth/services/mds.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/mds.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/mds.html.
+ */
+
 #ifndef MDS_H_
 #define MDS_H_
 

--- a/include/bluetooth/services/nus.h
+++ b/include/bluetooth/services/nus.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/nus.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/nus.html.
+ */
+
 #ifndef BT_NUS_H_
 #define BT_NUS_H_
 

--- a/include/bluetooth/services/nus_client.h
+++ b/include/bluetooth/services/nus_client.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/nus_client.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/nus_client.html.
+ */
+
 #ifndef BT_NUS_CLIENT_H_
 #define BT_NUS_CLIENT_H_
 

--- a/include/bluetooth/services/rscs.h
+++ b/include/bluetooth/services/rscs.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/rscs.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/rscs.html.
+ */
+
 #ifndef BT_RSCS_H_
 #define BT_RSCS_H_
 

--- a/include/bluetooth/services/throughput.h
+++ b/include/bluetooth/services/throughput.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/bluetooth_services/services/throughput.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/services/throughput.html.
+ */
+
 /**
  * @file
  * @defgroup bt_throughput Bluetooth LE GATT Throughput Service API


### PR DESCRIPTION
Provided comments in the include/bluetooth/services/ header files
about the location of corresponding RST files and
rendered documentation for the particular library.

Ref: NCSDK-11624

Signed-off-by: Richa Pandey <richa.pandey@nordicsemi.no>