### PR TITLE
lib: nrf_modem_os: Use IRQ_PRIO_LOWEST instead of hard-coded 6

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -24,9 +24,13 @@
 
 #define UNUSED_FLAGS 0
 
-/* Handle modem traces from IRQ context with lower priority. */
+/* Handle communication with application and modem traces from IRQ contexts
+ * with the lowest available priority.
+ */
+#define APPLICATION_IRQ EGU1_IRQn
+#define APPLICATION_IRQ_PRIORITY IRQ_PRIO_LOWEST
 #define TRACE_IRQ EGU2_IRQn
-#define TRACE_IRQ_PRIORITY 6
+#define TRACE_IRQ_PRIORITY IRQ_PRIO_LOWEST
 
 #define THREAD_MONITOR_ENTRIES 10
 
@@ -293,12 +297,12 @@ unsigned int nrf_modem_os_sem_count_get(void *sem)
 
 void nrf_modem_os_application_irq_set(void)
 {
-	NVIC_SetPendingIRQ(NRF_MODEM_APPLICATION_IRQ);
+	NVIC_SetPendingIRQ(APPLICATION_IRQ);
 }
 
 void nrf_modem_os_application_irq_clear(void)
 {
-	NVIC_ClearPendingIRQ(NRF_MODEM_APPLICATION_IRQ);
+	NVIC_ClearPendingIRQ(APPLICATION_IRQ);
 }
 
 void nrf_modem_os_trace_irq_set(void)
@@ -364,10 +368,9 @@ void trace_irq_init(void)
 
 void read_task_create(void)
 {
-	IRQ_DIRECT_CONNECT(NRF_MODEM_APPLICATION_IRQ,
-			   NRF_MODEM_APPLICATION_IRQ_PRIORITY,
+	IRQ_DIRECT_CONNECT(APPLICATION_IRQ, APPLICATION_IRQ_PRIORITY,
 			   rpc_proxy_irq_handler, UNUSED_FLAGS);
-	irq_enable(NRF_MODEM_APPLICATION_IRQ);
+	irq_enable(APPLICATION_IRQ);
 }
 
 void *nrf_modem_os_alloc(size_t bytes)


### PR DESCRIPTION
Use the lowest priority available in a given Zephyr configuration
instead of a hard-coded value of 6 (defined as `TRACE_IRQ_PRIORITY`
in `nrf_modem_os.c` and as `NRF_MODEM_APPLICATION_IRQ_PRIORITY` in
nrfxlib), as the latter is invalid for `CONFIG_ZERO_LATENCY_IRQS=y`.

For consistency with the IRQ used for modem traces, use also a local
definition of the IRQ number for application communication instead
of using `NRF_MODEM_APPLICATION_IRQ` from nrfxlib.

This solves a problem reported for example here: https://devzone.nordicsemi.com/f/nordic-q-a/87533/regression-in-irq_direct_connect-behavior-from-ncs-1-7-to-1-9-1.