### PR TITLE
.github: disable tf-m oss-history check

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -21,10 +21,11 @@ jobs:
         run: |
           west init -l ncs/nrf
           cd ncs
-          west update zephyr mcuboot trusted-firmware-m
+          west update zephyr mcuboot
           git -C zephyr remote add upstream https://github.com/zephyrproject-rtos/zephyr
 
       - name: Check OSS history
         uses: nrfconnect/action-oss-history@main
         with:
           workspace: 'ncs'
+          args: -p zephyr -p mcuboot


### PR DESCRIPTION

Pull request https://github.com/nrfconnect/sdk-nrf/pull/7933/ is
bringing in a lot of commits from upstream tf-m that are not present
in the revision of tf-m in zephyr/west.yml, and the script is getting
confused.

In particular, it thinks that all of the new upstream commits are
actually downstream out-of-tree commits. Then it tries to reapply them
onto the old downstream. This fails, and the action fails.

I'm not sure how to handle this case, so let's just disable the check
for tf-m for now.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>