### PR TITLE
applications: asset_tracker_v2: Implement nRF modem lib fault handler

### DIFF
--- a/applications/asset_tracker_v2/prj.conf
+++ b/applications/asset_tracker_v2/prj.conf
@@ -26,6 +26,7 @@ CONFIG_LOG_MODE_DEFERRED=y
 
 # nRF modem library
 CONFIG_NRF_MODEM_LIB=y
+CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC=y
 
 # AT Host library - Used to send AT commands directy from an UART terminal and to allow
 #		    integration with nRF Connect for Desktop LTE Link monitor application.

--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <app_event_manager.h>
 #include <math.h>
+#include <nrf_modem.h>
 #include <modem/lte_lc.h>
 #include <modem/modem_info.h>
 #include <modem/pdn.h>
@@ -177,6 +178,12 @@ static bool app_event_handler(const struct app_event_header *aeh)
 	}
 
 	return false;
+}
+
+void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault_info)
+{
+	LOG_ERR("Modem error: 0x%x, PC: 0x%x", fault_info->reason, fault_info->program_counter);
+	SEND_ERROR(modem, MODEM_EVT_ERROR, -EFAULT);
 }
 
 static void lte_evt_handler(const struct lte_lc_evt *const evt)


### PR DESCRIPTION
Implement application-specific nRF modem lib fault handler to ensure that the system reboots in case the modem faults.

Future improvement is to reinitialize the modem in case this happens. But this is a larger effort because it ideally should be aligned with reinitialization of the modem after modem FOTA. Where the application currently also unnecessarily reboots.

Fixes CIA-578