### PR TITLE
mpsl: cx: Matched nrf7002 with nrf700x coex implementation

### DIFF
--- a/boards/arm/nrf7002dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf7002dk_nrf5340/Kconfig.defconfig
@@ -10,7 +10,6 @@ config BOARD
 
 # By default, if we build for a Non-Secure version of the board,
 # force building with TF-M as the Secure Execution Environment.
-
 config BUILD_WITH_TFM
 	# Temporarily disable building Non-Secure images with TF-M support by
 	# default.

--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -95,6 +95,15 @@
 		};
 	};
 
+	nrf_radio_coex: nrf7002-coex {
+		status = "okay";
+		compatible = "nordic,nrf700x-coex";
+		req-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
+		status0-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+		grant-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
+		swctrl1-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
@@ -189,10 +198,6 @@ arduino_i2c: &i2c1 {
 		iovdd-ctrl-gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
 		bucken-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		host-irq-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
-		coex-req-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
-		coex-status0-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
-		coex-grant-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
-		swctrl1-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpunet.dts
@@ -77,6 +77,15 @@
 			   <21 0 &gpio1 3 0>;	/* D15 */
 	};
 
+	nrf_radio_coex: nrf7002-coex {
+		status = "okay";
+		compatible = "nordic,nrf700x-coex";
+		req-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
+		status0-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+		grant-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
+		swctrl1-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;

--- a/boards/shields/nrf7002_ek/nrf7002_ek.overlay
+++ b/boards/shields/nrf7002_ek/nrf7002_ek.overlay
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #include <freq.h>
+#include "nrf7002_ek_coex.overlay"
 
 &arduino_spi {
 	status = "okay";
@@ -15,13 +16,8 @@
 		label = "NRF7002";
 		spi-max-frequency = <DT_FREQ_M(8)>;
 
-		iovdd-ctrl-gpios = <&arduino_header 6 GPIO_ACTIVE_HIGH>;	/* D0 */
-		bucken-gpios = <&arduino_header 7 GPIO_ACTIVE_HIGH>;		/* D1 */
-		host-irq-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;		/* D7 */
-
-		coex-req-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;		/* D2 */
-		coex-status0-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;	/* D3 */
-		coex-grant-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;	/* D4 */
-		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;		/* D6 */
+		iovdd-ctrl-gpios = <&arduino_header 6 GPIO_ACTIVE_HIGH>;    /* D0 */
+		bucken-gpios = <&arduino_header 7 GPIO_ACTIVE_HIGH>;        /* D1 */
+		host-irq-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;     /* D7 */
 	};
 };

--- a/boards/shields/nrf7002_ek/nrf7002_ek_coex.overlay
+++ b/boards/shields/nrf7002_ek/nrf7002_ek_coex.overlay
@@ -1,0 +1,15 @@
+/* Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	nrf_radio_coex: nrf7002-coex {
+		status = "okay";
+		compatible = "nordic,nrf700x-coex";
+		req-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;       /* D2 */
+		status0-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;   /* D3 */
+		grant-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;    /* D4 */
+		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;  /* D6 */
+	};
+};

--- a/dts/bindings/radio_coex/nordic,nrf700x-coex.yaml
+++ b/dts/bindings/radio_coex/nordic,nrf700x-coex.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+description: |
+    This is a representation of an external radio coexistence setup for coexistence
+    with nRF700x WiFi chips.
+
+compatible: "nordic,nrf700x-coex"
+
+include: base.yaml
+
+properties:
+    req-gpios:
+        type: phandle-array
+        required: true
+        description: |
+            GPIO of the SOC connected to the PTA's REQUEST pin.
+
+    status0-gpios:
+        type: phandle-array
+        required: true
+        description: |
+            GPIO of the SOC connected to the PTA's PRIORITY pin.
+            This GPIO is also used to indicate direction (TX/RX).
+
+    grant-gpios:
+        type: phandle-array
+        required: true
+        description: |
+            GPIO of the SOC connected to the PTA's GRANT pin.
+
+    swctrl1-gpios:
+        type: phandle-array
+        required: false
+        description: |
+            GPIO of the SOC controlling the Priority (STATUS1) pin (in 4-wire
+            coex case) of the nRF7002

--- a/dts/bindings/wifi/nordic,nrf7002.yaml
+++ b/dts/bindings/wifi/nordic,nrf7002.yaml
@@ -21,24 +21,3 @@ properties:
         required: true
         description: |
             GPIO of the SOC controlling the HOST IRQ pin of the nRF7002
-    coex-req-gpios:
-        type: phandle-array
-        required: true
-        description: |
-            GPIO of the SOC controlling SR Coexistence REQ pin of the nRF7002
-    coex-status0-gpios:
-        type: phandle-array
-        required: true
-        description: |
-            GPIO of the SOC controlling SR Coexistence STATUS pin of the nRF7002
-    coex-grant-gpios:
-        type: phandle-array
-        required: true
-        description: |
-            GPIO of the SOC controlling SR Coexistence GRANT pin of the nRF7002
-    swctrl1-gpios:
-        type: phandle-array
-        required: true
-        description: |
-            GPIO of the SOC controlling the Priority (STATUS1) pin (in 4-wire
-            coex case) of the nRF7002

--- a/subsys/mpsl/cx/CMakeLists.txt
+++ b/subsys/mpsl/cx/CMakeLists.txt
@@ -4,11 +4,11 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if (CONFIG_MPSL_CX_THREAD OR CONFIG_MPSL_CX_BT_1WIRE OR CONFIG_MPSL_CX_BT_3WIRE OR CONFIG_MPSL_CX_GENERIC_3PIN)
+if (CONFIG_MPSL_CX_THREAD OR CONFIG_MPSL_CX_BT_1WIRE OR CONFIG_MPSL_CX_BT_3WIRE OR CONFIG_MPSL_CX_NRF700X)
     zephyr_library()
 
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_THREAD thread/mpsl_cx_thread.c)
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_BT_1WIRE bluetooth/mpsl_cx_1w_bluetooth.c)
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_BT_3WIRE bluetooth/mpsl_cx_3w_bluetooth.c)
-    zephyr_library_sources_ifdef(CONFIG_MPSL_CX_GENERIC_3PIN generic_3pin/mpsl_cx_generic_3pin.c)
+    zephyr_library_sources_ifdef(CONFIG_MPSL_CX_NRF700X nrf700x/mpsl_cx_nrf700x.c)
 endif()

--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -4,8 +4,20 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+DT_COMPAT_CX_NRF700X := nordic,nrf700x-coex
+
+config MPSL_CX_ANY_SUPPORT
+	bool
+	default $(dt_nodelabel_enabled,nrf_radio_coex)
+
+config MPSL_CX_NRF700X_SUPPORT
+	bool
+	default $(dt_nodelabel_has_compat,nrf_radio_coex,$(DT_COMPAT_CX_NRF700X))
+
 config MPSL_CX
 	bool "Radio Coexistence interface support"
+	depends on MPSL_CX_ANY_SUPPORT
+	default WIFI && (BT || NRF_802154_RADIO_DRIVER || NRF_802154_SER_HOST)
 	help
 	  Controls if Radio Coexistence interface is to be configured and enabled
 	  when MPSL is initialized.
@@ -30,6 +42,14 @@ config MPSL_CX_INIT_PRIORITY
 
 choice MPSL_CX_CHOICE
 	prompt "Radio Coexistence interface implementation"
+
+config MPSL_CX_NRF700X
+	depends on MPSL_CX_NRF700X_SUPPORT
+	select NRFX_GPIOTE if !MPSL_CX_PIN_FORWARDER
+	select GPIO if !MPSL_CX_PIN_FORWARDER
+	bool "nRF700x Radio Coexistence"
+	help
+	  Radio Coexistence supporting nRF700x interface.
 
 config MPSL_CX_THREAD
 	select NRFX_GPIOTE if !MPSL_CX_PIN_FORWARDER
@@ -62,14 +82,6 @@ config MPSL_CX_BT_1WIRE
 	help
 	  Radio Coexistence interface implementation using a simple 1-wire PTA
 	  implementation for co-located radios.
-
-config MPSL_CX_GENERIC_3PIN
-	select NRFX_GPIOTE if !MPSL_CX_PIN_FORWARDER
-	select GPIO if !MPSL_CX_PIN_FORWARDER
-	bool "Generic 3-pin Radio Coexistence support [EXPERIMENTAL]"
-	select EXPERIMENTAL
-	help
-	  Radio Coexistence supporting Generic 3-pin interface.
 
 endchoice # MPSL_CX_CHOICE
 


### PR DESCRIPTION
This PR does the following:
- Adds the nrf700x CX implentation (based on the old generic three pin interface), mostly renames
- Deleted the legacy generic three pin interface
- Modified the nrf7002dk_nrf5340 devicetree files and nrf7002_ek device tree overlays to allow the usage of nRF700x coexistence interface.
- Enable seamless using of the nRF700x Coexistence interface by so that the coexistence interface is enabled by default if it is supported in the device tree, CONFIG_WIFI is selected and one of the SR radio protocols is used
- Update documentation

Signed-off-by: Artur Hadasz <artur.hadasz@nordicsemi.no>