### PR TITLE
samples: Change samples to sample

### DIFF
--- a/samples/event_manager_proxy/sample.yaml
+++ b/samples/event_manager_proxy/sample.yaml
@@ -2,13 +2,13 @@ sample:
   description: Sample showing usage of sending the events to another core via Event Manager Proxy
   name: Event Manager proxy sample
 tests:
-  samples.event_manager_proxy:
+  sample.event_manager_proxy:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     tags: ci_build
-  samples.event_manager_proxy.icmsg:
+  sample.event_manager_proxy.icmsg:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/sample.yaml
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: nRF Cloud MQTT Multi Service Sample
 tests:
-  samples.nrf9160.nrf_cloud_mqtt_multi_service:
+  sample.nrf9160.nrf_cloud_mqtt_multi_service:
     build_only: true
     platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
     integration_platforms:

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: OpenThread CLI sample
   description: Test OpenThread Command Line Interface.
 tests:
-  samples.openthread.cli:
+  sample.openthread.cli:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
@@ -12,7 +12,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840
-  samples.openthread.cli.thread_1_1:
+  sample.openthread.cli.thread_1_1:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build
@@ -23,7 +23,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833
       - nrf21540dk_nrf52840
-  samples.openthread.cli.usb:
+  sample.openthread.cli.usb:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf52833dk_nrf52833 nrf21540dk_nrf52840
     tags: ci_build


### PR DESCRIPTION
Some testcases start with `samples` instead of `sample`.
This commit rename these.

Signed-off-by: Katarzyna Giadla <katarzyna.giadla@nordicsemi.no>