### PR TITLE
manifest: Updated Zephyr revision to pull NVS cache fix.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.0.99-ncs1-rc2
+      revision: 3c8a7f7ad6d2458a3bcc30a22ef62323db87ed56
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The NVS cache size is too small, what results in long application
boot time after significant number of device reboots.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>

Fixes: KRKNWK-13977