### PR TITLE
lib: nrf_cloud: Handle disconnection request from nRF Cloud

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -310,6 +310,7 @@ Libraries for networking
   * Updated MQTT connection error handling.
     Now, unacknowledged pings and other errors result in a transition to the disconnected state.
     This ensures that reconnection can take place.
+  * nRF Cloud device removal now correctly triggers MQTT disconnection.
 
 * :ref:`lib_nrf_cloud_rest` library:
 

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
@@ -29,9 +29,12 @@ extern "C" {
 #define NRF_CLOUD_JSON_APPID_VAL_AGPS		"AGPS"
 #define NRF_CLOUD_JSON_APPID_VAL_PGPS		"PGPS"
 #define NRF_CLOUD_JSON_APPID_VAL_CELL_POS	"CELL_POS"
+#define NRF_CLOUD_JSON_APPID_VAL_DEVICE		"DEVICE"
 
 #define NRF_CLOUD_JSON_MSG_TYPE_KEY		"messageType"
 #define NRF_CLOUD_JSON_MSG_TYPE_VAL_DATA	"DATA"
+#define NRF_CLOUD_JSON_MSG_TYPE_VAL_DISCONNECT	"DISCON"
+#define NRF_CLOUD_JSON_MSG_MAX_LEN_DISCONNECT   200
 
 #define NRF_CLOUD_JSON_DATA_KEY			"data"
 
@@ -158,6 +161,9 @@ int nrf_cloud_format_single_cell_pos_req_json(cJSON * const req_obj_out);
 /** @brief Parses the cellular positioning response (REST and MQTT) from nRF Cloud. */
 int nrf_cloud_parse_cell_pos_response(const char *const buf,
 				      struct nrf_cloud_cell_pos_result *result);
+
+/** @brief Checks whether the provided MQTT payload is an nRF Cloud disconnection request */
+bool nrf_cloud_detect_disconnection_request(const char *const buf);
 
 /** @brief Obtains a pointer to the string at the specified index in the cJSON array.
  * No memory is allocated, pointer is valid as long as the cJSON array is valid.


### PR DESCRIPTION
nRF Cloud library now triggers nrf_cloud_disconnect() if an MQTT message
from nRF Cloud requesting that the device disconnect is received (for
example, when deleting a device from nRF Cloud portal).

Please note that the disconnection event type will be
NRF_CLOUD_DISCONNECT_USER_REQUEST.

IRIS-3728

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>