### PR TITLE
doc: fix Thingy:53 link to Edge Impulse

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -645,7 +645,7 @@
 .. _`Edge Impulse CLI installation guide`: https://docs.edgeimpulse.com/docs/cli-installation
 .. _`NCS simulated sensor machine learning model`: https://studio.edgeimpulse.com/public/18121/latest
 .. _`NCS hardware accelerometer machine learning model`: https://studio.edgeimpulse.com/public/33129/latest
-.. _`Nordic Semi Thingy:53 page`: https://www.edgeimpulse.com/docs/nordic-semi-thingy53
+.. _`Nordic Semi Thingy:53 page`: https://docs.edgeimpulse.com/docs/development-platforms/officially-supported-mcu-targets/nordic-semi-thingy53
 .. _`Nordic Semi nRF5340 DK page`: https://docs.edgeimpulse.com/docs/nordic-semi-nrf5340-dk
 
 .. ### Source: memfault.com

--- a/doc/nrf/ug_thingy53_gs.rst
+++ b/doc/nrf/ug_thingy53_gs.rst
@@ -262,7 +262,7 @@ Complete the following steps to get started with Edge Impulse:
 
 1. Go to the `Edge Impulse`_ website.
 #. Create a free Edge Impulse account.
-#. Follow the instructions in the `Nordic Semi nRF5340 DK page`_.
+#. Follow the instructions in the `Nordic Semi Thingy:53 page`_.
 
 Next steps
 **********


### PR DESCRIPTION
Edge Impulse has released the related page for Thingy:53, so
we can update the link in the machine learning section from
pointing to nRF5340 DK to pointing correctly to the Thingy:53 page.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>