### PR TITLE
manifest: zephyr: remove lwm2m posix names dependency

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c5340c156e0ce042b21ae716906b2746a7835343
+      revision: pull/950/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Removed LwM2M stack dependency to NET_SOCKETS_POSIX_NAMES.