### PR TITLE
samples: nrf9160: modem_shell: add console print after UART enable

### DIFF
--- a/samples/nrf9160/modem_shell/src/uart/uart_shell.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart_shell.c
@@ -81,6 +81,7 @@ void uart_toggle_power_state_at_event(const struct lte_lc_evt *const evt)
 		disable_uarts();
 	} else if (evt->type == LTE_LC_EVT_MODEM_SLEEP_EXIT) {
 		enable_uarts();
+		mosh_print("UARTs enabled");
 	}
 }
 


### PR DESCRIPTION
"UARTs enabled" info print been accidentally removed by recent changes
to UART disable during sleep mode feature. Reintroducing that.

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>