### PR TITLE
CODEOWNERS: Update owners of multicell_location and lte_link_control

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -94,7 +94,7 @@ Kconfig*                                  @tejlmand
 /lib/lte_link_control/                    @jtguggedal
 /lib/modem_info/                          @rlubos
 /lib/modem_key_mgmt/                      @rlubos
-/lib/multicell_location/                  @jtguggedal
+/lib/multicell_location/                  @jhirsi @tokangas
 /lib/multithreading_lock/                 @rugeGerritsen
 /lib/pdn/                                 @lemrey @rlubos
 /lib/ram_pwrdn/                           @mariuszpos @MarekPorwisz
@@ -197,7 +197,7 @@ Kconfig*                                  @tejlmand
 /tests/lib/date_time/                     @trantanen @tokangas
 /tests/lib/edge_impulse/                  @pdunaj @MarekPieta
 /tests/lib/hw_unique_key*/                @oyvindronningstad @Vge0rge
-/tests/lib/lte_lc/                        @jtguggedal
+/tests/lib/lte_lc/                        @jtguggedal @tokangas @simensrostad
 /tests/lib/modem_jwt/                     @SeppoTakalo
 /tests/lib/sms/                           @trantanen @tokangas
 /tests/lib/modem_trace/                   @balaji-nordic


### PR DESCRIPTION
Update the owners for multicell_location and lte_link_control.