### PR TITLE
doc: extensions: sml error -> warning

### DIFF
--- a/doc/_extensions/software_maturity_table.py
+++ b/doc/_extensions/software_maturity_table.py
@@ -68,7 +68,7 @@ class SoftwareMaturityTable(SphinxDirective):
         table_info = self.env.sml_table
 
         if table_type != "top_level" and table_type not in table_info["features"]:
-            logger.error(f"No information present for requested feature '{table_type}'")
+            logger.info(f"No information present for requested feature '{table_type}'")
             return []
 
         all_socs = table_info["all_socs"]

--- a/doc/nrf/software_maturity.rst
+++ b/doc/nrf/software_maturity.rst
@@ -76,3 +76,9 @@ Matter feature support
 The matter features are still experimental for now:
 
 .. sml-table:: matter
+
+Non-existing feature support
+****************************
+The table below should not be displayed:
+
+.. sml-table:: non_existing


### PR DESCRIPTION
Prevent build failure when adding a table for a feature that is
not present in the online cache yet. This allows changes to be
made in both software_maturity_features.yaml and
software_maturity.rst in the same commit.

Signed-off-by: Gaute Svanes Lunde <gaute.lunde@nordicsemi.no>