### PR TITLE
bluetooth: fast_pair: Add hash to verify provisioning data

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -198,7 +198,9 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_fast_pair_readme` service:
+
+  * Added a SHA-256 hash check to ensure the Fast Pair provisioning data integrity.
 
 Bootloader libraries
 --------------------
@@ -267,7 +269,9 @@ Scripts
 
 This section provides detailed lists of changes by :ref:`script <scripts>`.
 
-|no_changes_yet_note|
+* :ref:`bt_fast_pair_provision_script`:
+
+  * Added a SHA-256 hash of the Fast Pair provisioning data to ensure its integrity.
 
 Unity
 -----

--- a/scripts/nrf_provision/fast_pair/README.rst
+++ b/scripts/nrf_provision/fast_pair/README.rst
@@ -87,11 +87,13 @@ Implementation details
 
 The script converts the Model ID and Anti-Spoofing Private Key to bytes and places them under the predefined offsets in the generated hexadecimal file.
 The ID and the key are required by the Google Fast Pair Service and are provided as command line arguments (see `Using the script`_).
-The magic data with predefined value is placed right before and right after the mentioned provisioning data.
+The magic data with predefined value is placed right before the mentioned provisioning data.
+The SHA-256 hash is calculated using the magic data and the provisioning data, and then placed right after the provisioning data to ensure data integrity.
 
 The generated data must be placed on a dedicated ``bt_fast_pair`` partition defined by the :ref:`partition_manager`.
 The :ref:`bt_fast_pair_readme` knows both the offset sizes and lengths of the individual data fields in the provisioning data.
 The service accesses the data by reading flash content.
+The service calculates the hash on its own and checks whether it matches the hash stored on the partition.
 
 Dependencies
 ************

--- a/subsys/bluetooth/services/fast_pair/fp_registration_data.c
+++ b/subsys/bluetooth/services/fast_pair/fp_registration_data.c
@@ -10,6 +10,7 @@
 #include <zephyr/storage/flash_map.h>
 #include <pm_config.h>
 
+#include "fp_crypto.h"
 #include "fp_registration_data.h"
 
 #define FP_PARTITION_ID		PM_BT_FAST_PAIR_ID
@@ -22,16 +23,19 @@ static const uint8_t fp_magic[] = {0xFA, 0x57, 0xFA, 0x57};
 #define FP_DATA_ALIGN		 4
 #define FP_DATA_START		 0
 #define FP_OFFSET(_prev_item_offset, _prev_item_len) \
-	(_prev_item_offset + ROUND_UP(_prev_item_len, FP_DATA_ALIGN))
+	((_prev_item_offset) + ROUND_UP(_prev_item_len, FP_DATA_ALIGN))
 
-#define FP_MAGIC_HEADER_OFF	 FP_DATA_START
-#define FP_MODEL_ID_OFF		 FP_OFFSET(FP_MAGIC_HEADER_OFF, FP_MAGIC_SIZE)
+#define FP_MAGIC_OFF		 FP_DATA_START
+#define FP_MODEL_ID_OFF		 FP_OFFSET(FP_MAGIC_OFF, FP_MAGIC_SIZE)
 #define FP_ANTI_SPOOFING_KEY_OFF FP_OFFSET(FP_MODEL_ID_OFF, FP_REG_DATA_MODEL_ID_LEN)
-#define FP_MAGIC_TRAILER_OFF	 FP_OFFSET(FP_ANTI_SPOOFING_KEY_OFF, \
+#define FP_HASH_OFF		 FP_OFFSET(FP_ANTI_SPOOFING_KEY_OFF, \
 					   FP_REG_DATA_ANTI_SPOOFING_PRIV_KEY_LEN)
+#define FP_END_OFF		 FP_OFFSET(FP_HASH_OFF, FP_CRYPTO_SHA256_HASH_LEN)
 
-BUILD_ASSERT(FP_OFFSET(FP_MAGIC_TRAILER_OFF, FP_MAGIC_SIZE) <= FP_PARTITION_SIZE,
-	     "Fast Pair registration data partition is too small");
+#define FP_DATA_SIZE		 (FP_END_OFF - FP_DATA_START)
+#define FP_OFFSET_TO_DATA_IDX(_offset) ((_offset) - FP_DATA_START)
+
+BUILD_ASSERT(FP_END_OFF <= FP_PARTITION_SIZE, "Fast Pair registration data partition is too small");
 
 static bool data_valid;
 
@@ -81,17 +85,26 @@ int fp_get_anti_spoofing_priv_key(uint8_t *buf, size_t size)
 	return err;
 }
 
-static int validate_fp_magic(const struct flash_area *fa, off_t off)
+static int validate_fp_magic(const uint8_t *magic_data)
+{
+	if (memcmp(magic_data, fp_magic, FP_MAGIC_SIZE)) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int validate_fp_hash(const uint8_t *prov_data, const uint8_t *hash)
 {
 	int err;
-	uint8_t read_buf[FP_MAGIC_SIZE];
+	uint8_t hash_calc[FP_CRYPTO_SHA256_HASH_LEN];
 
-	err = flash_area_read(fa, off, read_buf, FP_MAGIC_SIZE);
+	err = fp_crypto_sha256(hash_calc, prov_data, FP_DATA_SIZE - FP_CRYPTO_SHA256_HASH_LEN);
 	if (err) {
 		return err;
 	}
 
-	if (memcmp(read_buf, fp_magic, FP_MAGIC_SIZE)) {
+	if (memcmp(hash, hash_calc, FP_CRYPTO_SHA256_HASH_LEN)) {
 		err = -EINVAL;
 	}
 
@@ -103,15 +116,20 @@ static int fp_registration_data_validate(const struct device *unused)
 	ARG_UNUSED(unused);
 
 	int err;
+	uint8_t data[FP_DATA_SIZE];
 	const struct flash_area *fa = NULL;
 
 	err = flash_area_open(FP_PARTITION_ID, &fa);
 	if (!err) {
-		err = validate_fp_magic(fa, FP_MAGIC_HEADER_OFF);
+		err = flash_area_read(fa, FP_DATA_START, data, FP_DATA_SIZE);
 	}
 
 	if (!err) {
-		err = validate_fp_magic(fa, FP_MAGIC_TRAILER_OFF);
+		err = validate_fp_magic(&data[FP_OFFSET_TO_DATA_IDX(FP_MAGIC_OFF)]);
+	}
+
+	if (!err) {
+		err = validate_fp_hash(data, &data[FP_OFFSET_TO_DATA_IDX(FP_HASH_OFF)]);
 	}
 
 	if (fa) {

--- a/subsys/partition_manager/pm.yml.bt_fast_pair
+++ b/subsys/partition_manager/pm.yml.bt_fast_pair
@@ -1,4 +1,4 @@
 bt_fast_pair:
   placement: {before: end}
-  size: 0x2c
+  size: 0x48
   align: {start: 0x04}


### PR DESCRIPTION
SHA-256 hash from Fast Pair provisioning data is added after data in a Fast Pair provisioning data partition. Fast Pair subsystem verifies whether hash is correct to ensure provisioning data integrity.

Partition size has been increased to fit calculated hash of provisioning data.
    
Jira: NCSDK-15100