### PR TITLE
test_spec: crypto: add cjson, tfm

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -208,6 +208,9 @@
   - "subsys/partition_manager/**/*"
   - "tests/crypto/**/*"
   - "modules/cjson/**/*"
+  - "include/tfm/**/*"
+  - "modules/tfm/**/*"
+  - "modules/trusted-firmware-m/**/*"
 
 "CI-rs-test":
   - "subsys/mpsl/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -207,6 +207,7 @@
   - "samples/crypto/**/*"
   - "subsys/partition_manager/**/*"
   - "tests/crypto/**/*"
+  - "modules/cjson/**/*"
 
 "CI-rs-test":
   - "subsys/mpsl/**/*"


### PR DESCRIPTION
Add entry for running crypto on any changes to the cJSON module.
Internal tests for crypto use this module and may fail due to changes
in configurations and similar.

Same treatment for changes in TFM.

Signed-off-by: Torstein Grindvik <torstein.grindvik@nordicsemi.no>