### PR TITLE
doc: Replace backslash with a slash for file references.

### DIFF
--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -383,10 +383,10 @@ To set up the toolchain, complete the following steps:
 
 1. Download the `GNU Arm Embedded Toolchain`_ for your operating system.
 #. Extract the contents of the root folder of the toolchain into a directory of your choice.
-   The recommended folder is :file:`c:/gnuarmemb` on Windows and :file:`~/gnuarmemb` on Linux or macOS.
+   The recommended folder is :file:`c:\\gnuarmemb` on Windows and :file:`~/gnuarmemb` on Linux or macOS.
    Make sure that the folder name does not contain any spaces or special characters.
    By default, the contents are extracted to another folder that corresponds to the GNU Arm Embedded Toolchain version (*version-folder* in the following step).
-   For example, :file:`c:/gccarmemb/9_2019-q4-major`, where :file:`9_2019-q4-major` is the *version-folder* name edited to contain no empty spaces.
+   For example, :file:`c:\\gccarmemb\\9_2019-q4-major`, where :file:`9_2019-q4-major` is the *version-folder* name edited to contain no empty spaces.
 #. If you want to build and program applications from the command line, define the environment variables for the GNU Arm Embedded Toolchain.
    Depending on your operating system:
 
@@ -520,7 +520,7 @@ If you chose to use |SES| for :ref:`building and programming a sample applicatio
 
          Open GNU ARM Embedded Toolchain directory
 
-   #. Set the GNU ARM Embedded Toolchain directory path to the location where it was downloaded (for example, :file:`c:/gnuarmemb`).
+   #. Set the GNU ARM Embedded Toolchain directory path to the location where it was downloaded (for example, :file:`c:\\gnuarmemb`).
    #. Close the :guilabel:`nRF Connect options` window.
    #. Navigate to :guilabel:`Tools` > :guilabel:`Options` and select the :guilabel:`nRF Connect` tab.
    #. Set the full path of the Zephyr Base directory to :file:`ncs/zephyr`.

--- a/doc/nrf/libraries/bin/lwm2m_carrier/app_integration.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/app_integration.rst
@@ -87,13 +87,13 @@ Note that these settings can put the LwM2M carrier library either in the normal 
    To redo the bootstrap process, you must erase the flash and then load your application again.
 
 After calling the :c:func:`lwm2m_carrier_init` function, your application can call the non-returning function :c:func:`lwm2m_carrier_run` in its own thread.
-Both these functions are called in :file:`nrf\\lib\\bin\\lwm2m_carrier\\os\\lwm2m_carrier.c`, which is included into the project when you enable the LwM2M carrier library.
+Both these functions are called in :file:`nrf/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c`, which is included into the project when you enable the LwM2M carrier library.
 
 The :c:func:`lwm2m_carrier_event_handler` function must be implemented by your application.
 This is shown in the :ref:`lwm2m_carrier` sample.
-A weak implementation is included in :file:`nrf\\lib\\bin\\lwm2m_carrier\\os\\lwm2m_carrier.c`.
+A weak implementation is included in :file:`nrf/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c`.
 
-See :file:`nrf\\lib\\bin\\lwm2m_carrier\\include\\lwm2m_carrier.h` for all the events and API.
+See :file:`nrf/lib/bin/lwm2m_carrier/include/lwm2m_carrier.h` for all the events and API.
 
 .. _lwm2m_events:
 
@@ -196,7 +196,7 @@ Following are the various LwM2M carrier library events:
       |                                                        | some carriers. If it has not been issued yet, the bootstrap process can not proceed. |                                                  |
       +--------------------------------------------------------+--------------------------------------------------------------------------------------+--------------------------------------------------+
 
-    * :c:macro:`LWM2M_CARRIER_ERROR_FOTA_PKG` - This error indicates that the update package has been rejected. The integrity check has failed because of a wrong package sent from the server, or a wrong package received by client. The :c:member:`value` field will have an error of type :c:type:`nrf_dfu_err_t` from the file :file:`nrfxlib\\nrf_modem\\include\\nrf_socket.h`.
+    * :c:macro:`LWM2M_CARRIER_ERROR_FOTA_PKG` - This error indicates that the update package has been rejected. The integrity check has failed because of a wrong package sent from the server, or a wrong package received by client. The :c:member:`value` field will have an error of type :c:type:`nrf_dfu_err_t` from the file :file:`nrfxlib/nrf_modem/include/nrf_socket.h`.
 
     * :c:macro:`LWM2M_CARRIER_ERROR_FOTA_PROTO` - This error indicates a protocol error. There might be unexpected HTTP header contents. The server might not support partial content requests.
 

--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -15,7 +15,7 @@ Library wrapper
 ***************
 
 The library wrapper provides an encapsulation over the core Modem library functions such as initialization and shutdown.
-The library wrapper is implemented in :file:`nrf\\lib\\nrf_modem_lib\\nrf_modem_lib.c`.
+The library wrapper is implemented in :file:`nrf/lib/nrf_modem_lib/nrf_modem_lib.c`.
 
 The library wrapper encapsulates the :c:func:`nrf_modem_init` and :c:func:`nrf_modem_shutdown` calls of the Modem library with :c:func:`nrf_modem_lib_init` and :c:func:`nrf_modem_lib_shutdown` calls, respectively.
 The library wrapper eases the task of initializing the Modem library by automatically passing the size and address of all the shared memory regions of the Modem library to the :c:func:`nrf_modem_init` call.
@@ -41,7 +41,7 @@ Socket offloading
 Zephyr Socket API offers the :ref:`socket offloading functionality <zephyr:net_socket_offloading>` to redirect or *offload* function calls to BSD socket APIs such as ``socket()`` and ``send()``.
 The integration layer utilizes this functionality to offload the socket API calls to the Modem library and thus eases the task of porting the networking code to the nRF9160 by providing a wrapper for Modem library's native socket API such as :c:func:`nrf_socket` and :c:func:`nrf_send`.
 
-The socket offloading functionality in the integration layer is implemented in :file:`nrf\\lib\\nrf_modem_lib\\nrf91_sockets.c`.
+The socket offloading functionality in the integration layer is implemented in :file:`nrf/lib/nrf_modem_lib/nrf91_sockets.c`.
 
 Modem library socket API sets errnos as defined in :file:`nrf_errno.h`.
 The socket offloading support in the integration layer in |NCS| converts those errnos to the errnos that adhere to the selected C library implementation.
@@ -58,7 +58,7 @@ OS abstraction layer
 
 For functioning, the Modem library requires the implementation of an OS abstraction layer, which is an interface over the operating system functionalities such as interrupt setup, threads, and heap.
 The integration layer provides an implementation of the OS abstraction layer using |NCS| components.
-The OS abstraction layer is implemented in the :file:`nrfxlib\\nrf_modem\\include\\nrf_modem_os.c`.
+The OS abstraction layer is implemented in the :file:`nrfxlib/nrf_modem/include/nrf_modem_os.c`.
 
 The behavior of the functions in the OS abstraction layer is dependent on the |NCS| components that are used in their implementation.
 This is relevant for functions such as :c:func:`nrf_modem_os_shm_tx_alloc`, which uses :ref:`Zephyr's Heap implementation <zephyr:heap_v2>` to dynamically allocate memory.
@@ -66,7 +66,7 @@ In this case, the characteristics of the allocations made by these functions dep
 
 Modem trace module
 ******************
-The modem trace module is implemented in :file:`nrf\\lib\\nrf_modem_lib\\nrf_modem_lib_trace.c`.
+The modem trace module is implemented in :file:`nrf/lib/nrf_modem_lib/nrf_modem_lib_trace.c`.
 
 The module provides the functionality for starting, stopping, and forwarding of modem traces to a transport medium that can be set by enabling any one of the following Kconfig options:
 

--- a/doc/nrf/ug_thingy53.rst
+++ b/doc/nrf/ug_thingy53.rst
@@ -188,7 +188,7 @@ Complete the following steps after installing the `nRF Connect for Visual Studio
       The welcome page for nRF Connect for VS Code.
 
 #. Click on :guilabel:`Add an existing applicaton to workspace...`.
-#. In the prompt, navigate to the folder containing the sample you want to build, such as :file:`nrf\\samples\\bluetooth\\peripheral_lbs`.
+#. In the prompt, navigate to the folder containing the sample you want to build, such as :file:`nrf/samples/bluetooth/peripheral_lbs`.
    You should now see the selected application in the :guilabel:`Applications` window in the lower left corner.
 
    .. note::


### PR DESCRIPTION
Replace backslash with a slash for file references
in a few documents.
Kept a backslash for the windows file references.

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>