### PR TITLE
manifest: openthread update with MTD DUA fix

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -69,7 +69,7 @@ The following list summarizes the most important changes inherited from the upst
 Thread
 ------
 
-|no_changes_yet_note|
+* Fixed a bug in which a Minimal Thread Device was not able to handle Address Error Notification messages.
 
 See `Thread samples`_ for the list of changes for the Thread samples.
 

--- a/west.yml
+++ b/west.yml
@@ -86,7 +86,6 @@ manifest:
           - net-tools
           - nrf_hw_models
           - open-amp
-          - openthread
           - psa-arch-tests
           - segger
           - tinycbor
@@ -177,6 +176,10 @@ manifest:
       revision: 9f6b3812237fbb0d4157ba3584c13f1644fcbe3a
       groups:
       - nrf5340_audio
+    - name: openthread
+      repo-path: sdk-openthread
+      path: modules/lib/openthread
+      revision: b6126a143ef1e1b68d1c86c321fae7668e6d5bf5
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
Update manifest with newer OpenThread revision fixing handling of
ADDR_ERR.ntf in MTD builds.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>

KRKNWK-14607