### PR TITLE
lte_lc: Implement support for AT%REDMOB

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -425,6 +425,18 @@ enum lte_lc_ce_level {
 	LTE_LC_CE_LEVEL_UNKNOWN			= UINT8_MAX,
 };
 
+/** @brief Reduced mobility mode */
+enum lte_lc_reduced_mobility_mode {
+	/** Functionality according to the 3GPP relaxed monitoring feature. */
+	LTE_LC_REDUCED_MOBILITY_DEFAULT = 0,
+	/** Enable Nordic-proprietary reduced mobility feature. */
+	LTE_LC_REDUCED_MOBILITY_NORDIC = 1,
+	/** Full measurements for best possible mobility. Disable the 3GPP relaxed
+	 *  monitoring and Nordic-proprietary reduced mobility features.
+	 */
+	LTE_LC_REDUCED_MOBILITY_DISABLED = 2,
+};
+
 /** @brief Modem domain events. */
 enum lte_lc_modem_evt {
 	/** Indicates that a light search has been performed. This event gives the
@@ -1189,6 +1201,33 @@ int lte_lc_periodic_search_clear(void);
  * @retval -EFAULT if an AT command could not be sent to the modem.
  */
 int lte_lc_periodic_search_request(void);
+
+/** @brief Read the current reduced mobility mode.
+ *
+ *  @note This feature is supported for nRF9160 modem firmware v1.3.2 and later
+ *	  versions. Attempting to use this API with older modem versions will
+ *	  result in an error being returned.
+ *
+ * @param[out] mode pointer to where the current reduced mobility mode should be written to
+ *
+ * @retval 0 if a mode was found and written to the provided pointer.
+ * @retval -EINVAL if input parameter was NULL.
+ * @retval -EFAULT if an AT command failed.
+ */
+int lte_lc_reduced_mobility_get(enum lte_lc_reduced_mobility_mode *mode);
+
+/** @brief Set reduced mobility mode.
+ *
+ *  @note This feature is supported for nRF9160 modem firmware v1.3.2 and later
+ *	  versions. Attempting to use this API with older modem versions will
+ *	  result in an error being returned.
+ *
+ * @param[in] mode new reduced mobility mode
+ *
+ * @retval 0 if the new reduced mobility mode was accepted by the modem.
+ * @retval -EFAULT if an AT command failed.
+ */
+int lte_lc_reduced_mobility_set(enum lte_lc_reduced_mobility_mode mode);
 
 /** @} */
 

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1676,6 +1676,39 @@ int lte_lc_periodic_search_get(struct lte_lc_periodic_search_cfg *const cfg)
 	return 0;
 }
 
+int lte_lc_reduced_mobility_get(enum lte_lc_reduced_mobility_mode *mode)
+{
+	int ret;
+	uint16_t mode_tmp;
+
+	if (mode == NULL) {
+		return -EINVAL;
+	}
+
+	ret = nrf_modem_at_scanf("AT%REDMOB?", "%%REDMOB: %hu", &mode_tmp);
+	if (ret != 1) {
+		LOG_ERR("AT command failed, nrf_modem_at_scanf() returned error: %d", ret);
+		return -EFAULT;
+	}
+
+	*mode = mode_tmp;
+
+	return 0;
+}
+
+int lte_lc_reduced_mobility_set(enum lte_lc_reduced_mobility_mode mode)
+{
+	int ret = nrf_modem_at_printf("AT%%REDMOB=%d", mode);
+
+	if (ret) {
+		/* Failure to send the AT command. */
+		LOG_ERR("AT command failed, returned error code: %d", ret);
+		return -EFAULT;
+	}
+
+	return 0;
+}
+
 #if defined(CONFIG_LTE_AUTO_INIT_AND_CONNECT)
 SYS_INIT(init_and_connect,
 		  APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/samples/nrf9160/modem_shell/src/link/link.h
+++ b/samples/nrf9160/modem_shell/src/link/link.h
@@ -17,6 +17,7 @@ enum link_ncellmeas_modes {
 #define LINK_APN_STR_MAX_LENGTH 100
 
 #define LINK_FUNMODE_NONE 99
+#define LINK_REDMOB_NONE 99
 
 void link_init(void);
 void link_ind_handler(const struct lte_lc_evt *const evt);

--- a/samples/nrf9160/modem_shell/src/link/link_shell_print.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_print.c
@@ -109,6 +109,18 @@ const char *link_shell_funmode_to_string(int funmode, char *out_str_buff)
 	return link_shell_map_to_string(mapping_table, funmode, out_str_buff);
 }
 
+const char *link_shell_redmob_mode_to_string(int funmode, char *out_str_buff)
+{
+	struct mapping_tbl_item const mapping_table[] = {
+		{ LTE_LC_REDUCED_MOBILITY_DEFAULT, "default" },
+		{ LTE_LC_REDUCED_MOBILITY_NORDIC, "nordic" },
+		{ LTE_LC_REDUCED_MOBILITY_DISABLED, "disabled" },
+		{ -1, NULL }
+	};
+
+	return link_shell_map_to_string(mapping_table, funmode, out_str_buff);
+}
+
 const char *link_shell_sysmode_to_string(int sysmode, char *out_str_buff)
 {
 	struct mapping_tbl_item const mapping_table[] = {

--- a/samples/nrf9160/modem_shell/src/link/link_shell_print.h
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_print.h
@@ -24,5 +24,6 @@ const char *link_shell_sysmode_preferred_to_string(int sysmode_preference, char 
 const char *link_shell_sysmode_currently_active_to_string(int actmode, char *out_str_buff);
 const char *link_shell_map_to_string(struct mapping_tbl_item const *mapping_table,
 				      int mode, char *out_str_buff);
+const char *link_shell_redmob_mode_to_string(int funmode, char *out_str_buff);
 
 #endif /* MOSH_LINK_SHELL_PRINT_H */


### PR DESCRIPTION
This patch adds lte_lc_reduced_mobility_{get,set} functions
and a corresponding "link redmob" command to support
the reduced mobility feature.

It addresses CIA-603.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>