### PR TITLE
tests: net: lib: azure_iot_hub: Fix segmentation fault in test

### DIFF
--- a/tests/subsys/net/lib/azure_iot_hub/mqtt/boards/qemu_cortex_m3.conf
+++ b/tests/subsys/net/lib/azure_iot_hub/mqtt/boards/qemu_cortex_m3.conf
@@ -1,6 +1,0 @@
-#
-# Copyright (c) 2022 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-CONFIG_NEWLIB_LIBC=y

--- a/tests/subsys/net/lib/azure_iot_hub/mqtt/src/azure_iot_hub_mqtt_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/mqtt/src/azure_iot_hub_mqtt_test.c
@@ -282,7 +282,19 @@ void test_mqtt_helper_connect_when_disconnected(void)
 	};
 
 	__wrap_mqtt_client_init_Expect(&mqtt_client);
-	__wrap_getaddrinfo_ExpectAnyArgsAndReturn(0);
+
+	/* Make getddrinfo return a pointer that points to NULL. Otherwise the unit under test
+	 * would be dereferencing uninitialized memory location. The behavior of the unit
+	 * under test for when non-NULL values are returned is out of scope of this test.
+	 */
+	struct zsock_addrinfo *test_res = NULL;
+
+	__wrap_getaddrinfo_ExpectAndReturn(NULL, NULL, NULL, NULL, 0);
+	__wrap_getaddrinfo_IgnoreArg_host();
+	__wrap_getaddrinfo_IgnoreArg_hints();
+	__wrap_getaddrinfo_IgnoreArg_res();
+	__wrap_getaddrinfo_ReturnThruPtr_res(&test_res);
+
 	__wrap_freeaddrinfo_ExpectAnyArgs();
 	__wrap_mqtt_connect_ExpectAndReturn(&mqtt_client, 0);
 


### PR DESCRIPTION
Fix an segmentation fault that occurs due to uninitialized variable. The test would crash randomly. It always crashed when disabling all compiler optimizations.
Fix was to make getddrinfo return a valid pointer as result. This valid pointer need to point NULL to avoid the Unit Under Test from dereferencing it further for further operations. Previously this pointer was uninitialized and was pointing some random value in memory which may or may not be zero.

The segmentation was seen in the new workflow added in https://github.com/nrfconnect/sdk-nrf/pull/7532 and was reproduced locally by disabling compiler optimization