### PR TITLE
bluetooth: fast_pair: Depend on system workq priority in fp_keys

### DIFF
--- a/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
+++ b/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
@@ -41,6 +41,7 @@ config BT_DIS_FW_REV_STR
 config BT_FAST_PAIR_KEYS
 	bool
 	default y
+	depends on SYSTEM_WORKQUEUE_PRIORITY < 0
 	help
 	  Add Fast Pair key handling source files.
 

--- a/subsys/bluetooth/services/fast_pair/fp_keys.c
+++ b/subsys/bluetooth/services/fast_pair/fp_keys.c
@@ -59,7 +59,7 @@ static void invalidate_key(struct fp_procedure *proc)
 	if (proc->state != FP_STATE_INITIAL) {
 		proc->state = FP_STATE_INITIAL;
 		memset(proc->aes_key, EMPTY_AES_KEY_BYTE, sizeof(proc->aes_key));
-		k_work_cancel_delayable(&proc->timeout);
+		(void)k_work_cancel_delayable(&proc->timeout);
 	}
 }
 
@@ -240,7 +240,7 @@ int fp_keys_generate_key(const struct bt_conn *conn, struct fp_keys_keygen_param
 	} else {
 		key_gen_failure_cnt = 0;
 		if (proc->state == FP_STATE_USE_TEMP_KEY) {
-			k_work_reschedule(&proc->timeout, FP_KEY_TIMEOUT);
+			(void)k_work_reschedule(&proc->timeout, FP_KEY_TIMEOUT);
 		}
 	}
 
@@ -279,7 +279,7 @@ void fp_keys_bt_auth_progress(const struct bt_conn *conn, bool authenticated)
 	struct fp_procedure *proc = &fp_procedures[bt_conn_index(conn)];
 
 	if (proc->state == FP_STATE_USE_TEMP_KEY) {
-		k_work_reschedule(&proc->timeout, FP_KEY_TIMEOUT);
+		(void)k_work_reschedule(&proc->timeout, FP_KEY_TIMEOUT);
 		if (authenticated) {
 			proc->state = FP_STATE_WAIT_FOR_ACCOUNT_KEY;
 		}


### PR DESCRIPTION
Change adds explicit dependency on system workqueue priority to fp_keys implementation. The implementation assumes that workqueue would not be preempted.