### PR TITLE
esb: fix CRC setup configuration

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -83,6 +83,11 @@ Zigbee
 
 See `Zigbee samples`_ for the list of changes for the Zigbee samples.
 
+ESB
+---
+
+* Fixed the ``update_radio_crc()`` function in order to correctly configure the CRC's registers (8 bits, 16 bits, or none).
+
 Applications
 ============
 

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -408,23 +408,22 @@ static bool update_radio_crc(void)
 	case ESB_CRC_16BIT:
 		NRF_RADIO->CRCINIT = 0xFFFFUL;  /* Initial value */
 		NRF_RADIO->CRCPOLY = 0x11021UL; /* CRC poly: x^16+x^12^x^5+1 */
+		NRF_RADIO->CRCCNF = ESB_CRC_16BIT << RADIO_CRCCNF_LEN_Pos;
 		break;
 
 	case ESB_CRC_8BIT:
 		NRF_RADIO->CRCINIT = 0xFFUL;  /* Initial value */
 		NRF_RADIO->CRCPOLY = 0x107UL; /* CRC poly: x^8+x^2^x^1+1 */
+		NRF_RADIO->CRCCNF = ESB_CRC_8BIT << RADIO_CRCCNF_LEN_Pos;
 		break;
 
 	case ESB_CRC_OFF:
+		NRF_RADIO->CRCCNF = ESB_CRC_OFF << RADIO_CRCCNF_LEN_Pos;
 		break;
 
 	default:
 		return false;
 	}
-
-	NRF_RADIO->CRCINIT = 0xFFFFUL;  /* Initial value */
-	NRF_RADIO->CRCPOLY = 0x11021UL; /* CRC poly: x^16+x^12^x^5+1 */
-	NRF_RADIO->CRCCNF = ESB_CRC_16BIT << RADIO_CRCCNF_LEN_Pos;
 
 	return true;
 }


### PR DESCRIPTION
Set the CRC's register properly (16 bits, 8 bits, none)