### PR TITLE
samples: wifi: shell: Add overlays for nRF52840 and nRF9160 DKs

### DIFF
--- a/samples/wifi/shell/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/wifi/shell/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Disabled because of a conflict on P1.08 - Arduino pin D7 (host-irq-gpios
+ * in nrf7002_ek). */
+&spi1 {
+	status = "disabled";
+};
+
+/* Disabled because of conflicts on P1.01 and P1.02 - Arduino pins D0 and D1
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002_ek, respectively). */
+&uart1 {
+	status = "disabled";
+};

--- a/samples/wifi/shell/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/wifi/shell/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Use high drive mode on SPI pins that handle communication with nRF7002
+ * so that SCK frequency > 4 MHz can be used. */
+&spi3_default {
+	group1 {
+		nordic,drive-mode = <NRF_DRIVE_H0H1>;
+	};
+};
+
+/* Disabled because of conflicts on P0.00 and P0.01 - Arduino pins D0 and D1
+ * (iovdd-ctrl-gpios and bucken-gpios in nrf7002_ek, respectively). */
+&uart1 {
+	status = "disabled";
+};


### PR DESCRIPTION
Add overlays that allow running the sample on nRF52840 and nRF9160 DKs with the nRF7002 EK shield. Some peripherals enabled by default on those DKs generate conflicts on lines that are used by nRF7002 EK, so these peripherals are disabled. For nRF9160 DK, additionally SPI pins are configured with high drive so that SCK frequency > 4 MHz can be used.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>