### PR TITLE
applications: nrf5340_audio: Check if all BIS streams are streaming

### DIFF
--- a/applications/nrf5340_audio/src/audio/streamctrl.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl.c
@@ -345,7 +345,7 @@ static void le_audio_evt_handler(enum le_audio_evt_type event)
 		LOG_DBG("LE audio evt streaming");
 
 		if (strm_state == STATE_STREAMING) {
-			LOG_WRN("Got streaming event in streaming state");
+			LOG_DBG("Got streaming event in streaming state");
 			break;
 		}
 
@@ -360,7 +360,7 @@ static void le_audio_evt_handler(enum le_audio_evt_type event)
 		LOG_DBG("LE audio evt not_streaming");
 
 		if (strm_state == STATE_PAUSED) {
-			LOG_WRN("Got not_streaming event in paused state");
+			LOG_DBG("Got not_streaming event in paused state");
 			break;
 		}
 

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -280,7 +280,7 @@ static void syncable_cb(struct bt_audio_broadcast_sink *sink, bool encrypted)
 
 	ret = bt_audio_broadcast_sink_sync(broadcast_sink, bis_index_bitfield, streams_p, NULL);
 	if (ret) {
-		LOG_ERR("Unable to sync to broadcast source");
+		LOG_WRN("Unable to sync to broadcast source, ret: %d", ret);
 		return;
 	}
 


### PR DESCRIPTION
Before sending audio data

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>