### PR TITLE
tfm: Add debug function for examining memory protection

### DIFF
--- a/modules/tfm/tfm/boards/CMakeLists.txt
+++ b/modules/tfm/tfm/boards/CMakeLists.txt
@@ -88,3 +88,10 @@ if(TFM_PARTITION_PLATFORM)
     ${src_dir}/tfm_ioctl_ns_api.c
     )
 endif()
+
+if(LOG_MEMORY_PROTECTION)
+  target_sources(platform_s
+	PRIVATE
+	src/log_memory_protection.c
+	)
+endif()

--- a/modules/tfm/tfm/boards/src/log_memory_protection.c
+++ b/modules/tfm/tfm/boards/src/log_memory_protection.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <cmsis.h>
+#include <tfm_spm_log.h>
+#include <mpu_armv8m_drv.h>
+#include <nrf.h>
+#include <nrf_peripherals.h>
+#include <array.h>
+#include <nrfx_nvmc.h>
+
+void log_memory_protection_of_mpu(void)
+{
+	MPU_Type *mpu = (MPU_Type *)MPU_BASE;
+	SPMLOG_DBGMSG("\nARM MPU configuration\r\n");
+	SPMLOG_DBGMSGVAL("CTRL", mpu->CTRL);
+
+	for (int i = 0; i < MPU_ARMV8M_NUM_REGIONS; i++) {
+		mpu->RNR = i;
+		SPMLOG_DBGMSGVAL("RNR", i);
+		uint32_t rbar = mpu->RBAR;
+		uint32_t rlar = mpu->RLAR;
+		uint32_t en = (rlar & MPU_RLAR_EN_Msk) >> MPU_RLAR_EN_Pos;
+
+		SPMLOG_DBGMSGVAL("  EN", en);
+		if (en) {
+			SPMLOG_DBGMSGVAL("  BASE", rbar & MPU_RBAR_BASE_Msk);
+
+			/* The last address that is protected is limit + 31 */
+			SPMLOG_DBGMSGVAL("  LIMIT*", (rlar & MPU_RLAR_LIMIT_Msk) + 31);
+
+			SPMLOG_DBGMSGVAL("  XN", (rbar & MPU_RBAR_XN_Msk) >> MPU_RBAR_XN_Pos);
+			SPMLOG_DBGMSGVAL("  AP", (rbar & MPU_RBAR_AP_Msk) >> MPU_RBAR_AP_Pos);
+			SPMLOG_DBGMSGVAL("  SH", (rbar & MPU_RBAR_SH_Msk) >> MPU_RBAR_SH_Pos);
+
+			SPMLOG_DBGMSGVAL("  ATTRINDEX",
+					 (rlar & MPU_RLAR_AttrIndx_Msk) >> MPU_RLAR_AttrIndx_Pos);
+		}
+	}
+}
+
+void log_memory_protection_of_spu_nsc(void)
+{
+	SPMLOG_DBGMSGVAL("NRF_SPU_S->FLASHNSC[0].REGION", NRF_SPU_S->FLASHNSC[0].REGION);
+	SPMLOG_DBGMSGVAL("NRF_SPU_S->FLASHNSC[1].REGION", NRF_SPU_S->FLASHNSC[1].REGION);
+
+	SPMLOG_DBGMSGVAL("NRF_SPU_S->FLASHNSC[0].SIZE", NRF_SPU_S->FLASHNSC[0].SIZE);
+	SPMLOG_DBGMSGVAL("NRF_SPU_S->FLASHNSC[1].SIZE", NRF_SPU_S->FLASHNSC[1].SIZE);
+
+	SPMLOG_DBGMSGVAL("NRF_SPU_S->RAMNSC[0].REGION", NRF_SPU_S->RAMNSC[0].REGION);
+	SPMLOG_DBGMSGVAL("NRF_SPU_S->RAMNSC[1].REGION", NRF_SPU_S->RAMNSC[1].REGION);
+
+	SPMLOG_DBGMSGVAL("NRF_SPU_S->RAMNSC[0].SIZE", NRF_SPU_S->RAMNSC[0].SIZE);
+	SPMLOG_DBGMSGVAL("NRF_SPU_S->RAMNSC[1].SIZE", NRF_SPU_S->RAMNSC[1].SIZE);
+}
+
+void log_memory_protection_of_spu_flash(void)
+{
+	SPMLOG_DBGMSG("SPU FLASH region permissions\n");
+	uint32_t num_flash_regions = ARRAY_SIZE(NRF_SPU_S->FLASHREGION);
+	uint32_t prev_perm = 0x0BADF00D;
+	for (int i = 0; i < num_flash_regions; i++) {
+		uint32_t perm = NRF_SPU_S->FLASHREGION[i].PERM;
+		if (perm != prev_perm) {
+			prev_perm = perm;
+			SPMLOG_DBGMSGVAL("i", i * nrfx_nvmc_flash_page_size_get());
+			SPMLOG_DBGMSGVAL("PERM", perm);
+		}
+	}
+}
+
+void log_memory_protection_of_spu_ram(void)
+{
+	SPMLOG_DBGMSG("SPU RAM region permissions\n");
+	uint32_t num_ram_regions = ARRAY_SIZE(NRF_SPU_S->RAMREGION);
+	uint32_t prev_perm = 0x0BADF00D;
+	for (int i = 0; i < num_ram_regions; i++) {
+		uint32_t perm = NRF_SPU_S->RAMREGION[i].PERM;
+		if (perm != prev_perm) {
+			prev_perm = perm;
+			SPMLOG_DBGMSGVAL("i", i * SPU_RAMREGION_SIZE);
+			SPMLOG_DBGMSGVAL("PERM", perm);
+		}
+	}
+}
+
+void log_memory_protection_of_spu(void)
+{
+	log_memory_protection_of_spu_nsc();
+	log_memory_protection_of_spu_flash();
+	log_memory_protection_of_spu_ram();
+}
+
+void log_memory_protection(void)
+{
+	log_memory_protection_of_mpu();
+	log_memory_protection_of_spu();
+}


### PR DESCRIPTION
It can be difficult to understand how memory protection has been
configured so we add a debug function for logging the MPU and SPU
configuration.

The user must set the CMake variable LOG_MEMORY_PROTECTION in the TF-M
CMake build and invoke log_memory_protection() from the secure
firmware or from GDB.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>