### PR TITLE
manifest: nrf_modem: version 1.5.2

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -293,6 +293,16 @@ void nrf_modem_os_trace_irq_clear(void)
 	NVIC_ClearPendingIRQ(TRACE_IRQ);
 }
 
+void nrf_modem_os_trace_irq_disable(void)
+{
+	irq_disable(TRACE_IRQ);
+}
+
+void nrf_modem_os_trace_irq_enable(void)
+{
+	irq_enable(TRACE_IRQ);
+}
+
 ISR_DIRECT_DECLARE(rpc_proxy_irq_handler)
 {
 	atomic_inc(&rpc_event_cnt);

--- a/west.yml
+++ b/west.yml
@@ -108,7 +108,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 43c662addc3e89f7fd36a9733f6a34b5ef16b928
+      revision: dc800f908e8c0e5ac2407f7dd4fcd19c64e1eb44
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update manifest for nrf_modem v1.5.2 release.

Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>
Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>
Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>
