### PR TITLE
CODEOWNERS: lib location test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -206,6 +206,7 @@ Kconfig*                                  @tejlmand
 /tests/lib/date_time/                     @trantanen @tokangas
 /tests/lib/edge_impulse/                  @pdunaj @MarekPieta
 /tests/lib/hw_unique_key*/                @oyvindronningstad @Vge0rge
+/tests/lib/location/                      @trantanen @hiltunent @jhirsi @tokangas
 /tests/lib/lte_lc/                        @jtguggedal @tokangas @simensrostad
 /tests/lib/modem_jwt/                     @SeppoTakalo
 /tests/lib/qos/                           @simensrostad


### PR DESCRIPTION
Add lib location test codeowners, as consequence of merge this PR: https://github.com/nrfconnect/sdk-nrf/pull/7982

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>