### PR TITLE
doc: fix links to NFC specifications

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -787,8 +787,8 @@
 .. _`nRF Mesh mobile app for iOS`: https://apps.apple.com/us/app/nrf-mesh/id1380726771
 .. _`nRF Mesh mobile app for Android`: https://play.google.com/store/apps/details?id=no.nordicsemi.android.nrfmeshprovisioner
 
-.. _`NFC Forum specification overview`: https://nfc-forum.org/our-work/specification-releases/specifications/
-.. _`Bluetooth Secure Simple Pairing Using NFC`: https://nfc-forum.org/our-work/specification-releases/specifications/#010ea0b1006cf5b44
+.. _`NFC Forum specification overview`: https://nfc-forum.org/build/specifications
+.. _`Bluetooth Secure Simple Pairing Using NFC`: https://nfc-forum.org/build/specifications#application-documents
 
 .. _`ISO/IEC 7816-4`: https://www.iso.org/standard/54550.html
 


### PR DESCRIPTION
NFC forum has changed to a payment model and thus,
the URLs to the specifications are changed. Pointing
the links now to the proper address.

Ref: NCSDK-16413

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>