### PR TITLE
samples: matter: Fixed emitting leave event at the factory reset

### DIFF
--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -265,7 +265,8 @@ void AppTask::FunctionTimerEventHandler(AppEvent *aEvent)
 	} else if (Instance().mFunctionTimerActive && Instance().mMode == OperatingMode::FactoryReset) {
 		/* Actually trigger Factory Reset */
 		Instance().mMode = OperatingMode::Normal;
-		ConfigurationMgr().InitiateFactoryReset();
+		LOG_INF("Factory Reset triggered");
+		chip::Server::GetInstance().ScheduleFactoryReset();
 	}
 }
 


### PR DESCRIPTION
The leave event was not sent after the factory reset trigger.
The solution is to use a chip server instance to schedule
the Factory Reset instead of the Configuration Manager.
