### PR TITLE
samples: modem_shell: Disable modem traces before disabling UART1

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -227,6 +227,13 @@ nRF9160 samples
         This includes several new fields in the PVT notification and a command to query the expiry times of assistance data.
       * Support for the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_STORAGE_PARTITION` option.
 
+    * Updated:
+
+      * The behavior of this sample when built with the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_MEDIUM_UART` option enabled, is changed as follows:
+
+        * When disabling of UART is requested either by a shell command or by a button press, modem traces are disabled before disabling UART1.
+        * When the UART1 is re-enabled (either after timer expiry or button press), the modem traces are also re-enabled.
+
   * :ref:`nrf_cloud_rest_fota` sample:
 
     * Updated:

--- a/samples/nrf9160/modem_shell/src/uart/uart.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart.c
@@ -21,17 +21,8 @@ static void uart1_set_enable(bool enable)
 {
 	if (enable) {
 		NRF_UARTE1_NS->ENABLE = UARTE_ENABLE_ENABLE_Enabled;
-		NRF_UARTE1_NS->TASKS_STARTRX = 1;
-		NRF_UARTE1_NS->TASKS_STARTTX = 1;
 	} else {
-		/* Stop TX and RX operation and wait for the corresponding events to be generated
-		 * before disabling the peripheral.
-		 * Ref: https://infocenter.nordicsemi.com/topic/ps_nrf9160/uarte.html
-		 */
-		NRF_UARTE1_NS->TASKS_STOPRX = 1;
-		while (NRF_UARTE1_NS->EVENTS_RXTO == 0) {
-			/* Wait until RX Timeout event is raised. */
-		}
+		/* Stop any ongoing transmission.*/
 		NRF_UARTE1_NS->TASKS_STOPTX = 1;
 		while (NRF_UARTE1_NS->EVENTS_TXSTOPPED == 0) {
 			/* Wait until TX Stopped event is raised. */

--- a/samples/nrf9160/modem_shell/src/uart/uart_shell.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart_shell.c
@@ -13,10 +13,12 @@
 #include <shell/shell.h>
 #include <shell/shell_uart.h>
 #include <modem/lte_lc.h>
+#include <modem/nrf_modem_lib_trace.h>
 
 #include "uart_shell.h"
 #include "uart.h"
 #include "mosh_print.h"
+
 
 bool uart_disable_during_sleep_requested;
 
@@ -34,18 +36,35 @@ static int print_help(const struct shell *shell, size_t argc, char **argv)
 	return ret;
 }
 
-void uart_reenable_timer_handler(struct k_timer *timer)
+static void uart_disable_handler(struct k_work *work)
 {
-	ARG_UNUSED(timer);
-	enable_uarts();
+#ifdef CONFIG_NRF_MODEM_LIB_TRACE_MEDIUM_UART
+	int err = nrf_modem_lib_trace_stop();
 
-	/* Use printk instead of mosh_print() as mosh_print() uses mutexes and hence cant be used
-	 * within an ISR.
-	 */
-	printk("UARTs enabled\n");
+	if (err) {
+		mosh_print("nrf_modem_lib_trace_stop failed with err = %d.", err);
+		return;
+	}
+#endif
+	disable_uarts();
 }
 
-static K_TIMER_DEFINE(uart_reenable_timer, uart_reenable_timer_handler, NULL);
+static void uart_enable_handler(struct k_work *work)
+{
+	enable_uarts();
+	mosh_print("UARTs enabled\n");
+#ifdef CONFIG_NRF_MODEM_LIB_TRACE_MEDIUM_UART
+	int err = nrf_modem_lib_trace_start(NRF_MODEM_LIB_TRACE_ALL);
+
+	if (err) {
+		mosh_print("nrf_modem_lib_trace_start failed with err = %d.", err);
+	}
+#endif
+}
+
+static K_WORK_DEFINE(uart_disable_work, &uart_disable_handler);
+
+static K_WORK_DELAYABLE_DEFINE(uart_enable_work, &uart_enable_handler);
 
 static int cmd_uart_disable(const struct shell *shell, size_t argc, char **argv)
 {
@@ -62,12 +81,11 @@ static int cmd_uart_disable(const struct shell *shell, size_t argc, char **argv)
 	} else {
 		mosh_print("disable: disabling UARTs indefinitely");
 	}
-
 	k_sleep(K_MSEC(500)); /* allow little time for printing the notification */
-	disable_uarts();
+	k_work_submit(&uart_disable_work);
 
 	if (sleep_time > 0) {
-		k_timer_start(&uart_reenable_timer, K_SECONDS(sleep_time), K_NO_WAIT);
+		k_work_schedule(&uart_enable_work, K_SECONDS(sleep_time));
 	}
 
 	return 0;
@@ -77,11 +95,9 @@ void uart_toggle_power_state_at_event(const struct lte_lc_evt *const evt)
 {
 	if (evt->type == LTE_LC_EVT_MODEM_SLEEP_ENTER) {
 		mosh_print("Modem sleep enter: disabling UARTs requested");
-		k_sleep(K_MSEC(500)); /* allow little time for printing the notification */
-		disable_uarts();
+		k_work_submit(&uart_disable_work);
 	} else if (evt->type == LTE_LC_EVT_MODEM_SLEEP_EXIT) {
-		enable_uarts();
-		mosh_print("UARTs enabled");
+		k_work_schedule(&uart_enable_work, K_NO_WAIT);
 	}
 }
 
@@ -104,22 +120,9 @@ void uart_toggle_power_state(void)
 	}
 
 	if (uart0_power_state == PM_DEVICE_STATE_ACTIVE) {
-		mosh_print("Disabling UARTs");
-
-		/* allow little time for printing the notification */
-		k_sleep(K_MSEC(500));
-
-		disable_uarts();
+		k_work_submit(&uart_disable_work);
 	} else {
-		enable_uarts();
-
-		mosh_print("UARTs enabled");
-
-		/* stop timer if uarts were disabled with command 'uart disable' */
-		k_timer_stop(&uart_reenable_timer);
-	}
-	if (err) {
-		mosh_print("Failed to change UART power state");
+		k_work_schedule(&uart_enable_work, K_NO_WAIT);
 	}
 }
 


### PR DESCRIPTION
- When UART is used as modem traces transport medium, the modem traces
need to be disabled before disabling UART. The modem traces need to be
reenabled after reenabling UART. This is done now.
- The enabling and disabling of modem traces cannot be done from an
interrupt context because they involve sending AT commands using the
nrf_modem_at_printf() which cannot be called from interrupt context.
Hence this is done from a work queue handler.
- Also removed the logic to stop RX when disabling UART1 because the
UART1 is not used for RX. The STARTTX is also not issued anymore when
enabling UART1 to avoid spurious transmissions.

Fixes MOSH-251.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>
Co-Authored-By: Gregers Gram Rygg <gregers.gram.rygg@nordicsemi.no>