### PR TITLE
cmake: save CONF_FILE_BUILD_TYPE in cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@
 # Point to NCS root directory.
 set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "NCS root directory")
 
+# We need to cache the build type so that it is not out of sync when CONF_FILE
+# is cached.
+set(CONF_FILE_BUILD_TYPE ${CONF_FILE_BUILD_TYPE} CACHE INTERNAL "The build type")
+
 include(cmake/extensions.cmake)
 include(cmake/version.cmake)
 include(cmake/multi_image.cmake)

--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -297,7 +297,7 @@ function(add_child_image_from_source)
       # Check for configuration fragment. The contents of these are appended
       # to the project configuration, as opposed to the CONF_FILE which is used
       # as the base configuration.
-      if (DEFINED CONF_FILE_BUILD_TYPE)
+      if(NOT "${CONF_FILE_BUILD_TYPE}" STREQUAL "")
         set(child_image_conf_fragment ${ACI_CONF_DIR}/${ACI_NAME}_${CONF_FILE_BUILD_TYPE}.conf)
       else()
         set(child_image_conf_fragment ${ACI_CONF_DIR}/${ACI_NAME}.conf)


### PR DESCRIPTION
This is done to avoid having out of sync build type when the
CONF_FILE is cached.

Ref: NCSDK-13845
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>