### PR TITLE
application: serial_lte_modem: Adjust MQTT buffers size

### DIFF
--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -1,7 +1,7 @@
 .. _SLM_AT_MQTT:
 
-MQTT AT commands
-****************
+MQTT client AT commands
+***********************
 
 .. contents::
    :local:
@@ -337,8 +337,9 @@ Syntax
   It indicates the topic on which data is published.
 * The ``<msg>`` parameter is a string.
   It contains the payload on the topic being published.
-  The max ``NET_IPV4_MTU`` is 576 bytes.
-  When this parameter is not specified, SLM enters ``slm_data_mode``.
+
+  The maximum size of the payload is 256 bytes when not empty.
+  If the payload is empty (for example, ``""``), SLM enters ``slm_data_mode``.
 * The ``<qos>`` parameter is an integer.
   It indicates the MQTT Quality of Service types.
   It can accept the following values:
@@ -351,7 +352,7 @@ Syntax
     The acknowledgment of the reception is expected and the message should be published only once.
 
 * The ``<retain>`` parameter is an integer.
-  Default value is  ``0``.
+  Its default vefault value is  ``0``..
   When ``1``, it indicates that the broker should store the message persistently.
 
 Response syntax
@@ -392,13 +393,12 @@ Examples
 ::
 
    AT#XMQTTPUB="nrf91/slm/mqtt/topic0"
-   {"msg":"Test Json publish"}
+   {"msg":"Test Json publish"}+++
+   OK
    #XMQTTMSG: 21,27
    nrf91/slm/mqtt/topic0
    {"msg":"Test Json publish"}
    #XMQTTEVT: 2,0
-   +++
-   OK
 
 ::
 
@@ -412,12 +412,14 @@ Examples
 
 ::
 
-   AT#XMQTTPUB="nrf91/slm/mqtt/topic2","Test message with QoS 2",2,0
+   AT#XMQTTPUB="nrf91/slm/mqtt/topic2","",2,0
+   Test message with QoS 2+++
    OK
    #XMQTTEVT: 4,0
    #XMQTTEVT: 6,0
    #XMQTTMSG: 21,23
-   nrf91/slm/mqtt/topic2Test message with QoS 2
+   nrf91/slm/mqtt/topic2
+   Test message with QoS 2
    #XMQTTEVT: 2,0
 
 Read command

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -174,6 +174,12 @@ CONFIG_SLM_FTPC - FTP client support in SLM
 CONFIG_SLM_MQTTC - MQTT client support in SLM
    This option enables additional AT commands for using the MQTT client service.
 
+.. _CONFIG_SLM_MQTTC_MESSAGE_BUFFER_LEN:
+
+CONFIG_SLM_MQTTC_MESSAGE_BUFFER_LEN - Size of the buffer for the MQTT library
+   This option specifies the maximum message size which can be transmitted or received through MQTT (excluding PUBLISH payload).
+   The default value is 512, meaning 512 bytes for TX and RX, respectively.
+
 .. _CONFIG_SLM_HTTPC:
 
 CONFIG_SLM_HTTPC - HTTP client support in SLM

--- a/applications/serial_lte_modem/src/mqtt_c/Kconfig
+++ b/applications/serial_lte_modem/src/mqtt_c/Kconfig
@@ -8,3 +8,14 @@ config SLM_MQTTC
 	default y
 	select MQTT_LIB
 	select MQTT_LIB_TLS
+
+if SLM_MQTTC
+
+config SLM_MQTTC_MESSAGE_BUFFER_LEN
+	int "Size of the buffer for MQTT library."
+	default 512
+	help
+	  Specifies maximum message size can be transmitted/received through
+	  MQTT (excluding MQTT PUBLISH payload).
+
+endif # SLM_MQTTC

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -93,6 +93,7 @@ nRF9160: Serial LTE Modem
 
   * Enhanced the #XHTTPCREQ AT command for better HTTP upload and download support.
   * Enhanced the #XSLEEP AT command to support data indication when idle.
+  * Enhanced the MQTT client to support the reception of large PUBLISH payloads.
 
 nRF Desktop
 -----------


### PR DESCRIPTION
Add CONFIG_SLM_MQTTC_MESSAGE_BUFFER_LEN to config TX/RX buffer
passed to MQTT library, default 512 (used to be 576)

#XMQTTPUB, send max 256 bytes in command mode (used to be 576)
< msg > must be present if qos/retain is present
To enter data mode, set < msg > as "" i.e. empty string.

Allow receive large PUBLISH payload (used to be max 576)
Use rsp_buf to receive PUBLISH payload.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>