### PR TITLE
samples: matter: Fixed issue with reading operational status

### DIFF
--- a/samples/matter/window_covering/src/zcl_callbacks.cpp
+++ b/samples/matter/window_covering/src/zcl_callbacks.cpp
@@ -60,7 +60,10 @@ void MatterWindowCoveringClusterServerAttributeChangedCallback(const app::Concre
 		case Attributes::CurrentPositionTiltPercent100ths::Id:
 			WindowCovering::Instance().PositionLEDUpdate(WindowCovering::MoveType::TILT);
 			break;
+		default:
+			WindowCovering::Instance().SchedulePostAttributeChange(attributePath.mEndpointId,
+									       attributePath.mAttributeId);
+			break;
 		};
 	}
-	WindowCovering::Instance().SchedulePostAttributeChange(attributePath.mEndpointId, attributePath.mAttributeId);
 }


### PR DESCRIPTION
During closing/opening the window roller shutter in the Window Covering example, an operational status wasn't read correctly. This bug has been fixed.
