### PR TITLE
applications: nrf5340_audio: Walkie-talkie demo

### DIFF
--- a/applications/nrf5340_audio/Kconfig
+++ b/applications/nrf5340_audio/Kconfig
@@ -21,6 +21,7 @@ config AUDIO_DEV
 
 choice NRF5340_AUDIO_TRANSPORT_MODE
 	prompt "Choose BIS or CIS for ISO transport"
+	default TRANSPORT_CIS if WALKIE_TALKIE_DEMO
 	default TRANSPORT_CIS
 
 config TRANSPORT_BIS

--- a/applications/nrf5340_audio/README.rst
+++ b/applications/nrf5340_audio/README.rst
@@ -86,10 +86,14 @@ Connected Isochronous Stream (CIS)
   This is the default configuration of the nRF5340 Audio application.
   In this configuration, you can use the nRF5340 Audio development kit in the role of the gateway, the left headset, or the right headset.
 
+  In the current version of the nRF5340 Audio application, the CIS mode offers both unidirectional and bidirectional communication.
+  You can configure the CIS to bidirectional communication, in which it will support a walkie-talkie demonstration.
+  In the bidirectional communication, the headset device will send audio from the on-board PDM microphone.
+  In the walkie-talkie demonstration, the gateway device will send audio from the on-board PDM microphone instead of using the line-in.
+  See `Enabling the walkie-talkie demo`_ for more information.
+
   .. note::
-     In the current version of the nRF5340 Audio application, the CIS mode offers both unidirectional and bidirectional communication.
-     In the bidirectional mode, the headset device will send audio from the on-board PDM microphone.
-     Note that only one headset device can be connected when testing the bidirectional mode
+     Only one headset device can be connected when testing the bidirectional mode or the walkie-talkie demo.
 
 Broadcast Isochronous Stream (BIS)
   BIS is a unidirectional communication protocol that allows for broadcasting one or more audio streams from a source device to an unlimited number of receivers that are not connected to the source.
@@ -782,8 +786,16 @@ Selecting the CIS bidirectional communication
 The CIS unidirectional mode is the default operating mode for the application.
 You can switch to the bidirectional mode by adding the :kconfig:option:`CONFIG_STREAM_BIDIRECTIONAL` Kconfig option set to ``y``  to the :file:`prj.conf` file (for the debug version) or to the :file:`prj_release.conf` file (for the release version).
 
+.. _nrf53_audio_app_configuration_enable_walkie_talkie:
+
+Enabling the walkie-talkie demo
+-------------------------------
+
+The walkie-talkie demo is a bidirectional stream using the PDM microphone as input on each side.
+You can switch to using the walkie-talkie by adding the :kconfig:option:`CONFIG_WALKIE_TALKIE_DEMO` Kconfig option set to ``y``  to the :file:`prj.conf` file (for the debug version) or to the :file:`prj_release.conf` file (for the release version).
+
 .. note::
-   Only one headset can be connected when using the bidirectional mode.
+   Only one headset can be connected when using the bidirectional mode or the walkie-talkie demo.
 
 .. _nrf53_audio_app_configuration_select_i2s:
 
@@ -1239,6 +1251,17 @@ Testing the BIS mode is identical to `Testing the default CIS mode`_, except for
 * You must :ref:`select the BIS mode manually <nrf53_audio_app_configuration_select_bis>` before building the application.
 * You can play the audio stream with different audio settings on the receivers.
   For example, you can decrease or increase the volume separately for each receiver during playback.
+
+.. _nrf53_audio_app_testing_steps_cis_walkie_talkie:
+
+Testing the walkie-talkie demo
+------------------------------
+
+Testing the walkie-talkie demo is identical to `Testing the default CIS mode`_, except for the following differences:
+
+* You must enable the Kconfig option mentioned in `Enabling the walkie-talkie demo`_ before building the application.
+* Instead of controlling the playback, you can speak through the PDM microphones.
+  The line is open all the time, no need to press any buttons to talk, but the volume control works as in `Testing the default CIS mode`_.
 
 .. _nrf53_audio_app_porting_guide:
 

--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -88,6 +88,7 @@ config AUDIO_BIT_DEPTH_OCTETS
 
 choice AUDIO_SOURCE_GATEWAY
 	prompt "Audio source for gateway"
+	default AUDIO_SOURCE_I2S if WALKIE_TALKIE_DEMO
 	default AUDIO_SOURCE_USB
 	help
 	  Select audio source for the gateway.
@@ -202,6 +203,14 @@ config STREAM_BIDIRECTIONAL
 	help
 	  Bidirectional stream enables encoder and decoder on both sides,
 	  and one device can both send and receive audio.
+
+config WALKIE_TALKIE_DEMO
+	select STREAM_BIDIRECTIONAL
+	bool "Walkie talkie demo"
+	default n
+	help
+	  The walkie talkie demo will set up a bidirectional stream using PDM
+	  microphones on each side.
 
 endmenu # Stream
 

--- a/applications/nrf5340_audio/src/audio/streamctrl.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl.c
@@ -237,6 +237,10 @@ static void button_evt_handler(struct button_evt event)
 
 	switch (event.button_pin) {
 	case BUTTON_PLAY_PAUSE:
+		if (IS_ENABLED(CONFIG_WALKIE_TALKIE_DEMO)) {
+			LOG_DBG("Play/pause not supported in walkie-talkie mode");
+			return;
+		}
 		/* Starts/pauses the audio stream */
 		switch (strm_state) {
 		case STATE_PAUSED:
@@ -296,6 +300,10 @@ static void button_evt_handler(struct button_evt event)
 		break;
 
 	case BUTTON_TEST_TONE:
+		if (IS_ENABLED(CONFIG_WALKIE_TALKIE_DEMO)) {
+			LOG_DBG("Test tone not supported in walkie-talkie mode");
+			return;
+		}
 		switch (strm_state) {
 		case STATE_STREAMING:
 			if (CONFIG_AUDIO_BIT_DEPTH_BITS != 16) {

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
@@ -95,6 +95,7 @@ config BT_GAP_PERIPHERAL_PREF_PARAMS
 	default n
 
 config BT_VCS
+	default n if WALKIE_TALKIE_DEMO
 	default y
 
 config BT_PACS_SNK_CONTEXT
@@ -137,6 +138,7 @@ config BT_AUDIO_UNICAST_CLIENT_ASE_SRC_COUNT
 	default 0
 
 config BT_VCS_CLIENT
+	default n if WALKIE_TALKIE_DEMO
 	default y
 
 endif # AUDIO_DEV = 2 (GATEWAY)

--- a/applications/nrf5340_audio/src/bluetooth/ble_audio_services.c
+++ b/applications/nrf5340_audio/src/bluetooth/ble_audio_services.c
@@ -162,7 +162,8 @@ int ble_vcs_volume_up(void)
 #elif (CONFIG_BT_VCS)
 	return bt_vcs_unmute_vol_up(vcs);
 #endif /* (CONFIG_BT_VCS_CLIENT) */
-	return -ENXIO;
+	hw_codec_volume_increase();
+	return 0;
 }
 
 int ble_vcs_volume_down(void)
@@ -186,7 +187,8 @@ int ble_vcs_volume_down(void)
 #elif (CONFIG_BT_VCS)
 	return bt_vcs_unmute_vol_down(vcs);
 #endif /* (CONFIG_BT_VCS_CLIENT) */
-	return -ENXIO;
+	hw_codec_volume_decrease();
+	return 0;
 }
 
 int ble_vcs_volume_mute(void)

--- a/applications/nrf5340_audio/src/modules/hw_codec.c
+++ b/applications/nrf5340_audio/src/modules/hw_codec.c
@@ -255,9 +255,17 @@ int hw_codec_default_conf_enable(void)
 	}
 
 #if ((CONFIG_AUDIO_DEV == GATEWAY) && (CONFIG_AUDIO_SOURCE_I2S))
-	ret = cs47l63_comm_reg_conf_write(line_in_enable, ARRAY_SIZE(line_in_enable));
-	if (ret) {
-		return ret;
+	if (IS_ENABLED(CONFIG_WALKIE_TALKIE_DEMO)) {
+		ret = cs47l63_comm_reg_conf_write(pdm_mic_enable_configure,
+						  ARRAY_SIZE(pdm_mic_enable_configure));
+		if (ret) {
+			return ret;
+		}
+	} else {
+		ret = cs47l63_comm_reg_conf_write(line_in_enable, ARRAY_SIZE(line_in_enable));
+		if (ret) {
+			return ret;
+		}
 	}
 #endif /* ((CONFIG_AUDIO_DEV == GATEWAY) && (CONFIG_AUDIO_SOURCE_I2S)) */
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -129,6 +129,7 @@ nRF5340 Audio
   * Kconfig options for different sample rates and BAP presets.
   * Added Kconfig options for different sample rates and BAP presets.
   * Added bidirectional mode for the CIS mode.
+  * Added a walkie talkie demo for bidirectional CIS.
 
 * Updated:
 


### PR DESCRIPTION
- Create config for turning on walkie-talkie demo
- Eanbles I2S, STREAM_BIDIRECTIONAL and PDM mics

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>