### PR TITLE
doc: Getting secure TF-M output on nRF5340 DK's

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -510,5 +510,6 @@ Documentation
   * :ref:`gs_assistant` steps to reflect the fact that the |nRFVSC| is the default recommended IDE.
   * :ref:`ug_matter_gs_adding_cluster` documentation with new code snippets to align it with the source code of refactored Matter template sample.
   * Split the existing Working with the nRF52 Series information into :ref:`ug_nrf52_features` and :ref:`ug_nrf52_developing`.
+  * :ref:`ug_tfm` with improved TF-M logging documentation on getting the secure output on nRF5340 DK.
 
 .. |no_changes_yet_note| replace:: No changes since the latest |NCS| release.

--- a/doc/nrf/ug_tfm.rst
+++ b/doc/nrf/ug_tfm.rst
@@ -101,12 +101,32 @@ Logging
 TF-M employs two UART interfaces for logging: one for the secure part (MCUboot and TF-M), and one for the non-secure application.
 The logs arrive on different COM ports on the host PC.
 
-.. note::
-   * On the nRF5340 DK v1.0.0, you must connect specific wires on the kit to receive secure logs on the host PC.
-     Specifically, wire the pins **P0.25** and **P0.26** of the **P2** connector respectively to **RxD** and **TxD**  of the **P24** connector.
-     See :ref:`logging_cpunet` on the Working with nRF5340 DK page for more information.
-   * On the nRF5340 DK v2.0.0, there is one fewer COM port than on v1.0.0, so the secure and non-secure UART peripheral must be wired to the same pins.
-     Specifically, wire the pins **P0.25** and **P0.26** to **P0.20** and **P0.22**, respectively.
+
+Virtual COM ports on the nRF5340 DK
+===================================
+
+On the nRF5340 DK v1.0.0, you must connect specific wires on the kit to receive secure logs on the host PC.
+Specifically, wire the pins **P0.25** and **P0.26** of the **P2** connector to **RxD** and **TxD** of the **P24** connector respectively.
+See :ref:`logging_cpunet` on the Working with nRF5340 DK page for more information.
+
+On the nRF5340 DK v2.0.0, there are only two virtual COM ports available.
+By default, one of the ports is used by the non-secure UART0 peripheral from the application and the other by the UART1 peripheral from the network core.
+
+There are several options to get UART output from the secure TF-M:
+
+* Disable the output for the network core and change the pins used by TF-M.
+  The network core will usually have an NCS child image.
+  To configure a child image, see Configuration of the child image section described in :ref:`ug_nrf5340_multi_image`.
+  To configure logging in an NCS image, see :ref:`ug_logging`.
+  To change the pins used by TF-M, the RXD (:kconfig:option:`CONFIG_TFM_UART1_RXD_PIN`) and TXD (:kconfig:option:`CONFIG_TFM_UART1_TXD_PIN`) Kconfig options in the application image can be set to **P1.00** (32) and **P1.01** (33).
+
+* The secure and non-secure UART peripherals can be wired to the same pins.
+  Specifically, physically wire together the pins **P0.25** and **P0.26** to **P0.20** and **P0.22**, respectively.
+
+* If the non-secure application, network core and TF-M outputs are all needed simultaneously, additional UART <-> USB hardware is needed.
+  A second nRF DK can be used if available.
+  Pin **P0.25** needs to be wired to the TXD pin, and **P0.26** to the RXD pin of the external hardware.
+  These pins will provide the secure TF-M output, while the two native COM ports of the DK will be used for the non-secure application and the network core output.
 
 Limitations
 ***********


### PR DESCRIPTION
Depending on which version of the nRF5340 DK is used there are several options to get logging output from the secure part of TF-M. So far not all of them were documented, including one that doesn't require wires.

Ref: NCSDK-16751

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>