### PR TITLE
applications: asset_tracker_v2: Use GNSS PVT format for nRF Cloud builds

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/json_protocol_names_nrf_cloud.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/json_protocol_names_nrf_cloud.h
@@ -40,7 +40,7 @@
 #define APP_ID_BUTTON	   "BUTTON"
 #define APP_ID_VOLTAGE	   "VOLTAGE"
 #define APP_ID_DEVICE      "DEVICE"
-#define APP_ID_GPS	   "GPS"
+#define APP_ID_GNSS	   "GNSS"
 #define APP_ID_HUMIDITY	   "HUMID"
 #define APP_ID_AIR_PRESS   "AIR_PRESS"
 #define APP_ID_AIR_QUAL    "AIR_QUAL"

--- a/applications/asset_tracker_v2/src/modules/Kconfig.gnss_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.gnss_module
@@ -13,7 +13,6 @@ if GNSS_MODULE
 
 choice GNSS_MODULE_DATA_FORMAT
 	prompt "Select GNSS data format"
-	default GNSS_MODULE_NMEA if NRF_CLOUD_MQTT
 	default GNSS_MODULE_PVT
 
 config GNSS_MODULE_PVT

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -109,6 +109,7 @@ nRF9160: Asset Tracker v2
   * Updated:
 
     * The default value of the GNSS timeout in the application's :ref:`Real-time configurations <real_time_configs>` is now 30 seconds.
+    * GNSS fixes are now published in PVT format instead of NMEA for nRF Cloud builds. To revert to NMEA, set the :ref:`CONFIG_GNSS_MODULE_NMEA <CONFIG_GNSS_MODULE_NMEA>` option.
 
   * Fixed:
 


### PR DESCRIPTION
Use GNSS PVT format for nRF Cloud builds:
 - Add support for GNSS PVT format in nRF Cloud application codec
   according to format specified in https://tinyurl.com/27ww78aw

 - Let app ID for GNSS data be `GNSS` instead of `GPS`.
   The use of `GPS` as the identifier has been deprecated.

Fixed CIA-500