### PR TITLE
manifest: Update zephyr revision to include per adv list bugfix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9dd0692b59ee2838ee3acb2b962821f9c8f0532a
+      revision: pull/708/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fixes an issue where the sync established event did not contain the
correect address and SID when establishing a sync using the periodic
advertiser list.
