### PR TITLE
partition_manager: pcd: Fix pcd_sram placement for samples

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -2015,6 +2015,14 @@ NCSDK-12483: Missing debug symbols
 
   **Workaround:** Add the following text in the application :file:`CMakeLists.txt` file: ``zephyr_link_libraries(-Wl,--undefined=my_missing_debug_symbol)``.
 
+.. rst-class:: v1-9-0
+
+NCSDK-14015: Execution halts during boot
+  When the :kconfig:`CONFIG_RPMSG_SERVICE` is enabled on the nRF5340 SoC together with TF-M, the firmware does not boot.
+  This option is used by OpenThread and Bluetooth modules.
+
+  **Workaround:** Place the ``rpmsg_nrf53_sram`` partition inside the ``sram_nonsecure`` partition using :ref:`partition_manager`.
+
 Zephyr
 ******
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -229,6 +229,11 @@ The change prompted some changes in the CMake for the module, notably:
 
 |no_changes_yet_note|
 
+Trusted Firmware-M
+==================
+
+* Fixed the NCSDK-14015 known issue that would cause crash during boot when the :kconfig:`CONFIG_RPMSG_SERVICE` Kconfig option was enabled on the nRF5340 SoC.
+
 Documentation
 =============
 

--- a/subsys/partition_manager/pm.yml.pcd
+++ b/subsys/partition_manager/pm.yml.pcd
@@ -3,6 +3,6 @@
 # This block of RAM is used for communicating Network Core firmware update
 # metadata
 pcd_sram:
-  placement: {before: [rpmsg_nrf53_sram, end]}
+  placement: {after: [start]}
   size: CONFIG_NRF_SPU_RAM_REGION_SIZE
   region: sram_primary

--- a/subsys/partition_manager/pm.yml.trustzone
+++ b/subsys/partition_manager/pm.yml.trustzone
@@ -4,9 +4,5 @@ sram_secure:
   region: sram_primary
 
 sram_nonsecure:
+  span: [sram_primary] /* Here, sram_primary refers to the (NS) app's RAM. */
   region: sram_primary
-  span:
-    - sram_primary /* Here, sram_primary refers to the (NS) app's RAM. */
-#ifdef CONFIG_BT_RPMSG_NRF53
-    - rpmsg_nrf53_sram
-#endif

--- a/subsys/partition_manager/pm.yml.trustzone
+++ b/subsys/partition_manager/pm.yml.trustzone
@@ -1,8 +1,11 @@
 # Create a span for the RAM to be configured as SECURE by the spm.
 sram_secure:
-  span: []
   region: sram_primary
+  span:
+    - pcd_sram
 
 sram_nonsecure:
-  span: [sram_primary] /* Here, sram_primary refers to the (NS) app's RAM. */
   region: sram_primary
+  span:
+    - sram_primary /* Here, sram_primary refers to the (NS) app's RAM. */
+    - rpmsg_nrf53_sram


### PR DESCRIPTION
Both https://github.com/nrfconnect/sdk-nrf/pull/6137 and https://github.com/nrfconnect/sdk-nrf/pull/6861 failed to work for all use cases.

This patch ensures that `pcd_sram` is placed in the secure partition
when Trustzone is used. If it not `pcd_sram` is placed at the end of
RAM.  If Trustzone is used `pcd_sram` is placed at the end of the secure
RAM partition.

In the case of nRF5340, Bluetooth subystem creates
rpmsg_nrf53_sram partition in SRAM for the HCI transport
between the two cores. If the partition is present,
sram_primary and sram_nonsecure partitions are reduced and
the rpmsg_nrf53_sram is not accessible from the non-secure
firmware - an application built with CONFIG_BT=y causes
the secure fault.

Make sram_nonsecure partition, which defines the non-secure
SRAM, span rpmsg_nrf53_sram as well

Ref. KRKNWK-12196
Ref. NCSDK-13647
Ref. NCSDK-14015