### PR TITLE
lib: lte_lc: Add checks to connect_lte() to avoid hanging

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -812,6 +812,7 @@ int lte_lc_init(void);
  * @retval -EFAULT if an AT command failed.
  * @retval -ETIMEDOUT if a connection attempt timed out before the device was
  *	   registered to a network.
+ * @retval -EINPROGRESS if a connection establishment attempt is already in progress.
  */
 int lte_lc_connect(void);
 
@@ -827,6 +828,7 @@ int lte_lc_connect(void);
  * @retval -EFAULT if an AT command failed.
  * @retval -ETIMEDOUT if a connection attempt timed out before the device was
  *	   registered to a network.
+ * @retval -EINPROGRESS if a connection establishment attempt is already in progress.
  */
 int lte_lc_init_and_connect(void);
 


### PR DESCRIPTION
If an application calls lte_lc_connect() or lte_lc_init_and_connect()
when the device is already registered with an LTE network, it would
previously hang until timing out, waiting for the link semaphore that
was already given.

A similar issue could occur if two threads called one of the APIs
at the same time. The semaphore would only be given to one of them,
and the other thread would hang.

This patch introduces two mechanisms to avoid this:
- Check network registration status before doing device configuration
  and setting the modem's functional mode.
- A flag to indicate that a connection establishment is already in
  progress.
