### PR TITLE
applications: nrf5340_audio: Choose which broadcaster to sync to

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio.h
@@ -9,7 +9,6 @@
 
 #include <zephyr.h>
 
-/* These defined name only used by CIS */
 #define DEVICE_NAME_PEER CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_PEER_LEN (sizeof(DEVICE_NAME_PEER) - 1)
 


### PR DESCRIPTION
By using BT_DEVICE_NAME

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>