### PR TITLE
wifi: shell: Fix network switching issue

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -218,7 +218,7 @@ static int cmd_wifi_connect(const struct shell *sh, size_t argc,
 			    char *argv[])
 {
 	struct net_if *iface = net_if_get_default();
-	static struct wifi_connect_req_params cnx_params;
+	struct wifi_connect_req_params cnx_params = { 0 };
 
 	if (__wifi_args_to_params(argc - 1, &argv[1], &cnx_params)) {
 		shell_help(sh);


### PR DESCRIPTION
When switching from a secure network to open network, the previous parameters are not reset which causes the open connection to fail.

Remove the unnecessary "static" storage and reset to zero for params.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>