### PR TITLE
doc improvement: link and term fixes

### DIFF
--- a/applications/asset_tracker_v2/doc/cloud_wrapper.rst
+++ b/applications/asset_tracker_v2/doc/cloud_wrapper.rst
@@ -105,8 +105,8 @@ AWS IoT topics
 
 The following tables list the various topics used in the AWS IoT implementation.
 
-Device-to-Cloud
----------------
+Device-to-cloud (D2C)
+---------------------
 
 +------------------------------+--------------------------------------------------------+
 |              Data            |            Topic                                       |
@@ -126,8 +126,8 @@ Device-to-Cloud
 | Buffered sensor/device data  | ``<imei>/batch``                                       |
 +------------------------------+--------------------------------------------------------+
 
-Cloud-to-Device
----------------
+Cloud-to-device (C2D)
+---------------------
 
 +------------------------------+--------------------------------------------------------+
 |              Data            |            Topic                                       |
@@ -149,8 +149,8 @@ Azure IoT Hub topics
 For simplicity, the following table omits certain meta values present in topics and property bags used in Azure IoT Hub.
 For more information on MQTT topics and property bags in Azure IoT Hub, refer to the `Azure IoT Hub MQTT protocol support`_ documentation.
 
-Device-to-Cloud
----------------
+Device-to-cloud (D2C)
+---------------------
 
 +------------------------------+---------------------------------------------+--------------+
 |               Data           |             Topic                           | Property bag |
@@ -170,8 +170,8 @@ Device-to-Cloud
 | Buffered sensor/device data  | ``devices/<imei>/messages/events/``         | ``batch``    |
 +------------------------------+---------------------------------------------+--------------+
 
-Cloud-to-Device
----------------
+Cloud-to-device (C2D)
+---------------------
 
 +------------------------------+------------------------------------------+----------------+
 |               Data           |             Topic                        | Property bag   |
@@ -188,8 +188,8 @@ nRF Cloud topics
 
 For more information on topics used in the nRF Cloud connection, refer to the `nRF Cloud MQTT API`_ documentation.
 
-Device-to-Cloud
----------------
+Device-to-cloud (D2C)
+---------------------
 
 +------------------------------+----------------------------------------------------+
 |              Data            |            AWS IoT topic                           |
@@ -209,8 +209,8 @@ Device-to-Cloud
 | Buffered sensor/device data  | ``<topic_prefix>/<imei>/d2c/batch``                |
 +------------------------------+----------------------------------------------------+
 
-Cloud-to-Device
----------------
+Cloud-to-device (C2D)
+---------------------
 
 +------------------------------+----------------------------------------------------+
 |              Data            |            AWS IoT topic                           |

--- a/samples/nrf9160/nrf_cloud_rest_cell_pos/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_cell_pos/README.rst
@@ -31,9 +31,9 @@ It requires one of the following:
 Overview
 ********
 
-After the sample initializes and connects to the network, it enters single-cell mode and sends a single-cell location request to nRF Cloud using network data obtained from the ref:`modem_info_readme` library.
+After the sample initializes and connects to the network, it enters single-cell mode and sends a single-cell location request to nRF Cloud using network data obtained from the :ref:`modem_info_readme` library.
 To enable multi-cell mode, press **button 1**.
-In multi-cell mode, the sample requests for neighbor cell measurement using the ref:`lte_lc_readme` library.
+In multi-cell mode, the sample requests for neighbor cell measurement using the :ref:`lte_lc_readme` library.
 If neighbor cell data is measured, the sample sends a multi-cell location request to nRF Cloud.
 Otherwise, the request is single-cell.
 In either mode, the sample sends a new location request if a change in cell ID is detected.

--- a/samples/nrf9160/nrf_cloud_rest_device_message/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_device_message/README.rst
@@ -33,13 +33,13 @@ See  `nRF Cloud Security`_ for more details.
 Generating valid JWTs requires the network carrier to provide date and time to the modem, so the sample must first connect to an LTE carrier and determine the current date and time before REST requests can be sent.
 
 Note also that the `nRF Cloud REST API`_ is stateless.
-This differs from the `nRF Cloud MQTT API`_, which requires you to establish and maintain an `MQTT`_ connection while sending `Device Messages <nRF Cloud Device Messages_>`.
+This differs from the `nRF Cloud MQTT API`_, which requires you to establish and maintain an `MQTT`_ connection while sending `Device Messages <nRF Cloud Device Messages_>`_.
 
 User interface
 **************
 
 Once the device is provisioned and connected, each press of the configured button (**Button 1** by default) (:ref:`CONFIG_REST_DEVICE_MESSAGE_BUTTON_EVT_NUM <CONFIG_REST_DEVICE_MESSAGE_BUTTON_EVT_NUM>`) generates a device-to-cloud button press `Device Message <nRF Cloud Device Messages_>`_ over REST.
-These messages are sent to the non-bulk d2c (Device to Cloud) topic, detailed in `topics used by devices running the nRF Cloud library <nRF Cloud MQTT Topics_>`_.
+These messages are sent to the non-bulk D2C (device-to-cloud) topic, detailed in `topics used by devices running the nRF Cloud library <nRF Cloud MQTT Topics_>`_.
 
 The configured LTE LED (**LED 1** by default) (:ref:`CONFIG_REST_DEVICE_MESSAGE_LTE_LED_NUM <CONFIG_REST_DEVICE_MESSAGE_LTE_LED_NUM>`) is lit once an LTE connection is established and JWT tokens are ready to be generated.
 


### PR DESCRIPTION
Fixed a link and a few terms.
As agreed, we are using lower case and hyphens
in terms cloud-to-device and device-to-cloud.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>