### PR TITLE
boards: arm: thingy91_nrf9160: Use TF-M as default

### DIFF
--- a/boards/arm/thingy91_nrf9160/Kconfig.defconfig
+++ b/boards/arm/thingy91_nrf9160/Kconfig.defconfig
@@ -9,6 +9,11 @@ if BOARD_THINGY91_NRF9160 || BOARD_THINGY91_NRF9160_NS
 config BOARD
 	default "thingy91_nrf9160"
 
+# By default, if we build for a Non-Secure version of the board,
+# enable building with TF-M as the Secure Execution Environment.
+config BUILD_WITH_TFM
+	default y if BOARD_THINGY91_NRF9160_NS
+
 if BUILD_WITH_TFM
 
 # By default, if we build with TF-M, instruct build system to

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -35,6 +35,11 @@ Application development
 
 * Added information about :ref:`app_build_output_files` on the :ref:`app_build_system` page.
 
+Board support
+-------------
+
+* TF-M is now enabled by default on Thingy:91
+
 Partition Manager
 -----------------
 


### PR DESCRIPTION
Use TF-M as default on thingy91_nrf9160 board.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>