### PR TITLE
samples: openthread: Logs errors by default in CLI sample.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -245,7 +245,7 @@ nRF9160 samples
 Thread samples
 --------------
 
-|no_changes_yet_note|
+* Enables logging of errors and hard faults in CLI sample by default.
 
 Matter samples
 --------------

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -85,7 +85,7 @@ The following configuration files are available:
 
 * :file:`overlay-usb.conf` - Enables USB transport support.
   Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to :file:`usb.overlay`.
-* :file:`overlay-logging.conf` - Turns on logging.
+* :file:`overlay-logging.conf` - Sets more detailed logging.
 * :file:`overlay-rtt.conf` - Redirects logs to RTT.
   For more information about RTT please refer to :ref:`RTT logging <ug_logging>`.
 * :file:`overlay-debug.conf` - Enables debbuging the Thread sample with GDB thread awareness.

--- a/samples/openthread/cli/overlay-logging.conf
+++ b/samples/openthread/cli/overlay-logging.conf
@@ -3,8 +3,11 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 
-# Enable Zephyr logging
-CONFIG_LOG=y
+# Use separate thread for logging
+CONFIG_LOG_MODE_DEFERRED=y
+
+# Increase max log level to informative
+CONFIG_LOG_MAX_LEVEL=3
 
 # Option for configuring log level in this sample
 CONFIG_OT_COMMAND_LINE_INTERFACE_LOG_LEVEL_INF=y

--- a/samples/openthread/cli/prj.conf
+++ b/samples/openthread/cli/prj.conf
@@ -24,3 +24,12 @@ CONFIG_MBEDTLS_SHA1_C=n
 CONFIG_FPU=y
 
 CONFIG_GPIO_SHELL=y
+
+# Enable Zephyr logging
+CONFIG_LOG=y
+
+# Use printk to log messages
+CONFIG_LOG_MODE_MINIMAL=y
+
+# Log only errors/hard faults
+CONFIG_LOG_MAX_LEVEL=1


### PR DESCRIPTION
This commit enables logging by default in CLI sample to print messages
in case of errors and hard faults.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>