### PR TITLE
drivers: wifi: Fix QSPI clock frequency configuration

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/qspi/inc/qspi_if.h
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/inc/qspi_if.h
@@ -28,8 +28,6 @@ struct qspi_config {
 	nrf_qspi_writeoc_t writeoc;
 	nrf_qspi_frequency_t sckfreq;
 #endif
-	unsigned int freq;
-	unsigned int spimfreq;
 	unsigned char RDC4IO;
 	bool easydma;
 	bool single_op;

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/inc/rpu_hw_if.h
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/inc/rpu_hw_if.h
@@ -46,7 +46,6 @@ int rpu_sleep(void);
 int rpu_wakeup(void);
 int rpu_sleep_status(void);
 void rpu_get_sleep_stats(uint32_t addr, uint32_t *buff, uint32_t wrd_len);
-int rpu_qspi_config(uint32_t freq, uint32_t latency, uint32_t mem_block);
 int rpu_irq_config(struct gpio_callback *irq_callback_data, void (*irq_handler)());
 
 int rpu_wrsr2(uint8_t data);

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/device.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/device.c
@@ -43,16 +43,11 @@ struct qspi_config *qspi_defconfig(void)
 #endif
 	config.addrmask = 0x800000; /* set bit23 (incr. addr mode) */
 
-	config.freq = 8; /* 8MHz */
-
 	config.test_name = "QSPI TEST";
 	config.test_hlread = false;
 	config.test_iteration = 0;
 
 	config.qspi_slave_latency = 0;
-
-	if (config.freq >= 16) /* 16MHz */
-		config.qspi_slave_latency = 1;
 
 	config.encryption = config.CMD_CNONCE = false;
 

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/rpu_hw_if.c
@@ -172,28 +172,6 @@ int rpu_qspi_init(void)
 
 	qdev->init(cfg);
 
-	LOG_INF("QSPI/SPIM freq = %d MHz\n", cfg->freq);
-	LOG_INF("QSPI/SPIM latency = %d\n", cfg->qspi_slave_latency);
-
-	return 0;
-}
-
-int rpu_qspi_config(uint32_t freq, uint32_t latency, uint32_t mem_block)
-{
-	struct qspi_config *cfg;
-
-	/* Re-initialize cfg */
-	cfg = qspi_defconfig();
-
-	cfg->freq = freq;
-	rpu_7002_memmap[mem_block][2] = mem_block;
-	cfg->qspi_slave_latency = latency;
-
-	qdev->init(cfg);
-
-	LOG_INF("QSPIM freq = %d MHz\n", cfg->freq);
-	LOG_INF("QSPIM latency = %d\n", cfg->qspi_slave_latency);
-
 	return 0;
 }
 

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/spi_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/spi_if.c
@@ -222,6 +222,14 @@ int spim_init(struct qspi_config *config)
 
 	k_sem_init(&spim_config->lock, 1, 1);
 
+	if (spi_spec.config.frequency >= MHZ(16)) {
+		spim_config->qspi_slave_latency = 1;
+	}
+
+	LOG_INF("SPIM %s: freq = %d MHz\n", spi_spec.bus->name,
+		spi_spec.config.frequency / MHZ(1));
+	LOG_INF("SPIM %s: latency = %d\n", spi_spec.bus->name, spim_config->qspi_slave_latency);
+
 	return 0;
 }
 


### PR DESCRIPTION
Even though the QSPI configuration is moved to DTS, there is still some configuration which is left over and overrides the DTS configuration.

So, even if DTS is configured with 24MHz, the QSPI clock is still 8MHz, fix this by removing local QSPI clock frequency configuration.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>