### PR TITLE
samples: bluetooth: multiple_adv_sets: nRF5340 enable advertising extension in Bluetooth controller

### DIFF
--- a/samples/bluetooth/multiple_adv_sets/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/multiple_adv_sets/child_image/hci_rpmsg.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR_ADV_SET=2
+CONFIG_BT_CTLR_ADV_EXT=y


### PR DESCRIPTION
Add missing hci_rpmsg configuration to enable advertisment extension support in the controller on nrf5340_nr5340_cpuapp/nrf5340dk_nrf5340_cpuapp_ns. This is needed to make the sample workout-of-the-box.

Signed-off-by: Vidar Berg <vidar.berg@nordicsemi.no>