### PR TITLE
lib: nrf_modem: keep CONFIG_NRF_MODEM_LIB_TRACE_ENABLED as deprecated

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -545,7 +545,7 @@ Modem libraries
       * The trace module has been updated to use the new APIs in Modem library.
         The modem trace output is now handled by a dedicated thread that starts automatically.
         The trace thread is synchronized with the initialization and shutdown operations of the Modem library.
-      * The Kconfig option ``CONFIG_NRF_MODEM_LIB_TRACE_ENABLED`` has been renamed to :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE`.
+      * The Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_ENABLED` is replaced by the Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE`. The Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_ENABLED` is now deprecated and will be removed in the future.
 
     * Removed:
 

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -22,8 +22,17 @@ config NRF_MODEM_LIB_LOG_FW_VERSION_UUID
 	depends on LOG
 	bool "Log FW version and UUID during initialization"
 
+config NRF_MODEM_LIB_TRACE_ENABLED
+	bool "Enable proprietary traces (DEPRECATED)"
+	help
+	  Deprecated, use NRF_MODEM_LIB_TRACE instead.
+	  When enabled, a portion of RAM (called Trace region) will be shared with the modem to receive modem's trace data.
+	  The size of the Trace region is defined by the NRF_MODEM_LIB_SHMEM_TRACE_SIZE option.
+	  Trace data is output on the chosen trace backend.
+
 config NRF_MODEM_LIB_TRACE
-	bool "Enable proprietary traces"
+	bool "Enable proprietary traces" if !NRF_MODEM_LIB_TRACE_ENABLED
+	default y if NRF_MODEM_LIB_TRACE_ENABLED
 	help
 	  When enabled, a portion of RAM (called Trace region) will be shared with the modem to receive modem's trace data.
 	  The size of the Trace region is defined by the NRF_MODEM_LIB_SHMEM_TRACE_SIZE option.


### PR DESCRIPTION
CONFIG_NRF_MODEM_LIB_TRACE_ENABLED is referenced in blog posts, on
DevZone and in other documentation and guides. Keep the Kconfig
option as deprecated to not break blog posts and guides immediately.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>