### PR TITLE
moules/mcuboot/zephyr: remove copy of BOOT_ERASE_PROGRESSIVELY Kconfig

### DIFF
--- a/modules/mcuboot/boot/zephyr/Kconfig
+++ b/modules/mcuboot/boot/zephyr/Kconfig
@@ -81,15 +81,6 @@ config BOOT_NRF_EXTERNAL_CRYPTO
 
 endchoice
 
-config BOOT_ERASE_PROGRESSIVELY
-	bool "Erase flash progressively when receiving new firmware"
-	default y if SOC_FAMILY_NRF
-	help
-	 If enabled, flash is erased as necessary when receiving new firmware,
-	 instead of erasing the whole image slot at once. This is necessary
-	 on some hardware that has long erase times, to prevent long wait
-	 times at the beginning of the DFU process.
-
 config BOOT_IMAGE_ACCESS_HOOKS_FILE
 	string
 	default "${ZEPHYR_NRF_MODULE_DIR}/modules/mcuboot/hooks/nrf53_hooks.c"


### PR DESCRIPTION
The property was exact redefinition of its original definition in
the mcuboot. There is no sense of having this copy.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>