### PR TITLE
samples: nrf5340: Add sample showing how to build multicore app

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -184,6 +184,7 @@ nrf5340 Samples
 * Added:
 
   * :ref:`nrf5340_remote_shell` sample.
+  * :ref:`nrf5340_multicore` sample.
 
 nrf9160 Samples
 ---------------

--- a/samples/nrf5340/multicore/CMakeLists.txt
+++ b/samples/nrf5340/multicore/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if("${BOARD}" STREQUAL "nrf5340dk_nrf5340_cpuapp")
+  set(CHILD_BOARD "nrf5340dk_nrf5340_cpunet")
+else()
+  message(FATAL_ERROR "${BOARD} is not supported for this sample")
+endif()
+
+set(ZEPHYR_EXTRA_MODULES ${CMAKE_CURRENT_LIST_DIR})
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(app)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/nrf5340/multicore/Kconfig
+++ b/samples/nrf5340/multicore/Kconfig
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "Kconfig.zephyr"
+
+config INCLUDE_NET_CORE_IMAGE
+	bool "Include net image as sub image"
+	depends on SOC_NRF5340_CPUAPP
+	default y if (BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPPNS)
+	select PARTITION_MANAGER_ENABLED
+	select BOARD_ENABLE_CPUNET

--- a/samples/nrf5340/multicore/README.rst
+++ b/samples/nrf5340/multicore/README.rst
@@ -1,0 +1,64 @@
+.. _nrf5340_multicore:
+
+nRF5340: Multicore application
+###############################
+
+.. contents::
+   :local:
+   :depth: 2
+
+You can use this sample to see how to build an application on the network core as a child image from the sample source files.
+
+Requirements
+************
+
+The sample supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340dk_nrf5340_cpuapp
+
+Overview
+********
+
+The sample demonstrates how to build a multicore application with the :c:macro:`add_child_image` CMake macro.
+For general information about multi-image builds, see :ref:`ug_multi_image`.
+When building any multi-image application, the build system in the |NCS| adds the child images based on the options selected for the parent image.
+This sample shows how to inform the build system about dedicated sources for the child image (in the :file:`zephyr` and :file:`aci` directories).
+The sample comes with the following additional files:
+
+* :file:`aci/CMakeLists.txt` - This file is used to add the child image and contains the :c:macro:`add_child_image` macro.
+* :file:`zephyr/module.yml` - This file contains information about the location of the :file:`CMakeLists.txt` file that invokes :c:macro:`add_child_image` that is required for the build system.
+* :file:`Kconfig` - Custom file that allows to add child image only for the application core.
+  Additionally, it enables options required by the multi-image build.
+
+Both the application and network cores use the same :file:`main.c` that prints the name of the DK on which the application is programmed.
+
+Building and running
+********************
+.. |sample path| replace:: :file:`samples/nrf5340/multicore`
+
+.. include:: /includes/build_and_run.txt
+
+Testing
+=======
+
+After programming the sample to your development kit, complete the following steps to test it:
+
+1. |connect_terminal|
+#. Reset the kit.
+#. Observe the console output for both cores:
+
+   * For the application core, the output is similar to the following one:
+
+      .. code-block:: console
+
+         *** Booting Zephyr OS build v2.7.99-ncs1-2193-gd359a86abf14  ***
+         Hello world from nrf5340dk_nrf5340_cpuapp
+
+   * For the network core, the output is similar to the following one:
+
+      .. code-block:: console
+
+         *** Booting Zephyr OS build v2.7.99-ncs1-2193-gd359a86abf14  ***
+         Hello world from nrf5340dk_nrf5340_cpunet

--- a/samples/nrf5340/multicore/aci/CMakeLists.txt
+++ b/samples/nrf5340/multicore/aci/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This check is needed to avoid infinite recursion. This module code will
+# be executed for all images in the build, also for the child image being
+# added below.
+if (CONFIG_INCLUDE_NET_CORE_IMAGE)
+  add_child_image(
+    NAME cpunet
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../cpunet
+    DOMAIN cpunet
+    BOARD ${CHILD_BOARD}
+    )
+endif()

--- a/samples/nrf5340/multicore/cpunet/CMakeLists.txt
+++ b/samples/nrf5340/multicore/cpunet/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(net)
+
+target_sources(app PRIVATE ../src/main.c)

--- a/samples/nrf5340/multicore/cpunet/prj.conf
+++ b/samples/nrf5340/multicore/cpunet/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_PRINTK=y

--- a/samples/nrf5340/multicore/prj.conf
+++ b/samples/nrf5340/multicore/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_PRINTK=y

--- a/samples/nrf5340/multicore/sample.yaml
+++ b/samples/nrf5340/multicore/sample.yaml
@@ -1,0 +1,10 @@
+sample:
+    name: Child image from source template
+    description: Template of application that builds cpunet from sources
+tests:
+  sample.nrf5340.multicore:
+    build_only: true
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/nrf5340/multicore/src/main.c
+++ b/samples/nrf5340/multicore/src/main.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr.h>
+#include <sys/printk.h>
+
+int main(void)
+{
+	printk("Hello world from %s\n", CONFIG_BOARD);
+
+	return 0;
+}

--- a/samples/nrf5340/multicore/zephyr/module.yml
+++ b/samples/nrf5340/multicore/zephyr/module.yml
@@ -1,0 +1,2 @@
+build:
+  cmake: aci


### PR DESCRIPTION
This change adds sample that shows how to build multi core
application with use of add_child_image macro and current
NCS build system.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>