### PR TITLE
samples: nrf9160: modem_shell: check if UART1 is configured

### DIFF
--- a/samples/nrf9160/modem_shell/src/uart/uart.c
+++ b/samples/nrf9160/modem_shell/src/uart/uart.c
@@ -19,6 +19,10 @@
  */
 static void uart1_set_enable(bool enable)
 {
+	if (!IS_ENABLED(CONFIG_NRFX_UARTE1)) {
+		return;
+	}
+
 	if (enable) {
 		NRF_UARTE1_NS->ENABLE = UARTE_ENABLE_ENABLE_Enabled;
 	} else {


### PR DESCRIPTION
Check if UART1 is configured before trying to enable/disable it.
Solves a crash when trying to disable UARTs when using with TF-M.

JIRA: NCSDK-15307

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>