### PR TITLE
fix: tests: Prevent hanging tests waiting for nonexistent device

### DIFF
--- a/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
@@ -2,5 +2,6 @@ tests:
   zigbee.osif.serial.async:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: osif_serial
+    harness: ztest
     harness_config:
       fixture: shorted_uart_1

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
@@ -2,5 +2,6 @@ tests:
   zigbee.osif.serial.basic:
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     tags: osif_serial
+    harness: ztest
     harness_config:
       fixture: shorted_uart_1


### PR DESCRIPTION
Test hangs waiting for device with harness forever.
Such test should be filtered out and not executed,
as there is no such harness connected (not indicated in HW map).
Due to twister issue, harness filtering will work only when
'harness:' is provided explicit.

Signed-off-by: Piotr Kosycarz <piotr.kosycarz@nordicsemi.no>