### PR TITLE
applications: nrf5340_audio: Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,7 +35,7 @@
 /applications/machine_learning/           @pdunaj
 /applications/matter_weather_station/     @Damian-Nordic @kkasperczyk-no
 /applications/nrf_desktop/                @pdunaj
-/applications/nrf5340_audio/              @koffes @alexsven @erikrobstad @rick1082 @nordic-auko
+/applications/nrf5340_audio/              @koffes @alexsven @erikrobstad @rick1082 @erik-nordic
 /applications/serial_lte_modem/           @junqingzou @pirun @rlubos
 /applications/zigbee_weather_station/     @adsz-nordic @tomchy
 # Boards


### PR DESCRIPTION
Update codeowners for applications/nrf5340_audio

Signed-off-by: Erik van Raalte <erik.van.raalte@nordicsemi.no>