### PR TITLE
bluetooth: services: fast_pair: add new storage api for finding a key

### DIFF
--- a/subsys/bluetooth/services/fast_pair/fp_storage.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage.c
@@ -111,7 +111,7 @@ static int fp_settings_set(const char *name, size_t len, settings_read_cb read_c
 			return -EINVAL;
 		}
 
-		memcpy(&account_key_list[index], data.account_key, sizeof(data.account_key));
+		memcpy(account_key_list[index], data.account_key, sizeof(data.account_key));
 		account_key_loaded_ids[index] = data.account_key_id;
 
 		return 0;
@@ -252,7 +252,7 @@ int fp_storage_account_key_save(const uint8_t *account_key)
 	int err;
 
 	for (size_t i = 0; i < account_key_count; i++) {
-		if (!memcmp(account_key, &account_key_list[i], FP_CRYPTO_ACCOUNT_KEY_LEN)) {
+		if (!memcmp(account_key, account_key_list[i], FP_CRYPTO_ACCOUNT_KEY_LEN)) {
 			LOG_INF("Account Key already saved - skipping.");
 			return 0;
 		}
@@ -277,7 +277,7 @@ int fp_storage_account_key_save(const uint8_t *account_key)
 		return err;
 	}
 
-	memcpy(&account_key_list[index], account_key, FP_CRYPTO_ACCOUNT_KEY_LEN);
+	memcpy(account_key_list[index], account_key, FP_CRYPTO_ACCOUNT_KEY_LEN);
 
 	account_key_next_id = next_key_id(account_key_next_id);
 

--- a/subsys/bluetooth/services/fast_pair/fp_storage.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage.c
@@ -239,6 +239,33 @@ int fp_storage_account_keys_get(uint8_t buf[][FP_CRYPTO_ACCOUNT_KEY_LEN], size_t
 	return 0;
 }
 
+int fp_storage_account_key_find(uint8_t account_key[FP_CRYPTO_ACCOUNT_KEY_LEN],
+				fp_storage_account_key_check_cb account_key_check_cb,
+				void *context)
+{
+	if (!atomic_get(&settings_loaded)) {
+		return -ENODATA;
+	}
+
+	if (!account_key_check_cb) {
+		return -EINVAL;
+	}
+
+	for (size_t i = 0; i < account_key_count; i++) {
+		if (account_key_check_cb(account_key_list[i], context)) {
+			if (account_key) {
+				memcpy(account_key,
+				       account_key_list[i],
+				       FP_CRYPTO_ACCOUNT_KEY_LEN);
+			}
+
+			return 0;
+		}
+	}
+
+	return -ESRCH;
+}
+
 int fp_storage_account_key_save(const uint8_t *account_key)
 {
 	if (!atomic_get(&settings_loaded)) {

--- a/subsys/bluetooth/services/fast_pair/include/fp_storage.h
+++ b/subsys/bluetooth/services/fast_pair/include/fp_storage.h
@@ -21,6 +21,19 @@ extern "C" {
 #include <sys/types.h>
 #include "fp_crypto.h"
 
+/**
+ * @typedef fp_storage_account_key_check_cb
+ * @brief Callback used to check if a given Account Key satisfies user-defined
+ *        conditions.
+ *
+ * @param[in] account_key 128-bit (16-byte) Account Key to be checked.
+ * @param[in] context     Pointer used to pass operation context.
+ *
+ * @return True if Account Key satisfies user-defined conditions.
+ *         False otherwise.
+ */
+typedef bool (*fp_storage_account_key_check_cb)(const uint8_t *account_key, void *context);
+
 /** Save Account Key.
  *
  * @param[in] account_key 128-bit (16-byte) Account Key to be saved.
@@ -49,6 +62,21 @@ int fp_storage_account_key_count(void);
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
 int fp_storage_account_keys_get(uint8_t buf[][FP_CRYPTO_ACCOUNT_KEY_LEN], size_t *key_count);
+
+/** Iterate over stored Account Keys to find a key that matches user-defined conditions.
+ *  If such a key is found, the iteration process stops and this function returns.
+ *
+ * @param[out] account_key Found Account Key. It is possible to pass NULL pointer if the found
+ *                         key value is irrelevant.
+ * @param[in] account_key_check_cb Callback for determining if a given Account Key satisfies
+ *                                 user-defined conditions.
+ * @param[in] context Pointer used to pass operation context.
+ *
+ * @return 0 If the Account Key was found. Otherwise, a (negative) error code is returned.
+ */
+int fp_storage_account_key_find(uint8_t account_key[FP_CRYPTO_ACCOUNT_KEY_LEN],
+				fp_storage_account_key_check_cb account_key_check_cb,
+				void *context);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added a new fp_storage_account_key_find API to the internal header
of the Fast Pair Storage module. This API allows the user to search
for a specific Account Key that satisfies certain conditions. These
conditions are defined via callback function.

The new Fast Pair Storage API is now used in the Keys module.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>