### PR TITLE
tests: crypto: Remove reference to removed CONFIG_NRF_CC310_PLATFORM

### DIFF
--- a/tests/crypto/src/common_test.h
+++ b/tests/crypto/src/common_test.h
@@ -18,11 +18,6 @@
 
 #include <mbedtls/platform.h>
 #include <mbedtls/cipher.h>
-#if defined(CONFIG_NRF_CC310_PLATFORM)
-#include <nrf_cc310_platform.h>
-#include <nrf_cc310_platform_abort.h>
-#include <nrf_cc310_platform_mutex.h>
-#endif /* CONFIG_NRF_CC310_PLATFORM) */
 
 /* Found in nrfxlib/nrf_security/mbedtls/mbedtls_heap.c
  * Used for reallocating the heap between suites.


### PR DESCRIPTION
Remove reference to the Kconfig option CONFIG_NRF_CC310_PLATFORM which
no longer exists.