### PR TITLE
event_manager_proxy: Check if remote instance was added already

### DIFF
--- a/include/event_manager_proxy.h
+++ b/include/event_manager_proxy.h
@@ -39,6 +39,7 @@
  * This function registers endpoint used to communication with another core.
  *
  * @param instance The instance used for IPC service to transfer data between cores.
+ * @retval -EALREADY Given remote instance was added already.
  * @retval -ENOMEM No place for the new endpoint. See @kconfig{CONFIG_EVENT_MANAGER_PROXY_CH_COUNT}.
  * @retval -EIO    Comes from IPC service,
  *                 see ipc_service_open_instance or ipc_service_register_endpoint.

--- a/samples/event_manager_proxy/remote/src/main.c
+++ b/samples/event_manager_proxy/remote/src/main.c
@@ -34,7 +34,7 @@ void main(void)
 	LOG_INF("Event manager initialized");
 
 	ret = event_manager_proxy_add_remote(ipc_instance);
-	if (ret) {
+	if (ret && ret != -EALREADY) {
 		LOG_ERR("Cannot add remote: %d", ret);
 		__ASSERT_NO_MSG(false);
 		return;

--- a/samples/event_manager_proxy/src/main.c
+++ b/samples/event_manager_proxy/src/main.c
@@ -39,7 +39,7 @@ void main(void)
 	LOG_INF("Event manager initialized");
 
 	ret = event_manager_proxy_add_remote(ipc_instance);
-	if (ret) {
+	if (ret && ret != -EALREADY) {
 		LOG_ERR("Cannot add remote: %d", ret);
 		__ASSERT_NO_MSG(false);
 		return;

--- a/subsys/event_manager_proxy/event_manager_proxy.c
+++ b/subsys/event_manager_proxy/event_manager_proxy.c
@@ -363,6 +363,10 @@ int event_manager_proxy_add_remote(const struct device *instance)
 {
 	__ASSERT_NO_MSG(find_ipc_by_instance(instance) == NULL);
 
+	if (find_ipc_by_instance(instance) != NULL) {
+		return -EALREADY;
+	}
+
 	for (size_t i = 0; i < ARRAY_SIZE(emp_ipc_data); ++i) {
 		if (!emp_ipc_data[i].used) {
 			return add_ipc_instace(&emp_ipc_data[i], instance);


### PR DESCRIPTION
This commit adds handling of the situation if remote instance
was added already and returns -EALREADY in such situation.
