### PR TITLE
samples: direct_test_mode: radio_test: Fix build warning

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
@@ -625,7 +625,7 @@ static int spim_gain_transfer(uint8_t gain)
 	return 0;
 }
 
-static int nrf21540_tx_gain_set(uint8_t gain)
+static int nrf21540_tx_gain_set(uint32_t gain)
 {
 	int err;
 	NRF_UARTE_Type *uarte_inst = NRF_UARTE0;


### PR DESCRIPTION
Fix build warnings for nrf5340dk with nrf21540ek in
the Direct Test Mode and Radio Test sample.