### PR TITLE
bluetooth: DTM: Use radio bindings for radio antennas

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -166,6 +166,10 @@ Bluetooth samples
       * Added the vendor-specific ``FEM_DEFAULT_PARAMS_SET`` command for restoring the default front-end module parameters.
 
     * Fixed handling of the disable Constant Tone Extension command.
+    * The front-end module test parameters are not set to their default value after the DTM reset command.
+    * Added the vendor-specific ``FEM_DEFAULT_PARAMS_SET`` command for restoring the default front-end module parameters.
+    * Changed the radio antennas array hardware description.
+      It is based now on the radio bindings instead of custom configuration.
 
   * :ref:`peripheral_hids_mouse` sample:
 

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -115,9 +115,73 @@ The following antenna switching patterns are possible:
 The application supports a maximum of 19 antennas in the direction finding mode.
 The RADIO can control up to 8 GPIO pins for the purpose of controlling the external antenna switches used in direction finding.
 
-The antenna is chosen by writing consecutive numbers to the SWITCHPATTERN register.
-This means that the antenna GPIO pins act like 8-bit registers.
-In other words, for the first antenna, antenna pin 1 is active, for the second antenna, pin 2 is active, for the third antenna, pins 1 and 2 are active, and so on.
+Antenna matrix configuration
+----------------------------
+
+To use this sample to test the Bluetooth Direction Finding feature, additional configuration of GPIOs is required to control the antenna array.
+An example of such configuration is provided in a devicetree overlay file :file:`nrf5340dk_nrf5340_cpunet.overlay`.
+
+The overlay file provides the information about of the GPIOs to be used by the Radio peripheral to switch between antenna patches during the Constant Tone Extension (CTE) reception or transmission.
+At least one GPIO must be provided to enable antenna switching.
+
+The GPIOs are used by the radio peripheral in order given by the ``dfegpio#-gpios`` properties.
+The order is important because it affects the mapping of the antenna switching patterns to GPIOs (see `Antenna patterns`_).
+
+To test Direction Finding, provide the following data related to antenna matrix design:
+
+* GPIO pins to ``dfegpio#-gpios`` properties in the :file:`nrf5340dk_nrf5340_cpunet.overlay` file.
+* The default antenna to be used to receive the PDU ``dfe-pdu-antenna`` property in the :file:`nrf5340dk_nrf5340_cpunet.overlay` file.
+
+.. note::
+   The PDU antenna is also used for the reference period transmission and reception.
+
+Antenna patterns
+----------------
+
+The antenna switching pattern is a binary number where each bit is applied to a particular antenna GPIO pin.
+For example, the pattern ``0x3`` means that antenna GPIOs at index 0,1 is set, while the next ones are left unset.
+
+This also means that, for example, when using four GPIOs, the pattern count cannot be greater than 16 and the maximum allowed value is 15.
+
+If the number of switch-sample periods is greater than the number of stored switching patterns, the radio loops back to the first pattern.
+
+The following table presents the patterns that you can use to switch antennas on the Nordic-designed antenna matrix:
+
++--------+--------------+
+|Antenna | PATTERN[3:0] |
++========+==============+
+| ANT_12 |  0 (0b0000)  |
++--------+--------------+
+| ANT_10 |  1 (0b0001)  |
++--------+--------------+
+| ANT_11 |  2 (0b0010)  |
++--------+--------------+
+| RFU    |  3 (0b0011)  |
++--------+--------------+
+| ANT_3  |  4 (0b0100)  |
++--------+--------------+
+| ANT_1  |  5 (0b0101)  |
++--------+--------------+
+| ANT_2  |  6 (0b0110)  |
++--------+--------------+
+| RFU    |  7 (0b0111)  |
++--------+--------------+
+| ANT_6  |  8 (0b1000)  |
++--------+--------------+
+| ANT_4  |  9 (0b1001)  |
++--------+--------------+
+| ANT_5  | 10 (0b1010)  |
++--------+--------------+
+| RFU    | 11 (0b1011)  |
++--------+--------------+
+| ANT_9  | 12 (0b1100)  |
++--------+--------------+
+| ANT_7  | 13 (0b1101)  |
++--------+--------------+
+| ANT_8  | 14 (0b1110)  |
++--------+--------------+
+| RFU    | 15 (0b1111)  |
++--------+--------------+
 
 nRF21540 front-end module
 =========================

--- a/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -7,16 +7,25 @@
 	status = "disabled";
 };
 
-/ {
-     zephyr,user {
-	     dtm_antenna_count = <12>;
-	     dtm_antenna_1_pin = <32>;
-	     dtm_antenna_2_pin = <33>;
-	     dtm_antenna_3_pin = <34>;
-	     dtm_antenna_4_pin = <35>;
-	     dtm_antenna_5_pin = <36>;
-	     dtm_antenna_6_pin = <37>;
-	     dtm_antenna_7_pin = <38>;
-	     dtm_antenna_8_pin = <39>;
-     };
+&radio {
+	status = "okay";
+	/* This is a number of antennas that are available on antenna matrix
+	 * designed by Nordic. For more information see README.rst.
+	 */
+	dfe-antenna-num = <12>;
+	/* This is a setting that enables antenna 12 (in antenna matrix designed
+	 * by Nordic) for PDU. For more information see README.rst.
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching.
+	 * Pin numbers are selected to drive switches on antenna matrix
+	 * desinged by Nordic. For more information see README.rst.
+	 */
+	dfegpio0-gpios = <&gpio0 4 0>;
+	dfegpio1-gpios = <&gpio0 5 0>;
+	dfegpio2-gpios = <&gpio0 6 0>;
+	dfegpio3-gpios = <&gpio0 7 0>;
 };

--- a/samples/bluetooth/direct_test_mode/src/dtm_hw.h
+++ b/samples/bluetooth/direct_test_mode/src/dtm_hw.h
@@ -16,6 +16,16 @@
 extern "C" {
 #endif
 
+/* Number of PSEL_DFEGPIO[n] registers in the radio peripheral. */
+#define DTM_HW_MAX_DFE_GPIO 8
+
+/* Indicates that GPIO pin is not connected to the radio */
+#define DTM_HW_DFE_PSEL_NOT_SET 0xFF
+
+/* Disconnect pin from the RADIO DFGPIO register. */
+#define DTM_HW_DFE_GPIO_PIN_DISCONNECT (RADIO_PSEL_DFEGPIO_CONNECT_Disconnected << \
+					RADIO_PSEL_DFEGPIO_CONNECT_Pos)
+
 /**@brief Function for validating tx power and radio mode settings.
  * @param[in] tx_power    TX power for transmission test.
  * @param[in] radio_mode  Radio mode value.
@@ -65,15 +75,21 @@ const uint32_t *dtm_hw_radio_power_array_get(void);
 /**@brief Function for getting antenna pins array. This array contains
  *        all antenna pins data.
  *
- * @retval Size of the antenna pin array.
- */
-size_t dtm_radio_antenna_pin_array_size_get(void);
-
-/**@brief Function for getting antenna pins array size.
- *
  * @retval Pointer to the first element in antenna pins array.
  */
-const uint32_t *dtm_hw_radion_antenna_pin_array_get(void);
+const uint8_t *dtm_hw_radio_antenna_pin_array_get(void);
+
+/**@brief Function for getting available antenna number.
+ *
+ * @retval Maximum antenna number that DTM can use.
+ */
+size_t dtm_hw_radio_antenna_number_get(void);
+
+/**@brief Function for getting the PDU antenna.
+ *
+ * @retval The PDU antenna.
+ */
+uint8_t dtm_hw_radio_pdu_antenna_get(void);
 
 #ifdef __cplusplus
 }

--- a/samples/bluetooth/direct_test_mode/src/dtm_hw_config.h
+++ b/samples/bluetooth/direct_test_mode/src/dtm_hw_config.h
@@ -11,13 +11,16 @@
 extern "C" {
 #endif
 
-#if DT_NODE_HAS_PROP(DT_NODELABEL(radio), dfe_supported) && \
-	DT_PROP(DT_PATH(zephyr_user), dtm_antenna_count) > 0
+/* Devicetree node identifier for the radio node. */
+#define RADIO_NODE DT_NODELABEL(radio)
+
+#if DT_PROP(DT_NODELABEL(radio), dfe_supported) && \
+	DT_NODE_HAS_STATUS(RADIO_NODE, okay)
 #define DIRECTION_FINDING_SUPPORTED 1
 #else
 #define DIRECTION_FINDING_SUPPORTED 0
-#endif /* DT_NODE_HAS_PROP(DT_NODELABEL(radio), dfe_supported) && \
-	* DT_PROP(DT_PATH(zephyr_user), dtm_antenna_count) > 0
+#endif /* DT_PROP(DT_NODELABEL(radio), dfe_supported) && \
+	* DT_NODE_HAS_STATUS(RADIO_NODE, okay)
 	*/
 
 /* Maximum transmit or receive time, in microseconds, that the local


### PR DESCRIPTION
The Direct Test Mode sample uses now the radio bindings instead of custom zephyr user devicetree entry for getting the radio antenna matrix configuration.