### PR TITLE
doc: update documentation for NCS 2.0.2

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -19,7 +19,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 project = "nRF Connect SDK"
 copyright = "2019-2022, Nordic Semiconductor"
 author = "Nordic Semiconductor"
-version = release = "2.0.1"
+version = release = "2.0.2"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/nrf/dm_adding_code.rst
+++ b/doc/nrf/dm_adding_code.rst
@@ -92,7 +92,7 @@ This is demonstrated by the following code:
        - name: nrf
          repo-path: sdk-nrf
          remote: ncs
-         revision: v2.0.1
+         revision: v2.0.2
          import: true
      self:
        path: application
@@ -119,7 +119,7 @@ For example:
      projects:
        - name: nrf
          remote: ncs
-         revision: v2.0.1
+         revision: v2.0.2
          import: true
        # Example for how to override a repository in the nRF Connect SDK with your own:
        - name: mcuboot

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -21,7 +21,8 @@ Use the drop-down filter to see known issues for previous releases and check if 
 
    <select name="versions" id="versions-select">
      <option value="all">All versions</option>
-     <option value="v2-0-1" selected>v2.0.1</option>
+     <option value="v2-0-2" selected>v2.0.2</option>
+     <option value="v2-0-1">v2.0.1</option>
      <option value="v2-0-0">v2.0.0</option>
      <option value="v1-9-1">v1.9.1</option>
      <option value="v1-9-0">v1.9.0</option>
@@ -136,7 +137,7 @@ CIA-604: ATv2 cannot be built for the ``thingy91_nrf9160_ns`` build target with 
 Serial LTE Modem
 ================
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
 
 NCSDK-13895: Build failure for target Thingy:91 with secure_bootloader overlay
   Building the application for Thingy:91 fails if secure_bootloader overlay is included.
@@ -144,7 +145,7 @@ NCSDK-13895: Build failure for target Thingy:91 with secure_bootloader overlay
 Other issues
 ============
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 NCSDK-15471: Compilation with SUPL client library fails when TF-M is enabled
   Building an application that uses the SUPL client library fails if TF-M is used.
@@ -154,7 +155,7 @@ NCSDK-15471: Compilation with SUPL client library fails when TF-M is enabled
   * Use :ref:`secure_partition_manager` instead of TF-M.
   * Disable the FPU by setting :kconfig:option:`CONFIG_FPU` to ``n``.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
 CIA-351: Connectivity issues with Azure IoT Hub
   If a ``device-bound`` message is sent to the device while it is in the LTE Power Saving Mode (PSM), the TCP connection will most likely be terminated by the server.
@@ -162,21 +163,21 @@ CIA-351: Connectivity issues with Azure IoT Hub
 
   **Workaround:** Avoid using LTE Power Saving Mode (PSM) and extended DRX intervals longer than approximately 30 seconds. This will reduce the risk of the issue occurring, at the cost of increased power consumption.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
 
 NCSDK-10106: Elevated current consumption when using applications without :ref:`nrfxlib:nrf_modem` on nRF9160
   When running applications that do not enable :ref:`nrfxlib:nrf_modem` on nRF9160 with build code B1A, current consumption will stay at 3 mA when in sleep.
 
   **Workaround:** Enable :ref:`nrfxlib:nrf_modem`.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0
 
 NCSDK-8075: Invalid initialization of ``mbedtls_entropy_context`` mutex type
   The calls to :cpp:func:`mbedtls_entropy_init` do not zero-initialize the member variable ``mutex`` when ``nrf_cc3xx`` is enabled.
 
   **Workaround:** Zero-initialize the structure type before using it or make it a static variable to ensure that it is zero-initialized.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
 Receive error with large packets
   nRF91 fails to receive large packets (over 4000 bytes).
@@ -313,7 +314,7 @@ nRF5
 nRF5340
 =======
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
 
 NCSDK-11432: DFU: Erasing secondary slot returns error response
   Trying to erase secondary slot results in an error response.
@@ -372,21 +373,26 @@ Missing :file:`CMakeLists.txt`
 Thread
 ======
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1
+
+KRKNWK-14756: Increased average latency during communication with nRF5340-based SED
+  The measured average latency (RTT) of the Echo Request/Response transaction sometimes shows a slight increase over the baseline when the receiver is a Sleepy End Device based on the nRF5340 SoC platform.
+
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 KRKNWK-14231: Device stops receiving after switching from SSED to MED
   Trying to switch to the MED mode after working as CSL Receiver makes the device stop receiving frames.
 
   **Workaround:** Before invoking :c:func:`otThreadSetLinkMode` to change the device mode, make sure to set the CSL Period to ``0`` with :c:func:`otLinkCslSetPeriod`.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
 
 KRKNWK-9094: Possible deadlock in shell subsystem
   Issuing OpenThread commands too fast might cause a deadlock in the shell subsystem.
 
   **Workaround:** If possible, avoid invoking a new command before execution of the previous one has completed.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
 
 KRKNWK-6848: Reduced throughput
   Performance testing for the :ref:`ot_coprocessor_sample` sample shows a decrease of throughput of around 10-20% compared with the standard OpenThread.
@@ -504,26 +510,26 @@ KRKNWK-6408: ``diag`` command not supported
 Zigbee
 ======
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 KRKNWK-14024 Fatal error when the network coordinator factory resets in the Identify mode
   A fatal error occurs when the :ref:`Zigbee network coordinator <zigbee_network_coordinator_sample>` triggers factory reset in the Identify mode.
 
   **Workaround:** Modify your application, so that the factory reset is requested only after the Identify mode ends.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
 
 KRKNWK-12937: Activation of Sleepy End Device must be done at the very first commissioning procedure for Zigbee light switch sample
    After programming the :ref:`Zigbee light switch <zigbee_light_switch_sample>` sample and its first commissioning, Zigbee End Device joins the Zigbee network as a normal End Device. Pressing **Button 3** does not switch the device to the Sleepy End Device configuration.
 
    **Workaround:** Keep **Button 3** pressed during the first commissioning procedure.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
 
 KRKNWK-12615: Get Group Membership Command returns all groups the node is assigned to
    Get Group Membership Command returns all groups the node is assigned to regardless of the destination endpoint.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
 
 KRKNWK-12115: Simultaneous commissioning of many devices can cause the Coordinator device to assert
   The Zigbee Coordinator device can assert when multiple devices are being commissioned simultaneously.
@@ -557,7 +563,7 @@ KRKNWK-12115: Simultaneous commissioning of many devices can cause the Coordinat
   #. To increase the scheduler queue size, replace ``XYZ`` next to ``ZB_CONFIG_SCHEDULER_Q_SIZE`` with the value of your choice, ranging from ``48U`` to ``256U``.
   #. To increase the buffer pool size, replace ``XYZ`` next to ``ZB_CONFIG_IOBUF_POOL_SIZE`` with the value of your choice, ranging from ``48U`` to ``127U``.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
 
 KRKNWK-11826: Zigbee Router does not accept new child devices if the maximum number of children is reached
   Once the maximum number of children devices on a Zigbee Router is reached and one of them leaves the network, the Zigbee Router does not update the flags inside beacon frames to indicate that it cannot accept new devices.
@@ -577,7 +583,7 @@ KRKNWK-12522: Incorrect Read Attributes Response on reading multiple attributes 
    When reading multiple attributes at once and the first one is not supported, the Read Attributes Response contains two records for the first supported attribute.
    The first one record has the Status field filled with Unsupported Attribute whereas the second record contains actual data.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
 
 KRKNWK-12017: Zigbee End Device does not recover from broken rejoin procedure
   If the Device Announcement packet is not acknowledged by the End Device's parent, joiner logic is stopped and device doesn't recover.
@@ -676,7 +682,7 @@ KRKNWK-11602: Zigbee device becomes not operable after receiving malformed packe
 
 Given these two options, we recommend to upgrade your |NCS| version to the latest available one.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
 
 KRKNWK-7723: OTA upgrade process restarting after client reset
   After the reset of OTA Upgrade Client, the client will start the OTA upgrade process from the beginning instead of continuing the previous process.
@@ -827,18 +833,27 @@ KRKNWK-6073: Potential delay during FOTA
 Matter (Project CHIP)
 =====================
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2
+
+KRKNWK-14748: Matter command times out when a Matter device becomes a Thread router
+  When a Full Thread Device becomes a router, it will ignore incoming packets for a short period of time, typically between 1-2 seconds.
+  This may disrupt the communication over Matter and lead to transaction timeouts.
+
+  In more recent versions of Matter, this problem has been eliminated by enhancing Matter's Message Reliability Protocol.
+  This fix will be included in the future versions of the |NCS|.
+
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 KRKNWK-14206: CHIP Tool for Android may crash when using Cluster Interactive Tool screen
   Cluster Interaction Tool screen crashes when trying to send a command that takes an optional argument.
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 KRKNWK-14180: The QSPI sleep mode is not handled efficiently in Matter samples on the nRF53 SoC
   QSPI is active during every Bluetooth LE connection in the Matter samples that are programmed on the nRF53 SoC.
   This results in higher power consumption, for example during commissioning into the Matter network.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
 
 KRKNWK-11225: CHIP Tool for Android cannot communicate with a Matter device after the device reboots
   CHIP Tool for Android does not implement any mechanism to recover a secure session to a Matter device after the device has rebooted and lost the session.
@@ -883,7 +898,7 @@ KRKNWK-9214: Pigweed submodule may not be accessible from some regions
 HomeKit
 =======
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 KRKNWK-14130: Bluetooth LE TX configuration is set to ``0`` dBm by default
   The minimum Bluetooth LE TX configuration required is at least ``4`` dBm.
@@ -892,29 +907,29 @@ KRKNWK-14130: Bluetooth LE TX configuration is set to ``0`` dBm by default
 
   **Workaround:** You need to configure the appropriate dBm values for Bluetooth LE and Thread manually in the source code.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
 KRKNWK-14081: HomeKit SDK light bulb example does not work with MTD
   If the MTD is set to ``y`` in the light bulb sample, user is not able to communicate with the device after it has been added to the Home app using an iPhone and a HomePod Mini.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
 
 KRKNWK-13947: Net core downgrade prevention does not work on nRF5340
   HAP certification requirements are not met because of this issue.
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 KRKNWK-13607: Stateless switch application crashes upon factory reset
   When running Thread test suit on the stateless switch application, the CI crashes upon factory reset.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
 
 KRKNWK-13249: Unexpected assertion in HAP Bluetooth Peripheral Manager
   When Bluetooth LE layer emits callback with a connect or disconnect event, one of its parameters is an underlying Bluetooth LE connection object.
   On rare occasions, this connection object is no longer valid by the time it is processed in HomeKit, and this results in assertion.
   There is no proven workaround yet.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
 KRKNWK-11729: Stateless switch event characteristic value not handled according to specification in Bluetooth LE mode
   The stateless programmable switch application does not handle the value of the stateless switch event characteristic in the Bluetooth LE mode according to the specification.
@@ -999,7 +1014,7 @@ KRKNWK-11365: HAP tool's ``provision`` command freezes
 nRF Desktop
 ===========
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0 v1-1-0 v1-0-0
 
 NCSDK-8304: HID configurator issues for peripherals connected over Bluetooth® LE to Linux host
   Using :ref:`nrf_desktop_config_channel_script` for peripherals connected to host directly over Bluetooth LE might result in receiving improper HID feature report ID.
@@ -1362,7 +1377,7 @@ The combination of nRF Secure Immutable Bootloader and MCUboot fails to upgrade 
 Build system
 ============
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
 
 NCSDK-6117: Build configuration issues
   The build configuration consisting of :ref:`bootloader`, :ref:`secure_partition_manager`, and application does not work.
@@ -1439,7 +1454,7 @@ NCSDK-7982: Partition manager: Incorrect partition size linkage from name confli
 DFU and FOTA
 ============
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
 
 NCSDK-11308: Powering off device immediately after serial recovery of the nRF53 network core firmware results in broken firmware
   The network core will not be able to boot if the device is powered off too soon after completing a serial recovery update procedure of the network core firmware.
@@ -1517,7 +1532,7 @@ Unstable NFC tag samples
 Secure Partition Manager (SPM)
 ==============================
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
 
 NCSIDB-114: Default logging causes crash
   Enabling default logging in the :ref:`secure_partition_manager` sample makes it crash if the sample logs any data after the application has booted (for example, during a SecureFault, or in a secure service).
@@ -1540,7 +1555,7 @@ CIA-248: Samples with default SPM config fails to build for ``thingy91_nrf9160_n
 MCUboot
 *******
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 NCSDK-15494: Unable to build with RSA and ECIES-X25519 image encryptions
   Building MCUboot with either RSA and ECIES-X25519 image encryptions feature enabled is not possible.
@@ -1558,17 +1573,17 @@ nrfxlib
 Crypto
 ======
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
 
 NCSDK-13843: Limited support for MAC in PSA Crypto APIs
   The provided message authentication codes (MAC) implementation in the PSA Crypto APIs has limited support in accelerators. Only the CryptoCell accelerator supports MAC operations in PSA Crypto APIs and the supported hash algorithms are SHA-1/SHA-224/SHA-256.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
 
 NCSDK-13843: Limited support for key derivation in PSA Crypto APIs
   The provided key derivation implementation in the PSA Crypto APIs has limited support in accelerators. Only the CryptoCell accelerator supports key derivation in PSA Crypto APIs and the supported hash algorithms are the SHA-1/SHA-224/SHA-256.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
 
 NCSDK-13842: Limited ECC support in PSA Crypto APIs
   The provided ECDSA implementation in the CryptoCell accelerator does not support 521 bit curves.
@@ -1650,23 +1665,23 @@ Closing sockets
 Multiprotocol Service Layer (MPSL)
 ==================================
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
 
 DRGN-16642: If radio notifications on ACTIVE are used, MPSL might assert
   When radio notifications are used with :c:enumerator:`MPSL_RADIO_NOTIFICATION_TYPE_INT_ON_ACTIVE` or :c:enumerator:`MPSL_RADIO_NOTIFICATION_TYPE_INT_ON_BOTH`, MPSL might assert.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0
 
 DRGN-15979: :kconfig:option:`CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION` must be set when :kconfig:option:`CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC` is set
   MPSL requires RC clock calibration to be enabled when the RC clock is used as the Low Frequency clock source.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0
 
 DRGN-14153: Radio Notification power performance penalty
   The Radio Notification feature has a power performance penalty proportional to the notification distance.
   This means an additional average current consumption of about 600 µA for the duration of the radio notification.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0
 
 KRKNWK-8842: MPSL does not support nRF21540 revision 1 or older
   The nRF21540 revision 1 or older is not supported by MPSL.
@@ -1674,7 +1689,7 @@ KRKNWK-8842: MPSL does not support nRF21540 revision 1 or older
 
   **Workaround:** Check the `Nordic Semiconductor website`_ for the latest information on availability of the product version of nRF21540.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0 v1-2-1 v1-2-0
 
 DRGN-6362: Do not use the synthesized low frequency clock source
   The synthesized low frequency clock source is neither tested nor intended for usage with MPSL.
@@ -1725,7 +1740,7 @@ DRGN-11059: Front-end module API not implemented for SoftDevice Controller
 802.15.4 Radio driver
 =====================
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0
 
 KRKNWK-12482: Reception of correct frames can occasionally end in failure with error ``NRF_802154_RX_ERROR_RUNTIME``
   This issue can occur for the ``nrf5340dk_nrf5340_cpunet`` target if a custom application (other than :ref:`multiprotocol-rpmsg-sample` sample or :ref:`zephyr:nrf-ieee802154-rpmsg-sample` sample) is used.
@@ -1735,7 +1750,7 @@ KRKNWK-12482: Reception of correct frames can occasionally end in failure with e
 KRKNWK-11384: Assertion with Bluetooth® LE and multiprotocol usage
   The device might assert on rare occasions during the use of Bluetooth® LE and 802.15.4 multiprotocol.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0
 
 KRKNWK-11204:
   Transmitting the 802.15.4 frame with improperly populated Auxiliary Security Header field might result in assert.
@@ -1761,14 +1776,14 @@ SoftDevice Controller
 
 In addition to the known issues listed here, see also :ref:`softdevice_controller_limitations` for permanent limitations.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
 
 DRGN-16013: Initiating connections over extended advertising is not supported when external radio coexistence and FEM support are enabled
   The initiator can assert when initiating a connection to an extended advertiser when both external radio coexistence and FEM are enabled.
 
   **Workaround:**  Do not enable both coex (:kconfig:option:`CONFIG_MPSL_CX_BT`) and FEM (:kconfig:option:`CONFIG_MPSL_FEM`) when support for extended advertising packets is enabled (:kconfig:option:`CONFIG_BT_EXT_ADV`).
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
 
 DRGN-15903: :kconfig:option:`BT_CTLR_TX_PWR` is ignored by the SoftDevice Controller
   Using :kconfig:option:`BT_CTLR_TX_PWR` does not set TX power.
@@ -2163,21 +2178,21 @@ tx_buffer_length set incorrectly
 Trusted Firmware-M (TF-M)
 *************************
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 NCSDK-15382: TF-M uses more RAM compared to SPM in the minimal configuration
   TF-M uses 64 KB of RAM in the minimal configuration, while SPM uses 32 KB of RAM.
 
   **Workaround:** Free up memory in the application if needed or keep :kconfig:option:`CONFIG_SPM` enabled in the application.
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 NCSDK-15379: TF-M does not support FP Hard ABI
   TF-M does not support enabling the Float Point Hard Application Binary Interface configuration enabled with :kconfig:option:`CONFIG_FP_HARDABI`.
 
   **Workaround:** Use :kconfig:option:`CONFIG_FP_SOFTABI` or keep :kconfig:option:`CONFIG_SPM` enabled in the application.
 
-.. rst-class:: v2-0-1 v2-0-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0
 
 NCSDK-15345: TF-M does not support non-secure partitions in external flash
   TF-M does not support configuring a non-secure partition in external flash, such as non-secure storage or MCUboot secondary partition.
@@ -2185,19 +2200,19 @@ NCSDK-15345: TF-M does not support non-secure partitions in external flash
 
   **Workaround:** Do not put non-secure partitions in external flash or keep :kconfig:option:`CONFIG_SPM` enabled in the application.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
 
 NCSDK-12483: Missing debug symbols
   Some debug symbols are missing sometimes.
 
   **Workaround:** Add the text ``zephyr_link_libraries(-Wl,--undefined=my_missing_debug_symbol)`` in the application :file:`CMakeLists.txt` file.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0
 
 NCSDK-12342: SecureFault exception while accessing protected storage
   When accessing protected storage, a SecureFault exception is sometimes triggered and execution halts.
 
-.. rst-class:: v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+.. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
 NCSDK-11195: Build errors when enabling :kconfig:option:`CONFIG_BUILD_WITH_TFM` option
   Configuring the BUILD_WITH_TFM configuration in SES project configuration or using ``west -t menuconfig`` results in build errors.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -151,6 +151,7 @@
 .. _`nRF Connect SDK latest documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/index.html
 
 .. _`known issues page on the main branch`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html
+.. _`known issues for nRF Connect SDK v2.0.2`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html?v=v2-0-2
 .. _`known issues for nRF Connect SDK v2.0.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html?v=v2-0-1
 .. _`known issues for nRF Connect SDK v2.0.0`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html?v=v2-0-0
 .. _`known issues for nRF Connect SDK v1.9.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/known_issues.html?v=v1-9-1
@@ -216,16 +217,19 @@
 .. _`TF-M documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/tfm/index.html
 .. _`TF-M secure partition integration guide`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/tfm/docs/integration_guide/services/tfm_secure_partition_addition.html
 
+.. _`Repositories and revisions for v2.0.2`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.0.2/nrf/introduction.html#repositories-and-revisions
 .. _`Repositories and revisions for v2.0.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.0.1/nrf/introduction.html#repositories-and-revisions
 .. _`Repositories and revisions for v2.0.0`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.0.0/nrf/introduction.html#repositories-and-revisions
 .. _`Repositories and revisions for v1.9.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/nrf/introduction.html#repositories-and-revisions
 .. _`Repositories and revisions`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.0/nrf/introduction.html#repositories-and-revisions
 
+.. _`Modem library changelog for v2.0.2`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.0.2/nrfxlib/nrf_modem/doc/CHANGELOG.html#nrf-modem-changelog
 .. _`Modem library changelog for v2.0.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.0.1/nrfxlib/nrf_modem/doc/CHANGELOG.html#nrf-modem-changelog
 .. _`Modem library changelog for v2.0.0`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.0.0/nrfxlib/nrf_modem/doc/CHANGELOG.html#nrf-modem-changelog
 .. _`Modem library changelog for v1.9.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/nrfxlib/nrf_modem/doc/CHANGELOG.html#nrf-modem-changelog
 .. _`Modem library changelog for v1.9.0`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.0/nrfxlib/nrf_modem/doc/CHANGELOG.html#nrf-modem-changelog
 
+.. _`LwM2M carrier library changelog for v2.0.2`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.0.2/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.html#liblwm2m-carrier-changelog
 .. _`LwM2M carrier library changelog for v2.0.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.0.1/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.html#liblwm2m-carrier-changelog
 .. _`LwM2M carrier library changelog for v2.0.0`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/2.0.0/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.html#liblwm2m-carrier-changelog
 .. _`LwM2M carrier library changelog for v1.9.1`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.html#liblwm2m-carrier-changelog

--- a/doc/nrf/release_notes.rst
+++ b/doc/nrf/release_notes.rst
@@ -19,6 +19,7 @@ This page is included only in the latest documentation, because it might contain
    :maxdepth: 1
    :caption: Subpages:
 
+   releases/release-notes-2.0.2
    releases/release-notes-2.0.1
    releases/release-notes-2.0.0
    migration/migration_guide_1.x_to_2.x

--- a/doc/nrf/releases/release-notes-2.0.2.rst
+++ b/doc/nrf/releases/release-notes-2.0.2.rst
@@ -1,0 +1,106 @@
+.. _ncs_release_notes_202:
+
+|NCS| v2.0.2 Release Notes
+##########################
+
+.. contents::
+   :local:
+   :depth: 2
+
+|NCS| delivers reference software and supporting libraries for developing low-power wireless applications with Nordic Semiconductor products in the nRF52, nRF53, and nRF91 Series.
+The SDK includes open source projects (TF-M, MCUboot, OpenThread, Matter, and the Zephyr RTOS), which are continuously integrated and redistributed with the SDK.
+
+Release notes might refer to "experimental" support for features, which indicates that the feature is incomplete in functionality or verification, and can be expected to change in future releases.
+The feature is made available in its current state though the design and interfaces can change between release tags.
+The feature will also be labeled with "EXPERIMENTAL" in Kconfig files to indicate this status.
+Build warnings will be generated to indicate when features labeled EXPERIMENTAL are included in builds unless the Kconfig option :kconfig:option:`CONFIG_WARN_EXPERIMENTAL` is disabled.
+
+Highlights
+**********
+
+This minor release adds the following changes on top of the :ref:`nRF Connect SDK v2.0.1 <ncs_release_notes_201>`:
+
+* Added support for Thread 1.3.0 to enable both the testing of Matter during Specification Validation Event (SVE) and the Thread 1.3.0 Certification by Inheritance for Matter 1.0 end products.
+
+See :ref:`ncs_release_notes_202_changelog` for the complete list of changes.
+
+Release tag
+***********
+
+The release tag for the |NCS| manifest repository (|ncs_repo|) is **v2.0.2**.
+Check the :file:`west.yml` file for the corresponding tags in the project repositories.
+
+To use this release, check out the tag in the manifest repository and run ``west update``.
+See :ref:`cloning_the_repositories` and :ref:`gs_updating_repos_examples` for more information.
+
+For information on the included repositories and revisions, see `Repositories and revisions for v2.0.2`_.
+
+IDE and tool support
+********************
+
+`nRF Connect extension for Visual Studio Code <nRF Connect for Visual Studio Code_>`_ is the only officially supported IDE for |NCS| v2.0.2.
+SEGGER Embedded Studio Nordic Edition is no longer tested or recommended for new projects.
+
+:ref:`gs_app_tcm`, used to install the |NCS| automatically from `nRF Connect for Desktop`_, is available for Windows, Linux, and macOS.
+
+Supported modem firmware
+************************
+
+See `Modem firmware compatibility matrix`_ for an overview of which modem firmware versions have been tested with this version of the |NCS|.
+
+Use the latest version of the nRF Programmer app of `nRF Connect for Desktop`_ to update the modem firmware.
+See :ref:`nrf9160_gs_updating_fw_modem` for instructions.
+
+Modem-related libraries and versions
+====================================
+
+.. list-table:: Modem-related libraries and versions
+   :widths: 15 10
+   :header-rows: 1
+
+   * - Library name
+     - Version information
+   * - Modem library
+     - `Changelog <Modem library changelog for v2.0.2_>`_
+   * - LwM2M carrier library
+     - `Changelog <LwM2M carrier library changelog for v2.0.2_>`_
+
+Known issues
+************
+
+Known issues are only tracked for the latest official release.
+See `known issues for nRF Connect SDK v2.0.2`_ for the list of issues valid for the latest release.
+
+.. _ncs_release_notes_202_changelog:
+
+Changelog
+*********
+
+The following sections provide detailed lists of changes by component.
+
+Protocols
+=========
+
+This section provides detailed lists of changes by :ref:`protocol <protocols>`.
+
+Thread
+------
+
+* Enabled Thread 1.3 features by default.
+* Removed support for Thread Border Router as part of the Master library feature set.
+* Updated:
+
+  * The recommended version of OpenThread Border Router and the accompanying ``nrfconnect/otbr`` docker image.
+  * Values in the memory requirement tables in :ref:`thread_ot_memory` after the update to the :ref:`nrfxlib:ot_libs` in nrfxlib.
+
+Zephyr
+======
+
+The Zephyr fork in |NCS| (``sdk-zephyr``) contains all commits from the upstream Zephyr repository up to and including ``53fbf40227de087423620822feedde6c98f3d631``, plus some |NCS| specific additions.
+This is the same commit ID as the one used for |NCS| :ref:`v2.0.0 <ncs_release_notes_200>` and :ref:`v2.0.1 <ncs_release_notes_201>`.
+
+For a complete list of |NCS| specific commits since v2.0.0, run the following command:
+
+.. code-block:: none
+
+   git log --oneline manifest-rev ^v3.0.99-ncs1

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -69,11 +69,7 @@ The following list summarizes the most important changes inherited from the upst
 Thread
 ------
 
-* Enabled Thread 1.3 features by default.
-* Removed support for Thread Border Router as part of the Master library feature set.
-* Fixed a bug in which a Minimal Thread Device was not able to handle Address Error Notification messages.
-* Updated the values in the memory requirement tables in :ref:`thread_ot_memory` after the update to the :ref:`nrfxlib:ot_libs` in nrfxlib.
-* Updated recommended version of OpenThread Border Router and the accompanying ``nrfconnect/otbr`` docker image.
+|no_changes_yet_note|
 
 See `Thread samples`_ for the list of changes for the Thread samples.
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -1,8 +1,8 @@
 .. |NCS| replace:: nRF Connect SDK
 
-.. |release| replace:: v2.0.1
-.. |release_tt| replace:: ``v2.0.1``
-.. |release_number_tt| replace:: ``2.0.1``
+.. |release| replace:: v2.0.2
+.. |release_tt| replace:: ``v2.0.2``
+.. |release_number_tt| replace:: ``2.0.2``
 
 .. |plusminus| unicode:: U+000B1 .. PLUS-MINUS SIGN
    :rtrim:

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -21,7 +21,7 @@ NRFXLIB_BASE = utils.get_projdir("nrfxlib")
 project = "nrfxlib"
 copyright = "2019-2022, Nordic Semiconductor"
 author = "Nordic Semiconductor"
-version = release = "2.0.1"
+version = release = "2.0.2"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/versions.json
+++ b/doc/versions.json
@@ -1,6 +1,7 @@
 {
   "VERSIONS": [
     "latest",
+    "2.0.2",
     "2.0.1",
     "2.0.0",
     "1.9.1",
@@ -28,8 +29,17 @@
   ],
   "COMPONENTS_BY_VERSION": {
     "latest": {
-      "ncs": "2.0.1",
-      "nrfxlib": "2.0.1",
+      "ncs": "2.0.2",
+      "nrfxlib": "2.0.2",
+      "zephyr": "3.0.99",
+      "mcuboot": "1.9.99",
+      "nrfx": "2.8",
+      "tfm": "1.5.0",
+      "matter": ""
+    },
+    "2.0.2": {
+      "ncs": "2.0.2",
+      "nrfxlib": "2.0.2",
       "zephyr": "3.0.99",
       "mcuboot": "1.9.99",
       "nrfx": "2.8",


### PR DESCRIPTION
Updated doc versions for NCS 2.0.2.
Cleaned changelog.
Added release notes.
Updated known issues.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>

----

- [x] Update highlights
- [x] Update release notes with an entry from https://github.com/nrfconnect/sdk-nrf/pull/8256/files