### PR TITLE
softdevice_controller: Support Connectionless AoA Transmitter

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+DT_PATH_NORDIC_RADIO := $(dt_nodelabel_path,radio)
+DT_NORDIC_RADIO_DFE_SUPPORTED := $(dt_node_has_bool_prop,$(DT_PATH_NORDIC_RADIO),dfe-supported)
+
 choice BT_LL_CHOICE
 	prompt "Bluetooth Link Layer Selection"
 	default BT_LL_SOFTDEVICE
@@ -27,6 +30,7 @@ config BT_LL_SOFTDEVICE
 	select BT_CTLR_PHY_2M_SUPPORT if HAS_HW_NRF_RADIO_BLE_2M
 	select BT_CTLR_PHY_CODED_SUPPORT if HAS_HW_NRF_RADIO_BLE_CODED
 	select BT_HAS_HCI_VS
+	select BT_CTLR_DF_CTE_TX_SUPPORT if $(DT_NORDIC_RADIO_DFE_SUPPORTED)
 	depends on (SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET)
 	help
 	  Use SoftDevice Link Layer implementation.
@@ -151,6 +155,20 @@ config BT_CTLR_SDC_RX_STACK_SIZE
 	  Size of the receiving thread stack, used to retrieve HCI events and
 	  data from the controller.
 
+# CONFIG_BT_CTLR_DF is declared in Zephyr and also here for a second time,
+# to avoid BT_CTLR_DF_SUPPORT dependency.
+config BT_CTLR_DF
+	bool "LE Direction Finding [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  Enable support for Bluetooth 5.1 Direction Finding
+
+# As CONFIG_BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY is defined for the Zephyr LL
+# only, and BT_CLTR_DF_ADV_CTE_TX expects it existence, we define it as an empty
+# configuration here.
+config BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY
+	bool
+
 choice BT_LL_SOFTDEVICE_VARIANT
 	prompt "SoftDevice Controller variant"
 	default BT_LL_SOFTDEVICE_MULTIROLE if ((BT_OBSERVER && BT_BROADCASTER) || \
@@ -158,6 +176,7 @@ choice BT_LL_SOFTDEVICE_VARIANT
 						     BT_CTLR_ADV_EXT || \
 						     BT_CTLR_PHY_CODED || \
 						     BT_CTLR_ADV_PERIODIC || \
+						     BT_CTLR_DF_CTE_TX || \
 						     MPSL_CX_BT_1WIRE || \
 						     MPSL_CX_BT_3WIRE || \
 						     BT_CTLR_SYNC_PERIODIC || \

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -350,6 +350,17 @@ static void supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_set_privacy_mode = 1;
 #endif
 
+#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
+	/* NOTE: The DTM commands are *not* supported by the SoftDevice
+	 * controller. See doc/nrf/known_issues.rst.
+	 */
+	cmds->hci_le_transmitter_test_v3 = 1;
+
+	cmds->hci_le_set_connectionless_cte_transmit_parameters = 1;
+	cmds->hci_le_set_connectionless_cte_transmit_enable = 1;
+	cmds->hci_le_read_antenna_information = 1;
+#endif
+
 #if (defined(CONFIG_BT_HCI_RAW) && defined(CONFIG_BT_TINYCRYPT_ECC)) || defined(CONFIG_BT_CTLR_ECDH)
 	cmds->hci_le_read_local_p256_public_key = 1;
 	cmds->hci_le_generate_dhkey_v1 = 1;
@@ -433,6 +444,10 @@ static void le_supported_features(sdc_hci_le_le_features_t *features)
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC) || defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 	features->le_periodic_advertising = 1;
+#endif
+
+#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
+	features->connectionless_cte_transmitter = 1;
 #endif
 
 	features->channel_selection_algorithm_2 = 1;
@@ -901,6 +916,18 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 #if defined(CONFIG_BT_PER_ADV_SYNC)
 	case SDC_HCI_OPCODE_CMD_LE_SET_PERIODIC_ADV_RECEIVE_ENABLE:
 		return sdc_hci_cmd_le_set_periodic_adv_receive_enable((void *)cmd_params);
+#endif
+
+#if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
+	case SDC_HCI_OPCODE_CMD_LE_SET_CONNLESS_CTE_TRANSMIT_PARAMS:
+		return sdc_hci_cmd_le_set_connless_cte_transmit_params((void *)cmd_params);
+
+	case SDC_HCI_OPCODE_CMD_LE_SET_CONNLESS_CTE_TRANSMIT_ENABLE:
+		return sdc_hci_cmd_le_set_connless_cte_transmit_enable((void *)cmd_params);
+
+	case SDC_HCI_OPCODE_CMD_LE_READ_ANTENNA_INFORMATION:
+		*param_length_out += sizeof(sdc_hci_cmd_le_read_antenna_information_return_t);
+		return sdc_hci_cmd_le_read_antenna_information((void *)event_out_params);
 #endif
 
 	default:


### PR DESCRIPTION
Marks the feature and commands as supported.
This feature is experimental for now.

Signed-off-by: Ryan Chu <ryan.chu@nordicsemi.no>