### PR TITLE
lib: nrf_modem_lib: make irq priority configurable

### DIFF
--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -20,7 +20,7 @@ config NRF_MODEM_LIB_SYS_INIT
 
 config NRF_MODEM_TRACE_IRQ_PRIORITY
 	int "IRQ priority for trace handler"
-	default 6
+	default 4
 
 config NRF_MODEM_LIB_TRACE_ENABLED
 	bool

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -18,6 +18,10 @@ config NRF_MODEM_LIB_SYS_INIT
 	  Please note that initialization is synchronous and can take up to one
 	  minute in case the modem firmware is updated.
 
+config NRF_MODEM_TRACE_IRQ_PRIORITY
+	int "IRQ priority for trace handler"
+	default 6
+
 config NRF_MODEM_LIB_TRACE_ENABLED
 	bool
 	prompt "Enable proprietary traces"

--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -26,7 +26,7 @@
 
 /* Handle modem traces from IRQ context with lower priority. */
 #define TRACE_IRQ EGU2_IRQn
-#define TRACE_IRQ_PRIORITY 6
+#define TRACE_IRQ_PRIORITY CONFIG_NRF_MODEM_TRACE_IRQ_PRIORITY
 
 #define THREAD_MONITOR_ENTRIES 10
 


### PR DESCRIPTION
As of now the IRQ priority is hard coded. The chosen IRQ level is illegal in case of enabled ZLI support. Adding this value to the KConfig seems to be the natural solution for the problem.

Signed-off-by: Sven Hädrich <sven.haedrich@grandcentrix.net>