### PR TITLE
dm: Generate a new random seed after synchronization

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -242,6 +242,12 @@ Bluetooth samples
 
     * Fixed code build with the :kconfig:option:`CONFIG_BT_NUS_SECURITY_ENABLED` Kconfig option disabled.
 
+* :ref: `ble_nrf_dm` sample:
+
+  * Changed:
+
+    * A new seed value is generated after each synchronization to provide different hopping sequences.
+
 Bluetooth mesh samples
 ----------------------
 
@@ -595,6 +601,7 @@ Other libraries
 * :ref:`mod_dm`:
   * Added a window length configuration to be used runtime, when a new measurement request is added.
   * Improved the calculation of MPSL timeslot length by using the :ref:`nrf_dm` library functionality.
+  * Renamed the ``access_address`` field to ``rng_seed`` in the :c:struct:`dm_request` structure.
 
 Common Application Framework (CAF)
 ----------------------------------

--- a/include/dm.h
+++ b/include/dm.h
@@ -128,8 +128,10 @@ struct dm_request {
 	/** Bluetooth LE device address. */
 	bt_addr_le_t bt_addr;
 
-	/** Access address used for packet exchanges. */
-	uint32_t access_address;
+	/** Seed used in pseudo random number generation.
+	 *  Needs to be the same for an initiator and a reflector that will range with each other.
+	 */
+	uint32_t rng_seed;
 
 	/** Ranging mode to use in the procedure. */
 	enum dm_ranging_mode ranging_mode;

--- a/samples/bluetooth/nrf_dm/src/peer.c
+++ b/samples/bluetooth/nrf_dm/src/peer.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/bluetooth/conn.h>
+#include <zephyr/random/rand32.h>
 
 #include "peer.h"
 #include "pwm_led.h"
@@ -35,7 +35,7 @@ struct peer_entry {
 };
 
 static struct peer_entry *closest_peer;
-static uint32_t access_address;
+static uint32_t rng_seed;
 static enum dm_ranging_mode ranging_mode = DEFAULT_RANGING_MODE;
 
 K_MSGQ_DEFINE(result_msgq, sizeof(struct dm_result), 16, 4);
@@ -226,28 +226,15 @@ enum dm_ranging_mode peer_ranging_mode_get(void)
 	return ranging_mode;
 }
 
-int peer_access_address_prepare(void)
+uint32_t peer_rng_seed_prepare(void)
 {
-	bt_addr_le_t addr = {0};
-	size_t count = 1;
-
-	bt_id_get(&addr, &count);
-
-	access_address = addr.a.val[0];
-	access_address |= addr.a.val[1] << 8;
-	access_address |= addr.a.val[2] << 16;
-	access_address |= addr.a.val[3] << 24;
-
-	if (access_address == 0) {
-		return -EFAULT;
-	}
-
-	return 0;
+	rng_seed = sys_rand32_get();
+	return rng_seed;
 }
 
-uint32_t peer_access_address_get(void)
+uint32_t peer_rng_seed_get(void)
 {
-	return access_address;
+	return rng_seed;
 }
 
 bool peer_supported_test(const bt_addr_le_t *peer)

--- a/samples/bluetooth/nrf_dm/src/peer.h
+++ b/samples/bluetooth/nrf_dm/src/peer.h
@@ -46,17 +46,17 @@ void peer_ranging_mode_set(enum dm_ranging_mode mode);
  */
 enum dm_ranging_mode peer_ranging_mode_get(void);
 
-/** @brief Prepare an access address.
+/** @brief Prepare and get a random seed.
  *
- *  @retval 0 if the operation was successful, otherwise a (negative) error code.
+ *  @retval Random seed value.
  */
-int peer_access_address_prepare(void);
+uint32_t peer_rng_seed_prepare(void);
 
-/** @brief Get the current access address.
+/** @brief Get the current random seed.
  *
- *  @retval Access address value.
+ *  @retval Random seed value.
  */
-uint32_t peer_access_address_get(void);
+uint32_t peer_rng_seed_get(void);
 
 /** @brief Initialize the peer management module.
  *

--- a/subsys/dm/dm.c
+++ b/subsys/dm/dm.c
@@ -127,7 +127,7 @@ static mpsl_timeslot_signal_return_param_t signal_callback_return_param;
 static void dm_config_get(struct dm_request *dm_req, nrf_dm_config_t *dm_config)
 {
 	*dm_config = NRF_DM_DEFAULT_CONFIG;
-	dm_config->access_address = dm_req->access_address;
+	dm_config->access_address = dm_req->rng_seed;
 
 	if (dm_req->role == DM_ROLE_INITIATOR) {
 		dm_config->role = NRF_DM_ROLE_INITIATOR;

--- a/subsys/dm/rpc/client/dm_rpc_client.c
+++ b/subsys/dm/rpc/client/dm_rpc_client.c
@@ -38,7 +38,7 @@ int dm_request_add(struct dm_request *req)
 	/* Encode the request structure */
 	ser_encode_uint(&ctx, req->role);
 	ser_encode_buffer(&ctx, &req->bt_addr, sizeof(bt_addr_le_t));
-	ser_encode_uint(&ctx, req->access_address);
+	ser_encode_uint(&ctx, req->rng_seed);
 	ser_encode_uint(&ctx, req->ranging_mode);
 	ser_encode_uint(&ctx, req->start_delay_us);
 	ser_encode_uint(&ctx, req->extra_window_time_us);

--- a/subsys/dm/rpc/host/dm_rpc_host.c
+++ b/subsys/dm/rpc/host/dm_rpc_host.c
@@ -55,7 +55,7 @@ static void dm_request_add_rpc_handler(const struct nrf_rpc_group *group,
 	/* Decode the request structure */
 	req.role = ser_decode_uint(ctx);
 	ser_decode_buffer(ctx, &req.bt_addr, sizeof(bt_addr_le_t));
-	req.access_address = ser_decode_uint(ctx);
+	req.rng_seed = ser_decode_uint(ctx);
 	req.ranging_mode = ser_decode_uint(ctx);
 	req.start_delay_us = ser_decode_uint(ctx);
 	req.extra_window_time_us = ser_decode_uint(ctx);

--- a/subsys/dm/timeslot_queue.c
+++ b/subsys/dm/timeslot_queue.c
@@ -103,7 +103,7 @@ int timeslot_queue_append(struct dm_request *req, uint32_t start_ref_tick,
 	item->timeslot_req.start_time = start_time;
 	item->timeslot_req.timeslot_length_us = timeslot_len_us;
 	item->timeslot_req.window_length_us = window_len_us;
-	req->access_address++;
+	req->rng_seed++;
 
 	memcpy(&item->timeslot_req.dm_req, req, sizeof(item->timeslot_req.dm_req));
 


### PR DESCRIPTION
Renames access_address to rng_seed because
access_address is a bit confusing.

The rng_seed is used to seeding the random number generation in
nrf_lib_dm. This value is updated after each synchronization to obtain
different hopping sequences on each ranging.