### PR TITLE
lib: at_monitor: enable setting logging level at compilation time

### DIFF
--- a/lib/at_monitor/at_monitor.c
+++ b/lib/at_monitor/at_monitor.c
@@ -13,7 +13,7 @@
 #include <toolchain/common.h>
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(at_monitor);
+LOG_MODULE_REGISTER(at_monitor, CONFIG_AT_MONITOR_LOG_LEVEL);
 
 struct at_notif_fifo {
 	void *fifo_reserved;


### PR DESCRIPTION
Added custom logging level to LOG_MODULE_REGISTER() to make it possible to change AT monitor logging level at compilation time. Without this, enabling for example CONFIG_AT_MONITOR_LOG_LEVEL_DBG in prj.conf doesn't seem to affect the logging level at all.