### PR TITLE
samples: app_event_manager: Add missing nRF5340 conf

### DIFF
--- a/samples/app_event_manager/sample.yaml
+++ b/samples/app_event_manager/sample.yaml
@@ -16,6 +16,8 @@ common:
     - qemu_cortex_m3
     - nrf52dk_nrf52832
     - nrf52840dk_nrf52840
+    - nrf5340dk_nrf5340_cpuapp
+    - nrf5340dk_nrf5340_cpuapp_ns
     - nrf9160dk_nrf9160_ns
     - nrf21540dk_nrf52840
 tests:


### PR DESCRIPTION
Add configuration for nRF5340 in secure and non secure variants.

Jira: NCSDK-17233.

Signed-off-by: Emil Obalski <Emil.Obalski@nordicsemi.no>