### PR TITLE
manifest: update Matter SDK to facilitate WiFi rev. A builds

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: eca96c021254c42abf9827aa8c958570316fd41e
+      revision: 63d38039b04789b5fcc633508629e75308f78dc5
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Recently the CONFIG_NRF700X_REV_A options has been introduced. It is disabled by default. Set it for Matter samples to make the building easier.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>