### PR TITLE
manifest: nrfxlib with crypto doc fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -108,7 +108,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v1.9.0-rc2
+      revision: 70dd41fedf14db7cc35a6904f38edc9a3ea30a7a
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
-This includes some doc additions regarding
 the PSA drivers in crypto

Ref: NCSDK-12563
Ref: NCSDK-12557

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>