### PR TITLE
caf: ble_adv: Update advertising data configuration documentation

### DIFF
--- a/applications/machine_learning/README.rst
+++ b/applications/machine_learning/README.rst
@@ -340,6 +340,14 @@ The following configuration files can be defined for any supported board:
   You must define a :file:`_def` file for every module that requires it and enable it in the configuration for the given board.
   The :file:`_def` files that are common for all the boards and build types are located in the :file:`applications/machine_learning/configuration/common` directory.
 
+Advertising configuration
+-------------------------
+
+If a given build type enables Bluetooth, the :ref:`caf_ble_adv` is used to control the Bluetooth advertising.
+This CAF module relies on :ref:`bt_le_adv_prov_readme` to manage advertising data and scan response data.
+The nRF Machine Learning application configures the data providers in :file:`src/util/Kconfig`.
+By default, the application enables a set of data providers available in the |NCS| and adds a custom provider that appends UUID128 of Nordic UART Service (NUS) to the scan response data if the NUS is enabled in the configuration and the Bluetooth local identity in use has no bond.
+
 Multi-image builds
 ------------------
 

--- a/applications/nrf_desktop/doc/ble_adv.rst
+++ b/applications/nrf_desktop/doc/ble_adv.rst
@@ -35,10 +35,12 @@ The nRF Desktop devices also enable :kconfig:option:`CONFIG_CAF_BLE_ADV_FILTER_A
 This is done to prevent Bluetooth Centrals other than the bonded one from connecting with the device.
 The nRF Desktop dongle scans for peripheral devices using the Bluetooth device name, which is provided in the scan response data.
 
-Transmission power level
-========================
+Advertised data
+===============
 
-Bluetooth TX power level is assumed to be 0 dBm during advertising.
-This value is sent in unbonded advertising.
+The :ref:`caf_ble_adv` relies on :ref:`bt_le_adv_prov_readme` to manage advertising data and scan response data.
+nRF Desktop application configures the data providers in :file:`src/util/Kconfig`.
+By default, the application enables a set of data providers available in the |NCS| and adds a custom provider of UUID16 values of Battery Service (BAS) and Human Interface Device Service (HIDS).
+The UUID16 of a given GATT Service is added to the advertising data only if the service is enabled in the configuration and the Bluetooth local identity in use has no bond.
 
 .. |ble_adv| replace:: Bluetooth® LE advertising module

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -202,7 +202,10 @@ nRF5340 Audio
 nRF Machine Learning (Edge Impulse)
 -----------------------------------
 
-|no_changes_yet_note|
+* Added configuration of :ref:`bt_le_adv_prov_readme`.
+  The subsystem is now used instead of the :file:`*.def` file to configure advertising data and scan response data in :ref:`caf_ble_adv`.
+* Updated Bluetooth advertising data and scan response data logic.
+  The UUID128 of Nordic UART Service (NUS) is now added to the scan response data only if the NUS is enabled and the Bluetooth local identity in use has no bond.
 
 nRF Desktop
 -----------
@@ -211,6 +214,13 @@ nRF Desktop
   The feature can be turned on using :kconfig:option:`CONFIG_CAF_BLE_STATE_SECURITY_REQ`.
 * nRF Desktop dongles start peripheral discovery immediately after Bluetooth LE connection is established.
   The dongles no longer wait until the connection is secured.
+* Added configuration of :ref:`bt_le_adv_prov_readme`.
+  The subsystem is now used instead of the :file:`*.def` file to configure advertising data and scan response data in :ref:`caf_ble_adv`.
+* Updated Bluetooth advertising data and scan response data logic.
+
+  * The TX power included in the advertising packet is no longer hardcoded, the application reads it from the Bluetooth controller.
+    The TX power is included in advertising packets even if the Bluetooth local identity in use has bond.
+  * The UUID16 of Battery Service (BAS) and Human Interface Device Service (HIDS) are included in advertising packets only if the Bluetooth local identity in use has no bond.
 
 Thingy:53 Zigbee weather station
 --------------------------------
@@ -703,6 +713,8 @@ Common Application Framework (CAF)
 
   * Added :kconfig:option:`CONFIG_CAF_BLE_ADV_FILTER_ACCEPT_LIST` Kconfig option.
     The option is used instead of :kconfig:option:`CONFIG_BT_FILTER_ACCEPT_LIST` option to enable the filter accept list.
+  * Integrated :ref:`bt_le_adv_prov_readme`.
+    The subsystem is now used instead of the :file:`*.def` file to configure advertising data and scan response data.
   * Bluetooth device name is no longer automatically included in scan response data.
     A dedicated data provider (:kconfig:option:`CONFIG_BT_LE_ADV_PROV_DEVICE_NAME`) can be used to add the Bluetooth device name to the scan response data.
 


### PR DESCRIPTION
Change updates documentation of CAF Bluetooth LE advertising module to inform about configuration of advertising data using Bluetooth LE providers subsystem.

Jira: NCSDK-16352