### PR TITLE
doc: update TFM instructions for samples that supports thingy:91

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -161,7 +161,7 @@ The application supports the following development kits:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/tfm.txt
+.. include:: /includes/tfm_spm_thingy91.txt
 
 User interface
 **************
@@ -302,7 +302,7 @@ See :ref:`Building with overlays <building_with_overlays>` for information on ho
 
 
 .. |sample path| replace:: :file:`applications/asset_tracker_v2`
-.. include:: /includes/build_and_run_ns.txt
+.. include:: /includes/thingy91_build_and_run.txt
 
 .. external_antenna_note_start
 
@@ -504,6 +504,7 @@ It uses the following `sdk-nrfxlib`_ library:
 
 * :ref:`nrfxlib:nrf_modem`
 
-In addition, it uses the following sample:
+In addition, it uses the following secure firmware components:
 
 * :ref:`secure_partition_manager`
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -25,7 +25,7 @@ The application supports the following development kits:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/tfm.txt
+.. include:: /includes/tfm_spm_thingy91.txt
 
 Configuration
 *************
@@ -307,7 +307,7 @@ Building and running
 
 .. |sample path| replace:: :file:`applications/serial_lte_modem`
 
-.. include:: /includes/build_and_run_ns.txt
+.. include:: /includes/thingy91_build_and_run.txt
 
 .. _slm_connecting_9160dk:
 
@@ -482,6 +482,7 @@ It uses the following `sdk-nrfxlib`_ libraries:
 
 * :ref:`nrfxlib:nrf_modem`
 
-In addition, it uses the following samples:
+In addition, it uses the following secure firmware components:
 
 * :ref:`secure_partition_manager`
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/doc/nrf/includes/tfm_spm_thingy91.txt
+++ b/doc/nrf/includes/tfm_spm_thingy91.txt
@@ -1,0 +1,8 @@
+The sample is configured to compile and run as a non-secure application.
+Therefore, it automatically includes an additional secure firmware component, that prepares the required peripherals and secure services to be available for the application.
+
+When built for the ``nrf9160dk_nrf9160_ns`` build target, the sample automatically includes :ref:`Trusted Firmware-M <ug_tfm>`.
+You can also configure it to use the :ref:`secure_partition_manager` instead of Trusted Firmware-M.
+
+When built for the ``thingy91_nrf9160_ns`` build target, the sample automatically includes the :ref:`secure_partition_manager`.
+You can also configure it to use :ref:`TF-M <ug_tfm>` instead of Secure Partition Manager.

--- a/doc/nrf/includes/thingy91_build_and_run.txt
+++ b/doc/nrf/includes/thingy91_build_and_run.txt
@@ -1,0 +1,9 @@
+This sample can be found under |sample path| in the |NCS| folder structure.
+
+When built as a non-secure firmware image for the ``nrf9160dk_nrf9160_ns`` build target, the sample automatically includes :ref:`Trusted Firmware-M <ug_tfm>` (TF-M).
+You can configure it to use the :ref:`secure_partition_manager` instead of TF-M.
+
+When built as a non-secure firmware image for the ``thingy91_nrf9160_ns`` build target, the sample automatically includes the :ref:`secure_partition_manager`.
+You can configure it to use the :ref:`TF-M <ug_tfm>` instead of Secure Partition Manager.
+
+See :ref:`gs_programming` for information about how to build and program the application.

--- a/samples/nrf9160/aws_iot/README.rst
+++ b/samples/nrf9160/aws_iot/README.rst
@@ -17,7 +17,7 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/tfm.txt
+.. include:: /includes/tfm_spm_thingy91.txt
 
 Overview
 ********
@@ -93,8 +93,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nrf9160/aws_iot`
 
-.. include:: /includes/build_and_run_ns.txt
-
+.. include:: /includes/thingy91_build_and_run.txt
 
 .. note::
 
@@ -181,6 +180,7 @@ It uses the following `sdk-nrfxlib`_ library:
 
 * :ref:`nrfxlib:nrf_modem`
 
-In addition, it uses the following sample:
+In addition, it uses the following secure firmware components:
 
 * :ref:`secure_partition_manager`
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/memfault/README.rst
+++ b/samples/nrf9160/memfault/README.rst
@@ -20,7 +20,7 @@ The sample supports the following development kits:
 
 Before using the Memfault platform, you must register an account in the `Memfault registration page`_ and `create a new project in Memfault`_.
 
-.. include:: /includes/tfm.txt
+.. include:: /includes/tfm_spm_thingy91.txt
 
 To get access to all the benefits, like up to 100 free devices connected, register at the `Memfault registration page`_.
 
@@ -146,7 +146,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nrf9160/memfault`
 
-.. include:: /includes/build_and_run_ns.txt
+.. include:: /includes/thingy91_build_and_run.txt
 
 Testing
 =======
@@ -230,6 +230,7 @@ It uses the following `sdk-nrfxlib`_ library:
 
 * :ref:`nrfxlib:nrf_modem`
 
-In addition, it uses the following sample:
+In addition, it uses the following secure firmware components:
 
 * :ref:`secure_partition_manager`
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/multicell_location/README.rst
+++ b/samples/nrf9160/multicell_location/README.rst
@@ -17,7 +17,7 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/tfm.txt
+.. include:: /includes/tfm_spm_thingy91.txt
 
 
 Overview
@@ -130,7 +130,7 @@ Building and running
 
    Before building the sample, you must configure a location provider and an API key as instructed in :ref:`lib_multicell_location`.
 
-.. include:: /includes/build_and_run_ns.txt
+.. include:: /includes/thingy91_build_and_run.txt
 
 
 Testing
@@ -237,6 +237,7 @@ It uses the following Zephyr libraries:
 
   * ``include/kernel.h``
 
-In addition, it uses the following samples:
+In addition, it uses the following secure firmware components:
 
 * :ref:`secure_partition_manager`
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
@@ -20,7 +20,7 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/tfm.txt
+.. include:: /includes/tfm_spm_thingy91.txt
 
 .. _nrf_cloud_mqtt_multi_service_features:
 
@@ -396,7 +396,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nrf9160/nrf_cloud_mqtt_multi_service`
 
-.. include:: /includes/build_and_run_ns.txt
+.. include:: /includes/thingy91_build_and_run.txt
 
 .. _nrf_cloud_mqtt_multi_service_dependencies:
 
@@ -413,3 +413,8 @@ This sample uses the following |NCS| libraries and drivers:
 It uses the following `sdk-nrfxlib`_ library:
 
 * :ref:`nrfxlib:nrf_modem`
+
+In addition, it uses the following secure firmware components:
+
+* :ref:`secure_partition_manager`
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/udp/README.rst
+++ b/samples/nrf9160/udp/README.rst
@@ -17,7 +17,7 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/tfm.txt
+.. include:: /includes/tfm_spm_thingy91.txt
 
 Additionally, it supports :ref:`qemu_x86`.
 
@@ -126,7 +126,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nrf9160/udp`
 
-.. include:: /includes/build_and_run_ns.txt
+.. include:: /includes/thingy91_build_and_run.txt
 
 Testing
 =======
@@ -172,6 +172,7 @@ It uses the following `sdk-nrfxlib`_ library:
 
 * :ref:`nrfxlib:nrf_modem`
 
-In addition, it uses the following sample:
+In addition, it uses the following secure firmware components:
 
 * :ref:`secure_partition_manager`
+* :ref:`Trusted Firmware-M <ug_tfm>`


### PR DESCRIPTION
SPM is still default for samples that are build using thingy:91.
Hence, the TFM instructions are updated in the following samples
that supports thingy:91:
nRF9160: AWS IoT
nRF9160: Memfault
nRF9160: Multicell location
nRF9160: nRF Cloud MQTT multi-service
nRF9160: UDP

Also, made the changes in following applications:
nRF9160: Asset Tracker v2
nRF9160: Serial LTE modem

This was a request from @jtguggedal. 

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>