### PR TITLE
manifest: zephyr: Pull fixes to tfm-regression-test sample.yaml file

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5cef595fdb172639d9c5730023e8517e250523bc
+      revision: 7c71945d42f690bbee663d9380ee604c94c42d6b
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull fixes to tfm-regression-test sample.yaml file. This caused the regression test config for library model to run in IPC model.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>