### PR TITLE
applications: asset_tracker_v2: Decouple nRF Cloud from the JSON common API

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/CMakeLists.txt
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/CMakeLists.txt
@@ -22,5 +22,7 @@ target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cloud_codec_ringbuffer.c)
 # Include JSON convenience APIs if used by the respective cloud codec backend.
 if (CONFIG_CLOUD_CODEC_AWS_IOT OR CONFIG_CLOUD_CODEC_AZURE_IOT_HUB OR CONFIG_CLOUD_CODEC_NRF_CLOUD)
         target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/json_helpers.c)
+endif()
+if (CONFIG_CLOUD_CODEC_AWS_IOT OR CONFIG_CLOUD_CODEC_AZURE_IOT_HUB)
         target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/json_common.c)
 endif()

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/json_protocol_names_nrf_cloud.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/json_protocol_names_nrf_cloud.h
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#define DATA_MOVEMENT	"acc"
-#define DATA_MOVEMENT_X	"x"
-#define DATA_MOVEMENT_Y	"y"
-#define DATA_MOVEMENT_Z	"z"
-
-#define DATA_GNSS	   "gnss"
 #define DATA_GNSS_LONGITUDE "lng"
 #define DATA_GNSS_LATITUDE  "lat"
 #define DATA_GNSS_ALTITUDE  "alt"
@@ -19,13 +13,6 @@
 
 #define DATA_MODEM_DYNAMIC  "networkInfo"
 #define DATA_MODEM_STATIC   "deviceInfo"
-#define DATA_BATTERY	    "batteryVoltage"
-#define DATA_TEMPERATURE    "temp"
-#define DATA_HUMIDITY	    "hum"
-#define DATA_PRESSURE       "atmp"
-#define DATA_BSEC_IAQ       "bsec_iaq"
-#define DATA_ENVIRONMENTALS "env"
-#define DATA_BUTTON	    "btn"
 #define DATA_CONFIG	    "config"
 #define DATA_VERSION	    "version"
 
@@ -33,7 +20,6 @@
 #define DATA_ID	       "appId"
 #define DATA_TYPE      "data"
 #define DATA_TIMESTAMP "ts"
-#define DATA_VALUE     "data"
 
 #define MESSAGE_TYPE_DATA "DATA"
 
@@ -61,18 +47,6 @@
 #define MODEM_IP_ADDRESS       "ipAddress"
 #define MODEM_IMEI             "imei"
 
-#define DATA_NEIGHBOR_CELLS_LTE           "lte"
-#define DATA_NEIGHBOR_CELLS_MCC		  "mcc"
-#define DATA_NEIGHBOR_CELLS_MNC		  "mnc"
-#define DATA_NEIGHBOR_CELLS_CID		  "eci"
-#define DATA_NEIGHBOR_CELLS_TAC		  "tac"
-#define DATA_NEIGHBOR_CELLS_EARFCN	  "earfcn"
-#define DATA_NEIGHBOR_CELLS_TIMING	  "adv"
-#define DATA_NEIGHBOR_CELLS_RSRP	  "rsrp"
-#define DATA_NEIGHBOR_CELLS_RSRQ	  "rsrq"
-#define DATA_NEIGHBOR_CELLS_NEIGHBOR_MEAS "nmr"
-#define DATA_NEIGHBOR_CELLS_PCI		  "pci"
-
 #define CONFIG_DEVICE_MODE		  "activeMode"
 #define CONFIG_ACTIVE_TIMEOUT		  "activeWaitTime"
 #define CONFIG_MOVE_TIMEOUT		  "movementTimeout"
@@ -83,34 +57,6 @@
 #define CONFIG_NO_DATA_LIST_GNSS	  "gnss"
 #define CONFIG_NO_DATA_LIST_NEIGHBOR_CELL "ncell"
 
-#define DATA_AGPS_REQUEST_MCC   "mcc"
-#define DATA_AGPS_REQUEST_MNC   "mnc"
-#define DATA_AGPS_REQUEST_CID   "cell"
-#define DATA_AGPS_REQUEST_TAC   "area"
-#define DATA_AGPS_REQUEST_TYPES "types"
-
-#define DATA_AGPS_REQUEST_TYPE_UTC_PARAMETERS		 1
-#define DATA_AGPS_REQUEST_TYPE_EPHEMERIDES		 2
-#define DATA_AGPS_REQUEST_TYPE_ALMANAC			 3
-#define DATA_AGPS_REQUEST_TYPE_KLOBUCHAR_CORRECTION	 4
-#define DATA_AGPS_REQUEST_TYPE_NEQUICK_CORRECTION	 5
-#define DATA_AGPS_REQUEST_TYPE_GPS_TOWS			 6
-#define DATA_AGPS_REQUEST_TYPE_GPS_SYSTEM_CLOCK_AND_TOWS 7
-#define DATA_AGPS_REQUEST_TYPE_LOCATION			 8
-#define DATA_AGPS_REQUEST_TYPE_INTEGRITY		 9
-
-#define DATA_PGPS_REQUEST_COUNT    "n"
-#define DATA_PGPS_REQUEST_INTERVAL "int"
-#define DATA_PGPS_REQUEST_DAY      "day"
-#define DATA_PGPS_REQUEST_TIME     "time"
-
 #define OBJECT_CONFIG	"config"
 #define OBJECT_REPORTED	"reported"
 #define OBJECT_STATE	"state"
-#define OBJECT_DATA	"data"
-#define OBJECT_DEVICE	"device"
-
-#define OBJECT_MSG_HUMID "MSG_HUMIDITY"
-#define OBJECT_MSG_TEMP	 "MSG_TEMPERATURE"
-#define OBJECT_MSG_GNSS	 "MSG_GNSS"
-#define OBJECT_MSG_RSRP	 "MSG_RSRP"


### PR DESCRIPTION
This patch removes the json_common dependency from the nrf cloud codec
by pulling in the few functions needed. Further, some simplifications
were applied and unused parts of the protocol names header were deleted.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>