### PR TITLE
doc: remove reference to legacy overlay file

### DIFF
--- a/doc/nrf/ug_thread_tools.rst
+++ b/doc/nrf/ug_thread_tools.rst
@@ -87,13 +87,13 @@ To program the nRF device with the RCP application, complete the following steps
 
          .. code-block:: console
 
-            west build -p always -b nrf52840dongle_nrf52840 nrf/samples/openthread/coprocessor/ -- -DOVERLAY_CONFIG="overlay-rcp.conf overlay-usb.conf" -DDTC_OVERLAY_FILE="usb.overlay"
+            west build -p always -b nrf52840dongle_nrf52840 nrf/samples/openthread/coprocessor/ -- -DOVERLAY_CONFIG="overlay-usb.conf" -DDTC_OVERLAY_FILE="usb.overlay"
 
       .. tab:: nRF52840 Development Kit (UART transport)
 
          .. code-block:: console
 
-            west build -p always -b nrf52840dk_nrf52840 nrf/samples/openthread/coprocessor/ -- -DOVERLAY_CONFIG="overlay-rcp.conf"
+            west build -p always -b nrf52840dk_nrf52840 nrf/samples/openthread/coprocessor/
 
 #. Depending on the hardware platform, complete the following steps:
 


### PR DESCRIPTION
`overlay-rcp.conf` was removed.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>