### PR TITLE
net: lib: nrf_cloud: remove the parameter of nrf_cloud_connect function

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
 #include <zephyr/kernel.h>
 #include <net/nrf_cloud.h>
 #include <zephyr/net/mqtt.h>
@@ -348,7 +354,7 @@ int cloud_wrap_connect(void)
 {
 	int err;
 
-	err = nrf_cloud_connect(NULL);
+	err = nrf_cloud_connect();
 	if (err) {
 		LOG_ERR("nrf_cloud_connect, error: %d", err);
 		return err;

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -947,7 +947,7 @@ int handle_at_nrf_cloud(enum at_cmd_type cmd_type)
 				}
 				location_signify = (signify > 0);
 			}
-			err = nrf_cloud_connect(NULL);
+			err = nrf_cloud_connect();
 			if (err) {
 				LOG_ERR("Cloud connection failed, error: %d", err);
 			} else {

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -344,6 +344,10 @@ Libraries for networking
 
     * The stack size of the MQTT connection monitoring thread can now be adjusted by setting the :kconfig:option:`CONFIG_NRF_CLOUD_CONNECTION_POLL_THREAD_STACK_SIZE` Kconfig option.
 
+  * Removed:
+
+    * An unused parameter of the :c:func:`nrf_cloud_connect` function.
+
 Libraries for NFC
 -----------------
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -570,11 +570,9 @@ int nrf_cloud_uninit(void);
  * If it is received before @ref NRF_CLOUD_EVT_TRANSPORT_CONNECTED,
  * the application may repeat the call to @ref nrf_cloud_connect to try again.
  *
- * @param[in] param Parameters to be used for the connection.
- *
  * @retval Connect result defined by enum nrf_cloud_connect_result.
  */
-int nrf_cloud_connect(const struct nrf_cloud_connect_param *param);
+int nrf_cloud_connect(void);
 
 /**
  * @brief Send sensor data reliably.

--- a/samples/nrf9160/lte_ble_gateway/src/main.c
+++ b/samples/nrf9160/lte_ble_gateway/src/main.c
@@ -442,19 +442,7 @@ static void cloud_connect(struct k_work *work)
 		return;
 	}
 
-	const enum nrf_cloud_sensor supported_sensors[] = {
-		NRF_CLOUD_SENSOR_GPS, NRF_CLOUD_SENSOR_FLIP
-	};
-
-	const struct nrf_cloud_sensor_list sensor_list = {
-		.size = ARRAY_SIZE(supported_sensors), .ptr = supported_sensors
-	};
-
-	const struct nrf_cloud_connect_param param = {
-		.sensor = &sensor_list,
-	};
-
-	err = nrf_cloud_connect(&param);
+	err = nrf_cloud_connect();
 	if (err) {
 		LOG_ERR("nrf_cloud_connect failed: %d", err);
 		nrf_cloud_error_handler(err);

--- a/samples/nrf9160/modem_shell/src/cloud/cloud_mqtt_shell.c
+++ b/samples/nrf9160/modem_shell/src/cloud/cloud_mqtt_shell.c
@@ -52,7 +52,7 @@ static int cloud_shell_print_usage(const struct shell *shell, size_t argc, char 
 
 static void cloud_reconnect_work_fn(struct k_work *work)
 {
-	int err = nrf_cloud_connect(NULL);
+	int err = nrf_cloud_connect();
 
 	if (err == NRF_CLOUD_CONNECT_RES_SUCCESS) {
 		mosh_print("Connecting to nRF Cloud...");

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/connection.c
@@ -614,7 +614,7 @@ static int connect_cloud(void)
 		LOG_INF("Next connection retry in %d seconds",
 			CONFIG_CLOUD_CONNECTION_RETRY_TIMEOUT_SECONDS);
 
-		err = nrf_cloud_connect(NULL);
+		err = nrf_cloud_connect();
 		if (err) {
 			LOG_ERR("cloud_connect, error: %d", err);
 		}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -229,7 +229,7 @@ static int connect_to_cloud(void)
 	return nct_connect();
 }
 
-int nrf_cloud_connect(const struct nrf_cloud_connect_param *param)
+int nrf_cloud_connect(void)
 {
 	int err;
 


### PR DESCRIPTION
Removed an unused parameter of the nrf_cloud_connect function and
refactored any applications, samples that use the function. The parameter
has only been used once in the lte_ble_gateway sample.

Signed-off-by: Tony Le <tony.le@nordicsemi.no>