### PR TITLE
boards: add network interface for nRF boards

### DIFF
--- a/boards/arm/nrf52820dongle_nrf52820/nrf52820dongle_nrf52820.yaml
+++ b/boards/arm/nrf52820dongle_nrf52820/nrf52820dongle_nrf52820.yaml
@@ -8,3 +8,4 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+  - netif:openthread

--- a/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.yaml
+++ b/boards/arm/nrf52833dongle_nrf52833/nrf52833dongle_nrf52833.yaml
@@ -8,3 +8,4 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+  - netif:openthread

--- a/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.yaml
+++ b/boards/arm/nrf52840gmouse_nrf52840/nrf52840gmouse_nrf52840.yaml
@@ -11,3 +11,4 @@ supported:
   - usb_device
   - ble
   - ieee802154
+  - netif:openthread

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp.yaml
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp.yaml
@@ -17,3 +17,4 @@ supported:
   - watchdog
   - usb_cdc
   - usb_device
+  - netif:openthread

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
@@ -16,3 +16,4 @@ supported:
   - watchdog
   - usb_cdc
   - usb_device
+  - netif:openthread

--- a/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpuapp.yaml
+++ b/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpuapp.yaml
@@ -16,3 +16,4 @@ supported:
   - watchdog
   - usb_cdc
   - usb_device
+  - netif:openthread

--- a/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/arm/nrf7002dk_nrf5340/nrf7002dk_nrf5340_cpuapp_ns.yaml
@@ -14,3 +14,4 @@ supported:
   - watchdog
   - usb_cdc
   - usb_device
+  - netif:openthread

--- a/boards/arm/thingy91_nrf52840/thingy91_nrf52840.yaml
+++ b/boards/arm/thingy91_nrf52840/thingy91_nrf52840.yaml
@@ -12,3 +12,4 @@ supported:
   - usb_device
   - ble
   - ieee802154
+  - netif:openthread

--- a/boards/arm/thingy91_nrf9160/thingy91_nrf9160_ns.yaml
+++ b/boards/arm/thingy91_nrf9160/thingy91_nrf9160_ns.yaml
@@ -9,3 +9,4 @@ ram: 128
 flash: 256
 supported:
   - i2c
+  - netif:modem


### PR DESCRIPTION
Some test configurations are skipped due to missing information about support of network interface on the nRF boards. These changes add to files with boards specification information about support of the network interface.

Signed-off-by: Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>