### PR TITLE
mpsl: increase mpsl_cx initialization priority

### DIFF
--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -21,6 +21,13 @@ config MPSL_CX_PIN_FORWARDER
 
 if MPSL_CX
 
+config MPSL_CX_INIT_PRIORITY
+	int "Initialization priority of the Radio Coexistence interface"
+	default KERNEL_INIT_PRIORITY_DEFAULT
+	help
+	  Set the initialization priority number. Do not mess with it unless
+	  you know what you are doing.
+
 choice MPSL_CX_CHOICE
 	prompt "Radio Coexistence interface implementation"
 

--- a/subsys/mpsl/cx/generic_3pin/mpsl_cx_generic_3pin.c
+++ b/subsys/mpsl/cx/generic_3pin/mpsl_cx_generic_3pin.c
@@ -272,7 +272,7 @@ static int mpsl_cx_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(mpsl_cx_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(mpsl_cx_init, POST_KERNEL, CONFIG_MPSL_CX_INIT_PRIORITY);
 
 #else // !defined(CONFIG_MPSL_CX_PIN_FORWARDER)
 static int mpsl_cx_init(const struct device *dev)


### PR DESCRIPTION
The mpsl_cx component needs to be initialized before the 802.15.4 stack
so that its API can be used on initialization of the 802.15.4 driver.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>