### PR TITLE
samples: tfm_hello_world: Print the approximate IPC overhead

### DIFF
--- a/samples/tfm/tfm_hello_world/sample.yaml
+++ b/samples/tfm/tfm_hello_world/sample.yaml
@@ -16,6 +16,7 @@ common:
         - "Generating random number"
         - "0x[0-9a-f]{64}"
         - "Reading some secure memory that NS is allowed to read"
+        - ".*"
         - "FICR->INFO.PART: 0x[0-9a-f]{8}"
         - "FICR->INFO.VARIANT: 0x[0-9a-f]{8}"
         - "Hashing 'Hello World! .*'"

--- a/samples/tfm/tfm_hello_world/src/main.c
+++ b/samples/tfm/tfm_hello_world/src/main.c
@@ -81,8 +81,16 @@ void main(void)
 	}
 
 	printk("Reading some secure memory that NS is allowed to read\n");
-	printk("FICR->INFO.PART: 0x%08x\n",
-		secure_read_word((intptr_t)&NRF_FICR_S->INFO.PART));
+
+	NRF_TIMER1_NS->TASKS_START = 1;
+
+	uint32_t part = secure_read_word((intptr_t)&NRF_FICR_S->INFO.PART);
+
+	NRF_TIMER1_NS->TASKS_CAPTURE[0] = 1;
+
+	printk("Approximate IPC overhead us: %d\n", NRF_TIMER1_NS->CC[0]);
+
+	printk("FICR->INFO.PART: 0x%08x\n", part);
 	printk("FICR->INFO.VARIANT: 0x%08x\n",
 		secure_read_word((intptr_t)&NRF_FICR_S->INFO.VARIANT));
 


### PR DESCRIPTION
Modify the tfm_hello_world sample to print the approximate IPC
overhead.

This assumes that reading a secure word is 0 us, which is not true, so
the value must be interpreted with some context and understanding.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>