### PR TITLE
bluetooth: fast_pair: Add Battery Notification crypto functions

### DIFF
--- a/subsys/bluetooth/services/fast_pair/fp_advertising.c
+++ b/subsys/bluetooth/services/fast_pair/fp_advertising.c
@@ -114,7 +114,7 @@ static int fp_adv_data_fill_non_discoverable(struct net_buf_simple *buf, size_t 
 		net_buf_simple_add_u8(buf, ENCODE_FIELD_LEN_TYPE(ak_filter_size, ak_filter_type));
 
 		err = fp_crypto_account_key_filter(net_buf_simple_add(buf, ak_filter_size), ak,
-						   account_key_cnt, salt);
+						   account_key_cnt, salt, NULL);
 		if (err) {
 			return err;
 		}

--- a/subsys/bluetooth/services/fast_pair/fp_crypto/include/fp_crypto.h
+++ b/subsys/bluetooth/services/fast_pair/fp_crypto/include/fp_crypto.h
@@ -34,6 +34,8 @@ extern "C" {
 #define FP_CRYPTO_ADDITIONAL_DATA_NONCE_LEN	8U
 /** Length of Additional Data packet header (128 bits = 16 bytes). */
 #define FP_CRYPTO_ADDITIONAL_DATA_HEADER_LEN	16U
+/** Length of battery info (1-byte length and type field and 3-byte battery values field). */
+#define FP_CRYPTO_BATTERY_INFO_LEN		4U
 
 /** Hash value using SHA-256.
  *
@@ -140,11 +142,13 @@ size_t fp_crypto_account_key_filter_size(size_t n);
  *			       equal to number of Account Keys.
  * @param[in] n Number of account keys (n >= 1).
  * @param[in] salt Random byte - Salt.
+ * @param[in] battery_info Battery info or NULL if there is no battery info. Length of battery info
+ *			   must be equal to @ref FP_CRYPTO_BATTERY_INFO_LEN.
  *
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
 int fp_crypto_account_key_filter(uint8_t *out, const struct fp_account_key *account_key_list,
-				 size_t n, uint8_t salt);
+				 size_t n, uint8_t salt, const uint8_t *battery_info);
 
 /** Encode data to Additional Data packet.
  *

--- a/tests/subsys/bluetooth/fast_pair/crypto/src/main.c
+++ b/tests/subsys/bluetooth/fast_pair/crypto/src/main.c
@@ -199,9 +199,23 @@ static void test_bloom_filter(void)
 	zassert_equal(s, sizeof(first_bloom_filter),
 		      "Invalid size of expected result.");
 	zassert_ok(fp_crypto_account_key_filter(first_result_buf, first_account_key_list,
-						ARRAY_SIZE(first_account_key_list), salt),
+						ARRAY_SIZE(first_account_key_list), salt, NULL),
 		   "Error during filter computing");
 	zassert_mem_equal(first_result_buf, first_bloom_filter, sizeof(first_bloom_filter),
+			  "Invalid resulting filter.");
+
+	static const uint8_t battery_info[] = {0b00110011, 0b01000000, 0b01000000, 0b01000000};
+
+	static const uint8_t first_bloom_filter_with_battery_info[] = {0x4A, 0x00, 0xF0, 0x00};
+
+	zassert_equal(sizeof(first_result_buf), sizeof(first_bloom_filter_with_battery_info),
+		      "Invalid size of expected result.");
+	zassert_ok(fp_crypto_account_key_filter(first_result_buf, first_account_key_list,
+						ARRAY_SIZE(first_account_key_list), salt,
+						battery_info),
+		   "Error during filter computing");
+	zassert_mem_equal(first_result_buf, first_bloom_filter_with_battery_info,
+			  sizeof(first_bloom_filter_with_battery_info),
 			  "Invalid resulting filter.");
 
 	static const struct fp_account_key second_account_key_list[] = {
@@ -219,9 +233,22 @@ static void test_bloom_filter(void)
 	zassert_equal(s, sizeof(second_bloom_filter),
 		      "Invalid size of expected result.");
 	zassert_ok(fp_crypto_account_key_filter(second_result_buf, second_account_key_list,
-						ARRAY_SIZE(second_account_key_list), salt),
+						ARRAY_SIZE(second_account_key_list), salt, NULL),
 		   "Error during filter computing");
 	zassert_mem_equal(second_result_buf, second_bloom_filter, sizeof(second_bloom_filter),
+			  "Invalid resulting filter.");
+
+	static const uint8_t second_bloom_filter_with_battery_info[] = {0x10, 0x22, 0x56, 0xC0,
+									0x4D};
+
+	zassert_equal(sizeof(second_result_buf), sizeof(second_bloom_filter_with_battery_info),
+		      "Invalid size of expected result.");
+	zassert_ok(fp_crypto_account_key_filter(second_result_buf, second_account_key_list,
+						ARRAY_SIZE(second_account_key_list), salt,
+						battery_info),
+		   "Error during filter computing");
+	zassert_mem_equal(second_result_buf, second_bloom_filter_with_battery_info,
+			  sizeof(second_bloom_filter_with_battery_info),
 			  "Invalid resulting filter.");
 }
 


### PR DESCRIPTION
Modifies crypto function that constructs Account Key Filter to allow using Battery Notification Fast Pair extension. See Google Fast Pair Specification for more details.

Jira: NCSDK-14055