### PR TITLE
applications: nrf5340_audio: Include mandatory codec support

### DIFF
--- a/applications/nrf5340_audio/LICENSE
+++ b/applications/nrf5340_audio/LICENSE
@@ -1,10 +1,6 @@
-/*************************************************************************************************/
+LicenseID:  LicenseRef-PCFT
 
-Copyright (c) 2021, PACKETCRAFT, INC.
-
-All rights reserved.
-/*************************************************************************************************/
-
+ExtractedText: <text>
 Redistribution and use of the Audio subsystem for nRF5340 Software, in binary
 and source code forms, with or without modification, are permitted provided that
 the following conditions are met:
@@ -36,3 +32,5 @@ OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTE
 AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
+
+</text>

--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -12,9 +12,9 @@ choice AUDIO_FRAME_DURATION
 	prompt "Select frame duration - 7.5 ms frame duration is not tested"
 	default AUDIO_FRAME_DURATION_10_MS
 	help
-		LC3 supports frame duration of 7.5 and 10 ms
-		If USB is selected as audio source, we should
-		have a frame duration of 10 ms since USB sends 1ms at a time
+	  LC3 supports frame duration of 7.5 and 10 ms.
+	  If USB is selected as audio source, we should
+	  have a frame duration of 10 ms since USB sends 1ms at a time.
 
 config AUDIO_FRAME_DURATION_7_5_MS
 	bool "Frame duration 7.5 ms"
@@ -28,31 +28,45 @@ config AUDIO_FRAME_DURATION_US
 	default 7500 if AUDIO_FRAME_DURATION_7_5_MS
 	default 10000 if AUDIO_FRAME_DURATION_10_MS
 	help
-		Audio frame duration in µs
+	  Audio frame duration in µs.
+
+choice AUDIO_SAMPLE_RATE
+	prompt "Audio sample rate"
+	default AUDIO_SAMPLE_RATE_48000_HZ if BT_AUDIO_BROADCAST_RECOMMENDED || BT_AUDIO_UNICAST_RECOMMENDED
+	default AUDIO_SAMPLE_RATE_16000_HZ if BT_AUDIO_BROADCAST_16_2_1 || BT_AUDIO_BROADCAST_16_2_2 || BT_AUDIO_UNICAST_16_2_1
+	default AUDIO_SAMPLE_RATE_24000_HZ if BT_AUDIO_BROADCAST_24_2_1 || BT_AUDIO_BROADCAST_24_2_2 || BT_AUDIO_UNICAST_24_2_1
+	help
+	  This will be selected based on the BAP settings.
+
+config AUDIO_SAMPLE_RATE_16000_HZ
+	bool "16 kHz"
+	depends on AUDIO_SOURCE_I2S
+
+config AUDIO_SAMPLE_RATE_24000_HZ
+	bool "24 kHz"
+	depends on AUDIO_SOURCE_I2S
+
+config AUDIO_SAMPLE_RATE_48000_HZ
+	bool "48 kHz"
+endchoice
 
 config AUDIO_SAMPLE_RATE_HZ
-	int "Sample rate Hz"
-	range 48000 48000
-	default 48000
+	int
+	default 16000 if AUDIO_SAMPLE_RATE_16000_HZ
+	default 24000 if AUDIO_SAMPLE_RATE_24000_HZ
+	default 48000 if AUDIO_SAMPLE_RATE_48000_HZ
 	help
-		For now 48 kHz is the only sample rate supported
+	  I2S supports 16, 24, and 48 kHz sample rates for both input and output.
+	  USB supports only 48 kHz for input.
 
 choice AUDIO_BIT_DEPTH
 	prompt "Audio bit depth"
 	default AUDIO_BIT_DEPTH_16
 	help
-		Select the bit depth for audio
+	  Select the bit depth for audio.
 
 config AUDIO_BIT_DEPTH_16
 	bool "16 bit audio"
-
-config AUDIO_BIT_DEPTH_24
-	bool "24 bit audio"
-	help
-		Setting a 24 bit depth for I2S leads to a mismatch between
-		requested MCK and actual MCK. Even though requested LRCLK is
-		48 kHz, actual LRCLK might be 42 kHz or 51 kHz, depending on
-		ratio and ACLK settings
 
 config AUDIO_BIT_DEPTH_32
 	bool "32 bit audio"
@@ -61,32 +75,28 @@ endchoice
 config AUDIO_BIT_DEPTH_BITS
 	int
 	default 16 if AUDIO_BIT_DEPTH_16
-	default 32 if AUDIO_BIT_DEPTH_24
 	default 32 if AUDIO_BIT_DEPTH_32
 	help
-		Bit depth of one sample in storage. Note that 24 bit depth
-		requires 32 bit for storage
+	  Bit depth of one sample in storage.
 
 config AUDIO_BIT_DEPTH_OCTETS
 	int
 	default 2 if AUDIO_BIT_DEPTH_16
-	default 4 if AUDIO_BIT_DEPTH_24
 	default 4 if AUDIO_BIT_DEPTH_32
 	help
-		Bit depth of one sample in storage given in octets.
-		Note that 24 bit depth requires 4 octets for storage
+	  Bit depth of one sample in storage given in octets.
 
 choice AUDIO_SOURCE_GATEWAY
 	prompt "Audio source for gateway"
 	default AUDIO_SOURCE_USB
 	help
-		Select audio source for the gateway
+	  Select audio source for the gateway.
 
 config AUDIO_SOURCE_USB
 	bool "Use USB as audio source"
 	help
-		Set USB as audio source. Note that this forces the
-		stream to be unidirectional because of CPU load
+	  Set USB as audio source. Note that this forces the
+	  stream to be unidirectional because of CPU load.
 
 config AUDIO_SOURCE_I2S
 	bool "Use I2S as audio source"
@@ -96,20 +106,20 @@ choice AUDIO_HEADSET_CHANNEL
 	prompt "Headset audio channel assignment"
 	default AUDIO_HEADSET_CHANNEL_RUNTIME
 	help
-		Set whether audio channel assignment for the headset
-		should happen at runtime or compile-time.
+	  Set whether audio channel assignment for the headset
+	  should happen at runtime or compile-time.
 
 config AUDIO_HEADSET_CHANNEL_RUNTIME
 	bool "Select at runtime"
 	help
-		Make channel selection at runtime. Selected value is stored in persistent memory.
-		Left channel: Hold volume-down button on headset while resetting headset.
-		Right channel: Hold volume-up button on headset while resetting headset.
+	  Make channel selection at runtime. Selected value is stored in persistent memory.
+	  Left channel: Hold volume-down button on headset while resetting headset.
+	  Right channel: Hold volume-up button on headset while resetting headset.
 
 config AUDIO_HEADSET_CHANNEL_COMPILE_TIME
 	bool "Set at compile-time"
 	help
-		Set channel selection at compile-time.
+	  Set channel selection at compile-time.
 endchoice
 
 if AUDIO_HEADSET_CHANNEL_COMPILE_TIME
@@ -119,9 +129,9 @@ config AUDIO_HEADSET_CHANNEL
 	range 0 1
 	default 0
 	help
-		Audio channel compile-time selection.
-		Left = 0.
-		Right = 1.
+	  Audio channel compile-time selection.
+	  Left = 0.
+	  Right = 1.
 
 endif # AUDIO_HEADSET_CHANNEL_COMPILE_TIME
 
@@ -132,13 +142,13 @@ choice SW_CODEC_DEFAULT
 	prompt "Starting SW codec"
 	default SW_CODEC_LC3
 	help
-		Select the default codec to use on start up
+	  Select the default codec to use on start up.
 
 config SW_CODEC_LC3
 	bool "LC3"
 	select SW_CODEC_LC3_T2_SOFTWARE
 	help
-		LC3 is the mandatory codec for LE Audio
+	  LC3 is the mandatory codec for LE Audio.
 
 # Leave room for other codecs
 endchoice
@@ -153,7 +163,9 @@ visible if SW_CODEC_LC3
 
 config LC3_BITRATE
 	int "Bitrate for LC3"
-	default 96000
+	default 96000 if BT_AUDIO_BROADCAST_RECOMMENDED || BT_AUDIO_UNICAST_RECOMMENDED
+	default 32000 if BT_AUDIO_BROADCAST_16_2_1 || BT_AUDIO_BROADCAST_16_2_2 || BT_AUDIO_UNICAST_16_2_1
+	default 48000 if BT_AUDIO_BROADCAST_24_2_1 || BT_AUDIO_BROADCAST_24_2_2 || BT_AUDIO_UNICAST_24_2_1
 
 config LC3_BITRATE_MAX
 	int "Max bitrate for LC3"
@@ -176,19 +188,19 @@ config BUF_BLE_RX_PACKET_NUM
 	default 5
 	range 2 5
 	help
-		Value can be adjusted to affect the overall latency.
-		This adjusts the number packets in the BLE FIFO RX buffer,
-		which is where the main latency resides. A low value will decrease
-		latency and reduce stability, and vice-versa.
-		Two is recommended minimum to reduce the likelyhood of audio
-		gaps due to BLE retransmits.
+	  Value can be adjusted to affect the overall latency.
+	  This adjusts the number packets in the BLE FIFO RX buffer,
+	  which is where the main latency resides. A low value will decrease
+	  latency and reduce stability, and vice-versa.
+	  Two is recommended minimum to reduce the likelyhood of audio
+	  gaps due to BLE retransmits.
 
 config STREAM_BIDIRECTIONAL
 	bool "Enable bi-directional stream - Currently not supported"
 	default n
 	help
-		Bi-directional stream enables encoder and decoder on both sides,
-		and one device can both send and receive audio.
+	  Bi-directional stream enables encoder and decoder on both sides,
+	  and one device can both send and receive audio.
 
 endmenu # Stream
 
@@ -197,6 +209,10 @@ menu "Log levels"
 
 config LOG_AUDIO_SYSTEM_LEVEL
 	int "Log level for audio system"
+	default 3
+
+config LOG_SW_CODEC_SELECT_LEVEL
+	int "Log level for sw_codec_select"
 	default 3
 
 config LOG_STREAMCTRL_LEVEL
@@ -220,13 +236,13 @@ config ENCODER_THREAD_PRIO
 	int "Priority for encoder thread"
 	default 3
 	help
-		This is a preemptible thread
+	  This is a preemptible thread.
 
 config AUDIO_DATAPATH_THREAD_PRIO
 	int "Priority for audio datapath thread"
 	default 4
 	help
-		This is a preemptible thread
+	  This is a preemptible thread.
 
 endmenu # Thread priorities
 
@@ -236,12 +252,12 @@ menu "Stack sizes"
 config ENCODER_STACK_SIZE
 	int "Stack size for encoder thread"
 	default 6750 if AUDIO_BIT_DEPTH_16
-	default 11264 if AUDIO_BIT_DEPTH_24 || AUDIO_BIT_DEPTH_32
+	default 11264 if AUDIO_BIT_DEPTH_32
 
 config AUDIO_DATAPATH_STACK_SIZE
 	int "Stack size for audio datapath thread"
 	default 4096 if AUDIO_BIT_DEPTH_16
-	default 7168 if AUDIO_BIT_DEPTH_24 || AUDIO_BIT_DEPTH_32
+	default 7168 if AUDIO_BIT_DEPTH_32
 
 endmenu # Stack sizes
 endmenu # Audio

--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -1,45 +1,7 @@
-/*************************************************************************************************/
 /*
  *  Copyright (c) 2021, PACKETCRAFT, INC.
- *  All rights reserved.
- */
-/*************************************************************************************************/
-
-/*
- * Redistribution and use of the Audio subsystem for nRF5340 Software, in binary
- * and source code forms, with or without modification, are permitted provided
- * that the following conditions are met:
  *
- * 1. Redistributions of source code form must retain the above copyright
- *    notice, this list of conditions, and the following disclaimer.
- *
- * 2. Redistributions in binary code form, except as embedded into a Nordic
- *    Semiconductor ASA nRF53 chip or a software update for such product,
- *    must reproduce the above copyright notice, this list of conditions
- *    and the following disclaimer in the documentation and/or other materials
- *    provided with the distribution.
- *
- * 3. Neither the name of Packetcraft, Inc. nor Nordic Semiconductor ASA nor
- *    the names of its contributors may be used to endorse or promote products
- *    derived from this software without specific prior written permission.
- *
- * 4. This software, with or without modification, must only be used with a
- *    Nordic Semiconductor ASA nRF53 chip.
- *
- * 5. Any software provided in binary or source code form under this license
- *    must not be reverse engineered, decompiled, modified and/or disassembled.
- *
- * THIS SOFTWARE IS PROVIDED BY PACKETCRAFT, INC. AND NORDIC SEMICONDUCTOR ASA
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE HEREBY DISCLAIMED. IN NO EVENT SHALL PACKETCRAFT, INC.,
- * NORDIC SEMICONDUCTOR ASA, OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ *  SPDX-License-Identifier: LicenseRef-PCFT
  */
 
 #include "audio_datapath.h"

--- a/applications/nrf5340_audio/src/audio/audio_datapath.h
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.h
@@ -1,45 +1,7 @@
-/*************************************************************************************************/
 /*
  *  Copyright (c) 2021, PACKETCRAFT, INC.
- *  All rights reserved.
- */
-/*************************************************************************************************/
-
-/*
- * Redistribution and use of the Audio subsystem for nRF5340 Software, in binary
- * and source code forms, with or without modification, are permitted provided
- * that the following conditions are met:
  *
- * 1. Redistributions of source code form must retain the above copyright
- *    notice, this list of conditions, and the following disclaimer.
- *
- * 2. Redistributions in binary code form, except as embedded into a Nordic
- *    Semiconductor ASA nRF53 chip or a software update for such product,
- *    must reproduce the above copyright notice, this list of conditions
- *    and the following disclaimer in the documentation and/or other materials
- *    provided with the distribution.
- *
- * 3. Neither the name of Packetcraft, Inc. nor Nordic Semiconductor ASA nor
- *    the names of its contributors may be used to endorse or promote products
- *    derived from this software without specific prior written permission.
- *
- * 4. This software, with or without modification, must only be used with a
- *    Nordic Semiconductor ASA nRF53 chip.
- *
- * 5. Any software provided in binary or source code form under this license
- *    must not be reverse engineered, decompiled, modified and/or disassembled.
- *
- * THIS SOFTWARE IS PROVIDED BY PACKETCRAFT, INC. AND NORDIC SEMICONDUCTOR ASA
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE HEREBY DISCLAIMED. IN NO EVENT SHALL PACKETCRAFT, INC.,
- * NORDIC SEMICONDUCTOR ASA, OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ *  SPDX-License-Identifier: LicenseRef-PCFT
  */
 
 #ifndef _AUDIO_DATAPATH_H_

--- a/applications/nrf5340_audio/src/audio/audio_sync_timer.c
+++ b/applications/nrf5340_audio/src/audio/audio_sync_timer.c
@@ -1,45 +1,7 @@
-/*************************************************************************************************/
 /*
  *  Copyright (c) 2021, PACKETCRAFT, INC.
- *  All rights reserved.
- */
-/*************************************************************************************************/
-
-/*
- * Redistribution and use of the Audio subsystem for nRF5340 Software, in binary
- * and source code forms, with or without modification, are permitted provided
- * that the following conditions are met:
  *
- * 1. Redistributions of source code form must retain the above copyright
- *    notice, this list of conditions, and the following disclaimer.
- *
- * 2. Redistributions in binary code form, except as embedded into a Nordic
- *    Semiconductor ASA nRF53 chip or a software update for such product,
- *    must reproduce the above copyright notice, this list of conditions
- *    and the following disclaimer in the documentation and/or other materials
- *    provided with the distribution.
- *
- * 3. Neither the name of Packetcraft, Inc. nor Nordic Semiconductor ASA nor
- *    the names of its contributors may be used to endorse or promote products
- *    derived from this software without specific prior written permission.
- *
- * 4. This software, with or without modification, must only be used with a
- *    Nordic Semiconductor ASA nRF53 chip.
- *
- * 5. Any software provided in binary or source code form under this license
- *    must not be reverse engineered, decompiled, modified and/or disassembled.
- *
- * THIS SOFTWARE IS PROVIDED BY PACKETCRAFT, INC. AND NORDIC SEMICONDUCTOR ASA
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE HEREBY DISCLAIMED. IN NO EVENT SHALL PACKETCRAFT, INC.,
- * NORDIC SEMICONDUCTOR ASA, OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ *  SPDX-License-Identifier: LicenseRef-PCFT
  */
 
 #include "audio_sync_timer.h"

--- a/applications/nrf5340_audio/src/audio/audio_sync_timer.h
+++ b/applications/nrf5340_audio/src/audio/audio_sync_timer.h
@@ -1,45 +1,7 @@
-/*************************************************************************************************/
 /*
  *  Copyright (c) 2021, PACKETCRAFT, INC.
- *  All rights reserved.
- */
-/*************************************************************************************************/
-
-/*
- * Redistribution and use of the Audio subsystem for nRF5340 Software, in binary
- * and source code forms, with or without modification, are permitted provided
- * that the following conditions are met:
  *
- * 1. Redistributions of source code form must retain the above copyright
- *    notice, this list of conditions, and the following disclaimer.
- *
- * 2. Redistributions in binary code form, except as embedded into a Nordic
- *    Semiconductor ASA nRF53 chip or a software update for such product,
- *    must reproduce the above copyright notice, this list of conditions
- *    and the following disclaimer in the documentation and/or other materials
- *    provided with the distribution.
- *
- * 3. Neither the name of Packetcraft, Inc. nor Nordic Semiconductor ASA nor
- *    the names of its contributors may be used to endorse or promote products
- *    derived from this software without specific prior written permission.
- *
- * 4. This software, with or without modification, must only be used with a
- *    Nordic Semiconductor ASA nRF53 chip.
- *
- * 5. Any software provided in binary or source code form under this license
- *    must not be reverse engineered, decompiled, modified and/or disassembled.
- *
- * THIS SOFTWARE IS PROVIDED BY PACKETCRAFT, INC. AND NORDIC SEMICONDUCTOR ASA
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE HEREBY DISCLAIMED. IN NO EVENT SHALL PACKETCRAFT, INC.,
- * NORDIC SEMICONDUCTOR ASA, OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ *  SPDX-License-Identifier: LicenseRef-PCFT
  */
 
 #ifndef _AUDIO_SYNC_TIMER_H_

--- a/applications/nrf5340_audio/src/audio/sw_codec_select.c
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.c
@@ -16,7 +16,7 @@
 #endif /* (CONFIG_SW_CODEC_LC3) */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(sw_codec_select);
+LOG_MODULE_REGISTER(sw_codec_select, CONFIG_LOG_SW_CODEC_SELECT_LEVEL);
 
 static struct sw_codec_config m_config;
 
@@ -263,10 +263,16 @@ int sw_codec_init(struct sw_codec_config sw_codec_cfg)
 			}
 			uint16_t pcm_bytes_req_enc;
 
+			LOG_DBG("Encode: %dHz %dbits %dus %dbps %d channel(s)",
+				CONFIG_AUDIO_SAMPLE_RATE_HZ, CONFIG_AUDIO_BIT_DEPTH_BITS,
+				CONFIG_AUDIO_FRAME_DURATION_US, sw_codec_cfg.encoder.bitrate,
+				sw_codec_cfg.encoder.channel_mode);
+
 			ret = sw_codec_lc3_enc_init(
 				CONFIG_AUDIO_SAMPLE_RATE_HZ, CONFIG_AUDIO_BIT_DEPTH_BITS,
 				CONFIG_AUDIO_FRAME_DURATION_US, sw_codec_cfg.encoder.bitrate,
 				sw_codec_cfg.encoder.channel_mode, &pcm_bytes_req_enc);
+
 			if (ret) {
 				return ret;
 			}
@@ -277,10 +283,16 @@ int sw_codec_init(struct sw_codec_config sw_codec_cfg)
 				LOG_WRN("The LC3 decoder is already initialized");
 				return -EALREADY;
 			}
+
+			LOG_DBG("Decode: %dHz %dbits %dus %d channel(s)",
+				CONFIG_AUDIO_SAMPLE_RATE_HZ, CONFIG_AUDIO_BIT_DEPTH_BITS,
+				CONFIG_AUDIO_FRAME_DURATION_US, sw_codec_cfg.decoder.channel_mode);
+
 			ret = sw_codec_lc3_dec_init(CONFIG_AUDIO_SAMPLE_RATE_HZ,
 						    CONFIG_AUDIO_BIT_DEPTH_BITS,
 						    CONFIG_AUDIO_FRAME_DURATION_US,
 						    sw_codec_cfg.decoder.channel_mode);
+
 			if (ret) {
 				return ret;
 			}

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -24,15 +24,15 @@ config BLE_LE_POWER_CONTROL_ENABLED
 	bool "Enable LE power control feature"
 	default n
 	help
-	 The LE power control feature makes devices be able to change TX power
-	 dynamically and automatically during connection, which provides effective
-	 communication.
+	  The LE power control feature makes devices be able to change TX power
+	  dynamically and automatically during connection, which provides effective
+	  communication.
 
 choice	BLE_CONN_TX_POWER
 	prompt "Default TX power for BLE connections"
 	default BLE_CONN_TX_POWER_0DBM
 	help
-		Set the default TX power for BLE connections.
+	  Set the default TX power for BLE connections.
 
 config BLE_CONN_TX_POWER_0DBM
 	bool "0dBm"
@@ -95,7 +95,7 @@ choice	BLE_ADV_TX_POWER
 	prompt "Default TX power for BLE advertising"
 	default BLE_ADV_TX_POWER_0DBM
 	help
-		Set the default TX power for BLE advertising
+	  Set the default TX power for BLE advertising
 
 config BLE_ADV_TX_POWER_0DBM
 	bool "0dBm"
@@ -158,13 +158,87 @@ config BLE_ISO_TEST_PATTERN
 	bool "Transmit a test pattern to measure link performance"
 	default n
 	help
-	 This will transmit the same amount of data as an audio stream, but the
-	 data will be an incrementing value ranging from 0-255 and repeating.
-	 Note that enabling this feature will disable the audio stream.
+	  This will transmit the same amount of data as an audio stream, but the
+	  data will be an incrementing value ranging from 0-255 and repeating.
+	  Note that enabling this feature will disable the audio stream.
 
 config BLE_ISO_RX_STATS_S
 	int "Interval in seconds to print BLE ISO RX stats. 0 to deactivate"
 	default 0
+
+choice BT_AUDIO_UNICAST_BAP_CONFIGURATION
+	prompt "Unicast codec configuration"
+	depends on TRANSPORT_CIS
+	default BT_AUDIO_UNICAST_RECOMMENDED
+	help
+	  Select the unicast codec configuration as given in
+	  Table 5.2 of BAP Specification, USB only supports BT_AUDIO_UNICAST_RECOMMENDED
+
+config BT_AUDIO_UNICAST_RECOMMENDED
+	bool "Recommended unicast codec capability"
+	depends on TRANSPORT_CIS
+	help
+	  Recommended unicast settings for the nRF5340_audio application
+	  48kHz, 96kbps, 2 retransmits, 20ms transport latency, and 10ms presentation delay
+
+config BT_AUDIO_UNICAST_16_2_1
+	bool "16_2_1"
+	depends on TRANSPORT_CIS
+	help
+	  Unicast mandatory codec capability 16_2_1
+	  16kHz, 32kbps, 2 retransmits, 10ms transport latency, and 40ms presentation delay
+
+config BT_AUDIO_UNICAST_24_2_1
+	bool "24_2_1"
+	depends on TRANSPORT_CIS
+	help
+	  Unicast codec capability 24_2_1
+	  24kHz, 48kbps, 2 retransmits, 10ms transport latency, and 40ms presentation delay
+endchoice
+
+choice BT_AUDIO_BROADCAST_BAP_CONFIGURATION
+	prompt "Broadcast codec configuration"
+	depends on TRANSPORT_BIS
+	default BT_AUDIO_BROADCAST_RECOMMENDED
+	help
+	  Select the broadcast codec configuration as given
+	  in Table 6.4 of the BAP specification. USB only supports BT_AUDIO_BROADCAST_RECOMMENDED
+
+config BT_AUDIO_BROADCAST_RECOMMENDED
+	bool "Recommended Broadcast codec capability"
+	depends on TRANSPORT_BIS
+	help
+	  Recommended broadcast settings for the nRF5340_audio application
+	  48kHz, 96kbps, 4 retransmits, 20ms transport latency, and 10ms presentation delay
+
+config BT_AUDIO_BROADCAST_16_2_1
+	bool "16_2_1"
+	depends on TRANSPORT_BIS
+	help
+	  Broadcast mandatory codec capability 16_2_1
+	  16kHz, 32kbps, 2 retransmits, 10ms transport latency, and 40ms presentation delay
+
+config BT_AUDIO_BROADCAST_24_2_1
+	bool "24_2_1"
+	depends on TRANSPORT_BIS
+	help
+	  Broadcast codec capability 24_2_1
+	  24kHz, 48kbps, 2 retransmits, 10ms transport latency, and 40ms presentation delay
+
+config BT_AUDIO_BROADCAST_16_2_2
+	bool "16_2_2"
+	depends on TRANSPORT_BIS
+	help
+	  Broadcast mandatory codec capability 16_2_2
+	  16kHz, 32kbps, 4 retransmits, 60ms transport latency, and 40ms presentation delay
+
+config BT_AUDIO_BROADCAST_24_2_2
+	bool "24_2_2"
+	depends on TRANSPORT_BIS
+	help
+	  Broadcast codec capability 24_2_2
+	  24kHz, 48kbps, 4 retransmits, 60ms transport latency, and 40ms presentation delay
+endchoice
 
 #----------------------------------------------------------------------------#
 menu "Log levels"

--- a/applications/nrf5340_audio/src/bluetooth/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio.h
@@ -8,12 +8,102 @@
 #define _LE_AUDIO_H_
 
 #include <zephyr.h>
+#include <bluetooth/audio/audio.h>
 
 #define DEVICE_NAME_PEER CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_PEER_LEN (sizeof(DEVICE_NAME_PEER) - 1)
 
 #define LE_AUDIO_SDU_SIZE_OCTETS(bitrate) (bitrate / (1000000 / CONFIG_AUDIO_FRAME_DURATION_US) / 8)
 #define LE_AUDIO_PRES_DELAY_US 10000u
+
+#if CONFIG_TRANSPORT_CIS
+#define BT_AUDIO_LC3_UNICAST_PRESET_RECOMMENDED(_loc, _stream_context)                             \
+	BT_AUDIO_LC3_PRESET(                                                                       \
+		BT_CODEC_LC3_CONFIG(                                                               \
+			BT_CODEC_CONFIG_LC3_FREQ_48KHZ, BT_CODEC_CONFIG_LC3_DURATION_10, _loc,     \
+			LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE), 1, _stream_context),         \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE), 2u,     \
+					     20u, LE_AUDIO_PRES_DELAY_US))
+
+#if CONFIG_AUDIO_SOURCE_USB
+/* Only 48kHz is supported when using USB */
+#if !CONFIG_BT_AUDIO_UNICAST_RECOMMENDED
+#error USB only supports 48kHz
+#endif /* !CONFIG_BT_AUDIO_UNICAST_RECOMMENDED */
+#define BT_AUDIO_LC3_UNICAST_PRESET_NRF5340_AUDIO                                                  \
+	BT_AUDIO_LC3_UNICAST_PRESET_RECOMMENDED(BT_AUDIO_LOCATION_FRONT_LEFT,                      \
+						BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#elif CONFIG_AUDIO_SOURCE_I2S
+#if CONFIG_BT_AUDIO_UNICAST_RECOMMENDED
+#define BT_AUDIO_LC3_UNICAST_PRESET_NRF5340_AUDIO                                                  \
+	BT_AUDIO_LC3_UNICAST_PRESET_RECOMMENDED(BT_AUDIO_LOCATION_FRONT_LEFT,                      \
+						BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#elif CONFIG_BT_AUDIO_UNICAST_16_2_1
+#define BT_AUDIO_LC3_UNICAST_PRESET_NRF5340_AUDIO                                                  \
+	BT_AUDIO_LC3_UNICAST_PRESET_16_2_1(BT_AUDIO_LOCATION_FRONT_LEFT,                           \
+					   BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#elif CONFIG_BT_AUDIO_UNICAST_24_2_1
+#define BT_AUDIO_LC3_UNICAST_PRESET_NRF5340_AUDIO                                                  \
+	BT_AUDIO_LC3_UNICAST_PRESET_24_2_1(BT_AUDIO_LOCATION_FRONT_LEFT,                           \
+					   BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#else
+#error Unsupported LC3 codec preset for unicast
+#endif /* CONFIG_BT_AUDIO_UNICAST_RECOMMENDED */
+#endif /* CONFIG_AUDIO_SOURCE_USB */
+#endif /* CONFIG_TRANSPORT_CIS */
+
+#if CONFIG_TRANSPORT_BIS
+#define BT_AUDIO_LC3_BROADCAST_PRESET_RECOMMENDED(_loc, _stream_context)                           \
+	BT_AUDIO_LC3_PRESET(                                                                       \
+		BT_CODEC_LC3_CONFIG(                                                               \
+			BT_CODEC_CONFIG_LC3_FREQ_48KHZ, BT_CODEC_CONFIG_LC3_DURATION_10, _loc,     \
+			LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE), 1, _stream_context),         \
+		BT_CODEC_LC3_QOS_10_UNFRAMED(LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE), 4u,     \
+					     20u, LE_AUDIO_PRES_DELAY_US))
+
+#if CONFIG_AUDIO_SOURCE_USB
+#if !CONFIG_BT_AUDIO_BROADCAST_RECOMMENDED
+#error USB only supports 48kHz
+#endif /* !CONFIG_BT_AUDIO_BROADCAST_RECOMMENDED */
+#define BT_AUDIO_LC3_BROADCAST_PRESET_NRF5340_AUDIO                                                \
+	BT_AUDIO_LC3_BROADCAST_PRESET_RECOMMENDED(BT_AUDIO_LOCATION_FRONT_LEFT,                    \
+						  BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#elif CONFIG_AUDIO_SOURCE_I2S
+#if CONFIG_BT_AUDIO_BROADCAST_RECOMMENDED
+#define BT_AUDIO_LC3_BROADCAST_PRESET_NRF5340_AUDIO                                                \
+	BT_AUDIO_LC3_BROADCAST_PRESET_RECOMMENDED(BT_AUDIO_LOCATION_FRONT_LEFT,                    \
+						  BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#elif CONFIG_BT_AUDIO_BROADCAST_16_2_1
+#define BT_AUDIO_LC3_BROADCAST_PRESET_NRF5340_AUDIO                                                \
+	BT_AUDIO_LC3_BROADCAST_PRESET_16_2_1(BT_AUDIO_LOCATION_FRONT_LEFT,                         \
+					     BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#elif CONFIG_BT_AUDIO_BROADCAST_24_2_1
+#define BT_AUDIO_LC3_BROADCAST_PRESET_NRF5340_AUDIO                                                \
+	BT_AUDIO_LC3_BROADCAST_PRESET_24_2_1(BT_AUDIO_LOCATION_FRONT_LEFT,                         \
+					     BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#elif CONFIG_BT_AUDIO_BROADCAST_16_2_2
+#define BT_AUDIO_LC3_BROADCAST_PRESET_NRF5340_AUDIO                                                \
+	BT_AUDIO_LC3_BROADCAST_PRESET_16_2_2(BT_AUDIO_LOCATION_FRONT_LEFT,                         \
+					     BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#elif CONFIG_BT_AUDIO_BROADCAST_24_2_2
+#define BT_AUDIO_LC3_BROADCAST_PRESET_NRF5340_AUDIO                                                \
+	BT_AUDIO_LC3_BROADCAST_PRESET_24_2_2(BT_AUDIO_LOCATION_FRONT_LEFT,                         \
+					     BT_AUDIO_CONTEXT_TYPE_MEDIA)
+
+#else
+#error Unsupported LC3 codec preset for broadcast
+#endif /* CONFIG_BT_AUDIO_BROADCAST_RECOMMENDED */
+#endif /* CONFIG_AUDIO_SOURCE_USB */
+#endif /* CONFIG_TRANSPORT_BIS */
 
 enum le_audio_evt_type {
 	LE_AUDIO_EVT_CONFIG_RECEIVED,

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
@@ -23,15 +23,6 @@ BUILD_ASSERT(CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT <= 2,
 
 #define HCI_ISO_BUF_ALLOC_PER_CHAN 2
 
-#define BT_AUDIO_LC3_BROADCAST_PRESET_NRF5340_AUDIO                                                \
-	BT_AUDIO_LC3_PRESET(                                                                       \
-		BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_48KHZ,                                \
-				    BT_CODEC_CONFIG_LC3_DURATION_10, BT_AUDIO_LOCATION_FRONT_LEFT, \
-				    LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE), 1,               \
-				    BT_AUDIO_CONTEXT_TYPE_MEDIA),                                  \
-		BT_CODEC_LC3_QOS_10_UNFRAMED(LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE), 4u,     \
-					     20u, LE_AUDIO_PRES_DELAY_US))
-
 /* For being able to dynamically define iso_tx_pools */
 #define NET_BUF_POOL_ITERATE(i, _)                                                                 \
 	NET_BUF_POOL_FIXED_DEFINE(iso_tx_pool_##i, HCI_ISO_BUF_ALLOC_PER_CHAN,                     \

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -19,15 +19,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(cis_gateway, CONFIG_LOG_BLE_LEVEL);
 
-#define BT_AUDIO_LC3_UNICAST_PRESET_NRF5340_AUDIO                                                  \
-	BT_AUDIO_LC3_PRESET(                                                                       \
-		BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_48KHZ,                                \
-				    BT_CODEC_CONFIG_LC3_DURATION_10, BT_AUDIO_LOCATION_FRONT_LEFT, \
-				    LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE), 1,               \
-				    BT_AUDIO_CONTEXT_TYPE_MEDIA),                                  \
-		BT_CODEC_LC3_QOS_10_UNFRAMED(LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_LC3_BITRATE), 2u,     \
-					     20u, LE_AUDIO_PRES_DELAY_US))
-
 #define HCI_ISO_BUF_ALLOC_PER_CHAN 2
 /* For being able to dynamically define iso_tx_pools */
 #define NET_BUF_POOL_ITERATE(i, _)                                                                 \

--- a/applications/nrf5340_audio/src/drivers/cs47l63_reg_conf.h
+++ b/applications/nrf5340_audio/src/drivers/cs47l63_reg_conf.h
@@ -31,9 +31,12 @@
 /* clang-format off */
 /* Set up clocks */
 const uint32_t clock_configuration[][2] = {
+	{ CS47L63_SAMPLE_RATE3, 0x0012 },
+	{ CS47L63_SAMPLE_RATE2, 0x0002 },
+	{ CS47L63_SAMPLE_RATE1, 0x0003 },
 	{ CS47L63_SYSTEM_CLOCK1, 0x034C },
 	{ CS47L63_ASYNC_CLOCK1, 0x034C },
-	{ CS47L63_FLL1_CONTROL2, 0x88208020 },
+	{ CS47L63_FLL1_CONTROL2, 0x88200008 },
 	{ CS47L63_FLL1_CONTROL3, 0x10000 },
 	{ CS47L63_FLL1_GPIO_CLOCK, 0x0005 },
 	{ CS47L63_FLL1_CONTROL1, 0x0001 },
@@ -101,7 +104,6 @@ const uint32_t input_enable[][2] = {
 /* Set up output */
 const uint32_t output_enable[][2] = {
 	{ CS47L63_OUTPUT_ENABLE_1, 0x0002 },
-
 	{ CS47L63_OUT1L_INPUT1, 0x800020 },
 	{ CS47L63_OUT1L_INPUT2, 0x800021 },
 };
@@ -119,8 +121,14 @@ const uint32_t asp1_enable[][2] = {
 	{ CS47L63_GPIO4_CTRL1, 0xE1000000 },
 	{ CS47L63_GPIO5_CTRL1, 0x61000001 },
 
-	/* Set ASP1 in slave mode and 16 bit per channel */
+/* Set ASP1 in slave mode and 16 bit per channel */
+#if CONFIG_AUDIO_SAMPLE_RATE_16000_HZ
+	{ CS47L63_ASP1_CONTROL1, 0x021B },
+#elif CONFIG_AUDIO_SAMPLE_RATE_24000_HZ
+	{ CS47L63_ASP1_CONTROL1, 0x011B },
+#elif CONFIG_AUDIO_SAMPLE_RATE_48000_HZ
 	{ CS47L63_ASP1_CONTROL1, 0x001B },
+#endif
 	{ CS47L63_ASP1_CONTROL2, 0x10100200 },
 	{ CS47L63_ASP1_CONTROL3, 0x0000 },
 	{ CS47L63_ASP1_DATA_CONTROL1, 0x0020 },

--- a/applications/nrf5340_audio/src/modules/audio_i2s.c
+++ b/applications/nrf5340_audio/src/modules/audio_i2s.c
@@ -1,45 +1,7 @@
-/*************************************************************************************************/
 /*
  *  Copyright (c) 2021, PACKETCRAFT, INC.
- *  All rights reserved.
- */
-/*************************************************************************************************/
-
-/*
- * Redistribution and use of the Audio subsystem for nRF5340 Software, in binary
- * and source code forms, with or without modification, are permitted provided
- * that the following conditions are met:
  *
- * 1. Redistributions of source code form must retain the above copyright
- *    notice, this list of conditions, and the following disclaimer.
- *
- * 2. Redistributions in binary code form, except as embedded into a Nordic
- *    Semiconductor ASA nRF53 chip or a software update for such product,
- *    must reproduce the above copyright notice, this list of conditions
- *    and the following disclaimer in the documentation and/or other materials
- *    provided with the distribution.
- *
- * 3. Neither the name of Packetcraft, Inc. nor Nordic Semiconductor ASA nor
- *    the names of its contributors may be used to endorse or promote products
- *    derived from this software without specific prior written permission.
- *
- * 4. This software, with or without modification, must only be used with a
- *    Nordic Semiconductor ASA nRF53 chip.
- *
- * 5. Any software provided in binary or source code form under this license
- *    must not be reverse engineered, decompiled, modified and/or disassembled.
- *
- * THIS SOFTWARE IS PROVIDED BY PACKETCRAFT, INC. AND NORDIC SEMICONDUCTOR ASA
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE HEREBY DISCLAIMED. IN NO EVENT SHALL PACKETCRAFT, INC.,
- * NORDIC SEMICONDUCTOR ASA, OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ *  SPDX-License-Identifier: LicenseRef-PCFT
  */
 
 #include "audio_i2s.h"
@@ -69,6 +31,16 @@ static enum audio_i2s_state state = AUDIO_I2S_STATE_UNINIT;
 
 PINCTRL_DT_DEFINE(I2S_NL);
 
+#if CONFIG_AUDIO_SAMPLE_RATE_16000_HZ
+#define CONFIG_AUDIO_RATIO NRF_I2S_RATIO_384X
+#elif CONFIG_AUDIO_SAMPLE_RATE_24000_HZ
+#define CONFIG_AUDIO_RATIO NRF_I2S_RATIO_256X
+#elif CONFIG_AUDIO_SAMPLE_RATE_48000_HZ
+#define CONFIG_AUDIO_RATIO NRF_I2S_RATIO_128X
+#else
+#error "Current AUDIO_SAMPLE_RATE_HZ setting not supported"
+#endif
+
 static nrfx_i2s_config_t cfg = {
 	/* Pins are configured by pinctrl. */
 	.skip_gpio_cfg = true,
@@ -77,19 +49,12 @@ static nrfx_i2s_config_t cfg = {
 	.mode = NRF_I2S_MODE_MASTER,
 	.format = NRF_I2S_FORMAT_I2S,
 	.alignment = NRF_I2S_ALIGN_LEFT,
+	.ratio = CONFIG_AUDIO_RATIO,
+	.mck_setup = 0x66666000,
 #if (CONFIG_AUDIO_BIT_DEPTH_16)
 	.sample_width = NRF_I2S_SWIDTH_16BIT,
-	.mck_setup = 0x66666000,
-	.ratio = NRF_I2S_RATIO_128X,
-#elif (CONFIG_AUDIO_BIT_DEPTH_24)
-	.sample_width = NRF_I2S_SWIDTH_24BIT,
-	/* Clock mismatch warning: See CONFIG_AUDIO_24_BIT in KConfig */
-	.mck_setup = 0x2BE2B000,
-	.ratio = NRF_I2S_RATIO_48X,
 #elif (CONFIG_AUDIO_BIT_DEPTH_32)
 	.sample_width = NRF_I2S_SWIDTH_32BIT,
-	.mck_setup = 0x66666000,
-	.ratio = NRF_I2S_RATIO_128X,
 #else
 #error Invalid bit depth selected
 #endif /* (CONFIG_AUDIO_BIT_DEPTH_16) */

--- a/applications/nrf5340_audio/src/modules/audio_i2s.h
+++ b/applications/nrf5340_audio/src/modules/audio_i2s.h
@@ -1,45 +1,7 @@
-/*************************************************************************************************/
 /*
  *  Copyright (c) 2021, PACKETCRAFT, INC.
- *  All rights reserved.
- */
-/*************************************************************************************************/
-
-/*
- * Redistribution and use of the Audio subsystem for nRF5340 Software, in binary
- * and source code forms, with or without modification, are permitted provided
- * that the following conditions are met:
  *
- * 1. Redistributions of source code form must retain the above copyright
- *    notice, this list of conditions, and the following disclaimer.
- *
- * 2. Redistributions in binary code form, except as embedded into a Nordic
- *    Semiconductor ASA nRF53 chip or a software update for such product,
- *    must reproduce the above copyright notice, this list of conditions
- *    and the following disclaimer in the documentation and/or other materials
- *    provided with the distribution.
- *
- * 3. Neither the name of Packetcraft, Inc. nor Nordic Semiconductor ASA nor
- *    the names of its contributors may be used to endorse or promote products
- *    derived from this software without specific prior written permission.
- *
- * 4. This software, with or without modification, must only be used with a
- *    Nordic Semiconductor ASA nRF53 chip.
- *
- * 5. Any software provided in binary or source code form under this license
- *    must not be reverse engineered, decompiled, modified and/or disassembled.
- *
- * THIS SOFTWARE IS PROVIDED BY PACKETCRAFT, INC. AND NORDIC SEMICONDUCTOR ASA
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE HEREBY DISCLAIMED. IN NO EVENT SHALL PACKETCRAFT, INC.,
- * NORDIC SEMICONDUCTOR ASA, OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ *  SPDX-License-Identifier: LicenseRef-PCFT
  */
 
 #ifndef _AUDIO_I2S_H_

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -124,7 +124,13 @@ nRF9160: Serial LTE modem
 nRF5340 Audio
 -------------
 
-* Updated LE Audio Controller Subsystem for nRF53 from version 3303 to version 3307.
+* Added:
+
+  * Added Kconfig options for different sample rates and BAP presets
+
+* Updated:
+
+  * LE Audio Controller Subsystem for nRF53 from version 3303 to version 3307.
 
 nRF Machine Learning (Edge Impulse)
 -----------------------------------

--- a/scripts/ci/license_allow_list.yaml
+++ b/scripts/ci/license_allow_list.yaml
@@ -15,6 +15,9 @@ LicenseRef-Nordic-5-Clause: ".*"
 # ZBOSS 4-clause is allowed only in zboss directory.
 LicenseRef-ZBOSS-4-Clause: "^nrfxlib/zboss/"
 
+# PCFT license is allowed for nRF53 Audio.
+LicenseRef-PCFT: "^nrf/applications/nrf5340_audio/"
+
 # Missing license information is allowed in all files except the ones listed below using
 # negative match.
 none: |


### PR DESCRIPTION
- Add support for BAP mandatory codec configurations

Signed-off-by: Graham Wacey <graham.wacey.nordicsemi.no>
Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>