### PR TITLE
samples: nrf9160: modem_shell: use SPM instead of TF-M

### DIFF
--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -14,6 +14,10 @@ CONFIG_MOSH_SMS=y
 CONFIG_MOSH_GNSS=y
 CONFIG_MOSH_LOCATION=y
 
+# Use SPM instead of TF-M because it leaves more SRAM for the application
+CONFIG_BUILD_WITH_TFM=n
+CONFIG_SPM=y
+
 # Stacks and heaps
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_HEAP_MEM_POOL_SIZE=10240


### PR DESCRIPTION
Enabling TF-M decreased the amount of available SRAM for the application, causing iPerf3 and curl to run out of memory.

Fixes MOSH-288.