### PR TITLE
samples: peripheral_uart: Allow build with security disabled

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1472,6 +1472,13 @@ Reconnection issues after bonding
   The peripheral samples (:ref:`peripheral_uart`, :ref:`peripheral_lbs`, :ref:`peripheral_hids_mouse`) have reconnection issues after performing bonding (LE Secure Connection pairing enable) with nRF Connect for Desktop.
   These issues result in disconnection.
 
+.. rst-class:: v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
+
+NCSDK-17883: Cannot build peripheral UART sample with security (:kconfig:option:`CONFIG_BT_NUS_SECURITY_ENABLED`) disabled
+  The :ref:`peripheral_uart` sample fails to build when the :kconfig:option:`BT_NUS_SECURITY_ENABLED` Kconfig option is disabled.
+
+  **Workaround:** In :file:`main.c` file, search for the ``#else`` entry of the ``#if defined(CONFIG_BT_NUS_SECURITY_ENABLED)`` item and add an empty declaration of the ``conn_auth_info_callbacks`` structure, just after the similar empty definition of ``conn_auth_callbacks``.
+
 Bluetooth mesh
 ==============
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -209,6 +209,12 @@ Bluetooth samples
     * On the nRF5340 development kit, the application core UART interface is used for communication with testers instead of the network core UART interface.
     * On the nRF5340 development kit, added support for the USB CDC ACM interface.
 
+* :ref:`peripheral_uart` sample:
+
+  * Changed:
+
+    * Fixed code build with the :kconfig:option:`CONFIG_BT_NUS_SECURITY_ENABLED` Kconfig option disabled.
+
 Bluetooth mesh samples
 ----------------------
 

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -42,3 +42,13 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
     platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: bluetooth ci_build
+  sample.bluetooth.peripheral_uart.security_disabled:
+    build_only: true
+    platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
+      nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns thingy53_nrf5340_cpuapp
+      thingy53_nrf5340_cpuapp_ns nrf21540dk_nrf52840
+    integration_platforms:
+      - nrf52840dk_nrf52840
+    tags: bluetooth ci_build
+    extra_configs:
+      - CONFIG_BT_NUS_SECURITY_ENABLED=n

--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -447,6 +447,7 @@ static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 };
 #else
 static struct bt_conn_auth_cb conn_auth_callbacks;
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks;
 #endif
 
 static void bt_receive_cb(struct bt_conn *conn, const uint8_t *const data,


### PR DESCRIPTION
This commit fix the build with BT_NUS_SECURITY_ENABLED option disabled. Test for such configuration added.

JIRA: NCSDK-17883

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>