### PR TITLE
samples: nrf9160: modem_shell: non-offloading build fix

### DIFF
--- a/samples/nrf9160/modem_shell/overlay-non-offloading.conf
+++ b/samples/nrf9160/modem_shell/overlay-non-offloading.conf
@@ -47,6 +47,13 @@ CONFIG_NET_IPV4=y
 CONFIG_NET_IPV6=n
 CONFIG_NET_TCP=y
 
+#Following selects MBEDTLS_MAC_MD5_ENABLED that needs bunch of other features
+CONFIG_NET_TCP_ISN_RFC6528=n
+
+#TFM takes more SRAM and we need that for enabling higher RPC buffers
+CONFIG_BUILD_WITH_TFM=n
+CONFIG_SPM=y
+
 #Default RTO is too short and causes spurious retransmissions in uplink
 CONFIG_NET_TCP_INIT_RETRANSMISSION_TIMEOUT=1500
 CONFIG_NET_TCP_RETRY_COUNT=6

--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -21,6 +21,13 @@ tests:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns
     tags: ci_build
+  sample.nrf9160.modem_shell.non_offloading_ip:
+    build_only: true
+    extra_args: OVERLAY_CONFIG=overlay-non-offloading.conf
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns
+    tags: ci_build
   sample.nrf9160.modem_shell.esp_wifi:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-esp-wifi.conf DTC_OVERLAY_FILE="esp_8266_nrf9160ns.overlay"


### PR DESCRIPTION
Fixing build failures caused by TFM enablation and the latest upmerge where was added
dependency need for MBEDTLS_MAC_MD5_ENABLED from
CONFIG_NET_TCP_ISN_RFC6528. TFM would need take much more SRAM that we
need for bigger RPC buffers.
Thus, disabling both TFM and TCP_ISN for non-offloading config.
Additionally, added non-offloading overlay to sample.yaml.
Fixes NCSDK-15364