### PR TITLE
Bluetooth: Mesh: Model shell arg alignment

### DIFF
--- a/subsys/bluetooth/mesh/shell/shell_bat_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_bat_cli.c
@@ -44,7 +44,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_BATTERY_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_ctl_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_ctl_cli.c
@@ -42,11 +42,17 @@ static int cmd_ctl_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int ctl_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t light = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t temp = (uint16_t)strtol(argv[2], NULL, 0);
-	int16_t delta = (int16_t)strtol(argv[3], NULL, 0);
-	uint32_t time = (argc >= 5) ? (uint32_t)strtol(argv[4], NULL, 0) : 0;
-	uint32_t delay = (argc == 6) ? (uint32_t)strtol(argv[5], NULL, 0) : 0;
+	int err = 0;
+	uint16_t light = shell_strtoul(argv[1], 0, &err);
+	uint16_t temp = shell_strtoul(argv[2], 0, &err);
+	int16_t delta = shell_strtol(argv[3], 0, &err);
+	uint32_t time = (argc >= 5) ? shell_strtoul(argv[4], 0, &err) : 0;
+	uint32_t delay = (argc == 6) ? shell_strtoul(argv[5], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_CTL_CLI, &mod)) {
 		return -ENODEV;
@@ -65,8 +71,8 @@ static int ctl_set(const struct shell *shell, size_t argc, char *argv[], bool ac
 
 	if (acked) {
 		struct bt_mesh_light_ctl_status rsp;
-		int err = bt_mesh_light_ctl_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_ctl_set(cli, NULL, &set, &rsp);
 		ctl_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -112,10 +118,16 @@ static int cmd_temp_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int temp_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t temp = (uint16_t)strtol(argv[1], NULL, 0);
-	int16_t delta = (int16_t)strtol(argv[2], NULL, 0);
-	uint32_t time = (argc >= 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
-	uint32_t delay = (argc == 5) ? (uint32_t)strtol(argv[4], NULL, 0) : 0;
+	int err = 0;
+	uint16_t temp = shell_strtoul(argv[1], 0, &err);
+	int16_t delta = shell_strtol(argv[2], 0, &err);
+	uint32_t time = (argc >= 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+	uint32_t delay = (argc == 5) ? shell_strtoul(argv[4], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_CTL_CLI, &mod)) {
 		return -ENODEV;
@@ -133,8 +145,8 @@ static int temp_set(const struct shell *shell, size_t argc, char *argv[], bool a
 
 	if (acked) {
 		struct bt_mesh_light_temp_status rsp;
-		int err = bt_mesh_light_temp_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_temp_set(cli, NULL, &set, &rsp);
 		temp_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -177,9 +189,15 @@ static int cmd_ctl_default_get(const struct shell *shell, size_t argc, char *arg
 
 static int default_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t light = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t temp = (uint16_t)strtol(argv[2], NULL, 0);
-	int16_t delta = (int16_t)strtol(argv[3], NULL, 0);
+	int err = 0;
+	uint16_t light = shell_strtoul(argv[1], 0, &err);
+	uint16_t temp = shell_strtoul(argv[2], 0, &err);
+	int16_t delta = shell_strtol(argv[3], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_CTL_CLI, &mod)) {
 		return -ENODEV;
@@ -194,8 +212,8 @@ static int default_set(const struct shell *shell, size_t argc, char *argv[], boo
 
 	if (acked) {
 		struct bt_mesh_light_ctl rsp;
-		int err = bt_mesh_light_ctl_default_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_ctl_default_set(cli, NULL, &set, &rsp);
 		default_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -239,8 +257,14 @@ static int cmd_temp_range_get(const struct shell *shell, size_t argc, char *argv
 
 static int temp_range_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t min = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t max = (uint16_t)strtol(argv[2], NULL, 0);
+	int err = 0;
+	uint16_t min = shell_strtoul(argv[1], 0, &err);
+	uint16_t max = shell_strtoul(argv[2], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_CTL_CLI, &mod)) {
 		return -ENODEV;
@@ -254,8 +278,8 @@ static int temp_range_set(const struct shell *shell, size_t argc, char *argv[], 
 
 	if (acked) {
 		struct bt_mesh_light_temp_range_status rsp;
-		int err = bt_mesh_light_temp_range_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_temp_range_set(cli, NULL, &set, &rsp);
 		range_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -280,7 +304,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_LIGHT_CTL_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_dtt_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_dtt_cli.c
@@ -38,7 +38,13 @@ static int cmd_dtt_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int dtt_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	int32_t trans_time = (int32_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	int32_t trans_time = shell_strtol(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_CLI, &mod)) {
 		return -ENODEV;
@@ -48,8 +54,8 @@ static int dtt_set(const struct shell *shell, size_t argc, char *argv[], bool ac
 
 	if (acked) {
 		int32_t rsp;
-		int err = bt_mesh_dtt_set(cli, NULL, trans_time, &rsp);
 
+		err = bt_mesh_dtt_set(cli, NULL, trans_time, &rsp);
 		dtt_print(shell, err, rsp);
 		return err;
 	} else {
@@ -74,7 +80,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_CLI,
 					elem_idx);

--- a/subsys/bluetooth/mesh/shell/shell_hsl_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_hsl_cli.c
@@ -42,11 +42,17 @@ static int cmd_hsl_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int hsl_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t light = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t hue = (uint16_t)strtol(argv[2], NULL, 0);
-	uint16_t saturation = (uint16_t)strtol(argv[3], NULL, 0);
-	uint32_t time = (argc >= 5) ? (uint32_t)strtol(argv[4], NULL, 0) : 0;
-	uint32_t delay = (argc == 6) ? (uint32_t)strtol(argv[5], NULL, 0) : 0;
+	int err = 0;
+	uint16_t light = shell_strtoul(argv[1], 0, &err);
+	uint16_t hue = shell_strtoul(argv[2], 0, &err);
+	uint16_t saturation = shell_strtoul(argv[3], 0, &err);
+	uint32_t time = (argc >= 5) ? shell_strtoul(argv[4], 0, &err) : 0;
+	uint32_t delay = (argc == 6) ? shell_strtoul(argv[5], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_HSL_CLI, &mod)) {
 		return -ENODEV;
@@ -65,8 +71,8 @@ static int hsl_set(const struct shell *shell, size_t argc, char *argv[], bool ac
 
 	if (acked) {
 		struct bt_mesh_light_hsl_status rsp;
-		int err = bt_mesh_light_hsl_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_hsl_set(cli, NULL, &set, &rsp);
 		hsl_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -133,9 +139,15 @@ static int cmd_hsl_default_get(const struct shell *shell, size_t argc, char *arg
 
 static int hsl_default_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t light = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t hue = (uint16_t)strtol(argv[2], NULL, 0);
-	uint16_t saturation = (uint16_t)strtol(argv[3], NULL, 0);
+	int err = 0;
+	uint16_t light = shell_strtoul(argv[1], 0, &err);
+	uint16_t hue = shell_strtoul(argv[2], 0, &err);
+	uint16_t saturation = shell_strtoul(argv[3], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_HSL_CLI, &mod)) {
 		return -ENODEV;
@@ -150,8 +162,8 @@ static int hsl_default_set(const struct shell *shell, size_t argc, char *argv[],
 
 	if (acked) {
 		struct bt_mesh_light_hsl rsp;
-		int err = bt_mesh_light_hsl_default_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_hsl_default_set(cli, NULL, &set, &rsp);
 		default_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -198,10 +210,16 @@ static int cmd_hsl_range_get(const struct shell *shell, size_t argc, char *argv[
 
 static int hsl_range_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t hue_min = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t hue_max = (uint16_t)strtol(argv[2], NULL, 0);
-	uint16_t sat_min = (uint16_t)strtol(argv[3], NULL, 0);
-	uint16_t sat_max = (uint16_t)strtol(argv[4], NULL, 0);
+	int err = 0;
+	uint16_t hue_min = shell_strtoul(argv[1], 0, &err);
+	uint16_t hue_max = shell_strtoul(argv[2], 0, &err);
+	uint16_t sat_min = shell_strtoul(argv[3], 0, &err);
+	uint16_t sat_max = shell_strtoul(argv[4], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_HSL_CLI, &mod)) {
 		return -ENODEV;
@@ -217,8 +235,8 @@ static int hsl_range_set(const struct shell *shell, size_t argc, char *argv[], b
 
 	if (acked) {
 		struct bt_mesh_light_hsl_range_status rsp;
-		int err = bt_mesh_light_hsl_range_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_hsl_range_set(cli, NULL, &set, &rsp);
 		range_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -261,9 +279,15 @@ static int cmd_hue_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int hue_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t lvl = (uint16_t)strtol(argv[1], NULL, 0);
-	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
-	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+	int err = 0;
+	uint16_t lvl = shell_strtoul(argv[1], 0, &err);
+	uint32_t time = (argc >= 3) ? shell_strtoul(argv[2], 0, &err) : 0;
+	uint32_t delay = (argc == 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_HSL_CLI, &mod)) {
 		return -ENODEV;
@@ -275,8 +299,8 @@ static int hue_set(const struct shell *shell, size_t argc, char *argv[], bool ac
 
 	if (acked) {
 		struct bt_mesh_light_hue_status rsp;
-		int err = bt_mesh_light_hue_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_hue_set(cli, NULL, &set, &rsp);
 		hue_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -320,9 +344,15 @@ static int cmd_saturation_get(const struct shell *shell, size_t argc, char *argv
 
 static int saturation_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t lvl = (uint16_t)strtol(argv[1], NULL, 0);
-	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
-	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+	int err = 0;
+	uint16_t lvl = shell_strtoul(argv[1], 0, &err);
+	uint32_t time = (argc >= 3) ? shell_strtoul(argv[2], 0, &err) : 0;
+	uint32_t delay = (argc == 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_HSL_CLI, &mod)) {
 		return -ENODEV;
@@ -334,8 +364,8 @@ static int saturation_set(const struct shell *shell, size_t argc, char *argv[], 
 
 	if (acked) {
 		struct bt_mesh_light_sat_status rsp;
-		int err = bt_mesh_light_saturation_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_saturation_set(cli, NULL, &set, &rsp);
 		saturation_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -360,7 +390,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_LIGHT_HSL_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_lightness_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_lightness_cli.c
@@ -39,9 +39,15 @@ static int cmd_light_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int light_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t lvl = (uint16_t)strtol(argv[1], NULL, 0);
-	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
-	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+	int err = 0;
+	uint16_t lvl = shell_strtoul(argv[1], 0, &err);
+	uint32_t time = (argc >= 3) ? shell_strtoul(argv[2], 0, &err) : 0;
+	uint32_t delay = (argc == 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_CLI, &mod)) {
 		return -ENODEV;
@@ -53,8 +59,8 @@ static int light_set(const struct shell *shell, size_t argc, char *argv[], bool 
 
 	if (acked) {
 		struct bt_mesh_lightness_status rsp;
-		int err = bt_mesh_lightness_cli_light_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_lightness_cli_light_set(cli, NULL, &set, &rsp);
 		light_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -98,8 +104,14 @@ static int cmd_range_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int range_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t min = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t max = (uint16_t)strtol(argv[2], NULL, 0);
+	int err = 0;
+	uint16_t min = shell_strtoul(argv[1], 0, &err);
+	uint16_t max = shell_strtoul(argv[2], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_CLI, &mod)) {
 		return -ENODEV;
@@ -110,8 +122,8 @@ static int range_set(const struct shell *shell, size_t argc, char *argv[], bool 
 
 	if (acked) {
 		struct bt_mesh_lightness_range_status rsp;
-		int err = bt_mesh_lightness_cli_range_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_lightness_cli_range_set(cli, NULL, &set, &rsp);
 		range_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -153,7 +165,13 @@ static int cmd_default_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int default_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t lvl = (uint16_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint16_t lvl = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_CLI, &mod)) {
 		return -ENODEV;
@@ -163,8 +181,8 @@ static int default_set(const struct shell *shell, size_t argc, char *argv[], boo
 
 	if (acked) {
 		uint16_t rsp;
-		int err = bt_mesh_lightness_cli_default_set(cli, NULL, lvl, &rsp);
 
+		err = bt_mesh_lightness_cli_default_set(cli, NULL, lvl, &rsp);
 		default_print(shell, err, rsp);
 		return err;
 	} else {
@@ -207,7 +225,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_LIGHT_LIGHTNESS_CLI,
 					elem_idx);

--- a/subsys/bluetooth/mesh/shell/shell_loc_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_loc_cli.c
@@ -39,9 +39,15 @@ static int cmd_loc_global_get(const struct shell *shell, size_t argc, char *argv
 
 static int global_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	double latitude = shell_model_str2dbl(shell, argv[1]);
-	double longitude = shell_model_str2dbl(shell, argv[2]);
-	int16_t altitude = (int16_t)strtol(argv[3], NULL, 0);
+	int err = 0;
+	double latitude = shell_model_strtodbl(argv[1], &err);
+	double longitude = shell_model_strtodbl(argv[2], &err);
+	int16_t altitude = shell_strtol(argv[3], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LOCATION_CLI, &mod)) {
 		return -ENODEV;
@@ -56,8 +62,8 @@ static int global_set(const struct shell *shell, size_t argc, char *argv[], bool
 
 	if (acked) {
 		struct bt_mesh_loc_global rsp;
-		int err = bt_mesh_loc_cli_global_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_loc_cli_global_set(cli, NULL, &set, &rsp);
 		global_loc_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -104,13 +110,19 @@ static int cmd_loc_local_get(const struct shell *shell, size_t argc, char *argv[
 
 static int local_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	int16_t north = (int16_t)strtol(argv[1], NULL, 0);
-	int16_t east = (int16_t)strtol(argv[2], NULL, 0);
-	int16_t altitude = (int16_t)strtol(argv[3], NULL, 0);
-	int16_t floor = (int16_t)strtol(argv[4], NULL, 0);
-	int32_t time_delta = (argc >= 6) ? (int32_t)strtol(argv[5], NULL, 0) : 0;
-	uint32_t precision_mm = (argc >= 7) ? (uint32_t)strtol(argv[6], NULL, 0) : 0;
-	bool is_mobile = (argc == 8) ? (bool)strtol(argv[7], NULL, 0) : false;
+	int err = 0;
+	int16_t north = shell_strtol(argv[1], 0, &err);
+	int16_t east = shell_strtol(argv[2], 0, &err);
+	int16_t altitude = shell_strtol(argv[3], 0, &err);
+	int16_t floor = shell_strtol(argv[4], 0, &err);
+	int32_t time_delta = (argc >= 6) ? shell_strtol(argv[5], 0, &err) : 0;
+	uint32_t precision_mm = (argc >= 7) ? shell_strtoul(argv[6], 0, &err) : 0;
+	bool is_mobile = (argc == 8) ? shell_strtobool(argv[7], 0, &err) : false;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LOCATION_CLI, &mod)) {
 		return -ENODEV;
@@ -129,8 +141,8 @@ static int local_set(const struct shell *shell, size_t argc, char *argv[], bool 
 
 	if (acked) {
 		struct bt_mesh_loc_local rsp;
-		int err = bt_mesh_loc_cli_local_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_loc_cli_local_set(cli, NULL, &set, &rsp);
 		local_loc_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -155,7 +167,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_LOCATION_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_lvl_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_lvl_cli.c
@@ -39,9 +39,15 @@ static int cmd_lvl_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int lvl_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	int16_t lvl = (int16_t)strtol(argv[1], NULL, 0);
-	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
-	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+	int err = 0;
+	int16_t lvl = shell_strtol(argv[1], 0, &err);
+	uint32_t time = (argc >= 3) ? shell_strtoul(argv[2], 0, &err) : 0;
+	uint32_t delay = (argc == 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LEVEL_CLI, &mod)) {
 		return -ENODEV;
@@ -56,8 +62,8 @@ static int lvl_set(const struct shell *shell, size_t argc, char *argv[], bool ac
 
 	if (acked) {
 		struct bt_mesh_lvl_status rsp;
-		int err = bt_mesh_lvl_cli_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_lvl_cli_set(cli, NULL, &set, &rsp);
 		status_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -77,9 +83,15 @@ static int cmd_lvl_set_unack(const struct shell *shell, size_t argc, char *argv[
 
 static int delta_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	int32_t delta = (int32_t)strtol(argv[1], NULL, 0);
-	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
-	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+	int err = 0;
+	int32_t delta = shell_strtol(argv[1], 0, &err);
+	uint32_t time = (argc >= 3) ? shell_strtoul(argv[2], 0, &err) : 0;
+	uint32_t delay = (argc == 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LEVEL_CLI, &mod)) {
 		return -ENODEV;
@@ -94,8 +106,8 @@ static int delta_set(const struct shell *shell, size_t argc, char *argv[], bool 
 
 	if (acked) {
 		struct bt_mesh_lvl_status rsp;
-		int err = bt_mesh_lvl_cli_delta_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_lvl_cli_delta_set(cli, NULL, &set, &rsp);
 		status_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -115,9 +127,15 @@ static int cmd_delta_set_unack(const struct shell *shell, size_t argc, char *arg
 
 static int move_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	int16_t delta = (int16_t)strtol(argv[1], NULL, 0);
-	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
-	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+	int err = 0;
+	int16_t delta = shell_strtol(argv[1], 0, &err);
+	uint32_t time = (argc >= 3) ? shell_strtoul(argv[2], 0, &err) : 0;
+	uint32_t delay = (argc == 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_LEVEL_CLI, &mod)) {
 		return -ENODEV;
@@ -132,8 +150,8 @@ static int move_set(const struct shell *shell, size_t argc, char *argv[], bool a
 
 	if (acked) {
 		struct bt_mesh_lvl_status rsp;
-		int err = bt_mesh_lvl_cli_move_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_lvl_cli_move_set(cli, NULL, &set, &rsp);
 		status_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -158,7 +176,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_LEVEL_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_onoff_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_onoff_cli.c
@@ -39,9 +39,15 @@ static int cmd_onoff_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int onoff_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	bool on_off = shell_model_str2bool(argv[1]);
-	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
-	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+	int err = 0;
+	bool on_off = shell_strtobool(argv[1], 0, &err);
+	uint32_t time = (argc >= 3) ? shell_strtoul(argv[2], 0, &err) : 0;
+	uint32_t delay = (argc == 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, &mod)) {
 		return -ENODEV;
@@ -54,8 +60,8 @@ static int onoff_set(const struct shell *shell, size_t argc, char *argv[], bool 
 
 	if (acked) {
 		struct bt_mesh_onoff_status rsp;
-		int err = bt_mesh_onoff_cli_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_onoff_cli_set(cli, NULL, &set, &rsp);
 		status_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -80,7 +86,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_ONOFF_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_plvl_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_plvl_cli.c
@@ -39,9 +39,15 @@ static int cmd_power_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int power_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t lvl = (uint16_t)strtol(argv[1], NULL, 0);
-	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
-	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+	int err = 0;
+	uint16_t lvl = shell_strtoul(argv[1], 0, &err);
+	uint32_t time = (argc >= 3) ? shell_strtoul(argv[2], 0, &err) : 0;
+	uint32_t delay = (argc == 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
 		return -ENODEV;
@@ -54,8 +60,8 @@ static int power_set(const struct shell *shell, size_t argc, char *argv[], bool 
 
 	if (acked) {
 		struct bt_mesh_plvl_status rsp;
-		int err = bt_mesh_plvl_cli_power_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_plvl_cli_power_set(cli, NULL, &set, &rsp);
 		status_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -98,8 +104,14 @@ static int cmd_range_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int range_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t min = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t max = (uint16_t)strtol(argv[2], NULL, 0);
+	int err = 0;
+	uint16_t min = shell_strtoul(argv[1], 0, &err);
+	uint16_t max = shell_strtoul(argv[2], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
 		return -ENODEV;
@@ -110,8 +122,8 @@ static int range_set(const struct shell *shell, size_t argc, char *argv[], bool 
 
 	if (acked) {
 		struct bt_mesh_plvl_range_status rsp;
-		int err = bt_mesh_plvl_cli_range_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_plvl_cli_range_set(cli, NULL, &set, &rsp);
 		range_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -153,7 +165,13 @@ static int cmd_default_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int default_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t lvl = (uint16_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint16_t lvl = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI, &mod)) {
 		return -ENODEV;
@@ -163,8 +181,8 @@ static int default_set(const struct shell *shell, size_t argc, char *argv[], boo
 
 	if (acked) {
 		uint16_t rsp;
-		int err = bt_mesh_plvl_cli_default_set(cli, NULL, lvl, &rsp);
 
+		err = bt_mesh_plvl_cli_default_set(cli, NULL, lvl, &rsp);
 		default_print(shell, err, rsp);
 		return err;
 	} else {
@@ -207,7 +225,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI,
 					elem_idx);

--- a/subsys/bluetooth/mesh/shell/shell_ponoff_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_ponoff_cli.c
@@ -38,7 +38,13 @@ static int cmd_on_power_up_get(const struct shell *shell, size_t argc, char *arg
 
 static int on_power_up_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	enum bt_mesh_on_power_up pow_up = (enum bt_mesh_on_power_up)strtol(argv[1], NULL, 0);
+	int err = 0;
+	enum bt_mesh_on_power_up pow_up = (enum bt_mesh_on_power_up)shell_strtol(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_POWER_ONOFF_CLI, &mod)) {
 		return -ENODEV;
@@ -48,8 +54,8 @@ static int on_power_up_set(const struct shell *shell, size_t argc, char *argv[],
 
 	if (acked) {
 		enum bt_mesh_on_power_up rsp;
-		int err = bt_mesh_ponoff_cli_on_power_up_set(cli, NULL, pow_up, &rsp);
 
+		err = bt_mesh_ponoff_cli_on_power_up_set(cli, NULL, pow_up, &rsp);
 		pwr_up_print(shell, err, rsp);
 		return err;
 	} else {
@@ -74,7 +80,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_POWER_ONOFF_CLI,
 					elem_idx);

--- a/subsys/bluetooth/mesh/shell/shell_prop_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_prop_cli.c
@@ -27,7 +27,13 @@ static void props_print(const struct shell *shell, int err, struct bt_mesh_prop_
 
 static int cmd_prop_client_props_get(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint16_t id = (uint16_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint16_t id = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
 		return -ENODEV;
@@ -37,15 +43,21 @@ static int cmd_prop_client_props_get(const struct shell *shell, size_t argc, cha
 	uint16_t ids[CONFIG_BT_MESH_PROP_MAXCOUNT];
 	struct bt_mesh_prop_list rsp = { .ids = &ids[0], .count = CONFIG_BT_MESH_PROP_MAXCOUNT };
 
-	int err = bt_mesh_prop_cli_client_props_get(cli, NULL, id, &rsp);
-
+	err = bt_mesh_prop_cli_client_props_get(cli, NULL, id, &rsp);
 	props_print(shell, err, &rsp);
 	return err;
 }
 
 static int cmd_prop_props_get(const struct shell *shell, size_t argc, char *argv[])
 {
-	enum bt_mesh_prop_srv_kind kind = (enum bt_mesh_prop_srv_kind)strtol(argv[1], NULL, 0);
+	int err = 0;
+	enum bt_mesh_prop_srv_kind kind =
+		(enum bt_mesh_prop_srv_kind)shell_strtol(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
 		return -ENODEV;
@@ -55,8 +67,7 @@ static int cmd_prop_props_get(const struct shell *shell, size_t argc, char *argv
 	uint16_t ids[CONFIG_BT_MESH_PROP_MAXCOUNT];
 	struct bt_mesh_prop_list rsp = { .ids = &ids[0], .count = CONFIG_BT_MESH_PROP_MAXCOUNT };
 
-	int err = bt_mesh_prop_cli_props_get(cli, NULL, kind, &rsp);
-
+	err = bt_mesh_prop_cli_props_get(cli, NULL, kind, &rsp);
 	props_print(shell, err, &rsp);
 	return err;
 }
@@ -70,8 +81,15 @@ static void prop_val_print(const struct shell *shell, int err, struct bt_mesh_pr
 
 static int cmd_prop_prop_get(const struct shell *shell, size_t argc, char *argv[])
 {
-	enum bt_mesh_prop_srv_kind kind = (enum bt_mesh_prop_srv_kind)strtol(argv[1], NULL, 0);
-	uint16_t id = (uint16_t)strtol(argv[2], NULL, 0);
+	int err = 0;
+	enum bt_mesh_prop_srv_kind kind =
+		(enum bt_mesh_prop_srv_kind)shell_strtol(argv[1], 0, &err);
+	uint16_t id = shell_strtoul(argv[2], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
 		return -ENODEV;
@@ -81,17 +99,22 @@ static int cmd_prop_prop_get(const struct shell *shell, size_t argc, char *argv[
 	uint8_t value[CONFIG_BT_MESH_PROP_MAXSIZE];
 	struct bt_mesh_prop_val rsp = { .value = &value[0], .size = CONFIG_BT_MESH_PROP_MAXSIZE };
 
-	int err = bt_mesh_prop_cli_prop_get(cli, NULL, kind, id, &rsp);
-
+	err = bt_mesh_prop_cli_prop_get(cli, NULL, kind, id, &rsp);
 	prop_val_print(shell, err, &rsp);
 	return err;
 }
 
 static int user_prop_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t id = (uint16_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint16_t id = shell_strtoul(argv[1], 0, &err);
 	uint8_t val[CONFIG_BT_MESH_PROP_MAXSIZE] = { 0 };
-	uint8_t len = shell_model_hexstr2num(shell, argv[2], val, sizeof(val));
+	uint8_t len = hex2bin(argv[2], strlen(argv[2]), val, sizeof(val));
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
 		return -ENODEV;
@@ -108,8 +131,8 @@ static int user_prop_set(const struct shell *shell, size_t argc, char *argv[], b
 		uint8_t rsp_val[CONFIG_BT_MESH_PROP_MAXSIZE];
 		struct bt_mesh_prop_val rsp = { .value = &rsp_val[0],
 						.size = CONFIG_BT_MESH_PROP_MAXSIZE };
-		int err = bt_mesh_prop_cli_user_prop_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_prop_cli_user_prop_set(cli, NULL, &set, &rsp);
 		prop_val_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -129,10 +152,16 @@ static int cmd_prop_user_prop_set_unack(const struct shell *shell, size_t argc, 
 
 static int admin_prop_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t id = (uint16_t)strtol(argv[1], NULL, 0);
-	enum bt_mesh_prop_access access = (enum bt_mesh_prop_access)strtol(argv[2], NULL, 0);
+	int err = 0;
+	uint16_t id = shell_strtoul(argv[1], 0, &err);
+	enum bt_mesh_prop_access access = (enum bt_mesh_prop_access)shell_strtol(argv[2], 0, &err);
 	uint8_t val[CONFIG_BT_MESH_PROP_MAXSIZE] = { 0 };
-	uint8_t len = shell_model_hexstr2num(shell, argv[3], val, sizeof(val));
+	uint8_t len = hex2bin(argv[3], strlen(argv[3]), val, sizeof(val));
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
 		return -ENODEV;
@@ -150,8 +179,8 @@ static int admin_prop_set(const struct shell *shell, size_t argc, char *argv[], 
 		uint8_t rsp_val[CONFIG_BT_MESH_PROP_MAXSIZE];
 		struct bt_mesh_prop_val rsp = { .value = &rsp_val[0],
 						.size = CONFIG_BT_MESH_PROP_MAXSIZE };
-		int err = bt_mesh_prop_cli_admin_prop_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_prop_cli_admin_prop_set(cli, NULL, &set, &rsp);
 		prop_val_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -171,8 +200,14 @@ static int cmd_prop_admin_prop_set_unack(const struct shell *shell, size_t argc,
 
 static int mfr_prop_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t id = (uint16_t)strtol(argv[1], NULL, 0);
-	enum bt_mesh_prop_access access = (enum bt_mesh_prop_access)strtol(argv[2], NULL, 0);
+	int err = 0;
+	uint16_t id = shell_strtoul(argv[1], 0, &err);
+	enum bt_mesh_prop_access access = (enum bt_mesh_prop_access)shell_strtol(argv[2], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_GEN_PROP_CLI, &mod)) {
 		return -ENODEV;
@@ -188,8 +223,8 @@ static int mfr_prop_set(const struct shell *shell, size_t argc, char *argv[], bo
 		uint8_t rsp_val[CONFIG_BT_MESH_PROP_MAXSIZE];
 		struct bt_mesh_prop_val rsp = { .value = &rsp_val[0],
 						.size = CONFIG_BT_MESH_PROP_MAXSIZE };
-		int err = bt_mesh_prop_cli_mfr_prop_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_prop_cli_mfr_prop_set(cli, NULL, &set, &rsp);
 		prop_val_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -214,7 +249,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_GEN_PROP_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_scene_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_scene_cli.c
@@ -74,7 +74,13 @@ static int cmd_register_get(const struct shell *shell, size_t argc, char *argv[]
 
 static int store(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t scene = (uint16_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint16_t scene = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_SCENE_CLI, &mod)) {
 		return -ENODEV;
@@ -88,8 +94,8 @@ static int store(const struct shell *shell, size_t argc, char *argv[], bool acke
 			.count = CONFIG_BT_MESH_SCENES_MAX,
 			.scenes = &scenes[0],
 		};
-		int err = bt_mesh_scene_cli_store(cli, NULL, scene, &rsp);
 
+		err = bt_mesh_scene_cli_store(cli, NULL, scene, &rsp);
 		scene_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -109,7 +115,13 @@ static int cmd_store_unack(const struct shell *shell, size_t argc, char *argv[])
 
 static int scene_del(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t scene = (uint16_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint16_t scene = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_SCENE_CLI, &mod)) {
 		return -ENODEV;
@@ -123,8 +135,8 @@ static int scene_del(const struct shell *shell, size_t argc, char *argv[], bool 
 			.count = CONFIG_BT_MESH_SCENES_MAX,
 			.scenes = &scenes[0],
 		};
-		int err = bt_mesh_scene_cli_delete(cli, NULL, scene, &rsp);
 
+		err = bt_mesh_scene_cli_delete(cli, NULL, scene, &rsp);
 		scene_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -144,9 +156,15 @@ static int cmd_delete_unack(const struct shell *shell, size_t argc, char *argv[]
 
 static int recall(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t scene = (uint16_t)strtol(argv[1], NULL, 0);
-	uint32_t time = (argc >= 3) ? (uint32_t)strtol(argv[2], NULL, 0) : 0;
-	uint32_t delay = (argc == 4) ? (uint32_t)strtol(argv[3], NULL, 0) : 0;
+	int err = 0;
+	uint16_t scene = shell_strtoul(argv[1], 0, &err);
+	uint32_t time = (argc >= 3) ? shell_strtoul(argv[2], 0, &err) : 0;
+	uint32_t delay = (argc == 4) ? shell_strtoul(argv[3], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_SCENE_CLI, &mod)) {
 		return -ENODEV;
@@ -157,9 +175,8 @@ static int recall(const struct shell *shell, size_t argc, char *argv[], bool ack
 
 	if (acked) {
 		struct bt_mesh_scene_state rsp;
-		int err = bt_mesh_scene_cli_recall(cli, NULL, scene, (argc > 2) ? &trans : NULL,
-						   &rsp);
 
+		err = bt_mesh_scene_cli_recall(cli, NULL, scene, (argc > 2) ? &trans : NULL, &rsp);
 		scene_get_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -184,7 +201,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_SCENE_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_scheduler_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_scheduler_cli.c
@@ -51,7 +51,13 @@ static void schedule_print(const struct shell *shell, int err, struct bt_mesh_sc
 
 static int cmd_action_get(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_SCHEDULER_CLI, &mod)) {
 		return -ENODEV;
@@ -60,25 +66,31 @@ static int cmd_action_get(const struct shell *shell, size_t argc, char *argv[])
 	struct bt_mesh_scheduler_cli *cli = mod->user_data;
 	struct bt_mesh_schedule_entry rsp;
 
-	int err = bt_mesh_scheduler_cli_action_get(cli, NULL, idx, &rsp);
-
+	err = bt_mesh_scheduler_cli_action_get(cli, NULL, idx, &rsp);
 	schedule_print(shell, err, &rsp);
 	return err;
 }
 
 static int cmd_action_ctx_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	set_entry.year = (uint8_t)strtol(argv[1], NULL, 0);
-	set_entry.month = (uint8_t)strtol(argv[2], NULL, 0);
-	set_entry.day = (uint8_t)strtol(argv[3], NULL, 0);
-	set_entry.hour = (uint8_t)strtol(argv[4], NULL, 0);
-	set_entry.minute = (uint8_t)strtol(argv[5], NULL, 0);
-	set_entry.second = (uint8_t)strtol(argv[6], NULL, 0);
-	set_entry.day_of_week = (uint8_t)strtol(argv[7], NULL, 0);
-	set_entry.action = (enum bt_mesh_scheduler_action)strtol(argv[8], NULL, 0);
-	set_entry.scene_number = (uint16_t)strtol(argv[10], NULL, 0);
+	int err = 0;
+	uint32_t transition_time;
 
-	uint32_t transition_time = (uint32_t)strtol(argv[9], NULL, 0);
+	set_entry.year = shell_strtoul(argv[1], 0, &err);
+	set_entry.month = shell_strtoul(argv[2], 0, &err);
+	set_entry.day = shell_strtoul(argv[3], 0, &err);
+	set_entry.hour = shell_strtoul(argv[4], 0, &err);
+	set_entry.minute = shell_strtoul(argv[5], 0, &err);
+	set_entry.second = shell_strtoul(argv[6], 0, &err);
+	set_entry.day_of_week = shell_strtoul(argv[7], 0, &err);
+	set_entry.action = (enum bt_mesh_scheduler_action)shell_strtol(argv[8], 0, &err);
+	transition_time = shell_strtoul(argv[9], 0, &err);
+	set_entry.scene_number = shell_strtoul(argv[10], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	set_entry.transition_time = model_transition_encode(transition_time);
 
@@ -89,7 +101,13 @@ static int cmd_action_ctx_set(const struct shell *shell, size_t argc, char *argv
 
 static int action_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint8_t idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_SCHEDULER_CLI, &mod)) {
 		return -ENODEV;
@@ -99,8 +117,8 @@ static int action_set(const struct shell *shell, size_t argc, char *argv[], bool
 
 	if (acked) {
 		struct bt_mesh_schedule_entry rsp;
-		int err = bt_mesh_scheduler_cli_action_set(cli, NULL, idx, &set_entry, &rsp);
 
+		err = bt_mesh_scheduler_cli_action_set(cli, NULL, idx, &set_entry, &rsp);
 		schedule_print(shell, 0, &set_entry);
 		return err;
 	} else {
@@ -125,7 +143,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_SCHEDULER_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_time_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_time_cli.c
@@ -42,12 +42,18 @@ static int cmd_time_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int cmd_time_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint64_t sec = (uint64_t)strtoul(argv[1], NULL, 0);
-	uint8_t subsec = (uint8_t)strtol(argv[2], NULL, 0);
-	uint64_t uncertainty = (uint64_t)strtoul(argv[3], NULL, 0);
-	int16_t tai_utc_delta = (int16_t)strtol(argv[4], NULL, 0);
-	int16_t time_zone_offset = (int16_t)strtol(argv[5], NULL, 0);
-	bool is_authority = (bool)strtol(argv[6], NULL, 0);
+	int err = 0;
+	uint64_t sec = shell_strtoul(argv[1], 0, &err);
+	uint8_t subsec = shell_strtoul(argv[2], 0, &err);
+	uint64_t uncertainty = shell_strtoul(argv[3], 0, &err);
+	int16_t tai_utc_delta = shell_strtol(argv[4], 0, &err);
+	int16_t time_zone_offset = shell_strtol(argv[5], 0, &err);
+	bool is_authority = shell_strtobool(argv[6], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_TIME_CLI, &mod)) {
 		return -ENODEV;
@@ -60,10 +66,9 @@ static int cmd_time_set(const struct shell *shell, size_t argc, char *argv[])
 					   .tai_utc_delta = tai_utc_delta,
 					   .time_zone_offset = time_zone_offset,
 					   .is_authority = is_authority };
-
 	struct bt_mesh_time_status rsp;
-	int err = bt_mesh_time_cli_time_set(cli, NULL, &set, &rsp);
 
+	err = bt_mesh_time_cli_time_set(cli, NULL, &set, &rsp);
 	time_print(shell, err, &rsp);
 	return err;
 }
@@ -94,8 +99,14 @@ static int cmd_zone_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int cmd_zone_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	int16_t new_offset = (int16_t)strtol(argv[1], NULL, 0);
-	uint64_t ts = (uint64_t)strtoul(argv[2], NULL, 0);
+	int err = 0;
+	int16_t new_offset = shell_strtol(argv[1], 0, &err);
+	uint64_t ts = shell_strtoul(argv[2], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_TIME_CLI, &mod)) {
 		return -ENODEV;
@@ -103,10 +114,9 @@ static int cmd_zone_set(const struct shell *shell, size_t argc, char *argv[])
 
 	struct bt_mesh_time_cli *cli = mod->user_data;
 	struct bt_mesh_time_zone_change set = { .new_offset = new_offset, .timestamp = ts };
-
 	struct bt_mesh_time_zone_status rsp;
-	int err = bt_mesh_time_cli_zone_set(cli, NULL, &set, &rsp);
 
+	err = bt_mesh_time_cli_zone_set(cli, NULL, &set, &rsp);
 	zone_print(shell, err, &rsp);
 	return err;
 }
@@ -138,8 +148,14 @@ static int cmd_tai_utc_delta_get(const struct shell *shell, size_t argc, char *a
 
 static int cmd_tai_utc_delta_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	int16_t delta_new = (int16_t)strtol(argv[1], NULL, 0);
-	uint64_t ts = (uint64_t)strtoul(argv[2], NULL, 0);
+	int err = 0;
+	int16_t delta_new = shell_strtol(argv[1], 0, &err);
+	uint64_t ts = shell_strtoul(argv[2], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_TIME_CLI, &mod)) {
 		return -ENODEV;
@@ -147,10 +163,9 @@ static int cmd_tai_utc_delta_set(const struct shell *shell, size_t argc, char *a
 
 	struct bt_mesh_time_cli *cli = mod->user_data;
 	struct bt_mesh_time_tai_utc_change set = { .delta_new = delta_new, .timestamp = ts };
-
 	struct bt_mesh_time_tai_utc_delta_status rsp;
-	int err = bt_mesh_time_cli_tai_utc_delta_set(cli, NULL, &set, &rsp);
 
+	err = bt_mesh_time_cli_tai_utc_delta_set(cli, NULL, &set, &rsp);
 	tai_utc_print(shell, err, &rsp);
 	return err;
 }
@@ -179,7 +194,13 @@ static int cmd_role_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int cmd_role_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	enum bt_mesh_time_role role = (enum bt_mesh_time_role)strtol(argv[1], NULL, 0);
+	int err = 0;
+	enum bt_mesh_time_role role = (enum bt_mesh_time_role)shell_strtol(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_TIME_CLI, &mod)) {
 		return -ENODEV;
@@ -188,8 +209,7 @@ static int cmd_role_set(const struct shell *shell, size_t argc, char *argv[])
 	struct bt_mesh_time_cli *cli = mod->user_data;
 	uint8_t rsp;
 
-	int err = bt_mesh_time_cli_role_set(cli, NULL, &role, &rsp);
-
+	err = bt_mesh_time_cli_role_set(cli, NULL, &role, &rsp);
 	role_print(shell, err, rsp);
 	return err;
 }
@@ -201,7 +221,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_SCHEDULER_CLI, elem_idx);
 }

--- a/subsys/bluetooth/mesh/shell/shell_utils.h
+++ b/subsys/bluetooth/mesh/shell/shell_utils.h
@@ -7,15 +7,11 @@
 #include <stdint.h>
 #include <zephyr/shell/shell.h>
 
-bool shell_model_str2bool(const char *str);
-
-int shell_model_str2sensorval(const char *str, struct sensor_value *out);
+struct sensor_value shell_model_strtosensorval(const char *str, int *err);
 
 void shell_model_print_sensorval(const struct shell *shell, struct sensor_value *value);
 
-uint8_t shell_model_hexstr2num(const struct shell *shell, char *str, uint8_t *buf, uint8_t buf_len);
-
-double shell_model_str2dbl(const struct shell *shell, const char *str);
+double shell_model_strtodbl(const char *str, int *err);
 
 bool shell_model_first_get(uint16_t id, struct bt_mesh_model **mod);
 

--- a/subsys/bluetooth/mesh/shell/shell_xyl_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_xyl_cli.c
@@ -42,11 +42,17 @@ static int cmd_xyl_get(const struct shell *shell, size_t argc, char *argv[])
 
 static int xyl_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t light = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t x = (uint16_t)strtol(argv[2], NULL, 0);
-	uint16_t y = (uint16_t)strtol(argv[3], NULL, 0);
-	uint32_t time = (argc >= 5) ? (uint32_t)strtol(argv[4], NULL, 0) : 0;
-	uint32_t delay = (argc == 6) ? (uint32_t)strtol(argv[5], NULL, 0) : 0;
+	int err = 0;
+	uint16_t light = shell_strtoul(argv[1], 0, &err);
+	uint16_t x = shell_strtoul(argv[2], 0, &err);
+	uint16_t y = shell_strtoul(argv[3], 0, &err);
+	uint32_t time = (argc >= 5) ? shell_strtoul(argv[4], 0, &err) : 0;
+	uint32_t delay = (argc == 6) ? shell_strtoul(argv[5], 0, &err) : 0;
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_XYL_CLI, &mod)) {
 		return -ENODEV;
@@ -65,8 +71,8 @@ static int xyl_set(const struct shell *shell, size_t argc, char *argv[], bool ac
 
 	if (acked) {
 		struct bt_mesh_light_xyl_status rsp;
-		int err = bt_mesh_light_xyl_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_xyl_set(cli, NULL, &set, &rsp);
 		xyl_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -124,9 +130,15 @@ static int cmd_xyl_default_get(const struct shell *shell, size_t argc, char *arg
 
 static int xyl_default_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t light = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t x = (uint16_t)strtol(argv[2], NULL, 0);
-	uint16_t y = (uint16_t)strtol(argv[3], NULL, 0);
+	int err = 0;
+	uint16_t light = shell_strtoul(argv[1], 0, &err);
+	uint16_t x = shell_strtoul(argv[2], 0, &err);
+	uint16_t y = shell_strtoul(argv[3], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_XYL_CLI, &mod)) {
 		return -ENODEV;
@@ -141,8 +153,8 @@ static int xyl_default_set(const struct shell *shell, size_t argc, char *argv[],
 
 	if (acked) {
 		struct bt_mesh_light_xyl rsp;
-		int err = bt_mesh_light_xyl_default_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_xyl_default_set(cli, NULL, &set, &rsp);
 		default_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -189,10 +201,16 @@ static int cmd_xyl_range_get(const struct shell *shell, size_t argc, char *argv[
 
 static int xyl_range_set(const struct shell *shell, size_t argc, char *argv[], bool acked)
 {
-	uint16_t x_min = (uint16_t)strtol(argv[1], NULL, 0);
-	uint16_t y_min = (uint16_t)strtol(argv[2], NULL, 0);
-	uint16_t x_max = (uint16_t)strtol(argv[3], NULL, 0);
-	uint16_t y_max = (uint16_t)strtol(argv[4], NULL, 0);
+	int err = 0;
+	uint16_t x_min = shell_strtoul(argv[1], 0, &err);
+	uint16_t y_min = shell_strtoul(argv[2], 0, &err);
+	uint16_t x_max = shell_strtoul(argv[3], 0, &err);
+	uint16_t y_max = shell_strtoul(argv[4], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	if (!mod && !shell_model_first_get(BT_MESH_MODEL_ID_LIGHT_XYL_CLI, &mod)) {
 		return -ENODEV;
@@ -208,8 +226,8 @@ static int xyl_range_set(const struct shell *shell, size_t argc, char *argv[], b
 
 	if (acked) {
 		struct bt_mesh_light_xyl_range_status rsp;
-		int err = bt_mesh_light_xyl_range_set(cli, NULL, &set, &rsp);
 
+		err = bt_mesh_light_xyl_range_set(cli, NULL, &set, &rsp);
 		range_print(shell, err, &rsp);
 		return err;
 	} else {
@@ -234,7 +252,13 @@ static int cmd_instance_get_all(const struct shell *shell, size_t argc, char *ar
 
 static int cmd_instance_set(const struct shell *shell, size_t argc, char *argv[])
 {
-	uint8_t elem_idx = (uint8_t)strtol(argv[1], NULL, 0);
+	int err = 0;
+	uint8_t elem_idx = shell_strtoul(argv[1], 0, &err);
+
+	if (err) {
+		shell_warn(shell, "Unable to parse input string arg");
+		return err;
+	}
 
 	return shell_model_instance_set(shell, &mod, BT_MESH_MODEL_ID_LIGHT_XYL_CLI, elem_idx);
 }


### PR DESCRIPTION
Alligns shell input argument conversion with upstream:

- Add error checking for all input arguments in shell model modules.
- Removes duplicate conversion functionality from utility library.
- Refactor conversion functions for double args and sensor value args.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>