### PR TITLE
applications: connectivity_bridge: uart rx timeout and assert fix

### DIFF
--- a/applications/connectivity_bridge/src/disk/config.c
+++ b/applications/connectivity_bridge/src/disk/config.c
@@ -453,6 +453,8 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		if (check_state(event, MODULE_ID(main), MODULE_STATE_READY)) {
 			settings_init();
 		}
+
+		return false;
 	}
 
 	/* If event is unhandled, unsubscribe. */

--- a/applications/connectivity_bridge/src/modules/uart_handler.c
+++ b/applications/connectivity_bridge/src/modules/uart_handler.c
@@ -31,7 +31,7 @@ static const struct device *devices[] = {
 #define UART_SLAB_BLOCK_SIZE sizeof(struct uart_rx_buf)
 #define UART_SLAB_BLOCK_COUNT (UART_DEVICE_COUNT * CONFIG_BRIDGE_UART_BUF_COUNT)
 #define UART_SLAB_ALIGNMENT 4
-#define UART_RX_TIMEOUT_MS 1
+#define UART_RX_TIMEOUT_USEC 1000
 
 #if defined(CONFIG_PM_DEVICE)
 #define UART_SET_PM_STATE true
@@ -259,7 +259,7 @@ static void enable_uart_rx(uint8_t dev_idx)
 		return;
 	}
 
-	err = uart_rx_enable(dev, buf->buf, sizeof(buf->buf), UART_RX_TIMEOUT_MS);
+	err = uart_rx_enable(dev, buf->buf, sizeof(buf->buf), UART_RX_TIMEOUT_USEC);
 	if (err) {
 		uart_rx_buf_unref(buf);
 		LOG_ERR("uart_rx_enable: %d", err);

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -171,6 +171,14 @@ Thingy:53 Zigbee weather station
 
 |no_changes_yet_note|
 
+Connectivity Bridge
+-------------------
+
+  * Fixed:
+
+    * Missing return statement that caused immediate asserts when asserts were enabled.
+    * Too low UART RX timeout that caused high level of fragmentation of UART RX data.
+
 Samples
 =======
 


### PR DESCRIPTION
Adapt timeout value to match updated uart_rx_enable function.
Add missing return value in event handler to avoid unhandled
message assert.

Signed-off-by: Audun Korneliussen <audun.korneliussen@nordicsemi.no>