### PR TITLE
subsys: logging: Remove log_strdup usage

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -150,7 +150,7 @@ void sdc_assertion_handler(const char *const file, const uint32_t line)
 #else /* !IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
 void sdc_assertion_handler(const char *const file, const uint32_t line)
 {
-	BT_ERR("SoftDevice Controller ASSERT: %s, %d", log_strdup(file), line);
+	BT_ERR("SoftDevice Controller ASSERT: %s, %d", file, line);
 	k_oops();
 }
 #endif /* IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -119,7 +119,7 @@ void m_assert_handler(const char *const file, const uint32_t line)
 #else /* !IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER) */
 static void m_assert_handler(const char *const file, const uint32_t line)
 {
-	LOG_ERR("MPSL ASSERT: %s, %d", log_strdup(file), line);
+	LOG_ERR("MPSL ASSERT: %s, %d", file, line);
 	k_oops();
 }
 #endif /* IS_ENABLED(CONFIG_MPSL_ASSERT_HANDLER) */


### PR DESCRIPTION
Remove the usage of wrapper function log_strdup in bluetooth,
mpsl because logging V1 has been removed.

Signed-off-by: Lang Xie <Lang.Xie@nordicsemi.no>