### PR TITLE
mpsl: Production support for 1wire coex

### DIFF
--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -58,8 +58,7 @@ config MPSL_CX_BT_1WIRE
 	select NRFX_GPIOTE
 	select GPIO
 	select NRFX_TIMER1
-	select EXPERIMENTAL
-	bool "Bluetooth Radio 1-Wire Coexistence [EXPERIMENTAL]"
+	bool "Bluetooth Radio 1-Wire Coexistence"
 	help
 	  Radio Coexistence interface implementation using a simple 1-wire PTA
 	  implementation for co-located radios.


### PR DESCRIPTION
Marks 1 wire coex as supported for production in the Kconfig.