### PR TITLE
doc: fix nRF9160 DK download link

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -220,11 +220,11 @@
 .. _`nRF Toolbox`: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Toolbox
 
 .. _`nRF9160 DK product page`: https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk/
+.. _`nRF9160 DK Downloads`: https://www.nordicsemi.com/Products/Development-hardware/nRF9160-DK/Download#infotabs
 .. _`SUPL client download`: https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF9160-DK/Download#supl-c
 
 .. _`nRF9160 product website`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160
 
-.. _`nRF9160 DK Downloads`:
 .. _`nRF9160 product website (compatible downloads)`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160/Download#infotabs
 
 .. _`nRF9160 Certifications`: https://www.nordicsemi.com/Products/Low-power-Cellular-IoT/nRF9160-Certifications

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -20,7 +20,7 @@ The nRF9160 DK contains an nRF52840 SoC that is used to route some of the nRF916
 For a complete list of all the routing options available, see the `nRF9160 DK board control section in the nRF9160 DK User Guide`_.
 
 The nRF52840 SoC on the DK comes preprogrammed with a firmware.
-If you need to restore the original firmware at some point, download the nRF9160 DK board controller firmware from the `nRF9160 DK product page`_.
+If you need to restore the original firmware at some point, download the nRF9160 DK board controller firmware from the `nRF9160 DK downloads`_ page.
 To program the HEX file, use nrfjprog (which is part of the `nRF Command Line Tools`_).
 
 If you want to route some pins differently from what is done in the preprogrammed firmware, program the :ref:`zephyr:hello_world` sample instead of the preprogrammed firmware.


### PR DESCRIPTION
The link currently points to the Download tab for the nRF9160 SiP
instead of the nRF916 DK as it should.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>