### PR TITLE
doc: asset_tracker_v2: Add a note about FOTA when enabling PGPS

### DIFF
--- a/applications/asset_tracker_v2/doc/app_behavior.rst
+++ b/applications/asset_tracker_v2/doc/app_behavior.rst
@@ -127,4 +127,9 @@ See :ref:`nRF Cloud A-GPS and P-GPS <nrfcloud_agps_pgps>` for further details.
 To enable support for P-GPS, add the parameter ``-DOVERLAY_CONFIG=overlay-pgps.conf`` to your build command.
 
 .. note::
+   Enabling support for P-GPS creates a new flash partition in the image for storing P-GPS data.
+   To ensure that the resulting binary can be deployed using FOTA, you must make sure that the new partition layout is compatible with layout of the old image.
+   See :ref:`static partitioning <ug_pm_static_providing>` for more details.
+
+.. note::
    |gps_tradeoffs|


### PR DESCRIPTION
Clarify that enabling P-GPS will change the partition layout of the image thus making it incompatible with any old images in the field.

NCSDK-16907

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>