### PR TITLE
samples: nrf9160: modem_shell: inject A-GPS data from command line

### DIFF
--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -30,8 +30,8 @@ CONFIG_SHELL=y
 CONFIG_SHELL_WILDCARD=n
 CONFIG_SHELL_PROMPT_UART="mosh:~$ "
 CONFIG_SHELL_ARGC_MAX=40
-# Command line buffer is set this large to enable writing of certificates.
-CONFIG_SHELL_CMD_BUFF_SIZE=3072
+# Command line buffer is set this large to enable writing of certificates and injecting A-GPS data on command line.
+CONFIG_SHELL_CMD_BUFF_SIZE=3584
 # Shell stack has impact for modem shell application, not CONFIG_MAIN_STACK_SIZE
 CONFIG_SHELL_STACK_SIZE=9216
 # Shell RX buffer needs to be increased to avoid problems with test automation


### PR DESCRIPTION
New feature allows injecting the A-GPS assistance data from command
line. Usage: 'gnss agps inject <data>'.

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>