### PR TITLE
net: lib: fota_download: Allow retry on socket timeout

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -225,7 +225,8 @@ static int download_client_callback(const struct download_client_evt *event)
 		 * or non-zero to stop
 		 */
 		if ((socket_retries_left) && ((event->error == -ENOTCONN) ||
-					      (event->error == -ECONNRESET))) {
+					      (event->error == -ECONNRESET) ||
+					      (event->error == -ETIMEDOUT))) {
 			LOG_WRN("Download socket error. %d retries left...",
 				socket_retries_left);
 			socket_retries_left--;


### PR DESCRIPTION
This is the most common download failure case that I see, re-connecting the socket typically allows the download to progress.