### PR TITLE
samples: nrf9160: modem_shell: add support for MFW v1.3.2 GNSS features

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -211,6 +211,8 @@ nrf9160 Samples
         In AT command mode, a maximum of 10 AT commands can be pipelined with ``|`` as the delimiter character between pipelined AT commands.
       * Threading support for the ``ping`` command.
       * Iperf3 usage over Zephyr native TCP/IP stack and nRF9160 LTE default context.
+      * Support for the GNSS features introduced in modem firmware v1.3.2.
+        This includes several new fields in the PVT notification and a command to query the expiry times of assistance data.
 
   * :ref:`nrf_cloud_rest_fota` sample:
 

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.c
@@ -228,34 +228,22 @@ static void print_pvt_flags(struct nrf_modem_gnss_pvt_data_frame *pvt)
 	mosh_print("");
 	mosh_print(
 		"Fix valid:          %s",
-		(pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID) ==
-		NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID ?
-		"true" :
-		"false");
+		pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID ? "true" : "false");
 	mosh_print(
 		"Leap second valid:  %s",
-		(pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_LEAP_SECOND_VALID) ==
-		NRF_MODEM_GNSS_PVT_FLAG_LEAP_SECOND_VALID ?
-		"true" :
-		"false");
+		pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_LEAP_SECOND_VALID ? "true" : "false");
 	mosh_print(
 		"Sleep between PVT:  %s",
-		(pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_SLEEP_BETWEEN_PVT) ==
-		NRF_MODEM_GNSS_PVT_FLAG_SLEEP_BETWEEN_PVT ?
-		"true" :
-		"false");
+		pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_SLEEP_BETWEEN_PVT ? "true" : "false");
 	mosh_print(
 		"Deadline missed:    %s",
-		(pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_DEADLINE_MISSED) ==
-		NRF_MODEM_GNSS_PVT_FLAG_DEADLINE_MISSED ?
-		"true" :
-		"false");
+		pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_DEADLINE_MISSED ? "true" : "false");
 	mosh_print(
 		"Insuf. time window: %s",
-		(pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_NOT_ENOUGH_WINDOW_TIME) ==
-		NRF_MODEM_GNSS_PVT_FLAG_NOT_ENOUGH_WINDOW_TIME ?
-		"true" :
-		"false");
+		pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_NOT_ENOUGH_WINDOW_TIME ? "true" : "false");
+	mosh_print(
+		"Velocity valid:     %s",
+		pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_VELOCITY_VALID ? "true" : "false");
 }
 
 static void print_pvt(struct nrf_modem_gnss_pvt_data_frame *pvt)
@@ -266,9 +254,11 @@ static void print_pvt(struct nrf_modem_gnss_pvt_data_frame *pvt)
 
 	print_pvt_flags(pvt);
 
-	if ((pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID) == NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID) {
+	mosh_print("Execution time:     %u ms", pvt->execution_time);
+
+	if (pvt->flags & NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID) {
 		mosh_print(
-			"Time:            %02d.%02d.%04d %02d:%02d:%02d.%03d",
+			"Time:              %02d.%02d.%04d %02d:%02d:%02d.%03d",
 			pvt->datetime.day,
 			pvt->datetime.month,
 			pvt->datetime.year,
@@ -277,20 +267,24 @@ static void print_pvt(struct nrf_modem_gnss_pvt_data_frame *pvt)
 			pvt->datetime.seconds,
 			pvt->datetime.ms);
 
-		mosh_print("Latitude:        %f", pvt->latitude);
-		mosh_print("Longitude:       %f", pvt->longitude);
-		mosh_print("Altitude:        %.1f m", pvt->altitude);
-		mosh_print("Accuracy:        %.1f m", pvt->accuracy);
-		mosh_print("Speed:           %.1f m/s", pvt->speed);
-		mosh_print("Speed accuracy:  %.1f m/s", pvt->speed_accuracy);
-		mosh_print("Heading:         %.1f deg", pvt->heading);
-		mosh_print("PDOP:            %.1f", pvt->pdop);
-		mosh_print("HDOP:            %.1f", pvt->hdop);
-		mosh_print("VDOP:            %.1f", pvt->vdop);
-		mosh_print("TDOP:            %.1f", pvt->tdop);
+		mosh_print("Latitude:          %f", pvt->latitude);
+		mosh_print("Longitude:         %f", pvt->longitude);
+		mosh_print("Accuracy:          %.1f m", pvt->accuracy);
+		mosh_print("Altitude:          %.1f m", pvt->altitude);
+		mosh_print("Altitude accuracy: %.1f m", pvt->altitude_accuracy);
+		mosh_print("Speed:             %.1f m/s", pvt->speed);
+		mosh_print("Speed accuracy:    %.1f m/s", pvt->speed_accuracy);
+		mosh_print("V. speed:          %.1f m/s", pvt->vertical_speed);
+		mosh_print("V. speed accuracy: %.1f m/s", pvt->vertical_speed_accuracy);
+		mosh_print("Heading:           %.1f deg", pvt->heading);
+		mosh_print("Heading accuracy:  %.1f deg", pvt->heading_accuracy);
+		mosh_print("PDOP:              %.1f", pvt->pdop);
+		mosh_print("HDOP:              %.1f", pvt->hdop);
+		mosh_print("VDOP:              %.1f", pvt->vdop);
+		mosh_print("TDOP:              %.1f", pvt->tdop);
 
 		mosh_print(
-			"Google maps URL: https://maps.google.com/?q=%f,%f",
+			"Google maps URL:   https://maps.google.com/?q=%f,%f",
 			pvt->latitude, pvt->longitude);
 	}
 
@@ -312,10 +306,8 @@ static void print_pvt(struct nrf_modem_gnss_pvt_data_frame *pvt)
 			pvt->sv[i].elevation,
 			pvt->sv[i].azimuth,
 			pvt->sv[i].signal,
-			(pvt->sv[i].flags & NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX) ==
-			NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX ? 1 : 0,
-			(pvt->sv[i].flags & NRF_MODEM_GNSS_SV_FLAG_UNHEALTHY) ==
-			NRF_MODEM_GNSS_SV_FLAG_UNHEALTHY ? 1 : 0);
+			pvt->sv[i].flags & NRF_MODEM_GNSS_SV_FLAG_USED_IN_FIX ? 1 : 0,
+			pvt->sv[i].flags & NRF_MODEM_GNSS_SV_FLAG_UNHEALTHY ? 1 : 0);
 	}
 }
 
@@ -340,28 +332,22 @@ static void get_agps_data_flags_string(char *flags_string, uint32_t data_flags)
 
 	*flags_string = '\0';
 
-	if ((data_flags & NRF_MODEM_GNSS_AGPS_GPS_UTC_REQUEST) ==
-	    NRF_MODEM_GNSS_AGPS_GPS_UTC_REQUEST) {
+	if (data_flags & NRF_MODEM_GNSS_AGPS_GPS_UTC_REQUEST) {
 		(void)strcat(flags_string, "utc | ");
 	}
-	if ((data_flags & NRF_MODEM_GNSS_AGPS_KLOBUCHAR_REQUEST) ==
-	    NRF_MODEM_GNSS_AGPS_KLOBUCHAR_REQUEST) {
+	if (data_flags & NRF_MODEM_GNSS_AGPS_KLOBUCHAR_REQUEST) {
 		(void)strcat(flags_string, "klob | ");
 	}
-	if ((data_flags & NRF_MODEM_GNSS_AGPS_NEQUICK_REQUEST) ==
-	    NRF_MODEM_GNSS_AGPS_NEQUICK_REQUEST) {
+	if (data_flags & NRF_MODEM_GNSS_AGPS_NEQUICK_REQUEST) {
 		(void)strcat(flags_string, "neq | ");
 	}
-	if ((data_flags & NRF_MODEM_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST) ==
-	    NRF_MODEM_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST) {
+	if (data_flags & NRF_MODEM_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST) {
 		(void)strcat(flags_string, "time | ");
 	}
-	if ((data_flags & NRF_MODEM_GNSS_AGPS_POSITION_REQUEST) ==
-	    NRF_MODEM_GNSS_AGPS_POSITION_REQUEST) {
+	if (data_flags & NRF_MODEM_GNSS_AGPS_POSITION_REQUEST) {
 		(void)strcat(flags_string, "pos | ");
 	}
-	if ((data_flags & NRF_MODEM_GNSS_AGPS_INTEGRITY_REQUEST) ==
-	    NRF_MODEM_GNSS_AGPS_INTEGRITY_REQUEST) {
+	if (data_flags & NRF_MODEM_GNSS_AGPS_INTEGRITY_REQUEST) {
 		(void)strcat(flags_string, "int | ");
 	}
 
@@ -876,14 +862,12 @@ static void gnss_api_init(void)
 {
 	static bool gnss_api_initialized;
 
+	/* Reset event handler in case some other handler was set in the meantime. */
+	(void)nrf_modem_gnss_event_handler_set(gnss_event_handler);
+
 	if (gnss_api_initialized) {
-		/* Reset event handler in case some other handler was set in the meantime */
-		(void)nrf_modem_gnss_event_handler_set(gnss_event_handler);
 		return;
 	}
-
-	/* Activate GNSS API v2 */
-	(void)nrf_modem_gnss_event_handler_set(gnss_event_handler);
 
 	gnss_api_initialized = true;
 
@@ -1458,6 +1442,55 @@ int gnss_enable_pgps(void)
 	mosh_error("GNSS: Enable CONFIG_NRF_CLOUD_PGPS for P-GPS support");
 	return -EOPNOTSUPP;
 #endif
+}
+
+static void get_expiry_string(char *string, uint32_t string_len, uint32_t expiry)
+{
+	if (expiry == UINT32_MAX) {
+		strncpy(string, "not used", string_len);
+	} else if (expiry == 0) {
+		strncpy(string, "expired", string_len);
+	} else {
+		snprintf(string, string_len, "%u", expiry);
+	}
+}
+
+int gnss_get_agps_expiry(void)
+{
+	int err;
+	struct nrf_modem_gnss_agps_expiry agps_expiry;
+	char expiry_string[16];
+	char expiry_string2[16];
+
+	err = nrf_modem_gnss_agps_expiry_get(&agps_expiry);
+	if (err) {
+		mosh_error("GNSS: Failed to query A-GPS data expiry, error: %d", err);
+		return err;
+	}
+
+	mosh_print("Time valid: %s",
+		   agps_expiry.data_flags & NRF_MODEM_GNSS_AGPS_SYS_TIME_AND_SV_TOW_REQUEST ?
+			"false" : "true");
+	get_expiry_string(expiry_string, sizeof(expiry_string), agps_expiry.utc_expiry);
+	mosh_print("UTC:        %s", expiry_string);
+	get_expiry_string(expiry_string, sizeof(expiry_string), agps_expiry.klob_expiry);
+	mosh_print("Klobuchar:  %s", expiry_string);
+	get_expiry_string(expiry_string, sizeof(expiry_string), agps_expiry.neq_expiry);
+	mosh_print("NeQuick:    %s", expiry_string);
+	get_expiry_string(expiry_string, sizeof(expiry_string), agps_expiry.integrity_expiry);
+	mosh_print("Integrity:  %s", expiry_string);
+
+	for (int i = 0; i < NRF_MODEM_GNSS_NUM_GPS_SATELLITES; i++) {
+		get_expiry_string(expiry_string, sizeof(expiry_string),
+				  agps_expiry.ephe_expiry[i]);
+		get_expiry_string(expiry_string2, sizeof(expiry_string2),
+				  agps_expiry.alm_expiry[i]);
+
+		mosh_print("PRN %02u:     ephe: %-10s alm: %-10s",
+			   i + 1, expiry_string, expiry_string2);
+	}
+
+	return 0;
 }
 
 int gnss_set_pvt_output_level(uint8_t level)

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.h
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.h
@@ -342,6 +342,14 @@ int gnss_inject_agps_data(void);
 int gnss_enable_pgps(void);
 
 /**
+ * @brief Queries A-GPS data expiry information from GNSS.
+ *
+ * @return 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int gnss_get_agps_expiry(void);
+
+/**
  * @brief Configures how much PVT information is printed out.
  *
  * @param level 0 = PVT output disabled

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_shell.c
@@ -524,6 +524,11 @@ static int cmd_gnss_agps_inject(const struct shell *shell, size_t argc, char **a
 	return gnss_inject_agps_data();
 }
 
+static int cmd_gnss_agps_expiry(const struct shell *shell, size_t argc, char **argv)
+{
+	return gnss_get_agps_expiry();
+}
+
 static int cmd_gnss_pgps(const struct shell *shell, size_t argc, char **argv)
 {
 	return print_help(shell, argc, argv);
@@ -982,6 +987,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		  cmd_gnss_agps_filter),
 	SHELL_CMD(filtephem, &sub_gnss_agps_filtered,
 		  "Enable/disable AGPS filtered ephemerides.", cmd_gnss_agps_filtered),
+	SHELL_CMD_ARG(expiry, NULL, "Query A-GPS data expiry information from GNSS.",
+		      cmd_gnss_agps_expiry, 1, 0),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Implemented support for new GNSS features in MFW v1.3.2. This includes several new fields in the PVT notification and a new command "gnss agps expiry" which can be used to query A-GPS data expiry times.