### PR TITLE
openthread: Fix setting the correct TF-M build profile

### DIFF
--- a/subsys/net/openthread/Kconfig
+++ b/subsys/net/openthread/Kconfig
@@ -64,7 +64,7 @@ config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	default 1024
 
 choice TFM_PROFILE_TYPE
-	default TFM_PROFILE_TYPE_MEDIUM
+	default TFM_PROFILE_TYPE_NOT_SET
 endchoice
 
 endmenu


### PR DESCRIPTION
The TF-M build profile was accidentally set to medium, should have not
been set.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>