### PR TITLE
Amend nRF7002 DK definition

### DIFF
--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -228,6 +228,11 @@ arduino_spi: &spi4 {
 	};
 };
 
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+};
+
 / {
 
 	reserved-memory {

--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -86,6 +86,14 @@
 				 <5 &adc 5>;	/* A5 = P0.26 = AIN5 */
 	};
 
+	gpio_fwd: nrf-gpio-forwarder {
+		compatible = "nordic,nrf-gpio-forwarder";
+		status = "okay";
+		uart {
+			gpios = <&gpio1 1 0>, <&gpio1 0 0>, <&gpio1 5 0>, <&gpio1 4 0>;
+		};
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;

--- a/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpuapp.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpuapp.dts
@@ -21,8 +21,3 @@
 		zephyr,sram-non-secure-partition = &sram0_ns;
 	};
 };
-
-zephyr_udc0: &usbd {
-	compatible = "nordic,nrf-usbd";
-	status = "okay";
-};

--- a/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpuapp_ns.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpuapp_ns.dts
@@ -18,8 +18,3 @@
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 };
-
-zephyr_udc0: &usbd {
-	compatible = "nordic,nrf-usbd";
-	status = "okay";
-};

--- a/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet-pinctrl.dtsi
+++ b/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet-pinctrl.dtsi
@@ -2,11 +2,11 @@
 	uart0_default: uart0_default {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
-				<NRF_PSEL(UART_RTS, 0, 11)>;
+				<NRF_PSEL(UART_RTS, 1, 5)>;
 		};
 		group2 {
 			psels = <NRF_PSEL(UART_RX, 1, 0)>,
-				<NRF_PSEL(UART_CTS, 0, 10)>;
+				<NRF_PSEL(UART_CTS, 1, 4)>;
 			bias-pull-up;
 		};
 	};
@@ -15,8 +15,8 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
 				<NRF_PSEL(UART_RX, 1, 0)>,
-				<NRF_PSEL(UART_RTS, 0, 11)>,
-				<NRF_PSEL(UART_CTS, 0, 10)>;
+				<NRF_PSEL(UART_RTS, 1, 5)>,
+				<NRF_PSEL(UART_CTS, 1, 4)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
*boards: nrf7002dk_nrf5340: Fix assignment of cpunet UART pins*

According to the nRF7002 DK schematic (and also to the silkscreen
on the board itself), UART_1 uses pins P1.05/P1.04 for RTS/CTS,
not P0.11/P0.10 as in nRF5340 DK.

*boards: nrf7002dk_nrf5340: Add nrf-gpio-forwarder node*

.. and specify there pins to be assigned to the Network core
so that uart0 on that core can be used.

*boards: nrf7002dk_nrf5340: Move usbd node overlay to common cpuapp dts*

For consistency with other boards with the nRF5340 SoC, overlay
the usbd node in the common cpuapp dts file instead of in separate
files for secure and non-secure targets.