### PR TITLE
doc: multicell location lib: remove an unnecsssary Kconfig reference

### DIFF
--- a/doc/nrf/libraries/networking/multicell_location.rst
+++ b/doc/nrf/libraries/networking/multicell_location.rst
@@ -38,7 +38,7 @@ To use the location services, see the respective documentation for account setup
    To start using the Multicell location library with nRF Cloud, you must perform either of the following actions:
 
       * Delete the device from nRF Cloud and reprovision it with a new ES256 device certificate. See :ref:`nrf9160_ug_updating_cloud_certificate` for more information.
-      * Register a separate key for JWT signing as described in `Securely Generating Credentials on the nRF9160`_ and set :kconfig:`CONFIG_MULTICELL_LOCATION_NRF_CLOUD_JWT_SEC_TAG` accordingly.
+      * Register a separate key for JWT signing as described in `Securely Generating Credentials on the nRF9160`_.
 
 .. reprovision_cert_note_end
 


### PR DESCRIPTION
Removed reference to Kconfig option
CONFIG_MULTICELL_LOCATION_NRF_CLOUD_JWT_SEC_TAG
in the Multicell location library document.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>