### PR TITLE
openthread: samples: Adding overlays for CI and multiprotocol.

### DIFF
--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -87,6 +87,8 @@ The following configuration files are available:
 * :file:`overlay-rtt.conf` - Redirects logs to RTT.
   For more information about RTT please refer to :ref:`RTT logging <ug_logging>`.
 * :file:`overlay-debug.conf` - Enables debbuging the Thread sample with GDB thread awareness.
+* :file:`overlay-ci.conf` - Disables boot banner and shell prompt.
+* :file:`overlay-multiprotocol.conf` - Enables Bluetooth LE support in this sample.
 
 FEM support
 ===========

--- a/samples/openthread/cli/overlay-ci.conf
+++ b/samples/openthread/cli/overlay-ci.conf
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Disable boot banner
+CONFIG_BOOT_BANNER=n
+
+# Shell configuration for CI
+CONFIG_SHELL_PROMPT_UART=""
+CONFIG_SHELL_VT100_COLORS=n
+CONFIG_SHELL_DEFAULT_TERMINAL_WIDTH=416

--- a/samples/openthread/cli/overlay-multiprotocol.conf
+++ b/samples/openthread/cli/overlay-multiprotocol.conf
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2144
+
+# Enable and configure Bluetooth LE
+CONFIG_BT=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_NAME="NCS DUT"
+CONFIG_BT_DEVICE_APPEARANCE=833

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -4,35 +4,41 @@ sample:
 tests:
   sample.openthread.cli:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
+    extra_args: OVERLAY_CONFIG=overlay-ci.conf;overlay-multiprotocol.conf
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf52840dk_nrf52840
-      - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840
+  sample.openthread.cli_hadron:
+    build_only: true
+    platform_allow: nrf52833dk_nrf52833
+    tags: ci_build
+    extra_args: OVERLAY_CONFIG=overlay-ci.conf
+    integration_platforms:
+      - nrf52833dk_nrf52833
   sample.openthread.cli.thread_1_1:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
     extra_args: CONFIG_OPENTHREAD_THREAD_VERSION_1_1=y
+                OVERLAY_CONFIG=overlay-ci.conf;overlay-multiprotocol.conf
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf52840dk_nrf52840
-      - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840
   sample.openthread.cli.usb:
     build_only: true
-    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
-    extra_args: OVERLAY_CONFIG=overlay-usb.conf
-                DTC_OVERLAY_FILE="usb.overlay"
+    extra_args: OVERLAY_CONFIG=overlay-usb.conf;overlay-ci.conf;overlay-multiprotocol.conf
+                DTC_OVERLAY_FILE=usb.overlay
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf52840dk_nrf52840
       - nrf52840dongle_nrf52840
-      - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840


### PR DESCRIPTION
This commit adds overlay for multiprotocol enablemnt and CI in
threead CLI sample.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>

test-sdk-nrf:sdk-nrf-PR-7554