### PR TITLE
doc: align installing manually steps with Zephyr

### DIFF
--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -372,11 +372,8 @@ The Zephyr Software Development Kit (SDK) contains toolchains for each of Zephyr
 It also includes additional host tools, such as custom QEMU and OpenOCD builds.
 
 .. note::
-
-   Set the following environment variables to ensure the Zephyr SDK is detected correctly:
-
-   * :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr``
-   * :envvar:`ZEPHYR_SDK_INSTALL_DIR` to the path of the Zephyr SDK
+   When updating Zephyr SDK, :ref:`verify the Zephyr SDK variables <zephyr:toolchain_zephyr_sdk_update>`.
+   Make sure that the ``zephyr`` toolchain is selected, not ``gnuarmemb``.
 
 .. ncs-include:: develop/getting_started/index.rst
    :docset: zephyr


### PR DESCRIPTION
Edited lines about setting Zephyr's env vars, now that upmerge is done.
NCSDK-15619.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>

----

This is a follow-up to https://github.com/zephyrproject-rtos/zephyr/pull/46365 on the NCS side. Now that upmerge is done, we can mirror the new structure on the Zephyr side by rephrasing the initial note and pointing to the Installation Troubleshooting section.