### PR TITLE
net: lib: download_client: add native TLS support

### DIFF
--- a/doc/nrf/libraries/networking/fota_download.rst
+++ b/doc/nrf/libraries/networking/fota_download.rst
@@ -30,6 +30,8 @@ When the download client sends the event indicating that the download has been c
 The library then sends a :c:enumerator:`FOTA_DOWNLOAD_EVT_FINISHED` callback event.
 When the application using the library receives this event, it must issue a reboot command to apply the upgrade.
 
+You can set :kconfig:option:`CONFIG_FOTA_DOWNLOAD_NATIVE_TLS` to configure the socket to be native for TLS instead of offloading TLS operations to the modem.
+
 HTTPS downloads
 ***************
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -432,6 +432,7 @@ Libraries for networking
   * :ref:`lib_download_client` library:
 
     * Fixed an issue where downloads of COAP URIs would fail when they contained multiple path elements.
+    * Added a parameter :c:member:`set_native_tls` in the configuration structure to configure native TLS support at runtime.
 
   * :ref:`lib_fota_download` library:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -432,11 +432,12 @@ Libraries for networking
   * :ref:`lib_download_client` library:
 
     * Fixed an issue where downloads of COAP URIs would fail when they contained multiple path elements.
-    * Added a parameter :c:member:`set_native_tls` in the configuration structure to configure native TLS support at runtime.
+    * Added the :c:member:`set_native_tls` parameter in the configuration structure to configure native TLS support at runtime.
 
   * :ref:`lib_fota_download` library:
 
     * Added :c:func:`fota_download_s0_active_get` function that gets the active B1 slot.
+    * Added :kconfig:option:`CONFIG_FOTA_DOWNLOAD_NATIVE_TLS` to configure the socket to be native for TLS instead of offloading TLS operations to the modem.
 
   * :ref:`lib_nrf_cloud` library:
 

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -177,6 +177,9 @@ struct download_client {
 
 	/** Event handler. */
 	download_client_callback_t callback;
+
+	/** Set socket to native TLS */
+	bool set_native_tls;
 };
 
 /**

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -277,6 +277,11 @@ static int client_connect(struct download_client *dl)
 		return -EAFNOSUPPORT;
 	}
 
+	if (dl->set_native_tls) {
+		LOG_DBG("Enabled native TLS");
+		type |= SOCK_NATIVE_TLS;
+	}
+
 	LOG_DBG("family: %d, type: %d, proto: %d",
 		dl->remote_addr.sa_family, type, dl->proto);
 

--- a/subsys/net/lib/fota_download/Kconfig
+++ b/subsys/net/lib/fota_download/Kconfig
@@ -26,6 +26,12 @@ config FOTA_DOWNLOAD_MCUBOOT_FLASH_BUF_SZ
 	help
 	  Buffer size must be aligned to the minimal flash write block size
 
+config FOTA_DOWNLOAD_NATIVE_TLS
+	bool "Enable native TLS socket"
+	help
+	  Enabling this option will configure the socket to be native for TLS
+	  instead of offloading TLS operations to the modem.
+
 module=FOTA_DOWNLOAD
 module-dep=LOG
 module-str=Firmware Over the Air Download

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -428,6 +428,13 @@ int fota_download_init(fota_download_callback_t client_callback)
 
 	callback = client_callback;
 
+#ifdef CONFIG_FOTA_DOWNLOAD_NATIVE_TLS
+	/* Enable native TLS for the download client socket
+	 * if configured.
+	 */
+	dlc.set_native_tls = CONFIG_FOTA_DOWNLOAD_NATIVE_TLS;
+#endif
+
 #ifdef CONFIG_DFU_TARGET_MCUBOOT
 	/* Set the required buffer for MCUboot targets */
 	err = dfu_target_mcuboot_set_buf(mcuboot_buf, sizeof(mcuboot_buf));


### PR DESCRIPTION
This commit adds an extra parameter in the configuration
structure to configure native TLS support at runtime.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>