### PR TITLE
manifest: Fix DTLS 1.2 resumption bug in MbedTLS

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -108,7 +108,7 @@ manifest:
     - name: mbedtls-nrf
       path: mbedtls
       repo-path: sdk-mbedtls
-      revision: abce0e893c8ad219370100dadaed0ae11a3e4d63
+      revision: d540e87d63c1bf51856a88657c58abc021c7ad8f
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib


### PR DESCRIPTION
This cherry picks a bug fx related to the
resumption of DTLS 1.2 from upstream.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>