### PR TITLE
samples: nrf5340: netboot: use DEVICE_DT_GET

### DIFF
--- a/samples/nrf5340/netboot/src/main.c
+++ b/samples/nrf5340/netboot/src/main.c
@@ -14,15 +14,19 @@
 #include <bl_validation.h>
 #include <dfu/pcd.h>
 #include <device.h>
-
-#define FLASH_NAME DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
+#include <devicetree.h>
 
 void main(void)
 {
-	int err = fprotect_area(PM_B0N_CONTAINER_ADDRESS,
-				PM_B0N_CONTAINER_SIZE);
-	const struct device *fdev = device_get_binding(FLASH_NAME);
+	int err;
+	const struct device *fdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 
+	if (!device_is_ready(fdev)) {
+		printk("Flash device not ready\n");
+		return;
+	}
+
+	err = fprotect_area(PM_B0N_CONTAINER_ADDRESS, PM_B0N_CONTAINER_SIZE);
 	if (err) {
 		printk("Failed to protect b0n flash, cancel startup\n\r");
 		goto failure;


### PR DESCRIPTION
Use DEVICE_DT_GET to obtain a flash controller device reference at
compile time.