### PR TITLE
drivers: wifi: Increase the wait time for RPU power on

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/qspi/inc/rpu_hw_if.h
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/inc/rpu_hw_if.h
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #include <zephyr/drivers/gpio.h>
 
-#define SLEEP_TIME_MS 2
+#define SLEEP_TIME_MS 6
 
 enum {
 	SYSBUS = 0,


### PR DESCRIPTION
In some scenarios it has been observed RPU power on needs more delay for
the MCU boot to work reliably. The root cause in unknown, so, add this
workaround for now.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>