### PR TITLE
net: lib: lwm2m_client_utils: Fix state changes when URI written

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -234,6 +234,10 @@ static int firmware_block_received_cb(uint16_t obj_inst_id,
 		client_acknowledge();
 
 		image_type = dfu_target_img_type(data, data_len);
+		if (image_type == -ENOTSUP) {
+			ret = -ENOMSG; /* Translates to unsupported image type */
+			goto cleanup;
+		}
 		LOG_INF("Image type %d", image_type);
 #if defined(CONFIG_DFU_TARGET_FULL_MODEM)
 		if (image_type == DFU_TARGET_IMAGE_TYPE_FULL_MODEM) {


### PR DESCRIPTION
When URI is written into a FOTA resource, it should first set state to DOWNLOADING before setting any error results.

In case wrong URI is written, the parser would otherwise set "result" to show some error, then set the state to DOWNLOADING which would wipe out the result.
