### PR TITLE
net: lib: azure_iot_hub: Use correct type when receiving the device twin

### DIFF
--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -351,7 +351,7 @@ AZ_HUB_STATIC void on_publish(struct azure_iot_hub_buf topic, struct azure_iot_h
 		 */
 		switch (twin_msg.response_type) {
 		case AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_GET:
-			evt.topic.type = AZURE_IOT_HUB_TOPIC_TWIN_DESIRED;
+			evt.topic.type = AZURE_IOT_HUB_TOPIC_TWIN_REQUEST_RESULT;
 			LOG_DBG("Message type: AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_GET");
 			break;
 		case AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES:

--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -734,6 +734,9 @@ int azure_iot_hub_connect(const struct azure_iot_hub_config *config)
 			.on_error = on_error,
 		},
 	};
+	struct azure_iot_hub_evt evt = {
+		evt.type = AZURE_IOT_HUB_EVT_CONNECTING,
+	};
 
 	if (iot_hub_state_verify(STATE_CONNECTING)) {
 		LOG_WRN("Azure IoT Hub connection establishment in progress");
@@ -771,6 +774,9 @@ int azure_iot_hub_connect(const struct azure_iot_hub_config *config)
 	}
 
 	iot_hub_state_set(STATE_CONNECTING);
+
+	/* Notify the application that the library is currently connecting to the IoT hub. */
+	azure_iot_hub_notify_event(&evt);
 
 #if IS_ENABLED(CONFIG_AZURE_IOT_HUB_DPS)
 	if (config && config->use_dps) {


### PR DESCRIPTION
After a connection has been established, the azure iot hub client
automatically requests the entire device twin document.

When the device twin response is received it is marked with the
`AZURE_IOT_HUB_TOPIC_TWIN_DESIRED` topic type which is wrong.
This type indicates that the response contains only the `desired`
section of the device twin.

Use the `AZURE_IOT_HUB_TOPIC_TWIN_REQUEST_RESULT` topic type
to correctly identify the payload, and to make sure that the correct
event `AZURE_IOT_HUB_EVT_TWIN_RECEIVED` is sent to the application.