### PR TITLE
samples: matter: Fixed sending light switch off command

### DIFF
--- a/samples/matter/light_switch/src/binding_handler.cpp
+++ b/samples/matter/light_switch/src/binding_handler.cpp
@@ -84,7 +84,7 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
 						      ->GetNodeId();
 			Messaging::ExchangeManager &exchangeMgr = Server::GetInstance().GetExchangeManager();
 			ret = Controller::InvokeGroupCommandRequest(&exchangeMgr, aBinding.fabricIndex,
-								    aBinding.groupId, sourceNodeId, onCommand);
+								    aBinding.groupId, sourceNodeId, offCommand);
 		}
 		break;
 	default:


### PR DESCRIPTION
There is a bug that when trying to send off command, the on
command id is used.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>