### PR TITLE
samples: Changes name of testcase

### DIFF
--- a/samples/nrf9160/ciphersuites/sample.yaml
+++ b/samples/nrf9160/ciphersuites/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: TLS Ciphersuites sample
 tests:
-  samples.nrf9160.ciphersuites:
+  sample.nrf9160.ciphersuites:
     build_only: true
     platform_allow: nrf9160dk_nrf9160_ns
     integration_platforms:


### PR DESCRIPTION
Name of testcase `samples.nrf9160.ciphersuites` starts with `samples` instead of `sample`.
This change renames this testcase.

Signed-off-by: Katarzyna Giadla <katarzyna.giadla@nordicsemi.no>