### PR TITLE
Bluetooth: Mesh: Shell support for generic models

### DIFF
--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -74,6 +74,7 @@ zephyr_library_sources_ifdef(CONFIG_BT_MESH_SCHEDULER_CLI scheduler_cli.c)
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_SCHEDULER_SRV scheduler_srv.c)
 
 add_subdirectory_ifdef(CONFIG_BT_MESH_VENDOR_MODELS vnd)
+add_subdirectory_ifdef(CONFIG_BT_MESH_SHELL shell)
 
 zephyr_linker_sources(SECTIONS sensor_types.ld)
 zephyr_linker_sources(SECTIONS scene_types.ld)

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -10,6 +10,7 @@ menu "Bluetooth mesh"
 
 rsource "Kconfig.models"
 rsource "Kconfig.dk_prov"
+rsource "shell/Kconfig"
 
 endmenu
 

--- a/subsys/bluetooth/mesh/shell/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/shell/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+
+zephyr_library_sources(shell_utils.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SHELL_ONOFF_CLI shell_onoff_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SHELL_LVL_CLI shell_lvl_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SHELL_DTT_CLI shell_dtt_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SHELL_PONOFF_CLI shell_ponoff_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SHELL_PLVL_CLI shell_plvl_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SHELL_BATTERY_CLI shell_bat_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SHELL_LOC_CLI shell_loc_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SHELL_PROP_CLI shell_prop_cli.c)

--- a/subsys/bluetooth/mesh/shell/Kconfig
+++ b/subsys/bluetooth/mesh/shell/Kconfig
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if BT_MESH_SHELL
+
+config BT_MESH_SHELL_ONOFF_CLI
+	bool "OnOff client shell support"
+	depends on BT_MESH_ONOFF_CLI
+	default y
+	help
+	  Generic onoff client shell support.
+config BT_MESH_SHELL_LVL_CLI
+	bool "Level client shell support"
+	depends on BT_MESH_LVL_CLI
+	default y
+	help
+	  Generic level client shell support.
+
+config BT_MESH_SHELL_DTT_CLI
+	bool "Default Transition time client shell support"
+	depends on BT_MESH_DTT_CLI
+	default y
+	help
+	  Transition time client shell support.
+
+config BT_MESH_SHELL_PONOFF_CLI
+	bool "Power onoff client shell support"
+	depends on BT_MESH_PONOFF_CLI
+	default y
+	help
+	  Power onoff client shell support.
+
+config BT_MESH_SHELL_PLVL_CLI
+	bool "Power level client shell support"
+	depends on BT_MESH_PLVL_CLI
+	default y
+	help
+	  Power level client shell support.
+
+config BT_MESH_SHELL_BATTERY_CLI
+	bool "Battery client shell support"
+	depends on BT_MESH_BATTERY_CLI
+	default y
+	help
+	  Battery client shell support.
+
+config BT_MESH_SHELL_LOC_CLI
+	bool "Location client shell support"
+	depends on BT_MESH_LOC_CLI
+	default y
+	help
+	  Location client shell support.
+
+config BT_MESH_SHELL_PROP_CLI
+	bool "Property client shell support"
+	depends on BT_MESH_PROP_CLI
+	default y
+	help
+	  Property client shell support.
+
+endif # BT_MESH_SHELL

--- a/subsys/bluetooth/mesh/shell/shell_bat_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_bat_cli.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+#include <bluetooth/mesh/models.h>
+#include <shell/shell.h>
+
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "shell_utils.h"
+
+static struct bt_mesh_model *mod;
+
+static int cmd_battery_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_BATTERY_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_battery_cli *cli = mod->user_data;
+	struct bt_mesh_battery_status rsp;
+
+	int err = bt_mesh_battery_cli_get(cli, NULL, &rsp);
+
+	if (!err) {
+		shell_print(shell,
+			    "Battery lvl: %d, discharge time: %d, charge time: %d\n"
+			    "Presence state: %d, indicator state: %d, "
+			    "charging state: %d, service state: %d",
+			    rsp.battery_lvl, rsp.discharge_minutes, rsp.charge_minutes,
+			    rsp.presence, rsp.indicator, rsp.charging, rsp.service);
+	}
+
+	return err;
+}
+
+static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *argv[])
+{
+	return shell_model_instances_get_all(shell, BT_MESH_MODEL_ID_GEN_BATTERY_CLI);
+}
+
+static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+
+	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_BATTERY_CLI, elem_idx);
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(instance_cmds,
+			       SHELL_CMD_ARG(set, NULL, "<elem_idx> ", cmd_instance_set, 2, 0),
+			       SHELL_CMD_ARG(get-all, NULL, NULL, cmd_instance_get_all, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(bat_cmds, SHELL_CMD_ARG(get, NULL, NULL, cmd_battery_get, 1, 0),
+			       SHELL_CMD(instance, &instance_cmds, "Instance commands",
+					 shell_model_cmds_help),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(mdl_battery, &bat_cmds, "Battery Cli commands", shell_model_cmds_help, 1,
+		       1);

--- a/subsys/bluetooth/mesh/shell/shell_dtt_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_dtt_cli.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+#include <bluetooth/mesh/models.h>
+#include <shell/shell.h>
+
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "shell_utils.h"
+
+static struct bt_mesh_model *mod;
+
+static void dtt_print(const struct shell *shell, int err, int32_t rsp)
+{
+	if (!err) {
+		shell_print(shell, "Transition time: %d", rsp);
+	}
+}
+
+static int cmd_dtt_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_dtt_cli *cli = mod->user_data;
+	int32_t rsp;
+
+	int err = bt_mesh_dtt_get(cli, NULL, &rsp);
+
+	dtt_print(shell, err, rsp);
+	return err;
+}
+
+static int dtt_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	int32_t trans_time = (int32_t)strtol(argv[1], NULL, 0);
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_dtt_cli *cli = mod->user_data;
+
+	if (acked) {
+		int32_t rsp;
+		int err = bt_mesh_dtt_set(cli, NULL, trans_time, &rsp);
+
+		dtt_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_dtt_set_unack(cli, NULL, trans_time);
+	}
+}
+
+static int cmd_dtt_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return dtt_set(shell, argc, argv, true);
+}
+
+static int cmd_dtt_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return dtt_set(shell, argc, argv, false);
+}
+
+static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *argv[])
+{
+	return shell_model_instances_get_all(shell, BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_CLI);
+}
+
+static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+
+	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_CLI,
+					elem_idx);
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(instance_cmds,
+			       SHELL_CMD_ARG(set, NULL, "<elem_idx> ", cmd_instance_set, 2, 0),
+			       SHELL_CMD_ARG(get-all, NULL, NULL, cmd_instance_get_all, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	dtt_cmds, SHELL_CMD_ARG(get, NULL, NULL, cmd_dtt_get, 1, 0),
+	SHELL_CMD_ARG(set, NULL, "<transition_time_ms>", cmd_dtt_set, 2, 0),
+	SHELL_CMD_ARG(set-unack, NULL, "<transition_time_ms>", cmd_dtt_set_unack, 2, 0),
+	SHELL_CMD(instance, &instance_cmds, "Instance commands", shell_model_cmds_help),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(mdl_dtt, &dtt_cmds, "Default transition time Cli commands",
+		       shell_model_cmds_help, 1, 1);

--- a/subsys/bluetooth/mesh/shell/shell_loc_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_loc_cli.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+#include <bluetooth/mesh/models.h>
+#include <shell/shell.h>
+
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "shell_utils.h"
+
+static struct bt_mesh_model *mod;
+
+static void global_loc_print(const struct shell *shell, int err, struct bt_mesh_loc_global rsp)
+{
+	if (!err) {
+		shell_print(shell, "Latitude: %f, longitude: %f, altitude: %d", rsp.latitude,
+			    rsp.longitude, rsp.altitude);
+	}
+}
+
+static int cmd_loc_global_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LOCATION_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_global rsp;
+
+	int err = bt_mesh_loc_cli_global_get(cli, NULL, &rsp);
+
+	global_loc_print(shell, err, rsp);
+	return err;
+}
+
+static int global_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	double latitude = shell_model_str2dbl(shell, argv[1]);
+	double longitude = shell_model_str2dbl(shell, argv[2]);
+	int16_t altitude = (int16_t)strtol(argv[3], NULL, 0);
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LOCATION_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_global set = {
+		.latitude = latitude,
+		.longitude = longitude,
+		.altitude = altitude,
+	};
+
+	if (acked) {
+		struct bt_mesh_loc_global rsp;
+		int err = bt_mesh_loc_cli_global_set(cli, NULL, &set, &rsp);
+
+		global_loc_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_loc_cli_global_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_loc_global_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return global_set(shell, argc, argv, true);
+}
+
+static int cmd_loc_global_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return global_set(shell, argc, argv, false);
+}
+
+static void local_loc_print(const struct shell *shell, int err, struct bt_mesh_loc_local rsp)
+{
+	if (!err) {
+		shell_print(shell,
+			    "North: %d, east: %d, altitude: %d, "
+			    "floor_number: %d, is_mobile: %d, "
+			    "time_delta: %d, precision_mm: %d",
+			    rsp.north, rsp.east, rsp.altitude, rsp.floor_number, rsp.is_mobile,
+			    rsp.time_delta, rsp.precision_mm);
+	}
+}
+
+static int cmd_loc_local_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LOCATION_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_local rsp;
+
+	int err = bt_mesh_loc_cli_local_get(cli, NULL, &rsp);
+
+	local_loc_print(shell, err, rsp);
+	return err;
+}
+
+static int local_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	int16_t north = (int16_t)strtol(argv[1], NULL, 0);
+	int16_t east = (int16_t)strtol(argv[2], NULL, 0);
+	int16_t altitude = (int16_t)strtol(argv[3], NULL, 0);
+	int16_t floor = (int16_t)strtol(argv[4], NULL, 0);
+	int32_t time_delta = (argc >= 6) ? (int32_t)strtol(argv[5], NULL, 0) : 0;
+	uint32_t precision_mm = (argc >= 7) ? (uint32_t)strtol(argv[6], NULL, 0) : 0;
+	bool is_mobile = (argc == 8) ? (bool)strtol(argv[7], NULL, 0) : false;
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LOCATION_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_local set = {
+		.north = north,
+		.east = east,
+		.altitude = altitude,
+		.floor_number = floor,
+		.is_mobile = is_mobile,
+		.time_delta = time_delta,
+		.precision_mm = precision_mm,
+	};
+
+	if (acked) {
+		struct bt_mesh_loc_local rsp;
+		int err = bt_mesh_loc_cli_local_set(cli, NULL, &set, &rsp);
+
+		local_loc_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_loc_cli_local_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_loc_local_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return local_set(shell, argc, argv, true);
+}
+
+static int cmd_loc_local_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return local_set(shell, argc, argv, false);
+}
+
+static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *argv[])
+{
+	return shell_model_instances_get_all(shell, BT_MESH_MODEL_ID_GEN_LOCATION_CLI);
+}
+
+static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+
+	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_LOCATION_CLI, elem_idx);
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(instance_cmds,
+			       SHELL_CMD_ARG(set, NULL, "<elem_idx> ", cmd_instance_set, 2, 0),
+			       SHELL_CMD_ARG(get-all, NULL, NULL, cmd_instance_get_all, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	loc_cmds, SHELL_CMD_ARG(global-get, NULL, NULL, cmd_loc_global_get, 1, 0),
+	SHELL_CMD_ARG(global-set, NULL, "<latitude> <longitude> <altitude>", cmd_loc_global_set,
+		      4, 0),
+	SHELL_CMD_ARG(global-set-unack, NULL, "<latitude> <longitude> <altitude>",
+		      cmd_loc_global_set_unack, 4, 0),
+	SHELL_CMD_ARG(local-get, NULL, NULL, cmd_loc_local_get, 1, 0),
+	SHELL_CMD_ARG(local-set, NULL,
+		      "<north> <east> <altitude> <floor> "
+		      "[time_delta [precision_mm [is_mobile]]]",
+		      cmd_loc_local_set, 5, 3),
+	SHELL_CMD_ARG(local-set-unack, NULL,
+		      "<north> <east> <altitude> <floor> "
+		      "[time_delta [precision_mm [is_mobile]]]",
+		      cmd_loc_local_set_unack, 5, 3),
+	SHELL_CMD(instance, &instance_cmds, "Instance commands", shell_model_cmds_help),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(mdl_loc, &loc_cmds, "Location Cli commands", shell_model_cmds_help, 1, 1);

--- a/subsys/bluetooth/mesh/shell/shell_lvl_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_lvl_cli.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+#include <bluetooth/mesh/models.h>
+#include <shell/shell.h>
+
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "shell_utils.h"
+
+static struct bt_mesh_model *mod;
+
+static void status_print(const struct shell *shell, int err, struct bt_mesh_lvl_status rsp)
+{
+	if (!err) {
+		shell_print(shell, "Current val: %d, target val: %d, rem time: %d", rsp.current,
+			    rsp.target, rsp.remaining_time);
+	}
+}
+
+static int cmd_lvl_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_lvl_cli *cli = mod->user_data;
+	struct bt_mesh_lvl_status rsp;
+
+	int err = bt_mesh_lvl_cli_get(cli, NULL, &rsp);
+
+	status_print(shell, err, rsp);
+	return err;
+}
+
+static int lvl_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	int16_t lvl = (int16_t)strtol(argv[1], NULL, 0);
+	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
+	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_lvl_cli *cli = mod->user_data;
+	struct bt_mesh_model_transition trans = { .time = time, .delay = delay };
+	struct bt_mesh_lvl_set set = {
+		.lvl = lvl,
+		.transition = (argc > 2) ? &trans : NULL,
+	};
+
+	if (acked) {
+		struct bt_mesh_lvl_status rsp;
+		int err = bt_mesh_lvl_cli_set(cli, NULL, &set, &rsp);
+
+		status_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_lvl_cli_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_lvl_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return lvl_set(shell, argc, argv, true);
+}
+
+static int cmd_lvl_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return lvl_set(shell, argc, argv, false);
+}
+
+static int delta_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	int32_t delta = (int32_t)strtol(argv[1], NULL, 0);
+	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
+	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_lvl_cli *cli = mod->user_data;
+	struct bt_mesh_model_transition trans = { .time = time, .delay = delay };
+	struct bt_mesh_lvl_delta_set set = {
+		.delta = delta,
+		.transition = (argc > 2) ? &trans : NULL,
+	};
+
+	if (acked) {
+		struct bt_mesh_lvl_status rsp;
+		int err = bt_mesh_lvl_cli_delta_set(cli, NULL, &set, &rsp);
+
+		status_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_lvl_cli_delta_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_delta_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return delta_set(shell, argc, argv, true);
+}
+
+static int cmd_delta_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return delta_set(shell, argc, argv, false);
+}
+
+static int move_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	int16_t delta = (int16_t)strtol(argv[1], NULL, 0);
+	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
+	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_lvl_cli *cli = mod->user_data;
+	struct bt_mesh_model_transition trans = { .time = time, .delay = delay };
+	struct bt_mesh_lvl_move_set set = {
+		.delta = delta,
+		.transition = (argc > 2) ? &trans : NULL,
+	};
+
+	if (acked) {
+		struct bt_mesh_lvl_status rsp;
+		int err = bt_mesh_lvl_cli_move_set(cli, NULL, &set, &rsp);
+
+		status_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_lvl_cli_move_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_move_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return move_set(shell, argc, argv, true);
+}
+
+static int cmd_move_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return move_set(shell, argc, argv, false);
+}
+
+static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *argv[])
+{
+	return shell_model_instances_get_all(shell, BT_MESH_MODEL_ID_GEN_LEVEL_CLI);
+}
+
+static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+
+	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_LEVEL_CLI, elem_idx);
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(instance_cmds,
+			       SHELL_CMD_ARG(set, NULL, "<elem_idx> ", cmd_instance_set, 2, 0),
+			       SHELL_CMD_ARG(get-all, NULL, NULL, cmd_instance_get_all, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	lvl_cmds, SHELL_CMD_ARG(get, NULL, NULL, cmd_lvl_get, 1, 0),
+	SHELL_CMD_ARG(set, NULL, "<lvl> [transition_time_ms [delay_ms]]",
+		      cmd_lvl_set, 2, 2),
+	SHELL_CMD_ARG(set-unack, NULL,
+		      "<lvl> [transition_time_ms [delay_ms]]",
+		      cmd_lvl_set_unack, 2, 2),
+	SHELL_CMD_ARG(delta-set, NULL,
+		      "<delta> [transition_time_ms [delay_ms]]]", cmd_delta_set,
+		      2, 2),
+	SHELL_CMD_ARG(delta-set-unack, NULL,
+		      "<delta> [transition_time_ms [delay_ms]]",
+		      cmd_delta_set_unack, 2, 2),
+	SHELL_CMD_ARG(move-set, NULL, "<delta> [transition_time_ms [delay_ms]]",
+		      cmd_move_set, 2, 2),
+	SHELL_CMD_ARG(move-set-unack, NULL,
+		      "<delta> [transition_time_ms [delay_ms]]",
+		      cmd_move_set_unack, 2, 2),
+	SHELL_CMD(instance, &instance_cmds, "Instance commands", shell_model_cmds_help),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(mdl_lvl, &lvl_cmds, "Level Cli commands", shell_model_cmds_help, 1, 1);

--- a/subsys/bluetooth/mesh/shell/shell_onoff_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_onoff_cli.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+#include <bluetooth/mesh/models.h>
+#include <shell/shell.h>
+
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "shell_utils.h"
+
+static struct bt_mesh_model *mod;
+
+static void status_print(const struct shell *shell, int err, struct bt_mesh_onoff_status rsp)
+{
+	if (!err) {
+		shell_print(shell, "Present val: %d, target val: %d, rem time: %d",
+			    rsp.present_on_off, rsp.target_on_off, rsp.remaining_time);
+	}
+}
+
+static int cmd_onoff_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_onoff_cli *cli = mod->user_data;
+	struct bt_mesh_onoff_status rsp;
+
+	int err = bt_mesh_onoff_cli_get(cli, NULL, &rsp);
+
+	status_print(shell, err, rsp);
+	return err;
+}
+
+static int onoff_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	bool on_off = shell_model_str2bool(argv[1]);
+	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
+	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_onoff_cli *cli = mod->user_data;
+	struct bt_mesh_model_transition trans = { .time = time, .delay = delay };
+	struct bt_mesh_onoff_set set = { .on_off = on_off,
+					 .transition = (argc > 2) ? &trans : NULL };
+
+	if (acked) {
+		struct bt_mesh_onoff_status rsp;
+		int err = bt_mesh_onoff_cli_set(cli, NULL, &set, &rsp);
+
+		status_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_onoff_cli_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_onoff_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return onoff_set(shell, argc, argv, true);
+}
+
+static int cmd_onoff_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return onoff_set(shell, argc, argv, false);
+}
+
+static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *argv[])
+{
+	return shell_model_instances_get_all(shell, BT_MESH_MODEL_ID_GEN_ONOFF_CLI);
+}
+
+static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+
+	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_ONOFF_CLI, elem_idx);
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(instance_cmds,
+			       SHELL_CMD_ARG(set, NULL, "<elem_idx> ", cmd_instance_set, 2, 0),
+			       SHELL_CMD_ARG(get-all, NULL, NULL, cmd_instance_get_all, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	onoff_cmds, SHELL_CMD_ARG(get, NULL, NULL, cmd_onoff_get, 1, 0),
+	SHELL_CMD_ARG(set, NULL, "<onoff> [transition_time_ms  [delay_ms]]", cmd_onoff_set, 2, 2),
+	SHELL_CMD_ARG(set-unack, NULL, "<onoff> [transition_time_ms  [delay_ms]]",
+		      cmd_onoff_set_unack, 2, 2),
+	SHELL_CMD(instance, &instance_cmds, "Instance commands", shell_model_cmds_help),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(mdl_onoff, &onoff_cmds, "OnOff Cli commands", shell_model_cmds_help, 1, 1);

--- a/subsys/bluetooth/mesh/shell/shell_plvl_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_plvl_cli.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+#include <bluetooth/mesh/models.h>
+#include <shell/shell.h>
+
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "shell_utils.h"
+
+static struct bt_mesh_model *mod;
+
+static void status_print(const struct shell *shell, int err, struct bt_mesh_plvl_status rsp)
+{
+	if (!err) {
+		shell_print(shell, "Current val: %d, target val: %d, rem time: %d", rsp.current,
+			    rsp.target, rsp.remaining_time);
+	}
+}
+
+static int cmd_power_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_status rsp;
+
+	int err = bt_mesh_plvl_cli_power_get(cli, NULL, &rsp);
+
+	status_print(shell, err, rsp);
+	return err;
+}
+
+static int power_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	uint16_t lvl = (uint16_t)strtol(argv[1], NULL, 0);
+	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
+	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_model_transition trans = { .time = time, .delay = delay };
+	struct bt_mesh_plvl_set set = { .power_lvl = lvl,
+					.transition = (argc > 2) ? &trans : NULL };
+
+	if (acked) {
+		struct bt_mesh_plvl_status rsp;
+		int err = bt_mesh_plvl_cli_power_set(cli, NULL, &set, &rsp);
+
+		status_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_plvl_cli_power_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_power_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return power_set(shell, argc, argv, true);
+}
+
+static int cmd_power_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return power_set(shell, argc, argv, false);
+}
+
+static void range_print(const struct shell *shell, int err, struct bt_mesh_plvl_range_status rsp)
+{
+	if (!err) {
+		shell_print(shell, "Status: %d, min: %d, max: %d", rsp.status, rsp.range.min,
+			    rsp.range.max);
+	}
+}
+
+static int cmd_range_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_range_status rsp;
+
+	int err = bt_mesh_plvl_cli_range_get(cli, NULL, &rsp);
+
+	range_print(shell, err, rsp);
+	return err;
+}
+
+static int range_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	uint16_t min = (uint16_t)strtol(argv[1], NULL, 0);
+	uint16_t max = (uint16_t)strtol(argv[2], NULL, 0);
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_range set = { .min = min, .max = max };
+
+	if (acked) {
+		struct bt_mesh_plvl_range_status rsp;
+		int err = bt_mesh_plvl_cli_range_set(cli, NULL, &set, &rsp);
+
+		range_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_plvl_cli_range_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_range_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return range_set(shell, argc, argv, true);
+}
+
+static int cmd_range_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return range_set(shell, argc, argv, false);
+}
+
+static void default_print(const struct shell *shell, int err, uint16_t rsp)
+{
+	if (!err) {
+		shell_print(shell, "Default power: %d", rsp);
+	}
+}
+
+static int cmd_default_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	uint16_t rsp;
+
+	int err = bt_mesh_plvl_cli_default_get(cli, NULL, &rsp);
+
+	default_print(shell, err, rsp);
+	return err;
+}
+
+static int default_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	uint16_t lvl = (uint16_t)strtol(argv[1], NULL, 0);
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+
+	if (acked) {
+		uint16_t rsp;
+		int err = bt_mesh_plvl_cli_default_set(cli, NULL, lvl, &rsp);
+
+		default_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_plvl_cli_default_set_unack(cli, NULL, lvl);
+	}
+}
+
+static int cmd_default_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return default_set(shell, argc, argv, true);
+}
+
+static int cmd_default_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return default_set(shell, argc, argv, false);
+}
+
+static int cmd_last_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	uint16_t rsp;
+
+	int err = bt_mesh_plvl_cli_last_get(cli, NULL, &rsp);
+
+	if (!err) {
+		shell_print(shell, "Last power Level: %d", rsp);
+	}
+
+	return err;
+}
+
+static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *argv[])
+{
+	return shell_model_instances_get_all(shell, BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI);
+}
+
+static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+
+	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI,
+					elem_idx);
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(instance_cmds,
+			       SHELL_CMD_ARG(set, NULL, "<elem_idx> ", cmd_instance_set, 2, 0),
+			       SHELL_CMD_ARG(get-all, NULL, NULL, cmd_instance_get_all, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	plvl_cmds, SHELL_CMD_ARG(get, NULL, NULL, cmd_power_get, 1, 0),
+	SHELL_CMD_ARG(set, NULL, "<lvl> [transition_time_ms [delay_ms]]", cmd_power_set,
+		      2, 2),
+	SHELL_CMD_ARG(set-unack, NULL, "<lvl> [transition_time_ms [delay_ms]]",
+		      cmd_power_set_unack, 2, 2),
+	SHELL_CMD_ARG(range-get, NULL, NULL, cmd_range_get, 1, 0),
+	SHELL_CMD_ARG(range-set, NULL, "<min> <max>", cmd_range_set, 3, 0),
+	SHELL_CMD_ARG(range-set-unack, NULL, "<min> <max>", cmd_range_set_unack, 3, 0),
+	SHELL_CMD_ARG(default-get, NULL, NULL, cmd_default_get, 1, 0),
+	SHELL_CMD_ARG(default-set, NULL, "<lvl>", cmd_default_set, 2, 0),
+	SHELL_CMD_ARG(default-set-unack, NULL, "<lvl>", cmd_default_set_unack, 2, 0),
+	SHELL_CMD_ARG(last-get, NULL, NULL, cmd_last_get, 1, 0),
+	SHELL_CMD(instance, &instance_cmds, "Instance commands", shell_model_cmds_help),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(mdl_plvl, &plvl_cmds, "Power level Cli commands", shell_model_cmds_help, 1,
+		       1);

--- a/subsys/bluetooth/mesh/shell/shell_ponoff_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_ponoff_cli.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+#include <bluetooth/mesh/models.h>
+#include <shell/shell.h>
+
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "shell_utils.h"
+
+static struct bt_mesh_model *mod;
+
+static void pwr_up_print(const struct shell *shell, int err, enum bt_mesh_on_power_up rsp)
+{
+	if (!err) {
+		shell_print(shell, "Power Up state: %d", rsp);
+	}
+}
+
+static int cmd_on_power_up_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_ONOFF_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_ponoff_cli *cli = mod->user_data;
+	enum bt_mesh_on_power_up rsp;
+
+	int err = bt_mesh_ponoff_cli_on_power_up_get(cli, NULL, &rsp);
+
+	pwr_up_print(shell, err, rsp);
+	return err;
+}
+
+static int on_power_up_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	enum bt_mesh_on_power_up pow_up = (enum bt_mesh_on_power_up)strtol(argv[1], NULL, 0);
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_ONOFF_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_ponoff_cli *cli = mod->user_data;
+
+	if (acked) {
+		enum bt_mesh_on_power_up rsp;
+		int err = bt_mesh_ponoff_cli_on_power_up_set(cli, NULL, pow_up, &rsp);
+
+		pwr_up_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_ponoff_cli_on_power_up_set_unack(cli, NULL, pow_up);
+	}
+}
+
+static int cmd_on_power_up_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return on_power_up_set(shell, argc, argv, true);
+}
+
+static int cmd_on_power_up_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return on_power_up_set(shell, argc, argv, false);
+}
+
+static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *argv[])
+{
+	return shell_model_instances_get_all(shell, BT_MESH_MODEL_ID_GEN_POWER_ONOFF_CLI);
+}
+
+static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+
+	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_POWER_ONOFF_CLI,
+					elem_idx);
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(instance_cmds,
+			       SHELL_CMD_ARG(set, NULL, "<elem_idx> ", cmd_instance_set, 2, 0),
+			       SHELL_CMD_ARG(get-all, NULL, NULL, cmd_instance_get_all, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	ponoff_cmds, SHELL_CMD_ARG(get, NULL, NULL, cmd_on_power_up_get, 1, 0),
+	SHELL_CMD_ARG(set, NULL, "<pow_up_state>", cmd_on_power_up_set, 2, 0),
+	SHELL_CMD_ARG(set-unack, NULL, "<pow_up_state>", cmd_on_power_up_set_unack, 2, 0),
+	SHELL_CMD(instance, &instance_cmds, "Instance commands", shell_model_cmds_help),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(mdl_ponoff, &ponoff_cmds, "Power OnOff Cli commands", shell_model_cmds_help,
+		       1, 1);

--- a/subsys/bluetooth/mesh/shell/shell_prop_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_prop_cli.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+#include <bluetooth/mesh/models.h>
+#include <shell/shell.h>
+
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "shell_utils.h"
+#include "common/log.h"
+
+static struct bt_mesh_model *mod;
+
+static void props_print(const struct shell *shell, int err, struct bt_mesh_prop_list rsp)
+{
+	if (!err) {
+		shell_print(shell, "ID count: %d", rsp.count);
+		for (uint8_t i = 0; i < rsp.count; i++) {
+			shell_print(shell, "ID %d val: %d", i, rsp.ids[i]);
+		}
+	}
+}
+
+static int cmd_prop_client_props_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint16_t id = (uint16_t)strtol(argv[1], NULL, 0);
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_prop_cli *cli = mod->user_data;
+	uint16_t ids[CONFIG_BT_MESH_PROP_MAXCOUNT];
+	struct bt_mesh_prop_list rsp = { .ids = &ids[0], .count = CONFIG_BT_MESH_PROP_MAXCOUNT };
+
+	int err = bt_mesh_prop_cli_client_props_get(cli, NULL, id, &rsp);
+
+	props_print(shell, err, rsp);
+	return err;
+}
+
+static int cmd_prop_props_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	enum bt_mesh_prop_srv_kind kind = (enum bt_mesh_prop_srv_kind)strtol(argv[1], NULL, 0);
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_prop_cli *cli = mod->user_data;
+	uint16_t ids[CONFIG_BT_MESH_PROP_MAXCOUNT];
+	struct bt_mesh_prop_list rsp = { .ids = &ids[0], .count = CONFIG_BT_MESH_PROP_MAXCOUNT };
+
+	int err = bt_mesh_prop_cli_props_get(cli, NULL, kind, &rsp);
+
+	props_print(shell, err, rsp);
+	return err;
+}
+
+static void prop_val_print(const struct shell *shell, int err, struct bt_mesh_prop_val rsp)
+{
+	if (!err) {
+		shell_print(shell, "Property value: %s", bt_hex(rsp.value, rsp.size));
+	}
+}
+
+static int cmd_prop_prop_get(const struct shell *shell, size_t argc, char *argv[])
+{
+	enum bt_mesh_prop_srv_kind kind = (enum bt_mesh_prop_srv_kind)strtol(argv[1], NULL, 0);
+	uint16_t id = (uint16_t)strtol(argv[2], NULL, 0);
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_prop_cli *cli = mod->user_data;
+	uint8_t value[CONFIG_BT_MESH_PROP_MAXSIZE];
+	struct bt_mesh_prop_val rsp = { .value = &value[0], .size = CONFIG_BT_MESH_PROP_MAXSIZE };
+
+	int err = bt_mesh_prop_cli_prop_get(cli, NULL, kind, id, &rsp);
+
+	prop_val_print(shell, err, rsp);
+	return err;
+}
+
+static int user_prop_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	uint16_t id = (uint16_t)strtol(argv[1], NULL, 0);
+	uint8_t val[CONFIG_BT_MESH_PROP_MAXSIZE] = { 0 };
+	uint8_t len = shell_model_hexstr2num(shell, argv[2], val, sizeof(val));
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_prop_cli *cli = mod->user_data;
+	struct bt_mesh_prop_val set = {
+		.meta.id = id,
+		.value = val,
+		.size = len,
+	};
+
+	if (acked) {
+		uint8_t rsp_val[CONFIG_BT_MESH_PROP_MAXSIZE];
+		struct bt_mesh_prop_val rsp = { .value = &rsp_val[0],
+						.size = CONFIG_BT_MESH_PROP_MAXSIZE };
+		int err = bt_mesh_prop_cli_user_prop_set(cli, NULL, &set, &rsp);
+
+		prop_val_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_prop_cli_user_prop_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_prop_user_prop_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return user_prop_set(shell, argc, argv, true);
+}
+
+static int cmd_prop_user_prop_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return user_prop_set(shell, argc, argv, false);
+}
+
+static int admin_prop_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	uint16_t id = (uint16_t)strtol(argv[1], NULL, 0);
+	enum bt_mesh_prop_access access = (enum bt_mesh_prop_access)strtol(argv[2], NULL, 0);
+	uint8_t val[CONFIG_BT_MESH_PROP_MAXSIZE] = { 0 };
+	uint8_t len = shell_model_hexstr2num(shell, argv[2], val, sizeof(val));
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_prop_cli *cli = mod->user_data;
+	struct bt_mesh_prop_val set = {
+		.meta.id = id,
+		.meta.user_access = access,
+		.value = val,
+		.size = len,
+	};
+
+	if (acked) {
+		uint8_t rsp_val[CONFIG_BT_MESH_PROP_MAXSIZE];
+		struct bt_mesh_prop_val rsp = { .value = &rsp_val[0],
+						.size = CONFIG_BT_MESH_PROP_MAXSIZE };
+		int err = bt_mesh_prop_cli_admin_prop_set(cli, NULL, &set, &rsp);
+
+		prop_val_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_prop_cli_admin_prop_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_prop_admin_prop_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return admin_prop_set(shell, argc, argv, true);
+}
+
+static int cmd_prop_admin_prop_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return admin_prop_set(shell, argc, argv, false);
+}
+
+static int mfr_prop_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
+{
+	uint16_t id = (uint16_t)strtol(argv[1], NULL, 0);
+	enum bt_mesh_prop_access access = (enum bt_mesh_prop_access)strtol(argv[3], NULL, 0);
+
+	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
+		return -ENODEV;
+	}
+
+	struct bt_mesh_prop_cli *cli = mod->user_data;
+	struct bt_mesh_prop set = {
+		.id = id,
+		.user_access = access,
+	};
+
+	if (acked) {
+		uint8_t rsp_val[CONFIG_BT_MESH_PROP_MAXSIZE];
+		struct bt_mesh_prop_val rsp = { .value = &rsp_val[0],
+						.size = CONFIG_BT_MESH_PROP_MAXSIZE };
+		int err = bt_mesh_prop_cli_mfr_prop_set(cli, NULL, &set, &rsp);
+
+		prop_val_print(shell, err, rsp);
+		return err;
+	} else {
+		return bt_mesh_prop_cli_mfr_prop_set_unack(cli, NULL, &set);
+	}
+}
+
+static int cmd_prop_mfr_prop_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	return mfr_prop_set(shell, argc, argv, true);
+}
+
+static int cmd_prop_mfr_prop_set_unack(const struct shell *shell, size_t argc, char *argv[])
+{
+	return mfr_prop_set(shell, argc, argv, false);
+}
+
+static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *argv[])
+{
+	return shell_model_instances_get_all(shell, BT_MESH_MODEL_ID_GEN_PROP_CLI);
+}
+
+static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
+{
+	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+
+	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_PROP_CLI, elem_idx);
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(instance_cmds,
+			       SHELL_CMD_ARG(set, NULL, "<elem_idx> ", cmd_instance_set, 2, 0),
+			       SHELL_CMD_ARG(get-all, NULL, NULL, cmd_instance_get_all, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	prop_cmds,
+	SHELL_CMD_ARG(cli-props-get, NULL, "<id>", cmd_prop_client_props_get, 2, 0),
+	SHELL_CMD_ARG(props-get, NULL, "<kind>", cmd_prop_props_get, 2, 0),
+	SHELL_CMD_ARG(prop-get, NULL, "<kind> <id>", cmd_prop_prop_get, 3, 0),
+	SHELL_CMD_ARG(user-prop-set, NULL, "<id> <hex_str_val>",
+		      cmd_prop_user_prop_set, 3, (CONFIG_BT_MESH_PROP_MAXSIZE - 1)),
+	SHELL_CMD_ARG(user-prop-set-unack, NULL, "<id> <hex_str_val>",
+		      cmd_prop_user_prop_set_unack, 3, (CONFIG_BT_MESH_PROP_MAXSIZE - 1)),
+	SHELL_CMD_ARG(admin-prop-set, NULL,
+		      "<id> <access> <hex_str_val>",
+		      cmd_prop_admin_prop_set, 4, (CONFIG_BT_MESH_PROP_MAXSIZE - 1)),
+	SHELL_CMD_ARG(admin-prop-set-unack, NULL,
+		      "<id> <access> <hex_str_val>",
+		      cmd_prop_admin_prop_set_unack, 4, (CONFIG_BT_MESH_PROP_MAXSIZE - 1)),
+	SHELL_CMD_ARG(mfr-prop-set, NULL, "<id> <access>", cmd_prop_mfr_prop_set, 3, 0),
+	SHELL_CMD_ARG(mfr-prop-set-unack, NULL, "<id> <access>",
+		      cmd_prop_mfr_prop_set_unack, 3, 0),
+	SHELL_CMD(instance, &instance_cmds, "Instance commands", shell_model_cmds_help),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(mdl_prop, &prop_cmds, "Property Cli commands", shell_model_cmds_help, 1, 1);

--- a/subsys/bluetooth/mesh/shell/shell_utils.c
+++ b/subsys/bluetooth/mesh/shell/shell_utils.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <bluetooth/mesh/models.h>
+#include <shell/shell.h>
+#include <ctype.h>
+#include <string.h>
+
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "shell_utils.h"
+
+struct shell_model_instance {
+	uint16_t addr;
+	uint8_t elem_idx;
+};
+
+static void model_instances_get(uint16_t id, struct shell_model_instance *arr, uint8_t len)
+{
+	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
+	struct bt_mesh_elem *elem;
+	struct bt_mesh_model *mod;
+
+	for (int i = 0; i < len; i++) {
+		elem = bt_mesh_elem_find(comp->elem[i].addr);
+		mod = bt_mesh_model_find(elem, id);
+		if (mod) {
+			arr[i].addr = comp->elem[i].addr;
+			arr[i].elem_idx = mod->elem_idx;
+		}
+	}
+}
+
+static uint8_t str2u8(const char *str)
+{
+	if (isdigit((unsigned char)str[0])) {
+		return strtoul(str, NULL, 0);
+	}
+
+	return (!strcmp(str, "on") || !strcmp(str, "enable"));
+}
+
+bool shell_model_str2bool(const char *str)
+{
+	return str2u8(str);
+}
+
+static bool hex_str_check(char *str, uint8_t str_len)
+{
+	if (str_len % 2) {
+		return false;
+	}
+
+	for (int i = 0; i < str_len; i++) {
+		if (!isxdigit((int)str[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+uint8_t shell_model_hexstr2num(const struct shell *shell, char *str, uint8_t *buf, uint8_t buf_len)
+{
+	char str_num[3] = { 0 };
+	int str_len = strlen(str);
+
+	if (!hex_str_check(str, str_len)) {
+		shell_error(shell, "Invalid hex string format");
+		return 0;
+	}
+
+	if ((str_len / 2) > buf_len) {
+		shell_error(shell, "Hex value is too large");
+		return 0;
+	}
+
+	for (int i = 0; i < str_len / 2; i++) {
+		strncpy(str_num, str + (i * 2), 2);
+		buf[i] = strtol(str_num, NULL, 16);
+	}
+
+	return str_len / 2;
+}
+
+double shell_model_str2dbl(const struct shell *shell, const char *str)
+{
+	char *point;
+	char frac_buf[10] = {0};
+	double decimal, frac;
+	int len;
+
+	decimal = (double)strtol(str, &point, 0);
+
+	if ((decimal <= LONG_MIN) || (decimal >= LONG_MAX)) {
+		shell_warn(shell, "Passed input value is too small/large. Returning zero");
+		return 0;
+	}
+
+	if (!strlen(point)) {
+		return decimal;
+	}
+
+	len = MIN((strlen(point) - 1), sizeof(frac_buf) - 1);
+	strncpy(frac_buf, point + 1, len);
+	frac = (double)strtol(frac_buf, NULL, 0);
+
+	for (int i = 0; i < len; i++) {
+		frac /= 10;
+	}
+
+	return (decimal < 0) ? (decimal - frac) : (decimal + frac);
+}
+
+bool shell_model_first_get(uint16_t id, struct bt_mesh_model **mod)
+{
+	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
+
+	for (int i = 0; i < comp->elem_count; i++) {
+		*mod = bt_mesh_model_find(&comp->elem[i], id);
+		if (*mod) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+int shell_model_instance_set(const struct shell *shell, struct bt_mesh_model **mod,
+			      uint16_t mod_id, uint8_t elem_idx)
+{
+	struct bt_mesh_model *mod_temp;
+	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
+
+	if (elem_idx >= comp->elem_count) {
+		shell_error(shell, "Invalid element index");
+		return -EINVAL;
+	}
+
+	mod_temp = bt_mesh_model_find(&comp->elem[elem_idx], mod_id);
+
+	if (mod_temp) {
+		*mod = mod_temp;
+	} else {
+		shell_error(shell, "Unable to find model instance for element index %d", elem_idx);
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+int shell_model_instances_get_all(const struct shell *shell, uint16_t mod_id)
+{
+	uint8_t elem_cnt = bt_mesh_elem_count();
+	struct shell_model_instance mod_arr[elem_cnt];
+
+	memset(mod_arr, 0, sizeof(mod_arr));
+	model_instances_get(mod_id, mod_arr, ARRAY_SIZE(mod_arr));
+
+	for (int i = 0; i < ARRAY_SIZE(mod_arr); i++) {
+		if (mod_arr[i].addr) {
+			shell_print(shell,
+				    "Client model instance found at addr 0x%.4X. Element index: %d",
+				    mod_arr[i].addr, mod_arr[i].elem_idx);
+		}
+	}
+
+	return 0;
+}
+
+int shell_model_cmds_help(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc == 1) {
+		shell_help(shell);
+		return 1;
+	}
+
+	shell_error(shell, "%s unknown command: %s", argv[0], argv[1]);
+	return -EINVAL;
+}

--- a/subsys/bluetooth/mesh/shell/shell_utils.h
+++ b/subsys/bluetooth/mesh/shell/shell_utils.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdint.h>
+#include <shell/shell.h>
+
+bool shell_model_str2bool(const char *str);
+
+uint8_t shell_model_hexstr2num(const struct shell *shell, char *str, uint8_t *buf, uint8_t buf_len);
+
+double shell_model_str2dbl(const struct shell *shell, const char *str);
+
+bool shell_model_first_get(uint16_t id, struct bt_mesh_model **mod);
+
+int shell_model_instance_set(const struct shell *shell, struct bt_mesh_model **mod,
+			      uint16_t mod_id, uint8_t elem_idx);
+
+int shell_model_instances_get_all(const struct shell *shell, uint16_t mod_id);
+
+int shell_model_cmds_help(const struct shell *shell, size_t argc, char **argv);


### PR DESCRIPTION
Adds support for shell interaction with client model instances in a mesh
application.

This includes:
- Generic OnOff
- Generic Level
- Generic Default Transition Time
- Generic OnPowerUp
- Generic Power Level
- Generic Battery
- Generic Location
- Generic Property

Adds basic framework for mesh model shell support.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>