### PR TITLE
lib: bin: lwm2m_carrier: place library storage in non-secure region

### DIFF
--- a/lib/bin/lwm2m_carrier/pm.yml.lwm2m_carrier
+++ b/lib/bin/lwm2m_carrier/pm.yml.lwm2m_carrier
@@ -1,6 +1,12 @@
 #include <autoconf.h>
 
 lwm2m_carrier:
-  placement: {before: [tfm_storage, end]}
+  placement:
+    before: [tfm_storage, end]
+#ifdef CONFIG_BUILD_WITH_TFM
+    align: {start: CONFIG_NRF_SPU_FLASH_REGION_SIZE}
+#else
+    align: {start: CONFIG_LWM2M_CARRIER_STORAGE_SECTOR_SIZE}
+#endif
   size: CONFIG_LWM2M_CARRIER_STORAGE_AREA_SIZE
-  align: {start: CONFIG_LWM2M_CARRIER_STORAGE_SECTOR_SIZE}
+  inside: [nonsecure_storage]


### PR DESCRIPTION
Make sure the carrier library storage is inside nonsecure_storage.
This is needed by TF-M.

Signed-off-by: Håvard Vermeer <havard.vermeer@nordicsemi.no>