### PR TITLE
manifest: update matter sdk version to pull network iterator bugfix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 5faaee50ed398de2109881d1aa5320f489131264
+      revision: 6cfff048290771cb6c295fa52d6ced33b7222eb4
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Some ecosystems read `networks` attribute from `networkcommissioning` 
cluster during commissioning. This fix allows to return proper network info
instead of creating an infinite loop in that case.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>