### PR TITLE
samples: matter: harden OTA NotifyUpdateApplied handling

### DIFF
--- a/applications/matter_weather_station/src/app_task.cpp
+++ b/applications/matter_weather_station/src/app_task.cpp
@@ -224,9 +224,6 @@ CHIP_ERROR AppTask::Init()
 	(void)initParams.InitializeStaticResourcesBeforeServerInit();
 
 	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
-#if CONFIG_CHIP_OTA_REQUESTOR
-	InitBasicOTARequestor();
-#endif
 	ConfigurationMgr().LogDeviceConfig();
 	PrintOnboardingCodes(
 		chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
@@ -655,6 +652,11 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 		sIsThreadProvisioned = ConnectivityMgr().IsThreadProvisioned();
 		sIsThreadEnabled = ConnectivityMgr().IsThreadEnabled();
 		UpdateStatusLED();
+		break;
+	case DeviceEventType::kDnssdPlatformInitialized:
+#if CONFIG_CHIP_OTA_REQUESTOR
+		InitBasicOTARequestor();
+#endif
 		break;
 	default:
 		break;

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -418,11 +418,9 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 		sIsThreadEnabled = ConnectivityMgr().IsThreadEnabled();
 		UpdateStatusLED();
 		break;
-	case DeviceEventType::kThreadConnectivityChange:
+	case DeviceEventType::kDnssdPlatformInitialized:
 #if CONFIG_CHIP_OTA_REQUESTOR
-		if (event->ThreadConnectivityChange.Result == kConnectivity_Established) {
-			InitBasicOTARequestor();
-		}
+		InitBasicOTARequestor();
 #endif
 		break;
 	default:

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -355,11 +355,9 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *aEvent, intptr_t /* arg */
 		sIsThreadEnabled = ConnectivityMgr().IsThreadEnabled();
 		UpdateStatusLED();
 		break;
-	case DeviceEventType::kThreadConnectivityChange:
+	case DeviceEventType::kDnssdPlatformInitialized:
 #if CONFIG_CHIP_OTA_REQUESTOR
-		if (aEvent->ThreadConnectivityChange.Result == kConnectivity_Established) {
-			InitBasicOTARequestor();
-		}
+		InitBasicOTARequestor();
 #endif
 		break;
 	default:

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -492,11 +492,9 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 #endif
 		UpdateStatusLED();
 		break;
-	case DeviceEventType::kThreadConnectivityChange:
+	case DeviceEventType::kDnssdPlatformInitialized:
 #if CONFIG_CHIP_OTA_REQUESTOR
-		if (event->ThreadConnectivityChange.Result == kConnectivity_Established) {
-			InitBasicOTARequestor();
-		}
+		InitBasicOTARequestor();
 #endif
 		break;
 	default:

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -264,11 +264,9 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 		sIsThreadEnabled = ConnectivityMgr().IsThreadEnabled();
 		UpdateStatusLED();
 		break;
-	case DeviceEventType::kThreadConnectivityChange:
+	case DeviceEventType::kDnssdPlatformInitialized:
 #if CONFIG_CHIP_OTA_REQUESTOR
-		if (event->ThreadConnectivityChange.Result == kConnectivity_Established) {
-			InitBasicOTARequestor();
-		}
+		InitBasicOTARequestor();
 #endif
 		break;
 	default:

--- a/samples/matter/window_covering/src/app_task.cpp
+++ b/samples/matter/window_covering/src/app_task.cpp
@@ -460,11 +460,9 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *aEvent, intptr_t)
 		Instance().mIsThreadEnabled = ConnectivityMgr().IsThreadEnabled();
 		UpdateStatusLED();
 		break;
-	case DeviceEventType::kThreadConnectivityChange:
+	case DeviceEventType::kDnssdPlatformInitialized:
 #if CONFIG_CHIP_OTA_REQUESTOR
-		if (aEvent->ThreadConnectivityChange.Result == kConnectivity_Established) {
-			InitBasicOTARequestor();
-		}
+		InitBasicOTARequestor();
 #endif
 		break;
 	default:


### PR DESCRIPTION
NotifyUpdateApplied command was sent right after joining
a Thread network, but the outcome was racy because it might
happen that the SRP client was not yet fully initialized.
In such a case, an attempt to send the command would fail.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>