### PR TITLE
manifest: Update sdk-zephyr revision with IP QoS updates

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c5340c156e0ce042b21ae716906b2746a7835343
+      revision: 5cef595fdb172639d9c5730023e8517e250523bc
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add support for DSCP/ECN IPv4/IPv6 header fields.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>