### PR TITLE
samples: peripheral: radio_test: Add nRF7002 DK support

### DIFF
--- a/boards/arm/nrf7002dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf7002dk_nrf5340/nrf5340_cpunet_reset.c
@@ -8,6 +8,8 @@
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 
+#include <soc.h>
+
 LOG_MODULE_REGISTER(nrf7002dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
 #if defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP)

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -144,6 +144,11 @@ nRF9160 samples
 
 |no_changes_yet_note|
 
+Peripheral samples
+------------------
+
+* Added support for nrf7002 board for :ref:`radio_test`.
+
 Trusted Firmware-M (TF-M) samples
 ---------------------------------
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -44,6 +44,7 @@
 .. ### Board shortcuts
 
 .. |nRF5340DKnoref| replace:: nRF5340 DK board (PCA10095)
+.. |nRF7002DKnoref| replace:: nRF7002 DK board (PCA10143)
 
 .. |nRF9160DK| replace:: nRF9160 DK board (PCA10090) - see :ref:`ug_nrf9160`
 .. |nRF5340DK| replace:: nRF5340 DK board (PCA10095) - see :ref:`ug_nrf5340`

--- a/samples/nrf5340/empty_app_core/sample.yaml
+++ b/samples/nrf5340/empty_app_core/sample.yaml
@@ -6,5 +6,6 @@ tests:
     build_only: true
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf5340dk_nrf5340_cpuapp
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
     tags: ci_build

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -24,7 +24,7 @@ The sample supports the following development kits:
 You can use any one of the development kits listed above.
 
 .. note::
-   On nRF5340 DK, the sample is designed to run on the network core and requires the :ref:`nrf5340_remote_shell` running on the application core.
+   On nRF5340 DK and nRF7002 DK, the sample is designed to run on the network core and requires the :ref:`nrf5340_remote_shell` running on the application core.
    This sample uses the :ref:`shell_ipc_readme` library to forward shell data through the physical UART interface of the application core.
 
 The sample also requires one of the following testing devices:
@@ -168,7 +168,7 @@ Building and running
 .. include:: /includes/build_and_run.txt
 
 .. note::
-   On the nRF5340 development kit, the Radio Test sample requires the :ref:`nrf5340_remote_shell` sample on the application core.
+   On the nRF5340 or nRF7002 development kit, the Radio Test sample requires the :ref:`nrf5340_remote_shell` sample on the application core.
    The Remote IPC shell sample is built and programmed automatically by default.
    If you want to program your custom solution for the application core, unset the :kconfig:option:`CONFIG_NCS_SAMPLE_REMOTE_SHELL_CHILD_IMAGE` Kconfig option.
 
@@ -189,6 +189,9 @@ You can use the following command:
 
   west build samples/peripheral/radio_test -b nrf5340dk_nrf5340_cpunet -- -DSHIELD=nrf21540_ek -DCONFIG_RADIO_TEST_USB=y
 
+.. note::
+    You can also build the sample with the remote IPC Service Shell for the |nRF7002DKnoref| using the ``nrf7002dk_nrf5340_cpunet`` build target in the commands.
+
 .. _radio_test_testing:
 
 Testing
@@ -197,7 +200,7 @@ Testing
 After programming the sample to your development kit, complete the following steps to test it in one of the following two ways:
 
 .. note::
-   For the |nRF5340DKnoref|, see :ref:`logging_cpunet` for information about the COM terminals on which the logging output is available.
+   For the |nRF5340DKnoref| or |nRF7002DKnoref|, see :ref:`logging_cpunet` for information about the COM terminals on which the logging output is available.
 
 .. _radio_test_testing_board:
 

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -8,7 +8,8 @@ tests:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpunet
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpunet
+      - nrf7002dk_nrf5340_cpunet
+    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpunet nrf7002dk_nrf5340_cpunet
     tags: ci_build
   sample.peripheral.radio_test.nrf5340_nrf21540:
     build_only: true


### PR DESCRIPTION
Add nRF7002 DK support for radio test and empty application core samples, this is same as nRF5340 as there are no Wi-Fi changes but helps use test nRF7002 definitions (DTS).

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>