### PR TITLE
tfm: Increase crypto partition stack size in minimal configuration

### DIFF
--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -106,7 +106,7 @@ config TFM_CRYPTO_IOVEC_BUFFER_SIZE
 config TFM_CRYPTO_PARTITION_STACK_SIZE
 	hex
 	prompt "TF-M Crypto Partition - Stack size" if !TFM_PROFILE_TYPE_MINIMAL
-	default 0x400 if TFM_PROFILE_TYPE_MINIMAL
+	default 0x800 if TFM_PROFILE_TYPE_MINIMAL
 	default 0x2000
 	help
 	  The stack size of the Crypto Secure Partition


### PR DESCRIPTION
Increase the crypto partition stack size in minimal configuration.

NCSDK-16972

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>