### PR TITLE
CODEOWNERS: Add entry for nrf700x driver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,6 +64,7 @@ Kconfig*                                  @tejlmand
 /drivers/serial/                          @nordic-krch @anangl
 /drivers/sensor/paw3212/                  @anangl @pdunaj @MarekPieta
 /drivers/sensor/pmw3360/                  @anangl @pdunaj @MarekPieta
+/drivers/wifi/nrf700x/                    @krish2718 @sachinthegreen @sr1dh48r @rlubos
 /dts/                                     @mbolivar-nordic @anangl
 /ext/                                     @carlescufi
 /include/                                 @anangl @rlubos


### PR DESCRIPTION
This is maintained by Wi-Fi host team.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>