### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6a901e0d1dbe5162d5019f772912b93274365e69
+      revision: pull/717/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Introduce a fix for excessive current consumption of the QSPI
peripheral on nRF5340.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>