### PR TITLE
net: lib: nrf_cloud: rest: function to update device status

### DIFF
--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -305,6 +305,20 @@ int nrf_cloud_rest_shadow_service_info_update(struct nrf_cloud_rest_context *con
 	const char *const device_id, const struct nrf_cloud_svc_info * const svc_inf);
 
 /**
+ * @brief Update the device status in the shadow.
+ *
+ * @param[in,out] rest_ctx Context for communicating with nRF Cloud's REST API.
+ * @param[in]     device_id Null-terminated, unique device ID registered with nRF Cloud.
+ * @param[in]     dev_status Device status to be encoded.
+ *
+ * @retval 0 If successful.
+ *         Otherwise, a (negative) error code is returned.
+ *         See @verbatim embed:rst:inline :ref:`nrf_cloud_rest_failure` @endverbatim for details.
+ */
+int nrf_cloud_rest_shadow_device_status_update(struct nrf_cloud_rest_context *const rest_ctx,
+	const char *const device_id, const struct nrf_cloud_device_status *const dev_status);
+
+/**
  * @brief Closes the connection to the server.
  *	  The socket pointed to by @p rest_ctx.connect_socket will be closed,
  *	  and @p rest_ctx.connect_socket will be set to -1.

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -345,23 +345,19 @@ clean_up:
 	return ret;
 }
 
-int nrf_cloud_rest_shadow_service_info_update(struct nrf_cloud_rest_context *const rest_ctx,
-	const char *const device_id, const struct nrf_cloud_svc_info * const svc_inf)
+int nrf_cloud_rest_shadow_device_status_update(struct nrf_cloud_rest_context *const rest_ctx,
+	const char *const device_id, const struct nrf_cloud_device_status *const dev_status)
 {
-	if (svc_inf == NULL) {
+	if (dev_status == NULL) {
 		return -EINVAL;
 	}
 
 	int ret;
 	struct nrf_cloud_data data_out;
-	const struct nrf_cloud_device_status dev_status = {
-		.modem = NULL,
-		.svc = (struct nrf_cloud_svc_info *)svc_inf
-	};
 
 	(void)nrf_cloud_codec_init();
 
-	ret = nrf_cloud_device_status_encode(&dev_status, &data_out, false);
+	ret = nrf_cloud_device_status_encode(dev_status, &data_out, false);
 	if (ret) {
 		LOG_ERR("Failed to encode device status, error: %d", ret);
 		return ret;
@@ -375,6 +371,21 @@ int nrf_cloud_rest_shadow_service_info_update(struct nrf_cloud_rest_context *con
 	nrf_cloud_device_status_free(&data_out);
 
 	return ret;
+}
+
+int nrf_cloud_rest_shadow_service_info_update(struct nrf_cloud_rest_context *const rest_ctx,
+	const char *const device_id, const struct nrf_cloud_svc_info * const svc_inf)
+{
+	if (svc_inf == NULL) {
+		return -EINVAL;
+	}
+
+	const struct nrf_cloud_device_status dev_status = {
+		.modem = NULL,
+		.svc = (struct nrf_cloud_svc_info *)svc_inf
+	};
+
+	return nrf_cloud_rest_shadow_device_status_update(rest_ctx, device_id, &dev_status);
 }
 
 int nrf_cloud_rest_fota_job_update(struct nrf_cloud_rest_context *const rest_ctx,


### PR DESCRIPTION
To be aligned with corresponding MQTT support; nrf_cloud_rest_shadow_device_status_update() was added also for REST usage.
Note: the change was tested with upcoming MoSh changes, separate PR with also other changes will be created later for that.
