### PR TITLE
net: lib: nrf_cloud: update nrf cloud host name

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -465,6 +465,7 @@ Libraries for networking
         The data is now sent to the application even if no ``"config"`` section is present.
       * The application can now send shadow updates earlier in the connection process.
       * nRF Cloud error message responses to location service MQTT requests are now handled.
+      * The value of the :kconfig:option:`NRF_CLOUD_HOST_NAME` option is now "mqtt.nrfcloud.com".
 
     * Fixed the validation of bootloader FOTA updates.
 

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -29,7 +29,9 @@ if NRF_CLOUD_MQTT || NRF_CLOUD_REST || NRF_CLOUD_PGPS || MODEM_JWT
 
 config NRF_CLOUD_HOST_NAME
 	string "nRF Cloud server hostname"
-	default "a2n7tk1kp18wix-ats.iot.us-east-1.amazonaws.com"
+	default "mqtt.nrfcloud.com"
+	help
+	  Used for MQTT and JITP performed with REST
 
 config NRF_CLOUD_SEC_TAG
 	int "Security tag to use for nRF Cloud connection"


### PR DESCRIPTION
The value of Kconfig option  NRF_CLOUD_HOST_NAME is now
simply "mqtt.nrfcloud.com"
IRIS-4190

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>