### PR TITLE
tree: Remove CI checks on nrf51 boards

### DIFF
--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -5,19 +5,17 @@ tests:
   sample.bluetooth.central_bas:
     harness: bluetooth
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth
   sample.bluetooth.central_bas.build:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -5,19 +5,17 @@ tests:
   sample.bluetooth.central_hids:
     harness: bluetooth
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth
   sample.bluetooth.central_hids.build:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_smp_client/sample.yaml
+++ b/samples/bluetooth/central_smp_client/sample.yaml
@@ -5,19 +5,17 @@ tests:
   sample.bluetooth.central_dfu_smp:
     harness: bluetooth
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth
   sample.bluetooth.central_dfu_smp.build:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -5,12 +5,11 @@ tests:
   sample.bluetooth.central_uart:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf21540dk_nrf52840
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf21540dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/enocean/sample.yaml
+++ b/samples/bluetooth/enocean/sample.yaml
@@ -5,8 +5,7 @@ tests:
   sample.bluetooth.enocean:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_gatt_dm/sample.yaml
+++ b/samples/bluetooth/peripheral_gatt_dm/sample.yaml
@@ -5,11 +5,10 @@ tests:
   sample.bluetooth.peripheral_gatt_dm:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -5,20 +5,18 @@ tests:
   sample.bluetooth.peripheral_hids_mouse:
     harness: bluetooth
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840
     tags: bluetooth
   sample.bluetooth.peripheral_hids_mouse.build:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
     tags: bluetooth ci_build
   sample.bluetooth.peripheral_hids_mouse.ble_rpc:

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -5,14 +5,13 @@ tests:
   sample.bluetooth.peripheral_lbs:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
       - thingy53_nrf5340_cpuapp_ns
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       thingy53_nrf5340_cpuapp_ns
     tags: bluetooth ci_build
@@ -20,24 +19,22 @@ tests:
     build_only: true
     extra_args: OVERLAY_CONFIG=prj_minimal.conf
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52810
       - nrf52840dk_nrf52811
       - nrf52833dk_nrf52820
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52810 nrf52840dk_nrf52811 nrf52833dk_nrf52820
+    platform_allow: nrf52dk_nrf52810 nrf52840dk_nrf52811 nrf52833dk_nrf52820
     tags: bluetooth ci_build
   sample.bluetooth.peripheral_lbs_no_security:
     build_only: true
     extra_args: CONFIG_BT_LBS_SECURITY_ENABLED=n
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - thingy53_nrf5340_cpuapp
       - thingy53_nrf5340_cpuapp_ns
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       thingy53_nrf5340_cpuapp_ns
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -4,11 +4,10 @@ sample:
 tests:
   sample.bluetooth.peripheral_uart:
     build_only: true
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
       nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
       thingy53_nrf5340_cpuapp_ns nrf21540dk_nrf52840
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840

--- a/samples/bluetooth/shell_bt_nus/sample.yaml
+++ b/samples/bluetooth/shell_bt_nus/sample.yaml
@@ -5,11 +5,10 @@ tests:
   sample.bluetooth.shell_bt_nus:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
       nrf5340dk_nrf5340_cpuapp_ns
     tags: bluetooth ci_build

--- a/samples/bootloader/sample.yaml
+++ b/samples/bootloader/sample.yaml
@@ -9,8 +9,7 @@ tests:
       - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
-      - nrf51dk_nrf51422
       - nrf21540dk_nrf52840
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160 nrf52840dk_nrf52840
-      nrf52833dk_nrf52833 nrf52dk_nrf52832 nrf51dk_nrf51422 nrf21540dk_nrf52840
+      nrf52833dk_nrf52833 nrf52dk_nrf52832 nrf21540dk_nrf52840
     tags: ci_build

--- a/samples/esb/prx/sample.yaml
+++ b/samples/esb/prx/sample.yaml
@@ -5,21 +5,19 @@ tests:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
     harness: keyboard
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52810
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
     tags: samples console
   sample.esb.prx.build:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52810
       - nrf5340dk_nrf5340_cpunet
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
       nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/samples/esb/ptx/sample.yaml
+++ b/samples/esb/ptx/sample.yaml
@@ -5,21 +5,19 @@ tests:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT
     harness: keyboard
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52810
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf52dk_nrf52810
     tags: samples console
   sample.esb.ptx.build:
     build_only: true
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52833dk_nrf52833
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52810
       - nrf5340dk_nrf5340_cpunet
-    platform_allow: nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
       nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
     tags: ci_build

--- a/tests/drivers/fprotect/negative/testcase.yaml
+++ b/tests/drivers/fprotect/negative/testcase.yaml
@@ -1,11 +1,10 @@
 tests:
   drivers.fprotect.negative:
     platform_allow: nrf9160dk_nrf9160 nrf52dk_nrf52832
-      nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840 nrf51dk_nrf51422
+      nrf5340dk_nrf5340_cpuapp nrf52840dk_nrf52840
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf52dk_nrf52832
       - nrf5340dk_nrf5340_cpuapp
       - nrf52840dk_nrf52840
-      - nrf51dk_nrf51422
     tags: b0 fprotect ignore_faults

--- a/tests/drivers/fprotect/positive/testcase.yaml
+++ b/tests/drivers/fprotect/positive/testcase.yaml
@@ -1,11 +1,10 @@
 tests:
   drivers.fprotect.positive:
-    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
+    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
-      - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
     tags: b0 fprotect

--- a/tests/drivers/nrfx_integration_test/testcase.yaml
+++ b/tests/drivers/nrfx_integration_test/testcase.yaml
@@ -4,7 +4,6 @@ tests:
     filter: CONFIG_HAS_NRFX
     tags: drivers ci_build
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160
       - nrf9160dk_nrf9160_ns
@@ -27,6 +26,5 @@ tests:
     extra_configs:
       - CONFIG_NRFX_AND_BT_LL_SW_SPLIT=y
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpunet

--- a/tests/modules/mcuboot/direct_xip/testcase.yaml
+++ b/tests/modules/mcuboot/direct_xip/testcase.yaml
@@ -1,11 +1,10 @@
 tests:
   mcuboot.direct_xip:
     tags: mcuboot direct_xip
-    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
+    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
-      - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp

--- a/tests/subsys/app_event_manager/testcase.yaml
+++ b/tests/subsys/app_event_manager/testcase.yaml
@@ -1,7 +1,6 @@
 tests:
   app_event_manager.core:
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160_ns
@@ -10,7 +9,6 @@ tests:
   app_event_manager.size_enabled:
     extra_args: OVERLAY_CONFIG=overlay-event_size.conf
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160_ns

--- a/tests/subsys/bluetooth/fast_pair/crypto/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/crypto/testcase.yaml
@@ -1,17 +1,15 @@
 tests:
   fast_pair.crypto.mbedtls:
     platform_allow:
-      nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
   fast_pair.crypto.tinycrypt:
     platform_allow:
-      nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns qemu_cortex_m3
+      nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns qemu_cortex_m3
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp

--- a/tests/subsys/bluetooth/fast_pair/storage/testcase.yaml
+++ b/tests/subsys/bluetooth/fast_pair/storage/testcase.yaml
@@ -1,7 +1,6 @@
 tests:
   fast_pair.storage.default:
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp

--- a/tests/subsys/bootloader/bl_crypto/testcase.yaml
+++ b/tests/subsys/bootloader/bl_crypto/testcase.yaml
@@ -1,12 +1,11 @@
 tests:
   bootloader.bl_crypto:
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf9160dk_nrf9160 nrf51dk_nrf51422
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf9160dk_nrf9160
       nrf5340dk_nrf5340_cpuapp nrf52833dk_nrf52833
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
       - nrf9160dk_nrf9160
-      - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
       - nrf52833dk_nrf52833
     tags: b0

--- a/tests/subsys/bootloader/bl_validation/testcase.yaml
+++ b/tests/subsys/bootloader/bl_validation/testcase.yaml
@@ -1,12 +1,11 @@
 tests:
   bootloader.bl_validation:
-    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
+    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf5340dk_nrf5340_cpuapp nrf52833dk_nrf52833
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
-      - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
       - nrf52833dk_nrf52833
     tags: b0 bl_validation

--- a/tests/subsys/caf/sensor_data_aggregator/testcase.yaml
+++ b/tests/subsys/caf/sensor_data_aggregator/testcase.yaml
@@ -1,9 +1,8 @@
 tests:
   caf_sensor_aggregator.core:
     platform_allow:
-      nrf51dk_nrf51422 nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns qemu_cortex_m3
+      nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf9160dk_nrf9160_ns qemu_cortex_m3
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp

--- a/tests/subsys/dfu/dfu_target/mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target/mcuboot/testcase.yaml
@@ -1,10 +1,9 @@
 tests:
   dfu.dfu_target.mcuboot:
-    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422 nrf9160dk_nrf9160 native_posix qemu_cortex_m3
+    platform_allow: nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf9160dk_nrf9160 native_posix qemu_cortex_m3
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
-      - nrf51dk_nrf51422
       - nrf9160dk_nrf9160
       - native_posix
       - qemu_cortex_m3

--- a/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
@@ -4,7 +4,6 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
-      - nrf51dk_nrf51422
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
       - native_posix

--- a/tests/subsys/fw_info/testcase.yaml
+++ b/tests/subsys/fw_info/testcase.yaml
@@ -1,11 +1,10 @@
 tests:
   fw_info.core:
-    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832 nrf51dk_nrf51422
+    platform_allow: nrf9160dk_nrf9160 nrf52840dk_nrf52840 nrf52dk_nrf52832
       nrf5340dk_nrf5340_cpuapp
     integration_platforms:
       - nrf9160dk_nrf9160
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
-      - nrf51dk_nrf51422
       - nrf5340dk_nrf5340_cpuapp
     tags: b0 fw_info

--- a/tests/subsys/nrf_profiler/testcase.yaml
+++ b/tests/subsys/nrf_profiler/testcase.yaml
@@ -2,7 +2,6 @@ tests:
   nrf_profiler.core:
     platform_exclude: native_posix qemu_x86 qemu_cortex_m3
     integration_platforms:
-      - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf9160dk_nrf9160ns


### PR DESCRIPTION
Do not check code on nrf51 boards.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>