### PR TITLE
zigbee: Align PAN ID conflict resolution APIs

### DIFF
--- a/doc/nrf/libraries/zigbee/zigbee_app_utils.rst
+++ b/doc/nrf/libraries/zigbee/zigbee_app_utils.rst
@@ -466,6 +466,10 @@ To enable the Zigbee application utilities library, set the :kconfig:option:`CON
 Logging
     To configure the logging level of the library, use the :kconfig:option:`CONFIG_ZIGBEE_APP_UTILS_LOG_LEVEL` Kconfig option.
 
+Automatic PAN ID conflict resolution
+    To enable automatic PAN ID conflict resolution, use the :kconfig:option:`CONFIG_ZIGBEE_PANID_CONFLICT_RESOLUTION` Kconfig option.
+    This option is enabled by default.
+
 Factory reset button
     To configure the time of the button press that initiates the device factory reset, use the :kconfig:option:`CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS` Kconfig option.
     This option is set to 5 seconds by default.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -74,7 +74,10 @@ See `Thread samples`_ for the list of changes for the Thread samples.
 Zigbee
 ------
 
-|no_changes_yet_note|
+* Updated:
+
+  * Enabled the PAN ID conflict resolution in applications that uses :ref:`lib_zigbee_application_utilities` library.
+    For details, see `Libraries for Zigbee`_.
 
 See `Zigbee samples`_ for the list of changes for the Zigbee samples.
 
@@ -230,7 +233,10 @@ Shell libraries
 Libraries for Zigbee
 --------------------
 
-|no_changes_yet_note|
+* :ref:`lib_zigbee_application_utilities` library:
+
+  * Added :kconfig:option:`CONFIG_ZIGBEE_PANID_CONFLICT_RESOLUTION` for enabling automatic PAN ID conflict resolution.
+    This option is enabled by default.
 
 Shell libraries
 ---------------

--- a/samples/zigbee/shell/src/main.c
+++ b/samples/zigbee/shell/src/main.c
@@ -213,9 +213,6 @@ void zboss_signal_handler(zb_bufid_t bufid)
 		} else {
 			LOG_ERR("Unable to leave network (status: %d)", status);
 		}
-		if (!IS_ENABLED(CONFIG_ZIGBEE_ROLE_END_DEVICE)) {
-			zb_enable_auto_pan_id_conflict_resolution(ZB_FALSE);
-		}
 		break;
 	default:
 		/* Call default signal handler. */

--- a/subsys/zigbee/lib/zigbee_app_utils/Kconfig
+++ b/subsys/zigbee/lib/zigbee_app_utils/Kconfig
@@ -20,6 +20,10 @@ module = ZIGBEE_APP_UTILS
 module-str = Zigbee application utilities
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
+config ZIGBEE_PANID_CONFLICT_RESOLUTION
+	bool "Enable automatic PAN ID conflict resolution"
+	default y
+
 menuconfig ZIGBEE_FACTORY_RESET
 	bool "Enable API for Zigbee factory reset"
 	default y

--- a/subsys/zigbee/lib/zigbee_app_utils/zigbee_app_utils.c
+++ b/subsys/zigbee/lib/zigbee_app_utils/zigbee_app_utils.c
@@ -228,6 +228,7 @@ zb_ret_t zigbee_default_signal_handler(zb_bufid_t bufid)
 		ZB_ERROR_CHECK(zb_zcl_set_backward_comp_mode(ZB_ZCL_AUTO_MODE));
 		ZB_ERROR_CHECK(
 			zb_zcl_set_backward_compatible_statuses_mode(ZB_ZCL_STATUSES_ZCL8_MODE));
+		zb_enable_panid_conflict_resolution(CONFIG_ZIGBEE_PANID_CONFLICT_RESOLUTION);
 		stack_initialised = true;
 		LOG_INF("Zigbee stack initialized");
 		comm_status = bdb_start_top_level_commissioning(
@@ -351,9 +352,6 @@ zb_ret_t zigbee_default_signal_handler(zb_bufid_t bufid)
 					status);
 			}
 		}
-		if (!IS_ENABLED(CONFIG_ZIGBEE_ROLE_END_DEVICE)) {
-			zb_enable_auto_pan_id_conflict_resolution(ZB_FALSE);
-		}
 		break;
 
 	case ZB_BDB_SIGNAL_FORMATION:
@@ -433,9 +431,6 @@ zb_ret_t zigbee_default_signal_handler(zb_bufid_t bufid)
 			}
 		} else {
 			LOG_ERR("Unable to leave network (status: %d)", status);
-		}
-		if (!IS_ENABLED(CONFIG_ZIGBEE_ROLE_END_DEVICE)) {
-			zb_enable_auto_pan_id_conflict_resolution(ZB_FALSE);
 		}
 		break;
 


### PR DESCRIPTION
Add the Kconfig option to enable automatic PAN ID conflict resolution.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>