### PR TITLE
samples: openthread: remove data lenght check for ble data

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -291,6 +291,7 @@ Thread samples
   * All sample documentation with a Configuration section, and organized relevant information under that section.
   * Mnimal configuration for CLI sample has been removed.
   * BLE advertising interval has been increased from 100 ms to 300 ms for CLI sample when multiprotocol is enabled.
+  * CoAP Client sample with Multiprotocol Bluetooth LE extension is now compatible with Bluetooth Central UART sample.
 
 Matter samples
 --------------

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -27,7 +27,7 @@ You also need one or more compatible development kits programmed with the :ref:`
 Multiprotocol extension requirements
 ====================================
 
-If you enable the :ref:`coap_client_sample_multi_ext`, make sure you have a phone or a tablet with the `nRF Toolbox`_ application installed.
+If you enable the :ref:`coap_client_sample_multi_ext`, make sure you have a phone with the `nRF Toolbox`_ application installed or an additional development kit programmed with :ref:`central_uart` sample.
 
 .. note::
   The :ref:`testing instructions <coap_client_sample_testing_ble>` refer to nRF Toolbox, but similar applications can be used as well, for example `nRF Connect for Mobile`_.
@@ -188,7 +188,10 @@ Switching between SED and MED modes does not affect the standard testing procedu
 Testing multiprotocol Bluetooth LE extension
 --------------------------------------------
 
-To test the multiprotocol Bluetooth LE extension, you need to first set up nRF Toolbox as follows:
+To test the multiprotocol Bluetooth LE extension, you can use nRF Toolbox or the :ref:`central_uart` sample.
+The steps below assume nRF Toolbox as the Bluetooth tester.
+
+First, you need to set up nRF Toolbox as follows:
 
 1. Tap :guilabel:`UART` to open the UART application in nRF Toolbox.
 

--- a/samples/openthread/coap_client/src/coap_client.c
+++ b/samples/openthread/coap_client/src/coap_client.c
@@ -32,11 +32,6 @@ LOG_MODULE_REGISTER(coap_client, CONFIG_COAP_CLIENT_LOG_LEVEL);
 static void on_nus_received(struct bt_conn *conn, const uint8_t *const data,
 			    uint16_t len)
 {
-	if (len != 1) {
-		LOG_WRN("Received invalid data length (%hd) from NUS", len);
-		return;
-	}
-
 	LOG_INF("Received data: %c", data[0]);
 
 	switch (*data) {


### PR DESCRIPTION
Accept ble data with len > 1 to support bluetooth/central_uart sample
as ble tester. central_uart appends new line char to the input data
therefore puting "p" we've got "p\n".
