### PR TITLE
zigbee: samples: Identify only when in a network

### DIFF
--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -210,7 +210,7 @@ static void start_identifying(zb_bufid_t bufid)
 			zb_bdb_finding_binding_target_cancel();
 		}
 	} else {
-		LOG_WRN("Device not in a network - cannot identify itself");
+		LOG_WRN("Device not in a network - cannot enter identify mode");
 	}
 }
 

--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -195,17 +195,22 @@ static void start_identifying(zb_bufid_t bufid)
 
 	ZVUNUSED(bufid);
 
-	/* Check if endpoint is in identifying mode,
-	 * if not, put desired endpoint in identifying mode.
-	 */
-	if (dev_ctx.identify_attr.identify_time == ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-		LOG_INF("Enter identify mode");
+	if (ZB_JOINED()) {
+		/* Check if endpoint is in identifying mode,
+		 * if not, put desired endpoint in identifying mode.
+		 */
+		if (dev_ctx.identify_attr.identify_time ==
+		    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
+			LOG_INF("Enter identify mode");
 
-		zb_err_code = zb_bdb_finding_binding_target(HA_DIMMABLE_LIGHT_ENDPOINT);
-		ZB_ERROR_CHECK(zb_err_code);
+			zb_err_code = zb_bdb_finding_binding_target(HA_DIMMABLE_LIGHT_ENDPOINT);
+			ZB_ERROR_CHECK(zb_err_code);
+		} else {
+			LOG_INF("Cancel identify mode");
+			zb_bdb_finding_binding_target_cancel();
+		}
 	} else {
-		LOG_INF("Cancel identify mode");
-		zb_bdb_finding_binding_target_cancel();
+		LOG_WRN("Device not in a network - cannot identify itself");
 	}
 }
 

--- a/samples/zigbee/network_coordinator/src/main.c
+++ b/samples/zigbee/network_coordinator/src/main.c
@@ -156,7 +156,7 @@ static void start_identifying(zb_bufid_t bufid)
 			zb_bdb_finding_binding_target_cancel();
 		}
 	} else {
-		LOG_WRN("Device not in a network - cannot identify itself");
+		LOG_WRN("Device not in a network - cannot enter identify mode");
 	}
 }
 

--- a/samples/zigbee/network_coordinator/src/main.c
+++ b/samples/zigbee/network_coordinator/src/main.c
@@ -142,16 +142,21 @@ static void start_identifying(zb_bufid_t bufid)
 
 	ZVUNUSED(bufid);
 
-	/* Check if endpoint is in identifying mode,
-	 * if not, put desired endpoint in identifying mode.
-	 */
-	if (dev_ctx.identify_attr.identify_time == ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-		LOG_INF("Enter identify mode");
-		zb_err_code = zb_bdb_finding_binding_target(ZIGBEE_COORDINATOR_ENDPOINT);
-		ZB_ERROR_CHECK(zb_err_code);
+	if (ZB_JOINED()) {
+		/* Check if endpoint is in identifying mode,
+		 * if not, put desired endpoint in identifying mode.
+		 */
+		if (dev_ctx.identify_attr.identify_time ==
+		    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
+			LOG_INF("Enter identify mode");
+			zb_err_code = zb_bdb_finding_binding_target(ZIGBEE_COORDINATOR_ENDPOINT);
+			ZB_ERROR_CHECK(zb_err_code);
+		} else {
+			LOG_INF("Cancel identify mode");
+			zb_bdb_finding_binding_target_cancel();
+		}
 	} else {
-		LOG_INF("Cancel identify mode");
-		zb_bdb_finding_binding_target_cancel();
+		LOG_WRN("Device not in a network - cannot identify itself");
 	}
 }
 

--- a/samples/zigbee/shell/src/main.c
+++ b/samples/zigbee/shell/src/main.c
@@ -128,18 +128,22 @@ static void start_identifying(zb_bufid_t bufid)
 
 	ZVUNUSED(bufid);
 
-	/* Check if endpoint is in identifying mode,
-	 * if not put desired endpoint in identifying mode.
-	 */
-	if (dev_ctx.identify_attr.identify_time ==
-	    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-		LOG_INF("Enter identify mode");
-		zb_err_code = zb_bdb_finding_binding_target(
-			APP_ZIGBEE_ENDPOINT);
-		ZB_ERROR_CHECK(zb_err_code);
+	if (ZB_JOINED()) {
+		/* Check if endpoint is in identifying mode,
+		 * if not put desired endpoint in identifying mode.
+		 */
+		if (dev_ctx.identify_attr.identify_time ==
+		ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
+			LOG_INF("Enter identify mode");
+			zb_err_code = zb_bdb_finding_binding_target(
+				APP_ZIGBEE_ENDPOINT);
+			ZB_ERROR_CHECK(zb_err_code);
+		} else {
+			LOG_INF("Cancel identify mode");
+			zb_bdb_finding_binding_target_cancel();
+		}
 	} else {
-		LOG_INF("Cancel identify mode");
-		zb_bdb_finding_binding_target_cancel();
+		LOG_WRN("Device not in a network - cannot identify itself");
 	}
 }
 

--- a/samples/zigbee/shell/src/main.c
+++ b/samples/zigbee/shell/src/main.c
@@ -143,7 +143,7 @@ static void start_identifying(zb_bufid_t bufid)
 			zb_bdb_finding_binding_target_cancel();
 		}
 	} else {
-		LOG_WRN("Device not in a network - cannot identify itself");
+		LOG_WRN("Device not in a network - cannot enter identify mode");
 	}
 }
 

--- a/samples/zigbee/template/src/main.c
+++ b/samples/zigbee/template/src/main.c
@@ -128,18 +128,22 @@ static void start_identifying(zb_bufid_t bufid)
 
 	ZVUNUSED(bufid);
 
-	/* Check if endpoint is in identifying mode,
-	 * if not put desired endpoint in identifying mode.
-	 */
-	if (dev_ctx.identify_attr.identify_time ==
-	    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-		LOG_INF("Enter identify mode");
-		zb_err_code = zb_bdb_finding_binding_target(
-			APP_TEMPLATE_ENDPOINT);
-		ZB_ERROR_CHECK(zb_err_code);
+	if (ZB_JOINED()) {
+		/* Check if endpoint is in identifying mode,
+		 * if not put desired endpoint in identifying mode.
+		 */
+		if (dev_ctx.identify_attr.identify_time ==
+		ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
+			LOG_INF("Enter identify mode");
+			zb_err_code = zb_bdb_finding_binding_target(
+				APP_TEMPLATE_ENDPOINT);
+			ZB_ERROR_CHECK(zb_err_code);
+		} else {
+			LOG_INF("Cancel identify mode");
+			zb_bdb_finding_binding_target_cancel();
+		}
 	} else {
-		LOG_INF("Cancel identify mode");
-		zb_bdb_finding_binding_target_cancel();
+		LOG_WRN("Device not in a network - cannot identify itself");
 	}
 }
 

--- a/samples/zigbee/template/src/main.c
+++ b/samples/zigbee/template/src/main.c
@@ -143,7 +143,7 @@ static void start_identifying(zb_bufid_t bufid)
 			zb_bdb_finding_binding_target_cancel();
 		}
 	} else {
-		LOG_WRN("Device not in a network - cannot identify itself");
+		LOG_WRN("Device not in a network - cannot enter identify mode");
 	}
 }
 


### PR DESCRIPTION
Start device identification only when already joined a network.
Log warning in case device is not yet in a network.

Modified samples:
- light_bulb
- network_coordinator
- shell
- template

Signed-off-by: Adam Szczygieł <adam.szczygiel@nordicsemi.no>