### PR TITLE
manifest: PSA arch tests with increased timeout 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 482dcc7865f7d3a458f061a1d8276c5801eed1e4
+      revision: pull/853/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
    This brings a change in the PSA arch tests where
    we increase the timeout to 90 seconds for Nordic
    devices. Since we run RSA key generation tests
    this is necessary.

    Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>