### PR TITLE
manifest: Zephyr update for lwm2m fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.7.99-ncs1
+      revision: 22e3f8090e8439b71b70c4b308cec98bb201776c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This brings a fix for a bug in the firmware update
object in the lwm2m-library.

https://github.com/nrfconnect/sdk-zephyr/pull/738

Signed-off-by: Jarno Lamsa <jarno.lamsa@nordicsemi.no>