### PR TITLE
spm: Mark SPM as deprecated

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -138,6 +138,13 @@ RF Front-End Modules
   The :ref:`MPSL library <nrfxlib:mpsl>` is linked into the build without initialization.
   You cannot use other MPSL features when this option is enabled.
 
+Secure Partition Manager (SPM)
+==============================
+
+* The Secure Partition Manager (SPM), the Kconfig option :kconfig:option:`CONFIG_SPM`, is deprecated.
+  It is replaced by the Trusted Firmware-M (TF-M) as the supported trusted execution solution.
+  See :ref:`ug_tfm` for more information about the TF-M.
+
 Applications
 ============
 

--- a/include/secure_services.h
+++ b/include/secure_services.h
@@ -60,7 +60,7 @@ ret __attribute__((naked)) name(__VA_ARGS__) \
  *
  * Rebooting is not available from the Non-Secure Firmware.
  */
-void spm_request_system_reboot(void);
+__deprecated void spm_request_system_reboot(void);
 
 /** Request a random number from the Secure Firmware.
  *
@@ -72,7 +72,7 @@ void spm_request_system_reboot(void);
  *
  * @return non-negative on success, negative errno code on fail
  */
-int spm_request_random_number(uint8_t *output, size_t len, size_t *olen);
+__deprecated int spm_request_random_number(uint8_t *output, size_t len, size_t *olen);
 
 /** Request a read operation to be executed from Secure Firmware.
  *
@@ -85,7 +85,7 @@ int spm_request_random_number(uint8_t *output, size_t len, size_t *olen);
  * @retval -EINVAL  If destination is NULL, or if len is <= 0.
  * @retval -EPERM   If source is outside of allowed ranges.
  */
-int spm_request_read(void *destination, uint32_t addr, size_t len);
+__deprecated int spm_request_read(void *destination, uint32_t addr, size_t len);
 
 /** Check if S0 is the active B1 slot.
  *
@@ -96,7 +96,7 @@ int spm_request_read(void *destination, uint32_t addr, size_t len);
  * @retval 0        If successful.
  * @retval -EINVAL  If info for both slots are NULL.
  */
-int spm_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active);
+__deprecated int spm_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active);
 
 /** Search for the fw_info structure in firmware image located at address.
  *
@@ -107,7 +107,7 @@ int spm_s0_active(uint32_t s0_address, uint32_t s1_address, bool *s0_active);
  * @retval -EINVAL  If info is NULL.
  * @retval -EFAULT  If no info is found.
  */
-int spm_firmware_info(uint32_t fw_address, struct fw_info *info);
+__deprecated int spm_firmware_info(uint32_t fw_address, struct fw_info *info);
 
 /** Prevalidate a B1 update
  *
@@ -121,7 +121,7 @@ int spm_firmware_info(uint32_t fw_address, struct fw_info *info);
  * @retval 0         If the upgrade is invalid.
  * @retval -ENOTSUP  If the functionality is unavailable.
  */
-int spm_prevalidate_b1_upgrade(uint32_t dst_addr, uint32_t src_addr);
+__deprecated int spm_prevalidate_b1_upgrade(uint32_t dst_addr, uint32_t src_addr);
 
 /** Busy wait in secure mode (debug function)
  *
@@ -130,7 +130,7 @@ int spm_prevalidate_b1_upgrade(uint32_t dst_addr, uint32_t src_addr);
  *
  * @param[in]  busy_wait_us  The number of microseconds to wait for.
  */
-void spm_busy_wait(uint32_t busy_wait_us);
+__deprecated void spm_busy_wait(uint32_t busy_wait_us);
 
 /** @brief Prototype of the function that is called in non-secure context from
  *	   secure fault handler context.
@@ -150,13 +150,13 @@ typedef void (*spm_ns_on_fatal_error_t)(void);
  * @retval -ENOTSUP if feature is disabled.
  * @retval 0 on success.
  */
-int spm_set_ns_fatal_error_handler(spm_ns_on_fatal_error_t handler);
+__deprecated int spm_set_ns_fatal_error_handler(spm_ns_on_fatal_error_t handler);
 
 /** @brief Call non-secure fatal error handler.
  *
  * Must be called from fatal error handler.
  */
-void z_spm_ns_fatal_error_handler(void);
+__deprecated void z_spm_ns_fatal_error_handler(void);
 
 #ifdef __cplusplus
 }

--- a/include/spm.h
+++ b/include/spm.h
@@ -11,6 +11,8 @@
 #ifndef SPM_H_
 #define SPM_H_
 
+#include <zephyr/toolchain.h>
+
 /**
  * @defgroup secure_partition_manager Secure Partition Manager
  * @{
@@ -31,7 +33,7 @@ extern "C" {
  * DT_FLASH_AREA_IMAGE_0_NONSECURE_OFFSET_0 and configures the MSP
  * accordingly before jumping to VTOR_NS[1].
  */
-void spm_jump(void);
+__deprecated void spm_jump(void);
 
 
 /** @brief Configure security attributes of flash, RAM, and peripherals.
@@ -39,7 +41,7 @@ void spm_jump(void);
  * This function reads the security attribute options set for peripherals in
  * Kconfig. The RAM and flash partitioning is configured statically.
  */
-void spm_config(void);
+__deprecated void spm_config(void);
 
 #ifdef __cplusplus
 }

--- a/samples/nrf9160/secure_services/CMakeLists.txt
+++ b/samples/nrf9160/secure_services/CMakeLists.txt
@@ -10,5 +10,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(secure_services)
 
 # NORDIC SDK APP START
+zephyr_compile_options(-Wno-deprecated-declarations)
 target_sources(app PRIVATE src/main.c)
 # NORDIC SDK APP END

--- a/samples/spm/CMakeLists.txt
+++ b/samples/spm/CMakeLists.txt
@@ -13,4 +13,6 @@ zephyr_include_directories(
   ${ARCH_DIR}/${ARCH}/include
 )
 
+zephyr_compile_options(-Wno-deprecated-declarations)
+
 zephyr_library_sources(src/main.c)

--- a/samples/spm/README.rst
+++ b/samples/spm/README.rst
@@ -11,7 +11,8 @@ The Secure Partition Manager sample provides a reference use of the System Prote
 This firmware sets up an nRF device with Trusted Execution (|trusted_execution|) so that it can run user applications in the non-secure domain.
 
 .. note::
-   SPM is an alternative for using the Trusted Firmware-M (TF-M). See :ref:`ug_tfm`.
+   SPM is deprecated as of |NCS| v2.1.0 and will be removed in a future version of the SDK.
+   :ref:`Trusted Firmware-M (TF-M) <ug_tfm>` will replace SPM as the trusted execution solution.
 
 To use the Secure Partition Manager instead of TF-M, do the following:
 

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -7,8 +7,7 @@
 menu "SPM"
 
 config SPM
-	bool "Use Secure Partition Manager"
-	default y if TRUSTED_EXECUTION_NONSECURE
+	bool "Use Secure Partition Manager [DEPRECATED]"
 	depends on !BUILD_WITH_TFM
 	select FW_INFO
 	select ENTROPY_CC3XX

--- a/tests/subsys/spm/secure_services/CMakeLists.txt
+++ b/tests/subsys/spm/secure_services/CMakeLists.txt
@@ -9,5 +9,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
+zephyr_compile_options(-Wno-deprecated-declarations)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/spm/thread_swap/CMakeLists.txt
+++ b/tests/subsys/spm/thread_swap/CMakeLists.txt
@@ -9,5 +9,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
+zephyr_compile_options(-Wno-deprecated-declarations)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Mark SPM configuration as deprecated and add __deprecate attribute
to the SPM secure API functions.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>