### PR TITLE
(WIP) lib: modem_info: Introduce individual functions to read version info

### DIFF
--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -242,6 +242,85 @@ int modem_info_json_object_encode(struct modem_param_info *modem,
  */
 int modem_info_params_get(struct modem_param_info *modem_param);
 
+/** @brief Obtain the UUID of the modem firmware build.
+ *
+ * The UUID is represented as a string, for example:
+ * 25c95751-efa4-40d4-8b4a-1dcaab81fac9
+ *
+ * See the documentation for the AT command %XMODEMUUID.
+ *
+ * @param buf Pointer to the target buffer.
+ * @param buf_size Size of target buffer.
+ *
+ * @retval 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_fw_uuid(char *buf, size_t buf_size);
+
+/** @brief Obtain the short software identification.
+ *
+ * The short software identification is represented as a string, for example:
+ * nrf9160_1.1.2
+ *
+ * See the documentation for the AT command %SHORTSWVER.
+ *
+ * @param buf Pointer to the target buffer.
+ * @param buf_size Size of target buffer.
+ *
+ * @retval 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_fw_version(char *buf, size_t buf_size);
+
+/** @brief Obtain the modem Software Version Number (SVN).
+ *
+ * The SVN is represented as a string, for example:
+ * 12
+ *
+ * See the documentation for the AT command +CGSN.
+ *
+ * @param buf Pointer to the target buffer.
+ * @param buf_size Size of target buffer.
+ *
+ * @retval 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_svn(char *buf, size_t buf_size);
+
+/** @brief Obtain the battery voltage.
+ *
+ * Get the battery voltage, in mV, with a 4 mV resolution.
+ *
+ * @param val Pointer to the target variable.
+ *
+ * @retval 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_batt_voltage(int *val);
+
+/** @brief Obtain the internal temperature.
+ *
+ * Get the internal temperature, in degrees Celsius.
+ *
+ * @param val Pointer to the target variable.
+ *
+ * @retval 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_temperature(int *val);
+
+/** @brief Obtain the RSRP.
+ *
+ * Get the reference signal received strength (RSRP), in dBm.
+ *
+ * @param val Pointer to the target variable.
+ *
+ * @retval 0 if the operation was successful.
+ * @retval -ENOENT if there is no valid RSRP.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_rsrp(int *val);
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Introduces new functions to read firmware version information.
Information is read via individual functions with flexible parsing
based on the new nrf_modem_at interface.

The intent is to cover each variable of interest with a similar function, dealing with any quirks of parsing within their respective functions, and eventually phase out the current generic approach.

More variables will be added to this PR in short order as they are implemented and tested. Meanwhile, this is a good place for discussion about the approach in general.