### PR TITLE
boards/arm: Add MCUbootr's button and led aliases

### DIFF
--- a/boards/arm/nrf52820dongle_nrf52820/nrf52820dongle_nrf52820.dts
+++ b/boards/arm/nrf52820dongle_nrf52820/nrf52820dongle_nrf52820.dts
@@ -57,6 +57,8 @@
 		led1-red   = &led1_red;
 		led1-green = &led1_green;
 		led1-blue  = &led1_blue;
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led1_blue;
 	};
 };
 

--- a/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.dts
+++ b/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.dts
@@ -57,6 +57,8 @@
 		led1-red   = &led1_red;
 		led1-green = &led1_green;
 		led1-blue  = &led1_blue;
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led1_blue;
 	};
 };
 

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_shared.dts
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_shared.dts
@@ -129,5 +129,7 @@ leds:	leds {
 		sw2 = &button3;
 		sw3 = &button4;
 		sw4 = &button5;
+		mcuboot-led0 = &led1_blue;
+		mcuboot-button0 = &button3;
 	};
 };

--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -103,6 +103,8 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
@@ -85,6 +85,7 @@
 		rgb-pwm = &pwm0;
 		nmos-pwm = &pwm2;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &blue_led;
 	};
 };
 


### PR DESCRIPTION
Added alias for the button's gpio pin which might be used by MCUboot.
Added alias (mcuboot-led0) for the LED gpio pin which might be
used by MCUboot.

This patch follows
https://github.com/zephyrproject-rtos/zephyr/pull/44741
New aliases will be used thanks to future inheritance of the upstream PR:
https://github.com/mcu-tools/mcuboot/pull/1344

fixes: NCSDK-16967

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>