### PR TITLE
bluetooth: fast_pair: Integrate provisioning script to the build system

### DIFF
--- a/samples/bluetooth/peripheral_fast_pair/sample.yaml
+++ b/samples/bluetooth/peripheral_fast_pair/sample.yaml
@@ -12,3 +12,5 @@ tests:
     tags: bluetooth ci_build
     platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
+    extra_args: FP_MODEL_ID=0xFFFFFF
+                FP_ANTI_SPOOFING_KEY=AbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbA=

--- a/subsys/bluetooth/services/fast_pair/CMakeLists.txt
+++ b/subsys/bluetooth/services/fast_pair/CMakeLists.txt
@@ -17,3 +17,48 @@ zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_GATT_SERVICE	   fp_gatt_service
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_KEYS		   fp_keys.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_REGISTRATION_DATA fp_registration_data.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_STORAGE	   fp_storage.c)
+
+set(FP_PARTITION_NAME bt_fast_pair)
+
+set(
+  FP_PROVISIONING_DATA_HEX
+  ${CMAKE_BINARY_DIR}/modules/nrf/subsys/bluetooth/services/fast_pair/fp_provisioning_data.hex
+  )
+
+set(FP_PROVISIONING_DATA_ADDRESS $<TARGET_PROPERTY:partition_manager,PM_BT_FAST_PAIR_ADDRESS>)
+
+if(NOT DEFINED FP_MODEL_ID OR NOT DEFINED FP_ANTI_SPOOFING_KEY)
+  message(FATAL_ERROR "FP_MODEL_ID and FP_ANTI_SPOOFING_KEY build variables must be specified.")
+endif()
+
+add_custom_command(
+  OUTPUT
+  ${FP_PROVISIONING_DATA_HEX}
+  DEPENDS
+  "${CMAKE_BINARY_DIR}/pm.config"
+  COMMAND
+  ${PYTHON_EXECUTABLE} ${NRF_DIR}/scripts/nrf_provision/fast_pair/fp_provision_cli.py
+                       -o ${FP_PROVISIONING_DATA_HEX} -a ${FP_PROVISIONING_DATA_ADDRESS}
+                       -m ${FP_MODEL_ID} -k ${FP_ANTI_SPOOFING_KEY}
+  COMMENT
+  "Generating Fast Pair provisioning data hex file"
+  USES_TERMINAL
+  )
+
+add_custom_target(
+  ${FP_PARTITION_NAME}_target
+  DEPENDS
+  "${FP_PROVISIONING_DATA_HEX}"
+  )
+
+set_property(
+  GLOBAL PROPERTY
+  ${FP_PARTITION_NAME}_PM_HEX_FILE
+  "${FP_PROVISIONING_DATA_HEX}"
+  )
+
+set_property(
+  GLOBAL PROPERTY
+  ${FP_PARTITION_NAME}_PM_TARGET
+  ${FP_PARTITION_NAME}_target
+  )


### PR DESCRIPTION
Change makes Fast Pair provisioning data to be specified at build time.
The hex file that is generated by script is added to merged.hex file by
the build system.

From now on to build Fast Pair sample use following command:
`west build -b nrf52840dk_nrf52840 --pristine -- -DFP_MODEL_ID=0xFFFFFF -DFP_ANTI_SPOOFING_KEY=AbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbA=`

Jira: NCSDK-14937

Signed-off-by: Aleksander Strzebonski <aleksander.strzebonski@nordicsemi.no>

This PR was earlier on reviewed here: https://github.com/MarekPieta/fw-nrfconnect-nrf/pull/12 and is now transferred to main repository.