### PR TITLE
manifest: Update sdk-zephyr with flash map fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1b5216019d2f8bc9a69e7c34de02eb245b0dd3fa
+      revision: pull/805/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr SHA to take in flash_area_open fix.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>