### PR TITLE
asset_tracker_v2: app_module_event: avoid undefined behavior

### DIFF
--- a/applications/asset_tracker_v2/src/events/app_module_event.c
+++ b/applications/asset_tracker_v2/src/events/app_module_event.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "app_module_event.h"
+#include "common_module_event.h"
 
 static char *type2str(enum app_module_data_type type)
 {
@@ -104,22 +105,12 @@ static void profile_event(struct log_event_buf *buf,
 #endif
 }
 
-EVENT_INFO_DEFINE(app_module_event,
-#if defined(CONFIG_PROFILER_EVENT_TYPE_STRING)
-		  ENCODE(PROFILER_ARG_STRING),
-#else
-		  ENCODE(PROFILER_ARG_U8),
-#endif
-		  ENCODE("type"),
-		  profile_event);
+COMMON_EVENT_INFO_DEFINE(app_module_event,
+			 profile_event);
 
 #endif /* CONFIG_PROFILER */
 
-EVENT_TYPE_DEFINE(app_module_event,
-		  CONFIG_APP_EVENTS_LOG,
-		  log_event,
-#if defined(CONFIG_PROFILER)
-		  &app_module_event_info);
-#else
-		  NULL);
-#endif
+COMMON_EVENT_TYPE_DEFINE(app_module_event,
+			 CONFIG_APP_EVENTS_LOG,
+			 log_event,
+			 &app_module_event_info);

--- a/applications/asset_tracker_v2/src/events/cloud_module_event.c
+++ b/applications/asset_tracker_v2/src/events/cloud_module_event.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "cloud_module_event.h"
+#include "common_module_event.h"
 
 static char *get_evt_type_str(enum cloud_module_event_type type)
 {
@@ -67,22 +68,12 @@ static void profile_event(struct log_event_buf *buf,
 #endif
 }
 
-EVENT_INFO_DEFINE(cloud_module_event,
-#if defined(CONFIG_PROFILER_EVENT_TYPE_STRING)
-		  ENCODE(PROFILER_ARG_STRING),
-#else
-		  ENCODE(PROFILER_ARG_U8),
-#endif
-		  ENCODE("type"),
-		  profile_event);
+COMMON_EVENT_INFO_DEFINE(cloud_module_event,
+			 profile_event);
 
 #endif /* CONFIG_PROFILER */
 
-EVENT_TYPE_DEFINE(cloud_module_event,
-		  CONFIG_CLOUD_EVENTS_LOG,
-		  log_event,
-#if defined(CONFIG_PROFILER)
-		  &cloud_module_event_info);
-#else
-		  NULL);
-#endif
+COMMON_EVENT_TYPE_DEFINE(cloud_module_event,
+			 CONFIG_CLOUD_EVENTS_LOG,
+			 log_event,
+			 &cloud_module_event_info);

--- a/applications/asset_tracker_v2/src/events/common_module_event.h
+++ b/applications/asset_tracker_v2/src/events/common_module_event.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <sys/util_macro.h>
+#include <event_manager.h>
+#include <event_manager_profiler_tracer.h>
+
+#ifndef _COMMON_MODULE_EVENT_H_
+#define _COMMON_MODULE_EVENT_H_
+
+#define COMMON_EVENT_TYPES						\
+	COND_CODE_1(CONFIG_PROFILER_EVENT_TYPE_STRING,			\
+		    (PROFILER_ARG_STRING),				\
+		    (PROFILER_ARG_U8)),					\
+
+#define COMMON_EVENT_INFO_DEFINE(ename, profile_func)			\
+	EVENT_INFO_DEFINE(ename,					\
+			  ENCODE(COMMON_EVENT_TYPES),			\
+			  ENCODE("type"),				\
+			  profile_func)
+
+#define COMMON_EVENT_TYPE_DEFINE(ename, init_log_en, log_fn, ev_info_struct) \
+	EVENT_TYPE_DEFINE(ename,					\
+			  init_log_en,					\
+			  log_fn,					\
+			  COND_CODE_1(CONFIG_PROFILER,			\
+				      (ev_info_struct),			\
+				      (NULL)))
+
+#endif /* _COMMON_MODULE_EVENT_H_ */

--- a/applications/asset_tracker_v2/src/events/data_module_event.c
+++ b/applications/asset_tracker_v2/src/events/data_module_event.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "data_module_event.h"
+#include "common_module_event.h"
 
 static char *get_evt_type_str(enum data_module_event_type type)
 {
@@ -72,22 +73,12 @@ static void profile_event(struct log_event_buf *buf,
 #endif
 }
 
-EVENT_INFO_DEFINE(data_module_event,
-#if defined(CONFIG_PROFILER_EVENT_TYPE_STRING)
-		  ENCODE(PROFILER_ARG_STRING),
-#else
-		  ENCODE(PROFILER_ARG_U8),
-#endif
-		  ENCODE("type"),
-		  profile_event);
+COMMON_EVENT_INFO_DEFINE(data_module_event,
+			 profile_event);
 
 #endif /* CONFIG_PROFILER */
 
-EVENT_TYPE_DEFINE(data_module_event,
-		  CONFIG_DATA_EVENTS_LOG,
-		  log_event,
-#if defined(CONFIG_PROFILER)
-		  &data_module_event_info);
-#else
-		  NULL);
-#endif
+COMMON_EVENT_TYPE_DEFINE(data_module_event,
+			 CONFIG_DATA_EVENTS_LOG,
+			 log_event,
+			 &data_module_event_info);

--- a/applications/asset_tracker_v2/src/events/debug_module_event.c
+++ b/applications/asset_tracker_v2/src/events/debug_module_event.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "debug_module_event.h"
+#include "common_module_event.h"
 
 static char *get_evt_type_str(enum debug_module_event_type type)
 {
@@ -43,22 +44,12 @@ static void profile_event(struct log_event_buf *buf,
 #endif
 }
 
-EVENT_INFO_DEFINE(debug_module_event,
-#if defined(CONFIG_PROFILER_EVENT_TYPE_STRING)
-		  ENCODE(PROFILER_ARG_STRING),
-#else
-		  ENCODE(PROFILER_ARG_U8),
-#endif
-		  ENCODE("type"),
-		  profile_event);
+COMMON_EVENT_INFO_DEFINE(debug_module_event,
+			 profile_event);
 
 #endif /* CONFIG_PROFILER */
 
-EVENT_TYPE_DEFINE(debug_module_event,
-		  CONFIG_DEBUG_EVENTS_LOG,
-		  log_event,
-#if defined(CONFIG_PROFILER)
-		  &debug_module_event_info);
-#else
-		  NULL);
-#endif
+COMMON_EVENT_TYPE_DEFINE(debug_module_event,
+			 CONFIG_DEBUG_EVENTS_LOG,
+			 log_event,
+			 &debug_module_event_info);

--- a/applications/asset_tracker_v2/src/events/gnss_module_event.c
+++ b/applications/asset_tracker_v2/src/events/gnss_module_event.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "gnss_module_event.h"
+#include "common_module_event.h"
 
 static char *get_evt_type_str(enum gnss_module_event_type type)
 {
@@ -58,22 +59,12 @@ static void profile_event(struct log_event_buf *buf,
 #endif
 }
 
-EVENT_INFO_DEFINE(gnss_module_event,
-#if defined(CONFIG_PROFILER_EVENT_TYPE_STRING)
-		  ENCODE(PROFILER_ARG_STRING),
-#else
-		  ENCODE(PROFILER_ARG_U8),
-#endif
-		  ENCODE("type"),
-		  profile_event);
+COMMON_EVENT_INFO_DEFINE(gnss_module_event,
+			 profile_event);
 
 #endif /* CONFIG_PROFILER */
 
-EVENT_TYPE_DEFINE(gnss_module_event,
-		  CONFIG_GNSS_EVENTS_LOG,
-		  log_event,
-#if defined(CONFIG_PROFILER)
-		  &gnss_module_event_info);
-#else
-		  NULL);
-#endif
+COMMON_EVENT_TYPE_DEFINE(gnss_module_event,
+			 CONFIG_GNSS_EVENTS_LOG,
+			 log_event,
+			 &gnss_module_event_info);

--- a/applications/asset_tracker_v2/src/events/modem_module_event.c
+++ b/applications/asset_tracker_v2/src/events/modem_module_event.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "modem_module_event.h"
+#include "common_module_event.h"
 
 static char *get_evt_type_str(enum modem_module_event_type type)
 {
@@ -86,21 +87,12 @@ static void profile_event(struct log_event_buf *buf,
 #endif
 }
 
-EVENT_INFO_DEFINE(modem_module_event,
-#if defined(CONFIG_PROFILER_EVENT_TYPE_STRING)
-		  ENCODE(PROFILER_ARG_STRING),
-#else
-		  ENCODE(PROFILER_ARG_U8),
-#endif
-		  ENCODE("type"),
-		  profile_event);
+COMMON_EVENT_INFO_DEFINE(modem_module_event,
+			 profile_event);
 
 #endif /* CONFIG_PROFILER */
-EVENT_TYPE_DEFINE(modem_module_event,
-		  CONFIG_MODEM_EVENTS_LOG,
-		  log_event,
-#if defined(CONFIG_PROFILER)
-		  &modem_module_event_info);
-#else
-		  NULL);
-#endif
+
+COMMON_EVENT_TYPE_DEFINE(modem_module_event,
+			 CONFIG_MODEM_EVENTS_LOG,
+			 log_event,
+			 &modem_module_event_info);

--- a/applications/asset_tracker_v2/src/events/sensor_module_event.c
+++ b/applications/asset_tracker_v2/src/events/sensor_module_event.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "sensor_module_event.h"
+#include "common_module_event.h"
 
 static char *get_evt_type_str(enum sensor_module_event_type type)
 {
@@ -61,22 +62,12 @@ static void profile_event(struct log_event_buf *buf,
 #endif
 }
 
-EVENT_INFO_DEFINE(sensor_module_event,
-#if defined(CONFIG_PROFILER_EVENT_TYPE_STRING)
-		  ENCODE(PROFILER_ARG_STRING),
-#else
-		  ENCODE(PROFILER_ARG_U8),
-#endif
-		  ENCODE("type"),
-		  profile_event);
+COMMON_EVENT_INFO_DEFINE(sensor_module_event,
+			 profile_event);
 
 #endif /* CONFIG_PROFILER */
 
-EVENT_TYPE_DEFINE(sensor_module_event,
-		  CONFIG_SENSOR_EVENTS_LOG,
-		  log_event,
-#if defined(CONFIG_PROFILER)
-		  &sensor_module_event_info);
-#else
-		  NULL);
-#endif
+COMMON_EVENT_TYPE_DEFINE(sensor_module_event,
+			 CONFIG_SENSOR_EVENTS_LOG,
+			 log_event,
+			 &sensor_module_event_info);

--- a/applications/asset_tracker_v2/src/events/ui_module_event.c
+++ b/applications/asset_tracker_v2/src/events/ui_module_event.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "ui_module_event.h"
+#include "common_module_event.h"
 
 static char *get_evt_type_str(enum ui_module_event_type type)
 {
@@ -50,22 +51,12 @@ static void profile_event(struct log_event_buf *buf,
 #endif
 }
 
-EVENT_INFO_DEFINE(ui_module_event,
-#if defined(CONFIG_PROFILER_EVENT_TYPE_STRING)
-		  ENCODE(PROFILER_ARG_STRING),
-#else
-		  ENCODE(PROFILER_ARG_U8),
-#endif
-		  ENCODE("type"),
-		  profile_event);
+COMMON_EVENT_INFO_DEFINE(ui_module_event,
+			 profile_event);
 
 #endif /* CONFIG_PROFILER */
 
-EVENT_TYPE_DEFINE(ui_module_event,
-		  CONFIG_UI_EVENTS_LOG,
-		  log_event,
-#if defined(CONFIG_PROFILER)
-		  &ui_module_event_info);
-#else
-		  NULL);
-#endif
+COMMON_EVENT_TYPE_DEFINE(ui_module_event,
+			 CONFIG_UI_EVENTS_LOG,
+			 log_event,
+			 &ui_module_event_info);

--- a/applications/asset_tracker_v2/src/events/util_module_event.c
+++ b/applications/asset_tracker_v2/src/events/util_module_event.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "util_module_event.h"
+#include "common_module_event.h"
 
 static char *get_evt_type_str(enum util_module_event_type type)
 {
@@ -41,22 +42,12 @@ static void profile_event(struct log_event_buf *buf,
 #endif
 }
 
-EVENT_INFO_DEFINE(util_module_event,
-#if defined(CONFIG_PROFILER_EVENT_TYPE_STRING)
-		  ENCODE(PROFILER_ARG_STRING),
-#else
-		  ENCODE(PROFILER_ARG_U8),
-#endif
-		  ENCODE("type"),
-		  profile_event);
+COMMON_EVENT_INFO_DEFINE(util_module_event,
+			 profile_event);
 
 #endif /* CONFIG_PROFILER */
 
-EVENT_TYPE_DEFINE(util_module_event,
-		  CONFIG_UTIL_EVENTS_LOG,
-		  log_event,
-#if defined(CONFIG_PROFILER)
-		  &util_module_event_info);
-#else
-		  NULL);
-#endif
+COMMON_EVENT_TYPE_DEFINE(util_module_event,
+			 CONFIG_UTIL_EVENTS_LOG,
+			 log_event,
+			 &util_module_event_info);


### PR DESCRIPTION
Preprocessor directives within macro arguments are technically
undefined behavior, even though GCC supports them. Let's avoid that by
using COND_CODE_1.

https://gcc.gnu.org/onlinedocs/cpp/Directives-Within-Macro-Arguments.html

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>