### PR TITLE
bluetooth: mesh: add model context to sensor callbacks

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -48,6 +48,14 @@ Protocols
 This section provides detailed lists of changes by :ref:`protocol <protocols>`.
 See `Samples`_ for lists of changes for the protocol-related samples.
 
+Bluetooth mesh
+--------------
+
+* Added:
+
+  * :c:struct:`bt_mesh_sensor_srv` context to relevant callbacks and APIs to help resolve the associated sensor model instance.
+    For details, see `Bluetooth mesh samples`_ and `Bluetooth libraries and services`_.
+
 Thread
 ------
 
@@ -128,6 +136,9 @@ Bluetooth mesh samples
 * Updated
 
   * All samples are using the Partition Manager, replacing the use of the Device Tree Source flash partitions.
+  * :ref:`bluetooth_mesh_sensor_server` sample:
+
+    * Updated definitions for sensor callbacks to include the :c:struct:`bt_mesh_sensor_srv` context.
 
 Thread samples
 --------------
@@ -191,6 +202,17 @@ Bluetooth libraries and services
 * :ref:`gatt_dm_readme` library:
 
   * Fixed discovery of empty services.
+
+* :ref:`bt_mesh` library:
+
+  * Added:
+
+    * :c:struct:`bt_mesh_sensor_srv` context to the following API and callbacks:
+
+      * :c:func:`sensor_column_encode` API.
+      * :c:member:`get` and :c:member:`set` callbacks in :c:struct:`bt_mesh_sensor_setting`.
+      * :c:member:`get` callback in :c:struct:`bt_mesh_sensor_series`.
+      * :c:member:`get` callback in :c:struct:`bt_mesh_sensor`.
 
 Libraries for networking
 ------------------------

--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -219,6 +219,7 @@ struct bt_mesh_sensor_type {
 };
 
 struct bt_mesh_sensor;
+struct bt_mesh_sensor_srv;
 
 /** Single sensor setting. */
 struct bt_mesh_sensor_setting {
@@ -229,6 +230,8 @@ struct bt_mesh_sensor_setting {
 	 *
 	 *  @note This handler is mandatory.
 	 *
+	 *  @param[in]  srv     Sensor server instance associated with this
+	 *                      setting.
 	 *  @param[in]  sensor  Sensor this setting belongs to.
 	 *  @param[in]  setting Pointer to this setting structure.
 	 *  @param[in]  ctx     Context parameters for the packet this call
@@ -239,7 +242,8 @@ struct bt_mesh_sensor_setting {
 	 *                      by the setting sensor type. All channels must be
 	 *                      filled.
 	 */
-	void (*get)(struct bt_mesh_sensor *sensor,
+	void (*get)(struct bt_mesh_sensor_srv *srv,
+		    struct bt_mesh_sensor *sensor,
 		    const struct bt_mesh_sensor_setting *setting,
 		    struct bt_mesh_msg_ctx *ctx,
 		    struct sensor_value *rsp);
@@ -248,6 +252,8 @@ struct bt_mesh_sensor_setting {
 	 *
 	 *  Should only be specified for writable sensor settings.
 	 *
+	 *  @param[in] srv     Sensor server instance associated with this
+	 *                     setting.
 	 *  @param[in] sensor  Sensor this setting belongs to.
 	 *  @param[in] setting Pointer to this setting structure.
 	 *  @param[in] ctx     Context parameters for the packet this call
@@ -258,7 +264,7 @@ struct bt_mesh_sensor_setting {
 	 *
 	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
-	int (*set)(
+	int (*set)(struct bt_mesh_sensor_srv *srv,
 		struct bt_mesh_sensor *sensor,
 		const struct bt_mesh_sensor_setting *setting,
 		struct bt_mesh_msg_ctx *ctx,
@@ -305,6 +311,7 @@ struct bt_mesh_sensor_series {
 	 *  Should return the historical data for the latest sensor readings in
 	 *  the given column.
 	 *
+	 *  @param[in]  srv    Sensor server associated with sensor instance.
 	 *  @param[in]  sensor Sensor pointer.
 	 *  @param[in]  ctx    Message context pointer, or NULL if this call
 	 *                     didn't originate from a mesh message.
@@ -316,9 +323,11 @@ struct bt_mesh_sensor_series {
 	 *
 	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
-	int (*get)(struct bt_mesh_sensor *sensor, struct bt_mesh_msg_ctx *ctx,
-		   const struct bt_mesh_sensor_column *column,
-		   struct sensor_value *value);
+	int (*get)(struct bt_mesh_sensor_srv *srv,
+		struct bt_mesh_sensor *sensor,
+		struct bt_mesh_msg_ctx *ctx,
+		const struct bt_mesh_sensor_column *column,
+		struct sensor_value *value);
 };
 
 /** Sensor instance. */
@@ -349,6 +358,7 @@ struct bt_mesh_sensor {
 
 	/** @brief Getter function for the sensor value.
 	 *
+	 *  @param[in]  srv    Sensor server associated with sensor instance.
 	 *  @param[in]  sensor Sensor instance.
 	 *  @param[in]  ctx    Message context, or NULL if the call wasn't
 	 *                     triggered by a mesh message.
@@ -358,8 +368,10 @@ struct bt_mesh_sensor {
 	 *
 	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
-	int (*const get)(struct bt_mesh_sensor *sensor,
-			 struct bt_mesh_msg_ctx *ctx, struct sensor_value *rsp);
+	int (*const get)(struct bt_mesh_sensor_srv *srv,
+			 struct bt_mesh_sensor *sensor,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct sensor_value *rsp);
 
 	/* Internal state, overwritten on init. Should only be written to by
 	 * internal modules.

--- a/samples/bluetooth/mesh/sensor_server/src/model_handler.c
+++ b/samples/bluetooth/mesh/sensor_server/src/model_handler.c
@@ -39,8 +39,10 @@ static uint32_t col_samps[ARRAY_SIZE(columns)];
 
 static int32_t prev_pres;
 
-static int chip_temp_get(struct bt_mesh_sensor *sensor,
-			 struct bt_mesh_msg_ctx *ctx, struct sensor_value *rsp)
+static int chip_temp_get(struct bt_mesh_sensor_srv *srv,
+			 struct bt_mesh_sensor *sensor,
+			 struct bt_mesh_msg_ctx *ctx,
+			 struct sensor_value *rsp)
 {
 	int err;
 
@@ -69,9 +71,11 @@ static struct bt_mesh_sensor chip_temp = {
 	.get = chip_temp_get,
 };
 
-static int relative_runtime_in_chip_temp_get(
-	struct bt_mesh_sensor *sensor, struct bt_mesh_msg_ctx *ctx,
-	const struct bt_mesh_sensor_column *column, struct sensor_value *value)
+static int relative_runtime_in_chip_temp_get(struct bt_mesh_sensor_srv *srv,
+	struct bt_mesh_sensor *sensor,
+	struct bt_mesh_msg_ctx *ctx,
+	const struct bt_mesh_sensor_column *column,
+	struct sensor_value *value)
 {
 	if (tot_temp_samps) {
 		int32_t index = column - &columns[0];
@@ -104,9 +108,10 @@ static struct bt_mesh_sensor presence_sensor = {
 	.type = &bt_mesh_sensor_presence_detected,
 };
 
-static int time_since_presence_detected_get(struct bt_mesh_sensor *sensor,
-					    struct bt_mesh_msg_ctx *ctx,
-					    struct sensor_value *rsp)
+static int time_since_presence_detected_get(struct bt_mesh_sensor_srv *srv,
+					struct bt_mesh_sensor *sensor,
+					struct bt_mesh_msg_ctx *ctx,
+					struct sensor_value *rsp)
 {
 	if (prev_pres) {
 		rsp->val1 = (k_uptime_get_32() - prev_pres) / MSEC_PER_SEC;

--- a/subsys/bluetooth/mesh/sensor.c
+++ b/subsys/bluetooth/mesh/sensor.c
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include <bluetooth/mesh/sensor.h>
-#include <bluetooth/mesh/properties.h>
+
 #include "sensor.h"
+#include <bluetooth/mesh/properties.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -254,6 +254,7 @@ bt_mesh_sensor_column_format_get(const struct bt_mesh_sensor_type *type)
 }
 
 int sensor_column_encode(struct net_buf_simple *buf,
+			 struct bt_mesh_sensor_srv *srv,
 			 struct bt_mesh_sensor *sensor,
 			 struct bt_mesh_msg_ctx *ctx,
 			 const struct bt_mesh_sensor_column *col)
@@ -287,7 +288,7 @@ int sensor_column_encode(struct net_buf_simple *buf,
 		return err;
 	}
 
-	err = sensor->series.get(sensor, ctx, col, values);
+	err = sensor->series.get(srv, sensor, ctx, col, values);
 	if (err) {
 		return err;
 	}

--- a/subsys/bluetooth/mesh/sensor.h
+++ b/subsys/bluetooth/mesh/sensor.h
@@ -13,6 +13,7 @@
 
 #include <bluetooth/mesh/sensor.h>
 #include <bluetooth/mesh/sensor_cli.h>
+#include <bluetooth/mesh/sensor_srv.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -155,6 +156,7 @@ int sensor_ch_decode(struct net_buf_simple *buf,
 		     struct sensor_value *value);
 
 int sensor_column_encode(struct net_buf_simple *buf,
+			 struct bt_mesh_sensor_srv *srv,
 			 struct bt_mesh_sensor *sensor,
 			 struct bt_mesh_msg_ctx *ctx,
 			 const struct bt_mesh_sensor_column *col);

--- a/tests/bluetooth/tester/src/model_handler.c
+++ b/tests/bluetooth/tester/src/model_handler.c
@@ -280,7 +280,8 @@ static void prop_mfr_get(struct bt_mesh_prop_srv *srv,
 	memcpy(val->value, &property.current, sizeof(property));
 }
 
-static int sensor_data_get(struct bt_mesh_sensor *sensor,
+static int sensor_data_get(struct bt_mesh_sensor_srv *srv,
+			   struct bt_mesh_sensor *sensor,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct sensor_value *rsp);
 
@@ -298,7 +299,8 @@ static struct sensor_value values[ARRAY_SIZE(sensors)];
 static struct bt_mesh_sensor_srv sensor_srv =
 	BT_MESH_SENSOR_SRV_INIT(sensors, ARRAY_SIZE(sensors));
 
-static int sensor_data_get(struct bt_mesh_sensor *sensor,
+static int sensor_data_get(struct bt_mesh_sensor_srv *srv,
+			   struct bt_mesh_sensor *sensor,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct sensor_value *rsp)
 {


### PR DESCRIPTION
This adds sensor model context information to sensor
callbacks.

test-sdk-nrf: PR-119

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>