### PR TITLE
application: serial_lte_modem: #XCMNG for credentials

### DIFF
--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -137,13 +137,13 @@ The ``<shutdown_mode>`` parameter accepts only the following integer values:
 * ``0`` - Deprecated.
 * ``1`` - Enter Sleep.
   In this mode, both the SLM service and the LTE connection are terminated.
-  The development kit can be waken up using the :kconfig:option:`CONFIG_SLM_WAKEUP_PIN`.
+  The development kit can be waken up using the :ref:`CONFIG_SLM_WAKEUP_PIN <CONFIG_SLM_WAKEUP_PIN>`.
 
 * ``2`` - Enter Idle.
   In this mode, both the SLM service and the LTE connection are maintained.
-  The development kit can be made to exit idle using the :kconfig:option:`CONFIG_SLM_WAKEUP_PIN`.
-  If the :kconfig:option:`CONFIG_SLM_INDICATE_PIN` is defined, SLM toggle this GPIO when there is data for MCU.
-  MCU could in turn make SLM to exit idle by :kconfig:option:`CONFIG_SLM_WAKEUP_PIN`.
+  The development kit can be made to exit idle using the :ref:`CONFIG_SLM_WAKEUP_PIN <CONFIG_SLM_WAKEUP_PIN>`.
+  If the :ref:`CONFIG_SLM_INDICATE_PIN <CONFIG_SLM_INDICATE_PIN>` is defined, SLM toggle this GPIO when there is data for MCU.
+  MCU could in turn make SLM to exit idle by :ref:`CONFIG_SLM_WAKEUP_PIN <CONFIG_SLM_WAKEUP_PIN>`.
   The data is buffered during the idle status and is sent to MCU after exiting the ilde status.
 
 .. note::
@@ -377,6 +377,90 @@ Example
   #XUUID: 50503041-3633-4261-803d-1e2b8f70111a
 
   OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.
+
+SLM CMNG #XCMNG
+===============
+
+The ``#XCMNG`` command manages the credentials to support :ref:`CONFIG_SLM_NATIVE_TLS <CONFIG_SLM_NATIVE_TLS>`.
+This command is implemented similarly to the modem ``%CMNG`` command.
+
+Set command
+-----------
+
+The set command is used for credential storage management.
+The command writes, reads, deletes, and checks the existence of keys and certificates.
+
+Syntax
+~~~~~~
+
+The following is the syntax when :ref:`CONFIG_SLM_NATIVE_TLS <CONFIG_SLM_NATIVE_TLS>` is selected:
+::
+
+   #XCMNG=<opcode>[,<sec_tag>[,<type>[,<content>]]]
+
+The ``<opcode>`` parameter is an integer.
+It accepts the following values:
+
+* ``0`` - Write a credential.
+* ``1`` - List credentials (currently not supported).
+* ``2`` - Read a credential (currently not supported).
+* ``3`` - Delete a credential.
+
+The ``<sec_tag>`` parameter is an integer ranging between ``0`` and ``2147483647``.
+It is mandatory for *write*, *read*, and *delete* operations.
+It is optional for *list* operations.
+
+The ``<type>`` parameter is an integer.
+It accepts the following values:
+
+* ``0`` - Root CA certificate (ASCII text)
+* ``1`` - Certificate (ASCII text)
+* ``2`` - Private key (ASCII text)
+
+The ``<content>`` parameter is a string.
+It is mandatory if ``<opcode>`` is ``0`` (write a credential).
+It's the content of a Privacy Enhanced Mail (PEM) file enclosed in double quotes (X.509 PEM entities).
+An empty string is not allowed.
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+There is no response.
+
+Example
+~~~~~~~
+
+::
+
+   AT#XCMNG=0,10,0,"-----BEGIN CERTIFICATE-----
+   MIICpTCCAkugAwIBAgIUS+wVM0VsVmpDIV8NTW8N2KEdRdowCgYIKoZIzj0EAwIw
+   gacxCzAJBgNVBAYTAlRXMQ8wDQYDVQQIDAZUYWl3YW4xDzANBgNVBAcMBlRhaXBl
+   aTEWMBQGA1UECgwNTm9yZGljIFRhaXBlaTEOMAwGA1UECwwFU2FsZXMxETAPBgNV
+   BAMMCExhcnJ5IENBMTswOQYJKoZIhvcNAQkBFixsYXJyeS52ZXJ5bG9uZ2xvbmds
+   b25nbG9uZ2xvbmdAbm9yZGljc2VtaS5ubzAeFw0yMDExMTcxMTE3MDlaFw0zMDEx
+   MTUxMTE3MDlaMIGnMQswCQYDVQQGEwJUVzEPMA0GA1UECAwGVGFpd2FuMQ8wDQYD
+   VQQHDAZUYWlwZWkxFjAUBgNVBAoMDU5vcmRpYyBUYWlwZWkxDjAMBgNVBAsMBVNh
+   bGVzMREwDwYDVQQDDAhMYXJyeSBDQTE7MDkGCSqGSIb3DQEJARYsbGFycnkudmVy
+   eWxvbmdsb25nbG9uZ2xvbmdsb25nQG5vcmRpY3NlbWkubm8wWTATBgcqhkjOPQIB
+   BggqhkjOPQMBBwNCAASvk+LcLXwteWokU1In+FQUWkkbQhkpW61u7d0jV1y/eF3Q
+   PTDAoEz//SnU1kIZccAqV64fFrrd2nkXknLCrhtxo1MwUTAdBgNVHQ4EFgQUMYSO
+   cWPI+SQUs1oVatNQvN/F0UowHwYDVR0jBBgwFoAUMYSOcWPI+SQUs1oVatNQvN/F
+   0UowDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiB2IrzpUmQqcUIw
+   OVqOMNAlzR6v4YHlI9InxU01quIRtQIhAOTITnLNuA0r0571SSBKZyrNGzxJxcPO
+   FDkGjew9OVov
+   -----END CERTIFICATE-----"
+
+   OK
 
 Read command
 ------------

--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -8,9 +8,7 @@ TCP and UDP AT commands
    :depth: 2
 
 The following commands list contains TCP-related and UDP-related AT commands.
-
-When TLS/DTLS is expected, the credentials should be stored on the modem side using either ``AT%XCMNG`` or the Nordic nRF Connect LTE Link Monitor tool.
-The modem needs to be in an offline state.
+When native TLS is used, you must store the credentials using the ``AT#XCMNG`` AT command.
 
 For more information on the networking services, visit the `BSD Networking Services Spec Reference`_.
 

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -94,11 +94,15 @@ CONFIG_SLM_WAKEUP_PIN - Interface GPIO to exit from sleep or idle
 
    **P0.26** (Multi-function button on Thingy:91) is used when the target is Thingy:91.
 
+.. _CONFIG_SLM_INDICATE_PIN:
+
 CONFIG_SLM_INDICATE_PIN - Interface GPIO to indicate data available or unexpected reset
    This option specifies which interface GPIO to use for indicating data available or unexpected reset.
    By default, **P0.2** (LED 1 on the nRF9160 DK) is used when :ref:`CONFIG_SLM_CONNECT_UART_0 <CONFIG_SLM_CONNECT_UART_0>` is selected, and **P0.30** is used when :ref:`CONFIG_SLM_CONNECT_UART_2 <CONFIG_SLM_CONNECT_UART_2>` is selected.
 
    It is not defined when the target is Thingy:91.
+
+.. _CONFIG_SLM_INDICATE_TIME:
 
 CONFIG_SLM_INDICATE_TIME - Indicate GPIO active time
    This option specifies the length, in milliseconds, of the time interval during which the indicate GPIO must stay active.
@@ -270,19 +274,22 @@ See :ref:`app_build_system`: for more information on the |NCS| configuration sys
 
 .. _slm_native_tls:
 
-Native TLS sockets
-------------------
+Native TLS
+----------
 
 By default, the secure socket (TLS/DTLS) is offloaded onto the modem.
-However, if you need customized TLS/DTLS features that are not supported by the modem firmware, you can use a native TLS socket instead.
-The serial LTE modem application will then handle all secure sockets used in TCP/IP, TCP/IP proxy, and MQTT.
+However, if you need customized TLS/DTLS features that are not supported by the modem firmware, you can use native TLS instead.
+Currently, the SLM application can be built to use native TLS for the following services:
 
-If native TLS is enabled, the `Credential storage management %CMNG`_ command is overridden to map the :ref:`security tag <nrfxlib:security_tags>` from the serial LTE modem application to the modem.
-You must use the overridden ``AT%CMNG`` command to provision the credentials to the modem.
+* TLS Proxy server
+* HTTPS client
+
+If native TLS is enabled, you must use the ``AT#XCMNG`` command to store the credentials.
 
 .. note::
 
-   The Serial LTE Modem application supports security tags ranging from 0 to 214748364.
+   The modem needs to be in an offline state when storing the credentials.
+   The SLM application supports security tags ranging from ``0`` to ``214748364``.
 
 The configuration options that are required to enable the native TLS socket are defined in the :file:`overlay-native_tls.conf` file.
 
@@ -292,8 +299,7 @@ The configuration options that are required to enable the native TLS socket are 
 
    * PSK, PSK identity, and PSK public key are currently not supported.
    * The DTLS server is currently not supported.
-   * ``AT%CMNG=1`` is not supported.
-   * The FTP and HTTP clients currently do not support native TLS.
+   * TLS session resumption is currently not supported.
 
 .. _slm_building:
 

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -476,8 +476,7 @@ static struct slm_at_cmd {
 	{"AT#XGETADDRINFO", handle_at_getaddrinfo},
 
 #if defined(CONFIG_SLM_NATIVE_TLS)
-	/* Hijacked modem command */
-	{"AT%CMNG", handle_at_xcmng},
+	{"AT#XCMNG", handle_at_xcmng},
 #endif
 	/* ICMP commands */
 	{"AT#XPING", handle_at_icmp_ping},

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -97,6 +97,8 @@ nRF9160: Serial LTE Modem
   * Enhanced the #XSLEEP AT command to support data indication when idle.
   * Enhanced the MQTT client to support the reception of large PUBLISH payloads.
   * Added the #XDFUGET and #XDFURUN AT commands to support the cloud-to-nRF52 DFU service.
+  * Added native TLS support to the HTTPS client.
+  * Added the #XCMNG command to support the use of native TLS.
 
 nRF Desktop
 -----------


### PR DESCRIPTION
Remove the hijacking of modem %CMNG command as SLM support modem
and native TLS at the same time. When native TLS is configured,
allow normal %CMNG for those service using modem TLS.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>