### PR TITLE
samples: debug: ppi_trace: use DEVICE_DT_GET

### DIFF
--- a/samples/debug/ppi_trace/src/main.c
+++ b/samples/debug/ppi_trace/src/main.c
@@ -10,6 +10,7 @@
 #include <hal/nrf_rtc.h>
 #include <hal/nrf_clock.h>
 #include <device.h>
+#include <devicetree.h>
 #include <logging/log.h>
 
 LOG_MODULE_REGISTER(app);
@@ -18,10 +19,10 @@ LOG_MODULE_REGISTER(app);
 
 #if IS_ENABLED(CONFIG_USE_RTC2)
 #define RTC       NRF_RTC2
-#define RTC_LABEL DT_LABEL(DT_NODELABEL(rtc2))
+#define RTC_NODE  DT_NODELABEL(rtc2)
 #else
 #define RTC       NRF_RTC0
-#define RTC_LABEL DT_LABEL(DT_NODELABEL(rtc0))
+#define RTC_NODE  DT_NODELABEL(rtc0)
 #endif
 
 static void alarm_callback(const struct device *dev, uint8_t chan_id, uint32_t ticks,
@@ -79,9 +80,9 @@ static void alarm_callback(const struct device *dev, uint8_t chan_id,
 static void counter_setup(void)
 {
 	int err;
-	const struct device *dev = device_get_binding(RTC_LABEL);
+	const struct device *dev = DEVICE_DT_GET(RTC_NODE);
 
-	__ASSERT(dev, "Sample cannot run on this board.");
+	__ASSERT(device_is_ready(dev), "RTC device not ready");
 
 	alarm_cfg.ticks = counter_us_to_ticks(dev, ALARM_PERIOD_US);
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);


### PR DESCRIPTION
- Obtain RTC device reference at compile time
- Remove redundant Kconfig symbols (use DT status check instead)