### PR TITLE
net: lib: lwm2m_client_utils: Fix storing of bootstrap settings

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
@@ -374,7 +374,23 @@ int lwm2m_init_security(struct lwm2m_ctx *ctx, char *endpoint)
 
 	have_permanently_stored_keys = false;
 
-	settings_register(&lwm2m_security_settings);
+	ret = settings_subsys_init();
+	if (ret) {
+		LOG_ERR("Failed to initialize settings subsystem, %d", ret);
+		return ret;
+	}
+
+	ret = settings_register(&lwm2m_security_settings);
+	if (ret) {
+		LOG_ERR("Failed to register settings, %d", ret);
+		return ret;
+	}
+
+	ret = settings_load_subtree(SETTINGS_PREFIX);
+	if (ret) {
+		LOG_ERR("Failed to load settings, %d", ret);
+		return ret;
+	}
 
 	/* setup SECURITY object */
 


### PR DESCRIPTION
All submodules that use settings, should independently call
settings_subsys_init();
settings_register(&my_settings);
settings_load_subtree(SETTINGS_PREFIX);

Otherwise you are depending some specific order which modules
load. This was broken in lwM2M client sample, once settings_load()
call was moved to before security object was initialized, so we did
not load any security related settings. This commit fixes that.
