### PR TITLE
caf: ble_state: Optional security request 

### DIFF
--- a/applications/nrf_desktop/doc/ble_discovery.rst
+++ b/applications/nrf_desktop/doc/ble_discovery.rst
@@ -59,7 +59,7 @@ The |ble_discovery| implementation is tasked with peripheral discovery and verif
 Peripheral discovery
 ====================
 
-The module starts the peripheral device discovery when it receives :c:struct:`ble_peer_event` with :c:member:`ble_peer_event.state` set to :c:enumerator:`PEER_STATE_SECURED`.
+The module starts the peripheral device discovery when it receives :c:struct:`ble_peer_event` with :c:member:`ble_peer_event.state` set to :c:enumerator:`PEER_STATE_CONNECTED`.
 
 The peripheral discovery consists of the following steps:
 

--- a/applications/nrf_desktop/doc/ble_scan.rst
+++ b/applications/nrf_desktop/doc/ble_scan.rst
@@ -129,7 +129,6 @@ After the scan filter match, the following happens:
 
 a. The scanning is stopped and the |NCS|'s :ref:`nrf_bt_scan_readme` automatically establishes the Bluetooth connection with the peripheral.
    The initial Bluetooth connection interval is set by default to 7.5 ms, that is to the shortest connection interval allowed by the Bluetooth specification.
-#. The connection is secured.
 #. The peer discovery is started.
 #. After the :ref:`nrf_desktop_ble_discovery` completes the peer discovery, the :ref:`nrf_desktop_ble_conn_params` receives the ``ble_discovery_complete_event`` and updates the Bluetooth connection interval.
 

--- a/applications/nrf_desktop/src/modules/ble_discovery.c
+++ b/applications/nrf_desktop/src/modules/ble_discovery.c
@@ -340,7 +340,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			cast_ble_peer_event(aeh);
 
 		switch (event->state) {
-		case PEER_STATE_SECURED:
+		case PEER_STATE_CONNECTED:
 			discovering_peer_conn = event->id;
 			bt_conn_ref(discovering_peer_conn);
 			k_work_submit(&next_discovery_step);

--- a/doc/nrf/libraries/caf/ble_state.rst
+++ b/doc/nrf/libraries/caf/ble_state.rst
@@ -27,7 +27,6 @@ To use the module, you must enable the following Kconfig options:
 
 * :kconfig:option:`CONFIG_BT`
 * :kconfig:option:`CONFIG_BT_SMP` - This option enables Security Manager Protocol support.
-  The |ble_state| on Bluetooth Peripheral requires at least the connection security level 2 (encryption).
 * :kconfig:option:`CONFIG_CAF_BLE_STATE` - This option enables the |ble_state| and selects the :kconfig:option:`CONFIG_CAF_BLE_COMMON_EVENTS` Kconfig option, which enables Bluetooth LE common events in CAF.
 
 The following Kconfig options are also available for this module:
@@ -36,6 +35,9 @@ The following Kconfig options are also available for this module:
   This option is enabled by default.
 * :kconfig:option:`CONFIG_CAF_BLE_USE_LLPM` - This option enables the Low Latency Packet Mode (LLPM).
   This option is enabled by default and depends on :kconfig:option:`CONFIG_BT_CTLR_SDC_LLPM` and :kconfig:option:`CONFIG_BT_LL_SOFTDEVICE`.
+* :kconfig:option:`CONFIG_CAF_BLE_STATE_SECURITY_REQ` - This option enables setting the security level 2 for a Bluetooth LE connection automatically, right after the connection is established.
+  The security level 2 or higher enables connection encryption.
+  The device disconnects if establishing the connection security level 2 fails.
 
 Implementation details
 **********************
@@ -65,9 +67,6 @@ The connection state can be set to one of the following values:
 
 Other application modules can call :c:func:`bt_conn_disconnect` to disconnect the remote peer.
 The application module can submit a :c:struct:`ble_peer_event` with :c:member:`ble_peer_event.state` set to :c:enum:`PEER_STATE_DISCONNECTING` to let other application modules prepare for the disconnection.
-
-On Bluetooth Peripheral, the |ble_state| requires the connection security level 2.
-If the connection security level 2 is not established, the Peripheral disconnects.
 
 Connection parameter change
 ===========================

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -101,6 +101,11 @@ nRF Machine Learning (Edge Impulse)
 nRF Desktop
 -----------
 
+* nRF Desktop peripherals no longer automatically send security request right after Bluetooth LE connection is established.
+  The feature can be turned on using :kconfig:option:`CONFIG_CAF_BLE_STATE_SECURITY_REQ`.
+* nRF Desktop dongles start peripheral discovery right after Bluetooth LE connection is established.
+  The dongles no longer wait until the connection is secured.
+
 |no_changes_yet_note|
 
 Thingy:53 Zigbee weather station
@@ -219,6 +224,10 @@ Other libraries
 
 Common Application Framework (CAF)
 ----------------------------------
+
+* :ref:`caf_ble_state` running on Bluetooth Peripheral no longer automatically sends security request right after Bluetooth LE connection is established.
+  The :kconfig:option:`CONFIG_CAF_BLE_STATE_SECURITY_REQ` can be used to enable this feature.
+  The option can be used for both Bluetooth Peripheral and Bluetooth Central.
 
 |no_changes_yet_note|
 

--- a/subsys/caf/modules/Kconfig.ble_state
+++ b/subsys/caf/modules/Kconfig.ble_state
@@ -17,6 +17,11 @@ menuconfig CAF_BLE_STATE
 
 if CAF_BLE_STATE
 
+config CAF_BLE_STATE_SECURITY_REQ
+	bool "Request connection encryption (security level 2)"
+	help
+	  Automatically request connection encryption right after the connection is established.
+
 config CAF_BLE_STATE_PM
 	bool "Enable bluetooth LE power manager integration"
 	depends on CAF_BLE_STATE

--- a/subsys/caf/modules/ble_state.c
+++ b/subsys/caf/modules/ble_state.c
@@ -205,6 +205,9 @@ static void connected(struct bt_conn *conn, uint8_t error)
 			LOG_INF("Already bonded to %s", log_strdup(addr_str));
 			goto disconnect;
 		}
+	}
+
+	if (IS_ENABLED(CONFIG_CAF_BLE_STATE_SECURITY_REQ)) {
 		/* Security must be enabled after peer event is sent.
 		 * This is to make sure notification events are propagated
 		 * in the right order.
@@ -279,7 +282,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	} else {
 		LOG_WRN("Security with %s failed, level %u err %d",
 			log_strdup(addr), level, bt_err);
-		if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+		if (IS_ENABLED(CONFIG_CAF_BLE_STATE_SECURITY_REQ)) {
 			disconnect_peer(conn);
 		}
 


### PR DESCRIPTION
Change makes security level 2 request optional. The security request is no longer enabled by default for peripheral.
PR also introduces a follow-up commit to nRF Desktop to make sure that Central would work fine.

Jira: NCSDK-14084