### PR TITLE
drivers: bh1749: re-work to follow current best practices

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -21,6 +21,7 @@
 --ignore FILE_PATH_CHANGES
 --ignore SPDX_LICENSE_TAG
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
+--ignore TRAILING_SEMICOLON
 --exclude ext
 --exclude samples/matter/.*/src
 --exclude applications/matter_weather_station/src

--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
@@ -124,10 +124,10 @@
 	};
 
 	bh1749@38 {
-			compatible = "rohm,bh1749";
-			label = "BH1749";
-			reg = <0x38>;
-			int-gpios = <&gpio0 27 0>;
+		compatible = "rohm,bh1749";
+		label = "BH1749";
+		reg = <0x38>;
+		int-gpios = <&gpio0 27 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };
 

--- a/drivers/sensor/bh1749/bh1749.c
+++ b/drivers/sensor/bh1749/bh1749.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2019, 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,25 +16,21 @@
 
 #include "bh1749.h"
 
-static struct k_work_delayable bh1749_init_work;
-static const struct device *bh1749_dev;
-
 LOG_MODULE_REGISTER(BH1749, CONFIG_SENSOR_LOG_LEVEL);
 
 #define DT_DRV_COMPAT rohm_bh1749
 
-static const int32_t async_init_delay[ASYNC_INIT_STEP_COUNT] = {
+static const uint32_t async_init_delay[ASYNC_INIT_STEP_COUNT] = {
 	[ASYNC_INIT_STEP_RESET_CHECK] = 2,
 	[ASYNC_INIT_RGB_ENABLE] = 0,
 	[ASYNC_INIT_STEP_CONFIGURE] = 0
 };
 
-static int bh1749_async_init_reset_check(struct bh1749_data *data);
-static int bh1749_async_init_rgb_enable(struct bh1749_data *data);
-static int bh1749_async_init_configure(struct bh1749_data *data);
+static int bh1749_async_init_reset_check(const struct device *dev);
+static int bh1749_async_init_rgb_enable(const struct device *dev);
+static int bh1749_async_init_configure(const struct device *dev);
 
-static int(*const async_init_fn[ASYNC_INIT_STEP_COUNT])(
-	struct bh1749_data *data) = {
+static int(*const async_init_fn[ASYNC_INIT_STEP_COUNT])(const struct device *) = {
 	[ASYNC_INIT_STEP_RESET_CHECK] = bh1749_async_init_reset_check,
 	[ASYNC_INIT_RGB_ENABLE] = bh1749_async_init_rgb_enable,
 	[ASYNC_INIT_STEP_CONFIGURE] = bh1749_async_init_configure,
@@ -44,7 +40,10 @@ static int bh1749_sample_fetch(const struct device *dev, enum sensor_channel cha
 
 {
 	struct bh1749_data *data = dev->data;
+	const struct bh1749_config *config = dev->config;
+	const struct i2c_dt_spec *i2c = &config->i2c;
 	uint8_t status;
+	int err;
 
 	if (chan != SENSOR_CHAN_ALL) {
 		LOG_ERR("Unsupported sensor channel");
@@ -58,10 +57,10 @@ static int bh1749_sample_fetch(const struct device *dev, enum sensor_channel cha
 
 	LOG_DBG("Fetching sample...\n");
 
-	if (i2c_reg_read_byte(data->i2c, DT_REG_ADDR(DT_DRV_INST(0)),
-			      BH1749_MODE_CONTROL2, &status)) {
+	err = i2c_reg_read_byte_dt(i2c, BH1749_MODE_CONTROL2, &status);
+	if (err < 0) {
 		LOG_ERR("Could not read status register CONTROL2");
-		return -EIO;
+		return err;
 	}
 
 	LOG_DBG("MODE_CONTROL_2 %x", status);
@@ -71,30 +70,29 @@ static int bh1749_sample_fetch(const struct device *dev, enum sensor_channel cha
 		return -EIO;
 	}
 
-	if (i2c_burst_read(data->i2c, DT_REG_ADDR(DT_DRV_INST(0)),
-			   BH1749_RED_DATA_LSB,
-			   (uint8_t *)data->sample_rgb_ir,
-			   BH1749_SAMPLES_TO_FETCH * sizeof(uint16_t))) {
+	err = i2c_burst_read_dt(i2c, BH1749_RED_DATA_LSB,
+				(uint8_t *)data->sample_rgb_ir,
+				BH1749_SAMPLES_TO_FETCH * sizeof(uint16_t));
+	if (err < 0) {
 		LOG_ERR("Could not read sensor samples");
-		return -EIO;
+		return err;
 	}
 
 	if (IS_ENABLED(CONFIG_BH1749_TRIGGER)) {
 		/* Clearing interrupt by reading INTERRUPT register */
 		uint8_t dummy;
 
-		if (i2c_reg_read_byte(data->i2c,
-				      DT_REG_ADDR(DT_DRV_INST(0)),
-				      BH1749_INTERRUPT, &dummy)) {
+		err = i2c_reg_read_byte_dt(i2c, BH1749_INTERRUPT, &dummy);
+		if (err < 0) {
 			LOG_ERR("Could not disable sensor interrupt.");
-			return -EIO;
+			return err;
 		}
 
-		if (gpio_pin_interrupt_configure(data->gpio,
-					DT_INST_GPIO_PIN(0, int_gpios),
-					GPIO_INT_LEVEL_LOW)) {
+		err = gpio_pin_interrupt_configure_dt(&config->int_gpio,
+						      GPIO_INT_LEVEL_LOW);
+		if (err < 0) {
 			LOG_ERR("Could not enable pin callback");
-			return -EIO;
+			return err;
 		}
 	}
 
@@ -140,14 +138,15 @@ static int bh1749_channel_get(const struct device *dev,
 	return 0;
 }
 
-static int bh1749_check(struct bh1749_data *data)
+static int bh1749_check(const struct i2c_dt_spec *i2c)
 {
 	uint8_t manufacturer_id;
+	int err;
 
-	if (i2c_reg_read_byte(data->i2c, DT_REG_ADDR(DT_DRV_INST(0)),
-			      BH1749_MANUFACTURER_ID, &manufacturer_id)) {
-		LOG_ERR("Failed when reading manufacturer ID");
-		return -EIO;
+	err = i2c_reg_read_byte_dt(i2c, BH1749_MANUFACTURER_ID, &manufacturer_id);
+	if (err < 0) {
+		LOG_ERR("Failed when reading manufacturer ID: %d", err);
+		return err;
 	}
 
 	LOG_DBG("Manufacturer ID: 0x%02x", manufacturer_id);
@@ -159,10 +158,10 @@ static int bh1749_check(struct bh1749_data *data)
 
 	uint8_t part_id;
 
-	if (i2c_reg_read_byte(data->i2c, DT_REG_ADDR(DT_DRV_INST(0)),
-			      BH1749_SYSTEM_CONTROL, &part_id)) {
-		LOG_ERR("Failed when reading part ID");
-		return -EIO;
+	err = i2c_reg_read_byte_dt(i2c, BH1749_SYSTEM_CONTROL, &part_id);
+	if (err < 0) {
+		LOG_ERR("Failed when reading part ID: %d", err);
+		return err;
 	}
 
 	if ((part_id & BH1749_SYSTEM_CONTROL_PART_ID_Msk) !=
@@ -176,37 +175,34 @@ static int bh1749_check(struct bh1749_data *data)
 	return 0;
 }
 
-static int bh1749_sw_reset(const struct device *dev)
+static int bh1749_sw_reset(const struct i2c_dt_spec *i2c)
 {
-	return i2c_reg_update_byte(dev, DT_REG_ADDR(DT_DRV_INST(0)),
-				   BH1749_SYSTEM_CONTROL,
-				   BH1749_SYSTEM_CONTROL_SW_RESET_Msk,
-				   BH1749_SYSTEM_CONTROL_SW_RESET);
+	return i2c_reg_update_byte_dt(i2c, BH1749_SYSTEM_CONTROL,
+				      BH1749_SYSTEM_CONTROL_SW_RESET_Msk,
+				      BH1749_SYSTEM_CONTROL_SW_RESET);
 }
 
-static int bh1749_rgb_measurement_enable(struct bh1749_data *data, bool enable)
+static int bh1749_rgb_measurement_enable(const struct i2c_dt_spec *i2c, bool enable)
 {
 	uint8_t en = enable ?
 		  BH1749_MODE_CONTROL2_RGB_EN_ENABLE :
 		  BH1749_MODE_CONTROL2_RGB_EN_DISABLE;
 
-	return i2c_reg_update_byte(data->i2c,
-				   DT_REG_ADDR(DT_DRV_INST(0)),
-				   BH1749_MODE_CONTROL2,
-				   BH1749_MODE_CONTROL2_RGB_EN_Msk,
-				   en);
+	return i2c_reg_update_byte_dt(i2c, BH1749_MODE_CONTROL2,
+				      BH1749_MODE_CONTROL2_RGB_EN_Msk,
+				      en);
 }
-
 
 static void bh1749_async_init(struct k_work *work)
 {
-	struct bh1749_data *data = bh1749_dev->data;
-
-	ARG_UNUSED(work);
+	struct k_work_delayable *init_work = k_work_delayable_from_work(work);
+	struct bh1749_data *data = CONTAINER_OF(init_work,
+						struct bh1749_data,
+						init_work);
 
 	LOG_DBG("BH1749 async init step %d", data->async_init_step);
 
-	data->err = async_init_fn[data->async_init_step](data);
+	data->err = async_init_fn[data->async_init_step](data->dev);
 
 	if (data->err) {
 		LOG_ERR("BH1749 initialization failed");
@@ -217,58 +213,61 @@ static void bh1749_async_init(struct k_work *work)
 			data->ready = true;
 			LOG_INF("BH1749 initialized");
 		} else {
-			k_work_schedule(&bh1749_init_work,
+			k_work_schedule(init_work,
 					K_MSEC(async_init_delay[data->async_init_step]));
 		}
 	}
 }
 
-static int bh1749_async_init_reset_check(struct bh1749_data *data)
+static int bh1749_async_init_reset_check(const struct device *dev)
 {
+	struct bh1749_data *data = dev->data;
+	const struct bh1749_config *config = dev->config;
+	const struct i2c_dt_spec *i2c = &config->i2c;
+	int err;
+
 	(void)memset(data->sample_rgb_ir, 0, sizeof(data->sample_rgb_ir));
-	int err;
 
-	err = bh1749_sw_reset(data->i2c);
+	err = bh1749_sw_reset(i2c);
+	if (err < 0) {
+		LOG_ERR("Could not apply software reset");
+		return err;
+	}
 
-	if (err) {
-		LOG_ERR("Could not apply software reset.");
-		return -EIO;
-	}
-	err = bh1749_check(data);
-	if (err) {
-		LOG_ERR("Communication with BH1749 failed with error %d", err);
-		return -EIO;
-	}
-	return 0;
+	return bh1749_check(i2c);
 }
 
-static int bh1749_async_init_rgb_enable(struct bh1749_data *data)
+static int bh1749_async_init_rgb_enable(const struct device *dev)
 {
+	const struct bh1749_config *config = dev->config;
+	const struct i2c_dt_spec *i2c = &config->i2c;
 	int err;
 
-	err = bh1749_rgb_measurement_enable(data, true);
-	if (err) {
+	err = bh1749_rgb_measurement_enable(i2c, true);
+	if (err < 0) {
 		LOG_ERR("Could not set measurement mode.");
-		return -EIO;
 	}
-	return 0;
+	return err;
 }
 
-static int bh1749_async_init_configure(struct bh1749_data *data)
+static int bh1749_async_init_configure(const struct device *dev)
 {
-	if (i2c_reg_write_byte(data->i2c, DT_REG_ADDR(DT_DRV_INST(0)),
-			       BH1749_MODE_CONTROL1,
-			       BH1749_MODE_CONTROL1_DEFAULTS)) {
-		LOG_ERR(
-			"Could not set gain and measurement mode configuration.");
-		return -EIO;
+	const struct bh1749_config *config = dev->config;
+	const struct i2c_dt_spec *i2c = &config->i2c;
+	int err;
+
+	err = i2c_reg_write_byte_dt(i2c, BH1749_MODE_CONTROL1,
+				    BH1749_MODE_CONTROL1_DEFAULTS);
+	if (err < 0) {
+		LOG_ERR("Could not set gain and measurement mode configuration.");
+		return err;
 	}
 
 #ifdef CONFIG_BH1749_TRIGGER
-	int err = bh1749_gpio_interrupt_init(bh1749_dev);
-	if (err) {
+	err = bh1749_gpio_interrupt_init(dev);
+	if (err < 0) {
 		LOG_ERR("Failed to initialize interrupt with error %d", err);
-		return -EIO;
+		return err;
 	}
 
 	LOG_DBG("GPIO Sense Interrupts initialized");
@@ -279,19 +278,17 @@ static int bh1749_async_init_configure(struct bh1749_data *data)
 
 static int bh1749_init(const struct device *dev)
 {
-	bh1749_dev = dev;
+	struct bh1749_data *data = dev->data;
+	const struct bh1749_config *config = dev->config;
+	const struct device *bus = config->i2c.bus;
 
-	struct bh1749_data *data = bh1749_dev->data;
-	data->i2c = device_get_binding(DT_BUS_LABEL(DT_DRV_INST(0)));
-
-	if (data->i2c == NULL) {
-		LOG_ERR("Failed to get pointer to %s device!",
-			DT_BUS_LABEL(DT_DRV_INST(0)));
-
-		return -EINVAL;
+	if (!device_is_ready(bus)) {
+		LOG_ERR("%s: bus device %s is not ready", dev->name, bus->name);
+		return -ENODEV;
 	}
-	k_work_init_delayable(&bh1749_init_work, bh1749_async_init);
-	k_work_schedule(&bh1749_init_work, K_MSEC(async_init_delay[data->async_init_step]));
+	data->dev = dev;
+	k_work_init_delayable(&data->init_work, bh1749_async_init);
+	k_work_schedule(&data->init_work, K_MSEC(async_init_delay[data->async_init_step]));
 	return 0;
 };
 
@@ -304,8 +301,16 @@ static const struct sensor_driver_api bh1749_driver_api = {
 #endif
 };
 
-static struct bh1749_data bh1749_data;
+#define BH1749_DEFINE(inst)						\
+	static struct bh1749_data bh1749_data_##inst;			\
+	static const struct bh1749_config bh1749_config_##inst = {	\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),			\
+		.int_gpio = GPIO_DT_SPEC_INST_GET(inst, int_gpios),	\
+	};								\
+	DEVICE_DT_INST_DEFINE(inst, bh1749_init, NULL,			\
+			      &bh1749_data_##inst,			\
+			      &bh1749_config_##inst,			\
+			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, \
+			      &bh1749_driver_api);
 
-DEVICE_DEFINE(bh1749, DT_INST_LABEL(0),
-	      bh1749_init, NULL, &bh1749_data, NULL,
-	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &bh1749_driver_api);
+DT_INST_FOREACH_STATUS_OKAY(BH1749_DEFINE)

--- a/drivers/sensor/bh1749/bh1749.h
+++ b/drivers/sensor/bh1749/bh1749.h
@@ -103,9 +103,8 @@ enum async_init_step {
 };
 
 struct bh1749_data {
-	const struct device *i2c;
-	const struct device *gpio;
 	struct gpio_callback gpio_cb;
+	struct k_work_delayable init_work;
 	struct k_work work;
 	const struct device *dev;
 	uint16_t sample_rgb_ir[BH1749_SAMPLES_TO_FETCH];
@@ -117,6 +116,11 @@ struct bh1749_data {
 	sensor_trigger_handler_t trg_handler;
 	struct sensor_trigger trigger;
 #endif
+};
+
+struct bh1749_config {
+	const struct i2c_dt_spec i2c;
+	const struct gpio_dt_spec int_gpio;
 };
 
 #ifdef CONFIG_BH1749_TRIGGER

--- a/drivers/sensor/bh1749/bh1749_trigger.c
+++ b/drivers/sensor/bh1749/bh1749_trigger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2019, 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,26 +15,23 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(BH1749_TRIGGER, CONFIG_SENSOR_LOG_LEVEL);
 
-#define DT_DRV_COMPAT rohm_bh1749
-
 /* Callback for active sense pin from BH1749 */
-static void bh1749_gpio_callback(const struct device *dev,
+static void bh1749_gpio_callback(const struct device *gpio_dev,
 				 struct gpio_callback *cb,
 				 uint32_t pins)
 {
-	struct bh1749_data *drv_data =
-		CONTAINER_OF(cb, struct bh1749_data, gpio_cb);
+	struct bh1749_data *data = CONTAINER_OF(cb, struct bh1749_data,
+						gpio_cb);
+	const struct device *bh1749_dev = data->dev;
+	const struct bh1749_config *config = bh1749_dev->config;
 
-	gpio_pin_interrupt_configure(dev, DT_INST_GPIO_PIN(0, int_gpios),
-				     GPIO_INT_DISABLE);
-
-	k_work_submit(&drv_data->work);
+	gpio_pin_interrupt_configure_dt(&config->int_gpio, GPIO_INT_DISABLE);
+	k_work_submit(&data->work);
 }
 
 static void bh1749_work_cb(struct k_work *work)
 {
-	struct bh1749_data *data = CONTAINER_OF(work,
-						struct bh1749_data,
+	struct bh1749_data *data = CONTAINER_OF(work, struct bh1749_data,
 						work);
 	const struct device *dev = data->dev;
 
@@ -49,46 +46,44 @@ int bh1749_attr_set(const struct device *dev,
 		    enum sensor_attribute attr,
 		    const struct sensor_value *val)
 {
-	struct bh1749_data *data = dev->data;
+	const struct bh1749_config *config = dev->config;
+	const struct i2c_dt_spec *i2c = &config->i2c;
+	int err;
 
 	if (chan != SENSOR_CHAN_ALL) {
 		return -ENOTSUP;
 	}
 
 	if (attr == SENSOR_ATTR_UPPER_THRESH) {
-		if (i2c_reg_write_byte(data->i2c,
-				       DT_REG_ADDR(DT_DRV_INST(0)),
-				       BH1749_TH_HIGH_LSB,
-				       (uint8_t)val->val1)) {
-			LOG_ERR("Could not set upper threshold");
-			return -EIO;
+		err = i2c_reg_write_byte_dt(i2c, BH1749_TH_HIGH_LSB,
+					    (uint8_t)val->val1);
+		if (err < 0) {
+			LOG_ERR("Could not set upper threshold: %d", err);
+			return err;
 		}
 
-		if (i2c_reg_write_byte(data->i2c,
-				       DT_REG_ADDR(DT_DRV_INST(0)),
-				       BH1749_TH_HIGH_MSB,
-				       (uint8_t)(val->val1 >> 8))) {
-			LOG_ERR("Could not set upper threshold");
-			return -EIO;
+		err = i2c_reg_write_byte_dt(i2c, BH1749_TH_HIGH_MSB,
+					    (uint8_t)(val->val1 >> 8));
+		if (err < 0) {
+			LOG_ERR("Could not set upper threshold: %d", err);
+			return err;
 		}
 		return 0;
 	}
 
 	if (attr == SENSOR_ATTR_LOWER_THRESH) {
-		if (i2c_reg_write_byte(data->i2c,
-				       DT_REG_ADDR(DT_DRV_INST(0)),
-				       BH1749_TH_LOW_LSB,
-				       (uint8_t)val->val1)) {
-			LOG_ERR("Could not set lower threshold");
-			return -EIO;
+		err = i2c_reg_write_byte_dt(i2c, BH1749_TH_LOW_LSB,
+					    (uint8_t)val->val1);
+		if (err < 0) {
+			LOG_ERR("Could not set lower threshold: %d", err);
+			return err;
 		}
 
-		if (i2c_reg_write_byte(data->i2c,
-				       DT_REG_ADDR(DT_DRV_INST(0)),
-				       BH1749_TH_LOW_MSB,
-				       (uint8_t)(val->val1 >> 8))) {
-			LOG_ERR("Could not set lower threshold");
-			return -EIO;
+		err = i2c_reg_write_byte_dt(i2c, BH1749_TH_LOW_MSB,
+					    (uint8_t)(val->val1 >> 8));
+		if (err < 0) {
+			LOG_ERR("Could not set lower threshold: %d", err);
+			return err;
 		}
 		return 0;
 	}
@@ -100,20 +95,26 @@ int bh1749_trigger_set(const struct device *dev,
 		       sensor_trigger_handler_t handler)
 {
 	struct bh1749_data *data = dev->data;
+	const struct bh1749_config *config = dev->config;
+	const struct i2c_dt_spec *i2c = &config->i2c;
 	uint8_t interrupt_source = 0;
+	int err;
 
-	gpio_pin_interrupt_configure(data->gpio,
-		DT_INST_GPIO_PIN(0, int_gpios), GPIO_INT_DISABLE);
+	err = gpio_pin_interrupt_configure_dt(&config->int_gpio,
+					      GPIO_INT_DISABLE);
+	if (err < 0) {
+		return err;
+	}
 
 	switch (trig->type) {
 	case SENSOR_TRIG_THRESHOLD:
-		if (i2c_reg_update_byte(
-			    data->i2c, DT_REG_ADDR(DT_DRV_INST(0)),
-			    BH1749_PERSISTENCE,
-			    BH1749_PERSISTENCE_PERSISTENCE_Msk,
-			    BH1749_PERSISTENCE_PERSISTENCE_8_SAMPLES)) {
-			LOG_ERR("Unable to set threshold persistence");
-			return -EIO;
+		err = i2c_reg_update_byte_dt(i2c, BH1749_PERSISTENCE,
+				     BH1749_PERSISTENCE_PERSISTENCE_Msk,
+				     BH1749_PERSISTENCE_PERSISTENCE_8_SAMPLES);
+		if (err < 0) {
+			LOG_ERR("Unable to set threshold persistence: %d",
+				err);
+			return err;
 		}
 		if (trig->chan == SENSOR_CHAN_RED) {
 			interrupt_source = BH1749_INTERRUPT_INT_SOURCE_RED;
@@ -127,13 +128,12 @@ int bh1749_trigger_set(const struct device *dev,
 		}
 		break;
 	case SENSOR_TRIG_DATA_READY:
-		if (i2c_reg_update_byte(data->i2c,
-				DT_REG_ADDR(DT_DRV_INST(0)),
-				BH1749_PERSISTENCE,
+		err = i2c_reg_update_byte_dt(i2c, BH1749_PERSISTENCE,
 				BH1749_PERSISTENCE_PERSISTENCE_Msk,
-				BH1749_PERSISTENCE_PERSISTENCE_ACTIVE_END)) {
-			LOG_ERR("Unable to set data ready trigger");
-			return -EIO;
+				BH1749_PERSISTENCE_PERSISTENCE_ACTIVE_END);
+		if (err < 0) {
+			LOG_ERR("Unable to set data ready trigger: %d", err);
+			return err;
 		}
 		break;
 	default:
@@ -141,57 +141,59 @@ int bh1749_trigger_set(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	if (i2c_reg_update_byte(data->i2c, DT_REG_ADDR(DT_DRV_INST(0)),
-				BH1749_INTERRUPT,
-				BH1749_INTERRUPT_ENABLE_Msk |
-				BH1749_INTERRUPT_INT_SOURCE_Msk,
-				BH1749_INTERRUPT_ENABLE_ENABLE |
-				interrupt_source)) {
+	err = i2c_reg_update_byte_dt(i2c, BH1749_INTERRUPT,
+				     BH1749_INTERRUPT_ENABLE_Msk |
+				     BH1749_INTERRUPT_INT_SOURCE_Msk,
+				     BH1749_INTERRUPT_ENABLE_ENABLE |
+				     interrupt_source);
+	if (err < 0) {
 		LOG_ERR("Interrupts could not be enabled.");
-		return -EIO;
+		return err;
 	}
 
 	data->trg_handler = handler;
 	data->trigger = *trig;
-	gpio_pin_interrupt_configure(data->gpio,
-		DT_INST_GPIO_PIN(0, int_gpios), GPIO_INT_LEVEL_LOW);
 
-	return 0;
+	return gpio_pin_interrupt_configure_dt(&config->int_gpio,
+					       GPIO_INT_LEVEL_LOW);
 }
 
 /* Enabling GPIO sense on BH1749 INT pin. */
 int bh1749_gpio_interrupt_init(const struct device *dev)
 {
+	struct bh1749_data *data = dev->data;
+	const struct bh1749_config *config = dev->config;
+	const struct gpio_dt_spec *int_gpio = &config->int_gpio;
 	int err;
-	struct bh1749_data *drv_data = dev->data;
 
 	/* Setup gpio interrupt */
-	drv_data->gpio =
-		device_get_binding(DT_INST_GPIO_LABEL(0, int_gpios));
-	if (drv_data->gpio == NULL) {
-		LOG_ERR("Failed to get binding to %s device!",
-			DT_INST_GPIO_LABEL(0, int_gpios));
-		return -EINVAL;
+	if (!device_is_ready(int_gpio->port)) {
+		LOG_ERR("GPIO device %s is not ready", int_gpio->port->name);
+		return -ENODEV;
 	}
 
-	if (gpio_pin_configure(drv_data->gpio,
-			DT_INST_GPIO_PIN(0, int_gpios),
-			(GPIO_INPUT | GPIO_PULL_UP))) {
-		LOG_DBG("Failed to configure interrupt GPIO");
-		return -EIO;
-	}
+	k_work_init(&data->work, bh1749_work_cb);
 
-	gpio_init_callback(&drv_data->gpio_cb, bh1749_gpio_callback,
-			   BIT(DT_INST_GPIO_PIN(0, int_gpios)));
-
-	err = gpio_add_callback(drv_data->gpio, &drv_data->gpio_cb);
-	if (err) {
-		LOG_DBG("Failed to set GPIO callback");
+	err = gpio_pin_configure_dt(&config->int_gpio, GPIO_INPUT);
+	if (err < 0) {
+		LOG_ERR("Failed to configure interrupt GPIO: %d", err);
 		return err;
 	}
 
-	drv_data->work.handler = bh1749_work_cb;
-	drv_data->dev = dev;
+	gpio_init_callback(&data->gpio_cb, bh1749_gpio_callback,
+			   BIT(int_gpio->pin));
 
-	return 0;
+	err = gpio_add_callback(int_gpio->port, &data->gpio_cb);
+	if (err < 0) {
+		LOG_ERR("Failed to set GPIO callback: %d", err);
+		return err;
+	}
+
+	err = gpio_pin_interrupt_configure_dt(&config->int_gpio,
+					      GPIO_INT_LEVEL_ACTIVE);
+	if (err < 0) {
+		LOG_ERR("Failed to configure interrupt: %d", err);
+	}
+
+	return err;
 }


### PR DESCRIPTION
Update to follow best practices from upstream Zephyr, such as:

- use i2c_dt_spec and gpio_dt_spec to avoid boilerplate and save RAM
- log and propagate error codes received from drivers
- support multiple BH1749 device instances
- respect devicetree GPIO flags instead of hard-coding configurations
  that may not apply on boards with external pull-ups on the bus

Keep in-tree users up to date by adding the right GPIO flags to the
Thingy:91 board DTS.

Ref: NCSDK-13380

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>