### PR TITLE
samples: Bluetooth: df: Add info about max ant sw pattern len Kconfig

### DIFF
--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -163,9 +163,9 @@ For example, the CTE length is 120 µs and the antenna switching slot is 1 µs.
 This will result in the following number of IQ samples:
 
 * 8 samples from the reference period.
-* Switch-sample period duration is: 120 µs - 16 µs = 104 µs. For the 1 µs antenna switching slot, the sample is taken every 2 µs (1 µs antenna switch slot, 1 µs sample slot). Meaning, the number of samples from the switch-sample period is 104 µs / 2 µs = 52.
+* Switch-sample period duration is: 120 µs - 12 µs = 108 µs. For the 1 µs antenna switching slot, the sample is taken every 2 µs (1 µs antenna switch slot, 1 µs sample slot). Meaning, the number of samples from the switch-sample period is 108 µs / 2 µs = 54.
 
-The total number of samples is 60.
+The total number of samples is 62.
 
 Building and running
 ********************

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -85,6 +85,10 @@ This also means that, for example, when using four GPIOs, the pattern count cann
 
 If the number of switch-sample periods is greater than the number of stored switching patterns, then the radio loops back to the first pattern.
 
+The length of the antenna switching pattern is limited by the :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` option.
+If the required length of the antenna switching pattern is greater than the default value of :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN`, set the :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` option to the required value in the board configuration file.
+For example, for the :ref:`nRF52833 DK <ug_nrf52>` add :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` =N, where N is the required antenna switching pattern length, to the :file:`nrf52833dk_nrf52833.conf` file.
+
 The following table presents the patterns that you can use to switch antennas on the Nordic-designed antenna matrix:
 
 +--------+--------------+

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -163,9 +163,9 @@ For example, the CTE length is 120 µs and the antenna switching slot is 1 µs.
 This will result in the following number of IQ samples:
 
 * 8 samples from the reference period.
-* Switch-sample period duration is: 120 µs - 16 µs = 104 µs. For the 1 µs antenna switching slot, the sample is taken every 2 µs (1 µs antenna switch slot, 1 µs sample slot). Meaning, the number of samples from the switch-sample period is 104 µs / 2 µs = 52.
+* Switch-sample period duration is: 120 µs - 12 µs = 108 µs. For the 1 µs antenna switching slot, the sample is taken every 2 µs (1 µs antenna switch slot, 1 µs sample slot). Meaning, the number of samples from the switch-sample period is 108 µs / 2 µs = 54.
 
-The total number of samples is 60.
+The total number of samples is 62.
 
 Building and running
 ********************

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -85,6 +85,10 @@ This also means that, for example, when using four GPIOs, the pattern count cann
 
 If the number of switch-sample periods is greater than the number of stored switching patterns, then the radio loops back to the first pattern.
 
+The length of the antenna switching pattern is limited by the :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` option.
+If the required length of the antenna switching pattern is greater than the default value of :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN`, set the :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` option to the required value in the board configuration file.
+For example, for the :ref:`nRF52833 DK <ug_nrf52>` add :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` =N, where N is the required antenna switching pattern length, to the :file:`nrf52833dk_nrf52833.conf` file.
+
 The following table presents the patterns that you can use to switch antennas on the Nordic-designed antenna matrix:
 
 +--------+--------------+

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -85,6 +85,10 @@ This also means that, for example, when using four GPIOs, the pattern count cann
 
 If the number of switch-sample periods is greater than the number of stored switching patterns, then the radio loops back to the first pattern.
 
+The length of the antenna switching pattern is limited by the :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` option.
+If the required length of the antenna switching pattern is greater than the default value of :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN`, set the :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` option to the required value in the board configuration file.
+For example, for the :ref:`nRF52833 DK <ug_nrf52>` add :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` =N, where N is the required antenna switching pattern length, to the :file:`nrf52833dk_nrf52833.conf` file.
+
 The following table presents the patterns that you can use to switch antennas on the Nordic-designed antenna matrix:
 
 +--------+--------------+

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -85,6 +85,10 @@ This also means that, for example, when using four GPIOs, the pattern count cann
 
 If the number of switch-sample periods is greater than the number of stored switching patterns, then the radio loops back to the first pattern.
 
+The length of the antenna switching pattern is limited by the :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` option.
+If the required length of the antenna switching pattern is greater than the default value of :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN`, set the :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` option to the required value in the board configuration file.
+For example, for the :ref:`nRF52833 DK <ug_nrf52>` add :kconfig:`CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN` =N, where N is the required antenna switching pattern length, to the :file:`nrf52833dk_nrf52833.conf` file.
+
 The following table presents the patterns that you can use to switch antennas on the Nordic-designed antenna matrix:
 
 +--------+--------------+


### PR DESCRIPTION
There is a maximum length of antenna switch pattern defined by
CONFIG_BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN. It limits number of
antenna ids that may be used by an application.

There were no information about it in direction finding samples
README.rst files.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>