### PR TITLE
bluetooth: adv_prov: Change bond count to pairing mode

### DIFF
--- a/applications/machine_learning/src/util/bt_le_adv_prov_uuid128.c
+++ b/applications/machine_learning/src/util/bt_le_adv_prov_uuid128.c
@@ -16,7 +16,7 @@ static int get_data(struct bt_data *sd, const struct bt_le_adv_prov_adv_state *s
 {
 	ARG_UNUSED(fb);
 
-	if (state->bond_cnt > 0) {
+	if (!state->pairing_mode) {
 		return -ENOENT;
 	}
 

--- a/applications/nrf_desktop/src/util/bt_le_adv_prov_uuid16.c
+++ b/applications/nrf_desktop/src/util/bt_le_adv_prov_uuid16.c
@@ -12,7 +12,7 @@ static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *s
 {
 	ARG_UNUSED(fb);
 
-	if (state->bond_cnt > 0) {
+	if (!state->pairing_mode) {
 		return -ENOENT;
 	}
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -237,6 +237,8 @@ Bluetooth libraries and services
 
   * Added the :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` option to TX power advertising data provider (:kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER`).
     The option adds a predefined value to the TX power, that is included in the advertising data.
+  * Changed :c:member:`bt_le_adv_prov_adv_state.bond_cnt` to :c:member:`bt_le_adv_prov_adv_state.pairing_mode`.
+    The information about whether the advertising device is looking for a new peer is more meaningful for the Bluetooth LE data providers.
 
 * :ref:`bt_mesh` library:
 

--- a/include/bluetooth/adv_prov.h
+++ b/include/bluetooth/adv_prov.h
@@ -26,8 +26,8 @@ extern "C" {
 
 /** Structure describing Bluetooth advertising state. */
 struct bt_le_adv_prov_adv_state {
-	/** Number of Bluetooth bonds of Bluetooth local identity used for advertising. */
-	size_t bond_cnt;
+	/** Information if the advertising device is looking for a new peer. */
+	bool pairing_mode;
 
 	/** Instead of instantly stopping Bluetooth advertising, the advertising may enter grace
 	 * period (if requested by at least one of the providers). During the grace period

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.flags
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.flags
@@ -7,5 +7,5 @@
 config BT_ADV_PROV_FLAGS
 	bool "Advertising flags"
 	help
-	  Adds flag indicating that BR/EDR is not supported. If used Bluetooth
-	  local identity has no bonds, adds also General Discoverable flag.
+	  Adds flag indicating that BR/EDR is not supported. If device is
+	  in pairing mode, adds also General Discoverable flag.

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.gap_appearance
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.gap_appearance
@@ -7,5 +7,4 @@
 config BT_ADV_PROV_GAP_APPEARANCE
 	bool "GAP appearance"
 	help
-	  Adds GAP appearance to advertising data if used Bluetooth local
-	  identity has no bonds.
+	  Adds GAP appearance to advertising data if device is in pairing mode.

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.swift_pair
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.swift_pair
@@ -8,8 +8,8 @@ menuconfig BT_ADV_PROV_SWIFT_PAIR
 	bool "Microsoft Swift Pair"
 	help
 	  Adds Microsoft Swfit Pair manufacturer data to advertising data if
-	  used Bluetooth local identity has no bonds and advertising has not
-	  entered grace period.
+	  device is in pairing mode and advertising has not entered grace
+	  period.
 
 if BT_ADV_PROV_SWIFT_PAIR
 

--- a/subsys/bluetooth/adv_prov/providers/flags.c
+++ b/subsys/bluetooth/adv_prov/providers/flags.c
@@ -14,7 +14,7 @@ static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *s
 
 	static uint8_t flags = BT_LE_AD_NO_BREDR;
 
-	if (state->bond_cnt == 0) {
+	if (state->pairing_mode) {
 		flags |= BT_LE_AD_GENERAL;
 	} else {
 		flags &= ~BT_LE_AD_GENERAL;

--- a/subsys/bluetooth/adv_prov/providers/gap_appearance.c
+++ b/subsys/bluetooth/adv_prov/providers/gap_appearance.c
@@ -15,7 +15,7 @@ static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *s
 {
 	ARG_UNUSED(fb);
 
-	if (state->bond_cnt > 0) {
+	if (!state->pairing_mode) {
 		return -ENOENT;
 	}
 

--- a/subsys/bluetooth/adv_prov/providers/swift_pair.c
+++ b/subsys/bluetooth/adv_prov/providers/swift_pair.c
@@ -19,7 +19,7 @@ static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *s
 		0x80		/* Reserved RSSI Byte */
 	};
 
-	if (state->in_grace_period || (state->bond_cnt > 0)) {
+	if (state->in_grace_period || (!state->pairing_mode)) {
 		return -ENOENT;
 	}
 

--- a/subsys/caf/modules/ble_adv.c
+++ b/subsys/caf/modules/ble_adv.c
@@ -189,9 +189,9 @@ static int update_undirected_advertising(struct bt_le_adv_param *adv_param, bool
 	struct bt_le_adv_prov_feedback fb;
 
 	if (bt_addr_le_cmp(&bond_find_data.peer_address, BT_ADDR_LE_ANY)) {
-		state.bond_cnt = 1;
+		state.pairing_mode = false;
 	} else {
-		state.bond_cnt = 0;
+		state.pairing_mode = true;
 	}
 
 	state.in_grace_period = in_grace_period;


### PR DESCRIPTION
The number of Bluetooth bonds for given local identity not always directly defines if device is looking for a new peer. Informing about pairing mode is more explicit.
Commit also aligns CAF BLE advertising module and applications with the new API.

Jira: NCSDK-16744