### PR TITLE
samples: matter: Added support for WiFi in lock sample

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -93,8 +93,8 @@
 
 .. _`SMP over Bluetooth`: https://github.com/apache/mynewt-mcumgr/blob/master/transport/smp-bluetooth.md
 
-.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/632800fe/src/android/CHIPTool
-.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/632800fe/src/controller
+.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/238a18db/src/android/CHIPTool
+.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/238a18db/src/controller
 .. _`ZCL Advanced Platform`: https://github.com/project-chip/zap
 .. _`Matter nRF Connect releases`: https://github.com/nrfconnect/sdk-connectedhomeip/releases
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -83,6 +83,7 @@ The following list summarizes the most important changes inherited from the upst
 
   * Support for Matter device factory data.
     This includes a set of scripts for building the factory data partition content, and the ``FactoryDataProvider`` class for accessing this data.
+  * Experimental support for Matter over Wi-Fi.
 
 Thread
 ------
@@ -367,6 +368,7 @@ Matter samples
 * :ref:`matter_lock_sample`:
 
   * Set :kconfig:option:`CONFIG_CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT` to be enabled by default.
+  * Introduced support for Matter over Wi-Fi on ``nrf7002dk_nrf5340_cpuapp`` and on ``nrf5340dk_nrf5340_cpuapp`` with the ``nrf7002_ek`` shield.
 
 * :ref:`matter_window_covering_sample`:
 

--- a/doc/nrf/samples/samples_matter.rst
+++ b/doc/nrf/samples/samples_matter.rst
@@ -30,12 +30,24 @@ The following table lists variants and extensions available out of the box for e
       - ✔
       - ✔
       - ✔
+    * - Thread support
+      - ✔
+      - ✔
+      - ✔
+      - ✔
+      - ✔
     * - :ref:`Thread role <thread_ot_device_types>`
       - Router
       - SED
       - SED
       - MED
       - SSED
+    * - Wi-Fi support
+      -
+      -
+      - ✔
+      -
+      -
 
 See the sample documentation pages for instructions about how to enable these variants and extenstions.
 

--- a/samples/matter/common/src/board_util.h
+++ b/samples/matter/common/src/board_util.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#pragma once
+
+#include <zephyr/devicetree.h>
+
+#define LEDS_NODE_ID DT_PATH(leds)
+#define BUTTONS_NODE_ID DT_PATH(buttons)
+#define INCREMENT_BY_ONE(button_or_led) +1
+#define NUMBER_OF_LEDS (0 DT_FOREACH_CHILD(LEDS_NODE_ID, INCREMENT_BY_ONE))
+#define NUMBER_OF_BUTTONS (0 DT_FOREACH_CHILD(BUTTONS_NODE_ID, INCREMENT_BY_ONE))

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -46,9 +46,14 @@ You can enable both methods after :ref:`building and running the sample <matter_
 Remote testing in a network
 ===========================
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_remote_testing_start
-    :end-before: matter_door_lock_sample_remote_testing_end
+.. matter_light_bulb_sample_remote_testing_start
+
+By default, the Matter accessory device has Thread disabled.
+You must pair it with the Matter controller over Bluetooth® LE to get the configuration from the controller to use the device within a Thread network.
+The controller must get the commissioning information from the Matter accessory device and provision the device into the network.
+For details, see the `Commissioning the device`_ section.
+
+.. matter_light_bulb_sample_remote_testing_end
 
 Configuration
 *************
@@ -58,16 +63,73 @@ Configuration
 Matter light bulb build types
 =============================
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_configuration_file_types_start
-    :end-before: matter_door_lock_sample_configuration_file_types_end
+.. matter_light_bulb_sample_configuration_file_types_start
+
+The sample uses different configuration files depending on the supported features.
+Configuration files are provided for different build types and they are located in the application root directory.
+
+The :file:`prj.conf` file represents a ``debug`` build type.
+Other build types are covered by dedicated files with the build type added as a suffix to the ``prj`` part, as per the following list.
+For example, the ``release`` build type file name is :file:`prj_release.conf`.
+If a board has other configuration files, for example associated with partition layout or child image configuration, these follow the same pattern.
+
+.. include:: /gs_modifying.rst
+   :start-after: build_types_overview_start
+   :end-before: build_types_overview_end
+
+Before you start testing the application, you can select one of the build types supported by the sample.
+This sample supports the following build types, depending on the selected board:
+
+* ``debug`` -- Debug version of the application - can be used to enable additional features for verifying the application behavior, such as logs or command-line shell.
+* ``release`` -- Release version of the application - can be used to enable only the necessary application functionalities to optimize its performance.
+* ``no_dfu`` -- Debug version of the application without Device Firmware Upgrade feature support - can be used for the nRF52840 DK, nRF5340 DK, and nRF21540 DK.
+
+.. note::
+    `Selecting a build type`_ is optional.
+    The ``debug`` build type is used by default if no build type is explicitly selected.
+
+.. matter_light_bulb_sample_configuration_file_types_end
 
 Device Firmware Upgrade support
 ===============================
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_build_with_dfu_start
-    :end-before: matter_door_lock_sample_build_with_dfu_end
+.. matter_light_bulb_sample_build_with_dfu_start
+
+.. note::
+   You can enable over-the-air Device Firmware Upgrade only on hardware platforms that have external flash memory.
+   Currently only nRF52840 DK and nRF5340 DK support Device Firmware Upgrade feature.
+
+The sample supports over-the-air (OTA) device firmware upgrade (DFU) using one of the two following protocols:
+
+* Matter OTA update protocol that uses the Matter operational network for querying and downloading a new firmware image.
+* Simple Management Protocol (SMP) over Bluetooth® LE.
+  In this case, the DFU can be done either using a smartphone application or a PC command line tool.
+  Note that this protocol is not part of the Matter specification.
+
+In both cases, :ref:`MCUboot <mcuboot:mcuboot_wrapper>` secure bootloader is used to apply the new firmware image.
+
+The DFU over Matter is enabled by default.
+The following configuration arguments are available during the build process for configuring DFU:
+
+* To configure the sample to support the DFU over Matter and SMP, use the ``-DCONFIG_CHIP_DFU_OVER_BT_SMP=y`` build flag.
+* To configure the sample to disable the DFU and the secure bootloader, use the ``-DCONF_FILE=prj_no_dfu.conf`` build flag.
+
+See :ref:`cmake_options` for instructions on how to add these options to your build.
+
+When building on the command line, run the following command with *build_target* replaced with the build target name of the hardware platform you are using (see `Requirements`_), and *dfu_build_flag* replaced with the desired DFU build flag:
+
+.. parsed-literal::
+   :class: highlight
+
+   west build -b *build_target* -- *dfu_build_flag*
+
+For example:
+
+.. code-block:: console
+
+   west build -b nrf52840dk_nrf52840 -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
+
+.. matter_light_bulb_sample_build_with_dfu_end
 
 FEM support
 ===========
@@ -223,9 +285,19 @@ Remote control allows you to control the Matter light bulb device from a Thread 
 Commissioning the device
 ------------------------
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_commissioning_start
-    :end-before: matter_door_lock_sample_commissioning_end
+.. matter_light_bulb_sample_commissioning_start
+
+To commission the device, go to the :ref:`ug_matter_configuring_env` guide and complete the steps for the Matter controller you want to use.
+The guide walks you through the following steps:
+
+* Configure the Thread Border Router.
+* Build and install the Matter controller.
+* Commission the device.
+* Send Matter commands that cover scenarios described in the `Testing`_ section.
+
+If you are new to Matter, the recommended approach is to use :ref:`ug_matter_configuring_controller_chip_tool`.
+
+.. matter_light_bulb_sample_commissioning_end
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
 The device becomes discoverable automatically upon the device startup, but only for a predefined period of time (15 minutes by default).

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -92,9 +92,9 @@ Configuration
 Matter light switch build types
 ===============================
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_configuration_file_types_start
-    :end-before: matter_door_lock_sample_configuration_file_types_end
+.. include:: ../light_bulb/README.rst
+    :start-after: matter_light_bulb_sample_configuration_file_types_start
+    :end-before: matter_light_bulb_sample_configuration_file_types_end
 
 FEM support
 ===========
@@ -126,9 +126,9 @@ For example:
 Device Firmware Upgrade support
 ===============================
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_build_with_dfu_start
-    :end-before: matter_door_lock_sample_build_with_dfu_end
+.. include:: ../light_bulb/README.rst
+    :start-after: matter_light_bulb_sample_build_with_dfu_start
+    :end-before: matter_light_bulb_sample_build_with_dfu_end
 
 .. _matter_light_switch_sample_ui:
 
@@ -422,9 +422,9 @@ Complete the following steps:
 Commissioning the device
 ========================
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_commissioning_start
-    :end-before: matter_door_lock_sample_commissioning_end
+.. include:: ../light_bulb/README.rst
+    :start-after: matter_light_bulb_sample_commissioning_start
+    :end-before: matter_light_bulb_sample_commissioning_end
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
 By default, the device is not discoverable automatically upon startup and **Button 4** must be used to enable the Bluetooth LE advertising.

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -41,7 +41,7 @@ target_sources(app PRIVATE
     src/zap-generated/IMClusterCommandHandler.cpp
     src/zap-generated/callback-stub.cpp
     ${COMMON_ROOT}/src/led_widget.cpp
-    ${COMMON_ROOT}/src/thread_util.cpp
+    $<$<BOOL:${CONFIG_NET_L2_OPENTHREAD}>:${COMMON_ROOT}/src/thread_util.cpp>
 )
 
 if(CONFIG_CHIP_OTA_REQUESTOR)

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -26,6 +26,23 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
+# Sample configuration used for Thread networking
+if NET_L2_OPENTHREAD
+
+choice OPENTHREAD_NORDIC_LIBRARY_CONFIGURATION
+	default OPENTHREAD_NORDIC_LIBRARY_MTD
+endchoice
+
+choice OPENTHREAD_DEVICE_TYPE
+	default OPENTHREAD_MTD
+endchoice
+
+config CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT
+	bool
+	default y
+
+endif # NET_L2_OPENTHREAD
+
 if MPSL_FEM
 
 config OPENTHREAD_DEFAULT_TX_POWER

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -9,8 +9,9 @@ Matter: Door lock
    :depth: 2
 
 This door lock sample demonstrates the usage of the :ref:`Matter <ug_matter>` application layer to build a door lock device with one basic bolt.
-This device works as a Matter accessory device, meaning it can be paired and controlled remotely over a Matter network built on top of a low-power 802.15.4 Thread network.
-Additionally, this device works as a Thread :ref:`Router <thread_ot_device_types>`.
+This device works as a Matter accessory device, meaning it can be paired and controlled remotely over a Matter network built on top of a low-power 802.15.4 Thread or Wi-Fi network.
+Support for both Thread and Wi-Fi is mutually exclusive and depends on the hardware platform, so only one protocol can be supported for a specific lock device.
+In case of Thread, this device works as a Thread :ref:`Sleepy End Device <thread_ot_device_types>`.
 You can use this sample as a reference for creating your application.
 
 Requirements
@@ -20,11 +21,19 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-If you want to commission the lock device and :ref:`control it remotely <matter_lock_sample_network_mode>` through a Thread network, you also need a Matter controller device :ref:`configured on PC or mobile <ug_matter_configuring>`.
+If you want to commission the lock device and :ref:`control it remotely <matter_lock_sample_network_mode>` through an IPv6 network, you also need a Matter controller device :ref:`configured on PC or mobile <ug_matter_configuring>`.
 This requires additional hardware depending on the setup you choose.
 
 .. note::
     |matter_gn_required_note|
+
+IPv6 network support
+====================
+
+The development kits for this sample offer the following IPv6 network support for Matter:
+
+* Matter over Thread is supported for ``nrf52840dk_nrf52840``, ``nrf5340dk_nrf5340_cpuapp``, and ``nrf21540dk_nrf52840``.
+* Matter over Wi-Fi is supported for ``nrf5340dk_nrf5340_cpuapp`` with the ``nrf7002_ek`` shield attached or for ``nrf7002dk_nrf5340_cpuapp``.
 
 Overview
 ********
@@ -33,9 +42,8 @@ The sample uses buttons for changing the lock and device states, and LEDs to sho
 You can test it in the following ways:
 
 * Standalone, using a single DK that runs the door lock application.
-* Remotely over the Thread protocol, which requires more devices.
+* Remotely over the Thread or the Wi-Fi protocol, which in either case requires more devices, including a Matter controller that you can configure either on a PC or a mobile device.
 
-The remote control testing requires a Matter controller that you can configure either on a PC or a mobile device (for remote testing in a network).
 You can enable both methods after :ref:`building and running the sample <matter_lock_sample_remote_control>`.
 
 .. _matter_lock_sample_network_mode:
@@ -45,8 +53,8 @@ Remote testing in a network
 
 .. matter_door_lock_sample_remote_testing_start
 
-By default, the Matter accessory device has Thread disabled.
-You must pair it with the Matter controller over Bluetooth® LE to get the configuration from the controller to use the device within a Thread network.
+By default, the Matter accessory device has IPv6 networking disabled.
+You must pair it with the Matter controller over Bluetooth® LE to get the configuration from the controller to use the device within a Thread or Wi-Fi network.
 You have to make the device discoverable manually (for security reasons).
 The controller must get the commissioning information from the Matter accessory device and provision the device into the network.
 For details, see the `Commissioning the device`_ section.
@@ -80,7 +88,7 @@ This sample supports the following build types, depending on the selected board:
 
 * ``debug`` -- Debug version of the application - can be used to enable additional features for verifying the application behavior, such as logs or command-line shell.
 * ``release`` -- Release version of the application - can be used to enable only the necessary application functionalities to optimize its performance.
-* ``no_dfu`` -- Debug version of the application without Device Firmware Upgrade feature support - can be used for the nRF52840 DK, nRF5340 DK and nRF21540 DK.
+* ``no_dfu`` -- Debug version of the application without Device Firmware Upgrade feature support - can be used for the nRF52840 DK, nRF5340 DK, nRF7002 DK, and nRF21540 DK.
 
 .. note::
     `Selecting a build type`_ is optional.
@@ -104,11 +112,13 @@ The sample supports over-the-air (OTA) device firmware upgrade (DFU) using one o
   In this case, the DFU can be done either using a smartphone application or a PC command line tool.
   Note that this protocol is not part of the Matter specification.
 
-In both cases, MCUboot secure bootloader is used to apply the new firmware image.
+In both cases, :ref:`MCUboot <mcuboot:mcuboot_wrapper>` secure bootloader is used to apply the new firmware image.
 
 The DFU over Matter is enabled by default.
-To configure the sample to support the DFU over Matter and SMP, use the ``-DCONFIG_CHIP_DFU_OVER_BT_SMP=y`` build flag during the build process.
-To configure the sample to disable the DFU and the secure bootloader, use the ``-DCONF_FILE=prj_no_dfu.conf`` build flag during the build process.
+The following configuration arguments are available during the build process for configuring DFU:
+
+* To configure the sample to support the DFU over Matter and SMP, use the ``-DCONFIG_CHIP_DFU_OVER_BT_SMP=y`` build flag.
+* To configure the sample to disable the DFU and the secure bootloader, use the ``-DCONF_FILE=prj_no_dfu.conf`` build flag.
 
 See :ref:`cmake_options` for instructions on how to add these options to your build.
 
@@ -118,6 +128,12 @@ When building on the command line, run the following command with *build_target*
    :class: highlight
 
    west build -b *build_target* -- *dfu_build_flag*
+
+For example:
+
+.. code-block:: console
+
+   west build -b nrf52840dk_nrf52840 -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
 
 .. matter_door_lock_sample_build_with_dfu_end
 
@@ -155,7 +171,7 @@ Button 1:
     Depending on how long you press the button:
 
     * If pressed for less than three seconds, it initiates the SMP server (Security Manager Protocol).
-      After that the Direct Firmware Update (DFU) over Bluetooth Low Energy can be started.
+      After that, the Direct Firmware Update (DFU) over Bluetooth Low Energy can be started.
       (See `Upgrading the device firmware`_.)
     * If pressed for more than three seconds, it initiates the factory reset of the device.
       Releasing the button within the 3-second window cancels the factory reset procedure.
@@ -163,13 +179,19 @@ Button 1:
 .. matter_door_lock_sample_button1_end
 
 Button 2:
-    Changes the lock state to the opposite one.
+    * On nRF52840 DK, nRF5340 DK, and nRF21540 DK: Changes the lock state to the opposite one.
+    * On nRF7002 DK:
+
+      * If pressed for less than three seconds, it changes the lock state to the opposite one.
+      * If pressed for more than three seconds, it starts the NFC tag emulation, enables Bluetooth LE advertising for the predefined period of time (15 minutes by default), and makes the device discoverable over Bluetooth LE.
 
 .. matter_door_lock_sample_button4_start
 
 Button 4:
-    Starts the NFC tag emulation, enables Bluetooth LE advertising for the predefined period of time (15 minutes by default), and makes the device discoverable over Bluetooth LE.
-    This button is used during the :ref:`commissioning procedure <matter_lock_sample_remote_control_commissioning>`.
+    * On nRF52840 DK, nRF5340 DK, and nRF21540 DK: Starts the NFC tag emulation, enables Bluetooth LE advertising for the predefined period of time (15 minutes by default), and makes the device discoverable over Bluetooth LE.
+      This button is used during the :ref:`commissioning procedure <matter_lock_sample_remote_control_commissioning>`.
+
+    * On nRF7002 DK: Not available.
 
 .. matter_door_lock_sample_button4_end
 
@@ -264,11 +286,11 @@ The device reboots after all its settings are erased.
 Enabling remote control
 =======================
 
-Remote control allows you to control the Matter door lock device from a Thread network.
+Remote control allows you to control the Matter door lock device from a Thread or a Wi-Fi network.
 
 .. matter_door_lock_sample_remote_control_start
 
-`Commissioning the device`_ allows you to set up a testing environment and remotely control the sample over a Matter-enabled Thread network.
+`Commissioning the device`_ allows you to set up a testing environment and remotely control the sample over a Matter-enabled Thread or Wi-Fi network.
 
 .. matter_door_lock_sample_remote_control_end
 
@@ -282,7 +304,7 @@ Commissioning the device
 To commission the device, go to the :ref:`ug_matter_configuring_env` guide and complete the steps for the Matter controller you want to use.
 The guide walks you through the following steps:
 
-* Configure the Thread Border Router.
+* Only if you are configuring Matter over Thread: Configure the Thread Border Router.
 * Build and install the Matter controller.
 * Commission the device.
 * Send Matter commands that cover scenarios described in the `Testing`_ section.

--- a/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -20,9 +20,6 @@
 &adc {
 	status = "disabled";
 };
-&gpio1 {
-	status = "disabled";
-};
 &i2c1 {
 	status = "disabled";
 };

--- a/samples/matter/lock/prj.conf
+++ b/samples/matter/lock/prj.conf
@@ -18,17 +18,8 @@ CONFIG_STD_CPP14=y
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 
-# OpenThread configs
-CONFIG_OPENTHREAD_NORDIC_LIBRARY_MTD=y
-CONFIG_OPENTHREAD_MTD=y
-CONFIG_OPENTHREAD_FTD=n
-CONFIG_CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT=y
-
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLock"
-
-# Stack size settings
-CONFIG_IEEE802154_NRF5_RX_STACK_SIZE=1024
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/lock/prj_no_dfu.conf
+++ b/samples/matter/lock/prj_no_dfu.conf
@@ -18,17 +18,8 @@ CONFIG_STD_CPP14=y
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 
-# OpenThread configs
-CONFIG_OPENTHREAD_NORDIC_LIBRARY_MTD=y
-CONFIG_OPENTHREAD_MTD=y
-CONFIG_OPENTHREAD_FTD=n
-CONFIG_CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT=y
-
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLock"
-
-# Stack size settings
-CONFIG_IEEE802154_NRF5_RX_STACK_SIZE=1024
 
 # Other settings
 CONFIG_THREAD_NAME=y

--- a/samples/matter/lock/prj_release.conf
+++ b/samples/matter/lock/prj_release.conf
@@ -18,20 +18,11 @@ CONFIG_STD_CPP14=y
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
 
-# OpenThread configs
-CONFIG_OPENTHREAD_NORDIC_LIBRARY_MTD=y
-CONFIG_OPENTHREAD_MTD=y
-CONFIG_OPENTHREAD_FTD=n
-CONFIG_CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT=y
-
 # Bluetooth Low Energy configuration
 CONFIG_BT_DEVICE_NAME="MatterLock"
 
 # Enable system reset on fatal error
 CONFIG_RESET_ON_FATAL_ERROR=y
-
-# Stack size settings
-CONFIG_IEEE802154_NRF5_RX_STACK_SIZE=1024
 
 # Suspend devices when the CPU goes into sleep
 CONFIG_PM_DEVICE=y

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -16,7 +16,8 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf21540dk_nrf52840 nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.matter.lock.release:
     build_only: true
@@ -33,4 +34,11 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    tags: ci_build
+  sample.matter.lock.no_dfu.nrf7002_ek:
+    build_only: true
+    extra_args: SHIELD=nrf7002_ek CONF_FILE=prj_no_dfu.conf
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/matter/lock/src/app_event.h
+++ b/samples/matter/lock/src/app_event.h
@@ -27,7 +27,7 @@ struct AppEvent {
 
 	AppEvent() = default;
 	AppEvent(LockEventType type, BoltLockManager::OperationSource source) : Type(type), LockEvent{ source } {}
-	explicit AppEvent(FunctionEventType type) : Type(type) {}
+	AppEvent(FunctionEventType type, uint8_t buttonNumber) : Type(type), FunctionEvent{ buttonNumber } {}
 	AppEvent(UpdateLedStateEventType type, LEDWidget *ledWidget) : Type(type), UpdateLedStateEvent{ ledWidget } {}
 	explicit AppEvent(OtherEventType type) : Type(type) {}
 
@@ -40,5 +40,8 @@ struct AppEvent {
 		struct {
 			LEDWidget *LedWidget;
 		} UpdateLedStateEvent;
+		struct {
+			uint8_t ButtonNumber;
+		} FunctionEvent;
 	};
 };

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -8,10 +8,14 @@
 
 #include "bolt_lock_manager.h"
 #include "led_widget.h"
+
+#ifdef CONFIG_NET_L2_OPENTHREAD
 #include "thread_util.h"
+#endif
 
 #include <platform/CHIPDeviceLayer.h>
 
+#include "board_util.h"
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
@@ -24,6 +28,11 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <system/SystemError.h>
+
+#ifdef CONFIG_CHIP_WIFI
+#include <app/clusters/network-commissioning/network-commissioning.h>
+#include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
+#endif
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR
 #include "ota_util.h"
@@ -47,22 +56,32 @@ namespace
 constexpr size_t kAppEventQueueSize = 10;
 constexpr uint32_t kFactoryResetTriggerTimeout = 3000;
 constexpr uint32_t kFactoryResetCancelWindow = 3000;
+#if NUMBER_OF_BUTTONS == 2
+constexpr uint32_t kAdvertisingTriggerTimeout = 3000;
+#endif
 constexpr EndpointId kLockEndpointId = 1;
 
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), kAppEventQueueSize, alignof(AppEvent));
 LEDWidget sStatusLED;
 LEDWidget sLockLED;
+#if NUMBER_OF_LEDS == 4
 LEDWidget sUnusedLED;
 LEDWidget sUnusedLED_1;
+#endif
 
-bool sIsThreadProvisioned;
-bool sIsThreadEnabled;
+bool sIsNetworkProvisioned;
+bool sIsNetworkEnabled;
 bool sHaveBLEConnections;
 
 k_timer sFunctionTimer;
 } /* namespace */
 
 AppTask AppTask::sAppTask;
+
+#ifdef CONFIG_CHIP_WIFI
+app::Clusters::NetworkCommissioning::Instance
+	sWiFiCommissioningInstance(0, &(NetworkCommissioning::NrfWiFiDriver::Instance()));
+#endif
 
 CHIP_ERROR AppTask::Init()
 {
@@ -81,6 +100,7 @@ CHIP_ERROR AppTask::Init()
 		return err;
 	}
 
+#if defined(CONFIG_NET_L2_OPENTHREAD)
 	err = ThreadStackMgr().InitThreadStack();
 	if (err != CHIP_NO_ERROR) {
 		LOG_ERR("ThreadStackMgr().InitThreadStack() failed");
@@ -91,7 +111,7 @@ CHIP_ERROR AppTask::Init()
 	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
 #else
 	err = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
-#endif
+#endif /* CONFIG_OPENTHREAD_MTD_SED */
 	if (err != CHIP_NO_ERROR) {
 		LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
 		return err;
@@ -103,7 +123,12 @@ CHIP_ERROR AppTask::Init()
 		LOG_ERR("Cannot set default Thread output power");
 		return err;
 	}
-#endif
+#endif /* CONFIG_OPENTHREAD_DEFAULT_TX_POWER */
+#elif defined(CONFIG_CHIP_WIFI)
+	sWiFiCommissioningInstance.Init();
+#else
+	return CHIP_ERROR_INTERNAL;
+#endif /* CONFIG_NET_L2_OPENTHREAD */
 
 	/* Initialize LEDs */
 	LEDWidget::InitGpio();
@@ -112,8 +137,10 @@ CHIP_ERROR AppTask::Init()
 	sStatusLED.Init(DK_LED1);
 	sLockLED.Init(DK_LED2);
 	sLockLED.Set(BoltLockMgr().IsLocked());
+#if NUMBER_OF_LEDS == 4
 	sUnusedLED.Init(DK_LED3);
 	sUnusedLED_1.Init(DK_LED4);
+#endif
 
 	UpdateStatusLED();
 
@@ -250,10 +277,10 @@ void AppTask::DispatchEvent(const AppEvent &event)
 		BoltLockMgr().CompleteLockAction();
 		break;
 	case AppEvent::FunctionPress:
-		FunctionPressHandler();
+		FunctionPressHandler(event.FunctionEvent.ButtonNumber);
 		break;
 	case AppEvent::FunctionRelease:
-		FunctionReleaseHandler();
+		FunctionReleaseHandler(event.FunctionEvent.ButtonNumber);
 		break;
 	case AppEvent::FunctionTimer:
 		FunctionTimerEventHandler();
@@ -275,37 +302,58 @@ void AppTask::DispatchEvent(const AppEvent &event)
 	}
 }
 
-void AppTask::FunctionPressHandler()
+void AppTask::FunctionPressHandler(uint8_t buttonNumber)
 {
-	sAppTask.StartFunctionTimer(kFactoryResetTriggerTimeout);
-	sAppTask.mFunction = TimerFunction::SoftwareUpdate;
+	if (buttonNumber == DK_BTN1) {
+		sAppTask.StartFunctionTimer(kFactoryResetTriggerTimeout);
+		sAppTask.mFunction = TimerFunction::SoftwareUpdate;
+	}
+#if NUMBER_OF_BUTTONS == 2
+	else if (buttonNumber == DK_BTN2) {
+		sAppTask.StartFunctionTimer(kAdvertisingTriggerTimeout);
+		sAppTask.mFunction = TimerFunction::AdvertisingStart;
+	}
+#endif
 }
 
-void AppTask::FunctionReleaseHandler()
+void AppTask::FunctionReleaseHandler(uint8_t buttonNumber)
 {
-	if (sAppTask.mFunction == TimerFunction::SoftwareUpdate) {
-		sAppTask.CancelFunctionTimer();
-		sAppTask.mFunction = TimerFunction::NoneSelected;
+	if (buttonNumber == DK_BTN1) {
+		if (sAppTask.mFunction == TimerFunction::SoftwareUpdate) {
+			sAppTask.CancelFunctionTimer();
+			sAppTask.mFunction = TimerFunction::NoneSelected;
 
 #ifdef CONFIG_MCUMGR_SMP_BT
-		GetDFUOverSMP().StartServer();
+			GetDFUOverSMP().StartServer();
 #else
-		LOG_INF("Software update is disabled");
+			LOG_INF("Software update is disabled");
 #endif
 
-	} else if (sAppTask.mFunction == TimerFunction::FactoryReset) {
-		sUnusedLED_1.Set(false);
-		sUnusedLED.Set(false);
+		} else if (sAppTask.mFunction == TimerFunction::FactoryReset) {
+#if NUMBER_OF_LEDS == 4
+			sUnusedLED_1.Set(false);
+			sUnusedLED.Set(false);
+#endif
 
-		/* Set lock status LED back to show state of lock. */
-		sLockLED.Set(BoltLockMgr().IsLocked());
+			/* Set lock status LED back to show state of lock. */
+			sLockLED.Set(BoltLockMgr().IsLocked());
 
-		UpdateStatusLED();
+			UpdateStatusLED();
 
-		sAppTask.CancelFunctionTimer();
-		sAppTask.mFunction = TimerFunction::NoneSelected;
-		LOG_INF("Factory Reset has been Canceled");
+			sAppTask.CancelFunctionTimer();
+			sAppTask.mFunction = TimerFunction::NoneSelected;
+			LOG_INF("Factory Reset has been Canceled");
+		}
 	}
+#if NUMBER_OF_BUTTONS == 2
+	else if (buttonNumber == DK_BTN2) {
+		if (sAppTask.mFunction == TimerFunction::AdvertisingStart) {
+			sAppTask.CancelFunctionTimer();
+			sAppTask.mFunction = TimerFunction::NoneSelected;
+			GetAppTask().PostEvent(AppEvent{ AppEvent::Toggle, BoltLockManager::OperationSource::kButton });
+		}
+	}
+#endif
 }
 
 void AppTask::FunctionTimerEventHandler()
@@ -319,19 +367,29 @@ void AppTask::FunctionTimerEventHandler()
 		/* Turn off all LEDs before starting blink to make sure blink is co-ordinated. */
 		sStatusLED.Set(false);
 		sLockLED.Set(false);
+#if NUMBER_OF_LEDS == 4
 		sUnusedLED_1.Set(false);
 		sUnusedLED.Set(false);
+#endif
 
 		sStatusLED.Blink(500);
 		sLockLED.Blink(500);
+#if NUMBER_OF_LEDS == 4
 		sUnusedLED.Blink(500);
 		sUnusedLED_1.Blink(500);
+#endif
 #endif
 	} else if (sAppTask.mFunction == TimerFunction::FactoryReset) {
 		sAppTask.mFunction = TimerFunction::NoneSelected;
 		LOG_INF("Factory Reset triggered");
 		chip::Server::GetInstance().ScheduleFactoryReset();
 	}
+#if NUMBER_OF_BUTTONS == 2
+	else if (sAppTask.mFunction == TimerFunction::AdvertisingStart) {
+		sAppTask.mFunction = TimerFunction::NoneSelected;
+		GetAppTask().PostEvent(AppEvent{ AppEvent::StartBleAdvertising });
+	}
+#endif
 }
 
 void AppTask::StartBLEAdvertisingHandler()
@@ -394,7 +452,7 @@ void AppTask::UpdateStatusLED()
 	 * rate of 100ms.
 	 *
 	 * Otherwise, blink the LED On for a very short time. */
-	if (sIsThreadProvisioned && sIsThreadEnabled) {
+	if (sIsNetworkProvisioned && sIsNetworkEnabled) {
 		sStatusLED.Set(true);
 	} else if (sHaveBLEConnections) {
 		sStatusLED.Blink(100, 100);
@@ -424,8 +482,14 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 		UpdateStatusLED();
 		break;
 	case DeviceEventType::kThreadStateChange:
-		sIsThreadProvisioned = ConnectivityMgr().IsThreadProvisioned();
-		sIsThreadEnabled = ConnectivityMgr().IsThreadEnabled();
+	case DeviceEventType::kWiFiConnectivityChange:
+#if defined(CONFIG_NET_L2_OPENTHREAD)
+		sIsNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned();
+		sIsNetworkEnabled = ConnectivityMgr().IsThreadEnabled();
+#elif defined(CONFIG_CHIP_WIFI)
+		sIsNetworkProvisioned = ConnectivityMgr().IsWiFiStationProvisioned();
+		sIsNetworkEnabled = ConnectivityMgr().IsWiFiStationEnabled();
+#endif
 		UpdateStatusLED();
 		break;
 	case DeviceEventType::kThreadConnectivityChange:
@@ -443,11 +507,19 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 void AppTask::ButtonEventHandler(uint32_t buttonState, uint32_t hasChanged)
 {
 	if (DK_BTN1_MSK & buttonState & hasChanged) {
-		GetAppTask().PostEvent(AppEvent{ AppEvent::FunctionPress });
+		GetAppTask().PostEvent(AppEvent{ AppEvent::FunctionPress, DK_BTN1 });
 	} else if (DK_BTN1_MSK & hasChanged) {
-		GetAppTask().PostEvent(AppEvent{ AppEvent::FunctionRelease });
+		GetAppTask().PostEvent(AppEvent{ AppEvent::FunctionRelease, DK_BTN1 });
 	}
 
+/* nRF7002DK has only two buttons, so it needs to use Button 2 for control and advertising purposes */
+#if NUMBER_OF_BUTTONS == 2
+	if (DK_BTN2_MSK & buttonState & hasChanged) {
+		GetAppTask().PostEvent(AppEvent{ AppEvent::FunctionPress, DK_BTN2 });
+	} else if (DK_BTN2_MSK & hasChanged) {
+		GetAppTask().PostEvent(AppEvent{ AppEvent::FunctionRelease, DK_BTN2 });
+	}
+#else
 	if (DK_BTN2_MSK & buttonState & hasChanged) {
 		GetAppTask().PostEvent(AppEvent{ AppEvent::Toggle, BoltLockManager::OperationSource::kButton });
 	}
@@ -455,6 +527,7 @@ void AppTask::ButtonEventHandler(uint32_t buttonState, uint32_t hasChanged)
 	if (DK_BTN4_MSK & buttonState & hasChanged) {
 		GetAppTask().PostEvent(AppEvent{ AppEvent::StartBleAdvertising });
 	}
+#endif /* NUMBER_OF_BUTTONS */
 }
 
 void AppTask::CancelFunctionTimer()
@@ -469,5 +542,5 @@ void AppTask::StartFunctionTimer(uint32_t timeoutInMs)
 
 void AppTask::TimerEventHandler(k_timer *timer)
 {
-	GetAppTask().PostEvent(AppEvent{ AppEvent::FunctionTimer });
+	GetAppTask().PostEvent(AppEvent{ AppEvent::FunctionTimer, 0 });
 }

--- a/samples/matter/lock/src/app_task.h
+++ b/samples/matter/lock/src/app_task.h
@@ -36,8 +36,8 @@ private:
 	void StartFunctionTimer(uint32_t timeoutInMs);
 
 	void DispatchEvent(const AppEvent &event);
-	void FunctionPressHandler();
-	void FunctionReleaseHandler();
+	void FunctionPressHandler(uint8_t buttonNumber);
+	void FunctionReleaseHandler(uint8_t buttonNumber);
 	void FunctionTimerEventHandler();
 	void StartBLEAdvertisingHandler();
 
@@ -53,7 +53,14 @@ private:
 
 	friend AppTask &GetAppTask();
 
-	enum class TimerFunction { NoneSelected = 0, SoftwareUpdate, FactoryReset };
+	enum class TimerFunction {
+		NoneSelected = 0,
+		SoftwareUpdate,
+		FactoryReset,
+#if CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP
+		AdvertisingStart,
+#endif
+	};
 
 	TimerFunction mFunction = TimerFunction::NoneSelected;
 

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -88,9 +88,9 @@ This sample supports the following build types, depending on the selected board:
 Device Firmware Upgrade support
 ===============================
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_build_with_dfu_start
-    :end-before: matter_door_lock_sample_build_with_dfu_end
+.. include:: ../light_bulb/README.rst
+    :start-after: matter_light_bulb_sample_build_with_dfu_start
+    :end-before: matter_light_bulb_sample_build_with_dfu_end
 
 FEM support
 ===========

--- a/samples/matter/window_covering/README.rst
+++ b/samples/matter/window_covering/README.rst
@@ -65,9 +65,9 @@ You can enable both methods after :ref:`building and running the sample <matter_
 Remote testing in a network
 ---------------------------
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_remote_testing_start
-    :end-before: matter_door_lock_sample_remote_testing_end
+.. include:: ../light_bulb/README.rst
+    :start-after: matter_light_bulb_sample_remote_testing_start
+    :end-before: matter_light_bulb_sample_remote_testing_end
 
 Configuration
 *************
@@ -77,16 +77,16 @@ Configuration
 Matter window covering build types
 ==================================
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_configuration_file_types_start
-    :end-before: matter_door_lock_sample_configuration_file_types_end
+.. include:: ../light_bulb/README.rst
+    :start-after: matter_light_bulb_sample_configuration_file_types_start
+    :end-before: matter_light_bulb_sample_configuration_file_types_end
 
 Device Firmware Upgrade support
 ===============================
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_build_with_dfu_start
-    :end-before: matter_door_lock_sample_build_with_dfu_end
+.. include:: ../light_bulb/README.rst
+    :start-after: matter_light_bulb_sample_build_with_dfu_start
+    :end-before: matter_light_bulb_sample_build_with_dfu_end
 
 FEM support
 ===========
@@ -220,9 +220,9 @@ Remote control allows you to control the Matter window covering device from a Th
 Commissioning the device
 ------------------------
 
-.. include:: ../lock/README.rst
-    :start-after: matter_door_lock_sample_commissioning_start
-    :end-before: matter_door_lock_sample_commissioning_end
+.. include:: ../light_bulb/README.rst
+    :start-after: matter_light_bulb_sample_commissioning_start
+    :end-before: matter_light_bulb_sample_commissioning_end
 
 Before starting the commissioning procedure, the device must be made discoverable over Bluetooth LE.
 Press **Button 4** to enable the Bluetooth LE advertising.

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 632800fe7f2ef765abb47311a34611a186d9f4b2
+      revision: 238a18db4eae15381c3c1838d8e863d841c59ead
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
* Updated sdk-connectedhomeip SHA to pull Wi-Fi support in Matter
* Added code necessary to initialize WiFi driver
* Moved OpenThread config options from prj.confs to Kconfig file
* Added nrf7002dk and nrf7002_ek platforms to twister builds
* Extended documentation to include information about Wi-Fi
* Added handling user interface for nrf7002dk that has two
LEDs and two buttons.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>