### PR TITLE
drivers: wifi: Allow only single scan at a time

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_disp_scan.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_disp_scan.c
@@ -41,6 +41,12 @@ int wifi_nrf_disp_scan_zep(const struct device *dev,
 		goto out;
 	}
 
+	if (vif_ctx_zep->scan_in_progress) {
+		LOG_INF("%s: Scan already in progress\n", __func__);
+		ret = -EBUSY;
+		goto out;
+	}
+
 	vif_ctx_zep->disp_scan_cb = cb;
 
 	memset(&scan_info, 0, sizeof(scan_info));

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
@@ -234,6 +234,10 @@ void wifi_nrf_wpa_supp_event_proc_scan_res(void *if_priv,
 
 	vif_ctx_zep->supp_callbk_fns.scan_res(vif_ctx_zep->supp_drv_if_ctx, r, more_res);
 
+	if (!more_res) {
+		vif_ctx_zep->scan_in_progress = false;
+	}
+
 	k_free(r);
 }
 
@@ -452,6 +456,12 @@ int wifi_nrf_wpa_supp_scan2(void *if_priv, struct wpa_driver_scan_params *params
 
 	vif_ctx_zep = if_priv;
 	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
+
+	if (vif_ctx_zep->scan_in_progress) {
+		LOG_INF("%s: Scan already in progress\n", __func__);
+		ret = -EBUSY;
+		goto out;
+	}
 
 	memset(&scan_info, 0x0, sizeof(scan_info));
 


### PR DESCRIPTION
Drop scan if one is already in progress. E.g., WPA supplicant scan and display scan in parallel.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>