### PR TITLE
application: serial_lte_modem: BUG-FIX GNSS sleep/wakeup event

### DIFF
--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -129,9 +129,7 @@ Response syntax
 
 * ``0`` - GNSS is stopped.
 * ``1`` - GNSS is started.
-* ``2`` - GNSS wakes up in periodic mode.
-* ``3`` - GNSS enters sleep because of timeout.
-* ``4`` - GNSS enters sleep because a fix is achieved.
+* ``2`` - GNSS enters sleep because of timeout.
 
 Example
 ~~~~~~~
@@ -456,9 +454,7 @@ Response syntax
 
 * ``0`` - AGPS is stopped.
 * ``1`` - AGPS is started.
-* ``2`` - GNSS wakes up in periodic mode.
-* ``3`` - GNSS enters sleep because of timeout.
-* ``4`` - GNSS enters sleep because a fix is achieved.
+* ``2`` - GNSS enters sleep because of timeout.
 
 Example
 ~~~~~~~
@@ -627,9 +623,7 @@ Response syntax
 
 * ``0`` - PGPS is stopped.
 * ``1`` - PGPS is started.
-* ``2`` - GNSS wakes up in periodic mode.
-* ``3`` - GNSS enters sleep because of timeout.
-* ``4`` - GNSS enters sleep because a fix is achieved.
+* ``2`` - GNSS enters sleep because of timeout.
 
 Test command
 ------------

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -59,9 +59,7 @@ static enum {
 static enum {
 	RUN_STATUS_STOPPED,
 	RUN_STATUS_STARTED,
-	RUN_STATUS_PERIODIC_WAKEUP,
 	RUN_STATUS_SLEEP_AFTER_TIMEOUT,
-	RUN_STATUS_SLEEP_AFTER_FIX,
 	RUN_STATUS_MAX
 } run_status;
 
@@ -533,8 +531,10 @@ static void fix_rep_wk(struct k_work *work)
 			}
 		}
 		/* GGA,hhmmss.ss,llll.ll,a,yyyyy.yy,a,x,xx,x.x,x.x,M,x.x,M,x.x,xxxx \r\n */
-		sprintf(rsp_buf, "\r\n#XGPS: %s", nmea.nmea_str);
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		if (location_signify) {
+			sprintf(rsp_buf, "\r\n#XGPS: %s", nmea.nmea_str);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+		}
 	}
 
 	if (run_type == RUN_TYPE_PGPS) {
@@ -602,9 +602,7 @@ static void gnss_event_handler(int event)
 		LOG_INF("GNSS_EVT_UNBLOCKED");
 		break;
 	case NRF_MODEM_GNSS_EVT_PERIODIC_WAKEUP:
-		LOG_INF("GNSS_EVT_PERIODIC_WAKEUP");
-		run_status = RUN_STATUS_PERIODIC_WAKEUP;
-		gnss_status_notify();
+		LOG_DBG("GNSS_EVT_PERIODIC_WAKEUP");
 		break;
 	case NRF_MODEM_GNSS_EVT_SLEEP_AFTER_TIMEOUT:
 		LOG_INF("GNSS_EVT_SLEEP_AFTER_TIMEOUT");
@@ -612,9 +610,7 @@ static void gnss_event_handler(int event)
 		gnss_status_notify();
 		break;
 	case NRF_MODEM_GNSS_EVT_SLEEP_AFTER_FIX:
-		LOG_INF("GNSS_EVT_SLEEP_AFTER_FIX");
-		run_status = RUN_STATUS_SLEEP_AFTER_FIX;
-		gnss_status_notify();
+		LOG_DBG("GNSS_EVT_SLEEP_AFTER_FIX");
 		break;
 	case NRF_MODEM_GNSS_EVT_REF_ALT_EXPIRED:
 		LOG_INF("GNSS_EVT_REF_ALT_EXPIRED");

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -120,7 +120,7 @@ nRF9160: Serial LTE modem
 
   * Added:
 
-    * URC for GNSS sleep and wakeup events.
+    * URC for GNSS timeout sleep event.
     * Selected flags support in #XRECV and #XRECVFROM commands.
     * Multi-PDN support in the Socket service.
     * The GNSS service now signifies location info to nRF Cloud.


### PR DESCRIPTION
The URC added in PR#7980 has caused problem in fix URC.
SLM use shared URC buffer that could lead to overwriting.
Adjust the sleep/wakeup URCs as below:
 MODEM_GNSS_EVT_PERIODIC_WAKEUP: normal behavior, remove
 MODEM_GNSS_EVT_SLEEP_AFTER_TIMEOUT: abnormal behavior, keep
 MODEM_GNSS_EVT_SLEEP_AFTER_FIX: normal behavior, remove

Also update PR#8116 a bit, that the $GPGGA NMEA URC is sent
only when `<signify>` is true.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>