### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 901604f9c22db2cbe7976297639c3b2be1283089
+      revision: pull/734/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit updates sdk-zephyr with following bugs on thingy53:
1.  Do not forward FEM SPI pins to cpunet
2. Add dts node to forcibly set PMIC to PWM mode
by setting GPIO pin high.

Jira: NCSDK-13806

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>