### PR TITLE
Bluetooth: tests: Add platform_allow to fast_pair testcase

### DIFF
--- a/tests/subsys/bluetooth/fast_pair/crypto/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/crypto/testcase.yaml
@@ -1,11 +1,15 @@
 tests:
   fast_pair.crypto.mbedtls:
+    platform_allow:
+      nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
   fast_pair.crypto.tinycrypt:
+    platform_allow:
+      nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns qemu_cortex_m3
     integration_platforms:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832


### PR DESCRIPTION
Add platform_allow to fast_pair test case that matches
integration_platform.

NCSDK-15306

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>