### PR TITLE
dfu_target: Define TYPE_ANY_MODEM and ANY_APPLICATION types for DFU

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -592,6 +592,14 @@ sdk-nrfxlib
 
 See the changelog for each library in the :doc:`nrfxlib documentation <nrfxlib:README>` for additional information.
 
+DFU libraries
+-------------
+* :ref:`lib_dfu_target`:
+  * Updated:
+
+    * Added new types :c:enum:`DFU_TARGET_IMAGE_TYPE_ANY_MODEM` and :c:enum:`DFU_TARGET_IMAGE_TYPE_ANY_APPLICATION`.
+      This makes any supported modem update type acceptable when downloading.
+
 Scripts
 =======
 

--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -20,11 +20,28 @@
 extern "C" {
 #endif
 
+/** @brief DFU image type.
+ *
+ * Bitmasks of different image types.
+ */
 enum dfu_target_image_type {
-	DFU_TARGET_IMAGE_TYPE_ANY = 0,
+	/** Not a DFU image */
+	DFU_TARGET_IMAGE_TYPE_NONE = 0,
+	/** Application image in MCUBoot format */
 	DFU_TARGET_IMAGE_TYPE_MCUBOOT = 1,
-	DFU_TARGET_IMAGE_TYPE_MODEM_DELTA,
-	DFU_TARGET_IMAGE_TYPE_FULL_MODEM
+	/** Modem delta-update image */
+	DFU_TARGET_IMAGE_TYPE_MODEM_DELTA = 2,
+	/** Full update image for modem */
+	DFU_TARGET_IMAGE_TYPE_FULL_MODEM = 4,
+	/** Any application image type */
+	DFU_TARGET_IMAGE_TYPE_ANY_APPLICATION = DFU_TARGET_IMAGE_TYPE_MCUBOOT,
+	/** Any modem image */
+	DFU_TARGET_IMAGE_TYPE_ANY_MODEM =
+		(DFU_TARGET_IMAGE_TYPE_MODEM_DELTA | DFU_TARGET_IMAGE_TYPE_FULL_MODEM),
+	/** Any DFU image type */
+	DFU_TARGET_IMAGE_TYPE_ANY =
+		(DFU_TARGET_IMAGE_TYPE_MCUBOOT | DFU_TARGET_IMAGE_TYPE_MODEM_DELTA |
+		 DFU_TARGET_IMAGE_TYPE_FULL_MODEM),
 };
 
 enum dfu_target_evt_id {
@@ -52,10 +69,10 @@ struct dfu_target {
  *		  image.
  * @param[in] len The length of the provided buffer.
  *
- * @return Positive identifier for a supported image type or a negative error
- *	   code indicating reason of failure.
+ * @return Identifier for a supported image type or DFU_TARGET_IMAGE_TYPE_NONE if
+ *         image type is not regognized.
  **/
-int dfu_target_img_type(const void *const buf, size_t len);
+enum dfu_target_image_type dfu_target_img_type(const void *const buf, size_t len);
 
 /**
  * @brief Initialize the resources needed for the specific image type DFU

--- a/subsys/dfu/dfu_target/src/dfu_target.c
+++ b/subsys/dfu/dfu_target/src/dfu_target.c
@@ -37,10 +37,10 @@ LOG_MODULE_REGISTER(dfu_target, CONFIG_DFU_TARGET_LOG_LEVEL);
 static const struct dfu_target *current_target;
 static int current_img_num = -1;
 
-int dfu_target_img_type(const void *const buf, size_t len)
+enum dfu_target_image_type dfu_target_img_type(const void *const buf, size_t len)
 {
 	if (len < MIN_SIZE_IDENTIFY_BUF) {
-		return -EAGAIN;
+		return DFU_TARGET_IMAGE_TYPE_NONE;
 	}
 #ifdef CONFIG_DFU_TARGET_MCUBOOT
 	if (dfu_target_mcuboot_identify(buf)) {
@@ -58,7 +58,7 @@ int dfu_target_img_type(const void *const buf, size_t len)
 	}
 #endif
 	LOG_ERR("No supported image type found");
-	return -ENOTSUP;
+	return DFU_TARGET_IMAGE_TYPE_NONE;
 }
 
 int dfu_target_init(int img_type, int img_num, size_t file_size, dfu_target_callback_t cb)

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -117,12 +117,11 @@ static int download_client_callback(const struct download_client_evt *event)
 			img_type = dfu_target_img_type(event->fragment.buf,
 							event->fragment.len);
 
-			if (img_type < 0) {
+			if (img_type == DFU_TARGET_IMAGE_TYPE_NONE) {
 				LOG_ERR("Unknown image type");
 				err_cause = FOTA_DOWNLOAD_ERROR_CAUSE_INVALID_UPDATE;
 				err = -EFAULT;
-			} else if ((img_type_expected != DFU_TARGET_IMAGE_TYPE_ANY) &&
-			    (img_type_expected != img_type)) {
+			} else if ((img_type & img_type_expected) != img_type) {
 				LOG_ERR("FOTA image type %d does not match expected type %d",
 					img_type, img_type_expected);
 				err_cause = FOTA_DOWNLOAD_ERROR_CAUSE_TYPE_MISMATCH;

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -232,7 +232,7 @@ static int firmware_block_received_cb(uint16_t obj_inst_id,
 		client_acknowledge();
 
 		image_type = dfu_target_img_type(data, data_len);
-		if (image_type == -ENOTSUP) {
+		if (image_type == DFU_TARGET_IMAGE_TYPE_NONE) {
 			ret = -ENOMSG; /* Translates to unsupported image type */
 			goto cleanup;
 		}

--- a/tests/subsys/net/lib/fota_download/src/test_fota_download.c
+++ b/tests/subsys/net/lib/fota_download/src/test_fota_download.c
@@ -40,9 +40,9 @@ int dfu_target_init(int img_type, int img_num, size_t file_size, dfu_target_call
 	return 0;
 }
 
-int dfu_target_img_type(const void *const buf, size_t len)
+enum dfu_target_image_type dfu_target_img_type(const void *const buf, size_t len)
 {
-	return 0;
+	return DFU_TARGET_IMAGE_TYPE_MCUBOOT;
 }
 
 int dfu_target_offset_get(size_t *offset)


### PR DESCRIPTION
This is usefull if you want to allow DFU downloader to download any type of supported modem update.
DFU Image type would be a bitmask and we could request fota_download with certain bitmasks.

FYI @jheiskan81 this would allow multi-instance FOTA to specify ANY_MODEM type for modem updates.
