### PR TITLE
lib: date_time: increase time update thread default stack size

### DIFF
--- a/lib/date_time/Kconfig
+++ b/lib/date_time/Kconfig
@@ -45,7 +45,7 @@ config DATE_TIME_NTP
 
 config DATE_TIME_THREAD_STACK_SIZE
 	int "Stack size of the thread maintaining date time"
-	default 1152
+	default 1280
 
 config DATE_TIME_NTP_QUERY_TIME_SECONDS
 	int "Duration in which the library will query for NTP time, in seconds"


### PR DESCRIPTION
The default stack size was too low if time was fetched using NTP and debug logging was enabled, causing a stack overflow.