### PR TITLE
doc: Add note about secure faults missed by memfault if using TF-M

### DIFF
--- a/doc/nrf/libraries/others/memfault_ncs.rst
+++ b/doc/nrf/libraries/others/memfault_ncs.rst
@@ -41,6 +41,11 @@ In addition, you must configure a Memfault project key using :kconfig:option:`CO
 
 To get access to all the benefits, like up to 100 free devices connected, register at the `Memfault registration page`_.
 
+.. note::
+   When building applications with :ref:`Trusted Firmware-M <ug_tfm>` (TF-M), the faults resulting from memory access in secure regions are not caught by Memfault's fault handler.
+   Instead, they are handled by TF-M.
+   This means that those faults are not reported to the Memfault platform.
+   You can configure your application to use the :ref:`secure_partition_manager` instead of TF-M if you prefer all such faults to be reported to the Memfault platform.
 
 Configuration
 *************


### PR DESCRIPTION
Add a note that explains why faults resulting from secure memory access
will not be collected by memfault SDK's fault handling code when TF-M is
used.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>