### PR TITLE
samples: bluetooth: direct_test_mode: Do not reset fem parameters

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -89,6 +89,8 @@ Bluetooth samples
   * :ref:`direct_test_mode` sample:
 
     * Fixed handling of the disable Constant Tone Extension command.
+    * The front-end module test parameters are not set to their default value after the DTM reset command.
+    * Added the vendor-specific ``FEM_DEFAULT_PARAMS_SET`` command for restoring the default front-end module parameters.
 
 |no_changes_yet_note|
 

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -166,7 +166,16 @@ Vendor specific commands can be divided into different categories as follows:
   For example, in the nRF21540 front-end module, the gain range is 0 - 31.
 * If the Length field is set to ``5`` (symbol ``FEM_ACTIVE_DELAY_SET``), the Frequency field sets the front-end module (FEM) activation delay in microseconds relative to the radio start.
   By default, this value is set to (radio ramp-up time - front-end module (FEM) TX/RX settling time).
+* If the Length field is set to ``6`` (symbol ``FEM_DEFAULT_PARAMS_SET``) and the Frequency field to any value, the front-end module parameters, such as antenna output, gain, and delay, are set to their default values.
 * All other values of Frequency and Length field are reserved.
+
+.. note::
+  Front-end module configuration parameters, such as antenna output, gain, and active delay, are not set to their default values after the DTM reset command.
+  Testers, for example Anritsu MT885, issue a reset command in the beginning of every test.
+  Therefore, you cannot run automated test scripts for front-end modules with other than the default parameters.
+
+  If you have changed the default parameters of the front-end module, you can restore them.
+  You can either send the ``FEM_DEFAULT_PARAMS_SET`` command or power cycle the front-end module.
 
 The DTM-to-Serial adaptation layer
 ==================================

--- a/samples/bluetooth/direct_test_mode/src/dtm.c
+++ b/samples/bluetooth/direct_test_mode/src/dtm.c
@@ -1192,6 +1192,17 @@ static enum dtm_err_code  dtm_vendor_specific_pkt(uint32_t vendor_cmd,
 		dtm_inst.fem.vendor_active_delay = vendor_option;
 
 		break;
+
+	case FEM_DEFAULT_PARAMS_SET:
+		dtm_inst.fem.gain = FEM_USE_DEFAULT_GAIN;
+		dtm_inst.fem.vendor_active_delay = 0;
+
+		if (fem_antenna_select(FEM_ANTENNA_1) != 0) {
+			dtm_inst.event = LE_TEST_STATUS_EVENT_ERROR;
+			return DTM_ERROR_ILLEGAL_CONFIGURATION;
+		}
+
+		break;
 #endif /* CONFIG_FEM */
 	}
 
@@ -1676,8 +1687,6 @@ static enum dtm_err_code on_test_setup_cmd(enum dtm_ctrl_code control,
 		dtm_inst.radio_mode = NRF_RADIO_MODE_BLE_1MBIT;
 		dtm_inst.packet_hdr_plen =
 			NRF_RADIO_PREAMBLE_LENGTH_8BIT;
-		dtm_inst.fem.vendor_active_delay = 0;
-		dtm_inst.fem.gain = FEM_USE_DEFAULT_GAIN;
 
 #if DIRECTION_FINDING_SUPPORTED
 		memset(&dtm_inst.cte_info, 0, sizeof(dtm_inst.cte_info));

--- a/samples/bluetooth/direct_test_mode/src/dtm.h
+++ b/samples/bluetooth/direct_test_mode/src/dtm.h
@@ -281,6 +281,9 @@ enum dtm_vs_subcmd {
 
 	/* Set front-end module (FEM) active delay set. */
 	FEM_ACTIVE_DELAY_SET = 5,
+
+	/* Restore front-end module (FEM) default parameters (antenna, gain, delay). */
+	FEM_DEFAULT_PARAMS_SET = 6
 };
 
 /* DTM Packet Type field */


### PR DESCRIPTION
Do not reset front-end module parameters like antenna,
gain, delay on the DTM Reset command. Testers like
Anritsu issues the DTM Reset command at every test
begging. So testing with different than default parameters
was not possible for aytomatic script testing.