### PR TITLE
net: lib: lwm2m_client_utils: API for applying update

### DIFF
--- a/include/net/lwm2m_client_utils.h
+++ b/include/net/lwm2m_client_utils.h
@@ -114,6 +114,18 @@ typedef int (*lwm2m_firmware_get_update_state_cb_t)(uint8_t update_state);
 void lwm2m_firmware_set_update_state_cb(lwm2m_firmware_get_update_state_cb_t cb);
 
 /**
+ * @brief Apply the firmware update.
+ *
+ * By default lwm2m firmware is applied when the update resource (5/0/2) is executed.
+ * If application needs to control the update, it can set its own callback for the
+ * update resource calling `lwm2m_firmware_set_update_cb`. After that, the application
+ * can apply the firmware update when it is ready.
+ *
+ * @param[in] obj_inst_id Instance id of the firmware update object.
+ */
+int lwm2m_firmware_apply_update(uint16_t obj_inst_id);
+
+/**
  * @brief Firmware read callback
  */
 void *firmware_read_cb(uint16_t obj_inst_id, size_t *data_len);

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -430,6 +430,20 @@ static int write_dl_uri(uint16_t obj_inst_id,
 	return 0;
 }
 
+int lwm2m_firmware_apply_update(uint16_t obj_inst_id)
+{
+	int ret = 0;
+
+	if (lwm2m_firmware_get_update_state_inst(obj_inst_id) == STATE_UPDATING) {
+		ret = firmware_update_cb(obj_inst_id, NULL, 0);
+	} else {
+		LOG_ERR("No updates scheduled for instance %d", obj_inst_id);
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
 void lwm2m_firmware_set_update_state_cb(lwm2m_firmware_get_update_state_cb_t cb)
 {
 	update_state_cb = cb;


### PR DESCRIPTION
Add an API for application to control the update.
Application can register its own callback to get noticed
that new update is available and able to be applied.
Application can then start the update process when it is ready.

Signed-off-by: Jarno Lamsa <jarno.lamsa@nordicsemi.no>