### PR TITLE
bluetooth: fast_pair: Describe discoverable advertising limitation

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
@@ -47,8 +47,15 @@ Bluetooth privacy
 -----------------
 
 The service selects Bluetooth privacy (:kconfig:option:`CONFIG_BT_PRIVACY`) and sets the default value of :kconfig:option:`CONFIG_BT_RPA_TIMEOUT` to 3600 seconds.
-During not discoverable advertising, the RPA address rotation must be done together with the Fast Pair payload update.
-Because of this, the RPA address cannot be rotated by Zephyr in the background.
+
+During not discoverable advertising, the Resolvable Private Address (RPA) rotation must be done together with the Fast Pair payload update.
+Because of this, the RPA cannot be rotated by Zephyr in the background.
+
+During discoverable advertising session, the Resolvable Private Address (RPA) rotation must not happen.
+Therefore, consider the following points:
+
+* Make sure that your advertising session is shorter than the value in the :kconfig:option:`CONFIG_BT_RPA_TIMEOUT` option.
+* Call :c:func:`bt_le_oob_get_local` to trigger RPA rotation and reset the RPA timeout right before the start of advertising.
 
 Bluetooth Security Manager Protocol (SMP)
 -----------------------------------------

--- a/doc/nrf/ug_bt_fast_pair.rst
+++ b/doc/nrf/ug_bt_fast_pair.rst
@@ -85,7 +85,10 @@ The Fast Pair service implementation provides API to generate the advertising da
   This function is to be used to set pairing mode before the advertising is started.
 
 Since you control the advertising, make sure to use advertising parameters consistent with the specification.
-The Bluetooth privacy is selected by the Fast Pair service, but you must make sure that the private address rotation is synchronized with the advertising payload update during the not discoverable advertising.
+The Bluetooth privacy is selected by the Fast Pair service, but you must make sure that the following requirements are met:
+
+* The Resolvable Private Address (RPA) rotation is synchronized with the advertising payload update during the not discoverable advertising.
+* The Resolvable Private Address (RPA) address is not rotated during discoverable advertising session.
 
 See the official `Fast Pair Advertising`_ documentation for detailed information about the requirements related to discoverable and not discoverable advertising.
 See :file:`samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c` for an example of the implementation.


### PR DESCRIPTION
User needs to ensure that RPA timeout would not happen while discoverable advertising is active.

Jira: NCSDK-14830