### PR TITLE
samples: multicore: fix incorrect domain name

### DIFF
--- a/samples/nrf5340/multicore/aci/CMakeLists.txt
+++ b/samples/nrf5340/multicore/aci/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CONFIG_INCLUDE_NET_CORE_IMAGE)
   add_child_image(
     NAME cpunet
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../cpunet
-    DOMAIN cpunet
+    DOMAIN CPUNET
     BOARD ${CONFIG_DOMAIN_CPUNET_BOARD}
     )
 endif()


### PR DESCRIPTION
The domain for the network core is CPUNET. Without this fix
the sample will fail if configured with B0N and PCD.

Ref: NCSDK-16339
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>