### PR TITLE
modules: tfm: Enable more isolation lvl 2 tests

### DIFF
--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -139,6 +139,20 @@ if (CONFIG_BOOTLOADER_MCUBOOT)
     )
 endif()
 
+if (CONFIG_TFM_ISOLATION_TEST_MEM_CHECK)
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS
+    -DTFM_ISOLATION_TEST_MEM_CHECK=TRUE
+    )
+endif()
+
+if (CONFIG_TFM_ISOLATION_TEST_APP_2_PSA)
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS
+    -DTFM_ISOLATION_TEST_APP_2_PSA=TRUE
+    )
+endif()
+
 # The ENGINE_BUF_SIZE holds the dynamic allocation buffer for
 # TF-M, which is the equivalent of dynamic allocation in MBEDTLS
 set_property(TARGET zephyr_property_target

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -56,6 +56,18 @@ config TFM_PROFILE_TYPE_MINIMAL
 	  and reproduce the desired configuration through kconfig fragments.
 endchoice
 
+config TFM_ISOLATION_TEST_APP_2_PSA
+	bool
+	default y
+	depends on TFM_ISOLATION_LEVEL = 2
+	depends on TFM_REGRESSION_S || TFM_REGRESSION_NS
+
+config TFM_ISOLATION_TEST_MEM_CHECK
+	bool
+	default y
+	depends on TFM_ISOLATION_LEVEL = 2
+	depends on TFM_REGRESSION_S || TFM_REGRESSION_NS
+
 config TFM_EXPERIMENTAL
 	bool
 	select EXPERIMENTAL


### PR DESCRIPTION
There are two TF-M isolation level 2 test
configurations which need to be manually
enabled.

We now enable:
TFM_ISOLATION_TEST_APP_2_PSA
TFM_ISOLATION_TEST_MEM_CHECK

Only for regression tests and only for
TF-M isolation level 2.

Ref: NCSDK-16734

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>