### PR TITLE
boards: Fixed LEDs active state for nRF7002dk

### DIFF
--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -38,13 +38,13 @@
 
 	pwm0_default: pwm0_default {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+			psels = <NRF_PSEL(PWM_OUT0, 1, 6)>;
 		};
 	};
 
 	pwm0_sleep: pwm0_sleep {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+			psels = <NRF_PSEL(PWM_OUT0, 1, 6)>;
 			low-power-enable;
 		};
 	};

--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -19,11 +19,11 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 0";
 		};
 		led1: led_1 {
-			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 1";
 		};
 	};
@@ -31,7 +31,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet.dts
@@ -27,11 +27,11 @@
 	leds {
 			compatible = "gpio-leds";
 			led0: led_0 {
-					gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+					gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
 					label = "Green LED 0";
 			};
 			led1: led_1 {
-					gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+					gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
 					label = "Green LED 1";
 			};
 	};


### PR DESCRIPTION
According to nRF7002dk schematic the LEDs should be lit up with the high state, but the board .dts file uses ACTIVE_LOW,
so in result leds on board are working in the opposite way than expected. Also the pin assignment to the PWM0 channel uses wrong pin number.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>