### PR TITLE
samples: matter: Added setting power for Thread devices that use FEM

### DIFF
--- a/samples/matter/common/src/thread_util.cpp
+++ b/samples/matter/common/src/thread_util.cpp
@@ -11,6 +11,11 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
+#include <openthread/platform/radio.h>
+#include <platform/OpenThread/OpenThreadUtils.h>
+#endif
+
 #include <zephyr/zephyr.h>
 
 void StartDefaultThreadNetwork(uint64_t datasetTimestamp)
@@ -43,3 +48,17 @@ void StartDefaultThreadNetwork(uint64_t datasetTimestamp)
 	chip::app::DnssdServer::Instance().StartServer();
 #endif
 }
+
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
+CHIP_ERROR SetDefaultThreadOutputPower()
+{
+	CHIP_ERROR err;
+	/* set output power when FEM is active */
+	chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
+	err = chip::DeviceLayer::Internal::MapOpenThreadError(
+		otPlatRadioSetTransmitPower(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance(),
+					    static_cast<int8_t>(CONFIG_OPENTHREAD_DEFAULT_TX_POWER)));
+	chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
+	return err;
+}
+#endif

--- a/samples/matter/common/src/thread_util.h
+++ b/samples/matter/common/src/thread_util.h
@@ -7,5 +7,10 @@
 #pragma once
 
 #include <cstdint>
+#include <core/CHIPError.h>
 
 void StartDefaultThreadNetwork(uint64_t datasetTimestamp = 0);
+
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
+CHIP_ERROR SetDefaultThreadOutputPower();
+#endif

--- a/samples/matter/light_bulb/Kconfig
+++ b/samples/matter/light_bulb/Kconfig
@@ -5,6 +5,25 @@
 #
 mainmenu "Matter nRF Connect Light Bulb Example Application"
 
+if MPSL_FEM
+
+config OPENTHREAD_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0
+# to set the output power to a similar value as for nRF52840DK.
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
+
+endif # MPSL_FEM
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -96,6 +96,14 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Cannot set default Thread output power");
+		return err;
+	}
+#endif
+
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
 	LEDWidget::SetStateUpdateCallback(LEDStateUpdateHandler);

--- a/samples/matter/light_switch/Kconfig
+++ b/samples/matter/light_switch/Kconfig
@@ -23,6 +23,25 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
+if MPSL_FEM
+
+config OPENTHREAD_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0
+# to set the output power to a similar value as for nRF52840DK.
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
+
+endif # MPSL_FEM
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -106,6 +106,14 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Cannot set default Thread output power");
+		return err;
+	}
+#endif
+
 	LightSwitch::GetInstance().Init(kLightSwitchEndpointId);
 
 	/* Initialize UI components */

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -14,6 +14,26 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
+if MPSL_FEM
+
+config OPENTHREAD_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0
+# to set the output power to a similar value as for nRF52840DK.
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
+
+endif # MPSL_FEM
+
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -97,6 +97,14 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Cannot set default Thread output power");
+		return err;
+	}
+#endif
+
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
 	LEDWidget::SetStateUpdateCallback(LEDStateUpdateHandler);

--- a/samples/matter/template/Kconfig
+++ b/samples/matter/template/Kconfig
@@ -5,6 +5,26 @@
 #
 mainmenu "Matter nRF Connect Template Example Application"
 
+if MPSL_FEM
+
+config OPENTHREAD_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0
+# to set the output power to a similar value as for nRF52840DK.
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
+
+endif # MPSL_FEM
+
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -6,6 +6,7 @@
 
 #include "app_task.h"
 #include "led_widget.h"
+#include "thread_util.h"
 
 #include <platform/CHIPDeviceLayer.h>
 
@@ -85,6 +86,14 @@ CHIP_ERROR AppTask::Init()
 		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
 		return err;
 	}
+
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Cannot set default Thread output power");
+		return err;
+	}
+#endif
 
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();

--- a/samples/matter/window_covering/Kconfig
+++ b/samples/matter/window_covering/Kconfig
@@ -14,6 +14,26 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
+if MPSL_FEM
+
+config OPENTHREAD_DEFAULT_TX_POWER
+	int "Set the default 802.15.4 output power (dBm) for device with FEM"
+	range -40 20
+	default 20
+	help
+	  Use this setting to set the default Thread (802.15.4) output power for device that
+	  uses FEM. This value has a unit in dBm and represents the Tx power at Antenna port of FEM device.
+
+# override FEM GAIN to 20 dB as a default
+# see subsys/mpsl/fem/Kconfig
+# Leave MPSL_FEM_NRF21540_TX_GAIN_DB unchanged when OPENTHREAD_DEFAULT_TX_POWER=0
+# to set the output power to a similar value as for nRF52840DK.
+config MPSL_FEM_NRF21540_TX_GAIN_DB
+	default 20 if OPENTHREAD_DEFAULT_TX_POWER != 0
+
+endif # MPSL_FEM
+
+
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.features"
 source "${ZEPHYR_BASE}/../modules/lib/matter/config/nrfconnect/chip-module/Kconfig.defaults"
 source "Kconfig.zephyr"

--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -9,6 +9,7 @@
 #include "app_event.h"
 #include "led_widget.h"
 #include "window_covering.h"
+#include "thread_util.h"
 
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -101,6 +102,14 @@ CHIP_ERROR AppTask::Init()
 		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
 		return err;
 	}
+
+#ifdef CONFIG_OPENTHREAD_DEFAULT_TX_POWER
+	err = SetDefaultThreadOutputPower();
+	if (err != CHIP_NO_ERROR) {
+		LOG_ERR("Cannot set default Thread output power");
+		return err;
+	}
+#endif
 
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();


### PR DESCRIPTION
After recent FEM changes, we needed to set the Thread output power to 20 dBm and FEM gain to 20 dB to restore the previous behavior of nRF21 within our samples.

Signed-off-by: Arkadiusz Balys <arkadiusz.balys@nordicsemi.no>