### PR TITLE
CODEOWNERS: Add missing "/" after bt_le_adv_prov

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -160,7 +160,7 @@ Kconfig*                                  @tejlmand
 /subsys/bluetooth/                        @alwa-nordic @carlescufi @KAGA164
 /subsys/bluetooth/mesh/                   @ludvigsj
 /subsys/bluetooth/controller/             @rugeGerritsen
-/subsys/bluetooth/bt_le_adv_prov          @MarekPieta @kapi-no @KAGA164
+/subsys/bluetooth/bt_le_adv_prov/         @MarekPieta @kapi-no @KAGA164
 /subsys/bluetooth/services/fast_pair/     @MarekPieta @kapi-no @KAGA164
 /subsys/bootloader/                       @hakonfam @SebastianBoe
 /subsys/caf/                              @pdunaj


### PR DESCRIPTION
Change adds missing "/" to fix compliance issue.