### PR TITLE
samples: radio_test: Fix for calculation of total payload size

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -430,6 +430,9 @@ Other samples
 
     * Added new configuration that builds the sample with support for remote IPC Service shell on nRF5340 application core through USB.
     * Added possibility to build with the limited nRF21540 front-end module hardware pinout.
+    * Improved the calculation of the total payload size for the radio duty cycle.
+    * Fast ramp-up is enabled for all radio modes.
+    * The duty cycle for modulated transmission is limited to 1-90%.
 
 Drivers
 =======

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -104,7 +104,7 @@ User interface
      - Start channel for the sweep or the channel for the constant carrier (in MHz, as difference from 2400 MHz).
    * - start_duty_cycle_modulated_tx
      - <duty_cycle>
-     - Duty cycle in percent (two decimal digits, between 01 and 99).
+     - Duty cycle in percent (two decimal digits, between 01 and 90).
    * - start_rx
      -
      - Start RX.

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -294,8 +294,8 @@ static int cmd_duty_cycle_set(const struct shell *shell, size_t argc,
 
 	duty_cycle = atoi(argv[1]);
 
-	if (duty_cycle > 100) {
-		shell_error(shell, "Duty cycle must be between 1 and 99.");
+	if (duty_cycle > 90) {
+		shell_error(shell, "Duty cycle must be between 1 and 90.");
 		return -EINVAL;
 	}
 
@@ -1308,7 +1308,7 @@ SHELL_CMD_REGISTER(transmit_pattern,
 		   cmd_transmit_pattern_set);
 SHELL_CMD_REGISTER(start_duty_cycle_modulated_tx, NULL,
 		   "Duty cycle in percent (two decimal digits, between 01 and "
-		   "99) <duty_cycle>", cmd_duty_cycle_set);
+		   "90) <duty_cycle>", cmd_duty_cycle_set);
 SHELL_CMD_REGISTER(parameters_print, NULL,
 		   "Print current delay, channel and so on",
 		   cmd_print);


### PR DESCRIPTION
The total payload size is used to set the duty cycles.
Fast ramp-up is enabled for all modes.
And the range of duty_cycle is limited.
Radio off time must be greater than ramp-up time.
