### PR TITLE
applications: asset_tracker_v2: Add GNSS use-case and dynamics kconfig

### DIFF
--- a/applications/asset_tracker_v2/src/modules/Kconfig.gnss_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.gnss_module
@@ -48,6 +48,37 @@ config GNSS_MODULE_ELEVATION_MASK
 	default NRF_CLOUD_AGPS_ELEVATION_MASK
 	depends on NRF_CLOUD_AGPS_FILTERED
 
+choice GNSS_MODULE_DYNAMICS_MODE
+	prompt "Tune GNSS performance for a specific use case"
+	default GNSS_MODULE_DYNAMICS_MODE_GENERAL_PURPOSE
+	help
+	  Dynamics mode can be used to tune GNSS performance for a specific use case.
+	  Use of a matching dynamics mode improves the positioning performance.
+
+config GNSS_MODULE_DYNAMICS_MODE_GENERAL_PURPOSE
+	bool "General purpose mode."
+
+config GNSS_MODULE_DYNAMICS_MODE_STATIONARY
+	bool "Optimize for stationary use case."
+
+config GNSS_MODULE_DYNAMICS_MODE_PEDESTRIAN
+	bool "Optimize for pedestrian use case."
+
+config GNSS_MODULE_DYNAMICS_MODE_AUTOMOTIVE
+	bool "Optimize for automotive use case."
+endchoice
+
+config GNSS_MODULE_ALLOW_LOW_ACCURACY
+	bool "Allow for low accuracy fixes using as few as three satellites."
+	default n
+
+config GNSS_MODULE_DISABLE_SCHED_DOWNLOAD
+	bool "Disable scheduled downloads of ephemerides and almanacs."
+	default n
+	help
+	  Should only be used with A-GPS. Otherwise, GNSS will never get some data
+	  (for example ionospheric corrections), which may affect the accuracy.
+
 endif # GNSS_MODULE
 
 module = GNSS_MODULE

--- a/applications/asset_tracker_v2/tests/gnss_module/CMakeLists.txt
+++ b/applications/asset_tracker_v2/tests/gnss_module/CMakeLists.txt
@@ -17,6 +17,7 @@ cmock_handle(../../src/modules/modules_common.h )
 cmock_handle(${ZEPHYR_BASE}/../nrf/include/app_event_manager.h )
 cmock_handle(${ZEPHYR_BASE}/../nrf/subsys/app_event_manager/app_event_manager_priv.h )
 cmock_handle(${ZEPHYR_BASE}/../nrf/include/date_time.h )
+cmock_handle(${ZEPHYR_BASE}/../nrf/include/modem/lte_lc.h )
 cmock_handle(${ZEPHYR_BASE}/../nrfxlib/nrf_modem/include/nrf_modem_at.h )
 cmock_handle(${ZEPHYR_BASE}/../nrfxlib/nrf_modem/include/nrf_modem_gnss.h )
 

--- a/applications/asset_tracker_v2/tests/gnss_module/src/gnss_module_test.c
+++ b/applications/asset_tracker_v2/tests/gnss_module/src/gnss_module_test.c
@@ -11,6 +11,7 @@
 #include <mock_app_event_manager_priv.h>
 #include <mock_date_time.h>
 #include <mock_nrf_modem_at.h>
+#include <mock_lte_lc.h>
 #include <mock_nrf_modem_gnss.h>
 
 #include "app_module_event.h"
@@ -260,6 +261,9 @@ static void setup_gnss_module_in_init_state(void)
 		&nrf_modem_gnss_event_handler_set_callback);
 	__wrap_nrf_modem_gnss_event_handler_set_ExpectAnyArgsAndReturn(0);
 	__wrap_module_start_Stub(&module_start_stub);
+	__wrap_lte_lc_func_mode_set_ExpectAndReturn(LTE_LC_FUNC_MODE_ACTIVATE_GNSS, 0);
+	__wrap_nrf_modem_gnss_use_case_set_ExpectAndReturn(
+		NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START, 0);
 
 	app_module_event->type = APP_EVT_START;
 
@@ -306,6 +310,8 @@ void test_gnss_start(void)
 	/* NMEA mask (GPGGA only). */
 	__wrap_nrf_modem_gnss_nmea_mask_set_ExpectAndReturn(NRF_MODEM_GNSS_NMEA_GGA_MASK, 0);
 	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__wrap_nrf_modem_gnss_dyn_mode_change_ExpectAndReturn(
+		NRF_MODEM_GNSS_DYNAMICS_GENERAL_PURPOSE, 0);
 
 	/* Set callback to validate GNSS module events. */
 	__wrap__event_submit_Stub(&validate_gnss_evt);
@@ -349,6 +355,8 @@ void test_gnss_fix(void)
 	/* NMEA mask (GPGGA only). */
 	__wrap_nrf_modem_gnss_nmea_mask_set_ExpectAndReturn(NRF_MODEM_GNSS_NMEA_GGA_MASK, 0);
 	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__wrap_nrf_modem_gnss_dyn_mode_change_ExpectAndReturn(
+		NRF_MODEM_GNSS_DYNAMICS_GENERAL_PURPOSE, 0);
 
 	/* Set callback to validate GNSS module events. */
 	__wrap__event_submit_Stub(&validate_gnss_evt);
@@ -406,6 +414,8 @@ void test_agps_request(void)
 	/* NMEA mask (GPGGA only). */
 	__wrap_nrf_modem_gnss_nmea_mask_set_ExpectAndReturn(NRF_MODEM_GNSS_NMEA_GGA_MASK, 0);
 	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__wrap_nrf_modem_gnss_dyn_mode_change_ExpectAndReturn(
+		NRF_MODEM_GNSS_DYNAMICS_GENERAL_PURPOSE, 0);
 
 	/* Set callback to validate GNSS module events. */
 	__wrap__event_submit_Stub(&validate_gnss_evt);
@@ -457,6 +467,8 @@ void test_msgq_full(void)
 	/* NMEA mask (GPGGA only). */
 	__wrap_nrf_modem_gnss_nmea_mask_set_ExpectAndReturn(NRF_MODEM_GNSS_NMEA_GGA_MASK, 0);
 	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__wrap_nrf_modem_gnss_dyn_mode_change_ExpectAndReturn(
+		NRF_MODEM_GNSS_DYNAMICS_GENERAL_PURPOSE, 0);
 
 	/* Set callback to validate GNSS module events. */
 	__wrap__event_submit_Stub(&validate_gnss_evt);


### PR DESCRIPTION
This patch adds KConfig options to configure GNSS use-case and dynamics settings. Both can be used to tune GNSS to a specific use-case.

Implements CIA-732.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>