### PR TITLE
doc: add direct link to VSC build instructions

### DIFF
--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -23,10 +23,12 @@ Building with the VS Code extension
 
 |vsc_extension_instructions|
 
+For instructions specifically for building, see `Building an application`_.
+
 .. _gs_programming_ses:
 
-Building with SES
-*****************
+Building with |SES|
+*******************
 
 .. build_SES_projimport_open_start
 


### PR DESCRIPTION
The VSC build instructions linked to the
main page of VSC docs.
Adding a link to one pointing directly
to the actual build instructions.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>