### PR TITLE
applications: asset_tracker_v2: Fix BSEC ABI settings

### DIFF
--- a/applications/asset_tracker_v2/src/ext_sensors/CMakeLists.txt
+++ b/applications/asset_tracker_v2/src/ext_sensors/CMakeLists.txt
@@ -10,7 +10,12 @@ target_sources_ifdef(CONFIG_EXTERNAL_SENSORS app PRIVATE ${CMAKE_CURRENT_SOURCE_
 if (CONFIG_EXTERNAL_SENSORS_BME680_BSEC)
         target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ext_sensors_bsec.c)
         set(bsec_dir ${CONFIG_EXTERNAL_SENSORS_BME680_BSEC_PATH})
-        set(BSEC_LIB_DIR ${bsec_dir}/algo/normal_version/bin/gcc/Cortex_M33F)
+        if (CONFIG_FP_SOFTABI)
+                set(BSEC_LIB_DIR ${bsec_dir}/algo/normal_version/bin/gcc/Cortex_M33)
+        endif()
+        if (CONFIG_FP_HARDABI)
+                set(BSEC_LIB_DIR ${bsec_dir}/algo/normal_version/bin/gcc/Cortex_M33F)
+        endif()
 
         if(NOT EXISTS "${BSEC_LIB_DIR}/libalgobsec.a")
                 assert(0 "Could not find BSEC library. Minimum version is 1.4.8.0_Generic_Release")

--- a/applications/asset_tracker_v2/src/ext_sensors/ext_sensors_bsec.c
+++ b/applications/asset_tracker_v2/src/ext_sensors/ext_sensors_bsec.c
@@ -18,8 +18,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ext_sensors_bsec, CONFIG_EXTERNAL_SENSORS_LOG_LEVEL);
 
-BUILD_ASSERT(CONFIG_FP_HARDABI, "CONFIG_FP_HARDABI must be set when using the BME680 BSEC library");
-
 /* Sample rate for the BSEC library
  *
  * BSEC_SAMPLE_RATE_ULP = 0.0033333 Hz = 300 second interval


### PR DESCRIPTION
Select correct bsec library based on used ABI.

Signed-off-by: Jorgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>