### PR TITLE
samples: edge_impulse: wrapper: Run Edge Impulse sample in CI

### DIFF
--- a/samples/edge_impulse/wrapper/sample.yaml
+++ b/samples/edge_impulse/wrapper/sample.yaml
@@ -1,15 +1,26 @@
 sample:
   description: Sample showing Edge Impulse wrapper usage
   name: Edge Impulse wrapper sample
+common:
+  harness: console
+  integration_platforms:
+    - nrf52dk_nrf52832
+    - nrf52840dk_nrf52840
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf5340dk_nrf5340_cpuapp_ns
+    - nrf9160dk_nrf9160_ns
+    - qemu_cortex_m3
+  platform_exclude: native_posix qemu_x86
+  harness_config:
+    type: multi_line
+    ordered: true
+    regex:
+     - "Classification results"
+     - "Value: (1[.]0[0-9]+)|(0[.]9[0-9]+)\tLabel: sine"
+     - "Value: 0[.]0[0-9]+\tLabel: triangle"
+     - "Value: 0[.]0[0-9]+\tLabel: idle"
+     - "Anomaly: (-[0-9]+[.][0-9]+)|(0[.]0[0-9]+)"
+
 tests:
   samples.edge_impulse.wrapper:
-    build_only: true
-    platform_exclude: native_posix qemu_x86
-    integration_platforms:
-      - nrf52dk_nrf52832
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-      - nrf5340dk_nrf5340_cpuapp_ns
-      - nrf9160dk_nrf9160_ns
-      - qemu_cortex_m3
-    tags: ci_build
+    build_only: false


### PR DESCRIPTION
Modifies Edge Impulse CI test.
Earlier, the test was build-only.
Now, the sample runs in CI and the test checks whether classification is
conducted correctly.
To be specific, the test checks whether:
  - sine classification value is greater than or equal to 0.9 and less
    than 1.1,
  - triangle and idle classification values are greater than or equal to
    0 and less than 0.1,
  - Anomaly value is negative.

Jira: NCSDK-12471

Signed-off-by: Aleksander Strzebonski <aleksander.strzebonski@nordicsemi.no>