### PR TITLE
doc: pull supported boards from sample.yaml

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -157,9 +157,7 @@ Requirements
 
 The application supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/applications/connectivity_bridge/README.rst
+++ b/applications/connectivity_bridge/README.rst
@@ -52,9 +52,7 @@ Requirements
 
 The sample supports the following nRF52840-based device:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf52840
+.. table-from-sample-yaml::
 
 The sample also requires a USB host which can communicate with CDC ACM devices, such as a Windows or Linux PC.
 

--- a/applications/machine_learning/README.rst
+++ b/applications/machine_learning/README.rst
@@ -131,9 +131,7 @@ Requirements
 
 The application supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy52_nrf52832, thingy53_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 The available configurations use only built-in sensors or the simulated sensor signal.
 There is no need to connect any additional components to the board.

--- a/applications/matter_weather_station/README.rst
+++ b/applications/matter_weather_station/README.rst
@@ -80,9 +80,7 @@ Requirements
 
 The application supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy53_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 To commission the weather station device and control it remotely through a Thread network, you also need a Matter controller device :ref:`configured on PC or smartphone <ug_matter_configuring>` (which requires additional hardware depending on which setup you choose).
 The recommended way of getting measurement values is using the mobile Matter controller application that comes with a neat graphical interface, performs measurements automatically and visualizes the data.

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -23,9 +23,7 @@ Requirements
 
 The application supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns, thingy91_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/applications/zigbee_weather_station/README.rst
+++ b/applications/zigbee_weather_station/README.rst
@@ -88,9 +88,7 @@ Requirements
 
 The application supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy53_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 To commission the Zigbee weather station device and control it remotely through a Zigbee network, you also need to progam a Zigbee network coordinator on a separate compatible development kit.
 The Zigbee network coordinator forms the network that the weather station node will join and onto which it will share its measurement data.

--- a/doc/_extensions/table_from_rows.py
+++ b/doc/_extensions/table_from_rows.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from docutils import io, statemachine
 from docutils.utils.error_reporting import ErrorString
 from docutils.parsers.rst import directives
@@ -10,7 +11,7 @@ import os
 import yaml
 
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 
 class TableFromRows(SphinxDirective):
@@ -22,7 +23,6 @@ class TableFromRows(SphinxDirective):
     option_spec = {
         'header': directives.unchanged,
         'rows': directives.unchanged,
-        'sample-yaml-rows': directives.flag,
     }
 
     def _load_section(self, lines, section):
@@ -84,7 +84,9 @@ class TableFromRows(SphinxDirective):
                 sizes = [max(sizes[i], row_sizes[i]) for i, _ in enumerate(sizes)]
         return sizes
 
-    def _load_header_and_rows(self, source_path, header_section, rows_sections):
+    def _load_header_and_rows(
+        self, source_path, header_section, rows_sections, transform_rows_func=None
+    ):
         try:
             self.state.document.settings.record_dependencies.add(source_path)
             include_file = io.FileInput(source_path=source_path)
@@ -94,24 +96,10 @@ class TableFromRows(SphinxDirective):
         lines = include_file.readlines()
         header_lines = self._load_section(lines, header_section)
         rows = [self._load_section(lines, section) for section in rows_sections]
+        if transform_rows_func:
+            transform_rows_func(rows)
         column_sizes = self._find_column_sizes(header_lines, rows)
         return self._build_table(column_sizes, header_lines, rows)
-
-    def _rows_from_sample_yaml(self, path):
-        rel_path = os.path.relpath(path, self.env.srcdir)
-        path = os.path.join(self.config.table_from_rows_base_dir, rel_path, 'sample.yaml')
-        try:
-            sample_yaml = open(path)
-        except FileNotFoundError:
-            raise self.severe('"%s" not found' % path)
-        data = yaml.load(sample_yaml, Loader=yaml.BaseLoader)
-        path_key = '.'.join(rel_path.split(os.path.sep))
-        for key in ['tests', path_key, 'platform_allow']:
-            if key not in data:
-                raise self.severe('Unexpected sample.yaml format detected, '
-                                  '"%s" key not found!' % key)
-            data = data[key]
-        return [r.strip() for r in data.split(' ') if r.strip() != '']
 
     def run(self):
         _, path = self.env.relfn2path(self.arguments[0])
@@ -126,38 +114,124 @@ class TableFromRows(SphinxDirective):
         if rows is not None:
             rows = [r.strip() for r in rows.split(',') if r.strip() != '']
         else:
-            rows = []
+            raise self.severe('No "rows" content provided for "%s" '
+                              % self.name)
 
-        if 'sample-yaml-rows' in self.options:
-            source = self.state_machine.input_lines.source(
-                 self.lineno - self.state_machine.input_offset - 1)
-            source_dir = os.path.dirname(os.path.abspath(source))
-            sample_yaml_rows = self._rows_from_sample_yaml(source_dir)
-        else:
-            sample_yaml_rows = []
-
-        if len(rows) == 0 and len(sample_yaml_rows) == 0:
-            raise self.severe('No "rows" content or "sample-yaml-rows" '
-                              'provided for "%s" ' % self.name)
-
-        # join all rows for uniqueness, using the order given in the :rows:
-        # option or inside sample.yaml, and prioritize :rows: order
+        # join all rows for uniqueness, using the order given in
+        # the :rows: option.
         all_rows = {}
-        if len(rows) > 0:
-            all_rows.update(dict.fromkeys(rows))
-        if len(sample_yaml_rows) > 0:
-            all_rows.update(dict.fromkeys(sample_yaml_rows))
+        all_rows.update(dict.fromkeys(rows))
         raw = '\n'.join(self._load_header_and_rows(path, header,
                                                    all_rows.keys()))
         lines = statemachine.string2lines(raw)
         self.state_machine.insert_input(lines, path)
         return []
 
+class TableFromSampleYaml(TableFromRows):
+
+    option_spec = {}
+    required_arguments = 0
+
+    @staticmethod
+    def _merge_rows(rows):
+        """Merge rows where all columns except the build target are equal."""
+
+        seen = {}
+        to_delete = []
+        for row in rows:
+            columns = row[0].split('|')[1:-1]
+            common_info = '|'.join(columns[:-1])
+            build_target = columns[-1]
+            if common_info in seen:
+                seen[common_info].append(f'| | | | {build_target} |')
+                to_delete.append(row)
+            else:
+                seen[common_info] = row
+
+        for row in to_delete:
+            rows.remove(row)
+
+    def _rows_from_sample_yaml(self, path):
+        """Search for a sample.yaml file and return a union of all relevant boards.
+
+        Boards are retrieved from the integration_platforms sections in the file.
+        If the file is not found and the document folder is named "doc", the
+        parent folder is searched. Should a sample.yaml still not be found, all
+        subfolders are searched and every found sample.yaml is used.
+
+        nrf51 and qemu boards are ignored."""
+
+        # Path from rst-file in build folder to source build directory.
+        rel_path = os.path.relpath(path, self.env.srcdir)
+
+        # In cases where ``path`` for some reason is not pointing to the
+        # build folder, remove all instances of '../' from the path.
+        rel_path = rel_path.lstrip('..' + os.path.sep)
+
+        # Path to the origin of the rst-file outside the build folder
+        dir_path = Path(self.config.table_from_rows_base_dir) / rel_path
+
+        sample_yamls = []
+        if (dir_path / 'sample.yaml').exists():
+            sample_yamls.append(dir_path / 'sample.yaml')
+        elif rel_path.endswith('doc'):
+            parent_path = dir_path.parent / 'sample.yaml'
+            if parent_path.exists():
+                sample_yamls.append(parent_path)
+        else:
+            sample_yamls += list(dir_path.glob('**/sample.yaml'))
+
+        if not sample_yamls:
+            raise self.severe(f'"{path}" not found')
+
+        boards = set()
+        for sample_yaml_path in sample_yamls:
+            with open(sample_yaml_path) as sample_yaml:
+                data = yaml.safe_load(sample_yaml)
+
+            if 'common' in data and 'integration_platforms' in data['common']:
+                boards.update(data['common']['integration_platforms'])
+            for test in data['tests'].values():
+                if 'integration_platforms' in test:
+                    boards.update(test['integration_platforms'])
+
+        boards = list(filter(
+            lambda b: not b.startswith('qemu') and not b.startswith('nrf51'),
+            boards,
+        ))
+        boards.sort(reverse=True)
+
+        if not boards:
+            raise self.severe(f'{path} has no relevant integration_platforms')
+
+        return boards
+
+    def run(self):
+        reference_file = self.config.table_from_sample_yaml_board_reference
+        _, path = self.env.relfn2path(reference_file)
+
+        source = self.state_machine.input_lines.source(
+                self.lineno - self.state_machine.input_offset - 1)
+        source_dir = os.path.dirname(os.path.abspath(source))
+        sample_yaml_rows = self._rows_from_sample_yaml(source_dir)
+
+        raw = '\n'.join(self._load_header_and_rows(
+            path,
+            'heading',
+            sample_yaml_rows,
+            transform_rows_func=self._merge_rows,
+        ))
+        lines = statemachine.string2lines(raw)
+        self.state_machine.insert_input(lines, path)
+        return []
+
 
 def setup(app):
-    app.add_config_value("table_from_rows_base_dir", None, "env")
+    app.add_config_value('table_from_rows_base_dir', None, 'env')
+    app.add_config_value('table_from_sample_yaml_board_reference', None, 'env')
 
     directives.register_directive('table-from-rows', TableFromRows)
+    directives.register_directive('table-from-sample-yaml', TableFromSampleYaml)
 
     return {
         'version': __version__,

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -163,6 +163,7 @@ external_content_keep = ["versions.txt"]
 # Options for table_from_rows --------------------------------------------------
 
 table_from_rows_base_dir = NRF_BASE
+table_from_sample_yaml_board_reference = "/includes/sample_board_rows.txt"
 
 # Options for options_from_kconfig ---------------------------------------------
 

--- a/doc/nrf/includes/sample_board_rows.txt
+++ b/doc/nrf/includes/sample_board_rows.txt
@@ -22,6 +22,12 @@
 
 | :ref:`nRF9160 DK <ug_nrf9160>` | PCA10090 | :ref:`nrf9160dk_nrf9160 <nrf9160dk_nrf9160>` | ``nrf9160dk_nrf9160_ns`` |
 
+.. nrf9160dk_nrf9160_and_ns
+
+| :ref:`nRF9160 DK <ug_nrf9160>` | PCA10090 | :ref:`nrf9160dk_nrf9160 <nrf9160dk_nrf9160>` | ``nrf9160dk_nrf9160``    |
+|                                |          |                                              |                          |
+|                                |          |                                              | ``nrf9160dk_nrf9160_ns`` |
+
 .. nrf9160dk_nrf52840
 
 | :ref:`nRF9160 DK <ug_nrf9160>` | PCA10090 | :ref:`nrf9160dk_nrf52840 <nrf9160dk_nrf52840>` | ``nrf9160dk_nrf52840`` |
@@ -53,6 +59,10 @@
 .. nrf52820dongle_nrf52820
 
 | nRF52820 Dongle | PCA10114 | nrf52820dongle_nrf52820 | ``nrf52820dongle_nrf52820`` |
+
+.. thingy91_nrf9160
+
+| :ref:`Thingy:91 <ug_thingy91>` | PCA20035 | thingy91_nrf9160 | ``thingy91_nrf9160`` |
 
 .. thingy91_nrf9160_ns
 

--- a/doc/nrf/templates/sample_README.rst
+++ b/doc/nrf/templates/sample_README.rst
@@ -33,7 +33,7 @@ Requirements
 
 .. note::
    * Supported kits are listed in a table, which is composed of rows from the :file:`doc/nrf/includes/sample_board_rows.txt` file.
-     Select the required rows in the ``:rows:`` configuration, or specify ``:sample-yaml-rows:`` to include all build targets specified in the :file:`sample.yaml` file.
+     Select the required rows in the ``:rows:`` configuration, or use the ``.. table-from-sample-yaml::`` directive to include all build targets specified in the :file:`sample.yaml` file.
    * If only one kit is supported, replace the introduction text with "The sample supports the following development kit:".
    * If several kits are required to test the sample, state it after the table (for example, "You can use one or more of the development kits listed above and mix different development kits.").
    * Mention additional requirements after the table.

--- a/samples/app_event_manager/README.rst
+++ b/samples/app_event_manager/README.rst
@@ -39,9 +39,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf52dk_nrf52832, nrf52840dk_nrf52840, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 Configuration
 *************

--- a/samples/app_event_manager_profiler_tracer/README.rst
+++ b/samples/app_event_manager_profiler_tracer/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf52dk_nrf52832, nrf52840dk_nrf52840, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/bluetooth/alexa_gadget/README.rst
+++ b/samples/bluetooth/alexa_gadget/README.rst
@@ -65,9 +65,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52dk_nrf52810
+.. table-from-sample-yaml::
 
 The sample also has the following requirements:
 

--- a/samples/bluetooth/central_and_peripheral_hr/README.rst
+++ b/samples/bluetooth/central_and_peripheral_hr/README.rst
@@ -29,9 +29,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 To test just the Bluetooth® LE Central Role operation, you need one of the following setups:
 

--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -22,9 +22,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns , nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 The sample also requires a device running a BAS Server to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -27,9 +27,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns , nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 The sample also requires a HIDS device to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 

--- a/samples/bluetooth/central_hr_coded/README.rst
+++ b/samples/bluetooth/central_hr_coded/README.rst
@@ -22,9 +22,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dongle_nrf52840, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/hci_rpmsg_overlay.txt
 

--- a/samples/bluetooth/central_nfc_pairing/README.rst
+++ b/samples/bluetooth/central_nfc_pairing/README.rst
@@ -57,9 +57,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 The sample has the following additional requirements:
 

--- a/samples/bluetooth/central_smp_client/README.rst
+++ b/samples/bluetooth/central_smp_client/README.rst
@@ -30,9 +30,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 The sample also requires a device running `mcumgr`_ with transport protocol over Bluetooth® Low Energy, for example, another development kit running the :ref:`smp_svr_sample`.
 

--- a/samples/bluetooth/central_uart/README.rst
+++ b/samples/bluetooth/central_uart/README.rst
@@ -39,9 +39,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 The sample also requires another development kit running a compatible application (see :ref:`peripheral_uart`).
 

--- a/samples/bluetooth/direct_test_mode/README.rst
+++ b/samples/bluetooth/direct_test_mode/README.rst
@@ -199,9 +199,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpunet, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 Additionally, the sample requires one of the following testing devices:
 

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns
+.. table-from-sample-yaml::
 
 The sample also requires an antenna matrix when operating in angle of arrival mode.
 It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns
+.. table-from-sample-yaml::
 
 The sample also requires an antenna matrix when operating in angle of arrival mode.
 It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns
+.. table-from-sample-yaml::
 
 The sample also requires an antenna matrix when operating in angle of departure mode.
 It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns
+.. table-from-sample-yaml::
 
 The sample also requires an antenna matrix when operating in angle of departure mode.
 It can be a Nordic Semiconductor design 12 patch antenna matrix, or any other antenna matrix.

--- a/samples/bluetooth/enocean/README.rst
+++ b/samples/bluetooth/enocean/README.rst
@@ -23,9 +23,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52840dk_nrf52811, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52dk_nrf52832, nrf52dk_nrf52810
+.. table-from-sample-yaml::
 
 The sample also requires at least one :ref:`supported EnOcean device <bt_enocean_devices>`.
 

--- a/samples/bluetooth/hci_lpuart/README.rst
+++ b/samples/bluetooth/hci_lpuart/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf52840
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -79,9 +79,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832, nrf52840dongle_nrf52840
+.. table-from-sample-yaml::
 
 The sample also supports other development kits running SoftDevice Controller variants that support LLPM (see :ref:`nrfxlib:softdevice_controller` Proprietary feature support).
 You can use any two of the development kits mentioned above and mix different development kits.

--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/README.rst
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The mesh and peripheral coexistence sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone with `nRF Connect for Mobile`_ and one of the following apps:
 

--- a/samples/bluetooth/mesh/chat/sample_description.rst
+++ b/samples/bluetooth/mesh/chat/sample_description.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :sample-yaml-rows:
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -18,9 +18,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, thingy53_nrf5340_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, thingy53_nrf5340_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -17,9 +17,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, thingy53_nrf5340_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You need at least two development kits:
 

--- a/samples/bluetooth/mesh/sensor_client/README.rst
+++ b/samples/bluetooth/mesh/sensor_client/README.rst
@@ -20,9 +20,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :sample-yaml-rows:
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -20,9 +20,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52dk_nrf52832, nrf52840dk_nrf52840, thingy53_nrf5340_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 For provisioning and configuring of the mesh model instances, the sample requires a smartphone with Nordic Semiconductor's nRF Mesh mobile app installed in one of the following versions:
 

--- a/samples/bluetooth/mesh/silvair_enocean/README.rst
+++ b/samples/bluetooth/mesh/silvair_enocean/README.rst
@@ -17,9 +17,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You need at least two development kits:
 

--- a/samples/bluetooth/multiple_adv_sets/README.rst
+++ b/samples/bluetooth/multiple_adv_sets/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/bluetooth/nrf_dm/README.rst
+++ b/samples/bluetooth/nrf_dm/README.rst
@@ -18,9 +18,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/bluetooth/peripheral_ams_client/README.rst
+++ b/samples/bluetooth/peripheral_ams_client/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 The sample also requires a device running an AMS Server to connect with (for example, an iPhone which runs iOS, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 

--- a/samples/bluetooth/peripheral_ancs_client/README.rst
+++ b/samples/bluetooth/peripheral_ancs_client/README.rst
@@ -28,9 +28,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 The sample also requires a device running an ANCS Server to connect with (for example, an iPhone which runs iOS, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 

--- a/samples/bluetooth/peripheral_bms/README.rst
+++ b/samples/bluetooth/peripheral_bms/README.rst
@@ -21,9 +21,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 The sample also requires a Bluetooth® Low Energy dongle and nRF Connect for Desktop.
 

--- a/samples/bluetooth/peripheral_cts_client/README.rst
+++ b/samples/bluetooth/peripheral_cts_client/README.rst
@@ -19,9 +19,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 The sample also requires a device running a CTS Server to connect with (for example, a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 

--- a/samples/bluetooth/peripheral_gatt_dm/README.rst
+++ b/samples/bluetooth/peripheral_gatt_dm/README.rst
@@ -19,9 +19,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820
+.. table-from-sample-yaml::
 
 The sample also requires a device to connect to the peripheral, for example, a phone or a tablet with `nRF Connect for Mobile`_ or `nRF Toolbox`_.
 

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -42,9 +42,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820
+.. table-from-sample-yaml::
 
 .. include:: /includes/hci_rpmsg_overlay.txt
 

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -31,9 +31,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833, nrf52833dk_nrf52820
+.. table-from-sample-yaml::
 
 .. include:: /includes/hci_rpmsg_overlay.txt
 

--- a/samples/bluetooth/peripheral_hr_coded/README.rst
+++ b/samples/bluetooth/peripheral_hr_coded/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dongle_nrf52840, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/hci_rpmsg_overlay.txt
 

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -22,9 +22,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52840dk_nrf52811, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52dk_nrf52832, nrf52dk_nrf52810, nrf52840dongle_nrf52840, thingy53_nrf5340_cpuapp_and_cpuapp_ns
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone or tablet running a compatible application.
 The `Testing`_ instructions refer to `nRF Connect for Mobile`_, but you can also use other similar applications (for example, `nRF Blinky`_ or `nRF Toolbox`_).

--- a/samples/bluetooth/peripheral_nfc_pairing/README.rst
+++ b/samples/bluetooth/peripheral_nfc_pairing/README.rst
@@ -26,9 +26,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 The sample has the following additional requirements:
 

--- a/samples/bluetooth/peripheral_rscs/README.rst
+++ b/samples/bluetooth/peripheral_rscs/README.rst
@@ -22,9 +22,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 The sample also requires a phone or tablet running a compatible application, for example `nRF Connect for Mobile`_ or `nRF Toolbox`_.
 

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52840dk_nrf52811, nrf52833dk_nrf52833, nrf52833dk_nrf52820, nrf52833dk_nrf52820, nrf52dk_nrf52832, nrf52dk_nrf52810, thingy53_nrf5340_cpuapp_and_cpuapp_ns, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 .. note::
    * The boards ``nrf52dk_nrf52810``, ``nrf52840dk_nrf52811``, and ``nrf52833dk_nrf52820`` only support the `Minimal sample variant`_.

--- a/samples/bluetooth/radio_coex_1wire/README.rst
+++ b/samples/bluetooth/radio_coex_1wire/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/bluetooth/radio_coex_3wire/README.rst
+++ b/samples/bluetooth/radio_coex_3wire/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/bluetooth/rpc_host/README.rst
+++ b/samples/bluetooth/rpc_host/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpunet
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/bluetooth/shell_bt_nus/README.rst
+++ b/samples/bluetooth/shell_bt_nus/README.rst
@@ -21,9 +21,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 You also need an additional nRF52 development kit, like the PCA10040 for connecting using the :file:`bt_nus_shell.py` script.
 Alternatively, you can use :ref:`ble_console_readme` for connecting, using Linux only.

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 You can use any two of the development kits listed above and mix different development kits.
 

--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -25,9 +25,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/caf/README.rst
+++ b/samples/caf/README.rst
@@ -17,9 +17,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/caf_sensor_manager/README.rst
+++ b/samples/caf_sensor_manager/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/crypto/aes_cbc/README.rst
+++ b/samples/crypto/aes_cbc/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/aes_ccm/README.rst
+++ b/samples/crypto/aes_ccm/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/aes_ctr/README.rst
+++ b/samples/crypto/aes_ctr/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/aes_gcm/README.rst
+++ b/samples/crypto/aes_gcm/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/chachapoly/README.rst
+++ b/samples/crypto/chachapoly/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/ecdh/README.rst
+++ b/samples/crypto/ecdh/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/ecdsa/README.rst
+++ b/samples/crypto/ecdsa/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/hkdf/README.rst
+++ b/samples/crypto/hkdf/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/hmac/README.rst
+++ b/samples/crypto/hmac/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/persistent_key_usage/README.rst
+++ b/samples/crypto/persistent_key_usage/README.rst
@@ -16,9 +16,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/psa_tls/README.rst
+++ b/samples/crypto/psa_tls/README.rst
@@ -18,9 +18,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 The sample requires a `TAP adapter`_ to perform the TLS handshake.
 This functionality is currently only supported in Linux.

--- a/samples/crypto/rng/README.rst
+++ b/samples/crypto/rng/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/rsa/README.rst
+++ b/samples/crypto/rsa/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows:  nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/crypto/sha256/README.rst
+++ b/samples/crypto/sha256/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160_ns, nrf9160dk_nrf9160, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/debug/ppi_trace/README.rst
+++ b/samples/debug/ppi_trace/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52dk_nrf52832, nrf52840dk_nrf52840, nrf9160dk_nrf9160, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 The sample also requires a logic analyzer.
 

--- a/samples/edge_impulse/data_forwarder/README.rst
+++ b/samples/edge_impulse/data_forwarder/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52dk_nrf52832, nrf52840dk_nrf52840
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/edge_impulse/wrapper/README.rst
+++ b/samples/edge_impulse/wrapper/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/esb/README.rst
+++ b/samples/esb/README.rst
@@ -35,9 +35,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You can use any two of the development kits listed above and mix different development kits.
 

--- a/samples/event_manager_proxy/README.rst
+++ b/samples/event_manager_proxy/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/gazell/gzll_ack_payload_host/README.rst
+++ b/samples/gazell/gzll_ack_payload_host/README.rst
@@ -21,9 +21,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 You can use any two of the development kits listed above and mix different development kits.
 

--- a/samples/gazell/gzp_dynamic_pairing_host/README.rst
+++ b/samples/gazell/gzp_dynamic_pairing_host/README.rst
@@ -21,9 +21,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 You can use any two of the development kits listed above and mix different development kits.
 

--- a/samples/ipc/ipc_service/README.rst
+++ b/samples/ipc/ipc_service/README.rst
@@ -22,9 +22,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 Configuration
 *************

--- a/samples/keys/hw_unique_key/README.rst
+++ b/samples/keys/hw_unique_key/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf5340dk_nrf5340_cpuapp_ns, nrf9160dk_nrf9160, nrf9160dk_nrf9160_ns, nrf52840dk_nrf52840, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 .. include:: /includes/tfm.txt
 

--- a/samples/keys/random_hw_unique_key/README.rst
+++ b/samples/keys/random_hw_unique_key/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160, nrf52840dk_nrf52840, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -21,9 +21,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 For remote testing scenarios, you also need the following:
 

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -17,9 +17,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 For this sample to work, you also need at least one :ref:`Matter light bulb <matter_light_bulb_sample>` sample programmed to another supported development kit.
 

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -17,9 +17,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 If you want to commission the lock device and :ref:`control it remotely <matter_lock_sample_network_mode>` through a Thread network, you also need a Matter controller device :ref:`configured on PC or smartphone <ug_matter_configuring>`. This requires additional hardware depending on the setup you choose.
 

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -18,9 +18,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 For testing purposes, that is to commission the device and :ref:`control it remotely <matter_template_network_mode>` through a Thread network, you also need a Matter controller device :ref:`configured on PC or smartphone <ug_matter_configuring>`. This requires additional hardware depending on the setup you choose.
 

--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports any one of the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpunet, nrf52840dk_nrf52840, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 .. note::
    For the nRF5340 DK, this sample is only supported on the network core (``nrf5340dk_nrf5340_cpunet``), and the :ref:`nrf5340_empty_app_core` sample must be programmed to the application core.

--- a/samples/nfc/record_launch_app/README.rst
+++ b/samples/nfc/record_launch_app/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 This sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840,  nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone or a tablet.
 You need to have the `nRF Toolbox`_ app installed for iOS devices.

--- a/samples/nfc/record_text/README.rst
+++ b/samples/nfc/record_text/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840,  nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone or tablet.
 

--- a/samples/nfc/system_off/README.rst
+++ b/samples/nfc/system_off/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone or tablet with the NFC feature.
 

--- a/samples/nfc/tag_reader/README.rst
+++ b/samples/nfc/tag_reader/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 The sample has the following additional requirements:
 

--- a/samples/nfc/tnep_poller/README.rst
+++ b/samples/nfc/tnep_poller/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 The sample has the following additional requirements:
 

--- a/samples/nfc/tnep_tag/README.rst
+++ b/samples/nfc/tnep_tag/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/nfc/writable_ndef_msg/README.rst
+++ b/samples/nfc/writable_ndef_msg/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpuapp_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf52833dk_nrf52833
+.. table-from-sample-yaml::
 
 The sample also requires a smartphone or tablet with NFC Tools application (or equivalent).
 

--- a/samples/nrf5340/empty_app_core/README.rst
+++ b/samples/nrf5340/empty_app_core/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/nrf5340/multicore/README.rst
+++ b/samples/nrf5340/multicore/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/nrf5340/multiprotocol_rpmsg/README.rst
+++ b/samples/nrf5340/multiprotocol_rpmsg/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpunet
+.. table-from-sample-yaml::
 
 The testing procedure of the sample also requires a second development kit that supports IEEE 802.15.4.
 

--- a/samples/nrf5340/netboot/README.rst
+++ b/samples/nrf5340/netboot/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpunet
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/nrf5340/remote_shell/README.rst
+++ b/samples/nrf5340/remote_shell/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/at_monitor/README.rst
+++ b/samples/nrf9160/at_monitor/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :sample-yaml-rows:
+.. table-from-sample-yaml::
 
 The sample requires an `AWS account`_ with access to Simple Storage Service (S3) and the IoT Core service.
 

--- a/samples/nrf9160/aws_iot/README.rst
+++ b/samples/nrf9160/aws_iot/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/azure_fota/README.rst
+++ b/samples/nrf9160/azure_fota/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 The sample also requires an Azure IoT Hub instance, and optionally an `Azure IoT Hub Device Provisioning Service (DPS)`_ instance, if the device is not already registered with the IoT hub.
 

--- a/samples/nrf9160/azure_iot_hub/README.rst
+++ b/samples/nrf9160/azure_iot_hub/README.rst
@@ -16,9 +16,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/cloud_client/README.rst
+++ b/samples/nrf9160/cloud_client/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :sample-yaml-rows:
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/nrf9160/coap_client/README.rst
+++ b/samples/nrf9160/coap_client/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 The sample also requires a public CoAP server IP address or URL available on the Internet.
 

--- a/samples/nrf9160/download/README.rst
+++ b/samples/nrf9160/download/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 
 .. include:: /includes/spm.txt

--- a/samples/nrf9160/fmfu_smp_svr/README.rst
+++ b/samples/nrf9160/fmfu_smp_svr/README.rst
@@ -16,9 +16,7 @@ Requirements
 
 This sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/gnss/README.rst
+++ b/samples/nrf9160/gnss/README.rst
@@ -18,9 +18,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/http_update/application_update/README.rst
+++ b/samples/nrf9160/http_update/application_update/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 The sample also requires two signed firmware images that have to be available for download from an HTTP server.
 The images are generated automatically when building the sample, but you must upload them to a server and configure the location from where they can be downloaded.

--- a/samples/nrf9160/http_update/full_modem_update/README.rst
+++ b/samples/nrf9160/http_update/full_modem_update/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kit, version 0.14.0 or higher:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/http_update/modem_delta_update/README.rst
+++ b/samples/nrf9160/http_update/modem_delta_update/README.rst
@@ -17,9 +17,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/https_client/README.rst
+++ b/samples/nrf9160/https_client/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/location/README.rst
+++ b/samples/nrf9160/location/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -17,9 +17,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 The sample also requires a `Nordic Thingy:52`_.
 

--- a/samples/nrf9160/lwm2m_carrier/README.rst
+++ b/samples/nrf9160/lwm2m_carrier/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-     :header: heading
-     :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/lwm2m_client/sample_description.rst
+++ b/samples/nrf9160/lwm2m_client/sample_description.rst
@@ -17,9 +17,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 Additionally, the sample requires an activated SIM card, and an LwM2M server such as `Leshan Demo Server`_ or `Coiote Device Management`_ server.
 

--- a/samples/nrf9160/memfault/README.rst
+++ b/samples/nrf9160/memfault/README.rst
@@ -16,9 +16,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 Before using the Memfault platform, you must register an account in the `Memfault registration page`_ and `create a new project in Memfault`_.
 

--- a/samples/nrf9160/modem_callbacks/README.rst
+++ b/samples/nrf9160/modem_callbacks/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/nrf9160/mqtt_simple/README.rst
+++ b/samples/nrf9160/mqtt_simple/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 Additionally, the sample supports :ref:`qemu_x86`.
 

--- a/samples/nrf9160/multicell_location/README.rst
+++ b/samples/nrf9160/multicell_location/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 
 .. include:: /includes/spm.txt

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
@@ -18,9 +18,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :sample-yaml-rows:
+.. table-from-sample-yaml::
 
 .. _nrf_cloud_mqtt_multi_service_features:
 

--- a/samples/nrf9160/nrf_cloud_rest_cell_pos/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_cell_pos/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 The sample requires an `nRF Cloud`_ account.
 It requires one of the following:

--- a/samples/nrf9160/nrf_cloud_rest_device_message/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_device_message/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 The sample requires an `nRF Cloud`_ account.
 

--- a/samples/nrf9160/nrf_cloud_rest_fota/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_fota/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 The sample requires an `nRF Cloud`_ account.
 

--- a/samples/nrf9160/pdn/README.rst
+++ b/samples/nrf9160/pdn/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/secure_services/README.rst
+++ b/samples/nrf9160/secure_services/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/sms/README.rst
+++ b/samples/nrf9160/sms/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/nrf9160/udp/README.rst
+++ b/samples/nrf9160/udp/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 Additionally, it supports :ref:`qemu_x86`.
 

--- a/samples/nrf_rpc/entropy_nrf53/README.rst
+++ b/samples/nrf_rpc/entropy_nrf53/README.rst
@@ -16,9 +16,7 @@ Requirements
 
 The sample supports the following development kit:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_and_cpunet
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits for testing the network status:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf5340dk_nrf5340_cpuapp_ns, nrf52840dk_nrf52840, nrf52840dongle_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 Optionally, you can use one or more compatible development kits programmed with this sample or another :ref:`Thread sample <openthread_samples>` for :ref:`testing communication or diagnostics <ot_cli_sample_testing_multiple>` and :ref:`thread_ot_commissioning_configuring_on-mesh`.
 

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -19,9 +19,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf5340dk_nrf5340_cpuapp_ns, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You can use one or more of the development kits listed above as the Thread CoAP Client.
 You also need one or more compatible development kits programmed with the :ref:`coap_server_sample` sample.

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -17,9 +17,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf5340dk_nrf5340_cpuapp_ns, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You can use one or more of these development kits as the Thread CoAP Server.
 You also need one or more compatible development kits programmed with the :ref:`coap_client_sample` sample.

--- a/samples/openthread/coprocessor/README.rst
+++ b/samples/openthread/coprocessor/README.rst
@@ -27,9 +27,7 @@ Requirements
 
 The sample supports the following development kits for testing the network status:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52840dongle_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 To test the sample, you need at least one development kit.
 You can use additional development kits programmed with the Co-processor sample for testing network joining.

--- a/samples/peripheral/802154_phy_test/README.rst
+++ b/samples/peripheral/802154_phy_test/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpunet, nrf52840dk_nrf52840, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 Conducting tests using the sample also requires a testing device, like another development kit running the same sample, set into DUT mode.
 For more information, see :ref:`802154_phy_test_testing`.

--- a/samples/peripheral/lpuart/README.rst
+++ b/samples/peripheral/lpuart/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf52dk_nrf52832, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 The sample also requires the following pins to be shorted:
 

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -19,9 +19,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpunet, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You can use any one of the development kits listed above.
 

--- a/samples/profiler/README.rst
+++ b/samples/profiler/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf9160dk_nrf9160_ns, nrf52840dk_nrf52840, nrf52dk_nrf52832, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/sensor/bh1749/README.rst
+++ b/samples/sensor/bh1749/README.rst
@@ -15,9 +15,7 @@ Requirements
 
 The sample supports the following nRF9160-based device:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: thingy91_nrf9160_ns
+.. table-from-sample-yaml::
 
 Building and running
 ********************

--- a/samples/spm/README.rst
+++ b/samples/spm/README.rst
@@ -18,9 +18,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp, nrf9160dk_nrf9160
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/tfm/tfm_hello_world/README.rst
+++ b/samples/tfm/tfm_hello_world/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 Overview
 ********

--- a/samples/tfm/tfm_secure_peripheral/README.rst
+++ b/samples/tfm/tfm_secure_peripheral/README.rst
@@ -14,9 +14,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf9160dk_nrf9160_ns
+.. table-from-sample-yaml::
 
 Optionally a logic analyzer can be used.
 

--- a/samples/zigbee/light_bulb/README.rst
+++ b/samples/zigbee/light_bulb/README.rst
@@ -16,9 +16,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You can use one or more of the development kits listed above and mix different development kits.
 

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -20,9 +20,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You can use one or more of the development kits listed above and mix different development kits.
 

--- a/samples/zigbee/ncp/README.rst
+++ b/samples/zigbee/ncp/README.rst
@@ -19,9 +19,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52840dongle_nrf52840, nrf52833dk_nrf52833, nrf21540dk_nrf52840, nrf5340dk_nrf5340_cpuapp
+.. table-from-sample-yaml::
 
 The nRF5340 DK (``nrf5340dk_nrf5340_cpuapp``) is supported only for development.
 

--- a/samples/zigbee/network_coordinator/README.rst
+++ b/samples/zigbee/network_coordinator/README.rst
@@ -16,9 +16,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You can use one of the development kits listed above.
 

--- a/samples/zigbee/shell/README.rst
+++ b/samples/zigbee/shell/README.rst
@@ -19,9 +19,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You can use one or more of the development kits listed above and mix different development kits.
 

--- a/samples/zigbee/template/README.rst
+++ b/samples/zigbee/template/README.rst
@@ -16,9 +16,7 @@ Requirements
 
 The sample supports the following development kits:
 
-.. table-from-rows:: /includes/sample_board_rows.txt
-   :header: heading
-   :rows: nrf52840dk_nrf52840, nrf52833dk_nrf52833, nrf5340dk_nrf5340_cpuapp, nrf21540dk_nrf52840
+.. table-from-sample-yaml::
 
 You can use one or more of the development kits listed above and mix different development kits.
 


### PR DESCRIPTION
Modified the `table-from-rows` directive to no longer support
the `sample-yaml-rows` option. Instead, a new directive
`table-from-sample-yaml` has been added which reads supported
boards from the integration_platforms section of the
`sample.yaml` file.

All samples and most applications have had their requirements
section updated to use the new directive.

A lot of the requirement section tables are changing as a
consequence of this modification. A complete list of all the
changes can be found in `changes.txt`. Files in the nrf folder
that still use the old extension can be found in
`manually_maintained.txt`.

[changes.txt](https://github.com/nrfconnect/sdk-nrf/files/8441051/changes.txt)
[manually_maintained.txt](https://github.com/nrfconnect/sdk-nrf/files/8441057/manually_maintained.txt.txt)

