### PR TITLE
tests: lib: at_sms_cert: Add debug information on CI connection issue

### DIFF
--- a/lib/modem_antenna/modem_antenna.c
+++ b/lib/modem_antenna/modem_antenna.c
@@ -15,21 +15,25 @@ NRF_MODEM_LIB_ON_INIT(gnss_cfg_init_hook, on_modem_lib_init, NULL);
 
 static void on_modem_lib_init(int ret, void *ctx)
 {
+	int err;
+
 	if (ret != 0) {
 		return;
 	}
 
 	if (strlen(CONFIG_MODEM_ANTENNA_AT_MAGPIO) > 0) {
 		LOG_DBG("Setting MAGPIO configuration: %s", CONFIG_MODEM_ANTENNA_AT_MAGPIO);
-		if (nrf_modem_at_printf("%s", CONFIG_MODEM_ANTENNA_AT_MAGPIO) != 0) {
-			LOG_ERR("Failed to set MAGPIO configuration");
+		err = nrf_modem_at_printf("%s", CONFIG_MODEM_ANTENNA_AT_MAGPIO);
+		if (err) {
+			LOG_ERR("Failed to set MAGPIO configuration (err: %d)", err);
 		}
 	}
 
 	if (strlen(CONFIG_MODEM_ANTENNA_AT_COEX0) > 0) {
 		LOG_DBG("Setting COEX0 configuration: %s", CONFIG_MODEM_ANTENNA_AT_COEX0);
-		if (nrf_modem_at_printf("%s", CONFIG_MODEM_ANTENNA_AT_COEX0) != 0) {
-			LOG_ERR("Failed to set COEX0 configuration");
+		err = nrf_modem_at_printf("%s", CONFIG_MODEM_ANTENNA_AT_COEX0);
+		if (err) {
+			LOG_ERR("Failed to set COEX0 configuration (err: %d)", err);
 		}
 	}
 }


### PR DESCRIPTION
* Add debug information to AT SMS Cert tests.
* Add debugging information on nrf_modem_at_printf if MAGPIO or COEX
  AT commands fails.