### PR TITLE
debug: cpu_load: Keep return value consistent

### DIFF
--- a/subsys/debug/cpu_load/cpu_load.c
+++ b/subsys/debug/cpu_load/cpu_load.c
@@ -200,6 +200,9 @@ int cpu_load_init(void)
 
 	if (IS_ENABLED(CONFIG_CPU_LOAD_LOG_PERIODIC)) {
 		ret = cpu_load_log_init();
+		if (ret >= 0) {
+			ret = 0;
+		}
 	}
 
 	ready = true;


### PR DESCRIPTION
Ensure that cpu_load_init returns 0 on success in all cases.

Ref. NCSIDB-811.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>