### PR TITLE
samples: Rename testcases

### DIFF
--- a/applications/serial_lte_modem/sample.yaml
+++ b/applications/serial_lte_modem/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: serial lte modem sample
 tests:
-  samples.nrf9160.serial_lte_modem:
+  applications.nrf9160.serial_lte_modem:
     build_only: true
     platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
     integration_platforms:
@@ -9,7 +9,7 @@ tests:
       - thingy91_nrf9160_ns
 
     tags: ci_build
-  samples.nrf9160.serial_lte_modem.native_tls:
+  applications.nrf9160.serial_lte_modem.native_tls:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-native_tls.conf
     platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns


### PR DESCRIPTION
Some names of testcase starts with samples instead of applications.
This change renames this testcase.

Signed-off-by: Katarzyna Giadla <katarzyna.giadla@nordicsemi.no>