### PR TITLE
application: serial_lte_modem: Adapt to Serial Async updates

### DIFF
--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -169,7 +169,7 @@ static int ftp_data_send(void)
 
 	if (ring_buf_is_empty(&ftp_data_buf) == 0) {
 		sz_send = ring_buf_get(&ftp_data_buf, rsp_buf, sizeof(rsp_buf));
-		datamode_send(rsp_buf, sz_send);
+		data_send(rsp_buf, sz_send);
 	}
 
 	return sz_send;

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -85,7 +85,7 @@ static void response_cb(struct http_response *rsp,
 		/* Response body starts from the beginning of receive buffer */
 		sprintf(rsp_buf, "\r\n#XHTTPCRSP:%d,%hu\r\n", rsp->data_len, final_data);
 		rsp_send(rsp_buf, strlen(rsp_buf));
-		rsp_send(data_buf, rsp->data_len);
+		data_send(data_buf, rsp->data_len);
 	}
 	/* Process response header if required */
 	if (httpc.state == HTTPC_REQ_DONE) {
@@ -99,19 +99,19 @@ static void response_cb(struct http_response *rsp,
 			LOG_DBG("There is more HTTP header data\n");
 			sprintf(rsp_buf, "\r\n#XHTTPCRSP:%d,%hu\r\n", rsp->data_len, final_data);
 			rsp_send(rsp_buf, strlen(rsp_buf));
-			rsp_send(data_buf, rsp->data_len);
+			data_send(data_buf, rsp->data_len);
 		} else {
 			httpc.state = HTTPC_RES_HEADER_DONE;
 			sprintf(rsp_buf, "\r\n#XHTTPCRSP:%d,%hu\r\n",
 						pch - data_buf + HEADER_END_LEN, final_data);
 			rsp_send(rsp_buf, strlen(rsp_buf));
-			rsp_send(data_buf, pch - data_buf + HEADER_END_LEN);
+			data_send(data_buf, pch - data_buf + HEADER_END_LEN);
 			/* Process response body if required */
 			if (rsp->body_start) {
 				sprintf(rsp_buf, "\r\n#XHTTPCRSP:%d,%hu\r\n",
 					rsp->data_len - (rsp->body_start - data_buf), final_data);
 				rsp_send(rsp_buf, strlen(rsp_buf));
-				rsp_send(rsp->body_start,
+				data_send(rsp->body_start,
 					rsp->data_len - (rsp->body_start - data_buf));
 			}
 		}

--- a/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
+++ b/applications/serial_lte_modem/src/mqtt_c/slm_at_mqtt.c
@@ -103,11 +103,11 @@ static int handle_mqtt_publish_evt(struct mqtt_client *const c, const struct mqt
 		evt->param.publish.message.topic.topic.size,
 		evt->param.publish.message.payload.len);
 	rsp_send(rsp_buf, strlen(rsp_buf));
-	rsp_send(evt->param.publish.message.topic.topic.utf8,
+	data_send(evt->param.publish.message.topic.topic.utf8,
 		evt->param.publish.message.topic.topic.size);
-	rsp_send("\r\n", 2);
-	rsp_send(payload_buf, evt->param.publish.message.payload.len);
-	rsp_send("\r\n", 2);
+	data_send("\r\n", 2);
+	data_send(payload_buf, evt->param.publish.message.payload.len);
+	data_send("\r\n", 2);
 
 	return 0;
 }

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -71,7 +71,7 @@ void rsp_send(const char *str, size_t len);
  * @param len Length of raw data
  *
  */
-void datamode_send(const uint8_t *data, size_t len);
+void data_send(const uint8_t *data, size_t len);
 
 /**
  * @brief Request SLM AT host to enter data mode

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -566,7 +566,7 @@ client_events:
 				continue;
 			}
 			if (in_datamode()) {
-				datamode_send(rx_data, ret);
+				data_send(rx_data, ret);
 			} else {
 				rsp_send(rx_data, ret);
 				sprintf(rsp_buf, "\r\n#XTCPDATA: %d\r\n", ret);
@@ -647,7 +647,7 @@ static void tcpcli_thread_func(void *p1, void *p2, void *p3)
 			continue;
 		}
 		if (in_datamode()) {
-			datamode_send(rx_data, ret);
+			data_send(rx_data, ret);
 		} else {
 			rsp_send(rx_data, ret);
 			sprintf(rsp_buf, "\r\n#XTCPDATA: %d\r\n", ret);

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -403,8 +403,10 @@ static void udp_thread_func(void *p1, void *p2, void *p3)
 		if (ret == 0) {
 			continue;
 		}
-		rsp_send(rx_data, ret);
-		if (!in_datamode()) {
+		if (in_datamode()) {
+			data_send(rx_data, ret);
+		} else {
+			rsp_send(rx_data, ret);
 			sprintf(rsp_buf, "\r\n#XUDPDATA: %d\r\n", ret);
 			rsp_send(rsp_buf, strlen(rsp_buf));
 		}


### PR DESCRIPTION
Roll back PR#7041, that the new TX cache does not serve the need
of holding TX data until DMA complete;
Change TX/RX timeout unit from millisecond to microsecond;
Separate raw data from URC before UART TX. The raw data buffer is
secured other than the rsp_buf. Received raw data in TCP, UDP,
FTP, MQTT and HTTP clients.
The rsp_send() function to be further enhanced.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>