### PR TITLE
test_spec: rs: run tests on changes to nrf_rpc

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -215,6 +215,7 @@
 "CI-rs-test":
   - "subsys/mpsl/**/*"
   - "subsys/ieee802154/**/*"
+  - "subsys/nrf_rpc/**/*"
   - "drivers/mpsl/**/*"
   - "dts/bindings/radio_fem/**/*"
   - "samples/nrf5340/multiprotocol_rpmsg/**/*"


### PR DESCRIPTION
Assign `CI-rs-test` label to PRs that modify `subsys/nrf_rpc` directory
and its subdirectories.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>