### PR TITLE
zigbee: Handle error while entering identify mode

### DIFF
--- a/applications/zigbee_weather_station/src/main.c
+++ b/applications/zigbee_weather_station/src/main.c
@@ -177,11 +177,17 @@ static void start_identifying(zb_bufid_t bufid)
 		 */
 		if (dev_ctx.identify_attr.identify_time ==
 		    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-			LOG_INF("Manually enter identify mode");
 
 			zb_ret_t zb_err_code = zb_bdb_finding_binding_target(
 				WEATHER_STATION_ENDPOINT_NB);
-			ZB_ERROR_CHECK(zb_err_code);
+
+			if (zb_err_code == RET_OK) {
+				LOG_INF("Manually enter identify mode");
+			} else if (zb_err_code == RET_INVALID_STATE) {
+				LOG_WRN("RET_INVALID_STATE - Cannot enter identify mode");
+			} else {
+				ZB_ERROR_CHECK(zb_err_code);
+			}
 		} else {
 			LOG_INF("Manually cancel identify mode");
 			zb_bdb_finding_binding_target_cancel();

--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -195,8 +195,6 @@ ZBOSS_DECLARE_DEVICE_CTX_1_EP(
  */
 static void start_identifying(zb_bufid_t bufid)
 {
-	zb_ret_t zb_err_code;
-
 	ZVUNUSED(bufid);
 
 	if (ZB_JOINED()) {
@@ -205,10 +203,17 @@ static void start_identifying(zb_bufid_t bufid)
 		 */
 		if (dev_ctx.identify_attr.identify_time ==
 		    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-			LOG_INF("Enter identify mode");
 
-			zb_err_code = zb_bdb_finding_binding_target(DIMMABLE_LIGHT_ENDPOINT);
-			ZB_ERROR_CHECK(zb_err_code);
+			zb_ret_t zb_err_code = zb_bdb_finding_binding_target(
+				DIMMABLE_LIGHT_ENDPOINT);
+
+			if (zb_err_code == RET_OK) {
+				LOG_INF("Enter identify mode");
+			} else if (zb_err_code == RET_INVALID_STATE) {
+				LOG_WRN("RET_INVALID_STATE - Cannot enter identify mode");
+			} else {
+				ZB_ERROR_CHECK(zb_err_code);
+			}
 		} else {
 			LOG_INF("Cancel identify mode");
 			zb_bdb_finding_binding_target_cancel();

--- a/samples/zigbee/light_switch/src/main.c
+++ b/samples/zigbee/light_switch/src/main.c
@@ -198,8 +198,6 @@ static void light_switch_send_on_off(zb_bufid_t bufid, zb_uint16_t on_off);
  */
 static void start_identifying(zb_bufid_t bufid)
 {
-	zb_ret_t zb_err_code;
-
 	ZVUNUSED(bufid);
 
 	if (ZB_JOINED()) {
@@ -208,9 +206,16 @@ static void start_identifying(zb_bufid_t bufid)
 		 */
 		if (dev_ctx.identify_attr.identify_time ==
 		    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-			LOG_INF("Enter identify mode");
-			zb_err_code = zb_bdb_finding_binding_target(LIGHT_SWITCH_ENDPOINT);
-			ZB_ERROR_CHECK(zb_err_code);
+
+			zb_ret_t zb_err_code = zb_bdb_finding_binding_target(LIGHT_SWITCH_ENDPOINT);
+
+			if (zb_err_code == RET_OK) {
+				LOG_INF("Enter identify mode");
+			} else if (zb_err_code == RET_INVALID_STATE) {
+				LOG_WRN("RET_INVALID_STATE - Cannot enter identify mode");
+			} else {
+				ZB_ERROR_CHECK(zb_err_code);
+			}
 		} else {
 			LOG_INF("Cancel identify mode");
 			zb_bdb_finding_binding_target_cancel();

--- a/samples/zigbee/network_coordinator/src/main.c
+++ b/samples/zigbee/network_coordinator/src/main.c
@@ -142,8 +142,6 @@ static void identify_cb(zb_bufid_t bufid)
  */
 static void start_identifying(zb_bufid_t bufid)
 {
-	zb_ret_t zb_err_code;
-
 	ZVUNUSED(bufid);
 
 	if (ZB_JOINED()) {
@@ -152,9 +150,17 @@ static void start_identifying(zb_bufid_t bufid)
 		 */
 		if (dev_ctx.identify_attr.identify_time ==
 		    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-			LOG_INF("Enter identify mode");
-			zb_err_code = zb_bdb_finding_binding_target(ZIGBEE_COORDINATOR_ENDPOINT);
-			ZB_ERROR_CHECK(zb_err_code);
+
+			zb_ret_t zb_err_code = zb_bdb_finding_binding_target(
+				ZIGBEE_COORDINATOR_ENDPOINT);
+
+			if (zb_err_code == RET_OK) {
+				LOG_INF("Enter identify mode");
+			} else if (zb_err_code == RET_INVALID_STATE) {
+				LOG_WRN("RET_INVALID_STATE - Cannot enter identify mode");
+			} else {
+				ZB_ERROR_CHECK(zb_err_code);
+			}
 		} else {
 			LOG_INF("Cancel identify mode");
 			zb_bdb_finding_binding_target_cancel();

--- a/samples/zigbee/shell/src/main.c
+++ b/samples/zigbee/shell/src/main.c
@@ -124,8 +124,6 @@ static void identify_cb(zb_bufid_t bufid)
  */
 static void start_identifying(zb_bufid_t bufid)
 {
-	zb_ret_t zb_err_code;
-
 	ZVUNUSED(bufid);
 
 	if (ZB_JOINED()) {
@@ -134,10 +132,17 @@ static void start_identifying(zb_bufid_t bufid)
 		 */
 		if (dev_ctx.identify_attr.identify_time ==
 		    ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-			LOG_INF("Enter identify mode");
-			zb_err_code = zb_bdb_finding_binding_target(
+
+			zb_ret_t zb_err_code = zb_bdb_finding_binding_target(
 				APP_ZIGBEE_ENDPOINT);
-			ZB_ERROR_CHECK(zb_err_code);
+
+			if (zb_err_code == RET_OK) {
+				LOG_INF("Enter identify mode");
+			} else if (zb_err_code == RET_INVALID_STATE) {
+				LOG_WRN("RET_INVALID_STATE - Cannot enter identify mode");
+			} else {
+				ZB_ERROR_CHECK(zb_err_code);
+			}
 		} else {
 			LOG_INF("Cancel identify mode");
 			zb_bdb_finding_binding_target_cancel();

--- a/samples/zigbee/template/src/main.c
+++ b/samples/zigbee/template/src/main.c
@@ -127,8 +127,6 @@ static void identify_cb(zb_bufid_t bufid)
  */
 static void start_identifying(zb_bufid_t bufid)
 {
-	zb_ret_t zb_err_code;
-
 	ZVUNUSED(bufid);
 
 	if (ZB_JOINED()) {
@@ -137,10 +135,17 @@ static void start_identifying(zb_bufid_t bufid)
 		 */
 		if (dev_ctx.identify_attr.identify_time ==
 		ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE) {
-			LOG_INF("Enter identify mode");
-			zb_err_code = zb_bdb_finding_binding_target(
+
+			zb_ret_t zb_err_code = zb_bdb_finding_binding_target(
 				APP_TEMPLATE_ENDPOINT);
-			ZB_ERROR_CHECK(zb_err_code);
+
+			if (zb_err_code == RET_OK) {
+				LOG_INF("Enter identify mode");
+			} else if (zb_err_code == RET_INVALID_STATE) {
+				LOG_WRN("RET_INVALID_STATE - Cannot enter identify mode");
+			} else {
+				ZB_ERROR_CHECK(zb_err_code);
+			}
 		} else {
 			LOG_INF("Cancel identify mode");
 			zb_bdb_finding_binding_target_cancel();


### PR DESCRIPTION
Add an error handling for a case when device is requested to enter
identify mode but is not ready to do so - usually on startup.

Signed-off-by: Filip Zajdel <filip.zajdel@nordicsemi.no>