### PR TITLE
applications: nrf_desktop: Fix memory alignment in ble_qos

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_qos.c
+++ b/applications/nrf_desktop/src/modules/ble_qos.c
@@ -84,7 +84,7 @@ struct params_blacklist {
 	uint16_t wifi_chn_bitmask;
 } __packed;
 
-static uint8_t chmap_instance_buf[CHMAP_FILTER_INST_SIZE];
+static uint8_t chmap_instance_buf[CHMAP_FILTER_INST_SIZE] __aligned(CHMAP_FILTER_INST_ALIGN);
 static struct chmap_instance *chmap_inst;
 static uint8_t current_chmap[CHMAP_BLE_BITMASK_SIZE] = CHMAP_BLE_BITMASK_DEFAULT;
 static atomic_t processing;

--- a/applications/nrf_desktop/src/util/chmap_filter/include/chmap_filter.h
+++ b/applications/nrf_desktop/src/util/chmap_filter/include/chmap_filter.h
@@ -47,6 +47,9 @@ extern "C" {
 /* Filter instance size [bytes] */
 #define CHMAP_FILTER_INST_SIZE 580
 
+/* Filter instance alignment [bytes] */
+#define CHMAP_FILTER_INST_ALIGN 4
+
 /* Static parameters */
 /* Target evaluation keepout for minimum size channel map */
 #define CHMAP_PARAM_DYN_EVAL_TARGET 10
@@ -143,7 +146,8 @@ void chmap_filter_init(void);
 /**@brief Initialize channel map filter instance.
  *
  * @details Sufficient memory should be supplied to hold filter state.
- * Allocate @ref CHMAP_FILTER_INST_SIZE bytes for this purpose.
+ * Allocate @ref CHMAP_FILTER_INST_SIZE bytes for this purpose. Make sure that
+ * used memory is aligned to @ref CHMAP_FILTER_INST_ALIGN.
  *
  * @param[in] p_inst Pointer to instance buffer
  * @param[in] size Size of instance buffer


### PR DESCRIPTION
Change fixes alignment of `chmap_instance_buf`. The buffer is casted to `struct chmap_instance`. Invalid alignment leads to ARM fault when module is initialized.

Jira: NCSDK-17088