### PR TITLE
samples: nrf9160: gnss: add reference position support

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -257,6 +257,7 @@ nRF9160 samples
 
     * Added support for the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_STORAGE_PARTITION` option.
     * Enabled the :ref:`lib_at_host` library to make it easier to update certificates.
+    * Added support to calculate distance from a configured reference position.
 
   * :ref:`location_sample` sample:
 

--- a/samples/nrf9160/gnss/Kconfig
+++ b/samples/nrf9160/gnss/Kconfig
@@ -137,6 +137,16 @@ endchoice
 
 endif # GNSS_SAMPLE_MODE_CONTINUOUS
 
+config GNSS_SAMPLE_REFERENCE_LATITUDE
+	string "Reference position latitude in degrees"
+	help
+	  When set, the sample calculates the distance from the reference position for each fix.
+
+config GNSS_SAMPLE_REFERENCE_LONGITUDE
+	string "Reference position longitude in degrees"
+	help
+	  When set, the sample calculates the distance from the reference position for each fix.
+
 config GNSS_SAMPLE_LOW_ACCURACY
 	bool "Allow low accuracy fixes"
 	help

--- a/samples/nrf9160/gnss/src/main.c
+++ b/samples/nrf9160/gnss/src/main.c
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <stdlib.h>
 #include <string.h>
+#include <math.h>
 #include <zephyr.h>
 #include <logging/log.h>
 #include <nrf_modem_at.h>
@@ -13,6 +15,8 @@
 #include <date_time.h>
 
 LOG_MODULE_REGISTER(gnss_sample, CONFIG_GNSS_SAMPLE_LOG_LEVEL);
+
+#define PI 3.14159265358979323846
 
 #if !defined(CONFIG_GNSS_SAMPLE_ASSISTANCE_NONE) || defined(CONFIG_GNSS_SAMPLE_MODE_TTFF_TEST)
 static struct k_work_q gnss_work_q;
@@ -36,13 +40,18 @@ static struct k_work_delayable ttff_test_got_fix_work;
 static struct k_work_delayable ttff_test_prepare_work;
 static struct k_work ttff_test_start_work;
 static uint32_t time_to_fix;
-static uint32_t time_blocked;
 #endif
 
 static const char update_indicator[] = {'\\', '|', '/', '-'};
 
 static struct nrf_modem_gnss_pvt_data_frame last_pvt;
 static uint64_t fix_timestamp;
+static uint32_t time_blocked;
+
+/* Reference position. */
+static bool ref_used;
+static double ref_latitude;
+static double ref_longitude;
 
 K_MSGQ_DEFINE(nmea_queue, sizeof(struct nrf_modem_gnss_nmea_data_frame *), 10, 4);
 static K_SEM_DEFINE(pvt_data_sem, 0, 1);
@@ -64,9 +73,37 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_LTE_NETWORK_MODE_LTE_M_GPS) ||
 	     "CONFIG_LTE_NETWORK_MODE_NBIOT_GPS or "
 	     "CONFIG_LTE_NETWORK_MODE_LTE_M_NBIOT_GPS must be enabled");
 
+BUILD_ASSERT((sizeof(CONFIG_GNSS_SAMPLE_REFERENCE_LATITUDE) == 1 &&
+	      sizeof(CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE) == 1) ||
+	     (sizeof(CONFIG_GNSS_SAMPLE_REFERENCE_LATITUDE) > 1 &&
+	      sizeof(CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE) > 1),
+	     "CONFIG_GNSS_SAMPLE_REFERENCE_LATITUDE and "
+	     "CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE must be both either set or empty");
+
 void nrf_modem_recoverable_error_handler(uint32_t error)
 {
 	LOG_ERR("Modem library recoverable error: %u", error);
+}
+
+/* Returns the distance between two coordinates in meters. The distance is calculated using the
+ * haversine formula.
+ */
+static double distance_calculate(double lat1, double lon1,
+				 double lat2, double lon2)
+{
+	double d_lat_rad = (lat2 - lat1) * PI / 180.0;
+	double d_lon_rad = (lon2 - lon1) * PI / 180.0;
+
+	double lat1_rad = lat1 * PI / 180.0;
+	double lat2_rad = lat2 * PI / 180.0;
+
+	double a = pow(sin(d_lat_rad / 2), 2) +
+		   pow(sin(d_lon_rad / 2), 2) *
+		   cos(lat1_rad) * cos(lat2_rad);
+
+	double c = 2 * asin(sqrt(a));
+
+	return 6371.0 * 1000.0 * c;
 }
 
 static void gnss_event_handler(int event)
@@ -240,6 +277,11 @@ static void ttff_test_got_fix_work_fn(struct k_work *item)
 	LOG_INF("Time to fix: %u", time_to_fix);
 	if (time_blocked > 0) {
 		LOG_INF("Time GNSS was blocked by LTE: %u", time_blocked);
+	}
+	if (ref_used) {
+		LOG_INF("Distance from reference: %.01f",
+			distance_calculate(last_pvt.latitude, last_pvt.longitude,
+					   ref_latitude, ref_longitude));
 	}
 	LOG_INF("Sleeping for %u seconds", CONFIG_GNSS_SAMPLE_MODE_TTFF_TEST_INTERVAL);
 }
@@ -562,12 +604,31 @@ static void print_fix_data(struct nrf_modem_gnss_pvt_data_frame *pvt_data)
 	printk("TDOP:           %.01f\n", pvt_data->tdop);
 }
 
+static void print_distance_from_reference(struct nrf_modem_gnss_pvt_data_frame *pvt_data)
+{
+	if (!ref_used) {
+		return;
+	}
+
+	printk("\nDistance from reference: %.01f\n",
+	       distance_calculate(pvt_data->latitude, pvt_data->longitude,
+				  ref_latitude, ref_longitude));
+}
+
 int main(void)
 {
 	uint8_t cnt = 0;
 	struct nrf_modem_gnss_nmea_data_frame *nmea_data;
 
 	LOG_INF("Starting GNSS sample");
+
+	/* Initialize reference coordinates (if used). */
+	if (sizeof(CONFIG_GNSS_SAMPLE_REFERENCE_LATITUDE) > 1 &&
+	    sizeof(CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE) > 1) {
+		ref_used = true;
+		ref_latitude = atof(CONFIG_GNSS_SAMPLE_REFERENCE_LATITUDE);
+		ref_longitude = atof(CONFIG_GNSS_SAMPLE_REFERENCE_LONGITUDE);
+	}
 
 	if (modem_init() != 0) {
 		LOG_ERR("Failed to initialize modem");
@@ -593,8 +654,30 @@ int main(void)
 		    k_sem_take(events[0].sem, K_NO_WAIT) == 0) {
 			/* New PVT data available */
 
-			if (!IS_ENABLED(CONFIG_GNSS_SAMPLE_NMEA_ONLY) &&
-			    !output_paused()) {
+			if (IS_ENABLED(CONFIG_GNSS_SAMPLE_MODE_TTFF_TEST)) {
+				/* TTFF test mode. */
+
+				/* Calculate the time GNSS has been blocked by LTE. */
+				if (last_pvt.flags & NRF_MODEM_GNSS_PVT_FLAG_DEADLINE_MISSED) {
+					time_blocked++;
+				}
+			} else if (IS_ENABLED(CONFIG_GNSS_SAMPLE_NMEA_ONLY)) {
+				/* NMEA-only output mode. */
+
+				if (output_paused()) {
+					goto handle_nmea;
+				}
+
+				if (last_pvt.flags & NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID) {
+					print_distance_from_reference(&last_pvt);
+				}
+			} else {
+				/* PVT and NMEA output mode. */
+
+				if (output_paused()) {
+					goto handle_nmea;
+				}
+
 				printk("\033[1;1H");
 				printk("\033[2J");
 				print_satellite_stats(&last_pvt);
@@ -614,6 +697,7 @@ int main(void)
 				if (last_pvt.flags & NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID) {
 					fix_timestamp = k_uptime_get();
 					print_fix_data(&last_pvt);
+					print_distance_from_reference(&last_pvt);
 				} else {
 					printk("Seconds since last fix: %lld\n",
 					       (k_uptime_get() - fix_timestamp) / 1000);
@@ -623,15 +707,9 @@ int main(void)
 
 				printk("\nNMEA strings:\n\n");
 			}
-#if defined(CONFIG_GNSS_SAMPLE_MODE_TTFF_TEST)
-			else {
-				/* Calculate the time GNSS has been blocked by LTE. */
-				if (last_pvt.flags & NRF_MODEM_GNSS_PVT_FLAG_DEADLINE_MISSED) {
-					time_blocked++;
-				}
-			}
-#endif /* CONFIG_GNSS_SAMPLE_MODE_TTFF_TEST */
 		}
+
+handle_nmea:
 		if (events[1].state == K_POLL_STATE_MSGQ_DATA_AVAILABLE &&
 		    k_msgq_get(events[1].msgq, &nmea_data, K_NO_WAIT) == 0) {
 			/* New NMEA data available */


### PR DESCRIPTION
Added support for reference position. When the reference position is configured, the sample calculates the distance from the reference position for each fix.