### PR TITLE
codeowners: add owner for tests of the nrf_cloud library

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -237,6 +237,7 @@ Kconfig*                                  @tejlmand
 /tests/subsys/net/lib/aws_*/              @simensrostad
 /tests/subsys/net/lib/azure_iot_hub/      @jtguggedal
 /tests/subsys/net/lib/fota_download/      @hakonfam @sigvartmh
+/tests/subsys/net/lib/nrf_cloud/          @tony-le-24
 /tests/subsys/partition_manager/region/   @hakonfam @sigvartmh
 /tests/subsys/pcd/                        @hakonfam @sigvartmh
 /tests/subsys/nrf_profiler/               @pdunaj @MarekPieta


### PR DESCRIPTION
Add my GitHub handle as owner for test cases that are in /tests/subsys/net/lib/nrf_cloud/ 
This folder is not added yet since PR#8418, which includes it, is opening

See NCSDK-16128

Signed-off by: Tony Le <tony.le@nordicsemi.no>