### PR TITLE
caf: power_manager: Fix reboot instead of power down

### DIFF
--- a/subsys/caf/modules/power_manager.c
+++ b/subsys/caf/modules/power_manager.c
@@ -257,7 +257,7 @@ static bool event_handler(const struct event_header *eh)
 				system_off();
 			}
 		}
-		if (is_off_allowed && !was_off_allowed) {
+		if (!is_off_allowed && was_off_allowed) {
 			/* System off is not allowed. Reboot if needed. */
 			if (power_state == POWER_STATE_OFF) {
 				LOG_INF("Off restricted - rebooting");


### PR DESCRIPTION
Because of improper condition in check, system was rebooted when power off restriction was removed while device was suspended.

Jira: NCSDK-13832