### PR TITLE
applications: nrf5340_audio: Change start tone freq and amplitude

### DIFF
--- a/applications/nrf5340_audio/src/main.c
+++ b/applications/nrf5340_audio/src/main.c
@@ -210,7 +210,7 @@ void main(void)
 	ret = streamctrl_start();
 	ERR_CHK(ret);
 
-	ret = audio_datapath_tone_play(1000, 400, 1);
+	ret = audio_datapath_tone_play(440, 500, 0.2);
 	ERR_CHK(ret);
 
 	while (1) {


### PR DESCRIPTION
- Change amplitude from 1 to 0.2 to stop ears from bleeding
- Change frequency from 400 to 440 to have a pure A

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>