### PR TITLE
applications: asset_tracker_v2: Update state handling in GNSS module

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -22,6 +22,7 @@
 --ignore SPDX_LICENSE_TAG
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
 --ignore TRAILING_SEMICOLON
+--ignore EMBEDDED_FUNCTION_NAME
 --exclude ext
 --exclude samples/matter/.*/src
 --exclude applications/matter_weather_station/src


### PR DESCRIPTION
Update state handling to ensure that the initial device configuration
received in the `DATA_EVT_CONFIG_INIT` event is handled by the
module. Previously this event was not handled due to the state being
set to `STATE_RUNNING` prior to receiving the event.

Also, move the `setup()` function to `STATE_INIT` to ensure proper
initialization / state handling order.

Add EMBEDDED_FUNCTION_NAME to checkpatch ignore list to
prevent warning that suggest that `__func__` should be used when
referring to function names in logs.
Checkpatch complains that `setup` is replaceable with `__func__` when
it actually prints the executing function `on_state_init`.
Which is not the intention to print.