### PR TITLE
caf: modules: sensor_manager: use device references

### DIFF
--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/app.overlay
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/app.overlay
@@ -1,5 +1,5 @@
 / {
-	sensor-sim {
+	sensor_sim: sensor-sim {
 		compatible = "nordic,sensor-sim";
 		label = "SENSOR_SIM";
 		acc-signal = "wave";

--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/sensor_manager_def.h
@@ -33,7 +33,7 @@ static const struct sm_sampled_channel accel_chan[] = {
 
 static const struct sm_sensor_config sensor_configs[] = {
 	{
-		.dev_name = "SENSOR_SIM",
+		.dev = DEVICE_DT_GET(DT_NODELABEL(sensor_sim)),
 		.event_descr = CONFIG_ML_APP_SENSOR_EVENT_DESCR,
 		.chans = accel_chan,
 		.chan_cnt = ARRAY_SIZE(accel_chan),

--- a/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/app.overlay
+++ b/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/app.overlay
@@ -5,7 +5,7 @@
 };
 
 / {
-	sensor-sim {
+	sensor_sim: sensor-sim {
 		compatible = "nordic,sensor-sim";
 		label = "SENSOR_SIM";
 		acc-signal = "wave";

--- a/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/sensor_manager_def.h
@@ -33,7 +33,7 @@ static const struct sm_sampled_channel accel_chan[] = {
 
 static const struct sm_sensor_config sensor_configs[] = {
 	{
-		.dev_name = "SENSOR_SIM",
+		.dev = DEVICE_DT_GET(DT_NODELABEL(sensor_sim)),
 		.event_descr = CONFIG_ML_APP_SENSOR_EVENT_DESCR,
 		.chans = accel_chan,
 		.chan_cnt = ARRAY_SIZE(accel_chan),

--- a/applications/machine_learning/configuration/thingy52_nrf52832/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/thingy52_nrf52832/sensor_manager_def.h
@@ -25,7 +25,7 @@ static const struct sm_sampled_channel accel_chan[] = {
 
 static const struct sm_sensor_config sensor_configs[] = {
 	{
-		.dev_name = "LIS2DH12-ACCEL",
+		.dev = DEVICE_DT_GET(DT_NODELABEL(lis2dh12)),
 		.event_descr = CONFIG_ML_APP_SENSOR_EVENT_DESCR,
 		.chans = accel_chan,
 		.chan_cnt = ARRAY_SIZE(accel_chan),

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/sensor_manager_def.h
@@ -40,7 +40,7 @@ static const struct sm_sampled_channel accel_chan[] = {
 
 static const struct sm_sensor_config sensor_configs[] = {
 	{
-		.dev_name = "ADXL362",
+		.dev = DEVICE_DT_GET(DT_NODELABEL(adxl362)),
 		.event_descr = CONFIG_ML_APP_SENSOR_EVENT_DESCR,
 		.chans = accel_chan,
 		.chan_cnt = ARRAY_SIZE(accel_chan),

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/sensor_manager_def.h
@@ -40,7 +40,7 @@ static const struct sm_sampled_channel accel_chan[] = {
 
 static const struct sm_sensor_config sensor_configs[] = {
 	{
-		.dev_name = "ADXL362",
+		.dev = DEVICE_DT_GET(DT_NODELABEL(adxl362)),
 		.event_descr = CONFIG_ML_APP_SENSOR_EVENT_DESCR,
 		.chans = accel_chan,
 		.chan_cnt = ARRAY_SIZE(accel_chan),

--- a/include/caf/sensor_manager.h
+++ b/include/caf/sensor_manager.h
@@ -11,6 +11,7 @@
 extern "C" {
 #endif
 
+#include <device.h>
 #include <drivers/sensor.h>
 
 enum act_type {
@@ -49,12 +50,9 @@ struct sm_sampled_channel {
  */
 struct sm_sensor_config {
 	/**
-	 * @brief Device name
-	 *
-	 * The device name that would be used to access the interface
-	 * using device_get_binding().
+	 * @brief Device
 	 */
-	const char *dev_name;
+	const struct device *dev;
 	/**
 	 * @brief Event descriptor
 	 *


### PR DESCRIPTION
Use `const struct device *` in `struct sm_sensor_config` instead of
device name, since device references can be obtained at compile time
using DEVICE_DT_GET().