### PR TITLE
Fix in gatt_dm.c for memory leak in case of error. Reproduce-able in …

### DIFF
--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -648,6 +648,7 @@ int bt_gatt_dm_start(struct bt_conn *conn,
 	if (err) {
 		LOG_ERR("Discover failed, error: %d.", err);
 		atomic_clear_bit(dm->state_flags, STATE_ATTRS_LOCKED);
+		discovery_complete_error(dm, err);
 	}
 
 	return err;


### PR DESCRIPTION
…case of ENOTCONN.