### PR TITLE
lib: modem_key_mgmt: don't read CME error if `nrf_modem_at_cmd` failed

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -195,7 +195,12 @@ Bootloader libraries
 Modem libraries
 ---------------
 
-|no_changes_yet_note|
+* Updated:
+
+  * :ref:`modem_key_mgmt` library:
+
+    * Fixed:
+      * An issue that would cause the library to assert on a unhandled CME error when the AT command failed to be sent.
 
 Libraries for networking
 ------------------------


### PR DESCRIPTION
Do not attempt to extract the CME error from the return value in case of errors in `nrf_modem_at_cmd()`, which are returned from the library (negatitve errnos), such as `-ESHUTDOWN` when the modem crashed, as it would not be possible to extract a valid CME error from it, and invalid CME errors are caught by an assert in the `modem_key_mgmt` library.