### PR TITLE
manifest: Zephyr upmerge with ipc_service changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 240c7b9a691f6bcee824d1b26a40a368a916bb05
+      revision: pull/788/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Changed default value of IPC priority which fixes an issue with IPC's priority in the Matter Network.
