### PR TITLE
hostap: pull changes to support IPv6-only build

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: bf7be5627d2fa528bd61ce1ff10d89828a4d4697
+      revision: pull/8/head
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 6097de22bd1f1b499e599bfef618a235de7073b2


### PR DESCRIPTION
Make it possible to build a Wi-Fi project with IPv6 only.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>