### PR TITLE
samples: direct_test_mode: Fix gain setting on nrf5340

### DIFF
--- a/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direct_test_mode/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -3,10 +3,6 @@
 	current-speed = <19200>;
 };
 
-&spi0 {
-	status = "disabled";
-};
-
 &radio {
 	status = "okay";
 	/* This is a number of antennas that are available on antenna matrix


### PR DESCRIPTION
It fixes the gain setting for nRF5340 with nRF21540 EK
shield. After new pin controller was introduced to the
Zephyr all peripherals must have okey status to conigure
pins of them.