### PR TITLE
samples: nrf9160: modem_shell: Use Zephyr subcommands for link

### DIFF
--- a/samples/nrf9160/modem_shell/src/link/link_shell.h
+++ b/samples/nrf9160/modem_shell/src/link/link_shell.h
@@ -10,8 +10,6 @@
 #include <zephyr/shell/shell.h>
 #include <modem/lte_lc.h>
 
-int link_shell(const struct shell *shell, size_t argc, char **argv);
-
 int link_shell_get_and_print_current_system_modes(
 	enum lte_lc_system_mode *sys_mode_current,
 	enum lte_lc_system_mode_preference *sys_mode_preferred,

--- a/samples/nrf9160/modem_shell/src/shell.c
+++ b/samples/nrf9160/modem_shell/src/shell.c
@@ -207,12 +207,6 @@ SHELL_CMD_REGISTER(sock, NULL,
 SHELL_CMD_REGISTER(ping, NULL, "For ping usage, just type \"ping\"", icmp_ping_shell);
 #endif
 
-#if defined(CONFIG_MOSH_LINK)
-SHELL_CMD_REGISTER(link, NULL,
-	"Commands for LTE link controlling and status information.",
-	link_shell);
-#endif
-
 #if defined(CONFIG_MOSH_IPERF3)
 SHELL_CMD_REGISTER(iperf3, NULL, "For iperf3 usage, just type \"iperf3 --manual\"", cmd_iperf3);
 #endif


### PR DESCRIPTION
Subcommands have been implemented on our own for 'link' command.
Use Zephyr shell subcommands so that autofill with TAB works.

test-sdk-nrf: mosh_update_link_output