### PR TITLE
caf: ble_adv: Add wake up on connection in grace period

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -783,6 +783,8 @@ Common Application Framework (CAF)
     A dedicated data provider (:kconfig:option:`CONFIG_BT_LE_ADV_PROV_DEVICE_NAME`) can be used to add the Bluetooth device name to the scan response data.
   * Added :c:struct:`ble_adv_data_update_event` that can be used to trigger update of advertising data and scan response data during undirected advertising.
     When the event is received, the module gets new data from providers and updates advertising payload.
+  * Added a wakeup call when connection is made in the grace period.
+    With this change, the call wakes up the whole system to avoid inconsistent power state between modules.
 
 * :ref:`caf_ble_state`:
 

--- a/subsys/caf/modules/ble_adv.c
+++ b/subsys/caf/modules/ble_adv.c
@@ -527,9 +527,19 @@ static bool handle_ble_peer_event(const struct ble_peer_event *event)
 
 	switch (event->state) {
 	case PEER_STATE_CONNECTED:
-		err = ble_adv_stop();
-		break;
+	{
+		bool wu = false;
 
+		if (IS_ENABLED(CONFIG_CAF_BLE_ADV_GRACE_PERIOD) &&
+		    (state == STATE_GRACE_PERIOD)) {
+			wu = true;
+		}
+		err = ble_adv_stop();
+		if (wu) {
+			APP_EVENT_SUBMIT(new_wake_up_event());
+		}
+		break;
+	}
 	case PEER_STATE_SECURED:
 		if (peer_is_rpa[cur_identity] == PEER_RPA_ERASED) {
 			if (bt_addr_le_is_rpa(bt_conn_get_dst(event->id))) {


### PR DESCRIPTION
This commit wake up the board if the connection was done during
the grace period.
This way we always have consistent power state of the all modules.