### PR TITLE
application: serial_lte_modem: Add background poller

### DIFF
--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -1193,6 +1193,102 @@ Test command
 
 The test command is not supported.
 
+Poll sockets in background #XPOLLER
+===================================
+
+The ``#XPOLLER`` command allows you to poll sockets in the background.
+
+Set command
+-----------
+
+The set command allows you to poll all client-role sockets for incoming events.
+
+.. note::
+   The poller must be explicitly started and stopped by the MCU.
+
+Syntax
+~~~~~~
+
+::
+
+   #XPOLLER=<op>[,<timeout>]
+
+The ``<op>`` parameter can accept one of the following values:
+
+* ``0`` - Stop the poller.
+* ``1`` - Start the poller.
+
+The ``<timeout>`` value sets the polling cycle in milliseconds.
+By default, the poller uses a cycle of 10 seconds.
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XPOLLER: <handle>,<revents>
+
+The ``<handle>`` value is an integer.
+It is the handle of a socket that have events returned, called also ``revents``.
+
+The ``<revents>`` value is a hexadecimal string.
+It represents the returned events, which could be a combination of POLLIN, POLLERR, POLLHUP and POLLNVAL.
+
+Examples
+~~~~~~~~
+
+::
+
+   AT#XPOLLER=1,2000
+   OK
+   #XPOLLER: 0,"0x0001"
+   #XPOLLER: 1,"0x0001"
+
+Read command
+------------
+
+The read command allows you to check whether the poller is running or not.
+
+Syntax
+~~~~~~
+
+::
+
+   #XPOLLER?
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+If the poller is running, the command returns ``OK``, otherwise it returns ``ERROR``.
+
+Test command
+------------
+
+::
+
+   #XPOLLER=?
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XPOLLER: <list of op>,<timeout>
+
+The ``<list of op>`` value can be one of the following:
+
+* ``0`` - Stop the poller.
+* ``1`` - Start the poller.
+
+Examples
+~~~~~~~~
+
+::
+
+   AT#XPOLLER=?
+   #XPOLLER: (0,1),<timeout>
+   OK
+
 Resolve hostname #XGETADDRINFO
 ==============================
 

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -390,6 +390,7 @@ int handle_at_recv(enum at_cmd_type cmd_type);
 int handle_at_sendto(enum at_cmd_type cmd_type);
 int handle_at_recvfrom(enum at_cmd_type cmd_type);
 int handle_at_poll(enum at_cmd_type cmd_type);
+int handle_at_poller(enum at_cmd_type cmd_type);
 int handle_at_getaddrinfo(enum at_cmd_type cmd_type);
 
 #if defined(CONFIG_SLM_NATIVE_TLS)
@@ -489,6 +490,7 @@ static struct slm_at_cmd {
 	{"AT#XSENDTO", handle_at_sendto},
 	{"AT#XRECVFROM", handle_at_recvfrom},
 	{"AT#XPOLL", handle_at_poll},
+	{"AT#XPOLLER", handle_at_poller},
 	{"AT#XGETADDRINFO", handle_at_getaddrinfo},
 
 #if defined(CONFIG_SLM_NATIVE_TLS)


### PR DESCRIPTION
Due to customer needs, add a background poller to socket service.
 `AT#XPOLLER=<op>[,<timeout>]`
The poller will poll all client-role sockets and send URC with
revents returned from poll().

MCU must explicitly start and stop the poller.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>