### PR TITLE
event_manager: Align memory free with Event Manager API

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_discovery.c
+++ b/applications/nrf_desktop/src/modules/ble_discovery.c
@@ -96,7 +96,7 @@ static void hids_discovery_completed(struct bt_gatt_dm *dm, void *context)
 	/* Nothing was found. */
 	LOG_ERR("Unrecognized peer");
 	peer_disconnect(bt_gatt_dm_conn_get(dm));
-	k_free(event);
+	event_manager_free(event);
 	int err = bt_gatt_dm_data_release(dm);
 
 	if (err) {

--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -266,7 +266,7 @@ static void drop_enqueued_reports(struct enqueued_reports *enqueued_reports,
 
 		item = get_enqueued_report(enqueued_reports, irep_idx);
 
-		k_free(item->report);
+		event_manager_free(item->report);
 		k_free(item);
 	}
 }
@@ -359,7 +359,7 @@ static void enqueue_hid_report(struct enqueued_reports *enqueued_reports,
 	} else {
 		LOG_WRN("Enqueue dropped the oldest report");
 		item = get_enqueued_report(enqueued_reports, irep_idx);
-		k_free(item->report);
+		event_manager_free(item->report);
 	}
 
 	if (!item) {

--- a/applications/nrf_desktop/src/util/config_channel_transport.c
+++ b/applications/nrf_desktop/src/util/config_channel_transport.c
@@ -221,7 +221,7 @@ int config_channel_transport_set(struct config_channel_transport *transport,
 
 	if (err < 0) {
 		LOG_WRN("Received improper frame");
-		k_free(event);
+		event_manager_free(event);
 		return -EINVAL;
 	}
 

--- a/tests/subsys/event_manager/src/modules/test_oom.c
+++ b/tests/subsys/event_manager/src/modules/test_oom.c
@@ -23,7 +23,7 @@ void oom_error_handler(void)
 
 	/* Freeing memory to enable further testing. */
 	while (event_tab[i] != NULL) {
-		k_free(event_tab[i]);
+		event_manager_free(event_tab[i]);
 		i++;
 	}
 


### PR DESCRIPTION
Make sure that Event Manager API is used to free memory allocated for events.

Jira: NCSDK-13871