### PR TITLE
lib: lte_lc: fix lte_lc_nw_reg_status_get

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1075,7 +1075,7 @@ int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status)
 	err = nrf_modem_at_scanf("AT+CEREG?",
 		"+CEREG: "
 		"%*u,"		/* <n> */
-		"%u,"		/* <stat> */
+		"%hu,"		/* <stat> */
 		"%*[^,],"	/* <tac> */
 		"\"%x\",",	/* <ci> */
 		&status_tmp,


### PR DESCRIPTION
The current code stores an int into a short, causing memory corruption. The symptom of this for me is that in `connect_lte` it overwrites `blocking` to false, so connect returns immediately when it should wait.

Side note, is there a reason why the fixed-width macros in `inttypes.h` aren't used in the code base? e.g. `PRIu32`, `PRIu16` which would avoid similar issues. 