### PR TITLE
ext: iperf3: updates

### DIFF
--- a/ext/iperf3/iperf_tcp.c
+++ b/ext/iperf3/iperf_tcp.c
@@ -517,7 +517,7 @@ iperf_tcp_connect(struct iperf_test *test)
     if (test->pdn_id_str != NULL) {
         int ret = iperf_util_socket_pdn_id_set(s, test->pdn_id_str);
         if (ret != 0) {
-            iperf_printf(test, "iperf_tcp_listen: cannot bind socket with PDN ID %s\n", test->pdn_id_str);
+            iperf_printf(test, "iperf_tcp_connect: cannot bind socket with PDN ID %s\n", test->pdn_id_str);
             i_errno = IESTREAMLISTEN;
             return -1;
         }				

--- a/ext/iperf3/iperf_udp.c
+++ b/ext/iperf3/iperf_udp.c
@@ -134,7 +134,7 @@ iperf_udp_recv(struct iperf_stream *sp)
 #if defined(CONFIG_NRF_IPERF3_INTEGRATION)
 	/* ....because 64bit printing ain't working */
 	if (sp->test->debug)
-	    fprintf(stderr, "pcount %d packet_count %d\n", (uint32_t)pcount, sp->packet_count);
+	    iperf_printf(sp->test, "pcount %d packet_count %d\n", (uint32_t)pcount, sp->packet_count);
 #else
 	if (sp->test->debug)
 	    fprintf(stderr, "pcount %" PRIu64 " packet_count %d\n", pcount, sp->packet_count);


### PR DESCRIPTION
Couple minor nrf specific updates to iperf3:
- server: timeout to parameter exchange phase to avoid possible hanging on that phase if nothing is received.
- udp debug printing aligned with other nrf specific printings, for example with modem_shell to avoid printing in foreground if running in a background thread.