### PR TITLE
tfm: fix missing type for TFM_SECURE_UART1

### DIFF
--- a/modules/tfm/zephyr/Kconfig
+++ b/modules/tfm/zephyr/Kconfig
@@ -16,6 +16,7 @@ config TFM_BOARD
 if BUILD_WITH_TFM
 
 config TFM_SECURE_UART1
+	bool
 	select NRF_UARTE1_SECURE
 
 endif # BUILD_WITH_TFM


### PR DESCRIPTION
The type of Kconfig option TFM_SECURE_UART1 was missing.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>