### PR TITLE
samples: nrf9160: lte_ble_gateway: add description of LED behaviour

### DIFF
--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -58,6 +58,23 @@ Two buttons and two switches are used to enter a pairing pattern to associate a 
 
 When the connection is established, set switch 2 to **N.C.** to send simulated GNSS data to nRF Cloud once every 2 seconds.
 
+On the nRF9160 DK, the LEDs display the following information regarding the application state:
+
+LED 3 and LED 4:
+    * LED 3 blinking: The device is connecting to the LTE network.
+    * LED 3 ON: The device is connected to the LTE network.
+    * LED 4 blinking: The device is connecting to nRF Cloud.
+    * LED 3 and LED 4 blinking: The MQTT connection has been established and the user association procedure with nRF Cloud has been initiated.
+    * LED 4 ON: The device is connected and ready for sensor data transfer.
+
+    .. figure:: /images/nrf_cloud_led_states.svg
+       :alt: Application state indicated by LEDs
+
+All LEDs (1-4):
+    * Blinking in groups of two (LED 1 and 3, LED 2 and 4): Modem fault.
+    * Blinking in a cross pattern (LED 1 and 4, LED 2 and 3): Communication error with nRF Cloud.
+    * Blinking in groups of two (LED 1 and 2, LED 3 and 4): Other error.
+
 
 Building and running
 ********************


### PR DESCRIPTION
This sample used to refer to asset_tracker for the LED behaviour when
connecting to nRF Cloud. When asset_tracker version 1 was removed, this
was not updated for this sample. This PR will reintroduce the
description from asset_tracker such that this behaviour is documented.

Signed-off-by: Markus Rekdal <markus.rekdal@nordicsemi.no>