### PR TITLE
net: lib: download_client: fixed segv on cancelling download

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -59,6 +59,8 @@ enum download_client_evt_id {
 	 * network socket as necessary before re-attempting the download.
 	 */
 	DOWNLOAD_CLIENT_EVT_ERROR,
+	/** Download cancelled. */
+	DOWNLOAD_CLIENT_EVT_CANCELLED,
 	/** Download complete. */
 	DOWNLOAD_CLIENT_EVT_DONE,
 };
@@ -245,11 +247,22 @@ int download_client_file_size_get(struct download_client *client, size_t *size);
 /**
  * @brief Disconnect from the server.
  *
+ * If a download is active, it must be cancelled before.
+ *
  * @param[in] client	Client instance.
  *
  * @return Zero on success, a negative error code otherwise.
  */
 int download_client_disconnect(struct download_client *client);
+
+/**
+ * @brief Cancel a running download
+ *
+* @param[in] client	Client instance.
+*
+* @return Zero on success, a negative error code otherwise.
+ */
+int download_client_cancel(struct download_client *client);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -328,6 +328,9 @@ static void fota_download_callback(const struct fota_download_evt *evt)
 
 	/* Following cases mark end of FOTA download */
 	case FOTA_DOWNLOAD_EVT_CANCELLED:
+		LOG_INF("FOTA_DOWNLOAD_EVT_CANCELLED");
+		lwm2m_firmware_set_update_state(STATE_IDLE);
+		break;
 	case FOTA_DOWNLOAD_EVT_ERROR:
 		LOG_ERR("FOTA_DOWNLOAD_EVT_ERROR");
 		lwm2m_firmware_set_update_state(STATE_IDLE);


### PR DESCRIPTION
Socket library seems not to be thread safe as closing a socket caused a
segv while receiving data. Therefore close the socket within the context
of the download thread by cancelling the download first within a cancel
event.

Signed-off-by: Andreas Chmielewski <andreas.chmielewski@grandcentrix.net>