### PR TITLE
application: nrf_desktop: update the b0 bootloader config in readme

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -1556,6 +1556,8 @@ The B0 bootloader requires the following options enabled:
 * :kconfig:option:`CONFIG_SB_SIGNING_KEY_FILE` - Required for providing the signature used for image signing and verification.
 * :kconfig:option:`CONFIG_FW_INFO` - Required for the application versioning information.
 * :kconfig:option:`CONFIG_FW_INFO_FIRMWARE_VERSION` - Enable this option to set the version of the application after you enabled :kconfig:option:`CONFIG_FW_INFO`.
+  For the DFU package generation, you need to update this configuration in the main application image and the ``s1_image`` child image.
+  You can do that by rebuilding the application from scratch or by changing the configuration independently in both images with the help of menuconfig.
 * :kconfig:option:`CONFIG_BUILD_S1_VARIANT` - Required for the build system to be able to construct the application binaries for both application's slots in flash memory.
 
 Configuring the MCUboot bootloader


### PR DESCRIPTION
Updated the B0 bootloader configuration section in the nRF Desktop application readme file with information on how to correctly set the firmware version on both image slots  before the DFU package generation.

Ref: NCSDK-13838

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>