### PR TITLE
samples: Bluetooth: df: Forward GPIO pins from app to network core

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -192,6 +192,26 @@ Bluetooth samples
 
   * Added possibility of toggling between show and hide UI indication in the Fast Pair not discoverable advertising.
 
+* :ref:`bluetooth_direction_finding_central` sample:
+
+  * Added devicetree overlay file for the nRF5340 application core that configures GPIO pin forwarding.
+    This enables the radio peripheral's Direction Finding Extension for antenna switching.
+
+* :ref:`bluetooth_direction_finding_connectionless_rx` sample:
+
+  * Added devicetree overlay file for the nRF5340 application core that configures GPIO pin forwarding.
+    This enables the radio peripheral's Direction Finding Extension for antenna switching.
+
+* :ref:`bluetooth_direction_finding_connectionless_tx` sample:
+
+  * Added devicetree overlay file for the nRF5340 application core that configures GPIO pin forwarding.
+    This enables the radio peripheral's Direction Finding Extension for antenna switching.
+
+* :ref:`bluetooth_direction_finding_peripheral` sample:
+
+  * Added devicetree overlay file for the nRF5340 application core that configures GPIO pin forwarding.
+    This enables the radio peripheral's Direction Finding Extension for antenna switching.
+
 Bluetooth mesh samples
 ----------------------
 

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -41,9 +41,15 @@ This sample configuration is split into the following two files:
 * generic configuration is available in the :file:`prj.conf` file
 * board specific configuration is available in the :file:`boards/<BOARD>.conf` file
 
-Board specific configuration involves configuring the Bluetooth LE controller.
-For :ref:`nRF5340 DK <ug_nrf5340>`, the Bluetooth LE controller is part of a ``child image`` meant to run on the network core.
-Configuration for the child image is stored in the :file:`child_image/` subdirectory.
+nRF5340 configuration files
+===========================
+
+The following additional configuration files are available for the :ref:`nRF5340 DK <ug_nrf5340>`:
+
+* The Bluetooth LE controller is part of a child image meant to run on the network core.
+  The configuration for the child image is stored in the :file:`child_image/` subdirectory.
+* :file:`boards/nrf5340dk_nrf5340_cpuapp.overlay` DTS overlay file is available for the application core.
+  This file forwards the control over GPIOs to network core, which gives control over GPIOs to the radio peripheral in order to execute antenna switching.
 
 Angle of departure mode
 =======================

--- a/samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Enable pin forwarding to the network core. The selected pins will be used by
+ * the Radio Direction Finding Extension for antenna switching purposes.
+ *
+ * Note: Pay attention to assigning the same GPIO pins as those provided in
+ * the network core DTS overlay.
+ */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 4 0>,
+			<&gpio0 5 0>,
+			<&gpio0 6 0>,
+			<&gpio0 7 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_central/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direction_finding_central/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -20,6 +20,9 @@
 	 * drive antenna switching when AoA is enabled.
 	 * Pin numbers are selected to drive switches on antenna matrix
 	 * desinged by Nordic Semiconductor. For more information see README.rst.
+	 *
+	 * NOTE: Make sure to select the same GPIOs in the application core DTS
+	 * overlay's gpio_fwd node.
 	 */
 	dfegpio0-gpios = <&gpio0 4 0>;
 	dfegpio1-gpios = <&gpio0 5 0>;

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -41,9 +41,15 @@ This sample configuration is split into the following two files:
 * generic configuration is available in :file:`prj.conf` file
 * board specific configuration is available in :file:`boards/<BOARD>.conf` file
 
-Board specific configuration involves configuring the Bluetooth LE controller.
-For :ref:`nRF5340 DK <ug_nrf5340>`, the Bluetooth LE controller is part of a ``child image`` aimed to run on the network core.
-Configuration for the child image is stored in :file:`child_image/` subdirectory.
+nRF5340 configuration files
+===========================
+
+The following additional configuration files are available for the :ref:`nRF5340 DK <ug_nrf5340>`:
+
+* The Bluetooth LE controller is part of a child image meant to run on the network core.
+  The configuration for the child image is stored in the :file:`child_image/` subdirectory.
+* :file:`boards/nrf5340dk_nrf5340_cpuapp.overlay` DTS overlay file is available for the application core.
+  This file forwards the control over GPIOs to network core, which gives control over GPIOs to the radio peripheral in order to execute antenna switching.
 
 Angle of departure mode
 =======================

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Enable pin forwarding to the network core. The selected pins will be used by
+ * the Radio Direction Finding Extension for antenna switching purposes.
+ *
+ * Note: Pay attention to assigning the same GPIO pins as those provided in
+ */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 4 0>,
+			<&gpio0 5 0>,
+			<&gpio0 6 0>,
+			<&gpio0 7 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_connectionless_rx/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_rx/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -20,6 +20,9 @@
 	 * drive antenna switching when AoA is enabled.
 	 * Pin numbers are selected to drive switches on antenna matrix
 	 * desinged by Nordic. For more information see README.rst.
+	 *
+	 * NOTE: Make sure to select the same GPIOs in the application core DTS
+	 * overlay's gpio_fwd node.
 	 */
 	dfegpio0-gpios = <&gpio0 4 0>;
 	dfegpio1-gpios = <&gpio0 5 0>;

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -41,9 +41,16 @@ This sample configuration is split into the following two files:
 * generic configuration is available in :file:`prj.conf` file
 * board specific configuration is available in :file:`boards/<BOARD>.conf` file
 
-Board specific configuration involves configuring the Bluetooth LE controller.
-For :ref:`nRF5340 DK <ug_nrf5340>`, the Bluetooth LE controller is part of a ``child image`` aimed to run on the network core.
-Configuration for the child image is stored in :file:`child_image/` subdirectory.
+nRF5340 configuration files
+===========================
+
+The following additional configuration files are available for the :ref:`nRF5340 DK <ug_nrf5340>`:
+
+* The Bluetooth LE controller is part of a child image meant to run on the network core.
+  The configuration for the child image is stored in the :file:`child_image/` subdirectory.
+* :file:`boards/nrf5340dk_nrf5340_cpuapp.overlay` DTS overlay file is available for the application core.
+  This file forwards the control over GPIOs to network core, which gives control over GPIOs to the radio peripheral in order to execute antenna switching.
+
 
 Angle of arrival mode
 =====================

--- a/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Enable pin forwarding to the network core. The selected pins will be used by
+ * the Radio Direction Finding Extension for antenna switching purposes.
+ *
+ * Note: Pay attention to assigning the same GPIO pins as those provided in
+ * the network core DTS overlay.
+ */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 4 0>,
+			<&gpio0 5 0>,
+			<&gpio0 6 0>,
+			<&gpio0 7 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_connectionless_tx/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_tx/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -20,6 +20,9 @@
 	 * drive antenna switching when AoD is enabled.
 	 * Pin numbers are selected to drive switches on antenna matrix
 	 * desinged by Nordic. For more information see README.rst.
+	 *
+	 * NOTE: Make sure to select the same GPIOs in the application core DTS
+	 * overlay's gpio_fwd node.
 	 */
 	dfegpio0-gpios = <&gpio0 4 0>;
 	dfegpio1-gpios = <&gpio0 5 0>;

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -41,9 +41,16 @@ This sample configuration is split into the following two files:
 * generic configuration is available in the :file:`prj.conf` file
 * board specific configuration is available in the :file:`boards/<BOARD>.conf` file
 
-Board specific configuration involves configuring the Bluetooth LE controller.
-For :ref:`nRF5340 DK <ug_nrf5340>`, the Bluetooth LE controller is part of a ``child image`` meant to run on the network core.
-Configuration for the child image is stored in the :file:`child_image/` subdirectory.
+nRF5340 configuration files
+===========================
+
+The following additional configuration files are available for the :ref:`nRF5340 DK <ug_nrf5340>`:
+
+* The Bluetooth LE controller is part of a child image meant to run on the network core.
+  The configuration for the child image is stored in the :file:`child_image/` subdirectory.
+* :file:`boards/nrf5340dk_nrf5340_cpuapp.overlay` DTS overlay file is available for the application core.
+  This file forwards the control over GPIOs to network core, which gives control over GPIOs to the radio peripheral in order to execute antenna switching.
+
 
 Angle of arrival mode
 =====================

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Enable pin forwarding to the network core. The selected pins will be used by
+ * the Radio Direction Finding Extension for antenna switching purposes.
+ *
+ * Note: Pay attention to assigning the same GPIO pins as those provided in
+ * the network core DTS overlay.
+ */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 4 0>,
+			<&gpio0 5 0>,
+			<&gpio0 6 0>,
+			<&gpio0 7 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_peripheral/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -20,6 +20,9 @@
 	 * drive antenna switching when AoA is enabled.
 	 * Pin numbers are selected to drive switches on antenna matrix
 	 * desinged by Nordic Semiconductor. For more information see README.rst.
+	 *
+	 * NOTE: Make sure to select the same GPIOs in the application core DTS
+	 * overlay's gpio_fwd node.
 	 */
 	dfegpio0-gpios = <&gpio0 4 0>;
 	dfegpio1-gpios = <&gpio0 5 0>;


### PR DESCRIPTION
To give control over GPIO pins for Direction Finding Extension in
Radio peripheral when build for nRF53 network core, the application
core has to assign those pins to network core.

The commit adds overlays with appropriate configuration assigning
GPIO pins in all DF related samples.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>