### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: f7b06162027da4421bd7df097137b601a21ceb8d
+      revision: 7b8a7f423dc838d874d2489f3c3f88280df83ba4
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update the zephyr module revision to pull in a pinctrl fix related
to S0D1 drive for TWI/TWIM peripherals.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>