### PR TITLE
doc: nrf: releases add ipc service entry to release notes

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -198,6 +198,10 @@ nrf5340 Samples
   * :ref:`nrf5340_remote_shell` sample.
   * :ref:`nrf5340_multicore` sample.
 
+* Changed the transport layer for inter-core communication on the nRF5340 device from the RPMsg to the IPC service library.
+  The IPC service library can work with different transport backends and uses the RPMsg backend with static VRINGs by default.
+  This transport layer change affects all samples that use Bluetooth HCI driver over RPMsg, 802.15.4 spinel backend over IPC or nRF RPC libraries.
+
 nrf9160 Samples
 ---------------
 


### PR DESCRIPTION
Added an entry to the release notes describing inter-core
communication changes for the nRF5340 device.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>