### PR TITLE
Add hex datamode (AT#XSENDB and AT#XRECVB) to serial_lte_modem commands

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -377,6 +377,8 @@ int handle_at_listen(enum at_cmd_type cmd_type);
 int handle_at_accept(enum at_cmd_type cmd_type);
 int handle_at_send(enum at_cmd_type cmd_type);
 int handle_at_recv(enum at_cmd_type cmd_type);
+int handle_at_sendb(enum at_cmd_type cmd_type);
+int handle_at_recvb(enum at_cmd_type cmd_type);
 int handle_at_sendto(enum at_cmd_type cmd_type);
 int handle_at_recvfrom(enum at_cmd_type cmd_type);
 int handle_at_poll(enum at_cmd_type cmd_type);
@@ -474,6 +476,8 @@ static struct slm_at_cmd {
 	{"AT#XACCEPT", handle_at_accept},
 	{"AT#XSEND", handle_at_send},
 	{"AT#XRECV", handle_at_recv},
+	{"AT#XSENDB", handle_at_sendb},
+	{"AT#XRECVB", handle_at_recvb},
 	{"AT#XSENDTO", handle_at_sendto},
 	{"AT#XRECVFROM", handle_at_recvfrom},
 	{"AT#XPOLL", handle_at_poll},


### PR DESCRIPTION
In version 1.7.1 the serial_lte_modem command was changed slightly and removed the option to send data in either ASCII or in HEX, this functionality is useful in some cases when sending binary data through the TCP connection.
The effected commands are:
AT#XSEND
AT#XRECV

In version 1.6.1 a parameter allowed to specify either ASCII or HEX as the data type, that option was removed with version 1.7.1.

Proposing to put the functionality back in without breaking the new AT#XSEND and AT#XRECV commands by adding the following new commands for hex data:
AT#XSENDB
AT#XRECVB

There are new methods to set the modem into a binary data mode, but I had not been successful in implementing those correctly.  An Arduino wrapper, TinyGSM, to which I have added nRF9160 serial_lte_modem support relies on the ability to send and receive HEX data when not sending standard ASCII.

It would be nice to have these commands merged into upstream, or some form of being able to use HEX data with AT#XSEND and AT#XRECV as was possible in version 1.6.1.