### PR TITLE
gh: workflows: Add the upstream Zephyr DNM workflow

### DIFF
--- a/.github/workflows/dnm.yml
+++ b/.github/workflows/dnm.yml
@@ -1,0 +1,17 @@
+name: Do Not Merge
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}
+    name: Prevent Merging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is labeled as 'DNM'"
+          echo "This workflow fails so that the pull request cannot be merged"
+          exit 1

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@2f1ad2908599d4fe747f886f9d733dd7eebae4ef
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
           manifest-path: 'west.yml'
           checkout-path: 'ncs/nrf'
           label-prefix: 'manifest-'


### PR DESCRIPTION
Make the GitHub build fail if the DNM label is present.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>