### PR TITLE
actions: manifest: Trigger unconditionally

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -2,8 +2,6 @@ name: Manifest
 
 on:
   pull_request_target:
-    paths:
-      - 'west.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
The GitHub Actions trigger-on-file-change mechanism may fail to trigger for very large PRs (300+ files changed).

This commit updates the manifest workflow such that it runs on all pull requests, regardless of whether `west.yml` is modified.

See
https://github.com/zephyrproject-rtos/zephyr/commit/d018b2ba670f09c8e460971ead642f2ae4b2b527

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>