### PR TITLE
lib: nrf_modem: don't enforce socket priority over native TLS

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -1311,9 +1311,6 @@ static int nrf91_socket_create(int family, int type, int proto)
 
 #define NRF91_SOCKET_PRIORITY 40
 
-BUILD_ASSERT(NRF91_SOCKET_PRIORITY < CONFIG_NET_SOCKETS_TLS_PRIORITY,
-	     "NRF91_SOCKET_PRIORITY have to be smaller than NET_SOCKETS_TLS_PRIORITY");
-
 NET_SOCKET_REGISTER(nrf91_socket, NRF91_SOCKET_PRIORITY, AF_UNSPEC,
 		    nrf91_socket_is_supported, nrf91_socket_create);
 


### PR DESCRIPTION
Commit 27e7ebd84722 ("lib: nrf_modem: Allow to create native sockets
with offloading enabled") introduced a build time check to enforce
offloaded socket priority over Zephyr native TLS.

In some cases native TLS might be the preferred choice, so remove that
enforcement and allow application developer to decide whether offloaded
TLS or native TLS should be used by default.