### PR TITLE
lib: multicell_location: Here: added more parameters

### DIFF
--- a/lib/multicell_location/Kconfig
+++ b/lib/multicell_location/Kconfig
@@ -108,7 +108,8 @@ config MULTICELL_LOCATION_HERE_HTTPS_PORT
 
 config MULTICELL_LOCATION_HERE_HOSTNAME
 	string "Server hostname for HERE"
-	default "pos.api.here.com" if MULTICELL_LOCATION_HERE_V1
+	default "pos.api.here.com" if MULTICELL_LOCATION_HERE_V1 && MULTICELL_LOCATION_HERE_USE_APP_CODE_ID
+	default "pos.ls.hereapi.com" if MULTICELL_LOCATION_HERE_V1 && MULTICELL_LOCATION_HERE_USE_API_KEY
 	default "positioning.hereapi.com" if MULTICELL_LOCATION_HERE_V2
 	help
 	  Server hostname to use when connecting to HERE location service


### PR DESCRIPTION
With both v1 and v2 LTE Positioning Here API versions: 
added support for tac, rsrp, rsrq and ta for current cell, and rsrp and rsrq for neighbor cells.

Additionally, updated a default Here api hostname with v1 api if using apiKey authentication.

Jira: NCSDK-12970