### PR TITLE
tests: cddl-gen: Initialize struct

### DIFF
--- a/tests/modules/lib/cddl-gen/decode/src/main.c
+++ b/tests/modules/lib/cddl-gen/decode/src/main.c
@@ -16,6 +16,10 @@ static void test_decode(void)
 	struct Test test;
 	bool res;
 
+	/* Initialize struct to ensure test isn't checking uninitialized pointers */
+	test._Test_name_tstr[0] = (cbor_string_type_t){NULL, 0};
+	test._Test_name_tstr[1] = (cbor_string_type_t){NULL, 0};
+
 	new_state(states, 4, payload, sizeof(payload), 1);
 
 	res = list_start_encode(states, 3);


### PR DESCRIPTION
Initialize structure to ensure that test isn't checking uninitialized pointers.
Fixes static analysis regression.


Static analysis error:

```3. Condition !_ret, taking true branch.
35 zassert_true(res, "Decoding should have been successful\n");
36

CID 154430 (#1-2 of 2): Uninitialized pointer read (UNINIT)
4. uninit_use_in_call: Using uninitialized value test._Test_name_tstr[0].value when calling memcmp.
37 zassert_mem_equal(test._Test_name_tstr[0].value, "Foo", test._Test_name_tstr[0].len, NULL);
38 zassert_mem_equal(test._Test_name_tstr[1].value, "Bar", test._Test_name_tstr[1].len, NULL);
39}
40