### PR TITLE
gazell: s/device_get_binding/DEVICE_DT_GET*

### DIFF
--- a/subsys/gazell/gzll_glue.c
+++ b/subsys/gazell/gzll_glue.c
@@ -86,7 +86,7 @@ static void gazell_swi_irq_handler(void *args)
 bool gzll_glue_init(void)
 {
 	bool is_ok = true;
-	const struct device *clkctrl;
+	const struct device *clkctrl = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 	nrfx_err_t err_code;
 	nrf_ppi_channel_t ppi_channel[3];
 	uint8_t i;
@@ -114,8 +114,7 @@ bool gzll_glue_init(void)
 			   gazell_radio_irq_handler,
 			   0);
 
-	clkctrl = device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
-	if (clkctrl == NULL) {
+	if (!device_is_ready(clkctrl)) {
 		is_ok = false;
 	}
 

--- a/subsys/gazell/gzp.c
+++ b/subsys/gazell/gzp.c
@@ -45,11 +45,11 @@ static enum gzp_key_select gzp_key_select;
 #endif
 
 #if defined(CONFIG_GAZELL_PAIRING_CRYPT) || defined(CONFIG_GAZELL_PAIRING_HOST)
-static const struct device *entropy_dev;
+static const struct device *entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 #endif
 
 #ifdef CONFIG_GAZELL_PAIRING_CRYPT
-static const struct device *crypto_dev;
+static const struct device *crypto_dev = DEVICE_DT_GET_ONE(nordic_nrf_ecb);
 #endif
 
 #ifdef CONFIG_GAZELL_PAIRING_CRYPT
@@ -61,13 +61,11 @@ static uint8_t gzp_dyn_key[GZP_DYN_KEY_LENGTH];
 void gzp_init_internal(void)
 {
 #if defined(CONFIG_GAZELL_PAIRING_CRYPT) || defined(CONFIG_GAZELL_PAIRING_HOST)
-	entropy_dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
-	__ASSERT(entropy_dev, "Cannot get entropy device binding");
+	__ASSERT(device_is_ready(entropy_dev), "Entropy device not ready");
 #endif
 
 #ifdef CONFIG_GAZELL_PAIRING_CRYPT
-	crypto_dev = device_get_binding(CRYPTO_DEV_NAME);
-	__ASSERT(crypto_dev, "Cannot get crypto device binding");
+	__ASSERT(device_is_ready(crypto_dev), "Crypto device not ready");
 #endif
 }
 


### PR DESCRIPTION
All devices in the gazell subsys can be obtained at compile time, so use
the DEVICE_DT_GET* macros.