### PR TITLE
fix: samples: matter: Fixed fails during reboot

### DIFF
--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/app.overlay
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/app.overlay
@@ -16,6 +16,8 @@
  * image data.
  */
 
+ #include <dt-bindings/ipc_service/static_vrings.h>
+
 / {
 	soc {
 		/* Add a flash controller which has the compatible
@@ -70,6 +72,10 @@
 	aliases {
 		buzzer-pwm = &pwm1;
 	};
+};
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
 };
 
 &zephyr_udc0 {

--- a/samples/matter/light_bulb/configuration/nrf5340dk_nrf5340_cpuapp/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/configuration/nrf5340dk_nrf5340_cpuapp/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <dt-bindings/ipc_service/static_vrings.h>
+
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
@@ -71,6 +73,10 @@
 		};
 	};
 
+};
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
 };
 
 &pwm0 {

--- a/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <dt-bindings/ipc_service/static_vrings.h>
+
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
@@ -55,4 +57,8 @@
 		};
 	};
 
+};
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
 };

--- a/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <dt-bindings/ipc_service/static_vrings.h>
+
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
@@ -52,6 +54,10 @@
 			};
 		};
 	};
+};
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/samples/matter/template/configuration/nrf5340dk_nrf5340_cpuapp/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/configuration/nrf5340dk_nrf5340_cpuapp/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <dt-bindings/ipc_service/static_vrings.h>
+
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
@@ -52,6 +54,10 @@
 			};
 		};
 	};
+};
+
+&ipc0 {
+    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */


### PR DESCRIPTION
An hardfault was observed during the recovery
of persistent storage data after reset after Zephyr's upmerge.
The solution was to set a lower priority for ipc_service for all samples. 

This is only a workaround before zephyr's upmerge.
