### PR TITLE
flash_patch: Add support for nRF52833

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -220,7 +220,10 @@ Libraries for NFC
 Other libraries
 ---------------
 
-|no_changes_yet_note|
+  * Flash Patch:
+
+    * Allow the :kconfig:option:`CONFIG_DISABLE_FLASH_PATCH` Kconfig option to be used on the nRF52833 SoC.
+
 
 Common Application Framework (CAF)
 ----------------------------------

--- a/lib/flash_patch/CMakeLists.txt
+++ b/lib/flash_patch/CMakeLists.txt
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if((NOT CONFIG_DISABLE_FLASH_PATCH) AND CONFIG_SOC_NRF52840
-    AND (CONFIG_IS_SECURE_BOOTLOADER OR CONFIG_MCUBOOT))
+if(CONFIG_FLASH_PATCH_WARN)
   message(WARNING "
       ----------------------------------------------------------
       --- WARNING: To maintain the integrity of secure boot, ---

--- a/lib/flash_patch/Kconfig
+++ b/lib/flash_patch/Kconfig
@@ -6,9 +6,17 @@
 
 config DISABLE_FLASH_PATCH
 	bool "Disable Cortex-M4 Flash Patch capabilities"
-	depends on SOC_NRF52840
+	depends on SOC_NRF52840 || SOC_NRF52833
 	depends on REBOOT
 	help
+	  This disables the Flash Patch and Breakpoint (FPB) unit.
 	  The flash patch can be used by malicious code to circumvent secure
-	  boot checks. Note that disabling flash patching also disables
+	  boot checks. Note that disabling the FPB also disables
 	  breakpoints.
+
+config FLASH_PATCH_WARN
+	bool
+	depends on SOC_NRF52840 || SOC_NRF52833
+	depends on !DISABLE_FLASH_PATCH
+	depends on IS_SECURE_BOOTLOADER || MCUBOOT
+	default y

--- a/tests/drivers/flash_patch/testcase.yaml
+++ b/tests/drivers/flash_patch/testcase.yaml
@@ -1,12 +1,14 @@
 tests:
   flash_patch.flash_patch_off:
-    platform_allow: nrf52840dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     integration_platforms:
       - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
     tags: flash_patch
     extra_args: CONFIG_DISABLE_FLASH_PATCH=n
   flash_patch.flash_patch_on:
-    platform_allow: nrf52840dk_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833
     integration_platforms:
       - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
     tags: flash_patch


### PR DESCRIPTION
The nRF52833, like the nRF52840, supports disabling flash patch via
UICR.

Add it as a dependency for the Kconfig, and print the Cmake warning
when using nRF52833 with the bootloader.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>