### PR TITLE
doc: update doc after dev tag 2.1.99-dev1

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -19,7 +19,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 project = "nRF Connect SDK"
 copyright = "2019-2022, Nordic Semiconductor"
 author = "Nordic Semiconductor"
-version = release = "2.1.99-dev1"
+version = release = "2.1.99"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -3,17 +3,6 @@
 Welcome to the |NCS|!
 #####################
 
-.. important::
-
-   |NCS| v2.1.99-dev1 is a development tag and will be replaced by v2.2.0 in the future.
-
-   The development tag contains the following major update, marked as experimental:
-
-   * Added integration of ANT protocol to the |NCS|.
-     ANT support is provided through an external, private repository.
-
-   For other changes that are included in this development tag, see :ref:`ncs_release_notes_changelog`.
-
 The |NCS| is where you begin building low-power wireless applications with Nordic Semiconductor nRF52, nRF53, and nRF91 Series devices.
 
 The SDK contains optimized cellular IoT (LTE-M and NB-IoT), Bluetooth® Low Energy, Thread, Zigbee, and Bluetooth mesh stacks, a range of applications, samples, and reference implementations, as well as a full suite of drivers for Nordic Semiconductor's devices.
@@ -43,6 +32,7 @@ A "99" at the end of the version number of this documentation indicates continuo
    libraries/index
    scripts
    release_notes
+   known_issues
    software_maturity
    documentation
    glossary

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _known_issues:
 
 Known issues

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -1,7 +1,7 @@
 .. _ncs_release_notes_changelog:
 
-Changelog for |NCS| v2.1.99-dev1
-################################
+Changelog for |NCS| v2.1.99
+###########################
 
 .. contents::
    :local:


### PR DESCRIPTION
Necessary changes in doc after the dev tag.

Signed-off-by: Bartosz Gentkowski <bartosz.gentkowski@nordicsemi.no>