### PR TITLE
samples: nrf9160: lwm2m_client: Update doc about hex keys

### DIFF
--- a/samples/nrf9160/lwm2m_client/sample_description.rst
+++ b/samples/nrf9160/lwm2m_client/sample_description.rst
@@ -224,6 +224,8 @@ The following instructions describe how to register your device to `Leshan Demo 
             * Security mode - psk (Pre-Shared Key)
             * Key - 000102030405060708090a0b0c0d0e0f
 
+            Also, make sure to select the :guilabel:`Key in hexadecimal` checkbox.
+
    .. _bootstrap_server_reg:
 
    For registering the device to an LwM2M bootstrap server, complete the following steps:
@@ -269,6 +271,8 @@ The following instructions describe how to register your device to `Leshan Demo 
             * Friendly Name - *recognisable name*
             * Security mode - psk (Pre-Shared Key)
             * Key - 000102030405060708090a0b0c0d0e0f
+
+            Also, make sure to select the :guilabel:`Key in hexadecimal` checkbox.
 
             The Coiote bootstrap server automatically creates an account for the LwM2M server using the same device endpoint name and random PSK key.
 


### PR DESCRIPTION
In AVSystem, you should inform the system that key you
entered is actually in hexadecimal format.
This detail was missing from the example steps.
