### PR TITLE
lib: nrf_modem: nrf91_sockets: add missing API

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -254,6 +254,10 @@ Modem libraries
   * Removed ``MODEM_INFO_NETWORK_MODE_MAX_SIZE``.
   * Removed ``CONFIG_MODEM_INFO_ADD_BOARD``.
 
+* :ref:`nrf_modem_lib_readme`:
+
+  * Added offloading implementation for the :c:func:`getsockname` function.
+
 Libraries for networking
 ------------------------
 

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -525,6 +525,14 @@ static int nrf91_socket_offload_getsockopt(void *obj, int level, int optname,
 	return retval;
 }
 
+static int nrf91_socket_offload_getsockname((void *obj, struct sockaddr *addr,
+					    socklen_t *addrlen)
+{
+	/* Not implemented. */
+	errno = ENOSYS;
+	return -1;
+}
+
 static ssize_t nrf91_socket_offload_recvfrom(void *obj, void *buf, size_t len,
 					     int flags, struct sockaddr *from,
 					     socklen_t *fromlen)
@@ -949,6 +957,7 @@ static const struct socket_op_vtable nrf91_socket_fd_op_vtable = {
 	.recvfrom = nrf91_socket_offload_recvfrom,
 	.getsockopt = nrf91_socket_offload_getsockopt,
 	.setsockopt = nrf91_socket_offload_setsockopt,
+	.getsockname = nrf91_socket_offload_getsockname,
 };
 
 static inline bool proto_is_secure(int proto)


### PR DESCRIPTION
This commit adds the missing implementation for
`getsockname`. The current implementation
always returns an error that indicates that the
functionality is not implemented.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>