### PR TITLE
drivers: wifi: Read request IEs in assoc response event

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_B/host_rpu_umac_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_B/host_rpu_umac_if.h
@@ -2885,6 +2885,8 @@ struct nrf_wifi_umac_event_mlme {
 	struct nrf_wifi_frame frame;
 	unsigned char mac_addr[NRF_WIFI_ETH_ADDR_LEN];
 	unsigned char wme_uapsd_queues;
+	unsigned int req_ie_len;
+	unsigned char req_ie[0];
 } __NRF_WIFI_PKD;
 
 #define NRF_WIFI_EVENT_CONNECT_STATUS_CODE_VALID (1 << 0)

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
@@ -342,6 +342,11 @@ void wifi_nrf_wpa_supp_event_proc_assoc_resp(void *if_priv,
 				(frame_len - 24 - sizeof(mgmt->u.assoc_resp));
 		}
 
+		if (assoc_resp->req_ie_len > 0) {
+			event.assoc_info.req_ies = (unsigned char *)assoc_resp->req_ie;
+			event.assoc_info.req_ies_len = assoc_resp->req_ie_len;
+		}
+
 	}
 
 	vif_ctx_zep->supp_callbk_fns.assoc_resp(vif_ctx_zep->supp_drv_if_ctx, &event, status);

--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 49fddb8f5bb9511cf8d9e56bf680576b26fe2fc8
+      revision: d92b1bd441b41a146f04fb658fd120b70000ac73
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 78fd7ff9f31d88b9119734965e2afdda0cb9689a


### PR DESCRIPTION
Reading request IEs in the assoc response event to identify the link mode.

Signed-off-by: Ravi Dondaputi <ravi.dondaputi@nordicsemi.no>