### PR TITLE
lib: at_host: allow custom commands prefix.

### DIFF
--- a/include/modem/at_host.h
+++ b/include/modem/at_host.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef AT_CMD_H_
+#define AT_CMD_H_
+
+/**
+ * @file at_host.h
+ *
+ * @defgroup at_host AT command interface driver to register custom handler
+ *
+ * @{
+ *
+ * @brief Public APIs for the AT custom command interface driver.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @typedef at_cmd_custom_handler_t
+ *
+ * This type defines a custom handler which will manage the custom commands
+ * received by the modem.
+ *
+ * @param cmd Pointer to null terminated AT command string
+ * @param buf Buffer to put the response in. NULL pointer is allowed, see
+ *            behaviour explanation for @p buf_len equals 0.
+ * @param buf_len Length of response buffer. 0 length is allowed and will send
+ *                the command, process the return code from the modem, but
+ *                any returned data will be dropped.
+ * @retval -ENOBUFS is returned if AT_CMD_RESPONSE_MAX_LEN is not large enough
+ *         to hold the data returned from the modem.
+ * @retval -ENOEXEC is returned if the modem returned ERROR.
+ * @retval -EMSGSIZE is returned if the supplied buffer is to small or NULL.
+ */
+typedef int (*at_cmd_custom_handler_t)(const char *const cmd,
+				       char *buf,
+				       size_t buf_len,
+				       enum at_cmd_state *state);
+
+/**
+ * @brief Sets the handler called when a custom commands is received.
+ *
+ * @note This function requires the CONFIG_AT_HOST_CUSTOM_COMMANDS to be set to
+ * have any effect.
+ *
+ * @param handler Pointer to a notification handler function of type
+ *                @ref at_cmd_custom_handler_t.
+ */
+void at_cmd_set_custom_handler(at_cmd_custom_handler_t handler);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AT_CMD_H_ */

--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -88,6 +88,16 @@ config AT_HOST_THREAD_PRIO
 	default 0 if !MULTITHREADING
 	default 10
 
+config AT_HOST_CUSTOM_COMMANDS
+	bool "Support custom commands"
+	default n
+
+if (AT_HOST_CUSTOM_COMMANDS)
+config AT_HOST_CUSTOM_COMMANDS_PREFIX
+	string "Custom commands prefix"
+	default "AT#"
+endif # AT_HOST_CUSTOM_COMMANDS
+
 module = AT_HOST
 module-str = AT host
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
This commit adds the possibility to define a custom
at commands prefix (AT# for example) which will be
passed to the application instead of being sent to
the modem.

This can be useful for example if the nRF9160 is
connected to another core with a UART bus. It allows
sending 'normal' AT commands that will be directly
exectuted by the modem and custom-made AT commands that
will be executed by the main application.

Signed-off-by: Giuliano Franchetto <giuliano.franchetto@intellinium.com>