### PR TITLE
modules: memfault: make link clickable

### DIFF
--- a/modules/memfault-firmware-sdk/memfault_integration.c
+++ b/modules/memfault-firmware-sdk/memfault_integration.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(memfault_ncs, CONFIG_MEMFAULT_NCS_LOG_LEVEL);
 
 /* Project key check */
 BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_PROJECT_KEY) > 1,
-	"Memfault Project Key not configured. Please visit " MEMFAULT_URL);
+	"Memfault Project Key not configured. Please visit " MEMFAULT_URL " ");
 
 /* Firmware type check */
 BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_FW_TYPE) > 1, "Firmware type must be configured");


### PR DESCRIPTION
This patch adds a space after the memfault link to make it clickable
in VS Code.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>