### PR TITLE
Audio DFU ADV name based on role

### DIFF
--- a/applications/nrf5340_audio/README.rst
+++ b/applications/nrf5340_audio/README.rst
@@ -848,6 +848,9 @@ See the following table for the pin definitions.
 | P1.10       | CS                | D8          |
 +-------------+-------------------+-------------+
 
+.. note::
+   External flash shields must be connected for the kits to boot, even if DFU mode is not initiated.
+
 Enabling FOTA upgrades
 ----------------------
 
@@ -861,6 +864,16 @@ Entering the DFU mode
 The |NCS| uses :ref:`SMP server and mcumgr <zephyr:device_mgmt>` as the DFU backend.
 Unlike the CIS and BIS modes for gateway and headsets, the DFU mode is advertising using the SMP server service.
 For this reason, to enter the DFU mode, you must long press **BTN 4** during each device startup to have the nRF5340 Audio DK enter the DFU mode.
+
+To identify the devices before the DFU takes place, the DFU mode advertising names mention the device type directly.
+The names follow the pattern in which the device *ROLE* is inserted before the ``_DFU`` suffix.
+For example:
+
+* Gateway: NRF5340_AUDIO_GW_DFU
+* Left Headset: NRF5340_AUDIO_HL_DFU
+* Right Headset: NRF5340_AUDIO_HR_DFU
+
+The first part of these names is based on :kconfig:option:`CONFIG_BT_DEVICE_NAME`.
 
 .. _nrf53_audio_app_building:
 

--- a/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
+++ b/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
@@ -123,6 +123,10 @@ config BT_DEVICE_NAME_GATT_WRITABLE
 	bool
 	default n
 
+config BT_DEVICE_NAME_MAX
+	int
+	default 30
+
 endif # AUDIO_DFU = 1 and AUDIO_DFU = 2 (INTERNAL/EXTERNAL)
 
 if AUDIO_DFU = 1

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
@@ -27,11 +27,11 @@ config BT_EXT_ADV
 	bool
 	default y
 
-if TRANSPORT_CIS # Depends on TRANSPORT_CIS
-
 config BT_DEVICE_NAME
 	string
 	default "NRF5340_AUDIO"
+
+if TRANSPORT_CIS # Depends on TRANSPORT_CIS
 
 config BT_GATT_CLIENT
 	bool
@@ -189,10 +189,6 @@ config BT_AUDIO_BROADCAST_SINK
 	bool
 	default y
 
-config BT_DEVICE_NAME
-	string
-	default "Broadcast Audio Sink"
-
 config BT_AUDIO_BROADCAST_SNK_STREAM_COUNT
 	int
 	default 2
@@ -221,10 +217,6 @@ config BT_ISO_BROADCASTER
 config BT_AUDIO_BROADCAST_SOURCE
 	bool
 	default y
-
-config BT_DEVICE_NAME
-	string
-	default "Broadcast Audio Source"
 
 config BT_ISO_TX_BUF_COUNT
 	int

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -505,10 +505,10 @@ static void on_device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 			bt_foreach_bond(BT_ID_DEFAULT, bond_connect, (void *)addr);
 		}
 		return;
+	} else if (type == BT_GAP_ADV_TYPE_ADV_IND) {
+		/* Note: May lead to connection creation */
+		ad_parse(p_ad, addr);
 	}
-
-	/* Note: May lead to connection creation */
-	ad_parse(p_ad, addr);
 }
 
 static void ble_acl_start_scan(void)

--- a/applications/nrf5340_audio/src/utils/channel_assignment.h
+++ b/applications/nrf5340_audio/src/utils/channel_assignment.h
@@ -18,6 +18,10 @@
 #define AUDIO_CHANNEL_DEFAULT AUDIO_CH_L
 #endif /* AUDIO_CHANNEL_DEFAULT */
 
+static const char CH_L_TAG[] = "HL";
+static const char CH_R_TAG[] = "HR";
+static const char GW_TAG[] = "GW";
+
 /**@brief Audio channel assignment values */
 enum audio_channel {
 	AUDIO_CH_L,

--- a/applications/nrf5340_audio/src/utils/fw_info_app.c.in
+++ b/applications/nrf5340_audio/src/utils/fw_info_app.c.in
@@ -49,8 +49,7 @@ int fw_info_app_print(void)
 	ret = channel_assignment_get(&channel);
 	if (ret) {
 		channel = AUDIO_CHANNEL_DEFAULT;
-		static const char log_tag[] = "HL";
-		ret = log_set_tag(log_tag);
+		ret = log_set_tag(CH_L_TAG);
 		if (ret) {
 			return ret;
 		}
@@ -58,15 +57,13 @@ int fw_info_app_print(void)
 			AUDIO_CHANNEL_DEFAULT) " " COLOR_RESET);
 	}
 	if (channel == AUDIO_CH_L) {
-		static const char log_tag[] = "HL";
-		ret = log_set_tag(log_tag);
+		ret = log_set_tag(CH_L_TAG);
 		if (ret) {
 			return ret;
 		}
 		LOG_INF(COLOR_CYAN "\r\n\t HEADSET left device" COLOR_RESET);
 	} else if (channel == AUDIO_CH_R) {
-		static const char log_tag[] = "HR";
-		ret = log_set_tag(log_tag);
+		ret = log_set_tag(CH_R_TAG);
 		if (ret) {
 			return ret;
 		}
@@ -76,13 +73,12 @@ int fw_info_app_print(void)
 	}
 
 #elif CONFIG_AUDIO_DEV == GATEWAY
-	static const char log_tag[] = "GW";
-	ret = log_set_tag(log_tag);
+	ret = log_set_tag(GW_TAG);
 	if (ret) {
 		return ret;
 	}
 	LOG_INF(COLOR_CYAN "\r\n\t Compiled for GATEWAY device" COLOR_RESET);
-#endif /* (CONFIG_AUDIO_DEV==HEADSET) */
+#endif /* (CONFIG_AUDIO_DEV == HEADSET) */
 #endif /* (CONFIG_DEBUG) */
 
 	return 0;

--- a/applications/nrf5340_audio/tools/buildprog/buildprog.py
+++ b/applications/nrf5340_audio/tools/buildprog/buildprog.py
@@ -197,8 +197,12 @@ def __populate_hex_paths(dev, options):
 
         if options.mcuboot != '':
             temp_dest_folder = str(temp_dest_folder)
-            indices = [i for i, c in enumerate(temp_dest_folder) if c == '/']
-            final_file_prefix = temp_dest_folder[indices[-2]+1:].replace('/', '_')+'_'
+            if os.name == 'nt':
+                folder_slash ='\\'
+            else:
+                folder_slash ='/'
+            indices = [i for i, c in enumerate(temp_dest_folder) if c == folder_slash]
+            final_file_prefix = temp_dest_folder[indices[-2]+1:].replace(folder_slash, '_')+'_'
             dev.hex_path_net = dest_folder / f"{final_file_prefix}pcft_CPUNET.hex"
         else:
             for hex_file in reversed(hex_files_found):

--- a/applications/nrf5340_audio/tools/buildprog/pcft_sign.py
+++ b/applications/nrf5340_audio/tools/buildprog/pcft_sign.py
@@ -39,17 +39,28 @@ def awklike(field_str, filename):
 
 def sign(orig_pcft_hex, build_dir):
     """ A function to combine and sign PCFT"""
+
+    if os.name == 'nt':
+        folder_slash ='\\'
+    else:
+        folder_slash ='/'
+
     # Make sure we input build_dir as absolute path
-    indices = [i for i, c in enumerate(build_dir) if c == '/']
-    final_file_prefix = build_dir[indices[-2]+1:].replace('/', '_')+'_'
+    indices = [i for i, c in enumerate(build_dir) if c == folder_slash]
+    final_file_prefix = build_dir[indices[-2]+1:].replace(folder_slash, '_')+'_'
 
     # RETEIVE setting value from .config
     # "${ZEPHYR_BASE}/../bootloader/mcuboot/root-rsa-2048.pem"
 
     mcuboot_rsa_key = awklike('CONFIG_BOOT_SIGNATURE_KEY_FILE=', build_dir +
                               '/mcuboot/zephyr/.config')
-    if ('/' in mcuboot_rsa_key) or ('\\' in mcuboot_rsa_key):
+
+    #'\\' is used for Windows, '/' is used for other Operating Systems like Linux.
+    if ('/' in mcuboot_rsa_key) or ('\\' in  mcuboot_rsa_key):
         print('absolute path')
+        # Zephyr script convert folder separator to '/'. Should do the same here no matter Windows or not.
+        if folder_slash in mcuboot_rsa_key:
+            mcuboot_rsa_key.replace(folder_slash, '/')
     else:
         print('relative path')
         mcuboot_rsa_key = ZEPHYR_BASE + '/../bootloader/mcuboot/' + mcuboot_rsa_key

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -185,6 +185,7 @@ nRF5340 Audio
   * Bonding between gateway and headsets in the CIS (Connected Isochronous Stream).
   * DFU support for internal and external flash layouts.
     See :ref:`nrf53_audio_app_configuration_configure_fota` in the application documentation for details.
+  * DFU advertising name based on role.
 
 * Updated:
 


### PR DESCRIPTION
1. Instead of advertising fix name NRF5340_AUDIO when in DFU mode, now ADV name will be combination of CONFIG_BT_DEVICE_NAME and role of gateway or headset.
