### PR TITLE
cmake: Clean up minimal required version

### DIFF
--- a/samples/bluetooth/nrf_dm/CMakeLists.txt
+++ b/samples/bluetooth/nrf_dm/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(nrf_dm)

--- a/samples/bluetooth/peripheral_rscs/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_rscs/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)

--- a/samples/keys/hw_unique_key/CMakeLists.txt
+++ b/samples/keys/hw_unique_key/CMakeLists.txt
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Building TFM requires Cmake 3.15.
 cmake_minimum_required(VERSION 3.20)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/keys/hw_unique_key/CMakeLists.txt
+++ b/samples/keys/hw_unique_key/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 # Building TFM requires Cmake 3.15.
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.20)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 

--- a/samples/keys/random_hw_unique_key/CMakeLists.txt
+++ b/samples/keys/random_hw_unique_key/CMakeLists.txt
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Building TFM requires Cmake 3.15.
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/samples/nrf9160/location/CMakeLists.txt
+++ b/samples/nrf9160/location/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(location_sample)

--- a/samples/tfm/tfm_hello_world/CMakeLists.txt
+++ b/samples/tfm/tfm_hello_world/CMakeLists.txt
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Building TFM requires Cmake 3.15.
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})


### PR DESCRIPTION
Update remaining samples to use 3.20 as minimal version as required by zephyr.
Remove comment about TF-M requiring cmake 3.15.