### PR TITLE
manifest: nrfxlib sanity check for psa key attributes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 303b506ec891ae6505ff1467eb868cd71ef37405
+      revision: pull/841/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Includes a new sanity check in the psa-core that sanity checks if the given parameters of key type, size and algorithm are valid

Ref: NCSDK-17103

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>

test-sdk-nrf: sdk-nrf-pr-8959