### PR TITLE
samples: peripheral: lpuart: Disable uart0

### DIFF
--- a/samples/peripheral/lpuart/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/peripheral/lpuart/boards/nrf9160dk_nrf9160_ns.overlay
@@ -16,7 +16,7 @@
 };
 
 &uart0 {
-	disable-rx;
+	status = "disabled";
 };
 
 &gpiote {


### PR DESCRIPTION
Disable uart0 in the same way as it is disabled in the other overlays.
Enabled uart0 leads to increased current consumption in certain
conditions (power toggling the board).

Ref. NCSDK-15470.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>