### PR TITLE
applications: asset_tracker_v2: Make `DATA_DEVICE_MODE` a choice

### DIFF
--- a/applications/asset_tracker_v2/doc/data_module.rst
+++ b/applications/asset_tracker_v2/doc/data_module.rst
@@ -66,10 +66,17 @@ The energy levels map directly to the :ref:`lte_lc_readme` structure :c:struct:`
 Configuration options
 *********************
 
-.. _CONFIG_DATA_DEVICE_MODE:
+Options that alter the default values of the application's real-time configurations:
 
-CONFIG_DATA_DEVICE_MODE
-   This configuration sets the device mode.
+.. _CONFIG_DATA_DEVICE_MODE_ACTIVE:
+
+CONFIG_DATA_DEVICE_MODE_ACTIVE
+   This configuration sets the device in active mode.
+
+.. _CONFIG_DATA_DEVICE_MODE_PASSIVE:
+
+CONFIG_DATA_DEVICE_MODE_PASSIVE
+   This configuration sets the device in passive mode.
 
 .. _CONFIG_DATA_ACTIVE_TIMEOUT_SECONDS:
 
@@ -95,6 +102,20 @@ CONFIG_DATA_ACCELEROMETER_THRESHOLD
 
 CONFIG_DATA_GNSS_TIMEOUT_SECONDS
    This configuration sets the GNSS timeout value.
+
+.. _CONFIG_DATA_SAMPLE_GNSS_DEFAULT:
+
+CONFIG_DATA_SAMPLE_GNSS_DEFAULT
+   This configuration includes GNSS during sampling.
+   Enabled by default.
+
+.. _CONFIG_DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT:
+
+CONFIG_DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT
+   This configuration includes neighbor cell measurements during sampling.
+   Enabled by default.
+
+Other options:
 
 .. _CONFIG_DATA_GRANT_SEND_ON_CONNECTION_QUALITY:
 

--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -91,13 +91,24 @@ config DATA_UI_BUFFER_STORE
 	bool "Store UI data received from the UI module"
 	default y
 
-config DATA_DEVICE_MODE
-	bool "Default device mode"
-	default y
+choice DATA_DEVICE_MODE
+	prompt "Device mode"
+	default DATA_DEVICE_MODE_ACTIVE
 	help
-	  Either active or passive mode. True evaluates to active mode. In active mode the device
-	  samples and publishes data at regular intervals. In passive mode the device samples and
-	  publishes data only if movement has been detected.
+	  The device can be in either active or passive mode.
+	  In active mode the device samples and sends data at regular intervals set by
+	  CONFIG_DATA_ACTIVE_TIMEOUT_SECONDS.
+	  In passive mode the device samples and sends data only if movement has been detected and
+	  the movement resolution timer set by CONFIG_DATA_MOVEMENT_RESOLUTION_SECONDS has
+	  expired.
+
+config DATA_DEVICE_MODE_ACTIVE
+	bool "Active mode"
+
+config DATA_DEVICE_MODE_PASSIVE
+	bool "Passive mode"
+
+endchoice # DATA_DEVICE_MODE #
 
 config DATA_ACTIVE_TIMEOUT_SECONDS
 	int "Default active wait timeout in seconds"

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -98,16 +98,14 @@ static K_SEM_DEFINE(config_load_sem, 0, 1);
 
 /* Default device configuration. */
 static struct cloud_data_cfg current_cfg = {
-	.gnss_timeout			= CONFIG_DATA_GNSS_TIMEOUT_SECONDS,
-	.active_mode			= (IS_ENABLED(CONFIG_DATA_DEVICE_MODE) ? true : false),
-	.active_wait_timeout		= CONFIG_DATA_ACTIVE_TIMEOUT_SECONDS,
-	.movement_resolution		= CONFIG_DATA_MOVEMENT_RESOLUTION_SECONDS,
-	.movement_timeout		= CONFIG_DATA_MOVEMENT_TIMEOUT_SECONDS,
-	.accelerometer_threshold	= CONFIG_DATA_ACCELEROMETER_THRESHOLD,
-	.no_data.gnss			= (IS_ENABLED(CONFIG_DATA_SAMPLE_GNSS_DEFAULT)
-					   ? false : true),
-	.no_data.neighbor_cell		= (IS_ENABLED(CONFIG_DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT)
-					   ? false : true)
+	.gnss_timeout		 = CONFIG_DATA_GNSS_TIMEOUT_SECONDS,
+	.active_mode		 = IS_ENABLED(CONFIG_DATA_DEVICE_MODE_ACTIVE),
+	.active_wait_timeout	 = CONFIG_DATA_ACTIVE_TIMEOUT_SECONDS,
+	.movement_resolution	 = CONFIG_DATA_MOVEMENT_RESOLUTION_SECONDS,
+	.movement_timeout	 = CONFIG_DATA_MOVEMENT_TIMEOUT_SECONDS,
+	.accelerometer_threshold = CONFIG_DATA_ACCELEROMETER_THRESHOLD,
+	.no_data.gnss		 = !IS_ENABLED(CONFIG_DATA_SAMPLE_GNSS_DEFAULT),
+	.no_data.neighbor_cell	 = !IS_ENABLED(CONFIG_DATA_SAMPLE_NEIGHBOR_CELLS_DEFAULT)
 };
 
 static struct k_work_delayable data_send_work;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -150,6 +150,7 @@ nRF9160: Asset Tracker v2
     * The conversions of RSRP and RSRQ now use common macros that follow the conversion algorithms defined in the `AT Commands Reference Guide`_.
     * Bootstrapping has been disabled by default to be able to connect to the default LwM2M service AVSystem's `Coiote Device Management`_ using free tier accounts.
     * Added support for full modem FOTA updates for nRF Cloud builds.
+    * ``CONFIG_DATA_DEVICE_MODE`` option is now a choice that can be set to either ``CONFIG_DATA_DEVICE_MODE_ACTIVE`` or ``CONFIG_DATA_DEVICE_MODE_PASSIVE`` depending on the desired device mode.
 
   * Fixed:
 


### PR DESCRIPTION
Make `DATA_DEVICE_MODE` a choice that can be set to either
`CONFIG_DATA_DEVICE_MODE_ACTIVE` or
`CONFIG_DATA_DEVICE_MODE_PASSIVE` depending on the desired device mode.

Previosuly the device mode was set to active if
`CONFIG_DATA_DEVICE_MODE` was `y` selected, and passive mode if not
selected. Not particularly intuitive.

This patch also adds some missing options to `data_module.rst` to
inform the user on all options that changes the device's behavior.