### PR TITLE
ci: github/workflows/manifest.yml: fix trailing comma

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -35,5 +35,5 @@ jobs:
           # zephyr module or the nrfxlib module is changed. Each line is comma-
           # separated.
           labels: >
-            manifest,
+            manifest
           dnm-labels: 'DNM'


### PR DESCRIPTION
  * github/workflows/manifest.yml: fix trailing comma in lables list

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>