### PR TITLE
drivers: wifi: Disable LPM by default

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -17,7 +17,6 @@ config WIFI_NRF700X
 
 config NRF_WIFI_LOW_POWER
 	bool "Enable low power mode in nRF Wi-Fi chipsets"
-	default y
 
 if WIFI_NRF700X
 


### PR DESCRIPTION
There are few issues that degrade the RX performance when LPM is
enabled, that cause poor scan results or performance, so, disable this
by default.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>