### PR TITLE
application: serial_lte_modem: BUG-FIX null terminator

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -747,7 +747,7 @@ static void format_final_result(char *buf)
 final_result:
 	/* insert CRLF before final result if there is information response before it */
 	if (result != buf) {
-		memmove((void *)(result + strlen(crlf_str)), (void *)result, strlen(result));
+		memmove((void *)(result + strlen(crlf_str)), (void *)result, strlen(result) + 1);
 		memcpy((void *)result, (void *)crlf_str, strlen(crlf_str));
 	}
 }


### PR DESCRIPTION
After PR#7377, the null terminator of AT response is lost.
If the next AT command has a response shorter than previous
command, the response string would be wrong due to no null
terminator to determine correct length.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>