### PR TITLE
test: lib: at_sms_cert: Add missing requirement for the test

### DIFF
--- a/tests/lib/at_sms_cert/testcase.yaml
+++ b/tests/lib/at_sms_cert/testcase.yaml
@@ -2,3 +2,6 @@ tests:
   at_sms_cert.functionality_test:
     platform_allow: nrf9160dk_nrf9160_ns
     tags: at_sms_cert
+    harness: ztest
+    harness_config:
+      fixture: sim_card


### PR DESCRIPTION
The test from tests/lib/at_sms_cert/testcase.yaml requires a board
with a sim card on. However, it was not reflected in the test yaml
and the test was pick up by our hw setups and failing. This commit
fixes the test description by adding a fixture dependancy.

fixes: https://projecttools.nordicsemi.no/jira/browse/NCSDK-15314

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>