### PR TITLE
applications: nrf5340_audio: Small bugfixes

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -862,7 +862,9 @@ void audio_datapath_stream_out(const uint8_t *buf, size_t size, uint32_t sdu_ref
 	}
 
 	if (pcm_size != (BLK_STEREO_SIZE_OCTETS * NUM_BLKS_IN_FRAME)) {
-		ERR_CHK_MSG(-ECANCELED, "Decoded audio has wrong size");
+		LOG_WRN("Decoded audio has wrong size");
+		/* Discard frame */
+		return;
 	}
 
 	/*** Add audio data to FIFO buffer ***/

--- a/applications/nrf5340_audio/src/audio/streamctrl.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl.c
@@ -313,7 +313,11 @@ static void button_evt_handler(struct button_evt event)
 				test_tone_hz = test_tone_hz * 2;
 			}
 
-			LOG_INF("Test tone set at %d Hz", test_tone_hz);
+			if (test_tone_hz != 0) {
+				LOG_INF("Test tone set at %d Hz", test_tone_hz);
+			} else {
+				LOG_INF("Test tone off");
+			}
 
 			ret = audio_encode_test_tone_set(test_tone_hz);
 			ERR_CHK_MSG(ret, "Failed to generate test tone");


### PR DESCRIPTION
- Change ERR_CHK to LOG_WRN for checking decoded size in audio_datapath
- Change log print to 'Test tone off' when turning off test tone

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>