### PR TITLE
treewide: Clean up RSRP and RSRQ conversions

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -491,12 +491,12 @@ static inline int adjust_rsrp(int input, enum sample_type type)
 	switch (type) {
 	case NEIGHBOR_CELL:
 		if (IS_ENABLED(CONFIG_MODEM_NEIGHBOR_CELLS_DATA_CONVERT_RSRP_TO_DBM)) {
-			return input - 140;
+			return RSRP_IDX_TO_DBM(input);
 		}
 		break;
 	case MODEM_DYNAMIC:
 		if (IS_ENABLED(CONFIG_MODEM_DYNAMIC_DATA_CONVERT_RSRP_TO_DBM)) {
-			return input - 140;
+			return RSRP_IDX_TO_DBM(input);
 		}
 		break;
 	default:
@@ -510,7 +510,7 @@ static inline int adjust_rsrp(int input, enum sample_type type)
 static inline int adjust_rsrq(int input)
 {
 	if (IS_ENABLED(CONFIG_MODEM_NEIGHBOR_CELLS_DATA_CONVERT_RSRQ_TO_DB)) {
-		return round(input * 0.5 - 19.5);
+		return round(RSRQ_IDX_TO_DB(input));
 	}
 
 	return input;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -131,6 +131,7 @@ nRF9160: Asset Tracker v2
     * The default value of the GNSS timeout in the application's :ref:`Real-time configurations <real_time_configs>` is now 30 seconds.
     * GNSS fixes are now published in PVT format instead of NMEA for nRF Cloud builds. To revert to NMEA, set the :ref:`CONFIG_GNSS_MODULE_NMEA <CONFIG_GNSS_MODULE_NMEA>` option.
     * The sensor module now forwards :c:enum:`SENSOR_EVT_MOVEMENT_ACTIVITY_DETECTED` and :c:enum:`SENSOR_EVT_MOVEMENT_INACTIVITY_DETECTED` events.
+    * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
 
   * Fixed:
 
@@ -317,6 +318,7 @@ nRF9160 samples
   * Updated:
 
     * Changed timeout parameters from seconds to milliseconds in ``location`` and ``rest`` commands.
+    * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
 
 * :ref:`nrf_cloud_mqtt_multi_service` sample:
 
@@ -337,6 +339,10 @@ nRF9160 samples
   * Added:
 
     * Support for full modem FOTA updates.
+
+* :ref:`at_monitor_sample` sample:
+
+  * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
 
 Thread samples
 --------------
@@ -527,6 +533,10 @@ Modem libraries
     * Changed timeout parameters' type from uint16_t to int32_t, unit from seconds to milliseconds, and value to disable them from 0 to SYS_FOREVER_MS.
       This change is done to align with Zephyr's style for timeouts.
 
+  * :ref:`modem_info_readme` library:
+
+    * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
+
 Libraries for networking
 ------------------------
 
@@ -538,6 +548,10 @@ Libraries for networking
 
       * Setting of the FOTA update result.
       * Reporting of the FOTA update result back to the LwM2M server.
+
+    * Updated:
+
+      * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
 
   * :ref:`lib_nrf_cloud` library:
 
@@ -555,10 +569,15 @@ Libraries for networking
       * :c:func:`nrf_cloud_fota_is_type_enabled` function that determines if the specified FOTA type is enabled by the configuration.
       * :c:func:`nrf_cloud_gnss_msg_json_encode` function that encodes GNSS data (PVT or NMEA) into an nRF Cloud device message.
 
+    * Updated:
+
+      * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
+
   * :ref:`lib_multicell_location` library:
 
     * Added timeout parameter.
     * Made a structure for input parameters for multicell_location_get() to make updates easier in the future.
+    * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
 
   * :ref:`lib_rest_client` library:
 

--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -32,7 +32,22 @@ extern "C" {
 #define MODEM_INFO_JSON_STRING_SIZE 512
 
 /** RSRP offset value. */
-#define MODEM_INFO_RSRP_OFFSET_VAL 141
+#define RSRP_OFFSET_VAL 140
+
+/** RSRQ offset value. */
+#define RSRQ_OFFSET_VAL 19.5
+
+/** RSRQ scale value. */
+#define RSRQ_SCALE_VAL 0.5
+
+/** Modem returns RSRP and RSRQ as index values which require
+ * a conversion to dBm and dB respectively. See modem AT
+ * command reference guide for more information.
+ */
+#define RSRP_IDX_TO_DBM(rsrp) ((rsrp) - RSRP_OFFSET_VAL)
+
+#define RSRQ_IDX_TO_DB(rsrq) ((((float)(rsrq)) * RSRQ_SCALE_VAL) - \
+			      RSRQ_OFFSET_VAL)
 
 /** Maximum string size of the network mode string */
 #define MODEM_INFO_NETWORK_MODE_MAX_SIZE 12

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -77,8 +77,6 @@ LOG_MODULE_REGISTER(modem_info);
 #define RSRP_PARAM_INDEX	6
 #define RSRP_PARAM_COUNT	7
 
-#define RSRP_OFFSET_VAL		141
-
 #define BAND_PARAM_INDEX	1 /* Index of desired parameter */
 #define BAND_PARAM_COUNT	2 /* Number of parameters */
 

--- a/lib/multicell_location/services/here_integration.c
+++ b/lib/multicell_location/services/here_integration.c
@@ -9,6 +9,7 @@
 #include <net/rest_client.h>
 #include <cJSON.h>
 #include <cJSON_os.h>
+#include <modem/modem_info.h>
 #include <net/multicell_location.h>
 
 #include "location_service.h"
@@ -104,13 +105,6 @@ BUILD_ASSERT(sizeof(HOSTNAME) > 1, "Hostname must be configured");
 static char body[HTTP_BODY_SIZE];
 static char neighbors[NEIGHBOR_BUFFER_SIZE];
 
-/* Modem returns RSRP and RSRQ as index values which require
- * a conversion to dBm and dB respectively. See modem AT
- * command reference guide for more information.
- */
-#define RSRP_ADJ(rsrp) (rsrp - ((rsrp <= 0) ? 140 : 141))
-#define RSRQ_ADJ(rsrq) (((double)rsrq * 0.5) - 19.5)
-
 #define HERE_MIN_RSRP -140
 #define HERE_MAX_RSRP -44
 
@@ -118,7 +112,7 @@ static int here_adjust_rsrp(int input)
 {
 	int return_value;
 
-	return_value = RSRP_ADJ(input);
+	return_value = RSRP_IDX_TO_DBM(input);
 
 	if (return_value < HERE_MIN_RSRP) {
 		return_value = HERE_MIN_RSRP;
@@ -136,7 +130,7 @@ static double here_adjust_rsrq(int input)
 {
 	double return_value;
 
-	return_value = RSRQ_ADJ(input);
+	return_value = RSRQ_IDX_TO_DB(input);
 
 	if (return_value < HERE_MIN_RSRQ) {
 		return_value = HERE_MIN_RSRQ;

--- a/lib/multicell_location/services/polte_integration.c
+++ b/lib/multicell_location/services/polte_integration.c
@@ -10,6 +10,7 @@
 #include <net/rest_client.h>
 #include <cJSON.h>
 #include <cJSON_os.h>
+#include <modem/modem_info.h>
 
 #include "location_service.h"
 
@@ -93,15 +94,6 @@ const char *location_service_get_certificate_polte(void)
 	return tls_certificate;
 }
 
-static int adjust_rsrp(int input)
-{
-	if (input <= 0) {
-		return input - 140;
-	}
-
-	return input - 141;
-}
-
 static int location_service_generate_request(
 	const struct lte_lc_cells_info *cell_data,
 	char *buf,
@@ -175,7 +167,7 @@ static int location_service_generate_request(
 	    !cJSON_AddItemToArray(earfcn_array,
 		cJSON_CreateNumber(cell_data->current_cell.earfcn)) ||
 	    !cJSON_AddItemToArray(rsrp_array,
-		cJSON_CreateNumber(adjust_rsrp(cell_data->current_cell.rsrp)))) {
+		cJSON_CreateNumber(RSRP_IDX_TO_DBM(cell_data->current_cell.rsrp)))) {
 		LOG_ERR("Failed to add current cell information");
 		err = -ENOMEM;
 		goto cleanup;
@@ -189,7 +181,7 @@ static int location_service_generate_request(
 				cJSON_CreateNumber(cell_data->neighbor_cells[i].earfcn)) ||
 			    !cJSON_AddItemToArray(rsrp_array,
 				cJSON_CreateNumber(
-					adjust_rsrp(cell_data->neighbor_cells[i].rsrp)))) {
+					RSRP_IDX_TO_DBM(cell_data->neighbor_cells[i].rsrp)))) {
 				LOG_ERR("Failed to add neighbor cell");
 				err = -ENOMEM;
 				goto cleanup;

--- a/samples/nrf9160/at_monitor/src/main.c
+++ b/samples/nrf9160/at_monitor/src/main.c
@@ -11,6 +11,7 @@
 #include <nrf_modem_at.h>
 #include <modem/nrf_modem_lib.h>
 #include <modem/at_monitor.h>
+#include <modem/modem_info.h>
 
 #define ENABLE 1
 #define DISABLE 0
@@ -58,7 +59,7 @@ static const char *cereg_str_get(enum cereg_status status)
 	}
 }
 
-static int rsps_status;
+static int rsrp_status;
 static char response[64];
 
 static void cereg_mon(const char *notif)
@@ -82,10 +83,9 @@ static void cereg_mon(const char *notif)
 
 static void cesq_mon(const char *notif)
 {
-	rsps_status = atoi(notif + strlen("%CESQ: "));
+	rsrp_status = atoi(notif + strlen("%CESQ: "));
 
-#define FLOOR 140
-	printk("Link quality: %d dBm\n", rsps_status - FLOOR);
+	printk("Link quality: %d dBm\n", RSRP_IDX_TO_DBM(rsrp_status));
 }
 
 static int psm_control(int enable)

--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -202,7 +202,7 @@ static void link_cell_change_work(struct k_work *work_item)
 		"LTE cell changed: ID: %d (0x%s), PCI %d, Tracking area: %d (0x%s), Band: %d, RSRP: %d (%ddBm), SNR: %d (%ddB)",
 		xmonitor_resp.cell_id, xmonitor_resp.cell_id_str, xmonitor_resp.pci,
 		xmonitor_resp.tac, xmonitor_resp.tac_str, xmonitor_resp.band,
-		xmonitor_resp.rsrp, (xmonitor_resp.rsrp - MODEM_INFO_RSRP_OFFSET_VAL),
+		xmonitor_resp.rsrp, RSRP_IDX_TO_DBM(xmonitor_resp.rsrp),
 		xmonitor_resp.snr, (xmonitor_resp.snr - LINK_SNR_OFFSET_VALUE));
 }
 
@@ -210,7 +210,7 @@ static void link_cell_change_work(struct k_work *work_item)
 
 static void link_rsrp_signal_handler(char rsrp_value)
 {
-	modem_rsrp = (int8_t)rsrp_value - MODEM_INFO_RSRP_OFFSET_VAL;
+	modem_rsrp = (int8_t)RSRP_IDX_TO_DBM(rsrp_value);
 	k_work_submit_to_queue(&mosh_common_work_q, &modem_info_signal_work);
 }
 
@@ -299,7 +299,7 @@ void link_ind_handler(const struct lte_lc_evt *const evt)
 				"    TA %s, TA meas time %lld",
 				cur_cell.id, cur_cell.phys_cell_id,
 				cur_cell.mcc, cur_cell.mnc, cur_cell.rsrp,
-				cur_cell.rsrp - MODEM_INFO_RSRP_OFFSET_VAL,
+				RSRP_IDX_TO_DBM(cur_cell.rsrp),
 				cur_cell.rsrq, cur_cell.tac, cur_cell.earfcn,
 				cur_cell.measurement_time,
 				tmp_ta_str,
@@ -319,8 +319,7 @@ void link_ind_handler(const struct lte_lc_evt *const evt)
 				"    phy ID %d, RSRP %d : %ddBm, RSRQ %d, earfcn %d, timediff %d",
 				cells.neighbor_cells[i].phys_cell_id,
 				cells.neighbor_cells[i].rsrp,
-				cells.neighbor_cells[i].rsrp -
-				MODEM_INFO_RSRP_OFFSET_VAL,
+				RSRP_IDX_TO_DBM(cells.neighbor_cells[i].rsrp),
 				cells.neighbor_cells[i].rsrq,
 				cells.neighbor_cells[i].earfcn,
 				cells.neighbor_cells[i].time_diff);

--- a/samples/nrf9160/modem_shell/src/link/link_api.c
+++ b/samples/nrf9160/modem_shell/src/link/link_api.c
@@ -197,7 +197,7 @@ void link_api_coneval_read_for_shell(void)
 			link_shell_map_to_string(coneval_energy_est_strs,
 				params.energy_estimate, snum));
 	mosh_print("  rsrp:            %d: %ddBm", params.rsrp,
-			(params.rsrp - MODEM_INFO_RSRP_OFFSET_VAL));
+			RSRP_IDX_TO_DBM(params.rsrp));
 	mosh_print("  rsrq:            %d", params.rsrq);
 
 	mosh_print("  snr:             %d: %ddB", params.snr,
@@ -333,7 +333,7 @@ static void link_api_modem_operator_info_read_for_shell(void)
 		mosh_print(
 			"Current rsrp:          %d: %ddBm",
 			xmonitor_resp.rsrp,
-			(xmonitor_resp.rsrp - MODEM_INFO_RSRP_OFFSET_VAL));
+			RSRP_IDX_TO_DBM(xmonitor_resp.rsrp));
 	}
 
 	if (xmonitor_resp.snr >= 0) {

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
@@ -108,7 +108,7 @@ static void modem_signal_handler(char rsrp_value)
 		return;
 	}
 
-	modem_rsrp = (int8_t)rsrp_value - MODEM_INFO_RSRP_OFFSET_VAL;
+	modem_rsrp = (int8_t)RSRP_IDX_TO_DBM(rsrp_value);
 	k_work_submit(&modem_signal_work);
 }
 

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/neighbour_cell_info.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/neighbour_cell_info.c
@@ -19,13 +19,6 @@
 LOG_MODULE_REGISTER(lwm2m_neighbour_cell, CONFIG_LWM2M_CLIENT_UTILS_LOG_LEVEL);
 #define MAX_INSTANCE_COUNT CONFIG_LWM2M_CLIENT_UTILS_SIGNAL_MEAS_INFO_INSTANCE_COUNT
 
-/* Modem returns RSRP and RSRQ as index values which require
- * a conversion to dBm and dB respectively. See modem AT
- * command reference guide for more information.
- */
-#define RSRP_ADJ(rsrp) (rsrp - ((rsrp <= 0) ? 140 : 141))
-#define RSRQ_ADJ(rsrq) (round((rsrq * 0.5) - 19.5))
-
 static void update_signal_meas_object(const struct lte_lc_ncell *const cell, uint16_t index)
 {
 	int obj_inst_id;
@@ -41,9 +34,9 @@ static void update_signal_meas_object(const struct lte_lc_ncell *const cell, uin
 	snprintk(path, sizeof(path), "10256/%" PRIu16 "/2", obj_inst_id);
 	lwm2m_engine_set_s32(path, cell->earfcn);
 	snprintk(path, sizeof(path), "10256/%" PRIu16 "/3", obj_inst_id);
-	lwm2m_engine_set_s32(path, RSRP_ADJ(cell->rsrp));
+	lwm2m_engine_set_s32(path, RSRP_IDX_TO_DBM(cell->rsrp));
 	snprintk(path, sizeof(path), "10256/%" PRIu16 "/4", obj_inst_id);
-	lwm2m_engine_set_s32(path, RSRQ_ADJ(cell->rsrq));
+	lwm2m_engine_set_s32(path, RSRQ_IDX_TO_DB(cell->rsrq));
 	snprintk(path, sizeof(path), "10256/%" PRIu16 "/5", obj_inst_id);
 	lwm2m_engine_set_s32(path, cell->time_diff);
 }

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -23,13 +23,6 @@ LOG_MODULE_REGISTER(nrf_cloud_codec, CONFIG_NRF_CLOUD_LOG_LEVEL);
 #define TIMEOUT_STR "timeout"
 #define PAIRED_STR "paired"
 
-/* Modem returns RSRP and RSRQ as index values which require
- * a conversion to dBm and dB respectively. See modem AT
- * command reference guide for more information.
- */
-#define RSRP_ADJ(rsrp) (rsrp - ((rsrp <= 0) ? 140 : 141))
-#define RSRQ_ADJ(rsrq) (((double)rsrq * 0.5) - 19.5)
-
 bool initialized;
 
 #if defined(CONFIG_NRF_CLOUD_MQTT)
@@ -185,7 +178,7 @@ static int json_format_modem_info_data_obj(cJSON *const data_obj,
 	    json_add_num_cs(data_obj, NRF_CLOUD_JSON_CELL_ID_KEY,
 		(uint32_t)modem_info->network.cellid_dec) ||
 	    json_add_num_cs(data_obj, NRF_CLOUD_CELL_POS_JSON_KEY_RSRP,
-		RSRP_ADJ(modem_info->network.rsrp.value))) {
+		RSRP_IDX_TO_DBM(modem_info->network.rsrp.value))) {
 		return -ENOMEM;
 	}
 
@@ -1333,13 +1326,13 @@ int nrf_cloud_format_cell_pos_req_json(struct lte_lc_cells_info const *const inf
 
 		if ((cur->rsrp != NRF_CLOUD_CELL_POS_OMIT_RSRP) &&
 		    json_add_num_cs(lte_obj, NRF_CLOUD_CELL_POS_JSON_KEY_RSRP,
-				    RSRP_ADJ(cur->rsrp))) {
+				    RSRP_IDX_TO_DBM(cur->rsrp))) {
 			goto cleanup;
 		}
 
 		if ((cur->rsrq != NRF_CLOUD_CELL_POS_OMIT_RSRQ) &&
 		    json_add_num_cs(lte_obj, NRF_CLOUD_CELL_POS_JSON_KEY_RSRQ,
-				    RSRQ_ADJ(cur->rsrq))) {
+				    RSRQ_IDX_TO_DB(cur->rsrq))) {
 			goto cleanup;
 		}
 
@@ -1399,12 +1392,12 @@ int nrf_cloud_format_cell_pos_req_json(struct lte_lc_cells_info const *const inf
 			/* optional */
 			if ((ncell->rsrp != NRF_CLOUD_CELL_POS_OMIT_RSRP) &&
 			    json_add_num_cs(ncell_obj, NRF_CLOUD_CELL_POS_JSON_KEY_RSRP,
-					    RSRP_ADJ(ncell->rsrp))) {
+					    RSRP_IDX_TO_DBM(ncell->rsrp))) {
 				goto cleanup;
 			}
 			if ((ncell->rsrq != NRF_CLOUD_CELL_POS_OMIT_RSRQ) &&
 			    json_add_num_cs(ncell_obj, NRF_CLOUD_CELL_POS_JSON_KEY_RSRQ,
-					    RSRQ_ADJ(ncell->rsrq))) {
+					    RSRQ_IDX_TO_DB(ncell->rsrq))) {
 				goto cleanup;
 			}
 		}


### PR DESCRIPTION
The modem-team-approved approach to converting RSRP
index to dBm is to subtract 140, for the %CESQ,
%NBRGRSRP, and %NCELLMEAS notification values.

Replace the 3 different hard-coded methods in various
libraries, applications, and samples to use a single
method defined in modem_info.h.

Do the same for RSRQ.

Jira: NRF91-1502

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>