### PR TITLE
workflow: New workflow to cancel previously running long workflows

### DIFF
--- a/.github/workflows/cancel-previous.yml
+++ b/.github/workflows/cancel-previous.yml
@@ -1,0 +1,16 @@
+name: Cancel previous workflow
+on:
+  workflow_run:
+    # List long running github workflows here.
+    workflows: ["Documentation Build"]
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Cancel Workflow Action
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
Added a new workflow that cancels any previously running workflow listed under 'workflows' in this file. As of now, this lists the Documentation Build alone as that is the longest known github action (takes ~27 mins.. and a new run is spawned for every push) on writing this. This should significantly bring down the billable run durations on the sdk-nrf repo.

Tested as follows on my private fork where I have this workflow installed.
-  Created two PRs from another fork of my private fork 
-  Pushed a few commits to both PRs. 
-  Found that the cancel workflow was successfully cancelling the previous runs of the Doc Build of the corresponding PR (leaving the other PR unaffected)

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>