### PR TITLE
samples: matter: use common configuration for hci_rpmsg image

### DIFF
--- a/doc/nrf/ug_matter_gs_kconfig.rst
+++ b/doc/nrf/ug_matter_gs_kconfig.rst
@@ -17,7 +17,7 @@ The Kconfig options for Matter applications in the |NCS| are stored in the follo
 * :file:`prj.conf` files, which are specific to the application.
 * :file:`Kconfig.defaults` file, which is available in the :file:`module/lib/matter/config/nrfconnect/chip-module` directory and is used to populate :file:`prj.conf` with Kconfig option settings common to all samples.
 
-The Matter samples use the same structure for other software images, such as MCUboot or Multiprotocol RPMsg, which have default options defined in the corresponding :file:`Kconfig.mcuboot.defaults` and :file:`Kconfig.multiprotocol_rpmsg.defaults` files.
+The Matter samples use the same structure for other software images, such as MCUboot, Multiprotocol RPMsg or HCI RPMsg, which have default options defined in the corresponding :file:`Kconfig.mcuboot.defaults`, :file:`Kconfig.multiprotocol_rpmsg.defaults` and :file:`Kconfig.hci_rpmsg.defaults` files.
 
 For an example configuration, see the :ref:`Matter Template sample's <matter_template_sample>` :file:`prj.conf` files in the sample root directory.
 

--- a/samples/matter/light_switch/CMakeLists.txt
+++ b/samples/matter/light_switch/CMakeLists.txt
@@ -11,6 +11,7 @@ get_filename_component(MATTER_MODULE_ROOT $ENV{ZEPHYR_BASE}/../modules/lib/matte
 # Set Kconfig root files that will be processed as a first Kconfig for used child images.
 set(mcuboot_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.mcuboot.root)
 set(multiprotocol_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root)
+set(hci_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.root)
 
 if(NOT CONF_FILE STREQUAL "prj_no_dfu.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)

--- a/samples/matter/light_switch/child_image/hci_rpmsg/prj.conf
+++ b/samples/matter/light_switch/child_image/hci_rpmsg/prj.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/light_switch/child_image/hci_rpmsg/prj_no_dfu.conf
+++ b/samples/matter/light_switch/child_image/hci_rpmsg/prj_no_dfu.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/light_switch/child_image/hci_rpmsg/prj_release.conf
+++ b/samples/matter/light_switch/child_image/hci_rpmsg/prj_release.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -11,6 +11,7 @@ get_filename_component(MATTER_MODULE_ROOT $ENV{ZEPHYR_BASE}/../modules/lib/matte
 # Set Kconfig root files that will be processed as a first Kconfig for used child images.
 set(mcuboot_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.mcuboot.root)
 set(multiprotocol_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root)
+set(hci_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.root)
 
 if(NOT CONF_FILE STREQUAL "prj_no_dfu.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)

--- a/samples/matter/lock/child_image/hci_rpmsg/prj.conf
+++ b/samples/matter/lock/child_image/hci_rpmsg/prj.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/lock/child_image/hci_rpmsg/prj_no_dfu.conf
+++ b/samples/matter/lock/child_image/hci_rpmsg/prj_no_dfu.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/lock/child_image/hci_rpmsg/prj_release.conf
+++ b/samples/matter/lock/child_image/hci_rpmsg/prj_release.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/template/CMakeLists.txt
+++ b/samples/matter/template/CMakeLists.txt
@@ -11,6 +11,7 @@ get_filename_component(MATTER_MODULE_ROOT $ENV{ZEPHYR_BASE}/../modules/lib/matte
 # Set Kconfig root files that will be processed as a first Kconfig for used child images.
 set(mcuboot_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.mcuboot.root)
 set(multiprotocol_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root)
+set(hci_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.root)
 
 if(NOT CONF_FILE STREQUAL "prj_no_dfu.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)

--- a/samples/matter/template/child_image/hci_rpmsg/prj.conf
+++ b/samples/matter/template/child_image/hci_rpmsg/prj.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/template/child_image/hci_rpmsg/prj_no_dfu.conf
+++ b/samples/matter/template/child_image/hci_rpmsg/prj_no_dfu.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/template/child_image/hci_rpmsg/prj_release.conf
+++ b/samples/matter/template/child_image/hci_rpmsg/prj_release.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: bb3c75702852ed7efaf6058a38b5a86a71581fa4
+      revision: a8afe86ea54fce40caa8d170e1f45135ca561115
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Matter samples built with Wi-fi support use hci_rpmsg image
instead of multiprotocol_rpmsg, but they only provide
default configuration for the latter.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>