### PR TITLE
manifest: update sdk-zephyr to bring in depfile changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ba4920ee7db4d17593d66664ff72304a1873e7d1
+      revision: pull/732/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit updates sdk-zephyr to pull in depfile changes.

This ensure proper path handling when using depfile and ensures that
targets are only relinked when there are code changes.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>