### PR TITLE
manifest: zephyr: Pull Wi-Fi native data support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: b341c1ffbee9e1694f07a62f55b76b3f4947f603
+      revision: pull/895/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull Wi-Fi offload APIs supporting Ethernet ops as well.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>