### PR TITLE
doc: nRF9160 Azure FOTA sample: added the configuration section

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -11,7 +11,7 @@
 
 .. |config| replace:: See :ref:`configure_application` for information about how to permanently or temporarily change the configuration.
 
-.. |test_sample| replace:: After programming the sample to your development kit, test it by performing the following steps:
+.. |test_sample| replace:: After programming the sample to your development kit, complete the following steps to test it:
 
 .. |connect_generic| replace:: Connect the device to the computer using a USB cable.
    The device is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.

--- a/samples/nrf9160/azure_fota/README.rst
+++ b/samples/nrf9160/azure_fota/README.rst
@@ -39,22 +39,26 @@ See :ref:`lib_azure_fota` for more details on the content of the firmware inform
 Certificates for using TLS
 ==========================
 
-If TLS is used as the transport layer, the required certificates must be provisioned to the device.
+If TLS is used as the transport layer, you must provision the required certificates to the device.
 The certificates that need to be provisioned depends on the location of the hosted FOTA image, and the TLS settings that are configured at the endpoint from where the file is downloaded.
-If, for instance, Azure Blob Storage is used for hosting, the same root certificate (`Baltimore CyberTrust Root certificate`_) that is used in the `Azure IoT Hub`_ connection can be used.
+If, for instance, Azure Blob Storage is used for hosting, you can use the same root certificate (`Baltimore CyberTrust Root certificate`_) that is used in the `Azure IoT Hub`_ connection.
 See :ref:`prereq_connect_to_azure_iot_hub` for more information.
 
 If a host other than Azure is used, the certificate requirements might be different.
 See the documentation for the respective host to locate the correct certificates.
-The certificates can be provisioned using the same procedure as described in :ref:`azure_iot_hub_flash_certs`.
+You can provision the certificates using the same procedure as described in :ref:`azure_iot_hub_flash_certs`.
 
+Configuration
+*************
+
+|config|
 
 .. _additional_config_azure_fota:
 
 Additional configuration
 ========================
 
-Check and configure the following library options that are used by the sample:
+Check and configure the following library Kconfig options:
 
 * :kconfig:option:`CONFIG_AZURE_FOTA_APP_VERSION` - Defines the application version string. Indicates the current firmware version on the development kit.
 * :kconfig:option:`CONFIG_AZURE_FOTA_APP_VERSION_AUTO` - Automatically generates the application version. If enabled, :kconfig:option:`CONFIG_AZURE_FOTA_APP_VERSION` is ignored.
@@ -64,8 +68,8 @@ Check and configure the following library options that are used by the sample:
 * :kconfig:option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID` - Specifies the device ID, which is used when connecting to Azure IoT Hub or when DPS is enabled.
 
 .. note::
-   If the :kconfig:option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID_APP` option is disabled, the device ID must be set in :file:`prj.conf`.
-   If the :kconfig:option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID_APP` option is enabled, the device ID must be provided using the :c:struct:`azure_iot_hub_config` configuration struct in a call to the :c:func:`azure_iot_hub_init` function.
+   If the :kconfig:option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID_APP` option is disabled, set the device ID in the :file:`prj.conf` file.
+   If the :kconfig:option:`CONFIG_AZURE_IOT_HUB_DEVICE_ID_APP` option is enabled, provide the device ID using the :c:struct:`azure_iot_hub_config` configuration struct in a call to the :c:func:`azure_iot_hub_init` function.
 
 Building and running
 ********************
@@ -75,11 +79,10 @@ Building and running
 .. include:: /includes/build_and_run_nrf9160.txt
 
 
-
 Testing
 =======
 
-After programming the sample to your development kit, test it by performing the following steps:
+|test_sample|
 
 #. |connect_kit|
 #. |connect_terminal|


### PR DESCRIPTION
The “Configuration” section was missing from the sample doc.
Added it and made the tone a bit more active.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>