### PR TITLE
spm: Allow UICR to be read in non-secure applications

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -106,6 +106,13 @@ config SPM_SERVICE_READ
 	  read operations within the ranges configured in
 	  secure_services.c.
 
+config SPM_SERVICE_READ_ALLOW_UICR
+	bool "Allow non-secure firmware to read from UICR register"
+	default n
+	select SPM_SERVICE_READ
+	help
+	  Allow a Non-Secure Firmware to read the UICR registers.
+
 config SPM_SERVICE_REBOOT
 	bool "Enable system reset as a secure service"
 	default n


### PR DESCRIPTION
Previously non-secure firmware could not read from the UICR registers.
Now the SPM read service can be configured to allow this. Note that we
must handle the UICR region carefully on the nRF9160 chip as it is in
the secure flash region involved in Erratum #7.

Signed-off-by: Samuel Pell <sam@redfernsolutions.co.nz>