### PR TITLE
bluetooth: rpc: Clean up

### DIFF
--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -21,3 +21,11 @@ tests:
     platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
     tags: bluetooth ci_build
+  sample.bluetooth.peripheral_hids_mouse.ble_rpc:
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_RPC_STACK=y
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -35,3 +35,11 @@ tests:
       - nrf52833dk_nrf52820
     platform_allow: nrf52dk_nrf52810 nrf52840dk_nrf52811 nrf52833dk_nrf52820
     tags: bluetooth ci_build
+  sample.bluetooth.peripheral_uart_ble_rpc:
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_RPC_STACK=y
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    tags: bluetooth ci_build

--- a/subsys/bluetooth/rpc/common/serialize.h
+++ b/subsys/bluetooth/rpc/common/serialize.h
@@ -220,9 +220,9 @@ int64_t ser_decode_int64(CborValue *value);
  *
  * @param[in]  value Value parsed from the CBOR stream.
  * @param[out] buffer Buffer for decoded string.
- * @param[in]  size Buffer size.
+ * @param[in]  buffer_size Buffer size.
  */
-void ser_decode_str(CborValue *value, char *buffer, size_t size);
+void ser_decode_str(CborValue *value, char *buffer, size_t buffer_size);
 
 /** Decode a string value into a scratchpad.
  *
@@ -236,7 +236,7 @@ char *ser_decode_str_into_scratchpad(struct ser_scratchpad *scratchpad);
  *
  * @param[in]  value Value parsed from the CBOR stream.
  * @param[out] buffer Buffer for a decoded buffer data.
- * @param[in]  size Buffer size.
+ * @param[in]  buffer_size Buffer size.
  *
  * @retval Pointer to a decoded buffer.
  */

--- a/subsys/bluetooth/rpc/host/bt_rpc_conn_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_conn_host.c
@@ -1160,7 +1160,9 @@ enum bt_security_err bt_rpc_auth_cb_pairing_accept(struct bt_conn *conn,
 {
 	struct nrf_rpc_cbor_ctx ctx;
 	struct bt_rpc_auth_cb_pairing_accept_rpc_res result;
-	size_t buffer_size_max = 15;
+	size_t buffer_size_max = 3;
+
+	buffer_size_max += bt_conn_pairing_feat_buf_size;
 
 	NRF_RPC_CBOR_ALLOC(ctx, buffer_size_max);
 


### PR DESCRIPTION
This is basic clean-up for the Bluetooth RPC, it contains:

- Improved string serializers
- Test cases for Bluetooth samples that can be build out of the box with serialized BLE stack
- Fix for the unused bt_conn_pairing_feat_buf_size variable 