### PR TITLE
doc: Gazell RF front-end module cleanup

### DIFF
--- a/doc/nrf/ug_gzll.rst
+++ b/doc/nrf/ug_gzll.rst
@@ -30,7 +30,6 @@ Gazell Link Layer provides the following features:
   * No polling packets are required to maintain a link.
   * Devices can enter and remove themselves from the network at any time.
 
-* Capability to control the RF front-end module.
 * Generates transmission statistics for each RF channel.
 
 .. _ug_gzll_configuration:


### PR DESCRIPTION
The Gazell in NCS does not support RF front-end module yet.
Remove the corresponding line in supported features.
