### PR TITLE
samples: nrf9160: location: increase AT monitor heap size

### DIFF
--- a/samples/nrf9160/location/prj.conf
+++ b/samples/nrf9160/location/prj.conf
@@ -15,6 +15,8 @@ CONFIG_MAIN_STACK_SIZE=2048
 # Extended memory heap size needed for encoding REST messages to JSON
 CONFIG_HEAP_MEM_POOL_SIZE=8192
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=1536
+# Increase AT monitor heap because %NCELLMEAS notifications can be large
+CONFIG_AT_MONITOR_HEAP_SIZE=512
 
 # Location sample
 CONFIG_LOCATION=y


### PR DESCRIPTION
Increased AT monitor heap size because the default value is too low for large %NCELLMEAS notifications.