### PR TITLE
applications: serial_lte_modem: Fix memory leak in slm_at_gpio module

### DIFF
--- a/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
+++ b/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
@@ -126,6 +126,7 @@ static int do_gpio_pin_configure_set(uint16_t op, gpio_pin_t pin)
 		err = gpio_pin_interrupt_configure(gpio_dev, pin, GPIO_INT_DISABLE);
 		if (err) {
 			LOG_ERR("Interface pin interrupt config error: %d", err);
+			k_free(slm_gpio_pin);
 			return err;
 		}
 		/* Remove callback */


### PR DESCRIPTION
slm_at_gpio module could leak memory in case of error during GPIO
configuration.

Found by coverity.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>