### PR TITLE
[backport-v2.0] manifest: Update Zephyr revision

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -203,7 +203,7 @@ add_custom_target(
   COMMENT "Generating Devicetree bindings documentation..."
 )
 
-add_docset(zephyr)
+add_docset(zephyr DODGY)
 add_dependencies(zephyr zephyr-devicetree)
 add_dependencies(zephyr-all zephyr-devicetree)
 

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -9,4 +9,4 @@ pyyaml
 azure-storage-blob
 sphinx_markdown_tables
 mistune<2.0 # Workaround for https://github.com/CrossNox/m2r2/issues/40
-breathe<4.33 # Workaround for #803 and #805 breathe issues
+breathe>=4.34

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.0.99-ncs1-1
+      revision: 5954b3a94af20a0f7a5ab350510906476b936fdf
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update the zephyr module revision to pull in a pinctrl fix related
to S0D1 drive for TWI/TWIM peripherals.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>