### PR TITLE
TF-M: Add support for storage partitions in external flash.

### DIFF
--- a/doc/nrf/ug_tfm.rst
+++ b/doc/nrf/ug_tfm.rst
@@ -162,4 +162,4 @@ If a static partition file is used for the application, make the following chang
 * Rename the ``spm`` partition to ``tfm``.
 * Add a partition called ``tfm_secure`` that spans ``mcuboot_pad`` (if MCUboot is enabled) and ``tfm`` partitions.
 * Add a partition called ``tfm_nonsecure`` that spans the application, and other possible application partitions that must be non-secure.
-* For non-secure storage partitions, place the partitions inside the ``nonsecure_storage`` partition, and enable the configuration :kconfig:option:`CONFIG_TFM_NONSECURE_STORAGE`.
+* For non-secure storage partitions, place the partitions inside the ``nonsecure_storage`` partition.

--- a/modules/tfm/tfm/boards/common/config.cmake
+++ b/modules/tfm/tfm/boards/common/config.cmake
@@ -10,3 +10,7 @@ set(PLATFORM_DEFAULT_CRYPTO_KEYS        FALSE       CACHE BOOL      "Use default
 # Disable crypto regression tests that are not supported
 set(TFM_CRYPTO_TEST_ALG_CFB             OFF         CACHE BOOL      "Test CFB cryptography mode")
 set(TFM_CRYPTO_TEST_ALG_OFB             OFF         CACHE BOOL      "Test OFB cryptography mode")
+
+# Always enable the nonsecure storage partition.
+# It will still be excluded if the partition manager excludes it.
+set(NRF_NS_STORAGE                      ON          CACHE BOOL      "Enable non-secure storage partition")

--- a/modules/tfm/tfm/boards/common/config.cmake
+++ b/modules/tfm/tfm/boards/common/config.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Override the AEAD algorithm configuration
+set(PLATFORM_DEFAULT_CRYPTO_KEYS        FALSE       CACHE BOOL      "Use default crypto keys implementation.")
+
+# Disable crypto regression tests that are not supported
+set(TFM_CRYPTO_TEST_ALG_CFB             OFF         CACHE BOOL      "Test CFB cryptography mode")
+set(TFM_CRYPTO_TEST_ALG_OFB             OFF         CACHE BOOL      "Test OFB cryptography mode")

--- a/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
+++ b/modules/tfm/tfm/boards/nrf5340_cpuapp/config.cmake
@@ -5,13 +5,10 @@
 #
 #-------------------------------------------------------------------------------
 
+include(${CMAKE_CURRENT_LIST_DIR}/../common/config.cmake)
+
 set(PLATFORM_PATH platform/ext/target/nordic_nrf/)
 include(${PLATFORM_PATH}/common/nrf5340/config.cmake)
 
 # Override the AEAD algorithm configuration
 set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_GCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")
-set(PLATFORM_DEFAULT_CRYPTO_KEYS        FALSE       CACHE BOOL      "Use default crypto keys implementation.")
-
-# Disable crypto regression tests that are not supported
-set(TFM_CRYPTO_TEST_ALG_CFB             OFF          CACHE BOOL      "Test CFB cryptography mode")
-set(TFM_CRYPTO_TEST_ALG_OFB             OFF          CACHE BOOL      "Test OFB cryptography mode")

--- a/modules/tfm/tfm/boards/nrf9160/config.cmake
+++ b/modules/tfm/tfm/boards/nrf9160/config.cmake
@@ -5,13 +5,10 @@
 #
 #-------------------------------------------------------------------------------
 
+include(${CMAKE_CURRENT_LIST_DIR}/../common/config.cmake)
+
 set(PLATFORM_PATH platform/ext/target/nordic_nrf/)
 include(${PLATFORM_PATH}/common/nrf9160/config.cmake)
 
 # Override the AEAD algorithm configuration since nRF9160 supports only AES_CCM
 set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_CCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")
-set(PLATFORM_DEFAULT_CRYPTO_KEYS        FALSE       CACHE BOOL      "Use default crypto keys implementation.")
-
-# Disable crypto regression tests that are not supported
-set(TFM_CRYPTO_TEST_ALG_CFB             OFF         CACHE BOOL      "Test CFB cryptography mode")
-set(TFM_CRYPTO_TEST_ALG_OFB             OFF         CACHE BOOL      "Test OFB cryptography mode")

--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -30,13 +30,6 @@ else()
   endif()
 endif()
 
-if (CONFIG_TFM_NONSECURE_STORAGE)
-  # Configure the storage partition to be non-secure
-  set_property(TARGET zephyr_property_target
-    APPEND PROPERTY TFM_CMAKE_OPTIONS -DNRF_NS_STORAGE=ON
-  )
-endif()
-
 if (CONFIG_TFM_HW_INIT_RESET_ON_BOOT)
   set_property(TARGET zephyr_property_target
     APPEND PROPERTY TFM_CMAKE_OPTIONS -DNRF_HW_INIT_RESET_ON_BOOT=ON

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -210,8 +210,6 @@ config TFM_STORAGE
 	default y if PM_PARTITION_SIZE_TFM_INTERNAL_TRUSTED_STORAGE != 0
 	default y if PM_PARTITION_SIZE_TFM_OTP_NV_COUNTERS != 0
 
-config TFM_NONSECURE_STORAGE
-	bool
 
 rsource "Kconfig.psa.defconfig"
 

--- a/subsys/partition_manager/Kconfig.template.partition_config
+++ b/subsys/partition_manager/Kconfig.template.partition_config
@@ -4,8 +4,3 @@ config PM_PARTITION_SIZE_$(partition)
 	default $(partition-size)
 	help
 	  Memory set aside for the $(partition) partition.
-if BUILD_WITH_TFM
-config TFM_NONSECURE_STORAGE
-	bool
-	default y if PM_PARTITION_SIZE_$(partition) != 0
-endif

--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: fe7c32c20486e9cf853ea7461eca84ccea1c0f51
+      revision: 3adf5462ee7f0f4e4ae24837fc3f2aba470cea97
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Add support for storage partitions to be placed in external flash when
TF-M is enabled.
Improve the handling of the non-secure storage by always enabling it and
pulling in a change in TF-M that excludes the non-secure storage when
it is empty.

~~This change is in addition to this: https://github.com/nrfconnect/sdk-nrf/pull/7927~~