### PR TITLE
dm: Improve the mpsl timeslot length setting

### DIFF
--- a/doc/nrf/libraries/others/dm.rst
+++ b/doc/nrf/libraries/others/dm.rst
@@ -51,7 +51,6 @@ To adjust the synchronization of the nodes, change the values of the following o
 
 * :kconfig:option:`CONFIG_DM_INITIATOR_DELAY_US` - Extra delay of the start of the initiator role for the distance measurement.
   Reducing this value decreases the power consumption, but leads to less successful rangings.
-* :kconfig:option:`CONFIG_DM_REFLECTOR_DELAY_US` - Extra delay of start of reflector role for the distance measurement.
 * :kconfig:option:`CONFIG_DM_MIN_TIME_BETWEEN_TIMESLOTS_US` - Minimum time between two timeslots.
   This option should account for processing of the ranging data after the timeslot.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -561,6 +561,10 @@ Other libraries
   * Changed the library implementation to bypass the flash driver when storing the emergency data.
     This allows calling the :c:func:`emds_store` function from an interrupt context.
 
+* :ref:`mod_dm`:
+  * Added a window length configuration to be used runtime, when a new measurement request is added.
+  * Improved the calculation of MPSL timeslot length by using the :ref:`nrf_dm` library functionality.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/include/dm.h
+++ b/include/dm.h
@@ -136,6 +136,9 @@ struct dm_request {
 
 	/** Start delay. */
 	uint32_t start_delay_us;
+
+	/** Extra time to extend the ranging window. */
+	uint32_t extra_window_time_us;
 };
 
 /** @brief Initialize the DM.

--- a/samples/bluetooth/nrf_dm/src/main.c
+++ b/samples/bluetooth/nrf_dm/src/main.c
@@ -105,6 +105,7 @@ static bool data_cb(struct bt_data *data, void *user_data)
 			req.ranging_mode = peer_ranging_mode_get();
 			req.access_address = sys_le32_to_cpu(recv_mfg_data->access_address);
 			req.start_delay_us = 0;
+			req.extra_window_time_us = 0;
 
 			dm_request_add(&req);
 		}
@@ -138,6 +139,7 @@ static void adv_scanned_cb(struct bt_le_ext_adv *adv,
 		req.ranging_mode = peer_ranging_mode_get();
 		req.access_address = peer_access_address_get();
 		req.start_delay_us = 0;
+		req.extra_window_time_us = 0;
 
 		dm_request_add(&req);
 	}

--- a/subsys/dm/Kconfig
+++ b/subsys/dm/Kconfig
@@ -51,25 +51,7 @@ config DM_INITIATOR_DELAY_US
 	int "Initiator start delay"
 	default 1000
 	help
-	  "Additional Initiator Start delay time. Used to improve synchronization."
-
-config DM_REFLECTOR_DELAY_US
-	int "Reflector start delay"
-	default 0
-	help
-	  "Additional Reflector Start delay time. Used to improve synchronization."
-
-config DM_INITIATOR_RANGING_WINDOW_US
-	int "Initiator ranging window"
-	default 23000
-	help
-	  "Time for ranging required by initiator role."
-
-config DM_REFLECTOR_RANGING_WINDOW_US
-	int "Reflector ranging window"
-	default 24500
-	help
-	  "Time for ranging required by reflector role."
+	  "Additional Initiator Start delay time. Used to adjust synchronization."
 
 config DM_MIN_TIME_BETWEEN_TIMESLOTS_US
 	int "Minimum time between two timeslots"

--- a/subsys/dm/rpc/client/dm_rpc_client.c
+++ b/subsys/dm/rpc/client/dm_rpc_client.c
@@ -31,7 +31,7 @@ int dm_request_add(struct dm_request *req)
 {
 	int res;
 	struct nrf_rpc_cbor_ctx ctx;
-	size_t buffer_size_max = 30; /* This value is due to the serialization method. */
+	size_t buffer_size_max = 34; /* This value is due to the serialization method. */
 
 	NRF_RPC_CBOR_ALLOC(&dm_rpc_grp, ctx, buffer_size_max);
 
@@ -41,6 +41,7 @@ int dm_request_add(struct dm_request *req)
 	ser_encode_uint(&ctx, req->access_address);
 	ser_encode_uint(&ctx, req->ranging_mode);
 	ser_encode_uint(&ctx, req->start_delay_us);
+	ser_encode_uint(&ctx, req->extra_window_time_us);
 
 	nrf_rpc_cbor_cmd_no_err(&dm_rpc_grp, DM_REQUEST_ADD_RPC_CMD, &ctx,
 				ser_rsp_decode_i32, &res);

--- a/subsys/dm/rpc/host/dm_rpc_host.c
+++ b/subsys/dm/rpc/host/dm_rpc_host.c
@@ -58,6 +58,7 @@ static void dm_request_add_rpc_handler(const struct nrf_rpc_group *group,
 	req.access_address = ser_decode_uint(ctx);
 	req.ranging_mode = ser_decode_uint(ctx);
 	req.start_delay_us = ser_decode_uint(ctx);
+	req.extra_window_time_us = ser_decode_uint(ctx);
 
 	if (!ser_decoding_done_and_check(group, ctx)) {
 		report_decoding_error(DM_REQUEST_ADD_RPC_CMD, handler_data);

--- a/subsys/dm/timeslot_queue.h
+++ b/subsys/dm/timeslot_queue.h
@@ -14,13 +14,6 @@
 extern "C" {
 #endif
 
-#define INITIATOR_DELAY_US           CONFIG_DM_INITIATOR_DELAY_US
-#define REFLECTOR_DELAY_US           CONFIG_DM_REFLECTOR_DELAY_US
-#define INITIATOR_RANGING_WINDOW_US  CONFIG_DM_INITIATOR_RANGING_WINDOW_US
-#define REFLECTOR_RANGING_WINDOW_US  CONFIG_DM_REFLECTOR_RANGING_WINDOW_US
-
-#define TIMESLOT_LENGTH_US (REFLECTOR_RANGING_WINDOW_US + (INITIATOR_DELAY_US) + 500)
-
 /** @brief Timeslot request structure */
 struct timeslot_request {
 	/* Distance measurement request structure */
@@ -28,18 +21,27 @@ struct timeslot_request {
 
 	/* The desired start time of timeslot */
 	uint32_t start_time;
+
+	/* Timeslot length*/
+	uint32_t timeslot_length_us;
+
+	/* Ranging window length */
+	uint32_t window_length_us;
 };
 
 /** @brief Append an element to the end of a queue.
  *
  *  @param req Address of the structure with request parameters.
- *  @param start_ref_tick Referen start time tick.
+ *  @param start_ref_tick Reference start time tick.
+ *  @param window_len Ranging window length.
+ *  @param timeslot_len Timeslot length.
  *
  *  @retval -ENOMEM when the tiemslot queue is full or a memory allocation error.
  *  @retval -EAGAIN when a single peer has a maximum number of timeslots scheduled.
  *  @retval -EBUSY when the timeslot cannot be scheduled due to time restrictions.
  */
-int timeslot_queue_append(struct dm_request *req, uint32_t start_ref_tick);
+int timeslot_queue_append(struct dm_request *req, uint32_t start_ref_tick,
+			  uint32_t window_len, uint32_t timeslot_len);
 
 /** @brief Peek element at the head of queue.
  *


### PR DESCRIPTION
The timeslot length and timeout for the nrf_dm_proc_execute() function
is calculated using the nrf_dm_get_duration_us() function.
In addition, these times can be extended by an additional
ranging window time, which is configured in run-time.