### PR TITLE
tfm: crypto_key: Fix incorrect length of private key

### DIFF
--- a/modules/tfm/tfm/boards/common/crypto_keys.c
+++ b/modules/tfm/tfm/boards/common/crypto_keys.c
@@ -66,7 +66,7 @@ tfm_plat_get_initial_attest_key(uint8_t *key_buf, uint32_t size,
 	}
 
 	ecc_key->priv_key = key_buf;
-	ecc_key->priv_key_size = size;
+	ecc_key->priv_key_size = 32;
 
 	ecc_key->pubx_key = NULL;
 	ecc_key->pubx_key_size = 0;


### PR DESCRIPTION
Fix setting of private key size when using PSA attestation.
Size private key incorrectly set to the size of the key buffer instead
of the size of the private key.

NCSDK-13688

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>