### PR TITLE
manifest: Update zephyr with check-compliance.py upgrades

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b341c1ffbee9e1694f07a62f55b76b3f4947f603
+      revision: af74fa5da141e8e385edaf4337572b2e14b8029e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
[nrf fromlist] changes made by Carles
FROM: from https://github.com/nrfconnect/sdk-zephyr/pull/889
* af74fa5da1 (HEAD -> main, ncs/main) [nrf fromtree] scripts: compliance: Add commit range info output
* 9da8b1df20 [nrf fromtree] scripts: compliance: Remove unused command-line args
* efb4ed7a9a [nrf fromtree] scripts: compliance: Tiny cleanup for -c
* 58e22444c6 [nrf fromtree] scripts: compliance: Clean up logging
* 36d71607ae [nrf fromtree] scripts: compliance: Complete transition to junitparser v2
* 84e137f6bf [nrf fromtree] scripts: compliance: Remove unused variable
* e97f6b97a2 [nrf fromtree] scripts/ci/check_compliance.py: Allow to run w/ZEPHYR_BASE

These were dangling on top of main, and will be pulled in with:
* b7b20d0b44 [nrf fromlist] net: lwm2m: Fix LwM2M pause and resume
* 6fe8700083 [nrf fromtree] net: zperf: Use zsock_* API instead of POSIX socket API
* f03286347a [nrf fromtree] net: zperf: Extract zperf into library

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>
