### PR TITLE
doc: zigbee|matter: add section about memory footprint

### DIFF
--- a/doc/nrf/app_memory.rst
+++ b/doc/nrf/app_memory.rst
@@ -9,6 +9,8 @@ Memory footprint optimization
 
 When developing an application, ROM and RAM footprint are important factors, especially when the firmware runs on the most resource-constrained devices like nRF52810 or nRF52811.
 
+.. _app_memory_general:
+
 General recommendations
 ***********************
 
@@ -23,6 +25,8 @@ Complete the following actions to optimize your application:
 * Go through each component and subsystem and turn off all peripherals and features that your application does not use.
 
 The following subsections give more information on how to optimize specific subsystems.
+
+.. _app_memory_bt:
 
 Bluetooth
 *********
@@ -64,6 +68,24 @@ Besides applying `General recommendations`_, you can also complete the following
 
 For reference, you can find minimal footprint configurations of the :ref:`peripheral_lbs` sample in :file:`nrf/samples/bluetooth/peripheral_lbs/minimal.conf` and the :ref:`peripheral_uart` sample in :file:`nrf/samples/bluetooth/peripheral_uart/minimal.conf`.
 
+.. _app_memory_matter:
+
+Matter
+******
+
+Besides applying `General recommendations`_, you can also complete the following actions to optimize the :ref:`Matter <ug_matter>` part of your application:
+
+* Make sure Zephyr's :ref:`zephyr:shell_api` is disabled for your application.
+  Related configuration options are listed in a dedicated section in each Matter sample's :file:`prj.conf` file.
+* Use :file:`prj_release.conf` for building the application.
+  The release configuration has a smaller memory footprint than the default, debug-enabled :file:`prj.conf`.
+* If the logs in your application do not use the default log level, you can change the default log level of Zephyr modules from ``info`` to ``warning`` by setting :kconfig:option:`CONFIG_LOG_DEFAULT_LEVEL` to ``2``.
+* Change the log level of the Matter logs from ``debug`` to ``info`` by setting :kconfig:option:`CONFIG_MATTER_LOG_LEVEL_INFO` to ``y``.
+* Reduce the verbosity of assert messages by setting :kconfig:option:`CONFIG_ASSERT_VERBOSE` to ``n``.
+* Check `Thread`_ memory footprint optimization actions, as the Matter application layer uses OpenThread.
+
+.. _app_memory_thread:
+
 Thread
 ******
 
@@ -94,6 +116,8 @@ Besides applying `General recommendations`_, you can also complete the following
   * :kconfig:option:`CONFIG_ISR_STACK_SIZE`
 
 For reference, you can find minimal footprint configurations for the single protocol and multiprotocol variants of the :ref:`ot_cli_sample` sample in :file:`nrf/samples/openthread/cli/overlay-minimal_*protocol.conf`.
+
+.. _app_memory_zigbee:
 
 Zigbee
 ******

--- a/doc/nrf/app_memory.rst
+++ b/doc/nrf/app_memory.rst
@@ -9,6 +9,9 @@ Memory footprint optimization
 
 When developing an application, ROM and RAM footprint are important factors, especially when the firmware runs on the most resource-constrained devices like nRF52810 or nRF52811.
 
+General recommendations
+***********************
+
 To reduce the memory footprint, ensure that your application uses the minimum required resources and tune the |NCS| configuration parameters.
 Complete the following actions to optimize your application:
 
@@ -16,16 +19,15 @@ Complete the following actions to optimize your application:
   Also see the implementation of the :ref:`zephyr:minimal_sample` sample.
 * Analyze stack usage in each thread of your application by using the :ref:`zephyr:thread_analyzer`.
   Reduce the stack sizes where possible.
-* Limit or disable debugging features such as logging or asserts.
-* Go through each component and subsystem and turn off all features that your application does not use.
+* Limit or disable debugging features, such as logging or asserts.
+* Go through each component and subsystem and turn off all peripherals and features that your application does not use.
 
 The following subsections give more information on how to optimize specific subsystems.
-
 
 Bluetooth
 *********
 
-Complete the following actions to optimize the Bluetooth® part of your application:
+Besides applying `General recommendations`_, you can also complete the following actions to optimize the Bluetooth® part of your application:
 
 * Disable features that your application does not use.
   For example, disable the following features:
@@ -62,19 +64,15 @@ Complete the following actions to optimize the Bluetooth® part of your applicat
 
 For reference, you can find minimal footprint configurations of the :ref:`peripheral_lbs` sample in :file:`nrf/samples/bluetooth/peripheral_lbs/minimal.conf` and the :ref:`peripheral_uart` sample in :file:`nrf/samples/bluetooth/peripheral_uart/minimal.conf`.
 
-
 Thread
 ******
 
-Complete the following actions to optimize the Thread part of your application:
+The current Thread memory requirements are listed on the :ref:`thread_ot_memory` page.
 
-* Disable features that your application does not use.
-  For example, disable the following features:
+Besides applying `General recommendations`_, you can also complete the following actions to optimize the :ref:`Thread <ug_thread>` part of your application:
 
-  * Asserts
-  * Logging
-  * Network shell and OpenThread CLI shell support (see :ref:`ug_thread_configuring_additional`)
-
+* Disable Thread features that your application does not use.
+  For example, disable network shell and OpenThread CLI shell support (see :ref:`ug_thread_configuring_additional`)
 * :ref:`Configure the OpenThread stack. <ug_thread_configuring_basic_building>`
 * :ref:`Select the appropriate OpenThread device type. <thread_ug_device_type>`
 * Reduce the stack sizes of the Thread internal threads where possible.
@@ -96,3 +94,10 @@ Complete the following actions to optimize the Thread part of your application:
   * :kconfig:option:`CONFIG_ISR_STACK_SIZE`
 
 For reference, you can find minimal footprint configurations for the single protocol and multiprotocol variants of the :ref:`ot_cli_sample` sample in :file:`nrf/samples/openthread/cli/overlay-minimal_*protocol.conf`.
+
+Zigbee
+******
+
+The current Zigbee memory requirements are listed on the :ref:`zigbee_memory` page.
+
+Apply `General recommendations`_ to optimize the :ref:`Zigbee <ug_zigbee>` part of your application.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -589,10 +589,11 @@ Documentation
   * Notes to the :ref:`bluetooth_central_dfu_smp` sample document specifying the intended use of the sample.
   * DevAcademy links to the :ref:`index` and :ref:`getting_started` pages.
 
-* Changed:
+* Updated:
 
-  * Updated the outdated protocol architecture diagram on the :ref:`ug_matter_architecture` page.
-  * Updated the :ref:`thread_ug_feature_updating_libs` section to clarify the use, and added |VSC| instructions.
+  * :ref:`ug_matter_architecture` with updated protocol architecture diagram.
+  * :ref:`app_memory` with sections for Matter and Zigbee.
+  * :ref:`thread_ug_feature_updating_libs` to clarify the use, and added |VSC| instructions.
 
 * Removed:
 


### PR DESCRIPTION
Added Zigbee section to Memory footprint optimization page.
KRKNWK-11442.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>