### PR TITLE
doc: sml: remove amazon frustration free setup row

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -32,7 +32,6 @@ features:
     Matter commissioning over Bluetooth LE with NFC onboarding: CHIP && BT && CHIP_NFC_COMMISSIONING
     Matter - OTA DFU over Bluetooth LE: CHIP && BT && MCUMGR_SMP_BT
     OTA DFU over Matter: CHIP && CHIP_OTA_REQUESTOR
-    Matter - Amazon Frustration Free Setup support: CHIP && BT && CHIP_ROTATING_DEVICE_ID && CHIP_COMMISSIONABLE_DEVICE_TYPE
     Matter Sleepy End Device: CHIP && CHIP_ENABLE_SLEEPY_END_DEVICE_SUPPORT && NET_L2_OPENTHREAD && OPENTHREAD_MTD_SED
   homekit:
     HomeKit over Bluetooth LE: HOMEKIT && BT && !CONFIG_HAP_HAVE_THREAD


### PR DESCRIPTION
Removed the row "Matter - Amazon Frustration Free Setup support" from the "Matter feature support" section.

Signed-off-by: Gaute Svanes Lunde <gaute.lunde@nordicsemi.no>