### PR TITLE
application: serial_lte_modem: BUG-FIX gnss JSON encoding

### DIFF
--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -530,6 +530,11 @@ static void send_location(struct nrf_modem_gnss_nmea_data_frame * const nmea_dat
 		return;
 	}
 
+	msg_obj = cJSON_CreateObject();
+	if (!msg_obj) {
+		return;
+	}
+
 	err = nrf_cloud_gnss_msg_json_encode(&gnss, msg_obj);
 	if (err) {
 		goto clean_up;


### PR DESCRIPTION
Before encoding GNSS info into JSON message, the message object
needs to be created first.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>