### PR TITLE
kconfig: increase default value of BT_BUF_CMD_TX_COUNT for nRF5340

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -51,6 +51,10 @@ config PRIVILEGED_STACK_SIZE
 config MCUMGR_BUF_SIZE
 	default 1024 if UPDATEABLE_IMAGE_NUMBER > 1
 
+# When using HCI on the nRF5340 we need a larger command buffer.
+config BT_BUF_CMD_TX_COUNT
+	default 10 if SOC_NRF5340_CPUAPP || SOC_NRF5340_CPUNET
+
 # Set ENTROPY_GENERATOR to true for TF-M or SPM builds with enabled
 # RNG provided from secure services.
 config ENTROPY_GENERATOR


### PR DESCRIPTION
Fixes: NCSDK-13801

Increase the default value of BT_BUF_CMD_TX_COUNT to 10 when building
for the nRF5340 SoC as the amount of buffers are too small.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

--------


Note: long term, we should try to adjust this upstream.