### PR TITLE
net: lib: nrf_cloud: REST lib error handling minor improvements

### DIFF
--- a/doc/nrf/libraries/networking/nrf_cloud_rest.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_rest.rst
@@ -10,21 +10,83 @@ nRF Cloud REST
 The nRF Cloud REST library enables applications to use `nRF Cloud's REST-based device API <nRF Cloud REST API_>`_.
 This library is an enhancement to the :ref:`lib_nrf_cloud` library.
 
-To make a REST call, configure a :c:struct:`nrf_cloud_rest_context` structure with your desired parameters.
+Usage
+#####
 
-* ``auth`` - Use :ref:`lib_modem_jwt` to generate a JWT string. The ``sec_tag`` used for JWT generation must contain a credential that has been registered with nRF Cloud.
+This library exposes a number of functions that provide access to nRF Cloud REST API endpoints.
 
-Pass the REST context structure, along with any other required parameters, to the desired function.
-When the function returns, the context contains the status of the API call.
+When called, these functions initiate an HTTP request to the nRF Cloud REST backend.
+Various `nRF Cloud REST API endpoints <nRF Cloud REST API_>`_ are provided for tasks such as:
+
+* Updating a device's shadow.
+* Sending and receiving device messages.
+* Interacting with location services.
+
+All of these functions operate on a :c:struct:`nrf_cloud_rest_context` structure that you must initialize and provide with your desired parameters.
+When each function returns, the context contains the status of the API call.
+
+Authentication
+**************
+
+Each HTTP/REST request must include a valid JSON Web Token (JWT) that serves as a proof of identity.
+Usually, these tokens are generated based on the `device credentials <nRF Cloud Security_>`_, and must be passed to the ``auth`` parameter of the :c:struct:`nrf_cloud_rest_context` structure.
+To generate a token, call the :c:func:`nrf_cloud_jwt_generate` function, or use the :ref:`lib_modem_jwt` library.
+Alternatively, if you have enabled the :kconfig:`NRF_CLOUD_REST_AUTOGEN_JWT` option (along with its dependencies), the nRF Cloud REST library generates a JWT automatically if one is not provided.
+
+Socket management and reuse
+***************************
+
+The socket used for each HTTP request is determined by the ``connect_socket`` parameter of the :c:struct:`nrf_cloud_rest_context` structure.
+If a valid socket file descriptor is passed, this socket is used.
+If -1 is passed, a socket will be created automatically.
+
+The selected socket can be reused depending on the passed-in value of the ``keep_alive`` property of the :c:struct:`nrf_cloud_rest_context` structure:
+
+ * If you set ``keep_alive`` to false, then the selected socket is closed after each request, and the ``connect_socket`` property is reset to ``-1``.
+ * If you set ``keep_alive`` to true, the socket remains open and ``connect_socket`` remains unaltered, meaning the socket is reused on the next API call.
+
+However, if you set ``keep_alive`` to true, make sure that the socket has not been closed externally (for example, due to inactivity) before sending each request.
+Otherwise, the request will be dropped.
+
+There are two ways a timed out socket can manifest:
+
+* The socket may be closed immediately on timeout, causing ``-ENOTCONN`` to be returned by the next REST request function call, without reaching nRF Cloud.
+* The socket may be left open, allowing the next REST request to reach nRF Cloud, but the request is ignored and the socket is closed gracefully (FIN,ACK) with null HTTP response.
+  In this case, the called request function returns ``-ESHUTDOWN``.
+
+See :ref:`nrf_cloud_rest_failure` for more details.
+
+Request success
+***************
 If the API call is successful, the context also contains the response data and length.
 Some functions also have an optional ``result`` parameter.
 If this parameter is provided, the response data is parsed into ``result``.
 
-Response is handled in the following way:
+A number of functions automatically handle response data themselves:
 
 * :c:func:`nrf_cloud_rest_pgps_data_get` - Pass response data to the P-GPS library :ref:`lib_nrf_cloud_pgps`.
 * :c:func:`nrf_cloud_rest_agps_data_get` - Pass response data to the A-GPS library :ref:`lib_nrf_cloud_agps`.
-* :c:func:`nrf_cloud_rest_fota_job_get` - If a FOTA job exists, :ref:`lib_fota_download` can perform the firmware download and installation. Call the :c:func:`nrf_cloud_rest_fota_job_update` function to report the status of the job.
+* :c:func:`nrf_cloud_rest_fota_job_get` - If a FOTA job exists, :ref:`lib_fota_download` can perform the firmware download and installation.
+  Call the :c:func:`nrf_cloud_rest_fota_job_update` function to report the status of the job.
+
+.. _nrf_cloud_rest_failure:
+
+Request failure
+***************
+
+If an API call is unsuccessful, the called request function may return a variety of outputs:
+
+* If the error occurred at the socket level, the exact socket errno is returned.
+  For instance, ``-ENOTCONN`` if the socket was closed, or was never opened before the request was made.
+* If the remote endpoint closes the connection gracefully without giving a response (a null HTTP response), ``-ESHUTDOWN`` is returned.
+* If the remote endpoint responds with an unexpected HTTP status code (indicating request rejection), ``-EBADMSG`` is returned.
+  Possible causes include, but are not limited to: bad endpoint, invalid request data, invalid JWT.
+* If the response body is empty and the request expects response data, ``-ENODATA`` is returned.
+* If a heap allocation fails, ``-ENOMEM`` is returned.
+* Request formatting errors return ``-ETXTBSY``
+
+Some functions may have additional return values.
+These are documented on the function itself.
 
 Configuration
 *************

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -628,6 +628,8 @@
 .. _`nRF Cloud Location Services documentation`: https://docs.nrfcloud.com/Reference/LocationServices
 .. _`nRF Cloud MQTT API`: https://docs.nrfcloud.com/Reference/Interacting/MQTT
 
+.. _`nRF Cloud Security`: https://docs.nrfcloud.com/Reference/Devices/Security/
+
 .. _`nRF Cloud Getting Started FOTA documentation`: https://docs.nrfcloud.com/Guides/GettingStarted/FOTA/
 
 .. _`Nordic Semiconductor's IoT cloud platform`: https://www.nordicsemi.com/Products/Cloud-services

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -262,6 +262,8 @@ Libraries for networking
 
     * During the connection process, shadow data is sent to the application even if no "config" section is present.
     * The application can now send shadow updates earlier in the connection process.
+    * Centralized error handling.
+      Changes to error return values.
 
 * :ref:`lib_download_client` library:
 

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -175,6 +175,7 @@ struct nrf_cloud_rest_pgps_request {
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
+ *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
  */
 int nrf_cloud_rest_cell_pos_get(struct nrf_cloud_rest_context *const rest_ctx,
 	struct nrf_cloud_rest_cell_pos_request const *const request,
@@ -195,7 +196,14 @@ int nrf_cloud_rest_cell_pos_get(struct nrf_cloud_rest_context *const rest_ctx,
  *           size specified by rest_ctx->fragment_size, a positive value is
  *           returned, which indicates the size (in bytes) of the necessary
  *           result buffer.
- *           Otherwise, a (negative) error code is returned.
+ *           Otherwise, a (negative) error code is returned:
+ *           - -EINVAL will be returned, and an error message printed, if invalid parameters
+ *		are given.
+ *           - -ENOBUFS will be returned, and an error message printed, if there is not enough
+ *             buffer space to store retrieved AGPS data.
+ *           - See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for all
+ *             other possible error codes.
+ *
  */
 int nrf_cloud_rest_agps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
 	struct nrf_cloud_rest_agps_request const *const request,
@@ -212,6 +220,7 @@ int nrf_cloud_rest_agps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
+ *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
  */
 int nrf_cloud_rest_pgps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
 	struct nrf_cloud_rest_pgps_request const *const request);
@@ -231,6 +240,7 @@ int nrf_cloud_rest_pgps_data_get(struct nrf_cloud_rest_context *const rest_ctx,
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
+ *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
  */
 int nrf_cloud_rest_fota_job_get(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, struct nrf_cloud_fota_job_info *const job);
@@ -256,6 +266,7 @@ void nrf_cloud_rest_fota_job_free(struct nrf_cloud_fota_job_info *const job);
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
+ *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
  */
 int nrf_cloud_rest_fota_job_update(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const char *const job_id,
@@ -270,6 +281,7 @@ int nrf_cloud_rest_fota_job_update(struct nrf_cloud_rest_context *const rest_ctx
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
+ *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
  */
 int nrf_cloud_rest_shadow_state_update(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const char * const shadow_json);
@@ -282,18 +294,25 @@ int nrf_cloud_rest_shadow_state_update(struct nrf_cloud_rest_context *const rest
  * @param[in]     svc_inf Service info items to be updated in the shadow.
  *
  * @retval 0 If successful.
- *          Otherwise, a (negative) error code is returned.
+ *         Otherwise, a (negative) error code is returned.
+ *         See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
  */
 int nrf_cloud_rest_shadow_service_info_update(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const struct nrf_cloud_svc_info * const svc_inf);
 
 /**
  * @brief Closes the connection to the server.
+ *	  The socket pointed to by @p rest_ctx.connect_socket will be closed,
+ *	  and @p rest_ctx.connect_socket will be set to -1.
  *
  * @param[in,out] rest_ctx Context for communicating with nRF Cloud's REST API.
  *
  * @retval 0 If successful.
- *          Otherwise, a (negative) error code is returned.
+ *          Otherwise, a (negative) error code is returned:
+ *	    - -EINVAL, if valid context is not given.
+ *	    - -ENOTCONN, if socket was already closed, or never opened.
+ *	    - -EIO, for any kind of socket-level closure failure.
+ *
  */
 int nrf_cloud_rest_disconnect(struct nrf_cloud_rest_context *const rest_ctx);
 
@@ -308,7 +327,9 @@ int nrf_cloud_rest_disconnect(struct nrf_cloud_rest_context *const rest_ctx);
  *
  * @retval 0 If successful; wait 30s before associating device with nRF Cloud account.
  * @retval 1 Device is already provisioned.
- *         Otherwise, a (negative) error code is returned.
+ *         Otherwise, a (negative) error code is returned:
+ *         - Any underlying socket or HTTP response error will be returned directly.
+ *	   - -ENODEV will be returned if device JITP immediately rejected.
  */
 int nrf_cloud_rest_jitp(const sec_tag_t nrf_cloud_sec_tag);
 
@@ -324,6 +345,7 @@ int nrf_cloud_rest_jitp(const sec_tag_t nrf_cloud_sec_tag);
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
+ *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
  */
 int nrf_cloud_rest_send_device_message(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const char *const json_msg, const bool bulk,
@@ -340,6 +362,7 @@ int nrf_cloud_rest_send_device_message(struct nrf_cloud_rest_context *const rest
  *
  * @retval 0 If successful.
  *          Otherwise, a (negative) error code is returned.
+ *          See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
  */
 int nrf_cloud_rest_send_location(struct nrf_cloud_rest_context *const rest_ctx,
 	const char *const device_id, const char *const nmea_sentence, const int64_t ts_ms);


### PR DESCRIPTION
Centralize error handling for nRF Cloud REST API lib,

Add dedicated error code for empty response from REST endpoint

Update documentation to include specifics on failure handling

IRIS-4011
IRIS-3983

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>