### PR TITLE
applications: asset_tracker_v2: Default coredump storage to RAM

### DIFF
--- a/applications/asset_tracker_v2/doc/debug_module.rst
+++ b/applications/asset_tracker_v2/doc/debug_module.rst
@@ -64,10 +64,16 @@ To enable Memfault, you must set the following mandatory options:
  * :kconfig:option:`CONFIG_MEMFAULT`
  * :kconfig:option:`CONFIG_MEMFAULT_NCS_PROJECT_KEY`
 
-To get detailed stack traces in coredumps sent to Memfault, you can increase the values for the following options:
+To get more detailed stack traces in coredumps sent to Memfault, you can increase the values of the following options:
 
- * :kconfig:option:`CONFIG_PM_PARTITION_SIZE_MEMFAULT_STORAGE` - For example, you can increase the value to ``0x30000``.
- * :kconfig:option:`CONFIG_MEMFAULT_COREDUMP_STACK_SIZE_TO_COLLECT` - For example, you can increase the value to ``8192``.
+ * :kconfig:option:`CONFIG_MEMFAULT_RAM_BACKED_COREDUMP_SIZE`
+ * :kconfig:option:`CONFIG_MEMFAULT_COREDUMP_STACK_SIZE_TO_COLLECT`
+
+Coredumps are by default stored to non-initialized RAM.
+To enable storing to flash, configure the following options:
+
+ * :kconfig:option:`CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP` - To enable storing to flash.
+ * :kconfig:option:`CONFIG_PM_PARTITION_SIZE_MEMFAULT_STORAGE` - To set the size of the coredumps storage flash partition.
 
 For extended documentation regarding |NCS| Memfault integration, see :ref:`mod_memfault` module.
 

--- a/applications/asset_tracker_v2/overlay-memfault.conf
+++ b/applications/asset_tracker_v2/overlay-memfault.conf
@@ -13,9 +13,7 @@ CONFIG_MEMFAULT_LOGGING_ENABLE=y
 CONFIG_MEMFAULT_ROOT_CERT_STORAGE_NRF9160_MODEM=y
 CONFIG_MODEM_KEY_MGMT=y
 
-CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP=y
 CONFIG_MEMFAULT_COREDUMP_COLLECT_BSS_REGIONS=y
-CONFIG_PM_PARTITION_SIZE_MEMFAULT_STORAGE=0x10000
 
 # Increase the stack size of the system workqueue in case Memfault is enabled. If the debug module
 # is configured to forward Memfault data via an external transport the data will be carried on

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -132,13 +132,17 @@ CIA-604: ATv2 cannot be built for the ``thingy91_nrf9160_ns`` build target with 
 
 .. rst-class:: v2-0-0
 
-CIA-661: Asset Tracker v2 application configured for LwM2M cannot be built for the ``nrf9160dk_nrf9160_ns`` build target with modem traces enabled
-  The :ref:`asset_tracker_v2` application configured for LwM2M cannot be built for the ``nrf9160dk_nrf9160_ns`` build target with :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_ENABLED` enabled due to memory constraints.
+CIA-661: Asset Tracker v2 application configured for LwM2M cannot be built for the ``nrf9160dk_nrf9160_ns`` build target with modem traces or memfault enabled
+  The :ref:`asset_tracker_v2` application configured for LwM2M cannot be built for the ``nrf9160dk_nrf9160_ns`` build target with :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_ENABLED` for modem traces or ``overlay-memfault.conf`` for memfault due to memory constraints.
 
-  **Workaround:** Use one of the following workarounds:
+  **Workaround**
+
+  Use one of the following workarounds for modem traces:
 
   * Use :ref:`secure_partition_manager` instead of TF-M by setting :kconfig:option:`CONFIG_SPM` to ``y`` and :kconfig:option:`CONFIG_BUILD_WITH_TFM` to ``n``.
   * Reduce the value of :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHMEM_TRACE_SIZE` to 8 Kb, however, this might lead to loss of modem traces.
+
+  For memfault, use :ref:`secure_partition_manager` instead of TF-M by setting :kconfig:option:`CONFIG_SPM` to ``y`` and :kconfig:option:`CONFIG_BUILD_WITH_TFM` to ``n``.
 
 Serial LTE Modem
 ================


### PR DESCRIPTION
Default coredump storage to RAM instead of flash to free up flash
storage so that the application can be combined with features
such as LwM2M.

Fixes CIA-645

Signed-off-by: Simen S. Røstad <simen.rostad@nordicsemi.no>