### PR TITLE
applications: nrf5340_audio: Refactor use of BT_ISO_MAX_CHAN

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.h
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.h
@@ -19,7 +19,7 @@
 #define PRES_DLY_BUFFER_US 2500
 #define MAX_PRES_DLY_US 40000
 #define DEFAULT_PRES_DLY_US 10000
-#define MIN_PRES_DLY_US ((DEC_TIME_US * CONFIG_BT_ISO_MAX_CHAN) + PRES_DLY_BUFFER_US)
+#define MIN_PRES_DLY_US (DEC_TIME_US + PRES_DLY_BUFFER_US)
 
 /**
  * @brief Mixes a tone into the I2S TX stream

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
@@ -28,10 +28,10 @@ BUILD_ASSERT(CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT <= 2,
 	NET_BUF_POOL_FIXED_DEFINE(iso_tx_pool_##i, HCI_ISO_BUF_ALLOC_PER_CHAN,                     \
 				  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU), 8, NULL);
 #define NET_BUF_POOL_PTR_ITERATE(i, ...) IDENTITY(&iso_tx_pool_##i)
-LISTIFY(CONFIG_BT_ISO_MAX_CHAN, NET_BUF_POOL_ITERATE, (;))
+LISTIFY(CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT, NET_BUF_POOL_ITERATE, (;))
 
 /* clang-format off */
-static struct net_buf_pool *iso_tx_pools[] = { LISTIFY(CONFIG_BT_ISO_MAX_CHAN,
+static struct net_buf_pool *iso_tx_pools[] = { LISTIFY(CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT,
 						       NET_BUF_POOL_PTR_ITERATE, (,)) };
 /* clang-format on */
 
@@ -42,9 +42,9 @@ static struct bt_audio_stream *streams_p[ARRAY_SIZE(streams)];
 
 static struct bt_audio_lc3_preset lc3_preset = BT_AUDIO_LC3_BROADCAST_PRESET_NRF5340_AUDIO;
 
-static atomic_t iso_tx_pool_alloc[CONFIG_BT_ISO_MAX_CHAN];
+static atomic_t iso_tx_pool_alloc[CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT];
 static bool delete_broadcast_src;
-static uint32_t seq_num[CONFIG_BT_ISO_MAX_CHAN];
+static uint32_t seq_num[CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT];
 
 static bool is_iso_buffer_full(uint8_t idx)
 {
@@ -206,7 +206,7 @@ int le_audio_pause(void)
 int le_audio_send(uint8_t const *const data, size_t size)
 {
 	int ret;
-	static bool wrn_printed[CONFIG_BT_ISO_MAX_CHAN];
+	static bool wrn_printed[CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT];
 	struct net_buf *buf;
 	size_t num_streams = ARRAY_SIZE(streams);
 	size_t data_size = size / num_streams;


### PR DESCRIPTION
- Use SRC and SNK instead of BT_ISO_MAX_CHAN

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>