### PR TITLE
samples: nrf9160: modem_shell: use DEVICE_DT_GET

### DIFF
--- a/samples/nrf9160/modem_shell/src/uart/uart.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart.c
@@ -8,6 +8,7 @@
 
 #include <zephyr.h>
 #include <device.h>
+#include <devicetree.h>
 #include <pm/device.h>
 #include "uart.h"
 
@@ -48,11 +49,9 @@ static void uart1_set_enable(bool enable)
  */
 static void uart0_set_enable(bool enable)
 {
-	const struct device *uart_dev;
+	const struct device *uart_dev = DEVICE_DT_GET(DT_NODELABEL(uart0));
 
-	uart_dev = device_get_binding(DT_LABEL(DT_NODELABEL(uart0)));
-
-	if (!uart_dev) {
+	if (!device_is_ready(uart_dev)) {
 		return;
 	}
 

--- a/samples/nrf9160/modem_shell/src/uart/uart_shell.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart_shell.c
@@ -8,6 +8,7 @@
 
 #include <zephyr.h>
 #include <device.h>
+#include <devicetree.h>
 #include <pm/device.h>
 #include <shell/shell.h>
 #include <shell/shell_uart.h>
@@ -85,13 +86,12 @@ void uart_toggle_power_state_at_event(const struct lte_lc_evt *const evt)
 
 void uart_toggle_power_state(void)
 {
-	const struct device *uart_dev;
+	const struct device *uart_dev = DEVICE_DT_GET(DT_NODELABEL(uart0));
 	enum pm_device_state uart0_power_state;
 	int err;
 
-	uart_dev = device_get_binding(DT_LABEL(DT_NODELABEL(uart0)));
-	if (uart_dev == NULL) {
-		mosh_print("Could not get UART device");
+	if (!device_is_ready(uart_dev)) {
+		mosh_print("UART device not ready");
 		return;
 	}
 


### PR DESCRIPTION
The uart0 device can be obtained at compile time using DEVICE_DT_GET.