### PR TITLE
cmake: pass Zephyr Python version to TF-M build system

### DIFF
--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -146,6 +146,11 @@ set_property(TARGET zephyr_property_target
     -DCRYPTO_ENGINE_BUF_SIZE=${CONFIG_TFM_CRYPTO_ENGINE_BUF_SIZE}
     -DCRYPTO_CONC_OPER_NUM=${CONFIG_TFM_CRYPTO_CONC_OPER_NUM}
     -DCRYPTO_IOVEC_BUFFER_SIZE=${CONFIG_TFM_CRYPTO_IOVEC_BUFFER_SIZE}
+    # Pass Zephyr Python to TF-M so both uses identical Python.
+    -DPython3_EXECUTABLE=${Python3_EXECUTABLE}
+    # TF-M calls back into nrf_security which loads Zephyr Python lookup
+    # mechanism, thus also set PYTHON_PREFER.
+    -DPYTHON_PREFER=${Python3_EXECUTABLE}
 )
 
 zephyr_include_directories(${NRF_DIR}/include/tfm)


### PR DESCRIPTION
We pass both Python3_EXECUTABLE and PYTHON_PREFER. Python3_EXECUTABLE is the regular CMake Python3 search mechanism which is used first by TF-M, but in NCS context nrf_security hooks into the TF-M build system and loads Zephyr Python3 find package, therefore PYTHON_PREFER must also be set to unsure identical behaviour in all situations.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>