### PR TITLE
doc: Remove GNU Arm Embedded Toolchain from NCS documentation

### DIFF
--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -608,7 +608,6 @@ Glossary
 
    Toolchain
       A set of development tools.
-      See `GNU Arm Embedded Toolchain`_.
 
    Transmit Data (TXD)
       A signal line in a serial interface that transmits data to another device.

--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -20,7 +20,6 @@ See the following sections for detailed instructions.
 If you already have your system set up to work with Zephyr OS based on Zephyr's :ref:`zephyr:getting_started`, you already have some of the requirements for the |NCS| installed.
 The only requirement not covered by the installation steps in Zephyr is the :ref:`GN tool <gs_installing_gn>`.
 This tool is needed only for :ref:`ug_matter` applications.
-You can also skip the `Install the GNU Arm Embedded Toolchain`_ section.
 
 Before you start setting up the toolchain, install available updates for your operating system.
 See :ref:`gs_recommended_versions` for information on the supported operating systems and Zephyr features.
@@ -67,10 +66,6 @@ The installation process is different depending on your operating system.
       Ensure that these dependencies are installed with their versions as specified in the :ref:`Required tools table <req_tools_table>`.
       Refer to the :ref:`zephyr:installation_linux` page for additional information on updating the dependencies manually.
       If you are using other Linux-based operating systems, see the :ref:`zephyr:linux_requirements` section in the Zephyr documentation.
-
-      .. note::
-         You do not need to install the Zephyr SDK.
-         We recommend to install the compiler toolchain separately, as detailed in `Install the GNU Arm Embedded Toolchain`_.
 
    .. group-tab:: macOS
 
@@ -365,88 +360,16 @@ Use the following commands to install the requirements for each repository.
 
 .. rst-class:: numbered-step
 
-Install the GNU Arm Embedded Toolchain
-**************************************
+Install a Toolchain
+*******************
 
-To be able to cross-compile your applications for Arm targets, you must install version 9-2019-q4-major of the `GNU Arm Embedded Toolchain`_.
+A toolchain provides a compiler, assembler, linker, and other programs required to build Zephyr applications.
 
-.. important::
-   Make sure to install the toolchain version that is mentioned above.
-   Other toolchain versions might not work with this version of the |NCS|.
-   Similarly, other versions of the |NCS| might require a different toolchain version.
-
-   |tfm_gnu_version_incompatibility|
-
-To set up the toolchain, complete the following steps:
-
-.. _toolchain_setup:
-
-1. Download the `GNU Arm Embedded Toolchain`_ for your operating system.
-#. Extract the contents of the root folder of the toolchain into a directory of your choice.
-   The recommended folder is :file:`c:\\gnuarmemb` on Windows and :file:`~/gnuarmemb` on Linux or macOS.
-   Make sure that the folder name does not contain any spaces or special characters.
-   By default, the contents are extracted to another folder that corresponds to the GNU Arm Embedded Toolchain version (*version-folder* in the following step).
-   For example, :file:`c:\\gccarmemb\\9_2019-q4-major`, where :file:`9_2019-q4-major` is the *version-folder* name edited to contain no empty spaces.
-#. If you want to build and program applications from the command line, define the environment variables for the GNU Arm Embedded Toolchain.
-   Depending on your operating system:
-
-    .. tabs::
-
-       .. group-tab:: Windows
-
-          Open a command-line window and enter the commands below.
-
-          If you did not install the toolchain in the recommended folder, change the value of :envvar:`GNUARMEMB_TOOLCHAIN_PATH` to the folder you used and make sure to provide the name of the *version-folder*.
-
-            .. parsed-literal::
-               :class: highlight
-
-               set ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-               set GNUARMEMB_TOOLCHAIN_PATH=\ c:\\gnuarmemb\\version-folder
-
-       .. group-tab:: Linux
-
-          Open a terminal window and enter the commands below.
-
-          If you did not install the toolchain in the recommended folder, change the value of :envvar:`GNUARMEMB_TOOLCHAIN_PATH` to the folder you used and make sure to provide the name of the *version-folder*.
-
-            .. parsed-literal::
-               :class: highlight
-
-               export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-               export GNUARMEMB_TOOLCHAIN_PATH=\ "~/gnuarmemb/*version-folder*"
-
-       .. group-tab:: macOS
-
-          Open a terminal window and enter the commands below.
-
-          If you did not install the toolchain in the recommended folder, change the value of :envvar:`GNUARMEMB_TOOLCHAIN_PATH` to the folder you used and make sure to provide the name of the *version-folder*.
-
-            .. parsed-literal::
-               :class: highlight
-
-               export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-               export GNUARMEMB_TOOLCHAIN_PATH=\ "~/gnuarmemb/*version-folder*"
-
-#. Set the environment variables persistently.
-   Depending on your operating system:
-
-    .. tabs::
-
-       .. group-tab:: Windows
-
-          Add the environment variables as system environment variables or define them in the :file:`%userprofile%\zephyrrc.cmd` file as described in :ref:`build_environment_cli`.
-          This lets you avoid setting them every time you open a command-line window.
-
-       .. group-tab:: Linux
-
-          Define the environment variables in the :file:`~/.zephyrrc` file as described in :ref:`build_environment_cli`.
-          This lets you avoid setting them every time you open a terminal window.
-
-       .. group-tab:: macOS
-
-          Define the environment variables in the :file:`~/.zephyrrc` file as described in :ref:`build_environment_cli`.
-          This lets you avoid setting them every time you open a terminal window.
+.. ncs-include:: develop/getting_started/index.rst
+   :docset: zephyr
+   :dedent: 0
+   :start-after: to build Zephyr applications.
+   :end-before: .. _getting_started_run_sample:
 
 .. rst-class:: numbered-step
 

--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -14,7 +14,7 @@ After programming and testing an application, you probably want to make some mod
 Adding files and changing compiler settings
 *******************************************
 
-The |NCS| build system is based on Zephyr, whose build system is based on `CMake`_.
+The |NCS| build system is based on Zephyr, whose build system is based on `CMake <CMake documentation_>`_.
 For more information about how the build system works in Zephyr, see :ref:`zephyr:build_overview` and :ref:`zephyr:application` in the Zephyr documentation.
 
 In the |NCS|, the application is a CMake project.
@@ -24,7 +24,7 @@ The application's :file:`CMakeLists.txt` file is the main CMake project file and
 Zephyr provides a CMake package that must be loaded by the application into its :file:`CMakeLists.txt` file.
 When loaded, the application can reference items provided by both Zephyr and the |NCS|.
 
-Loading Zephyr's `CMake`_ package creates the ``app`` CMake target.
+Loading Zephyr's `CMake <CMake documentation_>`_ package creates the ``app`` CMake target.
 You can add application source files to this target from the application :file:`CMakeLists.txt` file.
 
 To update the :file:`CMakeLists.txt` file, either edit it directly or use |VSC| to maintain it.

--- a/doc/nrf/gs_recommended_versions.rst
+++ b/doc/nrf/gs_recommended_versions.rst
@@ -47,9 +47,6 @@ It lists the minimum version that is required and the version that is installed 
          * - git
            -
            - |git_recommended_ver_win10|
-         * - GNU Arm Embedded Toolchain
-           - |gnuarmemb_min_ver|
-           - |gnuarmemb_recommended_ver_win10|
          * - gperf
            - |gperf_min_ver|
            - |gperf_recommended_ver_win10|
@@ -92,9 +89,6 @@ It lists the minimum version that is required and the version that is installed 
          * - git
            -
            - |git_recommended_ver_linux|
-         * - GNU Arm Embedded Toolchain
-           - |gnuarmemb_min_ver|
-           - |gnuarmemb_recommended_ver_linux|
          * - gperf
            - |gperf_min_ver|
            - |gperf_recommended_ver_linux|
@@ -131,9 +125,6 @@ It lists the minimum version that is required and the version that is installed 
          * - git
            -
            - |git_recommended_ver_darwin|
-         * - GNU Arm Embedded Toolchain
-           - |gnuarmemb_min_ver|
-           - |gnuarmemb_recommended_ver_darwin|
          * - gperf
            - |gperf_min_ver|
            - |gperf_recommended_ver_darwin|

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -606,7 +606,6 @@
 
 .. ### Source: cmake.org
 
-.. _`CMake`:
 .. _`CMake documentation`: https://cmake.org/cmake/help/latest/
 .. _`VERBOSE`: https://cmake.org/cmake/help/latest/envvar/VERBOSE.html
 .. _`CMAKE_BUILD_PARALLEL_LEVEL`: https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html

--- a/doc/nrf/releases/release-notes-1.0.0.rst
+++ b/doc/nrf/releases/release-notes-1.0.0.rst
@@ -71,7 +71,7 @@ In addition to the tools mentioned in :ref:`gs_installing`, the following tool v
      - v1.4.6 or later
      - :ref:`gs_installing_tools`
    * - GCC
-     - See :ref:`gs_installing_toolchain`
+     - See Install the GNU Arm Embedded Toolchain
      - `GNU Arm Embedded Toolchain`_
 
 

--- a/doc/nrf/releases/release-notes-1.1.0.rst
+++ b/doc/nrf/releases/release-notes-1.1.0.rst
@@ -81,7 +81,7 @@ In addition to the tools mentioned in :ref:`gs_installing`, the following tool v
      - v1.4.6 or later
      - :ref:`gs_installing_tools`
    * - GCC
-     - See :ref:`gs_installing_toolchain`
+     - See Install the GNU Arm Embedded Toolchain
      - `GNU Arm Embedded Toolchain`_
 
 

--- a/doc/nrf/releases/release-notes-1.2.0.rst
+++ b/doc/nrf/releases/release-notes-1.2.0.rst
@@ -83,7 +83,7 @@ In addition to the tools mentioned in :ref:`gs_installing`, the following tool v
      - v1.4.6 or later
      - :ref:`gs_installing_tools`
    * - GCC
-     - See :ref:`gs_installing_toolchain`
+     - See Install the GNU Arm Embedded Toolchain
      - `GNU Arm Embedded Toolchain`_
 
 

--- a/doc/nrf/releases/release-notes-1.2.1.rst
+++ b/doc/nrf/releases/release-notes-1.2.1.rst
@@ -86,7 +86,7 @@ In addition to the tools mentioned in :ref:`gs_installing`, the following tool v
      - v1.4.6 or later
      - :ref:`gs_installing_tools`
    * - GCC
-     - See :ref:`gs_installing_toolchain`
+     - See Install the GNU Arm Embedded Toolchain
      - `GNU Arm Embedded Toolchain`_
 
 

--- a/doc/nrf/releases/release-notes-1.8.0.rst
+++ b/doc/nrf/releases/release-notes-1.8.0.rst
@@ -826,7 +826,7 @@ In addition to documentation related to the changes listed above, the following 
   * Added a section describing the Git tool.
   * Expanded the existing section about the west tool.
 
-* :ref:`gs_installing` - Added a note in the :ref:`gs_installing_toolchain` section about TF-M sample incompatibility issue related to GNU Arm Embedded Toolchain versions *9-2020-q2-update* and *10-2020-q4-major*.
+* :ref:`gs_installing` - Added a note in the Install the GNU Arm Embedded Toolchain section about TF-M sample incompatibility issue related to GNU Arm Embedded Toolchain versions *9-2020-q2-update* and *10-2020-q4-major*.
   This was listed earlier as a known issue.
 * :ref:`gs_programming`:
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -116,6 +116,3 @@
 .. |thingy53_unreleased| replace:: As of the |NCS| |release| release, Thingy:53 is an unreleased product that will be released in the near future.
 
 .. |nrf5340_octave_note| replace:: The |NCS| includes the :ref:`octave` application, a complete project that integrates the LE Audio standard with custom reference hardware based on the nRF5340 SiP.
-
-.. |tfm_gnu_version_incompatibility| replace:: Do not use GNU Arm Embedded Toolchain versions *9-2020-q2-update* and *10-2020-q4-major* due to `TF-M sample incompatibility issue`_.
-   These versions do not work correctly when compiling binaries for Cortex-M Secure Extensions.


### PR DESCRIPTION
This PR replaces GNU Arm Embedded Toolchain with Zephyr
toolchain in Manual Installation page for NCS 2.0.0.

Ref: NCSDK-15011

Signed-off-by: Richa Pandey <richa.pandey@nordicsemi.no>