### PR TITLE
Samples: Bluetooth: Mesh: light nRF52 DFU support

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -283,8 +283,12 @@
 .. _`nRF Programmer mobile app`: https://www.nordicsemi.com/Products/Development-tools/nrf-programmer
 
 .. _`nRF Connect Device Manager`: https://www.nordicsemi.com/Products/Development-tools/nrf-connect-device-manager
+.. _`nRF Device Manager mobile app for iOS`: https://apps.apple.com/us/app/nrf-connect-device-manager/id1519423539
+.. _`nRF Device Manager mobile app for Android`: https://play.google.com/store/apps/details?id=no.nordicsemi.android.nrfconnectdevicemanager
 
 .. _`nRF Mesh mobile app`: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Mesh
+.. _`nRF Mesh mobile app for iOS`: https://apps.apple.com/us/app/nrf-mesh/id1380726771
+.. _`nRF Mesh mobile app for Android`: https://play.google.com/store/apps/details?id=no.nordicsemi.android.nrfmeshprovisioner
 
 .. _`nRF Toolbox`: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Toolbox
 
@@ -845,9 +849,6 @@
 .. _`GCC compiler`: https://gcc.gnu.org/
 
 .. _`MCUboot`: https://www.mcuboot.com
-
-.. _`nRF Mesh mobile app for iOS`: https://apps.apple.com/us/app/nrf-mesh/id1380726771
-.. _`nRF Mesh mobile app for Android`: https://play.google.com/store/apps/details?id=no.nordicsemi.android.nrfmeshprovisioner
 
 .. _`NFC Forum specification overview`: https://nfc-forum.org/build/specifications
 .. _`Bluetooth Secure Simple Pairing Using NFC`: https://nfc-forum.org/build/specifications#application-documents

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -206,6 +206,12 @@ Bluetooth mesh samples
 
     * Support for running the light switch as a Low Power node.
 
+* :ref:`bluetooth_mesh_light` sample:
+
+  * Added:
+
+    * Point-to-point Device Firmware Update (DFU) support over the Simple Management Protocol (SMP) for supported nRF52 Series development kits.
+
 * :ref:`bluetooth_mesh_sensor_server` sample:
 
   * Added:

--- a/samples/bluetooth/mesh/light/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light/CMakeLists.txt
@@ -18,6 +18,12 @@ target_sources(app PRIVATE
 	src/model_handler.c)
 target_include_directories(app PRIVATE include)
 
+# Preinitialization related to DFU over SMP for nRF52 series
+if(CONFIG_SOC_SERIES_NRF52X)
+  target_sources_ifdef(CONFIG_MCUMGR_SMP_BT app PRIVATE
+    src/smp_dfu.c)
+endif()
+
 # Preinitialization related to Thingy:53 DFU
 target_sources_ifdef(CONFIG_BOARD_THINGY53_NRF5340_CPUAPP app PRIVATE
   boards/thingy53.c

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -13,6 +13,8 @@ The Bluetooth® mesh light sample demonstrates how to set up a mesh server model
    This sample is self-contained, and can be tested on its own.
    However, it is required when testing the :ref:`bluetooth_mesh_light_switch` sample.
 
+This sample also provides support for point-to-point Device Firmware Update (DFU) over the Simple Management Protocol (SMP).
+
 Requirements
 ************
 
@@ -29,6 +31,28 @@ The sample also requires a smartphone with Nordic Semiconductor's nRF Mesh mobil
    |thingy53_sample_note|
 
 .. include:: /includes/tfm.txt
+
+DFU requirements
+================
+
+The configuration overlay :file:`overlay-dfu.conf` enables DFU support in the application, and applies for the nRF52 series, including:
+
+* nrf52dk_nrf52832
+
+* nrf52840dk_nrf52840
+
+* nrf52833dk_nrf52833
+
+While this overlay configuration is only applicable for the nRF52 Series in this sample, DFU over SMP can be utilized on other platforms as well.
+
+.. note::
+   Point-to-point DFU for :ref:`zephyr:thingy53_nrf5340` is supported by default.
+   See :ref:`thingy53_app_update` for more information about updating firmware image on :ref:`zephyr:thingy53_nrf5340`.
+
+The DFU feature also requires a smartphone with Nordic Semiconductor's nRF Device Manager mobile app installed in one of the following versions:
+
+  * `nRF Device Manager mobile app for Android`_
+  * `nRF Device Manager mobile app for iOS`_
 
 Overview
 ********
@@ -104,6 +128,20 @@ This sample is split into the following source files:
 * :file:`thingy53.c` used to handle preinitialization of the :ref:`zephyr:thingy53_nrf5340` board.
   Only compiled when the sample is built for :ref:`zephyr:thingy53_nrf5340` board.
 
+DFU configuration
+=================
+
+To enable the DFU feature, set :makevar:`OVERLAY_CONFIG` to :file:`overlay-dfu.conf` when building the sample.
+For example, when building from the command line, use the following command:
+
+  .. code-block:: console
+
+     west build -b <BOARD> -p -- -DOVERLAY_CONFIG="overlay-dfu.conf"
+
+The configuration overlay :file:`overlay-dfu.conf` enables the DFU feature.
+To review the required configuration alterations, open and inspect the :file:`overlay-dfu.conf` file.
+For more information about using configuration overlay files, see :ref:`zephyr:important-build-vars` in the Zephyr documentation.
+
 FEM support
 ===========
 
@@ -144,6 +182,12 @@ Configure the Generic OnOff Server model on each element on the **Mesh Light** n
 * In the model view, tap :guilabel:`ON` (one of the Generic On Off Controls) to light up the first LED on the development kit.
 
 Make sure to complete the configuration on each of the elements on the node to enable controlling each of the remaining three LEDs.
+
+Running DFU
+===========
+
+After the sample is built with the :file:`overlay-dfu.conf` and programmed to your development kit, support for FOTA upgrades is enabled.
+See FOTA in Bluetooth mesh (link) for instructions on how to perform FOTA upgrade and initiate the DFU process.
 
 Dependencies
 ************

--- a/samples/bluetooth/mesh/light/include/smp_dfu.h
+++ b/samples/bluetooth/mesh/light/include/smp_dfu.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ * @brief SMP DFU support
+ */
+
+#ifndef SMP_DFU_H__
+#define SMP_DFU_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void smp_dfu_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SMP_DFU_H__ */

--- a/samples/bluetooth/mesh/light/overlay-dfu.conf
+++ b/samples/bluetooth/mesh/light/overlay-dfu.conf
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Enable point to point DFU over SMP
+CONFIG_BOOTLOADER_MCUBOOT=y
+CONFIG_MCUMGR=y
+CONFIG_MCUMGR_CMD_OS_MGMT=y
+CONFIG_MCUMGR_CMD_IMG_MGMT=y
+CONFIG_MCUMGR_SMP_BT=y
+CONFIG_MCUMGR_SMP_BT_AUTHEN=n
+
+CONFIG_BT_L2CAP_TX_MTU=252
+CONFIG_BT_BUF_ACL_RX_SIZE=256
+
+# Enable Extended Advertiser to advertise BT SMP service
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=4
+
+# One extra for mesh GATT/proxy and one for SMP BT.
+CONFIG_BT_MAX_CONN=3

--- a/samples/bluetooth/mesh/light/src/main.c
+++ b/samples/bluetooth/mesh/light/src/main.c
@@ -12,6 +12,7 @@
 #include <bluetooth/mesh/dk_prov.h>
 #include <dk_buttons_and_leds.h>
 #include "model_handler.h"
+#include "smp_dfu.h"
 
 static void bt_ready(int err)
 {
@@ -39,6 +40,10 @@ static void bt_ready(int err)
 	bt_mesh_prov_enable(BT_MESH_PROV_ADV | BT_MESH_PROV_GATT);
 
 	printk("Mesh initialized\n");
+
+	if (IS_ENABLED(CONFIG_SOC_SERIES_NRF52X) && IS_ENABLED(CONFIG_MCUMGR_SMP_BT)) {
+		smp_dfu_init();
+	}
 }
 
 void main(void)

--- a/samples/bluetooth/mesh/light/src/smp_dfu.c
+++ b/samples/bluetooth/mesh/light/src/smp_dfu.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/init.h>
+
+#include <img_mgmt/img_mgmt.h>
+#include <os_mgmt/os_mgmt.h>
+#include <zephyr/mgmt/mcumgr/smp_bt.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+
+static struct bt_le_ext_adv *adv;
+static struct bt_le_ext_adv_start_param ext_adv_param = { .num_events = 0, .timeout = 1000 };
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL, 0x84, 0xaa, 0x60, 0x74, 0x52, 0x8a, 0x8b, 0x86, 0xd3,
+		      0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
+};
+
+void sent_cb(struct bt_le_ext_adv *adv, struct bt_le_ext_adv_sent_info *info)
+{
+	int err;
+
+	err = bt_le_ext_adv_start(adv, &ext_adv_param);
+
+	if (err) {
+		printk("Advertising SMP service failed (err %d)\n", err);
+		return;
+	}
+
+	printk("Advertising SMP service\n");
+}
+
+struct bt_le_ext_adv_cb adv_callbacks = {
+	.sent = sent_cb,
+};
+
+void smp_service_adv_init(void)
+{
+	int err;
+
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, &adv_callbacks, &adv);
+	if (err) {
+		printk("Creating SMP service adv instance failed (err %d)\n", err);
+	}
+
+	err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Setting SMP service adv data failed (err %d)\n", err);
+	}
+
+	err = bt_le_ext_adv_start(adv, &ext_adv_param);
+	if (err) {
+		printk("Starting advertising of SMP service failed (err %d)\n", err);
+	}
+}
+
+void smp_dfu_init(void)
+{
+	int err;
+
+	img_mgmt_register_group();
+	os_mgmt_register_group();
+
+	err = smp_bt_register();
+
+	if (err) {
+		printk("SMP BT service registration failed (err %d)\n", err);
+		return;
+	}
+
+	/**
+	 * Since Bluetooth mesh utilizes the advertiser as the main channel of
+	 * communication, a secondary advertising set is necessary to broadcast
+	 * the SMP service.
+	 */
+	smp_service_adv_init();
+}


### PR DESCRIPTION
Adds point to point DFU support for nRF52 series, over SMP, to the mesh light sample.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>