### PR TITLE
manifest: Update zephyr with doc tool versions

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -55,8 +55,7 @@ jobs:
       - name: Install documentation dependencies
         working-directory: ncs
         run: |
-          pip3 install -r zephyr/scripts/requirements-doc.txt
-          pip3 install -r nrf/scripts/requirements-doc.txt
+          pip3 install -r zephyr/scripts/requirements-doc.txt -r nrf/scripts/requirements-doc.txt
 
       - name: Build documentation
         working-directory: ncs/nrf

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 44ede1e459c061fb1f7b65431535d6b66654ec78
+      revision: 86893246053c50d34618f09ec6722cae8ba19472
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/48947
https://github.com/nrfconnect/sdk-zephyr/pull/910
Update to Sphinx 5.x, also update breathe since version 4.34 is the
first to officially support Sphinx 5.x.