### PR TITLE
bluetooth: Crash kernel when non-discardable events are discarded

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -332,6 +332,7 @@ static void event_packet_process(uint8_t *hci_buf)
 		}
 
 		BT_ERR("No event buffer available");
+		k_oops();
 		return;
 	}
 


### PR DESCRIPTION
Discarding critical events leads to hard-to-debug propagation failures.  This crashes the device more visibly in those cases.

Signed-off-by: Olivier Lesage <olivier.lesage@nordicsemi.no>