### PR TITLE
applications: asset_tracker_v2: Improve sample request handling

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -106,7 +106,7 @@ The real-time configurations supported by the application are listed in the foll
 |          +---------------------+--------------------------------------------------------------------------------------------------------------------------------------+----------------+
 |          | Movement timeout    | Number of seconds between each sampling/publication in passive mode, whether the device is moving or not.                            | 3600 seconds   |
 +----------+---------------------+--------------------------------------------------------------------------------------------------------------------------------------+----------------+
-| GNSS timeout                   | Timeout for acquiring a GNSS fix during data sampling.                                                                               | 60 seconds     |
+| GNSS timeout                   | Timeout for acquiring a GNSS fix during data sampling.                                                                               | 30 seconds     |
 +--------------------------------+--------------------------------------------------------------------------------------------------------------------------------------+----------------+
 | Accelerometer threshold        | Accelerometer threshold in m/s². Minimal absolute value in m/s² for accelerometer readings to be considered valid movement.          | 10 m/s²        |
 +--------------------------------+--------------------------------------------------------------------------------------------------------------------------------------+----------------+

--- a/applications/asset_tracker_v2/src/modules/Kconfig.app_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.app_module
@@ -6,10 +6,6 @@
 
 menu "Application control module"
 
-config APP_REQUEST_GNSS_ON_INITIAL_SAMPLING
-	bool "Request GNSS on initial data sampling after connection"
-	default y if GNSS_MODULE
-
 config APP_REQUEST_GNSS_WAIT_FOR_AGPS
 	bool "Wait for A-GPS data before requesting sampling of GNSS data"
 	default y
@@ -28,14 +24,5 @@ config APP_REQUEST_GNSS_WAIT_FOR_AGPS_THRESHOLD_SEC
 	  Number of seconds that the application module will wait for A-GPS data to be processed
 	  before requesting GNSS data. If set to -1, the application module will wait
 	  until A-GPS data has been processed.
-
-config APP_REQUEST_NEIGHBOR_CELLS_DATA
-	bool "Request neighbor cells data"
-	depends on AWS_IOT || NRF_CLOUD_MQTT || AZURE_IOT_HUB || LWM2M_INTEGRATION
-	default y
-	help
-	  Include LTE neighbor cell measurement data in regular sampling requests.
-	  The data will be encoded together with the other sampled data and sent to cloud,
-	  where it can be used to determine the device's location.
 
 endmenu

--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -128,7 +128,7 @@ config DATA_ACCELEROMETER_THRESHOLD
 
 config DATA_GNSS_TIMEOUT_SECONDS
 	int "Default GNSS timeout"
-	default 60
+	default 30
 	help
 	  Timeout for acquiring a GNSS fix during sampling of data.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -89,7 +89,14 @@ This section provides detailed lists of changes by :ref:`application <applicatio
 nRF9160: Asset Tracker v2
 -------------------------
 
-|no_changes_yet_note|
+  * Removed:
+
+    * ``CONFIG_APP_REQUEST_GNSS_ON_INITIAL_SAMPLING`` option.
+    * ``CONFIG_APP_REQUEST_NEIGHBOR_CELLS_DATA`` option.
+
+  * Updated:
+
+    * The default value of the GNSS timeout in the application's :ref:`Real-time configurations <real_time_configs>` is now 30 seconds.
 
 nRF9160: Serial LTE modem
 -------------------------


### PR DESCRIPTION
Improve sample request handling:
 - Make sure that static modem data has been sampled by the modem module
   by including static modem data in each sample request until the
   `MODEM_EVT_MODEM_STATIC_DATA_READY` has been received.

- Remove `CONFIG_APP_REQUEST_GNSS_ON_INITIAL_SAMPLING` option.
  This was added to decrease the time from a successful cloud connection
  to the first update was received in cloud.
  The first sample request will still not include GNSS due to
  `CONFIG_APP_REQUEST_GNSS_WAIT_FOR_AGPS` being enabled by default.
  After a connection the application will request A-GPS and when A-GPS
  has been successfully processed, GNSS sampling will be included in
  subsequent sample requests.

- Remove `CONFIG_APP_REQUEST_NEIGHBOR_CELLS_DATA` option.
  This Kconfig is redundant. The user can either specify Neighbor cell
  measurements not being sampled in the real-time configurations
  nod list or set `CONFIG_DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT=n`.

- Decrease the default value of GNSS timeout to 30 seconds.
  This is now possible because the application will wait for A-GPS
  before GNSS is requested. Without A-GPS being processed before a
  GNSS search the modem will bypass the set threshold value and search
  for a minimum of 60 seconds. If A-GPS has been processed,
  30 seconds should be sufficient enough time to obtain a fix.
  GNSS search consumes a lot of energy and should be kept at a minimum.

Fixes CIA-561