### PR TITLE
doc: add HomeKit software maturity table

### DIFF
--- a/doc/nrf/software_maturity.rst
+++ b/doc/nrf/software_maturity.rst
@@ -80,6 +80,15 @@ The following table indicates the software maturity levels of the support for ea
 
 .. sml-table:: top_level
 
+HomeKit features support
+************************
+
+The following table indicates the software maturity levels of the support for each HomeKit feature:
+
+.. toggle::
+
+  .. sml-table:: homekit
+
 Thread features support
 ***********************
 


### PR DESCRIPTION
Add HomeKit features to the Software Maturity page in doc.

Signed-off-by: Mariusz Poslinski <mariusz.poslinski@nordicsemi.no>