### PR TITLE
samples: zigbee: Cleanup NCP sample

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -379,6 +379,9 @@ Zigbee samples
   * Added support for :ref:`zephyr:nrf52840dongle_nrf52840`.
   * Added an option to build :ref:`zigbee_shell_sample` sample with the nRF USB CDC ACM as shell backend.
 
+* :ref:`zigbee_ncp_sample` sample:
+
+  * Set :kconfig:option:`CONFIG_ZBOSS_TRACE_BINARY_LOGGING` to be disabled by default for NCP over USB variant.
 
 Other samples
 -------------

--- a/samples/zigbee/ncp/boards/nrf21540dk_nrf52840_usb.overlay
+++ b/samples/zigbee/ncp/boards/nrf21540dk_nrf52840_usb.overlay
@@ -14,6 +14,5 @@
 / {
 	chosen {
 		ncs,zigbee-uart = &cdc_acm_uart0;
-		ncs,zboss-trace-uart = &uart1;
 	};
 };

--- a/samples/zigbee/ncp/boards/nrf52833dk_nrf52833_usb.overlay
+++ b/samples/zigbee/ncp/boards/nrf52833dk_nrf52833_usb.overlay
@@ -14,6 +14,5 @@
 / {
 	chosen {
 		ncs,zigbee-uart = &cdc_acm_uart0;
-		ncs,zboss-trace-uart = &uart1;
 	};
 };

--- a/samples/zigbee/ncp/boards/nrf52840dk_nrf52840_usb.overlay
+++ b/samples/zigbee/ncp/boards/nrf52840dk_nrf52840_usb.overlay
@@ -14,6 +14,5 @@
 / {
 	chosen {
 		ncs,zigbee-uart = &cdc_acm_uart0;
-		ncs,zboss-trace-uart = &uart1;
 	};
 };

--- a/samples/zigbee/ncp/boards/nrf5340dk_nrf5340_cpuapp_usb.overlay
+++ b/samples/zigbee/ncp/boards/nrf5340dk_nrf5340_cpuapp_usb.overlay
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-&uart1 {
-	status = "okay";
-};
-
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
@@ -18,6 +14,5 @@
 / {
 	chosen {
 		ncs,zigbee-uart = &cdc_acm_uart0;
-		ncs,zboss-trace-uart = &uart1;
 	};
 };

--- a/samples/zigbee/ncp/prj_usb.conf
+++ b/samples/zigbee/ncp/prj_usb.conf
@@ -8,7 +8,7 @@
 CONFIG_ZIGBEE_UART_SUPPORTS_FLOW_CONTROL=y
 
 # Configure NCP sample to print ZBOSS stack logs in binary format using "UART_1" device
-CONFIG_ZBOSS_TRACE_BINARY_LOGGING=y
+# CONFIG_ZBOSS_TRACE_BINARY_LOGGING=y
 
 #### Use this configuration to print ZBOSS stack logs in binary format using USB "CDC_ACM_1" device
 # CONFIG_ZBOSS_TRACE_BINARY_LOGGING=y


### PR DESCRIPTION
- Removed Kconfig option that enables logger for ZBOSS trace logs by default
- Removed additional instance of USB CDC ACM as no longer required