### PR TITLE
samples: peripheral_fast_pair: Add support for nRF53

### DIFF
--- a/samples/bluetooth/peripheral_fast_pair/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/peripheral_fast_pair/child_image/hci_rpmsg.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL=y


### PR DESCRIPTION
Change introduces hci_rpmsg Kconfig overlay need to support nRF53.

Jira: NCSDK-14869