### PR TITLE
samples: bluetooth: Enable BT privacy in peripheral HIDS Mouse and add usage note for the Zephyr LE Controller.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -650,6 +650,7 @@ Documentation
   * :ref:`ug_thread_prebuilt_libs` as a separate page instead of being part of :ref:`ug_thread_configuring`.
   * Added software maturity entries for security features: TF-M, PSA crypto, Immutable bootloader, HW unique key.
   * A section about NFC in the :ref:`app_memory` page.
+  * A note in the :ref:`ug_ble_controller` about the usage of the Zephyr LE Controller.
 
 * Updated:
 

--- a/doc/nrf/ug_ble_controller.rst
+++ b/doc/nrf/ug_ble_controller.rst
@@ -60,3 +60,6 @@ An exception is the :ref:`ble_llpm` sample, which requires the SoftDevice Contro
 
 By default, all samples are currently configured to use SoftDevice Controller.
 To use the Zephyr Bluetooth LE Controller instead, set :kconfig:option:`CONFIG_BT_LL_SW_SPLIT` to ``y`` in the :file:`prj.conf` file (see :ref:`configure_application`) and make sure to build from a clean build directory.
+
+.. note::
+   If your Bluetooth application requires the LE Secure Connections pairing and you want to use the Zephyr Bluetooth LE Controller, make sure to enable the :kconfig:option:`CONFIG_BT_TINYCRYPT_ECC` option as the ECDH cryptography is not supported by this Bluetooth LE Controller.

--- a/samples/bluetooth/peripheral_hids_mouse/Kconfig
+++ b/samples/bluetooth/peripheral_hids_mouse/Kconfig
@@ -18,5 +18,6 @@ config BT_HIDS_SECURITY_ENABLED
 config BT_DIRECTED_ADVERTISING
 	bool "Enable directed advertising"
 	default y
+	select BT_PRIVACY
 
 endmenu

--- a/samples/bluetooth/peripheral_hids_mouse/child_image/rpc_host.conf
+++ b/samples/bluetooth/peripheral_hids_mouse/child_image/rpc_host.conf
@@ -11,6 +11,8 @@ CONFIG_BT_L2CAP_TX_BUF_COUNT=5
 CONFIG_BT_PERIPHERAL=y
 CONFIG_BT_DEVICE_NAME="Nordic_HIDS_mouse"
 CONFIG_BT_DEVICE_APPEARANCE=962
+# Enable BT_PRIVACY to allow directed advertising using RPA as a destination address
+CONFIG_BT_PRIVACY=y
 
 # Enable bonding
 CONFIG_BT_SETTINGS=y


### PR DESCRIPTION
This PR fixes a test failure in Bluetooth samples for peripheral_hids_mouse. The reason for the configuration change is commit: https://github.com/nrfconnect/sdk-zephyr/commit/59eef60665dc816510bd7a9cc43b6167a20d42a1

Additionally: add a note in the Bluetooth Controller documentation that `BT_TINYCRYPT_ECC` must be enabled if LE Secure Connections is used and the Zephyr LE Controller is selected.