### PR TITLE
samples: nrf9160: multicell_location: increase AT monitor heap size

### DIFF
--- a/samples/nrf9160/multicell_location/prj.conf
+++ b/samples/nrf9160/multicell_location/prj.conf
@@ -67,6 +67,8 @@ CONFIG_DK_LIBRARY=y
 CONFIG_MAIN_STACK_SIZE=4096
 # The AT parser, link controller, and nRF Cloud (if enabled) libraries use the heap
 CONFIG_HEAP_MEM_POOL_SIZE=4096
+# Increase AT monitor heap because %NCELLMEAS notifications can be large
+CONFIG_AT_MONITOR_HEAP_SIZE=512
 
 # Enable the configurations below to send AT commands over serial
 CONFIG_AT_HOST_LIBRARY=y


### PR DESCRIPTION
Increased AT monitor heap size because the default value is too low for large %NCELLMEAS notifications.