### PR TITLE
doc: requirements: stick to breathe < 4.33

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -10,4 +10,4 @@ azure-storage-blob
 sphinx_markdown_tables
 markdown<3.3.5 # Workaround for ryanfox/sphinx-markdown-tables#34
 mistune<2.0 # Workaround for https://github.com/CrossNox/m2r2/issues/40
-breathe!=4.33 # Workaround for https://github.com/michaeljones/breathe/issues/803
+breathe<4.33 # Workaround for #803 and #805 breathe issues


### PR DESCRIPTION
Looks like the 4.33 release has some more issues, so let's wait until
everything gets fixed before allowing future versions.

Ref. https://github.com/michaeljones/breathe/issues/805