### PR TITLE
samples: matter: fix DFU over SMP on nRF53

### DIFF
--- a/samples/matter/common/src/dfu_over_smp.h
+++ b/samples/matter/common/src/dfu_over_smp.h
@@ -24,12 +24,15 @@ private:
 	friend DFUOverSMP &GetDFUOverSMP(void);
 
 	static int UploadConfirmHandler(uint32_t offset, uint32_t size, void *arg);
+	static void OnBleConnect(bt_conn *conn, uint8_t err);
 	static void OnBleDisconnect(bt_conn *conn, uint8_t reason);
 	static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent *event, intptr_t arg);
 
 	bool mIsEnabled;
 	bool mIsAdvertisingEnabled;
 	bt_conn_cb mBleConnCallbacks;
+	k_work mFlashSleepWork;
+	k_work mFlashWakeUpWork;
 	DFUOverSMPRestartAdvertisingHandler restartAdvertisingCallback;
 
 	static DFUOverSMP sDFUOverSMP;


### PR DESCRIPTION
When a Matter sample is built for nRF53 with PM_DEVICE
enabled, the QSPI NOR flash must be explicitly woken
up and put into sleep when necessary to reduce the power
consumption.

The existing solution based on
img_mgmt_register_callbacks() callbacks does not work
properly with mcumgr commands since the existing callbacks
do not cover all situations in which access to the QSPI NOR
flash is needed.

Instead, use BLE connect/disconnect callbacks to control
the QSPI NOR power mode.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>