### PR TITLE
caf: settings_loader: Initialize settings on system start

### DIFF
--- a/doc/nrf/libraries/caf/settings_loader.rst
+++ b/doc/nrf/libraries/caf/settings_loader.rst
@@ -45,6 +45,12 @@ To use the module, you must complete the following steps:
 This function is called on the settings loader module initialization.
 After each of modules that sets bit in :c:func:`get_req_modules` is initialized, the |settings_loader| calls :c:func:`settings_load` function and starts loading all the settings from non-volatile memory.
 
+File system as settings backend
+===============================
+
+If the settings backend is a file system (set with the :kconfig:option:`CONFIG_SETTINGS_FS` Kconfig option), make sure that the application mounts the file system before the Zephyr settings subsystem is initialized.
+The CAF settings loader module calls the :c:func:`settings_subsys_init` initialization function during the system boot with the ``APPLICATION`` level and the initialization priority set by the :kconfig:option:`CONFIG_APPLICATION_INIT_PRIORITY` Kconfig option.
+
 Implementation details
 **********************
 

--- a/subsys/caf/modules/settings_loader.c
+++ b/subsys/caf/modules/settings_loader.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/device.h>
 #include <zephyr/settings/settings.h>
 
 #include <app_event_manager.h>
@@ -114,3 +115,21 @@ static bool app_event_handler(const struct app_event_header *aeh)
 
 APP_EVENT_LISTENER(MODULE, app_event_handler);
 APP_EVENT_SUBSCRIBE(MODULE, module_state_event);
+
+static int caf_settings_init(const struct device *unused)
+{
+	ARG_UNUSED(unused);
+
+	/* Initialize settings subsystem on system start to ensure that the subsystem is initialized
+	 * before the application starts using it (e.g. before registering runtime handlers).
+	 */
+	int err = settings_subsys_init();
+
+	if (err) {
+		LOG_ERR("Settings init failed (%d)", err);
+	}
+
+	return err;
+}
+
+SYS_INIT(caf_settings_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Initialize settings subsystem on system start to ensure that it's initialized before the application starts using it.

Jira: NCSDK-16763