### PR TITLE
nvs: pull change that adds NVS cache

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.0.99-ncs1-rc1
+      revision: 10a0d79e2731463624a296b134ac08407591cc6b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
In Matter we observe significant performance degradation
when more and more data is written to NVS. Pull a change
that allows one to enable NVS lookup cache that speeds
up finding data in the NVS.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>