### PR TITLE
samples: Bluetooth: df: Add build_only to DF sample.yaml

### DIFF
--- a/samples/bluetooth/direction_finding_central/sample.yaml
+++ b/samples/bluetooth/direction_finding_central/sample.yaml
@@ -3,7 +3,7 @@ sample:
   description: Sample application showing central role of Direction Finding in connected mode
 tests:
   sample.bluetooth.direction_finding_central:
-    harness: bluetooth
+    build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
@@ -12,7 +12,7 @@ tests:
         - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_central.aod:
     extra_args: OVERLAY_CONFIG="overlay-aod.conf"
-    harness: bluetooth
+    build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:

--- a/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
@@ -3,7 +3,7 @@ sample:
   description: Sample application showing connectionless Direction Finding reception
 tests:
   sample.bluetooth.direction_finding_connectionless_rx:
-    harness: bluetooth
+    build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
@@ -12,7 +12,7 @@ tests:
         - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless_rx.aod:
     extra_args: OVERLAY_CONFIG="overlay-aod.conf"
-    harness: bluetooth
+    build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:

--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -3,7 +3,7 @@ sample:
   description: Sample application showing connectionless Direction Finding transmission
 tests:
   sample.bluetooth.direction_finding_connectionless:
-    harness: bluetooth
+    build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
@@ -12,7 +12,7 @@ tests:
         - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless.aoa:
     extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
-    harness: bluetooth
+    build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:

--- a/samples/bluetooth/direction_finding_peripheral/sample.yaml
+++ b/samples/bluetooth/direction_finding_peripheral/sample.yaml
@@ -3,7 +3,7 @@ sample:
   description: Sample application showing peripheral role of Direction Finding in connected mode
 tests:
   sample.bluetooth.direction_finding_peripheral:
-    harness: bluetooth
+    build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:
@@ -12,7 +12,7 @@ tests:
         - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_peripheral.aod:
     extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
-    harness: bluetooth
+    build_only: true
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:


### PR DESCRIPTION
The direction finding samples didn't include build_only in
samples.yaml. Some of them could be executed on hardware by
CI. That ends with CI failures.
The samples should not be used by CI in standalone setup
for testing purposes because they depend on the availability
of other communication site, for example connectionless RX
requires connectionless TX sample to be run in parallel.

The commit fixes possible problem by adding build_only
to sample.yaml files in all DF samples.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>