### PR TITLE
net: lib: azure_iot_hub: Fix issues suggested by static analysis

### DIFF
--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_dps.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub_dps.c
@@ -203,18 +203,18 @@ AZ_DPS_STATIC int dps_save_hostname(char *hostname_ptr, size_t hostname_len)
 	size_t buf_hostname_len = MIN(sizeof(assigned_hub_buf) - 1, hostname_len);
 
 	memcpy(assigned_hub_buf, hostname_ptr,  buf_hostname_len);
-	assigned_hub_buf[hostname_len] = '\0';
+	assigned_hub_buf[buf_hostname_len] = '\0';
 
 	dps_reg_ctx.assigned_hub = az_span_create(assigned_hub_buf, buf_hostname_len);
 
 	err = settings_save_one(DPS_SETTINGS_KEY "/" DPS_SETTINGS_HOSTNAME_LEN_KEY,
-				&hostname_len, sizeof(hostname_len));
+				&buf_hostname_len, sizeof(buf_hostname_len));
 	if (err) {
 		return err;
 	}
 
 	err = settings_save_one(DPS_SETTINGS_KEY "/" DPS_SETTINGS_HOSTNAME_KEY,
-				assigned_hub_buf, hostname_len);
+				assigned_hub_buf, buf_hostname_len);
 	if (err) {
 		return err;
 	}
@@ -238,13 +238,13 @@ AZ_DPS_STATIC int dps_save_device_id(char *device_id_ptr, size_t device_id_len)
 	dps_reg_ctx.assigned_device_id = az_span_create(assigned_device_id_buf, buf_device_id_len);
 
 	err = settings_save_one(DPS_SETTINGS_KEY "/" DPS_SETTINGS_DEVICE_ID_LEN_KEY,
-				&device_id_len, sizeof(device_id_len));
+				&buf_device_id_len, sizeof(buf_device_id_len));
 	if (err) {
 		return err;
 	}
 
 	err = settings_save_one(DPS_SETTINGS_KEY "/" DPS_SETTINGS_DEVICE_ID_KEY,
-				assigned_device_id_buf, device_id_len);
+				assigned_device_id_buf, buf_device_id_len);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
Use correct length variable when handling buffers to avoid
writing/reading past buffer actual length.