### PR TITLE
manifest: update sdk-zephyr

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -74,6 +74,9 @@ config INIT_ARCH_HW_AT_BOOT
 	  leave the system in a clean state, so it is necessary to perform
 	  architecture specific hardware initialization.
 
+config LINKER_LAST_SECTION_ID
+	default n if IS_SPM
+
 DT_COMPAT_NORDIC_QSPI_NOR := nordic,qspi-nor
 config NORDIC_QSPI_NOR
 	default y if $(dt_compat_on_bus,$(DT_COMPAT_NORDIC_QSPI_NOR),qspi) && PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY && !SPI_NOR

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 97c4a1a6d1bda83f0272d9bbf68b211efadc7b4a
+      revision: 731d4be8bb86159cbe48ea19998ba7451e70cef9
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
JIRA: NCSIDB-838

Update sdk-zephyr revision to pull/914/head

This update corrects the issue where firmware info total size reported could be larger than actual image size due to location counter being increment to higher value than actual flash usage because of alignment.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>