### PR TITLE
bluetooth: controller: use DEVICE_DT_GET

### DIFF
--- a/subsys/bluetooth/controller/crypto.c
+++ b/subsys/bluetooth/controller/crypto.c
@@ -21,16 +21,12 @@
 
 #define BT_ECB_BLOCK_SIZE 16
 
+static const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(rng));
+
 int bt_rand(void *buf, size_t len)
 {
-	static const struct device *dev;
-
-	if (unlikely(!dev)) {
-		dev = device_get_binding(DT_LABEL(DT_NODELABEL(rng)));
-
-		if (!dev) {
-			return -ENODEV;
-		}
+	if (unlikely(!device_is_ready(dev))) {
+		return -ENODEV;
 	}
 
 	return entropy_get_entropy(dev, (uint8_t *)buf, len);

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -434,7 +434,7 @@ static void receive_work_handler(struct k_work *work)
 	hci_driver_receive_process();
 }
 
-static const struct device *entropy_source;
+static const struct device *entropy_source = DEVICE_DT_GET(DT_NODELABEL(rng));
 
 static uint8_t rand_prio_low_vector_get(uint8_t *p_buff, uint8_t length)
 {
@@ -713,9 +713,8 @@ static int hci_driver_open(void)
 		return err;
 	}
 
-	entropy_source = device_get_binding(DT_LABEL(DT_NODELABEL(rng)));
-	if (!entropy_source) {
-		BT_ERR("An entropy source is required");
+	if (!device_is_ready(entropy_source)) {
+		BT_ERR("Entropy source device not ready");
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Simplify implementation by using DEVICE_DT_GET, since rng device can be
obtained at compile time.