### PR TITLE
application: serial_lte_modem: Change modem Sleep command

### DIFF
--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -147,7 +147,10 @@ The ``<shutdown_mode>`` parameter accepts only the following integer values:
   The data is buffered during the idle status and is sent to MCU after exiting the ilde status.
 
 .. note::
-   This parameter does not accept ``0`` anymore.
+
+   * This parameter does not accept ``0`` anymore.
+   * If the modem is on, entering Sleep mode sends a ``+CFUN=0`` command to the modem, which causes a non-volatile memory (NVM) write.
+     Take the NVM wear into account, or put the modem in flight mode by issuing a ``AT+CFUN=4`` before Sleep mode.
 
 Examples
 ~~~~~~~~
@@ -158,6 +161,16 @@ Examples
    ERROR
 
 ::
+
+   AT#XSLEEP=1
+   OK
+
+See the following for an example of when the modem is on:
+
+::
+
+   AT+CFUN=4
+   OK
 
    AT#XSLEEP=1
    OK

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -87,6 +87,15 @@ extern int slm_setting_uart_save(void);
 
 static void modem_power_off(void)
 {
+	int rc;
+	int cfun;
+
+	/*
+	 * First check if the modem has already been put in Flight
+	 * or OFF mode by the MCU
+	 */
+	rc = nrf_modem_at_scanf("AT+CFUN?", "+CFUN: %d", &cfun);
+	if (rc != 1 || (cfun != 0 && cfun != 4)) {
 	/*
 	 * The LTE modem also needs to be stopped by issuing AT command
 	 * through the modem API, before entering System OFF mode.
@@ -96,8 +105,9 @@ static void modem_power_off(void)
 	 * Refer to https://infocenter.nordicsemi.com/topic/ps_nrf9160/
 	 * pmu.html?cp=2_0_0_4_0_0_1#system_off_mode
 	 */
-	(void)nrf_modem_at_printf("AT+CFUN=0");
-	k_sleep(K_SECONDS(1));
+		(void)nrf_modem_at_printf("AT+CFUN=0");
+		k_sleep(K_SECONDS(1));
+	}
 }
 
 /**@brief handle AT#XSLMVER commands


### PR DESCRIPTION
Using +CFUN=0 writes to NVM, and there is a caution in the
nRF9160 AT reference to take NVM wear into account.

Using +CFUN=4 results in the same power consumption
without writing to NVM.

Signed-off-by: Mariano Goluboff <mariano.goluboff@nordicsemi.no>