### PR TITLE
bluetooth: controller: production support for Connection CTE Response

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -177,7 +177,6 @@ config BT_CTLR_DF
 config BT_CTLR_DF_CONN_CTE_RSP
 	bool "Connection CTE Response feature"
 	depends on BT_CTLR_DF_CONN_CTE_TX
-	select EXPERIMENTAL
 	help
 	  Enable support for Bluetooth v5.1 Connection CTE Response feature
 	  in controller.


### PR DESCRIPTION
Remove experimental flag for BT_CTLR_DF_CONN_CTE_RSP

Signed-off-by: Yuxuan Cai <yuxuan.cai@nordicsemi.no>