### PR TITLE
CODEOWNERS: Update mcuboot codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -115,7 +115,7 @@ Kconfig*                                  @tejlmand
 /lib/modem_attest_token/                  @jayteemo
 /lib/qos/                                 @simensrostad
 /modules/                                 @tejlmand
-/modules/mcuboot/                         @nvlsianpu
+/modules/mcuboot/                         @de-nordic @nordicjm
 /modules/cjson/                           @simensrostad @plskeggs @sigvartmh
 /samples/                                 @nrfconnect/ncs-test-leads
 /samples/sensor/bh1749/                   @wlgrd


### PR DESCRIPTION
Unless I am mistaken, the new codeowners for MCUBoot are @de-nordic and @nordicjm.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>