### PR TITLE
lib: zigbee_shell: Allow bdb factory_reset only after ZBOSS is started

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -469,6 +469,8 @@ Libraries for Zigbee
   * Changed :ref:`lib_zigbee_shell` structure to be an independent library.
   * Changed file names from ``zigbee_cli*`` to ``zigbee_shell*``.
   * Changed function names from ``zigbee_cli*`` to ``zigbee_shell*``.
+  * Changed ``bdb factory_reset`` command.
+    Now the command checks if the ZBOSS stack is started before performing the factory reset.
   * Extended ``zcl cmd`` shell command to allow sending groupcasts.
   * Extended ``zdo`` shell commands to allow binding to a group addresses.
   * Fixed an issue where printing binding table containing group-binding entries results in corrupted output.

--- a/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_bdb.c
+++ b/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_bdb.c
@@ -1113,6 +1113,12 @@ static int cmd_zb_factory_reset(const struct shell *shell, size_t argc,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
+	/* Do not allow to call factory_reset before the ZBOSS stack is started. */
+	if (!zigbee_is_stack_started()) {
+		zb_shell_print_error(shell, "Stack not started", ZB_FALSE);
+		return -ENOEXEC;
+	}
+
 	ZB_SCHEDULE_APP_CALLBACK(zb_bdb_reset_via_local_action, 0);
 	zb_shell_print_done(shell, ZB_FALSE);
 	return 0;


### PR DESCRIPTION
This commit changes the Zigbee shell "bdb factory_reset" command
by adding a check to prevent performing factory reset before ZBOSS
stack is started at the device.

Signed-off-by: Sebastian Draus <sebastian.draus@nordicsemi.no>