### PR TITLE
net: lib: azure_iot_hub: add native TLS support

### DIFF
--- a/doc/nrf/libraries/networking/azure_iot_hub.rst
+++ b/doc/nrf/libraries/networking/azure_iot_hub.rst
@@ -156,6 +156,7 @@ Configure the following parameters when using this library:
 * :kconfig:option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID_APP` - Used to provide the device ID at run time.
 * :kconfig:option:`CONFIG_AZURE_IOT_HUB_DPS` - Enables Azure IoT Hub DPS.
 * :kconfig:option:`CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE` - Sets the Azure IoT Hub DPS ID scope that is used while provisioning the device.
+* :kconfig:option:`CONFIG_AZURE_IOT_HUB_NATIVE_TLS` - Configures the socket to be native for TLS instead of offloading TLS operations to the modem.
 
 API documentation
 *****************

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -464,7 +464,9 @@ Libraries for networking
     * Added support for using location assistance when using Coiote LwM2M server.
     * Updated the library to store credentials and server settings permanently on bootstrap.
 
+  * :ref:`lib_azure_iot_hub` library:
 
+    * Added :kconfig:option:`CONFIG_AZURE_IOT_HUB_NATIVE_TLS` option to configure the socket to be native for TLS instead of offloading TLS operations to the modem.
 
 Libraries for NFC
 -----------------
@@ -477,7 +479,6 @@ Libraries for NFC
 
       * :c:func:`nfc_ndef_msg_parse` with a fix to the declaration, a new assertion to avoid a potential usage fault, and added a note in the function documentation.
       * ``NFC_NDEF_PARSER_REQUIRED_MEMO_SIZE_CALC`` macro has been renamed to :c:macro:`NFC_NDEF_PARSER_REQUIRED_MEM`.
-
 
 Other libraries
 ---------------

--- a/subsys/net/lib/azure_iot_hub/Kconfig
+++ b/subsys/net/lib/azure_iot_hub/Kconfig
@@ -158,6 +158,13 @@ config AZURE_IOT_HUB_DPS
 	  is provided, or alternatively the device ID provided by the
 	  application if AZURE_IOT_HUB_DEVICE_ID_APP is enabled.
 
+config AZURE_IOT_HUB_NATIVE_TLS
+	bool "Enable native TLS socket"
+	help
+	  Enabling this option will configure the socket to be native for TLS
+	  instead of offloading TLS operations to the modem.
+
+
 if AZURE_IOT_HUB_DPS
 
 config AZURE_IOT_HUB_DPS_ID_SCOPE

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -849,6 +849,7 @@ static int client_broker_init(struct mqtt_client *const client, bool dps)
 	tls_cfg->sec_tag_count		= ARRAY_SIZE(sec_tag_list);
 	tls_cfg->sec_tag_list		= sec_tag_list;
 	tls_cfg->session_cache		= TLS_SESSION_CACHE_DISABLED;
+	tls_cfg->set_native_tls		= IS_ENABLED(CONFIG_AZURE_IOT_HUB_NATIVE_TLS);
 
 #if defined(CONFIG_AZURE_IOT_HUB_PROVISION_CERTIFICATES)
 	err = certificates_provision();


### PR DESCRIPTION
This commit adds native TLS support.
Applications cannot directly interact with the socket creation
at runtime when using this library, so a new Kconfig option
is added to enable the user to indirectly configure the socket
to use native TLS instead of offloading the TLS operations to the
modem.

Signed-off-by: Mirko Covizzi mirko.covizzi@nordicsemi.no

sdk-zephyr: https://github.com/nrfconnect/sdk-zephyr/pull/761