### PR TITLE
caf: Allow linker to use correct memory for module_ids

### DIFF
--- a/subsys/caf/events/module_id_list.ld
+++ b/subsys/caf/events/module_id_list.ld
@@ -3,4 +3,4 @@ module_id_list_all :
 	__start_module_id_list = .;
 	KEEP(*(module_id_list));
 	__stop_module_id_list = .;
-} > FLASH
+} GROUP_LINK_IN(ROMABLE_REGION)


### PR DESCRIPTION
On some platforms (e.g. qemu) there might be no flash memory.
Let build system select the best memory matching romable attribute.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>