### PR TITLE
bluetooth: fast_pair: Add Battery Notification extension

### DIFF
--- a/include/bluetooth/adv_prov/fast_pair.h
+++ b/include/bluetooth/adv_prov/fast_pair.h
@@ -40,6 +40,20 @@ void bt_le_adv_prov_fast_pair_enable(bool enable);
  */
 void bt_le_adv_prov_fast_pair_show_ui_pairing(bool enable);
 
+/** Set advertising battery mode in Fast Pair not dicoverable advertising.
+ *
+ * To prevent tracking, the Fast Pair Provider should not include battery data in the advertising
+ * packet all the time.
+ *
+ * User shall make sure that this function is not called while Fast Pair advertising data provider
+ * is providing advertising data.
+ *
+ * @param[in] mode		Advertising battery mode.
+ *
+ * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
+ */
+int bt_le_adv_prov_fast_pair_set_battery_mode(enum bt_fast_pair_adv_battery_mode mode);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/bluetooth/peripheral_fast_pair/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_fast_pair/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(app PRIVATE
   src/bt_adv_helper.c
   src/hids_helper.c
   src/bt_le_adv_prov_uuid16.c
+  src/battery_module.c
 )
 
 target_include_directories(app PRIVATE include)

--- a/samples/bluetooth/peripheral_fast_pair/include/battery_module.h
+++ b/samples/bluetooth/peripheral_fast_pair/include/battery_module.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef BATTERY_MODULE_H_
+#define BATTERY_MODULE_H_
+
+/**
+ * @defgroup fast_pair_sample_battery_module Fast Pair sample battery module
+ * @brief Fast Pair sample battery module
+ *
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Initialize battery module.
+ *
+ * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
+ */
+int battery_module_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* BATTERY_MODULE_H_ */

--- a/samples/bluetooth/peripheral_fast_pair/src/battery_module.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/battery_module.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <bluetooth/services/fast_pair.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(fp_sample, LOG_LEVEL_INF);
+
+#include "battery_module.h"
+
+int battery_module_init(void)
+{
+	static const struct bt_fast_pair_battery fp_batteries[BT_FAST_PAIR_BATTERY_COMP_COUNT] = {
+		[BT_FAST_PAIR_BATTERY_COMP_LEFT_BUD]  = { .charging = true, .level = 67},
+		[BT_FAST_PAIR_BATTERY_COMP_RIGHT_BUD] = { .charging = false, .level = 100},
+		[BT_FAST_PAIR_BATTERY_COMP_BUD_CASE]  = { .charging = false, .level = 1},
+	};
+	int err;
+
+	for (size_t i = 0; i < BT_FAST_PAIR_BATTERY_COMP_COUNT; i++) {
+		err = bt_fast_pair_battery_set(i, fp_batteries[i]);
+		if (err) {
+			LOG_ERR("Unable to set battery value (err %d, idx %zu)", err, i);
+			return err;
+		}
+	}
+
+	return 0;
+}

--- a/samples/bluetooth/peripheral_fast_pair/src/main.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/main.c
@@ -10,6 +10,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/settings/settings.h>
 #include <bluetooth/services/fast_pair.h>
+#include <bluetooth/adv_prov/fast_pair.h>
 
 #include <dk_buttons_and_leds.h>
 
@@ -18,6 +19,7 @@ LOG_MODULE_REGISTER(fp_sample, LOG_LEVEL_INF);
 
 #include "bt_adv_helper.h"
 #include "hids_helper.h"
+#include "battery_module.h"
 
 #define RUN_STATUS_LED						DK_LED1
 #define CON_STATUS_LED						DK_LED2
@@ -393,6 +395,18 @@ void main(void)
 	err = dk_leds_init();
 	if (err) {
 		LOG_ERR("LEDs init failed (err %d)", err);
+		return;
+	}
+
+	err = battery_module_init();
+	if (err) {
+		LOG_ERR("Battery module init failed (err %d)", err);
+		return;
+	}
+
+	err = bt_le_adv_prov_fast_pair_set_battery_mode(BT_FAST_PAIR_ADV_BATTERY_MODE_SHOW_UI_IND);
+	if (err) {
+		LOG_ERR("Setting advertising battery mode failed (err %d)", err);
 		return;
 	}
 

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
@@ -12,6 +12,7 @@ menuconfig BT_ADV_PROV_FAST_PAIR
 
 	  If device is in pairing mode, provider uses Fast Pair discoverable
 	  advertising. Otherwise, Fast Pair not discoverable advertising is used.
+	  By default, battery data is included in not discoverable advertising payload.
 
 	  Application can control the generated payload using provider's Kconfig
 	  options or dedicated API.
@@ -32,6 +33,29 @@ config BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING
 	help
 	  The UI indication should be displayed if device is ready for pairing.
 	  The provider also exposes API to show/hide UI indication in runtime.
+
+choice BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_MODE
+	prompt "Select advertising battery data mode"
+	default BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_SHOW_UI
+	help
+	  The provider also exposes API to change battery data advertising mode in runtime.
+
+config BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_SHOW_UI
+	bool "Include battery data in Fast Pair not discoverable advertising and show UI indication"
+	help
+	  When this option is enabled, battery data is included in Fast Pair not discoverable
+	  advertising and the show battery data UI indication mode is enabled.
+
+config BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_HIDE_UI
+	bool "Include battery data in Fast Pair not discoverable advertising and hide UI indication"
+	help
+	  When this option is enabled, battery data is included in Fast Pair not discoverable
+	  advertising and the hide battery data UI indication mode is enabled.
+
+config BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_NONE
+	bool "Do not include battery data in Fast Pair advertising"
+
+endchoice
 
 config BT_ADV_PROV_FAST_PAIR_AUTO_SET_PAIRING_MODE
 	bool "Automatically set Fast Pair pairing mode"

--- a/subsys/bluetooth/adv_prov/providers/fast_pair.c
+++ b/subsys/bluetooth/adv_prov/providers/fast_pair.c
@@ -11,6 +11,13 @@
 
 static bool enabled = true;
 static bool show_ui_pairing = IS_ENABLED(CONFIG_BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING);
+static enum bt_fast_pair_adv_battery_mode adv_battery_mode = (
+	IS_ENABLED(CONFIG_BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_NONE) ?
+		BT_FAST_PAIR_ADV_BATTERY_MODE_NONE :
+			(IS_ENABLED(CONFIG_BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_SHOW_UI) ?
+				BT_FAST_PAIR_ADV_BATTERY_MODE_SHOW_UI_IND :
+							BT_FAST_PAIR_ADV_BATTERY_MODE_HIDE_UI_IND)
+);
 
 
 void bt_le_adv_prov_fast_pair_enable(bool enable)
@@ -23,34 +30,48 @@ void bt_le_adv_prov_fast_pair_show_ui_pairing(bool enable)
 	show_ui_pairing = enable;
 }
 
+int bt_le_adv_prov_fast_pair_set_battery_mode(enum bt_fast_pair_adv_battery_mode mode)
+{
+	if ((mode < 0) || (mode >= BT_FAST_PAIR_ADV_BATTERY_MODE_COUNT)) {
+		return -EINVAL;
+	}
+
+	adv_battery_mode = mode;
+
+	return 0;
+}
+
 static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *state,
 		    struct bt_le_adv_prov_feedback *fb)
 {
 	static uint8_t buf[ADV_DATA_BUF_SIZE];
-	enum bt_fast_pair_adv_mode adv_mode;
+	struct bt_fast_pair_adv_config adv_config;
 
 	if (!enabled) {
 		return -ENOENT;
 	}
 
 	if (state->pairing_mode) {
-		adv_mode = BT_FAST_PAIR_ADV_MODE_DISCOVERABLE;
+		adv_config.adv_mode = BT_FAST_PAIR_ADV_MODE_DISCOVERABLE;
 	} else {
 		if (show_ui_pairing) {
-			adv_mode = BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_SHOW_UI_IND;
+			adv_config.adv_mode = BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_SHOW_UI_IND;
 		} else {
-			adv_mode = BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_HIDE_UI_IND;
+			adv_config.adv_mode = BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_HIDE_UI_IND;
 		}
 	}
 
+	adv_config.adv_battery_mode = adv_battery_mode;
+
 	if (IS_ENABLED(CONFIG_BT_ADV_PROV_FAST_PAIR_AUTO_SET_PAIRING_MODE)) {
 		/* Set Fast Pair pairing mode to match Fast Pair advertising mode. */
-		bt_fast_pair_set_pairing_mode(adv_mode == BT_FAST_PAIR_ADV_MODE_DISCOVERABLE);
+		bt_fast_pair_set_pairing_mode(adv_config.adv_mode ==
+					      BT_FAST_PAIR_ADV_MODE_DISCOVERABLE);
 	}
 
-	__ASSERT_NO_MSG(bt_fast_pair_adv_data_size(adv_mode) <= sizeof(buf));
+	__ASSERT_NO_MSG(bt_fast_pair_adv_data_size(adv_config) <= sizeof(buf));
 
-	return bt_fast_pair_adv_data_fill(ad, buf, sizeof(buf), adv_mode);
+	return bt_fast_pair_adv_data_fill(ad, buf, sizeof(buf), adv_config);
 }
 
 BT_LE_ADV_PROV_AD_PROVIDER_REGISTER(fast_pair, get_data);

--- a/subsys/bluetooth/services/fast_pair/CMakeLists.txt
+++ b/subsys/bluetooth/services/fast_pair/CMakeLists.txt
@@ -17,6 +17,7 @@ zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_AUTH		   fp_auth.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_GATT_SERVICE	   fp_gatt_service.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_KEYS		   fp_keys.c)
 zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_REGISTRATION_DATA fp_registration_data.c)
+zephyr_library_sources_ifdef(CONFIG_BT_FAST_PAIR_BATTERY	   fp_battery.c)
 
 if(CONFIG_BT_FAST_PAIR_CRYPTO)
   add_subdirectory(fp_crypto)

--- a/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
+++ b/subsys/bluetooth/services/fast_pair/Kconfig.fast_pair
@@ -109,6 +109,12 @@ config BT_FAST_PAIR_REGISTRATION_DATA
 	help
 	  Add Fast Pair registration data source files.
 
+config BT_FAST_PAIR_BATTERY
+	bool
+	default y
+	help
+	  Add Fast Pair battery module source files.
+
 module = BT_FAST_PAIR
 module-str = Fast Pair Service
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/bluetooth/services/fast_pair/fp_battery.c
+++ b/subsys/bluetooth/services/fast_pair/fp_battery.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <bluetooth/services/fast_pair.h>
+#include "fp_battery.h"
+
+static struct bt_fast_pair_battery_data fp_battery_data = {
+	.batteries = {
+		[BT_FAST_PAIR_BATTERY_COMP_LEFT_BUD]  = {
+			.charging = false, .level = BT_FAST_PAIR_BATTERY_LEVEL_UNKNOWN
+		},
+		[BT_FAST_PAIR_BATTERY_COMP_RIGHT_BUD] = {
+			.charging = false, .level = BT_FAST_PAIR_BATTERY_LEVEL_UNKNOWN
+		},
+		[BT_FAST_PAIR_BATTERY_COMP_BUD_CASE]  = {
+			.charging = false, .level = BT_FAST_PAIR_BATTERY_LEVEL_UNKNOWN
+		},
+	}
+};
+
+static bool is_battery_level_valid(uint8_t level)
+{
+	if ((level > 100) && (level != BT_FAST_PAIR_BATTERY_LEVEL_UNKNOWN)) {
+		return false;
+	}
+
+	return true;
+}
+
+int bt_fast_pair_battery_set(enum bt_fast_pair_battery_comp battery_comp,
+			     struct bt_fast_pair_battery battery)
+{
+	if (!is_battery_level_valid(battery.level)) {
+		return -EINVAL;
+	}
+
+	if ((battery_comp < 0) || (battery_comp >= BT_FAST_PAIR_BATTERY_COMP_COUNT)) {
+		return -EINVAL;
+	}
+
+	BUILD_ASSERT(ARRAY_SIZE(fp_battery_data.batteries) == BT_FAST_PAIR_BATTERY_COMP_COUNT);
+
+	fp_battery_data.batteries[battery_comp] = battery;
+
+	return 0;
+}
+
+struct bt_fast_pair_battery_data fp_battery_get_battery_data(void)
+{
+	return fp_battery_data;
+}

--- a/subsys/bluetooth/services/fast_pair/include/fp_battery.h
+++ b/subsys/bluetooth/services/fast_pair/include/fp_battery.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _FP_BATTERY_H_
+#define _FP_BATTERY_H_
+
+#include <bluetooth/services/fast_pair.h>
+
+/**
+ * @defgroup fp_battery Fast Pair battery
+ * @brief Internal API for Fast Pair battery module implementation
+ *
+ * Fast Pair battery module provides API for application to set battery data and for Fast Pair
+ * subsystem to get battery data and use it when generating advertising data.
+ *
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Fast Pair battery data related to all three batteries (left bud, right bud, case). */
+struct bt_fast_pair_battery_data {
+	/** Fast Pair battery values. */
+	struct bt_fast_pair_battery batteries[BT_FAST_PAIR_BATTERY_COMP_COUNT];
+};
+
+/** Get battery data.
+ *
+ * @return Battery data.
+ */
+struct bt_fast_pair_battery_data fp_battery_get_battery_data(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* _FP_BATTERY_H_ */


### PR DESCRIPTION
Adds support for Battery Notification Fast Pair extension. Adds the most basic usage in sample.
It should be expanded later on.

Jira: NCSDK-14074