### PR TITLE
samples: matter: fix initialization order

### DIFF
--- a/applications/matter_weather_station/src/app_task.h
+++ b/applications/matter_weather_station/src/app_task.h
@@ -20,7 +20,7 @@ struct k_timer;
 
 class AppTask {
 public:
-	int StartApp();
+	CHIP_ERROR StartApp();
 
 	void PostEvent(const AppEvent &aEvent);
 	void UpdateClustersState();
@@ -30,7 +30,8 @@ public:
 private:
 	friend AppTask &GetAppTask();
 
-	int Init();
+	CHIP_ERROR Init();
+
 	void OpenPairingWindow();
 	void DispatchEvent(AppEvent &event);
 	void UpdateTemperatureClusterState();

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -21,6 +21,9 @@
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <system/SystemError.h>
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
@@ -77,8 +80,35 @@ chip::OTARequestor sOTARequestor;
 
 AppTask AppTask::sAppTask;
 
-int AppTask::Init()
+CHIP_ERROR AppTask::Init()
 {
+	/* Initialize CHIP stack */
+	LOG_INF("Init CHIP stack");
+
+	CHIP_ERROR err = chip::Platform::MemoryInit();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Platform::MemoryInit() failed");
+		return err;
+	}
+
+	err = PlatformMgr().InitChipStack();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("PlatformMgr().InitChipStack() failed");
+		return err;
+	}
+
+	err = ThreadStackMgr().InitThreadStack();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("ThreadStackMgr().InitThreadStack() failed");
+		return err;
+	}
+
+	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
+		return err;
+	}
+
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
 	LEDWidget::SetStateUpdateCallback(LEDStateUpdateHandler);
@@ -95,10 +125,11 @@ int AppTask::Init()
 	int ret = dk_buttons_init(ButtonEventHandler);
 	if (ret) {
 		LOG_ERR("dk_buttons_init() failed");
-		return ret;
+		return chip::System::MapErrorZephyr(ret);
 	}
 
 #ifdef CONFIG_MCUMGR_SMP_BT
+	/* Initialize DFU over SMP */
 	GetDFUOverSMP().Init(RequestSMPAdvertisingStart);
 	GetDFUOverSMP().ConfirmNewImage();
 #endif
@@ -116,20 +147,13 @@ int AppTask::Init()
 
 	ret = LightingMgr().Init(PWM_DEVICE, PWM_CHANNEL, minLightLevel, maxLightLevel);
 	if (ret) {
-		return ret;
+		return chip::System::MapErrorZephyr(ret);
 	}
 
 	LightingMgr().SetCallbacks(ActionInitiated, ActionCompleted);
 
-	/* Init ZCL Data Model and start server */
-	chip::Server::GetInstance().Init();
-
-	/* Initialize device attestation config */
+	/* Initialize CHIP server */
 	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-	ConfigurationMgr().LogDeviceConfig();
-	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
-
-	PlatformMgr().AddEventHandler(AppTask::ChipEventHandler, 0);
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 	sOTAImageProcessor.SetOTADownloader(&sBDXDownloader);
@@ -139,18 +163,31 @@ int AppTask::Init()
 	chip::SetRequestorInstance(&sOTARequestor);
 #endif
 
+	ReturnErrorOnFailure(chip::Server::GetInstance().Init());
+	ConfigurationMgr().LogDeviceConfig();
+	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
+
+	/*
+	 * Add CHIP event handler and start CHIP thread.
+	 * Note that all the initialization code should happen prior to this point
+	 * to avoid data races between the main and the CHIP threads.
+	 */
+	PlatformMgr().AddEventHandler(ChipEventHandler, 0);
+
+	err = PlatformMgr().StartEventLoopTask();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
+		return err;
+	}
+
 	sLightBulbPublishService.Init();
-	return 0;
+
+	return CHIP_NO_ERROR;
 }
 
-int AppTask::StartApp()
+CHIP_ERROR AppTask::StartApp()
 {
-	int ret = Init();
-
-	if (ret) {
-		LOG_ERR("AppTask.Init() failed");
-		return ret;
-	}
+	ReturnErrorOnFailure(Init());
 
 	AppEvent event = {};
 
@@ -158,6 +195,8 @@ int AppTask::StartApp()
 		k_msgq_get(&sAppEventQueue, &event, K_FOREVER);
 		DispatchEvent(event);
 	}
+
+	return CHIP_NO_ERROR;
 }
 
 void AppTask::PostEvent(const AppEvent &aEvent)

--- a/samples/matter/light_bulb/src/app_task.h
+++ b/samples/matter/light_bulb/src/app_task.h
@@ -22,13 +22,13 @@ class AppTask {
 public:
 	static constexpr size_t APP_EVENT_QUEUE_SIZE = 10;
 
-	int StartApp();
+	CHIP_ERROR StartApp();
 
 	void PostEvent(const AppEvent &aEvent);
 	void UpdateClusterState();
 
 private:
-	int Init();
+	CHIP_ERROR Init();
 
 	void CancelFunctionTimer();
 	void StartFunctionTimer(uint32_t timeoutInMs);

--- a/samples/matter/light_bulb/src/main.cpp
+++ b/samples/matter/light_bulb/src/main.cpp
@@ -8,56 +8,12 @@
 
 #include <logging/log.h>
 
-#include <lib/support/CHIPMem.h>
-#include <platform/CHIPDeviceLayer.h>
-
 LOG_MODULE_REGISTER(app);
-
-using namespace ::chip::DeviceLayer;
 
 int main()
 {
-	int ret = 0;
-	CHIP_ERROR err = CHIP_NO_ERROR;
+	CHIP_ERROR err = GetAppTask().StartApp();
 
-	err = chip::Platform::MemoryInit();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Platform::MemoryInit() failed");
-		goto exit;
-	}
-
-	LOG_INF("Init CHIP stack");
-	err = PlatformMgr().InitChipStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().InitChipStack() failed");
-		goto exit;
-	}
-
-	LOG_INF("Starting CHIP task");
-	err = PlatformMgr().StartEventLoopTask();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
-		goto exit;
-	}
-
-	LOG_INF("Init Thread stack");
-	err = ThreadStackMgr().InitThreadStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadStackMgr().InitThreadStack() failed");
-		goto exit;
-	}
-
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
-		goto exit;
-	}
-
-	ret = GetAppTask().StartApp();
-	if (ret != 0) {
-		err = chip::System::MapErrorZephyr(ret);
-	}
-
-exit:
+	LOG_ERR("Exited with code %" CHIP_ERROR_FORMAT, err.Format());
 	return err == CHIP_NO_ERROR ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -20,13 +20,13 @@ struct k_timer;
 
 class AppTask {
 public:
-	int StartApp();
+	CHIP_ERROR StartApp();
 
 	void PostEvent(const AppEvent &aEvent);
 	void UpdateClusterState();
 
 private:
-	int Init();
+	CHIP_ERROR Init();
 
 	void CancelFunctionTimer();
 	void StartFunctionTimer(uint32_t timeoutInMs);

--- a/samples/matter/lock/src/main.cpp
+++ b/samples/matter/lock/src/main.cpp
@@ -8,60 +8,12 @@
 
 #include <logging/log.h>
 
-#include <lib/support/CHIPMem.h>
-#include <platform/CHIPDeviceLayer.h>
-
 LOG_MODULE_REGISTER(app);
-
-using namespace ::chip::DeviceLayer;
 
 int main()
 {
-	int ret = 0;
-	CHIP_ERROR err = CHIP_NO_ERROR;
+	CHIP_ERROR err = GetAppTask().StartApp();
 
-	err = chip::Platform::MemoryInit();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Platform::MemoryInit() failed");
-		goto exit;
-	}
-
-	LOG_INF("Init CHIP stack");
-	err = PlatformMgr().InitChipStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().InitChipStack() failed");
-		goto exit;
-	}
-
-	LOG_INF("Starting CHIP task");
-	err = PlatformMgr().StartEventLoopTask();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
-		goto exit;
-	}
-
-	LOG_INF("Init Thread stack");
-	err = ThreadStackMgr().InitThreadStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadStackMgr().InitThreadStack() failed");
-		goto exit;
-	}
-
-#ifdef CONFIG_OPENTHREAD_MTD_SED
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
-#else
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-#endif
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
-		goto exit;
-	}
-
-	ret = GetAppTask().StartApp();
-	if (ret != 0) {
-		err = chip::System::MapErrorZephyr(ret);
-	}
-
-exit:
+	LOG_ERR("Exited with code %" CHIP_ERROR_FORMAT, err.Format());
 	return err == CHIP_NO_ERROR ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -13,6 +13,9 @@
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <system/SystemError.h>
 
 #include <dk_buttons_and_leds.h>
 #include <logging/log.h>
@@ -43,8 +46,35 @@ k_timer sFunctionTimer;
 
 AppTask AppTask::sAppTask;
 
-int AppTask::Init()
+CHIP_ERROR AppTask::Init()
 {
+	/* Initialize CHIP stack */
+	LOG_INF("Init CHIP stack");
+
+	CHIP_ERROR err = chip::Platform::MemoryInit();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Platform::MemoryInit() failed");
+		return err;
+	}
+
+	err = PlatformMgr().InitChipStack();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("PlatformMgr().InitChipStack() failed");
+		return err;
+	}
+
+	err = ThreadStackMgr().InitThreadStack();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("ThreadStackMgr().InitThreadStack() failed");
+		return err;
+	}
+
+	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
+		return err;
+	}
+
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
 	LEDWidget::SetStateUpdateCallback(LEDStateUpdateHandler);
@@ -60,32 +90,38 @@ int AppTask::Init()
 	int ret = dk_buttons_init(ButtonEventHandler);
 	if (ret) {
 		LOG_ERR("dk_buttons_init() failed");
-		return ret;
+		return chip::System::MapErrorZephyr(ret);
 	}
 
 	/* Initialize function timer */
 	k_timer_init(&sFunctionTimer, &AppTask::TimerEventHandler, nullptr);
 	k_timer_user_data_set(&sFunctionTimer, this);
 
-	/* Init ZCL Data Model and start server */
-	chip::Server::GetInstance().Init();
-
-	/* Initialize device attestation config */
+	/* Initialize CHIP server */
 	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+	ReturnErrorOnFailure(chip::Server::GetInstance().Init());
 	ConfigurationMgr().LogDeviceConfig();
 	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
 
-	return 0;
+	/*
+	 * Add CHIP event handler and start CHIP thread.
+	 * Note that all the initialization code should happen prior to this point
+	 * to avoid data races between the main and the CHIP threads.
+	 */
+	PlatformMgr().AddEventHandler(ChipEventHandler, 0);
+
+	err = PlatformMgr().StartEventLoopTask();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
+		return err;
+	}
+
+	return CHIP_NO_ERROR;
 }
 
-int AppTask::StartApp()
+CHIP_ERROR AppTask::StartApp()
 {
-	int ret = Init();
-
-	if (ret) {
-		LOG_ERR("AppTask.Init() failed");
-		return ret;
-	}
+	ReturnErrorOnFailure(Init());
 
 	AppEvent event = {};
 
@@ -93,6 +129,8 @@ int AppTask::StartApp()
 		k_msgq_get(&sAppEventQueue, &event, K_FOREVER);
 		DispatchEvent(event);
 	}
+
+	return CHIP_NO_ERROR;
 }
 
 void AppTask::PostEvent(const AppEvent &event)

--- a/samples/matter/template/src/app_task.h
+++ b/samples/matter/template/src/app_task.h
@@ -15,12 +15,12 @@ struct k_timer;
 
 class AppTask {
 public:
-	int StartApp();
+	CHIP_ERROR StartApp();
 
 	void PostEvent(const AppEvent &aEvent);
 
 private:
-	int Init();
+	CHIP_ERROR Init();
 
 	void CancelFunctionTimer();
 	void StartFunctionTimer(uint32_t timeoutInMs);

--- a/samples/matter/template/src/main.cpp
+++ b/samples/matter/template/src/main.cpp
@@ -8,56 +8,12 @@
 
 #include <logging/log.h>
 
-#include <lib/support/CHIPMem.h>
-#include <platform/CHIPDeviceLayer.h>
-
 LOG_MODULE_REGISTER(app);
-
-using namespace ::chip::DeviceLayer;
 
 int main()
 {
-	int ret = 0;
-	CHIP_ERROR err = CHIP_NO_ERROR;
+	CHIP_ERROR err = GetAppTask().StartApp();
 
-	err = chip::Platform::MemoryInit();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("Platform::MemoryInit() failed");
-		goto exit;
-	}
-
-	LOG_INF("Init CHIP stack");
-	err = PlatformMgr().InitChipStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().InitChipStack() failed");
-		goto exit;
-	}
-
-	LOG_INF("Starting CHIP task");
-	err = PlatformMgr().StartEventLoopTask();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
-		goto exit;
-	}
-
-	LOG_INF("Init Thread stack");
-	err = ThreadStackMgr().InitThreadStack();
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ThreadStackMgr().InitThreadStack() failed");
-		goto exit;
-	}
-
-	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-	if (err != CHIP_NO_ERROR) {
-		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
-		goto exit;
-	}
-
-	ret = GetAppTask().StartApp();
-	if (ret != 0) {
-		err = chip::System::MapErrorZephyr(ret);
-	}
-
-exit:
+	LOG_ERR("Exited with code %" CHIP_ERROR_FORMAT, err.Format());
 	return err == CHIP_NO_ERROR ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
Make sure that all the initialization code happens prior to
the point in which the CHIP thread is started to guarantee
no data races can occur in that phase.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>