### PR TITLE
samples: event_manager: Run Event Manager sample in CI

### DIFF
--- a/samples/event_manager/sample.yaml
+++ b/samples/event_manager/sample.yaml
@@ -1,12 +1,23 @@
 sample:
   description: Sample showing Event Manager usage
   name: Event Manager sample
+common:
+  harness: console
+  integration_platforms:
+    - qemu_cortex_m3
+    - nrf52dk_nrf52832
+    - nrf52840dk_nrf52840
+    - nrf9160dk_nrf9160_ns
+    - nrf21540dk_nrf52840
+  harness_config:
+    type: multi_line
+    ordered: false
+    regex:
+      - "config_event"
+      - "measurement_event"
+      - "control_event"
+      - "ack_event"
+      - "Average value3: 45"
 tests:
   samples.event_manager:
-    build_only: true
-    integration_platforms:
-      - nrf52dk_nrf52832
-      - nrf52840dk_nrf52840
-      - nrf9160dk_nrf9160_ns
-      - nrf21540dk_nrf52840
-    tags: ci_build
+    build_only: false


### PR DESCRIPTION
Modifies Event Manager CI test.
Earlier, the test was build-only.
Now, the sample runs in CI and the test checks whether all events occurs
and values are correct.

Jira: NCSDK-12471

Signed-off-by: Aleksander Strzebonski <aleksander.strzebonski@nordicsemi.no>