### PR TITLE
Samples: Bluetooth: Mesh: Upd adv param smp dfu

### DIFF
--- a/samples/bluetooth/mesh/light/src/smp_dfu.c
+++ b/samples/bluetooth/mesh/light/src/smp_dfu.c
@@ -42,7 +42,7 @@ void smp_service_adv_init(void)
 {
 	int err;
 
-	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, &adv_callbacks, &adv);
+	err = bt_le_ext_adv_create(BT_LE_ADV_CONN_NAME, &adv_callbacks, &adv);
 	if (err) {
 		printk("Creating SMP service adv instance failed (err %d)\n", err);
 	}


### PR DESCRIPTION
Changes the advertising parameters for the smp dfu advertising set in the mesh light sample.

This is done to ensure compabillity with devices that does not support extended advertising.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>