### PR TITLE
ci: Fix Software maturity dependencies

### DIFF
--- a/doc/_scripts/software_maturity/requirements.txt
+++ b/doc/_scripts/software_maturity/requirements.txt
@@ -1,3 +1,4 @@
 azure-storage-blob==12.9.0
+azure-core==1.16.0
 kconfiglib==14.1.0
 PyYAML==5.4.1


### PR DESCRIPTION
Newer version of azure-core does not work as expected.
Issue:
ImportError: cannot import name 'ParamSpec' from 'typing_extensions'

Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>