### PR TITLE
net:lib: lwm2m_client_utils: Remove unnecessarily included file

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <zephyr/net/lwm2m.h>
 #include <net/lwm2m_client_utils.h>
-#include <net/lwm2m_client_utils_location.h>
 
 #include <modem/lte_lc.h>
 #include <modem/modem_info.h>


### PR DESCRIPTION
There is no reason I can see for lwm2m_connmon.c to include lwm2m_client_utils_location.h. 

Trying to create an app that uses lwm2m connection monitoring without enabling the app event manager throws an error because of this include. Connection monitoring does not depend on the app event manager in any way, though. Removing this include doesn't break anything that I've been able to find.