### PR TITLE
application: serial_lte_modem: Support multiple sockets

### DIFF
--- a/applications/serial_lte_modem/doc/DFU_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/DFU_AT_commands.rst
@@ -119,7 +119,7 @@ Response syntax
 
 ::
 
-   #XDFUGET: <list of op value>,<host>,<image_1><image_2><sec_tag>
+   #XDFUGET: <list of op value>,<host>,<image_1>,<image_2>,<sec_tag>
 
 Examples
 ~~~~~~~~
@@ -128,7 +128,7 @@ Examples
 
    AT#XDFUGET=?
 
-   #XDFUGET: (0,1,8),,<host>,<image_1><image_2><sec_tag>
+   #XDFUGET: (0,1,8),<host>,<image_1>,<image_2>,<sec_tag>
 
    OK
 

--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -388,11 +388,11 @@ Test command
 
 The test command is not supported.
 
-SLM CMNG #XCMNG
-===============
+Native TLS CMNG #XCMNG
+======================
 
 The ``#XCMNG`` command manages the credentials to support :ref:`CONFIG_SLM_NATIVE_TLS <CONFIG_SLM_NATIVE_TLS>`.
-This command is implemented similarly to the modem ``%CMNG`` command.
+This command is similar to the modem ``%CMNG`` command.
 
 Set command
 -----------
@@ -429,7 +429,7 @@ It accepts the following values:
 
 The ``<content>`` parameter is a string.
 It is mandatory if ``<opcode>`` is ``0`` (write a credential).
-It's the content of a Privacy Enhanced Mail (PEM) file enclosed in double quotes (X.509 PEM entities).
+It is the content of a Privacy Enhanced Mail (PEM) file enclosed in double quotes (X.509 PEM entities).
 An empty string is not allowed.
 
 Response syntax

--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -8,13 +8,14 @@ Socket AT commands
    :depth: 2
 
 The following commands list contains socket-related AT commands.
+The application can open up to 8 sockets and select the active one among them.
 
 For more information on the networking services, visit the `BSD Networking Services Spec Reference`_.
 
 Socket #XSOCKET
 ===============
 
-The ``#XSOCKET`` command allows you to open or close a socket, and to check the socket handle.
+The ``#XSOCKET`` command allows you to open or close a socket and to check the socket handle.
 
 Set command
 -----------
@@ -33,6 +34,8 @@ Syntax
   * ``0`` - Close a socket.
   * ``1`` - Open a socket for IP protocol family version 4.
   * ``2`` - Open a socket for IP protocol family version 6.
+
+  When ``0``, the highest-ranked socket is made active after the current one is closed.
 
 * The ``<type>`` parameter can accept one of the following values:
 
@@ -207,6 +210,8 @@ Syntax
   * ``1`` - Open a socket for IP protocol family version 4.
   * ``2`` - Open a socket for IP protocol family version 6.
 
+  When ``0``, the highest-ranked socket is made active after the current one is closed.
+
 * The ``<type>`` parameter can accept one of the following values:
 
   * ``1`` - Set SOCK_STREAM for the stream socket type using the TLS 1.2 protocol.
@@ -355,6 +360,138 @@ Examples
    AT#XSSOCKET=?
    #XSSOCKET: (0,1,2),(1,2),<sec_tag>,<peer_verify>,<hostname_verify>
    OK
+
+Select Socket #XSOCKETSELECT
+============================
+
+The ``#XSOCKETSELECT`` command allows you to select an active socket among multiple opened ones.
+
+Set command
+-----------
+
+The set command allows you to select an active socket.
+
+Syntax
+~~~~~~
+
+::
+
+   #XSOCKETSELECT=<handle>
+
+* The ``<handle>`` parameter is the handle value returned from the #XSOCKET or #XSSOCKET commands.
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XSOCKETSELECT: <handle>,<family>,<role>
+
+* The ``<handle>`` value is an integer.
+  When positive, the socket is valid.
+
+* The ``<family>`` value can be one of the following integers:
+
+  * ``1`` - IP protocol family version 4.
+  * ``2`` - IP protocol family version 6.
+
+* The ``<role>`` value can be one of the following integers:
+
+  * ``0`` - Client
+  * ``1`` - Server
+
+Examples
+~~~~~~~~
+
+::
+
+   AT#XSOCKETSELECT=4
+   #XSOCKETSELECT: 4,1,1
+   OK
+
+Read command
+------------
+
+The read command allows you to list all sockets that have been opened and the active socket.
+
+Syntax
+~~~~~~
+
+::
+
+   #XSOCKETSELECT?
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XSOCKETSELECT: <handle>,<family>,<role>,<type>,<sec_tag>,<ranking>
+   #XSOCKETSELECT: <handle_active>
+
+* The ``<handle>`` value is an integer that indicates the handle of the socket.
+
+* The ``<family>`` value can be one of the following integers:
+
+  * ``1`` - IP protocol family version 4.
+  * ``2`` - IP protocol family version 6.
+
+* The ``<role>`` value can be one of the following integers:
+
+  * ``0`` - Client
+  * ``1`` - Server
+
+* The ``<type>`` value can assume one of the following values:
+
+  * ``1`` - Set ``SOCK_STREAM`` for the stream socket type using the TLS 1.2 protocol.
+  * ``2`` - Set ``SOCK_DGRAM`` for the datagram socket type using the DTLS 1.2 protocol.
+
+* The ``<sec_tag>`` value is an integer.
+  It indicates to the modem the credential of the security tag to be used for establishing a secure connection.
+  For a non-secure socket, it assumes the value of -1.
+
+* The ``<ranking>`` value is an integer.
+  It indicates the ranking value of this socket, where the largest value means the highest ranking.
+
+* The ``<handle_active>`` value is an integer that indicates the handle of the active socket.
+
+Examples
+~~~~~~~~
+
+::
+
+  AT#XSOCKETSELECT?
+  #XSOCKETSELECT: 0,1,0,1,-1,2
+  #XSOCKETSELECT: 1,1,0,2,-1,3
+  #XSOCKETSELECT: 2,1,0,1,16842755,4
+  #XSOCKETSELECT: 3,1,0,2,16842755,5
+  #XSOCKETSELECT: 4,1,1,1,-1,6
+  #XSOCKETSELECT: 5,1,1,2,-1,7
+  #XSOCKETSELECT: 6,1,1,1,16842755,8
+  #XSOCKETSELECT: 7,1,0,1,-1,9
+  #XSOCKETSELECT: 7
+  OK
+
+  AT#XSOCKETSELECT=4
+  #XSOCKETSELECT: 4,1,1
+  OK
+
+  AT#XSOCKETSELECT?
+  #XSOCKETSELECT: 0,1,0,1,-1,2
+  #XSOCKETSELECT: 1,1,0,2,-1,3
+  #XSOCKETSELECT: 2,1,0,1,16842755,4
+  #XSOCKETSELECT: 3,1,0,2,16842755,5
+  #XSOCKETSELECT: 4,1,1,1,-1,6
+  #XSOCKETSELECT: 5,1,1,2,-1,7
+  #XSOCKETSELECT: 6,1,1,1,16842755,8
+  #XSOCKETSELECT: 7,1,0,1,-1,9
+  #XSOCKETSELECT: 4
+  OK
+
+Test command
+------------
+
+The test command is not supported.
 
 Socket options #XSOCKETOPT
 ==========================
@@ -941,6 +1078,71 @@ Examples
    AT#XRECVFROM=10
    Test OK
    #XRECVFROM: 7,"192.168.1.100"
+   OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command is not supported.
+
+Poll sockets #XPOLL
+===================
+
+The ``#XPOLL`` command allows you to poll selected or all sockets that have already been opened.
+
+Set command
+-----------
+
+The set command allows you to poll a set of sockets to check whether they are ready for I/O.
+
+Syntax
+~~~~~~
+
+::
+
+   #XPOLL=<timeout>[,<handle1>[,<handle2> ...<handle8>]
+
+* The ``<timeout>`` value sets the timeout value in milliseconds, and the poll blocks up to this timeout.
+  ``0`` means no timeout, and the poll returns without blocking.
+  ``-1`` means indefinite, and the poll blocks indefinitely until any events are received.
+
+* The ``<handleN>`` value sets the socket handles to poll.
+  The handles values could be obtained by ``AT#XSOCKETSELECT?`` command.
+  If no handle values are specified, all opened sockets will be polled.
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XPOLL: <error>
+   #XPOLL: <handle>,<revents>
+
+* The ``<error>`` value is an error code when the poll fails.
+* The ``<handle>`` value is an integer. It is the handle of a socket that have events returned, so-called ``revents``.
+* The ``<revents>`` value is a hexadecimal string. It represents the returned events, which could be a combination of POLLIN, POLLERR, POLLHUP and POLLNVAL.
+
+Examples
+~~~~~~~~
+
+::
+
+   AT#XPOLL=2000,0
+   #XPOLL: 0,"0x00000001"
+   OK
+
+   AT#XPOLL=2000,1
+   #XPOLL: 1,"0x00000001"
+   OK
+
+   AT#XPOLL=2000
+   #XPOLL: 0,"0x00000001"
+   #XPOLL: 1,"0x00000001"
    OK
 
 Read command

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -281,6 +281,7 @@ By default, the secure socket (TLS/DTLS) is offloaded onto the modem.
 However, if you need customized TLS/DTLS features that are not supported by the modem firmware, you can use native TLS instead.
 Currently, the SLM application can be built to use native TLS for the following services:
 
+* Secure socket
 * TLS Proxy server
 * HTTPS client
 

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -368,6 +368,7 @@ int handle_at_udp_send(enum at_cmd_type cmd_type);
 /* Socket-type TCPIP commands */
 int handle_at_socket(enum at_cmd_type cmd_type);
 int handle_at_secure_socket(enum at_cmd_type cmd_type);
+int handle_at_socket_select(enum at_cmd_type cmd_type);
 int handle_at_socketopt(enum at_cmd_type cmd_type);
 int handle_at_secure_socketopt(enum at_cmd_type cmd_type);
 int handle_at_bind(enum at_cmd_type cmd_type);
@@ -378,6 +379,7 @@ int handle_at_send(enum at_cmd_type cmd_type);
 int handle_at_recv(enum at_cmd_type cmd_type);
 int handle_at_sendto(enum at_cmd_type cmd_type);
 int handle_at_recvfrom(enum at_cmd_type cmd_type);
+int handle_at_poll(enum at_cmd_type cmd_type);
 int handle_at_getaddrinfo(enum at_cmd_type cmd_type);
 
 #if defined(CONFIG_SLM_NATIVE_TLS)
@@ -463,6 +465,7 @@ static struct slm_at_cmd {
 	/* Socket-type TCPIP commands */
 	{"AT#XSOCKET", handle_at_socket},
 	{"AT#XSSOCKET", handle_at_secure_socket},
+	{"AT#XSOCKETSELECT", handle_at_socket_select},
 	{"AT#XSOCKETOPT", handle_at_socketopt},
 	{"AT#XSSOCKETOPT", handle_at_secure_socketopt},
 	{"AT#XBIND", handle_at_bind},
@@ -473,6 +476,7 @@ static struct slm_at_cmd {
 	{"AT#XRECV", handle_at_recv},
 	{"AT#XSENDTO", handle_at_sendto},
 	{"AT#XRECVFROM", handle_at_recvfrom},
+	{"AT#XPOLL", handle_at_poll},
 	{"AT#XGETADDRINFO", handle_at_getaddrinfo},
 
 #if defined(CONFIG_SLM_NATIVE_TLS)

--- a/applications/serial_lte_modem/src/slm_at_socket.c
+++ b/applications/serial_lte_modem/src/slm_at_socket.c
@@ -47,14 +47,18 @@ enum slm_socket_role {
 static char udp_url[SLM_MAX_URL];
 static uint16_t udp_port;
 
-static struct {
+static struct slm_socket {
 	uint16_t type;     /* SOCK_STREAM or SOCK_DGRAM */
 	uint16_t role;     /* Client or Server */
 	sec_tag_t sec_tag; /* Security tag of the credential */
 	int family;        /* Socket address family */
 	int fd;            /* Socket descriptor. */
 	int fd_peer;       /* Socket descriptor for peer. */
-} sock;
+	int ranking;       /* Ranking of socket */
+} socks[SLM_MAX_SOCKET_COUNT];
+
+static struct pollfd fds[SLM_MAX_SOCKET_COUNT];
+static struct slm_socket sock;
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
@@ -64,15 +68,46 @@ extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 #define SOCKET_SEND_TMO_SEC      30
 static int socket_poll(int sock_fd, int event, int timeout);
 
+static int socket_ranking;
+
+#define INIT_SOCKET(socket)			\
+	socket.family  = AF_UNSPEC;		\
+	socket.sec_tag = INVALID_SEC_TAG;	\
+	socket.role    = AT_SOCKET_ROLE_CLIENT;	\
+	socket.fd      = INVALID_SOCKET;	\
+	socket.fd_peer = INVALID_SOCKET;	\
+	socket.ranking = 0;
+
+static bool is_opened_socket(int fd)
+{
+	if (fd == INVALID_SOCKET) {
+		return false;
+	}
+
+	for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+		if (socks[i].fd == fd) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static int find_avail_socket(void)
+{
+	for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+		if (socks[i].fd == INVALID_SOCKET) {
+			return i;
+		}
+	}
+
+	return -ENOENT;
+}
+
 static int do_socket_open(void)
 {
 	int ret = 0;
 	int proto = IPPROTO_TCP;
-
-	if (sock.fd != INVALID_SOCKET) {
-		LOG_WRN("Socket is already opened");
-		return -EINVAL;
-	}
 
 	if (sock.type == SOCK_STREAM) {
 		ret = socket(sock.family, SOCK_STREAM, IPPROTO_TCP);
@@ -94,6 +129,9 @@ static int do_socket_open(void)
 	}
 
 	sock.fd = ret;
+	sock.ranking = socket_ranking++;
+	ret = find_avail_socket();
+	socks[ret] = sock;
 	sprintf(rsp_buf, "\r\n#XSOCKET: %d,%d,%d\r\n", sock.fd, sock.type, proto);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 
@@ -104,11 +142,6 @@ static int do_secure_socket_open(int peer_verify)
 {
 	int ret = 0;
 	int proto = IPPROTO_TLS_1_2;
-
-	if (sock.fd != INVALID_SOCKET) {
-		LOG_WRN("Secure socket is already opened");
-		return -EINVAL;
-	}
 
 	if (sock.type == SOCK_STREAM) {
 		ret = socket(sock.family, SOCK_STREAM, IPPROTO_TLS_1_2);
@@ -130,9 +163,7 @@ static int do_secure_socket_open(int peer_verify)
 	ret = slm_tls_loadcrdl(sock.sec_tag);
 	if (ret < 0) {
 		LOG_ERR("Fail to load credential: %d", ret);
-		close(sock.fd);
-		slm_at_socket_init();
-		return -EAGAIN;
+		goto error_exit;
 	}
 #endif
 	ret = setsockopt(sock.fd, SOL_TLS, TLS_SEC_TAG_LIST, sec_tag_list, sizeof(sec_tag_t));
@@ -161,21 +192,23 @@ static int do_secure_socket_open(int peer_verify)
 		}
 	}
 
+	sock.ranking = socket_ranking++;
+	ret = find_avail_socket();
+	socks[ret] = sock;
 	sprintf(rsp_buf, "\r\n#XSSOCKET: %d,%d,%d\r\n", sock.fd, sock.type, proto);
 	rsp_send(rsp_buf, strlen(rsp_buf));
 
 	return 0;
 
 error_exit:
-	close(sock.fd);
-	slm_at_socket_init();
 #if defined(CONFIG_SLM_NATIVE_TLS)
 	if (sock.sec_tag != INVALID_SEC_TAG) {
 		(void)slm_tls_unloadcrdl(sock.sec_tag);
+		sock.sec_tag = INVALID_SEC_TAG;
 	}
 #endif
 	close(sock.fd);
-	slm_at_socket_init();
+	INIT_SOCKET(sock);
 	return ret;
 }
 
@@ -191,9 +224,9 @@ static int do_socket_close(void)
 	if (sock.sec_tag != INVALID_SEC_TAG) {
 		ret = slm_tls_unloadcrdl(sock.sec_tag);
 		if (ret < 0) {
-			LOG_ERR("Fail to load credential: %d", ret);
-			return ret;
+			LOG_WRN("Fail to unload credential: %d", ret);
 		}
+		sock.sec_tag = INVALID_SEC_TAG;
 	}
 #endif
 	if (sock.fd_peer != INVALID_SOCKET) {
@@ -201,15 +234,40 @@ static int do_socket_close(void)
 		if (ret) {
 			LOG_WRN("peer close() error: %d", -errno);
 		}
+		sock.fd_peer = INVALID_SOCKET;
 	}
 	ret = close(sock.fd);
 	if (ret) {
 		LOG_WRN("close() error: %d", -errno);
 		ret = -errno;
 	}
-	slm_at_socket_init();
+
 	sprintf(rsp_buf, "\r\n#XSOCKET: %d,\"closed\"\r\n", ret);
 	rsp_send(rsp_buf, strlen(rsp_buf));
+
+	/* Select most recent socket as current active */
+	int ranking = 0, index = -1;
+
+	for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+		if (socks[i].fd == INVALID_SOCKET) {
+			continue;
+		}
+		if (socks[i].fd == sock.fd) {
+			LOG_DBG("Set socket %d null", sock.fd);
+			INIT_SOCKET(socks[i]);
+		} else {
+			if (ranking < socks[i].ranking) {
+				ranking = socks[i].ranking;
+				index = i;
+			}
+		}
+	}
+	if (index >= 0) {
+		LOG_INF("Swap to socket %d", socks[index].fd);
+		sock = socks[index];
+	} else {
+		INIT_SOCKET(sock);
+	}
 
 	return ret;
 }
@@ -838,6 +896,30 @@ static int do_recvfrom(int timeout)
 	return 0;
 }
 
+static int do_poll(int timeout)
+{
+	int ret = poll(fds, SLM_MAX_SOCKET_COUNT, timeout);
+
+	if (ret < 0) {
+		sprintf(rsp_buf, "\r\n#XPOLL: %d\r\n", ret);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		return ret;
+	}
+	/* ret == 0 means timeout */
+	if (ret > 0) {
+		for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+			/* If fd is equal to -1	then revents is cleared (set to zero) */
+			if (fds[i].revents != 0) {
+				sprintf(rsp_buf, "\r\n#XPOLL: %d,\"0x%08x\"\r\n",
+					fds[i].fd, fds[i].revents);
+				rsp_send(rsp_buf, strlen(rsp_buf));
+			}
+		}
+	}
+
+	return 0;
+}
+
 static int socket_poll(int sock_fd, int event, int timeout)
 {
 	int ret;
@@ -903,10 +985,11 @@ int handle_at_socket(enum at_cmd_type cmd_type)
 			return err;
 		}
 		if (op == AT_SOCKET_OPEN || op == AT_SOCKET_OPEN6) {
-			if (sock.fd >= 0) {
-				LOG_WRN("Socket is already opened");
+			if (find_avail_socket() < 0) {
+				LOG_ERR("Max socket count reached");
 				return -EINVAL;
 			}
+			INIT_SOCKET(sock);
 			err = at_params_unsigned_short_get(&at_param_list, 2, &sock.type);
 			if (err) {
 				return err;
@@ -919,16 +1002,16 @@ int handle_at_socket(enum at_cmd_type cmd_type)
 			err = do_socket_open();
 		} else if (op == AT_SOCKET_CLOSE) {
 			err = do_socket_close();
+		} else {
+			err = -EINVAL;
 		} break;
 
 	case AT_CMD_TYPE_READ_COMMAND:
 		if (sock.fd != INVALID_SOCKET) {
 			sprintf(rsp_buf, "\r\n#XSOCKET: %d,%d,%d\r\n", sock.fd,
 				sock.family, sock.role);
-		} else {
-			sprintf(rsp_buf, "\r\n#XSOCKET: 0\r\n");
+			rsp_send(rsp_buf, strlen(rsp_buf));
 		}
-		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;
 
@@ -974,10 +1057,11 @@ int handle_at_secure_socket(enum at_cmd_type cmd_type)
 			 */
 			uint16_t peer_verify;
 
-			if (sock.fd >= 0) {
-				LOG_WRN("Socket is already opened");
+			if (find_avail_socket() < 0) {
+				LOG_ERR("Max socket count reached");
 				return -EINVAL;
 			}
+			INIT_SOCKET(sock);
 			err = at_params_unsigned_short_get(&at_param_list, 2, &sock.type);
 			if (err) {
 				return err;
@@ -1008,16 +1092,16 @@ int handle_at_secure_socket(enum at_cmd_type cmd_type)
 			err = do_secure_socket_open(peer_verify);
 		} else if (op == AT_SOCKET_CLOSE) {
 			err = do_socket_close();
+		} else {
+			err = -EINVAL;
 		} break;
 
 	case AT_CMD_TYPE_READ_COMMAND:
 		if (sock.fd != INVALID_SOCKET) {
 			sprintf(rsp_buf, "\r\n#XSSOCKET: %d,%d,%d\r\n", sock.fd,
 				sock.family, sock.role);
-		} else {
-			sprintf(rsp_buf, "\r\n#XSSOCKET: 0\r\n");
+			rsp_send(rsp_buf, strlen(rsp_buf));
 		}
-		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;
 
@@ -1036,6 +1120,63 @@ int handle_at_secure_socket(enum at_cmd_type cmd_type)
 	}
 
 	return err;
+}
+
+/**@brief handle AT#XSOCKETSELECT commands
+ *  AT#XSOCKETSELECT=<fd>
+ *  AT#XSOCKETSELECT?
+ *  AT#XSOCKETSELECT=?
+ */
+int handle_at_socket_select(enum at_cmd_type cmd_type)
+{
+	int err = 0;
+	int fd;
+	char buf[64];
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		err = at_params_int_get(&at_param_list, 1, &fd);
+		if (err) {
+			return err;
+		}
+		if (fd < 0) {
+			return -EINVAL;
+		}
+		for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+			if (socks[i].fd == fd) {
+				sock = socks[i];
+				sprintf(rsp_buf, "\r\n#XSOCKETSELECT: %d,%d,%d\r\n",
+					sock.fd, sock.family, sock.role);
+				rsp_send(rsp_buf, strlen(rsp_buf));
+				return 0;
+			}
+		}
+		err = -EBADF;
+		break;
+
+	case AT_CMD_TYPE_READ_COMMAND:
+		memset(rsp_buf, 0x00, sizeof(rsp_buf));
+		for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+			if (socks[i].fd != INVALID_SOCKET) {
+				sprintf(buf, "\r\n#XSOCKETSELECT: %d,%d,%d,%d,%d,%d\r\n",
+					socks[i].fd, socks[i].family, socks[i].role,
+					socks[i].type, socks[i].sec_tag, socks[i].ranking);
+				strcat(rsp_buf, buf);
+			}
+		}
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		if (sock.fd != INVALID_SOCKET) {
+			sprintf(rsp_buf, "\r\n#XSOCKETSELECT: %d\r\n", sock.fd);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+
 }
 
 /**@brief handle AT#XSOCKETOPT commands
@@ -1167,7 +1308,6 @@ int handle_at_secure_socketopt(enum at_cmd_type cmd_type)
 
 	return err;
 }
-
 
 /**@brief handle AT#XBIND commands
  *  AT#XBIND=<port>
@@ -1488,15 +1628,67 @@ int handle_at_getaddrinfo(enum at_cmd_type cmd_type)
 	return err;
 }
 
+/**@brief handle AT#XPOLL commands
+ *  AT#XPOLL=<timeout>[,<handle1>[,<handle2> ...<handle8>]
+ *  AT#XPOLL? READ command not support
+ *  AT#XPOLL=? TEST command not support
+ */
+int handle_at_poll(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	int timeout, handle;
+	int count = at_params_valid_count_get(&at_param_list);
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		err = at_params_int_get(&at_param_list, 1, &timeout);
+		if (err) {
+			return err;
+		}
+		if (count == 2) {
+			/* poll all opened socket */
+			for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+				fds[i].fd = socks[i].fd;
+				if (fds[i].fd != INVALID_SOCKET) {
+					fds[i].events = POLLIN;
+				}
+			}
+		} else {
+			/* poll selected sockets */
+			for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+				fds[i].fd = INVALID_SOCKET;
+				if (count > 2 + i) {
+					err = at_params_int_get(&at_param_list, 2 + i, &handle);
+					if (err) {
+						return err;
+					}
+					if (!is_opened_socket(handle)) {
+						return -EINVAL;
+					}
+					fds[i].fd = handle;
+					fds[i].events = POLLIN;
+				}
+			}
+		}
+		err = do_poll(timeout);
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
 /**@brief API to initialize Socket AT commands handler
  */
 int slm_at_socket_init(void)
 {
-	sock.family  = AF_UNSPEC;
-	sock.sec_tag = INVALID_SEC_TAG;
-	sock.role    = AT_SOCKET_ROLE_CLIENT;
-	sock.fd      = INVALID_SOCKET;
-	sock.fd_peer = INVALID_SOCKET;
+	INIT_SOCKET(sock);
+	for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+		INIT_SOCKET(socks[i]);
+	}
+	socket_ranking = 1;
 
 	return 0;
 }
@@ -1505,5 +1697,15 @@ int slm_at_socket_init(void)
  */
 int slm_at_socket_uninit(void)
 {
-	return do_socket_close();
+	(void)do_socket_close();
+	for (int i = 0; i < SLM_MAX_SOCKET_COUNT; i++) {
+		if (socks[i].fd_peer != INVALID_SOCKET) {
+			close(sock.fd_peer);
+		}
+		if (socks[i].fd != INVALID_SOCKET) {
+			close(socks[i].fd);
+		}
+	}
+
+	return 0;
 }

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -14,19 +14,19 @@
 #define INVALID_ROLE         -1
 
 #define SLM_AT_CMD_RESPONSE_MAX_LEN 2100 /** re-define CONFIG_AT_CMD_RESPONSE_MAX_LEN */
+#define SLM_MAX_SOCKET_COUNT 8    /** re-define NRF_MODEM_MAX_SOCKET_COUNT */
 
 #define SLM_MAX_URL          128  /** max size of URL string */
 #define SLM_MAX_USERNAME     32   /** max size of username in login */
 #define SLM_MAX_PASSWORD     32   /** max size of password in login */
 
-#define MODEM_MSS            708
 #define MODEM_MTU            1280
-#define TCP_MAX_PAYLOAD_IPV4 (MODEM_MSS - NET_IPV4TCPH_LEN)
+#define TCP_MAX_PAYLOAD_IPV4 (MODEM_MTU - NET_IPV4TCPH_LEN)
 #define UDP_MAX_PAYLOAD_IPV4 (MODEM_MTU - NET_IPV4UDPH_LEN)
-#define TCP_MAX_PAYLOAD_IPV6 (MODEM_MSS - NET_IPV6TCPH_LEN)
-#define UDP_MAX_PAYLOAD_IPV6 (MODEM_MTU - NET_IPV6TCPH_LEN)
-#define SLM_MAX_PAYLOAD      UDP_MAX_PAYLOAD_IPV4
-#define SLM_MAX_PAYLOAD6     UDP_MAX_PAYLOAD_IPV6
+#define TCP_MAX_PAYLOAD_IPV6 (MODEM_MTU - NET_IPV6TCPH_LEN)
+#define UDP_MAX_PAYLOAD_IPV6 (MODEM_MTU - NET_IPV6UDPH_LEN)
+#define SLM_MAX_PAYLOAD      (MODEM_MTU - NET_IPV4UDPH_LEN)
+#define SLM_MAX_PAYLOAD6     (MODEM_MTU - NET_IPV6UDPH_LEN)
 
 #define SLM_NRF52_BLK_SIZE   4096 /** nRF52 flash block size for write operation */
 #define SLM_NRF52_BLK_TIME   2000 /** nRF52 flash block write time in millisecond (1.x second) */

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -106,6 +106,8 @@ nRF9160: Serial LTE Modem
   * Added the #XDFUGET and #XDFURUN AT commands to support the cloud-to-nRF52 DFU service.
   * Added native TLS support to the HTTPS client.
   * Added the #XCMNG command to support the use of native TLS.
+  * Added the #XSOCKETSELECT AT command to support multiple sockets in the Socket service.
+  * Added the #XPOLL AT command to poll selected or all sockets for incoming data.
 
 nRF Desktop
 -----------


### PR DESCRIPTION
Allow to open up to 8 sockets in Socket service.
Add #XSOCKETSELCT to select active socket among opened ones.
Add socket ranking to activate highest-ranked socket when
current active one is closed.
Add #XPOLL to poll selected or all sockets that are opened.
No change to existing Socket AT commands.
Correct MAX_PAYLOAD definition for TCP/UDP sockets.

Re-implementation of PR#7334

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>