### PR TITLE
nfc: ndef: msg_parser: prevent usage fault in case of unaligned buffer and other fixes

### DIFF
--- a/doc/nrf/libraries/nfc/ndef/msg_parser.rst
+++ b/doc/nrf/libraries/nfc/ndef/msg_parser.rst
@@ -25,7 +25,7 @@ The following code example shows how to parse an NDEF message, after you have us
 .. code-block:: c
 
    int  err;
-   uint8_t desc_buf[NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(MAX_NDEF_RECORDS)];
+   uint8_t desc_buf[NFC_NDEF_PARSER_REQUIRED_MEM(MAX_NDEF_RECORDS)];
    size_t desc_buf_len = sizeof(desc_buf);
 
    err = nfc_ndef_msg_parse(desc_buf,

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -169,6 +169,15 @@ Matter samples
 
   * Release configuration for all samples.
 
+NFC samples
+-----------
+
+* Updated:
+
+  * :ref:`nfc_tag_reader` sample:
+
+    * Skip NDEF content printing when message parsing returns an error.
+
 nrf5340 Samples
 ---------------
 
@@ -257,6 +266,14 @@ Libraries
 =========
 
 This section provides detailed lists of changes by :ref:`library <libraries>`.
+
+Libraries for NFC
+-----------------
+
+* :ref:`nfc_ndef_parser_readme`
+
+  * :c:func:`nfc_ndef_msg_parse`: fixed declaration, added an assertion to avoid a potential usage fault and added a note in the function documentation.
+  * Renamed the :c:macro:`NFC_NDEF_PARSER_REQUIRED_MEM` macro.
 
 Bluetooth libraries and services
 --------------------------------

--- a/include/nfc/ndef/msg_parser.h
+++ b/include/nfc/ndef/msg_parser.h
@@ -81,7 +81,7 @@ struct nfc_ndef_msg_parser_msg_2 {
  *  @retval 0 If the operation was successful.
  *            Otherwise, a (negative) error code is returned.
  */
-int nfc_ndef_msg_parse(const uint8_t  *result_buf,
+int nfc_ndef_msg_parse(uint8_t  *result_buf,
 		       uint32_t *result_buf_len,
 		       const uint8_t *raw_data,
 		       uint32_t *raw_data_len);

--- a/include/nfc/ndef/msg_parser.h
+++ b/include/nfc/ndef/msg_parser.h
@@ -53,7 +53,7 @@ struct nfc_ndef_msg_parser_msg_2 {
  *
  *  @param[in] max_count_of_records Maximum number of records to hold.
  */
-#define NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(max_count_of_records)          \
+#define NFC_NDEF_PARSER_REQUIRED_MEM(max_count_of_records)          \
 	(sizeof(struct nfc_ndef_msg_parser_msg_1) +                           \
 	 ((NFC_NDEF_MSG_PARSER_DELTA) * ((uint32_t)(max_count_of_records) - 1)))
 

--- a/include/nfc/ndef/msg_parser.h
+++ b/include/nfc/ndef/msg_parser.h
@@ -61,6 +61,8 @@ struct nfc_ndef_msg_parser_msg_2 {
  *
  *  This function parses NDEF messages using NDEF binary record descriptors.
  *
+ *  @note The @p result_buf parameter must point to a word-aligned address.
+ *
  *  @param[out] result_buf Pointer to the buffer that will be used to hold
  *                         the NDEF message descriptor. After parsing is
  *                         completed successfully, the first address

--- a/samples/bluetooth/central_nfc_pairing/src/nfc_poller.c
+++ b/samples/bluetooth/central_nfc_pairing/src/nfc_poller.c
@@ -194,7 +194,7 @@ static void ndef_data_analyze(const uint8_t *ndef_msg_buff, size_t nfc_data_len)
 {
 	int  err;
 	struct nfc_ndef_msg_desc *ndef_msg_desc;
-	uint8_t desc_buf[NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(MAX_NDEF_RECORDS)];
+	uint8_t desc_buf[NFC_NDEF_PARSER_REQUIRED_MEM(MAX_NDEF_RECORDS)];
 	size_t desc_buf_len = sizeof(desc_buf);
 
 	err = nfc_ndef_msg_parse(desc_buf,
@@ -313,7 +313,7 @@ static int on_t2t_transfer_complete(const uint8_t *data, size_t len)
 static bool tnep_data_search(const uint8_t *ndef_msg_buff, size_t nfc_data_len)
 {
 	int  err;
-	uint8_t desc_buf[NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(MAX_NDEF_RECORDS)];
+	uint8_t desc_buf[NFC_NDEF_PARSER_REQUIRED_MEM(MAX_NDEF_RECORDS)];
 	size_t desc_buf_len = sizeof(desc_buf);
 	uint8_t cnt = ARRAY_SIZE(services);
 

--- a/samples/nfc/tag_reader/src/main.c
+++ b/samples/nfc/tag_reader/src/main.c
@@ -241,7 +241,7 @@ static void ndef_data_analyze(const uint8_t *ndef_msg_buff, size_t nfc_data_len)
 {
 	int  err;
 	struct nfc_ndef_msg_desc *ndef_msg_desc;
-	uint8_t desc_buf[NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(MAX_NDEF_RECORDS)];
+	uint8_t desc_buf[NFC_NDEF_PARSER_REQUIRED_MEM(MAX_NDEF_RECORDS)];
 	size_t desc_buf_len = sizeof(desc_buf);
 
 	err = nfc_ndef_msg_parse(desc_buf,

--- a/samples/nfc/tag_reader/src/main.c
+++ b/samples/nfc/tag_reader/src/main.c
@@ -250,6 +250,7 @@ static void ndef_data_analyze(const uint8_t *ndef_msg_buff, size_t nfc_data_len)
 				 &nfc_data_len);
 	if (err) {
 		printk("Error during parsing a NDEF message, err: %d.\n", err);
+		return;
 	}
 
 	ndef_msg_desc = (struct nfc_ndef_msg_desc *) desc_buf;

--- a/samples/nfc/tnep_poller/src/main.c
+++ b/samples/nfc/tnep_poller/src/main.c
@@ -115,7 +115,7 @@ static void nfc_tag_detect(bool all_request)
 static bool tnep_data_search(const uint8_t *ndef_msg_buff, size_t nfc_data_len)
 {
 	int  err;
-	uint8_t desc_buf[NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(MAX_NDEF_RECORDS)];
+	uint8_t desc_buf[NFC_NDEF_PARSER_REQUIRED_MEM(MAX_NDEF_RECORDS)];
 	size_t desc_buf_len = sizeof(desc_buf);
 	uint8_t cnt = ARRAY_SIZE(services);
 

--- a/subsys/nfc/ndef/msg_parser.c
+++ b/subsys/nfc/ndef/msg_parser.c
@@ -9,7 +9,7 @@
 
 LOG_MODULE_REGISTER(nfc_ndef_parser, CONFIG_NFC_NDEF_PARSER_LOG_LEVEL);
 
-int nfc_ndef_msg_parse(const uint8_t *result_buf,
+int nfc_ndef_msg_parse(uint8_t *result_buf,
 		       uint32_t *result_buf_len,
 		       const uint8_t *raw_data,
 		       uint32_t *raw_data_len)

--- a/subsys/nfc/ndef/msg_parser.c
+++ b/subsys/nfc/ndef/msg_parser.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+#include <kernel.h>
 #include <logging/log.h>
 #include "msg_parser_local.h"
 
@@ -13,6 +14,9 @@ int nfc_ndef_msg_parse(const uint8_t *result_buf,
 		       const uint8_t *raw_data,
 		       uint32_t *raw_data_len)
 {
+	__ASSERT((POINTER_TO_UINT(result_buf) % 4) == 0,
+			"Buffer address for the msg parser must be word-aligned");
+
 	int err;
 	struct nfc_ndef_parser_memo_desc parser_memory_helper;
 

--- a/subsys/nfc/ndef/msg_parser_local.c
+++ b/subsys/nfc/ndef/msg_parser_local.c
@@ -77,7 +77,7 @@ int nfc_ndef_msg_parser_internal(struct nfc_ndef_parser_memo_desc *parser_memo_d
 }
 
 
-int nfc_ndef_msg_parser_memo_resolve(const uint8_t *result_buf,
+int nfc_ndef_msg_parser_memo_resolve(uint8_t *result_buf,
 				     uint32_t *result_buf_len,
 				     struct nfc_ndef_parser_memo_desc *parser_memo_desc)
 {

--- a/subsys/nfc/ndef/msg_parser_local.h
+++ b/subsys/nfc/ndef/msg_parser_local.h
@@ -44,8 +44,8 @@ struct nfc_ndef_parser_memo_desc {
  *
  *  This function should not be used directly.
  *
- *  @param[in] result_buf Pointer to the buffer that will be used to allocate
- *                        data instances.
+ *  @param[out] result_buf Pointer to the buffer that will be used to allocate
+ *                         data instances.
  *  @param[in,out] result_buf_len As input: size of the buffer specified
  *                                by @p result_buf.
  *                                As output: size of the reserved (used)
@@ -56,7 +56,7 @@ struct nfc_ndef_parser_memo_desc {
  *  @retval 0 If the operation was successful.
  *            Otherwise, a (negative) error code is returned.
  */
-int nfc_ndef_msg_parser_memo_resolve(const uint8_t *result_buf,
+int nfc_ndef_msg_parser_memo_resolve(uint8_t *result_buf,
 				     uint32_t *result_buf_len,
 				     struct nfc_ndef_parser_memo_desc *parser_memo_desc);
 

--- a/subsys/nfc/tnep/ch/common.c
+++ b/subsys/nfc/tnep/ch/common.c
@@ -56,7 +56,7 @@ static int handover_rec_parse(const struct nfc_ndef_ch_rec **ch_rec,
 	size_t rec_data_size;
 
 	rec_data_size = sizeof(struct nfc_ndef_ch_rec) +
-		NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(CONFIG_NFC_TNEP_CH_MAX_LOCAL_RECORD_COUNT);
+		NFC_NDEF_PARSER_REQUIRED_MEM(CONFIG_NFC_TNEP_CH_MAX_LOCAL_RECORD_COUNT);
 
 	rec_data = memory_allocate(buf, rec_data_size);
 	if (!rec_data) {

--- a/subsys/nfc/tnep/ch/tag.c
+++ b/subsys/nfc/tnep/ch/tag.c
@@ -175,8 +175,7 @@ static void ch_svc_msg_received(const uint8_t *data, size_t len)
 {
 	int err;
 	struct nfc_ndef_msg_desc *ch_msg;
-	uint8_t desc_buf[
-		NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(CONFIG_NFC_TNEP_CH_MAX_RECORD_COUNT)];
+	uint8_t desc_buf[NFC_NDEF_PARSER_REQUIRED_MEM(CONFIG_NFC_TNEP_CH_MAX_RECORD_COUNT)];
 	size_t desc_buf_len = sizeof(desc_buf);
 
 	NET_BUF_SIMPLE_DEFINE(ch_buf,

--- a/subsys/nfc/tnep/poller.c
+++ b/subsys/nfc/tnep/poller.c
@@ -601,7 +601,7 @@ int nfc_tnep_poller_svc_write(const struct nfc_ndef_msg_desc *msg,
 int nfc_tnep_poller_on_ndef_read(const uint8_t *data, size_t len)
 {
 	int err;
-	uint8_t desc_buf[NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(CONFIG_NFC_TNEP_POLLER_RX_MAX_RECORD_CNT)];
+	uint8_t desc_buf[NFC_NDEF_PARSER_REQUIRED_MEM(CONFIG_NFC_TNEP_POLLER_RX_MAX_RECORD_CNT)];
 	size_t desc_buf_len = sizeof(desc_buf);
 	struct nfc_tnep_poller_msg poller_msg;
 	struct nfc_ndef_msg_desc *msg;

--- a/subsys/nfc/tnep/tag.c
+++ b/subsys/nfc/tnep/tag.c
@@ -246,7 +246,7 @@ static int tnep_svc_select_from_msg(void)
 	int err;
 	enum tnep_svc_record_status svc_status = TNEP_SVC_NOT_FOUND;
 	const struct nfc_ndef_msg_desc *msg_p;
-	uint8_t desc_buf[NFC_NDEF_PARSER_REQIRED_MEMO_SIZE_CALC(
+	uint8_t desc_buf[NFC_NDEF_PARSER_REQUIRED_MEM(
 				CONFIG_NFC_TNEP_RX_MAX_RECORD_CNT)];
 	size_t desc_buf_len = sizeof(desc_buf);
 


### PR DESCRIPTION
- protect the message parser against a possible usage fault, 
- fixed macro name
- fixed an API function declaration in include/nfc/ndef/msg_parser.h
- removed printing the NDEF content in the Tag Reader sample, when parsing the NDEF message returned an error