### PR TITLE
bluetooth: Solving deadlocks and removing a memcpy

### DIFF
--- a/include/mpsl/mpsl_work.h
+++ b/include/mpsl/mpsl_work.h
@@ -49,6 +49,12 @@ static inline int mpsl_work_submit(struct k_work *work)
 	return k_work_submit_to_queue(&mpsl_work_q, work);
 }
 
+static inline int mpsl_work_schedule(struct k_work_delayable *work, k_timeout_t delay)
+{
+	return k_work_reschedule_for_queue(&mpsl_work_q, work, delay);
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -156,9 +156,16 @@ void sdc_assertion_handler(const char *const file, const uint32_t line)
 #endif /* IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
 
 static struct k_work receive_work;
+static struct k_work_delayable receive_work_delayable;
+
 static inline void receive_signal_raise(void)
 {
 	mpsl_work_submit(&receive_work);
+}
+
+static inline void receive_signal_raise_delayable(void)
+{
+	mpsl_work_schedule(&receive_work_delayable, K_MSEC(10));
 }
 
 static int cmd_handle(struct net_buf *cmd)
@@ -236,17 +243,11 @@ static int hci_driver_send(struct net_buf *buf)
 	return err;
 }
 
-static void data_packet_process(uint8_t *hci_buf)
+void data_packet_process(struct net_buf *data_buf)
 {
-	struct net_buf *data_buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_FOREVER);
-	struct bt_hci_acl_hdr *hdr = (void *)hci_buf;
+	struct bt_hci_acl_hdr *hdr = (void *)data_buf->data;
 	uint16_t hf, handle, len;
 	uint8_t flags, pb, bc;
-
-	if (!data_buf) {
-		BT_ERR("No data buffer available");
-		return;
-	}
 
 	len = sys_le16_to_cpu(hdr->len);
 	hf = sys_le16_to_cpu(hdr->handle);
@@ -257,63 +258,31 @@ static void data_packet_process(uint8_t *hci_buf)
 
 	BT_DBG("Data: handle (0x%02x), PB(%01d), BC(%01d), len(%u)", handle,
 	       pb, bc, len);
-
-	net_buf_add_mem(data_buf, &hci_buf[0], len + sizeof(*hdr));
+	net_buf_add(data_buf, len + sizeof(hdr));
 	bt_recv(data_buf);
 }
 
-static bool event_packet_is_discardable(const uint8_t *hci_buf)
+
+
+static void event_packet_process(struct net_buf *evt_buf)
 {
-	struct bt_hci_evt_hdr *hdr = (void *)hci_buf;
-
-	switch (hdr->evt) {
-	case BT_HCI_EVT_LE_META_EVENT: {
-		struct bt_hci_evt_le_meta_event *me = (void *)&hci_buf[2];
-
-		switch (me->subevent) {
-		case BT_HCI_EVT_LE_ADVERTISING_REPORT:
-			return true;
-		default:
-			return false;
-		}
-	}
-	case BT_HCI_EVT_VENDOR:
-	{
-		uint8_t subevent = hci_buf[2];
-
-		switch (subevent) {
-		case SDC_HCI_SUBEVENT_VS_QOS_CONN_EVENT_REPORT:
-			return true;
-		default:
-			return false;
-		}
-	}
-	default:
-		return false;
-	}
-}
-
-static void event_packet_process(uint8_t *hci_buf)
-{
-	bool discardable = event_packet_is_discardable(hci_buf);
-	struct bt_hci_evt_hdr *hdr = (void *)hci_buf;
-	struct net_buf *evt_buf;
+	struct bt_hci_evt_hdr *hdr = (void *)evt_buf->data;
 
 	if (hdr->evt == BT_HCI_EVT_LE_META_EVENT) {
-		struct bt_hci_evt_le_meta_event *me = (void *)&hci_buf[2];
+		struct bt_hci_evt_le_meta_event *me = (void *)&evt_buf->data[2];
 
 		BT_DBG("LE Meta Event (0x%02x), len (%u)",
 		       me->subevent, hdr->len);
 	} else if (hdr->evt == BT_HCI_EVT_CMD_COMPLETE) {
-		struct bt_hci_evt_cmd_complete *cc = (void *)&hci_buf[2];
-		struct bt_hci_evt_cc_status *ccs = (void *)&hci_buf[5];
+		struct bt_hci_evt_cmd_complete *cc = (void *)&evt_buf->data[2];
+		struct bt_hci_evt_cc_status *ccs = (void *)&evt_buf->data[5];
 		uint16_t opcode = sys_le16_to_cpu(cc->opcode);
 
 		BT_DBG("Command Complete (0x%04x) status: 0x%02x,"
 		       " ncmd: %u, len %u",
 		       opcode, ccs->status, cc->ncmd, hdr->len);
 	} else if (hdr->evt == BT_HCI_EVT_CMD_STATUS) {
-		struct bt_hci_evt_cmd_status *cs = (void *)&hci_buf[2];
+		struct bt_hci_evt_cmd_status *cs = (void *)&evt_buf->data[2];
 		uint16_t opcode = sys_le16_to_cpu(cs->opcode);
 
 		BT_DBG("Command Status (0x%04x) status: 0x%02x",
@@ -321,43 +290,60 @@ static void event_packet_process(uint8_t *hci_buf)
 	} else {
 		BT_DBG("Event (0x%02x) len %u", hdr->evt, hdr->len);
 	}
-
-	evt_buf = bt_buf_get_evt(hdr->evt, discardable,
-				 discardable ? K_NO_WAIT : K_FOREVER);
-
-	if (!evt_buf) {
-		if (discardable) {
-			BT_DBG("Discarding event");
-			return;
-		}
-
-		BT_ERR("No event buffer available");
-		return;
-	}
-
-	net_buf_add_mem(evt_buf, &hci_buf[0], hdr->len + sizeof(*hdr));
+	net_buf_add(evt_buf, hdr->len + sizeof(*hdr));
 	bt_recv(evt_buf);
 }
 
-static bool fetch_and_process_hci_msg(uint8_t *p_hci_buffer)
+static bool fetch_and_process_hci_msg(void)
+
 {
 	int errcode;
-	sdc_hci_msg_type_t msg_type;
-
+	sdc_hci_msg_type_t msg_type_peeked;
+	uint8_t hdr_peeked;
 	errcode = MULTITHREADING_LOCK_ACQUIRE();
 	if (!errcode) {
-		errcode = hci_internal_msg_get(p_hci_buffer, &msg_type);
+		errcode = hci_internal_msg_peek(&hdr_peeked, &msg_type_peeked);
 		MULTITHREADING_LOCK_RELEASE();
 	}
-
+	if (errcode) {
+		return false;
+	}
+	if (msg_type_peeked == 0)
+	{
+		return false;
+	}
+	struct net_buf *buf;
+	if (msg_type_peeked == SDC_HCI_MSG_TYPE_DATA)
+	{
+		buf = bt_buf_get_rx(BT_BUF_ACL_IN, K_NO_WAIT);
+	} else if (msg_type_peeked == SDC_HCI_MSG_TYPE_EVT)
+	{
+		buf = bt_buf_get_evt(hdr_peeked, false, K_NO_WAIT);
+	} else {
+		__ASSERT(false, "sdc_hci_msg_type_t has changed. This if-else needs a new branch");
+		return false;
+	}
+	if (buf == 0)
+	{
+		/*Wasn't able to allocate a buffer even though there are events pending
+		 Schedule a retry later. And let other threads run in between.
+		 */
+		receive_signal_raise_delayable();
+		return false;
+	}
+	sdc_hci_msg_type_t msg_type;
+	if (!errcode) {
+		errcode = hci_internal_msg_get(buf->data, &msg_type);
+		MULTITHREADING_LOCK_RELEASE();
+	}
 	if (errcode) {
 		return false;
 	}
 
 	if (msg_type == SDC_HCI_MSG_TYPE_EVT) {
-		event_packet_process(p_hci_buffer);
+		event_packet_process(buf);
 	} else if (msg_type == SDC_HCI_MSG_TYPE_DATA) {
-		data_packet_process(p_hci_buffer);
+		data_packet_process(buf);
 	} else {
 		__ASSERT(false, "sdc_hci_msg_type_t has changed. This if-else needs a new branch");
 		return false;
@@ -368,14 +354,7 @@ static bool fetch_and_process_hci_msg(uint8_t *p_hci_buffer)
 
 void hci_driver_receive_process(void)
 {
-#if defined(CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT)
-	static uint8_t hci_buf[MAX(BT_BUF_RX_SIZE,
-				   BT_BUF_EVT_SIZE(CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE))];
-#else
-	static uint8_t hci_buf[BT_BUF_RX_SIZE];
-#endif
-
-	if (fetch_and_process_hci_msg(&hci_buf[0])) {
+	if (fetch_and_process_hci_msg()) {
 		/* Let other threads of same priority run in between. */
 		receive_signal_raise();
 	}
@@ -759,6 +738,7 @@ static int hci_driver_open(void)
 	}
 
 	k_work_init(&receive_work, receive_work_handler);
+	k_work_init_delayable(&receive_work_delayable, receive_work_handler);
 
 	err = MULTITHREADING_LOCK_ACQUIRE();
 	if (!err) {

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -1192,3 +1192,14 @@ int hci_internal_msg_get(uint8_t *msg_out, sdc_hci_msg_type_t *msg_type_out)
 
 	return sdc_hci_get(msg_out, msg_type_out);
 }
+
+int hci_internal_msg_peek(uint8_t *evt_hdr_out, sdc_hci_msg_type_t *msg_type_out)
+{
+	if (cmd_complete_or_status.occurred) {
+		*evt_hdr_out = cmd_complete_or_status.raw_event[0];
+		*msg_type_out = SDC_HCI_MSG_TYPE_EVT;
+		return 0;
+	}
+	evt_hdr_out = BT_HCI_EVT_UNKNOWN;
+	return sdc_hci_peek(msg_type_out);
+}

--- a/subsys/bluetooth/controller/hci_internal.h
+++ b/subsys/bluetooth/controller/hci_internal.h
@@ -81,5 +81,6 @@ int hci_internal_user_cmd_handler_register(const hci_internal_user_cmd_handler_t
  * @return Zero on success or (negative) error code otherwise.
  */
 int hci_internal_msg_get(uint8_t *msg_out, sdc_hci_msg_type_t *msg_type_out);
+int hci_internal_msg_peek(uint8_t *evt_hdr_out, sdc_hci_msg_type_t *msg_type_out);
 
 #endif

--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 90bad439cd19ad912877cc0d4d04e5294356e2b6
+      revision: pull/849/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Peek to see what the next event going to be fetched is. If it not possible to get a net_buf buffer for the event, schedule to retry in 10ms. And then let other threads run.

Also, this commit removes the need for an extra memcpy that was needed before. And also removes the extra hci buffer that memcpy went into.