### PR TITLE
tests: lib: location: Make cmock skip generating mock for at_scanf

### DIFF
--- a/tests/unity/unity_cfg.yaml
+++ b/tests/unity/unity_cfg.yaml
@@ -30,7 +30,10 @@
         'uint32_t': 'HEX32'
         'int64_t': 'INT64'
         'uint64_t': 'HEX64'
-
+    :strippables:
+        # Skip mock generation for nrf_modem_at_scanf as CMock does not have proper support for
+        # mocking variadic functions like this one.
+        - '(?:.*nrf_modem_at_scanf\s*\(+.*?\)+)'
 :unity:
     :suite_teardown: >
        extern int test_suiteTearDown(int); return test_suiteTearDown(num_failures);


### PR DESCRIPTION
Make cmock skip generating mock for nrf_modem_at_scanf. The test suite will now have its own implementation of the mock which will test the arguments and return a fixed system mode.

This is done as a preparatory step for more unit tests that depend on CMock skipping the mock generation for nrf_modem_at_scanf.

The reason why we want to skip generation of mock is because CMock does not have good enough support for variadic functions. Related issue: https://github.com/ThrowTheSwitch/CMock/issues/397

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>
Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>