### PR TITLE
nrf_modem_lib: trace_backends: fix log module

### DIFF
--- a/lib/nrf_modem_lib/trace_backends/rtt/rtt.c
+++ b/lib/nrf_modem_lib/trace_backends/rtt/rtt.c
@@ -9,7 +9,7 @@
 #include <modem/trace_backend.h>
 #include <SEGGER_RTT.h>
 
-LOG_MODULE_DECLARE(modem_trace_backend, CONFIG_MODEM_TRACE_BACKEND_LOG_LEVEL);
+LOG_MODULE_REGISTER(modem_trace_backend, CONFIG_MODEM_TRACE_BACKEND_LOG_LEVEL);
 
 static int trace_rtt_channel;
 static char rtt_buffer[CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RTT_BUF_SIZE];

--- a/lib/nrf_modem_lib/trace_backends/uart/uart.c
+++ b/lib/nrf_modem_lib/trace_backends/uart/uart.c
@@ -10,7 +10,7 @@
 #include <modem/trace_backend.h>
 #include <nrfx_uarte.h>
 
-LOG_MODULE_DECLARE(modem_trace_backend, CONFIG_MODEM_TRACE_BACKEND_LOG_LEVEL);
+LOG_MODULE_REGISTER(modem_trace_backend, CONFIG_MODEM_TRACE_BACKEND_LOG_LEVEL);
 
 #define UART1_NL DT_NODELABEL(uart1)
 PINCTRL_DT_DEFINE(UART1_NL);

--- a/lib/nrf_modem_lib/trace_backends/uart/uart_sync.c
+++ b/lib/nrf_modem_lib/trace_backends/uart/uart_sync.c
@@ -10,7 +10,7 @@
 #include <modem/trace_backend.h>
 #include <nrfx_uarte.h>
 
-LOG_MODULE_DECLARE(modem_trace_backend, CONFIG_MODEM_TRACE_BACKEND_LOG_LEVEL);
+LOG_MODULE_REGISTER(modem_trace_backend, CONFIG_MODEM_TRACE_BACKEND_LOG_LEVEL);
 
 #define UART1_NL DT_NODELABEL(uart1)
 PINCTRL_DT_DEFINE(UART1_NL);


### PR DESCRIPTION
The backends are erroneously using the `LOG_MODULE_DECLARE` macro
instead of the `LOG_MODULE_REGISTER` macro when only one backend
can exist at a time (log registration is required in at least one
source file).

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>