### PR TITLE
boards: arm: thingy91_nrf9160: Use SPM instad of TF-M

### DIFF
--- a/boards/arm/thingy91_nrf9160/Kconfig.defconfig
+++ b/boards/arm/thingy91_nrf9160/Kconfig.defconfig
@@ -9,11 +9,6 @@ if BOARD_THINGY91_NRF9160 || BOARD_THINGY91_NRF9160_NS
 config BOARD
 	default "thingy91_nrf9160"
 
-# By default, if we build for a Non-Secure version of the board,
-# enable building with TF-M as the Secure Execution Environment.
-config BUILD_WITH_TFM
-	default y if BOARD_THINGY91_NRF9160_NS
-
 if BUILD_WITH_TFM
 
 # By default, if we build with TF-M, instruct build system to


### PR DESCRIPTION
Use SPM instead of TF-M to be backwards-compatible with
MCUboot from NCS v1.9.1 and earlier.
SPM must be used because earlier MCUboot versions by default
leaves the CPU in a state where TF-M cannot run properly and
the application will not boot.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>