### PR TITLE
manifest: sdk-hostap: Increase log buffer size for debugs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 6754055fca6c6d26795e5a21b00554ef891c8afc
+      revision: pull/27/head
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: v1.9.99-ncs2


### PR DESCRIPTION
Pull fix to increase log buffer size in case debug logs are enabled.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>