### PR TITLE
samples: nrf9160: lwm2m_client: Use buttons for location assist

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -159,7 +159,11 @@ Bluetooth mesh samples
 nRF9160 samples
 ---------------
 
-|no_changes_yet_note|
+* :ref:`lwm2m_client` sample:
+
+  * Added:
+
+    * Ability to use buttons to generate location assistance requests.
 
 Thread samples
 --------------

--- a/samples/nrf9160/lwm2m_client/location_assistance.rst
+++ b/samples/nrf9160/lwm2m_client/location_assistance.rst
@@ -6,6 +6,11 @@ Location assistance
 The LwM2M Client sample supports a proprietary mechanism to fetch location assistance data from `nRF Cloud`_ by proxying it through the LwM2M server.
 This is achieved by using LwM2M objects ECID-Signal Measurement Information object(ID 10256) and proprietary Location assistance object (ID 50001).
 
+To trigger location assistance, use the following buttons on the board:
+
+* **Button 1** - For GNSS
+* **Button 2** - For cell location
+
 .. note::
    This feature is currently under development and as of now, only AVSystem's Coiote LwM2M server can be used for utilizing the location assistance data from nRF Cloud.
 


### PR DESCRIPTION
Use buttons to trigger the location assistance events.
Button 1 for triggering GNSS search and A-GPS assistance request.
Button 2 for triggering cell based location request.

Signed-off-by: Jarno Lämsä <jarno.lamsa@nordicsemi.no>