### PR TITLE
lib: edge_impulse: Add profiling information

### DIFF
--- a/doc/nrf/libraries/others/ei_wrapper.rst
+++ b/doc/nrf/libraries/others/ei_wrapper.rst
@@ -32,6 +32,7 @@ The Edge Impulse NCS library can be configured with the following Kconfig option
 * :kconfig:option:`CONFIG_EI_WRAPPER_DATA_BUF_SIZE`
 * :kconfig:option:`CONFIG_EI_WRAPPER_THREAD_STACK_SIZE`
 * :kconfig:option:`CONFIG_EI_WRAPPER_THREAD_PRIORITY`
+* :kconfig:option:`CONFIG_EI_WRAPPER_PROFILING`
 
 For more detailed description of these options, refer to the Kconfig help.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -635,6 +635,10 @@ Other libraries
 
       * Renamed Profiler to nRF Profiler.
 
+  * :ref:`ei_wrapper`:
+
+      * Added :kconfig:option:`CONFIG_EI_WRAPPER_PROFILING` for logging time of classifier execution.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/lib/edge_impulse/Kconfig
+++ b/lib/edge_impulse/Kconfig
@@ -81,6 +81,14 @@ config EI_WRAPPER_THREAD_PRIORITY
 	  that the thread will not block other operations in system for
 	  a long time.
 
+config EI_WRAPPER_PROFILING
+	bool "Run Edge Impulse library with profiling logging"
+	depends on LOG
+	help
+	  EI wrapper provides logs with execution time in ms of the classifier
+	  with detailed information about time spent in the following stages:
+	  sampling, dsp, classification, and anomaly.
+
 config EI_WRAPPER_DEBUG_MODE
 	bool "Run Edge Impulse library in debug mode"
 


### PR DESCRIPTION
This commit adds posibility to enable profiling information logging
for performance measurement purpose. It requires logging to be turned
on with level 3.
To enable this add `CONFIG_EI_WRAPPER_PROFILING=y` to your Kconfig.

Profiling information contains total execution time in ms of classifier
computation and time spend on following stages:
- sampling
- dsp
- classification
- anomaly

Jira: NRFX-1828

Signed-off-by: Adam Wojasinski <adam.wojasinski@nordicsemi.no>