### PR TITLE
lib: location: Add LTE system mode sanity check

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -371,6 +371,13 @@ Other libraries
   * This library can use different transport implementation for each nRF RPC group.
   * Memory for remote procedure calls is now allocated on a heap instead of the calling thread stack.
 
+* :ref:`lib_location`:
+
+  * Added sanity check to verify that the currently selected modem system mode supports GNSS when using the GNSS location method for a location request.
+    An error is printed and the location request returns an error code if the sanity check fails.
+  * Added sanity check to verify that the currently selected modem system mode supports LTE when downloading GNSS assistance data.
+    An error is printed and the assistance data download fails if LTE is not supported.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/lib/location/location_utils.h
+++ b/lib/location/location_utils.h
@@ -61,4 +61,22 @@ const char *location_utils_nrf_cloud_jwt_generate(void);
  */
 void location_utils_systime_to_location_datetime(struct location_datetime *datetime);
 
+/**
+ * @brief Check whether the currently active LTE link controller system mode supports GNSS
+ *
+ * @return 0		If GNSS is supported
+ * @return -EBUSY	If the LTE link controller system mode could not be determined
+ * @return -EINVAL	If GNSS is not supported
+ */
+int location_utils_check_modem_supports_gnss(void);
+
+/**
+ * @brief Check whether the currently active LTE link controller system mode supports LTE
+ *
+ * @return 0		If LTE is supported
+ * @return -EBUSY	If LTE support could not be determined
+ * @return -EINVAL	If LTE is not supported
+ */
+int location_utils_check_modem_supports_lte(void);
+
 #endif /* LOCATION_UTILS_H */

--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -202,8 +202,17 @@ void method_gnss_lte_ind_handler(const struct lte_lc_evt *const evt)
 #if defined(CONFIG_NRF_CLOUD_MQTT)
 static void method_gnss_agps_request_work_fn(struct k_work *item)
 {
-	int err = nrf_cloud_agps_request(&agps_request);
+	int err;
 
+	err = location_utils_check_modem_supports_lte();
+	if (err) {
+		LOG_ERR("nRF Cloud A-GPS request failed: %s",
+			(err == -EINVAL) ? "Current modem system mode does not support LTE"    :
+					   "Current modem system mode could not be determined");
+		return;
+	}
+
+	err = nrf_cloud_agps_request(&agps_request);
 	if (err) {
 		LOG_ERR("nRF Cloud A-GPS request failed, error: %d", err);
 		return;
@@ -225,6 +234,14 @@ static void method_gnss_agps_request_work_fn(struct k_work *item)
 		.rx_buf_len = sizeof(rest_api_recv_buf),
 		.fragment_size = 0
 	};
+
+	err = location_utils_check_modem_supports_lte();
+	if (err) {
+		LOG_ERR("nRF Cloud A-GPS request failed: %s",
+			(err == -EINVAL) ? "Current modem system mode does not support LTE"    :
+					   "Current modem system mode could not be determined");
+		return;
+	}
 
 	jwt_buf = location_utils_nrf_cloud_jwt_generate();
 	if (jwt_buf == NULL) {
@@ -304,6 +321,14 @@ static void method_gnss_pgps_request_work_fn(struct k_work *item)
 		.rx_buf_len = sizeof(rest_api_recv_buf),
 		.fragment_size = 0
 	};
+
+	err = location_utils_check_modem_supports_lte();
+	if (err) {
+		LOG_ERR("nRF Cloud A-GPS request failed: %s",
+			(err == -EINVAL) ? "Current modem system mode does not support LTE"    :
+					   "Current modem system mode could not be determined");
+		return;
+	}
 
 	jwt_buf = location_utils_nrf_cloud_jwt_generate();
 	if (jwt_buf == NULL) {
@@ -739,6 +764,14 @@ static void method_gnss_positioning_work_fn(struct k_work *work)
 int method_gnss_location_get(const struct location_method_config *config)
 {
 	int err;
+
+	err = location_utils_check_modem_supports_gnss();
+	if (err) {
+		LOG_ERR("GNSS location acquisition failed: %s",
+			(err == -EINVAL) ? "Current modem system mode does not support GNSS"   :
+					   "Current modem system mode could not be determined");
+		return err;
+	}
 
 	gnss_config = config->gnss;
 


### PR DESCRIPTION
method_gnss now checks that the currently selected
modem system mode supports GNSS when performing
location requests. If it does not, the location
request will print an error and fail.

method_gnss will also now check that the currently
selected modem system mode supports LTE when
attempting to download GNSS assistance data.
If not, the download attempt will print an error
and fail.

IRIS4187

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>