### PR TITLE
applications: nrf5340_audio: Store channel_assignment in RAM

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -220,11 +220,8 @@ static void base_recv_cb(struct bt_audio_broadcast_sink *sink, const struct bt_a
 		return;
 	}
 
-	ret = channel_assignment_get(&channel);
-	if (ret) {
-		/* Channel is not assigned yet: use default */
-		channel = AUDIO_CHANNEL_DEFAULT;
-	}
+	channel_assignment_get(&channel);
+
 	channel = BIT(channel);
 
 	LOG_DBG("Received BASE with %u subgroup(s) from broadcast sink", base->subgroup_count);
@@ -308,11 +305,8 @@ static void initialize(le_audio_receive_cb recv_cb)
 	if (!initialized) {
 		receive_cb = recv_cb;
 
-		ret = channel_assignment_get(&channel);
-		if (ret) {
-			/* Channel is not assigned yet: use default */
-			channel = AUDIO_CHANNEL_DEFAULT;
-		}
+		channel_assignment_get(&channel);
+
 		if (channel == AUDIO_CH_L) {
 			ret = bt_audio_capability_set_location(BT_AUDIO_DIR_SINK,
 							       BT_AUDIO_LOCATION_FRONT_LEFT);

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -418,11 +418,7 @@ static int initialize(le_audio_receive_cb recv_cb)
 #endif /* (CONFIG_BT_VCS) */
 
 		receive_cb = recv_cb;
-		ret = channel_assignment_get(&channel);
-		if (ret) {
-			/* Channel is not assigned yet: use default */
-			channel = AUDIO_CHANNEL_DEFAULT;
-		}
+		channel_assignment_get(&channel);
 
 		for (size_t i = 0; i < ARRAY_SIZE(caps); i++) {
 			ret = bt_audio_capability_register(&caps[i]);

--- a/applications/nrf5340_audio/src/main.c
+++ b/applications/nrf5340_audio/src/main.c
@@ -74,11 +74,7 @@ static int leds_set(void)
 #if (CONFIG_AUDIO_DEV == HEADSET)
 	enum audio_channel channel;
 
-	ret = channel_assignment_get(&channel);
-	if (ret) {
-		/* Channel is not assigned yet: use default */
-		channel = AUDIO_CHANNEL_DEFAULT;
-	}
+	channel_assignment_get(&channel);
 
 	if (channel == AUDIO_CH_L) {
 		ret = led_on(LED_APP_RGB, LED_COLOR_BLUE);
@@ -121,11 +117,6 @@ static int bonding_clear_check(void)
 static int channel_assign_check(void)
 {
 #if (CONFIG_AUDIO_DEV == HEADSET) && CONFIG_AUDIO_HEADSET_CHANNEL_RUNTIME
-	if (!channel_assignment_get(&(enum audio_channel){ AUDIO_CH_L })) {
-		/* Channel already assigned */
-		return 0;
-	}
-
 	int ret;
 	bool pressed;
 
@@ -135,7 +126,8 @@ static int channel_assign_check(void)
 	}
 
 	if (pressed) {
-		return channel_assignment_set(AUDIO_CH_L);
+		channel_assignment_set(AUDIO_CH_L);
+		return 0;
 	}
 
 	ret = button_pressed(BUTTON_VOLUME_UP, &pressed);
@@ -144,7 +136,8 @@ static int channel_assign_check(void)
 	}
 
 	if (pressed) {
-		return channel_assignment_set(AUDIO_CH_R);
+		channel_assignment_set(AUDIO_CH_R);
+		return 0;
 	}
 #endif
 
@@ -180,6 +173,8 @@ void main(void)
 
 	ret = button_handler_init();
 	ERR_CHK(ret);
+
+	channel_assignment_init();
 
 	ret = channel_assign_check();
 	ERR_CHK(ret);

--- a/applications/nrf5340_audio/src/modules/dfu_entry.c
+++ b/applications/nrf5340_audio/src/modules/dfu_entry.c
@@ -42,27 +42,26 @@ LOG_MODULE_REGISTER(dfu, CONFIG_LOG_DFU_ENTRY_LEVEL);
 static struct bt_le_adv_param adv_param;
 static const struct bt_data ad_peer[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
-		      0x84, 0xaa, 0x60, 0x74, 0x52, 0x8a, 0x8b, 0x86,
-		      0xd3, 0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL, 0x84, 0xaa, 0x60, 0x74, 0x52, 0x8a, 0x8b, 0x86, 0xd3,
+		      0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
 };
 
 /* MCUMGR related functions */
 static void mcumgr_register(void)
 {
-	/* Enable MCUMGR */
-	#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
-		os_mgmt_register_group();
-	#endif
-	#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
-		img_mgmt_register_group();
-	#endif
-	#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
-		stat_mgmt_register_group();
-	#endif
-	#ifdef CONFIG_MCUMGR_SMP_BT
-		smp_bt_register();
-	#endif
+/* Enable MCUMGR */
+#ifdef CONFIG_MCUMGR_CMD_OS_MGMT
+	os_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
+	img_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_CMD_STAT_MGMT
+	stat_mgmt_register_group();
+#endif
+#ifdef CONFIG_MCUMGR_SMP_BT
+	smp_bt_register();
+#endif
 }
 
 static void smp_adv(void)
@@ -96,7 +95,7 @@ static struct bt_conn_cb dfu_conn_callbacks = {
 
 static void dfu_set_bt_name(void)
 {
-	char name[CONFIG_BT_DEVICE_NAME_MAX] = {0};
+	char name[CONFIG_BT_DEVICE_NAME_MAX] = { 0 };
 
 	strlcpy(name, CONFIG_BT_DEVICE_NAME, CONFIG_BT_DEVICE_NAME_MAX);
 	strlcat(name, "_", CONFIG_BT_DEVICE_NAME_MAX);
@@ -106,11 +105,7 @@ static void dfu_set_bt_name(void)
 	int ret;
 	enum audio_channel channel;
 
-	ret = channel_assignment_get(&channel);
-	if (ret) {
-		/* Channel is not assigned yet: use default */
-		channel = AUDIO_CHANNEL_DEFAULT;
-	}
+	channel_assignment_get(&channel);
 
 	if (channel == AUDIO_CH_L) {
 		strlcat(name, CH_L_TAG, CONFIG_BT_DEVICE_NAME_MAX);

--- a/applications/nrf5340_audio/src/utils/Kconfig
+++ b/applications/nrf5340_audio/src/utils/Kconfig
@@ -48,5 +48,9 @@ config LOG_CS47L63_LEVEL
 	int "Log level for CS47L63"
 	default 2
 
+config LOG_CHANNEL_ASSIGNMENT_LEVEL
+	int "Log level for channel assignment"
+	default 3
+
 endmenu # Log levels
 endmenu # Utils

--- a/applications/nrf5340_audio/src/utils/channel_assignment.h
+++ b/applications/nrf5340_audio/src/utils/channel_assignment.h
@@ -33,23 +33,21 @@ enum audio_channel {
  * @brief Get assigned audio channel.
  *
  * @param[out] channel Channel value
- *
- * @return 0 if successful
- * @return -EIO if channel is not assigned.
  */
-int channel_assignment_get(enum audio_channel *channel);
+void channel_assignment_get(enum audio_channel *channel);
 
 #if CONFIG_AUDIO_HEADSET_CHANNEL_RUNTIME
 /**
  * @brief Assign audio channel.
  *
  * @param[out] channel Channel value
- *
- * @return 0 if successful
- * @return -EROFS if different channel is already written
- * @return -EIO if channel is not assigned.
  */
-int channel_assignment_set(enum audio_channel channel);
+void channel_assignment_set(enum audio_channel channel);
 #endif /* AUDIO_HEADSET_CHANNEL_RUNTIME */
+
+/**
+ * @brief Initialize the channel assignment
+ */
+void channel_assignment_init(void);
 
 #endif /* _CHANNEL_ASSIGNMENT_H_ */

--- a/applications/nrf5340_audio/src/utils/fw_info_app.c.in
+++ b/applications/nrf5340_audio/src/utils/fw_info_app.c.in
@@ -35,16 +35,7 @@ int fw_info_app_print(void)
 #if (CONFIG_AUDIO_DEV == HEADSET)
 	enum audio_channel channel;
 
-	ret = channel_assignment_get(&channel);
-	if (ret) {
-		channel = AUDIO_CHANNEL_DEFAULT;
-		ret = log_set_tag(CH_L_TAG);
-		if (ret) {
-			return ret;
-		}
-		LOG_INF(COLOR_CYAN "HEADSET <no ch selected> defaulting to " STRINGIFY(
-			AUDIO_CHANNEL_DEFAULT) " " COLOR_RESET);
-	}
+	channel_assignment_get(&channel);
 	if (channel == AUDIO_CH_L) {
 		ret = log_set_tag(CH_L_TAG);
 		if (ret) {


### PR DESCRIPTION
- Move channel assignment to RAM to be able to change on boot
- Hold button VOL+ for right device
- Hold button VOL- for left device

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>