### PR TITLE
manifest: TF-M ensure netcore runs as non-secure

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -119,7 +119,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 39288b5df80e5915c1eee1d9b753a931824b3836
+      revision: pull/75/head
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot


### PR DESCRIPTION
This ensures in TF-M that the SPU EXTDOMAIN register is set to non-secure for the network core and locks it.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>