### PR TITLE
samples: matter: Fixed starting BLE advertising for SMP

### DIFF
--- a/samples/matter/common/src/dfu_over_smp.cpp
+++ b/samples/matter/common/src/dfu_over_smp.cpp
@@ -162,7 +162,7 @@ void DFUOverSMP::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg 
 				sDFUOverSMP.restartAdvertisingCallback();
 		}
 		break;
-	case DeviceEventType::kCommissioningComplete:
+	case DeviceEventType::kCHIPoBLEConnectionClosed:
 		/* Check if after closing CHIPoBLE connection advertising is working, if no start SMP advertising. */
 		if (!ConnectivityMgr().IsBLEAdvertisingEnabled()) {
 			sDFUOverSMP.restartAdvertisingCallback();


### PR DESCRIPTION
There is a bug that BLE advertising for DFU over SMP is not
started after commissioning the device to Matter network.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>