### PR TITLE
samples: Change duplicated name of testcase

### DIFF
--- a/samples/nrf5340/remote_shell/sample.yaml
+++ b/samples/nrf5340/remote_shell/sample.yaml
@@ -2,13 +2,13 @@ sample:
   description: Remote shell sample based on IPC service shell backend.
   name: Remote IPC shell sample
 tests:
-  sample.nrf5340.empty_app_core.build:
+  sample.nrf5340.remote_ipc_shell.empty_app_core.build:
     build_only: true
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build
-  sample.nrf5340.remote_shell.uart.build:
+  sample.nrf5340.remote_ipc_shell.uart.build:
     build_only: true
     extra_args: CONF_FILE=prj_uart.conf
     integration_platforms:


### PR DESCRIPTION
Name of the testcase `sample.nrf5340.empty_app_core.build` is
duplicated in another files.
This change rename duplicated testcase.

Signed-off-by: Katarzyna Giadla <katarzyna.giadla@nordicsemi.no>