### PR TITLE
MPSL: Move kconfig to sdk-nrf and do some cleanups

### DIFF
--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -6,6 +6,17 @@
 
 menu "Nordic MPSL"
 
+config MPSL
+	bool "Nordic Multi Protocol Service Layer (MPSL)"
+	select ZERO_LATENCY_IRQS
+	select IEEE802154_NRF5_EXT_IRQ_MGMT if IEEE802154_NRF5
+	select NRF_802154_MULTIPROTOCOL_SUPPORT if NRF_802154_RADIO_DRIVER
+	select MULTITHREADING_LOCK
+	depends on (SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET)
+	help
+	  Use Nordic Multi Protocol Service Layer (MPSL) implementation,
+	  providing services for single and multi-protocol implementations.
+
 config MPSL_FEM_ONLY
 	bool "Support only radio front-end module (FEM)"
 	depends on MPSL_FEM
@@ -13,7 +24,20 @@ config MPSL_FEM_ONLY
 	  Support only radio front-end module (FEM) feature. The MPSL library is linked
 	  into a build without the initialization. Using other MPSL features is not possible.
 
+if MPSL
+
+choice MPSL_BUILD_TYPE
+	prompt "MPSL build type"
+	default MPSL_BUILD_TYPE_LIB
+
+config MPSL_BUILD_TYPE_LIB
+	bool "Use library"
+
+endchoice
+
 rsource "fem/Kconfig"
+
+endif
 
 if !MPSL_FEM_ONLY
 

--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -4,18 +4,18 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-menu "Nordic MPSL"
+menu "Multiprocol Service Layer (MPSL)"
 
 config MPSL
-	bool "Nordic Multi Protocol Service Layer (MPSL)"
+	bool "Multiprotocol Service Layer (MPSL)"
 	select ZERO_LATENCY_IRQS
 	select IEEE802154_NRF5_EXT_IRQ_MGMT if IEEE802154_NRF5
 	select NRF_802154_MULTIPROTOCOL_SUPPORT if NRF_802154_RADIO_DRIVER
 	select MULTITHREADING_LOCK
 	depends on (SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET)
 	help
-	  Use Nordic Multi Protocol Service Layer (MPSL) implementation,
-	  providing services for single and multi-protocol implementations.
+	  The Multiprotocol Service Layer (MPSL) is a library of common services
+	  for single and multiprotocol implementations.
 
 config MPSL_FEM_ONLY
 	bool "Support only radio front-end module (FEM)"
@@ -31,7 +31,7 @@ choice MPSL_BUILD_TYPE
 	default MPSL_BUILD_TYPE_LIB
 
 config MPSL_BUILD_TYPE_LIB
-	bool "Use library"
+	bool "Library"
 
 endchoice
 

--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -89,8 +89,8 @@ config MPSL_CX_BT_1WIRE
 
 endchoice # MPSL_CX_CHOICE
 
-endif	# MPSL_CX
-
 module=MPSL_CX
 module-str=MPSL_CX
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif	# MPSL_CX

--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -205,8 +205,6 @@ config MPSL_FEM_BUILTIN_POWER_MODEL_UPDATE_PERIOD
 
 endif   # MPSL_FEM_POWER_MODEL
 
-endif	# MPSL_FEM || MPSL_FEM_PIN_FORWARDER
-
 config MPSL_FEM_DEVICE_CONFIG_254
 	bool "Apply device configuration 254"
 	default MPSL_FEM
@@ -220,3 +218,5 @@ config MPSL_FEM_DEVICE_CONFIG_254
 module=MPSL_FEM
 module-str=MPSL_FEM
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif	# MPSL_FEM || MPSL_FEM_PIN_FORWARDER


### PR DESCRIPTION
To make it easier to browse the kconfig tree, it is more logical that the MPSL kconfig resides under nRF Connect SDK.
Also apply some other minor cleanups