### PR TITLE
net: lib: nrf_cloud: fix duplicate disconnect events

### DIFF
--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -612,6 +612,10 @@ static void cloud_event_handler(const struct nrf_cloud_evt *evt)
 	switch (evt->type) {
 	case NRF_CLOUD_EVT_TRANSPORT_CONNECTING:
 		LOG_DBG("NRF_CLOUD_EVT_TRANSPORT_CONNECTING");
+		if (evt->status != NRF_CLOUD_CONNECT_RES_SUCCESS) {
+			LOG_ERR("Failed to connect to nRF Cloud, status: %d",
+				(enum nrf_cloud_connect_result)evt->status);
+		}
 		break;
 	case NRF_CLOUD_EVT_TRANSPORT_CONNECTED:
 		LOG_INF("NRF_CLOUD_EVT_TRANSPORT_CONNECTED");
@@ -621,7 +625,8 @@ static void cloud_event_handler(const struct nrf_cloud_evt *evt)
 		on_cloud_evt_ready();
 		break;
 	case NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED:
-		LOG_INF("NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED");
+		LOG_INF("NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED: status %d",
+			(enum nrf_cloud_disconnect_status)evt->status);
 		on_cloud_evt_disconnected();
 		break;
 	case NRF_CLOUD_EVT_ERROR:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -200,7 +200,12 @@ Modem libraries
 Libraries for networking
 ------------------------
 
-|no_changes_yet_note|
+* Updated:
+
+  * :ref:`lib_nrf_cloud` library:
+
+    * Fixed:
+      * An issue that caused the application to receive multiple disconnect events.
 
 Libraries for NFC
 -----------------

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -37,7 +37,6 @@ static const fsm_transition idle_fsm_transition[NCT_EVT_TOTAL] = {
 
 static const fsm_transition initialized_fsm_transition[NCT_EVT_TOTAL] = {
 	[NCT_EVT_CONNECTED] = connection_handler,
-	[NCT_EVT_DISCONNECTED] = disconnection_handler,
 };
 
 static const fsm_transition connected_fsm_transition[NCT_EVT_TOTAL] = {


### PR DESCRIPTION
Sometimes duplicate disconnect events are generated.
Remove disconnection_handler from initialized state handler;
device is already disconnected.
Cleanup disconnect event handling in poll thread.
NCSIDB-759