### PR TITLE
tfm: Fix Kconfig Pin Description

### DIFF
--- a/modules/tfm/zephyr/Kconfig
+++ b/modules/tfm/zephyr/Kconfig
@@ -32,36 +32,36 @@ config TFM_UART0_TXD_PIN
 	        TF-M regression tests.
 
 config TFM_UART0_RXD_PIN
-	int "UART0 TXD pin"
+	int "UART0 RXD pin"
 	default 28 if BOARD_NRF9160DK_NRF9160_NS
 	default 22 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
-	  The GPIO pin the TFM build system will use for UART0 TXD pin.
+	  The GPIO pin the TFM build system will use for UART0 RXD pin.
 	  UART0 is used by TF-M as the log output for the non-secure image.
 
 	  Note: The non-secure image is only ever used when running the
 	        TF-M regression tests.
 
 config TFM_UART0_RTS_PIN
-	int "UART0 TXD pin"
+	int "UART0 RTS pin"
 	default 27 if BOARD_NRF9160DK_NRF9160_NS
 	default 19 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
-	  The GPIO pin the TFM build system will use for UART0 TXD pin.
+	  The GPIO pin the TFM build system will use for UART0 RTS pin.
 	  UART0 is used by TF-M as the log output for the non-secure image.
 
 	  Note: The non-secure image is only ever used when running the
 	        TF-M regression tests.
 
 config TFM_UART0_CTS_PIN
-	int "UART0 TXD pin"
+	int "UART0 CTS pin"
 	default 26 if BOARD_NRF9160DK_NRF9160_NS
 	default 21 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
-	  The GPIO pin the TFM build system will use for UART0 TXD pin.
+	  The GPIO pin the TFM build system will use for UART0 CTS pin.
 	  UART0 is used by TF-M as the log output for the non-secure image.
 
 	  Note: The non-secure image is only ever used when running the
@@ -78,13 +78,13 @@ config TFM_UART1_TXD_PIN
 	  UART1 is used by TF-M as the log output for the secure image.
 
 config TFM_UART1_RXD_PIN
-	int "UART1 TXD pin"
+	int "UART1 RXD pin"
 	depends on TFM_SECURE_UART1
 	default 0 if BOARD_NRF9160DK_NRF9160_NS
 	default 26 if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 	default 4294967295 # 0xffffffff i.e. disconnected
 	help
-	  The GPIO pin the TFM build system will use for UART1 TXD pin.
+	  The GPIO pin the TFM build system will use for UART1 RXD pin.
 	  UART1 is used by TF-M as the log output for the secure image.
 
 endif # BUILD_WITH_TFM


### PR DESCRIPTION
Fixed Kconfig pin description, previously all pins were named TXD
Signed-off-by: Ethan Dunne <ethan.dunne4@gmail.com>