### PR TITLE
manifest: Update for detecting license of binary files

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.0.0-rc1
+      revision: pull/712/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
A new tool for a license report generation will be introduced in
the new NCS. It will recognize licenses from the source code,
but it needs additional information for binary files. This commit
adds special tag to license files allowing clear binary files
license recognition.

Related to: https://github.com/nrfconnect/sdk-nrfxlib/pull/712