### PR TITLE
bluetooth: fast_pair: Update Kconfig of Personalized Name

### DIFF
--- a/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
+++ b/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
@@ -14,10 +14,13 @@ menuconfig BT_FAST_PAIR
 if BT_FAST_PAIR
 
 config BT_FAST_PAIR_EXT_PN
-	bool "Personalized Name extension"
+	bool
 	select BT_FAST_PAIR_STORAGE_EXT_PN
 	help
 	  Enable Fast Pair Personalized Name extension.
+
+	  The feature is not fully supported. Fast Pair Service's Additional
+	  Data characteristic is not implemented.
 
 rsource "fp_crypto/Kconfig.fp_crypto"
 rsource "fp_storage/Kconfig.fp_storage"

--- a/subsys/bluetooth/services/fast_pair/fp_storage/Kconfig.fp_storage
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/Kconfig.fp_storage
@@ -31,7 +31,7 @@ config BT_FAST_PAIR_STORAGE_EXPOSE_PRIV_API
 	  The option could be used by unit tests to prepopulate settings with mocked data.
 
 config BT_FAST_PAIR_STORAGE_EXT_PN
-	bool "Fast Pair storage for Personalized Name extension"
+	bool
 	help
 	  Add Fast Pair storage source files for Personalized Name extension.
 


### PR DESCRIPTION
Change removes prompt from Personalized Name feature Kconfig and adds a note to inform that the feature is not yet fully supported.

The Personalized Name storage no longer provides prompt - it's selected by Personalized Name feature Kconfig.