### PR TITLE
KRKNWK-14615: Fix coverity issue in PHY Test Tool

### DIFF
--- a/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_cmd_mode_uart.c
+++ b/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_cmd_mode_uart.c
@@ -1454,7 +1454,7 @@ static enum ptt_ret cmd_uart_l_set_payload(void)
 				/* lets be sure that there are no extra parameters */
 				ret = PTT_RET_INVALID_VALUE;
 			} else {
-				uint8_t actual_len;
+				uint8_t actual_len = 0;
 
 				ret = ptt_parser_hex_string_to_uint8_array(
 					token_str, payload, PTT_CUSTOM_LTX_PAYLOAD_MAX_SIZE,


### PR DESCRIPTION
Fixed uninitialized variable the same way it was done in
cmd_uart_l_set_extended_address.

Signed-off-by: Piotr Sławęcki <piotr.slawecki@nordicsemi.no>