### PR TITLE
doc: remove DODGY flag from Zephyr and nrfx docsets

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -211,7 +211,7 @@ add_custom_target(
   USES_TERMINAL
 )
 
-add_docset(zephyr DODGY)
+add_docset(zephyr)
 add_dependencies(zephyr-html zephyr-devicetree)
 add_dependencies(zephyr-html-all zephyr-devicetree)
 
@@ -271,7 +271,7 @@ add_docset(mcuboot)
 #-------------------------------------------------------------------------------
 # docset: nrfx
 
-add_docset(nrfx DODGY)
+add_docset(nrfx)
 
 #-------------------------------------------------------------------------------
 # docset: tfm

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: e0b8c6a30c7831600c52cabf34898e8f9fd03958
+      revision: d0c263747dad8c1878a04ee117ae675945deb3a8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Both docsets can now be built without warnings, so it is safe to remove
the DODGY flag.