### PR TITLE
fix SUPL socket handling when peer closes the socket

### DIFF
--- a/samples/nrf9160/gnss/src/assistance_supl.c
+++ b/samples/nrf9160/gnss/src/assistance_supl.c
@@ -30,7 +30,11 @@ static ssize_t supl_read(void *p_buff, size_t nbytes, void *user_data)
 	ssize_t rc = recv(supl_fd, p_buff, nbytes, 0);
 
 	if (rc < 0 && (errno == EAGAIN)) {
-		return 0;
+		/* Return 0 to indicate a timeout. */
+		rc = 0;
+	} else if (rc == 0) {
+		/* Peer closed the socket, return an error. */
+		rc = -1;
 	}
 
 	return rc;

--- a/samples/nrf9160/modem_shell/src/gnss/gnss_supl_support.c
+++ b/samples/nrf9160/modem_shell/src/gnss/gnss_supl_support.c
@@ -154,7 +154,11 @@ ssize_t supl_read(void *buf, size_t nbytes, void *user_data)
 	ssize_t rc = recv(supl_fd, buf, nbytes, 0);
 
 	if (rc < 0 && (errno == EAGAIN)) {
-		return 0;
+		/* Return 0 to indicate a timeout. */
+		rc = 0;
+	} else if (rc == 0) {
+		/* Peer closed the socket, return an error. */
+		rc = -1;
 	}
 
 	return rc;

--- a/samples/nrf9160/modem_shell/src/link/link_api.c
+++ b/samples/nrf9160/modem_shell/src/link/link_api.c
@@ -430,16 +430,14 @@ parse:
 	}
 	dns_addr_str[param_str_len] = '\0';
 
-	if (dns_addr_str != NULL) {
-		family = net_utils_sa_family_from_ip_string(dns_addr_str);
+	family = net_utils_sa_family_from_ip_string(dns_addr_str);
 
-		if (family == AF_INET) {
-			addr = &(populated_info->dns_addr4_primary);
-			(void)inet_pton(AF_INET, dns_addr_str, addr);
-		} else if (family == AF_INET6) {
-			addr6 = &(populated_info->dns_addr6_primary);
-			(void)inet_pton(AF_INET6, dns_addr_str, addr6);
-		}
+	if (family == AF_INET) {
+		addr = &(populated_info->dns_addr4_primary);
+		(void)inet_pton(AF_INET, dns_addr_str, addr);
+	} else if (family == AF_INET6) {
+		addr6 = &(populated_info->dns_addr6_primary);
+		(void)inet_pton(AF_INET6, dns_addr_str, addr6);
 	}
 
 	/* Read secondary DNS address */
@@ -455,16 +453,14 @@ parse:
 	}
 	dns_addr_str[param_str_len] = '\0';
 
-	if (dns_addr_str != NULL) {
-		family = net_utils_sa_family_from_ip_string(dns_addr_str);
+	family = net_utils_sa_family_from_ip_string(dns_addr_str);
 
-		if (family == AF_INET) {
-			addr = &(populated_info->dns_addr4_secondary);
-			(void)inet_pton(AF_INET, dns_addr_str, addr);
-		} else if (family == AF_INET6) {
-			addr6 = &(populated_info->dns_addr6_secondary);
-			(void)inet_pton(AF_INET6, dns_addr_str, addr6);
-		}
+	if (family == AF_INET) {
+		addr = &(populated_info->dns_addr4_secondary);
+		(void)inet_pton(AF_INET, dns_addr_str, addr);
+	} else if (family == AF_INET6) {
+		addr6 = &(populated_info->dns_addr6_secondary);
+		(void)inet_pton(AF_INET6, dns_addr_str, addr6);
 	}
 
 	/* Read link MTU if exists:

--- a/samples/nrf9160/modem_shell/src/ping/icmp_ping_shell.c
+++ b/samples/nrf9160/modem_shell/src/ping/icmp_ping_shell.c
@@ -169,7 +169,7 @@ int icmp_ping_shell_th(const struct shell *shell, size_t argc, char **argv,
 	}
 
 	/* Check that all mandatory args were given: */
-	if (ping_args.target_name == NULL) {
+	if (strlen(ping_args.target_name) == 0) {
 		ping_error(&ping_args, "-d destination, MUST be given. See usage:");
 		goto show_usage;
 	}


### PR DESCRIPTION
Added missing handling for a case where the SUPL server unexpectedly closes the socket. Fixes NCSDK-17762.

Fixed a few compilation warnings with Zephyr SDK 0.15.0. The warning in "ping" command handling was a real bug, the command was accepted even when the destination address was not given.