### PR TITLE
Zigbee weather station app: fix initial values

### DIFF
--- a/applications/zigbee_weather_station/src/main.c
+++ b/applications/zigbee_weather_station/src/main.c
@@ -125,16 +125,19 @@ static void mandatory_clusters_attr_init(void)
 static void measurements_clusters_attr_init(void)
 {
 	/* Temperature */
+	dev_ctx.temp_attrs.measure_value = ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_UNKNOWN;
 	dev_ctx.temp_attrs.min_measure_value = WEATHER_STATION_ATTR_TEMP_MIN;
 	dev_ctx.temp_attrs.max_measure_value = WEATHER_STATION_ATTR_TEMP_MAX;
 	dev_ctx.temp_attrs.tolerance = WEATHER_STATION_ATTR_TEMP_TOLERANCE;
 
 	/* Pressure */
+	dev_ctx.pres_attrs.measure_value = ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_UNKNOWN;
 	dev_ctx.pres_attrs.min_measure_value = WEATHER_STATION_ATTR_PRESSURE_MIN;
 	dev_ctx.pres_attrs.max_measure_value = WEATHER_STATION_ATTR_PRESSURE_MAX;
 	dev_ctx.pres_attrs.tolerance = WEATHER_STATION_ATTR_PRESSURE_TOLERANCE;
 
 	/* Humidity */
+	dev_ctx.humidity_attrs.measure_value = ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_VALUE_UNKNOWN;
 	dev_ctx.humidity_attrs.min_measure_value = WEATHER_STATION_ATTR_HUMIDITY_MIN;
 	dev_ctx.humidity_attrs.max_measure_value = WEATHER_STATION_ATTR_HUMIDITY_MAX;
 	/* Humidity measurements tolerance is not supported at the moment */


### PR DESCRIPTION
Set initial sensor measurement values to match ZCL specification.

Signed-off-by: Adam Szczygieł <adam.szczygiel@nordicsemi.no>