### PR TITLE
bluetooth: adv_prov: tx_power: Add correction value

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -231,6 +231,11 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
+* :ref:`bt_le_adv_prov_readme`:
+
+  * Added the :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` option to TX power advertising data provider (:kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER`).
+    The option adds a predefined value to the TX power, that is included in the advertising data.
+
 * :ref:`bt_mesh` library:
 
   * :ref:`bt_mesh_dk_prov` module: Changed the UUID generation to prevent trailing zeros in the UUID.

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.swift_pair
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.swift_pair
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-config BT_ADV_PROV_SWIFT_PAIR
+menuconfig BT_ADV_PROV_SWIFT_PAIR
 	bool "Microsoft Swift Pair"
 	help
 	  Adds Microsoft Swfit Pair manufacturer data to advertising data if

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.tx_power
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.tx_power
@@ -4,9 +4,22 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-config BT_ADV_PROV_TX_POWER
+menuconfig BT_ADV_PROV_TX_POWER
 	bool "TX power"
 	select BT_CTLR_TX_PWR_DYNAMIC_CONTROL
 	help
 	  Adds TX power to advertising data. Provider reads the advertising TX
-	  power from Bluetooth controller.
+	  power from Bluetooth controller and adds predefined correction value
+	  to it.
+
+if BT_ADV_PROV_TX_POWER
+
+config BT_ADV_PROV_TX_POWER_CORRECTION_VAL
+	int "TX power correction value"
+	default 0
+	help
+	  The configured value is added to the TX power incluced in the
+	  advertising data. The correction may be needed to take into acccount
+	  hardware configuration (e.g. used antenna, device's casing).
+
+endif # BT_ADV_PROV_TX_POWER

--- a/subsys/bluetooth/adv_prov/providers/tx_power.c
+++ b/subsys/bluetooth/adv_prov/providers/tx_power.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <limits.h>
 #include <zephyr/sys/byteorder.h>
 
 #include <zephyr/bluetooth/hci.h>
@@ -42,7 +43,13 @@ static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *s
 		LOG_ERR("Read Tx power err: %d", err);
 	} else {
 		rp = (struct bt_hci_rp_vs_read_tx_power_level *)rsp->data;
-		tx_power = (uint8_t)rp->tx_power_level;
+
+		int readout = rp->tx_power_level;
+
+		readout += CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL;
+		__ASSERT_NO_MSG((readout >= INT8_MIN) && (readout <= INT8_MAX));
+		tx_power = (uint8_t)readout;
+
 		net_buf_unref(rsp);
 
 		ad->type = BT_DATA_TX_POWER;


### PR DESCRIPTION
Change introduces TX power correction value defined in Kconfig.

Jira: NCSDK-16584