### PR TITLE
samples: nrf9160: modem_shell: add command for deleting GNSS TCXO offset

### DIFF
--- a/samples/nrf9160/modem_shell/src/gnss/gnss.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.c
@@ -991,6 +991,10 @@ int gnss_delete_data(enum gnss_data_delete data)
 			      NRF_MODEM_GNSS_DELETE_UTC_DATA;
 		break;
 
+	case GNSS_DATA_DELETE_TCXO:
+		delete_mask = NRF_MODEM_GNSS_DELETE_TCXO_OFFSET;
+		break;
+
 	default:
 		mosh_error("GNSS: Invalid erase data value");
 		return -1;

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.h
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.h
@@ -17,7 +17,8 @@ enum gnss_duty_cycling_policy {
 
 enum gnss_data_delete {
 	GNSS_DATA_DELETE_EPHEMERIDES,
-	GNSS_DATA_DELETE_ALL
+	GNSS_DATA_DELETE_ALL,
+	GNSS_DATA_DELETE_TCXO
 };
 
 enum gnss_dynamics_mode {

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
@@ -96,6 +96,16 @@ static int cmd_gnss_delete_all(const struct shell *shell, size_t argc, char **ar
 	return gnss_delete_data(GNSS_DATA_DELETE_ALL);
 }
 
+static int cmd_gnss_delete_tcxo(const struct shell *shell, size_t argc, char **argv)
+{
+	if (gnss_running) {
+		mosh_error("%s: stop GNSS to execute command", argv[0]);
+		return -ENOEXEC;
+	}
+
+	return gnss_delete_data(GNSS_DATA_DELETE_TCXO);
+}
+
 static int cmd_gnss_mode(const struct shell *shell, size_t argc, char **argv)
 {
 	return print_help(shell, argc, argv);
@@ -839,8 +849,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_gnss_delete,
 	SHELL_CMD_ARG(ephe, NULL, "Delete ephemerides (forces a warm start).",
 		      cmd_gnss_delete_ephe, 1, 0),
-	SHELL_CMD_ARG(all, NULL, "Delete all data (forces a cold start).",
+	SHELL_CMD_ARG(all, NULL, "Delete all data, except the TCXO offset (forces a cold start).",
 		      cmd_gnss_delete_all, 1, 0),
+	SHELL_CMD_ARG(tcxo, NULL, "Delete the TCXO offset.",
+		      cmd_gnss_delete_tcxo, 1, 0),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Implemented a new command to delete the stored GNSS TCXO offset.