### PR TITLE
boards: thingy91: Add mcuboot button aliases in dts

### DIFF
--- a/boards/arm/thingy91_nrf52840/thingy91_nrf52840.dts
+++ b/boards/arm/thingy91_nrf52840/thingy91_nrf52840.dts
@@ -18,6 +18,19 @@
 		zephyr,sram = &sram0;
 		zephyr,uart-mcumgr = &uart0;
 	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		button0: button_0 {
+			gpios = <&gpio1 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Button 1";
+		};
+	};
+
+	aliases {
+		mcuboot-button0 = &button0;
+	};
 };
 
 &adc {

--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_common.dts
@@ -84,6 +84,7 @@
 		pwm-led2 = &pwm_led2;
 		rgb-pwm = &pwm0;
 		nmos-pwm = &pwm2;
+		mcuboot-button0 = &button0;
 	};
 };
 


### PR DESCRIPTION
This fixes an issue from last upmerge where using
the button to activate serial recovery mode was
not working for thingy91 boards.

Signed-off-by: Jorgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>