### PR TITLE
tests: lib: sms: restrict platforms to native_posix

### DIFF
--- a/tests/lib/sms/testcase.yaml
+++ b/tests/lib/sms/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   unity.sms_test:
     tags: sms
+    platform_allow: native_posix
     integration_platforms:
       - native_posix


### PR DESCRIPTION
Added "platform_allow" keyword to restrict compilation to native_posix.

Fixes NCSDK-15235.