### PR TITLE
doc: zigbee: add fota section for 5340

### DIFF
--- a/doc/nrf/libraries/zigbee/index.rst
+++ b/doc/nrf/libraries/zigbee/index.rst
@@ -9,7 +9,7 @@ See the :ref:`ug_zigbee` user guide for an overview of the technology.
 Zigbee libraries are a set of components that can be directly reused in Zigbee applications.
 They implement the default behavior of a Zigbee device and are used in :ref:`zigbee_samples` in this SDK.
 
-The following table lists libraries enabled by default for each available Zigbee sample (✔) or available through an overlay file (``**``):
+The following table lists libraries enabled by default for each available Zigbee sample (✔) or available through a configuration file (``**``):
 
 .. list-table::
     :widths: auto
@@ -75,7 +75,7 @@ The following table lists libraries enabled by default for each available Zigbee
 Read the table symbols in the following manner:
 
 * ``✔`` - The library is enabled by default for the given Zigbee sample.
-* ``**`` - The library support is available through an overlay file for the given Zigbee sample.
+* ``**`` - The library support is available through the :file:`prj_fota.conf` for the given Zigbee sample.
 * No symbol - The library is not enabled for the given sample, but you can enable support by following the instructions on the :ref:`ug_zigbee_configuring_libraries`.
 
 .. toctree::

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -94,7 +94,7 @@ Zigbee
 
 * Fixed:
 
-  * In case of an MCU reset between the completion of the OTA image transfer and a postponed firmware upgrade, the upgrade will be applied immediately.
+  * An issue where an MCU reset between the completion of the OTA image transfer and a postponed firmware upgrade would cause the upgrade to be applied immediately.
 
 Applications
 ============

--- a/doc/nrf/ug_nrf52.rst
+++ b/doc/nrf/ug_nrf52.rst
@@ -321,11 +321,15 @@ FOTA over Thread
 
 .. fota_upgrades_thread_end
 
+.. fota_upgrades_zigbee_start
+
 FOTA over Zigbee
 ================
 
-When working with the nRF52840 DK (PCA10056), you can enable support for FOTA over the Zigbee network using the :ref:`lib_zigbee_fota` library.
+You can enable support for FOTA over the Zigbee network using the :ref:`lib_zigbee_fota` library.
 For detailed information about how to configure the Zigbee FOTA library for your application, see :ref:`ug_zigbee_configuring_components_ota`.
+
+.. fota_upgrades_zigbee_end
 
 Building and programming a sample
 *********************************

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -609,6 +609,10 @@ See the following instructions.
    :start-after: fota_upgrades_thread_start
    :end-before: fota_upgrades_thread_end
 
+.. include:: ug_nrf52.rst
+   :start-after: fota_upgrades_zigbee_start
+   :end-before: fota_upgrades_zigbee_end
+
 Simultaneous multi-image DFU
 ****************************
 


### PR DESCRIPTION
Updated Working with nRF5340 user guide with a Zigbee section.
KRKNWK-13942.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>