### PR TITLE
lib: lte_lc: Increase XMONITOR response buffer

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -855,7 +855,7 @@ int lte_lc_psm_get(int *tau, int *active_time)
 	char active_time_str[9] = {0};
 	char tau_ext_str[9] = {0};
 	char tau_legacy_str[9] = {0};
-	char response[128] = { 0 };
+	char response[160] = { 0 };
 	const char ch = ',';
 	char *comma_ptr;
 


### PR DESCRIPTION
The XMONITOR response buffer is too small if the operator
reports relatively long full name and short name.

This PR increases the buffer size to work around the issue.