### PR TITLE
bootloader: Add nrf52833dk_nrf52833 to some sample.yml and testcase.yml

### DIFF
--- a/samples/bootloader/sample.yaml
+++ b/samples/bootloader/sample.yaml
@@ -6,10 +6,11 @@ tests:
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf9160dk_nrf9160
+      - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
       - nrf51dk_nrf51422
       - nrf21540dk_nrf52840
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840
-      nrf52dk_nrf52832 nrf51dk_nrf51422 nrf21540dk_nrf52840
+      nrf52833dk_nrf52833 nrf52dk_nrf52832 nrf51dk_nrf51422 nrf21540dk_nrf52840
     tags: ci_build

--- a/tests/subsys/bootloader/bl_crypto/testcase.yaml
+++ b/tests/subsys/bootloader/bl_crypto/testcase.yaml
@@ -1,11 +1,12 @@
 tests:
   bootloader.bl_crypto:
     platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf9160dk_nrf9160 nrf51dk_nrf51422
-      nrf5340dk_nrf5340_cpuapp
+      nrf5340dk_nrf5340_cpuapp nrf52833dk_nrf52833
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
       - nrf9160dk_nrf9160
       - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
+      - nrf52833dk_nrf52833
     tags: b0

--- a/tests/subsys/bootloader/bl_validation/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation/testcase.yaml
@@ -1,11 +1,12 @@
 tests:
   bootloader.bl_validation:
     platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
-      nrf5340dk_nrf5340_cpuapp
+      nrf5340dk_nrf5340_cpuapp nrf52833dk_nrf52833
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
       - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
+      - nrf52833dk_nrf52833
     tags: b0 bl_validation


### PR DESCRIPTION
To test on CI, and to add it to the software maturity.

Ref: NCSDK-15774

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>