### PR TITLE
manifest: sdk-zephyr: Pull DHCP event fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: d4b8ac4db1ed463928126383281b1989d200653b
+      revision: pull/929/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix the net management maximum event size to include DHCP events.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>