### PR TITLE
drivers: wifi: Fix powersave configuration for RevB

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -284,6 +284,15 @@ enum wifi_nrf_status wifi_nrf_fmac_def_vif_state_chg(struct wifi_nrf_vif_ctx_zep
 		LOG_ERR("%s: wifi_nrf_fmac_chg_vif_state failed\n", __func__);
 		goto out;
 	}
+
+#ifdef CONFIG_NRF_WIFI_LOW_POWER
+	status = wifi_nrf_fmac_set_power_save(rpu_ctx_zep->rpu_ctx,
+					vif_ctx_zep->vif_idx, NRF_WIFI_PS_ENABLED);
+	if (status != WIFI_NRF_STATUS_SUCCESS) {
+		LOG_ERR("%s: wifi_nrf_fmac_set_power_save failed\n", __func__);
+		goto out;
+	}
+#endif /* CONFIG_NRF_WIFI_LOW_POWER */
 out:
 	return status;
 }


### PR DESCRIPTION
Rev-B UMAC doesn't automatically enable power save, instead it relies on host to control the setting. So, enable power save when LPM is enabled, in future once support to control this either using API or shell will be added.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>