### PR TITLE
lib: modem_info: Introduce individual functions to read version info

### DIFF
--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -40,6 +40,9 @@ extern "C" {
 /** RSRQ scale value. */
 #define RSRQ_SCALE_VAL 0.5
 
+/** Modem firmware version string can be up to 40 characters long. */
+#define MODEM_INFO_FWVER_SIZE 41
+
 /** Modem returns RSRP and RSRQ as index values which require
  * a conversion to dBm and dB respectively. See modem AT
  * command reference guide for more information.
@@ -256,6 +259,89 @@ int modem_info_json_object_encode(struct modem_param_info *modem,
  *           Otherwise, a (negative) error code is returned.
  */
 int modem_info_params_get(struct modem_param_info *modem_param);
+
+/** @brief Obtain the UUID of the modem firmware build.
+ *
+ * The UUID is represented as a string, for example:
+ * 25c95751-efa4-40d4-8b4a-1dcaab81fac9
+ *
+ * See the documentation for the AT command %XMODEMUUID.
+ *
+ * @param buf Pointer to the target buffer.
+ * @param buf_size Size of target buffer.
+ *
+ * @retval 0 if the operation was successful.
+ * @retval -EINVAL if the provided buf_size was not enough.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_fw_uuid(char *buf, size_t buf_size);
+
+/** @brief Obtain the short software identification.
+ *
+ * The short software identification is represented as a string, for example:
+ * nrf9160_1.1.2
+ *
+ * See the documentation for the AT command %SHORTSWVER.
+ *
+ * @param buf Pointer to the target buffer.
+ * @param buf_size Size of target buffer.
+ *
+ * @retval 0 if the operation was successful.
+ * @retval -EINVAL if the provided buf_size was not enough.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_fw_version(char *buf, size_t buf_size);
+
+/** @brief Obtain the modem Software Version Number (SVN).
+ *
+ * The SVN is represented as a string, for example:
+ * 12
+ *
+ * See the documentation for the AT command +CGSN.
+ *
+ * @param buf Pointer to the target buffer.
+ * @param buf_size Size of target buffer.
+ *
+ * @retval 0 if the operation was successful.
+ * @retval -EINVAL if the provided buf_size was not enough.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_svn(char *buf, size_t buf_size);
+
+/** @brief Obtain the battery voltage.
+ *
+ * Get the battery voltage, in mV, with a 4 mV resolution.
+ *
+ * @param val Pointer to the target variable.
+ *
+ * @retval 0 if the operation was successful.
+ * @retval -EINVAL if the provided buf_size was not enough.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_batt_voltage(int *val);
+
+/** @brief Obtain the internal temperature.
+ *
+ * Get the internal temperature, in degrees Celsius.
+ *
+ * @param val Pointer to the target variable.
+ *
+ * @retval 0 if the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_temperature(int *val);
+
+/** @brief Obtain the RSRP.
+ *
+ * Get the reference signal received strength (RSRP), in dBm.
+ *
+ * @param val Pointer to the target variable.
+ *
+ * @retval 0 if the operation was successful.
+ * @retval -ENOENT if there is no valid RSRP.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int modem_info_get_rsrp(int *val);
 
 /** @} */
 

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -11,6 +11,7 @@
 #include <zephyr/device.h>
 #include <errno.h>
 #include <modem/modem_info.h>
+#include <nrf_errno.h>
 #include <zephyr/net/socket.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -128,6 +129,17 @@ LOG_MODULE_REGISTER(modem_info);
 
 #define APN_PARAM_INDEX		3
 #define APN_PARAM_COUNT		7
+
+#define CELL_RSRP_INVALID	255
+
+/* FW UUID is 36 characters: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX */
+#define FW_UUID_SIZE 37
+
+/* Size of the format string for requesting modem firmware version */
+#define SWVER_FMT_STR_SIZE 23
+
+/* SVN is a NULL-terminated string with 2 digits: XX */
+#define SVN_SIZE 3
 
 struct modem_info_data {
 	const char *cmd;
@@ -380,6 +392,22 @@ static int modem_info_parse(const struct modem_info_data *modem_data,
 	}
 
 	return err;
+}
+
+static int map_nrf_modem_at_scanf_error(int err)
+{
+	switch (err) {
+	case -NRF_EPERM:
+		return -EPERM;
+	case -NRF_EFAULT:
+		return -EFAULT;
+	case -NRF_EBADMSG:
+		return -EBADMSG;
+	case -NRF_ENOMEM:
+		return -ENOMEM;
+	default:
+		return -EIO;
+	}
 }
 
 enum at_param_type modem_info_type_get(enum modem_info info_type)
@@ -715,6 +743,125 @@ int modem_info_rsrp_register(rsrp_cb_t cb)
 		return -EIO;
 	}
 
+	return 0;
+}
+
+int modem_info_get_fw_uuid(char *buf, size_t buf_size)
+{
+	int ret;
+
+	if (buf == NULL || buf_size < FW_UUID_SIZE) {
+		return -EINVAL;
+	}
+
+	ret = nrf_modem_at_scanf("AT%XMODEMUUID",
+				 "%%XMODEMUUID: %" STRINGIFY(FW_UUID_SIZE) "[^\r\n]",
+				 buf);
+	if (ret != 1) {
+		LOG_ERR("Could not get FW ID, error: %d", ret);
+		return map_nrf_modem_at_scanf_error(ret);
+	}
+	return 0;
+}
+
+int modem_info_get_fw_version(char *buf, size_t buf_size)
+{
+	int ret;
+	char format[SWVER_FMT_STR_SIZE];
+
+	if (buf == NULL || buf_size < MODEM_INFO_FWVER_SIZE) {
+		return -EINVAL;
+	}
+
+	sprintf(format, "%%%%SHORTSWVER: %%%d[^\r\n]", buf_size);
+
+	ret = nrf_modem_at_scanf("AT%SHORTSWVER",
+				 format,
+				 buf);
+
+	if (ret != 1) {
+		LOG_ERR("Could not get FW version, error: %d", ret);
+		return map_nrf_modem_at_scanf_error(ret);
+	}
+	return 0;
+}
+
+
+int modem_info_get_svn(char *buf, size_t buf_size)
+{
+	int ret;
+
+	if (buf == NULL || buf_size < SVN_SIZE) {
+		return -EINVAL;
+	}
+
+	ret = nrf_modem_at_scanf("AT+CGSN=3",
+				 "+CGSN: \"%" STRINGIFY(SVN_SIZE) "[^\"]",
+				 buf);
+
+	if (ret != 1) {
+		LOG_ERR("Could not get SVN, error: %d", ret);
+		return map_nrf_modem_at_scanf_error(ret);
+	}
+	return 0;
+}
+
+int modem_info_get_batt_voltage(int *val)
+{
+	int ret;
+
+	if (val == NULL) {
+		return -EINVAL;
+	}
+
+	ret = nrf_modem_at_scanf("AT%XVBAT", "%%XVBAT: %d", val);
+
+	if (ret != 1) {
+		LOG_ERR("Could not get battery voltage, error: %d", ret);
+		return map_nrf_modem_at_scanf_error(ret);
+	}
+	return 0;
+}
+
+int modem_info_get_temperature(int *val)
+{
+	int ret;
+
+	if (val == NULL) {
+		return -EINVAL;
+	}
+
+	ret = nrf_modem_at_scanf("AT%XTEMP?", "%%XTEMP: %d", val);
+
+	if (ret != 1) {
+		LOG_ERR("Could not get temperature, error: %d", ret);
+		return map_nrf_modem_at_scanf_error(ret);
+	}
+	return 0;
+}
+
+int modem_info_get_rsrp(int *val)
+{
+	int ret;
+
+	if (val == NULL) {
+		return -EINVAL;
+	}
+
+	ret = nrf_modem_at_scanf("AT+CESQ",
+				 "+CESQ: %*d,%*d,%*d,%*d,%*d,%d", val);
+
+	if (ret != 1) {
+		LOG_ERR("at_scanf_int failed");
+		return map_nrf_modem_at_scanf_error(ret);
+	}
+
+	if (*val == CELL_RSRP_INVALID) {
+		LOG_WRN("No valid RSRP");
+		return -ENOENT;
+	}
+
+	*val = *val - RSRP_OFFSET_VAL;
 	return 0;
 }
 

--- a/tests/lib/modem_info/CMakeLists.txt
+++ b/tests/lib/modem_info/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(modem_info)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+test_runner_generate(src/main.c)
+
+target_sources(app
+  PRIVATE
+  ${ZEPHYR_BASE}/../nrf/lib/modem_info/modem_info.c
+)
+
+zephyr_include_directories(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/)
+zephyr_include_directories(${ZEPHYR_BASE}/../nrf/include/modem/)
+zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
+
+target_compile_options(app
+  PRIVATE
+  -DCONFIG_MODEM_INFO_BUFFER_SIZE=128
+  -DCONFIG_MODEM_INFO_MAX_AT_PARAMS_RSP=10
+)

--- a/tests/lib/modem_info/prj.conf
+++ b/tests/lib/modem_info/prj.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_UNITY=y

--- a/tests/lib/modem_info/src/main.c
+++ b/tests/lib/modem_info/src/main.c
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <unity.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+
+#include "modem_info.h"
+
+#include <zephyr/fff.h>
+
+#include <nrf_modem_at.h>
+
+DEFINE_FFF_GLOBALS;
+
+FAKE_VALUE_FUNC(int, nrf_modem_at_notif_handler_set, nrf_modem_at_notif_handler_t);
+FAKE_VALUE_FUNC(int, at_params_list_init, struct at_param_list *, size_t);
+FAKE_VALUE_FUNC_VARARG(int, nrf_modem_at_scanf, const char *, const char *, ...);
+
+#define FW_UUID_SIZE 37
+#define SVN_SIZE 3
+#define EXAMPLE_UUID "48d7cbc0-3354-11ed-9a95-e334dfb8a3cb"
+#define EXAMPLE_FWVER "nrf9160_1.3.2"
+#define EXAMPLE_SVN "25"
+#define EXAMPLE_VBAT 5054
+#define EXAMPLE_TEMP 24
+#define EXAMPLE_RSRP_INVALID 255
+#define EXAMPLE_RSRP_VALID 160
+#define RSRP_OFFSET 140
+
+struct at_param at_params[10] = {};
+static struct at_param_list m_param_list = {
+	.param_count = 0,
+	.params = at_params,
+};
+
+static int nrf_modem_at_scanf_custom_no_match(const char *cmd, const char *fmt, va_list args)
+{
+	return 0;
+}
+
+static int nrf_modem_at_scanf_custom_modemuuid(const char *cmd, const char *fmt, va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT%XMODEMUUID", cmd);
+	TEST_ASSERT_EQUAL_STRING("%%XMODEMUUID: %" STRINGIFY(FW_UUID_SIZE) "[^\r\n]", fmt);
+
+	char *buf = va_arg(args, char *);
+
+	strncpy(buf, EXAMPLE_UUID, FW_UUID_SIZE);
+
+	return 1;
+}
+
+static int nrf_modem_at_scanf_custom_shortswver(const char *cmd, const char *fmt, va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT%SHORTSWVER", cmd);
+	TEST_ASSERT_EQUAL_STRING("%%SHORTSWVER: %" STRINGIFY(MODEM_INFO_FWVER_SIZE) "[^\r\n]", fmt);
+
+	char *buf = va_arg(args, char *);
+
+	strncpy(buf, EXAMPLE_FWVER, MODEM_INFO_FWVER_SIZE);
+
+	return 1;
+}
+
+static int nrf_modem_at_scanf_custom_cgsn(const char *cmd, const char *fmt, va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT+CGSN=3", cmd);
+	TEST_ASSERT_EQUAL_STRING("+CGSN: \"%" STRINGIFY(SVN_SIZE) "[^\"]", fmt);
+
+	char *buf = va_arg(args, char *);
+
+	strncpy(buf, EXAMPLE_SVN, SVN_SIZE);
+
+	return 1;
+}
+
+static int nrf_modem_at_scanf_custom_vbat(const char *cmd, const char *fmt, va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT%XVBAT", cmd);
+	TEST_ASSERT_EQUAL_STRING("%%XVBAT: %d", fmt);
+
+	int *val = va_arg(args, int *);
+
+	*val = EXAMPLE_VBAT;
+
+	return 1;
+}
+
+static int nrf_modem_at_scanf_custom_temp(const char *cmd, const char *fmt, va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT%XTEMP?", cmd);
+	TEST_ASSERT_EQUAL_STRING("%%XTEMP: %d", fmt);
+
+	int *val = va_arg(args, int *);
+
+	*val = EXAMPLE_TEMP;
+
+	return 1;
+}
+
+static int nrf_modem_at_scanf_custom_cesq(const char *cmd, const char *fmt, va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT+CESQ", cmd);
+	TEST_ASSERT_EQUAL_STRING("+CESQ: %*d,%*d,%*d,%*d,%*d,%d", fmt);
+
+	int *val = va_arg(args, int *);
+
+	*val = EXAMPLE_RSRP_VALID;
+
+	return 1;
+}
+
+static int nrf_modem_at_scanf_custom_cesq_invalid(const char *cmd, const char *fmt, va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT+CESQ", cmd);
+	TEST_ASSERT_EQUAL_STRING("+CESQ: %*d,%*d,%*d,%*d,%*d,%d", fmt);
+
+	int *val = va_arg(args, int *);
+
+	*val = EXAMPLE_RSRP_INVALID;
+
+	return 1;
+}
+
+
+void setUp(void)
+{
+	RESET_FAKE(nrf_modem_at_notif_handler_set);
+	RESET_FAKE(at_params_list_init);
+	RESET_FAKE(nrf_modem_at_scanf);
+}
+
+void tearDown(void)
+{
+}
+
+int at_params_list_init_custom(struct at_param_list *list, size_t max_params_count)
+{
+	*list = m_param_list;
+	return EXIT_SUCCESS;
+}
+
+void test_modem_info_init_success(void)
+{
+	int ret;
+
+	at_params_list_init_fake.custom_fake = at_params_list_init_custom;
+	ret = modem_info_init();
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(1, at_params_list_init_fake.call_count);
+}
+
+void test_modem_info_get_fw_uuid_null(void)
+{
+	int ret;
+
+	ret = modem_info_get_fw_uuid(NULL, FW_UUID_SIZE);
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_fw_uuid_buf_too_small(void)
+{
+	int ret;
+	char buf[FW_UUID_SIZE-1];
+
+	ret = modem_info_get_fw_uuid(buf, ARRAY_SIZE(buf));
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_fw_uuid_at_returns_error(void)
+{
+	int ret;
+	char buf[FW_UUID_SIZE];
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_no_match;
+
+	ret = modem_info_get_fw_uuid(buf, ARRAY_SIZE(buf));
+	TEST_ASSERT_EQUAL(-EIO, ret);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_fw_uuid_success(void)
+{
+	int ret;
+	char buf[FW_UUID_SIZE];
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_modemuuid;
+
+	ret = modem_info_get_fw_uuid(buf, ARRAY_SIZE(buf));
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+	TEST_ASSERT_EQUAL_STRING(EXAMPLE_UUID, buf);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_fw_version_null(void)
+{
+	int ret;
+
+	ret = modem_info_get_fw_version(NULL, 0);
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_fw_version_buf_too_small(void)
+{
+	int ret;
+	char buf[MODEM_INFO_FWVER_SIZE-1];
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_shortswver;
+
+	ret = modem_info_get_fw_version(buf, ARRAY_SIZE(buf));
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_fw_version_at_returns_error(void)
+{
+	int ret;
+	char buf[MODEM_INFO_FWVER_SIZE];
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_no_match;
+
+	ret = modem_info_get_fw_version(buf, ARRAY_SIZE(buf));
+	TEST_ASSERT_EQUAL(-EIO, ret);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_fw_version_success(void)
+{
+	int ret;
+	char buf[MODEM_INFO_FWVER_SIZE];
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_shortswver;
+
+	ret = modem_info_get_fw_version(buf, ARRAY_SIZE(buf));
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+	TEST_ASSERT_EQUAL_STRING(EXAMPLE_FWVER, buf);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_svn_null(void)
+{
+	int ret;
+
+	ret = modem_info_get_svn(NULL, SVN_SIZE);
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_svn_buf_too_small(void)
+{
+	int ret;
+	char buf[SVN_SIZE-1];
+
+	ret = modem_info_get_svn(buf, ARRAY_SIZE(buf));
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_svn_at_returns_error(void)
+{
+	int ret;
+	char buf[SVN_SIZE];
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_no_match;
+
+	ret = modem_info_get_svn(buf, ARRAY_SIZE(buf));
+	TEST_ASSERT_EQUAL(-EIO, ret);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_svn_success(void)
+{
+	int ret;
+	char buf[SVN_SIZE];
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_cgsn;
+
+	ret = modem_info_get_svn(buf, ARRAY_SIZE(buf));
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+	TEST_ASSERT_EQUAL_STRING(EXAMPLE_SVN, buf);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_batt_voltage_null(void)
+{
+	int ret;
+
+	ret = modem_info_get_batt_voltage(NULL);
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_batt_voltage_at_returns_error(void)
+{
+	int ret;
+	int val;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_no_match;
+
+	ret = modem_info_get_batt_voltage(&val);
+	TEST_ASSERT_EQUAL(-EIO, ret);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_batt_voltage_success(void)
+{
+	int ret;
+	int val;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_vbat;
+
+	ret = modem_info_get_batt_voltage(&val);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+	TEST_ASSERT_EQUAL(EXAMPLE_VBAT, val);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_temperature_null(void)
+{
+	int ret;
+
+	ret = modem_info_get_temperature(NULL);
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_temperature_at_returns_error(void)
+{
+	int ret;
+	int val;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_no_match;
+
+	ret = modem_info_get_temperature(&val);
+	TEST_ASSERT_EQUAL(-EIO, ret);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_temperature_success(void)
+{
+	int ret;
+	int val;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_temp;
+
+	ret = modem_info_get_temperature(&val);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+	TEST_ASSERT_EQUAL(EXAMPLE_TEMP, val);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_rsrp_null(void)
+{
+	int ret;
+
+	ret = modem_info_get_rsrp(NULL);
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_rsrp_at_returns_error(void)
+{
+	int ret;
+	int val;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_no_match;
+
+	ret = modem_info_get_rsrp(&val);
+	TEST_ASSERT_EQUAL(-EIO, ret);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_rsrp_invalid_rsrp(void)
+{
+	int ret;
+	int val = 0;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_cesq_invalid;
+
+	ret = modem_info_get_rsrp(&val);
+	TEST_ASSERT_EQUAL(-ENOENT, ret);
+	TEST_ASSERT_EQUAL(EXAMPLE_RSRP_INVALID, val);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_rsrp_success(void)
+{
+	int ret;
+	int val = 0;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_cesq;
+
+	ret = modem_info_get_rsrp(&val);
+	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
+	TEST_ASSERT_EQUAL(EXAMPLE_RSRP_VALID-RSRP_OFFSET, val);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+extern int unity_main(void);
+
+void main(void)
+{
+	(void)unity_main();
+}

--- a/tests/lib/modem_info/testcase.yml
+++ b/tests/lib/modem_info/testcase.yml
@@ -1,0 +1,6 @@
+tests:
+  modem_info.unit_test:
+    tags: modem_info
+    platform_allow: native_posix
+    integration_platforms:
+      - native_posix


### PR DESCRIPTION
Introduces new functions to read firmware version information.
Information is read via individual functions with flexible parsing
based on the new nrf_modem_at interface.

This is a revival of https://github.com/nrfconnect/sdk-nrf/pull/6921

Co-authored-by: Bernt Johan Damslora <bernt.johan.damslora@nordicsemi.no>
Co-authored-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>