### PR TITLE
lib: at_shell: fix format of at cmd sent

### DIFF
--- a/lib/at_shell/at_shell.c
+++ b/lib/at_shell/at_shell.c
@@ -54,7 +54,7 @@ int at_shell(const struct shell *shell, size_t argc, char **argv)
 		at_monitor_pause(&at_shell_monitor);
 		shell_print(shell, "AT command event handler disabled");
 	} else {
-		err = nrf_modem_at_cmd(response, sizeof(response), command);
+		err = nrf_modem_at_cmd(response, sizeof(response), "%s", command);
 		if (err < 0) {
 			shell_print(shell, "Sending AT command failed with error code %d", err);
 			return err;


### PR DESCRIPTION
at shell did not format the commands sent.

Signed-off-by: Emilia O'Brien <emilia.obrien@nordicsemi.no>