### PR TITLE
lib: lte_lc: update CEREG scanf format

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -607,6 +607,10 @@ Modem libraries
 
 * Updated:
 
+  * :ref:`lte_lc_readme` library:
+
+    * Fixed an issue that caused stack corruption in the :c:func:`lte_lc_nw_reg_status_get` function.
+
   * :ref:`at_monitor_readme` library:
 
     * The :c:func:`at_monitor_pause` and :c:func:`at_monitor_resume` macros are now functions, and take a pointer to the AT monitor entry.

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1086,7 +1086,7 @@ int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status)
 	err = nrf_modem_at_scanf("AT+CEREG?",
 		"+CEREG: "
 		"%*u,"		/* <n> */
-		"%u,"		/* <stat> */
+		"%hu,"		/* <stat> */
 		"%*[^,],"	/* <tac> */
 		"\"%x\",",	/* <ci> */
 		&status_tmp,


### PR DESCRIPTION
<stat> was being copied into a 4 byte area,
but the variable `status_tmp` was only 2 bytes long.

This corrupted the stack.

PRs #8007 and #8274 were opened for this issue, but were not merged.