### PR TITLE
[backport-v2.1] manifest: Update Zephyr revision

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt update
-          sudo apt-get install -y ninja-build mscgen plantuml libclang1-9 libclang-cpp9
+          sudo apt-get install -y ninja-build mscgen plantuml
           DOXYGEN_VERSION=$(cat ./ncs/nrf/scripts/tools-versions-linux.txt |grep 'doxygen' | sed 's/^.*=//')
           wget --no-verbose https://downloads.sourceforge.net/project/doxygen/rel-${DOXYGEN_VERSION}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
           tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -4,7 +4,7 @@ sphinxcontrib-mscgen>=0.6
 sphinx-ncs-theme>=1.0.3,<1.1
 m2r2>=0.3.2
 sphinxcontrib-plantuml
-pygit2
+pygit2<=1.10
 pyyaml==5.4.1
 azure-storage-blob
 sphinx_markdown_tables

--- a/scripts/requirements-extra.txt
+++ b/scripts/requirements-extra.txt
@@ -1,4 +1,4 @@
-pygit2>=1.6.1
+pygit2<=1.10
 editdistance>=0.5.0
 PyGithub
 zcbor>=0.5.1

--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.1.99-ncs1-1
+      revision: 5cdbe42e49680de7b0c6d7102d61385d56e7e663
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in two fixes that allow successful compilation of:
- drivers/i2c/i2c_nrfx_twim.c with CONFIG_PINCTRL=n
- arch/arm/core/aarch32/cortex_m/fault.c with CONFIG_FAULT_DUMP=1