### PR TITLE
net:lib:  azure_iot_hub: Fix doc reference to secondary sec tag

### DIFF
--- a/doc/nrf/libraries/networking/azure_iot_hub.rst
+++ b/doc/nrf/libraries/networking/azure_iot_hub.rst
@@ -49,7 +49,7 @@ The Azure IoT Hub library requires provisioning of the following certificates an
    Azure has started the process of migrating their IoT Hub and DPS server certificates from `Baltimore CyberTrust Root Certificate`_ to `DigiCert Global Root G2`_.
    Azure advises to have both Baltimore CyberTrust Root and DigiCert Global Root G2 certificates for all devices to avoid disruption of service during the transition.
    Refer to `Azure IoT TLS: Critical changes`_ for updated information and timeline.
-   Due to this, it is recommended to provision the DigiCert Root G2 certificate to a secondary security tag set by the :kconfig:option:`CONFIG_AZURE_IOT_HUB_SEC_TAG` option.
+   Due to this, it is recommended to provision the DigiCert Root G2 certificate to a secondary security tag set by the :kconfig:option:`CONFIG_AZURE_IOT_HUB_SECONDARY_SEC_TAG` option.
    This ensures that the device can connect after the transition.
 
 .. note::


### PR DESCRIPTION
Set the reference to secondary sec tag option to the correct one.