### PR TITLE
doc: Add bt_mesh_sensor_ch_str_real to release notes

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -574,6 +574,9 @@ Bluetooth libraries and services
       *  :ref:`bt_mesh_lightness_srv_readme`
       * Replay protection list (RPL)
 
+  * Updated:
+
+    * The ``bt_mesh_sensor_ch_str_real`` function is now replaced with the :c:func:`bt_mesh_sensor_ch_str` function, which was previously a macro.
 
 Bootloader libraries
 --------------------


### PR DESCRIPTION
Function `bt_mesh_sensor_ch_str_real` has been replaced with
`bt_mesh_sensor_ch_str` in
3a983aab723bf98efcf2a2300fdcec286d6e8944 commit. This needs to be
mentioned in the release notes.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>