### PR TITLE
applications: asset_tracker_v2: Use low power modes for ADXL362.

### DIFF
--- a/applications/asset_tracker_v2/boards/thingy91_nrf9160_ns.overlay
+++ b/applications/asset_tracker_v2/boards/thingy91_nrf9160_ns.overlay
@@ -18,5 +18,8 @@
 };
 
 &spi3 {
-	adxl362: adxl362@0 {};
+	adxl362: adxl362@0 {
+		wakeup-mode;
+		autosleep;
+	};
 };


### PR DESCRIPTION
This patch uses the wakeup and autosleep features of the low-power accelerometer on the thingy91 to save some power.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>