### PR TITLE
doc: add info on fota in bt mesh to nRF52/53 ug

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -62,7 +62,10 @@ For details, see :ref:`nrfxlib:softdevice_controller_changelog`.
 Bluetooth mesh
 --------------
 
-|no_changes_yet_note|
+* Added:
+
+  * Documentation page about :ref:`ug_bt_mesh_fota`.
+  * Documentation page about :ref:`ug_bt_mesh_node_removal`.
 
 See `Bluetooth mesh samples`_ for the list of changes for the Bluetooth mesh samples.
 
@@ -846,7 +849,6 @@ Documentation
   * :ref:`app_memory`: Configuration options affecting memory footprint for Bluetooth mesh, that can be used to optimize the application.
   * Documentation for the :ref:`lib_bh1749`.
   * The :ref:`ug_nrf52_gs` page.
-  * :ref:`ug_bt_mesh_node_removal` page in the :ref:`ug_bt_mesh` user guide.
 
 * Updated:
 
@@ -855,5 +857,6 @@ Documentation
   * Split the existing Working with the nRF52 Series information into :ref:`ug_nrf52_features` and :ref:`ug_nrf52_developing`.
   * :ref:`ug_tfm` with improved TF-M logging documentation on getting the secure output on nRF5340 DK.
   * :ref:`nrf_bt_scan_readme`, :ref:`ancs_client_readme`, :ref:`hogp_readme` and :ref:`lib_hrs_client_readme` libraries documentation to improve readability.
+  * Pages :ref:`ug_nrf52_developing` and :ref:`ug_nrf5340` with sections describing FOTA in Bluetooth mesh.
 
 .. |no_changes_yet_note| replace:: No changes since the latest |NCS| release.

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -57,10 +57,10 @@
 
 .. ### FOTA shortcuts
 
-.. |fota_upgrades_def| replace:: You can upgrade the firmware of the device over the air, thus without a wired connection.
-   Such an upgrade is called a FOTA (firmware over-the-air) upgrade.
+.. |fota_upgrades_def| replace:: You can update the firmware of the device over the air, thus without a wired connection.
+   Such an update is called a FOTA (firmware over-the-air) update.
 
-.. |fota_upgrades_building| replace:: To create a binary file for an application upgrade, build the application with the :kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` option enabled.
+.. |fota_upgrades_building| replace:: To create a binary file for an application update, build the application with the :kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` option enabled.
 
 .. ### VSC shortcuts
 

--- a/doc/nrf/ug_bt_mesh.rst
+++ b/doc/nrf/ug_bt_mesh.rst
@@ -30,6 +30,7 @@ Make also sure to check the official `Bluetooth mesh glossary`_.
    ug_bt_mesh_architecture.rst
    ug_bt_mesh_configuring.rst
    ug_bt_mesh_model_config_app.rst
+   ug_bt_mesh_fota.rst
    ug_bt_mesh_node_removal.rst
    ug_bt_mesh_vendor_model.rst
    ug_bt_mesh_reserved_ids.rst

--- a/doc/nrf/ug_bt_mesh_fota.rst
+++ b/doc/nrf/ug_bt_mesh_fota.rst
@@ -1,0 +1,75 @@
+.. _ug_bt_mesh_fota:
+
+Performing FOTA updates in Bluetooth mesh
+#########################################
+
+In |NCS|, there is currently no support for Device Firmware Update (DFU) over Bluetooth® mesh when performing firmware over-the-air (FOTA) updates for your Bluetooth mesh devices and applications.
+However, support for FOTA updates with point-to-point DFU over Bluetooth Low Energy using the MCUmgr subsystem and the Simple Management Protocol (SMP) is available.
+
+Following the instructions described in :ref:`FOTA over Bluetooth Low Energy<ug_nrf52_developing_ble_fota>`, you can enable the support for and perform FOTA updates using a mobile app.
+
+If the device's composition data is going to change after the FOTA update on a Bluetooth mesh device is performed, unprovision the device before downloading the new image.
+
+If you are using the `nRF Connect Device Manager`_ mobile app to perform FOTA updates, your Bluetooth mesh device might not be visible in the list of available devices.
+This happens if the device is not advertising the SMP service UUID and the filter that only shows devices advertising this service is enabled.
+The device can still be discovered through a service discovery, for example using the `nRF Connect for Mobile`_ app.
+See `Discovering Bluetooth mesh devices in nRF Connect Device Manager`_ for more details.
+
+FOTA in Bluetooth mesh samples
+******************************
+
+The :ref:`bluetooth_mesh_light` sample enables support for point-to-point DFU over Bluetooth Low Energy for nRF52 Series development kits.
+See the sample documentation for more details.
+
+Point-to-point DFU over Bluetooth Low Energy is supported by default, out-of-the-box, for all samples and applications compatible with :ref:`zephyr:thingy53_nrf5340`.
+See :ref:`thingy53_app_update` for more information about updating firmware image on :ref:`zephyr:thingy53_nrf5340`.
+For full list of samples and applications supported on :ref:`zephyr:thingy53_nrf5340`, see :ref:`thingy53_compatible_applications`.
+
+.. note::
+   If you are using the `nRF Connect Device Manager`_ mobile app to perform FOTA updates on :ref:`zephyr:thingy53_nrf5340`, your Bluetooth mesh device might not be visible in the list of available devices.
+
+Discovering Bluetooth mesh devices in nRF Connect Device Manager
+****************************************************************
+
+To make sure your device is visible in the `nRF Connect Device Manager`_ mobile app, do one of the following:
+
+* Disable the filter that only shows devices advertising the SMP service UUID in the `nRF Connect Device Manager`_ mobile app.
+* Make the device advertise the SMP service UUID, and thus be discoverable by the `nRF Connect Device Manager`_ mobile app with the filter enabled.
+
+Disabling the filter
+====================
+
+To disable the filter in the `nRF Connect Device Manager`_ mobile app, do the following steps:
+
+1. Tap the :guilabel:`Filter` button at the right top corner of your screen.
+#. Deselect :guilabel:`Only devices advertising SMP UUID`.
+
+You should see the device appear in the list of devices.
+
+Advertising SMP UUID
+====================
+
+To make sure that your Bluetooth mesh device advertises the SMP service UUID, in addition to the instructions described in :ref:`FOTA over Bluetooth Low Energy<ug_nrf52_developing_ble_fota>`, do the following:
+
+1. Add the following code to your application:
+
+   .. literalinclude:: ../../samples/bluetooth/mesh/light/src/smp_dfu.c
+      :language: c
+      :start-after: include_startingpoint_light_smp_dfu_rst_1
+      :end-before: include_endpoint_light_smp_dfu_rst_1
+
+#. Register Bluetooth connection callbacks and call ``smp_service_adv_init`` after Bluetooth is initialized:
+
+   ..literalinclude:: ../../samples/bluetooth/mesh/light/src/smp_dfu.c
+     :language: c
+	 :start-after: include_startingpoint_light_smp_dfu_rst_2
+	 :end-before: include_endpoint_light_smp_dfu_rst_2
+
+#. Increase the following configuration option values by one in the :file:`prj.conf` file of your application:
+
+   * Number of advertising sets (see :kconfig:option:`CONFIG_BT_EXT_ADV_MAX_ADV_SET`).
+   * The maximum number of allowed connections (see :kconfig:option:`CONFIG_BT_MAX_CONN`).
+   * The maximum number of local identities (see :kconfig:option:`CONFIG_BT_ID_MAX`).
+
+This will make the device discoverable by the `nRF Connect Device Manager`_ mobile app with the :guilabel:`Only devices advertising SMP UUID` filter enabled.
+Observe that the device appears in the list of devices in the mobile app.

--- a/doc/nrf/ug_nrf52_developing.rst
+++ b/doc/nrf/ug_nrf52_developing.rst
@@ -19,13 +19,14 @@ See one of the following guides for detailed information about the corresponding
 To get started with your nRF52 Series DK, follow the steps in the :ref:`ug_nrf52_gs` section.
 If you are not familiar with the |NCS| and the development environment, see the :ref:`introductory documentation <getting_started>`.
 
+.. _ug_nrf52_developing_ble_fota:
 .. fota_upgrades_start
 
-FOTA upgrades
-*************
+FOTA updates
+************
 
 |fota_upgrades_def|
-You can also use FOTA upgrades to replace the application.
+You can also use FOTA updates to replace the application.
 
 .. note::
    For the possibility of introducing an upgradable bootloader, refer to :ref:`ug_bootloader_adding`.
@@ -33,7 +34,7 @@ You can also use FOTA upgrades to replace the application.
 FOTA over Bluetooth Low Energy
 ==============================
 
-To enable support for FOTA upgrades, do the following:
+To enable support for FOTA updates, do the following:
 
 * Use MCUboot as the upgradable bootloader (:kconfig:option:`CONFIG_BOOTLOADER_MCUBOOT` must be enabled).
   For more information, go to the :doc:`mcuboot:index-ncs` page.
@@ -45,7 +46,7 @@ To enable support for FOTA upgrades, do the following:
 
   After completing these steps, your application advertises the SMP Service with ``UUID 8D53DC1D-1DB7-4CD3-868B-8A527460AA84``.
 
-To perform a FOTA upgrade, complete the following steps:
+To perform a FOTA update, complete the following steps:
 
 1. Create a binary file that contains the new image.
 
@@ -54,20 +55,18 @@ To perform a FOTA upgrade, complete the following steps:
 #. Download the :file:`app_update.bin` image file to your device.
 
    .. note::
-      When performing FOTA upgrade on a Bluetooth mesh device and the device's composition data is going to change after the upgrade, unprovision the device before downloading the new image.
-
       nRF Connect for Desktop does not currently support the FOTA process.
 
-   Use `nRF Connect Device Manager`_, `nRF Connect for Mobile`_, or `nRF Toolbox`_ to upgrade your device with the new firmware.
+   Use `nRF Connect Device Manager`_, `nRF Connect for Mobile`_, or `nRF Toolbox`_ to update your device with the new firmware.
 
    a. Ensure that you can access the :file:`app_update.bin` image file from your phone or tablet.
    #. Connect to the device with the mobile app.
    #. Initiate the DFU process to transfer the image to the device.
 
-FOTA upgrade sample
-===================
+FOTA update sample
+==================
 
-The :ref:`zephyr:smp_svr_sample` demonstrates how to set up your project to support FOTA upgrades.
+The :ref:`zephyr:smp_svr_sample` demonstrates how to set up your project to support FOTA updates.
 
 The sample documentation is from the Zephyr project and is incompatible with the :ref:`ug_multi_image`.
 When working in the |NCS| environment, ignore the part of the sample documentation that describes the building and programming steps.
@@ -80,15 +79,26 @@ In |NCS|, you can build and program the :ref:`zephyr:smp_svr_sample` as any othe
     west flash
 
 Make sure to indicate the :file:`overlay-bt.conf` overlay configuration for the Bluetooth transport like in the command example.
-This configuration was carefully selected to achieve the maximum possible throughput of the FOTA upgrade transport over Bluetooth with the help of the following features:
+This configuration was carefully selected to achieve the maximum possible throughput of the FOTA update transport over Bluetooth with the help of the following features:
 
 * Bluetooth MTU - To increase the packet size of a single Bluetooth packet transmitted over the air (:kconfig:option:`CONFIG_BT_BUF_ACL_RX_SIZE` and others).
 * Bluetooth connection parameters - To adaptively change the connection interval and latency on the detection of the SMP service activity (:kconfig:option:`CONFIG_MCUMGR_SMP_BT_CONN_PARAM_CONTROL`).
 * MCUmgr packet reassembly - To allow exchange of large SMP packets (:kconfig:option:`CONFIG_MCUMGR_SMP_REASSEMBLY_BT`, :kconfig:option:`CONFIG_MCUMGR_BUF_SIZE` and others).
 
-Consider using these features in your project to speed up the FOTA upgrade process.
+Consider using these features in your project to speed up the FOTA update process.
 
 .. fota_upgrades_end
+
+.. _ug_nrf52_developing_fota_in_mesh:
+.. fota_upgrades_bt_mesh_start
+
+FOTA in Bluetooth mesh
+======================
+
+To perform FOTA update when working with the Bluetooth mesh protocol, use point-to-point Device Firmware Update (DFU) over Bluetooth Low Energy as described in `FOTA over Bluetooth Low Energy`_ above.
+See also :ref:`ug_bt_mesh_fota` for more details about FOTA in Bluetooth mesh.
+
+.. fota_upgrades_bt_mesh_end
 
 .. fota_upgrades_matter_start
 

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -527,6 +527,14 @@ See the following instructions.
    :end-before: fota_upgrades_end
 
 .. include:: ug_nrf52_developing.rst
+   :start-after: fota_upgrades_bt_mesh_start
+   :end-before: fota_upgrades_bt_mesh_end
+
+.. note::
+   Point-to-point DFU over Bluetooth Low Energy is supported by default, out-of-the-box, for all samples and applications compatible with :ref:`zephyr:thingy53_nrf5340`.
+   See :ref:`thingy53_app_update` for more information about updating firmware image on :ref:`zephyr:thingy53_nrf5340`.
+
+.. include:: ug_nrf52_developing.rst
    :start-after: fota_upgrades_matter_start
    :end-before: fota_upgrades_matter_end
 

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -38,21 +38,20 @@ DFU requirements
 The configuration overlay :file:`overlay-dfu.conf` enables DFU support in the application, and applies for the nRF52 series, including:
 
 * nrf52dk_nrf52832
-
 * nrf52840dk_nrf52840
-
 * nrf52833dk_nrf52833
+* nrf21540dk_nrf52840
 
-While this overlay configuration is only applicable for the nRF52 Series in this sample, DFU over SMP can be utilized on other platforms as well.
+While this overlay configuration is only applicable for the nRF52 Series in this sample, DFU over Bluetooth Low Energy can be utilized on other platforms as well.
 
 .. note::
-   Point-to-point DFU for :ref:`zephyr:thingy53_nrf5340` is supported by default.
+   Point-to-point DFU over Bluetooth Low Energy for :ref:`zephyr:thingy53_nrf5340` is supported by default.
    See :ref:`thingy53_app_update` for more information about updating firmware image on :ref:`zephyr:thingy53_nrf5340`.
 
 The DFU feature also requires a smartphone with Nordic Semiconductor's nRF Device Manager mobile app installed in one of the following versions:
 
-  * `nRF Device Manager mobile app for Android`_
-  * `nRF Device Manager mobile app for iOS`_
+* `nRF Device Manager mobile app for Android`_
+* `nRF Device Manager mobile app for iOS`_
 
 Overview
 ********
@@ -133,7 +132,7 @@ This sample is split into the following source files:
 DFU configuration
 =================
 
-To enable the DFU feature, set :makevar:`OVERLAY_CONFIG` to :file:`overlay-dfu.conf` when building the sample.
+To enable the DFU feature for the supported nRF52 Series development kits, set :makevar:`OVERLAY_CONFIG` to :file:`overlay-dfu.conf` when building the sample.
 For example, when building from the command line, use the following command:
 
   .. code-block:: console
@@ -188,8 +187,8 @@ Make sure to complete the configuration on each of the elements on the node to e
 Running DFU
 ===========
 
-After the sample is built with the :file:`overlay-dfu.conf` and programmed to your development kit, support for FOTA upgrades is enabled.
-See FOTA in Bluetooth mesh (link) for instructions on how to perform FOTA upgrade and initiate the DFU process.
+After the sample is built with the :file:`overlay-dfu.conf` and programmed to your development kit, support for FOTA update is enabled.
+See :ref:`FOTA over Bluetooth Low Energy<ug_nrf52_developing_ble_fota>` for instructions on how to perform FOTA update and initiate the DFU process.
 
 Dependencies
 ************

--- a/samples/bluetooth/mesh/light/src/smp_dfu.c
+++ b/samples/bluetooth/mesh/light/src/smp_dfu.c
@@ -10,6 +10,7 @@
 #include <os_mgmt/os_mgmt.h>
 #include <zephyr/mgmt/mcumgr/smp_bt.h>
 
+/* .. include_startingpoint_light_smp_dfu_rst_1 */
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 
@@ -141,6 +142,7 @@ int smp_service_adv_init(void)
 
 	return err;
 }
+/* .. include_endpoint_light_smp_dfu_rst_1 */
 
 int smp_dfu_init(void)
 {
@@ -156,6 +158,8 @@ int smp_dfu_init(void)
 		return err;
 	}
 
+
+/* .. include_startingpoint_light_smp_dfu_rst_2 */
 	bt_conn_cb_register(&conn_callbacks);
 
 	/**
@@ -164,5 +168,6 @@ int smp_dfu_init(void)
 	 * the SMP service.
 	 */
 	err = smp_service_adv_init();
+/* .. include_endpoint_light_smp_dfu_rst_2 */
 	return err;
 }


### PR DESCRIPTION
Updated nRF52 Series and nRF5340 ug with
Bluetooth mesh related FOTA info
(DFU over BLE, point-to-point)

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>