### PR TITLE
Update documentation with upmerge changes

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -759,7 +759,7 @@ zcbor
 =====
 
 The `zcbor`_ module has been updated from version 0.4.0 to 0.5.1.
-Release notes for 0.5.0 and 0.5.1 can be found in :file:`ncs/nrf/modules/lib/zcbor/RELEASE_NOTES.md`.
+Release notes for 0.5.0 and 0.5.1 can be found in :file:`ncs/modules/lib/zcbor/RELEASE_NOTES.md`.
 :ref:`lib_fmfu_fdev` code has been regenerated using zcbor 0.5.1.
 
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -41,6 +41,8 @@ Partition Manager
 * Added :kconfig:option:`CONFIG_PM_PARTITION_REGION_LITTLEFS_EXTERNAL`, :kconfig:option:`CONFIG_PM_PARTITION_REGION_SETTINGS_STORAGE_EXTERNAL`, and :kconfig:option:`CONFIG_PM_PARTITION_REGION_NVS_STORAGE_EXTERNAL` to specify that the relevant partition must be located in external flash memory.
   You must add a ``chosen`` entry for ``nordic,pm-ext-flash`` in your devicetree to make this option available.
   See :file:`tests/subsys/partition_manager/region` for example configurations.
+* Added :kconfig:option:`CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK` to override the external driver check.
+  This is needed when using an external flash which is not using the :ref:`QSPI NOR <zephyr:dtbinding_nordic_qspi_nor>` driver from Zephyr.
 
 Protocols
 =========

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -739,21 +739,21 @@ Zephyr
 
 .. NOTE TO MAINTAINERS: All the Zephyr commits in the below git commands must be handled specially after each upmerge and each NCS release.
 
-The Zephyr fork in |NCS| (``sdk-zephyr``) contains all commits from the upstream Zephyr repository up to and including ``fb802fb6c0af80dbd383e744065bcf1745ecbc66``, plus some |NCS| specific additions.
+The Zephyr fork in |NCS| (``sdk-zephyr``) contains all commits from the upstream Zephyr repository up to and including ``71ef669ea4a73495b255f27024bcd5d542bf038c``, plus some |NCS| specific additions.
 
 For the list of upstream Zephyr commits (not including cherry-picked commits) incorporated into nRF Connect SDK since the most recent release, run the following command from the :file:`ncs/zephyr` repository (after running ``west update``):
 
 .. code-block:: none
 
-   git log --oneline fb802fb6c0 ^45ef0d2
+   git log --oneline 71ef669ea4 ^45ef0d2
 
 For the list of |NCS| specific commits, including commits cherry-picked from upstream, run:
 
 .. code-block:: none
 
-   git log --oneline manifest-rev ^fb802fb6c0
+   git log --oneline manifest-rev ^71ef669ea4
 
-The current |NCS| main branch is based on revision ``fb802fb6c0`` of Zephyr.
+The current |NCS| main branch is based on revision ``71ef669ea4`` of Zephyr.
 
 zcbor
 =====

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -728,13 +728,29 @@ Unity
 MCUboot
 =======
 
-The MCUboot fork in |NCS| (``sdk-mcuboot``) contains all commits from the upstream MCUboot repository up to and including ``e86f575f68fdac2cab1898e0a893c8c6d8fd0fa1``, plus some |NCS| specific additions.
+The MCUboot fork in |NCS| (``sdk-mcuboot``) contains all commits from the upstream MCUboot repository up to and including ``1d4404116a9a6b54d54ea9aa3dd2575286e666cd``, plus some |NCS| specific additions.
 
 The code for integrating MCUboot into |NCS| is located in the :file:`ncs/nrf/modules/mcuboot` folder.
 
 The following list summarizes both the main changes inherited from upstream MCUboot and the main changes applied to the |NCS| specific additions:
 
-* |no_changes_yet_note|
+* boot_serial:
+
+  * Refactored and optimized the code, mainly in what affects the progressive erase implementation.
+  * Fixed a compilation issue with the echo command code.
+  * Upgraded from cddl-gen v0.1.0 to zcbor v0.4.0.
+
+* imgtool: Added support for providing signature through a third party.
+
+* zephyr:
+
+  * Added initial support for leveraging the RAM-LOAD mode with the zephyr-rtos port.
+  * Added the MCUboot status callback support.
+    See :kconfig:option:`CONFIG_MCUBOOT_ACTION_HOOKS`.
+  * Edited includes to have the ``zephyr/`` prefix.
+  * Edited the DFU detection's GPIO-pin configuration to be done through DTS using the ``mcuboot-button0`` pin alias.
+  * Edited the LED usage to prefer DTS' ``mcuboot-led0`` alias over the ``bootloader-led0`` alias.
+  * Removed :c:func:`device_get_binding()` usage in favor of :c:func:`DEVICE_DT_GET()`.
 
 Zephyr
 ======

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -523,6 +523,9 @@ After the ``nordic,pm-ext-flash`` value is set, you can place partitions in the 
      region: external_flash
      size: CONFIG_EXTERNAL_PLZ_SIZE
 
+.. note::
+    If the external flash device is not using the :ref:`QSPI NOR <zephyr:dtbinding_nordic_qspi_nor>` driver, :kconfig:option:`CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK` must be enabled to override the Partition Manager's external flash driver check, and the required driver must also be enabled for all applications that need it.
+
 See :ref:`ug_bootloader_external_flash` for more details on using external flash memory with MCUboot.
 
 .. _pm_build_system:


### PR DESCRIPTION
Updates the release note documentation to have the zephyr commit
details resulting from the latest upmerge