### PR TITLE
applications: asset_tracker_v2: Forward Memfault data through Azure IoT

### DIFF
--- a/applications/asset_tracker_v2/doc/debug_module.rst
+++ b/applications/asset_tracker_v2/doc/debug_module.rst
@@ -44,7 +44,8 @@ Configuration options
 .. _CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT:
 
 CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT - Configuration for transfer of Memfault data
-   This option, if enabled, makes the debug module trigger events carrying Memfault data. This data can be routed through an external transport to Memfault cloud, for example, through AWS IoT, Azure IoT Hub, or `nRF Cloud`_.
+   This option, if enabled, makes the debug module trigger events carrying Memfault data. This data can be routed through an external transport to Memfault cloud, for example, through AWS IoT, and Azure IoT Hub.
+   This option is not supported for nRF Cloud.
 
 .. _CONFIG_DEBUG_MODULE_MEMFAULT_HEARTBEAT_INTERVAL_SEC:
 

--- a/applications/asset_tracker_v2/src/modules/Kconfig.debug_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.debug_module
@@ -23,7 +23,7 @@ config DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX
 
 config DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT
 	bool "Use external transport when sending memfault data"
-	default y if AWS_IOT
+	default y if AWS_IOT || AZURE_IOT_HUB
 	help
 	  If enabled, the debug module will forward captured Memfault data via events of type
 	  DEBUG_EVT_MEMFAULT_DATA_READY. The data will be forwarded via the configured cloud


### PR DESCRIPTION
Start forwarding Memfault data through Azure IoT Hub.