### PR TITLE
event_manager_proxy: Add delay after ipc_send error

### DIFF
--- a/subsys/event_manager_proxy/event_manager_proxy.c
+++ b/subsys/event_manager_proxy/event_manager_proxy.c
@@ -295,10 +295,11 @@ static int send_event_to_remote(struct emp_ipc_data *ipc, const struct app_event
 		if (ret >= 0) {
 			break;
 		}
+		k_usleep(1);
 	}
 
 	if (ret < 0) {
-		LOG_ERR("Cannot send event to remote %p", ipc);
+		LOG_ERR("Cannot send event to remote %p, err: %d", ipc, ret);
 		__ASSERT_NO_MSG(false);
 	}
 


### PR DESCRIPTION
This commit gives some small time for the remote core to process data if the error was detected.
Tests shows that during test adding just 1us here allows transfer to be finished in up to 2 retries.