### PR TITLE
samples: matter: Fixed bug with hardfault on C3 char read.

### DIFF
--- a/samples/matter/light_bulb/prj.conf
+++ b/samples/matter/light_bulb/prj.conf
@@ -32,6 +32,7 @@ CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLight"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/light_bulb/prj_no_dfu.conf
+++ b/samples/matter/light_bulb/prj_no_dfu.conf
@@ -32,6 +32,7 @@ CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLight"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/light_bulb/prj_release.conf
+++ b/samples/matter/light_bulb/prj_release.conf
@@ -32,6 +32,7 @@ CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLight"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Enable system reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/samples/matter/light_switch/prj.conf
+++ b/samples/matter/light_switch/prj.conf
@@ -24,6 +24,7 @@ CONFIG_OPENTHREAD_FTD=n
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterSwitch"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/light_switch/prj_no_dfu.conf
+++ b/samples/matter/light_switch/prj_no_dfu.conf
@@ -24,6 +24,7 @@ CONFIG_OPENTHREAD_FTD=n
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterSwitch"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/light_switch/prj_release.conf
+++ b/samples/matter/light_switch/prj_release.conf
@@ -24,6 +24,7 @@ CONFIG_OPENTHREAD_FTD=n
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterSwitch"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Enable system reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/samples/matter/lock/prj.conf
+++ b/samples/matter/lock/prj.conf
@@ -31,6 +31,7 @@ CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLock"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/lock/prj_no_dfu.conf
+++ b/samples/matter/lock/prj_no_dfu.conf
@@ -31,6 +31,7 @@ CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLock"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/lock/prj_release.conf
+++ b/samples/matter/lock/prj_release.conf
@@ -31,6 +31,7 @@ CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLock"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Enable system reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/samples/matter/template/prj.conf
+++ b/samples/matter/template/prj.conf
@@ -34,6 +34,7 @@ CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterTemplate"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/template/prj_no_dfu.conf
+++ b/samples/matter/template/prj_no_dfu.conf
@@ -34,6 +34,7 @@ CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterTemplate"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/template/prj_release.conf
+++ b/samples/matter/template/prj_release.conf
@@ -34,6 +34,7 @@ CONFIG_OPENTHREAD_XPANID="11:11:11:11:22:22:22:22"
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterTemplate"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Enable system reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=y

--- a/samples/matter/window_covering/prj.conf
+++ b/samples/matter/window_covering/prj.conf
@@ -28,6 +28,7 @@ CONFIG_OPENTHREAD_FTD=n
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterWinCov"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/window_covering/prj_no_dfu.conf
+++ b/samples/matter/window_covering/prj_no_dfu.conf
@@ -28,6 +28,7 @@ CONFIG_OPENTHREAD_FTD=n
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterWinCov"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/window_covering/prj_release.conf
+++ b/samples/matter/window_covering/prj_release.conf
@@ -28,6 +28,7 @@ CONFIG_OPENTHREAD_FTD=n
 
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterWinCov"
+CONFIG_BT_RX_STACK_SIZE=1200
 
 # Enable system reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=y


### PR DESCRIPTION
After recent changes in Zephyr BT RX stack size seems to not be
big enough and we get hardfault on C3 characteristic read.
It was fixed by increasing the stack size.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>