### PR TITLE
net: lib: rest_client: http status string and fetching only the http header

### DIFF
--- a/include/net/rest_client.h
+++ b/include/net/rest_client.h
@@ -18,6 +18,7 @@
 #define REST_CLIENT_H__
 
 #include <zephyr/kernel.h>
+#include <zephyr/net/http_client.h>
 #include <zephyr/net/http_parser.h>
 
 /** @brief TLS is not used. */
@@ -112,6 +113,12 @@ struct rest_client_resp_context {
 
 	/** Numeric HTTP status code. */
 	uint16_t http_status_code;
+
+	/** HTTP status code as a textual description, i.e. the reason-phrase element.
+	 * https://tools.ietf.org/html/rfc7230#section-3.1.2
+	 * Copied here from http_status[] of http_response.
+	 */
+	char http_status_code_str[HTTP_STATUS_STR_SIZE];
 
 	/** Used socket identifier. Use this for keepalive connections as
 	 *  connect_socket for upcoming requests.

--- a/samples/nrf9160/modem_shell/src/rest/rest_shell.c
+++ b/samples/nrf9160/modem_shell/src/rest/rest_shell.c
@@ -41,7 +41,7 @@ static const char rest_shell_cmd_usage_str[] =
 	"  -l, --resp_len,      Length of the buffer reserved for the REST response\n"
 	"                       (default: 1024 bytes)\n"
 	"  -k, --keepalive,     Keep socket connection alive for upcoming requests\n"
-	"                       towards the ame server (default: false)\n"
+	"                       towards the same server (default: false)\n"
 	"      --print_headers, Print HTTP headers of the response\n"
 	"  -i, --sckt_id,       Use existing socket id (default: create a new connection)\n";
 
@@ -287,13 +287,15 @@ int rest_shell(const struct shell *shell, size_t argc, char **argv)
 		mosh_print(
 			"Response:\n"
 			"  Socket ID: %d (sckt closed: %s)\n"
-			"  HTTP status: %d\n"
+			"  HTTP status: %d (%s)\n"
 			"  Headers/Body/Total length: %d/%d/%d\n\n"
 			"%.*s"
 			"%s",
 			resp_ctx.used_socket_id,
 			(resp_ctx.used_socket_is_alive) ? "no" : "yes",
 			resp_ctx.http_status_code,
+			(resp_ctx.http_status_code) ? resp_ctx.http_status_code_str :
+				"No response / timeout",
 			headers_len,
 			resp_ctx.response_len,
 			resp_ctx.total_response_len,

--- a/samples/nrf9160/modem_shell/src/rest/rest_shell.c
+++ b/samples/nrf9160/modem_shell/src/rest/rest_shell.c
@@ -22,27 +22,33 @@ static const char rest_shell_cmd_usage_str[] =
 	"Usage:\n"
 	"rest -d host [-m method] [-p port] [-s sec_tag] [-v verify_level] [-u url] [-t timeout_in_ms]\n"
 	"              [-H header1] [-H header2]...[-H header10] [-b body] [-l response_buffer_length]\n"
-	"              [-k] [-i sckt_id]\n"
+	"              [-k] [-i sckt_id] [--print_headers]\n"
 	"\n"
-	"  -d, --host,         Destination host/domain of the URL\n"
+	"  -d, --host,          Destination host/domain of the URL\n"
 	"Optionals:\n"
-	"  -m, --method,       HTTP method (one of the: \"get\" (default),\"head\",\n"
-	"                      \"post\",\"put\",\"delete\" or \"patch\")\n"
-	"  -p, --port,         Destination port (default: 80)\n"
-	"  -s, --sec_tag,      Used security tag for TLS connection\n"
-	"  -v, --peer_verify,  TLS peer verification level. None (0),\n"
-	"                      optional (1) or required (2). Default value is 2.\n"
-	"  -u, --url,          URL beyond host/domain (default: \"/index.html\")\n"
-	"  -t, --timeout,      Request timeout in seconds\n"
-	"                      (default: CONFIG_REST_CLIENT_REST_REQUEST_TIMEOUT)\n"
-	"  -H, --header,       Header including CRLF, for example:\n"
-	"                      -H \"Content-Type: application/json\\x0D\\x0A\"\n"
-	"  -b, --body,         Payload body, example: -b '{\"foo\":bar}'\n"
-	"  -l, --resp_len,     Length of the buffer reserved for the REST response\n"
-	"                      (default: 1024 bytes)\n"
-	"  -k, --keepalive,    Keep socket connection alive for upcoming requests\n"
-	"                      towards the ame server (default: false)\n"
-	"  -i, --sckt_id,      Use existing socket id (default: create a new connection)\n";
+	"  -m, --method,        HTTP method (one of the: \"get\" (default),\"head\",\n"
+	"                       \"post\",\"put\",\"delete\" or \"patch\")\n"
+	"  -p, --port,          Destination port (default: 80)\n"
+	"  -s, --sec_tag,       Used security tag for TLS connection\n"
+	"  -v, --peer_verify,   TLS peer verification level. None (0),\n"
+	"                       optional (1) or required (2). Default value is 2.\n"
+	"  -u, --url,           URL beyond host/domain (default: \"/index.html\")\n"
+	"  -t, --timeout,       Request timeout in seconds\n"
+	"                       (default: CONFIG_REST_CLIENT_REST_REQUEST_TIMEOUT)\n"
+	"  -H, --header,        Header including CRLF, for example:\n"
+	"                       -H \"Content-Type: application/json\\x0D\\x0A\"\n"
+	"  -b, --body,          Payload body, example: -b '{\"foo\":bar}'\n"
+	"  -l, --resp_len,      Length of the buffer reserved for the REST response\n"
+	"                       (default: 1024 bytes)\n"
+	"  -k, --keepalive,     Keep socket connection alive for upcoming requests\n"
+	"                       towards the ame server (default: false)\n"
+	"      --print_headers, Print HTTP headers of the response\n"
+	"  -i, --sckt_id,       Use existing socket id (default: create a new connection)\n";
+
+/* Following are not having short options: */
+enum {
+	REST_SHELL_OPT_PRINT_RESP_HEADERS = 1001,
+};
 
 /* Specifying the expected options (both long and short): */
 static struct option long_options[] = {
@@ -58,6 +64,7 @@ static struct option long_options[] = {
 	{ "timeout", required_argument, 0, 't' },
 	{ "keepalive", no_argument, 0, 'k' },
 	{ "sckt_id", required_argument, 0, 'i' },
+	{ "print_headers", no_argument, 0, REST_SHELL_OPT_PRINT_RESP_HEADERS },
 	{ 0, 0, 0, 0 }
 };
 
@@ -85,6 +92,7 @@ int rest_shell(const struct shell *shell, size_t argc, char **argv)
 	bool headers_set = false;
 	bool method_set = false;
 	bool host_set = false;
+	bool print_headers_from_resp = false;
 	int response_buf_len = REST_RESPONSE_BUFF_SIZE;
 
 	/* Set the defaults: */
@@ -229,6 +237,9 @@ int rest_shell(const struct shell *shell, size_t argc, char **argv)
 				goto end;
 			}
 			break;
+		case REST_SHELL_OPT_PRINT_RESP_HEADERS:
+			print_headers_from_resp = true;
+			break;
 		case '?':
 			show_usage = true;
 			goto end;
@@ -265,17 +276,28 @@ int rest_shell(const struct shell *shell, size_t argc, char **argv)
 	if (ret) {
 		mosh_error("Error %d from rest_lib", ret);
 	} else {
+		int headers_len = resp_ctx.response - req_ctx.resp_buff;
+		char *headers_start = req_ctx.resp_buff;
+		int printed_headers_len = 0;
+
+		if (print_headers_from_resp) {
+			printed_headers_len = headers_len;
+		}
+
 		mosh_print(
 			"Response:\n"
 			"  Socket ID: %d (sckt closed: %s)\n"
 			"  HTTP status: %d\n"
-			"  Body/Total length: %d/%d\n\n"
-			"  %s\n",
+			"  Headers/Body/Total length: %d/%d/%d\n\n"
+			"%.*s"
+			"%s",
 			resp_ctx.used_socket_id,
 			(resp_ctx.used_socket_is_alive) ? "no" : "yes",
 			resp_ctx.http_status_code,
+			headers_len,
 			resp_ctx.response_len,
 			resp_ctx.total_response_len,
+			printed_headers_len, headers_start,
 			resp_ctx.response);
 	}
 

--- a/subsys/net/lib/rest_client/src/rest_client.c
+++ b/subsys/net/lib/rest_client/src/rest_client.c
@@ -61,6 +61,7 @@ static void rest_client_http_response_cb(struct http_response *rsp,
 		}
 		resp_ctx->http_status_code = rsp->http_status_code;
 		resp_ctx->response_len = rsp->processed;
+		strcpy(resp_ctx->http_status_code_str, rsp->http_status);
 
 		LOG_DBG("HTTP: All data received (content/total: %d/%d), status: %u %s",
 			resp_ctx->response_len,
@@ -292,6 +293,7 @@ static int rest_client_do_api_call(struct http_request *http_req,
 	resp_ctx->response_len = 0;
 	resp_ctx->total_response_len = 0;
 	resp_ctx->used_socket_id = req_ctx->connect_socket;
+	resp_ctx->http_status_code_str[0] = '\0';
 
 	err = http_client_req(req_ctx->connect_socket, http_req, req_ctx->timeout_ms, resp_ctx);
 	if (err < 0) {

--- a/subsys/net/lib/rest_client/src/rest_client.c
+++ b/subsys/net/lib/rest_client/src/rest_client.c
@@ -354,10 +354,12 @@ int rest_client_request(struct rest_client_req_context *req_ctx,
 	}
 
 	if (!resp_ctx->response || !resp_ctx->response_len) {
+		char *end_ptr = &req_ctx->resp_buff[resp_ctx->total_response_len];
+
 		LOG_WRN("No data in a response body");
 		/* Make it as zero length string */
-		*req_ctx->resp_buff = '\0';
-		resp_ctx->response = req_ctx->resp_buff;
+		*end_ptr = '\0';
+		resp_ctx->response = end_ptr;
 		resp_ctx->response_len = 0;
 	}
 	LOG_DBG("API call response len: http status: %d, %u bytes", resp_ctx->http_status_code,


### PR DESCRIPTION
This PR adds (in backwards compatible manners) to rest_client lib:
- the reason-phrase element of the http status-line  is copied from http_response to rest_client_resp_context
- decent support for fetching only the header.

Additionally, modem_shell was updated to have an option to print the response http header and printing of http status