### PR TITLE
nfc: Modify platform.c to work with new NFC library

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -446,6 +446,14 @@ Libraries for NFC
 
 |no_changes_yet_note|
 
+  * :file:`ncs/nrf/subsys/nfc/lib/platform.c`:
+
+    * Updated:
+
+      * Add the possibility of deffering nfc callback to a thread context. (Experimental)
+      * Add support for Zero Latency Interrupts for NFC. (Experimental)
+      * Align file with new library implementation.
+
 Other libraries
 ---------------
 

--- a/samples/nfc/writable_ndef_msg/src/main.c
+++ b/samples/nfc/writable_ndef_msg/src/main.c
@@ -32,7 +32,8 @@
 
 #define NDEF_RESTORE_BTN_MSK	DK_BTN1_MSK
 
-static uint8_t ndef_msg_buf[CONFIG_NDEF_FILE_SIZE]; /**< Buffer for NDEF file. */
+/**< Buffer for NDEF file. */
+static uint8_t ndef_msg_buf[CONFIG_NDEF_FILE_SIZE];
 
 enum {
 	FLASH_WRITE_FINISHED,

--- a/subsys/nfc/lib/CMakeLists.txt
+++ b/subsys/nfc/lib/CMakeLists.txt
@@ -4,4 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_NFC_PLATFORM platform.c)
+if(DEFINED CONFIG_NFC_PLATFORM)
+zephyr_library_sources(platform.c)
+zephyr_library_sources_ifdef(CONFIG_NFC_THREAD_CALLBACK platform_internal_thread.c)
+zephyr_library_sources_ifndef(CONFIG_NFC_THREAD_CALLBACK platform_internal_irq.c)
+endif()

--- a/subsys/nfc/lib/Kconfig
+++ b/subsys/nfc/lib/Kconfig
@@ -21,6 +21,97 @@ config NFCT_IRQ_PRIORITY
 	  Sets NFC interrupt priority.
 	  Levels are from 0 (highest priority) to 6 (lowest priority)
 
+config NFC_THREAD_CALLBACK
+	bool "Thread context for NFC callbacks"
+	select RING_BUFFER
+	default y
+	help
+	  Use this option to decouple the user NFC callback
+	  from the NFC interrupt context. When enabled, the user
+	  callback is called from a thread (System Workqueue
+	  or a dedicated thread depending on the CONFIG_NFC_OWN_THREAD
+	  setting) instead of being called from the interrupt context.
+	  Using this option ensures robust NFC communication
+	  (deterministic time of the interrupt handling) and allows
+	  deferred callback execution, while it results in higher memory
+	  footprint and CPU load.
+
+if NFC_THREAD_CALLBACK
+
+config HEAP_MEM_POOL_SIZE
+	default 512
+
+config NFC_RING_SIZE
+	int "Size of ring buffer in bytes."
+	default 2048
+	help
+	  Size of the ring buffer.
+	  The specified size is expressed as n bytes.
+
+config NFC_LIB_CTX_MAX_SIZE
+	int "Maximum size of NFC library context in bytes."
+	default 16
+
+config NFC_OWN_THREAD
+	bool "Call NFC callback from its own thread"
+	default n
+
+if NFC_OWN_THREAD
+
+config NFC_THREAD_STACK_SIZE
+	int "Size of NFC thread stack"
+	default 256
+
+config NFC_THREAD_PRIORITY
+	int "Priority of NFC callback thread"
+	default -1
+
+endif# NFC_OWN_THREAD
+
+config NFC_ZERO_LATENCY_IRQ
+	bool "Use Zero Latency IRQ for NFC"
+	default y
+	select ZERO_LATENCY_IRQS
+	help
+	  Using this option ensures fast NFC interrupt
+	  execution on the cost of using additional interrupt (SWI).
+
+if NFC_ZERO_LATENCY_IRQ
+
+choice NFC_SWI
+	default NFC_SWI1
+	prompt "Software interrupt to use for NFC callback request."
+
+config NFC_SWI0
+	bool "SWI0"
+	depends on HAS_HW_NRF_EGU0
+
+config NFC_SWI1
+	bool "SWI1"
+	depends on HAS_HW_NRF_EGU1
+
+config NFC_SWI2
+	bool "SWI2"
+	depends on HAS_HW_NRF_EGU2
+
+config NFC_SWI3
+	bool "SWI3"
+	depends on HAS_HW_NRF_EGU3
+
+config NFC_SWI4
+	bool "SWI4"
+	depends on HAS_HW_NRF_EGU4
+
+config NFC_SWI5
+	bool "SWI5"
+	depends on HAS_HW_NRF_EGU5
+
+endchoice
+
+endif
+
+endif # NFC_THREAD_CALLBACK
+
 module = NFC_PLATFORM
 module-str = nfc_platform
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/nfc/lib/platform.c
+++ b/subsys/nfc/lib/platform.c
@@ -3,10 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+#include <zephyr.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <nrfx_nfct.h>
 #include <nrfx_timer.h>
+#include <nfc_platform.h>
+#include "platform_internal.h"
 
 #ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
 #if defined(CONFIG_BUILD_WITH_TFM)
@@ -29,6 +32,12 @@ LOG_MODULE_REGISTER(nfc_platform, CONFIG_NFC_PLATFORM_LOG_LEVEL);
 
 #define DT_DRV_COMPAT nordic_nrf_clock
 
+#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
+#define NFCT_IRQ_FLAGS	IRQ_ZERO_LATENCY
+#else
+#define NFCT_IRQ_FLAGS	0
+#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
+
 static struct onoff_manager *hf_mgr;
 static struct onoff_client cli;
 
@@ -50,15 +59,23 @@ static void clock_handler(struct onoff_manager *mgr, int res)
 	nrfx_nfct_state_force(NRFX_NFCT_STATE_ACTIVATED);
 }
 
-nrfx_err_t nfc_platform_setup(void)
+nrfx_err_t nfc_platform_setup(nfc_lib_cb_resolve_t nfc_lib_cb_resolve)
 {
+	int err;
+
 	hf_mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
 	__ASSERT_NO_MSG(hf_mgr);
 
 	IRQ_DIRECT_CONNECT(NFCT_IRQn, CONFIG_NFCT_IRQ_PRIORITY,
-			   nfc_isr_wrapper, 0);
+			   nfc_isr_wrapper, NFCT_IRQ_FLAGS);
 	IRQ_CONNECT(NFC_TIMER_IRQn, CONFIG_NFCT_IRQ_PRIORITY,
-			   nfc_timer_irq_handler, NULL,  0);
+		    nfc_timer_irq_handler, NULL,  0);
+
+	err = nfc_platform_internal_init(nfc_lib_cb_resolve);
+	if (err) {
+		LOG_ERR("NFC platform init fail: callback resolution function pointer is invalid");
+		return NRFX_ERROR_NULL;
+	}
 
 	LOG_DBG("NFC platform initialized");
 	return NRFX_SUCCESS;

--- a/subsys/nfc/lib/platform_internal.h
+++ b/subsys/nfc/lib/platform_internal.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#ifndef NFC_PLATFORM_INTERNAL_H_
+#define NFC_PLATFORM_INTERNAL_H_
+
+/**@file
+ * @defgroup nfc_platform_internal Platform-specific module for NFC
+ * @{
+ * @brief Internal part of the NFC platform.
+ */
+
+#include <nfc_platform.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Function for initializing internal nfc_platform layer.
+ *
+ *  This internal function initializes callback scheduling mechanism
+ *  used by selected NFC configuration.
+ *
+ *  This function should not be used directly.
+ *
+ *  @param[in] cb_rslv Pointer to the callback resolution function.
+ *
+ *  @retval 0 If the operation was successful.
+ *  @retval -ENVAL Invalid callback resolution function pointer.
+ */
+int nfc_platform_internal_init(nfc_lib_cb_resolve_t cb_rslv);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NFC_PLATFORM_INTERNAL_H_ */

--- a/subsys/nfc/lib/platform_internal_irq.c
+++ b/subsys/nfc/lib/platform_internal_irq.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <zephyr.h>
+#include <nfc_platform.h>
+#include "platform_internal.h"
+
+static nfc_lib_cb_resolve_t nfc_cb_resolve;
+
+int nfc_platform_internal_init(nfc_lib_cb_resolve_t cb_rslv)
+{
+	if (!cb_rslv) {
+		return -EINVAL;
+	}
+
+	nfc_cb_resolve = cb_rslv;
+	return 0;
+}
+
+void nfc_platform_cb_request(const void *ctx,
+			     size_t ctx_len,
+			     const uint8_t *data,
+			     size_t data_len,
+			     bool copy_data)
+{
+	nfc_cb_resolve(ctx, data);
+}

--- a/subsys/nfc/lib/platform_internal_thread.c
+++ b/subsys/nfc/lib/platform_internal_thread.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <zephyr.h>
+#include <sys/ring_buffer.h>
+#include <nfc_platform.h>
+#include "platform_internal.h"
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(nfc_platform, CONFIG_NFC_PLATFORM_LOG_LEVEL);
+
+#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
+#ifdef CONFIG_SOC_SERIES_NRF53X
+#define SWI_NAME(number)	EGU ## number ## _IRQn
+#else
+#define SWI_NAME(number)	SWI ## number ## _IRQn
+#endif /* CONFIG_SOC_SERIES_NRF53X */
+
+#if defined(CONFIG_NFC_SWI0)
+#define NFC_SWI_IRQN		SWI_NAME(0)
+#elif defined(CONFIG_NFC_SWI1)
+#define NFC_SWI_IRQN		SWI_NAME(1)
+#elif defined(CONFIG_NFC_SWI2)
+#define NFC_SWI_IRQN		SWI_NAME(2)
+#elif defined(CONFIG_NFC_SWI3)
+#define NFC_SWI_IRQN		SWI_NAME(3)
+#elif defined(CONFIG_NFC_SWI4)
+#define NFC_SWI_IRQN		SWI_NAME(4)
+#elif defined(CONFIG_NFC_SWI5)
+#define NFC_SWI_IRQN		SWI_NAME(5)
+#else
+#error "NFC software interrupt is undefined."
+#endif /* CONFIG_NFC_SWI */
+#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
+
+#define NFC_LIB_CTX_SIZE CONFIG_NFC_LIB_CTX_MAX_SIZE
+
+struct nfc_item_header {
+	uint16_t ctx_size;
+	uint16_t data_size;
+};
+
+#ifdef CONFIG_NFC_OWN_THREAD
+static K_SEM_DEFINE(cb_sem, 0, 1);
+#endif /* CONFIG_NFC_OWN_THREAD */
+
+static bool buf_full;
+static nfc_lib_cb_resolve_t nfc_cb_resolve;
+RING_BUF_DECLARE(nfc_cb_ring, CONFIG_NFC_RING_SIZE);
+
+static int ring_buf_get_data(struct ring_buf *buf, void **data, uint32_t size, bool *is_alloc)
+{
+	uint32_t tmp;
+	int err;
+
+	*is_alloc = false;
+
+	/* Try to access data without copying.
+	 * If this fails (for example, the data wraps in ring buffer), try to allocate a buffer
+	 * and copy data into it.
+	 */
+	tmp = ring_buf_get_claim(buf, (uint8_t **)data, size);
+	if (tmp < size) {
+		err = ring_buf_get_finish(&nfc_cb_ring, 0);
+		if (err) {
+			LOG_DBG("Tried to finish a read with 0 bytes, err %i.", err);
+			return err;
+		}
+
+		*data = k_malloc(size);
+		if (data == NULL) {
+			LOG_DBG("Could not allocate %d bytes.", size);
+			return -ENOMEM;
+		}
+
+		tmp = ring_buf_get(buf, (uint8_t *)*data, size);
+		if (tmp < size) {
+			LOG_DBG("Tried to read %d bytes, but read %d.", size, tmp);
+			k_free(*data);
+			return -EBADMSG;
+		}
+
+		*is_alloc = true;
+	}
+
+	return 0;
+}
+
+static void cb_work(struct k_work *work)
+{
+	struct nfc_item_header header;
+	uint32_t ctx[NFC_LIB_CTX_SIZE / 4];
+	void *data;
+	uint32_t size;
+	bool is_alloc = false;
+	int err = 0;
+
+	/* Data from ring buffer is always processed in pairs - context + data in order
+	 * to avoid double copying
+	 */
+	size = ring_buf_get(&nfc_cb_ring, (uint8_t *)&header, sizeof(header));
+	if (size != sizeof(header)) {
+		LOG_ERR("Tried to read header: %d bytes, read %d.", sizeof(header), size);
+		goto error;
+	}
+
+	__ASSERT(header.ctx_size <= NFC_LIB_CTX_SIZE, "NFC context is bigger than expected.");
+
+	size = ring_buf_get(&nfc_cb_ring, (uint8_t *)&ctx, header.ctx_size);
+	if (size != header.ctx_size) {
+		LOG_ERR("Tried to read ctx: %d bytes, read %d.", sizeof(header.ctx_size), size);
+		goto error;
+	}
+
+	if (header.data_size == 0) {
+		size = ring_buf_get(&nfc_cb_ring, (uint8_t *)&data, sizeof(data));
+		if (size != sizeof(data)) {
+			LOG_ERR("Tried to read data pointer: %d bytes, read %d.", sizeof(data),
+											      size);
+			goto error;
+		}
+	} else {
+		err = ring_buf_get_data(&nfc_cb_ring, &data, header.data_size, &is_alloc);
+		if (err) {
+			LOG_ERR("Reading nfc data failed, err %i.", err);
+			goto error;
+		}
+	}
+
+	nfc_cb_resolve(ctx, data);
+
+	if (header.data_size == 0) {
+		return;
+	}
+
+	if (is_alloc) {
+		k_free(data);
+	} else {
+		err = ring_buf_get_finish(&nfc_cb_ring, size);
+		if (err) {
+			LOG_ERR("Tried to finish a read with %d bytes, err %i.", size, err);
+		}
+	}
+
+	return;
+
+error:
+	LOG_ERR("Reading nfc ring buffer failed, resetting ring buffer.");
+	ring_buf_reset(&nfc_cb_ring);
+}
+
+#ifdef CONFIG_NFC_OWN_THREAD
+static void nfc_cb_wrapper(void)
+{
+	while (1) {
+		k_sem_take(&cb_sem, K_FOREVER);
+		cb_work(NULL);
+	}
+}
+
+K_THREAD_DEFINE(nfc_cb_thread, CONFIG_NFC_THREAD_STACK_SIZE, nfc_cb_wrapper,
+		 NULL, NULL, NULL, CONFIG_NFC_THREAD_PRIORITY, 0, 0);
+#else
+static K_WORK_DEFINE(nfc_cb_work, cb_work);
+#endif /* CONFIG_NFC_OWN_THREAD */
+
+static void schedule_callback(void)
+{
+	__ASSERT(buf_full == false, "NFC ring buffer overflow");
+#ifdef CONFIG_NFC_OWN_THREAD
+	k_sem_give(&cb_sem);
+#else
+	k_work_submit(&nfc_cb_work);
+#endif /* CONFIG_NFC_OWN_THREAD */
+}
+
+#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
+ISR_DIRECT_DECLARE(nfc_swi_handler)
+{
+	schedule_callback();
+
+	ISR_DIRECT_PM();
+
+	return 1;
+}
+#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
+
+int nfc_platform_internal_init(nfc_lib_cb_resolve_t cb_rslv)
+{
+	if (!cb_rslv) {
+		return -EINVAL;
+	}
+
+#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
+	IRQ_DIRECT_CONNECT(NFC_SWI_IRQN, CONFIG_NFCT_IRQ_PRIORITY,
+			   nfc_swi_handler, 0);
+	irq_enable(NFC_SWI_IRQN);
+#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
+
+	nfc_cb_resolve = cb_rslv;
+	buf_full = false;
+	ring_buf_reset(&nfc_cb_ring);
+
+	return 0;
+}
+
+void nfc_platform_cb_request(const void *ctx,
+			     size_t ctx_len,
+			     const uint8_t *data,
+			     size_t data_len,
+			     bool copy_data)
+{
+	struct nfc_item_header header;
+	uint32_t size;
+	uint32_t exp_size;
+
+	header.ctx_size = ctx_len;
+	header.data_size = copy_data ? data_len : 0;
+
+	size = ring_buf_put(&nfc_cb_ring, (uint8_t *)&header, sizeof(header));
+	if (size != sizeof(header)) {
+		buf_full = true;
+		goto end;
+	}
+
+	size = ring_buf_put(&nfc_cb_ring, (uint8_t *)ctx, header.ctx_size);
+	if (size != header.ctx_size) {
+		buf_full = true;
+		goto end;
+	}
+
+	if (copy_data) {
+		size = ring_buf_put(&nfc_cb_ring, data, header.data_size);
+		exp_size = header.data_size;
+	} else {
+		size = ring_buf_put(&nfc_cb_ring, (uint8_t *)&data, sizeof(data));
+		exp_size = sizeof(data);
+	}
+
+	if (size != exp_size) {
+		buf_full = true;
+	}
+
+end:
+#ifdef CONFIG_NFC_ZERO_LATENCY_IRQ
+	NVIC_SetPendingIRQ(NFC_SWI_IRQN);
+#else
+	schedule_callback();
+#endif /* CONFIG_NFC_ZERO_LATENCY_IRQ */
+}


### PR DESCRIPTION
platform.c functionality added to allow
nfc callback in thread or sysworkqueue context (default)
with Zero Latency Interrupts (experimental) and
direct callback (legacy option).

This PR requires modifications to nrfxlib.
Jira: NCSDK-13079

Signed-off-by: Dominik Chat <dominik.chat@nordicsemi.no>