### PR TITLE
lib: nrf_modem_lib: Improve nrf_modem_trace_get error handling

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_lib_trace.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib_trace.c
@@ -86,6 +86,9 @@ trace_reset:
 	while (true) {
 		err = nrf_modem_trace_get(&frags, &n_frags);
 		switch (err) {
+		case 0:
+			/* Success */
+			break;
 		case -NRF_ESHUTDOWN:
 			LOG_INF("Modem was turned off, no more traces");
 			goto out;
@@ -94,6 +97,9 @@ trace_reset:
 			goto out;
 		case -NRF_EINPROGRESS:
 			__ASSERT(0, "Error in transport backend");
+			goto out;
+		default:
+			__ASSERT(0, "Unhandled err %d", err);
 			goto out;
 		}
 


### PR DESCRIPTION
Added default case so that unhandled errors are caught. This also involved adding a case for success which inturn improves the speed of execution as 0 is the most often returned value by nrf_modem_trace_get.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>