### PR TITLE
codeowners: add tests/lib/ram_pwrdn code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -201,6 +201,7 @@ Kconfig*                                  @tejlmand
 /tests/lib/modem_jwt/                     @SeppoTakalo
 /tests/lib/sms/                           @trantanen @tokangas
 /tests/lib/modem_trace/                   @balaji-nordic
+/tests/lib/ram_pwrdn/                     @Damian-Nordic
 /tests/modules/lib/cddl-gen/              @oyvindronningstad
 /tests/modules/mcuboot/external_flash/    @hakonfam @sigvartmh
 /tests/modules/tfm/                       @hakonfam @SebastianBoe


### PR DESCRIPTION
Add myself as a code owner of the newly added test.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>