### PR TITLE
net: lib: nrf_cloud: Alternate P-GPS download transports

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -527,6 +527,7 @@ Modem libraries
 
     * Changed timeout parameters' type from uint16_t to int32_t, unit from seconds to milliseconds, and value to disable them from 0 to SYS_FOREVER_MS.
       This change is done to align with Zephyr's style for timeouts.
+    * Fixed an issue with P-GPS predictions not being used to speed up GNSS when first downloaded.
 
 Libraries for networking
 ------------------------
@@ -570,6 +571,14 @@ Libraries for networking
   * :ref:`lib_nrf_cloud_rest` library:
 
     * Updated the :c:func:`nrf_cloud_rest_send_location` function to accept a :c:struct `nrf_cloud_gnss_data` pointer instead of an NMEA sentence.
+
+  * :ref:`lib_nrf_cloud_pgps` library:
+
+    * Reduced logging level for many messages to DBG.
+    * Added the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_HTTP`, and :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_CUSTOM` Kconfig options.
+    * Added the :c:func:`nrf_cloud_pgps_begin_update` function that prepares the P-GPS subsystem to receive downloads from a custom transport.
+    * Added the :c:func:`nrf_cloud_pgps_process_update` function that stores a portion of a P-GPS download to flash.
+    * Added the :c:func:`nrf_cloud_pgps_finish_update` function that a user of the P-GPS library calls when the custom download completes.
 
 Libraries for NFC
 -----------------

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.c
@@ -17,6 +17,7 @@
 LOG_MODULE_REGISTER(location_tracking, CONFIG_MQTT_MULTI_SERVICE_LOG_LEVEL);
 
 static location_update_cb_t location_update_handler;
+static bool location_initialized;
 
 void location_assistance_data_handler(const char *buf, size_t len)
 {
@@ -33,6 +34,11 @@ void location_assistance_data_handler(const char *buf, size_t len)
 	 * to the modem by nrf_cloud_agps_process.
 	 */
 	int err;
+
+	if (!location_initialized) {
+		LOG_DBG("Received data but not ready for it.");
+		return;
+	}
 
 	/* First, try to process the payload as A-GPS data, if AGPS is enabled */
 	if (IS_ENABLED(CONFIG_NRF_CLOUD_AGPS)) {
@@ -117,6 +123,7 @@ int start_location_tracking(location_update_cb_t handler_cb, int interval)
 		LOG_ERR("Initializing the Location library failed, error: %d", err);
 		return err;
 	}
+	location_initialized = true;
 
 	/* Construct a request for a periodic location report. */
 	struct location_config config;

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
@@ -67,7 +67,7 @@ config NRF_CLOUD_PGPS_DOWNLOAD_FRAGMENT_SIZE
 	  headers.
 
 choice NRF_CLOUD_PGPS_TRANSPORT
-	prompt "nRF Cloud P-GPS transport"
+	prompt "nRF Cloud P-GPS transport for requests and responses"
 	default NRF_CLOUD_PGPS_TRANSPORT_MQTT if NRF_CLOUD_MQTT
 	default NRF_CLOUD_PGPS_TRANSPORT_NONE
 
@@ -75,17 +75,39 @@ config NRF_CLOUD_PGPS_TRANSPORT_NONE
 	bool "Application-provided transport"
 	help
 	  Enabling this option will make the nRF Cloud P-GPS library not request
-	  data from nRF Cloud when its APIs are called. This will instead let
-	  it be up to the user to request, receive and process P-GPS data.
+	  or receive data from nRF Cloud when its APIs are called. This will
+	  instead let it be up to the user to request, receive and process P-GPS
+	  data.
 
 config NRF_CLOUD_PGPS_TRANSPORT_MQTT
 	bool "MQTT transport"
 	depends on NRF_CLOUD_MQTT
+	depends on NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_HTTP
 	help
 	  Use nRF Cloud library's MQTT implementation to send requests for P-GPS
-	  data and receive responses.
+	  data and receive responses. Responses indicate where the device can
+	  download predictions from, using the NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT.
 
 endchoice # NRF_CLOUD_PGPS_TRANSPORT
+
+choice NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT
+	prompt "nRF Cloud P-GPS download transport"
+	default NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_HTTP
+
+config NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_HTTP
+	bool "Transport P-GPS prediction data over HTTP(S)"
+	help
+	  Enabling this option will make the nRF Cloud P-GPS library use the
+	  download_client library to download prediction data.
+
+config NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_CUSTOM
+	bool "Transport P-GPS data using application-supplied transport"
+	help
+	  Enabling this option bypasses the built-in HTTP(S) transport and
+	  replaces it with an application-specific transport for downloading
+	  prediction data.
+
+endchoice # NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT
 
 config NRF_CLOUD_PGPS_SOCKET_RETRIES
 	int "Number of times to retry a P-GPS download"

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_pgps_utils.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_pgps_utils.h
@@ -46,6 +46,12 @@ struct nrf_cloud_pgps_header;
 
 typedef int (*npgps_buffer_handler_t)(uint8_t *buf, size_t len);
 
+typedef void (*npgps_eot_handler_t)(int err);
+
+/* access control functions */
+int npgps_lock(void);
+void npgps_unlock(void);
+
 /* settings functions */
 int npgps_save_header(struct nrf_cloud_pgps_header *header);
 const struct nrf_cloud_pgps_header *npgps_get_saved_header(void);
@@ -75,7 +81,7 @@ int npgps_pointer_to_block(uint8_t *p);
 void *npgps_block_to_pointer(int block);
 
 /* download functions */
-int npgps_download_init(npgps_buffer_handler_t handler);
+int npgps_download_init(npgps_buffer_handler_t buf_handler, npgps_eot_handler_t eot_handler);
 int npgps_download_start(const char *host, const char *file, int sec_tag,
 			 uint8_t pdn_id, size_t fragment_size);
 


### PR DESCRIPTION
When building with CONFIG_NRF_CLOUD_PGPS_TRANSPORT_NONE, make public  nrf_cloud_pgps_begin_update(), nrf_cloud_process_buffer(), and nrf_cloud_pgps_finish_update(), so alternative transport can be used for downloading predictions, rather than the default download_client over HTTP(S).

Jira: NCSDK-15734

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>