### PR TITLE
Add at_host to nrf_cloud samples

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -222,6 +222,7 @@ nRF9160 samples
 
       * Enabled building of bootloader FOTA update files.
       * Corrected handling of the bootloader FOTA updates.
+      * Enabled the :ref:`lib_at_host` library to make it easier to update certificates.
 
   * :ref:`lwm2m_client` sample:
 
@@ -244,6 +245,11 @@ nRF9160 samples
   * :ref:`gnss_sample` sample:
 
     * Added support for the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_STORAGE_PARTITION` option.
+    * Enabled the :ref:`lib_at_host` library to make it easier to update certificates.
+
+  * :ref:`location_sample` sample:
+
+    * Enabled the :ref:`lib_at_host` library to make it easier to update certificates.
 
 OpenThread samples
 ------------------

--- a/samples/nrf9160/gnss/README.rst
+++ b/samples/nrf9160/gnss/README.rst
@@ -319,6 +319,7 @@ This sample uses the following |NCS| libraries:
 * :ref:`lib_nrf_cloud_pgps`
 * :ref:`lib_nrf_cloud_rest`
 * :ref:`supl_client`
+* :ref:`lib_at_host`
 
 It uses the following `sdk-nrfxlib`_ library:
 

--- a/samples/nrf9160/gnss/prj.conf
+++ b/samples/nrf9160/gnss/prj.conf
@@ -30,6 +30,10 @@ CONFIG_LTE_PSM_REQ_RAT="00000011"
 # Auto-connect should be left off as we want the application to control LTE
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=n
 
+# AT Host library - Used to send AT commands directy from an UART terminal and to allow
+#		    integration with nRF Connect for Desktop LTE Link monitor application.
+CONFIG_AT_HOST_LIBRARY=y
+
 # Networking
 CONFIG_NETWORKING=y
 CONFIG_NET_SOCKETS_OFFLOAD=y

--- a/samples/nrf9160/location/README.rst
+++ b/samples/nrf9160/location/README.rst
@@ -187,6 +187,7 @@ This sample uses the following |NCS| libraries:
 * :ref:`lib_location`
 * :ref:`lte_lc_readme`
 * :ref:`lib_date_time`
+* :ref:`lib_at_host`
 
 In addition, it uses the following sample:
 

--- a/samples/nrf9160/location/prj.conf
+++ b/samples/nrf9160/location/prj.conf
@@ -39,6 +39,11 @@ CONFIG_LTE_EDRX_REQ=y
 # Request PSM active time of 8 seconds.
 CONFIG_LTE_PSM_REQ_RAT="00000100"
 
+# AT Host library - Used to send AT commands directy from an UART terminal and to allow
+#		    integration with nRF Connect for Desktop LTE Link monitor application.
+CONFIG_UART_INTERRUPT_DRIVEN=y
+CONFIG_AT_HOST_LIBRARY=y
+
 # nRF Cloud (for A-GPS and cell location)
 CONFIG_NRF_CLOUD_REST=y
 CONFIG_NRF_CLOUD_AGPS=y

--- a/samples/nrf9160/nrf_cloud_rest_device_message/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_device_message/README.rst
@@ -115,3 +115,4 @@ This sample uses the following |NCS| libraries:
 * :ref:`lte_lc_readme`
 * :ref:`dk_buttons_and_leds_readme`
 * :ref:`modem_info_readme`
+* :ref:`lib_at_host`

--- a/samples/nrf9160/nrf_cloud_rest_device_message/prj.conf
+++ b/samples/nrf9160/nrf_cloud_rest_device_message/prj.conf
@@ -18,10 +18,14 @@ CONFIG_NET_NATIVE=n
 CONFIG_DK_LIBRARY=y
 
 # Modem/LTE Link
-CONFIG_NRF_MODEM_LIB_SYS_INIT=n
+CONFIG_NRF_MODEM_LIB_SYS_INIT=y
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_NETWORK_MODE_LTE_M=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=n
+
+# AT Host library - Used to send AT commands directy from an UART terminal and to allow
+#		    integration with nRF Connect for Desktop LTE Link monitor application.
+CONFIG_AT_HOST_LIBRARY=y
 
 # System
 CONFIG_HEAP_MEM_POOL_SIZE=8192

--- a/samples/nrf9160/nrf_cloud_rest_device_message/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_device_message/src/main.c
@@ -288,7 +288,11 @@ static int init(void)
 	}
 
 	/* Init modem */
-	modem_lib_init_result = nrf_modem_lib_init(NORMAL_MODE);
+	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_SYS_INIT)) {
+		modem_lib_init_result = nrf_modem_lib_get_init_ret();
+	} else {
+		modem_lib_init_result = nrf_modem_lib_init(NORMAL_MODE);
+	}
 	if (modem_lib_init_result) {
 		LOG_ERR("Failed to initialize modem library: 0x%X", modem_lib_init_result);
 		return -EFAULT;

--- a/samples/nrf9160/nrf_cloud_rest_fota/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_fota/README.rst
@@ -117,3 +117,4 @@ This sample uses the following |NCS| libraries:
 * :ref:`lte_lc_readme`
 * :ref:`dk_buttons_and_leds_readme`
 * :ref:`modem_info_readme`
+* :ref:`lib_at_host`

--- a/samples/nrf9160/nrf_cloud_rest_fota/prj.conf
+++ b/samples/nrf9160/nrf_cloud_rest_fota/prj.conf
@@ -38,10 +38,15 @@ CONFIG_MPU_ALLOW_FLASH_WRITE=y
 CONFIG_DK_LIBRARY=y
 
 # Modem/LTE Link
-CONFIG_NRF_MODEM_LIB_SYS_INIT=n
+CONFIG_NRF_MODEM_LIB_SYS_INIT=y
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_NETWORK_MODE_LTE_M=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=n
+
+# AT Host library - Used to send AT commands directy from an UART terminal and to allow
+#		    integration with nRF Connect for Desktop LTE Link monitor application.
+CONFIG_AT_HOST_LIBRARY=y
+
 # Modem info
 CONFIG_MODEM_INFO=y
 CONFIG_MODEM_INFO_ADD_DEVICE=y

--- a/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
@@ -427,7 +427,11 @@ int init(void)
 		LOG_WRN("Failed to load settings, error: %d", err);
 	}
 
-	modem_lib_init_result = nrf_modem_lib_init(NORMAL_MODE);
+	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_SYS_INIT)) {
+		modem_lib_init_result = nrf_modem_lib_get_init_ret();
+	} else {
+		modem_lib_init_result = nrf_modem_lib_init(NORMAL_MODE);
+	}
 
 	/* This function may perform a reboot if a FOTA update is in progress */
 	process_pending_job();


### PR DESCRIPTION
Enable at_host library to nrf_cloud_rest_fota and nrf_cloud_rest_device_message samples.

This is to make it easier to update the certificates using LTE Link Monitor, if needed, without having to flash a different sample that does enable at_host first.