### PR TITLE
doc improvement:  stylistic fixes

### DIFF
--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -51,6 +51,7 @@ The installation process is different depending on your operating system.
          :dedent: 6
          :start-after: .. _install_dependencies_windows:
          :end-before: #. Close the window and open a new
+
       Ensure that these dependencies are installed with their versions as specified in the :ref:`Required tools table <req_tools_table>`.
 
    .. group-tab:: Linux

--- a/doc/nrf/ug_nrf9160_gs.rst
+++ b/doc/nrf/ug_nrf9160_gs.rst
@@ -151,7 +151,7 @@ If you experience any problems during the process, restart the Programmer app by
 
    If the three COM ports are not visible, press ``Ctrl+R`` in Windows or ``command+R`` in macOS to restart the Programmer application.
 
-   The drop-down text changes to the type of the selected device, with the SEGGER ID below the name.
+   The drop-down text changes to the type of the selected device, with its SEGGER ID below the name.
    The :guilabel:`Device Memory Layout` section also changes its name to the device name, and indicates that the device is connected.
    If the :guilabel:`Auto read memory` option is selected in the :guilabel:`Device` section of the side panel, the memory layout will update.
    If it is not selected and you wish to see the memory layout, click :guilabel:`Read` in the :guilabel:`Device` section of the side panel.
@@ -207,17 +207,17 @@ Creating an nRF Cloud account
 
 To create an nRF Cloud account, complete the following steps:
 
-1. Go to `nRF Cloud`_ and click :guilabel:`Register`.
+1. Open the `nRF Cloud`_ landing page and click :guilabel:`Register`.
 #. Enter your email address and choose a password, then click :guilabel:`Create Account`.
    nRF Cloud will send you a verification email.
 #. Copy the 6-digit verification code and paste it into the registration dialog box.
-   If you do not see the verification email, check your junk mail for an email from no-reply@verificationemail.com.
+   If you do not see the verification email, check your junk mail for an email from ``no-reply@verificationemail.com``.
 
    If you closed the registration dialog box, you can repeat Step 1 and then click :guilabel:`Already have a code?`.
    Then enter your email and the verification code.
 
-You can now sign in on `nRF Cloud`_ with your email and the password you chose.
-After signing in, you are taken to the dashboard view that displays your device count and service usage.
+You can now log in with your email and the password you chose.
+After logging in, you are taken to the dashboard view that displays your device count and service usage.
 
 .. _nrf9160_gs_connect_to_cloud:
 
@@ -234,7 +234,7 @@ To transmit data from your nRF9160 DK to nRF Cloud, you must activate your SIM c
 
 Complete the following steps:
 
-1. Go to `nRF Cloud`_ and sign in.
+1. Log in to the `nRF Cloud`_ portal.
 #. Click the :guilabel:`+` icon in the top left corner.
    The :guilabel:`Add New` window appears.
 
@@ -314,7 +314,7 @@ The application programmed in the DK is :ref:`asset_tracker_v2`, and it is used 
 For a basic test, complete the following steps:
 
 1. Turn on or reset your nRF9160 DK.
-#. Go to `nRF Cloud`_ and sign in.
+#. Log in to the `nRF Cloud`_ portal.
 #. Click :guilabel:`Devices` under :guilabel:`Device Management` in the navigation pane on the left.
 
    .. figure:: /images/nrfcloud_devices.png
@@ -352,7 +352,7 @@ Testing the GNSS functionality
 To achieve the fastest Time To First Fix of GNSS position, the following conditions need to be met:
 
 * The device must be able to connect to nRF Cloud.
-  You can confirm this by checking whether the status of your DK is displayed correctly on nRF Cloud.
+  You can confirm this by checking whether the status of your DK is displayed correctly on the nRF Cloud portal.
   The cloud connection is used to download GPS assistance data.
 * Your network operator should support Power Saving Mode (PSM) or Extended Discontinuous Reception (eDRX) with the SIM card that you are using.
   If you are using an iBasis SIM card, check the `iBasis network coverage spreadsheet`_ to see the supported features and network coverage for different countries.
@@ -367,7 +367,7 @@ Complete the following steps to test the GNSS functionality:
 1. If you have an external antenna for your nRF9160 DK, attach it to connector **J2** to the left of the LTE antenna.
    See `nRF9160 DK GPS`_ for more information.
 #. Turn on or reset your DK.
-#. Go to `nRF Cloud`_ and sign in.
+#. Log in to the `nRF Cloud`_ portal.
 #. Click :guilabel:`Devices` under :guilabel:`Device Management` in the navigation pane on the left.
 
    .. figure:: /images/nrfcloud_devices.png

--- a/doc/nrf/ug_thingy91_gsg.rst
+++ b/doc/nrf/ug_thingy91_gsg.rst
@@ -442,7 +442,7 @@ You must sign up with `nRF Cloud`_ before you can start using the service.
 
 To create an nRF Cloud account, complete the following steps:
 
-1. Go to `nRF Cloud`_ and click :guilabel:`Register`.
+1. Open the `nRF Cloud`_ landing page and click :guilabel:`Register`.
 #. Enter your email address and choose a password, then click :guilabel:`Create Account`.
    nRF Cloud will send you a verification email.
 #. Copy the 6-digit verification code and paste it into the registration dialog box.
@@ -451,8 +451,8 @@ To create an nRF Cloud account, complete the following steps:
    If you closed the registration dialog box, you can repeat Step 1 and then click :guilabel:`Already have a code?`.
    Then enter your email and the verification code.
 
-You can now sign in on `nRF Cloud`_ with your email and the password your chose.
-After signing in, you are directed to the dashboard view that displays your device count and service usage.
+You can now log in to `nRF Cloud`_ with your email and the password your chose.
+After logging in, you are directed to the dashboard view that displays your device count and service usage.
 Next, you need to activate the SIM card for the Thingy:91.
 
 Activating the iBasis SIM card
@@ -485,7 +485,7 @@ To activate the SIM card, complete the following steps:
 
          Inserting SIM
 
-#. Sign in to nRF Cloud.
+#. Log in to the nRF Cloud portal.
 #. Click the large plus sign in the upper-left corner.
    The :guilabel:`Add New` window appears.
 
@@ -530,7 +530,7 @@ complete the following steps:
    After a few moments, the nRF Cloud user association process starts.
    This is indicated by white double pulse blinking of the Thingy:91's RGB LED as indicated in :ref:`Operating states <led_indication>`.
 
-#. To complete the user association, navigate to `nRF Cloud`_.
+#. To complete the user association, open the `nRF Cloud`_ portal.
 #. Click the large plus sign in the upper-left corner.
    The :guilabel:`Add New` window appears.
 
@@ -574,7 +574,7 @@ complete the following steps:
 
    .. note::
 
-      If you see an error message, check the error code and see `nRF Cloud REST API (v1)`_ in nRF Cloud to find out what is causing the error.
+      If you see an error message, check the error code and see `nRF Cloud REST API (v1)`_ to find out what is causing the error.
 
 #. When the message has disappeared, go to the menu on the left and click :guilabel:`Devices`.
 
@@ -583,7 +583,7 @@ complete the following steps:
 
    .. note::
 
-      It might take a while for the sensor data to appear in the nRF Cloud UI, depending on the duration of time GNSS uses to search for a fix.
+      It might take a while for the sensor data to appear in the nRF Cloud portal, depending on the duration of time GNSS uses to search for a fix.
 
 Next steps
 **********


### PR DESCRIPTION
Making a clickable (no-reply) email address non-clickable and
rephrasing some nRF Cloud items.
Also adding a missing empty line to get rid of build warnings.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>