### PR TITLE
manifest: Update zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 186cf4539e5a28fc1653240d5d675b75c4548010
+      revision: b0aff86e3563718ceec979e6b4e9b2d4b451c575
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr with fix for increased current consumption when
using calibration on nrf52833.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>