### PR TITLE
TF-M: Fix PSA Architecture Tests - Compilation Errors

### DIFF
--- a/modules/tfm/tfm/boards/partition/region_defs.h
+++ b/modules/tfm/tfm/boards/partition/region_defs.h
@@ -148,6 +148,28 @@
 				    PSA_TEST_SCRATCH_AREA_SIZE - \
 				    FF_TEST_PARTITION_SIZE)
 
+/* The psa-arch-tests implementation requires that the test partitions are
+ * placed in this specific order:
+ * TEST_NSPE_MMIO < TEST_SERVER < TEST_DRIVER
+ *
+ * TEST_NSPE_MMIO region must be in the NSPE, while TEST_SERVER and TEST_DRIVER
+ * must be in SPE.
+ *
+ * The TEST_NSPE_MMIO region is defined in the psa-arch-tests implementation,
+ * and it should be placed at the end of the NSPE area, after
+ * PSA_TEST_SCRATCH_AREA.
+ */
+#define FF_TEST_SERVER_PARTITION_MMIO_START (NS_DATA_LIMIT + 1)
+#define FF_TEST_SERVER_PARTITION_MMIO_END (FF_TEST_SERVER_PARTITION_MMIO_START + \
+					   FF_TEST_PARTITION_SIZE - 1)
+#define FF_TEST_DRIVER_PARTITION_MMIO_START (FF_TEST_SERVER_PARTITION_MMIO_END + 1)
+#define FF_TEST_DRIVER_PARTITION_MMIO_END (FF_TEST_DRIVER_PARTITION_MMIO_START + \
+					   FF_TEST_PARTITION_SIZE - 1)
+#else
+/* Development APIs test suites */
+#define PSA_TEST_SCRATCH_AREA_BASE (NS_DATA_LIMIT + 1 - \
+				    PSA_TEST_SCRATCH_AREA_SIZE)
+
 #endif /* PSA_API_TEST_IPC */
 
 #endif /* __REGION_DEFS_H__ */

--- a/modules/tfm/tfm/boards/partition/region_defs.h
+++ b/modules/tfm/tfm/boards/partition/region_defs.h
@@ -137,4 +137,17 @@
 #define BOOT_TFM_SHARED_DATA_LIMIT (BOOT_TFM_SHARED_DATA_BASE + \
 				    BOOT_TFM_SHARED_DATA_SIZE - 1)
 
+/* Regions used by psa-arch-tests to keep state */
+#define PSA_TEST_SCRATCH_AREA_SIZE (0x400)
+
+#ifdef PSA_API_TEST_IPC
+
+/* Firmware Framework test suites */
+#define FF_TEST_PARTITION_SIZE 0x100
+#define PSA_TEST_SCRATCH_AREA_BASE (NS_DATA_LIMIT + 1 - \
+				    PSA_TEST_SCRATCH_AREA_SIZE - \
+				    FF_TEST_PARTITION_SIZE)
+
+#endif /* PSA_API_TEST_IPC */
+
 #endif /* __REGION_DEFS_H__ */


### PR DESCRIPTION
Update region_defs.h to match the change in TF-m:
```
  Change the PSA test scratch area to be fixed to the end of the non
  secure RAM area so that the scratch are will be the same for both
  secure and non secure partitions.
```

Ref: NCSDK-13494

Update region_defs.h to include changes that add support for
psa-arch-tests Firmware Framework tests.

Update matches change done in TF-M:
```
  Add memory functionality and peripheral configurations needed to
  execute the psa-arch-tests Firmware Framework tests.
```
