### PR TITLE
drivers: mpsl: Make clock/power IRQ handler weak

### DIFF
--- a/drivers/mpsl/clock_control/nrfx_clock_mpsl.c
+++ b/drivers/mpsl/clock_control/nrfx_clock_mpsl.c
@@ -55,8 +55,7 @@ nrfx_err_t nrfx_clock_init(nrfx_clock_event_handler_t handler)
 	return NRFX_SUCCESS;
 }
 
-
-void nrfx_clock_irq_handler(void)
+__attribute__((weak)) void nrfx_clock_irq_handler(void)
 {
 	MPSL_IRQ_CLOCK_Handler();
 }


### PR DESCRIPTION
This allows for the power/clock interrupt to be overridden in user
applications.

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>