### PR TITLE
CODEOWNERS: Update Bluetooth Host assignments

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -79,7 +79,7 @@ Kconfig*                                  @tejlmand
 /include/net/azure_*                      @jtguggedal @simensrostad @coderbyheart
 /include/net/wifi_credentials.h           @maxd-nordic
 /include/net/nrf_cloud_*                  @plskeggs @jayteemo @glarsennordic
-/include/bluetooth/                       @alwa-nordic @KAGA164
+/include/bluetooth/                       @alwa-nordic @jori-nordic @KAGA164
 /include/bluetooth/services/fast_pair.h   @MarekPieta @kapi-no @KAGA164
 /include/bluetooth/adv_prov.h             @MarekPieta @kapi-no @KAGA164
 /include/bluetooth/mesh/                  @ludvigsj
@@ -137,10 +137,10 @@ Kconfig*                                  @tejlmand
 /samples/                                 @nrfconnect/ncs-test-leads
 /samples/net/mqtt/                        @simensrostad
 /samples/sensor/bh1749/                   @gregersrygg
-/samples/bluetooth/                       @alwa-nordic @carlescufi @KAGA164
+/samples/bluetooth/                       @alwa-nordic @jori-nordic @carlescufi @KAGA164
 /samples/bluetooth/mesh/                  @ludvigsj
-/samples/bluetooth/direction_finding_connectionless_rx/ @ppryga-nordic @alwa-nordic
-/samples/bluetooth/direction_finding_connectionless_tx/ @ppryga-nordic @alwa-nordic
+/samples/bluetooth/direction_finding_connectionless_rx/ @ppryga-nordic
+/samples/bluetooth/direction_finding_connectionless_tx/ @ppryga-nordic
 /samples/bluetooth/peripheral_fast_pair/  @MarekPieta @kapi-no @KAGA164
 /samples/bootloader/                      @hakonfam @oyvindronningstad
 /samples/matter/                          @Damian-Nordic @kkasperczyk-no
@@ -196,7 +196,7 @@ Kconfig*                                  @tejlmand
 /share/zephyrbuild-package/               @tejlmand
 /share/ncs-package/                       @tejlmand
 /snippets/nrf91-modem-trace-uart/         @eivindj-nordic
-/subsys/bluetooth/                        @alwa-nordic @carlescufi @KAGA164
+/subsys/bluetooth/                        @alwa-nordic @jori-nordic @carlescufi @KAGA164
 /subsys/bluetooth/mesh/                   @ludvigsj
 /subsys/bluetooth/controller/             @rugeGerritsen
 /subsys/bluetooth/adv_prov/               @MarekPieta @kapi-no @KAGA164


### PR DESCRIPTION
@jori-nordic is on the Bluetooth Host team.
@alwa-nordic is not an expert on subsys/bluetooth/rpc nor direction finding.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>