### PR TITLE
lib: location: use Devicetree to specify chosen Wi-Fi device

### DIFF
--- a/doc/nrf/libraries/modem/location.rst
+++ b/doc/nrf/libraries/modem/location.rst
@@ -110,7 +110,14 @@ Configure the following Kconfig options to enable this library:
 Configure the following Kconfig options to enable Wi-Fi interface:
 
 * :kconfig:option:`CONFIG_WIFI` - Enable Wi-Fi for Zephyr.
-* :kconfig:option:`CONFIG_LOCATION_METHOD_WIFI_DEV_NAME` - Name of the Wi-Fi device.
+
+The chosen Wi-Fi device needs to be set in Devicetree:
+
+.. code-block:: devicetree
+
+    chosen {
+      ncs,location-wifi = &mywifi;
+    };
 
 Configure the following options to enable location methods of your choice:
 

--- a/lib/location/Kconfig
+++ b/lib/location/Kconfig
@@ -75,10 +75,6 @@ endif # LOCATION_METHOD_GNSS
 
 if LOCATION_METHOD_WIFI
 
-config LOCATION_METHOD_WIFI_DEV_NAME
-	string "Used Wi-Fi device name"
-	default "esp8266"
-
 config LOCATION_METHOD_WIFI_SERVICE_NRF_CLOUD
 	bool "nRF Cloud location service"
 	default y

--- a/lib/location/method_wifi.c
+++ b/lib/location/method_wifi.c
@@ -275,13 +275,12 @@ int method_wifi_init(void)
 	running = false;
 	current_scan_result_count = 0;
 	latest_scan_result_count = 0;
-	const struct device *wifi_dev;
+	const struct device *wifi_dev = DEVICE_DT_GET(DT_CHOSEN(ncs_location_wifi));
 
 	wifi_iface = NULL;
-	wifi_dev = device_get_binding(CONFIG_LOCATION_METHOD_WIFI_DEV_NAME);
-	if (!wifi_dev) {
-		LOG_ERR("Could not get Wi-Fi dev by name %s", CONFIG_LOCATION_METHOD_WIFI_DEV_NAME);
-		return -EFAULT;
+	if (!device_is_ready(wifi_dev)) {
+		LOG_ERR("Wi-Fi device %s not ready", wifi_dev->name);
+		return -ENODEV;
 	}
 
 	wifi_iface = net_if_lookup_by_dev(wifi_dev);

--- a/samples/nrf9160/location/esp_8266_nrf9160ns.overlay
+++ b/samples/nrf9160/location/esp_8266_nrf9160ns.overlay
@@ -28,7 +28,7 @@
 	pinctrl-0 = <&uart3_default_alt>;
 	pinctrl-1 = <&uart3_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	esp8266 {
+	esp8266: esp8266 {
 		compatible = "espressif,esp-at";
 		label = "esp8266";
 		status = "okay";
@@ -51,4 +51,10 @@
 		};
 	};
 
+};
+
+/ {
+	chosen {
+		ncs,location-wifi = &esp8266;
+	};
 };

--- a/samples/nrf9160/modem_shell/esp_8266_nrf9160ns.overlay
+++ b/samples/nrf9160/modem_shell/esp_8266_nrf9160ns.overlay
@@ -28,7 +28,7 @@
 	pinctrl-0 = <&uart3_default_alt>;
 	pinctrl-1 = <&uart3_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	esp8266 {
+	esp8266: esp8266 {
 		compatible = "espressif,esp-at";
 		label = "esp8266";
 		status = "okay";
@@ -51,4 +51,10 @@
 		};
 	};
 
+};
+
+/ {
+	chosen {
+		ncs,location-wifi = &esp8266;
+	};
 };


### PR DESCRIPTION
The chosen Wi-Fi device for location purposes was set via Kconfig using
CONFIG_LOCATION_METHOD_WIFI_DEV_NAME, which forced usage of
device_get_binding. This patch changes the library to rely on a choice
made in Devicetree: ncs,location-wifi.

All samples/docs have been adjusted.