### PR TITLE
manifest: update zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.1.99-ncs1-rc2
+      revision: adbe09d60d49be7dcfa773280db501c241dc0074
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
zephyr was updated to version which contains MCuboot's DTS aliases for thingy53 boards.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>