### PR TITLE
modules/mcuboot: added CMake for nrf53 hooks inclusion

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -6,3 +6,4 @@
 
 add_subdirectory_ifdef(CONFIG_BUILD_WITH_TFM tfm/zephyr)
 add_subdirectory_ifdef(CONFIG_MEMFAULT memfault-firmware-sdk)
+add_subdirectory_ifdef(CONFIG_MCUBOOT mcuboot/hooks)

--- a/modules/mcuboot/boot/zephyr/Kconfig
+++ b/modules/mcuboot/boot/zephyr/Kconfig
@@ -90,11 +90,6 @@ config BOOT_ERASE_PROGRESSIVELY
 	 on some hardware that has long erase times, to prevent long wait
 	 times at the beginning of the DFU process.
 
-config BOOT_IMAGE_ACCESS_HOOKS_FILE
-	string
-	default "${ZEPHYR_NRF_MODULE_DIR}/modules/mcuboot/hooks/nrf53_hooks.c"
-	depends on BOOT_IMAGE_ACCESS_HOOKS
-
 config BOOT_IMAGE_ACCESS_HOOKS
 	bool
 	default y if UPDATEABLE_IMAGE_NUMBER > 1 && SOC_NRF5340_CPUAPP && PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY

--- a/modules/mcuboot/hooks/CMakeLists.txt
+++ b/modules/mcuboot/hooks/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(CONFIG_BOOT_IMAGE_ACCESS_HOOKS)
+  zephyr_library()
+  zephyr_library_sources(nrf53_hooks.c)
+  zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
+endif()

--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
       revision: 386a52e67193f5166090f40a59a5bb0951900ce4
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: b3e43db105b3eeb6490e0c9ea31c33d76b55361d
+      revision: 74b34fe10bde956ddecd84104536dcb78a612e5f
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Added Cmake which is adding nRF53 hooks implementation
C file to the build.
Previously this was done in MCUboot CMake basing on the
configurable path which was recognized as technical debt.

ref. VES-93