### PR TITLE
doc: Improve nRF Cloud device security docs

### DIFF
--- a/doc/nrf/ext_comps.rst
+++ b/doc/nrf/ext_comps.rst
@@ -11,4 +11,3 @@ The following user guides show how you can use external components in your appli
 
    ug_bt_coex
    ug_edge_impulse
-   ug_nrf_cloud

--- a/doc/nrf/glossary.rst
+++ b/doc/nrf/glossary.rst
@@ -37,6 +37,9 @@ Glossary
       It improves the :term:`Time to First Fix (TTFF)` by utilizing a connection (for example, over cellular) to the internet to retrieve the :term:`Almanac data` and :term:`Ephemeris data`.
       A connection to an internet server that has the Almanac and Ephemeris data is several times quicker than using the data link to the GPS satellites.
 
+   Association
+      The process of adding a provisioned device to a cloud account using the device ID.
+
    Attribute Protocol (ATT)
       "[It] allows a device referred to as the server to expose a set of attributes and their associated values to a peer device referred to as the client."
       `Bluetooth Core Specification`_, Version 5.3, Vol 3, Part F, Section 1.1.
@@ -257,6 +260,10 @@ Glossary
    Isochronous channels (ISO)
       A feature of the :term:`LE Audio` standard that allows for relaying audio data to multiple devices at the same time (isochronously) without having to split the stereo stream.
 
+   Just In Time Provisioning (JITP)
+     A device is provisioned when it first tries to connect to the IoT broker and presents its device certificate.
+      Before the first communication, the device is not known to the broker and is not stored in the fleet registry.
+
    Kconfig file
       A configuration file for a module or a sample, written in the :term:`Kconfig language` syntax.
       It defines build-time configuration options, also called symbols, namely application-specific values for one or more kernel configuration options.
@@ -461,6 +468,9 @@ Glossary
       A feature introduced in 3GPP Release 12 to improve the battery life of IoT (Internet of Things) devices by minimizing energy consumption.
       The device stays dormant during the PSM window.
 
+   Preconnect provisioning
+      The process of securely generating and storing credentials in a device, then uploading a device ID and device certificate to a cloud account so that the device is ready to connect to the cloud.
+
    Predicted GPS (P-GPS)
       A form of assistance provided to devices trying to obtain a :term:`Global Navigation Satellite System (GNSS)` fix, where the device can download up to two weeks of predicted satellite Ephemerides data.
       It enables devices to determine the exact orbital location of the satellite without connecting to the network every two hours with a trade-off of reduced accuracy of the calculated position over time.
@@ -485,6 +495,7 @@ Glossary
         It is a step in the commissioning process.
       * In a Bluetooth Mesh network, the process of adding devices to the network.
       * In a bootloader, the process of storing public key hashes in a separate region of memory from the bootloader image.
+      * In a device-to-cloud connection, the process of storing a device ID and device certificate to a cloud account.
 
    Pull Request
       A set of :term:`commits <Commit>` that are sent as a :term:`contribution <Contribution>` to a Git :term:`repository <Repository>`.

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -63,6 +63,7 @@ In addition to the |NCS| documentation, information is available in the followin
    ug_nrf91
    ug_nrf53
    ug_nrf52
+   ug_nrf_cloud
    protocols
    applications
    samples

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -891,6 +891,7 @@ Documentation
   * :ref:`ug_thread_communication` by moving it to a separate page instead of it being under :ref:`ug_thread_architectures`.
   * Added a note to several nRF Cloud samples using the `nRF Cloud REST API`_ indicating the need for valid and registered request signing credentials.
   * :ref:`thread_ot_memory` with definitions of variants listed on the tables.
+  * :ref:`ug_nrf_cloud` with more information about security.
 
 * Removed:
 

--- a/doc/nrf/ug_nrf_cloud.rst
+++ b/doc/nrf/ug_nrf_cloud.rst
@@ -56,6 +56,46 @@ MQTT overview
 * Once connected, the device subscribes to the desired MQTT topics.
 * Each MQTT publish event contains the MQTT topic and the payload.
 
+Security
+********
+
+A device can successfully connect to `nRF Cloud`_ using REST if the following requirements are met:
+
+* The device contains a correct x509 CA certificate, and private key.
+* The public key derived from the private key is registered with an nRF Cloud account.
+* The device calls nRF Cloud REST APIs which require a JSON Web Token (JWT) by providing a JWT signed by the private key
+
+A device can successfully connect to `nRF Cloud`_ using MQTT if the following requirements are met:
+
+* The device contains a correct x509 CA certificate, device certificate, and private key.
+* The device ID and device certificate are provisioned with nRF Cloud.
+* The device ID is associated with an nRF Cloud account.
+
+`nRF Cloud`_ supports the following two ways for creating and installing these certificates both in the device and the cloud:
+
+* Just in time provisioning
+
+  1. In your nRF Cloud account, enter the device ID in a web form, then download a JSON file containing the CA certificate, device certificate, and private key.
+
+     Alternatively, use the nRF Cloud REST API to do this.
+
+  #. Program the credentials in the JSON file into the device using LTE Link Monitor.
+
+  The private key is exposed during these steps, and therefore, this is the less secure option.
+  See :ref:`nrf9160_ug_updating_cloud_certificate` for details.
+
+* Preconnect provisioning
+
+  Run the  :file:`device_credentials_installer.py` Python script.
+  You need to specify a number of parameters including the device ID.
+
+  The script instructs the device to securely generate and store a private key, which never leaves the device.
+  It programs  the specified CA certificate into the device.
+  The private key never leaves the device, which makes this a more secure option.
+
+  See `Securely Generating Credentials on the nRF9160`_  and `nRF Cloud Provisioning`_ for more details.
+
+
 |NCS| library support
 *********************
 
@@ -75,13 +115,19 @@ The following application uses the :ref:`lib_nrf_cloud` for services in |NCS|:
 
 * :ref:`asset_tracker_v2`
 
-The following samples demonstrate specific nRF Cloud functionality:
+The following sample demonstrates nRF Cloud-specific functionality using MQTT:
 
-* :ref:`cloud_client`
-* :ref:`gnss_sample`
-* :ref:`lte_sensor_gateway`
-* :ref:`multicell_location`
 * :ref:`nrf_cloud_mqtt_multi_service`
+
+The following samples demonstrate nRF Cloud-specific functionality using REST:
+
+* :ref:`gnss_sample`
 * :ref:`nrf_cloud_rest_fota`
 * :ref:`nrf_cloud_rest_device_message`
 * :ref:`nrf_cloud_rest_cell_pos_sample`
+
+Other related samples:
+
+* :ref:`cloud_client`
+* :ref:`lte_sensor_gateway`
+* :ref:`multicell_location`


### PR DESCRIPTION
Add some cloud-related terms to the glossary.

Add a security section to the nRF Cloud user guide.

Reorganize the list of samples into MQTT, REST, and other.

Add ug_nrf_cloud to the top level index so nRF Cloud is not buried so deeply in the hierarchy.

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>