### PR TITLE
doc: update theme

### DIFF
--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -36,7 +36,7 @@ html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
 
-html_theme_options = {"docsets": utils.ALL_DOCSETS}
+html_theme_options = {"docset": "kconfig", "docsets": utils.ALL_DOCSETS}
 
 # Options for ncs_cache --------------------------------------------------------
 

--- a/doc/matter/conf.py
+++ b/doc/matter/conf.py
@@ -35,7 +35,7 @@ html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
 
-html_theme_options = {"docsets": utils.ALL_DOCSETS}
+html_theme_options = {"docset": "matter", "docsets": utils.ALL_DOCSETS}
 
 # Options for external_content -------------------------------------------------
 

--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -43,7 +43,7 @@ html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
 
-html_theme_options = {"docsets": utils.ALL_DOCSETS}
+html_theme_options = {"docset": "mcuboot", "docsets": utils.ALL_DOCSETS}
 
 # Options for intersphinx ------------------------------------------------------
 

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -76,7 +76,7 @@ html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
 
-html_theme_options = {"docsets": utils.ALL_DOCSETS}
+html_theme_options = {"docset": "nrf", "docsets": utils.ALL_DOCSETS}
 
 # Options for intersphinx ------------------------------------------------------
 

--- a/doc/nrfx/conf.py
+++ b/doc/nrfx/conf.py
@@ -31,7 +31,7 @@ extensions.extend(["ncs_cache", "zephyr.external_content", "zephyr.doxyrunner"])
 # Options for HTML output ------------------------------------------------------
 
 html_static_path.append(str(NRF_BASE / "doc" / "_static"))
-html_theme_options = {"docsets": utils.ALL_DOCSETS}
+html_theme_options = {"docset": "nrfx", "docsets": utils.ALL_DOCSETS}
 
 # -- Options for doxyrunner ----------------------------------------------------
 

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -53,7 +53,7 @@ html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
 
-html_theme_options = {"docsets": utils.ALL_DOCSETS}
+html_theme_options = {"docset": "nrfxlib", "docsets": utils.ALL_DOCSETS}
 
 # Options for intersphinx ------------------------------------------------------
 

--- a/doc/tfm/conf.py
+++ b/doc/tfm/conf.py
@@ -48,7 +48,7 @@ html_show_sourcelink = True
 html_show_sphinx = False
 html_show_copyright = False
 
-html_theme_options = {"docsets": utils.ALL_DOCSETS}
+html_theme_options = {"docset": "tfm", "docsets": utils.ALL_DOCSETS}
 
 # Options for autosectionlabel -------------------------------------------------
 

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -49,7 +49,7 @@ html_context = {
     "is_release": is_release,
 }
 
-html_theme_options = {"docsets": utils.ALL_DOCSETS}
+html_theme_options = {"docset": "zephyr", "docsets": utils.ALL_DOCSETS}
 
 # Options for intersphinx ------------------------------------------------------
 

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,7 +1,7 @@
 recommonmark==0.6.0
 CommonMark>=0.9.1
 sphinxcontrib-mscgen>=0.6
-sphinx-ncs-theme>=1.0
+sphinx-ncs-theme>=1.0.3,<1.1
 m2r2
 sphinxcontrib-plantuml
 pygit2


### PR DESCRIPTION
Update to the latest theme version, 1.0.3.

Fixes:
- Some scrolling/toc navigation should now be fixed
- Active docset is now highlighted