### PR TITLE
samples: peripheral_uart: Fix initialization error on Thingy:53

### DIFF
--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -243,7 +243,7 @@ static int uart_init(void)
 
 	if (IS_ENABLED(CONFIG_USB_DEVICE_STACK)) {
 		err = usb_enable(NULL);
-		if (err) {
+		if (err && (err != -EALREADY)) {
 			LOG_ERR("Failed to enable USB");
 			return err;
 		}


### PR DESCRIPTION
Change fixes error in uart_init on Thingy:53. The usb_enable function is called twice which results in returning -EALREADY error code in uart_init. The error code can be ignored.