### PR TITLE
applications: asset_tracker_v2: Increase IMEI buffer size

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/azure_iot_hub_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/azure_iot_hub_integration.c
@@ -275,7 +275,7 @@ int cloud_wrap_init(cloud_wrap_evt_handler_t event_handler)
 	int err;
 
 #if !defined(CONFIG_CLOUD_CLIENT_ID_USE_CUSTOM)
-	char imei_buf[20];
+	char imei_buf[20 + sizeof("OK\r\n")];
 
 	/* Retrieve device IMEI from modem. */
 	err = nrf_modem_at_cmd(imei_buf, sizeof(imei_buf), "AT+CGSN");


### PR DESCRIPTION
Increase the IMEI buffer size for the Azure IoT Hub integration.
This is needed because the AT command responses now have an added
"OK\r\n" after the switch from at_cmd to nrf_modem_at for AT
command handling.