### PR TITLE
bluetooth: hci_driver_receive_process treat lock the same

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -762,7 +762,7 @@ static int hci_driver_open(void)
 
 	err = MULTITHREADING_LOCK_ACQUIRE();
 	if (!err) {
-		err = sdc_enable(hci_driver_receive_process, sdc_mempool);
+		err = sdc_enable(receive_signal_raise, sdc_mempool);
 		MULTITHREADING_LOCK_RELEASE();
 	}
 	if (err < 0) {


### PR DESCRIPTION
Without this, hci_driver_receive_process behaves differntly when called from mpsl_low_priority_process directly, and when it is submited as its own work-q element. When it is called from mpsl_low_priority_process, it will run with the
MULTITHREADING_LOCK the whole execution time.

But with this PR, it is at least coherent, it will acuire the lock when it needs to (just around the call to hci_internal_msg_get), in both cases (own work-q element, and directly
from mpsl_low_priority_process).

Signed-off-by: Martin Tverdal <martin.tverdal@nordicsemi.no>