### PR TITLE
tests: subsys: net/lib: lwm2m_client_utils: Fix signature

### DIFF
--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
@@ -64,7 +64,7 @@ DEFINE_FAKE_VALUE_FUNC(int, lte_lc_rai_param_set, const char *);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_rai_req, bool);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_edrx_param_set, enum lte_lc_lte_mode, const char *);
 DEFINE_FAKE_VALUE_FUNC(int, lte_lc_edrx_req, bool);
-DEFINE_FAKE_VALUE_FUNC(int, lte_lc_neighbor_cell_measurement, enum lte_lc_neighbor_search_type);
+DEFINE_FAKE_VALUE_FUNC(int, lte_lc_neighbor_cell_measurement, struct lte_lc_ncellmeas_params *);
 DEFINE_FAKE_VOID_FUNC(lte_lc_register_handler, lte_lc_evt_handler_t);
 DEFINE_FAKE_VALUE_FUNC(int, settings_load_subtree, const char *);
 DEFINE_FAKE_VALUE_FUNC(int, settings_register, struct settings_handler *);

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
@@ -58,7 +58,7 @@ DECLARE_FAKE_VALUE_FUNC(int, lte_lc_rai_param_set, const char *);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_rai_req, bool);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_edrx_param_set, enum lte_lc_lte_mode, const char *);
 DECLARE_FAKE_VALUE_FUNC(int, lte_lc_edrx_req, bool);
-DECLARE_FAKE_VALUE_FUNC(int, lte_lc_neighbor_cell_measurement, enum lte_lc_neighbor_search_type);
+DECLARE_FAKE_VALUE_FUNC(int, lte_lc_neighbor_cell_measurement, struct lte_lc_ncellmeas_params *);
 DECLARE_FAKE_VOID_FUNC(lte_lc_register_handler, lte_lc_evt_handler_t);
 DECLARE_FAKE_VALUE_FUNC(int, settings_load_subtree, const char *);
 DECLARE_FAKE_VALUE_FUNC(int, settings_register, struct settings_handler *);


### PR DESCRIPTION
This patch updates the signature of lte_lc_neighbor_cell_measurement in the test to make it work again.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>