### PR TITLE
samples: Add building of newlib_libc configuration for two samples

### DIFF
--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -25,3 +25,10 @@ tests:
             - nrf5340dk_nrf5340_cpuapp_ns
             - nrf52840dk_nrf52840
             - nrf52833dk_nrf52833
+    sample.newlib_libc.sha256:
+        build_only: True
+        extra_args: CONFIG_NEWLIB_LIBC=y
+        platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840
+        integration_platforms:
+            - nrf5340dk_nrf5340_cpuapp_ns
+            - nrf52840dk_nrf52840

--- a/samples/keys/random_hw_unique_key/sample.yaml
+++ b/samples/keys/random_hw_unique_key/sample.yaml
@@ -18,3 +18,10 @@ common:
 tests:
   sample.keys.random_hw_unique_key:
     tags: huk ci_build
+  sample.newlib_libc.random_hw_unique_key:
+        build_only: True
+        extra_args: CONFIG_NEWLIB_LIBC=y
+        platform_allow: nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
+        integration_platforms:
+            - nrf5340dk_nrf5340_cpuapp
+            - nrf52840dk_nrf52840


### PR DESCRIPTION
- Add the configuration CONFIG_NEWLIB_LIBC=y for 2 samples that
 are using nrf_security.

Ref: NCSDK-15371

Signed-off-by: Magne Værnes <magne.varnes@nordicsemi.no>