### PR TITLE
samples: lwm2m_client: Ensure modem is not active when privisioning

### DIFF
--- a/samples/nrf9160/lwm2m_client/scripts/provision.py
+++ b/samples/nrf9160/lwm2m_client/scripts/provision.py
@@ -36,6 +36,8 @@ if __name__ == "__main__":
 
     dev = Device(args.serial)
 
+    dev.at_client.at_cmd("AT+CFUN=4")
+
     imei = dev.get_imei()
     identity = f'urn:imei:{imei}'
     logging.info('Identity: %s', identity)


### PR DESCRIPTION
When running provisioning script, we must ensure that modem is not in the connected state. This is stated in AT manual
