### PR TITLE
Remove PCD partition

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -2010,6 +2010,14 @@ NCSDK-12483: Missing debug symbols
 
   **Workaround:** Add the following text in the application :file:`CMakeLists.txt` file: ``zephyr_link_libraries(-Wl,--undefined=my_missing_debug_symbol)``.
 
+.. rst-class:: v1-9-0
+
+NCSDK-14015: Execution halts during boot
+  When the :kconfig:`CONFIG_RPMSG_SERVICE` is enabled on the nRF5340 SoC together with TF-M, the firmware does not boot.
+  This option is used by OpenThread and Bluetooth modules.
+
+  **Workaround:** Place the ``rpmsg_nrf53_sram`` partition inside the ``sram_nonsecure`` partition using :ref:`partition_manager`.
+
 Zephyr
 ******
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -147,6 +147,11 @@ Unity
 
 |no_changes_yet_note|
 
+Trusted Firmware-M
+==================
+
+* Fixed an issue that would cause crash during boot when the :kconfig:`CONFIG_RPMSG_SERVICE` Kconfig option was enabled on the nRF5340 SoC.
+
 MCUboot
 =======
 

--- a/include/dfu/pcd.h
+++ b/include/dfu/pcd.h
@@ -40,11 +40,11 @@ extern "C" {
 
 #include <pm_config.h>
 
-#ifdef PM_PCD_SRAM_ADDRESS
-#define PCD_CMD_ADDRESS PM_PCD_SRAM_ADDRESS
+#ifdef PM_RPMSG_NRF53_SRAM_ADDRESS
+#define PCD_CMD_ADDRESS PM_RPMSG_NRF53_SRAM_ADDRESS
 #else
 /* extra '_' since its in a different domain */
-#define PCD_CMD_ADDRESS PM__PCD_SRAM_ADDRESS
+#define PCD_CMD_ADDRESS PM__RPMSG_NRF53_SRAM_ADDRESS
 #endif /* PM_PCD_SRAM_ADDRESS */
 
 #endif /* CONFIG_PCD_CMD_ADDRESS */

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -77,10 +77,6 @@ if (CONFIG_RPMSG_SERVICE AND CONFIG_SOC_NRF5340_CPUAPP)
   ncs_add_partition_manager_config(pm.yml.rpmsg_nrf53)
 endif()
 
-if (CONFIG_PCD_APP)
-  ncs_add_partition_manager_config(pm.yml.pcd)
-endif()
-
 if (CONFIG_BUILD_WITH_TFM)
   ncs_add_partition_manager_config(pm.yml.tfm)
 endif()

--- a/subsys/partition_manager/pm.yml.pcd
+++ b/subsys/partition_manager/pm.yml.pcd
@@ -1,8 +1,0 @@
-#include <autoconf.h>
-
-# This block of RAM is used for communicating Network Core firmware update
-# metadata
-pcd_sram:
-  placement: {before: [rpmsg_nrf53_sram, end]}
-  size: CONFIG_NRF_SPU_RAM_REGION_SIZE
-  region: sram_primary

--- a/subsys/partition_manager/pm.yml.trustzone
+++ b/subsys/partition_manager/pm.yml.trustzone
@@ -7,6 +7,4 @@ sram_nonsecure:
   region: sram_primary
   span:
     - sram_primary /* Here, sram_primary refers to the (NS) app's RAM. */
-#ifdef CONFIG_BT_RPMSG_NRF53
     - rpmsg_nrf53_sram
-#endif

--- a/subsys/pcd/src/pcd.c
+++ b/subsys/pcd/src/pcd.c
@@ -190,10 +190,7 @@ int pcd_network_core_update(const void *src_addr, size_t len)
 
 void pcd_lock_ram(void)
 {
-	uint32_t region = PCD_CMD_ADDRESS/CONFIG_NRF_SPU_RAM_REGION_SIZE;
-
-	nrf_spu_ramregion_set(NRF_SPU, region, false, NRF_SPU_MEM_PERM_READ,
-			true);
+	/* TODO: Remove refrence to locking in MCUBoot to remove this function */
 }
 
 #endif /* CONFIG_PCD_APP */


### PR DESCRIPTION
See commit message for some rationality.

@hakonfam : If PCD area can be written by an app, then any firmware can be installed to the network core without any firmware verification. Hence PCD must be write-locked before the app is booted.

@hakonfam: If PCD is not locked before the app is booted, then the app can write any update instructions it wants to the pcd area. These instructions are followed blindly by the network core bootloader.

> While this is the case the network-core will be non-secure hence only compromising non-secure. However a full application core reboot may set the network core to be secure. The default is non-secure on reboot, removing the write-locking will increase the attack surface on non-secure.