### PR TITLE
tfm: Enable testing of cipher mode CFB

### DIFF
--- a/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
+++ b/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
@@ -13,5 +13,5 @@ set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_GCM CACHE STRING    "The AEAD al
 set(PLATFORM_DEFAULT_CRYPTO_KEYS        FALSE       CACHE BOOL      "Use default crypto keys implementation.")
 
 # Disable crypto regression tests that are not supported
-set(TFM_CRYPTO_TEST_ALG_CFB             OFF          CACHE BOOL      "Test CFB cryptography mode")
+set(TFM_CRYPTO_TEST_ALG_CFB             ON           CACHE BOOL      "Test CFB cryptography mode")
 set(TFM_CRYPTO_TEST_ALG_OFB             OFF          CACHE BOOL      "Test OFB cryptography mode")

--- a/modules/tfm/tfm/boards/nrf9160/config.cmake
+++ b/modules/tfm/tfm/boards/nrf9160/config.cmake
@@ -13,5 +13,5 @@ set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_CCM CACHE STRING    "The AEAD al
 set(PLATFORM_DEFAULT_CRYPTO_KEYS        FALSE       CACHE BOOL      "Use default crypto keys implementation.")
 
 # Disable crypto regression tests that are not supported
-set(TFM_CRYPTO_TEST_ALG_CFB             OFF         CACHE BOOL      "Test CFB cryptography mode")
+set(TFM_CRYPTO_TEST_ALG_CFB             ON          CACHE BOOL      "Test CFB cryptography mode")
 set(TFM_CRYPTO_TEST_ALG_OFB             OFF         CACHE BOOL      "Test OFB cryptography mode")


### PR DESCRIPTION
Enable the CFB mode for TF-M Regression tests

Signed-off-by: Andreas Vibeto <andreas.vibeto@nordicsemi.no>