### PR TITLE
bluetooth: hci_driver: ext adv reports are not discardable.

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -296,7 +296,6 @@ static bool event_packet_is_discardable(const uint8_t *hci_buf)
 
 		switch (me->subevent) {
 		case BT_HCI_EVT_LE_ADVERTISING_REPORT:
-		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT:
 			return true;
 		default:
 			return false;


### PR DESCRIPTION
Discarding the extended adv reports caused the host not being
able to reassemble the reports properly.

Signed-off-by: Minoo Kargar Bideh <minoo.kargarbideh@nordicsemi.no>