### PR TITLE
tests: event_manager: Remove excluded platforms

### DIFF
--- a/tests/subsys/event_manager/testcase.yaml
+++ b/tests/subsys/event_manager/testcase.yaml
@@ -1,6 +1,5 @@
 tests:
   event_manager.core:
-    platform_exclude: native_posix qemu_x86
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832


### PR DESCRIPTION
Support for these boards was already introduced.

Jira: NCSDK-12471