### PR TITLE
esb: fix ESB_CRC_OFF configuration

### DIFF
--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -418,6 +418,8 @@ static bool update_radio_crc(void)
 		break;
 
 	case ESB_CRC_OFF:
+		NRF_RADIO->CRCINIT = 0x00UL;
+		NRF_RADIO->CRCPOLY = 0x00UL;
 		NRF_RADIO->CRCCNF = ESB_CRC_OFF << RADIO_CRCCNF_LEN_Pos;
 		break;
 


### PR DESCRIPTION
- Fixes ESB so that CRC can be turned off after it has been turned on.

Ref: NCSDK-15854

Signed-off-by: Magne Værnes <magne.varnes@nordicsemi.no>