### PR TITLE
lib: nrf_modem: nrf91_sockets: Free file descriptor on accept error

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -274,6 +274,7 @@ Modem libraries
 * :ref:`nrf_modem_lib_readme` library:
 
   * Fixed a bug in the socket offloading component, where the :c:func:`recvfrom` wrapper could do an out-of-bounds copy of the sender's address, when the application is compiled without IPv6 support. In some cases, the out of bounds copy could indefinitely block the :c:func:`send` and other socket API calls.
+  * Fixed a bug in the socket offloading component, where the :c:func:`accept` wrapper did not free the reserved file descriptor if the call to :c:func:`nrf_accept` failed. On subsequent failing calls to :c:func:`accept`, this bug could result in the OS running out of file descriptors.
 
 * :ref:`at_monitor_readme` library:
 

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -577,7 +577,7 @@ static int nrf91_socket_offload_accept(void *obj, struct sockaddr *addr,
 	new_sd = nrf_accept(sd, nrf_addr_ptr, nrf_addrlen_ptr);
 	if (new_sd < 0) {
 		/* nrf_accept sets errno appropriately */
-		return -1;
+		goto error;
 	}
 
 	ctx = allocate_ctx(new_sd);


### PR DESCRIPTION
When called, nrf91_socket_offload_accept will reserve a file descriptor.
Free the file descriptor when accept fails, to allow subsequent calls
without running out of unused file descriptors.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>