### PR TITLE
dfu: dfu_target: Implement `dfu_target_erase` for MCUboot and modem

### DIFF
--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -40,6 +40,7 @@ struct dfu_target {
 	int (*init)(size_t file_size, dfu_target_callback_t cb);
 	int (*offset_get)(size_t *offset);
 	int (*write)(const void *const buf, size_t len);
+	int (*erase)(int slot, bool force);
 	int (*done)(bool successful);
 };
 
@@ -98,6 +99,17 @@ int dfu_target_offset_get(size_t *offset);
  *	   code identicating reason of failure.
  **/
 int dfu_target_write(const void *const buf, size_t len);
+
+/**
+ * @brief Erase the DFU storage for the initialized DFU target.
+ *
+ * @param[in] force Indicate whether the erase should be exectued even if the
+ *		    area already reports as empty.
+ *
+ * @return 0 for an successful erase or a negative error
+ *	   code identicating reason of failure.
+ **/
+int dfu_target_erase(int slot, bool force);
 
 /**
  * @brief Deinitialize the resources that were needed for the current DFU

--- a/include/dfu/dfu_target_full_modem.h
+++ b/include/dfu/dfu_target_full_modem.h
@@ -107,6 +107,17 @@ int dfu_target_full_modem_write(const void *const buf, size_t len);
  */
 int dfu_target_full_modem_done(bool successful);
 
+/**
+ * @brief Erase the DFU storage for the initialized DFU target.
+ *
+ * @param[in] force Indicate whether the erase should be exectued even if the
+ *		    area already reports as empty.
+ *
+ * @return 0 for an successful erase or a negative error
+ *	   code identicating reason of failure.
+ */
+int dfu_target_full_modem_erase(int slot, bool force);
+
 #endif /* DFU_TARGET_FULL_MODEM_H__ */
 
 /**@} */

--- a/include/dfu/dfu_target_mcuboot.h
+++ b/include/dfu/dfu_target_mcuboot.h
@@ -94,6 +94,18 @@ int dfu_target_mcuboot_write(const void *const buf, size_t len);
  */
 int dfu_target_mcuboot_done(bool successful);
 
+/**
+ * @brief Erase the DFU storage for the initialized DFU target.
+ *
+ * @param[in] force Indicate whether the erase should be exectued even if the
+ *		    area already reports as empty.
+ *
+ * @return 0 for an successful erase or a negative error
+ *	   code identicating reason of failure.
+ **/
+
+int dfu_target_mcuboot_erase(int slot, bool force);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dfu/dfu_target_modem_delta.h
+++ b/include/dfu/dfu_target_modem_delta.h
@@ -67,6 +67,17 @@ int dfu_target_modem_delta_write(const void *const buf, size_t len);
  */
 int dfu_target_modem_delta_done(bool successful);
 
+/**
+ * @brief Erase the DFU storage for the initialized DFU target.
+ *
+ * @param[in] force Indicate whether the erase should be exectued even if the
+ *		    area already reports as empty.
+ *
+ * @return 0 for an successful erase or a negative error
+ *	   code identicating reason of failure.
+ */
+int dfu_target_modem_delta_erase(int slot, bool force);
+
 #endif /* DFU_TARGET_MODEM_H__ */
 
 /**@} */

--- a/subsys/dfu/dfu_target/Kconfig
+++ b/subsys/dfu/dfu_target/Kconfig
@@ -55,7 +55,6 @@ config DFU_TARGET_MODEM_DELTA
 	help
 	  Enable support for updates to the modem firmware.
 
-if (DFU_TARGET_MODEM_DELTA)
 config DFU_TARGET_MODEM_TIMEOUT
 	int "Erase pending timeout"
 	default 60
@@ -68,8 +67,13 @@ config DFU_TARGET_MODEM_TIMEOUT
 	  DFU_ERASE_PENDING request. It's also possible to reboot the device to
 	  achive the same desired behavior.
 
-
-endif # DFU_TARGET_MODEM_DELTA
+config DFU_TARGET_MODEM_ERASE_ON_INIT
+	bool "Erase on init"
+	default y
+	depends on DFU_TARGET_MODEM_DELTA
+	help
+	  Enable erasing the modem delta update DFU bank on initialization of
+	  the DFU target.
 
 config DFU_TARGET_FULL_MODEM
 	bool "Full Modem update support"

--- a/subsys/dfu/dfu_target/src/dfu_target.c
+++ b/subsys/dfu/dfu_target/src/dfu_target.c
@@ -13,6 +13,7 @@ static const struct dfu_target dfu_target_ ## name  = { \
 	.init = dfu_target_ ## name ## _init, \
 	.offset_get = dfu_target_## name ##_offset_get, \
 	.write = dfu_target_ ## name ## _write, \
+	.erase = dfu_target_ ## name ## _erase, \
 	.done = dfu_target_ ## name ## _done, \
 }
 
@@ -106,6 +107,15 @@ int dfu_target_offset_get(size_t *offset)
 	}
 
 	return current_target->offset_get(offset);
+}
+
+int dfu_target_erase(int slot, bool force)
+{
+	if (current_target == NULL) {
+		return -EACCES;
+	}
+
+	return current_target->erase(slot, force);
 }
 
 int dfu_target_write(const void *const buf, size_t len)

--- a/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
@@ -58,6 +58,15 @@ int dfu_target_full_modem_init(size_t file_size,
 	return 0;
 }
 
+int dfu_target_full_modem_erase(int slot, bool force)
+{
+	ARG_UNUSED(slot);
+	ARG_UNUSED(force);
+
+	return -ENOSYS;
+}
+
+
 int dfu_target_full_modem_offset_get(size_t *out)
 {
 	return dfu_target_stream_offset_get(out);

--- a/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
@@ -150,6 +150,14 @@ int dfu_target_mcuboot_offset_get(size_t *out)
 	return err;
 }
 
+int dfu_target_mcuboot_erase(int slot, bool force)
+{
+	if (force) {
+		return boot_erase_img_bank(slot);
+	}
+	return 0;
+}
+
 int dfu_target_mcuboot_write(const void *const buf, size_t len)
 {
 	stream_buf_bytes = (stream_buf_bytes + len) % stream_buf_len;


### PR DESCRIPTION
This adds the functionality of deferring the erase of the modem DFU bank
to the application. Through the `dfu_target` API using
`dfu_target_erase`. This is also implemented for MCUBoot targets but not
for full modem.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>