### PR TITLE
applications: nrf_desktop: motion_sensor: use DEVICE_DT_GET_ONE

### DIFF
--- a/applications/nrf_desktop/configuration/common/motion_sensor.h
+++ b/applications/nrf_desktop/configuration/common/motion_sensor.h
@@ -23,7 +23,7 @@ enum motion_sensor_option {
 
  #include <sensor/pmw3360.h>
 
- #define MOTION_SENSOR_DEV_NAME "PMW3360"
+ #define MOTION_SENSOR_COMPATIBLE pixart_pmw3360
 
  static const int motion_sensor_option_attr[MOTION_SENSOR_OPTION_COUNT] = {
 	[MOTION_SENSOR_OPTION_CPI] = PMW3360_ATTR_CPI,
@@ -40,7 +40,7 @@ enum motion_sensor_option {
 
  #include <sensor/paw3212.h>
 
- #define MOTION_SENSOR_DEV_NAME "PAW3212"
+ #define MOTION_SENSOR_COMPATIBLE pixart_paw3212
 
  static const int motion_sensor_option_attr[MOTION_SENSOR_OPTION_COUNT] = {
 	[MOTION_SENSOR_OPTION_CPI] = PAW3212_ATTR_CPI,

--- a/applications/nrf_desktop/src/hw_interface/motion_sensor.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_sensor.c
@@ -70,7 +70,8 @@ static K_SEM_DEFINE(sem, 1, 1);
 static K_THREAD_STACK_DEFINE(thread_stack, THREAD_STACK_SIZE);
 static struct k_thread thread;
 
-static const struct device *sensor_dev;
+static const struct device *sensor_dev =
+	DEVICE_DT_GET_ONE(MOTION_SENSOR_COMPATIBLE);
 
 static struct sensor_state state;
 
@@ -321,12 +322,11 @@ static void set_default_configuration(void)
 
 static int init(void)
 {
-	int err = -ENXIO;
+	int err;
 
-	sensor_dev = device_get_binding(MOTION_SENSOR_DEV_NAME);
-	if (!sensor_dev) {
-		LOG_ERR("Cannot get motion sensor device");
-		return err;
+	if (!device_is_ready(sensor_dev)) {
+		LOG_ERR("Sensor device not ready");
+		return -ENODEV;
 	}
 
 	k_spinlock_key_t key = k_spin_lock(&state.lock);


### PR DESCRIPTION
Use DEVICE_DT_GET_ONE to obtain an instance of a motion sensor. Note
that the architecture of the nrf_desktop could be improved to make use
of DT to further describe the configuration needed by modules. Kconfig
does this job now (e.g. to select the motion sensor), but this is likely
not the way it would be done upstream.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>