### PR TITLE
ci: Add owners of requirements files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -152,7 +152,8 @@ Kconfig*                                  @tejlmand
 /samples/nrf5340/multiprotocol_rpmsg/     @hubertmis
 /scripts/                                 @mbolivar-nordic @tejlmand @nrfconnect/ncs-test-leads
 /scripts/hid_configurator/                @pdunaj
-/scripts/tools-versions-*.txt             @tejlmand @grho @shantha-14
+/scripts/tools-versions-*.txt             @tejlmand @grho @shantha-14 @ihansse
+/scripts/requirements-*.txt               @tejlmand @grho @shantha-14 @ihansse
 /scripts/west_commands/sbom/              @doki-nordic @maje-emb
 /share/zephyrbuild-package/               @tejlmand
 /share/ncs-package/                       @tejlmand


### PR DESCRIPTION
Add owners of requirements files.

Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>