### PR TITLE
samples: openthread: adjust logging options to logger v2

### DIFF
--- a/doc/nrf/ug_thread_configuring.rst
+++ b/doc/nrf/ug_thread_configuring.rst
@@ -190,13 +190,10 @@ Select one of the following logging levels to customize the logging output:
 * :kconfig:option:`CONFIG_OPENTHREAD_LOG_LEVEL_INFO` - This option additionally enables informational logging.
 * :kconfig:option:`CONFIG_OPENTHREAD_LOG_LEVEL_DEBG` - This option additionally enables debug logging.
 
-The more detailed logging level you select, the more logging buffers you need to be able to see all messages.
-The buffer size must also be increased.
-Use the following Kconfig options for this purpose:
+The more detailed logging level you select, the bigger logging buffer you need to have to see all messages.
+Use the following Kconfig option for this purpose:
 
-* :kconfig:option:`CONFIG_LOG_STRDUP_BUF_COUNT` - This option specifies the number of logging buffers.
-* :kconfig:option:`CONFIG_LOG_STRDUP_MAX_STRING` - This option specifies the size of logging buffers.
-
+* :kconfig:option:`CONFIG_LOG_BUFFER_SIZE` - This option specifies the number of bytes dedicated to the logger internal buffer.
 
 Zephyr L2 logging options
 =========================

--- a/samples/openthread/cli/overlay-logging.conf
+++ b/samples/openthread/cli/overlay-logging.conf
@@ -24,5 +24,3 @@ CONFIG_OT_COMMAND_LINE_INTERFACE_LOG_LEVEL_INF=y
 CONFIG_OPENTHREAD_DEBUG=y
 # Option for configuring log level in OpenThread
 CONFIG_OPENTHREAD_LOG_LEVEL_INFO=y
-
-# Adjust log strdup settings

--- a/samples/openthread/coap_client/overlay-logging.conf
+++ b/samples/openthread/coap_client/overlay-logging.conf
@@ -16,7 +16,3 @@
 
 # Option for configuring log level in OpenThread
 CONFIG_OPENTHREAD_LOG_LEVEL_INFO=y
-
-# Adjust log strdup settings
-CONFIG_LOG_STRDUP_BUF_COUNT=32
-CONFIG_LOG_STRDUP_MAX_STRING=128

--- a/samples/openthread/coap_server/overlay-logging.conf
+++ b/samples/openthread/coap_server/overlay-logging.conf
@@ -16,7 +16,3 @@
 
 # Option for configuring log level in OpenThread
 CONFIG_OPENTHREAD_LOG_LEVEL_INFO=y
-
-# Adjust log strdup settings
-CONFIG_LOG_STRDUP_BUF_COUNT=32
-CONFIG_LOG_STRDUP_MAX_STRING=128

--- a/samples/openthread/coprocessor/overlay-logging.conf
+++ b/samples/openthread/coprocessor/overlay-logging.conf
@@ -11,5 +11,3 @@ CONFIG_OT_COPROCESSOR_LOG_LEVEL_INF=y
 
 # Option for configuring log level in OpenThread
 CONFIG_OPENTHREAD_LOG_LEVEL_INFO=y
-
-# Adjust log strdup settings

--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -26,6 +26,10 @@ config MAIN_STACK_SIZE
 	int
 	default 2560
 
+config LOG_BUFFER_SIZE
+	int
+	default 4048 if LOG
+
 config INIT_STACKS
 	bool
 	default y


### PR DESCRIPTION
With the last zephyr upmerge the default logger is LOG2 which does not use strdup function. Any related Kconfig options stops to be applicable.
Adjust Thread samples configuration to the changes.