### PR TITLE
manifest: Update to nrfxlib PR #813 and other manifest changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: a17a9780db839b0d1fa50e7d44b1ccf0fc88da81
+      revision: pull/63/head
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot

--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.1.0-rc1
+      revision: pull/813/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
-Adds nrf_cc3xx v0.9.15 which is built against Mbed TLS 3.1.0
-Adds nrf_oberon v3.0.12 which is built against Mbed TLS 3.1.0

ref: NCSDK-15110
ref: NCSDK-15114

test-sdk-nrf: sdk-nrf-PR-8546

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>