### PR TITLE
doc: Bluetooth: Zephyr Controller supports Advertising Extensions

### DIFF
--- a/doc/nrf/ug_ble_controller.rst
+++ b/doc/nrf/ug_ble_controller.rst
@@ -48,7 +48,7 @@ It is developed by the Zephyr community and provided as open source.
 
 To use Zephyr's Bluetooth LE Controller in your application, include a :ref:`Controller-only build <zephyr:bluetooth-build-types>` of the Bluetooth LE stack.
 
-Zephyr's Bluetooth LE Controller supports most of the standard Bluetooth LE features, except for Advertising Extensions.
+Zephyr's Bluetooth LE Controller supports most of the standard Bluetooth LE features.
 See the :ref:`Zephyr documentation <zephyr:bluetooth-overview>` for a detailed list of supported features.
 
 


### PR DESCRIPTION
Zephyr Controller now supports a fully qualifiable
Advertising Extensions, Periodic Advertising and Direction
Finding features.

Update the documentation to remove the text that stated
that Advertising Extensions was not supported.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>