### PR TITLE
LwM2M carrier library v0.30.0 corrections

### DIFF
--- a/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst
@@ -27,10 +27,10 @@ See :ref:`lwm2m_lib_size` for an explanation of the library size in different sc
 +-------------------------+---------------+------------+
 |                         | Flash (Bytes) | RAM (Bytes)|
 +-------------------------+---------------+------------+
-| Library size            | 71566         | 15739      |
+| Library size            | 71582         | 15844      |
 | (binary)                |               |            |
 +-------------------------+---------------+------------+
-| Library size            | 93860         | 38720      |
+| Library size            | 93876         | 38824      |
 | (reference application) |               |            |
 +-------------------------+---------------+------------+
 

--- a/samples/nrf9160/lwm2m_carrier/README.rst
+++ b/samples/nrf9160/lwm2m_carrier/README.rst
@@ -16,14 +16,15 @@ The sample supports the following development kit:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/spm.txt
+The sample is configured to compile and run as a non-secure application on nRF91's Cortex-M33.
+Therefore, it automatically includes the :ref:`secure_partition_manager` that prepares the required peripherals to be available for the application.
 
 Building and running
 ********************
 
 .. |sample path| replace:: :file:`samples/nrf9160/lwm2m_carrier`
 
-.. include:: /includes/build_and_run_ns.txt
+.. include:: /includes/build_and_run.txt
 
 Testing
 =======

--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -247,6 +247,10 @@ void link_init(void)
 
 	lte_lc_register_handler(link_ind_handler);
 
+	if (link_sett_is_dnsaddr_enabled()) {
+		(void)link_setdnsaddr(link_sett_dnsaddr_ip_get());
+	}
+
 	if (link_sett_is_normal_mode_autoconn_enabled() == true) {
 		link_func_mode_set(LTE_LC_FUNC_MODE_NORMAL,
 				   link_sett_is_normal_mode_autoconn_rel14_used());


### PR DESCRIPTION
* Restored a function call in modem shell sample that was removed during a rebase.
* Corrected the library size estimate for v0.30.0
* TF-M is not supported in lwM2M carrier sample. Documentation has been updated to reflect this.