### PR TITLE
remove unused options from sample documentation

### DIFF
--- a/samples/nrf9160/gnss/README.rst
+++ b/samples/nrf9160/gnss/README.rst
@@ -105,11 +105,6 @@ Check and configure the following Kconfig options for the sample:
 CONFIG_GNSS_SAMPLE_NMEA_ONLY - To enable NMEA-only output mode
    The NMEA-only output mode can be used for example with 3rd party tools to visualize the GNSS output.
 
-.. _CONFIG_GNSS_SAMPLE_ANTENNA_EXTERNAL:
-
-CONFIG_GNSS_SAMPLE_ANTENNA_EXTERNAL - To use an external GNSS antenna
-   This configuration option should be enabled if an external GNSS antenna is used, so that the Low Noise Amplifier (LNA) can be configured accordingly.
-
 .. _CONFIG_GNSS_SAMPLE_ASSISTANCE_NRF_CLOUD:
 
 CONFIG_GNSS_SAMPLE_ASSISTANCE_NRF_CLOUD - To use nRF Cloud A-GPS

--- a/samples/nrf9160/location/README.rst
+++ b/samples/nrf9160/location/README.rst
@@ -36,22 +36,6 @@ Configuration
 
 |config|
 
-Configuration options
-=====================
-
-Check and set the following configuration options for the sample:
-
-.. _CONFIG_LOCATION_SAMPLE_GNSS_ANTENNA_ONBOARD:
-
-CONFIG_LOCATION_SAMPLE_GNSS_ANTENNA_ONBOARD - Configuration for onboard GNSS antenna (default)
-   This option enables the onboard GNSS antenna.
-
-
-.. _CONFIG_LOCATION_SAMPLE_GNSS_ANTENNA_EXTERNAL:
-
-CONFIG_LOCATION_SAMPLE_GNSS_ANTENNA_EXTERNAL - External GNSS antenna
-   This option enables the external GNSS antenna.
-
 Additional configuration
 ========================
 


### PR DESCRIPTION
Removed obsolete GNSS antenna related configuration options from GNSS and Location sample documentations.