### PR TITLE
scripts: add modemlib typedef for compliance

### DIFF
--- a/scripts/checkpatch/typedefsfile
+++ b/scripts/checkpatch/typedefsfile
@@ -13,3 +13,4 @@ zb_uint64_t
 zb_time_t
 zb_ieee_addr_t
 zb_ret_t
+nrf_sa_family_t


### PR DESCRIPTION
This commit adds the `nrf_sa_family_t` type to the
`typedefsfile` to fix a compliance error in release
v2.1.0 of modemlib.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>