### PR TITLE
doc: Added links to RST files in caf header files

### DIFF
--- a/include/caf/click_detector.h
+++ b/include/caf/click_detector.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/click_detector.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/click_detector.html.
+ */
+
 #ifndef _CLICK_DETECTOR_H_
 #define _CLICK_DETECTOR_H_
 

--- a/include/caf/events/ble_common_event.h
+++ b/include/caf/events/ble_common_event.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _BLE_COMMON_EVENT_H_
 #define _BLE_COMMON_EVENT_H_
 

--- a/include/caf/events/button_event.h
+++ b/include/caf/events/button_event.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _BUTTON_EVENT_H_
 #define _BUTTON_EVENT_H_
 

--- a/include/caf/events/click_event.h
+++ b/include/caf/events/click_event.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _CLICK_EVENT_H_
 #define _CLICK_EVENT_H_
 

--- a/include/caf/events/force_power_down_event.h
+++ b/include/caf/events/force_power_down_event.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _FORCE_POWER_DOWN_EVENT_H_
 #define _FORCE_POWER_DOWN_EVENT_H_
 

--- a/include/caf/events/keep_alive_event.h
+++ b/include/caf/events/keep_alive_event.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _KEEP_ALIVE_EVENT_H_
 #define _KEEP_ALIVE_EVENT_H_
 

--- a/include/caf/events/led_event.h
+++ b/include/caf/events/led_event.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _LED_EVENT_H_
 #define _LED_EVENT_H_
 

--- a/include/caf/events/module_state_event.h
+++ b/include/caf/events/module_state_event.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _MODULE_STATE_EVENT_H_
 #define _MODULE_STATE_EVENT_H_
 

--- a/include/caf/events/power_event.h
+++ b/include/caf/events/power_event.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _POWER_EVENT_H_
 #define _POWER_EVENT_H_
 

--- a/include/caf/events/power_manager_event.h
+++ b/include/caf/events/power_manager_event.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _POWER_MANAGER_EVENT_H_
 #define _POWER_MANAGER_EVENT_H_
 

--- a/include/caf/events/sensor_event.h
+++ b/include/caf/events/sensor_event.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/caf_overview.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/caf_overview.html.
+ */
+
 #ifndef _SENSOR_EVENT_H_
 #define _SENSOR_EVENT_H_
 

--- a/include/caf/gpio_pins.h
+++ b/include/caf/gpio_pins.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf.
+ * Rendered documentation is available at
+ * http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/index.html.
+ */
+
 #ifndef _GPIO_PINS_H_
 #define _GPIO_PINS_H_
 

--- a/include/caf/key_id.h
+++ b/include/caf/key_id.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf.
+ * Rendered documentation is available at
+ * http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/index.html.
+ */
+
 #ifndef _KEY_ID_H_
 #define _KEY_ID_H_
 

--- a/include/caf/sensor_manager.h
+++ b/include/caf/sensor_manager.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/caf/sensor_manager.rst
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/caf/sensor_manager.htmll.
+ */
+
 #ifndef _SENSOR_MANAGER_H_
 #define _SENSOR_MANAGER_H_
 


### PR DESCRIPTION
Provided comments in the include/caf -header files
about the location of corresponding RST files and
rendered documentation for the particular library.

Ref: NCSDK-11624

Signed-off-by: Richa Pandey <richa.pandey@nordicsemi.no>