### PR TITLE
manifest: nrfxlib: Update nrfxlib revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -115,7 +115,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 4f4cda1d86d6e8a71ea370588c4b1bcb3a26dd5e
+      revision: pull/766/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
nrfxlib no longer contains KConfig entries for MPSL as these have been moved to sdk-nrf.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>