### PR TITLE
bluetooth: gatt_dm: Add additional guard in discovery_callback

### DIFF
--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -464,6 +464,8 @@ static uint8_t discovery_callback(struct bt_conn *conn,
 	default:
 		/* This should not be possible */
 		__ASSERT(false, "Unknown param type.");
+		discovery_complete_error(&bt_gatt_dm_inst, -EINVAL);
+
 		break;
 	}
 


### PR DESCRIPTION
This adds additional call of the discovery_complete_error
callback function in case when discovery callback would be
invoked with invalid parameter type and assertion are disabled.
This case should not happen.