### PR TITLE
tests: Remove _ns boards from bootloader tests (including fprotect)

### DIFF
--- a/tests/drivers/fprotect/negative/testcase.yaml
+++ b/tests/drivers/fprotect/negative/testcase.yaml
@@ -1,12 +1,11 @@
 tests:
   drivers.fprotect.negative:
     platform_allow: nrf9160dk_nrf9160 nrf52dk_nrf52832
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf51dk_nrf51422
+      nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf51dk_nrf51422
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf52dk_nrf52832
       - nrf5340dk_nrf5340_cpuapp
-      - nrf5340dk_nrf5340_cpuapp_ns
       - nrf52840dk_nrf52840
       - nrf51dk_nrf51422
     tags: b0 fprotect ignore_faults

--- a/tests/drivers/fprotect/positive/testcase.yaml
+++ b/tests/drivers/fprotect/positive/testcase.yaml
@@ -1,12 +1,11 @@
 tests:
   drivers.fprotect.positive:
     platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
       - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
-      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0 fprotect

--- a/tests/subsys/bootloader/bl_crypto/testcase.yaml
+++ b/tests/subsys/bootloader/bl_crypto/testcase.yaml
@@ -1,13 +1,11 @@
 tests:
   bootloader.bl_crypto:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf9160dk_nrf9160 nrf51dk_nrf51422
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
+      nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
       - nrf9160dk_nrf9160
-      - nrf9160dk_nrf9160_ns
       - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
-      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0

--- a/tests/subsys/bootloader/bl_storage/testcase.yaml
+++ b/tests/subsys/bootloader/bl_storage/testcase.yaml
@@ -1,12 +1,9 @@
 tests:
   bootloader.bl_storage:
-    platform_allow: nrf9160dk_nrf9160 nrf9160dk_nrf9160_ns
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+    platform_allow: nrf9160dk_nrf9160 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf9160dk_nrf9160
-      - nrf9160dk_nrf9160_ns
       - nrf5340dk_nrf5340_cpuapp
-      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0
     harness: console
     harness_config:

--- a/tests/subsys/bootloader/bl_validation/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation/testcase.yaml
@@ -1,12 +1,11 @@
 tests:
   bootloader.bl_validation:
     platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
       - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
-      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0 bl_validation

--- a/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation_neg/testcase.yaml
@@ -1,11 +1,10 @@
 tests:
   bootloader.bl_validation.negative:
     platform_allow: nrf9160dk_nrf9160
-      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns
+      nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
-      - nrf5340dk_nrf5340_cpuapp_ns
     tags: b0 bl_validation negative bl_validation_negative
     harness: console
     harness_config:


### PR DESCRIPTION
They don't work for these tests. They were added by mistake during
various porting efforts.

Ref: NCSDK-14834
Ref: NCSDK-14838
Ref: NCSDK-14840

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>