### PR TITLE
doc improvement: fix link to nRF9160 DK downloads

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -217,7 +217,10 @@
 .. _`SUPL client download`: https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF9160-DK/Download#supl-c
 
 .. _`nRF9160 product website`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160
+
+.. _`nRF9160 DK Downloads`:
 .. _`nRF9160 product website (compatible downloads)`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160/Download#infotabs
+
 .. _`nRF9160 Certifications`: https://www.nordicsemi.com/Products/Low-power-Cellular-IoT/nRF9160-Certifications
 .. _`Energy efficiency`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/What-is-cellular-IoT#energy_efficiency
 

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -187,7 +187,7 @@ Building and programming
 
 You can program applications and samples on the nRF9160 DK after obtaining the corresponding firmware images.
 
-Download the latest application and modem firmware from the `nRF9160 DK Downloads <nRF9160 product website (compatible downloads)>`_ page.
+Download the latest application and modem firmware from the `nRF9160 DK Downloads`_ page.
 
 To program applications using the Programmer app from `nRF Connect for Desktop`_, follow the instructions in :ref:`nrf9160_gs_updating_fw_application`.
 In Step 2, set the switch to **nRF91** or **nRF52** as appropriate for the application or sample you are programming.

--- a/doc/nrf/ug_nrf9160_gs.rst
+++ b/doc/nrf/ug_nrf9160_gs.rst
@@ -48,7 +48,7 @@ After installing and starting the application, install the following apps:
 Updating the DK firmware
 ************************
 
-Download the latest application and modem firmware from the `nRF9160 DK Downloads <nRF9160 product website (compatible downloads)>`_ page and extract to a folder of your choice.
+Download the latest application and modem firmware from the `nRF9160 DK Downloads`_ page and extract to a folder of your choice.
 
 The downloaded zip contains the following firmware:
 


### PR DESCRIPTION
Due to a missing character, the link isn't working.
Solved here by adding a new explicit target name and
using that instead.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>