### PR TITLE
wifi: Fix secure associations

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: bf7be5627d2fa528bd61ce1ff10d89828a4d4697
+      revision: 3dabc364cb4e4e7f3513889431737b02ee0111e0
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 6097de22bd1f1b499e599bfef618a235de7073b2


### PR DESCRIPTION
Update sdk-hostap with fixes for secure association.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>