### PR TITLE
[wip] unity: first stage in creating a ncs_unity module

### DIFF
--- a/tests/unity/src/generic_teardown.c
+++ b/tests/unity/src/generic_teardown.c
@@ -8,7 +8,7 @@
  * @file
  * @brief Additional Unity support code for the native_posix board.
  */
-#include <zephyr/kernel.h>
+//#include <zephyr/kernel.h>
 #ifdef CONFIG_BOARD_NATIVE_POSIX
 #include "posix_board_if.h"
 #endif
@@ -20,8 +20,8 @@ int generic_suiteTearDown(int num_failures)
 	/* Sanitycheck bases the result of native_posix based unit tests on the
 	 * output:
 	 */
-	printk("PROJECT EXECUTION %s\n",
-	       num_failures == 0 ? "SUCCESSFUL" : "FAILED");
+//	printk("PROJECT EXECUTION %s\n",
+//	       num_failures == 0 ? "SUCCESSFUL" : "FAILED");
 
 #ifdef CONFIG_BOARD_NATIVE_POSIX
 	/* The native posix board will loop forever after leaving the runner's
@@ -36,7 +36,6 @@ int generic_suiteTearDown(int num_failures)
 	return ret;
 }
 
-__weak int test_suiteTearDown(int num_failures)
-{
+ __attribute__((__weak__)) int test_suiteTearDown(int num_failures ){
 	return generic_suiteTearDown(num_failures);
 }

--- a/tests/unity/wrap_test/CMakeLists.txt
+++ b/tests/unity/wrap_test/CMakeLists.txt
@@ -6,8 +6,18 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wrap_test)
+
+# add module test_code
+set(SOURCES src/test_code/test_code.c)
+
+# add module call
+list(APPEND SOURCES src/wrap_test.c)
+
+# add test file
+list(APPEND SOURCES src/call/call.c)
+
+find_package(Zephyr REQUIRED COMPONENTS ncs_unity unittest HINTS $ENV{ZEPHYR_BASE})
 
 # generate runner for the test
 test_runner_generate(src/wrap_test.c)
@@ -15,15 +25,9 @@ test_runner_generate(src/wrap_test.c)
 # create mocks for test_code functions
 cmock_handle(src/test_code/test_code.h test_code)
 
-# add module test_code
-target_sources(app PRIVATE src/test_code/test_code.c)
-target_include_directories(app PRIVATE src)
+target_include_directories(testbinary PRIVATE src)
 
-# add module call
-target_sources(app PRIVATE src/call/call.c)
-target_include_directories(app PRIVATE ./src/call)
+target_include_directories(testbinary PRIVATE ./src/call)
 
-# add test file
-target_sources(app PRIVATE src/wrap_test.c)
-target_include_directories(app PRIVATE .)
-target_include_directories(app PRIVATE src/test_code)
+target_include_directories(testbinary PRIVATE .)
+target_include_directories(testbinary PRIVATE src/test_code)

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 97c4a1a6d1bda83f0272d9bbf68b211efadc7b4a
+      revision: pull/921/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
NCS unity module allows to use unity with Zephyr board: unit_testing This provides a mechanism to do pure unit testing without dragging Zephyr kernel into the build.

This commit is work in progress.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>