### PR TITLE
dfu: multi image package library

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -160,6 +160,7 @@ Kconfig*                                  @tejlmand
 /subsys/caf/                              @pdunaj
 /subsys/debug/                            @nordic-krch @anangl
 /subsys/dfu/                              @hakonfam @sigvartmh
+/subsys/dfu/dfu_multi_image/              @Damian-Nordic
 /subsys/dm/                               @maje-emb
 /subsys/ieee802154/                       @rlubos @czeslawmakarski
 /subsys/mgmt/                             @hakonfam @sigvartmh
@@ -219,6 +220,7 @@ Kconfig*                                  @tejlmand
 /tests/subsys/bootloader/                 @hakonfam
 /tests/subsys/debug/cpu_load/             @nordic-krch
 /tests/subsys/dfu/                        @hakonfam @sigvartmh
+/tests/subsys/dfu/dfu_multi_image/        @Damian-Nordic
 /tests/subsys/emds/                       @balaklaka
 /tests/subsys/app_event_manager/          @pdunaj @MarekPieta @rakons
 /tests/subsys/fw_info/                    @oyvindronningstad

--- a/cmake/dfu_multi_image.cmake
+++ b/cmake/dfu_multi_image.cmake
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+find_package(Python3 REQUIRED)
+
+#
+# Create CMake target for building a DFU Multi Image package.
+#
+# Required arguments:
+#   IMAGE_IDS     list of numeric identifiers (signed integers) of all images to be
+#                 included in the package
+#   IMAGE_PATHS   list of paths to image files to be included in the package; must be
+#                 of the same length as IMAGE_IDS. The package builder is indifferent
+#                 to image formats used.
+#   OUTPUT        location of the created package
+#
+function(dfu_multi_image_package TARGET_NAME)
+    cmake_parse_arguments(ARG "" "OUTPUT" "IMAGE_IDS;IMAGE_PATHS" ${ARGN})
+
+    if (NOT DEFINED ARG_IMAGE_IDS OR NOT ARG_IMAGE_PATHS OR NOT ARG_OUTPUT)
+        message(FATAL_ERROR "All IMAGE_IDS, IMAGE_PATHS and OUTPUT arguments must be specified")
+    endif()
+
+    # Prepare dfu_multi_image_tool.py argument list
+    set(SCRIPT_ARGS "create")
+
+    foreach(image IN ZIP_LISTS ARG_IMAGE_IDS ARG_IMAGE_PATHS)
+        list(APPEND SCRIPT_ARGS "--image" "${image_0}" "${image_1}")
+    endforeach()
+
+    list(APPEND SCRIPT_ARGS ${ARG_OUTPUT})
+
+    # Pass the argument list via file to avoid hitting Windows command-line length limit
+    string(REPLACE ";" "\n" SCRIPT_ARGS "${SCRIPT_ARGS}")
+    file(GENERATE OUTPUT ${ARG_OUTPUT}.args CONTENT ${SCRIPT_ARGS})
+
+    add_custom_target(${TARGET_NAME} ALL
+        COMMAND
+        ${Python3_EXECUTABLE}
+        ${NRF_DIR}/scripts/bootloader/dfu_multi_image_tool.py
+        @${ARG_OUTPUT}.args
+        BYPRODUCTS
+        ${ARG_OUTPUT}
+    )
+endfunction()

--- a/doc/nrf/libraries/dfu/dfu_multi_image.rst
+++ b/doc/nrf/libraries/dfu/dfu_multi_image.rst
@@ -1,0 +1,43 @@
+.. _lib_dfu_multi_image:
+
+DFU multi-image
+###############
+
+.. contents::
+   :local:
+   :depth: 2
+
+The DFU multi-image library provides an API for writing a DFU multi-image package that can be downloaded in chunks of arbitrary size.
+The DFU multi-image package is a simple archive file that consists of a CBOR-based header that describes contents of the package, followed by a number of updates images, such as firmware images for different MCU cores.
+
+Images included in a DFU multi-image package are identified by numeric identifiers assigned by the user.
+The library provides a way for the user to register custom functions for writing a single image with a given identifier.
+
+Because the library makes no assumptions about the formats of images included in a written package, it serves as a general-purpose solution for device firmware upgrades.
+For example, it can be used to upgrade the :ref:`nRF5340 <ug_nrf5340_multi_image>` firmware.
+
+Configuration
+*************
+
+To enable the DFU multi-image library, set the :kconfig:option:`CONFIG_DFU_MULTI_IMAGE` Kconfig option.
+
+To configure the maximum number of images that the DFU multi-image library is able to process, use the :kconfig:option:`CONFIG_DFU_MULTI_IMAGE_MAX_IMAGE_COUNT` Kconfig option.
+
+To enable building the DFU multi-image package that contains commonly used update images, such as the application core firmware, the network core firmware, or MCUboot images, set the :kconfig:option:`CONFIG_DFU_MULTI_IMAGE_PACKAGE_BUILD` Kconfig option.
+
+Dependencies
+************
+
+This module uses the following |NCS| libraries and drivers:
+
+* `zcbor <https://github.com/NordicSemiconductor/zcbor>`_
+
+API documentation
+*****************
+
+| Header file: :file:`include/dfu/dfu_multi_image.h`
+| Source files: :file:`subsys/dfu/dfu_multi_image/src/`
+
+.. doxygengroup:: dfu_multi_image
+   :project: nrf
+   :members:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -610,6 +610,7 @@ Other libraries
   * :ref:`event_manager_proxy` library.
   * :ref:`QoS` library.
   * :ref:`emds_readme` library.
+  * :ref:`lib_dfu_multi_image` library.
 
 
 * Updated:

--- a/include/dfu/dfu_multi_image.h
+++ b/include/dfu/dfu_multi_image.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @defgroup dfu_multi_image DFU Multi Image
+ * @brief Provides an API for writing DFU Multi Image package
+ *
+ * DFU Multi Image package is a general-purpose update file consisting of a CBOR-based
+ * header that describes contents of the package, followed by a number of update
+ * components, such as firmware images for different MCU cores. More specifically, the
+ * header contains signed numeric identifiers and sizes of included images. The meaning
+ * of the identifiers is application-specific, that is, a user is allowed to assign
+ * arbitrary identifiers to their images.
+ *
+ * A DFU Multi Image package can be built manually using either the Python script
+ * located at 'scripts/bootloader/dfu_multi_image_tool.py' or the CMake wrapper defined
+ * in 'cmake/dfu_multi_image.cmake'. Additionally, @c DFU_MULTI_IMAGE_PACKAGE_BUILD and
+ * related Kconfig options are available to enable building of a package that includes
+ * common update images.
+ *
+ * The DFU Multi Image library can be used to process a DFU Multi Image package downloaded
+ * onto a device during the DFU process. Its proper usage consists of the following steps:
+ *
+ * 1. Call @c dfu_multi_image_init function to initialize the library's context.
+ * 2. Call @c dfu_multi_image_register_writer for each image identifier you would like to
+ *    extract from the package. Images included in the package for which no corresponding
+ *    writers have been registered will be ignored.
+ * 3. Pass subsequent downloaded chunks of the package to @c dfu_multi_image_write
+ *    function. The chunks must be provided in order. Note that if the function returns
+ *    an error, no more chunks shall be provided.
+ * 4. Call @c dfu_multi_image_done function to release open resources and verify that all
+ *    data declared in the header have been written properly.
+ *
+ * @{
+ */
+
+#ifndef DFU_MULTI_IMAGE_H__
+#define DFU_MULTI_IMAGE_H__
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int (*dfu_image_open_t)(int image_id, size_t image_size);
+typedef int (*dfu_image_write_t)(const uint8_t *chunk, size_t chunk_size);
+typedef int (*dfu_image_close_t)(bool success);
+
+/**
+ * @brief User-provided functions for writing a single image from DFU Multi Image package.
+ */
+struct dfu_image_writer {
+	/**
+	 * @brief Identifier of the applicable image.
+	 */
+	int image_id;
+
+	/**
+	 * @brief Function called before writing the first byte of the applicable image.
+	 *
+	 * The function is indirectly called by @c dfu_multi_image_write and in the case
+	 * of failure the error code is propagated and returned from the latter function.
+	 *
+	 * @return negative On failure.
+	 * @return 0        On success.
+	 */
+	dfu_image_open_t open;
+
+	/** @brief Function called to write a subsequent chunk of the applicable image.
+	 *
+	 * The function is indirectly called by @c dfu_multi_image_write and in the case
+	 * of failure the error code is propagated and returned from the latter function.
+	 *
+	 * @return negative On failure.
+	 * @return 0        On success.
+	 */
+	dfu_image_write_t write;
+
+	/**
+	 * @brief Function called after writing the last byte of the applicable image.
+	 *
+	 * The function is indirectly called by @c dfu_multi_image_write or
+	 * @c dfu_multi_image_done and in the case of failure the error code is propagated
+	 * and returned from the latter function.
+	 *
+	 * @return negative On failure.
+	 * @return 0        On success.
+	 */
+	dfu_image_close_t close;
+};
+
+/**
+ * @brief Initialize DFU Multi Image library context.
+ *
+ * Resets the internal state of the DFU Multi Image library and initializes necessary
+ * resources. In particular, the function removes all writers previously registered with
+ * the @c dfu_multi_image_register_writer function.
+ *
+ * @param[in] buffer Buffer to store DFU Multi Image header in case it spans multiple
+ *                   chunks of the package. The buffer is only needed until the header
+ *                   is parsed, so the same buffer can be provided to the
+ *                   @c dfu_target_mcuboot_set_buf function.
+ * @param[in] buffer_size Size of the buffer to store DFU Multi Image header.
+ *
+ * @return -EINVAL If the provided buffer is too small.
+ * @return 0       On success.
+ */
+int dfu_multi_image_init(uint8_t *buffer, size_t buffer_size);
+
+/**
+ * @brief Register DFU image writer.
+ *
+ * Registers functions for opening, writing and closing a single image included in
+ * the downloaded DFU Multi Image package.
+ *
+ * @param[in] writer Structure that contains the applicable image identifier and
+ *                   functions to be registered.
+ *
+ * @return -ENOMEM If the image writer could not be registered due to lack of empty slots.
+ * @return 0	   On success.
+ */
+int dfu_multi_image_register_writer(const struct dfu_image_writer *writer);
+
+/**
+ * @brief Write subsequent DFU Multi Image package chunk.
+ *
+ * Called to consume a subsequent chunk of the DFU Multi Image package.
+ * The initial bytes of the package contain a header that allows the library to learn
+ * offsets of particular images within the entire package. After the header is parsed,
+ * the registered image writers are used to store the image data.
+ *
+ * The package chunks must be provided in order.
+ *
+ * When an image for which no writer has been registered is found in the package, the
+ * library may decide to skip ahead the image. For that reason, a user of the function
+ * must provide the @c offset argument to validate the chunk's position against the
+ * current write position and potentially drop the bytes that are not needed anymore.
+ *
+ * A user shall NOT write any more chunks after any write results in a failure.
+ *
+ * @param[in] offset Offset of the chunk within the entire package.
+ * @param[in] chunk Pointer to the chunk's data.
+ * @param[in] chunk_size Size of the chunk.
+ *
+ * @retval -ESPIPE  If @c offset is bigger than expected which may indicate a data gap
+ *                  or writing more data than declared in the package header.
+ * @return negative On other failure.
+ * @return 0        On success.
+ */
+int dfu_multi_image_write(size_t offset, const uint8_t *chunk, size_t chunk_size);
+
+/**
+ * @brief Returns DFU Multi Image package write position.
+ *
+ * @return Offset of the next needed package chunk in bytes.
+ */
+size_t dfu_multi_image_offset(void);
+
+/**
+ * @brief Complete DFU Multi Image package write.
+ *
+ * Close an open image writer if such exists. Additionally, if @c success argument is
+ * true, the function validates that all images listed in the package header have been
+ * fully written.
+ *
+ * @param[in] success Indicates that a user expects all the package contents to have
+ *                    been written successfully.
+ *
+ * @return -ESPIPE  If @c success and not all package contents have been written yet.
+ * @return negative On other failure.
+ * @return 0        On success.
+ */
+int dfu_multi_image_done(bool success);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* DFU_MULTI_IMAGE_H__ */

--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -32,6 +32,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   endif()
 
   include(${ZEPHYR_BASE}/../nrf/cmake/fw_zip.cmake)
+  include(${ZEPHYR_BASE}/../nrf/cmake/dfu_multi_image.cmake)
 
   function(sign)
     # Signs a hex image
@@ -554,6 +555,38 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
         )
     endif()
   endif(CONFIG_SIGN_IMAGES)
+endif()
+
+if (CONFIG_DFU_MULTI_IMAGE_PACKAGE_BUILD)
+  set(dfu_multi_image_ids)
+  set(dfu_multi_image_paths)
+  set(dfu_multi_image_targets)
+
+  if (CONFIG_DFU_MULTI_IMAGE_PACKAGE_APP)
+    list(APPEND dfu_multi_image_ids 0)
+    list(APPEND dfu_multi_image_paths "${PROJECT_BINARY_DIR}/${app_core_binary_name}")
+    list(APPEND dfu_multi_image_targets mcuboot_sign_target)
+  endif()
+
+  if (CONFIG_DFU_MULTI_IMAGE_PACKAGE_NET)
+    list(APPEND dfu_multi_image_ids 1)
+    list(APPEND dfu_multi_image_paths "${PROJECT_BINARY_DIR}/${net_core_binary_name}")
+    list(APPEND dfu_multi_image_targets net_core_app_sign_target)
+  endif()
+
+  if (CONFIG_DFU_MULTI_IMAGE_PACKAGE_MCUBOOT)
+    list(APPEND dfu_multi_image_ids -2 -1)
+    list(APPEND dfu_multi_image_paths "${s0_bin_path}" "${s1_bin_path}")
+    list(APPEND dfu_multi_image_targets signed_s0_target signed_s1_target)
+  endif()
+
+  dfu_multi_image_package(dfu_multi_image_pkg
+    IMAGE_IDS ${dfu_multi_image_ids}
+    IMAGE_PATHS ${dfu_multi_image_paths}
+    OUTPUT ${PROJECT_BINARY_DIR}/dfu_multi_image.bin
+    )
+
+  add_dependencies(dfu_multi_image_pkg ${dfu_multi_image_targets})
 endif()
 
 # Zephyr has a Kconfig option used for signing an application image

--- a/modules/mcuboot/Kconfig
+++ b/modules/mcuboot/Kconfig
@@ -64,4 +64,30 @@ config MCUBOOT_USB_SUPPORT
 	bool
 	default y if "$(dt_nodelabel_enabled,zephyr_udc0)"
 
+config DFU_MULTI_IMAGE_PACKAGE_BUILD
+	bool "Build DFU Multi Image package"
+	depends on BOOTLOADER_MCUBOOT
+	help
+	  Build DFU Multi Image package that contains a manifest file followed by
+	  selected update images.
+
+if DFU_MULTI_IMAGE_PACKAGE_BUILD
+
+config DFU_MULTI_IMAGE_PACKAGE_APP
+	bool "Include Application Core image in DFU Multi Image package"
+	default y
+
+config DFU_MULTI_IMAGE_PACKAGE_NET
+	bool "Include Network Core image in DFU Multi Image package"
+	depends on NRF53_UPGRADE_NETWORK_CORE
+	default y
+
+config DFU_MULTI_IMAGE_PACKAGE_MCUBOOT
+	bool "Include MCUboot image in DFU Multi Image package"
+	depends on BUILD_S1_VARIANT
+	# Currently simultaneous application and MCUboot updates are unsupported
+	depends on !DFU_MULTI_IMAGE_PACKAGE_APP && !DFU_MULTI_IMAGE_PACKAGE_NET
+
+endif # DFU_MULTI_IMAGE_PACKAGE_BUILD
+
 endmenu

--- a/scripts/bootloader/dfu_multi_image_tool.py
+++ b/scripts/bootloader/dfu_multi_image_tool.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+"""
+Utility for manipulating DFU Multi Image packages.
+
+DFU Multi Image package is a general-purpose update file consisting of
+a CBOR-based header that describes contents of the package, followed by a number
+of update components, such as firmware images for different MCU cores.
+
+The CBOR header currently complies with the following format:
+{
+    "img": [
+        {"id": 0, "size": 102400},
+        {"id": 1, "size": 204800}
+        ...
+    ]
+}
+
+Usage examples:
+
+Creating DFU Multi Image package:
+./dfu_multi_image_tool.py create --image 0 app_update.bin --image 1 net_core_app_update.bin dfu_multi_image.bin
+
+Showing DFU Multi Image package header:
+./dfu_multi_image_tool.py show dfu_multi_image.bin
+"""
+
+import argparse
+import cbor2
+import struct
+import os
+
+
+# Buffer size used for file reads to ensure large files are not loaded into memory at once
+READ_BUFFER_SIZE = 16 * 1024
+
+
+def generate_header(image: list) -> bytes:
+    """
+    Generate DFU Multi Image package header
+    """
+
+    image_data = [{'id': int(id), 'size': os.path.getsize(path)} for id, path in image]
+    header_data = {'img': image_data}
+    header_cbor = cbor2.dumps(header_data)
+
+    return struct.pack('<H', len(header_cbor)) + header_cbor
+
+
+def parse_header(file: object) -> object:
+    """
+    Parse DFU Multi Image package header
+    """
+
+    header_fixed_size = struct.calcsize('<H')
+    header_cbor_size, = struct.unpack('<H', file.read(header_fixed_size))
+    header_cbor = file.read(header_cbor_size)
+
+    return cbor2.loads(header_cbor)
+
+
+def generate_image(images: list, output_file: str) -> None:
+    """
+    Generate DFU Multi Image package
+    """
+
+    with open(output_file, 'wb') as out_file:
+        out_file.write(generate_header(images))
+
+        for _, path in images:
+            with open(path, 'rb') as file:
+                while True:
+                    chunk = file.read(READ_BUFFER_SIZE)
+                    if not chunk:
+                        break
+                    out_file.write(chunk)
+
+
+def show_header(input_file: str) -> None:
+    """
+    Parse and print DFU Multi Image package header
+    """
+
+    with open(input_file, 'rb') as file:
+        header = parse_header(file)
+        print('Images:')
+
+        for image in header['img']:
+            print(f'- Id: {image["id"]}')
+            print(f'  Size: {image["size"]}')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='DFU Multi Image tool', fromfile_prefix_chars='@')
+    subcommands = parser.add_subparsers(dest='subcommand', title='valid subcommands')
+
+    create_parser = subcommands.add_parser(
+        'create', help='Create DFU Multi Image package')
+    create_parser.add_argument(
+        '-i', '--image',
+        required=True, action='append', nargs=2, metavar=('id', 'path'),
+        help='Image to be included in package')
+    create_parser.add_argument(
+        'output_file', help='Path to output package file')
+
+    show_parser = subcommands.add_parser(
+        'show', help='Show DFU Multi Image package header')
+    show_parser.add_argument(
+        'input_file', help='Path to package file')
+
+    args = parser.parse_args()
+
+    if args.subcommand == 'create':
+        generate_image(args.image, args.output_file)
+    elif args.subcommand == 'show':
+        show_header(args.input_file)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/subsys/dfu/CMakeLists.txt
+++ b/subsys/dfu/CMakeLists.txt
@@ -4,5 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+add_subdirectory_ifdef(CONFIG_DFU_MULTI_IMAGE dfu_multi_image)
 add_subdirectory_ifdef(CONFIG_DFU_TARGET dfu_target)
 add_subdirectory_ifdef(CONFIG_FMFU_FDEV fmfu_fdev)

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -6,6 +6,8 @@
 
 menu "DFU"
 
+rsource "dfu_multi_image/Kconfig"
+
 rsource "dfu_target/Kconfig"
 
 rsource "fmfu_fdev/Kconfig"

--- a/subsys/dfu/dfu_multi_image/CMakeLists.txt
+++ b/subsys/dfu/dfu_multi_image/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+
+zephyr_library_sources(src/dfu_multi_image.c)

--- a/subsys/dfu/dfu_multi_image/Kconfig
+++ b/subsys/dfu/dfu_multi_image/Kconfig
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menuconfig DFU_MULTI_IMAGE
+	bool "Device Firmware Upgrade Multi Image API"
+	select ZCBOR
+
+if DFU_MULTI_IMAGE
+
+config DFU_MULTI_IMAGE_MAX_IMAGE_COUNT
+	int "Maximum image count"
+	default 2
+	help
+	  The maximum number of images that can be included in a DFU package
+	  and correctly processed by the DFU Multi Image library.
+
+endif # DFU_MULTI_IMAGE

--- a/subsys/dfu/dfu_multi_image/src/dfu_multi_image.c
+++ b/subsys/dfu/dfu_multi_image/src/dfu_multi_image.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <dfu/dfu_multi_image.h>
+#include <sys/byteorder.h>
+#include <sys/util.h>
+#include <zcbor_decode.h>
+
+#include <errno.h>
+#include <string.h>
+
+#define FIXED_HEADER_SIZE sizeof(uint16_t)
+#define CBOR_HEADER_NESTING_LEVEL 3
+#define IMAGE_NO_FIXED_HEADER -2
+#define IMAGE_NO_CBOR_HEADER -1
+
+struct image_info {
+	int32_t id;
+	uint32_t size;
+};
+
+struct header {
+	struct image_info images[CONFIG_DFU_MULTI_IMAGE_MAX_IMAGE_COUNT];
+	size_t image_count;
+};
+
+struct dfu_multi_image_ctx {
+	/* User configuration */
+	uint8_t *buffer;
+	size_t buffer_size;
+	struct dfu_image_writer writers[CONFIG_DFU_MULTI_IMAGE_MAX_IMAGE_COUNT];
+	size_t writer_count;
+
+	/* Parsed header */
+	struct header header;
+
+	/* Current parser state */
+	int cur_image_no;
+	size_t cur_offset;
+	size_t cur_item_offset;
+	size_t cur_item_size;
+};
+
+static struct dfu_multi_image_ctx ctx;
+
+static int parse_fixed_header(void)
+{
+	ctx.cur_item_size += sys_get_le16(ctx.buffer);
+	ctx.cur_image_no = IMAGE_NO_CBOR_HEADER;
+
+	return (ctx.cur_item_size <= ctx.buffer_size) ? 0 : -ENOMEM;
+}
+
+static bool parse_image_info(zcbor_state_t *states, struct image_info *image)
+{
+	bool res;
+
+	res = zcbor_map_start_decode(states);
+	res = res && zcbor_tstr_expect_lit(states, "id");
+	res = res && zcbor_int32_decode(states, &image->id);
+	res = res && zcbor_tstr_expect_lit(states, "size");
+	res = res && zcbor_uint32_decode(states, &image->size);
+	res = res && zcbor_map_end_decode(states);
+
+	return res;
+}
+
+static int parse_cbor_header(void)
+{
+	bool res;
+	uint_fast32_t image_count;
+
+	ZCBOR_STATE_D(states, CBOR_HEADER_NESTING_LEVEL, ctx.buffer + FIXED_HEADER_SIZE,
+		      ctx.cur_item_size - FIXED_HEADER_SIZE, 1);
+
+	res = zcbor_map_start_decode(states);
+	res = res && zcbor_tstr_expect_lit(states, "img");
+	res = res && zcbor_list_start_decode(states);
+	res = res && zcbor_multi_decode(1, CONFIG_DFU_MULTI_IMAGE_MAX_IMAGE_COUNT, &image_count,
+					(zcbor_decoder_t *)parse_image_info, states,
+					ctx.header.images, sizeof(struct image_info));
+	res = res && zcbor_list_end_decode(states);
+	res = res && zcbor_map_end_decode(states);
+
+	if (!res) {
+		return zcbor_pop_error(states);
+	}
+
+	ctx.header.image_count = image_count;
+
+	return 0;
+}
+
+static const struct dfu_image_writer *current_image_writer(void)
+{
+	if (ctx.cur_image_no >= 0 && (size_t)ctx.cur_image_no < ctx.header.image_count) {
+		const int image_id = ctx.header.images[ctx.cur_image_no].id;
+
+		for (size_t i = 0; i < ctx.writer_count; i++) {
+			if (ctx.writers[i].image_id == image_id) {
+				return &ctx.writers[i];
+			}
+		}
+	}
+
+	return NULL;
+}
+
+static void select_next_image(void)
+{
+	ctx.cur_item_offset = 0;
+	ctx.cur_item_size = 0;
+
+	while (++ctx.cur_image_no < ctx.header.image_count && current_image_writer() == NULL) {
+		ctx.cur_offset += ctx.header.images[ctx.cur_image_no].size;
+	}
+
+	if (ctx.cur_image_no < ctx.header.image_count) {
+		ctx.cur_item_size = ctx.header.images[ctx.cur_image_no].size;
+	}
+}
+
+static int process_current_item(const uint8_t *chunk, size_t chunk_size)
+{
+	int err = 0;
+
+	/* Process only remaining bytes of the current item (header or image) */
+	chunk_size = MIN(chunk_size, ctx.cur_item_size - ctx.cur_item_offset);
+
+	if (ctx.cur_image_no < 0) {
+		memcpy(ctx.buffer + ctx.cur_item_offset, chunk, chunk_size);
+
+		if (ctx.cur_item_offset + chunk_size == ctx.cur_item_size) {
+			if (ctx.cur_image_no == IMAGE_NO_FIXED_HEADER) {
+				err = parse_fixed_header();
+			} else {
+				err = parse_cbor_header();
+			}
+		}
+	} else {
+		/* Image data */
+		const struct dfu_image_writer *writer = current_image_writer();
+
+		if (!writer) {
+			err = -ESPIPE;
+		}
+
+		if (!err && ctx.cur_item_offset == 0) {
+			err = writer->open(writer->image_id,
+					   ctx.header.images[ctx.cur_image_no].size);
+		}
+
+		if (!err) {
+			err = writer->write(chunk, chunk_size);
+		}
+
+		if (!err && ctx.cur_item_offset + chunk_size == ctx.cur_item_size) {
+			err = writer->close(true);
+		}
+	}
+
+	if (err) {
+		return err;
+	}
+
+	ctx.cur_offset += chunk_size;
+	ctx.cur_item_offset += chunk_size;
+
+	if (ctx.cur_item_offset == ctx.cur_item_size) {
+		select_next_image();
+	}
+
+	return chunk_size;
+}
+
+int dfu_multi_image_init(uint8_t *buffer, size_t buffer_size)
+{
+	if (buffer == NULL || buffer_size < FIXED_HEADER_SIZE) {
+		return -EINVAL;
+	}
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.buffer = buffer;
+	ctx.buffer_size = buffer_size;
+	ctx.cur_image_no = IMAGE_NO_FIXED_HEADER;
+	ctx.cur_item_size = FIXED_HEADER_SIZE;
+
+	return 0;
+}
+
+int dfu_multi_image_register_writer(const struct dfu_image_writer *writer)
+{
+	if (ctx.writer_count == CONFIG_DFU_MULTI_IMAGE_MAX_IMAGE_COUNT) {
+		return -ENOMEM;
+	}
+
+	ctx.writers[ctx.writer_count++] = *writer;
+	return 0;
+}
+
+int dfu_multi_image_write(size_t offset, const uint8_t *chunk, size_t chunk_size)
+{
+	int result;
+	size_t chunk_offset = 0;
+
+	if (offset > ctx.cur_offset) {
+		/* Unexpected data gap */
+		return -ESPIPE;
+	}
+
+	while (1) {
+		/* Skip ahead to the current write offset */
+		chunk_offset += (ctx.cur_offset - offset);
+
+		if (chunk_offset >= chunk_size) {
+			break;
+		}
+
+		result = process_current_item(chunk + chunk_offset, chunk_size - chunk_offset);
+
+		if (result <= 0) {
+			return result;
+		}
+
+		chunk_offset += (size_t)result;
+		offset += (size_t)result;
+	}
+
+	return 0;
+}
+
+size_t dfu_multi_image_offset(void)
+{
+	return ctx.cur_offset;
+}
+
+int dfu_multi_image_done(bool success)
+{
+	const struct dfu_image_writer *writer = current_image_writer();
+	int err = 0;
+
+	/* Close any active writer if such exists */
+	if (writer != NULL) {
+		err = writer->close(success);
+	}
+
+	/* On success, verify that all images have been fully written */
+	if (!err && success && ctx.cur_image_no != ctx.header.image_count) {
+		return -ESPIPE;
+	}
+
+	return err;
+}

--- a/tests/subsys/dfu/dfu_multi_image/CMakeLists.txt
+++ b/tests/subsys/dfu/dfu_multi_image/CMakeLists.txt
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(dfu_multi_image_test)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+# Generate a test DFU Multi Image package to be parsed by a unit test to verify
+# that both the package builder and the parser are compatible with each other.
+
+file(WRITE
+  ${PROJECT_BINARY_DIR}/update1.bin
+  "somecontent"
+  )
+
+file(WRITE
+  ${PROJECT_BINARY_DIR}/update2.bin
+  "anothercontent"
+  )
+
+execute_process(
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+  COMMAND ${Python3_EXECUTABLE}
+    ${NRF_DIR}/scripts/bootloader/dfu_multi_image_tool.py
+    create
+    --image -1 update1.bin
+    --image 1000000 update2.bin
+    dfu_package.bin
+  )
+
+file(READ
+  ${PROJECT_BINARY_DIR}/dfu_package.bin
+  DFU_PACKAGE_HEX
+  HEX
+  )
+
+target_compile_definitions(app PRIVATE
+  DFU_PACKAGE_HEX="${DFU_PACKAGE_HEX}"
+  )

--- a/tests/subsys/dfu/dfu_multi_image/prj.conf
+++ b/tests/subsys/dfu/dfu_multi_image/prj.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_ZTEST=y
+CONFIG_DFU_MULTI_IMAGE=y

--- a/tests/subsys/dfu/dfu_multi_image/src/main.c
+++ b/tests/subsys/dfu/dfu_multi_image/src/main.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <dfu/dfu_multi_image.h>
+#include <sys/util.h>
+#include <ztest.h>
+
+#include <string.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/*
+ * Expected properties of an update image that is supposed to be written while downloading
+ * and unpacking a given DFU Multi Image package.
+ */
+struct expected_image {
+	int image_id;
+	const char *content;
+	size_t content_size;
+};
+
+#define EXPECTED_IMAGE(id, contentstr)                                                             \
+	{                                                                                          \
+		.image_id = id, .content = contentstr, .content_size = strlen(contentstr)          \
+	}
+
+/*
+ * Expected results of downloading and unpacking a given DFU Multi Image package.
+ */
+struct expected {
+	struct expected_image images[CONFIG_DFU_MULTI_IMAGE_MAX_IMAGE_COUNT];
+	size_t image_count;
+};
+
+/*
+ * Implement fake image writer which compares written data with expected content instead of
+ * actually storing it.
+ */
+
+struct comparison_context {
+	struct expected expected;
+	size_t current_image_no;
+	size_t current_image_offset;
+};
+
+static struct comparison_context ctx;
+
+static int image_comparator_open(int image_id, size_t image_size)
+{
+	zassert_true(ctx.current_image_no < ctx.expected.image_count, "Too many images written");
+	zassert_equal(ctx.expected.images[ctx.current_image_no].image_id, image_id,
+		      "Unexpected image id");
+	zassert_equal(ctx.expected.images[ctx.current_image_no].content_size, image_size,
+		      "Unexpected image size");
+	zassert_equal(ctx.current_image_offset, 0, "Opening image while already in progress");
+
+	return 0;
+}
+
+static int image_comparator_write(const uint8_t *chunk, size_t chunk_size)
+{
+	const struct expected_image *image = &ctx.expected.images[ctx.current_image_no];
+
+	zassert_true(ctx.current_image_offset + chunk_size <= image->content_size,
+		     "Too large image written");
+	zassert_ok(memcmp(image->content + ctx.current_image_offset, chunk, chunk_size),
+		   "Unexpected image content");
+
+	ctx.current_image_offset += chunk_size;
+
+	return 0;
+}
+
+static int image_comparator_close(bool success)
+{
+	zassert_true(success, "Closing image with failure");
+
+	ctx.current_image_no++;
+	ctx.current_image_offset = 0;
+
+	return 0;
+}
+
+/*
+ * Generic test that verifies that expected image data is written while downloading and
+ * unpacking a given DFU Multi Image package.
+ */
+
+static int comparison_test(const uint8_t *package, size_t package_size,
+			   const struct expected *expected, uint8_t *buffer, size_t buffer_size,
+			   size_t chunk_size)
+{
+	int err;
+
+	ctx.expected = *expected;
+	ctx.current_image_no = 0;
+	ctx.current_image_offset = 0;
+
+	/* Initialize DFU and register image writers for all expected images */
+
+	err = dfu_multi_image_init(buffer, buffer_size);
+
+	if (err) {
+		return err;
+	}
+
+	for (size_t i = 0; i < expected->image_count; ++i) {
+		struct dfu_image_writer writer = { .image_id = expected->images[i].image_id,
+						   .open = image_comparator_open,
+						   .write = image_comparator_write,
+						   .close = image_comparator_close };
+
+		err = dfu_multi_image_register_writer(&writer);
+
+		if (err) {
+			return err;
+		}
+	}
+
+	/* Write the package using the requested chunk size */
+
+	for (size_t i = 0; i < package_size; i += chunk_size) {
+		err = dfu_multi_image_write(i, package + i, MIN(chunk_size, package_size));
+
+		if (err) {
+			return err;
+		}
+	}
+
+	err = dfu_multi_image_done(true);
+
+	if (err) {
+		return err;
+	}
+
+	zassert_equal(ctx.current_image_no, expected->image_count, "Too few images written");
+	return 0;
+}
+
+static const uint8_t two_image_package[] = {
+	0x1e, 0x00, 0xa1, 0x63, 0x69, 0x6d, 0x67, 0x82, 0xa2, 0x62, 0x69, 0x64, 0x00,
+	0x64, 0x73, 0x69, 0x7a, 0x65, 0x0f, 0xa2, 0x62, 0x69, 0x64, 0x19, 0x01, 0x00,
+	0x64, 0x73, 0x69, 0x7a, 0x65, 0x11, 0x69, 0x6d, 0x61, 0x67, 0x65, 0x20, 0x30,
+	0x20, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x6e, 0x74, 0x69, 0x6d, 0x61, 0x67, 0x65,
+	0x20, 0x32, 0x35, 0x36, 0x20, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x6e, 0x74
+};
+
+static const struct expected two_image_package_expected = {
+	.images = { EXPECTED_IMAGE(0, "image 0 content"),
+		    EXPECTED_IMAGE(256, "image 256 content") },
+	.image_count = 2,
+};
+
+static void test_two_image_package(void)
+{
+	uint8_t buffer[128];
+
+	zassert_ok(comparison_test(two_image_package, sizeof(two_image_package),
+				   &two_image_package_expected, buffer, sizeof(buffer), 100),
+		   "DFU failed");
+}
+
+static void test_two_image_package_small_chunk(void)
+{
+	uint8_t buffer[128];
+
+	zassert_ok(comparison_test(two_image_package, sizeof(two_image_package),
+				   &two_image_package_expected, buffer, sizeof(buffer), 1),
+		   "DFU failed");
+}
+
+static void test_too_small_buffer(void)
+{
+	int err;
+	uint8_t buffer[31];
+
+	/*
+	 * Test that the DFU fails gracefully when the provided buffer is too small
+	 * to store the package header.
+	 */
+	err = comparison_test(two_image_package, sizeof(two_image_package),
+			      &two_image_package_expected, buffer, sizeof(buffer), 100);
+	zassert_equal(err, -ENOMEM, "Memory error expected but not occurred");
+
+	/*
+	 * Test that the DFU fails with "invalid argument" error when the provided buffer
+	 * is too small to store the package header size.
+	 */
+	err = comparison_test(two_image_package, sizeof(two_image_package),
+			      &two_image_package_expected, buffer, 1, 100);
+	zassert_equal(err, -EINVAL, "Invalid argument error expected but not occurred");
+}
+
+static void test_too_small_package(void)
+{
+	int err;
+	uint8_t buffer[32];
+	struct expected expected;
+
+	/*
+	 * Test that the DFU fails gracefully when the provided package is truncated.
+	 */
+
+	expected = two_image_package_expected;
+	err = comparison_test(two_image_package, sizeof(two_image_package) - 1, &expected, buffer,
+			      sizeof(buffer), 100);
+	zassert_equal(err, -ESPIPE, "DFU passed despite of truncated package");
+}
+
+static void test_too_large_package(void)
+{
+	int err;
+	uint8_t buffer[32];
+	uint8_t package[sizeof(two_image_package) + 1];
+
+	/*
+	 * Test that the DFU fails gracefully when the provided package contains trailing data
+	 * (not listed in the header).
+	 */
+
+	memcpy(package, two_image_package, sizeof(two_image_package));
+	err = comparison_test(package, sizeof(package), &two_image_package_expected, buffer,
+			      sizeof(buffer), 100);
+	zassert_equal(err, -ESPIPE, "DFU passed despite of trailing data");
+}
+
+static void test_skipped_image(void)
+{
+	uint8_t buffer[128];
+	struct expected expected = two_image_package_expected;
+
+	/*
+	 * Test that if an application only registers a writer for the second of two
+	 * images, the first one is silently ignored and the DFU still passes.
+	 */
+	expected.images[0] = expected.images[1];
+	expected.image_count = 1;
+	zassert_ok(comparison_test(two_image_package, sizeof(two_image_package), &expected, buffer,
+				   sizeof(buffer), 100),
+		   "DFU failed");
+}
+
+/*
+ * See CMakeLists.txt of the test project for parameters passed to the script generating
+ * the DFU Multi Image package. The expected values below should match the parameters.
+ */
+
+static const struct expected generated_dfu_package_expected = {
+	.images = { EXPECTED_IMAGE(-1, "somecontent"), EXPECTED_IMAGE(1000000, "anothercontent") },
+	.image_count = 2,
+};
+
+static void test_generated_dfu_package(void)
+{
+	uint8_t buffer[128];
+	uint8_t package[strlen(DFU_PACKAGE_HEX) / 2];
+	size_t package_len;
+
+	package_len = hex2bin(DFU_PACKAGE_HEX, strlen(DFU_PACKAGE_HEX), package, sizeof(package));
+	zassert_true(package_len > 0, "Failed to convert package from hex string");
+
+	zassert_ok(comparison_test(package, package_len, &generated_dfu_package_expected, buffer,
+				   sizeof(buffer), 100),
+		   "DFU failed");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(dfu_multi_image_test, ztest_unit_test(test_two_image_package),
+			 ztest_unit_test(test_two_image_package_small_chunk),
+			 ztest_unit_test(test_too_small_buffer),
+			 ztest_unit_test(test_too_small_package),
+			 ztest_unit_test(test_too_large_package),
+			 ztest_unit_test(test_skipped_image),
+			 ztest_unit_test(test_generated_dfu_package));
+	ztest_run_test_suite(dfu_multi_image_test);
+}

--- a/tests/subsys/dfu/dfu_multi_image/testcase.yaml
+++ b/tests/subsys/dfu/dfu_multi_image/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  dfu.dfu_multi_image:
+    platform_allow: native_posix
+    integration_platforms:
+      - native_posix
+    tags: dfu


### PR DESCRIPTION
Many projects, including Matter or Zigbee, must implement their own parsers for DFU packages that contain multiple images (at least the application core + network core firmware for nRF53). Would be good to have some generic solution for that.

* If `DFU_MULTI_IMAGE_PACKAGE_BUILD` is set, build a DFU Multi Image package consisting of a CBOR manifest followed by a list of selected image files, such as `app_update.bin`, `net_core_app_update.bin` or MCUboot images.
* Add library for downloading and parsing a DFU Multi Image package consisting of a CBOR manifest and a number of firmware images. The library mimics the DFU Target library in terms of API and can be easily integrated with the latter but is not limited to that and a user may provide a custom image writer for writing a specific firmware image included in the package.