### PR TITLE
samples: nrf9160: modem_shell: fix for stopping GNSS in periodic mode

### DIFF
--- a/samples/nrf9160/modem_shell/src/gnss/gnss.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss.c
@@ -166,7 +166,7 @@ static void gnss_event_handler(int event_id)
 		 */
 		if (operation_mode == GNSS_OP_MODE_PERIODIC_FIX) {
 			k_work_cancel_delayable(&gnss_timeout_work);
-			k_work_submit_to_queue(&mosh_common_work_q, &gnss_stop_work);
+			k_work_submit(&gnss_stop_work);
 		}
 		break;
 
@@ -706,14 +706,10 @@ static void start_gnss_work_fn(struct k_work *item)
 		}
 	}
 
-	k_work_schedule_for_queue(&mosh_common_work_q,
-				  &gnss_start_work,
-				  K_SECONDS(periodic_fix_interval));
+	k_work_schedule(&gnss_start_work, K_SECONDS(periodic_fix_interval));
 
 	if (periodic_fix_retry > 0 && periodic_fix_retry < periodic_fix_interval) {
-		k_work_schedule_for_queue(&mosh_common_work_q,
-					  &gnss_timeout_work,
-					  K_SECONDS(periodic_fix_retry));
+		k_work_schedule(&gnss_timeout_work, K_SECONDS(periodic_fix_retry));
 	}
 }
 
@@ -913,7 +909,7 @@ int gnss_start(void)
 	}
 
 	if (operation_mode == GNSS_OP_MODE_PERIODIC_FIX) {
-		k_work_schedule_for_queue(&mosh_common_work_q, &gnss_start_work, K_NO_WAIT);
+		k_work_schedule(&gnss_start_work, K_NO_WAIT);
 		return 0;
 	}
 


### PR DESCRIPTION
In application controlled GNSS periodic mode GNSS should be stopped as soon as it gets the first fix. However, when A-GPS or P-GPS data download was ongoing, stopping could be delayed because the used work queue was executing the download. This commit moves starting and stopping of GNSS from the modem_shell common work queue to the system work queue to prevent this kind of delay.

Fixes MOSH-343.