### PR TITLE
lib: fota_download: Ensure file string is properly terminated

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -333,7 +333,8 @@ int fota_download_start_with_image_type(const char *host, const char *file,
 
 	socket_retries_left = CONFIG_FOTA_SOCKET_RETRIES;
 
-	strncpy(file_buf, file, sizeof(file_buf));
+	strncpy(file_buf, file, sizeof(file_buf) - 1);
+	file_buf[sizeof(file_buf) - 1] = '\0';
 
 #ifdef PM_S1_ADDRESS
 	/* B1 upgrade is supported, check what B1 slot is active,


### PR DESCRIPTION
strncpy() does not guarantee that the resulting string is NULL
terminated - fix this by saving the last byte and writing NULL in there,
so that even if strncpy reaches the maximum size the buffer is still
NULL terminated.

Reported by coverity

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>