### PR TITLE
manifest: zephyr, mcuboot, upmerge 20220622

### DIFF
--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -511,5 +511,6 @@ _BLOCKED_PROJECTS = set(
      'modules/hal/telink',
      'modules/hal/ti',
      'modules/hal/xtensa',
+     'modules/lib/picolibc',
      'modules/lib/tflite-micro',
      ])

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 85a0034809612b332fbdf478357e8a4109c493fd
+      revision: pull/838/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -100,7 +100,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.9.99-ncs1
+      revision: pull/205/head
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Manifest update for upmerge 20220622.

Additional upmerge related changes introduced:
- Block the recently introduced picolibc.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>