### PR TITLE
mcuboot: tfm: Enable option required by TF-M

### DIFF
--- a/modules/mcuboot/tfm.conf
+++ b/modules/mcuboot/tfm.conf
@@ -2,8 +2,12 @@
 # we are building for TF-M. This is necessary so MCUBoot can configure
 # itself to boot TF-M correctly.
 
-# Cleaning up the core's state as TF-M assumes a clean core.
+# Cleaning up the core state as TF-M assumes a clean core.
 CONFIG_MCUBOOT_CLEANUP_ARM_CORE=y
+
+# Cleaning up the peripheral state as TF-M enables interrupts which could
+# be sent to the application before the application is initialized.
+CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL=y
 
 # Don't configure the MPU in the bootloader. Configuring the MPU from
 # the bootloader results in a configuration where all memory accesses


### PR DESCRIPTION
Enable the option to clean up peripheral state required by TF-M. This option is default enabled so this should not change any configuration.

NCSDK-15369

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>