### PR TITLE
samples: direct_test_mode: Fix active delay calculation

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
@@ -911,9 +911,9 @@ static uint32_t nrf21540_default_active_delay_calculate(bool rx, nrf_radio_mode_
 	bool fast_ramp_up = nrf_radio_modecnf0_ru_get(NRF_RADIO);
 
 	return rx ? (fem_radio_rx_ramp_up_delay_get(fast_ramp_up, mode) -
-		     TX_EN_SETTLE_TIME) :
+		     RX_EN_SETTLE_TIME) :
 		    (fem_radio_tx_ramp_up_delay_get(fast_ramp_up, mode) -
-		     RX_EN_SETTLE_TIME);
+		     TX_EN_SETTLE_TIME);
 }
 
 static const struct fem_interface_api nrf21540_api = {


### PR DESCRIPTION
This fixes the active delay calculation for Front-end
module Rx and Tx mode. The settle times were mismatch
between calculated for Rx and Tx.