### PR TITLE
tfm: Fix TF-M size alignment requirement on nrf91 with mcuboot enabled

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -105,6 +105,7 @@
   - "include/tfm/**/*"
   - "modules/nrfxlib/**/*"
   - "modules/tfm/**/*"
+  - "modules/trusted-firmware-m/**/*"
   - "samples/tfm/**/*"
   - "subsys/bootloader/**/*"
   - "subsys/partition_manager/**/*"

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -103,6 +103,7 @@ config PM_PARTITION_SIZE_TFM
 	hex
 	prompt  "Memory reserved for TFM" if !TFM_PROFILE_TYPE_MINIMAL
 	default 0x10000 if TFM_PROFILE_TYPE_MINIMAL && TFM_CMAKE_BUILD_TYPE_DEBUG
+	default 0xC000 if TFM_PROFILE_TYPE_MINIMAL && SOC_NRF9160 && BOOTLOADER_MCUBOOT && !SECURE_BOOT
 	default 0x8000 if TFM_PROFILE_TYPE_MINIMAL
 	# NCSDK-13503: Temporarily bump size while regressions are being fixed
 	default 0x60000 if TFM_REGRESSION_S


### PR DESCRIPTION
Fix TF-M size alignment requirement on nrf9160 with MCUboot enabled.
The TF-M veneers needs to be located at the end of a 32 KB boundary
on nrf9160.
Since the bootloader default size is 48 KB having then TF-M needs to be
48 KB in order for the combined size to meet this requirement.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>