### PR TITLE
manifest: Bring sdk-mbedtls repo with entropy fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -107,7 +107,7 @@ manifest:
     - name: mbedtls-nrf
       path: mbedtls
       repo-path: sdk-mbedtls
-      revision: v3.1.0-ncs1
+      revision: abce0e893c8ad219370100dadaed0ae11a3e4d63
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib


### PR DESCRIPTION
This introduces a workaround in the sdk-mbedtls repo
which caused a fault when the mbedtls_entropy_init
function was called with a non zeroed context.

Ref: NCSDK-8075

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
