### PR TITLE
samples: lwm2m_client: Fix Suspend issue without Bootstrap

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -629,14 +629,10 @@ void main(void)
 			break;
 
 		case CONNECTING:
-			if (!modem_connected_to_network) {
-				/* LTE connection down suspend LwM2M engine */
-				suspend_lwm2m_engine();
-			} else {
-				LOG_INF("LwM2M is connecting to server");
-				k_mutex_unlock(&lte_mutex);
-			}
+			LOG_INF("LwM2M is connecting to server");
+			k_mutex_unlock(&lte_mutex);
 			break;
+
 		case CONNECTED:
 			if (!modem_connected_to_network) {
 				/* LTE connection down suspend LwM2M engine */


### PR DESCRIPTION
**Bug fix for client build without bootstrap**

Client connection to server without bootstrap was not working after credentials write. Now Client is only suspended at connected state.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>