### PR TITLE
cmake: moving mcuboot image sign warning to the proper block

### DIFF
--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -276,19 +276,19 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     endif()
   endif()
 
-  # Set default key
-  if (NOT DEFINED mcuboot_key_file)
-    message(WARNING "
-      ---------------------------------------------------------
-      --- WARNING: Using default MCUBoot key, it should not ---
-      --- be used for production.                           ---
-      ---------------------------------------------------------
-      \n"
-    )
-    set(mcuboot_key_file ${ZEPHYR_MCUBOOT_MODULE_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})
-  endif()
-
   if(CONFIG_SIGN_IMAGES)
+    # Set default key
+    if (NOT DEFINED mcuboot_key_file)
+      message(WARNING "
+        ---------------------------------------------------------
+        --- WARNING: Using default MCUBoot key, it should not ---
+        --- be used for production.                           ---
+        ---------------------------------------------------------
+        \n"
+      )
+      set(mcuboot_key_file ${ZEPHYR_MCUBOOT_MODULE_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})
+    endif()
+
     set(app_core_binary_name app_update.bin)
 
     execute_process(COMMAND


### PR DESCRIPTION
This commit fixes the "default key" warning for mcuboot image signing
that should be raised only when we are really signing the image.

The warning was being raised even when
CONFIG_MCUBOOT_BUILD_STRATEGY_SKIP_BUILD was set.

This is a nit detail but is a wrong warning we see on every dev build.

Signed-off-by: Rodrigo Brochado <git.rodrigobrochado@gmail.com>