### PR TITLE
manifest: nrf_modem: version 1.5.0

### DIFF
--- a/doc/nrf/releases/release-notes-1.7.0.rst
+++ b/doc/nrf/releases/release-notes-1.7.0.rst
@@ -600,6 +600,6 @@ nrfxlib
 
   * :ref:`nrfxlib:nrf_modem_api` - Updated with new API sections.
   * :ref:`full_dfu` - Updated with major changes.
-  * Renamed the "AT commands" page to :ref:`nrfxlib:at_socket`.
+  * Renamed the "AT commands" page to ``AT socket``.
   * :ref:`nrfxlib:nrf_modem_at` - Page added.
   * :ref:`nrfxlib:nrf_modem_delta_dfu` - Page added.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -493,3 +493,11 @@ In addition to documentation related to the changes listed above, the following 
 * Added the :ref:`ug_thingy91_gsg` guide and reworked the :ref:`ug_thingy91` user guide.
 
 .. |no_changes_yet_note| replace:: No changes since the latest |NCS| release.
+
+* :ref:`nrf_modem` section pages:
+
+  * :ref:`nrfxlib:architecture` - Updated architecture diagram.
+  * :ref:`nrfxlib:nrf_modem_delta_dfu` - Updated.
+  * :ref:`nrfxlib:nrf_modem` - Removed overview diagram.
+  * ``AT socket`` page removed.
+  * ``Extensions`` page removed.

--- a/west.yml
+++ b/west.yml
@@ -108,7 +108,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 3a5ee62b2d13d6acea9998ea32fde5a4176cafc0
+      revision: 7588c863d46d35084463e7ee871d79b4ef935f85
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
* The AT socket has been removed.
* The DFU socket has been removed.

See the CHANGELOG file for a detailed list of changes.