### PR TITLE
boards: nrf7002dk_nrf5340: define Wi-Fi Coexistence pins

### DIFF
--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -95,6 +95,14 @@
 		};
 	};
 
+	nrf_radio_coex: radio_coex_three_wire {
+		status = "okay";
+		compatible = "generic-radio-coex-three-wire";
+		req-gpios =     <&gpio0 30 (GPIO_ACTIVE_HIGH)>;
+		pri-dir-gpios = <&gpio0 28 (GPIO_ACTIVE_HIGH)>;
+		grant-gpios =   <&gpio0 24 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;

--- a/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet.dts
@@ -77,6 +77,14 @@
 			   <21 0 &gpio1 3 0>;	/* D15 */
 	};
 
+	nrf_radio_coex: radio_coex_three_wire {
+		status = "okay";
+		compatible = "generic-radio-coex-three-wire";
+		req-gpios =     <&gpio0 30 (GPIO_ACTIVE_HIGH)>;
+		pri-dir-gpios = <&gpio0 28 (GPIO_ACTIVE_HIGH)>;
+		grant-gpios =   <&gpio0 24 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;


### PR DESCRIPTION
Add Device Tree node to the nRF7002 DK board definition
that describes pins used by the MPSL Wi-Fi Coexistence
implementation.