### PR TITLE
net: lib: nrf_cloud: fix nrf_cloud_client_id_get for MQTT and REST

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -594,6 +594,7 @@ Libraries for networking
 
       * An issue that caused the application to receive multiple disconnect events.
       * An issue that prevented full modem FOTA updates to be installed during library initialization.
+      * An issue that caused the :c:func:`nrf_cloud_client_id_get` function to fail if both :kconfig:option:`CONFIG_NRF_CLOUD_MQTT` and :kconfig:option:`CONFIG_NRF_CLOUD_REST` were enabled.
 
     * Added:
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_client_id.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_client_id.c
@@ -36,11 +36,23 @@ BUILD_ASSERT(IMEI_CLIENT_ID_LEN <= NRF_CLOUD_CLIENT_ID_MAX_LEN,
 
 int nrf_cloud_client_id_get(char *id_buf, size_t id_len)
 {
+	int ret = -ENODEV;
+
 #if defined(CONFIG_NRF_CLOUD_MQTT)
-	return nct_client_id_get(id_buf, id_len);
-#else
-	return nrf_cloud_configured_client_id_get(id_buf, id_len);
+	/* For MQTT, the client ID is allocated and generated when nrf_cloud_init is called,
+	 * so just get a copy.
+	 */
+	ret = nct_client_id_get(id_buf, id_len);
 #endif
+
+#if defined(CONFIG_NRF_CLOUD_REST)
+	if (ret != 0) {
+		/* For REST, the client ID is generated on demand. */
+		ret = nrf_cloud_configured_client_id_get(id_buf, id_len);
+	}
+#endif
+
+	return ret;
 }
 
 size_t nrf_cloud_configured_client_id_length_get(void)


### PR DESCRIPTION
Fix nrf_cloud_client_id_get so that it returns a valid client ID
when MQTT and REST are both enabled and nrf_cloud_init has not
been called.
NCSDK-16475

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>