### PR TITLE
doc: Fixed generating software maturity table for Matter

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -4,6 +4,7 @@ top_table:
   Thread: NET_L2_OPENTHREAD
   LTE: LTE_LINK_CONTROL
   HomeKit: HOMEKIT
+  Matter: CHIP
 features:
   zigbee:
     Zigbee (Sleepy) End Device: ZIGBEE_ROLE_END_DEVICE
@@ -27,7 +28,7 @@ features:
     Thread + nRF21540 (GPIO): NET_L2_OPENTHREAD && (MPSL_FEM_NRF21540_GPIO_SUPPORT || MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT)
   matter:
     Matter over Thread: CHIP && NET_L2_OPENTHREAD
-    Matter over Wi-Fi: CHIP && WIFI_NRF700X
+    Matter over Wi-Fi: CHIP_OVER_WIFI
     Matter commissioning over IP: CHIP
     Matter commissioning over Bluetooth LE with QR code onboarding: CHIP && BT
     Matter commissioning over Bluetooth LE with NFC onboarding: CHIP && BT && CHIP_NFC_COMMISSIONING

--- a/subsys/matter/Kconfig
+++ b/subsys/matter/Kconfig
@@ -4,6 +4,7 @@
 #
 
 # Support for Matter (formerly Connected Home over IP) protocol in NCS is experimental for Wi-Fi technology
-config CHIP
+config CHIP_OVER_WIFI
 	bool
-	select EXPERIMENTAL if WIFI_NRF700X
+	default y if CHIP && WIFI_NRF700X
+	select EXPERIMENTAL


### PR DESCRIPTION
Currently the software maturity table is generated in a wrong way for Matter, because it shows experimental support for all features on nRF5340 instead of supported. That's because nRF7002DK configuration that is experimental affects nRF5340 results due to using the same SoC.

* Fixed maturity table condition for Matter
* Added Matter to the table of protocols
* Replaced setting experimental symbol to CHIP for Wi-Fi with setting experimental symbol for CHIP_OVER_WIFI

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>