### PR TITLE
lib: lte_lc: Add simple shell commands

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -330,6 +330,7 @@ Modem libraries
   * :ref:`lte_lc_readme` library:
 
     * Added :c:macro:`LTE_LC_ON_CFUN` macro for compile-time registration of callbacks on modem functional mode changes using :c:func:`lte_lc_func_mode_set`.
+    * Added support for simple shell commands.
 
 Libraries for networking
 ------------------------

--- a/lib/lte_link_control/CMakeLists.txt
+++ b/lib/lte_link_control/CMakeLists.txt
@@ -9,5 +9,6 @@ zephyr_library_sources(lte_lc.c)
 zephyr_library_sources(lte_lc_helpers.c)
 zephyr_library_sources(lte_lc_modem_hooks.c)
 zephyr_library_sources_ifdef(CONFIG_LTE_LC_TRACE lte_lc_trace.c)
+zephyr_library_sources_ifdef(CONFIG_LTE_SHELL lte_lc_shell.c)
 
 zephyr_linker_sources(RODATA lte_lc.ld)

--- a/lib/lte_link_control/Kconfig
+++ b/lib/lte_link_control/Kconfig
@@ -19,6 +19,11 @@ config LTE_AUTO_INIT_AND_CONNECT
 		automatically initialize and connect the modem
 		before the application starts
 
+config LTE_SHELL
+	bool "Enable LTE shell commands"
+	default y
+	depends on SHELL
+
 config LTE_LOCK_BANDS
 	bool "Enable LTE bands lock"
 	help

--- a/lib/lte_link_control/lte_lc_shell.c
+++ b/lib/lte_link_control/lte_lc_shell.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <shell/shell.h>
+#include <modem/lte_lc.h>
+
+static int cmd_normal(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	int ret = lte_lc_normal();
+
+	if (ret) {
+		shell_error(shell, "Error: lte_lc_normal() returned %d", ret);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int cmd_power_off(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	int ret = lte_lc_power_off();
+
+	if (ret) {
+		shell_error(shell, "Error: lte_lc_power_off() returned %d", ret);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int cmd_offline(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	int ret = lte_lc_offline();
+
+	if (ret) {
+		shell_error(shell, "Error: lte_lc_offline() returned %d", ret);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_lte,
+	SHELL_CMD(normal, NULL, "Send the modem to normal mode", cmd_normal),
+	SHELL_CMD(offline, NULL, "Send the modem to offline mode", cmd_offline),
+	SHELL_CMD(power_off, NULL, "Send the modem to power off mode", cmd_power_off),
+	SHELL_SUBCMD_SET_END /* Array terminated. */
+);
+
+SHELL_CMD_REGISTER(lte, &sub_lte, "LTE Link control", NULL);

--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -34,6 +34,8 @@ CONFIG_SHELL_ARGC_MAX=40
 CONFIG_SHELL_CMD_BUFF_SIZE=3072
 # Shell stack has impact for modem shell application, not CONFIG_MAIN_STACK_SIZE
 CONFIG_SHELL_STACK_SIZE=16384
+# LTE shell is unnecessary with Modem Shell
+CONFIG_LTE_SHELL=n
 # Enable use of vsnprintfcb() for extending mosh_print() format
 CONFIG_CBPRINTF_LIBC_SUBSTS=y
 


### PR DESCRIPTION
Many samples and test applications have shell module
enabled already. It would benefit if LTE Link controll would
provide shell commands for some simple control functions.

This would be much better than samples implementing custom LTE commands for same purpose, as proposed in https://github.com/nrfconnect/sdk-nrf/pull/6749
