### PR TITLE
zigbee: Configure frequency of FOTA image queries

### DIFF
--- a/doc/nrf/libraries/zigbee/zigbee_fota.rst
+++ b/doc/nrf/libraries/zigbee/zigbee_fota.rst
@@ -35,6 +35,7 @@ OTA upgrade process
 *******************
 
 After querying the OTA Upgrade Server for available images and receiving information about the image, the library begins the OTA upgrade process.
+The interval between queries for the available Zigbee FOTA images is defined by :kconfig:option:`CONFIG_ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS`.
 The library uses :ref:`nrfxlib:zboss`'s ZCL API to download the image.
 
 After the OTA Upgrade Client downloads the Zigbee OTA image header, the stack verifies the following mandatory fields:
@@ -78,6 +79,7 @@ To configure the Zigbee FOTA library, use the following options:
 * :kconfig:option:`CONFIG_ZIGBEE_FOTA_MIN_HW_VERSION`
 * :kconfig:option:`CONFIG_ENABLE_ZIGBEE_FOTA_MAX_HW_VERSION`
 * :kconfig:option:`CONFIG_ZIGBEE_FOTA_MAX_HW_VERSION`
+* :kconfig:option:`CONFIG_ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS`
 
 For detailed steps about configuring the library in a Zigbee sample or application, see :ref:`ug_zigbee_configuring_components_ota`.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -701,6 +701,12 @@ Libraries for Zigbee
       * Crypto library used for performing software AES ecryption.
         Now, the :ref:`nrfxlib:nrf_oberon_readme` is used instead of the Tinycrypt library.
 
+  * :ref:`lib_zigbee_fota`:
+
+    * Added:
+
+      * New :kconfig:option:`CONFIG_ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS` Kconfig option to configure interval between queries for the available Zigbee FOTA images.
+
   * Fixed:
 
     * An issue where printing binding table containing group-binding entries results in corrupted output.

--- a/subsys/zigbee/lib/zigbee_fota/Kconfig
+++ b/subsys/zigbee/lib/zigbee_fota/Kconfig
@@ -75,6 +75,10 @@ config ZIGBEE_FOTA_MAX_HW_VERSION
 	range 0x00 0xFF
 	depends on ENABLE_ZIGBEE_FOTA_MAX_HW_VERSION
 
+config ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS
+	int "Time interval between queries for the available Zigbee FOTA images"
+	default 24
+
 module=ZIGBEE_FOTA
 module-dep=LOG
 module-str=Zigbee FOTA

--- a/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
+++ b/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
@@ -497,7 +497,8 @@ void zigbee_fota_signal_handler(zb_bufid_t bufid)
 	/* fall-through */
 	case ZB_BDB_SIGNAL_STEERING:
 		if (status == RET_OK) {
-			k_timer_start(&dev_ctx.alarm, K_NO_WAIT, K_HOURS(24));
+			k_timer_start(&dev_ctx.alarm, K_NO_WAIT,
+				K_HOURS(CONFIG_ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS));
 		}
 		break;
 	default:


### PR DESCRIPTION
Add new Kconfig optin to cinfigure interval between
queries for the avilable Zigbee FOTA images

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>