### PR TITLE
applications: asset_tracker_v2: BOOT FOTA service depends on config

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -54,10 +54,14 @@ static void user_association_work_fn(struct k_work *work)
 static int send_service_info(void)
 {
 	int err;
+	bool fota_capable = IS_ENABLED(CONFIG_NRF_CLOUD_FOTA) &&
+			    IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT);
+	bool boot_fota_capable = IS_ENABLED(CONFIG_BUILD_S1_VARIANT) &&
+				 IS_ENABLED(CONFIG_SECURE_BOOT);
 	struct nrf_cloud_svc_info_fota fota_info = {
-		.application = true,
-		.bootloader = true,
-		.modem = true
+		.application = fota_capable,
+		.bootloader = fota_capable && boot_fota_capable,
+		.modem = fota_capable
 	};
 	struct nrf_cloud_svc_info_ui ui_info = {
 		.gps = true,

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -88,6 +88,7 @@ nRF9160: Asset Tracker v2
 * Added new documentation for :ref:`asset_tracker_v2_util_module` and :ref:`api_modules_common`.
 * Updated support for P-GPS preemptive updates and P-GPS coexistence with A-GPS.
 * Added functionality that allows the application to wait for A-GPS data to be processed before starting GNSS positioning.
+* Fixed nRF Cloud FOTA issue to only enable image types on the cloud if they are enabled on the device.
 
 nRF9160: Asset Tracker
 ----------------------


### PR DESCRIPTION
The nRF Cloud shadow state.reported.device.serviceInfo.fota_v2 array defines which types of FOTA images the application supports.

The BOOT FOTA type requires both CONFIG_BUILD_S1_VARIANT and CONFIG_SECURE_BOOT to be enabled.  As it was, it was always enabled, which would result in failed FOTA jobs in the event the user attempted a BOOT update.

All FOTA types require CONFIG_NRF_CLOUD_FOTA and CONFIG_BOOTLOADER_MCUBOOT also, so none should be enabled on the cloud without these options.

This PR adds the proper checks, and updates the changelog.

Jira: CIA-543

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>