### PR TITLE
partition_manager: Add PM_EXTERNAL_FLASH_HAS_DRIVER Kconfig option

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -219,11 +219,7 @@ if (DEFINED ext_flash_dev)
   dt_prop(num_bits PATH ${ext_flash_dev} PROPERTY size)
   math(EXPR num_bytes "${num_bits} / 8")
 
-  if (CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK)
-    set(external_flash_driver_kconfig CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK)
-  else()
-    set(external_flash_driver_kconfig CONFIG_NORDIC_QSPI_NOR)
-  endif()
+  set(external_flash_driver_kconfig CONFIG_PM_EXTERNAL_FLASH_HAS_DRIVER)
 
   add_region(
     NAME external_flash

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -30,6 +30,13 @@ Changelog
 
 The following sections provide detailed lists of changes by component.
 
+MCUboot
+=======
+
+* Added the :kconfig:option:`PM_EXTERNAL_FLASH_HAS_DRIVER` kconfig option.
+  When set, it makes MCUboot fail to boot when the external flash memory is used for non-primary application images but the driver for the external flash memory is not enabled.
+  See :ref:`ug_bootloader_external_flash` and :ref:`pm_external_flash` for details.
+
 Application development
 =======================
 

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -133,6 +133,17 @@ config PM_SINGLE_IMAGE
 
 DT_CHOSEN_EXT_FLASH:= nordic,pm-ext-flash
 
+config PM_EXTERNAL_FLASH_HAS_DRIVER
+	bool
+	default y if NORDIC_QSPI_NOR || SPI_NOR
+	default y if PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
+	help
+	  This option needs to be enabled by flash drivers that provide
+	  support for external flash devices with partition manager
+	  controlled partitions on them.
+	  Partitions on devices without drivers will not have partition map
+	  entries generated and will not be available from Flash Map API.
+
 config PM_EXTERNAL_FLASH_BASE
 	hex "External flash base address"
 	default 0


### PR DESCRIPTION
This hidden Kconfig option is used by partition manager to group
external flash Kconfig driver enablers.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

**2022-11-23**: Documentation update has been moved to this PR https://github.com/nrfconnect/sdk-nrf/pull/9423, with all comments from this PR applied; sorry for inconvenience.
**2022-11-24**: I had to revert dependency between PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY  and PM_EXTERNAL_FLASH_HAS_DRIVER due to dependency loop.
**2022-11-24-0259**: Rebase on main, no changes to code re-review not required.