### PR TITLE
Replace deprecated nrfx API

### DIFF
--- a/modules/nrfxlib/nrf_802154/sl/platform/nrf_802154_hp_timer.c
+++ b/modules/nrfxlib/nrf_802154/sl/platform/nrf_802154_hp_timer.c
@@ -53,7 +53,7 @@ static inline uint32_t timer_time_get(void)
 void nrf_802154_hp_timer_init(void)
 {
 	nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
-	nrf_timer_frequency_set(TIMER, NRF_TIMER_FREQ_1MHz);
+	nrf_timer_prescaler_set(TIMER, NRF_TIMER_FREQ_1MHz);
 	nrf_timer_mode_set(TIMER, NRF_TIMER_MODE_TIMER);
 }
 

--- a/samples/bluetooth/direct_test_mode/src/fem/generic_fem.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/generic_fem.c
@@ -306,7 +306,7 @@ static int generic_fem_init(void)
 	nrf_timer_mode_set(generic_fem_cfg.timer.p_reg, NRF_TIMER_MODE_TIMER);
 	nrf_timer_bit_width_set(generic_fem_cfg.timer.p_reg,
 				NRF_TIMER_BIT_WIDTH_16);
-	nrf_timer_frequency_set(generic_fem_cfg.timer.p_reg, NRF_TIMER_FREQ_1MHz);
+	nrf_timer_prescaler_set(generic_fem_cfg.timer.p_reg, NRF_TIMER_FREQ_1MHz);
 
 	err = gppi_channel_config();
 	if (err) {

--- a/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/nrf21540.c
@@ -399,7 +399,7 @@ static int nrf21540_init(void)
 	nrf_timer_mode_set(nrf21540_cfg.timer.p_reg, NRF_TIMER_MODE_TIMER);
 	nrf_timer_bit_width_set(nrf21540_cfg.timer.p_reg,
 				NRF_TIMER_BIT_WIDTH_16);
-	nrf_timer_frequency_set(nrf21540_cfg.timer.p_reg, NRF_TIMER_FREQ_1MHz);
+	nrf_timer_prescaler_set(nrf21540_cfg.timer.p_reg, NRF_TIMER_FREQ_1MHz);
 
 	err = gpio_configure();
 	if (err) {

--- a/samples/tfm/tfm_hello_world/src/main.c
+++ b/samples/tfm/tfm_hello_world/src/main.c
@@ -20,8 +20,8 @@
 #define PIN_XL2 1
 
 /* Check if MCU selection is required */
-#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
-static void gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_mcusel_t mcu)
+#if NRF_GPIO_HAS_SEL
+static void gpio_pin_control_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu)
 {
 	uint32_t err;
 	enum tfm_platform_err_t plt_err;
@@ -32,7 +32,7 @@ static void gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_mcusel_t mcu)
 			plt_err, err);
 	}
 }
-#endif /* defined(GPIO_PIN_CNF_MCUSEL_Msk) */
+#endif /* NRF_GPIO_HAS_SEL */
 
 static uint32_t secure_read_word(intptr_t ptr)
 {
@@ -119,17 +119,17 @@ void main(void)
 	}
 
 	if (IS_ENABLED(CONFIG_TFM_PARTITION_PLATFORM)) {
-#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
+#if NRF_GPIO_HAS_SEL
 		/* Configure properly the XL1 and XL2 pins so that the low-frequency crystal
 		 * oscillator (LFXO) can be used.
 		 * This configuration has already been done by TF-M so this is redundant.
 		 */
-		gpio_pin_mcu_select(PIN_XL1, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
-		gpio_pin_mcu_select(PIN_XL2, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
+		gpio_pin_control_select(PIN_XL1, NRF_GPIO_PIN_SEL_PERIPHERAL);
+		gpio_pin_control_select(PIN_XL2, NRF_GPIO_PIN_SEL_PERIPHERAL);
 		printk("MCU selection configured\n");
 #else
 		printk("MCU selection skipped\n");
-#endif /* defined(GPIO_PIN_CNF_MCUSEL_Msk) */
+#endif /* NRF_GPIO_HAS_SEL */
 
 #ifdef PM_S1_ADDRESS
 		bool s0_active = false;

--- a/samples/tfm/tfm_secure_peripheral/secure_peripheral_partition/secure_peripheral_partition.c
+++ b/samples/tfm/tfm_secure_peripheral/secure_peripheral_partition/secure_peripheral_partition.c
@@ -44,7 +44,7 @@ static void timer_init(NRF_TIMER_Type *timer, uint32_t ticks)
 {
 	nrf_timer_mode_set(timer, NRF_TIMER_MODE_TIMER);
 	nrf_timer_bit_width_set(timer, NRF_TIMER_BIT_WIDTH_32);
-	nrf_timer_frequency_set(timer, NRF_TIMER_FREQ_1MHz);
+	nrf_timer_prescaler_set(timer, NRF_TIMER_FREQ_1MHz);
 	nrf_timer_cc_set(timer, NRF_TIMER_CC_CHANNEL0, ticks);
 	/* Clear the timer once event is generated. */
 	nrf_timer_shorts_enable(timer, NRF_TIMER_SHORT_COMPARE0_CLEAR_MASK);

--- a/subsys/mpsl/cx/nrf700x/mpsl_cx_nrf700x.c
+++ b/subsys/mpsl/cx/nrf700x/mpsl_cx_nrf700x.c
@@ -285,17 +285,17 @@ static int mpsl_cx_init(const struct device *dev)
 #if DT_NODE_HAS_PROP(CX_NODE, req_gpios)
 	uint8_t req_pin = NRF_DT_GPIOS_TO_PSEL(CX_NODE, req_gpios);
 
-	soc_secure_gpio_pin_mcu_select(req_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(req_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 #if DT_NODE_HAS_PROP(CX_NODE, status0_gpios)
 	uint8_t status0_pin = NRF_DT_GPIOS_TO_PSEL(CX_NODE, status0_gpios);
 
-	soc_secure_gpio_pin_mcu_select(status0_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(status0_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 #if DT_NODE_HAS_PROP(CX_NODE, grant_gpios)
 	uint8_t grant_pin = NRF_DT_GPIOS_TO_PSEL(CX_NODE, grant_gpios);
 
-	soc_secure_gpio_pin_mcu_select(grant_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(grant_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 
 	return 0;

--- a/subsys/mpsl/cx/thread/mpsl_cx_thread.c
+++ b/subsys/mpsl/cx/thread/mpsl_cx_thread.c
@@ -224,17 +224,17 @@ static int mpsl_cx_init(const struct device *dev)
 #if DT_NODE_HAS_PROP(CX_NODE, req_gpios)
 	uint8_t req_pin = NRF_DT_GPIOS_TO_PSEL(CX_NODE, req_gpios);
 
-	soc_secure_gpio_pin_mcu_select(req_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(req_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 #if DT_NODE_HAS_PROP(CX_NODE, pri_dir_gpios)
 	uint8_t pri_dir_pin = NRF_DT_GPIOS_TO_PSEL(CX_NODE, pri_dir_gpios);
 
-	soc_secure_gpio_pin_mcu_select(pri_dir_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(pri_dir_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 #if DT_NODE_HAS_PROP(CX_NODE, grant_gpios)
 	uint8_t grant_pin = NRF_DT_GPIOS_TO_PSEL(CX_NODE, grant_gpios);
 
-	soc_secure_gpio_pin_mcu_select(grant_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(grant_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 
 	return 0;

--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -304,31 +304,31 @@ static int mpsl_fem_host_init(const struct device *dev)
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), tx_en_gpios)
 	uint8_t tx_en_pin = NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(nrf_radio_fem), tx_en_gpios);
 
-	soc_secure_gpio_pin_mcu_select(tx_en_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(tx_en_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), rx_en_gpios)
 	uint8_t rx_en_pin = NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(nrf_radio_fem), rx_en_gpios);
 
-	soc_secure_gpio_pin_mcu_select(rx_en_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(rx_en_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), pdn_gpios)
 	uint8_t pdn_pin = NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(nrf_radio_fem), pdn_gpios);
 
-	soc_secure_gpio_pin_mcu_select(pdn_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(pdn_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), mode_gpios)
 	uint8_t mode_pin = NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(nrf_radio_fem), mode_gpios);
 
-	soc_secure_gpio_pin_mcu_select(mode_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(mode_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios)
 	uint8_t ant_sel_pin = NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios);
 
-	soc_secure_gpio_pin_mcu_select(ant_sel_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(ant_sel_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 
 	return 0;

--- a/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
+++ b/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
@@ -217,13 +217,13 @@ static int mpsl_fem_host_init(const struct device *dev)
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), ctx_gpios)
 	uint8_t ctx_pin = NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(nrf_radio_fem), ctx_gpios);
 
-	soc_secure_gpio_pin_mcu_select(ctx_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(ctx_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), crx_gpios)
 	uint8_t crx_pin = NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(nrf_radio_fem), crx_gpios);
 
-	soc_secure_gpio_pin_mcu_select(crx_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
+	soc_secure_gpio_pin_mcu_select(crx_pin, NRF_GPIO_PIN_SEL_NETWORK);
 #endif
 
 	return 0;

--- a/tests/modules/tfm/secure_services/src/main.c
+++ b/tests/modules/tfm/secure_services/src/main.c
@@ -104,8 +104,8 @@ void test_tfm_gpio_service(void)
 	uint32_t err = UINT32_MAX;
 	enum tfm_platform_err_t plt_err;
 
-#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
-	plt_err = tfm_platform_gpio_pin_mcu_select(0, NRF_GPIO_PIN_MCUSEL_PERIPHERAL, &err);
+#if NRF_GPIO_HAS_SEL
+	plt_err = tfm_platform_gpio_pin_mcu_select(0, NRF_GPIO_PIN_SEL_PERIPHERAL, &err);
 	zassert_equal(plt_err, TFM_PLATFORM_ERR_SUCCESS,
 		      "Valid GPIO mcu select operation returned an unexpected error");
 	zassert_equal(err, 0, "Valid GPIO select arguments returned an unexpected result");
@@ -116,7 +116,7 @@ void test_tfm_gpio_service(void)
 	zassert_equal(err, -1,
 		      "Invalid GPIO select mcu argument returned an unexpected result");
 
-	plt_err = tfm_platform_gpio_pin_mcu_select(66, NRF_GPIO_PIN_MCUSEL_NETWORK, &err);
+	plt_err = tfm_platform_gpio_pin_mcu_select(66, NRF_GPIO_PIN_SEL_NETWORK, &err);
 	zassert_equal(plt_err, TFM_PLATFORM_ERR_SUCCESS,
 		      "Valid GPIO mcu select operation returned an unexpected error");
 	zassert_equal(err, -1,


### PR DESCRIPTION
With the release of nrfx2.9 some API become deprecated
(see https://github.com/NordicSemiconductor/nrfx/blob/v2.9.0/CHANGELOG.md).
This PR replaces deprecated API with suggested in CHANGELOG