### PR TITLE
drivers: serial: lpuart: Align to uart API change

### DIFF
--- a/drivers/serial/uart_nrf_sw_lpuart.c
+++ b/drivers/serial/uart_nrf_sw_lpuart.c
@@ -713,7 +713,7 @@ static void int_driven_evt_handler(const struct device *lpuart,
 		data->int_driven.rxlen = 0;
 		data->int_driven.rxrd = 0;
 		err = api_rx_enable(lpuart, data->int_driven.rxbuf,
-					sizeof(data->int_driven.rxbuf), 1);
+					sizeof(data->int_driven.rxbuf), 1000);
 		__ASSERT_NO_MSG(err >= 0);
 		break;
 	}
@@ -907,7 +907,7 @@ static int lpuart_init(const struct device *dev)
 	}
 
 	err = api_rx_enable(dev, data->int_driven.rxbuf,
-				sizeof(data->int_driven.rxbuf), 1);
+				sizeof(data->int_driven.rxbuf), 1000);
 #endif
 
 	data->txbyte = -1;

--- a/samples/peripheral/lpuart/src/main.c
+++ b/samples/peripheral/lpuart/src/main.c
@@ -103,11 +103,11 @@ static void async(const struct device *lpuart)
 	err = uart_callback_set(lpuart, uart_callback, (void *)lpuart);
 	__ASSERT(err == 0, "Failed to set callback");
 
-	err = uart_rx_enable(lpuart, buf, BUF_SIZE, 10);
+	err = uart_rx_enable(lpuart, buf, BUF_SIZE, 10000);
 	__ASSERT(err == 0, "Failed to enable RX");
 
 	while (1) {
-		err = uart_tx(lpuart, txbuf, sizeof(txbuf), 10);
+		err = uart_tx(lpuart, txbuf, sizeof(txbuf), 10000);
 		__ASSERT(err == 0, "Failed to initiate transmission");
 
 		k_sleep(K_MSEC(500));


### PR DESCRIPTION
RX and TX timeouts are given in microseconds in uart API. Previously
it was in milliseconds. Adapting LPUART to that change.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>