### PR TITLE
doc: maturity: Explicitly document when security fixes are applied

### DIFF
--- a/doc/nrf/software_maturity.rst
+++ b/doc/nrf/software_maturity.rst
@@ -46,8 +46,8 @@ See the following table for more details:
      - Customer issues raised for experimental features on tagged |NCS| releases are handled by technical support on DevZone.
      - Not available.
    * - **Bug fixing**
-     - Reported critical bugs will be resolved in both ``main`` and the latest tagged versions.
-     - Bug fixes and improvements are not guaranteed to be applied.
+     - Reported critical bugs and security fixes will be resolved in both ``main`` and the latest tagged versions.
+     - Bug fixes, security fixes, and improvements are not guaranteed to be applied.
      - Not available.
    * - **Implementation completeness**
      - Complete implementation of the agreed features set.


### PR DESCRIPTION
Explicitly document that security fixes, like bug fixes, are not guaranteed to be applied for experimentally supported features.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>