### PR TITLE
doc: Align platforms in rst and yaml

### DIFF
--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/sample.yaml
@@ -7,6 +7,7 @@ tests:
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf21540dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -7,6 +7,7 @@ tests:
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
@@ -14,5 +15,5 @@ tests:
       - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
-      nrf21540dk_nrf52840
+      nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -7,6 +7,7 @@ tests:
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
@@ -14,5 +15,5 @@ tests:
       - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
-      nrf21540dk_nrf52840
+      nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -7,6 +7,7 @@ tests:
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
@@ -14,5 +15,5 @@ tests:
       - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
-      nrf21540dk_nrf52840
+      nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/silvair_enocean/sample.yaml
+++ b/samples/bluetooth/mesh/silvair_enocean/sample.yaml
@@ -7,9 +7,10 @@ tests:
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-      nrf5340dk_nrf5340_cpuapp_ns nrf21540dk_nrf52840
+      nrf5340dk_nrf5340_cpuapp_ns nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build


### PR DESCRIPTION
integration_platforms in sample.yaml and
the listed supported boards in rst files
should be the same. This is now aligned.

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>