### PR TITLE
lib: nrf_modem: updates

### DIFF
--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -46,7 +46,7 @@ extern "C" {
  *
  * @return int Zero on success, non-zero otherwise.
  */
-int nrf_modem_lib_init(enum nrf_modem_mode_t mode);
+int nrf_modem_lib_init(enum nrf_modem_mode mode);
 
 /**
  * @brief Modem library initialization callback struct.

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -168,9 +168,6 @@ static int z_to_nrf_optname(int z_in_level, int z_in_optname,
 		case TLS_CIPHERSUITE_LIST:
 			*nrf_out_optname = NRF_SO_SEC_CIPHERSUITE_LIST;
 			break;
-		case TLS_CIPHERSUITE_USED:
-			*nrf_out_optname = NRF_SO_SEC_CIPHER_IN_USE;
-			break;
 		case TLS_PEER_VERIFY:
 			*nrf_out_optname = NRF_SO_SEC_PEER_VERIFY;
 			break;
@@ -307,7 +304,7 @@ static int z_to_nrf_family(sa_family_t z_family)
 	}
 }
 
-static int nrf_to_z_family(nrf_socket_family_t nrf_family)
+static int nrf_to_z_family(nrf_sa_family_t nrf_family)
 {
 	switch (nrf_family) {
 	case NRF_AF_INET:

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -42,9 +42,9 @@ static bool first_time_init;
 static struct k_mutex slist_mutex;
 
 static int init_ret;
-static enum nrf_modem_mode_t init_mode;
+static enum nrf_modem_mode init_mode;
 
-static const nrf_modem_init_params_t init_params = {
+static const struct nrf_modem_init_params init_params = {
 	.ipc_irq_prio = NRF_MODEM_NETWORK_IRQ_PRIORITY,
 	.shmem.ctrl = {
 		.base = PM_NRF_MODEM_LIB_CTRL_ADDRESS,
@@ -186,7 +186,7 @@ void nrf_modem_lib_shutdown_wait(void)
 	k_mutex_unlock(&slist_mutex);
 }
 
-int nrf_modem_lib_init(enum nrf_modem_mode_t mode)
+int nrf_modem_lib_init(enum nrf_modem_mode mode)
 {
 	init_mode = mode;
 	if (mode == NORMAL_MODE) {


### PR DESCRIPTION
- removed nrf_socket_family_t - use nrf_sa_family_t instead
- removed NRF_SO_SEC_CIPHER_IN_USE
- enum nrf_modem_mode_t -> enum nrf_modem_mode
- nrf_modem_init_params_t -> struct nrf_modem_init_params