### PR TITLE
net: lib: download_client: handle coap urls with multiple path elems

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -132,6 +132,15 @@ Bluetooth libraries and services
 
   * Fixed discovery of empty services.
 
+Libraries for networking
+------------------------
+
+* :ref:`lib_download_client` library:
+
+  * Fixed
+
+    * An issue where downloads of COAP URIs would fail when they contained multiple path elements.
+
 sdk-nrfxlib
 -----------
 


### PR DESCRIPTION
rfc 7252 6.4: [...] for each segment in the <path> component, include a
Uri-Path Option and let that option's value be the segment (not
including the delimiting slash characters)

This was (correctly, I presume) handled in zephyrs lwm2m/coap implementation,
but seems to not be implemented in download_client. For us (using leshan-server)
this lead to 4.04 reponses on firmware pull request.