### PR TITLE
bluetooth: mesh: Fix in Time srv API

### DIFF
--- a/include/bluetooth/mesh/time_srv.h
+++ b/include/bluetooth/mesh/time_srv.h
@@ -127,7 +127,9 @@ struct bt_mesh_time_srv {
  * @param[in] ctx    Message context, or NULL to publish with the configured
  *                   parameters.
  *
- * @return 0              Successfully published the current Light state.
+ * @return 0              Successfully published the current Time state.
+ * @retval -EOPNOTSUPP    The server Time Role state does not support sending
+ *                        of unsolicited Time Status messages.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  *                        not configured.
  * @retval -EAGAIN        The device has not been provisioned.

--- a/subsys/bluetooth/mesh/time_srv.c
+++ b/subsys/bluetooth/mesh/time_srv.c
@@ -477,6 +477,15 @@ int bt_mesh_time_srv_time_status_send(struct bt_mesh_time_srv *srv,
 				      struct bt_mesh_msg_ctx *ctx)
 {
 	srv->model->pub->ttl = 0;
+
+	/** Mesh Model Specification 5.3.1.2.2:
+	 * The message (Time Status) may be sent as an unsolicited message at any time
+	 * if the value of the Time Role state is 0x01 (Time Authority) or 0x02 (Time Relay).
+	 */
+	if ((srv->data.role != BT_MESH_TIME_AUTHORITY) && (srv->data.role != BT_MESH_TIME_RELAY)) {
+		return -EOPNOTSUPP;
+	}
+
 	return send_time_status(srv->model, ctx, k_uptime_get());
 }
 


### PR DESCRIPTION
Allow only servers with Time Role State 0x01 (Time Authority) or 0x02 (Time Relay) to send unsolicited Time Status messages (Mesh Model Specification 5.3.1.2.2).

Signed-off-by: Stine Akredalen <stine.akredalen@nordicsemi.no>