### PR TITLE
bluetooth: remove now unused config

### DIFF
--- a/doc/nrf/app_memory.rst
+++ b/doc/nrf/app_memory.rst
@@ -48,7 +48,6 @@ Besides applying `General recommendations`_, you can also complete the following
 
   The following configuration options affect the stack sizes of the Bluetooth threads:
 
-  * :kconfig:option:`CONFIG_BT_CTLR_SDC_RX_STACK_SIZE`
   * :kconfig:option:`CONFIG_BT_RX_STACK_SIZE`
   * :kconfig:option:`CONFIG_BT_HCI_TX_STACK_SIZE`
   * :kconfig:option:`CONFIG_MPSL_WORK_STACK_SIZE`

--- a/samples/bluetooth/peripheral_lbs/prj_minimal.conf
+++ b/samples/bluetooth/peripheral_lbs/prj_minimal.conf
@@ -71,7 +71,6 @@ CONFIG_ARM_MPU=n
 # idle 00             : unused 192 usage 64 / 256 (25 %)
 # main                : unused 136 usage 888 / 1024 (86 %)
 # Configurations set based on thread analyzer output.
-CONFIG_BT_CTLR_SDC_RX_STACK_SIZE=324
 CONFIG_BT_RX_STACK_SIZE=1024
 CONFIG_BT_HCI_TX_STACK_SIZE_WITH_PROMPT=y
 CONFIG_BT_HCI_TX_STACK_SIZE=640

--- a/samples/bluetooth/peripheral_uart/prj_minimal.conf
+++ b/samples/bluetooth/peripheral_uart/prj_minimal.conf
@@ -90,7 +90,6 @@ CONFIG_ARM_MPU=n
 #MPSL signal         : unused 928 usage 96 / 1024 (9 %)
 #idle 00             : unused 224 usage 96 / 320 (30 %)
 #main                : unused 568 usage 456 / 1024 (44 %)
-CONFIG_BT_CTLR_SDC_RX_STACK_SIZE=324
 CONFIG_BT_RX_STACK_SIZE=1024
 CONFIG_BT_HCI_TX_STACK_SIZE_WITH_PROMPT=y
 CONFIG_BT_HCI_TX_STACK_SIZE=640

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -145,13 +145,6 @@ config BT_CTLR_SDC_RX_PRIO
 	int
 	default BT_DRIVER_RX_HIGH_PRIO
 
-config BT_CTLR_SDC_RX_STACK_SIZE
-	int "Size of the receive thread stack"
-	default 1024
-	help
-	  Size of the receiving thread stack, used to retrieve HCI events and
-	  data from the controller.
-
 # CONFIG_BT_CTLR_DF is declared in Zephyr and also here for a second time,
 # to avoid BT_CTLR_DF_SUPPORT dependency.
 config BT_CTLR_DF


### PR DESCRIPTION
I couldn't find this config beeing used anywhere. So I propose removing it.
I might be surprised when CI is run now though.
