### PR TITLE
applications: nrf_desktop: Allow more than one bond per local ID

### DIFF
--- a/applications/nrf_desktop/configuration/common/led_state.h
+++ b/applications/nrf_desktop/configuration/common/led_state.h
@@ -75,7 +75,12 @@ enum led_id_nrf_desktop {
 #endif
 
 #if defined(CONFIG_BT_PERIPHERAL)
-#define LED_PEER_COUNT (CONFIG_BT_MAX_PAIRED - 1)
+/* By default, peripheral uses a separate Bluetooth local identity per every Bluetooth peer.
+ * The default local identity cannot be used, because application cannot reset it.
+ * One Bluetooth local identity is reserved for the erase advertising.
+ */
+BUILD_ASSERT(CONFIG_BT_ID_MAX >= 3);
+#define LED_PEER_COUNT (CONFIG_BT_ID_MAX - 2)
 #else
 #define LED_PEER_COUNT 1
 #endif

--- a/applications/nrf_desktop/src/modules/ble_bond.c
+++ b/applications/nrf_desktop/src/modules/ble_bond.c
@@ -123,7 +123,7 @@ static bool erase_adv_was_extended;
 
 
 #if CONFIG_BT_PERIPHERAL
-#define BT_STACK_ID_LUT_SIZE CONFIG_BT_MAX_PAIRED
+#define BT_STACK_ID_LUT_SIZE (CONFIG_BT_ID_MAX - 1)
 #elif CONFIG_BT_CENTRAL
 #define BT_STACK_ID_LUT_SIZE 0
 #else
@@ -133,7 +133,7 @@ static bool erase_adv_was_extended;
 static uint8_t bt_stack_id_lut[BT_STACK_ID_LUT_SIZE];
 static bool bt_stack_id_lut_valid;
 
-#define TEMP_PEER_ID (CONFIG_BT_MAX_PAIRED - 1)
+#define TEMP_PEER_ID (BT_STACK_ID_LUT_SIZE - 1)
 #if CONFIG_DESKTOP_BLE_DONGLE_PEER_ENABLE
 #define DONGLE_PEER_ID (TEMP_PEER_ID - 1)
 #else
@@ -349,7 +349,7 @@ static void cancel_operation(void)
 static uint8_t next_peer_id(uint8_t id)
 {
 	id++;
-	BUILD_ASSERT(TEMP_PEER_ID == (CONFIG_BT_MAX_PAIRED - 1));
+	BUILD_ASSERT(TEMP_PEER_ID == (BT_STACK_ID_LUT_SIZE - 1));
 	BUILD_ASSERT(DONGLE_PEER_ID <= TEMP_PEER_ID);
 	if (id >= DONGLE_PEER_ID) {
 		__ASSERT_NO_MSG(id == DONGLE_PEER_ID);

--- a/applications/nrf_desktop/src/modules/ble_latency.c
+++ b/applications/nrf_desktop/src/modules/ble_latency.c
@@ -43,10 +43,6 @@ static uint8_t latency_state;
 
 static void security_timeout_fn(struct k_work *w)
 {
-	/* Assert one local identity holds exactly one bond.
-	 * One local identity is unused.
-	 */
-	BUILD_ASSERT(CONFIG_BT_MAX_PAIRED == (CONFIG_BT_ID_MAX - 1));
 	BUILD_ASSERT(CONFIG_BT_MAX_CONN == 1);
 	BUILD_ASSERT(CONFIG_DESKTOP_BLE_SECURITY_FAIL_TIMEOUT_S > 0);
 	__ASSERT_NO_MSG(active_conn);


### PR DESCRIPTION
Change allows for having more than one Bluetooth bond per local identity in nRF Desktop. This is needed for Fast Pair integration.

Jira: NCSDK-17784