### PR TITLE
subsys: event_manager: Add functionality to get the event size

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -209,7 +209,7 @@ Kconfig*                                  @tejlmand
 /tests/subsys/bootloader/                 @hakonfam
 /tests/subsys/debug/cpu_load/             @nordic-krch
 /tests/subsys/dfu/                        @hakonfam @sigvartmh
-/tests/subsys/event_manager/              @pdunaj @MarekPieta
+/tests/subsys/event_manager/              @pdunaj @MarekPieta @rakons
 /tests/subsys/fw_info/                    @oyvindronningstad
 /tests/subsys/net/lib/aws_*/              @simensrostad
 /tests/subsys/net/lib/azure_iot_hub/      @jtguggedal

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -208,9 +208,20 @@ Bluetooth libraries and services
 
   * :ref:`ams_client_readme` library.
 
-* :ref:`gatt_dm_readme` library:
+* Updated:
 
-  * Fixed discovery of empty services.
+  * :ref:`gatt_dm_readme` library:
+
+    * To fix discovery for empty services.
+
+Other libraries
+----------------
+
+* Updated:
+
+  * :ref:`event_manager`:
+
+      * To add :c:func:`event_manager_event_size` function with corresponding :kconfig:`CONFIG_EVENT_MANAGER_PROVIDE_EVENT_SIZE` option.
 
 Libraries for networking
 ------------------------

--- a/include/event_manager.h
+++ b/include/event_manager.h
@@ -148,6 +148,35 @@ extern "C" {
 #define EVENT_SUBMIT(event) _event_submit(&event->header)
 
 
+/**
+ * @brief Get the event size
+ *
+ * Function that calculates the event size using its header.
+ * @note
+ * For this function to be available the @kconfig{CONFIG_EVENT_MANAGER_PROVIDE_EVENT_SIZE} option
+ * needs to be enabled.
+ *
+ * @param eh Pointer to the event header.
+ *
+ * @return Event size in bytes.
+ */
+static inline size_t event_manager_event_size(const struct event_header *eh)
+{
+#if IS_ENABLED(CONFIG_EVENT_MANAGER_PROVIDE_EVENT_SIZE)
+	size_t size = eh->type_id->struct_size;
+
+	if (eh->type_id->has_dyndata) {
+		size += ((const struct event_dyndata *)
+			 (((const uint8_t *)eh) + size - sizeof(struct event_dyndata)))->size;
+	}
+	return size;
+#else
+	__ASSERT_NO_MSG(false);
+	return 0;
+#endif
+}
+
+
 /** @brief Initialize the Event Manager.
  *
  * @retval 0 If the operation was successful. Error values can be added by overwriting

--- a/subsys/event_manager/Kconfig
+++ b/subsys/event_manager/Kconfig
@@ -46,4 +46,11 @@ config EVENT_MANAGER_MAX_EVENT_CNT
 	help
 	  Maximum number of declared event types in Event Manager.
 
+config EVENT_MANAGER_PROVIDE_EVENT_SIZE
+	bool "Provide information about the event size"
+	help
+	  This option enables the information about event size.
+	  This would require to store more information with event type
+	  and should be enabled only if such an information is required.
+
 endif # EVENT_MANAGER

--- a/tests/subsys/event_manager/overlay-event_size.conf
+++ b/tests/subsys/event_manager/overlay-event_size.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_EVENT_MANAGER_PROVIDE_EVENT_SIZE=y

--- a/tests/subsys/event_manager/src/events/CMakeLists.txt
+++ b/tests/subsys/event_manager/src/events/CMakeLists.txt
@@ -10,4 +10,6 @@ target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/multicontext_event.c)
 
 target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/order_event.c)
 
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/sized_events.c)
+
 target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test_events.c)

--- a/tests/subsys/event_manager/src/events/sized_events.c
+++ b/tests/subsys/event_manager/src/events/sized_events.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "sized_events.h"
+
+
+EVENT_TYPE_DEFINE(test_size1_event, false, NULL, NULL);
+EVENT_TYPE_DEFINE(test_size2_event, false, NULL, NULL);
+EVENT_TYPE_DEFINE(test_size3_event, false, NULL, NULL);
+EVENT_TYPE_DEFINE(test_size_big_event, false, NULL, NULL);
+
+EVENT_TYPE_DEFINE(test_dynamic_event, false, NULL, NULL);
+EVENT_TYPE_DEFINE(test_dynamic_with_data_event, false, NULL, NULL);

--- a/tests/subsys/event_manager/src/events/sized_events.h
+++ b/tests/subsys/event_manager/src/events/sized_events.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _SIZED_EVENTS_H_
+#define _SIZED_EVENTS_H_
+
+/**
+ * @brief Events with different sizes
+ * @defgroup sized_events Events used to test @ref event_manager_event_size
+ * @{
+ */
+
+#include <event_manager.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+struct test_size1_event {
+	struct event_header header;
+
+	uint8_t val1;
+};
+
+EVENT_TYPE_DECLARE(test_size1_event);
+
+
+struct test_size2_event {
+	struct event_header header;
+
+	uint8_t val1;
+	uint8_t val2;
+};
+
+EVENT_TYPE_DECLARE(test_size2_event);
+
+
+struct test_size3_event {
+	struct event_header header;
+
+	uint8_t val1;
+	uint8_t val2;
+	uint8_t val3;
+};
+
+EVENT_TYPE_DECLARE(test_size3_event);
+
+
+struct test_size_big_event {
+	struct event_header header;
+
+	uint32_t array[64];
+};
+
+EVENT_TYPE_DECLARE(test_size_big_event);
+
+
+struct test_dynamic_event {
+	struct event_header header;
+
+	struct event_dyndata dyndata;
+};
+
+EVENT_TYPE_DYNDATA_DECLARE(test_dynamic_event);
+
+
+struct test_dynamic_with_data_event {
+	struct event_header header;
+
+	uint32_t val1;
+	uint32_t val2;
+	struct event_dyndata dyndata;
+};
+
+EVENT_TYPE_DYNDATA_DECLARE(test_dynamic_with_data_event);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* _SIZED_EVENTS_H_ */

--- a/tests/subsys/event_manager/testcase.yaml
+++ b/tests/subsys/event_manager/testcase.yaml
@@ -7,3 +7,12 @@ tests:
       - nrf9160dk_nrf9160_ns
       - qemu_cortex_m3
     tags: event_manager
+  event_manager.size_enabled:
+    extra_args: OVERLAY_CONFIG=overlay-event_size.conf
+    integration_platforms:
+      - nrf51dk_nrf51422
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf9160dk_nrf9160_ns
+      - qemu_cortex_m3
+    tags: event_manager


### PR DESCRIPTION
This commit adds optional functionality to gather the event size.
It provides universal mechanism to gather the size of event data
for dynamic and for static events in elegant and universal way.

JIRA: NCSDK-13755