### PR TITLE
samples: nrf9160: modem_shell: Add link dnsaddr command

### DIFF
--- a/samples/nrf9160/modem_shell/src/link/link.h
+++ b/samples/nrf9160/modem_shell/src/link/link.h
@@ -31,5 +31,6 @@ int link_func_mode_set(enum lte_lc_func_mode fun, bool rel14_used);
 int link_func_mode_get(void);
 void link_rai_read(void);
 int link_rai_enable(bool enable);
+int link_setdnsaddr(const char *ip_address);
 
 #endif /* MOSH_LINK_H */

--- a/samples/nrf9160/modem_shell/src/link/link_settings.c
+++ b/samples/nrf9160/modem_shell/src/link/link_settings.c
@@ -47,6 +47,13 @@
 
 /* ****************************************************************************/
 
+#define LINK_SETT_DNSADDR_MAX_IP_LEN 46
+
+#define LINK_SETT_DNSADDR_ENABLED "dnsaddr_enabled"
+#define LINK_SETT_DNSADDR_IP_KEY "dnsaddr_ip"
+
+/* ****************************************************************************/
+
 #define LINK_SETT_SYSMODE_KEY "sysmode"
 #define LINK_SETT_SYSMODE_LTE_PREFERENCE_KEY "sysmode_lte_pref"
 
@@ -69,6 +76,9 @@ struct link_sett_t {
 	char defcontauth_uname_str[LINK_SETT_DEFCONTAUTH_MAX_UNAME_STR_LEN + 1];
 	char defcontauth_pword_str[LINK_SETT_DEFCONTAUTH_MAX_PWORD_STR_LEN + 1];
 	bool defcontauth_enabled;
+
+	char dnsaddr_ip_str[LINK_SETT_DNSADDR_MAX_IP_LEN + 1];
+	bool dnsaddr_enabled;
 
 	enum lte_lc_system_mode sysmode;
 	enum lte_lc_system_mode_preference sysmode_lte_preference;
@@ -152,6 +162,22 @@ static int link_sett_handler(const char *key, size_t len,
 			      sizeof(link_settings.defcontauth_prot));
 		if (err < 0) {
 			mosh_error("Failed to read defcontauth password, error: %d", err);
+			return err;
+		}
+		return 0;
+	} else if (strcmp(key, LINK_SETT_DNSADDR_ENABLED) == 0) {
+		err = read_cb(cb_arg, &link_settings.dnsaddr_enabled,
+			      sizeof(link_settings.dnsaddr_enabled));
+		if (err < 0) {
+			mosh_error("Failed to read dnsaddr enabled, error: %d", err);
+			return err;
+		}
+		return 0;
+	} else if (strcmp(key, LINK_SETT_DNSADDR_IP_KEY) == 0) {
+		err = read_cb(cb_arg, &link_settings.dnsaddr_ip_str,
+			      sizeof(link_settings.dnsaddr_ip_str));
+		if (err < 0) {
+			mosh_error("Failed to read dnsaddr IP, error: %d", err);
 			return err;
 		}
 		return 0;
@@ -442,6 +468,62 @@ void link_sett_defcontauth_conf_shell_print(void)
 
 /* ****************************************************************************/
 
+int link_sett_save_dnsaddr_enabled(bool enabled)
+{
+	const char *key = LINK_SETT_KEY "/" LINK_SETT_DNSADDR_ENABLED;
+	int err;
+
+	link_settings.dnsaddr_enabled = enabled;
+	mosh_print("link dnsaddr %s", ((enabled == true) ? "enabled" : "disabled"));
+
+	err = settings_save_one(key, &link_settings.dnsaddr_enabled,
+				sizeof(link_settings.dnsaddr_enabled));
+	if (err) {
+		mosh_error("%s: err %d from settings_save_one()", __func__, err);
+		return err;
+	}
+	return 0;
+}
+
+bool link_sett_is_dnsaddr_enabled(void)
+{
+	return link_settings.dnsaddr_enabled;
+}
+
+int link_sett_save_dnsaddr_ip(const char *dnsaddr_ip_str)
+{
+	int err;
+	const char *key = LINK_SETT_KEY "/" LINK_SETT_DNSADDR_IP_KEY;
+	int len = strlen(dnsaddr_ip_str);
+
+	assert(len <= LINK_SETT_DNSADDR_MAX_IP_LEN);
+
+	err = settings_save_one(key, dnsaddr_ip_str, len + 1);
+	if (err) {
+		mosh_error("%s: err %d from settings_save_one()", (__func__), err);
+		return err;
+	}
+	mosh_print("%s: key %s with value %s saved", (__func__), key, dnsaddr_ip_str);
+
+	strcpy(link_settings.dnsaddr_ip_str, dnsaddr_ip_str);
+
+	return 0;
+}
+
+const char *link_sett_dnsaddr_ip_get(void)
+{
+	return link_settings.dnsaddr_ip_str;
+}
+
+void link_sett_dnsaddr_conf_shell_print(void)
+{
+	mosh_print("link dnsaddr config:");
+	mosh_print("  Enabled: %s", link_settings.dnsaddr_enabled ? "true" : "false");
+	mosh_print("  IP address: %s", link_settings.dnsaddr_ip_str);
+}
+
+/* ****************************************************************************/
+
 int link_sett_sysmode_save(enum lte_lc_system_mode mode,
 			   enum lte_lc_system_mode_preference lte_pref)
 {
@@ -687,6 +769,7 @@ void link_sett_all_print(void)
 	link_sett_sysmode_print();
 	link_sett_defcont_conf_shell_print();
 	link_sett_defcontauth_conf_shell_print();
+	link_sett_dnsaddr_conf_shell_print();
 	link_sett_normal_mode_at_cmds_shell_print();
 	link_sett_normal_mode_autoconn_shell_print();
 }
@@ -703,6 +786,9 @@ void link_sett_defaults_set(void)
 	link_sett_save_defcontauth_username(LINK_SETT_DEFCONTAUTH_DEFAULT_USERNAME);
 	link_sett_save_defcontauth_password(LINK_SETT_DEFCONTAUTH_DEFAULT_PASSWORD);
 	link_sett_save_defcontauth_prot(PDN_AUTH_NONE);
+
+	link_sett_save_dnsaddr_enabled(false);
+	link_sett_save_dnsaddr_ip("");
 
 	link_sett_sysmode_default_set();
 

--- a/samples/nrf9160/modem_shell/src/link/link_settings.h
+++ b/samples/nrf9160/modem_shell/src/link/link_settings.h
@@ -36,6 +36,12 @@ char *link_sett_defcontauth_username_get(void);
 int link_sett_save_defcontauth_password(const char *password_str);
 char *link_sett_defcontauth_password_get(void);
 
+int link_sett_save_dnsaddr_enabled(bool enabled);
+bool link_sett_is_dnsaddr_enabled(void);
+int link_sett_save_dnsaddr_ip(const char *dnsaddr_ip_str);
+const char *link_sett_dnsaddr_ip_get(void);
+void link_sett_dnsaddr_conf_shell_print(void);
+
 int link_sett_sysmode_save(enum lte_lc_system_mode mode,
 			    enum lte_lc_system_mode_preference lte_pref);
 int link_sett_sysmode_get(void);

--- a/samples/nrf9160/modem_shell/src/link/link_shell.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell.c
@@ -20,6 +20,7 @@
 #include "link_shell_print.h"
 #include "link_shell_pdn.h"
 #include "link_settings.h"
+#include "net_utils.h"
 
 #define LINK_SHELL_EDRX_VALUE_STR_LENGTH 4
 #define LINK_SHELL_EDRX_PTW_STR_LENGTH 4
@@ -43,7 +44,8 @@ enum link_shell_command {
 	LINK_CMD_NORMAL_MODE_AUTO,
 	LINK_CMD_EDRX,
 	LINK_CMD_PSM,
-	LINK_CMD_RAI
+	LINK_CMD_RAI,
+	LINK_CMD_DNSADDR
 };
 
 enum link_shell_common_options {
@@ -106,7 +108,13 @@ static const char link_usage_str[] =
 	"  psm:          Enable/disable Power Saving Mode (PSM) with\n"
 	"                default or with custom parameters\n"
 	"  rai:          Enable/disable RAI feature. Actual use must be set for commands\n"
-	"                supporting RAI. Effective when going to normal mode.\n";
+	"                supporting RAI. Effective when going to normal mode.\n"
+	"  dnsaddr:      Set a manual DNS server address.\n"
+	"                The manual DNS server address will be used if the mobile network\n"
+	"                operator does not provide any DNS addresses, or if the name\n"
+	"                resolution using DNS server(s) provided by mobile network operator\n"
+	"                fails for given domain name. The manual DNS address does not\n"
+	"                override the mobile network operator provided DNS addresses.\n";
 
 static const char link_settings_usage_str[] =
 	"Usage: link settings --read | --reset | --mreset_all | --mreset_user\n"
@@ -299,6 +307,14 @@ static const char link_rai_usage_str[] =
 	"  -d, --disable,      Disable RAI\n"
 	"  -e, --enable,       Enable RAI\n";
 
+static const char link_dnsaddr_usage_str[] =
+	"Usage: link dnsaddr [options] | --read | --enable | --disable\n"
+	"Options:\n"
+	"  -r, --read,         Read and print current config\n"
+	"  -d, --disable,      Disable manual DNS server address\n"
+	"  -e, --enable,       Enable manual DNS server address\n"
+	"  -i, --ipaddr, [str] DNS server IP address\n";
+
 /******************************************************************************/
 
 /* Following are not having short options: */
@@ -338,6 +354,7 @@ static struct option long_options[] = {
 	{ "apn", required_argument, 0, 'a' },
 	{ "cid", required_argument, 0, 'I' },
 	{ "family", required_argument, 0, 'f' },
+	{ "ipaddr", required_argument, 0, 'i' },
 	{ "subscribe", no_argument, 0, 's' },
 	{ "unsubscribe", no_argument, 0, 'u' },
 	{ "read", no_argument, 0, 'r' },
@@ -441,6 +458,9 @@ static void link_shell_print_usage(struct link_shell_cmd_args_t *link_cmd_args)
 		break;
 	case LINK_CMD_RAI:
 		mosh_print_no_format(link_rai_usage_str);
+		break;
+	case LINK_CMD_DNSADDR:
+		mosh_print_no_format(link_dnsaddr_usage_str);
 		break;
 	default:
 		mosh_print_no_format(link_usage_str);
@@ -567,6 +587,7 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 	bool nmode_use_rel14 = true;
 	char *apn = NULL;
 	char *family = NULL;
+	char *ip_address = NULL;
 	int protocol = 0;
 	bool protocol_given = false;
 	char *username = NULL;
@@ -630,6 +651,8 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 	} else if (strcmp(argv[1], "rai") == 0) {
 		require_option = true;
 		link_cmd_args.command = LINK_CMD_RAI;
+	} else if (strcmp(argv[1], "dnsaddr") == 0) {
+		link_cmd_args.command = LINK_CMD_DNSADDR;
 	} else {
 		mosh_error("Unsupported command=%s\n", argv[1]);
 		ret = -EINVAL;
@@ -660,7 +683,7 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 	uint8_t normal_mode_at_mem_slot = 0;
 
 	while ((opt = getopt_long(argc, argv,
-				  "a:I:f:x:w:p:t:A:P:U:su014rmngMNed",
+				  "a:I:f:i:x:w:p:t:A:P:U:su014rmngMNed",
 				  long_options, &long_index)) != -1) {
 		switch (opt) {
 		/* RSRP: */
@@ -817,6 +840,9 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 			break;
 		case 'f': /* Address family */
 			family = optarg;
+			break;
+		case 'i': /* IP address */
+			ip_address = optarg;
 			break;
 		case 'A': /* auth protocol */
 			protocol = atoi(optarg);
@@ -1387,6 +1413,33 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 			link_rai_enable(false);
 		} else {
 			goto show_usage;
+		}
+		break;
+	case LINK_CMD_DNSADDR:
+		if (link_cmd_args.common_option == LINK_COMMON_READ) {
+			link_sett_dnsaddr_conf_shell_print();
+			break;
+		}
+
+		if (ip_address && strlen(ip_address) > 0 &&
+		    net_utils_ip_string_is_valid(ip_address) == false) {
+			mosh_error("Invalid IP address: %s", ip_address);
+			ret = -EINVAL;
+			break;
+		}
+
+		if (link_cmd_args.common_option == LINK_COMMON_ENABLE) {
+			link_sett_save_dnsaddr_enabled(true);
+		} else if (link_cmd_args.common_option == LINK_COMMON_DISABLE) {
+			link_sett_save_dnsaddr_enabled(false);
+		} else if (link_cmd_args.common_option == LINK_COMMON_NONE && ip_address == NULL) {
+			goto show_usage;
+		}
+
+		ret = link_setdnsaddr(ip_address ? ip_address : link_sett_dnsaddr_ip_get());
+
+		if (ip_address) {
+			link_sett_save_dnsaddr_ip(ip_address);
 		}
 		break;
 	case LINK_CMD_DISCONNECT:

--- a/samples/nrf9160/modem_shell/src/utils/net_utils.c
+++ b/samples/nrf9160/modem_shell/src/utils/net_utils.c
@@ -10,6 +10,7 @@
 #include <zephyr/posix/sys/socket.h>
 #include <zephyr/posix/netdb.h>
 #include <zephyr/shell/shell.h>
+#include <nrf_socket.h>
 
 #include "net_utils.h"
 #include "mosh_print.h"
@@ -62,4 +63,13 @@ int net_utils_sa_family_from_ip_string(const char *src)
 		return AF_INET6;
 	}
 	return -1;
+}
+
+bool net_utils_ip_string_is_valid(const char *src)
+{
+	struct nrf_in6_addr in6_addr;
+
+	/* Use nrf_inet_pton() because this has full IP address validation. */
+	return (nrf_inet_pton(NRF_AF_INET, src, &in6_addr) == 1 ||
+		nrf_inet_pton(NRF_AF_INET6, src, &in6_addr) == 1);
 }

--- a/samples/nrf9160/modem_shell/src/utils/net_utils.h
+++ b/samples/nrf9160/modem_shell/src/utils/net_utils.h
@@ -10,5 +10,6 @@
 char *net_utils_sckt_addr_ntop(const struct sockaddr *addr);
 int net_utils_sa_family_from_ip_string(const char *src);
 int net_utils_socket_pdn_id_set(int fd, uint32_t pdn_id);
+bool net_utils_ip_string_is_valid(const char *src);
 
 #endif /* MOSH_NET_UTILS_H */


### PR DESCRIPTION
Add a link command to set a manual DNS address.

The manual DNS server address will be used if the mobile network
operator does not provide any DNS addresses, or if the name
resolution using DNS server(s) provided by mobile network operator
fails for given domain name. The manual DNS address does not
override the mobile network operator provided DNS addresses.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>