### PR TITLE
samples: matter: reduce MCUBoot partition size

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -441,6 +441,7 @@ Matter samples
 
 * Removed the low-power configuration build type from all Matter samples.
 * Optimized the usage of the QSPI NOR flash sleep mode to reduce power consumption during the Matter commissioning.
+* Reduced the size of MCUBoot partition on ``nrf5340dk_nrf5340_cpuapp`` by 16kB.
 
 * :ref:`matter_light_switch_sample`:
 

--- a/samples/matter/light_bulb/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/samples/matter/light_bulb/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/samples/matter/light_switch/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/samples/matter/template/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/samples/matter/template/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/samples/matter/window_covering/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/samples/matter/window_covering/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:


### PR DESCRIPTION
MCUBoot partition has 48kB in Matter samples, while 32kB seems to be sufficient.

test-sdk-nrf: PR-238