### PR TITLE
manifest: update Zephyr revision

### DIFF
--- a/samples/tfm/its/.gdbinit
+++ b/samples/tfm/its/.gdbinit
@@ -1,0 +1,3 @@
+add-symbol-file build/nrf5340dk_nrf5340_cpuapp_ns/sample.tfm.its/tfm/bin/tfm_s.elf
+rb fs_prepare
+

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c5340c156e0ce042b21ae716906b2746a7835343
+      revision: pull/931/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update to Zephyr revision having a fix for
TFM regression test secure UART output on newer
nrf5340 boards.

Ref: NCSDK-16751

test-sdk-nrf: sdk-nrf-PR-9018

Signed-off-by: Torstein Grindvik <torstein.grindvik@nordicsemi.no>