### PR TITLE
lib: nrf_modem: deprecate init ret function

### DIFF
--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -127,6 +127,18 @@ static struct module_data self = {
 	.supports_shutdown = true,
 };
 
+#if defined(CONFIG_NRF_MODEM_LIB)
+NRF_MODEM_LIB_ON_INIT(asset_tracker_init_hook, on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+#endif /* CONFIG_NRF_MODEM_LIB */
+
 /* Convenience functions used in internal state handling. */
 static char *state2str(enum state_type new_state)
 {
@@ -217,7 +229,7 @@ static void lwm2m_update_modem_fota_counter(void)
 static void handle_nrf_modem_lib_init_ret(void)
 {
 #if defined(CONFIG_NRF_MODEM_LIB)
-	int ret = nrf_modem_lib_get_init_ret();
+	int ret = modem_lib_init_result;
 
 	/* Handle return values relating to modem firmware update */
 	switch (ret) {

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -53,6 +53,16 @@ static void indicate_wk(struct k_work *work);
 
 BUILD_ASSERT(CONFIG_SLM_WAKEUP_PIN >= 0, "Wake up pin not configured");
 
+NRF_MODEM_LIB_ON_INIT(serial_lte_modem_init_hook, on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+
 #if defined(CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC)
 static void on_modem_failure_shutdown(struct k_work *item);
 static void on_modem_failure_reinit(struct k_work *item);
@@ -246,7 +256,7 @@ void enter_sleep(void)
 
 static void handle_nrf_modem_lib_init_ret(void)
 {
-	int ret = nrf_modem_lib_get_init_ret();
+	int ret = modem_lib_init_result;
 
 	/* Handle return values relating to modem firmware update */
 	switch (ret) {

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -687,6 +687,8 @@ Modem libraries
         * ``nrf_modem_lib_heap_diagnose``
         * ``nrf_modem_lib_shm_tx_diagnose``
 
+    * Deprecated the ``nrf_modem_lib_get_init_ret`` function.
+
   * :ref:`lib_location` library:
 
     * Changed timeout parameters' type from uint16_t to int32_t, unit from seconds to milliseconds, and value to disable them from 0 to SYS_FOREVER_MS.

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -131,7 +131,7 @@ __deprecated void nrf_modem_lib_shutdown_wait(void);
  *
  * @return int The last return value of nrf_modem_lib_init.
  */
-int nrf_modem_lib_get_init_ret(void);
+__deprecated int nrf_modem_lib_get_init_ret(void);
 
 /**
  * @brief Shutdown the Modem library, releasing its resources.

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -62,6 +62,16 @@ AT_MONITOR(lwm2m_carrier_at_handler, ANY, lwm2m_os_at_handler);
 /* LwM2M carrier OS logs. */
 LOG_MODULE_REGISTER(lwm2m_os, LOG_LEVEL_DBG);
 
+NRF_MODEM_LIB_ON_INIT(lwm2m_os_init_hook, on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+
 int lwm2m_os_init(void)
 {
 #if defined CONFIG_LOG_RUNTIME_FILTERING
@@ -357,7 +367,7 @@ int lwm2m_os_thread_start(int index, lwm2m_os_thread_entry_t entry, const char *
 int lwm2m_os_nrf_modem_init(void)
 {
 #if defined CONFIG_NRF_MODEM_LIB_SYS_INIT
-	int nrf_err = nrf_modem_lib_get_init_ret();
+	int nrf_err = modem_lib_init_result;
 #else
 	int nrf_err = nrf_modem_lib_init(NORMAL_MODE);
 #endif /* CONFIG_NRF_MODEM_LIB_SYS_INIT */

--- a/samples/nrf9160/aws_iot/src/main.c
+++ b/samples/nrf9160/aws_iot/src/main.c
@@ -34,6 +34,18 @@ static bool cloud_connected;
 static K_SEM_DEFINE(lte_connected, 0, 1);
 static K_SEM_DEFINE(date_time_obtained, 0, 1);
 
+#if defined(CONFIG_NRF_MODEM_LIB)
+NRF_MODEM_LIB_ON_INIT(aws_iot_init_hook, on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+#endif
+
 static int json_add_obj(cJSON *parent, const char *str, cJSON *item)
 {
 	cJSON_AddItemToObject(parent, str, item);
@@ -407,7 +419,7 @@ static void nrf_modem_lib_dfu_handler(void)
 {
 	int err;
 
-	err = nrf_modem_lib_get_init_ret();
+	err = modem_lib_init_result;
 
 	switch (err) {
 	case MODEM_DFU_RESULT_OK:

--- a/samples/nrf9160/azure_fota/src/main.c
+++ b/samples/nrf9160/azure_fota/src/main.c
@@ -23,6 +23,16 @@ static struct k_work_delayable reboot_work;
 BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
 			 "This sample does not support auto init and connect");
 
+NRF_MODEM_LIB_ON_INIT(azure_fota_init_hook, on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+
 static void azure_event_handler(struct azure_iot_hub_evt *const evt)
 {
 	switch (evt->type) {
@@ -189,8 +199,7 @@ void main(void)
 	printk("Azure FOTA sample started\n");
 	printk("This may take a while if a modem firmware update is pending\n");
 
-	err = nrf_modem_lib_get_init_ret();
-	switch (err) {
+	switch (modem_lib_init_result) {
 	case MODEM_DFU_RESULT_OK:
 		printk("Modem firmware update successful!\n");
 		printk("Modem will run the new firmware after reboot\n");

--- a/samples/nrf9160/http_update/modem_delta_update/src/main.c
+++ b/samples/nrf9160/http_update/modem_delta_update/src/main.c
@@ -14,6 +14,17 @@
 
 #define FOTA_TEST "FOTA-TEST"
 
+NRF_MODEM_LIB_ON_INIT(modem_delta_update_init_hook,
+		      on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+
 static char version[256];
 
 static bool is_test_firmware(void)
@@ -90,7 +101,7 @@ void main(void)
 	/* If nrf_modem_lib is initialized on post-kernel we should
 	 * fetch the returned error code instead of nrf_modem_lib_init
 	 */
-	err = nrf_modem_lib_get_init_ret();
+	err = modem_lib_init_result;
 #endif
 	switch (err) {
 	case MODEM_DFU_RESULT_OK:

--- a/samples/nrf9160/modem_shell/src/main.c
+++ b/samples/nrf9160/modem_shell/src/main.c
@@ -147,6 +147,16 @@ void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault_info)
 	__ASSERT(false, "Modem crash detected, halting application execution");
 }
 
+NRF_MODEM_LIB_ON_INIT(modem_shell_init_hook, on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+
 static void mosh_print_version_info(void)
 {
 #if defined(APP_VERSION)
@@ -217,7 +227,7 @@ void main(void)
 
 #if !defined(CONFIG_LWM2M_CARRIER)
 	/* Get Modem library initialization return value. */
-	err = nrf_modem_lib_get_init_ret();
+	err = modem_lib_init_result;
 	switch (err) {
 	case 0:
 		/* Modem library was initialized successfully. */

--- a/samples/nrf9160/nrf_cloud_rest_device_message/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_device_message/src/main.c
@@ -48,6 +48,17 @@ static struct nrf_cloud_rest_context rest_ctx = {
 /* Flag to indicate if the user requested JITP to be performed */
 static bool jitp_requested;
 
+NRF_MODEM_LIB_ON_INIT(nrf_cloud_rest_device_message_init_hook,
+		      on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+
 static int set_led(const int led, const int state)
 {
 	int err = dk_set_led(led, state);
@@ -278,7 +289,6 @@ static void offer_jitp(void)
 static int init(void)
 {
 	int err;
-	int modem_lib_init_result;
 
 	/* Init the LEDs */
 	err = init_leds();
@@ -288,9 +298,7 @@ static int init(void)
 	}
 
 	/* Init modem */
-	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_SYS_INIT)) {
-		modem_lib_init_result = nrf_modem_lib_get_init_ret();
-	} else {
+	if (!IS_ENABLED(CONFIG_NRF_MODEM_LIB_SYS_INIT)) {
 		modem_lib_init_result = nrf_modem_lib_init(NORMAL_MODE);
 	}
 	if (modem_lib_init_result) {

--- a/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
@@ -90,6 +90,17 @@ static char rx_buf[REST_RX_BUF_SZ];
 /* Buffer used for JSON Web Tokens (JWTs) */
 static char jwt[JWT_BUF_SZ];
 
+NRF_MODEM_LIB_ON_INIT(nrf_cloud_rest_fota_init_hook,
+		      on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+
 /* nRF Cloud REST context */
 static struct nrf_cloud_rest_context rest_ctx = {
 	.connect_socket = -1,
@@ -422,7 +433,6 @@ static void process_pending_job(void)
 int init(void)
 {
 	struct modem_param_info mdm_param;
-	int modem_lib_init_result;
 	int err = init_led();
 
 	if (err) {
@@ -457,9 +467,7 @@ int init(void)
 	}
 #endif
 
-	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_SYS_INIT)) {
-		modem_lib_init_result = nrf_modem_lib_get_init_ret();
-	} else {
+	if (!IS_ENABLED(CONFIG_NRF_MODEM_LIB_SYS_INIT)) {
 		modem_lib_init_result = nrf_modem_lib_init(NORMAL_MODE);
 	}
 

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -59,6 +59,17 @@ static struct k_work download_work;
 
 void client_acknowledge(void);
 
+NRF_MODEM_LIB_ON_INIT(lwm2m_firmware_init_hook,
+		      on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+
 #if defined(CONFIG_DFU_TARGET_FULL_MODEM)
 static void apply_fmfu_from_ext_flash(struct k_work *work)
 {
@@ -520,10 +531,10 @@ int lwm2m_init_firmware(void)
 
 void lwm2m_verify_modem_fw_update(void)
 {
-	int ret = nrf_modem_lib_get_init_ret();
 	struct update_counter counter;
 
 	/* Handle return values relating to modem firmware update */
+	int ret = modem_lib_init_result;
 	switch (ret) {
 	case MODEM_DFU_RESULT_OK:
 		LOG_INF("MODEM UPDATE OK. Will run new firmware");

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -21,6 +21,19 @@
 #include <zephyr/logging/log.h>
 #include <net/nrf_cloud.h>
 
+#if defined(CONFIG_NRF_MODEM_LIB)
+NRF_MODEM_LIB_ON_INIT(nrf_cloud_fota_common_init_hook,
+		      on_modem_lib_init, NULL);
+
+/* Initialized to value different than success (0) */
+static int modem_lib_init_result = -1;
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
+	modem_lib_init_result = ret;
+}
+#endif
+
 LOG_MODULE_REGISTER(nrf_cloud_fota_common, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
 #if defined(CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE)
@@ -162,8 +175,6 @@ static enum nrf_cloud_fota_validate_status app_fota_validate_get(void)
 static enum nrf_cloud_fota_validate_status modem_delta_fota_validate_get(void)
 {
 #if defined(CONFIG_NRF_MODEM_LIB)
-	int modem_lib_init_result = nrf_modem_lib_get_init_ret();
-
 	switch (modem_lib_init_result) {
 	case MODEM_DFU_RESULT_OK:
 		LOG_INF("Modem FOTA update confirmed");


### PR DESCRIPTION
This commit deprecates the `nrf_modem_lib_get_init_ret` function
in favor of init hooks.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>