### PR TITLE
event_manager: Improved EVENT_SUBMIT macro

### DIFF
--- a/include/event_manager.h
+++ b/include/event_manager.h
@@ -142,7 +142,7 @@ extern "C" {
  *
  * @param event  Pointer to the event object.
  */
-#define EVENT_SUBMIT(event) _event_submit(&event->header)
+#define EVENT_SUBMIT(event) _event_submit(&((event)->header))
 
 /**
  * @brief Register event hook after the event manager is initialized.


### PR DESCRIPTION
Improved the EVENT_SUBMIT macro by adding parantheseses around the
event parameter, to allow the macro to be used not only on events
defined as pointer types.

Signed-off-by: Torbjørn Øvrebekk <torbjorn.ovrebekk@nordicsemi.no>