### PR TITLE
Doc: Update BT Mesh docs after extracting regulator

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg.rst
@@ -1,12 +1,110 @@
 .. _bt_mesh_light_ctrl_reg_readme:
 
-Light Lightness Control regulator
-#################################
+Illuminance regulator interface
+###############################
 
-This module is an abstract proportional integral (PI) regulator.
-Regulator implementations should declare a :c:struct:`bt_mesh_light_ctrl_reg` struct and supply implementations for ``init``, ``start``, and ``stop``.
+This module defines an interface for implementation and interaction with an abstract illuminance regulator.
 
-For an example of a regulator implementation, see :ref:`bt_mesh_light_ctrl_reg_spec_readme`.
+Using the regulator
+*******************
+
+As this defines an interface for an abstract illuminance regulator, it cannot be used on its own.
+For an example of regulator usage, see :ref:`bt_mesh_light_ctrl_srv_readme`.
+
+A regulator implementation will provide a :c:struct:`bt_mesh_light_ctrl_reg` instance, and this is used as the interface to the regulator.
+Field :c:member:`bt_mesh_light_ctrl_reg.user_data` of this struct can be used to store a user context.
+
+Before using the regulator, it needs to be initialized through the :c:member:`bt_mesh_light_ctrl_reg.init` function.
+Functions :c:member:`bt_mesh_light_ctrl_reg.start` and :c:member:`bt_mesh_light_ctrl_reg.stop` are used to start and stop the regulator.
+
+Regulator inputs
+----------------
+
+The regulator has two inputs:
+
+* Target value
+* Measured value
+
+The illuminance regulator takes the specified target value as the reference level and compares it to the reported measured value.
+The inputs are compared to establish an error for the regulator, which the regulator tries to minimize.
+
+The measured value is passed through the :c:member:`bt_mesh_light_ctrl_reg.measured` variable.
+The passed value is to be used in the next regulator step.
+The regulator depends on measurement frequency to provide a stable output.
+The measurement frequency should be as close as possible to the update interval of the regulator.
+If the measurement frequency is too low, the regulator might oscillate as it attempts to compensate for outdated feedback.
+
+The desired target value is passed through the :c:func:`bt_mesh_light_ctrl_reg_target_set` function.
+If the transition time is greater than zero, the target value will be interpolated linearly over the transition time from the previously set value to the new one.
+
+Regulator output
+----------------
+
+The regulator contains a proportional (P) and an integral (I) component whose outputs are summarized to a regulator output value.
+To get output from the regulator, set the :c:member:`bt_mesh_light_ctrl_reg.updated` callback.
+When the regulator is running, it will repeatedly call this callback.
+
+Tuning the regulator
+--------------------
+
+Regulator tuning is complex and depends on a lot of internal and external parameters.
+Varying sensor delay, light output and light change rate may significantly affect the regulator performance and accuracy.
+To compensate for the external parameters, each regulator component provides user controllable coefficients that change their impact on the output value:
+
+* K\ :sub:`p` - for the proportional component
+* K\ :sub:`i` - for the integral component
+
+These coefficients can have individual values for positive and negative errors, referenced as follows in the API:
+
+* K\ :sub:`pu` - proportional up; used when target is higher.
+* K\ :sub:`pd` - proportional down; used when target is lower.
+* K\ :sub:`iu` - integral up; used when target is higher.
+* K\ :sub:`id` - integral down; used when target is lower
+
+Regulators are tuned to fit their environment by changing the coefficients.
+The coefficient adjustments are typically done by analyzing the system's *step response*.
+The step response is the overall system response to a change in reference value, for instance in a state change in the light level state machine.
+
+.. note::
+    The transition time between states in the Light LC Server makes the feedback loop more forgiving.
+    A larger transition time can compensate for poor regulator response.
+
+The illuminance regulator is a PI regulator, which uses the following components to compensate for a mismatch between the reference and the measured level:
+
+* Instantaneous error - The proportional component that is typically the main source of correction for a PI regulator.
+  It compares the reference value to the most recent feedback value, and attempts to correct the error by eliminating the difference.
+* Accumulated error - The integral component that compensates for errors by adding up the sum of the error over time.
+  Its main contribution is to eliminate system bias and accelerate the system step response.
+
+Changing different coefficients will affect the step response differently.
+Increasing the two coefficients will have the following effect on the step response:
+
+=========== ========= ========= ============= ==================
+Coefficient Rise time Overshoot Settling time Steady-state error
+=========== ========= ========= ============= ==================
+K\ :sub:`p`  Faster    Higher    \-            \-
+K\ :sub:`i`  Faster    Higher    Longer        Reduced
+=========== ========= ========= ============= ==================
+
+The value of the coefficients is typically a trade-off between fast response time and system instability:
+
+* If the value is too high, the system might become unstable, potentially leading to oscillation and loss of control.
+* If the value is too low, the step response might be too slow or unable to reach the target value altogether.
+
+Implementing a new regulator
+****************************
+
+To implement a new regulator using this generic interface, declare a :c:struct:`bt_mesh_light_ctrl_reg` struct, and set the :c:member:`bt_mesh_light_ctrl_reg.init`, :c:member:`bt_mesh_light_ctrl_reg.start`, and :c:member:`bt_mesh_light_ctrl_reg.stop` fields to implementations of these functions.
+Use :c:func:`bt_mesh_light_ctrl_reg_input_get` to get the current target value for the regulator supplied by the regulator user.
+The value returned is interpolated linearly over the transition time, if a transition time is requested by the regulator user.
+
+The :c:member:`bt_mesh_light_ctrl_reg.init` function must perform the necessary steps to initialize the implementation, such as initializing interrupt handlers or timers, but not start the regulator.
+
+Use the :c:member:`bt_mesh_light_ctrl_reg.start` and :c:member:`bt_mesh_light_ctrl_reg.stop` functions to start and stop the regulator after it has been initialized by a call to ``init``.
+
+On every regulator step, the regulator must call :c:member:`bt_mesh_light_ctrl_reg.updated` callback supplied by the user.
+
+For an example of regulator implementation, see :ref:`bt_mesh_light_ctrl_reg_spec_readme`.
 
 
 API documentation

--- a/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg_spec.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/light_ctrl_reg_spec.rst
@@ -1,10 +1,24 @@
 .. _bt_mesh_light_ctrl_reg_spec_readme:
 
-Light Lightness Control spec regulator
-######################################
+Specification-defined illuminance regulator
+###########################################
 
-This module implements the PI lightness regulator specified in the Bluetooth® mesh model specification.
-Initialize using :c:macro:`BT_MESH_LIGHT_CTRL_REG_SPEC_INIT`.
+This module implements the illuminance regulator defined in the Bluetooth® mesh model specification.
+
+The regulator operates in a compile time configurable update interval between 10 and 100 ms.
+The interval can be configured through the :kconfig:`CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC_INTERVAL` option.
+
+For each step, the regulator:
+
+1. Calculates the integral of the error since the last step.
+#. Adds the integral to an internal sum.
+#. Multiplies this sum by an integral coefficient.
+#. Summarizes the sum with the raw difference multiplied by a proportional coefficient.
+
+The error, the regulator coefficients, and the internal sum, are represented as 32-bit floating point values.
+The resulting output level is represented as an unsigned 16-bit integer.
+
+To reduce noise, the regulator has a configurable accuracy property which allows it to ignore errors smaller than the configured accuracy (represented as a percentage of the light level).
 
 API documentation
 *****************

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -248,6 +248,10 @@ Bluetooth libraries and services
 
   * Fixed the issue related to missing buffer size variables for the user PHY update and the user data length update procedures.
 
+* :ref:`bt_mesh` library:
+
+  * Extracted proportional-integral (PI) regulator module from :ref:`bt_mesh_light_ctrl_srv_readme`, enabling easier implementation of custom regulators.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/include/bluetooth/mesh/light_ctrl_reg.h
+++ b/include/bluetooth/mesh/light_ctrl_reg.h
@@ -5,10 +5,10 @@
  */
 
 /** @file
- *  @defgroup bt_mesh_light_ctrl_reg Light Lightness Control Regulator
+ *  @defgroup bt_mesh_light_ctrl_reg Illuminance regulator
  *  @ingroup bt_mesh_light_ctrl
  *  @{
- *  @brief Light Lightness Control regulator API
+ *  @brief Illuminance regulator API
  */
 
 #ifndef BT_MESH_LIGHT_CTRL_REG_H__
@@ -27,7 +27,7 @@ struct bt_mesh_light_ctrl_reg_coeff {
 	float down;
 };
 
-/** Light Lightness Control regulator configuration. */
+/** Illuminance regulator configuration. */
 struct bt_mesh_light_ctrl_reg_cfg {
 	/** Regulator integral coefficient. */
 	struct bt_mesh_light_ctrl_reg_coeff ki;
@@ -66,7 +66,7 @@ struct bt_mesh_light_ctrl_reg {
  *  Sets the target lightness, also known as the setpoint, for the regulator.
  *  Transition time is optional.
  *
- *  @param[in] reg      Lightness regulator instance.
+ *  @param[in] reg      Illuminance regulator instance.
  *
  *  @param[in] target   Target lightness (setpoint).
  *
@@ -83,7 +83,7 @@ void bt_mesh_light_ctrl_reg_target_set(struct bt_mesh_light_ctrl_reg *reg,
  *  Returns the target lightness, taking the requested transition time into
  *  account, for use in regulator implementations.
  *
- *  @param[in] reg      Lightness regulator instance.
+ *  @param[in] reg      Illuminance regulator instance.
  *
  *  @returns    The current target lightness, interpolated during transition
  *              time.

--- a/include/bluetooth/mesh/light_ctrl_reg_spec.h
+++ b/include/bluetooth/mesh/light_ctrl_reg_spec.h
@@ -5,10 +5,10 @@
  */
 
 /** @file
- *  @defgroup bt_mesh_light_ctrl_reg_spec Light Lightness Control Spec Regulator
+ *  @defgroup bt_mesh_light_ctrl_reg_spec Specification-defined illuminance regulator
  *  @ingroup bt_mesh_light_ctrl
  *  @{
- *  @brief Light Lightness Control spec regulator
+ *  @brief Specification-defined illuminance regulator
  */
 
 #ifndef BT_MESH_LIGHT_CTRL_REG_SPEC_H__
@@ -33,7 +33,7 @@ extern "C" {
 		}                                                              \
 	}
 
-/** Light Lightness Control spec regulator context. */
+/** Specification-defined illuminance regulator context. */
 struct bt_mesh_light_ctrl_reg_spec {
 	/** Common regulator context. */
 	struct bt_mesh_light_ctrl_reg reg;

--- a/include/bluetooth/mesh/light_ctrl_srv.h
+++ b/include/bluetooth/mesh/light_ctrl_srv.h
@@ -54,7 +54,8 @@ struct bt_mesh_light_ctrl_srv;
  *
  *  @brief Initialization parameters for @ref bt_mesh_light_ctrl_srv.
  *
- *  This will enable the spec regulator if @kconfig{CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG} and
+ *  This will enable the specification-defined regulator if
+ *  @kconfig{CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG} and
  *  @kconfig{CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC} are selected.
  *
  *  @param[in] _lightness_srv Pointer to the @ref bt_mesh_lightness_srv this

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -298,7 +298,7 @@ config BT_MESH_LIGHT_CTRL_REG_SPEC_INTERVAL
 	default 100
 	range 10 100
 	help
-	  Update interval of the specification PI regulator (in milliseconds).
+	  Update interval of the specification-defined illuminance regulator (in milliseconds).
 
 endif #BT_MESH_LIGHT_CTRL_REG_SPEC
 endif #BT_MESH_LIGHT_CTRL_REG


### PR DESCRIPTION
This commit relocates some regulator documention to match the extracted
module, adds docs on how to implement your own regulator, and adds the
module extraction to the release notes.

Signed-off-by: Ludvig Samuelsen Jordet <ludvig.jordet@nordicsemi.no>