### PR TITLE
manifest: Update sdk-zephyr SHA to bring smp_sample fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v2.7.99-ncs1-1
+      revision: pull/819/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The commit brings in sdk-zephyr SHA with fix for endless loop,
when unsupported command is issued, while having fs command
group enabled.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>