### PR TITLE
samples: peripheral: lpuart: Exclude building for native_posix

### DIFF
--- a/samples/peripheral/lpuart/sample.yaml
+++ b/samples/peripheral/lpuart/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf9160dk_nrf9160_ns
       - nrf5340dk_nrf5340_cpuapp
       - nrf21540dk_nrf52840
+    platform_exclude: native_posix
 
   sample.peripheral.lpuart_nrf52840_debug:
     build_only: true


### PR DESCRIPTION
Excluded building this sample for native_posix as the existing filters dont result in twister excluding this sample from getting built for native_posix. When this happens the compilation would fail due to KConfig warnings related to missing UART in native_posix platform.

This was caught by the workflow run in this PR -> https://github.com/nrfconnect/sdk-nrf/pull/7532

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>