### PR TITLE
bluetooth: Label extended advertising reports as discardable

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -272,6 +272,7 @@ static bool event_packet_is_discardable(const uint8_t *hci_buf)
 
 		switch (me->subevent) {
 		case BT_HCI_EVT_LE_ADVERTISING_REPORT:
+		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT:
 			return true;
 		default:
 			return false;


### PR DESCRIPTION
Lets the HCI driver thread discard extended advertising reports when  host buffers aren't available, just like with legacy reports.

Signed-off-by: Olivier Lesage <olivier.lesage@nordicsemi.no>