### PR TITLE
bluetooth: fast_pair: Do not allow to silently write Account Key

### DIFF
--- a/subsys/bluetooth/services/fast_pair/fp_advertising.c
+++ b/subsys/bluetooth/services/fast_pair/fp_advertising.c
@@ -27,14 +27,14 @@ enum fp_field_type {
 };
 
 static const uint16_t fast_pair_uuid = FP_SERVICE_UUID;
-static const uint8_t flags;
+static const uint8_t version_and_flags;
 static const uint8_t empty_account_key_list;
 
 static size_t bt_fast_pair_adv_data_size_non_discoverable(size_t account_key_cnt)
 {
 	size_t res = 0;
 
-	res += sizeof(flags);
+	res += sizeof(version_and_flags);
 
 	if (account_key_cnt == 0) {
 		res += sizeof(empty_account_key_list);
@@ -83,7 +83,7 @@ size_t bt_fast_pair_adv_data_size(enum bt_fast_pair_adv_mode fp_adv_mode)
 static int fp_adv_data_fill_non_discoverable(struct net_buf_simple *buf, size_t account_key_cnt,
 					     enum fp_field_type ak_filter_type)
 {
-	net_buf_simple_add_u8(buf, flags);
+	net_buf_simple_add_u8(buf, version_and_flags);
 
 	if (account_key_cnt == 0) {
 		net_buf_simple_add_u8(buf, empty_account_key_list);

--- a/subsys/bluetooth/services/fast_pair/fp_auth.c
+++ b/subsys/bluetooth/services/fast_pair/fp_auth.c
@@ -90,6 +90,8 @@ enum bt_security_err auth_pairing_accept(struct bt_conn *conn,
 		return BT_SECURITY_ERR_AUTH_REQUIREMENT;
 	}
 
+	fp_keys_bt_auth_progress(conn, false);
+
 	return BT_SECURITY_ERR_SUCCESS;
 }
 
@@ -169,6 +171,7 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 	}
 
 	LOG_WRN("Pairing failed");
+	fp_keys_drop_key(conn);
 	update_conn_handling(conn, false);
 }
 

--- a/subsys/bluetooth/services/fast_pair/fp_auth.c
+++ b/subsys/bluetooth/services/fast_pair/fp_auth.c
@@ -208,12 +208,6 @@ int fp_auth_start(struct bt_conn *conn, bool send_pairing_req)
 		return -EALREADY;
 	}
 
-	/* Peer is already bonded. Allow to write the account key. */
-	if (bt_conn_get_security(conn) >= BT_SECURITY_L4) {
-		fp_keys_bt_auth_progress(conn, true);
-		return 0;
-	}
-
 	err = bt_conn_auth_cb_overlay(conn, &conn_auth_callbacks);
 	if (err) {
 		return err;


### PR DESCRIPTION
Do not allow to silently write an Account Key. Writing an Account Key after bonding through Bluetooth settings should follow procedure of retroactive Account Key write.

Jira: NCSDK-16311