### PR TITLE
manifest: nrf_modem: v2.1.3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -112,7 +112,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.1.0-rc1
+      revision: pull/824/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Fixed a bug that prevented the GNSS stack from correctly re-initializing after a modem fault.