### PR TITLE
zigbee: Fix typos in samples, tests and subsys

### DIFF
--- a/applications/zigbee_weather_station/README.rst
+++ b/applications/zigbee_weather_station/README.rst
@@ -90,7 +90,7 @@ The application supports the following development kits:
 
 .. table-from-sample-yaml::
 
-To commission the Zigbee weather station device and control it remotely through a Zigbee network, you also need to progam a Zigbee network coordinator on a separate compatible development kit.
+To commission the Zigbee weather station device and control it remotely through a Zigbee network, you also need to program a Zigbee network coordinator on a separate compatible development kit.
 The Zigbee network coordinator forms the network that the weather station node will join and onto which it will share its measurement data.
 You can use one of the following options for setting up the Zigbee network coordinator:
 
@@ -115,12 +115,12 @@ LED (LD1):
 
     * ``release`` build type
 
-      * Even flashing (red color, 500ms on/500ms off) - The device is in the Identify mode (after network comissioning).
+      * Even flashing (red color, 500ms on/500ms off) - The device is in the Identify mode (after network commissioning).
 
     * ``debug`` build type
 
       * Constant light (blue) - The device is connected to a Zigbee network.
-      * Even flashing (red color, 500ms on/500ms off) - The device is in the Identify mode (after network comissioning).
+      * Even flashing (red color, 500ms on/500ms off) - The device is in the Identify mode (after network commissioning).
 
     .. note::
        Thingy:53 allows you to control RGB components of its single LED independently.

--- a/samples/zigbee/light_bulb/src/main.c
+++ b/samples/zigbee/light_bulb/src/main.c
@@ -59,7 +59,7 @@
 #define BULB_INIT_BASIC_POWER_SOURCE    ZB_ZCL_BASIC_POWER_SOURCE_DC_SOURCE
 
 /* Describes the physical location of the device (16 bytes).
- * May be modified during commisioning process.
+ * May be modified during commissioning process.
  */
 #define BULB_INIT_BASIC_LOCATION_DESC   "Office desk"
 
@@ -370,7 +370,7 @@ static void bulb_clusters_attr_init(void)
 	/* Use ZB_ZCL_SET_STRING_VAL to set strings, because the first byte
 	 * should contain string length without trailing zero.
 	 *
-	 * For example "test" string wil be encoded as:
+	 * For example "test" string will be encoded as:
 	 *   [(0x4), 't', 'e', 's', 't']
 	 */
 	ZB_ZCL_SET_STRING_VAL(

--- a/samples/zigbee/light_switch/src/main.c
+++ b/samples/zigbee/light_switch/src/main.c
@@ -779,7 +779,7 @@ void main(void)
 	zigbee_enable();
 
 #if CONFIG_BT_NUS
-	/* Initalize NUS command service. */
+	/* Initialize NUS command service. */
 	nus_cmd_init(on_nus_connect, on_nus_disconnect, commands);
 #endif /* CONFIG_BT_NUS */
 

--- a/samples/zigbee/network_coordinator/src/main.c
+++ b/samples/zigbee/network_coordinator/src/main.c
@@ -198,9 +198,9 @@ static void button_changed(uint32_t button_state, uint32_t has_changed)
 
 		comm_status = bdb_start_top_level_commissioning(ZB_BDB_NETWORK_STEERING);
 		if (comm_status) {
-			LOG_INF("Top level comissioning restated");
+			LOG_INF("Top level commissioning restated");
 		} else {
-			LOG_INF("Top level comissioning hasn't finished yet!");
+			LOG_INF("Top level commissioning hasn't finished yet!");
 		}
 	}
 

--- a/samples/zigbee/shell/sample.yaml
+++ b/samples/zigbee/shell/sample.yaml
@@ -1,5 +1,5 @@
 sample:
-  description: Zigbee application thast includes all Zigbee shell commands
+  description: Zigbee application that includes all Zigbee shell commands
   name: Zigbee application with Zigbee shell
 tests:
   sample.zigbee.shell:

--- a/samples/zigbee/shell/src/main.c
+++ b/samples/zigbee/shell/src/main.c
@@ -118,7 +118,7 @@ static void identify_cb(zb_bufid_t bufid)
 	}
 }
 
-/**@breif Starts identifying the device.
+/**@brief Starts identifying the device.
  *
  * @param  bufid  Unused parameter, required by ZBOSS scheduler API.
  */

--- a/samples/zigbee/template/src/main.c
+++ b/samples/zigbee/template/src/main.c
@@ -121,7 +121,7 @@ static void identify_cb(zb_bufid_t bufid)
 	}
 }
 
-/**@breif Starts identifying the device.
+/**@brief Starts identifying the device.
  *
  * @param  bufid  Unused parameter, required by ZBOSS scheduler API.
  */

--- a/subsys/zigbee/Kconfig
+++ b/subsys/zigbee/Kconfig
@@ -86,7 +86,7 @@ config ZIGBEE_ROLE_COORDINATOR
 endchoice
 
 config ZBOSS_DEFAULT_THREAD_PRIORITY
-	int "Set default ZBOSS thread prority"
+	int "Set default ZBOSS thread priority"
 	default 3
 
 config ZBOSS_DEFAULT_THREAD_STACK_SIZE

--- a/subsys/zigbee/lib/zigbee_shell/include/zigbee_shell_ping_types.h
+++ b/subsys/zigbee/lib/zigbee_shell/include/zigbee_shell_ping_types.h
@@ -33,7 +33,7 @@ enum ping_time_evt {
 	PING_EVT_FRAME_TIMEOUT,
 	/* PING request was successfully scheduled for sending by the stack. */
 	PING_EVT_FRAME_SCHEDULED,
-	/* PING request was successfully sent. This event occurrs only
+	/* PING request was successfully sent. This event occurs only
 	 * if both APS ACK was not requested.
 	 */
 	PING_EVT_FRAME_SENT,
@@ -48,7 +48,7 @@ enum ping_time_evt {
 /**@brief  Ping event callback definition.
  *
  * @param[in] evt           Type of received  ping acknowledgment
- * @param[in] delay_ms      Time, in miliseconds, between ping request
+ * @param[in] delay_ms      Time, in milliseconds, between ping request
  *                          and the event.
  * @param[in] entry         Pointer to context manager entry in which the ping
  *                          request data is stored.
@@ -77,7 +77,7 @@ struct ping_reply {
 /**@brief Set ping request indication callback.
  *
  * @note The @p cb argument delay_ms will reflect current time
- *       in miliseconds.
+ *       in milliseconds.
  */
 void zb_ping_set_ping_indication_cb(ping_time_cb_t cb);
 

--- a/subsys/zigbee/lib/zigbee_shell/include/zigbee_shell_utils.h
+++ b/subsys/zigbee/lib/zigbee_shell/include/zigbee_shell_utils.h
@@ -120,7 +120,7 @@ int zb_shell_sscan_uint8(const char *bp, uint8_t *value);
  * up to (UINT32_MAX).
  *
  * @param[in]  bp     Pointer to input string.
- * @param[out] value  Pointer to variable to store reuslt of the function.
+ * @param[out] value  Pointer to variable to store result of the function.
  * @param[in]  size   Size, in bytes, that determines expected maximum value
  *                    of converted number.
  * @param[in]  base   Numerical base (radix) that determines the valid

--- a/subsys/zigbee/lib/zigbee_shell/include/zigbee_shell_zcl_types.h
+++ b/subsys/zigbee/lib/zigbee_shell/include/zigbee_shell_zcl_types.h
@@ -28,7 +28,7 @@ struct zcl_packet_info {
 	zb_bool_t disable_aps_ack;
 };
 
-/* Enum used to determine which command Write or Read Attribue to send. */
+/* Enum used to determine which command Write or Read Attribute to send. */
 enum attr_req_type {
 	ATTR_READ_REQUEST,
 	ATTR_WRITE_REQUEST

--- a/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_bdb.c
+++ b/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_bdb.c
@@ -493,7 +493,7 @@ static int cmd_zb_channel(const struct shell *shell, size_t argc, char **argv)
 		chan[0] = zb_get_bdb_primary_channel_set();
 		chan[1] = zb_get_bdb_secondary_channel_set();
 
-		/* Chech for case in which channel mask can not be read. */
+		/* Check for case in which channel mask can not be read. */
 		if (zigbee_is_nvram_initialised() && !zigbee_is_stack_started()
 #ifdef CONFIG_ZIGBEE_SHELL_DEBUG_CMD
 		    && zb_shell_nvram_enabled()

--- a/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_nbr.c
+++ b/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_nbr.c
@@ -193,7 +193,7 @@ static void refresh_active_nbt_table(zb_bufid_t bufid)
 	}
 }
 
-/**@brief Enable, disable or refresh neighbor table mintor.
+/**@brief Enable, disable or refresh neighbor table monitor.
  *
  * @code
  * nbr monitor {on,off,trigger}
@@ -202,7 +202,7 @@ static void refresh_active_nbt_table(zb_bufid_t bufid)
  * Register a neighbor table monitoring routine and log all entries once
  * a new entry is created or an existing one is removed.
  * The trigger command can be used to trigger logging the current state
- * of the nighbor table.
+ * of the neighbor table.
  *
  * Example:
  * @code

--- a/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_ping.c
+++ b/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_ping.c
@@ -170,13 +170,13 @@ static void zb_zcl_send_ping_frame(zb_uint8_t index)
 	}
 }
 
-/**@brief Get time difference, in miliseconds between ping request time
+/**@brief Get time difference, in milliseconds between ping request time
  *        and current time.
  *
  * @param[in] req_data  Pointer to the ping request structure,
  *                      from which the time difference should be calculated.
  *
- * @return  Time difference in miliseconds.
+ * @return  Time difference in milliseconds.
  */
 static zb_uint32_t get_request_duration(struct ctx_entry *req_data)
 {
@@ -273,7 +273,7 @@ static void dispatch_user_callback(zb_bufid_t bufid)
 /**@brief  Default ping event handler. Prints out measured time on the shell and exits.
  *
  * @param[in] evt           Type of received ping acknowledgment
- * @param[in] delay_ms      Time, in miliseconds, between ping request
+ * @param[in] delay_ms      Time, in milliseconds, between ping request
  *                          and the event.
  * @param[in] req_data      Pointer to the context manager entry with ongoing
  *                          ping request data.

--- a/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_zdo.c
+++ b/subsys/zigbee/lib/zigbee_shell/src/zigbee_shell_cmd_zdo.c
@@ -71,9 +71,9 @@
 #define ZIGBEE_SHELL_MATCH_DESC_RESP_TIMEOUT 5
 /* Defines how long to wait, in seconds, for Bind Response. */
 #define ZIGBEE_SHELL_BIND_RESP_TIMEOUT       5
-/* Defines how long to wait, in seconds, for Network Addrees Response. */
+/* Defines how long to wait, in seconds, for Network Address Response. */
 #define ZIGBEE_SHELL_NWK_ADDR_RESP_TIMEOUT   5
-/* Defines how long to wait, in seconds, for IEEE (EUI64) Addrees Response. */
+/* Defines how long to wait, in seconds, for IEEE (EUI64) Address Response. */
 #define ZIGBEE_SHELL_IEEE_ADDR_RESP_TIMEOUT  5
 /* Defines how long to wait, in seconds, for mgmt_leave response. */
 #define ZIGBEE_SHELL_MGMT_LEAVE_RESP_TIMEOUT 5
@@ -2183,7 +2183,7 @@ static bool zdo_mgmt_lqi_cb(struct ctx_entry *ctx_entry, zb_bufid_t bufid)
 							    zdo_request_cb);
 			if (ctx_entry->id != ZB_ZDO_INVALID_TSN) {
 				/* The request requires further communication,
-				 * hence the outer callback shoudn't free
+				 * hence the outer callback shouldn't free
 				 * resources.
 				 */
 				result = false;

--- a/subsys/zigbee/osif/zb_nrf_async_serial.c
+++ b/subsys/zigbee/osif/zb_nrf_async_serial.c
@@ -340,7 +340,7 @@ void zb_osif_serial_send_data(zb_uint8_t *buf, zb_ushort_t len)
 	uart_tx_buf_len = len;
 	uart_tx_buf_offset = 0;
 
-	/* Pass the TX callback for a single (ongoing) tranmission. */
+	/* Pass the TX callback for a single (ongoing) transmission. */
 	tx_trx_data_cb = tx_data_cb;
 
 	/* Enable TX ready event. */

--- a/subsys/zigbee/osif/zb_nrf_platform.c
+++ b/subsys/zigbee/osif/zb_nrf_platform.c
@@ -151,7 +151,7 @@ static void zb_app_cb_process(zb_bufid_t bufid)
 	zb_ret_t ret_code = RET_OK;
 	zb_app_cb_t new_app_cb;
 
-	/* Mark te processing callback as non-scheduled. */
+	/* Mark the processing callback as non-scheduled. */
 	(void)atomic_set((atomic_t *)&zb_app_cb_process_scheduled, 0);
 
 	/**
@@ -248,7 +248,7 @@ static void zb_app_cb_process_schedule(struct k_work *item)
 		return;
 	}
 
-	/* Check if processing callback is altready scheduled. */
+	/* Check if processing callback is already scheduled. */
 	if (atomic_set((atomic_t *)&zb_app_cb_process_scheduled, 1) == 1) {
 		return;
 	}

--- a/subsys/zigbee/osif/zb_nrf_pwr_mgmt.c
+++ b/subsys/zigbee/osif/zb_nrf_pwr_mgmt.c
@@ -87,7 +87,7 @@ __weak zb_uint32_t zb_osif_sleep(zb_uint32_t sleep_tmo)
 }
 
 /**@brief Function which is called after zb_osif_sleep
- *        finished and ZBOSS timer is reenabled.
+ *        finished and ZBOSS timer is re-enabled.
  *
  * Function is defined as weak; to be redefined if someone
  * wants to implement their own going-to-deep-sleep policy/share resources

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/src/main.c
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/src/main.c
@@ -73,7 +73,7 @@ static void setup_test_case(void)
 {
 	zassert_not_null(uart_dev, "UART device was not initialized");
 
-	/* Ensure that the driver usees user's buffer. */
+	/* Ensure that the driver uses user's buffer. */
 	zassert_equal_ptr(char_handler, uart_char_handler,
 			  "The UART RX callback in not properly set");
 


### PR DESCRIPTION
Fix typos in Zigbee-related source files.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>