### PR TITLE
mpsl: fem: fix Simple GPIO for nRF53 SoCs

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -88,6 +88,11 @@ ESB
 
 * Fixed the ``update_radio_crc()`` function in order to correctly configure the CRC's registers (8 bits, 16 bits, or none).
 
+RF Front-End Modules
+====================
+
+* Fixed a build error that occurred when building an application for nRF53 SoCs with Simple GPIO Front-End Module support enabled.
+
 Applications
 ============
 

--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -29,7 +29,7 @@ config MPSL_FEM
 config MPSL_FEM_PIN_FORWARDER
 	bool "Forward pin control for front-end module (FEM) to the radio core"
 	depends on SOC_NRF5340_CPUAPP
-	depends on MPSL_FEM_NRF21540_GPIO_SUPPORT
+	depends on MPSL_FEM_NRF21540_GPIO_SUPPORT || MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT
 	depends on !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
 	default y
 


### PR DESCRIPTION
This commit fixes a Kconfig build error that occurred when building an
application for nRF53 SoCs with Simple GPIO Front-End Module support
enabled.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>