### PR TITLE
TF-M: Fix TF-M non-secure application not flashed when MCUBoot is enabled

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -117,16 +117,27 @@ else()
     )
 endif()
 
-# Add the dynamic partition as an image partition.
-set_property(GLOBAL PROPERTY
+# Check if the dynamic partition image hex has already been defined
+get_property(DYNAMIC_PARTITION_HEX GLOBAL PROPERTY
   ${dynamic_partition}_PM_HEX_FILE
-  ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}
   )
+if (NOT DYNAMIC_PARTITION_HEX)
+  # Add the dynamic partition as an image partition.
+  set_property(GLOBAL PROPERTY
+    ${dynamic_partition}_PM_HEX_FILE
+    ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}
+    )
+endif()
 
-set_property(GLOBAL PROPERTY
+get_property(DYNAMIC_PARTITION_TARGET GLOBAL PROPERTY
   ${dynamic_partition}_PM_TARGET
-  ${logical_target_for_zephyr_elf}
   )
+if (NOT DYNAMIC_PARTITION_TARGET)
+  set_property(GLOBAL PROPERTY
+    ${dynamic_partition}_PM_TARGET
+    ${logical_target_for_zephyr_elf}
+    )
+endif()
 
 # Prepare the input_files, header_files, and images lists
 set(generated_path include/generated)

--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -37,9 +37,9 @@ if (CONFIG_TFM_BL2)
     tfm_secure_PM_HEX_FILE ${CMAKE_BINARY_DIR}/tfm_s_signed.hex
     )
 else()
-  if (CONFIG_TFM_REGRESSION_NS)
+  if (CONFIG_TFM_USE_NS_APP)
     set_property(GLOBAL PROPERTY
-      tfm_nonsecure_PM_HEX_FILE $<TARGET_PROPERTY:tfm,TFM_NS_HEX_FILE>
+      app_PM_HEX_FILE $<TARGET_PROPERTY:tfm,TFM_NS_HEX_FILE>
       )
   endif()
 endif()


### PR DESCRIPTION
Set the TF-M non-secure application as the main app.hex file instead
of defining a hex file for the tfm_nonsecure partition.
While these are the same partitions replacing the application hex
file allows the TF-M non-secure application to be properly signed and
flashed when CONFIG_BOOTLOADER_MCUBOOT is enabled.

This requires that the partition_manager to check f the app_PM_HEX_FILE has already been defined,
and then don't overwrite this value.
This allows the definition of the application hex file to be specified
before calling the partition_manager.
