### PR TITLE
samples: Change bulb PWM signal frequency

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -362,6 +362,7 @@ Zigbee samples
 
   * Removed implementation of Home Automation Profile Specification logic.
     This logic added dependency between On/Off and Level clusters, so changes in Level cluster were affecting the On/Off one.
+  * Updated the frequency of the LED PWM signal to 100Hz to remove unpleasant flickering.
 
 Other samples
 -------------

--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -100,8 +100,8 @@
 #error "Choose supported PWM driver"
 #endif
 
-/* Led PWM period, calculated for 50 Hz signal - in microseconds. */
-#define LED_PWM_PERIOD_US               (USEC_PER_SEC / 50U)
+/* Led PWM period, calculated for 100 Hz signal - in microseconds. */
+#define LED_PWM_PERIOD_US               (USEC_PER_SEC / 100U)
 
 #ifndef ZB_ROUTER_ROLE
 #error Define ZB_ROUTER_ROLE to compile router source code.

--- a/subsys/zigbee/osif/zb_nrf_led_button.c
+++ b/subsys/zigbee/osif/zb_nrf_led_button.c
@@ -11,7 +11,7 @@
 #include <zb_led_button.h>
 
 
-#define LED_PWM_PERIOD_US (USEC_PER_SEC / 50U)
+#define LED_PWM_PERIOD_US (USEC_PER_SEC / 100U)
 #define FLAGS_OR_ZERO(node) \
 	COND_CODE_1(DT_PHA_HAS_CELL(node, pwms, flags), \
 		    (DT_PWMS_FLAGS(node)), (0))


### PR DESCRIPTION
Update the frequency of the LED PWM signal in Zigbee Light Bulb sample to 100Hz to remove unpleasant flickering.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>