### PR TITLE
Fix netboot for non-secure nRF53 boards

### DIFF
--- a/subsys/partition_manager/pm.yml.rpmsg_nrf53
+++ b/subsys/partition_manager/pm.yml.rpmsg_nrf53
@@ -5,6 +5,3 @@ rpmsg_nrf53_sram:
   placement: {before: end}
   size: CONFIG_RPMSG_NRF53_SRAM_SIZE
   region: sram_primary
-#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
-  inside: sram_nonsecure
-#endif

--- a/subsys/partition_manager/pm.yml.trustzone
+++ b/subsys/partition_manager/pm.yml.trustzone
@@ -4,5 +4,9 @@ sram_secure:
   region: sram_primary
 
 sram_nonsecure:
-  span: [sram_primary] /* Here, sram_primary refers to the (NS) app's RAM. */
   region: sram_primary
+  span:
+    - sram_primary /* Here, sram_primary refers to the (NS) app's RAM. */
+#ifdef CONFIG_BT_RPMSG_NRF53
+    - rpmsg_nrf53_sram
+#endif


### PR DESCRIPTION
With the previous patch provided, it breaks netboot for non-secure boards as the partition manager is not able to resolve it correctly.

```
Partition manager failed: partition sram_nonsecure (['sram_primary', 'rpmsg_nrf53_sram']) does not span over consecutive parts. Solution: ['spm_sram', 'sram_primary', 'pcd_sram', 'rpmsg_nrf53_sram']
Failed to partition region sram_primary, size of region: 524288
Partition Configuration:
pcd_sram:
  placement:
    before:
    - rpmsg_nrf53_sram
    - end
  size: 8192
rpmsg_nrf53_sram:
  placement:
    before:
    - end
  size: 65536
spm_sram:
  placement:
    after:
    - start
  size: 32768
 ```

Tried to fix it in some other ways but the issue seems related to the fact that `sram_primary` is a region that contains `sram_secure` but is also included in the span of `sram_nonsecure`. 