### PR TITLE
doc: nrf: use sphinx-notfound-page extension

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx_tabs.tabs",
     "software_maturity_table",
     "sphinx_togglebutton",
+    "notfound.extension",
 ]
 
 linkcheck_ignore = [
@@ -183,6 +184,11 @@ ncs_cache_build_dir = utils.get_builddir()
 ncs_cache_config = NRF_BASE / "doc" / "cache.yml"
 ncs_cache_manifest = NRF_BASE / "west.yml"
 
+# Options for sphinx_notfound_page ---------------------------------------------
+
+notfound_urls_prefix = "/nRF_Connect_SDK/doc/{}/nrf/".format(
+    "latest" if version.endswith("99") else version
+)
 
 def setup(app):
     app.add_css_file("css/nrf.css")

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -11,3 +11,4 @@ sphinx_markdown_tables
 mistune<2.0 # Workaround for https://github.com/CrossNox/m2r2/issues/40
 breathe<4.33 # Workaround for #803 and #805 breathe issues
 sphinx-togglebutton
+sphinx-notfound-page

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -2,13 +2,12 @@ recommonmark==0.6.0
 CommonMark>=0.9.1
 sphinxcontrib-mscgen>=0.6
 sphinx-ncs-theme>=1.0.3,<1.1
-m2r2
+m2r2>=0.3.2
 sphinxcontrib-plantuml
 pygit2
 pyyaml
 azure-storage-blob
 sphinx_markdown_tables
-mistune<2.0 # Workaround for https://github.com/CrossNox/m2r2/issues/40
 breathe<4.33 # Workaround for #803 and #805 breathe issues
 sphinx-togglebutton
 sphinx-notfound-page


### PR DESCRIPTION
This extension allows to have custom 404 pages that render correctly. Should likely fix NCSIDB-793

Also update one of the dependencies (m2r2), which allows to remove a workaround.