### PR TITLE
west.yml: update sdk-zephyr to fix bugs related to Bluetooth ISO and ATT

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a49c0691993ce87d0a8216bd7a6cd8df9cd39941
+      revision: 1c01b57ee6a3fa14f96a51fddb780c7f76ecbbc8
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Bugs:

1. BUS FAULT can happen when a central disconnects an ISO
2. bt_conn_index asserts when disconnecting while doing service
discovery