### PR TITLE
lib: multicell_location: Fix errant MODEM_JWT requirement

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -342,6 +342,8 @@ Modem libraries
 
     * Current system time is attached to the ``location_datetime`` parameter of the location request response with Wi-Fi and cellular methods.
       The timestamp comes from the moment of scanning or neighbor measurements.
+    * Removed dependency on the :ref:`lib_modem_jwt` library.
+      The :ref:`lib_location` library now selects :kconfig:option:`CONFIG_NRF_CLOUD_REST_AUTOGEN_JWT` when using :kconfig:option:`CONFIG_NRF_CLOUD_REST`.
 
 Other libraries
 ---------------

--- a/lib/multicell_location/Kconfig
+++ b/lib/multicell_location/Kconfig
@@ -20,7 +20,8 @@ if MULTICELL_LOCATION
 
 config MULTICELL_LOCATION_SERVICE_NRF_CLOUD
 	bool "nRF Cloud location service"
-	depends on MODEM_JWT
+	depends on NRF_CLOUD_REST || NRF_CLOUD_MQTT
+	select NRF_CLOUD_REST_AUTOGEN_JWT if NRF_CLOUD_REST
 	help
 	  Use nRF Cloud location service
 


### PR DESCRIPTION
~~multicell_location erroneously requires MODEM_JWT be enabled in order
for MULTICELL_LOCATION_SERVICE_NRF_CLOUD to be enabled. In reality, this
is only necessary if NRF_CLOUD_MQTT is not enabled. This PR adjusts the
dependency clause for MULTICELL_LOCATION_SERVICE_NRF_CLOUD and also
conditionally disables the inclusion of modem/modem_jwt.h by
nrf_cloud_integration.c~~

multicell_location no longer requires MODEM_JWT be enabled in order
for MULTICELL_LOCATION_SERVICE_NRF_CLOUD to be enabled. Instead,
NRF_CLOUD_REST_AUTOGEN_JWT is used whenever NRF_CLOUD_REST is in use.

Resolves NCSDK-14444

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>