### PR TITLE
applications: asset_tracker_v2: Prefix IMEI with "nrf-"

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -21,13 +21,16 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_CLOUD_INTEGRATION_LOG_LEVEL);
  */
 #define CELL_POS_FILTER_STRING "CELL_POS"
 
+#define IMEI_LEN 15
+#define CLOUD_CLIENT_ID_IMEI_PREFIX_LEN (sizeof(CONFIG_CLOUD_CLIENT_ID_IMEI_PREFIX) - 1)
+
 #if !defined(CONFIG_CLOUD_CLIENT_ID_USE_CUSTOM)
-#define NRF_CLOUD_CLIENT_ID_LEN 15
+#define NRF_CLOUD_CLIENT_ID_LEN (IMEI_LEN + CLOUD_CLIENT_ID_IMEI_PREFIX_LEN)
+static char client_id_buf[NRF_CLOUD_CLIENT_ID_LEN + 1] = CONFIG_CLOUD_CLIENT_ID_IMEI_PREFIX;
 #else
 #define NRF_CLOUD_CLIENT_ID_LEN (sizeof(CONFIG_CLOUD_CLIENT_ID) - 1)
-#endif
-
 static char client_id_buf[NRF_CLOUD_CLIENT_ID_LEN + 1];
+#endif
 
 static struct k_work_delayable user_associating_work;
 
@@ -255,10 +258,9 @@ int cloud_wrap_init(cloud_wrap_evt_handler_t event_handler)
 	}
 
 	/* Set null character at the end of the device IMEI. */
-	imei_buf[NRF_CLOUD_CLIENT_ID_LEN] = 0;
+	imei_buf[IMEI_LEN] = 0;
 
-	strncpy(client_id_buf, imei_buf, sizeof(client_id_buf) - 1);
-
+	strncat(client_id_buf, imei_buf, IMEI_LEN);
 #else
 	snprintf(client_id_buf, sizeof(client_id_buf), "%s", CONFIG_CLOUD_CLIENT_ID);
 #endif

--- a/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.cloud_module
@@ -44,6 +44,15 @@ config CLOUD_THREAD_STACK_SIZE
 	default 4096 if NRF_CLOUD_MQTT || DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT
 	default 2688
 
+config CLOUD_CLIENT_ID_IMEI_PREFIX
+	string	"Cloud client ID IMEI prefix"
+	depends on NRF_CLOUD_MQTT
+	default "nrf-"
+	help
+	  Prefix used when passing in IMEI as the client ID. The default value "nrf-" is
+	  expected when building for offical devices (e.g. nRF9160 DK and Thingy:91).
+	  This only applies when configuring the application for nRF Cloud.
+
 config CLOUD_CLIENT_ID_USE_CUSTOM
 	bool "Use custom cloud client ID"
 	help


### PR DESCRIPTION
When passing in IMEI as the client ID to the nRF Cloud backend it
needs to be prefixed with "nrf-" by default. This was missed in
a previous PR that added support for passing in the client ID at
run time from the application. The nRF cloud backend does not
prefix client IDs that are passed in run time.