### PR TITLE
applications: nrf_desktop: use DEVICE_DT_GET for qdec

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/wheel.c
+++ b/applications/nrf_desktop/src/hw_interface/wheel.c
@@ -62,7 +62,7 @@ static const struct sensor_trigger qdec_trig = {
 	.chan = SENSOR_CHAN_ROTATION,
 };
 
-static const struct device *qdec_dev;
+static const struct device *qdec_dev = DEVICE_DT_GET(DT_NODELABEL(qdec));
 static const struct device *gpio_dev;
 static struct gpio_callback gpio_cbs[2];
 static struct k_spinlock lock;
@@ -306,10 +306,9 @@ static int init(void)
 		k_work_init_delayable(&idle_timeout, idle_timeout_fn);
 	}
 
-	qdec_dev = device_get_binding(DT_LABEL(DT_NODELABEL(qdec)));
-	if (!qdec_dev) {
-		LOG_ERR("Cannot get QDEC device");
-		return -ENXIO;
+	if (!device_is_ready(qdec_dev)) {
+		LOG_ERR("QDEC device not ready");
+		return -ENODEV;
 	}
 
 	gpio_dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));


### PR DESCRIPTION
Obtain device at compile time by using DEVICE_DT_GET.