### PR TITLE
mpsl: mpsl_fem_host: Fix forwarding pins to net core

### DIFF
--- a/subsys/mpsl/fem/mpsl_fem_host.c
+++ b/subsys/mpsl/fem/mpsl_fem_host.c
@@ -10,6 +10,8 @@
 #include <sys/__assert.h>
 #include <hal/nrf_gpio.h>
 
+#define MPSL_FEM_SPI_IF DT_PHANDLE(DT_NODELABEL(nrf_radio_fem), spi_if)
+
 static void fem_pin_num_correction(uint8_t *p_gpio_pin, const char *gpio_lbl)
 {
 	(void)p_gpio_pin;


### PR DESCRIPTION
Change fixes forwarding FEM SPI pins to the network core.
Without the define, the pins were not forwarded.

Jira: NCSDK-13725