### PR TITLE
caf: ble_adv: Improve initialization chain

### DIFF
--- a/applications/machine_learning/configuration/common/settings_loader_def.h
+++ b/applications/machine_learning/configuration/common/settings_loader_def.h
@@ -20,7 +20,7 @@ const struct {} settings_loader_def_include_once;
 static void get_req_modules(struct module_flags *mf)
 {
 	module_flags_set_bit(mf, MODULE_IDX(main));
-#ifdef CONFIG_CAF_BLE_ADV
-	module_flags_set_bit(mf, MODULE_IDX(ble_adv));
+#ifdef CONFIG_CAF_BLE_STATE
+	module_flags_set_bit(mf, MODULE_IDX(ble_state));
 #endif
 }

--- a/applications/nrf_desktop/configuration/common/settings_loader_def.h
+++ b/applications/nrf_desktop/configuration/common/settings_loader_def.h
@@ -26,8 +26,8 @@ static inline void get_req_modules(struct module_flags *mf)
 #if CONFIG_DESKTOP_BAS_ENABLE
 	module_flags_set_bit(mf, MODULE_IDX(bas));
 #endif
-#if CONFIG_CAF_BLE_ADV
-	module_flags_set_bit(mf, MODULE_IDX(ble_adv));
+#ifdef CONFIG_CAF_BLE_STATE
+	module_flags_set_bit(mf, MODULE_IDX(ble_state));
 #endif
 #if CONFIG_DESKTOP_MOTION_SENSOR_ENABLE
 	module_flags_set_bit(mf, MODULE_IDX(motion));

--- a/subsys/caf/modules/Kconfig.ble_adv
+++ b/subsys/caf/modules/Kconfig.ble_adv
@@ -8,6 +8,7 @@ menuconfig CAF_BLE_ADV
 	bool "Enable Bluetooth LE advertising"
 	depends on BT_PERIPHERAL
 	depends on CAF_BLE_COMMON_EVENTS
+	depends on CAF_BLE_STATE
 	select BT_ADV_PROV
 
 if CAF_BLE_ADV

--- a/subsys/caf/modules/ble_adv.c
+++ b/subsys/caf/modules/ble_adv.c
@@ -410,11 +410,6 @@ static void init(void)
 	if (IS_ENABLED(CONFIG_CAF_BLE_ADV_GRACE_PERIOD)) {
 		k_work_init_delayable(&grace_period_end, grace_period_fn);
 	}
-
-	/* We should not start advertising before ble_bond is ready.
-	 * Stay in disabled state. */
-
-	module_set_state(MODULE_STATE_READY);
 }
 
 static void start(void)
@@ -423,6 +418,8 @@ static void start(void)
 
 	if (err) {
 		module_set_state(MODULE_STATE_ERROR);
+	} else {
+		module_set_state(MODULE_STATE_READY);
 	}
 
 	return;
@@ -473,7 +470,7 @@ static void disconnect_peer(struct bt_conn *conn)
 	}
 }
 
-static void ble_initialized(void)
+static void ble_ready(void)
 {
 	static bool started;
 
@@ -498,23 +495,52 @@ static void ble_initialized(void)
 	started = true;
 }
 
+static inline void get_req_modules(struct module_flags *mf)
+{
+	BUILD_ASSERT(!(IS_ENABLED(CONFIG_BT_SETTINGS) && !IS_ENABLED(CONFIG_CAF_SETTINGS_LOADER)),
+		     "Bluetooth settings enabled, but settings loader module is disabled");
+
+	module_flags_set_bit(mf, MODULE_IDX(ble_state));
+
+	if (IS_ENABLED(CONFIG_CAF_SETTINGS_LOADER)) {
+		module_flags_set_bit(mf, MODULE_IDX(settings_loader));
+	}
+
+	if (IS_ENABLED(CONFIG_CAF_BLE_ADV_BLE_BOND_SUPPORTED)) {
+		module_flags_set_bit(mf, MODULE_IDX(ble_bond));
+	}
+}
+
 static bool handle_module_state_event(const struct module_state_event *event)
 {
-	if (check_state(event, MODULE_ID(ble_state), MODULE_STATE_READY)) {
-		static bool initialized;
+	static struct module_flags req_modules_bm;
+	static bool initialized;
 
+	if (check_state(event, MODULE_ID(main), MODULE_STATE_READY)) {
 		__ASSERT_NO_MSG(!initialized);
+
+		get_req_modules(&req_modules_bm);
+		__ASSERT_NO_MSG(!module_flags_check_zero(&req_modules_bm));
 
 		init();
 		initialized = true;
 
-		if (!IS_ENABLED(CONFIG_CAF_BLE_ADV_BLE_BOND_SUPPORTED)) {
-			ble_initialized();
+		return false;
+	}
+
+	if (module_flags_check_zero(&req_modules_bm)) {
+		/* Already initialized. */
+		return false;
+	}
+
+	if (event->state == MODULE_STATE_READY) {
+		__ASSERT_NO_MSG(initialized);
+
+		module_flags_clear_bit(&req_modules_bm, module_idx_get(event->module_id));
+
+		if (module_flags_check_zero(&req_modules_bm)) {
+			ble_ready();
 		}
-	} else if (IS_ENABLED(CONFIG_CAF_BLE_ADV_BLE_BOND_SUPPORTED) &&
-		   check_state(event, MODULE_ID(ble_bond), MODULE_STATE_READY)) {
-		/* Settings need to be loaded before advertising start */
-		ble_initialized();
 	}
 
 	return false;


### PR DESCRIPTION
The module must wait for Bluetooth settings load and ble_bond module readiness before the advertising is started. If any of these dependencies is not enabled, the module must not wait for it.

Jira: NCSDK-17522