### PR TITLE
doc: fixes to application configuration options in nRF desktop

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -295,7 +295,7 @@ The report is used by the :ref:`nrf_desktop_config_channel`.
 
 .. note::
    The nRF Desktop also uses a dedicated HID output report to forward the :ref:`nrf_desktop_config_channel` data through the nRF Desktop dongle.
-   This report is handled using the configuration channel's infrastructure and it can be enabled using :kconfig:option:`CONFIG_DESKTOP_CONFIG_CHANNEL_OUT_REPORT`.
+   This report is handled using the configuration channel's infrastructure and it can be enabled using :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_OUT_REPORT <config_desktop_app_options>`.
    See the Kconfig option's help for details about the report.
 
 HID protocols
@@ -864,7 +864,7 @@ After building the application with or without :ref:`specifying the build type <
    .. note::
         You can manually start the scanning for new peripheral devices by pressing the **SW1** button on the dongle for a short time.
         This might be needed if the dongle does not connect with all the peripherals before timeout.
-        The scanning is interrupted after the amount of time predefined in :kconfig:option:`CONFIG_DESKTOP_BLE_SCAN_DURATION_S`, because it negatively affects the performance of already connected peripherals.
+        The scanning is interrupted after the amount of time predefined in :ref:`CONFIG_DESKTOP_BLE_SCAN_DURATION_S <config_desktop_app_options>`, because it negatively affects the performance of already connected peripherals.
 
 #. Move the mouse and press any key on the keyboard.
    The input is reflected on the host.
@@ -1064,7 +1064,7 @@ To use the nRF Desktop application with your custom board:
    a. Ensure that the Bluetooth role is properly configured.
       For mouse, it should be configured as peripheral.
    #. Update the configuration related to peer control.
-      You can also disable the peer control using the :kconfig:option:`CONFIG_DESKTOP_BLE_PEER_CONTROL` option.
+      You can also disable the peer control using the :ref:`CONFIG_DESKTOP_BLE_PEER_CONTROL <config_desktop_app_options>` option.
       Peer control details are described in the :ref:`nrf_desktop_ble_bond` documentation.
 
    Refer to the :ref:`nrf_desktop_bluetooth_guide` section and Zephyr's :ref:`zephyr:bluetooth` page for more detailed information about the Bluetooth configuration.
@@ -1831,8 +1831,12 @@ These are valid for events that have many listeners or sources, and are gathered
    doc/hfclk_lock.rst
    doc/event_rel_modules.rst
 
+.. _config_desktop_app_options:
+
 Application configuration options
 *********************************
+
+Following are the application specific configuration options that can be configured for the nRF desktop and the internal modules:
 
 .. options-from-kconfig::
    :show-type:

--- a/applications/nrf_desktop/doc/bas.rst
+++ b/applications/nrf_desktop/doc/bas.rst
@@ -22,8 +22,8 @@ Module events
 Configuration
 *************
 
-The module is enabled with the :kconfig:option:`CONFIG_DESKTOP_BAS_ENABLE` option.
-The option is selected by :kconfig:option:`CONFIG_DESKTOP_HID_PERIPHERAL` -- Battery Service is required for the HID peripheral device.
+The module is enabled with the :ref:`CONFIG_DESKTOP_BAS_ENABLE <config_desktop_app_options>` option.
+The option is selected by :ref:`CONFIG_DESKTOP_HID_PERIPHERAL <config_desktop_app_options>` -- Battery Service is required for the HID peripheral device.
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/doc/battery_charger.rst
+++ b/applications/nrf_desktop/doc/battery_charger.rst
@@ -25,20 +25,20 @@ Configuration
 The module implemented in :file:`battery_charger.c` uses Zephyr's :ref:`zephyr:gpio_api` driver to control and monitor battery charging.
 For this reason, you should set :kconfig:option:`CONFIG_GPIO` option.
 
-By default, the module is disabled and the ``CONFIG_DESKTOP_BATTERY_CHARGER_NONE`` option is selected.
-Set the option ``CONFIG_DESKTOP_BATTERY_CHARGER_DISCRETE`` to enable the module.
+By default, the module is disabled and the :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_NONE <config_desktop_app_options>` option is selected.
+Set the option :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_DISCRETE <config_desktop_app_options>` to enable the module.
 
 The following module configuration options are available:
 
-* ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PIN`` - Configures the pin to which the charge status output (CSO) from the charger is connected.
+* :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PIN <config_desktop_app_options>` - Configures the pin to which the charge status output (CSO) from the charger is connected.
 
-  * ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_NONE`` - CSO pin pull disabled (default setting).
-  * ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_UP`` - CSO pin pull up.
-  * ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_DOWN`` - CSO pin pull down.
+  * :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_NONE <config_desktop_app_options>` - CSO pin pull disabled (default setting).
+  * :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_UP <config_desktop_app_options>` - CSO pin pull up.
+  * :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_PULL_DOWN <config_desktop_app_options>` - CSO pin pull down.
 
-* ``CONFIG_DESKTOP_BATTERY_CHARGER_ENABLE_PIN`` - Configures the pin that enables the battery charging.
-* ``CONFIG_DESKTOP_BATTERY_CHARGER_ENABLE_INVERSED`` - Option for inversing the charging enable signal.
-* ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_FREQ`` - Set this Kconfig option to the CSO pin state switching frequency (in Hz) for when a charging error occurs.
+* :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_ENABLE_PIN <config_desktop_app_options>` - Configures the pin that enables the battery charging.
+* :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_ENABLE_INVERSED <config_desktop_app_options>` - Option for inversing the charging enable signal.
+* :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_FREQ <config_desktop_app_options>` - Set this Kconfig option to the CSO pin state switching frequency (in Hz) for when a charging error occurs.
 
 Implementation details
 **********************
@@ -59,4 +59,4 @@ The battery state can have one of the following values:
 
 * :c:enumerator:`BATTERY_STATE_IDLE` - Battery is not being charged (CSO pin set to logical high).
 * :c:enumerator:`BATTERY_STATE_CHARGING` - Battery is being charged (CSO pin set to logical low).
-* :c:enumerator:`BATTERY_STATE_ERROR` - Battery charger reported an error (a signal with the ``CONFIG_DESKTOP_BATTERY_CHARGER_CSO_FREQ`` frequency and a 50% duty cycle on the CSO pin).
+* :c:enumerator:`BATTERY_STATE_ERROR` - Battery charger reported an error (a signal with the :ref:`CONFIG_DESKTOP_BATTERY_CHARGER_CSO_FREQ <config_desktop_app_options>` frequency and a 50% duty cycle on the CSO pin).

--- a/applications/nrf_desktop/doc/battery_meas.rst
+++ b/applications/nrf_desktop/doc/battery_meas.rst
@@ -29,14 +29,14 @@ For this reason, set the following options:
 * :kconfig:option:`CONFIG_ADC_ASYNC` - The module's implementation uses asynchronous calls.
 * :kconfig:option:`CONFIG_ADC_NRFX_SAADC` - The module's implementation uses nrfx SAADC driver for nRF52 MCU series.
 
-Set :kconfig:option:`CONFIG_DESKTOP_BATTERY_MEAS` to enable the module.
-Also, make sure to define :kconfig:option:`CONFIG_DESKTOP_BATTERY_MEAS_POLL_INTERVAL_MS`, that is the amount of time between the subsequent battery measurements (in ms).
+Set :ref:`CONFIG_DESKTOP_BATTERY_MEAS <config_desktop_app_options>` to enable the module.
+Also, make sure to define :ref:`CONFIG_DESKTOP_BATTERY_MEAS_POLL_INTERVAL_MS <config_desktop_app_options>`, that is the amount of time between the subsequent battery measurements (in ms).
 
-If the measurement circuit contains a voltage divider made of two resistors, set the :kconfig:option:`CONFIG_DESKTOP_BATTERY_MEAS_HAS_VOLTAGE_DIVIDER` option.
+If the measurement circuit contains a voltage divider made of two resistors, set the :ref:`CONFIG_DESKTOP_BATTERY_MEAS_HAS_VOLTAGE_DIVIDER <config_desktop_app_options>` option.
 The following defines specify the values of these two resistors (in kOhm):
 
-* :kconfig:option:`CONFIG_DESKTOP_BATTERY_MEAS_VOLTAGE_DIVIDER_UPPER` - Upper resistor.
-* :kconfig:option:`CONFIG_DESKTOP_BATTERY_MEAS_VOLTAGE_DIVIDER_LOWER` - Lower resistor.
+* :ref:`CONFIG_DESKTOP_BATTERY_MEAS_VOLTAGE_DIVIDER_UPPER <config_desktop_app_options>` - Upper resistor.
+* :ref:`CONFIG_DESKTOP_BATTERY_MEAS_VOLTAGE_DIVIDER_LOWER <config_desktop_app_options>` - Lower resistor.
 
 The module measures the voltage over the lower resistor.
 
@@ -45,12 +45,12 @@ You can find this file the in board-specific directory in the application config
 
 Remember to also define the following battery parameters (otherwise, the default values will be used):
 
-* :kconfig:option:`CONFIG_DESKTOP_BATTERY_MEAS_MIN_LEVEL` - Battery voltage in mV that corresponds to the 0% battery level.
-* :kconfig:option:`CONFIG_DESKTOP_BATTERY_MEAS_MAX_LEVEL` - Battery voltage in mV that corresponds to the 100% battery level.
-* :kconfig:option:`CONFIG_DESKTOP_VOLTAGE_TO_SOC_DELTA` - Difference in mV between the adjacent elements in the conversion lookup table.
+* :ref:`CONFIG_DESKTOP_BATTERY_MEAS_MIN_LEVEL <config_desktop_app_options>` - Battery voltage in mV that corresponds to the 0% battery level.
+* :ref:`CONFIG_DESKTOP_BATTERY_MEAS_MAX_LEVEL <config_desktop_app_options>` - Battery voltage in mV that corresponds to the 100% battery level.
+* :ref:`CONFIG_DESKTOP_VOLTAGE_TO_SOC_DELTA <config_desktop_app_options>` - Difference in mV between the adjacent elements in the conversion lookup table.
 
-If a pin is used to enable the battery measurement, enable the :kconfig:option:`CONFIG_DESKTOP_BATTERY_MEAS_HAS_ENABLE_PIN` option.
-The number of the pin used for this purpose must be defined as :kconfig:option:`CONFIG_DESKTOP_BATTERY_MEAS_ENABLE_PIN`.
+If a pin is used to enable the battery measurement, enable the :ref:`CONFIG_DESKTOP_BATTERY_MEAS_HAS_ENABLE_PIN <config_desktop_app_options>` option.
+The number of the pin used for this purpose must be defined as :ref:`CONFIG_DESKTOP_BATTERY_MEAS_ENABLE_PIN <config_desktop_app_options>` option.
 The implementation uses the ``GPIO0`` port.
 Because Zephyr's :ref:`zephyr:gpio_api` driver is used to control this pin, also set the :kconfig:option:`CONFIG_GPIO` option.
 

--- a/applications/nrf_desktop/doc/ble_bond.rst
+++ b/applications/nrf_desktop/doc/ble_bond.rst
@@ -96,7 +96,7 @@ When in this state, the following transitions are possible:
 * Start peer erase with :c:enumerator:`PEER_OPERATION_ERASE` by triggering a ``click_event`` with the ``CLICK_LONG`` click type.
 * Start erase advertising with :c:enumerator:`PEER_OPERATION_ERASE_ADV` by triggering a ``click_event`` with the ``ON_START_CLICK(CLICK_LONG)`` click type.
 * Select next peer with :c:enumerator:`PEER_OPERATION_SELECT` by triggering a ``click_event`` with the ``CLICK_SHORT`` click type.
-* Select the dongle peer with :c:enumerator:`PEER_OPERATION_SELECTED` by triggering a ``selector_event`` with the selector in the :kconfig:option:`CONFIG_DESKTOP_BLE_DONGLE_PEER_SELECTOR_POS` position.
+* Select the dongle peer with :c:enumerator:`PEER_OPERATION_SELECTED` by triggering a ``selector_event`` with the selector in the :ref:`CONFIG_DESKTOP_BLE_DONGLE_PEER_SELECTOR_POS <config_desktop_app_options>` position.
 
 It is also possible to trigger looking for a new peer with :c:enumerator:`PEER_OPERATION_SCAN_REQUEST` with a ``click_event`` of the ``CLICK_SHORT`` click type.
 
@@ -131,7 +131,7 @@ The application local identity still uses the Bluetooth local identity that was 
    The erase advertising timeout can be extended in case a new peer connects.
    This ensures that a new peer will have time to establish the Bluetooth security level.
 
-   The timeout is increased to a bigger value when the passkey authentication is enabled (:kconfig:option:`CONFIG_DESKTOP_BLE_ENABLE_PASSKEY`).
+   The timeout is increased to a bigger value when the passkey authentication is enabled (:ref:`CONFIG_DESKTOP_BLE_ENABLE_PASSKEY <config_desktop_app_options>`).
    This gives the end user enough time to enter the passkey.
 
 Peer selection (:c:enumerator:`STATE_SELECT_PEER`)
@@ -145,7 +145,7 @@ Dongle states
 
 The module can go into one of the following dongle states:
 
-* :c:enumerator:`STATE_DONGLE` - This is the default state of the module when the hardware selector used to select the dongle peer is placed in the :kconfig:option:`CONFIG_DESKTOP_BLE_DONGLE_PEER_SELECTOR_POS` position.
+* :c:enumerator:`STATE_DONGLE` - This is the default state of the module when the hardware selector used to select the dongle peer is placed in the :ref:`CONFIG_DESKTOP_BLE_DONGLE_PEER_SELECTOR_POS <config_desktop_app_options>` position.
   This state is used for connection with the nRF Desktop dongle.
 * :c:enumerator:`STATE_DONGLE_STANDBY` - The Bluetooth LE bond module is suspended when the dongle peer is selected.
   See :ref:`ble_bond_standby_states`.
@@ -183,7 +183,7 @@ Configuration
 *************
 
 The module requires the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
-Set the :kconfig:option:`CONFIG_DESKTOP_BLE_BOND_ENABLE` option to enable the module.
+Set the :ref:`CONFIG_DESKTOP_BLE_BOND_ENABLE <config_desktop_app_options>` option to enable the module.
 
 You can control the connected peers using the following methods:
 
@@ -199,19 +199,19 @@ Peer control using a button
 
 Complete the following steps to let the user control Bluetooth peers using the dedicated button:
 
-1. Set the :kconfig:option:`CONFIG_DESKTOP_BLE_PEER_CONTROL` option to enable the feature.
+1. Set the :ref:`CONFIG_DESKTOP_BLE_PEER_CONTROL <config_desktop_app_options>` option to enable the feature.
 #. Configure the :ref:`caf_buttons`.
-#. Define the button's key ID as :kconfig:option:`CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON`.
+#. Define the button's key ID as :ref:`CONFIG_DESKTOP_BLE_PEER_CONTROL_BUTTON <config_desktop_app_options>`.
 #. Add the button to the :ref:`nrf_desktop_click_detector` configuration, because the |ble_bond| reacts on ``click_event``.
 
 The following peer operations can be enabled:
 
-* :kconfig:option:`CONFIG_DESKTOP_BLE_PEER_ERASE` - Bluetooth LE peer erase triggered at any time.
-* :kconfig:option:`CONFIG_DESKTOP_BLE_PEER_ERASE_ON_START` - Erase advertising triggered by long press of the predefined button on system start.
+* :ref:`CONFIG_DESKTOP_BLE_PEER_ERASE <config_desktop_app_options>` - Bluetooth LE peer erase triggered at any time.
+* :ref:`CONFIG_DESKTOP_BLE_PEER_ERASE_ON_START <config_desktop_app_options>` - Erase advertising triggered by long press of the predefined button on system start.
   This option can be used only by nRF Desktop peripheral.
-* :kconfig:option:`CONFIG_DESKTOP_BLE_PEER_SELECT` - Select Bluetooth LE peer.
+* :ref:`CONFIG_DESKTOP_BLE_PEER_SELECT <config_desktop_app_options>` - Select Bluetooth LE peer.
   This option can be used only by nRF Desktop peripheral.
-* :kconfig:option:`CONFIG_DESKTOP_BLE_NEW_PEER_SCAN_REQUEST` - Scan for new Bluetooth peers.
+* :ref:`CONFIG_DESKTOP_BLE_NEW_PEER_SCAN_REQUEST <config_desktop_app_options>` - Scan for new Bluetooth peers.
   This option can be used only by nRF Desktop central.
 
 Peer control using a hardware selector
@@ -220,7 +220,7 @@ Peer control using a hardware selector
 .. note::
     This feature can be used only by nRF Desktop peripheral devices.
 
-Set the :kconfig:option:`CONFIG_DESKTOP_BLE_DONGLE_PEER_ENABLE` option to use the dedicated local identity to connect with the dongle.
+Set the :ref:`CONFIG_DESKTOP_BLE_DONGLE_PEER_ENABLE <config_desktop_app_options>` option to use the dedicated local identity to connect with the dongle.
 The last application local identity (the one with the highest ID) is used for this purpose.
 
 The dongle is the nRF Desktop central.
@@ -230,8 +230,8 @@ This local identity is meant to be paired with the dongle during the production 
 The dongle peer is selected using the :ref:`nrf_desktop_selector`.
 You must also define the following parameters of the selector used to switch between dongle peer and other Bluetooth LE peers:
 
-* :kconfig:option:`CONFIG_DESKTOP_BLE_DONGLE_PEER_SELECTOR_ID` - Selector ID.
-* :kconfig:option:`CONFIG_DESKTOP_BLE_DONGLE_PEER_SELECTOR_POS` - Selector position for the dongle peer (when selector is in other position, other Bluetooth peers are selected).
+* :ref:`CONFIG_DESKTOP_BLE_DONGLE_PEER_SELECTOR_ID <config_desktop_app_options>` - Selector ID.
+* :ref:`CONFIG_DESKTOP_BLE_DONGLE_PEER_SELECTOR_POS <config_desktop_app_options>` - Selector position for the dongle peer (when selector is in other position, other Bluetooth peers are selected).
 
 .. note::
     The Bluetooth local identity used for the dongle peer does not provide any special capabilities.
@@ -244,7 +244,7 @@ Default Bluetooth local identity on peripheral
 ==============================================
 
 By default, the default Bluetooth local identity is unused, because it cannot be reset.
-You can set :kconfig:option:`CONFIG_DESKTOP_BLE_USE_DEFAULT_ID` to make the nRF Desktop peripheral initially use the default Bluetooth local identity for the application local identity with ID ``0``.
+You can set :ref:`CONFIG_DESKTOP_BLE_USE_DEFAULT_ID <config_desktop_app_options>` to make the nRF Desktop peripheral initially use the default Bluetooth local identity for the application local identity with ID ``0``.
 After the successful erase advertising for application local identity with ID ``0``, the default Bluetooth local identity is switched out and it is no longer used.
 The peer bonded with the default Bluetooth local identity is unpaired.
 
@@ -256,8 +256,8 @@ Erasing dongle peers
 
 To enable erasing dongle peer you have to enable the following options:
 
-* :kconfig:option:`CONFIG_DESKTOP_BLE_DONGLE_PEER_ERASE_BOND_BUTTON` - If you want to enable erasing peers using buttons.
-* :kconfig:option:`CONFIG_DESKTOP_BLE_DONGLE_PEER_ERASE_BOND_CONF_CHANNEL` - If you want to enable erasing peers using `Configuration channel options`_.
+* :ref:`CONFIG_DESKTOP_BLE_DONGLE_PEER_ERASE_BOND_BUTTON <config_desktop_app_options>` - If you want to enable erasing peers using buttons.
+* :ref:`CONFIG_DESKTOP_BLE_DONGLE_PEER_ERASE_BOND_CONF_CHANNEL <config_desktop_app_options>` - If you want to enable erasing peers using `Configuration channel options`_.
 
 Configuration channel options
 *****************************

--- a/applications/nrf_desktop/doc/ble_discovery.rst
+++ b/applications/nrf_desktop/doc/ble_discovery.rst
@@ -49,7 +49,7 @@ Complete the following steps to configure the module:
 
         The assigned PIDs should be unique for devices with the same VID.
 
-#. Set the :kconfig:option:`CONFIG_DESKTOP_BLE_DISCOVERY_ENABLE` Kconfig option to enable the ``ble_discovery`` application module.
+#. Set the :ref:`CONFIG_DESKTOP_BLE_DISCOVERY_ENABLE <config_desktop_app_options>` Kconfig option to enable the ``ble_discovery`` application module.
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/doc/ble_latency.rst
+++ b/applications/nrf_desktop/doc/ble_latency.rst
@@ -30,10 +30,10 @@ Configuration
 The module requires the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
 The module is enabled for every nRF Desktop peripheral device.
 
-You can use the option :kconfig:option:`CONFIG_DESKTOP_BLE_SECURITY_FAIL_TIMEOUT_S` to define the maximum allowed time for establishing the connection security.
+You can use the option :ref:`CONFIG_DESKTOP_BLE_SECURITY_FAIL_TIMEOUT_S <config_desktop_app_options>` to define the maximum allowed time for establishing the connection security.
 If the connection is not secured during this period of time, the peripheral device disconnects.
 
-You can set the option :kconfig:option:`CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK` to keep the connection latency low for the LLPM connections.
+You can set the option :ref:`CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK <config_desktop_app_options>` to keep the connection latency low for the LLPM connections.
 This speeds up sending the first HID report after not sending a report for some connection intervals.
 Enabling this option increases the power consumption - the connection latency is kept low unless the device is in the low power mode.
 
@@ -55,7 +55,7 @@ When these events are received, the module sets the connection latency to low.
 When the :ref:`nrf_desktop_config_channel` is no longer in use and the firmware update is not received by :ref:`nrf_desktop_ble_smp` (no mentioned events for ``LOW_LATENCY_CHECK_PERIOD_MS``), the module sets the connection latency to :kconfig:option:`CONFIG_BT_PERIPHERAL_PREF_LATENCY`  to reduce the power consumption.
 
   .. note::
-     If the option :kconfig:option:`CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK` is enabled, the LLPM connection latency is not increased unless the device is in the low power mode.
+     If the option :ref:`CONFIG_DESKTOP_BLE_LOW_LATENCY_LOCK <config_desktop_app_options>` is enabled, the LLPM connection latency is not increased unless the device is in the low power mode.
 
      When the device is in the low power mode and the events related to data transfer are not received, the connection latency is set to higher value to reduce the power consumption.
 

--- a/applications/nrf_desktop/doc/ble_passkey.rst
+++ b/applications/nrf_desktop/doc/ble_passkey.rst
@@ -25,7 +25,7 @@ Configuration
 The module requires the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
 The module can be used only for Bluetooth Peripheral devices (:kconfig:option:`CONFIG_BT_PERIPHERAL`).
 
-Use the option :kconfig:option:`CONFIG_DESKTOP_BLE_ENABLE_PASSKEY` to enable the module.
+Use the option :ref:`CONFIG_DESKTOP_BLE_ENABLE_PASSKEY <config_desktop_app_options>` to enable the module.
 Make sure to enable and configure the :ref:`nrf_desktop_passkey` if you decide to use this option.
 
 Implementation details

--- a/applications/nrf_desktop/doc/ble_qos.rst
+++ b/applications/nrf_desktop/doc/ble_qos.rst
@@ -27,27 +27,27 @@ Configuration
 The module requires the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
 
 The QoS module uses the ``chmap_filter`` library, whose API is described in :file:`src/util/chmap_filter/include/chmap_filter.h`.
-The library is linked if :kconfig:option:`CONFIG_DESKTOP_BLE_QOS_ENABLE` Kconfig option is enabled.
+The library is linked if :ref:`CONFIG_DESKTOP_BLE_QOS_ENABLE <config_desktop_app_options>` Kconfig option is enabled.
 
-Enable the module using the :kconfig:option:`CONFIG_DESKTOP_BLE_QOS_ENABLE` Kconfig option.
+Enable the module using the :ref:`CONFIG_DESKTOP_BLE_QOS_ENABLE <config_desktop_app_options>` Kconfig option.
 The option selects :kconfig:option:`CONFIG_BT_HCI_VS_EVT_USER`, because the module uses vendor-specific HCI events.
 
-You can use the :kconfig:option:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE` option to enable real-time QoS information printouts through a virtual COM port (serial port emulated over USB).
+You can use the :ref:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE <config_desktop_app_options>` option to enable real-time QoS information printouts through a virtual COM port (serial port emulated over USB).
 This option also enables and configures the COM port (USB CDC ACM).
 For this reason, the :kconfig:option:`CONFIG_USB_DEVICE_STACK` must be enabled.
 
 The QoS module creates additional thread for processing the QoS algorithm.
 You can define the following options:
 
-* :kconfig:option:`CONFIG_DESKTOP_BLE_QOS_INTERVAL`
+* :ref:`CONFIG_DESKTOP_BLE_QOS_INTERVAL <config_desktop_app_options>`
     This option specifies the amount of time of the processing interval for the QoS thread.
     The interval is defined in milliseconds.
     The thread periodically performs calculations and then sleeps during the interval.
     Longer intervals give more time to accumulate the Cyclic Redundancy Check (CRC) stats.
-* :kconfig:option:`CONFIG_DESKTOP_BLE_QOS_STACK_SIZE`
+* :ref:`CONFIG_DESKTOP_BLE_QOS_STACK_SIZE <config_desktop_app_options>`
     This option defines the base stack size for the QoS thread.
-* :kconfig:option:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINT_STACK_SIZE`
-    This option specifies the stack size increase if :kconfig:option:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE` is enabled.
+* :ref:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINT_STACK_SIZE <config_desktop_app_options>`
+    This option specifies the stack size increase if :ref:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE <config_desktop_app_options>` is enabled.
 
 .. tip::
    You can use the default thread stack sizes as long as you do not modify the module source code.
@@ -123,7 +123,7 @@ The thread is used to periodically perform the following operations:
 * Submit the suggested channel map as ``ble_qos_event``.
 * If the device is a Bluetooth central, update the used Bluetooth LE channel map.
 
-If the :kconfig:option:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE` Kconfig option is set, the module prints the following information through the virtual COM port:
+If the :ref:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE <config_desktop_app_options>` Kconfig option is set, the module prints the following information through the virtual COM port:
 
 * HID report rate
    The module counts the number of HID input reports received through Bluetoooth LE and prints the report rate through the virtual COM port every 100 packets.

--- a/applications/nrf_desktop/doc/ble_scan.rst
+++ b/applications/nrf_desktop/doc/ble_scan.rst
@@ -63,7 +63,7 @@ Complete the following steps to enable the |ble_scan|:
    * When you request scan start or peer erase.
 
    If filters are not cleared by the application, the Bluetooth Central will be unable to reconnect to the peripheral after exceeding the maximum connection attempts.
-#. Configure the maximum number of bonded mice (:kconfig:option:`CONFIG_DESKTOP_BLE_SCAN_MOUSE_LIMIT`) and keyboards (:kconfig:option:`CONFIG_DESKTOP_BLE_SCAN_KEYBOARD_LIMIT`) for the nRF Desktop central.
+#. Configure the maximum number of bonded mice (:ref:`CONFIG_DESKTOP_BLE_SCAN_MOUSE_LIMIT <config_desktop_app_options>`) and keyboards (:ref:`CONFIG_DESKTOP_BLE_SCAN_KEYBOARD_LIMIT <config_desktop_app_options>`) for the nRF Desktop central.
    By default, the nRF Desktop central connects and bonds with only one mouse and one keyboard.
 #. Define the Bluetooth name filters in the :file:`ble_scan_def.h` file that is located in the board-specific directory in the application configuration directory.
    You must define a Bluetooth name filter for every peripheral type the nRF Desktop central connects to.
@@ -73,20 +73,20 @@ Complete the following steps to enable the |ble_scan|:
       The Bluetooth device name for given peripheral is defined as the :kconfig:option:`CONFIG_BT_DEVICE_NAME` Kconfig option in the peripheral's configuration.
       For more detailed information about the Bluetooth advertising configuration in the nRF Desktop application, see the :ref:`nrf_desktop_ble_adv` documentation.
 
-#. Set the :kconfig:option:`CONFIG_DESKTOP_BLE_SCANNING_ENABLE` option to enable the |ble_scan|.
+#. Set the :ref:`CONFIG_DESKTOP_BLE_SCANNING_ENABLE <config_desktop_app_options>` option to enable the |ble_scan|.
 
 By default, the nRF Desktop central always looks for both bonded and unbonded peripherals.
-You can set the :kconfig:option:`CONFIG_DESKTOP_BLE_NEW_PEER_SCAN_REQUEST` option to make the device look for unbonded peripherals only on user request.
+You can set the :ref:`CONFIG_DESKTOP_BLE_NEW_PEER_SCAN_REQUEST <config_desktop_app_options>` option to make the device look for unbonded peripherals only on user request.
 The request is submitted by :ref:`nrf_desktop_ble_bond` as :c:struct:`ble_peer_operation_event` with :c:member:`ble_peer_operation_event.op` set to :c:enumerator:`PEER_OPERATION_SCAN_REQUEST`.
 
 The central always looks for new bonds also after the bond erase (on :c:struct:`ble_peer_operation_event` with :c:member:`ble_peer_operation_event.op` set to :c:enumerator:`PEER_OPERATION_ERASED`).
-If :kconfig:option:`CONFIG_DESKTOP_BLE_NEW_PEER_SCAN_REQUEST` is enabled, you can also set the :kconfig:option:`CONFIG_DESKTOP_BLE_NEW_PEER_SCAN_ON_BOOT` option to make the central scan for new peers after every boot.
+If :ref:`CONFIG_DESKTOP_BLE_NEW_PEER_SCAN_REQUEST <config_desktop_app_options>` is enabled, you can also set the :ref:`CONFIG_DESKTOP_BLE_NEW_PEER_SCAN_ON_BOOT <config_desktop_app_options>` option to make the central scan for new peers after every boot.
 
 The following scanning scenarios are possible:
 
 * If no peripheral is connected, the central scans for the peripheral devices without interruption.
 * If a peripheral is connected, the scanning is triggered periodically.
-  If none of the connected peripherals is in use for at least :kconfig:option:`CONFIG_DESKTOP_BLE_SCAN_START_TIMEOUT_S`, the scanning is started.
+  If none of the connected peripherals is in use for at least :ref:`CONFIG_DESKTOP_BLE_SCAN_START_TIMEOUT_S <config_desktop_app_options>`, the scanning is started.
 
 Scanning not started
 ====================
@@ -106,7 +106,7 @@ The scanning is interrupted if one of the following conditions occurs:
 
 * A connected peripheral is in use.
   Scanning in this situation will have a negative impact on user experience.
-* The maximum scan duration specified by :kconfig:option:`CONFIG_DESKTOP_BLE_SCAN_DURATION_S` times out.
+* The maximum scan duration specified by :ref:`CONFIG_DESKTOP_BLE_SCAN_DURATION_S <config_desktop_app_options>` times out.
 
 The scanning is never interrupted if there is no connected Bluetooth peer.
 

--- a/applications/nrf_desktop/doc/buttons.rst
+++ b/applications/nrf_desktop/doc/buttons.rst
@@ -29,5 +29,5 @@ See the :ref:`CAF button module <caf_buttons>` page for implementation details.
 Key ID
 ======
 
-If :kconfig:option:`CONFIG_DESKTOP_FN_KEYS_ENABLE` is enabled, the :c:member:`button_event.key_id` additionally encodes if a button related to :c:struct:`button_event` is a function key.
+If :ref:`CONFIG_DESKTOP_FN_KEYS_ENABLE <config_desktop_app_options>` is enabled, the :c:member:`button_event.key_id` additionally encodes if a button related to :c:struct:`button_event` is a function key.
 See the :ref:`nRF Desktop function key module <nrf_desktop_fn_keys>` page for implementation details.

--- a/applications/nrf_desktop/doc/buttons_sim.rst
+++ b/applications/nrf_desktop/doc/buttons_sim.rst
@@ -28,13 +28,13 @@ To configure the |button_sim|:
 
 1. Enable and configure the :ref:`caf_buttons`.
    ``button_event`` is used to trigger the simulated button sequence.
-#. Enable the ``buttons_sim`` module by setting the :kconfig:option:`CONFIG_DESKTOP_BUTTONS_SIM_ENABLE` Kconfig option.
+#. Enable the ``buttons_sim`` module by setting the :ref:`CONFIG_DESKTOP_BUTTONS_SIM_ENABLE <config_desktop_app_options>` Kconfig option.
 #. Define the output key ID sequence in the :file:`buttons_sim_def.h` file located in the board-specific directory in the :file:`configuration` directory.
    The mapping from the defined key ID to the HID report ID and usage ID is defined in :file:`hid_keymap_def.h` (this might be different for different boards).
-#. Define the interval between subsequent simulated button presses (:kconfig:option:`CONFIG_DESKTOP_BUTTONS_SIM_INTERVAL`).
+#. Define the interval between subsequent simulated button presses (:ref:`CONFIG_DESKTOP_BUTTONS_SIM_INTERVAL <config_desktop_app_options>`).
    One second is used by default.
 
-If you want the sequence to automatically restart after it ends, set :kconfig:option:`CONFIG_DESKTOP_BUTTONS_SIM_LOOP_FOREVER`.
+If you want the sequence to automatically restart after it ends, set :ref:`CONFIG_DESKTOP_BUTTONS_SIM_LOOP_FOREVER <config_desktop_app_options>`.
 By default, the sequence is generated only once.
 
 Implementation details
@@ -43,6 +43,6 @@ Implementation details
 The |button_sim| generates button sequence using :c:struct:`k_work_delayable`, which resubmits itself.
 The work handler submits the press and the release of a single button from the sequence.
 
-Receiving ``button_event`` with the key ID set to :kconfig:option:`CONFIG_DESKTOP_BUTTONS_SIM_TRIGGER_KEY_ID` either stops generating the sequence (in case it is already being generated) or starts generating it.
+Receiving ``button_event`` with the key ID set to :ref:`CONFIG_DESKTOP_BUTTONS_SIM_TRIGGER_KEY_ID <config_desktop_app_options>` either stops generating the sequence (in case it is already being generated) or starts generating it.
 
 .. |button_sim| replace:: button simulator module

--- a/applications/nrf_desktop/doc/config_channel.rst
+++ b/applications/nrf_desktop/doc/config_channel.rst
@@ -356,7 +356,7 @@ For example, :ref:`nrf_desktop_motion` uses this option to identify a motion sen
 Handling configuration channel in firmware
 ******************************************
 
-To enable the configuration channel in the nRF Desktop firmware, set the :kconfig:option:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE` Kconfig option.
+To enable the configuration channel in the nRF Desktop firmware, set the :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE <config_desktop_app_options>` Kconfig option.
 This option also enables the mandatory :ref:`nrf_desktop_info`.
 
 Make sure you also configure the following configuration channel elements:
@@ -388,7 +388,7 @@ Depending on the connection method:
 
    The "GATT write without response" operation cannot be performed on the HID feature report.
    To allow the "GATT write without response", the Peripheral must provide an additional HID output report.
-   Use the :kconfig:option:`CONFIG_DESKTOP_CONFIG_CHANNEL_OUT_REPORT` Kconfig option in the nRF Desktop peripheral configuration to add the mentioned HID output report.
+   Use the :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_OUT_REPORT <config_desktop_app_options>` Kconfig option in the nRF Desktop peripheral configuration to add the mentioned HID output report.
    Disabling this option reduces the memory consumption.
 
 The :c:struct:`config_event` is used to propagate the configuration channel data.

--- a/applications/nrf_desktop/doc/constlat.rst
+++ b/applications/nrf_desktop/doc/constlat.rst
@@ -23,7 +23,7 @@ Module events
 Configuration
 *************
 
-Enable the module with the :kconfig:option:`CONFIG_DESKTOP_CONSTLAT_ENABLE` Kconfig option.
+Enable the module with the :ref:`CONFIG_DESKTOP_CONSTLAT_ENABLE <config_desktop_app_options>` option.
 
-You can set the :kconfig:option:`CONFIG_DESKTOP_CONSTLAT_DISABLE_ON_STANDBY` to disable the constant latency interrupts when the device goes to the low power mode (on ``power_down_event``).
+You can set the :ref:`CONFIG_DESKTOP_CONSTLAT_DISABLE_ON_STANDBY <config_desktop_app_options>` to disable the constant latency interrupts when the device goes to the low power mode (on ``power_down_event``).
 The constant latency interrupts are reenabled on ``wake_up_event``.

--- a/applications/nrf_desktop/doc/cpu_meas.rst
+++ b/applications/nrf_desktop/doc/cpu_meas.rst
@@ -22,11 +22,11 @@ Module events
 Configuration
 *************
 
-Enable the module using the :kconfig:option:`CONFIG_DESKTOP_CPU_MEAS_ENABLE` Kconfig option.
+Enable the module using the :ref:`CONFIG_DESKTOP_CPU_MEAS_ENABLE <config_desktop_app_options>` option.
 This Kconfig option selects the :kconfig:option:`CONFIG_CPU_LOAD` option.
 The :kconfig:option:`CONFIG_CPU_LOAD` option enables :ref:`cpu_load`, that is used to perform the measurements.
 
-Set the time between subsequent CPU load measurements, in milliseconds, using the :kconfig:option:`CONFIG_DESKTOP_CPU_MEAS_PERIOD` option.
+Set the time between subsequent CPU load measurements, in milliseconds, using the :ref:`CONFIG_DESKTOP_CPU_MEAS_PERIOD <config_desktop_app_options>` option.
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/doc/dfu.rst
+++ b/applications/nrf_desktop/doc/dfu.rst
@@ -35,10 +35,10 @@ For more information on how to enable the bootloader, see the :ref:`nrf_desktop_
    * Requests the image upgrade after the whole image is transferred over the :ref:`nrf_desktop_config_channel`.
    * Confirms the running image after device reboot.
 
-Enable the DFU module using the :kconfig:option:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_ENABLE` option.
-It requires the transport option :kconfig:option:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE` to be selected, as it uses :ref:`nrf_desktop_config_channel` for the transmission of the update image.
+Enable the DFU module using the :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_ENABLE <config_desktop_app_options>` option.
+It requires the transport option :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE <config_desktop_app_options>` to be selected, as it uses :ref:`nrf_desktop_config_channel` for the transmission of the update image.
 
-Set the value of :kconfig:option:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_SYNC_BUFFER_SIZE` to specify the size of the sync buffer (in words).
+Set the value of :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_DFU_SYNC_BUFFER_SIZE <config_desktop_app_options>` to specify the size of the sync buffer (in words).
 During the DFU, the data is initially stored in the buffer and then it is moved to flash.
 The buffer is located in the RAM, so increasing the buffer size increases the RAM usage.
 If the buffer is small, the host must perform the DFU progress synchronization more often.

--- a/applications/nrf_desktop/doc/failsafe.rst
+++ b/applications/nrf_desktop/doc/failsafe.rst
@@ -23,7 +23,7 @@ Module Events
 Configuration
 *************
 
-Use the :kconfig:option:`CONFIG_DESKTOP_FAILSAFE_ENABLE` option to enable the module.
+Use the :ref:`CONFIG_DESKTOP_FAILSAFE_ENABLE <config_desktop_app_options>` option to enable the module.
 
 Additionally, make sure that the following options are set as follows:
 

--- a/applications/nrf_desktop/doc/fn_keys.rst
+++ b/applications/nrf_desktop/doc/fn_keys.rst
@@ -25,14 +25,14 @@ Configuration
 The module uses ``button_event`` sent by :ref:`caf_buttons`.
 Make sure mentioned hardware interface is defined.
 
-The module is enabled with :kconfig:option:`CONFIG_DESKTOP_FN_KEYS_ENABLE` option.
+The module is enabled with :ref:`CONFIG_DESKTOP_FN_KEYS_ENABLE <config_desktop_app_options>` option.
 
 You must configure the following options:
 
-* :kconfig:option:`CONFIG_DESKTOP_FN_KEYS_SWITCH` - Fn key button.
-* :kconfig:option:`CONFIG_DESKTOP_FN_KEYS_LOCK` - Fn lock button.
-* :kconfig:option:`CONFIG_DESKTOP_STORE_FN_LOCK` - Option for defining if the device should store the Fn lock state after reboot (set by default to storing the state).
-* :kconfig:option:`CONFIG_DESKTOP_FN_KEYS_MAX_ACTIVE` - Maximum number of dual-purpose keys pressed at the same time (8 by default).
+* :ref:`CONFIG_DESKTOP_FN_KEYS_SWITCH <config_desktop_app_options>` - Fn key button.
+* :ref:`CONFIG_DESKTOP_FN_KEYS_LOCK <config_desktop_app_options>` - Fn lock button.
+* :ref:`CONFIG_DESKTOP_STORE_FN_LOCK <config_desktop_app_options>` - Option for defining if the device should store the Fn lock state after reboot (set by default to storing the state).
+* :ref:`CONFIG_DESKTOP_FN_KEYS_MAX_ACTIVE <config_desktop_app_options>` - Maximum number of dual-purpose keys pressed at the same time (8 by default).
   The module remembers the pressed keys to send proper key releases.
 
 In the file :file:`fn_keys_def.h`, define all the dual-purpose keys.

--- a/applications/nrf_desktop/doc/hfclk_lock.rst
+++ b/applications/nrf_desktop/doc/hfclk_lock.rst
@@ -24,7 +24,7 @@ Module events
 Configuration
 *************
 
-Enable the module with the :kconfig:option:`CONFIG_DESKTOP_HFCLK_LOCK_ENABLE` Kconfig option.
+Enable the module with the :ref:`CONFIG_DESKTOP_HFCLK_LOCK_ENABLE <config_desktop_app_options>` Kconfig option.
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/doc/hid_forward.rst
+++ b/applications/nrf_desktop/doc/hid_forward.rst
@@ -29,7 +29,7 @@ Configuration
 Complete the following steps to configure the module:
 
 1. Complete the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
-#. Make sure that the :kconfig:option:`CONFIG_DESKTOP_HID_STATE_ENABLE` option is disabled.
+#. Make sure that the :ref:`CONFIG_DESKTOP_HID_STATE_ENABLE <config_desktop_app_options>` option is disabled.
    The nRF Desktop central does not generate its own HID input reports.
    It only forwards HID input reports that it receives from the peripherals connected over Bluetooth.
 #. Enable and configure the :ref:`hogp_readme` (:kconfig:option:`CONFIG_BT_HOGP`).
@@ -38,19 +38,19 @@ Complete the following steps to configure the module:
        Make sure to define the maximum number of supported HID reports (:kconfig:option:`CONFIG_BT_HOGP_REPORTS_MAX`).
 
 #. Make sure to enable the :kconfig:option:`CONFIG_BT_CENTRAL` Kconfig option.
-#. Enable |hid_forward| using the :kconfig:option:`CONFIG_DESKTOP_HID_FORWARD_ENABLE` option.
+#. Enable |hid_forward| using the :ref:`CONFIG_DESKTOP_HID_FORWARD_ENABLE <config_desktop_app_options>` option.
    This option is available only if you enable both options from the previous steps.
    The module is used on Bluetooth Central to forward the HID reports that are received by the HID service client.
 #. Depending on your hardware, enable one of the following options:
 
-   * :kconfig:option:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD` - This option enables forwarding keyboard boot reports.
-   * :kconfig:option:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE` - This option enables forwarding mouse boot reports.
+   * :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD <config_desktop_app_options>` - This option enables forwarding keyboard boot reports.
+   * :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE <config_desktop_app_options>` - This option enables forwarding mouse boot reports.
 
    Those options affect :ref:`nrf_desktop_usb_state` that subscribes for HID boot reports.
    The Dongle forwards HID reports from both mouse and keyboard, and so either option works if you want to have the Dongle work as boot mouse or boot keyboard.
    For more information about the configuration of the HID boot protocol, see the boot protocol configuration section in the :ref:`nrf_desktop_usb_state` documentation.
 
-You can set the queued HID input reports limit using the :kconfig:option:`CONFIG_DESKTOP_HID_FORWARD_MAX_ENQUEUED_REPORTS` Kconfig option.
+You can set the queued HID input reports limit using the :ref:`CONFIG_DESKTOP_HID_FORWARD_MAX_ENQUEUED_REPORTS <config_desktop_app_options>` Kconfig option.
 
 Implementation details
 **********************
@@ -106,7 +106,7 @@ Enqueuing incoming HID input reports
 The |hid_forward| forwards only one HID input report to the HID-class USB device at a time.
 Another HID input report may be received from a peripheral connected over Bluetooth before the previous one was sent.
 In that case, ``hid_report_event`` is enqueued and submitted later.
-Up to the number of reports specified in :kconfig:option:`CONFIG_DESKTOP_HID_FORWARD_MAX_ENQUEUED_REPORTS` reports can be enqueued at a time for each report type and for each connected peripheral.
+Up to the number of reports specified in :ref:`CONFIG_DESKTOP_HID_FORWARD_MAX_ENQUEUED_REPORTS <config_desktop_app_options>` reports can be enqueued at a time for each report type and for each connected peripheral.
 If there is not enough space to enqueue a new event, the module drops the oldest enqueued event that was received from this peripheral (of the same type).
 
 Upon receiving the ``hid_report_sent_event``, the |hid_forward| submits the ``hid_report_event`` enqueued for the peripheral that is associated with the HID-class USB device.

--- a/applications/nrf_desktop/doc/hid_state.rst
+++ b/applications/nrf_desktop/doc/hid_state.rst
@@ -29,13 +29,13 @@ Module events
 Configuration
 *************
 
-The |hid_state| is enabled by selecting :kconfig:option:`CONFIG_DESKTOP_HID_STATE_ENABLE`.
+The |hid_state| is enabled by selecting :ref:`CONFIG_DESKTOP_HID_STATE_ENABLE <config_desktop_app_options>`.
 This module is optional and turned off by default.
 
 To send boot reports, enable the respective Kconfig option:
 
-* :kconfig:option:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD` - This option enables sending keyboard boot reports.
-* :kconfig:option:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE` - This option enables sending mouse boot reports.
+* :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD <config_desktop_app_options>` - This option enables sending keyboard boot reports.
+* :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE <config_desktop_app_options>` - This option enables sending mouse boot reports.
 
 HID keymap
 ==========
@@ -66,7 +66,7 @@ For example, the file contents should look like the following:
 		{ FN_KEY_ID(0x06, 0x03), 0x0196, REPORT_ID_CONSUMER_CTRL }, /* internet */
 	};
 
-You must define the mentioned array in this configuration file, and specify its location with the :kconfig:option:`CONFIG_DESKTOP_HID_STATE_HID_KEYMAP_DEF_PATH` Kconfig option.
+You must define the mentioned array in this configuration file, and specify its location with the :ref:`CONFIG_DESKTOP_HID_STATE_HID_KEYMAP_DEF_PATH <config_desktop_app_options>` Kconfig option.
 
 .. note::
    The configuration file should be included only by the configured module.
@@ -101,7 +101,7 @@ For example, the file contents should look like follows:
 		[HID_KEYBOARD_LEDS_KANA] = LED_UNAVAILABLE,
 	};
 
-You must define all of the mentioned data in this configuration file, and specify its location with the :kconfig:option:`CONFIG_DESKTOP_HID_STATE_HID_KEYBOARD_LEDS_DEF_PATH` Kconfig option.
+You must define all of the mentioned data in this configuration file, and specify its location with the :ref:`CONFIG_DESKTOP_HID_STATE_HID_KEYBOARD_LEDS_DEF_PATH <config_desktop_app_options>` Kconfig option.
 
 .. note::
    The configuration file should be included only by the configured module.
@@ -110,13 +110,13 @@ You must define all of the mentioned data in this configuration file, and specif
 Report expiration
 =================
 
-With the :kconfig:option:`CONFIG_DESKTOP_HID_REPORT_EXPIRATION` configuration option, you can set the amount of time after which a key will be considered expired.
+With the :ref:`CONFIG_DESKTOP_HID_REPORT_EXPIRATION <config_desktop_app_options>` configuration option, you can set the amount of time after which a key will be considered expired.
 The higher the value, the longer the period after which the nRF Desktop application will recall pressed keys when the connection is established.
 
 Queue event size
 ================
 
-With the :kconfig:option:`CONFIG_DESKTOP_HID_EVENT_QUEUE_SIZE` configuration option, you can set the number of elements on the queue where the keys are stored before the connection is established.
+With the :ref:`CONFIG_DESKTOP_HID_EVENT_QUEUE_SIZE <config_desktop_app_options>` configuration option, you can set the number of elements on the queue where the keys are stored before the connection is established.
 When a key state changes (it is pressed or released) before the connection is established, an element containing this key's usage is pushed onto the queue.
 If there is no space in the queue, the oldest element is released.
 
@@ -200,11 +200,11 @@ This queue preserves an order at which input data events are received.
 Storing limitations
 -------------------
 
-The number of events that can be inserted into the queue is limited by :kconfig:option:`CONFIG_DESKTOP_HID_EVENT_QUEUE_SIZE`.
+The number of events that can be inserted into the queue is limited by :ref:`CONFIG_DESKTOP_HID_EVENT_QUEUE_SIZE <config_desktop_app_options>` option.
 
 Discarding events
-    When there is no space for a new input event, the |hid_state| will try to free space by discarding the oldest event in the queue.
-    Events stored in the queue are automatically discarded after the period defined by :kconfig:option:`CONFIG_DESKTOP_HID_REPORT_EXPIRATION`.
+    When there is no space for a new input event, the |hid_state| tries to free space by discarding the oldest event in the queue.
+    Events stored in the queue are automatically discarded after the period defined by :ref:`CONFIG_DESKTOP_HID_REPORT_EXPIRATION <config_desktop_app_options>` option.
 
     When discarding an event from the queue, the module checks if the key associated with the event is pressed.
     This is to avoid missing key releases for earlier key presses when the keys from the queue are replayed to the host.
@@ -262,7 +262,7 @@ The :c:struct:`report_data` structure is passed as an argument to this function.
 
 .. note::
     The HID report formatting function must work according to the HID report descriptor (``hid_report_desc``).
-    The source file containing the descriptor is given by :kconfig:option:`CONFIG_DESKTOP_HID_REPORT_DESC`.
+    The source file containing the descriptor is given by :ref:`CONFIG_DESKTOP_HID_REPORT_DESC <config_desktop_app_options>` option.
 
 Handling HID keyboard LED state
 ===============================

--- a/applications/nrf_desktop/doc/hid_state_pm.rst
+++ b/applications/nrf_desktop/doc/hid_state_pm.rst
@@ -22,7 +22,7 @@ Module events
 Configuration
 *************
 
-The module is enabled by :kconfig:option:`CONFIG_DESKTOP_HID_STATE_PM_ENABLE` Kconfig option.
+The module is enabled by :ref:`CONFIG_DESKTOP_HID_STATE_PM_ENABLE <config_desktop_app_options>` Kconfig option.
 The option depends on :kconfig:option:`CONFIG_CAF_POWER_MANAGER` and it is enabled by default.
 
 Implementation details

--- a/applications/nrf_desktop/doc/hids.rst
+++ b/applications/nrf_desktop/doc/hids.rst
@@ -28,10 +28,10 @@ Complete the following steps to configure the module:
 
 1. Complete the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
    During this configuration, you must enable the :kconfig:option:`CONFIG_BT_PERIPHERAL` Kconfig option for every nRF Desktop peripheral.
-   When this option is enabled, the :kconfig:option:`CONFIG_DESKTOP_HID_PERIPHERAL` is set to ``y``, which enables the following two additional options, among others:
+   When this option is enabled, the :ref:`CONFIG_DESKTOP_HID_PERIPHERAL <config_desktop_app_options>` is set to ``y``, which enables the following two additional options, among others:
 
    * :kconfig:option:`CONFIG_BT_HIDS` - This is required because the HID Service module is based on the :ref:`hids_readme` implementation of the GATT Service.
-   * :kconfig:option:`CONFIG_DESKTOP_HIDS_ENABLE` - This enables the ``hids`` application module.
+   * :ref:`CONFIG_DESKTOP_HIDS_ENABLE <config_desktop_app_options>` - This enables the ``hids`` application module.
 
    This step also enables the |GATT_HID|.
 #. Enable the :ref:`bt_conn_ctx_readme` (:kconfig:option:`CONFIG_BT_CONN_CTX`).
@@ -46,13 +46,13 @@ The HID Service application module forwards the information about the enabled HI
 These notifications are enabled by the connected Bluetooth® Central.
 By default, the ``hids`` application module starts forwarding the subscriptions right after the Bluetooth connection is secured.
 
-You can define additional delay for forwarding the notifications on connection (:kconfig:option:`CONFIG_DESKTOP_HIDS_FIRST_REPORT_DELAY`).
+You can define additional delay for forwarding the notifications on connection (:ref:`CONFIG_DESKTOP_HIDS_FIRST_REPORT_DELAY <config_desktop_app_options>`).
 Sending the first HID report to the connected Bluetooth peer is delayed by this period of time.
 
 .. note::
    The nRF Desktop centrals perform the GATT service discovery and reenable the HID notifications on every reconnection.
    A HID report that is received before the subscription is reenabled will be dropped before it reaches the application.
-   The :kconfig:option:`CONFIG_DESKTOP_HIDS_FIRST_REPORT_DELAY` is used for keyboard reference design (nRF52832 Desktop Keyboard) to make sure that the input will not be lost on reconnection with the nRF Desktop dongle.
+   The :ref:`CONFIG_DESKTOP_HIDS_FIRST_REPORT_DELAY <config_desktop_app_options>` is used for keyboard reference design (nRF52832 Desktop Keyboard) to make sure that the input will not be lost on reconnection with the nRF Desktop dongle.
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/doc/info.rst
+++ b/applications/nrf_desktop/doc/info.rst
@@ -31,7 +31,7 @@ Configuration
 The module uses Zephyr's :ref:`zephyr:hwinfo_api` to obtain the hardware ID.
 Enable the required driver using :kconfig:option:`CONFIG_HWINFO`.
 
-The module is enabled with the same Kconfig option as the :ref:`nrf_desktop_config_channel`: :kconfig:option:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE`.
+The module is enabled with the same Kconfig option as the :ref:`nrf_desktop_config_channel`: :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE <config_desktop_app_options>`.
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/doc/led_stream.rst
+++ b/applications/nrf_desktop/doc/led_stream.rst
@@ -24,11 +24,11 @@ Configuration
 *************
 
 The module receives LED effects through the :ref:`nrf_desktop_config_channel` and displays them using the :ref:`caf_leds`.
-For this reason, make sure that :kconfig:option:`CONFIG_CAF_LEDS` and :kconfig:option:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE` are both set.
+For this reason, make sure that both :kconfig:option:`CONFIG_CAF_LEDS` and :ref:`CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE <config_desktop_app_options>` options are set.
 
-To enable the module, use the :kconfig:option:`CONFIG_DESKTOP_LED_STREAM_ENABLE` Kconfig option.
+To enable the module, use the :ref:`CONFIG_DESKTOP_LED_STREAM_ENABLE <config_desktop_app_options>` Kconfig option.
 
-You can also define the stream LED event queue size (:kconfig:option:`CONFIG_DESKTOP_LED_STREAM_QUEUE_SIZE`).
+You can also define the stream LED event queue size using :ref:`CONFIG_DESKTOP_LED_STREAM_QUEUE_SIZE <config_desktop_app_options>` option.
 The queue is used by the module as a data buffer for the data received from the host computer.
 
 Configuration channel

--- a/applications/nrf_desktop/doc/motion.rst
+++ b/applications/nrf_desktop/doc/motion.rst
@@ -27,11 +27,11 @@ Configuration
 
 The motion module selects the source of movement based on the following configuration options:
 
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_NONE` - Module is disabled.
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_PMW3360_ENABLE` - Movement data is obtained from the gaming-grade ``PMW3360`` motion sensor.
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_PAW3212_ENABLE` - Movement data is obtained from ``PAW3212`` motion sensor.
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_BUTTONS_ENABLE` - Movement data is generated using buttons.
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_SIMULATED_ENABLE` - Movement data is simulated (controlled from Zephyr's :ref:`zephyr:shell_api`).
+* :ref:`CONFIG_DESKTOP_MOTION_NONE <config_desktop_app_options>` - Module is disabled.
+* :ref:`CONFIG_DESKTOP_MOTION_SENSOR_PMW3360_ENABLE <config_desktop_app_options>` - Movement data is obtained from the gaming-grade ``PMW3360`` motion sensor.
+* :ref:`CONFIG_DESKTOP_MOTION_SENSOR_PAW3212_ENABLE <config_desktop_app_options>` - Movement data is obtained from ``PAW3212`` motion sensor.
+* :ref:`CONFIG_DESKTOP_MOTION_BUTTONS_ENABLE <config_desktop_app_options>` - Movement data is generated using buttons.
+* :ref:`CONFIG_DESKTOP_MOTION_SIMULATED_ENABLE <config_desktop_app_options>` - Movement data is simulated (controlled from Zephyr's :ref:`zephyr:shell_api`).
 
 See the following sections for more information.
 
@@ -40,24 +40,24 @@ Depending on the selected configuration option, a different implementation file 
 Movement data from motion sensors
 =================================
 
-Selecting either of the motion sensors (:kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_PMW3360_ENABLE` or :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_PAW3212_ENABLE`) adds the :file:`src/hw_interface/motion_sensor.c` file to the compilation.
+Selecting either of the motion sensors (:ref:`CONFIG_DESKTOP_MOTION_SENSOR_PMW3360_ENABLE <config_desktop_app_options>` or :ref:`CONFIG_DESKTOP_MOTION_SENSOR_PAW3212_ENABLE <config_desktop_app_options>`) adds the :file:`src/hw_interface/motion_sensor.c` file to the compilation.
 
 The motion sensor is sampled from the context of a dedicated thread.
-The option :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_THREAD_STACK_SIZE` is used to set the thread's stack size.
+The option :ref:`CONFIG_DESKTOP_MOTION_SENSOR_THREAD_STACK_SIZE <config_desktop_app_options>` is used to set the thread's stack size.
 
 The motion sensor default sensitivity and power saving switching times can be set with the following options:
 
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_CPI` - Default CPI.
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_SLEEP1_TIMEOUT_MS` - ``Sleep 1`` mode default switch time.
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_SLEEP2_TIMEOUT_MS` - ``Sleep 2`` mode default switch time.
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_SLEEP3_TIMEOUT_MS` - ``Sleep 3`` mode default switch time.
+* :ref:`CONFIG_DESKTOP_MOTION_SENSOR_CPI <config_desktop_app_options>` - Default CPI.
+* :ref:`CONFIG_DESKTOP_MOTION_SENSOR_SLEEP1_TIMEOUT_MS <config_desktop_app_options>` - ``Sleep 1`` mode default switch time.
+* :ref:`CONFIG_DESKTOP_MOTION_SENSOR_SLEEP2_TIMEOUT_MS <config_desktop_app_options>` - ``Sleep 2`` mode default switch time.
+* :ref:`CONFIG_DESKTOP_MOTION_SENSOR_SLEEP3_TIMEOUT_MS <config_desktop_app_options>` - ``Sleep 3`` mode default switch time.
 
 For more information, see the sensor documentation and the Kconfig help.
 
 Movement data from buttons
 ==========================
 
-Selecting the :kconfig:option:`CONFIG_DESKTOP_MOTION_BUTTONS_ENABLE` option adds the :file:`src/hw_interface/motion_buttons.c` file to the compilation.
+Selecting the :ref:`CONFIG_DESKTOP_MOTION_BUTTONS_ENABLE <config_desktop_app_options>` option adds the :file:`src/hw_interface/motion_buttons.c` file to the compilation.
 
 Simulated movement data
 =======================
@@ -72,15 +72,15 @@ The movement data in each event will be tracing the predefined path, an eight-si
 
 You can configure the path with the following options:
 
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_SIMULATED_EDGE_TIME` - Sets how long each edge is traced.
-* :kconfig:option:`CONFIG_DESKTOP_MOTION_SIMULATED_SCALE_FACTOR` - Scales the size of the polygon.
+* :ref:`CONFIG_DESKTOP_MOTION_SIMULATED_EDGE_TIME <config_desktop_app_options>` - Sets how long each edge is traced.
+* :ref:`CONFIG_DESKTOP_MOTION_SIMULATED_SCALE_FACTOR <config_desktop_app_options>` - Scales the size of the polygon.
 
 The ``stop`` command will cause the module to stop generating new events.
 
 Configuration channel
 *********************
 
-In a :ref:`configuration <nrf_desktop_motion_configuration>` where either :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_PMW3360_ENABLE` or :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_PAW3212_ENABLE` is used, you can configure the module through the :ref:`nrf_desktop_config_channel`.
+In a :ref:`configuration <nrf_desktop_motion_configuration>` where either :ref:`CONFIG_DESKTOP_MOTION_SENSOR_PMW3360_ENABLE <config_desktop_app_options>` or :ref:`CONFIG_DESKTOP_MOTION_SENSOR_PAW3212_ENABLE <config_desktop_app_options>` is used, you can configure the module through the :ref:`nrf_desktop_config_channel`.
 In these configurations, the module is a configuration channel listener and it provides the following configuration options:
 
 * :c:macro:`OPT_DESCR_MODULE_VARIANT`
@@ -145,5 +145,5 @@ Upon connection, the following happens:
 #. At that point, a next motion sampling is performed and the next ``motion_event`` sent.
 
 The module continues to sample data until disconnection or when there is no motion detected.
-The ``motion`` module assumes no motion when a number of consecutive samples equal to :kconfig:option:`CONFIG_DESKTOP_MOTION_SENSOR_EMPTY_SAMPLES_COUNT` returns zero on both axis.
+The ``motion`` module assumes no motion when a number of consecutive samples equal to :ref:`CONFIG_DESKTOP_MOTION_SENSOR_EMPTY_SAMPLES_COUNT <config_desktop_app_options>` returns zero on both axis.
 In such case, the module will switch back to ``STATE_IDLE`` and wait for the motion sensor trigger.

--- a/applications/nrf_desktop/doc/passkey.rst
+++ b/applications/nrf_desktop/doc/passkey.rst
@@ -28,8 +28,8 @@ The passkey input handling is based on ``button_event``.
 To configure the passkey module, complete the following steps:
 
 1. Enable and configure the :ref:`caf_buttons`.
-#. Enable the passkey module by using the :kconfig:option:`CONFIG_DESKTOP_PASSKEY_BUTTONS` Kconfig option.
-#. Define the maximum number of digits in the passkey by using the :kconfig:option:`CONFIG_DESKTOP_PASSKEY_MAX_LEN` option.
+#. Enable the passkey module by using the :ref:`CONFIG_DESKTOP_PASSKEY_BUTTONS <config_desktop_app_options>` option.
+#. Define the maximum number of digits in the passkey by using the :ref:`CONFIG_DESKTOP_PASSKEY_MAX_LEN <config_desktop_app_options>` option.
 #. Define the IDs of the keys used by the passkey module in the :file:`passkey_buttons_def.h` file located in the board-specific directory in the :file:`configuration` directory.
    You must define the IDs of the following keys:
 

--- a/applications/nrf_desktop/doc/profiler_sync.rst
+++ b/applications/nrf_desktop/doc/profiler_sync.rst
@@ -36,10 +36,10 @@ For this reason, the ``sync_event`` execution is not traced.
 
 You must also define the following:
 
-* The GPIO port (:kconfig:option:`CONFIG_DESKTOP_PROFILER_SYNC_GPIO_PORT`) and the pin (:kconfig:option:`CONFIG_DESKTOP_PROFILER_SYNC_GPIO_PIN`) that are used for synchronization.
+* The GPIO port (:ref:`CONFIG_DESKTOP_PROFILER_SYNC_GPIO_PORT <config_desktop_app_options>`) and the pin (:ref:`CONFIG_DESKTOP_PROFILER_SYNC_GPIO_PIN <config_desktop_app_options>`) that are used for synchronization.
   These GPIOs must be defined separately for both devices and connected using a physical wire.
 * The device role.
-  One of the devices must be set as ``Central`` (:kconfig:option:`CONFIG_DESKTOP_PROFILER_SYNC_CENTRAL`) and the other device must be set as ``Peripheral`` (:kconfig:option:`CONFIG_DESKTOP_PROFILER_SYNC_PERIPHERAL`).
+  One of the devices must be set as ``Central`` (:ref:`CONFIG_DESKTOP_PROFILER_SYNC_CENTRAL <config_desktop_app_options>`) and the other device must be set as ``Peripheral`` (:ref:`CONFIG_DESKTOP_PROFILER_SYNC_PERIPHERAL <config_desktop_app_options>`).
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/doc/qos.rst
+++ b/applications/nrf_desktop/doc/qos.rst
@@ -34,7 +34,7 @@ Configuration
 
 The module requires the basic Bluetooth® configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
 
-The module is enabled with :kconfig:option:`CONFIG_DESKTOP_QOS_ENABLE` option.
+The module is enabled with :ref:`CONFIG_DESKTOP_QOS_ENABLE <config_desktop_app_options>` option.
 The module is available on the :ref:`peripheral devices <nrf_desktop_bluetooth_guide_peripheral>` only and requires the :ref:`nrf_desktop_ble_qos` to be enabled.
 
 Implementation details

--- a/applications/nrf_desktop/doc/selector.rst
+++ b/applications/nrf_desktop/doc/selector.rst
@@ -26,7 +26,7 @@ Configuration
 The module implemented in :file:`selector_hw.c` uses the Zephyr :ref:`zephyr:gpio_api` driver to check the state of hardware selectors.
 For this reason, you should set :kconfig:option:`CONFIG_GPIO` option.
 
-Set :kconfig:option:`CONFIG_DESKTOP_SELECTOR_HW_ENABLE` option to enable the module.
+Set :ref:`CONFIG_DESKTOP_SELECTOR_HW_ENABLE <config_desktop_app_options>` option to enable the module.
 The configuration for this module is an array of :c:struct:`selector_config` pointers.
 The array is written in the :file:`selector_hw_def.h` file located in the board-specific directory in the application configuration directory.
 

--- a/applications/nrf_desktop/doc/usb_state.rst
+++ b/applications/nrf_desktop/doc/usb_state.rst
@@ -23,7 +23,7 @@ Module events
 Configuration
 *************
 
-The module is enabled by selecting :kconfig:option:`CONFIG_DESKTOP_USB_ENABLE`.
+The module is enabled by selecting :ref:`CONFIG_DESKTOP_USB_ENABLE <config_desktop_app_options>` option.
 It depends on :kconfig:option:`CONFIG_USB_DEVICE_HID`.
 
 When enabling the USB support for the device, set the following generic device options:
@@ -64,7 +64,7 @@ nRF Desktop Peripheral
 The nRF Desktop Peripheral devices by default use only a single HID-class USB instance.
 In that case, this instance is used for all the HID reports.
 
-Enable :kconfig:option:`CONFIG_DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION` to use more than one HID-class USB instance on nRF Desktop Peripheral.
+Enable :ref:`CONFIG_DESKTOP_USB_SELECTIVE_REPORT_SUBSCRIPTION <config_desktop_app_options>` to use more than one HID-class USB instance on nRF Desktop Peripheral.
 Make sure to set a greater value in the :kconfig:option:`CONFIG_USB_HID_DEVICE_COUNT` option and create an additional :file:`usb_state_def.h` header in the configuration.
 The header assigns HID reports to the HID-class USB instances.
 A given HID report can be handled only by a single HID-class USB instance.

--- a/applications/nrf_desktop/doc/usb_state_pm.rst
+++ b/applications/nrf_desktop/doc/usb_state_pm.rst
@@ -23,8 +23,8 @@ Module events
 Configuration
 *************
 
-The module is enabled by selecting :kconfig:option:`CONFIG_DESKTOP_USB_PM_ENABLE`.
-It depends on :kconfig:option:`CONFIG_DESKTOP_USB_ENABLE` and :kconfig:option:`CONFIG_CAF_POWER_MANAGER`.
+The module is enabled by selecting :ref:`CONFIG_DESKTOP_USB_PM_ENABLE <config_desktop_app_options>` option.
+It depends on :ref:`CONFIG_DESKTOP_USB_ENABLE <config_desktop_app_options>` and :kconfig:option:`CONFIG_CAF_POWER_MANAGER` options.
 
 The log level is inherited from the :ref:`nrf_desktop_usb_state`.
 

--- a/applications/nrf_desktop/doc/watchdog.rst
+++ b/applications/nrf_desktop/doc/watchdog.rst
@@ -28,9 +28,9 @@ Configuration
 The module uses Zephyr's :ref:`zephyr:watchdog_api` driver.
 For this reason, set the :kconfig:option:`CONFIG_WATCHDOG` option.
 
-The module is enabled by the :kconfig:option:`CONFIG_DESKTOP_WATCHDOG_ENABLE` option.
+The module is enabled by the :ref:`CONFIG_DESKTOP_WATCHDOG_ENABLE <config_desktop_app_options>` option.
 
-You must define :kconfig:option:`CONFIG_DESKTOP_WATCHDOG_TIMEOUT`.
+You must define :ref:`CONFIG_DESKTOP_WATCHDOG_TIMEOUT <config_desktop_app_options>` option.
 After this amount of time (in ms), the device will be restarted if the watchdog timer was not reset.
 
 .. note::

--- a/applications/nrf_desktop/doc/wheel.rst
+++ b/applications/nrf_desktop/doc/wheel.rst
@@ -22,17 +22,17 @@ Module events
 Configuration
 *************
 
-Enable the module with the :kconfig:option:`CONFIG_DESKTOP_WHEEL_ENABLE` Kconfig option.
+Enable the module with the :ref:`CONFIG_DESKTOP_WHEEL_ENABLE <config_desktop_app_options>` Kconfig option.
 
 For detecting rotation, the wheel module uses Zephyr's QDEC driver.
 The module can be enabled only when QDEC is configured in DTS (that is, :kconfig:option:`CONFIG_QDEC_NRFX` is set).
 
 The QDEC DTS configuration specifies how many steps are done during one full angle.
 The sensor reports the rotation data in angle degrees.
-Then, :kconfig:option:`CONFIG_DESKTOP_WHEEL_SENSOR_VALUE_DIVIDER` (a wheel configuration option) converts the angle value into a value that is passed with a ``wheel_event`` to the destination module.
+Then, :ref:`CONFIG_DESKTOP_WHEEL_SENSOR_VALUE_DIVIDER <config_desktop_app_options>` (a wheel configuration option) converts the angle value into a value that is passed with a ``wheel_event`` to the destination module.
 
 For example, configuring QDEC with 24 steps means that for each step the sensor will report a rotation of 15 degrees.
-For HID to see this rotation as increment of one, :kconfig:option:`CONFIG_DESKTOP_WHEEL_SENSOR_VALUE_DIVIDER` should be set to 15.
+For HID to see this rotation as increment of one, :ref:`CONFIG_DESKTOP_WHEEL_SENSOR_VALUE_DIVIDER <config_desktop_app_options>` should be set to 15.
 
 Implementation details
 **********************
@@ -47,7 +47,7 @@ The wheel module can be in the following states:
 When in ``STATE_ACTIVE``, the module enables the QDEC driver and waits for callback that indicates rotation.
 The QDEC driver may consume power during its operation.
 
-If no rotation is detected after the time specified in :kconfig:option:`CONFIG_DESKTOP_WHEEL_SENSOR_IDLE_TIMEOUT`, the wheel module switches to ``STATE_ACTIVE_IDLE``, in which QDEC is disabled.
+If no rotation is detected after the time specified in :ref:`CONFIG_DESKTOP_WHEEL_SENSOR_IDLE_TIMEOUT <config_desktop_app_options>`, the wheel module switches to ``STATE_ACTIVE_IDLE``, in which QDEC is disabled.
 In this state, the rotation is detected using GPIO interrupts.
 When the rotation is detected, the module switches back to ``STATE_ACTIVE``.
 

--- a/doc/nrf/libraries/caf/net_state.rst
+++ b/doc/nrf/libraries/caf/net_state.rst
@@ -19,7 +19,7 @@ The module selects the backend based on the link layer enabled.
 Log information about connection waiting
 ========================================
 
-The option :kconfig:option:`CONFIG_CAF_NET_STATE_WAITING` enables periodically logging message, while the module is waiting for network connection.
+The option :kconfig:option:`CONFIG_CAF_LOG_NET_STATE_WAITING` enables periodically logging message, while the module is waiting for network connection.
 The period between logs may be configured by :kconfig:option:`CONFIG_CAF_LOG_NET_STATE_WAITING_PERIOD`.
 
 Implementation details

--- a/doc/nrf/libraries/caf/settings_loader.rst
+++ b/doc/nrf/libraries/caf/settings_loader.rst
@@ -52,8 +52,8 @@ Getting the required modules is wrapped into the :c:func:`get_req_modules` funct
 
 Settings are loaded in the :ref:`event_manager` handler, which by default is invoked from a system workqueue context.
 This blocks the workqueue until the operation is finished.
-You can set the :kconfig:option:`CONFIG_DESKTOP_SETTINGS_LOADER_USE_THREAD` Kconfig option to load the settings in a separate thread in the background instead of using the system workqueue for that purpose.
-This will prevent blocking the system workqueue, but it requires creating an additional thread.
-The stack size for the background thread is defined in the :kconfig:option:`CONFIG_DESKTOP_SETTINGS_LOADER_THREAD_STACK_SIZE` Kconfig option.
+You can set the :kconfig:option:`CONFIG_CAF_SETTINGS_LOADER_USE_THREAD` Kconfig option to load the settings in a separate thread in the background instead of using the system workqueue for that purpose.
+This prevents blocking the system workqueue, but it requires creating an additional thread.
+The stack size for the background thread is defined in the :kconfig:option:`CONFIG_CAF_SETTINGS_LOADER_THREAD_STACK_SIZE` Kconfig option.
 
 .. |settings_loader| replace:: Settings loader module


### PR DESCRIPTION
fixing the link to application specific configuration options
in nRF desktop, its sub modules and CAF libraries.
Jira ticket:NCSDK-13598

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>