### PR TITLE
doc: peripheral_uart: add info about async_adapter

### DIFF
--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -80,11 +80,17 @@ USB CDC ACM extension
 =====================
 
 For the boards with the USB device peripheral, you can build the sample with support for the USB CDC ACM class serial port instead of the physical UART.
-This build uses the UART async adapter module that acts as a bridge between the USB CDC ACM and the default sample configuration.
-The USB CDC ACM provides only the interrupt interface and the default sample configuration uses the UART async API.
+This build uses the sample-specific UART async adapter module that acts as a bridge between USB CDC ACM and Zephyr's UART asynchronous API used by the sample.
+See :ref:`peripheral_uart_sample_activating_variants` for details about how to build the sample with this extension using the :file:`prj_cdc.conf`.
 
-For more information about the adapter, see the :file:`uart_async_adapter` source files available in the :file:`peripheral_uart/src` directory.
-See :ref:`peripheral_uart_sample_activating_variants` for details about how to build the sample with this extension.
+Async adapter experimental module
+   The default sample configuration uses the UART async API.
+   The UART async adapter creates and initializes an instance of the async module.
+   This is needed because the USB CDC ACM implementation provides only the interrupt interface.
+   The adapter uses data provided in the :c:struct:`uart_async_adapter_data` to connect to the UART device that does not use the asynchronous interface.
+
+   The module requires the :kconfig:option:`CONFIG_BT_NUS_UART_ASYNC_ADAPTER` to be set to ``y``.
+   For more information about the adapter, see the :file:`uart_async_adapter` source files available in the :file:`peripheral_uart/src` directory.
 
 User interface
 **************
@@ -134,7 +140,8 @@ Activating sample extensions
 To activate the optional extensions supported by this sample, modify :makevar:`OVERLAY_CONFIG` in the following manner:
 
 * For the minimal build variant, set :file:`prj_minimal.conf`.
-* For the USB CDC ACM extension, set :file:`prj_cdc.conf`. Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to :file:`usb.overlay`.
+* For the USB CDC ACM extension, set :file:`prj_cdc.conf`.
+  Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to :file:`usb.overlay`.
 
 See :ref:`cmake_options` for instructions on how to add this option.
 For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
@@ -172,6 +179,10 @@ After programming the sample to your development kit, complete the following ste
 
 Dependencies
 ************
+
+This sample uses the following sample-specific library:
+
+* :file:`uart_async_adapter` at :file:`peripheral_uart/src`
 
 This sample uses the following |NCS| libraries:
 


### PR DESCRIPTION
Added more info about the sample's custom module.
NCSDK-11562.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>