### PR TITLE
manifest: zephyr: i2c_shell: add command to set bus speed

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 731d4be8bb86159cbe48ea19998ba7451e70cef9
+      revision: pull/926/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit integrates zephyr with a new I2C_SHELL command to set i2c bus speed.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>