### PR TITLE
zigbee: Add support for ZED/SED role in Shell

### DIFF
--- a/doc/nrf/libraries/zigbee/shell.rst
+++ b/doc/nrf/libraries/zigbee/shell.rst
@@ -165,12 +165,13 @@ Returns the following values:
 * ``zc`` if it is a coordinator.
 * ``zr`` it it is a router.
 * ``zed`` if it is an end device.
+* ``sed`` if it is a sleepy end device.
 
 If the optional argument is provided, set the device role to *role*.
-Can be either ``zc`` or ``zr``.
+Can be either ``zc``, ``zr``, ``zed`` or ``sed``.
 
 .. note::
-    Zigbee End Device is not currently supported by the Shell sample.
+    Switching between Zigbee roles requires a factory new state or a factory reset and a reboot.
 
 
 ----

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -75,6 +75,7 @@ Zigbee
   * Documentation page about :ref:`ug_zigbee_commissioning`.
   * Experimental support for Zigbee Green Power Combo Basic functionality.
   * Zigbee device definition for each Zigbee sample and application.
+  * Support for Sleepy End Device role in :ref:` Zigbee shell library <lib_zigbee_shell>`.
 
 * Updated:
 


### PR DESCRIPTION
It is allowed to set ZED/SED roles while using the library, chosen by the ZC/ZR Kconfigs.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>