### PR TITLE
lib: at_host: use ncs,at-host-uart

### DIFF
--- a/doc/nrf/libraries/modem/at_host.rst
+++ b/doc/nrf/libraries/modem/at_host.rst
@@ -24,11 +24,16 @@ The various configuration options used in the library are listed below:
 * :kconfig:option:`CONFIG_AT_HOST_CMD_MAX_LEN` - Sets the maximum length for an AT command
 * :kconfig:option:`CONFIG_AT_HOST_THREAD_PRIO` - Sets the priority level for the AT host work queue thread
 
-Configuration options for setting the UART:
+The library will use ``uart0`` by default.
+However, ``ncs,at-host-uart`` choice in devicetree can be used to change the UART device in the following way:
 
-* :kconfig:option:`CONFIG_AT_HOST_UART_0` - Enables UART 0
-* :kconfig:option:`CONFIG_AT_HOST_UART_1` - Enables UART 1
-* :kconfig:option:`CONFIG_AT_HOST_UART_2` - Enables UART 2
+.. code-block:: devicetree
+
+   / {
+      chosen {
+         ncs,at-host-uart = &uart1;
+      };
+   };
 
 Configuration options for setting the termination character:
 

--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -11,29 +11,6 @@ menuconfig AT_HOST_LIBRARY
 
 if AT_HOST_LIBRARY
 
-choice
-	prompt "UART for AT Host"
-	default AT_HOST_UART_0
-	depends on AT_HOST_LIBRARY
-	help
-		Sets the UART to use for the AT Host
-		-  UART 0
-		-  UART 1
-		-  UART 2
-	config AT_HOST_UART_0
-		bool "UART 0"
-	config AT_HOST_UART_1
-		bool "UART 1"
-	config AT_HOST_UART_2
-		bool "UART 2"
-endchoice
-
-config AT_HOST_UART
-	int
-	default 0 if AT_HOST_UART_0
-	default 1 if AT_HOST_UART_1
-	default 2 if AT_HOST_UART_2
-
 config AT_HOST_UART_INIT_TIMEOUT
 	int "Timeout waiting for a valid UART line on init (ms)"
 	help


### PR DESCRIPTION
Move AT Host UART choice to Devicetree by using ncs,at-host-uart. This
allows to obtain the UART device reference at compile time.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>