### PR TITLE
samples: wifi: sta: Remove unnecessary NULL pointer check

### DIFF
--- a/samples/wifi/sta/src/main.c
+++ b/samples/wifi/sta/src/main.c
@@ -71,10 +71,9 @@ static int cmd_wifi_status(void)
 		       wifi_link_mode_txt(status.link_mode));
 		printk("SSID: %-32s\n", status.ssid);
 		printk("BSSID: %s\n",
-		       status.bssid ? net_sprint_ll_addr_buf(status.bssid,
-				WIFI_MAC_ADDR_LEN, mac_string_buf,
-				sizeof(mac_string_buf)) :
-				"");
+		       net_sprint_ll_addr_buf(
+				status.bssid, WIFI_MAC_ADDR_LEN,
+				mac_string_buf, sizeof(mac_string_buf)));
 		printk("Band: %s\n", wifi_band_txt(status.band));
 		printk("Channel: %d\n", status.channel);
 		printk("Security: %s\n", wifi_security_txt(status.security));


### PR DESCRIPTION
status.bssid is an array, not a pointer, therefore NULL pointer check is unnecessary and will always evaluate to true. Remove the check to prevent build warning:

  "The comparison will always evaluate as 'true' for the address
   of 'bssid' will never be NULL."

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>