### PR TITLE
lib: zigbee zcl scenes: Allow storing empty scenes [KRKNWK-14022]

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -658,7 +658,11 @@ Libraries for Zigbee
       *  ``zdo`` shell commands extended to allow binding to a group address.
       * Internal context manager structures.
 
-  * ref:`lib_zigbee_osif`:
+  * :ref:`lib_zigbee_zcl_scenes`:
+
+    * Updated the library, so that it is allowed to store empty scenes.
+
+  * :ref:`lib_zigbee_osif`:
 
     * Updated:
 

--- a/subsys/zigbee/lib/zigbee_scenes/zigbee_zcl_scenes.c
+++ b/subsys/zigbee/lib/zigbee_scenes/zigbee_zcl_scenes.c
@@ -726,15 +726,16 @@ zb_bool_t zcl_scenes_cb(zb_bufid_t bufid)
 					fieldset,
 					fs_content_length);
 			}
-			if (empty_entry == ZB_FALSE) {
-				/* Store this scene */
-				scenes_table[idx].common.group_id = add_scene_req->group_id;
-				scenes_table[idx].common.scene_id = add_scene_req->scene_id;
-				scenes_table[idx].common.transition_time =
-						add_scene_req->transition_time;
-				*add_scene_status = ZB_ZCL_STATUS_SUCCESS;
-				scenes_table_save();
+
+			if (empty_entry) {
+				LOG_WRN("Saving empty scene.");
 			}
+			/* Store this scene */
+			scenes_table[idx].common.group_id = add_scene_req->group_id;
+			scenes_table[idx].common.scene_id = add_scene_req->scene_id;
+			scenes_table[idx].common.transition_time = add_scene_req->transition_time;
+			*add_scene_status = ZB_ZCL_STATUS_SUCCESS;
+			scenes_table_save();
 		} else {
 			LOG_ERR("Unable to add scene: ZB_ZCL_STATUS_INSUFF_SPACE");
 			*add_scene_status = ZB_ZCL_STATUS_INSUFF_SPACE;


### PR DESCRIPTION
ChangeD zigbee scene library to allow storing scenes that do not have any fieldset set in them.