### PR TITLE
net: lwm2m_client_utils: Add support for RAI

### DIFF
--- a/doc/nrf/libraries/networking/lwm2m_client_utils.rst
+++ b/doc/nrf/libraries/networking/lwm2m_client_utils.rst
@@ -52,6 +52,11 @@ Disable the :kconfig:option:`CONFIG_LWM2M_CLIENT_UTILS_DEVICE_OBJ_SUPPORT` Kconf
 
 If you are using the Firmware Update object and require downloading of firmware images from TLS enabled services like HTTPS, configure :kconfig:option:`CONFIG_LWM2M_CLIENT_UTILS_DOWNLOADER_SEC_TAG` to specify the security tag that has root certificate for the target server.
 
+Additional configuration
+========================
+
+The :kconfig:option:`CONFIG_LWM2M_CLIENT_UTILS_RAI` Kconfig option enables Release Assistance Indication (RAI) for access stratum (AS). When AS RAI is configured, the device may indicate that no further data is expected in the near future and the connection may be released. AS RAI was introduced in the 3GPP Release 14 and needs to be supported by the network.
+
 Defining custom objects
 =======================
 

--- a/include/net/lwm2m_client_utils.h
+++ b/include/net/lwm2m_client_utils.h
@@ -199,6 +199,23 @@ int lwm2m_update_connmon(void);
 int lwm2m_init_cellular_connectivity_object(void);
 #endif
 
+/**
+ * @brief Initialize release assistance indication (RAI) module.
+ */
+int lwm2m_init_rai(void);
+
+/**
+ * @brief Set socket option SO_RAI_NO_DATA to bypass
+ * RRC Inactivity period and immediately switch to Idle mode.
+ */
+int lwm2m_rai_no_data(void);
+
+/**
+ * @brief Set socket option SO_RAI_LAST and send dummy packet to bypass
+ * RRC Inactivity period and immediately switch to Idle mode.
+ */
+int lwm2m_rai_last(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -270,6 +270,9 @@ static int lwm2m_setup(void)
 #if defined(CONFIG_LWM2M_CLIENT_UTILS_CELL_CONN_OBJ_SUPPORT)
 	lwm2m_init_cellular_connectivity_object();
 #endif
+	if (IS_ENABLED(CONFIG_LWM2M_CLIENT_UTILS_RAI)) {
+		lwm2m_init_rai();
+	}
 	return 0;
 }
 
@@ -404,6 +407,9 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 
 	case LWM2M_RD_CLIENT_EVENT_QUEUE_MODE_RX_OFF:
 		LOG_DBG("Queue mode RX window closed");
+		if (IS_ENABLED(CONFIG_LWM2M_CLIENT_UTILS_RAI)) {
+			lwm2m_rai_last();
+		}
 		k_mutex_unlock(&lte_mutex);
 		break;
 

--- a/subsys/net/lib/lwm2m_client_utils/CMakeLists.txt
+++ b/subsys/net/lib/lwm2m_client_utils/CMakeLists.txt
@@ -27,4 +27,6 @@ zephyr_library_sources_ifdef(CONFIG_LWM2M_CLIENT_UTILS_GNSS_ASSIST_OBJ_SUPPORT
 			     lwm2m/gnss_assistance_obj.c)
 zephyr_library_sources_ifdef(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_ASSISTANCE
 			     location/location_assistance.c)
+zephyr_library_sources_ifdef(CONFIG_LWM2M_CLIENT_UTILS_RAI
+			     lwm2m/lwm2m_rai.c)
 zephyr_include_directories(lwm2m/include)

--- a/subsys/net/lib/lwm2m_client_utils/Kconfig
+++ b/subsys/net/lib/lwm2m_client_utils/Kconfig
@@ -221,6 +221,13 @@ config LWM2M_CELL_CONN_APN_PROFILE_COUNT
 
 endif #LWM2M_CLIENT_UTILS_CELL_CONN_OBJ_SUPPORT
 
+config LWM2M_CLIENT_UTILS_RAI
+	bool "Enable release assistance indication (RAI)"
+	help
+	  This option enables RAI for access stratum (AS) which was introduced in REL14.
+	  When AS RAI is configured, device may indicate that no further data is
+	  expected in the near future and the connection may be released.
+
 module = LWM2M_CLIENT_UTILS
 module-dep = LOG
 module-str = LwM2M client utilities library

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_rai.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_rai.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/lwm2m.h>
+#include <modem/lte_lc.h>
+#include <nrf_modem_at.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(lwm2m_rai, CONFIG_LWM2M_CLIENT_UTILS_LOG_LEVEL);
+static void lte_rrc_event_handler(const struct lte_lc_evt *const evt);
+
+static bool rrc_connected;
+
+static int set_rel14feat(void)
+{
+	int ret;
+
+	ret = nrf_modem_at_printf("AT%%REL14FEAT=0,1,0,0,0");
+	if (ret) {
+		LOG_ERR("AT command failed, error code: %d", ret);
+		return -EFAULT;
+	}
+
+	return 0;
+}
+
+static int read_rai(void)
+{
+	uint16_t rai;
+	int ret;
+
+	ret = nrf_modem_at_scanf("AT%RAI?", "%%RAI: %hu", &rai);
+	if (ret != 1) {
+		LOG_ERR("Failed to read RAI, error code: %d", ret);
+		return ret;
+	}
+	LOG_DBG("RAI: %d", rai);
+	return 0;
+}
+
+static int rai_req(bool enable)
+{
+	int ret;
+
+	ret = nrf_modem_at_printf("AT%%RAI=%d", enable);
+	if (ret) {
+		LOG_ERR("AT command failed, error code: %d", ret);
+		return -EFAULT;
+	}
+
+	return 0;
+}
+
+static void lwm2m_lte_handler_register(void)
+{
+	lte_lc_register_handler(lte_rrc_event_handler);
+}
+
+static inline const char *lte_lc_rrc_mode2str(enum lte_lc_rrc_mode rrc_mode)
+{
+#if CONFIG_LWM2M_CLIENT_UTILS_LOG_LEVEL >= LOG_LEVEL_DBG
+	switch (rrc_mode) {
+	case LTE_LC_RRC_MODE_IDLE:
+		return "Idle";
+	case LTE_LC_RRC_MODE_CONNECTED:
+		return "Connected";
+	default:
+		break;
+	}
+
+	return "<Unknown>";
+#else
+	ARG_UNUSED(rrc_mode);
+
+	return "";
+#endif /* CONFIG_LWM2M_CLIENT_UTILS_LOG_LEVEL >= LOG_LEVEL_DBG */
+}
+
+static void lte_rrc_event_handler(const struct lte_lc_evt *const evt)
+{
+	switch (evt->type) {
+	case LTE_LC_EVT_RRC_UPDATE:
+		if (evt->rrc_mode == LTE_LC_RRC_MODE_CONNECTED) {
+			rrc_connected = true;
+		} else {
+			rrc_connected = false;
+		}
+		LOG_DBG("LTE RRC mode: %s", lte_lc_rrc_mode2str(evt->rrc_mode));
+		break;
+	default:
+		break;
+	}
+}
+
+int lwm2m_rai_no_data(void)
+{
+	int ret;
+	struct lwm2m_ctx *ctx;
+
+	if (rrc_connected) {
+		ctx = lwm2m_rd_client_ctx();
+
+		if (ctx->sock_fd >= 0) {
+			LOG_DBG("Set socket option SO_RAI_NO_DATA");
+			ret = setsockopt(ctx->sock_fd, SOL_SOCKET, SO_RAI_NO_DATA, NULL, 0);
+
+			if (ret < 0) {
+				ret = -errno;
+				LOG_ERR("Failed to set RAI socket option, error code: %d", ret);
+				return ret;
+			}
+		}
+	}
+
+	return 0;
+}
+
+int lwm2m_rai_last(void)
+{
+	int ret;
+	struct lwm2m_ctx *ctx;
+	u_int8_t data = 0;
+
+	if (rrc_connected) {
+		ctx = lwm2m_rd_client_ctx();
+
+		if (ctx->sock_fd >= 0) {
+			LOG_INF("Set socket option SO_RAI_LAST");
+			ret = setsockopt(ctx->sock_fd, SOL_SOCKET, SO_RAI_LAST, NULL, 0);
+
+			if (ret < 0) {
+				ret = -errno;
+				LOG_ERR("Failed to set RAI socket option, error code: %d", ret);
+				return ret;
+			}
+
+			ret = send(ctx->sock_fd, &data, sizeof(data), 0);
+
+			if (ret < 0) {
+				ret = -errno;
+				LOG_ERR("Failed to send dummy packet, error code: %d", ret);
+				return ret;
+			}
+		}
+	}
+
+	return 0;
+}
+
+int lwm2m_init_rai(void)
+{
+	set_rel14feat();
+	rai_req(true);
+	read_rai();
+	lwm2m_lte_handler_register();
+
+	return 0;
+}


### PR DESCRIPTION
Change adds support for Release Assistance Indication (RAI) which can be used to bypass RRC inactivity period and immediately switch to Idle mode.