### PR TITLE
bluetooth: Remove sdc_hci_data_get() and sdc_hci_evt_get()

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1175,22 +1175,6 @@ int hci_internal_cmd_put(uint8_t *cmd_in)
 	return 0;
 }
 
-int hci_internal_evt_get(uint8_t *evt_out)
-{
-	if (cmd_complete_or_status.occurred) {
-		struct bt_hci_evt_hdr *evt_hdr = (void *)&cmd_complete_or_status.raw_event[0];
-
-		memcpy(evt_out,
-		       &cmd_complete_or_status.raw_event[0],
-		       evt_hdr->len + BT_HCI_EVT_HDR_SIZE);
-		cmd_complete_or_status.occurred = false;
-
-		return 0;
-	}
-
-	return sdc_hci_evt_get(evt_out);
-}
-
 int hci_internal_msg_get(uint8_t *msg_out, sdc_hci_msg_type_t *msg_type_out)
 {
 	if (cmd_complete_or_status.occurred) {

--- a/subsys/bluetooth/controller/hci_internal.h
+++ b/subsys/bluetooth/controller/hci_internal.h
@@ -66,21 +66,6 @@ typedef uint8_t (*hci_internal_user_cmd_handler_t)(uint8_t const *cmd,
  */
 int hci_internal_user_cmd_handler_register(const hci_internal_user_cmd_handler_t handler);
 
-/** @brief Retrieve an HCI event packet from the SoftDevice Controller.
- *
- * This API is non-blocking.
- *
- * @note The application should ensure that the size of the provided buffer is at least
- *       @ref HCI_EVENT_PACKET_MAX_SIZE bytes.
- *
- * @param[in,out] evt_out Buffer where the HCI event will be stored.
- *                        If an event is retrieved, the first byte corresponds to Event Code,
- *                        as specified by the Bluetooth Core Specification.
- *
- * @return Zero on success or (negative) error code otherwise.
- */
-int hci_internal_evt_get(uint8_t *evt_out);
-
 /** @brief Retrieve an HCI packet from the SoftDevice Controller.
  *
  * This API is non-blocking.


### PR DESCRIPTION
They are no longer implemented by SDC.

Signed-off-by: Olivier Lesage <olivier.lesage@nordicsemi.no>