### PR TITLE
samples: Direct Test mode, Radio Test add test case for nrf5340 with nrf21540ek

### DIFF
--- a/samples/bluetooth/direct_test_mode/sample.yaml
+++ b/samples/bluetooth/direct_test_mode/sample.yaml
@@ -9,3 +9,10 @@ tests:
       - nrf5340dk_nrf5340_cpunet
       - nrf21540dk_nrf52840
     tags: bluetooth ci_build
+  samples.bluetooth.direct_test_mode.nrf5340_nrf21540:
+    build_only: true
+    platform_allow: nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+    extra_args: SHIELD=nrf21540_ek
+    tags: bluetooth ci_build

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -10,3 +10,10 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpunet
     tags: ci_build
+  samples.peripheral.radio_test.nrf5340_nrf21540:
+    build_only: true
+    platform_allow: nrf5340dk_nrf5340_cpunet
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+    extra_args: SHIELD=nrf21540_ek
+    tags: ci_build


### PR DESCRIPTION
Adds a test case for the Direct Test Mode sample and the Radio Test sample for the nrf5340 network core target with nr21540ek shield