### PR TITLE
application: serial_lte_modem: Support GNSS data delete

### DIFF
--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -91,7 +91,7 @@ Example
   AT+CFUN=31
 
   OK
-  at#xgps=1,1
+  AT#XGPS=1,1
 
   #XGPS: 1,1
 
@@ -129,7 +129,9 @@ Response syntax
 
 * ``0`` - GNSS is stopped.
 * ``1`` - GNSS is started.
-* ``2`` - GNSS enters sleep because of timeout.
+* ``2`` - GNSS wakes up in periodic mode.
+* ``3`` - GNSS enters sleep because of timeout.
+* ``4`` - GNSS enters sleep because a fix is achieved.
 
 Example
 ~~~~~~~
@@ -454,7 +456,9 @@ Response syntax
 
 * ``0`` - AGPS is stopped.
 * ``1`` - AGPS is started.
-* ``2`` - GNSS enters sleep because of timeout.
+* ``2`` - GNSS wakes up in periodic mode.
+* ``3`` - GNSS enters sleep because of timeout.
+* ``4`` - GNSS enters sleep because a fix is achieved.
 
 Example
 ~~~~~~~
@@ -623,7 +627,9 @@ Response syntax
 
 * ``0`` - PGPS is stopped.
 * ``1`` - PGPS is started.
-* ``2`` - GNSS enters sleep because of timeout.
+* ``2`` - GNSS wakes up in periodic mode.
+* ``3`` - GNSS enters sleep because of timeout.
+* ``4`` - GNSS enters sleep because a fix is achieved.
 
 Test command
 ------------
@@ -645,6 +651,79 @@ Example
   AT#XPGPS=?
 
   #XPGPS: (0,1),<interval>,<timeout>
+
+  OK
+
+Delete GNSS data
+================
+
+The ``#XGPSDEL`` command deletes GNSS data from non-volatile memory.
+This command should be issued when GNSS is activated but not started yet.
+
+Set command
+-----------
+
+The set command allows you to delete old GNSS data.
+
+Syntax
+~~~~~~
+
+::
+
+   #XGPSDEL=<mask>
+
+The ``<mask>`` parameter accepts an integer that is the ``OR`` value of the following bitmasks :
+
+* ``0x001`` - Ephemerides
+* ``0x002`` - Almanacs (excluding leap second and ionospheric correction)
+* ``0x004`` - Ionospheric correction parameters
+* ``0x008`` - Last good fix (the last position)
+* ``0x010`` - GPS time-of-week (TOW)
+* ``0x020`` - GPS week number
+* ``0x040`` - Leap second (UTC parameters)
+* ``0x080`` - Local clock (TCXO) frequency offset
+* ``0x100`` - Precision estimate of GPS time-of-week (TOW)
+* ``511`` - All of the above
+
+Example
+~~~~~~~
+
+::
+
+  AT%XSYSTEMMODE=0,0,1,0
+  OK
+  AT+CFUN=31
+  OK
+  AT#XGPSDEL=511
+  OK
+  AT+CFUN=0
+  OK
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command tests the existence of the command and provides information about the type of its subparameters.
+
+Syntax
+~~~~~~
+
+::
+
+   #XGPSDEL=?
+
+Example
+~~~~~~~
+
+::
+
+  AT#XGPSDEL=?
+
+  #XGPSDEL: <mask>
 
   OK
 

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -412,6 +412,7 @@ int handle_at_gps(enum at_cmd_type cmd_type);
 int handle_at_nrf_cloud(enum at_cmd_type cmd_type);
 int handle_at_agps(enum at_cmd_type cmd_type);
 int handle_at_pgps(enum at_cmd_type cmd_type);
+int handle_at_gps_delete(enum at_cmd_type cmd_type);
 int handle_at_cellpos(enum at_cmd_type cmd_type);
 #endif
 
@@ -513,6 +514,7 @@ static struct slm_at_cmd {
 #if defined(CONFIG_SLM_PGPS)
 	{"AT#XPGPS", handle_at_pgps},
 #endif
+	{"AT#XGPSDEL", handle_at_gps_delete},
 #if defined(CONFIG_SLM_CELL_POS)
 	{"AT#XCELLPOS", handle_at_cellpos},
 #endif

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -124,6 +124,7 @@ nRF9160: Serial LTE modem
     * Selected flags support in #XRECV and #XRECVFROM commands.
     * Multi-PDN support in the Socket service.
     * The GNSS service now signifies location info to nRF Cloud.
+    * New #XGPSDEL command to delete GNSS data from non-volatile memory.
 
   * Updated:
 


### PR DESCRIPTION
Add #XGPSDEL to delete GNSS data from non-volatile memory.
This can for instance be used to trigger cold or warm starts.

Other minor updates
.Restore status code for periodical wakeup and sleep
.Restore URC for downlink nRF Cloud data
.Remove redundant nrf_cloud_initd global flag
.Logging improvemnt

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>