### PR TITLE
manifest: Update manifest for TF-M I/O buffer check in library model

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -118,7 +118,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: a07f8eb8fa336f04a79f9d6c6a7548f801ce3870
+      revision: ce077f50732f56dc277d829638ad6e033ab9f37b
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Update manifest for trusted-firmware-m (TF-M).
Includes fix to return an error to the application when providing invalid arguments for the input or output buffer instead of triggering a panic.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>