### PR TITLE
samples: Bluetooth: llpm: Fixing llpm sample on nrf53

### DIFF
--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -32,7 +32,9 @@
 #define INTERVAL_LLPM   0x0D01   /* Proprietary  1 ms */
 #define INTERVAL_LLPM_US 1000
 
-static volatile bool test_ready;
+
+static K_SEM_DEFINE(test_ready_sem, 0, 1);
+static bool test_ready;
 static struct bt_conn *default_conn;
 static struct bt_latency latency;
 static struct bt_latency_client latency_client;
@@ -128,6 +130,7 @@ static void discovery_complete(struct bt_gatt_dm *dm, void *context)
 
 	/* Start testing when the GATT service is discovered */
 	test_ready = true;
+	k_sem_give(&test_ready_sem);
 }
 
 static void discovery_service_not_found(struct bt_conn *conn, void *context)
@@ -492,8 +495,7 @@ void main(void)
 	}
 
 	for (;;) {
-		if (test_ready) {
-			test_run();
-		}
+		k_sem_take(&test_ready_sem, K_FOREVER);
+		test_run();
 	}
 }


### PR DESCRIPTION
Without this I'm not able to run this sample on nrf53 app core.
I think it is because IPC work doens't get to execute, since main thread is in this busylopp.
But I don't understand IPC so well, so I might be wrong. I thought main thread was preemptive and that IPC to hci_rpmsg on the netcore should work even if main thread is busylooping. Please let me know if I have misunderstood and something else is going on.

Anyway, I tested locally and it doesn't work without this commit, but works with it. This is how I built:
west build -b nrf5340dk_nrf5340_cpuapp nrf/samples/bluetooth/llpm --build-dir build_53

And then flash, and observe that you don't receive any adv reports when you select central (by typing c on the console).
But with this commit it works