### PR TITLE
doc improvement: Add links to Connectivity bridge documentation

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/nus.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/nus.rst
@@ -10,6 +10,7 @@ Nordic UART Service (NUS)
 The Bluetooth® LE GATT Nordic UART Service is a custom service that receives and writes data and serves as a bridge to the UART interface.
 
 The NUS Service is used in the :ref:`peripheral_uart` sample.
+It is also included with the Thingy:91 :ref:`connectivity_bridge`, but is disabled by default.
 
 Service UUID
 ************

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -24,10 +24,22 @@ This guide gives you more information on the various aspects of Thingy:91.
 Connecting to Thingy:91
 ***********************
 
-For connecting to Thingy:91, you can use `LTE Link Monitor`_, `Trace Collector`_, or a serial terminal.
+You can connect to Thingy:91 wirelessly (using the `nRF Toolbox`_ app) or over a serial connection (using `LTE Link Monitor`_, `Trace Collector`_, or a serial terminal).
 
-Using serial ports
-==================
+Using nRF Toolbox
+=================
+
+To connect to your Thingy:91 wirelessly, you need to meet the following prerequisites:
+
+* The :ref:`connectivity_bridge` installed on your Thingy:91.
+* The :ref:`nus_service_readme` enabled.
+
+  .. note::
+     By default, the Bluetooth LE interface is off, as the connection is not encrypted or authenticated.
+     To turn it on at runtime, set the appropriate option in the :file:`Config.txt` file located on the USB Mass storage Device.
+
+Using a serial terminal
+=======================
 
 If you prefer to use a standard serial terminal, the baud rate has to be specified manually.
 
@@ -43,7 +55,6 @@ Thingy:91 uses the following UART baud rate configuration:
      - 115200
    * - UART_1
      - 1000000
-
 
 Using LTE Link Monitor
 ======================

--- a/doc/nrf/ug_thingy91_gsg.rst
+++ b/doc/nrf/ug_thingy91_gsg.rst
@@ -568,3 +568,4 @@ See the following links for where to go next:
 
 * :ref:`ug_thingy91` for more advanced topics related to the Thingy:91.
 * The :ref:`introductory documentation <getting_started>` for more information on the |NCS| and the development environment.
+* :ref:`connectivity_bridge` about using the nRF UART Service with Thingy:91.


### PR DESCRIPTION
Added references to the Connectivity bridge doc in the following pieces of documentation:

- Getting started with Thingy:91
- Developing with Thingy:91
- Nordic UART Service library doc

Ref: NCSDK-16954

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>