### PR TITLE
applications: nrf_desktop: hw_interface: allow GPIO device to be NULL

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/selector_hw.c
+++ b/applications/nrf_desktop/src/hw_interface/selector_hw.c
@@ -274,6 +274,10 @@ static int init(void)
 			 "There is no active selector");
 
 	for (size_t i = 0; i < ARRAY_SIZE(gpio_dev); i++) {
+		if (gpio_dev[i] == NULL) {
+			continue;
+		}
+
 		if (!device_is_ready(gpio_dev[i])) {
 			LOG_ERR("GPIO port %u not ready", i);
 			return -ENODEV;


### PR DESCRIPTION
In some devices one of the GPIO ports may be NULL, so allow that
condition to happen.