### PR TITLE
configure GNSS LNA after modem library init

### DIFF
--- a/samples/nrf9160/location/src/main.c
+++ b/samples/nrf9160/location/src/main.c
@@ -7,26 +7,30 @@
 #include <string.h>
 #include <zephyr.h>
 #include <nrf_modem_at.h>
+#include <modem/nrf_modem_lib.h>
 #include <modem/lte_lc.h>
 #include <modem/location.h>
 #include <date_time.h>
 
 static K_SEM_DEFINE(location_event, 0, 1);
 
-static void antenna_configure(void)
+NRF_MODEM_LIB_ON_INIT(init_hook, on_modem_lib_init, NULL);
+
+static void on_modem_lib_init(int ret, void *ctx)
 {
-	int err;
+	if (ret != 0) {
+		printk("Modem library initialization failed, error: %d\n", ret);
+		return;
+	}
 
 	if (strlen(CONFIG_LOCATION_SAMPLE_GNSS_AT_MAGPIO) > 0) {
-		err = nrf_modem_at_printf("%s", CONFIG_LOCATION_SAMPLE_GNSS_AT_MAGPIO);
-		if (err) {
+		if (nrf_modem_at_printf("%s", CONFIG_LOCATION_SAMPLE_GNSS_AT_MAGPIO) != 0) {
 			printk("Failed to set MAGPIO configuration\n");
 		}
 	}
 
 	if (strlen(CONFIG_LOCATION_SAMPLE_GNSS_AT_COEX0) > 0) {
-		err = nrf_modem_at_printf("%s", CONFIG_LOCATION_SAMPLE_GNSS_AT_COEX0);
-		if (err) {
+		if (nrf_modem_at_printf("%s", CONFIG_LOCATION_SAMPLE_GNSS_AT_COEX0) != 0) {
 			printk("Failed to set COEX0 configuration\n");
 		}
 	}
@@ -241,8 +245,6 @@ int main(void)
 	int err;
 
 	printk("Location sample started\n\n");
-
-	antenna_configure();
 
 	if (IS_ENABLED(CONFIG_DATE_TIME)) {
 		/* Registering early for date_time event handler to avoid missing

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.c
@@ -119,35 +119,6 @@ static uint8_t pvt_output_level = 2;
 static uint8_t nmea_output_level;
 static uint8_t event_output_level;
 
-int gnss_configure_lna(void)
-{
-	int err;
-	const char *xmagpio_command;
-	const char *xcoex0_command;
-
-	xmagpio_command = CONFIG_MOSH_AT_MAGPIO;
-	xcoex0_command = CONFIG_MOSH_AT_COEX0;
-
-	/* Make sure the AT command is not empty */
-	if (xmagpio_command[0] != '\0') {
-		err = nrf_modem_at_printf("%s", xmagpio_command);
-		if (err) {
-			mosh_error("Failed to send XMAGPIO command");
-			return err;
-		}
-	}
-
-	if (xcoex0_command[0] != '\0') {
-		err = nrf_modem_at_printf("%s", xcoex0_command);
-		if (err) {
-			mosh_error("Failed to send XCOEX0 command");
-			return err;
-		}
-	}
-
-	return 0;
-}
-
 static int get_event_data(void **dest, uint8_t type, size_t len)
 {
 	void *data;

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.h
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.h
@@ -63,12 +63,6 @@ struct gnss_1pps_mode {
 	uint8_t second;
 };
 
-/* Common functions */
-
-int gnss_configure_lna(void);
-
-/* Functions implemented by different API implementations */
-
 /**
  * @brief Starts GNSS.
  *


### PR DESCRIPTION
Moved GNSS Low Noise Amplifier (LNA) configuration to modem library initialization callback for GNSS, location and modem_shell samples.