### PR TITLE
samples: nrf9160: modem_shell: link: unnecessary PDN evt subscription

### DIFF
--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -616,9 +616,6 @@ int link_func_mode_set(enum lte_lc_func_mode fun, bool rel14_used)
 		/* Enable/disable Rel14 features before going to normal mode */
 		link_enable_disable_rel14_features(rel14_used);
 
-		/* (Re)register for PDN lib notifications */
-		link_shell_pdn_events_subscribe();
-
 		/* (Re)register for rsrp notifications: */
 		modem_info_rsrp_register(link_rsrp_signal_handler);
 

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -222,8 +222,6 @@ void main(void)
 
 	/* Resize terminal width and height of the shell to have proper command editing. */
 	shell_execute_cmd(shell, "resize");
-	/* Run empty command because otherwise "resize" would be set to the command line. */
-	shell_execute_cmd(shell, "");
 
 #if defined(CONFIG_MOSH_STARTUP_CMDS)
 	startup_cmd_ctrl_init();


### PR DESCRIPTION
Removing unnecessary (re)subscription to PDN lib events when going to
normal mode.
Recent PDN lib changes caused this be causing multiple mosh
prints of the same PDN event.
Jira: MOSH-321

Additionally removing unnecessary empty command after a resize command in a bootup.
Jira: MOSH-148

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>