### PR TITLE
applications: asset_tracker_v2: Silence cbprint warning

### DIFF
--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -675,7 +675,7 @@ static void qos_event_handler(const struct qos_evt *evt)
 		LOG_DBG("QOS_EVT_MESSAGE_REMOVED_FROM_LIST");
 
 		if (evt->message.heap_allocated) {
-			LOG_DBG("Freeing pointer: %p", evt->message.data.buf);
+			LOG_DBG("Freeing pointer: %p", (void *)evt->message.data.buf);
 			k_free(evt->message.data.buf);
 		}
 		break;

--- a/lib/qos/qos.c
+++ b/lib/qos/qos.c
@@ -279,7 +279,7 @@ void qos_message_print(const struct qos_data *message)
 	LOG_DBG("Notified count: %d", message->notified_count);
 	LOG_DBG("Message heap_allocated: %d", message->heap_allocated);
 	LOG_DBG("Message ID: %d", message->id);
-	LOG_DBG("Message Buffer pointer: %p", message->data.buf);
+	LOG_DBG("Message Buffer pointer: %p", (void *)message->data.buf);
 	LOG_DBG("Message Buffer length: %d", message->data.len);
 	LOG_DBG("Message Flags: %x", message->flags);
 	LOG_DBG("Message type: %d", message->type);


### PR DESCRIPTION
Silence cbprint warning that recommends casting argument used in
print statements to void * to avoid misbehavior in certain
configurations.