### PR TITLE
Add direction finding sample applications for connected mode

### DIFF
--- a/samples/bluetooth/direction_finding_central/CMakeLists.txt
+++ b/samples/bluetooth/direction_finding_central/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(direction_finding_central)
+
+# NORDIC SDK APP START
+target_sources(app PRIVATE
+  src/main.c
+)
+# NORDIC SDK APP END

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -1,0 +1,213 @@
+.. _bluetooth_direction_finding_central:
+
+Bluetooth: Direction finding central
+####################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The direction finding central sample application demonstrates Bluetooth® LE direction finding in a response received from a connected peripheral device.
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns
+
+The sample also requires an antenna matrix when operating in angle of arrival mode.
+It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.
+
+Overview
+********
+
+The direction finding central sample application uses Constant Tone Extension (CTE), received in a request response from a connected peer device.
+
+The sample supports two direction finding modes:
+
+* angle of arrival (AoA)
+* angle of departure (AoD)
+
+By default, both modes are available in the sample.
+
+Configuration
+*************
+
+|config|
+
+This sample configuration is split into the following two files:
+
+* generic configuration is available in the :file:`prj.conf` file
+* board specific configuration is available in the :file:`boards/<BOARD>.conf` file
+
+Board specific configuration involves configuring the Bluetooth LE controller.
+For :ref:`nRF5340 DK <ug_nrf5340>`, the Bluetooth LE controller is part of a ``child image`` meant to run on the network core.
+Configuration for the child image is stored in the :file:`child_image/` subdirectory.
+
+Angle of departure mode
+=======================
+
+To build this sample with angle of departure mode only, set ``OVERLAY_CONFIG`` to :file:`overlay-aod.conf`.
+
+See :ref:`cmake_options` for instructions on how to add this option.
+For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
+To build this sample for :ref:`nRF5340 DK <ug_nrf5340>`, with angle of arrival mode only, add content of :file:`overlay-aod.conf` file to :file:`child_image/hci_rpmsg.conf` file.
+
+Antenna matrix configuration for angle of arrival mode
+======================================================
+
+To use this sample when angle of arrival mode is enabled, additional configuration of GPIOs is required to control the antenna array.
+Example of such configuration is provided in a devicetree overlay file :file:`nrf52833dk_nrf52833.overlay`.
+
+The overlay file provides the information about which GPIOs should be used by the Radio peripheral to switch between antenna patches during the CTE reception in the AoA mode.
+At least two GPIOs must be provided to enable antenna switching.
+
+The GPIOs are used by the Radio peripheral in order given by the ``dfegpio#-gpios`` properties.
+The order is important because it affects mapping of the antenna switching patterns to GPIOs (see `Antenna patterns`_).
+
+To successfully use the direction finding central when the AoA mode is enabled, provide the following data related to antenna matrix design:
+
+* Provide the GPIO pins to ``dfegpio#-gpios`` properties in :file:`nrf52833dk_nrf52833.overlay` file
+* Provide the default antenna that will be used to receive a PDU ``dfe-pdu-antenna`` property in the :file:`nrf52833dk_nrf52833.overlay` file
+* Update the antenna switching patterns in :c:member:`ant_patterns` array in :file:`main.c`.
+
+Antenna patterns
+================
+
+The antenna switching pattern is a binary number where each bit is applied to a particular antenna GPIO pin.
+For example, the pattern 0x3 means that antenna GPIOs at index 0,1 will be set, while the following are left unset.
+
+This also means that, for example, when using four GPIOs, the pattern count cannot be greater than 16 and maximum allowed value is 15.
+
+If the number of switch-sample periods is greater than the number of stored switching patterns, then the radio loops back to the first pattern.
+
+The following table presents the patterns that you can use to switch antennas on the Nordic-designed antenna matrix:
+
++--------+--------------+
+|Antenna | PATTERN[3:0] |
++========+==============+
+| ANT_12 |  0 (0b0000)  |
++--------+--------------+
+| ANT_10 |  1 (0b0001)  |
++--------+--------------+
+| ANT_11 |  2 (0b0010)  |
++--------+--------------+
+| RFU    |  3 (0b0011)  |
++--------+--------------+
+| ANT_3  |  4 (0b0100)  |
++--------+--------------+
+| ANT_1  |  5 (0b0101)  |
++--------+--------------+
+| ANT_2  |  6 (0b0110)  |
++--------+--------------+
+| RFU    |  7 (0b0111)  |
++--------+--------------+
+| ANT_6  |  8 (0b1000)  |
++--------+--------------+
+| ANT_4  |  9 (0b1001)  |
++--------+--------------+
+| ANT_5  | 10 (0b1010)  |
++--------+--------------+
+| RFU    | 11 (0b1011)  |
++--------+--------------+
+| ANT_9  | 12 (0b1100)  |
++--------+--------------+
+| ANT_7  | 13 (0b1101)  |
++--------+--------------+
+| ANT_8  | 14 (0b1110)  |
++--------+--------------+
+| RFU    | 15 (0b1111)  |
++--------+--------------+
+
+Constant Tone Extension transmit and receive parameters
+=======================================================
+
+Constant Tone Extension works in one of two modes, angle of arrival (AoA) or angle of departure (AoD).
+The transmitter is configured with operation mode that is used for CTE transmission.
+The receiver operating mode depends on the configuration.
+By default, both AoA and AoD modes are enabled, and the CTE type is received in the CTEInfo field in PDU's extended advertising header.
+Depending on the operation mode selected for the CTE reception, the receiver's radio peripheral will either execute both antenna switching and CTE sampling (AoA), or CTE sampling only (AoD).
+
+There are two antenna switch slot lengths allowed, 1 µs or 2 µs.
+The transmitter uses the antenna switch slot length to configure radio peripheral in angle of departure mode only.
+The receiver uses the local setting of the antenna switch slot length in angle of arrival mode only.
+When the CTE type in the received PDU is AoD, the receiver's radio peripheral uses the antenna switch slot length appropriate for the AoD type (1 or 2 µs).
+The antenna switch slot length influences the number of IQ samples provided in the IQ samples report.
+
+Constant Tone Extension length is limited to a range between 16 µs and 160 µs.
+The value is provided in units of 8 µs.
+The transmitter is responsible for setting the CTE length.
+The value is sent to the receiver as part of the CTEInfo field in PDU's extended advertising header.
+The receiver's radio peripheral uses the CTE length, provided in periodic advertising PDU, to execute antenna switching and CTE sampling in AoA mode, or CTE sampling only in AoD mode.
+The CTE length has influence on number of IQ samples provided in the IQ samples report.
+
+Constant Tone Extension consists of three periods:
+
+* Guard period that lasts for 4 µs. There is a gap before the actual CTE reception and the adjacent PDU transmission to avoid interference.
+* Reference period where single antenna is used for sampling. The samples are spaced 1 µs from each other. The period duration is 8 µs.
+* Switch-sample period that is split into switch and sample slots. Each slot may be either 1 µs or 2 µs long.
+
+The total number of IQ samples provided by the IQ samples report varies.
+It depends on the CTE length and the antenna switch slot length.
+There will always be 8 samples from the reference period, 1 to 37 samples with 2 µs antenna switching slots, 2 to 74 samples with 1 µs antenna switching slots, meaning 9 to 82 samples in total.
+
+For example, the CTE length is 120 µs and the antenna switching slot is 1 µs.
+This will result in the following number of IQ samples:
+
+* 8 samples from the reference period.
+* Switch-sample period duration is: 120 µs - 16 µs = 104 µs. For the 1 µs antenna switching slot, the sample is taken every 2 µs (1 µs antenna switch slot, 1 µs sample slot). Meaning, the number of samples from the switch-sample period is 104 µs / 2 µs = 52.
+
+The total number of samples is 60.
+
+Building and running
+********************
+.. |sample path| replace:: :file:`samples/bluetooth/direction_finding_central`
+
+.. include:: /includes/build_and_run.txt
+
+Testing
+=======
+
+After programming the sample to your development kit, test it by performing the following steps:
+
+1. |connect_terminal_specific|
+#. In the terminal window, check for information similar to the following::
+
+      Bluetooth initialized
+      <inf> bt_hci_core: HW Platform: Nordic Semiconductor (XxXXXX)
+      <inf> bt_hci_core: HW Variant: nRF52x (XxXXXX)
+      <inf> bt_hci_core: Firmware: Standard Bluetooth controller (0xXX) Version 3.0 Build X
+      <inf> bt_hci_core: Identity: XX:XX:XX:XX:XX:XX (random)
+      <inf> bt_hci_core: HCI: version 5.3 (XxXX) revision XxXXXX, manufacturer XxXXXX
+      <inf> bt_hci_core: LMP: version 5.3 (XxXX) subver XxXXXX
+      Scanning successfully started
+      [DEVICE]: XX:XX:XX:XX:XX:XX (public), AD evt type 0, AD data len XX, RSSI XXX
+      [AD]: X data_len X
+      [AD]: X data_len X
+      Connected: XX:XX:XX:XX:XX:XX (random)
+      Enable receiving of CTE...
+      success. CTE receive enabled.
+      Request CTE from peer device...
+      success. CTE request enabled.
+      CTE[XX:XX:XX:XX:XX:XX (random)]: samples count XX, cte type XXX, slot durations: X [us], packet status XXX , RSSI XXX
+
+Dependencies
+************
+
+This sample uses the following Zephyr libraries:
+
+* ``include/zephyr/types.h``
+* ``lib/libc/minimal/include/errno.h``
+* ``include/sys/printk.h``
+* ``include/sys/byteorder.h``
+* ``include/sys/util.h``
+* :ref:`zephyr:bluetooth_api`:
+
+  * ``include/bluetooth/bluetooth.h``
+  * ``include/bluetooth/hci.h``
+  * ``include/bluetooth/direction.h``
+  * ``include/bluetooth/conn.h``

--- a/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52820.conf
+++ b/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52820.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+# Enable new implementation of LLCPs
+CONFIG_BT_LL_SW_LLCP=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+CONFIG_BT_CTLR_DF_CTE_RX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_RX=y
+CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_REQ=y
+
+# Ensure that there are enough control procedure contexts to queue and execute all procedures
+CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM=6
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y

--- a/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52820.overlay
+++ b/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52820.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is the number of antennas that are available on the antenna matrix
+	 * designed by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 0 (in antenna matrix designed
+	 * by Nordic Semiconductor) for Rx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoA is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
+};

--- a/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52833.conf
+++ b/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52833.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+# Enable new implementation of LLCPs
+CONFIG_BT_LL_SW_LLCP=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+CONFIG_BT_CTLR_DF_CTE_RX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_RX=y
+CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_REQ=y
+
+# Ensure that there are enough control procedure contexts to queue and execute all procedures
+CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM=6
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y

--- a/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52833.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is the number of antennas that are available on the antenna matrix
+	 * designed by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 0 (in antenna matrix designed
+	 * by Nordic Semiconductor) for Rx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoA is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
+};

--- a/samples/bluetooth/direction_finding_central/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/direction_finding_central/child_image/hci_rpmsg.conf
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+# Enable new implementation of LLCPs
+CONFIG_BT_LL_SW_LLCP=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+CONFIG_BT_CTLR_DF_CTE_RX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_RX=y
+CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_REQ=y
+
+# Ensure that there are enough control procedure contexts to queue and execute all procedures
+CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM=6
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+
+# Increase the size of buffer for events received by Host. It must be enough to store
+# comple IQ samples report.
+CONFIG_BT_BUF_EVT_RX_SIZE=255

--- a/samples/bluetooth/direction_finding_central/child_image/hci_rpmsg/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direction_finding_central/child_image/hci_rpmsg/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is the number of antennas that are available on the antenna matrix
+	 * designed by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 0 (in antenna matrix designed
+	 * by Nordic Semiconductor) for Rx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoA is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 4 0>;
+	dfegpio1-gpios = <&gpio0 5 0>;
+	dfegpio2-gpios = <&gpio0 6 0>;
+	dfegpio3-gpios = <&gpio0 7 0>;
+};

--- a/samples/bluetooth/direction_finding_central/overlay-aod.conf
+++ b/samples/bluetooth/direction_finding_central/overlay-aod.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable AoA Feature (antenna switching) in Rx mode in Controller and Host
+CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=n
+CONFIG_BT_DF_CTE_RX_AOA=n

--- a/samples/bluetooth/direction_finding_central/prj.conf
+++ b/samples/bluetooth/direction_finding_central/prj.conf
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT=y
+CONFIG_BT_DEBUG_LOG=y
+CONFIG_BT_DEVICE_NAME="Direction Finding Central"
+
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_SMP=y
+CONFIG_BT_GATT_CLIENT=y
+
+# Enable Direction Finding Feature RX in connected mode
+CONFIG_BT_DF=y
+CONFIG_BT_DF_CONNECTION_CTE_RX=y
+CONFIG_BT_DF_CONNECTION_CTE_REQ=y

--- a/samples/bluetooth/direction_finding_central/sample.yaml
+++ b/samples/bluetooth/direction_finding_central/sample.yaml
@@ -1,0 +1,17 @@
+sample:
+  name: Direction Finding Central
+  description: Sample application showing central role of Direction Finding in connected mode
+tests:
+  sample.bluetooth.direction_finding_central:
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833
+  sample.bluetooth.direction_finding_central.aod:
+    extra_args: OVERLAY_CONFIG="overlay-aod.conf"
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833

--- a/samples/bluetooth/direction_finding_central/src/main.c
+++ b/samples/bluetooth/direction_finding_central/src/main.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <errno.h>
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <sys/byteorder.h>
+
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/direction.h>
+#include <bluetooth/conn.h>
+
+/* Latency set to zero, to enforce PDU exchange every connection event */
+#define CONN_LATENCY 0U
+/* Arbitrary selected timeout value */
+#define CONN_TIMEOUT 400U
+/* Inteval used to run CTE request procedure periodically.
+ * Value is a number of connection events.
+ */
+#define CTE_REQ_INTERVAL (CONN_LATENCY + 10U)
+/* Length of CTE in unit of 8 us */
+#define CTE_LEN (0x14U)
+
+#define DF_FEAT_ENABLED BIT64(BT_LE_FEAT_BIT_CONN_CTE_RESP)
+
+static struct bt_conn *default_conn;
+static const struct bt_le_conn_param conn_params = BT_LE_CONN_PARAM_INIT(
+	BT_GAP_INIT_CONN_INT_MIN, BT_GAP_INIT_CONN_INT_MAX, CONN_LATENCY, CONN_TIMEOUT);
+
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
+/* Example sequence of antenna switch patterns for antenna matrix designed by
+ * Nordic. For more information about antenna switch patterns see README.rst.
+ */
+static const uint8_t ant_patterns[] = { 0x2, 0x0, 0x5, 0x6, 0x1, 0x4,
+					0xC, 0x9, 0xE, 0xD, 0x8, 0xA };
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
+
+static void start_scan(void);
+
+static const char *cte_type2str(uint8_t type)
+{
+	switch (type) {
+	case BT_DF_CTE_TYPE_AOA:
+		return "AOA";
+	case BT_DF_CTE_TYPE_AOD_1US:
+		return "AOD 1 [us]";
+	case BT_DF_CTE_TYPE_AOD_2US:
+		return "AOD 2 [us]";
+	default:
+		return "Unknown";
+	}
+}
+
+static const char *packet_status2str(uint8_t status)
+{
+	switch (status) {
+	case BT_DF_CTE_CRC_OK:
+		return "CRC OK";
+	case BT_DF_CTE_CRC_ERR_CTE_BASED_TIME:
+		return "CRC not OK, CTE Info OK";
+	case BT_DF_CTE_CRC_ERR_CTE_BASED_OTHER:
+		return "CRC not OK, Sampled other way";
+	case BT_DF_CTE_INSUFFICIENT_RESOURCES:
+		return "No resources";
+	default:
+		return "Unknown";
+	}
+}
+
+static bool eir_found(struct bt_data *data, void *user_data)
+{
+	bt_addr_le_t *addr = user_data;
+	uint64_t u64 = 0U;
+	int err;
+
+	printk("[AD]: %u data_len %u\n", data->type, data->data_len);
+
+	switch (data->type) {
+	case BT_DATA_LE_SUPPORTED_FEATURES:
+		if (data->data_len > sizeof(u64)) {
+			return true;
+		}
+
+		(void)memcpy(&u64, data->data, data->data_len);
+
+		u64 = sys_le64_to_cpu(u64);
+
+		if (!(u64 & DF_FEAT_ENABLED)) {
+			return true;
+		}
+
+		err = bt_le_scan_stop();
+		if (err) {
+			printk("Stop LE scan failed (err %d)\n", err);
+			return true;
+		}
+
+		err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, &conn_params, &default_conn);
+		if (err) {
+			printk("Create conn failed (err %d)\n", err);
+			start_scan();
+		}
+		return false;
+	}
+
+	return true;
+}
+
+static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+			 struct net_buf_simple *ad)
+{
+	char dev[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(addr, dev, sizeof(dev));
+	printk("[DEVICE]: %s, AD evt type %u, AD data len %u, RSSI %i\n", dev, type, ad->len, rssi);
+
+	/* We're only interested in connectable events */
+	if (type == BT_GAP_ADV_TYPE_ADV_IND || type == BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {
+		bt_data_parse(ad, eir_found, (void *)addr);
+	}
+}
+
+static void enable_cte_reqest(void)
+{
+	int err;
+
+	const struct bt_df_conn_cte_rx_param cte_rx_params = {
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
+		.cte_types = BT_DF_CTE_TYPE_ALL,
+		.slot_durations = 0x2,
+		.num_ant_ids = ARRAY_SIZE(ant_patterns),
+		.ant_ids = ant_patterns,
+#else
+		.cte_types = BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US,
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
+	};
+
+	const struct bt_df_conn_cte_req_params cte_req_params = {
+		.interval = CTE_REQ_INTERVAL,
+		.cte_length = CTE_LEN,
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
+		.cte_type = BT_DF_CTE_TYPE_AOA,
+#else
+		.cte_type = BT_DF_CTE_TYPE_AOD_2US,
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
+	};
+
+	printk("Enable receiving of CTE...\n");
+	err = bt_df_conn_cte_rx_enable(default_conn, &cte_rx_params);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success. CTE receive enabled.\n");
+
+	printk("Request CTE from peer device...\n");
+	err = bt_df_conn_cte_req_enable(default_conn, &cte_req_params);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success. CTE request enabled.\n");
+}
+
+static void start_scan(void)
+{
+	int err;
+
+	/* Use active scanning and disable duplicate filtering to handle any
+	 * devices that might update their advertising data at runtime.
+	 */
+	struct bt_le_scan_param scan_param = {
+		.type = BT_LE_SCAN_TYPE_ACTIVE,
+		.options = BT_LE_SCAN_OPT_NONE,
+		.interval = BT_GAP_SCAN_FAST_INTERVAL,
+		.window = BT_GAP_SCAN_FAST_WINDOW,
+	};
+
+	err = bt_le_scan_start(&scan_param, device_found);
+	if (err) {
+		printk("Scanning failed to start (err %d)\n", err);
+		return;
+	}
+
+	printk("Scanning successfully started\n");
+}
+
+static void connected(struct bt_conn *conn, uint8_t conn_err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (conn_err) {
+		printk("Failed to connect to %s (%u)\n", addr, conn_err);
+
+		bt_conn_unref(default_conn);
+		default_conn = NULL;
+
+		start_scan();
+		return;
+	}
+
+	printk("Connected: %s\n", addr);
+
+	if (conn == default_conn) {
+		enable_cte_reqest();
+	}
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	printk("Disconnected: %s (reason 0x%02x)\n", addr, reason);
+
+	if (default_conn != conn) {
+		return;
+	}
+
+	bt_conn_unref(default_conn);
+	default_conn = NULL;
+
+	start_scan();
+}
+
+static void cte_recv_cb(struct bt_conn *conn, struct bt_df_conn_iq_samples_report const *report)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (report->err == BT_DF_IQ_REPORT_ERR_SUCCESS) {
+		printk("CTE[%s]: samples count %d, cte type %s, slot durations: %u [us], "
+		       "packet status %s, RSSI %i\n",
+		       addr, report->sample_count, cte_type2str(report->cte_type),
+		       report->slot_durations, packet_status2str(report->packet_status),
+		       report->rssi);
+	} else {
+		printk("CTE[%s]: request failed, err %u\n", addr, report->err);
+	}
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+	.cte_report_cb = cte_recv_cb,
+};
+
+void main(void)
+{
+	int err;
+
+	err = bt_enable(NULL);
+	if (err) {
+		printk("Bluetooth init failed (err %d)\n", err);
+		return;
+	}
+
+	printk("Bluetooth initialized\n");
+
+	start_scan();
+}

--- a/samples/bluetooth/direction_finding_connectionless_rx/overlay-aod.conf
+++ b/samples/bluetooth/direction_finding_connectionless_rx/overlay-aod.conf
@@ -4,5 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Disable AoA Feature (antenna switching) in Rx mode
+# Disable AoA Feature (antenna switching) in Rx mode for in Controller and Host
 CONFIG_BT_CTLR_DF_ANT_SWITCH_RX=n
+CONFIG_BT_DF_CTE_RX_AOA=n

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -32,13 +32,13 @@ static K_SEM_DEFINE(sem_per_adv, 0, 1);
 static K_SEM_DEFINE(sem_per_sync, 0, 1);
 static K_SEM_DEFINE(sem_per_sync_lost, 0, 1);
 
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
 /* Example sequence of antenna switch patterns for antenna matrix designed by
  * Nordic. For more information about antenna switch patterns see README.rst.
  */
 static const uint8_t ant_patterns[] = { 0x2, 0x0, 0x5, 0x6, 0x1, 0x4,
 					0xC, 0x9, 0xE, 0xD, 0x8, 0xA };
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
 
 static inline uint32_t adv_interval_to_ms(uint16_t interval)
 {
@@ -235,14 +235,14 @@ static void enable_cte_rx(void)
 
 	const struct bt_df_per_adv_sync_cte_rx_param cte_rx_params = {
 		.max_cte_count = 5,
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
+#if defined(CONFIG_BT_DF_CTE_RX_AOA)
 		.cte_types = BT_DF_CTE_TYPE_ALL,
 		.slot_durations = 0x2,
 		.num_ant_ids = ARRAY_SIZE(ant_patterns),
 		.ant_ids = ant_patterns,
 #else
 		.cte_types = BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US,
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_RX */
+#endif /* CONFIG_BT_DF_CTE_RX_AOA */
 	};
 
 	printk("Enable receiving of CTE...\n");

--- a/samples/bluetooth/direction_finding_connectionless_tx/overlay-aoa.conf
+++ b/samples/bluetooth/direction_finding_connectionless_tx/overlay-aoa.conf
@@ -4,5 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Disable AoD Feature (antenna switching) in Tx mode
+# Disable AoD Feature (antenna switching) in Tx mode in Controller and Host
 CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
+CONFIG_BT_DF_CTE_TX_AOD=n

--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -58,11 +58,11 @@ const struct bt_df_adv_cte_tx_param cte_params = {
 	.cte_len = CTE_LEN,
 	.cte_count = 1,
 #if defined(CONFIG_BT_DF_CTE_TX_AOD)
-	.cte_type = BT_HCI_LE_AOD_CTE_2US,
+	.cte_type = BT_DF_CTE_TYPE_AOD_2US,
 	.num_ant_ids = ARRAY_SIZE(ant_patterns),
 	.ant_ids = ant_patterns
 #else
-	.cte_type = BT_HCI_LE_AOA_CTE,
+	.cte_type = BT_DF_CTE_TYPE_AOA,
 	.num_ant_ids = 0,
 	.ant_ids = NULL
 #endif /* CONFIG_BT_DF_CTE_TX_AOD */

--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -46,18 +46,18 @@ const static struct bt_le_per_adv_param per_adv_param = {
 	.options = BT_LE_ADV_OPT_USE_TX_POWER,
 };
 
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+#if defined(CONFIG_BT_DF_CTE_TX_AOD)
 /* Example sequence of antenna switch patterns for antenna matrix designed by
  * Nordic. For more information about antenna switch patterns see README.rst.
  */
 static uint8_t ant_patterns[] = {0x2, 0x0, 0x5, 0x6, 0x1, 0x4, 0xC, 0x9, 0xE,
 				 0xD, 0x8, 0xA};
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+#endif /* CONFIG_BT_DF_CTE_TX_AOD */
 
 const struct bt_df_adv_cte_tx_param cte_params = {
 	.cte_len = CTE_LEN,
 	.cte_count = 1,
-#if defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_TX)
+#if defined(CONFIG_BT_DF_CTE_TX_AOD)
 	.cte_type = BT_HCI_LE_AOD_CTE_2US,
 	.num_ant_ids = ARRAY_SIZE(ant_patterns),
 	.ant_ids = ant_patterns
@@ -65,7 +65,7 @@ const struct bt_df_adv_cte_tx_param cte_params = {
 	.cte_type = BT_HCI_LE_AOA_CTE,
 	.num_ant_ids = 0,
 	.ant_ids = NULL
-#endif /* CONFIG_BT_CTLR_DF_ANT_SWITCH_TX */
+#endif /* CONFIG_BT_DF_CTE_TX_AOD */
 	};
 
 static void adv_sent_cb(struct bt_le_ext_adv *adv,

--- a/samples/bluetooth/direction_finding_peripheral/CMakeLists.txt
+++ b/samples/bluetooth/direction_finding_peripheral/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(direction_finding_peripheral)
+
+# NORDIC SDK APP START
+target_sources(app PRIVATE
+  src/main.c
+)
+# NORDIC SDK APP END

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -1,0 +1,162 @@
+.. _direction_finding_peripheral:
+
+Bluetooth: Direction finding peripheral
+#######################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The direction finding peripheral sample demonstrates Bluetooth® LE direction finding transmission as a response to a request received from a connected central device.
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns
+
+The sample also requires an antenna matrix when operating in angle of departure mode.
+It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.
+
+Overview
+********
+
+The direction finding peripheral sample uses Constant Tone Extension (CTE), that is transmitted with periodic advertising PDUs.
+
+The sample supports two direction finding modes:
+
+* angle of arrival (AoA)
+* angle of departure (AoD)
+
+By default, both modes are available in the sample.
+
+Configuration
+*************
+
+|config|
+
+This sample configuration is split into the following two files:
+
+* generic configuration is available in the :file:`prj.conf` file
+* board specific configuration is available in the :file:`boards/<BOARD>.conf` file
+
+Board specific configuration involves configuring the Bluetooth LE controller.
+For :ref:`nRF5340 DK <ug_nrf5340>`, the Bluetooth LE controller is part of a ``child image`` meant to run on the network core.
+Configuration for the child image is stored in the :file:`child_image/` subdirectory.
+
+Angle of arrival mode
+=====================
+
+To build this sample with angle of arrival mode only, set ``OVERLAY_CONFIG`` to :file:`overlay-aoa.conf`.
+
+See :ref:`cmake_options` for instructions on how to add this option.
+For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
+To build this sample for :ref:`nRF5340 DK <ug_nrf5340>`, with angle of arrival mode only, add content of :file:`overlay-aoa.conf` file to :file:`child_image/hci_rpmsg.conf` file.
+
+Antenna matrix configuration for angle of departure mode
+========================================================
+
+To use this sample when angle of departure mode is enabled, additional configuration of GPIOs is required to control the antenna array.
+Example of such configuration is provided in a devicetree overlay file :file:`nrf52833dk_nrf52833.overlay`.
+
+The overlay file provides the information about which GPIOs should be used by the Radio peripheral to switch between antenna patches during the CTE transmission in the AoD mode.
+At least two GPIOs must be provided to enable antenna switching.
+
+The GPIOs are used by the Radio peripheral in order given by the ``dfegpio#-gpios`` properties.
+The order is important because it affects mapping of the antenna switching patterns to GPIOs (see `Antenna patterns`_).
+
+To successfully use the direction finding beacon when the AoD mode is enabled, provide the following data related to antenna matrix design:
+
+* Provide the GPIO pins to ``dfegpio#-gpios`` properties in :file:`nrf52833dk_nrf52833.overlay` file
+* Provide the default antenna that will be used to transmit a PDU ``dfe-pdu-antenna`` property in the :file:`nrf52833dk_nrf52833.overlay` file
+* Update the antenna switching patterns in :c:member:`ant_patterns` array in :file:`main.c`.
+
+Antenna patterns
+================
+
+The antenna switching pattern is a binary number where each bit is applied to a particular antenna GPIO pin.
+For example, the pattern 0x3 means that antenna GPIOs at index 0,1 will be set, while the following are left unset.
+
+This also means that, for example, when using four GPIOs, the pattern count cannot be greater than 16 and maximum allowed value is 15.
+
+If the number of switch-sample periods is greater than the number of stored switching patterns, then the radio loops back to the first pattern.
+
+The following table presents the patterns that you can use to switch antennas on the Nordic-designed antenna matrix:
+
++--------+--------------+
+|Antenna | PATTERN[3:0] |
++========+==============+
+| ANT_12 |  0 (0b0000)  |
++--------+--------------+
+| ANT_10 |  1 (0b0001)  |
++--------+--------------+
+| ANT_11 |  2 (0b0010)  |
++--------+--------------+
+| RFU    |  3 (0b0011)  |
++--------+--------------+
+| ANT_3  |  4 (0b0100)  |
++--------+--------------+
+| ANT_1  |  5 (0b0101)  |
++--------+--------------+
+| ANT_2  |  6 (0b0110)  |
++--------+--------------+
+| RFU    |  7 (0b0111)  |
++--------+--------------+
+| ANT_6  |  8 (0b1000)  |
++--------+--------------+
+| ANT_4  |  9 (0b1001)  |
++--------+--------------+
+| ANT_5  | 10 (0b1010)  |
++--------+--------------+
+| RFU    | 11 (0b1011)  |
++--------+--------------+
+| ANT_9  | 12 (0b1100)  |
++--------+--------------+
+| ANT_7  | 13 (0b1101)  |
++--------+--------------+
+| ANT_8  | 14 (0b1110)  |
++--------+--------------+
+| RFU    | 15 (0b1111)  |
++--------+--------------+
+
+Building and Running
+********************
+.. |sample path| replace:: :file:`samples/bluetooth/direction_finding_peripheral`
+
+.. include:: /includes/build_and_run.txt
+
+Testing
+=======
+
+After programming the sample to your development kit, test it by performing the following steps:
+
+1. |connect_terminal_specific|
+#. In the terminal window, check for information similar to the following::
+
+      Bluetooth initialized
+      <inf> bt_hci_core: HW Platform: Nordic Semiconductor (XxXXXX)
+      <inf> bt_hci_core: HW Variant: nRF52x (XxXXXX)
+      <inf> bt_hci_core: Firmware: Standard Bluetooth controller (XxXX) Version 3.0 Build X
+      <inf> bt_hci_core: Identity: XX:XX:XX:XX:XX (random)
+      <inf> bt_hci_core: HCI: version 5.3 (XxXX) revision XxXXXX, manufacturer XxXXXX
+      <inf> bt_hci_core: LMP: version 5.3 (XxXX) subver XxXXXX
+
+Dependencies
+************
+
+This sample uses the following Zephyr libraries:
+
+* ``include/zephyr/types.h``
+* ``lib/libc/minimal/include/errno.h``
+* ``include/sys/printk.h``
+* ``include/sys/byteorder.h``
+* :ref:`zephyr:bluetooth_api`:
+
+  * ``include/bluetooth/bluetooth.h``
+  * ``include/bluetooth/hci.h``
+  * ``include/bluetooth/direction.h``
+  * ``include/bluetooth/conn.h``

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.conf
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+# Enable new implementation of LLCPs
+CONFIG_BT_LL_SW_LLCP=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+CONFIG_BT_CTLR_DF_CTE_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_TX=y
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_RSP=y
+
+# Ensure that there are enough control procedure contexts to queue and execute all procedures
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM=6

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is the number of antennas that are available on the antenna matrix
+	 * designed by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 0 (in antenna matrix designed
+	 * by Nordic Semiconductor) for Rx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoA is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
+};

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.conf
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+# Enable new implementation of LLCPs
+CONFIG_BT_LL_SW_LLCP=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+CONFIG_BT_CTLR_DF_CTE_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_TX=y
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_RSP=y
+
+# Ensure that there are enough control procedure contexts to queue and execute all procedures
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM=6

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is the number of antennas that are available on the antenna matrix
+	 * designed by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 0 (in antenna matrix designed
+	 * by Nordic Semiconductor) for Rx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoA is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
+};

--- a/samples/bluetooth/direction_finding_peripheral/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/direction_finding_peripheral/child_image/hci_rpmsg.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR=y
+CONFIG_BT_LL_SW_SPLIT=y
+
+# Enable new implementation of LLCPs
+CONFIG_BT_LL_SW_LLCP=y
+
+# Enable Direction Finding Feature including AoA and AoD
+CONFIG_BT_CTLR_DF=y
+
+CONFIG_BT_CTLR_DF_CTE_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_TX=y
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=y
+CONFIG_BT_CTLR_DF_CONN_CTE_RSP=y
+
+# Ensure that there are enough control procedure contexts to queue and execute all procedures
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+CONFIG_BT_CTLR_LLCP_PROC_CTX_BUF_NUM=6

--- a/samples/bluetooth/direction_finding_peripheral/child_image/hci_rpmsg/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/child_image/hci_rpmsg/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&radio {
+	status = "okay";
+	/* This is the number of antennas that are available on the antenna matrix
+	 * designed by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 0 (in antenna matrix designed
+	 * by Nordic Semiconductor) for Rx PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoA is enabled.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic Semiconductor. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 4 0>;
+	dfegpio1-gpios = <&gpio0 5 0>;
+	dfegpio2-gpios = <&gpio0 6 0>;
+	dfegpio3-gpios = <&gpio0 7 0>;
+};

--- a/samples/bluetooth/direction_finding_peripheral/overlay-aoa.conf
+++ b/samples/bluetooth/direction_finding_peripheral/overlay-aoa.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable AoD Feature (antenna switching) in Tx mode in Controller and Host
+CONFIG_BT_CTLR_DF_ANT_SWITCH_TX=n
+CONFIG_BT_DF_CTE_TX_AOD=n

--- a/samples/bluetooth/direction_finding_peripheral/prj.conf
+++ b/samples/bluetooth/direction_finding_peripheral/prj.conf
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT=y
+CONFIG_BT_DEBUG_LOG=y
+CONFIG_BT_DEVICE_NAME="DF Conn App"
+CONFIG_BT_SMP=y
+
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_APPEARANCE=833
+
+# Enable Direction Finding Feature RX in connected mode
+CONFIG_BT_DF=y
+CONFIG_BT_DF_CONNECTION_CTE_TX=y
+CONFIG_BT_DF_CONNECTION_CTE_RSP=y

--- a/samples/bluetooth/direction_finding_peripheral/sample.yaml
+++ b/samples/bluetooth/direction_finding_peripheral/sample.yaml
@@ -1,0 +1,17 @@
+sample:
+  name: Direction Finding Peripheral
+  description: Sample application showing peripheral role of Direction Finding in connected mode
+tests:
+  sample.bluetooth.direction_finding_peripheral:
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833
+  sample.bluetooth.direction_finding_peripheral.aod:
+    extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
+    harness: bluetooth
+    platform_allow: nrf52833dk_nrf52833
+    tags: bluetooth
+    integration_platforms:
+        - nrf52833dk_nrf52833

--- a/samples/bluetooth/direction_finding_peripheral/src/main.c
+++ b/samples/bluetooth/direction_finding_peripheral/src/main.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/types.h>
+#include <errno.h>
+#include <sys/printk.h>
+#include <sys/byteorder.h>
+#include <zephyr.h>
+
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/conn.h>
+#include <bluetooth/direction.h>
+
+#define DF_FEAT_ENABLED BIT64(BT_LE_FEAT_BIT_CONN_CTE_RESP)
+
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA_BYTES(BT_DATA_LE_SUPPORTED_FEATURES, BT_LE_SUPP_FEAT_24_ENCODE(DF_FEAT_ENABLED)),
+};
+
+/* Latency set to zero, to enforce PDU exchange every connection event */
+#define CONN_LATENCY 0U
+/* Interval used to run CTE request procedure periodically.
+ * Value is a number of connection events.
+ */
+#define CTE_REQ_INTERVAL (CONN_LATENCY + 10U)
+/* Length of CTE in unit of 8 us */
+#define CTE_LEN (0x14U)
+
+#if defined(CONFIG_BT_DF_CTE_TX_AOD)
+/* Example sequence of antenna switch patterns for antenna matrix designed by
+ * Nordic. For more information about antenna switch patterns see README.rst.
+ */
+static uint8_t ant_patterns[] = {0x2, 0x0, 0x5, 0x6, 0x1, 0x4, 0xC, 0x9, 0xE,
+				 0xD, 0x8, 0xA};
+#endif /* CONFIG_BT_DF_CTE_TX_AOD */
+
+static void enable_cte_response(struct bt_conn *conn)
+{
+	int err;
+
+	const struct bt_df_conn_cte_tx_param cte_tx_params = {
+#if defined(CONFIG_BT_DF_CTE_TX_AOD)
+		.cte_types = BT_DF_CTE_TYPE_ALL,
+		.num_ant_ids = ARRAY_SIZE(ant_patterns),
+		.ant_ids = ant_patterns,
+#else
+		.cte_types = BT_DF_CTE_TYPE_AOA,
+#endif /* CONFIG_BT_DF_CTE_TX_AOD */
+	};
+
+	printk("Set CTE transmission params...");
+	err = bt_df_set_conn_cte_tx_param(conn, &cte_tx_params);
+	if (err) {
+		printk("failed (err %d)\n", err);
+		return;
+	}
+	printk("success.\n");
+
+	printk("Set CTE response enable...");
+	err = bt_df_conn_cte_rsp_enable(conn);
+	if (err) {
+		printk("failed (err %d).\n", err);
+		return;
+	}
+	printk("success.\n");
+}
+
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	if (err) {
+		printk("Connection failed (err 0x%02x)\n", err);
+	} else {
+		printk("Connected\n");
+
+		enable_cte_response(conn);
+	}
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	printk("Disconnected (reason 0x%02x)\n", reason);
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+};
+
+static void bt_ready(void)
+{
+	int err;
+
+	printk("Bluetooth initialized\n");
+
+	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Advertising failed to start (err %d)\n", err);
+		return;
+	}
+
+	printk("Advertising successfully started\n");
+}
+
+void main(void)
+{
+	int err;
+
+	err = bt_enable(NULL);
+	if (err) {
+		printk("Bluetooth init failed (err %d)\n", err);
+		return;
+	}
+
+	bt_ready();
+}

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d5a653348eeab5a3bd6305e4f1cd2d6dcf56774a
+      revision: ba4920ee7db4d17593d66664ff72304a1873e7d1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The PR provides two new applications that show how to use direction finding in connected mode.

Besides that there is a commit that updates connectionless samples to use Kconfigs that originate from Host.
It fixes issues with split builds for nRF53.
