### PR TITLE
Bluetooth: Mesh: Added usage of EMDS for RPL data.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -59,7 +59,8 @@ For details, see :ref:`nrfxlib:softdevice_controller_changelog`.
 Bluetooth mesh
 --------------
 
-|no_changes_yet_note|
+* Added support for usage of :ref:`emds_readme`.
+  For details, see `Bluetooth mesh samples`_ and `Bluetooth libraries and services`_.
 
 See `Bluetooth mesh samples`_ for the list of changes for the Bluetooth mesh samples.
 
@@ -276,7 +277,10 @@ Bluetooth samples
 Bluetooth mesh samples
 ----------------------
 
-|no_changes_yet_note|
+* :ref:`bluetooth_mesh_light_lc` sample:
+
+  * Added overlay file with support for storing data with :ref:`emds_readme`.
+    Also changed the sample to restore Light state after power-down.
 
 nRF9160 samples
 ---------------
@@ -423,7 +427,7 @@ Bluetooth libraries and services
   * Added:
 
     * Use of decommissioned callback in :ref:`bt_mesh_silvair_enocean_srv_readme` when EnOcean switch is decommissioned.
-    * Emergency data storage (EMDS) support to:
+    * :ref:`emds_readme` support to:
 
       *  :ref:`bt_mesh_plvl_srv_readme`
       *  :ref:`bt_mesh_light_hue_srv_readme`
@@ -431,6 +435,7 @@ Bluetooth libraries and services
       *  :ref:`bt_mesh_light_temp_srv_readme`
       *  :ref:`bt_mesh_light_xyl_srv_readme`
       *  :ref:`bt_mesh_lightness_srv_readme`
+      * Replay protection list (RPL)
 
 
 Bootloader libraries

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -104,10 +104,12 @@ User interface
 Buttons:
    Can be used to input the out-of-band (OOB) authentication value during provisioning.
    All buttons have the same functionality during this procedure.
+   If the :ref:`emds_readme` feature is enabled and the provisioning and configuration are complete, **Button 4** can be used to trigger storing for data with emergency data storage and halt the system.
 
 LEDs:
    Show the OOB authentication value during provisioning if the "Push button" OOB method is used.
    First LED outputs the current light level of the Light Lightness Server in the first element.
+   If the :ref:`emds_readme` feature is enabled and **Button 4** is pressed LEDs 2 to 4 will light up to show that the board is halted.
 
 .. note::
    :ref:`zephyr:thingy53_nrf5340` supports only one RGB LED.
@@ -134,6 +136,15 @@ FEM support
 
 .. include:: /includes/sample_fem_support.txt
 
+Emergency data storage
+======================
+
+To build this sample with support for emergency data storage, set ``OVERLAY_CONFIG`` to :file:`overlay-emds.conf`.
+This will save replay protection list (RPL) data and some of the :ref:`bt_mesh_lightness_srv_readme` data to the emergency data storage instead of to the :ref:`settings_api`.
+
+See :ref:`cmake_options` for instructions on how to add this option.
+For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
 Building and running
 ********************
 
@@ -148,6 +159,9 @@ Testing
 
 After programming the sample to your development kit, you can test it by using a smartphone with `nRF Mesh mobile app`_ installed.
 Testing consists of provisioning the device and configuring it for communication with the mesh models.
+
+When the development kit is started, it will keep its previous Light state as the ``BT_MESH_ON_POWER_UP_RESTORE`` is set for the :ref:`bt_mesh_lightness_srv_readme`.
+When :ref:`emds_readme` is enabled it is important that the **Button 4** is used to store the data before the development kit is halted and then restarted.
 
 Provisioning the device
 -----------------------

--- a/samples/bluetooth/mesh/light_ctrl/overlay-emds.conf
+++ b/samples/bluetooth/mesh/light_ctrl/overlay-emds.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_EMDS=y
+CONFIG_BT_MESH_RPL_STORAGE_MODE_EMDS=y

--- a/samples/bluetooth/mesh/light_ctrl/sample.yaml
+++ b/samples/bluetooth/mesh/light_ctrl/sample.yaml
@@ -17,3 +17,19 @@ tests:
       nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
       nrf21540dk_nrf52840 nrf52833dk_nrf52833
     tags: bluetooth ci_build
+  sample.bluetooth.mesh.light_ctrl.emds:
+    extra_args: OVERLAY_CONFIG="overlay-emds.conf"
+    build_only: true
+    integration_platforms:
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf52833dk_nrf52833
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - thingy53_nrf5340_cpuapp
+      - thingy53_nrf5340_cpuapp_ns
+      - nrf21540dk_nrf52840
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp thingy53_nrf5340_cpuapp_ns
+      nrf21540dk_nrf52840 nrf52833dk_nrf52833
+    tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/model_handler.c
@@ -198,6 +198,9 @@ void model_handler_start(void)
 		return;
 	}
 
+	bt_mesh_ponoff_srv_set(&light_ctrl_srv.lightness->ponoff,
+			       BT_MESH_ON_POWER_UP_RESTORE);
+
 	err = bt_mesh_light_ctrl_srv_enable(&light_ctrl_srv);
 	if (!err) {
 		printk("Successfully enabled LC server\n");

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -78,3 +78,5 @@ add_subdirectory_ifdef(CONFIG_BT_MESH_SHELL shell)
 
 zephyr_linker_sources(SECTIONS sensor_types.ld)
 zephyr_linker_sources(SECTIONS scene_types.ld)
+
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_RPL_STORAGE_MODE_EMDS rpl.c)

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -11,6 +11,7 @@ menu "Bluetooth mesh"
 rsource "Kconfig.models"
 rsource "Kconfig.dk_prov"
 rsource "shell/Kconfig"
+rsource "Kconfig.rpl"
 
 endmenu
 

--- a/subsys/bluetooth/mesh/Kconfig.rpl
+++ b/subsys/bluetooth/mesh/Kconfig.rpl
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+choice BT_MESH_RPL_STORAGE_MODE
+	prompt "Replay protection list storage mode"
+
+config BT_MESH_RPL_STORAGE_MODE_EMDS
+	bool "Persistent storage of RPL in Emergency Data Storage"
+	depends on EMDS
+	help
+	  Persistent storage of RPL in Emergency Data Storage.
+
+endchoice
+
+if BT_MESH_RPL_STORAGE_MODE_EMDS
+
+config BT_MESH_RPL_INDEX
+	int "Unique index for the storage of RPL data"
+	default 999
+	help
+	  This value defines the storage index for the RPL data in Emergency
+	  Data Storage, and can not overlap with any other index in the
+	  Emergency Data Storage.
+
+endif # BT_MESH_RPL_STORAGE_MODE_EMDS

--- a/subsys/bluetooth/mesh/rpl.c
+++ b/subsys/bluetooth/mesh/rpl.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/zephyr.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <zephyr/bluetooth/mesh.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_RPL)
+#define LOG_MODULE_NAME bt_mesh_rpl
+#include "common/log.h"
+
+#include <mesh/net.h>
+#include <mesh/rpl.h>
+#include <emds/emds.h>
+
+static struct bt_mesh_rpl replay_list[CONFIG_BT_MESH_CRPL];
+
+EMDS_STATIC_ENTRY_DEFINE(rpl_store, CONFIG_BT_MESH_RPL_INDEX, replay_list, sizeof(replay_list));
+
+static inline int rpl_idx(const struct bt_mesh_rpl *rpl)
+{
+	return rpl - &replay_list[0];
+}
+
+void bt_mesh_rpl_update(struct bt_mesh_rpl *rpl,
+		struct bt_mesh_net_rx *rx)
+{
+	/* If this is the first message on the new IV index, we should reset it
+	 * to zero to avoid invalid combinations of IV index and seg.
+	 */
+	if (rpl->old_iv && !rx->old_iv) {
+		rpl->seg = 0;
+	}
+
+	rpl->src = rx->ctx.addr;
+	rpl->seq = rx->seq;
+	rpl->old_iv = rx->old_iv;
+}
+
+/* Check the Replay Protection List for a replay attempt. If non-NULL match
+ * parameter is given the RPL slot is returned but it is not immediately
+ * updated (needed for segmented messages), whereas if a NULL match is given
+ * the RPL is immediately updated (used for unsegmented messages).
+ */
+bool bt_mesh_rpl_check(struct bt_mesh_net_rx *rx,
+		struct bt_mesh_rpl **match)
+{
+	int i;
+
+	/* Don't bother checking messages from ourselves */
+	if (rx->net_if == BT_MESH_NET_IF_LOCAL) {
+		return false;
+	}
+
+	/* The RPL is used only for the local node */
+	if (!rx->local_match) {
+		return false;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(replay_list); i++) {
+		struct bt_mesh_rpl *rpl = &replay_list[i];
+
+		/* Empty slot */
+		if (!rpl->src) {
+			if (match) {
+				*match = rpl;
+			} else {
+				bt_mesh_rpl_update(rpl, rx);
+			}
+
+			return false;
+		}
+
+		/* Existing slot for given address */
+		if (rpl->src == rx->ctx.addr) {
+			if (rx->old_iv && !rpl->old_iv) {
+				return true;
+			}
+
+			if ((!rx->old_iv && rpl->old_iv) ||
+			    rpl->seq < rx->seq) {
+				if (match) {
+					*match = rpl;
+				} else {
+					bt_mesh_rpl_update(rpl, rx);
+				}
+
+				return false;
+			} else {
+				return true;
+			}
+		}
+	}
+
+	BT_ERR("RPL is full!");
+	return true;
+}
+
+void bt_mesh_rpl_clear(void)
+{
+	(void)memset(replay_list, 0, sizeof(replay_list));
+}
+
+void bt_mesh_rpl_reset(void)
+{
+	int shift = 0;
+	int last = 0;
+
+	/* Discard "old" IV Index entries from RPL and flag
+	 * any other ones (which are valid) as old.
+	 */
+	for (int i = 0; i < ARRAY_SIZE(replay_list); i++) {
+		struct bt_mesh_rpl *rpl = &replay_list[i];
+
+		if (rpl->src) {
+			if (rpl->old_iv) {
+				(void)memset(rpl, 0, sizeof(*rpl));
+
+				shift++;
+			} else {
+				rpl->old_iv = true;
+
+				if (shift > 0) {
+					replay_list[i - shift] = *rpl;
+				}
+			}
+
+			last = i;
+		}
+	}
+
+	(void) memset(&replay_list[last - shift + 1], 0, sizeof(struct bt_mesh_rpl) * shift);
+}
+
+void bt_mesh_rpl_pending_store(uint16_t addr)
+{}


### PR DESCRIPTION
Added functionality for EMDS for RPL data if configured. Expanded
the Mesh light fixture example so can be configured to use EMDS
together with settings.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>