### PR TITLE
applications: asset_tracker_v2: Improve Memfault handling

### DIFF
--- a/applications/asset_tracker_v2/src/events/cloud_module_event.c
+++ b/applications/asset_tracker_v2/src/events/cloud_module_event.c
@@ -34,8 +34,6 @@ static char *get_evt_type_str(enum cloud_module_event_type type)
 		return "CLOUD_EVT_CONFIG_RECEIVED";
 	case CLOUD_EVT_CONFIG_EMPTY:
 		return "CLOUD_EVT_CONFIG_EMPTY";
-	case CLOUD_EVT_DATA_ACK:
-		return "CLOUD_EVT_DATA_ACK";
 	case CLOUD_EVT_DATA_SEND_QOS:
 		return "CLOUD_EVT_DATA_SEND_QOS";
 	case CLOUD_EVT_SHUTDOWN_READY:

--- a/applications/asset_tracker_v2/src/events/cloud_module_event.h
+++ b/applications/asset_tracker_v2/src/events/cloud_module_event.h
@@ -69,13 +69,12 @@ enum cloud_module_event_type {
 	/** An error occurred during a FOTA update. */
 	CLOUD_EVT_FOTA_ERROR,
 
-	/** Sending of data to cloud has been attempted.
-	 *  The payload associated with this event is of type @ref cloud_module_data_ack (ack).
-	 */
-	CLOUD_EVT_DATA_ACK,
-
 	/** Sending data to cloud using QoS library.
 	 *  The payload associated with this event is of type @ref qos_data (message).
+	 *
+	 *  This event is only meant for the cloud module and is used to filter QoS data through
+	 *  the module's internal message queue. This event is consumed by the cloud module as soon
+	 *  as it has been processed.
 	 */
 	CLOUD_EVT_DATA_SEND_QOS,
 

--- a/applications/asset_tracker_v2/src/events/data_module_event.h
+++ b/applications/asset_tracker_v2/src/events/data_module_event.h
@@ -29,18 +29,27 @@ enum data_module_event_type {
 	/** Send newly sampled data.
 	 *  The event has an associated payload of type @ref data_module_data_buffers in
 	 *  the `data.buffer` member.
+	 *
+	 *  If a non LwM2M build is used the data is heap allocated and must be freed after use by
+	 *  calling k_free() on `data.buffer.buf`.
 	 */
 	DATA_EVT_DATA_SEND,
 
 	/** Send older batched data.
 	 *  The event has an associated payload of type @ref data_module_data_buffers in
 	 *  the `data.buffer` member.
+	 *
+	 *  If a non LwM2M build is used the data is heap allocated and must be freed after use by
+	 *  calling k_free() on `data.buffer.buf`.
 	 */
 	DATA_EVT_DATA_SEND_BATCH,
 
 	/** Send UI button data.
 	 *  The event has an associated payload of type @ref data_module_data_buffers in
 	 *  the `data.buffer` member.
+	 *
+	 *  If a non LwM2M build is used the data is heap allocated and must be freed after use by
+	 *  calling k_free() on `data.buffer.buf`.
 	 */
 	DATA_EVT_UI_DATA_SEND,
 
@@ -50,12 +59,18 @@ enum data_module_event_type {
 	/** Send neighbor cell measurements.
 	 *  The event has an associated payload of type @ref data_module_data_buffers in
 	 *  the `data.buffer` member.
+	 *
+	 *  If a non LwM2M build is used the data is heap allocated and must be freed after use by
+	 *  calling k_free() on `data.buffer.buf`.
 	 */
 	DATA_EVT_NEIGHBOR_CELLS_DATA_SEND,
 
 	/** Send A-GPS request.
 	 *  The event has an associated payload of type @ref data_module_data_buffers in
 	 *  the `data.buffer` member.
+	 *
+	 *  If a non LwM2M build is used the data is heap allocated and must be freed after use by
+	 *  calling k_free() on `data.buffer.buf`.
 	 */
 	DATA_EVT_AGPS_REQUEST_DATA_SEND,
 
@@ -74,6 +89,9 @@ enum data_module_event_type {
 	/** Acknowledge the applied device configuration to cloud.
 	 *  The event has an associated payload of type @ref data_module_data_buffers in
 	 *  the `data.buffer` member.
+	 *
+	 *  If a non LwM2M build is used the data is heap allocated and must be freed after use by
+	 *  calling k_free() on `data.buffer.buf`.
 	 */
 	DATA_EVT_CONFIG_SEND,
 

--- a/applications/asset_tracker_v2/src/events/debug_module_event.h
+++ b/applications/asset_tracker_v2/src/events/debug_module_event.h
@@ -20,17 +20,13 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT)
-#define MEMFAULT_BUFFER_SIZE_MAX CONFIG_DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX
-#else
-#define MEMFAULT_BUFFER_SIZE_MAX 0
-#endif /* if defined(CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT) */
-
 enum debug_module_event_type {
 	/** Event carrying memfault data that should be forwarded via the configured cloud
 	 *  backend to Memfault cloud. Only sent if
 	 *  CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT is enabled.
 	 *  Payload is of type @ref debug_module_memfault_data.
+	 *
+	 *  The payload is heap allocated and must be freed after use.
 	 */
 	DEBUG_EVT_MEMFAULT_DATA_READY,
 
@@ -52,7 +48,7 @@ enum debug_module_event_type {
 };
 
 struct debug_module_memfault_data {
-	uint8_t buf[MEMFAULT_BUFFER_SIZE_MAX];
+	uint8_t *buf;
 	size_t len;
 };
 

--- a/applications/asset_tracker_v2/src/modules/Kconfig.debug_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.debug_module
@@ -9,14 +9,29 @@ menuconfig DEBUG_MODULE
 
 if DEBUG_MODULE && MEMFAULT
 
+config DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX
+	int "Fragment size of data transmitted to memfault"
+	default 2048
+	help
+	  Decreasing this value, will in case of a core-dump, produce more events carrying
+	  Memfault data to the cloud module. This increases the possibility of an overfilled
+	  cloud module message queue depending on how fast the cloud module thread can handle
+	  incoming queue messages. An overfilled message queue is in general considered a fatal
+	  error that can cause undefined behaviour. To reduce the likelihood of this issue
+	  occurring, this value should be kept reasonably high, within the modem firmware's
+	  documented limitations.
+
 config DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT
 	bool "Use external transport when sending memfault data"
+	default y if AWS_IOT
 	help
 	  If enabled, the debug module will forward captured Memfault data via events of type
 	  DEBUG_EVT_MEMFAULT_DATA_READY. The data will be forwarded via the configured cloud
 	  to Memfault. If this option is disabled, the debug module will use Memfault firwmare SDKs
 	  own internal HTTP transport. Transporting Memfault data over an already pre-established
 	  transport can save data associated with maintaining multiple connections.
+	  The AWS IoT configuration of the application is the only implementation that currently
+	  supports this option.
 
 config DEBUG_MODULE_MEMFAULT_HEARTBEAT_INTERVAL_SEC
 	int "Memfault heartbeat interval in seconds"
@@ -36,20 +51,11 @@ config DEBUG_MODULE_MEMFAULT_WATCHDOG_DELTA_MS
 
 config DEBUG_MODULE_MEMFAULT_THREAD_STACK_SIZE
 	int "Debug module Memfault thread stack size"
-	default 1152
+	default 4096
 
-config DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX
-	int "Fragment size of data transmitted to memfault"
-	default 2048 if DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT
-	default 80
-	help
-	  Decreasing this value, will in case of a core-dump, produce more events carrying
-	  Memfault data to the cloud module. This increases the possibility of an overfilled
-	  cloud module message queue depending on how fast the cloud module thread can handle
-	  incoming queue messages. An overfilled message queue is in general considered a fatal
-	  error that can cause undefined behaviour. To reduce the likelyhood of this issue
-	  occurring, this value should be kept reasonably high, wihin the modem firmware's
-	  documented limitations.
+config DEBUG_MODULE_MEMFAULT_UPDATES_MIN_INTERVAL_SEC
+	int "Minimum time between Memfault metric updates, in seconds"
+	default 900
 
 endif # DEBUG_MODULE && MEMFAULT
 

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -1392,10 +1392,6 @@ static void on_all_states(struct data_msg_data *msg)
 	if (IS_EVENT(msg, gnss, GNSS_EVT_TIMEOUT)) {
 		requested_data_status_set(APP_DATA_GNSS);
 	}
-
-	if (IS_EVENT(msg, cloud, CLOUD_EVT_DATA_ACK)) {
-		k_free(msg->module.cloud.data.ack.ptr);
-	}
 }
 
 static void module_thread_fn(void)

--- a/applications/asset_tracker_v2/tests/debug_module/CMakeLists.txt
+++ b/applications/asset_tracker_v2/tests/debug_module/CMakeLists.txt
@@ -22,6 +22,7 @@ cmock_handle(${MEMFAULT_SDK_DIR}/components/include/memfault/metrics/metrics.h m
 cmock_handle(${MEMFAULT_SDK_DIR}/ports/zephyr/include/memfault/ports/zephyr/http.h memfault/ports/zephyr)
 cmock_handle(${MEMFAULT_SDK_DIR}/components/include/memfault/core/data_packetizer.h memfault/core)
 cmock_handle(${MEMFAULT_SDK_DIR}/components/include/memfault/core/trace_event.h memfault/core)
+cmock_handle(${MEMFAULT_SDK_DIR}/components/include/memfault/panics/coredump.h memfault/panics)
 cmock_handle(${MEMFAULT_SDK_DIR}/ports/include/memfault/ports/watchdog.h memfault/ports)
 
 # Create mock for nRF SDK
@@ -57,6 +58,12 @@ target_include_directories(app PRIVATE ${MEMFAULT_SDK_DIR}/components/include/co
 # Include nRFxlib directories
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/../nrfxlib/nrf_modem/include/)
 
+# Include platform specific header file that is used to describe the registers of
+# the given platform. Without this file, generation of mocks will
+# fail due to a incomplete type warning.
+set_property(SOURCE mocks/memfault/panics/mock_coredump.c PROPERTY COMPILE_FLAGS
+	     "-include ${MEMFAULT_SDK_DIR}/components/include/memfault/panics/arch/arm/cortex_m.h")
+
 # Options that cannot be passed through Kconfig fragments.
 target_compile_options(app PRIVATE
   	-DCONFIG_ASSET_TRACKER_V2_APP_VERSION_MAX_LEN=20
@@ -68,6 +75,7 @@ target_compile_options(app PRIVATE
 	-DCONFIG_DEBUG_MODULE_MEMFAULT_WATCHDOG_DELTA_MS=5000
 	-DCONFIG_DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX=80
 	-DCONFIG_DEBUG_MODULE_MEMFAULT_THREAD_STACK_SIZE=256
+	-DCONFIG_DEBUG_MODULE_MEMFAULT_UPDATES_MIN_INTERVAL_SEC=900
 	-DCONFIG_CLOUD_CODEC_APN_LEN_MAX=1
 	-DCONFIG_MODEM_APN_LEN_MAX=1
 	-DCONFIG_CLOUD_CODEC_LWM2M_PATH_LIST_ENTRIES_MAX=1


### PR DESCRIPTION
Improve/fix memfault handling by:

 - Incorporate sending of memfault data with the QoS library.

   *This ensures that failed transmissions are retired. However,
    it also require that each chunk is heap allocated (for now)
    so that we are able to persist each chunk until it has been ACKed.
    Setting aside aside 16kB++ for storage in case a
    coredumps happens (which is expected to be rare)* doesn't seem
    viable.

 - Prevent modules that subscribe to cloud module events from receiving
   the `CLOUD_EVT_DATA_SEND_QOS` event.

   *Upon coredumps (and batched metrics/events), a lot of the
    aforementioned events are sent out from the cloud module
    causing message queues in other modules
    (that have lower number of message queue entries) to overflow.*

 - Remove the `CLOUD_EVT_DATA_ACK` event.

   *Move responsibility of freeing data to the cloud module and remove
    the `CLOUD_EVT_DATA_ACK` event. This is due to the same
    reason stated in the previous point. Since the cloud module already
    implements handling of retransmissions and has access to
    information about each message, I think its ok to have it free the
    data as well.*