### PR TITLE
ram_pwrdn: Add support for nrf5340 and prevent powering down reserved RAM

### DIFF
--- a/doc/nrf/libraries/others/ram_pwrdn.rst
+++ b/doc/nrf/libraries/others/ram_pwrdn.rst
@@ -18,6 +18,10 @@ This function will automatically disable all memory regions that are not used by
     Working with an indirectly accessed memory that is not associated with any variable or a memory segment does not cause the ``_image_ram_end`` symbol to increase its value.
     For this reason, do not access powered down RAM sections when using this power optimization method.
 
+.. note::
+   :c:func:`power_down_unused_ram` does not power down segments of RAM reserved by the :ref:`partition_manager`.
+   If you need to reserve a segment of RAM, create your own RAM partition using the :ref:`partition_manager`.
+
 API documentation
 *****************
 

--- a/doc/nrf/libraries/others/ram_pwrdn.rst
+++ b/doc/nrf/libraries/others/ram_pwrdn.rst
@@ -1,13 +1,13 @@
 .. _lib_ram_pwrdn:
 
-RAM Power Down
+RAM power-down
 ##############
 
 .. contents::
    :local:
    :depth: 2
 
-The RAM Power Down library is a basic module for disabling unused sections of RAM, which allows to save power in low power applications.
+The RAM power-down library is a basic module for disabling unused sections of RAM, which allows to save power in low-power applications.
 
 To disable unused RAM sections, call :c:func:`power_down_unused_ram`.
 This function will automatically disable all memory regions that are not used by the application.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -331,8 +331,10 @@ Other libraries
   * Added support for GNSS high accuracy.
 
 * :ref:`lib_ram_pwrdn` library:
+
   * Added functions for powering up and down RAM sections for a given address range.
   * Added experimental functionality to automatically power up and down RAM sections based on the libc heap usage.
+  * Added support for nRF5340 application core to power up and down RAM sections.
 
 Event Manager
 +++++++++++++

--- a/lib/ram_pwrdn/Kconfig
+++ b/lib/ram_pwrdn/Kconfig
@@ -6,7 +6,7 @@
 
 menuconfig RAM_POWER_DOWN_LIBRARY
 	bool "Enable API for turning off unused RAM segments"
-	depends on SOC_NRF52840 || SOC_NRF52833
+	depends on SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUAPP
 	help
 	  This allows application to call API for disabling unused RAM segments
 	  in the System ON mode. Effectively the application looses possibility

--- a/lib/ram_pwrdn/Kconfig
+++ b/lib/ram_pwrdn/Kconfig
@@ -29,7 +29,7 @@ config RAM_POWER_ADJUST_ON_HEAP_RESIZE
 	  area following the application image) is increased or trimmed.
 
 module =  RAM_POWERDOWN
-module-str = RAM Power down module
+module-str = RAM power-down library
 source "$(ZEPHYR_BASE)/subsys/logging/Kconfig.template.log_config"
 
 endif # RAM_POWER_DOWN_LIBRARY

--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -14,7 +14,7 @@
 #elif defined(CONFIG_SOC_NRF5340_CPUAPP)
 #include <hal/nrf_vmc.h>
 #else
-#error "RAM power-down module is not supported on the current platform"
+#error "RAM power-down library is not supported on the current platform"
 #endif
 
 #if CONFIG_RAM_POWER_ADJUST_ON_HEAP_RESIZE

--- a/lib/ram_pwrdn/ram_pwrdn.c
+++ b/lib/ram_pwrdn/ram_pwrdn.c
@@ -22,10 +22,14 @@
 #include <sys/heap_listener.h>
 #endif
 
-LOG_MODULE_REGISTER(ram_pwrdn, CONFIG_RAM_POWERDOWN_LOG_LEVEL);
+#if defined(CONFIG_PARTITION_MANAGER_ENABLED)
+#include <pm_config.h>
+#endif
 
 #define RAM_IMAGE_END_ADDR ((uintptr_t)_image_ram_end)
 #define RAM_BANK_COUNT ARRAY_SIZE(banks)
+
+LOG_MODULE_REGISTER(ram_pwrdn, CONFIG_RAM_POWERDOWN_LOG_LEVEL);
 
 struct ram_bank {
 	uintptr_t start;
@@ -145,9 +149,13 @@ static uint8_t ram_bank_section_id_ceil(uintptr_t address, const struct ram_bank
  */
 static uintptr_t ram_end_addr(void)
 {
+#if !defined(CONFIG_PARTITION_MANAGER_ENABLED)
 	const struct ram_bank *last_bank = &banks[RAM_BANK_COUNT - 1];
 
 	return last_bank->start + ram_bank_size(last_bank);
+#else
+	return PM_SRAM_PRIMARY_END_ADDRESS;
+#endif
 }
 
 void power_down_ram(uintptr_t start_address, uintptr_t end_address)


### PR DESCRIPTION
- Add support for nRF5340 application core in ram_pwrdn library
- Prevent powering down reserved RAM - calculate unused segment of RAM with use of DTS and Partition Manager (if enabled) to find reserved segments of RAM (shared memory, user defined RAM partition, etc.)