### PR TITLE
Bluetooth: Mesh: Automatic decommission of EnOcean switch

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/mesh/vnd/silvair_enocean_srv.rst
+++ b/doc/nrf/libraries/bluetooth_services/mesh/vnd/silvair_enocean_srv.rst
@@ -11,7 +11,7 @@ The Silvair EnOcean Proxy Server model integrates an EnOcean switch together wit
 It implements the `Silvair EnOcean Switch Mesh Proxy Server`_ specification.
 
 The model initializes the :ref:`bt_enocean_readme` library.
-The EnOcean switch can be automatically commissioned if option :kconfig:option:`CONFIG_BT_MESH_SILVAIR_ENOCEAN_AUTO_COMMISSION` is set.
+The EnOcean switch can be automatically commissioned/decommissioned if option :kconfig:option:`CONFIG_BT_MESH_SILVAIR_ENOCEAN_AUTO_COMMISSION` is set.
 
 The Silvair EnOcean Proxy Server uses either one or two elements on a node.
 Each element handles its own button pair and has its own corresponding :ref:`bt_mesh_onoff_srv_readme` and :ref:`bt_mesh_lvl_srv_readme` models.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -286,6 +286,15 @@ Bluetooth libraries and services
   * Added a SHA-256 hash check to ensure the Fast Pair provisioning data integrity.
   * Added unit test for the storage module.
 
+* :ref:`bt_enocean_readme` library
+  * Added callback :c:member:`decommissioned` to :c:struct:`bt_enocean_callbacks` when EnOcean switch is decommissioned.
+
+* :ref:`bt_mesh` library:
+
+  * Added:
+
+    * :ref:`bt_mesh_silvair_enocean_srv_readme` added use of decommissioned callback when EnOcean switch is decommissioned.
+
 Bootloader libraries
 --------------------
 

--- a/include/bluetooth/enocean.h
+++ b/include/bluetooth/enocean.h
@@ -112,6 +112,15 @@ struct bt_enocean_callbacks {
 	 */
 	void (*commissioned)(struct bt_enocean_device *device);
 
+	/** @brief Callback for EnOcean decommissioning.
+	 *
+	 *  This callback is called for every new EnOcean device being
+	 *  decommissioned.
+	 *
+	 *  @param device Device that got decommissioned.
+	 */
+	void (*decommissioned)(struct bt_enocean_device *device);
+
 	/** @brief Callback for EnOcean devices being loaded from
 	 *         persistent storage.
 	 *

--- a/samples/bluetooth/enocean/src/main.c
+++ b/samples/bluetooth/enocean/src/main.c
@@ -77,10 +77,27 @@ static void enocean_commissioned(struct bt_enocean_device *device)
 	bt_addr_le_to_str(&device->addr, addr, sizeof(addr));
 	printk("EnOcean Device commissioned: %s\n", addr);
 
+	/* Blink leds number of times to show commissioned */
 	for (int i = 0; i < 4; ++i) {
 		dk_set_leds_state(DK_LED1_MSK | DK_LED2_MSK, 0);
 		k_sleep(K_MSEC(100));
 		dk_set_leds_state(0, DK_LED1_MSK | DK_LED2_MSK);
+		k_sleep(K_MSEC(100));
+	}
+}
+
+static void enocean_decommissioned(struct bt_enocean_device *device)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(&device->addr, addr, sizeof(addr));
+	printk("EnOcean Device decommissioned: %s\n", addr);
+
+	/* Blink leds number of times to show decommissioned */
+	for (int i = 0; i < 4; ++i) {
+		dk_set_leds_state(DK_LED3_MSK | DK_LED4_MSK, 0);
+		k_sleep(K_MSEC(100));
+		dk_set_leds_state(0, DK_LED3_MSK | DK_LED4_MSK);
 		k_sleep(K_MSEC(100));
 	}
 }
@@ -113,6 +130,7 @@ void main(void)
 		.button = enocean_button,
 		.sensor = enocean_sensor,
 		.commissioned = enocean_commissioned,
+		.decommissioned = enocean_decommissioned,
 		.loaded = enocean_loaded,
 	};
 

--- a/subsys/bluetooth/enocean.c
+++ b/subsys/bluetooth/enocean.c
@@ -609,6 +609,10 @@ void bt_enocean_decommission(struct bt_enocean_device *dev)
 	}
 
 	dev->flags = 0;
+
+	if (cb->decommissioned) {
+		cb->decommissioned(dev);
+	}
 }
 
 uint32_t bt_enocean_foreach(bt_enocean_foreach_cb_t cb, void *user_data)

--- a/subsys/bluetooth/mesh/vnd/Kconfig
+++ b/subsys/bluetooth/mesh/vnd/Kconfig
@@ -27,7 +27,7 @@ if BT_MESH_SILVAIR_ENOCEAN_SRV
 config BT_MESH_SILVAIR_ENOCEAN_AUTO_COMMISSION
 	bool "Automatically commission"
 	help
-	  Automatically commission EnOcean switches.
+	  Automatically commission/decommission EnOcean switches.
 
 config BT_MESH_SILVAIR_ENOCEAN_TICK_TIME
 	int "Tick time"


### PR DESCRIPTION
Added support for automatic decommissioning of EnOcean switch
in the Silvair EnOcean Proxy Server model. 

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>