### PR TITLE
manifest: fix comment typo

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -74,7 +74,7 @@ manifest:
           - fatfs
           - fff
           - hal_nordic
-          - hal_st # required for ST sensors (unrealted to STM32 MCUs)
+          - hal_st # required for ST sensors (unrelated to STM32 MCUs)
           - hal_wurthelektronik
           - liblc3
           - libmetal


### PR DESCRIPTION
Fix typo from commit e786c3acc96ea15c38d3588165398e0117d582f8.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>