### PR TITLE
application: serial_lte_modem: Support socket receive flags

### DIFF
--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -950,10 +950,17 @@ Syntax
 
 ::
 
-   #XRECV=<timeout>
+   #XRECV=<timeout>[,<flags>]
 
-* The ``<timeout>`` value sets the timeout value in seconds.
-  ``0`` means no timeout, and it makes this request become blocking.
+The ``<timeout>`` value sets the timeout value in seconds.
+When ``0``, it means no timeout, and it makes this request become blocking.
+
+The ``<flags>`` value sets the receiving behavior based on the BSD socket definition.
+It can be set to one of the following values:
+
+* ``2`` means reading data without removing it from the socket input queue.
+* ``64`` means overriding the operation to non-blocking.
+* ``256`` (TCP only) means blocking until the full amount of data can be returned.
 
 Response syntax
 ~~~~~~~~~~~~~~~
@@ -1057,10 +1064,16 @@ Syntax
 
 ::
 
-   #XRECVFROM=<timeout>
+   #XRECVFROM=<timeout>[,<flags>]
 
-* The ``<timeout>`` value sets the timeout value in seconds.
-  ``0`` means no timeout, and it makes this request become blocking.
+The ``<timeout>`` value sets the timeout value in seconds.
+When ``0``, it means no timeout, and it makes this request become blocking.
+
+The ``<flags>`` value sets the receiving behavior based on the BSD socket definition.
+It can be set to one of the following values:
+
+* ``2`` means reading data without removing it from the socket input queue.
+* ``64`` means overriding the operation to non-blocking.
 
 Response syntax
 ~~~~~~~~~~~~~~~

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -120,6 +120,7 @@ nRF9160: Serial LTE modem
   * Added:
 
     * URC for GNSS sleep and wakeup events.
+    * Selected flags support in #XRECV and #XRECVFROM commands
 
 nRF5340 Audio
 -------------


### PR DESCRIPTION
Support the flags that are supported in nrf_socket for command
XRECV and XRECVFROM:
.2     MSG_PEEK 0x02
.64   MSG_DONTWAIT 0x40 (if operation would block, returns ERROR)
.256 MSG_WAITALL 0x100 (apply to TCP socket only)

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>