### PR TITLE
pinctrl: Prefix `drive-mode` property with `nordic,`

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
@@ -8,7 +8,7 @@
 	i2s0_default: i2s0_default {
 		group1 {
 			psels = <NRF_PSEL(I2S_MCK, 0, 12)>;
-			drive-mode = <NRF_DRIVE_H0H1>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 		group2 {
 			psels = <NRF_PSEL(I2S_SCK_M, 0, 14)>,
@@ -72,7 +72,7 @@
 				<NRF_PSEL(SPIM_MOSI, 0, 9)>;
 			/* Workaround for issue with PCA10121 v0.7.0
 			 * related to SD-card */
-			drive-mode = <NRF_DRIVE_H0H1>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 		group2 {
 			psels = <NRF_PSEL(SPIM_MISO, 0, 10)>;

--- a/doc/nrf/ug_pinctrl.rst
+++ b/doc/nrf/ug_pinctrl.rst
@@ -108,7 +108,7 @@ Here is a list of the supported standard pin properties:
 
 The following non-standard, nRF-specific properties are also supported:
 
-* ``drive-mode`` - Pin output drive mode. Available drive modes are pre-defined in :file:`include/dt-bindings/pinctrl/nrf-pinctrl.h`. Note that extra modes might not be available on certain devices. When not specified, pin defaults to standard mode for 0 and 1 (``NRF_DRIVE_S0S1``).
+* ``nordic,drive-mode`` - Pin output drive mode. Available drive modes are pre-defined in :file:`include/dt-bindings/pinctrl/nrf-pinctrl.h`. Note that extra modes might not be available on certain devices. When not specified, pin defaults to standard mode for 0 and 1 (``NRF_DRIVE_S0S1``).
 * ``nordic,invert`` - Invert pin polarity  (set active state to low). This property is valid only for PWM channel output pins.
 
 To link this pin configuration with a device, use a pinctrl-N property where N is the state index starting from zero.

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: dde1f8d7071a304be21ebff3c1b3ef8cdd32d617
+      revision: 04acceb93debb30437757802d189357bab5152f2
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update the name of the `drive-mode` pinctrl property after it was
prefixed with `nordic,` in Zephyr.