### PR TITLE
Bluetooth: Mesh: Fix logging in sensor modules

### DIFF
--- a/subsys/bluetooth/mesh/sensor.c
+++ b/subsys/bluetooth/mesh/sensor.c
@@ -61,9 +61,21 @@ bool bt_mesh_sensor_delta_threshold(const struct bt_mesh_sensor *sensor,
 		thrsh_mill = (prev_mill * thrsh_mill) / (100LL * 1000000LL);
 	}
 
-	BT_DBG("Delta: %u (%d - %d) thrsh: %u", (uint32_t)(delta_mill / 1000000L),
-	       (int32_t)curr->val1, (int32_t)sensor->state.prev.val1,
-	       (uint32_t)(thrsh_mill / 1000000L));
+	if (BT_DBG_ENABLED) {
+		char delta_str[BT_MESH_SENSOR_CH_STR_LEN];
+		char curr_str[BT_MESH_SENSOR_CH_STR_LEN];
+		char prev_str[BT_MESH_SENSOR_CH_STR_LEN];
+		char thrsh_str[BT_MESH_SENSOR_CH_STR_LEN];
+
+		strcpy(delta_str, bt_mesh_sensor_ch_str(&delta));
+		strcpy(curr_str, bt_mesh_sensor_ch_str(curr));
+		strcpy(prev_str, bt_mesh_sensor_ch_str(&sensor->state.prev));
+		strcpy(thrsh_str, delta_mill < 0 ?
+		       bt_mesh_sensor_ch_str(&sensor->state.threshold.delta.down) :
+		       bt_mesh_sensor_ch_str(&sensor->state.threshold.delta.up));
+
+		BT_DBG("Delta: %s (%s - %s) thrsh: %s", delta_str, curr_str, prev_str, thrsh_str);
+	}
 
 	return (delta_mill > thrsh_mill);
 }

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -539,17 +539,23 @@ static int cadence_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		return err;
 	}
 
-	BT_DBG("Min int: %u div: %u "
-	       "delta: %s to %s "
-	       "range: %s to %s (%s)",
-	       min_int, period_div,
-	       bt_mesh_sensor_ch_str(&threshold.delta.down),
-	       bt_mesh_sensor_ch_str(&threshold.delta.up),
-	       bt_mesh_sensor_ch_str(&threshold.range.low),
-	       bt_mesh_sensor_ch_str(&threshold.range.high),
-	       (threshold.range.cadence == BT_MESH_SENSOR_CADENCE_FAST ?
+	if (BT_DBG_ENABLED) {
+		char delta_down_str[BT_MESH_SENSOR_CH_STR_LEN];
+		char delta_up_str[BT_MESH_SENSOR_CH_STR_LEN];
+		char range_low_str[BT_MESH_SENSOR_CH_STR_LEN];
+		char range_high_str[BT_MESH_SENSOR_CH_STR_LEN];
+
+		strcpy(delta_down_str, bt_mesh_sensor_ch_str(&threshold.delta.down));
+		strcpy(delta_up_str, bt_mesh_sensor_ch_str(&threshold.delta.up));
+		strcpy(range_low_str, bt_mesh_sensor_ch_str(&threshold.range.low));
+		strcpy(range_high_str, bt_mesh_sensor_ch_str(&threshold.range.high));
+
+		BT_DBG("Min int: %u div: %u delta: %s to %s range: %s to %s (%s)", min_int,
+		       period_div, delta_down_str, delta_up_str, range_low_str, range_high_str,
+		       (threshold.range.cadence == BT_MESH_SENSOR_CADENCE_FAST ?
 			"fast" :
 			"slow"));
+	}
 
 	sensor->state.min_int = min_int;
 	sensor->state.pub_div = period_div;


### PR DESCRIPTION
This PR fixes 2 issues:
- incorrect usage of bt_mesh_sensor_ch_str;
- incorrect print of delta, sensor and threshold values when they are not integers;