### PR TITLE
manifest: update mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -100,7 +100,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 129b6312d61a9dc2c3b0c8810326678cdbd27b80
+      revision: pull/204/head
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Bring two upstream fixes for fix building with
the image encryption enabled.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>