### PR TITLE
samples: matter: increase retransmission interval

### DIFF
--- a/samples/matter/light_bulb/src/chip_project_config.h
+++ b/samples/matter/light_bulb/src/chip_project_config.h
@@ -18,3 +18,10 @@
 /* Use a default pairing code if one hasn't been provisioned in flash. */
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+
+/*
+ * Switching from Thread child to router may cause a few second packet stall.
+ * Until this is improved in OpenThread we need to increase the retransmission
+ * interval to survive the stall.
+ */
+#define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (1000_ms32)


### PR DESCRIPTION
Switching from Thread child to router may cause a few second packet stall, so it is beneficial that Matter samples acting as Full Thread Devices advertise increased retransmission intervals to make commands more likely to succeed in such a case.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>