### PR TITLE
Fix nrf_profiler python script

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -663,6 +663,7 @@ Other libraries
   * :ref:`nrf_profiler`:
 
       * Renamed Profiler to nRF Profiler.
+      * Updated versions of required python modules (pynrfjprog and matplotlib)
 
 Common Application Framework (CAF)
 ----------------------------------

--- a/scripts/nrf_profiler/plot_nordic.py
+++ b/scripts/nrf_profiler/plot_nordic.py
@@ -372,7 +372,7 @@ class PlotNordic():
                 self.draw_state.r_line_coord,
                 self.draw_state.l_line_coord)
             self.draw_state.duration_marker = plt.annotate(
-                s=PlotNordic._stringify_time(
+                text=PlotNordic._stringify_time(
                     bigger_coord - smaller_coord), xy=(
                     smaller_coord, 0.5), xytext=(
                     bigger_coord, 0.5), arrowprops=dict(

--- a/scripts/nrf_profiler/requirements.txt
+++ b/scripts/nrf_profiler/requirements.txt
@@ -1,3 +1,3 @@
 pynrfjprog
-matplotlib
+matplotlib>=3.5.2
 numpy

--- a/scripts/nrf_profiler/requirements.txt
+++ b/scripts/nrf_profiler/requirements.txt
@@ -1,3 +1,3 @@
-pynrfjprog<=10.12.2
+pynrfjprog
 matplotlib
 numpy


### PR DESCRIPTION
Fix python scripts to avoid errors in used libraries.

Jira: NCSDK-12859.