### PR TITLE
doc: multi-image: add build file table

### DIFF
--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -30,6 +30,8 @@ If you want to build and program with custom options, read about the advanced `C
    :start-after: vsc_mig_note_start
    :end-before: vsc_mig_note_end
 
+|output_files_note|
+
 .. _gs_programming_cmd:
 
 Building on the command line
@@ -86,7 +88,8 @@ After completing the :ref:`manual <build_environment_cli>` or :ref:`automatic <g
       See :ref:`configure_application` for additional information about configuring an application.
 
       After running the ``west build`` command, the build files can be found in :file:`build/zephyr`.
-      For more information on the contents of the build directory, see :ref:`zephyr:build-directory-contents`.
+      |output_files_note|
+      For more information on the contents of the build directory, see :ref:`zephyr:build-directory-contents` in the Zephyr documentation.
 
       .. important::
          If you are working with an nRF9160 DK, make sure to select the correct controller before you program the application to your development kit.
@@ -122,3 +125,5 @@ After completing the :ref:`manual <build_environment_cli>` or :ref:`automatic <g
       The ``west flash`` command automatically resets the kit and starts the application.
 
 For more information on building and programming using the command line, see the Zephyr documentation on :ref:`zephyr:west-build-flash-debug`.
+
+.. |output_files_note| replace:: For more information about files generated as output of the build process, see :ref:`app_build_output_files`.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -33,7 +33,7 @@ The following sections provide detailed lists of changes by component.
 Application development
 =======================
 
-|no_changes_yet_note|
+* Added information about :ref:`app_build_output_files` on the :ref:`app_build_system` page.
 
 Protocols
 =========

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -8,21 +8,19 @@ Multi-image builds
    :depth: 2
 
 The firmware programmed to a device can be composed of either one application or several separate images.
-In the latter, one of the images, the *parent image*, requires one or more other images, the *child images*, to be present.
+In the latter case, one of the images (the *parent image*) requires one or more other images (the *child images*) to be present.
 The child image then *chain-loads*, or *boots*, the parent image, which could also be a child image to another parent image, and boots that one.
 
 The most common use cases for builds composed of multiple images are applications that require a bootloader to be present or applications for multi-core CPUs.
 
-When to use multiple images
-***************************
+.. _ug_multi_image_what_are_images:
 
-An *image*, also referred to as *executable*, *program*, or *elf file*, consists of pieces of code and data that are identified by image-unique names recorded in a single symbol table.
-The symbol table exists as metadata in a :file:`.elf` or :file:`.exe` file and is not included when the image is converted to a HEX file for programming.
-Instead, a linker places the code and data at their addresses.
+What are image files
+********************
 
-Only images require this linking process.
-Object files do not require linking.
-To determine if you have zero, one, or more images, count the number of times the linker runs.
+.. include:: app_build_system.rst
+   :start-after: output_build_files_info_start
+   :end-before: output_build_files_info_end
 
 Using multiple images has the following advantages:
 
@@ -31,6 +29,15 @@ Using multiple images has the following advantages:
 * Since there is a symbol table for each image, the same symbol names can exist multiple times in the final firmware.
   This is useful for bootloader images, which can require their own copy of a library that the application uses, but in a different version or configuration.
 * In multi-core builds, the build configuration of a child image in a separate core can be made known to the parent image.
+
+.. include:: app_build_system.rst
+   :start-after: output_build_files_table_start
+   :end-before: output_build_files_table_end
+
+.. _ug_multi_image_when_to_use_images:
+
+When to use multiple images
+***************************
 
 In the |NCS|, multiple images are required in the following scenarios:
 
@@ -62,6 +69,8 @@ nRF5340 Audio development kit support
    The network core image is programmed with an application-specific precompiled Bluetooth Low Energy Controller binary file that contains the LE Audio Controller Subsystem for nRF53.
 
    See the :ref:`nrf53_audio_app` application documentation for more information.
+
+.. _ug_multi_image_default_config:
 
 Default configuration
 *********************

--- a/doc/nrf/ug_thingy53.rst
+++ b/doc/nrf/ug_thingy53.rst
@@ -40,10 +40,10 @@ To set up your system to be able to build a compatible firmware image, follow th
 
 .. _thingy53_build_pgm_targets:
 
-Build Targets
+Build targets
 =============
 
-The build targets of interest for Thingy:53 in the |NCS| are listed on the table below.
+The build targets of interest for Thingy:53 in the |NCS| are listed in the following table.
 
 +--------------------------------+----------------------------------------------------------+
 |Component                       |  Build target                                            |
@@ -73,19 +73,7 @@ The build process generates firmware in two formats:
   For convenience, the binary files are bundled in :file:`dfu_application.zip`, together with a manifest that describes them.
   You can use the binary files or the combined zip archive to update application firmware for both cores, with either MCUboot serial recovery or OTA DFU using Bluetooth LE.
 
-The following table shows the relevant types of build files that are generated and the different scenarios in which they are used.
-
-+---------------------------------+-------------------------------------------------+---------------------------------------------------------------------+
-| File                            | File format                                     | Programming scenario                                                |
-+=================================+=================================================+=====================================================================+
-| :file:`merged_domain.hex`       | Full image for both cores                       | Using an external debug probe and nRF Connect Programmer            |
-+---------------------------------+-------------------------------------------------+---------------------------------------------------------------------+
-| :file:`app_update.bin`          | MCUboot compatible application core update      | Using the built-in bootloader and nRF Connect Programmer            |
-+---------------------------------+-------------------------------------------------+---------------------------------------------------------------------+
-| :file:`net_core_app_update.bin` | MCUboot compatible network core update          | Using the built-in bootloader and nRF Connect Programmer            |
-+---------------------------------+-------------------------------------------------+---------------------------------------------------------------------+
-| :file:`dfu_application.zip`     | MCUboot compatible update images for both cores | Using nRF Programmer for Android and iOS, or nRF Connect Programmer |
-+---------------------------------+-------------------------------------------------+---------------------------------------------------------------------+
+For more information about files generated as output of the build process, see :ref:`app_build_output_files`.
 
 See the following sections for details regarding building and programming the firmware for Thingy:53 in various environments.
 If your Thingy:53 is already programmed with a Thingy:53-compatible sample or application, you can also use the MCUboot bootloader to update the firmware after you finish building.


### PR DESCRIPTION
Added build file table to explain the purpose of different files.
KRKNWK-13103.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>

----

- [x] Squash to one commit