### PR TITLE
doc: change calling Thread v1.2 from experimental to optional

### DIFF
--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -65,8 +65,8 @@ See `Testing diagnostic module`_ section for an example.
 
 .. _ot_cli_sample_thread_v12:
 
-Experimental Thread 1.2 extension
-=================================
+Optional Thread 1.2 extension
+=============================
 
 This optional extension allows you to test :ref:`available features from the Thread 1.2 Specification <thread_ug_thread_specification_options>`.
 To enable this extension, set ``-DCONF_FILE=prj_thread_1_2.conf``.


### PR DESCRIPTION
This sample is the only place calling Thread v1.2 experimental.
With the wider application of v1.2, it makes more sense to call
the section optional instead.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>