### PR TITLE
doc: improve user guidance

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -712,6 +712,7 @@ Documentation
   * Section describing how to enable Amazon Frustration-Free Setup (FFS) support in :ref:`ug_matter_configuring_device_identification`.
   * Notes to the :ref:`bluetooth_central_dfu_smp` sample document specifying the intended use of the sample.
   * DevAcademy links to the :ref:`index` and :ref:`getting_started` pages.
+  * Additional user guidance to the :ref:`ug_nrf9160_gs` and :ref:`ug_thingy91_gsg` pages and the corresponding Developing with pages.
 
 * Updated:
 

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -8,8 +8,10 @@ Developing with nRF9160 DK
    :depth: 2
 
 The nRF9160 DK is a hardware development platform used to design and develop application firmware on the nRF9160 LTE Cat-M1 and Cat-NB1 :term:`System in Package (SiP)`.
+
 See the `nRF9160 DK Hardware`_ guide for detailed information about the nRF9160 DK hardware.
 To get started with the nRF9160 DK, follow the steps in the :ref:`ug_nrf9160_gs` section.
+If you are not familiar with the |NCS| and the development environment, see the :ref:`introductory documentation <getting_started>`.
 
 .. _nrf9160_ug_intro:
 

--- a/doc/nrf/ug_nrf9160_gs.rst
+++ b/doc/nrf/ug_nrf9160_gs.rst
@@ -10,6 +10,11 @@ Getting started with nRF9160 DK
 This section will get you started with your nRF9160 DK.
 You will update the firmware (both the application firmware and the modem firmware) and the nRF Cloud certificates of the DK, and conduct some initial tests.
 
+If you have already set up your nRF9160 DK and want to learn more, see the following documentation:
+
+* :ref:`ug_nrf9160` for more advanced topics related to the nRF9160 DK if you are already familiar with the |NCS|.
+* The :ref:`introductory documentation <getting_started>` for more information on the |NCS| and the development environment.
+
 .. _nrf9160_gs_requirements:
 
 Minimum requirements
@@ -372,3 +377,12 @@ Complete the following steps to test the GNSS functionality:
 
 #. From the :guilabel:`Devices` view, open the entry for your device.
 #. Observe that after a while, the GNSS data is displayed on the map in the :guilabel:`GPS Data` card on nRF Cloud.
+
+Next steps
+**********
+
+You have now completed getting started with the nRF9160 DK.
+See the following links for where to go next:
+
+* :ref:`ug_nrf9160` for more advanced topics related to the nRF9160 DK.
+* The :ref:`introductory documentation <getting_started>` for more information on the |NCS| and the development environment.

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -15,6 +15,7 @@ Thingy:91 integrates an nRF9160 SiP that supports LTE-M, NB-IoT, and Global Navi
 
 You can find more information on the product in the `Thingy:91 product page`_ and in the `Nordic Thingy:91 User Guide`_.
 The |NCS| provides support for developing applications on the Thingy:91.
+If you are not familiar with the |NCS| and the development environment, see the :ref:`introductory documentation <getting_started>`.
 
 This guide gives you more information on the various aspects of Thingy:91.
 

--- a/doc/nrf/ug_thingy91_gsg.rst
+++ b/doc/nrf/ug_thingy91_gsg.rst
@@ -11,6 +11,11 @@ Getting started with Thingy:91
 This guide helps you get started with Thingy:91.
 It tells you how to update the Thingy:91 application and modem firmware and connect the Thingy:91 to `nRF Cloud`_.
 
+If you have already set up your Thingy:91 and want to learn more, see the following documentation:
+
+* :ref:`ug_thingy91` for more advanced topics related to the Thingy:91.
+* The :ref:`introductory documentation <getting_started>` for more information on the |NCS| and the development environment.
+
 Requirements for setting up the Thingy:91
 *****************************************
 
@@ -579,3 +584,12 @@ complete the following steps:
    .. note::
 
       It might take a while for the sensor data to appear in the nRF Cloud UI, depending on the duration of time GNSS uses to search for a fix.
+
+Next steps
+**********
+
+You have now completed getting started with the Thingy:91.
+See the following links for where to go next:
+
+* :ref:`ug_thingy91` for more advanced topics related to the Thingy:91.
+* The :ref:`introductory documentation <getting_started>` for more information on the |NCS| and the development environment.


### PR DESCRIPTION
The Getting started documentation for nRF9160 DK and
the Nordic Thingy:91 does not do a perfect job guiding the user
where they should go after completing that documentation.

This adds explicit guidance to both the start and end of
the Getting started with [product] pages. Additionally, a hint
to familiarize with the nRF Connect SDK in general is added to
the Developing with [product] pages.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>