### PR TITLE
manifest: Update zephyr with test fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 6e460c0847d437abb3b519bca048fafccbdd9411
+      revision: pull/900/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update zephyr with fix for tests/subsys/logging/log_core_additional
test.

Regression introduced by https://github.com/nrfconnect/sdk-zephyr/pull/888

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>