### PR TITLE
doc: Update Zephyr version in toolchain installation

### DIFF
--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -405,13 +405,13 @@ It also includes additional host tools, such as custom QEMU and OpenOCD builds.
          .. code-block:: console
 
             cd %HOMEPATH%
-            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_windows-x86_64.zip
+            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_windows-x86_64.zip
 
       #. Extract the Zephyr SDK bundle archive:
 
          .. code-block:: console
 
-            unzip zephyr-sdk-0.14.1_windows-x86_64.zip
+            unzip zephyr-sdk-0.15.1_windows-x86_64.zip
 
          .. note::
             It is recommended to extract the Zephyr SDK bundle at one of the following locations:
@@ -419,15 +419,15 @@ It also includes additional host tools, such as custom QEMU and OpenOCD builds.
             * ``%HOMEPATH%``
             * ``%PROGRAMFILES%``
 
-            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.14.1`` directory and, when
+            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
             extracted under ``%HOMEPATH%``, the resulting installation path will be
-            ``%HOMEPATH%\zephyr-sdk-0.14.1``.
+            ``%HOMEPATH%\zephyr-sdk-0.15.1``.
 
       #. Run the Zephyr SDK bundle setup script:
 
          .. code-block:: console
 
-            cd zephyr-sdk-0.14.1
+            cd zephyr-sdk-0.15.1
             setup.cmd
 
          .. note::
@@ -445,8 +445,8 @@ It also includes additional host tools, such as custom QEMU and OpenOCD builds.
          .. code-block:: bash
 
             cd ~
-            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_linux-x86_64.tar.gz
-            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/sha256.sum | shasum --check --ignore-missing
+            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_linux-x86_64.tar.gz
+            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/sha256.sum | shasum --check --ignore-missing
 
          If your host architecture is 64-bit ARM (for example, Raspberry Pi), replace ``x86_64``
          with ``aarch64`` in order to download the 64-bit ARM Linux SDK.
@@ -455,7 +455,7 @@ It also includes additional host tools, such as custom QEMU and OpenOCD builds.
 
          .. code-block:: bash
 
-            tar xvf zephyr-sdk-0.14.1_linux-x86_64.tar.gz
+            tar xvf zephyr-sdk-0.15.1_linux-x86_64.tar.gz
 
          .. note::
             It is recommended to extract the Zephyr SDK bundle at one of the following locations:
@@ -467,15 +467,15 @@ It also includes additional host tools, such as custom QEMU and OpenOCD builds.
             * ``/opt``
             * ``/usr/local``
 
-            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.14.1`` directory and, when
+            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
             extracted under ``$HOME``, the resulting installation path will be
-            ``$HOME/zephyr-sdk-0.14.1``.
+            ``$HOME/zephyr-sdk-0.15.1``.
 
       #. Run the Zephyr SDK bundle setup script:
 
          .. code-block:: bash
 
-            cd zephyr-sdk-0.14.1
+            cd zephyr-sdk-0.15.1
             ./setup.sh
 
          .. note::
@@ -489,7 +489,7 @@ It also includes additional host tools, such as custom QEMU and OpenOCD builds.
 
          .. code-block:: bash
 
-            sudo cp ~/zephyr-sdk-0.14.1/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
+            sudo cp ~/zephyr-sdk-0.15.1/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
             sudo udevadm control --reload
 
    .. group-tab:: macOS
@@ -503,22 +503,22 @@ It also includes additional host tools, such as custom QEMU and OpenOCD builds.
          .. code-block:: bash
 
             cd ~
-            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_macos-aarch64.tar.gz
-            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/sha256.sum | shasum --check --ignore-missing
+            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-aarch64.tar.gz
+            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/sha256.sum | shasum --check --ignore-missing
 
          * For 64-bit AMD (Intel) host architecture:
 
          .. code-block:: bash
 
             cd ~
-            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_macos-x86_64.tar.gz
-            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/sha256.sum | shasum --check --ignore-missing
+            wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-x86_64.tar.gz
+            wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/sha256.sum | shasum --check --ignore-missing
 
       #. Extract the Zephyr SDK bundle archive, matching the file name of the bundle you downloaded:
 
          .. code-block:: bash
 
-            tar xvf zephyr-sdk-0.14.1_macos-x86_64.tar.gz
+            tar xvf zephyr-sdk-0.15.1_macos-x86_64.tar.gz
 
          .. note::
             It is recommended to extract the Zephyr SDK bundle at one of the following locations:
@@ -530,15 +530,15 @@ It also includes additional host tools, such as custom QEMU and OpenOCD builds.
             * ``/opt``
             * ``/usr/local``
 
-            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.14.1`` directory and, when
+            The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.15.1`` directory and, when
             extracted under ``$HOME``, the resulting installation path will be
-            ``$HOME/zephyr-sdk-0.14.1``.
+            ``$HOME/zephyr-sdk-0.15.1``.
 
       #. Run the Zephyr SDK bundle setup script:
 
          .. code-block:: bash
 
-            cd zephyr-sdk-0.14.1
+            cd zephyr-sdk-0.15.1
             ./setup.sh
 
          .. note::


### PR DESCRIPTION
Latest version of the Zephyr SDK is v0.15.1, our instructions used v0.14.1. This updates it to the current version.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>