### PR TITLE
manifest: Enable TF-M isolation level 2 by default

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -16,7 +16,10 @@
 if BUILD_WITH_TFM
 
 config TFM_IPC
-	default y if TFM_PROFILE_TYPE_MINIMAL
+	default y
+
+config TFM_ISOLATION_LEVEL
+	default 2 if TFM_IPC
 
 config TFM_BL2
 	bool

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -91,6 +91,7 @@ config TFM_CRYPTO_IOVEC_BUFFER_SIZE
 	prompt "TF-M Crypto - PSA FF IO vector buffer size" if !TFM_PROFILE_TYPE_MINIMAL
 	depends on TFM_IPC
 	default 1024 if TFM_PROFILE_TYPE_MINIMAL
+	default 16384 if TFM_REGRESSION_S || TFM_REGRESSION_NS
 	default 5120
 	help
 	  This parameter applies only to IPC model builds. In IPC model,

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6e460c0847d437abb3b519bca048fafccbdd9411
+      revision: pull/844/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 88749734479f91e560828d95faec94aeb6f5c88b
+      revision: pull/55/head
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot

--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 0771980258922ad44c01c01a1d62fc9e574caf34
+      revision: pull/774/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
This PR brings the fixes required in TF-M to enable the isolation level 2. 
It also brings fixes so that the TF-M regression tests are passing when isolation level 2 is enabled.
And finally it defaults the tests and the crypto samples to isolation level 2.

Ref: NCSDK-12585

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>

test-sdk-nrf: sdk-nrf-PR-8101

