### PR TITLE
Bluetooth: Mesh: Add sensor server API change to changelog

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -70,6 +70,7 @@ Bluetooth mesh
 
 * Added support for usage of :ref:`emds_readme`.
   For details, see `Bluetooth mesh samples`_ and `Bluetooth libraries and services`_.
+* API change in :ref:`bt_mesh_sensor_srv_readme`, column get callback now gets called with column index instead pointer to column, to support series for sensors with one or two channels.
 
 See `Bluetooth mesh samples`_ for the list of changes for the Bluetooth mesh samples.
 


### PR DESCRIPTION
This adds a note about a change in the Sensor Server API to the changelog

Signed-off-by: Ludvig Samuelsen Jordet <ludvig.jordet@nordicsemi.no>