### PR TITLE
lib: nrf_modem: Revert modem trace change from #6471

### DIFF
--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -31,7 +31,7 @@ If your application performs an update of the nRF9160 modem firmware, you must d
 The library wrapper also coordinates the shutdown operation among different parts of the application that use the Modem library.
 This is done by the :c:func:`nrf_modem_lib_shutdown` function call, by waking the sleeping threads when the modem is being shut down.
 
-When :kconfig:`CONFIG_NRF_MODEM_LIB_TRACE_ENABLED` Kconfig option is enabled, the library wrapper enables proprietary modem traces and forwards it to the `Modem trace module`_.
+When :kconfig:`CONFIG_NRF_MODEM_LIB_TRACE_ENABLED` Kconfig option is enabled, the modem traces are enabled in the modem and are forwarded to the `Modem trace module`_.
 
 When using the Modem library in |NCS|, the library should be initialized and shutdown using the :c:func:`nrf_modem_lib_init` and :c:func:`nrf_modem_lib_shutdown` function calls, respectively.
 
@@ -73,8 +73,6 @@ The module provides the functionality for starting, stopping, and forwarding of 
 * :kconfig:`CONFIG_NRF_MODEM_LIB_TRACE_MEDIUM_UART` to send modem traces over UARTE1
 * :kconfig:`CONFIG_NRF_MODEM_LIB_TRACE_MEDIUM_RTT` to send modem traces over SEGGER RTT
 
-When :kconfig:`CONFIG_NRF_MODEM_LIB_TRACE_ENABLED` Kconfig option is enabled, :c:func:`nrf_modem_lib_init` sends the trace memory configuration to the modem.
-When this happens, the modem starts sending startup trace data.
 If the application wants the trace data, :c:func:`nrf_modem_lib_trace_init` must be called before :c:func:`nrf_modem_lib_init`.
 This is done automatically when using the OS Abstraction layer.
 If the application wants to stop an ongoing trace session, it can use the :c:func:`nrf_modem_lib_trace_stop` function.

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -43,6 +43,11 @@ LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
 static bool is_initialized;
 
+#if defined(CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
+/* Enable modem trace */
+static const char mdm_trace[] = "AT%%XMODEMTRACE=1,2";
+#endif
+
 #if defined(CONFIG_LTE_LOCK_BANDS)
 /* Lock LTE bands 3, 4, 13 and 20 (volatile setting) */
 static const char lock_bands[] = "AT%%XBANDLOCK=2,\""CONFIG_LTE_LOCK_BAND_MASK
@@ -578,6 +583,11 @@ static int init_and_config(void)
 #if defined(CONFIG_LTE_EDRX_REQ)
 	/* Request configured eDRX settings to save power */
 	if (lte_lc_edrx_req(true) != 0) {
+		return -EIO;
+	}
+#endif
+#if defined(CONFIG_NRF_MODEM_LIB_TRACE_ENABLED)
+	if (nrf_modem_at_printf(mdm_trace)) {
 		return -EIO;
 	}
 #endif


### PR DESCRIPTION
It was assumed that the modem trace was always enabled at boot, but the
modem trace configuration is persisted in the modem periodically and when
using AT+CFUN=0. This caused a regression when the modem did not already
have the modem trace enabled in the persisted configuration. This commit
reverts the changes in lib/lte_link_control/lte_lc.c from #6471 and
corrects the documentation accordingly. Then modem traces should always
be enabled when CONFIG_NRF_MODEM_LIB_TRACE_ENABLED is turned on.

Fixes NCSDK-13500

Signed-off-by: Gregers Gram Rygg <gregers.gram.rygg@nordicsemi.no>