### PR TITLE
lib: pdn: use portable format specifier to scan the PDN ID

### DIFF
--- a/lib/pdn/pdn.c
+++ b/lib/pdn/pdn.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
@@ -218,7 +219,7 @@ int pdn_ctx_create(uint8_t *cid, pdn_event_handler_t cb)
 		return -ENOMEM;
 	}
 
-	err = nrf_modem_at_scanf("AT%XNEWCID?", "%%XNEWCID: %d", &pdn->context_id);
+	err = nrf_modem_at_scanf("AT%XNEWCID?", "%%XNEWCID: %" SCNd8, &pdn->context_id);
 	if (err < 0) {
 		return err;
 	}


### PR DESCRIPTION
The PDN ID was being scanned into a int8_t type using %d.
Clearly, this was not a good idea :)

Use the SCNd8 format specifier instead, which has the right
size and which won't compile unless newlibc has been compiled
with the correct flags to enable C99 I/O format support for
8-bit scan formats.