### PR TITLE
scripts: quarantine: skip lib.modem_trace

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -8,6 +8,8 @@
 #    - None
 
 - scenarios:
-    - None
+    - lib.modem_trace_rtt
+    - lib.modem_trace_uart
   platforms:
-    - None
+    - qemu_cortex_m3
+  comment: "Not passing on zephyr-sdk 0.14.1"


### PR DESCRIPTION
Tests are not passing using zephyr-sdk 0.14.1

Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>