### PR TITLE
doc: move note about NCP discontinued higher

### DIFF
--- a/doc/nrf/ug_thread_architectures.rst
+++ b/doc/nrf/ug_thread_architectures.rst
@@ -128,6 +128,9 @@ OpenThread runs on either the radio processor or the host processor, depending o
 Network co-processor (NCP)
 ==========================
 
+.. note::
+   This platform design is currently discontinued by |NCS|.
+
 In the standard NCP design, the full OpenThread stack runs on the processor that provides the Thread radio (the *network processor*), and the application layer runs on a host processor.
 The host processor is typically more capable than the network processor, but it has greater power demands.
 The host processor communicates with the network processor through a serial interface (typically UART or SPI) over the `Spinel protocol`_.
@@ -154,8 +157,6 @@ It has the following disadvantages:
 
 .. note::
     |connection_options_limited|
-
-This platform design is currently discontinued by |NCS|.
 
 .. _thread_architectures_designs_cp_rcp:
 


### PR DESCRIPTION
The note about the network co-processor platform design being
discontinued was at the bottom of the section, where it was not
very visible. This moves it right to the start of the section
and makes it a formatted note.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>