### PR TITLE
lib: nrf_cloud: Clean up POSIX socket includes

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -15,19 +15,17 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <zephyr/net/mqtt.h>
-#include <zephyr/net/socket.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/settings/settings.h>
-#if defined(CONFIG_NRF_MODEM_LIB)
+
 #if defined(CONFIG_POSIX_API)
 #include <zephyr/posix/arpa/inet.h>
 #include <zephyr/posix/netdb.h>
 #include <zephyr/posix/sys/socket.h>
 #else
 #include <zephyr/net/socket.h>
-#endif
-#endif /* defined(CONFIG_NRF_MODEM_LIB) */
+#endif /* defined(CONFIG_POSIX_API) */
 
 LOG_MODULE_REGISTER(nrf_cloud_transport, CONFIG_NRF_CLOUD_LOG_LEVEL);
 


### PR DESCRIPTION
Slight alterations to how POSIX socket control functions are included
in order to prevent a rare edge-case where they may not be included
at all.

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>