### PR TITLE
samples: crypto: Add missing crypto tags

### DIFF
--- a/samples/crypto/aes_cbc/sample.yaml
+++ b/samples/crypto/aes_cbc/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: AES CBC example
 tests:
     sample.aes_cbc:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/aes_ccm/sample.yaml
+++ b/samples/crypto/aes_ccm/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: AES CCM example
 tests:
     sample.aes_ccm:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/aes_ctr/sample.yaml
+++ b/samples/crypto/aes_ctr/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: AES CTR example
 tests:
     sample.aes_ctr:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/aes_gcm/sample.yaml
+++ b/samples/crypto/aes_gcm/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: AES GCM example
 tests:
     sample.aes_gcm.cc312:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp
         harness: console
         harness_config:
@@ -15,7 +15,7 @@ tests:
             - nrf5340dk_nrf5340_cpuapp_ns
             - nrf5340dk_nrf5340_cpuapp
     sample.aes_gcm.cc310:
-        tags: introduction psa oberon
+        tags: introduction psa oberon cc3xx_oberon
         platform_allow: nrf52840dk_nrf52840 nrf9160dk_nrf9160_ns nrf9160dk_nrf9160
         harness: console
         harness_config:

--- a/samples/crypto/chachapoly/sample.yaml
+++ b/samples/crypto/chachapoly/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: Chacha20-Poly1305 example
 tests:
     sample.chacha_poly:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/ecdh/sample.yaml
+++ b/samples/crypto/ecdh/sample.yaml
@@ -5,7 +5,7 @@ sample:
     name: ECDH example
 tests:
     sample.ecdh:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/ecdsa/sample.yaml
+++ b/samples/crypto/ecdsa/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: ECDSA example
 tests:
     sample.ecdsa:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/hkdf/sample.yaml
+++ b/samples/crypto/hkdf/sample.yaml
@@ -3,7 +3,7 @@ sample:
     name: HKDF example
 tests:
     sample.hkdf:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/hmac/sample.yaml
+++ b/samples/crypto/hmac/sample.yaml
@@ -5,7 +5,7 @@ sample:
     name: HMAC example
 tests:
     sample.hmac:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/persistent_key_usage/sample.yaml
+++ b/samples/crypto/persistent_key_usage/sample.yaml
@@ -5,7 +5,7 @@ sample:
     name: Persistent key example
 tests:
     sample.persistent_key_usage:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/psa_tls/sample.yaml
+++ b/samples/crypto/psa_tls/sample.yaml
@@ -17,7 +17,7 @@ tests:
           - nrf5340dk_nrf5340_cpuapp_ns
           - nrf9160dk_nrf9160
           - nrf9160dk_nrf9160_ns
-        tags: ci_build cc3xx_oberon
+        tags: ci_build psa cc3xx_oberon
 
     sample.psa_tls.client.rsa.cc3xx_oberon:
         build_only: true
@@ -28,7 +28,7 @@ tests:
           - nrf5340dk_nrf5340_cpuapp_ns
           - nrf9160dk_nrf9160
           - nrf9160dk_nrf9160_ns
-        tags: ci_build cc3xx_oberon
+        tags: ci_build psa cc3xx_oberon
 
     sample.psa_tls.server.ecdsa.cc3xx_oberon:
         build_only: true
@@ -39,7 +39,7 @@ tests:
           - nrf5340dk_nrf5340_cpuapp_ns
           - nrf9160dk_nrf9160
           - nrf9160dk_nrf9160_ns
-        tags: ci_build cc3xx_oberon
+        tags: ci_build psa cc3xx_oberon
 
     sample.psa_tls.client.ecdsa.cc3xx_oberon:
         build_only: true
@@ -50,7 +50,7 @@ tests:
           - nrf5340dk_nrf5340_cpuapp_ns
           - nrf9160dk_nrf9160
           - nrf9160dk_nrf9160_ns
-        tags: ci_build cc3xx_oberon
+        tags: ci_build psa cc3xx_oberon
 
     ################################################################################
     ## Legacy APIs with Cryptocell (secure-only)

--- a/samples/crypto/rng/sample.yaml
+++ b/samples/crypto/rng/sample.yaml
@@ -3,7 +3,7 @@ sample:
     name: RNG example
 tests:
     sample.rng:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/rsa/sample.yaml
+++ b/samples/crypto/rsa/sample.yaml
@@ -4,7 +4,7 @@ sample:
     name: RSA example
 tests:
     sample.rsa:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:

--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -3,7 +3,7 @@ sample:
     name: SHA256 example
 tests:
     sample.sha256:
-        tags: introduction psa cc3xx
+        tags: introduction psa cc3xx cc3xx_oberon
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns nrf9160dk_nrf9160 nrf52840dk_nrf52840
         harness: console
         harness_config:


### PR DESCRIPTION
Internal CI filters on certain tags to determine
what to build and run.

Add missing tags to crypto samples to ensure the
filtering strategy succeeds.

Signed-off-by: Torstein Grindvik <torstein.grindvik@nordicsemi.no>