### PR TITLE
samples: openthread: Adding CI overlay for cli sample.

### DIFF
--- a/samples/openthread/cli/overlay-ci.conf
+++ b/samples/openthread/cli/overlay-ci.conf
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable logging
+CONFIG_BOOT_BANNER=n
+
+# Shell configuration for harness
+CONFIG_SHELL_PROMPT_UART=""
+CONFIG_SHELL_VT100_COLORS=n
+CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=416
+
+# Increase stack
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2144
+
+# Enable and configure Bluetooth LE
+CONFIG_BT=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_NAME="NCS DUT"
+CONFIG_BT_DEVICE_APPEARANCE=833

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -4,24 +4,24 @@ sample:
 tests:
   samples.openthread.cli:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
+    extra_args: OVERLAY_CONFIG="overlay-ci.conf"
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf52840dk_nrf52840
-      - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840
   samples.openthread.cli.thread_1_1:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: CONFIG_OPENTHREAD_THREAD_VERSION_1_1=y
+                OVERLAY_CONFIG="overlay-ci.conf"
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf52840dk_nrf52840
-      - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840
   samples.openthread.cli.usb:
     build_only: true


### PR DESCRIPTION
This commit adds ci overlay enabling multiprotocol
and diabling prompt for CI integration with twister.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>