### PR TITLE
CODEOWNERS: Add codeowners for lte_link_control

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -89,7 +89,7 @@ Kconfig*                                  @tejlmand
 /lib/fprotect/                            @hakonfam
 /lib/flash_patch/                         @hakonfam
 /lib/location/                            @trantanen @hiltunent @jhirsi @tokangas
-/lib/lte_link_control/                    @jtguggedal
+/lib/lte_link_control/                    @jtguggedal @tokangas @simensrostad
 /lib/modem_info/                          @rlubos
 /lib/modem_key_mgmt/                      @rlubos
 /lib/multicell_location/                  @jhirsi @tokangas


### PR DESCRIPTION
Add codeowners for lte_link_control.

In a00e4490cb31e78bb66d3db4260cb589ac1437e6, I only added new owners for the lte_lc tests by mistake. This PR adds the same owners for the library too.