### PR TITLE
samples: matter: fix the crash during CASE session resumption

### DIFF
--- a/samples/matter/light_switch/src/binding_handler.cpp
+++ b/samples/matter/light_switch/src/binding_handler.cpp
@@ -23,17 +23,12 @@ void BindingHandler::Init()
 	DeviceLayer::PlatformMgr().ScheduleWork(InitInternal);
 }
 
-void BindingHandler::OnInvokeCommandFailure(DeviceProxy *aDevice, BindingData &aBindingData, CHIP_ERROR aError)
+void BindingHandler::OnInvokeCommandFailure(BindingData &aBindingData, CHIP_ERROR aError)
 {
 	CHIP_ERROR error;
 
 	if (aError == CHIP_ERROR_TIMEOUT && !BindingHandler::GetInstance().mCaseSessionRecovered) {
 		LOG_INF("Response timeout for invoked command, trying to recover CASE session.");
-		if (!aDevice)
-			return;
-
-		/* Release current CASE session. */
-		aDevice->Disconnect();
 
 		/* Set flag to not try recover session multiple times. */
 		BindingHandler::GetInstance().mCaseSessionRecovered = true;
@@ -69,8 +64,8 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
 			BindingHandler::GetInstance().mCaseSessionRecovered = false;
 	};
 
-	auto onFailure = [aDevice, dataRef = *data](CHIP_ERROR aError) mutable {
-		BindingHandler::OnInvokeCommandFailure(aDevice, dataRef, aError);
+	auto onFailure = [dataRef = *data](CHIP_ERROR aError) mutable {
+		BindingHandler::OnInvokeCommandFailure(dataRef, aError);
 	};
 
 	if (aDevice) {
@@ -140,8 +135,8 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Embe
 			BindingHandler::GetInstance().mCaseSessionRecovered = false;
 	};
 
-	auto onFailure = [aDevice, dataRef = *data](CHIP_ERROR aError) mutable {
-		BindingHandler::OnInvokeCommandFailure(aDevice, dataRef, aError);
+	auto onFailure = [dataRef = *data](CHIP_ERROR aError) mutable {
+		BindingHandler::OnInvokeCommandFailure(dataRef, aError);
 	};
 
 	CHIP_ERROR ret = CHIP_NO_ERROR;

--- a/samples/matter/light_switch/src/binding_handler.h
+++ b/samples/matter/light_switch/src/binding_handler.h
@@ -27,7 +27,7 @@ public:
 	bool IsGroupBound();
 
 	static void SwitchWorkerHandler(intptr_t);
-	static void OnInvokeCommandFailure(chip::DeviceProxy *aDevice, BindingData &aBindingData, CHIP_ERROR aError);
+	static void OnInvokeCommandFailure(BindingData &aBindingData, CHIP_ERROR aError);
 
 	static BindingHandler &GetInstance()
 	{


### PR DESCRIPTION
After recent upmerge accessing DeviceProxy object in the application callback
is redundant and leads to crash, because of modified lifetime of this object in Matter core.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>