### PR TITLE
doc: kconfig: disable prev/next navigation buttons

### DIFF
--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -36,7 +36,10 @@ html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = True
 html_show_sphinx = False
 
-html_theme_options = {"docset": "kconfig", "docsets": utils.ALL_DOCSETS}
+html_theme_options = {
+    "docset": "kconfig", "docsets": utils.ALL_DOCSETS,
+    "prev_next_buttons_location": None
+}
 
 # Options for ncs_cache --------------------------------------------------------
 


### PR DESCRIPTION
The Kconfig docset only has a search page and a regex tips/tricks page. Navigation buttons are confusing when using search functionality (as it also provides prev/next buttons to nativagate through the results). Disable Sphinx buttons as they are not useful in this docset.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>