### PR TITLE
manifest: Update sdk-zephyr to include hci rpmsg fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 186cf4539e5a28fc1653240d5d675b75c4548010
+      revision: pull/774/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -141,7 +141,7 @@ manifest:
       revision: c6af068b7f05207b28d68880740e4b9ec1e4b50a
     - name: homekit
       repo-path: sdk-homekit
-      revision: e3af62081234a4eee9430a10817c79ea0e788ce9
+      revision: pull/353/head
       groups:
       - homekit
     - name: find-my


### PR DESCRIPTION
This brings in fixes to HCI event handling when using HCI over RPMsg.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>