### PR TITLE
manifest: Update to TF-M 1.6 and MBedTLS 3.1.0

### DIFF
--- a/modules/tfm/tfm/boards/CMakeLists.txt
+++ b/modules/tfm/tfm/boards/CMakeLists.txt
@@ -68,6 +68,9 @@ endif()
 
 if (${TFM_PARTITION_CRYPTO})
   target_link_libraries(platform_s PRIVATE platform_cc3xx)
+
+  # Needed in order to get crypto partition modules flags
+  target_link_libraries(platform_s PRIVATE tfm_psa_rot_partition_crypto)
 endif()
 
 if (NRF_ALLOW_NON_SECURE_RESET)

--- a/modules/tfm/tfm/boards/partition/region_defs.h
+++ b/modules/tfm/tfm/boards/partition/region_defs.h
@@ -13,7 +13,13 @@
 #define BL2_MSP_STACK_SIZE      (0x00001800)
 
 #define S_HEAP_SIZE             (0x00001000)
+#if !defined(TFM_CRYPTO_KEY_DERIVATION_MODULE_DISABLED) && \
+    !defined(PLATFORM_DEFAULT_CRYPTO_KEYS)
+/* Need a larger stack in init to write random Hardware Unique Keys to the KMU */
+#define S_MSP_STACK_SIZE_INIT   (0x00000800)
+#else
 #define S_MSP_STACK_SIZE_INIT   (0x00000400)
+#endif
 #define S_MSP_STACK_SIZE        (0x00000800)
 #define S_PSP_STACK_SIZE        (0x00000800)
 

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d6cd4fc1ceec4bb41c217709c373e5b9ffd05e51
+      revision: 85a0034809612b332fbdf478357e8a4109c493fd
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -105,15 +105,15 @@ manifest:
     - name: mbedtls-nrf
       path: mbedtls
       repo-path: sdk-mbedtls
-      revision: v3.0.0-ncs2
+      revision: 0add9081ba3ab67123ffe2590a1acc6a846a2646
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 0562ed3c831a1217eb487c05f37eafed4a937e27
+      revision: 4e5af7b8015c7c11555fb4798eacb0b99b887fcf
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v1.5.0-ncs2
+      revision: 37ffd937eb33a648fb2f058387bdbe972696346a
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Update the following dependencies:
- Update TF-M from 1.5 to 1.6.
- Update MBedTLS from 3.0.0 to 3.1.0.

Pull following additional fixes:
- Zephyr pull TF-M test repositories and zephyr TF-M patches.
- nrfxlib update nrf_security for mbedtls.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>

test-sdk-nrf: sdk-nrf-PR-7933