### PR TITLE
doc: update working with nRF5340 DK: Application core

### DIFF
--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -56,10 +56,12 @@ Use this core for tasks that require high performance and for application-level 
 The M33 TrustZone divides the application MCU into secure and non-secure domains.
 When the MCU boots, it always starts executing from the secure area.
 
-In Zephyr, the application core is divided into two different build targets:
+In Zephyr, the firmware of the application core is built using one of the following build targets:
 
-* ``nrf5340dk_nrf5340_cpuapp`` for the secure domain
-* ``nrf5340dk_nrf5340_cpuapp_ns`` for the non-secure domain
+* ``nrf5340dk_nrf5340_cpuapp`` for the secure domain.
+* ``nrf5340dk_nrf5340_cpuapp_ns`` for the non-secure domain.
+  On selecting this build target, the build system includes an additional secure firmware component before building the main firmware on the non-secure domain.
+  The additional component can either be :ref:`Secure Partition Manager (SPM) <secure_partition_manager>` or :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
 
 .. note::
    In |NCS| releases before v1.6.1, the build target ``nrf5340dk_nrf5340_cpuapp_ns`` was named ``nrf5340dk_nrf5340_cpuappns``.


### PR DESCRIPTION
NCSDK-13898: Updated the "working with nRF5340 DK" document
to be clear that we could select any one of the build
targets for the Application core.

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>