### PR TITLE
samples: peripheral_gatt_dm: Fix pairing unref

### DIFF
--- a/samples/bluetooth/peripheral_gatt_dm/src/main.c
+++ b/samples/bluetooth/peripheral_gatt_dm/src/main.c
@@ -160,8 +160,8 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 	printk("Pairing failed conn: %s, reason %d\n", addr, reason);
 
 	if (pairing_confirmation_conn) {
-		pairing_confirmation_conn = NULL;
 		bt_conn_unref(pairing_confirmation_conn);
+		pairing_confirmation_conn = NULL;
 	}
 }
 


### PR DESCRIPTION
The sample was unreferencing a Bluetooth connection which
has been nulled in the previous statement.

Signed-off-by: Pavel Hübner <pavel.hubner@hardwario.com>