### PR TITLE
doc improvement: Rename "Working with" sections

### DIFF
--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -1,7 +1,7 @@
 .. _ug_nrf9160:
 
-Working with nRF9160 DK
-#######################
+Developing with nRF9160 DK
+##########################
 
 .. contents::
    :local:

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -2,8 +2,8 @@
 
 .. _thingy91_ug_intro:
 
-Working with Thingy:91
-######################
+Developing with Thingy:91
+#########################
 
 .. contents::
    :local:


### PR DESCRIPTION
The "Working with" sections for nRF9160 DK and Thingy:91 are
not as clear as they can be about what they contain with
the addition of the "Getting started" sections.

This PR renames those sections to "Developing with" instead to
make their purpose more clear.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>