### PR TITLE
lib: lte_link_control: ncellmeas: support for GCI search types

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -825,15 +825,17 @@ static int battery_data_get(void)
 static int neighbor_cells_measurement_start(void)
 {
 	int err;
-	enum lte_lc_neighbor_search_type type = LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT;
+	struct lte_lc_ncellmeas_params ncellmeas_params = {
+		.search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT,
+	};
 
 	if (IS_ENABLED(CONFIG_MODEM_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT)) {
-		type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT;
+		ncellmeas_params.search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT;
 	} else if (IS_ENABLED(CONFIG_MODEM_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE)) {
-		type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE;
+		ncellmeas_params.search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE;
 	}
 
-	err = lte_lc_neighbor_cell_measurement(type);
+	err = lte_lc_neighbor_cell_measurement(&ncellmeas_params);
 	if (err) {
 		LOG_ERR("Failed to start neighbor cell measurements, error: %d", err);
 		return err;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -448,6 +448,13 @@ Modem libraries
 
   * Added timeout for the entire location request.
 
+* :ref:`lte_lc_readme` library:
+
+  * Added support for GCI (Global Cell ID) neighbor cell measurement search types, which are supported by the modem firmware versions >= 1.3.4.
+
+    Parameter type in :c:func:`lte_lc_neighbor_cell_measurement` changed to :c:struct:`lte_lc_ncellmeas_params`.
+    It includes both search type and GCI count that have an impact only with GCI search types.
+
 * :ref:`modem_key_mgmt` library:
 
   * Added:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -273,6 +273,7 @@ nRF9160 samples
     * LED 1 (nRF9160 DK)/Purple LED (Thingy:91) is lit for five seconds indicating that a current location has been acquired by using the ``location get`` command.
     * Overlay files for nRF9160 DK with nRF7002 EK to enable Wi-Fi scanning support.
       With this configuration, you can, for example, obtain the current location by using the ``location get`` command.
+    * Support for new GCI (Global Cell ID) search types for ``link ncellmeas`` command, which are supported by the modem firmware versions >= 1.3.4.
 
 * :ref:`location_sample`:
 

--- a/lib/location/method_cellular.c
+++ b/lib/location/method_cellular.c
@@ -57,7 +57,7 @@ void method_cellular_lte_ind_handler(const struct lte_lc_evt *const evt)
 			cell_data.ncells_count = evt->cells_info.ncells_count;
 		} else {
 			cell_data.ncells_count = 0;
-			LOG_INF("No neighbor cell information from modem.");
+			LOG_DBG("No neighbor cell information from modem.");
 		}
 		k_sem_give(&cellmeas_data_ready);
 	} break;
@@ -73,7 +73,8 @@ static int method_cellular_ncellmeas_start(void)
 
 	LOG_DBG("Triggering cell measurements");
 
-	err = lte_lc_neighbor_cell_measurement(LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT);
+	/* Starting measurements with lte_lc default parameters */
+	err = lte_lc_neighbor_cell_measurement(NULL);
 	if (err) {
 		LOG_WRN("Failed to initiate neighbor cell measurements: %d, "
 			"next: fallback to get modem parameters",

--- a/lib/lte_link_control/lte_lc_helpers.h
+++ b/lib/lte_link_control/lte_lc_helpers.h
@@ -107,6 +107,8 @@
 	(AT_NCELLMEAS_PRE_NCELLS_PARAMS_COUNT +				\
 	 AT_NCELLMEAS_N_PARAMS_COUNT * CONFIG_LTE_NEIGHBOR_CELLS_MAX)
 
+#define AT_NCELLMEAS_GCI_CELL_PARAMS_COUNT	12
+
 /* XMODEMSLEEP command parameters. */
 #define AT_XMODEMSLEEP_SUB			"AT%%XMODEMSLEEP=1,%d,%d"
 #define AT_XMODEMSLEEP_PARAMS_COUNT_MAX		4
@@ -240,8 +242,26 @@ uint32_t neighborcell_count_get(const char *at_response);
  * @param ncell Pointer to ncell structure.
  *
  * @return Zero on success or (negative) error code otherwise.
+ *         Returns -E2BIG if the static buffers set by CONFIG_LTE_NEIGHBOR_CELLS_MAX
+ *         are to small for the modem response. The associated data is still valid,
+ *         but not complete.
  */
 int parse_ncellmeas(const char *at_response, struct lte_lc_cells_info *cells);
+
+/* @brief Parses a NCELLMEAS notification for GCI search types, and stores neighboring cell
+ *	  and measured GCI cell information in a struct.
+ *
+ * @param params Neighbor cell measurement parameters.
+ * @param at_response Pointer to buffer with AT response.
+ * @param cells Pointer to lte_lc_cells_info structure.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ *         Returns -E2BIG if the static buffers set by CONFIG_LTE_NEIGHBOR_CELLS_MAX
+ *         are to small for the modem response. The associated data is still valid,
+ *         but not complete.
+ */
+int parse_ncellmeas_gci(struct lte_lc_ncellmeas_params *params,
+	const char *at_response, struct lte_lc_cells_info *cells);
 
 /* @brief Parses an XMODEMSLEEP response and extracts the sleep type and time.
  *

--- a/samples/nrf9160/modem_shell/prj.conf
+++ b/samples/nrf9160/modem_shell/prj.conf
@@ -79,7 +79,11 @@ CONFIG_NRF_MODEM_LIB_TRACE=n
 
 # AT monitor library
 CONFIG_AT_MONITOR=y
-CONFIG_AT_MONITOR_HEAP_SIZE=512
+
+# Increase AT monitor heap because %NCELLMEAS notifications can be long.
+# Note: with legacy NCELLMEAS types, 512 is enough, but with GCI search types
+# it could be even longer: theoretical maximum of 4020 bytes.
+CONFIG_AT_MONITOR_HEAP_SIZE=4096
 
 # PDN library
 CONFIG_PDN=y

--- a/samples/nrf9160/modem_shell/src/link/link.h
+++ b/samples/nrf9160/modem_shell/src/link/link.h
@@ -24,7 +24,8 @@ void link_init(void);
 void link_ind_handler(const struct lte_lc_evt *const evt);
 void link_rsrp_subscribe(bool subscribe);
 void link_ncellmeas_start(bool start, enum link_ncellmeas_modes mode,
-			  enum lte_lc_neighbor_search_type search_type, int periodic_interval);
+			  struct lte_lc_ncellmeas_params ncellmeas_params,
+			  int periodic_interval);
 void link_modem_sleep_notifications_subscribe(uint32_t warn_time_ms, uint32_t threshold_ms);
 void link_modem_sleep_notifications_unsubscribe(void);
 void link_modem_tau_notifications_subscribe(uint32_t warn_time_ms, uint32_t threshold_ms);

--- a/samples/nrf9160/modem_shell/src/link/link_shell.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell.c
@@ -233,7 +233,13 @@ static const char link_ncellmeas_usage_str[] =
 	"                      New cell measurement is done everytime when current cell changes.\n"
 	"   --cancel,          Cancel/Stop neighbor cell measurement if still ongoing\n"
 	"   --search_type,     Used search type:\n"
-	"                      'default', 'ext_light' or 'ext_comp.'\n"
+	"                      'default', 'ext_light', 'ext_comp', 'gci_default', 'gci_ext_light'\n"
+	"                      and 'gci_ext_comp'.\n"
+	"Options for GCI search_types:\n"
+	"   --gci_count, [int] Result notification for GCI (Global Cell Id) search types from\n"
+	"                      gci_default to gci_ext_comp include Cell ID, PLMN and TAC for\n"
+	"                      up to <gci_count> cells, and optionally list of neighbor cell\n"
+	"                      measurement results related to current cell. Default 5. Range 2-15.\n"
 	"Options for continuous mode:\n"
 	"   --interval, [int]  Interval can be given in seconds. In addition to continuous mode\n"
 	"                      functionality, new cell measurement is done in every interval.\n"
@@ -251,7 +257,21 @@ static const char link_ncellmeas_usage_str[] =
 	"                      Extended complete: the modem follows the same\n"
 	"                      procedure as for type_ext_light, but will continue to perform\n"
 	"                      a complete search instead of a light search, and the search is\n"
-	"                      performed for all supported bands.\n";
+	"                      performed for all supported bands.\n"
+	"\n"
+	"                      GCI search, default. Modem searches EARFCNs\n"
+	"                      based on previous cell history.\n"
+	"\n"
+	"                      GCI search, extended light. Modem starts with the same search\n"
+	"                      method than in search_type gci_default.\n"
+	"                      If less than <gci_count> cells were found, modem continues by\n"
+	"                      performing light search on bands that are valid for the area of\n"
+	"                      the current ITU-T region.\n"
+	"\n"
+	"                      GCI search, extended complete. Modem starts with the same search\n"
+	"                      method than in search_type gci_default.\n"
+	"                      If less than <gci_count> cells were found, modem performs complete\n"
+	"                      search on all supported bands.\n";
 
 static const char link_msleep_usage_str[] =
 	"Usage: link msleep --subscribe [options] | --unsubscribe\n"
@@ -331,6 +351,7 @@ enum {
 	LINK_SHELL_OPT_CONTINUOUS,
 	LINK_SHELL_OPT_NCELLMEAS_SEARCH_TYPE,
 	LINK_SHELL_OPT_NCELLMEAS_CONTINUOUS_INTERVAL_TIME,
+	LINK_SHELL_OPT_NCELLMEAS_GCI_COUNT,
 	LINK_SHELL_OPT_SEARCH_CFG,
 	LINK_SHELL_OPT_SEARCH_PATTERN_RANGE,
 	LINK_SHELL_OPT_SEARCH_PATTERN_TABLE,
@@ -396,6 +417,7 @@ static struct option long_options[] = {
 	{ "continuous", no_argument, 0, LINK_SHELL_OPT_CONTINUOUS },
 	{ "threshold", required_argument, 0, LINK_SHELL_OPT_THRESHOLD_TIME },
 	{ "interval", required_argument, 0, LINK_SHELL_OPT_NCELLMEAS_CONTINUOUS_INTERVAL_TIME },
+	{ "gci_count", required_argument, 0, LINK_SHELL_OPT_NCELLMEAS_GCI_COUNT },
 	{ "search_type", required_argument, 0, LINK_SHELL_OPT_NCELLMEAS_SEARCH_TYPE },
 	{ "search_cfg", required_argument, 0, LINK_SHELL_OPT_SEARCH_CFG },
 	{ "search_pattern_range", required_argument, 0, LINK_SHELL_OPT_SEARCH_PATTERN_RANGE },
@@ -533,6 +555,12 @@ static enum lte_lc_neighbor_search_type
 		search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_LIGHT;
 	} else if (strcmp(search_type_str, "ext_comp") == 0) {
 		search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_EXTENDED_COMPLETE;
+	} else if (strcmp(search_type_str, "gci_default") == 0) {
+		search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_DEFAULT;
+	} else if (strcmp(search_type_str, "gci_ext_light") == 0) {
+		search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_EXTENDED_LIGHT;
+	} else if (strcmp(search_type_str, "gci_ext_comp") == 0) {
+		search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_GCI_EXTENDED_COMPLETE;
 	}
 
 	return search_type;
@@ -1183,11 +1211,16 @@ static int link_shell_msleep(const struct shell *shell, size_t argc, char **argv
 
 static int link_shell_ncellmeas(const struct shell *shell, size_t argc, char **argv)
 {
+	struct lte_lc_ncellmeas_params ncellmeas_params = {
+		.gci_count = 5,
+		.search_type = LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT,
+	};
 	enum link_shell_common_options common_option = LINK_COMMON_NONE;
 	enum link_ncellmeas_modes ncellmeasmode = LINK_NCELLMEAS_MODE_NONE;
 	enum lte_lc_neighbor_search_type ncellmeas_search_type =
 		LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT;
 	int periodic_time = 0;
+	int gci_count;
 
 	int long_index = 0;
 	int opt;
@@ -1211,6 +1244,14 @@ static int link_shell_ncellmeas(const struct shell *shell, size_t argc, char **a
 				link_shell_print_usage(LINK_CMD_NCELLMEAS);
 			}
 			break;
+		case LINK_SHELL_OPT_NCELLMEAS_GCI_COUNT:
+			gci_count = atoi(optarg);
+			if (gci_count <= 0) {
+				mosh_error("Not a valid number for --gci_count.");
+				return -EINVAL;
+			}
+			ncellmeas_params.gci_count = gci_count;
+			break;
 		case LINK_SHELL_OPT_NCELLMEAS_CONTINUOUS_INTERVAL_TIME:
 			periodic_time = atoi(optarg);
 			if (periodic_time <= 0) {
@@ -1225,11 +1266,12 @@ static int link_shell_ncellmeas(const struct shell *shell, size_t argc, char **a
 
 	if (common_option == LINK_COMMON_STOP) {
 		link_ncellmeas_start(
-			false, LINK_NCELLMEAS_MODE_NONE, LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT, 0);
+			false, LINK_NCELLMEAS_MODE_NONE, ncellmeas_params, 0);
 
 	} else if (ncellmeasmode != LINK_NCELLMEAS_MODE_NONE) {
 		mosh_print("Neighbor cell measurements and reporting starting");
-		link_ncellmeas_start(true, ncellmeasmode, ncellmeas_search_type, periodic_time);
+		ncellmeas_params.search_type = ncellmeas_search_type;
+		link_ncellmeas_start(true, ncellmeasmode, ncellmeas_params, periodic_time);
 	} else {
 		link_shell_print_usage(LINK_CMD_NCELLMEAS);
 	}

--- a/samples/nrf9160/modem_shell/src/location/location_shell.c
+++ b/samples/nrf9160/modem_shell/src/location/location_shell.c
@@ -17,7 +17,6 @@
 #include <modem/location.h>
 #include <dk_buttons_and_leds.h>
 
-
 #include "mosh_print.h"
 #include "location_cmd_utils.h"
 

--- a/samples/nrf9160/multicell_location/src/main.c
+++ b/samples/nrf9160/multicell_location/src/main.c
@@ -181,7 +181,7 @@ static void start_cell_measurements(void)
 		return;
 	}
 
-	err = lte_lc_neighbor_cell_measurement(LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT);
+	err = lte_lc_neighbor_cell_measurement(NULL);
 	if (err) {
 		LOG_ERR("Failed to initiate neighbor cell measurements, error: %d",
 			err);

--- a/samples/nrf9160/nrf_cloud_rest_cell_location/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_cell_location/src/main.c
@@ -192,9 +192,13 @@ static void get_cell_info(void)
 		k_sem_give(&cell_info_ready_sem);
 
 	} else {
+		struct lte_lc_ncellmeas_params ncellmeas_params = {
+			.search_type = search_type,
+		};
+
 		LOG_INF("Requesting neighbor cell measurement...");
 		cell_info.neighbor_cells = neighbor_cells;
-		err = lte_lc_neighbor_cell_measurement(search_type);
+		err = lte_lc_neighbor_cell_measurement(&ncellmeas_params);
 		if (err) {
 			LOG_ERR("Failed to start neighbor cell measurement, error: %d", err);
 		}

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_lte_notification.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_lte_notification.c
@@ -38,7 +38,7 @@ void lwm2m_ncell_schedule_measurement(void)
 		return;
 	}
 
-	lte_lc_neighbor_cell_measurement(LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT);
+	lte_lc_neighbor_cell_measurement(NULL);
 	measurement_scheduled = false;
 	k_sem_give(&rrc_idle);
 }
@@ -70,8 +70,7 @@ void lte_notify_handler(const struct lte_lc_evt *const evt)
 			k_sem_reset(&rrc_idle);
 		} else if (evt->rrc_mode == LTE_LC_RRC_MODE_IDLE) {
 			if (measurement_scheduled) {
-				lte_lc_neighbor_cell_measurement(
-					LTE_LC_NEIGHBOR_SEARCH_TYPE_DEFAULT);
+				lte_lc_neighbor_cell_measurement(NULL);
 				measurement_scheduled = false;
 			}
 			k_sem_give(&rrc_idle);

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -525,6 +525,12 @@ void test_location_request_default(void)
 	rest_req_ctx.port = CONFIG_MULTICELL_LOCATION_HERE_HTTPS_PORT;
 	rest_req_ctx.host = CONFIG_MULTICELL_LOCATION_HERE_HOSTNAME;
 
+	/* Wait a bit so that NCELLMEAS is sent from location lib before we send a response.
+	 * Otherwise, lte_lc would ignore NCELLMEAS notification because no NCELLMEAS on going
+	 * from lte_lc point of view.
+	 */
+	k_sleep(K_MSEC(1000));
+
 	/* Trigger NCELLMEAS response which further triggers the rest of the location calculation */
 	at_monitor_dispatch(ncellmeas_resp);
 }
@@ -567,6 +573,9 @@ void test_location_request_mode_all_cellular_gnss(void)
 	rest_req_ctx.sec_tag = CONFIG_MULTICELL_LOCATION_HERE_TLS_SEC_TAG;
 	rest_req_ctx.port = CONFIG_MULTICELL_LOCATION_HERE_HTTPS_PORT;
 	rest_req_ctx.host = CONFIG_MULTICELL_LOCATION_HERE_HOSTNAME;
+
+	/* Wait a bit so that NCELLMEAS is sent before we send response */
+	k_sleep(K_MSEC(1000));
 
 	/* Trigger NCELLMEAS response which further triggers the rest of the location calculation */
 	at_monitor_dispatch(ncellmeas_resp);

--- a/tests/lib/lte_lc/CMakeLists.txt
+++ b/tests/lib/lte_lc/CMakeLists.txt
@@ -26,4 +26,5 @@ target_include_directories(app
 target_compile_options(app
   PRIVATE
   -DCONFIG_LTE_LINK_CONTROL_LOG_LEVEL=0
+  -DCONFIG_LTE_NEIGHBOR_CELLS_MAX=10
 )


### PR DESCRIPTION
lte_lc_neighbor_cell_measurement() changed to have new lte_lc_ncellmeas_params instead of just a search_type.
In addition to old search types, lte_lc_ncellmeas_params contains new GCI (Global Cell Id) search_types and gci_count. lte_lc_cells_info data structure changed to contain also CGI neighbor cells. 
Excluding api type change (from enum to structure), changes are done in backward compatibility manners and existing ncellmeas with existing search types is working as earlier.
GCI neighbor measurements are supported by modem firmware versions >= 1.3.4.