### PR TITLE
manifest: remove flash_map out of tree patch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bb39dfe3121a1c245d7c5804de0e14e19b299b83
+      revision: pull/776/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Remove flash_map out of tree patch in zephyr.

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>