### PR TITLE
tfm: Increase default TF-M flash size with debug build type

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -80,6 +80,7 @@ config PM_PARTITION_SIZE_TFM
 	default 0x10000 if TFM_MINIMAL
 	# NCSDK-13503: Temporarily bump size while regressions are being fixed
 	default 0x60000 if TFM_REGRESSION_S
+	default 0x50000 if TFM_CMAKE_BUILD_TYPE_DEBUG
 	default 0x40000
 	help
 	  Memory set aside for the TFM partition. This size is fixed if


### PR DESCRIPTION
Increase the default TF-M flash size when building TF-M in debug
configuration. This does not optimize the flash size.

NCSDK-14475

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>