### PR TITLE
test-spec: narrow down sdk-homekit test plan triggers

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -263,7 +263,7 @@
   - "subsys/dfu/*"
   - "subsys/ieee802154/**/*"
   - "subsys/mpsl/**/*"
-  - "subsys/net/**/*"
+  - "subsys/net/openthread/*"
   - "subsys/nfc/**/*"
   - "subsys/nrf_rpc/**/*"
   - "subsys/partition_manager/**/*"


### PR DESCRIPTION
`subsys/net/**/*` is quite broad, use `subsys/net/openthread/*` instead.