### PR TITLE
doc: software_maturity: add entries for HomeKit

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -35,12 +35,12 @@ features:
     Matter - Amazon Frustration Free Setup support: CHIP && BT && CHIP_ROTATING_DEVICE_ID && CHIP_COMMISSIONABLE_DEVICE_TYPE
     Matter Sleepy End Device: CHIP && CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT && NET_L2_OPENTHREAD && OPENTHREAD_MTD_SED
   homekit:
-    HomeKit over Bluetooth LE: HOMEKIT && BT
-    HomeKit over Thread FTD: HOMEKIT && BT && NET_L2_OPENTHREAD && OPENTHREAD_FTD
-    HomeKit over Thread MTD SED: HOMEKIT && BT && NET_L2_OPENTHREAD && OPENTHREAD_MTD && OPENTHREAD_MTD_SED
-    HomeKit commissioning over Bluetooth LE with QR code: HOMEKIT && BT
-    HomeKit commissioning over Bluetooth LE with NFC: HOMEKIT && BT && CONFIG_HAP_HAVE_NFC && CONFIG_NFC_NDEF
-    HomeKit - OTA DFU over Bluetooth LE: HOMEKIT && BT && MCUMGR_SMP_BT && HOMEKIT_NORDIC_DFU
+    HomeKit over Bluetooth LE: HOMEKIT && BT && !CONFIG_HAP_HAVE_THREAD
+    HomeKit over Thread FTD: HOMEKIT && BT && OPENTHREAD_FTD
+    HomeKit over Thread MTD SED: HOMEKIT && BT && OPENTHREAD_MTD_SED
+    HomeKit commissioning over Bluetooth LE with QR code: HOMEKIT && BT && !CONFIG_HAP_HAVE_NFC
+    HomeKit commissioning over Bluetooth LE with NFC: HOMEKIT && BT && CONFIG_HAP_HAVE_NFC
+    HomeKit - OTA DFU over Bluetooth LE: HOMEKIT && HOMEKIT_NORDIC_DFU
     HomeKit - OTA DFU over HomeKit: HOMEKIT && BT && CONFIG_HAP_FIRMWARE_UPDATE
   trusted_firmware_m:
     Minimal Build: BUILD_WITH_TFM && TFM_PROFILE_TYPE_MINIMAL

--- a/west.yml
+++ b/west.yml
@@ -146,7 +146,7 @@ manifest:
       revision: c6af068b7f05207b28d68880740e4b9ec1e4b50a
     - name: homekit
       repo-path: sdk-homekit
-      revision: 4296c2ad29120d3f7897e996623857d89554e2ff
+      revision: ef2b2e156a65a5920585e5de26132b0221139ed5
       groups:
       - homekit
     - name: find-my


### PR DESCRIPTION
Added KConfig rules to yaml input file for HomeKit.

Signed-off-by: Mariusz Poslinski <mariusz.poslinski@nordicsemi.no>