### PR TITLE
net: lib: skip duplicate packets

### DIFF
--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -494,6 +494,10 @@ restart_and_suspend:
 			}
 		} else if (IS_ENABLED(CONFIG_COAP)) {
 			rc = coap_parse(client, len);
+			if (rc == 1) {
+				/* Duplicate packet received */
+				continue;
+			}
 		}
 
 		if (rc < 0) {


### PR DESCRIPTION
Duplicate packets are not handled/skipped that results in a continuous
write of the fota package to dfu.

The reason for this is that if recv fails due to a bad connection
(timeout etc), always the current block is requested. Once the connection
is back it is likely that all the requested blocks are received.

Signed-off-by: Andreas Chmielewski <andreas.chmielewski@grandcentrix.net>