### PR TITLE
doc: changelog: Add missing changes for NCS 1.9.0 (Protocols scope).

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -159,6 +159,7 @@ Bluetooth samples
   * :ref:`peripheral_hids_keyboard` - Added a notice about encryption requirement.
   * :ref:`central_and_peripheral_hrs` - Clarified the "Requirements" section and fixed a link in the "Testing" section of the document.
   * :ref:`peripheral_uart` - Increased the system workqueue stack size for the :file:`prj_minimal.conf` file.
+  * Aligned all samples to use the Bluetooth helper macros: :c:macro:`BT_UUID_16_ENCODE` and :c:macro:`BT_CONN_CB_DEFINE`.
 
 
 nRF9160 samples


### PR DESCRIPTION
- Add note about aligning macro usage in BT samples (as per https://github.com/nrfconnect/sdk-nrf/pull/6441).