### PR TITLE
applications: asset_tracker_v2: Grant/deny send based on energy estimate

### DIFF
--- a/applications/asset_tracker_v2/doc/data_module.rst
+++ b/applications/asset_tracker_v2/doc/data_module.rst
@@ -43,6 +43,24 @@ These value are persisted in flash between reboots using the :ref:`settings_api`
 If a new configuration update is received from the cloud, the data module distributes the new configuration values using the :c:enum:`DATA_EVT_CONFIG_READY` event.
 You can alter the default values of the :ref:`Real-time configurations <real_time_configs>` compile time using the options listed in the :ref:`Default device configuration options <default_config_values>`.
 
+Connection evaluation
+=====================
+
+This is an experimental feature.
+The module can decide to hold off encoding and sending of sampled data based on evaluation of the LTE connection and estimated energy consumed to send the data.
+This feature is enabled by setting the :ref:`CONFIG_DATA_GRANT_SEND_ON_CONNECTION_QUALITY <CONFIG_DATA_GRANT_SEND_ON_CONNECTION_QUALITY>` Kconfig option.
+The module can deny the sending of data a number of times before it is sent regardless.
+This limit is configurable and set by the :ref:`CONFIG_DATA_SEND_ATTEMPTS_COUNT_MAX <CONFIG_DATA_SEND_ATTEMPTS_COUNT_MAX>` Kconfig option.
+This feature is supported for regular updates that include neighbor cell measurements, generic (GNSS, sensor data, and so on), and historical batched data, which are scheduled based on the application's :ref:`Real-time configurations <real_time_configs>`.
+
+To adjust the minimum allowed energy threshold for a specific type, set the following Kconfig options:
+
+* :ref:`CONFIG_DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_MIN <CONFIG_DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_MIN>`
+* :ref:`CONFIG_DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_MIN <CONFIG_DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_MIN>`
+* :ref:`CONFIG_DATA_BATCH_UPDATES_ENERGY_THRESHOLD_MIN <CONFIG_DATA_BATCH_UPDATES_ENERGY_THRESHOLD_MIN>`
+
+The energy levels map directly to the :ref:`lte_lc_readme` structure :c:struct:`lte_lc_energy_estimate` and the current energy level that is evaluated before sending of data is retrieved with the :c:func:`lte_lc_conn_eval_params_get` function call.
+
 .. _default_config_values:
 
 Configuration options
@@ -77,6 +95,31 @@ CONFIG_DATA_ACCELEROMETER_THRESHOLD
 
 CONFIG_DATA_GNSS_TIMEOUT_SECONDS
    This configuration sets the GNSS timeout value.
+
+.. _CONFIG_DATA_GRANT_SEND_ON_CONNECTION_QUALITY:
+
+CONFIG_DATA_GRANT_SEND_ON_CONNECTION_QUALITY
+   Grants or denies encoding and sending of data based on LTE connection quality.
+
+.. _CONFIG_DATA_SEND_ATTEMPTS_COUNT_MAX:
+
+CONFIG_DATA_SEND_ATTEMPTS_COUNT_MAX
+   Maximum number of times sending can be denied due to connection quality before the data is sent regardless.
+
+.. _CONFIG_DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_MIN:
+
+CONFIG_DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_MIN
+   Minimum energy threshold for generic updates.
+
+.. _CONFIG_DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_MIN:
+
+CONFIG_DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_MIN
+   Minimum energy threshold for neighbor cell updates.
+
+.. _CONFIG_DATA_BATCH_UPDATES_ENERGY_THRESHOLD_MIN:
+
+CONFIG_DATA_BATCH_UPDATES_ENERGY_THRESHOLD_MIN
+   Minimum energy threshold for batch updates.
 
 Module states
 *************

--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -148,6 +148,107 @@ config DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT
 	  data in sample requests sent to other modules. This configuration can be overwritten by
 	  changing the application's real-time configuration using the cloud-side state.
 
+config DATA_GRANT_SEND_ON_CONNECTION_QUALITY
+	bool "Grant or deny encoding and sending of data based on LTE connection quality"
+	select EXPERIMENTAL
+	help
+	  If this option is enabled the module will hold off encoding and sending of data based
+	  on an evaluation of the current LTE connection and estimated energy
+	  consumed to send the data. This feature is individually supported for
+	  neighbor cell measurements, regular updates, and batch updates to cloud.
+	  The maximum number of times that a update can be held back is determined
+	  by the CONFIG_DATA_SEND_ATTEMPTS_COUNT_MAX option.
+
+if DATA_GRANT_SEND_ON_CONNECTION_QUALITY
+
+choice DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_MIN
+	prompt "Neighbor cell updates minimum energy threshold"
+	default DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_NORMAL
+	help
+	  Minimum energy threshold that neighbor cell measurement updates will be encoded and sent.
+	  These choices maps directly to the lte_lc_energy_estimate structure defined in
+	  lte_lc.h.
+
+config DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_EXCESSIVE
+	bool "Neighbor cell updates threshold exessive"
+
+config DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_INCREASED
+	bool "Neighbor cell updates threshold increased"
+
+config DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_NORMAL
+	bool "Neighbor cell updates threshold normal"
+
+config DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_REDUCED
+	bool "Neighbor cell updates threshold reduced"
+
+config DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_EFFICIENT
+	bool "Neighbor cell updates threshold efficient"
+
+endchoice # DATA_NEIGHBOR_CELL_UPDATES_ENERGY_THRESHOLD_MIN
+
+choice DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_MIN
+	prompt "Generic updates minimum energy threshold"
+	default DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_NORMAL
+	help
+	  Minimum energy threshold that generic updates will be encoded and sent.
+	  These choices maps directly to the lte_lc_energy_estimate structure defined in
+	  lte_lc.h.
+
+config DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_EXCESSIVE
+	bool "Generic updates threshold exessive"
+
+config DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_INCREASED
+	bool "Generic updates threshold increased"
+
+config DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_NORMAL
+	bool "Generic updates threshold normal"
+
+config DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_REDUCED
+	bool "Generic updates threshold reduced"
+
+config DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_EFFICIENT
+	bool "Generic updates threshold efficient"
+
+endchoice # DATA_GENERIC_UPDATES_ENERGY_THRESHOLD_MIN
+
+choice DATA_BATCH_UPDATES_ENERGY_THRESHOLD_MIN
+	prompt "Batch updates minimum energy threshold"
+	default DATA_BATCH_UPDATES_ENERGY_THRESHOLD_NORMAL if NRF_CLOUD_MQTT
+	default DATA_BATCH_UPDATES_ENERGY_THRESHOLD_REDUCED
+	help
+	  Minimum energy threshold that batch updates will be encoded and sent.
+	  These choices maps directly to the lte_lc_energy_estimate structure defined in
+	  lte_lc.h.
+	  The nRF Cloud integration uses batch data exclusively for regular data updates.
+	  Due to this we lower the energy estimate requirement for batch data if configured for
+	  nRF Cloud.
+
+config DATA_BATCH_UPDATES_ENERGY_THRESHOLD_EXCESSIVE
+	bool "Batch updates threshold exessive"
+
+config DATA_BATCH_UPDATES_ENERGY_THRESHOLD_INCREASED
+	bool "Batch updates threshold increased"
+
+config DATA_BATCH_UPDATES_ENERGY_THRESHOLD_NORMAL
+	bool "Batch updates threshold normal"
+
+config DATA_BATCH_UPDATES_ENERGY_THRESHOLD_REDUCED
+	bool "Batch updates threshold reduced"
+
+config DATA_BATCH_UPDATES_ENERGY_THRESHOLD_EFFICIENT
+	bool "Batch updates threshold efficient"
+
+endchoice # DATA_BATCH_UPDATES_ENERGY_THRESHOLD_MIN
+
+config DATA_SEND_ATTEMPTS_COUNT_MAX
+	int "Maximum number of denied send attempts"
+	default 3
+	help
+	  Maximum number of times sending can be denied due to connection
+	  quality before the data is sent regardless.
+
+endif # DATA_GRANT_SEND_ON_CONNECTION_QUALITY
+
 endif # DATA_MODULE
 
 module = DATA_MODULE

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -298,6 +298,7 @@
 .. _`Packet Domain AT commands`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/packet_domain/packet_domain.html?cp=2_1_6
 .. _`AT+CNEC set command`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mobile_termination_errors/cnec_set.html
 .. _`AT+CGEREP set command`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/packet_domain/cgerep_set.html
+.. _`AT%CONEVAL`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/coneval.html
 
 .. _`Getting started with nRF Connect SDK (nRF53 Series)`: https://infocenter.nordicsemi.com/topic/ug_gsg_ncs/UG/gsg/intro.html
 .. _`Debugging nRF5340 with SES`: https://infocenter.nordicsemi.com/topic/ug_gsg_ncs/UG/gsg/debug.html?cp=1_1_0_7

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -113,6 +113,7 @@ nRF9160: Asset Tracker v2
   * Support for :ref:`QoS` library to handle multiple in-flight messages for MQTT based cloud backends such as AWS IoT, Azure IoT Hub, and nRF Cloud.
   * Documentation for Asset tracker v2 :ref:`asset_tracker_unit_test`.
   * Support for Lightweight Machine to Machine (LwM2M).
+  * Support for filtering updates to cloud based on LTE connection evaluation (`AT%CONEVAL`_).
 
 * Updated:
 


### PR DESCRIPTION
Grant/deny send based on energy estimate retrieved from the
Link controller API `lte_lc_conn_eval_params_get` that calls
`AT%CONEVAL` AT command.

Rebased on top of https://github.com/nrfconnect/sdk-nrf/pull/7458

Fixes CIA-218

**edit**
This feature is initially added as experimental and by default off.
To review this only commit https://github.com/nrfconnect/sdk-nrf/commit/2ea0789870d488c85464f2fa11e138a315f05f04 should be considered.