### PR TITLE
applications: nrf5340_audio: Increase BT_ISO_MAX_CHAN to 2 for bidir

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
@@ -79,6 +79,7 @@ config BT_MAX_CONN
 	default 1
 
 config BT_ISO_MAX_CHAN
+	default 2 if STREAM_BIDIRECTIONAL
 	default 1
 
 config BT_ASCS_ASE_SNK_COUNT


### PR DESCRIPTION
- When creating a bidirectional stream we need 2 ISO_CHAN because of a bug in host

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>