### PR TITLE
Bluetooth: services: hrs: fix rr_interval_present evaluation statement

### DIFF
--- a/subsys/bluetooth/services/hrs_client.c
+++ b/subsys/bluetooth/services/hrs_client.c
@@ -61,7 +61,7 @@ static int hrs_measurement_data_parse(struct bt_hrs_client_measurement *meas,
 						1 : 0;
 	meas->flags.energy_expended_present = (flags & HRS_MEASUREMENT_FLAGS_ENERGY_EXPENDED) ?
 						1 : 0;
-	meas->flags.rr_intervals_present = (false & HRS_MEASUREMENT_FLAGS_RR_INTERVALS) ? 1 : 0;
+	meas->flags.rr_intervals_present = (flags & HRS_MEASUREMENT_FLAGS_RR_INTERVALS) ? 1 : 0;
 
 	length--;
 


### PR DESCRIPTION
Evaluation of a flag that stores information about RR interval data presence in received notification data, was wrong. There should be and operation where first argument is flags variable instead of false boolean value.

The commit fixes the issue.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>