### PR TITLE
tests: add platform_allow to tests without it

### DIFF
--- a/samples/caf_sensor_manager/sample.yaml
+++ b/samples/caf_sensor_manager/sample.yaml
@@ -5,6 +5,7 @@ tests:
   sample.caf_sensor_manager.correctness_test:
     build_only: false
     harness: console
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp qemu_cortex_m3
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
@@ -19,16 +20,19 @@ tests:
         - "sensor_data_aggregator_release_buffer_event"
   sample.caf_sensor_manager.nrf52840dk.power_consumption_test:
     build_only: false
+    platform_allow: nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n
   sample.caf_sensor_manager.multi_core.power_consumption_test:
     build_only: false
+    platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     extra_args: CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n remote_CONFIG_SERIAL=n remote_CONFIG_CONSOLE=n remote_CONFIG_UART_CONSOLE=n remote_CONFIG_LOG=n
   sample.caf_sensor_manager.nrf5340dk_singlecore.power_consumption_test:
     build_only: false
+    platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     extra_args: OVERLAY_CONFIG=boards/nrf5340dk_nrf5340_cpuapp_nrf5340_singlecore.conf CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n

--- a/tests/subsys/event_manager_proxy/testcase.yaml
+++ b/tests/subsys/event_manager_proxy/testcase.yaml
@@ -1,10 +1,12 @@
 tests:
   event_manager_proxy.openamp:
+    platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     tags: event_manager_proxy
   event_manager_proxy.icmsg:
     extra_args: CONF_FILE=prj_icmsg.conf
+    platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     tags: event_manager_proxy


### PR DESCRIPTION
Add platform_allow to test yaml for caf_sensor_manager sample and
tests event_manager_proxy.

Jira: NCSDK-15236 NCSDK-15238

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>