### PR TITLE
net: lib: download_client: stop retrying on disconnect

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -255,6 +255,10 @@ Libraries for networking
     * Removed ``MODEM_INFO_NETWORK_MODE_MAX_SIZE``.
     * Removed ``CONFIG_MODEM_INFO_ADD_BOARD``.
 
+* :ref:`lib_download_client` library:
+
+  * Updated the library so that it does not retry download on disconnect.
+
 Libraries for NFC
 -----------------
 


### PR DESCRIPTION
Once disconnect is called a blocking socket recv/send the download
client did not stop immediately.

Signed-off-by: Andreas Chmielewski <andreas.chmielewski@grandcentrix.net>