### PR TITLE
bluetooth: controller: Update reservation of used resources

### DIFF
--- a/subsys/bluetooth/controller/bt_ctlr_used_resources.h
+++ b/subsys/bluetooth/controller/bt_ctlr_used_resources.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef BT_CTLR_USED_RESOURCES_H__
+#define BT_CTLR_USED_RESOURCES_H__
+
+/* As per the section "SoftDevice Controller/Integration with applications"
+ * in the nrfxlib documentation, the controller uses the following channels:
+ */
+#if defined(PPI_PRESENT)
+	/* PPI channels 17 - 31, for the nRF52 Series */
+	#define PPI_CHANNELS_USED_BY_CTLR (BIT_MASK(15) << 17)
+#else
+	/* DPPI channels 0 - 13, for the nRF53 Series */
+	#define PPI_CHANNELS_USED_BY_CTLR BIT_MASK(14)
+#endif
+
+/* Additionally, MPSL requires several PPI channels (as per the section
+ * "Multiprotocol Service Layer/Integration notes").
+ */
+#include <mpsl.h>
+
+/* The following macros are used in nrfx_glue.h for marking these PPI channels
+ * and groups and GPIOTE channels as occupied and thus unavailable to other
+ * modules.
+ */
+#define BT_CTLR_USED_PPI_CHANNELS    (PPI_CHANNELS_USED_BY_CTLR | MPSL_RESERVED_PPI_CHANNELS)
+#define BT_CTLR_USED_PPI_GROUPS	     0
+#define BT_CTLR_USED_GPIOTE_CHANNELS 0
+
+#endif /* BT_CTLR_USED_RESOURCES_H__ */

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -33,35 +33,6 @@
 #define LOG_MODULE_NAME sdc_hci_driver
 #include "common/log.h"
 
-/* As per the section "SoftDevice Controller/Integration with applications"
- * in the nrfxlib documentation, the controller uses the following channels:
- */
-#if defined(PPI_PRESENT)
-	/* PPI channels 17 - 31, for the nRF52 Series */
-	#define PPI_CHANNELS_USED_BY_CTLR (BIT_MASK(15) << 17)
-#else
-	/* DPPI channels 0 - 13, for the nRF53 Series */
-	#define PPI_CHANNELS_USED_BY_CTLR BIT_MASK(14)
-#endif
-
-/* Additionally, MPSL requires the following channels (as per the section
- * "Multiprotocol Service Layer/Integration notes"):
- */
-#if defined(PPI_PRESENT)
-	/* PPI channel 19, 30, 31, for the nRF52 Series */
-	#define PPI_CHANNELS_USED_BY_MPSL (BIT(19) | BIT(30) | BIT(31))
-#else
-	/* DPPI channels 0 - 2, for the nRF53 Series */
-	#define PPI_CHANNELS_USED_BY_MPSL BIT_MASK(3)
-#endif
-
-/* The following two constants are used in nrfx_glue.h for marking these PPI
- * channels and groups as occupied and thus unavailable to other modules.
- */
-const uint32_t z_bt_ctlr_used_nrf_ppi_channels =
-	PPI_CHANNELS_USED_BY_CTLR | PPI_CHANNELS_USED_BY_MPSL;
-const uint32_t z_bt_ctlr_used_nrf_ppi_groups;
-
 #if defined(CONFIG_BT_CONN)
 /* It should not be possible to set CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT larger than
  * CONFIG_BT_MAX_CONN. Kconfig should make sure of that, this assert is to

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 04826f2942611856562aeea35e97fb70314ef312
+      revision: 6544ef4f0b1a250d518862fa0f808a489ce25471
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update the way in which PPI channels required by the SoftDevice
controller and MPSL are reserved in nrfx_glue.h so that other
modules do not use them (this is no longer done by global constants,
preprocessor macros defined in a file named bt_ctlr_used_resources.h
must be used instead).