### PR TITLE
lib: location: new request mode for running all given methods sequentially

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -420,6 +420,8 @@ Modem libraries
       * Obstructed satellite visibility detection feature for GNSS.
         When this feature is enabled, the library tries to detect occurrences where getting a GNSS fix is unlikely or would consume a lot of energy.
         When such an occurrence is detected, GNSS is stopped without waiting for a fix or a timeout.
+      * In addition to the current default fallback mode for acquiring a location, it can also be acquired using the :c:enumerator:`LOCATION_REQ_MODE_ALL` mode that runs all methods in the list sequentially.
+        Each run method receives a location event, either a success or a failure.
 
     * Updated:
 

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -38,10 +38,18 @@ enum location_method {
 	LOCATION_METHOD_WIFI,
 };
 
+/** Location acquisition mode. */
+enum location_req_mode {
+	/** Fallback to next preferred method (default). */
+	LOCATION_REQ_MODE_FALLBACK = 0,
+	/** All requested methods are used sequentially. */
+	LOCATION_REQ_MODE_ALL,
+};
+
 /** Event IDs. */
 enum location_event_id {
 	/** Location update. */
-	LOCATION_EVT_LOCATION,
+	LOCATION_EVT_LOCATION = 1,
 	/** Getting location timed out. */
 	LOCATION_EVT_TIMEOUT,
 	/** An error occurred when trying to get the location. */
@@ -250,6 +258,11 @@ struct location_config {
 	 * the valid range is 10...65535 seconds.
 	 */
 	uint16_t interval;
+
+	/**
+	 * @brief Location acquisition mode.
+	 */
+	enum location_req_mode mode;
 };
 
 /**

--- a/lib/location/location.c
+++ b/lib/location/location.c
@@ -154,6 +154,7 @@ void location_config_defaults_set(
 
 	memset(config, 0, sizeof(struct location_config));
 	config->methods_count = methods_count;
+	config->mode = LOCATION_REQ_MODE_FALLBACK;
 	for (int i = 0; i < methods_count; i++) {
 		location_config_method_defaults_set(&config->methods[i], method_types[i]);
 	}


### PR DESCRIPTION
In addition to existing default fallback mode for acquiring a location,
now on, location can be acquired by using new mode LOCATION_REQ_MODE_ALL that runs
all methods sequentially in methods list. Each run methods will receive a location event, either a success or a failure.
Additionally, location command of the MoSh updated to have optional new hook (--mode <all|fallback>) to use this new ALL mode.