### PR TITLE
serial_lte_modem: Apply workaround for partition manager alignment issue 

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
@@ -158,11 +158,10 @@ endchoice # NRF_CLOUD_PGPS_STORAGE
 if NRF_CLOUD_PGPS_STORAGE_PARTITION
 
 config NRF_CLOUD_PGPS_PARTITION_SIZE
-	int "Size of flash partition for P-GPS data storage"
-	default 86016
+	hex "Size of flash partition for P-GPS data storage"
+	default 0x15000
 	help
-	  This must be >= NRF_CLOUD_PGPS_NUM_PREDICTIONS times 2048, which is
-	  the nRF9160 flash page size.
+	  This must be at least 2048 bytes times NRF_COUND_PGPS_NUM_PREDICTIONS.
 
 config NRF_CLOUD_PGPS_PARTITION_ALIGN
 	hex "Align P-GPS partition to flash block boundary"

--- a/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
+++ b/subsys/net/lib/nrf_cloud/Kconfig.nrf_cloud_pgps
@@ -159,6 +159,9 @@ if NRF_CLOUD_PGPS_STORAGE_PARTITION
 
 config NRF_CLOUD_PGPS_PARTITION_SIZE
 	hex "Size of flash partition for P-GPS data storage"
+	# Workaround for known issue NCSDK-16916.
+	# Set the size of the storage partition to a multiple of CONFIG_NRF_SPU_FLASH_REGION_SIZE.
+	default 0x18000 if BUILD_WITH_TFM
 	default 0x15000
 	help
 	  This must be at least 2048 bytes times NRF_COUND_PGPS_NUM_PREDICTIONS.


### PR DESCRIPTION
Apply the workaround for partition manager alignment issue.
The partition manager calculates the wrong size of a span partition when
the partitions inside have alignment requirements.

NCSDK-17524

Provide the flash partition size of the PGPS partition in hex.
This is consistent with other flash partitions, and easier to reason
about since it has to be aligned on flash page boundaries.
Remove incorrect comment stating that 2048 is the nrf9160 flash page
size, it is 4096 (0x1000).