### PR TITLE
doc: openthread: update "Configuring a radio co-processor" section

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -60,6 +60,7 @@ Thread
 * Added support for the Link Metrics and CSL Thread v1.2 features for the nRF53 Series devices.
 * Removed support for the :ref:`thread_architectures_designs_cp_ncp` architecture and the related tools.
 * Memory requirements page shows requirements based on the configuration used for certification instead of minimal configuration which has been removed.
+* Updated "Configuring a radio co-processor" section on Thread Border Router page with the information about forcing Hardware Flow Control in JLink.
 
 Zigbee
 ------

--- a/doc/nrf/ug_thread_tools.rst
+++ b/doc/nrf/ug_thread_tools.rst
@@ -143,7 +143,8 @@ To program the nRF device with the RCP application, complete the following steps
 
                west flash --erase
 
-         #. Disable the Mass Storage feature on the device, so that it does not interfere with the core RCP functionalities:
+         #. Disable the Mass Storage feature on the device, so that it does not interfere with the core RCP functionalities.
+            Also, force Hardware Flow Control to avoid potential race conditions related to the auto-detection:
 
             .. parsed-literal::
                :class: highlight
@@ -151,6 +152,8 @@ To program the nRF device with the RCP application, complete the following steps
                JLinkExe -device NRF52840_XXAA -if SWD -speed 4000 -autoconnect 1 -SelectEmuBySN *SEGGER_ID*
                J-Link>MSDDisable
                Probe configured successfully.
+               J-Link>SetHWFC Force
+               New configuration applies immediately.
                J-Link>exit
 
             Replace *SEGGER_ID* with the SEGGER ID of your nRF52840 Development Kit.


### PR DESCRIPTION
Add information about forcing hardware flow control in JLink.