### PR TITLE
manifest: Update sdk-zephyr SHA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1b5216019d2f8bc9a69e7c34de02eb245b0dd3fa
+      revision: pull/806/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The commit updates sdk-zephyr SHA to include fix for mcumgr
image list crashing on two image DFU applications with asserts
enabled.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>