### PR TITLE
samples: openthread: shrink settings partition for nrf52833

### DIFF
--- a/samples/openthread/cli/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/openthread/cli/boards/nrf52833dk_nrf52833.overlay
@@ -7,3 +7,17 @@
 	status = "okay";
 	hw-flow-control;
 };
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		storage_partition: partition@7a000 {
+			label = "storage";
+			reg = <0x0007C000 0x4000>;
+		};
+	};
+};


### PR DESCRIPTION
Currently the image for the build with harness/cert-overlay.conf overlaps the storage partition which causes runtime failure.
This PR fixes it by decreasing the size of the storage partition from 24kB to 16kB.
