### PR TITLE
docs: added note on changing version in s1 image

### DIFF
--- a/doc/nrf/ug_bootloader_adding.rst
+++ b/doc/nrf/ug_bootloader_adding.rst
@@ -338,3 +338,9 @@ Enable the :kconfig:option:`CONFIG_BUILD_S1_VARIANT` option when building the up
    -DCONFIG_BUILD_S1_VARIANT=y
 
 This is a necessary step for creating application update images for use with :ref:`ug_fw_update`.
+
+The S1 variant is built as a separate child image called ``s1_image``.
+For this reason, any modifications to the configuration of the S1 variant must be done to the ``s1_image`` child image.
+By default this child image is an exact duplicate of the original image, with the exception of its placement in memory.
+The only configuration option that must be modified is the version set in ``CONFIG_FW_INFO_FIRMWARE_VERSION``.
+To make ``s1_image`` bootable with |NSIB|, the value of ``CONFIG_FW_INFO_FIRMWARE_VERSION`` for ``s1_image`` must be bigger than the one for original image.

--- a/doc/nrf/ug_fw_update.rst
+++ b/doc/nrf/ug_fw_update.rst
@@ -266,12 +266,16 @@ With the |NCS|, you must choose the method for versioning an image for use in fi
 
 .. _ug_fw_update_image_versions_b0:
 
+
 Using |NSIB|
 ============
 
 .. include:: ../../samples/bootloader/README.rst
    :start-after: bootloader_monotonic_counter_start
    :end-before: bootloader_monotonic_counter_end
+
+Special handling is needed when updating the S1 variant of an image.
+See :ref:`ug_bootloader_adding_presigned_variants` for details.
 
 .. _ug_fw_update_image_versions_mcuboot:
 


### PR DESCRIPTION
As S1 image is separate child image its version must
be set in the child image, not through the original
images' kconfig as was the case before.

Ref: NCSDK-13827
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>