### PR TITLE
zigbee: Improve checks in Zigbee timer UT

### DIFF
--- a/tests/subsys/zigbee/osif/timer_ktimer/src/main.c
+++ b/tests/subsys/zigbee/osif/timer_ktimer/src/main.c
@@ -37,8 +37,10 @@ static void test_zb_osif_timer(void)
 	k_usleep(ZB_BEACON_INTERVAL_MSEC * 1000);
 	uint32_t time_stop_bi = zb_timer_get();
 
-	zassert_true((time_stop_bi == time_start_bi + 1),
+	zassert_true((time_stop_bi > time_start_bi),
 		     "ZBOSS time value was not increased");
+	zassert_true((time_stop_bi <= time_start_bi + 2),
+		     "ZBOSS time value was increased by more than 2 BI");
 }
 
 void test_main(void)


### PR DESCRIPTION
In case of ktimer-based ZBOSS timer, it is possible that waiting for a single beacon interval (15.36ms), rounded up to full milliseconds (16ms), will increase the ZBOSS timer value by 2.

Example:
 - At the beginning of the test ktimer returns 15 (0.975 BI)
 - Zephyr waits for 16ms, which increases the ktimer value to 31
 - ZBOSS OSIF divides this value by 15.36, which results in 2.018 BI

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>