### PR TITLE
manifest: nrf_modem: version 2.0.1+b1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -109,7 +109,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 5b9d987b485b57c22523bcb1ae8d2b082cb785a5
+      revision: 0daeb739910e52be27815f7ad64c81e13e135df9
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update manifest for nrf_modem v2.0.1+b1 release.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>