### PR TITLE
lib: nrf_modem: upmerge 20220622

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -1317,7 +1317,7 @@ static void nrf91_socket_iface_init(struct net_if *iface)
 {
 	nrf91_socket_iface_data.iface = iface;
 
-	iface->if_dev->offloaded = true;
+	iface->if_dev->socket_offload = nrf91_socket_create;
 
 	socket_offload_dns_register(&nrf91_socket_dns_offload_ops);
 }

--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -557,9 +557,16 @@ void nrf_modem_os_log(int level, const char *fmt, ...)
 		z_log_minimal_vprintk(fmt, ap);
 		printk("\n");
 	} else {
-		z_log_msg2_runtime_vcreate(
-			CONFIG_LOG_DOMAIN_ID, __log_current_dynamic_data,
-			level, NULL, 0, 0, fmt, ap);
+		void *source;
+
+		if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
+			source = (void *)__log_current_dynamic_data;
+		} else {
+			source = (void *)__log_current_const_data;
+		}
+
+		z_log_msg2_runtime_vcreate(CONFIG_LOG_DOMAIN_ID, source, level,
+					   NULL, 0, 0, fmt, ap);
 	}
 
 	va_end(ap);
@@ -576,12 +583,16 @@ void nrf_modem_os_logdump(int level, const char *str, const void *data, size_t l
 		printk("%c: %s\n", z_log_minimal_level_to_char(level), str);
 		z_log_minimal_hexdump_print(level, data, len);
 	} else {
-		struct log_msg_ids src_level = {
-			.level = level,
-			.domain_id = CONFIG_LOG_DOMAIN_ID,
-			.source_id = LOG_CURRENT_MODULE_ID()
-		};
-		log_hexdump(str, data, len, src_level);
+		void *source;
+
+		if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
+			source = (void *)__log_current_dynamic_data;
+		} else {
+			source = (void *)__log_current_const_data;
+		}
+
+		z_log_msg2_runtime_vcreate(CONFIG_LOG_DOMAIN_ID, source, level,
+					   data, len, 0, str, (va_list){ 0 });
 	}
 #endif /* CONFIG_LOG */
 }

--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -511,5 +511,6 @@ _BLOCKED_PROJECTS = set(
      'modules/hal/telink',
      'modules/hal/ti',
      'modules/hal/xtensa',
+     'modules/lib/picolibc',
      'modules/lib/tflite-micro',
      ])

--- a/tests/subsys/net/lib/download_client/src/mock/socket.c
+++ b/tests/subsys/net/lib/download_client/src/mock/socket.c
@@ -299,7 +299,7 @@ void mock_socket_iface_init(struct net_if *iface)
 {
 	mock_socket_iface_data.iface = iface;
 
-	iface->if_dev->offloaded = true;
+	iface->if_dev->socket_offload = mock_socket_create;
 
 	socket_offload_dns_register(&mock_socket_dns_offload_ops);
 }

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 85a0034809612b332fbdf478357e8a4109c493fd
+      revision: pull/838/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -100,7 +100,7 @@ manifest:
     # changes.
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.9.99-ncs1
+      revision: pull/205/head
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Zephyr replaced the `offload` bool in the `net_if_dev` struct
in favor of 'socket_offload;, a pointer to a function
that creates the offloaded socket.

Depends on: https://github.com/nrfconnect/sdk-nrf/pull/8056