### PR TITLE
samples: add UART1 board conf for nrf5340 ns

### DIFF
--- a/tests/tfm/tfm_regression_test/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/tests/tfm/tfm_regression_test/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -1,0 +1,7 @@
+# Using the following configuration for TFM UART1 allows both secure and
+# non-secure UART output to arrive on the two COM ports available on the
+# newer (>=2.0.0) dev-kits.
+# Users of older versioned dev-kits should take appropriate actions in
+# order to get both UART outputs. See: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_tfm.html#id7
+CONFIG_TFM_UART1_RXD_PIN=32
+CONFIG_TFM_UART1_TXD_PIN=33


### PR DESCRIPTION
The TFM regression tests sample does not display the secure output when running on newer (version >=2.0.0) nrf5340 dev-kits.
Add a board config file to mitigate this issue.

Ref: NCSDK-16751

Signed-off-by: Torstein Grindvik <torstein.grindvik@nordicsemi.no>

Re-sumbit of: https://github.com/nrfconnect/sdk-zephyr/pull/931 

test-sdk-nrf: sdk-nrf-PR-9213