### PR TITLE
applications: nrf5340_audio: Clean up audio_channel enum

### DIFF
--- a/applications/nrf5340_audio/src/audio/sw_codec_select.c
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.c
@@ -9,6 +9,7 @@
 #include <zephyr/kernel.h>
 #include <errno.h>
 
+#include "channel_assignment.h"
 #include "pcm_stream_channel_modifier.h"
 #if (CONFIG_SW_CODEC_LC3)
 #include "sw_codec_lc3.h"

--- a/applications/nrf5340_audio/src/audio/sw_codec_select.h
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.h
@@ -8,6 +8,7 @@
 #define _SW_CODEC_SELECT_H_
 
 #include <zephyr/kernel.h>
+#include "channel_assignment.h"
 
 #if (CONFIG_SW_CODEC_LC3)
 #define LC3_MAX_FRAME_SIZE_MS 10
@@ -42,23 +43,17 @@ enum sw_codec_select_ch {
 	SW_CODEC_STEREO, /* Use both channels */
 };
 
-enum audio_channel_select {
-	AUDIO_CH_L,
-	AUDIO_CH_R,
-	AUDIO_CH_NUM,
-};
-
 struct sw_codec_encoder {
 	bool enabled;
 	int bitrate;
 	enum sw_codec_select_ch channel_mode;
-	enum audio_channel_select audio_ch; /* Only used if channel mode is mono */
+	enum audio_channel audio_ch; /* Only used if channel mode is mono */
 };
 
 struct sw_codec_decoder {
 	bool enabled;
 	enum sw_codec_select_ch channel_mode;
-	enum audio_channel_select audio_ch; /* Only used if channel mode is mono */
+	enum audio_channel audio_ch; /* Only used if channel mode is mono */
 };
 
 /** @brief  Sw_codec configuration structure

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -117,9 +117,9 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 	int ret;
 
 	if (loc == BT_AUDIO_LOCATION_SIDE_LEFT) {
-		headset_conn[AUDIO_CHANNEL_LEFT] = conn;
+		headset_conn[AUDIO_CH_L] = conn;
 	} else if (loc == BT_AUDIO_LOCATION_SIDE_RIGHT) {
-		headset_conn[AUDIO_CHANNEL_RIGHT] = conn;
+		headset_conn[AUDIO_CH_R] = conn;
 	} else {
 		LOG_ERR("Channel location not supported");
 		ret = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
@@ -266,8 +266,8 @@ static void stream_stopped_cb(struct bt_audio_stream *stream)
 		atomic_clear(&iso_tx_pool_alloc[channel_index]);
 	}
 
-	if (audio_streams[AUDIO_CHANNEL_LEFT].ep->status.state != BT_AUDIO_EP_STATE_STREAMING &&
-	    audio_streams[AUDIO_CHANNEL_RIGHT].ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
+	if (audio_streams[AUDIO_CH_L].ep->status.state != BT_AUDIO_EP_STATE_STREAMING &&
+	    audio_streams[AUDIO_CH_R].ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
 		ret = ctrl_events_le_audio_event_send(LE_AUDIO_EVT_NOT_STREAMING);
 		ERR_CHK(ret);
 	}
@@ -748,11 +748,11 @@ int le_audio_send(uint8_t const *const data, size_t size)
 		return -ECANCELED;
 	}
 
-	if (audio_streams[AUDIO_CHANNEL_LEFT].ep->status.state == BT_AUDIO_EP_STATE_STREAMING) {
-		ret = bt_iso_chan_get_tx_sync(audio_streams[AUDIO_CHANNEL_LEFT].iso, &tx_info);
-	} else if (audio_streams[AUDIO_CHANNEL_RIGHT].ep->status.state ==
+	if (audio_streams[AUDIO_CH_L].ep->status.state == BT_AUDIO_EP_STATE_STREAMING) {
+		ret = bt_iso_chan_get_tx_sync(audio_streams[AUDIO_CH_L].iso, &tx_info);
+	} else if (audio_streams[AUDIO_CH_R].ep->status.state ==
 		   BT_AUDIO_EP_STATE_STREAMING) {
-		ret = bt_iso_chan_get_tx_sync(audio_streams[AUDIO_CHANNEL_RIGHT].iso, &tx_info);
+		ret = bt_iso_chan_get_tx_sync(audio_streams[AUDIO_CH_R].iso, &tx_info);
 	} else {
 		LOG_DBG("No headset in stream state");
 		return -ECANCELED;
@@ -768,12 +768,12 @@ int le_audio_send(uint8_t const *const data, size_t size)
 		audio_datapath_just_in_time_check_and_adjust(tx_info.ts);
 	}
 
-	ret = iso_stream_send(data, sdu_size, AUDIO_CHANNEL_LEFT);
+	ret = iso_stream_send(data, sdu_size, AUDIO_CH_L);
 	if (ret) {
 		LOG_DBG("Failed to send data to left channel");
 	}
 
-	ret = iso_stream_send(&data[sdu_size], sdu_size, AUDIO_CHANNEL_RIGHT);
+	ret = iso_stream_send(&data[sdu_size], sdu_size, AUDIO_CH_R);
 	if (ret) {
 		LOG_DBG("Failed to send data to right channel");
 	}

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -361,7 +361,7 @@ static int initialize(le_audio_receive_cb recv_cb)
 			/* Channel is not assigned yet: use default */
 			channel = AUDIO_CHANNEL_DEFAULT;
 		}
-		if (channel == AUDIO_CHANNEL_LEFT) {
+		if (channel == AUDIO_CH_L) {
 			ret = bt_audio_capability_set_location(BT_AUDIO_DIR_SINK,
 							       BT_AUDIO_LOCATION_SIDE_LEFT);
 		} else {

--- a/applications/nrf5340_audio/src/main.c
+++ b/applications/nrf5340_audio/src/main.c
@@ -76,7 +76,7 @@ static int leds_set(void)
 		channel = AUDIO_CHANNEL_DEFAULT;
 	}
 
-	if (channel == AUDIO_CHANNEL_LEFT) {
+	if (channel == AUDIO_CH_L) {
 		ret = led_on(LED_APP_RGB, LED_COLOR_BLUE);
 	} else {
 		ret = led_on(LED_APP_RGB, LED_COLOR_MAGENTA);
@@ -117,7 +117,7 @@ static int bonding_clear_check(void)
 static int channel_assign_check(void)
 {
 #if (CONFIG_AUDIO_DEV == HEADSET) && CONFIG_AUDIO_HEADSET_CHANNEL_RUNTIME
-	if (!channel_assignment_get(&(enum audio_channel){ AUDIO_CHANNEL_LEFT })) {
+	if (!channel_assignment_get(&(enum audio_channel){ AUDIO_CH_L })) {
 		/* Channel already assigned */
 		return 0;
 	}
@@ -131,7 +131,7 @@ static int channel_assign_check(void)
 	}
 
 	if (pressed) {
-		return channel_assignment_set(AUDIO_CHANNEL_LEFT);
+		return channel_assignment_set(AUDIO_CH_L);
 	}
 
 	ret = button_pressed(BUTTON_VOLUME_UP, &pressed);
@@ -140,7 +140,7 @@ static int channel_assign_check(void)
 	}
 
 	if (pressed) {
-		return channel_assignment_set(AUDIO_CHANNEL_RIGHT);
+		return channel_assignment_set(AUDIO_CH_R);
 	}
 #endif
 

--- a/applications/nrf5340_audio/src/utils/channel_assignment.c
+++ b/applications/nrf5340_audio/src/utils/channel_assignment.c
@@ -17,7 +17,7 @@ int channel_assignment_get(enum audio_channel *channel)
 
 	channel_value = uicr_channel_get();
 
-	if (channel_value >= AUDIO_CHANNEL_COUNT) {
+	if (channel_value >= AUDIO_CH_NUM) {
 		return -EIO;
 	}
 

--- a/applications/nrf5340_audio/src/utils/channel_assignment.h
+++ b/applications/nrf5340_audio/src/utils/channel_assignment.h
@@ -15,15 +15,14 @@
  */
 
 #ifndef AUDIO_CHANNEL_DEFAULT
-#define AUDIO_CHANNEL_DEFAULT AUDIO_CHANNEL_LEFT
+#define AUDIO_CHANNEL_DEFAULT AUDIO_CH_L
 #endif /* AUDIO_CHANNEL_DEFAULT */
 
 /**@brief Audio channel assignment values */
 enum audio_channel {
-	AUDIO_CHANNEL_LEFT = 0,
-	AUDIO_CHANNEL_RIGHT,
-
-	AUDIO_CHANNEL_COUNT
+	AUDIO_CH_L,
+	AUDIO_CH_R,
+	AUDIO_CH_NUM,
 };
 
 /**

--- a/applications/nrf5340_audio/src/utils/fw_info_app.c.in
+++ b/applications/nrf5340_audio/src/utils/fw_info_app.c.in
@@ -55,14 +55,14 @@ int fw_info_app_print(void)
 			}
 			LOG_INF(COLOR_CYAN"\r\n\t HEADSET <no ch selected> defaulting to " STRINGIFY(AUDIO_CHANNEL_DEFAULT)" "COLOR_RESET);
 		}
-		if (channel == AUDIO_CHANNEL_LEFT) {
+		if (channel == AUDIO_CH_L) {
 			static const char log_tag[] = "HL";
 			ret = log_set_tag(log_tag);
 			if (ret) {
 				return ret;
 			}
 			LOG_INF(COLOR_CYAN"\r\n\t HEADSET left device"COLOR_RESET);
-		} else if (channel == AUDIO_CHANNEL_RIGHT) {
+		} else if (channel == AUDIO_CH_R) {
 			static const char log_tag[] = "HR";
 			ret = log_set_tag(log_tag);
 			if (ret) {

--- a/applications/nrf5340_audio/src/utils/pcm_stream_channel_modifier.c
+++ b/applications/nrf5340_audio/src/utils/pcm_stream_channel_modifier.c
@@ -9,6 +9,8 @@
 #include <zephyr/kernel.h>
 #include <errno.h>
 
+#include "channel_assignment.h"
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pscm);
 
@@ -49,7 +51,7 @@ static bool is_valid_size(size_t size, uint8_t bytes_per_sample, uint8_t no_chan
 	return true;
 }
 
-int pscm_zero_pad(void const *const input, size_t input_size, enum audio_channel_select channel,
+int pscm_zero_pad(void const *const input, size_t input_size, enum audio_channel channel,
 		  uint8_t pcm_bit_depth, void *output, size_t *output_size)
 {
 	uint8_t bytes_per_sample = pcm_bit_depth / 8;
@@ -143,7 +145,7 @@ int pscm_combine(void const *const input_left, void const *const input_right, si
 }
 
 int pscm_one_channel_split(void const *const input, size_t input_size,
-			   enum audio_channel_select channel, uint8_t pcm_bit_depth, void *output,
+			   enum audio_channel channel, uint8_t pcm_bit_depth, void *output,
 			   size_t *output_size)
 {
 	uint8_t bytes_per_sample = pcm_bit_depth / 8;

--- a/applications/nrf5340_audio/src/utils/pcm_stream_channel_modifier.h
+++ b/applications/nrf5340_audio/src/utils/pcm_stream_channel_modifier.h
@@ -25,7 +25,7 @@
  *
  * @return	0 if success
  */
-int pscm_zero_pad(void const *const input, size_t input_size, enum audio_channel_select channel,
+int pscm_zero_pad(void const *const input, size_t input_size, enum audio_channel channel,
 		  uint8_t pcm_bit_depth, void *output, size_t *output_size);
 
 /**@brief  Adds a copy of every sample from *input
@@ -73,7 +73,7 @@ int pscm_combine(void const *const input_left, void const *const input_right, si
  * @return	0 if success.
  */
 int pscm_one_channel_split(void const *const input, size_t input_size,
-			   enum audio_channel_select channel, uint8_t pcm_bit_depth, void *output,
+			   enum audio_channel channel, uint8_t pcm_bit_depth, void *output,
 			   size_t *output_size);
 
 /**@brief  Splits a stereo stream to two separate mono streams


### PR DESCRIPTION
Remove audio_channel enum from sw_codec_select.c and use the
one in channel_assignment.h

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>