### PR TITLE
lib: nrf_modem: remove obsolete KConfig entries

### DIFF
--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -57,14 +57,6 @@ endif # NRF_MODEM_LIB_TRACE_MEDIUM_RTT
 
 endif # NRF_MODEM_LIB_TRACE_ENABLED
 
-config NRF91_SOCKET_BLOCK_LIMIT
-	int "Maximum size the modem can send"
-	default 2048
-	help
-	  Blocks larger than this value will be split into two or more
-	  send() or sendto() calls. This may not work for certain kinds
-	  of sockets or certain flag parameter values.
-
 config NRF_MODEM_LIB_SENDMSG_BUF_SIZE
 	int "Size of the sendmsg intermediate buffer"
 	default 128

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -57,15 +57,6 @@ endif # NRF_MODEM_LIB_TRACE_MEDIUM_RTT
 
 endif # NRF_MODEM_LIB_TRACE_ENABLED
 
-config NRF91_SOCKET_SEND_SPLIT_LARGE_BLOCKS
-	bool "Split large blocks passed to send() or sendto()"
-	default n
-	help
-	  Workaround a limitation in the Modem library regarding the return
-	  value for send() or sendto() calls larger than the module can handle.
-	  It should send the data up to the maximum, and return that as the return value.
-	  Instead, it returns error 22.
-
 config NRF91_SOCKET_BLOCK_LIMIT
 	int "Maximum size the modem can send"
 	default 2048

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -838,10 +838,6 @@ static ssize_t nrf91_socket_offload_sendto(void *obj, const void *buf,
 	int sd = OBJ_TO_SD(obj);
 	ssize_t retval;
 
-	if (IS_ENABLED(CONFIG_NRF91_SOCKET_SEND_SPLIT_LARGE_BLOCKS)) {
-		len = MIN(len, CONFIG_NRF91_SOCKET_BLOCK_LIMIT);
-	}
-
 	if (to == NULL) {
 		retval = nrf_sendto(sd, buf, len, z_to_nrf_flags(flags), NULL,
 				    0);


### PR DESCRIPTION
These are no longer needed.