### PR TITLE
tfm: Fix regression test issues for TF-M

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -78,6 +78,8 @@ config PM_PARTITION_SIZE_TFM
 	hex
 	prompt  "Memory reserved for TFM" if !TFM_MINIMAL
 	default 0x10000 if TFM_MINIMAL
+	# NCSDK-13503: Temporarily bump size while regressions are being fixed
+	default 0x60000 if TFM_REGRESSION_S
 	default 0x40000
 	help
 	  Memory set aside for the TFM partition. This size is fixed if

--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 943bf88606f0df8b705e38182c10a8cf959dba45
+      revision: de528be2629da8ddbc10c865d037776131107eb3
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Fix issues discovered by TF-M regression test suite.

Increase the default TF-M flash size when the secure regression test
suite has been enabled.

Update nrf_security with TF-M fixes discovered by the regression tests.
 - Disable SHA-1 with TF-M as secure-image.
 - Add workaround for hash verify with Oberon not supporting key pair.