### PR TITLE
samples: nrf9160: modem_shell: Modem search support

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -326,6 +326,8 @@ nRF9160 samples
       For a position fix using only three satellites, GNSS module must have a reference altitude that can now be injected using the ``gnss agps ref_altitude`` command.
     * New command ``startup_cmd``, which can be used to store up to three MoSh commands to be run on start/bootup.
       By default, commands are run after the default PDN context is activated, but can be set to run N seconds after bootup.
+    * New command ``link search`` for setting periodic modem search parameters.
+    * Added printing of modem domain events.
 
   * Updated:
 

--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -251,6 +251,7 @@ void link_init(void)
 	link_shell_pdn_init();
 
 	lte_lc_register_handler(link_ind_handler);
+	(void)lte_lc_modem_events_enable();
 
 	if (link_sett_is_dnsaddr_enabled()) {
 		(void)link_setdnsaddr(link_sett_dnsaddr_ip_get());
@@ -409,6 +410,9 @@ void link_ind_handler(const struct lte_lc_evt *const evt)
 		}
 		break;
 	}
+	case LTE_LC_EVT_MODEM_EVENT:
+		link_shell_print_modem_domain_event(evt->modem_evt);
+		break;
 	default:
 		break;
 	}

--- a/samples/nrf9160/modem_shell/src/link/link_api.c
+++ b/samples/nrf9160/modem_shell/src/link/link_api.c
@@ -72,7 +72,7 @@ static void link_api_context_info_fill_activation_status(
 		return;
 	}
 
-	/* For each contexts: */
+	/* For each contexts */
 	for (int i = 0; i < ctx_cnt; i++) {
 		/* Search for a string +CGACT: <cid>,<state> */
 		snprintf(buf, sizeof(buf), "+CGACT: %d,1", ctx_tbl[i].cid);
@@ -386,7 +386,7 @@ static int link_api_pdp_context_dynamic_params_get(struct pdp_context_info *popu
 		return ret;
 	}
 
-	/* Check how many rows of info do we have: */
+	/* Check how many rows of info do we have */
 	while (strncmp(tmp_ptr, "OK", 2) &&
 	       (tmp_ptr = strstr(tmp_ptr, AT_CMD_PDP_CONTEXT_READ_RSP_DELIM)) != NULL) {
 		tmp_ptr += 2;
@@ -477,7 +477,7 @@ parse:
 		ret = at_params_int_get(&param_list, AT_CMD_PDP_CONTEXT_READ_INFO_MTU_INDEX,
 					&(populated_info->ipv6_mtu));
 		if (ret) {
-			/* Don't care if it fails: */
+			/* Don't care if it fails */
 			ret = 0;
 			populated_info->ipv6_mtu = 0;
 		}
@@ -485,7 +485,7 @@ parse:
 		ret = at_params_int_get(&param_list, AT_CMD_PDP_CONTEXT_READ_INFO_MTU_INDEX,
 					&(populated_info->ipv4_mtu));
 		if (ret) {
-			/* Don't care if it fails: */
+			/* Don't care if it fails */
 			ret = 0;
 			populated_info->ipv4_mtu = 0;
 		}
@@ -494,7 +494,7 @@ parse:
 	if (resp_continues) {
 		at_ptr = next_param_str;
 		iterator++;
-		if (iterator < lines && strncmp(next_param_str, "OK", 2)) {
+		if (iterator < lines) {
 			goto parse;
 		}
 	}
@@ -540,14 +540,14 @@ int link_api_pdp_contexts_read(struct pdp_context_info_array *pdp_info)
 		goto clean_exit;
 	}
 
-	/* Check how many rows/context do we have: */
+	/* Check how many rows/context do we have */
 	while (strncmp(tmp_ptr, "OK", 2) &&
 	       (tmp_ptr = strstr(tmp_ptr, AT_CMD_PDP_CONTEXT_READ_RSP_DELIM)) != NULL) {
 		tmp_ptr += 2;
 		pdp_cnt++;
 	}
 
-	/* Allocate array of PDP info accordingly: */
+	/* Allocate array of PDP info accordingly */
 	pdp_info->array = calloc(pdp_cnt, sizeof(struct pdp_context_info));
 	pdp_info->size = pdp_cnt;
 
@@ -652,7 +652,7 @@ parse:
 	}
 	if (ip_address2 != NULL) {
 		/* Note: If we are here, PDP_addr_2 should be IPv6,
-		 * thus in following ipv4 branch should not be possible:
+		 * thus in following ipv4 branch should not be possible
 		 */
 		family = net_utils_sa_family_from_ip_string(ip_address2);
 		if (family == AF_INET) {
@@ -664,7 +664,7 @@ parse:
 		}
 	}
 
-	/* Get DNS addresses etc.  for this IP context: */
+	/* Get DNS addresses etc. for this IP context */
 	if (populated_info[iterator].pdp_type != PDP_TYPE_NONIP) {
 		(void)link_api_pdp_context_dynamic_params_get(&(populated_info[iterator]));
 	}
@@ -672,17 +672,17 @@ parse:
 	if (resp_continues) {
 		at_ptr = next_param_str;
 		iterator++;
-		if (iterator < pdp_cnt && strncmp(next_param_str, "OK", 2)) {
+		if (iterator < pdp_cnt) {
 			goto parse;
 		}
 	}
 
-	/* ...and finally, fill PDP context activation status for each: */
+	/* ...and finally, fill PDP context activation status for each */
 	link_api_context_info_fill_activation_status(pdp_info);
 
 clean_exit:
 	at_params_list_free(&param_list);
-	/* user need do free pdp_info->array also in case of error */
+	/* User need to free pdp_info->array also in case of error */
 
 	k_mutex_unlock(&at_resp_buf_mutex);
 
@@ -765,7 +765,7 @@ void link_api_modem_info_get_for_shell(bool connected)
 					sprintf(tmp_str, "%d", info_tbl[i].pdn_id);
 				}
 
-				/* Parsed PDP context info: */
+				/* Parsed PDP context info */
 				mosh_print("PDP context info %d:", (i + 1));
 				mosh_print("  CID:                %d", info_tbl[i].cid);
 				mosh_print("  PDN ID:             %s",

--- a/samples/nrf9160/modem_shell/src/link/link_shell_print.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_print.c
@@ -68,6 +68,27 @@ void link_shell_print_modem_sleep_notif(const struct lte_lc_evt *const evt)
 	}
 }
 
+void link_shell_print_modem_domain_event(enum lte_lc_modem_evt modem_evt)
+{
+	switch (modem_evt) {
+	case LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE:
+		mosh_print("Modem domain event: Light search done");
+		break;
+	case LTE_LC_MODEM_EVT_SEARCH_DONE:
+		mosh_print("Modem domain event: Search done");
+		break;
+	case LTE_LC_MODEM_EVT_RESET_LOOP:
+		mosh_print("Modem domain event: Reset loop");
+		break;
+	case LTE_LC_MODEM_EVT_BATTERY_LOW:
+		mosh_print("Modem domain event: Battery low");
+		break;
+	case LTE_LC_MODEM_EVT_OVERHEATED:
+		mosh_print("Modem domain event: Overheated");
+		break;
+	}
+}
+
 const char *link_shell_funmode_to_string(int funmode, char *out_str_buff)
 {
 	struct mapping_tbl_item const mapping_table[] = {

--- a/samples/nrf9160/modem_shell/src/link/link_shell_print.h
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_print.h
@@ -17,6 +17,7 @@ struct mapping_tbl_item {
 
 void link_shell_print_reg_status(enum lte_lc_nw_reg_status reg_status);
 void link_shell_print_modem_sleep_notif(const struct lte_lc_evt *const evt);
+void link_shell_print_modem_domain_event(enum lte_lc_modem_evt modem_evt);
 const char *link_shell_funmode_to_string(int funmode, char *out_str_buff);
 const char *link_shell_sysmode_to_string(int sysmode, char *out_str_buff);
 const char *link_shell_sysmode_preferred_to_string(int sysmode_preference, char *out_str_buff);


### PR DESCRIPTION
Add support for modem search operation done with AT%PERIODICSEARCHCONF.
Add support for modem domain events (LTE_LC_EVT_MODEM_EVENT).