### PR TITLE
manifest: Fix nrfxlib revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: pull/740/head
+      revision: 459bc7d547c13c60aa161b7aa35989679f1d00cf
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
This is a follow-up to commit 85e00e2f0b651f5eb9a5ade5657b4b3593e1703d
("manifest: Update sdk-nrfxlib revision").

Update nrfxlib revision with the proper SHA.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>