### PR TITLE
scripts: hid_configurator: Update required hid library version

### DIFF
--- a/scripts/hid_configurator/requirements.txt
+++ b/scripts/hid_configurator/requirements.txt
@@ -1,3 +1,3 @@
 # pyhidapi
-hid>=1.0.3
+hid>=1.0.3, <1.0.5
 imgtool>=1.7.0


### PR DESCRIPTION
Change updates hid library version in requirements.txt file. This is needed to workaround undefined symbol: hid_get_input_report observed in version 1.0.5.

Jira: NCSDK-16985