### PR TITLE
tests: lib: nrf_modem_lib: nrf91_sockets: fix test case and CI

### DIFF
--- a/tests/lib/nrf_modem_lib/nrf91_sockets/src/nrf91_sockets_test.c
+++ b/tests/lib/nrf_modem_lib/nrf91_sockets/src/nrf91_sockets_test.c
@@ -642,7 +642,7 @@ void test_nrf91_socket_offload_accept_addr_null_addrlen_null_error(void)
 	TEST_ASSERT_EQUAL(ret, 0);
 }
 
-void test_nrf91_socket_offload_accept_addr_not_null_addrlen_not_null_wrong_family(void)
+void test_nrf91_socket_offload_accept_addr_not_null_addrlen_not_null_enotsup(void)
 {
 	int ret;
 	int fd;
@@ -673,17 +673,17 @@ void test_nrf91_socket_offload_accept_addr_not_null_addrlen_not_null_wrong_famil
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_accept_ExpectAndReturn(nrf_fd, NULL, NULL, accept_fd);
-	__wrap_nrf_accept_IgnoreArg_address();
-	__wrap_nrf_accept_IgnoreArg_address_len();
-	__wrap_nrf_close_ExpectAndReturn(accept_fd, 0);
-
 	/* Modifying value to a wrong one to trigger the error case */
-	address.sin_family = WRONG_VALUE;
+	test_state_nrf_accept.nrf_addr.sa_family = WRONG_VALUE;
+	test_state_nrf_accept.ret = accept_fd;
+
+	__wrap_nrf_accept_Stub(nrf_accept_stub);
+	__wrap_nrf_close_ExpectAndReturn(accept_fd, 0);
 
 	ret = accept(fd, (struct sockaddr *)&address, (socklen_t *)&addrlen);
 
 	TEST_ASSERT_EQUAL(ret, -1);
+	TEST_ASSERT_EQUAL(errno, ENOTSUP);
 	TEST_ASSERT_EQUAL(addrlen, addrlen_unchanged);
 
 	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);

--- a/tests/lib/nrf_modem_lib/nrf91_sockets/testcase.yaml
+++ b/tests/lib/nrf_modem_lib/nrf91_sockets/testcase.yaml
@@ -1,5 +1,6 @@
 tests:
   unity.nrf91_sockets_test:
+    platform_allow: native_posix
     tags: nrf_modem_lib
     integration_platforms:
       - native_posix


### PR DESCRIPTION
 tests: lib: nrf_modem_lib: nrf91_sockets: fix test

Rewritten a unit test to now properly flow into the expected
execution flow.

 tests: lib: nrf_modem_lib: nrf91_sockets: add platform allow

This commit adds missing `platform_allow` option in the
`testcase.yaml` file to properly limit execution to
`native_posix` only.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>