### PR TITLE
lib: adp536x: require device to initialize

### DIFF
--- a/boards/arm/thingy91_nrf9160/adp5360_init.c
+++ b/boards/arm/thingy91_nrf9160/adp5360_init.c
@@ -10,7 +10,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(board_secure, CONFIG_BOARD_LOG_LEVEL);
 
-#define ADP536X_I2C_DEV_NAME	DT_LABEL(DT_NODELABEL(i2c2))
+#define ADP536X_I2C_DEVICE	DEVICE_DT_GET(DT_NODELABEL(i2c2))
 #define LC_MAX_READ_LENGTH	128
 
 /* The BH1749 on must be powered by the ADP5360 before it can be initialized. */
@@ -24,7 +24,7 @@ static int power_mgmt_init(void)
 {
 	int err;
 
-	err = adp536x_init(ADP536X_I2C_DEV_NAME);
+	err = adp536x_init(ADP536X_I2C_DEVICE);
 	if (err) {
 		LOG_ERR("ADP536X failed to initialize, error: %d\n", err);
 		return err;

--- a/include/adp536x.h
+++ b/include/adp536x.h
@@ -14,7 +14,10 @@
  * @{
  */
 
-#include <zephyr/kernel.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <zephyr/device.h>
 
 /* Definition of VBUS current limit values. */
 #define ADP536X_VBUS_ILIM_50mA		0x00
@@ -49,12 +52,12 @@
 /**
  * @brief Initialize ADP536X.
  *
- * @param[in] dev_name Pointer to the device name.
+ * @param[in] dev Pointer to the I2C bus device.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int adp536x_init(const char *dev_name);
+int adp536x_init(const struct device *dev);
 
 /**
  * @brief Set the VBUS current limit.

--- a/lib/adp536x/adp536x.c
+++ b/lib/adp536x/adp536x.c
@@ -291,12 +291,13 @@ int adp536x_factory_reset(void)
 	return 0;
 }
 
-int adp536x_init(const char *dev_name)
+int adp536x_init(const struct device *dev)
 {
-	i2c_dev = device_get_binding(dev_name);
-	if (i2c_dev == NULL) {
+	if (!device_is_ready(dev)) {
 		return -ENODEV;
 	}
+
+	i2c_dev = dev;
 
 	return 0;
 }


### PR DESCRIPTION
Instead of requiring a device label, require a device pointer. This
allows caller to obtain the device reference at compile time.

Note that this pseudo-driver needs to be refactored as a proper driver.
See NCSDK-16202.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>