### PR TITLE
doc: more fixes to tool name formatting

### DIFF
--- a/doc/nrf/doc_build_process.rst
+++ b/doc/nrf/doc_build_process.rst
@@ -38,7 +38,7 @@ The |NCS| documentation consists of multiple docsets.
 The main docset is the nRF documentation, while the other docsets are pulled from their upstream versions.
 The only file that is needed to maintain for this, is a customized :file:`conf.py` file located under :file:`doc/\\{docset-name\\}/`.
 To be able to make references across docsets, the Sphinx extension Intersphinx is used, and local paths are configured under :code:`intersphinx_mapping` in :file:`doc/nrf/conf.py`.
-The upstream docsets are pulled using ``west``.
+The upstream docsets are pulled using west.
 
 Building and publishing the documentation
 *****************************************
@@ -49,7 +49,7 @@ This is done through two chained GitHub actions, :file:`docbuild.yml` and :file:
 Docbuild
 --------
 Whenever a pull request is created the `docbuild`_ workflow is triggered.
-This will checkout all the relevant repositories with ``west``, install the necessary dependencies and build the documentation with ``cmake``.
+This will checkout all the relevant repositories with west, install the necessary dependencies and build the documentation with cmake.
 After the documentation is built a cache file is created using :file:`doc/_scripts/cache_create.py` which can be used locally to speed up builds.
 
 Docpublish

--- a/samples/nrf5340/netboot/README.rst
+++ b/samples/nrf5340/netboot/README.rst
@@ -102,7 +102,7 @@ After programming the sample to your development kit, complete the following ste
       I: Jumping to the first image slot
       *** Booting Zephyr OS build v2.7.99-ncs1-2195-g186cf4539e5a  ***
 
-#. Program the network core update image using ``nrfjprog``:
+#. Program the network core update image using nrfjprog:
 
    .. code-block:: console
 
@@ -110,7 +110,7 @@ After programming the sample to your development kit, complete the following ste
 
    .. note::
       Typically, the update image is received through serial interface or Bluetooth.
-      For testing purposes, use ``nrfjprog`` to program the update image directly into the update slot.
+      For testing purposes, use nrfjprog to program the update image directly into the update slot.
 
 
 #. Reset the kit.

--- a/scripts/west_commands/sbom/README.rst
+++ b/scripts/west_commands/sbom/README.rst
@@ -115,11 +115,11 @@ You can also mix them, for example, to generate a report for the application and
 
      -d build_directory
 
-  You have to first build the ``build_directory`` with the ``west build`` command using ``Ninja`` as the underlying build tool (default).
+  You have to first build the ``build_directory`` with the ``west build`` command using Ninja as the underlying build tool (default).
   The build must be successful.
   Any change in the application configuration may affect the results, so always rebuild it after reconfiguration and before calling the ``west ncs-sbom``.
 
-  You can skip this option if you are in the application directory and you have a default ``build`` directory there - the same way as in ``west build`` command.
+  You can skip this option if you are in the application directory and you have a default :file:`build` directory there - the same way as in ``west build`` command.
 
   The :ref:`west_sbom Extracting from build` section describes in detail how to extract a list of files from a build directory.
 
@@ -328,10 +328,10 @@ Extracting a list of files from a build directory
 *************************************************
 
 The ``ncs-sbom`` extracts a list of files from a build directory.
-It queries ``ninja`` for the targets and dependencies.
+It queries ninja for the targets and dependencies.
 
 The entry point is the :file:`zephyr/zephyr.elf` target file.
-The script asks ``ninja`` for all input targets of the :file:`zephyr/zephyr.elf` target.
+The script asks ninja for all input targets of the :file:`zephyr/zephyr.elf` target.
 It also asks for all input targets of the previously extracted input targets,
 until it reaches all leaves in the dependency tree.
 The result is a list of all the leaves.
@@ -345,15 +345,15 @@ To change the target or specify multiple targets, you can add them after the bui
 
 There are two additional methods for improving the correctness of the above algorithm:
 
-* Each library is examined using the GNU ``ar`` tool.
+* Each library is examined using the GNU ar tool.
 
-  If the list of files returned by the GNU ``ar`` tool is covered by the list returned from the ``ninja``, the list is assumed to be valid.
+  If the list of files returned by the GNU ar tool is covered by the list returned from the ninja, the list is assumed to be valid.
   Otherwise, the library is assumed to be a leaf, so it is shown in the report and its inputs are not analyzed further.
 
 * The ``ncs-sbom`` parses the :file:`.map` file created during the :file:`zephyr/zephyr.elf` linking.
 
   It provides a list of all object files and libraries linked to the :file:`zephyr/zephyr.elf` file.
-  The script ends with a fatal error if any file in the :file:`.map` file is not visible by ``ninja``.
+  The script ends with a fatal error if any file in the :file:`.map` file is not visible by ninja.
 
   Exceptions are the runtime and standard libraries.
   You can specify the list of exceptions with the ``--allowed-in-map-file-only`` option.


### PR DESCRIPTION
Due to my limited search before, I did not
catch all misspelled tool names. A new round
revealed a few more and this PR fixes them.

Ref: https://projecttools.nordicsemi.no/jira/browse/NCSDK-16136

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>