### PR TITLE
doc: apply correct screenshot

### DIFF
--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -115,10 +115,10 @@ Complete the following steps to provision the certificate:
 #. Click :guilabel:`Select device` and select the DK from the drop-down list.
    You can identify the nRF9160 DK by the fact that it has three COM ports.
 
-   .. figure:: /images/programmer_com_ports.png
-      :alt: Programmer - COM ports
+   .. figure:: /images/ltelinkmonitor_selectdevice.png
+      :alt: LTE Link Monitor - COM ports
 
-      Programmer - COM ports
+      LTE Link Monitor - COM ports
 
    If the three COM ports are not visible, press ``Ctrl+R`` in Windows or ``command+R`` in macOS to restart the Programmer application.
 


### PR DESCRIPTION
A screenshot used in the Provisioning the nRF Cloud certificate
section of Developing with the nRF9160 DK used the wrong screenshot.
This changes it to use the correct, existing screenshot.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>