### PR TITLE
net: lib: download_client: fixed race condition on dl start

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -261,6 +261,7 @@ Libraries for networking
 * :ref:`lib_download_client` library:
 
   * Updated the library so that it does not retry download on disconnect.
+  * Fixed a race condition when starting the download.
 
 Libraries for NFC
 -----------------

--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -171,6 +171,8 @@ struct download_client {
 	k_tid_t tid;
 	/** Internal download thread. */
 	struct k_thread thread;
+	/** Ensure that thread is ready for download */
+	struct k_sem wait_for_download;
 	/* Internal thread stack. */
 	K_THREAD_STACK_MEMBER(thread_stack,
 			      CONFIG_DOWNLOAD_CLIENT_STACK_SIZE);


### PR DESCRIPTION
If the download thread is created with a delay, the download thread might be resumed in download_client_start before the actual download thread is started. This causes the download thread to start the download but not continue.

This bug actually occurred when trying to install a modem delta update that was invalid (bad version) in a loop and was very easy to reproduce.

Signed-off-by: Andreas Chmielewski <andreas.chmielewski@grandcentrix.net>