### PR TITLE
lib: supl: fix AT%XMONITOR response handling in some networks

### DIFF
--- a/lib/supl/os/supl_os_client.c
+++ b/lib/supl/os/supl_os_client.c
@@ -105,7 +105,7 @@ static int set_device_id(void)
 
 static int set_lte_params(void)
 {
-	char response[128] = { 0 };
+	char response[192] = { 0 };
 
 	lte_params_init(&supl_client_ctx.lte_params);
 


### PR DESCRIPTION
The AT%XMONITOR response in some networks was too long for the temporary buffer. This happened when the network names were very long.

NCSIDB-684