### PR TITLE
applications: asset_tracker_v2: Suspend lwm2m socket on RX window close

### DIFF
--- a/applications/asset_tracker_v2/overlay-lwm2m.conf
+++ b/applications/asset_tracker_v2/overlay-lwm2m.conf
@@ -34,6 +34,7 @@ CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME=43200
 
 # LwM2M Queue Mode
 CONFIG_LWM2M_QUEUE_MODE_ENABLED=y
+CONFIG_LWM2M_RD_CLIENT_SUSPEND_SOCKET_AT_IDLE=y
 # Sets the duration that the lwm2m engine will be polling for data after transmission before
 # the socket is closed.
 CONFIG_LWM2M_QUEUE_MODE_UPTIME=30


### PR DESCRIPTION
Enable the Kconfig option that suspends the lwm2m socket
instead of closing it when Queue Mode RX Window is closed.
This avoids sending socket close alert to the lwm2m server which
in turn reduces LTE activity thereby enabling the modem to
enter PSM more faster.