### PR TITLE
samples: app_event_manager: Fix test with shell on native_posix

### DIFF
--- a/samples/app_event_manager/sample.yaml
+++ b/samples/app_event_manager/sample.yaml
@@ -12,17 +12,33 @@ common:
       - "ack_event"
       - "Average value3: 45"
     type: multi_line
-  integration_platforms:
-    - qemu_cortex_m3
-    - nrf52dk_nrf52832
-    - nrf52840dk_nrf52840
-    - nrf5340dk_nrf5340_cpuapp
-    - nrf5340dk_nrf5340_cpuapp_ns
-    - nrf9160dk_nrf9160_ns
-    - nrf21540dk_nrf52840
 tests:
   sample.app_event_manager:
     build_only: false
+    integration_platforms:
+      - qemu_cortex_m3
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf9160dk_nrf9160_ns
+      - nrf21540dk_nrf52840
   sample.app_event_manager_shell:
     build_only: false
-    extra_args: CONFIG_SHELL=y
+    integration_platforms:
+      - qemu_cortex_m3
+      - nrf52dk_nrf52832
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf9160dk_nrf9160_ns
+      - nrf21540dk_nrf52840
+    extra_configs:
+      - CONFIG_SHELL=y
+    platform_exclude: native_posix
+  sample.app_event_manager_shell.native_posix:
+    build_only: false
+    extra_configs:
+      - CONFIG_SHELL=y
+      - CONFIG_NATIVE_UART_0_ON_STDINOUT=y
+    platform_allow: native_posix

--- a/subsys/app_event_manager/app_event_manager_shell.c
+++ b/subsys/app_event_manager/app_event_manager_shell.c
@@ -22,7 +22,7 @@ static int show_events(const struct shell *shell, size_t argc,
 
 		shell_fprintf(shell,
 			      SHELL_NORMAL,
-			      "%c %d:\t%s\n",
+			      "%c %zu:\t%s\n",
 			      (atomic_test_bit(_app_event_manager_event_display_bm.flags, ev_id)) ?
 				'E' : 'D',
 			      ev_id,


### PR DESCRIPTION
Change adds CONFIG_NATIVE_UART_0_ON_STDINOUT to redirect UART0. This allows twister to properly verify the logs.

Jira: NCSDK-17461