### PR TITLE
bluetooth: mesh: fixes for sensor model issues

### DIFF
--- a/subsys/bluetooth/mesh/sensor_cli.c
+++ b/subsys/bluetooth/mesh/sensor_cli.c
@@ -259,9 +259,14 @@ static int handle_column_status(struct bt_mesh_model *model, struct bt_mesh_msg_
 
 yield_ack:
 	if (bt_mesh_msg_ack_ctx_match(&cli->ack_ctx, BT_MESH_SENSOR_OP_COLUMN_STATUS, ctx->addr,
-				      (void **)&rsp) &&
-	    rsp->col->start.val1 == entry.column.start.val1 &&
-	    rsp->col->start.val2 == entry.column.start.val2) {
+								  (void **)&rsp)) {
+		/* If column format exists verify Raw Value A */
+		if (col_format &&
+			(rsp->col->start.val1 != entry.column.start.val1 ||
+			 rsp->col->start.val2 != entry.column.start.val2)) {
+			return 0;
+		}
+
 		if (err) {
 			rsp->count = 0;
 		} else {


### PR DESCRIPTION
This patch contains fixes for issues caught during testing MMDL/CL/SNR/BV-12-C and MMDL/CL/SNR/BV-13-C. This fixes issues with `handle_column_status`, `bt_mesh_sensor_cli_series_entry_get`, `bt_mesh_sensor_cli_series_entries_get` and related commands in tester app: `sensor_column_get` and `sensor_series_get`