### PR TITLE
applications: nrf5340_audio: Fix wrong description in README and Kconfig

### DIFF
--- a/applications/nrf5340_audio/README.rst
+++ b/applications/nrf5340_audio/README.rst
@@ -384,7 +384,7 @@ The following table is a complete overview of the solder bridges on the nRF5340 
 +------------+-------------------------------------------------------------------------------------+--------------+--------+
 |SB5         | Cut to enable VBAT current measurements on P6                                       | Shorted      | Top    |
 +------------+-------------------------------------------------------------------------------------+--------------+--------+
-|SB6         | Cut to enable VBAT current measurements on P6                                       | Shorted      | Top    |
+|SB6         | Cut to enable HW CODEC 1.2V current measurements on P7                              | Shorted      | Top    |
 +------------+-------------------------------------------------------------------------------------+--------------+--------+
 |SB7         | Cut to enable HW CODEC 1.8V current measurements on P8                              | Shorted      | Top    |
 +------------+-------------------------------------------------------------------------------------+--------------+--------+

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -154,14 +154,6 @@ config BLE_ADV_TX_POWER_DBM
 	default -20 if BLE_ADV_TX_POWER_NEG_20DBM
 	default -40 if BLE_ADV_TX_POWER_NEG_40DBM
 
-config BLE_DEVICE_NAME_BASE
-	string
-	default "NRF5340_AUDIO"
-	help
-	 Base for the device name that will be visible over the air. The actual
-	 name on air could look like: NRF5340_AUDIO_DEV_H_L or NRF5340_AUDIO_DEV_H_R
-	 depending on which device it is.
-
 config BLE_ISO_TEST_PATTERN
 	bool "Transmit a test pattern to measure link performance"
 	default n

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
@@ -37,9 +37,6 @@ config BT_GATT_CLIENT
 	bool
 	default y
 
-	bool
-	default y
-
 config BT_BONDABLE
 	bool
 	default y


### PR DESCRIPTION
Fix wrong description and out of date Kconfig.

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>