### PR TITLE
manifest: update Zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8e883581d322f9212f50cfb15f686873a96d6a29
+      revision: c5689f8516fa094c34ee6c0f36d51b7115c2ea3f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr to pull changes aligning RAI related values
with modemlib's.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>

Zephyr: https://github.com/nrfconnect/sdk-zephyr/pull/864