### PR TITLE
modules: hal_nordic: Extend functionality of the 802154 lp_timer platform

### DIFF
--- a/modules/nrfxlib/nrf_802154/sl/platform/nrf_802154_platform_sl_lptimer_zephyr.c
+++ b/modules/nrfxlib/nrf_802154/sl/platform/nrf_802154_platform_sl_lptimer_zephyr.c
@@ -7,13 +7,16 @@
 #include "platform/nrf_802154_platform_sl_lptimer.h"
 
 #include <assert.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/kernel.h>
 
 #include <zephyr/drivers/timer/nrf_rtc_timer.h>
+#include <helpers/nrfx_gppi.h>
 
 #include "platform/nrf_802154_clock.h"
 #include "nrf_802154_sl_utils.h"
 
+#define RTC_CHAN_INVALID (-1)
 
 struct timer_desc {
 	z_nrf_rtc_timer_compare_handler_t handler;
@@ -22,8 +25,23 @@ struct timer_desc {
 	int32_t int_lock_key;
 };
 
+enum hw_task_state_type {
+	HW_TASK_STATE_IDLE,
+	HW_TASK_STATE_SETTING_UP,
+	HW_TASK_STATE_READY,
+	HW_TASK_STATE_UPDATING,
+	HW_TASK_STATE_CLEANING
+};
+
+struct hw_task_desc {
+	atomic_t state;
+	int32_t chan;
+	int32_t ppi;
+};
+
 static struct timer_desc m_timer;
 static struct timer_desc m_sync_timer;
+static struct hw_task_desc m_hw_task;
 static volatile bool m_clock_ready;
 static bool m_in_critical_section;
 
@@ -79,9 +97,41 @@ static void timer_start_at(struct timer_desc *timer, uint64_t target_time)
 	nrf_802154_sl_mcu_critical_exit(state);
 }
 
+static bool hw_task_state_set(enum hw_task_state_type expected_state,
+			      enum hw_task_state_type new_state)
+{
+	return atomic_cas(&m_hw_task.state, expected_state, new_state);
+}
+
+static void cc_bind_to_ppi(int32_t cc_num, uint32_t ppi_num)
+{
+	uint32_t event_address = z_nrf_rtc_timer_compare_evt_address_get(cc_num);
+
+	nrfx_gppi_event_endpoint_setup(ppi_num, event_address);
+}
+
+static void cc_unbind(int32_t cc_num, uint32_t ppi_num)
+{
+	if (ppi_num != NRF_802154_SL_HW_TASK_PPI_INVALID) {
+		uint32_t event_address = z_nrf_rtc_timer_compare_evt_address_get(cc_num);
+
+		nrfx_gppi_event_endpoint_clear(ppi_num, event_address);
+	}
+}
+
+static bool cc_event_check(int32_t cc_num)
+{
+	uint32_t event_address = z_nrf_rtc_timer_compare_evt_address_get(cc_num);
+
+	return *(volatile uint32_t *)event_address;
+}
+
 void nrf_802154_platform_sl_lp_timer_init(void)
 {
 	m_in_critical_section = false;
+	m_hw_task.state = HW_TASK_STATE_IDLE;
+	m_hw_task.chan = RTC_CHAN_INVALID;
+	m_hw_task.ppi = NRF_802154_SL_HW_TASK_PPI_INVALID;
 	m_timer.handler = timer_handler;
 	m_sync_timer.handler = sync_timer_handler;
 
@@ -106,6 +156,11 @@ void nrf_802154_platform_sl_lp_timer_deinit(void)
 
 	z_nrf_rtc_timer_chan_free(m_timer.chan);
 	z_nrf_rtc_timer_chan_free(m_sync_timer.chan);
+
+	if (m_hw_task.chan != RTC_CHAN_INVALID) {
+		z_nrf_rtc_timer_chan_free(m_hw_task.chan);
+		m_hw_task.chan = RTC_CHAN_INVALID;
+	}
 }
 
 uint64_t nrf_802154_platform_sl_lptimer_current_lpticks_get(void)
@@ -200,4 +255,99 @@ uint32_t nrf_802154_platform_sl_lptimer_sync_event_get(void)
 uint64_t nrf_802154_platform_sl_lptimer_sync_lpticks_get(void)
 {
 	return m_sync_timer.target_time;
+}
+
+nrf_802154_sl_lptimer_platform_result_t nrf_802154_platform_sl_lptimer_hw_task_prepare(
+	uint64_t fire_lpticks,
+	uint32_t ppi_channel)
+{
+	uint32_t evt_address;
+	nrf_802154_sl_mcu_critical_state_t mcu_cs_state;
+
+	if (!hw_task_state_set(HW_TASK_STATE_IDLE, HW_TASK_STATE_SETTING_UP)) {
+		/* The only one available set of peripherals is already used. */
+		return NRF_802154_SL_LPTIMER_PLATFORM_NO_RESOURCES;
+	}
+
+	/* Allocate the channel if not already done. */
+	if (m_hw_task.chan == RTC_CHAN_INVALID) {
+		/* The channel allocation cannot take place during module
+		 * initialization, because for nRF53 it would run
+		 * out of resources - some other module temporarily needs
+		 * an rtc channel to initialize. For this reason, this is where
+		 * the allocation is made.
+		 * Once a channel has been successfully allocated, it will be held
+		 * until nrf_802154_platform_sl_lp_timer_deinit is called.
+		 */
+		m_hw_task.chan = z_nrf_rtc_timer_chan_alloc();
+		if (m_hw_task.chan < 0) {
+			m_hw_task.chan = RTC_CHAN_INVALID;
+			hw_task_state_set(HW_TASK_STATE_SETTING_UP, HW_TASK_STATE_IDLE);
+			return NRF_802154_SL_LPTIMER_PLATFORM_NO_RESOURCES;
+		}
+	}
+
+	if (z_nrf_rtc_timer_set(m_hw_task.chan, fire_lpticks, NULL, NULL) != 0) {
+		hw_task_state_set(HW_TASK_STATE_SETTING_UP, HW_TASK_STATE_IDLE);
+		return NRF_802154_SL_LPTIMER_PLATFORM_TOO_DISTANT;
+	}
+
+	evt_address = z_nrf_rtc_timer_compare_evt_address_get(m_hw_task.chan);
+
+	nrf_802154_sl_mcu_critical_enter(mcu_cs_state);
+
+	/* For triggering to take place a safe margin is 2 lpticks from `now`. */
+	if ((z_nrf_rtc_timer_read() + 2) > fire_lpticks) {
+		/* it is too late */
+		nrf_802154_sl_mcu_critical_exit(mcu_cs_state);
+		cc_unbind(m_hw_task.chan, ppi_channel);
+		m_hw_task.ppi = NRF_802154_SL_HW_TASK_PPI_INVALID;
+		z_nrf_rtc_timer_abort(m_hw_task.chan);
+		hw_task_state_set(HW_TASK_STATE_SETTING_UP, HW_TASK_STATE_IDLE);
+		return NRF_802154_SL_LPTIMER_PLATFORM_TOO_LATE;
+	}
+
+	if (ppi_channel != NRF_802154_SL_HW_TASK_PPI_INVALID) {
+		nrfx_gppi_event_endpoint_setup(ppi_channel, evt_address);
+	}
+	m_hw_task.ppi = ppi_channel;
+	nrf_802154_sl_mcu_critical_exit(mcu_cs_state);
+	hw_task_state_set(HW_TASK_STATE_SETTING_UP, HW_TASK_STATE_READY);
+	return NRF_802154_SL_LPTIMER_PLATFORM_SUCCESS;
+}
+
+nrf_802154_sl_lptimer_platform_result_t nrf_802154_platform_sl_lptimer_hw_task_cleanup(void)
+{
+	if (!hw_task_state_set(HW_TASK_STATE_READY, HW_TASK_STATE_CLEANING)) {
+		return NRF_802154_SL_LPTIMER_PLATFORM_WRONG_STATE;
+	}
+
+	z_nrf_rtc_timer_abort(m_hw_task.chan);
+
+	cc_unbind(m_hw_task.chan, m_hw_task.ppi);
+	m_hw_task.ppi = NRF_802154_SL_HW_TASK_PPI_INVALID;
+
+	hw_task_state_set(HW_TASK_STATE_CLEANING, HW_TASK_STATE_IDLE);
+
+	return NRF_802154_SL_LPTIMER_PLATFORM_SUCCESS;
+}
+
+nrf_802154_sl_lptimer_platform_result_t nrf_802154_platform_sl_lptimer_hw_task_update_ppi(
+	uint32_t ppi_channel)
+{
+	bool cc_triggered;
+
+	if (!hw_task_state_set(HW_TASK_STATE_READY, HW_TASK_STATE_UPDATING)) {
+		return NRF_802154_SL_LPTIMER_PLATFORM_WRONG_STATE;
+	}
+
+	cc_bind_to_ppi(m_hw_task.chan, ppi_channel);
+	m_hw_task.ppi = ppi_channel;
+
+	cc_triggered = cc_event_check(m_hw_task.chan);
+
+	hw_task_state_set(HW_TASK_STATE_UPDATING, HW_TASK_STATE_READY);
+
+	return cc_triggered ? NRF_802154_SL_LPTIMER_PLATFORM_TOO_LATE :
+	       NRF_802154_SL_LPTIMER_PLATFORM_SUCCESS;
 }

--- a/west.yml
+++ b/west.yml
@@ -115,7 +115,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 7dd2e19bf585e17c3572c87dc70151d58e1a2f1b
+      revision: d8c456d422a1180a564fc276ca8b06317f5717f4
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Adds new functionality to the lp_timer platform that is needed to implement SL timer hardware task feature.
~~(changes depend on https://github.com/nrfconnect/sdk-zephyr/pull/875)~~
(changes depend on https://github.com/nrfconnect/sdk-nrfxlib/pull/790)
