### PR TITLE
bluetooth: controller: Increase range of periodic sync buffer size

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -124,7 +124,7 @@ config BT_CTLR_SDC_SCAN_BUFFER_COUNT
 config BT_CTLR_SDC_PERIODIC_SYNC_BUFFER_COUNT
 	int "Number of periodic synchronization receive buffers"
 	default 2
-	range 2 10
+	range 2 20
 	help
 	  The buffers are used for processing incoming packets
 	  and storing periodic advertising reports.


### PR DESCRIPTION
The current buffer size is not sufficient for receiving
16 PDUs in a periodic interval, e.g. when CTE_count is set to 16.

By increasing the maximum size to 20 it should be fixed.

Signed-off-by: Yuxuan Cai <yuxuan.cai@nordicsemi.no>