### PR TITLE
manifest: Update SoftDevice Controller revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -108,7 +108,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: c72e91d8014fe257fa4112664d213d80ae30c8c6
+      revision: f215460bec9869a2122059af28550792358a77e5
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Fixed an issue where reading advertiser radio output
power using the vendor-specific HCI command
Zephyr Read TX Power Level returned "Unknown Advertiser Identifier"

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>