### PR TITLE
workflow: Run native_posix tests and generate code coverage in github actions

### DIFF
--- a/.github/workflows/native-posix-tests.yml
+++ b/.github/workflows/native-posix-tests.yml
@@ -1,0 +1,53 @@
+name: Native Posix tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - 'v*-branch'
+  push:
+    branches:
+      - main
+      - 'v*-branch'
+    tags:
+      - v*
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  native_posix_test:
+    runs-on: ubuntu-latest
+    name: Run native_posix tests and generate coverage report
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        with:
+          path: ncs/nrf
+          fetch-depth: 0
+
+      - name: West init and update
+        uses: docker://nordicplayground/nrfconnect-sdk:main
+        with:
+          args: bash -c "cd ncs/nrf && west init -l && west update --narrow -o=--depth=1"
+
+      - name: Run native_posix tests with twister
+        uses: docker://nordicplayground/nrfconnect-sdk:main
+        with:
+          args: bash -c "apt install -y lcov gcc-multilib && cd ncs/nrf && source ../zephyr/zephyr-env.sh && ../zephyr/scripts/twister -i -C -T ./ -p native_posix"
+
+      - name: Replace docker paths in coverage file
+        run: |
+          sudo sed -i 's/\/github\/workspace\//\/home\/runner\/work\/sdk-nrf\/sdk-nrf\//g' ncs/nrf/twister-out/coverage.info
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v1.5.0
+        with:
+          coverage-files: ncs/nrf/twister-out/coverage.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          minimum-coverage: 10
+          working-directory: ncs/nrf
+          artifact-name: code-coverage-report


### PR DESCRIPTION
- Run native_posix tests (which currently include unit tests) in sdk-nrf in github actions. 
- Generate code coverage and publish the summary as a PR comment.
![image](https://user-images.githubusercontent.com/41895435/187429151-bf739efc-c3e3-4a68-9191-ec9a81e0d04b.png)
- Coverage report (html) available as artifact of the job
![image](https://user-images.githubusercontent.com/41895435/187435012-b9370725-0e9c-42ec-8892-6ef77a928a13.png)

- Since the workflow is not yet in the repo, it will not have permissions to post comment or upload the code coverage artifact. To see how this will work, refer https://github.com/balaji-nordic/sdk-nrf/pull/5 
- Future work:
  - Make the action fail if the code coverage is not adequate OR if the PR reduces the coverage on main
  - Replace this with a more feature-rich tool like sonarcloud. See [this conversation](https://teams.microsoft.com/l/message/19:e7aa575b8c2a4438aecc6daa5b380ef8@thread.skype/1662723812041?tenantId=28e5afa2-bf6f-419a-8cf6-b31c6e9e5e8d&groupId=bbf3a6ae-b458-4b7b-9c01-2d2881d8b2fb&parentMessageId=1662723812041&teamName=NCS&channelName=General&createdTime=1662723812041&allowXTenantAccess=false)

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>
