### PR TITLE
kconfig: set ROM offset to 0

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -8,6 +8,9 @@ rsource "subsys/net/openthread/Kconfig.defconfig"
 
 menu "Nordic nRF Connect"
 
+config ROM_START_OFFSET
+	default 0
+
 #
 # Provide a new choice to override the mbedtls_external library completely
 # and not have to provide a "dummy" path for the implementation


### PR DESCRIPTION
NCS use partition manager to enforce this offset.

Ref: NCSDK-11993
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>