### PR TITLE
lib: st23r3911b: use gpio-dt-spec

### DIFF
--- a/samples/bluetooth/central_nfc_pairing/nrf52833dk_nrf52833.overlay
+++ b/samples/bluetooth/central_nfc_pairing/nrf52833dk_nrf52833.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 3 0>;
-		led-nfca-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/bluetooth/central_nfc_pairing/nrf52840dk_nrf52840.overlay
+++ b/samples/bluetooth/central_nfc_pairing/nrf52840dk_nrf52840.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 3 0>;
-		led-nfca-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/bluetooth/central_nfc_pairing/nrf52dk_nrf52832.overlay
+++ b/samples/bluetooth/central_nfc_pairing/nrf52dk_nrf52832.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 3 0>;
-		led-nfca-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/bluetooth/central_nfc_pairing/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/central_nfc_pairing/nrf5340dk_nrf5340_cpuapp.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 4 0>;
-		led-nfca-gpios = <&gpio0 7 0>;
+		irq-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/nfc/tag_reader/nrf52833dk_nrf52833.overlay
+++ b/samples/nfc/tag_reader/nrf52833dk_nrf52833.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 3 0>;
-		led-nfca-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/nfc/tag_reader/nrf52840dk_nrf52840.overlay
+++ b/samples/nfc/tag_reader/nrf52840dk_nrf52840.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 3 0>;
-		led-nfca-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/nfc/tag_reader/nrf52dk_nrf52832.overlay
+++ b/samples/nfc/tag_reader/nrf52dk_nrf52832.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 3 0>;
-		led-nfca-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/nfc/tag_reader/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/nfc/tag_reader/nrf5340dk_nrf5340_cpuapp.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 4 0>;
-		led-nfca-gpios = <&gpio0 7 0>;
+		irq-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/nfc/tnep_poller/nrf52833dk_nrf52833.overlay
+++ b/samples/nfc/tnep_poller/nrf52833dk_nrf52833.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 3 0>;
-		led-nfca-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/nfc/tnep_poller/nrf52840dk_nrf52840.overlay
+++ b/samples/nfc/tnep_poller/nrf52840dk_nrf52840.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 3 0>;
-		led-nfca-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/nfc/tnep_poller/nrf52dk_nrf52832.overlay
+++ b/samples/nfc/tnep_poller/nrf52dk_nrf52832.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 3 0>;
-		led-nfca-gpios = <&gpio0 29 0>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/samples/nfc/tnep_poller/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/nfc/tnep_poller/nrf5340dk_nrf5340_cpuapp.overlay
@@ -11,8 +11,8 @@
 		compatible = "st,st25r3911b";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
-		irq-gpios = <&gpio0 4 0>;
-		led-nfca-gpios = <&gpio0 7 0>;
+		irq-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		led-nfca-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 	};
 };
 


### PR DESCRIPTION
Modernize library by using gpio-dt-spec facilities.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>