### PR TITLE
samples: bluetooth: direct_test_mode: Fix CTE disable handling

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -84,6 +84,12 @@ For lists of protocol-specific changes, see `Protocols`_.
 Bluetooth samples
 -----------------
 
+* Updated:
+
+  * :ref:`direct_test_mode` sample:
+
+    * Fixed handling of the disable Constant Tone Extension command.
+
 |no_changes_yet_note|
 
 Bluetooth mesh samples


### PR DESCRIPTION
This fixes handling CTE disable command parameter.
Now it can handled even by the devices that don't support
CTE, it also improves handling CTE disable parameter on
the devices supporting the CTE.