### PR TITLE
manifest: Cherry-pick new ipc service backend

### DIFF
--- a/subsys/nrf_rpc/Kconfig
+++ b/subsys/nrf_rpc/Kconfig
@@ -20,14 +20,6 @@ config NRF_RPC_TR_RPMSG
 	select IPC_SERVICE
 	select MBOX
 
-if NRF_RPC_TR_RPMSG
-
-choice IPC_SERVICE_BACKEND
-	default IPC_SERVICE_BACKEND_RPMSG
-endchoice
-
-endif
-
 config NRF_RPC_CBOR
 	bool
 	select TINYCBOR

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bb39dfe3121a1c245d7c5804de0e14e19b299b83
+      revision: 1cd6e614e35d7b821e09087d35de7cce128fc256
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This change update manifest in order to cherry-pick
recently added IPC service backend in upstream.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>