### PR TITLE
samples: caf_sensor_manager: Define sensor stub test for multicore

### DIFF
--- a/samples/caf_sensor_manager/sample.yaml
+++ b/samples/caf_sensor_manager/sample.yaml
@@ -21,10 +21,9 @@ tests:
   sample.caf_sensor_manager.sensor_stub.correctness_test:
     build_only: false
     harness: console
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp qemu_cortex_m3
+    platform_allow: nrf52840dk_nrf52840 qemu_cortex_m3
     integration_platforms:
       - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
       - qemu_cortex_m3
     extra_args: remote_OVERLAY_CONFIG=sensor_stub_overlay.conf
     harness_config:
@@ -32,6 +31,20 @@ tests:
       ordered: true
       regex:
         - "sensor_stub_gen: READY"
+        - "main state:READY"
+        - "Send sensor buffer desc address:"
+        - "sensor_data_aggregator_release_buffer_event"
+  sample.caf_sensor_manager.sensor_stub_multicore.correctness_test:
+    build_only: false
+    harness: console
+    platform_allow: nrf5340dk_nrf5340_cpuapp
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    extra_args: remote_OVERLAY_CONFIG=sensor_stub_overlay.conf
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
         - "main state:READY"
         - "Send sensor buffer desc address:"
         - "sensor_data_aggregator_release_buffer_event"


### PR DESCRIPTION
When running sensor manager with sensor stub on other core it would not generate READY log that is expected by the single core test.

JIRA: NCSDK-16629