### PR TITLE
bluetooth: rpc: Add host missing callback handlers

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -268,6 +268,12 @@ Bluetooth libraries and services
 
     * Shell commands for client models.
 
+* :ref:`ble_rpc` library:
+
+  * Added host callback handlers for the ``write`` and ``match`` operations of the CCC descriptor.
+  * Fixed the serialization of the write callback applied to the GATT attribute.
+  * Fixed the serialization of the :c:func:`bt_gatt_service_unregister` function call .
+
 Libraries for networking
 ------------------------
 

--- a/subsys/bluetooth/rpc/host/bt_rpc_gatt_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_gatt_host.c
@@ -306,9 +306,9 @@ ssize_t bt_rpc_normal_attr_write(struct bt_conn *conn, const struct bt_gatt_attr
 	size_t buffer_size_max = 26;
 	size_t scratchpad_size = 0;
 
-	NRF_RPC_CBOR_ALLOC(ctx, buffer_size_max);
-
 	buffer_size_max += len;
+
+	NRF_RPC_CBOR_ALLOC(ctx, buffer_size_max);
 
 	scratchpad_size += SCRATCHPAD_ALIGN(len);
 
@@ -714,7 +714,7 @@ NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_rpc_gatt_end_service, BT_RPC_GATT_END_SE
 
 static void bt_rpc_gatt_service_unregister_rpc_handler(CborValue *value, void *handler_data)
 {
-	int result;
+	int result = 0;
 	uint16_t svc_index;
 	const struct bt_gatt_service *svc;
 


### PR DESCRIPTION
This adds missing callback handlers for a CCC descriptor write and match operation on the host side.