### PR TITLE
net: lib: lwm2m_client_utils: connmon: Check return value

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_connmon.c
@@ -139,7 +139,11 @@ int lwm2m_init_connmon(void)
 		return ret;
 	}
 
-	modem_info_params_init(&modem_param);
+	ret = modem_info_params_init(&modem_param);
+	if (ret) {
+		LOG_ERR("Modem parameters could not be initialized: %d", ret);
+		return ret;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Return value was not checked when calling modem_info_params_init()

Signed-off-by: Juha Ylinen <juha.ylinen@nordicsemi.no>