### PR TITLE
manifest: update sdk-zephyr to 749.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a49c0691993ce87d0a8216bd7a6cd8df9cd39941
+      revision: pull/749/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Manifest to run CI.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>