### PR TITLE
asset_tracker_v2: Fix atv2 offline after a carrier_lib FOTA failure

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <app_event_manager.h>
 #include <math.h>
@@ -441,7 +442,12 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *evt)
 		LOG_ERR("LWM2M_CARRIER_EVENT_ERROR");
 		print_carrier_error(evt);
 
-		if (err->type == LWM2M_CARRIER_ERROR_FOTA_FAIL) {
+		bool fota_error = err->type == LWM2M_CARRIER_ERROR_FOTA_PKG ||
+				  err->type == LWM2M_CARRIER_ERROR_FOTA_PROTO ||
+				  err->type == LWM2M_CARRIER_ERROR_FOTA_CONN ||
+				  err->type == LWM2M_CARRIER_ERROR_FOTA_CONN_LOST ||
+				  err->type == LWM2M_CARRIER_ERROR_FOTA_FAIL;
+		if (fota_error) {
 			SEND_EVENT(modem, MODEM_EVT_CARRIER_FOTA_STOPPED);
 		}
 		break;


### PR DESCRIPTION
This change handles all the LWM2M_CARRIER_ERROR_FOTA_* errors and makes sure the device turns on the LTE connection after a failed FOTA update.

Fixes CIA-767

Signed-off-by: Gregers Gram Rygg <gregers.gram.rygg@nordicsemi.no>

Log output of a failed update:

```
[00:06:20.705,444] <inf> modem_module: LWM2M_CARRIER_EVENT_FOTA_START
[00:06:20.705,535] <inf> app_event_manager: MODEM_EVT_CARRIER_FOTA_PENDING
[00:06:20.971,496] <inf> download_client: Connecting to http://example.com/file.bin
[00:06:21.267,669] <inf> download_client: Downloading: http://example.com/file.bin [0]
[00:06:21.267,700] <inf> app_event_manager: CLOUD_EVT_DISCONNECTED
[00:06:21.625,885] <err> download_client: Unexpected HTTP response: 404 not found
[00:06:21.634,521] <inf> download_client: Connecting to http://example.com/file.bin
[00:06:21.907,684] <inf> download_client: Downloading: http://example.com/file.bin [0]
[00:06:22.282,897] <err> download_client: Unexpected HTTP response: 404 not found
[00:06:22.291,168] <inf> download_client: Connecting to http://example.com/file.bin
[00:06:22.547,698] <inf> download_client: Downloading: http://example.com/file.bin [0]
[00:06:22.842,346] <err> download_client: Unexpected HTTP response: 404 not found
[00:06:22.851,165] <inf> download_client: Connecting to http://example.com/file.bin
[00:06:23.107,727] <inf> download_client: Downloading: http://example.com/file.bin [0]
[00:06:23.389,404] <err> download_client: Unexpected HTTP response: 404 not found
[00:06:23.398,193] <inf> download_client: Connecting to http://example.com/file.bin
[00:06:23.666,198] <inf> download_client: Downloading: http://example.com/file.bin [0]
[00:06:23.707,458] <inf> app_event_manager: GNSS_EVT_TIMEOUT
[00:06:23.707,916] <inf> app_event_manager: GNSS_EVT_INACTIVE
[00:06:23.708,953] <inf> app_event_manager: DATA_EVT_DATA_READY
[00:06:23.869,415] <err> download_client: Unexpected HTTP response: 404 not found
[00:06:23.878,234] <inf> download_client: Connecting to http://example.com/file.bin
[00:06:24.147,766] <inf> download_client: Downloading: http://example.com/file.bin [0]
[00:06:24.422,393] <err> download_client: Unexpected HTTP response: 404 not found
[00:06:24.430,786] <inf> download_client: Connecting to http://example.com/file.bin
[00:06:24.707,794] <inf> download_client: Downloading: http://example.com/file.bin [0]
[00:06:24.978,454] <err> download_client: Unexpected HTTP response: 404 not found
[00:06:24.986,846] <inf> download_client: Connecting to http://example.com/file.bin
[00:06:25.267,822] <inf> download_client: Downloading: http://example.com/file.bin [0]
[00:06:25.471,740] <err> download_client: Unexpected HTTP response: 404 not found
[00:06:25.480,346] <inf> download_client: Connecting to http://example.com/file.bin
[00:06:25.747,833] <inf> download_client: Downloading: http://example.com/file.bin [0]
[00:06:26.015,533] <err> download_client: Unexpected HTTP response: 404 not found
[00:06:26.021,118] <err> modem_module: LWM2M_CARRIER_EVENT_ERROR
[00:06:26.021,148] <err> modem_module: Protocol error, reason -77

[00:06:26.021,209] <inf> app_event_manager: MODEM_EVT_CARRIER_FOTA_STOPPED
[00:06:26.022,003] <wrn> cloud_module: Cloud connection establishment in progress
[00:06:26.022,003] <wrn> cloud_module: New connection attempt in 32 seconds if not successful
[00:06:26.022,125] <inf> app_event_manager: CLOUD_EVT_CONNECTING
[00:06:49.774,047] <inf> app_event_manager: CLOUD_EVT_CONFIG_RECEIVED
[00:06:49.782,104] <inf> app_event_manager: DATA_EVT_CONFIG_SEND
[00:06:49.782,897] <inf> app_event_manager: CLOUD_EVT_DATA_SEND_QOS
[00:06:50.832,885] <inf> app_event_manager: CLOUD_EVT_CONNECTED
```