### PR TITLE
bluetooth: fast_pair: Add "zephyr/" prefix to included headers

### DIFF
--- a/include/bluetooth/services/fast_pair.h
+++ b/include/bluetooth/services/fast_pair.h
@@ -7,7 +7,7 @@
 #ifndef BT_FAST_PAIR_H_
 #define BT_FAST_PAIR_H_
 
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 /**
  * @defgroup bt_fast_pair Fast Pair API

--- a/samples/bluetooth/peripheral_fast_pair/include/bt_adv_helper.h
+++ b/samples/bluetooth/peripheral_fast_pair/include/bt_adv_helper.h
@@ -7,7 +7,7 @@
 #ifndef BT_ADV_HELPER_H_
 #define BT_ADV_HELPER_H_
 
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 /**
  * @defgroup fast_pair_sample_adv_helper Fast Pair sample advertising helper API

--- a/samples/bluetooth/peripheral_fast_pair/include/bt_tx_power_adv.h
+++ b/samples/bluetooth/peripheral_fast_pair/include/bt_tx_power_adv.h
@@ -7,7 +7,7 @@
 #ifndef BT_TX_POWER_ADV_H_
 #define BT_TX_POWER_ADV_H_
 
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 /**
  * @defgroup fast_pair_sample_bt_tx_power_adv Fast Pair sample TX power advertising API

--- a/samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <random/rand32.h>
+#include <zephyr/random/rand32.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
 #include <bluetooth/services/fast_pair.h>
 
 #include "bt_tx_power_adv.h"

--- a/samples/bluetooth/peripheral_fast_pair/src/bt_tx_power_adv.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/bt_tx_power_adv.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <sys/byteorder.h>
+#include <zephyr/sys/byteorder.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/hci_vs.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_vs.h>
 
 #include "bt_tx_power_adv.h"
 

--- a/samples/bluetooth/peripheral_fast_pair/src/hids_helper.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/hids_helper.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <device.h>
-#include <sys/byteorder.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/byteorder.h>
 #include <bluetooth/services/hids.h>
 
 #include "hids_helper.h"

--- a/samples/bluetooth/peripheral_fast_pair/src/main.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <settings/settings.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/settings/settings.h>
 
 #include <dk_buttons_and_leds.h>
 

--- a/subsys/bluetooth/services/fast_pair/crypto/fp_crypto_common.c
+++ b/subsys/bluetooth/services/fast_pair/crypto/fp_crypto_common.c
@@ -6,8 +6,8 @@
 
 #include <errno.h>
 #include <string.h>
-#include <sys/util.h>
-#include <sys/byteorder.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/byteorder.h>
 #include "fp_crypto.h"
 
 int fp_aes_key_compute(uint8_t *out, const uint8_t *in)

--- a/subsys/bluetooth/services/fast_pair/crypto/fp_crypto_mbedtls.c
+++ b/subsys/bluetooth/services/fast_pair/crypto/fp_crypto_mbedtls.c
@@ -14,9 +14,9 @@
 #include <mbedtls/ecp.h>
 #include <mbedtls/sha256.h>
 
-#include <random/rand32.h>
+#include <zephyr/random/rand32.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(fast_pair, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
 
 /* Bit length of the AES-128 key. */

--- a/subsys/bluetooth/services/fast_pair/fp_advertising.c
+++ b/subsys/bluetooth/services/fast_pair/fp_advertising.c
@@ -5,9 +5,9 @@
  */
 
 #include <errno.h>
-#include <net/buf.h>
-#include <random/rand32.h>
-#include <bluetooth/bluetooth.h>
+#include <zephyr/net/buf.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 #include <bluetooth/services/fast_pair.h>
 #include "fp_common.h"

--- a/subsys/bluetooth/services/fast_pair/fp_auth.c
+++ b/subsys/bluetooth/services/fast_pair/fp_auth.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(fast_pair, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
 
 #include "fp_auth.h"

--- a/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
+++ b/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <net/buf.h>
-#include <sys/byteorder.h>
-#include <random/rand32.h>
+#include <zephyr/net/buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/random/rand32.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/l2cap.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/bluetooth/gatt.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fast_pair, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
 
 #include "fp_registration_data.h"

--- a/subsys/bluetooth/services/fast_pair/fp_keys.c
+++ b/subsys/bluetooth/services/fast_pair/fp_keys.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <device.h>
-#include <sys/byteorder.h>
-#include <bluetooth/conn.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/bluetooth/conn.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(fast_pair, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
 
 #include "fp_registration_data.h"

--- a/subsys/bluetooth/services/fast_pair/fp_registration_data.c
+++ b/subsys/bluetooth/services/fast_pair/fp_registration_data.c
@@ -6,8 +6,8 @@
 
 #include <errno.h>
 #include <string.h>
-#include <device.h>
-#include <storage/flash_map.h>
+#include <zephyr/device.h>
+#include <zephyr/storage/flash_map.h>
 #include <pm_config.h>
 
 #include "fp_registration_data.h"

--- a/subsys/bluetooth/services/fast_pair/fp_storage.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage.c
@@ -9,14 +9,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/__assert.h>
-#include <sys/atomic.h>
-#include <settings/settings.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/settings/settings.h>
 
 #include "fp_storage.h"
 #include "fp_crypto.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(fast_pair, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
 
 #define SUBTREE_NAME "fp"


### PR DESCRIPTION
The "zephyr/" prefix should be used for Zephyr headers.

Jira: NCSDK-15174