### PR TITLE
samples: nrf9160: lwm2m_client: Fix wrong level resource data type

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_buzzer.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_buzzer.c
@@ -46,7 +46,7 @@ static int buzzer_intensity_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t r
 			       uint8_t *data, uint16_t data_len, bool last_block, size_t total_size)
 {
 	int ret;
-	uint8_t intensity = *data;
+	uint8_t intensity = *(double *)data;
 
 	ret = ui_buzzer_set_intensity(intensity);
 	if (ret) {


### PR DESCRIPTION
Buzzer level resource 5548 data is double type instead of integer.

Signed-off-by: Charlie Shao <charlie.shao@nordicsemi.no>