### PR TITLE
lib: nrf_cloud: Make connection_poll_thread stack size adjustible

### DIFF
--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -30,12 +30,18 @@ If this API fails, the application must not use any APIs of the module.
 
 Connecting
 **********
-The application can use :c:func:`nrf_cloud_connect` to connect to the cloud.
+The application can use the :c:func:`nrf_cloud_connect` function to connect to the cloud.
 This API triggers a series of events and actions in the system.
 If the API fails, the application must retry to connect.
-If the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` Kconfig option is not enabled, the application should monitor the connection socket. :c:func:`nrf_cloud_connect` blocks and returns success when the MQTT connection to the cloud completes.
-If the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` Kconfig option is enabled, an nRF Cloud library thread monitors the connection socket. :c:func:`nrf_cloud_connect` does not block and returns success if the connection monitoring thread has started.
-When :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` is enabled, an additional event, :c:enum:`NRF_CLOUD_EVT_TRANSPORT_CONNECTING`, is sent to the application.
+
+If the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` Kconfig option is not enabled, the application should monitor the connection socket.
+The :c:func:`nrf_cloud_connect` function blocks and returns success when the MQTT connection to the cloud completes.
+
+If the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` Kconfig option is enabled, an nRF Cloud library thread monitors the connection socket.
+The :c:func:`nrf_cloud_connect` function does not block and returns success if the connection monitoring thread has started.
+
+When the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD` Kconfig option is enabled, an additional event, :c:enum:`NRF_CLOUD_EVT_TRANSPORT_CONNECTING`, is sent to the application.
+To adjust the stack size of the connection monitoring thread, set the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD_STACK_SIZE` Kconfig option.
 The status field of :c:struct:`nrf_cloud_evt` contains the connection status that is defined by :c:enumerator:`nrf_cloud_connect_result`.
 The event :c:enumerator:`NRF_CLOUD_EVT_TRANSPORT_DISCONNECTED` also contains additional information in the status field that is defined by :c:enumerator:`nrf_cloud_disconnect_status`.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -189,9 +189,11 @@ nRF9160 samples
 
     * Ability to use buttons to generate location assistance requests.
 
+* :ref:`nrf_cloud_rest_cell_pos_sample` sample:
+
   * Changed:
 
-   * :ref:`nrf_cloud_rest_cell_pos_sample` sample moved from :file:`samples/nrf9160/nrf_cloud_rest_cell_pos` to :file:`samples/nrf9160/nrf_cloud_rest_cell_location`.
+   * Sample moved from :file:`samples/nrf9160/nrf_cloud_rest_cell_pos` to :file:`samples/nrf9160/nrf_cloud_rest_cell_location`.
 
 Thread samples
 --------------

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -306,6 +306,12 @@ Libraries for networking
   * Updated the library so that it does not retry download on disconnect.
   * Fixed a race condition when starting the download.
 
+* :ref:`lib_nrf_cloud` library:
+
+  * Updated:
+
+    * The stack size of the MQTT connection monitoring thread can now be adjusted by setting the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD_STACK_SIZE` Kconfig option.
+
 Libraries for NFC
 -----------------
 

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_mqtt
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_mqtt
@@ -103,6 +103,16 @@ config NRF_CLOUD_CONNECTION_POLL_THREAD
 	bool "Poll cloud connection in a separate thread"
 	default y
 
+
+if NRF_CLOUD_CONNECTION_POLL_THREAD
+
+config NRF_CLOUD_CONNECTION_POLL_THREAD_STACK_SIZE
+	int "Stack size for nRF Cloud connection poll thread."
+	default 4096 if BOARD_QEMU_X86
+	default 3072
+
+endif
+
 config NRF_CLOUD_MQTT_KEEPALIVE
 	int "Maximum number of keep alive time for MQTT (in seconds)"
 	default 1200

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -591,13 +591,7 @@ reset:
 	k_sem_take(&connection_poll_sem, K_NO_WAIT);
 	goto start;
 }
-
-#ifdef CONFIG_BOARD_QEMU_X86
-#define POLL_THREAD_STACK_SIZE 4096
-#else
-#define POLL_THREAD_STACK_SIZE 3072
-#endif
-K_THREAD_DEFINE(nrfcloud_connection_poll_thread, POLL_THREAD_STACK_SIZE,
+K_THREAD_DEFINE(nrfcloud_connection_poll_thread, CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD_STACK_SIZE,
 		nrf_cloud_run, NULL, NULL, NULL,
 		K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
 #endif


### PR DESCRIPTION
Added `CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD_STACK_SIZE` KConfig option, which is now used to determine the stack size of `nrfcloud_connection_poll_thread`

IRIS-4765

Signed-off-by: Georges Oates_Larsen <georges.larsen@nordicsemi.no>