### PR TITLE
caf: Add polichrom led glitches to know issue for NCS 2.0

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1130,6 +1130,18 @@ NCSDK-15675: Possible advertising start failure and module state error in :ref:`
 
   **Workaround:** Manually cherry-pick and apply commit with fix from main (commit hash: ``934a25ac23125758e350b64bca23885486682109``).
 
+.. rst-class:: v2-0-0
+
+NCSDK-15707: Visual glitches when updating an RGB LED's color in :ref:`caf_leds`
+  Due to changes in the default DTS of the boards, the default PWM period has been increased.
+  The first LED channel is updated one PWM period before other channels.
+  This causes visual glitches for LEDs with more than one color channel when the LED color is being updated.
+  A shorter LED PWM period mitigates the observed issue.
+  See :ref:`caf_leds` for more information.
+
+  **Workaround:** Make sure your application includes the devicetree overlay file in which PWM period is decreased.
+  For example, include the following commit to solve the issue for the :ref:`nrf_machine_learning_app` application for Nordic Thingy:53: ``fa2b57cddbaacf393c77def5d0302e1a45138d21``.
+
 Subsystems
 **********
 

--- a/doc/nrf/libraries/caf/leds.rst
+++ b/doc/nrf/libraries/caf/leds.rst
@@ -201,19 +201,19 @@ The following code snippets show examples of the DTS nodes:
 
 		pwm_led0: led_pwm_0 {
 			status = "okay";
-			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = <&pwm0 0 PWM_MSEC(1) PWM_POLARITY_INVERTED>;
 			label = "LED0 red";
 		};
 
 		pwm_led1: led_pwm_1 {
 			status = "okay";
-			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = <&pwm0 1 PWM_MSEC(1) PWM_POLARITY_INVERTED>;
 			label = "LED0 green";
 		};
 
 		pwm_led2: led_pwm_2 {
 			status = "okay";
-			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = <&pwm0 2 PWM_MSEC(1) PWM_POLARITY_INVERTED>;
 			label = "LED0 blue";
 		};
 	};
@@ -231,6 +231,12 @@ The following code snippets show examples of the DTS nodes:
 
   In this example, ``pwmleds0`` is a tri-channel color LED node, while ``pwmleds1`` is a monochromatic LED node.
   Both ``pwmleds`` nodes are pointing to the ``pwms`` properties corresponding to PWM nodes set in Example 2 in `Enabling the PWM ports`_, with the respective channel numbers.
+
+.. note::
+   Set the PWM period for the LED to a smaller value, such as 1 millisecond, to avoid glitches during tri-channel LED color updates.
+   Because of the limitations of Zephyr's :ref:`zephyr:pwm_api`, color channels are not updated simultaneously.
+   The first LED channel is updated one PWM period before other channels.
+   A short LED PWM period mitigates the glitches.
 
 Configuring GPIO LEDs
 ---------------------


### PR DESCRIPTION
Add polychromatic LED  glitches caused by change in pwm_period
 to know issue for NCS 2.0

Jira: NCSDK-15707

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@nordicsemi.no>