### PR TITLE
manifest: sdk-zephyr: Pull fix to disable zperf UDP prints

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 7c71945d42f690bbee663d9380ee604c94c42d6b
+      revision: 78a9e8effce0366562b9bb1f4e08096fa4cb13b9
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix to improve UDP-TX performance.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>