### PR TITLE
west.yml: Update Zephyr ref for Bluetooth Host fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 901604f9c22db2cbe7976297639c3b2be1283089
+      revision: c889e34413faba52c73731cfe42e6623c2452ef6
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update of Zephyr reference to include fixes for Bluetooth
Host: GATT and direction finding.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>