### PR TITLE
manifest: Update sdk-zephyr SHA to fix release notes for mcumgr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: dd316f35a15eba0cef07f3fc6cd2cd5b47218aae
+      revision: af4d2d0bdfc1f47f06201522eced43dd97f6928d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The commit moves sdk-zephyr SHA to include release notes for mcumgr.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>