### PR TITLE
bluetooth: Fix scan API/implementation mismatch

### DIFF
--- a/include/bluetooth/scan.h
+++ b/include/bluetooth/scan.h
@@ -471,7 +471,7 @@ void bt_scan_filter_disable(void);
  * @return 0 If the operation was successful. Otherwise, a (negative) error
  *	     code is returned.
  */
-int bt_scan_filter_status(struct bt_filter_status *status);
+int bt_scan_filter_status_get(struct bt_filter_status *status);
 
 /**@brief Function for adding any type of filter to the scanning.
  *

--- a/subsys/bluetooth/scan.c
+++ b/subsys/bluetooth/scan.c
@@ -1294,7 +1294,7 @@ int bt_scan_filter_enable(uint8_t mode, bool match_all)
 	return 0;
 }
 
-int bt_scan_filter_get(struct bt_filter_status *status)
+int bt_scan_filter_status_get(struct bt_filter_status *status)
 {
 	if (!status) {
 		return -EINVAL;


### PR DESCRIPTION
The API bt_scan_filter_status() seems to be implemented by
bt_scan_filter_get(). This aligns the API and implementation to be
bt_scan_filter_status_get().

Fixes NCSIDB-683.

Signed-off-by: Thomas Stenersen <thomas.stenersen@nordicsemi.no>