### PR TITLE
doc: Update Zigbee entries in SW maturity level table [KRKNWK-14567]

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -9,11 +9,10 @@ features:
     Zigbee (Sleepy) End Device: ZIGBEE_ROLE_END_DEVICE
     Zigbee Router: CONFIG_ZIGBEE_ROLE_ROUTER
     Zigbee Coordinator: CONFIG_ZIGBEE_ROLE_COORDINATOR
-    Zigbee (Sleepy) End Device + Bluetooth LE multiprotocol: ZIGBEE_ROLE_END_DEVICE && BT
-    Zigbee Router + Bluetooth LE multiprotocol: ZIGBEE_ROLE_ROUTER && BT
-    Zigbee Coordinator + Bluetooth LE multiprotocol: ZIGBEE_ROLE_COORDINATOR && BT
+    Zigbee + Bluetooth LE multiprotocol: ZIGBEE && BT
     Zigbee Network Co-Processor (NCP): ZIGBEE_LIBRARY_NCP_DEV
     OTA DFU over Zigbee: ZIGBEE_FOTA
+    Zigbee + nRF21540 (GPIO): ZIGBEE && (MPSL_FEM_NRF21540_GPIO_SUPPORT || MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT)
   thread:
     Thread 1.1: OPENTHREAD_THREAD_VERSION_1_1
     Thread 1.2 - Core: OPENTHREAD_THREAD_VERSION_1_2


### PR DESCRIPTION
Changed role dependent Zigbee + BT entries in SW maturity level table to single Zigbee + BT entry.