### PR TITLE
application: serial_lte_modem: Adjust GPIO behaviors

### DIFF
--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -88,17 +88,33 @@ CONFIG_SLM_START_SLEEP - Enter sleep on startup
 
 CONFIG_SLM_WAKEUP_PIN - Interface GPIO to exit from sleep or idle
    This option specifies which interface GPIO to use for exiting sleep or idle mode.
-   By default, **P0.6** (Button 1 on the nRF9160 DK) is used when :ref:`CONFIG_SLM_CONNECT_UART_0 <CONFIG_SLM_CONNECT_UART_0>` is selected, and **P0.31** is used when :ref:`CONFIG_SLM_CONNECT_UART_2 <CONFIG_SLM_CONNECT_UART_2>` is selected.
+   It is set by default as follows:
 
-   **P0.26** (Multi-function button on Thingy:91) is used when the target is Thingy:91.
+   * On the nRF9160 DK:
+
+     * **P0.6** (Button 1 on the nRF9160 DK) is used when :ref:`CONFIG_SLM_CONNECT_UART_0 <CONFIG_SLM_CONNECT_UART_0>` is selected.
+     * **P0.31** is used when :ref:`CONFIG_SLM_CONNECT_UART_2 <CONFIG_SLM_CONNECT_UART_2>` is selected.
+
+   * On Thingy:91, **P0.26** (Multi-function button on Thingy:91) is used.
+
+   .. note::
+      This pin is used as input GPIO and configured as *Active Low*.
+      By default, the application pulls up this GPIO.
 
 .. _CONFIG_SLM_INDICATE_PIN:
 
-CONFIG_SLM_INDICATE_PIN - Interface GPIO to indicate data available or unexpected reset
-   This option specifies which interface GPIO to use for indicating data available or unexpected reset.
-   By default, **P0.2** (LED 1 on the nRF9160 DK) is used when :ref:`CONFIG_SLM_CONNECT_UART_0 <CONFIG_SLM_CONNECT_UART_0>` is selected, and **P0.30** is used when :ref:`CONFIG_SLM_CONNECT_UART_2 <CONFIG_SLM_CONNECT_UART_2>` is selected.
+CONFIG_SLM_INDICATE_PIN - Interface GPIO to indicate data available or unsolicited event notifications
+   This option specifies which interface GPIO to use for indicating data available or unsolicited event notifications from the modem.
+   On the nRF9160 DK, it is set by default as follows:
+
+   * **P0.2** (LED 1 on the nRF9160 DK) is used when :ref:`CONFIG_SLM_CONNECT_UART_0 <CONFIG_SLM_CONNECT_UART_0>` is selected.
+   * **P0.30** is used when :ref:`CONFIG_SLM_CONNECT_UART_2 <CONFIG_SLM_CONNECT_UART_2>` is selected.
 
    It is not defined when the target is Thingy:91.
+
+   .. note::
+      This pin is used as output GPIO and configured as *Active Low*.
+      By default, the application sets this GPIO as *Inactive High*.
 
 .. _CONFIG_SLM_INDICATE_TIME:
 

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -125,6 +125,34 @@ static int ext_xtal_control(bool xtal_on)
 	return err;
 }
 
+/* This function is safe to call twice after reset */
+static int init_gpio(void)
+{
+	int err;
+
+	gpio_dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
+	if (gpio_dev == NULL) {
+		LOG_ERR("GPIO_0 bind error");
+		return -EAGAIN;
+	}
+	err = gpio_pin_configure(gpio_dev, CONFIG_SLM_WAKEUP_PIN,
+				 GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_LOW);
+	if (err) {
+		LOG_ERR("GPIO_0 config error: %d", err);
+		return err;
+	}
+#if (CONFIG_SLM_INDICATE_PIN >= 0)
+	err = gpio_pin_configure(gpio_dev, CONFIG_SLM_INDICATE_PIN,
+				 GPIO_OUTPUT_INACTIVE | GPIO_ACTIVE_LOW);
+	if (err) {
+		LOG_ERR("GPIO_0 config error: %d", err);
+		return err;
+	}
+#endif
+
+	return 0;
+}
+
 int indicate_start(void)
 {
 	int err = 0;
@@ -134,16 +162,6 @@ int indicate_start(void)
 		return 0;
 	}
 	LOG_DBG("Start indicating");
-	gpio_dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
-	if (gpio_dev == NULL) {
-		LOG_ERR("GPIO_0 bind error");
-		return -EAGAIN;
-	}
-	err = gpio_pin_configure(gpio_dev, CONFIG_SLM_INDICATE_PIN, GPIO_OUTPUT);
-	if (err) {
-		LOG_ERR("GPIO_0 config error: %d", err);
-		return -EAGAIN;
-	}
 	err = gpio_pin_set(gpio_dev, CONFIG_SLM_INDICATE_PIN, 1);
 	if (err) {
 		LOG_ERR("GPIO_0 set error: %d", err);
@@ -160,7 +178,6 @@ static void indicate_stop(void)
 	if (gpio_pin_set(gpio_dev, CONFIG_SLM_INDICATE_PIN, 0) != 0) {
 		LOG_WRN("GPIO_0 set error");
 	}
-	gpio_pin_configure(gpio_dev, CONFIG_SLM_INDICATE_PIN, GPIO_DISCONNECTED);
 	LOG_DBG("Stop indicating");
 #endif
 }
@@ -190,23 +207,12 @@ static void gpio_cb_func(const struct device *dev, struct gpio_callback *gpio_cb
 
 	gpio_pin_interrupt_configure(gpio_dev, CONFIG_SLM_WAKEUP_PIN, GPIO_INT_DISABLE);
 	gpio_remove_callback(gpio_dev, gpio_cb);
-	gpio_pin_configure(gpio_dev, CONFIG_SLM_WAKEUP_PIN, GPIO_DISCONNECTED);
 }
 
 void enter_idle(void)
 {
 	int err;
 
-	gpio_dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
-	if (gpio_dev == NULL) {
-		LOG_ERR("GPIO_0 bind error");
-		return;
-	}
-	err = gpio_pin_configure(gpio_dev, CONFIG_SLM_WAKEUP_PIN, GPIO_INPUT | GPIO_PULL_UP);
-	if (err) {
-		LOG_ERR("GPIO_0 config error: %d", err);
-		return;
-	}
 	gpio_init_callback(&gpio_cb, gpio_cb_func, BIT(CONFIG_SLM_WAKEUP_PIN));
 	err = gpio_add_callback(gpio_dev, &gpio_cb);
 	if (err) {
@@ -229,8 +235,8 @@ void enter_sleep(void)
 {
 	/*
 	 * Due to errata 4, Always configure PIN_CNF[n].INPUT before PIN_CNF[n].SENSE.
+	 * At this moment WAKEUP_PIN has already been configured as INPUT at init_gpio().
 	 */
-	nrf_gpio_cfg_input(CONFIG_SLM_WAKEUP_PIN, NRF_GPIO_PIN_PULLUP);
 	nrf_gpio_cfg_sense_set(CONFIG_SLM_WAKEUP_PIN, NRF_GPIO_PIN_SENSE_LOW);
 
 	k_sleep(K_MSEC(100));
@@ -324,25 +330,21 @@ void handle_mcuboot_swap_ret(void)
 int start_execute(void)
 {
 	int err;
-	static bool slm_started;
 
-	if (!slm_started) {
-		LOG_INF("Serial LTE Modem");
-		err = ext_xtal_control(true);
-		if (err < 0) {
-			LOG_ERR("Failed to enable ext XTAL: %d", err);
-			return err;
-		}
-		err = slm_at_host_init();
-		if (err) {
-			LOG_ERR("Failed to init at_host: %d", err);
-			return err;
-		}
-		k_work_queue_start(&slm_work_q, slm_wq_stack_area,
-				   K_THREAD_STACK_SIZEOF(slm_wq_stack_area),
-				   SLM_WQ_PRIORITY, NULL);
-		slm_started = true;
+	LOG_INF("Serial LTE Modem");
+	err = ext_xtal_control(true);
+	if (err < 0) {
+		LOG_ERR("Failed to enable ext XTAL: %d", err);
+		return err;
 	}
+	err = slm_at_host_init();
+	if (err) {
+		LOG_ERR("Failed to init at_host: %d", err);
+		return err;
+	}
+	k_work_queue_start(&slm_work_q, slm_wq_stack_area,
+			   K_THREAD_STACK_SIZEOF(slm_wq_stack_area),
+			   SLM_WQ_PRIORITY, NULL);
 
 	return 0;
 }
@@ -352,7 +354,6 @@ static void indicate_wk(struct k_work *work)
 	ARG_UNUSED(work);
 
 	indicate_stop();
-	(void)start_execute();
 }
 
 int main(void)
@@ -363,6 +364,10 @@ int main(void)
 	LOG_DBG("RR: 0x%08x", rr);
 	k_work_init_delayable(&indicate_work, indicate_wk);
 
+	/* Init GPIOs */
+	if (init_gpio() != 0) {
+		LOG_WRN("Failed to init gpio");
+	}
 	/* Init and load settings */
 	if (slm_settings_init() != 0) {
 		LOG_WRN("Failed to init slm settings");
@@ -389,15 +394,6 @@ int main(void)
 	enter_sleep();
 	return 0;
 #else
-#if (CONFIG_SLM_INDICATE_PIN >= 0)
-	if ((rr & NRF_POWER_RESETREAS_DOG_MASK) ||     /* watch dog reset */
-	    (rr & NRF_POWER_RESETREAS_SREQ_MASK) ||    /* software reset */
-	    (rr & NRF_POWER_RESETREAS_LOCKUP_MASK)) {  /* CPU lockup reset */
-		if (indicate_start() == 0) {
-			return 0;
-		}
-	}
-#endif /* CONFIG_SLM_INDICATE_PIN >= 0 */
 	return start_execute();
 #endif /* CONFIG_SLM_START_SLEEP */
 }

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -118,15 +118,20 @@ nRF9160: Asset Tracker v2
 nRF9160: Serial LTE modem
 -------------------------
 
-  * Updated:
-
-    * AT response and the URC sent when the application enters and exits data mode.
-
   * Added:
 
     * URC for GNSS sleep and wakeup events.
     * Selected flags support in #XRECV and #XRECVFROM commands.
     * Multi-PDN support in the Socket service.
+
+  * Updated:
+
+    * The AT response and the URC sent when the application enters and exits data mode.
+    * ``WAKEUP_PIN`` and ``INTERFACE_PIN`` are now defined as *Active Low*. Both are *High* when the SLM application starts.
+
+  * Removed:
+
+    * The software toggle of ``INDICATE_PIN`` in case of reset.
 
 nRF5340 Audio
 -------------


### PR DESCRIPTION
Old behavior
On power-on: INDICATE/WAKEUP = GPIO disconnected
On sleep: INDICATE = disconnected, WAKEUP = INPUT & PULL-UP
On toggle: INDICATE active high, WAKEUP active low

New behavior
On power-on: INDICATE = OUTPUT & HIGH, WAKEUP = INPUT & PULL-UP
On sleep: INDICATE = OUTPUT & HIGH, WAKEUP = INPUT & PULL-UP
On toggle: INDICATE active low, WAKEUP active low

To help MCU to monitor INDICATE input and control WAKEUP output
Scenarios: power-on, sleep/wakeup, exter/exit idle

Remove the toggle (high-low-high) by SLM for Reset

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>