### PR TITLE
tfm: cmake: Only define NRF_NS_SECONDARY when it exists

### DIFF
--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -47,7 +47,8 @@ endif()
 if (CONFIG_BOOTLOADER_MCUBOOT AND NOT CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY)
   # Configure the secondary partition to be non-secure
   set_property(TARGET zephyr_property_target
-    APPEND PROPERTY TFM_CMAKE_OPTIONS -DNRF_NS_SECONDARY=ON
+    APPEND PROPERTY TFM_CMAKE_OPTIONS
+	-DNRF_NS_SECONDARY=$<TARGET_PROPERTY:partition_manager,PM_mcuboot_secondary_IS_ENABLED>
   )
 endif()
 


### PR DESCRIPTION
NRF_NS_SECONDARY was being set when BOOTLOADER_MCUBOOT and NOT CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY, but MCUBoot can be configured to not have a secondary partition with the config options:

-Dmcuboot_CONFIG_SINGLE_APPLICATION_SLOT=y
-Dmcuboot_CONFIG_UPDATEABLE_IMAGE_NUMBER=1

In this case NRF_NS_SECONDARY becomes misconfigured. Unfortunately we don't have access to the MCUBoot Kconfig's from the app, so we can't check for SINGLE_APPLICATION_SLOT.

Instead we check if PM has defined a secondary slot before setting NRF_NS_SECONDARY.

Presumably it would be even cleaner to drop the NRF_NS_SECONDARY config and just have TF-M use pm_config.h directly, but vanilla TF-M does not support pm_config.h.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>