### PR TITLE
manifest: update nrfxlib for nrf_security

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -108,7 +108,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.9.0
+      revision: 086bb820dda27cc51d9e849d90b2aff751f8a534
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Remove obsolete `MBEDTLS_HARDWARE_POLL_WORKAROUND`.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>