### PR TITLE
application: serial_lte_modem: BUG-FIX enter data mode

### DIFF
--- a/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/HTTPC_AT_commands.rst
@@ -204,7 +204,7 @@ The following example sends a POST request, with headers delimited by "\\r\\n", 
    {"hello":"world"}+++
    #XHTTPCREQ: 0
 
-   OK
+   #XDATAMODE: 0
 
    HTTP/1.1 200 OK
    Date: Tue, 01 Mar 2022 05:22:28 GMT

--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -393,8 +393,9 @@ Examples
 ::
 
    AT#XMQTTPUB="nrf91/slm/mqtt/topic0"
-   {"msg":"Test Json publish"}+++
    OK
+   {"msg":"Test Json publish"}+++
+   #XDATAMODE: 0
    #XMQTTMSG: 21,27
    nrf91/slm/mqtt/topic0
    {"msg":"Test Json publish"}
@@ -413,8 +414,9 @@ Examples
 ::
 
    AT#XMQTTPUB="nrf91/slm/mqtt/topic2","",2,0
-   Test message with QoS 2+++
    OK
+   Test message with QoS 2+++
+   #XDATAMODE: 0
    #XMQTTEVT: 4,0
    #XMQTTEVT: 6,0
    #XMQTTMSG: 21,23

--- a/applications/serial_lte_modem/doc/slm_data_mode.rst
+++ b/applications/serial_lte_modem/doc/slm_data_mode.rst
@@ -47,7 +47,7 @@ Other examples:
 * ``AT#XMQTTPUB=<topic>,"",<qos>,<retain>``
 * ``AT#XNRFCLOUD=2``
 
-The SLM application does not send an *OK* response when it enters data mode.
+The SLM application sends an *OK* response when it successfully enters data mode.
 
 Exiting data mode
 =================
@@ -56,9 +56,7 @@ To exit data mode, the MCU sends the termination command set by the :ref:`CONFIG
 
 The pattern string could be sent alone or as an affix to the data.
 
-When instructed to exit data mode, the SLM application returns the AT command response ``OK``.
-
-If the current sending function fails, the SLM application exits data mode and returns the AT command response ``ERROR``.
+If the current sending function fails, the SLM application exits data mode and returns the result as ``#XDATAMODE: <result>``.
 
 The SLM application also exits data mode automatically in the following scenarios:
 
@@ -173,3 +171,30 @@ Response syntax
 ::
 
    #XDATACTRL=<time_limit>
+
+Exit data mode #XDATAMODE
+=========================
+
+When the application exits data mode, it sends the ``#XDATAMODE`` unsolicited notification.
+
+Unsolicited notification
+------------------------
+
+The application sends the following unsolicited notification when it exits data mode:
+
+::
+
+   #XDATAMODE: <result>
+
+The ``<result>`` value returns an integer indicating the result of the sending operation in data mode.
+
+Example
+~~~~~~~
+
+::
+
+   AT#XSEND
+   OK
+   Test TCP datamode
+   +++
+   #XDATAMODE: 0

--- a/applications/serial_lte_modem/doc/slm_testing.rst
+++ b/applications/serial_lte_modem/doc/slm_testing.rst
@@ -181,7 +181,7 @@ TCP client
          :class: highlight
 
          +++
-         OK
+         #XDATAMODE: 0
 
    #. Receive the response from the server.
 

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -680,9 +680,9 @@ static int nrf_cloud_datamode_callback(uint8_t op, const uint8_t *data, int len)
 		ret = do_cloud_send_msg(data, len);
 		LOG_INF("datamode send: %d", ret);
 		if (ret < 0) {
-			(void)exit_datamode(DATAMODE_EXIT_ERROR);
+			(void)exit_datamode(ret);
 		} else {
-			(void)exit_datamode(DATAMODE_EXIT_OK);
+			(void)exit_datamode(0);
 		}
 	} else if (op == DATAMODE_EXIT) {
 		LOG_DBG("datamode exit");

--- a/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
+++ b/applications/serial_lte_modem/src/http_c/slm_at_httpc.c
@@ -508,14 +508,16 @@ static void httpc_thread_fn(void *arg1, void *arg2, void *arg3)
 	int err;
 
 	err = do_http_request();
-	(void)exit_datamode(DATAMODE_EXIT_URC);
 	if (err < 0) {
+		(void)exit_datamode(err);
 		LOG_ERR("do_http_request fail:%d", err);
 		/* Disconnect from server */
 		err = do_http_disconnect();
 		if (err) {
 			LOG_ERR("Fail to disconnect. Error: %d", err);
 		}
+	} else {
+		(void)exit_datamode(0);
 	}
 
 	LOG_INF("HTTP thread terminated");

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -196,7 +196,7 @@ bool in_datamode(void)
 	return (slm_operation_mode == SLM_DATA_MODE);
 }
 
-bool exit_datamode(int exit_mode)
+bool exit_datamode(int result)
 {
 	if (slm_operation_mode == SLM_DATA_MODE) {
 		ring_buf_reset(&data_rb);
@@ -205,13 +205,7 @@ bool exit_datamode(int exit_mode)
 		k_sleep(K_MSEC(10));
 		(void)uart_receive();
 
-		if (exit_mode == DATAMODE_EXIT_OK) {
-			strcpy(rsp_buf, OK_STR);
-		} else if (exit_mode == DATAMODE_EXIT_ERROR) {
-			strcpy(rsp_buf, ERROR_STR);
-		} else {
-			sprintf(rsp_buf, "\r\n#XDATAMODE: 0\r\n");
-		}
+		sprintf(rsp_buf, "\r\n#XDATAMODE: %d\r\n", result);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 
 		slm_operation_mode = SLM_AT_COMMAND_MODE;
@@ -567,7 +561,7 @@ static void datamode_quit(struct k_work *work)
 	} else {
 		LOG_WRN("missing datamode handler");
 	}
-	(void)exit_datamode(DATAMODE_EXIT_OK);
+	(void)exit_datamode(0);
 }
 
 static int raw_rx_handler(const uint8_t *data, int datalen)
@@ -772,9 +766,7 @@ static void cmd_send(struct k_work *work)
 
 	err = slm_at_parse(at_buf);
 	if (err == 0) {
-		if (!in_datamode()) {
-			rsp_send(OK_STR, sizeof(OK_STR) - 1);
-		}
+		rsp_send(OK_STR, sizeof(OK_STR) - 1);
 		goto done;
 	} else if (err != -ENOENT) {
 		rsp_send(ERROR_STR, sizeof(ERROR_STR) - 1);

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -26,13 +26,6 @@ enum slm_datamode_operation {
 	DATAMODE_EXIT   /* Exit data mode */
 };
 
-/**@brief Exit modes in datamode. */
-enum slm_datamode_exit_mode {
-	DATAMODE_EXIT_OK,      /* Exit datamode, send OK response */
-	DATAMODE_EXIT_ERROR,   /* Exit datamode, send ERROR response */
-	DATAMODE_EXIT_URC      /* Exit datamode, send URC notification */
-};
-
 /**@brief Data mode sending handler type.
  *
  * @retval 0 means all data is sent successfully.
@@ -95,12 +88,12 @@ bool in_datamode(void);
 /**
  * @brief Request SLM AT host to exit data mode
  *
- * @param exit_mode Response type. Refer to enum slm_datamode_exit_mode.
+ * @param result Result of sending in data mode.
  *
  * @retval true If normal exit from data mode.
  *         false If not in data mode.
  */
-bool exit_datamode(int exit_mode);
+bool exit_datamode(int result);
 /** @} */
 
 #endif /* SLM_AT_HOST_ */

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -426,7 +426,7 @@ static int tcp_datamode_callback(uint8_t op, const uint8_t *data, int len)
 static void tcpsvr_terminate_connection(int cause)
 {
 	if (in_datamode()) {
-		(void)exit_datamode(DATAMODE_EXIT_URC);
+		(void)exit_datamode(cause);
 	}
 	if (proxy.sock_peer != INVALID_SOCKET) {
 		close(proxy.sock_peer);
@@ -656,7 +656,7 @@ static void tcpcli_thread_func(void *p1, void *p2, void *p3)
 	}
 
 	if (in_datamode()) {
-		(void)exit_datamode(DATAMODE_EXIT_URC);
+		(void)exit_datamode(ret);
 	}
 	if (proxy.sock != INVALID_SOCKET) {
 		(void)close(proxy.sock);

--- a/applications/serial_lte_modem/src/slm_at_udp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_udp_proxy.c
@@ -413,7 +413,7 @@ static void udp_thread_func(void *p1, void *p2, void *p3)
 	} while (true);
 
 	if (in_datamode()) {
-		(void)exit_datamode(false);
+		(void)exit_datamode(ret);
 	}
 	if (proxy.sock != INVALID_SOCKET) {
 		(void)close(proxy.sock);

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -107,7 +107,9 @@ nRF9160: Asset Tracker v2
 nRF9160: Serial LTE modem
 -------------------------
 
-|no_changes_yet_note|
+  * Updated:
+
+    * Updated the AT response and the URC sent when the application enters and exits data mode.
 
 nRF5340 Audio
 -------------


### PR DESCRIPTION
The swap of command mode to data mode could be delayed by Zephyr
system workqueue, but MCU side is not aware of that and could
send raw data while SLM is still in command mode.

Solution is to restore old-behavior of entering data mode, that
the AT command causing SLM to enter data mode will send OK before
that, then MCU side would be sure of that SLM enters data mode.

A related change is that SLM would send below URC when quitting
data mode, signaling MCU side that SLM is back to command mode.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>