### PR TITLE
applications: Asset_Tracker_v2: Use PDN events instead of CEREG notifs

### DIFF
--- a/applications/asset_tracker_v2/prj.conf
+++ b/applications/asset_tracker_v2/prj.conf
@@ -48,9 +48,6 @@ CONFIG_LTE_PSM_REQ_RPTAU="11000001"
 ### 20 seconds active time.
 CONFIG_LTE_PSM_REQ_RAT="00001010"
 
-# Modem info library to obtain information about network and device
-CONFIG_MODEM_INFO=y
-
 # Settings - Used to store real-time device configuration to flash.
 CONFIG_SETTINGS=y
 CONFIG_SETTINGS_FCB=y

--- a/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
@@ -7,6 +7,8 @@
 menuconfig MODEM_MODULE
 	bool "Modem module"
 	select LTE_LINK_CONTROL
+	select PDN
+	select PDN_ESM_STRERROR
 	select MODEM_INFO
 	default y
 


### PR DESCRIPTION
Use PDN instead of CEREG notifications when notifying the application when
LTE has been established.