### PR TITLE
manifest: Update Zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d72a2bceca9d820ad3c982fa741682536380581c
+      revision: c892c51704ca8f82cb44d1216fd4e4e23164246d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Includes fixes needed for Bluetooth Host qualification, in particular
GAP/CONN/DCEP/BV-01-C.

Signed-off-by: Berget, Herman <herman.berget@nordicsemi.no>