### PR TITLE
manifest: pull sdk-trusted-firmware-m FICR NS copy fix

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -166,6 +166,11 @@ The change prompted some changes in the CMake for the module, notably:
 
 |no_changes_yet_note|
 
+Trusted Firmware-M
+==================
+
+* Fixed the NCSDK-14015 known issue that would cause crash during boot when the :kconfig:`CONFIG_RPMSG_SERVICE` Kconfig option was enabled on the nRF5340 SoC.
+
 Documentation
 =============
 

--- a/subsys/partition_manager/pm.yml.pcd
+++ b/subsys/partition_manager/pm.yml.pcd
@@ -3,6 +3,6 @@
 # This block of RAM is used for communicating Network Core firmware update
 # metadata
 pcd_sram:
-  placement: {before: [rpmsg_nrf53_sram, end]}
+  placement: {after: [start]}
   size: CONFIG_NRF_SPU_RAM_REGION_SIZE
   region: sram_primary

--- a/subsys/partition_manager/pm.yml.trustzone
+++ b/subsys/partition_manager/pm.yml.trustzone
@@ -4,9 +4,5 @@ sram_secure:
   region: sram_primary
 
 sram_nonsecure:
+  span: [sram_primary] /* Here, sram_primary refers to the (NS) app's RAM. */
   region: sram_primary
-  span:
-    - sram_primary /* Here, sram_primary refers to the (NS) app's RAM. */
-#ifdef CONFIG_BT_RPMSG_NRF53
-    - rpmsg_nrf53_sram
-#endif

--- a/subsys/partition_manager/pm.yml.trustzone
+++ b/subsys/partition_manager/pm.yml.trustzone
@@ -1,8 +1,11 @@
 # Create a span for the RAM to be configured as SECURE by the spm.
 sram_secure:
-  span: []
   region: sram_primary
+  span:
+    - pcd_sram
 
 sram_nonsecure:
-  span: [sram_primary] /* Here, sram_primary refers to the (NS) app's RAM. */
   region: sram_primary
+  span:
+    - sram_primary /* Here, sram_primary refers to the (NS) app's RAM. */
+    - rpmsg_nrf53_sram

--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v1.5.0-ncs1
+      revision: c6667fa3010e1ff44501aa94b4796a72346cbe77
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Pull sdk-trusted-firmware-m to include fix for missing
NRF_SKIP_FICR_NS_COPY_TO_RAM for nrf9160.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>