### PR TITLE
nRF21540 runtime MODE pin switching

### DIFF
--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -241,15 +241,28 @@ The following properties are optional and you can add them to the devicetree nod
 
 * Properties that control the other pins:
 
-   * ``ant-sel-gpios`` - GPIO characteristic of the device that controls the ``ANT_SEL`` signal of nRF21540.
-   * ``mode-gpios`` - GPIO characteristic of the device that controls the ``MODE`` signal of nRF21540.
+  * ``ant-sel-gpios`` - GPIO characteristic of the device that controls the ``ANT_SEL`` signal of the nRF21540.
+  * ``mode-gpios`` - GPIO characteristic of the device that controls the ``MODE`` signal of the nRF21540.
+
+    The ``MODE`` signal of the nRF21540 switches between two values of PA gain.
+    The pin can either be set to a fixed state on initialization, which results in a constant PA gain, or it can be switched in run-time by the protocol drivers to match the transmission power requested by the application.
+
+    To enable run-time ``MODE`` pin switching, you must enable :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_RUNTIME_PA_GAIN_CONTROL`.
+
+    .. note::
+       The state of the ``MODE`` pin is selected based on the available PA gains and the required transmission power.
+       To achieve reliable performance, :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA` and :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTB` must reflect the content of the nRF21540 registers.
+       Their default values match chip production defaults.
+       For details, see the `nRF21540 Product Specification`_.
+
+    If the run-time ``MODE`` pin switching is disabled, the PA gain is constant and equal to :kconfig:option:`CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB`.
 
 * Properties that control the timing of interface signals:
 
   * ``tx-en-settle-time-us`` - Minimal time interval between asserting the ``TX_EN`` signal and starting the radio transmission, in microseconds.
   * ``rx-en-settle-time-us`` - Minimal time interval between asserting the ``RX_EN`` signal and starting the radio transmission, in microseconds.
 
-    .. important::
+    .. note::
         Values for these two properties cannot be higher than the Radio Ramp-Up time defined by :c:macro:`TX_RAMP_UP_TIME` and :c:macro:`RX_RAMP_UP_TIME`.
         If the value is too high, the radio driver will not work properly and will not control FEM.
         Moreover, setting a value that is lower than the default value can cause disturbances in the radio transmission, because FEM may be triggered too late.
@@ -312,7 +325,7 @@ To use the Simple GPIO implementation of FEM with SKY66112-11, complete the foll
 Optional properties
 -------------------
 
-The following properties are optional and you can add them to the devicetree node if needed.
+The following properties are optional and   you can add them to the devicetree node if needed.
 
 * Properties that control the other pins:
 

--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -97,6 +97,17 @@ config MPSL_FEM_NRF21540_RX_GAIN_DB
 	  The default value of 13 dB is based on nRF21540 Product Specification
 	  (v1.0)
 
+config MPSL_FEM_NRF21540_RUNTIME_PA_GAIN_CONTROL
+	bool "Support for a run-time PA gain control of the nRF21540 FEM"
+	help
+	  If this option is enabled the PA gain will be controlled during run-time by setting
+	  appropriate level of MODE pin of the nRF21540 device. Initial default gain is determined by
+	  MPSL_FEM_NRF21540_TX_GAIN_DB. The MODE is switched during run-time based on required transmit
+	  power and selects between gain MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA and
+	  MPSL_FEM_NRF21540_TX_GAIN_DB_POUTB.
+	  If this option is disabled the PA gain will be constant during run-time and is
+	  determined by MPSL_FEM_NRF21540_TX_GAIN_DB.
+
 endif
 
 endif	# MPSL_FEM

--- a/subsys/mpsl/fem/mpsl_fem.c
+++ b/subsys/mpsl/fem/mpsl_fem.c
@@ -26,11 +26,16 @@
 
 #define MPSL_FEM_GPIO_INVALID_PIN        0xFFU
 #define MPSL_FEM_GPIOTE_INVALID_CHANNEL  0xFFU
-#define MPSL_FEM_DISABLED_GPIO_CONFIG_INIT \
+#define MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT \
 	.enable       = false, \
 	.active_high  = true, \
 	.gpio_pin     = MPSL_FEM_GPIO_INVALID_PIN, \
 	.gpiote_ch_id = MPSL_FEM_GPIOTE_INVALID_CHANNEL
+
+#define MPSL_FEM_DISABLED_GPIO_CONFIG_INIT \
+	.enable       = false, \
+	.active_high  = true, \
+	.gpio_pin     = MPSL_FEM_GPIO_INVALID_PIN
 
 static void fem_pin_num_correction(uint8_t *p_gpio_pin, const char *gpio_lbl)
 {
@@ -191,8 +196,12 @@ static int fem_nrf21540_gpio_configure(void)
 			.trx_hold_us     =
 				DT_PROP(DT_NODELABEL(nrf_radio_fem),
 					trx_hold_time_us),
-			.pa_gain_db      =
+			.pa_gain_db =
 				CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB,
+			.pa_gains_db = {
+				[0] = CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA,
+				[1] = CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTB,
+			},
 			.lna_gain_db     =
 				CONFIG_MPSL_FEM_NRF21540_RX_GAIN_DB
 		},
@@ -206,7 +215,7 @@ static int fem_nrf21540_gpio_configure(void)
 					    tx_en_gpios),
 			.gpiote_ch_id = txen_gpiote_channel
 #else
-			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
 		},
 		.lna_pin_config = {
@@ -219,7 +228,7 @@ static int fem_nrf21540_gpio_configure(void)
 					    rx_en_gpios),
 			.gpiote_ch_id = rxen_gpiote_channel
 #else
-			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
 		},
 		.pdn_pin_config = {
@@ -231,6 +240,19 @@ static int fem_nrf21540_gpio_configure(void)
 				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
 					    pdn_gpios),
 			.gpiote_ch_id = pdn_gpiote_channel
+#else
+			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
+#endif
+		},
+		.mode_pin_config = {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), mode_gpios) && \
+	IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_RUNTIME_PA_GAIN_CONTROL)
+			.enable      = true,
+			.active_high =
+				MPSL_FEM_GPIO_POLARITY_GET(mode_gpios),
+			.gpio_pin    =
+				DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem),
+					    mode_gpios)
 #else
 			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
 #endif
@@ -281,21 +303,28 @@ static int fem_nrf21540_gpio_configure(void)
 	  (CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB == CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA) ||
 	  (CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB == CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTB));
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), mode_gpios)
-	gpio_flags_t mode_pin_flags = GPIO_OUTPUT_ACTIVE;
-
-	if (CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB == CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA) {
-		mode_pin_flags = GPIO_OUTPUT_INACTIVE;
+	if (IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_RUNTIME_PA_GAIN_CONTROL)) {
+		fem_pin_num_correction(&cfg.mode_pin_config.gpio_pin,
+						DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem),
+								mode_gpios));
 	}
+	else {
+		gpio_flags_t mode_pin_flags = GPIO_OUTPUT_ACTIVE;
 
-	mode_pin_flags |= DT_GPIO_FLAGS(DT_NODELABEL(nrf_radio_fem), mode_gpios);
+		if (CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB == CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA) {
+			mode_pin_flags = GPIO_OUTPUT_INACTIVE;
+		}
 
-	err = gpio_pin_configure(
-		DEVICE_DT_GET(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), mode_gpios)),
-		DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), mode_gpios),
-		mode_pin_flags);
+		mode_pin_flags |= DT_GPIO_FLAGS(DT_NODELABEL(nrf_radio_fem), mode_gpios);
 
-	if (err) {
-		return err;
+		err = gpio_pin_configure(
+			DEVICE_DT_GET(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), mode_gpios)),
+			DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), mode_gpios),
+			mode_pin_flags);
+
+		if (err) {
+			return err;
+		}
 	}
 #endif
 
@@ -365,7 +394,7 @@ static int fem_simple_gpio_configure(void)
 					    ctx_gpios),
 			.gpiote_ch_id = ctx_gpiote_channel
 #else
-			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
 		},
 		.lna_pin_config = {
@@ -378,7 +407,7 @@ static int fem_simple_gpio_configure(void)
 					    crx_gpios),
 			.gpiote_ch_id = crx_gpiote_channel
 #else
-			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
+			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
 #endif
 		}
 	};


### PR DESCRIPTION
This PR brings ability to control gain of nRF21540 in run-time by switching `MODE` pin.
The feature is implemented in mpsl, changes in the sdk-nrf allow this feature to be enabled by an user.

mpsl will go with https://github.com/nrfconnect/sdk-nrf/pull/7578, so merge this PR after that

- [x] Merge after https://github.com/nrfconnect/sdk-nrf/pull/7578
- [x] Remove commit "manifest: Update nrfxlib revision" after #7578 is merged