### PR TITLE
modules/mcuboot/CMakeLists: use imgtool getpub for validating the key

### DIFF
--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -275,7 +275,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     execute_process(COMMAND
       ${PYTHON_EXECUTABLE}
       ${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py
-      getpriv -k ${mcuboot_key_file}
+      getpub -k ${mcuboot_key_file}
       OUTPUT_QUIET
       ERROR_QUIET
       RESULT_VARIABLE ret_val


### PR DESCRIPTION
`imgtool getpriv` command is used to check whether given signing
key is valid. Issue with this approach is that
`getpiv` doesn't support ed25519 of key type.
This patch modify the check so it starts using `getpub` commnd which
is supported for ed5519 as well.

fixes NCSDK-13555

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>