### PR TITLE
doc fix: doxygen configuration to show all API definitions

### DIFF
--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -1992,7 +1992,19 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_ZIGBEE_DEBUG_FUNCTIONS=y" \
                          "CONFIG_ZBOSS_ERROR_PRINT_TO_LOG=y" \
                          "CONFIG_BT_MESH_LIGHT_CTRL_SRV_REG=y" \
-                         "MODULE="
+                         "CONFIG_BT_MESH_LIGHT_CTRL_SRV=y" \
+                         "MODULE=" \
+                         "RADIO_MODE_MODE_Nrf_250Kbit=y" \
+                         "CONFIG_SOC_SERIES_NRF52X=y" \
+                         "CONFIG_LOCATION_METHOD_GNSS_AGPS_EXTERNAL=y" \
+                         "CONFIG_LOCATION_METHOD_GNSS_PGPS_EXTERNAL=y" \
+                         "CONFIG_NRF_MODEM_LIB_MEM_DIAG=y" \
+                         "CONFIG_NRF_CLOUD_MQTT=y" \
+                         "CONFIG_MODEM_INFO=y" \
+                         "CONFIG_NRF_MODEM=y" \
+                         "CONFIG_ZIGBEE_ROLE_END_DEVICE=y" \
+                         "CONFIG_ZIGBEE_FACTORY_RESET=y" \
+                         "CONFIG_NRF_CLOUD_GATEWAY=y"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
Some terms are currently not showing when viewing the rendered API documentation because they are inside if statements. This adds the required terms to the PREDEFINED section of the Doxygen configuration so the terms will render.

Examples of affected term:
* nRF Cloud A-GPS library, the function `nrf_cloud_agps_request()`.
* Modem - Location library, `nrf_modem_gnss_agps_data_frame` and `gps_pgps_request` structs.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>