### PR TITLE
mpsl: cx: support for nRF5340

### DIFF
--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -13,14 +13,20 @@ config MPSL_CX
 	  Radio Coexistence interface connects nRF5 radio protocols with external
 	  Packet Traffic Arbiter (PTA) which denies or grants access to RF.
 
+config MPSL_CX_PIN_FORWARDER
+	bool
+	depends on SOC_NRF5340_CPUAPP
+	depends on MPSL_CX
+	default y
+
 if MPSL_CX
 
 choice MPSL_CX_CHOICE
 	prompt "Radio Coexistence interface implementation"
 
 config MPSL_CX_THREAD
-	select NRFX_GPIOTE
-	select GPIO
+	select NRFX_GPIOTE if !MPSL_CX_PIN_FORWARDER
+	select GPIO if !MPSL_CX_PIN_FORWARDER
 	depends on !BT
 	bool "Thread Radio Coexistence [EXPERIMENTAL]"
 	select EXPERIMENTAL
@@ -52,8 +58,8 @@ config MPSL_CX_BT_1WIRE
 	  implementation for co-located radios.
 
 config MPSL_CX_GENERIC_3PIN
-	select NRFX_GPIOTE
-	select GPIO
+	select NRFX_GPIOTE if !MPSL_CX_PIN_FORWARDER
+	select GPIO if !MPSL_CX_PIN_FORWARDER
 	bool "Generic 3-pin Radio Coexistence support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help

--- a/subsys/mpsl/cx/thread/mpsl_cx_thread.c
+++ b/subsys/mpsl/cx/thread/mpsl_cx_thread.c
@@ -11,7 +11,10 @@
  *
  */
 
+
+#if !defined(CONFIG_MPSL_CX_PIN_FORWARDER)
 #include <mpsl_cx_abstract_interface.h>
+#endif
 
 #include <stddef.h>
 #include <stdint.h>
@@ -22,8 +25,8 @@
 
 #include "hal/nrf_gpio.h"
 
-#if DT_NODE_HAS_STATUS(DT_PHANDLE(DT_NODELABEL(radio), coex), okay)
-#define CX_NODE DT_PHANDLE(DT_NODELABEL(radio), coex)
+#if DT_NODE_EXISTS(DT_NODELABEL(nrf_radio_coex))
+#define CX_NODE DT_NODELABEL(nrf_radio_coex)
 #else
 #define CX_NODE DT_INVALID_NODE
 #error No enabled coex nodes registered in DTS.
@@ -32,11 +35,12 @@
 /* Value from chapter 7. Logic Timing from Thread Radio Coexistence */
 #define REQUEST_TO_GRANT_US 50U
 
-static mpsl_cx_cb_t callback;
-
 static const struct gpio_dt_spec req_spec = GPIO_DT_SPEC_GET(CX_NODE, req_gpios);
 static const struct gpio_dt_spec pri_spec = GPIO_DT_SPEC_GET(CX_NODE, pri_dir_gpios);
 static const struct gpio_dt_spec gra_spec = GPIO_DT_SPEC_GET(CX_NODE, grant_gpios);
+
+#if !defined(CONFIG_MPSL_CX_PIN_FORWARDER)
+static mpsl_cx_cb_t callback;
 static struct gpio_callback grant_cb;
 
 static int32_t grant_pin_is_asserted(bool *is_asserted)
@@ -208,3 +212,17 @@ static int mpsl_cx_init(const struct device *dev)
 }
 
 SYS_INIT(mpsl_cx_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+
+#else // !defined(CONFIG_MPSL_CX_PIN_FORWARDER)
+static int mpsl_cx_init(const struct device *dev)
+{
+	nrf_gpio_pin_mcu_select(req_spec.pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	nrf_gpio_pin_mcu_select(pri_spec.pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	nrf_gpio_pin_mcu_select(gra_spec.pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+
+	return 0;
+}
+
+SYS_INIT(mpsl_cx_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+#endif // !defined(CONFIG_MPSL_CX_PIN_FORWARDER)


### PR DESCRIPTION
This commit adds a MPSL_CX_PIN_FORWARDER Kconfig option that makes it
possible to forward control over Coexistence interface to the nRF5340
network core. It enables use of mpsl_cx for nRF5340 SoCs.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>