### PR TITLE
west.yml: update memfault-firmware-sdk

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
       path: modules/lib/cddl-gen
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 0.27.3
+      revision: 0.28.2
       remote: memfault
 
   # West-related configuration for the nrf repository.


### PR DESCRIPTION
Update memfault-firmware-sdk to version 0.28.2

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>