### PR TITLE
samples: nrf9160: modem_shell: link: fixing re-entering of normal mode from pwroff

### DIFF
--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -638,14 +638,7 @@ int link_func_mode_set(enum lte_lc_func_mode fun, bool rel14_used)
 			}
 		}
 
-		if (IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT)) {
-			return_value = lte_lc_normal();
-		} else {
-			/* TODO: why not just do lte_lc_normal() as notifications are
-			 * subscribed there also nowadays?
-			 */
-			return_value = lte_lc_init_and_connect_async(link_ind_handler);
-		}
+		return_value = lte_lc_normal();
 		break;
 	case LTE_LC_FUNC_MODE_DEACTIVATE_LTE:
 	case LTE_LC_FUNC_MODE_ACTIVATE_LTE:


### PR DESCRIPTION
lte_lc_init_and_connect_async() was used when going to normal mode and
that was messing things in this case.
That was used due to workarounding past issues of re-subscribing of missing LTE_LC
notifications that were missed if pwroff was entered after once in
normal mode. Now, as needed notifications are re-enabled in LTE_LC,
we can start of using simply lte_lc_normal() when re-going to normal
mode from pwroff.
Jira: MOSH-280