### PR TITLE
nrf_security: Add integration regression builds

### DIFF
--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -30,11 +30,7 @@ tests:
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build
   # Build integration regression protection.
-  #
-  # Use the nrf_security_build_integration tag to ensure this is built on CI
-  # when crypto library changes are made.
   integration.nrf_security.bluetooth:
-      tags: nrf_security_build_integration
       build_only: True
       extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
       platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -29,3 +29,14 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build
+  # Build integration regression protection.
+  #
+  # Use the nrf_security_build_integration tag to ensure this is built on CI
+  # when crypto library changes are made.
+  integration.nrf_security.bluetooth:
+      tags: nrf_security_build_integration
+      build_only: True
+      extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
+      platform_allow: nrf5340dk_nrf5340_cpuapp
+      integration_platforms:
+          - nrf5340dk_nrf5340_cpuapp

--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -17,11 +17,7 @@ tests:
             - nrf9160dk_nrf9160
             - nrf52840dk_nrf52840
     # Build integration regression protection.
-    #
-    # Use the nrf_security_build_integration tag to ensure this is built on CI
-    # when crypto library changes are made.
     integration.nrf_security.sha256:
-        tags: nrf_security_build_integration
         build_only: True
         extra_args: CONFIG_BOOTLOADER_MCUBOOT=y
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833

--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -16,3 +16,16 @@ tests:
             - nrf9160dk_nrf9160_ns
             - nrf9160dk_nrf9160
             - nrf52840dk_nrf52840
+    # Build integration regression protection.
+    #
+    # Use the nrf_security_build_integration tag to ensure this is built on CI
+    # when crypto library changes are made.
+    integration.nrf_security.sha256:
+        tags: nrf_security_build_integration
+        build_only: True
+        extra_args: CONFIG_BOOTLOADER_MCUBOOT=y
+        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833
+        integration_platforms:
+            - nrf5340dk_nrf5340_cpuapp_ns
+            - nrf52840dk_nrf52840
+            - nrf52833dk_nrf52833

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -34,3 +34,14 @@ tests:
     - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: ci_build
+  # Build integration regression protection.
+  #
+  # Use the nrf_security_build_integration tag to ensure this is built on CI
+  # when crypto library changes are made.
+  integration.nrf_security.matter:
+      tags: nrf_security_build_integration
+      build_only: True
+      extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
+      platform_allow: nrf52840dk_nrf52840
+      integration_platforms:
+          - nrf52840dk_nrf52840

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -35,11 +35,7 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: ci_build
   # Build integration regression protection.
-  #
-  # Use the nrf_security_build_integration tag to ensure this is built on CI
-  # when crypto library changes are made.
   integration.nrf_security.matter:
-      tags: nrf_security_build_integration
       build_only: True
       extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
       platform_allow: nrf52840dk_nrf52840

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -42,3 +42,15 @@ tests:
       - nrf52840dk_nrf52840
       - nrf52840dongle_nrf52840
       - nrf21540dk_nrf52840
+  # Build integration regression protection.
+  #
+  # Use the nrf_security_build_integration tag to ensure this is built on CI
+  # when crypto library changes are made.
+  integration.nrf_security.openthread:
+      tags: nrf_security_build_integration
+      build_only: True
+      extra_args: CONFIG_NRF_SECURITY=y
+      platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840
+      integration_platforms:
+          - nrf5340dk_nrf5340_cpuapp_ns
+          - nrf52840dk_nrf52840

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -43,11 +43,7 @@ tests:
       - nrf52840dongle_nrf52840
       - nrf21540dk_nrf52840
   # Build integration regression protection.
-  #
-  # Use the nrf_security_build_integration tag to ensure this is built on CI
-  # when crypto library changes are made.
   integration.nrf_security.openthread:
-      tags: nrf_security_build_integration
       build_only: True
       extra_args: CONFIG_NRF_SECURITY=y
       platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840


### PR DESCRIPTION
Previous builds against MCUboot, matter, openthread,
bluetooth has failed when nrf_security changes.
Catch this early by adding integration builds.
The CI process can opt-in to building this via
the tag "nrf_security_build_integration".

Ref.: NCSDK-13723