### PR TITLE
boards: nrf5340dk_audio_dk_nrf5340_ns: Enable PINCTRL by default

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_ns_defconfig
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_ns_defconfig
@@ -16,5 +16,8 @@ CONFIG_ARM_TRUSTZONE_M=y
 # This Board implies building Non-Secure firmware
 CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 
-# enable GPIO
+# Enable PINCTRL
+CONFIG_PINCTRL=y
+
+# Enable GPIO
 CONFIG_GPIO=y


### PR DESCRIPTION
This is a follow-up to commit ea85b53a02c2e6bb112ff31764351bb020116bac.

As the `_ns` target uses now pinctrl properties in devicetree,
it should also enable PINCTRL by default.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>