### PR TITLE
applications: nrf5340_audio: Turn on ISO_LOST_NOTIFY

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/ble_core.c
+++ b/applications/nrf5340_audio/src/bluetooth/ble_core.c
@@ -80,6 +80,11 @@ static void mac_print(void)
 	LOG_INF("MAC: %s", dev);
 }
 
+static int ble_core_le_lost_notify_enable(void)
+{
+	return ble_hci_vsc_set_op_flag(BLE_HCI_VSC_OP_ISO_LOST_NOTIFY, 1);
+}
+
 /* Callback called by the Bluetooth stack in Zephyr when Bluetooth is ready */
 static void on_bt_ready(int err)
 {
@@ -98,6 +103,9 @@ static void on_bt_ready(int err)
 	ERR_CHK_MSG(ret, "Failed to get controller version");
 
 	LOG_INF("Controller version: %d", ctrl_version);
+
+	ble_core_le_lost_notify_enable();
+
 	m_ready_callback();
 }
 


### PR DESCRIPTION
- Enable bad_frame flags from controller

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>