### PR TITLE
emds: Ensure flash is ready before writing emds data

### DIFF
--- a/subsys/emds/emds_flash.c
+++ b/subsys/emds/emds_flash.c
@@ -137,6 +137,8 @@ static int flash_direct_write(const struct device *dev, off_t offset, const void
 
 	flash_addr += DT_REG_ADDR(SOC_NV_FLASH_NODE);
 
+	nvmc_wait_ready();
+
 	if (SUSPEND_POFWARN()) {
 		return -ECANCELED;
 	}


### PR DESCRIPTION
Ensure that partial erase finished erasing chunk before emds starts writing.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>