### PR TITLE
doc: ESB TX/RX sample: remove FEM support

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -298,7 +298,9 @@ Wi-Fi samples
 Other samples
 -------------
 
-|no_changes_yet_note|
+* :ref:`esb_prx_ptx` sample:
+
+  * Removed the FEM support section.
 
 Drivers
 =======

--- a/samples/esb/README.rst
+++ b/samples/esb/README.rst
@@ -44,11 +44,6 @@ Configuration
 
 |config|
 
-FEM support
-===========
-
-.. include:: /includes/sample_fem_support.txt
-
 User interface
 ***************
 


### PR DESCRIPTION
The sample does not yet support FEM. Took the
FEM support section out.

Ref: NCSDK-16547

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>