### PR TITLE
Bluetooth: Mesh: Model: Fix last temp storage

### DIFF
--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -143,6 +143,8 @@ struct bt_mesh_light_temp_srv {
 	struct bt_mesh_light_temp dflt;
 	/** Current Temperature range. */
 	struct bt_mesh_light_temp_range range;
+	/** Corrective delta used by the generic level server. */
+	uint16_t corrective_delta;
 	struct __packed {
 		/** The last known color temperature. */
 		struct bt_mesh_light_temp last;

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -221,7 +221,7 @@ static void lvl_delta_set(struct bt_mesh_lvl_srv *lvl_srv,
 		srv->handlers->get(srv, NULL, &status);
 		start_lvl = temp_to_lvl(srv, status.current.temp);
 	} else {
-		start_lvl = temp_to_lvl(srv, srv->transient.last.temp);
+		start_lvl = temp_to_lvl(srv, srv->corrective_delta);
 	}
 
 	/* Clamp to int16_t range before storing the value in a 16 bit integer
@@ -234,12 +234,10 @@ static void lvl_delta_set(struct bt_mesh_lvl_srv *lvl_srv,
 
 	bt_mesh_light_temp_srv_set(srv, ctx, &set, &status);
 
-	/* Override last temp value to be able to make corrective deltas when
-	 * new_transaction is false. Note that the last temp value in
-	 * persistent storage will still be the target value, allowing us to
-	 * recover correctly on power loss.
+	/* Copy start level to be able to make corrective deltas when
+	 * new_transaction is false.
 	 */
-	srv->transient.last.temp = lvl_to_temp(srv, start_lvl);
+	srv->corrective_delta = lvl_to_temp(srv, start_lvl);
 
 	(void)bt_mesh_light_temp_srv_pub(srv, NULL, &status);
 


### PR DESCRIPTION
Fixes bug in temprature server where the last stored temprature value is
incorrectly set to the start value for a level delta set message. To
make it possible to do corrective deltas in this call, the start value
has previously been stored in the last value state, assuming that the
actual last value has already been saved to persistent storage.
When the CONFIG_BT_MESH_MODEL_SRV_STORE_TIMEOUT is set to a
value greater than 0 this assumption is not valid.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>