### PR TITLE
matter: pull SoftwareUpdateComleted boot reason fix

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -93,8 +93,8 @@
 
 .. _`SMP over Bluetooth`: https://github.com/apache/mynewt-mcumgr/blob/master/transport/smp-bluetooth.md
 
-.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/238a18db/src/android/CHIPTool
-.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/238a18db/src/controller
+.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/bb3c7570/src/android/CHIPTool
+.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/bb3c7570/src/controller
 .. _`ZCL Advanced Platform`: https://github.com/project-chip/zap
 .. _`Matter nRF Connect releases`: https://github.com/nrfconnect/sdk-connectedhomeip/releases
 

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 238a18db4eae15381c3c1838d8e863d841c59ead
+      revision: bb3c75702852ed7efaf6058a38b5a86a71581fa4
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Boot reason was incorrectly recognized in Matter in some
scenarios on nRF53 and nRF52 with BLE SMP enabled.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>