### PR TITLE
doc: thread: Update samples to match template

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -162,6 +162,8 @@ Thread samples
     * Added :file:`prj_thread_1_2.conf` to support Thread v1.2 build for the nRF52 and nRF53 Series devices.
     * Added child image configuration files for network core builds for Thread v1.2 build.
 
+  * All sample documentation with a Configuration section, and organized relevant information under that section.
+
 Matter samples
 --------------
 

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -50,6 +50,12 @@ Certification tests with CLI sample
 You can use the Thread CLI sample to run certification tests.
 See :ref:`ug_thread_cert` for information on how to use this sample on Thread Certification Test Harness.
 
+User interface
+**************
+
+All interactions with the application are handled using serial communication.
+See `OpenThread CLI Reference`_ for the list of available serial commands.
+
 .. _ot_cli_sample_diag_module:
 
 Diagnostic module
@@ -62,6 +68,38 @@ See `Testing diagnostic module`_ section for an example.
 
 .. note::
     If you disable the :kconfig:option:`CONFIG_OPENTHREAD_NORDIC_LIBRARY_MASTER` feature set, you can enable the diagnostic module with the :kconfig:option:`CONFIG_OPENTHREAD_DIAG` Kconfig option.
+
+Configuration
+*************
+
+|config|
+
+.. _ot_cli_sample_activating_variants:
+
+Configuration files
+===================
+
+The sample provides predefined configuration files for typical use cases, and to activate sample extensions.
+You can find the configuration files in the root directory of the sample.
+
+Specify the corresponding file names in the :makevar:`OVERLAY_CONFIG` option when building.
+See :ref:`cmake_options` for instructions on how to add this option.
+For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
+The following configuration files are available:
+
+* :file:`overlay-minimal_singleprotocol.conf` - Enables the minimal single protocol variant.
+  Optimizes the memory footprint for single protocol use.
+  For more information, see :ref:`app_memory`.
+* :file:`overlay-minimal_multiprotocol.conf` - Enables the minimal multiprotocol variant.
+  Optimizes the memory footprint for multiprotocol use.
+  For more information, see :ref:`app_memory`.
+* :file:`overlay-usb.conf` - Enables USB transport support.
+  Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to :file:`usb.overlay`.
+* :file:`overlay-logging.conf` - Turns on logging.
+* :file:`overlay-rtt.conf` - Redirects logs to RTT.
+  For more information about RTT please refer to :ref:`RTT logging <ug_logging>`.
+* :file:`overlay-debug.conf` - Enables debbuging the Thread sample with GDB thread awareness.
 
 .. _ot_cli_sample_thread_v12:
 
@@ -99,12 +137,6 @@ Trusted Firmware-M support
 
 .. include:: /includes/tfm.txt
 
-User interface
-**************
-
-All interactions with the application are handled using serial communication.
-See `OpenThread CLI Reference`_ for the list of available serial commands.
-
 Building and running
 ********************
 
@@ -115,25 +147,6 @@ Building and running
 .. include:: /includes/build_and_run.txt
 
 To update the OpenThread libraries provided by ``nrfxlib``, invoke ``west build -b nrf52840dk_nrf52840 -t install_openthread_libraries``.
-
-.. _ot_cli_sample_activating_variants:
-
-Activating sample extensions
-============================
-
-To activate the optional extensions supported by this sample, modify :makevar:`OVERLAY_CONFIG` as follows:
-
-* For the minimal single protocol variant, set :file:`overlay-minimal_singleprotocol.conf`.
-* For the minimal multiprotocol variant, set :file:`overlay-minimal_multiprotocol.conf`.
-* For USB transport support, set :file:`overlay-usb.conf`.
-  Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to :file:`usb.overlay`.
-* For turning on logging, set :file:`overlay-logging.conf`.
-* For redirecting logs to RTT, set :file:`overlay-rtt.conf`.
-  For more information about RTT please refer to :ref:`RTT logging <ug_logging>`.
-* For debbuging a Thread sample with GDB thread awareness, set :file:`overlay-debug.conf`.
-
-See :ref:`cmake_options` for instructions on how to add this option.
-For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
 
 .. _ot_cli_sample_testing:
 

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -49,11 +49,6 @@ The following CoAP resources are accessed on the server side:
 This sample uses :ref:`Zephyr CoAP API<zephyr:coap_sock_interface>` for communication, which is the preferred API to use for new CoAP applications.
 For example usage of the native Thread CoAP API, see the :ref:`coap_server_sample` sample.
 
-FEM support
-===========
-
-.. include:: /includes/sample_fem_support.txt
-
 .. _coap_client_sample_multi_ext:
 
 Multiprotocol Bluetooth LE extension
@@ -62,11 +57,6 @@ Multiprotocol Bluetooth LE extension
 This optional extension demonstrates the OpenThread stack and :ref:`nrfxlib:softdevice_controller` working concurrently.
 It uses the :ref:`nus_service_readme` library to control the LED states over Bluetooth® LE in a Thread network.
 For more information about the multiprotocol feature, see :ref:`ug_multiprotocol_support`.
-
-Trusted Firmware-M support
-==========================
-
-.. include:: /includes/tfm.txt
 
 User interface
 **************
@@ -116,6 +106,39 @@ UART command assignments:
    * ``m`` - Send a multicast CoAP message over Thread (the same operation as **Button 2**).
    * ``p`` - Send a pairing request as CoAP message over Thread (the same operation as **Button 4**).
 
+Configuration
+*************
+
+|config|
+
+.. _coap_client_sample_activating_variants:
+
+Configuration files
+===================
+
+The sample provides predefined configuration files for typical use cases, and to activate sample extensions.
+You can find the configuration files in the root directory of the sample.
+
+Specify the corresponding file names in the :makevar:`OVERLAY_CONFIG` option when building.
+See :ref:`cmake_options` for instructions on how to add this option.
+For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
+The following configuration files are available:
+
+* :file:`overlay-mtd.conf` - Enables the Minimal Thread Device variant.
+* :file:`overlay-multiprotocol_ble.conf` - Enables the Multiprotocol Bluetooth LE extension.
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
+
+
+Trusted Firmware-M support
+==========================
+
+.. include:: /includes/tfm.txt
+
 Building and running
 ********************
 
@@ -124,19 +147,6 @@ Building and running
 |enable_thread_before_testing|
 
 .. include:: /includes/build_and_run.txt
-
-.. _coap_client_sample_activating_variants:
-
-Activating sample extensions
-============================
-
-To activate the optional extensions supported by this sample, modify :makevar:`OVERLAY_CONFIG` in the following manner:
-
-* For the Minimal Thread Device variant, set :file:`overlay-mtd.conf`.
-* For the Multiprotocol Bluetooth LE extension, set :file:`overlay-multiprotocol_ble.conf`.
-
-See :ref:`cmake_options` for instructions on how to add this option.
-For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
 
 Testing
 =======

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -24,11 +24,6 @@ The sample supports the following development kits:
 You can use one or more of these development kits as the Thread CoAP Server.
 You also need one or more compatible development kits programmed with the :ref:`coap_client_sample` sample.
 
-Trusted Firmware-M support
-==========================
-
-.. include:: /includes/tfm.txt
-
 Overview
 ********
 
@@ -44,11 +39,6 @@ This sample uses the native `OpenThread CoAP API`_ for communication.
 For new application development, use :ref:`Zephyr's CoAP API<zephyr:coap_sock_interface>`.
 For example usage of the Zephyr CoAP API, see the :ref:`coap_client_sample` sample.
 
-FEM support
-===========
-
-.. include:: /includes/sample_fem_support.txt
-
 User interface
 **************
 
@@ -63,6 +53,21 @@ LED 3:
 
 LED 4:
   Turned on and off by messages sent from the client nodes.
+
+Configuration
+*************
+
+|config|
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
+
+Trusted Firmware-M support
+==========================
+
+.. include:: /includes/tfm.txt
 
 Building and running
 ********************

--- a/samples/openthread/coprocessor/README.rst
+++ b/samples/openthread/coprocessor/README.rst
@@ -60,12 +60,6 @@ By default, the log levels for all modules are set to critical to not engage the
 To make the solution flexible, you can change independently the log levels for your modules, for the whole Zephyr system, and for OpenThread.
 Use the :file:`overlay-logging.conf` overlay file as reference for this purpose.
 
-FEM support
-===========
-
-.. include:: /includes/sample_fem_support.txt
-
-
 User interface
 **************
 
@@ -109,6 +103,11 @@ The following configuration files are available:
   This file enables the RCP architecture with basic functionality and optimizes stacks and buffer sizes.
   For more information, see :ref:`app_memory`.
 * :file:`overlay-usb.conf` - Enables emulating a serial port over USB for Spinel communication with the host. Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to :file:`usb.overlay`.
+
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
 
 Building and running
 ********************


### PR DESCRIPTION
Adds the missing Configuration section to the Thread sample
documentation and moves the relevant information from other
sections there.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>