### PR TITLE
samples: nrf9160: lwm2m_client: Generate timestamp for location

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -273,6 +273,7 @@ nRF9160 samples
     * Bootstrap is not TLV only anymore.
       With v1.1, preferred content format is sent in the bootstrap request.
       SenML CBOR takes precedence over SenML JSON and OMA TLV, when enabled.
+    * Generation of the timestamp of LwM2M Location object on obtaining location fix.
 
   * Added:
 


### PR DESCRIPTION
In order to comply with LwM2M Location object specification,
we should update the timestamp as well.

I wonder if we should add equivalent helper function to nrfx library that would convert the timestamp already. Or function to convert gnss datetime into a `struct tm`