### PR TITLE
doc: kconfig: fix memfault extended Kconfig path

### DIFF
--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -60,12 +60,8 @@ kconfig_ext_paths = [ZEPHYR_BASE, NRF_BASE]
 # task has been completed.
 os.environ["NCS_MEMFAULT_FIRMWARE_SDK_KCONFIG"] = str(
     NRF_BASE
-    / ".."
     / "modules"
-    / "lib"
     / "memfault-firmware-sdk"
-    / "ports"
-    / "zephyr"
     / "Kconfig"
 )
 


### PR DESCRIPTION
NCS extends memfault-sdk Kconfig options. The path inserted in the
conf.py was pointing to the module (already provided by standard
mechanisms).

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>