### PR TITLE
doc: Added links to RST files in nfc header files

### DIFF
--- a/include/nfc/ndef/ch_msg.h
+++ b/include/nfc/ndef/ch_msg.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/ch_msg.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/ch_msg.html.
+ */
+
 #ifndef NFC_NDEF_CH_MSG_H_
 #define NFC_NDEF_CH_MSG_H_
 

--- a/include/nfc/ndef/ch_rec_parser.h
+++ b/include/nfc/ndef/ch_rec_parser.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/ch_rec_parser.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/ch_rec_parser.html.
+ */
+
 #ifndef NFC_NDEF_CH_REC_PARSER_H_
 #define NFC_NDEF_CH_REC_PARSER_H_
 

--- a/include/nfc/ndef/launchapp_msg.h
+++ b/include/nfc/ndef/launchapp_msg.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/launchapp.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/launchapp.html.
+ */
+
 #ifndef NFC_LAUNCHAPP_MSG_H__
 #define NFC_LAUNCHAPP_MSG_H__
 

--- a/include/nfc/ndef/launchapp_rec.h
+++ b/include/nfc/ndef/launchapp_rec.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/launchapp.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/launchapp.html.
+ */
+
 #ifndef NFC_LAUNCHAPP_REC_H__
 #define NFC_LAUNCHAPP_REC_H__
 

--- a/include/nfc/ndef/le_oob_rec.h
+++ b/include/nfc/ndef/le_oob_rec.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/le_oob_rec.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/le_oob_rec.html.
+ */
+
 #ifndef NFC_NDEF_LE_OOB_REC_H_
 #define NFC_NDEF_LE_OOB_REC_H_
 

--- a/include/nfc/ndef/le_oob_rec_parser.h
+++ b/include/nfc/ndef/le_oob_rec_parser.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/le_oob_rec_parser.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/le_oob_rec_parser.html.
+ */
+
 #ifndef NFC_NDEF_LE_OOB_REC_PARSER_H_
 #define NFC_NDEF_LE_OOB_REC_PARSER_H_
 

--- a/include/nfc/ndef/msg.h
+++ b/include/nfc/ndef/msg.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/msg.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/msg.html.
+ */
+
 #ifndef NFC_NDEF_MSG_H_
 #define NFC_NDEF_MSG_H_
 

--- a/include/nfc/ndef/msg_parser.h
+++ b/include/nfc/ndef/msg_parser.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/msg_parser.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/msg_parser.html.
+ */
+
 #ifndef NFC_NDEF_MSG_PARSER_H_
 #define NFC_NDEF_MSG_PARSER_H_
 

--- a/include/nfc/ndef/record.h
+++ b/include/nfc/ndef/record.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/msg.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/msg.html.
+ */
+
 #ifndef NFC_NDEF_RECORD_H_
 #define NFC_NDEF_RECORD_H_
 

--- a/include/nfc/ndef/record_parser.h
+++ b/include/nfc/ndef/record_parser.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/msg_parser.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/msg_parser.html.
+ */
+
 #ifndef NFC_NDEF_RECORD_PARSER_H_
 #define NFC_NDEF_RECORD_PARSER_H_
 

--- a/include/nfc/ndef/text_rec.h
+++ b/include/nfc/ndef/text_rec.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/text_rec.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/text_rec.html.
+ */
+
 #ifndef NFC_NDEF_TEXT_REC_H_
 #define NFC_NDEF_TEXT_REC_H_
 

--- a/include/nfc/ndef/uri_msg.h
+++ b/include/nfc/ndef/uri_msg.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/uri_msg.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/uri_msg.html.
+ */
+
 #ifndef NFC_NDEF_URI_MSG_H_
 #define NFC_NDEF_URI_MSG_H_
 

--- a/include/nfc/ndef/uri_rec.h
+++ b/include/nfc/ndef/uri_rec.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/ndef/uri_msg.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/ndef/uri_msg.html.
+ */
+
 #ifndef NFC_NDEF_URI_REC_H_
 #define NFC_NDEF_URI_REC_H_
 

--- a/include/nfc/t2t/parser.h
+++ b/include/nfc/t2t/parser.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/t2t/t2t_parser.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/t2t/t2t_parser.html.
+ */
+
 #ifndef NFC_T2T_PARSER_H_
 #define NFC_T2T_PARSER_H_
 

--- a/include/nfc/t2t/tlv_block.h
+++ b/include/nfc/t2t/tlv_block.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/t2t/t2t_parser.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/t2t/t2t_parser.html.
+ */
+
 #ifndef NFC_T2T_TLV_BLOCK_H_
 #define NFC_T2T_TLV_BLOCK_H_
 

--- a/include/nfc/t4t/apdu.h
+++ b/include/nfc/t4t/apdu.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/t4t/apdu.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/t4t/apdu.html.
+ */
+
 #ifndef NFC_T4T_APDU_H_
 #define NFC_T4T_APDU_H_
 

--- a/include/nfc/t4t/cc_file.h
+++ b/include/nfc/t4t/cc_file.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/t4t/cc_file.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/t4t/cc_file.html.
+ */
+
 #ifndef NFC_T4T_CC_FILE_H_
 #define NFC_T4T_CC_FILE_H_
 

--- a/include/nfc/t4t/hl_procedure.h
+++ b/include/nfc/t4t/hl_procedure.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/t4t/hl_procedure.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/t4t/hl_procedure.html.
+ */
+
 #ifndef NFC_T4T_HL_PROCEDURE_
 #define NFC_T4T_HL_PROCEDURE_
 

--- a/include/nfc/t4t/isodep.h
+++ b/include/nfc/t4t/isodep.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/t4t/isodep.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/t4t/isodep.html.
+ */
+
 #ifndef NFC_T4T_ISODEP_H_
 #define NFC_T4T_ISODEP_H_
 

--- a/include/nfc/t4t/ndef_file.h
+++ b/include/nfc/t4t/ndef_file.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/t4t/ndef_file.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/t4t/ndef_file.html.
+ */
+
 #ifndef NFC_T4T_NDEF_FILE_H_
 #define NFC_T4T_NDEF_FILE_H_
 

--- a/include/nfc/tnep/ch.h
+++ b/include/nfc/tnep/ch.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/tnep/ch.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/tnep/ch.html.
+ */
+
 #ifndef NFC_TNEP_CH_H_
 #define NFC_TNEP_CH_H_
 

--- a/include/nfc/tnep/poller.h
+++ b/include/nfc/tnep/poller.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/tnep/poller.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/tnep/poller.html.
+ */
+
 #ifndef NFC_TNEP_POLLER_
 #define NFC_TNEP_POLLER_
 

--- a/include/nfc/tnep/tag.h
+++ b/include/nfc/tnep/tag.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/nfc/tnep/tag.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/nfc/tnep/tag.html.
+ */
+
 #ifndef NFC_TNEP_TAG_H_
 #define NFC_TNEP_TAG_H_
 


### PR DESCRIPTION
Provided comments in the include/nfc  header files
about the location of corresponding RST files and
rendered documentation for the particular library.

Ref: NCSDK-11624

Signed-off-by: Richa Pandey <richa.pandey@nordicsemi.no>