### PR TITLE
net: lib: lwm2m_client_utils: Verify maximum instance count on create

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/ecid_signal_meas_info.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/ecid_signal_meas_info.c
@@ -104,6 +104,11 @@ static struct lwm2m_engine_obj_inst *signal_meas_info_create(uint16_t obj_inst_i
 		}
 	}
 
+	if (index >= MAX_INSTANCE_COUNT) {
+		LOG_ERR("Not enough memory to create object instance.");
+		return NULL;
+	}
+
 	(void)memset(res[index], 0,
 		     sizeof(res[index][0]) * ARRAY_SIZE(res[index]));
 	init_res_instance(res_inst[index], ARRAY_SIZE(res_inst[index]));


### PR DESCRIPTION
Object instnace creation of ECID Signal Measurement object did not
verify the maximum allowed instance count, which could result in out of
bounds access.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>