### PR TITLE
samples: matter: Fixed commissioning error

### DIFF
--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -129,6 +129,7 @@ CHIP_ERROR AppTask::Init()
 	k_timer_user_data_set(&sFunctionTimer, this);
 
 	/* Initialize CHIP server */
+	SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 	static chip::CommonCaseDeviceServerInitParams initParams;
 	(void)initParams.InitializeStaticResourcesBeforeServerInit();
 	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));


### PR DESCRIPTION
The Window Covering Sample could not perform commissioning to Matter Network.

This bug occurred because attestation credentials had not been set.
