### PR TITLE
Bluetooth: Mesh: fix typo in apparent energy sensor

### DIFF
--- a/include/bluetooth/mesh/sensor_types.h
+++ b/include/bluetooth/mesh/sensor_types.h
@@ -961,7 +961,7 @@ extern const struct bt_mesh_sensor_type
  *    - Encoding: 32 bit unsigned scalar (Resolution: 0.001 kVAh)
  *    - Range: 0 to 4294967.293
  */
-extern const struct bt_mesh_sensor_type bt_mesh_sensor_apparent_energy32;
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_apparent_energy;
 
 /** Apparent power
  *


### PR DESCRIPTION
The apparent energy sensor type has a typo in the name
that coincides with the sensor type. PR fixes that.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>