### PR TITLE
samples: data_forwarder: Do not test on boards without async UART

### DIFF
--- a/samples/edge_impulse/data_forwarder/sample.yaml
+++ b/samples/edge_impulse/data_forwarder/sample.yaml
@@ -10,4 +10,5 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
       - nrf9160dk_nrf9160_ns
+    platform_exclude: native_posix qemu_x86 qemu_cortex_m3
     tags: ci_build


### PR DESCRIPTION
The sample uses the UART async API and cannot run on boards that do not support it.