### PR TITLE
doc: ug_thingy53: Mention missing supported mesh samples

### DIFF
--- a/doc/nrf/ug_thingy53.rst
+++ b/doc/nrf/ug_thingy53.rst
@@ -361,4 +361,6 @@ Some of the samples that are compatible with Thingy:53 are:
 * :ref:`peripheral_lbs`
 * :ref:`peripheral_uart`
 * :ref:`bluetooth_mesh_light`
+* :ref:`bluetooth_mesh_light_lc`
 * :ref:`bluetooth_mesh_light_switch`
+* :ref:`bluetooth_mesh_sensor_server`


### PR DESCRIPTION
Change adds missing samples to the list of samples that are supported by Thingy:53.