### PR TITLE
CODEOWNERS: modem info test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -218,6 +218,7 @@ Kconfig*                                  @tejlmand
 /tests/lib/location/                      @trantanen @hiltunent @jhirsi @tokangas
 /tests/lib/lte_lc/                        @jtguggedal @tokangas @simensrostad
 /tests/lib/modem_jwt/                     @SeppoTakalo
+/tests/lib/modem_info/                    @maxd-nordic
 /tests/lib/qos/                           @simensrostad
 /tests/lib/sms/                           @trantanen @tokangas
 /tests/lib/nrf_modem_lib/                 @lemrey @MirkoCovizzi


### PR DESCRIPTION
Add modem info test codeowners, as a result of merging this PR:
https://github.com/nrfconnect/sdk-nrf/pull/8305