### PR TITLE
Bluetooth: Mesh: Remove doc ref to Zephyr.

### DIFF
--- a/doc/nrf/ug_bt_mesh_configuring.rst
+++ b/doc/nrf/ug_bt_mesh_configuring.rst
@@ -13,9 +13,6 @@ The Bluetooth® mesh support is controlled by :kconfig:`CONFIG_BT_MESH`, which d
 * :kconfig:`CONFIG_BT_OBSERVER` - Enables the Bluetooth Observer role.
 * :kconfig:`CONFIG_BT_PERIPHERAL` - Enables the Bluetooth Peripheral role.
 
-The Bluetooth mesh subsystem currently performs best with :ref:`Zephyr's Bluetooth LE Controller <zephyr:bluetooth-arch>`.
-To force |NCS| to build with this controller, enable :kconfig:`CONFIG_BT_LL_SW_SPLIT`.
-
 Optional features configuration
 *******************************
 


### PR DESCRIPTION
The documentation refers that the best controller for mesh is the
Zephyr controller. From the NCS v1.7.0 the default has been the
SoftDevice Controller, so the comment should be removed.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>