### PR TITLE
bluetooth: extended adv reports with legacy content discardable

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -273,6 +273,17 @@ static bool event_packet_is_discardable(const uint8_t *hci_buf)
 		switch (me->subevent) {
 		case BT_HCI_EVT_LE_ADVERTISING_REPORT:
 			return true;
+#if defined(CONFIG_BT_EXT_ADV)
+		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT:
+		{
+			const struct bt_hci_evt_le_ext_advertising_report *ext_adv =
+				(void *)&hci_buf[3];
+
+			return (ext_adv->num_reports == 1) &&
+				   ((ext_adv->adv_info->evt_type &
+					 BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
+		}
+#endif
 		default:
 			return false;
 		}

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.1.99-ncs1
+      revision: 399ade4fc374d53595ef1999bf842e44a4cbf91d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
To avoid legacy extended adv repots blocking important events or work, mark them as discaradble.

Signed-off-by: Martin Tverdal <martin.tverdal@nordicsemi.no>