### PR TITLE
Updated sample documentation because of secure firmware change

### DIFF
--- a/samples/nrf9160/gnss/README.rst
+++ b/samples/nrf9160/gnss/README.rst
@@ -20,7 +20,7 @@ The sample supports the following development kit:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/spm.txt
+.. include:: /includes/tfm.txt
 
 Overview
 ********

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -16,7 +16,7 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/spm.txt
+.. include:: /includes/tfm.txt
 
 Overview
 ********


### PR DESCRIPTION
Updated documentation because the secure firmware for `gnss` and `modem_shell` samples was changed from SPM to TF-M.