### PR TITLE
manifest: Extended advertiser fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 399ade4fc374d53595ef1999bf842e44a4cbf91d
+      revision: cbe3b8fe8b051c976ef7f0ff913c9dc174ffea91
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Added fixes to extended advertiser to work with mesh.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>