### PR TITLE
zigbee: Add device declaration for each sample

### DIFF
--- a/applications/zigbee_weather_station/src/main.c
+++ b/applications/zigbee_weather_station/src/main.c
@@ -11,6 +11,7 @@
 #include <ram_pwrdn.h>
 #include <zb_nrf_platform.h>
 #include <zboss_api.h>
+#include <zboss_api_addons.h>
 #include <zephyr.h>
 #include <zigbee/zigbee_app_utils.h>
 #include <zigbee/zigbee_error_handler.h>
@@ -64,8 +65,13 @@ ZB_ZCL_DECLARE_BASIC_ATTRIB_LIST(
 	basic_attr_list,
 	&dev_ctx.basic_attr.zcl_version, &dev_ctx.basic_attr.power_source);
 
-ZB_ZCL_DECLARE_IDENTIFY_ATTRIB_LIST(
-	identify_attr_list,
+/* Declare attribute list for Identify cluster (client). */
+ZB_ZCL_DECLARE_IDENTIFY_CLIENT_ATTRIB_LIST(
+	identify_client_attr_list);
+
+/* Declare attribute list for Identify cluster (server). */
+ZB_ZCL_DECLARE_IDENTIFY_SERVER_ATTRIB_LIST(
+	identify_server_attr_list,
 	&dev_ctx.identify_attr.identify_time);
 
 ZB_ZCL_DECLARE_TEMP_MEASUREMENT_ATTRIB_LIST(
@@ -95,7 +101,8 @@ ZB_ZCL_DECLARE_REL_HUMIDITY_MEASUREMENT_ATTRIB_LIST(
 ZB_HA_DECLARE_WEATHER_STATION_CLUSTER_LIST(
 	weather_station_cluster_list,
 	basic_attr_list,
-	identify_attr_list,
+	identify_client_attr_list,
+	identify_server_attr_list,
 	temperature_measurement_attr_list,
 	pressure_measurement_attr_list,
 	humidity_measurement_attr_list);

--- a/applications/zigbee_weather_station/src/weather_station.h
+++ b/applications/zigbee_weather_station/src/weather_station.h
@@ -50,6 +50,8 @@
 /* Number chosen for the single endpoint provided by weather station */
 #define WEATHER_STATION_ENDPOINT_NB 42
 
+/* Temperature sensor device version */
+#define ZB_HA_DEVICE_VER_TEMPERATURE_SENSOR     0
 /* Basic, identify, temperature, pressure, humidity */
 #define ZB_HA_WEATHER_STATION_IN_CLUSTER_NUM    5
 /* Identify */
@@ -61,7 +63,8 @@
 #define ZB_HA_DECLARE_WEATHER_STATION_CLUSTER_LIST(						\
 		cluster_list_name,								\
 		basic_attr_list,								\
-		identify_attr_list,								\
+		identify_client_attr_list,							\
+		identify_server_attr_list,							\
 		temperature_measurement_attr_list,						\
 		pressure_measurement_attr_list,							\
 		humidity_measurement_attr_list							\
@@ -77,8 +80,8 @@
 			),									\
 		ZB_ZCL_CLUSTER_DESC(								\
 			ZB_ZCL_CLUSTER_ID_IDENTIFY,						\
-			ZB_ZCL_ARRAY_SIZE(identify_attr_list, zb_zcl_attr_t),			\
-			(identify_attr_list),							\
+			ZB_ZCL_ARRAY_SIZE(identify_server_attr_list, zb_zcl_attr_t),		\
+			(identify_server_attr_list),						\
 			ZB_ZCL_CLUSTER_SERVER_ROLE,						\
 			ZB_ZCL_MANUF_CODE_INVALID						\
 			),									\
@@ -105,8 +108,8 @@
 			),									\
 		ZB_ZCL_CLUSTER_DESC(								\
 			ZB_ZCL_CLUSTER_ID_IDENTIFY,						\
-			0,									\
-			NULL,									\
+			ZB_ZCL_ARRAY_SIZE(identify_client_attr_list, zb_zcl_attr_t),		\
+			(identify_client_attr_list),						\
 			ZB_ZCL_CLUSTER_CLIENT_ROLE,						\
 			ZB_ZCL_MANUF_CODE_INVALID						\
 			),									\

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -331,6 +331,8 @@ Zigbee samples
   * :ref:`zigbee_shell_sample`
   * :ref:`zigbee_template_sample`
 
+* Added identify handler in the :ref:`Zigbee Light Switch sample <zigbee_light_switch_sample>`.
+
 Other Samples
 -------------
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -82,6 +82,9 @@ Zigbee
     For details, see `Libraries for Zigbee`_.
   * Return code in the ZCL callbacks from :c:macro:`RET_ERROR` to :c:macro:`RET_NOT_IMPLEMENTED` if the device does not handle the ZCL command.
   * Enabled the ZCL8 compatibility mode :c:macro:`ZB_ZCL_AUTO_MODE` inside the :c:func:`zigbee_default_signal_handler`.
+  * Production version of :ref:`nrfxlib:zboss` from v3.11.1.0 to v3.11.2.0 and platform v5.1.2 (``v3.11.2.0+v5.1.2``).
+  * Development version of :ref:`nrfxlib:zboss` from v3.11.1.177 to v3.12.1.0 and platform v5.2.0 (``v3.12.1.0+v5.2.0``).
+  * :ref:`ZBOSS Network Co-processor Host <ug_zigbee_tools_ncp_host>` package to the new version v2.2.0.
 
 Applications
 ============

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -76,8 +76,11 @@ Zigbee
   * Experimental support for Zigbee Green Power Combo Basic functionality.
   * Zigbee device definition for each Zigbee sample and application.
 
-* Updated :ref:`Zigbee shell library <lib_zigbee_shell>`.
-  For details, see `Libraries for Zigbee`_.
+* Updated:
+
+  * :ref:` Zigbee shell library <lib_zigbee_shell>`.
+    For details, see `Libraries for Zigbee`_.
+  * Return code in the ZCL callbacks from :c:macro:`RET_ERROR` to :c:macro:`RET_NOT_IMPLEMENTED` if the device does not handle the ZCL command.
 
 Applications
 ============

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -81,6 +81,7 @@ Zigbee
   * :ref:` Zigbee shell library <lib_zigbee_shell>`.
     For details, see `Libraries for Zigbee`_.
   * Return code in the ZCL callbacks from :c:macro:`RET_ERROR` to :c:macro:`RET_NOT_IMPLEMENTED` if the device does not handle the ZCL command.
+  * Enabled the ZCL8 compatibility mode :c:macro:`ZB_ZCL_AUTO_MODE` inside the :c:func:`zigbee_default_signal_handler`.
 
 Applications
 ============

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -74,6 +74,7 @@ Zigbee
     It is meant to be used only for debugging purposes.
   * Documentation page about :ref:`ug_zigbee_commissioning`.
   * Experimental support for Zigbee Green Power Combo Basic functionality.
+  * Zigbee device definition for each Zigbee sample and application.
 
 * Updated :ref:`Zigbee shell library <lib_zigbee_shell>`.
   For details, see `Libraries for Zigbee`_.

--- a/samples/zigbee/light_bulb/CMakeLists.txt
+++ b/samples/zigbee/light_bulb/CMakeLists.txt
@@ -14,4 +14,6 @@ project("Zigbee light bulb with Scenes")
 target_sources(app PRIVATE
   src/main.c
 )
+
+target_include_directories(app PRIVATE include)
 # NORDIC SDK APP END

--- a/samples/zigbee/light_bulb/include/zb_dimmable_light.h
+++ b/samples/zigbee/light_bulb/include/zb_dimmable_light.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef ZB_DIMMABLE_LIGHT_H
+#define ZB_DIMMABLE_LIGHT_H 1
+
+/**
+ *  @defgroup ZB_DEFINE_DEVICE_DIMMABLE_LIGHT Dimmable Light
+ *  @{
+ *  @details
+ *      - @ref ZB_ZCL_BASIC \n
+ *      - @ref ZB_ZCL_IDENTIFY \n
+ *      - @ref ZB_ZCL_SCENES \n
+ *      - @ref ZB_ZCL_GROUPS \n
+ *      - @ref ZB_ZCL_ON_OFF \n
+ *      - @ref ZB_ZCL_LEVEL_CONTROL
+ */
+
+/** Dimmable Light Device ID */
+#define ZB_DIMMABLE_LIGHT_DEVICE_ID 0x0101
+
+/** Dimmable light device version */
+#define ZB_DEVICE_VER_DIMMABLE_LIGHT 1
+
+/** @cond internals_doc */
+
+/** Dimmable Light IN (server) clusters number */
+#define ZB_DIMMABLE_LIGHT_IN_CLUSTER_NUM 6
+
+/** Dimmable Light OUT (client) clusters number */
+#define ZB_DIMMABLE_LIGHT_OUT_CLUSTER_NUM 0
+
+/** Dimmable light total (IN+OUT) cluster number */
+#define ZB_DIMMABLE_LIGHT_CLUSTER_NUM \
+	(ZB_DIMMABLE_LIGHT_IN_CLUSTER_NUM + ZB_DIMMABLE_LIGHT_OUT_CLUSTER_NUM)
+
+/** Number of attribute for reporting on Dimmable Light device */
+#define ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT \
+	(ZB_ZCL_ON_OFF_REPORT_ATTR_COUNT + ZB_ZCL_LEVEL_CONTROL_REPORT_ATTR_COUNT)
+
+/** Continuous value change attribute count */
+#define ZB_DIMMABLE_LIGHT_CVC_ATTR_COUNT 1
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare cluster list for Dimmable Light device
+ * @param cluster_list_name - cluster list variable name
+ * @param basic_attr_list - attribute list for Basic cluster
+ * @param identify_attr_list - attribute list for Identify cluster
+ * @param groups_attr_list - attribute list for Groups cluster
+ * @param scenes_attr_list - attribute list for Scenes cluster
+ * @param on_off_attr_list - attribute list for On/Off cluster
+ * @param level_control_attr_list - attribute list for Level Control cluster
+ */
+#define ZB_DECLARE_DIMMABLE_LIGHT_CLUSTER_LIST(					   \
+	cluster_list_name,							   \
+	basic_attr_list,							   \
+	identify_attr_list,							   \
+	groups_attr_list,							   \
+	scenes_attr_list,							   \
+	on_off_attr_list,							   \
+	level_control_attr_list)						   \
+	zb_zcl_cluster_desc_t cluster_list_name[] =				   \
+	{									   \
+		ZB_ZCL_CLUSTER_DESC(						   \
+			ZB_ZCL_CLUSTER_ID_IDENTIFY,				   \
+			ZB_ZCL_ARRAY_SIZE(identify_attr_list, zb_zcl_attr_t),	   \
+			(identify_attr_list),					   \
+			ZB_ZCL_CLUSTER_SERVER_ROLE,				   \
+			ZB_ZCL_MANUF_CODE_INVALID				   \
+		),								   \
+		ZB_ZCL_CLUSTER_DESC(						   \
+			ZB_ZCL_CLUSTER_ID_BASIC,				   \
+			ZB_ZCL_ARRAY_SIZE(basic_attr_list, zb_zcl_attr_t),	   \
+			(basic_attr_list),					   \
+			ZB_ZCL_CLUSTER_SERVER_ROLE,				   \
+			ZB_ZCL_MANUF_CODE_INVALID				   \
+		),								   \
+		ZB_ZCL_CLUSTER_DESC(						   \
+			ZB_ZCL_CLUSTER_ID_SCENES,				   \
+			ZB_ZCL_ARRAY_SIZE(scenes_attr_list, zb_zcl_attr_t),	   \
+			(scenes_attr_list),					   \
+			ZB_ZCL_CLUSTER_SERVER_ROLE,				   \
+			ZB_ZCL_MANUF_CODE_INVALID				   \
+		),								   \
+		ZB_ZCL_CLUSTER_DESC(						   \
+			ZB_ZCL_CLUSTER_ID_GROUPS,				   \
+			ZB_ZCL_ARRAY_SIZE(groups_attr_list, zb_zcl_attr_t),	   \
+			(groups_attr_list),					   \
+			ZB_ZCL_CLUSTER_SERVER_ROLE,				   \
+			ZB_ZCL_MANUF_CODE_INVALID				   \
+		),								   \
+		ZB_ZCL_CLUSTER_DESC(						   \
+			ZB_ZCL_CLUSTER_ID_ON_OFF,				   \
+			ZB_ZCL_ARRAY_SIZE(on_off_attr_list, zb_zcl_attr_t),	   \
+			(on_off_attr_list),					   \
+			ZB_ZCL_CLUSTER_SERVER_ROLE,				   \
+			ZB_ZCL_MANUF_CODE_INVALID				   \
+		),								   \
+		ZB_ZCL_CLUSTER_DESC(						   \
+			ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL,			   \
+			ZB_ZCL_ARRAY_SIZE(level_control_attr_list, zb_zcl_attr_t), \
+			(level_control_attr_list),				   \
+			ZB_ZCL_CLUSTER_SERVER_ROLE,				   \
+			ZB_ZCL_MANUF_CODE_INVALID				   \
+		)								   \
+	}
+
+
+/** @cond internals_doc */
+/**
+ * @brief Declare simple descriptor for Dimmable Light device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param in_clust_num - number of supported input clusters
+ * @param out_clust_num - number of supported output clusters
+ */
+#define ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
+	ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);					  \
+	ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =		  \
+	{											  \
+		ep_id,										  \
+		ZB_AF_HA_PROFILE_ID,								  \
+		ZB_DIMMABLE_LIGHT_DEVICE_ID,							  \
+		ZB_DEVICE_VER_DIMMABLE_LIGHT,							  \
+		0,										  \
+		in_clust_num,									  \
+		out_clust_num,									  \
+		{										  \
+			ZB_ZCL_CLUSTER_ID_BASIC,						  \
+			ZB_ZCL_CLUSTER_ID_IDENTIFY,						  \
+			ZB_ZCL_CLUSTER_ID_SCENES,						  \
+			ZB_ZCL_CLUSTER_ID_GROUPS,						  \
+			ZB_ZCL_CLUSTER_ID_ON_OFF,						  \
+			ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL,					  \
+		}										  \
+	}
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare endpoint for Dimmable Light device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param cluster_list - endpoint cluster list
+ */
+#define ZB_DECLARE_DIMMABLE_LIGHT_EP(ep_name, ep_id, cluster_list)		      \
+	ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC(ep_name, ep_id,		      \
+		ZB_DIMMABLE_LIGHT_IN_CLUSTER_NUM, ZB_DIMMABLE_LIGHT_OUT_CLUSTER_NUM); \
+	ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,		      \
+		ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT);				      \
+	ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## ep_name,	      \
+		ZB_DIMMABLE_LIGHT_CVC_ATTR_COUNT);				      \
+	ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,	      \
+		0,								      \
+		NULL,								      \
+		ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
+			(zb_af_simple_desc_1_1_t *)&simple_desc_## ep_name,	      \
+			ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT,			      \
+			reporting_info## ep_name,				      \
+			ZB_DIMMABLE_LIGHT_CVC_ATTR_COUNT,			      \
+			cvc_alarm_info## ep_name)
+
+/** @} */
+
+#endif /* ZB_DIMMABLE_LIGHT_H */

--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -25,12 +25,13 @@
 #include <zigbee/zigbee_error_handler.h>
 #include <zigbee/zigbee_zcl_scenes.h>
 #include <zb_nrf_platform.h>
+#include "zb_dimmable_light.h"
 
 #define RUN_STATUS_LED                  DK_LED1
 #define RUN_LED_BLINK_INTERVAL          1000
 
 /* Device endpoint, used to receive light controlling commands. */
-#define HA_DIMMABLE_LIGHT_ENDPOINT      10
+#define DIMMABLE_LIGHT_ENDPOINT         10
 
 /* Version of the application software (1 byte). */
 #define BULB_INIT_BASIC_APP_VERSION     01
@@ -169,7 +170,7 @@ ZB_ZCL_DECLARE_LEVEL_CONTROL_ATTRIB_LIST(
 	&dev_ctx.level_control_attr.current_level,
 	&dev_ctx.level_control_attr.remaining_time);
 
-ZB_HA_DECLARE_DIMMABLE_LIGHT_CLUSTER_LIST(
+ZB_DECLARE_DIMMABLE_LIGHT_CLUSTER_LIST(
 	dimmable_light_clusters,
 	basic_attr_list,
 	identify_attr_list,
@@ -179,12 +180,12 @@ ZB_HA_DECLARE_DIMMABLE_LIGHT_CLUSTER_LIST(
 	level_control_attr_list);
 
 
-ZB_HA_DECLARE_DIMMABLE_LIGHT_EP(
+ZB_DECLARE_DIMMABLE_LIGHT_EP(
 	dimmable_light_ep,
-	HA_DIMMABLE_LIGHT_ENDPOINT,
+	DIMMABLE_LIGHT_ENDPOINT,
 	dimmable_light_clusters);
 
-ZB_HA_DECLARE_DIMMABLE_LIGHT_CTX(
+ZBOSS_DECLARE_DEVICE_CTX_1_EP(
 	dimmable_light_ctx,
 	dimmable_light_ep);
 
@@ -206,7 +207,7 @@ static void start_identifying(zb_bufid_t bufid)
 		    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
 			LOG_INF("Enter identify mode");
 
-			zb_err_code = zb_bdb_finding_binding_target(HA_DIMMABLE_LIGHT_ENDPOINT);
+			zb_err_code = zb_bdb_finding_binding_target(DIMMABLE_LIGHT_ENDPOINT);
 			ZB_ERROR_CHECK(zb_err_code);
 		} else {
 			LOG_INF("Cancel identify mode");
@@ -297,7 +298,7 @@ static void level_control_set_value(zb_uint16_t new_level)
 	LOG_INF("Set level value: %i", new_level);
 
 	ZB_ZCL_SET_ATTRIBUTE(
-		HA_DIMMABLE_LIGHT_ENDPOINT,
+		DIMMABLE_LIGHT_ENDPOINT,
 		ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL,
 		ZB_ZCL_CLUSTER_SERVER_ROLE,
 		ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID,
@@ -311,7 +312,7 @@ static void level_control_set_value(zb_uint16_t new_level)
 		zb_uint8_t value = ZB_FALSE;
 
 		ZB_ZCL_SET_ATTRIBUTE(
-			HA_DIMMABLE_LIGHT_ENDPOINT,
+			DIMMABLE_LIGHT_ENDPOINT,
 			ZB_ZCL_CLUSTER_ID_ON_OFF,
 			ZB_ZCL_CLUSTER_SERVER_ROLE,
 			ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID,
@@ -321,7 +322,7 @@ static void level_control_set_value(zb_uint16_t new_level)
 		zb_uint8_t value = ZB_TRUE;
 
 		ZB_ZCL_SET_ATTRIBUTE(
-			HA_DIMMABLE_LIGHT_ENDPOINT,
+			DIMMABLE_LIGHT_ENDPOINT,
 			ZB_ZCL_CLUSTER_ID_ON_OFF,
 			ZB_ZCL_CLUSTER_SERVER_ROLE,
 			ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID,
@@ -341,7 +342,7 @@ static void on_off_set_value(zb_bool_t on)
 	LOG_INF("Set ON/OFF value: %i", on);
 
 	ZB_ZCL_SET_ATTRIBUTE(
-		HA_DIMMABLE_LIGHT_ENDPOINT,
+		DIMMABLE_LIGHT_ENDPOINT,
 		ZB_ZCL_CLUSTER_ID_ON_OFF,
 		ZB_ZCL_CLUSTER_SERVER_ROLE,
 		ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID,
@@ -445,7 +446,7 @@ static void bulb_clusters_attr_init(void)
 		ZB_ZCL_LEVEL_CONTROL_REMAINING_TIME_DEFAULT_VALUE;
 
 	ZB_ZCL_SET_ATTRIBUTE(
-		HA_DIMMABLE_LIGHT_ENDPOINT,
+		DIMMABLE_LIGHT_ENDPOINT,
 		ZB_ZCL_CLUSTER_ID_ON_OFF,
 		ZB_ZCL_CLUSTER_SERVER_ROLE,
 		ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID,
@@ -453,7 +454,7 @@ static void bulb_clusters_attr_init(void)
 		ZB_FALSE);
 
 	ZB_ZCL_SET_ATTRIBUTE(
-		HA_DIMMABLE_LIGHT_ENDPOINT,
+		DIMMABLE_LIGHT_ENDPOINT,
 		ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL,
 		ZB_ZCL_CLUSTER_SERVER_ROLE,
 		ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID,
@@ -578,7 +579,7 @@ void main(void)
 	level_control_set_value(dev_ctx.level_control_attr.current_level);
 
 	/* Register handler to identify notifications. */
-	ZB_AF_SET_IDENTIFY_NOTIFICATION_HANDLER(HA_DIMMABLE_LIGHT_ENDPOINT, identify_cb);
+	ZB_AF_SET_IDENTIFY_NOTIFICATION_HANDLER(DIMMABLE_LIGHT_ENDPOINT, identify_cb);
 
 	/* Initialize ZCL scene table */
 	zcl_scenes_init();

--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -518,12 +518,13 @@ static void zcl_device_cb(zb_bufid_t bufid)
 			/* Other clusters can be processed here */
 			LOG_INF("Unhandled cluster attribute id: %d",
 				cluster_id);
+			device_cb_param->status = RET_NOT_IMPLEMENTED;
 		}
 		break;
 
 	default:
 		if (zcl_scenes_cb(bufid) == ZB_FALSE) {
-			device_cb_param->status = RET_ERROR;
+			device_cb_param->status = RET_NOT_IMPLEMENTED;
 		}
 		break;
 	}

--- a/samples/zigbee/light_switch/include/zb_dimmer_switch.h
+++ b/samples/zigbee/light_switch/include/zb_dimmer_switch.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef ZB_DIMMER_SWITCH_H
+#define ZB_DIMMER_SWITCH_H 1
+
+/**
+ *  @defgroup ZB_DEFINE_DEVICE_DIMMER_SWITCH Dimmer Switch
+ *  @{
+ *  @details
+ *      - @ref ZB_ZCL_BASIC \n
+ *      - @ref ZB_ZCL_IDENTIFY \n
+ *      - @ref ZB_ZCL_SCENES \n
+ *      - @ref ZB_ZCL_GROUPS \n
+ *      - @ref ZB_ZCL_ON_OFF \n
+ *      - @ref ZB_ZCL_LEVEL_CONTROL
+ */
+
+/** Dimmer Switch Device ID */
+#define ZB_DIMMER_SWITCH_DEVICE_ID 0x0104
+
+/** Dimmer Switch device version */
+#define ZB_DEVICE_VER_DIMMER_SWITCH 0
+
+/** @cond internals_doc */
+
+/** Dimmer Switch IN (server) clusters number */
+#define ZB_DIMMER_SWITCH_IN_CLUSTER_NUM 2
+
+/** Dimmer Switch OUT (client) clusters number */
+#define ZB_DIMMER_SWITCH_OUT_CLUSTER_NUM 5
+
+/** Dimmer switch total (IN+OUT) cluster number */
+#define ZB_DIMMER_SWITCH_CLUSTER_NUM \
+	(ZB_DIMMER_SWITCH_IN_CLUSTER_NUM + ZB_DIMMER_SWITCH_OUT_CLUSTER_NUM)
+
+/** Number of attribute for reporting on Dimmer Switch device */
+#define ZB_DIMMER_SWITCH_REPORT_ATTR_COUNT 0
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare cluster list for Dimmer Switch device
+ * @param cluster_list_name - cluster list variable name
+ * @param basic_server_attr_list - attribute list for Basic cluster (server role)
+ * @param identify_client_attr_list - attribute list for Identify cluster (client role)
+ * @param identify_server_attr_list - attribute list for Identify cluster (server role)
+ * @param scenes_client_attr_list - attribute list for Scenes cluster (client role)
+ * @param groups_client_attr_list - attribute list for Groups cluster (client role)
+ * @param on_off_client_attr_list - attribute list for On/Off cluster (client role)
+ * @param level_control_client_attr_list - attribute list for Level Control cluster (client role)
+ */
+#define ZB_DECLARE_DIMMER_SWITCH_CLUSTER_LIST(					  \
+		cluster_list_name,						  \
+		basic_server_attr_list,						  \
+		identify_client_attr_list,					  \
+		identify_server_attr_list,					  \
+		scenes_client_attr_list,					  \
+		groups_client_attr_list,					  \
+		on_off_client_attr_list,					  \
+		level_control_client_attr_list)					  \
+zb_zcl_cluster_desc_t cluster_list_name[] =					  \
+{										  \
+	ZB_ZCL_CLUSTER_DESC(							  \
+		ZB_ZCL_CLUSTER_ID_BASIC,					  \
+		ZB_ZCL_ARRAY_SIZE(basic_server_attr_list, zb_zcl_attr_t),	  \
+		(basic_server_attr_list),					  \
+		ZB_ZCL_CLUSTER_SERVER_ROLE,					  \
+		ZB_ZCL_MANUF_CODE_INVALID					  \
+	),									  \
+	ZB_ZCL_CLUSTER_DESC(							  \
+		ZB_ZCL_CLUSTER_ID_IDENTIFY,					  \
+		ZB_ZCL_ARRAY_SIZE(identify_server_attr_list, zb_zcl_attr_t),	  \
+		(identify_server_attr_list),					  \
+		ZB_ZCL_CLUSTER_SERVER_ROLE,					  \
+		ZB_ZCL_MANUF_CODE_INVALID					  \
+	),									  \
+	ZB_ZCL_CLUSTER_DESC(							  \
+		ZB_ZCL_CLUSTER_ID_IDENTIFY,					  \
+		ZB_ZCL_ARRAY_SIZE(identify_client_attr_list, zb_zcl_attr_t),	  \
+		(identify_client_attr_list),					  \
+		ZB_ZCL_CLUSTER_CLIENT_ROLE,					  \
+		ZB_ZCL_MANUF_CODE_INVALID					  \
+	),									  \
+	ZB_ZCL_CLUSTER_DESC(							  \
+		ZB_ZCL_CLUSTER_ID_SCENES,					  \
+		ZB_ZCL_ARRAY_SIZE(scenes_client_attr_list, zb_zcl_attr_t),	  \
+		(scenes_client_attr_list),					  \
+		ZB_ZCL_CLUSTER_CLIENT_ROLE,					  \
+		ZB_ZCL_MANUF_CODE_INVALID					  \
+	),									  \
+	ZB_ZCL_CLUSTER_DESC(							  \
+		ZB_ZCL_CLUSTER_ID_GROUPS,					  \
+		ZB_ZCL_ARRAY_SIZE(groups_client_attr_list, zb_zcl_attr_t),	  \
+		(groups_client_attr_list),					  \
+		ZB_ZCL_CLUSTER_CLIENT_ROLE,					  \
+		ZB_ZCL_MANUF_CODE_INVALID					  \
+	),									  \
+	ZB_ZCL_CLUSTER_DESC(							  \
+		ZB_ZCL_CLUSTER_ID_ON_OFF,					  \
+		ZB_ZCL_ARRAY_SIZE(on_off_client_attr_list, zb_zcl_attr_t),	  \
+		(on_off_client_attr_list),					  \
+		ZB_ZCL_CLUSTER_CLIENT_ROLE,					  \
+		ZB_ZCL_MANUF_CODE_INVALID					  \
+	),									  \
+	ZB_ZCL_CLUSTER_DESC(							  \
+		ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL,				  \
+		ZB_ZCL_ARRAY_SIZE(level_control_client_attr_list, zb_zcl_attr_t), \
+		(level_control_client_attr_list),				  \
+		ZB_ZCL_CLUSTER_CLIENT_ROLE,					  \
+		ZB_ZCL_MANUF_CODE_INVALID					  \
+	)									  \
+}
+
+
+/** @cond internals_doc */
+/**
+ * @brief Declare simple descriptor for Dimmer switch device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param in_clust_num - number of supported input clusters
+ * @param out_clust_num - number of supported output clusters
+ */
+#define ZB_ZCL_DECLARE_DIMMER_SWITCH_SIMPLE_DESC(				    \
+	ep_name, ep_id, in_clust_num, out_clust_num)				    \
+	ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);			    \
+	ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name = \
+	{									    \
+		ep_id,								    \
+		ZB_AF_HA_PROFILE_ID,						    \
+		ZB_DIMMER_SWITCH_DEVICE_ID,					    \
+		ZB_DEVICE_VER_DIMMER_SWITCH,					    \
+		0,								    \
+		in_clust_num,							    \
+		out_clust_num,							    \
+		{								    \
+			ZB_ZCL_CLUSTER_ID_BASIC,				    \
+			ZB_ZCL_CLUSTER_ID_IDENTIFY,				    \
+			ZB_ZCL_CLUSTER_ID_IDENTIFY,				    \
+			ZB_ZCL_CLUSTER_ID_SCENES,				    \
+			ZB_ZCL_CLUSTER_ID_GROUPS,				    \
+			ZB_ZCL_CLUSTER_ID_ON_OFF,				    \
+			ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL,			    \
+		}								    \
+	}
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare endpoint for Dimmer Switch device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param cluster_list - endpoint cluster list
+ */
+#define ZB_DECLARE_DIMMER_SWITCH_EP(ep_name, ep_id, cluster_list)		      \
+	ZB_ZCL_DECLARE_DIMMER_SWITCH_SIMPLE_DESC(ep_name, ep_id,		      \
+		  ZB_DIMMER_SWITCH_IN_CLUSTER_NUM, ZB_DIMMER_SWITCH_OUT_CLUSTER_NUM); \
+										      \
+	ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,     \
+		ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
+		(zb_af_simple_desc_1_1_t *)&simple_desc_##ep_name,		      \
+		0, NULL, /* No reporting ctx */					      \
+		0, NULL) /* No CVC ctx */
+
+/** @} */
+
+#endif /* ZB_DIMMER_SWITCH_H */

--- a/samples/zigbee/light_switch/src/main.c
+++ b/samples/zigbee/light_switch/src/main.c
@@ -566,6 +566,23 @@ static void ota_evt_handler(const struct zigbee_fota_evt *evt)
 		break;
 	}
 }
+
+/**@brief Callback function for handling ZCL commands.
+ *
+ * @param[in]   bufid   Reference to Zigbee stack buffer
+ *                      used to pass received data.
+ */
+static void zcl_device_cb(zb_bufid_t bufid)
+{
+	zb_zcl_device_callback_param_t *device_cb_param =
+		ZB_BUF_GET_PARAM(bufid, zb_zcl_device_callback_param_t);
+
+	if (device_cb_param->device_cb_id == ZB_ZCL_OTA_UPGRADE_VALUE_CB_ID) {
+		zigbee_fota_zcl_cb(bufid);
+	} else {
+		device_cb_param->status = RET_NOT_IMPLEMENTED;
+	}
+}
 #endif /* CONFIG_ZIGBEE_FOTA */
 
 /**@brief Zigbee stack event handler.
@@ -726,7 +743,7 @@ void main(void)
 	confirm_image();
 
 	/* Register callback for handling ZCL commands. */
-	ZB_ZCL_REGISTER_DEVICE_CB(zigbee_fota_zcl_cb);
+	ZB_ZCL_REGISTER_DEVICE_CB(zcl_device_cb);
 #endif /* CONFIG_ZIGBEE_FOTA */
 
 	/* Register dimmer switch device context (endpoints). */

--- a/samples/zigbee/light_switch/src/main.c
+++ b/samples/zigbee/light_switch/src/main.c
@@ -20,6 +20,7 @@
 #include <zigbee/zigbee_error_handler.h>
 #include <zb_nrf_platform.h>
 #include "zb_mem_config_custom.h"
+#include "zb_dimmer_switch.h"
 
 #if CONFIG_ZIGBEE_FOTA
 #include <zigbee/zigbee_fota.h>
@@ -111,25 +112,43 @@ static zb_uint8_t attr_zcl_version = ZB_ZCL_VERSION;
 static zb_uint8_t attr_power_source = ZB_ZCL_BASIC_POWER_SOURCE_UNKNOWN;
 static zb_uint16_t attr_identify_time;
 
-/* Declare attribute list for Basic cluster. */
-ZB_ZCL_DECLARE_BASIC_ATTRIB_LIST(basic_attr_list, &attr_zcl_version,
-				 &attr_power_source);
+/* Declare attribute list for Basic cluster (server). */
+ZB_ZCL_DECLARE_BASIC_SERVER_ATTRIB_LIST(basic_server_attr_list, &attr_zcl_version, &attr_power_source);
 
-/* Declare attribute list for Identify cluster. */
-ZB_ZCL_DECLARE_IDENTIFY_ATTRIB_LIST(identify_attr_list, &attr_identify_time);
+/* Declare attribute list for Identify cluster (client). */
+ZB_ZCL_DECLARE_IDENTIFY_CLIENT_ATTRIB_LIST(identify_client_attr_list);
 
-/* Declare cluster list for Dimmer Switch device (Identify, Basic, Scenes,
- * Groups, On Off, Level Control).
- * Only clusters Identify and Basic have attributes.
- */
-ZB_HA_DECLARE_DIMMER_SWITCH_CLUSTER_LIST(dimmer_switch_clusters,
-					 basic_attr_list,
-					 identify_attr_list);
+/* Declare attribute list for Identify cluster (server). */
+ZB_ZCL_DECLARE_IDENTIFY_SERVER_ATTRIB_LIST(identify_server_attr_list, &attr_identify_time);
+
+/* Declare attribute list for Scenes cluster (client). */
+ZB_ZCL_DECLARE_SCENES_CLIENT_ATTRIB_LIST(scenes_client_attr_list);
+
+/* Declare attribute list for Groups cluster (client). */
+ZB_ZCL_DECLARE_GROUPS_CLIENT_ATTRIB_LIST(groups_client_attr_list);
+
+/* Declare attribute list for On/Off cluster (client). */
+ZB_ZCL_DECLARE_ON_OFF_CLIENT_ATTRIB_LIST(on_off_client_attr_list);
+
+/* Declare attribute list for Level control cluster (client). */
+ZB_ZCL_DECLARE_LEVEL_CONTROL_CLIENT_ATTRIB_LIST(level_control_client_attr_list);
+
+/* Declare cluster list for Dimmer Switch device. */
+ZB_DECLARE_DIMMER_SWITCH_CLUSTER_LIST(
+	dimmer_switch_clusters,
+	basic_server_attr_list,
+	identify_client_attr_list,
+	identify_server_attr_list,
+	scenes_client_attr_list,
+	groups_client_attr_list,
+	on_off_client_attr_list,
+	level_control_client_attr_list);
 
 /* Declare endpoint for Dimmer Switch device. */
-ZB_HA_DECLARE_DIMMER_SWITCH_EP(dimmer_switch_ep,
-			       LIGHT_SWITCH_ENDPOINT,
-			       dimmer_switch_clusters);
+ZB_DECLARE_DIMMER_SWITCH_EP(
+	dimmer_switch_ep,
+	LIGHT_SWITCH_ENDPOINT,
+	dimmer_switch_clusters);
 
 /* Declare application's device context (list of registered endpoints)
  * for Dimmer Switch device.

--- a/samples/zigbee/network_coordinator/CMakeLists.txt
+++ b/samples/zigbee/network_coordinator/CMakeLists.txt
@@ -14,4 +14,6 @@ project("Zigbee coordinator")
 target_sources(app PRIVATE
   src/main.c
 )
+
+target_include_directories(app PRIVATE include)
 # NORDIC SDK APP END

--- a/samples/zigbee/network_coordinator/include/zb_range_extender.h
+++ b/samples/zigbee/network_coordinator/include/zb_range_extender.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef ZB_RANGE_EXTENDER_H
+#define ZB_RANGE_EXTENDER_H 1
+
+/**
+ *  @defgroup ZB_DEFINE_DEVICE_RANGE_EXTENDER Range Extender
+ *  @{
+ *  @details
+ *      - @ref ZB_ZCL_IDENTIFY \n
+ *      - @ref ZB_ZCL_BASIC
+ */
+
+/** Range Extender Device ID*/
+#define ZB_RANGE_EXTENDER_DEVICE_ID 0x0008
+
+/** Range extender device version */
+#define ZB_DEVICE_VER_RANGE_EXTENDER 0
+
+/** @cond internals_doc */
+
+/** Range extender IN (server) clusters number */
+#define ZB_RANGE_EXTENDER_IN_CLUSTER_NUM 2
+
+/** Range extender OUT (client) clusters number */
+#define ZB_RANGE_EXTENDER_OUT_CLUSTER_NUM 0
+
+#define ZB_RANGE_EXTENDER_CLUSTER_NUM \
+	(ZB_RANGE_EXTENDER_IN_CLUSTER_NUM + ZB_RANGE_EXTENDER_OUT_CLUSTER_NUM)
+
+/** Number of attribute for reporting on Range extender device */
+#define ZB_RANGE_EXTENDER_REPORT_ATTR_COUNT 0
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare cluster list for Range extender device
+ * @param cluster_list_name - cluster list variable name
+ * @param basic_attr_list - attribute list for Basic cluster
+ * @param identify_attr_list - attribute list for Identify cluster
+ */
+#define ZB_DECLARE_RANGE_EXTENDER_CLUSTER_LIST(			      \
+		cluster_list_name,				      \
+		basic_attr_list,				      \
+		identify_attr_list)				      \
+zb_zcl_cluster_desc_t cluster_list_name[] =			      \
+{								      \
+	ZB_ZCL_CLUSTER_DESC(					      \
+		ZB_ZCL_CLUSTER_ID_IDENTIFY,			      \
+		ZB_ZCL_ARRAY_SIZE(identify_attr_list, zb_zcl_attr_t), \
+		(identify_attr_list),				      \
+		ZB_ZCL_CLUSTER_SERVER_ROLE,			      \
+		ZB_ZCL_MANUF_CODE_INVALID			      \
+	),							      \
+	ZB_ZCL_CLUSTER_DESC(					      \
+		ZB_ZCL_CLUSTER_ID_BASIC,			      \
+		ZB_ZCL_ARRAY_SIZE(basic_attr_list, zb_zcl_attr_t),    \
+		(basic_attr_list),				      \
+		ZB_ZCL_CLUSTER_SERVER_ROLE,			      \
+		ZB_ZCL_MANUF_CODE_INVALID			      \
+	)							      \
+}
+
+/** @cond internals_doc */
+
+/**
+ * @brief Declare simple descriptor for Range extender device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param in_clust_num - number of supported input clusters
+ * @param out_clust_num - number of supported output clusters
+ */
+#define ZB_ZCL_DECLARE_RANGE_EXTENDER_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
+	ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);				       \
+	ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =	       \
+	{										       \
+		ep_id,									       \
+		ZB_AF_HA_PROFILE_ID,							       \
+		ZB_RANGE_EXTENDER_DEVICE_ID,						       \
+		ZB_DEVICE_VER_RANGE_EXTENDER,						       \
+		0,									       \
+		in_clust_num,								       \
+		out_clust_num,								       \
+		{									       \
+			ZB_ZCL_CLUSTER_ID_BASIC,					       \
+			ZB_ZCL_CLUSTER_ID_IDENTIFY					       \
+		}									       \
+	}
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare endpoint for Range extender device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param cluster_list - endpoint cluster list
+ */
+#define ZB_DECLARE_RANGE_EXTENDER_EP(ep_name, ep_id, cluster_list)		      \
+	ZB_ZCL_DECLARE_RANGE_EXTENDER_SIMPLE_DESC(ep_name, ep_id,		      \
+		ZB_RANGE_EXTENDER_IN_CLUSTER_NUM, ZB_RANGE_EXTENDER_OUT_CLUSTER_NUM); \
+	ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,     \
+		ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
+			(zb_af_simple_desc_1_1_t *)&simple_desc_##ep_name,	      \
+			0, NULL, /* No reporting ctx */				      \
+			0, NULL) /* No CVC ctx */
+
+/*! @} */
+
+#endif /* ZB_RANGE_EXTENDER_H */

--- a/samples/zigbee/network_coordinator/src/main.c
+++ b/samples/zigbee/network_coordinator/src/main.c
@@ -18,6 +18,7 @@
 #include <zigbee/zigbee_error_handler.h>
 #include <zigbee/zigbee_app_utils.h>
 #include <zb_nrf_platform.h>
+#include "zb_range_extender.h"
 
 
 #define RUN_STATUS_LED                         DK_LED1
@@ -77,12 +78,12 @@ ZB_ZCL_DECLARE_BASIC_ATTRIB_LIST(
 	&dev_ctx.basic_attr.zcl_version,
 	&dev_ctx.basic_attr.power_source);
 
-ZB_HA_DECLARE_RANGE_EXTENDER_CLUSTER_LIST(
+ZB_DECLARE_RANGE_EXTENDER_CLUSTER_LIST(
 	nwk_coordinator_clusters,
 	basic_attr_list,
 	identify_attr_list);
 
-ZB_HA_DECLARE_RANGE_EXTENDER_EP(
+ZB_DECLARE_RANGE_EXTENDER_EP(
 	nwk_coordinator_ep,
 	ZIGBEE_COORDINATOR_ENDPOINT,
 	nwk_coordinator_clusters);

--- a/samples/zigbee/shell/CMakeLists.txt
+++ b/samples/zigbee/shell/CMakeLists.txt
@@ -14,4 +14,6 @@ project("Zigbee application with Zigbee shell")
 target_sources(app PRIVATE
   src/main.c
 )
+
+target_include_directories(app PRIVATE include)
 # NORDIC SDK APP END

--- a/samples/zigbee/shell/include/zb_range_extender.h
+++ b/samples/zigbee/shell/include/zb_range_extender.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef ZB_RANGE_EXTENDER_H
+#define ZB_RANGE_EXTENDER_H 1
+
+/**
+ *  @defgroup ZB_DEFINE_DEVICE_RANGE_EXTENDER Range Extender
+ *  @{
+ *  @details
+ *      - @ref ZB_ZCL_IDENTIFY \n
+ *      - @ref ZB_ZCL_BASIC
+ */
+
+/** Range Extender Device ID*/
+#define ZB_RANGE_EXTENDER_DEVICE_ID 0x0008
+
+/** Range extender device version */
+#define ZB_DEVICE_VER_RANGE_EXTENDER 0
+
+/** @cond internals_doc */
+
+/** Range extender IN (server) clusters number */
+#define ZB_RANGE_EXTENDER_IN_CLUSTER_NUM 2
+
+/** Range extender OUT (client) clusters number */
+#define ZB_RANGE_EXTENDER_OUT_CLUSTER_NUM 0
+
+#define ZB_RANGE_EXTENDER_CLUSTER_NUM \
+	(ZB_RANGE_EXTENDER_IN_CLUSTER_NUM + ZB_RANGE_EXTENDER_OUT_CLUSTER_NUM)
+
+/** Number of attribute for reporting on Range extender device */
+#define ZB_RANGE_EXTENDER_REPORT_ATTR_COUNT 0
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare cluster list for Range extender device
+ * @param cluster_list_name - cluster list variable name
+ * @param basic_attr_list - attribute list for Basic cluster
+ * @param identify_attr_list - attribute list for Identify cluster
+ */
+#define ZB_DECLARE_RANGE_EXTENDER_CLUSTER_LIST(			      \
+		cluster_list_name,				      \
+		basic_attr_list,				      \
+		identify_attr_list)				      \
+zb_zcl_cluster_desc_t cluster_list_name[] =			      \
+{								      \
+	ZB_ZCL_CLUSTER_DESC(					      \
+		ZB_ZCL_CLUSTER_ID_IDENTIFY,			      \
+		ZB_ZCL_ARRAY_SIZE(identify_attr_list, zb_zcl_attr_t), \
+		(identify_attr_list),				      \
+		ZB_ZCL_CLUSTER_SERVER_ROLE,			      \
+		ZB_ZCL_MANUF_CODE_INVALID			      \
+	),							      \
+	ZB_ZCL_CLUSTER_DESC(					      \
+		ZB_ZCL_CLUSTER_ID_BASIC,			      \
+		ZB_ZCL_ARRAY_SIZE(basic_attr_list, zb_zcl_attr_t),    \
+		(basic_attr_list),				      \
+		ZB_ZCL_CLUSTER_SERVER_ROLE,			      \
+		ZB_ZCL_MANUF_CODE_INVALID			      \
+	)							      \
+}
+
+/** @cond internals_doc */
+
+/**
+ * @brief Declare simple descriptor for Range extender device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param in_clust_num - number of supported input clusters
+ * @param out_clust_num - number of supported output clusters
+ */
+#define ZB_ZCL_DECLARE_RANGE_EXTENDER_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
+	ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);				       \
+	ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =	       \
+	{										       \
+		ep_id,									       \
+		ZB_AF_HA_PROFILE_ID,							       \
+		ZB_RANGE_EXTENDER_DEVICE_ID,						       \
+		ZB_DEVICE_VER_RANGE_EXTENDER,						       \
+		0,									       \
+		in_clust_num,								       \
+		out_clust_num,								       \
+		{									       \
+			ZB_ZCL_CLUSTER_ID_BASIC,					       \
+			ZB_ZCL_CLUSTER_ID_IDENTIFY					       \
+		}									       \
+	}
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare endpoint for Range extender device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param cluster_list - endpoint cluster list
+ */
+#define ZB_DECLARE_RANGE_EXTENDER_EP(ep_name, ep_id, cluster_list)		      \
+	ZB_ZCL_DECLARE_RANGE_EXTENDER_SIMPLE_DESC(ep_name, ep_id,		      \
+		ZB_RANGE_EXTENDER_IN_CLUSTER_NUM, ZB_RANGE_EXTENDER_OUT_CLUSTER_NUM); \
+	ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,     \
+		ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
+			(zb_af_simple_desc_1_1_t *)&simple_desc_##ep_name,	      \
+			0, NULL, /* No reporting ctx */				      \
+			0, NULL) /* No CVC ctx */
+
+/*! @} */
+
+#endif /* ZB_RANGE_EXTENDER_H */

--- a/samples/zigbee/shell/src/main.c
+++ b/samples/zigbee/shell/src/main.c
@@ -17,6 +17,7 @@
 #include <zigbee/zigbee_error_handler.h>
 #include <zigbee/zigbee_app_utils.h>
 #include <zb_nrf_platform.h>
+#include "zb_range_extender.h"
 
 
 /* Device endpoint, used to receive ZCL commands. */
@@ -58,12 +59,12 @@ ZB_ZCL_DECLARE_BASIC_ATTRIB_LIST(
 	&dev_ctx.basic_attr.zcl_version,
 	&dev_ctx.basic_attr.power_source);
 
-ZB_HA_DECLARE_RANGE_EXTENDER_CLUSTER_LIST(
+ZB_DECLARE_RANGE_EXTENDER_CLUSTER_LIST(
 	app_template_clusters,
 	basic_attr_list,
 	identify_attr_list);
 
-ZB_HA_DECLARE_RANGE_EXTENDER_EP(
+ZB_DECLARE_RANGE_EXTENDER_EP(
 	app_zigbee_ep,
 	APP_ZIGBEE_ENDPOINT,
 	app_template_clusters);

--- a/samples/zigbee/template/CMakeLists.txt
+++ b/samples/zigbee/template/CMakeLists.txt
@@ -14,4 +14,6 @@ project("Zigbee application template")
 target_sources(app PRIVATE
   src/main.c
 )
+
+target_include_directories(app PRIVATE include)
 # NORDIC SDK APP END

--- a/samples/zigbee/template/include/zb_range_extender.h
+++ b/samples/zigbee/template/include/zb_range_extender.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef ZB_RANGE_EXTENDER_H
+#define ZB_RANGE_EXTENDER_H 1
+
+/**
+ *  @defgroup ZB_DEFINE_DEVICE_RANGE_EXTENDER Range Extender
+ *  @{
+ *  @details
+ *      - @ref ZB_ZCL_IDENTIFY \n
+ *      - @ref ZB_ZCL_BASIC
+ */
+
+/** Range Extender Device ID*/
+#define ZB_RANGE_EXTENDER_DEVICE_ID 0x0008
+
+/** Range extender device version */
+#define ZB_DEVICE_VER_RANGE_EXTENDER 0
+
+/** @cond internals_doc */
+
+/** Range extender IN (server) clusters number */
+#define ZB_RANGE_EXTENDER_IN_CLUSTER_NUM 2
+
+/** Range extender OUT (client) clusters number */
+#define ZB_RANGE_EXTENDER_OUT_CLUSTER_NUM 0
+
+#define ZB_RANGE_EXTENDER_CLUSTER_NUM \
+	(ZB_RANGE_EXTENDER_IN_CLUSTER_NUM + ZB_RANGE_EXTENDER_OUT_CLUSTER_NUM)
+
+/** Number of attribute for reporting on Range extender device */
+#define ZB_RANGE_EXTENDER_REPORT_ATTR_COUNT 0
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare cluster list for Range extender device
+ * @param cluster_list_name - cluster list variable name
+ * @param basic_attr_list - attribute list for Basic cluster
+ * @param identify_attr_list - attribute list for Identify cluster
+ */
+#define ZB_DECLARE_RANGE_EXTENDER_CLUSTER_LIST(			      \
+		cluster_list_name,				      \
+		basic_attr_list,				      \
+		identify_attr_list)				      \
+zb_zcl_cluster_desc_t cluster_list_name[] =			      \
+{								      \
+	ZB_ZCL_CLUSTER_DESC(					      \
+		ZB_ZCL_CLUSTER_ID_IDENTIFY,			      \
+		ZB_ZCL_ARRAY_SIZE(identify_attr_list, zb_zcl_attr_t), \
+		(identify_attr_list),				      \
+		ZB_ZCL_CLUSTER_SERVER_ROLE,			      \
+		ZB_ZCL_MANUF_CODE_INVALID			      \
+	),							      \
+	ZB_ZCL_CLUSTER_DESC(					      \
+		ZB_ZCL_CLUSTER_ID_BASIC,			      \
+		ZB_ZCL_ARRAY_SIZE(basic_attr_list, zb_zcl_attr_t),    \
+		(basic_attr_list),				      \
+		ZB_ZCL_CLUSTER_SERVER_ROLE,			      \
+		ZB_ZCL_MANUF_CODE_INVALID			      \
+	)							      \
+}
+
+/** @cond internals_doc */
+
+/**
+ * @brief Declare simple descriptor for Range extender device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param in_clust_num - number of supported input clusters
+ * @param out_clust_num - number of supported output clusters
+ */
+#define ZB_ZCL_DECLARE_RANGE_EXTENDER_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
+	ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);				       \
+	ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =	       \
+	{										       \
+		ep_id,									       \
+		ZB_AF_HA_PROFILE_ID,							       \
+		ZB_RANGE_EXTENDER_DEVICE_ID,						       \
+		ZB_DEVICE_VER_RANGE_EXTENDER,						       \
+		0,									       \
+		in_clust_num,								       \
+		out_clust_num,								       \
+		{									       \
+			ZB_ZCL_CLUSTER_ID_BASIC,					       \
+			ZB_ZCL_CLUSTER_ID_IDENTIFY					       \
+		}									       \
+	}
+
+/** @endcond */ /* internals_doc */
+
+/**
+ * @brief Declare endpoint for Range extender device
+ * @param ep_name - endpoint variable name
+ * @param ep_id - endpoint ID
+ * @param cluster_list - endpoint cluster list
+ */
+#define ZB_DECLARE_RANGE_EXTENDER_EP(ep_name, ep_id, cluster_list)		      \
+	ZB_ZCL_DECLARE_RANGE_EXTENDER_SIMPLE_DESC(ep_name, ep_id,		      \
+		ZB_RANGE_EXTENDER_IN_CLUSTER_NUM, ZB_RANGE_EXTENDER_OUT_CLUSTER_NUM); \
+	ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,     \
+		ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
+			(zb_af_simple_desc_1_1_t *)&simple_desc_##ep_name,	      \
+			0, NULL, /* No reporting ctx */				      \
+			0, NULL) /* No CVC ctx */
+
+/*! @} */
+
+#endif /* ZB_RANGE_EXTENDER_H */

--- a/samples/zigbee/template/src/main.c
+++ b/samples/zigbee/template/src/main.c
@@ -17,6 +17,7 @@
 #include <zigbee/zigbee_error_handler.h>
 #include <zigbee/zigbee_app_utils.h>
 #include <zb_nrf_platform.h>
+#include "zb_range_extender.h"
 
 
 /* Device endpoint, used to receive ZCL commands. */
@@ -61,12 +62,12 @@ ZB_ZCL_DECLARE_BASIC_ATTRIB_LIST(
 	&dev_ctx.basic_attr.zcl_version,
 	&dev_ctx.basic_attr.power_source);
 
-ZB_HA_DECLARE_RANGE_EXTENDER_CLUSTER_LIST(
+ZB_DECLARE_RANGE_EXTENDER_CLUSTER_LIST(
 	app_template_clusters,
 	basic_attr_list,
 	identify_attr_list);
 
-ZB_HA_DECLARE_RANGE_EXTENDER_EP(
+ZB_DECLARE_RANGE_EXTENDER_EP(
 	app_template_ep,
 	APP_TEMPLATE_ENDPOINT,
 	app_template_clusters);

--- a/subsys/zigbee/lib/zigbee_app_utils/zigbee_app_utils.c
+++ b/subsys/zigbee/lib/zigbee_app_utils/zigbee_app_utils.c
@@ -225,6 +225,9 @@ zb_ret_t zigbee_default_signal_handler(zb_bufid_t bufid)
 		 * Next step: perform BDB initialization procedure,
 		 *            (see BDB specification section 7.1).
 		 */
+		ZB_ERROR_CHECK(zb_zcl_set_backward_comp_mode(ZB_ZCL_AUTO_MODE));
+		ZB_ERROR_CHECK(
+			zb_zcl_set_backward_compatible_statuses_mode(ZB_ZCL_STATUSES_ZCL8_MODE));
 		stack_initialised = true;
 		LOG_INF("Zigbee stack initialized");
 		comm_status = bdb_start_top_level_commissioning(

--- a/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
+++ b/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
@@ -601,6 +601,7 @@ void zigbee_fota_zcl_cb(zb_bufid_t bufid)
 		break;
 
 	default:
+		device_cb_param->status = RET_NOT_IMPLEMENTED;
 		break;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 10a433b07290b5df928a5471d681a9d41452c862
+      revision: 552bc9d1b5e8b604d19d5aa2f48843d9c32f0e18
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Since the HA declarations do not conform to the ZCL8 specification, each zigbee sample and application shall provide its own device definition.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>