### PR TITLE
zigbee: Fix setting intervals between image query

### DIFF
--- a/doc/nrf/libraries/zigbee/zigbee_fota.rst
+++ b/doc/nrf/libraries/zigbee/zigbee_fota.rst
@@ -34,8 +34,10 @@ The following entities participate in the Zigbee OTA Upgrade process:
 OTA upgrade process
 *******************
 
+The OTA Upgrade Client queries for OTA Upgrade Servers with the intervals defined by the :kconfig:option:`CONFIG_ZIGBEE_FOTA_SERVER_DISOVERY_INTERVAL_HRS` Kconfig option until at least one server is found.
+Once found, the client starts to query the server for images.
+The interval between queries for the available Zigbee FOTA images is defined by the :kconfig:option:`CONFIG_ZIGBEE_FOTA_IMAGE_QUERY_INTERVAL_MIN` Kconfig option.
 After querying the OTA Upgrade Server for available images and receiving information about the image, the library begins the OTA upgrade process.
-The interval between queries for the available Zigbee FOTA images is defined by :kconfig:option:`CONFIG_ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS`.
 The library uses :ref:`nrfxlib:zboss`'s ZCL API to download the image.
 
 After the OTA Upgrade Client downloads the Zigbee OTA image header, the stack verifies the following mandatory fields:
@@ -76,7 +78,8 @@ To configure the Zigbee FOTA library, use the following options:
 * :kconfig:option:`CONFIG_ZIGBEE_FOTA_MIN_HW_VERSION`
 * :kconfig:option:`CONFIG_ENABLE_ZIGBEE_FOTA_MAX_HW_VERSION`
 * :kconfig:option:`CONFIG_ZIGBEE_FOTA_MAX_HW_VERSION`
-* :kconfig:option:`CONFIG_ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS`
+* :kconfig:option:`CONFIG_ZIGBEE_FOTA_SERVER_DISOVERY_INTERVAL_HRS`
+* :kconfig:option:`CONFIG_ZIGBEE_FOTA_IMAGE_QUERY_INTERVAL_MIN`
 
 For detailed steps about configuring the library in a Zigbee sample or application, see :ref:`ug_zigbee_configuring_components_ota`.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -769,7 +769,8 @@ Libraries for Zigbee
 
     * Added:
 
-      * New :kconfig:option:`CONFIG_ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS` Kconfig option to configure interval between queries for the available Zigbee FOTA images.
+      * New :kconfig:option:`CONFIG_ZIGBEE_FOTA_SERVER_DISOVERY_INTERVAL_HRS` Kconfig option to configure the interval between queries for the Zigbee FOTA server.
+      * New :kconfig:option:`CONFIG_ZIGBEE_FOTA_IMAGE_QUERY_INTERVAL_MIN` Kconfig option to configure the interval between queries for the available Zigbee FOTA images.
       * Support for the combined application and network core updates for the nRF5340 SoC.
 
     * Updated:

--- a/subsys/zigbee/lib/zigbee_fota/Kconfig
+++ b/subsys/zigbee/lib/zigbee_fota/Kconfig
@@ -89,9 +89,13 @@ config ZIGBEE_FOTA_MAX_HW_VERSION
 	range 0x00 0xFF
 	depends on ENABLE_ZIGBEE_FOTA_MAX_HW_VERSION
 
-config ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS
-	int "Time interval between queries for the available Zigbee FOTA images"
+config ZIGBEE_FOTA_SERVER_DISOVERY_INTERVAL_HRS
+	int "Time interval between queries for the Zigbee FOTA server"
 	default 24
+
+config ZIGBEE_FOTA_IMAGE_QUERY_INTERVAL_MIN
+	int "Time interval between queries for the available Zigbee FOTA images"
+	default 60
 
 module=ZIGBEE_FOTA
 module-dep=LOG

--- a/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
+++ b/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
@@ -88,7 +88,7 @@ ZB_ZCL_DECLARE_OTA_UPGRADE_ATTRIB_LIST(ota_upgrade_attr_list,
 				&dev_ctx.ota_attr.server_ep,
 				(uint16_t)CONFIG_ZIGBEE_FOTA_HW_VERSION,
 				CONFIG_ZIGBEE_FOTA_DATA_BLOCK_SIZE,
-				ZB_ZCL_OTA_UPGRADE_QUERY_TIMER_COUNT_DEF);
+				CONFIG_ZIGBEE_FOTA_IMAGE_QUERY_INTERVAL_MIN);
 
 ZB_HA_DECLARE_OTA_UPGRADE_CLIENT_CLUSTER_LIST(ota_upgrade_client_clusters,
 	ota_basic_attr_list, ota_upgrade_attr_list);
@@ -485,7 +485,7 @@ void zigbee_fota_signal_handler(zb_bufid_t bufid)
 	case ZB_BDB_SIGNAL_STEERING:
 		if (status == RET_OK) {
 			k_timer_start(&dev_ctx.alarm, K_NO_WAIT,
-				K_HOURS(CONFIG_ZIGBEE_FOTA_IMAGE_DISOVERY_INTERVAL_HRS));
+				K_HOURS(CONFIG_ZIGBEE_FOTA_SERVER_DISOVERY_INTERVAL_HRS));
 		}
 		break;
 	default:


### PR DESCRIPTION
Fix the attribute name - it is setting interval between server queries instead of image queries and add the correct one.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>