### PR TITLE
Fix capitalisation

### DIFF
--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -53,7 +53,7 @@ After completing the :ref:`manual <build_environment_cli>` or :ref:`automatic <g
 
       .. code-block:: console
 
-         cd nrf/samples/nRF9160/at_client
+         cd nrf/samples/nrf9160/at_client
 
 
 #.    Build the application using the west command.


### PR DESCRIPTION
The folder is `nrf9160`, all in lower letters: https://github.com/nrfconnect/sdk-nrf/tree/main/samples/nrf9160/at_client

So the command does not work on an OS + FS combination that is case sensitive.