### PR TITLE
manifest: openthread update with link metrics fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
     - name: openthread
       repo-path: sdk-openthread
       path: modules/lib/openthread
-      revision: 316ee75ae63bf719411650f386b3c9646dc85ec9
+      revision: 02e61a2edd80417e9b8f9a5f4c1b2dad4ac486b4
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
Update OpenThread revision with required fix for Thread 1.2
certification.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>