### PR TITLE
applications: nrf5340_audio: Corrected Coverity issues

### DIFF
--- a/applications/nrf5340_audio/src/audio/streamctrl.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl.c
@@ -154,6 +154,7 @@ static void le_audio_rx_data_handler(uint8_t const *const p_data, size_t data_si
 
 	if (data_size > ARRAY_SIZE(iso_received->data)) {
 		ERR_CHK_MSG(-ENOMEM, "Data size too large for buffer");
+		return;
 	}
 
 	memcpy(iso_received->data, p_data, data_size);

--- a/applications/nrf5340_audio/src/modules/hw_codec.h
+++ b/applications/nrf5340_audio/src/modules/hw_codec.h
@@ -12,14 +12,14 @@
 /**
  * @brief  Set volume on HW_CODEC
  *
- * @details Also unmute the volume on HW_CODEC
+ * @details Also unmutes the volume on HW_CODEC
  *
  * @param  set_val  Set the volume to a specific value.
  *                  This range of the value is between 0 to 128.
  *
  * @return 0 if successful, error otherwise
  */
-int hw_codec_volume_set(uint16_t set_val);
+int hw_codec_volume_set(uint8_t set_val);
 
 /**
  * @brief  Adjust volume on HW_CODEC


### PR DESCRIPTION
Changed volume types and memcopy out of bounds access

Signed-off-by: Kristoffer Rist Skøien <kristoffer.skoien@nordicsemi.no>