### PR TITLE
kconfig: mpsl: Mark 1-wire coex as supported for production

### DIFF
--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -58,8 +58,7 @@ config MPSL_CX_BT_1WIRE
 	select NRFX_GPIOTE
 	select GPIO
 	select NRFX_TIMER1
-	select EXPERIMENTAL
-	bool "Bluetooth Radio 1-Wire Coexistence [EXPERIMENTAL]"
+	bool "Bluetooth Radio 1-Wire Coexistence"
 	help
 	  Radio Coexistence interface implementation using a simple 1-wire PTA
 	  implementation for co-located radios.

--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: d5b5156e32ccb1897a26f4885317cd11193773b0
+      revision: c3c9b6bb1d73abed1a775ec0dca4e29d3ccc301e
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Remove "experimental" tag for MPSL_CX_BT_1WIRE in Kconfig.

Related PR in sdk-nrfxlib to update the changelog and documentation: https://github.com/nrfconnect/sdk-nrfxlib/pull/789

Signed-off-by: Olav Thoresen <olav.thoresen@nordicsemi.no>