### PR TITLE
Bluetooth: Mesh: Invalidate scene when state changed by state machine

### DIFF
--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -618,6 +618,10 @@ static void timeout(struct k_work *work)
 		return;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_MESH_SCENE_SRV)) {
+		bt_mesh_scene_invalidate(srv->model);
+	}
+
 	if (srv->state == LIGHT_CTRL_STATE_ON) {
 		prolong(srv);
 		return;


### PR DESCRIPTION
From MshMDLv1.0.1, section 5.1.3.2.1:

When any of the element's state that is marked as “Stored with Scene”
has changed not as a result of a Scene Recall operation, the value of
the Current Scene state shall be set to 0x0000.

Thus, when Light LC State Machine changes Light OnOff state, the scene
shall be invalidated.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>