### PR TITLE
lib: multicell_location: Added timeout to API

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -225,6 +225,10 @@ nRF9160 samples
     * Support for injecting GNSS reference altitude for low accuracy mode.
       For a position fix using only three satellites, GNSS module must have a reference altitude that can now be injected using the ``gnss agps ref_altitude`` command.
 
+  * Updated:
+
+    * Changed timeout parameters from seconds to milliseconds in ``location`` and ``rest`` commands.
+
 * :ref:`nrf_cloud_mqtt_multi_service` sample:
 
   * Changed:
@@ -359,6 +363,11 @@ Modem libraries
 
       * Ability to add :ref:`custom trace backends <adding_custom_modem_trace_backends>`.
 
+  * :ref:`lib_location` library:
+
+    * Changed timeout parameters' type from uint16_t to int32_t, unit from seconds to milliseconds, and value to disable them from 0 to SYS_FOREVER_MS.
+      This change is done to align with Zephyr's style for timeouts.
+
 Libraries for networking
 ------------------------
 
@@ -375,6 +384,16 @@ Libraries for networking
       * :c:func:`nrf_cloud_fota_pending_job_validate` function that enables an application to validate a pending FOTA job before initializing the :ref:`lib_nrf_cloud` library.
       * Handling for new nRF Cloud REST error code 40499.
         Moved the error log from the :c:func:`nrf_cloud_parse_rest_error` function into the calling function.
+
+  * :ref:`lib_multicell_location` library:
+
+    * Added timeout parameter.
+    * Made a structure for input parameters for multicell_location_get() to make updates easier in the future.
+
+  * :ref:`lib_rest_client` library:
+
+    * Updated timeout handling. Now using http_client library timeout also.
+    * Removed CONFIG_REST_CLIENT_SCKT_SEND_TIMEOUT and CONFIG_REST_CLIENT_SCKT_RECV_TIMEOUT.
 
 Libraries for NFC
 -----------------

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -154,8 +154,8 @@ struct location_event_data {
 /** GNSS configuration. */
 struct location_gnss_config {
 	/**
-	 * @brief Timeout (in seconds), meaning how long GNSS is allowed to run when trying to
-	 * acquire a fix. Zero means that the timer is disabled, meaning that GNSS will
+	 * @brief Timeout (in milliseconds), meaning how long GNSS is allowed to run when trying to
+	 * acquire a fix. SYS_FOREVER_MS means that the timer is disabled, meaning that GNSS will
 	 * continue to search until it gets a fix or the application calls cancel.
 	 *
 	 * @details Note that this is not real time as experienced by the user.
@@ -165,7 +165,7 @@ struct location_gnss_config {
 	 * and A-GPS is disabled, library waits until modem enters PSM before starting GNSS,
 	 * thus maximizing uninterrupted operating window and minimizing power consumption.
 	 */
-	uint16_t timeout;
+	int32_t timeout;
 
 	/** @brief Desired accuracy level.
 	 *
@@ -202,10 +202,10 @@ struct location_gnss_config {
 /** LTE cellular positioning configuration. */
 struct location_cellular_config {
 	/**
-	 * @brief Timeout (in seconds) of how long the cellular positioning procedure can take.
-	 * Zero means that the timer is disabled.
+	 * @brief Timeout (in milliseconds) of how long the cellular positioning procedure can take.
+	 * SYS_FOREVER_MS means that the timer is disabled.
 	 */
-	uint16_t timeout;
+	int32_t timeout;
 
 	/** Used cellular positioning service. */
 	enum location_service service;
@@ -214,10 +214,10 @@ struct location_cellular_config {
 /** Wi-Fi positioning configuration. */
 struct location_wifi_config {
 	/**
-	 * @brief Timeout (in seconds) of how long the Wi-Fi positioning procedure can take.
-	 * Zero means that the timer is disabled.
+	 * @brief Timeout (in milliseconds) of how long the Wi-Fi positioning procedure can take.
+	 * SYS_FOREVER_MS means that the timer is disabled.
 	 */
-	uint16_t timeout;
+	int32_t timeout;
 
 	/** Used Wi-Fi positioning service. */
 	enum location_service service;

--- a/include/net/multicell_location.h
+++ b/include/net/multicell_location.h
@@ -41,19 +41,31 @@ enum multicell_service {
 	MULTICELL_SERVICE_POLTE
 };
 
+/** Cellular positioning input parameters. */
+struct multicell_location_params {
+	/** Cellular positioning service to be used. */
+	enum multicell_service service;
+	/** Neighbor cell data. */
+	const struct lte_lc_cells_info *cell_data;
+	/**
+	 * @brief Timeout (in milliseconds) of how long the cellular positioning procedure can take.
+	 * SYS_FOREVER_MS means that the timer is disabled.
+	 */
+	int32_t timeout;
+};
+
 /**
  * @brief Send a request for location based on cell measurements to the
  *        selected location service.
  *
  * @note This function will block the calling thread until a response
- *       is received from the location service.
+ *       is received from the location service, or timeout has elapsed.
  *
  * @note Certificate must be provisioned before a request can be sent,
  *       @ref multicell_location_provision_certificate.
  *
- * @param[in] service Cellular positioning service to be used.
- * @param[in] cell_data Pointer to neighbor cell data.
- * @param[out] location Pointer to location.
+ * @param[in] params Cellular positioning parameters to be used.
+ * @param[out] location Location.
  *
  * @return 0 on success, or negative error code on failure.
  * @retval -ENOENT No cellular cells found from cell_data. I.e., even current cell
@@ -61,8 +73,7 @@ enum multicell_service {
  * @retval -ENOMEM Out of memory.
  * @retval -ENOMSG Parsing response from the location service failed.
  */
-int multicell_location_get(enum multicell_service service,
-			   const struct lte_lc_cells_info *cell_data,
+int multicell_location_get(const struct multicell_location_params *params,
 			   struct multicell_location *location);
 
 /**

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -50,7 +50,6 @@ enum nrf_cloud_rest_agps_req_type {
 	NRF_CLOUD_REST_AGPS_REQ_UNSPECIFIED,
 };
 
-#define NRF_CLOUD_REST_TIMEOUT_MINIMUM		(5000)
 #define NRF_CLOUD_REST_TIMEOUT_NONE		(SYS_FOREVER_MS)
 
 /** @brief Parameters and data for using the nRF Cloud REST API */
@@ -65,11 +64,10 @@ struct nrf_cloud_rest_context {
 	 * being closed.
 	 */
 	bool keep_alive;
-	/** Timeout value, in milliseconds, for receiving response data.
-	 * Minimum timeout value specified by NRF_CLOUD_REST_TIMEOUT_MINIMUM.
+	/** Timeout value, in milliseconds, for REST request. The timeout is set individually
+	 * for socket connection creation and data transfer meaning REST request can take
+	 * longer than this given timeout.
 	 * For no timeout, set to NRF_CLOUD_REST_TIMEOUT_NONE.
-	 * @note This parameter is currently not used; set
-	 * CONFIG_REST_CLIENT_SCKT_RECV_TIMEOUT instead.
 	 */
 	int32_t timeout_ms;
 	/** Authentication string: JWT @ref modem_jwt.

--- a/include/net/rest_client.h
+++ b/include/net/rest_client.h
@@ -83,7 +83,9 @@ struct rest_client_req_context {
 	/** Payload/body, may be NULL. */
 	const char *body;
 
-	/** User-defined timeout value for receiving response data.
+	/** User-defined timeout value for REST request. The timeout is set individually
+	 *  for socket connection creation and data transfer meaning REST request can take
+	 *  longer than this given timeout. To disable, set the timeout duration to SYS_FOREVER_MS.
 	 *  Default: CONFIG_REST_CLIENT_REST_REQUEST_TIMEOUT.
 	 */
 	int32_t timeout_ms;

--- a/lib/location/location.c
+++ b/lib/location/location.c
@@ -129,15 +129,15 @@ static void location_config_method_defaults_set(
 
 	method->method = method_type;
 	if (method_type == LOCATION_METHOD_GNSS) {
-		method->gnss.timeout = 120;
+		method->gnss.timeout = 120 * MSEC_PER_SEC;
 		method->gnss.accuracy = LOCATION_ACCURACY_NORMAL;
 		method->gnss.num_consecutive_fixes = 3;
 		method->gnss.visibility_detection = false;
 	} else if (method_type == LOCATION_METHOD_CELLULAR) {
-		method->cellular.timeout = 30;
+		method->cellular.timeout = 30 * MSEC_PER_SEC;
 		method->cellular.service = LOCATION_SERVICE_ANY;
 	} else if (method_type == LOCATION_METHOD_WIFI) {
-		method->wifi.timeout = 30;
+		method->wifi.timeout = 30 * MSEC_PER_SEC;
 		method->wifi.service = LOCATION_SERVICE_ANY;
 	}
 }

--- a/lib/location/location_core.h
+++ b/lib/location/location_core.h
@@ -33,7 +33,8 @@ void location_core_event_cb_pgps_request(const struct gps_pgps_request *request)
 #endif
 
 void location_core_config_log(const struct location_config *config);
-void location_core_timer_start(uint16_t timeout);
+void location_core_timer_start(int32_t timeout);
+void location_core_timer_stop(void);
 struct k_work_q *location_core_work_queue_get(void);
 
 #endif /* LOCATION_CORE_H */

--- a/lib/location/wifi/wifi_service.h
+++ b/lib/location/wifi/wifi_service.h
@@ -17,7 +17,6 @@
 #include <zephyr/net/wifi.h>
 #include <modem/location.h>
 
-#define REST_WIFI_MIN_TIMEOUT_MS 1500
 #define WIFI_MAC_ADDR_STR_LEN 17
 
 /** @brief Item for passing a Wi-Fi scanning result */

--- a/lib/multicell_location/multicell_location.c
+++ b/lib/multicell_location/multicell_location.c
@@ -24,26 +24,30 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_MULTICELL_LOCATION_SERVICE_NRF_CLOUD) ||
 	     "At least one location service must be enabled");
 
 
-int multicell_location_get(enum multicell_service service,
-			   const struct lte_lc_cells_info *cell_data,
-			   struct multicell_location *location)
+int multicell_location_get(
+	const struct multicell_location_params *params,
+	struct multicell_location *location)
 {
-	if ((cell_data == NULL) || (location == NULL)) {
+	if (params == NULL || (params->cell_data == NULL) || (location == NULL)) {
 		return -EINVAL;
 	}
 
-	if (cell_data->current_cell.id == LTE_LC_CELL_EUTRAN_ID_INVALID) {
+	LOG_DBG("Multicell location parameters:");
+	LOG_DBG("  Service: %d", params->service);
+	LOG_DBG("  Timeout: %dms", params->timeout);
+
+	if (params->cell_data->current_cell.id == LTE_LC_CELL_EUTRAN_ID_INVALID) {
 		LOG_WRN("Invalid cell ID, device may not be connected to a network");
 		return -ENOENT;
 	}
 
-	if (cell_data->ncells_count > CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS) {
+	if (params->cell_data->ncells_count > CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS) {
 		LOG_WRN("Found %d neighbor cells, but %d cells will be used in location request",
-			cell_data->ncells_count, CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS);
+			params->cell_data->ncells_count, CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS);
 		LOG_WRN("Increase CONFIG_MULTICELL_LOCATION_MAX_NEIGHBORS to use more cells");
 	}
 
-	return location_service_get_cell_location(service, cell_data, location);
+	return location_service_get_cell_location(params, location);
 }
 
 static int multicell_location_provision_service_certificate(

--- a/lib/multicell_location/services/here_integration.c
+++ b/lib/multicell_location/services/here_integration.c
@@ -358,7 +358,7 @@ clean_exit:
 }
 
 int location_service_get_cell_location_here(
-	const struct lte_lc_cells_info *cell_data,
+	const struct multicell_location_params *params,
 	char * const rcv_buf,
 	const size_t rcv_buf_len,
 	struct multicell_location *const location)
@@ -373,7 +373,7 @@ int location_service_get_cell_location_here(
 		NULL
 	};
 
-	err = location_service_generate_request(cell_data, body, sizeof(body));
+	err = location_service_generate_request(params->cell_data, body, sizeof(body));
 	if (err) {
 		LOG_ERR("Failed to generate HTTP request, error: %d", err);
 		return err;
@@ -391,6 +391,7 @@ int location_service_get_cell_location_here(
 	req_ctx.header_fields = (const char **)headers;
 	req_ctx.resp_buff = rcv_buf;
 	req_ctx.resp_buff_len = rcv_buf_len;
+	req_ctx.timeout_ms = params->timeout;
 
 	/* Get the body/payload to request: */
 	req_ctx.body = body;

--- a/lib/multicell_location/services/here_integration.h
+++ b/lib/multicell_location/services/here_integration.h
@@ -18,7 +18,7 @@ extern "C" {
 const char *location_service_get_certificate_here(void);
 
 int location_service_get_cell_location_here(
-	const struct lte_lc_cells_info *cell_data,
+	const struct multicell_location_params *params,
 	char *const rcv_buf,
 	const size_t rcv_buf_len,
 	struct multicell_location *const location);

--- a/lib/multicell_location/services/location_service.c
+++ b/lib/multicell_location/services/location_service.c
@@ -37,26 +37,28 @@ const char *location_service_get_certificate(enum multicell_service service)
 }
 
 int location_service_get_cell_location(
-	enum multicell_service service,
-	const struct lte_lc_cells_info *cell_data,
-	struct multicell_location *const location)
+	const struct multicell_location_params *params,
+	struct multicell_location *location)
 {
 #if defined(CONFIG_MULTICELL_LOCATION_SERVICE_NRF_CLOUD)
-	if (service == MULTICELL_SERVICE_NRF_CLOUD || service == MULTICELL_SERVICE_ANY) {
+	if (params->service == MULTICELL_SERVICE_NRF_CLOUD ||
+	    params->service == MULTICELL_SERVICE_ANY) {
 		return location_service_get_cell_location_nrf_cloud(
-			cell_data, recv_buf, sizeof(recv_buf), location);
+			params, recv_buf, sizeof(recv_buf), location);
 	}
 #endif
 #if defined(CONFIG_MULTICELL_LOCATION_SERVICE_HERE)
-	if (service == MULTICELL_SERVICE_HERE || service == MULTICELL_SERVICE_ANY) {
+	if (params->service == MULTICELL_SERVICE_HERE ||
+	    params->service == MULTICELL_SERVICE_ANY) {
 		return location_service_get_cell_location_here(
-			cell_data, recv_buf, sizeof(recv_buf), location);
+			params, recv_buf, sizeof(recv_buf), location);
 	}
 #endif
 #if defined(CONFIG_MULTICELL_LOCATION_SERVICE_POLTE)
-	if (service == MULTICELL_SERVICE_POLTE || service == MULTICELL_SERVICE_ANY) {
+	if (params->service == MULTICELL_SERVICE_POLTE ||
+	    params->service == MULTICELL_SERVICE_ANY) {
 		return location_service_get_cell_location_polte(
-			cell_data, recv_buf, sizeof(recv_buf), location);
+			params, recv_buf, sizeof(recv_buf), location);
 	}
 #endif
 	/* We should never get here as at least one service must be enabled */

--- a/lib/multicell_location/services/location_service.h
+++ b/lib/multicell_location/services/location_service.h
@@ -28,8 +28,7 @@ const char *location_service_get_certificate(enum multicell_service service);
 /**
  * @brief Generate location request, send, and parse response.
  *
- * @param[in] service Cellular positioning service to be used.
- * @param[in] cell_data Pointer to neighbor cell data.
+ * @param[in] params Cellular positioning parameters to be used.
  * @param[out] location Storage for the result from response parsing.
  *
  * @return 0 on success, or negative error code on failure.
@@ -39,9 +38,8 @@ const char *location_service_get_certificate(enum multicell_service service);
  * @retval -ENOMSG Parsing response from the location service failed.
  */
 int location_service_get_cell_location(
-	enum multicell_service service,
-	const struct lte_lc_cells_info *cell_data,
-	struct multicell_location *const location);
+	const struct multicell_location_params *params,
+	struct multicell_location *location);
 
 #ifdef __cplusplus
 }

--- a/lib/multicell_location/services/nrf_cloud_integration.c
+++ b/lib/multicell_location/services/nrf_cloud_integration.c
@@ -133,7 +133,7 @@ int location_service_get_cell_location_nrf_cloud(
 }
 #else /* defined(CONFIG_NRF_CLOUD_MQTT) */
 int location_service_get_cell_location_nrf_cloud(
-	const struct lte_lc_cells_info *cell_data,
+	const struct multicell_location_params *params,
 	char * const rcv_buf,
 	const size_t rcv_buf_len,
 	struct multicell_location *const location)
@@ -143,13 +143,13 @@ int location_service_get_cell_location_nrf_cloud(
 	struct nrf_cloud_rest_context rest_ctx = {
 		.connect_socket = -1,
 		.keep_alive = false,
-		.timeout_ms = NRF_CLOUD_REST_TIMEOUT_NONE,
+		.timeout_ms = params->timeout,
 		.rx_buf = rcv_buf,
 		.rx_buf_len = rcv_buf_len,
 		.fragment_size = 0
 	};
 	const struct nrf_cloud_rest_cell_pos_request loc_req = {
-		.net_info = (struct lte_lc_cells_info *)cell_data
+		.net_info = (struct lte_lc_cells_info *)params->cell_data
 	};
 
 	LOG_DBG("Sending cellular positioning request (REST)");

--- a/lib/multicell_location/services/nrf_cloud_integration.h
+++ b/lib/multicell_location/services/nrf_cloud_integration.h
@@ -18,7 +18,7 @@ extern "C" {
 const char *location_service_get_certificate_nrf_cloud(void);
 
 int location_service_get_cell_location_nrf_cloud(
-	const struct lte_lc_cells_info *cell_data,
+	const struct multicell_location_params *params,
 	char *const rcv_buf,
 	const size_t rcv_buf_len,
 	struct multicell_location *const location);

--- a/lib/multicell_location/services/polte_integration.c
+++ b/lib/multicell_location/services/polte_integration.c
@@ -281,7 +281,7 @@ clean_exit:
 }
 
 int location_service_get_cell_location_polte(
-	const struct lte_lc_cells_info *cell_data,
+	const struct multicell_location_params *params,
 	char * const rcv_buf,
 	const size_t rcv_buf_len,
 	struct multicell_location *const location)
@@ -298,7 +298,7 @@ int location_service_get_cell_location_polte(
 	};
 	static char body[HTTP_BODY_SIZE];
 
-	err = location_service_generate_request(cell_data, body, sizeof(body));
+	err = location_service_generate_request(params->cell_data, body, sizeof(body));
 	if (err) {
 		LOG_ERR("Failed to generate HTTP request, error: %d", err);
 		return err;
@@ -316,6 +316,7 @@ int location_service_get_cell_location_polte(
 	req_ctx.header_fields = (const char **)headers;
 	req_ctx.resp_buff = rcv_buf;
 	req_ctx.resp_buff_len = rcv_buf_len;
+	req_ctx.timeout_ms = params->timeout;
 
 	/* Get the body/payload to request: */
 	req_ctx.body = body;

--- a/lib/multicell_location/services/polte_integration.h
+++ b/lib/multicell_location/services/polte_integration.h
@@ -18,7 +18,7 @@ extern "C" {
 const char *location_service_get_certificate_polte(void);
 
 int location_service_get_cell_location_polte(
-	const struct lte_lc_cells_info *cell_data,
+	const struct multicell_location_params *params,
 	char *const rcv_buf,
 	const size_t rcv_buf_len,
 	struct multicell_location *const location);

--- a/samples/nrf9160/location/src/main.c
+++ b/samples/nrf9160/location/src/main.c
@@ -104,9 +104,9 @@ static void location_with_fallback_get(void)
 
 	location_config_defaults_set(&config, ARRAY_SIZE(methods), methods);
 	/* GNSS timeout is set to 1 second to force a failure. */
-	config.methods[0].gnss.timeout = 1;
+	config.methods[0].gnss.timeout = 1 * MSEC_PER_SEC;
 	/* Default cellular configuration may be overridden here. */
-	config.methods[1].cellular.timeout = 30;
+	config.methods[1].cellular.timeout = 40 * MSEC_PER_SEC;
 
 	printk("Requesting location with short GNSS timeout to trigger fallback to cellular...\n");
 

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -399,13 +399,13 @@ Examples
 
   .. code-block:: console
 
-     location get --method wifi --wifi_timeout 60 --method cellular --cellular_service nrf
+     location get --method wifi --wifi_timeout 60000 --method cellular --cellular_service nrf
 
 * Retrieve location periodically every hour with GNSS and if not found, use cellular positioning:
 
   .. code-block:: console
 
-     location get --interval 3600 --method gnss --gnss_timeout 300 --method cellular
+     location get --interval 3600 --method gnss --gnss_timeout 300000 --method cellular
 
 * Cancel ongoing location request or periodic location request:
 

--- a/samples/nrf9160/modem_shell/src/location/location_shell.c
+++ b/samples/nrf9160/modem_shell/src/location/location_shell.c
@@ -63,14 +63,14 @@ static const char location_get_usage_str[] =
 	"  --gnss_accuracy,    Used GNSS accuracy: 'low', 'normal' or 'high'\n"
 	"  --gnss_num_fixes,   Number of consecutive fix attempts (if gnss_accuracy\n"
 	"                      set to 'high', default: 3)\n"
-	"  --gnss_timeout,     GNSS timeout in seconds\n"
+	"  --gnss_timeout,     GNSS timeout in milliseconds. Zero means timeout is disabled.\n"
 	"  --gnss_visibility,  Enables GNSS obstructed visibility detection\n"
 	"  --gnss_cloud_nmea,  Send acquired GNSS location to nRF Cloud formatted as NMEA\n"
 	"  --gnss_cloud_pvt,   Send acquired GNSS location to nRF Cloud formatted as PVT\n"
-	"  --cellular_timeout, Cellular timeout in seconds\n"
+	"  --cellular_timeout, Cellular timeout in milliseconds. Zero means timeout is disabled.\n"
 	"  --cellular_service, Used cellular positioning service:\n"
 	"                      'any' (default), 'nrf', 'here' or 'polte'\n"
-	"  --wifi_timeout,     Wi-Fi timeout in seconds\n"
+	"  --wifi_timeout,     Wi-Fi timeout in milliseconds. Zero means timeout is disabled.\n"
 	"  --wifi_service,     Used Wi-Fi positioning service:\n"
 	"                      'any' (default), 'nrf' or 'here'\n";
 
@@ -364,6 +364,9 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 		case LOCATION_SHELL_OPT_GNSS_TIMEOUT:
 			gnss_timeout = atoi(optarg);
 			gnss_timeout_set = true;
+			if (gnss_timeout == 0) {
+				gnss_timeout = SYS_FOREVER_MS;
+			}
 			break;
 
 		case LOCATION_SHELL_OPT_GNSS_NUM_FIXES:
@@ -379,6 +382,9 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 		case LOCATION_SHELL_OPT_CELLULAR_TIMEOUT:
 			cellular_timeout = atoi(optarg);
 			cellular_timeout_set = true;
+			if (cellular_timeout == 0) {
+				cellular_timeout = SYS_FOREVER_MS;
+			}
 			break;
 
 		case LOCATION_SHELL_OPT_CELLULAR_SERVICE:
@@ -392,6 +398,9 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 		case LOCATION_SHELL_OPT_WIFI_TIMEOUT:
 			wifi_timeout = atoi(optarg);
 			wifi_timeout_set = true;
+			if (wifi_timeout == 0) {
+				wifi_timeout = SYS_FOREVER_MS;
+			}
 			break;
 
 		case LOCATION_SHELL_OPT_WIFI_SERVICE:

--- a/samples/nrf9160/modem_shell/src/rest/rest_shell.c
+++ b/samples/nrf9160/modem_shell/src/rest/rest_shell.c
@@ -33,7 +33,7 @@ static const char rest_shell_cmd_usage_str[] =
 	"  -v, --peer_verify,   TLS peer verification level. None (0),\n"
 	"                       optional (1) or required (2). Default value is 2.\n"
 	"  -u, --url,           URL beyond host/domain (default: \"/index.html\")\n"
-	"  -t, --timeout,       Request timeout in seconds\n"
+	"  -t, --timeout,       Request timeout in seconds. Zero means timeout is disabled.\n"
 	"                       (default: CONFIG_REST_CLIENT_REST_REQUEST_TIMEOUT)\n"
 	"  -H, --header,        Header including CRLF, for example:\n"
 	"                       -H \"Content-Type: application/json\\x0D\\x0A\"\n"
@@ -165,11 +165,8 @@ int rest_shell(const struct shell *shell, size_t argc, char **argv)
 		case 't':
 			req_ctx.timeout_ms = atoi(optarg);
 			if (req_ctx.timeout_ms == 0) {
-				mosh_warn("timeout not an integer (> 0)");
-				ret = -EINVAL;
-				goto end;
+				req_ctx.timeout_ms = SYS_FOREVER_MS;
 			}
-			req_ctx.timeout_ms *= 1000;
 			break;
 		case 'p':
 			req_ctx.port = atoi(optarg);

--- a/samples/nrf9160/multicell_location/src/main.c
+++ b/samples/nrf9160/multicell_location/src/main.c
@@ -261,11 +261,15 @@ static void print_cell_data(void)
 static void request_location(enum multicell_service service, const char *service_str)
 {
 	int err;
+	struct multicell_location_params params = { 0 };
 	struct multicell_location location;
 
 	LOG_INF("Sending location request for %s ...", service_str);
 
-	err = multicell_location_get(service, &cell_data, &location);
+	params.service = service;
+	params.cell_data = &cell_data;
+	params.timeout = SYS_FOREVER_MS;
+	err = multicell_location_get(&params, &location);
 	if (err) {
 		LOG_ERR("Failed to acquire location, error: %d", err);
 		return;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -226,7 +226,7 @@ static void init_rest_client_request(struct nrf_cloud_rest_context const *const 
 	req->port		= HTTPS_PORT;
 	req->host		= CONFIG_NRF_CLOUD_REST_HOST_NAME;
 	req->tls_peer_verify	= TLS_PEER_VERIFY_REQUIRED;
-	req->timeout_ms		= SYS_FOREVER_MS;
+	req->timeout_ms		= rest_ctx->timeout_ms;
 
 	req->http_method	= meth;
 
@@ -1249,7 +1249,7 @@ int nrf_cloud_rest_jitp(const sec_tag_t nrf_cloud_sec_tag)
 	req.header_fields	= (const char **)headers;
 	req.url			= JITP_URL;
 	req.host		= JITP_HOSTNAME_TLS;
-	req.timeout_ms		= SYS_FOREVER_MS;
+	req.timeout_ms		= JITP_HTTP_TIMEOUT_MS;
 	req.http_method		= HTTP_POST;
 	req.resp_buff		= rx_buf;
 	req.resp_buff_len	= sizeof(rx_buf);

--- a/subsys/net/lib/rest_client/Kconfig
+++ b/subsys/net/lib/rest_client/Kconfig
@@ -10,23 +10,12 @@ menuconfig REST_CLIENT
 if REST_CLIENT
 
 config REST_CLIENT_REQUEST_TIMEOUT
-	int "Rest request timeout, in seconds"
-	default 65
-	help
-	  Sets the timeout duration in seconds to wait for the response data.
-
-config REST_CLIENT_SCKT_SEND_TIMEOUT
-	int "Socket send timeout, in seconds"
+	int "REST request timeout, in seconds"
 	default 60
 	help
-	  Sets the timeout duration in seconds to use when sending data.
-	  To disable, set the timeout duration to 0.
-
-config REST_CLIENT_SCKT_RECV_TIMEOUT
-	int "Socket receive timeout, in seconds"
-	default 60
-	help
-	  Sets the timeout duration in seconds to use when receiving data.
+	  Sets the default timeout duration in seconds to wait for socket connection
+	  creation and data transfer. The timeout is set individually for these phases
+	  meaning REST request can take longer than this given timeout.
 	  To disable, set the timeout duration to 0.
 
 config REST_CLIENT_SCKT_TLS_SESSION_CACHE_IN_USE


### PR DESCRIPTION
Timeout is passed to multicell location library and time taken for neighbour cell measurement is been subtracted.
I will change the timeouts in location library library into `int32_t timeout`, which will be in milliseconds and SYS_FOREVER_MS will indicate no timeout.
Combine input parameters for multicell_location_get() into a structure to make it easier to modify the API.
