### PR TITLE
mpsl: Fix dependencies to the fem Kconfig file

### DIFF
--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -35,9 +35,9 @@ config MPSL_BUILD_TYPE_LIB
 
 endchoice
 
-rsource "fem/Kconfig"
-
 endif
+
+rsource "fem/Kconfig"
 
 if !MPSL_FEM_ONLY
 


### PR DESCRIPTION
The fem Kconfig file cannot have dependency
to the MPSL. This commit fixes this issue.
This fixes regression from the #7939