### PR TITLE
doc: add a section about modem traces in the nRF91 user guide

### DIFF
--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -78,6 +78,8 @@ The behavior of the functions in the OS abstraction layer is dependent on the |N
 This is relevant for functions such as :c:func:`nrf_modem_os_shm_tx_alloc`, which uses :ref:`Zephyr's Heap implementation <zephyr:heap_v2>` to dynamically allocate memory.
 In this case, the characteristics of the allocations made by these functions depend on the heap implementation by Zephyr.
 
+.. _modem_trace_module:
+
 Modem trace module
 ******************
 The modem trace module is implemented in :file:`nrf/lib/nrf_modem_lib/nrf_modem_lib_trace.c`.
@@ -86,6 +88,17 @@ The module implements a thread that initializes, deinitializes, and forwards mod
 
 * :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_UART` to send modem traces over UARTE1
 * :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_RTT` to send modem traces over SEGGER RTT
+
+To reduce the amount of trace data sent from the modem, a different trace level can be selected.
+Complete the following steps to configure the modem trace level at compile time:
+
+#. Set :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_LEVEL_OVERRIDE` to ``y`` in your project configuration.
+#. Enable any one of the following Kconfig options by setting it to ``y`` in your project configuration:
+
+   * :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_LEVEL_FULL`
+   * :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_LEVEL_LTE_AND_IP`
+   * :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_LEVEL_IP_ONLY`
+   * :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_LEVEL_COREDUMP_ONLY`
 
 The application can use the :c:func:`nrf_modem_lib_trace_level_set` function to set the desired trace level.
 Passing ``NRF_MODEM_LIB_TRACE_LEVEL_OFF`` to the :c:func:`nrf_modem_lib_trace_level_set` function disables trace output.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -347,6 +347,7 @@
 .. _`AT+CNEC set command`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mobile_termination_errors/cnec_set.html
 .. _`AT+CGEREP set command`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/packet_domain/cgerep_set.html
 .. _`AT%CONEVAL`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/coneval.html
+.. _`Modem trace AT command documentation`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xmodemtrace.html
 
 .. _`Getting started with nRF Connect SDK (nRF53 Series)`: https://infocenter.nordicsemi.com/topic/ug_gsg_ncs/UG/gsg/intro.html
 .. _`Debugging nRF5340 with SES`: https://infocenter.nordicsemi.com/topic/ug_gsg_ncs/UG/gsg/debug.html?cp=1_1_0_7

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -853,6 +853,7 @@ Documentation
   * A section about :ref:`modem_trace_backend_uart_custom_board` in the :ref:`nrf_modem_lib_readme` page.
   * A note in the :ref:`ug_ble_controller` about the usage of the Zephyr LE Controller.
   * Documentation for the :ref:`ug_nrf70`.
+  * A section about :ref:`modem_trace` in the :ref:`ug_nrf91_features` page.
 
 * Updated:
 

--- a/doc/nrf/ug_nrf91_features.rst
+++ b/doc/nrf/ug_nrf91_features.rst
@@ -160,6 +160,26 @@ The :ref:`nrfxlib:nrf_modem` is released as an OS-independent binary library in 
 The Modem library integration layer fulfills the integration requirements of the Modem library in |NCS|.
 For more information on the integration, see :ref:`nrf_modem_lib_readme`.
 
+.. _modem_trace:
+
+Modem trace
+-----------
+
+The modem traces of the nRF9160 modem can be captured using the nRF Connect Trace Collector.
+For more information on how to collect traces using nRF Connect Trace Collector, see the `Trace Collector`_ documentation.
+When the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE` Kconfig option is enabled, the modem traces are enabled in the modem and are forwarded to the :ref:`modem_trace_module`.
+
+.. note::
+   For the :ref:`serial_lte_modem` application and the :ref:`at_client_sample` sample, you must also run ``AT%xmodemtrace=1,2`` to manually activate the predefined trace set.
+
+You can set the trace level using the AT command ``%XMODEMTRACE``.
+See `modem trace AT command documentation`_ for more information.
+
+If the existing trace backends are not sufficient, it is possible to implement custom trace backends.
+You can implement your own custom modem traces to store the traces on an external flash.
+You can then upload the traces to the cloud for remote analysis when needed.
+For more information on the implementation of a custom trace backend, see :ref:`adding_custom_modem_trace_backends`.
+
 .. _nrf9160_fota:
 
 FOTA upgrades


### PR DESCRIPTION
NCSDK-16315
Added a section for modem traces in the nRF91 user guide.
Also, added details about the following Kconfig options
to the Modem library integration layer library:
NRF_MODEM_LIB_TRACE_LEVEL_OVERRIDE
NRF_MODEM_LIB_TRACE_LEVEL_FULL
NRF_MODEM_LIB_TRACE_LEVEL_LTE_AND_IP
NRF_MODEM_LIB_TRACE_LEVEL_IP_ONLY
NRF_MODEM_LIB_TRACE_LEVEL_COREDUMP_ONLY

Signed-off-by: divya <divya.pillai@nordicsemi.no>