### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 199d339e98f91cd44f038bf4eb81e41e1d5ccac5
+      revision: 901604f9c22db2cbe7976297639c3b2be1283089
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a variety of BT patches from upstream (https://github.com/nrfconnect/sdk-zephyr/pull/730)