### PR TITLE
doc: Change warnings to notes

### DIFF
--- a/applications/asset_tracker_v2/src/watchdog/watchdog_app.h
+++ b/applications/asset_tracker_v2/src/watchdog/watchdog_app.h
@@ -43,7 +43,7 @@ int watchdog_init_and_start(void);
 
 /** @brief Register handler to receive watchdog callback events.
  *
- *  @warning The library only allows for one event handler to be registered
+ *  @note The library only allows for one event handler to be registered
  *           at a time. A passed in event handler in this function will
  *           overwrite the previously set event handler.
  *

--- a/include/bl_crypto.h
+++ b/include/bl_crypto.h
@@ -114,10 +114,10 @@ typedef int (*bl_sha256_init_t)(bl_sha256_ctx_t *ctx);
 /**
  * @brief Hash a portion of data.
  *
- * @warning @p ctx must be initialized before being used in this function.
- *          An uninitialized @p ctx might not be reported as an error. Also,
- *          @p ctx must not be used if it has been finalized, though this might
- *          also not be reported as an error.
+ * @note @p ctx must be initialized before being used in this function.
+ *       An uninitialized @p ctx might not be reported as an error. Also,
+ *       @p ctx must not be used if it has been finalized, though this might
+ *       also not be reported as an error.
  *
  * @param[in]  ctx       Context variable. Must have been initialized.
  * @param[in]  data      Data to hash.

--- a/include/bluetooth/mesh/scheduler_srv.h
+++ b/include/bluetooth/mesh/scheduler_srv.h
@@ -41,9 +41,9 @@ struct bt_mesh_scheduler_srv;
  *
  *  @brief Scheduler Server model composition data entry.
  *
- *  @warning If the Scheduler model is registered on the element then
- *           the Scene model shouldn't. The Scheduler model includes already
- *           the Scene model.
+ *  @note If the Scheduler model is registered on the element then
+ *        the Scene model shouldn't. The Scheduler model includes already
+ *        the Scene model.
  *
  *  @param[in] _srv Pointer to a @ref bt_mesh_scheduler_srv instance.
  */

--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -534,7 +534,7 @@ int bt_hids_disconnected(struct bt_hids *hids_obj, struct bt_conn *conn);
 
 /** @brief Send Input Report.
  *
- *  @warning The function is not thread safe.
+ *  @note The function is not thread safe.
  *	     It can not be called from multiple threads at the same time.
  *
  *  @param hids_obj Pointer to HIDS instance.
@@ -553,7 +553,7 @@ int bt_hids_inp_rep_send(struct bt_hids *hids_obj, struct bt_conn *conn,
 
 /** @brief Send Boot Mouse Input Report.
  *
- *  @warning The function is not thread safe.
+ *  @note The function is not thread safe.
  *	     It can not be called from multiple threads at the same time.
  *
  *  @param hids_obj Pointer to HIDS instance.
@@ -575,7 +575,7 @@ int bt_hids_boot_mouse_inp_rep_send(struct bt_hids *hids_obj,
 
 /** @brief Send Boot Keyboard Input Report.
  *
- *  @warning The function is not thread safe.
+ *  @note The function is not thread safe.
  *	     It can not be called from multiple threads at the same time.
  *
  *  @param hids_obj Pointer to HIDS instance.

--- a/include/caf/events/power_event.h
+++ b/include/caf/events/power_event.h
@@ -46,8 +46,8 @@ extern "C" {
  * event, it's ensured that all other application modules that handle power down event are already
  * suspended. Then it can continue the power down procedure.
  *
- * @warning An application module that handles power down event must also handle @ref wake_up_event.
- *          Otherwise the module will never be woken up after suspending.
+ * @note An application module that handles power down event must also handle @ref wake_up_event.
+ *       Otherwise the module will never be woken up after suspending.
  */
 struct power_down_event {
 	/** Event header. */

--- a/include/caf/events/sensor_event.h
+++ b/include/caf/events/sensor_event.h
@@ -49,8 +49,8 @@ enum sensor_state {
  * application. The Common Application Framework does not impose any standard way of describing
  * sensors. Format and content of the sensor description is defined by the application.
  *
- * @warning The sensor state event related to the given sensor must use the same description as
- *          #sensor_event related to the sensor.
+ * @note The sensor state event related to the given sensor must use the same description as
+ *       #sensor_event related to the sensor.
  */
 struct sensor_state_event {
 	struct app_event_header header; /**< Event header. */
@@ -74,8 +74,8 @@ APP_EVENT_TYPE_DECLARE(sensor_state_event);
  * in X, Y and Z axis as three floating-point values. @ref sensor_event_get_data_cnt and @ref
  * sensor_event_get_data_ptr can be used to access the sensor data provided by a given sensor event.
  *
- * @warning The sensor event related to the given sensor must use the same description as
- *          #sensor_state_event related to the sensor.
+ * @note The sensor event related to the given sensor must use the same description as
+ *       #sensor_state_event related to the sensor.
  */
 struct sensor_event {
 	struct app_event_header header; /**< Event header. */

--- a/include/date_time.h
+++ b/include/date_time.h
@@ -65,8 +65,8 @@ int date_time_set(const struct tm *new_date_time);
  *         passing variable uptime prior to the function call. In that case the uptime
  *         will not be too large or negative.
  *
- *  @warning If the function fails, the passed in variable retains its
- *           old value.
+ *  @note If the function fails, the passed in variable retains its
+ *        old value.
  *
  *  @param[in, out] uptime Pointer to a previously set uptime.
  *
@@ -79,8 +79,8 @@ int date_time_uptime_to_unix_time_ms(int64_t *uptime);
 
 /** @brief Get the current date time UTC.
  *
- *  @warning If the function fails, the passed in variable retains its
- *           old value.
+ *  @note If the function fails, the passed in variable retains its
+ *        old value.
  *
  *  @param[out] unix_time_ms Pointer to a variable to store the current date
  *                           time UTC.
@@ -106,9 +106,9 @@ bool date_time_is_valid(void);
 
 /** @brief Register an event handler for Date time library events.
  *
- *  @warning The library only allows for one event handler to be registered
- *           at a time. A passed in event handler in this function will
- *           overwrite the previously set event handler.
+ *  @note The library only allows for one event handler to be registered
+ *        at a time. A passed in event handler in this function will
+ *        overwrite the previously set event handler.
  *
  *  @param evt_handler Event handler. Handler is de-registered if parameter is
  *                     NULL.

--- a/include/mpsl/mpsl_work.h
+++ b/include/mpsl/mpsl_work.h
@@ -33,7 +33,7 @@ extern struct k_work_q mpsl_work_q;
  * processed, or is currently being processed, its work is considered
  * complete and the work item can be resubmitted.
  *
- * @warning
+ * @note
  * Work items submitted to the MPSL workqueue should avoid using handlers
  * that block or yield since this may prevent the MPSL workqueue from
  * processing other work items in a timely manner.

--- a/include/net/aws_iot.h
+++ b/include/net/aws_iot.h
@@ -191,8 +191,8 @@ struct aws_iot_config {
 
 /** @brief Initialize the module.
  *
- *  @warning This API must be called exactly once, and it must return
- *           successfully.
+ *  @note This API must be called exactly once, and it must return
+ *        successfully.
  *
  *  @param[in] config Pointer to struct containing connection parameters.
  *  @param[in] event_handler Pointer to event handler to receive AWS IoT module

--- a/include/net/azure_iot_hub.h
+++ b/include/net/azure_iot_hub.h
@@ -228,8 +228,8 @@ struct azure_iot_hub_config {
 
 /** @brief Initialize the module.
  *
- *  @warning This API must be called exactly once, and it must return
- *           successfully for subsequent calls to this library to succeed.
+ *  @note This API must be called exactly once, and it must return
+ *        successfully for subsequent calls to this library to succeed.
  *
  *  @param[in] config Pointer to struct containing connection parameters. Can be
  *		      NULL if @kconfig{CONFIG_AZURE_IOT_HUB_DEVICE_ID} is set.

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -431,8 +431,8 @@ struct nrf_cloud_init_param {
 /**
  * @brief Initialize the module.
  *
- * @warning This API must be called prior to using nRF Cloud
- *  and it must return successfully.
+ * @note This API must be called prior to using nRF Cloud
+ *       and it must return successfully.
  *
  * @param[in] param Initialization parameters.
  *

--- a/include/net/nrf_cloud_pgps.h
+++ b/include/net/nrf_cloud_pgps.h
@@ -287,7 +287,7 @@ int nrf_cloud_pgps_preemptive_updates(void);
  * requests any missing predictions, or full set if expired or missing.
  * When successful, it is ready to provide valid ephemeris predictions.
  *
- * @warning It must return successfully before using P-GPS services.
+ * @note It must return successfully before using P-GPS services.
  *
  * @param[in] param Initialization parameters.
  *

--- a/include/nrf_profiler.h
+++ b/include/nrf_profiler.h
@@ -79,8 +79,8 @@ struct log_event_buf {
 
 /** @brief Initialize the Profiler.
  *
- * @warning This function is thread-safe, but not safe to use in
- *	    interrupts.
+ * @note This function is thread-safe, but not safe to use in
+ *       interrupts.
  *
  * @retval 0 If the operation was successful.
  */
@@ -132,8 +132,8 @@ static inline bool is_profiling_enabled(size_t nrf_profiler_event_id)
 
 /** @brief Register an event type.
  *
- * @warning This function is thread-safe, but not safe to use in
- * interrupts.
+ * @note This function is thread-safe, but not safe to use in
+ *       interrupts.
  *
  * @param name Name of the event type.
  * @param args Names of data values sent with the event.
@@ -165,8 +165,8 @@ static inline void nrf_profiler_log_start(struct log_event_buf *buf) {}
 
 /** @brief Encode and add uint32_t data type to a buffer.
  *
- * @warning The buffer must be initialized with @ref nrf_profiler_log_start
- *          before calling this function.
+ * @note The buffer must be initialized with @ref nrf_profiler_log_start
+ *       before calling this function.
  *
  * @param buf Pointer to the data buffer.
  * @param data Data to add to the buffer.
@@ -180,8 +180,8 @@ static inline void nrf_profiler_log_encode_uint32(struct log_event_buf *buf,
 
 /** @brief Encode and add int32_t data type to a buffer.
  *
- * @warning The buffer must be initialized with @ref nrf_profiler_log_start
- *          before calling this function.
+ * @note The buffer must be initialized with @ref nrf_profiler_log_start
+ *       before calling this function.
  *
  * @param buf Pointer to the data buffer.
  * @param data Data to add to the buffer.
@@ -195,8 +195,8 @@ static inline void nrf_profiler_log_encode_int32(struct log_event_buf *buf,
 
 /** @brief Encode and add uint16_t data type to a buffer.
  *
- * @warning The buffer must be initialized with @ref nrf_profiler_log_start
- *          before calling this function.
+ * @note The buffer must be initialized with @ref nrf_profiler_log_start
+ *       before calling this function.
  *
  * @param buf Pointer to the data buffer.
  * @param data Data to add to the buffer.
@@ -210,8 +210,8 @@ static inline void nrf_profiler_log_encode_uint16(struct log_event_buf *buf,
 
 /** @brief Encode and add int16_t data type to a buffer.
  *
- * @warning The buffer must be initialized with @ref nrf_profiler_log_start
- *          before calling this function.
+ * @note The buffer must be initialized with @ref nrf_profiler_log_start
+ *       before calling this function.
  *
  * @param buf Pointer to the data buffer.
  * @param data Data to add to the buffer.
@@ -225,8 +225,8 @@ static inline void nrf_profiler_log_encode_int16(struct log_event_buf *buf,
 
 /** @brief Encode and add uint8_t data type to a buffer.
  *
- * @warning The buffer must be initialized with @ref nrf_profiler_log_start
- *          before calling this function.
+ * @note The buffer must be initialized with @ref nrf_profiler_log_start
+ *       before calling this function.
  *
  * @param buf Pointer to the data buffer.
  * @param data Data to add to the buffer.
@@ -240,8 +240,8 @@ static inline void nrf_profiler_log_encode_uint8(struct log_event_buf *buf,
 
 /** @brief Encode and add int8_t data type to a buffer.
  *
- * @warning The buffer must be initialized with @ref nrf_profiler_log_start
- *          before calling this function.
+ * @note The buffer must be initialized with @ref nrf_profiler_log_start
+ *       before calling this function.
  *
  * @param buf Pointer to the data buffer.
  * @param data Data to add to the buffer.
@@ -257,8 +257,8 @@ static inline void nrf_profiler_log_encode_int8(struct log_event_buf *buf,
  *
  * Maximum 255 characters can be sent (the rest is ommited).
  *
- * @warning The buffer must be initialized with @ref nrf_profiler_log_start
- *          before calling this function.
+ * @note The buffer must be initialized with @ref nrf_profiler_log_start
+ *       before calling this function.
  *
  * @param buf Pointer to the data buffer.
  * @param string String to add to the buffer.
@@ -275,8 +275,8 @@ static inline void nrf_profiler_log_encode_string(struct log_event_buf *buf,
  *
  * This information is used for event identification.
  *
- * @warning The buffer must be initialized with @ref nrf_profiler_log_start
- *          before calling this function.
+ * @note The buffer must be initialized with @ref nrf_profiler_log_start
+ *       before calling this function.
  *
  * @param buf Pointer to the data buffer.
  * @param mem_address Memory address to encode.

--- a/subsys/emds/emds_flash.h
+++ b/subsys/emds/emds_flash.h
@@ -62,7 +62,7 @@ int emds_flash_init(struct emds_fs *fs, const char *dev_name);
  *
  * @param fs Pointer to file system
  *
- * @warning Calling this function will make any subsequent read attempts fail. Be sure to
+ * @note Calling this function will make any subsequent read attempts fail. Be sure to
  * restore all necessary entries before using this function.
  *
  * @retval 0 on success or negative error code
@@ -107,10 +107,10 @@ ssize_t emds_flash_read(struct emds_fs *fs, uint16_t id, void *data, size_t len)
  * entries from flash. It will invalidate all prior entries, and potentially clear the flash
  * area.
  *
- * @warning Calling this function will make any subsequent read attempts fail. Be sure to
+ * @note Calling this function will make any subsequent read attempts fail. Be sure to
  * restore all necessary entries before using this function.
  *
- * @warning Should only be called once.
+ * @note Should only be called once.
  *
  * @param fs Pointer to file system
  * @param byte_size Total number of bytes

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_fota.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_fota.h
@@ -76,7 +76,7 @@ typedef void (*nrf_cloud_fota_callback_t)
  * @brief  BLE FOTA handler registered with the nRF Cloud FOTA module to handle
  *  asynchronous events.
  *
- * @warning The memory pointed to by ble_job will be freed after the handler
+ * @note The memory pointed to by ble_job will be freed after the handler
  * has returned.
  *
  * @param[in]  ble_job The BLE FOTA job.
@@ -87,7 +87,7 @@ typedef void (*nrf_cloud_fota_ble_callback_t)
 /**
  * @brief Initialize the nRF Cloud FOTA module.
  *
- * @warning This API must be called prior to using nRF Cloud FOTA and it must
+ * @note This API must be called prior to using nRF Cloud FOTA and it must
  * return successfully.
  *
  * @param[in] cb FOTA event handler.

--- a/tests/crypto/src/common_test.h
+++ b/tests/crypto/src/common_test.h
@@ -495,11 +495,11 @@ void stop_time_measurement(void);
 
 /**@brief   Macro for retrieving a variable from a section.
  *
- * @warning     The stored symbol can only be resolved using this macro if the
- *              type of the data is word aligned. The operation of acquiring
- *              the stored symbol relies on the size of the stored type. No
- *              padding can exist in the named section in between individual
- *              stored items or this macro will fail.
+ * @note     The stored symbol can only be resolved using this macro if the
+ *           type of the data is word aligned. The operation of acquiring
+ *           the stored symbol relies on the size of the stored type. No
+ *           padding can exist in the named section in between individual
+ *           stored items or this macro will fail.
  *
  * @param[in]   section_name    Name of the section.
  * @param[in]   data_type       Data type of the variable.


### PR DESCRIPTION
Update API documentation to use rather notes instead of warnings.