### PR TITLE
boards: Add missing RAM/Flash sizes in several boards

### DIFF
--- a/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.yaml
+++ b/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+ram: 256
+flash: 1024
 supported:
   - usb_device
   - ble

--- a/boards/arm/nrf52kbd_nrf52832/nrf52kbd_nrf52832.yaml
+++ b/boards/arm/nrf52kbd_nrf52832/nrf52kbd_nrf52832.yaml
@@ -5,5 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+ram: 64
+flash: 512
 supported:
   - ble

--- a/boards/arm/thingy91_nrf52840/thingy91_nrf52840.yaml
+++ b/boards/arm/thingy91_nrf52840/thingy91_nrf52840.yaml
@@ -5,6 +5,8 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
+ram: 256
+flash: 1024
 supported:
   - adc
   - usb_device


### PR DESCRIPTION
Some boards did not include the RAM and Flash information in their
corresponding yaml files, add those.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>