### PR TITLE
doc: update nRF9160 user guide with VSC and command line instructions

### DIFF
--- a/doc/nrf/includes/cmd_build_and_run.txt
+++ b/doc/nrf/includes/cmd_build_and_run.txt
@@ -1,0 +1,29 @@
+Complete the :ref:`command-line build setup <build_environment_cli>` before you start building |NCS| projects on the command line.
+
+To build and program the source code from the command line, complete the following steps:
+
+1. Open a terminal window.
+#. Go to the specific sample or application directory.
+   For example, the folder path is :file:`ncs/nrf/applications/asset_tracker_v2` when building the source code for the :ref:`asset_tracker_v2` application |cmd_folder_path|.
+
+#. Make sure that you have the required version of the |NCS| repository by pulling the |NCS| repository, `sdk-nrf`_ on GitHub using the procedures described in :ref:`dm-wf-get-ncs` and :ref:`dm-wf-update-ncs`.
+
+#. To get the rest of the dependencies, run the ``west update`` command as follows:
+
+   .. code-block:: console
+
+      west update
+
+#. To build the sample or application code, run the ``west build`` command as follows:
+
+   .. parsed-literal::
+      :class: highlight
+
+      west build -b *build_target*
+
+   The parameter *build_target* must be |cmd_build_target|.
+
+   .. note::
+
+      The parameter *destination_directory_name* can be used to optionally specify the destination directory in the west command.
+      Unless a *destination_directory_name* is specified, the build files are automatically generated in :file:`build/zephyr/`.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -503,6 +503,7 @@ Documentation
     Also added further clarifications to the page to make everything clearer.
   * :ref:`ug_nrf9160_gs` guide by moving :ref:`nrf9160_gs_updating_fw_modem` section before :ref:`nrf9160_gs_updating_fw_application` because updating modem firmware erases application firmware.
   * :ref:`ug_matter_tools` page with a new section about the ZAP tool.
+  * :ref:`build_pgm_nrf9160` section in the :ref:`ug_nrf9160` documentation by adding |VSC| and command line instructions.
 
 * Removed:
 

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -136,7 +136,7 @@ Complete the following steps to provision the certificate:
 #. Enter ``AT+CFUN?`` in the text field for AT commands and click :guilabel:`Send`.
    This AT command returns the state of the modem.
 
-   The command should return ``+CFUN: 4``, which indicates that the modem is in offline state.
+   The command must return ``+CFUN: 4``, which indicates that the modem is in offline state.
    If it returns a different value, repeat the previous step.
 #. Click :guilabel:`Certificate manager` in the navigation bar to switch to the certificate manager view.
 
@@ -184,6 +184,8 @@ In Zephyr, :ref:`zephyr:nrf9160dk_nrf9160` is divided into two different build t
 
 Make sure to select a suitable build target when building your application.
 
+.. _build_pgm_nrf9160:
+
 Building and programming
 ************************
 
@@ -199,8 +201,71 @@ Likewise, in Step 7, choose the :file:`.hex` file for the application you are pr
 .. note::
    When you update the application firmware on an nRF9160 DK, you must also update the modem firmware as described in :ref:`nrf9160_gs_updating_fw_modem`.
 
-See :ref:`gs_programming` for more information on building and programming samples on nRF9160 DK.
+.. _build_pgm_nrf9160_vsc:
 
+Building and programming using |VSC|
+====================================
+
+|vsc_extension_instructions|
+
+Complete the following steps after installing the |nRFVSC|:
+
+.. |sample_path_vsc| replace:: :file:`ncs/nrf/applications/asset_tracker_v2`
+
+.. |vsc_sample_board_target_line| replace:: you must use the build target ``nrf9160dk_nrf9160_ns`` when building the application code for the nRF9160 DK
+
+.. include:: /includes/vsc_build_and_run.txt
+
+#. Program the application:
+
+.. prog_nrf9160_start
+..
+
+   a. Set the **SW10** switch (marked PROG/DEBUG) in the **nRF91** position to program the nRF9160 application.
+      In nRF9160 DK v0.9.0 and earlier, the switch is called **SW5**.
+   #. Connect the nRF9160 DK to your PC using a USB cable.
+   #. Power on the nRF9160 DK.
+
+.. prog_nrf9160_end
+..
+
+   d. In |VSC|, click the :guilabel:`Flash` option in the :guilabel:`Actions` panel.
+
+      If you have multiple boards connected, you are prompted to pick a device at the top of the screen.
+
+      A small notification banner appears in the bottom-right corner of |VSC| to display the progress and confirm when the flash is complete.
+
+.. _build_pgm_nrf9160_cmdline:
+
+Building and programming on the command line
+============================================
+
+.. |cmd_folder_path| replace:: on the nRF9160 DK
+
+.. |cmd_build_target| replace:: ``nrf9160dk_nrf9160_ns`` when building the application code for the nRF9160 DK
+
+
+.. include:: /includes/cmd_build_and_run.txt
+
+#. Program the application:
+
+.. include:: ug_nrf9160.rst
+   :start-after: prog_nrf9160_start
+   :end-before: prog_nrf9160_end
+..
+
+   d. Program the sample or application to the device using the following command:
+
+      .. code-block:: console
+
+         west flash
+
+      .. note::
+         When programming with the :ref:`asset_tracker_v2` application, use the ``west flash --erase`` command.
+         The application has secure boot enabled by default that includes data in the :ref:`One-Time Programmable region (OTP)<bootloader_provisioning_otp>`.
+         This means that everything must be erased before flashing.
+
+      The device resets and runs the programmed sample or application.
 
 Board revisions
 ***************
@@ -218,7 +283,7 @@ To make use of these features, specify the board revision when building your app
    Newer revisions are compatible with the default revision.
 
 To specify the board revision, append it to the build target when building.
-For example, when building a non-secure application for nRF9160 DK v1.0.0, use ``nrf9160dk_nrf9106ns@1.0.0`` as build target.
+For example, when building a non-secure application for nRF9160 DK v1.0.0, use ``nrf9160dk_nrf9106_ns@1.0.0`` as build target.
 
 See :ref:`zephyr:application_board_version` and :ref:`zephyr:nrf9160dk_additional_hardware` for more information.
 

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -85,7 +85,7 @@ LTE Band Lock
 The modem within Thingy:91 can be configured to use specific LTE bands by using the band lock AT command.
 See :ref:`nrf9160_ug_band_lock` and the `band lock section in the AT Commands reference document`_ for additional information.
 The preprogrammed firmware configures the modem to use the bands currently certified on the Thingy:91 hardware.
-When building the firmware, you can configure which bands should be enabled.
+When building the firmware, you can configure which bands must be enabled.
 
 LTE-M / NB-IoT switching
 ************************
@@ -107,14 +107,12 @@ The build targets of interest for Thingy:91 in |NCS| are as follows:
 +---------------+---------------------------------------------------+
 |Component      |  Build target                                     |
 +===============+===================================================+
-|nRF9160 SiP    |``thingy91_nrf9160`` for the secure version        |
-|               |                                                   |
-|               |``thingy91_nrf9160_ns`` for the non-secure version |
+|nRF9160 SiP    |``thingy91_nrf9160_ns``                            |
 +---------------+---------------------------------------------------+
 |nRF52840 SoC   |``thingy91_nrf52840``                              |
 +---------------+---------------------------------------------------+
 
-You must use the build target ``thingy91_nrf9160`` or ``thingy91_nrf9160_ns`` when building the application code for the nRF9160 SiP and the build target ``thingy91_nrf52840`` when building the application code for the onboard nRF52840 SoC.
+You must use the build target ``thingy91_nrf9160_ns`` when building the application code for the nRF9160 SiP and the build target ``thingy91_nrf52840`` when building the application code for the onboard nRF52840 SoC.
 
 .. note::
 
@@ -170,9 +168,9 @@ Building and programming using |VSC|
 
 Complete the following steps after installing the |nRFVSC|:
 
-.. |sample_path_vsc| replace:: :file:`samples/nrf9160/cloud_client`
+.. |sample_path_vsc| replace:: :file:`ncs/nrf/applications/asset_tracker_v2`
 
-.. |vsc_sample_board_target_line| replace:: you must use the build target ``thingy91_nrf9160`` or ``thingy91_nrf9160_ns`` when building the application code for the nRF9160 SiP and the build target ``thingy91_nrf52840`` when building the application code for the onboard nRF52840 SoC.
+.. |vsc_sample_board_target_line| replace:: you must use the build target ``thingy91_nrf9160_ns`` when building the application code for the nRF9160 SiP and the build target ``thingy91_nrf52840`` when building the application code for the onboard nRF52840 SoC
 
 .. include:: /includes/vsc_build_and_run.txt
 
@@ -205,35 +203,11 @@ Complete the following steps after installing the |nRFVSC|:
 Building and programming on the command line
 ============================================
 
-Complete the :ref:`command-line build setup <build_environment_cli>` before you start building |NCS| projects on the command line.
+.. |cmd_folder_path| replace:: on the nRF9160 SiP component and ``ncs/nrf/applications/connectivity_bridge`` when building the source code for the :ref:`connectivity_bridge` application on the nRF52840 SoC component
 
-To build and program the source code from the command line, complete the following steps:
+.. |cmd_build_target| replace:: ``thingy91_nrf9160_ns`` if building for the nRF9160 SiP component and ``thingy91_nrf52840`` if building for the nRF52840 SoC component
 
-1. Open a terminal window.
-#. Go to the specific sample or application directory.
-   For example, the folder path is ``ncs/nrf/applications/asset_tracker_v2`` when building the source code for the :ref:`asset_tracker_v2` application on the nRF9160 SiP component and ``ncs/nrf/applications/connectivity_bridge`` when building the source code for the :ref:`connectivity_bridge` application on the nRF52840 SoC component.
-
-#. Make sure that you have the required version of the |NCS| repository by pulling the |NCS| repository, `sdk-nrf`_ on GitHub using the procedures described in :ref:`dm-wf-get-ncs` and :ref:`dm-wf-update-ncs`.
-
-#. To get the rest of the dependencies, run the ``west update`` command as follows:
-
-   .. code-block:: console
-
-      west update
-
-#. To build the sample or application code, run the ``west build`` command as follows:
-
-   .. parsed-literal::
-      :class: highlight
-
-      west build -b *build_target* -d *destination_directory_name*
-
-   The parameter *build_target* should be ``thingy91_nrf9160`` or ``thingy91_nrf9160_ns`` if building for the nRF9160 SiP component and ``thingy91_nrf52840`` if building for the nRF52840 SoC component.
-
-   .. note::
-
-	   The parameter *destination_directory_name* can be used to optionally specify the destination directory in the west command.
-	   Unless a *destination_directory_name* is specified, the build files are automatically generated in ``build/zephyr/``.
+.. include:: /includes/cmd_build_and_run.txt
 
 #. Program the application:
 
@@ -246,6 +220,6 @@ To build and program the source code from the command line, complete the followi
 
       .. code-block:: console
 
-       west flash
+          west flash
 
-      The device will reset and run the programmed sample or application.
+      The device resets and runs the programmed sample or application.


### PR DESCRIPTION
updated the Building and programming section with
Visual Studio Code and command line instructions
on the Developing with nRF9160 DK documentation.

This change was done to align with other
Thingy:91, nRF5340 and Thingy:53 user guides.

Signed-off-by: divya <divya.pillai@nordicsemi.no>