### PR TITLE
partition_manager: Fix non-secure and secure storage alignment

### DIFF
--- a/subsys/partition_manager/pm.yml.file_system
+++ b/subsys/partition_manager/pm.yml.file_system
@@ -2,6 +2,6 @@
 
 #ifdef CONFIG_FILE_SYSTEM_LITTLEFS
 littlefs_storage:
-  placement: {before: [end]}
+  placement: {before: [tfm_storage, end]}
   size: CONFIG_PM_PARTITION_SIZE_LITTLEFS
 #endif

--- a/subsys/partition_manager/pm.yml.memfault
+++ b/subsys/partition_manager/pm.yml.memfault
@@ -1,6 +1,6 @@
 #include <autoconf.h>
 
 memfault_storage:
-  placement: {before: [end]}
+  placement: {before: [tfm_storage, end]}
   size: CONFIG_PM_PARTITION_SIZE_MEMFAULT_STORAGE
   align: {start: CONFIG_MEMFAULT_NCS_FLASH_REGION_SIZE}

--- a/subsys/partition_manager/pm.yml.nvs
+++ b/subsys/partition_manager/pm.yml.nvs
@@ -1,5 +1,5 @@
 #include <autoconf.h>
 
 nvs_storage:
-  placement: {before: [end]}
+  placement: {before: [tfm_storage, end]}
   size: CONFIG_PM_PARTITION_SIZE_NVS_STORAGE

--- a/subsys/partition_manager/pm.yml.settings
+++ b/subsys/partition_manager/pm.yml.settings
@@ -2,7 +2,7 @@
 
 settings_storage:
   placement:
-    before: [end]
+    before: [tfm_storage, end]
 #ifdef CONFIG_BUILD_WITH_TFM
     align: {start: CONFIG_NRF_SPU_FLASH_REGION_SIZE}
 #endif

--- a/subsys/partition_manager/pm.yml.tfm
+++ b/subsys/partition_manager/pm.yml.tfm
@@ -36,17 +36,23 @@ app_secondary:
   share_size: app_primary
 #endif
 
+tfm_storage:
+  span: []
+
 tfm_ps:
-  placement: {after: [app_secondary, app]}
+  placement: {before: end}
+  inside: tfm_storage
   size: CONFIG_PM_PARTITION_SIZE_TFM_PROTECTED_STORAGE
-  align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
+  align: {start: CONFIG_NRF_SPU_FLASH_REGION_SIZE}
 
 tfm_its:
-  placement: {after: [app_secondary, app]}
+  placement: {before: end}
+  inside: tfm_storage
   size: CONFIG_PM_PARTITION_SIZE_TFM_INTERNAL_TRUSTED_STORAGE
-  align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
+  align: {start: CONFIG_NRF_SPU_FLASH_REGION_SIZE}
 
 tfm_otp_nv_counters:
-  placement: {after: [app_secondary, app]}
+  placement: {before: end}
+  inside: tfm_storage
   size: CONFIG_PM_PARTITION_SIZE_TFM_OTP_NV_COUNTERS
-  align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
+  align: {start: CONFIG_NRF_SPU_FLASH_REGION_SIZE}


### PR DESCRIPTION
Fix non-secure and secure storage alignment.
Non-secure storage was placed after the secure storage, in this
configuration they would have to be aligned on the SPU flash region
size. Move it before the secure storage to avoid this.

Secure storage was aligned using the wrong configuraion.
This was not an actual bug since they are equal, but could be a problem
in the future.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>