### PR TITLE
manifest: sdk-hostap: Fix BLE provisioning crash

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -100,7 +100,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 4848da7c1a45aee06f8b3475daf1ea37f5684060
+      revision: 74352f6ebf87c50039a646c1f2c7fbfaaeb73805
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: v1.9.99-ncs2


### PR DESCRIPTION
During BLE provisioning if the shell is also used in parallel, then there is a crash in the shell due to stack corruption.

Pull the fix for that in the wifi_mgmt API implementation.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>