### PR TITLE
openthread: revert workaround for SRP encryption problem.

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -127,7 +127,6 @@ if OPENTHREAD_THREAD_VERSION_1_2
 # Thread 1.2 dependencies
 config NRF_802154_ENCRYPTION
 	bool
-	default n if CHIP
 	default y
 
 config IEEE802154_2015
@@ -144,7 +143,6 @@ config NET_PKT_TIMESTAMP
 
 config OPENTHREAD_MAC_SOFTWARE_TX_SECURITY_ENABLE
 	bool
-	default y if CHIP
 	default n
 
 if OPENTHREAD_CSL_RECEIVER


### PR DESCRIPTION
This commit reverts the workaround applied for ecryption
problem discoveded in SRP protocol when using NRF_security.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>