### PR TITLE
doc: matter: Added information about Amazon FFS support

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -520,6 +520,7 @@
 .. _`Alexa.Gadget.StateListener interface`: https://developer.amazon.com/en-US/docs/alexa/alexa-gadgets-toolkit/alexa-gadget-statelistener-interface.html
 .. _`Alexa Gadgets Notifications interface`: https://developer.amazon.com/en-US/docs/alexa/alexa-gadgets-toolkit/notifications-interface.html
 .. _`Alexa Gadgets Pairing`: https://www.amazon.com/gp/help/customer/display.html?nodeId=GV66YEZ2245F4QYS
+.. _`Amazon Frustration-Free Setup (FFS)`: https://developer.amazon.com/docs/frustration-free-setup/matter-simple-setup-overview.html
 
 .. ### Source: openthread.io
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -260,6 +260,7 @@ Documentation
 * Added:
 
   * Documentation for :ref:`degugging of nRF5340 <debugging>` in :ref:`working with nRF5340 DK<ug_nrf5340>` user guide.
+  * Section describing how to enable Amazon Frustration-Free Setup (FFS) support in :ref:`ug_matter_configuring_device_identification`.
 
 * Removed:
 

--- a/doc/nrf/ug_matter_configuring_protocol.rst
+++ b/doc/nrf/ug_matter_configuring_protocol.rst
@@ -87,11 +87,24 @@ These can be used for various purposes, such as dividing devices into groups (by
 
 Some of these can be configured using the Kconfig options listed below:
 
+* :kconfig:`CONFIG_CHIP_DEVICE_VENDOR_ID` sets the device manufacturer identifier that is assigned by the Connectivity Standards Alliance.
+* :kconfig:`CONFIG_CHIP_DEVICE_PRODUCT_ID` sets the product identifier that is assigned by the product manufacturer.
 * :kconfig:`CONFIG_CHIP_DEVICE_TYPE` sets the type of the device using the Matter Device Type Identifier, for example Door Lock (0x000A) or Dimmable Light Bulb (0x0101).
 * :kconfig:`CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE` enables including an optional device type subtype in the commissionable node discovery record.
   This allows filtering of the discovery results to find the nodes that match the device type.
 * :kconfig:`CONFIG_CHIP_ROTATING_DEVICE_ID` enables an optional rotating device identifier feature that provides an additional unique identifier for each device.
   This identifier is similar to the serial number, but it additionally changes at predefined times to protect against long-term tracking of the device.
+
+Amazon FFS support
+==================
+
+Matter in the |NCS| supports `Amazon Frustration-Free Setup (FFS)`_ that allows Matter devices to be automatically commissioned to the Matter network using the Matter-enabled Amazon Echo device.
+To enable the FFS support, set the following configuration options to meet the Amazon FFS setup prerequisites:
+
+* :kconfig:`CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE` to ``y``.
+* :kconfig:`CONFIG_CHIP_ROTATING_DEVICE_ID` to ``y``.
+* :kconfig:`CONFIG_CHIP_DEVICE_TYPE` to the appropriate value, depending on the device used.
+  The value must be compliant with the Matter Device Type Identifier.
 
 .. _ug_matter_configuring_requirements:
 


### PR DESCRIPTION
There is no clear statement in the documentation that Nordic
supports Amazon FFS in Matter and how to enable it.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>