### PR TITLE
doc: update nRF Cloud links with a trailing slash

### DIFF
--- a/doc/nrf/includes/nrf_cloud_rest_sample_requirements.txt
+++ b/doc/nrf/includes/nrf_cloud_rest_sample_requirements.txt
@@ -4,7 +4,7 @@ This sample uses the `nRF Cloud REST API`_, which requires that your device has 
 
 .. requirement_keysign_moreinfo_start
 
-(See `nRF Connect for Cloud REST API`_ and `Securely Generating Credentials on the nRF9160`_ for more details on this requirement).
+(See `nRF Cloud REST API`_ and `Securely generating credentials on the nRF9160`_ for more details on this requirement).
 
 Modem version v1.3.x or later is also required.
 
@@ -20,7 +20,7 @@ To obtain and register a valid signing key, you can do one of the following:
 
 * Provision your device on nRF Cloud using Just-In-Time Provisioning (JITP) (detailed below).
 * Provision your device on nRF Cloud with preconnect provisioning (detailed in `nRF Cloud Provisioning`_).
-* Install or generate a private key on your device and register its public key with nRF Cloud (detailed in `Securely Generating Credentials on the nRF9160`_).
+* Install or generate a private key on your device and register its public key with nRF Cloud (detailed in `Securely generating credentials on the nRF9160`_).
 
 To provision your device on nRF Cloud using JITP, complete the following steps:
 

--- a/doc/nrf/libraries/networking/multicell_location.rst
+++ b/doc/nrf/libraries/networking/multicell_location.rst
@@ -36,7 +36,7 @@ To use the location services, see the respective documentation for account setup
    To start using the Multicell location library with nRF Cloud, you must perform either of the following actions:
 
    * Delete the device from nRF Cloud and reprovision it with a new ES256 device certificate. See :ref:`nrf9160_ug_updating_cloud_certificate` for more information.
-   * Register a separate key for JWT signing as described in `Securely Generating Credentials on the nRF9160`_.
+   * Register a separate key for JWT signing as described in `Securely generating credentials on the nRF9160`_.
 
 .. reprovision_cert_note_end
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -746,32 +746,33 @@
 
 .. _`nRF Cloud`:
 .. _`nRF Connect for Cloud`: https://nrfcloud.com/
+
+.. _`Nordic Semiconductor's IoT cloud platform`: https://www.nordicsemi.com/Products/Cloud-services
+
 .. _`nRF Cloud documentation`:
 .. _`nRF Connect for Cloud documentation`: https://docs.nrfcloud.com/
-.. _`nRF Cloud Patch Device State`:
-.. _`nRF Connect for Cloud Patch Device State`: https://api.nrfcloud.com/v1#operation/UpdateDeviceState
+.. _`nRF Cloud Device Messages`: https://docs.nrfcloud.com/Devices/Messages/DeviceMessages/
+.. _`nRF Cloud Device Shadows`: https://docs.nrfcloud.com/Devices/Properties/Shadows/
+.. _`nRF Cloud Security`: https://docs.nrfcloud.com/Devices/Security/Security/
+.. _`nRF Cloud Just-In-Time-Provisioning`: https://docs.nrfcloud.com/Devices/Associations/Provisioning#just-in-time-provisioning
+.. _`nRF Cloud Provisioning`: https://docs.nrfcloud.com/Devices/Associations/Provisioning/
+.. _`nRF Cloud FOTA`: https://docs.nrfcloud.com/Devices/FirmwareUpdate/FOTA/
+.. _`nRF Cloud MQTT FOTA`: https://docs.nrfcloud.com/Devices/FirmwareUpdate/FOTA/#mqtt-job-execution-notifications
+.. _`nRF Cloud Getting Started FOTA documentation`: https://docs.nrfcloud.com/Devices/FirmwareUpdate/FOTATutorial/
+.. _`Securely generating credentials on the nRF9160`: https://docs.nrfcloud.com/Devices/Security/Credentials/
+.. _`nRF Cloud REST API`:
+.. _`nRF Connect for Cloud REST API`: https://docs.nrfcloud.com/APIs/REST/RESTIntro/
+.. _`nRF Cloud Location Services documentation`: https://docs.nrfcloud.com/LocationServices/LocationServicesOverview/
+.. _`nRF Cloud MQTT API`: https://docs.nrfcloud.com/APIs/MQTT/MQTTIntro/
+.. _`nRF Cloud MQTT Topics`: https://docs.nrfcloud.com/APIs/MQTT/Topics/
+
 .. _`nRF Cloud REST API (v1)`:
 .. _`nRF Cloud Device API`: https://api.nrfcloud.com/v1
+.. _`nRF Cloud Patch Device State`:
+.. _`nRF Connect for Cloud Patch Device State`: https://api.nrfcloud.com/v1#operation/UpdateDeviceState
 .. _`nRF Cloud REST API ListMessages`: https://api.nrfcloud.com/v1#operation/ListMessages
-.. _`nRF Cloud Device Messages`: https://docs.nrfcloud.com/Devices/Messages/DeviceMessages
-.. _`nRF Cloud Device Shadows`: https://docs.nrfcloud.com/Devices/DeviceProperties/Shadows
-.. _`nRF Cloud REST API`:
-.. _`nRF Connect for Cloud REST API`: https://docs.nrfcloud.com/APIs/REST/RESTIntro
 .. _`nRF Cloud Location Services`: https://api.nrfcloud.com/v1#tag/Location-Services
 .. _`nRF Cloud RegisterPublicKeys Endpoint`: https://api.nrfcloud.com/v1/#operation/RegisterPublicKeys
-.. _`nRF Cloud Location Services documentation`: https://docs.nrfcloud.com/LocationServices/LocationServicesOverview
-.. _`nRF Cloud MQTT API`: https://docs.nrfcloud.com/APIs/MQTT
-.. _`nRF Cloud Security`: https://docs.nrfcloud.com/Devices/DeviceSecurity/Security
-.. _`nRF Cloud MQTT Topics`: https://docs.nrfcloud.com/APIs/MQTT#message-topics
-.. _`nRF Cloud Just-In-Time-Provisioning`: https://docs.nrfcloud.com/Devices/DeviceAssociations/Provisioning#just-in-time-provisioning
-.. _`nRF Cloud Provisioning`: https://docs.nrfcloud.com/Devices/DeviceAssociations/Provisioning/
-.. _`nRF Cloud Security`: https://docs.nrfcloud.com/Devices/DeviceSecurity/Security
-.. _`nRF Cloud FOTA`: https://docs.nrfcloud.com/Devices/FirmwareUpdate/FOTA
-.. _`nRF Cloud MQTT FOTA`: https://docs.nrfcloud.com/Devices/FirmwareUpdate/FOTA/#mqtt-job-execution-notifications
-.. _`nRF Cloud Getting Started FOTA documentation`: https://docs.nrfcloud.com/Devices/FirmwareUpdate/FOTATutorial
-.. _`Nordic Semiconductor's IoT cloud platform`: https://www.nordicsemi.com/Products/Cloud-services
-.. _`Securely Generating Credentials on the nRF9160`: https://docs.nrfcloud.com/Devices/DeviceSecurity/Credentials
-
 
 .. ### Source: zigbeealliance.org & csa-iot.org
 

--- a/doc/nrf/ug_nrf_cloud.rst
+++ b/doc/nrf/ug_nrf_cloud.rst
@@ -94,7 +94,7 @@ A device can successfully connect to `nRF Cloud`_ using MQTT if the following re
   It programs  the specified CA certificate into the device.
   The private key never leaves the device, which makes this a more secure option.
 
-  See `Securely Generating Credentials on the nRF9160`_  and `nRF Cloud Provisioning`_ for more details.
+  See `Securely generating credentials on the nRF9160`_  and `nRF Cloud Provisioning`_ for more details.
 
 
 |NCS| library support


### PR DESCRIPTION
When a link pointing to the nRF Cloud documentation does not have a trailing slash, the browser redirects to a version that does, which adds a small delay and can cause 302 errors. This PR adds the trailing slash to all current links along with small fixes to the links.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>