### PR TITLE
doc: zigbee: add link to factory reset

### DIFF
--- a/doc/nrf/libraries/zigbee/zigbee_app_utils.rst
+++ b/doc/nrf/libraries/zigbee/zigbee_app_utils.rst
@@ -463,10 +463,14 @@ Configuration
 
 To enable the Zigbee application utilities library, set the :kconfig:option:`CONFIG_ZIGBEE_APP_UTILS` Kconfig option.
 
-To configure the logging level of the library, use the :kconfig:option:`CONFIG_ZIGBEE_APP_UTILS_LOG_LEVEL` Kconfig option.
+Logging
+    To configure the logging level of the library, use the :kconfig:option:`CONFIG_ZIGBEE_APP_UTILS_LOG_LEVEL` Kconfig option.
 
-To configure the time of the button press that initiates the device factory reset, use the :kconfig:option:`CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS` Kconfig option.
-This option is set to 5 seconds by default.
+Factory reset button
+    To configure the time of the button press that initiates the device factory reset, use the :kconfig:option:`CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS` Kconfig option.
+    This option is set to 5 seconds by default.
+
+    For more information about the factory reset, see the `Resetting to factory defaults`_ section in the ZBOSS stack documentation.
 
 For detailed steps about configuring the library in a Zigbee sample or application, see :ref:`ug_zigbee_configuring_components_application_utilities`.
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -167,6 +167,7 @@
 .. _`Declaring simple descriptors`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.11.1.0/using_zigbee__z_c_l.html#simple_desc_declaration
 .. _`Declaring Zigbee device context`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.11.1.0/using_zigbee__z_c_l.html#zigbee_device_context_dec
 .. _`Declaring Zigbee device context with multiple endpoints`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.11.1.0/using_zigbee__z_c_l.html#zigbee_device_context_mult_ep_dec
+.. _`Resetting to factory defaults`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.11.1.0/using_zigbee__z_c_l.html#reset_factory_defaults
 .. _`Registering device context`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.11.1.0/using_zigbee__z_c_l.html#register_zigbee_device
 
 .. _`ZB_BDB_SIGNAL_FINDING_AND_BINDING_INITIATOR_FINISHED`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/3.11.1.0/group__zb__comm__signals.html#ga18f5e7ddfefb7d01ef98f696a9694d79

--- a/samples/zigbee/light_bulb/README.rst
+++ b/samples/zigbee/light_bulb/README.rst
@@ -61,7 +61,7 @@ Button 4:
     Depending on how long the button is pressed:
 
     * If pressed for less than five seconds, it starts or cancels the Identify mode.
-    * If pressed for five seconds, it initiates the factory reset of the device.
+    * If pressed for five seconds, it initiates the `factory reset of the device <Resetting to factory defaults_>`_.
       The length of the button press can be edited using the :kconfig:option:`CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS` Kconfig option from :ref:`lib_zigbee_application_utilities`.
       Releasing the button within this time does not trigger the factory reset procedure.
 

--- a/samples/zigbee/light_switch/README.rst
+++ b/samples/zigbee/light_switch/README.rst
@@ -149,7 +149,7 @@ Button 2:
     Pressing this button for a longer period of time decreases the brightness of the **LED 4** of the connected light bulb.
 
 Button 4:
-    When pressed for five seconds, it initiates the factory reset of the device.
+    When pressed for five seconds, it initiates the `factory reset of the device <Resetting to factory defaults_>`_.
     The length of the button press can be edited using the :kconfig:option:`CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS` Kconfig option from :ref:`lib_zigbee_application_utilities`.
     Releasing the button within this time does not trigger the factory reset procedure.
 

--- a/samples/zigbee/network_coordinator/README.rst
+++ b/samples/zigbee/network_coordinator/README.rst
@@ -74,7 +74,7 @@ Button 4:
     Depending on how long the button is pressed:
 
     * If pressed for less than five seconds, it starts or cancels the Identify mode.
-    * If pressed for five seconds, it initiates the factory reset of the device.
+    * If pressed for five seconds, it initiates the `factory reset of the device <Resetting to factory defaults_>`_.
       The length of the button press can be edited using the :kconfig:option:`CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS` Kconfig option from :ref:`lib_zigbee_application_utilities`.
       Releasing the button within this time does not trigger the factory reset procedure.
 

--- a/samples/zigbee/template/README.rst
+++ b/samples/zigbee/template/README.rst
@@ -56,7 +56,7 @@ Button 4:
     Depending on how long the button is pressed:
 
     * If pressed for less than five seconds, it starts or cancels the Identify mode.
-    * If pressed for five seconds, it initiates the factory reset of the device.
+    * If pressed for five seconds, it initiates the `factory reset of the device <Resetting to factory defaults_>`_.
       The length of the button press can be edited using the :kconfig:option:`CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS` Kconfig option from :ref:`lib_zigbee_application_utilities`.
       Releasing the button within this time does not trigger the factory reset procedure.
 


### PR DESCRIPTION
Added a link to a section in the ZBOSS docs about resetting to factory
defaults.
KRKNWK-13725.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>