### PR TITLE
applications: nrf5340_audio: Removed pin fwd in led driver

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/ble_core.c
+++ b/applications/nrf5340_audio/src/bluetooth/ble_core.c
@@ -3,15 +3,17 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
 #include "ble_core.h"
-#include "ble_hci_vsc.h"
+
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/gpio.h>
 #include <errno.h>
+
 #include "macros_common.h"
+#include "ble_hci_vsc.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ble, CONFIG_LOG_BLE_LEVEL);
@@ -116,15 +118,15 @@ static int controller_leds_mapping(void)
 	int ret;
 
 	ret = ble_hci_vsc_map_led_pin(PAL_LED_ID_CPU_ACTIVE,
-				      DT_GPIO_FLAGS_BY_IDX(DT_NODELABEL(rgb2_green), gpios, 0),
-				      DT_GPIO_PIN_BY_IDX(DT_NODELABEL(rgb2_green), gpios, 0));
+			DT_GPIO_FLAGS_BY_IDX(DT_NODELABEL(rgb2_green), gpios, 0),
+			DT_GPIO_PIN_BY_IDX(DT_NODELABEL(rgb2_green), gpios, 0));
 	if (ret) {
 		return ret;
 	}
 
 	ret = ble_hci_vsc_map_led_pin(PAL_LED_ID_ERROR,
-				      DT_GPIO_FLAGS_BY_IDX(DT_NODELABEL(rgb2_red), gpios, 0),
-				      DT_GPIO_PIN_BY_IDX(DT_NODELABEL(rgb2_red), gpios, 0));
+			DT_GPIO_FLAGS_BY_IDX(DT_NODELABEL(rgb2_red), gpios, 0),
+			DT_GPIO_PIN_BY_IDX(DT_NODELABEL(rgb2_red), gpios, 0));
 	if (ret) {
 		return ret;
 	}

--- a/applications/nrf5340_audio/src/modules/led.h
+++ b/applications/nrf5340_audio/src/modules/led.h
@@ -9,6 +9,12 @@
 
 #include <stdint.h>
 
+#define LED_APP_RGB 0
+#define LED_NET_RGB 1
+#define LED_APP_1_BLUE 2
+#define LED_APP_2_GREEN 3
+#define LED_APP_3_GREEN 4
+
 #define RED 0
 #define GREEN 1
 #define BLUE 2
@@ -42,8 +48,8 @@ enum led_color {
  * @note		If the given LED unit is an RGB LED, color must be
  *			provided as a single vararg. See led_color.
  *			For monochrome LEDs, the vararg will be ignored.
+ *			Using a LED unit assigned to another core will do nothing and return 0.
  * @return		0 on success
- *			-ENXIO if the given led unit is assigned to another core
  *			-EPERM if the module has not been initialised
  *			-EINVAL if the color argument is illegal
  *			Other errors from underlying drivers.
@@ -59,8 +65,8 @@ int led_blink(uint8_t led_unit, ...);
  * @note		If the given LED unit is an RGB LED, color must be
  *			provided as a single vararg. See led_color.
  *			For monochrome LEDs, the vararg will be ignored.
+*			Using a LED unit assigned to another core will do nothing and return 0.
  * @return		0 on success
- *			-ENXIO if the given led unit is assigned to another core
  *			-EPERM if the module has not been initialised
  *			-EINVAL if the color argument is illegal
  *			Other errors from underlying drivers.
@@ -71,10 +77,10 @@ int led_on(uint8_t led_unit, ...);
  * @brief Set the state of a given LED unit to off.
  *
  * @note A led unit is defined as an RGB LED or a monochrome LED.
+ *		Using a LED unit assigned to another core will do nothing and return 0.
  *
  * @param led_unit	Selected LED unit. Defines are located in board.h
  * @return		0 on success
- *			-ENXIO if the given led unit is assigned to another core
  *			-EPERM if the module has not been initialised
  *			-EINVAL if the color argument is illegal
  *			Other errors from underlying drivers.
@@ -89,8 +95,7 @@ int led_off(uint8_t led_unit);
  * @return	0 on success
  *		-EPERM if already initialsed
  *		-ENXIO if a LED is missing unit number in dts
- *		-ENODEV if a LED is missing core specifier or
- *		color identifier
+ *		-ENODEV if a LED is missing color identifier
  */
 int led_init(void);
 

--- a/boards/arm/nrf5340_audio_dk_nrf5340/board.h
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/board.h
@@ -57,10 +57,4 @@ static const struct board_version BOARD_VERSION_ARR[] = {
 	 BOARD_PCA10121_0_9_0_MSK | BOARD_PCA10121_0_10_0_MSK | BOARD_PCA10121_1_0_0_MSK |         \
 	 BOARD_PCA10121_1_1_0_MSK)
 
-#define LED_APP_RGB 0
-#define LED_NET_RGB 1
-#define LED_APP_1_BLUE 2
-#define LED_APP_2_GREEN 3
-#define LED_APP_3_GREEN 4
-
 #endif

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dts
@@ -21,6 +21,9 @@
 		uart {
 			gpios = <&gpio1 9 0>, <&gpio1 8 0>, <&gpio1 11 0>, <&gpio1 10 0>;
 		};
+		leds {
+			gpios = <&gpio0 28 0>, <&gpio0 29 0>, <&gpio0 30 0>;
+		};
 	};
 };
 

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_shared.dts
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_shared.dts
@@ -1,45 +1,44 @@
 / {
-leds:	leds {
+	leds:	leds {
 		compatible = "gpio-leds";
 		rgb1_red: led_0 {
 			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
-			label = "0 LED_RGB_RED CORE_APP";
+			label = "0 LED_RGB_RED";
 		};
 		rgb1_green: led_1 {
 			gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
-			label = "0 LED_RGB_GREEN CORE_APP";
+			label = "0 LED_RGB_GREEN";
 		};
 		rgb1_blue: led_2 {
 			gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
-			label = "0 LED_RGB_BLUE CORE_APP";
+			label = "0 LED_RGB_BLUE";
 		};
 		rgb2_red: led_3 {
 			gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
-			label = "1 LED_RGB_RED CORE_NET";
+			label = "1 LED_RGB_RED";
 		};
 		rgb2_green: led_4 {
 			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
-			label = "1 LED_RGB_GREEN CORE_NET";
+			label = "1 LED_RGB_GREEN";
 		};
 		rgb2_blue: led_5 {
 			gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
-			label = "1 LED_RGB_BLUE CORE_NET";
+			label = "1 LED_RGB_BLUE";
 		};
 		led1_blue: led_6 {
 			gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
-			label = "2 LED_MONO_BLUE CORE_APP";
+			label = "2 LED_MONO_BLUE";
 		};
 		led2_green: led_7 {
 			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
-			label = "3 LED_MONO_GREEN CORE_APP";
+			label = "3 LED_MONO_GREEN";
 		};
 		led3_green: led_8 {
 			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
-			label = "4 LED_MONO_GREEN CORE_APP";
+			label = "4 LED_MONO_GREEN";
 		};
 
 	};
-
 	buttons {
 		compatible = "gpio-keys";
 		button_1_vol_dn: button_1_vol_dn {


### PR DESCRIPTION
Pin forwarding is now performed in the devicetree

Signed-off-by: Kristoffer Rist Skøien <kristoffer.skoien@nordicsemi.no>