### PR TITLE
lib: nrf_modem: add include guard to nrf_modem_lib.h and align modem headers

### DIFF
--- a/include/modem/at_cmd_parser.h
+++ b/include/modem/at_cmd_parser.h
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/**
- * @file at_cmd_parser.h
- *
- * @defgroup at_cmd_parser AT command parser
- * @{
- * @brief Basic parser for AT commands.
- */
 #ifndef AT_CMD_PARSER_H__
 #define AT_CMD_PARSER_H__
 
@@ -22,6 +14,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @file at_cmd_parser.h
+ *
+ * @defgroup at_cmd_parser AT command parser
+ * @{
+ * @brief Basic parser for AT commands.
+ */
 
 /**
  * @brief Parse a maximum number of AT command or response parameters

--- a/include/modem/at_monitor.h
+++ b/include/modem/at_monitor.h
@@ -7,6 +7,16 @@
 #ifndef AT_MONITOR_H_
 #define AT_MONITOR_H_
 
+#include <stddef.h>
+#include <stdbool.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain/common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file at_monitor.h
  *
@@ -16,16 +26,6 @@
  *
  * @brief Public APIs for the AT monitor library.
  */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <stddef.h>
-#include <stdbool.h>
-#include <zephyr/kernel.h>
-#include <zephyr/sys/util_macro.h>
-#include <zephyr/toolchain/common.h>
 
 /**
  * @brief AT monitor callback.

--- a/include/modem/at_params.h
+++ b/include/modem/at_params.h
@@ -3,6 +3,14 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+#ifndef AT_PARAMS_H__
+#define AT_PARAMS_H__
+
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @file at_params.h
@@ -23,14 +31,6 @@
  * cleared to free that memory. Getter and setter methods are available
  * to read and write parameter values.
  */
-#ifndef AT_PARAMS_H__
-#define AT_PARAMS_H__
-
-#include <zephyr/types.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /** @brief Parameter types that can be stored. */
 enum at_param_type {

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/**
- * @file location.h
- * @brief Public APIs for the Location library.
- * @defgroup location Location library
- * @{
- */
-
 #ifndef LOCATION_H_
 #define LOCATION_H_
 
@@ -27,6 +19,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @file location.h
+ * @brief Public APIs for the Location library.
+ * @defgroup location Location library
+ * @{
+ */
 
 /** Location method. */
 enum location_method {

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -1,9 +1,3 @@
-/**
- * @file lte_lc.h
- *
- * @brief Public APIs for the LTE Link Control driver.
- */
-
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
@@ -11,6 +5,14 @@
  */
 #ifndef ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
 #define ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <zephyr/kernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @file lte_lc.h
@@ -21,14 +23,6 @@
  *
  * @brief Public APIs for the LTE Link Controller.
  */
-
-#include <stdbool.h>
-#include <stdint.h>
-#include <zephyr/kernel.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /* NOTE: enum lte_lc_nw_reg_status maps directly to the registration status
  *	 as returned by the AT command "AT+CEREG?".

--- a/include/modem/modem_attest_token.h
+++ b/include/modem/modem_attest_token.h
@@ -3,6 +3,14 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+#ifndef MODEM_ATTEST_TOKEN_H__
+#define MODEM_ATTEST_TOKEN_H__
+
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @file modem_attest_token.h
@@ -12,14 +20,6 @@
  * @{
  *
  */
-#ifndef MODEM_ATTEST_TOKEN_H__
-#define MODEM_ATTEST_TOKEN_H__
-
-#include <zephyr/types.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /** @brief Base64url attestation and COSE strings */
 struct nrf_attestation_token {

--- a/include/modem/modem_jwt.h
+++ b/include/modem/modem_jwt.h
@@ -3,15 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/**
- * @file modem_jwt.h
- *
- * @brief Request a JWT from the modem.
- * @defgroup modem_jwt JWT generation
- * @{
- *
- */
 #ifndef MODEM_JWT_H__
 #define MODEM_JWT_H__
 
@@ -21,6 +12,15 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @file modem_jwt.h
+ *
+ * @brief Request a JWT from the modem.
+ * @defgroup modem_jwt JWT generation
+ * @{
+ *
+ */
 
 /**@brief The type of key to be used for signing the JWT. */
 enum jwt_key_type {

--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/**@file modem_key_mgmt.h
- *
- * @defgroup modem_key_mgmt nRF91 Modem Key Management
- * @{
- */
 #ifndef MODEM_KEY_MGMT_H__
 #define MODEM_KEY_MGMT_H__
 
@@ -16,6 +11,17 @@
 #include <stdint.h>
 
 #include <nrf_socket.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file modem_key_mgmt.h
+ *
+ * @defgroup modem_key_mgmt nRF91 Modem Key Management
+ * @{
+ */
 
 /**@brief Credential types. */
 enum modem_key_mgmt_cred_type {
@@ -126,5 +132,10 @@ int modem_key_mgmt_exists(nrf_sec_tag_t sec_tag,
 			  enum modem_key_mgmt_cred_type cred_type,
 			  bool *exists);
 
-#endif /* MODEM_KEY_MGMT_H__ */
 /**@} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MODEM_KEY_MGMT_H__ */

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+#ifndef NRF_MODEM_LIB_H_
+#define NRF_MODEM_LIB_H_
 
 /**
  * @file nrf_modem_lib.h
@@ -156,3 +158,5 @@ void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault_info);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* NRF_MODEM_LIB_H_ */

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -3,8 +3,16 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
+
 #ifndef NRF_MODEM_LIB_H_
 #define NRF_MODEM_LIB_H_
+
+#include <zephyr/kernel.h>
+#include <nrf_modem.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @file nrf_modem_lib.h
@@ -15,13 +23,6 @@
  *
  * @brief API of the SMS nRF Modem library wrapper module.
  */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <zephyr/kernel.h>
-#include <nrf_modem.h>
 
 /**
  * @brief Initialize the Modem library.

--- a/include/modem/nrf_modem_lib_trace.h
+++ b/include/modem/nrf_modem_lib_trace.h
@@ -4,16 +4,22 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/**@file nrf_modem_lib_trace.h
- *
- * @defgroup nrf_modem_lib_trace nRF91 Modem trace module
- * @{
- */
 #ifndef NRF_MODEM_LIB_TRACE_H__
 #define NRF_MODEM_LIB_TRACE_H__
 
 #include <zephyr/kernel.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file nrf_modem_lib_trace.h
+ *
+ * @defgroup nrf_modem_lib_trace nRF91 Modem trace module
+ * @{
+ */
 
 /** @brief Initialize the modem trace module.
  *
@@ -72,5 +78,10 @@ int nrf_modem_lib_trace_stop(void);
  */
 void nrf_modem_lib_trace_deinit(void);
 
-#endif /* NRF_MODEM_LIB_TRACE_H__ */
 /**@} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_MODEM_LIB_TRACE_H__ */

--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/**
- * @file pdn.h
- * @brief Public APIs for the PDN library.
- * @defgroup pdn PDN library
- * @{
- */
-
 #ifndef PDN_H_
 #define PDN_H_
 
@@ -21,6 +14,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @file pdn.h
+ * @brief Public APIs for the PDN library.
+ * @defgroup pdn PDN library
+ * @{
+ */
 
 /** @brief PDN family */
 enum pdn_fam {

--- a/include/modem/sms.h
+++ b/include/modem/sms.h
@@ -7,6 +7,13 @@
 #ifndef SMS_H_
 #define SMS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/types.h>
+#include <sys/types.h>
+
 /**
  * @file sms.h
  *
@@ -16,13 +23,6 @@
  *
  * @brief Public APIs of the SMS subscriber manager module.
  */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <zephyr/types.h>
-#include <sys/types.h>
 
 /**
  * @brief SMS message type.

--- a/include/modem/trace_backend.h
+++ b/include/modem/trace_backend.h
@@ -4,14 +4,19 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#ifndef TRACE_BACKEND_H__
+#define TRACE_BACKEND_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file trace_backend.h
  *
  * @defgroup trace_backend nRF91 Modem trace backend interface.
  * @{
  */
-#ifndef TRACE_BACKEND_H__
-#define TRACE_BACKEND_H__
 
 /**
  * @brief Initialize the compile-time selected trace backend.
@@ -40,5 +45,10 @@ int trace_backend_deinit(void);
  */
 int trace_backend_write(const void *data, size_t len);
 
-#endif /* TRACE_BACKEND_H__ */
 /**@} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TRACE_BACKEND_H__ */


### PR DESCRIPTION
Add missing include guard to nrf_modem_lib.h.

Align guards, doxygen groups and extern C declarations for modem
headers.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>