### PR TITLE
mcuboot: nrf53_hooks: Update network core from hook

### DIFF
--- a/modules/mcuboot/hooks/nrf53_hooks.c
+++ b/modules/mcuboot/hooks/nrf53_hooks.c
@@ -15,12 +15,20 @@
 
 #define NET_CORE_SECONDARY_SLOT 1
 #define NET_CORE_VIRTUAL_PRIMARY_SLOT 3
+#define NRF5340_CPUNET_FLASH_SIZE 0x40000
 
 #include <dfu/pcd.h>
+
+#ifndef CONFIG_FLASH_SIMULATOR
+static uint8_t mock_flash[NRF5340_CPUNET_FLASH_SIZE];
+#endif
+int network_core_update(bool wait);
 
 int boot_read_image_header_hook(int img_index, int slot,
 		struct image_header *img_head)
 {
+
+#ifdef PM_MCUBOOT_PRIMARY_1_ADDRESS
 	if (img_index == 1 && slot == 0) {
 		img_head->ih_magic = IMAGE_MAGIC;
 		img_head->ih_hdr_size = PM_MCUBOOT_PAD_SIZE;
@@ -34,6 +42,7 @@ int boot_read_image_header_hook(int img_index, int slot,
 		img_head->_pad1 = 0;
 		return 0;
 	}
+#endif
 
 	return BOOT_HOOK_REGULAR;
 }
@@ -50,6 +59,33 @@ fih_int boot_image_check_hook(int img_index, int slot)
 int boot_perform_update_hook(int img_index, struct image_header *img_head,
 		const struct flash_area *area)
 {
+
+#ifndef CONFIG_FLASH_SIMULATOR
+	uint32_t reset_addr = 0;
+	int32_t rc;
+
+	rc = flash_area_read(area, img_head->ih_hdr_size + 4, &reset_addr, 4);
+
+	if (reset_addr > PM_CPUNET_B0N_ADDRESS) {
+		if (img_head->ih_hdr_size + img_head->ih_img_size > NRF5340_CPUNET_FLASH_SIZE) {
+			return 1;
+		}
+		rc = flash_area_read(area, 0, (uint8_t *)mock_flash,
+				     img_head->ih_hdr_size + img_head->ih_img_size);
+		if (rc == 0) {
+			struct flash_sector fs[CONFIG_BOOT_MAX_IMG_SECTORS];
+			uint32_t count = CONFIG_BOOT_MAX_IMG_SECTORS;
+
+			rc = network_core_update(true);
+
+			//erase the trailer of secondary slot
+			flash_area_get_sectors(area->fa_id, &count, fs);
+			flash_area_erase(area, area->fa_size - fs[0].fs_size, fs[0].fs_size);
+		}
+		return rc;
+	}
+#endif
+
 	return BOOT_HOOK_REGULAR;
 }
 
@@ -76,7 +112,9 @@ int boot_read_swap_state_primary_slot_hook(int image_index,
 
 int network_core_update(bool wait)
 {
+
 	struct image_header *hdr;
+#ifdef CONFIG_FLASH_SIMULATOR
 	static const struct device *mock_flash_dev;
 	void *mock_flash;
 	size_t mock_size;
@@ -87,7 +125,9 @@ int network_core_update(bool wait)
 	}
 
 	mock_flash = flash_simulator_get_memory(NULL, &mock_size);
-	hdr = (struct image_header *) mock_flash;
+#endif
+
+	hdr = (struct image_header *)mock_flash;
 	if (hdr->ih_magic == IMAGE_MAGIC) {
 		uint32_t fw_size = hdr->ih_img_size;
 		uint32_t vtable_addr = (uint32_t)hdr + hdr->ih_hdr_size;
@@ -110,9 +150,12 @@ int network_core_update(bool wait)
 int boot_copy_region_post_hook(int img_index, const struct flash_area *area,
 		size_t size)
 {
+
+#ifdef CONFIG_FLASH_SIMULATOR
 	if (img_index == NET_CORE_SECONDARY_SLOT) {
 		return network_core_update(true);
 	}
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Moved network_core_update() from loader.c to here. In this way,
we support network core update from different secondary slot
locations: external secondary slot, internal secondary slot and
external secondary slot 1 and internal secondary slot 1.

This PR works with another PR: https://github.com/nrfconnect/sdk-mcuboot/pull/208

Signed-off-by: Kevin Ai <kevin.ai@nordicsemi.no>