### PR TITLE
caf: modules: buttons: use DEVICE_DT_GET_OR_NULL

### DIFF
--- a/include/caf/gpio_pins.h
+++ b/include/caf/gpio_pins.h
@@ -7,13 +7,6 @@
 #ifndef _GPIO_PINS_H_
 #define _GPIO_PINS_H_
 
-static const char * const port_map[] = {
-	COND_CODE_1(DT_NODE_HAS_STATUS(DT_NODELABEL(gpio0), okay),
-			(DT_LABEL(DT_NODELABEL(gpio0))), (NULL)),
-	COND_CODE_1(DT_NODE_HAS_STATUS(DT_NODELABEL(gpio1), okay),
-			(DT_LABEL(DT_NODELABEL(gpio1))), (NULL))
-};
-
 struct gpio_pin {
 	uint8_t port;
 	uint8_t pin;


### PR DESCRIPTION
GPIO ports can be obtained at compile time, so simplify the
implementation by using DEVICE_DT_GET_OR_NULL (since port is optional).