### PR TITLE
gazell: Select NRFX_PPI

### DIFF
--- a/subsys/gazell/Kconfig
+++ b/subsys/gazell/Kconfig
@@ -7,6 +7,7 @@
 menuconfig GAZELL
 	bool "Gazell"
 	depends on GZLL && CLOCK_CONTROL_NRF
+	select NRFX_PPI if HAS_HW_NRF_PPI
 	help
 	  Enable Gazell functionality.
 


### PR DESCRIPTION
The Gazell Link Layer glue module requests 3 PPI channels through NRFX_PPI.
Explicitly selects the nrfx module to prevent linker error.

The overlooked dependency was uncovered by #8334.

To measure Gazell current consumption, the UART should be disabled. It triggers a linker error in the current samples. This change fixes the issue.