### PR TITLE
lib: nrf_modem: trace: measure backend bitrate

### DIFF
--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -106,6 +106,12 @@ Passing ``NRF_MODEM_LIB_TRACE_LEVEL_OFF`` to the :c:func:`nrf_modem_lib_trace_le
 During tracing, the integration layer ensures that modem traces are always flushed before the Modem library is re-initialized (including when the modem has crashed).
 The application can synchronize with the flushing of modem traces by calling the :c:func:`nrf_modem_lib_trace_processing_done_wait` function.
 
+To enable the measurement of the modem trace backend bitrate, set the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE` Kconfig option to ``y`` in your project configuration.
+After enabling this Kconfig option, the application can use the :c:func:`nrf_modem_lib_trace_backend_bitrate_get` function to retrieve the rolling average bitrate of the modem trace backend, measured over the period defined by the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS` Kconfig option.
+To enable logging of the modem trace backend bitrate, set the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG` Kconfig option to ``y``.
+The logging happens at an interval set by the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG_PERIOD_MS` Kconfig option.
+If the difference in the values of the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS` Kconfig option and the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG_PERIOD_MS` Kconfig option is very high, you can sometimes observe high variation in measurements due to the short period over which the rolling average is calculated.
+
 .. _adding_custom_modem_trace_backends:
 
 Adding custom trace backends

--- a/doc/nrf/libraries/modem/nrf_modem_lib.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib.rst
@@ -112,6 +112,8 @@ To enable logging of the modem trace backend bitrate, set the :kconfig:option:`C
 The logging happens at an interval set by the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG_PERIOD_MS` Kconfig option.
 If the difference in the values of the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS` Kconfig option and the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG_PERIOD_MS` Kconfig option is very high, you can sometimes observe high variation in measurements due to the short period over which the rolling average is calculated.
 
+To enable logging of the modem trace bitrate, set the :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BITRATE_LOG` Kconfig option to ``y``.
+
 .. _adding_custom_modem_trace_backends:
 
 Adding custom trace backends

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -379,6 +379,8 @@ Modem libraries
 
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE` Kconfig option to override the IPC IRQ priority from the devicetree.
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO` Kconfig option to configure the IPC IRQ priority when the Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE` is enabled.
+    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE` Kconfig option to enable the measurement of the modem trace backend bitrate.
+    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG` Kconfig option to enable logging of the modem trace backend bitrate.
 
   * Updated:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -381,6 +381,7 @@ Modem libraries
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO` Kconfig option to configure the IPC IRQ priority when the Kconfig option :kconfig:option:`CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO_OVERRIDE` is enabled.
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE` Kconfig option to enable the measurement of the modem trace backend bitrate.
     * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG` Kconfig option to enable logging of the modem trace backend bitrate.
+    * The :kconfig:option:`CONFIG_NRF_MODEM_LIB_TRACE_BITRATE_LOG` Kconfig option to enable logging of the modem trace bitrate.
 
   * Updated:
 

--- a/include/modem/nrf_modem_lib_trace.h
+++ b/include/modem/nrf_modem_lib_trace.h
@@ -51,6 +51,17 @@ int nrf_modem_lib_trace_processing_done_wait(k_timeout_t timeout);
  */
 int nrf_modem_lib_trace_level_set(enum nrf_modem_lib_trace_level trace_level);
 
+#if defined(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE) || defined(__DOXYGEN__)
+/** @brief Get the last measured rolling average bitrate of the trace backend.
+ *
+ * This function returns the last measured rolling average bitrate of the trace backend
+ * calculated over the last @kconfig(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS) period.
+ *
+ * @return Rolling average bitrate of the trace backend
+ */
+uint32_t nrf_modem_lib_trace_backend_bitrate_get(void);
+#endif /* defined(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE) || defined(__DOXYGEN__) */
+
 /** @} */
 
 #ifdef __cplusplus

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -100,6 +100,18 @@ endif # NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG
 
 endif # NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
 
+config NRF_MODEM_LIB_TRACE_BITRATE_LOG
+	depends on LOG
+	bool "Log trace bitrate"
+
+if NRF_MODEM_LIB_TRACE_BITRATE_LOG
+
+config NRF_MODEM_LIB_TRACE_BITRATE_LOG_PERIOD_MS
+	int "Bitrate log interval (millisec)"
+	default 1000
+
+endif # NRF_MODEM_LIB_TRACE_BITRATE_LOG
+
 # Add trace backends
 rsource "trace_backends/Kconfig"
 

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -77,6 +77,29 @@ config NRF_MODEM_LIB_TRACE_THREAD_PRIO
 	depends on NRF_MODEM_LIB_TRACE_THREAD_PRIO_OVERRIDE
 	default 0
 
+config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
+	bool "Measure trace backend bitrate"
+
+if NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
+
+config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS
+	int "Rolling interval where the bitrate is measured (millisec)"
+	default 1000
+
+config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG
+	depends on LOG
+	bool "Log trace backend bitrate"
+
+if NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG
+
+config NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG_PERIOD_MS
+	int "Bitrate log interval (millisec)"
+	default 5000
+
+endif # NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_LOG
+
+endif # NRF_MODEM_LIB_TRACE_BACKEND_BITRATE
+
 # Add trace backends
 rsource "trace_backends/Kconfig"
 


### PR DESCRIPTION
This commit adds measurement and logging of the trace backend
bitrate. Useful for measuring performance of trace backends.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>

Chosen `bitrate` and `bps` naming convention because the name is shorter compared to using `throughput` everywhere. Also, bitrate is a standard unit of measure of throughput.