### PR TITLE
lib: zigbee_shell: Change zc role to form new network after factory reset

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -472,6 +472,7 @@ Libraries for Zigbee
   * Extended ``zcl cmd`` shell command to allow sending groupcasts.
   * Extended ``zdo`` shell commands to allow binding to a group addresses.
   * Fixed an issue where printing binding table containing group-binding entries results in corrupted output.
+  * Fixed an issue where Zigbee shell coordinator would not form a new network after the factory reset operation.
 
 Scripts
 =======

--- a/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_bdb.c
+++ b/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_bdb.c
@@ -317,6 +317,12 @@ static int cmd_zb_start(const struct shell *shell, size_t argc, char **argv)
 
 		zigbee_enable();
 	} else {
+		/* Handle case where Zigbee coordinator has left the network
+		 * and a new network needs to be formed.
+		 */
+		if ((default_role == ZB_NWK_DEVICE_TYPE_COORDINATOR) && !ZB_JOINED()) {
+			mode_mask = ZB_BDB_NETWORK_FORMATION;
+		}
 		ret = bdb_start_top_level_commissioning(mode_mask);
 	}
 


### PR DESCRIPTION
This commit changes the Zigbee shell coordinator to form a new network
after bdb start cmd if coordinator has left the network,
e.g. after factory reset.

Signed-off-by: Sebastian Draus <sebastian.draus@nordicsemi.no>