### PR TITLE
Add VS_ZEPHYR_READ_CHIP_TEMP to make temperature sensor work

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -971,6 +971,10 @@ static uint8_t vs_cmd_put(uint8_t const * const cmd,
 	case SDC_HCI_OPCODE_CMD_VS_ZEPHYR_WRITE_BD_ADDR:
 		return sdc_hci_cmd_vs_zephyr_write_bd_addr((void *)cmd_params);
 
+	case SDC_HCI_OPCODE_CMD_VS_ZEPHYR_READ_CHIP_TEMP:
+		*param_length_out += sizeof(sdc_hci_cmd_vs_zephyr_read_chip_temp_return_t);
+		return sdc_hci_cmd_vs_zephyr_read_chip_temp((void *)event_out_params);
+
 #if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
 	case SDC_HCI_OPCODE_CMD_VS_ZEPHYR_WRITE_TX_POWER:
 		*param_length_out += sizeof(sdc_hci_cmd_vs_zephyr_write_tx_power_return_t);


### PR DESCRIPTION
This issue is on nRF5430 with all current versions of NCS.

The vendor-specific HCI command BT_HCI_OP_VS_READ_CHIP_TEMP is supposed to allow the application core to read the chip temperature from the network core.  But it always returns an error because the corresponding switch case is not implemented on the network core side.  This patch adds the necessary code to nrf/subsys/bluetooth/hci_internal.c to make the temperature sensor work correctly.
