### PR TITLE
manifest: sdk-zephyr: Fix nRF Wi-Fi management events

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 731d4be8bb86159cbe48ea19998ba7451e70cef9
+      revision: 98bc3a7a6b3917ce5a058e7a7271d3036edffb88
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull fix for nRF Wi-Fi management events.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>