### PR TITLE
samples: Rename integration tests

### DIFF
--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -30,7 +30,7 @@ tests:
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build
   # Build integration regression protection.
-  integration.nrf_security.bluetooth:
+  sample.nrf_security.bluetooth.integration:
       build_only: True
       extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
       platform_allow: nrf5340dk_nrf5340_cpuapp

--- a/samples/crypto/sha256/sample.yaml
+++ b/samples/crypto/sha256/sample.yaml
@@ -17,7 +17,7 @@ tests:
             - nrf9160dk_nrf9160
             - nrf52840dk_nrf52840
     # Build integration regression protection.
-    integration.nrf_security.sha256:
+    sample.nrf_security.sha256.integration:
         build_only: True
         extra_args: CONFIG_BOOTLOADER_MCUBOOT=y
         platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52833dk_nrf52833

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -35,7 +35,7 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     tags: ci_build
   # Build integration regression protection.
-  integration.nrf_security.matter:
+  sample.nrf_security.matter.integration:
       build_only: True
       extra_args: CONFIG_NRF_SECURITY=y CONFIG_BOOTLOADER_MCUBOOT=y
       platform_allow: nrf52840dk_nrf52840

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -43,7 +43,7 @@ tests:
       - nrf52840dongle_nrf52840
       - nrf21540dk_nrf52840
   # Build integration regression protection.
-  integration.nrf_security.openthread:
+  sample.nrf_security.openthread.integration:
       build_only: True
       extra_args: CONFIG_NRF_SECURITY=y
       platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840


### PR DESCRIPTION
Some samples of the testcases start names with `integration`
to mark integration testcases.
It deranges a standard of the naming of the testcases.
This change standardizes the names of these testcases and
marks these as integration tests.

Signed-off-by: Katarzyna Giadla <katarzyna.giadla@nordicsemi.no>