### PR TITLE
doc: cmake: some minor cleanups

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -20,8 +20,11 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS doc)
 #-------------------------------------------------------------------------------
 # Options
 
-set(SPHINXOPTS_DEFAULT -j auto CACHE INTERNAL "Default Sphinx Options")
+set(SPHINXOPTS_DEFAULT "-j auto" CACHE STRING "Default Sphinx Options")
 set(SPHINXOPTS_EXTRA "" CACHE STRING "Extra Sphinx Options")
+
+separate_arguments(SPHINXOPTS_DEFAULT)
+separate_arguments(SPHINXOPTS_EXTRA)
 
 #-------------------------------------------------------------------------------
 # Dependencies

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -63,11 +63,10 @@ file(MAKE_DIRECTORY ${KCONFIG_BINARY_DIR})
 # docset sources into that folder.
 #
 # Configured targets:
-# - ${name}: Alias for ${name}-html.
 # - ${name}-inventory: Run Sphinx "inventory" build. It requires to enable
 #   the "inventory" builder on the docset conf.py. This target can be used
 #   to solve circular dependencies between docsets.
-# - ${name}-html: Run Sphinx "html" build.
+# - ${name}: Run Sphinx "html" build.
 # - ${name}-linkcheck: Run Sphinx "linkcheck" target.
 # - ${name}-clean: Clean build artifacts.
 #
@@ -104,7 +103,7 @@ function(add_docset name)
   )
 
   add_doc_target(
-    ${name}-html
+    ${name}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${DOCSET_MAKE_DIRS}
     COMMAND ${CMAKE_COMMAND} -E env ${DOCSET_ENV}
     ${SPHINXBUILD}
@@ -139,7 +138,7 @@ function(add_docset name)
 
   set_target_properties(
     ${name}-inventory ${name}-inventory-all
-    ${name}-html ${name}-html-all
+    ${name} ${name}-all
     ${name}-linkcheck
     PROPERTIES
       ADDITIONAL_CLEAN_FILES "${DOCSET_CLEAN_DIRS}"
@@ -149,9 +148,6 @@ function(add_docset name)
     ${name}-clean
     COMMAND ${CMAKE_COMMAND} -E rm -rf ${DOCSET_CLEAN_DIRS}
   )
-
-  add_custom_target(${name})
-  add_dependencies(${name} ${name}-html)
 endfunction()
 
 # Create a custom doc target.
@@ -205,8 +201,8 @@ add_custom_target(
 )
 
 add_docset(zephyr)
-add_dependencies(zephyr-html zephyr-devicetree)
-add_dependencies(zephyr-html-all zephyr-devicetree)
+add_dependencies(zephyr zephyr-devicetree)
+add_dependencies(zephyr-all zephyr-devicetree)
 
 #-------------------------------------------------------------------------------
 # docset: nrf
@@ -253,8 +249,8 @@ add_custom_target(
 )
 
 add_docset(nrf)
-add_dependencies(nrf-html nrf-versions)
-add_dependencies(nrf-html-all nrf-versions)
+add_dependencies(nrf nrf-versions)
+add_dependencies(nrf-all nrf-versions)
 
 #-------------------------------------------------------------------------------
 # docset: mcuboot
@@ -305,34 +301,34 @@ add_custom_target(
 )
 
 add_dependencies(merge-search-indexes
-    nrf-html-all
-    nrfx-html-all
-    nrfxlib-html-all
-    zephyr-html-all
-    mcuboot-html-all
-    tfm-html-all
-    kconfig-html-all
+    nrf-all
+    nrfx-all
+    nrfxlib-all
+    zephyr-all
+    mcuboot-all
+    tfm-all
+    kconfig-all
 )
 
-add_dependencies(zephyr-html-all kconfig-html-all)
-add_dependencies(mcuboot-html-all kconfig-html-all)
-add_dependencies(nrfxlib-inventory-all kconfig-html-all)
-add_dependencies(nrf-html-all zephyr-html-all nrfxlib-inventory-all mcuboot-html-all matter-html-all kconfig-html-all)
-add_dependencies(nrf-html-all zephyr-html-all nrfxlib-inventory-all mcuboot-html-all tfm-html-all kconfig-html-all)
-add_dependencies(nrfxlib-html-all nrf-html-all)
+add_dependencies(zephyr-all kconfig-all)
+add_dependencies(mcuboot-all kconfig-all)
+add_dependencies(nrfxlib-inventory-all kconfig-all)
+add_dependencies(nrf-all zephyr-all nrfxlib-inventory-all mcuboot-all matter-all kconfig-all)
+add_dependencies(nrf-all zephyr-all nrfxlib-inventory-all mcuboot-all tfm-all kconfig-all)
+add_dependencies(nrfxlib-all nrf-all)
 
 add_custom_target(build-all ALL)
 add_dependencies(build-all
     copy-extra-content
     merge-search-indexes
-    nrf-html-all
-    nrfx-html-all
-    nrfxlib-html-all
-    zephyr-html-all
-    mcuboot-html-all
-    tfm-html-all
-    matter-html-all
-    kconfig-html-all
+    nrf-all
+    nrfx-all
+    nrfxlib-all
+    zephyr-all
+    mcuboot-all
+    tfm-all
+    matter-all
+    kconfig-all
 )
 
 add_custom_target(linkcheck)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -142,17 +142,10 @@ function(add_docset name)
       ADDITIONAL_CLEAN_FILES "${DOCSET_CLEAN_DIRS}"
   )
 
-  if(${CMAKE_VERSION} VERSION_LESS 3.17)
-    add_custom_target(
-      ${name}-clean
-      COMMAND ${CMAKE_COMMAND} -E remove_directory ${DOCSET_CLEAN_DIRS}
-    )
-  else()
-    add_custom_target(
-      ${name}-clean
-      COMMAND ${CMAKE_COMMAND} -E rm -rf ${DOCSET_CLEAN_DIRS}
-    )
-  endif()
+  add_custom_target(
+    ${name}-clean
+    COMMAND ${CMAKE_COMMAND} -E rm -rf ${DOCSET_CLEAN_DIRS}
+  )
 
   add_custom_target(${name})
   add_dependencies(${name} ${name}-html)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -100,6 +100,7 @@ function(add_docset name)
       ${DOCSET_SRC_DIR}
       ${DOCSET_HTML_DIR}
     USES_TERMINAL
+    COMMENT "Building ${name} inventory..."
   )
 
   add_doc_target(
@@ -116,6 +117,7 @@ function(add_docset name)
       ${DOCSET_SRC_DIR}
       ${DOCSET_HTML_DIR}
     USES_TERMINAL
+    COMMENT "Building ${name} docset..."
   )
 
   add_custom_target(
@@ -132,6 +134,7 @@ function(add_docset name)
       ${DOCSET_SRC_DIR}
       ${DOCSET_BUILD_DIR}
     USES_TERMINAL
+    COMMENT "Checking links for ${name} docset..."
   )
 
   set_target_properties(
@@ -198,6 +201,7 @@ add_custom_target(
     ${ZEPHYR_BINARY_DIR}/src/reference/devicetree
   VERBATIM
   USES_TERMINAL
+  COMMENT "Generating Devicetree bindings documentation..."
 )
 
 add_docset(zephyr)

--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -74,18 +74,12 @@ If you have not built all documentation sets before, it is recommended to run th
 
 .. parsed-literal::
 
-   ninja *docset-name*-html-all
+   ninja *docset-name*-all
 
 Here, *docset-name* is the name of the documentation set, for example, ``nrf``.
 This target will build the :ref:`documentation sets <documentation_sets>` that are needed for *docset-name*.
 
 On subsequent builds, it is recommended to just run the following command:
-
-.. parsed-literal::
-
-   ninja *docset-name*-html
-
-Alternatively, for subsequent builds, you can run the ninja command using the alias target *docset-name* instead of *docset-name*-html:
 
 .. parsed-literal::
 


### PR DESCRIPTION
- Remove old CMake specifics
- Add comments to doc targets, so that it is more clear what is being built
- Remove `-html` targets so that only docset name is needed.