### PR TITLE
samples: matter: Fixed enabling DFU over SMP without Matter OTA

### DIFF
--- a/applications/matter_weather_station/CMakeLists.txt
+++ b/applications/matter_weather_station/CMakeLists.txt
@@ -50,7 +50,7 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/dfu_over_smp.cpp
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)
 endif()
 

--- a/samples/matter/common/src/dfu_over_smp.cpp
+++ b/samples/matter/common/src/dfu_over_smp.cpp
@@ -41,10 +41,10 @@ void DFUOverSMP::Init(DFUOverSMPRestartAdvertisingHandler startAdvertisingCb)
 	mgmt_register_evt_cb([](uint8_t opcode, uint16_t group, uint8_t id, void *arg) {
 		switch (opcode) {
 		case MGMT_EVT_OP_CMD_RECV:
-			GetFlashHandler().DoAction(FlashHandler::Action::WAKE_UP);
+			GetFlashHandler().DoAction(ExternalFlashManager::Action::WAKE_UP);
 			break;
 		case MGMT_EVT_OP_CMD_DONE:
-			GetFlashHandler().DoAction(FlashHandler::Action::SLEEP);
+			GetFlashHandler().DoAction(ExternalFlashManager::Action::SLEEP);
 			break;
 		default:
 			break;

--- a/samples/matter/common/src/ota_util.cpp
+++ b/samples/matter/common/src/ota_util.cpp
@@ -5,15 +5,19 @@
  */
 
 #include "ota_util.h"
+
+#if CONFIG_CHIP_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/server/Server.h>
+#endif
 
 using namespace chip;
 using namespace chip::DeviceLayer;
 
+#if CONFIG_CHIP_OTA_REQUESTOR
 namespace
 {
 DefaultOTARequestorStorage sOTARequestorStorage;
@@ -21,12 +25,6 @@ DefaultOTARequestorDriver sOTARequestorDriver;
 chip::BDXDownloader sBDXDownloader;
 chip::DefaultOTARequestor sOTARequestor;
 } /* namespace */
-
-FlashHandler &GetFlashHandler()
-{
-	static FlashHandler sFlashHandler;
-	return sFlashHandler;
-}
 
 /* compile-time factory method */
 OTAImageProcessorImpl &GetOTAImageProcessor()
@@ -50,5 +48,12 @@ void InitBasicOTARequestor()
 	sOTARequestor.Init(Server::GetInstance(), sOTARequestorStorage, sOTARequestorDriver, sBDXDownloader);
 	chip::SetRequestorInstance(&sOTARequestor);
 	sOTARequestorDriver.Init(&sOTARequestor, &imageProcessor);
-	imageProcessor.TriggerFlashAction(FlashHandler::Action::SLEEP);
+	imageProcessor.TriggerFlashAction(ExternalFlashManager::Action::SLEEP);
+}
+#endif
+
+ExternalFlashManager &GetFlashHandler()
+{
+	static ExternalFlashManager sFlashHandler;
+	return sFlashHandler;
 }

--- a/samples/matter/common/src/ota_util.h
+++ b/samples/matter/common/src/ota_util.h
@@ -4,17 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <platform/nrfconnect/OTAImageProcessorImpl.h>
-
 #pragma once
 
-/**
- * Get FlashHandler static instance.
- *
- * Returned object can be used to control the QSPI external flash,
- * which can be introduced into sleep mode and woken up on demand.
- */
-chip::DeviceLayer::FlashHandler &GetFlashHandler();
+#include <platform/nrfconnect/ExternalFlashManager.h>
+
+#if CONFIG_CHIP_OTA_REQUESTOR
+#include <platform/nrfconnect/OTAImageProcessorImpl.h>
 
 /**
  * Select recommended OTA image processor implementation.
@@ -33,3 +28,13 @@ chip::DeviceLayer::OTAImageProcessorImpl &GetOTAImageProcessor();
  * an update so the confirmation must be done on the OTA provider side.
  */
 void InitBasicOTARequestor();
+
+#endif /* CONFIG_CHIP_OTA_REQUESTOR */
+
+/**
+ * Get FlashHandler static instance.
+ *
+ * Returned object can be used to control the QSPI external flash,
+ * which can be introduced into sleep mode and woken up on demand.
+ */
+chip::DeviceLayer::ExternalFlashManager &GetFlashHandler();

--- a/samples/matter/light_bulb/CMakeLists.txt
+++ b/samples/matter/light_bulb/CMakeLists.txt
@@ -44,7 +44,7 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/pwm_device.cpp
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)
 endif()
 

--- a/samples/matter/light_switch/CMakeLists.txt
+++ b/samples/matter/light_switch/CMakeLists.txt
@@ -48,7 +48,7 @@ target_sources(app PRIVATE
     src/zap-generated/callback-stub.cpp
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)
 endif()
 

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -45,7 +45,7 @@ target_sources(app PRIVATE
     $<$<BOOL:${CONFIG_NET_L2_OPENTHREAD}>:${COMMON_ROOT}/src/thread_util.cpp>
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)
 endif()
 

--- a/samples/matter/window_covering/CMakeLists.txt
+++ b/samples/matter/window_covering/CMakeLists.txt
@@ -45,7 +45,7 @@ target_sources(app PRIVATE
     ${COMMON_ROOT}/src/thread_util.cpp
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${COMMON_ROOT}/src/ota_util.cpp)
 endif()
 

--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 93c5937ac4195b721cf375a6e28d26ce652bda0d
+      revision: 470d1f92c078af1ad906c955e94d0064f53fb5f6
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
It was not possible to enable DFU over BT SMP without Matter OTA enabled, due to incorrect modules dependencies.

* Added ifdefs to OTAUtil that prevents from building Matter OTA dependencies while Matter OTA is disabled
* Updated Matter repository to pull platform fixes.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>