### PR TITLE
applications: nrf_desktop: use DEVICE_DT_GET

### DIFF
--- a/applications/nrf_desktop/configuration/common/port_state.h
+++ b/applications/nrf_desktop/configuration/common/port_state.h
@@ -8,8 +8,9 @@
 #define _PORT_STATE_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
-#include <zephyr/types.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,7 +22,7 @@ struct pin_state {
 };
 
 struct port_state {
-	const char             *name;
+	const struct device    *port;
 	const struct pin_state *ps;
 	size_t                  ps_count;
 };

--- a/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52810dmouse_nrf52810/port_state_def.h
@@ -29,7 +29,7 @@ static const struct pin_state port0_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	}
@@ -37,7 +37,7 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/port_state_def.h
@@ -27,7 +27,7 @@ static const struct pin_state port0_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	}
@@ -35,7 +35,7 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/port_state_def.h
@@ -27,7 +27,7 @@ static const struct pin_state port0_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	}
@@ -35,7 +35,7 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/port_state_def.h
@@ -35,12 +35,12 @@ static const struct pin_state port1_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_on,
 		.ps_count = ARRAY_SIZE(port1_on),
 	}
@@ -48,12 +48,12 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_off,
 		.ps_count = ARRAY_SIZE(port1_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/port_state_def.h
@@ -35,12 +35,12 @@ static const struct pin_state port1_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_on,
 		.ps_count = ARRAY_SIZE(port1_on),
 	}
@@ -48,12 +48,12 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_off,
 		.ps_count = ARRAY_SIZE(port1_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840dk_nrf52840/port_state_def.h
@@ -33,12 +33,12 @@ static const struct pin_state port1_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_on,
 		.ps_count = ARRAY_SIZE(port1_on),
 	}
@@ -46,12 +46,12 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_off,
 		.ps_count = ARRAY_SIZE(port1_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840dongle_nrf52840/port_state_def.h
@@ -35,12 +35,12 @@ static const struct pin_state port1_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_on,
 		.ps_count = ARRAY_SIZE(port1_on),
 	}
@@ -48,12 +48,12 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_off,
 		.ps_count = ARRAY_SIZE(port1_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52840gmouse_nrf52840/port_state_def.h
@@ -59,12 +59,12 @@ static const struct pin_state port1_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_on,
 		.ps_count = ARRAY_SIZE(port1_on),
 	}
@@ -72,12 +72,12 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_off,
 		.ps_count = ARRAY_SIZE(port1_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf52dmouse_nrf52832/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52dmouse_nrf52832/port_state_def.h
@@ -29,7 +29,7 @@ static const struct pin_state port0_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	}
@@ -37,7 +37,7 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf52kbd_nrf52832/port_state_def.h
@@ -37,7 +37,7 @@ static const struct pin_state port0_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	}
@@ -45,7 +45,7 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	}

--- a/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/port_state_def.h
+++ b/applications/nrf_desktop/configuration/nrf5340dk_nrf5340_cpuapp/port_state_def.h
@@ -33,12 +33,12 @@ static const struct pin_state port1_off[] = {
 
 static const struct port_state port_state_on[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_on,
 		.ps_count = ARRAY_SIZE(port0_on),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_on,
 		.ps_count = ARRAY_SIZE(port1_on),
 	}
@@ -46,12 +46,12 @@ static const struct port_state port_state_on[] = {
 
 static const struct port_state port_state_off[] = {
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio0)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 		.ps       = port0_off,
 		.ps_count = ARRAY_SIZE(port0_off),
 	},
 	{
-		.name     = DT_LABEL(DT_NODELABEL(gpio1)),
+		.port     = DEVICE_DT_GET(DT_NODELABEL(gpio1)),
 		.ps       = port1_off,
 		.ps_count = ARRAY_SIZE(port1_off),
 	}

--- a/applications/nrf_desktop/doc/ble_qos.rst
+++ b/applications/nrf_desktop/doc/ble_qos.rst
@@ -32,7 +32,8 @@ The library is linked if :ref:`CONFIG_DESKTOP_BLE_QOS_ENABLE <config_desktop_app
 Enable the module using the :ref:`CONFIG_DESKTOP_BLE_QOS_ENABLE <config_desktop_app_options>` Kconfig option.
 The option selects :kconfig:option:`CONFIG_BT_HCI_VS_EVT_USER`, because the module uses vendor-specific HCI events.
 
-You can use the :ref:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE <config_desktop_app_options>` option to enable real-time QoS information printouts through a virtual COM port (serial port emulated over USB).
+You can use the :ref:`CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE <config_desktop_app_options>` option to enable real-time QoS information printouts through a UART (e.g. a virtual COM port).
+The chosen UART needs to be specified in Devicetree using ``ncs,ble-qos-uart``.
 This option also enables and configures the COM port (USB CDC ACM).
 For this reason, the :kconfig:option:`CONFIG_USB_DEVICE_STACK` must be enabled.
 

--- a/applications/nrf_desktop/src/hw_interface/wheel.c
+++ b/applications/nrf_desktop/src/hw_interface/wheel.c
@@ -63,7 +63,7 @@ static const struct sensor_trigger qdec_trig = {
 };
 
 static const struct device *qdec_dev = DEVICE_DT_GET(DT_NODELABEL(qdec));
-static const struct device *gpio_dev;
+static const struct device *const gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 static struct gpio_callback gpio_cbs[2];
 static struct k_spinlock lock;
 static struct k_work_delayable idle_timeout;
@@ -311,10 +311,9 @@ static int init(void)
 		return -ENODEV;
 	}
 
-	gpio_dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
-	if (!gpio_dev) {
-		LOG_ERR("Cannot get GPIO device");
-		return -ENXIO;
+	if (!device_is_ready(gpio_dev)) {
+		LOG_ERR("GPIO device not ready");
+		return -ENODEV;
 	}
 
 	BUILD_ASSERT(ARRAY_SIZE(qdec_pin) == ARRAY_SIZE(gpio_cbs),

--- a/applications/nrf_desktop/src/modules/ble_qos.c
+++ b/applications/nrf_desktop/src/modules/ble_qos.c
@@ -39,12 +39,6 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_DESKTOP_BLE_QOS_LOG_LEVEL);
 # endif
 #endif
 
-#ifdef CONFIG_USB_CDC_ACM_DEVICE_NAME
-#define USB_SERIAL_DEVICE_NAME CONFIG_USB_CDC_ACM_DEVICE_NAME
-#else
-#define USB_SERIAL_DEVICE_NAME  ""
-#endif
-
 #ifndef ROUNDED_DIV
 #define ROUNDED_DIV(a, b)  (((a) + ((b) / 2)) / (b))
 #endif /* ROUNDED_DIV */
@@ -106,7 +100,8 @@ BUILD_ASSERT(THREAD_PRIORITY >= CONFIG_BT_HCI_TX_PRIO);
 
 static void ble_qos_thread_fn(void);
 
-static const struct device *cdc_dev;
+static const struct device *const cdc_dev =
+	DEVICE_DT_GET_OR_NULL(DT_CHOSEN(ncs_ble_qos_uart));
 static uint32_t cdc_dtr;
 
 enum ble_qos_opt {
@@ -696,9 +691,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			atomic_set(&params_updated, false);
 
 			if (IS_ENABLED(CONFIG_DESKTOP_BLE_QOS_STATS_PRINTOUT_ENABLE)) {
-				cdc_dev = device_get_binding(
-					USB_SERIAL_DEVICE_NAME "_0");
-				__ASSERT_NO_MSG(cdc_dev != NULL);
+				__ASSERT_NO_MSG(device_is_ready(cdc_dev));
 				/* CONFIG_UART_LINE_CTRL == 1: dynamic dtr */
 				cdc_dtr = !IS_ENABLED(CONFIG_UART_LINE_CTRL);
 			}

--- a/applications/nrf_desktop/src/modules/watchdog.c
+++ b/applications/nrf_desktop/src/modules/watchdog.c
@@ -17,18 +17,21 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_DESKTOP_WATCHDOG_LOG_LEVEL);
 #define WDT_FEED_WORKER_DELAY_MS ((CONFIG_DESKTOP_WATCHDOG_TIMEOUT)/3)
 
 struct wdt_data_storage {
-	const struct device *wdt_drv;
+	const struct device *const wdt;
 	int wdt_channel_id;
 	struct k_work_delayable work;
 };
-static struct wdt_data_storage wdt_data;
+
+static struct wdt_data_storage wdt_data = {
+	.wdt = DEVICE_DT_GET(DT_NODELABEL(wdt)),
+};
 
 static void watchdog_feed_worker(struct k_work *work_desc)
 {
 	struct wdt_data_storage *data =
 			CONTAINER_OF(work_desc, struct wdt_data_storage, work);
 
-	int err = wdt_feed(data->wdt_drv, data->wdt_channel_id);
+	int err = wdt_feed(data->wdt, data->wdt_channel_id);
 
 	if (err) {
 		LOG_ERR("Cannot feed watchdog. Error code: %d", err);
@@ -53,7 +56,7 @@ static int watchdog_timeout_install(struct wdt_data_storage *data)
 	__ASSERT_NO_MSG(data != NULL);
 
 	data->wdt_channel_id = wdt_install_timeout(
-			data->wdt_drv, &wdt_settings);
+			data->wdt, &wdt_settings);
 	if (data->wdt_channel_id < 0) {
 		LOG_ERR("Cannot install watchdog timer! Error code: %d",
 			data->wdt_channel_id);
@@ -68,7 +71,7 @@ static int watchdog_start(struct wdt_data_storage *data)
 {
 	__ASSERT_NO_MSG(data != NULL);
 
-	int err = wdt_setup(data->wdt_drv, WDT_OPT_PAUSE_HALTED_BY_DBG);
+	int err = wdt_setup(data->wdt, WDT_OPT_PAUSE_HALTED_BY_DBG);
 
 	if (err) {
 		LOG_ERR("Cannot start watchdog! Error code: %d", err);
@@ -100,12 +103,11 @@ static int watchdog_enable(struct wdt_data_storage *data)
 {
 	__ASSERT_NO_MSG(data != NULL);
 
-	int err = -ENXIO;
+	int err;
 
-	data->wdt_drv = device_get_binding(DT_LABEL(DT_NODELABEL(wdt)));
-	if (data->wdt_drv == NULL) {
-		LOG_ERR("Cannot bind watchdog driver");
-		return err;
+	if (!device_is_ready(data->wdt)) {
+		LOG_ERR("Watchdog device not ready");
+		return -ENODEV;
 	}
 
 	err = watchdog_timeout_install(data);


### PR DESCRIPTION
Obtain device instances at compile time using DEVICE_DT_GET. Refer to each individual commit for more details.