### PR TITLE
ci: matter: verify building with FFS feature enabled

### DIFF
--- a/samples/matter/light_bulb/sample.yaml
+++ b/samples/matter/light_bulb/sample.yaml
@@ -35,3 +35,11 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: ci_build
+  sample.matter.light_bulb.ffs:
+    build_only: true
+    extra_args: CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y CONFIG_CHIP_ROTATING_DEVICE_ID=y CONFIG_CHIP_DEVICE_TYPE=257
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    tags: ci_build


### PR DESCRIPTION
Add build variant to Matter Light Bulb with FFS feature enabled.

Signed-off-by: Lukasz Duda <lukasz.duda@nordicsemi.no>