### PR TITLE
drivers: sensor: pmw3360: refactor driver

### DIFF
--- a/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.dts
+++ b/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.dts
@@ -62,7 +62,7 @@
 &spi1 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
-	cs-gpios = <&gpio0 13 0>;
+	cs-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-1 = <&spi1_sleep>;
@@ -70,7 +70,7 @@
 	pmw3360@0 {
 		compatible = "pixart,pmw3360";
 		reg = <0>;
-		irq-gpios = <&gpio0 21 0>;
+		irq-gpios = <&gpio0 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		spi-max-frequency = <2000000>;
 		label = "PMW3360";
 	};

--- a/doc/nrf/drivers/pmw3360.rst
+++ b/doc/nrf/drivers/pmw3360.rst
@@ -83,7 +83,6 @@ Moreover, you must configure the following parameters:
 
   * ``reg`` - The slave ID number the device has on a bus.
   * ``label`` - Name of the device.
-    Used to get device binding with :c:func:`device_get_binding`.
   * ``spi-max-frequency`` - Used for setting the bus clock frequency.
 
 * Pin to which the motion sensor IRQ line is connected (``irq-gpios``).


### PR DESCRIPTION
Refactor the driver to follow more modern driver development practices:

- Use `gpio_dt_spec`
- Use `spi_dt_spec`
- Convert to multi-instance
- Other minor cleanups

NOTE: I don't have hardware to test this, would appreciate some real testing.