### PR TITLE
samples: peripheral_fast_pair: Document advertising providers

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/adv_prov.rst
+++ b/doc/nrf/libraries/bluetooth_services/adv_prov.rst
@@ -90,11 +90,12 @@ These options share a common Kconfig option prefix of ``CONFIG_BT_ADV_PROV_``.
 
 Among others, the following providers are available:
 
-* Advertising Flags (:kconfig:option:`CONFIG_BT_ADV_PROV_FLAGS`),
-* GAP Appearance (:kconfig:option:`CONFIG_BT_ADV_PROV_GAP_APPEARANCE`),
-* Microsoft Swift Pair (:kconfig:option:`CONFIG_BT_ADV_PROV_SWIFT_PAIR`),
-* TX Power (:kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER`).
-* Bluetooth device name (:kconfig:option:`CONFIG_BT_ADV_PROV_DEVICE_NAME`).
+* Advertising Flags (:kconfig:option:`CONFIG_BT_ADV_PROV_FLAGS`)
+* GAP Appearance (:kconfig:option:`CONFIG_BT_ADV_PROV_GAP_APPEARANCE`)
+* Microsoft Swift Pair (:kconfig:option:`CONFIG_BT_ADV_PROV_SWIFT_PAIR`)
+* Google Fast Pair (:kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR`)
+* TX Power (:kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER`)
+* Bluetooth device name (:kconfig:option:`CONFIG_BT_ADV_PROV_DEVICE_NAME`)
 
 For details about each advertising provider, see the Kconfig option description.
 
@@ -105,5 +106,15 @@ API documentation
 | Source files: :file:`subsys/bluetooth/adv_prov/`
 
 .. doxygengroup:: bt_le_adv_prov
+   :project: nrf
+   :members:
+
+Fast Pair provider API
+======================
+
+| Header file: :file:`include/bluetooth/adv_prov/fast_pair.h`
+| Source files: :file:`subsys/bluetooth/adv_prov/providers/fast_pair.c`
+
+.. doxygengroup:: bt_le_adv_prov_fast_pair
    :project: nrf
    :members:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -176,6 +176,12 @@ Bluetooth samples
   * Added terminal commands for selecting the role.
   * Updated the ASCII art used for showing progress to feature the current Nordic Semiconductor logo.
 
+* :ref:`peripheral_fast_pair` sample:
+
+  * Switched to using :ref:`bt_le_adv_prov_readme` to generate Bluetooth advertising and scan response data.
+  * After the device reaches the maximum number of paired devices (:kconfig:option:`CONFIG_BT_MAX_PAIRED`), the device stops looking for new peers.
+    Therefore, the Fast Pair payload is no longer included in the advertising data.
+
 Bluetooth mesh samples
 ----------------------
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -281,8 +281,16 @@ Bluetooth libraries and services
 
 * :ref:`bt_le_adv_prov_readme`:
 
-  * Added the :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` option to TX power advertising data provider (:kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER`).
-    The option adds a predefined value to the TX power, that is included in the advertising data.
+  * Added:
+
+    * Google Fast Pair advertising data provider (:kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR`).
+    * The :kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER_CORRECTION_VAL` option to TX power advertising data provider (:kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER`).
+      The option adds a predefined value to the TX power, that is included in the advertising data.
+    * The :kconfig:option:`CONFIG_BT_ADV_PROV_GAP_APPEARANCE_SD` option to GAP appearance data provider (:kconfig:option:`CONFIG_BT_ADV_PROV_GAP_APPEARANCE`).
+      The option can be used to move the GAP appearance value to the scan response data.
+    * The :kconfig:option:`CONFIG_BT_ADV_PROV_DEVICE_NAME_SD` option to Bluetooth device name data provider (:kconfig:option:`CONFIG_BT_ADV_PROV_DEVICE_NAME`).
+      The option can be used to move the Bluetooth device name to the advertising data.
+
   * Changed :c:member:`bt_le_adv_prov_adv_state.bond_cnt` to :c:member:`bt_le_adv_prov_adv_state.pairing_mode`.
     The information about whether the advertising device is looking for a new peer is more meaningful for the Bluetooth LE data providers.
 
@@ -301,6 +309,7 @@ See `Bluetooth mesh samples`_ for the list of changes for the Bluetooth mesh sam
 * :ref:`bt_fast_pair_readme` service:
 
   * Disabled automatic security re-establishment request as a peripheral (:kconfig:option:`CONFIG_BT_GATT_AUTO_SEC_REQ`) to allow the Fast Pair Seeker to control the security re-establishment.
+  * Added API to check Account Key presence (:c:func:`bt_fast_pair_has_account_key`).
 
 Bootloader libraries
 --------------------

--- a/doc/nrf/ug_bt_fast_pair.rst
+++ b/doc/nrf/ug_bt_fast_pair.rst
@@ -43,12 +43,12 @@ A device model must be registered with Google to work as a Fast Pair Provider.
 The data is used for procedures defined by the Fast Pair standard.
 
 Registering Fast Pair Provider
-------------------------------
+==============================
 
 See the official `Fast Pair Model Registration`_ documentation for information how to register the device and obtain the Model ID and Anti-Spoofing Public/Private Key pair.
 
 Provisioning registration data onto device
-------------------------------------------
+==========================================
 
 The Fast Pair standard requires provisioning the device with Model ID and Anti-Spoofing Private Key obtained during device model registration.
 In the |NCS|, the provisioning data is generated as a hexadecimal file using the :ref:`bt_fast_pair_provision_script`.
@@ -91,7 +91,13 @@ The Bluetooth privacy is selected by the Fast Pair service, but you must make su
 * The Resolvable Private Address (RPA) address is not rotated during discoverable advertising session.
 
 See the official `Fast Pair Advertising`_ documentation for detailed information about the requirements related to discoverable and not discoverable advertising.
-See :file:`samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c` for an example of the implementation.
+
+Fast Pair advertising data provider
+===================================
+
+The Fast Pair :ref:`advertising data provider <bt_le_adv_prov_readme>` (:kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR`) can be used to manage the Fast Pair advertising data.
+See :ref:`peripheral_fast_pair` for an example of using the provider in a sample.
+See :file:`subsys/bluetooth/adv_prov/providers/fast_pair.c` for provider implementation.
 
 .. rst-class:: numbered-step
 

--- a/include/bluetooth/adv_prov/fast_pair.h
+++ b/include/bluetooth/adv_prov/fast_pair.h
@@ -10,7 +10,7 @@
 #include <bluetooth/services/fast_pair.h>
 
 /**
- * @defgroup bt_adv_prov_fast_pair Fast Pair advertising data provider API
+ * @defgroup bt_le_adv_prov_fast_pair Fast Pair advertising data provider API
  * @brief Fast Pair advertising data provider API
  *
  * @{
@@ -27,7 +27,7 @@ extern "C" {
  *
  * @param[in] fp_adv_mode	Fast Pair advertising mode.
  */
-void bt_adv_prov_fast_pair_mode_set(enum bt_fast_pair_adv_mode fp_adv_mode);
+void bt_le_adv_prov_fast_pair_mode_set(enum bt_fast_pair_adv_mode fp_adv_mode);
 
 #ifdef __cplusplus
 }

--- a/samples/bluetooth/peripheral_fast_pair/README.rst
+++ b/samples/bluetooth/peripheral_fast_pair/README.rst
@@ -102,6 +102,9 @@ Button 1:
        * After 10 minutes of active advertising.
        * After a Bluetooth Central successfully pairs.
 
+       After the device reaches the maximum number of paired devices (:kconfig:option:`CONFIG_BT_MAX_PAIRED`), the device stops looking for new peers.
+       Therefore, the Fast Pair payload is no longer included in the advertising data.
+
 Button 2:
    Increases audio volume of the connected Bluetooth Central.
 
@@ -236,10 +239,35 @@ Test not discoverable advertising by completing `Testing`_ and the following add
 Dependencies
 ************
 
+The sample uses subsystems and firmware components available in the |NCS|.
+For details, see the sections below.
+
+Fast Pair GATT Service
+======================
+
 This sample uses the :ref:`bt_fast_pair_readme` and its dependencies and is configured to meet the requirements of the Fast Pair standard.
 See :ref:`ug_bt_fast_pair` for details about integrating Fast Pair in the |NCS|.
 
 The :ref:`bt_fast_pair_provision_script` is used by the build system to automatically generate the hexadecimal file that contains Fast Pair Model ID and Anti Spoofing Private Key.
+
+Bluetooth LE advertising data providers
+=======================================
+
+The :ref:`bt_le_adv_prov_readme` are used to generate Bluetooth advertising and scan response data.
+The sample uses the following providers to generate the advertising packet payload:
+
+* Advertising flags provider (:kconfig:option:`CONFIG_BT_ADV_PROV_FLAGS`)
+* TX power provider (:kconfig:option:`CONFIG_BT_ADV_PROV_TX_POWER`)
+* Google Fast Pair provider (:kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR`)
+* Sample-specific provider that appends UUID16 values of GATT Human Interface Device Service (HIDS) and GATT Battery Service (BAS)
+
+The sample uses the following providers to generate the scan response data:
+
+* Bluetooth device name provider (:kconfig:option:`CONFIG_BT_ADV_PROV_DEVICE_NAME`)
+* Generic Access Profile (GAP) appearance provider (:kconfig:option:`CONFIG_BT_ADV_PROV_GAP_APPEARANCE`)
+
+Other
+=====
 
 The sample also uses the following secure firmware component:
 

--- a/samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/bt_adv_helper.c
@@ -79,7 +79,7 @@ static int adv_start_internal(enum bt_fast_pair_adv_mode fp_adv_mode)
 	}
 
 	/* Set advertising mode of Fast Pair advertising data provider. */
-	bt_adv_prov_fast_pair_mode_set(fp_adv_mode);
+	bt_le_adv_prov_fast_pair_mode_set(fp_adv_mode);
 
 	size_t ad_len = bt_le_adv_prov_get_ad_prov_cnt();
 	size_t sd_len = bt_le_adv_prov_get_sd_prov_cnt();

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.gap_appearance
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.gap_appearance
@@ -7,7 +7,8 @@
 menuconfig BT_ADV_PROV_GAP_APPEARANCE
 	bool "GAP appearance"
 	help
-	  Adds GAP appearance to advertising data if device is in pairing mode.
+	  Adds Generic Access Profile (GAP) appearance to advertising data if
+	  device is in pairing mode.
 
 if BT_ADV_PROV_GAP_APPEARANCE
 

--- a/subsys/bluetooth/adv_prov/providers/fast_pair.c
+++ b/subsys/bluetooth/adv_prov/providers/fast_pair.c
@@ -12,7 +12,7 @@
 static enum bt_fast_pair_adv_mode set_fp_adv_mode = BT_FAST_PAIR_ADV_MODE_COUNT;
 
 
-void bt_adv_prov_fast_pair_mode_set(enum bt_fast_pair_adv_mode fp_adv_mode)
+void bt_le_adv_prov_fast_pair_mode_set(enum bt_fast_pair_adv_mode fp_adv_mode)
 {
 	set_fp_adv_mode = fp_adv_mode;
 }


### PR DESCRIPTION
PR adds documentation for using Bluetooth advertising data providers in the Fast Pair sample. PR also documents advertising data providers update needed to introduce the providers to Fast Pair sample and aligns the Fast Pair provider API prefix with advertising providers API.

Jira: NCSDK-16744