### PR TITLE
Lwm2m client sample update

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/events/accel_event.c
+++ b/samples/nrf9160/lwm2m_client/src/events/accel_event.c
@@ -6,35 +6,14 @@
 
 #include "accel_event.h"
 
-static const char *accel_orienation_state_to_string(enum accel_orientation_state state)
-{
-	switch (state) {
-	case ORIENTATION_NOT_KNOWN:
-		return "not known";
-
-	case ORIENTATION_NORMAL:
-		return "normal";
-
-	case ORIENTATION_UPSIDE_DOWN:
-		return "upside down";
-
-	case ORIENTATION_ON_SIDE:
-		return "on side";
-
-	default:
-		return "";
-	}
-}
-
 static void log_accel_event(const struct app_event_header *aeh)
 {
 	struct accel_event *event = cast_accel_event(aeh);
 
 	APP_EVENT_MANAGER_LOG(aeh,
-		"Accelerometer event: x = %d.%06d, y = %d.%06d, z = %d.%06d, orientation = %s.",
+		"Accelerometer event: x = %d.%06d, y = %d.%06d, z = %d.%06d.",
 		event->data.x.val1, event->data.x.val2, event->data.y.val1, event->data.y.val2,
-		event->data.z.val1, event->data.z.val2,
-		accel_orienation_state_to_string(event->orientation));
+		event->data.z.val1, event->data.z.val2);
 }
 
 APP_EVENT_TYPE_DEFINE(accel_event, log_accel_event, NULL, APP_EVENT_FLAGS_CREATE());

--- a/samples/nrf9160/lwm2m_client/src/events/include/accel_event.h
+++ b/samples/nrf9160/lwm2m_client/src/events/include/accel_event.h
@@ -21,7 +21,6 @@ struct accel_event {
 	struct app_event_header header;
 
 	struct accelerometer_sensor_data data;
-	enum accel_orientation_state orientation;
 };
 
 APP_EVENT_TYPE_DECLARE(accel_event);

--- a/samples/nrf9160/lwm2m_client/src/sensors/include/accelerometer.h
+++ b/samples/nrf9160/lwm2m_client/src/sensors/include/accelerometer.h
@@ -14,20 +14,11 @@
 extern "C" {
 #endif
 
-/**@brief Orientation states. */
-enum accel_orientation_state {
-	ORIENTATION_NOT_KNOWN, /**< Initial state. */
-	ORIENTATION_NORMAL, /**< Has normal orientation. */
-	ORIENTATION_UPSIDE_DOWN, /**< System is upside down. */
-	ORIENTATION_ON_SIDE /**< System is placed on its side. */
-};
-
 /**@brief Struct containing current orientation and 3 axis acceleration data. */
 struct accelerometer_sensor_data {
 	struct sensor_value x; /**< x-axis acceleration [m/s^2]. */
 	struct sensor_value y; /**< y-axis acceleration [m/s^2]. */
 	struct sensor_value z; /**< z-axis acceleration [m/s^2]. */
-	enum accel_orientation_state orientation; /**< Current orientation. */
 };
 
 int accelerometer_read(struct accelerometer_sensor_data *data);

--- a/samples/nrf9160/lwm2m_client/src/ui/ui_input.c
+++ b/samples/nrf9160/lwm2m_client/src/ui/ui_input.c
@@ -39,6 +39,10 @@ static void dk_input_device_event_handler(uint32_t device_states, uint32_t has_c
 			}
 		}
 
+		if (dev_num == 0) {
+			return;
+		}
+
 		/* Device number has been stored, remove from bitmask. */
 		has_changed &= ~(1UL << (dev_num - 1));
 


### PR DESCRIPTION
- Fix possible negative shifting
- Removed unused and uninitialized orientation data from accelerometer event structure