### PR TITLE
applications: nrf5340_audio: Change name from dsp to hw_codec

### DIFF
--- a/applications/nrf5340_audio/src/drivers/cs47l63_comm.c
+++ b/applications/nrf5340_audio/src/drivers/cs47l63_comm.c
@@ -26,9 +26,12 @@ LOG_MODULE_REGISTER(CS47L63, CONFIG_LOG_CS47L63_LEVEL);
 /* Delay the processing thread to allow interrupts to settle after boot */
 #define CS47L63_PROCESS_THREAD_DELAY_MS 10
 
-static const struct gpio_dt_spec dsp_gpio = GPIO_DT_SPEC_GET(DT_NODELABEL(dsp_gpio_in), gpios);
-static const struct gpio_dt_spec dsp_irq = GPIO_DT_SPEC_GET(DT_NODELABEL(dsp_irq_in), gpios);
-static const struct gpio_dt_spec dsp_reset = GPIO_DT_SPEC_GET(DT_NODELABEL(dsp_reset_out), gpios);
+static const struct gpio_dt_spec hw_codec_gpio =
+	GPIO_DT_SPEC_GET(DT_NODELABEL(hw_codec_gpio_in), gpios);
+static const struct gpio_dt_spec hw_codec_irq =
+	GPIO_DT_SPEC_GET(DT_NODELABEL(hw_codec_irq_in), gpios);
+static const struct gpio_dt_spec hw_codec_reset =
+	GPIO_DT_SPEC_GET(DT_NODELABEL(hw_codec_reset_out), gpios);
 
 const static struct device *cirrus_dev = DEVICE_DT_GET(DT_BUS(DT_NODELABEL(cs47l63)));
 const static struct device *gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
@@ -108,7 +111,7 @@ static void cs47l63_comm_pin_int_handler(const struct device *gpio_port, struct 
 		ERR_CHK_MSG(-ENODEV, "No callback registered");
 	}
 
-	if (pins == BIT(dsp_irq.pin)) {
+	if (pins == BIT(hw_codec_irq.pin)) {
 		bsp_callback(BSP_STATUS_OK, bsp_callback_arg);
 		k_sem_give(&sem_cs47l63);
 	}
@@ -320,8 +323,8 @@ static void cs47l63_comm_thread(void *cs47l63_driver, void *dummy2, void *dummy3
 	}
 }
 
-static cs47l63_bsp_config_t bsp_config = { .bsp_reset_gpio_id = dsp_reset.pin,
-					   .bsp_int_gpio_id = dsp_irq.pin,
+static cs47l63_bsp_config_t bsp_config = { .bsp_reset_gpio_id = hw_codec_reset.pin,
+					   .bsp_int_gpio_id = hw_codec_irq.pin,
 					   .cp_config.bus_type = CS47L63_BUS_TYPE_SPI,
 					   .cp_config.spi_pad_len = 4,
 					   .notification_cb = &notification_callback,
@@ -347,32 +350,32 @@ int cs47l63_comm_init(cs47l63_t *cs47l63_driver)
 		return -ENXIO;
 	}
 
-	if (!device_is_ready(dsp_gpio.port)) {
+	if (!device_is_ready(hw_codec_gpio.port)) {
 		LOG_ERR("GPIO is not ready!");
 		return -ENXIO;
 	}
 
-	ret = gpio_pin_configure_dt(&dsp_gpio, GPIO_INPUT);
+	ret = gpio_pin_configure_dt(&hw_codec_gpio, GPIO_INPUT);
 	if (ret) {
 		return ret;
 	}
 
-	if (!device_is_ready(dsp_irq.port)) {
+	if (!device_is_ready(hw_codec_irq.port)) {
 		LOG_ERR("GPIO is not ready!");
 		return -ENXIO;
 	}
 
-	ret = gpio_pin_configure_dt(&dsp_irq, GPIO_INPUT);
+	ret = gpio_pin_configure_dt(&hw_codec_irq, GPIO_INPUT);
 	if (ret) {
 		return ret;
 	}
 
-	if (!device_is_ready(dsp_reset.port)) {
+	if (!device_is_ready(hw_codec_reset.port)) {
 		LOG_ERR("GPIO is not ready!");
 		return -ENXIO;
 	}
 
-	ret = gpio_pin_configure_dt(&dsp_reset, GPIO_OUTPUT);
+	ret = gpio_pin_configure_dt(&hw_codec_reset, GPIO_OUTPUT);
 	if (ret) {
 		return ret;
 	}

--- a/applications/nrf5340_audio/src/modules/hw_codec.c
+++ b/applications/nrf5340_audio/src/modules/hw_codec.c
@@ -25,7 +25,8 @@ LOG_MODULE_REGISTER(HW_CODEC, CONFIG_LOG_HW_CODEC_LEVEL);
 #define HW_CODEC_SELECT_DELAY_MS 2
 
 static cs47l63_t cs47l63_driver;
-static const struct gpio_dt_spec dsp_sel = GPIO_DT_SPEC_GET(DT_NODELABEL(dsp_sel_out), gpios);
+static const struct gpio_dt_spec hw_codec_sel =
+	GPIO_DT_SPEC_GET(DT_NODELABEL(hw_codec_sel_out), gpios);
 
 /**@brief Write to multiple registers in CS47L63
  */
@@ -60,11 +61,11 @@ static int hw_codec_on_board_set(void)
 {
 	int ret;
 
-	if (!device_is_ready(dsp_sel.port)) {
+	if (!device_is_ready(hw_codec_sel.port)) {
 		return -ENXIO;
 	}
 
-	ret = gpio_pin_configure_dt(&dsp_sel, GPIO_OUTPUT_LOW);
+	ret = gpio_pin_configure_dt(&hw_codec_sel, GPIO_OUTPUT_LOW);
 	if (ret) {
 		return ret;
 	}

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_cpunet_reset.c
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_cpunet_reset.c
@@ -60,29 +60,29 @@ static int core_config(void)
 	}
 
 	/* Set on-board DSP/HW codec as default */
-	static const struct gpio_dt_spec dsp_sel =
-		GPIO_DT_SPEC_GET(DT_NODELABEL(dsp_sel_out), gpios);
+	static const struct gpio_dt_spec hw_codec_sel =
+		GPIO_DT_SPEC_GET(DT_NODELABEL(hw_codec_sel_out), gpios);
 
-	if (!device_is_ready(dsp_sel.port)) {
+	if (!device_is_ready(hw_codec_sel.port)) {
 		LOG_ERR("GPIO is not ready!");
 		return -ENXIO;
 	}
 
-	ret = gpio_pin_configure_dt(&dsp_sel, GPIO_OUTPUT_LOW);
+	ret = gpio_pin_configure_dt(&hw_codec_sel, GPIO_OUTPUT_LOW);
 	if (ret) {
 		return ret;
 	}
 
 	/* Pull the CS47L63 reset line to high (this pin is active low) */
-	static const struct gpio_dt_spec dsp_reset =
-		GPIO_DT_SPEC_GET(DT_NODELABEL(dsp_reset_out), gpios);
+	static const struct gpio_dt_spec hw_codec_reset =
+		GPIO_DT_SPEC_GET(DT_NODELABEL(hw_codec_reset_out), gpios);
 
-	if (!device_is_ready(dsp_reset.port)) {
+	if (!device_is_ready(hw_codec_reset.port)) {
 		LOG_ERR("GPIO is not ready!");
 		return -ENXIO;
 	}
 
-	ret = gpio_pin_configure_dt(&dsp_reset, GPIO_OUTPUT_HIGH);
+	ret = gpio_pin_configure_dt(&hw_codec_reset, GPIO_OUTPUT_HIGH);
 	if (ret) {
 		return ret;
 	}

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_shared.dts
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_shared.dts
@@ -66,31 +66,31 @@ leds:	leds {
 
 	nrf5340_audio_dk {
 		compatible = "gpio-keys";
-		dsp_gpio_in: dsp_gpio_in {
+		hw_codec_gpio_in: hw_codec_gpio_in {
 			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
-			label = "GPIO from DSP/Codec";
+			label = "GPIO from HW codec";
 		};
 
-		dsp_irq_in: dsp_irq_in {
+		hw_codec_irq_in: hw_codec_irq_in {
 			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
-			label = "Interrupt from DSP/Codec";
+			label = "Interrupt from HW codec";
 		};
 
-		dsp_reset_out: dsp_reset_out {
+		hw_codec_reset_out: hw_codec_reset_out {
 			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
-			label = "Reset DSP/Codec";
+			label = "Reset HW codec";
 		};
 
-		dsp_sel_out: dsp_sel_out {
+		hw_codec_sel_out: hw_codec_sel_out {
 			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
-			label = "DSP selector. Low selects OB DSP/Codec, high \
-				 selects external DSP/Codec";
+			label = "HW codec selector. Low selects OB HW codec, high \
+				 selects external HW codec";
 		};
 
 		spi_sel_in: spi_sel_in {
 			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
-			label = "SPI select in. High = nRF SPI to DSP/Codec. \
-				 Low = FTDI to DSP/Codec";
+			label = "SPI select in. High = nRF SPI to HW codec. \
+				 Low = FTDI to HW codec";
 		};
 
 		pmic_iset_out: pmic_iset_out {


### PR DESCRIPTION
- Change gpio names from using dsp to hw_codec

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>