### PR TITLE
samples: nrf9160: at_monitor: add cereg status codes

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -142,6 +142,10 @@ nrf9160 Samples
 
 * Updated:
 
+   * :ref:`at_monitor_sample` sample:
+
+    * Added ``denied``, ``unknown``, ``roaming``, and ``UICC failure`` CEREG status codes to :c:func:`cereg_mon`.
+
   * :ref:`modem_shell_application` sample:
 
     * Added:


### PR DESCRIPTION
The cereg monitor expects the cereg status code to be in the range zero
to two. This is the status codes "not registered", "registered home" and
"searching". However, more status codes can be expected that will now
crash the application if present.
* Add "denied", "unknown", "roaming" and
 "UICC failure" status codes as they can also occur with the
 nRF91 AT commands v2.0 spec.
* Add handling of unexpected status codes to avoid this crashing the
 application.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>