### PR TITLE
lib: pdn: remove `PDN_SYS_INIT` and `pdn_init()`

### DIFF
--- a/doc/nrf/libraries/modem/pdn.rst
+++ b/doc/nrf/libraries/modem/pdn.rst
@@ -19,8 +19,13 @@ The library uses several AT commands, and it relies on the following two types o
 * Packet domain events notifications (``+CGEV``) - Subscribed by using the `AT+CGEREP set command`_ (``AT+CGEREP=1``)
 * Notifications for unsolicited reporting of error codes sent by the network (``+CNEC``) - Subscribed by using the `AT+CNEC set command`_ (``AT+CNEC=16``)
 
+If the application uses the :ref:`lte_lc_readme` library to change the modem's functional mode, the PDN library automatically subscribes to the necessary AT notifications.
+This includes automatically resubscribing to the notifications upon functional mode changes.
+If the application does not use the :ref:`lte_lc_readme` library to change the modem's functional mode, the application must subscribe to the necessary AT notifications manually.
+
 .. note::
-   The application must subscribe to the AT notifications for packet domain events and unsolicited reporting of error codes manually.
+   The subscription to AT notifications is lost upon changing the modem functional mode to ``+CFUN=0``.
+   If the application subscribes to these notifications manually, it must also take care of resubscription.
 
 Following are the AT commands that are used by the library:
 

--- a/doc/nrf/libraries/modem/pdn.rst
+++ b/doc/nrf/libraries/modem/pdn.rst
@@ -42,7 +42,7 @@ Multiple PDP contexts might share the same PDN connection if they are configured
 Configuration
 *************
 
-The PDN library overrides the default PDP context configuration during initialization (:c:func:`pdn_init`) if you have set the :kconfig:option:`CONFIG_PDN_DEFAULTS_OVERRIDE` Kconfig option.
+The PDN library overrides the default PDP context configuration automatically after the :ref:`nrfxlib:nrf_modem` is initialized, if the :kconfig:option:`CONFIG_PDN_DEFAULTS_OVERRIDE` Kconfig option is set.
 The default PDP context configuration consists of the following parameters, each controlled with a Kconfig setting:
 
 * Access point name, :kconfig:option:`CONFIG_PDN_DEFAULT_APN`

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -277,6 +277,10 @@ Modem libraries
     * Fixed:
       * An issue that would cause AT command responses like ``+CNCEC_EMM`` with underscore to be filtered out.
 
+  * :ref:`pdn_readme` library:
+
+    * Automatically subscribe to ``+CNEC=16`` and ``+CGEREP=1`` if the :ref:`lte_lc_readme` library is used to change the modem's functional mode.
+
 Libraries for networking
 ------------------------
 

--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -87,13 +87,6 @@ typedef void (*pdn_event_handler_t)(uint8_t cid, enum pdn_event event,
 				    int reason);
 
 /**
- * @brief Initialize the PDN library.
- *
- * @return int Zero on success or a negative errno otherwise.
- */
-int pdn_init(void);
-
-/**
  * @brief Create a Packet Data Protocol (PDP) context.
  *
  * If a callback is provided via the @p cb parameter, the library will

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -591,7 +591,7 @@ BUILD_ASSERT(
 
 int lwm2m_os_pdn_init(void)
 {
-	return pdn_init();
+	return 0;
 }
 
 int lwm2m_os_pdn_ctx_create(uint8_t *cid, lwm2m_os_pdn_event_handler_t cb)

--- a/lib/pdn/Kconfig
+++ b/lib/pdn/Kconfig
@@ -29,21 +29,14 @@ config PDN_ESM_TIMEOUT
 	help
 	  Timeout for waiting for an ESM notification when activating a PDN, in milliseconds.
 
-config PDN_SYS_INIT
-	bool "Initialize during SYS_INIT"
-	depends on NRF_MODEM_LIB_SYS_INIT
-	default y if NRF_MODEM_LIB_SYS_INIT
-
-if PDN_SYS_INIT
-
 config PDN_INIT_PRIORITY
 	int "Initialization priority"
 	default APPLICATION_INIT_PRIORITY
 
-endif # PDN_SYS_INIT
-
 config PDN_DEFAULTS_OVERRIDE
 	bool "Override defaults for PDP context 0"
+	help
+	  The defaults are overridden automatically as soon as the modem has been initialized.
 
 if PDN_DEFAULTS_OVERRIDE
 

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
@@ -377,8 +377,6 @@ int link_shell_pdn_event_forward_cb_set(pdn_event_handler_t cb)
 
 void link_shell_pdn_init(void)
 {
-
-	pdn_init();
 	link_shell_pdn_events_subscribe();
 	sys_dlist_init(&pdn_info_list);
 }

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
@@ -347,20 +347,6 @@ int link_shell_pdn_activate(int pdn_cid)
 
 void link_shell_pdn_events_subscribe(void)
 {
-	int err;
-
-	/* Register to the necessary packet domain AT notifications */
-	err = nrf_modem_at_printf("AT+CNEC=16");
-	if (err) {
-		mosh_error("AT+CNEC=16 failed, err %d\n", err);
-		return;
-	}
-
-	err = nrf_modem_at_printf("AT+CGEREP=1");
-	if (err) {
-		mosh_error("AT+CGEREP=1 failed, err %d\n", err);
-		return;
-	}
 	pdn_default_callback_set(link_pdn_event_handler);
 }
 

--- a/samples/nrf9160/pdn/README.rst
+++ b/samples/nrf9160/pdn/README.rst
@@ -21,12 +21,16 @@ The sample supports the following development kit:
 Overview
 ********
 
-The sample first initializes the :ref:`nrfxlib:nrf_modem` and registers to the Packet Domain Events notifications (using the `AT+CGEREP=1 <AT+CGEREP set command_>`_ AT command) and notifications for unsolicited reporting of error codes sent by the network (using the `AT+CNEC=16 <AT+CNEC set command_>`_ AT command).
+The sample first initializes the :ref:`nrfxlib:nrf_modem`.
 Next, the sample initializes the :ref:`pdn_readme` library and registers a callback for events pertaining to the default PDP context.
 This is done before changing the function mode to 1 (``AT+CFUN=1``) to receive the activation event for the default PDP context.
 The sample then creates a new PDP context and configures it to use the default APN, registers a callback for its events and activates the PDN connection.
 Finally, the sample prints the PDP context IDs and PDN IDs of both the default PDP context and the new PDP context that it has created.
 
+.. note::
+   The sample uses the :ref:`lte_lc_readme` library to change the modem's functional mode.
+   Hence, the :ref:`pdn_readme` library can automatically register to the necessary packet domain events notifications using the `AT+CGEREP=1 <AT+CGEREP set command_>`_ AT command, and notifications for unsolicited reporting of error codes sent by the network using the `AT+CNEC=16 <AT+CNEC set command_>`_ AT command.
+   If your application does not use the :ref:`lte_lc_readme` library to change the modem's functional mode, you have to subscribe to these notifications manually before the functional mode is changed.
 
 Building and running
 ********************

--- a/samples/nrf9160/pdn/src/main.c
+++ b/samples/nrf9160/pdn/src/main.c
@@ -48,19 +48,6 @@ void main(void)
 
 	printk("PDN sample started\n");
 
-	/* Register to the necessary packet domain AT notifications */
-	err = nrf_modem_at_printf("AT+CNEC=16");
-	if (err) {
-		printk("AT+CNEC=16 failed, err %d\n", err);
-		return;
-	}
-
-	err = nrf_modem_at_printf("AT+CGEREP=1");
-	if (err) {
-		printk("AT+CGEREP=1 failed, err %d\n", err);
-		return;
-	}
-
 	/* Setup a callback for the default PDP context (zero).
 	 * Do this before switching to function mode 1 (CFUN=1)
 	 * to receive the first activation event.

--- a/samples/nrf9160/pdn/src/main.c
+++ b/samples/nrf9160/pdn/src/main.c
@@ -61,11 +61,6 @@ void main(void)
 		return;
 	}
 
-	err = pdn_init();
-	if (err) {
-		return;
-	}
-
 	/* Setup a callback for the default PDP context (zero).
 	 * Do this before switching to function mode 1 (CFUN=1)
 	 * to receive the first activation event.


### PR DESCRIPTION
- Remove `PDN_SYS_INIT` and `pdn_init()`, now the library can initialize automatically
- If the link controller is used to change functional mode, subscribe (and re-subscribe) to the necessary notifications automatically

test-sdk-nrf: sdk-nrf-PR-7303