### PR TITLE
tfm: Add support for configurable baud rate

### DIFF
--- a/modules/tfm/tfm/boards/board/device_cfg.h
+++ b/modules/tfm/tfm/boards/board/device_cfg.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef DEVICE_CFG_H__
+#define DEVICE_CFG_H__
+
+/**
+ * \file device_cfg.h
+ * \brief
+ * This is the default device configuration file with all peripherals
+ * defined and configured to be use via the secure and/or non-secure base
+ * address.
+ */
+/* ARRAY_SIZE causes a conflict as it is defined both by TF-M and indirectly by devicetree.h */
+#undef ARRAY_SIZE
+#include <autoconf.h>
+#include <zephyr/devicetree.h>
+
+#define DEFAULT_UART_BAUDRATE DT_PROP(DT_NODELABEL(uart1), current_speed)
+
+#endif /* DEVICE_CFG_H__ */

--- a/west.yml
+++ b/west.yml
@@ -118,7 +118,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: ce077f50732f56dc277d829638ad6e033ab9f37b
+      revision: 11b5f0a978afff3893143a09b4f771938a3bba5e
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
Add support for configurable baud rate for TF-M secure log.

Signed-off-by: Vidar Lillebø <vidar.lillebo@nordicsemi.no>