### PR TITLE
applications: asset_tracker_v2: adding asset_tracker_v2 to test_spec

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -138,6 +138,7 @@
   - "subsys/net/lib/azure_iot_hub/**/*"
   - "lib/date_time/**/*"
   - "drivers/sensor/sensor_sim/**/*"
+  - "applications/asset_tracker_v2/**/*"
   - "samples/nrf9160/udp/**/*"
   - "samples/nrf9160/aws_iot/**/*"
   - "samples/nrf9160/azure_iot_hub/**/*"


### PR DESCRIPTION
Adding asset_tracker_v2 to test specification to trigger oncommit
tests on changes in the application.

Signed-off-by: David Dilner <david.dilner@nordicsemi.no>