### PR TITLE
net: lib: nrf_cloud: use new c2d topics

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -160,18 +160,6 @@ static int send_service_info(void)
 	return 0;
 }
 
-/* Function used to filter out responses to cellular position requests. */
-static int cell_pos_response_filter(char *response, size_t len)
-{
-	ARG_UNUSED(len);
-
-	if (strstr(response, CELL_POS_FILTER_STRING) != NULL) {
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
 static void nrf_cloud_event_handler(const struct nrf_cloud_evt *evt)
 {
 	struct cloud_wrap_event cloud_wrap_evt = { 0 };
@@ -234,23 +222,19 @@ static void nrf_cloud_event_handler(const struct nrf_cloud_evt *evt)
 		cloud_wrap_evt.type = CLOUD_WRAP_EVT_FOTA_ERROR;
 		notify = true;
 		break;
-	case NRF_CLOUD_EVT_RX_DATA:
-		LOG_DBG("NRF_CLOUD_EVT_RX_DATA");
-
-		/* Filter out responses to cellular position requests. The application does not care
-		 * about getting its location back after neighbor cell measurements have been
-		 * sent to cloud.
-		 */
-		err = cell_pos_response_filter((char *)evt->data.ptr, evt->data.len);
-		if (err) {
-			LOG_DBG("Cellular position response received, aborting");
-			return;
-		}
-
+	case NRF_CLOUD_EVT_RX_DATA_GENERAL:
+		LOG_DBG("NRF_CLOUD_EVT_RX_DATA_GENERAL");
+		break;
+	case NRF_CLOUD_EVT_RX_DATA_SHADOW:
+		LOG_DBG("NRF_CLOUD_EVT_RX_DATA_SHADOW");
+		/* Configuration data is contained in the shadow events */
 		cloud_wrap_evt.type = CLOUD_WRAP_EVT_DATA_RECEIVED;
 		cloud_wrap_evt.data.buf = (char *)evt->data.ptr;
 		cloud_wrap_evt.data.len = evt->data.len;
 		notify = true;
+		break;
+	case NRF_CLOUD_EVT_RX_DATA_CELL_POS:
+		LOG_DBG("NRF_CLOUD_EVT_RX_DATA_CELL_POS");
 		break;
 	case NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST:
 		LOG_WRN("NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST");

--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -192,7 +192,7 @@ static void nrf_cloud_event_handler(const struct nrf_cloud_evt *evt)
 		notify = true;
 		break;
 	case NRF_CLOUD_EVT_ERROR:
-		LOG_ERR("NRF_CLOUD_EVT_ERROR");
+		LOG_ERR("NRF_CLOUD_EVT_ERROR: %d", evt->status);
 		cloud_wrap_evt.type = CLOUD_WRAP_EVT_ERROR;
 		notify = true;
 		break;

--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -270,50 +270,63 @@ static bool app_event_handler(const struct app_event_header *aeh)
 	return consume;
 }
 
-static void agps_data_handle(const uint8_t *buf, size_t len)
+static void config_data_handle(uint8_t *buf, const size_t len)
 {
 	int err;
 
-#if defined(CONFIG_NRF_CLOUD_AGPS)
-	err = nrf_cloud_agps_process(buf, len);
-	if (err) {
-		if (err == -EFAULT) {
-			/* An A-GPS error code from nRF Cloud was received */
-			return;
-		}
-		LOG_WRN("Unable to process A-GPS data, error: %d", err);
+	/* Use the config copy when populating the config variable
+	 * before it is sent to the Data module. This way we avoid
+	 * sending uninitialized variables to the Data module.
+	 */
+	err = cloud_codec_decode_config(buf, len, &copy_cfg);
+	if (err == 0) {
+		LOG_DBG("Device configuration encoded");
+		send_config_received();
+	} else if (err == -ENODATA) {
+		LOG_WRN("Device configuration empty!");
+		SEND_EVENT(cloud, CLOUD_EVT_CONFIG_EMPTY);
+	} else if (err == -ECANCELED) {
+		/* The incoming message has already been handled, ignored. */
+	} else if (err == -ENOENT) {
+		/* Encoding of incoming message is not supported. */
 	} else {
-		LOG_DBG("A-GPS data processed");
+		LOG_ERR("Decoding of device configuration, error: %d", err);
+		SEND_ERROR(cloud, CLOUD_EVT_ERROR, err);
 	}
-#endif
+}
 
-#if defined(CONFIG_NRF_CLOUD_PGPS)
+static void agps_data_handle(const uint8_t *buf, const size_t len)
+{
 #if defined(CONFIG_NRF_CLOUD_AGPS)
-	if (!err) {
-		err = nrf_cloud_pgps_notify_prediction();
-		if (err) {
-			LOG_ERR("Error requesting prediction notification: %d", err);
-		} else {
-			return;
-		}
-	}
-#endif
+	int err = nrf_cloud_agps_process(buf, len);
 
-	LOG_DBG("Process incoming data if P-GPS related");
-
-#if !defined(CONFIG_NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_CUSTOM)
-	err = nrf_cloud_pgps_process(buf, len);
 	if (err) {
-		if (err == -EFAULT) {
-			/* A P-GPS error code from nRF Cloud was received */
-			return;
-		}
-		LOG_ERR("Unable to process P-GPS data, error: %d", err);
+		LOG_ERR("Unable to process A-GPS data, error: %d", err);
+		return;
 	}
-#endif
-#endif
+#if defined(CONFIG_NRF_CLOUD_PGPS)
+	err = nrf_cloud_pgps_notify_prediction();
+	if (err) {
+		LOG_ERR("Error requesting prediction notification: %d", err);
+		return;
+	}
+#endif /* CONFIG_NRF_CLOUD_PGPS */
+#endif /* CONFIG_NRF_CLOUD_AGPS */
+}
 
-	(void)err;
+static void pgps_data_handle(const uint8_t *buf, const size_t len)
+{
+#if defined(CONFIG_NRF_CLOUD_PGPS)
+#if !defined(CONFIG_NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_CUSTOM)
+	int err = nrf_cloud_pgps_process(buf, len);
+
+	if (err) {
+		LOG_ERR("Unable to process P-GPS data, error: %d", err);
+		return;
+	}
+
+#endif /* CONFIG_NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_CUSTOM */
+#endif /* CONFIG_NRF_CLOUD_PGPS */
 }
 
 static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
@@ -336,37 +349,14 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 	}
 	case CLOUD_WRAP_EVT_DATA_RECEIVED:
 		LOG_DBG("CLOUD_WRAP_EVT_DATA_RECEIVED");
-
-		int err;
-
-		/* Use the config copy when populating the config variable
-		 * before it is sent to the Data module. This way we avoid
-		 * sending uninitialized variables to the Data module.
-		 */
-		err = cloud_codec_decode_config(evt->data.buf, evt->data.len,
-						&copy_cfg);
-		if (err == 0) {
-			LOG_DBG("Device configuration encoded");
-			send_config_received();
-			break;
-		} else if (err == -ENODATA) {
-			LOG_WRN("Device configuration empty!");
-			SEND_EVENT(cloud, CLOUD_EVT_CONFIG_EMPTY);
-			break;
-		} else if (err == -ECANCELED) {
-			/* The incoming message has already been handled, ignored. */
-			break;
-		} else if (err == -ENOENT) {
-			/* Encoding of incoming message is not supported. */
-		} else {
-			LOG_ERR("Decoding of device configuration, error: %d", err);
-			SEND_ERROR(cloud, CLOUD_EVT_ERROR, err);
-			break;
-		}
-
+		config_data_handle(evt->data.buf, evt->data.len);
 		break;
 	case CLOUD_WRAP_EVT_PGPS_DATA_RECEIVED:
 		LOG_DBG("CLOUD_WRAP_EVT_PGPS_DATA_RECEIVED");
+		pgps_data_handle(evt->data.buf, evt->data.len);
+		break;
+	case CLOUD_WRAP_EVT_AGPS_DATA_RECEIVED:
+		LOG_DBG("CLOUD_WRAP_EVT_AGPS_DATA_RECEIVED");
 		agps_data_handle(evt->data.buf, evt->data.len);
 		break;
 	case CLOUD_WRAP_EVT_USER_ASSOCIATION_REQUEST: {
@@ -380,8 +370,8 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 		connect_retries = 0;
 
 		SEND_EVENT(cloud, CLOUD_EVT_USER_ASSOCIATION_REQUEST);
-	};
 		break;
+	}
 	case CLOUD_WRAP_EVT_USER_ASSOCIATED: {
 		LOG_DBG("CLOUD_WRAP_EVT_USER_ASSOCIATED");
 
@@ -393,29 +383,25 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 		}
 
 		SEND_EVENT(cloud, CLOUD_EVT_USER_ASSOCIATED);
-	};
 		break;
+	}
 	case CLOUD_WRAP_EVT_REBOOT_REQUEST: {
 		SEND_EVENT(cloud, CLOUD_EVT_REBOOT_REQUEST);
-	};
 		break;
+	}
 	case CLOUD_WRAP_EVT_LTE_DISCONNECT_REQUEST: {
 		SEND_EVENT(cloud, CLOUD_EVT_LTE_DISCONNECT);
-	};
 		break;
+	}
 	case CLOUD_WRAP_EVT_LTE_CONNECT_REQUEST: {
 		SEND_EVENT(cloud, CLOUD_EVT_LTE_CONNECT);
-	};
 		break;
+	}
 	case CLOUD_WRAP_EVT_FOTA_DONE: {
 		LOG_DBG("CLOUD_WRAP_EVT_FOTA_DONE");
 		SEND_EVENT(cloud, CLOUD_EVT_FOTA_DONE);
 		break;
 	}
-	case CLOUD_WRAP_EVT_AGPS_DATA_RECEIVED:
-		LOG_DBG("CLOUD_WRAP_EVT_AGPS_DATA_RECEIVED");
-		agps_data_handle(evt->data.buf, evt->data.len);
-		break;
 	case CLOUD_WRAP_EVT_FOTA_START: {
 		LOG_DBG("CLOUD_WRAP_EVT_FOTA_START");
 		SEND_EVENT(cloud, CLOUD_EVT_FOTA_START);
@@ -435,7 +421,8 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 	case CLOUD_WRAP_EVT_DATA_ACK: {
 		LOG_DBG("CLOUD_WRAP_EVT_DATA_ACK: %d", evt->message_id);
 
-		err = qos_message_remove(evt->message_id);
+		int err = qos_message_remove(evt->message_id);
+
 		if (err == -ENODATA) {
 			LOG_DBG("Message Acknowledgment not in pending QoS list, ID: %d",
 				evt->message_id);

--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -357,21 +357,13 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 			/* The incoming message has already been handled, ignored. */
 			break;
 		} else if (err == -ENOENT) {
-			/* Encoding of incoming message is not supported. Proceed to check if the
-			 * message is AGPS/PGPS related data.
-			 */
+			/* Encoding of incoming message is not supported. */
 		} else {
 			LOG_ERR("Decoding of device configuration, error: %d", err);
 			SEND_ERROR(cloud, CLOUD_EVT_ERROR, err);
 			break;
 		}
 
-		/* If incoming message is A-GPS/P-GPS related, handle it. nRF Cloud publishes A-GPS
-		 * data on a generic c2d topic meaning that the integration layer cannot filter
-		 * based on topic. This means that agps_data_handle() must be called on both
-		 * CLOUD_WRAP_EVT_AGPS_DATA_RECEIVED and CLOUD_WRAP_EVT_DATA_RECEIVED events.
-		 */
-		agps_data_handle(evt->data.buf, evt->data.len);
 		break;
 	case CLOUD_WRAP_EVT_PGPS_DATA_RECEIVED:
 		LOG_DBG("CLOUD_WRAP_EVT_PGPS_DATA_RECEIVED");

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -795,7 +795,7 @@ static void cloud_event_handler(const struct nrf_cloud_evt *evt)
 		on_cloud_evt_disconnected();
 		break;
 	case NRF_CLOUD_EVT_ERROR:
-		LOG_ERR("NRF_CLOUD_EVT_ERROR");
+		LOG_ERR("NRF_CLOUD_EVT_ERROR: %d", evt->status);
 		break;
 	case NRF_CLOUD_EVT_SENSOR_DATA_ACK:
 		LOG_DBG("NRF_CLOUD_EVT_SENSOR_DATA_ACK");

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -514,6 +514,7 @@ Libraries for networking
     * Replaced event :c:enum:`NRF_CLOUD_EVT_RX_DATA` with :c:enum:`NRF_CLOUD_EVT_RX_DATA_GENERAL`.
     * Added events :c:enum:`NRF_CLOUD_EVT_RX_DATA_CELL_POS` and :c:enum:`NRF_CLOUD_EVT_RX_DATA_SHADOW`.
     * The library now processes A-GPS and P-GPS data; it is no longer passed to the application.
+    * The status field of :c:enum:`NRF_CLOUD_EVT_ERROR` events uses values from the enumeration :c:enumerator:`nrf_cloud_error_status`.
 
   * Removed:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -116,6 +116,11 @@ nRF9160: Asset Tracker v2
 * Updated:
 
   * The application now uses the new LwM2M location assistance objects through the :ref:`lib_lwm2m_location_assistance` library.
+  * Added handling for the new data receive events in the :ref:`lib_nrf_cloud` library.
+
+* Removed:
+
+    * A-GPS and P-GPS processing; it is now handled by the :ref:`lib_nrf_cloud` library.
 
 nRF9160: Serial LTE modem
 -------------------------
@@ -127,6 +132,7 @@ nRF9160: Serial LTE modem
 * Updated:
 
   * Removed automatic quit of data mode in GNSS, FTP and HTTP services.
+  * Added handling for the new data receive events in the :ref:`lib_nrf_cloud` library.
 
 nRF5340 Audio
 -------------
@@ -279,6 +285,27 @@ nRF9160 samples
   * Added:
 
     * Overlay files for nRF9160 DK with nRF7002 EK to obtain the current location by using Wi-Fi scanning results.
+
+* :ref:`lte_sensor_gateway` sample:
+
+  * Updated:
+
+    * Added handling for the new data receive events in the :ref:`lib_nrf_cloud` library.
+    * Removed A-GPS and P-GPS processing; it is now handled by the :ref:`lib_nrf_cloud` library.
+
+* :ref:`modem_shell_application` sample:
+
+  * Updated:
+
+    * Added handling for the new data receive events in the :ref:`lib_nrf_cloud` library.
+    * Removed A-GPS and P-GPS processing; it is now handled by the :ref:`lib_nrf_cloud` library.
+
+* :ref:`nrf_cloud_mqtt_multi_service` sample:
+
+  * Changed:
+
+    * Added handling for the new data receive events in the :ref:`lib_nrf_cloud` library.
+    * Removed A-GPS and P-GPS processing; it is now handled by the :ref:`lib_nrf_cloud` library.
 
 Thread samples
 --------------
@@ -482,6 +509,11 @@ Libraries for networking
   * Updated:
 
     * The stack size of the MQTT connection monitoring thread can now be adjusted by setting the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD_STACK_SIZE` Kconfig option.
+    * The library now subscribes to a wildcard cloud-to-device (/c2d) topic.
+      This enables the device to receive nRF Cloud Location Services data on separate topics.
+    * Replaced event :c:enum:`NRF_CLOUD_EVT_RX_DATA` with :c:enum:`NRF_CLOUD_EVT_RX_DATA_GENERAL`.
+    * Added events :c:enum:`NRF_CLOUD_EVT_RX_DATA_CELL_POS` and :c:enum:`NRF_CLOUD_EVT_RX_DATA_SHADOW`.
+    * The library now processes A-GPS and P-GPS data; it is no longer passed to the application.
 
   * Removed:
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -98,8 +98,14 @@ enum nrf_cloud_evt_type {
 	NRF_CLOUD_EVT_USER_ASSOCIATED,
 	/** The device can now start sending sensor data to the cloud. */
 	NRF_CLOUD_EVT_READY,
-	/** The device received data from the cloud. */
-	NRF_CLOUD_EVT_RX_DATA,
+	/** The device received non-specific data from the cloud. */
+	NRF_CLOUD_EVT_RX_DATA_GENERAL,
+	/** The device received cellular positioning data from the cloud
+	 *  and no response callback was registered
+	 */
+	NRF_CLOUD_EVT_RX_DATA_CELL_POS,
+	/** The device received shadow related data from the cloud. */
+	NRF_CLOUD_EVT_RX_DATA_SHADOW,
 	/** The device has received a ping response from the cloud. */
 	NRF_CLOUD_EVT_PINGRESP,
 	/** The data sent to the cloud was acknowledged. */

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -118,8 +118,35 @@ enum nrf_cloud_evt_type {
 	NRF_CLOUD_EVT_FOTA_DONE,
 	/** An error occurred during the FOTA update. */
 	NRF_CLOUD_EVT_FOTA_ERROR,
-	/** There was an error communicating with the cloud. */
+	/** An error occurred. The status field in the event struct will
+	 * be populated with a @ref nrf_cloud_error_status value
+	 */
 	NRF_CLOUD_EVT_ERROR = 0xFF
+};
+
+/**@ nRF Cloud error status, used to describe NRF_CLOUD_EVT_ERROR */
+enum nrf_cloud_error_status {
+	/** No error */
+	NRF_CLOUD_ERR_STATUS_NONE = 0,
+
+	/** MQTT connection failed */
+	NRF_CLOUD_ERR_STATUS_MQTT_CONN_FAIL,
+	/** MQTT protocol version not supported by server */
+	NRF_CLOUD_ERR_STATUS_MQTT_CONN_BAD_PROT_VER,
+	/** MQTT client identifier rejected by server */
+	NRF_CLOUD_ERR_STATUS_MQTT_CONN_ID_REJECTED,
+	/** MQTT service is unavailable */
+	NRF_CLOUD_ERR_STATUS_MQTT_CONN_SERVER_UNAVAIL,
+	/** Malformed user name or password */
+	NRF_CLOUD_ERR_STATUS_MQTT_CONN_BAD_USR_PWD,
+	/** Client is not authorized to connect */
+	NRF_CLOUD_ERR_STATUS_MQTT_CONN_NOT_AUTH,
+	/** Failed to subscribe to MQTT topic */
+	NRF_CLOUD_ERR_STATUS_MQTT_SUB_FAIL,
+	/** Error processing A-GPS data */
+	NRF_CLOUD_ERR_STATUS_AGPS_PROC,
+	/** Error processing P-GPS data */
+	NRF_CLOUD_ERR_STATUS_PGPS_PROC,
 };
 
 /**@ nRF Cloud disconnect status. */
@@ -151,7 +178,10 @@ enum nrf_cloud_connect_result {
 	NRF_CLOUD_CONNECT_RES_ERR_ALREADY_CONNECTED = -11,
 };
 
-/**@ nRF Cloud error codes. */
+/**@ nRF Cloud error codes.
+ * See the <a href="https://api.nrfcloud.com/v1#section/Error-Codes">Error Codes</a>
+ * section of nRF Cloud API documentation for more information.
+ */
 enum nrf_cloud_error {
 	NRF_CLOUD_ERROR_UNKNOWN			= -1,
 	NRF_CLOUD_ERROR_NONE			= 0,

--- a/include/net/nrf_cloud_cell_pos.h
+++ b/include/net/nrf_cloud_cell_pos.h
@@ -76,7 +76,7 @@ typedef void (*nrf_cloud_cell_pos_response_t)(const struct nrf_cloud_cell_pos_re
  *                    If false, cloud will not send location to the device.
  * @param cb Callback function to receive parsed cell pos result. Only used when
  *           request_loc is true. If NULL, JSON result will be sent to the cloud event
- *           handler as an NRF_CLOUD_EVT_RX_DATA event.
+ *           handler as an NRF_CLOUD_EVT_RX_DATA_CELL_POS event.
  * @retval 0       Request sent successfully.
  * @retval -EACCES Cloud connection is not established; wait for @ref NRF_CLOUD_EVT_READY.
  * @return A negative value indicates an error.

--- a/samples/nrf9160/lte_ble_gateway/src/main.c
+++ b/samples/nrf9160/lte_ble_gateway/src/main.c
@@ -141,7 +141,18 @@ void error_handler(enum error_type err_type, int err)
 
 void nrf_cloud_error_handler(int err)
 {
-	error_handler(ERROR_NRF_CLOUD, err);
+	switch (err) {
+	case NRF_CLOUD_ERR_STATUS_MQTT_CONN_FAIL:
+	case NRF_CLOUD_ERR_STATUS_MQTT_CONN_BAD_PROT_VER:
+	case NRF_CLOUD_ERR_STATUS_MQTT_CONN_ID_REJECTED:
+	case NRF_CLOUD_ERR_STATUS_MQTT_CONN_SERVER_UNAVAIL:
+	case NRF_CLOUD_ERR_STATUS_MQTT_CONN_BAD_USR_PWD:
+	case NRF_CLOUD_ERR_STATUS_MQTT_CONN_NOT_AUTH:
+	case NRF_CLOUD_ERR_STATUS_MQTT_SUB_FAIL:
+		error_handler(ERROR_NRF_CLOUD, err);
+	default:
+		return;
+	}
 }
 
 /**@brief Modem fault handler. */

--- a/samples/nrf9160/lte_ble_gateway/src/main.c
+++ b/samples/nrf9160/lte_ble_gateway/src/main.c
@@ -345,8 +345,6 @@ static void on_cloud_evt_user_associated(void)
 /**@brief Callback for nRF Cloud events. */
 static void cloud_event_handler(const struct nrf_cloud_evt *evt)
 {
-	int err;
-
 	switch (evt->type) {
 	case NRF_CLOUD_EVT_TRANSPORT_CONNECTED:
 		LOG_DBG("NRF_CLOUD_EVT_TRANSPORT_CONNECTED");
@@ -377,22 +375,14 @@ static void cloud_event_handler(const struct nrf_cloud_evt *evt)
 		atomic_set(&send_data_enable, 1);
 		k_work_schedule(&aggregated_work, K_MSEC(100));
 		break;
-	case NRF_CLOUD_EVT_RX_DATA:
-		LOG_DBG("NRF_CLOUD_EVT_RX_DATA");
-		/* nRF Cloud publishes A-GPS data on a generic c2d topic meaning that the
-		 * integration layer cannot filter based on topic. We therefore try to process the
-		 * data as A-GPS data and allow the message to have the wrong format.
-		 */
-		err = nrf_cloud_agps_process(evt->data.ptr, evt->data.len);
-		if (!err){
-			LOG_INF("AGPS data processed");
-			break;
-		}
-		if (err && err != -ENOMSG) {
-			LOG_ERR("Processing AGPS data failed");
-			break;
-		}
-
+	case NRF_CLOUD_EVT_RX_DATA_GENERAL:
+		LOG_DBG("NRF_CLOUD_EVT_RX_DATA_GENERAL");
+		break;
+	case NRF_CLOUD_EVT_RX_DATA_SHADOW:
+		LOG_DBG("NRF_CLOUD_EVT_RX_DATA_SHADOW");
+		break;
+	case NRF_CLOUD_EVT_RX_DATA_CELL_POS:
+		LOG_DBG("NRF_CLOUD_EVT_RX_DATA_CELL_POS");
 		break;
 	case NRF_CLOUD_EVT_SENSOR_DATA_ACK:
 		LOG_DBG("NRF_CLOUD_EVT_SENSOR_DATA_ACK");

--- a/samples/nrf9160/modem_shell/src/cloud/cloud_mqtt_shell.c
+++ b/samples/nrf9160/modem_shell/src/cloud/cloud_mqtt_shell.c
@@ -188,7 +188,7 @@ static void nrf_cloud_event_handler(const struct nrf_cloud_evt *evt)
 		}
 		break;
 	case NRF_CLOUD_EVT_ERROR:
-		mosh_print("NRF_CLOUD_EVT_ERROR");
+		mosh_print("NRF_CLOUD_EVT_ERROR: %d", evt->status);
 		break;
 	case NRF_CLOUD_EVT_SENSOR_DATA_ACK:
 		mosh_print("NRF_CLOUD_EVT_SENSOR_DATA_ACK");

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
@@ -163,12 +163,7 @@ Location tracking
 =================
 
 All matters concerning location tracking are handled in the :file:`src/location_tracking.c` file.
-For the most part, this amounts to setting up a periodic location request, and then passing the results to a callback configured by the :file:`src/application.c` file.
-
-Additionally, the :ref:`lib_location` library requires GPS assistance data (either A-GPS, P-GPS, or both) to have the fastest possible `time-to-first-fix <TTFF_>`_.
-The library requests this data automatically, but has no way to automatically receive the response.
-Therefore, all MQTT messages received from `nRF Cloud`_ must be be passed directly through to the :ref:`lib_nrf_cloud_agps` and :ref:`lib_nrf_cloud_pgps` libraries to be checked for A-GPS and P-GPS data, respectively.
-The :c:func:`location_assistance_data_handler` function handles this task, and MQTT messages are sent directly to it from the :file:`src/connection.c` file.
+This involves setting up a periodic location request, and then passing the results to a callback configured by the :file:`src/application.c` file.
 
 .. note::
   For location readings to be visible in the nRF Cloud portal, they must be marked as enabled in the `Device Shadow <nRF Cloud Device Shadows_>`_.

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
@@ -271,15 +271,12 @@ static void cloud_event_handler(const struct nrf_cloud_evt *nrf_cloud_evt)
 	case NRF_CLOUD_EVT_ERROR:
 		LOG_DBG("NRF_CLOUD_EVT_ERROR: %d", nrf_cloud_evt->status);
 		break;
-	case NRF_CLOUD_EVT_RX_DATA:
-		LOG_DBG("NRF_CLOUD_EVT_RX_DATA");
+	case NRF_CLOUD_EVT_RX_DATA_GENERAL:
+		LOG_DBG("NRF_CLOUD_EVT_RX_DATA_GENERAL");
 		LOG_DBG("%d bytes received from cloud", nrf_cloud_evt->data.len);
-
-		/* The Location library sends assistance data requests on our behalf, but cannot
-		 * intercept the responses. We must, therefore, check all received MQTT payloads for
-		 * assistance data ourselves.
-		 */
-		location_assistance_data_handler(nrf_cloud_evt->data.ptr, nrf_cloud_evt->data.len);
+		break;
+	case NRF_CLOUD_EVT_RX_DATA_SHADOW:
+		LOG_DBG("NRF_CLOUD_EVT_RX_DATA_SHADOW");
 		break;
 	case NRF_CLOUD_EVT_FOTA_START:
 		LOG_DBG("NRF_CLOUD_EVT_FOTA_START");

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.h
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/location_tracking.h
@@ -10,15 +10,6 @@
 struct location_data;
 
 /**
- * @brief Check an MQTT message payload for AGPS data, and if AGPS data is present,
- * pass it along to the modem for use in GNSS fix acquisition.
- *
- * @param[in] buf The MQTT message payload buffer.
- * @param[in] len the length of the MQTT message payload.
- */
-void location_assistance_data_handler(const char *buf, size_t len);
-
-/**
  * @brief Callback to receive tracked locations.
  *
  * @param[in] location_data The tracked location data.

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
@@ -152,14 +152,14 @@ int nrf_cloud_encode_shadow_data(const struct nrf_cloud_sensor_data *sensor,
 int nrf_cloud_decode_requested_state(const struct nrf_cloud_data *payload,
 				     enum nfsm_state *requested_state);
 
-/**@brief Decodes data endpoint information. */
+/**@brief Decode data endpoint information. */
 int nrf_cloud_decode_data_endpoint(const struct nrf_cloud_data *input,
 				   struct nrf_cloud_data *tx_endpoint,
 				   struct nrf_cloud_data *rx_endpoint,
 				   struct nrf_cloud_data *bulk_endpoint,
 				   struct nrf_cloud_data *m_endpoint);
 
-/** @brief Encodes state information. */
+/** @brief Encode state information. */
 int nrf_cloud_encode_state(uint32_t reported_state, const bool update_desired_topic,
 			   struct nrf_cloud_data *output);
 
@@ -179,10 +179,10 @@ int nrf_cloud_device_status_encode(const struct nrf_cloud_device_status * const 
 /** @brief Free memory allocated by @ref nrf_cloud_device_status_encode. */
 void nrf_cloud_device_status_free(struct nrf_cloud_data *status);
 
-/** @brief Frees memory allocated by @ref nrf_cloud_rest_fota_execution_parse */
+/** @brief Free memory allocated by @ref nrf_cloud_rest_fota_execution_parse */
 void nrf_cloud_fota_job_free(struct nrf_cloud_fota_job_info *const job);
 
-/** @brief Parses the response from a FOTA execution request REST call.
+/** @brief Parse the response from a FOTA execution request REST call.
  * If successful, memory will be allocated for the data in @ref nrf_cloud_fota_job_info.
  * The user is responsible for freeing the memory by calling @ref nrf_cloud_fota_job_free.
  */
@@ -190,85 +190,85 @@ int nrf_cloud_rest_fota_execution_parse(const char *const response,
 					struct nrf_cloud_fota_job_info *const job);
 
 #if defined(CONFIG_NRF_CLOUD_PGPS)
-/** @brief Parses the PGPS response (REST and MQTT) from nRF Cloud */
+/** @brief Parse the PGPS response (REST and MQTT) from nRF Cloud */
 int nrf_cloud_parse_pgps_response(const char *const response,
 				  struct nrf_cloud_pgps_result *const result);
 #endif
 
-/** @brief Adds common [network] modem info to the provided cJSON object */
+/** @brief Add common [network] modem info to the provided cJSON object */
 int nrf_cloud_json_add_modem_info(cJSON * const data_obj);
 
-/** @brief Builds a cellular positioning request string using the provided cell info.
+/** @brief Build a cellular positioning request string using the provided cell info.
  * If successful, memory will be allocated for the output string and the user is
  * responsible for freeing it using @ref cJSON_free.
  */
 int nrf_cloud_format_cell_pos_req(struct lte_lc_cells_info const *const inf,
 				  size_t inf_cnt, char **string_out);
 
-/** @brief Builds a cellular positioning request in the provided cJSON object
+/** @brief Build a cellular positioning request in the provided cJSON object
  * using the provided cell info
  */
 int nrf_cloud_format_cell_pos_req_json(struct lte_lc_cells_info const *const inf,
 				       size_t inf_cnt, cJSON * const req_obj_out);
 
-/** @brief Builds a [single-cell] cellular positioning request in the provided cJSON object.
- * Function obtains the necessary network info from the modem.
+/** @brief Obtain the necessary network info from the modem and build a
+ * [single-cell] cellular positioning request in the provided cJSON object.
  */
 int nrf_cloud_format_single_cell_pos_req_json(cJSON * const req_obj_out);
 
-/** @brief Parses the cellular positioning response (REST and MQTT) from nRF Cloud. */
+/** @brief Parse the cellular positioning response (REST and MQTT) from nRF Cloud. */
 int nrf_cloud_parse_cell_pos_response(const char *const buf,
 				      struct nrf_cloud_cell_pos_result *result);
 
-/** @brief Checks whether the provided MQTT payload is an nRF Cloud disconnection request */
+/** @brief Check whether the provided MQTT payload is an nRF Cloud disconnection request */
 bool nrf_cloud_detect_disconnection_request(const char *const buf);
 
-/** @brief Obtains a pointer to the string at the specified index in the cJSON array.
+/** @brief Obtain a pointer to the string at the specified index in the cJSON array.
  * No memory is allocated, pointer is valid as long as the cJSON array is valid.
  */
 int get_string_from_array(const cJSON * const array, const int index,
 			  char **string_out);
 
-/** @brief Obtains a pointer to the string of the specified key in the cJSON object.
+/** @brief Obtain a pointer to the string of the specified key in the cJSON object.
  * No memory is allocated, pointer is valid as long as the cJSON object is valid.
  */
 int get_string_from_obj(const cJSON * const obj, const char *const key,
 			char **string_out);
 
-/** @brief Sends the cJSON object to nRF Cloud on the d2c topic */
+/** @brief Send the cJSON object to nRF Cloud on the d2c topic */
 int json_send_to_cloud(cJSON * const request);
 
-/** @brief Creates a cJSON object containing the specified appId and messageType.
+/** @brief Create a cJSON object containing the specified appId and messageType.
  * If successful, user is responsible for calling @ref cJSON_Delete to free
  * the cJSON object's memory.
  */
 cJSON *json_create_req_obj(const char *const app_id, const char *const msg_type);
 
-/** @brief Parses received REST data for an nRF Cloud error code */
+/** @brief Parse received REST data for an nRF Cloud error code */
 int nrf_cloud_parse_rest_error(const char *const buf, enum nrf_cloud_error *const err);
 
-/** @brief Encodes PVT data to be sent to nRF Cloud */
+/** @brief Encode PVT data to be sent to nRF Cloud */
 int nrf_cloud_pvt_data_encode(const struct nrf_cloud_gnss_pvt * const pvt,
 			      cJSON * const pvt_data_obj);
 
 #if defined(CONFIG_NRF_MODEM)
-/** @brief Encodes a modem PVT data frame to be sent to nRF Cloud */
+/** @brief Encode a modem PVT data frame to be sent to nRF Cloud */
 int nrf_cloud_modem_pvt_data_encode(const struct nrf_modem_gnss_pvt_data_frame	* const mdm_pvt,
 				    cJSON * const pvt_data_obj);
 #endif
 
-/** @brief Replaces legacy c2d topic with wilcard topic string. Returns true
- *  if the topic was modified; otherwise false.
+/** @brief Replace legacy c2d topic with wilcard topic string.
+ * Return true, if the topic was modified; otherwise false.
  */
 bool nrf_cloud_set_wildcard_c2d_topic(char *const topic, size_t topic_len);
 
-/** @brief Decodes dc receive topic string into defined types */
+/** @brief Decode a dc receive topic string into an enum value */
 enum nrf_cloud_rcv_topic nrf_cloud_decode_dc_rx_topic(const char * const topic);
 
 #ifdef CONFIG_NRF_CLOUD_GATEWAY
 typedef int (*gateway_state_handler_t)(void *root_obj);
 
-/** @brief Registers a callback, which is called whenever the shadow changes.
+/** @brief Register a callback, which is called whenever the shadow changes.
  *  The callback is passed a pointer to the shadow JSON document.  The callback
  *  should return 0 to allow further processing of shadow changes in
  *  nrf_cloud_codec.c.  It should return a negative error code only when the

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
@@ -128,6 +128,15 @@ extern "C" {
 #define NRF_CLOUD_DEVICE_JSON_KEY_SIM_INF	"simInfo"
 #define NRF_CLOUD_DEVICE_JSON_KEY_DEV_INF	"deviceInfo"
 
+enum nrf_cloud_rcv_topic {
+	NRF_CLOUD_RCV_TOPIC_GENERAL,
+	NRF_CLOUD_RCV_TOPIC_AGPS,
+	NRF_CLOUD_RCV_TOPIC_PGPS,
+	NRF_CLOUD_RCV_TOPIC_CELL_POS,
+	/* Unknown/unhandled topic */
+	NRF_CLOUD_RCV_TOPIC_UNKNOWN
+};
+
 /**@brief Initialize the codec used encoding the data to the cloud. */
 int nrf_cloud_codec_init(struct nrf_cloud_os_mem_hooks *hooks);
 
@@ -151,7 +160,8 @@ int nrf_cloud_decode_data_endpoint(const struct nrf_cloud_data *input,
 				   struct nrf_cloud_data *m_endpoint);
 
 /** @brief Encodes state information. */
-int nrf_cloud_encode_state(uint32_t reported_state, struct nrf_cloud_data *output);
+int nrf_cloud_encode_state(uint32_t reported_state, const bool update_desired_topic,
+			   struct nrf_cloud_data *output);
 
 /** @brief Search input for config and encode response if necessary. */
 int nrf_cloud_encode_config_response(struct nrf_cloud_data const *const input,
@@ -234,7 +244,7 @@ int json_send_to_cloud(cJSON * const request);
  */
 cJSON *json_create_req_obj(const char *const app_id, const char *const msg_type);
 
-/** @brief Parses received REST data for an nRF Cloud error code  */
+/** @brief Parses received REST data for an nRF Cloud error code */
 int nrf_cloud_parse_rest_error(const char *const buf, enum nrf_cloud_error *const err);
 
 /** @brief Encodes PVT data to be sent to nRF Cloud */
@@ -246,6 +256,14 @@ int nrf_cloud_pvt_data_encode(const struct nrf_cloud_gnss_pvt * const pvt,
 int nrf_cloud_modem_pvt_data_encode(const struct nrf_modem_gnss_pvt_data_frame	* const mdm_pvt,
 				    cJSON * const pvt_data_obj);
 #endif
+
+/** @brief Replaces legacy c2d topic with wilcard topic string. Returns true
+ *  if the topic was modified; otherwise false.
+ */
+bool nrf_cloud_set_wildcard_c2d_topic(char *const topic, size_t topic_len);
+
+/** @brief Decodes dc receive topic string into defined types */
+enum nrf_cloud_rcv_topic nrf_cloud_decode_dc_rx_topic(const char * const topic);
 
 #ifdef CONFIG_NRF_CLOUD_GATEWAY
 typedef int (*gateway_state_handler_t)(void *root_obj);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -885,9 +885,11 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 	case MQTT_EVT_PUBLISH: {
 		const struct mqtt_publish_param *p = &_mqtt_evt->param.publish;
 
-		LOG_DBG("MQTT_EVT_PUBLISH: id = %d len = %d",
+		LOG_DBG("MQTT_EVT_PUBLISH: id = %d len = %d, topic = %.*s",
 			p->message_id,
-			p->message.payload.len);
+			p->message.payload.len,
+			p->message.topic.topic.size,
+			p->message.topic.topic.utf8);
 
 		int err = publish_get_payload(mqtt_client,
 					      p->message.payload.len);
@@ -1322,8 +1324,16 @@ int nct_dc_disconnect(void)
 
 	LOG_DBG("nct_dc_disconnect");
 
+	struct mqtt_topic subscribe_topic = {
+		.topic = {
+			.utf8 = nct.dc_rx_endp.utf8,
+			.size = nct.dc_rx_endp.size
+		},
+		.qos = MQTT_QOS_1_AT_LEAST_ONCE
+	};
+
 	const struct mqtt_subscription_list subscription_list = {
-		.list = (struct mqtt_topic *)&nct.dc_rx_endp,
+		.list = &subscribe_topic,
 		.list_count = 1,
 		.message_id = NCT_MSG_ID_DC_UNSUB
 	};

--- a/tests/subsys/net/lib/nrf_cloud/src/main.c
+++ b/tests/subsys/net/lib/nrf_cloud/src/main.c
@@ -26,7 +26,7 @@ void event_handler(const struct nrf_cloud_evt *const evt)
 		printk("Device is connected and ready");
 		break;
 	case NRF_CLOUD_EVT_ERROR:
-		printk("Failed to connect to cloud");
+		printk("Cloud error: %d", evt->status);
 		break;
 	default:
 		break;


### PR DESCRIPTION
Use new topics to receive data from nRF Cloud.
Data for location services now comes in on separate topics to allow for better filtering.
A-GPS and P-GPS is no longer forwarded to the application. Cellular positioning data is forwarded only if a callback has not been registered.
Created new event IDs for RX data.
NCSDK-11891

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>