### PR TITLE
doc: Moved glossary menu entry

### DIFF
--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -16,7 +16,6 @@ A "99" at the end of the version number of this documentation indicates continuo
    :caption: Contents
 
    introduction
-   glossary
    getting_started
    ug_dev_model
    ug_app_dev
@@ -36,5 +35,6 @@ A "99" at the end of the version number of this documentation indicates continuo
    known_issues
    software_maturity
    documentation
+   glossary
 
 ..   cheat_sheet


### PR DESCRIPTION
Moved the menu entry for the glossary.

Signed-off-by: Francesco Domenico Servidio <francesco.servidio@nordicsemi.no>

(As agreed with Oisin)