### PR TITLE
net: lib: nrf_cloud: add fota validation function 

### DIFF
--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -14,6 +14,7 @@
 #endif /* CONFIG_NRF_MODEM_LIB */
 #include <zephyr/sys/reboot.h>
 #include <net/lwm2m_client_utils_fota.h>
+#include <net/nrf_cloud.h>
 
 #if defined(CONFIG_NRF_CLOUD_AGPS) || defined(CONFIG_NRF_CLOUD_PGPS)
 #include <net/nrf_cloud_agps.h>
@@ -241,6 +242,11 @@ static void handle_nrf_modem_lib_init_ret(void)
 		LOG_ERR("nRF modem lib initialization failed, error: %d", ret);
 		break;
 	}
+
+#if defined(CONFIG_NRF_CLOUD_FOTA)
+	/* Ignore return value, rebooting below */
+	(void)nrf_cloud_fota_pending_job_validate(NULL);
+#endif
 
 	LOG_WRN("Rebooting...");
 	LOG_PANIC();

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -102,6 +102,7 @@ nRF9160: Asset Tracker v2
   * Fixed:
 
     * An issue that reports GNSS altitude, accuracy, and speed incorrectly when using LwM2M engine.
+    * An issue that caused modem FOTA jobs to be reported as not validated to nRF Cloud.
 
 nRF9160: Serial LTE modem
 -------------------------
@@ -177,7 +178,7 @@ nRF9160 samples
 
     * Default configuration conforms to the LwM2M specification v1.0 instead of v1.1.
       For enabling v1.1 there is already an overlay file.
-    * Bootstrap is not TLV only anymore. 
+    * Bootstrap is not TLV only anymore.
       With v1.1, preferred content format is sent in the bootstrap request.
       SenML CBOR takes precedence over SenML JSON and OMA TLV, when enabled.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -320,6 +320,8 @@ Libraries for networking
     * Added:
 
       * :c:func:`nrf_cloud_fota_pending_job_validate` function that enables an application to validate a pending FOTA job before initializing the :ref:`lib_nrf_cloud` library.
+      * Handling for new nRF Cloud REST error code 40499.
+        Moved the error log from the :c:func:`nrf_cloud_parse_rest_error` function into the calling function.
 
 Libraries for NFC
 -----------------

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -313,7 +313,12 @@ Libraries for networking
   * :ref:`lib_nrf_cloud` library:
 
     * Fixed:
+
       * An issue that caused the application to receive multiple disconnect events.
+
+    * Added:
+
+      * :c:func:`nrf_cloud_fota_pending_job_validate` function that enables an application to validate a pending FOTA job before initializing the :ref:`lib_nrf_cloud` library.
 
 Libraries for NFC
 -----------------

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -144,7 +144,7 @@ enum nrf_cloud_connect_result {
 enum nrf_cloud_error {
 	NRF_CLOUD_ERROR_UNKNOWN			= -1,
 	NRF_CLOUD_ERROR_NONE			= 0,
-	/* nRF Cloud API error codes */
+	/** nRF Cloud API error codes */
 	NRF_CLOUD_ERROR_BAD_REQUEST		= 40000,
 	NRF_CLOUD_ERROR_INVALID_CERT		= 40001,
 	NRF_CLOUD_ERROR_DISSOCIATE		= 40002,
@@ -157,6 +157,8 @@ enum nrf_cloud_error {
 	NRF_CLOUD_ERROR_NO_DEV_NOT_PROV		= 40412,
 	NRF_CLOUD_ERROR_NO_DEV_DISSOCIATE	= 40413,
 	NRF_CLOUD_ERROR_NO_DEV_DELETE		= 40414,
+	/** Item was not found. No error occured, the requested item simply does not exist */
+	NRF_CLOUD_ERROR_NOT_FOUND_NO_ERROR	= 40499,
 	NRF_CLOUD_ERROR_BAD_RANGE		= 41600,
 	NRF_CLOUD_ERROR_VALIDATION		= 42200,
 	NRF_CLOUD_ERROR_INTERNAL_SERVER		= 50010,

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -650,7 +650,7 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char * const jwt_buf, size_t j
  *
  * @retval 0       A Pending FOTA job has been processed.
  * @retval -ENODEV No pending/unvalidated FOTA job exists.
- * @return A negative value indicates an error.
+ * @retval -ENOENT Error; unknown FOTA job type.
  */
 int nrf_cloud_pending_fota_job_process(struct nrf_cloud_settings_fota_job * const job,
 				       bool * const reboot_required);
@@ -688,6 +688,25 @@ int nrf_cloud_handle_error_message(const char *const buf,
 				   const char *const app_id,
 				   const char *const msg_type,
 				   enum nrf_cloud_error *const err);
+
+/**
+ * @brief Function to validate a pending FOTA installation before initializing this library.
+ *        This function enables the application to control the reboot/reinit process during FOTA
+ *        updates. If this function is not called directly by the application, it will
+ *        be called internally when @ref nrf_cloud_init is executed.
+ *        Depends on CONFIG_NRF_CLOUD_FOTA.
+ *
+ * @param[out] fota_type_out FOTA type of pending job.
+ *                           NRF_CLOUD_FOTA_TYPE__INVALID if no pending job.
+ *                           Can be NULL.
+ *
+ * @retval 0 Pending FOTA job processed.
+ * @retval 1 Pending FOTA job processed and requires the application to perform a reboot or,
+ *           for NRF_CLOUD_FOTA_MODEM types, reinitialization of the modem library.
+ * @retval -ENODEV No pending/unvalidated FOTA job exists.
+ * @retval -ENOENT Error; unknown FOTA job type.
+ */
+int nrf_cloud_fota_pending_job_validate(enum nrf_cloud_fota_type * const fota_type_out);
 
 /** @} */
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -1658,7 +1658,6 @@ int nrf_cloud_parse_rest_error(const char *const buf, enum nrf_cloud_error *cons
 	if (cJSON_IsNumber(err_obj)) {
 		ret = 0;
 		*err = (enum nrf_cloud_error)cJSON_GetNumberValue(err_obj);
-		LOG_ERR("nRF Cloud REST error code: %d", *err);
 	}
 
 cleanup:

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -259,6 +259,11 @@ static int do_rest_client_request(struct nrf_cloud_rest_context *const rest_ctx,
 	if ((ret == 0) && (rest_ctx->status >= NRF_CLOUD_HTTP_STATUS__ERROR_BEGIN) &&
 	    rest_ctx->response && rest_ctx->response_len) {
 		(void)nrf_cloud_parse_rest_error(rest_ctx->response, &rest_ctx->nrf_err);
+
+		if ((rest_ctx->nrf_err != NRF_CLOUD_ERROR_NONE) &&
+		    (rest_ctx->nrf_err != NRF_CLOUD_ERROR_NOT_FOUND_NO_ERROR)) {
+			LOG_ERR("nRF Cloud REST error code: %d", rest_ctx->nrf_err);
+		}
 	}
 
 	if (ret) {


### PR DESCRIPTION
Add function to validate a FOTA job prior to initializing
the nrf_cloud library. This allows applications to control
the reboot/modem lib reinit process.

For atv2, properly validate an nrf cloud modem FOTA job after checking
modem lib init status.
CIA-656

Also including a trivial FOTA related commit for REST error code processing.
IRIS-4451