### PR TITLE
applications: nrf5340_audio: Fix PACS sampling rate and location issue

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -133,9 +133,9 @@ static void unicast_client_location_cb(struct bt_conn *conn, enum bt_audio_dir d
 {
 	int ret;
 
-	if (loc == BT_AUDIO_LOCATION_SIDE_LEFT) {
+	if (loc == BT_AUDIO_LOCATION_FRONT_LEFT) {
 		headset_conn[AUDIO_CH_L] = conn;
-	} else if (loc == BT_AUDIO_LOCATION_SIDE_RIGHT) {
+	} else if (loc == BT_AUDIO_LOCATION_FRONT_RIGHT) {
 		headset_conn[AUDIO_CH_R] = conn;
 	} else {
 		LOG_ERR("Channel location not supported");

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -38,7 +38,7 @@ static const struct bt_data ad_peer[] = {
 static le_audio_receive_cb receive_cb;
 static struct bt_audio_capability_ops lc3_cap_codec_ops;
 static struct bt_codec lc3_codec =
-	BT_CODEC_LC3(BT_CODEC_LC3_FREQ_ANY, BT_CODEC_LC3_DURATION_10, CHANNEL_COUNT_1,
+	BT_CODEC_LC3(BT_CODEC_LC3_FREQ_48KHZ, BT_CODEC_LC3_DURATION_10, CHANNEL_COUNT_1,
 		     LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MIN),
 		     LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE_MAX), 1u,
 		     BT_AUDIO_CONTEXT_TYPE_MEDIA);


### PR DESCRIPTION
Fix PACS support sampling rate from ANY to 48KHz.
Update channel location check in CIS gateway.

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>