### PR TITLE
net: lib: fota_download: Return proper error if FOTA init fails

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -359,6 +359,9 @@ Libraries for networking
 
   * Added support for using X509 certificates.
 
+* :ref:`lib_fota_download` library:
+
+  * Added an error code :c:enumerator:`FOTA_DOWNLOAD_ERROR_CAUSE_INTERNAL` to indicate that the source of error is not network related.
 
 Libraries for NFC
 -----------------

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -57,6 +57,8 @@ enum fota_download_error_cause {
 	FOTA_DOWNLOAD_ERROR_CAUSE_INVALID_UPDATE,
 	/** Actual firmware type does not match expected. Retry will not help. */
 	FOTA_DOWNLOAD_ERROR_CAUSE_TYPE_MISMATCH,
+	/** Generic error on device side. */
+	FOTA_DOWNLOAD_ERROR_CAUSE_INTERNAL,
 };
 
 /**


### PR DESCRIPTION
Add a new error code FOTA_DOWNLOAD_ERROR_CAUSE_INTERNAL to be
used when any of the initialization phase fails. This should
reflect that the error cause is not coming from the network
or from the image itself.

When dfu_target_img_type() cannot detect the image type
or when  images are too large, they are rejected with
FOTA_DOWNLOAD_ERROR_CAUSE_INVALID_UPDATE

This error was seen when testing for https://github.com/nrfconnect/sdk-nrf/pull/8834
