### PR TITLE
doc: Added links to RST files in modem and zigbee header files

### DIFF
--- a/include/modem/at_cmd_parser.h
+++ b/include/modem/at_cmd_parser.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/at_cmd_parser.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/at_cmd_parser.html.
+ */
+
 #ifndef AT_CMD_PARSER_H__
 #define AT_CMD_PARSER_H__
 

--- a/include/modem/at_monitor.h
+++ b/include/modem/at_monitor.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/at_monitor.rst
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/at_monitor.html.
+ */
+
 #ifndef AT_MONITOR_H_
 #define AT_MONITOR_H_
 

--- a/include/modem/at_params.h
+++ b/include/modem/at_params.h
@@ -12,6 +12,12 @@
 extern "C" {
 #endif
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/at_params.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/at_params.html.
+ */
+
 /**
  * @file at_params.h
  *

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/location.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/location.html.
+ */
+
 #ifndef LOCATION_H_
 #define LOCATION_H_
 

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -1,4 +1,10 @@
 /*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/lte_lc.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/lte_lc.html.
+ */
+
+/*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause

--- a/include/modem/modem_attest_token.h
+++ b/include/modem/modem_attest_token.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/modem_attest_token.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/modem_attest_token.html.
+ */
+
 #ifndef MODEM_ATTEST_TOKEN_H__
 #define MODEM_ATTEST_TOKEN_H__
 

--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/modem_info.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/modem_info.html.
+ */
+
 #ifndef ZEPHYR_INCLUDE_MODEM_INFO_H_
 #define ZEPHYR_INCLUDE_MODEM_INFO_H_
 

--- a/include/modem/modem_jwt.h
+++ b/include/modem/modem_jwt.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/modem_jwt.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/modem_jwt.html.
+ */
+
 #ifndef MODEM_JWT_H__
 #define MODEM_JWT_H__
 

--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/modem_key_mgmt.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/modem_key_mgmt.html.
+ */
+
 #ifndef MODEM_KEY_MGMT_H__
 #define MODEM_KEY_MGMT_H__
 

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/nrf_modem_lib.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/nrf_modem_lib.html.
+ */
+
 #ifndef NRF_MODEM_LIB_H_
 #define NRF_MODEM_LIB_H_
 

--- a/include/modem/nrf_modem_lib_trace.h
+++ b/include/modem/nrf_modem_lib_trace.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/nrf_modem_lib.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/nrf_modem_lib.html.
+ */
+
 #ifndef NRF_MODEM_LIB_TRACE_H__
 #define NRF_MODEM_LIB_TRACE_H__
 

--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/pdn.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/pdn.html.
+ */
+
 #ifndef PDN_H_
 #define PDN_H_
 

--- a/include/modem/sms.h
+++ b/include/modem/sms.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/modem/sms.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/sms.html.
+ */
+
 #ifndef SMS_H_
 #define SMS_H_
 

--- a/include/zigbee/zigbee_app_utils.h
+++ b/include/zigbee/zigbee_app_utils.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/zigbee/zigbee_app_utils.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/zigbee/zigbee_app_utils.html.
+ */
+
 #ifndef ZIGBEE_APP_UTILS_H__
 #define ZIGBEE_APP_UTILS_H__
 

--- a/include/zigbee/zigbee_error_handler.h
+++ b/include/zigbee/zigbee_error_handler.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/zigbee/zigbee_error_handler.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/zigbee/zigbee_error_handler.html.
+ */
+
 /**
  * @file
  *  @defgroup zb_error ZBOSS error handling utilities

--- a/include/zigbee/zigbee_fota.h
+++ b/include/zigbee/zigbee_fota.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/zigbee/zigbee_fota.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/zigbee/zigbee_fota.html.
+ */
+
 /** @file zigbee_fota.h
  *
  * @defgroup zigbee_fota Zigbee firmware over-the-air download library

--- a/include/zigbee/zigbee_logger_eprxzcl.h
+++ b/include/zigbee/zigbee_logger_eprxzcl.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/zigbee/zigbee_logger_eprxzcl.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/zigbee/zigbee_logger_eprxzcl.html.
+ */
+
 #ifndef ZIGBEE_COMMON_ZIGBEE_LOGGER_EPRXZCL_H_
 #define ZIGBEE_COMMON_ZIGBEE_LOGGER_EPRXZCL_H_
 

--- a/include/zigbee/zigbee_zcl_scenes.h
+++ b/include/zigbee/zigbee_zcl_scenes.h
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in
+ * doc/nrf/libraries/zigbee/zigbee_zcl_scenes.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/zigbee/zigbee_zcl_scenes.html.
+ */
+
 #ifndef ZIGBEE_ZCL_SCENES_H__
 #define ZIGBEE_ZCL_SCENES_H__
 


### PR DESCRIPTION
Provided comments in the include/modem and include/zigbee
header files about the location of corresponding RST files
and rendered documentation for the particular library.

Ref: NCSDK-11624

Signed-off-by: Richa Pandey <richa.pandey@nordicsemi.no>