### PR TITLE
manifest: Point to nrfxlib with ecdh legacy off

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1630,6 +1630,11 @@ nrfxlib
 Crypto
 ======
 
+.. rst-class:: v2-0-1 v2-0-0
+
+NCSDK-15697: ECDH key generation for Curve25519 is failing with the legacy Mbed TLS APIs for CryptoCell
+  This only affects the functions ``mbedtls_ecdh_make_params_edwards`` and ``mbedtls_ecdh_read_params_edwards``.
+
 .. rst-class:: v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0
 
 NCSDK-13843: Limited support for MAC in PSA Crypto APIs

--- a/west.yml
+++ b/west.yml
@@ -113,7 +113,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 3c31ad3aef3666de47f9ac3751ac2ce23f254a55
+      revision: 87dc83fc9c7680a4f0db7f5f271a7893abe9c327
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
-This nrfxlib removes the ECDH_LEGACY_CONTEXT
 configuration since it is not actually used
 in the build and it is frustrating.

Ref: NCSDK-15697

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
