### PR TITLE
samples: tfm_hello_world: Fix regex failure when skipping MCU selection

### DIFF
--- a/samples/tfm/tfm_hello_world/sample.yaml
+++ b/samples/tfm/tfm_hello_world/sample.yaml
@@ -21,7 +21,7 @@ common:
         - "Hashing 'Hello World! .*'"
         - "SHA256 digest:"
         - "0x[0-9a-f]{64}"
-        - "(Configuring MCU selection for LFXO)?"
+        - "MCU selection .*"
 tests:
   sample.tfm.helloworld:
     tags: tfm ci_build

--- a/samples/tfm/tfm_hello_world/src/main.c
+++ b/samples/tfm/tfm_hello_world/src/main.c
@@ -107,8 +107,10 @@ void main(void)
 	 * oscillator (LFXO) can be used.
 	 * This configuration has already been done by TF-M so this is redundant.
 	 */
-	printk("Configuring MCU selection for LFXO\n");
 	gpio_pin_mcu_select(PIN_XL1, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
 	gpio_pin_mcu_select(PIN_XL2, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
+	printk("MCU selection configured\n");
+#else
+	printk("MCU selection skipped\n");
 #endif /* defined(GPIO_PIN_CNF_MCUSEL_Msk) */
 }


### PR DESCRIPTION
Fix regex matching in the sample.yaml file when the skipping the GPIO
MCU selection. This was failing for nrf9160dk_nrf9160_ns.

Ref: NCSDK-13570

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>