### PR TITLE
tests: Fix nrf91 name

### DIFF
--- a/tests/subsys/nrf_profiler/testcase.yaml
+++ b/tests/subsys/nrf_profiler/testcase.yaml
@@ -4,5 +4,5 @@ tests:
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
-      - nrf9160dk_nrf9160ns
+      - nrf9160dk_nrf9160_ns
     tags: nrf_profiler


### PR DESCRIPTION
Fix platform name nrf9160dk_nrf9160ns -> nrf9160dk_nrf9160_ns

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>