### PR TITLE
github: workflows: quick fix for west version

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Install extra python dependencies
         run: |
-          pip3 install west
+          pip3 install west==0.12.0
           pip3 install -r ncs/nrf/scripts/requirements-extra.txt
 
       - name: Set up the workspace


### PR DESCRIPTION
It looks like west 0,13 is breaking OSS history check. Fixing
its version to 0.12.0.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>