### PR TITLE
treewide: Fix location library timeout parameters

### DIFF
--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.c
@@ -164,7 +164,7 @@ int start_location_tracking(location_update_cb_t handler_cb, int interval)
 	 */
 	if (IS_ENABLED(CONFIG_LOCATION_TRACKING_GNSS)) {
 		/* Set the GNSS timeout and desired accuracy. */
-		config.methods[0].gnss.timeout = CONFIG_GNSS_FIX_TIMEOUT_SECONDS;
+		config.methods[0].gnss.timeout = CONFIG_GNSS_FIX_TIMEOUT_SECONDS * MSEC_PER_SEC;
 		config.methods[0].gnss.accuracy = LOCATION_ACCURACY_NORMAL;
 	}
 

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -194,7 +194,7 @@ void test_location_gnss(void)
 	enum location_method methods[] = {LOCATION_METHOD_GNSS};
 
 	location_config_defaults_set(&config, 1, methods);
-	config.methods[0].gnss.timeout = 120;
+	config.methods[0].gnss.timeout = 120 * MSEC_PER_SEC;
 	config.methods[0].gnss.accuracy = LOCATION_ACCURACY_NORMAL;
 
 	test_location_event_data.id = LOCATION_EVT_LOCATION;


### PR DESCRIPTION
Recent PR updated how location lib stores timeouts.
A couple of locations were not updated accordingly.
This commit fixes said locations.

IRIS4522

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>