### PR TITLE
net: lib: lwm2m_client_utils: Add support for X509 certificates

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -349,6 +349,11 @@ Libraries for networking
 
     * An unused parameter of the :c:func:`nrf_cloud_connect` function.
 
+* :ref:`lib_lwm2m_client_utils` library:
+
+  * Added support for using X509 certificates.
+
+
 Libraries for NFC
 -----------------
 

--- a/include/net/lwm2m_client_utils.h
+++ b/include/net/lwm2m_client_utils.h
@@ -69,10 +69,46 @@ struct modem_mode_change {
 int lwm2m_init_security(struct lwm2m_ctx *ctx, char *endpoint, struct modem_mode_change *mmode);
 
 /**
- * @brief Check if we already have client credentials stored
+ * @brief Set security object to PSK mode.
  *
- * @return true If we need bootstrap.
- * @return false If we already have client credentials.
+ * Any pointer can be given as a NULL, which means that data related to this field is set to
+ * zero legth in the engine. Effectively, it causes that relative data is not written into
+ * the modem. This can be used if the given data is already provisioned to the modem.
+ *
+ * @param sec_obj_inst Security object ID to modify.
+ * @param psk Pointer to PSK key, either in HEX or binary format.
+ * @param psk_len Length of data in PSK pointer.
+ * @param psk_is_hex True if PSK points to data in HEX format. False if the data is binary.
+ * @param psk_id PSK key ID in string format.
+ * @return Zero if success, negative error code otherwise.
+ */
+int lwm2m_security_set_psk(uint16_t sec_obj_inst, const void *psk, int psk_len, bool psk_is_hex,
+			   const char *psk_id);
+
+/**
+ * @brief Set security object to certificate mode.
+ *
+ * Any pointer can be given as a NULL, which means that data related to this field is set to
+ * zero legth in the engine. Effectively, it causes that relative data is not written into
+ * the modem. This can be used if the given data is already provisioned to the modem.
+ *
+ * @param sec_obj_inst Security object ID to modify.
+ * @param cert Pointer to certificate.
+ * @param cert_len Certificate length.
+ * @param private_key Pointer to private key.
+ * @param key_len Private key length.
+ * @param ca_chain Pointer to CA certificate or server certificate.
+ * @param ca_len CA chain length.
+ * @return Zero if success, negative error code otherwise.
+ */
+int lwm2m_security_set_certificate(uint16_t sec_obj_inst, const void *cert, int cert_len,
+				   const void *private_key, int key_len, const void *ca_chain,
+				   int ca_len);
+/**
+ * @brief Check if the client credentials are already stored.
+ *
+ * @return true If bootstrap is needed.
+ * @return false If client credentials are already available.
  */
 bool lwm2m_security_needs_bootstrap(void);
 

--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -204,15 +204,12 @@ static int lwm2m_setup(void)
 	lwm2m_app_init_device(imei_buf);
 	lwm2m_init_security(&client, endpoint_name, NULL);
 
-	if (IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) && sizeof(CONFIG_APP_LWM2M_PSK) > 1) {
+	if (sizeof(CONFIG_APP_LWM2M_PSK) > 1) {
 		/* Write hard-coded PSK key to engine */
-		char buf[1 + sizeof(CONFIG_APP_LWM2M_PSK) / 2];
-		size_t len = hex2bin(CONFIG_APP_LWM2M_PSK, sizeof(CONFIG_APP_LWM2M_PSK) - 1, buf,
-				     sizeof(buf));
-
 		/* First security instance is the right one, because in bootstrap mode, */
 		/* it is the bootstrap PSK. In normal mode, it is the server key */
-		lwm2m_engine_set_opaque("0/0/5", buf, len);
+		lwm2m_security_set_psk(0, CONFIG_APP_LWM2M_PSK, sizeof(CONFIG_APP_LWM2M_PSK), true,
+				       endpoint_name);
 	}
 
 #if defined(CONFIG_LWM2M_CLIENT_UTILS_FIRMWARE_UPDATE_OBJ_SUPPORT)

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
@@ -29,6 +29,12 @@ LOG_MODULE_REGISTER(lwm2m_security, CONFIG_LWM2M_CLIENT_UTILS_LOG_LEVEL);
 #define SERVER_SHORT_SERVER_ID 0
 #define SERVER_LIFETIME_ID 1
 
+enum security_mode {
+	SEC_MODE_PSK = 0,
+	SEC_MODE_CERTIFICATE = 2,
+	SEC_MODE_NO_SEC = 3,
+};
+
 static struct modem_mode_change mm;
 
 int lwm2m_modem_mode_cb(enum lte_lc_func_mode new_mode, void *user_data)
@@ -85,7 +91,12 @@ static int write_credential_type(int sec_obj_inst, int sec_tag, int res_id,
 	}
 
 	if (cred_len == 0) {
-		LOG_ERR("No credential on %s", pathstr);
+		bool exist;
+
+		modem_key_mgmt_exists(sec_tag, type, &exist);
+		if (exist) {
+			return -EEXIST;
+		}
 		return -ENOENT;
 	}
 
@@ -108,21 +119,139 @@ static int write_credential_type(int sec_obj_inst, int sec_tag, int res_id,
 	return 0;
 }
 
+static int write_sec_obj_to_sec_tag(int sec_obj_inst, int sec_tag, int mode)
+{
+	int ret;
+
+	if (mode == SEC_MODE_PSK) {
+		ret = write_credential_type(sec_obj_inst, sec_tag, SECURITY_CLIENT_PK_ID,
+					    MODEM_KEY_MGMT_CRED_TYPE_IDENTITY);
+		if (ret) {
+			goto out;
+		}
+
+		ret = write_credential_type(sec_obj_inst, sec_tag, SECURITY_SECRET_KEY_ID,
+					    MODEM_KEY_MGMT_CRED_TYPE_PSK);
+		if (ret) {
+			goto out;
+		}
+	} else if (mode == SEC_MODE_CERTIFICATE) {
+		/* Don't fail if we already have a given data in the modem and we did not receive
+		 * that as part of bootstrap. It might have been written as part of EST process.
+		 */
+		ret = write_credential_type(sec_obj_inst, sec_tag, SECURITY_SERVER_PK_ID,
+					    MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN);
+		if (ret && ret != -EEXIST) {
+			goto out;
+		}
+		ret = write_credential_type(sec_obj_inst, sec_tag, SECURITY_CLIENT_PK_ID,
+					    MODEM_KEY_MGMT_CRED_TYPE_PUBLIC_CERT);
+		if (ret && ret != -EEXIST) {
+			goto out;
+		}
+		ret = write_credential_type(sec_obj_inst, sec_tag, SECURITY_SECRET_KEY_ID,
+					    MODEM_KEY_MGMT_CRED_TYPE_PRIVATE_CERT);
+		if (ret && ret != -EEXIST) {
+			goto out;
+		}
+	} else {
+		ret = -ENOTSUP;
+	}
+out:
+	LOG_DBG("write_sec_obj_to_sec_tag(%d, %d, %d) ret = %d", sec_obj_inst, sec_tag, mode, ret);
+	return ret;
+}
+
+static int sec_mode(int sec_obj_inst)
+{
+	uint8_t mode;
+	char path[sizeof("0/0/0")];
+	int ret;
+
+	snprintk(path, sizeof(path), "0/%d/%d", sec_obj_inst, SECURITY_MODE_ID);
+	ret = lwm2m_engine_get_u8(path, &mode);
+	if (ret < 0) {
+		return ret;
+	}
+	return mode;
+}
+
 static bool sec_obj_has_credentials(int sec_obj_inst)
 {
 	int ret;
 	void *cred = NULL;
 	uint16_t cred_len;
-	char pathstr[sizeof("0/0/0")];
+	char path[sizeof("0/0/0")];
+	int mode;
 
-	snprintk(pathstr, sizeof(pathstr), "0/%d/%d", sec_obj_inst, SECURITY_SECRET_KEY_ID);
-	ret = lwm2m_engine_get_res_buf(pathstr, &cred, NULL, &cred_len, NULL);
-	if (ret < 0) {
-		LOG_ERR("Unable to get resource data for '%s'", pathstr);
+	mode = sec_mode(sec_obj_inst);
+	if (mode < 0) {
+		return false;
+	}
+	if (mode != SEC_MODE_CERTIFICATE && mode != SEC_MODE_PSK) {
 		return false;
 	}
 
+	snprintk(path, sizeof(path), "0/%d/%d", sec_obj_inst, SECURITY_CLIENT_PK_ID);
+	ret = lwm2m_engine_get_res_buf(path, &cred, NULL, &cred_len, NULL);
+	if (ret < 0) {
+		goto fail;
+	}
+	if (cred_len == 0) {
+		return false;
+	}
+	snprintk(path, sizeof(path), "0/%d/%d", sec_obj_inst, SECURITY_SECRET_KEY_ID);
+	ret = lwm2m_engine_get_res_buf(path, &cred, NULL, &cred_len, NULL);
+	if (ret < 0) {
+		goto fail;
+	}
+
 	return cred_len != 0;
+fail:
+	LOG_ERR("Unable to get resource data for '%s', rc = %d", path, ret);
+	return false;
+}
+
+static bool modem_has_credentials(int sec_tag, int mode)
+{
+	bool exist;
+	int ret;
+
+	if (mode == SEC_MODE_CERTIFICATE) {
+		bool val1, val2, val3;
+
+		ret = modem_key_mgmt_exists(sec_tag, MODEM_KEY_MGMT_CRED_TYPE_CA_CHAIN, &val1);
+		if (ret < 0) {
+			return false;
+		}
+		ret = modem_key_mgmt_exists(sec_tag, MODEM_KEY_MGMT_CRED_TYPE_PUBLIC_CERT, &val2);
+		if (ret < 0) {
+			return false;
+		}
+		ret = modem_key_mgmt_exists(sec_tag, MODEM_KEY_MGMT_CRED_TYPE_PRIVATE_CERT, &val3);
+		if (ret < 0) {
+			return false;
+		}
+		exist = val1 & val2 & val3;
+	} else if (mode == SEC_MODE_PSK) {
+		bool val1, val2;
+
+		ret = modem_key_mgmt_exists(sec_tag, MODEM_KEY_MGMT_CRED_TYPE_PSK, &val1);
+		if (ret < 0) {
+			return false;
+		}
+
+		ret = modem_key_mgmt_exists(sec_tag, MODEM_KEY_MGMT_CRED_TYPE_IDENTITY, &val2);
+		if (ret < 0) {
+			return false;
+		}
+		exist = val1 && val2;
+	} else if (mode == SEC_MODE_NO_SEC) {
+		return true;
+	} else {
+		return false;
+	}
+	return exist;
 }
 
 static int load_credentials_to_modem(struct lwm2m_ctx *ctx)
@@ -130,6 +259,7 @@ static int load_credentials_to_modem(struct lwm2m_ctx *ctx)
 	int ret;
 	bool exist;
 	bool has_credentials;
+	int mode;
 
 	if (ctx->bootstrap_mode) {
 		ctx->tls_tag = CONFIG_LWM2M_CLIENT_UTILS_BOOTSTRAP_TLS_TAG;
@@ -137,12 +267,12 @@ static int load_credentials_to_modem(struct lwm2m_ctx *ctx)
 		ctx->tls_tag = CONFIG_LWM2M_CLIENT_UTILS_SERVER_TLS_TAG;
 	}
 
-	ret = modem_key_mgmt_exists(ctx->tls_tag, MODEM_KEY_MGMT_CRED_TYPE_PSK, &exist);
-	if (ret < 0) {
-		LOG_ERR("modem_key_mgmt_exists() failed %d", ret);
-		return ret;
+	mode = sec_mode(ctx->sec_obj_inst);
+	if (mode < 0) {
+		return mode;
 	}
 
+	exist = modem_has_credentials(ctx->tls_tag, mode);
 	has_credentials = sec_obj_has_credentials(ctx->sec_obj_inst);
 
 	/* If we have credentials already in modem, and we have loaded settings from the flash
@@ -172,15 +302,9 @@ static int load_credentials_to_modem(struct lwm2m_ctx *ctx)
 		k_sleep(K_SECONDS(ret));
 	}
 
-	ret = write_credential_type(ctx->sec_obj_inst, ctx->tls_tag, SECURITY_CLIENT_PK_ID,
-				    MODEM_KEY_MGMT_CRED_TYPE_IDENTITY);
-	if (ret) {
-		goto out;
-	}
-
-	ret = write_credential_type(ctx->sec_obj_inst, ctx->tls_tag, SECURITY_SECRET_KEY_ID,
-				    MODEM_KEY_MGMT_CRED_TYPE_PSK);
-	if (ret) {
+	ret = write_sec_obj_to_sec_tag(ctx->sec_obj_inst, ctx->tls_tag, mode);
+	if (ret < 0) {
+		LOG_ERR("Failed to write credentials to modem, err %d", ret);
 		goto out;
 	}
 
@@ -190,21 +314,15 @@ static int load_credentials_to_modem(struct lwm2m_ctx *ctx)
 	 */
 	if (bootstrap_settings_loaded_inst != -1 &&
 	    sec_obj_has_credentials(bootstrap_settings_loaded_inst)) {
-		ret = write_credential_type(bootstrap_settings_loaded_inst,
-					    CONFIG_LWM2M_CLIENT_UTILS_BOOTSTRAP_TLS_TAG,
-					    SECURITY_CLIENT_PK_ID,
-					    MODEM_KEY_MGMT_CRED_TYPE_IDENTITY);
-		if (ret) {
+		int bs_mode = sec_mode(bootstrap_settings_loaded_inst);
+
+		ret = write_sec_obj_to_sec_tag(bootstrap_settings_loaded_inst,
+					       CONFIG_LWM2M_CLIENT_UTILS_BOOTSTRAP_TLS_TAG,
+					       bs_mode);
+		if (ret < 0) {
+			LOG_ERR("Failed to write Boostrap credentials to modem, err %d", ret);
 			goto out;
 		}
-
-		ret = write_credential_type(bootstrap_settings_loaded_inst,
-					    CONFIG_LWM2M_CLIENT_UTILS_BOOTSTRAP_TLS_TAG,
-					    SECURITY_SECRET_KEY_ID, MODEM_KEY_MGMT_CRED_TYPE_PSK);
-		if (ret) {
-			goto out;
-		}
-
 		/* Prevent rewriting the same key on next reconnect or next boostrap */
 		bootstrap_settings_loaded_inst = -1;
 	}
@@ -434,21 +552,7 @@ static int security_created(uint16_t id)
 
 static bool server_keys_exist_in_modem(void)
 {
-	int ret;
-	bool exist;
-
-	ret = modem_key_mgmt_exists(CONFIG_LWM2M_CLIENT_UTILS_SERVER_TLS_TAG,
-				    MODEM_KEY_MGMT_CRED_TYPE_PSK, &exist);
-	if (ret || !exist) {
-		return false;
-	}
-
-	ret = modem_key_mgmt_exists(CONFIG_LWM2M_CLIENT_UTILS_SERVER_TLS_TAG,
-				    MODEM_KEY_MGMT_CRED_TYPE_IDENTITY, &exist);
-	if (ret || !exist) {
-		return false;
-	}
-	return true;
+	return modem_has_credentials(CONFIG_LWM2M_CLIENT_UTILS_SERVER_TLS_TAG, SEC_MODE_PSK);
 }
 
 bool lwm2m_security_needs_bootstrap(void)
@@ -483,16 +587,13 @@ static int init_default_security_obj(struct lwm2m_ctx *ctx, char *endpoint)
 	lwm2m_engine_set_res_data_len(LWM2M_PATH(LWM2M_OBJECT_SECURITY_ID, 0,
 						 SECURITY_SERVER_URI_ID), server_url_len + 1);
 
-	/* Security Mode */
-	lwm2m_engine_set_u8(LWM2M_PATH(LWM2M_OBJECT_SECURITY_ID, 0, SECURITY_MODE_ID),
-			    IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) ? 0 : 3);
-#if defined(CONFIG_LWM2M_DTLS_SUPPORT)
-	/* Empty the PSK key as data length of uninitialized opaque resources is not zero */
-	lwm2m_engine_set_opaque(LWM2M_PATH(LWM2M_OBJECT_SECURITY_ID, 0, SECURITY_SECRET_KEY_ID),
-				NULL, 0);
-	lwm2m_engine_set_string(LWM2M_PATH(LWM2M_OBJECT_SECURITY_ID, 0, SECURITY_CLIENT_PK_ID),
-				endpoint);
-#endif /* CONFIG_LWM2M_DTLS_SUPPORT */
+	/* Security Mode, default to PSK with key written by application */
+	if (IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT)) {
+		lwm2m_security_set_psk(0, NULL, 0, false, endpoint);
+	} else {
+		lwm2m_engine_set_u8(LWM2M_PATH(LWM2M_OBJECT_SECURITY_ID, 0, SECURITY_MODE_ID),
+				    SEC_MODE_NO_SEC);
+	}
 
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 	/* Mark 1st instance of security object as a bootstrap server */
@@ -503,6 +604,87 @@ static int init_default_security_obj(struct lwm2m_ctx *ctx, char *endpoint)
 	lwm2m_engine_set_u16("1/0/0", 101);
 #endif
 	return 0;
+}
+
+static int lwm2m_security_set_opaque_res(uint16_t sec_obj_inst, uint16_t resource, const void *buf,
+					 int len)
+{
+	int rc;
+	char path[sizeof("0/10/10")];
+
+	rc = snprintk(path, sizeof(path), "0/%d/%d", sec_obj_inst, resource);
+	if (rc < 0 || rc >= sizeof(path)) {
+		return -EINVAL;
+	}
+
+	if (buf && len) {
+		return lwm2m_engine_set_opaque(path, (void *) buf, len);
+	} else {
+		return lwm2m_engine_set_res_data_len(path, 0);
+	}
+}
+
+static int lwm2m_security_set(uint16_t sec_obj_inst, uint8_t mode, const void *pubkey,
+			      int pubkeylen, const void *serverkey, int serverkeylen,
+			      const void *secretkey, int secretkeylen)
+{
+	int rc;
+
+	rc = lwm2m_security_set_opaque_res(sec_obj_inst, SECURITY_MODE_ID, &mode, sizeof(mode));
+	if (rc) {
+		return rc;
+	}
+
+	rc = lwm2m_security_set_opaque_res(sec_obj_inst, SECURITY_CLIENT_PK_ID, pubkey, pubkeylen);
+	if (rc) {
+		return rc;
+	}
+
+	rc = lwm2m_security_set_opaque_res(sec_obj_inst, SECURITY_SERVER_PK_ID, serverkey,
+					   serverkeylen);
+	if (rc) {
+		return rc;
+	}
+
+	rc = lwm2m_security_set_opaque_res(sec_obj_inst, SECURITY_SECRET_KEY_ID, secretkey,
+					   secretkeylen);
+	return rc;
+}
+
+int lwm2m_security_set_psk(uint16_t sec_obj_inst, const void *psk, int psk_len, bool psk_is_hex,
+			   const char *psk_id)
+{
+	char buf[1 + psk_len / 2];
+
+	if (!IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT)) {
+		return -ENOTSUP;
+	}
+
+	if (psk && psk_len && psk_is_hex) {
+		/* Need to skip the nul terminator from string */
+		size_t len = hex2bin(psk, psk_len - 1, buf, sizeof(buf));
+
+		if (len <= 0) {
+			return -EINVAL;
+		}
+
+		psk_len = len;
+		psk = buf;
+	}
+
+	return lwm2m_security_set(sec_obj_inst, SEC_MODE_PSK, psk_id, strlen(psk_id) + 1, NULL, 0,
+			      psk, psk_len);
+}
+
+int lwm2m_security_set_certificate(uint16_t sec_obj_inst, const void *cert, int cert_len,
+				   const void *private_key, int key_len, const void *ca_chain,
+				   int ca_len)
+{
+	if (!IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT)) {
+		return -ENOTSUP;
+	}
+	return lwm2m_security_set(sec_obj_inst, SEC_MODE_CERTIFICATE, cert, cert_len, ca_chain,
+				  ca_len, private_key, key_len);
 }
 
 int lwm2m_init_security(struct lwm2m_ctx *ctx, char *endpoint, struct modem_mode_change *mmode)


### PR DESCRIPTION
Also add hepler to set security object to a PSK mode. Now application may call

    lwm2m_security_set_psk(sec_obj_inst, psk_key, sizeof(psk_key),
                           true, endpoint_name);

Similarly, for X509 certificate mode, application with pre-provisioned keys in the modem, may call

    lwm2m_security_set_certificate(sec_obj_inst, NULL, 0,
                                   NULL, 0, NULL,0);

