### PR TITLE
bluetooth: controller: Enable new feature supports

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -405,6 +405,7 @@ static void le_supported_features(sdc_hci_le_le_features_t *features)
 
 	features->le_encryption = 1;
 	features->extended_reject_indication = 1;
+	features->slave_initiated_features_exchange = 1;
 	features->le_ping = 1;
 
 #ifdef CONFIG_BT_CTLR_DATA_LENGTH

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -437,6 +437,10 @@ static void le_supported_features(sdc_hci_le_le_features_t *features)
 #endif
 
 	features->channel_selection_algorithm_2 = 1;
+
+#if defined(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)
+	features->periodic_advertising_adi_support = 1;
+#endif
 }
 
 static void le_read_supported_states(uint8_t *buf)


### PR DESCRIPTION
Peripheral initiated feature exchange support is added to sdc.
The feature is supported as default.

Signed-off-by: Ilhan Ates <ilhan.ates@nordicsemi.no>