### PR TITLE
tfm: Add option to enable SFN model

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/Kconfig
@@ -22,6 +22,8 @@ config BOARD_ENABLE_DCDC_HV
 
 config BOARD_ENABLE_CPUNET
 	bool "Enable nRF53 Network MCU"
+	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \
+		$(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_GPIO_FORWARDER))
 	help
 	  This option enables releasing the Network 'force off' signal, which
 	  as a consequence will power up the Network MCU during system boot.

--- a/boards/arm/nrf7002dk_nrf5340/Kconfig
+++ b/boards/arm/nrf7002dk_nrf5340/Kconfig
@@ -38,6 +38,8 @@ config BT_HCI_VS
 
 config BOARD_ENABLE_CPUNET
 	bool "Enable nRF53 Network MCU"
+	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \
+		$(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_GPIO_FORWARDER))
 	help
 	  This option enables releasing the Network 'force off' signal, which
 	  as a consequence will power up the Network MCU during system boot.

--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if (NOT CONFIG_TFM_BUILD_NS)
+if (NOT CONFIG_TFM_BUILD_NS AND CONFIG_TFM_PARTITION_PLATFORM AND CONFIG_SOC_FAMILY_NRF)
   zephyr_library_named(tfm_api_nrf)
 
   # The non-secure API files are located in a folder associated with the TF-M
@@ -13,7 +13,7 @@ if (NOT CONFIG_TFM_BUILD_NS)
   # For convenience we instead refer directly to the source files here.
   set(src_dir ${CMAKE_CURRENT_LIST_DIR}/../tfm/boards/src)
 
-  zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PLATFORM
+  zephyr_library_sources(
     ${src_dir}/tfm_ioctl_ns_api.c
     )
 endif()

--- a/modules/trusted-firmware-m/Kconfig
+++ b/modules/trusted-firmware-m/Kconfig
@@ -15,9 +15,6 @@
 
 if BUILD_WITH_TFM
 
-config TFM_IPC
-	default y
-
 config TFM_ISOLATION_LEVEL
 	default 1 if SOC_NRF5340_CPUAPP || SOC_NRF9160
 
@@ -92,7 +89,7 @@ config TFM_CRYPTO_CONC_OPER_NUM
 config TFM_CRYPTO_IOVEC_BUFFER_SIZE
 	int
 	prompt "TF-M Crypto - PSA FF IO vector buffer size" if !TFM_PROFILE_TYPE_MINIMAL
-	depends on TFM_IPC
+	depends on !TFM_LIBRARY
 	default 1024 if TFM_PROFILE_TYPE_MINIMAL
 	default 16384 if TFM_REGRESSION_S || TFM_REGRESSION_NS
 	default 5120

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d9f99ed1951a973c691cd5d6bd70aecb597b2030
+      revision: c5340c156e0ce042b21ae716906b2746a7835343
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update revision of zephyr to include the option to enable the SFN model. This defaults to using the IPC model, so remove the local default value which is not needed anymore.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>