### PR TITLE
ci: docbuild: extend version regex

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -89,7 +89,7 @@ jobs:
             echo "publish2 dev PR-${{ github.event.number }} __FILE__" > monitor.txt
             echo "${{ github.event.number }}" > pr.txt
           else
-            VERSION_REGEX="^v([0-9\.]+)$"
+            VERSION_REGEX="^v([0-9a-z\.\-]+)$"
             if [[ ${GITHUB_REF#refs/tags/} =~ $VERSION_REGEX ]]; then
               VERSION=${BASH_REMATCH[1]}
             elif [[ ${GITHUB_REF#refs/heads/} == "main" ]]; then


### PR DESCRIPTION
Extend the version regex to include a-z and '-' characters. This adds
support for tags like v1.9.99-dev1, previously ignored.