### PR TITLE
applications: nrf5340_audio: Add button check to enter DFU

### DIFF
--- a/applications/nrf5340_audio/README.rst
+++ b/applications/nrf5340_audio/README.rst
@@ -646,26 +646,28 @@ Buttons
 
 The application uses the following buttons on the supported development kit:
 
-+---------------+----------------------------------------------------------------+
-| Button        | Function                                                       |
-+===============+================================================================+
-| **VOL-**      | Turns the playback volume down (and unmutes).                  |
-+---------------+----------------------------------------------------------------+
-| **VOL+**      | Turns the playback volume up (and unmutes).                    |
-+---------------+----------------------------------------------------------------+
-| **PLAY/PAUSE**| Starts or pauses the playback.                                 |
-+---------------+----------------------------------------------------------------+
-| **BTN 4**     | During playback, sends a test tone generated on the device.    |
-|               | Pressing the button multiple times changes the tone frequency. |
-|               | The available values are 1000 Hz, 2000 Hz, and 4000 Hz.        |
-|               | Use this tone to check the synchronization of headsets.        |
-|               | Sending of test tone is currently only supported on the        |
-|               | gateway.                                                       |
-+---------------+----------------------------------------------------------------+
-| **BTN 5**     | Mutes the playback volume.                                     |
-+---------------+----------------------------------------------------------------+
-| **RESET**     | Resets the device.                                             |
-+---------------+----------------------------------------------------------------+
++---------------+----------------------------------------------------------------------------------------+
+| Button        | Function                                                                               |
++===============+========================================================================================+
+| **VOL-**      | Turns the playback volume down (and unmutes).                                          |
++---------------+----------------------------------------------------------------------------------------+
+| **VOL+**      | Turns the playback volume up (and unmutes).                                            |
++---------------+----------------------------------------------------------------------------------------+
+| **PLAY/PAUSE**| Starts or pauses the playback.                                                         |
++---------------+----------------------------------------------------------------------------------------+
+| **BTN 4**     | Depending on the moment it is pressed:                                                 |
+|               |                                                                                        |
+|               | * Long-pressed during startup: Turns on the DFU mode, if                               |
+|               |   the device is :ref:`configured <nrf53_audio_app_configuration_configure_fota>`.      |
+|               | * Pressed on the gateway during playback: Sends a test tone generated on the device.   |
+|               |   Use this tone to check the synchronization of headsets.                              |
+|               | * Pressed on the gateway during playback multiple times: Changes the tone frequency.   |
+|               |   The available values are 1000 Hz, 2000 Hz, and 4000 Hz.                              |
++---------------+----------------------------------------------------------------------------------------+
+| **BTN 5**     | Mutes the playback volume.                                                             |
++---------------+----------------------------------------------------------------------------------------+
+| **RESET**     | Resets the device.                                                                     |
++---------------+----------------------------------------------------------------------------------------+
 
 .. _nrf53_audio_app_ui_leds:
 
@@ -852,6 +854,13 @@ Enabling FOTA upgrades
 The FOTA upgrades are only available when :ref:`nrf53_audio_app_building_script`.
 With the appropriate parameter provided, the :file:`buildprog.py` Python script will add overlay files for the given DFU type.
 For the full list of parameters and examples, see the :ref:`nrf53_audio_app_building_script_running` section.
+
+Entering the DFU mode
+---------------------
+
+The |NCS| uses :ref:`SMP server and mcumgr <zephyr:device_mgmt>` as the DFU backend.
+Unlike the CIS and BIS modes for gateway and headsets, the DFU mode is advertising using the SMP server service.
+For this reason, to enter the DFU mode, you must long press **BTN 4** during each device startup to have the nRF5340 Audio DK enter the DFU mode.
 
 .. _nrf53_audio_app_building:
 
@@ -1064,8 +1073,8 @@ Complete the following steps to build the application:
 
    #. (Optional) Choose the DFU flash memory layouts:
 
-      * For Internal flash memory DFU: ``-DCONFIG_AUDIO_DFU=1``
-      * For External flash memory DFU: ``-DCONFIG_AUDIO_DFU=2``
+      * For internal flash memory DFU: ``-DCONFIG_AUDIO_DFU=1``
+      * For external flash memory DFU: ``-DCONFIG_AUDIO_DFU=2``
       * For minimal sizes of the net core bootloader: ``-DCONFIG_B0N_MINIMAL=y``
 
 #. Build the application using the standard :ref:`build steps <gs_programming>`.

--- a/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
+++ b/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
@@ -111,6 +111,18 @@ config MCUBOOT_IMAGE_VERSION
 	string
 	default "0.0.0+0"
 
+config LOG_DFU_ENTRY_LEVEL
+	int "Log level for DFU entry module"
+	default 3
+
+config BT_DEVICE_NAME_DYNAMIC
+	bool
+	default y
+
+config BT_DEVICE_NAME_GATT_WRITABLE
+	bool
+	default n
+
 endif # AUDIO_DFU = 1 and AUDIO_DFU = 2 (INTERNAL/EXTERNAL)
 
 if AUDIO_DFU = 1

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -590,10 +590,11 @@ static void security_changed_cb(struct bt_conn *conn, bt_security_t level, enum 
 	}
 }
 
-BT_CONN_CB_DEFINE(conn_callbacks) = {
+static struct bt_conn_cb conn_callbacks = {
 	.connected = connected_cb,
 	.disconnected = disconnected_cb,
 	.security_changed = security_changed_cb,
+
 };
 
 static int iso_stream_send(uint8_t const *const data, size_t size, uint8_t iso_chan_idx)
@@ -665,6 +666,7 @@ static int initialize(le_audio_receive_cb recv_cb)
 
 	ARG_UNUSED(recv_cb);
 	if (!initialized) {
+		bt_conn_cb_register(&conn_callbacks);
 		for (size_t i = 0; i < ARRAY_SIZE(audio_streams); i++) {
 			audio_streams[i].ops = &stream_ops;
 			group_params[i].stream = &audio_streams[i];

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -332,7 +332,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	advertising_start();
 }
 
-BT_CONN_CB_DEFINE(conn_callbacks) = {
+static struct bt_conn_cb conn_callbacks = {
 	.connected = connected_cb,
 	.disconnected = disconnected_cb,
 };
@@ -347,6 +347,7 @@ static int initialize(le_audio_receive_cb recv_cb)
 	enum audio_channel channel;
 
 	if (!initialized) {
+		bt_conn_cb_register(&conn_callbacks);
 #if (CONFIG_BT_VCS)
 		ret = ble_vcs_server_init();
 		if (ret) {

--- a/applications/nrf5340_audio/src/main.c
+++ b/applications/nrf5340_audio/src/main.c
@@ -26,17 +26,9 @@
 #include "audio_system.h"
 #include "channel_assignment.h"
 #include "streamctrl.h"
-#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
-#include <os_mgmt/os_mgmt.h>
-#endif
-#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
-#include <img_mgmt/img_mgmt.h>
-#endif
-#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
-#include <stat_mgmt/stat_mgmt.h>
-#endif
-#ifdef CONFIG_MCUMGR_SMP_BT
-#include <zephyr/mgmt/mcumgr/smp_bt.h>
+
+#if defined(CONFIG_AUDIO_DFU_ENABLE)
+#include "dfu_entry.h"
 #endif
 
 #include <zephyr/logging/log.h>
@@ -174,26 +166,6 @@ void on_ble_core_ready(void)
 	}
 }
 
-/* MCUMGR related functions */
-static void mcumgr_register(void)
-{
-#if (CONFIG_AUDIO_DFU > 0)
-	/* Enable MCUMGR */
-	#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
-		os_mgmt_register_group();
-	#endif
-	#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
-		img_mgmt_register_group();
-	#endif
-	#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
-		stat_mgmt_register_group();
-	#endif
-	#ifdef CONFIG_MCUMGR_SMP_BT
-		smp_bt_register();
-	#endif
-#endif
-}
-
 void main(void)
 {
 	int ret;
@@ -239,6 +211,11 @@ void main(void)
 	ret = power_module_init();
 	ERR_CHK(ret);
 
+#if defined(CONFIG_AUDIO_DFU_ENABLE)
+	/* Check DFU BTN before Initialize BLE */
+	dfu_entry_check();
+#endif
+
 	/* Initialize BLE, with callback for when BLE is ready */
 	ret = ble_core_init(on_ble_core_ready);
 	ERR_CHK(ret);
@@ -255,8 +232,6 @@ void main(void)
 
 	ret = streamctrl_start();
 	ERR_CHK(ret);
-
-	mcumgr_register();
 
 	while (1) {
 		streamctrl_event_handler();

--- a/applications/nrf5340_audio/src/modules/CMakeLists.txt
+++ b/applications/nrf5340_audio/src/modules/CMakeLists.txt
@@ -14,3 +14,9 @@ target_sources(app PRIVATE
 	       ${CMAKE_CURRENT_SOURCE_DIR}/power_module.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/sd_card.c
 )
+
+if (CONFIG_AUDIO_DFU_ENABLE)
+	target_sources(app PRIVATE
+			    ${CMAKE_CURRENT_SOURCE_DIR}/dfu_entry.c
+	)
+endif()

--- a/applications/nrf5340_audio/src/modules/dfu_entry.c
+++ b/applications/nrf5340_audio/src/modules/dfu_entry.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <zephyr/kernel.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/conn.h>
+#include "button_assignments.h"
+#include "ble_core.h"
+#include "button_handler.h"
+#include "macros_common.h"
+
+#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+#include <os_mgmt/os_mgmt.h>
+#endif
+#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
+#include <img_mgmt/img_mgmt.h>
+#endif
+#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
+#include <stat_mgmt/stat_mgmt.h>
+#endif
+#ifdef CONFIG_MCUMGR_SMP_BT
+#include <zephyr/mgmt/mcumgr/smp_bt.h>
+#endif
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(dfu, CONFIG_LOG_DFU_ENTRY_LEVEL);
+
+/* These defined name only used by DFU */
+#define DEVICE_NAME_DFU CONFIG_BT_DFU_DEVICE_NAME
+#define DEVICE_NAME_DFU_LEN (sizeof(DEVICE_NAME_DFU) - 1)
+
+/* Advertising data for SMP_SVR UUID */
+static struct bt_le_adv_param adv_param;
+static const struct bt_data ad_peer[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
+		      0x84, 0xaa, 0x60, 0x74, 0x52, 0x8a, 0x8b, 0x86,
+		      0xd3, 0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
+};
+
+/* MCUMGR related functions */
+static void mcumgr_register(void)
+{
+	/* Enable MCUMGR */
+	#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+		os_mgmt_register_group();
+	#endif
+	#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
+		img_mgmt_register_group();
+	#endif
+	#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
+		stat_mgmt_register_group();
+	#endif
+	#ifdef CONFIG_MCUMGR_SMP_BT
+		smp_bt_register();
+	#endif
+}
+
+static void smp_adv(void)
+{
+	int ret;
+
+	ret = bt_le_adv_start(&adv_param, ad_peer, ARRAY_SIZE(ad_peer), NULL, 0);
+	if (ret) {
+		LOG_ERR("SMP_SVR Advertising failed to start (ret %d)", ret);
+		return;
+	}
+
+	LOG_INF("Regular SMP_SVR advertising started");
+}
+
+/* These callbacks are to override callback registed in module le_audio_ */
+static void dfu_connected_cb(struct bt_conn *conn, uint8_t err)
+{
+	LOG_INF("SMP connected\n");
+}
+
+static void dfu_disconnected_cb(struct bt_conn *conn, uint8_t reason)
+{
+	LOG_INF("SMP disconnected %d\n", reason);
+}
+
+static struct bt_conn_cb dfu_conn_callbacks = {
+	.connected = dfu_connected_cb,
+	.disconnected = dfu_disconnected_cb,
+};
+
+static void on_ble_core_ready_dfu_entry(void)
+{
+	char name[CONFIG_BT_DEVICE_NAME_MAX];
+
+	bt_conn_cb_register(&dfu_conn_callbacks);
+	adv_param = *BT_LE_ADV_CONN_NAME;
+	strncpy(name, CONFIG_BT_DEVICE_NAME, CONFIG_BT_DEVICE_NAME_MAX);
+	strncat(name, "_DFU", 4);
+	bt_set_name(name);
+	mcumgr_register();
+	smp_adv();
+}
+
+void dfu_entry_check(void)
+{
+	int ret;
+	bool pressed;
+
+	ret = button_pressed(BUTTON_TEST_TONE, &pressed);
+	if (ret) {
+		return;
+	}
+
+	if (pressed) {
+		LOG_INF("Enter SMP_SVR service only status");
+		ret = ble_core_init(on_ble_core_ready_dfu_entry);
+		ERR_CHK(ret);
+
+		while (1) {
+			k_sleep(K_MSEC(100));
+		}
+	}
+}

--- a/applications/nrf5340_audio/src/modules/dfu_entry.h
+++ b/applications/nrf5340_audio/src/modules/dfu_entry.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _DFU_ENTRY_H_
+#define _DFU_ENTRY_H_
+
+/**
+ * @brief Check Btn pressed status to advertise SMP_SVR service only
+ */
+
+void dfu_entry_check(void);
+
+#endif /* _DFU_ENTRY_H_ */

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -162,21 +162,25 @@ nRF9160: Serial LTE modem
 
 nRF5340 Audio
 -------------
-  * Added:
 
-    * Implemented Basic Audio Profile
-      * Add support for stereo BIS (Broadcast Isochronous Stream)
-    * Remove support for SBC
-    * Update network controller
-    * Bonding between gateway and headset(s) in CIS (Connected Isochronous Stream)
-    * Add DFU support for internal and external flash layouts
+* Added:
 
-  * Updated:
+  * Support for Basic Audio Profile, including support for the stereo BIS (Broadcast Isochronous Stream).
+  * Bonding between gateway and headsets in the CIS (Connected Isochronous Stream).
+  * DFU support for internal and external flash layouts.
+    See :ref:`nrf53_audio_app_configuration_configure_fota` in the application documentation for details.
 
-    * Documentation in the :ref:`nrf53_audio_app_building_script` section.
-      The text now mentions how to recover the device if programming using script fails.
-    * Documentation of the operating temperature maximum range in the
-      :ref:`nrf53_audio_app_dk_features` and :ref:`nrf53_audio_app_dk_legal` sections.
+* Updated:
+
+  * Network controller.
+  * Documentation in the :ref:`nrf53_audio_app_building_script` section.
+    The text now mentions how to recover the device if programming using script fails.
+  * Documentation of the operating temperature maximum range in the
+    :ref:`nrf53_audio_app_dk_features` and :ref:`nrf53_audio_app_dk_legal` sections.
+
+* Removed:
+
+  * Support for SBC.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------


### PR DESCRIPTION
There are two situations that ADK is unable to be discovered its SMP service .

1. Paired Headset.
2. Gateway.

To solve that, add a feature to long press button MUTE during boot-up to enter SMP_SVR service only(DFU mode).

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>