### PR TITLE
samples: nrf9160: modem_shell: disable iPerf3 in app FOTA overlay

### DIFF
--- a/samples/nrf9160/modem_shell/overlay-app_fota.conf
+++ b/samples/nrf9160/modem_shell/overlay-app_fota.conf
@@ -5,6 +5,7 @@
 #
 
 # Some of the MoSh features need to be switched off to free enough flash
+CONFIG_MOSH_IPERF3=n
 CONFIG_MOSH_CURL=n
 CONFIG_MOSH_REST=n
 CONFIG_MOSH_WORKER_THREADS=n


### PR DESCRIPTION
Disabled iPerf3 support in application FOTA overlay, because otherwise the image is too big and application FOTA fails.

Fixes MOSH-292.