### PR TITLE
samples: Change samples to sample

### DIFF
--- a/samples/peripheral/lpuart/sample.yaml
+++ b/samples/peripheral/lpuart/sample.yaml
@@ -12,7 +12,7 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
 
-  samples.peripheral.lpuart_nrf52840_debug:
+  sample.peripheral.lpuart_nrf52840_debug:
     build_only: true
     platform_allow: nrf52840dk_nrf52840
     integration_platforms:
@@ -21,7 +21,7 @@ tests:
       DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;debug.overlay"
     tags: ci_build
 
-  samples.peripheral.lpuart_nrf9160dk_debug:
+  sample.peripheral.lpuart_nrf9160dk_debug:
     build_only: true
     platform_allow: nrf9160dk_nrf9160_ns
     integration_platforms:


### PR DESCRIPTION
Some testcases start with samples instead of sample.
This commit rename these.

Signed-off-by: Katarzyna Giadla <katarzyna.giadla@nordicsemi.no>