### PR TITLE
manifest: update nrfxlib revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1d528872a2e53a7b42022bf3f106ff658900778b
+      revision: 8069b13c1f430cbee98ba8963ae41c6a7b5a3e68
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update to nrf_security to enable Mbed-TLS debug logging.

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>