### PR TITLE
samples: peripheral_fast_pair: Introduce logger

### DIFF
--- a/samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c
@@ -11,6 +11,9 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/services/fast_pair.h>
 
+#include <logging/log.h>
+LOG_MODULE_DECLARE(fp_sample, LOG_LEVEL_INF);
+
 #include "bt_tx_power_adv.h"
 #include "bt_adv_helper.h"
 
@@ -136,26 +139,26 @@ static int adv_start_internal(bool fp_discoverable)
 	int err = bt_le_adv_stop();
 
 	if (err) {
-		printk("Cannot stop advertising (err: %d)\n", err);
+		LOG_ERR("Cannot stop advertising (err: %d)", err);
 		return err;
 	}
 
 	err = bt_adv_helper_fast_pair_prepare(&ad[FAST_PAIR_ADV_DATA_POS], fp_discoverable);
 	if (err) {
-		printk("Cannot prepare Fast Pair advertising data (err: %d)\n", err);
+		LOG_ERR("Cannot prepare Fast Pair advertising data (err: %d)", err);
 		return err;
 	}
 
 	err = bt_adv_helper_tx_power_prepare(&ad[TX_POWER_ADV_DATA_POS]);
 	if (err) {
-		printk("Cannot prepare TX power advertising data (err: %d)\n", err);
+		LOG_ERR("Cannot prepare TX power advertising data (err: %d)", err);
 		return err;
 	}
 
 	/* Generate new Resolvable Private Address (RPA). */
 	err = bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
 	if (err) {
-		printk("Cannot trigger RPA rotation (err: %d)\n", err);
+		LOG_ERR("Cannot trigger RPA rotation (err: %d)", err);
 		return err;
 	}
 
@@ -181,7 +184,7 @@ static int adv_start_internal(bool fp_discoverable)
 			rpa_timeout_ms += ((int)(RPA_TIMEOUT_OFFSET_MAX * MSEC_PER_SEC)) *
 					  rand / INT8_MAX;
 		} else {
-			printk("Cannot get random RPA timeout (err: %d). Used fixed value", err);
+			LOG_WRN("Cannot get random RPA timeout (err: %d). Used fixed value", err);
 		}
 
 		__ASSERT_NO_MSG(rpa_timeout_ms <= RPA_TIMEOUT_FAST_PAIR_MAX * MSEC_PER_SEC);

--- a/samples/bluetooth/peripheral_fast_pair/src/bt_tx_power_adv.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/bt_tx_power_adv.c
@@ -10,6 +10,9 @@
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_vs.h>
 
+#include <logging/log.h>
+LOG_MODULE_DECLARE(fp_sample, LOG_LEVEL_INF);
+
 #include "bt_tx_power_adv.h"
 
 
@@ -43,7 +46,7 @@ int bt_tx_power_adv_data_fill(struct bt_data *adv_data, uint8_t *buf, size_t buf
 	if (err) {
 		uint8_t reason = rsp ?
 				((struct bt_hci_rp_vs_read_tx_power_level *) rsp->data)->status : 0;
-		printk("Read Tx power err: %d reason 0x%02x\n", err, reason);
+		LOG_ERR("Read Tx power err: %d reason 0x%02x", err, reason);
 	} else {
 		rp = (void *)rsp->data;
 		buf[0] = rp->tx_power_level;

--- a/samples/bluetooth/peripheral_fast_pair/src/hids_helper.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/hids_helper.c
@@ -8,6 +8,9 @@
 #include <sys/byteorder.h>
 #include <bluetooth/services/hids.h>
 
+#include <logging/log.h>
+LOG_MODULE_DECLARE(fp_sample, LOG_LEVEL_INF);
+
 #include "hids_helper.h"
 
 #define BASE_USB_HID_SPEC_VERSION	0x0101
@@ -27,7 +30,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 		int error = bt_hids_connected(&hids_obj, conn);
 
 		if (error) {
-			printk("Failed to notify HIDS about connection %d\n", error);
+			LOG_ERR("Failed to notify HIDS about connection %d", error);
 		}
 	}
 }
@@ -37,7 +40,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	int err = bt_hids_disconnected(&hids_obj, conn);
 
 	if (err) {
-		printk("Failed to notify HIDS about disconnection %d\n", err);
+		LOG_ERR("Failed to notify HIDS about disconnection %d", err);
 	}
 }
 


### PR DESCRIPTION
Use logger instead of printk. The sample already displays debug level logs from Fast Pair Service. The log related to failure while controlling audio volume was removed because HIDS reports unexpected error code.

Jira: NCSDK-15194