### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 04acceb93debb30437757802d189357bab5152f2
+      revision: pull/809/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr in order to use the version with fix to
high power consumption while using QSPI on nRF53.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>