### PR TITLE
spm: lower RAM requirements for nRF9160

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -153,6 +153,10 @@ Bluetooth samples
 nRF9160 samples
 ---------------
 
+* :ref:`secure_partition_manager` sample:
+
+  * Reduced the amount of RAM reserved in the default configuration of the sample for nRF9160, freeing up 32 Kb of RAM for the application.
+
 * :ref:`modem_shell_application` sample:
 
   * Added a new shell command ``cloud`` for establishing an MQTT connection to nRF Cloud.

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -104,7 +104,7 @@ config NRF_MODEM_LIB_SHMEM_CTRL_SIZE
 
 config NRF_MODEM_LIB_SHMEM_TX_SIZE
 	int "TX region size"
-	range 1024 16384
+	range 1024 32768
 	default 8192
 	help
 	  Size of the shared memory area owned by the application.
@@ -113,13 +113,11 @@ config NRF_MODEM_LIB_SHMEM_TX_SIZE
 
 config NRF_MODEM_LIB_SHMEM_RX_SIZE
 	int "RX region size"
-	range 1544 16384
+	range 1544 32768
 	default 8192
 	help
 	  Size of the shared memory area owned by the modem.
 	  This area holds all incoming data from the modem, plus the modem's own control structures.
-	  The minimum memory requirements stem from the size of the RPC lists (264 bytes = 8 + (32 * 8)),
-	  plus the RPC messages and data buffers (1280 bytes = 256 + 1024).
 
 config NRF_MODEM_LIB_SHMEM_TRACE_SIZE_OVERRIDE
 	bool "Custom Trace region size"

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -55,15 +55,9 @@ config PM_PARTITION_SIZE_SPM
 config PM_PARTITION_SIZE_SPM_SRAM
 	hex "RAM reserved for SPM"
 	default 0 if !SPM_SECURE_SERVICES
-	default 0x10000 if SOC_NRF9160
 	default 0x8000
 	help
 	  RAM area set aside for the SPM.
-	  On the nRF9160 the Modem library needs to be included in the build.
-	  There are scrict requirements to the RAM area reserved for Modem library.
-	  Specifically it must be 64kB from RAM offset 0x10000.
-	  By setting the SPM RAM to 0x10000 we ensure that Modem library RAM ends
-	  up in the right place.
 
 config SPM_BOOT_SILENTLY
 	bool "Boot silently"


### PR DESCRIPTION
A default of 0x10000 was specified, with a comment stating that the RAM for libmodem should start from that offset.
That was incorrect, it could start from any address in the lower 128K range.

Also bump the range on `NRF_MODEM_LIB_SHMEM_TX_SIZE` and `NRF_MODEM_LIB_SHMEM_RX_SIZE`
