### PR TITLE
Ncs 2.0 rebase

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c2b857a3b8d53bd92ee09b40e0ede0356d8c82fa
+      revision: v3.0.99-ncs1-snapshot1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -100,7 +100,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: e7db8251d5fa2588870382319bc3858314870227
+      revision: v1.9.99-ncs1-snapshot1
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls
@@ -113,7 +113,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 08c58a9fc769ad562941b50980a1c76a28977f14
+      revision: v1.5.0-ncs2-snapshot1
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.0.99-ncs1-snapshot1
+      revision: v3.0.99-ncs1-rc1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -100,7 +100,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.9.99-ncs1-snapshot1
+      revision: v1.9.99-ncs1-rc1
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls
@@ -113,7 +113,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v1.5.0-ncs2-snapshot1
+      revision: v1.5.0-ncs2-rc1
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Prepare for the next release by cleaning up history in OSS repositories where we carry downstream patches.