### PR TITLE
manifest: Use out of tree cc3xx libraries

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: ef455434921b5a57801fcb6eeeacaf0839e32660
+      revision: pull/839/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Cmake change in nrfxlib to use custom nrfxlib libraries

Ref: NCSDK-17366
Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>