### PR TITLE
Partition Manager external flash mcuboot/thingy53

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -226,7 +226,7 @@ if (DEFINED ext_flash_dev)
     SIZE ${num_bytes}
     BASE ${CONFIG_PM_EXTERNAL_FLASH_BASE}
     PLACEMENT start_to_end
-    DEVICE ${ext_flash_dev}
+    DEVICE "DT_CHOSEN(nordic_pm_ext_flash)"
     DEFAULT_DRIVER_KCONFIG ${external_flash_driver_kconfig}
     )
 endif()

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -809,6 +809,10 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 
     * Updated the :file:`ncs/nrf/subsys/partition_manager/pm.yml.pgps` file to place P-GPS partition in external flash when so configured.
 
+  * Fixed:
+
+    * Fixed an issue with the driver and devicetree symbol for the external flash memory where the driver was sometimes NULL, even if the DT node was chosen.
+
 MCUboot
 =======
 

--- a/samples/bluetooth/mesh/light/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/mesh/light/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/bluetooth/mesh/light_ctrl/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/mesh/light_ctrl/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/bluetooth/mesh/light_switch/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/mesh/light_switch/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/bluetooth/mesh/sensor_server/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/mesh/sensor_server/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/bluetooth/peripheral_lbs/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_lbs/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/bluetooth/peripheral_uart/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/peripheral_uart/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_bulb/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/matter/light_bulb/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_bulb/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_bulb/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_switch/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/matter/light_switch/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_switch/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_switch/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/lock/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/matter/lock/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/lock/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/lock/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/template/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/matter/template/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/template/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/template/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/scripts/partition_manager_output.py
+++ b/scripts/partition_manager_output.py
@@ -24,15 +24,6 @@ def get_header_guard_end(filename):
 DEST_HEADER = 1
 DEST_KCONFIG = 2
 
-# If nl is something like /soc/peripheral@50000000/qspi@2b000/mx25r6435f@0, it will be
-# converted to C define for node, in this example
-# DT_N_S_soc_S_peripheral_50000000_S_qspi_2b000_S_mx25r6435f_0.
-# If it is just node label, something like flash_sim0, it will just return that.
-def dt_device_node_label_or_node(nl):
-    out = nl.replace('/', "_S_").replace('@', '_' )
-    if (out != nl):
-        out = f"DT_N{out}"
-    return out
 
 def get_config_lines(gpm_config, greg_config, head, split, dest, current_domain=None):
     config_lines = list()
@@ -86,7 +77,7 @@ def get_config_lines(gpm_config, greg_config, head, split, dest, current_domain=
 
             if dest is DEST_HEADER:
                 if partition_has_device(partition):
-                    add_line(f'{name_upper}_DEV', dt_device_node_label_or_node(region['device']))
+                    add_line(f'{name_upper}_DEV', region['device'])
                     if region['default_driver_kconfig']:
                         add_line(f'{name_upper}_DEFAULT_DRIVER_KCONFIG', region['default_driver_kconfig'])
 

--- a/tests/modules/mcuboot/external_flash/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/tests/modules/mcuboot/external_flash/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};


### PR DESCRIPTION
Fixes an issue where the fa_dev of the external flash was NULL because the devicetree node was resolved in the wrong context.