### PR TITLE
samples: nrf9160: modem_shell: stored commands could be set to be run after a startup

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -215,6 +215,8 @@ nRF9160 samples
       When running this configuration, you can perform BT scanning and advertising using the ``bt`` command.
     * Support for injecting GNSS reference altitude for low accuracy mode.
       For a position fix using only three satellites, GNSS module must have a reference altitude that can now be injected using the ``gnss agps ref_altitude`` command.
+    * New command ``startup_cmd``, which can be used to store up to three MoSh commands to be run on start/bootup.
+      By default, commands are run after the default PDN context is activated, but can be set to run N seconds after bootup.
 
 Thread samples
 --------------

--- a/samples/nrf9160/modem_shell/CMakeLists.txt
+++ b/samples/nrf9160/modem_shell/CMakeLists.txt
@@ -32,6 +32,7 @@ add_subdirectory_ifdef(CONFIG_MOSH_LOCATION src/location)
 add_subdirectory_ifdef(CONFIG_MOSH_PPP src/ppp)
 add_subdirectory_ifdef(CONFIG_MOSH_FOTA src/fota)
 add_subdirectory_ifdef(CONFIG_MOSH_REST src/rest)
+add_subdirectory_ifdef(CONFIG_MOSH_STARTUP_CMDS src/startup_cmd)
 add_subdirectory(src/cloud)
 
 if(NOT ENV{PROJECT_NAME})

--- a/samples/nrf9160/modem_shell/Kconfig
+++ b/samples/nrf9160/modem_shell/Kconfig
@@ -109,6 +109,7 @@ config MOSH_PRINT_BUFFER_SIZE
 
 config MOSH_COMMON_WORKQUEUE_STACK_SIZE
 	int "Common workqueue stack size"
+	default 6144 if MOSH_STARTUP_CMDS && MOSH_CURL#
 	default 4096
 
 config MOSH_COMMON_WORKQUEUE_PRIORITY
@@ -120,6 +121,10 @@ menu "MoSH iperf3 and ping command selections"
 
 config MOSH_WORKER_THREADS
 	bool "Possibility to run iperf3 or ping instances in separate threads"
+	default y
+
+config MOSH_STARTUP_CMDS
+	bool "Possibility to run stored MoSh commands from settings after bootup"
 	default y
 
 config MOSH_NRF91_NON_OFFLOADING_DEV

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -538,6 +538,26 @@ Examples
 
 ----
 
+Running stored commands after startup
+=====================================
+
+MoSh command: ``startup_cmd``
+
+You can store up to three MoSh commands to run on start/bootup.
+By default, commands are run after the default PDN context is activated,
+but can be set to run N seconds after bootup.
+
+Examples
+--------
+
+* Starting periodic location acquiring after LTE has been connected with both cellular and GNSS, including sending the location to nRF Cloud:
+
+  .. code-block:: console
+
+     startup_cmd --mem1 "location get --mode all --method cellular --method gnss --gnss_cloud_pvt --interval 15"
+
+----
+
 Cloud
 =====
 

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
@@ -14,7 +14,9 @@
 #if defined(CONFIG_MOSH_PPP)
 #include "ppp_ctrl.h"
 #endif
-
+#if defined(CONFIG_MOSH_STARTUP_CMDS)
+#include "startup_cmd_ctrl.h"
+#endif
 #include "link_shell_print.h"
 #include "link_shell_pdn.h"
 #include "mosh_print.h"
@@ -47,16 +49,21 @@ void link_pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)
 		break;
 	default:
 		mosh_print("PDN event: PDP context %d %s", cid, event_str[event]);
-#if defined(CONFIG_MOSH_PPP)
 		if (cid == 0) {
+#if defined(CONFIG_MOSH_STARTUP_CMDS)
+			if (event == PDN_EVENT_ACTIVATED) {
+				startup_cmd_ctrl_default_pdn_active();
+			}
+#endif
+#if defined(CONFIG_MOSH_PPP)
 			/* Notify PPP side about the default PDN activation status */
 			if (event == PDN_EVENT_ACTIVATED) {
 				ppp_ctrl_default_pdn_active(true);
 			} else if (event == PDN_EVENT_DEACTIVATED) {
 				ppp_ctrl_default_pdn_active(false);
 			}
-		}
 #endif
+		}
 		break;
 	}
 

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -52,6 +52,10 @@
 #include "location_shell.h"
 #endif
 
+#if defined(CONFIG_MOSH_STARTUP_CMDS)
+#include "startup_cmd_ctrl.h"
+#endif
+
 #if defined(CONFIG_MOSH_AT_CMD_MODE)
 #include "at_cmd_mode.h"
 #include "at_cmd_mode_sett.h"
@@ -220,6 +224,10 @@ void main(void)
 	shell_execute_cmd(shell, "resize");
 	/* Run empty command because otherwise "resize" would be set to the command line. */
 	shell_execute_cmd(shell, "");
+
+#if defined(CONFIG_MOSH_STARTUP_CMDS)
+	startup_cmd_ctrl_init();
+#endif
 
 #if defined(CONFIG_MOSH_AT_CMD_MODE)
 	at_cmd_mode_sett_init();

--- a/samples/nrf9160/modem_shell/src/startup_cmd/CMakeLists.txt
+++ b/samples/nrf9160/modem_shell/src/startup_cmd/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+target_include_directories(app PRIVATE .)
+
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/startup_cmd_ctrl.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/startup_cmd_shell.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/startup_cmd_settings.c)

--- a/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_ctrl.c
+++ b/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_ctrl.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <stdio.h>
+
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_uart.h>
+
+#include "mosh_print.h"
+#include "startup_cmd_settings.h"
+
+extern struct k_work_q mosh_common_work_q;
+
+/* Work for running commands: */
+struct startup_cmd_worker_data {
+	struct k_work_delayable work;
+	uint8_t running_mem_slot;
+};
+static struct startup_cmd_worker_data startup_cmd_worker_data;
+
+static bool running;
+
+static void startup_cmd_worker(struct k_work *work_item)
+{
+	const struct shell *shell = shell_backend_uart_get_ptr();
+	char *shell_cmd_str;
+	int len = 0;
+	struct startup_cmd_worker_data *data_ptr =
+		CONTAINER_OF(work_item, struct startup_cmd_worker_data, work);
+
+	shell_cmd_str = startup_cmd_settings_get(data_ptr->running_mem_slot);
+
+	len = strlen(shell_cmd_str);
+	if (len) {
+		mosh_print("Starting to execute sett_cmd %d \"%s\"...",
+			data_ptr->running_mem_slot, shell_cmd_str);
+		shell_execute_cmd(shell, shell_cmd_str);
+	}
+
+	/* We are done for this one. Schedule next stored command. */
+	if (data_ptr->running_mem_slot < STARTUP_CMD_MAX_COUNT) {
+		startup_cmd_worker_data.running_mem_slot++;
+		k_work_schedule_for_queue(
+			&mosh_common_work_q, &startup_cmd_worker_data.work, K_NO_WAIT);
+	} else {
+		/* No more commands to run */
+		startup_cmd_worker_data.running_mem_slot = 0;
+	}
+}
+
+static bool startup_cmd_can_be_started(void)
+{
+	return (!running && startup_cmd_settings_enabled());
+}
+
+void startup_cmd_ctrl_default_pdn_active(void)
+{
+	if (startup_cmd_can_be_started()) {
+		startup_cmd_worker_data.running_mem_slot = 1;
+
+		/* Give some time for the link module for getting status etc. */
+		k_work_schedule_for_queue(&mosh_common_work_q, &startup_cmd_worker_data.work,
+					  K_SECONDS(2));
+		running = true;
+	}
+}
+
+void startup_cmd_ctrl_settings_loaded(void)
+{
+	int starttime = startup_cmd_settings_starttime_get();
+
+	if (startup_cmd_can_be_started() && starttime >= 0) {
+		startup_cmd_worker_data.running_mem_slot = 1;
+		k_work_schedule_for_queue(&mosh_common_work_q, &startup_cmd_worker_data.work,
+					  K_SECONDS(starttime));
+		running = true;
+	}
+}
+
+void startup_cmd_ctrl_init(void)
+{
+	k_work_init_delayable(&startup_cmd_worker_data.work, startup_cmd_worker);
+	startup_cmd_settings_init();
+}

--- a/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_ctrl.h
+++ b/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_ctrl.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef MOSH_STARTUP_CMD_CTRL_H
+#define MOSH_STARTUP_CMD_CTRL_H
+
+void startup_cmd_ctrl_settings_loaded(void);
+void startup_cmd_ctrl_default_pdn_active(void);
+void startup_cmd_ctrl_init(void);
+
+#endif /* MOSH_STARTUP_CMD_CTRL_H */

--- a/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_settings.c
+++ b/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_settings.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/settings/settings.h>
+
+#include "mosh_defines.h"
+#include "mosh_print.h"
+
+#include "startup_cmd_ctrl.h"
+#include "startup_cmd_settings.h"
+
+#define STARTUP_CMD_SETTINGS_KEY "startup_cmd_settings"
+
+/* ****************************************************************************/
+
+#define STARTUP_CMD_STARTTIME "starttime"
+#define STARTUP_CMD_1_KEY     "startup_cmd_1"
+#define STARTUP_CMD_2_KEY     "startup_cmd_2"
+#define STARTUP_CMD_3_KEY     "startup_cmd_3"
+
+/* ****************************************************************************/
+
+struct startup_cmd_t {
+	int starttime;
+	char cmd1_str[STARTUP_CMD_MAX_LEN + 1];
+	char cmd2_str[STARTUP_CMD_MAX_LEN + 1];
+	char cmd3_str[STARTUP_CMD_MAX_LEN + 1];
+
+};
+static struct startup_cmd_t startup_cmd_data;
+
+/* ****************************************************************************/
+
+/**@brief Callback when settings_load() is called. */
+static int startup_cmd_settings_handler(const char *key, size_t len,
+			       settings_read_cb read_cb, void *cb_arg)
+{
+	int err;
+
+	if (strcmp(key, STARTUP_CMD_STARTTIME) == 0) {
+		err = read_cb(cb_arg, &startup_cmd_data.starttime,
+			      sizeof(startup_cmd_data.starttime));
+		if (err < 0) {
+			mosh_error("Failed to read starttime, error: %d", err);
+			return err;
+		}
+	} else if (strcmp(key, STARTUP_CMD_1_KEY) == 0) {
+		err = read_cb(cb_arg, &startup_cmd_data.cmd1_str,
+			      sizeof(startup_cmd_data.cmd1_str));
+		if (err < 0) {
+			mosh_error("Failed to read set_cmd #1, error: %d", err);
+			return err;
+		}
+	} else if (strcmp(key, STARTUP_CMD_2_KEY) == 0) {
+		err = read_cb(cb_arg, &startup_cmd_data.cmd2_str,
+			      sizeof(startup_cmd_data.cmd2_str));
+		if (err < 0) {
+			mosh_error("Failed to read set_cmd #2, error: %d", err);
+			return err;
+		}
+	} else if (strcmp(key, STARTUP_CMD_3_KEY) == 0) {
+		err = read_cb(cb_arg, &startup_cmd_data.cmd3_str,
+			      sizeof(startup_cmd_data.cmd3_str));
+		if (err < 0) {
+			mosh_error("Failed to read set_cmd #3, error: %d", err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+/* ****************************************************************************/
+
+char *startup_cmd_settings_get(uint8_t mem_slot)
+{
+	if (mem_slot == 1) {
+		return startup_cmd_data.cmd1_str;
+	} else if (mem_slot == 2) {
+		return startup_cmd_data.cmd2_str;
+	}
+	__ASSERT_NO_MSG(mem_slot == 3);
+	return startup_cmd_data.cmd3_str;
+}
+
+int startup_cmd_settings_save(const char *cmd_str, int mem_slot)
+{
+	int err = 0;
+	const char *key;
+	int len = strlen(cmd_str);
+	char *tmp_ptr = NULL;
+
+	__ASSERT_NO_MSG(mem_slot >= 1 && mem_slot <= STARTUP_CMD_MAX_COUNT);
+
+	if (len > STARTUP_CMD_MAX_LEN) {
+		mosh_error("%s: Too long cmd, max is %d", (__func__), STARTUP_CMD_MAX_LEN);
+		return -EINVAL;
+	}
+
+	if (mem_slot == 1) {
+		key = STARTUP_CMD_SETTINGS_KEY "/" STARTUP_CMD_1_KEY;
+		tmp_ptr = startup_cmd_data.cmd1_str;
+	} else if (mem_slot == 2) {
+		key = STARTUP_CMD_SETTINGS_KEY "/" STARTUP_CMD_2_KEY;
+		tmp_ptr = startup_cmd_data.cmd2_str;
+	} else if (mem_slot == 3) {
+		key = STARTUP_CMD_SETTINGS_KEY "/" STARTUP_CMD_3_KEY;
+		tmp_ptr = startup_cmd_data.cmd3_str;
+	} else {
+		mosh_error("%s: unsupported memory slot %d", (__func__), mem_slot);
+		err = -EINVAL;
+		return err;
+	}
+	err = settings_save_one(key, cmd_str, len + 1);
+	if (err) {
+		mosh_error("%s: cannot save command %s to settings."
+			   "err %d from settings_save_one()",
+			   (__func__), cmd_str, err);
+		return err;
+	}
+	strcpy(tmp_ptr, cmd_str);
+	mosh_print("%s: key %s with value %s saved", (__func__), key, cmd_str);
+
+	return 0;
+}
+
+bool startup_cmd_settings_enabled(void)
+{
+	if (strlen(startup_cmd_data.cmd1_str) ||
+	    strlen(startup_cmd_data.cmd2_str) ||
+	    strlen(startup_cmd_data.cmd3_str)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+/* ****************************************************************************/
+
+int startup_cmd_settings_starttime_set(int starttime)
+{
+	int ret;
+	char *key;
+
+	key = STARTUP_CMD_SETTINGS_KEY "/" STARTUP_CMD_STARTTIME;
+	ret = settings_save_one(key, &starttime, sizeof(starttime));
+	if (ret) {
+		mosh_error("Cannot save start time %d to settings", starttime);
+		return ret;
+	}
+	startup_cmd_data.starttime = starttime;
+
+	mosh_print("%s: key %s with value %d saved", (__func__), key, starttime);
+	return 0;
+}
+
+int startup_cmd_settings_starttime_get(void)
+{
+	return startup_cmd_data.starttime;
+}
+
+/* ****************************************************************************/
+
+void startup_cmd_settings_conf_shell_print(void)
+{
+	int starttime = startup_cmd_settings_starttime_get();
+
+	mosh_print("startup_cmd config:");
+	if (starttime < 0) {
+		mosh_print("  Start time: default");
+	} else {
+		mosh_print("  Start time: %d", starttime);
+	}
+	mosh_print("  Command #1: %s", startup_cmd_settings_get(1));
+	mosh_print("  Command #2: %s", startup_cmd_settings_get(2));
+	mosh_print("  Command #3: %s", startup_cmd_settings_get(3));
+}
+
+/* ****************************************************************************/
+
+static int startup_cmd_settings_loaded(void)
+{
+	/* All loaded, let's make them effective. */
+	startup_cmd_ctrl_settings_loaded();
+	return 0;
+}
+
+static struct settings_handler cfg = { .name = STARTUP_CMD_SETTINGS_KEY,
+				       .h_set = startup_cmd_settings_handler,
+				       .h_commit = startup_cmd_settings_loaded };
+
+int startup_cmd_settings_init(void)
+{
+	int err;
+
+	memset(&startup_cmd_data, 0, sizeof(startup_cmd_data));
+	startup_cmd_data.starttime = STARTUP_CMD_STARTTIME_NOT_SET;
+
+	err = settings_subsys_init();
+	if (err) {
+		mosh_error("Failed to initialize settings subsystem, error: %d", err);
+		return err;
+	}
+	err = settings_register(&cfg);
+	if (err) {
+		mosh_error("Cannot register settings handler %d", err);
+		return err;
+	}
+	err = settings_load();
+	if (err) {
+		mosh_error("Cannot load settings %d", err);
+		return err;
+	}
+	return 0;
+}

--- a/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_settings.h
+++ b/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_settings.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef MOSH_STARTUP_CMD_SETTINGS_H
+#define MOSH_STARTUP_CMD_SETTINGS_H
+
+#define STARTUP_CMD_MAX_LEN 128
+#define STARTUP_CMD_MAX_COUNT 3
+#define STARTUP_CMD_STARTTIME_NOT_SET -1
+
+int startup_cmd_settings_init(void);
+void startup_cmd_settings_conf_shell_print(void);
+int startup_cmd_settings_save(const char *cmd_str, int mem_slot);
+char *startup_cmd_settings_get(uint8_t mem_slot);
+bool startup_cmd_settings_enabled(void);
+
+int startup_cmd_settings_starttime_set(int starttime);
+int startup_cmd_settings_starttime_get(void);
+
+#endif /* MOSH_STARTUP_CMD_SETTINGS_H */

--- a/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_shell.c
+++ b/samples/nrf9160/modem_shell/src/startup_cmd/startup_cmd_shell.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <stdio.h>
+
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_uart.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include "mosh_print.h"
+#include "startup_cmd_settings.h"
+
+enum startup_cmd_common_options {
+	SETT_CMD_COMMON_NONE = 0,
+	SETT_CMD_COMMON_READ,
+};
+
+/******************************************************************************/
+
+static const char startup_cmd_usage_str[] =
+	"Usage: startup_cmd --read | --mem<1-3> <cmd_str> | -t <timeout_in_secs>\n"
+	"Options:\n"
+	"  -r, --read,      Read all stored MoSh startup commands from settings\n"
+	"      --mem[1-3],  Store a MoSh command to a given memory slot.\n"
+	"                   Clear the given memslot by giving an empty string:\n"
+	"                   startup_cmd --mem2 \"\"\n"
+	"  -t, --time,      Starting time of executing of commands (in seconds after a bootup).\n"
+	"                   By default execution will be done when LTE is connected\n"
+	"                   for the first time after the bootup. Restore default value\n"
+	"                   by giving a negative value.\n";
+
+/******************************************************************************/
+
+/* Following are not having short options: */
+enum {
+	SETT_CMD_SHELL_OPT_MEM_SLOT_1 = 1001,
+	SETT_CMD_SHELL_OPT_MEM_SLOT_2,
+	SETT_CMD_SHELL_OPT_MEM_SLOT_3,
+};
+
+/* Specifying the expected options (both long and short): */
+static struct option long_options[] = {
+	{ "read", no_argument, 0, 'r' },
+	{ "time", required_argument, 0, 't' },
+	{ "mem1", required_argument, 0, SETT_CMD_SHELL_OPT_MEM_SLOT_1 },
+	{ "mem2", required_argument, 0, SETT_CMD_SHELL_OPT_MEM_SLOT_2 },
+	{ "mem3", required_argument, 0, SETT_CMD_SHELL_OPT_MEM_SLOT_3 },
+	{ 0, 0, 0, 0 }
+};
+
+/******************************************************************************/
+
+static void startup_cmd_shell_print_usage(void)
+{
+	mosh_print_no_format(startup_cmd_usage_str);
+}
+
+/******************************************************************************/
+
+int startup_cmd_shell(const struct shell *shell, size_t argc, char **argv)
+{
+	enum startup_cmd_common_options common_option = SETT_CMD_COMMON_NONE;
+	int ret = 0;
+	int long_index = 0;
+	int starttime;
+	int opt;
+	uint8_t startup_cmd_mem_slot = 0;
+	char *startup_cmd_str = NULL;
+	bool starttime_given = false;
+
+	if (!argc) {
+		goto show_usage;
+	}
+
+	/* Reset getopt due to possible previous failures: */
+	optreset = 1;
+	optind = 1;
+
+	while ((opt = getopt_long(argc, argv, "t:r",
+				  long_options, &long_index)) != -1) {
+		switch (opt) {
+		case 'r':
+			common_option = SETT_CMD_COMMON_READ;
+			break;
+		case 't':
+			starttime = atoi(optarg);
+			starttime_given = true;
+			break;
+		case SETT_CMD_SHELL_OPT_MEM_SLOT_1:
+			startup_cmd_str = optarg;
+			startup_cmd_mem_slot = 1;
+			break;
+		case SETT_CMD_SHELL_OPT_MEM_SLOT_2:
+			startup_cmd_str = optarg;
+			startup_cmd_mem_slot = 2;
+			break;
+		case SETT_CMD_SHELL_OPT_MEM_SLOT_3:
+			startup_cmd_str = optarg;
+			startup_cmd_mem_slot = 3;
+			break;
+
+		case '?':
+			goto show_usage;
+		default:
+			mosh_error("Unknown option. See usage:");
+			goto show_usage;
+		}
+	}
+	if (!starttime_given && common_option == SETT_CMD_COMMON_NONE &&
+	    startup_cmd_str == NULL) {
+		mosh_warn("No command option given. Please, see the usage.");
+		goto show_usage;
+	}
+
+	if (starttime_given) {
+		startup_cmd_settings_starttime_set(starttime);
+	}
+	if (common_option == SETT_CMD_COMMON_READ) {
+		startup_cmd_settings_conf_shell_print();
+	} else if (startup_cmd_str != NULL) {
+		ret = startup_cmd_settings_save(startup_cmd_str, startup_cmd_mem_slot);
+		if (ret < 0) {
+			mosh_error("Cannot set command %s to settings: \"%s\"", startup_cmd_str);
+		} else {
+			mosh_print("Command \"%s\" set successfully to "
+				   "memory slot %d.",
+				   ((strlen(startup_cmd_str)) ? startup_cmd_str : "<empty>"),
+				   startup_cmd_mem_slot);
+		}
+	}
+
+	return ret;
+
+show_usage:
+	/* Reset getopt for another users: */
+	optreset = 1;
+
+	startup_cmd_shell_print_usage();
+	return ret;
+}
+
+SHELL_CMD_REGISTER(startup_cmd, NULL,
+	"Command to store MoSH commands to be run sequentially after a bootup.",
+	startup_cmd_shell);


### PR DESCRIPTION
By using new MoSH command, `startup_cmd`, 
user can store up to 3 MoSh commands (max len of 128 chars) to be run after a start/bootup.
As a default, commands are run after a default PDN context
is getting active, but optionally can be set to be run N seconds after a bootup.

An example of starting periodic location acquiring after a LTE has been connected, both cellular and gnss with sending a location to nRF Cloud: 
`startup_cmd --mem1 "location get --mode all --method cellular --method gnss --gnss_cloud_nmea --interval 10"`
