### PR TITLE
samples: peripheral: lpuart: use DEVICE_DT_GET

### DIFF
--- a/samples/peripheral/lpuart/src/main.c
+++ b/samples/peripheral/lpuart/src/main.c
@@ -5,6 +5,8 @@
  */
 
 #include <zephyr.h>
+#include <device.h>
+#include <devicetree.h>
 #include <logging/log.h>
 #include <drivers/uart.h>
 
@@ -119,10 +121,9 @@ static void async(const struct device *lpuart)
 
 void main(void)
 {
-	const struct device *lpuart;
+	const struct device *lpuart = DEVICE_DT_GET(DT_NODELABEL(lpuart));
 
-	lpuart = device_get_binding("LPUART");
-	__ASSERT(lpuart, "Failed to get the device");
+	__ASSERT(device_is_ready(lpuart), "LPUART device not ready");
 
 	if (IS_ENABLED(CONFIG_NRF_SW_LPUART_INT_DRIVEN)) {
 		interrupt_driven(lpuart);

--- a/samples/peripheral/lpuart/src/main.c
+++ b/samples/peripheral/lpuart/src/main.c
@@ -121,8 +121,6 @@ void main(void)
 {
 	const struct device *lpuart;
 
-	k_msleep(1000);
-
 	lpuart = device_get_binding("LPUART");
 	__ASSERT(lpuart, "Failed to get the device");
 


### PR DESCRIPTION
Obtain LPUART device at compile time using DEVICE_DT_GET. Also remove
init sleep of 1s, if this is papering over a bug it should be fixed
properly.