### PR TITLE
lib: zigbee shell: Fix incorrect index in zcl generic shell cmd [KRKNWK-14019]

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -691,6 +691,10 @@ Libraries for Zigbee
       *  ``zdo`` shell commands extended to allow binding to a group address.
       * Internal context manager structures.
 
+    * Fixed:
+
+      * The issue where the `zcl cmd` shell command was using the incorrect index of a context manager entry during cleanup after the command was sent.
+
   * :ref:`lib_zigbee_zcl_scenes`:
 
     * Updated the library, so that it is allowed to store empty scenes.

--- a/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_generic_cmd.c
+++ b/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_generic_cmd.c
@@ -29,7 +29,7 @@ static void zb_zcl_cmd_acked(zb_uint8_t bufid)
 	uint8_t index = 0;
 	zb_ret_t zb_err_code = RET_OK;
 	zb_zcl_command_send_status_t *cmd_status = NULL;
-	struct ctx_entry *entry = ctx_mgr_get_entry_by_index(index);
+	struct ctx_entry *entry = NULL;
 
 	if (bufid == ZB_BUF_INVALID) {
 		return;
@@ -49,6 +49,9 @@ static void zb_zcl_cmd_acked(zb_uint8_t bufid)
 		LOG_ERR("Couldn't find matching entry for ZCL generic cmd");
 		goto exit;
 	}
+
+	/* Get index of the entry to cancel the timeout callback. */
+	index = ctx_mgr_get_index_by_entry(entry);
 
 	zb_shell_print_done(entry->shell, ZB_FALSE);
 


### PR DESCRIPTION
Fixed the issue where Zigbee generic cmd shell cmd uses incorrect index of a context manager entry during cleanup after the command was sent.