### PR TITLE
applications: nrf5340_audio: Bugfix DFU

### DIFF
--- a/applications/nrf5340_audio/CMakeLists.txt
+++ b/applications/nrf5340_audio/CMakeLists.txt
@@ -17,7 +17,10 @@ if (CONFIG_AUDIO_DFU EQUAL 2)
     set(mcuboot_OVERLAY_CONFIG
         ${CMAKE_CURRENT_LIST_DIR}/dfu/conf/overlay-mcuboot_external_flash.conf
     )
-    set(mcuboot_DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dfu/conf/overlay-dfu_external_flash.overlay)
+    list(APPEND mcuboot_DTC_OVERLAY_FILE
+        "${CMAKE_CURRENT_LIST_DIR}/dfu/conf/overlay-dfu_external_flash.overlay"
+        "$ENV{ZEPHYR_BASE}/../nrf/modules/mcuboot/flash_sim.overlay"
+    )
     set(DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dfu/conf/overlay-dfu_external_flash.overlay)
     set(mcuboot_PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/dfu/conf/pm_dfu_external_flash.yml)
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/dfu/conf/pm_dfu_external_flash.yml)

--- a/applications/nrf5340_audio/dfu/conf/overlay-dfu_external_flash.overlay
+++ b/applications/nrf5340_audio/dfu/conf/overlay-dfu_external_flash.overlay
@@ -4,52 +4,6 @@
 	};
 };
 
-/ {
-	soc {
-		/* Add a flash controller which has the compatible
-		 * 'zephyr,sim-flash'. This will ensure that the flash
-		 * simulator can use it. None of the other properties in this
-		 * node is used for anything.
-		 */
-		nordic_ram_flash_controller: nordic_ram-flash-controller@0 {
-			compatible = "zephyr,sim-flash";
-			reg = <0x00000000 DT_SIZE_K(40)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			erase-value = <0xff>;
-			label = "nordic_ram_flash_flash_controller";
-
-			/* This node label must match that used in the flash
-			 * simulator.
-			 */
-			flash_sim0: flash_sim@0 {
-				status = "okay";
-				compatible = "soc-nv-flash";
-				label = "simulated_flash";
-				erase-block-size = <4096>;
-				write-block-size = <4>;
-				reg = <0x00000000 DT_SIZE_K(256)>;
-
-				partitions {
-					compatible = "fixed-partitions";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					/* This partition must be defined for
-					 * MCUboot to find the partition ID
-					 * of the primary slot for image 1,
-					 * which is stored in this partition.
-					 */
-					slot2_partition: partition@0 {
-						label = "image-2";
-						reg = <0x00000000 0x00000A000>;
-					};
-				};
-			};
-		};
-	};
-};
-
 &qspi {
 	status = "disabled";
 };

--- a/applications/nrf5340_audio/src/modules/dfu_entry.c
+++ b/applications/nrf5340_audio/src/modules/dfu_entry.c
@@ -10,6 +10,8 @@
 #include <zephyr/kernel.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
+#include <settings/settings.h>
+
 #include "button_assignments.h"
 #include "ble_core.h"
 #include "button_handler.h"
@@ -123,6 +125,10 @@ static void dfu_set_bt_name(void)
 
 static void on_ble_core_ready_dfu_entry(void)
 {
+	if (IS_ENABLED(CONFIG_SETTINGS)) {
+		settings_load();
+	}
+
 	bt_conn_cb_register(&dfu_conn_callbacks);
 	adv_param = *BT_LE_ADV_CONN_NAME;
 	dfu_set_bt_name();


### PR DESCRIPTION
-Fix 256KB Sram is occupied by FLASH_SIMULATOR driver.
 This driver should be enabled in mcuboot only,
 and explicitly enabled by kconfig.
 https://github.com/nrfconnect/sdk-zephyr/commit/a529c4511d220c0bc20a4259e8ef243fdbce56c5
 introduce new feature which enable driver by default
 based on devicetree.

-Fix SMP_BT is not advertising if CONFIG_BT_PRIVACY is enabled.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>