### PR TITLE
codeowners: remove figure codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -54,7 +54,6 @@ Kconfig*                                  @tejlmand
 /doc/**/conf.py                           @carlescufi
 /doc/kconfig/                             @gmarull
 /doc/nrf/                                 @carlescufi
-/doc/nrf/images/                          @Avalei
 /doc/nrfx/                                @gmarull
 /doc/matter/                              @gmarull
 /doc/mcuboot/                             @carlescufi


### PR DESCRIPTION
Removed @Avalei as figure codeowner.
Discussed with Oisin and the team.
Enforcing guidelines is on each tech writer now.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>