### PR TITLE
doc: requirements: disallow breathe 4.33.0

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -10,3 +10,4 @@ azure-storage-blob
 sphinx_markdown_tables
 markdown<3.3.5 # Workaround for ryanfox/sphinx-markdown-tables#34
 mistune<2.0 # Workaround for https://github.com/CrossNox/m2r2/issues/40
+breathe!=4.33 # Workaround for https://github.com/michaeljones/breathe/issues/803


### PR DESCRIPTION
Sphinx 4.33.0 introduces Graphviz support, but the Graphviz
configuration value names clash with the Sphinx built-in Graphviz extension.

Issue: https://github.com/michaeljones/breathe/issues/803