### PR TITLE
boards: arm: thingy91_nrf9160: Change pwmleds frequency

### DIFF
--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
@@ -55,13 +55,13 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 0 PWM_MSEC(8) PWM_POLARITY_NORMAL>;
 		};
 		pwm_led1: pwm_led_1 {
-			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 1 PWM_MSEC(8) PWM_POLARITY_NORMAL>;
 		};
 		pwm_led2: pwm_led_2 {
-			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 2 PWM_MSEC(8) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -369,6 +369,14 @@ Other samples
 
 |no_changes_yet_note|
 
+Devicetree configuration
+========================
+
+Thingy:91
+---------
+
+* Changed the PWM frequency of the pwmleds device from 50 Hz to 125 Hz.
+
 Drivers
 =======
 


### PR DESCRIPTION
Changed the PWM frequency of pwmleds from 50hz to 125hz

50hz is directly perceptible by most humans

125hz is significantly less perceptible

IRIS4619

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>