### PR TITLE
net: lib: lwm2m_client_utils: Report RSRP and RSRQ as dBm

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
@@ -105,7 +105,7 @@ static void modem_signal_handler(char rsrp_value)
 		return;
 	}
 
-	modem_rsrp = (int8_t)rsrp_value;
+	modem_rsrp = (int8_t)rsrp_value - MODEM_INFO_RSRP_OFFSET_VAL;
 	k_work_submit(&modem_signal_work);
 }
 

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/neighbour_cell_info.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/neighbour_cell_info.c
@@ -7,6 +7,7 @@
 #include <zephyr.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h>
 #include <net/lwm2m.h>
 #include <net/lwm2m_client_utils.h>
 #include <lwm2m_engine.h>
@@ -17,6 +18,13 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(lwm2m_neighbour_cell, CONFIG_LWM2M_CLIENT_UTILS_LOG_LEVEL);
 #define MAX_INSTANCE_COUNT CONFIG_LWM2M_CLIENT_UTILS_SIGNAL_MEAS_INFO_INSTANCE_COUNT
+
+/* Modem returns RSRP and RSRQ as index values which require
+ * a conversion to dBm and dB respectively. See modem AT
+ * command reference guide for more information.
+ */
+#define RSRP_ADJ(rsrp) (rsrp - ((rsrp <= 0) ? 140 : 141))
+#define RSRQ_ADJ(rsrq) (round((rsrq * 0.5) - 19.5))
 
 static void update_signal_meas_object(const struct lte_lc_ncell *const cell, uint16_t index)
 {
@@ -33,9 +41,9 @@ static void update_signal_meas_object(const struct lte_lc_ncell *const cell, uin
 	snprintk(path, sizeof(path), "10256/%" PRIu16 "/2", obj_inst_id);
 	lwm2m_engine_set_s32(path, cell->earfcn);
 	snprintk(path, sizeof(path), "10256/%" PRIu16 "/3", obj_inst_id);
-	lwm2m_engine_set_s32(path, cell->rsrp - MODEM_INFO_RSRP_OFFSET_VAL);
+	lwm2m_engine_set_s32(path, RSRP_ADJ(cell->rsrp));
 	snprintk(path, sizeof(path), "10256/%" PRIu16 "/4", obj_inst_id);
-	lwm2m_engine_set_s32(path, cell->rsrq);
+	lwm2m_engine_set_s32(path, RSRQ_ADJ(cell->rsrq));
 	snprintk(path, sizeof(path), "10256/%" PRIu16 "/5", obj_inst_id);
 	lwm2m_engine_set_s32(path, cell->time_diff);
 }


### PR DESCRIPTION
Report the indexed values as dBm to the lwm2m objects.

Signed-off-by: Jarno Lamsa <jarno.lamsa@nordicsemi.no>