### PR TITLE
applications: nrf5340_audio: change SDMMC_OVER_SPI to SPI_SDHC

### DIFF
--- a/applications/nrf5340_audio/prj.conf
+++ b/applications/nrf5340_audio/prj.conf
@@ -8,7 +8,7 @@
 CONFIG_NRF5340_AUDIO=y
 CONFIG_REBOOT=y
 CONFIG_MAIN_THREAD_PRIORITY=10
-CONFIG_MAIN_STACK_SIZE=1940
+CONFIG_MAIN_STACK_SIZE=3616
 
 # Disable Zephyr HCI Vendor-Specific extensions
 CONFIG_BT_HCI_VS_EXT=n
@@ -70,3 +70,7 @@ CONFIG_NCS_INCLUDE_RPMSG_CHILD_IMAGE=n
 # Workaround to not use fatal_error.c in NCS. Note that the system may still
 # reset on error depending on the build configuraion
 CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Suppress err msg from sd_check_card_type. Because SPI_SDHC has no card presence method,
+# assume card is in slot. Thus error message is always shown if card is not inserted
+CONFIG_SD_LOG_LEVEL_OFF=y

--- a/applications/nrf5340_audio/src/modules/sd_card.c
+++ b/applications/nrf5340_audio/src/modules/sd_card.c
@@ -40,6 +40,7 @@ int sd_card_list_files(char *path)
 	if (!sd_init_success) {
 		return -ENODEV;
 	}
+	fs_dir_t_init(&dirp);
 
 	if (path == NULL) {
 		ret = fs_opendir(&dirp, sd_root_path);
@@ -103,6 +104,7 @@ int sd_card_write(char const *const filename, char const *const data, size_t *si
 	}
 
 	strcat(abs_path_name, filename);
+	fs_file_t_init(&f_entry);
 
 	ret = fs_open(&f_entry, abs_path_name, FS_O_CREATE | FS_O_WRITE | FS_O_APPEND);
 	if (ret) {
@@ -150,6 +152,7 @@ int sd_card_read(char const *const filename, char *const data, size_t *size)
 	}
 
 	strcat(abs_path_name, filename);
+	fs_file_t_init(&f_entry);
 
 	ret = fs_open(&f_entry, abs_path_name, FS_O_READ);
 	if (ret) {

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dts
@@ -71,10 +71,15 @@
 	pinctrl-1 = <&spi4_sleep>;
 	pinctrl-names = "default", "sleep";
 	sdhc0: sdhc@0 {
-		compatible = "zephyr,mmc-spi-slot";
+		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		status = "okay";
 		label = "SDHC0";
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			status = "okay";
+		};
+
 		spi-max-frequency = <8000000>;
 	};
 	cs47l63: cs47l63@1 {


### PR DESCRIPTION
SDMMC_OVER_SPI has been removed in commit [102f4c2 ](https://github.com/nrfconnect/sdk-zephyr/commit/102f4c25f8bf11d7563ee765a4d911b2e483844d).
Change SD card reader driver to SPI_SDHC.
Increase main stack size for SPI_SDHC.
Initial file entry before using it to prevent busfault.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>