### PR TITLE
applications: nrf_desktop: Add prj_b0_wwcb to CI

### DIFF
--- a/applications/nrf_desktop/sample.yaml
+++ b/applications/nrf_desktop/sample.yaml
@@ -29,6 +29,13 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build
     extra_args: CONF_FILE=prj_b0.conf
+  applications.nrf_desktop.zdebug_b0_wwcb:
+    build_only: true
+    platform_allow: nrf52840dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
+    tags: bluetooth ci_build
+    extra_args: CONF_FILE=prj_b0_wwcb.conf
   applications.nrf_desktop.zdebug_mcuboot:
     build_only: true
     platform_allow: nrf52833dongle_nrf52833


### PR DESCRIPTION
Change adds prj_b0_wwcb configuration to sample.yaml to ensure that the configuration is built in CI.

Jira: NCSDK-14117