### PR TITLE
lte: fix stack corruption caused by incorrect scanf format

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1075,7 +1075,7 @@ int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status)
 	err = nrf_modem_at_scanf("AT+CEREG?",
 		"+CEREG: "
 		"%*u,"		/* <n> */
-		"%u,"		/* <stat> */
+		"%hu,"		/* <stat> */
 		"%*[^,],"	/* <tac> */
 		"\"%x\",",	/* <ci> */
 		&status_tmp,


### PR DESCRIPTION
The status_tmp variable is a uint16_t, so the format string must
be %hu. Otherwise the stack will get corrupted.

For example lte_lc_nw_reg_status_get() is used in
date_time_ntp_get(int64_t *date_time_ms). There, the last two bytes of the
date_time_ms pointer will be set to 0. As a consequence another 8 bytes will
be corrupted somewhere in RAM when the SNTP result is written to this pointer.
Thus, time-sync over SNTP doesn't work.

Signed-off-by: Hubert Feurstein <h.feurstein@gmail.com>