### PR TITLE
samples: zigbee: Cleanup for nRF52 dongle platform

### DIFF
--- a/samples/zigbee/ncp/boards/nrf52840dongle_nrf52840_usb.overlay
+++ b/samples/zigbee/ncp/boards/nrf52840dongle_nrf52840_usb.overlay
@@ -14,7 +14,6 @@
 / {
 	chosen {
 		ncs,zigbee-uart = &cdc_acm_uart0;
-		ncs,zboss-trace-uart = &cdc_acm_uart1;
 	};
 
 	buttons {
@@ -27,17 +26,5 @@
 
 	aliases {
 		rst0 = &rst_button0;
-	};
-};
-
-&zephyr_udc0 {
-	cdc_acm_uart0: cdc_acm_uart0 {
-		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
-	};
-
-	cdc_acm_uart1: cdc_acm_uart1 {
-		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_1";
 	};
 };


### PR DESCRIPTION
Removed additional instance of USB CDC ACM as no longer required for the nRF52 dongle platform.

Changelog entry not necessarily required as these changes should have been a part of https://github.com/nrfconnect/sdk-nrf/pull/8320