### PR TITLE
manifest: Include more BT fixes from upstream zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 9271a81c5d32b3c6159cde782568399121b5cd16
+      revision: pull/715/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
See https://github.com/nrfconnect/sdk-zephyr/pull/715 for more
details.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>