### PR TITLE
tfm: Fix input validation and abort handling for crypto partition

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 88749734479f91e560828d95faec94aeb6f5c88b
+      revision: 6fbfa99924391e64495a945bb861f215c5cc97d4
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Pull TF-M with fix for the input validation and abort handling for the
crypto secure functions tfm_crypto_key_derivation_set_capacity and
tfm_crypto_key_derivation_output_bytes.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>

test-sdk-nrf: sdk-nrf-PR-8451