### PR TITLE
samples: matter: Added support for DFU over Wi-Fi on nRF7002 DK.

### DIFF
--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -90,7 +90,7 @@
 		};
 	};
 
-	spi4_default: spi4_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
 				<NRF_PSEL(SPIM_MISO, 1, 14)>,
@@ -98,11 +98,28 @@
 		};
 	};
 
-	spi4_sleep: spi4_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
 				<NRF_PSEL(SPIM_MISO, 1, 14)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			low-power-enable;
+		};
+	};
+
+	spi4_default: spi4_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 9)>;
+		};
+	};
+
+	spi4_sleep: spi4_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 9)>;
 			low-power-enable;
 		};
 	};

--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -145,6 +145,32 @@ arduino_i2c: &i2c1 {
 	pinctrl-names = "default", "sleep";
 };
 
+&spi4 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	pinctrl-0 = <&spi4_default>;
+	pinctrl-1 = <&spi4_sleep>;
+	pinctrl-names = "default", "sleep";
+	cs-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+	mx25r64: mx25r6435f@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <33000000>;
+		label = "MX25R64";
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff ff ff ff 03 44 eb 08 6b 08 3b 04 bb
+			ee ff ff ff ff ff 00 ff ff ff 00 ff 0c 20 0f 52
+			10 d8 00 ff 23 72 f5 00 82 ed 04 cc 44 83 68 44
+			30 b0 30 b0 f7 c4 d5 5c 00 be 29 ff f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <5000>;
+	};
+};
+
 &qspi {
 	status = "okay";
 
@@ -187,11 +213,11 @@ arduino_serial: &uart1 {
 	pinctrl-names = "default", "sleep";
 };
 
-arduino_spi: &spi4 {
+arduino_spi: &spi3 {
 	compatible = "nordic,nrf-spim";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
-	pinctrl-0 = <&spi4_default>;
-	pinctrl-1 = <&spi4_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 };
 

--- a/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_switch/child_image/mcuboot/prj.conf
+++ b/samples/matter/light_switch/child_image/mcuboot/prj.conf
@@ -13,7 +13,6 @@ CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
 # Bootloader size optimization
 # Disable not used modules that cannot be set in Kconfig.mcuboot.defaults due to overriding
 # in board files.
-CONFIG_GPIO=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/light_switch/child_image/mcuboot/prj_release.conf
+++ b/samples/matter/light_switch/child_image/mcuboot/prj_release.conf
@@ -13,7 +13,6 @@ CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
 # Bootloader size optimization
 # Disable not used modules that cannot be set in Kconfig.mcuboot.defaults due to overriding
 # in board files.
-CONFIG_GPIO=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/light_switch/configuration/nrf7002dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/samples/matter/light_switch/configuration/nrf7002dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,0 +1,56 @@
+mcuboot:
+    address: 0x0
+    size: 0xC000
+    region: flash_primary
+mcuboot_pad:
+    address: 0xC000
+    size: 0x200
+app:
+    address: 0xC200
+    size: 0xeee00
+mcuboot_primary:
+    orig_span: &id001
+        - mcuboot_pad
+        - app
+    span: *id001
+    address: 0xC000
+    size: 0xef000
+    region: flash_primary
+mcuboot_primary_app:
+    orig_span: &id002
+        - app
+    span: *id002
+    address: 0xC200
+    size: 0xeee00
+factory_data:
+    address: 0xfb000
+    size: 0x1000
+    region: flash_primary
+settings_storage:
+    address: 0xfc000
+    size: 0x4000
+    region: flash_primary
+mcuboot_primary_1:
+    address: 0x0
+    size: 0x40000
+    device: flash_ctrl
+    region: ram_flash
+mcuboot_secondary:
+    address: 0x0
+    size: 0xef000
+    device: MX25R64
+    region: external_flash
+mcuboot_secondary_1:
+    address: 0xef000
+    size: 0x40000
+    device: MX25R64
+    region: external_flash
+external_flash:
+    address: 0x12f000
+    size: 0x6D1000
+    device: MX25R64
+    region: external_flash
+pcd_sram:
+    address: 0x20000000
+    size: 0x2000
+    region: sram_primary

--- a/samples/matter/light_switch/sample.yaml
+++ b/samples/matter/light_switch/sample.yaml
@@ -7,7 +7,8 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.matter.light_switch.no_dfu:
     build_only: true
@@ -25,7 +26,8 @@ tests:
     integration_platforms:
     - nrf52840dk_nrf52840
     - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.matter.light_switch.smp_dfu:
     build_only: true

--- a/samples/matter/light_switch/src/app_task.cpp
+++ b/samples/matter/light_switch/src/app_task.cpp
@@ -395,22 +395,27 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *aEvent, intptr_t /* arg */
 		sHaveBLEConnections = ConnectivityMgr().NumBLEConnections() != 0;
 		UpdateStatusLED();
 		break;
-	case DeviceEventType::kThreadStateChange:
-	case DeviceEventType::kWiFiConnectivityChange:
 #if defined(CONFIG_NET_L2_OPENTHREAD)
-		sIsNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned();
-		sIsNetworkEnabled = ConnectivityMgr().IsThreadEnabled();
-#elif defined(CONFIG_CHIP_WIFI)
-		sIsNetworkProvisioned = ConnectivityMgr().IsWiFiStationProvisioned();
-		sIsNetworkEnabled = ConnectivityMgr().IsWiFiStationEnabled();
-#endif
-		UpdateStatusLED();
-		break;
 	case DeviceEventType::kDnssdPlatformInitialized:
 #if CONFIG_CHIP_OTA_REQUESTOR
 		InitBasicOTARequestor();
-#endif
+#endif /* CONFIG_CHIP_OTA_REQUESTOR */
 		break;
+	case DeviceEventType::kThreadStateChange:
+		sIsNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned();
+		sIsNetworkEnabled = ConnectivityMgr().IsThreadEnabled();
+#elif defined(CONFIG_CHIP_WIFI)
+	case DeviceEventType::kWiFiConnectivityChange:
+		sIsNetworkProvisioned = ConnectivityMgr().IsWiFiStationProvisioned();
+		sIsNetworkEnabled = ConnectivityMgr().IsWiFiStationEnabled();
+#if CONFIG_CHIP_OTA_REQUESTOR
+		if (aEvent->WiFiConnectivityChange.Result == kConnectivity_Established) {
+			InitBasicOTARequestor();
+		}
+#endif /* CONFIG_CHIP_OTA_REQUESTOR */
+		UpdateStatusLED();
+		break;
+#endif
 	default:
 		break;
 	}

--- a/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/lock/child_image/mcuboot/prj.conf
+++ b/samples/matter/lock/child_image/mcuboot/prj.conf
@@ -13,7 +13,6 @@ CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
 # Bootloader size optimization
 # Disable not used modules that cannot be set in Kconfig.mcuboot.defaults due to overriding
 # in board files.
-CONFIG_GPIO=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/lock/child_image/mcuboot/prj_release.conf
+++ b/samples/matter/lock/child_image/mcuboot/prj_release.conf
@@ -13,7 +13,6 @@ CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
 # Bootloader size optimization
 # Disable not used modules that cannot be set in Kconfig.mcuboot.defaults due to overriding
 # in board files.
-CONFIG_GPIO=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/lock/configuration/nrf7002dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/samples/matter/lock/configuration/nrf7002dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,0 +1,56 @@
+mcuboot:
+    address: 0x0
+    size: 0xC000
+    region: flash_primary
+mcuboot_pad:
+    address: 0xC000
+    size: 0x200
+app:
+    address: 0xC200
+    size: 0xeee00
+mcuboot_primary:
+    orig_span: &id001
+        - mcuboot_pad
+        - app
+    span: *id001
+    address: 0xC000
+    size: 0xef000
+    region: flash_primary
+mcuboot_primary_app:
+    orig_span: &id002
+        - app
+    span: *id002
+    address: 0xC200
+    size: 0xeee00
+factory_data:
+    address: 0xfb000
+    size: 0x1000
+    region: flash_primary
+settings_storage:
+    address: 0xfc000
+    size: 0x4000
+    region: flash_primary
+mcuboot_primary_1:
+    address: 0x0
+    size: 0x40000
+    device: flash_ctrl
+    region: ram_flash
+mcuboot_secondary:
+    address: 0x0
+    size: 0xef000
+    device: MX25R64
+    region: external_flash
+mcuboot_secondary_1:
+    address: 0xef000
+    size: 0x40000
+    device: MX25R64
+    region: external_flash
+external_flash:
+    address: 0x12f000
+    size: 0x6D1000
+    device: MX25R64
+    region: external_flash
+pcd_sram:
+    address: 0x20000000
+    size: 0x2000
+    region: sram_primary

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -7,7 +7,8 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.matter.lock.no_dfu:
     build_only: true
@@ -25,7 +26,8 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.matter.lock.smp_dfu:
     build_only: true
@@ -33,7 +35,8 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.matter.lock.no_dfu.nrf7002_ek:
     build_only: true

--- a/samples/matter/lock/src/app_task.cpp
+++ b/samples/matter/lock/src/app_task.cpp
@@ -481,22 +481,27 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 		sHaveBLEConnections = ConnectivityMgr().NumBLEConnections() != 0;
 		UpdateStatusLED();
 		break;
-	case DeviceEventType::kThreadStateChange:
-	case DeviceEventType::kWiFiConnectivityChange:
 #if defined(CONFIG_NET_L2_OPENTHREAD)
-		sIsNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned();
-		sIsNetworkEnabled = ConnectivityMgr().IsThreadEnabled();
-#elif defined(CONFIG_CHIP_WIFI)
-		sIsNetworkProvisioned = ConnectivityMgr().IsWiFiStationProvisioned();
-		sIsNetworkEnabled = ConnectivityMgr().IsWiFiStationEnabled();
-#endif
-		UpdateStatusLED();
-		break;
 	case DeviceEventType::kDnssdPlatformInitialized:
 #if CONFIG_CHIP_OTA_REQUESTOR
 		InitBasicOTARequestor();
-#endif
+#endif /* CONFIG_CHIP_OTA_REQUESTOR */
 		break;
+	case DeviceEventType::kThreadStateChange:
+		sIsNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned();
+		sIsNetworkEnabled = ConnectivityMgr().IsThreadEnabled();
+#elif defined(CONFIG_CHIP_WIFI)
+	case DeviceEventType::kWiFiConnectivityChange:
+		sIsNetworkProvisioned = ConnectivityMgr().IsWiFiStationProvisioned();
+		sIsNetworkEnabled = ConnectivityMgr().IsWiFiStationEnabled();
+#if CONFIG_CHIP_OTA_REQUESTOR
+		if (event->WiFiConnectivityChange.Result == kConnectivity_Established) {
+			InitBasicOTARequestor();
+		}
+#endif /* CONFIG_CHIP_OTA_REQUESTOR */
+		UpdateStatusLED();
+		break;
+#endif
 	default:
 		break;
 	}

--- a/samples/matter/template/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/template/child_image/mcuboot/prj.conf
+++ b/samples/matter/template/child_image/mcuboot/prj.conf
@@ -13,7 +13,6 @@ CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
 # Bootloader size optimization
 # Disable not used modules that cannot be set in Kconfig.mcuboot.defaults due to overriding
 # in board files.
-CONFIG_GPIO=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/template/child_image/mcuboot/prj_release.conf
+++ b/samples/matter/template/child_image/mcuboot/prj_release.conf
@@ -13,7 +13,6 @@ CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
 # Bootloader size optimization
 # Disable not used modules that cannot be set in Kconfig.mcuboot.defaults due to overriding
 # in board files.
-CONFIG_GPIO=n
 CONFIG_CONSOLE=n
 CONFIG_SERIAL=n
 CONFIG_UART_CONSOLE=n

--- a/samples/matter/template/configuration/nrf7002dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/samples/matter/template/configuration/nrf7002dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,0 +1,56 @@
+mcuboot:
+    address: 0x0
+    size: 0xC000
+    region: flash_primary
+mcuboot_pad:
+    address: 0xC000
+    size: 0x200
+app:
+    address: 0xC200
+    size: 0xeee00
+mcuboot_primary:
+    orig_span: &id001
+        - mcuboot_pad
+        - app
+    span: *id001
+    address: 0xC000
+    size: 0xef000
+    region: flash_primary
+mcuboot_primary_app:
+    orig_span: &id002
+        - app
+    span: *id002
+    address: 0xC200
+    size: 0xeee00
+factory_data:
+    address: 0xfb000
+    size: 0x1000
+    region: flash_primary
+settings_storage:
+    address: 0xfc000
+    size: 0x4000
+    region: flash_primary
+mcuboot_primary_1:
+    address: 0x0
+    size: 0x40000
+    device: flash_ctrl
+    region: ram_flash
+mcuboot_secondary:
+    address: 0x0
+    size: 0xef000
+    device: MX25R64
+    region: external_flash
+mcuboot_secondary_1:
+    address: 0xef000
+    size: 0x40000
+    device: MX25R64
+    region: external_flash
+external_flash:
+    address: 0x12f000
+    size: 0x6D1000
+    device: MX25R64
+    region: external_flash
+pcd_sram:
+    address: 0x20000000
+    size: 0x2000
+    region: sram_primary

--- a/samples/matter/template/sample.yaml
+++ b/samples/matter/template/sample.yaml
@@ -7,7 +7,8 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.matter.template.release:
     build_only: true
@@ -15,7 +16,8 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
     tags: ci_build
   sample.matter.template.no_dfu:
     build_only: true

--- a/samples/matter/template/src/app_task.cpp
+++ b/samples/matter/template/src/app_task.cpp
@@ -287,22 +287,27 @@ void AppTask::ChipEventHandler(const ChipDeviceEvent *event, intptr_t /* arg */)
 		sHaveBLEConnections = ConnectivityMgr().NumBLEConnections() != 0;
 		UpdateStatusLED();
 		break;
-	case DeviceEventType::kThreadStateChange:
-	case DeviceEventType::kWiFiConnectivityChange:
 #if defined(CONFIG_NET_L2_OPENTHREAD)
-		sIsNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned();
-		sIsNetworkEnabled = ConnectivityMgr().IsThreadEnabled();
-#elif defined(CONFIG_CHIP_WIFI)
-		sIsNetworkProvisioned = ConnectivityMgr().IsWiFiStationProvisioned();
-		sIsNetworkEnabled = ConnectivityMgr().IsWiFiStationEnabled();
-#endif
-		UpdateStatusLED();
-		break;
 	case DeviceEventType::kDnssdPlatformInitialized:
 #if CONFIG_CHIP_OTA_REQUESTOR
 		InitBasicOTARequestor();
-#endif
+#endif /* CONFIG_CHIP_OTA_REQUESTOR */
 		break;
+	case DeviceEventType::kThreadStateChange:
+		sIsNetworkProvisioned = ConnectivityMgr().IsThreadProvisioned();
+		sIsNetworkEnabled = ConnectivityMgr().IsThreadEnabled();
+#elif defined(CONFIG_CHIP_WIFI)
+	case DeviceEventType::kWiFiConnectivityChange:
+		sIsNetworkProvisioned = ConnectivityMgr().IsWiFiStationProvisioned();
+		sIsNetworkEnabled = ConnectivityMgr().IsWiFiStationEnabled();
+#if CONFIG_CHIP_OTA_REQUESTOR
+		if (event->WiFiConnectivityChange.Result == kConnectivity_Established) {
+			InitBasicOTARequestor();
+		}
+#endif /* CONFIG_CHIP_OTA_REQUESTOR */
+		UpdateStatusLED();
+		break;
+#endif
 	default:
 		break;
 	}

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: a8afe86ea54fce40caa8d170e1f45135ca561115
+      revision: 98f29c5e9e1c15440b6a20eea3f021c900d2bf56
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
For Matter:
* Added initialization of OTA requestor for Wi-Fi build
* Added pm_static and overlay for nRF7002dk
* Bumped sdk-connectedhomeip to pull support for SPI_NOR

For nRF7002DK board:
* Modified spi4 pinctrl to use pins that are connected
with external flash chip
* Added spi3 pinctrl using the same pins that spi4 used to do
* Modified spi4 property by adding mx25r64 external flash chip
* Changed arduino spi to use spi3 instead of spi4

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>