### PR TITLE
cmake: multi_image: match ^CLI_CONFIG in addition to ^CONFIG_

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -59,9 +59,12 @@ else()
       list(APPEND application_vars ${var_name})
     endif()
 
-    # All CONFIG_.* variables are given helptext by the build system. Therefore
-    # we need this special handling for passing the value to the variant image.
-    if("${var_name}" MATCHES "^CONFIG_.*")
+    # All CONFIG_.* and CLI_CONFIG_* variables are given helptext by the build
+    # system. Therefore we need this special handling for passing the value to
+    # the variant image.
+    if("${var_name}" MATCHES "^CONFIG_.*" OR
+       "${var_name}" MATCHES "^CLI_CONFIG_.*"
+    )
       list(APPEND application_vars ${var_name})
     endif()
 


### PR DESCRIPTION
The Zephyr commit: 4cb2ef83bfd1a4db3c37e66e1cf65bb6ec0145ef introduced a CLI_CONFIG_ symbol to proper handle quoted Kconfig strings.

This means that CMake cache now contains CLI_CONFIG_ variables which must be passed on to image variants through the image_preload.cmake file.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>