### PR TITLE
bluetooth: adv_prov: fast_pair: Change generated advertising data

### DIFF
--- a/applications/nrf_desktop/src/util/Kconfig
+++ b/applications/nrf_desktop/src/util/Kconfig
@@ -23,6 +23,14 @@ config BT_ADV_PROV_SWIFT_PAIR
 config BT_ADV_PROV_FAST_PAIR
 	default y if BT_FAST_PAIR
 
+config BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING
+	depends on BT_ADV_PROV_FAST_PAIR
+	default n
+	help
+	  nRF Desktop peripheral supports one bond per local identity. Disable
+	  the UI indication during Fast Pair not discoverable advertising to
+	  prevent bonding failures.
+
 config BT_ADV_PROV_TX_POWER
 	default y
 

--- a/include/bluetooth/adv_prov/fast_pair.h
+++ b/include/bluetooth/adv_prov/fast_pair.h
@@ -20,14 +20,25 @@
 extern "C" {
 #endif
 
-/** Set Fast Pair advertising mode.
+/** Enable/disable Fast Pair advertising provider.
  *
- * User shall make sure that advertising mode is not modified while Fast Pair advertising data
- * provider is providing advertising data.
+ * User shall make sure that this function is not called while Fast Pair advertising data provider
+ * is providing advertising data.
  *
- * @param[in] fp_adv_mode	Fast Pair advertising mode.
+ * @param[in] enable		Enable/disable Fast Pair provider.
  */
-void bt_le_adv_prov_fast_pair_mode_set(enum bt_fast_pair_adv_mode fp_adv_mode);
+void bt_le_adv_prov_fast_pair_enable(bool enable);
+
+/** Show/hide UI indication in Fast Pair not discoverable advertising.
+ *
+ * This configuration does not affect Fast Pair discoverable advertising.
+ *
+ * User shall make sure that this function is not called while Fast Pair advertising data provider
+ * is providing advertising data.
+ *
+ * @param[in] enable		Show/hide the UI indication.
+ */
+void bt_le_adv_prov_fast_pair_show_ui_pairing(bool enable);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
@@ -8,13 +8,13 @@ menuconfig BT_ADV_PROV_FAST_PAIR
 	bool "Google Fast Pair"
 	depends on BT_FAST_PAIR
 	help
-	  Adds Google Fast Pair payload to advertising data if device is looking
-	  for a new peer (pairing mode in the advertising state is set).
-	  By default, the advertising data provider uses Fast Pair discoverable
-	  advertising and switches to not discoverable advertising show UI
-	  indication after device receives an Account Key. Alternatively,
-	  dedicated API can be used to explicitly set the Fast Pair advertising
-	  mode.
+	  Adds Google Fast Pair payload to advertising data.
+
+	  If device is in pairing mode, provider uses Fast Pair discoverable
+	  advertising. Otherwise, Fast Pair not discoverable advertising is used.
+
+	  Application can control the generated payload using provider's Kconfig
+	  options or dedicated API.
 
 if BT_ADV_PROV_FAST_PAIR
 
@@ -25,6 +25,13 @@ config BT_ADV_PROV_FAST_PAIR_ADV_BUF_SIZE
 	help
 	  Size of the buffer must be big enough to fit Fast Pair advertising
 	  packet.
+
+config BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING
+	bool "Show UI indication in Fast Pair not discoverable advertising"
+	default y
+	help
+	  The UI indication should be displayed if device is ready for pairing.
+	  The provider also exposes API to show/hide UI indication in runtime.
 
 config BT_ADV_PROV_FAST_PAIR_AUTO_SET_PAIRING_MODE
 	bool "Automatically set Fast Pair pairing mode"

--- a/subsys/bluetooth/adv_prov/providers/fast_pair.c
+++ b/subsys/bluetooth/adv_prov/providers/fast_pair.c
@@ -9,12 +9,18 @@
 
 #define ADV_DATA_BUF_SIZE	CONFIG_BT_ADV_PROV_FAST_PAIR_ADV_BUF_SIZE
 
-static enum bt_fast_pair_adv_mode set_fp_adv_mode = BT_FAST_PAIR_ADV_MODE_COUNT;
+static bool enabled = true;
+static bool show_ui_pairing = IS_ENABLED(CONFIG_BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING);
 
 
-void bt_le_adv_prov_fast_pair_mode_set(enum bt_fast_pair_adv_mode fp_adv_mode)
+void bt_le_adv_prov_fast_pair_enable(bool enable)
 {
-	set_fp_adv_mode = fp_adv_mode;
+	enabled = enable;
+}
+
+void bt_le_adv_prov_fast_pair_show_ui_pairing(bool enable)
+{
+	show_ui_pairing = enable;
 }
 
 static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *state,
@@ -23,17 +29,17 @@ static int get_data(struct bt_data *ad, const struct bt_le_adv_prov_adv_state *s
 	static uint8_t buf[ADV_DATA_BUF_SIZE];
 	enum bt_fast_pair_adv_mode adv_mode;
 
-	if (!state->pairing_mode) {
+	if (!enabled) {
 		return -ENOENT;
 	}
 
-	if (set_fp_adv_mode != BT_FAST_PAIR_ADV_MODE_COUNT) {
-		adv_mode = set_fp_adv_mode;
+	if (state->pairing_mode) {
+		adv_mode = BT_FAST_PAIR_ADV_MODE_DISCOVERABLE;
 	} else {
-		if (bt_fast_pair_has_account_key()) {
+		if (show_ui_pairing) {
 			adv_mode = BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_SHOW_UI_IND;
 		} else {
-			adv_mode = BT_FAST_PAIR_ADV_MODE_DISCOVERABLE;
+			adv_mode = BT_FAST_PAIR_ADV_MODE_NOT_DISCOVERABLE_HIDE_UI_IND;
 		}
 	}
 


### PR DESCRIPTION
Use Fast Pair discoverable payload when in pairing mode and Fast Pair not discoverable payload when outside of pairing mode. This is done to improve user experience. The commit also introduces the needed follow-up changes to Fast Pair sample and nRF Desktop.

Jira: NCSDK-17813