### PR TITLE
lte_lc: Enable/disable RAI on LTE-M&NB-IoT

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1094,6 +1094,8 @@ int lte_lc_rai_req(bool enable)
 		return -EOPNOTSUPP;
 	case LTE_LC_SYSTEM_MODE_NBIOT:
 	case LTE_LC_SYSTEM_MODE_NBIOT_GPS:
+	case LTE_LC_SYSTEM_MODE_LTEM_NBIOT:
+	case LTE_LC_SYSTEM_MODE_LTEM_NBIOT_GPS:
 		break;
 	default:
 		LOG_ERR("Unknown system mode");


### PR DESCRIPTION
Adds ability to enable and disable RAI on LTE-M+NB-Iot system modes.
RAI seems to be enabled by default on modem firmware v1.3.1 (NB-IoT).

Signed-off-by: Tero Nikula <tero.nikula@anicare.fi>