### PR TITLE
doc: doc fixes related to spm deprecation

### DIFF
--- a/doc/nrf/libraries/others/spm.rst
+++ b/doc/nrf/libraries/others/spm.rst
@@ -8,6 +8,10 @@ Secure Partition Manager (SPM)
    :depth: 2
 
 The Secure Partition Manager (SPM) provides functionality for the Trusted Execution Environment of the nRF9160 SiP and the nRF5340 SoC.
+As of |NCS| v2.1.0, the Secure Partition Manager is replaced by the Trusted Firmware-M (TF-M) and deprecated.
+It will be removed in a future release of the |NCS|.
+
+See :ref:`ug_tfm` for more information about the TF-M.
 
 Overview
 ********

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -294,7 +294,6 @@ This section provides detailed lists of changes by :ref:`sample <sample>`, inclu
 For lists of protocol-specific changes, see `Protocols`_.
 
 * All samples running on non-secure boards are documented to use TF-M as the trusted execution solution, as SPM is deprecated.
-  Sample :ref:`secure_partition_manager` is the exception.
 
 Bluetooth samples
 -----------------


### PR DESCRIPTION
Added info about SPM being deprecated to
the SPM library description.
Minor fix in the release notes
(removed a sentence).

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>