### PR TITLE
openthread: extending main stack for openthread samples

### DIFF
--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -24,7 +24,7 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 
 config MAIN_STACK_SIZE
 	int
-	default 2048
+	default 2560
 
 config INIT_STACKS
 	bool


### PR DESCRIPTION
This commit extends main stack on Openthread samples due to stack
overflow when invoking `openthread_start`.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>