### PR TITLE
lib: nrf_modem: Remove auto stopping of traces from modem_trace module

### DIFF
--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -77,7 +77,6 @@ If the application wants the trace data, :c:func:`nrf_modem_lib_trace_init` must
 This is done automatically when using the OS Abstraction layer.
 If the application wants to stop an ongoing trace session, it can use the :c:func:`nrf_modem_lib_trace_stop` function.
 The :c:func:`nrf_modem_lib_trace_start` function supports activating a subset of traces or all traces.
-It is also possible to use this function to run a trace session either for a specific time interval or until a given amount of trace data is received.
 
 .. _partition_mgr_integration:
 

--- a/include/modem/nrf_modem_lib_trace.h
+++ b/include/modem/nrf_modem_lib_trace.h
@@ -38,25 +38,10 @@ enum nrf_modem_lib_trace_mode {
  * This function sends AT command that requests the modem to start sending traces.
  *
  * @param trace_mode Trace mode
- * @param duration   Trace duration in seconds. If set to 0, the trace session will
- *                   continue until @ref nrf_modem_lib_trace_stop is called or until
- *                   the required size of max trace data (specified by the
- *                   @p max_size parameter) is received.
- * @param max_size   Maximum size (in bytes) of trace data that should be received.
- *                   The tracing will be stopped after receiving @p max_size
- *                   bytes. If set to 0, the trace session will continue until
- *                   @ref nrf_modem_lib_trace_stop is called or until the duration
- *                   set via the @p duration parameter is reached.
- *                   To ensure the integrity of the trace output, the
- *                   modem_trace module will never skip a trace message. For
- *                   this purpose, if it detects that a received trace won't fit
- *                   in the maximum allowed size, it will stop the trace session
- *                   without sending out that trace to the transport medium.
  *
  * @return Zero on success, non-zero otherwise.
  */
-int nrf_modem_lib_trace_start(enum nrf_modem_lib_trace_mode trace_mode, uint16_t duration,
-			      uint32_t max_size);
+int nrf_modem_lib_trace_start(enum nrf_modem_lib_trace_mode trace_mode);
 
 /** @brief Process modem trace data
  *

--- a/tests/lib/modem_trace/modem_trace_uart/src/modem_trace_test.c
+++ b/tests/lib/modem_trace/modem_trace_uart/src/modem_trace_test.c
@@ -13,16 +13,12 @@
 
 extern int unity_main(void);
 
-static int64_t trace_stop_timestamp = INT64_MAX;
 static const nrfx_uarte_t *p_uarte_inst_in_use;
 
 static const char *start_trace_at_cmd_fmt = "AT%%XMODEMTRACE=1,%hu";
 static unsigned int exp_trace_mode;
 static int nrf_modem_at_printf_retval;
 static bool exp_trace_stop;
-
-#define NO_TIMEOUT 0
-#define NO_MAX_SIZE 0
 
 /* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
 extern int generic_suiteTearDown(int num_failures);
@@ -36,7 +32,6 @@ void tearDown(void)
 {
 	mock_nrfx_uarte_Verify();
 
-	trace_stop_timestamp = INT64_MAX;
 	p_uarte_inst_in_use = NULL;
 	exp_trace_stop = false;
 }
@@ -53,11 +48,7 @@ static void nrf_modem_at_printf_ExpectTraceModeAndReturn(unsigned int trace_mode
 int nrf_modem_at_printf(const char *fmt, ...)
 {
 	if (exp_trace_stop) {
-		if (strcmp(fmt, "AT%%XMODEMTRACE=0") == 0) {
-			trace_stop_timestamp = k_uptime_get();
-		} else {
-			TEST_ASSERT_EQUAL_STRING("AT%%XMODEMTRACE=0", fmt);
-		}
+		TEST_ASSERT_EQUAL_STRING("AT%%XMODEMTRACE=0", fmt);
 	} else {
 		va_list args;
 		unsigned int trace_mode;
@@ -110,47 +101,12 @@ static void modem_trace_init_with_uart_transport(void)
 	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_init());
 }
 
-static void trace_session_setup_with_uart_transport(uint16_t duration, uint32_t max_size)
-{
-	modem_trace_init_with_uart_transport();
-
-	nrf_modem_at_printf_ExpectTraceModeAndReturn(NRF_MODEM_LIB_TRACE_ALL, 0);
-
-	TEST_ASSERT_EQUAL(0,
-			  nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL, duration, max_size));
-}
-
-/* Utility function that sends a given number of bytes to the modem_trace module. */
-static void traces_send(const uint32_t bytes_to_send)
-{
-	const uint16_t sample_trace_buffer_size = 10;
-	const uint8_t sample_trace_data[sample_trace_buffer_size];
-
-	uint16_t num_full_trace_buffers = bytes_to_send / sample_trace_buffer_size;
-
-	for (int i = 0; i < num_full_trace_buffers; i++) {
-		__wrap_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
-						     sizeof(sample_trace_data), NRFX_SUCCESS);
-
-		nrf_modem_lib_trace_process(sample_trace_data, sizeof(sample_trace_data));
-	}
-
-	uint16_t extra_bytes_needed = bytes_to_send % sample_trace_buffer_size;
-
-	if (extra_bytes_needed != 0) {
-		__wrap_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
-						     extra_bytes_needed, NRFX_SUCCESS);
-
-		nrf_modem_lib_trace_process(sample_trace_data, extra_bytes_needed);
-	}
-}
-
 /* Test that nrf_modem_lib_trace_start returns error when the modem trace module was not
  * initialized.
  */
 void test_modem_trace_start_when_not_initialized(void)
 {
-	TEST_ASSERT_EQUAL(-ENXIO, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL, 0, 0));
+	TEST_ASSERT_EQUAL(-ENXIO, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL));
 }
 
 void test_modem_trace_init_uart_transport_medium(void)
@@ -164,147 +120,25 @@ void test_modem_trace_init_uart_transport_medium(void)
 void test_modem_trace_start_coredump_only(void)
 {
 	nrf_modem_at_printf_ExpectTraceModeAndReturn(NRF_MODEM_LIB_TRACE_COREDUMP_ONLY, 0);
-	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_COREDUMP_ONLY, 0, 10));
+	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_COREDUMP_ONLY));
 }
 
 void test_modem_trace_start_all(void)
 {
 	nrf_modem_at_printf_ExpectTraceModeAndReturn(NRF_MODEM_LIB_TRACE_ALL, 0);
-	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL, 0, 10));
+	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL));
 }
 
 void test_modem_trace_start_ip_only(void)
 {
 	nrf_modem_at_printf_ExpectTraceModeAndReturn(NRF_MODEM_LIB_TRACE_IP_ONLY, 0);
-	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_IP_ONLY, 0, 10));
+	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_IP_ONLY));
 }
 
 void test_modem_trace_start_lte_ip(void)
 {
 	nrf_modem_at_printf_ExpectTraceModeAndReturn(NRF_MODEM_LIB_TRACE_LTE_IP, 0);
-	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_LTE_IP, 0, 10));
-}
-
-/* Test that verifies that the modem_trace module runs a trace session only for a given duration.
- * The max size of the trace is set to zero (i.e no limit for max size of trace data).
- */
-void test_modem_trace_start_with_duration_and_no_max_size(void)
-{
-	const uint16_t test_duration_in_seconds = 2;
-	const uint16_t threshold_in_ms = 20;
-
-	trace_session_setup_with_uart_transport(test_duration_in_seconds, NO_MAX_SIZE);
-
-	int64_t trace_start_time_stamp = k_uptime_get();
-
-	exp_trace_stop = true;
-
-	k_sleep(K_MSEC((test_duration_in_seconds * 1000)));
-
-	/* Verify that the trace session was stopped only after the required duration. */
-	TEST_ASSERT_GREATER_OR_EQUAL((test_duration_in_seconds * 1000) - threshold_in_ms,
-				     (trace_stop_timestamp - trace_start_time_stamp));
-}
-
-/* Test that verifies that the modem_trace module runs a trace session only until specified amount
- * of trace data is received when the duration parameter is set to zero (no timeout).
- * In this test case, the sizes of all individual trace sent are the same. The max size configured
- * is divisible the size of individual trace buffers.
- */
-void test_modem_trace_stop_when_max_size_reached(void)
-{
-	const uint32_t test_max_data_size_bytes = 200;
-
-	trace_session_setup_with_uart_transport(NO_TIMEOUT, test_max_data_size_bytes);
-
-	const uint16_t last_sample_trace_data_size = 10;
-	const uint8_t last_sample_trace_data[last_sample_trace_data_size];
-
-	/* Simulate the reception of modem traces until just before max size is reached. */
-	traces_send(test_max_data_size_bytes - sizeof(last_sample_trace_data));
-
-	/* In the next call to nrf_modem_lib_trace_process(), we send just enough data to reach max
-	 * size. So we expect the module to send that trace data to the transport medium and then
-	 * disable the traces.
-	 */
-	__wrap_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, last_sample_trace_data,
-					     sizeof(last_sample_trace_data), NRFX_SUCCESS);
-
-	exp_trace_stop = true;
-
-	nrf_modem_lib_trace_process(last_sample_trace_data, sizeof(last_sample_trace_data));
-}
-
-/* Test that verifies that the modem_trace module stops a trace session when it receives a trace
- * that will not fit in the max allowed size configured.
- */
-void test_modem_trace_stop_when_received_trace_wont_fit_in_max_size_allocated(void)
-{
-	const uint32_t test_max_data_size_bytes = 200;
-
-	trace_session_setup_with_uart_transport(NO_TIMEOUT, test_max_data_size_bytes);
-
-	/* Simulate the reception of modem traces until just before max size is reached. */
-	traces_send(test_max_data_size_bytes - 1);
-
-	/* In the next call to nrf_modem_lib_trace_process(), we send trace data that will not fit
-	 * in the max size configured.
-	 * Expect the module to disable traces. Do not expect the trace to be forwarded to the
-	 * transport medium.
-	 */
-	exp_trace_stop = true;
-	const uint8_t test_trace_data_that_wont_fit[10];
-
-	nrf_modem_lib_trace_process(test_trace_data_that_wont_fit,
-				    sizeof(test_trace_data_that_wont_fit));
-}
-
-/* Test that simulates a scenario when the application had provided both duration and max_size
- * parameters to the nrf_modem_lib_trace_start() API. And the max size had reached before duration.
- * The test verifies that verifies that the modem_trace module stops trace session as soon as
- * duration is reached.
- */
-void test_modem_trace_stop_when_max_size_reached_before_duration(void)
-{
-	const uint32_t test_max_data_size_bytes = 2000;
-	const uint32_t test_duration_in_seconds = 2;
-
-	trace_session_setup_with_uart_transport(test_duration_in_seconds, test_max_data_size_bytes);
-
-	exp_trace_stop = true;
-
-	/* Simulate the reception of traces until max_size is reached. */
-	traces_send(test_max_data_size_bytes);
-
-	/* Sleep for the test duration to verify no other calls to nrf_modem_at_printf is made. */
-	k_sleep(K_SECONDS(test_duration_in_seconds));
-}
-
-/* Test that simulates a scenario when the application had provided both duration and max_size
- * parameters to the nrf_modem_lib_trace_start() API. And the duration had reached before the
- * number of trace bytes specified by max_size parameter was received.
- * The test verifies that verifies that the modem_trace module stops trace session as soon as
- * the max_size limit is reached.
- */
-void test_modem_trace_stop_when_duration_reached_before_max_size(void)
-{
-	const uint32_t test_max_data_size_bytes = 2000;
-	const uint32_t test_duration_in_seconds = 2;
-
-	trace_session_setup_with_uart_transport(test_duration_in_seconds, test_max_data_size_bytes);
-
-	int64_t trace_start_time_stamp = k_uptime_get();
-
-	/* Simulate the reception of some traces without reaching the max_size limit. */
-	traces_send(test_max_data_size_bytes - 1);
-
-	exp_trace_stop = true;
-
-	k_sleep(K_SECONDS(test_duration_in_seconds));
-
-	/* Verify that the trace session was stopped only after the required duration. */
-	TEST_ASSERT_GREATER_OR_EQUAL(test_duration_in_seconds * 1000,
-				     (trace_stop_timestamp - trace_start_time_stamp));
+	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_LTE_IP));
 }
 
 /* Test that when UART is configured as trace transport, the traces are forwarded to UART API. */
@@ -317,7 +151,11 @@ void test_modem_trace_forwarding_to_uart(void)
 	const uint32_t sample_trace_buffer_size = max_uart_frag_size + 10;
 	const uint8_t sample_trace_data[sample_trace_buffer_size];
 
-	trace_session_setup_with_uart_transport(NO_TIMEOUT, NO_MAX_SIZE);
+	modem_trace_init_with_uart_transport();
+
+	nrf_modem_at_printf_ExpectTraceModeAndReturn(NRF_MODEM_LIB_TRACE_ALL, 0);
+
+	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL));
 
 	/* Simulate the reception of modem trace and expect the UART API to be called.
 	 * Since the trace buffer size is larger than maximum possible easydma transfer size,
@@ -341,7 +179,7 @@ void test_modem_trace_when_transport_uart_init_fails(void)
 	__wrap_nrfx_uarte_init_ExpectAnyArgsAndReturn(NRFX_ERROR_BUSY);
 
 	TEST_ASSERT_EQUAL(-EBUSY, nrf_modem_lib_trace_init());
-	TEST_ASSERT_EQUAL(-ENXIO, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL, 0, 0));
+	TEST_ASSERT_EQUAL(-ENXIO, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL));
 
 	const uint16_t sample_trace_buffer_size = 10;
 	const uint8_t sample_trace_data[sample_trace_buffer_size];
@@ -388,7 +226,7 @@ void test_modem_trace_start_when_nrf_modem_at_printf_fails(void)
 	/* Make nrf_modem_at_printf return failure. */
 	nrf_modem_at_printf_ExpectTraceModeAndReturn(NRF_MODEM_LIB_TRACE_ALL, -1);
 
-	TEST_ASSERT_EQUAL(-EOPNOTSUPP, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL, 0, 0));
+	TEST_ASSERT_EQUAL(-EOPNOTSUPP, nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL));
 }
 
 /* Test nrf_modem_lib_trace_stop when nrf_modem_at_printf returns fails. */
@@ -399,6 +237,16 @@ void test_modem_trace_stop_when_nrf_modem_at_printf_fails(void)
 	nrf_modem_at_printf_retval = -1;
 
 	TEST_ASSERT_EQUAL(-EOPNOTSUPP, nrf_modem_lib_trace_stop());
+}
+
+/* Test nrf_modem_lib_trace_stop when nrf_modem_at_printf returns success. */
+void test_modem_trace_stop(void)
+{
+	/* Make nrf_modem_at_printf return failure. */
+	exp_trace_stop = true;
+	nrf_modem_at_printf_retval = 0;
+
+	TEST_ASSERT_EQUAL(0, nrf_modem_lib_trace_stop());
 }
 
 void main(void)


### PR DESCRIPTION
It is currently not possible to call `nrf_modem_at_printf` from interrupt context. This happened when the trace session timer expired leading to an assert failure. Hence we remove the duration argument.

Since the modem can start sending traces before the `nrf_modem_lib_start()` is called, any maximum size configured by the application may be ignored when the first few traces are received. This leads to erroneous calculation of number of trace bytes received. It is better for the application to handle the size of trace data received and stop using the `nrf_modem_lib_trace_stop()` API when needed.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>