### PR TITLE
applications: asset_tracker_v2: Fix unit test failures on native_posix

### DIFF
--- a/applications/asset_tracker_v2/tests/debug_module/src/debug_module_test.c
+++ b/applications/asset_tracker_v2/tests/debug_module/src/debug_module_test.c
@@ -97,6 +97,16 @@ static void validate_debug_data_ready_evt(struct event_header *eh, int no_of_cal
 	TEST_ASSERT_EQUAL(DEBUG_EVT_MEMFAULT_DATA_READY, event->type);
 }
 
+/* Stub used to verify parameters passed into module_start(). */
+static int module_start_stub(struct module_data *module, int num_calls)
+{
+	TEST_ASSERT_EQUAL_STRING("debug", module->name);
+	TEST_ASSERT_NULL(module->msg_q);
+	TEST_ASSERT_FALSE(module->supports_shutdown);
+
+	return 0;
+}
+
 void setup_debug_module_in_init_state(void)
 {
 	__wrap_event_manager_alloc_ExpectAnyArgsAndReturn(&app_module_event_memory);
@@ -105,15 +115,9 @@ void setup_debug_module_in_init_state(void)
 
 	app_module_event->type = APP_EVT_START;
 
-	static struct module_data expected_module_data = {
-		.name = "debug",
-		.msg_q = NULL,
-		.supports_shutdown = false,
-	};
-
 	__wrap_watchdog_register_handler_ExpectAnyArgs();
 	__wrap_watchdog_register_handler_AddCallback(&latch_watchdog_callback);
-	__wrap_module_start_ExpectAndReturn(&expected_module_data, 0);
+	__wrap_module_start_Stub(&module_start_stub);
 
 	TEST_ASSERT_EQUAL(0, DEBUG_MODULE_EVT_HANDLER((struct event_header *)app_module_event));
 	event_manager_free(app_module_event);

--- a/applications/asset_tracker_v2/tests/gnss_module/src/gnss_module_test.c
+++ b/applications/asset_tracker_v2/tests/gnss_module/src/gnss_module_test.c
@@ -240,17 +240,21 @@ static int validate_date_time(const struct tm *new_date_time, int no_of_calls)
 	return 0;
 }
 
+/* Stub used to verify parameters passed into module_start(). */
+static int module_start_stub(struct module_data *module, int num_calls)
+{
+	TEST_ASSERT_EQUAL_STRING("gnss", module->name);
+	TEST_ASSERT_NULL(module->msg_q);
+	TEST_ASSERT_TRUE(module->supports_shutdown);
+
+	return 0;
+}
+
 static void setup_gnss_module_in_init_state(void)
 {
 	__wrap_event_manager_alloc_ExpectAnyArgsAndReturn(&app_module_event_memory);
 	__wrap_event_manager_free_ExpectAnyArgs();
 	struct app_module_event *app_module_event = new_app_module_event();
-
-	static struct module_data expected_module_data = {
-		.name = "gnss",
-		.msg_q = NULL,
-		.supports_shutdown = true,
-	};
 
 	/* AT%XMAGPIO and AT%XCOEX0 AT commands for LNA configuration. */
 	__wrap_nrf_modem_at_printf_ExpectAnyArgsAndReturn(0);
@@ -259,7 +263,7 @@ static void setup_gnss_module_in_init_state(void)
 	__wrap_nrf_modem_gnss_event_handler_set_AddCallback(
 		&nrf_modem_gnss_event_handler_set_callback);
 	__wrap_nrf_modem_gnss_event_handler_set_ExpectAnyArgsAndReturn(0);
-	__wrap_module_start_ExpectAndReturn(&expected_module_data, 0);
+	__wrap_module_start_Stub(&module_start_stub);
 
 	app_module_event->type = APP_EVT_START;
 


### PR DESCRIPTION
The unit tests for debug_module and gnss_module were failing because the
mock for module_start() was checking all parameters in the input
structure. Some of those parameters can be random values and they may
make the test fail intermittently. This is now fixed by using a stub
that only checks the fields in the struct that are relevant for the
test.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>