### PR TITLE
doc: added links to RST files from header files in different folders

### DIFF
--- a/include/debug/cpu_load.h
+++ b/include/debug/cpu_load.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/debug/cpu_load.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/debug/cpu_load.html.
+ */
+
 #ifndef __CPU_LOAD_H
 #define __CPU_LOAD_H
 

--- a/include/debug/ppi_trace.h
+++ b/include/debug/ppi_trace.h
@@ -3,6 +3,13 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/debug/ppi_trace.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/debug/ppi_trace.html.
+ */
+
 #ifndef __PPI_TRACE_H
 #define __PPI_TRACE_H
 

--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/dfu/dfu_target.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/dfu/dfu_target.html.
+ */
+
 #ifndef DFU_TARGET_H__
 #define DFU_TARGET_H__
 

--- a/include/dfu/fmfu_fdev.h
+++ b/include/dfu/fmfu_fdev.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/dfu/fmfu_fdev.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/dfu/fmfu_fdev.html.
+ */
+
 #ifndef FMFU_FDEV_H__
 #define FMFU_FDEV_H__
 

--- a/include/dfu/pcd.h
+++ b/include/dfu/pcd.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/dfu/pcd.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/dfu/pcd.html.
+ */
+
 /** @file pcd.h
  *
  * @defgroup pcd Peripheral Core DFU

--- a/include/mgmt/fmfu_mgmt.h
+++ b/include/mgmt/fmfu_mgmt.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/dfu/fmfu_mgmt.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/dfu/fmfu_mgmt.html.
+ */
+
 /** @file fmfu_mgmt.h
  * @defgroup fmfu_mgmt MCUMgr module for full Modem Firmware Upgrade
  * @{

--- a/include/mgmt/fmfu_mgmt_stat.h
+++ b/include/mgmt/fmfu_mgmt_stat.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/dfu/fmfu_mgmt.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/dfu/fmfu_mgmt.html.
+ */
+
 /** @file fmfu_mgmt_stat.h
  * @defgroup fmfu_mgmt_stat MCUMgr hooks for Full Modem Firmware Upgrade stats
  * @{

--- a/include/mpsl/mpsl_assert.h
+++ b/include/mpsl/mpsl_assert.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/mpsl/mpsl_assert.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/mpsl/mpsl_assert.html.
+ */
+
 /**
  * @file mpsl_assert.h
  *

--- a/include/shell/shell_bt_nus.h
+++ b/include/shell/shell_bt_nus.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/shell/shell_bt_nus.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/shell/shell_bt_nus.html.
+ */
+
 #ifndef SHELL_BT_NUS_H_
 #define SHELL_BT_NUS_H_
 

--- a/include/tfm/tfm_ioctl_api.h
+++ b/include/tfm/tfm_ioctl_api.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/*
+ * The RST file for this library can be found in doc/nrf/libraries/tfm/tfm_ioctl_api.rst.
+ * Rendered documentation is available at
+ * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/tfm/tfm_ioctl_api.html.
+ */
+
 /** @file
  * @brief TFM IOCTL API header.
  */


### PR DESCRIPTION
Provided comments in the debug, dfu, mgmt, mpsl, shell, tfm
header files about the location of corresponding RST files and
rendered documentation for the particular library.

Ref: NCSDK-11624

Signed-off-by: Richa Pandey <richa.pandey@nordicsemi.no>