### PR TITLE
mainfest: Add TF-M read service to flash driver

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -212,12 +212,14 @@ Drivers
 This section provides detailed lists of changes by :ref:`driver <drivers>`.
 
 
-Flash driver
---------------------
+Flash memory driver
+-------------------
 
-*  nRF SoC Flash driver
+* nRF SoC flash memory driver:
 
-  * Added TF-M secure read service.
+  * Added:
+
+    * TF-M secure read service.
 
 
 Libraries

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -211,7 +211,14 @@ Drivers
 
 This section provides detailed lists of changes by :ref:`driver <drivers>`.
 
-* |no_changes_yet_note|
+
+Flash driver
+--------------------
+
+*  nRF SoC Flash driver
+
+  * Added TF-M secure read service.
+
 
 Libraries
 =========

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d143ae93cabf2979b4bc3d049145e108a7d7adcf
+      revision: pull/720/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add TF-M read service to flash driver for nRF chips.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>