### PR TITLE
drivers: mpsl: clock: Add dependencies to CLOCK_CONTROL_MPSL

### DIFF
--- a/drivers/mpsl/clock_control/Kconfig
+++ b/drivers/mpsl/clock_control/Kconfig
@@ -7,5 +7,6 @@
 config CLOCK_CONTROL_MPSL
 	bool
 	depends on MPSL
+	depends on CLOCK_CONTROL
 	default y
 	select CLOCK_CONTROL_NRF_FORCE_ALT


### PR DESCRIPTION
The CLOCK_CONTROL_MPSL must be build only when CLOCK_CONTROL module is enabled.
Misconfiguration between the two configs may cause build errors.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>