### PR TITLE
lib: nrf_modem: trace:  fix assert on apply_state for uart1 pinctrl.

### DIFF
--- a/lib/nrf_modem_lib/trace_backends/uart/uart.c
+++ b/lib/nrf_modem_lib/trace_backends/uart/uart.c
@@ -85,12 +85,14 @@ int trace_backend_init(void)
 
 int trace_backend_deinit(void)
 {
-	int err;
-
 	nrfx_uarte_uninit(&uarte_inst);
+
+#if CONFIG_PM_DEVICE
+	int err;
 
 	err = pinctrl_apply_state(PINCTRL_DT_DEV_CONFIG_GET(UART1_NL), PINCTRL_STATE_SLEEP);
 	__ASSERT_NO_MSG(err == 0);
+#endif /* CONFIG_PM_DEVICE */
 
 	return 0;
 }

--- a/lib/nrf_modem_lib/trace_backends/uart/uart_sync.c
+++ b/lib/nrf_modem_lib/trace_backends/uart/uart_sync.c
@@ -42,12 +42,14 @@ int trace_backend_init(void)
 
 int trace_backend_deinit(void)
 {
-	int err;
-
 	nrfx_uarte_uninit(&uarte_inst);
+
+#if CONFIG_PM_DEVICE
+	int err;
 
 	err = pinctrl_apply_state(PINCTRL_DT_DEV_CONFIG_GET(UART1_NL), PINCTRL_STATE_SLEEP);
 	__ASSERT_NO_MSG(err == 0);
+#endif /* CONFIG_PM_DEVICE */
 
 	return 0;
 }

--- a/tests/lib/nrf_modem_lib/trace_backends/uart/prj.conf
+++ b/tests/lib/nrf_modem_lib/trace_backends/uart/prj.conf
@@ -13,3 +13,5 @@ CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART=y
 # CONFIG_UART_STELLARIS_PORT_0 is not disabled because that is needed for console output.
 CONFIG_UART_STELLARIS_PORT_1=n
 CONFIG_UART_STELLARIS_PORT_2=n
+# Enable PM_DEVICE to have pinctrl called on deinit
+CONFIG_PM_DEVICE=y


### PR DESCRIPTION
Setting pincontrol sleep mode is only allowed when CONFIG_PM_DEVICE is
set. We skip it unless the application has set CONFIG_PM_DEVICE.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>