### PR TITLE
manifest: sdk-nrfxlib PR #850, sdk-mbedtls PR #13

### DIFF
--- a/modules/tfm/tfm/boards/common/attest_hal.c
+++ b/modules/tfm/tfm/boards/common/attest_hal.c
@@ -92,7 +92,7 @@ enum tfm_plat_err_t tfm_plat_get_boot_seed(uint32_t size, uint8_t *buf)
 		return TFM_PLAT_ERR_INVALID_INPUT;
 	}
 
-	nrf_err = nrf_cc3xx_plaform_get_boot_seed(buf);
+	nrf_err = nrf_cc3xx_platform_get_boot_seed(buf);
 	if (nrf_err != NRF_CC3XX_PLATFORM_SUCCESS) {
 		return TFM_PLAT_ERR_SYSTEM_ERR;
 	}

--- a/west.yml
+++ b/west.yml
@@ -112,11 +112,11 @@ manifest:
     - name: mbedtls-nrf
       path: mbedtls
       repo-path: sdk-mbedtls
-      revision: d540e87d63c1bf51856a88657c58abc021c7ad8f
+      revision: 89419b374d17d30b7637cfb91f699c2d8432127a
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 688cdced97ff20d507def2d17d42d20654968758
+      revision: 6dd4001e584dc3a590c2d3704d9ae0b5f6edb417
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
-Adds nrf_cc3xx_platform/nrf_cc3xx_mbedcrypto v0.9.16 -Ensure constant size for psa_core_key_attributes_t with or without
 TF-M enabled to ensure binary compatibility with PSA Crypto drivers
-Add better support for TLS/DTLS when MBEDTLS_USE_PSA_CRYPTO is enabled

NCSDK-17003
NCSDK-17103
NCSDK-17464

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>

test-sdk-nrf: sdk-nrf-pr-9075