### PR TITLE
tests: turn on build_only in sensor manager sample

### DIFF
--- a/samples/caf_sensor_manager/sample.yaml
+++ b/samples/caf_sensor_manager/sample.yaml
@@ -14,24 +14,24 @@ tests:
       type: multi_line
       ordered: true
       regex:
+        - "main: Event manager initialized"
         - "main state:READY"
-        - "sensor_sim_ctrl state:READY"
         - "Send sensor buffer desc address:"
         - "sensor_data_aggregator_release_buffer_event"
   sample.caf_sensor_manager.nrf52840dk.power_consumption_test:
-    build_only: false
+    build_only: true
     platform_allow: nrf52840dk_nrf52840
     integration_platforms:
       - nrf52840dk_nrf52840
     extra_args: CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n
   sample.caf_sensor_manager.multi_core.power_consumption_test:
-    build_only: false
+    build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     extra_args: CONFIG_SERIAL=n CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_LOG=n remote_CONFIG_SERIAL=n remote_CONFIG_CONSOLE=n remote_CONFIG_UART_CONSOLE=n remote_CONFIG_LOG=n
   sample.caf_sensor_manager.nrf5340dk_singlecore.power_consumption_test:
-    build_only: false
+    build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
Change in caf_sensor_manager sample so power_consumption tests
won't be run on twisterr DKs.

Jira: NCSDK-15311

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>