### PR TITLE
cmake: multi_image: Fix building on windows

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -352,7 +352,7 @@ function(add_child_image_from_source)
         file(
           APPEND
           ${preload_file}
-          "set(${shared_var} ${${shared_var}} CACHE INTERNAL \"NCS child image controlled\")\n"
+          "set(${shared_var} \"${${shared_var}}\" CACHE INTERNAL \"NCS child image controlled\")\n"
           )
       endif()
     endforeach()


### PR DESCRIPTION
If the toolchain path contained spaces, the build would fail:

CMake Error at C:/ncs/zephyr/cmake/toolchain/
gnuarmemb/generic.cmake:15 (if):  
if given arguments:    "NOT" "EXISTS"
"C:/Program" "Files" "(" "x86" ")" "/GNU"
"Tools" "ARM" "Embedded/8" "2019-q3-update"

Solved this by adding approstophes around each variable.

Ref: NCSDK-13765

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>