### PR TITLE
EMDS: Write to flash bypassing the flash driver

### DIFF
--- a/doc/nrf/libraries/others/emds.rst
+++ b/doc/nrf/libraries/others/emds.rst
@@ -48,7 +48,7 @@ When changing the :kconfig:option:`CONFIG_EMDS_FLASH_TIME_BASE_OVERHEAD_US` opti
 
 The application must call the :c:func:`emds_store` function to store all entries.
 This can only be done once, before the :c:func:`emds_prepare` function must be called again.
-When invoked, the :c:func:`emds_store` function triggers the emergency data store process in a separate thread, and then stores all the registered entries.
+When invoked, the :c:func:`emds_store` function stores all the registered entries.
 Invocation of this call should be performed when the application detects loss of power, or when a reboot is triggered.
 
 .. note::
@@ -82,7 +82,6 @@ The above described process is summarized in a message sequence diagram.
     ...;
     Application->Application  [ label = "Interrupt calling emds_store()" ];
     Application=>EMDS         [ label = "emds_store()" ];
-    EMDS box EMDS [ label = "Thread storing data executing" ];
     Application<<=EMDS        [ label = "emds_store_cb_t callback" ];
     Application->Application [ label = "Reboot/halt" ];
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -221,6 +221,11 @@ Bluetooth mesh samples
 
     * Ability to use buttons to send get and set messages for a sensor setting, as well as a get message for a sensor descriptor.
 
+* :ref:`bluetooth_mesh_light_lc`
+
+  * Removed the :c:func:`bt_disable` function call from the interrupt context before calling the :c:func:`emds_store` function.
+  * Replaced the :c:func:`mpsl_uninit` function with :c:func:`mpsl_lib_uninit`.
+
 nRF9160 samples
 ---------------
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -463,6 +463,13 @@ Other libraries
 * Added:
   * :ref:`lib_sfloat` library.
 
+* :ref:`emds_readme`:
+
+  * Removed the internal thread for storing the emergency data.
+    The emergency data is now stored by the :c:func:`emds_store` function.
+  * Changed the library implementation to bypass the flash driver when storing the emergency data.
+    This allows calling the :c:func:`emds_store` function from an interrupt context.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/samples/bluetooth/mesh/light_ctrl/src/main.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/main.c
@@ -17,6 +17,10 @@
 #ifdef CONFIG_EMDS
 #include <emds/emds.h>
 
+#if defined(CONFIG_BT_CTLR)
+#include <mpsl/mpsl_lib.h>
+#endif
+
 #define EMDS_DEV_IRQ 24
 #define EMDS_DEV_PRIO 0
 #define EMDS_ISR_ARG 0
@@ -44,10 +48,9 @@ static void isr_emds_cb(void *arg)
 {
 	ARG_UNUSED(arg);
 
-	/* Stop bt and mpsl to reduce power usage and increase storage speed. */
-	(void) bt_disable();
 #if defined(CONFIG_BT_CTLR)
-	mpsl_uninit();
+	/* Stop mpsl to reduce power usage. */
+	mpsl_lib_uninit();
 #endif
 
 	emds_store();

--- a/subsys/emds/emds.c
+++ b/subsys/emds/emds.c
@@ -14,67 +14,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(emds, CONFIG_EMDS_LOG_LEVEL);
 
-K_SEM_DEFINE(emds_sem, 0, 1);
 static bool emds_ready;
 static bool emds_initialized;
-static uint32_t store_key;
 
 static sys_slist_t emds_dynamic_entries;
 static struct emds_fs emds_flash;
 static emds_store_cb_t app_store_cb;
-
-static void emds_handler(void)
-{
-	while (true) {
-		k_sem_reset(&emds_sem);
-		k_sem_take(&emds_sem, K_FOREVER);
-
-		k_sched_lock();
-
-		LOG_DBG("Emergency Data Storeage released");
-
-		STRUCT_SECTION_FOREACH(emds_entry, ch) {
-			ssize_t len = emds_flash_write(&emds_flash,
-						       ch->id, ch->data, ch->len);
-			if (len < 0) {
-				LOG_ERR("Write static entry: (%d) error (%d)",
-					ch->id, len);
-			} else if (len != ch->len) {
-				LOG_ERR("Write static entry: (%d) failed (%d:%d)",
-					ch->id, ch->len, len);
-			}
-		}
-
-		struct emds_dynamic_entry *ch;
-
-		SYS_SLIST_FOR_EACH_CONTAINER(&emds_dynamic_entries, ch, node) {
-			ssize_t len = emds_flash_write(&emds_flash,
-						       ch->entry.id, ch->entry.data, ch->entry.len);
-			if (len < 0) {
-				LOG_ERR("Write dynamic entry: (%d) error (%d).",
-					ch->entry.id, len);
-			}
-			if (len != ch->entry.len) {
-				LOG_ERR("Write dynamic entry: (%d) failed (%d:%d).",
-					ch->entry.id, ch->entry.len, len);
-			}
-		}
-
-		emds_ready = false;
-
-		k_sched_unlock();
-
-		/* Unlock all interrupts */
-		irq_unlock(store_key);
-
-		if (app_store_cb) {
-			app_store_cb();
-		}
-	}
-}
-
-K_THREAD_DEFINE(emds_tid, CONFIG_EMDS_THREAD_STACK_SIZE, emds_handler, NULL,
-		NULL, NULL, K_PRIO_COOP(CONFIG_EMDS_THREAD_PRIORITY), 0, 0);
 
 static int emds_fs_init(void)
 {
@@ -194,6 +139,8 @@ int emds_entry_add(struct emds_dynamic_entry *entry)
 
 int emds_store(void)
 {
+	uint32_t store_key;
+
 	if (!emds_ready) {
 		return -ECANCELED;
 	}
@@ -202,7 +149,43 @@ int emds_store(void)
 	store_key = irq_lock();
 
 	/* Start the emergency data storage process. */
-	k_sem_give(&emds_sem);
+	LOG_DBG("Emergency Data Storeage released");
+
+	STRUCT_SECTION_FOREACH(emds_entry, ch) {
+		ssize_t len = emds_flash_write(&emds_flash,
+					       ch->id, ch->data, ch->len);
+		if (len < 0) {
+			LOG_ERR("Write static entry: (%d) error (%d)",
+				ch->id, len);
+		} else if (len != ch->len) {
+			LOG_ERR("Write static entry: (%d) failed (%d:%d)",
+				ch->id, ch->len, len);
+		}
+	}
+
+	struct emds_dynamic_entry *ch;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&emds_dynamic_entries, ch, node) {
+		ssize_t len = emds_flash_write(&emds_flash,
+					       ch->entry.id, ch->entry.data, ch->entry.len);
+		if (len < 0) {
+			LOG_ERR("Write dynamic entry: (%d) error (%d).",
+				ch->entry.id, len);
+		}
+		if (len != ch->entry.len) {
+			LOG_ERR("Write dynamic entry: (%d) failed (%d:%d).",
+				ch->entry.id, ch->entry.len, len);
+		}
+	}
+
+	emds_ready = false;
+
+	/* Unlock all interrupts */
+	irq_unlock(store_key);
+
+	if (app_store_cb) {
+		app_store_cb();
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This PR solves several issues:
- Allows EMDS to bypass the flash driver when writing emds data to flash to ensure deterministic write time without being blocked by mpsl;

- It also allows to call emds_store from ISR, which was not possible with the flash driver;
- Removes bt_disable call from the sample as it un-trustable and replaces mpsl_uninit call with mpsl_lib_uninit which also disables interrupts for peripherals used by SDC;