### PR TITLE
lib: nrf_modem: Add kconfig override for trace heap size

### DIFF
--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -137,8 +137,14 @@ config NRF_MODEM_LIB_SHMEM_TRACE_SIZE
 	help
 	  Size of the shared memory area used to receive modem traces.
 
+config NRF_MODEM_LIB_TRACE_HEAP_SIZE_OVERRIDE
+	bool "Custom trace heap size"
+	depends on NRF_MODEM_LIB_TRACE_ENABLED
+	help
+	  Override the default trace heap size.
+
 config NRF_MODEM_LIB_TRACE_HEAP_SIZE
-	int "Modem trace heap size" if NRF_MODEM_LIB_TRACE_ENABLED
+	int "Modem trace heap size" if NRF_MODEM_LIB_TRACE_HEAP_SIZE_OVERRIDE
 	default 2048 if NRF_MODEM_LIB_TRACE_ENABLED
 	default 0
 	help


### PR DESCRIPTION
The trace heap size config could be stuck at 0 when using menuconfig
even though NRF_MODEM_LIB_TRACE_EANBLED was enabled. Adding a separate
user configurable bool solves this problem, as described in the
[Kconfig - Tips and Best Practices](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/build/kconfig/tips.html#stuck-symbols-in-menuconfig-and-guiconfig) documentation.