### PR TITLE
dfu: dfu_target: Add an API for clearing dfu_target_stream progress

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -212,6 +212,15 @@ Libraries for networking
 
     * An issue where downloads of COAP URIs would fail when they contained multiple path elements.
 
+DFU libraries
+-------------
+
+* Updated:
+
+  * :ref:`lib_dfu_target` library:
+
+    * Added the :c:func:`dfu_target_stream_clear_progress` function, which resets the offset of the flash stream DFU Target.
+
 sdk-nrfxlib
 -----------
 

--- a/include/dfu/dfu_target_stream.h
+++ b/include/dfu/dfu_target_stream.h
@@ -91,13 +91,23 @@ int dfu_target_stream_write(const uint8_t *buf, size_t len);
 
 /**
  * @brief De-initialize resources and finalize stream flash write if successful.
-
+ *
  * @param[in] successful Indicate whether the firmware was successfully
  * received.
  *
  * @return Non-negative value on success, negative errno otherwise.
  */
 int dfu_target_stream_done(bool successful);
+
+/**
+ * @brief Clear the firmware download progress.
+ *
+ * This resets the firmware upgrade offset to 0, to ensure that an aborted
+ * download is not resumed when `CONFIG_DFU_TARGET_STREAM_SAVE_PROGRESS` is set.
+ *
+ * @return Non-negative value on success, negative errno otherwise.
+ */
+int dfu_target_stream_clear_progress(void);
 
 #endif /* DFU_TARGET_STREAM_H__ */
 

--- a/subsys/dfu/dfu_target/src/dfu_target_stream.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_stream.c
@@ -45,6 +45,17 @@ static int store_progress(void)
 	return 0;
 }
 
+static int clear_progress(void)
+{
+	int err = settings_delete(current_name_key);
+
+	if (err != 0) {
+		LOG_ERR("setting_delete error %d", err);
+	}
+
+	return err;
+}
+
 /**
  * @brief Function used by settings_load() to restore the stream_flash ctx.
  *	  See the Zephyr documentation of the settings subsystem for more
@@ -196,10 +207,7 @@ int dfu_target_stream_done(bool successful)
 		/* Delete state so that a new call to 'init' will
 		 * start with offset 0.
 		 */
-		err = settings_delete(current_name_key);
-		if (err != 0) {
-			LOG_ERR("setting_delete error %d", err);
-		}
+		err = clear_progress();
 
 	} else {
 		/* The stream has not completed, store the progress so that
@@ -213,6 +221,18 @@ int dfu_target_stream_done(bool successful)
 	}
 
 	current_id = NULL;
+
+	return err;
+}
+
+int dfu_target_stream_clear_progress(void)
+{
+	int err = 0;
+
+#ifdef CONFIG_DFU_TARGET_STREAM_SAVE_PROGRESS
+	err = clear_progress();
+#endif
+	stream.bytes_written = 0;
 
 	return err;
 }


### PR DESCRIPTION
Added dfu_target_stream_clear_progress() for resetting the offset to 0
and deleting it from settings (when DFU_TARGET_STREAM_SAVE_PROGRESS=y).
This allows the user to avoid resuming an aborted download.

Signed-off-by: Grzegorz Swiderski <grzegorz.swiderski@nordicsemi.no>