### PR TITLE
applications: asset_tracker_v2: add neighbor scan KConfig option

### DIFF
--- a/applications/asset_tracker_v2/doc/modem_module.rst
+++ b/applications/asset_tracker_v2/doc/modem_module.rst
@@ -79,7 +79,7 @@ Neighbor cell measurements
 ==========================
 
 Neighbor cell measurements can be requested by the application by sending an ``APP_EVT_DATA_GET`` event where ``APP_DATA_NEIGHBOR_CELLS`` is part of the requested data list.
-Upon reception of that event, the modem module uses the LTE link controller to start a neighbor cell  search of type :c:enum:`LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT`.
+Upon reception of that event, the modem module uses the LTE link controller to start a neighbor cell search of type :kconfig:option:`CONFIG_MODEM_NEIGHBOR_SEARCH_TYPE`.
 See :ref:`lte_lc_readme` for more details on the available search types.
 When the search completes, the module sends a :c:enum:`MODEM_EVT_NEIGHBOR_CELLS_DATA_READY` event containing the cell information received from the modem.
 If the search fails, a :c:enum:`MODEM_EVT_NEIGHBOR_CELLS_DATA_NOT_READY` event is sent.

--- a/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
@@ -56,6 +56,25 @@ config MODEM_NEIGHBOR_CELLS_DATA_CONVERT_RSRQ_TO_DB
 	  Don't convert RSRQ to dB when building for nRF Cloud, this is handled during encoding
 	  using the nRF Cloud cellular positioning library.
 
+choice MODEM_NEIGHBOR_SEARCH_TYPE
+	prompt "Type of search for neighbor cell measurements"
+	default MODEM_NEIGHBOR_SEARCH_TYPE_DEFAULT
+	help
+	  This setting specifies how much effort the modem will put into neighbor cell
+	  measurements. Depending on the modem's state, the extended options might take longer
+	  than the default one.
+
+config MODEM_NEIGHBOR_SEARCH_TYPE_DEFAULT
+	bool "Modem searches the registered network based on previous cell history"
+
+config MODEM_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT
+	bool "Modem additionally performs a light search with all networks"
+
+config MODEM_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE
+	bool "Modem additionally performs a complete search with all networks"
+
+endchoice # MODEM_NEIGHBOR_SEARCH_TYPE
+
 endif # MODEM_MODULE
 
 # Since this configuration is used in the module's event header file, it cannot be guarded

--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -800,8 +800,15 @@ static int battery_data_get(void)
 static int neighbor_cells_measurement_start(void)
 {
 	int err;
+	enum lte_lc_neighbor_search_type type = LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT;
 
-	err = lte_lc_neighbor_cell_measurement(LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT);
+	if (IS_ENABLED(CONFIG_MODEM_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT)) {
+		type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT;
+	} else if (IS_ENABLED(CONFIG_MODEM_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE)) {
+		type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE;
+	}
+
+	err = lte_lc_neighbor_cell_measurement(type);
 	if (err) {
 		LOG_ERR("Failed to start neighbor cell measurements, error: %d", err);
 		return err;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -155,6 +155,7 @@ nRF9160: Asset Tracker v2
       * :ref:`CONFIG_DATA_ACCELEROMETER_INACT_THRESHOLD <CONFIG_DATA_ACCELEROMETER_INACT_THRESHOLD>`
       * :ref:`CONFIG_DATA_ACCELEROMETER_INACT_TIMEOUT_SECONDS <CONFIG_DATA_ACCELEROMETER_INACT_TIMEOUT_SECONDS>`
     * Data sampling is now performed when the device detects both activity and inactivity in passive mode, notified by the :c:enum:`SENSOR_EVT_MOVEMENT_INACTIVITY_DETECTED` event of the :ref:`sensor module <asset_tracker_v2_sensor_module>`.
+    * ``CONFIG_MODEM_NEIGHBOR_SEARCH_TYPE`` option.
 
   * Removed:
 
@@ -186,6 +187,7 @@ nRF9160: Asset Tracker v2
     * Added support for full modem FOTA updates for nRF Cloud builds.
     * ``CONFIG_DATA_DEVICE_MODE`` option is now a choice that can be set to either ``CONFIG_DATA_DEVICE_MODE_ACTIVE`` or ``CONFIG_DATA_DEVICE_MODE_PASSIVE`` depending on the desired device mode.
     * Restructured the documentation.
+    * The default sample timeout for sample requests that include neighbor cell searches is now 11 seconds.
 
   * Fixed:
 


### PR DESCRIPTION
This patch adds a KConfig option to specify which type of
neighbor cell measurement is to be performed.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>