### PR TITLE
applications: nrf_desktop: Fix clearing reset reason in failsafe

### DIFF
--- a/applications/nrf_desktop/src/modules/failsafe.c
+++ b/applications/nrf_desktop/src/modules/failsafe.c
@@ -22,8 +22,6 @@ static bool failsafe_check(void)
 
 	uint32_t reas = nrfx_reset_reason_get();
 
-	nrfx_reset_reason_clear(reas);
-
 	return (reas & mask) != 0;
 }
 
@@ -45,6 +43,11 @@ static void failsafe_erase(void)
 	}
 }
 
+static void failsafe_clear(void)
+{
+	nrfx_reset_reason_clear(nrfx_reset_reason_get());
+}
+
 static bool app_event_handler(const struct app_event_header *aeh)
 {
 	if (is_module_state_event(aeh)) {
@@ -60,6 +63,8 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			if (failsafe_check()) {
 				failsafe_erase();
 			}
+			failsafe_clear();
+
 			module_set_state(MODULE_STATE_READY);
 		}
 


### PR DESCRIPTION
Change moves clearing reset reason after storage is erased. This is needed to ensure that application would not boot with partially erased settings.

Jira: NCSDK-17706