### PR TITLE
samples: matter: Disabled BLE+NFC advertising after the device's boot

### DIFF
--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -448,8 +448,7 @@ Commissioning the device
     :end-before: matter_door_lock_sample_commissioning_end
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
-The device becomes discoverable automatically upon the device startup, but only for a predefined period of time (15 minutes by default).
-If the Bluetooth LE advertising times out, press **Button 4** to re-enable it.
+By default, the device is not discoverable automatically upon startup and **Button 4** must be used to enable the Bluetooth LE advertising.
 
 When you start the commissioning procedure, the controller must get the commissioning information from the Matter accessory device.
 The data payload includes the device discriminator and setup PIN code.

--- a/samples/matter/light_switch/configuration/nrf21540dk_nrf52840/prj.conf
+++ b/samples/matter/light_switch/configuration/nrf21540dk_nrf52840/prj.conf
@@ -11,9 +11,6 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP14=y
 
-# Enable CHIP pairing automatically on application start.
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
-
 # General networking settings
 CONFIG_NETWORKING=y
 CONFIG_NET_IPV6_NBR_CACHE=n

--- a/samples/matter/light_switch/configuration/nrf21540dk_nrf52840/prj_release.conf
+++ b/samples/matter/light_switch/configuration/nrf21540dk_nrf52840/prj_release.conf
@@ -11,9 +11,6 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP14=y
 
-# Enable CHIP pairing automatically on application start.
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
-
 # General networking settings
 CONFIG_NETWORKING=y
 CONFIG_NET_IPV6_NBR_CACHE=n

--- a/samples/matter/light_switch/configuration/nrf52840dk_nrf52840/prj.conf
+++ b/samples/matter/light_switch/configuration/nrf52840dk_nrf52840/prj.conf
@@ -11,9 +11,6 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP14=y
 
-# Enable CHIP pairing automatically on application start.
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
-
 # General networking settings
 CONFIG_NETWORKING=y
 CONFIG_NET_IPV6_NBR_CACHE=n

--- a/samples/matter/light_switch/configuration/nrf52840dk_nrf52840/prj_no_dfu.conf
+++ b/samples/matter/light_switch/configuration/nrf52840dk_nrf52840/prj_no_dfu.conf
@@ -11,9 +11,6 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP14=y
 
-# Enable CHIP pairing automatically on application start.
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
-
 # General networking settings
 CONFIG_NETWORKING=y
 CONFIG_NET_IPV6_NBR_CACHE=n

--- a/samples/matter/light_switch/configuration/nrf52840dk_nrf52840/prj_release.conf
+++ b/samples/matter/light_switch/configuration/nrf52840dk_nrf52840/prj_release.conf
@@ -11,9 +11,6 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP14=y
 
-# Enable CHIP pairing automatically on application start.
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
-
 # General networking settings
 CONFIG_NETWORKING=y
 CONFIG_NET_IPV6_NBR_CACHE=n

--- a/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/prj.conf
+++ b/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/prj.conf
@@ -11,9 +11,6 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP14=y
 
-# Enable CHIP pairing automatically on application start.
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
-
 # General networking settings
 CONFIG_NETWORKING=y
 CONFIG_NET_IPV6_NBR_CACHE=n

--- a/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/prj_no_dfu.conf
+++ b/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/prj_no_dfu.conf
@@ -11,9 +11,6 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP14=y
 
-# Enable CHIP pairing automatically on application start.
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
-
 # General networking settings
 CONFIG_NETWORKING=y
 CONFIG_NET_IPV6_NBR_CACHE=n

--- a/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/prj_release.conf
+++ b/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/prj_release.conf
@@ -11,9 +11,6 @@ CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32772
 CONFIG_STD_CPP14=y
 
-# Enable CHIP pairing automatically on application start.
-CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=y
-
 # General networking settings
 CONFIG_NETWORKING=y
 CONFIG_NET_IPV6_NBR_CACHE=n


### PR DESCRIPTION
The Lightswitch sample in NRF-SDK should not start BLE+NFC advertising after boot to be compatible with Matter upstream examples.