### PR TITLE
[crypto] psa_tls sample fix kconfig cert description

### DIFF
--- a/samples/crypto/psa_tls/Kconfig
+++ b/samples/crypto/psa_tls/Kconfig
@@ -18,7 +18,7 @@ config PSA_TLS_CERTIFICATE_TYPE_RSA
 	  Enable RSA certificates when testing ciphers that supports RSA for authentication.
 
 config PSA_TLS_CERTIFICATE_TYPE_ECDSA
-	bool "Use RSA certificate in PSA TLS sample"
+	bool "Use ECDSA certificate in PSA TLS sample"
 	help
 	  Enable ECDSA certificates when testing ciphers that supports ECDSA for authentication.
 


### PR DESCRIPTION
The ECDSA certifacte was also labeled as RSA.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>