### PR TITLE
samples: bluetooth: peripheral_mds: Add new testing scenario

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -989,3 +989,6 @@
 .. _`GNU Project Debugger`: https://www.sourceware.org/gdb/
 
 .. _`SIGMA`: https://webee.technion.ac.il/~hugo/sigma-pdf.pdf
+
+.. _`nRF Memfault for Android`: https://play.google.com/store/apps/details?id=no.nordicsemi.memfault&hl=en&gl=ES
+.. _`nRF Memfault for iOS`: https://apps.apple.com/no/app/nrf-memfault/id1641119282?platform=iphone

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -191,6 +191,12 @@ Bluetooth samples
   * After the device reaches the maximum number of paired devices (:kconfig:option:`CONFIG_BT_MAX_PAIRED`), the device stops looking for new peers.
     Therefore, the Fast Pair payload is no longer included in the advertising data.
 
+* :ref:`peripheral_mds` sample:
+
+  * Changed:
+
+    * Added a documentation section about testing with the `nRF Memfault for Android`_ and the `nRF Memfault for iOS`_ mobile applications to the documentation.
+
 Bluetooth mesh samples
 ----------------------
 

--- a/samples/bluetooth/peripheral_mds/README.rst
+++ b/samples/bluetooth/peripheral_mds/README.rst
@@ -152,6 +152,35 @@ Before testing, ensure that your device is configured with the project key of yo
 
 |test_sample|
 
+Testing with nRF Memfault mobile applications
+---------------------------------------------
+
+You can use the `nRF Memfault for Android`_ or the `nRF Memfault for iOS`_ applications for testing the :ref:`mds_readme`.
+You can also use them for your custom applications using the Memfault Diagnostic Service.
+
+1. |connect_terminal_ANSI|
+#. Reset your development kit.
+#. Observe that the sample starts.
+#. On your mobile phone with access to the Internet, open the nRF Memfault application.
+#. In the mobile application, tap the :guilabel:`Start` button.
+#. Look for your device running the Memfault Diagnostic Service in the :guilabel:`Discovered devices` list.
+#. Select your device from the list.
+#. Tap :guilabel:`Connect` button to connect with your development kit.
+#. Wait for the application to establish connection with your development kit.
+
+   In the mobile application, observe that Memfault chunks are forwarded from your device to the Memfault Cloud.
+#. Return to the terminal and press Tab to confirm that the Memfault shell is working.
+   The shell commands available are displayed.
+
+   To learn about the Memfault shell commands, issue command ``mflt help``.
+#. Use the buttons to trigger Memfault crashes, traces and metrics collection.
+
+   See :ref:`peripheral_mds_user_interface` for details about button functions.
+#. Explore the Memfault user interface to see the errors and metrics sent from your device.
+#. When you have finished collecting diagnostic data, tap :guilabel:`Disconnect` to the close connection with your development kit.
+
+   As the bond information is preserved, you can tap :guilabel:`Connect` again to immediately reconnect to the device.
+
 Testing with Memfault WebBluetooth Client
 -----------------------------------------
 


### PR DESCRIPTION
This commit adds documentation section about testing the Peripheral MDS sample with the nRF Memfault
mobile applications for iOS and Android.