### PR TITLE
samples: nrf9160: modem_shell: Auto enable modem sleep notifications

### DIFF
--- a/samples/nrf9160/modem_shell/src/link/link.c
+++ b/samples/nrf9160/modem_shell/src/link/link.c
@@ -40,7 +40,7 @@
 #include <modem/at_cmd_parser.h>
 #include <modem/at_params.h>
 
-extern bool uart_disable_during_sleep_requested;
+extern bool uart_shell_disable_during_sleep_requested;
 extern struct k_work_q mosh_common_work_q;
 extern char at_resp_buf[MOSH_AT_CMD_RESPONSE_MAX_LEN];
 extern struct k_mutex at_resp_buf_mutex;
@@ -344,7 +344,7 @@ void link_ind_handler(const struct lte_lc_evt *const evt)
 	case LTE_LC_EVT_MODEM_SLEEP_EXIT:
 		link_shell_print_modem_sleep_notif(evt);
 
-		if (uart_disable_during_sleep_requested) {
+		if (uart_shell_disable_during_sleep_requested) {
 			uart_toggle_power_state_at_event(evt);
 		}
 		break;

--- a/samples/nrf9160/modem_shell/src/link/link_shell.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell.c
@@ -450,6 +450,8 @@ static struct option long_options[] = {
 
 /******************************************************************************/
 
+bool link_shell_msleep_notifications_subscribed;
+
 static void link_shell_print_usage(struct link_shell_cmd_args_t *link_cmd_args)
 {
 	switch (link_cmd_args->command) {
@@ -1586,8 +1588,10 @@ int link_shell(const struct shell *shell, size_t argc, char **argv)
 				((threshold_time) ?
 					 threshold_time :
 					 CONFIG_LTE_LC_MODEM_SLEEP_NOTIFICATIONS_THRESHOLD_MS));
+			link_shell_msleep_notifications_subscribed = true;
 		} else {
 			link_modem_sleep_notifications_unsubscribe();
+			link_shell_msleep_notifications_subscribed = false;
 		}
 		break;
 	case LINK_CMD_TAU:


### PR DESCRIPTION
Enable modem sleep notifications automatically if UART disabling is
requested during sleep periods.

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>