### PR TITLE
gitignore: ignore `.idea` CLion workspace dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ cscope.*
 .dir
 venv
 .venv
+.idea
 
 /*.patch
 


### PR DESCRIPTION
This commit updates the `.gitignore` file to ignore
the `.idea` workspace directory that gets created
automatically by CLion for every CMake project.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>

Zephyr RTOS is already officially ignoring this folder: https://github.com/zephyrproject-rtos/zephyr/commit/6e07e75538807f03b42eec1f38c983990384fb84 I've been using CLion with sdk-nrf for a long time already and handling a local different `.gitignore` is cumbersome when this line can easily be added to the repo's `.gitignore`.