### PR TITLE
doc: remove banners from the welcome & GSG pages

### DIFF
--- a/doc/nrf/getting_started.rst
+++ b/doc/nrf/getting_started.rst
@@ -7,11 +7,6 @@ To quickly get started with the |NCS|, use :ref:`nRF Connect for Desktop <gs_ass
 Alternatively, you can enroll in the `nRF Connect SDK Fundamentals course`_ in the `Nordic Developer Academy`_.
 You can also check the :ref:`gs_installing` documentation for instructions on setting up your environment manually.
 
-.. rst-class:: doc-link-image
-
-.. image:: /images/ncs_get_started_banner.png
-   :target: `nRF Connect SDK Fundamentals course`_
-
 We recommend using |VSC| with the |nRFVSC| to build applications.
 See the `nRF Connect for Visual Studio Code`_ documentation page for more information about the extension.
 

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -11,45 +11,6 @@ The |NCS| includes the Zephyr™ real-time operating system (RTOS), which is bui
 To access different versions of the |NCS| documentation, use the version drop-down in the top right corner.
 A "99" at the end of the version number of this documentation indicates continuous updates on the main branch since the previous major.minor release.
 
-In addition to the |NCS| documentation, information is available in the following locations:
-
-.. rst-class:: doc-link blue-box
-..
-
-    .. rst-class:: doc-link-image
-
-    .. image:: /images/doc_icon.svg
-       :target: `Nordic Semiconductor Infocenter`_
-
-    .. rst-class:: doc-link-text
-
-    `Nordic Semiconductor Infocenter`_
-
-.. rst-class:: doc-link gray-box
-..
-
-    .. rst-class:: doc-link-image
-
-    .. image:: /images/DevAcademy.svg
-       :target: `DevAcademy`_
-
-    .. rst-class:: doc-link-text
-
-    `Accelerated learning <DevAcademy_>`_
-
-.. rst-class:: doc-link gray-box
-..
-
-    .. rst-class:: doc-link-image
-
-    .. image:: /images/DevZone.svg
-       :target: `DevZone`_
-
-    .. rst-class:: doc-link-text
-
-    `Tutorials and blog posts <DevZone_>`_
-
-
 .. toctree::
    :maxdepth: 2
    :caption: Contents


### PR DESCRIPTION
Remove Infocenter, DevAcademy and DevZone banners
from the welcome page. Also, remove DevAcademy banner
from the GSG page.

Ref: NCSDK-15718

Signed-off-by: Richa Pandey <richa.pandey@nordicsemi.no>