### PR TITLE
drivers: net: eth_rtt: allocate device from Devicetree

### DIFF
--- a/doc/nrf/drivers/eth_rtt.rst
+++ b/doc/nrf/drivers/eth_rtt.rst
@@ -42,7 +42,17 @@ The content of this frame is constant and it is available in the driver source c
 Initialization
 **************
 
-You can initialize the RTT driver using the :kconfig:option:`CONFIG_ETH_RTT` Kconfig option.
+You need to define one instance of the device in Devicetree like this:
+
+.. code-block:: devicetree
+
+  / {
+    eth-rtt {
+      compatible = "segger,eth-rtt";
+    };
+  };
+
+Driver can then be enabled by using the :kconfig:option:`CONFIG_ETH_RTT` Kconfig option.
 
 API documentation
 *****************

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -19,12 +19,6 @@ menuconfig ETH_RTT
 
 if ETH_RTT
 
-config ETH_RTT_DRV_NAME
-	string "Ethernet over RTT driver name"
-	default "eth_rtt"
-	help
-	  This option sets the driver name.
-
 config ETH_RTT_MAC_ADDR
 	string "MAC address for the interface"
 	default ""

--- a/drivers/net/eth_rtt.c
+++ b/drivers/net/eth_rtt.c
@@ -29,6 +29,8 @@
  * MTU.
  */
 
+#define DT_DRV_COMPAT segger_eth_rtt
+
 #define LOG_MODULE_NAME eth_rtt
 #define LOG_LEVEL CONFIG_ETH_RTT_LOG_LEVEL
 
@@ -543,7 +545,6 @@ static const struct ethernet_api if_api = {
 };
 
 /** Initialization of network device driver. */
-ETH_NET_DEVICE_INIT(eth_rtt, CONFIG_ETH_RTT_DRV_NAME, eth_rtt_init,
-		    NULL, &context_data, NULL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &if_api,
-		    CONFIG_ETH_RTT_MTU);
+ETH_NET_DEVICE_DT_INST_DEFINE(0, eth_rtt_init, NULL, &context_data, NULL,
+			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &if_api,
+			      CONFIG_ETH_RTT_MTU);

--- a/dts/bindings/net/segger,eth-rtt.yaml
+++ b/dts/bindings/net/segger,eth-rtt.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+description: Segger Ethernet RTT
+
+compatible: "segger,eth-rtt"
+
+include: base.yaml

--- a/samples/crypto/psa_tls/app.overlay
+++ b/samples/crypto/psa_tls/app.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	eth-rtt {
+		compatible = "segger,eth-rtt";
+	};
+};


### PR DESCRIPTION
Allocate device from Devicetree. This task is part of Device drivers
modernization work.