### PR TITLE
samples: peripheral_fast_pair: Workaround disconnection (reason 42)

### DIFF
--- a/samples/bluetooth/peripheral_fast_pair/prj.conf
+++ b/samples/bluetooth/peripheral_fast_pair/prj.conf
@@ -29,6 +29,12 @@ CONFIG_BT_PERIPHERAL_PREF_TIMEOUT=400
 # Appear as a Generic Human Interface Device
 CONFIG_BT_DEVICE_APPEARANCE=960
 
+# Disable automatic initiation of PHY updates.
+# Workaround to prevent disconnection with reason 42 (BT_HCI_ERR_DIFF_TRANS_COLLISION).
+# Some Android phones reply to the LL_PHY_REQ and at the same time initiate a connection
+# update which triggers an invalid procedure collision.
+CONFIG_BT_AUTO_PHY_UPDATE=n
+
 CONFIG_BT_ID_MAX=1
 CONFIG_BT_MAX_CONN=1
 CONFIG_BT_MAX_PAIRED=8


### PR DESCRIPTION
Change adds workaround for disconnection right after a connection is established with Android (BT_HCI_ERR_DIFF_TRANS_COLLISION).

Jira: NCSDK-16437