### PR TITLE
doc: update some sample docs to use VT100/ANSI supported serial terminal.

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -25,6 +25,17 @@
 .. |connect_terminal_both| replace:: Connect to both kits with a terminal emulator (for example, PuTTY).
    See :ref:`putty` for the required settings.
 
+.. |connect_terminal_ANSI| replace:: Connect to the kit with a terminal emulator that supports VT100/ANSI escape characters (for example, PuTTY).
+   See :ref:`putty` for the required settings.
+
+.. |connect_terminal_specific_ANSI| replace:: Connect to the kit that runs this sample with a terminal emulator that supports VT100/ANSI escape characters (for example, PuTTY).
+   See :ref:`putty` for the required settings.
+
+.. |connect_terminal_both_ANSI| replace:: Connect to both kits with a terminal emulator that supports VT100/ANSI escape characters (for example, PuTTY).
+   See :ref:`putty` for the required settings.
+
+.. |ANSI| replace:: that supports VT100/ANSI escape characters
+
 .. |nRF5340DKnoref| replace:: nRF5340 DK board (PCA10095)
 
 .. |nRF9160DK| replace:: nRF9160 DK board (PCA10090) - see :ref:`ug_nrf9160`

--- a/samples/bluetooth/mesh/chat/sample_description.rst
+++ b/samples/bluetooth/mesh/chat/sample_description.rst
@@ -145,7 +145,7 @@ Interacting with the sample
 
 1. Connect the development kit to the computer using a USB cable.
    The development kit is assigned a COM port (Windows), ttyACM device (Linux) or tty.usbmodem (MacOS).
-#. |connect_terminal_specific|
+#. |connect_terminal_specific_ANSI|
 #. Enable local echo in the terminal to see the text you are typing.
 
 After completing the steps above, a command can be sent to the sample.

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -23,7 +23,7 @@ You can use any two of the development kits listed above and mix different devel
 
 .. include:: /includes/hci_rpmsg_overlay.txt
 
-The sample also requires a connection to a computer with a serial terminal for each of the development kits.
+The sample also requires a connection to a computer with a serial terminal |ANSI| for each of the development kits.
 
 Overview
 ********
@@ -111,8 +111,7 @@ Testing
 
 After programming the sample to both kits, complete following steps to test it:
 
-1. Connect to both kits with a terminal emulator (for example, PuTTY).
-   See :ref:`putty` for the required settings.
+1. |connect_terminal_both_ANSI|
 #. Reset both kits.
 #. Press **Button 1** on the kit to set the kit into master (tester) role.
 #. Press **Button 2** on the other kit to set the kit into slave (peer) mode.

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -147,7 +147,7 @@ Testing basic features
 After building the sample and programming it to your development kit, complete the following steps to test its basic features:
 
 #. |connect_kit|
-#. |connect_terminal|
+#. |connect_terminal_ANSI|
 #. Observe that **LED 2** is off.
 #. Press **Button 2** on the light bulb device.
    The **LED 2** turns on and the following messages appear on the console:

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -107,7 +107,7 @@ After building this and :ref:`Matter light bulb <matter_light_bulb_sample>` samp
 #. Complete the following actions for both devices:
 
    a. |connect_kit|
-   #. |connect_terminal|
+   #. |connect_terminal_ANSI|
 
 #. On both devices, press **Button 1** to reset them to factory settings.
 #. Pair both devices by completing the following steps:

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -220,7 +220,7 @@ Testing
 After building the sample and programming it to your development kit, complete the following steps to test its basic features:
 
 #. |connect_kit|
-#. |connect_terminal|
+#. |connect_terminal_ANSI|
 #. Observe that **LED 2** is lit, which means that the door lock is closed.
 #. Press **Button 2** to unlock the door.
    **LED 2** is blinking while the lock is opening.

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -110,7 +110,7 @@ To test the sample in a Matter-enabled Thread network, complete the following st
 .. matter_template_sample_testing_start
 
 1. |connect_kit|
-#. |connect_terminal|
+#. |connect_terminal_ANSI|
 #. Commission the device into a Thread network by following the guides linked on the :ref:`ug_matter_configuring` page for the Matter controller you want to use.
    The guides walk you through the following steps:
 

--- a/samples/nrf9160/download/README.rst
+++ b/samples/nrf9160/download/README.rst
@@ -107,7 +107,7 @@ Testing
 After programming the sample to your development kit, test it by performing the following steps:
 
 1. Connect the development kit to your PC using a USB cable and power on or reset the kit.
-#. Open a terminal emulator and observe that the sample starts, provisions certificates, and starts to download.
+#. Open a terminal emulator |ANSI| and observe that the sample starts, provisions certificates, and starts to download.
 #. Observe that the progress bar fills up as the download progresses.
 #. Observe that the sample displays the message "Download completed" on the terminal when the download completes.
 

--- a/samples/nrf9160/memfault/README.rst
+++ b/samples/nrf9160/memfault/README.rst
@@ -156,7 +156,7 @@ Testing
 Before testing, ensure that your device is configured with the project key of your Memfault project.
 |test_sample|
 
-1. |connect_terminal|
+1. |connect_terminal_ANSI|
 #. Observe that the sample starts.
    Following is a sample output on the terminal:
 

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -643,7 +643,7 @@ After programming the application and all prerequisites to your development kit,
 1. Connect the development kit to the computer using a USB cable.
    The development kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 
-#. Create a serial connection to the development kit (J-Link COM port) with a terminal using the following settings:
+#. Create a serial connection to the development kit (J-Link COM port) with a terminal |ANSI| using the following settings:
 
    * Hardware flow control: disabled
    * Baud rate: 115200
@@ -696,7 +696,7 @@ After programming the development kit, test it in the Linux environment by perfo
 1. Connect the development kit to the computer using a USB cable.
    The development kit is assigned a ttyACM device (Linux).
 
-#. Open a serial connection to the development kit (/dev/ttyACM2) with a terminal (for example PuTTY).
+#. Open a serial connection to the development kit (/dev/ttyACM2) with a terminal |ANSI| (for example PuTTY).
 
 #. Reset the development kit.
 

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -141,8 +141,7 @@ Testing
 After building the sample and programming it to your development kit, complete the following steps to test it:
 
 #. Turn on the development kit.
-#. Set up the serial connection with the development kit.
-   For more details, see :ref:`putty`.
+#. |connect_terminal_ANSI|
 
    .. note::
         |thread_hwfc_enabled|
@@ -197,8 +196,7 @@ To test communication between kits, complete the following steps:
 
 #. Make sure both development kits are programmed with the CLI sample.
 #. Turn on the developments kits.
-#. Set up the serial connection with both development kits.
-   For more details, see :ref:`putty`.
+#. |connect_terminal_both_ANSI|
 
    .. note::
         |thread_hwfc_enabled|
@@ -226,8 +224,7 @@ To test diagnostic commands, complete the following steps:
 
 #. Make sure both development kits are programmed with the CLI sample.
 #. Turn on the developments kits.
-#. Set up the serial connection with both development kits.
-   For more details, see :ref:`putty`.
+#. |connect_terminal_both_ANSI|
 
    .. note::
         |thread_hwfc_enabled|.
@@ -280,8 +277,7 @@ To test the Thread 1.2 features, complete the following steps:
 
 #. Make sure both development kits are programmed with the CLI sample with the :ref:`ot_cli_sample_thread_v12` enabled.
 #. Turn on the developments kits.
-#. Set up the serial connection with both development kits.
-   For more details, see :ref:`putty`.
+#. |connect_terminal_both_ANSI|
 #. .. include:: /includes/thread_configure_network.txt
 #. .. include:: /includes/thread_enable_network.txt
 #. Test the state of the Thread network with the ``ot state`` command to see which kit is the leader:

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -318,7 +318,7 @@ Device Firmware Upgrade using mcumgr
 Sample output
 =============
 
-You can observe the sample logging output through a serial port.
+You can observe the sample logging output with a terminal emulator |ANSI|.
 For more details, see :ref:`putty`.
 
 Dependencies

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -97,7 +97,7 @@ After building the sample and programming it to your development kit, complete t
 Running OpenThread CLI commands
 -------------------------------
 
-You can connect to any of the Simple CoAP Server or Simple CoAP Client nodes through a serial port.
+You can connect to any of the Simple CoAP Server or Simple CoAP Client nodes with a terminal emulator |ANSI|.
 For more details, see :ref:`putty`.
 
 Once the serial connection is ready, you can run OpenThread CLI commands.

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -162,7 +162,7 @@ Testing with another development kit
 
 1. Connect both development kits to the computer using a USB cable.
    The kits are assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
-#. |connect_terminal_both|
+#. |connect_terminal_both_ANSI|
 #. Run the following commands on one of the kits:
 
    a. Set the data rate with the ``data_rate`` command to ``ble_2Mbit``.
@@ -182,7 +182,7 @@ Testing with RSSI Viewer
 
 1. Connect the kit to the computer using a USB cable.
    The kit is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
-#. |connect_terminal|
+#. |connect_terminal_ANSI|
 #. Set the start channel with the ``start_channel`` command to 20.
 #. Set the end channel with the ``end_channel`` command to 60.
 #. Set the time on channel with the ``time_on_channel`` command to 50 ms.


### PR DESCRIPTION
As per NCSDK-14045 task, we have added instruction to use
serial terminal that supports VT100/ANSI characters in the following
samples as the shell used in these samples uses these special characters:

../../samples/bluetooth/mesh/chat/sample_description.rst
../../samples/bluetooth/throughput/README.rst
../../samples/matter/light_bulb/README.rst
../../samples/matter/light_switch/README.rst
../../samples/matter/lock/README.rst
../../samples/matter/template/README.rst
../../samples/nrf9160/download/README.rst
../../samples/nrf9160/memfault/README.rst
../../samples/nrf9160/modem_shell/README.rst
../../samples/openthread/cli/README.rst
../../samples/openthread/coap_client/README.rst
../../samples/openthread/coap_server/README.rst
../../samples/peripheral/radio_test/README.rst

Please refer to the Jira ticket NCSDK-14045 for more information.

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>