### PR TITLE
matter: pull change to disable Wi-Fi low-power mode by default

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -95,8 +95,8 @@
 
 .. _`Matter GitHub repository`: https://github.com/project-chip/connectedhomeip
 .. _`dedicated Matter fork`: https://github.com/nrfconnect/sdk-connectedhomeip
-.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/4b3e81a0/src/android/CHIPTool
-.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/4b3e81a0/src/controller
+.. _`Android CHIPTool`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/b8c6fe4c/src/android/CHIPTool
+.. _`other controller setups`: https://github.com/nrfconnect/sdk-connectedhomeip/tree/b8c6fe4c/src/controller
 .. _`ZCL Advanced Platform`: https://github.com/project-chip/zap
 .. _`Matter nRF Connect releases`: https://github.com/nrfconnect/sdk-connectedhomeip/releases
 .. _`Matter Certification Policy`: https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/policies/matter_certificate_policy.adoc

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.1.0-rc1
+      revision: b8c6fe4ca632dd802a828f886e1decdd98a3952b
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
I noticed the low-power mode causes stability/performance
issues, at least on my Access Point.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>