### PR TITLE
tests: event_manager_proxy: Configure OpenAMP to work on preemptive p…

### DIFF
--- a/tests/subsys/event_manager_proxy/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/subsys/event_manager_proxy/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <dt-bindings/ipc_service/static_vrings.h>
+
+&ipc0 {
+	zephyr,priority = <0 PRIO_PREEMPT>;
+};

--- a/tests/subsys/event_manager_proxy/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/tests/subsys/event_manager_proxy/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <dt-bindings/ipc_service/static_vrings.h>
+
+&ipc0 {
+	zephyr,priority = <0 PRIO_PREEMPT>;
+};


### PR DESCRIPTION
…riority

This commit fixes the issue provided zephyrproject-rtos/zephyr#7f51907.
This test pushes the IPC to the limit and having it on cooperative
priority level by default starves the thread that should consume
and process the events that was received.