### PR TITLE
manifest: update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 4ab692bec88a143f89f2abfdc086e3f8087622f4
+      revision: fec8aa6c1312a3e208b1c920f833cfb1c40cebe9
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Mesh is no longer Experimental, as it has been ready
for production since v1.7.1. Experimantal status should
not be shown while building with mesh.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>