### PR TITLE
cmake: multi_image: fix child image dtc overlay file not working

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -309,7 +309,7 @@ function(add_child_image_from_source)
       # Check for overlay named <ACI_NAME>.overlay.
       set(child_image_dts_overlay ${ACI_CONF_DIR}/${ACI_NAME}.overlay)
       if (EXISTS ${child_image_dts_overlay})
-        add_overlay_dts(${ACI_NAME} ${child_image_dts_overlay})
+        set(${ACI_NAME}_DTC_OVERLAY_FILE ${child_image_dts_overlay})
       endif()
       if(DEFINED ${ACI_NAME}_CONF_FILE)
         set(${ACI_NAME}_CONF_FILE ${${ACI_NAME}_CONF_FILE} CACHE STRING


### PR DESCRIPTION
Without this fix, child image dtc overlay file, e.g. mcuboot.overlay
cannot take effect.

Signed-off-by: Kevin Ai <kevin.ai@nordicsemi.no>