### PR TITLE
license: Replace old license reference

### DIFF
--- a/lib/fprotect/sys_init_fprotect.c
+++ b/lib/fprotect/sys_init_fprotect.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr.h>

--- a/samples/nrf9160/lwm2m_carrier/src/carrier_certs.c
+++ b/samples/nrf9160/lwm2m_carrier/src/carrier_certs.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <stdint.h>

--- a/samples/nrf9160/lwm2m_carrier/src/carrier_certs.h
+++ b/samples/nrf9160/lwm2m_carrier/src/carrier_certs.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #ifndef CARRIER_CERTS_H__

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <stdio.h>


### PR DESCRIPTION
Replace old LicenseRef with the new one currently in use.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>