### PR TITLE
samples: matter: Added emitting events on factory reset

### DIFF
--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -358,7 +358,7 @@ void AppTask::FunctionTimerEventHandler()
 	} else if (sAppTask.mFunction == TimerFunction::FactoryReset) {
 		sAppTask.mFunction = TimerFunction::NoneSelected;
 		LOG_INF("Factory Reset triggered");
-		ConfigurationMgr().InitiateFactoryReset();
+		chip::Server::GetInstance().ScheduleFactoryReset();
 	}
 }
 

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -285,7 +285,7 @@ void AppTask::TimerEventHandler(AppEvent *aEvent)
 			} else if (sAppTask.mFunction == TimerFunction::FactoryReset) {
 				sAppTask.mFunction = TimerFunction::NoneSelected;
 				LOG_INF("Factory Reset triggered");
-				ConfigurationMgr().InitiateFactoryReset();
+				chip::Server::GetInstance().ScheduleFactoryReset();
 			}
 			break;
 		case Timer::DimmerTrigger:

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -336,7 +336,7 @@ void AppTask::FunctionTimerEventHandler()
 	} else if (sAppTask.mFunction == TimerFunction::FactoryReset) {
 		sAppTask.mFunction = TimerFunction::NoneSelected;
 		LOG_INF("Factory Reset triggered");
-		ConfigurationMgr().InitiateFactoryReset();
+		chip::Server::GetInstance().ScheduleFactoryReset();
 	}
 }
 

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -226,7 +226,7 @@ void AppTask::FunctionTimerEventHandler()
 		sUnusedLED_1.Set(true);
 		sUnusedLED_2.Set(true);
 
-		ConfigurationMgr().InitiateFactoryReset();
+		chip::Server::GetInstance().ScheduleFactoryReset();
 	}
 }
 


### PR DESCRIPTION
Leave and shutdown events are not emitted after scheduling
device factory reset.

KRKNWK-13692

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>