### PR TITLE
boards: arm: thingy91: Fix ADP5360 configuration when TF-M is used

### DIFF
--- a/boards/arm/thingy91_nrf9160/CMakeLists.txt
+++ b/boards/arm/thingy91_nrf9160/CMakeLists.txt
@@ -6,12 +6,19 @@
 
 if(CONFIG_BOARD_THINGY91_NRF9160 AND NOT DEFINED CONFIG_MCUBOOT)
 	zephyr_library()
-	zephyr_library_sources(board_secure.c)
+	zephyr_library_sources(adp5360_init.c)
 endif()
 
 if(CONFIG_BOARD_THINGY91_NRF9160_NS)
 	zephyr_library()
 	zephyr_library_sources(board_nonsecure.c)
+
+	# If TF-M is used, the ADP5360 configuration must be done in non-secure
+	# as we can't instruct TF-M to run it.
+	# If SPM is used instead, it will run the ADP5360 configuration in secure.
+	if(CONFIG_BUILD_WITH_TFM)
+		zephyr_library_sources(adp5360_init.c)
+	endif()
 
 	# Use static partition layout to ensure the partition layout remains
 	# unchanged after DFU. This needs to be made globally available

--- a/boards/arm/thingy91_nrf9160/Kconfig
+++ b/boards/arm/thingy91_nrf9160/Kconfig
@@ -4,6 +4,19 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
+if BOARD_THINGY91_NRF9160 || BOARD_THINGY91_NRF9160_NS
+
+config BOARD_INIT_PRIORITY
+	int "Initialization priority for board configuration"
+	default 80
+	help
+	  The Thingy:91 board contains an ADP5360 PMIC that needs to be configured to
+	  set up the power domains on the board correctly. This happens during sys_init,
+	  and the PMIC setup must happen before the sensors are initialized in order
+	  to power them up in time.
+
+endif # BOARD_THINGY91_NRF9160 || BOARD_THINGY91_NRF9160_NS
+
 module=BOARD
 module-dep=LOG
 module-str=Log level for board

--- a/boards/arm/thingy91_nrf9160/adp5360_init.c
+++ b/boards/arm/thingy91_nrf9160/adp5360_init.c
@@ -13,6 +13,13 @@ LOG_MODULE_REGISTER(board_secure, CONFIG_BOARD_LOG_LEVEL);
 #define ADP536X_I2C_DEV_NAME	DT_LABEL(DT_NODELABEL(i2c2))
 #define LC_MAX_READ_LENGTH	128
 
+/* The BH1749 on must be powered by the ADP5360 before it can be initialized. */
+#if IS_ENABLED(CONFIG_BH1749)
+BUILD_ASSERT(CONFIG_BOARD_INIT_PRIORITY < CONFIG_SENSOR_INIT_PRIORITY,
+	     "The board initialization must happen before the sensor initialization "
+	     "for the sensors to be powered before initializing");
+#endif
+
 static int power_mgmt_init(void)
 {
 	int err;
@@ -94,4 +101,4 @@ static int thingy91_board_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(thingy91_board_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+SYS_INIT(thingy91_board_init, POST_KERNEL, CONFIG_BOARD_INIT_PRIORITY);


### PR DESCRIPTION
Fixes an issue where the code configuring ADP5360 on Thingy:91
is not run if TF-M is enabled.
The PMIC will now be configured in non-secure if TF-M is used.

Fixes CIA-637