### PR TITLE
bluetooth: fast_pair: Reject pairing if NoInput/NoOutput

### DIFF
--- a/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
+++ b/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
@@ -56,6 +56,7 @@ config BT_FAST_PAIR_AUTH
 	default y
 	select BT_SMP
 	select BT_SMP_APP_PAIRING_ACCEPT
+	select BT_SMP_ENFORCE_MITM
 	help
 	  Add Fast Pair Bluetooth authentication source files.
 


### PR DESCRIPTION
Fast Pair specification states that:
```
When a pairing request/response packet is received from the Seeker:
If the Device Capabilities in the request are NoInput/NoOutput, end
pairing, to avoid using the Just Works pairing method.
```
Change aligns the implementation.

Jira: NCSDK-16311