### PR TITLE
manifest: update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 283c8063bc06ceb951b1f7ee116d70b9efbd1b0a
+      revision: pull/792/head
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Mesh is no longer Experimental, as it has been ready
for production since v1.7.1. Experimantal status should
not be shown while building with mesh.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>