### PR TITLE
doc: gsg: Document environment variables for the Zephyr SDK

### DIFF
--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -366,10 +366,20 @@ Install a Toolchain
 
 A toolchain provides a compiler, assembler, linker, and other programs required to build Zephyr applications.
 
+The Zephyr Software Development Kit (SDK) contains toolchains for each of Zephyr's supported architectures.
+It also includes additional host tools, such as custom QEMU and OpenOCD builds.
+
+.. note::
+
+   Set the following environment variables to ensure the Zephyr SDK is detected correctly:
+
+   * :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr``
+   * :envvar:`ZEPHYR_SDK_INSTALL_DIR` to the path of the Zephyr SDK
+
 .. ncs-include:: develop/getting_started/index.rst
    :docset: zephyr
    :dedent: 0
-   :start-after: to build Zephyr applications.
+   :start-after: and OpenOCD builds.
    :end-before: .. _getting_started_run_sample:
 
 .. rst-class:: numbered-step


### PR DESCRIPTION
Since many of our users are updating from a previous version of NCS,
which defaulted to using GNU Arm Embedded as a toolchain, they have the
ZEPHYR_TOOLCHAIN_VARIANT set, and so they need to override it. To
simplify, just refer to the env vars themselves without going into
detail on whether they are really required.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>