### PR TITLE
partition_manager: Calling yamllint on all Yaml input files

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -7,6 +7,7 @@
 import argparse
 import yaml
 from os import path
+from os import system
 import sys
 from pprint import pformat
 
@@ -666,6 +667,9 @@ def load_reqs(input_config):
 
     for ymlpath in input_config:
         if path.exists(ymlpath):
+            ret = system("yamllint " + ymlpath)
+            if ret != 0:
+                sys.exit(1)
             with open(ymlpath, 'r') as f:
                 loaded_reqs = yaml.safe_load(f)
                 if loaded_reqs is None:

--- a/scripts/requirements-extra.txt
+++ b/scripts/requirements-extra.txt
@@ -2,3 +2,4 @@ pygit2>=1.6.1
 editdistance>=0.5.0
 PyGithub
 zcbor>=0.4.0
+yamllint

--- a/subsys/partition_manager/pm.yml.libmodem
+++ b/subsys/partition_manager/pm.yml.libmodem
@@ -1,7 +1,8 @@
 #include <autoconf.h>
 
 nrf_modem_lib_sram:
-  span: [nrf_modem_lib_ctrl, nrf_modem_lib_tx, nrf_modem_lib_rx, nrf_modem_lib_trace]
+  span: [nrf_modem_lib_ctrl, nrf_modem_lib_tx, nrf_modem_lib_rx,
+         nrf_modem_lib_trace]
 
 nrf_modem_lib_ctrl:
   placement: {after: [tfm_sram, spm_sram, start]}


### PR DESCRIPTION
Calling yamllint on all Yaml input files to Partition Manager
Added yamllint to requirements-extra.txt
Fixed long line in pm.yml.libmodem

ref: NCSDK-7398

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>