### PR TITLE
doc: Updating samples converted to use TF-M

### DIFF
--- a/applications/machine_learning/README.rst
+++ b/applications/machine_learning/README.rst
@@ -605,6 +605,10 @@ The application uses the following |NCS| libraries and drivers:
 * :ref:`ei_wrapper`
 * :ref:`nus_service_readme`
 
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`
+
 In addition, you can use the :ref:`central_uart` sample together with the application.
 The sample is used to receive data over NUS and forward it to the host over UART.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -144,6 +144,9 @@ Applications
 
 This section provides detailed lists of changes by :ref:`application <applications>`.
 
+* All applications running on non-secure boards are documented to use TF-M as the trusted execution solution by default.
+  SPM is deprecated.
+
 nRF9160: Asset Tracker v2
 -------------------------
 
@@ -278,6 +281,9 @@ Samples
 
 This section provides detailed lists of changes by :ref:`sample <sample>`, including protocol-related samples.
 For lists of protocol-specific changes, see `Protocols`_.
+
+* All samples running on non-secure boards are documented to use TF-M as the trusted execution solution, as SPM is deprecated.
+  Sample :ref:`secure_partition_manager` is the exception.
 
 Bluetooth samples
 -----------------

--- a/samples/app_event_manager/README.rst
+++ b/samples/app_event_manager/README.rst
@@ -41,6 +41,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 Configuration
 *************
 
@@ -50,7 +52,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/app_event_manager`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 
 Testing
@@ -89,3 +91,7 @@ This sample uses the following |NCS| subsystems:
 In addition, it uses the following Zephyr subsystems:
 
 * :ref:`zephyr:logging_api`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/app_event_manager_profiler_tracer/README.rst
+++ b/samples/app_event_manager_profiler_tracer/README.rst
@@ -16,6 +16,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 Overview
 ********
 
@@ -64,7 +66,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/app_event_manager_profiler_tracer`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -112,3 +114,7 @@ This sample uses the following |NCS| subsystems:
 In addition, it uses the following Zephyr subsystems:
 
 * :ref:`zephyr:logging_api`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/central_and_peripheral_hr/README.rst
+++ b/samples/bluetooth/central_and_peripheral_hr/README.rst
@@ -31,6 +31,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 To test just the Bluetooth® LE Central Role operation, you need one of the following setups:
 
   * A smartphone or a tablet running a compatible application.
@@ -62,7 +64,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/central_and_peripheral_hr`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 
 .. _central_and_peripheral_hrs_testing:
@@ -168,3 +170,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/uuid.h``
   * ``include/bluetooth/services/hrs.h``
   * ``include/bluetooth/services/bas.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -24,6 +24,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a device running a BAS Server to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 
 User interface
@@ -38,7 +40,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/central_bas`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. _central_bas_testing:
 
@@ -150,3 +152,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/gatt.h``
   * ``include/bluetooth/hci.h``
   * ``include/bluetooth/uuid.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -29,6 +29,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a HIDS device to connect with (for example, another development kit running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 
 User interface
@@ -56,7 +58,7 @@ Building and Running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/central_hids`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 
 Testing
@@ -182,3 +184,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/hci.h``
   * ``include/bluetooth/conn.h``
   * ``include/bluetooth/uuid.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/central_smp_client/README.rst
+++ b/samples/bluetooth/central_smp_client/README.rst
@@ -32,6 +32,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a device running `mcumgr`_ with transport protocol over Bluetooth® Low Energy, for example, another development kit running the :ref:`smp_svr_sample`.
 
 .. note::
@@ -49,7 +51,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/central_smp_client`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. _bluetooth_central_dfu_smp_testing:
 
@@ -110,3 +112,7 @@ It uses the following Zephyr libraries:
 In addition, it uses the following external library that is distributed with Zephyr:
 
 * `zcbor`_
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/central_uart/README.rst
+++ b/samples/bluetooth/central_uart/README.rst
@@ -41,13 +41,15 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires another development kit running a compatible application (see :ref:`peripheral_uart`).
 
 Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/central_uart`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 
 .. _central_uart_testing:
@@ -99,3 +101,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/gatt.h``
   * ``include/bluetooth/hci.h``
   * ``include/bluetooth/uuid.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -168,3 +168,7 @@ In addition, it uses the following Zephyr libraries:
 * :ref:`zephyr:bluetooth_mesh`:
 
   * ``include/bluetooth/mesh.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -228,3 +228,7 @@ In addition, it uses the following Zephyr libraries:
 * :ref:`zephyr:bluetooth_mesh`:
 
   * ``include/bluetooth/mesh.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -198,3 +198,7 @@ In addition, it uses the following Zephyr libraries:
 * :ref:`zephyr:bluetooth_mesh`:
 
   * ``include/bluetooth/mesh.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -186,3 +186,7 @@ In addition, it uses the following Zephyr libraries:
 * :ref:`zephyr:bluetooth_mesh`:
 
   * ``include/bluetooth/mesh.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/mesh/silvair_enocean/README.rst
+++ b/samples/bluetooth/mesh/silvair_enocean/README.rst
@@ -201,3 +201,7 @@ In addition, it uses the following Zephyr libraries:
 * :ref:`zephyr:bluetooth_mesh`:
 
   * ``include/bluetooth/mesh.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/multiple_adv_sets/README.rst
+++ b/samples/bluetooth/multiple_adv_sets/README.rst
@@ -16,6 +16,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 Overview
 ********
 
@@ -49,7 +51,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/multiple_adv_sets`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. _multiple_adv_sets_testing:
 
@@ -89,3 +91,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/conn.h``
   * ``include/bluetooth/uuid.h``
   * ``include/bluetooth/services/dis.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_ams_client/README.rst
+++ b/samples/bluetooth/peripheral_ams_client/README.rst
@@ -16,6 +16,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a device running an AMS Server to connect with (for example, an iPhone which runs iOS, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 
 Overview
@@ -55,7 +57,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_ams_client`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. _peripheral_ams_client_testing:
 
@@ -278,3 +280,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/conn.h``
   * ``include/bluetooth/uuid.h``
   * ``include/bluetooth/gatt.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_ancs_client/README.rst
+++ b/samples/bluetooth/peripheral_ancs_client/README.rst
@@ -30,6 +30,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a device running an ANCS Server to connect with (for example, an iPhone which runs iOS, or a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 
 User interface
@@ -58,7 +60,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_ancs_client`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. _peripheral_ancs_client_testing:
 
@@ -295,3 +297,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/conn.h``
   * ``include/bluetooth/uuid.h``
   * ``include/bluetooth/gatt.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_cts_client/README.rst
+++ b/samples/bluetooth/peripheral_cts_client/README.rst
@@ -21,6 +21,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a device running a CTS Server to connect with (for example, a Bluetooth® Low Energy dongle and nRF Connect for Desktop).
 
 User interface
@@ -39,7 +41,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_cts_client`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. _peripheral_cts_client_testing:
 
@@ -136,3 +138,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/conn.h``
   * ``include/bluetooth/uuid.h``
   * ``include/bluetooth/gatt.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_fast_pair/README.rst
+++ b/samples/bluetooth/peripheral_fast_pair/README.rst
@@ -46,6 +46,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 .. include:: /includes/hci_rpmsg_overlay.txt
 
 Fast Pair device registration
@@ -135,7 +137,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_fast_pair`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 When building the sample, you must provide the Fast Pair Model ID (:c:macro:`FP_MODEL_ID`) and the Fast Pair Anti Spoofing Key (:c:macro:`FP_ANTI_SPOOFING_KEY`) as CMake options.
 See :ref:`ug_bt_fast_pair_provisioning` for detailed guide.
@@ -238,3 +240,7 @@ This sample uses the :ref:`bt_fast_pair_readme` and its dependencies and is conf
 See :ref:`ug_bt_fast_pair` for details about integrating Fast Pair in the |NCS|.
 
 The :ref:`bt_fast_pair_provision_script` is used by the build system to automatically generate the hexadecimal file that contains Fast Pair Model ID and Anti Spoofing Private Key.
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_gatt_dm/README.rst
+++ b/samples/bluetooth/peripheral_gatt_dm/README.rst
@@ -21,6 +21,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a device to connect to the peripheral, for example, a phone or a tablet with `nRF Connect for Mobile`_ or `nRF Toolbox`_.
 
 User interface
@@ -36,7 +38,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_gatt_dm`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. _peripheral_gatt_dm_testing:
 
@@ -73,3 +75,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/conn.h``
   * ``include/bluetooth/uuid.h``
   * ``include/bluetooth/gatt.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -44,6 +44,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 .. include:: /includes/hci_rpmsg_overlay.txt
 
 If the `NFC_OOB_PAIRING` feature is enabled, the sample requires  a smartphone or a tablet with Android v8.0.0 or newer.
@@ -92,7 +94,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_hids_keyboard`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -234,3 +236,7 @@ References
 * `HID usage tables`_
 * `Bluetooth Secure Simple Pairing Using NFC`_
 * `Bluetooth Core Specification`_ Volume 3 Part H Chapter 2
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -33,6 +33,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 .. include:: /includes/hci_rpmsg_overlay.txt
 
 User interface
@@ -68,7 +70,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_hids_mouse`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -153,6 +155,10 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/uuid.h``
   * ``include/bluetooth/gatt.h``
   * ``samples/bluetooth/gatt/bas.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`
 
 References
 **********

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -24,6 +24,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a smartphone or tablet running a compatible application.
 The `Testing`_ instructions refer to `nRF Connect for Mobile`_, but you can also use other similar applications (for example, `nRF Blinky`_ or `nRF Toolbox`_).
 
@@ -86,7 +88,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_lbs`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Minimal build
 =============
@@ -160,3 +162,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/conn.h``
   * ``include/bluetooth/uuid.h``
   * ``include/bluetooth/gatt.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_mds/README.rst
+++ b/samples/bluetooth/peripheral_mds/README.rst
@@ -17,6 +17,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 .. include:: /includes/hci_rpmsg_overlay.txt
 
 Before using the Memfault platform, you must register an account in the `Memfault registration page`_ and `create a new project in Memfault`_.
@@ -140,7 +142,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_mds`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -256,3 +258,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/bluetooth.h``
   * ``include/bluetooth/conn.h``
   * ``samples/bluetooth/gatt/bas.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_nfc_pairing/README.rst
+++ b/samples/bluetooth/peripheral_nfc_pairing/README.rst
@@ -28,6 +28,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample has the following additional requirements:
 
 * NFC polling device (for example, a smartphone or a tablet with NFC support).
@@ -95,7 +97,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_nfc_pairing`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -141,3 +143,7 @@ It uses the following Zephyr libraries:
 * ``include/zephyr.h``
 * ``include/device.h``
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_rscs/README.rst
+++ b/samples/bluetooth/peripheral_rscs/README.rst
@@ -24,6 +24,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a phone or tablet running a compatible application, for example `nRF Connect for Mobile`_ or `nRF Toolbox`_.
 
 
@@ -40,7 +42,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_rscs`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. _peripheral_rscs_testing:
 
@@ -91,3 +93,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/conn.h``
   * ``include/bluetooth/uuid.h``
   * ``include/bluetooth/gatt.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -17,6 +17,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 .. note::
    * The boards ``nrf52dk_nrf52810``, ``nrf52840dk_nrf52811``, and ``nrf52833dk_nrf52820`` only support the `Minimal sample variant`_.
    * When used with :ref:`zephyr:thingy53_nrf5340`, the sample supports the MCUboot bootloader with serial recovery and SMP DFU over Bluetooth.
@@ -132,7 +134,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/peripheral_uart`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. _peripheral_uart_sample_activating_variants:
 
@@ -210,3 +212,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/gatt.h``
   * ``include/bluetooth/hci.h``
   * ``include/bluetooth/uuid.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/shell_bt_nus/README.rst
+++ b/samples/bluetooth/shell_bt_nus/README.rst
@@ -23,6 +23,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 You also need an additional nRF52 development kit, like the PCA10040 for connecting using the :file:`bt_nus_shell.py` script.
 Alternatively, you can use :ref:`ble_console_readme` for connecting, using Linux only.
 
@@ -31,7 +33,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/bluetooth/shell_bt_nus`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 *******
@@ -93,3 +95,7 @@ In addition, it uses the following Zephyr libraries:
   * ``include/bluetooth/gatt.h``
   * ``samples/bluetooth/gatt/bas.h``
 * :ref:`zephyr:logging_api`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -17,6 +17,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 You can use any two of the development kits listed above and mix different development kits.
 
 .. include:: /includes/hci_rpmsg_overlay.txt
@@ -102,7 +104,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/bluetooth/throughput`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -279,6 +281,9 @@ In addition, it uses the following Zephyr libraries:
 
   * ``include/shell/shell.h``
 
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`
 
 References
 ***********

--- a/samples/edge_impulse/data_forwarder/README.rst
+++ b/samples/edge_impulse/data_forwarder/README.rst
@@ -17,6 +17,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 Overview
 ********
 
@@ -52,7 +54,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/edge_impulse/data_forwarder`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -92,3 +94,7 @@ This sample uses the following |NCS| drivers:
 In addition, it uses the following Zephyr drivers:
 
 * :ref:`zephyr:uart_api`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/edge_impulse/wrapper/README.rst
+++ b/samples/edge_impulse/wrapper/README.rst
@@ -17,6 +17,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 Overview
 ********
 
@@ -78,7 +80,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/edge_impulse/wrapper`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -117,3 +119,7 @@ Dependencies
 This sample uses the following |NCS| subsystems:
 
 * :ref:`ei_wrapper`
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nfc/record_launch_app/README.rst
+++ b/samples/nfc/record_launch_app/README.rst
@@ -17,6 +17,8 @@ This sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a smartphone or a tablet.
 You need to have the `nRF Toolbox`_ app installed for iOS devices.
 
@@ -39,7 +41,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nfc/record_launch_app`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. note::
    |nfc_nfct_driver_note|
@@ -74,3 +76,7 @@ The sample uses the following Zephyr libraries:
 
 * ``include/zephyr.h``
 * ``include/power/reboot.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nfc/record_text/README.rst
+++ b/samples/nfc/record_text/README.rst
@@ -17,6 +17,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a smartphone or tablet.
 
 Overview
@@ -38,7 +40,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nfc/record_text`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. note::
    |nfc_nfct_driver_note|
@@ -70,3 +72,7 @@ It uses the following Zephyr libraries:
 * ``include/device.h``
 * ``include/power/reboot.h``
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nfc/system_off/README.rst
+++ b/samples/nfc/system_off/README.rst
@@ -17,6 +17,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a smartphone or tablet with the NFC feature.
 
 Overview
@@ -67,7 +69,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nfc/system_off`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. note::
    |nfc_nfct_driver_note|
@@ -108,3 +110,7 @@ The sample uses the following Zephyr libraries:
 * ``include/device.h``
 * ``include/power/power.h``
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nfc/tnep_tag/README.rst
+++ b/samples/nfc/tnep_tag/README.rst
@@ -16,6 +16,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 Overview
 ********
 
@@ -48,7 +50,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nfc/tnep_tag`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. note::
    |nfc_nfct_driver_note|
@@ -79,3 +81,7 @@ This sample uses the following |NCS| libraries:
 In addition, it uses the following Zephyr libraries:
 
 * ``include/sys/until.h``
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nfc/writable_ndef_msg/README.rst
+++ b/samples/nfc/writable_ndef_msg/README.rst
@@ -17,6 +17,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires a smartphone or tablet with NFC Tools application (or equivalent).
 
 Overview
@@ -48,7 +50,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/nfc/writable_ndef_msg`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 .. note::
    |nfc_nfct_driver_note|
@@ -83,3 +85,7 @@ It uses the following Zephyr libraries:
 * ``include/device.h``
 * ``include/nvs/nvs.h``
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/gnss/README.rst
+++ b/samples/nrf9160/gnss/README.rst
@@ -165,7 +165,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nrf9160/gnss`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 If the sample is to be used with the SUPL client library, the library must be downloaded and enabled in the sample configuration.
 You can download it from the `Nordic Semiconductor website`_.
@@ -313,7 +313,6 @@ Dependencies
 
 This sample uses the following |NCS| libraries:
 
-* :ref:`secure_partition_manager`
 * :ref:`lib_nrf_cloud_agps`
 * :ref:`lib_nrf_cloud_pgps`
 * :ref:`lib_nrf_cloud_rest`
@@ -328,3 +327,7 @@ It uses the following Zephyr library:
 
 * :ref:`net_socket_offloading`
 * :ref:`settings_api`
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/http_update/application_update/README.rst
+++ b/samples/nrf9160/http_update/application_update/README.rst
@@ -105,7 +105,6 @@ After programming the sample to your development kit, test it by performing the 
 
    .. code-block::
 
-      SPM: prepare to jump to Non-Secure image
       ***** Booting Zephyr OS v1.13.99 *****
 
 #. Observe that **LED 1** is lit.

--- a/samples/nrf9160/lwm2m_carrier/README.rst
+++ b/samples/nrf9160/lwm2m_carrier/README.rst
@@ -16,15 +16,14 @@ The sample supports the following development kit:
 
 .. table-from-sample-yaml::
 
-The sample is configured to compile and run as a non-secure application on nRF91's Cortex-M33.
-Therefore, it automatically includes the :ref:`secure_partition_manager` that prepares the required peripherals to be available for the application.
+.. include:: /includes/tfm.txt
 
 Building and running
 ********************
 
 .. |sample path| replace:: :file:`samples/nrf9160/lwm2m_carrier`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -65,6 +64,6 @@ It uses the following `sdk-nrfxlib`_ library:
 
 * :ref:`nrfxlib:nrf_modem`
 
-In addition, it uses the following sample:
+In addition, it uses the following secure firmware component:
 
-* :ref:`secure_partition_manager`
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/lwm2m_client/sample_description.rst
+++ b/samples/nrf9160/lwm2m_client/sample_description.rst
@@ -19,7 +19,7 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
-.. include:: /includes/spm.txt
+.. include:: /includes/tfm.txt
 
 Additionally, the sample requires an activated SIM card, and an LwM2M server such as `Leshan Demo Server`_ or `Coiote Device Management`_ server.
 
@@ -212,7 +212,7 @@ The following instructions describe how to register your device to `Leshan Demo 
          #. Enter the following data and click :guilabel:`ADD`:
 
             * Endpoint - urn\:imei\:*your Device IMEI*.
-	      The IMEI value is printed on the development kit.
+              The IMEI value is printed on the development kit.
             * Security Mode - psk
             * Identity: - urn\:imei\:*your Device IMEI*
             * Key - 000102030405060708090a0b0c0d0e0f
@@ -226,7 +226,7 @@ The following instructions describe how to register your device to `Leshan Demo 
          #. Enter the following data and click :guilabel:`Add device`:
 
             * Endpoint - urn\:imei\:*your Device IMEI*.
-	      The IMEI value is printed on the development kit.
+              The IMEI value is printed on the development kit.
             * Friendly Name - *recognizable name*.
             * Security mode - psk (Pre-Shared Key).
             * Key - 000102030405060708090a0b0c0d0e0f.
@@ -494,7 +494,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nrf9160/lwm2m_client`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 After building and running the sample, you can locate your device in the server:
 
@@ -594,6 +594,6 @@ It uses the following Zephyr libraries:
 * :ref:`pwm_api`
 * :ref:`sensor_api`
 
-In addition, it uses the following sample:
+In addition, it uses the following secure firmware component:
 
-* :ref:`secure_partition_manager`
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -766,7 +766,7 @@ Building and running
 
 .. |sample path| replace:: :file:`samples/nrf9160/modem_shell`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 See :ref:`cmake_options` for instructions on how to provide CMake options, for example to use a configuration overlay.
 
@@ -1131,3 +1131,7 @@ This sample uses the following |NCS| libraries:
 This sample uses the following `sdk-nrfxlib`_ libraries:
 
 * :ref:`nrfxlib:nrf_modem`
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/nrf_cloud_rest_cell_pos/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_cell_pos/README.rst
@@ -100,3 +100,7 @@ This sample uses the following |NCS| libraries:
 * :ref:`modem_info_readme`
 * :ref:`app_event_manager`
 * :ref:`caf_overview`
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/nrf_cloud_rest_device_message/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_device_message/README.rst
@@ -116,3 +116,7 @@ This sample uses the following |NCS| libraries:
 * :ref:`dk_buttons_and_leds_readme`
 * :ref:`modem_info_readme`
 * :ref:`lib_at_host`
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/nrf_cloud_rest_fota/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_fota/README.rst
@@ -124,3 +124,7 @@ This sample uses the following |NCS| libraries:
 * :ref:`dk_buttons_and_leds_readme`
 * :ref:`modem_info_readme`
 * :ref:`lib_at_host`
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf9160/sms/README.rst
+++ b/samples/nrf9160/sms/README.rst
@@ -113,3 +113,7 @@ This sample uses the following |NCS| library:
 It uses the following `sdk-nrfxlib`_ library:
 
 * :ref:`nrfxlib:nrf_modem`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/nrf_profiler/README.rst
+++ b/samples/nrf_profiler/README.rst
@@ -17,6 +17,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 Overview
 ********
 
@@ -36,7 +38,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/nrf_profiler`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -71,3 +73,7 @@ Dependencies
 This sample uses the following |NCS| subsystems:
 
 * :ref:`nrf_profiler`
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -539,3 +539,7 @@ The following dependencies are added by the optional multiprotocol Bluetooth® L
   * ``include/bluetooth/gatt.h``
   * ``include/bluetooth/hci.h``
   * ``include/bluetooth/uuid.h``
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -274,3 +274,7 @@ The following dependencies are added by the optional multiprotocol Bluetooth LE 
   * ``include/bluetooth/gatt.h``
   * ``include/bluetooth/hci.h``
   * ``include/bluetooth/uuid.h``
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/openthread/coap_server/README.rst
+++ b/samples/openthread/coap_server/README.rst
@@ -123,3 +123,7 @@ In addition, it uses the following Zephyr libraries:
 OpenThread CoAP API is used in this sample:
 
 * `OpenThread CoAP API`_
+
+In addition, it uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`

--- a/samples/peripheral/lpuart/README.rst
+++ b/samples/peripheral/lpuart/README.rst
@@ -16,6 +16,8 @@ The sample supports the following development kits:
 
 .. table-from-sample-yaml::
 
+.. include:: /includes/tfm.txt
+
 The sample also requires the following pins to be shorted:
 
 * TX (Arduino Digital Pin 10 (4 on nRF21540 DK)) with RX (Arduino Digital Pin 11 (5 on nRF21540 DK))
@@ -43,7 +45,7 @@ Building and running
 ********************
 .. |sample path| replace:: :file:`samples/peripheral/lpuart`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_ns.txt
 
 Testing
 =======
@@ -66,3 +68,7 @@ In addition, it uses the following Zephyr libraries:
 
 * :ref:`zephyr:device_model_api`
 * :ref:`zephyr:logging_api`
+
+The sample also uses the following secure firmware component:
+
+* :ref:`Trusted Firmware-M <ug_tfm>`


### PR DESCRIPTION
Updated samples and applications to reflect
use of TF-M instead of SPM.
Except for secure services sample for nRF9160.

Checked for ALL apps and samples with _ns build target
listed in requirements table and made sure they referred to
tfm.txt and build_and_run_ns.txt.

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>