### PR TITLE
manifest: sdk-hostap: Pull events fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 2e7d29c4868ada9cc4c7bc2c434b3b0c1af08527
+      revision: f665cad9361eab62d3eea077b04e68613c7e93a6
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 14e45ce9478b8b95a3d41aac6ba92a12569784c4


### PR DESCRIPTION
Pull the fix to skip sending terminate event always.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>