### PR TITLE
doc: nrf5340_audio: Change documentation to fit BAP implementation

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -449,7 +449,7 @@
 .. ### Source: bluetooth.org and bluetooth.com
 
 .. _`Bluetooth Core Specification`: https://www.bluetooth.com/specifications/specs/
-.. _`Bluetooth LE Audio specifications`: https://www.bluetooth.com/learn-about-bluetooth/recent-enhancements/le-audio/le-audio-specifications/
+.. _`Bluetooth® LE Audio specifications`: https://www.bluetooth.com/learn-about-bluetooth/recent-enhancements/le-audio/le-audio-specifications/
 
 .. _`HID Service Specification`: https://www.bluetooth.org/docman/handlers/downloaddoc.ashx?doc_id=245140
 .. _`Battery Service Specification`: https://www.bluetooth.org/docman/handlers/downloaddoc.ashx?doc_id=245138


### PR DESCRIPTION
Several aspects are changed when the application
is transitioned over to using Basic Audio Profile.

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>