### PR TITLE
doc: Add a supported OS section to the Getting Started

### DIFF
--- a/doc/nrf/gs_recommended_versions.rst
+++ b/doc/nrf/gs_recommended_versions.rst
@@ -22,6 +22,73 @@ However, there are some Zephyr features that are currently only available on Lin
 
    Before you start setting up the toolchain, install available updates for your operating system.
 
+.. _gs_supported_OS:
+
+Supported operating systems
+***************************
+
+The following table shows the operating system versions that support the |NCS| tools:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Operating System
+     - x86
+     - x64
+     - ARM64
+   * - `Windows 11`_
+     - Tier 3
+     - Tier 3
+     - Not supported
+   * - `Windows 10`_
+     - Tier 1
+     - Tier 2
+     - Not supported
+   * - `Linux - Ubuntu 22.04 LTS`_
+     - Not supported
+     - Not supported
+     - Not supported
+   * - `Linux - Ubuntu 20.04 LTS`_
+     - Not supported
+     - Tier 1
+     - Not supported
+   * - `macOS 12`_
+     - Not applicable
+     - Tier 2
+     - Tier 2
+   * - `macOS 11`_
+     - Not applicable
+     - Tier 1
+     - Not supported
+   * - `macOS 10.15`_
+     - Not applicable
+     - Tier 3
+     - Not supported
+
+The table uses the following tier definitions to categorize the level of operating system support:
+
+Tier 1
+  The |NCS| tools will always work.
+  The automated build and automated testing ensure that the |NCS| tools build and successfully complete tests after each change.
+
+Tier 2
+  The |NCS| tools will always build.
+  The automated build ensures that the |NCS| tools build successfully after each change.
+  There is no guarantee that a build will work because the automation tests do not always run.
+
+Tier 3
+  The |NCS| tools are supported by design but are not built or tested after each change.
+  Therefore, the application may or may not work.
+
+Not supported
+  The |NCS| tools do not work, but it may be supported in the future.
+
+Not applicable
+  The specified architecture is not supported for the respective operating system.
+
+.. note::
+   The |NCS| tools are not supported by the older versions of the operating system.
+
 Required tools
 **************
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -556,6 +556,10 @@
 
 .. _`Windows path length limitations`: https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
 
+.. _`Windows 11`: https://www.microsoft.com/software-download/windows11
+.. _`Windows 10`: https://www.microsoft.com/en-us/software-download/windows10
+
+
 .. ### Source: ietf.org
 
 .. _`CoAP response codes`: https://datatracker.ietf.org/doc/html/rfc7252#section-12.1.2
@@ -782,6 +786,19 @@
 
 .. _`Google Chrome browser`: https://www.google.com/chrome
 
+.. ### Source: ubuntu.com
+
+.. _`Linux - Ubuntu 22.04 LTS`: https://releases.ubuntu.com/22.04/
+.. _`Linux - Ubuntu 20.04 LTS`: https://releases.ubuntu.com/20.04/
+
+.. ### Source: apple.com
+
+.. _`macOS 12`: https://www.apple.com/macos/monterey/
+.. _`macOS 11`: https://support.apple.com/en-us/HT211896
+.. _`macOS 10.15`: https://support.apple.com/en-us/HT210642
+.. _`Apple Notification Center Service Specification`: https://developer.apple.com/library/archive/documentation/CoreBluetooth/Reference/AppleNotificationCenterServiceSpecification/Introduction/Introduction.html
+.. _`Apple Media Service Reference`: https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/AppleMediaService_Reference/Introduction/Introduction.html
+
 .. ### Source: other
 
 .. _`Developing Matter products with nRF Connect SDK`: https://www.youtube.com/watch?v=kdMJQFDRoss
@@ -807,10 +824,6 @@
 .. _`GCC compiler`: https://gcc.gnu.org/
 
 .. _`MCUboot`: https://www.mcuboot.com
-
-.. _`Apple Notification Center Service Specification`: https://developer.apple.com/library/archive/documentation/CoreBluetooth/Reference/AppleNotificationCenterServiceSpecification/Introduction/Introduction.html
-
-.. _`Apple Media Service Reference`: https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/AppleMediaService_Reference/Introduction/Introduction.html
 
 .. _`nRF Mesh mobile app for iOS`: https://apps.apple.com/us/app/nrf-mesh/id1380726771
 .. _`nRF Mesh mobile app for Android`: https://play.google.com/store/apps/details?id=no.nordicsemi.android.nrfmeshprovisioner

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -869,6 +869,7 @@ Documentation
   * :ref:`build_pgm_nrf9160` section in the :ref:`ug_nrf9160` documentation by adding |VSC| and command line instructions.
   * Restructured the :ref:`programming_thingy` and :ref:`connect_nRF_cloud` sections in the :ref:`ug_thingy91_gsg` documentation.
   * The instructions and images in the :ref:`ug_thingy91_gsg` and :ref:`ug_nrf9160_gs` documentations about also accepting :term:`eUICC Identifier (EID)` when activating your iBasis SIM card from the `nRF Cloud`_ website.
+  * :ref:`gs_recommended_versions` page with a new section about :ref:`gs_supported_OS`.
 
 * Removed:
 


### PR DESCRIPTION
NCSDK-15918
Add a supported OS section on the Requirements page
of the Getting started documentation.

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>