### PR TITLE
samples: peripheral: 802154_phy_test: Fix antenna diversity commands

### DIFF
--- a/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_dut_mode.c
+++ b/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_dut_mode.c
@@ -188,12 +188,10 @@ static void dut_idle_packet_proc(void)
 
 	case PTT_CMD_GET_TX_ANTENNA:
 		ret = dut_get_tx_antenna();
-		dut_reset_cur_evt();
 		break;
 
 	case PTT_CMD_GET_LAST_BEST_RX_ANTENNA:
 		ret = dut_get_last_best_rx_antenna();
-		dut_reset_cur_evt();
 		break;
 
 	default:


### PR DESCRIPTION
This commit fixes an assertion error which occurred in the 802.15.4 PHY Test Tool  each time when the rgetbestrxantenna or the rgettxantenna were called. 

The assertion was caused by the fact that the current PTT event was reset by `dut_reset_cur_evt` when it was still locked - for "getter" commands on DUT the current PTT event is unlocked and reset after the answer is transmitted (in `dut_rf_tx_finished`).

Note that for other "getter" commands (such as `rsoftwareversion`, `rhardwareversion`, `rgetpower`) the event wasn't reset immediately - so they were working correctly.

Signed-off-by: Artur Hadasz <artur.hadasz@nordicsemi.no>