### PR TITLE
applications: asset_tracker_v2: Disable LwM2M bootstrap option

### DIFF
--- a/applications/asset_tracker_v2/doc/cloud_module.rst
+++ b/applications/asset_tracker_v2/doc/cloud_module.rst
@@ -178,9 +178,9 @@ To enable communication with Azure IoT Hub, set the following options in the :fi
 Configurations for LwM2M integration layer
 ------------------------------------------
 
-When building for LwM2M, the cloud module is configured to communicate with AVSystem's `Coiote Device Management`_ by default, using a bootstrap server with a runtime provisioned `Pre-shared key (PSK)`_.
-This enables the application to work out of the box with `Coiote Device Management`_, if the device has been correctly added to the service.
-To allow the application to communicate with other services, modify the default configuration by changing the following Kconfig options:
+When building for LwM2M, the cloud module's default configuration is to communicate with AVSystem's `Coiote Device Management`_, with a runtime provisioned `Pre-shared key (PSK)`_ set by the :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PSK` option.
+This enables the device to work with `Coiote Device Management`_ without provisioning the PSK to the modem before running the application.
+To allow the device to communicate with other LwM2M servers, modify the default configuration by changing the following Kconfig options:
 
 * :kconfig:option:`CONFIG_LWM2M_CLIENT_UTILS_SERVER`
 * :kconfig:option:`CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP`
@@ -188,7 +188,14 @@ To allow the application to communicate with other services, modify the default 
 * :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PSK`
 * :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PROVISION_CREDENTIALS`
 
-See :ref:`server setup <server_setup_lwm2m>` for information on how the `Coiote Device Management server`_ can be configured to communicate with the application.
+See :ref:`server setup <server_setup_lwm2m>` for information on how you can configure the `Coiote Device Management server`_ to communicate with the application using the default PSK.
+
+.. important::
+   In production, it is not recommended to use the default PSK that is automatically provisioned by the application.
+   If possible, bootstrapping should be enabled to periodically change the PSK used in the connection.
+   The PSK should also be provisioned to the modem before running the application.
+   Disable the :kconfig:option:`CONFIG_LWM2M_INTEGRATION_PROVISION_CREDENTIALS` option and provision the PSK to a sec tag set by :kconfig:option:`CONFIG_LWM2M_CLIENT_UTILS_SERVER_TLS_TAG` or :kconfig:option:`CONFIG_LWM2M_CLIENT_UTILS_BOOTSTRAP_TLS_TAG`.
+
 
 In addition to the steps documented in the aforementioned section, you must also enable manipulation of the application's real-time configurations through the `Coiote Device Management`_ console.
 This is documented in :ref:`object_xml_config`.

--- a/applications/asset_tracker_v2/overlay-lwm2m.conf
+++ b/applications/asset_tracker_v2/overlay-lwm2m.conf
@@ -45,10 +45,12 @@ CONFIG_LWM2M_QUEUE_MODE_UPTIME=30
 CONFIG_LTE_PSM_REQ_RAT="00100001"
 
 # Use LwM2M client bootstrap server.
-CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP=y
+# CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP=y
 
-# Provision PSK to the modem at run-time. The default PSK used is set by
-# the CONFIG_LWM2M_INTEGRATION_PSK option.
+# Provision the default PSK to the modem at run-time. The default PSK is set by
+# the CONFIG_LWM2M_INTEGRATION_PSK option. If CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP is set,
+# the PSK is provisioned to a sec tag that is used in the connection towards
+# the configured bootstrap server.
 CONFIG_MODEM_KEY_MGMT=y
 CONFIG_LWM2M_INTEGRATION_PROVISION_CREDENTIALS=y
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -133,6 +133,7 @@ nRF9160: Asset Tracker v2
     * GNSS fixes are now published in PVT format instead of NMEA for nRF Cloud builds. To revert to NMEA, set the :ref:`CONFIG_GNSS_MODULE_NMEA <CONFIG_GNSS_MODULE_NMEA>` option.
     * The sensor module now forwards :c:enum:`SENSOR_EVT_MOVEMENT_ACTIVITY_DETECTED` and :c:enum:`SENSOR_EVT_MOVEMENT_INACTIVITY_DETECTED` events.
     * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
+    * Bootstrapping has been disabled by default to be able to connect to the default LwM2M service AVSystem's `Coiote Device Management`_ using free tier accounts.
 
   * Fixed:
 


### PR DESCRIPTION
Bootstrapping is a paid service and not included in free tier accounts
in AVSystem Coiote Device management.

To enfore the out of box experience with AVSystem and not depend on
customers paying for the bootstrap service, bootstrapping
is disabled by default in the application.

CIA-719