### PR TITLE
quarantine_windows: add lwm2m tests

### DIFF
--- a/scripts/quarantine_windows.yaml
+++ b/scripts/quarantine_windows.yaml
@@ -21,6 +21,8 @@
 - scenarios:
     - asset_tracker_v2.debug_module_test.tester
     - asset_tracker_v2.gnss_module_test.tester
+    - asset_tracker_v2.lwm2m_codec
+    - asset_tracker_v2.lwm2m_integration
     - asset_tracker_v2.ui_module_test.tester
   platforms:
     - all


### PR DESCRIPTION
Due to the fact that Windows toolchain does not have ruby package, then
tests written with Unity test framework cannot be run in Windows CI,
so they should be put into quarantine.

Those changes are necessary as a consequence of merging those two PR:
https://github.com/nrfconnect/sdk-nrf/pull/8420
https://github.com/nrfconnect/sdk-nrf/pull/8404

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>