### PR TITLE
matter: rebase sdk-connectedhomeip

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -121,7 +121,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.0.0
+      revision: 7a4b10cc5bb5b51c0e775b7813e7d5e709235a04
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Rebase sdk-connectedhomeip after the last release to simplify future upmerges.
Update sdk-connectedhomeip to ToT.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>