### PR TITLE
tests: fast_pair: Add corrupted data test suite

### DIFF
--- a/subsys/bluetooth/services/fast_pair/fp_storage.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage.c
@@ -13,30 +13,12 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/settings/settings.h>
 
-#include "fp_storage.h"
 #include "fp_common.h"
+#include "fp_storage.h"
+#include "fp_storage_priv.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(fast_pair, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
-
-#define SUBTREE_NAME "fp"
-#define SETTINGS_AK_NAME_PREFIX "ak_data"
-#define SETTINGS_NAME_CONNECTOR "/"
-#define SETTINGS_AK_FULL_PREFIX (SUBTREE_NAME SETTINGS_NAME_CONNECTOR SETTINGS_AK_NAME_PREFIX)
-#define SETTINGS_AK_NAME_MAX_SUFFIX_LEN 1
-#define SETTINGS_NAME_MAX_SIZE (sizeof(SETTINGS_AK_FULL_PREFIX) + SETTINGS_AK_NAME_MAX_SUFFIX_LEN)
-
-#define ACCOUNT_KEY_CNT    CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX
-#define ACCOUNT_KEY_MIN_ID 1
-#define ACCOUNT_KEY_MAX_ID (2 * ACCOUNT_KEY_CNT)
-
-BUILD_ASSERT(ACCOUNT_KEY_MAX_ID < UINT8_MAX);
-BUILD_ASSERT(ACCOUNT_KEY_CNT <= 10);
-
-struct account_key_data {
-	uint8_t account_key_id;
-	struct fp_account_key account_key;
-};
 
 static struct fp_account_key account_key_list[ACCOUNT_KEY_CNT];
 static uint8_t account_key_loaded_ids[ACCOUNT_KEY_CNT];
@@ -45,23 +27,6 @@ static uint8_t account_key_count;
 
 static int settings_set_err;
 static atomic_t settings_loaded = ATOMIC_INIT(false);
-
-
-static uint8_t key_id_to_idx(uint8_t account_key_id)
-{
-	__ASSERT_NO_MSG(account_key_id >= ACCOUNT_KEY_MIN_ID);
-
-	return (account_key_id - ACCOUNT_KEY_MIN_ID) % ACCOUNT_KEY_CNT;
-}
-
-static uint8_t next_key_id(uint8_t key_id)
-{
-	if (key_id == ACCOUNT_KEY_MAX_ID) {
-		return ACCOUNT_KEY_MIN_ID;
-	}
-
-	return key_id + 1;
-}
 
 static int fp_settings_load_ak(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg)
 {
@@ -89,7 +54,7 @@ static int fp_settings_load_ak(const char *name, size_t len, settings_read_cb re
 		return -EINVAL;
 	}
 
-	index = key_id_to_idx(data.account_key_id);
+	index = account_key_id_to_idx(data.account_key_id);
 	name_suffix = &name[sizeof(SETTINGS_AK_NAME_PREFIX) - 1];
 	name_suffix_len = strlen(name_suffix);
 
@@ -154,7 +119,8 @@ static bool id_sequence_check(uint8_t start_idx)
 {
 	__ASSERT_NO_MSG(start_idx > 0);
 	for (size_t i = start_idx; i < ACCOUNT_KEY_CNT; i++) {
-		if (account_key_loaded_ids[i] != next_key_id(account_key_loaded_ids[i - 1])) {
+		if (account_key_loaded_ids[i] !=
+		    next_account_key_id(account_key_loaded_ids[i - 1])) {
 			return false;
 		}
 	}
@@ -180,7 +146,7 @@ static int fp_settings_commit(void)
 	}
 
 	cur_id = account_key_loaded_ids[0];
-	if ((cur_id != 0) && (key_id_to_idx(cur_id) != 0)) {
+	if ((cur_id != 0) && (account_key_id_to_idx(cur_id) != 0)) {
 		return -EINVAL;
 	}
 
@@ -200,7 +166,7 @@ static int fp_settings_commit(void)
 			first_zero_idx = i;
 			break;
 		}
-		if (cur_id != next_key_id(prev_id)) {
+		if (cur_id != next_account_key_id(prev_id)) {
 			if (!rollover_check(cur_id, prev_id)) {
 				return -EINVAL;
 			}
@@ -223,10 +189,11 @@ static int fp_settings_commit(void)
 		}
 
 		account_key_count = ACCOUNT_KEY_CNT;
-		account_key_next_id = next_key_id(account_key_loaded_ids[rollover_idx - 1]);
+		account_key_next_id = next_account_key_id(account_key_loaded_ids[rollover_idx - 1]);
 	} else {
 		account_key_count = ACCOUNT_KEY_CNT;
-		account_key_next_id = next_key_id(account_key_loaded_ids[ACCOUNT_KEY_CNT - 1]);
+		account_key_next_id = next_account_key_id(
+					account_key_loaded_ids[ACCOUNT_KEY_CNT - 1]);
 	}
 
 	atomic_set(&settings_loaded, true);
@@ -234,7 +201,7 @@ static int fp_settings_commit(void)
 	return 0;
 }
 
-SETTINGS_STATIC_HANDLER_DEFINE(fast_pair_storage, SUBTREE_NAME, NULL, fp_settings_set,
+SETTINGS_STATIC_HANDLER_DEFINE(fast_pair_storage, SETTINGS_AK_SUBTREE_NAME, NULL, fp_settings_set,
 			       fp_settings_commit, NULL);
 
 int fp_storage_account_key_count(void)
@@ -295,7 +262,7 @@ int fp_storage_account_key_save(const struct fp_account_key *account_key)
 
 	uint8_t index;
 	struct account_key_data data;
-	char name[SETTINGS_NAME_MAX_SIZE];
+	char name[SETTINGS_AK_NAME_MAX_SIZE];
 	int n;
 	int err;
 
@@ -309,13 +276,13 @@ int fp_storage_account_key_save(const struct fp_account_key *account_key)
 		LOG_INF("Account Key List full - erasing the oldest Account Key.");
 	}
 
-	index = key_id_to_idx(account_key_next_id);
+	index = account_key_id_to_idx(account_key_next_id);
 
 	data.account_key_id = account_key_next_id;
 	data.account_key = *account_key;
 
-	n = snprintf(name, SETTINGS_NAME_MAX_SIZE, "%s%u", SETTINGS_AK_FULL_PREFIX, index);
-	__ASSERT_NO_MSG(n < SETTINGS_NAME_MAX_SIZE);
+	n = snprintf(name, SETTINGS_AK_NAME_MAX_SIZE, "%s%u", SETTINGS_AK_FULL_PREFIX, index);
+	__ASSERT_NO_MSG(n < SETTINGS_AK_NAME_MAX_SIZE);
 	if (n < 0) {
 		return n;
 	}
@@ -327,7 +294,7 @@ int fp_storage_account_key_save(const struct fp_account_key *account_key)
 
 	account_key_list[index] = *account_key;
 
-	account_key_next_id = next_key_id(account_key_next_id);
+	account_key_next_id = next_account_key_id(account_key_next_id);
 
 	if (account_key_count < ACCOUNT_KEY_CNT) {
 		account_key_count++;

--- a/subsys/bluetooth/services/fast_pair/include/fp_storage_priv.h
+++ b/subsys/bluetooth/services/fast_pair/include/fp_storage_priv.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _FP_STORAGE_PRIV_H_
+#define _FP_STORAGE_PRIV_H_
+
+#include "fp_common.h"
+
+/**
+ * @defgroup fp_storage_priv Fast Pair storage module private
+ * @brief Private data of the Fast Pair storage module
+ *
+ * Private data structures, definitions and functionalities of the Fast Pair
+ * storage module. Used only by the module and by the unit test to prepopulate
+ * settings with mocked data.
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Settings subtree name for Fast Pair storage.  */
+#define SETTINGS_AK_SUBTREE_NAME "fp"
+
+/** Settings key name prefix for Account Key.  */
+#define SETTINGS_AK_NAME_PREFIX "ak_data"
+
+/** String used as a connector in settings keys. */
+#define SETTINGS_NAME_CONNECTOR "/"
+
+/** Full settings key name prefix for Account Key (including subtree name). */
+#define SETTINGS_AK_FULL_PREFIX \
+	(SETTINGS_AK_SUBTREE_NAME SETTINGS_NAME_CONNECTOR SETTINGS_AK_NAME_PREFIX)
+
+/** Max length of suffix (key ID) in settings key name for Account Key. */
+#define SETTINGS_AK_NAME_MAX_SUFFIX_LEN 1
+
+/** Max length of settings key for Account Key. */
+#define SETTINGS_AK_NAME_MAX_SIZE \
+	(sizeof(SETTINGS_AK_FULL_PREFIX) + SETTINGS_AK_NAME_MAX_SUFFIX_LEN)
+
+/** Max number of Account Keys. */
+#define ACCOUNT_KEY_CNT CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX
+
+/** Min valid Acccount Key ID. */
+#define ACCOUNT_KEY_MIN_ID 1
+
+/** Max valid Acccount Key ID. */
+#define ACCOUNT_KEY_MAX_ID (2 * ACCOUNT_KEY_CNT)
+
+BUILD_ASSERT(ACCOUNT_KEY_MAX_ID < UINT8_MAX);
+BUILD_ASSERT(ACCOUNT_KEY_CNT <= 10);
+
+/** Account Key settings record data format. */
+struct account_key_data {
+	/** Internal Account Key ID. */
+	uint8_t account_key_id;
+
+	/** Account Key value. */
+	struct fp_account_key account_key;
+};
+
+
+/** Get Account Key index for given Account Key ID.
+ *
+ * @param[in] account_key_id	ID of an Account Key.
+ *
+ * @return Account Key index.
+ */
+static inline uint8_t account_key_id_to_idx(uint8_t account_key_id)
+{
+        __ASSERT_NO_MSG(account_key_id >= ACCOUNT_KEY_MIN_ID);
+
+        return (account_key_id - ACCOUNT_KEY_MIN_ID) % ACCOUNT_KEY_CNT;
+}
+
+/** Generate next Account Key ID.
+ *
+ * @param[in] account_key_id		Current Account Key ID.
+ *
+ * @return Next Account Key ID.
+ */
+static inline uint8_t next_account_key_id(uint8_t account_key_id)
+{
+        if (account_key_id == ACCOUNT_KEY_MAX_ID) {
+                return ACCOUNT_KEY_MIN_ID;
+        }
+
+        return account_key_id + 1;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* _FP_STORAGE_PRIV_H_ */

--- a/tests/subsys/bluetooth/fast_pair/storage/CMakeLists.txt
+++ b/tests/subsys/bluetooth/fast_pair/storage/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(app PRIVATE
 	       src/main.c
 	       src/common_utils.c
 	       src/settings_mock.c
+	       src/test_corrupted_data.c
 )
 target_include_directories(app PRIVATE include)
 

--- a/tests/subsys/bluetooth/fast_pair/storage/CMakeLists.txt
+++ b/tests/subsys/bluetooth/fast_pair/storage/CMakeLists.txt
@@ -12,6 +12,7 @@ project("Fast Pair storage unit test")
 # Add test sources
 target_sources(app PRIVATE
 	       src/main.c
+	       src/common_utils.c
 	       src/settings_mock.c
 )
 target_include_directories(app PRIVATE include)

--- a/tests/subsys/bluetooth/fast_pair/storage/include/common_utils.h
+++ b/tests/subsys/bluetooth/fast_pair/storage/include/common_utils.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _COMMON_UTILS_H_
+#define _COMMON_UTILS_H_
+
+/**
+ * @defgroup fp_storage_test_common_utils Fast Pair storage unit test common utilities
+ * @brief Common utilities of the Fast Pair storage unit test
+ *
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Generate mocked Account Key data.
+ *
+ * @param[in]  seed		Seed used to generate the Account Key.
+ * @param[out] account_key 	Buffer used to store generated Account Key.
+ */
+void cu_generate_account_key(uint8_t seed, struct fp_account_key *account_key);
+
+/** Check if Account Key data was generated from provided seed.
+ *
+ * @param[in] seed		Seed to be verified.
+ * @param[in] account_key	Account Key data to be verified.
+ *
+ * @return true If the Account Key data was generated from provided seed.
+ *              Otherwise, false is returned.
+ */
+bool cu_check_account_key_seed(uint8_t seed, const struct fp_account_key *account_key);
+
+/** Validate that Account Keys are not loaded.
+ *
+ * The function uses Fast Pair storage API to validate that the data is not loaded from settings.
+ * Ztest asserts are used to signalize error.
+ */
+void cu_account_keys_validate_unloaded(void);
+
+/** Validate the loaded Account Keys.
+ *
+ * The function uses Fast Pair storage API to validate that the data is valid.
+ * The function assumes that @ref cu_generate_account_key was used to generate subsequent Account
+ * Keys and seed value was incremented by one for each subsequent Account Key.
+ * Ztest asserts are used to signalize error.
+ *
+ * @param[in] seed_first	Seed assigned to the first generated Account Key.
+ * @param[in] stored_cnt	Number of stored keys.
+ */
+void cu_account_keys_validate_loaded(uint8_t seed_first, uint8_t stored_cnt);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* _COMMON_UTILS_H_ */

--- a/tests/subsys/bluetooth/fast_pair/storage/include/test_corrupted_data.h
+++ b/tests/subsys/bluetooth/fast_pair/storage/include/test_corrupted_data.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _TEST_CORRUPTED_DATA_H_
+#define _TEST_CORRUPTED_DATA_H_
+
+/**
+ * @defgroup fp_storage_test_corrupted_data Fast Pair storage corrupted data unit test
+ * @brief Unit test of handling corrupted data in the Fast Pair storage
+ *
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Start test suite of corrupted data handling in the Fast Pair storage.
+ *
+ * The test suite verifies handling of corrupted settings data in the Fast Pair storage module.
+ */
+void test_corrupted_data_run(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* _TEST_CORRUPTED_DATA_H_ */

--- a/tests/subsys/bluetooth/fast_pair/storage/src/common_utils.c
+++ b/tests/subsys/bluetooth/fast_pair/storage/src/common_utils.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <ztest.h>
+
+#include "fp_common.h"
+#include "fp_storage.h"
+
+#define ACCOUNT_KEY_MAX_CNT	CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX
+#define ACCOUNT_KEY_LEN		FP_ACCOUNT_KEY_LEN
+
+
+void cu_generate_account_key(uint8_t seed, struct fp_account_key *account_key)
+{
+	memset(account_key->key, seed, ACCOUNT_KEY_LEN);
+}
+
+bool cu_check_account_key_seed(uint8_t seed, const struct fp_account_key *account_key)
+{
+	if (account_key->key[0] != seed) {
+		return false;
+	}
+
+	uint8_t expected[ACCOUNT_KEY_LEN - 1];
+
+	memset(expected, seed, sizeof(expected));
+	zassert_mem_equal(&account_key->key[1], expected, sizeof(expected), "Invalid Account Key");
+
+	return true;
+}
+
+static bool unloaded_account_key_find_cb(const struct fp_account_key *account_key, void *context)
+{
+	zassert_true(false, "Callback should not be called before settings are loaded");
+
+	return false;
+}
+
+void cu_account_keys_validate_unloaded(void)
+{
+	int err;
+	struct fp_account_key all_keys[ACCOUNT_KEY_MAX_CNT];
+	size_t key_count = ACCOUNT_KEY_MAX_CNT;
+
+	err = fp_storage_account_key_count();
+	zassert_equal(err, -ENODATA, "Expected error before settings load");
+
+	err = fp_storage_account_keys_get(all_keys, &key_count);
+	zassert_equal(err, -ENODATA, "Expected error before settings load");
+
+	err = fp_storage_account_key_find(&all_keys[0], unloaded_account_key_find_cb, NULL);
+	zassert_equal(err, -ENODATA, "Expected error before settings load");
+}
+
+void cu_account_keys_validate_loaded(uint8_t seed_first, uint8_t stored_cnt)
+{
+	int res;
+	int key_cnt;
+	struct fp_account_key read_keys[ACCOUNT_KEY_MAX_CNT];
+	size_t read_cnt = ACCOUNT_KEY_MAX_CNT;
+
+	key_cnt = fp_storage_account_key_count();
+
+	res = fp_storage_account_keys_get(read_keys, &read_cnt);
+	zassert_ok(res, "Getting Account Keys failed");
+	zassert_equal(key_cnt, read_cnt, "Invalid key count");
+	zassert_equal(key_cnt, MIN(stored_cnt, ACCOUNT_KEY_MAX_CNT), "Invalid key count");
+
+	size_t seed_min = (stored_cnt < ACCOUNT_KEY_MAX_CNT) ?
+			  (0) : (stored_cnt - ACCOUNT_KEY_MAX_CNT);
+	size_t seed_max = stored_cnt - 1;
+
+	seed_min += seed_first;
+	seed_max += seed_first;
+
+	for (size_t i = seed_min; i <= seed_max; i++) {
+		bool found = false;
+
+		for (size_t j = 0; j < read_cnt; j++) {
+			if (found) {
+				zassert_false(cu_check_account_key_seed(i, &read_keys[j]),
+					      "Key duplicate found");
+			}
+
+			if (cu_check_account_key_seed(i, &read_keys[j])) {
+				found = true;
+			}
+		}
+
+		zassert_true(found, "Key dropped by the Fast Pair storage");
+	}
+}

--- a/tests/subsys/bluetooth/fast_pair/storage/src/main.c
+++ b/tests/subsys/bluetooth/fast_pair/storage/src/main.c
@@ -12,6 +12,7 @@
 
 #include "storage_mock.h"
 #include "common_utils.h"
+#include "test_corrupted_data.h"
 
 #define ACCOUNT_KEY_MAX_CNT	CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX
 
@@ -250,4 +251,8 @@ void test_main(void)
 			 );
 
 	ztest_run_test_suite(fast_pair_storage_tests);
+	/* Test cases verifying that module properly handles settings data corruption.
+	 * Corrupted data test suite relies on internal data representation.
+	 */
+	test_corrupted_data_run();
 }

--- a/tests/subsys/bluetooth/fast_pair/storage/src/test_corrupted_data.c
+++ b/tests/subsys/bluetooth/fast_pair/storage/src/test_corrupted_data.c
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <ztest.h>
+#include <zephyr/settings/settings.h>
+
+#include "fp_storage.h"
+#include "fp_storage_priv.h"
+
+#include "storage_mock.h"
+#include "common_utils.h"
+
+#include "test_corrupted_data.h"
+
+
+static void setup_fn(void)
+{
+	/* Make sure that settings are not yet loaded. Settings will be populated with data and
+	 * loaded by the unit test.
+	 */
+	cu_account_keys_validate_unloaded();
+}
+
+static void teardown_fn(void)
+{
+	int err = settings_load();
+
+	zassert_not_equal(err, 0, "Expected error in settings load");
+	cu_account_keys_validate_unloaded();
+
+	fp_storage_ram_clear();
+	storage_mock_clear();
+}
+
+/* Self test is done to ensure that the test method is valid. */
+static void test_self_teardown_fn(void)
+{
+	fp_storage_ram_clear();
+	storage_mock_clear();
+	cu_account_keys_validate_unloaded();
+}
+
+static void test_wrong_settings_key(void)
+{
+	static const uint8_t key_id = ACCOUNT_KEY_MIN_ID;
+
+	int err;
+	struct account_key_data data;
+
+	data.account_key_id = key_id;
+	cu_generate_account_key(key_id, &data.account_key);
+
+	err = settings_save_one(SETTINGS_AK_SUBTREE_NAME SETTINGS_NAME_CONNECTOR "not_account_key",
+				&data, sizeof(data));
+	zassert_ok(err, "Unexpected error in settings save");
+}
+
+static void test_wrong_data_len(void)
+{
+	static const uint8_t key_id = ACCOUNT_KEY_MIN_ID;
+
+	int err;
+	char settings_key[SETTINGS_AK_NAME_MAX_SIZE] = SETTINGS_AK_FULL_PREFIX;
+	struct account_key_data data;
+
+	zassert_true(('0' + account_key_id_to_idx(key_id)) <= '9', "Key index out of range");
+	settings_key[ARRAY_SIZE(settings_key) - 2] = ('0' + account_key_id_to_idx(key_id));
+
+	data.account_key_id = key_id;
+	cu_generate_account_key(key_id, &data.account_key);
+
+	err = settings_save_one(settings_key, &data, sizeof(data) - 1);
+	zassert_ok(err, "Unexpected error in settings save");
+}
+
+static void test_inconsistent_key_id(void)
+{
+	static const uint8_t key_id = ACCOUNT_KEY_MIN_ID;
+
+	int err;
+	char settings_key[SETTINGS_AK_NAME_MAX_SIZE] = SETTINGS_AK_FULL_PREFIX;
+	struct account_key_data data;
+
+	zassert_true(('0' + account_key_id_to_idx(key_id)) <= '9', "Key index out of range");
+	settings_key[ARRAY_SIZE(settings_key) - 2] = ('0' + account_key_id_to_idx(key_id));
+
+	data.account_key_id = next_account_key_id(key_id);
+	cu_generate_account_key(key_id, &data.account_key);
+
+	err = settings_save_one(settings_key, &data, sizeof(data));
+	zassert_ok(err, "Unexpected error in settings save");
+}
+
+static void store_key(uint8_t key_id)
+{
+	int err;
+	char settings_key[SETTINGS_AK_NAME_MAX_SIZE] = SETTINGS_AK_FULL_PREFIX;
+	struct account_key_data data;
+
+	zassert_true(('0' + account_key_id_to_idx(key_id)) <= '9', "Key index out of range");
+	settings_key[ARRAY_SIZE(settings_key) - 2] = ('0' + account_key_id_to_idx(key_id));
+
+	data.account_key_id = key_id;
+	cu_generate_account_key(key_id, &data.account_key);
+
+	err = settings_save_one(settings_key, &data, sizeof(data));
+	zassert_ok(err, "Unexpected error in settings save");
+}
+
+static void test_self(void)
+{
+	int err;
+	uint8_t key_id = ACCOUNT_KEY_MIN_ID;
+	uint8_t key_cnt = 0;
+
+	store_key(key_id);
+	key_cnt++;
+	key_id = next_account_key_id(key_id);
+
+	store_key(key_id);
+	key_cnt++;
+	key_id = next_account_key_id(key_id);
+
+	store_key(key_id);
+	key_cnt++;
+
+	err = settings_load();
+	zassert_ok(err, "Unexpected error in settings load");
+
+	cu_account_keys_validate_loaded(ACCOUNT_KEY_MIN_ID, key_cnt);
+}
+
+static void test_self_rollover(void)
+{
+	int err;
+	uint8_t key_id = ACCOUNT_KEY_MIN_ID;
+	uint8_t key_cnt = 0;
+
+	for (size_t i = 0; i < ACCOUNT_KEY_CNT; i++) {
+		store_key(key_id);
+		key_cnt++;
+		key_id = next_account_key_id(key_id);
+	}
+
+	store_key(key_id);
+	key_cnt++;
+	key_id = next_account_key_id(key_id);
+
+	store_key(key_id);
+	key_cnt++;
+
+	err = settings_load();
+	zassert_ok(err, "Unexpected error in settings load");
+
+	cu_account_keys_validate_loaded(ACCOUNT_KEY_MIN_ID, key_cnt);
+}
+
+static void test_drop_first_key(void)
+{
+	store_key(next_account_key_id(ACCOUNT_KEY_MIN_ID));
+}
+
+static void test_drop_key(void)
+{
+	uint8_t key_id = ACCOUNT_KEY_MIN_ID;
+
+	store_key(key_id);
+
+	key_id = next_account_key_id(key_id);
+	store_key(key_id);
+
+	key_id = next_account_key_id(key_id);
+	key_id = next_account_key_id(key_id);
+	store_key(key_id);
+}
+
+static void test_drop_keys(void)
+{
+	uint8_t key_id = ACCOUNT_KEY_MIN_ID;
+
+	store_key(key_id);
+
+	for (size_t i = 0; i < ACCOUNT_KEY_CNT; i++) {
+		key_id = next_account_key_id(key_id);
+	}
+
+	zassert_equal(account_key_id_to_idx(ACCOUNT_KEY_MIN_ID), account_key_id_to_idx(key_id),
+		      "Test should write key exactly after rollover");
+	store_key(key_id);
+}
+
+static void test_drop_rollover(void)
+{
+	uint8_t key_id = ACCOUNT_KEY_MIN_ID;
+
+	for (size_t i = 0; i < ACCOUNT_KEY_CNT; i++) {
+		store_key(key_id);
+		key_id = next_account_key_id(key_id);
+	}
+
+	zassert_equal(account_key_id_to_idx(ACCOUNT_KEY_MIN_ID), account_key_id_to_idx(key_id),
+		      "Test should drop key exactly after rollover");
+	key_id = next_account_key_id(key_id);
+	store_key(key_id);
+}
+
+void test_corrupted_data_run(void)
+{
+	ztest_test_suite(fast_pair_storage_courrupted_data_tests,
+			 ztest_unit_test_setup_teardown(test_self, setup_fn, test_self_teardown_fn),
+			 ztest_unit_test_setup_teardown(test_self_rollover, setup_fn,
+							test_self_teardown_fn),
+			 ztest_unit_test_setup_teardown(test_wrong_settings_key, setup_fn,
+							teardown_fn),
+			 ztest_unit_test_setup_teardown(test_wrong_data_len, setup_fn, teardown_fn),
+			 ztest_unit_test_setup_teardown(test_inconsistent_key_id, setup_fn,
+							teardown_fn),
+			 ztest_unit_test_setup_teardown(test_drop_first_key, setup_fn, teardown_fn),
+			 ztest_unit_test_setup_teardown(test_drop_key, setup_fn, teardown_fn),
+			 ztest_unit_test_setup_teardown(test_drop_keys, setup_fn, teardown_fn),
+			 ztest_unit_test_setup_teardown(test_drop_rollover, setup_fn, teardown_fn)
+			 );
+
+	ztest_run_test_suite(fast_pair_storage_courrupted_data_tests);
+}


### PR DESCRIPTION
Change introduces test suite that verifies if invalid settings data is properly handled by Fast Pair storage.

Jira: NCSDK-15693