### PR TITLE
Feature/update pip dependencies to support apple m1

### DIFF
--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -21,7 +21,7 @@ cmsis-pack-manager==0.2.10
 colorama==0.4.4
 commonmark==0.9.1
 coverage==5.4
-cryptography==3.3.1
+cryptography==37.0.4
 docopt==0.6.2
 docutils==0.16
 ecdsa==0.16.1

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -59,7 +59,7 @@ psutil==5.8.0
 py==1.10.0
 pycparser==2.20
 pyelftools==0.27
-pygit2==1.6.1
+pygit2==1.10.0
 Pygments==2.7.4
 pykwalify==1.8.0
 pylink-square==0.8.1

--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -21,7 +21,7 @@ cmsis-pack-manager==0.2.10
 colorama==0.4.4
 commonmark==0.9.1
 coverage==5.4
-cryptography==37.0.4
+cryptography==3.4.8
 docopt==0.6.2
 docutils==0.16
 ecdsa==0.16.1


### PR DESCRIPTION
Currently, on main there are two pip-packages that normally relies on pre-built binaries from pip, but who don't have these binaries built for M1 on the provided versions. Updating these packages to the newest solves this problem and allows us to build this bundle. 

This PR is not the end-all be-all for which versions can be used, since multiple versions of the packages support m1. (For cryptography, both version `3.4.8` and version `37.0.4` should work.)