### PR TITLE
doc: fixes to tool name formatting and spelling

### DIFF
--- a/doc/nrf/ug_fw_update.rst
+++ b/doc/nrf/ug_fw_update.rst
@@ -222,7 +222,7 @@ You can test that the bootloader no longer boots images signed with the earlier 
       CONFIG_SB_SIGNING_KEY_FILE="/path/to/priv_b.pem"
       CONFIG_FW_INFO_FIRMWARE_VERSION=3
 
-#. To facilitate testing, you can use ``nrfjprog`` to program this image directly into a slot:
+#. To facilitate testing, you can use nrfjprog to program this image directly into a slot:
 
    .. code-block:: console
 

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -197,7 +197,7 @@ For example, to change the ``VARIABLEONE`` variable for the ``childimageone`` ch
 You can extend the CMake command used to create the child images by adding flags to the CMake variable ``EXTRA_MULTI_IMAGE_CMAKE_ARGS``.
 For example, add ``--trace-expand`` to that variable to output more debug information.
 
-With ``west``, you can pass these configuration variables into CMake by using the ``--`` separator:
+With west, you can pass these configuration variables into CMake by using the ``--`` separator:
 
 .. code-block:: console
 
@@ -344,7 +344,7 @@ Unlike CMake options, CMake environment variables allow you to control the build
 
 You can use the CMake environment variables `VERBOSE`_ and `CMAKE_BUILD_PARALLEL_LEVEL`_ to control the verbosity and the number of parallel jobs for a build:
 
-When using the command line or |VSC| terminal window, you must set them before invoking ``west``.
+When using the command line or |VSC| terminal window, you must set them before invoking west.
 They apply to both the parent and child images.
 For example, to build with verbose output and one parallel job, use the following command, where *build_target* is the target for the development kit for which you are building:
 

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -132,7 +132,7 @@ The table below shows the different types of build files that are generated and 
 +--------------+----------------------------------------+----------------------------------------------------------------+
 |app_signed.hex| MCUboot compatible image, HEX format   | Using the built-in bootloader and nRF Connect Programmer       |
 +--------------+----------------------------------------+----------------------------------------------------------------+
-|app_update.bin| MCUboot compatible image, binary format|* Using the built-in bootloader and ``mcumgr`` command line tool|
+|app_update.bin| MCUboot compatible image, binary format|* Using the built-in bootloader and mcumgr command line tool    |
 |              |                                        |* For FOTA updates                                              |
 +--------------+----------------------------------------+----------------------------------------------------------------+
 

--- a/doc/nrf/ug_zigbee_configuring_zboss_traces.rst
+++ b/doc/nrf/ug_zigbee_configuring_zboss_traces.rst
@@ -33,7 +33,7 @@ To collect and view the log files, you will need the following:
 
 * Correct COM port.
 
-   * For traces using the UART, the JLink COM port is used. The development kit is assigned to a COM port (Windows) or a ttyACM device (Linux), which is visible in the system's :guilabel:`Device Manager`.
+   * For traces using the UART, the J-Link COM port is used. The development kit is assigned to a COM port (Windows) or a ttyACM device (Linux), which is visible in the system's :guilabel:`Device Manager`.
 
    * For traces using USB, a virtual COM port (a serial port emulated over USB) is used. You can set :kconfig:option:`CONFIG_USB_DEVICE_PRODUCT` to help identify the COM port in the system's :guilabel:`Device Manager`.
 
@@ -102,7 +102,7 @@ To configure trace logs using the UART, complete the following steps:
 #. Optionally, configure which UART device you want to use with the Kconfig option :kconfig:option:`CONFIG_ZBOSS_TRACE_LOGGER_DEVICE_NAME`.
    The default ``UART_1`` will be used if no other UART device is configured.
 
-#. Configure the UART device that you want to use to be connected to the onboard JLink instead of ``UART_0``, by extending the DTS overlay file for the selected board with the following:
+#. Configure the UART device that you want to use to be connected to the onboard J-Link instead of ``UART_0``, by extending the DTS overlay file for the selected board with the following:
 
    .. code-block:: devicetree
 
@@ -155,8 +155,8 @@ To configure trace logs using the UART, complete the following steps:
       };
 
    .. note::
-      By connecting the UART device to the on-board JLink, trace logs can be read directly from the JLink COM port.
-      As a consequence, the UART device used by the logger is disconnected and application logs cannot be accessed from the JLink COM port.
+      By connecting the UART device to the on-board J-Link, trace logs can be read directly from the J-Link COM port.
+      As a consequence, the UART device used by the logger is disconnected and application logs cannot be accessed from the J-Link COM port.
 
 
 Optional: Increasing the UART throughput
@@ -202,8 +202,8 @@ Trace logs using native USB
 ===========================
 
 Trace logs can also be configured to use a native USB.
-This is useful because trace logs will be printed through a separate virtual COM port so that the console logs can still be read through the JLink COM port.
-For applications that relay on the UART connection through the JLink COM port, for example the Network co-processor (NCP) sample, trace logs can only be configured through USB (COM port emulated over USB).
+This is useful because trace logs will be printed through a separate virtual COM port so that the console logs can still be read through the J-Link COM port.
+For applications that relay on the UART connection through the J-Link COM port, for example the Network co-processor (NCP) sample, trace logs can only be configured through USB (COM port emulated over USB).
 See the :ref:`Zigbee NCP <zigbee_ncp_sample>` sample page for how to configure trace logs for USB in this case.
 
 .. note::


### PR DESCRIPTION
Some of the command-line tool names were wrongly
formatted (between double backticks). Fixed now.

Also fixed a few misspellings of J-link (not Jlink).

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>