### PR TITLE
Upgrade junitparser==2.8.0 to fix compliance workflow

### DIFF
--- a/scripts/requirements-fixed.txt
+++ b/scripts/requirements-fixed.txt
@@ -38,7 +38,7 @@ intervaltree==3.1.0
 isort==5.7.0
 Jinja2==2.11.3
 junit2html==30.0.4
-junitparser==1.6.3
+junitparser==2.8.0
 lazy-object-proxy==1.4.3
 lpc-checksum==2.2.0
 lxml==4.9.1


### PR DESCRIPTION
Upstream scripts expect version >2.0