### PR TITLE
mpsl: fem: switch to mpsl_fem_pin_t for pin description

### DIFF
--- a/subsys/mpsl/fem/CMakeLists.txt
+++ b/subsys/mpsl/fem/CMakeLists.txt
@@ -12,8 +12,8 @@ zephyr_library_sources_ifdef(CONFIG_MPSL_FEM_API_AVAILABLE api_init/mpsl_fem_api
 
 if (CONFIG_MPSL_FEM_NCS_SUPPORTED_FEM_USED)
 
-    zephyr_library_include_directories(common/include)
-    zephyr_library_sources(common/mpsl_fem_utils.c)
+    zephyr_library_include_directories_ifdef(CONFIG_MPSL_FEM common/include)
+    zephyr_library_sources_ifdef(CONFIG_MPSL_FEM common/mpsl_fem_utils.c)
 
     zephyr_library_sources_ifdef(CONFIG_MPSL_FEM_NRF21540_GPIO nrf21540_gpio/mpsl_fem_nrf21540_gpio.c)
 

--- a/subsys/mpsl/fem/common/include/mpsl_fem_utils.h
+++ b/subsys/mpsl/fem/common/include/mpsl_fem_utils.h
@@ -8,8 +8,92 @@
 #define MPSL_FEM_UTILS_H__
 
 #include <stdint.h>
-#if !defined(CONFIG_MPSL_FEM_PIN_FORWARDER)
+#include <stddef.h>
+#include <errno.h>
 #include <mpsl_fem_config_common.h>
+
+#define MPSL_FEM_GPIO_POLARITY_GET(dt_property) \
+	((GPIO_ACTIVE_LOW & \
+	  DT_GPIO_FLAGS(DT_NODELABEL(nrf_radio_fem), dt_property)) \
+	 ? false : true)
+
+#define MPSL_FEM_GPIO_PORT(pin)     DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), pin)
+#define MPSL_FEM_GPIO_PORT_REG(pin) ((NRF_GPIO_Type *)DT_REG_ADDR(MPSL_FEM_GPIO_PORT(pin)))
+#define MPSL_FEM_GPIO_PORT_NO(pin)  DT_PROP(MPSL_FEM_GPIO_PORT(pin), port)
+#define MPSL_FEM_GPIO_PIN_NO(pin)   DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), pin)
+
+#define MPSL_FEM_GPIO_INVALID_PIN        0xFFU
+#define MPSL_FEM_GPIOTE_INVALID_CHANNEL  0xFFU
+
+#define MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT	\
+	.gpio_pin      = {				\
+		.port_pin = MPSL_FEM_GPIO_INVALID_PIN,	\
+	},						\
+	.enable        = false,				\
+	.active_high   = true,				\
+	.gpiote_ch_id  = MPSL_FEM_GPIOTE_INVALID_CHANNEL
+
+#define MPSL_FEM_DISABLED_GPIO_CONFIG_INIT		\
+	.gpio_pin      = {				\
+		.port_pin = MPSL_FEM_GPIO_INVALID_PIN,	\
+	},						\
+	.enable        = false,				\
+	.active_high   = true,				\
+
+#if defined(CONFIG_HAS_HW_NRF_DPPIC)
+/** @brief Allocates free EGU instance.
+ *
+ * @param[out]  egu_instance_no  Number of allocated EGU instance.
+ *
+ * @return  0 in case of success, appropriate error code otherwise.
+ */
+static inline int mpsl_fem_utils_egu_instance_alloc(uint8_t *egu_instance_no)
+{
+	/* Always return EGU0. */
+	*egu_instance_no = 0;
+
+	return 0;
+}
+
+/** @brief Allocates free EGU channels and stores them in @p egu_channels.
+ *
+ * @param[out]  egu_channels     Array of allocated EGU channels.
+ * @param[in]   size             Number of channels to allocate.
+ * @param[in]   egu_instance_no  Number of EGU instance to allocate channels from.
+ *
+ * @return  0 in case of success, appropriate error code otherwise.
+ */
+static inline int mpsl_fem_utils_egu_channel_alloc(
+	uint8_t *egu_channels, size_t size, uint8_t egu_instance_no)
+{
+	(void)egu_instance_no;
+
+	/* The 802.15.4 radio driver is the only user of EGU peripheral on nRF5340 network core
+	 * and it uses channels: 0, 1, 2, 3, 4, 15. Therefore starting from channel 5, a consecutive
+	 * block of at most 10 channels can be allocated.
+	 */
+	if (size > 10U) {
+		return -ENOMEM;
+	}
+
+	uint8_t starting_channel = 5U;
+
+	for (int i = 0; i < size; i++) {
+		egu_channels[i] = starting_channel + i;
+	}
+
+	return 0;
+}
+#endif /* defined(CONFIG_HAS_HW_NRF_DPPIC) */
+
+/** @brief Allocates free (D)PPI channels and stores them in @p ppi_channels.
+ *
+ * @param[out]  ppi_channels  Array of allocated (D)PPI channels.
+ * @param[in]   size          Number of channels to allocate.
+ *
+ * @return  0 in case of success, appropriate error code otherwise.
+ */
+int mpsl_fem_utils_ppi_channel_alloc(uint8_t *ppi_channels, size_t size);
 
 /** @brief Converts pin number extended with port number to an mpsl_fem_pin_t structure.
  *
@@ -17,7 +101,5 @@
  * @param[inout]  p_fem_pin  Pointer to be filled with pin represented as an mpsl_fem_pin_t struct.
  */
 void mpsl_fem_extended_pin_to_mpsl_fem_pin(uint32_t pin_num, mpsl_fem_pin_t *p_fem_pin);
-
-#endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 
 #endif /* MPSL_FEM_UTILS_H__ */

--- a/subsys/mpsl/fem/common/mpsl_fem_utils.c
+++ b/subsys/mpsl/fem/common/mpsl_fem_utils.c
@@ -10,8 +10,28 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/__assert.h>
 #include <hal/nrf_gpio.h>
+#if IS_ENABLED(CONFIG_HAS_HW_NRF_PPI)
+#include <nrfx_ppi.h>
+#elif IS_ENABLED(CONFIG_HAS_HW_NRF_DPPIC)
+#include <nrfx_dppi.h>
+#endif
 
-#if !defined(CONFIG_MPSL_FEM_PIN_FORWARDER)
+int mpsl_fem_utils_ppi_channel_alloc(uint8_t *ppi_channels, size_t size)
+{
+	nrfx_err_t err = NRFX_ERROR_NOT_SUPPORTED;
+
+	for (int i = 0; i < size; i++) {
+		IF_ENABLED(CONFIG_HAS_HW_NRF_PPI,
+			(err = nrfx_ppi_channel_alloc(&ppi_channels[i]);));
+		IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
+			(err = nrfx_dppi_channel_alloc(&ppi_channels[i]);));
+		if (err != NRFX_SUCCESS) {
+			return -ENOMEM;
+		}
+	}
+
+	return 0;
+}
 
 void mpsl_fem_extended_pin_to_mpsl_fem_pin(uint32_t pin_num, mpsl_fem_pin_t *p_fem_pin)
 {
@@ -24,5 +44,3 @@ void mpsl_fem_extended_pin_to_mpsl_fem_pin(uint32_t pin_num, mpsl_fem_pin_t *p_f
 
 	p_fem_pin->port_pin = pin_num;
 }
-
-#endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */

--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#if defined(CONFIG_MPSL_FEM_NRF21540_GPIO)
-
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <string.h>
@@ -17,13 +15,8 @@
 #include "mpsl_fem_power_model_interface.h"
 #endif
 #include <nrfx_gpiote.h>
-#if IS_ENABLED(CONFIG_HAS_HW_NRF_PPI)
-#include <nrfx_ppi.h>
-#elif IS_ENABLED(CONFIG_HAS_HW_NRF_DPPIC)
-#include <nrfx_dppi.h>
-#endif
-#else /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 #include <mpsl_fem_utils.h>
+#else /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 #include <soc_secure.h>
 #if IS_ENABLED(CONFIG_PINCTRL)
 #include <pinctrl_soc.h>
@@ -31,83 +24,6 @@
 #endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 
 #if !defined(CONFIG_MPSL_FEM_PIN_FORWARDER)
-
-#define MPSL_FEM_GPIO_POLARITY_GET(dt_property) \
-	((GPIO_ACTIVE_LOW & \
-	  DT_GPIO_FLAGS(DT_NODELABEL(nrf_radio_fem), dt_property)) \
-	 ? false : true)
-
-#define MPSL_FEM_GPIO_PORT(pin)     DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), pin)
-#define MPSL_FEM_GPIO_PORT_REG(pin) ((NRF_GPIO_Type *)DT_REG_ADDR(MPSL_FEM_GPIO_PORT(pin)))
-#define MPSL_FEM_GPIO_PORT_NO(pin)  DT_PROP(MPSL_FEM_GPIO_PORT(pin), port)
-#define MPSL_FEM_GPIO_PIN_NO(pin)   DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), pin)
-
-#define MPSL_FEM_GPIO_INVALID_PIN        0xFFU
-#define MPSL_FEM_GPIOTE_INVALID_CHANNEL  0xFFU
-#define MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT	\
-	.gpio_pin      = {				\
-		.port_pin = MPSL_FEM_GPIO_INVALID_PIN,	\
-	},						\
-	.enable        = false,				\
-	.active_high   = true,				\
-	.gpiote_ch_id  = MPSL_FEM_GPIOTE_INVALID_CHANNEL
-
-#define MPSL_FEM_DISABLED_GPIO_CONFIG_INIT		\
-	.gpio_pin      = {				\
-		.port_pin = MPSL_FEM_GPIO_INVALID_PIN,	\
-	},						\
-	.enable        = false,				\
-	.active_high   = true,				\
-
-static int ppi_channel_alloc(uint8_t *ppi_channels, size_t size)
-{
-	nrfx_err_t err = NRFX_ERROR_NOT_SUPPORTED;
-
-	for (int i = 0; i < size; i++) {
-		IF_ENABLED(CONFIG_HAS_HW_NRF_PPI,
-			(err = nrfx_ppi_channel_alloc(&ppi_channels[i]);));
-		IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
-			(err = nrfx_dppi_channel_alloc(&ppi_channels[i]);));
-		if (err != NRFX_SUCCESS) {
-			return -ENOMEM;
-		}
-	}
-
-	return 0;
-}
-
-#if defined(CONFIG_HAS_HW_NRF_DPPIC)
-static int egu_instance_alloc(uint8_t *p_egu_instance_no)
-{
-	/* Always return EGU0. */
-	*p_egu_instance_no = 0;
-
-	return 0;
-}
-
-static int egu_channel_alloc(uint8_t *egu_channels, size_t size, uint8_t egu_instance_no)
-{
-	(void)egu_instance_no;
-
-	/* The 802.15.4 radio driver is the only user of EGU peripheral on nRF5340 network core
-	 * and it uses channels: 0, 1, 2, 3, 4, 15. Therefore starting from channel 5, a consecutive
-	 * block of at most 10 channels can be allocated.
-	 */
-	if (size > 10U) {
-		return -ENOMEM;
-	}
-
-	uint8_t starting_channel = 5U;
-
-	for (int i = 0; i < size; i++) {
-		egu_channels[i] = starting_channel + i;
-	}
-
-	return 0;
-}
-#endif
-
-#if IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_GPIO)
 static int fem_nrf21540_gpio_configure(void)
 {
 	int err;
@@ -218,23 +134,25 @@ static int fem_nrf21540_gpio_configure(void)
 	};
 
 	IF_ENABLED(CONFIG_HAS_HW_NRF_PPI,
-		   (err = ppi_channel_alloc(cfg.ppi_channels, ARRAY_SIZE(cfg.ppi_channels));));
+		   (err = mpsl_fem_utils_ppi_channel_alloc(cfg.ppi_channels,
+							   ARRAY_SIZE(cfg.ppi_channels));));
 	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
-		   (err = ppi_channel_alloc(cfg.dppi_channels, ARRAY_SIZE(cfg.dppi_channels));));
+		   (err = mpsl_fem_utils_ppi_channel_alloc(cfg.dppi_channels,
+							   ARRAY_SIZE(cfg.dppi_channels));));
 	if (err) {
 		return err;
 	}
 
 	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
-		   (err = egu_instance_alloc(&cfg.egu_instance_no);));
+		   (err = mpsl_fem_utils_egu_instance_alloc(&cfg.egu_instance_no);));
 	if (err) {
 		return err;
 	}
 
 	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
-		   (err = egu_channel_alloc(cfg.egu_channels,
-					    ARRAY_SIZE(cfg.egu_channels),
-					    cfg.egu_instance_no);))
+		   (err = mpsl_fem_utils_egu_channel_alloc(cfg.egu_channels,
+							   ARRAY_SIZE(cfg.egu_channels),
+							   cfg.egu_instance_no);))
 	if (err) {
 		return err;
 	}
@@ -279,7 +197,6 @@ static int fem_nrf21540_gpio_configure(void)
 
 	return mpsl_fem_nrf21540_gpio_interface_config_set(&cfg);
 }
-#endif
 
 static int mpsl_fem_init(const struct device *dev)
 {
@@ -346,5 +263,3 @@ static int mpsl_fem_host_init(const struct device *dev)
 SYS_INIT(mpsl_fem_host_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
-
-#endif /* defined(CONFIG_MPSL_FEM_NRF21540_GPIO) */

--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -44,16 +44,20 @@
 
 #define MPSL_FEM_GPIO_INVALID_PIN        0xFFU
 #define MPSL_FEM_GPIOTE_INVALID_CHANNEL  0xFFU
-#define MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT \
-	.enable        = false, \
-	.active_high   = true, \
-	.gpio_port_pin = MPSL_FEM_GPIO_INVALID_PIN, \
+#define MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT	\
+	.gpio_pin      = {				\
+		.port_pin = MPSL_FEM_GPIO_INVALID_PIN,	\
+	},						\
+	.enable        = false,				\
+	.active_high   = true,				\
 	.gpiote_ch_id  = MPSL_FEM_GPIOTE_INVALID_CHANNEL
 
-#define MPSL_FEM_DISABLED_GPIO_CONFIG_INIT \
-	.enable        = false, \
-	.active_high   = true, \
-	.gpio_port_pin = MPSL_FEM_GPIO_INVALID_PIN
+#define MPSL_FEM_DISABLED_GPIO_CONFIG_INIT		\
+	.gpio_pin      = {				\
+		.port_pin = MPSL_FEM_GPIO_INVALID_PIN,	\
+	},						\
+	.enable        = false,				\
+	.active_high   = true,				\
 
 static int ppi_channel_alloc(uint8_t *ppi_channels, size_t size)
 {
@@ -157,12 +161,13 @@ static int fem_nrf21540_gpio_configure(void)
 		},
 		.pa_pin_config = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), tx_en_gpios)
-			.cfg_type      = MPSL_FEM_PIN_CFG_TYPE_PIN_PORT,
+			.gpio_pin      = {
+				.p_port   = MPSL_FEM_GPIO_PORT_REG(tx_en_gpios),
+				.port_no  = MPSL_FEM_GPIO_PORT_NO(tx_en_gpios),
+				.port_pin = MPSL_FEM_GPIO_PIN_NO(tx_en_gpios),
+			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(tx_en_gpios),
-			.p_port        = MPSL_FEM_GPIO_PORT_REG(tx_en_gpios),
-			.gpio_port_no  = MPSL_FEM_GPIO_PORT_NO(tx_en_gpios),
-			.gpio_port_pin = MPSL_FEM_GPIO_PIN_NO(tx_en_gpios),
 			.gpiote_ch_id  = txen_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
@@ -170,12 +175,13 @@ static int fem_nrf21540_gpio_configure(void)
 		},
 		.lna_pin_config = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), rx_en_gpios)
-			.cfg_type      = MPSL_FEM_PIN_CFG_TYPE_PIN_PORT,
+			.gpio_pin      = {
+				.p_port   = MPSL_FEM_GPIO_PORT_REG(rx_en_gpios),
+				.port_no  = MPSL_FEM_GPIO_PORT_NO(rx_en_gpios),
+				.port_pin = MPSL_FEM_GPIO_PIN_NO(rx_en_gpios),
+			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(rx_en_gpios),
-			.p_port        = MPSL_FEM_GPIO_PORT_REG(rx_en_gpios),
-			.gpio_port_no  = MPSL_FEM_GPIO_PORT_NO(rx_en_gpios),
-			.gpio_port_pin = MPSL_FEM_GPIO_PIN_NO(rx_en_gpios),
 			.gpiote_ch_id  = rxen_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
@@ -183,12 +189,13 @@ static int fem_nrf21540_gpio_configure(void)
 		},
 		.pdn_pin_config = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
-			.cfg_type      = MPSL_FEM_PIN_CFG_TYPE_PIN_PORT,
+			.gpio_pin      = {
+				.p_port   = MPSL_FEM_GPIO_PORT_REG(pdn_gpios),
+				.port_no  = MPSL_FEM_GPIO_PORT_NO(pdn_gpios),
+				.port_pin = MPSL_FEM_GPIO_PIN_NO(pdn_gpios),
+			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(pdn_gpios),
-			.p_port        = MPSL_FEM_GPIO_PORT_REG(pdn_gpios),
-			.gpio_port_no  = MPSL_FEM_GPIO_PORT_NO(pdn_gpios),
-			.gpio_port_pin = MPSL_FEM_GPIO_PIN_NO(pdn_gpios),
 			.gpiote_ch_id  = pdn_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
@@ -197,12 +204,13 @@ static int fem_nrf21540_gpio_configure(void)
 		.mode_pin_config = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), mode_gpios) && \
 	IS_ENABLED(CONFIG_MPSL_FEM_NRF21540_RUNTIME_PA_GAIN_CONTROL)
-			.cfg_type      = MPSL_FEM_PIN_CFG_TYPE_PIN_PORT,
+			.gpio_pin      = {
+				.p_port   = MPSL_FEM_GPIO_PORT_REG(mode_gpios),
+				.port_no  = MPSL_FEM_GPIO_PORT_NO(mode_gpios),
+				.port_pin = MPSL_FEM_GPIO_PIN_NO(mode_gpios),
+			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(mode_gpios),
-			.p_port        = MPSL_FEM_GPIO_PORT_REG(mode_gpios),
-			.gpio_port_no  = MPSL_FEM_GPIO_PORT_NO(mode_gpios),
-			.gpio_port_pin = MPSL_FEM_GPIO_PIN_NO(mode_gpios)
 #else
 			MPSL_FEM_DISABLED_GPIO_CONFIG_INIT
 #endif

--- a/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
+++ b/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
@@ -268,12 +268,13 @@ static int fem_nrf21540_gpio_spi_configure(void)
 		},
 		.pa_pin_config = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), tx_en_gpios)
-			.cfg_type      = MPSL_FEM_PIN_CFG_TYPE_PIN_PORT,
+			.gpio_pin      = {
+				.p_port   = MPSL_FEM_GPIO_PORT_REG(tx_en_gpios),
+				.port_no  = MPSL_FEM_GPIO_PORT_NO(tx_en_gpios),
+				.port_pin = MPSL_FEM_GPIO_PIN_NO(tx_en_gpios),
+			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(tx_en_gpios),
-			.p_port        = MPSL_FEM_GPIO_PORT_REG(tx_en_gpios),
-			.gpio_port_no  = MPSL_FEM_GPIO_PORT_NO(tx_en_gpios),
-			.gpio_port_pin = MPSL_FEM_GPIO_PIN_NO(tx_en_gpios),
 			.gpiote_ch_id  = txen_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
@@ -281,12 +282,13 @@ static int fem_nrf21540_gpio_spi_configure(void)
 		},
 		.lna_pin_config = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), rx_en_gpios)
-			.cfg_type      = MPSL_FEM_PIN_CFG_TYPE_PIN_PORT,
+			.gpio_pin      = {
+				.p_port   = MPSL_FEM_GPIO_PORT_REG(rx_en_gpios),
+				.port_no  = MPSL_FEM_GPIO_PORT_NO(rx_en_gpios),
+				.port_pin = MPSL_FEM_GPIO_PIN_NO(rx_en_gpios),
+			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(rx_en_gpios),
-			.p_port        = MPSL_FEM_GPIO_PORT_REG(rx_en_gpios),
-			.gpio_port_no  = MPSL_FEM_GPIO_PORT_NO(rx_en_gpios),
-			.gpio_port_pin = MPSL_FEM_GPIO_PIN_NO(rx_en_gpios),
 			.gpiote_ch_id  = rxen_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
@@ -294,12 +296,13 @@ static int fem_nrf21540_gpio_spi_configure(void)
 		},
 		.pdn_pin_config = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
-			.cfg_type      = MPSL_FEM_PIN_CFG_TYPE_PIN_PORT,
+			.gpio_pin      = {
+				.p_port   = MPSL_FEM_GPIO_PORT_REG(pdn_gpios),
+				.port_no  = MPSL_FEM_GPIO_PORT_NO(pdn_gpios),
+				.port_pin = MPSL_FEM_GPIO_PIN_NO(pdn_gpios),
+			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(pdn_gpios),
-			.p_port        = MPSL_FEM_GPIO_PORT_REG(pdn_gpios),
-			.gpio_port_no  = MPSL_FEM_GPIO_PORT_NO(pdn_gpios),
-			.gpio_port_pin = MPSL_FEM_GPIO_PIN_NO(pdn_gpios),
 			.gpiote_ch_id  = pdn_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT

--- a/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
+++ b/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
@@ -44,10 +44,12 @@
 
 #define MPSL_FEM_GPIO_INVALID_PIN        0xFFU
 #define MPSL_FEM_GPIOTE_INVALID_CHANNEL  0xFFU
-#define MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT \
-	.enable        = false, \
-	.active_high   = true, \
-	.gpio_port_pin = MPSL_FEM_GPIO_INVALID_PIN, \
+#define MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT	\
+	.gpio_pin      = {				\
+		.port_pin = MPSL_FEM_GPIO_INVALID_PIN,	\
+	},						\
+	.enable        = false,				\
+	.active_high   = true,				\
 	.gpiote_ch_id  = MPSL_FEM_GPIOTE_INVALID_CHANNEL
 
 static int ppi_channel_alloc(uint8_t *ppi_channels, size_t size)
@@ -135,12 +137,13 @@ static int fem_simple_gpio_configure(void)
 		},
 		.pa_pin_config = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ctx_gpios)
-			.cfg_type      = MPSL_FEM_PIN_CFG_TYPE_PIN_PORT,
+			.gpio_pin      = {
+				.p_port   = MPSL_FEM_GPIO_PORT_REG(ctx_gpios),
+				.port_no  = MPSL_FEM_GPIO_PORT_NO(ctx_gpios),
+				.port_pin = MPSL_FEM_GPIO_PIN_NO(ctx_gpios),
+			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(ctx_gpios),
-			.p_port        = MPSL_FEM_GPIO_PORT_REG(ctx_gpios),
-			.gpio_port_no  = MPSL_FEM_GPIO_PORT_NO(ctx_gpios),
-			.gpio_port_pin = MPSL_FEM_GPIO_PIN_NO(ctx_gpios),
 			.gpiote_ch_id  = ctx_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT
@@ -148,12 +151,13 @@ static int fem_simple_gpio_configure(void)
 		},
 		.lna_pin_config = {
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), crx_gpios)
-			.cfg_type      = MPSL_FEM_PIN_CFG_TYPE_PIN_PORT,
+			.gpio_pin      = {
+				.p_port   = MPSL_FEM_GPIO_PORT_REG(crx_gpios),
+				.port_no  = MPSL_FEM_GPIO_PORT_NO(crx_gpios),
+				.port_pin = MPSL_FEM_GPIO_PIN_NO(crx_gpios),
+			},
 			.enable        = true,
 			.active_high   = MPSL_FEM_GPIO_POLARITY_GET(crx_gpios),
-			.p_port        = MPSL_FEM_GPIO_PORT_REG(crx_gpios),
-			.gpio_port_no  = MPSL_FEM_GPIO_PORT_NO(crx_gpios),
-			.gpio_port_pin = MPSL_FEM_GPIO_PIN_NO(crx_gpios),
 			.gpiote_ch_id  = crx_gpiote_channel
 #else
 			MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT

--- a/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
+++ b/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#if defined(CONFIG_MPSL_FEM_SIMPLE_GPIO)
-
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
 #include <string.h>
@@ -17,13 +15,8 @@
 #include "mpsl_fem_power_model_interface.h"
 #endif
 #include <nrfx_gpiote.h>
-#if IS_ENABLED(CONFIG_HAS_HW_NRF_PPI)
-#include <nrfx_ppi.h>
-#elif IS_ENABLED(CONFIG_HAS_HW_NRF_DPPIC)
-#include <nrfx_dppi.h>
-#endif
-#else /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 #include <mpsl_fem_utils.h>
+#else /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 #include <soc_secure.h>
 #if IS_ENABLED(CONFIG_PINCTRL)
 #include <pinctrl_soc.h>
@@ -31,75 +24,6 @@
 #endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 
 #if !defined(CONFIG_MPSL_FEM_PIN_FORWARDER)
-
-#define MPSL_FEM_GPIO_POLARITY_GET(dt_property) \
-	((GPIO_ACTIVE_LOW & \
-	  DT_GPIO_FLAGS(DT_NODELABEL(nrf_radio_fem), dt_property)) \
-	 ? false : true)
-
-#define MPSL_FEM_GPIO_PORT(pin)     DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), pin)
-#define MPSL_FEM_GPIO_PORT_REG(pin) ((NRF_GPIO_Type *)DT_REG_ADDR(MPSL_FEM_GPIO_PORT(pin)))
-#define MPSL_FEM_GPIO_PORT_NO(pin)  DT_PROP(MPSL_FEM_GPIO_PORT(pin), port)
-#define MPSL_FEM_GPIO_PIN_NO(pin)   DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), pin)
-
-#define MPSL_FEM_GPIO_INVALID_PIN        0xFFU
-#define MPSL_FEM_GPIOTE_INVALID_CHANNEL  0xFFU
-#define MPSL_FEM_DISABLED_GPIOTE_PIN_CONFIG_INIT	\
-	.gpio_pin      = {				\
-		.port_pin = MPSL_FEM_GPIO_INVALID_PIN,	\
-	},						\
-	.enable        = false,				\
-	.active_high   = true,				\
-	.gpiote_ch_id  = MPSL_FEM_GPIOTE_INVALID_CHANNEL
-
-static int ppi_channel_alloc(uint8_t *ppi_channels, size_t size)
-{
-	nrfx_err_t err = NRFX_ERROR_NOT_SUPPORTED;
-
-	for (int i = 0; i < size; i++) {
-		IF_ENABLED(CONFIG_HAS_HW_NRF_PPI,
-			(err = nrfx_ppi_channel_alloc(&ppi_channels[i]);));
-		IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
-			(err = nrfx_dppi_channel_alloc(&ppi_channels[i]);));
-		if (err != NRFX_SUCCESS) {
-			return -ENOMEM;
-		}
-	}
-
-	return 0;
-}
-
-#if defined(CONFIG_HAS_HW_NRF_DPPIC)
-static int egu_instance_alloc(uint8_t *p_egu_instance_no)
-{
-	/* Always return EGU0. */
-	*p_egu_instance_no = 0;
-
-	return 0;
-}
-
-static int egu_channel_alloc(uint8_t *egu_channels, size_t size, uint8_t egu_instance_no)
-{
-	(void)egu_instance_no;
-
-	/* The 802.15.4 radio driver is the only user of EGU peripheral on nRF5340 network core
-	 * and it uses channels: 0, 1, 2, 3, 4, 15. Therefore starting from channel 5, a consecutive
-	 * block of at most 10 channels can be allocated.
-	 */
-	if (size > 10U) {
-		return -ENOMEM;
-	}
-
-	uint8_t starting_channel = 5U;
-
-	for (int i = 0; i < size; i++) {
-		egu_channels[i] = starting_channel + i;
-	}
-
-	return 0;
-}
-#endif
-
 static int fem_simple_gpio_configure(void)
 {
 	int err;
@@ -166,23 +90,25 @@ static int fem_simple_gpio_configure(void)
 	};
 
 	IF_ENABLED(CONFIG_HAS_HW_NRF_PPI,
-		   (err = ppi_channel_alloc(cfg.ppi_channels, ARRAY_SIZE(cfg.ppi_channels));));
+		   (err = mpsl_fem_utils_ppi_channel_alloc(cfg.ppi_channels,
+							   ARRAY_SIZE(cfg.ppi_channels));));
 	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
-		   (err = ppi_channel_alloc(cfg.dppi_channels, ARRAY_SIZE(cfg.dppi_channels));));
+		   (err = mpsl_fem_utils_ppi_channel_alloc(cfg.dppi_channels,
+							   ARRAY_SIZE(cfg.dppi_channels));));
 	if (err) {
 		return err;
 	}
 
 	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
-		   (err = egu_instance_alloc(&cfg.egu_instance_no);));
+		   (err = mpsl_fem_utils_egu_instance_alloc(&cfg.egu_instance_no);));
 	if (err) {
 		return err;
 	}
 
 	IF_ENABLED(CONFIG_HAS_HW_NRF_DPPIC,
-		   (err = egu_channel_alloc(cfg.egu_channels,
-					    ARRAY_SIZE(cfg.egu_channels),
-					    cfg.egu_instance_no);))
+		   (err = mpsl_fem_utils_egu_channel_alloc(cfg.egu_channels,
+							   ARRAY_SIZE(cfg.egu_channels),
+							   cfg.egu_instance_no);))
 	if (err) {
 		return err;
 	}
@@ -236,5 +162,3 @@ static int mpsl_fem_host_init(const struct device *dev)
 SYS_INIT(mpsl_fem_host_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
-
-#endif /* defined(CONFIG_MPSL_FEM_SIMPLE_GPIO) */


### PR DESCRIPTION
This commit aligns all FEM implementations to use `mpsl_fem_pin_t`
structure for representing GPIO pins.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>