### PR TITLE
tests: tfm: Don't run TFM regression tests and PSA architecture tests in twister

### DIFF
--- a/samples/tfm/tfm_secure_peripheral/sample.yaml
+++ b/samples/tfm/tfm_secure_peripheral/sample.yaml
@@ -15,5 +15,5 @@ common:
             - "SPP: sending message: Success"
             - "SPP: processing signals: Success"
 tests:
-    sample.tfm.secure_partition:
+    sample.tfm.secure_peripheral:
         tags: tfm ci_build

--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -16,3 +16,16 @@
   platforms:
     - all
   comment: "Zephyr include paths need to updated in the sdk-ant repository."
+
+- scenarios:
+    - sample.tfm.psa_test_crypto
+    - sample.tfm.psa_test_initial_attestation
+    - sample.tfm.psa_test_internal_trusted_storage
+    - sample.tfm.psa_test_protected_storage
+    - sample.tfm.psa_test_storage
+    - sample.tfm.regression_ipc_lvl1
+    - sample.tfm.regression_ipc_lvl2
+    - sample.tfm.regression_lib_mode
+  platforms:
+    - all
+  comment: "Disable zephyr Regression and PSA Arch tests, we maintain copies of these in sdk-nrf"

--- a/tests/tfm/tfm_psa_test/testcase.yaml
+++ b/tests/tfm/tfm_psa_test/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   tags: tfm
+  build_only: true
   platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
   integration_platforms:
     - nrf5340dk_nrf5340_cpuapp_ns

--- a/tests/tfm/tfm_regression_test/testcase.yaml
+++ b/tests/tfm/tfm_regression_test/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   tags: tfm
+  build_only: true
   platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
   integration_platforms:
     - nrf5340dk_nrf5340_cpuapp_ns


### PR DESCRIPTION
Don't run TF-M regression tests and PSA architecture tests in twister.
These require special handling and are running in the CI plan for TF-M.

Update test case name for tfm_secure_peripheral.

NCSDK-17954