### PR TITLE
modules: memfault: option for custom Memfault Device Info

### DIFF
--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -12,6 +12,24 @@ config MEMFAULT_NCS_PROJECT_KEY
 	  Memfault project key
 
 choice
+	prompt "Choose built-in Memfault Device Info or custom implementation"
+	default MEMFAULT_DEVICE_INFO_BUILTIN
+
+config MEMFAULT_DEVICE_INFO_BUILTIN
+	bool "Built-in Memfault Device Info implementation"
+	help
+	  Use built-in Memfault Device Info implementation
+
+config MEMFAULT_DEVICE_INFO_CUSTOM
+	bool "Custom user-defined Memfault Device Info implementation"
+	help
+	  Use custom user-defined Memfault Device Info implementation.
+	  'memfault_platform_get_device_info()' will need to be defined in the
+	  application.
+
+endchoice
+
+choice
 	prompt "Memfault device ID generation method"
 	default MEMFAULT_NCS_DEVICE_ID_IMEI if (BOARD_NRF9160DK_NRF9160_NS || BOARD_THINGY91_NRF9160_NS)
 	default MEMFAULT_NCS_DEVICE_ID_STATIC
@@ -51,6 +69,7 @@ config MEMFAULT_NCS_HW_VERSION
 	string "Hardware version"
 	default "nrf9160dk" if BOARD_NRF9160DK_NRF9160_NS
 	default "thingy91" if BOARD_THINGY91_NRF9160_NS
+	default BOARD
 	help
 	  Device hardware version
 

--- a/modules/memfault-firmware-sdk/memfault_integration.c
+++ b/modules/memfault-firmware-sdk/memfault_integration.c
@@ -56,12 +56,16 @@ BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC) > 1,
 	static char device_serial[CONFIG_MEMFAULT_NCS_DEVICE_ID_MAX_LEN + 1];
 #endif
 
+/* Hardware version check */
+BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_HW_VERSION) > 1, "Hardware version must be configured");
+
 extern void memfault_ncs_metrcics_init(void);
 
 sMfltHttpClientConfig g_mflt_http_client_config = {
 	.api_key = CONFIG_MEMFAULT_NCS_PROJECT_KEY,
 };
 
+#if defined(CONFIG_MEMFAULT_DEVICE_INFO_BUILTIN)
 void memfault_platform_get_device_info(sMemfaultDeviceInfo *info)
 {
 #if defined(CONFIG_MEMFAULT_NCS_FW_VERSION_AUTO)
@@ -90,6 +94,7 @@ void memfault_platform_get_device_info(sMemfaultDeviceInfo *info)
 		.hardware_version = CONFIG_MEMFAULT_NCS_HW_VERSION,
 	};
 }
+#endif /* defined(CONFIG_MEMFAULT_DEVICE_INFO_BUILTIN) */
 
 #ifdef CONFIG_MEMFAULT_NCS_DEVICE_ID_IMEI
 static int request_imei(const char *cmd, char *buf, size_t buf_len)


### PR DESCRIPTION
 ### Summary

Occasionally we see customers wanting a more complex implementation for
`memfault_platform_get_device_info()` (typically when setting the
parameters at runtime). There's support for runtime setting of the
`device_serial`, but the other parameters are set at complile time.
Instead of adding individual support for runtime setting each value, add
a Kconfig option to enable implementing a custom
`memfault_platform_get_device_info()` function.

Three changes in this patch:

1. add Kconfig options to enable a custom implementation of
   `memfault_platform_get_device_info()`
2. add a compile-time check that `CONFIG_MEMFAULT_NCS_HW_VERSION` is set
   to a string of length > 1 (rarely, we see people run into this)
3. set the default `CONFIG_MEMFAULT_NCS_HW_VERSION` value to be `BOARD`
   in the fallthrough case (in the situation where the user is
   specifying a custom `BOARD`)

 ### Test Plan

- able to build `samples/nrf9160/memfault` with default values as before
- building with `CONFIG_MEMFAULT_NCS_HW_VERSION` explicitly set to `""`
  causes a build error
- building with `-- -DCONFIG_MEMFAULT_DEVICE_INFO_CUSTOM=y` causes an
  expected link error due to missing
  `memfault_platform_get_device_info()`. adding an implementation
  resolves it

Signed-off-by: Noah Pendleton <noah@memfault.com>