### PR TITLE
applications: asset_tracker_v2: Fix linker error when combining memfault and low power overlays

### DIFF
--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -112,3 +112,11 @@ tests:
       - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
     extra_args: OVERLAY_CONFIG="overlay-lwm2m.conf;overlay-debug.conf;overlay-memfault.conf"
     tags: ci_build
+  applications.asset_tracker_v2.memfault-low-power:
+    build_only: true
+    build_on_all: true
+    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
+    extra_configs:
+      - CONFIG_MEMFAULT_NCS_PROJECT_KEY="PROJECTKEY"
+    extra_args: OVERLAY_CONFIG="overlay-low-power.conf;overlay-memfault.conf"
+    tags: ci_build

--- a/west.yml
+++ b/west.yml
@@ -171,7 +171,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 0.33.0
+      revision: 0.33.2
       remote: memfault
     - name: cirrus
       repo-path: sdk-mcu-drivers


### PR DESCRIPTION
- Added additional build configuration that enables both memfault overlay
and the low-power overlay. This is to ensure that this combination
always builds.
- Also contains memfault SDK version update with the fix for the linker error

CIA-770

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>