### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3c8a7f7ad6d2458a3bcc30a22ef62323db87ed56
+      revision: 6c08d64440ad3e692b028c76fcfad22113dca66c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This updates Zephyr revision with fix for
reading PHY when using extended advertising
with PHY different than 1M.