### PR TITLE
lib: nrf_modem: update diagnostic code

### DIFF
--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -303,12 +303,11 @@ When the Modem library is initialized by the integration layer in |NCS|, the int
 Diagnostic functionality
 ************************
 
-The Modem library integration layer in |NCS| provides some diagnostic functionalities to log the allocations on the Modem library heap and the TX memory region.
-These functionalities can be turned on by the :kconfig:option:`CONFIG_NRF_MODEM_LIB_DEBUG_ALLOC` and :kconfig:option:`CONFIG_NRF_MODEM_LIB_DEBUG_SHM_TX_ALLOC` options.
+The Modem library integration layer in |NCS| provides some memory diagnostic functionality that is enabled by the :kconfig:option:`CONFIG_NRF_MODEM_LIB_MEM_DIAG` option.
 
-The contents of both the Modem library heap and the TX memory region can be examined through the :c:func:`nrf_modem_lib_heap_diagnose` and :c:func:`nrf_modem_lib_shm_tx_diagnose` functions, respectively.
-Additionally, it is possible to schedule a periodic report of the contents of these two areas of memory by using the :kconfig:option:`CONFIG_NRF_MODEM_LIB_HEAP_DUMP_PERIODIC` and :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHM_TX_DUMP_PERIODIC` options, respectively.
-The report will be printed by a dedicated work queue that is distinct from the system work queue at configurable time intervals.
+The application can retrieve runtime statistics for the library and TX memory region heaps by enabling the :kconfig:option:`CONFIG_NRF_MODEM_LIB_MEM_DIAG` option and calling the :c:func:`nrf_modem_lib_diag_stats_get` function.
+The application can schedule a periodic report of the runtime statistics of the library and TX memory region heaps, by enabling the :kconfig:option:`CONFIG_NRF_MODEM_LIB_MEM_DIAG_DUMP` option.
+The application can log the allocations on the Modem library heap and the TX memory region by enabling the :kconfig:option:`CONFIG_NRF_MODEM_LIB_MEM_DIAG_ALLOC` option.
 
 API documentation
 *****************

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -593,6 +593,10 @@ Modem libraries
         The modem trace output is now handled by a dedicated thread that starts automatically.
         The trace thread is synchronized with the initialization and shutdown operations of the Modem library.
       * The Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_ENABLED` is replaced by the Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE`. The Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_ENABLED` is now deprecated and will be removed in the future.
+      * Added the :kconfig:option:`CONFIG_NRF_MODEM_LIB_MEM_DIAG` option to enable the :c:func:`nrf_modem_lib_diag_stats_get` function that retrieves memory runtime statistics, replacing the ``nrf_modem_lib_heap_diagnose`` and ``nrf_modem_lib_shm_tx_diagnose`` functions.
+      * Consolidated ``CONFIG_NRF_MODEM_LIB_DEBUG_ALLOC`` and ``CONFIG_NRF_MODEM_LIB_DEBUG_SHM_TX_ALLOC`` into the new :kconfig:option:`CONFIG_NRF_MODEM_LIB_MEM_DIAG_ALLOC` option.
+      * Consolidated ``CONFIG_NRF_MODEM_LIB_HEAP_DUMP_PERIODIC`` and ``CONFIG_NRF_MODEM_LIB_SHM_TX_DUMP_PERIODIC`` into the new :kconfig:option:`CONFIG_NRF_MODEM_LIB_MEM_DIAG_DUMP` option.
+      * Consolidated ``CONFIG_NRF_MODEM_LIB_HEAP_DUMP_PERIOD_MS`` and ``CONFIG_NRF_MODEM_LIB_SHMEM_TX_DUMP_PERIOD_MS`` into the new :kconfig:option:`CONFIG_NRF_MODEM_LIB_MEM_DIAG_DUMP_PERIOD_MS` option.
 
     * Removed:
 
@@ -603,11 +607,19 @@ Modem libraries
         * ``CONFIG_NRF_MODEM_LIB_TRACE_HEAP_SIZE_OVERRIDE``
         * ``CONFIG_NRF_MODEM_LIB_TRACE_HEAP_DUMP_PERIODIC``
         * ``CONFIG_NRF_MODEM_LIB_TRACE_HEAP_DUMP_PERIOD_MS``
+        * ``CONFIG_NRF_MODEM_LIB_DEBUG_ALLOC``
+        * ``CONFIG_NRF_MODEM_LIB_DEBUG_SHM_TX_ALLOC``
+        * ``CONFIG_NRF_MODEM_LIB_HEAP_DUMP_PERIODIC``
+        * ``CONFIG_NRF_MODEM_LIB_HEAP_DUMP_PERIOD_MS``
+        * ``CONFIG_NRF_MODEM_LIB_SHM_TX_DUMP_PERIODIC``
+        * ``CONFIG_NRF_MODEM_LIB_SHMEM_TX_DUMP_PERIOD_MS``
 
       * The following functions:
 
         * ``nrf_modem_lib_trace_start``
         * ``nrf_modem_lib_trace_stop``
+        * ``nrf_modem_lib_heap_diagnose``
+        * ``nrf_modem_lib_shm_tx_diagnose``
 
   * :ref:`lib_location` library:
 

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -10,6 +10,10 @@
 #include <zephyr/kernel.h>
 #include <nrf_modem.h>
 
+#if CONFIG_NRF_MODEM_LIB_MEM_DIAG
+#include <zephyr/sys/sys_heap.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -137,22 +141,34 @@ int nrf_modem_lib_get_init_ret(void);
 int nrf_modem_lib_shutdown(void);
 
 /**
- * @brief Print diagnostic information for the TX heap.
- */
-void nrf_modem_lib_shm_tx_diagnose(void);
-
-/**
- * @brief Print diagnostic information for the library heap.
- */
-void nrf_modem_lib_heap_diagnose(void);
-
-/**
  * @brief Modem fault handler.
  *
  * @param[in] fault_info Modem fault information.
  *			 Contains the fault reason and, in some cases, the modem program counter.
  */
 void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault_info);
+
+#if defined(CONFIG_NRF_MODEM_LIB_MEM_DIAG) || defined(__DOXYGEN__)
+
+struct nrf_modem_lib_diag_stats {
+	struct {
+		struct sys_memory_stats heap;
+		uint32_t failed_allocs;
+	} library;
+	struct {
+		struct sys_memory_stats heap;
+		uint32_t failed_allocs;
+	} shmem;
+};
+
+/**
+ * @brief Retrieve heap runtime statistics.
+ *
+ * Retrieve runtime statistics for the shared memory and library heaps.
+ */
+int nrf_modem_lib_diag_stats_get(struct nrf_modem_lib_diag_stats *stats);
+
+#endif /* defined(CONFIG_NRF_MODEM_LIB_MEM_DIAG) || defined(__DOXYGEN__) */
 
 /** @} */
 

--- a/lib/nrf_modem_lib/CMakeLists.txt
+++ b/lib/nrf_modem_lib/CMakeLists.txt
@@ -7,6 +7,7 @@
 zephyr_library()
 zephyr_library_sources(nrf_modem_lib.c)
 zephyr_library_sources(nrf_modem_os.c)
+zephyr_library_sources_ifdef(CONFIG_NRF_MODEM_LIB_MEM_DIAG diag.c)
 zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS nrf91_sockets.c)
 
 if(CONFIG_NRF_MODEM_LIB_TRACE)

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -147,20 +147,17 @@ choice NRF_MODEM_LIB_ON_FAULT
 config NRF_MODEM_LIB_ON_FAULT_DO_NOTHING
 	bool "Do nothing"
 	help
-	  Do nothing but log the fault if the application is notified of a fault in the modem.
+	  Let the fault handler log the fault and return.
 
 config NRF_MODEM_LIB_ON_FAULT_RESET_MODEM
 	bool "Reset modem"
 	help
-	  If the application is notified of a fault in the modem it will shut down and reinitialize
-	  the modem and modem library. The reinitialization will destroy all sockets and state of
-	  the modem, and it is up to the application to recover properly.
+	  Let the fault handler reset the modem.
 
 config NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
 	bool "Application defined"
 	help
-	  If the application is notified of a fault in the modem it will call an application
-	  specific handler named nrf_modem_fault_handler.
+	  Let the application define the fault handler function.
 
 endchoice # NRF_MODEM_LIB_ON_FAULT
 

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -161,41 +161,33 @@ config NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC
 
 endchoice # NRF_MODEM_LIB_ON_FAULT
 
-menu "Diagnostics"
-
-config NRF_MODEM_LIB_DEBUG_ALLOC
-	depends on LOG
-	bool "Debug allocations on the library heap"
+menuconfig NRF_MODEM_LIB_MEM_DIAG
+	bool "Memory diagnostic"
+	select SYS_HEAP_LISTENER
+	select SYS_HEAP_RUNTIME_STATS
 	help
-	   Log all nrf_modem_os_alloc() and nrf_modem_os_free() calls.
+	  Keep track of the library and shared memory heap usage.
 
-config NRF_MODEM_LIB_DEBUG_SHM_TX_ALLOC
-	depends on LOG
-	bool "Debug allocations on the TX region"
+if (NRF_MODEM_LIB_MEM_DIAG && LOG)
+
+config NRF_MODEM_LIB_MEM_DIAG_ALLOC
+	bool "Log all memory allocations"
 	help
-	  Log all nrf_modem_os_shm_tx_alloc() and nrf_modem_os_shm_tx_free() calls.
+	   Log all nrf_modem_os_alloc(), nrf_modem_os_free()
+	   nrf_modem_os_shm_tx_alloc() and nrf_modem_os_shm_tx_free() calls.
 
-config NRF_MODEM_LIB_HEAP_DUMP_PERIODIC
-	bool "Periodically print library heap info"
+config NRF_MODEM_LIB_MEM_DIAG_DUMP
+	bool "Periodically log shared memory and heap statistics"
 	help
-	  Schedule a periodic system workqueue task to print the library heap info.
+	  Schedule a periodic system workqueue task to print
+	  the library and shared memory heap runtime statistics.
 
-config NRF_MODEM_LIB_HEAP_DUMP_PERIOD_MS
-	depends on NRF_MODEM_LIB_HEAP_DUMP_PERIODIC
+config NRF_MODEM_LIB_MEM_DIAG_DUMP_PERIOD_MS
+	depends on NRF_MODEM_LIB_MEM_DIAG_DUMP
 	int "Period (millisec)"
 	default 20000
 
-config NRF_MODEM_LIB_SHM_TX_DUMP_PERIODIC
-	bool "Periodically print the TX region heap info"
-	help
-	  Schedule a periodic system workqueue task to print the library TX region heap info.
-
-config NRF_MODEM_LIB_SHMEM_TX_DUMP_PERIOD_MS
-	depends on NRF_MODEM_LIB_SHM_TX_DUMP_PERIODIC
-	int "Period (millisec)"
-	default 20000
-
-endmenu
+endif
 
 module = NRF_MODEM_LIB
 module-str = Modem library

--- a/lib/nrf_modem_lib/diag.c
+++ b/lib/nrf_modem_lib/diag.c
@@ -1,0 +1,117 @@
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/sys/heap_listener.h>
+#include <zephyr/logging/log.h>
+#include <modem/nrf_modem_lib.h>
+
+LOG_MODULE_DECLARE(nrf_modem, CONFIG_NRF_MODEM_LIB_LOG_LEVEL);
+
+/* extern in nrf_modem_os.c */
+uint32_t nrf_modem_lib_shmem_failed_allocs;	/* failed allocations on shared memory heap */
+uint32_t nrf_modem_lib_failed_allocs;		/* failed allocations on library heap */
+
+/* from nrf_modem_os.c */
+extern struct k_heap nrf_modem_lib_shmem_heap;
+extern struct k_heap nrf_modem_lib_heap;
+
+#if CONFIG_NRF_MODEM_LIB_MEM_DIAG_DUMP
+static struct k_work_delayable diag_work;
+#endif
+
+int nrf_modem_lib_diag_stats_get(struct nrf_modem_lib_diag_stats *stats)
+{
+	if (!stats) {
+		return -EFAULT;
+	}
+
+	sys_heap_runtime_stats_get(&nrf_modem_lib_shmem_heap.heap, &stats->shmem.heap);
+	sys_heap_runtime_stats_get(&nrf_modem_lib_heap.heap, &stats->library.heap);
+
+	stats->shmem.failed_allocs = nrf_modem_lib_shmem_failed_allocs;
+	stats->library.failed_allocs = nrf_modem_lib_failed_allocs;
+
+	return 0;
+}
+
+#if CONFIG_NRF_MODEM_LIB_MEM_DIAG_ALLOC
+static void on_heap_alloc(uintptr_t heap_id, void *mem, size_t bytes)
+{
+	LOG_INF("lib alloc %p, size %u", mem, bytes);
+}
+
+static void on_heap_free(uintptr_t heap_id, void *mem, size_t bytes)
+{
+	LOG_INF("lib free  %p, size %u", mem, bytes);
+}
+
+static void on_shmem_alloc(uintptr_t heap_id, void *mem, size_t bytes)
+{
+	LOG_INF("shm alloc %p, size %u", mem, bytes);
+}
+
+static void on_shmem_free(uintptr_t heap_id, void *mem, size_t bytes)
+{
+	LOG_INF("shm free  %p, size %u", mem, bytes);
+}
+#endif
+
+#if CONFIG_NRF_MODEM_LIB_MEM_DIAG_DUMP
+static void diag_task(struct k_work *item)
+{
+	struct nrf_modem_lib_diag_stats stats = { 0 };
+
+	(void)nrf_modem_lib_diag_stats_get(&stats);
+
+	LOG_INF("shm: free %.4u, allocated %.4u, max allocated %.4u, failed %u",
+		stats.shmem.heap.free_bytes, stats.shmem.heap.allocated_bytes,
+		stats.shmem.heap.max_allocated_bytes, nrf_modem_lib_shmem_failed_allocs);
+	LOG_INF("lib: free %.4u, allocated %.4u, max allocated %.4u, failed %u",
+		stats.library.heap.free_bytes, stats.library.heap.allocated_bytes,
+		stats.library.heap.max_allocated_bytes, nrf_modem_lib_failed_allocs);
+
+	k_work_reschedule(&diag_work, K_MSEC(CONFIG_NRF_MODEM_LIB_MEM_DIAG_DUMP_PERIOD_MS));
+}
+#endif
+
+static int nrf_modem_lib_diag_sys_init(const struct device *unused)
+{
+#if CONFIG_NRF_MODEM_LIB_MEM_DIAG_ALLOC
+	static HEAP_LISTENER_ALLOC_DEFINE(
+		shmem_alloc_listener,
+		HEAP_ID_FROM_POINTER(&nrf_modem_lib_shmem_heap.heap),
+		on_shmem_alloc);
+
+	static HEAP_LISTENER_FREE_DEFINE(
+		shmem_free_listener,
+		HEAP_ID_FROM_POINTER(&nrf_modem_lib_shmem_heap.heap),
+		on_shmem_free);
+
+	heap_listener_register(&shmem_alloc_listener);
+	heap_listener_register(&shmem_free_listener);
+
+	static HEAP_LISTENER_ALLOC_DEFINE(
+		heap_alloc_listener,
+		HEAP_ID_FROM_POINTER(&nrf_modem_lib_heap.heap),
+		on_heap_alloc);
+
+	static HEAP_LISTENER_FREE_DEFINE(
+		heap_free_listener,
+		HEAP_ID_FROM_POINTER(&nrf_modem_lib_heap.heap),
+		on_heap_free);
+
+	heap_listener_register(&heap_alloc_listener);
+	heap_listener_register(&heap_free_listener);
+#endif
+
+#if CONFIG_NRF_MODEM_LIB_MEM_DIAG_DUMP
+	k_work_init_delayable(&diag_work, diag_task);
+	k_work_reschedule(&diag_work, K_MSEC(CONFIG_NRF_MODEM_LIB_MEM_DIAG_DUMP_PERIOD_MS));
+#endif
+
+	LOG_INF("Diagnostic initialized");
+
+	return 0;
+}
+
+SYS_INIT(nrf_modem_lib_diag_sys_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Use the new `SYS_HEAP_LISTENER` and `SYS_HEAP_RUNTIME_STATS` from Zephyr to keep track of allocations and runtime statistics. Moved diagnostic code into a separate C file and consolidated the Kconfig options.

Introduce `NRF_MODEM_LIB_MEM_DIAG` option to let the application retrieve heap runtime statistics using `nrf_modem_lib_diag_stats_get()`, replacing `nrf_modem_lib_heap_diagnose()` and `nrf_modem_lib_shm_tx_diagnose()`, which are removed.

Consolidated Kconfig options.