### PR TITLE
doc: software_maturity: Update rst to point to new entries in the yaml

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -433,6 +433,7 @@ Documentation
 
   * Added documentation page for the :ref:`lib_flash_map_pm` library.
   * :ref:`ug_thread_prebuilt_libs` as a separate page instead of being part of :ref:`ug_thread_configuring`.
+  * Added software maturity entries for security features: TF-M, PSA crypto, Immutable bootloader, HW unique key.
 
 * Updated:
 

--- a/doc/nrf/software_maturity.rst
+++ b/doc/nrf/software_maturity.rst
@@ -77,3 +77,26 @@ Zigbee feature support
 **********************
 
 .. sml-table:: zigbee
+
+Security Feature Support
+************************
+
+Trusted Firmware-M support
+--------------------------
+
+.. sml-table:: trusted_firmware_m
+
+PSA Crypto support
+------------------
+
+.. sml-table:: psa_crypto
+
+Immutable Bootloader
+--------------------
+
+.. sml-table:: immutable_bootloader
+
+Hardware Unique Key
+-------------------
+
+.. sml-table:: hw_unique_key


### PR DESCRIPTION
For TF-M, psa_crypto, B0 and HUK.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

The entries were added in https://github.com/nrfconnect/sdk-nrf/pull/7740