### PR TITLE
doc: Add a known issue for radio_test and DTM (nRF5340 with nRF21540 EK build).

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -317,6 +317,10 @@ KRKNWK-6756: 802.15.4 Service Layer (SL) library support for the nRF53
 FOTA does not work
   FOTA with the :ref:`zephyr:smp_svr_sample` does not work.
 
+.. rst-class:: v1-9-0
+
+NCSDK-13925: :ref:`radio_test` and :ref:`direct_test_mode` build with warnings for nRF5340 with the :ref:`ug_radio_fem_nrf21540_ek` support.
+
 nRF52820
 ========
 


### PR DESCRIPTION
Report a known issue - build warning in radio_test and DTM for nRF5340 with
nRF21540 EK support.

PR with fix: https://github.com/nrfconnect/sdk-nrf/pull/6925