### PR TITLE
[backport v1.5] lib: nrf_modem: Clear the address structure on recvfrom

### DIFF
--- a/doc/nrf/releases/release-notes-latest.rst
+++ b/doc/nrf/releases/release-notes-latest.rst
@@ -34,7 +34,12 @@ Zigbee
 nRF9160
 =======
 
+Modem libraries
+---------------
 
+* Modem library integration layer:
+
+  * Fixed a bug in the socket offloading component, where the :c:func:`recvfrom` wrapper could do an out-of-bounds copy of the sender's address, when the application is compiled without IPv6 support. In some cases, the out of bounds copy could indefinitely block the :c:func:`send` and other socket API calls.
 
 Common
 ======

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -764,12 +764,16 @@ static ssize_t nrf91_socket_offload_recvfrom(void *obj, void *buf, size_t len,
 				      NULL);
 	} else {
 		/* Allocate space for maximum of IPv4 and IPv6 family type. */
-		struct nrf_sockaddr_in6 cliaddr_storage;
+		struct nrf_sockaddr_in6 cliaddr_storage = { 0 };
 		nrf_socklen_t sock_len = sizeof(struct nrf_sockaddr_in6);
 		struct nrf_sockaddr *cliaddr = (struct nrf_sockaddr *)&cliaddr_storage;
 
 		retval = nrf_recvfrom(sd, buf, len, z_to_nrf_flags(flags),
 				      cliaddr, &sock_len);
+		if (retval < 0) {
+			goto exit;
+		}
+
 		if (cliaddr->sa_family == NRF_AF_INET) {
 			nrf_to_z_ipv4(from, (struct nrf_sockaddr_in *)cliaddr);
 			*fromlen = sizeof(struct sockaddr_in);
@@ -780,6 +784,7 @@ static ssize_t nrf91_socket_offload_recvfrom(void *obj, void *buf, size_t len,
 		}
 	}
 
+exit:
 	return retval;
 }
 


### PR DESCRIPTION
Always zero the sender address structure before passing it to
`nrf_recvfrom()` and only use it when the function is successful.

This fixes a bug where the offloading code would peek into a
uninitialized structure and perform an out of bounds memory copy,
which could have happened when the application was compiled
without IPv6 support and:
- the socket protocol did not provide a sender address (DTLS) or
- the recvfrom() call failed, leaving the structure untouched

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>
Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>
Signed-off-by: Divya Pillai <divya.pillai@nordicsemi.no>