### PR TITLE
drivers: wifi: Dynamic QSPI clock switching

### DIFF
--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -192,7 +192,7 @@ arduino_i2c: &i2c1 {
 		status = "okay";
 		compatible = "nordic,nrf7002-qspi";
 		reg = <1>;
-		sck-frequency = <8000000>;
+		sck-frequency = <24000000>;
 		quad-mode;
 		/* Wi-Fi Pins used */
 		iovdd-ctrl-gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
Use 8MHz QSPI clock for waking up RPU and once its awake then switch back to configured clock frequency from the DTS.

Change the default frequency to 24MHz (32MHz has some timing closure issues).

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>