### PR TITLE
bluetooth: SDC: Only fetch events when there's no data left to fetch

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -386,10 +386,12 @@ void hci_driver_receive_process(void)
 	bool received_evt = false;
 	bool received_data = false;
 
-	received_evt = fetch_and_process_hci_evt(&hci_buf[0]);
-
 	if (IS_ENABLED(CONFIG_BT_CONN)) {
 		received_data = fetch_and_process_acl_data(&hci_buf[0]);
+	}
+
+	if (!received_data) {
+		received_evt = fetch_and_process_hci_evt(&hci_buf[0]);
 	}
 
 	if (received_evt || received_data) {


### PR DESCRIPTION
This is done so that SDC links aren't disconnected while data is still 
pending.

Signed-off-by: Olivier Lesage <olivier.lesage@nordicsemi.no>