### PR TITLE
CODEOWNERS: sensor manager test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -231,7 +231,7 @@ Kconfig*                                  @tejlmand
 /tests/subsys/bluetooth/mesh/             @ludvigsj
 /tests/subsys/bluetooth/fast_pair/        @MarekPieta @kapi-no @KAGA164
 /tests/subsys/bootloader/                 @hakonfam
-/tests/subsys/caf/sensor_data_aggregator/ @zycz
+/tests/subsys/caf/                        @zycz
 /tests/subsys/debug/cpu_load/             @nordic-krch
 /tests/subsys/dfu/                        @hakonfam @sigvartmh
 /tests/subsys/dfu/dfu_multi_image/        @Damian-Nordic


### PR DESCRIPTION
Add sensor manager test codeowners, as a result of merging this PR:
https://github.com/nrfconnect/sdk-nrf/pull/8830

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>