### PR TITLE
nrf_rpc: Add default heap size for IPC Service transport

### DIFF
--- a/subsys/nrf_rpc/Kconfig
+++ b/subsys/nrf_rpc/Kconfig
@@ -26,6 +26,13 @@ menuconfig NRF_RPC_IPC_SERVICE
 
 if NRF_RPC_IPC_SERVICE
 
+# Redefine this symbol here and give it a non-zero default value
+# so that the Zephyr system heap is enabled, the nRF IPC IPC service
+# depends on it
+config HEAP_MEM_POOL_SIZE
+	int
+	default 2048
+
 config NRF_RPC_IPC_SERVICE_BIND_TIMEOUT_MS
 	int "Timeout while waiting for the endpoint to bind in ms"
 	range 1 1000


### PR DESCRIPTION
It adds heap size configuration override for the nRF RPC
IPC Service transport which requires heap for packets
allocation.