### PR TITLE
partition_manager: settings: fix unaligned partition without tfm

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -481,6 +481,12 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
   * SPDX License List database updated to version 3.18.
 
+* :ref:`partition_manager`:
+
+  * Added:
+
+    * :kconfig:option:`CONFIG_PM_PARTITION_ALIGN_SETTINGS_STORAGE` Kconfig option to specify the alignment of the settings storage partition.
+
 MCUboot
 =======
 

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -58,6 +58,14 @@ partition=SETTINGS_STORAGE
 partition-size=0x2000
 rsource "Kconfig.template.partition_config"
 rsource "Kconfig.template.partition_region"
+
+config PM_PARTITION_ALIGN_SETTINGS_STORAGE
+	hex "Settings storage partition alignment"
+	default NRF_SPU_FLASH_REGION_SIZE if BUILD_WITH_TFM
+	default FPROTECT_BLOCK_SIZE
+	help
+	  Alignment of the settings storage partition.
+
 endif
 
 if NVS && !SETTINGS_NVS

--- a/subsys/partition_manager/pm.yml.settings
+++ b/subsys/partition_manager/pm.yml.settings
@@ -6,9 +6,7 @@ settings_storage:
 #ifdef CONFIG_PM_PARTITION_REGION_SETTINGS_STORAGE_EXTERNAL
   region: external_flash
 #else
-#ifdef CONFIG_BUILD_WITH_TFM
-    align: {start: CONFIG_NRF_SPU_FLASH_REGION_SIZE}
-#endif
+    align: {start: CONFIG_PM_PARTITION_ALIGN_SETTINGS_STORAGE}
   inside: [nonsecure_storage]
   size: CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE
 #endif


### PR DESCRIPTION
Fixed the alignment for the Settings partition in the Partition Manager module for builds without the TFM option enabled.

The additional syntax should prevent the PM from placing the Settings partition at the unaligned address like in the partitions.yaml example below that was generated for the Bluetooth Fast Pair sample and the nRF52840 DK target:

_app:
  address: 0x0
  end_address: 0xfdfb8
  region: flash_primary
  size: 0xfdfb8
bt_fast_pair:
  address: 0xfffb8
  end_address: 0x100000
  placement:
    align:
      start: 0x4
    before:
    - end
  region: flash_primary
  size: 0x48
settings_storage:
  address: 0xfdfb8
  end_address: 0xfffb8
  placement:
    before:
    - end
  region: flash_primary
  size: 0x2000_
