### PR TITLE
manifest: zephyr: Pull restart DHCP APIs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -100,7 +100,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 1508f2ba60f8f606a32daaa48914c3376df45132
+      revision: 8c5ed9a2d35543bed588018353f7fd2106c0d2ae
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 74b34fe10bde956ddecd84104536dcb78a612e5f

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: e5ff5593aec822d2e478cae6a96cd7b00011aed2
+      revision: 6e460c0847d437abb3b519bca048fafccbdd9411
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull Restart DHCP APIs from sdk-zephyr.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>