### PR TITLE
doc: sml: fixed top_level keys in uploaded report

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_scanner.py
+++ b/doc/_scripts/software_maturity/software_maturity_scanner.py
@@ -535,12 +535,12 @@ def generate_tables(
     top_table = {}
     for tech in sorted(top_table_info):
         top_table[tech] = {
-            MaturityLevels.SUPPORTED.value: [],
-            MaturityLevels.EXPERIMENTAL.value: [],
+            MaturityLevels.SUPPORTED.get_str(): [],
+            MaturityLevels.EXPERIMENTAL.get_str(): [],
         }
         for soc in all_socs:
             if soc in soc_sets[tech]:
-                top_table[tech][MaturityLevels.SUPPORTED.value].append(soc)
+                top_table[tech][MaturityLevels.SUPPORTED.get_str()].append(soc)
 
     # Feature tables
     category_results = {}


### PR DESCRIPTION
Changed the per-technology key for the top_level field in the
output report to conform with the new ordering system introduced
in #7740

Signed-off-by: Gaute Svanes Lunde <gaute.lunde@nordicsemi.no>