### PR TITLE
thingy91: Adding missing documentation

### DIFF
--- a/samples/bluetooth/hci_lpuart/README.rst
+++ b/samples/bluetooth/hci_lpuart/README.rst
@@ -21,6 +21,10 @@ Overview
 
 The sample implements the Bluetooth® HCI controller using the :ref:`uart_nrf_sw_lpuart` for UART communication.
 
+This sample is also supported on the Thingy:91.
+However, it must be programmed using a debugger and a 10-pin SWD cable.
+Firmware updates over serial using MCUboot are not supported for either of the MCUs on the Thingy:91 in this configuration.
+
 Building and running
 ********************
 

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -35,6 +35,10 @@ When the connection is established, it starts collecting data from two sensors:
 The sample aggregates the data from both sensors in memory.
 You can then trigger an alarm that sends the aggregated data over LTE to `nRF Cloud`_ by flipping the Thingy:52, which causes a change in the flip state to ``UPSIDE_DOWN``.
 
+This sample is also supported on the Thingy:91.
+However, it must be programmed using a debugger and a 10-pin SWD cable.
+Serial communication and firmware updates over serial using MCUboot are not supported in this configuration.
+
 Configuration
 *************
 


### PR DESCRIPTION
This commit adds documentation that should have been included with
[PR-5785](https://github.com/nrfconnect/sdk-nrf/pull/5785).

Signed-off-by: Carl Richard Steen Fosse <carl.fosse@nordicsemi.no>