### PR TITLE
doc: Thread: explain variants in memory requirements tables

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -748,6 +748,7 @@ Documentation
   * :ref:`thread_ug_feature_updating_libs` to clarify the use, and added |VSC| instructions.
   * :ref:`ug_thread_communication` by moving it to a separate page instead of it being under :ref:`ug_thread_architectures`.
   * Added a note to several nRF Cloud samples using the `nRF Cloud REST API`_ indicating the need for valid and registered request signing credentials.
+  * :ref:`thread_ot_memory` with definitions of variants listed on the tables.
 
 * Removed:
 

--- a/doc/nrf/ug_thread_ot_memory.rst
+++ b/doc/nrf/ug_thread_ot_memory.rst
@@ -24,6 +24,14 @@ Moreover, take into account the following considerations:
 * The single protocol sample was configured by setting :kconfig:option:`CONFIG_BT` to ``n``.
 * Values for the :ref:`Thread CLI sample <ot_cli_sample>`, which works with all OpenThread calls, are the highest possible for the OpenThread stack using the master image library configuration.
 
+The tables provide memory requirements for the following device type variants:
+
+* *FTD* - Full Thread Device.
+* *MTD* - Minimal Thread Device.
+
+Some tables also list a *master* variant, which is an FTD with additional features, such as being able to have the *commissioner* or *border router* commissioning roles.
+See :ref:`thread_ug_feature_sets` for more information.
+
 .. _thread_ot_memory_5340:
 
 nRF5340 DK RAM and flash memory requirements


### PR DESCRIPTION
The memory requirements tables list different values for FTD, MTD
and master, but these are not explained. This adds very brief
clarifications and links to commissioning documentation for
further information.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>