### PR TITLE
applications: matter_weather_station: use adc/gpio-dt-spec

### DIFF
--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/app.overlay
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/app.overlay
@@ -103,6 +103,21 @@
 	};
 };
 
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 40)>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>;
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <4>;
+	};
+};
+
 /* Disable unused peripherals to reduce power consumption */
 &pwm0 {
 	status = "disabled";

--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/app.overlay
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/app.overlay
@@ -63,6 +63,10 @@
 		};
 	};
 
+	zephyr,user {
+		battery-charge-gpios = <&gpio1 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+
 	chosen {
 		zephyr,console = &cdc_acm_uart0;
 		zephyr,shell-uart = &cdc_acm_uart0;

--- a/applications/matter_weather_station/src/battery.cpp
+++ b/applications/matter_weather_station/src/battery.cpp
@@ -19,12 +19,12 @@ LOG_MODULE_DECLARE(app);
 #define BATTERY_ADC_DEVICE_NAME DT_LABEL(DT_NODELABEL(adc))
 #define BATTERY_CHARGE_GPIO DT_LABEL(DT_NODELABEL(gpio1))
 #define BATTERY_CHARGE_PIN 0
-#define BATTERY_FULL_OHMS DT_PROP(VBATT, full_ohms)
-#define BATTERY_OUTPUT_OHMS DT_PROP(VBATT, output_ohms)
 
 namespace
 {
 const struct gpio_dt_spec sPowerGpio = GPIO_DT_SPEC_GET(VBATT, power_gpios);
+const uint32_t sFullOhms = DT_PROP(VBATT, full_ohms);
+const uint32_t sOutputOhms = DT_PROP(VBATT, output_ohms);
 const device *sAdcController;
 const device *sChargeGpioController;
 
@@ -106,8 +106,7 @@ int32_t BatteryMeasurementReadVoltageMv()
 			int32_t val = sAdcBuffer;
 			adc_raw_to_millivolts(adc_ref_internal(sAdcController), sAdcConfig.gain, sAdcSeq.resolution,
 					      &val);
-			result = static_cast<int32_t>(static_cast<int64_t>(val) * BATTERY_FULL_OHMS /
-						      BATTERY_OUTPUT_OHMS);
+			result = static_cast<int32_t>(static_cast<int64_t>(val) * sFullOhms / sOutputOhms);
 		}
 	}
 	return result;

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 48467b3ba546883a564a7536cae8de227e7cfc07
+      revision: 45ea96586f1380fabae4c7048bcb4418742ce311
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Modernize application by using dt-spec facilities.

Note that the battery module is now relying on two sources in DT, the `vbatt` node and a `zephyr,user` entry. The module should likely have its own compatible to align with best upstream practices, but that can be done in a 2nd cleanup stage.