### PR TITLE
manifest: revert softdevice_controller and mpsl update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -115,7 +115,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 5a16b708e83a0b210eab610a8aba0fd3e05d3ba8
+      revision: 4f4cda1d86d6e8a71ea370588c4b1bcb3a26dd5e
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Update manifest to revert softdevice_controller and mpsl update that introduced a regression.
The Bluetooth tests CI are red because of this regression.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>