### PR TITLE
fix expected errno for SUPL support recv() timeouts

### DIFF
--- a/samples/nrf9160/gnss/src/assistance_supl.c
+++ b/samples/nrf9160/gnss/src/assistance_supl.c
@@ -29,7 +29,7 @@ static ssize_t supl_read(void *p_buff, size_t nbytes, void *user_data)
 
 	ssize_t rc = recv(supl_fd, p_buff, nbytes, 0);
 
-	if (rc < 0 && (errno == ETIMEDOUT)) {
+	if (rc < 0 && (errno == EAGAIN)) {
 		return 0;
 	}
 

--- a/samples/nrf9160/modem_shell/src/gnss/gnss.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.c
@@ -878,7 +878,7 @@ static void gnss_api_init(void)
 		.read = supl_read,
 		.write = supl_write,
 		.handler = inject_agps_data,
-		.logger = NULL, /* set to "supl_logger" to enable logging */
+		.logger = supl_logger,
 		.counter_ms = k_uptime_get
 	};
 

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_supl_support.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_supl_support.c
@@ -153,7 +153,7 @@ ssize_t supl_read(void *buf, size_t nbytes, void *user_data)
 
 	ssize_t rc = recv(supl_fd, buf, nbytes, 0);
 
-	if (rc < 0 && (errno == ETIMEDOUT)) {
+	if (rc < 0 && (errno == EAGAIN)) {
 		return 0;
 	}
 


### PR DESCRIPTION
SUPL support implementation for the GNSS sample and modem_shell was expecting wrong `errno` value from `recv()` in case of a timeout. Because of this the timeout logic in the SUPL client library didn't work properly and the library gave up earlier than expected.