### PR TITLE
doc: software_maturity: collapsible tables

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "zephyr.doxyrunner",
     "sphinx_tabs.tabs",
     "software_maturity_table",
+    "sphinx_togglebutton",
 ]
 
 linkcheck_ignore = [

--- a/doc/nrf/software_maturity.rst
+++ b/doc/nrf/software_maturity.rst
@@ -66,17 +66,23 @@ Protocol support
 Thread feature support
 **********************
 
-.. sml-table:: thread
+.. toggle::
+
+  .. sml-table:: thread
 
 Matter feature support
 **********************
 
-.. sml-table:: matter
+.. toggle::
+
+  .. sml-table:: matter
 
 Zigbee feature support
 **********************
 
-.. sml-table:: zigbee
+.. toggle::
+
+  .. sml-table:: zigbee
 
 Security Feature Support
 ************************
@@ -84,19 +90,27 @@ Security Feature Support
 Trusted Firmware-M support
 --------------------------
 
-.. sml-table:: trusted_firmware_m
+.. toggle::
+
+  .. sml-table:: trusted_firmware_m
 
 PSA Crypto support
 ------------------
 
-.. sml-table:: psa_crypto
+.. toggle::
+
+  .. sml-table:: psa_crypto
 
 Immutable Bootloader
 --------------------
 
-.. sml-table:: immutable_bootloader
+.. toggle::
+
+  .. sml-table:: immutable_bootloader
 
 Hardware Unique Key
 -------------------
 
-.. sml-table:: hw_unique_key
+.. toggle::
+
+  .. sml-table:: hw_unique_key

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -11,3 +11,4 @@ sphinx_markdown_tables
 markdown<3.3.5 # Workaround for ryanfox/sphinx-markdown-tables#34
 mistune<2.0 # Workaround for https://github.com/CrossNox/m2r2/issues/40
 breathe<4.33 # Workaround for #803 and #805 breathe issues
+sphinx-togglebutton


### PR DESCRIPTION
Added the sphinx-togglebutton extension to allow collapsible
content. The sml feature tables are now collapsible.

Signed-off-by: Gaute Svanes Lunde <gaute.lunde@nordicsemi.no>