### PR TITLE
samples: openthread: increase ble advertising interval

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -284,6 +284,7 @@ Thread samples
   * The relevant sample documentation pages with information about support for :ref:`Trusted Firmware-M <ug_tfm>`.
   * All sample documentation with a Configuration section, and organized relevant information under that section.
   * Mnimal configuration for CLI sample has been removed.
+  * BLE advertising interval has been increased from 100 ms to 300 ms for CLI sample when multiprotocol is enabled.
 
 Matter samples
 --------------

--- a/samples/openthread/cli/src/ble.c
+++ b/samples/openthread/cli/src/ble.c
@@ -12,6 +12,9 @@
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
+#define ADV_INT_MIN 0x01e0 /* 300 ms */
+#define ADV_INT_MAX 0x0260 /* 380 ms */
+
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
 	BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
@@ -21,7 +24,10 @@ static struct bt_conn_cb conn_callbacks;
 
 void ble_enable(void)
 {
+	struct bt_le_adv_param *adv_param = BT_LE_ADV_PARAM(
+		BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME, ADV_INT_MIN, ADV_INT_MAX, NULL);
+
 	bt_enable(NULL);
 	bt_conn_cb_register(&conn_callbacks);
-	bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	bt_le_adv_start(adv_param, ad, ARRAY_SIZE(ad), NULL, 0);
 }


### PR DESCRIPTION
Increase BLE advertising interval from 100 ms to 300 ms to avoid
potentional Thread communication problems.
It has been observed on CI that BLE advertising with 100 ms interval
may interfere with e.g. Data Resonse packets from parent which include
queried link metrics.