### PR TITLE
lib: location: cellular: fixing a post-timeout functionality

### DIFF
--- a/lib/location/method_cellular.c
+++ b/lib/location/method_cellular.c
@@ -41,6 +41,9 @@ void method_cellular_lte_ind_handler(const struct lte_lc_evt *const evt)
 {
 	switch (evt->type) {
 	case LTE_LC_EVT_NEIGHBOR_CELL_MEAS: {
+		if (!running) {
+			return;
+		}
 		LOG_DBG("Cell measurements results received");
 
 		/* Copy current cell information. */
@@ -200,9 +203,11 @@ int method_cellular_location_get(const struct location_method_config *config)
 int method_cellular_cancel(void)
 {
 	if (running) {
+		running = false;
+
+		/* Cancel/stopping might trigger a NCELLMEAS notification */
 		(void)lte_lc_neighbor_cell_measurement_cancel();
 		(void)k_work_cancel(&method_cellular_positioning_work.work_item);
-		running = false;
 		k_sem_reset(&cellmeas_data_ready);
 	} else {
 		return -EPERM;

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -529,7 +529,7 @@ void test_location_request_default(void)
 	 * Otherwise, lte_lc would ignore NCELLMEAS notification because no NCELLMEAS on going
 	 * from lte_lc point of view.
 	 */
-	k_sleep(K_MSEC(1000));
+	k_sleep(K_MSEC(10000));
 
 	/* Trigger NCELLMEAS response which further triggers the rest of the location calculation */
 	at_monitor_dispatch(ncellmeas_resp);
@@ -575,7 +575,7 @@ void test_location_request_mode_all_cellular_gnss(void)
 	rest_req_ctx.host = CONFIG_MULTICELL_LOCATION_HERE_HOSTNAME;
 
 	/* Wait a bit so that NCELLMEAS is sent before we send response */
-	k_sleep(K_MSEC(1000));
+	k_sleep(K_MSEC(10000));
 
 	/* Trigger NCELLMEAS response which further triggers the rest of the location calculation */
 	at_monitor_dispatch(ncellmeas_resp);


### PR DESCRIPTION
Handle NCELLMEAS results only if running the method. Otherwise, it resulted that a semaphore was given also when not running the method anymore, for example in case where NCELLMEAS notification came after timeout()/cancel(), resulting on next call to cellular method from location api: that we were sending a position request with the old data right away without waiting for NCELLMEAS response.
Happened when method specific timeout happened during waiting for NCELLMEAS results.
Jira: NCSDK-17978
