### PR TITLE
sample: Add name "sample" in the some samples modules

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -1,37 +1,37 @@
 sample:
-  name: Matter Light Bulb
   description: Matter Light Bulb example
+  name: Matter Light Bulb
 tests:
-  matter.light_bulb.debug:
+  sample.matter.light_bulb.debug:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
-    tags: ci_build
-  matter.light_bulb.release:
-    build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-      - nrf21540dk_nrf52840
     tags: ci_build
-    extra_args: CONF_FILE=prj_release.conf
-  matter.light_bulb.no_dfu:
+  sample.matter.light_bulb.no_dfu:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-    tags: ci_build
     extra_args: CONF_FILE=prj_no_dfu.conf
-  matter.light_bulb.smp_dfu:
-    build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: ci_build
-    extra_args: "OVERLAY_CONFIG=../../overlay-smp_dfu.conf"
+  sample.matter.light_bulb.release:
+    build_only: true
+    extra_args: CONF_FILE=prj_release.conf
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+    tags: ci_build
+  sample.matter.light_bulb.smp_dfu:
+    build_only: true
+    extra_args: OVERLAY_CONFIG=../../overlay-smp_dfu.conf
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -1,37 +1,37 @@
 sample:
-  name: Matter Light Switch
   description: Matter Light Switch example
+  name: Matter Light Switch
 tests:
-  matter.light_switch.debug:
+  sample.matter.light_switch.debug:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
-    tags: ci_build
-  matter.light_switch.release:
-    build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-      - nrf21540dk_nrf52840
     tags: ci_build
-    extra_args: CONF_FILE=prj_release.conf
-  matter.light_switch.no_dfu:
+  sample.matter.light_switch.no_dfu:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-    tags: ci_build
     extra_args: CONF_FILE=prj_no_dfu.conf
-  matter.light_switch.smp_dfu:
-    build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: ci_build
-    extra_args: "OVERLAY_CONFIG=../../overlay-smp_dfu.conf"
+  sample.matter.light_switch.release:
+    build_only: true
+    extra_args: CONF_FILE=prj_release.conf
+    integration_platforms:
+    - nrf52840dk_nrf52840
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+    tags: ci_build
+  sample.matter.light_switch.smp_dfu:
+    build_only: true
+    extra_args: OVERLAY_CONFIG=../../overlay-smp_dfu.conf
+    integration_platforms:
+    - nrf52840dk_nrf52840
+    - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -1,45 +1,45 @@
 sample:
-  name: Matter Lock
   description: Matter Lock example
+  name: Matter Lock
 tests:
-  matter.lock.debug:
+  sample.matter.lock.debug:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
-    tags: ci_build
-  matter.lock.release:
-    build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+    tags: ci_build
+  sample.matter.lock.low_power:
+    build_only: true
+    extra_args: OVERLAY_CONFIG=../../overlay-low_power.conf
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-      - nrf21540dk_nrf52840
-    tags: ci_build
-    extra_args: CONF_FILE=prj_release.conf
-  matter.lock.no_dfu:
-    build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
     tags: ci_build
+  sample.matter.lock.no_dfu:
+    build_only: true
     extra_args: CONF_FILE=prj_no_dfu.conf
-  matter.lock.smp_dfu:
-    build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-    tags: ci_build
-    extra_args: "OVERLAY_CONFIG=../../overlay-smp_dfu.conf"
-  matter.lock.low_power:
-    build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    tags: ci_build
+  sample.matter.lock.release:
+    build_only: true
+    extra_args: CONF_FILE=prj_release.conf
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
     tags: ci_build
-    extra_args: "OVERLAY_CONFIG=../../overlay-low_power.conf"
+  sample.matter.lock.smp_dfu:
+    build_only: true
+    extra_args: OVERLAY_CONFIG=../../overlay-smp_dfu.conf
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    tags: ci_build

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -1,25 +1,25 @@
 sample:
-  name: Matter Template
   description: Matter Template sample
+  name: Matter Template
 tests:
-  matter.template.debug:
+  sample.matter.template.debug:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
-    tags: ci_build
-  matter.template.release:
-    build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-      - nrf21540dk_nrf52840
     tags: ci_build
+  sample.matter.template.release:
+    build_only: true
     extra_args: CONF_FILE=prj_release.conf
-  matter.template.no_dfu:
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+    tags: ci_build
+  sample.matter.template.no_dfu:
     build_only: true
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:

--- a/samples/zigbee/light_bulb/sample.yaml
+++ b/samples/zigbee/light_bulb/sample.yaml
@@ -1,24 +1,25 @@
 sample:
-  name: Zigbee Light control
   description: Zigbee Light control - light bulb sample
+  name: Zigbee Light control
 tests:
-  zigbee.light_bulb:
+  sample.zigbee.light_bulb:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    tags: ci_build smoke
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
-
-  zigbee.light_bulb.with_shell:
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+      nrf21540dk_nrf52840
+    tags: ci_build smoke
+  sample.zigbee.light_bulb.with_shell:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    tags: ci_build shell
     extra_args: CONFIG_ZIGBEE_SHELL=y CONFIG_ZIGBEE_DEBUG_FUNCTIONS=y CONFIG_ZIGBEE_SHELL_ENDPOINT=10
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+      nrf21540dk_nrf52840
+    tags: ci_build shell

--- a/samples/zigbee/light_switch/sample.yaml
+++ b/samples/zigbee/light_switch/sample.yaml
@@ -1,61 +1,58 @@
 sample:
-  name: Zigbee Light switch
   description: Zigbee dimmable light switch based on ZBOSS stack
+  name: Zigbee Light switch
 tests:
-  zigbee.light_switch:
+  sample.zigbee.light_switch:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    tags: ci_build smoke
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
-
-  zigbee.light_switch.fota:
-    build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+      nrf21540dk_nrf52840
     tags: ci_build smoke
-    extra_args: DOVERLAY_CONFIG=overlay-fota.conf
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf21540dk_nrf52840
-
-  zigbee.light_switch.fota_and_multiprotocol:
+  sample.zigbee.light_switch.current_measurement:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840
-    tags: ci_build
-    extra_args: DOVERLAY_CONFIG=overlay-fota.conf DOVERLAY_CONFIG=overlay-multiprotocol_ble.conf
-    integration_platforms:
-      - nrf52840dk_nrf52840
-
-  zigbee.light_switch.multiprotocol:
-    build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
-    tags: ci_build
-    extra_args: DOVERLAY_CONFIG=overlay-multiprotocol_ble.conf
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf52833dk_nrf52833
-      - nrf5340dk_nrf5340_cpuapp
-
-  zigbee.light_switch.current_measurement:
-    build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
-    tags: ci_build current_measurement
     extra_args: CONFIG_SERIAL=n
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
-
-  zigbee.light_switch.with_shell:
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+    tags: ci_build current_measurement
+  sample.zigbee.light_switch.fota:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    tags: ci_build shell
+    extra_args: DOVERLAY_CONFIG=overlay-fota.conf
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840
+    tags: ci_build smoke
+  sample.zigbee.light_switch.fota_and_multiprotocol:
+    build_only: true
+    extra_args: DOVERLAY_CONFIG=overlay-fota.conf DOVERLAY_CONFIG=overlay-multiprotocol_ble.conf
+    integration_platforms:
+      - nrf52840dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840
+    tags: ci_build
+  sample.zigbee.light_switch.multiprotocol:
+    build_only: true
+    extra_args: DOVERLAY_CONFIG=overlay-multiprotocol_ble.conf
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+    tags: ci_build
+  sample.zigbee.light_switch.with_shell:
+    build_only: true
     extra_args: CONFIG_ZIGBEE_SHELL=y CONFIG_ZIGBEE_DEBUG_FUNCTIONS=y CONFIG_ZIGBEE_SHELL_ENDPOINT=1
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+      nrf21540dk_nrf52840
+    tags: ci_build shell

--- a/samples/zigbee/ncp/sample.yaml
+++ b/samples/zigbee/ncp/sample.yaml
@@ -1,22 +1,18 @@
 sample:
-  name: Zigbee NCP
   description: Zigbee network co-processor
-
+  name: Zigbee NCP
 tests:
-  zigbee.ncp:
+  sample.zigbee.ncp:
     build_only: true
-    platform_allow: nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
-    tags: ci_build ncp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-
-  zigbee.ncp.usb:
-    build_only: true
-    platform_allow: nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: ci_build ncp
+  sample.zigbee.ncp.usb:
+    build_only: true
     extra_args: CONF_FILE=prj_usb.conf
     integration_platforms:
       - nrf52840dk_nrf52840
@@ -24,11 +20,13 @@ tests:
       - nrf21540dk_nrf52840
       - nrf52840dongle_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-
-  zigbee.ncp.with_nrf21540ek:
+    platform_allow: nrf52833dk_nrf52833 nrf52840dk_nrf52840 nrf52840dongle_nrf52840
+      nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    tags: ci_build ncp
+  sample.zigbee.ncp.with_nrf21540ek:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840
-    tags: ci_build
     extra_args: SHIELD=nrf21540_ek
     integration_platforms:
       - nrf52840dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840
+    tags: ci_build

--- a/samples/zigbee/network_coordinator/sample.yaml
+++ b/samples/zigbee/network_coordinator/sample.yaml
@@ -1,13 +1,14 @@
 sample:
-  name: Zigbee Network coordinator
   description: Zigbee Light control - coordinator sample
+  name: Zigbee Network coordinator
 tests:
-  zigbee.network_coordinator:
+  sample.zigbee.network_coordinator:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    tags: ci_build smoke
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+      nrf21540dk_nrf52840
+    tags: ci_build smoke

--- a/samples/zigbee/shell/sample.yaml
+++ b/samples/zigbee/shell/sample.yaml
@@ -1,13 +1,14 @@
 sample:
-  name: Zigbee application with Zigbee shell
   description: Zigbee application thast includes all Zigbee shell commands
+  name: Zigbee application with Zigbee shell
 tests:
-  zigbee.shell:
+  sample.zigbee.shell:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    tags: ci_build shell
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+      nrf21540dk_nrf52840
+    tags: ci_build shell

--- a/samples/zigbee/template/sample.yaml
+++ b/samples/zigbee/template/sample.yaml
@@ -1,13 +1,14 @@
 sample:
-  name: Zigbee application template
   description: Zigbee application template
+  name: Zigbee application template
 tests:
-  zigbee.template:
+  sample.zigbee.template:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
-    tags: ci_build smoke
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
+      nrf21540dk_nrf52840
+    tags: ci_build smoke


### PR DESCRIPTION
Some test cases in the module `samples` have not a name of this module.
This change adds the name `sample ` to these test cases.

Signed-off-by: Katarzyna Giadla <katarzyna.giadla@nordicsemi.no>