### PR TITLE
bluetooth: fast_pair: Fix parsing Key-based Pairing request

### DIFF
--- a/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
+++ b/subsys/bluetooth/services/fast_pair/fp_gatt_service.c
@@ -163,7 +163,7 @@ static int parse_key_based_pairing_req(const struct bt_conn *conn,
 		err = -EINVAL;
 	}
 
-	return 0;
+	return err;
 }
 
 static int handle_key_based_pairing_req(struct bt_conn *conn,


### PR DESCRIPTION
Change fixes parsing Key-based Pairing request. An error must be reported also in case invalid address is included in the message.