### PR TITLE
docs: fix CMake arg passing to west build

### DIFF
--- a/applications/nrf5340_audio/README.rst
+++ b/applications/nrf5340_audio/README.rst
@@ -1107,7 +1107,7 @@ Complete the following steps to build the application:
 
    .. code-block:: console
 
-      west build -b nrf5340_audio_dk_nrf5340_cpuapp --pristine -DCONFIG_AUDIO_DEV=1 -DCONF_FILE=prj_release.conf
+      west build -b nrf5340_audio_dk_nrf5340_cpuapp --pristine -- -DCONFIG_AUDIO_DEV=1 -DCONF_FILE=prj_release.conf
 
    Unlike when :ref:`nrf53_audio_app_building_script`, this command creates the build files directly in the :file:`build` directory.
    This means that you first need to program the headset development kits before you build and program gateway development kits.


### PR DESCRIPTION
When building using `west`, then arguments passed to CMake must come
after `--`.

Correct this in the readme documentation for nrf5340_audio.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>