### PR TITLE
manifest: update sdk-zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1cd6e614e35d7b821e09087d35de7cce128fc256
+      revision: d359a86abf14d37ca3a2fbb69db3ccf1e41155aa
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit updates sdk-zephyr revision to bring the possibility of
setting Tx power for every IEEE 802.15.4 transmission separately.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>