### PR TITLE
Bluetooth: Mesh: Prevent trailing zero on UUID gen

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -225,7 +225,13 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`bt_mesh` library:
+
+  * :ref:`bt_mesh_dk_prov` module: Changed the UUID generation to prevent trailing zeros in the UUID.
+
+    **Migration notes:** To retain the legacy generation of UUID, enable the option ``CONFIG_BT_MESH_DK_LEGACY_UUID_GEN``.
+
+See `Bluetooth mesh samples`_ for the list of changes for the Bluetooth mesh samples.
 
 Bootloader libraries
 --------------------

--- a/subsys/bluetooth/mesh/Kconfig.dk_prov
+++ b/subsys/bluetooth/mesh/Kconfig.dk_prov
@@ -30,6 +30,12 @@ config BT_MESH_DK_PROV_OOB_LOG
 	depends on LOG_PRINTK
 	default y
 
+config BT_MESH_DK_LEGACY_UUID_GEN
+	bool "Use legacy generation of UUID"
+	help
+	  Use legacy generation of UUID. For most platforms this will generate UUIDs
+	  with trailing zeros.
+
 module = BT_MESH_DK_PROV
 module-str = DK BT mesh provisioning library
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/bluetooth/mesh/dk_prov.c
+++ b/subsys/bluetooth/mesh/dk_prov.c
@@ -199,7 +199,17 @@ const struct bt_mesh_prov *bt_mesh_dk_prov_init(void)
 	 *
 	 * https://tools.ietf.org/html/rfc4122
 	 */
-	hwinfo_get_device_id(dev_uuid, sizeof(dev_uuid));
+	size_t id_len = hwinfo_get_device_id(dev_uuid, sizeof(dev_uuid));
+
+	if (!IS_ENABLED(CONFIG_BT_MESH_DK_LEGACY_UUID_GEN)) {
+		/* If device ID is shorter than UUID size, fill rest of buffer with
+		 * inverted device ID.
+		 */
+		for (size_t i = id_len; i < sizeof(dev_uuid); i++) {
+			dev_uuid[i] = dev_uuid[i % id_len] ^ 0xff;
+		}
+	}
+
 	dev_uuid[6] = (dev_uuid[6] & BIT_MASK(4)) | BIT(6);
 	dev_uuid[8] = (dev_uuid[8] & BIT_MASK(6)) | BIT(7);
 


### PR DESCRIPTION
Updates the generation of UUID to fill trailing zeros if device ID is smaller than the UUID size.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>