### PR TITLE
bluetooth: fast_pair: Disable automatic security re-establishment

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
@@ -87,6 +87,12 @@ Because of this requirement, the default values of the following Kconfig options
    In case of :ref:`nRF53 Series <ug_nrf53>`, this part of the configuration cannot be automatically updated for the network core and you must manually align it.
    The listed options must be set on the network core to default values specified by the GFPS Kconfig options.
 
+Security re-establishment
+-------------------------
+
+By default, the Fast Pair service disables the automatic security re-establishment request as a peripheral (:kconfig:option:`CONFIG_BT_GATT_AUTO_SEC_REQ`).
+This is done to allow Fast Pair Seeker to control the security re-establishment.
+
 Partition Manager
 -----------------
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -254,6 +254,10 @@ See `Bluetooth mesh samples`_ for the list of changes for the Bluetooth mesh sam
 
   * Added the ability to use the module when the Bluetooth Observer role is enabled.
 
+* :ref:`bt_fast_pair_readme` service:
+
+  * Disabled automatic security re-establishment request as a peripheral (:kconfig:option:`CONFIG_BT_GATT_AUTO_SEC_REQ`) to allow the Fast Pair Seeker to control the security re-establishment.
+
 Bootloader libraries
 --------------------
 

--- a/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
+++ b/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
@@ -70,6 +70,12 @@ config BT_FAST_PAIR_GATT_SERVICE
 
 if BT_FAST_PAIR_GATT_SERVICE
 
+config BT_GATT_AUTO_SEC_REQ
+	default n
+	help
+	  Disable automatic security re-establishment request as a peripheral
+	  to allow Fast Pair Seeker to control the security re-establishment.
+
 config BT_L2CAP_TX_MTU
 	default 83
 	help


### PR DESCRIPTION
Change disables automatic security re-establishment request as a peripheral to allow Fast Pair Seeker to control the security re-establishment.

Jira: NCSDK-17264