### PR TITLE
drivers: wifi: Add build time packet RAM length assert

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_bb.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_bb.h
@@ -19,8 +19,6 @@
 #define VIRT_TO_PHYS(addr) (HOST_PKTRAM_BB_START + (addr - fmac_ctx->base_addr_host_pktram_bb))
 #endif
 
-#define TX_MAX_DATA_SIZE (1600)
-
 void bb_init(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx);
 
 #endif /* __FMAC_BB_H__ */

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_A/host_rpu_data_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_A/host_rpu_data_if.h
@@ -18,6 +18,7 @@
 #include "pack_def.h"
 
 #define NRF_WIFI_ETH_ADDR_LEN 6
+#define TX_MAX_DATA_SIZE (1600)
 #define TX_BUF_HEADROOM 52
 
 /*

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_B/host_rpu_data_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_B/host_rpu_data_if.h
@@ -18,6 +18,7 @@
 #include "pack_def.h"
 
 #define NRF_WIFI_ETH_ADDR_LEN 6
+#define TX_MAX_DATA_SIZE (1600)
 #define TX_BUF_HEADROOM 52
 
 /*

--- a/drivers/wifi/nrf700x/osal/hw_if/hal/inc/fw_A/rpu_if.h
+++ b/drivers/wifi/nrf700x/osal/hw_if/hal/inc/fw_A/rpu_if.h
@@ -179,6 +179,8 @@
 #define NRF_WIFI_RPU_RF_CLK_TYPE_MAX 2
 #endif /* RPU_RF_C0_SUPPORT */
 
+#define RPU_PKTRAM_SIZE (RPU_ADDR_PKTRAM_END - RPU_ADDR_PKTRAM_START + 1)
+
 /**
  * struct nrf_wifi_rpu_pwr_data - Data that host may want to read from the Power IP.
  * @lfc_err: Estimated Lo Frequency Clock error in ppm.

--- a/drivers/wifi/nrf700x/osal/hw_if/hal/inc/fw_B/rpu_if.h
+++ b/drivers/wifi/nrf700x/osal/hw_if/hal/inc/fw_B/rpu_if.h
@@ -179,6 +179,7 @@
 #define NRF_WIFI_RPU_RF_CLK_TYPE_MAX 2
 #endif /* RPU_RF_C0_SUPPORT */
 
+#define RPU_PKTRAM_SIZE (RPU_ADDR_PKTRAM_END - RPU_ADDR_PKTRAM_START + 1)
 /**
  * struct nrf_wifi_rpu_pwr_data - Data that host may want to read from the Power IP.
  * @lfc_err: Estimated Lo Frequency Clock error in ppm.

--- a/drivers/wifi/nrf700x/osal/hw_if/hal/src/hal_api.c
+++ b/drivers/wifi/nrf700x/osal/hw_if/hal/src/hal_api.c
@@ -17,8 +17,6 @@
 #include "hal_interrupt.h"
 #include "pal.h"
 
-#define RPU_PKTRAM_SIZE (RPU_ADDR_PKTRAM_END - RPU_ADDR_PKTRAM_START + 1)
-
 #ifndef CONFIG_NRF700X_RADIO_TEST
 static enum wifi_nrf_status
 wifi_nrf_hal_rpu_pktram_buf_map_init(struct wifi_nrf_hal_dev_ctx *hal_dev_ctx)

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -11,6 +11,7 @@
 
 #include <stdlib.h>
 
+#include <zephyr/kernel.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/logging/log.h>
 #include <zephyr_util.h>
@@ -31,6 +32,19 @@ struct wifi_nrf_drv_priv_zep rpu_drv_priv_zep;
 
 #ifndef CONFIG_NRF700X_RADIO_TEST
 #ifdef CONFIG_NRF700X_DATA_TX
+
+#define MAX_TX_AGG 9
+#define RX_NUM_BUFS 63
+#define RX_BUF_SIZE 1600
+#define MAX_RX_QUEUES 3
+
+#define TOTAL_TX_SIZE (TX_MAX_DATA_SIZE + TX_BUF_HEADROOM)
+
+BUILD_ASSERT(RPU_PKTRAM_SIZE >=
+		((MAX_TX_AGG * MAX_TX_TOKENS * TOTAL_TX_SIZE) +
+		(RX_NUM_BUFS * RX_BUF_SIZE)),
+		"Not enough PKTRAM");
+
 static const unsigned char aggregation = 1;
 static const unsigned char wmm = 1;
 static const unsigned char max_num_tx_agg_sessions = 4;
@@ -38,15 +52,15 @@ static const unsigned char max_num_rx_agg_sessions = 2;
 static const unsigned char reorder_buf_size = 64;
 static const unsigned char max_rxampdu_size = MAX_RX_AMPDU_SIZE_64KB;
 
-static const unsigned char max_tx_aggregation = 9;
+static const unsigned char max_tx_aggregation = MAX_TX_AGG;
 
-static const unsigned int rx1_num_bufs = 21;
-static const unsigned int rx2_num_bufs = 21;
-static const unsigned int rx3_num_bufs = 21;
+static const unsigned int rx1_num_bufs = RX_NUM_BUFS / MAX_RX_QUEUES;
+static const unsigned int rx2_num_bufs = RX_NUM_BUFS / MAX_RX_QUEUES;
+static const unsigned int rx3_num_bufs = RX_NUM_BUFS / MAX_RX_QUEUES;
 
-static const unsigned int rx1_buf_sz = 1600;
-static const unsigned int rx2_buf_sz = 1600;
-static const unsigned int rx3_buf_sz = 1600;
+static const unsigned int rx1_buf_sz = RX_BUF_SIZE;
+static const unsigned int rx2_buf_sz = RX_BUF_SIZE;
+static const unsigned int rx3_buf_sz = RX_BUF_SIZE;
 
 static const unsigned char rate_protection_type;
 #else


### PR DESCRIPTION
In order to save time, add a build time packet RAM fitment assert. Add defines as its a static assert and use them for programming to RPU as well.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>