### PR TITLE
lib: at_cmd_parser: Handle type double

### DIFF
--- a/include/modem/at_params.h
+++ b/include/modem/at_params.h
@@ -38,6 +38,8 @@ enum at_param_type {
 	AT_PARAM_TYPE_INVALID,
 	/** Parameter of type integer. */
 	AT_PARAM_TYPE_NUM_INT,
+	/** Parameter of type double. */
+	AT_PARAM_TYPE_NUM_DOUBLE,
 	/** Parameter of type string. */
 	AT_PARAM_TYPE_STRING,
 	/** Parameter of type array. */
@@ -50,6 +52,8 @@ enum at_param_type {
 union at_param_value {
 	/** Integer value. */
 	int64_t int_val;
+	/** Double value. */
+	double double_val;
 	/** String value. */
 	char *str_val;
 	/** Array of uint32_t */
@@ -122,6 +126,22 @@ void at_params_list_free(struct at_param_list *list);
  *           Otherwise, a (negative) error code is returned.
  */
 int at_params_int_put(const struct at_param_list *list, size_t index, int64_t value);
+
+/**
+ * @brief Add a parameter in the list at the specified index and assign it a
+ * double value.
+ *
+ * If a parameter exists at this index, it is replaced.
+ *
+ * @param[in] list      Parameter list.
+ * @param[in] index     Index in the list where to put the parameter.
+ * @param[in] value     Parameter value.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int at_params_double_put(const struct at_param_list *list, size_t index, double value);
+
 
 /**
  * @brief Add a parameter in the list at the specified index and assign it a
@@ -231,6 +251,20 @@ int at_params_unsigned_short_get(const struct at_param_list *list, size_t index,
  */
 int at_params_int_get(const struct at_param_list *list, size_t index,
 		      int32_t *value);
+
+
+/**
+ * @brief Get a parameter value as a double number.
+ *
+ * @param[in] list    Parameter list.
+ * @param[in] index   Parameter index in the list.
+ * @param[out] value  Parameter value.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int at_params_double_get(const struct at_param_list *list, size_t index,
+		      double *value);
 
 /**
  * @brief Get a parameter value as an unsigned integer number.

--- a/lib/at_cmd_parser/at_cmd_parser.c
+++ b/lib/at_cmd_parser/at_cmd_parser.c
@@ -272,12 +272,17 @@ static int at_parse_process_element(const char **str, int index,
 
 		tmpstr++;
 	} else if (state == NUMBER) {
-		char *next;
-		int64_t value = (int64_t)strtoll(tmpstr, &next, 10);
+		char *nextint, *nextdouble;
+		int64_t valueint = (int64_t)strtoll(tmpstr, &nextint, 10);
+		double valuedouble = strtod(tmpstr, &nextdouble);
 
-		tmpstr = next;
-
-		at_params_int_put(list, index, value);
+		if (nextint == nextdouble) {
+			at_params_int_put(list, index, valueint);
+			tmpstr = nextint;
+		} else {
+			at_params_double_put(list, index, valuedouble);
+			tmpstr = nextdouble;
+		}
 	} else if (state == SMS_PDU) {
 		const char *start_ptr = tmpstr;
 

--- a/lib/at_cmd_parser/at_params.c
+++ b/lib/at_cmd_parser/at_params.c
@@ -148,6 +148,26 @@ int at_params_int_put(const struct at_param_list *list, size_t index, int64_t va
 	return 0;
 }
 
+
+int at_params_double_put(const struct at_param_list *list, size_t index, double value)
+{
+	if (list == NULL || list->params == NULL) {
+		return -EINVAL;
+	}
+
+	struct at_param *param = at_params_get(list, index);
+
+	if (param == NULL) {
+		return -EINVAL;
+	}
+
+	at_param_clear(param);
+
+	param->type = AT_PARAM_TYPE_NUM_DOUBLE;
+	param->value.double_val = value;
+	return 0;
+}
+
 int at_params_string_put(const struct at_param_list *list, size_t index,
 			 const char *str, size_t str_len)
 {
@@ -295,6 +315,28 @@ int at_params_int_get(const struct at_param_list *list, size_t index,
 	}
 
 	*value = (int32_t)param->value.int_val;
+	return 0;
+}
+
+
+int at_params_double_get(const struct at_param_list *list, size_t index,
+		      double *value)
+{
+	if (list == NULL || list->params == NULL || value == NULL) {
+		return -EINVAL;
+	}
+
+	struct at_param *param = at_params_get(list, index);
+
+	if (param == NULL) {
+		return -EINVAL;
+	}
+
+	if (param->type != AT_PARAM_TYPE_NUM_DOUBLE) {
+		return -EINVAL;
+	}
+
+	*value = param->value.double_val;
 	return 0;
 }
 

--- a/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
@@ -275,6 +275,87 @@ static void test_params_string_parsing_teardown(void)
 	at_params_list_free(&test_list2);
 }
 
+static void test_params_gps_parsing_setup(void)
+{
+	at_params_list_init(&test_list2, TEST_PARAMS2);
+}
+
+static void test_params_gps_parsing(void)
+{
+	int ret;
+	double tmpdouble;
+	char tmpbuf[32];
+	const double DOUBLE_CMP_EPSILON = 0.00001;
+	uint32_t tmpbuf_len;
+
+	static const char at_cmd_agps[] = "AT+XGPS: 35.457417,139.625211,162.850952,15.621976,"
+		"1.418092,0.000000,\"2021-06-02 05:21:31\"";
+
+	ret = at_parser_params_from_str(at_cmd_agps, NULL, &test_list2);
+	zassert_true(ret == 0, "at_parser_params_from_str should return 0");
+
+	ret = at_params_valid_count_get(&test_list2);
+	zassert_true(ret == 8,
+		     "at_params_valid_count_get returns wrong valid count");
+
+	zassert_true(at_params_type_get(&test_list2, 0) == AT_PARAM_TYPE_STRING,
+		     "Param type at index 0 should be a string");
+	zassert_true(at_params_type_get(&test_list2, 1) ==
+							AT_PARAM_TYPE_NUM_DOUBLE,
+		     "Param type at index 1 should be a double");
+	zassert_true(at_params_type_get(&test_list2, 2) ==
+							AT_PARAM_TYPE_NUM_DOUBLE,
+		     "Param type at index 2 should be a double");
+	zassert_true(at_params_type_get(&test_list2, 3) ==
+							AT_PARAM_TYPE_NUM_DOUBLE,
+		     "Param type at index 3 should be a double");
+	zassert_true(at_params_type_get(&test_list2, 4) ==
+							AT_PARAM_TYPE_NUM_DOUBLE,
+		     "Param type at index 4 should be a double");
+	zassert_true(at_params_type_get(&test_list2, 5) ==
+							AT_PARAM_TYPE_NUM_DOUBLE,
+		     "Param type at index 4 should be a double");
+	zassert_true(at_params_type_get(&test_list2, 6) ==
+							AT_PARAM_TYPE_NUM_DOUBLE,
+		     "Param type at index 4 should be a double");
+	zassert_true(at_params_type_get(&test_list2, 7) ==
+							AT_PARAM_TYPE_STRING,
+		     "Param type at index 4 should be a string");
+
+	zassert_equal(0, at_params_double_get(&test_list2, 1, &tmpdouble),
+		      "Get double should not fail");
+	zassert_within(35.457417, tmpdouble, DOUBLE_CMP_EPSILON, "Double should be 35.457417");
+	zassert_equal(0, at_params_double_get(&test_list2, 2, &tmpdouble),
+		      "Get double should not fail");
+	zassert_within(139.625211, tmpdouble, DOUBLE_CMP_EPSILON, "Double should be 139.625211");
+	zassert_equal(0, at_params_double_get(&test_list2, 3, &tmpdouble),
+		      "Get double should not fail");
+	zassert_within(162.850952, tmpdouble, DOUBLE_CMP_EPSILON, "Double should be 162.850952");
+	zassert_equal(0, at_params_double_get(&test_list2, 4, &tmpdouble),
+		      "Get double should not fail");
+	zassert_within(15.621976, tmpdouble, DOUBLE_CMP_EPSILON, "Double should be 15.621976");
+	zassert_equal(0, at_params_double_get(&test_list2, 5, &tmpdouble),
+		      "Get double should not fail");
+	zassert_within(1.418092, tmpdouble, DOUBLE_CMP_EPSILON, "Double should be 1.418092");
+	zassert_equal(0, at_params_double_get(&test_list2, 6, &tmpdouble),
+		      "Get double should not fail");
+	zassert_within(0.000000, tmpdouble, DOUBLE_CMP_EPSILON, "Double should be 0.000000");
+	tmpbuf_len = sizeof(tmpbuf);
+	zassert_equal(0, at_params_string_get(&test_list2, 7,
+					      tmpbuf, &tmpbuf_len),
+		      "Get string should not fail");
+	zassert_equal(strlen("2021-06-02 05:21:31"), tmpbuf_len, "String length mismatch");
+	zassert_equal(0, memcmp("2021-06-02 05:21:31", tmpbuf, tmpbuf_len),
+		      "The string in tmpbuf should "
+		      "equal to 2021-06-02 05:21:31");
+
+}
+
+static void test_params_gps_parsing_teardown(void)
+{
+	at_params_list_free(&test_list2);
+}
+
 static void test_params_empty_params_setup(void)
 {
 	at_params_list_init(&test_list2, TEST_PARAMS2);
@@ -791,6 +872,10 @@ void test_main(void)
 				test_params_string_parsing,
 				test_params_string_parsing_setup,
 				test_params_string_parsing_teardown),
+			 ztest_unit_test_setup_teardown(
+				test_params_gps_parsing,
+				test_params_gps_parsing_setup,
+				test_params_gps_parsing_teardown),
 			 ztest_unit_test_setup_teardown(
 				test_params_empty_params,
 				test_params_empty_params_setup,

--- a/tests/lib/at_cmd_parser/at_params/src/main.c
+++ b/tests/lib/at_cmd_parser/at_params/src/main.c
@@ -180,6 +180,57 @@ static void test_params_put_get_int_teardown(void)
 	at_params_list_free(&test_list);
 }
 
+static void test_params_put_get_double_setup(void)
+{
+	at_params_list_init(&test_list, TEST_PARAMS);
+}
+
+static void test_params_put_get_double(void)
+{
+	double double_value;
+	const double DOUBLE_CMP_EPSILON = 0.00001;
+
+	/* Test list put. */
+
+	zassert_equal(-EINVAL, at_params_double_put(NULL, 0, 1),
+		      "at_params_double_put should return -EINVAL");
+
+	zassert_equal(-EINVAL, at_params_double_put(NULL, TEST_PARAMS, 1),
+		      "at_params_double_put should return -EINVAL");
+
+	/* Populate AT param list. */
+
+	zassert_equal(0, at_params_double_put(&test_list, 1, 56.2594),
+		      "at_params_double_put should return 0");
+
+	zassert_equal(0, at_params_double_put(&test_list, 2, -56.2594),
+		      "at_params_double_put should return 0");
+
+	/* Test unpopulated list entry. */
+
+	zassert_equal(-EINVAL, at_params_double_get(&test_list, 0, &double_value),
+		      "at_params_double_get should return -EINVAL");
+
+	/* Test first list entry. */
+
+	zassert_equal(0, at_params_double_get(&test_list, 1, &double_value),
+		      "at_params_double_get should return 0");
+	zassert_within(56.2594, double_value, DOUBLE_CMP_EPSILON,
+			  "at_params_double_get should get 56.2594");
+
+	/* Test second list entry. */
+
+	zassert_equal(0, at_params_double_get(&test_list, 2, &double_value),
+			  "at_params_double_get should return 0");
+	zassert_within(-56.2594, double_value, DOUBLE_CMP_EPSILON,
+			  "at_params_double_get should get -56.2594");
+}
+
+static void test_params_put_get_double_teardown(void)
+{
+	at_params_list_free(&test_list);
+}
+
 static void test_params_put_get_string_setup(void)
 {
 	at_params_list_init(&test_list, TEST_PARAMS);
@@ -513,6 +564,10 @@ void test_main(void)
 					test_params_put_get_int,
 					test_params_put_get_int_setup,
 					test_params_put_get_int_teardown),
+			 ztest_unit_test_setup_teardown(
+					test_params_put_get_double,
+					test_params_put_get_double_setup,
+					test_params_put_get_double_teardown),
 			 ztest_unit_test_setup_teardown(
 					test_params_put_get_string,
 					test_params_put_get_string_setup,


### PR DESCRIPTION
Allow the library [AT command parser](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/modem/at_cmd_parser.html) to handle the double type. It is useful because currently this library cannot parse [GPS responses](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/serial_lte_modem/doc/GNSS_AT_commands.html#id15) sent by the modem with the [Serial LTE modem](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/serial_lte_modem/README.html) application as the response parameters latitude, longitude, altitude, accuracy, speed and heading are returned as double numbers:

example of GPS response sent by the modem:
`
#XGPS: 35.457417,139.625211,162.850952,15.621976,1.418092,0.000000,"2021-06-02 05:21:31"
`

Tests has been added as well for the library at_cmd_parser.