### PR TITLE
caf: ble_smp: Log application image version

### DIFF
--- a/subsys/caf/modules/ble_smp.c
+++ b/subsys/caf/modules/ble_smp.c
@@ -56,6 +56,7 @@ static bool event_handler(const struct event_header *eh)
 				module_set_state(MODULE_STATE_ERROR);
 			} else {
 				LOG_INF("Service initialized");
+				LOG_INF("MCUboot image version: %s", CONFIG_MCUBOOT_IMAGE_VERSION);
 				module_set_state(MODULE_STATE_READY);
 			}
 		}


### PR DESCRIPTION
Adds info about application image version to logs.
The info is logged, when CAF BLE SMP module initializes.

Jira: NCSDK-12998

Signed-off-by: Aleksander Strzebonski <aleksander.strzebonski@nordicsemi.no>