### PR TITLE
applications: nrf_desktop: Remove leftover configuration from nrf52833dk_nrf52820

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/child_image/mcuboot/prj_release_mcuboot.conf
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/child_image/mcuboot/prj_release_mcuboot.conf
@@ -8,7 +8,6 @@ CONFIG_SIZE_OPTIMIZATIONS=y
 # Disable memory guard to avoid false faults in application after boot
 CONFIG_HW_STACK_PROTECTION=n
 
-CONFIG_SYSTEM_CLOCK_DISABLE=y
 CONFIG_SYSTEM_CLOCK_NO_WAIT=y
 CONFIG_PM=n
 


### PR DESCRIPTION
Remove CONFIG_SYSTEM_CLOCK_DISABLE from
nrf52833dk_nrf52820 config

Jira: NCSDK-13540

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>