### PR TITLE
applications: asset_tracker_v2: add full modem FOTA support 

### DIFF
--- a/applications/asset_tracker_v2/doc/cloud_module.rst
+++ b/applications/asset_tracker_v2/doc/cloud_module.rst
@@ -96,6 +96,17 @@ The client libraries supported by the cloud wrapper API all implement their own 
 This enables the cloud to issue FOTA updates and update the application and modem firmware while the device is in field.
 For additional documentation on the various FOTA implementations, refer to the respective client library documentation linked to in :ref:`Integration layers <integration_layers>`.
 
+Full modem FOTA updates are only supported by nRF Cloud.
+This application implements full modem FOTA only for the nRF9160 development kit version 1.0.1 and higher.
+To enable full modem FOTA, add the following parameter to your build command:
+
+``-DOVERLAY_CONFIG=overlay-full_modem_fota.conf``
+
+Also, specify your development kit version by appending it to the board name.
+For example, if your development kit version is 1.0.1, use the following board name in your build command:
+
+``nrf9160dk_nrf9160_ns@1_0_1``
+
 Connection awareness
 ====================
 

--- a/applications/asset_tracker_v2/overlay-full_modem_fota.conf
+++ b/applications/asset_tracker_v2/overlay-full_modem_fota.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Full Modem FOTA
+CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE=y
+CONFIG_MAIN_STACK_SIZE=2048
+# Disable AT host library as it's incompatible with the FMFU's requirement
+# to initialize the modem library
+CONFIG_AT_HOST_LIBRARY=n
+CONFIG_NRF_MODEM_LIB_SYS_INIT=n
+CONFIG_SPI=y
+CONFIG_SPI_NOR=y

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -371,6 +371,7 @@ static int config_settings_handler(const char *key, size_t len,
 			LOG_ERR("Failed to load configuration, error: %d", err);
 		} else {
 			LOG_DBG("Device configuration loaded from flash");
+			err = 0;
 		}
 	}
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -140,6 +140,7 @@ nRF9160: Asset Tracker v2
     * The sensor module now forwards :c:enum:`SENSOR_EVT_MOVEMENT_ACTIVITY_DETECTED` and :c:enum:`SENSOR_EVT_MOVEMENT_INACTIVITY_DETECTED` events.
     * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
     * Bootstrapping has been disabled by default to be able to connect to the default LwM2M service AVSystem's `Coiote Device Management`_ using free tier accounts.
+    * Added support for full modem FOTA updates for nRF Cloud builds.
 
   * Fixed:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -602,6 +602,7 @@ Libraries for networking
       * Support for full modem FOTA updates.
       * :c:func:`nrf_cloud_fota_is_type_enabled` function that determines if the specified FOTA type is enabled by the configuration.
       * :c:func:`nrf_cloud_gnss_msg_json_encode` function that encodes GNSS data (PVT or NMEA) into an nRF Cloud device message.
+      * :c:func:`nrf_cloud_fota_pending_job_type_get` function that retreives the FOTA type of a pending FOTA job.
 
     * Updated:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -607,6 +607,7 @@ Libraries for networking
     * Updated:
 
       * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
+      * Function :c:func:`nrf_cloud_fota_is_type_enabled` no longer depends on :kconfig:option:`CONFIG_NRF_CLOUD_FOTA`.
 
   * :ref:`lib_multicell_location` library:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -747,6 +747,9 @@ int nrf_cloud_jwt_generate(uint32_t time_valid_s, char * const jwt_buf, size_t j
  *        information is read from non-volatile storage on startup. This function
  *        is intended to be used by custom REST-based FOTA implementations.
  *        It is called internally if CONFIG_NRF_CLOUD_FOTA is enabled.
+ *        For pending NRF_CLOUD_FOTA_MODEM_DELTA jobs the modem library must
+ *        be initialized before calling this function, otherwise the job will
+ *        be marked as completed without validation.
  *
  * @param[in] job FOTA job state information.
  * @param[out] reboot_required A reboot is needed to complete a FOTA update.
@@ -794,10 +797,26 @@ int nrf_cloud_handle_error_message(const char *const buf,
 				   enum nrf_cloud_error *const err);
 
 /**
+ * @brief Function to retrieve the FOTA type of a pending FOTA job. A value of
+ *        NRF_CLOUD_FOTA_TYPE__INVALID indicates that there are no pending FOTA jobs.
+ *        Depends on CONFIG_NRF_CLOUD_FOTA.
+ *
+ * @param[out] pending_fota_type FOTA type of pending job.
+ *
+ * @retval 0 FOTA type was retrieved.
+ * @retval -EINVAL Error; invalid parameter.
+ * @return A negative value indicates an error.
+ */
+int nrf_cloud_fota_pending_job_type_get(enum nrf_cloud_fota_type * const pending_fota_type);
+
+/**
  * @brief Function to validate a pending FOTA installation before initializing this library.
  *        This function enables the application to control the reboot/reinit process during FOTA
  *        updates. If this function is not called directly by the application, it will
  *        be called internally when @ref nrf_cloud_init is executed.
+ *        For pending NRF_CLOUD_FOTA_MODEM_DELTA jobs the modem library must
+ *        be initialized before calling this function, otherwise the job will
+ *        be marked as completed without validation.
  *        Depends on CONFIG_NRF_CLOUD_FOTA.
  *
  * @param[out] fota_type_out FOTA type of pending job.
@@ -817,7 +836,8 @@ int nrf_cloud_fota_pending_job_validate(enum nrf_cloud_fota_type * const fota_ty
  * @brief Function to set the flash device used for full modem FOTA updates.
  *        This function is intended to be used by custom REST-based FOTA implementations.
  *        It is called internally when @ref nrf_cloud_init is executed if
- *        CONFIG_NRF_CLOUD_FOTA is enabled.
+ *        CONFIG_NRF_CLOUD_FOTA is enabled. It can be called before @ref nrf_cloud_init
+ *        if required by the application.
  *
  * @param[in] fmfu_dev_inf Flash device information.
  *

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -872,10 +872,10 @@ bool nrf_cloud_fota_is_type_modem(const enum nrf_cloud_fota_type type);
 
 /**
  * @brief Function to determine if the specified FOTA type is enabled by the
- *        configuration.
- *        Depends on CONFIG_NRF_CLOUD_FOTA.
- *        REST-based FOTA applications are responsible for determining
- *        their supported FOTA types.
+ *        configuration. This function returns false if both CONFIG_NRF_CLOUD_FOTA
+ *        and CONFIG_NRF_CLOUD_REST are disabled.
+ *        REST-based applications are responsible for implementing FOTA updates
+ *        for all configured types.
  *
  * @param[in] type Fota type.
  *

--- a/subsys/net/lib/nrf_cloud/CMakeLists.txt
+++ b/subsys/net/lib/nrf_cloud/CMakeLists.txt
@@ -6,7 +6,8 @@
 zephyr_library()
 zephyr_library_sources(
 	src/nrf_cloud_codec.c
-	src/nrf_cloud_client_id.c)
+	src/nrf_cloud_client_id.c
+	src/nrf_cloud_fota_common.c)
 zephyr_library_sources_ifdef(
 	CONFIG_MODEM_JWT
 	src/nrf_cloud_jwt.c)
@@ -30,10 +31,8 @@ zephyr_library_sources_ifdef(
 	src/nrf_cloud_cell_pos.c)
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_FOTA
-	src/nrf_cloud_fota.c
-	src/nrf_cloud_fota_common.c)
+	src/nrf_cloud_fota.c)
 zephyr_library_sources_ifdef(
 	CONFIG_NRF_CLOUD_REST
-	src/nrf_cloud_rest.c
-	src/nrf_cloud_fota_common.c)
+	src/nrf_cloud_rest.c)
 zephyr_include_directories(./include)

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_fota
@@ -4,7 +4,7 @@
 #
 
 menuconfig NRF_CLOUD_FOTA
-	bool "Enable FOTA through nRF Cloud"
+	bool "Enable nRF Cloud MQTT FOTA library"
 	select FOTA_DOWNLOAD
 	select FOTA_DOWNLOAD_PROGRESS_EVT
 	select DFU_TARGET

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -93,7 +93,7 @@ int nrf_cloud_init(const struct nrf_cloud_init_param *param)
 		return -EACCES;
 	}
 
-	if (param->event_handler == NULL) {
+	if ((param == NULL) || (param->event_handler == NULL)) {
 		return -EINVAL;
 	}
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -1790,6 +1790,8 @@ int nrf_cloud_gnss_msg_json_encode(const struct nrf_cloud_gnss_data * const gnss
 		} else {
 #if defined(CONFIG_NRF_MODEM)
 			ret = nrf_cloud_modem_pvt_data_encode(gnss->mdm_pvt, data_obj);
+#else
+			ret = -ENOSYS;
 #endif
 		}
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -222,26 +222,6 @@ static int pending_fota_job_validate(void)
 	return (int)reboot;
 }
 
-bool nrf_cloud_fota_is_type_enabled(const enum nrf_cloud_fota_type type)
-{
-	switch (type)
-	{
-	case NRF_CLOUD_FOTA_APPLICATION:
-		return IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT);
-	case NRF_CLOUD_FOTA_BOOTLOADER:
-		return IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT) &&
-		       IS_ENABLED(CONFIG_BUILD_S1_VARIANT) &&
-		       IS_ENABLED(CONFIG_SECURE_BOOT);
-	case NRF_CLOUD_FOTA_MODEM_DELTA:
-		return IS_ENABLED(CONFIG_NRF_MODEM);
-	case NRF_CLOUD_FOTA_MODEM_FULL:
-		return IS_ENABLED(CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE) &&
-		       IS_ENABLED(CONFIG_NRF_MODEM);
-	default:
-		return false;
-	}
-}
-
 int nrf_cloud_fota_pending_job_type_get(enum nrf_cloud_fota_type * const pending_fota_type)
 {
 	if (!pending_fota_type) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota.c
@@ -242,12 +242,27 @@ bool nrf_cloud_fota_is_type_enabled(const enum nrf_cloud_fota_type type)
 	}
 }
 
-int nrf_cloud_fota_pending_job_validate(enum nrf_cloud_fota_type * const fota_type_out)
+int nrf_cloud_fota_pending_job_type_get(enum nrf_cloud_fota_type * const pending_fota_type)
 {
+	if (!pending_fota_type) {
+		return -EINVAL;
+	}
+
 	int err = load_fota_settings();
 
+	*pending_fota_type = (err ? NRF_CLOUD_FOTA_TYPE__INVALID : saved_job.type);
+
+	return err;
+}
+
+int nrf_cloud_fota_pending_job_validate(enum nrf_cloud_fota_type * const fota_type_out)
+{
+	int err = 0;
+
 	if (fota_type_out) {
-		*fota_type_out = (err ? NRF_CLOUD_FOTA_TYPE__INVALID : saved_job.type);
+		err = nrf_cloud_fota_pending_job_type_get(fota_type_out);
+	} else {
+		err = load_fota_settings();
 	}
 
 	if (err) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -63,6 +63,7 @@ int nrf_cloud_fota_fmfu_dev_set(const struct dfu_target_fmfu_fdev *const fmfu_de
 int nrf_cloud_fota_fmfu_apply(void)
 {
 	if (!fmfu_dev_set) {
+		LOG_ERR("Flash device for full modem FOTA is not set");
 		return -EACCES;
 	}
 
@@ -184,6 +185,9 @@ static enum nrf_cloud_fota_validate_status modem_full_fota_validate_get(void)
 
 #if defined(CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE)
 	err = nrf_cloud_fota_fmfu_apply();
+	if (err) {
+		LOG_ERR("Full modem FOTA was not applied, error: %d", err);
+	}
 #endif
 
 	return (err ? NRF_CLOUD_FOTA_VALIDATE_FAIL :

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -6,8 +6,12 @@
 
 #include <zephyr.h>
 #include <stdbool.h>
+#if defined(CONFIG_NRF_MODEM)
 #include <nrf_modem.h>
+#endif
+#if defined(CONFIG_NRF_MODEM_LIB)
 #include <modem/nrf_modem_lib.h>
+#endif
 #include <zephyr/dfu/mcuboot.h>
 #include <dfu/dfu_target_full_modem.h>
 #include <dfu/fmfu_fdev.h>
@@ -288,4 +292,27 @@ int nrf_cloud_pending_fota_job_process(struct nrf_cloud_settings_fota_job * cons
 	}
 
 	return 0;
+}
+
+bool nrf_cloud_fota_is_type_enabled(const enum nrf_cloud_fota_type type)
+{
+	if (!IS_ENABLED(CONFIG_NRF_CLOUD_FOTA) && !IS_ENABLED(CONFIG_NRF_CLOUD_REST)) {
+		return false;
+	}
+
+	switch (type) {
+	case NRF_CLOUD_FOTA_APPLICATION:
+		return IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT);
+	case NRF_CLOUD_FOTA_BOOTLOADER:
+		return IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT) &&
+		       IS_ENABLED(CONFIG_BUILD_S1_VARIANT) &&
+		       IS_ENABLED(CONFIG_SECURE_BOOT);
+	case NRF_CLOUD_FOTA_MODEM_DELTA:
+		return IS_ENABLED(CONFIG_NRF_MODEM);
+	case NRF_CLOUD_FOTA_MODEM_FULL:
+		return IS_ENABLED(CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE) &&
+		       IS_ENABLED(CONFIG_NRF_MODEM);
+	default:
+		return false;
+	}
 }


### PR DESCRIPTION
Add full modem FOTA support to Asset Tracker v2.
Requires nRF Cloud and an nRF9160 DK version 1.0.1 or higher.

CIA-724