### PR TITLE
samples: matter: Fixed an issue with pwm overflow

### DIFF
--- a/samples/matter/common/src/pwm_device.cpp
+++ b/samples/matter/common/src/pwm_device.cpp
@@ -99,5 +99,5 @@ void PWMDevice::UpdateLight()
 	const uint8_t effectiveLevel =
 		mState == kState_On ? chip::min<uint8_t>(mLevel - mMinLevel, maxEffectiveLevel) : 0;
 
-	pwm_set_pulse_dt(mPwmDevice, mPwmDevice->period * effectiveLevel / maxEffectiveLevel);
+	pwm_set_pulse_dt(mPwmDevice, static_cast<uint32_t>(static_cast<const uint64_t>(mPwmDevice->period) * effectiveLevel / maxEffectiveLevel));
 }

--- a/samples/matter/light_bulb/src/lighting_manager.cpp
+++ b/samples/matter/light_bulb/src/lighting_manager.cpp
@@ -94,5 +94,5 @@ void LightingManager::UpdateLight()
 	const uint8_t maxEffectiveLevel = mMaxLevel - mMinLevel;
 	const uint8_t effectiveLevel = mState == State::On ? MIN(mLevel - mMinLevel, maxEffectiveLevel) : 0;
 
-	pwm_set_pulse_dt(mPwmDevice, mPwmDevice->period * effectiveLevel / maxEffectiveLevel);
+	pwm_set_pulse_dt(mPwmDevice, static_cast<uint32_t>(static_cast<const uint64_t>(mPwmDevice->period) * effectiveLevel / maxEffectiveLevel));
 }


### PR DESCRIPTION
A uint32 variable had overflowed when the new PWM value for LED was set.