### PR TITLE
Handle zero timeout value in nrf_cloud_rest

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -564,6 +564,7 @@ Libraries for networking
 
     * Updated timeout handling. Now using http_client library timeout also.
     * Removed CONFIG_REST_CLIENT_SCKT_SEND_TIMEOUT and CONFIG_REST_CLIENT_SCKT_RECV_TIMEOUT.
+    * Updated to handle a zero timeout value as "no timeout" (wait forever) to avoid immediate timeouts.
 
   * :ref:`lib_nrf_cloud_rest` library:
 

--- a/include/net/nrf_cloud_rest.h
+++ b/include/net/nrf_cloud_rest.h
@@ -67,7 +67,9 @@ struct nrf_cloud_rest_context {
 	/** Timeout value, in milliseconds, for REST request. The timeout is set individually
 	 * for socket connection creation and data transfer meaning REST request can take
 	 * longer than this given timeout.
-	 * For no timeout, set to NRF_CLOUD_REST_TIMEOUT_NONE.
+	 * For no timeout (wait forever) set to less than or equal to zero,
+	 * or NRF_CLOUD_REST_TIMEOUT_NONE.
+	 * Using a timeout value that is too short can result in failed REST requests.
 	 */
 	int32_t timeout_ms;
 	/** Authentication string: JWT @ref modem_jwt.

--- a/include/net/rest_client.h
+++ b/include/net/rest_client.h
@@ -86,6 +86,7 @@ struct rest_client_req_context {
 	/** User-defined timeout value for REST request. The timeout is set individually
 	 *  for socket connection creation and data transfer meaning REST request can take
 	 *  longer than this given timeout. To disable, set the timeout duration to SYS_FOREVER_MS.
+	 *  A value of zero will result in an immediate timeout.
 	 *  Default: CONFIG_REST_CLIENT_REST_REQUEST_TIMEOUT.
 	 */
 	int32_t timeout_ms;

--- a/samples/nrf9160/modem_shell/src/cloud/cloud_rest_shell.c
+++ b/samples/nrf9160/modem_shell/src/cloud/cloud_rest_shell.c
@@ -90,10 +90,11 @@ static int cmd_cloud_rest_shadow_device_status_update(const struct shell *shell,
 #define REST_RX_BUF_SZ 300 /* No payload in response, "just" headers */
 	static char rx_buf[REST_RX_BUF_SZ];
 	struct nrf_cloud_rest_context rest_ctx = { .connect_socket = -1,
-							  .keep_alive = false,
-							  .rx_buf = rx_buf,
-							  .rx_buf_len = sizeof(rx_buf),
-							  .fragment_size = 0 };
+						   .keep_alive = false,
+						   .rx_buf = rx_buf,
+						   .rx_buf_len = sizeof(rx_buf),
+						   .timeout_ms = NRF_CLOUD_REST_TIMEOUT_NONE,
+						   .fragment_size = 0 };
 
 	err = nrf_cloud_client_id_get(device_id, sizeof(device_id));
 	if (err) {

--- a/samples/nrf9160/nrf_cloud_rest_cell_pos/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_cell_pos/src/main.c
@@ -57,7 +57,7 @@ static char device_id[NRF_CLOUD_CLIENT_ID_MAX_LEN + 1];
 static char rx_buf[REST_RX_BUF_SZ];
 
 /* nRF Cloud REST context */
-struct nrf_cloud_rest_context rest_ctx = {
+static struct nrf_cloud_rest_context rest_ctx = {
 	.connect_socket = -1,
 	.rx_buf = rx_buf,
 	.rx_buf_len = sizeof(rx_buf),

--- a/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
@@ -91,7 +91,7 @@ static char rx_buf[REST_RX_BUF_SZ];
 static char jwt[JWT_BUF_SZ];
 
 /* nRF Cloud REST context */
-struct nrf_cloud_rest_context rest_ctx = {
+static struct nrf_cloud_rest_context rest_ctx = {
 	.connect_socket = -1,
 	.keep_alive = true,
 	.rx_buf = rx_buf,

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_rest.c
@@ -226,7 +226,12 @@ static void init_rest_client_request(struct nrf_cloud_rest_context const *const 
 	req->port		= HTTPS_PORT;
 	req->host		= CONFIG_NRF_CLOUD_REST_HOST_NAME;
 	req->tls_peer_verify	= TLS_PEER_VERIFY_REQUIRED;
-	req->timeout_ms		= rest_ctx->timeout_ms;
+
+	if (rest_ctx->timeout_ms <= 0) {
+		req->timeout_ms = SYS_FOREVER_MS;
+	} else {
+		req->timeout_ms = rest_ctx->timeout_ms;
+	}
 
 	req->http_method	= meth;
 


### PR DESCRIPTION
Handle a zero timeout value as "no timeout" to avoid immediate timeouts.

CIA-731