### PR TITLE
ci: Disable mergify on draft PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,6 +4,8 @@ pull_request_rules:
       - base=main
       - "#approved-reviews-by>=1"
       - approved-reviews-by=@ncs-code-owners
+      - -draft
+      - -label=DNM
       - or:
         - label=manifest-homekit
         - label=manifest-find-my


### PR DESCRIPTION
Disable automerge if PR is draft or has DNM label

I have not tested it.
Changes prepared based on https://docs.mergify.com/conditions/#conditions

Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>