### PR TITLE
doc: vsc: fix shortcuts

### DIFF
--- a/doc/nrf/getting_started.rst
+++ b/doc/nrf/getting_started.rst
@@ -12,11 +12,11 @@ You can also check the :ref:`gs_installing` documentation for instructions on se
 .. image:: /images/ncs_get_started_banner.png
    :target: `nRF Connect SDK Fundamentals course`_
 
-We recommend using |VSC| to build applications.
+We recommend using |VSC| with the |nRFVSC| to build applications.
 See the `nRF Connect for Visual Studio Code`_ documentation page for more information about the extension.
 
 .. note::
-   Some samples in the |NCS| are currently not designed to work out-of-tree. You may need to manually configure your sample to work correctly in |VSC|.
+   Some samples in the |NCS| are currently not designed to work out-of-tree. You may need to manually configure your sample to work correctly in the |nRFVSC|.
 
 Once you are set up, check out the :ref:`samples`.
 If this is the first time you are working with embedded devices, it is probably a good idea to program an unchanged sample to your development kit first and test if it works as expected.

--- a/doc/nrf/gs_assistant.rst
+++ b/doc/nrf/gs_assistant.rst
@@ -18,8 +18,8 @@ See :ref:`gs_recommended_versions` for information on the supported operating sy
 Toolchain Manager
 *****************
 
-The Toolchain manager application is available for Windows, Linux, and macOS.
-It installs the full toolchain that you need to work with the |NCS|, including the |VSC| extension and the |NCS| source code.
+The Toolchain Manager application is available for Windows, Linux, and macOS.
+It installs the full toolchain that you need to work with the |NCS|, including the |nRFVSC| and the |NCS| source code.
 
 .. _tcm_setup:
 

--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -373,10 +373,10 @@ A toolchain provides a compiler, assembler, linker, and other programs required 
 
 .. rst-class:: numbered-step
 
-Install |VSC|
-*************
+Install |nRFVSC|
+****************
 
-You can install the |VSC| to open and compile projects in the |NCS|.
+You can install the |nRFVSC| to open and compile projects in the |NCS|.
 
 .. _installing_vsc:
 

--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -27,7 +27,7 @@ When loaded, the application can reference items provided by both Zephyr and the
 Loading Zephyr's `CMake <CMake documentation_>`_ package creates the ``app`` CMake target.
 You can add application source files to this target from the application :file:`CMakeLists.txt` file.
 
-To update the :file:`CMakeLists.txt` file, either edit it directly or use |VSC| to maintain it.
+To update the :file:`CMakeLists.txt` file, either edit it directly or use the |nRFVSC| to maintain it.
 
 Editing CMakeLists.txt
 ======================
@@ -59,12 +59,12 @@ For example, to turn off optimizations, select :kconfig:option:`CONFIG_NO_OPTIMI
 
 Compiler options not controlled by the Zephyr build system can be controlled through the :kconfig:option:`CONFIG_COMPILER_OPT` Kconfig option.
 
-VS Code extension compiler settings
-===================================
+|VSC| compiler settings
+=======================
 
 .. modify_vsc_compiler_options_start
 
-The |VSC| extension lets you build and program with custom options.
+The |nRFVSC| lets you build and program with custom options.
 For more information, read about the advanced `Custom launch and debug configurations`_ and `Application-specific flash options`_ in the extension documentation.
 
 .. modify_vsc_compiler_options_end
@@ -167,10 +167,10 @@ This means that this file is available when building the application, but it is 
 To quickly test different configuration options, or to build your application in different variants, you can update the :file:`.config` file in the build directory.
 Changes are picked up immediately.
 
-While it is possible to edit the :file:`.config` file directly, you should use the nRF Kconfig GUI in |VSC| or a tool like menuconfig or guiconfig to update it.
+While it is possible to edit the :file:`.config` file directly, you should use the nRF Kconfig GUI in the |nRFVSC| or a tool like menuconfig or guiconfig to update it.
 These tools present all available options and allow you to select the ones that you need.
 
-The nRF Kconfig GUI in |VSC| organizes the Kconfig options in a hierarchical list and lets you select the desired options.
+The nRF Kconfig GUI in the |nRFVSC| organizes the Kconfig options in a hierarchical list and lets you select the desired options.
 To save the changes made using the nRF Kconfig GUI, click the :guilabel:`Save` button.
 Read the `nRF Kconfig`_ documentation for more information.
 
@@ -212,8 +212,8 @@ Providing CMake options
 You can provide additional options for building your application to the CMake process, which can be useful, for example, to switch between different build scenarios.
 These options are specified when CMake is run, thus not during the actual build, but when configuring the build.
 
-If you work with the |VSC| extension, you can specify project-specific CMake options when you add the build configuration for a new |NCS| project.
-See `Building an application`_ in the |VSC| documentation.
+If you work with the |nRFVSC|, you can specify project-specific CMake options when you add the build configuration for a new |NCS| project.
+See `Building an application`_ in the |nRFVSC| documentation.
 
 If you work on the command line, pass the additional options to the ``west build`` command.
 The options must be added after a ``--`` at the end of the command.
@@ -245,14 +245,14 @@ The Devicetree configuration is not affected by the build type.
 .. note::
     For an example of an application that is using build types, see the :ref:`nrf_desktop` application (:ref:`nrf_desktop_requirements_build_types`) or the :ref:`nrf_machine_learning_app` application (:ref:`nrf_machine_learning_app_requirements_build_types`).
 
-Selecting a build type in the VS Code extension
-===============================================
+Selecting a build type in |VSC|
+===============================
 
 .. build_types_selection_vsc_start
 
-To select the build type in the |VSC| extension:
+To select the build type in the |nRFVSC|:
 
-1. When `Building an application`_ as described in the |VSC| extension documentation, follow the steps for setting up the build configuration.
+1. When `Building an application`_ as described in the |nRFVSC| documentation, follow the steps for setting up the build configuration.
 #. In the :guilabel:`Add Build Configuration` screen, select the desired :file:`.conf` file from the :guilabel:`Configuration` drop-down menu.
 #. Fill in other configuration options, if applicable, and click :guilabel:`Build Configuration`.
 

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -18,8 +18,8 @@ For example, see :ref:`ug_nrf5340_building` in the :ref:`ug_nrf5340` user guide 
 
 .. _gs_programming_vsc:
 
-Building with the VS Code extension
-***********************************
+Building with |VSC|
+*******************
 
 |vsc_extension_instructions|
 

--- a/doc/nrf/gs_testing.rst
+++ b/doc/nrf/gs_testing.rst
@@ -16,10 +16,10 @@ See the user interface section of the application's documentation for descriptio
 
 .. _testing_vscode:
 
-How to connect with the VS Code extension
-*****************************************
+How to connect with |nRFVSC|
+****************************
 
-The |VSC| extension is a complete IDE for developing applications for nRF91, nRF53 and nRF52 Series devices.
+The |nRFVSC| is a complete IDE for developing applications for nRF91, nRF53 and nRF52 Series devices.
 The extension pack includes nRF Terminal, which is an integrated serial port and RTT terminal to connect to your board.
 For detailed instructions, see the `nRF Terminal documentation`_ on the `nRF Connect for Visual Studio Code`_ documentation site.
 

--- a/doc/nrf/gs_updating.rst
+++ b/doc/nrf/gs_updating.rst
@@ -24,7 +24,7 @@ Updating the repositories
 Updating in |VSC|
 =================
 
-The |VSC| extension lets you update the associated |NCS| repositories within the :guilabel:`Source Control` panel.
+The |nRFVSC| lets you update the associated |NCS| repositories within the :guilabel:`Source Control` panel.
 For detailed instructions, see the `West integration`_ section of the extension's documentation.
 
 Updating in Toolchain Manager
@@ -88,15 +88,15 @@ To switch to the latest state of development, enter the following commands::
 
 .. _gs_updating_vsc:
 
-Updating |VSC|
-**************
+Updating |nRFVSC|
+*****************
 
-Visual Studio Code checks for extension updates and automatically installs them when they are available.
-After an extension is updated, VS Code prompts you to reload the application.
+|VSC| checks for extension updates and automatically installs them when they are available.
+After an extension is updated, |VSC| prompts you to reload the application.
 
 If you disabled automatic updates:
 
-1. Open the :guilabel:`Extensions` tab and locate the |VSC| extension.
+1. Open the :guilabel:`Extensions` tab and locate the |nRFVSC|.
 
 #. The :guilabel:`Update` button appears when an update is available.
    Click on the button to install the update.

--- a/doc/nrf/includes/vsc_build_and_run.txt
+++ b/doc/nrf/includes/vsc_build_and_run.txt
@@ -1,8 +1,8 @@
-1. Open Visual Studio Code.
+1. Open |VSC|.
 
    If you installed the |NCS| using the :ref:`gs_app_tcm`, you can click the :guilabel:`Open VS Code` button next to the version you installed.
 
-#. Open the |VSC| extension by clicking its icon or pressing ``Ctrl`` + ``Alt`` + ``N``.
+#. Open the |nRFVSC| by clicking its icon or pressing ``Ctrl`` + ``Alt`` + ``N``.
 #. Click the :guilabel:`Add an existing application` from the :guilabel:`Welcome` panel.
 #. In the prompt, navigate to the folder containing the sample or application you want to build, such as |sample_path_vsc|.
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -4,8 +4,9 @@
 .. |release_tt| replace:: ``v2.0.0``
 .. |release_number_tt| replace:: ``2.0.0``
 
-.. |plusminus| unicode:: U+000B1 .. PLUS-MINUS SIGN
-   :rtrim:
+.. ### Config shortcuts
+
+.. |how_to_configure| replace:: See :ref:`configure_application` for information on how to set the required configuration options temporarily or permanently.
 
 .. |config| replace:: See :ref:`configure_application` for information about how to permanently or temporarily change the configuration.
 
@@ -40,6 +41,8 @@
 
 .. |ANSI| replace:: that supports VT100/ANSI escape characters
 
+.. ### Board shortcuts
+
 .. |nRF5340DKnoref| replace:: nRF5340 DK board (PCA10095)
 
 .. |nRF9160DK| replace:: nRF9160 DK board (PCA10090) - see :ref:`ug_nrf9160`
@@ -52,6 +55,8 @@
 .. |Thingy91| replace:: Thingy:91 (PCA20035) - see :ref:`ug_thingy91`
 .. |nRF21540DK| replace:: nRF21540 DK board (PCA10112)
 
+.. ### FOTA shortcuts
+
 .. |fota_upgrades_def| replace:: You can upgrade the firmware of the device over the air, thus without a wired connection.
    Such an upgrade is called a FOTA (firmware over-the-air) upgrade.
 
@@ -60,12 +65,20 @@
 .. |fota_upgrades_building| replace:: To create a binary file for an application upgrade, make sure that :kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` is enabled and build the application as usual.
    The build will create several binary files (see :ref:`mcuboot:mcuboot_ncs`).
 
-.. |Google_CCLicense| replace:: Portions of this page are reproduced from work created and `shared by Google`_, and used according to terms described in the `Creative Commons 4.0 Attribution License`_.
+.. ### VSC shortcuts
+
+.. |vsc_extension_instructions| replace:: The |nRFVSC| is a complete IDE for developing applications for nRF91, nRF53 and nRF52 Series devices. This includes an interface to the compiler and linker, an RTOS-aware debugger, a seamless interface to the nRF Connect SDK, and a serial terminal. For detailed instructions, see the `nRF Connect for Visual Studio Code`_ documentation site.
+.. |VSC| replace:: Visual Studio Code
+.. |nRFVSC| replace:: nRF Connect for VS Code extension
+
+.. ### Thread usage shortcuts
 
 .. |enable_thread_before_testing| replace:: Make sure to enable the OpenThread stack before building and testing this sample.
    See :ref:`ug_thread` for more information.
 .. |thread_hwfc_enabled| replace:: This sample has Hardware Flow Control mechanism enabled by default in serial communication.
    When enabled, it allows devices to manage transmission by informing each other about their current state, and ensures more reliable connection in high-speed communication scenarios.
+
+.. ### Zigbee & ZBOSS shortcuts
 
 .. |zigbee_version| replace:: Zigbee 3.0
 .. |zboss_version| replace:: 3.11.2.0
@@ -82,33 +95,38 @@
 .. |zigbee_shell_config| replace:: You can add support for Zigbee shell commands to any of the available :ref:`Zigbee samples <zigbee_samples>`, except for the :ref:`NCP sample <zigbee_ncp_sample>`.
    Some of the commands use an endpoint for sending packets, so no endpoint handler is allowed to be registered for this endpoint.
 
+.. ### nRF Desktop shortcuts
+
 .. |nrf_desktop_module_event_note| replace:: See the :ref:`nrf_desktop_architecture` for more information about the event-based communication in the nRF Desktop application and about how to read this table.
 .. |nrf_desktop_build_type_conf| replace:: In addition to these build types, some boards can have additional build type configurations that you can use to generate an application in a specific variant.
    Such board-specific configurations use dedicated :file:`app_*build_type*.conf` files, where the name of the configuration replaces the ``*build_type*`` part in the file name.
    Given the potential number of such configurations, they are not listed above and you can read the description of each of them in the respective configuration file.
 
-.. |how_to_configure| replace:: See :ref:`configure_application` for information on how to set the required configuration options temporarily or permanently.
-
-.. |trusted_execution| replace:: nRF5340 and nRF9160
+.. ### Matter shortcuts
 
 .. |matter_sample_button3_note| replace:: Use **Button 3** to enable this mode after building and running the sample.
 .. |matter_gn_required_note| replace:: Matter requires the GN tool.
    If you are updating from the |NCS| version earlier than v1.5.0, see the :ref:`GN installation instructions <gs_installing_gn>`.
 
-.. |NSIB| replace:: nRF Secure Immutable Bootloader
-
-.. |external_flash_size| replace:: external flash memory with minimum 4MB
+.. ### Other shortcuts
 
 .. |application_sample_definition| replace:: For simplicity, this guide will refer to both :ref:`samples<samples>` and :ref:`applications<applications>` as "applications".
 .. |application_sample_long_path_windows| replace:: On Windows, because of the `Windows path length limitations`_, the build can fail with errors related to permissions or missing files if some paths in the build are too long.
    To avoid this issue, shorten the build folder name, for example, from ``build_nrf5340dk_nrf5340_cpuapp_ns`` to ``build``, or shorten the path to the build folder in some other way.
 
+.. |NSIB| replace:: nRF Secure Immutable Bootloader
+
+.. |external_flash_size| replace:: external flash memory with minimum 4 MB
+
 .. |gps_tradeoffs| replace:: For more information on the various trade-offs of using A-GPS compared to using P-GPS, see the `nRF Cloud Location Services documentation`_.
-
-.. |vsc_extension_instructions| replace:: The |VSC| extension is a complete IDE for developing applications for nRF91, nRF53 and nRF52 Series devices. This includes an interface to the compiler and linker, an RTOS-aware debugger, a seamless interface to the nRF Connect SDK, and a serial terminal. For detailed instructions, see the `nRF Connect for Visual Studio Code`_ documentation site.
-
-.. |VSC| replace:: nRF Connect for Visual Studio Code
 
 .. |thingy53_sample_note| replace:: If you build this application for Thingy:53, it enables additional features. See :ref:`thingy53_app_guide` for details.
 
 .. |nrf5340_audio_note| replace:: The |NCS| includes the :ref:`nrf53_audio_app` application, a complete project that integrates the LE Audio standard with custom reference hardware based on the nRF5340 SiP.
+
+.. |trusted_execution| replace:: nRF5340 and nRF9160
+
+.. |plusminus| unicode:: U+000B1 .. PLUS-MINUS SIGN
+   :rtrim:
+
+.. |Google_CCLicense| replace:: Portions of this page are reproduced from work created and `shared by Google`_, and used according to terms described in the `Creative Commons 4.0 Attribution License`_.

--- a/doc/nrf/templates/sample_README.rst
+++ b/doc/nrf/templates/sample_README.rst
@@ -126,7 +126,7 @@ Configuration options*
    * You do not need to list all configuration options of the sample, but only the ones that are important for the sample and make sense for the user to know about.
    * The syntax below allows sample configuration options to link to the option descriptions in the same way as the library configuration options link to the corresponding Kconfig descriptions (``:kconfig:option:`SAMPLE_CONFIG```, which results in :kconfig:option:`SAMPLE_CONFIG`).
    * For each configuration option, list the symbol name and the string describing it.
-   * For |VSC| instructions, list the configuration options as they are stated on the Generate Configuration screen.
+   * For the |nRFVSC| instructions, list the configuration options as they are stated on the Generate Configuration screen.
 
 Check and configure the following Kconfig options:
 
@@ -176,8 +176,8 @@ Building and running
 
 .. note::
    * Include the standard text for building - either ``.. include:: /includes/build_and_run.txt`` or ``.. include:: /includes/build_and_run_nrf9160.txt``.
-   * The main supported IDE for |NCS| is |VSC|.
-     Therefore, build instructions for |VSC| are required.
+   * The main supported IDE for |NCS| is |VSC|, with the |nRFVSC| installed.
+     Therefore, build instructions for the |nRFVSC| are required.
      Build instructions for the command line are optional.
    * See the link to the `nRF Connect for Visual Studio Code`_ documentation site for basic instructions on building with the extension.
    * If the sample uses a non-standard setup, point it out and link to more information, if possible.

--- a/doc/nrf/ug_bt_fast_pair.rst
+++ b/doc/nrf/ug_bt_fast_pair.rst
@@ -61,7 +61,7 @@ You must provide the following CMake options:
 
 The ``bt_fast_pair`` partition address is provided automatically by the build system.
 
-For example, when building an application with |VSC|, you need to add the following parameters in the :guilabel:`Extra CMake arguments` field on :guilabel:`Add Build Configuration`: ``-DFP_MODEL_ID=0xFFFFFF -DFP_ANTI_SPOOFING_KEY=AbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbA=``.
+For example, when building an application with the |nRFVSC|, you need to add the following parameters in the :guilabel:`Extra CMake arguments` field on :guilabel:`Add Build Configuration`: ``-DFP_MODEL_ID=0xFFFFFF -DFP_ANTI_SPOOFING_KEY=AbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbA=``.
 Make sure to replace ``0xFFFFFF`` and ``AbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbAbA=`` with values obtained for your device.
 See :ref:`cmake_options` for more information about defining CMake options.
 

--- a/doc/nrf/ug_edge_impulse.rst
+++ b/doc/nrf/ug_edge_impulse.rst
@@ -86,7 +86,7 @@ Complete the following steps to configure the building process:
      If the URI requires providing an additional API key, you can provide it using the :c:macro:`EI_API_KEY_HEADER` CMake definition.
      The API key is provided using a format in which *key_name* is followed by *key_value*.
      For example, ``api-key:aaaabbbbccccdddd``, where ``aaaabbbbccccdddd`` is a sample *key_value*.
-     See :ref:`cmake_options` for more information about defining CMake options for command line builds and |VSC|.
+     See :ref:`cmake_options` for more information about defining CMake options for command line builds and the |nRFVSC|.
 
 Downloading model directly from Edge Impulse studio
 ---------------------------------------------------

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -410,7 +410,7 @@ Using |VSC|
 
 |vsc_extension_instructions|
 
-You can build and program separate images or combined images using |VSC|.
+You can build and program separate images or combined images using the |nRFVSC|.
 
 Separate images
 ---------------
@@ -601,13 +601,13 @@ Debugging
 *********
 
 To debug the application core firmware, you need a single debug session.
-Set up the debug session as described in `Debugging an application`_ with |VSC|.
+Set up the debug session as described in `Debugging an application`_ in the |nRFVSC| documentation.
 
 To debug the firmware running on the network core, you also need to set up a separate debug session for the application core.
 
 Complete the following steps to start debugging the network core:
 
-1. Set up sessions for the application core and network core as mentioned in `Debugging an application`_ with |VSC|.
+1. Set up sessions for the application core and network core as mentioned in `Debugging an application`_.
 #. Select the appropriate CPU for debugging in each session, the nRF5340 application core and the nRF5340 network core respectively.
 #. Once both sessions are established, execute the code on the application core.
 

--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -460,7 +460,7 @@ Alternatively, add the shield in the project's :file:`CMakeLists.txt` file:
 
 	set(SHIELD nrf21540_ek)
 
-To build with |VSC|, in the :guilabel:`Extra Cmake arguments`, specify ``-DSHIELD=nrf21540_ek``.
+To build with the |nRFVSC|, specify ``-DSHIELD=nrf21540_ek`` in the :guilabel:`Extra Cmake arguments`.
 See :ref:`cmake_options`.
 
 When building for a board with an additional network core, for example nRF5340, add an additional ``-DSHIELD`` variable with the *childImageName_* parameter between ``-D`` and ``SHIELD`` to build for the network core as well.

--- a/doc/nrf/ug_thingy53.rst
+++ b/doc/nrf/ug_thingy53.rst
@@ -93,12 +93,12 @@ See :ref:`thingy53_app_update` for more detailed information about updating firm
 
 .. _thingy53_build_pgm_vscode:
 
-Building and programming using Visual Studio Code
-=================================================
+Building and programming using |VSC|
+====================================
 
 |vsc_extension_instructions|
 
-Complete the following steps after installing |VSC|:
+Complete the following steps after installing the |nRFVSC|:
 
 .. |sample_path_vsc| replace:: :file:`nrf/samples/bluetooth/peripheral_lbs`
 

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -163,12 +163,12 @@ You can choose the method based on the availability or absence of an external de
 
 .. _build_pgm_vsc:
 
-Building and programming using VS Code extension
-================================================
+Building and programming using |VSC|
+====================================
 
 |vsc_extension_instructions|
 
-Complete the following steps after installing |VSC|:
+Complete the following steps after installing the |nRFVSC|:
 
 .. |sample_path_vsc| replace:: :file:`samples/nrf9160/cloud_client`
 
@@ -198,7 +198,7 @@ Complete the following steps after installing |VSC|:
 
       If you have multiple boards connected, you are prompted to pick a device at the top of the screen.
 
-      A small notification banner appears in the bottom-right corner of VS Code to display the progress and confirm when the flash is complete.
+      A small notification banner appears in the bottom-right corner of |VSC| to display the progress and confirm when the flash is complete.
 
 .. _build_pgm_cmdline:
 

--- a/doc/nrf/ug_thread_certification.rst
+++ b/doc/nrf/ug_thread_certification.rst
@@ -73,7 +73,7 @@ Complete the following steps to prepare for the certification tests:
         cd ncs/nrf/samples/openthread/cli/
         west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG=harness/overlay-cert.conf -DCONFIG_OPENTHREAD_LIBRARY=y
 
-   * If building using Visual Studio Code, you must first `create the application <Creating an application_>`_ using the CLI sample, and then `build the application <Building an application_>`_.
+   * If building using |VSC|, you must first `create the application <Creating an application_>`_ using the CLI sample, and then `build the application <Building an application_>`_.
      Select the :file:`harness/overlay-cert.conf` overlay file in the :guilabel:`Kconfig fragment` drop-down menu and add ``CONFIG_OPENTHREAD_LIBRARY=y`` to the :guilabel:`Additional CMake arguments` text field.
 
      If the overlay file is not visible in the drop-down menu, navigate to :file:`ncs/nrf/samples/openthread/cli/harness/` and copy the :file:`overlay-cert.conf` file to :file:`ncs/nrf/samples/openthread/cli/` and try again.

--- a/doc/nrf/ug_thread_configuring.rst
+++ b/doc/nrf/ug_thread_configuring.rst
@@ -486,7 +486,7 @@ Updating the libraries without debug symbols
 
 There is a single command to update the libraries without debug symbols.
 When using the command line, run the command in the project folder.
-When using |VSC|, open a terminal and choose :guilabel:`nRF Terminal`, then run the command there.
+When using the |nRFVSC|, open a terminal and choose :guilabel:`nRF Terminal`, then run the command there.
 
 Use the following command:
 
@@ -504,7 +504,7 @@ Updating the libraries with debug symbols
 
 There is a single command to update the libraries with debug symbols.
 When using the command line, run the command in the project folder.
-When using |VSC|, open a terminal and choose :guilabel:`nRF Terminal`, then run the command there.
+When using the |nRFVSC|, open a terminal and choose :guilabel:`nRF Terminal`, then run the command there.
 
 Use the following command:
 

--- a/doc/nrf/ug_zigbee_qsg.rst
+++ b/doc/nrf/ug_zigbee_qsg.rst
@@ -7,7 +7,7 @@ Zigbee quick start guide
    :local:
    :depth: 2
 
-This guide demonstrates some of the basic concepts of the Zigbee network using the |NCS| and the |VSC| extension.
+This guide demonstrates some of the basic concepts of the Zigbee network using the |NCS| and the |nRFVSC|.
 It guides you through the installation of the required tools and programming of the required samples.
 
 Overview
@@ -99,8 +99,8 @@ Software requirements
 For this quick start guide, we will install the following software:
 
 * Toolchain Manager - An application for installing the full |NCS| toolchain.
-* Microsoft's Visual Studio Code - The recommended IDE for the |NCS|.
-* |VSC| - Extension for VS Code that allows you to develop applications for the |NCS|.
+* Microsoft's |VSC| - The recommended IDE for the |NCS|.
+* |nRFVSC| - An add-on for |VSC| that allows you to develop applications for the |NCS|.
 * nRF Command Line Tools - A set of mandatory tools for working with the |NCS|.
 * SEGGER J-Link - Tool for handling the serial connection.
 
@@ -127,12 +127,12 @@ To set up the required software, complete the following steps:
 #. Click the :guilabel:`Open VS Code` button.
    The installation wizard checks whether you have the following software installed:
 
-   * Microsoft's Visual Studio Code
-   * |VSC|
+   * Microsoft's |VSC|
+   * |nRFVSC|
    * nRF Command Line Tools (with SEGGER J-Link)
 
    If any of these items is missing, you are taken to its installation page to complete the setup.
-   At the end of the process, the VS Code main window opens.
+   At the end of the process, the |VSC| main window opens.
 
 .. rst-class:: numbered-step
 


### PR DESCRIPTION
Divided shortcuts for VSC: one for IDE, one for extension.
NCSDK-15445.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>