### PR TITLE
applications: asset_tracker_v2: Handle modem functional mode requests

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/Kconfig.lwm2m_integration
+++ b/applications/asset_tracker_v2/src/cloud/Kconfig.lwm2m_integration
@@ -32,6 +32,15 @@ config LWM2M_INTEGRATION_FLUSH_SESSION_CACHE
 	  Wireshark needs the initial first handshake in order to do this. This is forced by
 	  flushing the DTLS session cache after boot.
 
+config LWM2M_INTEGRATION_MODEM_MODE_REQUEST_RETRY_SECONDS
+	int "Modem functional mode request retry, in seconds"
+	default 2
+	help
+	  Time in between each time the security object will request a modem
+	  functional mode change.
+	  The security object requests functional mode change before and
+	  after provisioning the credentials to the modem.
+
 if LWM2M_INTEGRATION_PROVISION_CREDENTIALS
 
 config LWM2M_INTEGRATION_PSK

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec.c
@@ -376,7 +376,7 @@ int cloud_codec_init(struct cloud_data_cfg *cfg, cloud_codec_evt_handler_t event
 		return err;
 	}
 
-	/* Humidity object. */
+	/* Pressure object. */
 	err = lwm2m_engine_set_float(LWM2M_PATH(IPSO_OBJECT_PRESSURE_ID, 0, MIN_RANGE_VALUE_RID),
 				     &pressure_min_range_val);
 	if (err) {

--- a/applications/asset_tracker_v2/src/events/cloud_module_event.h
+++ b/applications/asset_tracker_v2/src/events/cloud_module_event.h
@@ -37,10 +37,20 @@ enum cloud_module_event_type {
 	/** Connection has timed out. */
 	CLOUD_EVT_CONNECTION_TIMEOUT,
 
-	/** Connect to LTE. */
+	/** Connect to LTE.
+	 *  This event is sent out when the modem should connect to LTE (put into normal mode) post
+	 *  provisioning of server credentials.
+	 *
+	 *  Only used when building for LwM2M.
+	 */
 	CLOUD_EVT_LTE_CONNECT,
 
-	/** Disconnect from LTE. */
+	/** Disconnect from LTE.
+	 *  This event is sent out when the modem should be put into offline mode prior to
+	 *  provisioning of server credentials.
+	 *
+	 *  Only used when building for LwM2M.
+	 */
 	CLOUD_EVT_LTE_DISCONNECT,
 
 	/** User association request received from cloud. */

--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -909,7 +909,7 @@ static void on_state_disconnected(struct modem_msg_data *msg)
 
 	if ((IS_EVENT(msg, app, APP_EVT_LTE_DISCONNECT)) ||
 	    (IS_EVENT(msg, modem, MODEM_EVT_CARRIER_EVENT_LTE_LINK_UP_REQUEST)) ||
-	    (IS_EVENT(msg, cloud, CLOUD_EVT_LTE_DISCONNECT))) {
+	    (IS_EVENT(msg, cloud, CLOUD_EVT_LTE_CONNECT))) {
 		int err;
 
 		err = lte_connect();


### PR DESCRIPTION
Handle modem functional mode requests from the security object:

During provisioning of a Pre Shared Key used in the DTLS connection to
either the bootstrap or the management server, the security object
requests via a callback that the modem must be put in a certain
functional mode.

To provision the PSK, the modem must be put in offline mode, and after
provisioning has been carried out, the security object requests
the modem to be put into normal mode to resume execution.

Implementing this callback gives the application control of when
this functional mode takes place. If not implemented, the security
object will put the modem into the respective state itself.

Fixes CIA-643