### PR TITLE
lib: location: support external transport method for P-GPS data

### DIFF
--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -121,7 +121,8 @@ Configure the following options to enable location methods of your choice:
 
 The following options control the use of GNSS assistance data:
 
-* :kconfig:option:`CONFIG_LOCATION_METHOD_GNSS_AGPS_EXTERNAL` - Enables A-GPS data retrieval from an external source which the application implements separately. If enabled, Location library throws event :c:enum:`LOCATION_EVT_GNSS_ASSISTANCE_REQUEST` when assistance is needed. Once application has obtained the assistance data it should call :c:func:`location_agps_data_process` function to feed it into Location library.
+* :kconfig:option:`CONFIG_LOCATION_METHOD_GNSS_AGPS_EXTERNAL` - Enables A-GPS data retrieval from an external source, implemented separately by the application. If enabled, the library triggers a :c:enum:`LOCATION_EVT_GNSS_ASSISTANCE_REQUEST` event when assistance is needed. Once the application has obtained the assistance data, it should call the :c:func:`location_agps_data_process` function to feed it into the library.
+* :kconfig:option:`CONFIG_LOCATION_METHOD_GNSS_PGPS_EXTERNAL` - Enables P-GPS data retrieval from an external source, implemented separately by the application. If enabled, the library triggers a :c:enum:`LOCATION_EVT_GNSS_PREDICTION_REQUEST` event when assistance is needed. Once the application has obtained the assistance data, it should call the :c:func:`location_pgps_data_process` function to feed it into the library.
 * :kconfig:option:`CONFIG_NRF_CLOUD_AGPS` - Enables A-GPS data retrieval from `nRF Cloud`_.
 * :kconfig:option:`CONFIG_NRF_CLOUD_PGPS` - Enables P-GPS data retrieval from `nRF Cloud`_.
 * :kconfig:option:`CONFIG_NRF_CLOUD_AGPS_FILTERED` - Reduces assistance size by only downloading ephemerides for visible satellites.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -268,7 +268,22 @@ Bluetooth libraries and services
 
   * Added host callback handlers for the ``write`` and ``match`` operations of the CCC descriptor.
   * Fixed the serialization of the write callback applied to the GATT attribute.
-  * Fixed the serialization of the :c:func:`bt_gatt_service_unregister` function call .
+  * Fixed the serialization of the :c:func:`bt_gatt_service_unregister` function call.
+
+Modem libraries
+------------------------
+
+* :ref:`lib_location` library:
+
+  * Added:
+
+    * Support for P-GPS data retrieval from an external source, implemented separately by the application.
+      Enabled by setting the :kconfig:option:`CONFIG_LOCATION_METHOD_GNSS_PGPS_EXTERNAL` option.
+      The library triggers a :c:enum:`LOCATION_EVT_GNSS_PREDICTION_REQUEST` event when assistance is needed.
+
+  * Updated:
+
+    * The :c:member:`request` member of the :c:struct:`location_event_data` structure was renamed to :c:member:`agps_request`.
 
 Libraries for networking
 ------------------------

--- a/lib/location/Kconfig
+++ b/lib/location/Kconfig
@@ -43,6 +43,13 @@ config LOCATION_METHOD_GNSS_AGPS_EXTERNAL
 	help
 	  Allow application to download the A-GPS data and merely feed it to Location library for
 	  processing.
+
+config LOCATION_METHOD_GNSS_PGPS_EXTERNAL
+	bool "Requesting P-GPS data is handled by the application outside of Location library."
+	depends on NRF_CLOUD_PGPS
+	help
+	  Allow application to download the P-GPS data and merely feed it to Location library for
+	  processing.
 endif # LOCATION_METHOD_GNSS
 
 if LOCATION_METHOD_WIFI

--- a/lib/location/location.c
+++ b/lib/location/location.c
@@ -11,6 +11,9 @@
 #if defined(CONFIG_LOCATION_METHOD_GNSS_AGPS_EXTERNAL)
 #include <net/nrf_cloud_agps.h>
 #endif
+#if defined(CONFIG_LOCATION_METHOD_GNSS_PGPS_EXTERNAL)
+#include <net/nrf_cloud_pgps.h>
+#endif
 
 #include "location_core.h"
 
@@ -184,6 +187,33 @@ int location_agps_data_process(const char *buf, size_t buf_len)
 		return -EINVAL;
 	}
 	return nrf_cloud_agps_process(buf, buf_len);
+#endif
+	return -ENOTSUP;
+}
+
+int location_pgps_data_process(const char *buf, size_t buf_len)
+{
+#if defined(CONFIG_LOCATION_METHOD_GNSS_PGPS_EXTERNAL)
+	int err;
+
+	if (!buf) {
+		LOG_ERR("P-GPS data buffer cannot be a NULL pointer.");
+		return -EINVAL;
+	}
+
+	if (!buf_len) {
+		LOG_ERR("P-GPS data buffer length cannot be zero.");
+		return -EINVAL;
+	}
+
+	err = nrf_cloud_pgps_process(buf, buf_len);
+
+	if (err) {
+		nrf_cloud_pgps_request_reset();
+		LOG_ERR("P-GPS data processing failed, error: %d", err);
+	}
+
+	return err;
 #endif
 	return -ENOTSUP;
 }

--- a/lib/location/location_core.c
+++ b/lib/location/location_core.c
@@ -365,13 +365,24 @@ void location_core_event_cb_timeout(void)
 }
 
 #if defined(CONFIG_LOCATION_METHOD_GNSS_AGPS_EXTERNAL)
-void location_core_event_cb_assistance_request(const struct nrf_modem_gnss_agps_data_frame *request)
+void location_core_event_cb_agps_request(const struct nrf_modem_gnss_agps_data_frame *request)
 {
 	struct location_event_data agps_request_event_data;
 
 	agps_request_event_data.id = LOCATION_EVT_GNSS_ASSISTANCE_REQUEST;
-	agps_request_event_data.request = *request;
+	agps_request_event_data.agps_request = *request;
 	event_handler(&agps_request_event_data);
+}
+#endif
+
+#if defined(CONFIG_LOCATION_METHOD_GNSS_PGPS_EXTERNAL)
+void location_core_event_cb_pgps_request(const struct gps_pgps_request *request)
+{
+	struct location_event_data pgps_request_event_data;
+
+	pgps_request_event_data.id = LOCATION_EVT_GNSS_PREDICTION_REQUEST;
+	pgps_request_event_data.pgps_request = *request;
+	event_handler(&pgps_request_event_data);
 }
 #endif
 

--- a/lib/location/location_core.h
+++ b/lib/location/location_core.h
@@ -26,8 +26,10 @@ void location_core_event_cb(const struct location_data *location);
 void location_core_event_cb_error(void);
 void location_core_event_cb_timeout(void);
 #if defined(CONFIG_LOCATION_METHOD_GNSS_AGPS_EXTERNAL)
-void location_core_event_cb_assistance_request(
-	const struct nrf_modem_gnss_agps_data_frame *request);
+void location_core_event_cb_agps_request(const struct nrf_modem_gnss_agps_data_frame *request);
+#endif
+#if defined(CONFIG_LOCATION_METHOD_GNSS_PGPS_EXTERNAL)
+void location_core_event_cb_pgps_request(const struct gps_pgps_request *request);
 #endif
 
 void location_core_config_log(const struct location_config *config);

--- a/samples/nrf9160/location/src/main.c
+++ b/samples/nrf9160/location/src/main.c
@@ -72,7 +72,11 @@ static void location_event_handler(const struct location_event_data *event_data)
 		break;
 
 	case LOCATION_EVT_GNSS_ASSISTANCE_REQUEST:
-		printk("Getting location assistance requested. Not doing anything.\n\n");
+		printk("Getting location assistance requested (A-GPS). Not doing anything.\n\n");
+		break;
+
+	case LOCATION_EVT_GNSS_PREDICTION_REQUEST:
+		printk("Getting location assistance requested (P-GPS). Not doing anything.\n\n");
 		break;
 
 	default:

--- a/samples/nrf9160/modem_shell/src/location/location_shell.c
+++ b/samples/nrf9160/modem_shell/src/location/location_shell.c
@@ -161,9 +161,20 @@ void location_ctrl_event_handler(const struct location_event_data *event_data)
 		mosh_print(
 			"MoSh: A-GPS request from Location library "
 			"(ephe: 0x%08x alm: 0x%08x flags: 0x%02x)",
-			event_data->request.sv_mask_ephe,
-			event_data->request.sv_mask_alm,
-			event_data->request.data_flags);
+			event_data->agps_request.sv_mask_ephe,
+			event_data->agps_request.sv_mask_alm,
+			event_data->agps_request.data_flags);
+#endif
+		break;
+	case LOCATION_EVT_GNSS_PREDICTION_REQUEST:
+#if defined(CONFIG_LOCATION_METHOD_GNSS_PGPS_EXTERNAL)
+		mosh_print(
+			"MoSh: P-GPS request from Location library "
+			"(prediction count: %d validity time: %d gps day: %d time of day: %d)",
+			event_data->pgps_request.prediction_count,
+			event_data->pgps_request.prediction_period_min,
+			event_data->pgps_request.gps_day,
+			event_data->pgps_request.gps_time_of_day);
 #endif
 		break;
 	}


### PR DESCRIPTION
The nRF Cloud P-GPS library can be used without depending on the nRF
Cloud REST / MQTT transport libraries to request/receive P-GPS data.
Config item LOCATION_METHOD_GNSS_PGPS_EXTERNAL was added to Location
library to enable the application to handle the P-GPS data.

JIRA: NCSDK-13323

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>