### PR TITLE
applications: serial_lte_modem: BUG-FIX SLM_UART_HWFC_RUNTIME not enable

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -47,11 +47,11 @@ choice
 		-  UART 2
 	config SLM_CONNECT_UART_0
 		bool "UART 0"
-		select SLM_UART_HWFC_RUNTIME if $(dt_node_has_prop,uart0,hw-flow-control)
+		select SLM_UART_HWFC_RUNTIME if $(dt_nodelabel_bool_prop,uart0,hw-flow-control)
 
 	config SLM_CONNECT_UART_2
 		bool "UART 2"
-		select SLM_UART_HWFC_RUNTIME if $(dt_node_has_prop,uart2,hw-flow-control)
+		select SLM_UART_HWFC_RUNTIME if $(dt_nodelabel_bool_prop,uart2,hw-flow-control)
 endchoice
 
 choice

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -285,10 +285,13 @@ int slm_uart_configure(void)
 		return err;
 	}
 #if defined(CONFIG_SLM_UART_HWFC_RUNTIME)
+	uint32_t RTS_PIN;
+	uint32_t CTS_PIN;
 /* Set HWFC dynamically */
 	#if defined(CONFIG_SLM_CONNECT_UART_0)
-		#define RTS_PIN DT_PROP(DT_NODELABEL(uart0), rts_pin)
-		#define CTS_PIN DT_PROP(DT_NODELABEL(uart0), cts_pin)
+		RTS_PIN = nrf_uarte_rts_pin_get(NRF_UARTE0);
+		CTS_PIN = nrf_uarte_cts_pin_get(NRF_UARTE0);
+
 		if (slm_uart.flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
 			nrf_uarte_hwfc_pins_set(NRF_UARTE0,
 						RTS_PIN,
@@ -299,8 +302,9 @@ int slm_uart_configure(void)
 		}
 	#endif
 	#if defined(CONFIG_SLM_CONNECT_UART_2)
-		#define RTS_PIN DT_PROP(DT_NODELABEL(uart2), rts_pin)
-		#define CTS_PIN DT_PROP(DT_NODELABEL(uart2), cts_pin)
+		RTS_PIN = nrf_uarte_rts_pin_get(NRF_UARTE2);
+		CTS_PIN = nrf_uarte_cts_pin_get(NRF_UARTE2);
+
 		if (slm_uart.flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
 			nrf_uarte_hwfc_pins_set(NRF_UARTE2,
 						RTS_PIN,


### PR DESCRIPTION
kconfigfunctions.py dt_node_has_prop behavior changes causes
SLM_UART_HWFC_RUNTINE is not enabled.
Modify RTS/CTS pin binding method.

Jira ticket:NCSIDB-788
Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>