### PR TITLE
manifest: update sdk-zephyr for Twister short-path

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ba4920ee7db4d17593d66664ff72304a1873e7d1
+      revision: 199d339e98f91cd44f038bf4eb81e41e1d5ccac5
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update needed for testing sdk-nrf samples on Windows OS.

Relevant PR on `sdk-zephyr` repository: https://github.com/nrfconnect/sdk-zephyr/pull/729

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>