### PR TITLE
CODEOWNERS: event manager proxy test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -220,6 +220,7 @@ Kconfig*                                  @tejlmand
 /tests/subsys/debug/cpu_load/             @nordic-krch
 /tests/subsys/dfu/                        @hakonfam @sigvartmh
 /tests/subsys/emds/                       @balaklaka
+/tests/subsys/event_manager_proxy/        @rakons
 /tests/subsys/app_event_manager/          @pdunaj @MarekPieta @rakons
 /tests/subsys/fw_info/                    @oyvindronningstad
 /tests/subsys/net/lib/aws_*/              @simensrostad


### PR DESCRIPTION
Add event manager proxy test's codeowners, as consequence of merge this PR: https://github.com/nrfconnect/sdk-nrf/pull/7561 

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>