### PR TITLE
Fix secure_services with bootloader

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -232,6 +232,9 @@ Other libraries
 
     * Allow the :kconfig:option:`CONFIG_DISABLE_FLASH_PATCH` Kconfig option to be used on the nRF52833 SoC.
 
+  * :ref:`doc_fw_info` module:
+
+    * Fixed a bug where MCUboot would experience a fault when using the :ref:`doc_fw_info_ext_api` feature.
 
 Common Application Framework (CAF)
 ----------------------------------

--- a/samples/nrf9160/secure_services/sample.yaml
+++ b/samples/nrf9160/secure_services/sample.yaml
@@ -9,7 +9,7 @@ tests:
     platform_allow: nrf9160dk_nrf9160_ns
     tags: ci_build
   sample.nrf9160.secure_services.bootloaders:
-    extra_args: CONFIG_BOOTLOADER_MCUBOOT=y CONFIG_SECURE_BOOT=y CONFIG_SPM_SERVICE_PREVALIDATE=y mcuboot_CONFIG_EXT_API_PROVIDE_EXT_API_ENABLED=y CONFIG_SPM_SERVICE_S0_ACTIVE=y
+    extra_args: CONFIG_BOOTLOADER_MCUBOOT=y CONFIG_SECURE_BOOT=y CONFIG_SPM_SERVICE_PREVALIDATE=y mcuboot_CONFIG_EXT_API_PROVIDE_EXT_API_ENABLED=y mcuboot_CONFIG_EXT_API_PROVIDE_EXT_API_REQUIRED=y CONFIG_SPM_SERVICE_S0_ACTIVE=y
     harness: console
     harness_config:
       ordered: true

--- a/subsys/fw_info/fw_info.c
+++ b/subsys/fw_info/fw_info.c
@@ -68,7 +68,7 @@ static bool ext_api_satisfies_req(const struct fw_info_ext_api * const ext_api,
 }
 
 
-static const struct fw_info_ext_api_request *skip_ext_apis(
+const struct fw_info_ext_api_request *skip_ext_apis(
 					const struct fw_info * const fw_info)
 {
 	const struct fw_info_ext_api *ext_api = &fw_info->ext_apis[0];


### PR DESCRIPTION
Two fixes needed for the sample.nrf9160.secure_services.bootloaders to pass.

Based on #7848 