### PR TITLE
applications: nrf_desktop: Decrease RGB LED PWM period

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/app.overlay
@@ -14,17 +14,17 @@
 		status = "okay";
 
 		led1_r: led_pwm_1 {
-			pwms = <&pwm1 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = <&pwm1 0 PWM_MSEC(1) PWM_POLARITY_INVERTED>;
 			label = "LED1 Red";
 		};
 
 		led1_g: led_pwm_2 {
-			pwms = <&pwm1 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = <&pwm1 1 PWM_MSEC(1) PWM_POLARITY_INVERTED>;
 			label = "LED1 Green";
 		};
 
 		led1_b: led_pwm_3 {
-			pwms = <&pwm1 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = <&pwm1 2 PWM_MSEC(1) PWM_POLARITY_INVERTED>;
 			label = "LED1 Blue";
 		};
 	};

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/app.overlay
@@ -10,6 +10,18 @@
 		zephyr,entropy = &rng;
 	};
 
+	pwmleds {
+		red_pwm_led: pwm_led_0 {
+			pwms = <&pwm0 0 PWM_MSEC(1) PWM_POLARITY_INVERTED>;
+		};
+		green_pwm_led: pwm_led_1 {
+			pwms = <&pwm0 1 PWM_MSEC(1) PWM_POLARITY_INVERTED>;
+		};
+		blue_pwm_led: pwm_led_2 {
+			pwms = <&pwm0 2 PWM_MSEC(1) PWM_POLARITY_INVERTED>;
+		};
+	};
+
 	pwmleds1 {
 		compatible = "pwm-leds";
 		status = "okay";

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/app.overlay
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/app.overlay
@@ -15,17 +15,17 @@
 		status = "okay";
 
 		led0_r: led_pwm_0 {
-			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 0 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 			label = "LED0 Red";
 		};
 
 		led0_g: led_pwm_1 {
-			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 1 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 			label = "LED0 Green";
 		};
 
 		led0_b: led_pwm_2 {
-			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 2 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 			label = "LED0 Blue";
 		};
 	};
@@ -35,17 +35,17 @@
 		status = "okay";
 
 		led1_r: led_pwm_3 {
-			pwms = <&pwm1 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm1 0 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 			label = "LED1 Red";
 		};
 
 		led1_g: led_pwm_4 {
-			pwms = <&pwm1 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm1 1 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 			label = "LED1 Green";
 		};
 
 		led1_b: led_pwm_5 {
-			pwms = <&pwm1 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm1 2 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 			label = "LED1 Blue";
 		};
 	};


### PR DESCRIPTION
Change decreses RGB LED PWM period to prevent glitches during LED color update. Update of the first LED channel occurs one PWM period earlier than update of remaining channels. Shorter LED PWM period mitigates the observed issue.

Jira: NCSDK-15707