### PR TITLE
dfu: dfu_target: Fix settings handler

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -735,6 +735,10 @@ Other libraries
 
       * Added :kconfig:option:`CONFIG_EI_WRAPPER_PROFILING` for logging time of classifier execution.
 
+  * :ref:`lib_dfu_target`:
+
+      * Fixed a NULL dereference bug, which could happen if :c:func:`settings_load` was called outside of the library.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/subsys/dfu/dfu_target/src/dfu_target_stream.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_stream.c
@@ -53,7 +53,7 @@ static int store_progress(void)
 static int settings_set(const char *key, size_t len_rd,
 			settings_read_cb read_cb, void *cb_arg)
 {
-	if (!strcmp(key, current_id)) {
+	if (current_id && !strcmp(key, current_id)) {
 		int err;
 		off_t absolute_offset;
 		struct flash_pages_info page;


### PR DESCRIPTION
Avoid dereferencing a NULL pointer when another part of the application
calls `settings_load()` while `dfu_target_stream` is not initialized.

NCSDK-15377

Signed-off-by: Grzegorz Swiderski <grzegorz.swiderski@nordicsemi.no>