### PR TITLE
KRKNWK-15290: enable nRF21540 built-in model by default

### DIFF
--- a/boards/shields/nrf21540_ek/nrf21540_ek.overlay
+++ b/boards/shields/nrf21540_ek/nrf21540_ek.overlay
@@ -12,6 +12,7 @@
 		ant-sel-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 */
 		mode-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;     /* D2 */
 		spi-if = <&nrf_radio_fem_spi>;
+		supply-voltage-mv = <3000>;
 	};
 };
 

--- a/boards/shields/nrf21540_ek/nrf21540_ek_fwd.overlay
+++ b/boards/shields/nrf21540_ek/nrf21540_ek_fwd.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* This file matches the contents of nrf21540_ek.overlay and is intended to be applied to nRF5340
+ * application core when nrf21540_ek shield is provided to the network core's image build.
+ *
+ * For instance, consider an application targeted for nRF5340 application core that specifies
+ * a child image targeted for nRF5340 network core, which drives the nRF21540 Front-End Module.
+ * The shield overlays could be provided to the build using the following command:
+ *
+ * west build -p -b nrf5340dk_nrf5340_cpuapp -- -DSHIELD=nrf21540_ek_fwd -D<child_image>_SHIELD=nrf21540_ek
+ */
+&gpio_fwd {
+	nrf21540-gpio-if {
+		gpios = <&arduino_header 11 0>,		/* tx-en-gpios */
+			<&arduino_header 9 0>,		/* rx-en-gpios */
+			<&arduino_header 15 0>,		/* pdn-gpios */
+			<&arduino_header 10 0>,		/* ant-sel-gpios */
+			<&arduino_header 8 0>;		/* mode-gpios */
+	};
+	nrf21540-spi-if {
+		gpios = <&arduino_header 16 0>,		/* cs-gpios */
+			<&gpio1 15 0>,			/* SPIM_SCK */
+			<&gpio1 14 0>,			/* SPIM_MISO */
+			<&gpio1 13 0>;			/* SPIM_MOSI */
+	};
+};

--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -69,11 +69,11 @@ config MPSL_FEM_NRF21540_GPIO
 
 config MPSL_FEM_NRF21540_GPIO_SPI
 	depends on MPSL_FEM_NRF21540_GPIO_SPI_SUPPORT
-	select EXPERIMENTAL
 	select NRFX_GPIOTE
 	select NRFX_PPI if SOC_SERIES_NRF52X
 	select NRFX_DPPI if SOC_SERIES_NRF53X
 	select MPSL_FEM_NCS_SUPPORTED_FEM_USED
+	imply MPSL_FEM_POWER_MODEL if MPSL_FEM   # Don't force the model, but make it a default
 	bool "nRF21540 front-end module in GPIO + SPI mode"
 	help
 	  FEM device is nRF21540 and it uses both GPIO and SPI.
@@ -149,8 +149,11 @@ config MPSL_FEM_NRF21540_RUNTIME_PA_GAIN_CONTROL
 
 endif   # (MPSL_FEM_NRF21540_GPIO || MPSL_FEM_NRF21540_GPIO_SPI) && MPSL_FEM
 
+endif	# MPSL_FEM || MPSL_FEM_PIN_FORWARDER
+
 config MPSL_FEM_POWER_MODEL
 	bool "Use a model to split the requested TX power into values used to control the internal state of the FEM"
+	depends on MPSL_FEM
 	default n
 	help
 	  Use a model to split the requested TX power into values used to control
@@ -167,7 +170,7 @@ if MPSL_FEM_POWER_MODEL
 
 choice MPSL_FEM_POWER_MODEL_CHOICE
 	prompt "Model used to split the requested TX power into values used to control the internal state of the FEM"
-	optional
+	default MPSL_FEM_POWER_MODEL_NRF21540_USE_BUILTIN if MPSL_FEM_NRF21540_GPIO_SPI
 	help
 	  The model which is used to split the requested TX power into values used to control
 	  the internal state of the FEM. This model can be used for compensating for external
@@ -178,7 +181,6 @@ choice MPSL_FEM_POWER_MODEL_CHOICE
 
 config MPSL_FEM_POWER_MODEL_NRF21540_USE_BUILTIN
 	depends on MPSL_FEM_NRF21540_GPIO_SPI
-	select EXPERIMENTAL
 	bool "Use built-in MPSL model for gain control and compensation of the nRF21540 FEM"
 	help
 	  If this option is enabled a model which is contained in the MPSL is used for calculating
@@ -220,5 +222,3 @@ config MPSL_FEM_DEVICE_CONFIG_254
 module=MPSL_FEM
 module-str=MPSL_FEM
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
-
-endif	# MPSL_FEM || MPSL_FEM_PIN_FORWARDER

--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -149,10 +149,6 @@ config MPSL_FEM_NRF21540_RUNTIME_PA_GAIN_CONTROL
 
 endif   # (MPSL_FEM_NRF21540_GPIO || MPSL_FEM_NRF21540_GPIO_SPI) && MPSL_FEM
 
-config MPSL_FEM_POWER_VOLTAGE
-	int "Voltage which is used to power the FEM chip in mV"
-	default 3000
-
 config MPSL_FEM_POWER_MODEL
 	bool "Use a model to split the requested TX power into values used to control the internal state of the FEM"
 	default n

--- a/subsys/mpsl/fem/nrf21540_gpio_spi/models/mpsl_fem_nrf21540_power_model_builtin.c
+++ b/subsys/mpsl/fem/nrf21540_gpio_spi/models/mpsl_fem_nrf21540_power_model_builtin.c
@@ -14,6 +14,12 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 
+#if DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), supply_voltage_mv)
+#define MPSL_FEM_NRF21540_SUPPLY_VOLTAGE_MV  DT_PROP(DT_NODELABEL(nrf_radio_fem), supply_voltage_mv)
+#else
+#error Cannot use nRF21540 built-in power model with unspecified supply-voltage-mv property
+#endif /* !DT_NODE_HAS_PROP(DT_NODELABEL(nrf_radio_fem), supply_voltage_mv) */
+
 static int32_t last_temperature = INT32_MIN;
 
 static void model_update_work_handler(struct k_work *work)
@@ -23,7 +29,7 @@ static void model_update_work_handler(struct k_work *work)
 
 	if (last_temperature != current_temperature) {
 		external_conditions.temperature = mpsl_temperature_get() / 4;
-		external_conditions.voltage = CONFIG_MPSL_FEM_POWER_VOLTAGE / 100;
+		external_conditions.voltage = MPSL_FEM_NRF21540_SUPPLY_VOLTAGE_MV / 100;
 		mpsl_fem_nrf21540_power_model_builtin_update(&external_conditions);
 	}
 }

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8a249246bc2add52db9d1b9ee5db111e0ccda4c3
+      revision: 39044ef875edc9c2abbc7c2e142ed2a5188b3121
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This PR is marked as `DNM` now as the required changes in sdk-nrfxlib are missing.