### PR TITLE
manifest: nrf_802154_irq API change to allow ZLI

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f0876d46f0fc6c48a0e9dbecfe02001d7c5d355f
+      revision: d143ae93cabf2979b4bc3d049145e108a7d7adcf
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -108,7 +108,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 19377140adb905e361614980882cdad537a65b14
+      revision: b17e812a570a2dde7184209a907ceda8b8793497
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
This commit changes prototype of `nrf_802154_irq_init` function to
allow negative `prio` values intended to allow use of ZLI priorities
by Zephyr-based platforms.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>