### PR TITLE
kconfig: manifest: remove downstream patch for offset

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -8,6 +8,12 @@ rsource "subsys/net/openthread/Kconfig.defconfig"
 
 menu "Nordic nRF Connect"
 
+# Override configuration from zephyr which sets this to 0x200 if MCUboot is
+# enabled (CONFIG_BOOTLOADER_MCUBOOT), since NCS use partition_manager to
+# get this offset intsead.
+config ROM_START_OFFSET
+	default 0 if PARTITION_MANAGER_ENABLED
+
 #
 # Provide a new choice to override the mbedtls_external library completely
 # and not have to provide a "dummy" path for the implementation

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: adc9392ed854b9a3de8c5d3040bb0013911d79e4
+      revision: 799065491e4d940e27e7331a4df856423067d5e0
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Set ROM_START_OFFSET to 0 unconditionally in nrf to override configuration from zephyr so that we don't need a downstream patch for this.

We don't use ROM_START_OFFSET in NCS since partition manager is used for this purpose.

Ref: NCSDK-11993
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>