### PR TITLE
applications: asset_tracker_v2: Don't write to security object 0 after bootstrap

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
@@ -333,15 +333,19 @@ int cloud_wrap_init(cloud_wrap_evt_handler_t event_handler)
 	 */
 #if defined(CONFIG_LWM2M_INTEGRATION_PROVISION_CREDENTIALS)
 	if (IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) && sizeof(CONFIG_LWM2M_INTEGRATION_PSK) > 1) {
-		char buf[1 + sizeof(CONFIG_LWM2M_INTEGRATION_PSK) / 2];
-		size_t len = hex2bin(CONFIG_LWM2M_INTEGRATION_PSK,
-				     sizeof(CONFIG_LWM2M_INTEGRATION_PSK) - 1, buf,
-				     sizeof(buf));
+		if (!IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP) ||
+		    (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP) &&
+		     lwm2m_security_needs_bootstrap())) {
+			char buf[1 + sizeof(CONFIG_LWM2M_INTEGRATION_PSK) / 2];
+			size_t len =
+				hex2bin(CONFIG_LWM2M_INTEGRATION_PSK,
+					sizeof(CONFIG_LWM2M_INTEGRATION_PSK) - 1, buf, sizeof(buf));
 
-		err = lwm2m_engine_set_opaque("0/0/5", buf, len);
-		if (err) {
-			LOG_ERR("Failed setting PSK, error: %d", err);
-			return err;
+			err = lwm2m_engine_set_opaque("0/0/5", buf, len);
+			if (err) {
+				LOG_ERR("Failed setting PSK, error: %d", err);
+				return err;
+			}
 		}
 	}
 #endif /* CONFIG_LWM2M_INTEGRATION_PROVISION_CREDENTIALS */


### PR DESCRIPTION
If bootstrap is succesfully completed, the security module deletes the
security object instance 0, unless that is what is supposed to be used.

So writing to hardcoded "0/0/5" leads to error after a bootstrap.

So if bootstrap is enabled, only write to instance 0, if `lwm2m_security_needs_bootstrap()` which can only be true if we have not yet bootstrapped.
