### PR TITLE
doc: avoid repetition in the sample doc template

### DIFF
--- a/doc/nrf/templates/sample_README.rst
+++ b/doc/nrf/templates/sample_README.rst
@@ -128,7 +128,7 @@ Configuration options*
    * For each configuration option, list the symbol name and the string describing it.
    * For |VSC| instructions, list the configuration options as they are stated on the Generate Configuration screen.
 
-Check and configure the following configuration options for the sample:
+Check and configure the following Kconfig options:
 
 .. _SAMPLE_CONFIG:
 


### PR DESCRIPTION
Changed slightly the wording in the Configuration options section
just to avoid unnecessary repetition.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>