### PR TITLE
[backport v1.7] lib: nrf_modem: Clear the address structure on recvfrom

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -33,7 +33,12 @@ The following sections provide detailed lists of changes by component.
 nRF9160
 =======
 
-There are no entries for this section yet.
+Modem libraries
+---------------
+
+* :ref:`nrf_modem_lib_readme` library:
+
+  * Fixed a bug in the socket offloading component, where the :c:func:`recvfrom` wrapper could do an out-of-bounds copy of the sender's address, when the application is compiled without IPv6 support. In some cases, the out of bounds copy could indefinitely block the :c:func:`send` and other socket API calls.
 
 nRF5
 ====

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -855,12 +855,16 @@ static ssize_t nrf91_socket_offload_recvfrom(void *obj, void *buf, size_t len,
 				      NULL, NULL);
 	} else {
 		/* Allocate space for maximum of IPv4 and IPv6 family type. */
-		struct nrf_sockaddr_in6 cliaddr_storage;
+		struct nrf_sockaddr_in6 cliaddr_storage = { 0 };
 		nrf_socklen_t sock_len = sizeof(struct nrf_sockaddr_in6);
 		struct nrf_sockaddr *cliaddr = (struct nrf_sockaddr *)&cliaddr_storage;
 
 		retval = nrf_recvfrom(ctx->nrf_fd, buf, len, z_to_nrf_flags(flags),
 				      cliaddr, &sock_len);
+		if (retval < 0) {
+			goto exit;
+		}
+
 		if (cliaddr->sa_family == NRF_AF_INET) {
 			nrf_to_z_ipv4(from, (struct nrf_sockaddr_in *)cliaddr);
 			*fromlen = sizeof(struct sockaddr_in);
@@ -871,6 +875,7 @@ static ssize_t nrf91_socket_offload_recvfrom(void *obj, void *buf, size_t len,
 		}
 	}
 
+exit:
 	k_mutex_lock(ctx->lock, K_FOREVER);
 
 	return retval;


### PR DESCRIPTION
Always zero the sender address structure before passing it to
`nrf_recvfrom()` and only use it when the function is successful.

This fixes a bug where the offloading code would peek into a
uninitialized structure and perform an out of bounds memory copy,
which could have happened when the application was compiled
without IPv6 support and:
- the socket protocol did not provide a sender address (DTLS) or
- the recvfrom() call failed, leaving the structure untouched

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>
Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>
Signed-off-by: Divya Pillai <divya.pillai@nordicsemi.no>