### PR TITLE
application: serial_lte_modem: BUG-FIX post FOTA handling

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -115,12 +115,6 @@ config SLM_DATAMODE_TERMINATOR
 	help
 	  Use a pattern to terminate data mode
 
-config SLM_DATAMODE_SILENCE
-	int "Silence time to exit data mode"
-	default 1
-	help
-	  Exit data mode after the specified time (in seconds) of UART silence
-
 #
 # Configurable services
 #

--- a/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
@@ -81,8 +81,11 @@ Example
    OK
    #XFOTA: 1,0,0
    ...
-   #XFOTA: 1,4,0
+   #XFOTA:4,0
    AT#XRESET
+   OK
+   READY
+   #XFOTA: 5,0
 
    Erase previous image after FOTA
    AT#XFOTA=8
@@ -102,8 +105,11 @@ Example
    OK
    #XFOTA: 1,0,0
    ...
-   #XFOTA: 1,4,0
+   #XFOTA: 4,0
    AT#XRESET
+   OK
+   READY
+   #XFOTA: 5,0
 
 Unsolicited notification
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
@@ -133,7 +133,7 @@ Syntax
   If ``payload_length`` is greater than ``0``, the SLM will enter data mode and expect the upcoming UART input data as payload.
   The SLM will then send the payload to the HTTP server until the ``payload_length`` bytes are sent.
   To abort sending the payload, terminate data mode by sending the terminator string defined in :kconfig:`CONFIG_SLM_DATAMODE_TERMINATOR`.
-  The default pattern string is "+++". Keep in mind that UART silence as configured in :kconfig:`CONFIG_SLM_DATAMODE_SILENCE` is required before and after the pattern string.
+  The default pattern string is "+++".
 
 Response syntax
 ~~~~~~~~~~~~~~~

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -39,6 +39,7 @@ static bool full_idle_mode;
 struct k_work_q slm_work_q;
 
 /* global variable defined in different files */
+extern uint8_t fota_type;
 extern uint8_t fota_stage;
 extern uint8_t fota_status;
 extern int32_t fota_info;
@@ -267,8 +268,15 @@ void start_execute(void)
 
 	/* Post-FOTA handling */
 	if (fota_stage != FOTA_STAGE_INIT) {
-		handle_nrf_modem_lib_init_ret();
-		handle_mcuboot_swap_ret();
+		if (fota_type == DFU_TARGET_IMAGE_TYPE_MODEM_DELTA) {
+			handle_nrf_modem_lib_init_ret();
+		} else if (fota_type == DFU_TARGET_IMAGE_TYPE_MCUBOOT) {
+			handle_mcuboot_swap_ret();
+		} else {
+			LOG_ERR("Unknown DFU type: %d", fota_type);
+			fota_status = FOTA_STATUS_ERROR;
+			fota_info = -EAGAIN;
+		}
 	}
 
 	err = ext_xtal_control(true);

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -52,6 +52,7 @@ int slm_setting_fota_save(void);
 /* global variable defined in different files */
 extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 extern struct at_param_list at_param_list;
+extern uint8_t fota_type;
 extern uint8_t fota_stage;
 extern uint8_t fota_status;
 extern int32_t fota_info;
@@ -246,6 +247,8 @@ static int do_fota_start(int op, const char *file_uri, int sec_tag,
 		rsp_send(rsp_buf, strlen(rsp_buf));
 	}
 
+	fota_type = type;
+
 	return ret;
 }
 
@@ -362,6 +365,8 @@ int handle_at_fota(enum at_cmd_type cmd_type)
 			err = do_fota_erase_app();
 		} else if (op == SLM_FOTA_ERASE_MFW) {
 			err = do_fota_erase_mfw();
+		} else {
+			err = -EINVAL;
 		} break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:

--- a/applications/serial_lte_modem/src/slm_settings.c
+++ b/applications/serial_lte_modem/src/slm_settings.c
@@ -9,6 +9,7 @@
 #include <zephyr.h>
 #include <settings/settings.h>
 #include <drivers/uart.h>
+#include <dfu/dfu_target.h>
 #include "slm_at_fota.h"
 
 LOG_MODULE_REGISTER(slm_config, CONFIG_SLM_LOG_LEVEL);
@@ -16,6 +17,7 @@ LOG_MODULE_REGISTER(slm_config, CONFIG_SLM_LOG_LEVEL);
 /**
  * Serial LTE Modem setting page for persistent data
  */
+uint8_t fota_type;		/* FOTA: image type */
 uint8_t fota_stage;		/* FOTA: stage of FOTA process */
 uint8_t fota_status;		/* FOTA: OK/Error status */
 int32_t fota_info;		/* FOTA: failure cause in case of error or download percentage*/
@@ -25,7 +27,12 @@ struct uart_config slm_uart;	/* UART: config */
 
 static int settings_set(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg)
 {
-	if (!strcmp(name, "fota_stage")) {
+	if (!strcmp(name, "fota_type")) {
+		if (len != sizeof(fota_type))
+			return -EINVAL;
+		if (read_cb(cb_arg, &fota_type, len) > 0)
+			return 0;
+	} else if (!strcmp(name, "fota_stage")) {
 		if (len != sizeof(fota_stage))
 			return -EINVAL;
 		if (read_cb(cb_arg, &fota_stage, len) > 0)
@@ -107,6 +114,11 @@ int slm_setting_fota_save(void)
 	int ret;
 
 	/* Write a single serialized value to persisted storage (if it has changed value). */
+	ret = settings_save_one("slm/fota_type", &(fota_type), sizeof(fota_type));
+	if (ret) {
+		LOG_ERR("save slm/fota_type failed: %d", ret);
+		return ret;
+	}
 	ret = settings_save_one("slm/fota_stage", &(fota_stage), sizeof(fota_stage));
 	if (ret) {
 		LOG_ERR("save slm/fota_stage failed: %d", ret);
@@ -128,6 +140,7 @@ int slm_setting_fota_save(void)
 
 void slm_setting_fota_init(void)
 {
+	fota_type = DFU_TARGET_IMAGE_TYPE_ANY;
 	fota_stage = FOTA_STAGE_INIT;
 	fota_status = FOTA_STATUS_OK;
 	fota_info = 0;


### PR DESCRIPTION
After modem FOTA, DFU URC error due to unconditional call of
MCUBOOT API, which returns unexpected swap type. Solution is
to separate mcuboot FOTA from modem FOTA.

Also remove unused CONFIG_SLM_DATAMODE_SILENCE.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>