### PR TITLE
SoftDevice Controller: Use default TX power level set by kconfigs

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -46,6 +46,7 @@ Bluetooth LE
 
 * Added support for changing the radio transmitter's default power level using the :c:func:`sdc_default_tx_power_set` function.
 * Added support for changing the peripheral latency mode using the :c:func:`sdc_hci_cmd_vs_peripheral_latency_mode_set` function.
+* Added support for changing the default TX power using ``CONFIG_BT_CTLR_TX_PWR_*``.
 
 For details, see :ref:`nrfxlib:softdevice_controller_changelog`.
 

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -28,6 +28,7 @@
 #include "multithreading_lock.h"
 #include "hci_internal.h"
 #include "ecdh.h"
+#include "radio_nrf5_txp.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME sdc_hci_driver
@@ -532,6 +533,13 @@ static int configure_supported_features(void)
 			return -ENOTSUP;
 		}
 	}
+
+#if RADIO_TXP_DEFAULT != 0
+	err = sdc_default_tx_power_set(RADIO_TXP_DEFAULT);
+	if (err) {
+		return -ENOTSUP;
+	}
+#endif
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/radio_nrf5_txp.h
+++ b/subsys/bluetooth/controller/radio_nrf5_txp.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined(CONFIG_BT_CTLR_TX_PWR_0)
+#define RADIO_TXP_DEFAULT  0
+#elif defined(CONFIG_BT_CTLR_TX_PWR_PLUS_8)
+#define RADIO_TXP_DEFAULT  8
+#elif defined(CONFIG_BT_CTLR_TX_PWR_PLUS_7)
+#define RADIO_TXP_DEFAULT  7
+#elif defined(CONFIG_BT_CTLR_TX_PWR_PLUS_6)
+#define RADIO_TXP_DEFAULT  6
+#elif defined(CONFIG_BT_CTLR_TX_PWR_PLUS_5)
+#define RADIO_TXP_DEFAULT  5
+#elif defined(CONFIG_BT_CTLR_TX_PWR_PLUS_4)
+#define RADIO_TXP_DEFAULT  4
+#elif defined(CONFIG_BT_CTLR_TX_PWR_PLUS_3)
+#define RADIO_TXP_DEFAULT  3
+#elif defined(CONFIG_BT_CTLR_TX_PWR_PLUS_2)
+#define RADIO_TXP_DEFAULT  2
+#elif defined(CONFIG_BT_CTLR_TX_PWR_MINUS_4)
+#define RADIO_TXP_DEFAULT -4
+#elif defined(CONFIG_BT_CTLR_TX_PWR_MINUS_8)
+#define RADIO_TXP_DEFAULT -8
+#elif defined(CONFIG_BT_CTLR_TX_PWR_MINUS_12)
+#define RADIO_TXP_DEFAULT -12
+#elif defined(CONFIG_BT_CTLR_TX_PWR_MINUS_16)
+#define RADIO_TXP_DEFAULT -16
+#elif defined(CONFIG_BT_CTLR_TX_PWR_MINUS_20)
+#define RADIO_TXP_DEFAULT -20
+#elif defined(CONFIG_BT_CTLR_TX_PWR_MINUS_30)
+#define RADIO_TXP_DEFAULT -30
+#elif defined(CONFIG_BT_CTLR_TX_PWR_MINUS_40)
+#define RADIO_TXP_DEFAULT -40
+#else
+#error Unknown output power
+#endif


### PR DESCRIPTION
Enable a default radio TX power level to be set via kconfig in
the SDC

Signed-off-by: Timothy Keys <timothy.keys@nordicsemi.no>