### PR TITLE
zigbee: Increase UT stability by rounding inteval

### DIFF
--- a/tests/subsys/zigbee/osif/timer_counter/src/main.c
+++ b/tests/subsys/zigbee/osif/timer_counter/src/main.c
@@ -10,6 +10,7 @@
 #include <zb_osif_platform.h>
 
 #define ZB_BEACON_INTERVAL_USEC 15360
+#define ZB_BEACON_INTERVAL_MSEC ((ZB_BEACON_INTERVAL_USEC + 1000 - 1) / 1000)
 
 static zb_uint32_t alarm_counter;
 
@@ -44,7 +45,7 @@ static void test_zb_osif_timer(void)
 	ZB_START_HW_TIMER();
 	uint32_t alarm_count = GetAlarmCount();
 
-	k_usleep(ZB_BEACON_INTERVAL_USEC);
+	k_usleep(ZB_BEACON_INTERVAL_MSEC * 1000);
 	uint32_t new_alarm_count = GetAlarmCount();
 
 	zassert_true((alarm_count != new_alarm_count),

--- a/tests/subsys/zigbee/osif/timer_ktimer/src/main.c
+++ b/tests/subsys/zigbee/osif/timer_ktimer/src/main.c
@@ -10,6 +10,7 @@
 #include <zb_osif_platform.h>
 
 #define ZB_BEACON_INTERVAL_USEC 15360
+#define ZB_BEACON_INTERVAL_MSEC ((ZB_BEACON_INTERVAL_USEC + 1000 - 1) / 1000)
 
 static void test_zb_osif_timer(void)
 {
@@ -33,7 +34,7 @@ static void test_zb_osif_timer(void)
 	ZB_START_HW_TIMER();
 	uint32_t time_start_bi = zb_timer_get();
 
-	k_usleep(ZB_BEACON_INTERVAL_USEC);
+	k_usleep(ZB_BEACON_INTERVAL_MSEC * 1000);
 	uint32_t time_stop_bi = zb_timer_get();
 
 	zassert_true((time_stop_bi == time_start_bi + 1),


### PR DESCRIPTION
Sleep for a Beacon Interval time, rounded up to a 1ms, so in case of any 1us precision loss in `k_usleep(..)` the test will not fail.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>