### PR TITLE
application: serial_lte_modem: BUG-FIX UART re-enable EBUSY

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -124,7 +124,7 @@ static int uart_receive(void)
 	int ret;
 
 	ret = uart_rx_enable(uart_dev, uart_rx_buf[0], sizeof(uart_rx_buf[0]), UART_RX_TIMEOUT_MS);
-	if (ret) {
+	if (ret && ret != -EBUSY) {
 		LOG_ERR("UART RX failed: %d", ret);
 		rsp_send(FATAL_STR, sizeof(FATAL_STR) - 1);
 		return ret;


### PR DESCRIPTION
After an PR in Zephyr Serial, UART RX re-enable could return
-EBUSY, which means UART RX is already enabled or in progress

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>