### PR TITLE
mainfest: Add TF-M debug symbols workaround

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: v1.6.0-ncs1
+      revision: a07f8eb8fa336f04a79f9d6c6a7548f801ce3870
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Adds a workround to add previous missing debug symbols in the TF-M secure
build debug

Ref: NCSDK-12483

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>