### PR TITLE
applications: nrf5340_audio: Disabled Zephyr HCI VS extensions

### DIFF
--- a/applications/nrf5340_audio/prj.conf
+++ b/applications/nrf5340_audio/prj.conf
@@ -10,6 +10,9 @@ CONFIG_REBOOT=y
 CONFIG_MAIN_THREAD_PRIORITY=10
 CONFIG_MAIN_STACK_SIZE=1940
 
+# Disable Zephyr HCI Vendor-Specific extensions
+CONFIG_BT_HCI_VS_EXT=n
+
 # As long as thread names are used, config must be set to "y"
 CONFIG_THREAD_NAME=y
 


### PR DESCRIPTION
Disable Zephyr HCI VS extensions
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>