### PR TITLE
applications: asset_tracker_v2: limit activity events

### DIFF
--- a/applications/asset_tracker_v2/src/modules/Kconfig.data_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.data_module
@@ -142,7 +142,7 @@ config DATA_ACCELEROMETER_INACT_THRESHOLD
 
 config DATA_ACCELEROMETER_INACT_TIMEOUT_SECONDS
 	int "Default accelerometer inactivity timeout in seconds"
-	default 1
+	default 60
 	help
 	  Minimum time for lack of movement to be considered stillness in passive mode.
 


### PR DESCRIPTION
This patch limits the activity events to only once per movement resolution cycle. Also, a more sensible default value for the inactivity timeout is introduced.

Fixes CIA-777.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>