### PR TITLE
bluetooth: Add support for le power control feature commands

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -286,5 +286,12 @@ config BT_CTLR_SDC_CX_ADV_CLOSE_ADV_EVT_ON_DENIAL
 endchoice
 endif # MPSL_CX && BT_BROADCASTER
 
+config BT_CTLR_LE_POWER_CONTROL
+	bool "LE Power Control [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  Enable support for LE Power Control feature that defined in the Bluetooth
+	  Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.31.
+
 endmenu
 endif  # BT_LL_SOFTDEVICE

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -569,6 +569,22 @@ static int configure_supported_features(void)
 	}
 #endif
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_LE_POWER_CONTROL)) {
+		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+			err = sdc_support_le_power_control_central();
+			if (err) {
+				return -ENOTSUP;
+			}
+		}
+
+		if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+			err = sdc_support_le_power_control_peripheral();
+			if (err) {
+				return -ENOTSUP;
+			}
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
LE Power Control feature is implemented for softdevice controller. The feature is defined in the Bluetooth Core specification Version 5.3 | Vol 6, Part B, Section 4.6.31.

Signed-off-by: Ilhan Ates <ilhan.ates@nordicsemi.no>