### PR TITLE
applications: connectivity_bridge: Increase default transport buffer …

### DIFF
--- a/applications/connectivity_bridge/src/modules/Kconfig
+++ b/applications/connectivity_bridge/src/modules/Kconfig
@@ -73,7 +73,7 @@ endif
 
 config BRIDGE_BUF_SIZE
 	int "Transport interface buffer size"
-	default 2048
+	default 4096
 	help
 	  Size of transmit/receive buffer for transfer between interfaces.
 


### PR DESCRIPTION
…size

Default transport buffer size too small for some large AT commands.
Increase size to reduce likelihood of overflows when transmitting
data from (fast) USB to (slow) UART.

Signed-off-by: Audun Korneliussen <audun.korneliussen@nordicsemi.no>