### PR TITLE
samples: modem_shell: Disable modem traces before disabling UART1

### DIFF
--- a/samples/nrf9160/modem_shell/src/uart/uart.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart.c
@@ -21,17 +21,8 @@ static void uart1_set_enable(bool enable)
 {
 	if (enable) {
 		NRF_UARTE1_NS->ENABLE = UARTE_ENABLE_ENABLE_Enabled;
-		NRF_UARTE1_NS->TASKS_STARTRX = 1;
-		NRF_UARTE1_NS->TASKS_STARTTX = 1;
 	} else {
-		/* Stop TX and RX operation and wait for the corresponding events to be generated
-		 * before disabling the peripheral.
-		 * Ref: https://infocenter.nordicsemi.com/topic/ps_nrf9160/uarte.html
-		 */
-		NRF_UARTE1_NS->TASKS_STOPRX = 1;
-		while (NRF_UARTE1_NS->EVENTS_RXTO == 0) {
-			/* Wait until RX Timeout event is raised. */
-		}
+		/* Stop any ongoing transmission.*/
 		NRF_UARTE1_NS->TASKS_STOPTX = 1;
 		while (NRF_UARTE1_NS->EVENTS_TXSTOPPED == 0) {
 			/* Wait until TX Stopped event is raised. */


### PR DESCRIPTION
When UART is used as modem traces transport medium, the modem traces
need to be disabled before disabling UART. The modem traces need to be
reenabled after reenabling UART. This is done now.
The enabling and disabling of modem traces cannot be done from an
interrupt context because they involve sending AT commands using the
nrf_modem_at_printf() which cannot be called from interrupt context.
Hence this is done from a work queue handler.

Fixes MOSH-251.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>