### PR TITLE
app_event_manager_profiler_tracer: Exclude building for native_posix

### DIFF
--- a/samples/app_event_manager_profiler_tracer/sample.yaml
+++ b/samples/app_event_manager_profiler_tracer/sample.yaml
@@ -4,6 +4,7 @@ sample:
 tests:
   sample.app_event_manager_profiler_tracer:
     build_only: true
+    platform_exclude: native_posix
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840


### PR DESCRIPTION
Excluded building this sample for native_posix as the existing filters dont result in twister excluding this sample from getting built for native_posix. When this happens the compilation would fail due to KConfig warnings related to missing HAS_SEGGER_RTT in native_posix platform.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>