### PR TITLE
cmake: Escape literal '"' chars in image_preload variables

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -75,10 +75,11 @@ else()
   endforeach()
 
   foreach(app_var_name ${application_vars})
+    string(REPLACE "\"" "\\\"" app_var_value "${${app_var_name}}")
     file(
       APPEND
       ${base_image_preload_file}
-      "set(${app_var_name} \"${${app_var_name}}\" CACHE INTERNAL \"NCS child image controlled\")\n"
+      "set(${app_var_name} \"${app_var_value}\" CACHE INTERNAL \"NCS child image controlled\")\n"
       )
   endforeach()
 
@@ -374,10 +375,11 @@ function(add_child_image_from_source)
       # '_'. We run the regex twice because it is believed that
       # list(FILTER is faster than doing a string(REGEX on each item.
       string(REGEX MATCH "^${ACI_NAME}_(.+)" unused_out_var ${var_name})
+      string(REPLACE "\"" "\\\"" var_value "${${var_name}}")
       file(
         APPEND
         ${preload_file}
-        "set(${CMAKE_MATCH_1} \"${${var_name}}\" CACHE INTERNAL \"NCS child image controlled\")\n"
+        "set(${CMAKE_MATCH_1} \"${var_value}\" CACHE INTERNAL \"NCS child image controlled\")\n"
         )
     endforeach()
   endif()


### PR DESCRIPTION
The Zephyr build system supports passing `CONFIG_` variables on the west command line, like this:

```
    west build -- -D"CONFIG_SOME_STRING=\"some string\""
```

The logic in zephyr/cmake/modules/kconfig.cmake which implements this feature takes each `CONFIG_` variable defined in the cmake cache, and writes the value of that variable directly into extra_kconfig_options.conf. Therefore, if the user wants to add a *string* value to kconfig using this mechanism, the extra_kconfig_options.conf entry would need to look like:

```
    CONFIG_BOOT_SIGNATURE_KEY_FILE="/foo/bar/private.pem"
```

and the image_preload.cmake definition that generates this result would therefore be:

```
    set(CONFIG_BOOT_SIGNATURE_KEY_FILE "\"/foo/bar/private.pem\"" CACHE INTERNAL "NCS child image controlled")
```

However, as of NCS v2.0.0, this doesn't work correctly.  If I build with this command line:

```
    west build --pristine --cmake-only -b nrf52840dk_nrf52840 -- \
        -D"mcuboot_CONFIG_BOOT_SIGNATURE_KEY_FILE=\"/foo/bar/private.pem\""
```

I see that the multi_image.cmake script from NCS generates invalid syntax in both image_preload files:

```
    set(CONFIG_BOOT_SIGNATURE_KEY_FILE ""/foo/bar/private.pem"" CACHE INTERNAL "NCS child image controlled")
```

To fix this, NCS must add explicit escaping of '"' characters if they are present in the user-supplied string.