### PR TITLE
samples: nrf9160: modem_shell: wifi overlay: more SRAM needed

### DIFF
--- a/samples/nrf9160/modem_shell/overlay-esp-wifi.conf
+++ b/samples/nrf9160/modem_shell/overlay-esp-wifi.conf
@@ -1,6 +1,11 @@
+# Need to disable iper3 worker thread support to have more SRAM
+CONFIG_MOSH_WORKER_THREADS=n
+
+# Extended memory heap size needed for encoding REST messages (including possible long ssid) to JSON
+CONFIG_HEAP_MEM_POOL_SIZE=13312
+
 # ESP 8266 Wi-Fi
 CONFIG_WIFI=y
-CONFIG_WIFI_LOG_LEVEL_DBG=y # optional
 CONFIG_WIFI_OFFLOAD=y
 
 CONFIG_NET_IPV4=y # needed for ESP8266 to compile


### PR DESCRIPTION
Had to disable iperf3 worker threads from wifi-overlay in order to get more SRAM.
Additionally, had to increase CONFIG_HEAP_MEM_POOL_SIZE
that is needed for encoding WiFi positioning REST requests
and there are always possibility to be long ssids which resulted
sometimes out-of-mem failures.
Jira: MOSH-225

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>