### PR TITLE
samples: nrf9160: modem_shell: fix FOTA download CA certificate usage

### DIFF
--- a/samples/nrf9160/modem_shell/src/fota/fota.c
+++ b/samples/nrf9160/modem_shell/src/fota/fota.c
@@ -15,9 +15,9 @@
 #include "fota.h"
 #include "mosh_print.h"
 
-#define MOSH_FOTA_TLS_SECURITY_TAG 4242424
+#define MOSH_FOTA_US_TLS_SECURITY_TAG 4242424
 
-static const char root_ca_cert[] = {
+static const char us_root_ca_cert[] = {
 #include "cert/Baltimore-CyberTrust-Root"
 };
 
@@ -65,12 +65,13 @@ static void fota_download_callback(const struct fota_download_evt *evt)
 	}
 }
 
-static bool fota_ca_cert_exists(void)
+static bool fota_us_ca_cert_exists(void)
 {
 	int err;
 	bool exists;
 
-	err = modem_key_mgmt_exists(MOSH_FOTA_TLS_SECURITY_TAG, MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN,
+	err = modem_key_mgmt_exists(MOSH_FOTA_US_TLS_SECURITY_TAG,
+				    MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN,
 				    &exists);
 
 	if (!err && exists) {
@@ -80,20 +81,21 @@ static bool fota_ca_cert_exists(void)
 	}
 }
 
-static int fota_write_ca_cert(void)
+static int fota_write_us_ca_cert(void)
 {
-	return modem_key_mgmt_write(MOSH_FOTA_TLS_SECURITY_TAG, MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN,
-				    root_ca_cert, sizeof(root_ca_cert));
+	return modem_key_mgmt_write(MOSH_FOTA_US_TLS_SECURITY_TAG,
+				    MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN,
+				    us_root_ca_cert, sizeof(us_root_ca_cert));
 }
 
 int fota_init(void)
 {
 	int err;
 
-	if (!fota_ca_cert_exists()) {
-		err = fota_write_ca_cert();
+	if (!fota_us_ca_cert_exists()) {
+		err = fota_write_us_ca_cert();
 		if (err) {
-			printk("Failed to write root CA to modem, error %d\n",
+			printk("Failed to write US server root CA to modem, error %d\n",
 			       err);
 		}
 	}
@@ -103,5 +105,14 @@ int fota_init(void)
 
 int fota_start(const char *host, const char *file)
 {
-	return fota_download_start(host, file, MOSH_FOTA_TLS_SECURITY_TAG, 0, 0);
+	int sec_tag;
+
+	if (strstr(host, "us") != 0) {
+		/* The US server uses a different root CA. */
+		sec_tag = MOSH_FOTA_US_TLS_SECURITY_TAG;
+	} else {
+		sec_tag = CONFIG_NRF_CLOUD_SEC_TAG;
+	}
+
+	return fota_download_start(host, file, sec_tag, 0, 0);
 }


### PR DESCRIPTION
The root CA used by AWS has changed for some of the servers. This change selects the correct CA depending on the server.

Fixes NCSDK-13819.