### PR TITLE
applications: nrf5340_audio: Add metadata for ble5-ctr-rpmsg build

### DIFF
--- a/applications/nrf5340_audio/bin/manifest.yaml
+++ b/applications/nrf5340_audio/bin/manifest.yaml
@@ -1,0 +1,7 @@
+description: LE Audio Controller Subsystem for nRF53
+git_revision: 458dbee1366e793df67f0f7378946cbb16bbab53
+ll_subversion_number: '0x0CB3'
+ll_version_number: '0x0B'
+ll_subversion_number_decimal: '3251'
+ll_version_number_decimal: '11'
+timestamp: '2022-04-22T06:12:11Z'


### PR DESCRIPTION
Adds a manifest.yaml file with metadata for the controller used
with the nRF5340_audio application.

Signed-off-by: Frode van der Meeren <frode.vandermeeren@nordicsemi.no>