### PR TITLE
bluetooth: fast_pair: Use per-connection authentication cbs

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
@@ -62,7 +62,6 @@ Bluetooth Security Manager Protocol (SMP)
 
 The service selects :kconfig:option:`CONFIG_BT_SMP` and :kconfig:option:`CONFIG_BT_SMP_APP_PAIRING_ACCEPT`.
 The Fast Pair specification requires support for Bluetooth LE pairing.
-During an ongoing Fast Pair procedure, peers using a normal Bluetooth LE bonding procedures are rejected by the service to prevent reporting invalid bonding capabilities.
 
 Firmware Revision characteristic
 --------------------------------
@@ -109,22 +108,13 @@ No application input is required to handle the requests.
 Bluetooth authentication
 ========================
 
-The Fast Pair service overrides the set of Zephyr's Bluetooth authentication callbacks (:c:struct:`bt_conn_auth_cb`) while handling Key-Based Pairing request.
-The callbacks are updated to report proper device capabilities for Bluetooth LE pairing request/response packets.
-Overriding callbacks allows the GFPS to take over Bluetooth authentication during `Fast Pair Procedure`_ and perform all of the required operations without interacting with the application.
-After the procedure is finished, the previously used callbacks are assigned back.
+The Bluetooth pairing is handled using a set of Bluetooth authentication callbacks (:c:struct:`bt_conn_auth_cb`).
+The pairing flow and the set of Bluetooth authentication callbacks in use depend on whether the connected peer follows the Fast Pair pairing flow:
 
-The Fast Pair Provider can still bond using a normal Bluetooth LE bonding procedures, without using Fast Pair.
-The normal Bluetooth LE bonding procedure can be used, for example, if the connected Bluetooth Central does not support Fast Pair.
-In that case, the bonding uses Bluetooth authentication callbacks registered by the application.
-
-.. note::
-   Zephyr supports only one set of Bluetooth authentication callbacks.
-   Because of this limitation, it is not possible to simultaneously handle bonding using Fast Pair procedure and normal Bluetooth LE bonding.
-   In that case improper device capabilities would be reported.
-
-   Make sure that the normal Bluetooth LE bonding procedure and Fast Pair procedure do no overlap with each other.
-   The recommended approach is to avoid handling more than one bonding procedure at a time.
+* If the peer follows the Fast Pair pairing flow, the Fast Pair service calls :c:func:`bt_conn_auth_cb_overlay` to automatically overlay the Bluetooth authentication callbacks.
+  The function is called while handling the Key-based Pairing request.
+  Overlying callbacks allow the GFPS to take over Bluetooth authentication during `Fast Pair Procedure`_ and perform all of the required operations without interacting with the application.
+* If the peer does not follow the Fast Pair pairing flow, normal Bluetooth LE pairing and global Bluetooth authentication callbacks are used.
 
 API documentation
 *****************


### PR DESCRIPTION
Change switches to using per-connection authentication callbacks.

Jira: NCSDK-16347