### PR TITLE
bluetooth: fast_pair: Add Battery Notification extension

### DIFF
--- a/include/bluetooth/services/fast_pair.h
+++ b/include/bluetooth/services/fast_pair.h
@@ -20,7 +20,14 @@
 extern "C" {
 #endif
 
-/** @brief Fast Pair advertising mode. Used to generate advertising packet. */
+/** Value that denotes unknown battery level (see @ref bt_fast_pair_battery_value). */
+#define BT_FAST_PAIR_UNKNOWN_BATTERY_LEVEL	0x7f
+
+/** @brief Fast Pair advertising mode. Used to generate advertising packet.
+ *
+ * According to Fast Pair specification, when no Account Key has been saved on the device both Fast
+ * Pair not discoverable advertising modes result in the same advertising data.
+ */
 enum bt_fast_pair_adv_mode {
 	/** Fast Pair discoverable advertising. */
 	BT_FAST_PAIR_ADV_MODE_DISCOVERABLE,
@@ -34,14 +41,67 @@ enum bt_fast_pair_adv_mode {
 	BT_FAST_PAIR_ADV_MODE_COUNT
 };
 
+/** @brief Fast Pair advertising battery mode. Used to generate advertising packet.
+ *
+ * Battery data can be included in advertising packet only if the Fast Pair Provider is in Fast Pair
+ * not discoverable advertising mode. To prevent tracking, the Fast Pair Provider should not include
+ * battery data in the advertising packet all the time.
+ */
+enum bt_fast_pair_adv_battery_mode {
+	/** Do not advertise battery data. */
+	BT_FAST_PAIR_ADV_BATTERY_MODE_NONE,
+
+	/** Show battery data UI indication. */
+	BT_FAST_PAIR_ADV_BATTERY_MODE_SHOW_UI_IND,
+
+	/** Hide battery data UI indication. */
+	BT_FAST_PAIR_ADV_BATTERY_MODE_HIDE_UI_IND,
+	/** Number of Fast Pair advertising battery modes. */
+	BT_FAST_PAIR_ADV_BATTERY_MODE_COUNT
+};
+
+/** @brief Fast Pair advertising info. Used to generate advertising packet. */
+struct bt_fast_pair_adv_info {
+	/** Fast Pair advertising mode. */
+	enum bt_fast_pair_adv_mode adv_mode;
+
+	/** Fast Pair advertising battery mode. */
+	enum bt_fast_pair_adv_battery_mode adv_battery_mode;
+};
+
+/** @brief Fast Pair battery value related to single battery */
+struct bt_fast_pair_battery_value {
+	/** Battery status. True means that battery is charging and False means that battery is not
+	 *  charging.
+	 */
+	bool charging;
+
+	/** Battery level ranging from 0 to 100 percent. Use @ref BT_FAST_PAIR_UNKNOWN_BATTERY_LEVEL
+	 *  for unknown.
+	 */
+	uint8_t level;
+};
+
+/** @brief Fast Pair battery data related to all three batteries (left bud, right bud, case). */
+struct bt_fast_pair_battery_data {
+	/** Left bud. */
+	struct bt_fast_pair_battery_value left_bud;
+
+	/** Right bud. */
+	struct bt_fast_pair_battery_value right_bud;
+
+	/** Case. */
+	struct bt_fast_pair_battery_value bud_case;
+};
+
 /** Get Fast Pair advertising data buffer size.
  *
- * @param[in] fp_adv_mode	Fast Pair advertising mode.
+ * @param[in] fp_adv_info	Fast Pair advertising info.
  *
  * @return Fast Pair advertising data buffer size in bytes if the operation was successful.
  *         Otherwise zero is returned.
  */
-size_t bt_fast_pair_adv_data_size(enum bt_fast_pair_adv_mode fp_adv_mode);
+size_t bt_fast_pair_adv_data_size(struct bt_fast_pair_adv_info fp_adv_info);
 
 /** Fill Bluetooth advertising packet with Fast Pair advertising data.
  *
@@ -56,14 +116,12 @@ size_t bt_fast_pair_adv_data_size(enum bt_fast_pair_adv_mode fp_adv_mode);
  * @param[out] adv_data		Pointer to the Bluetooth advertising data structure to be filled.
  * @param[out] buf		Pointer to the buffer used to store Fast Pair advertising data.
  * @param[in]  buf_size		Size of the buffer used to store Fast Pair advertising data.
- * @param[in]  fp_adv_mode	Fast Pair advertising mode. According to Fast Pair specification,
- *				when no Account Key has been saved on the device both Fast Pair not
- *				discoverable advertising modes result in the same advertising data.
+ * @param[in]  fp_adv_info	Fast Pair advertising info.
  *
  * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
  */
 int bt_fast_pair_adv_data_fill(struct bt_data *adv_data, uint8_t *buf, size_t buf_size,
-			       enum bt_fast_pair_adv_mode fp_adv_mode);
+			       struct bt_fast_pair_adv_info fp_adv_info);
 
 /** Enable or disable Fast Pair pairing mode.
  *
@@ -76,6 +134,17 @@ int bt_fast_pair_adv_data_fill(struct bt_data *adv_data, uint8_t *buf, size_t bu
  * @param[in] pairing_mode Boolean indicating if device is in pairing mode.
  */
 void bt_fast_pair_set_pairing_mode(bool pairing_mode);
+
+/** Set or update battery data values.
+ *
+ * Battery data values may be used to generate advertising packet.
+ *
+ * @param[in] battery_data Battery data values.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if battery data is invalid.
+ */
+int bt_fast_pair_set_battery_data(struct bt_fast_pair_battery_data battery_data);
 
 #ifdef __cplusplus
 }

--- a/samples/bluetooth/peripheral_fast_pair/include/bt_adv_helper.h
+++ b/samples/bluetooth/peripheral_fast_pair/include/bt_adv_helper.h
@@ -28,11 +28,11 @@ extern "C" {
  *
  * The function handles also periodic RPA rotation and Fast Pair advertising data update.
  *
- * @param[in] fp_adv_mode	Fast Pair advertising mode.
+ * @param[in] fp_adv_info	Fast Pair advertising info.
  *
  * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
  */
-int bt_adv_helper_adv_start(enum bt_fast_pair_adv_mode fp_adv_mode);
+int bt_adv_helper_adv_start(struct bt_fast_pair_adv_info fp_adv_info);
 
 /** Stop Fast Pair sample advertising
  *

--- a/subsys/bluetooth/services/fast_pair/CMakeLists.txt
+++ b/subsys/bluetooth/services/fast_pair/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_AUTH		   fp_auth.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_GATT_SERVICE	   fp_gatt_service.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_KEYS		   fp_keys.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_REGISTRATION_DATA fp_registration_data.c)
+zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_BATTERY	   fp_battery.c)
 
 if(CONFIG_BT_FAST_PAIR_CRYPTO)
   add_subdirectory(fp_crypto)

--- a/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
+++ b/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
@@ -108,6 +108,12 @@ config BT_FAST_PAIR_REGISTRATION_DATA
 	help
 	  Add Fast Pair registration data source files.
 
+config BT_FAST_PAIR_BATTERY
+	bool
+	default y
+	help
+	  Add Fast Pair battery module source files.
+
 module = BT_FAST_PAIR
 module-str = Fast Pair Service
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/bluetooth/services/fast_pair/fp_advertising.c
+++ b/subsys/bluetooth/services/fast_pair/fp_advertising.c
@@ -10,6 +10,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 
 #include <bluetooth/services/fast_pair.h>
+#include "fp_battery.h"
 #include "fp_common.h"
 #include "fp_crypto.h"
 #include "fp_registration_data.h"
@@ -20,17 +21,25 @@
 #define FIELD_LEN_TYPE_SIZE			sizeof(uint8_t)
 #define ENCODE_FIELD_LEN_TYPE(len, type)	(((len) << TYPE_BITS) | (type))
 
+#define BATTERY_LEVEL_BITS			7
+#define BATTERY_VALUE_SIZE			sizeof(uint8_t)
+#define ENCODE_FIELD_BATTERY_STATUS_LEVEL(charging, level) \
+						(((charging) << BATTERY_LEVEL_BITS) | (level))
+
 enum fp_field_type {
-	FP_FIELD_TYPE_SHOW_UI_INDICATION = 0b0000,
-	FP_FIELD_TYPE_SALT		 = 0b0001,
-	FP_FIELD_TYPE_HIDE_UI_INDICATION = 0b0010,
+	FP_FIELD_TYPE_SHOW_UI_INDICATION	 = 0b0000,
+	FP_FIELD_TYPE_SALT			 = 0b0001,
+	FP_FIELD_TYPE_HIDE_UI_INDICATION	 = 0b0010,
+	FP_FIELD_TYPE_SHOW_BATTERY_UI_INDICATION = 0b0011,
+	FP_FIELD_TYPE_HIDE_BATTERY_UI_INDICATION = 0b0100,
 };
 
 static const uint16_t fast_pair_uuid = FP_SERVICE_UUID;
 static const uint8_t version_and_flags;
 static const uint8_t empty_account_key_list;
 
-static size_t bt_fast_pair_adv_data_size_non_discoverable(size_t account_key_cnt)
+static size_t bt_fast_pair_adv_data_size_non_discoverable(size_t account_key_cnt,
+							  struct bt_fast_pair_adv_info fp_adv_info)
 {
 	size_t res = 0;
 
@@ -48,6 +57,10 @@ static size_t bt_fast_pair_adv_data_size_non_discoverable(size_t account_key_cnt
 		res += sizeof(salt);
 	}
 
+	if (fp_adv_info.adv_battery_mode != BT_FAST_PAIR_ADV_BATTERY_MODE_NONE) {
+		res += FP_CRYPTO_BATTERY_INFO_LEN;
+	}
+
 	return res;
 }
 
@@ -56,12 +69,17 @@ static size_t bt_fast_pair_adv_data_size_discoverable(void)
 	return FP_REG_DATA_MODEL_ID_LEN;
 }
 
-size_t bt_fast_pair_adv_data_size(enum bt_fast_pair_adv_mode fp_adv_mode)
+size_t bt_fast_pair_adv_data_size(struct bt_fast_pair_adv_info fp_adv_info)
 {
 	int account_key_cnt = fp_storage_account_key_count();
 	size_t res = 0;
 
-	if ((fp_adv_mode >= BT_FAST_PAIR_ADV_MODE_COUNT) || (fp_adv_mode < 0)) {
+	if ((fp_adv_info.adv_mode >= BT_FAST_PAIR_ADV_MODE_COUNT) || (fp_adv_info.adv_mode < 0)) {
+		return 0;
+	}
+
+	if ((fp_adv_info.adv_battery_mode >= BT_FAST_PAIR_ADV_BATTERY_MODE_COUNT) ||
+	    (fp_adv_info.adv_battery_mode < 0)) {
 		return 0;
 	}
 
@@ -71,19 +89,63 @@ size_t bt_fast_pair_adv_data_size(enum bt_fast_pair_adv_mode fp_adv_mode)
 
 	res += sizeof(fast_pair_uuid);
 
-	if (fp_adv_mode == BT_FAST_PAIR_ADV_MODE_DISCOVERABLE) {
+	if (fp_adv_info.adv_mode == BT_FAST_PAIR_ADV_MODE_DISCOVERABLE) {
 		res += bt_fast_pair_adv_data_size_discoverable();
 	} else {
-		res += bt_fast_pair_adv_data_size_non_discoverable(account_key_cnt);
+		res += bt_fast_pair_adv_data_size_non_discoverable(account_key_cnt, fp_adv_info);
 	}
 
 	return res;
 }
 
-static int fp_adv_data_fill_non_discoverable(struct net_buf_simple *buf, size_t account_key_cnt,
-					     enum fp_field_type ak_filter_type)
+static void fp_adv_data_fill_battery_info(uint8_t *battery_info,
+					  enum fp_field_type battery_data_type)
 {
+	struct bt_fast_pair_battery_data battery_data = fp_battery_get_battery_data();
+	size_t battery_data_size = FP_CRYPTO_BATTERY_INFO_LEN - FIELD_LEN_TYPE_SIZE;
+	size_t pos = 0;
+
+	BUILD_ASSERT(sizeof(uint8_t) == FIELD_LEN_TYPE_SIZE);
+	__ASSERT_NO_MSG(battery_data_size <= BIT_MASK(LEN_BITS));
+	battery_info[pos] = ENCODE_FIELD_LEN_TYPE(battery_data_size, battery_data_type);
+	pos++;
+
+	BUILD_ASSERT(sizeof(uint8_t) == BATTERY_VALUE_SIZE);
+
+	__ASSERT_NO_MSG(battery_data.left_bud.level <= BIT_MASK(BATTERY_LEVEL_BITS));
+	battery_info[pos] = ENCODE_FIELD_BATTERY_STATUS_LEVEL(battery_data.left_bud.charging,
+							      battery_data.left_bud.level);
+	pos++;
+
+	__ASSERT_NO_MSG(battery_data.right_bud.level <= BIT_MASK(BATTERY_LEVEL_BITS));
+	battery_info[pos] = ENCODE_FIELD_BATTERY_STATUS_LEVEL(battery_data.right_bud.charging,
+							      battery_data.right_bud.level);
+	pos++;
+
+	__ASSERT_NO_MSG(battery_data.bud_case.level <= BIT_MASK(BATTERY_LEVEL_BITS));
+	battery_info[pos] = ENCODE_FIELD_BATTERY_STATUS_LEVEL(battery_data.bud_case.charging,
+							      battery_data.bud_case.level);
+}
+
+static int fp_adv_data_fill_non_discoverable(struct net_buf_simple *buf, size_t account_key_cnt,
+					     enum fp_field_type ak_filter_type,
+					     struct bt_fast_pair_adv_info fp_adv_info)
+{
+	uint8_t battery_info[FP_CRYPTO_BATTERY_INFO_LEN];
+
 	net_buf_simple_add_u8(buf, version_and_flags);
+
+	if (fp_adv_info.adv_battery_mode != BT_FAST_PAIR_ADV_BATTERY_MODE_NONE) {
+		enum fp_field_type battery_data_type;
+
+		if (fp_adv_info.adv_battery_mode == BT_FAST_PAIR_ADV_BATTERY_MODE_SHOW_UI_IND) {
+			battery_data_type = FP_FIELD_TYPE_SHOW_BATTERY_UI_INDICATION;
+		} else {
+			battery_data_type = FP_FIELD_TYPE_HIDE_BATTERY_UI_INDICATION;
+		}
+
+		fp_adv_data_fill_battery_info(battery_info, battery_data_type);
+	}
 
 	if (account_key_cnt == 0) {
 		net_buf_simple_add_u8(buf, empty_account_key_list);
@@ -113,14 +175,23 @@ static int fp_adv_data_fill_non_discoverable(struct net_buf_simple *buf, size_t 
 		__ASSERT_NO_MSG(ak_filter_size <= BIT_MASK(LEN_BITS));
 		net_buf_simple_add_u8(buf, ENCODE_FIELD_LEN_TYPE(ak_filter_size, ak_filter_type));
 
-		err = fp_crypto_account_key_filter(net_buf_simple_add(buf, ak_filter_size), ak,
-						   account_key_cnt, salt, NULL);
+		if (fp_adv_info.adv_battery_mode != BT_FAST_PAIR_ADV_BATTERY_MODE_NONE) {
+			err = fp_crypto_account_key_filter(net_buf_simple_add(buf, ak_filter_size),
+							   ak, account_key_cnt, salt, battery_info);
+		} else {
+			err = fp_crypto_account_key_filter(net_buf_simple_add(buf, ak_filter_size),
+							   ak, account_key_cnt, salt, NULL);
+		}
 		if (err) {
 			return err;
 		}
 
 		net_buf_simple_add_u8(buf, ENCODE_FIELD_LEN_TYPE(sizeof(salt), FP_FIELD_TYPE_SALT));
 		net_buf_simple_add_u8(buf, salt);
+	}
+
+	if (fp_adv_info.adv_battery_mode != BT_FAST_PAIR_ADV_BATTERY_MODE_NONE) {
+		net_buf_simple_add_mem(buf, battery_info, sizeof(battery_info));
 	}
 
 	return 0;
@@ -133,13 +204,22 @@ static int fp_adv_data_fill_discoverable(struct net_buf_simple *buf)
 }
 
 int bt_fast_pair_adv_data_fill(struct bt_data *bt_adv_data, uint8_t *buf, size_t buf_size,
-			       enum bt_fast_pair_adv_mode fp_adv_mode)
+			       struct bt_fast_pair_adv_info fp_adv_info)
 {
 	struct net_buf_simple nb;
 	int account_key_cnt = fp_storage_account_key_count();
-	size_t adv_data_len = bt_fast_pair_adv_data_size(fp_adv_mode);
+	size_t adv_data_len = bt_fast_pair_adv_data_size(fp_adv_info);
 	enum fp_field_type ak_filter_type;
 	int err;
+
+	if ((fp_adv_info.adv_mode >= BT_FAST_PAIR_ADV_MODE_COUNT) || (fp_adv_info.adv_mode < 0)) {
+		return -EINVAL;
+	}
+
+	if ((fp_adv_info.adv_battery_mode >= BT_FAST_PAIR_ADV_BATTERY_MODE_COUNT) ||
+	    (fp_adv_info.adv_battery_mode < 0)) {
+		return -EINVAL;
+	}
 
 	if ((adv_data_len == 0) || (account_key_cnt < 0)) {
 		return -ENODATA;
@@ -149,24 +229,21 @@ int bt_fast_pair_adv_data_fill(struct bt_data *bt_adv_data, uint8_t *buf, size_t
 		return -EINVAL;
 	}
 
-	if ((fp_adv_mode >= BT_FAST_PAIR_ADV_MODE_COUNT) || (fp_adv_mode < 0)) {
-		return -EINVAL;
-	}
-
 	net_buf_simple_init_with_data(&nb, buf, buf_size);
 	net_buf_simple_reset(&nb);
 
 	net_buf_simple_add_le16(&nb, fast_pair_uuid);
 
-	if (fp_adv_mode == BT_FAST_PAIR_ADV_MODE_DISCOVERABLE) {
+	if (fp_adv_info.adv_mode == BT_FAST_PAIR_ADV_MODE_DISCOVERABLE) {
 		err = fp_adv_data_fill_discoverable(&nb);
 	} else {
-		if (fp_adv_mode == BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_SHOW_UI_IND) {
+		if (fp_adv_info.adv_mode == BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_SHOW_UI_IND) {
 			ak_filter_type = FP_FIELD_TYPE_SHOW_UI_INDICATION;
 		} else {
 			ak_filter_type = FP_FIELD_TYPE_HIDE_UI_INDICATION;
 		}
-		err = fp_adv_data_fill_non_discoverable(&nb, account_key_cnt, ak_filter_type);
+		err = fp_adv_data_fill_non_discoverable(&nb, account_key_cnt, ak_filter_type,
+							fp_adv_info);
 	}
 
 	if (!err) {

--- a/subsys/bluetooth/services/fast_pair/fp_battery.c
+++ b/subsys/bluetooth/services/fast_pair/fp_battery.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <bluetooth/services/fast_pair.h>
+#include "fp_battery.h"
+
+
+static struct bt_fast_pair_battery_data fp_battery_data = {
+	.left_bud = { .charging = false, .level = BT_FAST_PAIR_UNKNOWN_BATTERY_LEVEL},
+	.right_bud = { .charging = false, .level = BT_FAST_PAIR_UNKNOWN_BATTERY_LEVEL},
+	.bud_case = { .charging = false, .level = BT_FAST_PAIR_UNKNOWN_BATTERY_LEVEL}
+	};
+
+
+static bool validate_battery_value(struct bt_fast_pair_battery_value battery_value)
+{
+	if ((battery_value.level > 100) &&
+	    (battery_value.level != BT_FAST_PAIR_UNKNOWN_BATTERY_LEVEL)) {
+		return false;
+	}
+
+	return true;
+}
+
+int bt_fast_pair_set_battery_data(struct bt_fast_pair_battery_data battery_data)
+{
+	if (!validate_battery_value(battery_data.left_bud)) {
+		return -EINVAL;
+	}
+
+	if (!validate_battery_value(battery_data.right_bud)) {
+		return -EINVAL;
+	}
+
+	if (!validate_battery_value(battery_data.bud_case)) {
+		return -EINVAL;
+	}
+
+	fp_battery_data = battery_data;
+
+	return 0;
+}
+
+struct bt_fast_pair_battery_data fp_battery_get_battery_data(void)
+{
+	return fp_battery_data;
+}

--- a/subsys/bluetooth/services/fast_pair/include/fp_battery.h
+++ b/subsys/bluetooth/services/fast_pair/include/fp_battery.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _FP_BATTERY_H_
+#define _FP_BATTERY_H_
+
+#include <bluetooth/services/fast_pair.h>
+
+/**
+ * @defgroup fp_battery Fast Pair battery
+ * @brief Internal API for Fast Pair battery module implementation
+ *
+ * Fast Pair battery module provides API for application to set battery data and for Fast Pair
+ * subsystem to get battery data and use it when generating advertising data.
+ *
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Get battery data.
+ *
+ * @return Battery data.
+ */
+struct bt_fast_pair_battery_data fp_battery_get_battery_data(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* _FP_BATTERY_H_ */


### PR DESCRIPTION
Adds support for Battery Notification Fast Pair extension. Adds the most basic usage in sample.
It should be expanded later on.

Jira: NCSDK-14074

Signed-off-by: Aleksander Strzebonski <aleksander.strzebonski@nordicsemi.no>