### PR TITLE
bluetooth: GATT DM discover many service instances by UUID

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -270,6 +270,7 @@ Bluetooth libraries and services
 * :ref:`gatt_dm_readme` library:
 
   * Fixed discovery of empty services.
+  * Added option to discover several service instances using the UUID.
 
 * :ref:`bt_mesh` library:
 

--- a/include/bluetooth/gatt_dm.h
+++ b/include/bluetooth/gatt_dm.h
@@ -38,7 +38,7 @@ struct bt_gatt_dm_attr {
 	/** Attribute UUID */
 	struct bt_uuid	*uuid;
 	/** Attribute handle */
-	uint16_t		handle;
+	uint16_t	handle;
 	/** Attribute permissions */
 	uint8_t		perm;
 };
@@ -268,16 +268,25 @@ const struct bt_gatt_dm_attr *bt_gatt_dm_desc_next(
  * another one, wait for the result of the previous procedure to finish
  * and call @ref bt_gatt_dm_data_release if it was successful.
  *
+ * If the service UUID is set when you start service discovery using the
+ * @ref bt_gatt_dm_start function. If there are more instances of the same service
+ * on the GATT server, it discovers the next instance. Use this function to discover
+ * all service instances with the given UUID.
+ *
  * @param[in]     conn Connection object.
  * @param[in]     svc_uuid UUID of target service
  *                or NULL if any service should be discovered.
  * @param[in]     cb Callback structure.
-  * @param[in,out] context Context argument to be passed to
-  *                callback functions.
+ * @param[in,out] context Context argument to be passed to
+ *                callback functions.
  *
  * @note
  * If @p svc_uuid is set to NULL, all services may be discovered.
  * To process the next service, call @ref bt_gatt_dm_continue.
+ *
+ * If @p svc_uuid is set to the service UUID, all
+ * service instances may be discovered.
+ * To discover next service instance if it exist, call @ref bt_gatt_dm_continue.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.

--- a/include/bluetooth/gatt_dm.h
+++ b/include/bluetooth/gatt_dm.h
@@ -268,11 +268,6 @@ const struct bt_gatt_dm_attr *bt_gatt_dm_desc_next(
  * another one, wait for the result of the previous procedure to finish
  * and call @ref bt_gatt_dm_data_release if it was successful.
  *
- * If the service UUID is set when you start service discovery using the
- * @ref bt_gatt_dm_start function. If there are more instances of the same service
- * on the GATT server, it discovers the next instance. Use this function to discover
- * all service instances with the given UUID.
- *
  * @param[in]     conn Connection object.
  * @param[in]     svc_uuid UUID of target service
  *                or NULL if any service should be discovered.
@@ -286,7 +281,7 @@ const struct bt_gatt_dm_attr *bt_gatt_dm_desc_next(
  *
  * If @p svc_uuid is set to the service UUID, all
  * service instances may be discovered.
- * To discover next service instance if it exist, call @ref bt_gatt_dm_continue.
+ * Call @ref bt_gatt_dm_continue to discover the next service instance.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.

--- a/tests/subsys/bluetooth/gatt_dm/src/main.c
+++ b/tests/subsys/bluetooth/gatt_dm/src/main.c
@@ -50,8 +50,14 @@ const struct bt_gatt_attr discover_sim[] = {
 	BT_GATT_DISCOVER_MOCK_SERV(17, BT_UUID_EMPTY, 17),
 
 	/* Another instance of service with the same UUID, but with a single characteristic */
-	BT_GATT_DISCOVER_MOCK_SERV(18, BT_UUID_EMPTY, 0xffff),
+	BT_GATT_DISCOVER_MOCK_SERV(18, BT_UUID_EMPTY, 19),
 	BT_GATT_DISCOVER_MOCK_CHRC(19, BT_UUID_EMPTY_CHR, BT_GATT_CHRC_READ),
+
+	BT_GATT_DISCOVER_MOCK_SERV(20, BT_UUID_HRS, 21),
+	BT_GATT_DISCOVER_MOCK_CHRC(21, BT_UUID_HRS_MEASUREMENT, BT_GATT_CHRC_READ),
+
+	BT_GATT_DISCOVER_MOCK_SERV(22, BT_UUID_HRS, 0xffff),
+	BT_GATT_DISCOVER_MOCK_CHRC(23, BT_UUID_HRS_MEASUREMENT, BT_GATT_CHRC_READ),
 };
 
 
@@ -152,7 +158,8 @@ void test_gatt_DIS_simple_next_attr(void)
 	zassert_is_null(attr, "Attr after 11 should be NULL");
 
 	bt_gatt_dm_data_release(dm);
-	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d", bt_gatt_dm_attr_cnt(dm));
+	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d",
+		      bt_gatt_dm_attr_cnt(dm));
 }
 
 void test_gatt_DIS_attr_by_handle(void)
@@ -173,7 +180,8 @@ void test_gatt_DIS_attr_by_handle(void)
 		zassert_equal(i, attr->handle, "Attr handle: %d", i);
 	}
 	bt_gatt_dm_data_release(dm);
-	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d", bt_gatt_dm_attr_cnt(dm));
+	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d",
+		      bt_gatt_dm_attr_cnt(dm));
 }
 
 void test_gatt_HIDS_simple_next_attr(void)
@@ -193,7 +201,8 @@ void test_gatt_HIDS_simple_next_attr(void)
 	zassert_is_null(attr, "Attr after 11 should be NULL");
 
 	bt_gatt_dm_data_release(dm);
-	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d", bt_gatt_dm_attr_cnt(dm));
+	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d",
+		      bt_gatt_dm_attr_cnt(dm));
 }
 
 void test_gatt_HIDS_attr_by_handle(void)
@@ -214,7 +223,8 @@ void test_gatt_HIDS_attr_by_handle(void)
 		zassert_equal(i, attr->handle, "Attr handle: %d", i);
 	}
 	bt_gatt_dm_data_release(dm);
-	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d", bt_gatt_dm_attr_cnt(dm));
+	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d",
+		      bt_gatt_dm_attr_cnt(dm));
 }
 
 void test_gatt_HIDS_next_chrc_access(void)
@@ -263,8 +273,10 @@ void test_gatt_HIDS_next_chrc_access(void)
 	zassert_equal(4, attr_chrc->handle, "Unexpected handle value for HIDS_REPORT_MAP");
 	chrc_val = bt_gatt_dm_attr_chrc_val(attr_chrc);
 	zassert_not_null(chrc_val, "Unexpected NULL instead HIDS_REPORT_MAP value");
-	zassert_true(!bt_uuid_cmp(BT_UUID_HIDS_REPORT_MAP, chrc_val->uuid), "Unexpected HIDS_REPORT_MAP UUID");
-	zassert_equal(BT_GATT_CHRC_READ, chrc_val->properties, "Unexpected HIDS_REPORT_MAP properties");
+	zassert_true(!bt_uuid_cmp(BT_UUID_HIDS_REPORT_MAP, chrc_val->uuid),
+		     "Unexpected HIDS_REPORT_MAP UUID");
+	zassert_equal(BT_GATT_CHRC_READ, chrc_val->properties,
+		      "Unexpected HIDS_REPORT_MAP properties");
 	/* Simple access to next descriptors */
 	attr_desc = bt_gatt_dm_desc_next(dm, attr_chrc);
 	zassert_not_null(attr_desc, "Unexpected NULL");
@@ -279,7 +291,8 @@ void test_gatt_HIDS_next_chrc_access(void)
 	zassert_equal(6, attr_chrc->handle, "Unexpected handle value for HIDS_REPORT");
 	chrc_val = bt_gatt_dm_attr_chrc_val(attr_chrc);
 	zassert_not_null(chrc_val, "Unexpected NULL instead HIDS_REPORT value");
-	zassert_true(!bt_uuid_cmp(BT_UUID_HIDS_REPORT, chrc_val->uuid), "Unexpected HIDS_REPORT UUID");
+	zassert_true(!bt_uuid_cmp(BT_UUID_HIDS_REPORT, chrc_val->uuid),
+		     "Unexpected HIDS_REPORT UUID");
 	zassert_equal(BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
 		      chrc_val->properties,
 		      "Unexpected HIDS_REPORT properties");
@@ -312,7 +325,8 @@ void test_gatt_HIDS_next_chrc_access(void)
 	zassert_is_null(attr_chrc, "Unexpected characteristic detected");
 
 	bt_gatt_dm_data_release(dm);
-	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d", bt_gatt_dm_attr_cnt(dm));
+	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d",
+		      bt_gatt_dm_attr_cnt(dm));
 }
 
 void test_gatt_HIDS_chrc_by_uuid(void)
@@ -351,7 +365,8 @@ void test_gatt_HIDS_chrc_by_uuid(void)
 	/* ------------------------------------------------------ */
 	/* Clean up */
 	bt_gatt_dm_data_release(dm);
-	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d", bt_gatt_dm_attr_cnt(dm));
+	zassert_equal(0, bt_gatt_dm_attr_cnt(dm), "Parameter count after clearing: %d",
+		      bt_gatt_dm_attr_cnt(dm));
 }
 
 void test_gatt_generic_serv(void)
@@ -401,9 +416,57 @@ void test_gatt_generic_serv(void)
 		      bt_gatt_dm_attr_cnt(dm));
 
 	dm = run_dm_next(dm);
+	zassert_not_null(dm, "Device Manager pointer not set");
+	attr_serv = bt_gatt_dm_service_get(dm);
+	serv_val  = bt_gatt_dm_attr_service_val(attr_serv);
+	zassert_true(!bt_uuid_cmp(BT_UUID_HRS, serv_val->uuid), "Invalid service detected");
+	zassert_equal(2,
+		      bt_gatt_dm_attr_cnt(dm),
+		      "Unexpected number of attributes detected: %d",
+		      bt_gatt_dm_attr_cnt(dm));
+
+	dm = run_dm_next(dm);
+	zassert_not_null(dm, "Device Manager pointer not set");
+	attr_serv = bt_gatt_dm_service_get(dm);
+	serv_val  = bt_gatt_dm_attr_service_val(attr_serv);
+	zassert_true(!bt_uuid_cmp(BT_UUID_HRS, serv_val->uuid), "Invalid service detected");
+	zassert_equal(2,
+		      bt_gatt_dm_attr_cnt(dm),
+		      "Unexpected number of attributes detected: %d",
+		      bt_gatt_dm_attr_cnt(dm));
+
+	dm = run_dm_next(dm);
 	zassert_is_null(dm, "Unexpected service detected");
 	/* ------------------------------------------------------ */
 	/* No cleanup here - cleanup is done in run_dm_next */
+}
+
+void test_gatt_many_serv_by_uuid(void)
+{
+	struct bt_gatt_dm *dm;
+	const struct bt_gatt_dm_attr *attr_serv;
+	const struct bt_gatt_service_val *serv_val;
+
+	dm = run_dm(BT_UUID_HRS);
+
+	zassert_not_null(dm, "Device Manager pointer not set");
+	attr_serv = bt_gatt_dm_service_get(dm);
+	serv_val  = bt_gatt_dm_attr_service_val(attr_serv);
+	zassert_true(!bt_uuid_cmp(BT_UUID_HRS, serv_val->uuid), "Invalid service detected");
+	zassert_equal(2,
+		      bt_gatt_dm_attr_cnt(dm),
+		      "Unexpected number of attributes detected: %d",
+		      bt_gatt_dm_attr_cnt(dm));
+
+	dm = run_dm_next(dm);
+	zassert_not_null(dm, "Device Manager pointer not set");
+	attr_serv = bt_gatt_dm_service_get(dm);
+	serv_val  = bt_gatt_dm_attr_service_val(attr_serv);
+	zassert_true(!bt_uuid_cmp(BT_UUID_HRS, serv_val->uuid), "Invalid service detected");
+	zassert_equal(2,
+		      bt_gatt_dm_attr_cnt(dm),
+		      "Unexpected number of attributes detected: %d",
+		      bt_gatt_dm_attr_cnt(dm));
 }
 
 void test_main(void)
@@ -411,13 +474,21 @@ void test_main(void)
 	ztest_test_suite(
 		test_gatt,
 		ztest_unit_test_setup_teardown(test_gatt_none_serv, test_setup, unit_test_noop),
-		ztest_unit_test_setup_teardown(test_gatt_DIS_simple_next_attr, test_setup, unit_test_noop),
-		ztest_unit_test_setup_teardown(test_gatt_DIS_attr_by_handle, test_setup, unit_test_noop),
-		ztest_unit_test_setup_teardown(test_gatt_HIDS_simple_next_attr, test_setup, unit_test_noop),
-		ztest_unit_test_setup_teardown(test_gatt_HIDS_attr_by_handle, test_setup, unit_test_noop),
-		ztest_unit_test_setup_teardown(test_gatt_HIDS_next_chrc_access, test_setup, unit_test_noop),
-		ztest_unit_test_setup_teardown(test_gatt_HIDS_chrc_by_uuid, test_setup, unit_test_noop),
-		ztest_unit_test_setup_teardown(test_gatt_generic_serv, test_setup, unit_test_noop)
+		ztest_unit_test_setup_teardown(test_gatt_DIS_simple_next_attr, test_setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_gatt_DIS_attr_by_handle, test_setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_gatt_HIDS_simple_next_attr, test_setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_gatt_HIDS_attr_by_handle, test_setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_gatt_HIDS_next_chrc_access, test_setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_gatt_HIDS_chrc_by_uuid, test_setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_gatt_generic_serv, test_setup, unit_test_noop),
+		ztest_unit_test_setup_teardown(test_gatt_many_serv_by_uuid, test_setup,
+					       unit_test_noop)
 	);
 
 	ztest_run_test_suite(test_gatt);


### PR DESCRIPTION
Adds a possibility to discover all the same service instances using the UUID