### PR TITLE
doc: fix broken links in Asset Tracker v2 documentation

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -207,7 +207,7 @@ Setting up the Asset Tracker cloud example
 
 To set up the application to work with a specific cloud example, see the following documentation:
 
-* nRF Cloud - `Creating an nRF Cloud account`_ and `Connecting your device to nRF Cloud`_.
+* nRF Cloud - :ref:`Connecting your device to nRF Cloud <nrf9160_gs_connecting_dk_to_cloud>`.
 * AWS IoT Core - `Getting started guide for nRF Asset Tracker for AWS`_
 * Azure IoT Hub - `Getting started guide for nRF Asset Tracker for Azure`_
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -341,12 +341,6 @@
 
 .. _`nRF9160 SiP revisions and variants`: https://infocenter.nordicsemi.com/topic/comp_matrix_nrf9160/COMP/nrf9160/nrf9160_ic_revision_overview.html
 
-.. _`Creating an nRF Cloud account`:
-.. _`Creating an nRF Connect for Cloud account`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/common/create_nrfcloud_account.html
-
-.. _`Connecting your device to nRF Cloud`:
-.. _`Connecting your device to nRF Connect for Cloud`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/connecting_nrf_cloud.html
-
 .. _`SWD Select`: https://infocenter.nordicsemi.com/topic/ug_thingy91/UG/thingy91/hw_description/programming_debugging_interface.html
 
 

--- a/doc/nrf/ug_nrf91_features.rst
+++ b/doc/nrf/ug_nrf91_features.rst
@@ -215,7 +215,7 @@ Currently, delta modem firmware FOTA files are available in nRF Cloud under :gui
 If you intend to obtain FOTA files from nRF Cloud, see the additional requirements in :ref:`lib_nrf_cloud_fota`.
 
 You can upload custom application binaries to nRF Cloud for application FOTA updates.
-After `Creating an nRF Cloud account`_, you can upload the files to your nRF Cloud account as a bundle after navigating to :guilabel:`Device Management` on the left and clicking :guilabel:`Firmware Updates`.
+After :ref:`nrf9160_gs_connecting_dk_to_cloud`, you can upload the files to your nRF Cloud account as a bundle after navigating to :guilabel:`Device Management` on the left and clicking :guilabel:`Firmware Updates`.
 
 FOTA upgrades using other cloud services
 ----------------------------------------


### PR DESCRIPTION
Links pointed to sections that were moved from the infocenter
to the nRF Connect SDK documentation. Replaced two old links
with one new link to a header one level higher.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>