### PR TITLE
zigbee: Wait for app_update in DFU scripts

### DIFF
--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -164,6 +164,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
 
       DEPENDS
       ${SIGN_ARG_DEPENDS}
+      ${update_bin}
       )
   endfunction()
 


### PR DESCRIPTION
Wait for the generation of the app_update.bin before the Zigbee OTA DFU image starts to generate the .zigbee file.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>