### PR TITLE
asset_tracker_v2: Kconfig: make A-GPS depend on GNSS

### DIFF
--- a/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
@@ -17,6 +17,7 @@ CLOUD_SERVICE_SELECTOR := choice
 # A-GPS takes precedence if both A-GPS and P-GPS are enabled at the same time. Therefore, A-GPS is
 # disabled when enabling P-GPS.
 config NRF_CLOUD_AGPS
+	depends on GNSS_MODULE
 	default y
 
 # Enable MQTT clean session by default. This is to ensure that the configured cloud MQTT service

--- a/applications/asset_tracker_v2/src/modules/Kconfig.gnss_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.gnss_module
@@ -5,7 +5,7 @@
 #
 
 menuconfig GNSS_MODULE
-	bool "GPS module"
+	bool "GNSS module"
 	select DATE_TIME
 	default y
 


### PR DESCRIPTION
There is no need to fetch A-GPS data if the GNSS module is not enabled.