### PR TITLE
doc: openthread: update SHA of recommended OT Border Router

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -73,6 +73,7 @@ Thread
 * Removed support for Thread Border Router as part of the Master library feature set.
 * Fixed a bug in which a Minimal Thread Device was not able to handle Address Error Notification messages.
 * Updated the values in the memory requirement tables in :ref:`thread_ot_memory` after the update to the :ref:`nrfxlib:ot_libs` in nrfxlib.
+* Updated recommended version of OpenThread Border Router and the accompanying ``nrfconnect/otbr`` docker image.
 
 See `Thread samples`_ for the list of changes for the Thread samples.
 

--- a/doc/nrf/ug_thread_tools.rst
+++ b/doc/nrf/ug_thread_tools.rst
@@ -175,7 +175,7 @@ To set up and configure the OpenThread Border Router, follow the official `OpenT
 
       cd ot-br-posix
       git pull --unshallow
-      git checkout 4b04548
+      git checkout 1813352
 
 * After the *Build and install OTBR* section, configure RCP device's UART baud rate in *otbr-agent*.
   Modify the :file:`/etc/default/otbr-agent` configuration file with default RCP baud rate:
@@ -217,7 +217,7 @@ To install and configure the OpenThread Border Router using the Docker container
 
    .. code-block:: console
 
-      docker pull nrfconnect/otbr:4b04548
+      docker pull nrfconnect/otbr:1813352
 
 #. Connect the radio co-processor that you configured in :ref:`ug_thread_tools_tbr_rcp` to the Border Router device.
 #. Start the OpenThread Border Router container using the following commands:
@@ -227,7 +227,7 @@ To install and configure the OpenThread Border Router using the Docker container
       sudo modprobe ip6table_filter
       sudo docker run -it --rm --privileged --name otbr --network otbr -p 8080:80 \
       --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1" \
-      --volume /dev/ttyACM0:/dev/radio nrfconnect/otbr:4b04548 --radio-url spinel+hdlc+uart:///dev/radio?uart-baudrate=1000000
+      --volume /dev/ttyACM0:/dev/radio nrfconnect/otbr:1813352 --radio-url spinel+hdlc+uart:///dev/radio?uart-baudrate=1000000
 
    Replace ``/dev/ttyACM0`` with the device node name of the OpenThread radio co-processor.
 


### PR DESCRIPTION
Updated OTBR revision to be compatible with Thread RCP.

Signed-off-by: Lukasz Duda <lukasz.duda@nordicsemi.no>