### PR TITLE
bluetooth: rpc: serialize bt_hci_cmd_send_sync

### DIFF
--- a/subsys/bluetooth/rpc/client/bt_rpc_internal_client.c
+++ b/subsys/bluetooth/rpc/client/bt_rpc_internal_client.c
@@ -11,9 +11,13 @@
 #include "serialize.h"
 #include "cbkproxy.h"
 
+#include <zephyr/bluetooth/buf.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(BT_RPC, CONFIG_BT_RPC_LOG_LEVEL);
+
+#define CMD_BUF_SIZE MAX(BT_BUF_EVT_RX_SIZE, BT_BUF_CMD_TX_SIZE)
+NET_BUF_POOL_FIXED_DEFINE(hci_cmd_pool, CONFIG_BT_BUF_CMD_TX_COUNT, CMD_BUF_SIZE, 8, NULL);
 
 bool bt_addr_le_is_bonded(uint8_t id, const bt_addr_le_t *addr)
 {
@@ -31,4 +35,74 @@ bool bt_addr_le_is_bonded(uint8_t id, const bt_addr_le_t *addr)
 				&ctx, ser_rsp_decode_bool, &result);
 
 	return result;
+}
+
+struct bt_hci_cmd_send_sync_res {
+	int result;
+	struct net_buf *buf;
+	struct net_buf **rsp;
+};
+
+static void decode_net_buf(struct ser_scratchpad *scratchpad, struct net_buf *data)
+{
+	size_t len;
+	void *buf;
+
+	buf = ser_decode_buffer_into_scratchpad(scratchpad, &len);
+	net_buf_add_mem(data, buf, len);
+}
+
+static void bt_hci_cmd_send_sync_rsp(const struct nrf_rpc_group *group,
+				     struct nrf_rpc_cbor_ctx *ctx, void *handler_data)
+{
+	struct bt_hci_cmd_send_sync_res *res;
+	struct ser_scratchpad scratchpad;
+
+	res = (struct bt_hci_cmd_send_sync_res *)handler_data;
+
+	res->result = ser_decode_int(ctx);
+
+	if (ser_decode_is_null(ctx)) {
+		*res->rsp = NULL;
+	} else {
+		SER_SCRATCHPAD_DECLARE(&scratchpad, ctx);
+		*res->rsp = net_buf_alloc(&hci_cmd_pool, K_FOREVER);
+		decode_net_buf(&scratchpad, *res->rsp);
+	}
+}
+
+int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf, struct net_buf **rsp)
+{
+	struct nrf_rpc_cbor_ctx ctx;
+	struct bt_hci_cmd_send_sync_res result;
+	size_t buffer_size_max = 5;
+	size_t scratchpad_size;
+
+	buffer_size_max += buf == NULL ? 1 : 13 + buf->len;
+	buffer_size_max += rsp == NULL ? 1 : 0;
+
+	NRF_RPC_CBOR_ALLOC(&bt_rpc_grp, ctx, buffer_size_max);
+	ser_encode_uint(&ctx, opcode);
+
+	if (buf == NULL) {
+		ser_encode_null(&ctx);
+	} else {
+		scratchpad_size = SCRATCHPAD_ALIGN(buf->len);
+		ser_encode_uint(&ctx, scratchpad_size);
+		ser_encode_uint(&ctx, buf->len);
+		ser_encode_buffer(&ctx, buf->data, buf->len);
+	}
+
+	if (rsp == NULL) {
+		/* The caller is not interested in the response. */
+		ser_encode_null(&ctx);
+	}
+
+	result.buf = buf;
+	result.rsp = rsp;
+
+	nrf_rpc_cbor_cmd_no_err(&bt_rpc_grp, BT_HCI_CMD_SEND_SYNC_RPC_CMD,
+				&ctx, bt_hci_cmd_send_sync_rsp, &result);
+
+	return result.result;
 }

--- a/subsys/bluetooth/rpc/common/bt_rpc_common.h
+++ b/subsys/bluetooth/rpc/common/bt_rpc_common.h
@@ -142,6 +142,7 @@ enum bt_rpc_cmd_from_cli_to_host {
 	BT_CCM_ENCRYPT_RPC_CMD,
 	/* internal.h API */
 	BT_ADDR_LE_IS_BONDED_CMD,
+	BT_HCI_CMD_SEND_SYNC_RPC_CMD,
 };
 
 /** @brief Host commands IDs used in bluetooth API serialization.

--- a/subsys/bluetooth/rpc/host/bt_rpc_internal_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_internal_host.c
@@ -52,3 +52,92 @@ decoding_error:
 
 NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_addr_le_is_bonded, BT_ADDR_LE_IS_BONDED_CMD,
 			 bt_addr_le_is_bonded_rpc_handler, NULL);
+
+static void decode_net_buf(struct ser_scratchpad *scratchpad, struct net_buf *data)
+{
+	size_t len;
+	void *buf;
+
+	buf = ser_decode_buffer_into_scratchpad(scratchpad, &len);
+	net_buf_add_mem(data, buf, len);
+}
+
+static void bt_hci_cmd_send_sync_rsp(const struct nrf_rpc_group *group, int result,
+				     const struct net_buf *rsp)
+{
+	size_t buffer_size_max = 20;
+	size_t scratchpad_size = 0;
+	struct nrf_rpc_cbor_ctx ctx;
+
+	buffer_size_max += (rsp == NULL) ? 1 : (3 + rsp->len);
+	NRF_RPC_CBOR_ALLOC(group, ctx, buffer_size_max);
+
+	ser_encode_int(&ctx, result);
+
+	if (rsp == NULL) {
+		ser_encode_null(&ctx);
+	} else {
+		scratchpad_size = SCRATCHPAD_ALIGN(rsp->len);
+		ser_encode_uint(&ctx, scratchpad_size);
+		ser_encode_buffer(&ctx, rsp->data, rsp->len);
+	}
+
+	nrf_rpc_cbor_rsp_no_err(group, &ctx);
+}
+
+static void bt_hci_cmd_send_sync_rpc_handler(const struct nrf_rpc_group *group,
+					     struct nrf_rpc_cbor_ctx *ctx, void *hanler_data)
+{
+	int ret = 0;
+	uint16_t opcode;
+	size_t len;
+	struct net_buf *buf = NULL;
+	struct net_buf *rsp = NULL;
+	struct ser_scratchpad scratchpad;
+	bool response;
+
+	opcode = ser_decode_uint(ctx);
+
+	if (ser_decode_is_null(ctx)) {
+		ser_decode_skip(ctx);
+		buf = NULL;
+	} else {
+		SER_SCRATCHPAD_DECLARE(&scratchpad, ctx);
+		len = ser_decode_uint(ctx);
+		buf = bt_hci_cmd_create(opcode, len);
+		if (!buf) {
+			ret = -ENOBUFS;
+		} else {
+			decode_net_buf(&scratchpad, buf);
+		}
+	}
+
+	if (ser_decode_is_null(ctx)) {
+		/* The caller is not interested in the response. */
+		response = false;
+	} else {
+		response = true;
+	}
+
+	if (!ser_decoding_done_and_check(group, ctx)) {
+		goto decoding_error;
+	}
+
+	if (!ret) {
+		ret = bt_hci_cmd_send_sync(opcode, buf, response ? &rsp : NULL);
+	}
+
+	bt_hci_cmd_send_sync_rsp(group, ret, rsp);
+
+	if (response && (ret == 0)) {
+		net_buf_unref(rsp);
+	}
+
+	return;
+
+decoding_error:
+	report_decoding_error(BT_HCI_CMD_SEND_SYNC_RPC_CMD, hanler_data);
+}
+
+NRF_RPC_CBOR_CMD_DECODER(bt_rpc_grp, bt_hci_cmd_send_sync, BT_HCI_CMD_SEND_SYNC_RPC_CMD,
+			 bt_hci_cmd_send_sync_rpc_handler, NULL);


### PR DESCRIPTION
Tester application from test repository uses bt_hci_cmd_send_sync
function. In order to run this app with BLE over RPC, the
bt_hci_cmd_send_sync function needs to be serialised.