### PR TITLE
samples: nrf9160: modem_shell: command for setting reference altitude

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -139,6 +139,8 @@ nRF9160 samples
 
     * nRF9160 DK overlays for enabling BT support.
       When running this configuration, you can perform BT scanning and advertising using the ``bt`` command.
+    * Support for injecting GNSS reference altitude for low accuracy mode.
+      For a position fix using only three satellites, GNSS module must have a reference altitude that can now be injected using the ``gnss agps ref_altitude`` command.
 
 Thread samples
 --------------


### PR DESCRIPTION
New command "gnss agps ref_altitude" for setting the reference
altitude required for 3-satellite fixes.

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>