### PR TITLE
manifest: Bump nrxlib revision + osif button init fix [KRKNWK- 13598]

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -72,6 +72,7 @@ Zigbee
     This implementation must not be used in production.
     It is meant to be used only for debugging purposes.
   * Documentation page about :ref:`ug_zigbee_commissioning`.
+  * Experimental support for Zigbee Green Power Combo Basic functionality.
 
 * Updated :ref:`Zigbee shell library <lib_zigbee_shell>`.
   For details, see `Libraries for Zigbee`_.

--- a/subsys/zigbee/osif/zb_nrf_led_button.c
+++ b/subsys/zigbee/osif/zb_nrf_led_button.c
@@ -189,13 +189,20 @@ void zb_osif_button_cb(zb_uint8_t arg)
 
 zb_bool_t zb_setup_buttons_cb(zb_callback_t cb)
 {
-	int err = dk_buttons_init(button_handler);
+	static bool is_init;
+	int err;
+
+	if (is_init) {
+		return ZB_TRUE;
+	}
+	err = dk_buttons_init(button_handler);
 
 	if (err) {
 		LOG_ERR("Cannot init buttons (err: %d)", err);
 
 		return ZB_FALSE;
 	}
+	is_init = true;
 
 	return ZB_TRUE;
 }

--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 5a88e0c14dbaf6233100c2b4827bd83545ae0da2
+      revision: 410ee7791eb26ff28607b4b1a7b24cac451f91f3
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
- Fixes zigbee osif button init function
- Updates nrxlib revision to include changes inthe zboss library.