### PR TITLE
applications: asset_tracker_v2: Reset QoS timer upon LTE disconnection

### DIFF
--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -523,6 +523,7 @@ static void disconnect_cloud(void)
 	cloud_wrap_disconnect();
 
 	connect_retries = 0;
+	qos_timer_reset();
 
 	k_work_cancel_delayable(&connect_check_work);
 }


### PR DESCRIPTION
Reset QoS timer upon disconnection from LTE. Without this patch, the
QoS library will continue to dispatch unACKed messages even though a
connection is not available.

Fixes CIA-648