### PR TITLE
application: serial_lte_modem: HTTP Request enhancement

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -86,6 +86,13 @@ nRF9160: Asset Tracker v2
 
   * For nRF Cloud builds, the configuration section in the shadow is now initialized during the cloud connection process.
 
+nRF9160: Serial LTE Modem
+-------------------------
+
+* Updated:
+
+  * Enhanced the #XHTTPCREQ AT command for better HTTP upload and download support.
+
 nRF Desktop
 -----------
 


### PR DESCRIPTION
old: #XHTTPCREQ=< method >,< resource >,< headers >[,< payload_length >]
new: #XHTTPCREQ=< method >,< resource >[,< headers >[,< content_type >, < content_length >[,< chunked_transfer >]]]
Config HTTP Content-Type and Content-Length explicitly;
Support of HTTP chunked transfer;
Align to universal datamode enter/exit behavior;
Fixed small issue in request headers/payload callbacks;
Enable TLS session resumption by default;
Set TLS handshake timeout to be max 123 seconds;

Enlarged response buffer from 1K to 2K;
One URC for headers and one URC for body;

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>