### PR TITLE
dts: Add missing IPC mapping for BLE HCI RPMsg

### DIFF
--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -13,6 +13,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
+		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 	};
 
 	leds {

--- a/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet.dts
@@ -18,6 +18,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
+		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
 		zephyr,code-partition = &slot0_partition;


### PR DESCRIPTION
This fixes build failure for a combined nRF700x Wi-Fi + BLE build.

Signed-off-by: Bansidhar M <bansidhar.mangalwedhekar@nordicsemi.no>
Signed-off-by: Wentong Li <wentong.li@nordicsemi.no>