### PR TITLE
applications: asset_tracker_v2: Centralize check of nrf_modem_init ret

### DIFF
--- a/applications/asset_tracker_v2/prj.conf
+++ b/applications/asset_tracker_v2/prj.conf
@@ -14,7 +14,7 @@ CONFIG_FPU=y
 
 # Heap and stacks
 CONFIG_HEAP_MEM_POOL_SIZE=32768
-CONFIG_MAIN_STACK_SIZE=1280
+CONFIG_MAIN_STACK_SIZE=1408
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 CONFIG_HW_STACK_PROTECTION=y
 # Increase AT monitor heap size to be able to fit both neighbor cell measurement

--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -13,6 +13,7 @@
 #include <modem/nrf_modem_lib.h>
 #endif /* CONFIG_NRF_MODEM_LIB */
 #include <zephyr/sys/reboot.h>
+#include <net/lwm2m_client_utils_fota.h>
 
 #if defined(CONFIG_NRF_CLOUD_AGPS) || defined(CONFIG_NRF_CLOUD_PGPS)
 #include <net/nrf_cloud_agps.h>
@@ -171,7 +172,35 @@ static void sub_state_set(enum sub_state_type new_state)
 	sub_state = new_state;
 }
 
-/* Check the return code from nRF modem library initializaton to ensure that
+#if defined(CONFIG_LWM2M_INTEGRATION)
+static void lwm2m_update_modem_fota_counter(void)
+{
+	int ret;
+	struct update_counter counter = { 0 };
+
+	ret = fota_settings_init();
+	if (ret) {
+		LOG_WRN("Unable to init settings, error: %d", ret);
+		return;
+	}
+
+	ret = fota_update_counter_read(&counter);
+	if (ret) {
+		LOG_ERR("Failed read the update counter, error: %d", ret);
+		return;
+	}
+
+	if (counter.update != -1) {
+		ret = fota_update_counter_update(COUNTER_CURRENT, counter.update);
+		if (ret) {
+			LOG_ERR("Failed to update the update counter, error: %d", ret);
+			return;
+		}
+	}
+}
+#endif /* CONFIG_LWM2M_INTEGRATION */
+
+/* Check the return code from nRF modem library initialization to ensure that
  * the modem is rebooted if a modem firmware update is ready to be applied or
  * an error condition occurred during firmware update or library initialization.
  */
@@ -186,7 +215,10 @@ static void handle_nrf_modem_lib_init_ret(void)
 		/* Initialization successful, no action required. */
 		return;
 	case MODEM_DFU_RESULT_OK:
-		LOG_INF("MODEM UPDATE OK. Will run new firmware after reboot");
+		LOG_WRN("MODEM UPDATE OK. Will run new modem firmware after reboot");
+#if defined(CONFIG_LWM2M_INTEGRATION)
+		lwm2m_update_modem_fota_counter();
+#endif
 		break;
 	case MODEM_DFU_RESULT_UUID_ERROR:
 	case MODEM_DFU_RESULT_AUTH_ERROR:
@@ -543,7 +575,7 @@ void main(void)
 	int err;
 	struct app_msg_data msg;
 
-	if (!IS_ENABLED(CONFIG_LWM2M_CARRIER) && !IS_ENABLED(CONFIG_NRF_CLOUD_FOTA)) {
+	if (!IS_ENABLED(CONFIG_LWM2M_CARRIER)) {
 		handle_nrf_modem_lib_init_ret();
 	}
 


### PR DESCRIPTION
Centralize check of the `nrf_modem_lib_get_init_ret` return value.

Modem FOTA requires that the system is rebooted after a new modem image
has been applied indicated by the `MODEM_DFU_RESULT_OK`
return value from `nrf_modem_lib_get_init_ret`.

The application modules should not be allowed to initialize if
the modem is in this state where it expects a reboot to occur.
AT commands sent to the modem in this state fails, which causes the
various module `setup` functions to fail and trigger an assert.

The `cloud_module` will for instance try to retrieve the IMEI from
the modem during its call  to `setup`.

This patch also moves updating of the FOTA counter required for
LwM2M builds. This was failing due to the settings API not being
initialized when called from a `nrf_modem_init` callback handler.

Initializing the settings API in a `nrf_modem_init` callback handler
fails due to the settings API not finding the configured flash backend
which indicates that the flash backend is ready after `nrf_modem_init`
is called, which is set at init priority `POST_KERNEL`.

Fixes CIA-605

Signed-off-by: Simen S. Røstad <simen.rostad@nordicsemi.no>