### PR TITLE
doc: add link to updating repo to rel notes

### DIFF
--- a/doc/nrf/gs_updating.rst
+++ b/doc/nrf/gs_updating.rst
@@ -58,6 +58,8 @@ Running ``west update`` updates the project repositories to the state specified 
    :start-after: west-error-start
    :end-before: west-error-end
 
+.. _gs_updating_repos_examples:
+
 Examples of commands
 ====================
 

--- a/doc/nrf/releases/release-notes-2.0.1.rst
+++ b/doc/nrf/releases/release-notes-2.0.1.rst
@@ -31,7 +31,7 @@ The release tag for the |NCS| manifest repository (|ncs_repo|) is **v2.0.1**.
 Check the :file:`west.yml` file for the corresponding tags in the project repositories.
 
 To use this release, check out the tag in the manifest repository and run ``west update``.
-See :ref:`cloning_the_repositories` for more information.
+See :ref:`cloning_the_repositories` and :ref:`gs_updating_repos_examples` for more information.
 
 For information on the included repositories and revisions, see `Repositories and revisions for v2.0.1`_.
 


### PR DESCRIPTION
Added link to gs_updating in the release tag section of rel notes.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>