### PR TITLE
manifest: Add TF-M with FPU and FICR fixes

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -210,6 +210,12 @@ Unity
 
 |no_changes_yet_note|
 
+Trusted Firmware-M
+==================
+
+* Fixed the NCSDK-13949 known issue where the TF-M Secure Image would copy FICR to RAM on nRF9160.
+* Fixed the NCSDK-12306 known issue where a usage fault would be triggered in the debug build on nRF9160.
+
 MCUboot
 =======
 

--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v1.5.0-ncs1
+      revision: 49dfb1cbaa7d48e0d68a32c33372429a835f8dbd
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
-This fixes a minor bug in the configuration
 of the FPU and adds the missing
 NRF_SKIP_FICR_NS_COPY_TO_RAM define to BL2
 build and nrf9160 platform.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>