### PR TITLE
caf: Add ble_adv_data_update_event

### DIFF
--- a/doc/nrf/libraries/caf/ble_adv.rst
+++ b/doc/nrf/libraries/caf/ble_adv.rst
@@ -68,6 +68,8 @@ Power-down
 
 When the system goes to the power-down state, the advertising either instantly stops or enters the grace period state.
 
+.. _caf_ble_adv_grace_period:
+
 Grace period
 ------------
 
@@ -95,6 +97,18 @@ Implementation details
 The |ble_adv| is used only by Bluetooth Peripheral devices.
 
 The |ble_adv| uses Zephyr's :ref:`zephyr:settings_api` to store the information if the peer for the given local identity uses the Resolvable Private Address (RPA).
+
+Undirected advertising data update
+==================================
+
+The module does not instantly update advertising and scan response payloads when either advertising data or scan response data (provided by :ref:`bt_le_adv_prov_readme`) is modified.
+The module automatically gets new advertising data and scan response data from Bluetooth LE's advertising data provider subsystem only in the following cases:
+
+* Bluetooth LE undirected advertising is started or restarted.
+* Undirected advertising enters the :ref:`caf_ble_adv_grace_period`.
+
+The payload update can be triggered by the application using :c:struct:`ble_adv_data_update_event`.
+Make sure to submit the event after changing the Bluetooth data provided by a provider.
 
 Reaction on Bluetooth peer operation
 ====================================

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -721,6 +721,8 @@ Common Application Framework (CAF)
     The subsystem is now used instead of the :file:`*.def` file to configure advertising data and scan response data.
   * Bluetooth device name is no longer automatically included in scan response data.
     A dedicated data provider (:kconfig:option:`CONFIG_BT_LE_ADV_PROV_DEVICE_NAME`) can be used to add the Bluetooth device name to the scan response data.
+  * Added :c:struct:`ble_adv_data_update_event` that can be used to trigger update of advertising data and scan response data during undirected advertising.
+    When the event is received, the module gets new data from providers and updates advertising payload.
 
 * :ref:`caf_ble_state`:
 

--- a/include/caf/events/ble_common_event.h
+++ b/include/caf/events/ble_common_event.h
@@ -184,6 +184,16 @@ struct ble_peer_search_event {
 	bool active;
 };
 
+/** @brief Bluetooth LE advertising data update event.
+ *
+ * The Bluetooth LE advertising data update event is submitted to trigger update of advertising data
+ * and scan response data.
+ */
+struct ble_adv_data_update_event {
+	/** Event header. */
+	struct app_event_header header;
+};
+
 #ifdef __cplusplus
 }
 #endif
@@ -200,6 +210,7 @@ APP_EVENT_TYPE_DECLARE(ble_peer_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_operation_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_conn_params_event);
 APP_EVENT_TYPE_DECLARE(ble_peer_search_event);
+APP_EVENT_TYPE_DECLARE(ble_adv_data_update_event);
 
 #ifdef __cplusplus
 }

--- a/subsys/caf/events/Kconfig
+++ b/subsys/caf/events/Kconfig
@@ -41,6 +41,12 @@ config CAF_INIT_LOG_BLE_PEER_SEARCH_EVENTS
 	depends on LOG
 	default y
 
+config CAF_INIT_LOG_BLE_ADV_DATA_UPDATE_EVENTS
+	bool "Log BLE advertising data update events"
+	depends on CAF_BLE_COMMON_EVENTS
+	depends on LOG
+	default y
+
 config CAF_INIT_LOG_BLE_PEER_OPERATION_EVENTS
 	bool "Log BLE peer operation events"
 	depends on CAF_BLE_COMMON_EVENTS

--- a/subsys/caf/events/ble_common_event.c
+++ b/subsys/caf/events/ble_common_event.c
@@ -80,6 +80,18 @@ APP_EVENT_TYPE_DEFINE(ble_peer_search_event,
 				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));
 
 
+static void log_ble_adv_data_update_event(const struct app_event_header *aeh)
+{
+	APP_EVENT_MANAGER_LOG(aeh, "");
+}
+
+APP_EVENT_TYPE_DEFINE(ble_adv_data_update_event,
+		      log_ble_adv_data_update_event,
+		      NULL,
+		      APP_EVENT_FLAGS_CREATE(
+			IF_ENABLED(CONFIG_CAF_INIT_LOG_BLE_ADV_DATA_UPDATE_EVENTS,
+				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));
+
 static const char * const op_name[] = {
 	"SELECT",
 	"SELECTED",


### PR DESCRIPTION
Change introduces the ble_adv_data_update_event. The event is used to trigger advertising data update.
The PR also introduces code handling the new event in CAF Bluetooth LE advertising module.

Jira: NCSDK-16453