### PR TITLE
samples: bluetooth: Update coex sample overlays

### DIFF
--- a/samples/bluetooth/radio_coex_1wire/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/bluetooth/radio_coex_1wire/boards/nrf52840dk_nrf52840.overlay
@@ -8,7 +8,7 @@
     coex-pta-grant-gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
   };
 
-  radio_coex_1w: radio_coex_one_wire {
+  nrf_radio_coex: radio_coex_one_wire {
     status = "okay";
     compatible = "sdc-radio-coex-one-wire";
     grant-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
@@ -17,5 +17,5 @@
 };
 
 &radio {
-  coex = <&radio_coex_1w>;
+  coex = <&nrf_radio_coex>;
 };

--- a/samples/bluetooth/radio_coex_3wire/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/bluetooth/radio_coex_3wire/boards/nrf52840dk_nrf52840.overlay
@@ -9,7 +9,7 @@
     coex-pta-grant-gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
   };
 
-  radio_coex: radio_coex_three_wire {
+  nrf_radio_coex: radio_coex_three_wire {
     status = "okay";
     compatible = "sdc-radio-coex-three-wire";
     req-gpios =     <&gpio0 3 GPIO_ACTIVE_HIGH>;
@@ -22,5 +22,5 @@
 };
 
 &radio {
-  coex = <&radio_coex>;
+  coex = <&nrf_radio_coex>;
 };


### PR DESCRIPTION
Commit 80f056af introduced a dependency on the nrf_radio_coex DT label for MPSL_CX indirectly via MPSL_CX_ANY_SUPPORT. 
Fix the coex samples so they reference the new DT label, enabling the coex interface build.

Signed-off-by: Aleksandar Stanoev <aleksandar.stanoev@nordicsemi.no>