### PR TITLE
net: lib: lwm2m_client_utils: Simultaneous assistance methods

### DIFF
--- a/include/net/lwm2m_client_utils_location.h
+++ b/include/net/lwm2m_client_utils_location.h
@@ -40,7 +40,8 @@ struct gnss_agps_request_event {
 
 APP_EVENT_TYPE_DECLARE(gnss_agps_request_event);
 
-#elif defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL)
+#endif
+#if defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL)
 struct cell_location_request_event {
 	struct app_event_header header;
 };

--- a/subsys/net/lib/lwm2m_client_utils/Kconfig
+++ b/subsys/net/lib/lwm2m_client_utils/Kconfig
@@ -115,20 +115,22 @@ config LWM2M_CLIENT_UTILS_LOCATION_ASSIST_EVENTS
 
 if LWM2M_CLIENT_UTILS_LOCATION_ASSIST_OBJ_SUPPORT
 
-choice
-	default LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL
-	prompt "Select which method is used for device location"
-
 config LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL
 	bool "Use location based on current cell and possibly neighboring cells"
+	help
+	  Information of current cell and neighboring cells are sent to lwm2m server to
+	  obtain coarse location.
 
 config LWM2M_CLIENT_UTILS_LOCATION_ASSIST_AGPS
 	bool "Use location based on A-GPS"
+	help
+	  A-GPS assistance data is requested from lwm2m server and fed to the GNSS module
+	  after the data has been received.
 
-config LWM2M_CLIENT_UTILS_LOCATION_ASSIST_PGPS
-	bool "Use location based on P-GPS"
-
-endchoice
+config LWM2M_CLIENT_UTILS_LOCATION_ASSIST_AGPS_BUF_SIZE
+	int "Size of the buffer for storing the assistance data coming from server"
+	depends on LWM2M_CLIENT_UTILS_LOCATION_ASSIST_AGPS
+	default 4096
 
 endif # LWM2M_CLIENT_UTILS_LOCATION_ASSIST_OBJ_SUPPORT
 

--- a/subsys/net/lib/lwm2m_client_utils/location/location_event_handler.c
+++ b/subsys/net/lib/lwm2m_client_utils/location/location_event_handler.c
@@ -122,7 +122,8 @@ static bool event_handler(const struct app_event_header *eh)
 		handle_agps_request(event);
 		return true;
 	}
-#elif defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL)
+#endif
+#if defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL)
 	if (is_cell_location_request_event(eh)) {
 		handle_cell_location_event(true);
 		return true;
@@ -138,7 +139,8 @@ static bool event_handler(const struct app_event_header *eh)
 APP_EVENT_LISTENER(MODULE, event_handler);
 #if defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_AGPS)
 APP_EVENT_SUBSCRIBE(MODULE, gnss_agps_request_event);
-#elif defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL)
+#endif
+#if defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL)
 APP_EVENT_SUBSCRIBE(MODULE, cell_location_request_event);
 APP_EVENT_SUBSCRIBE(MODULE, cell_location_inform_event);
 #endif

--- a/subsys/net/lib/lwm2m_client_utils/location/location_events.c
+++ b/subsys/net/lib/lwm2m_client_utils/location/location_events.c
@@ -17,7 +17,8 @@ static void log_gnss_agps_request_event(const struct app_event_header *eh)
 APP_EVENT_TYPE_DEFINE(gnss_agps_request_event, log_gnss_agps_request_event, NULL,
 		      APP_EVENT_FLAGS_CREATE());
 
-#elif defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL)
+#endif
+#if defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_CELL)
 static void log_cell_location_request_event(const struct app_event_header *eh)
 {
 	APP_EVENT_MANAGER_LOG(eh, "got cell location request event");

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/location_assistance_obj.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/location_assistance_obj.c
@@ -55,8 +55,8 @@ static int32_t pgps_pred_interval;
 static int32_t pgps_start_gps_day;
 static int32_t pgps_start_gps_time_of_day;
 #if defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_AGPS)
-static char assist_buf[4096];
-static char assist_data[1024];
+static char assist_buf[CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSIST_AGPS_BUF_SIZE];
+static char assist_data[CONFIG_LWM2M_COAP_BLOCK_SIZE];
 #endif
 
 static int32_t result;


### PR DESCRIPTION
Allow using all assistance methods at the same time. The application
should then decide which assistance method it should be using and when.

Signed-off-by: Jarno Lamsa <jarno.lamsa@nordicsemi.no>