### PR TITLE
[backport v1.8] lib: nrf_modem: Clear the address structure on recvfrom

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -84,7 +84,12 @@ Bluetooth libraries and services
 
 Updated:
 
-There are no entries for this section yet.
+Modem libraries
+---------------
+
+* :ref:`nrf_modem_lib_readme` library:
+
+  * Fixed a bug in the socket offloading component, where the :c:func:`recvfrom` wrapper could do an out-of-bounds copy of the sender's address, when the application is compiled without IPv6 support. In some cases, the out of bounds copy could indefinitely block the :c:func:`send` and other socket API calls.
 
 sdk-nrfxlib
 -----------


### PR DESCRIPTION
Always zero the sender address structure before passing it to
`nrf_recvfrom()` and only use it when the function is successful.

This fixes a bug where the offloading code would peek into a
uninitialized structure and perform an out of bounds memory copy,
which could have happened when the application was compiled
without IPv6 support and:
- the socket protocol did not provide a sender address (DTLS) or
- the recvfrom() call failed, leaving the structure untouched

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>
Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>
Signed-off-by: Divya Pillai <divya.pillai@nordicsemi.no>