### PR TITLE
zigbee: Allow for using USB logs in NCP

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -112,6 +112,7 @@ Zigbee
 * Fixed:
 
   * An issue where an MCU reset between the completion of the OTA image transfer and a postponed firmware upgrade would cause the upgrade to be applied immediately.
+  * An issue where NCP SoC fails to initialize when ZBOSS traces over the second UBS CDC ACM class are enabled.
 
 See `Zigbee samples`_ for the list of changes for the Zigbee samples.
 

--- a/samples/zigbee/ncp/src/main.c
+++ b/samples/zigbee/ncp/src/main.c
@@ -170,7 +170,8 @@ int main(void)
 	/* Enable USB device. */
 	int ret = usb_enable(NULL);
 
-	if (ret != 0) {
+	if ((ret != 0) && (ret != -EALREADY)) {
+		LOG_ERR("USB initialization failed");
 		return ret;
 	}
 

--- a/subsys/zigbee/osif/zb_nrf_serial_logger.c
+++ b/subsys/zigbee/osif/zb_nrf_serial_logger.c
@@ -163,7 +163,7 @@ void zb_osif_serial_logger_init(void)
 	if (IS_ENABLED(CONFIG_ZBOSS_TRACE_USB_CDC_LOGGING)) {
 		int ret = usb_enable(NULL);
 
-		if (ret != 0) {
+		if ((ret != 0) && (ret != -EALREADY)) {
 			LOG_ERR("USB initialization failed - No UART device to log ZBOSS Traces");
 			/* USB initialization failed - mark UART device as unavailable. */
 			uart_dev = NULL;


### PR DESCRIPTION
Handle the USB initialization error that indicates that it has been already initialized.
A good example of such case is when both ZBOSS traces over USB CDC ACM is enabled as well as NCP over USB CDC ACM.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>