### PR TITLE
doc: tfm/spm related update for includes files

### DIFF
--- a/doc/nrf/includes/build_and_run_ns.txt
+++ b/doc/nrf/includes/build_and_run_ns.txt
@@ -1,6 +1,5 @@
 This sample can be found under |sample path| in the |NCS| folder structure.
 
 When built as a non-secure firmware image for the ``_ns`` build target, the sample automatically includes the :ref:`Trusted Firmware-M <ug_tfm>` (TF-M).
-You can configure it to use the :ref:`secure_partition_manager` instead of TF-M.
 
 See :ref:`gs_programming` for information about how to build and program the application and :ref:`gs_testing` for general information about testing and debugging in the |NCS|.

--- a/doc/nrf/includes/tfm.txt
+++ b/doc/nrf/includes/tfm.txt
@@ -1,4 +1,2 @@
 When built for an ``_ns`` build target, the sample is configured to compile and run as a non-secure application.
 Therefore, it automatically includes :ref:`Trusted Firmware-M <ug_tfm>` that prepares the required peripherals and secure services to be available for the application.
-
-You can also configure it to use the :ref:`secure_partition_manager`.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -916,5 +916,6 @@ Documentation
   * :ref:`ug_thread_configuring` page to better indicate what is required and what is optional.
     Also added further clarifications to the page to make everything clearer.
   * :ref:`ug_matter_tools` page with a new section about the ZAP tool.
+  * Updated TF-M/SPM related files, included in samples and applications with _ns build targets, to no longer include SPM as an alternative to TF-M.
 
 .. |no_changes_yet_note| replace:: No changes since the latest |NCS| release.


### PR DESCRIPTION
Since we're deprecating SPM, updated tfm.txt and
build_and_run_ns.txt includes files, used in
samples and applications with _ns build targets,
to no longer include SPM as an alternative to TF-M.

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>