### PR TITLE
bluetooth: fast_pair: Add missing const to bt_conn struct pointer

### DIFF
--- a/subsys/bluetooth/services/fast_pair/fp_auth.c
+++ b/subsys/bluetooth/services/fast_pair/fp_auth.c
@@ -34,12 +34,12 @@ static uint32_t handled_conn_bm;
 
 static void update_bt_auth_callbacks(void);
 
-static bool is_conn_handled(struct bt_conn *conn)
+static bool is_conn_handled(const struct bt_conn *conn)
 {
 	return ((handled_conn_bm & BIT(bt_conn_index(conn))) != 0);
 }
 
-static void update_conn_handling(struct bt_conn *conn, bool handled)
+static void update_conn_handling(const struct bt_conn *conn, bool handled)
 {
 	size_t conn_idx = bt_conn_index(conn);
 

--- a/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
+++ b/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
@@ -128,7 +128,7 @@ static ssize_t read_model_id(struct bt_conn *conn,
 	return res;
 }
 
-static int parse_key_based_pairing_req(struct bt_conn *conn,
+static int parse_key_based_pairing_req(const struct bt_conn *conn,
 				       struct msg_key_based_pairing_req *parsed_req,
 				       struct net_buf_simple *req)
 {
@@ -218,7 +218,8 @@ static int handle_key_based_pairing_req(struct bt_conn *conn,
 	return 0;
 }
 
-static int validate_key_based_pairing_req(struct bt_conn *conn, const uint8_t *req, void *context)
+static int validate_key_based_pairing_req(const struct bt_conn *conn, const uint8_t *req,
+					  void *context)
 {
 	struct msg_key_based_pairing_req *parsed_req = context;
 	struct net_buf_simple req_net_buf;

--- a/subsys/bluetooth/services/fast_pair/fp_keys.c
+++ b/subsys/bluetooth/services/fast_pair/fp_keys.c
@@ -39,7 +39,7 @@ struct fp_procedure {
 };
 
 struct fp_key_gen_account_key_check_context {
-	struct bt_conn *conn;
+	const struct bt_conn *conn;
 	struct fp_keys_keygen_params *keygen_params;
 };
 
@@ -83,7 +83,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-int fp_keys_encrypt(struct bt_conn *conn, uint8_t *out, const uint8_t *in)
+int fp_keys_encrypt(const struct bt_conn *conn, uint8_t *out, const uint8_t *in)
 {
 	struct fp_procedure *proc = &fp_procedures[bt_conn_index(conn)];
 	int err = 0;
@@ -106,7 +106,7 @@ int fp_keys_encrypt(struct bt_conn *conn, uint8_t *out, const uint8_t *in)
 	return err;
 }
 
-int fp_keys_decrypt(struct bt_conn *conn, uint8_t *out, const uint8_t *in)
+int fp_keys_decrypt(const struct bt_conn *conn, uint8_t *out, const uint8_t *in)
 {
 	struct fp_procedure *proc = &fp_procedures[bt_conn_index(conn)];
 	int err = 0;
@@ -129,7 +129,8 @@ int fp_keys_decrypt(struct bt_conn *conn, uint8_t *out, const uint8_t *in)
 	return err;
 }
 
-static int key_gen_public_key(struct bt_conn *conn, struct fp_keys_keygen_params *keygen_params)
+static int key_gen_public_key(const struct bt_conn *conn,
+			      struct fp_keys_keygen_params *keygen_params)
 {
 	int err;
 	struct fp_procedure *proc = &fp_procedures[bt_conn_index(conn)];
@@ -165,7 +166,7 @@ static bool key_gen_account_key_check(const uint8_t *account_key, void *context)
 	int err;
 	uint8_t req[FP_CRYPTO_AES128_BLOCK_LEN];
 	struct fp_key_gen_account_key_check_context *ak_check_context = context;
-	struct bt_conn *conn = ak_check_context->conn;
+	const struct bt_conn *conn = ak_check_context->conn;
 	struct fp_keys_keygen_params *keygen_params = ak_check_context->keygen_params;
 	struct fp_procedure *proc = &fp_procedures[bt_conn_index(conn)];
 
@@ -184,7 +185,8 @@ static bool key_gen_account_key_check(const uint8_t *account_key, void *context)
 	return true;
 }
 
-static int key_gen_account_key(struct bt_conn *conn, struct fp_keys_keygen_params *keygen_params)
+static int key_gen_account_key(const struct bt_conn *conn,
+			       struct fp_keys_keygen_params *keygen_params)
 {
 	struct fp_key_gen_account_key_check_context context = {
 		.conn = conn,
@@ -197,7 +199,7 @@ static int key_gen_account_key(struct bt_conn *conn, struct fp_keys_keygen_param
 	return fp_storage_account_key_find(NULL, key_gen_account_key_check, &context);
 }
 
-int fp_keys_generate_key(struct bt_conn *conn, struct fp_keys_keygen_params *keygen_params)
+int fp_keys_generate_key(const struct bt_conn *conn, struct fp_keys_keygen_params *keygen_params)
 {
 	struct fp_procedure *proc = &fp_procedures[bt_conn_index(conn)];
 	int err = 0;
@@ -241,7 +243,7 @@ int fp_keys_generate_key(struct bt_conn *conn, struct fp_keys_keygen_params *key
 	return err;
 }
 
-int fp_keys_store_account_key(struct bt_conn *conn, const uint8_t *account_key)
+int fp_keys_store_account_key(const struct bt_conn *conn, const uint8_t *account_key)
 {
 	struct fp_procedure *proc = &fp_procedures[bt_conn_index(conn)];
 	int err = 0;
@@ -268,7 +270,7 @@ int fp_keys_store_account_key(struct bt_conn *conn, const uint8_t *account_key)
 	return err;
 }
 
-void fp_keys_bt_auth_progress(struct bt_conn *conn, bool authenticated)
+void fp_keys_bt_auth_progress(const struct bt_conn *conn, bool authenticated)
 {
 	struct fp_procedure *proc = &fp_procedures[bt_conn_index(conn)];
 
@@ -280,7 +282,7 @@ void fp_keys_bt_auth_progress(struct bt_conn *conn, bool authenticated)
 	}
 }
 
-void fp_keys_drop_key(struct bt_conn *conn)
+void fp_keys_drop_key(const struct bt_conn *conn)
 {
 	invalidate_key(&fp_procedures[bt_conn_index(conn)]);
 }

--- a/subsys/bluetooth/services/fast_pair/include/fp_keys.h
+++ b/subsys/bluetooth/services/fast_pair/include/fp_keys.h
@@ -35,7 +35,7 @@ extern "C" {
  *
  * @return 0 If the decrypted request is valid. Otherwise, a (negative) error code is returned.
  */
-typedef int (*fp_keys_validate_cb)(struct bt_conn *conn, const uint8_t *req, void *context);
+typedef int (*fp_keys_validate_cb)(const struct bt_conn *conn, const uint8_t *req, void *context);
 
 /** @brief Fast Pair keys key generation parameters. */
 struct fp_keys_keygen_params {
@@ -68,7 +68,7 @@ struct fp_keys_keygen_params {
  *
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
-int fp_keys_encrypt(struct bt_conn *conn, uint8_t *out, const uint8_t *in);
+int fp_keys_encrypt(const struct bt_conn *conn, uint8_t *out, const uint8_t *in);
 
 /** Decrypt request from the Fast Pair Seeker.
  *
@@ -82,7 +82,7 @@ int fp_keys_encrypt(struct bt_conn *conn, uint8_t *out, const uint8_t *in);
  *
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
-int fp_keys_decrypt(struct bt_conn *conn, uint8_t *out, const uint8_t *in);
+int fp_keys_decrypt(const struct bt_conn *conn, uint8_t *out, const uint8_t *in);
 
 /** Generate Fast Pair key for a given Fast Pair Seeker.
  *
@@ -94,7 +94,7 @@ int fp_keys_decrypt(struct bt_conn *conn, uint8_t *out, const uint8_t *in);
  *
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
-int fp_keys_generate_key(struct bt_conn *conn, struct fp_keys_keygen_params *keygen_params);
+int fp_keys_generate_key(const struct bt_conn *conn, struct fp_keys_keygen_params *keygen_params);
 
 /** Store Account Key of a given Fast Pair Seeker in non-volatile memory.
  *
@@ -103,7 +103,7 @@ int fp_keys_generate_key(struct bt_conn *conn, struct fp_keys_keygen_params *key
  *
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
-int fp_keys_store_account_key(struct bt_conn *conn, const uint8_t *account_key);
+int fp_keys_store_account_key(const struct bt_conn *conn, const uint8_t *account_key);
 
 /** Inform Fast Pair Keys about the progress of the Bluetooth authentication procedure.
  *
@@ -113,7 +113,7 @@ int fp_keys_store_account_key(struct bt_conn *conn, const uint8_t *account_key);
  * @param[in] conn		Pointer to Bluetooth connection (determines Fast Pair Seeker).
  * @param[in] authenticated	Boolean informing if connection was already authenticated.
  */
-void fp_keys_bt_auth_progress(struct bt_conn *conn, bool authenticated);
+void fp_keys_bt_auth_progress(const struct bt_conn *conn, bool authenticated);
 
 /** Drop key of a given Fast Pair Seeker.
  *
@@ -124,7 +124,7 @@ void fp_keys_bt_auth_progress(struct bt_conn *conn, bool authenticated);
  *
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
-void fp_keys_drop_key(struct bt_conn *conn);
+void fp_keys_drop_key(const struct bt_conn *conn);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
bt_conn_index already accepts `const struct bt_conn *`. Change adds needed follow-up to Fast Pair code.

Jira: NCSDK-15633