### PR TITLE
lib: location: add missing note to API

### DIFF
--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -188,6 +188,8 @@ struct location_gnss_config {
 	 * timeout.
 	 *
 	 * @details See Kconfig for related configuration options.
+	 *
+	 * @note Only supported with modem firmware v1.3.2 or later.
 	 */
 	bool visibility_detection;
 };


### PR DESCRIPTION
Added a note about required modem firmware version for obstructed visibility detection feature.