### PR TITLE
net: lib: lwm2m_client_utils: Move `CONFIG_APP_MCUBOOT_FLASH_BUF_SZ`

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/Kconfig.lwm2m_integration
+++ b/applications/asset_tracker_v2/src/cloud/Kconfig.lwm2m_integration
@@ -68,13 +68,6 @@ config LWM2M_CLIENT_UTILS_SERVER
 	help
 	  Kconfig redefinition, please see the help text of the original definition.
 
-config APP_MCUBOOT_FLASH_BUF_SZ
-	int "Size of buffer used for flash write operations during MCUboot updates"
-	depends on DFU_TARGET_MCUBOOT
-	default 512
-	help
-	  Buffer size must be aligned to the minimal flash write block size.
-
 endmenu
 
 endif # LWM2M_INTEGRATION

--- a/samples/nrf9160/lwm2m_client/Kconfig
+++ b/samples/nrf9160/lwm2m_client/Kconfig
@@ -137,13 +137,6 @@ config APP_HOLD_TIME_RSRP
 	  The minimum time in seconds that notifications can be sent to observers of the
 	  Connectivity Monitoring data.
 
-config APP_MCUBOOT_FLASH_BUF_SZ
-	int "Size of buffer used for flash write operations during MCUboot updates"
-	depends on DFU_TARGET_MCUBOOT
-	default 512
-	help
-	  Buffer size must be aligned to the minimal flash write block size.
-
 config APP_CUSTOM_VERSION
 	string "Application version. Leave empty to use NCS version"
 

--- a/subsys/net/lib/lwm2m_client_utils/Kconfig
+++ b/subsys/net/lib/lwm2m_client_utils/Kconfig
@@ -77,6 +77,13 @@ config LWM2M_CLIENT_UTILS_FIRMWARE_UPDATE_OBJ_SUPPORT
 
 if LWM2M_CLIENT_UTILS_FIRMWARE_UPDATE_OBJ_SUPPORT
 
+config LWM2M_CLIENT_UTILS_MCUBOOT_FLASH_BUF_SIZE
+	int "Size of buffer used for flash write operations during MCUboot updates"
+	depends on DFU_TARGET_MCUBOOT
+	default 512
+	help
+	  Buffer size must be aligned to the minimal flash write block size.
+
 config LWM2M_CLIENT_UTILS_DOWNLOADER_SEC_TAG
 	int "Security tag for FOTA download library"
 	default 16842753

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -44,7 +44,7 @@ static struct k_work full_modem_update_work;
 #endif
 
 #ifdef CONFIG_DFU_TARGET_MCUBOOT
-static uint8_t mcuboot_buf[CONFIG_APP_MCUBOOT_FLASH_BUF_SZ] __aligned(4);
+static uint8_t mcuboot_buf[CONFIG_LWM2M_CLIENT_UTILS_MCUBOOT_FLASH_BUF_SIZE] __aligned(4);
 #endif
 
 static int image_type = DFU_TARGET_IMAGE_TYPE_ANY;


### PR DESCRIPTION
The `CONFIG_APP_MCUBOOT_FLASH_BUF_SZ` option is exclusively used in the firmware object of the LwM2M client utils library. To prevent applications/samples from needing to create a separate definition of the option, the Kconfig definition is moved to the aforementioned library.