### PR TITLE
mpsl: Add possibility to use only front-end modules API

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -126,6 +126,9 @@ RF Front-End Modules
 ====================
 
 * Fixed a build error that occurred when building an application for nRF53 SoCs with Simple GPIO Front-End Module support enabled.
+* Added the :kconfig:option:`CONFIG_MPSL_FEM_ONLY` Kconfig option that allows the :ref:`nrfxlib:mpsl_fem` API to be used without other MPSL features.
+  The :ref:`MPSL library <nrfxlib:mpsl>` is linked into the build without initialization.
+  You cannot use other MPSL features when this option is enabled.
 
 Applications
 ============

--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -62,6 +62,13 @@ Before you add the devicetree node in your application, complete the following s
    See :ref:`nrfxlib:mpsl_lib` in the nrfxlib documentation for details.
 #. Enable support for MPSL implementation in |NCS| by setting the :kconfig:option:`CONFIG_MPSL` Kconfig option to ``y``.
 
+You can use only the :ref:`nrfxlib:mpsl_fem` API if your application does not require other MPSL features.
+This might be useful when you want to run simple radio protocols that are not intended to be used concurrently with other protocols.
+Enable the following Kconfig options:
+
+* :kconfig:option:`CONFIG_MPSL`
+* :kconfig:option:`CONFIG_MPSL_FEM_ONLY`
+
 .. _ug_radio_fem_direct_support:
 
 Direct support

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -6,7 +6,11 @@
 
 add_subdirectory_ifdef(CONFIG_SENSOR sensor)
 add_subdirectory_ifdef(CONFIG_NETWORKING net)
-add_subdirectory_ifdef(CONFIG_MPSL mpsl)
+
+if (CONFIG_MPSL AND NOT CONFIG_MPSL_FEM_ONLY)
+  add_subdirectory(mpsl)
+endif()
+
 add_subdirectory(hw_cc310)
 add_subdirectory(entropy)
 add_subdirectory(serial)

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -14,7 +14,7 @@ rsource "sensor/Kconfig"
 rsource "serial/Kconfig"
 rsource "wifi/Kconfig"
 
-if MPSL
+if MPSL && !MPSL_FEM_ONLY
 rsource "mpsl/Kconfig"
 endif
 

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -26,11 +26,19 @@ add_subdirectory(pcd)
 endif()
 add_subdirectory_ifdef(CONFIG_IS_SPM		spm)
 add_subdirectory_ifdef(CONFIG_TRUSTED_EXECUTION_NONSECURE nonsecure)
-add_subdirectory_ifdef(CONFIG_MPSL mpsl/init)
+
+if (CONFIG_MPSL AND NOT CONFIG_MPSL_FEM_ONLY)
+  add_subdirectory(mpsl/init)
+endif()
+
 if (CONFIG_MPSL_FEM OR CONFIG_MPSL_FEM_PIN_FORWARDER)
   add_subdirectory(mpsl/fem)
 endif()
-add_subdirectory_ifdef(CONFIG_MPSL_CX mpsl/cx)
+
+if (CONFIG_MPSL_CX AND NOT CONFIG_MPSL_FEM_ONLY)
+  add_subdirectory(mpsl/cx)
+endif()
+
 add_subdirectory_ifdef(CONFIG_ZIGBEE zigbee)
 add_subdirectory_ifdef(CONFIG_MGMT_FMFU mgmt/fmfu)
 add_subdirectory_ifdef(CONFIG_GAZELL gazell)

--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -6,8 +6,20 @@
 
 menu "Nordic MPSL"
 
-rsource "cx/Kconfig"
+config MPSL_FEM_ONLY
+	bool "Support only radio front-end module (FEM)"
+	depends on MPSL_FEM
+	help
+	  Support only radio front-end module (FEM) feature. The MPSL library is linked
+	  into a build without the initialization. Using other MPSL features is not possible.
+
 rsource "fem/Kconfig"
+
+if !MPSL_FEM_ONLY
+
+rsource "cx/Kconfig"
 rsource "init/Kconfig"
+
+endif # !MPSL_FEM_ONLY
 
 endmenu


### PR DESCRIPTION
Add possibility to use front-end modules API from MPSL
without other MPSL features. It gives us possibility
to use FEM drivers from MPSL in the Direct Test Mode
sample, the Radio Test sample and in other Nordic's
radio protocols like the ESB.