### PR TITLE
samples: nrf9160: modem_shell: link ncellmeas: interval option

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -121,6 +121,15 @@ nrf9160 Samples
 
   * Shell functionality to HTTP Update samples.
 
+* Updated:
+
+  * :ref:`modem_shell_application` sample:
+
+    * Added:
+
+      * An option ``--interval`` (in seconds) to neighbor cell measurements in continuous mode  (``link ncellmeas --continuous``).
+        When using this option, a new measurement is started in each interval.
+
 Drivers
 =======
 

--- a/samples/nrf9160/modem_shell/src/link/link.h
+++ b/samples/nrf9160/modem_shell/src/link/link.h
@@ -22,7 +22,7 @@ void link_init(void);
 void link_ind_handler(const struct lte_lc_evt *const evt);
 void link_rsrp_subscribe(bool subscribe);
 void link_ncellmeas_start(bool start, enum link_ncellmeas_modes mode,
-			  enum lte_lc_neighbor_search_type search_type);
+			  enum lte_lc_neighbor_search_type search_type, int periodic_interval);
 void link_modem_sleep_notifications_subscribe(uint32_t warn_time_ms, uint32_t threshold_ms);
 void link_modem_sleep_notifications_unsubscribe(void);
 void link_modem_tau_notifications_subscribe(uint32_t warn_time_ms, uint32_t threshold_ms);


### PR DESCRIPTION
Addition to neighbor cell measurements in continuous mode:
optional interval (in seconds) can be given and then new measurement is
started in each interval seconds after previous measurement was
reported.
Usage example: link ncellmeas --continuous --interval 10
Jira: MOSH-229

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>