### PR TITLE
ci: Check licenses contained in the PR

### DIFF
--- a/.github/workflows/license-reusable.yml
+++ b/.github/workflows/license-reusable.yml
@@ -1,0 +1,131 @@
+#
+# You can call this workflow in your repository. See the example caller workflow:
+#
+# --------------------------------------------------------------------------------------
+# name: My License Check Caller
+# on: pull_request
+# jobs:
+#   call-workflow:
+#     uses: nrfconnect/sdk-nrf/.github/workflows/license-reusable.yml@main
+#     with:
+#       path: my_module_path
+#       license_allow_list: my_module_path/license_allow_list.yaml
+#         # You can find more details about the inputs below.
+# --------------------------------------------------------------------------------------
+
+name: Reusable License Check
+
+on:
+  workflow_call:
+    inputs:
+
+      path:
+        # Required path to your module relative to west workspace.
+        type: string
+        required: true
+
+      license_allow_list:
+        # Optional path to your custom license allow list file relative to west workspace.
+        # By default, the list form the "sdk-nrf" repository is used. For details about
+        # format of the list, see "scripts/ci/license_allow_list.yaml" in the
+        # "sdk-nrf" repository.
+        type: string
+        default: nrf/scripts/ci/license_allow_list.yaml
+
+      nrf_repo:
+        # Optional URL of the custom "sdk-nrf" repository that contains license check
+        # script and the west manifest. By default official "sdk-nrf" repository is used.
+        type: string
+        default: https://github.com/nrfconnect/sdk-nrf
+
+      nrf_rev:
+        # Optional revision of the "sdk-nrf" repository. By default, "main" is used.
+        type: string
+        default: main
+
+jobs:
+  license_job:
+    runs-on: ubuntu-latest
+    name: Run license checks on patch series (PR)
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v2
+      with:
+        path: ncs/${{ inputs.path }}
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
+    - name: cache-pip
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-doc-pip
+
+    - name: Install python dependencies
+      run: |
+        pip3 install -U pip
+        pip3 install -U setuptools
+        export PATH="$HOME/.local/bin:$PATH"
+        pip3 install -U wheel
+        pip3 install --user -U west
+        pip3 show -f west
+
+    - name: Git config and rebase
+      env:
+        BASE_REF: ${{ github.base_ref }}
+      working-directory: ncs/${{ inputs.path }}
+      run: |
+        git config --global user.email "you@example.com"
+        git config --global user.name "Your Name"
+        git remote -v
+        git branch
+        git rebase origin/${BASE_REF}
+        # debug
+        git log --pretty=oneline | head -n 10
+
+    - name: West init and update
+      working-directory: ncs
+      env:
+        PR_REF: ${{ github.event.pull_request.head.sha }}
+      run: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export PATH="$HOME/bin:$PATH"
+        if [ "${{ inputs.path }}" = "nrf" ]; then
+            west init -l nrf
+        else
+            west init -m ${{ inputs.nrf_repo }} --mr ${{ inputs.nrf_rev }}
+        fi
+        west update zephyr
+        west zephyr-export
+        echo "ZEPHYR_BASE=$(pwd)/zephyr" >> $GITHUB_ENV
+        # debug
+        ( cd ${{ inputs.path }}; echo "${{ inputs.path }}"; git log --pretty=oneline --max-count=10 )
+        ( cd nrf; echo "nrf"; git log --pretty=oneline --max-count=10 )
+        ( cd zephyr; echo "zephyr"; git log --pretty=oneline --max-count=10 )
+
+    - name: Install license check script dependencies
+      run: |
+        pip3 install -U -r ncs/nrf/scripts/ci/requirements.txt
+
+    - name: Run license checks
+      id: license_checks
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        ZEPHYR_BASE: ${{ env.ZEPHYR_BASE }}
+      working-directory: ncs/${{ inputs.path }}
+      if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
+      run: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export PATH="$HOME/bin:$PATH"
+        ${ZEPHYR_BASE}/../nrf/scripts/ci/check_license.py \
+            --github \
+            -l ${ZEPHYR_BASE}/../${{ inputs.license_allow_list }} \
+            -c origin/${BASE_REF}..
+
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      continue-on-error: True
+      if: always() && contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
+      with:
+        name: licenses.xml
+        path: ncs/${{ inputs.path }}/licenses.xml

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,9 @@
+name: License Check
+
+on: pull_request
+
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/license-reusable.yml
+    with:
+      path: nrf

--- a/scripts/ci/check_license.py
+++ b/scripts/ci/check_license.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+import argparse
+import json
+import re
+import sys
+import shlex
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+import yaml
+import junit_xml
+
+
+# Messages shown in the output
+LICENSE_ALLOWED = '"*" license is allowed for this file.'
+NONE_LICENSE_ALLOWED = 'Missing license information is allowed for this file.'
+ANY_LICENSE_ALLOWED = 'Any license is allowed for this file.'
+LICENSE_WARNING = '"*" license is allowed for this file, but it is not recommended.'
+NONE_LICENSE_WARNING = ('Missing license information is allowed for this file, but it is '
+                        'recommended to add one.')
+ANY_LICENSE_WARNING = ('Any license is allowed for this file, but it is recommended to use a more '
+                       'suitable one.')
+LICENSE_ERROR = '"*" license is not allowed for this file.'
+NONE_LICENSE_ERROR = 'Missing license information is not allowed for this file.'
+SKIP_MISSING_FILE_TEXT = 'The file does not exist anymore.'
+SKIP_DIRECTORY_TEXT = 'This is a directory.'
+RECOMMENDATIONS_TEXT = textwrap.dedent('''\
+    ===============================================================================
+    You have some license problems. Check the following:
+    * The files in the commits are covered by a license allowed in the nRF Connect
+      SDK.
+    * The source files have a correct "SPDX-License-Identifier" tag.
+    * The libraries have an associated external license file and the tags contained
+      in it are correct. For details, see documentation for the Software Bill of
+      Materials script.
+    ===============================================================================
+''')
+
+
+def parse_args():
+    '''Parse command line arguments.'''
+    default_allow_list = Path(__file__).parent / 'license_allow_list.yaml'
+    parser = argparse.ArgumentParser(
+        description='Check for allowed licenses.')
+    parser.add_argument('-c', '--commits', default='HEAD~1..',
+                        help='Commit range in the form: a..[b], default is HEAD~1..HEAD')
+    parser.add_argument('-o', '--output', type=Path, default='licenses.xml',
+                        help='''Name of outfile in JUnit format, default is ./licenses.xml''')
+    parser.add_argument('-l', '--allow-list', type=Path, default=default_allow_list,
+                        help=f'Allow list file, default is {default_allow_list}')
+    parser.add_argument('--github', action='store_true',
+                        help='Add GitHub Actions Workflow commands to the stdout.')
+    return parser.parse_args()
+
+
+def unlink_quietly(path: Path) -> None:
+    '''Delete a file if it exists.'''
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+class FileLicenseChecker:
+    '''Class that checks if a license is allowed for a file.'''
+
+    allow_list: 'dict[str, list[tuple[re.Pattern, bool]]]'
+
+    def __init__(self, allow_list_file: Path):
+        with open(allow_list_file, 'r') as fd:
+            data = yaml.safe_load(fd)
+        self.allow_list = {}
+        for key in data:
+            self.allow_list[key.upper()] = self.parse_re(data[key])
+
+    @staticmethod
+    def parse_re(re_str: str) -> 'list[tuple[re.Pattern, bool]]':
+        '''
+        Convert a multiline string to a list of regular expressions and boolean indicating if it is
+        negative match.
+        '''
+        result = []
+        lines = re_str.strip().splitlines()
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            if line[0] == '!':
+                value = False
+                line = line[1:].strip()
+            else:
+                value = True
+            result.append((re.compile(line), value))
+        return result
+
+    def check(self, license_identifier: str, file_path: 'str|Path') -> bool:
+        '''
+        Check if a license is allowed for a file. The file is relative to the west workspace.
+        The license identifier can be prefixed with a '-' to check if the license is allowed,
+        but with a warning.
+        '''
+        file_path = str(file_path).replace('\\', '/')
+        license_identifier = license_identifier.upper()
+        if license_identifier not in self.allow_list:
+            return False
+        allow = False
+        for pattern, value in self.allow_list[license_identifier]:
+            if pattern.search(file_path):
+                allow = value
+        return allow
+
+
+class PatchLicenseChecker:
+    '''Check licenses for a git patch.'''
+
+    args: dict
+    license_checker: FileLicenseChecker
+    git_top: Path
+    west_workspace: Path
+    junit_test_cases: str
+    total_tests: int
+    total_skipped: int
+    total_errors: int
+    total_warnings: int
+
+    def __init__(self, args: dict):
+        self.args = args
+        self.license_checker = FileLicenseChecker(args.allow_list)
+
+    def run(self, program: str, *args: 'list[str|Path]', cwd=None) -> str:
+        '''A helper function to run an external program.'''
+        run_cmd = (program,) + tuple(str(a) for a in args)
+        run_str = ' '.join(shlex.quote(arg) for arg in run_cmd)
+        try:
+            process = subprocess.Popen(run_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                       cwd=cwd)
+        except OSError as e:
+            self.report('error', f'Failed to run "{run_str}": {e}')
+            self.write_junit()
+            sys.exit(2)
+        stdout, stderr = process.communicate()
+        stdout = stdout.decode('utf-8')
+        stderr = stderr.decode('utf-8')
+        if process.returncode or stderr:
+            self.report('error', f'Command "{run_str}" exited with {process.returncode}\n'
+                                 f'==stdout==\n{stdout}\n==stderr==\n{stderr}')
+            self.write_junit()
+            sys.exit(2)
+        return stdout.rstrip()
+
+    def report(self, label: str, message: str, file_name: 'str|Path' = '<none>', license: str = ''):
+        '''Report results to the user.'''
+        file_name = str(file_name)
+        # Print to stdout/stderr with optional GitHub Actions Workflow commands.
+        if not self.args.github:
+            if label in ('error', 'warning'):
+                print(f'{label.upper()}: {file_name}: {message}', file=sys.stderr)
+            else:
+                print(f'{label.upper()}: {file_name}: {message}')
+        else:
+            print(f'{file_name}: ')
+            if label in ('error', 'warning'):
+                if file_name != '<none>':
+                    file_path = (self.west_workspace / file_name).relative_to(self.git_top)
+                else:
+                    file_path = file_name
+                print(f'::{label} file={file_path},title=License Problem::' +
+                      message.replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A'))
+            else:
+                print(f'{label.upper()}: {message}')
+        # Put result in JUnit file.
+        test_case = junit_xml.TestCase(file_name + (f':{license}' if license else ''),
+                                       'LicenseCheck')
+        if label == 'error':
+            test_case.add_failure_info(message)
+        elif label == 'warning':
+            test_case.add_skipped_info('WARNING: ' + message)
+        elif label == 'skip':
+            test_case.add_skipped_info(message)
+        self.junit_test_cases.append(test_case)
+        # Increment counters.
+        self.total_tests += 1
+        if label == 'error':
+            self.total_errors += 1
+        elif label == 'warning':
+            self.total_warnings += 1
+        elif label == 'skip':
+            self.total_skipped += 1
+
+    def generate_list_of_files(self) -> 'list[Path]':
+        '''
+        Generate a list of files changed in the git patch. The returned path is relative to the
+        west workspace.
+        '''
+        files = self.run('git', 'diff', '--name-only', '--diff-filter=d', self.args.commits)
+        files = files.splitlines()
+        files = [(self.git_top / f.strip()).relative_to(self.west_workspace)
+                 for f in files if f.strip()]
+        return files
+
+    def skip_files(self, files: 'list[Path]') -> 'list[Path]':
+        '''
+        Remove files from the list, because they do not exist, or they can have any license.
+        A new list is returned.
+        '''
+        new_list = []
+        for file_name in files:
+            if not (self.west_workspace / file_name).exists():
+                self.report('skip', SKIP_MISSING_FILE_TEXT, file_name)
+            if not (self.west_workspace / file_name).is_file():
+                self.report('skip', SKIP_DIRECTORY_TEXT, file_name)
+            elif self.license_checker.check('ANY', file_name):
+                self.report('skip', ANY_LICENSE_ALLOWED, file_name)
+            else:
+                new_list.append(file_name)
+        return new_list
+
+    def detect_licenses(self, files: 'list[Path]') -> 'list[dict]':
+        '''Use the "west ncs-sbom" command to detect the licenses of the files.'''
+        with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', suffix='.txt', prefix='_tmp',
+                                         dir=self.west_workspace, delete=False) as tmp:
+            for file_name in files:
+                tmp.write(f'{file_name}\n')
+            tmp_list = Path(tmp.name)
+            tmp_json = tmp_list.with_suffix('.json')
+        try:
+            self.run('west', 'ncs-sbom', '--input-list-file', tmp_list, '--license-detectors',
+                     'spdx-tag,full-text,external-file', '--output-cache-database', tmp_json)
+            with open(tmp_json, 'r', encoding='utf-8') as fd:
+                output = json.load(fd)
+                return output['files']
+        finally:
+            unlink_quietly(tmp_list)
+            unlink_quietly(tmp_json)
+
+    def show_results(self, detected: 'list[dict]') -> bool:
+        '''Interpret detected licenses and report results to the user.'''
+        for file_name, file_info in detected.items():
+            if len(file_info['license']) == 0:
+                file_info['license'] = ['NONE']
+            for license in file_info['license']:
+                if self.license_checker.check(license, file_name):
+                    message = LICENSE_ALLOWED if license != 'NONE' else NONE_LICENSE_ALLOWED
+                    self.report('ok', message.replace('*', license), file_name, license)
+                elif self.license_checker.check('-' + license, file_name):
+                    message = LICENSE_WARNING if license != 'NONE' else NONE_LICENSE_WARNING
+                    self.report('warning', message.replace('*', license), file_name, license)
+                elif self.license_checker.check('-ANY', file_name):
+                    self.report('warning', ANY_LICENSE_WARNING, file_name, license)
+                else:
+                    message = LICENSE_ERROR if license != 'NONE' else NONE_LICENSE_ERROR
+                    self.report('error', message.replace('*', license), file_name, license)
+        if self.total_errors > 0:
+            print(f'License check failed with {self.total_errors} error(s) '
+                  f'and {self.total_warnings} warning(s)!')
+            print(RECOMMENDATIONS_TEXT)
+            return False
+        elif self.total_warnings > 0:
+            print(f'License check successful, but with {self.total_warnings} warning(s)!')
+            print(RECOMMENDATIONS_TEXT)
+            return True
+        else:
+            print('License check successful.')
+            return True
+
+    def write_junit(self):
+        '''Write the JUnit file.'''
+        test_suite = junit_xml.TestSuite("LicenseCheck", self.junit_test_cases)
+        with open(self.args.output, 'w') as fd:
+            junit_xml.TestSuite.to_file(fd, [test_suite], prettyprint=False)
+
+    def check(self) -> bool:
+        '''Do the license check based on command-line arguments provided in the constructor.'''
+
+        self.junit_test_cases = []
+        self.total_tests = 0
+        self.total_skipped = 0
+        self.total_errors = 0
+        self.total_warnings = 0
+        self.git_top = Path(self.run('git', 'rev-parse', '--show-toplevel')).resolve()
+        self.west_workspace = Path(self.git_top).parent
+
+        print(f'Repository top directory: {self.git_top}')
+        print(f'West workspace directory: {self.west_workspace}')
+
+        files = self.generate_list_of_files()
+        files = self.skip_files(files)
+        detected = self.detect_licenses(files)
+        success = self.show_results(detected)
+        self.write_junit()
+
+        return success
+
+
+def main():
+    '''Main function.'''
+    args = parse_args()
+    checker = PatchLicenseChecker(args)
+    success = checker.check()
+    if not success:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/ci/license_allow_list.yaml
+++ b/scripts/ci/license_allow_list.yaml
@@ -1,0 +1,43 @@
+# List of licenses allowed by the "license_check.py" script.
+# Key is a license identifier, value is a regular expression (see Python's
+# re.search) that matches the files that are allowed to have the license.
+# The value can be multiline string. Each line is a regexp that can optionally
+# start with a '!' character to indicate that it is a negative match.
+# File paths are relative to west workspace directory.
+# Special key "none" match no license. Special key "any" match any license
+# including no license.
+# You can add a '-' character to the beginning of the license identifier to
+# allow specific license, but using it will generate a warning.
+
+# Nordic 5-Clause is always allowed.
+LicenseRef-Nordic-5-Clause: ".*"
+
+# ZBOSS 4-clause is allowed only in zboss directory.
+LicenseRef-ZBOSS-4-Clause: "^nrfxlib/zboss/"
+
+# Missing license information is allowed in all files except the ones listed below using
+# negative match.
+none: |
+  .*
+  !\.c$
+  !\.h$
+  !\.cpp$
+  !\.a$
+  !\.py$
+
+# Any license information is allowed in Python scripts, but it will generate a warning.
+-any: |
+  \.py$
+
+# The 'license-texts.yaml' file contains texts of multiple licenses.
+# Ignore all detected licenses in that file.
+any: |
+  .*/license-texts.yaml$
+
+# Allow different licenses from external sources
+LicenseRef-west-ncs-sbom-iperf-BSD-3-Clause: "^nrf/ext/"
+Apache-2.0: "^nrf/ext/"
+curl: "^nrf/ext/"
+MIT: "^nrf/ext/"
+BSD-3-CLAUSE: "^nrf/ext/"
+BSD-2-CLAUSE-NETBSD: "^nrf/ext/"

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -1,0 +1,3 @@
+jinja2
+pyyaml
+junit-xml

--- a/scripts/west_commands/sbom/data/license-texts.yaml
+++ b/scripts/west_commands/sbom/data/license-texts.yaml
@@ -169,6 +169,18 @@
     either express or implied. See the License for the specific language governing permissions
     and limitations under the License.
 
+- id: Apache-2.0
+  text: |
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at:
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
 - id: BSD-3-Clause
   text: |
     Redistribution and use in source and binary forms, with or without modification, are permitted


### PR DESCRIPTION
The license information is important for many users, so it have to be accurate. As history shows, incorrect license information can easily sneak in the repository. This script and workflow checks all files changed in each PR and and verifies if they have correct license information.

You can see sample failing PR here: https://github.com/doki-nordic/fw-nrfconnect-nrf/pull/8. The failing test log and summary contains error details. The PR's "Files changed" tab contains file annotation with errors. The successful PR sample is this PR.

The content of the `license_allow_list.yaml` file is a subject for discussion and I am thinking that we can do it in this PR. @carlescufi, can you give a feedback about this file and comment on general license requirements.

CI team, can you give a feedback about this script location and if it was integrated correctly?