### PR TITLE
modules: nrfxlib: nrf_802154: ECB use ZLI irq prio

### DIFF
--- a/modules/nrfxlib/nrf_802154/CMakeLists.txt
+++ b/modules/nrfxlib/nrf_802154/CMakeLists.txt
@@ -30,7 +30,7 @@ if (CONFIG_NRF_802154_RADIO_DRIVER OR CONFIG_NRF_802154_SERIALIZATION)
   target_link_libraries(nrf-802154-driver-interface INTERFACE zephyr-802154-interface)
   target_link_libraries(nrf-802154-serialization-interface INTERFACE zephyr-802154-interface)
 
-  target_compile_definitions(nrf-802154-driver-interface INTERFACE NRF_802154_ECB_PRIORITY=0)
+  target_compile_definitions(nrf-802154-driver-interface INTERFACE NRF_802154_ECB_PRIORITY=-1)
   target_compile_definitions(nrf-802154-driver-interface INTERFACE NRF_802154_SWI_PRIORITY=1)
   target_compile_definitions(nrf-802154-platform PUBLIC NRF_802154_SL_RTC_IRQ_PRIORITY=1)
 

--- a/west.yml
+++ b/west.yml
@@ -108,7 +108,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: b17e812a570a2dde7184209a907ceda8b8793497
+      revision: 3a5ee62b2d13d6acea9998ea32fde5a4176cafc0
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Blocking interrupts with k_spin_lock blocked ECB IRQ. This led to
possibility that nRF 802.15.4 Radio Driver transmits frames filled
with zeros instead of proper ciphertext. This commit sets ECB IRQ
priority to ZLI, as it is as time-critical.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>