### PR TITLE
asset_tracker_v2: Workaround for multiple non-secure partitions

### DIFF
--- a/applications/asset_tracker_v2/overlay-carrier.conf
+++ b/applications/asset_tracker_v2/overlay-carrier.conf
@@ -6,6 +6,10 @@
 
 CONFIG_LWM2M_CARRIER=y
 
+# Workaround for known issue NCSDK-16916.
+# Set the size of the storage partition to a multiple of CONFIG_NRF_SPU_FLASH_REGION_SIZE.
+CONFIG_LWM2M_CARRIER_STORAGE_AREA_SIZE=0x8000
+
 # LwM2M carrier is only compiled for hard-float
 CONFIG_FP_HARDABI=y
 

--- a/boards/arm/thingy91_nrf9160/CMakeLists.txt
+++ b/boards/arm/thingy91_nrf9160/CMakeLists.txt
@@ -23,6 +23,8 @@ if(CONFIG_BOARD_THINGY91_NRF9160_NS)
 	# because it is used in other CMake files.
 	if (CONFIG_SPM)
 		set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91_pm_static_spm.yml CACHE INTERNAL "")
+	elseif(CONFIG_LWM2M_CARRIER)
+		set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91_pm_static_lwm2m_carrier.yml CACHE INTERNAL "")
 	else()
 		set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91_pm_static.yml CACHE INTERNAL "")
 	endif()

--- a/boards/arm/thingy91_nrf9160/thingy91_pm_static_lwm2m_carrier.yml
+++ b/boards/arm/thingy91_nrf9160/thingy91_pm_static_lwm2m_carrier.yml
@@ -1,0 +1,61 @@
+app: {address: 0x18200, size: 0x5ae00}
+mcuboot:
+  address: 0x0
+  placement:
+    before: [mcuboot_primary]
+  size: 0xc000
+mcuboot_pad:
+  address: 0xc000
+  placement:
+    align: {start: 0x1000}
+    before: [mcuboot_primary_app]
+  size: 0x200
+mcuboot_primary:
+  address: 0xc000
+  size: 0x69000
+  span: [tfm, mcuboot_pad, app]
+mcuboot_primary_app:
+  address: 0xc200
+  size: 0x68e00
+  span: [app, tfm]
+mcuboot_scratch:
+  address: 0xde000
+  placement:
+    after: [app]
+    align: {start: 0x1000}
+  size: 0x1e000
+mcuboot_secondary:
+  address: 0x75000
+  placement:
+    after: [mcuboot_primary]
+    align: {start: 0x1000}
+  share_size: [mcuboot_primary]
+  size: 0x69000
+EMPTY_0:
+  address: 0xfc000
+  size: 0x2000
+lwm2m_carrier:
+  address: 0xfb000
+  placement:
+    before: [settings_storage, tfm_storage, end]
+  size: 0x3000
+settings_storage:
+  address: 0xfe000
+  placement:
+    after: [mcuboot_scratch]
+  size: 0x2000
+nonsecure_storage:
+  address: 0xfb000
+  size: 0x5000
+  span: [lwm2m_carrier, settings_storage]
+tfm_secure:
+  address: 0xc000
+  size: 0xc200
+  span: [mcuboot_pad, tfm]
+tfm_nonsecure:
+  address: 0x18200
+  size: 0x5ae00
+  span: [app]
+tfm:
+  address: 0xc200
+  size: 0xc000

--- a/samples/nrf9160/lwm2m_carrier/prj.conf
+++ b/samples/nrf9160/lwm2m_carrier/prj.conf
@@ -6,6 +6,11 @@
 
 CONFIG_LWM2M_CARRIER=y
 
+# Workaround for known issue NCSDK-16916.
+# Set the size of the storage partition to a multiple of CONFIG_NRF_SPU_FLASH_REGION_SIZE.
+# Commented out because the sample only use one storage partition.
+# CONFIG_LWM2M_CARRIER_STORAGE_AREA_SIZE=0x8000
+
 # The library requires newlibc
 CONFIG_NEWLIB_LIBC=y
 


### PR DESCRIPTION
Partition manager has a bug that calculates the wrong size for the
non-secure storage span when it contains multiple partitions. It
it adds empty partitions in between the partitions so each becomes
the size of the SPU region size. However the empty partitions are not
taken into account, which triggers a Secure Fault in TF-M when trying
to access the other non-secure partition. This workaround increases
the size of the lwm2m_carrier partition so there is no need for an
empty partition in between the partitions.

Add the config to the lwm2m_carrier sample, so it's easy for customers
to see the config in case they need it.

Add new static partition for thingy:91 for lwm2m_carrier if
`CONFIG_LWM2M_CARRIER` is enabled.

Signed-off-by: Gregers Gram Rygg <gregers.gram.rygg@nordicsemi.no>

Partition manager bug: NCSDK-16916