### PR TITLE
nfc: Add annotation about debug messages

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -310,7 +310,7 @@ Matter samples
 NFC samples
 -----------
 
-|no_changes_yet_note|
+* Added a note to the documentation of each NFC sample about debug message configuration with the NFCT driver from the `nrfx`_ repository.
 
 nRF5340 samples
 ---------------

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -130,3 +130,7 @@
    :rtrim:
 
 .. |Google_CCLicense| replace:: Portions of this page are reproduced from work created and `shared by Google`_, and used according to terms described in the `Creative Commons 4.0 Attribution License`_.
+
+.. |nfc_nfct_driver_note| replace:: If you are using debug messages in the NFCT driver, the driver might not be working properly if you have :kconfig:option:`CONFIG_LOG_MODE_IMMEDIATE` enabled.
+   The NFCT driver is part of the nrfx driver package.
+   For more information about this driver, see the NFCT driver page in the `nrfx`_ repository.

--- a/samples/nfc/record_launch_app/README.rst
+++ b/samples/nfc/record_launch_app/README.rst
@@ -41,6 +41,9 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
+.. note::
+   |nfc_nfct_driver_note|
+
 Testing
 =======
 

--- a/samples/nfc/record_text/README.rst
+++ b/samples/nfc/record_text/README.rst
@@ -40,6 +40,9 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
+.. note::
+   |nfc_nfct_driver_note|
+
 Testing
 =======
 

--- a/samples/nfc/system_off/README.rst
+++ b/samples/nfc/system_off/README.rst
@@ -69,6 +69,9 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
+.. note::
+   |nfc_nfct_driver_note|
+
 Testing
 =======
 

--- a/samples/nfc/tag_reader/README.rst
+++ b/samples/nfc/tag_reader/README.rst
@@ -43,6 +43,9 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
+.. note::
+   |nfc_nfct_driver_note|
+
 Testing
 =======
 After programming the sample to your development kit, you can test it with an NFC-A Type 2 Tag or Tag 4 Type.

--- a/samples/nfc/tnep_poller/README.rst
+++ b/samples/nfc/tnep_poller/README.rst
@@ -37,6 +37,9 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
+.. note::
+   |nfc_nfct_driver_note|
+
 Testing
 =======
 

--- a/samples/nfc/tnep_tag/README.rst
+++ b/samples/nfc/tnep_tag/README.rst
@@ -50,6 +50,9 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
+.. note::
+   |nfc_nfct_driver_note|
+
 Testing
 =======
 

--- a/samples/nfc/writable_ndef_msg/README.rst
+++ b/samples/nfc/writable_ndef_msg/README.rst
@@ -50,6 +50,9 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
+.. note::
+   |nfc_nfct_driver_note|
+
 Testing
 =======
 


### PR DESCRIPTION
NRF driver may not work properly when log debug is enabled and
LOG_MODE_IMMEDIATE logging mode is enabled.