### PR TITLE
CODEOWNERS: update code owner nick name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -117,8 +117,8 @@ Kconfig*                                  @tejlmand
 /samples/sensor/bh1749/                   @wlgrd
 /samples/bluetooth/                       @alwa-nordic @carlescufi @KAGA164
 /samples/bluetooth/mesh/                  @ludvigsj
-/samples/bluetooth/direction_finding_connectionless_rx/ @ppryga @alwa-nordic
-/samples/bluetooth/direction_finding_connectionless_tx/ @ppryga @alwa-nordic
+/samples/bluetooth/direction_finding_connectionless_rx/ @ppryga-nordic @alwa-nordic
+/samples/bluetooth/direction_finding_connectionless_tx/ @ppryga-nordic @alwa-nordic
 /samples/bluetooth/peripheral_fast_pair/  @MarekPieta @kapi-no @KAGA164
 /samples/bootloader/                      @hakonfam @SebastianBoe
 /samples/matter/                          @Damian-Nordic @kkasperczyk-no


### PR DESCRIPTION
Update ppryga code owner nick name.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>