### PR TITLE
lib: sms: Clarify number format

### DIFF
--- a/include/modem/sms.h
+++ b/include/modem/sms.h
@@ -196,11 +196,14 @@ void sms_unregister_listener(int handle);
  * in 3GPP TS 23.038 Section 4 and Section 6.2.
  * This function doesn't support sending of 8bit binary data messages or UCS2 encoded text.
  *
- * @param[in] number Recipient number.
+ * @param[in] number Recipient number in international format.
  * @param[in] text Text to be sent.
  *
  * @retval -EINVAL Invalid parameter.
  * @return 0 on success, otherwise error code.
+ *         A positive value on AT error with "ERROR", "+CME ERROR", and "+CMS ERROR" responses.
+ *         The type can be resolved with @c nrf_modem_at_err_type and
+ *         the error value with @c nrf_modem_at_err.
  */
 int sms_send_text(const char *number, const char *text);
 

--- a/lib/sms/sms.c
+++ b/lib/sms/sms.c
@@ -120,6 +120,18 @@ static void sms_reregister(struct k_work *work)
 	err = nrf_modem_at_printf(AT_SMS_SUBSCRIBER_REGISTER);
 	if (err) {
 		LOG_ERR("Unable to re-register SMS client, err: %d", err);
+		/* Pause AT commands notifications. */
+		at_monitor_pause(&sms_at_handler_cmt);
+		at_monitor_pause(&sms_at_handler_cds);
+		at_monitor_pause(&sms_at_handler_cms);
+
+		/* Clear all observers. */
+		for (size_t i = 0; i < ARRAY_SIZE(subscribers); i++) {
+			subscribers[i].ctx = NULL;
+			subscribers[i].listener = NULL;
+		}
+
+		sms_client_registered = false;
 	}
 }
 
@@ -338,12 +350,6 @@ static void sms_uninit(void)
 	at_monitor_pause(&sms_at_handler_cmt);
 	at_monitor_pause(&sms_at_handler_cds);
 	at_monitor_pause(&sms_at_handler_cms);
-
-	/* Clear all observers. */
-	for (size_t i = 0; i < ARRAY_SIZE(subscribers); i++) {
-		subscribers[i].ctx = NULL;
-		subscribers[i].listener = NULL;
-	}
 
 	sms_client_registered = false;
 }

--- a/lib/sms/sms_deliver.c
+++ b/lib/sms/sms_deliver.c
@@ -158,7 +158,7 @@ static void convert_number_to_str(uint8_t *number, uint8_t number_length, char *
 
 		if (number_value >= 10) {
 			LOG_WRN("Single number in phone number is higher than 10: "
-				"index=%d, number_value=%d, lower semi-octet",
+				"index=%d, number_value=%d, higher semi-octet",
 				i, number_value);
 		}
 		sprintf(str_number + hex_str_index, "%d", number_value);

--- a/lib/sms/sms_submit.c
+++ b/lib/sms/sms_submit.c
@@ -89,6 +89,32 @@ static int sms_submit_encode_number(
 }
 
 /**
+ * @brief Prints error information for positive error codes of @c nrf_modem_at_printf.
+ *
+ * @param[in] err Error code.
+ */
+static void sms_submit_print_error(int err)
+{
+#if (CONFIG_SMS_LOG_LEVEL >= LOG_LEVEL_ERR)
+	if (err <= 0) {
+		return;
+	}
+
+	switch (nrf_modem_at_err_type(err)) {
+	case NRF_MODEM_AT_ERROR:
+		LOG_ERR("ERROR");
+		break;
+	case NRF_MODEM_AT_CME_ERROR:
+		LOG_ERR("+CME ERROR: %d", nrf_modem_at_err(err));
+		break;
+	case NRF_MODEM_AT_CMS_ERROR:
+		LOG_ERR("+CMS ERROR: %d", nrf_modem_at_err(err));
+		break;
+	}
+#endif
+}
+
+/**
  * @brief Create SMS-SUBMIT message as specified in specified in 3GPP TS 23.040 chapter 9.2.2.2.
  *
  * @details Optionally allows adding User-Data-Header.
@@ -170,6 +196,7 @@ static int sms_submit_encode(
 	err = nrf_modem_at_printf(send_buf);
 	if (err) {
 		LOG_ERR("Sending AT command failed, err=%d", err);
+		sms_submit_print_error(err);
 	} else {
 		LOG_DBG("Sending AT command succeeded");
 	}

--- a/samples/nrf9160/modem_shell/src/sms/sms.c
+++ b/samples/nrf9160/modem_shell/src/sms/sms.c
@@ -120,6 +120,9 @@ int sms_send_msg(char *number, char *text)
 	}
 
 	ret = sms_send_text(number, text);
+	if (ret) {
+		printk("Sending SMS failed with error: %d\n", ret);
+	}
 
 	return ret;
 }

--- a/samples/nrf9160/sms/README.rst
+++ b/samples/nrf9160/sms/README.rst
@@ -39,8 +39,8 @@ Check and configure the following configuration option for the sample:
 
 .. _CONFIG_SMS_SEND_PHONE_NUMBER:
 
-CONFIG_SMS_SEND_PHONE_NUMBER - Configuration for recipient phone number
-   The sample configuration is used to set the recipient phone number if you need to send SMS.
+CONFIG_SMS_SEND_PHONE_NUMBER - Configuration for recipient phone number in international format
+   The sample configuration is used to set the recipient phone number in international format if you need to send an SMS.
 
 Additional configuration
 ========================

--- a/samples/nrf9160/sms/src/main.c
+++ b/samples/nrf9160/sms/src/main.c
@@ -74,7 +74,7 @@ void main(void)
 			CONFIG_SMS_SEND_PHONE_NUMBER);
 		ret = sms_send_text(CONFIG_SMS_SEND_PHONE_NUMBER, "SMS sample: testing");
 		if (ret) {
-			printk("sms_send returned err: %d\n", ret);
+			printk("Sending SMS failed with error: %d\n", ret);
 		}
 	} else {
 		printk("\nSMS sending is skipped but receiving will still work.\n"


### PR DESCRIPTION
Add comment about international number format into SMS library and SMS sample documentation.
Improve error logging especially when nrf_modem_at_printf fails when sending SMS.
Update the internal state of the library to unregistered if reregistration fails.
Add few more unit tests to cover the changes done in the past year.