### PR TITLE
manifest: Enable hal_wurthelektronik project from Zephyr

### DIFF
--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -511,7 +511,6 @@ _BLOCKED_PROJECTS = set(
      'modules/hal/stm32',
      'modules/hal/telink',
      'modules/hal/ti',
-     'modules/hal/wurthelektronik',
      'modules/hal/xtensa',
      'modules/lib/tflite-micro',
      'modules/tee/tf-a/trusted-firmware-a',

--- a/west.yml
+++ b/west.yml
@@ -75,6 +75,7 @@ manifest:
           - fff
           - hal_nordic
           - hal_st # required for ST sensors (unrealted to STM32 MCUs)
+          - hal_wurthelektronik
           - liblc3
           - libmetal
           - littlefs


### PR DESCRIPTION
This is a follow-up to commit e615c5f342f7db8078d311cb5282093bf76a625f.

hal_wurthelektronik needs to be enabled since the WSEN-HIDS and WSEN-ITDS sensor drivers require it.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>