### PR TITLE
Support encrypted firmware signature key.

### DIFF
--- a/modules/mcuboot/CMakeLists.txt
+++ b/modules/mcuboot/CMakeLists.txt
@@ -133,6 +133,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
 
       DEPENDS
       ${SIGN_ARG_DEPENDS}
+      USES_TERMINAL
         )
 
     add_custom_command(
@@ -159,6 +160,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       ${update_bin}
       DEPENDS
       ${SIGN_ARG_DEPENDS}
+      USES_TERMINAL
         )
 
     add_custom_command(
@@ -182,6 +184,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
       DEPENDS
       ${SIGN_ARG_DEPENDS}
       ${update_bin}
+      USES_TERMINAL
       )
   endfunction()
 


### PR DESCRIPTION
When the firmware signature key is encrypted with a passphrase, imgtool.py asks the user to enter the passphrase several times during the build process.

Currently, this only works with "Unix Makefiles". With "Ninja", which is the default CMake generator in Zephyr, the build blocks without any prompt to enter the passphrase.

This patch adds the option USES_TERMINAL to several calls of add_custom_command(). Together with my pull request in repository sdk-mcuboot it allows to use encrypted firmware signature keys with default Ninja builds.

