### PR TITLE
samples: matter: Fixed open commissioning window condition

### DIFF
--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -249,9 +249,8 @@ CHIP_ERROR AppTask::Init()
 
 void AppTask::OpenPairingWindow()
 {
-	/* Don't allow on starting Matter service BLE advertising after Thread provisioning. */
-	if (ConnectivityMgr().IsThreadProvisioned()) {
-		LOG_INF("NFC Tag emulation and Matter service BLE advertising not started - device is commissioned to a Thread network.");
+	if (Server::GetInstance().GetFabricTable().FabricCount() != 0) {
+		LOG_INF("Matter service BLE advertising not started - device is already commissioned");
 		return;
 	}
 

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -352,9 +352,8 @@ void AppTask::StartThreadHandler()
 
 void AppTask::StartBLEAdvertisingHandler()
 {
-	/* Don't allow on starting Matter service BLE advertising after Thread provisioning. */
-	if (ConnectivityMgr().IsThreadProvisioned()) {
-		LOG_INF("NFC Tag emulation and Matter service BLE advertising not started - device is commissioned to a Thread network.");
+	if (Server::GetInstance().GetFabricTable().FabricCount() != 0) {
+		LOG_INF("Matter service BLE advertising not started - device is already commissioned");
 		return;
 	}
 

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -296,7 +296,6 @@ void AppTask::IdentifyStopHandler(Identify *)
 
 void AppTask::StartBLEAdvertisingHandler(AppEvent *aEvent)
 {
-	/* Don't allow on starting Matter service BLE advertising after Thread provisioning. */
 	if (Server::GetInstance().GetFabricTable().FabricCount() != 0) {
 		LOG_INF("Matter service BLE advertising not started - device is already commissioned");
 		return;

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -326,9 +326,8 @@ void AppTask::StartThreadHandler()
 
 void AppTask::StartBLEAdvertisingHandler()
 {
-	/* Don't allow on starting Matter service BLE advertising after Thread provisioning. */
-	if (ConnectivityMgr().IsThreadProvisioned()) {
-		LOG_INF("NFC Tag emulation and Matter service BLE advertising not started - device is commissioned to a Thread network.");
+	if (Server::GetInstance().GetFabricTable().FabricCount() != 0) {
+		LOG_INF("Matter service BLE advertising not started - device is already commissioned");
 		return;
 	}
 


### PR DESCRIPTION
After removing the fabric it is not possible to open commissioning
window again, due to inproper advertising start condition. Replace
condition checking IsThreadProvisioned with FabricCount.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>