### PR TITLE
esb: RADIO interrupt disable added to esb_disable()

### DIFF
--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -1102,7 +1102,8 @@ void esb_disable(void)
 	memset(rx_pipe_info, 0, sizeof(rx_pipe_info));
 	memset(pids, 0, sizeof(pids));
 
-	/*  Disable the radio */
+	/*  Disable the radio and ESB interrupts */
+	irq_disable(RADIO_IRQn);
 	irq_disable(ESB_EVT_IRQ);
 
 	NRF_RADIO->SHORTS =

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -1102,8 +1102,9 @@ void esb_disable(void)
 	memset(rx_pipe_info, 0, sizeof(rx_pipe_info));
 	memset(pids, 0, sizeof(pids));
 
-	/*  Disable the radio and ESB interrupts */
+	/*  Disable the interrupts used by ESB */
 	irq_disable(RADIO_IRQn);
+	irq_disable(ESB_SYS_TIMER_IRQn);
 	irq_disable(ESB_EVT_IRQ);
 
 	NRF_RADIO->SHORTS =


### PR DESCRIPTION
The esb_disable() function disabled the ESB event interrupt, but not
the radio interrupt. This has been added.

Signed-off-by: Torbjørn Øvrebekk <torbjorn.ovrebekk@nordicsemi.no>