### PR TITLE
samples: nrf9160: modem_shell: fix print cloud functionality

### DIFF
--- a/samples/nrf9160/modem_shell/src/utils/mosh_print.c
+++ b/samples/nrf9160/modem_shell/src/utils/mosh_print.c
@@ -147,7 +147,7 @@ void mosh_fprintf_valist(enum mosh_print_level print_level, const char *fmt, va_
 		break;
 	}
 
-#if defined(CONFIG_MOSH_CLOUD)
+#if defined(CONFIG_MOSH_CLOUD_MQTT)
 	if (mosh_print_cloud_echo) {
 		struct nrf_cloud_sensor_data mosh_cloud_print = {
 			.type = NRF_CLOUD_DEVICE_INFO,


### PR DESCRIPTION
CONFIG_MOSH_CLOUD has been removed causing the code that sends mosh
output to cloud (i.e. print cloud) not to be included in the build.
Moved the implementation behind CONFIG_MOSH_CLOUD_MQTT instead.

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>