### PR TITLE
manifest: Pull nrfxlib for FPU flags fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 304545d691ccd1d916c62e790fb21e0321652e90
+      revision: pull/715/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Pull nrfxlib:
- FPU flags in mbedcrypto from TF-M build system.
- ~~Fix dependency in oberon PSA rename target.~~

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>