### PR TITLE
samples: nrf9160: modem_shell: AT command mode and pipelining

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -148,7 +148,10 @@ nrf9160 Samples
 
       * An option ``--interval`` (in seconds) to neighbor cell measurements in continuous mode  (``link ncellmeas --continuous``).
         When using this option, a new measurement is started in each interval.
-      * Separate plain AT command mode that can be started by typing: ``at at_cmd_mode start``.
+      * Separate plain AT command mode that can be started with the command ``at at_cmd_mode start``.
+        AT command termination methods can be configured using Kconfig options.
+        The default method, is CR termination.
+        In AT command mode, a maximum of 10 AT commands can be pipelined with ``|`` as the delimiter character between pipelined AT commands.
 
 Drivers
 =======

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -148,6 +148,7 @@ nrf9160 Samples
 
       * An option ``--interval`` (in seconds) to neighbor cell measurements in continuous mode  (``link ncellmeas --continuous``).
         When using this option, a new measurement is started in each interval.
+      * Separate plain AT command mode that can be started by typing: ``at at_cmd_mode start``.
 
 Drivers
 =======

--- a/samples/nrf9160/modem_shell/CMakeLists.txt
+++ b/samples/nrf9160/modem_shell/CMakeLists.txt
@@ -16,11 +16,11 @@ target_include_directories(app PRIVATE
 
 target_sources(app PRIVATE src/main.c)
 target_sources(app PRIVATE src/shell.c)
-target_sources(app PRIVATE src/at/at_shell.c)
 
 add_subdirectory(src/print)
 add_subdirectory(src/utils)
 add_subdirectory(src/uart)
+add_subdirectory(src/at)
 add_subdirectory_ifdef(CONFIG_MOSH_WORKER_THREADS src/th)
 add_subdirectory_ifdef(CONFIG_MOSH_SOCK src/sock)
 add_subdirectory_ifdef(CONFIG_MOSH_LINK src/link)

--- a/samples/nrf9160/modem_shell/Kconfig
+++ b/samples/nrf9160/modem_shell/Kconfig
@@ -98,6 +98,14 @@ config MOSH_PRINT_BUFFER_SIZE
 	  If the printed string exceeds this buffer, an error message is printed first and
 	  then the requested string cut into the length of this buffer.
 
+config MOSH_COMMON_WORKQUEUE_STACK_SIZE
+	int "Common workqueue stack size"
+	default 8192
+
+config MOSH_COMMON_WORKQUEUE_PRIORITY
+	int "Common workqueue priority"
+	default 5
+
 if MOSH_IPERF3
 menu "MoSH iperf3 command selections"
 

--- a/samples/nrf9160/modem_shell/Kconfig
+++ b/samples/nrf9160/modem_shell/Kconfig
@@ -91,6 +91,10 @@ config MOSH_CLOUD
 	help
 	  MQTT connection to nRFCloud.
 
+config MOSH_AT_CMD_MODE
+	bool "Specific AT command mode"
+	default y
+
 config MOSH_PRINT_BUFFER_SIZE
 	int "Buffer size used when printing modem shell output"
 	default 1024
@@ -115,6 +119,34 @@ config MOSH_WORKER_THREADS
 
 endmenu
 endif #MOSH_IPERF3
+
+if MOSH_AT_CMD_MODE
+choice
+	prompt "Command termination"
+	default MOSH_AT_CMD_MODE_CR_TERMINATION
+	help
+		Sets the command termination ending from the serial terminal
+		Levels are:
+		-  NULL Termination
+		-  CR Termination
+		-  LF Termination
+		-  CR+LF Termination
+	config MOSH_AT_CMD_MODE_NULL_TERMINATION
+		bool "NULL Termination"
+	config MOSH_AT_CMD_MODE_CR_TERMINATION
+		bool "CR Termination"
+	config MOSH_AT_CMD_MODE_LF_TERMINATION
+		bool "LF Termination"
+	config MOSH_AT_CMD_MODE_CR_LF_TERMINATION
+		bool "CR+LF Termination"
+endchoice
+config MOSH_AT_CMD_MODE_TERMINATION
+	int
+	default 0 if MOSH_AT_CMD_MODE_NULL_TERMINATION
+	default 1 if MOSH_AT_CMD_MODE_CR_TERMINATION
+	default 2 if MOSH_AT_CMD_MODE_LF_TERMINATION
+	default 3 if MOSH_AT_CMD_MODE_CR_LF_TERMINATION
+endif
 
 if MOSH_LINK
 menu "MoSH link control selections"

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -93,7 +93,7 @@ AT commands
 MoSh command: ``at``
 
 You can use the AT command module to send AT commands to the modem, individually or
-in a separate plain AT command mode.
+in a separate plain AT command mode where also pipelining of AT commands is supported.
 
 Examples
 --------
@@ -136,6 +136,9 @@ Examples
      MoSh AT command mode started, press ctrl-x ctrl-q to escape
      MoSh specific AT commands:
        ICMP Ping: AT+NPING=<addr>[,<payload_length>,<timeout_msecs>,<count>[,<interval_msecs>[,<cid>]]]
+     Other custom functionalities:
+       AT command pipelining, for example:
+         at+cgmr|at+cfun?|at+nping="example.com"
      ===========================================================
      at
      OK

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -92,7 +92,8 @@ AT commands
 
 MoSh command: ``at``
 
-You can use the AT command module to send AT commands to the modem.
+You can use the AT command module to send AT commands to the modem, individually or
+in a separate plain AT command mode.
 
 Examples
 --------
@@ -120,6 +121,24 @@ Examples
   .. code-block:: console
 
      at events_disable
+
+* Enable autostarting of AT command mode in next bootup:
+
+  .. code-block:: console
+
+     at at_cmd_mode enable_autostart
+
+* Start AT command mode:
+
+  .. code-block:: console
+
+     at at_cmd_mode start
+     MoSh AT command mode started, press ctrl-x ctrl-q to escape
+     MoSh specific AT commands:
+       ICMP Ping: AT+NPING=<addr>[,<payload_length>,<timeout_msecs>,<count>[,<interval_msecs>[,<cid>]]]
+     ===========================================================
+     at
+     OK
 
 ----
 

--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -21,8 +21,9 @@ CONFIG_MOSH_LOCATION=y
 # Stacks and heaps
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_HEAP_MEM_POOL_SIZE=10240
-# System queue is used by LTE connection and many other parts
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=8192
+
+# System queue is used e.g. by AT monitor and SMS lib
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 
 # Shell configurations
 CONFIG_SHELL=y

--- a/samples/nrf9160/modem_shell/src/at/CMakeLists.txt
+++ b/samples/nrf9160/modem_shell/src/at/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+target_include_directories(app PRIVATE .)
+
+target_sources(app PRIVATE at_shell.c)
+target_sources_ifdef(CONFIG_MOSH_AT_CMD_MODE app PRIVATE at_cmd_mode.c)
+target_sources_ifdef(CONFIG_MOSH_AT_CMD_MODE app PRIVATE at_cmd_mode_sett.c)
+target_sources_ifdef(CONFIG_MOSH_AT_CMD_MODE app PRIVATE at_cmd.c)
+target_sources_ifdef(CONFIG_MOSH_AT_CMD_MODE app PRIVATE at_cmd_ping.c)

--- a/samples/nrf9160/modem_shell/src/at/at_cmd.c
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+#include <ctype.h>
+
+#include <shell/shell.h>
+
+#include <modem/at_cmd_parser.h>
+
+#include "mosh_defines.h"
+#include "mosh_print.h"
+
+#include "at_cmd_ping.h"
+#include "at_cmd.h"
+
+/* Globals */
+struct at_param_list at_param_list;      /* For AT parser */
+
+/**@brief AT command handler type. */
+typedef int (*mosh_at_handler_t) (enum at_cmd_type);
+
+/* MoSh specific AT commands */
+static struct mosh_at_cmd {
+	char *string;
+	mosh_at_handler_t handler;
+} mosh_at_cmd_list[] = {
+	{"AT+NPING", at_cmd_ping_handle},
+};
+
+#define MOSH_AT_CMD_MAX_PARAM 8
+
+static bool at_cmd_mode_util_mosh_cmd_casecmp(const char *at_cmd, const char *mosh_cmd)
+{
+	int i;
+	int mosh_cmd_len = strlen(mosh_cmd);
+
+	if (strlen(at_cmd) < mosh_cmd_len) {
+		return false;
+	}
+
+	for (i = 0; i < mosh_cmd_len; i++) {
+		if (toupper((int)*(at_cmd + i)) != toupper((int)*(mosh_cmd + i))) {
+			return false;
+		}
+	}
+#if defined(CONFIG_SLM_CR_LF_TERMINATION)
+	if (strlen(at_cmd) > (mosh_cmd_len + 2)) {
+#else
+	if (strlen(at_cmd) > (mosh_cmd_len + 1)) {
+#endif
+		char ch = *(at_cmd + i);
+		/* With parameter, SET TEST, "="; READ, "?" */
+		return ((ch == '=') || (ch == '?'));
+	}
+
+	return true;
+}
+
+int at_cmd_mosh_parse(const char *at_cmd)
+{
+	int ret;
+	int total = ARRAY_SIZE(mosh_at_cmd_list);
+
+	ret = at_params_list_init(&at_param_list, MOSH_AT_CMD_MAX_PARAM);
+	if (ret) {
+		printk("Could not init AT params list, error: %d\n", ret);
+		return ret;
+	}
+	ret = -ENOENT;
+	for (int i = 0; i < total; i++) {
+		if (at_cmd_mode_util_mosh_cmd_casecmp(at_cmd, mosh_at_cmd_list[i].string)) {
+			enum at_cmd_type type = at_parser_cmd_type_get(at_cmd);
+
+			at_params_list_clear(&at_param_list);
+			ret = at_parser_params_from_str(at_cmd, NULL, &at_param_list);
+			if (ret) {
+				printk("Failed to parse AT command %d\n", ret);
+				ret = -EINVAL;
+				break;
+			}
+			ret = mosh_at_cmd_list[i].handler(type);
+			break;
+		}
+	}
+	at_params_list_free(&at_param_list);
+	return ret;
+}

--- a/samples/nrf9160/modem_shell/src/at/at_cmd.c
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd.c
@@ -33,7 +33,11 @@ static struct mosh_at_cmd {
 
 #define MOSH_AT_CMD_MAX_PARAM 8
 
-static bool at_cmd_mode_util_mosh_cmd_casecmp(const char *at_cmd, const char *mosh_cmd)
+/**
+ * @brief Case insensitive string comparison between given at_cmd and supported mosh_cmd.
+ */
+
+static bool at_cmd_mode_util_mosh_cmd(const char *at_cmd, const char *mosh_cmd)
 {
 	int i;
 	int mosh_cmd_len = strlen(mosh_cmd);
@@ -60,7 +64,7 @@ static bool at_cmd_mode_util_mosh_cmd_casecmp(const char *at_cmd, const char *mo
 	return true;
 }
 
-int at_cmd_mosh_parse(const char *at_cmd)
+int at_cmd_mosh_execute(const char *at_cmd)
 {
 	int ret;
 	int total = ARRAY_SIZE(mosh_at_cmd_list);
@@ -72,7 +76,8 @@ int at_cmd_mosh_parse(const char *at_cmd)
 	}
 	ret = -ENOENT;
 	for (int i = 0; i < total; i++) {
-		if (at_cmd_mode_util_mosh_cmd_casecmp(at_cmd, mosh_at_cmd_list[i].string)) {
+		/* Check if given command is MoSh specific AT command */
+		if (at_cmd_mode_util_mosh_cmd(at_cmd, mosh_at_cmd_list[i].string)) {
 			enum at_cmd_type type = at_parser_cmd_type_get(at_cmd);
 
 			at_params_list_clear(&at_param_list);

--- a/samples/nrf9160/modem_shell/src/at/at_cmd.h
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef MOSH_AT_CMD_H
+#define MOSH_AT_CMD_H
+
+int at_cmd_mosh_parse(const char *at_cmd);
+
+#endif /* MOSH_AT_CMD_H */

--- a/samples/nrf9160/modem_shell/src/at/at_cmd.h
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd.h
@@ -7,6 +7,6 @@
 #ifndef MOSH_AT_CMD_H
 #define MOSH_AT_CMD_H
 
-int at_cmd_mosh_parse(const char *at_cmd);
+int at_cmd_mosh_execute(const char *at_cmd);
 
 #endif /* MOSH_AT_CMD_H */

--- a/samples/nrf9160/modem_shell/src/at/at_cmd_mode.c
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd_mode.c
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+
+#include <shell/shell.h>
+#include <modem/at_monitor.h>
+#include <nrf_modem_at.h>
+
+#include "mosh_defines.h"
+#include "mosh_print.h"
+
+#include "at_cmd.h"
+#include "at_cmd_mode.h"
+
+extern struct k_work_q mosh_common_work_q;
+
+bool at_cmd_mode_dont_print;
+
+/** @brief Termination Modes. */
+enum term_modes {
+	MODE_NULL_TERM, /**< Null Termination */
+	MODE_CR, /**< CR Termination */
+	MODE_LF, /**< LF Termination */
+	MODE_CR_LF /**< CR+LF Termination */
+};
+static enum term_modes term_mode;
+
+#define AT_MAX_CMD_LEN 4096
+static uint8_t at_buf[AT_MAX_CMD_LEN];
+
+AT_MONITOR(mosh_at_cmd_mode_handler, ANY, at_cmd_mode_event_handler, PAUSED);
+
+static struct k_work at_cmd_mode_work;
+
+static bool at_cmd_mode_active;
+static bool inside_quotes;
+static bool writing;
+static size_t at_cmd_len;
+
+K_MUTEX_DEFINE(at_buf_mutex);
+
+static void at_cmd_mode_event_handler(const char *response)
+{
+	if (writing) {
+		/* 1st we need to clear current writings */
+		printk("\r");
+		for (int i = 0; i < at_cmd_len; i++) {
+			printk(" ");
+		}
+
+		/* Then print AT notification */
+		printk("\r%s", response);
+
+		/* And at last, print the command that user was writing back */
+		k_mutex_lock(&at_buf_mutex, K_FOREVER);
+		at_buf[at_cmd_len] = '\0';
+		printk("%s", at_buf);
+		k_mutex_unlock(&at_buf_mutex);
+	} else {
+		printk("%s", response);
+	}
+}
+
+static void at_cmd_mode_worker(struct k_work *work)
+{
+	int err;
+
+	ARG_UNUSED(work);
+
+	/* 1st: handle MoSh specific AT commands */
+	err = at_cmd_mosh_parse(at_buf);
+	if (err == 0) {
+		sprintf(at_buf, "OK\n");
+		goto done;
+	} else if (err != -ENOENT) {
+		sprintf(at_buf, "ERROR\n");
+		goto done;
+	}
+
+	/* 2nd: modem at commands */
+	err = nrf_modem_at_cmd(at_buf, sizeof(at_buf), "%s", at_buf);
+	if (err < 0) {
+		sprintf(at_buf, "ERROR: AT command failed: %d\n", err);
+	} /* else if (err > 0): print error from modem */
+done:
+	/* Response */
+	printk("%s", at_buf);
+	return;
+}
+
+static void at_cmd_mode_cmd_rx_handler(uint8_t character)
+{
+	writing = true;
+
+	/* Handle control characters */
+	switch (character) {
+	case 0x08: /* Backspace. */
+		/* Fall through. */
+	case 0x7F: /* DEL character */
+		if (at_cmd_len > 0) {
+			/* Reprint with DEL/Backspace  */
+			k_mutex_lock(&at_buf_mutex, K_FOREVER);
+			at_buf[at_cmd_len] = '\0';
+			at_cmd_len--;
+			at_buf[at_cmd_len] = ' ';
+			printk("\r%s", at_buf);
+			at_buf[at_cmd_len] = '\0';
+			printk("\r%s", at_buf);
+			k_mutex_unlock(&at_buf_mutex);
+		}
+		return;
+	}
+
+	/* Handle termination characters, if outside quotes. */
+	if (!inside_quotes) {
+		switch (character) {
+		case '\0':
+			if (term_mode == MODE_NULL_TERM) {
+				goto send;
+			}
+			/* Ignored null and will terminate string early. */
+			break;
+		case '\r':
+			if (term_mode == MODE_CR) {
+				goto send;
+			}
+			break;
+		case '\n':
+			if (term_mode == MODE_LF) {
+				goto send;
+			}
+			if (term_mode == MODE_CR_LF && at_cmd_len > 0 &&
+			    at_buf[at_cmd_len - 1] == '\r') {
+				goto send;
+			}
+			break;
+		}
+	}
+
+	/* Detect AT command buffer overflow, leaving space for null */
+	if (at_cmd_len + 1 > sizeof(at_buf) - 1) {
+		printk("Buffer overflow, dropping '%c'\n", character);
+		return;
+	}
+
+	/* Write character to AT buffer */
+	k_mutex_lock(&at_buf_mutex, K_FOREVER);
+	at_buf[at_cmd_len] = character;
+	at_cmd_len++;
+	k_mutex_unlock(&at_buf_mutex);
+
+	/* Handle special written character */
+	if (character == '"') {
+		inside_quotes = !inside_quotes;
+	}
+
+	/* Echo */
+	printk("%c", character);
+	return;
+send:
+
+	k_mutex_lock(&at_buf_mutex, K_FOREVER);
+	at_buf[at_cmd_len] = '\0'; /* Terminate the command string */
+
+	inside_quotes = false;
+	at_cmd_len = 0;
+	k_mutex_unlock(&at_buf_mutex);
+
+	/* Check for the presence of one printable non-whitespace character */
+	for (const char *c = at_buf;; c++) {
+		if (*c > ' ') {
+			break;
+		} else if (*c == '\0') {
+			return; /* Drop command, if it has no such character */
+		}
+	}
+
+	/* Echo a line feed */
+	printk("\n");
+
+	writing = false;
+
+	k_work_submit_to_queue(&mosh_common_work_q, &at_cmd_mode_work);
+}
+
+#define CHAR_CAN 0x18
+#define CHAR_DC1 0x11
+
+static void at_cmd_mode_bypass_cb(const struct shell *sh, uint8_t *recv, size_t len)
+{
+	static uint8_t tail;
+	bool escape = false;
+
+	/* Check if escape criteria is met. */
+	if (tail == CHAR_CAN && recv[0] == CHAR_DC1) {
+		escape = true;
+	} else {
+		for (int i = 0; i < (len - 1); i++) {
+			if (recv[i] == CHAR_CAN && recv[i + 1] == CHAR_DC1) {
+				escape = true;
+				break;
+			}
+		}
+	}
+
+	if (escape) {
+		/* Cannot use shell/mosh_print in bybass callback */
+		printk("===========================================================\n");
+		printk("MoSh AT command mode exited\n");
+
+		shell_set_bypass(sh, NULL);
+		at_cmd_mode_dont_print = false;
+		at_monitor_pause(mosh_at_cmd_mode_handler);
+		at_cmd_mode_active = false;
+		inside_quotes = false;
+		tail = 0;
+		at_cmd_len = 0;
+		return;
+	}
+
+	/* Store last byte for escape sequence detection */
+	tail = recv[len - 1];
+
+	/* Handle byte by byte. */
+	for (int i = 0; i < len; i++) {
+		at_cmd_mode_cmd_rx_handler(recv[i]);
+	}
+}
+
+int at_cmd_mode_start(const struct shell *sh)
+{
+	if (at_cmd_mode_active) {
+		printk("AT command mode already started\n");
+		return -EBUSY;
+	}
+
+	k_work_init(&at_cmd_mode_work, at_cmd_mode_worker);
+	at_monitor_resume(mosh_at_cmd_mode_handler);
+
+	term_mode = CONFIG_MOSH_AT_CMD_MODE_TERMINATION;
+
+	at_cmd_mode_active = !at_cmd_mode_active;
+	if (at_cmd_mode_active) {
+		printk("MoSh AT command mode started, press ctrl-x ctrl-q to escape\n");
+		printk("MoSh specific AT commands:\n");
+#if defined(CONFIG_MOSH_PING)
+		printk("  ICMP Ping: ");
+		printk("AT+NPING=<addr>[,<payload_length>,<timeout_msecs>,<count>"
+		       "[,<interval_msecs>[,<cid>]]]\n");
+#endif
+		printk("===========================================================\n");
+		at_cmd_mode_active = true;
+		at_cmd_mode_dont_print = true;
+	}
+
+	at_monitor_resume(mosh_at_cmd_mode_handler);
+	shell_set_bypass(sh, at_cmd_mode_bypass_cb);
+
+	return 0;
+}

--- a/samples/nrf9160/modem_shell/src/at/at_cmd_mode.c
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd_mode.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <string.h>
 #include <stdlib.h>
 
 #include <shell/shell.h>
@@ -29,12 +30,26 @@ enum term_modes {
 };
 static enum term_modes term_mode;
 
-#define AT_MAX_CMD_LEN 4096
-static uint8_t at_buf[AT_MAX_CMD_LEN];
+#define AT_CMD_MODE_AT_CMD_MAX_LEN CONFIG_SHELL_CMD_BUFF_SIZE
+#define AT_CMD_MODE_PIPELINED_AT_CMD_MAX_LEN 1023
+
+static uint8_t at_buf[AT_CMD_MODE_AT_CMD_MAX_LEN + 1];
+static uint8_t at_buf_pipelined[AT_CMD_MODE_PIPELINED_AT_CMD_MAX_LEN + 1];
 
 AT_MONITOR(mosh_at_cmd_mode_handler, ANY, at_cmd_mode_event_handler, PAUSED);
 
-static struct k_work at_cmd_mode_work;
+struct at_cmd_mode_pipelining_info {
+	uint8_t *pipelined_cmd_start; /* Pointers to at_buf with pipelining */
+	int pipelined_cmd_len;
+};
+
+#define AT_MAX_CMD_PIPELINED 10
+struct at_cmd_mode_work_data {
+	struct k_work work;
+	int pipe_cnt;
+	struct at_cmd_mode_pipelining_info pipe_infos[AT_MAX_CMD_PIPELINED];
+};
+static struct at_cmd_mode_work_data at_cmd_mode_work;
 
 static bool at_cmd_mode_active;
 static bool inside_quotes;
@@ -65,31 +80,57 @@ static void at_cmd_mode_event_handler(const char *response)
 	}
 }
 
-static void at_cmd_mode_worker(struct k_work *work)
+static void at_cmd_mode_send_at_cmd(const char *at_str, char *rsp_buf, int rsp_buf_len)
 {
 	int err;
 
-	ARG_UNUSED(work);
-
 	/* 1st: handle MoSh specific AT commands */
-	err = at_cmd_mosh_parse(at_buf);
+	err = at_cmd_mosh_execute(at_str);
 	if (err == 0) {
-		sprintf(at_buf, "OK\n");
+		sprintf(rsp_buf, "OK\n");
 		goto done;
 	} else if (err != -ENOENT) {
-		sprintf(at_buf, "ERROR\n");
+		sprintf(rsp_buf, "ERROR\n");
 		goto done;
 	}
 
 	/* 2nd: modem at commands */
-	err = nrf_modem_at_cmd(at_buf, sizeof(at_buf), "%s", at_buf);
+	err = nrf_modem_at_cmd(rsp_buf, rsp_buf_len, "%s", at_str);
 	if (err < 0) {
-		sprintf(at_buf, "ERROR: AT command failed: %d\n", err);
+		sprintf(rsp_buf, "ERROR: AT command failed: %d\n", err);
 	} /* else if (err > 0): print error from modem */
 done:
 	/* Response */
-	printk("%s", at_buf);
-	return;
+	printk("%s", rsp_buf);
+}
+
+static void at_cmd_mode_send_at_cmd_from_at_buf(void)
+{
+	at_cmd_mode_send_at_cmd(at_buf, at_buf, sizeof(at_buf));
+}
+
+static void at_cmd_mode_worker(struct k_work *item)
+{
+	int i;
+	struct at_cmd_mode_work_data *data = CONTAINER_OF(item, struct at_cmd_mode_work_data, work);
+	struct at_cmd_mode_pipelining_info *pipes = data->pipe_infos;
+
+	if (data->pipe_cnt) {
+		for (i = 0; i < AT_MAX_CMD_PIPELINED; i++) {
+			if (pipes[i].pipelined_cmd_len) {
+				strncpy(at_buf_pipelined, pipes[i].pipelined_cmd_start,
+					pipes[i].pipelined_cmd_len);
+				at_buf_pipelined[pipes[i].pipelined_cmd_len] = '\0';
+
+				at_cmd_mode_send_at_cmd(at_buf_pipelined, at_buf_pipelined,
+							sizeof(at_buf_pipelined));
+				pipes[i].pipelined_cmd_len = 0;
+			}
+		}
+	} else {
+		at_cmd_mode_send_at_cmd_from_at_buf();
+	}
+	data->pipe_cnt = 0;
 }
 
 static void at_cmd_mode_cmd_rx_handler(uint8_t character)
@@ -165,17 +206,41 @@ send:
 
 	k_mutex_lock(&at_buf_mutex, K_FOREVER);
 	at_buf[at_cmd_len] = '\0'; /* Terminate the command string */
-
 	inside_quotes = false;
 	at_cmd_len = 0;
 	k_mutex_unlock(&at_buf_mutex);
 
-	/* Check for the presence of one printable non-whitespace character */
-	for (const char *c = at_buf;; c++) {
-		if (*c > ' ') {
-			break;
-		} else if (*c == '\0') {
-			return; /* Drop command, if it has no such character */
+	/* Scan AT command buffer for possible pipelined at commands */
+	at_cmd_mode_work.pipe_cnt = 0;
+
+	if (strchr(at_buf, '|')) {
+		struct at_cmd_mode_pipelining_info *pipes = at_cmd_mode_work.pipe_infos;
+		char *next_char;
+		char *tmp;
+		int pipelined_at_cmd_len;
+
+		next_char = at_buf;
+		tmp = strtok(next_char, "|");
+
+		while (tmp != NULL) {
+			if (at_cmd_mode_work.pipe_cnt >= AT_MAX_CMD_PIPELINED) {
+				printk("\nMax %d pipelined at commands supported, dropping: \"%s\"",
+				       AT_MAX_CMD_PIPELINED, tmp);
+			} else {
+				pipelined_at_cmd_len = strlen(tmp);
+				if (pipelined_at_cmd_len > AT_CMD_MODE_PIPELINED_AT_CMD_MAX_LEN) {
+					printk("\nPipelined AT cmd max len is %d,"
+					       " too long %d bytes AT cmd dropped",
+					       AT_CMD_MODE_PIPELINED_AT_CMD_MAX_LEN,
+					       pipelined_at_cmd_len);
+				} else {
+					pipes[at_cmd_mode_work.pipe_cnt].pipelined_cmd_start = tmp;
+					pipes[at_cmd_mode_work.pipe_cnt].pipelined_cmd_len =
+						pipelined_at_cmd_len;
+					at_cmd_mode_work.pipe_cnt++;
+				}
+			}
+			tmp = strtok(NULL, "|");
 		}
 	}
 
@@ -184,10 +249,12 @@ send:
 
 	writing = false;
 
-	k_work_submit_to_queue(&mosh_common_work_q, &at_cmd_mode_work);
+	k_work_submit_to_queue(&mosh_common_work_q, &at_cmd_mode_work.work);
 }
 
+/* ctrl + x */
 #define CHAR_CAN 0x18
+/* ctrl + q */
 #define CHAR_DC1 0x11
 
 static void at_cmd_mode_bypass_cb(const struct shell *sh, uint8_t *recv, size_t len)
@@ -238,24 +305,24 @@ int at_cmd_mode_start(const struct shell *sh)
 		return -EBUSY;
 	}
 
-	k_work_init(&at_cmd_mode_work, at_cmd_mode_worker);
-	at_monitor_resume(mosh_at_cmd_mode_handler);
+	k_work_init(&at_cmd_mode_work.work, at_cmd_mode_worker);
+	at_cmd_mode_work.pipe_cnt = 0;
 
 	term_mode = CONFIG_MOSH_AT_CMD_MODE_TERMINATION;
 
-	at_cmd_mode_active = !at_cmd_mode_active;
-	if (at_cmd_mode_active) {
-		printk("MoSh AT command mode started, press ctrl-x ctrl-q to escape\n");
-		printk("MoSh specific AT commands:\n");
+	printk("MoSh AT command mode started, press ctrl-x ctrl-q to escape\n");
+	printk("MoSh specific AT commands:\n");
 #if defined(CONFIG_MOSH_PING)
-		printk("  ICMP Ping: ");
-		printk("AT+NPING=<addr>[,<payload_length>,<timeout_msecs>,<count>"
+	printk("  ICMP Ping: ");
+	printk("AT+NPING=<addr>[,<payload_length>,<timeout_msecs>,<count>"
 		       "[,<interval_msecs>[,<cid>]]]\n");
 #endif
-		printk("===========================================================\n");
-		at_cmd_mode_active = true;
-		at_cmd_mode_dont_print = true;
-	}
+	printk("Other custom functionalities:\n");
+	printk("  AT command pipelining, for example:\n"
+		       "    at+cgmr|at+cfun?|at+nping=\"example.com\"\n");
+	printk("===========================================================\n");
+	at_cmd_mode_dont_print = true;
+	at_cmd_mode_active = true;
 
 	at_monitor_resume(mosh_at_cmd_mode_handler);
 	shell_set_bypass(sh, at_cmd_mode_bypass_cb);

--- a/samples/nrf9160/modem_shell/src/at/at_cmd_mode.h
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd_mode.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef MOSH_AT_CMD_MODE_H
+#define MOSH_AT_CMD_MODE_H
+
+int at_cmd_mode_start(const struct shell *sh);
+
+#endif /* MOSH_AT_CMD_MODE_H */

--- a/samples/nrf9160/modem_shell/src/at/at_cmd_mode_sett.c
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd_mode_sett.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include <drivers/uart.h>
+#include <settings/settings.h>
+
+#include "mosh_print.h"
+#include "at_cmd_mode_sett.h"
+
+#define AT_CMD_MODE_SETT_KEY "at_cmd_mode_settings"
+
+#define AT_CMD_MODE_SETT_AUTOSTART "autostart_enabled"
+
+static bool sett_autostart_enabled;
+
+/******************************************************************************/
+
+/**@brief Callback when settings_load() is called. */
+static int at_cmd_mode_sett_handler(const char *key, size_t len, settings_read_cb read_cb,
+				    void *cb_arg)
+{
+	int ret;
+
+	if (strcmp(key, AT_CMD_MODE_SETT_AUTOSTART) == 0) {
+		ret = read_cb(cb_arg, &sett_autostart_enabled, sizeof(sett_autostart_enabled));
+		if (ret < 0) {
+			mosh_error("Failed to read sett_autostart_enabled, error: %d", ret);
+			return ret;
+		}
+	}
+	return 0;
+}
+
+/******************************************************************************/
+
+int at_cmd_mode_sett_autostart_enabled(bool enabled)
+{
+	const char *key_enabled = AT_CMD_MODE_SETT_KEY "/" AT_CMD_MODE_SETT_AUTOSTART;
+	int err;
+
+	sett_autostart_enabled = enabled;
+
+	mosh_print("at_cmd_mode autostarting %s", ((enabled == true) ? "enabled" : "disabled"));
+
+	err = settings_save_one(key_enabled, &sett_autostart_enabled,
+				sizeof(sett_autostart_enabled));
+	if (err) {
+		mosh_error("sett_autostart_enabled: err %d from settings_save_one()", err);
+		return err;
+	}
+
+	return 0;
+}
+
+bool at_cmd_mode_sett_is_autostart_enabled(void)
+{
+	return sett_autostart_enabled;
+}
+
+/******************************************************************************/
+
+static struct settings_handler cfg = { .name = AT_CMD_MODE_SETT_KEY,
+				       .h_set = at_cmd_mode_sett_handler };
+
+int at_cmd_mode_sett_init(void)
+{
+	int ret = 0;
+
+	sett_autostart_enabled = false;
+
+	ret = settings_subsys_init();
+	if (ret) {
+		mosh_error("Failed to initialize settings subsystem, error: %d", ret);
+		return ret;
+	}
+
+	ret = settings_register(&cfg);
+	if (ret) {
+		mosh_error("Cannot register settings handler %d", ret);
+		return ret;
+	}
+
+	ret = settings_load();
+	if (ret) {
+		mosh_error("Cannot load settings %d", ret);
+		return ret;
+	}
+	return ret;
+}

--- a/samples/nrf9160/modem_shell/src/at/at_cmd_mode_sett.h
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd_mode_sett.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef MOSH_AT_CMD_MODE_SETT_H
+#define MOSH_AT_CMD_MODE_SETT_H
+
+int at_cmd_mode_sett_init(void);
+int at_cmd_mode_sett_autostart_enabled(bool enabled);
+bool at_cmd_mode_sett_is_autostart_enabled(void);
+
+#endif /* MOSH_AT_CMD_MODE_SETT_H */

--- a/samples/nrf9160/modem_shell/src/at/at_cmd_ping.c
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd_ping.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdlib.h>
+
+#include <sys/types.h>
+#include <net/net_ip.h>
+
+#include <shell/shell.h>
+#include <modem/at_cmd_parser.h>
+#include <nrf_modem_at.h>
+
+#include "mosh_defines.h"
+#include "mosh_print.h"
+
+#if defined(CONFIG_MOSH_PING)
+#include "../ping/icmp_ping.h"
+#endif
+#include "at_cmd_ping.h"
+
+extern struct at_param_list at_param_list;
+extern bool at_cmd_mode_dont_print;
+
+#if defined(CONFIG_MOSH_PING)
+static struct icmp_ping_shell_cmd_argv ping_args;
+#endif
+
+/**@brief handle AT+NPING commands
+ *  AT+NPING=<addr>,[<payload_length>,<timeout_msecs>,<count>[,<interval_msecs>[,<cid>]]]
+ *  AT+NPING? READ command not supported
+ *  AT+NPING=? TEST command not supported
+ */
+int at_cmd_ping_handle(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+#if defined(CONFIG_MOSH_PING)
+	int size = ICMP_MAX_URL;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		/* ping is an exception where we want to use mosh_print during AT command mode */
+		at_cmd_mode_dont_print = false;
+
+		icmp_ping_cmd_defaults_set(&ping_args);
+
+		err = at_params_string_get(&at_param_list, 1, ping_args.target_name, &size);
+		if (err < 0 || size == 0) {
+			err = -EINVAL;
+			return err;
+		}
+		ping_args.target_name[size] = '\0';
+
+		if (at_params_valid_count_get(&at_param_list) > 2) {
+			err = at_params_unsigned_int_get(&at_param_list, 2, &ping_args.len);
+			if (err < 0) {
+				return err;
+			}
+		}
+		if (at_params_valid_count_get(&at_param_list) > 3) {
+			err = at_params_unsigned_int_get(&at_param_list, 3, &ping_args.timeout);
+			if (err < 0) {
+				return err;
+			}
+		}
+		if (at_params_valid_count_get(&at_param_list) > 4) {
+			err = at_params_unsigned_int_get(&at_param_list, 4, &ping_args.count);
+			if (err < 0) {
+				return err;
+			};
+		}
+		if (at_params_valid_count_get(&at_param_list) > 5) {
+			err = at_params_unsigned_int_get(&at_param_list, 5, &ping_args.interval);
+			if (err < 0) {
+				return err;
+			};
+		}
+		if (at_params_valid_count_get(&at_param_list) > 6) {
+			err = at_params_int_get(&at_param_list, 6, &ping_args.cid);
+			if (err < 0) {
+				return err;
+			};
+		}
+		err = icmp_ping_start(&ping_args);
+		at_cmd_mode_dont_print = true;
+		break;
+
+	default:
+		break;
+	}
+#endif
+	return err;
+}

--- a/samples/nrf9160/modem_shell/src/at/at_cmd_ping.h
+++ b/samples/nrf9160/modem_shell/src/at/at_cmd_ping.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef MOSH_AT_CMD_ICMP
+#define MOSH_AT_CMD_ICMP
+
+int at_cmd_ping_handle(enum at_cmd_type cmd_type);
+
+#endif /* MOSH_AT_CMD_ICMP */

--- a/samples/nrf9160/modem_shell/src/at/at_shell.c
+++ b/samples/nrf9160/modem_shell/src/at/at_shell.c
@@ -13,16 +13,50 @@
 #include "mosh_defines.h"
 #include "mosh_print.h"
 
+#if defined(CONFIG_MOSH_AT_CMD_MODE)
+#include "at_cmd_mode.h"
+#include "at_cmd_mode_sett.h"
+#endif
+
 static const char at_usage_str[] =
 	"Usage: at <subcommand>\n"
 	"\n"
 	"Subcommands:\n"
 	"  events_enable     Enable AT event handler which prints AT notifications\n"
 	"  events_disable    Disable AT event handler\n"
+#if defined(CONFIG_MOSH_AT_CMD_MODE)
+	"  at_cmd_mode       AT command mode.\n"
+#endif
 	"\n"
 	"Any other subcommand is interpreted as AT command and sent to the modem.\n";
 
 AT_MONITOR(mosh_at_handler, ANY, at_cmd_handler, PAUSED);
+
+#if defined(CONFIG_MOSH_AT_CMD_MODE)
+static int at_shell_cmd_mode_print_help(const struct shell *shell, size_t argc, char **argv)
+{
+	shell_help(shell);
+
+	return 1;
+}
+
+static int at_shell_cmd_mode_start(const struct shell *shell, size_t argc, char **argv)
+{
+	at_cmd_mode_start(shell);
+	return 0;
+}
+
+static int at_shell_cmd_mode_enable_autostart(const struct shell *shell, size_t argc, char **argv)
+{
+	at_cmd_mode_sett_autostart_enabled(true);
+	return 0;
+}
+static int at_shell_cmd_mode_disable_autostart(const struct shell *shell, size_t argc, char **argv)
+{
+	at_cmd_mode_sett_autostart_enabled(false);
+	return 0;
+}
+#endif
 
 static void at_cmd_handler(const char *response)
 {
@@ -62,3 +96,28 @@ int at_shell(const struct shell *shell, size_t argc, char **argv)
 
 	return 0;
 }
+
+#if defined(CONFIG_MOSH_AT_CMD_MODE)
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_at_cmd_mode,
+	SHELL_CMD(start, NULL,
+		  "Start AT command mode.",
+		  at_shell_cmd_mode_start),
+	SHELL_CMD(enable_autostart, NULL,
+		  "Enable AT command autostart on bootup.",
+		  at_shell_cmd_mode_enable_autostart),
+	SHELL_CMD(disable_autostart, NULL,
+		 "Disable AT command mode autostart on bootup.",
+		  at_shell_cmd_mode_disable_autostart),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_at_shell,
+			       SHELL_CMD(at_cmd_mode, &sub_at_cmd_mode,
+					 "Enable/disable AT command mode.",
+					 at_shell_cmd_mode_print_help),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(at, &sub_at_shell, "Execute an AT command.", at_shell);
+#else
+SHELL_CMD_REGISTER(at, NULL, "Execute an AT command.", at_shell);
+#endif

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -52,6 +52,11 @@
 #include "location_shell.h"
 #endif
 
+#if defined(CONFIG_MOSH_AT_CMD_MODE)
+#include "at_cmd_mode.h"
+#include "at_cmd_mode_sett.h"
+#endif
+
 /***** Work queue and work item definitions *****/
 
 #define MOSH_COMMON_WORKQ_PRIORITY CONFIG_MOSH_COMMON_WORKQUEUE_PRIORITY
@@ -217,4 +222,12 @@ void main(void)
 	shell_execute_cmd(shell, "resize");
 	/* Run empty command because otherwise "resize" would be set to the command line. */
 	shell_execute_cmd(shell, "");
+
+#if defined(CONFIG_MOSH_AT_CMD_MODE)
+	at_cmd_mode_sett_init();
+	if (at_cmd_mode_sett_is_autostart_enabled()) {
+		/* Start directly in AT cmd mode */
+		at_cmd_mode_start(shell);
+	}
+#endif
 }

--- a/samples/nrf9160/modem_shell/src/ping/icmp_ping.c
+++ b/samples/nrf9160/modem_shell/src/ping/icmp_ping.c
@@ -750,5 +750,5 @@ exit:
 	if (pdp_context_info_tbl.array != NULL) {
 		free(pdp_context_info_tbl.array);
 	}
-	return -1;	
+	return -1;
 }

--- a/samples/nrf9160/modem_shell/src/ping/icmp_ping.h
+++ b/samples/nrf9160/modem_shell/src/ping/icmp_ping.h
@@ -56,11 +56,19 @@ struct icmp_ping_shell_cmd_argv {
 /**
  * @brief ICMP initiator.
  *
- * @param target_name Target domain name.
+ * @param ping_args Ping parameters.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
 int icmp_ping_start(struct icmp_ping_shell_cmd_argv *ping_args);
+
+/**
+ * @brief Set ICMP ping defaults.
+ *
+ * @param ping_args Ping parameters.
+ *
+ */
+void icmp_ping_cmd_defaults_set(struct icmp_ping_shell_cmd_argv *ping_args);
 
 #endif /* MOSH_ICMP_PING_H */

--- a/samples/nrf9160/modem_shell/src/ping/icmp_ping_shell.c
+++ b/samples/nrf9160/modem_shell/src/ping/icmp_ping_shell.c
@@ -52,59 +52,14 @@ static void icmp_ping_shell_usage_print(void)
 	mosh_print_no_format(icmp_ping_shell_cmd_usage_str);
 }
 
-static void
-icmp_ping_shell_cmd_defaults_set(struct icmp_ping_shell_cmd_argv *ping_args)
-{
-	memset(ping_args, 0, sizeof(struct icmp_ping_shell_cmd_argv));
-	/* ping_args->dest = NULL; */
-	ping_args->count = ICMP_PARAM_COUNT_DEFAULT;
-	ping_args->interval = ICMP_PARAM_INTERVAL_DEFAULT;
-	ping_args->timeout = ICMP_PARAM_TIMEOUT_DEFAULT;
-	ping_args->len = ICMP_PARAM_LENGTH_DEFAULT;
-	ping_args->cid = MOSH_ARG_NOT_SET;
-	ping_args->pdn_id_for_cid = MOSH_ARG_NOT_SET;
-}
-
-static bool icmp_ping_shell_set_ping_args_according_to_pdp_ctx(
-	struct icmp_ping_shell_cmd_argv *ping_args,
-	struct pdp_context_info_array *ctx_info_tbl)
-{
-	/* Find PDP context info for requested CID: */
-	int i;
-	bool found = false;
-
-	for (i = 0; i < ctx_info_tbl->size; i++) {
-		if (ctx_info_tbl->array[i].cid == ping_args->cid) {
-			ping_args->current_pdp_type = ctx_info_tbl->array[i].pdp_type;
-			ping_args->current_addr4 = ctx_info_tbl->array[i].ip_addr4;
-			ping_args->current_addr6 = ctx_info_tbl->array[i].ip_addr6;
-
-			if (ctx_info_tbl->array[i].pdn_id_valid) {
-				ping_args->pdn_id_for_cid = ctx_info_tbl->array[i].pdn_id;
-			}
-
-			strcpy(ping_args->current_apn_str, ctx_info_tbl->array[i].apn_str);
-
-			if (ctx_info_tbl->array[0].ipv4_mtu != 0) {
-				ping_args->mtu = ctx_info_tbl->array[0].ipv4_mtu;
-			} else {
-				ping_args->mtu = ICMP_DEFAULT_LINK_MTU;
-			}
-
-			found = true;
-		}
-	}
-	return found;
-}
 /*****************************************************************************/
 
 int icmp_ping_shell(const struct shell *shell, size_t argc, char **argv)
 {
 	struct icmp_ping_shell_cmd_argv ping_args;
-	struct pdp_context_info_array pdp_context_info_tbl = { 0 };
-	int flag, dest_len, ret;
+	int flag, dest_len;
 
-	icmp_ping_shell_cmd_defaults_set(&ping_args);
+	icmp_ping_cmd_defaults_set(&ping_args);
 
 	if (argc < 3) {
 		goto show_usage;
@@ -199,63 +154,9 @@ int icmp_ping_shell(const struct shell *shell, size_t argc, char **argv)
 		goto show_usage;
 	}
 
-	/* All good for args, get the current connection info and start the ping: */
-	ret = link_api_pdp_contexts_read(&pdp_context_info_tbl);
-	if (ret) {
-		mosh_error("cannot read current connection info: %d", ret);
-		goto show_usage;
-	}
-
-	if (pdp_context_info_tbl.size > 0) {
-		/* Default context: */
-		if (ping_args.cid == MOSH_ARG_NOT_SET) {
-			ping_args.current_pdp_type = pdp_context_info_tbl.array[0].pdp_type;
-			ping_args.current_addr4 = pdp_context_info_tbl.array[0].ip_addr4;
-			ping_args.current_addr6 = pdp_context_info_tbl.array[0].ip_addr6;
-			if (pdp_context_info_tbl.array[0].ipv4_mtu != 0) {
-				ping_args.mtu =	pdp_context_info_tbl.array[0].ipv4_mtu;
-			} else {
-				ping_args.mtu = ICMP_DEFAULT_LINK_MTU;
-			}
-		} else {
-			bool found = icmp_ping_shell_set_ping_args_according_to_pdp_ctx(
-				&ping_args, &pdp_context_info_tbl);
-
-			if (!found) {
-				mosh_error("cannot find CID: %d", ping_args.cid);
-				goto exit;
-			}
-		}
-	} else {
-		mosh_error("cannot read current connection info");
-		goto exit;
-	}
-
-	if (pdp_context_info_tbl.array != NULL) {
-		free(pdp_context_info_tbl.array);
-	}
-
-	/* Now we can check the max payload len vs link MTU (IPv6 check later): */
-	uint32_t ipv4_max_payload_len = ping_args.mtu - ICMP_IPV4_HDR_LEN - ICMP_HDR_LEN;
-
-	if (!ping_args.force_ipv6 && ping_args.len > ipv4_max_payload_len) {
-		mosh_warn(
-			"Payload size exceeds the link limits: MTU %d - headers %d = %d ",
-			ping_args.mtu,
-			(ICMP_IPV4_HDR_LEN - ICMP_HDR_LEN),
-			ipv4_max_payload_len);
-		/* Execute ping anyway */
-	}
-
 	return icmp_ping_start(&ping_args);
 
 show_usage:
 	icmp_ping_shell_usage_print();
-
-exit:
-	if (pdp_context_info_tbl.array != NULL) {
-		free(pdp_context_info_tbl.array);
-	}
-
 	return -1;
 }

--- a/samples/nrf9160/modem_shell/src/ppp/ppp_ctrl.c
+++ b/samples/nrf9160/modem_shell/src/ppp/ppp_ctrl.c
@@ -35,6 +35,8 @@
 #include "ppp_settings.h"
 #include "ppp_ctrl.h"
 
+extern struct k_work_q mosh_common_work_q;
+
 /* ppp globals: */
 struct net_if *ppp_iface_global;
 K_SEM_DEFINE(ppp_sockets_sem, 0, 2);
@@ -206,7 +208,7 @@ ppp_ctrl_net_mgmt_event_ipv4_levelhandler(struct net_mgmt_event_callback *cb,
 		 */
 		if (!ppp_closing) {
 			mosh_print("PPP: restarting...");
-			k_work_submit(&ppp_ctrl_restart_work);
+			k_work_submit_to_queue(&mosh_common_work_q, &ppp_ctrl_restart_work);
 		}
 	}
 }
@@ -279,7 +281,7 @@ void ppp_ctrl_init(void)
 void ppp_ctrl_default_pdn_active(bool default_pdn_active)
 {
 	ppp_ctrl_pdn_status_worker_data.default_pdn_active = default_pdn_active;
-	k_work_submit(&ppp_ctrl_pdn_status_worker_data.work);
+	k_work_submit_to_queue(&mosh_common_work_q, &ppp_ctrl_pdn_status_worker_data.work);
 }
 
 /******************************************************************************/

--- a/samples/nrf9160/modem_shell/src/shell.c
+++ b/samples/nrf9160/modem_shell/src/shell.c
@@ -14,7 +14,6 @@
 #if defined(CONFIG_LWM2M_CARRIER)
 #include <lwm2m_carrier.h>
 #endif
-#include "at/at_shell.h"
 #if defined(CONFIG_MOSH_PING)
 #include "ping/icmp_ping_shell.h"
 #endif
@@ -180,8 +179,6 @@ static int cmd_curl(const struct shell *shell, size_t argc, char **argv)
 }
 SHELL_CMD_REGISTER(curl, NULL, "For curl usage, just type \"curl --manual\"", cmd_curl);
 #endif
-
-SHELL_CMD_REGISTER(at, NULL, "Execute an AT command.", at_shell);
 
 #if defined(CONFIG_MOSH_SOCK)
 SHELL_CMD_REGISTER(sock, NULL,

--- a/samples/nrf9160/modem_shell/src/sock/sock.c
+++ b/samples/nrf9160/modem_shell/src/sock/sock.c
@@ -28,6 +28,7 @@
 #include "mosh_print.h"
 
 extern struct k_poll_signal mosh_signal;
+extern struct k_work_q mosh_common_work_q;
 
 /* Maximum number of sockets takes into account AT command socket */
 #define MAX_SOCKETS (CONFIG_POSIX_MAX_FDS - 1)
@@ -744,7 +745,8 @@ static void data_send_work_handler(struct k_work *item)
 		data_send_info_ptr->data_format_hex);
 
 	if (ret != -ECANCELED) {
-		k_work_schedule(&socket_info->send_info.work,
+		k_work_schedule_for_queue(&mosh_common_work_q,
+				&socket_info->send_info.work,
 				K_SECONDS(socket_info->send_info.interval));
 	}
 }
@@ -923,7 +925,8 @@ int sock_send_data(
 				&socket_info->send_info.work,
 				data_send_work_handler);
 			/* Send immediately for the first time */
-			k_work_schedule(&socket_info->send_info.work, K_SECONDS(0));
+			k_work_schedule_for_queue(&mosh_common_work_q, &socket_info->send_info.work,
+						  K_SECONDS(0));
 		}
 
 	} else if (data_out != NULL && data_out_length > 0) {

--- a/samples/nrf9160/modem_shell/src/utils/mosh_print.c
+++ b/samples/nrf9160/modem_shell/src/utils/mosh_print.c
@@ -19,6 +19,10 @@
 
 static const struct shell *mosh_shell;
 
+#if defined(CONFIG_MOSH_AT_CMD_MODE)
+extern bool at_cmd_mode_dont_print;
+#endif
+
 /** Configuration on whether timestamps are added to the print. */
 bool mosh_print_timestamp_use;
 
@@ -81,6 +85,12 @@ void mosh_fprintf(enum mosh_print_level print_level, const char *fmt, ...)
 	va_list args;
 	int chars = 0;
 	const char *timestamp;
+
+#if defined(CONFIG_MOSH_AT_CMD_MODE)
+	if (at_cmd_mode_dont_print) {
+		return;
+	}
+#endif
 
 	k_mutex_lock(&mosh_print_buf_mutex, K_FOREVER);
 


### PR DESCRIPTION
This PR adds a separate plain AT command mode with AT command pipelining support to MoSh.
Additionally, as an enabler, a common workq implemented and taken into use within MoSh.