### PR TITLE
Lwm2m Device and firmware utils reboot update

### DIFF
--- a/include/net/lwm2m_client_utils.h
+++ b/include/net/lwm2m_client_utils.h
@@ -120,6 +120,19 @@ bool lwm2m_security_needs_bootstrap(void);
  * @brief Initialize Device object
  */
 int lwm2m_init_device(void);
+
+/**
+ * @brief Reboot handler for a device object
+ *
+ * All arguments are ignored.
+ *
+ * @param obj_inst_id Device object instance.
+ * @param args Argument pointer's
+ * @param args_len Length of argument's
+ *
+ * @return Zero if success, negative error code otherwise.
+ */
+int lwm2m_device_reboot_cb(uint16_t obj_inst_id, uint8_t *args, uint16_t args_len);
 #endif
 
 #if defined(CONFIG_LWM2M_CLIENT_UTILS_LOCATION_OBJ_SUPPORT)

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_device.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_device.c
@@ -16,32 +16,37 @@ LOG_MODULE_REGISTER(lwm2m_device, CONFIG_LWM2M_CLIENT_UTILS_LOG_LEVEL);
 
 #define REBOOT_DELAY K_SECONDS(1)
 
-static struct k_work_delayable reboot_work;
+static void reboot_work_handler(struct k_work *work);
+
+/* Delayed work that is used to trigger a reboot. */
+static K_WORK_DELAYABLE_DEFINE(reboot_work, reboot_work_handler);
 
 static void reboot_work_handler(struct k_work *work)
 {
+	int rc;
+
+	rc = lte_lc_offline();
+	if (rc) {
+		LOG_ERR("Failed to put LTE link in offline state (%d)", rc);
+	}
+
 	LOG_PANIC();
 	sys_reboot(0);
 }
 
-static int device_reboot_cb(uint16_t obj_inst_id, uint8_t *args,
+int lwm2m_device_reboot_cb(uint16_t obj_inst_id, uint8_t *args,
 			    uint16_t args_len)
 {
+	ARG_UNUSED(obj_inst_id);
 	ARG_UNUSED(args);
 	ARG_UNUSED(args_len);
 
 	LOG_INF("DEVICE: Reboot in progress");
 
-	k_work_schedule(&reboot_work, REBOOT_DELAY);
-
-	return 0;
+	return k_work_schedule(&reboot_work, REBOOT_DELAY);
 }
 
 int lwm2m_init_device(void)
 {
-	k_work_init_delayable(&reboot_work, reboot_work_handler);
-
-	lwm2m_engine_register_exec_callback("3/0/4", device_reboot_cb);
-
-	return 0;
+	return lwm2m_engine_register_exec_callback("3/0/4", lwm2m_device_reboot_cb);
 }

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
@@ -48,6 +48,7 @@ DEFINE_FAKE_VALUE_FUNC(int, modem_key_mgmt_write, nrf_sec_tag_t, enum modem_key_
 		       const void *, size_t);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_set, enum lte_lc_func_mode);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_connect);
+DEFINE_FAKE_VALUE_FUNC(int, lte_lc_offline);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_get, enum lte_lc_func_mode *);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_lte_mode_get, enum lte_lc_lte_mode *);
 DEFINE_FAKE_VALUE_FUNC(int, settings_load_subtree, const char *);

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
@@ -43,6 +43,7 @@ DECLARE_FAKE_VALUE_FUNC(int, modem_key_mgmt_write, nrf_sec_tag_t, enum modem_key
 			const void *, size_t);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_set, enum lte_lc_func_mode);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_connect);
+DECLARE_FAKE_VALUE_FUNC(int, lte_lc_offline);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_func_mode_get, enum lte_lc_func_mode *);
 DECLARE_FAKE_VALUE_FUNC(int, settings_load_subtree, const char *);
 DECLARE_FAKE_VALUE_FUNC(int, settings_register, struct settings_handler *);
@@ -93,6 +94,7 @@ DECLARE_FAKE_VALUE_FUNC(int, lwm2m_engine_register_exec_callback, const char *,
 	FUNC(modem_info_rsrp_register)                  \
 	FUNC(lte_lc_func_mode_set)                      \
 	FUNC(lte_lc_connect)                            \
+	FUNC(lte_lc_offline)                            \
 	FUNC(lte_lc_func_mode_get)                      \
 	FUNC(lte_lc_lte_mode_get)                       \
 	FUNC(settings_load_subtree)                     \


### PR DESCRIPTION
**Device reboot API update**

Add API for trig Device reboot and added lte_offline() operation before boot.

**LwM2M firmware worker and reboot update**

Changed worker and worker delay definition by Macro.
Reboot Trigger use device public API.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>