### PR TITLE
samples: nrf9160: https_client: Make sure recv_buf is NULL terminated

### DIFF
--- a/samples/nrf9160/https_client/src/main.c
+++ b/samples/nrf9160/https_client/src/main.c
@@ -224,6 +224,13 @@ void main(void)
 
 	printk("Received %d bytes\n", off);
 
+	/* Make sure recv_buf is NULL terminated (for safe use with strstr) */
+	if (off < sizeof(recv_buf)) {
+		recv_buf[off] = '\0';
+	} else {
+		recv_buf[sizeof(recv_buf) - 1] = '\0';
+	}
+
 	/* Print HTTP response */
 	p = strstr(recv_buf, "\r\n");
 	if (p) {


### PR DESCRIPTION
Ensure that recv_buf is NULL terminated before treating the content as a
C-string.

Detected by Coverity.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>