### PR TITLE
matter: fix weather station after OpenThread update

### DIFF
--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/multiprotocol_rpmsg.conf
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/multiprotocol_rpmsg.conf
@@ -18,3 +18,7 @@ CONFIG_BT_BUF_ACL_RX_SIZE=502
 
 # Workaround FEM issue seen on older Thingy:53 revisions
 CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA=10
+
+# Enable the frame encryption feature in the radio driver, it's required for proper working
+# OPENTHREAD_CSL_RECEIVER and OPENTHREAD_LINK_METRICS_SUBJECT features
+CONFIG_NRF_802154_ENCRYPTION=y

--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/multiprotocol_rpmsg_release.conf
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/multiprotocol_rpmsg_release.conf
@@ -18,3 +18,7 @@ CONFIG_BT_BUF_ACL_RX_SIZE=502
 
 # Workaround FEM issue seen on older Thingy:53 revisions
 CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB_POUTA=10
+
+# Enable the frame encryption feature in the radio driver, it's required for proper working
+# OPENTHREAD_CSL_RECEIVER and OPENTHREAD_LINK_METRICS_SUBJECT features
+CONFIG_NRF_802154_ENCRYPTION=y


### PR DESCRIPTION
CONFIG_NRF_802154_ENCRYPTION must be enabled on the network
core. Otherwise, the core stops responding and the app core
crashes on a spinel timeout.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>