### PR TITLE
applications: nrf5340_audio: Shell command for changing hw_codec input

### DIFF
--- a/applications/nrf5340_audio/src/drivers/cs47l63_reg_conf.h
+++ b/applications/nrf5340_audio/src/drivers/cs47l63_reg_conf.h
@@ -57,7 +57,7 @@ const uint32_t pdm_mic_enable_configure[][2] = {
 	{ CS47L63_MICBIAS_CTRL5, 0x0272 },
 
 	/* Enable IN1L */
-	{ CS47L63_INPUT_CONTROL, 0x000E },
+	{ CS47L63_INPUT_CONTROL, 0x000F },
 
 	/* Enable PDM mic as digital input */
 	{ CS47L63_INPUT1_CONTROL1, 0x50021 },
@@ -75,7 +75,7 @@ const uint32_t pdm_mic_enable_configure[][2] = {
 };
 
 /* Set up input */
-const uint32_t input_enable[][2] = {
+const uint32_t line_in_enable[][2] = {
 	/* Select LINE-IN as analog input */
 	{ CS47L63_INPUT2_CONTROL1, 0x50020 },
 
@@ -88,7 +88,7 @@ const uint32_t input_enable[][2] = {
 	{ CS47L63_IN2R_CONTROL2, 0x800080 },
 
 	/* Enable IN2L and IN2R */
-	{ CS47L63_INPUT_CONTROL, 0x000E },
+	{ CS47L63_INPUT_CONTROL, 0x000F },
 
 	/* Volume Update */
 	{ CS47L63_INPUT_CONTROL3, 0x20000000 },


### PR DESCRIPTION
- By using shell command we can now change between PDM mic and LINE_IN as input to hw_codec

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>