### PR TITLE
doc: remove markdown pinned version

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -8,7 +8,6 @@ pygit2
 pyyaml
 azure-storage-blob
 sphinx_markdown_tables
-markdown<3.3.5 # Workaround for ryanfox/sphinx-markdown-tables#34
 mistune<2.0 # Workaround for https://github.com/CrossNox/m2r2/issues/40
 breathe<4.33 # Workaround for #803 and #805 breathe issues
 sphinx-togglebutton


### PR DESCRIPTION
The issue with sphinx-markdown-tables has been fixed and the pinned
version is now causing other problems.