### PR TITLE
crypto: Add tags to samples, tests

### DIFF
--- a/samples/crypto/aes_cbc/sample.yaml
+++ b/samples/crypto/aes_cbc/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: AES CBC example
 tests:
     sample.aes_cbc:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/aes_ccm/sample.yaml
+++ b/samples/crypto/aes_ccm/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: AES CCM example
 tests:
     sample.aes_ccm:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/aes_ctr/sample.yaml
+++ b/samples/crypto/aes_ctr/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: AES CTR example
 tests:
     sample.aes_cbc:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/aes_gcm/sample.yaml
+++ b/samples/crypto/aes_gcm/sample.yaml
@@ -3,9 +3,9 @@ sample:
                  encryption and decryption using AES GCM mode
     name: AES GCM example
 tests:
-    sample.aes_gcm:
-        tags: introduction
-        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
+    sample.aes_gcm.cc312:
+        tags: introduction psa cc3xx
+        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp
         harness: console
         harness_config:
           type: multi_line
@@ -14,6 +14,15 @@ tests:
         integration_platforms:
             - nrf5340dk_nrf5340_cpuapp_ns
             - nrf5340dk_nrf5340_cpuapp
+    sample.aes_gcm.cc310:
+        tags: introduction psa oberon
+        platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160_ns nrf9160dk_nrf9160
+        harness: console
+        harness_config:
+          type: multi_line
+          regex:
+            - ".*Example finished successfully!.*"
+        integration_platforms:
+            - nrf52840dk_nrf52840
             - nrf9160dk_nrf9160_ns
             - nrf9160dk_nrf9160
-            - nrf52840dk_nrf52840

--- a/samples/crypto/chachapoly/sample.yaml
+++ b/samples/crypto/chachapoly/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: Chacha20-Poly1305 example
 tests:
     sample.chacha_poly:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/ecdh/sample.yaml
+++ b/samples/crypto/ecdh/sample.yaml
@@ -5,7 +5,7 @@ sample:
     name: ECDH example
 tests:
     sample.ecdh:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/ecdsa/sample.yaml
+++ b/samples/crypto/ecdsa/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: ECDSA example
 tests:
     sample.ecdsa:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/hkdf/sample.yaml
+++ b/samples/crypto/hkdf/sample.yaml
@@ -3,7 +3,7 @@ sample:
     name: HKDF example
 tests:
     sample.hkdf:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/hmac/sample.yaml
+++ b/samples/crypto/hmac/sample.yaml
@@ -5,7 +5,7 @@ sample:
     name: HMAC example
 tests:
     sample.hmac:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/persistent_key_usage/sample.yaml
+++ b/samples/crypto/persistent_key_usage/sample.yaml
@@ -5,7 +5,7 @@ sample:
     name: Persistent key example
 tests:
     sample.aes_cbc:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/rng/sample.yaml
+++ b/samples/crypto/rng/sample.yaml
@@ -3,7 +3,7 @@ sample:
     name: RNG example
 tests:
     sample.rng:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/rsa/sample.yaml
+++ b/samples/crypto/rsa/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: RSA example
 tests:
     sample.rsa:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -3,7 +3,7 @@ sample:
     name: SHA256 example
 tests:
     sample.sha256:
-        tags: introduction
+        tags: introduction psa cc3xx
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/tests/crypto/testcase.yaml
+++ b/tests/crypto/testcase.yaml
@@ -6,7 +6,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
-    tags: crypto ci_build
+    tags: crypto ci_build legacy builtin_legacy
     timeout: 600
   crypto.cc3xx:
     extra_args: OVERLAY_CONFIG=overlay-cc3xx.conf
@@ -15,7 +15,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
-    tags: crypto ci_build
+    tags: crypto ci_build legacy cc3xx_legacy
     timeout: 200
   crypto.oberon:
     extra_args: OVERLAY_CONFIG=overlay-oberon.conf
@@ -24,5 +24,5 @@ tests:
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
-    tags: crypto ci_build
+    tags: crypto ci_build legacy oberon_legacy
     timeout: 200


### PR DESCRIPTION
Add relevant tags to crypto samples and crypto tests.
The chosen tags will allow filtering on the different backends
available, and also to filter on psa and/or legacy as groups.

Signed-off-by: Torstein Grindvik <torstein.grindvik@nordicsemi.no>