### PR TITLE
manifest: zephyr: Use nRF Wi-Fi management for stats

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6e460c0847d437abb3b519bca048fafccbdd9411
+      revision: pull/899/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
For nrf700x we use nRF Wi-Fi management, so, for statistics to work, use
nRF Wi-Fi management.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>