### PR TITLE
samples: nrf9160: lwm2m_client: Fixes for button handling

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_push_button.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_push_button.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 #define BUTTON2_OBJ_INST_ID 1
 #define BUTTON2_APP_NAME "Push button 2"
 
-static int32_t lwm2m_timstamp[2];
+static int32_t lwm2m_timestamp[2];
 
 int lwm2m_init_push_button(void)
 {
@@ -40,8 +40,8 @@ int lwm2m_init_push_button(void)
 	if (IS_ENABLED(CONFIG_LWM2M_IPSO_PUSH_BUTTON_VERSION_1_1)) {
 		lwm2m_engine_set_res_data(
 			LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON1_OBJ_INST_ID, TIMESTAMP_RID),
-			&lwm2m_timstamp[BUTTON1_OBJ_INST_ID],
-			sizeof(lwm2m_timstamp[BUTTON1_OBJ_INST_ID]), LWM2M_RES_DATA_FLAG_RW);
+			&lwm2m_timestamp[BUTTON1_OBJ_INST_ID],
+			sizeof(lwm2m_timestamp[BUTTON1_OBJ_INST_ID]), LWM2M_RES_DATA_FLAG_RW);
 	}
 
 	if (CONFIG_LWM2M_IPSO_PUSH_BUTTON_INSTANCE_COUNT == 2) {
@@ -57,8 +57,8 @@ int lwm2m_init_push_button(void)
 		if (IS_ENABLED(CONFIG_LWM2M_IPSO_PUSH_BUTTON_VERSION_1_1)) {
 			lwm2m_engine_set_res_data(LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID,
 							     BUTTON2_OBJ_INST_ID, TIMESTAMP_RID),
-						  &lwm2m_timstamp[BUTTON2_OBJ_INST_ID],
-						  sizeof(lwm2m_timstamp[BUTTON2_OBJ_INST_ID]),
+						  &lwm2m_timestamp[BUTTON2_OBJ_INST_ID],
+						  sizeof(lwm2m_timestamp[BUTTON2_OBJ_INST_ID]),
 						  LWM2M_RES_DATA_FLAG_RW);
 		}
 	}

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_push_button.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_push_button.c
@@ -94,7 +94,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			lwm2m_engine_set_bool(LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID,
 							 BUTTON2_OBJ_INST_ID,
 							 DIGITAL_INPUT_STATE_RID),
-					      event->device_number);
+					      event->state);
 
 			if (event->state) {
 				if (IS_ENABLED(CONFIG_LWM2M_IPSO_PUSH_BUTTON_VERSION_1_1)) {

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_push_button.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_push_button.c
@@ -24,7 +24,6 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 #define BUTTON2_OBJ_INST_ID 1
 #define BUTTON2_APP_NAME "Push button 2"
 
-static uint64_t btn_input_count[2];
 static int32_t lwm2m_timstamp[2];
 
 int lwm2m_init_push_button(void)
@@ -33,17 +32,7 @@ int lwm2m_init_push_button(void)
 
 	/* create button1 object */
 	lwm2m_engine_create_obj_inst(LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON1_OBJ_INST_ID));
-	/*
-	 * Overwriting post write callback of Digital Input State, as the original
-	 * callback in the ipso object directly modifies the Digital Input Counter
-	 * resource data buffer without notifying the engine, which effectively
-	 * disables Value Tracking functionality for the counter resource.
-	 * Won't be needed with new Zephyr update.
-	 */
-	lwm2m_engine_register_post_write_callback(LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID,
-							     BUTTON1_OBJ_INST_ID,
-							     DIGITAL_INPUT_STATE_RID),
-						  NULL);
+
 	lwm2m_engine_set_res_data(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON1_OBJ_INST_ID, APPLICATION_TYPE_RID),
 		BUTTON1_APP_NAME, sizeof(BUTTON1_APP_NAME), LWM2M_RES_DATA_FLAG_RO);
@@ -59,10 +48,7 @@ int lwm2m_init_push_button(void)
 		/* create button2 object */
 		lwm2m_engine_create_obj_inst(
 			LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON2_OBJ_INST_ID));
-		lwm2m_engine_register_post_write_callback(LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID,
-								     BUTTON2_OBJ_INST_ID,
-								     DIGITAL_INPUT_STATE_RID),
-							  NULL);
+
 		lwm2m_engine_set_res_data(LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID,
 						     BUTTON2_OBJ_INST_ID, APPLICATION_TYPE_RID),
 					  BUTTON2_APP_NAME, sizeof(BUTTON2_APP_NAME),
@@ -101,16 +87,6 @@ static bool app_event_handler(const struct app_event_header *aeh)
 					lwm2m_set_timestamp(IPSO_OBJECT_PUSH_BUTTON_ID,
 							    BUTTON1_OBJ_INST_ID);
 				}
-
-				/*
-				 * Won't be needed with new Zephyr update, as the counter
-				 * object is automatically updated in the ipso_push_button file.
-				 */
-				btn_input_count[BUTTON1_OBJ_INST_ID]++;
-				lwm2m_engine_set_u64(LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID,
-								BUTTON1_OBJ_INST_ID,
-								DIGITAL_INPUT_COUNTER_RID),
-						     btn_input_count[BUTTON1_OBJ_INST_ID]);
 			}
 			break;
 
@@ -125,16 +101,6 @@ static bool app_event_handler(const struct app_event_header *aeh)
 					lwm2m_set_timestamp(IPSO_OBJECT_PUSH_BUTTON_ID,
 							    BUTTON2_OBJ_INST_ID);
 				}
-
-				/*
-				 * Won't be needed with new Zephyr update, as the counter
-				 * object is automatically updated in the ipso_push_button file.
-				 */
-				btn_input_count[BUTTON2_OBJ_INST_ID]++;
-				lwm2m_engine_set_u64(LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID,
-								BUTTON2_OBJ_INST_ID,
-								DIGITAL_INPUT_COUNTER_RID),
-						     btn_input_count[BUTTON2_OBJ_INST_ID]);
 			}
 			break;
 


### PR DESCRIPTION
This contains some fixes for the button handling in the lwm2m_client sample. This will remove a hotfix that has become redundant thanks to a proper fix in zephyr as well as fix some typos. One fix will also allow the state of the second button on the nrf9160DK to be updated properly. 

Signed-off-by: Markus Rekdal <markus.rekdal@nordicsemi.no>