### PR TITLE
doc: updates related to spm deprecation

### DIFF
--- a/doc/nrf/app_power_opt.rst
+++ b/doc/nrf/app_power_opt.rst
@@ -52,20 +52,6 @@ To disable serial output, you must change the project configuration associated w
 
 1. Set the project configuration ``CONFIG_SERIAL`` to ``n`` irrespective of whether you are building the sample for the secure or non-secure build targets.
 #. For the non-secure build target (``nrf9160dk_nrf9160_ns``), ensure that serial logging is also disabled in Trusted Firmware-M by setting :kconfig:option:`CONFIG_TFM_LOG_LEVEL_SILENCE` to ``y``.
-   If using :ref:`secure_partition_manager`, disable serial logging by completing the following steps:
-
-   a. Add a :file:`spm.conf` file in the project directory with the following content:
-
-      .. code-block:: console
-
-	      CONFIG_IS_SPM=y
-	      CONFIG_FW_INFO=y
-	      CONFIG_GPIO=y
-	      CONFIG_SERIAL=n
-
-
-   #. Add the entry ``set(spm_CONF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/spm.conf)`` below the ``cmake_minimum_required(<VERSION x.x.x>)`` entry in the :file:`CMakeLists.txt` file.
-
 
 The output on Power Profiler Kit II shows the power consumption on an nRF9160 DK with the sample compiled for the ``nrf9160dk_nrf9160`` build target with ``CONFIG_SERIAL=n``.
 

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1624,6 +1624,8 @@ Unstable NFC tag samples
 Secure Partition Manager (SPM)
 ==============================
 
+The Secure Partition Manager (SPM) is deprecated as of |NCS| v2.1.0, replaced by the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
+
 .. rst-class:: v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
 
 NCSIDB-114: Default logging causes crash

--- a/doc/nrf/templates/sample_README.rst
+++ b/doc/nrf/templates/sample_README.rst
@@ -38,8 +38,6 @@ Requirements
    * If several kits are required to test the sample, state it after the table (for example, "You can use one or more of the development kits listed above and mix different development kits.").
    * Mention additional requirements after the table.
    * If TFM is included in the sample, add ``.. include:: /includes/tfm.txt`` to include the standard text that states this.
-     Else, if SPM is included in the sample, add ``.. include:: /includes/spm.txt`` to include the standard text that states this.
-     For samples that support both nRF9160 DK and Thingy:91, use ``.. include:: /includes/tfm_spm_thingy91.txt`` standard text.
 
 The sample supports the following development kits:
 
@@ -49,7 +47,7 @@ The sample supports the following development kits:
 
 The sample also requires ...
 
-.. include:: /includes/spm.txt
+.. include:: /includes/tfm.txt
 
 
 Overview
@@ -177,8 +175,7 @@ Building and running
 ********************
 
 .. note::
-   * Include the standard text for building - either ``.. include:: /includes/build_and_run.txt`` or ``.. include:: /includes/build_and_run_ns.txt``.
-     For samples that support both nRF9160 DK and Thingy:91, use ``.. include:: /includes/thingy91_build_and_run.txt`` standard text.
+   * Include the standard text for building - either ``.. include:: /includes/build_and_run.txt``, or ``.. include:: /includes/build_and_run_ns.txt`` for the non-secure build targets.
    * The main supported IDE for |NCS| is |VSC|, with the |nRFVSC| installed.
      Therefore, build instructions for the |nRFVSC| are required.
      Build instructions for the command line are optional.

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -41,13 +41,6 @@ When to use multiple images
 
 In the |NCS|, multiple images are required in the following scenarios:
 
-nRF9160 SPU configuration
-   The nRF9160 SiP application MCU is divided into a secure and non-secure domain.
-   The code in the secure domain can configure the System Protection Unit (SPU) to allow non-secure access to the CPU resources that are required by the application, and then jump to the code in the non-secure domain.
-   Therefore, each nRF9160 sample (the parent image) requires the :ref:`secure_partition_manager` (the child image) to be programmed together with the actual application.
-
-   See :ref:`zephyr:nrf9160dk_nrf9160` and :ref:`ug_nrf9160` for more information.
-
 First-stage and second-stage bootloaders
    The first-stage bootloader establishes a root of trust by verifying the next step in the boot sequence.
    This first-stage bootloader is immutable, which means it cannot be updated or deleted.
@@ -89,7 +82,7 @@ When building the child image from the source or using a prebuilt HEX file, the 
 This means that you can enable and integrate an additional image just by using the default configuration.
 
 To change the default configuration and configure how a child image is handled, locate the BUILD_STRATEGY configuration options for the child image in the parent image configuration.
-For example, to use a prebuilt HEX file of the :ref:`secure_partition_manager` instead of building it, select :kconfig:option:`CONFIG_SPM_BUILD_STRATEGY_USE_HEX_FILE` instead of the default :kconfig:option:`CONFIG_SPM_BUILD_STRATEGY_FROM_SOURCE`, and specify the HEX file in :kconfig:option:`CONFIG_SPM_HEX_FILE`.
+For example, to use a prebuilt HEX file of the MCUboot instead of building it, select :kconfig:option:`CONFIG_MCUBOOT_BUILD_STRATEGY_USE_HEX_FILE` instead of the default :kconfig:option:`CONFIG_MCUBOOT_BUILD_STRATEGY_FROM_SOURCE`, and specify the HEX file in :kconfig:option:`CONFIG_MCUBOOT_HEX_FILE`.
 To ignore an MCUboot child image, select :kconfig:option:`CONFIG_MCUBOOT_BUILD_STRATEGY_SKIP_BUILD` instead of :kconfig:option:`CONFIG_MCUBOOT_BUILD_STRATEGY_FROM_SOURCE`.
 
 .. _ug_multi_image_defining:
@@ -113,13 +106,6 @@ To do so, place the code from the following example in the CMake tree that is co
 In the |NCS|, the code is included in the :file:`CMakeLists.txt` file for the samples, and in the MCUboot repository.
 
 .. code-block:: cmake
-
-   if (CONFIG_SPM)
-     add_child_image(
-       NAME spm
-       SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/spm
-       )
-   endif()
 
    if (CONFIG_SECURE_BOOT)
      add_child_image(

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -61,37 +61,24 @@ In Zephyr, the firmware of the application core is built using one of the follow
 * ``nrf5340dk_nrf5340_cpuapp`` for the secure domain.
 * ``nrf5340dk_nrf5340_cpuapp_ns`` for the non-secure domain.
   On selecting this build target, the build system includes an additional secure firmware component before building the main firmware on the non-secure domain.
-  The additional component can either be :ref:`Trusted Firmware-M (TF-M) <ug_tfm>` or :ref:`Secure Partition Manager (SPM) <secure_partition_manager>`.
+  The additional component is :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
 
 .. note::
    In |NCS| releases before v1.6.1, the build target ``nrf5340dk_nrf5340_cpuapp_ns`` was named ``nrf5340dk_nrf5340_cpuappns``.
 
-The |NCS| provides two alternatives for running applications from the non-secure area of the memory: Trusted Firmware-M and Secure Partition Manager.
+The |NCS| provides Trusted Firmware-M for running applications from the non-secure area of the memory.
+The Secure Partition Manager (SPM) is deprecated.
 
 Trusted Firmware-M (TF-M)
 -------------------------
 
 Trusted Firmware-M provides a configurable set of software components to create a Trusted Execution Environment.
-It has replaced Secure Partition Manager as the default solution used by most |NCS| applications and samples.
+It has replaced Secure Partition Manager as the solution used by |NCS| applications and samples.
 This means that when you build your application for the non-secure domain, the :ref:`TF-M <ug_tfm>` is automatically included in the build.
 It is a framework for functions and use cases beyond the scope of Secure Partition Manager.
 
 For more information about the TF-M, see :ref:`ug_tfm`.
 See also :ref:`tfm_hello_world` for a sample that demonstrates how to add TF-M to an application.
-
-Secure Partition Manager (SPM)
-------------------------------
-
-The :ref:`secure_partition_manager` sample uses the SPU peripheral to configure security attributions for flash, SRAM, and peripherals.
-After the configuration setup is complete, the sample loads the application firmware from the non-secure domain.
-In addition, the SPM sample provides the application firmware with access to secure services.
-
-You can use :ref:`secure_partition_manager` as an alternative to Trusted Firmware-M (TF-M) for running an application from the non-secure area of the memory.
-
-To use the Secure Partition Manager instead of TF-M, do the following:
-
-* Disable the automatic inclusion of TF-M by setting the option :kconfig:option:`CONFIG_BUILD_WITH_TFM` to ``n`` in the project configuration.
-* Set the option :kconfig:option:`CONFIG_SPM` to ``y``.
 
 .. _ug_nrf5340_intro_inter_core:
 

--- a/doc/nrf/ug_nrf91_features.rst
+++ b/doc/nrf/ug_nrf91_features.rst
@@ -69,25 +69,12 @@ Trusted Firmware-M (TF-M)
 -------------------------
 
 Trusted Firmware-M provides a configurable set of software components to create a Trusted Execution Environment.
-It has replaced Secure Partition Manager as the default solution used by most |NCS| applications and samples.
+It has replaced Secure Partition Manager as the solution used by |NCS| applications and samples.
 This means that when you build your application for ``_ns`` build targets, TF-M is automatically included in the build.
 TF-M is a framework for functions and use cases beyond the scope of Secure Partition Manager.
 
 For more information about the TF-M, see :ref:`ug_tfm`.
 See also :ref:`tfm_hello_world` for a sample that demonstrates how to add TF-M to an application.
-
-.. _nrf9160_ug_secure_partition_manager:
-
-Secure Partition Manager
-------------------------
-
-The :ref:`secure_partition_manager` sample provides a reference implementation of a Secure Partition Manager firmware.
-You can use :ref:`secure_partition_manager` as an alternative to Trusted Firmware-M (TF-M) for running an application from the non-secure area of the memory.
-
-To use the Secure Partition Manager instead of TF-M, do the following:
-
-* Disable the automatic inclusion of TF-M by setting the option :kconfig:option:`CONFIG_BUILD_WITH_TFM` to ``n`` in the project configuration.
-* Set the option :kconfig:option:`CONFIG_SPM` to ``y``.
 
 Application
 -----------

--- a/doc/nrf/ug_tfm.rst
+++ b/doc/nrf/ug_tfm.rst
@@ -77,7 +77,7 @@ A minimal version of the TF-M secure application is provided in |NCS| to show ho
 
 The secure services supported by this minimal version allow for generating random numbers, and the platform services.
 
-This corresponds to the feature set provided by the :ref:`secure_partition_manager` (SPM).
+This corresponds to the feature set provided by the deprecated :ref:`secure_partition_manager` (SPM).
 
 The minimal version of TF-M is disabled by setting the :kconfig:option:`CONFIG_TFM_PROFILE_TYPE_NOT_SET` option or one of the other build profiles.
 

--- a/samples/spm/README.rst
+++ b/samples/spm/README.rst
@@ -7,12 +7,12 @@ Secure Partition Manager
    :local:
    :depth: 2
 
-The Secure Partition Manager sample provides a reference use of the System Protection Unit peripheral.
+The Secure Partition Manager (SPM) sample provides a reference use of the System Protection Unit peripheral.
 This firmware sets up an nRF device with Trusted Execution (|trusted_execution|) so that it can run user applications in the non-secure domain.
 
 .. note::
    SPM is deprecated as of |NCS| v2.1.0 and will be removed in a future version of the SDK.
-   :ref:`Trusted Firmware-M (TF-M) <ug_tfm>` will replace SPM as the trusted execution solution.
+   :ref:`Trusted Firmware-M (TF-M) <ug_tfm>` has replaced SPM as the trusted execution solution.
 
 To use the Secure Partition Manager instead of TF-M, do the following:
 


### PR DESCRIPTION
Removing SPM information where possible to
reduce visibility, and making sure we state it is
deprecated in e.g. user guides, making the TF-M the only
option.

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>