### PR TITLE
applications: nrf5340_audio: Fix underrun condition

### DIFF
--- a/applications/nrf5340_audio/src/modules/audio_i2s.c
+++ b/applications/nrf5340_audio/src/modules/audio_i2s.c
@@ -114,7 +114,9 @@ void audio_i2s_set_next_buf(const uint8_t *tx_buf, uint32_t *rx_buf)
 {
 	__ASSERT_NO_MSG(state == AUDIO_I2S_STATE_STARTED);
 	__ASSERT_NO_MSG(rx_buf != NULL);
+#if (CONFIG_STREAM_BIDIRECTIONAL || (CONFIG_AUDIO_DEV == HEADSET))
 	__ASSERT_NO_MSG(tx_buf != NULL);
+#endif /* (CONFIG_STREAM_BIDIRECTIONAL || (CONFIG_AUDIO_DEV == HEADSET)) */
 
 	const nrfx_i2s_buffers_t i2s_buf = { .p_rx_buffer = rx_buf,
 					     .p_tx_buffer = (uint32_t *)tx_buf };
@@ -129,7 +131,9 @@ void audio_i2s_start(const uint8_t *tx_buf, uint32_t *rx_buf)
 {
 	__ASSERT_NO_MSG(state == AUDIO_I2S_STATE_IDLE);
 	__ASSERT_NO_MSG(rx_buf != NULL);
+#if (CONFIG_STREAM_BIDIRECTIONAL || (CONFIG_AUDIO_DEV == HEADSET))
 	__ASSERT_NO_MSG(tx_buf != NULL);
+#endif /* (CONFIG_STREAM_BIDIRECTIONAL || (CONFIG_AUDIO_DEV == HEADSET)) */
 
 	const nrfx_i2s_buffers_t i2s_buf = { .p_rx_buffer = rx_buf,
 					     .p_tx_buffer = (uint32_t *)tx_buf };


### PR DESCRIPTION
When running an unidirectional stream with I2S as audio source, the I2S TX on the gateway is constantly in underrun condition. To remedy this, the tx buffer is set to NULL when initializing I2S