### PR TITLE
mpsl: subsys: Support direct dynamic interrupts

### DIFF
--- a/doc/nrf/libraries/mpsl/mpsl_lib.rst
+++ b/doc/nrf/libraries/mpsl/mpsl_lib.rst
@@ -1,0 +1,22 @@
+.. _mpsl_lib:
+
+Multiprotocol Service Layer library control
+###########################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The Multiprotocol Service Layer library control methods make it possible to control the initialization and uninitialization of the :ref:`nrfxlib:mpsl` library and all required interrupt handlers.
+Uninitializing MPSL allows the application to have full control over the `RADIO_IRQn`, `RTC0_IRQn`, and `TIMER0_IRQn` interrupts.
+
+:kconfig:option:`CONFIG_MPSL_DYNAMIC_INTERRUPTS` enables use of dynamic interrupts for MPSL and allows interrupt reconfiguration.
+
+API documentation
+*****************
+
+| Header file: :file:`include/mpsl/mpsl_lib.h`
+
+.. doxygengroup:: mpsl_lib
+   :project: nrf
+   :members:

--- a/include/mpsl/mpsl_lib.h
+++ b/include/mpsl/mpsl_lib.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file mpsl_lib.h
+ *
+ * @defgroup mpsl_lib Multiprotocol Service Layer library control.
+ *
+ * @brief Methods for initializing MPSL and required interrupt handlers.
+ * @{
+ */
+
+#ifndef MPSL_LIB__
+#define MPSL_LIB__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/** @brief Initialize MPSL and attach interrupt handlers.
+ *
+ * This routine initializes MPSL (via `mpsl_init`) after
+ * it has been uninitialized via @ref mpsl_lib_uninit, and attaches
+ * all required interrupt handlers.
+ *
+ * @pre This method requires CONFIG_MPSL_DYNAMIC_INTERRUPTS to be enabled and
+ *      MPSL to have been previously uninitialized via @ref mpsl_lib_uninit.
+ *
+ * @note
+ * After successful execution of this method, any existing interrupt handlers
+ * will be detached from RADIO_IRQn, RTC0_IRQn, and TIMER0_IRQn.
+ *
+ * @retval   0             MPSL enabled successfully.
+ * @retval   -NRF_EPERM    Operation is not supported or
+ *                         MPSL is already initialized.
+ * @retval   -NRF_EINVAL   Invalid parameters supplied to MPSL.
+ */
+int32_t mpsl_lib_init(void);
+
+/** @brief Uninitialize MPSL and disable interrupt handlers.
+ *
+ * This routine uninitializes MPSL (via `mpsl_uninit`) and
+ * disables MPSL interrupts. Uninitializing MPSL stops clocks and scheduler.
+ * This will release all peripherals and reduce power usage, allowing the
+ * user to override any interrupt handlers used by MPSL.
+ *
+ * @pre This method requires CONFIG_MPSL_DYNAMIC_INTERRUPTS to be enabled.
+ *
+ * @note
+ * After successful execution of this method, user-supplied interrupt
+ * handlers can be attached to RADIO_IRQn, RTC0_IRQn, and TIMER0_IRQn
+ * using `irq_connect_dynamic`.
+ * Care must be taken when developing these handlers, as they will be
+ * executed as direct dynamic interrupts.
+ * See `ARM_IRQ_DIRECT_DYNAMIC_CONNECT` for additional documentation.
+ * These interrupts will trigger thread re-scheduling upon return.
+ *
+ * @retval   0             MPSL disabled successfully.
+ * @retval   -NRF_EPERM    Operation is not supported.
+ */
+int32_t mpsl_lib_uninit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MPSL_LIB__ */
+
+/**@} */

--- a/subsys/mpsl/init/Kconfig
+++ b/subsys/mpsl/init/Kconfig
@@ -31,6 +31,14 @@ config MPSL_ASSERT_HANDLER
 	  application code and will be invoked whenever the
 	  MPSL code encounters an unrecoverable error.
 
+config MPSL_DYNAMIC_INTERRUPTS
+	bool "Use direct dynamic interrupts for MPSL IRQ handlers"
+	depends on DYNAMIC_DIRECT_INTERRUPTS
+	help
+	  This option configures MPSL IRQ handlers using direct dynamic
+	  interrupts. This allows reconfiguring TIMER0_IRQn, RTC0_IRQn,
+	  and RADIO_IRQn handlers during runtime when MPSL is uninitialized.
+
 module=MPSL
 module-str=MPSL
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Use direct dynamic interrupts for MPSL IRQ handlers when configured.
Allows reconfiguring TIMER0_IRQn, RTC0_IRQn, and RADIO_IRQn handlers
during runtime when MPSL is uninitialized.

Signed-off-by: Aleksandar Stanoev <aleksandar.stanoev@nordicsemi.no>