### PR TITLE
cmake: child image: support passing of quoted settings to child images

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -371,10 +371,9 @@ function(add_child_image_from_source)
     list(FILTER VARIABLES        INCLUDE REGEX ${regex})
     list(FILTER VARIABLES_CACHED INCLUDE REGEX ${regex})
 
-    foreach(var_name
-        ${VARIABLES}
-        ${VARIABLES_CACHED}
-        )
+    set(VARIABLES_ALL ${VARIABLES} ${VARIABLES_CACHED})
+    list(REMOVE_DUPLICATES VARIABLES_ALL)
+    foreach(var_name ${VARIABLES_ALL})
       # This regex is guaranteed to match due to the filtering done
       # above, we only re-run the regex to extract the part after
       # '_'. We run the regex twice because it is believed that

--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -81,10 +81,11 @@ else()
   endforeach()
 
   foreach(app_var_name ${application_vars})
+    string(REPLACE "\"" "\\\"" app_var_value "${${app_var_name}}")
     file(
       APPEND
       ${base_image_preload_file}
-      "set(${app_var_name} \"${${app_var_name}}\" CACHE INTERNAL \"NCS child image controlled\")\n"
+      "set(${app_var_name} \"${app_var_value}\" CACHE INTERNAL \"NCS child image controlled\")\n"
       )
   endforeach()
 
@@ -374,6 +375,7 @@ function(add_child_image_from_source)
     set(VARIABLES_ALL ${VARIABLES} ${VARIABLES_CACHED})
     list(REMOVE_DUPLICATES VARIABLES_ALL)
     foreach(var_name ${VARIABLES_ALL})
+      string(REPLACE "\"" "\\\"" ${var_name} "${${var_name}}")
       # This regex is guaranteed to match due to the filtering done
       # above, we only re-run the regex to extract the part after
       # '_'. We run the regex twice because it is believed that

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -56,6 +56,7 @@ Build system
 ------------
 
 * Fixed an issue with the |NCS| Toolchain where protoc and nanopb would not be correctly detected by the build system, resulting in builds trying to find locally installed versions instead of the version shipped with the |NCS| Toolchain.
+* Fixed an issue with passing quoted settings to child images.
 
 Protocols
 =========


### PR DESCRIPTION
JIRA: NCSIDB-806

CMake string variables which are defined with escaped quotes, such as
-D<image>_FOO=\"BAR\" loose their quotes when written to the pre-load
file. More precisely, <image>_FOO becomes `set(FOO ""BAR"" ...)`.

This commit correct this by properly escaping quotes in CMake string
variables before writing them to the pre-load file, so that
<image>_FOO becomes `set(FOO "\"BAR\"" ...)`.

The manifest is updated to get corresponding fix for quoted Kconfig
settings that are passed on command line to be treated properly.
