### PR TITLE
Bluetooth: Mesh: remove not used function in rpl

### DIFF
--- a/subsys/bluetooth/mesh/rpl.c
+++ b/subsys/bluetooth/mesh/rpl.c
@@ -22,11 +22,6 @@ static struct bt_mesh_rpl replay_list[CONFIG_BT_MESH_CRPL];
 
 EMDS_STATIC_ENTRY_DEFINE(rpl_store, CONFIG_BT_MESH_RPL_INDEX, replay_list, sizeof(replay_list));
 
-static inline int rpl_idx(const struct bt_mesh_rpl *rpl)
-{
-	return rpl - &replay_list[0];
-}
-
 void bt_mesh_rpl_update(struct bt_mesh_rpl *rpl,
 		struct bt_mesh_net_rx *rx)
 {


### PR DESCRIPTION
Seems `rpl_idx` function is not used anymore.
It has been removed.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>