### PR TITLE
tests: use DEVICE_DT_GET

### DIFF
--- a/tests/crypto/src/common_test.c
+++ b/tests/crypto/src/common_test.c
@@ -94,11 +94,11 @@ int init_drbg(const unsigned char *p_optional_seed, size_t len)
 		p_seed = p_optional_seed;
 	}
 
-	const struct device *p_device =
-	    device_get_binding(DT_LABEL(DT_CHOSEN(zephyr_entropy)));
+	const struct device *p_device = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
-	if (p_device == NULL)
+	if (!device_is_ready(p_device)) {
 		return -ENODEV;
+	}
 
 	// Ensure previously run test is properly deallocated
 	// (This frees the mutex inside ctr_drbg context)
@@ -130,11 +130,11 @@ int init_drbg(const unsigned char *p_optional_seed, size_t len)
 	mbedtls_hmac_drbg_free(&drbg_ctx);
 	mbedtls_hmac_drbg_init(&drbg_ctx);
 
-	const struct device *p_device =
-	    device_get_binding(DT_LABEL(DT_CHOSEN(zephyr_entropy)));
+	const struct device *p_device = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
-	if (!p_device)
+	if (!device_is_ready(p_device)) {
 		return -ENODEV;
+	}
 
 	const mbedtls_md_info_t *p_info =
 		mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);

--- a/tests/drivers/flash_nop_device/src/main.c
+++ b/tests/drivers/flash_nop_device/src/main.c
@@ -28,16 +28,8 @@
 		(((((((0xff & pat) << 8) | (0xff & pat)) << 8) | \
 		   (0xff & pat)) << 8) | (0xff & pat))
 
-static const struct device *flash_dev;
+static const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static uint8_t test_read_buf[TEST_NOP_FLASH_SIZE];
-
-static void test_init(void)
-{
-	flash_dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-
-	zassert_true(flash_dev != NULL,
-		     "Sim flash driver to nop was not found!");
-}
 
 static void test_read(void)
 {
@@ -186,8 +178,9 @@ static void test_get_erase_value(void)
 
 void test_main(void)
 {
+	__ASSERT_NO_MSG(device_is_ready(flash_dev));
+
 	ztest_test_suite(flash_nop_device,
-			 ztest_unit_test(test_init),
 			 ztest_unit_test(test_read),
 			 ztest_unit_test(test_write_read),
 			 ztest_unit_test(test_erase),

--- a/tests/drivers/fprotect/positive/src/main.c
+++ b/tests/drivers/fprotect/positive/src/main.c
@@ -15,18 +15,16 @@
 #include <device.h>
 #include <drivers/flash.h>
 
+static const struct device *flash_dev = DEVICE_DT_GET(DT_NODELABEL(flash_controller));
+
 static uint8_t write_data[] = "Hello World";
 static uint32_t valid_write_addr = 0x1C000;
 static uint32_t control_read_addr = 0x6032;
 static uint8_t read_data_before[sizeof(write_data)];
 static uint8_t read_data_after[sizeof(write_data)];
 
-#define SOC_NV_FLASH_CONTROLLER_NODE DT_NODELABEL(flash_controller)
-#define FLASH_DEV_NAME DT_LABEL(SOC_NV_FLASH_CONTROLLER_NODE)
-
 static void test_flash_write(void)
 {
-	const struct device *flash_dev = device_get_binding(FLASH_DEV_NAME);
 	int retval = flash_read(flash_dev, control_read_addr, read_data_before,
 				ARRAY_SIZE(read_data_before));
 
@@ -39,7 +37,6 @@ static void test_flash_write(void)
 static void test_flash_read(void)
 {
 	int retval = 0;
-	const struct device *flash_dev = device_get_binding(FLASH_DEV_NAME);
 
 	retval = flash_read(flash_dev, valid_write_addr, read_data_after,
 			    ARRAY_SIZE(read_data_after));
@@ -63,7 +60,6 @@ static void test_flash_read_protected(void)
 {
 	int retval;
 	uint8_t rd[256];
-	const struct device *flash_dev = device_get_binding(FLASH_DEV_NAME);
 
 	retval = flash_read(flash_dev, 0, rd, sizeof(rd));
 	zassert_true(retval == 0, "flash read to protected area failed");
@@ -71,6 +67,8 @@ static void test_flash_read_protected(void)
 
 void test_main(void)
 {
+	__ASSERT_NO_MSG(device_is_ready(flash_dev));
+
 	ztest_test_suite(test_fprotect_positive,
 			ztest_unit_test(test_flash_write),
 			ztest_unit_test(test_flash_read),

--- a/tests/subsys/dfu/dfu_target_stream/src/main.c
+++ b/tests/subsys/dfu/dfu_target_stream/src/main.c
@@ -11,7 +11,6 @@
 #include <ztest.h>
 #include <dfu/dfu_target_stream.h>
 
-#define FLASH_NAME DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
 #define FLASH_BASE (64*1024)
 #define FLASH_SIZE DT_REG_SIZE(SOC_NV_FLASH_NODE)
 #define FLASH_AVAILABLE (FLASH_SIZE-FLASH_BASE)
@@ -21,7 +20,7 @@
 
 #define BUF_LEN 14000 /* Note, not page aligned */
 
-static const struct device *fdev;
+static const struct device *fdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static uint8_t sbuf[128];
 static uint8_t read_buf[BUF_LEN];
 static uint8_t write_buf[BUF_LEN] = {[0 ... BUF_LEN - 1] = 0xaa};
@@ -285,7 +284,7 @@ static void test_dfu_target_stream_save_progress(void)
 
 void test_main(void)
 {
-	fdev = device_get_binding(FLASH_NAME);
+	__ASSERT_NO_MSG(device_is_ready(fdev));
 
 #ifdef CONFIG_DFU_TARGET_STREAM_SAVE_PROGRESS
 	/* Check that the FLASH_BASE macro is actually at the start of a page,

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -168,12 +168,10 @@ void set_s0_active(bool s0_active)
 #include <nrfx_nvmc.h>
 #include <device.h>
 
-#define FLASH_NAME DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
-
-static const struct device *fdev;
 void set_s0_active(bool s0_active)
 {
 	int err;
+	const struct device *fdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 	struct fw_info s0_info = { .magic = { FIRMWARE_INFO_MAGIC } };
 	struct fw_info s1_info = { .magic = { FIRMWARE_INFO_MAGIC } };
 
@@ -186,8 +184,7 @@ void set_s0_active(bool s0_active)
 		s0_info.version = s1_info.version - 1;
 	}
 
-	fdev = device_get_binding(FLASH_NAME);
-	zassert_not_equal(fdev, 0, "Unable to get fdev");
+	zassert_true(device_is_ready(fdev), "Flash device not ready");
 
 	err = flash_erase(fdev, PM_S0_ADDRESS, nrfx_nvmc_flash_page_size_get());
 	zassert_equal(err, 0, "flash_erase failed");


### PR DESCRIPTION
Use DEVICE_DT_GET to obtain device references at compile time wherever possible.