### PR TITLE
bluetooth: controller: Allow providing handlers for HCI commands

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -33,6 +33,8 @@ static struct
 	uint8_t raw_event[BT_BUF_EVT_RX_SIZE];
 } cmd_complete_or_status;
 
+static hci_internal_user_cmd_handler_t user_cmd_handler;
+
 static bool command_generates_command_complete_event(uint16_t hci_opcode)
 {
 	switch (hci_opcode) {
@@ -519,6 +521,16 @@ static void le_read_supported_states(uint8_t *buf)
 	states1 &= ~(BIT(22) | BIT(23));
 	*buf = states1;
 	*(buf + 4) = states2;
+}
+
+int hci_internal_user_cmd_handler_register(const hci_internal_user_cmd_handler_t handler)
+{
+	if (user_cmd_handler) {
+		return -EAGAIN;
+	}
+
+	user_cmd_handler = handler;
+	return 0;
 }
 
 #if defined(CONFIG_BT_CONN)
@@ -1014,52 +1026,65 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 
 static void cmd_put(uint8_t *cmd_in, uint8_t * const raw_event_out)
 {
-	uint8_t status;
+	uint8_t status = BT_HCI_ERR_UNKNOWN_CMD;
 	uint16_t opcode = sys_get_le16(cmd_in);
+	bool generate_command_status_event;
 
 	/* Assume command complete */
 	uint8_t return_param_length = sizeof(struct bt_hci_evt_cmd_complete)
 				      + sizeof(struct bt_hci_evt_cc_status);
 
-	switch (BT_OGF(opcode)) {
-#if defined(CONFIG_BT_CONN)
-	case BT_OGF_LINK_CTRL:
-		status = link_control_cmd_put(cmd_in);
-		break;
-#endif
-	case BT_OGF_BASEBAND:
-		status = controller_and_baseband_cmd_put(cmd_in,
-							 raw_event_out,
-							 &return_param_length);
-		break;
-	case BT_OGF_INFO:
-		status = info_param_cmd_put(cmd_in,
-					    raw_event_out,
-					    &return_param_length);
-		break;
-	case BT_OGF_STATUS:
-		status = status_param_cmd_put(cmd_in,
-					      raw_event_out,
-					      &return_param_length);
-		break;
-	case BT_OGF_LE:
-		status = le_controller_cmd_put(cmd_in,
-					       raw_event_out,
-					       &return_param_length);
-		break;
-#if defined(CONFIG_BT_HCI_VS)
-	case BT_OGF_VS:
-		status = vs_cmd_put(cmd_in,
-				    raw_event_out,
-				    &return_param_length);
-		break;
-#endif
-	default:
-		status = BT_HCI_ERR_UNKNOWN_CMD;
-		break;
+	if (user_cmd_handler) {
+		status = user_cmd_handler(cmd_in,
+					  raw_event_out,
+					  &return_param_length,
+					  &generate_command_status_event);
 	}
 
-	if (!command_generates_command_complete_event(opcode) ||
+	if (status == BT_HCI_ERR_UNKNOWN_CMD) {
+
+		switch (BT_OGF(opcode)) {
+#if defined(CONFIG_BT_CONN)
+		case BT_OGF_LINK_CTRL:
+			status = link_control_cmd_put(cmd_in);
+			break;
+#endif
+		case BT_OGF_BASEBAND:
+			status = controller_and_baseband_cmd_put(cmd_in,
+								 raw_event_out,
+								 &return_param_length);
+			break;
+		case BT_OGF_INFO:
+			status = info_param_cmd_put(cmd_in,
+						    raw_event_out,
+						    &return_param_length);
+			break;
+		case BT_OGF_STATUS:
+			status = status_param_cmd_put(cmd_in,
+						      raw_event_out,
+						      &return_param_length);
+			break;
+		case BT_OGF_LE:
+			status = le_controller_cmd_put(cmd_in,
+						       raw_event_out,
+						       &return_param_length);
+			break;
+#if defined(CONFIG_BT_HCI_VS)
+		case BT_OGF_VS:
+			status = vs_cmd_put(cmd_in,
+					    raw_event_out,
+					    &return_param_length);
+			break;
+#endif
+		default:
+			status = BT_HCI_ERR_UNKNOWN_CMD;
+			break;
+		}
+
+		generate_command_status_event = !command_generates_command_complete_event(opcode);
+	}
+
+	if (generate_command_status_event ||
 	    (status == BT_HCI_ERR_UNKNOWN_CMD))	{
 		encode_command_status(raw_event_out, opcode, status);
 	} else {

--- a/subsys/bluetooth/controller/hci_internal.h
+++ b/subsys/bluetooth/controller/hci_internal.h
@@ -17,12 +17,54 @@
 
 /** @brief Send an HCI command packet to the SoftDevice Controller.
  *
+ * If the application has provided a user handler, this handler get precedence
+ * above the default HCI command handlers. See @ref hci_internal_user_cmd_handler_register.
+ *
  * @param[in] cmd_in  HCI Command packet. The first byte in the buffer should correspond to
  *                    OpCode, as specified by the Bluetooth Core Specification.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
 int hci_internal_cmd_put(uint8_t *cmd_in);
+
+/** A user implementable HCI command handler
+ *
+ * What is done in the command handler is up to the user.
+ * Parameters can be returned to the host through the raw_event_out output parameter.
+ *
+ * When the command handler returns, a Command Complete or Command Status event is generated.
+ *
+ * @param[in]  cmd               The HCI command itself. The first byte in the buffer corresponds
+ *                               to OpCode, as specified by the Bluetooth Core Specification.
+ * @param[out] raw_event_out     Parameters to be returned from the event as return parameters in
+ *                               the Command Complete event.
+ *                               Parameters can only be returned if the generated event is
+ *                               a Command Complete event.
+ * @param[out] param_length_out  Length of parameters to be returned.
+ * @param[out] gives_cmd_status  Set to true if the command is returning a Command Status event.
+ *
+ * @return Bluetooth status code. BT_HCI_ERR_UNKNOWN_CMD if unknown.
+ */
+typedef uint8_t (*hci_internal_user_cmd_handler_t)(uint8_t const *cmd,
+						   uint8_t *raw_event_out,
+						   uint8_t *param_length_out,
+						   bool *gives_cmd_status);
+
+/** @brief Register a user handler for HCI commands.
+ *
+ * The user handler can be used to handle custom HCI commands.
+ *
+ * The user handler will have precedence over all other command handling.
+ * Therefore, the application needs to ensure it is not using opcodes that
+ * are used for other Bluetooth or vendor specific HCI commands.
+ * See sdc_hci_vs.h for the opcodes that are reserved.
+ *
+ * @note Only one handler can be registered.
+ *
+ * @param[in] handler
+ * @return Zero on success or (negative) error code otherwise
+ */
+int hci_internal_user_cmd_handler_register(const hci_internal_user_cmd_handler_t handler);
 
 /** @brief Retrieve an HCI event packet from the SoftDevice Controller.
  *


### PR DESCRIPTION
Provide a simple way to add handlers for HCI commands.
The user can now define its own vendor specific HCI commands, or it can
override the behavior of existing ones.

I didn't create a public header file for it for now as it has not been
requested.

