### PR TITLE
manifest: Update cmock to point to version with alignment fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -162,7 +162,7 @@ manifest:
     - name: cmock
       path: test/cmock
       submodules: true
-      revision: 9d092898ef26ece140d9225e037274b64d4f851e
+      revision: f65066f15d8248e6dcb778efb8739904a4512087
       remote: throwtheswitch
     - name: zcbor
       remote: nordicsemi

--- a/west.yml
+++ b/west.yml
@@ -161,11 +161,8 @@ manifest:
     # Other third-party repositories.
     - name: cmock
       path: test/cmock
+      submodules: true
       revision: 9d092898ef26ece140d9225e037274b64d4f851e
-      remote: throwtheswitch
-    - name: unity
-      path: test/cmock/vendor/unity
-      revision: 74cde089e65c3435ce9aa87d5c69f4f16b7f6ade
       remote: throwtheswitch
     - name: zcbor
       remote: nordicsemi


### PR DESCRIPTION
There is a bug in the cmock library. Fix is in Pull Request (https://github.com/ThrowTheSwitch/CMock/pull/401).
Pointing to the PR for now. Not sure how fast it can get merged.

Additionally, removed `unity` from manifest and started to use `submodules:true` for cmock which fetches unity.

Ref NCSDK-15302.