### PR TITLE
doc: matter: remove devzone tutorial link

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -640,6 +640,8 @@
 
 .. ### Source: other
 
+.. _`Developing Matter products with nRF Connect SDK`: https://www.youtube.com/watch?v=kdMJQFDRoss
+
 .. _`iBasis IoT network coverage`: https://ibasis.com/solutions/iot-connectivity/network-coverage/
 
 

--- a/doc/nrf/ug_matter.rst
+++ b/doc/nrf/ug_matter.rst
@@ -19,6 +19,7 @@ Matter is in an early development stage and must be treated as an experimental f
 
 The |NCS| allows you to develop applications that are compatible with Matter.
 See :ref:`matter_samples` for the list of available samples or :ref:`Matter Weather Station <matter_weather_station_app>` for specific Matter application.
+If you are new to Matter, you can follow along with the video tutorials on Nordic Semiconductor's YouTube channel, for example `Developing Matter products with nRF Connect SDK`_.
 
 .. note::
     |matter_gn_required_note|

--- a/doc/nrf/ug_matter.rst
+++ b/doc/nrf/ug_matter.rst
@@ -19,7 +19,6 @@ Matter is in an early development stage and must be treated as an experimental f
 
 The |NCS| allows you to develop applications that are compatible with Matter.
 See :ref:`matter_samples` for the list of available samples or :ref:`Matter Weather Station <matter_weather_station_app>` for specific Matter application.
-If you are new to Matter, check also the tutorials on `DevZone`_.
 
 .. note::
     |matter_gn_required_note|


### PR DESCRIPTION
Removed link to DevZone for Matter into page.
TECHDOC-2153.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>