### PR TITLE
drivers: flash_sync_mpsl: Close timeslot session without taking mutex

### DIFF
--- a/drivers/mpsl/flash_sync/flash_sync_mpsl.c
+++ b/drivers/mpsl/flash_sync/flash_sync_mpsl.c
@@ -187,10 +187,7 @@ int nrf_flash_sync_exe(struct flash_op_desc *op_desc)
 	}
 
 	/* This will cancel the timeslot if it is still in progress. */
-	errcode = MULTITHREADING_LOCK_ACQUIRE();
-	__ASSERT_NO_MSG(errcode == 0);
 	mpsl_timeslot_session_close(_context.session_id);
-	MULTITHREADING_LOCK_RELEASE();
 
 	/* Reset the semaphore after timeout, in case if the operation _did_
 	 * complete before closing the session. */


### PR DESCRIPTION
This allows the flash driver to recover more or less gracefully when the  HCI/MPSL work thread is hanging.

Signed-off-by: Olivier Lesage <olivier.lesage@nordicsemi.no>