### PR TITLE
applications: asset_tracker_v2: Increase stack for gnss event thread

### DIFF
--- a/applications/asset_tracker_v2/src/modules/gnss_module.c
+++ b/applications/asset_tracker_v2/src/modules/gnss_module.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_GNSS_MODULE_LOG_LEVEL);
  * with pre-v1.3.0 MFWs, which do not support the sleep events.
  */
 #define GNSS_INACTIVITY_TIMEOUT	     5
-#define GNSS_EVENT_THREAD_STACK_SIZE 768
+#define GNSS_EVENT_THREAD_STACK_SIZE 896
 #define GNSS_EVENT_THREAD_PRIORITY   5
 
 struct gnss_msg_data {


### PR DESCRIPTION
An overflow was observed in the `gnss_event_thread`.
Increase its stack size by 128 to reduce the risk of this occurring.