### PR TITLE
applications: nrf_desktop: Make LED state def file configurable

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.led_state
+++ b/applications/nrf_desktop/src/modules/Kconfig.led_state
@@ -8,6 +8,13 @@ if CAF_LED_EVENTS
 
 menu "LED state"
 
+config DESKTOP_LED_STATE_DEF_PATH
+	string "File defining used LED effects"
+	default "led_state_def.h"
+	help
+	  Location of configuration file that holds information about the used
+	  LED effects.
+
 module = DESKTOP_LED_STATE
 module-str = LED state
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/nrf_desktop/src/modules/led_state.c
+++ b/applications/nrf_desktop/src/modules/led_state.c
@@ -17,7 +17,7 @@
 LOG_MODULE_REGISTER(MODULE, CONFIG_DESKTOP_LED_STATE_LOG_LEVEL);
 
 #include "led_state.h"
-#include "led_state_def.h"
+#include CONFIG_DESKTOP_LED_STATE_DEF_PATH
 
 
 static enum led_system_state system_state = LED_SYSTEM_STATE_IDLE;


### PR DESCRIPTION
Allow to configure the LED state def file path using Kconfig.

Jira: NCSDK-17784