### PR TITLE
samples: bluetooth: peripheral_uart: Add DT chosen for NUS for nRF52833

### DIFF
--- a/samples/bluetooth/peripheral_uart/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/bluetooth/peripheral_uart/boards/nrf52833dk_nrf52833.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,nus-uart = &uart0;
+	};
+};

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -4,12 +4,13 @@ sample:
 tests:
   samples.bluetooth.peripheral_uart:
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       thingy53_nrf5340_cpuapp_ns nrf21540dk_nrf52840
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
+      - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns


### PR DESCRIPTION
DT chosen for NUS device was missing for nrf52833dk_nrf52833 build target, which is built in tests. Also adding this target to integration_platforms.
This is a complement to https://github.com/nrfconnect/sdk-nrf/pull/7224