### PR TITLE
hw_unique_key: Fix memset call for zeroing key bytes

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -748,6 +748,10 @@ Other libraries
 
       * Fixed a NULL dereference bug, which could happen if :c:func:`settings_load` was called outside of the library.
 
+  * :ref:`lib_hw_unique_key` library:
+
+    * Fixed a bug where the random key would not be deleted from RAM after being generated and written.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/lib/hw_unique_key/hw_unique_key.c
+++ b/lib/hw_unique_key/hw_unique_key.c
@@ -16,6 +16,7 @@
 void hw_unique_key_write_random(void)
 {
 	uint8_t rand_bytes[HUK_SIZE_BYTES * ARRAY_SIZE(huk_slots)];
+	uint8_t zeros[sizeof(rand_bytes)] = {0};
 	size_t olen;
 	uint8_t pers_str[] = "HW Unique Key";
 	int err, err2;
@@ -50,7 +51,12 @@ void hw_unique_key_write_random(void)
 		hw_unique_key_write(huk_slots[i], rand_bytes + (HUK_SIZE_BYTES * i));
 	}
 
-	memset(rand_bytes, sizeof(rand_bytes), 0);
+	memset(rand_bytes, 0, sizeof(rand_bytes));
+
+	if (memcmp(rand_bytes, zeros, sizeof(rand_bytes)) != 0) {
+		HUK_PRINT("The key bytes weren't correctly deleted from RAM.\n\r");
+		HUK_PANIC();
+	}
 
 	for (int i = 0; i < ARRAY_SIZE(huk_slots); i++) {
 		if (!hw_unique_key_is_written(huk_slots[i])) {


### PR DESCRIPTION
Argument order was wrong, also add a check that the bytes were zeroed
correctly.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>