### PR TITLE
lib: modem_key_mgmt: update CME error translation

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -429,6 +429,18 @@ Modem libraries
 
   * Added timeout for the entire location request.
 
+* :ref:`modem_key_mgmt` library:
+
+  * Added:
+
+    * The ``-EALREADY`` return value for the :c:func:`modem_key_mgmt_write` function when the credential already exists and cannot be overwritten.
+    * The ``-ECANCELED`` return value for the :c:func:`modem_key_mgmt_write` and :c:func:`modem_key_mgmt_delete` functions when the voltage is low.
+
+  * Updated:
+
+    * All the functions to return ``-EACCES`` instead of ``-EPERM`` when the access to the credential is not allowed.
+    * All the functions to return ``-EPERM`` instead of ``-EACCES`` when the operation is not permitted because the LTE link is active.
+
 Libraries for networking
 ------------------------
 

--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -48,15 +48,36 @@ enum modem_key_mgmt_cred_type {
  *
  * @retval 0		On success.
  * @retval -EINVAL	Invalid parameters.
- * @retval -ENOBUFS	Internal buffer is too small.
  * @retval -ENOMEM	Not enough memory to store the credential.
- * @retval -EACCES	Th operation failed because the LTE link is active.
- * @retval -ENOENT	The security tag could not be written.
- * @retval -EPERM	Insufficient permissions.
+ * @retval -ENOENT	The security tag @p sec_tag is invalid.
+ * @retval -EACCES	Access to credential not allowed.
+ * @retval -EALREADY	Credential already exists (and can't be overwritten).
+ * @retval -EPERM	Not permitted when the LTE link is active.
+ * @retval -ECANCELED	Canceled because voltage is low (power off warning).
  */
 int modem_key_mgmt_write(nrf_sec_tag_t sec_tag,
 			 enum modem_key_mgmt_cred_type cred_type,
 			 const void *buf, size_t len);
+
+/**
+ * @brief Delete a credential from persistent storage.
+ *
+ * @note If used when the LTE link is active, the function will return
+ *	 an error and the key will not be written.
+ *
+ * @param[in] sec_tag		The security tag of the credential.
+ * @param[in] cred_type		The credential type.
+ *
+ * @retval 0		On success.
+ * @retval -ENOBUFS	Internal buffer is too small.
+ * @retval -ENOENT	No credential associated with the given
+ *			@p sec_tag and @p cred_type.
+ * @retval -EACCES	Access to credential not allowed.
+ * @retval -EPERM	Not permitted when the LTE link is active.
+ * @retval -ECANCELED	Canceled because voltage is low (power off warning).
+ */
+int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
+			  enum modem_key_mgmt_cred_type cred_type);
 
 /**
  * @brief Read a credential from persistent storage.
@@ -69,10 +90,10 @@ int modem_key_mgmt_write(nrf_sec_tag_t sec_tag,
  *
  * @retval 0		On success.
  * @retval -ENOBUFS	Internal buffer is too small.
- * @retval -ENOMEM	If provided buffer is too small for result data.
+ * @retval -ENOMEM	Credential does not fit in @p buf.
  * @retval -ENOENT	No credential associated with the given
  *			@p sec_tag and @p cred_type.
- * @retval -EPERM	Insufficient permissions.
+ * @retval -EACCES	Access to credential not allowed.
  */
 int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
 			enum modem_key_mgmt_cred_type cred_type,
@@ -91,30 +112,11 @@ int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
  * @retval -ENOBUFS	Internal buffer is too small.
  * @retval -ENOENT	No credential associated with the given
  *			@p sec_tag and @p cred_type.
- * @retval -EPERM	Insufficient permissions.
+ * @retval -EACCES	Access to credential not allowed.
  */
 int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
 		       enum modem_key_mgmt_cred_type cred_type,
 		       const void *buf, size_t len);
-
-/**
- * @brief Delete a credential from persistent storage.
- *
- * @note If used when the LTE link is active, the function will return
- *	 an error and the key will not be written.
- *
- * @param[in] sec_tag		The security tag of the credential.
- * @param[in] cred_type		The credential type.
- *
- * @retval 0		On success.
- * @retval -ENOBUFS	Internal buffer is too small.
- * @retval -EACCES	The operation failed because the LTE link is active.
- * @retval -ENOENT	No credential associated with the given
- *			@p sec_tag and @p cred_type.
- * @retval -EPERM	Insufficient permissions.
- */
-int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
-			  enum modem_key_mgmt_cred_type cred_type);
 
 /**
  * @brief Check if a credential exists in persistent storage.
@@ -126,7 +128,7 @@ int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
  *
  * @retval 0		On success.
  * @retval -ENOBUFS	Internal buffer is too small.
- * @retval -EPERM	Insufficient permissions.
+ * @retval -EACCES	Access to credential not allowed.
  */
 int modem_key_mgmt_exists(nrf_sec_tag_t sec_tag,
 			  enum modem_key_mgmt_cred_type cred_type,

--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -65,20 +65,31 @@ static int translate_error(int err)
 
 	/* In case of CME error translate to an errno value */
 	switch (nrf_modem_at_err(err)) {
-	case 513:
+	case 513: /* not found */
+		LOG_WRN("Key not found");
 		return -ENOENT;
-	case 514:
-		return -EPERM;
-	case 515:
-		return -ENOMEM;
-	case 518:
+	case 514: /* no access */
+		LOG_WRN("Key access refused");
 		return -EACCES;
+	case 515: /* memory full */
+		LOG_WRN("Key storage memory full");
+		return -ENOMEM;
+	case 518: /* not allowed in active state */
+		LOG_WRN("Not allowed when LTE connection is active");
+		return -EPERM;
+	case 519: /* already exists */
+		LOG_WRN("Key already exists");
+		return -EALREADY;
+	case 528: /* not allowed in power off warning */
+		LOG_WRN("Not allowed when power off warning is active");
+		return -ECANCELED;
 	default:
 		/* Catch unexpected CME errors.
 		 * Return a magic value to make sure this
 		 * situation is clearly distinguishable.
 		 */
-		__ASSERT(false, "Untranslated CME error %d!", nrf_modem_at_err(err));
+		LOG_ERR("Untranslated CME error %d", nrf_modem_at_err(err));
+		__ASSERT(false, "Untranslated CME error %d", nrf_modem_at_err(err));
 		return 0xBAADBAAD;
 	}
 }


### PR DESCRIPTION
Update CME error translation:
* added -EALREADY and -ECANCELED
* -EACCESS is now returned instead of -EPERM and vice-versa

Added logs, updated doxygen.