### PR TITLE
doc: Add details about the board version in the LTE BLE Gateway sample

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -330,6 +330,29 @@ NCSDK-9441: Fmfu SMP server sample is unstable with the newest J-Link version
 
   **Workaround:** Downgrade the debugger chip to the firmware released with J-Link 6.88a or use another way of transferring serial data to the chip.
 
+.. rst-class:: v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+
+LTE Sensor Gateway fails to run
+  The :ref:`lte_sensor_gateway` sample system faults when the board version is not included with the build target while building the sample.
+  This is due to an issue with the low-power UART and HCI drivers.
+
+  **Workaround:** Include the board version when building the :ref:`bluetooth-hci-lpuart-sample` sample and the :ref:`lte_sensor_gateway` sample.
+  For example, for board version 1.1.0, the samples must be built in the following way:
+
+  The :ref:`bluetooth-hci-lpuart-sample` sample:
+
+  .. parsed-literal::
+    :class: highlight
+
+    west build --board nrf9160dk_nrf52840_ns@1.1.0
+
+  The :ref:`lte_sensor_gateway` sample:
+
+  .. parsed-literal::
+    :class: highlight
+
+    west build --board nrf9160dk_nrf9160_ns@1.1.0
+
 nRF5
 ****
 

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -81,7 +81,6 @@ Building and running
 
 .. include:: /includes/build_and_run_ns.txt
 
-
 Programming the sample
 ======================
 
@@ -96,6 +95,17 @@ Program the board controller as follows:
 1. Set the **SW10** switch, marked as *debug/prog*, in the **NRF52** position.
    On nRF9160 DK board version 0.9.0 and earlier versions, the switch was called **SW5**.
 #. Build the :ref:`bluetooth-hci-lpuart-sample` sample for the nrf9160dk_nrf52840 build target and program the board controller with it.
+
+   .. note::
+      To build the sample successfully, you must specify the board version along with the build target.
+      The board version is printed on the label of your DK, just below the PCA number.
+      For example, for board version 1.1.0, the sample must be built in the following way:
+
+      .. parsed-literal::
+         :class: highlight
+
+         west build --board nrf9160dk_nrf52840_ns@1.1.0
+
 #. Verify that the programming was successful.
    Use a terminal emulator, like PuTTY, to connect to the second serial port and check the output.
    See :ref:`putty` for the required settings.
@@ -106,6 +116,16 @@ Program the main controller as follows:
 1. Set the **SW10** switch, marked as *debug/prog*, in the **NRF91** position.
    On nRF9160 DK board version 0.9.0 and earlier versions, the switch was called **SW5**.
 #. Build the LTE Sensor Gateway sample (this sample) for the nrf9160dk_nrf9160_ns build target and program the main controller with it.
+
+   .. note::
+      To build the sample successfully, you must specify the board version along with the build target.
+      For example, for board version 1.1.0, the sample must be built in the following way:
+
+      .. parsed-literal::
+         :class: highlight
+
+         west build --board nrf9160dk_nrf9160_ns@1.1.0
+
 #. Verify that the programming was successful.
    To do so, use a terminal emulator, like PuTTY, to connect to the first serial port and check the output.
    See :ref:`putty` for the required settings.


### PR DESCRIPTION
Add a note about board version when building in the LTE BLE Gateway sample document.
Ref: NCSDK-16931

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>