### PR TITLE
cmake: pass WEST_PYTHON to child image builds

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -333,6 +333,7 @@ function(add_child_image_from_source)
       NCS_TOOLCHAIN_VERSION
       PM_DOMAINS
       ${ACI_DOMAIN}_PM_DOMAIN_DYNAMIC_PARTITION
+      WEST_PYTHON
       )
 
     foreach(kconfig_target ${EXTRA_KCONFIG_TARGETS})


### PR DESCRIPTION
Without this, child images keep picking up my system python and then complaining about `yaml` module not being present.