### PR TITLE
samples: peripheral: lpuart: Fix increased current draw on nRF5340 DK

### DIFF
--- a/samples/peripheral/lpuart/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/peripheral/lpuart/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -20,6 +20,16 @@
 	disable-rx;
 };
 
+&uart0_default {
+	group2 {
+		/* Remove assignment of P0.21 as CTS. This is a temporary
+		 * workaround for increased current consumption observed
+		 * on nRF5340 DKs only (~200 uA more on v0.9.0 and ~400 uA
+		 * more on v2.0.0). */
+		psels = <NRF_PSEL(UART_RX, 0, 22)>;
+	};
+};
+
 &gpiote {
 	interrupts = <13 NRF_DEFAULT_IRQ_PRIORITY>;
 };


### PR DESCRIPTION
Add a temporary workaround for increased current consumption observed for the lpuart sample on nRF5340 DKs.

Ref. NCSDK-16856

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>