### PR TITLE
Scripts: Update ble_console scripts for Python3 and Bluez>=5

### DIFF
--- a/scripts/shell/ble_console/BluetoothConsole.py
+++ b/scripts/shell/ble_console/BluetoothConsole.py
@@ -11,9 +11,6 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GObject, Gdk, GLib
 
-gi.require_version('Vte', '2.91')
-from gi.repository import Vte
-
 from dbus import DBusException
 from TerminalNotebook import TerminalNotebook
 from BlueZ_communication import BluetoothConnection
@@ -65,15 +62,15 @@ class BluetoothConsole( TerminalNotebook, BluetoothConnection):
         menubar = Gtk.MenuBar()
 
         filemenu = Gtk.Menu()
-        filem = Gtk.MenuItem("File")
+        filem = Gtk.MenuItem(label="File")
         filem.set_submenu(filemenu)
 
-        exit = Gtk.MenuItem("Exit")
+        exit = Gtk.MenuItem(label="Exit")
         exit.connect("activate", Gtk.main_quit)
         filemenu.append(exit)
 
         self.connect_menu = Gtk.Menu()
-        connect_item = Gtk.MenuItem("Select device")
+        connect_item = Gtk.MenuItem(label="Select device")
         connect_item.set_submenu(self.connect_menu)
 
         menubar.append(filem)
@@ -137,7 +134,7 @@ class BluetoothConsole( TerminalNotebook, BluetoothConnection):
                 self.connect_menu.remove(dev)
 
             for dev in connected_devs:
-                dev_menu_item = Gtk.CheckMenuItem(self.get_device_name(dev) + ' (' + dev + ')')
+                dev_menu_item = Gtk.CheckMenuItem(label=self.get_device_name(dev) + ' (' + dev + ')')
                 if dev in opened_devices:
                     dev_menu_item.set_active(True)
                     self.connect_to_device(dev)
@@ -150,7 +147,7 @@ class BluetoothConsole( TerminalNotebook, BluetoothConnection):
         # When there are no connected NUS devices, show info in menu
         items = [item for item in self.connect_menu]
         if not items:
-            no_bonded_menu_item = Gtk.CheckMenuItem('No compatible devices connected')
+            no_bonded_menu_item = Gtk.CheckMenuItem(label='No compatible devices connected')
             self.connect_menu.append(no_bonded_menu_item)
             self.connect_menu.show_all()
 

--- a/scripts/shell/ble_console/TerminalNotebook.py
+++ b/scripts/shell/ble_console/TerminalNotebook.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import warnings
 import re
 
 import gi
@@ -65,7 +64,7 @@ class TerminalNotebook(object):
                 self.device_string_dict[device] += text
 
     def receive_data_from_device(self, device, string):
-        self.device_terminal_dict[device].feed(string)
+        self.device_terminal_dict[device].feed(string.encode())
 
     def get_data_from_terminal(self):
         return self.device_string_dict
@@ -108,10 +107,11 @@ class TerminalNotebook(object):
         return opened_terminals
 
     def remove_terminal(self, device):
-        self.device_terminal_dict[device].feed('\033[2J')
+        termination_string = '\033[2J'
+        self.device_terminal_dict[device].feed(termination_string.encode())
         if self.notebook.get_n_pages() != 1:
-	        self.notebook.remove_page(self.notebook.page_num(self.device_terminal_dict[device]))
-	        self.notebook.queue_draw_area(0,0,-1,-1)
+            self.notebook.remove_page(self.notebook.page_num(self.device_terminal_dict[device]))
+            self.notebook.queue_draw_area(0,0,-1,-1)
         else:
             self.device_terminal_dict[device].set_color_background(COLOR_TERMINAL_INACTIVE)
         del self.device_sending_dict[device]

--- a/scripts/shell/ble_console/setup_with_cx_freeze.py
+++ b/scripts/shell/ble_console/setup_with_cx_freeze.py
@@ -5,7 +5,7 @@ from cx_Freeze import setup, Executable
 
 setup(name="Bluetooth NUS Shell for nRF Connect SDK",
       description="BLE Console is a host-side application providing access to Shell over Bluetooth Low Energy in Nordic devices.",
-      version="1.2",
+      version="1.3",
       options={"build_exe": {"build_exe": "build",
                              "packages": ["gi"],
                              "include_files":


### PR DESCRIPTION
The Python scripts used for the BLE NUS terminal example require the following minor fixes to run in Python 3. I haven't tested it with Bluez < 5.0, but I kept the original behaviour so it _should_ work. The GTK label changes are required to suppress the following deprecation warnings: "PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations"

Note that there might be more bugs hiding in the script, but these changes are at least enough to make it run and connect to a BLE device as expected. 