### PR TITLE
lib: lte_link_control: lte_lc_psm_get() changes when not registered

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -939,7 +939,8 @@ int lte_lc_psm_req(bool enable);
  * @retval 0 if successful.
  * @retval -EINVAL if input argument was invalid.
  * @retval -EFAULT if AT command failed.
- * @retval -EBADMSG if no active time and/or TAU value was received.
+ * @retval -EBADMSG if no active time and/or TAU value was received, including the case when
+ *         modem is not registered to network.
  */
 int lte_lc_psm_get(int *tau, int *active_time);
 


### PR DESCRIPTION
lte_lc_psm_get() to return -EBADMSG when not registered and
if parsing fails for needed params. -EFAULT returned only
when AT command fails.
Additionally, only dbg logging instead error logging
for that case and also if lte_lc_psm_get() fails when handling CEREG.
Jira: MOSH-317

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>