### PR TITLE
tree: prefix cmock generated wrap functions with __wrap_cmock

### DIFF
--- a/applications/asset_tracker_v2/tests/debug_module/src/debug_module_test.c
+++ b/applications/asset_tracker_v2/tests/debug_module/src/debug_module_test.c
@@ -106,15 +106,15 @@ static int module_start_stub(struct module_data *module, int num_calls)
 
 void setup_debug_module_in_init_state(void)
 {
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&app_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&app_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct app_module_event *app_module_event = new_app_module_event();
 
 	app_module_event->type = APP_EVT_START;
 
-	__wrap_watchdog_register_handler_ExpectAnyArgs();
-	__wrap_watchdog_register_handler_AddCallback(&latch_watchdog_callback);
-	__wrap_module_start_Stub(&module_start_stub);
+	__cmock_watchdog_register_handler_ExpectAnyArgs();
+	__cmock_watchdog_register_handler_AddCallback(&latch_watchdog_callback);
+	__cmock_module_start_Stub(&module_start_stub);
 
 	TEST_ASSERT_EQUAL(0, DEBUG_MODULE_EVT_HANDLER(
 		(struct app_event_header *)app_module_event));
@@ -126,18 +126,18 @@ void test_memfault_trigger_metric_sampling_on_gnss_fix(void)
 {
 	setup_debug_module_in_init_state();
 
-	__wrap_memfault_metrics_heartbeat_set_unsigned_ExpectAndReturn(
+	__cmock_memfault_metrics_heartbeat_set_unsigned_ExpectAndReturn(
 						MEMFAULT_METRICS_KEY(GnssTimeToFix),
 						60000,
 						0);
-	__wrap_memfault_metrics_heartbeat_set_unsigned_ExpectAndReturn(
+	__cmock_memfault_metrics_heartbeat_set_unsigned_ExpectAndReturn(
 						MEMFAULT_METRICS_KEY(GnssSatellitesTracked),
 						4,
 						0);
-	__wrap_memfault_metrics_heartbeat_debug_trigger_Expect();
+	__cmock_memfault_metrics_heartbeat_debug_trigger_Expect();
 
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&location_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&location_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct location_module_event *location_module_event = new_location_module_event();
 
 	location_module_event->type = LOCATION_MODULE_EVT_GNSS_DATA_READY;
@@ -156,18 +156,18 @@ void test_memfault_trigger_metric_sampling_on_location_timeout(void)
 	setup_debug_module_in_init_state();
 
 	/* Update this function to expect the search time and number of satellites. */
-	__wrap_memfault_metrics_heartbeat_set_unsigned_ExpectAndReturn(
+	__cmock_memfault_metrics_heartbeat_set_unsigned_ExpectAndReturn(
 						MEMFAULT_METRICS_KEY(LocationTimeoutSearchTime),
 						30000,
 						0);
-	__wrap_memfault_metrics_heartbeat_set_unsigned_ExpectAndReturn(
+	__cmock_memfault_metrics_heartbeat_set_unsigned_ExpectAndReturn(
 						MEMFAULT_METRICS_KEY(GnssSatellitesTracked),
 						2,
 						0);
-	__wrap_memfault_metrics_heartbeat_debug_trigger_Ignore();
+	__cmock_memfault_metrics_heartbeat_debug_trigger_Ignore();
 
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&location_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&location_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct location_module_event *location_module_event = new_location_module_event();
 
 	location_module_event->type = LOCATION_MODULE_EVT_TIMEOUT;
@@ -187,22 +187,22 @@ void test_memfault_trigger_data_send(void)
 	resetTest();
 	setup_debug_module_in_init_state();
 
-	__wrap__event_submit_ExpectAnyArgs();
+	__cmock__event_submit_ExpectAnyArgs();
 
-	__wrap_memfault_packetizer_data_available_ExpectAndReturn(1);
-	__wrap_memfault_packetizer_get_chunk_ExpectAnyArgsAndReturn(1);
-	__wrap_memfault_packetizer_get_chunk_ExpectAnyArgsAndReturn(0);
+	__cmock_memfault_packetizer_data_available_ExpectAndReturn(1);
+	__cmock_memfault_packetizer_get_chunk_ExpectAnyArgsAndReturn(1);
+	__cmock_memfault_packetizer_get_chunk_ExpectAnyArgsAndReturn(0);
 
 	/* Expect the debug module to generate an event with accompanied Memfault metric data. */
-	__wrap__event_submit_Stub(&validate_debug_data_ready_evt);
+	__cmock__event_submit_Stub(&validate_debug_data_ready_evt);
 
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&data_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&data_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct data_module_event *data_module_event = new_data_module_event();
 
 	data_module_event->type = DATA_EVT_DATA_SEND;
 
-	__wrap_app_event_manager_alloc_IgnoreAndReturn(&debug_module_event_memory);
+	__cmock_app_event_manager_alloc_IgnoreAndReturn(&debug_module_event_memory);
 	TEST_ASSERT_EQUAL(0, DEBUG_MODULE_EVT_HANDLER(
 		(struct app_event_header *)data_module_event));
 	app_event_manager_free(data_module_event);
@@ -223,8 +223,8 @@ void test_memfault_unhandled_event(void)
 
 	/* Expect no memfault APIs to be called on LOCATION_MODULE_EVT_ACTIVE */
 
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&location_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&location_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct location_module_event *location_module_event = new_location_module_event();
 
 	location_module_event->type = LOCATION_MODULE_EVT_ACTIVE;
@@ -257,11 +257,11 @@ void test_memfault_software_watchdog_trigger_on_callback(void)
 	resetTest();
 	setup_debug_module_in_init_state();
 
-	__wrap_memfault_software_watchdog_enable_ExpectAndReturn(0);
+	__cmock_memfault_software_watchdog_enable_ExpectAndReturn(0);
 
 	/* Expect a software watchdog timer 5 seconds lower than the passed in value to be used. */
-	__wrap_memfault_software_watchdog_update_timeout_ExpectAndReturn(55000, 0);
-	__wrap_memfault_software_watchdog_feed_ExpectAndReturn(0);
+	__cmock_memfault_software_watchdog_update_timeout_ExpectAndReturn(55000, 0);
+	__cmock_memfault_software_watchdog_feed_ExpectAndReturn(0);
 
 	struct watchdog_evt evt = {
 		.type = WATCHDOG_EVT_START

--- a/applications/asset_tracker_v2/tests/location_module/src/location_module_test.c
+++ b/applications/asset_tracker_v2/tests/location_module/src/location_module_test.c
@@ -259,15 +259,15 @@ static int module_start_stub(struct module_data *module, int num_calls)
 static void setup_location_module_in_init_state(void)
 {
 	/* Send APP_EVT_START. */
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&app_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&app_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct app_module_event *app_module_event = new_app_module_event();
 
-	__wrap_module_start_Stub(&module_start_stub);
+	__cmock_module_start_Stub(&module_start_stub);
 
 	app_module_event->type = APP_EVT_START;
 
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&location_module_event_memory);
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&location_module_event_memory);
 	bool ret = LOCATION_MODULE_EVT_HANDLER((struct app_event_header *)app_module_event);
 
 	app_event_manager_free(app_module_event);
@@ -280,10 +280,10 @@ static void setup_location_module_in_running_state(void)
 	setup_location_module_in_init_state();
 
 	/* Send MODEM_EVT_INITIALIZED. */
-	__wrap_location_init_ExpectAndReturn(&location_event_handler, 0);
+	__cmock_location_init_ExpectAndReturn(&location_event_handler, 0);
 
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&modem_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&modem_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct modem_module_event *modem_module_event = new_modem_module_event();
 
 	modem_module_event->type = MODEM_EVT_INITIALIZED;
@@ -293,8 +293,8 @@ static void setup_location_module_in_running_state(void)
 	app_event_manager_free(modem_module_event);
 
 	/* Send DATA_EVT_CONFIG_INIT. */
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&data_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&data_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct data_module_event *data_module_event = new_data_module_event();
 
 	data_module_event->type = DATA_EVT_CONFIG_INIT;
@@ -318,7 +318,7 @@ static void setup_location_module_in_active_state(void)
 
 	/* Set up expectations.  */
 	/* Set callback to validate location module events. */
-	__wrap__event_submit_Stub(&validate_location_module_evt);
+	__cmock__event_submit_Stub(&validate_location_module_evt);
 
 	/* Set default location configuration. */
 	enum location_method methods[] = { LOCATION_METHOD_GNSS, LOCATION_METHOD_CELLULAR };
@@ -333,9 +333,9 @@ static void setup_location_module_in_active_state(void)
 			{.method = LOCATION_METHOD_CELLULAR, .cellular.timeout = 11000}
 		}
 	};
-	__wrap_location_config_defaults_set_Expect(NULL, 2, methods);
-	__wrap_location_config_defaults_set_IgnoreArg_config();
-	__wrap_location_config_defaults_set_ReturnThruPtr_config(&config_defaults);
+	__cmock_location_config_defaults_set_Expect(NULL, 2, methods);
+	__cmock_location_config_defaults_set_IgnoreArg_config();
+	__cmock_location_config_defaults_set_ReturnThruPtr_config(&config_defaults);
 
 	/* Location configuration modified by location module for location request. */
 	struct location_config config_location_request = {
@@ -348,19 +348,19 @@ static void setup_location_module_in_active_state(void)
 			{.method = LOCATION_METHOD_CELLULAR, .cellular.timeout = 11000}
 		}
 	};
-	__wrap_location_request_ExpectAndReturn(&config_location_request, 0);
-	__wrap_location_request_IgnoreArg_config(); /* TODO: REMOVE */
+	__cmock_location_request_ExpectAndReturn(&config_location_request, 0);
+	__cmock_location_request_IgnoreArg_config(); /* TODO: REMOVE */
 
 	/* Send APP_EVT_DATA_GET with APP_DATA_LOCATION. */
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&app_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&app_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct app_module_event *app_module_event = new_app_module_event();
 
 	app_module_event->type = APP_EVT_DATA_GET;
 	app_module_event->count = 1;
 	app_module_event->data_list[0] = APP_DATA_LOCATION;
 
-	__wrap_app_event_manager_alloc_IgnoreAndReturn(&location_module_event_memory);
+	__cmock_app_event_manager_alloc_IgnoreAndReturn(&location_module_event_memory);
 	bool ret = LOCATION_MODULE_EVT_HANDLER((struct app_event_header *)app_module_event);
 
 	app_event_manager_free(app_module_event);
@@ -469,7 +469,7 @@ void test_location_cellular(void)
 	/* Location module indicates that it has handled neighbor cells
 	 * but the location is undefined.
 	 */
-	__wrap_location_cellular_ext_result_set_Expect(LOCATION_CELLULAR_EXT_RESULT_UNKNOWN, NULL);
+	__cmock_location_cellular_ext_result_set_Expect(LOCATION_CELLULAR_EXT_RESULT_UNKNOWN, NULL);
 
 	/* Location request is responded with location library events. */
 	struct location_event_data event_data_cellular = {
@@ -531,15 +531,15 @@ void test_location_fail_init(void)
 {
 	setup_location_module_in_init_state();
 
-	__wrap_location_init_ExpectAndReturn(&location_event_handler, -EINVAL);
+	__cmock_location_init_ExpectAndReturn(&location_event_handler, -EINVAL);
 
 	/* Set expected GNSS module events. */
 	expected_location_module_event_count = 1;
 	expected_location_module_events[0].type = LOCATION_MODULE_EVT_ERROR_CODE;
 	expected_location_module_events[0].data.err = -1;
 
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&modem_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&modem_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 	struct modem_module_event *modem_module_event = new_modem_module_event();
 
 	modem_module_event->type = MODEM_EVT_INITIALIZED;

--- a/applications/asset_tracker_v2/tests/lwm2m_codec/src/lwm2m_codec_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec/src/lwm2m_codec_test.c
@@ -119,216 +119,216 @@ void test_lwm2m_cloud_codec_init(void)
 	};
 
 	/* Create object instances. */
-	__wrap_lwm2m_engine_create_obj_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_obj_inst_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PRESSURE_ID, 0), 0);
 
-	__wrap_lwm2m_engine_create_obj_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_obj_inst_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_TEMP_SENSOR_ID, 0), 0);
 
-	__wrap_lwm2m_engine_create_obj_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_obj_inst_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0), 0);
 
-	__wrap_lwm2m_engine_create_obj_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_obj_inst_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON1_OBJ_INST_ID), 0);
 
-	__wrap_lwm2m_engine_create_obj_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_obj_inst_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON2_OBJ_INST_ID), 0);
 
 	/* Crate resource instances. */
-	__wrap_lwm2m_engine_create_res_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_res_inst_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, AVAIL_NETWORK_BEARER_ID, 0),
 		0);
 
-	__wrap_lwm2m_engine_create_res_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_res_inst_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, AVAIL_NETWORK_BEARER_ID, 1),
 		0);
 
-	__wrap_lwm2m_engine_create_res_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_res_inst_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, IP_ADDRESSES, 0), 0);
 
-	__wrap_lwm2m_engine_create_res_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_res_inst_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, APN, 0), 0);
 
-	__wrap_lwm2m_engine_create_res_inst_ExpectAndReturn(
+	__cmock_lwm2m_engine_create_res_inst_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, POWER_SOURCE_VOLTAGE_RID, 0), 0);
 
 	/* Set resource buffers. */
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, CURRENT_TIME_RID),
 		&current_time, sizeof(current_time), sizeof(current_time),
 		LWM2M_RES_DATA_FLAG_RW, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, POWER_SOURCE_VOLTAGE_RID),
 		&battery_voltage, sizeof(battery_voltage), sizeof(battery_voltage),
 		LWM2M_RES_DATA_FLAG_RW, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PRESSURE_ID, 0, TIMESTAMP_RID),
 		&pressure_ts, sizeof(pressure_ts), sizeof(pressure_ts),
 		LWM2M_RES_DATA_FLAG_RW, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_TEMP_SENSOR_ID, 0, TIMESTAMP_RID),
 		&temperature_ts, sizeof(temperature_ts), sizeof(temperature_ts),
 		LWM2M_RES_DATA_FLAG_RW, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0, TIMESTAMP_RID),
 		&humidity_ts, sizeof(humidity_ts), sizeof(humidity_ts),
 		LWM2M_RES_DATA_FLAG_RW, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_TEMP_SENSOR_ID, 0, SENSOR_UNITS_RID), BME680_TEMP_UNIT,
 		sizeof(BME680_TEMP_UNIT), sizeof(BME680_TEMP_UNIT), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0, SENSOR_UNITS_RID), BME680_HUMID_UNIT,
 		sizeof(BME680_HUMID_UNIT), sizeof(BME680_HUMID_UNIT), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PRESSURE_ID, 0, SENSOR_UNITS_RID), BME680_PRESSURE_UNIT,
 		sizeof(BME680_PRESSURE_UNIT), sizeof(BME680_PRESSURE_UNIT), LWM2M_RES_DATA_FLAG_RO,
 		0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON1_OBJ_INST_ID, APPLICATION_TYPE_RID),
 		BUTTON1_APP_NAME, sizeof(BUTTON1_APP_NAME), sizeof(BUTTON1_APP_NAME),
 		LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON1_OBJ_INST_ID, TIMESTAMP_RID),
 		&button_ts, sizeof(button_ts), sizeof(button_ts),
 		LWM2M_RES_DATA_FLAG_RW, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON2_OBJ_INST_ID, APPLICATION_TYPE_RID),
 		BUTTON2_APP_NAME, sizeof(BUTTON2_APP_NAME), sizeof(BUTTON2_APP_NAME),
 		LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, BUTTON2_OBJ_INST_ID, TIMESTAMP_RID),
 		&button_ts, sizeof(button_ts), sizeof(button_ts),
 		LWM2M_RES_DATA_FLAG_RW, 0);
 
 	/* Set floats. */
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_TEMP_SENSOR_ID, 0, MIN_RANGE_VALUE_RID),
 		&temp_min_range_val, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_TEMP_SENSOR_ID, 0, MAX_RANGE_VALUE_RID),
 		&temp_max_range_val, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0, MIN_RANGE_VALUE_RID),
 		&humid_min_range_val, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0, MAX_RANGE_VALUE_RID),
 		&humid_max_range_val, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PRESSURE_ID, 0, MIN_RANGE_VALUE_RID),
 		&pressure_min_range_val, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PRESSURE_ID, 0, MAX_RANGE_VALUE_RID),
 		&pressure_max_range_val, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACCELEROMETER_ACT_THRESHOLD_RID),
 		&cfg.accelerometer_activity_threshold, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACCELEROMETER_INACT_THRESHOLD_RID),
 		&cfg.accelerometer_inactivity_threshold, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACCELEROMETER_INACT_TIMEOUT_RID),
 		&cfg.accelerometer_inactivity_timeout, 0);
 
 	/* Set integers and booleans. */
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, LOCATION_TIMEOUT_RID),
 		cfg.location_timeout, 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACTIVE_WAIT_TIMEOUT_RID),
 		cfg.active_wait_timeout, 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, MOVEMENT_RESOLUTION_RID),
 		cfg.movement_resolution, 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, MOVEMENT_TIMEOUT_RID),
 		cfg.movement_timeout, 0);
 
-	__wrap_lwm2m_engine_set_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_bool_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, PASSIVE_MODE_RID),
 		!cfg.active_mode, 0);
 
-	__wrap_lwm2m_engine_set_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_bool_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, GNSS_ENABLE_RID),
 		!cfg.no_data.gnss, 0);
 
-	__wrap_lwm2m_engine_set_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_bool_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, NEIGHBOR_CELL_ENABLE_RID),
 		!cfg.no_data.neighbor_cell, 0);
 
 	/* Register callbacks from changes in device configurations. */
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, PASSIVE_MODE_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, LOCATION_TIMEOUT_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACTIVE_WAIT_TIMEOUT_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, MOVEMENT_RESOLUTION_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, MOVEMENT_TIMEOUT_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACCELEROMETER_ACT_THRESHOLD_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACCELEROMETER_INACT_THRESHOLD_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACCELEROMETER_INACT_TIMEOUT_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, GNSS_ENABLE_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
+	__cmock_lwm2m_engine_register_post_write_callback_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, NEIGHBOR_CELL_ENABLE_RID),
 		NULL, 0);
-	__wrap_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_post_write_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_post_write_callback_AddCallback(&post_write_callback_stub);
+	__cmock_lwm2m_engine_register_post_write_callback_AddCallback(&post_write_callback_stub);
 
 	TEST_ASSERT_NOT_NULL(post_write_callback_stub);
 	TEST_ASSERT_EQUAL(0, cloud_codec_init(&cfg, cloud_codec_event_handler));
@@ -363,26 +363,26 @@ void test_lwm2m_cloud_codec_encode_neighbor_cells(void)
 	cells->neighbor_cells = ncell.neighbor_cells;
 	cells->ncells_count = ncell.cell_data.ncells_count;
 
-	__wrap_lwm2m_update_signal_meas_objects_ExpectAndReturn(
+	__cmock_lwm2m_update_signal_meas_objects_ExpectAndReturn(
 		(const struct lte_lc_cells_info *)cells, 0);
 
-	__wrap_lwm2m_engine_set_s8_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s8_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, RADIO_SIGNAL_STRENGTH),
 		ncell.cell_data.current_cell.rsrp, 0);
 
-	__wrap_lwm2m_engine_set_u32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u32_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, CELLID),
 		ncell.cell_data.current_cell.id, 0);
 
-	__wrap_lwm2m_engine_set_u16_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u16_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, SMNC),
 		ncell.cell_data.current_cell.mnc, 0);
 
-	__wrap_lwm2m_engine_set_u16_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u16_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, SMCC),
 		ncell.cell_data.current_cell.mcc, 0);
 
-	__wrap_lwm2m_engine_set_u16_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u16_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, LAC),
 		ncell.cell_data.current_cell.tac, 0);
 
@@ -405,20 +405,20 @@ void test_lwm2m_cloud_codec_encode_agps_request(void)
 		.queued = true,
 	};
 
-	__wrap_location_assistance_agps_set_mask_ExpectAndReturn(&agps.request, 0);
+	__cmock_location_assistance_agps_set_mask_ExpectAndReturn(&agps.request, 0);
 
-	__wrap_location_assist_agps_set_elevation_mask_Expect(-1);
+	__cmock_location_assist_agps_set_elevation_mask_Expect(-1);
 
-	__wrap_lwm2m_engine_set_u32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u32_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, CELLID), agps.cell, 0);
 
-	__wrap_lwm2m_engine_set_u16_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u16_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, SMNC), agps.mnc, 0);
 
-	__wrap_lwm2m_engine_set_u16_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u16_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, SMCC), agps.mcc, 0);
 
-	__wrap_lwm2m_engine_set_u16_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u16_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, LAC), agps.area, 0);
 
 	TEST_ASSERT_EQUAL(0, cloud_codec_encode_agps_request(&codec, &agps));
@@ -437,10 +437,10 @@ void test_lwm2m_cloud_codec_encode_pgps_request(void)
 		.queued = true
 	};
 
-	__wrap_location_assist_pgps_set_prediction_count_ExpectAndReturn(pgps.count, 0);
-	__wrap_location_assist_pgps_set_prediction_interval_ExpectAndReturn(pgps.interval, 0);
-	__wrap_location_assist_pgps_set_start_time_ExpectAndReturn(pgps.time, 0);
-	__wrap_location_assist_pgps_set_start_gps_day_Expect(pgps.day);
+	__cmock_location_assist_pgps_set_prediction_count_ExpectAndReturn(pgps.count, 0);
+	__cmock_location_assist_pgps_set_prediction_interval_ExpectAndReturn(pgps.interval, 0);
+	__cmock_location_assist_pgps_set_start_time_ExpectAndReturn(pgps.time, 0);
+	__cmock_location_assist_pgps_set_start_gps_day_Expect(pgps.day);
 
 	TEST_ASSERT_EQUAL(0, cloud_codec_encode_pgps_request(&codec, &pgps));
 	TEST_ASSERT_EQUAL(codec.valid_object_paths, 0);
@@ -507,122 +507,122 @@ void test_lwm2m_cloud_codec_encode_data(void)
 	acc = (double)gnss.pvt.acc;
 	spd = (double)gnss.pvt.spd;
 
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAndReturn(&gnss.gnss_ts, 0);
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAndReturn(&sensor.env_ts, 0);
-	__wrap_date_time_now_ExpectAndReturn(&current_time, 0);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAndReturn(&gnss.gnss_ts, 0);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAndReturn(&sensor.env_ts, 0);
+	__cmock_date_time_now_ExpectAndReturn(&current_time, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, AVAIL_NETWORK_BEARER_ID, 0),
 		&bearers[0], sizeof(bearers[0]), sizeof(bearers[0]), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, AVAIL_NETWORK_BEARER_ID, 1),
 		&bearers[1], sizeof(bearers[1]), sizeof(bearers[1]), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, IP_ADDRESSES, 0),
 		modem_dynamic.ip, sizeof(modem_dynamic.ip), sizeof(modem_dynamic.ip),
 		LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, APN, 0), modem_dynamic.apn,
 		sizeof(modem_dynamic.apn), sizeof(modem_dynamic.apn), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, MODEL_NUMBER_RID), CONFIG_BOARD,
 		sizeof(CONFIG_BOARD), sizeof(CONFIG_BOARD), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, HARDWARE_VERSION_RID), CONFIG_SOC,
 		sizeof(CONFIG_SOC), sizeof(CONFIG_SOC), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, MANUFACTURER_RID),
 		CONFIG_CLOUD_CODEC_MANUFACTURER, sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER),
 		sizeof(CONFIG_CLOUD_CODEC_MANUFACTURER), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, FIRMWARE_VERSION_RID), modem_static.appv,
 		sizeof(modem_static.appv), sizeof(modem_static.appv), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, SOFTWARE_VERSION_RID), modem_static.fw,
 		sizeof(modem_static.fw), sizeof(modem_static.fw), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_res_buf_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_res_buf_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, DEVICE_SERIAL_NUMBER_ID), modem_static.imei,
 		sizeof(modem_static.imei), sizeof(modem_static.imei), LWM2M_RES_DATA_FLAG_RO, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0, LATITUDE_RID), &gnss.pvt.lat, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0, LONGITUDE_RID), &gnss.pvt.longi, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0, ALTITUDE_RID), &alt, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0, RADIUS_RID), &acc, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0, SPEED_RID), &spd, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_TEMP_SENSOR_ID, 0, SENSOR_VALUE_RID),
 		&sensor.temperature, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0, SENSOR_VALUE_RID),
 		&sensor.humidity, 0);
 
-	__wrap_lwm2m_engine_set_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_float_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PRESSURE_ID, 0, SENSOR_VALUE_RID),
 		&sensor.pressure, 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0,
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0,
 							       LOCATION_TIMESTAMP_RID),
 						    (int32_t)(gnss.gnss_ts / MSEC_PER_SEC), 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0,
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0,
 							       CURRENT_TIME_RID),
 						    (int32_t)(current_time / MSEC_PER_SEC), 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0, POWER_SOURCE_VOLTAGE_RID),
 		battery.bat, 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_TEMP_SENSOR_ID, 0, TIMESTAMP_RID),
 		(int32_t)(sensor.env_ts / MSEC_PER_SEC), 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_HUMIDITY_SENSOR_ID, 0, TIMESTAMP_RID),
 		(int32_t)(sensor.env_ts / MSEC_PER_SEC), 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PRESSURE_ID, 0, TIMESTAMP_RID),
 		(int32_t)(sensor.env_ts / MSEC_PER_SEC), 0);
 
-	__wrap_lwm2m_engine_set_u32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u32_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, CELLID),
 		modem_dynamic.cell, 0);
 
-	__wrap_lwm2m_engine_set_u8_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u8_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, NETWORK_BEARER_ID),
 		NB_IOT_BEARER, 0);
 
-	__wrap_lwm2m_engine_set_s8_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s8_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, RADIO_SIGNAL_STRENGTH),
 		modem_dynamic.rsrp, 0);
 
-	__wrap_lwm2m_engine_set_u16_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u16_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, SMNC), modem_dynamic.mnc, 0);
 
-	__wrap_lwm2m_engine_set_u16_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u16_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, SMCC), modem_dynamic.mcc, 0);
 
-	__wrap_lwm2m_engine_set_u16_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_u16_ExpectAndReturn(
 		LWM2M_PATH(LWM2M_OBJECT_CONNECTIVITY_MONITORING_ID, 0, LAC), modem_dynamic.area, 0);
 
 	const char *const path_list[] = {
@@ -666,15 +666,15 @@ void test_lwm2m_codec_encode_ui_data(void)
 		.queued = true
 	};
 
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAndReturn(&user_interface.btn_ts, 0);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAndReturn(&user_interface.btn_ts, 0);
 
-	__wrap_lwm2m_engine_set_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_bool_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, 0, DIGITAL_INPUT_STATE_RID), true, 0);
 
-	__wrap_lwm2m_engine_set_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_bool_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, 0, DIGITAL_INPUT_STATE_RID), false, 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, 0, TIMESTAMP_RID),
 		(int32_t)(user_interface.btn_ts / MSEC_PER_SEC), 0);
 
@@ -697,16 +697,16 @@ void test_lwm2m_codec_encode_ui_data(void)
 	user_interface.btn_ts = 1000;
 	user_interface.queued = true;
 
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAndReturn(&user_interface.btn_ts, 0);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAndReturn(&user_interface.btn_ts, 0);
 
 	/* Button 2 corresponds to object instance 1. */
-	__wrap_lwm2m_engine_set_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_bool_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, 1, DIGITAL_INPUT_STATE_RID), true, 0);
 
-	__wrap_lwm2m_engine_set_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_bool_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, 1, DIGITAL_INPUT_STATE_RID), false, 0);
 
-	__wrap_lwm2m_engine_set_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_set_s32_ExpectAndReturn(
 		LWM2M_PATH(IPSO_OBJECT_PUSH_BUTTON_ID, 1, TIMESTAMP_RID),
 		(int32_t)(user_interface.btn_ts / MSEC_PER_SEC), 0);
 
@@ -741,55 +741,55 @@ void test_lwm2m_codec_config_update(void)
 	 * parameter values (resources). The configuration values will be included in the
 	 * CLOUD_CODEC_EVT_CONFIG_UPDATE event received in the cloud_codec_event_handler.
 	 */
-	__wrap_lwm2m_engine_get_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_s32_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, LOCATION_TIMEOUT_RID), 0, 0);
-	__wrap_lwm2m_engine_get_s32_IgnoreArg_value();
-	__wrap_lwm2m_engine_get_s32_ReturnThruPtr_value(&cfg.location_timeout);
+	__cmock_lwm2m_engine_get_s32_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_s32_ReturnThruPtr_value(&cfg.location_timeout);
 
-	__wrap_lwm2m_engine_get_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_s32_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACTIVE_WAIT_TIMEOUT_RID), 0, 0);
-	__wrap_lwm2m_engine_get_s32_IgnoreArg_value();
-	__wrap_lwm2m_engine_get_s32_ReturnThruPtr_value(&cfg.active_wait_timeout);
+	__cmock_lwm2m_engine_get_s32_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_s32_ReturnThruPtr_value(&cfg.active_wait_timeout);
 
-	__wrap_lwm2m_engine_get_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_s32_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, MOVEMENT_RESOLUTION_RID), 0, 0);
-	__wrap_lwm2m_engine_get_s32_IgnoreArg_value();
-	__wrap_lwm2m_engine_get_s32_ReturnThruPtr_value(&cfg.movement_resolution);
+	__cmock_lwm2m_engine_get_s32_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_s32_ReturnThruPtr_value(&cfg.movement_resolution);
 
-	__wrap_lwm2m_engine_get_s32_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_s32_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, MOVEMENT_TIMEOUT_RID), 0, 0);
-	__wrap_lwm2m_engine_get_s32_IgnoreArg_value();
-	__wrap_lwm2m_engine_get_s32_ReturnThruPtr_value(&cfg.movement_timeout);
+	__cmock_lwm2m_engine_get_s32_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_s32_ReturnThruPtr_value(&cfg.movement_timeout);
 
-	__wrap_lwm2m_engine_get_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_float_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACCELEROMETER_ACT_THRESHOLD_RID), 0, 0);
-	__wrap_lwm2m_engine_get_float_IgnoreArg_buf();
-	__wrap_lwm2m_engine_get_float_ReturnThruPtr_buf(&cfg.accelerometer_activity_threshold);
+	__cmock_lwm2m_engine_get_float_IgnoreArg_buf();
+	__cmock_lwm2m_engine_get_float_ReturnThruPtr_buf(&cfg.accelerometer_activity_threshold);
 
-	__wrap_lwm2m_engine_get_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_float_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACCELEROMETER_INACT_THRESHOLD_RID), 0, 0);
-	__wrap_lwm2m_engine_get_float_IgnoreArg_buf();
-	__wrap_lwm2m_engine_get_float_ReturnThruPtr_buf(&cfg.accelerometer_inactivity_threshold);
+	__cmock_lwm2m_engine_get_float_IgnoreArg_buf();
+	__cmock_lwm2m_engine_get_float_ReturnThruPtr_buf(&cfg.accelerometer_inactivity_threshold);
 
-	__wrap_lwm2m_engine_get_float_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_float_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, ACCELEROMETER_INACT_TIMEOUT_RID), 0, 0);
-	__wrap_lwm2m_engine_get_float_IgnoreArg_buf();
-	__wrap_lwm2m_engine_get_float_ReturnThruPtr_buf(&cfg.accelerometer_inactivity_timeout);
+	__cmock_lwm2m_engine_get_float_IgnoreArg_buf();
+	__cmock_lwm2m_engine_get_float_ReturnThruPtr_buf(&cfg.accelerometer_inactivity_timeout);
 
-	__wrap_lwm2m_engine_get_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_bool_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, PASSIVE_MODE_RID), 0, 0);
-	__wrap_lwm2m_engine_get_bool_IgnoreArg_value();
-	__wrap_lwm2m_engine_get_bool_ReturnThruPtr_value(&passive_mode_temp);
+	__cmock_lwm2m_engine_get_bool_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_bool_ReturnThruPtr_value(&passive_mode_temp);
 
-	__wrap_lwm2m_engine_get_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_bool_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, GNSS_ENABLE_RID), 0, 0);
-	__wrap_lwm2m_engine_get_bool_IgnoreArg_value();
-	__wrap_lwm2m_engine_get_bool_ReturnThruPtr_value(&gnss_enable_temp);
+	__cmock_lwm2m_engine_get_bool_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_bool_ReturnThruPtr_value(&gnss_enable_temp);
 
-	__wrap_lwm2m_engine_get_bool_ExpectAndReturn(
+	__cmock_lwm2m_engine_get_bool_ExpectAndReturn(
 		LWM2M_PATH(CONFIGURATION_OBJECT_ID, 0, NEIGHBOR_CELL_ENABLE_RID), 0, 0);
-	__wrap_lwm2m_engine_get_bool_IgnoreArg_value();
-	__wrap_lwm2m_engine_get_bool_ReturnThruPtr_value(&ncell_enable_temp);
+	__cmock_lwm2m_engine_get_bool_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_bool_ReturnThruPtr_value(&ncell_enable_temp);
 
 	/* Trigger a configuration update. */
 	post_write_cb(0, 0, 0, NULL, 0, false, 0);

--- a/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
@@ -71,25 +71,25 @@ void setUp(void)
 	mock_lwm2m_Init();
 	mock_lte_lc_Init();
 
-	__wrap_lwm2m_init_image_ExpectAndReturn(0);
-	__wrap_lwm2m_init_firmware_ExpectAndReturn(0);
-	__wrap_lwm2m_init_security_ExpectAndReturn(&client,
+	__cmock_lwm2m_init_image_ExpectAndReturn(0);
+	__cmock_lwm2m_init_firmware_ExpectAndReturn(0);
+	__cmock_lwm2m_init_security_ExpectAndReturn(&client,
 						   endpoint_name,
 						   NULL,
 						   0);
-	__wrap_lwm2m_init_security_IgnoreArg_mmode();
+	__cmock_lwm2m_init_security_IgnoreArg_mmode();
 
-	__wrap_lwm2m_init_security_AddCallback(&init_security_callback_stub);
+	__cmock_lwm2m_init_security_AddCallback(&init_security_callback_stub);
 
-	__wrap_lwm2m_firmware_set_update_state_cb_ExpectAnyArgs();
-	__wrap_lwm2m_firmware_set_update_cb_ExpectAnyArgs();
+	__cmock_lwm2m_firmware_set_update_state_cb_ExpectAnyArgs();
+	__cmock_lwm2m_firmware_set_update_cb_ExpectAnyArgs();
 
-	__wrap_lwm2m_engine_register_exec_callback_ExpectAndReturn(REBOOT_PATH, NULL, 0);
-	__wrap_lwm2m_engine_register_exec_callback_IgnoreArg_cb();
+	__cmock_lwm2m_engine_register_exec_callback_ExpectAndReturn(REBOOT_PATH, NULL, 0);
+	__cmock_lwm2m_engine_register_exec_callback_IgnoreArg_cb();
 
-	__wrap_lwm2m_engine_register_exec_callback_AddCallback(&register_exec_callback_stub);
-	__wrap_lwm2m_firmware_set_update_state_cb_AddCallback(&set_update_state_callback_stub);
-	__wrap_lwm2m_firmware_set_update_cb_AddCallback(&set_update_callback_stub);
+	__cmock_lwm2m_engine_register_exec_callback_AddCallback(&register_exec_callback_stub);
+	__cmock_lwm2m_firmware_set_update_state_cb_AddCallback(&set_update_state_callback_stub);
+	__cmock_lwm2m_firmware_set_update_cb_AddCallback(&set_update_callback_stub);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_init(cloud_wrap_event_handler));
 }
@@ -161,7 +161,7 @@ void test_lwm2m_integration_connect(void)
 	uint32_t current_lifetime_expected = 0;
 	uint32_t new_lifetime_expected = CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME;
 
-	__wrap_lwm2m_rd_client_start_AddCallback(&rd_client_set_callback_stub);
+	__cmock_lwm2m_rd_client_start_AddCallback(&rd_client_set_callback_stub);
 
 	/* After the uut has been put into state CONNECTED, the lwm2m lifetime resource is
 	 * updated. This is done by getting the resource that contains the lifetime and setting it
@@ -169,17 +169,17 @@ void test_lwm2m_integration_connect(void)
 	 * bootstrapping because the boostrap server will override the default value set by the
 	 * application.
 	 */
-	__wrap_lwm2m_engine_get_u32_ExpectAndReturn(LIFETIME_PATH, &current_lifetime_expected, 0);
-	__wrap_lwm2m_engine_set_u32_ExpectAndReturn(LIFETIME_PATH, new_lifetime_expected, 0);
+	__cmock_lwm2m_engine_get_u32_ExpectAndReturn(LIFETIME_PATH, &current_lifetime_expected, 0);
+	__cmock_lwm2m_engine_set_u32_ExpectAndReturn(LIFETIME_PATH, new_lifetime_expected, 0);
 
-	__wrap_lwm2m_security_needs_bootstrap_ExpectAndReturn(0);
-	__wrap_lwm2m_rd_client_start_ExpectAndReturn(&client,
+	__cmock_lwm2m_security_needs_bootstrap_ExpectAndReturn(0);
+	__cmock_lwm2m_rd_client_start_ExpectAndReturn(&client,
 						     endpoint_name,
 						     0,
 						     NULL,
 						     NULL,
 						     0);
-	__wrap_lwm2m_rd_client_start_IgnoreArg_event_cb();
+	__cmock_lwm2m_rd_client_start_IgnoreArg_event_cb();
 
 	TEST_ASSERT_EQUAL(cloud_wrap_connect(), 0);
 
@@ -192,8 +192,8 @@ void test_lwm2m_integration_disconnect(void)
 {
 	test_lwm2m_integration_connect();
 
-	__wrap_lwm2m_rd_client_stop_ExpectAndReturn(&client, NULL, false, 0);
-	__wrap_lwm2m_rd_client_stop_IgnoreArg_event_cb();
+	__cmock_lwm2m_rd_client_stop_ExpectAndReturn(&client, NULL, false, 0);
+	__cmock_lwm2m_rd_client_stop_IgnoreArg_event_cb();
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_disconnect());
 }
@@ -209,7 +209,7 @@ void test_lwm2m_integration_data_send(void)
 		"4/0/7",
 	};
 
-	__wrap_lwm2m_engine_send_ExpectAndReturn(&client, (const char **)paths, PATH_LEN, true, 0);
+	__cmock_lwm2m_engine_send_ExpectAndReturn(&client, (const char **)paths, PATH_LEN, true, 0);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_data_send(NULL, PATH_LEN, true, 0, paths));
 }
@@ -225,21 +225,21 @@ void test_lwm2m_integration_ui_send(void)
 		"4/0/7",
 	};
 
-	__wrap_lwm2m_engine_send_ExpectAndReturn(&client, (const char **)paths, PATH_LEN, true, 0);
+	__cmock_lwm2m_engine_send_ExpectAndReturn(&client, (const char **)paths, PATH_LEN, true, 0);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_ui_send(NULL, PATH_LEN, true, 0, paths));
 }
 
 void test_lwm2m_integration_neighbor_cells_send(void)
 {
-	__wrap_location_assistance_ground_fix_request_send_ExpectAndReturn(&client, true, 0);
+	__cmock_location_assistance_ground_fix_request_send_ExpectAndReturn(&client, true, 0);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_neighbor_cells_send(NULL, 0, true, 0));
 }
 
 void test_lwm2m_integration_agps_request_send(void)
 {
-	__wrap_location_assistance_agps_request_send_ExpectAndReturn(&client, true, 0);
+	__cmock_location_assistance_agps_request_send_ExpectAndReturn(&client, true, 0);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_agps_request_send(NULL, 0, true, 0));
 }
@@ -265,7 +265,7 @@ void test_lwm2m_integration_batch_send(void)
 
 void test_lwm2m_integration_pgps_request_send(void)
 {
-	__wrap_location_assistance_pgps_request_send_ExpectAndReturn(&client, true, 0);
+	__cmock_location_assistance_pgps_request_send_ExpectAndReturn(&client, true, 0);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_pgps_request_send(NULL, 0, true, 0));
 }
@@ -283,9 +283,9 @@ void test_lwm2m_integration_mode_change_offline(void)
 	/* Simulate a condition where the lte_lc_func_mode_get returns LTE_LC_FUNC_MODE_NORMAL.*/
 	enum lte_lc_func_mode mode_current = LTE_LC_FUNC_MODE_NORMAL;
 
-	__wrap_lte_lc_func_mode_get_ExpectAndReturn(NULL, 0);
-	__wrap_lte_lc_func_mode_get_IgnoreArg_mode();
-	__wrap_lte_lc_func_mode_get_ReturnMemThruPtr_mode(&mode_current, sizeof(mode_current));
+	__cmock_lte_lc_func_mode_get_ExpectAndReturn(NULL, 0);
+	__cmock_lte_lc_func_mode_get_IgnoreArg_mode();
+	__cmock_lte_lc_func_mode_get_ReturnMemThruPtr_mode(&mode_current, sizeof(mode_current));
 
 	/* Trigger a change to LTE_LC_FUNC_MODE_OFFLINE. */
 	modem_mode_change_cb(LTE_LC_FUNC_MODE_OFFLINE, NULL);
@@ -297,9 +297,9 @@ void test_lwm2m_integration_mode_change_online(void)
 	/* Simulate a condition where the lte_lc_func_mode_get returns LTE_LC_FUNC_MODE_OFFLINE.*/
 	enum lte_lc_func_mode mode_current = LTE_LC_FUNC_MODE_OFFLINE;
 
-	__wrap_lte_lc_func_mode_get_ExpectAndReturn(NULL, 0);
-	__wrap_lte_lc_func_mode_get_IgnoreArg_mode();
-	__wrap_lte_lc_func_mode_get_ReturnMemThruPtr_mode(&mode_current, sizeof(mode_current));
+	__cmock_lte_lc_func_mode_get_ExpectAndReturn(NULL, 0);
+	__cmock_lte_lc_func_mode_get_IgnoreArg_mode();
+	__cmock_lte_lc_func_mode_get_ReturnMemThruPtr_mode(&mode_current, sizeof(mode_current));
 
 	/* Trigger a change to LTE_LC_FUNC_MODE_NORMAL. */
 	modem_mode_change_cb(LTE_LC_FUNC_MODE_NORMAL, NULL);
@@ -316,7 +316,7 @@ void test_lwm2m_integration_bootstrap_registration_failure(void)
 {
 	test_lwm2m_integration_connect();
 
-	__wrap_lwm2m_rd_client_stop_ExpectAnyArgsAndReturn(0);
+	__cmock_lwm2m_rd_client_stop_ExpectAnyArgsAndReturn(0);
 
 	rd_client_callback(&client, LWM2M_RD_CLIENT_EVENT_BOOTSTRAP_REG_FAILURE);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_DISCONNECTED, last_cb_type);
@@ -326,7 +326,7 @@ void test_lwm2m_integration_registration_failure(void)
 {
 	test_lwm2m_integration_connect();
 
-	__wrap_lwm2m_rd_client_stop_ExpectAnyArgsAndReturn(0);
+	__cmock_lwm2m_rd_client_stop_ExpectAnyArgsAndReturn(0);
 
 	rd_client_callback(&client, LWM2M_RD_CLIENT_EVENT_REGISTRATION_FAILURE);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_DISCONNECTED, last_cb_type);
@@ -362,17 +362,17 @@ void test_lwm2m_integration_network_error(void)
 void test_lwm2m_integration_fota_result_get(void)
 {
 	/* Expect the FOTA update result to be retrieved for any update in FOTA state. */
-	__wrap_lwm2m_engine_get_u8_ExpectAndReturn(FIRMWARE_UPDATE_RESULT_PATH, NULL, 0);
-	__wrap_lwm2m_engine_get_u8_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_u8_ExpectAndReturn(FIRMWARE_UPDATE_RESULT_PATH, NULL, 0);
+	__cmock_lwm2m_engine_get_u8_IgnoreArg_value();
 
-	__wrap_lwm2m_engine_get_u8_ExpectAndReturn(FIRMWARE_UPDATE_RESULT_PATH, NULL, 0);
-	__wrap_lwm2m_engine_get_u8_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_u8_ExpectAndReturn(FIRMWARE_UPDATE_RESULT_PATH, NULL, 0);
+	__cmock_lwm2m_engine_get_u8_IgnoreArg_value();
 
-	__wrap_lwm2m_engine_get_u8_ExpectAndReturn(FIRMWARE_UPDATE_RESULT_PATH, NULL, 0);
-	__wrap_lwm2m_engine_get_u8_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_u8_ExpectAndReturn(FIRMWARE_UPDATE_RESULT_PATH, NULL, 0);
+	__cmock_lwm2m_engine_get_u8_IgnoreArg_value();
 
-	__wrap_lwm2m_engine_get_u8_ExpectAndReturn(FIRMWARE_UPDATE_RESULT_PATH, NULL, 0);
-	__wrap_lwm2m_engine_get_u8_IgnoreArg_value();
+	__cmock_lwm2m_engine_get_u8_ExpectAndReturn(FIRMWARE_UPDATE_RESULT_PATH, NULL, 0);
+	__cmock_lwm2m_engine_get_u8_IgnoreArg_value();
 
 	firmware_update_state_cb(STATE_IDLE);
 	firmware_update_state_cb(STATE_DOWNLOADING);
@@ -382,7 +382,7 @@ void test_lwm2m_integration_fota_result_get(void)
 
 void test_lwm2m_integration_fota_result_get_error(void)
 {
-	__wrap_lwm2m_engine_get_u8_ExpectAnyArgsAndReturn(-1);
+	__cmock_lwm2m_engine_get_u8_ExpectAnyArgsAndReturn(-1);
 
 	firmware_update_state_cb(STATE_DOWNLOADING);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_ERROR, last_cb_type);
@@ -390,7 +390,7 @@ void test_lwm2m_integration_fota_result_get_error(void)
 
 void test_lwm2m_integration_fota_error(void)
 {
-	__wrap_lwm2m_engine_get_u8_IgnoreAndReturn(0);
+	__cmock_lwm2m_engine_get_u8_IgnoreAndReturn(0);
 
 	/* Expect an error event to be returned if FOTA state reverts to STATE_IDLE. */
 	firmware_update_state_cb(STATE_IDLE);
@@ -399,7 +399,7 @@ void test_lwm2m_integration_fota_error(void)
 
 void test_lwm2m_integration_fota_downloading(void)
 {
-	__wrap_lwm2m_engine_get_u8_IgnoreAndReturn(0);
+	__cmock_lwm2m_engine_get_u8_IgnoreAndReturn(0);
 
 	firmware_update_state_cb(STATE_DOWNLOADING);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_FOTA_START, last_cb_type);
@@ -407,7 +407,7 @@ void test_lwm2m_integration_fota_downloading(void)
 
 void test_lwm2m_integration_fota_downloaded(void)
 {
-	__wrap_lwm2m_engine_get_u8_IgnoreAndReturn(0);
+	__cmock_lwm2m_engine_get_u8_IgnoreAndReturn(0);
 
 	/* Expect no event to be called by setting last_cb_type to UINT8_MAX and verifying that
 	 * the value has not changed after the state change.
@@ -420,7 +420,7 @@ void test_lwm2m_integration_fota_downloaded(void)
 
 void test_lwm2m_integration_fota_updating(void)
 {
-	__wrap_lwm2m_engine_get_u8_IgnoreAndReturn(0);
+	__cmock_lwm2m_engine_get_u8_IgnoreAndReturn(0);
 
 	/* Expect no event to be called by setting last_cb_type to UINT8_MAX and verifying that
 	 * the value has not changed after the state change.
@@ -433,7 +433,7 @@ void test_lwm2m_integration_fota_updating(void)
 
 void test_lwm2m_integration_fota_unexpected_event(void)
 {
-	__wrap_lwm2m_engine_get_u8_IgnoreAndReturn(0);
+	__cmock_lwm2m_engine_get_u8_IgnoreAndReturn(0);
 
 	/* Trigger an event update with an unknown event type. */
 	firmware_update_state_cb(UINT8_MAX);
@@ -442,7 +442,7 @@ void test_lwm2m_integration_fota_unexpected_event(void)
 
 void test_lwm2m_integration_fota_done(void)
 {
-	__wrap_lwm2m_firmware_apply_update_ExpectAndReturn(0, 0);
+	__cmock_lwm2m_firmware_apply_update_ExpectAndReturn(0, 0);
 
 	firmware_update_cb(0, NULL, 0);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_FOTA_DONE, last_cb_type);
@@ -450,7 +450,7 @@ void test_lwm2m_integration_fota_done(void)
 
 void test_lwm2m_integration_fota_done_error(void)
 {
-	__wrap_lwm2m_firmware_apply_update_ExpectAndReturn(0, -1);
+	__cmock_lwm2m_firmware_apply_update_ExpectAndReturn(0, -1);
 
 	firmware_update_cb(0, NULL, 0);
 	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_FOTA_ERROR, last_cb_type);

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/src/nrf_cloud_codec_mocked_test.c
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/src/nrf_cloud_codec_mocked_test.c
@@ -25,7 +25,7 @@ void setUp(void)
 	mock_date_time_Init();
 	mock_json_helpers_Init();
 
-	__wrap_cJSON_Init_Ignore();
+	__cmock_cJSON_Init_Ignore();
 	ret = cloud_codec_init(NULL, NULL);
 	TEST_ASSERT_EQUAL(0, ret);
 
@@ -68,7 +68,7 @@ void test_enc_ui_fail0(void)
 	};
 
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
 
 	ret = cloud_codec_encode_ui_data(&codec, &data);
 	TEST_ASSERT_EQUAL(-ENOMEM, ret);
@@ -82,9 +82,9 @@ void test_enc_ui_fail1(void)
 	};
 
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(-ENOMEM);
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(-ENOMEM);
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_ui_data(&codec, &data);
 	TEST_ASSERT_EQUAL(-ENOMEM, ret);
@@ -98,12 +98,12 @@ void test_enc_ui_fail2(void)
 	};
 
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_meta_data */
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(-ENOMEM);
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(-ENOMEM);
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_ui_data(&codec, &data);
 	TEST_ASSERT_EQUAL(-ENOMEM, ret);
@@ -117,13 +117,13 @@ void test_enc_ui_fail3(void)
 	};
 
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_meta_data */
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(-ENOMEM);
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(-ENOMEM);
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_ui_data(&codec, &data);
 	TEST_ASSERT_EQUAL(-ENOMEM, ret);
@@ -137,14 +137,14 @@ void test_enc_ui_fail4(void)
 	};
 
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_meta_data */
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(-ENODATA);
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(-ENODATA);
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_ui_data(&codec, &data);
 	TEST_ASSERT_EQUAL(-ENODATA, ret);
@@ -158,15 +158,15 @@ void test_enc_ui_fail5(void)
 	};
 
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_meta_data */
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_number_ExpectAnyArgsAndReturn(-ENOMEM);
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_number_ExpectAnyArgsAndReturn(-ENOMEM);
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_ui_data(&codec, &data);
 	TEST_ASSERT_EQUAL(-ENOMEM, ret);
@@ -181,16 +181,16 @@ void test_enc_ui_fail6(void)
 	};
 
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_meta_data */
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_number_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_str_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_number_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* cloud_codec_encode_ui_data */
-	__wrap_cJSON_PrintUnformatted_ExpectAnyArgsAndReturn(NULL);
-	__wrap_cJSON_Delete_ExpectAnyArgs();
+	__cmock_cJSON_PrintUnformatted_ExpectAnyArgsAndReturn(NULL);
+	__cmock_cJSON_Delete_ExpectAnyArgs();
 
 	ret = cloud_codec_encode_ui_data(&codec, &data);				/*~A*/
 	TEST_ASSERT_EQUAL(-ENOMEM, ret);
@@ -201,11 +201,11 @@ void test_enc_batch_data_sensor_timefail(void)
 	struct cloud_data_sensors sensor_buf = { .queued = true	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(-EINVAL);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(-EINVAL);
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    NULL,
@@ -230,28 +230,28 @@ void test_enc_batch_data_sensor_big_values(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*B*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~B*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*B*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~B*/
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*C*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~C*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*C*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~C*/
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*D*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~D*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*D*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~D*/
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*E*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~E*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*E*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~E*/
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	/* some functions we don't care about here */
-	__wrap_cJSON_GetArraySize_IgnoreAndReturn(0);
-	__wrap_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_GetArraySize_IgnoreAndReturn(0);
+	__cmock_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    NULL,
@@ -276,18 +276,18 @@ void test_enc_batch_data_sensor_add_air_quality_fail(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	/* some functions we don't care about here */
-	__wrap_cJSON_GetArraySize_IgnoreAndReturn(0);
-	__wrap_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_GetArraySize_IgnoreAndReturn(0);
+	__cmock_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    NULL,
@@ -312,21 +312,21 @@ void test_enc_batch_data_sensor_add_humidity_fail(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*B*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~B*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*B*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~B*/
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	/* some functions we don't care about here */
-	__wrap_cJSON_GetArraySize_IgnoreAndReturn(0);
-	__wrap_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_GetArraySize_IgnoreAndReturn(0);
+	__cmock_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    NULL,
@@ -351,24 +351,24 @@ void test_enc_batch_data_sensor_add_temperature_fail(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*B*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~B*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*B*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~B*/
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*C*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~C*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*C*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~C*/
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	/* some functions we don't care about here */
-	__wrap_cJSON_GetArraySize_IgnoreAndReturn(0);
-	__wrap_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_GetArraySize_IgnoreAndReturn(0);
+	__cmock_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    NULL,
@@ -393,27 +393,27 @@ void test_enc_batch_data_sensor_add_pressure_fail(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*B*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~B*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*B*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~B*/
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*C*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~C*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*C*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~C*/
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*D*/
-	__wrap_json_add_obj_array_ExpectAnyArgs();					/*~D*/
+	__cmock_cJSON_CreateObject_ExpectAndReturn((void *)1);				/*D*/
+	__cmock_json_add_obj_array_ExpectAnyArgs();					/*~D*/
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	/* some functions we don't care about here */
-	__wrap_cJSON_GetArraySize_IgnoreAndReturn(0);
-	__wrap_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
-	__wrap_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_GetArraySize_IgnoreAndReturn(0);
+	__cmock_json_add_str_IgnoreAndReturn(EXIT_SUCCESS);
+	__cmock_json_add_number_IgnoreAndReturn(EXIT_SUCCESS);
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    NULL,
@@ -434,7 +434,7 @@ void test_enc_batch_data_gnss_no_array(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateArray_ExpectAndReturn(NULL);
 	ret = cloud_codec_encode_batch_data(&codec,
 					    &gnss_buf,
 					    NULL,
@@ -456,12 +456,12 @@ void test_enc_batch_data_bat_no_data_obj(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    NULL,
@@ -482,12 +482,12 @@ void test_enc_batch_data_gnss_no_data_obj(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    &gnss_buf,
@@ -508,12 +508,12 @@ void test_enc_batch_data_ui_no_data_obj(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
 	/* add_data */
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    NULL,
@@ -535,13 +535,13 @@ void test_enc_batch_data_modem_dyn_no_data_obj(void)
 	};
 
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
+	__cmock_cJSON_CreateArray_ExpectAndReturn((void *)1);				/*A*/
 	/* add_batch_data */
 	/* modem_dynamic_data_add */
-	__wrap_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_date_time_uptime_to_unix_time_ms_ExpectAnyArgsAndReturn(EXIT_SUCCESS);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
 	/* cloud_codec_encode_batch_data */
-	__wrap_cJSON_Delete_ExpectAnyArgs();						/*~A*/
+	__cmock_cJSON_Delete_ExpectAnyArgs();						/*~A*/
 
 	ret = cloud_codec_encode_batch_data(&codec,
 					    NULL,
@@ -561,12 +561,12 @@ void test_enc_config_nomem1(void)
 	struct cloud_data_cfg data = {0};
 
 	/* cloud_codec_encode_config */
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
-	__wrap_cJSON_CreateObject_ExpectAndReturn(NULL);
-	__wrap_cJSON_Delete_ExpectAnyArgs();
-	__wrap_cJSON_Delete_ExpectAnyArgs();
-	__wrap_cJSON_Delete_ExpectAnyArgs();
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_CreateObject_ExpectAndReturn(NULL);
+	__cmock_cJSON_Delete_ExpectAnyArgs();
+	__cmock_cJSON_Delete_ExpectAnyArgs();
+	__cmock_cJSON_Delete_ExpectAnyArgs();
 
 	ret = cloud_codec_encode_config(&codec, &data);
 	TEST_ASSERT_EQUAL(-ENOMEM, ret);

--- a/applications/asset_tracker_v2/tests/ui_module/src/ui_module_test.c
+++ b/applications/asset_tracker_v2/tests/ui_module/src/ui_module_test.c
@@ -39,8 +39,8 @@ static struct location_module_event location_module_event_memory;
 
 /* Macro used to submit module events of a specific type to the UI module. */
 #define TEST_SEND_EVENT(_mod, _type, _event)							\
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&_mod##_module_event_memory);	\
-	__wrap_app_event_manager_free_ExpectAnyArgs();						\
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&_mod##_module_event_memory);	\
+	__cmock_app_event_manager_free_ExpectAnyArgs();						\
 	_event = new_##_mod##_module_event();							\
 	_event->type = _type;									\
 	TEST_ASSERT_FALSE(UI_MODULE_EVT_HANDLER(						\
@@ -200,7 +200,7 @@ void setup_ui_module_in_init_state(void)
 {
 	state_verify(STATE_INIT, SUB_STATE_ACTIVE, SUB_SUB_STATE_LOCATION_INACTIVE);
 
-	__wrap_module_start_Stub(&module_start_stub);
+	__cmock_module_start_Stub(&module_start_stub);
 
 	struct app_module_event *app_module_event;
 
@@ -302,14 +302,14 @@ void test_state_shutdown_fota(void)
 	setup_ui_module_in_init_state();
 
 	/* Verify state transition to STATE_SHUTDOWN. */
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&util_module_event_memory);
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&util_module_event_memory);
 
 	/* When a shutdown request is notified by the utility module it is expected that
 	 * the UI module acknowledges the shutdown request.
 	 */
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&ui_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
-	__wrap__event_submit_Stub(&validate_ui_evt);
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&ui_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
+	__cmock__event_submit_Stub(&validate_ui_evt);
 
 	struct util_module_event *util_module_event = new_util_module_event();
 
@@ -332,14 +332,14 @@ void test_state_shutdown_error(void)
 	setup_ui_module_in_init_state();
 
 	/* Verify state transition to STATE_SHUTDOWN. */
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&util_module_event_memory);
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&util_module_event_memory);
 
 	/* When a shutdown request is notified by the utility module it is expected that
 	 * the UI module acknowledges the shutdown request.
 	 */
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&ui_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
-	__wrap__event_submit_Stub(&validate_ui_evt);
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&ui_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
+	__cmock__event_submit_Stub(&validate_ui_evt);
 
 	struct util_module_event *util_module_event = new_util_module_event();
 
@@ -387,10 +387,10 @@ void test_mode_transition(void)
 
 	verify_publication(true);
 
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&data_module_event_memory);
-	__wrap_app_event_manager_alloc_ExpectAnyArgsAndReturn(&data_module_event_memory);
-	__wrap_app_event_manager_free_ExpectAnyArgs();
-	__wrap_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&data_module_event_memory);
+	__cmock_app_event_manager_alloc_ExpectAnyArgsAndReturn(&data_module_event_memory);
+	__cmock_app_event_manager_free_ExpectAnyArgs();
+	__cmock_app_event_manager_free_ExpectAnyArgs();
 
 	/* Set module in SUB_STATE_PASSIVE */
 	data_module_event = new_data_module_event();

--- a/doc/nrf/ug_unity_testing.rst
+++ b/doc/nrf/ug_unity_testing.rst
@@ -25,8 +25,8 @@ To run the unit test, enable the Unity module (:kconfig:option:`CONFIG_UNITY`) a
 The module under test and all dependencies are enabled and compiled into the binary, even the mocked modules.
 
 The linker replaces all calls to the mocked API with a mock implementation using the wrapping feature.
-For example, :code:`-Wl,--wrap=foo` replaces every call to :code:`foo()` with a call to :code:`__wrap_foo()`.
-Because of that, all mock functions are prefixed with :code:`__wrap` (for example, :code:`__wrap_foo_Expect()` instead of :code:`foo_Expect()`).
+For example, :code:`-Wl,--wrap=foo` replaces every call to :code:`foo()` with a call to :code:`__cmock_foo()`.
+Because of that, all mock functions are prefixed with :code:`__cmock` (for example, :code:`__cmock_foo_Expect()` instead of :code:`foo_Expect()`).
 
 To specify the APIs that should be mocked in a given test, edit :file:`CMakeLists.txt` to call :code:`cmock_handle` with the header file and, optionally, the relative path to the header as arguments.
 The relative path is needed if a file is included as, for example, :code:`#include <zephyr/bluetooth/gatt.h>`.

--- a/scripts/unity/func_name_list.py
+++ b/scripts/unity/func_name_list.py
@@ -15,7 +15,7 @@ def func_names_from_header(in_file, out_file):
     with open(out_file, 'w') as f_out:
         # Regex match all function names in the header file
         # Tests for validating the regex in tests/unity/wrap
-        x = re.findall(r"^\s*(?:\w+[*\s]+)+(\w+?)\s*\([\w\s,*\.\[\]]*?\)\s*;",
+        x = re.findall(r"(?!^\s*static)^\s*(?:\w+[*\s]+)+(\w+?)\s*\([\w\s,*\.\[\]]*?\)\s*;",
                        content, re.M | re.S)
         for item in x:
             f_out.write(item + "\n")

--- a/scripts/unity/header_prepare.py
+++ b/scripts/unity/header_prepare.py
@@ -61,11 +61,11 @@ def header_prepare(in_file, out_file, out_wrap_file):
     with open(out_file, 'w') as f_out:
         f_out.write(content)
 
-    # Prepare file with functions prefixed with __wrap_ that will be used for
+    # Prepare file with functions prefixed with __cmock_ that will be used for
     # mock generation.
     func_pattern = re.compile(
         r"^\s*((?:\w+[*\s]+)+)(\w+?\s*\([\w\s,*\.\[\]]*?\)\s*;)", re.M)
-    content2 = func_pattern.sub(r"\n\1__wrap_\2", content)
+    content2 = func_pattern.sub(r"\n\1__cmock_\2", content)
 
     with open(out_wrap_file, 'w') as f_wrap:
         f_wrap.write(content2)
@@ -79,7 +79,7 @@ if __name__ == "__main__":
                         help="stripped header file to be included in the test",
                         required=True)
     parser.add_argument("-w", "--wrap", type=str,
-                        help='header with __wrap_-prefixed functions for'
+                        help='header with __cmock_-prefixed functions for'
                         'mock generation', required=True)
     args = parser.parse_args()
 

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -179,7 +179,8 @@ void test_location_init_fail_gnss_event_handler_set(void)
 {
 	int ret;
 
-	__wrap_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, -EPERM);
+	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler,
+		-EPERM);
 
 	ret = location_init(location_event_handler);
 	TEST_ASSERT_EQUAL(-EPERM, ret);
@@ -214,15 +215,15 @@ void test_location_init(void)
 {
 	int ret;
 
-	__wrap_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
+	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
 	// TODO: Change Ignores to Expects
-	__wrap_modem_key_mgmt_exists_IgnoreAndReturn(0);
+	__cmock_modem_key_mgmt_exists_IgnoreAndReturn(0);
 
 	/* TODO: This would be correct but printf syntax is what we receive into the mock
 	 *       so we cannot check that XMODEMSLEEP parameters are correct.
-	 * __wrap_nrf_modem_at_printf_ExpectAndReturn("AT%XMODEMSLEEP=1,0,10240", 0);
+	 * __cmock_nrf_modem_at_printf_ExpectAndReturn("AT%XMODEMSLEEP=1,0,10240", 0);
 	 */
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%XMODEMSLEEP=1,%d,%d", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%XMODEMSLEEP=1,%d,%d", 0);
 
 	ret = location_init(location_event_handler);
 	TEST_ASSERT_EQUAL(0, ret);
@@ -286,31 +287,31 @@ void test_location_gnss(void)
 
 	location_callback_called_expected = true;
 
-	__wrap_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
+	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
 
-	__wrap_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
-	__wrap_nrf_modem_gnss_use_case_set_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
+	__cmock_nrf_modem_gnss_use_case_set_ExpectAndReturn(
 		NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START, 0);
-	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_start_ExpectAndReturn(0);
 
 	/* TODO: Cannot determine the used system mode but it's set as zero by default in lte_lc */
-	__wrap_nrf_modem_at_scanf_ExpectAndReturn(
+	__cmock_nrf_modem_at_scanf_ExpectAndReturn(
 		"AT%XSYSTEMMODE?", "%%XSYSTEMMODE: %d,%d,%d,%d", 4);
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
 		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 	at_monitor_dispatch("+CSCON: 0");
 
-	__wrap_nrf_modem_gnss_read_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_read_ExpectAndReturn(
 		NULL, sizeof(test_pvt_data), NRF_MODEM_GNSS_DATA_PVT, 0);
-	__wrap_nrf_modem_gnss_read_IgnoreArg_buf();
-	__wrap_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
-	__wrap_nrf_modem_gnss_stop_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_read_IgnoreArg_buf();
+	__cmock_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
+	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 	method_gnss_event_handler(NRF_MODEM_GNSS_EVT_PVT);
 }
 
@@ -329,13 +330,14 @@ void cellular_rest_req_resp_handle(void)
 	rest_resp_ctx.response_len = strlen(http_resp + strlen(http_resp_header_ok));
 	rest_resp_ctx.response = http_resp + strlen(http_resp_header_ok);
 
-	__wrap_rest_client_request_defaults_set_ExpectAnyArgs();
+	__cmock_rest_client_request_defaults_set_ExpectAnyArgs();
 	// TODO: We should verify rest_req_ctx
-	//__wrap_rest_client_request_ExpectWithArrayAndReturn(&rest_req_ctx, 1, NULL, 0, 0);
-	__wrap_rest_client_request_ExpectAndReturn(&rest_req_ctx, NULL, 0);
-	__wrap_rest_client_request_IgnoreArg_req_ctx();
-	__wrap_rest_client_request_IgnoreArg_resp_ctx();
-	__wrap_rest_client_request_ReturnMemThruPtr_resp_ctx(&rest_resp_ctx, sizeof(rest_resp_ctx));
+	//__cmock_rest_client_request_ExpectWithArrayAndReturn(&rest_req_ctx, 1, NULL, 0, 0);
+	__cmock_rest_client_request_ExpectAndReturn(&rest_req_ctx, NULL, 0);
+	__cmock_rest_client_request_IgnoreArg_req_ctx();
+	__cmock_rest_client_request_IgnoreArg_resp_ctx();
+	__cmock_rest_client_request_ReturnMemThruPtr_resp_ctx(&rest_resp_ctx,
+		sizeof(rest_resp_ctx));
 }
 
 /* Test successful cellular location request utilizing HERE service.
@@ -357,7 +359,7 @@ void test_location_cellular(void)
 
 	location_callback_called_expected = true;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
 
 	cellular_rest_req_resp_handle();
 
@@ -389,13 +391,13 @@ void test_location_cellular_cancel_during_ncellmeas(void)
 	location_config_defaults_set(&config, 1, methods);
 	location_callback_called_expected = false;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
 	k_sleep(K_MSEC(1));
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEASSTOP", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEASSTOP", 0);
 
 	err = location_request_cancel();
 	TEST_ASSERT_EQUAL(0, err);
@@ -486,36 +488,36 @@ void test_location_request_default(void)
 
 	test_pvt_data.flags = NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID;
 
-	__wrap_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
+	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
 
-	__wrap_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
-	__wrap_nrf_modem_gnss_use_case_set_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
+	__cmock_nrf_modem_gnss_use_case_set_ExpectAndReturn(
 		NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START, 0);
-	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_start_ExpectAndReturn(0);
 
 	/* TODO: Cannot determine the used system mode but it's set as zero by default in lte_lc */
-	__wrap_nrf_modem_at_scanf_ExpectAndReturn(
+	__cmock_nrf_modem_at_scanf_ExpectAndReturn(
 		"AT%XSYSTEMMODE?", "%%XSYSTEMMODE: %d,%d,%d,%d", 4);
 
 	err = location_request(NULL);
 	TEST_ASSERT_EQUAL(0, err);
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
 		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 	at_monitor_dispatch("+CSCON: 0");
 
-	__wrap_nrf_modem_gnss_read_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_read_ExpectAndReturn(
 		NULL, sizeof(test_pvt_data), NRF_MODEM_GNSS_DATA_PVT, -EINVAL);
-	__wrap_nrf_modem_gnss_read_IgnoreArg_buf();
-	__wrap_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
+	__cmock_nrf_modem_gnss_read_IgnoreArg_buf();
+	__cmock_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
 	method_gnss_event_handler(NRF_MODEM_GNSS_EVT_PVT);
 
 	/***** Fallback to cellular *****/
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
 
 	cellular_rest_req_resp_handle();
 
@@ -561,7 +563,7 @@ void test_location_request_mode_all_cellular_gnss(void)
 
 	/***** First cellular positioning *****/
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -615,30 +617,30 @@ void test_location_request_mode_all_cellular_gnss(void)
 	test_pvt_data.datetime.ms = 789;
 	test_pvt_data.flags = NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID;
 
-	__wrap_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
+	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
 
-	__wrap_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
-	__wrap_nrf_modem_gnss_use_case_set_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
+	__cmock_nrf_modem_gnss_use_case_set_ExpectAndReturn(
 		NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START, 0);
-	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_start_ExpectAndReturn(0);
 
 	/* TODO: Cannot determine the used system mode but it's set as zero by default in lte_lc */
-	__wrap_nrf_modem_at_scanf_ExpectAndReturn(
+	__cmock_nrf_modem_at_scanf_ExpectAndReturn(
 		"AT%XSYSTEMMODE?", "%%XSYSTEMMODE: %d,%d,%d,%d", 4);
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
 		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 	at_monitor_dispatch("+CSCON: 0");
 	k_sleep(K_MSEC(1));
 
-	__wrap_nrf_modem_gnss_read_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_read_ExpectAndReturn(
 		NULL, sizeof(test_pvt_data), NRF_MODEM_GNSS_DATA_PVT, 0);
-	__wrap_nrf_modem_gnss_read_IgnoreArg_buf();
-	__wrap_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
-	__wrap_nrf_modem_gnss_stop_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_read_IgnoreArg_buf();
+	__cmock_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
+	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 	method_gnss_event_handler(NRF_MODEM_GNSS_EVT_PVT);
 }
 
@@ -665,7 +667,7 @@ void test_location_request_timeout_cellular_gnss_mode_all(void)
 
 	/***** First cellular positioning *****/
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
 
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -673,8 +675,8 @@ void test_location_request_timeout_cellular_gnss_mode_all(void)
 	/* Wait for location_event_handler call for 3 seconds.
 	 * If it doesn't happen, next assert will fail the test.
 	 */
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEASSTOP", 0);
-	__wrap_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEASSTOP", 0);
+	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
 	k_sem_take(&event_handler_called_sem, K_SECONDS(3));
 	TEST_ASSERT_EQUAL(location_callback_called_expected, location_callback_called_occurred);
 	location_callback_called_occurred = false;
@@ -683,24 +685,24 @@ void test_location_request_timeout_cellular_gnss_mode_all(void)
 	/***** Then GNSS positioning *****/
 	test_location_event_data.id = LOCATION_EVT_TIMEOUT;
 
-	__wrap_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
-	__wrap_nrf_modem_gnss_use_case_set_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
+	__cmock_nrf_modem_gnss_use_case_set_ExpectAndReturn(
 		NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START, 0);
-	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_start_ExpectAndReturn(0);
 
 	/* TODO: Cannot determine the used system mode but it's set as zero by default in lte_lc */
-	__wrap_nrf_modem_at_scanf_ExpectAndReturn(
+	__cmock_nrf_modem_at_scanf_ExpectAndReturn(
 		"AT%XSYSTEMMODE?", "%%XSYSTEMMODE: %d,%d,%d,%d", 4);
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
 		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 
 	at_monitor_dispatch("+CSCON: 0");
 
-	__wrap_nrf_modem_gnss_stop_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 }
 
 /********* TESTS PERIODIC POSITIONING REQUESTS ***********************/
@@ -747,30 +749,30 @@ void test_location_gnss_periodic(void)
 
 	location_callback_called_expected = true;
 
-	__wrap_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
-	__wrap_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
-	__wrap_nrf_modem_gnss_use_case_set_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
+	__cmock_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
+	__cmock_nrf_modem_gnss_use_case_set_ExpectAndReturn(
 		NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START, 0);
-	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_start_ExpectAndReturn(0);
 
 	/* TODO: Cannot determine the used system mode but it's set as zero by default in lte_lc */
-	__wrap_nrf_modem_at_scanf_ExpectAndReturn(
+	__cmock_nrf_modem_at_scanf_ExpectAndReturn(
 		"AT%XSYSTEMMODE?", "%%XSYSTEMMODE: %d,%d,%d,%d", 4);
 	err = location_request(&config);
 	TEST_ASSERT_EQUAL(0, err);
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
 		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 	at_monitor_dispatch("+CSCON: 0");
 
-	__wrap_nrf_modem_gnss_read_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_read_ExpectAndReturn(
 		NULL, sizeof(test_pvt_data), NRF_MODEM_GNSS_DATA_PVT, 0);
-	__wrap_nrf_modem_gnss_read_IgnoreArg_buf();
-	__wrap_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
-	__wrap_nrf_modem_gnss_stop_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_read_IgnoreArg_buf();
+	__cmock_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
+	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 	method_gnss_event_handler(NRF_MODEM_GNSS_EVT_PVT);
 	k_sleep(K_MSEC(1));
 
@@ -781,30 +783,30 @@ void test_location_gnss_periodic(void)
 	TEST_ASSERT_EQUAL(location_callback_called_expected, location_callback_called_occurred);
 	k_sem_reset(&event_handler_called_sem);
 
-	__wrap_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
-	__wrap_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
-	__wrap_nrf_modem_gnss_use_case_set_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_event_handler_set_ExpectAndReturn(&method_gnss_event_handler, 0);
+	__cmock_nrf_modem_gnss_fix_interval_set_ExpectAndReturn(1, 0);
+	__cmock_nrf_modem_gnss_use_case_set_ExpectAndReturn(
 		NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START, 0);
-	__wrap_nrf_modem_gnss_start_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_start_ExpectAndReturn(0);
 
 	/* TODO: Cannot determine the used system mode but it's set as zero by default in lte_lc */
-	__wrap_nrf_modem_at_scanf_ExpectAndReturn(
+	__cmock_nrf_modem_at_scanf_ExpectAndReturn(
 		"AT%XSYSTEMMODE?", "%%XSYSTEMMODE: %d,%d,%d,%d", 4);
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT%%XMONITOR", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
 		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 
 	k_sleep(K_MSEC(11000));
 	at_monitor_dispatch("+CSCON: 0");
 
-	__wrap_nrf_modem_gnss_read_ExpectAndReturn(
+	__cmock_nrf_modem_gnss_read_ExpectAndReturn(
 		NULL, sizeof(test_pvt_data), NRF_MODEM_GNSS_DATA_PVT, 0);
-	__wrap_nrf_modem_gnss_read_IgnoreArg_buf();
-	__wrap_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
-	__wrap_nrf_modem_gnss_stop_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_read_IgnoreArg_buf();
+	__cmock_nrf_modem_gnss_read_ReturnMemThruPtr_buf(&test_pvt_data, sizeof(test_pvt_data));
+	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 	method_gnss_event_handler(NRF_MODEM_GNSS_EVT_PVT);
 
 	/* Wait for location_event_handler call for 3 seconds.
@@ -817,7 +819,7 @@ void test_location_gnss_periodic(void)
 
 	/* Stop periodic by cancelling location request */
 	location_callback_called_expected = false;
-	__wrap_nrf_modem_gnss_stop_ExpectAndReturn(0);
+	__cmock_nrf_modem_gnss_stop_ExpectAndReturn(0);
 	err = location_request_cancel();
 	TEST_ASSERT_EQUAL(0, err);
 	k_sleep(K_MSEC(1));
@@ -843,7 +845,7 @@ void test_location_cellular_periodic(void)
 
 	location_callback_called_expected = true;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
 
 	cellular_rest_req_resp_handle();
 
@@ -883,7 +885,7 @@ void test_location_cellular_periodic(void)
 	rest_req_ctx.port = CONFIG_MULTICELL_LOCATION_HERE_HTTPS_PORT;
 	rest_req_ctx.host = CONFIG_MULTICELL_LOCATION_HERE_HOSTNAME;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT%%NCELLMEAS", 0);
 	/* Wait a bit more than the interval so that NCELLMEAS is sent before we send response
 	 * Note that we could first send results and then location library would send NCELLMEAS and
 	 * the test wouldn't see a failure so these things would need to be checked from the logs.
@@ -911,7 +913,7 @@ void test_location_cellular_periodic(void)
 /* This is needed because AT Monitor library is initialized in SYS_INIT. */
 static int location_test_sys_init(const struct device *unused)
 {
-	__wrap_nrf_modem_at_notif_handler_set_ExpectAnyArgsAndReturn(0);
+	__cmock_nrf_modem_at_notif_handler_set_ExpectAnyArgsAndReturn(0);
 
 	return 0;
 }

--- a/tests/lib/modem_jwt/src/jwt_test.c
+++ b/tests/lib/modem_jwt/src/jwt_test.c
@@ -66,7 +66,7 @@ void test_modem_jwt_generate(void)
 
 	jwt.jwt_buf = NULL;
 
-	__wrap_nrf_modem_at_cmd_Stub(cmd_cb);
+	__cmock_nrf_modem_at_cmd_Stub(cmd_cb);
 
 	/* First call should fail, pass through the error code */
 	rc = modem_jwt_generate(&jwt);

--- a/tests/lib/nrf_modem_lib/nrf91_sockets/src/nrf91_sockets_test.c
+++ b/tests/lib/nrf_modem_lib/nrf91_sockets/src/nrf91_sockets_test.c
@@ -139,10 +139,10 @@ void test_nrf91_socket_offload_getaddrinfo_errors(void)
 	};
 
 	for (int i = 0; i < ERROR_SIZE; i++) {
-		__wrap_nrf_getaddrinfo_ExpectAndReturn(HTTPS_HOSTNAME, NULL,
+		__cmock_nrf_getaddrinfo_ExpectAndReturn(HTTPS_HOSTNAME, NULL,
 						       NULL, NULL, nrf_errors[i]);
-		__wrap_nrf_getaddrinfo_IgnoreArg_hints();
-		__wrap_nrf_getaddrinfo_IgnoreArg_res();
+		__cmock_nrf_getaddrinfo_IgnoreArg_hints();
+		__cmock_nrf_getaddrinfo_IgnoreArg_res();
 
 		ret = getaddrinfo(HTTPS_HOSTNAME, NULL, &hints, &res);
 
@@ -166,8 +166,8 @@ void test_nrf91_socket_offload_getaddrinfo_eai_family(void)
 	test_state_nrf_getaddrinfo.res.ai_addr = (struct nrf_sockaddr *)&info_in;
 	test_state_nrf_getaddrinfo.ret = 0;
 
-	__wrap_nrf_getaddrinfo_Stub(nrf_getaddrinfo_stub);
-	__wrap_nrf_freeaddrinfo_Stub(nrf_freeaddrinfo_stub);
+	__cmock_nrf_getaddrinfo_Stub(nrf_getaddrinfo_stub);
+	__cmock_nrf_freeaddrinfo_Stub(nrf_freeaddrinfo_stub);
 
 	ret = getaddrinfo(HTTPS_HOSTNAME, NULL, &hints, &res);
 
@@ -191,8 +191,8 @@ void test_nrf91_socket_offload_getaddrinfo_ipv4_success(void)
 	test_state_nrf_getaddrinfo.res.ai_addr = (struct nrf_sockaddr *)&info_in;
 	test_state_nrf_getaddrinfo.ret = 0;
 
-	__wrap_nrf_getaddrinfo_Stub(nrf_getaddrinfo_stub);
-	__wrap_nrf_freeaddrinfo_Stub(nrf_freeaddrinfo_stub);
+	__cmock_nrf_getaddrinfo_Stub(nrf_getaddrinfo_stub);
+	__cmock_nrf_freeaddrinfo_Stub(nrf_freeaddrinfo_stub);
 
 	ret = getaddrinfo(HTTPS_HOSTNAME, NULL, &hints, &res);
 	TEST_ASSERT_EQUAL(ret, 0);
@@ -218,8 +218,8 @@ void test_nrf91_socket_offload_getaddrinfo_ipv6_success(void)
 	test_state_nrf_getaddrinfo.res.ai_addr = (struct nrf_sockaddr *)&info_in;
 	test_state_nrf_getaddrinfo.ret = 0;
 
-	__wrap_nrf_getaddrinfo_Stub(nrf_getaddrinfo_stub);
-	__wrap_nrf_freeaddrinfo_Stub(nrf_freeaddrinfo_stub);
+	__cmock_nrf_getaddrinfo_Stub(nrf_getaddrinfo_stub);
+	__cmock_nrf_freeaddrinfo_Stub(nrf_freeaddrinfo_stub);
 
 	ret = getaddrinfo(HTTPS_HOSTNAME, NULL, &hints, &res);
 
@@ -249,14 +249,14 @@ void test_nrf91_socket_offload_create_close_success(void)
 	int type = SOCK_STREAM;
 	int proto = IPPROTO_TCP;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -270,7 +270,7 @@ void test_nrf91_socket_offload_socket_error(void)
 	int type = SOCK_STREAM;
 	int proto = IPPROTO_TCP;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, -1);
 
 	fd = socket(family, type, proto);
@@ -312,14 +312,14 @@ void test_nrf91_socket_offload_create_close_proto_zero_success(void)
 	int family = AF_INET;
 	int type = SOCK_STREAM;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  0, nrf_fd);
 
 	fd = socket(family, type, 0);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -350,22 +350,22 @@ void test_nrf91_socket_offload_connect_ipv4_success(void)
 	/* IPv4 */
 	address.sa_family = AF_INET;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_connect_ExpectAndReturn(nrf_fd, NULL,
+	__cmock_nrf_connect_ExpectAndReturn(nrf_fd, NULL,
 					   sizeof(struct nrf_sockaddr_in), 0);
-	__wrap_nrf_connect_IgnoreArg_address();
+	__cmock_nrf_connect_IgnoreArg_address();
 
 	ret = connect(fd, &address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -385,22 +385,22 @@ void test_nrf91_socket_offload_connect_ipv6_success(void)
 	/* IPv6 */
 	address.sa_family = AF_INET6;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_connect_ExpectAndReturn(nrf_fd, NULL,
+	__cmock_nrf_connect_ExpectAndReturn(nrf_fd, NULL,
 					   sizeof(struct nrf_sockaddr_in6), 0);
-	__wrap_nrf_connect_IgnoreArg_address();
+	__cmock_nrf_connect_IgnoreArg_address();
 
 	ret = connect(fd, &address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -417,21 +417,21 @@ void test_nrf91_socket_offload_connect_non_ip_success(void)
 	int proto = IPPROTO_TCP;
 	struct sockaddr address = { 0 };
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_PACKET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_PACKET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_connect_ExpectAndReturn(nrf_fd, NULL, sizeof(address), 0);
-	__wrap_nrf_connect_IgnoreArg_address();
+	__cmock_nrf_connect_ExpectAndReturn(nrf_fd, NULL, sizeof(address), 0);
+	__cmock_nrf_connect_IgnoreArg_address();
 
 	ret = connect(fd, &address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -464,7 +464,7 @@ void test_nrf91_socket_offload_bind_eafnosupport(void)
 	int nrf_fd = 2;
 	struct sockaddr_in address;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
 	fd = socket(AF_INET, SOCK_STREAM, 0);
 
 	address.sin_family = WRONG_VALUE;
@@ -476,7 +476,7 @@ void test_nrf91_socket_offload_bind_eafnosupport(void)
 	TEST_ASSERT_EQUAL(ret, -1);
 	TEST_ASSERT_EQUAL(errno, EAFNOSUPPORT);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -490,21 +490,21 @@ void test_nrf91_socket_offload_bind_ipv4_success(void)
 	int nrf_fd = 2;
 	struct sockaddr_in address;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
 	fd = socket(AF_INET, SOCK_STREAM, 0);
 
 	address.sin_family = AF_INET;
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(PORT);
 
-	__wrap_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in), 0);
-	__wrap_nrf_bind_IgnoreArg_address();
+	__cmock_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in), 0);
+	__cmock_nrf_bind_IgnoreArg_address();
 
 	ret = bind(fd, (struct sockaddr *)&address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -518,21 +518,21 @@ void test_nrf91_socket_offload_bind_ipv6_success(void)
 	int nrf_fd = 2;
 	struct sockaddr_in address;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM, 0, nrf_fd);
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM, 0, nrf_fd);
 	fd = socket(AF_INET6, SOCK_STREAM, 0);
 
 	address.sin_family = AF_INET6;
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(PORT);
 
-	__wrap_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in6), 0);
-	__wrap_nrf_bind_IgnoreArg_address();
+	__cmock_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in6), 0);
+	__cmock_nrf_bind_IgnoreArg_address();
 
 	ret = bind(fd, (struct sockaddr *)&address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -557,27 +557,27 @@ void test_nrf91_socket_offload_listen_success(void)
 	struct sockaddr_in address;
 	int backlog = 1;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM, 0, nrf_fd);
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM, 0, nrf_fd);
 	fd = socket(AF_INET6, SOCK_STREAM, 0);
 
 	address.sin_family = AF_INET6;
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(PORT);
 
-	__wrap_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in6), 0);
-	__wrap_nrf_bind_IgnoreArg_address();
+	__cmock_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in6), 0);
+	__cmock_nrf_bind_IgnoreArg_address();
 
 	ret = bind(fd, (struct sockaddr *)&address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
+	__cmock_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
 
 	ret = listen(fd, backlog);
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -609,33 +609,33 @@ void test_nrf91_socket_offload_accept_addr_null_addrlen_null_error(void)
 	struct sockaddr_in address;
 	int backlog = 1;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
 	fd = socket(AF_INET, SOCK_STREAM, 0);
 
 	address.sin_family = AF_INET;
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(PORT);
 
-	__wrap_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in), 0);
-	__wrap_nrf_bind_IgnoreArg_address();
+	__cmock_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in), 0);
+	__cmock_nrf_bind_IgnoreArg_address();
 
 	ret = bind(fd, (struct sockaddr *)&address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
+	__cmock_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
 
 	ret = listen(fd, backlog);
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_accept_ExpectAndReturn(nrf_fd, NULL, NULL, -2);
+	__cmock_nrf_accept_ExpectAndReturn(nrf_fd, NULL, NULL, -2);
 
 	ret = accept(fd, NULL, NULL);
 
 	TEST_ASSERT_EQUAL(ret, -1);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -653,21 +653,21 @@ void test_nrf91_socket_offload_accept_addr_not_null_addrlen_not_null_enotsup(voi
 	int addrlen_unchanged = addrlen;
 	int backlog = 1;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
 	fd = socket(AF_INET, SOCK_STREAM, 0);
 
 	address.sin_family = AF_INET;
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(PORT);
 
-	__wrap_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in), 0);
-	__wrap_nrf_bind_IgnoreArg_address();
+	__cmock_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in), 0);
+	__cmock_nrf_bind_IgnoreArg_address();
 
 	ret = bind(fd, (struct sockaddr *)&address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
+	__cmock_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
 
 	ret = listen(fd, backlog);
 
@@ -677,8 +677,8 @@ void test_nrf91_socket_offload_accept_addr_not_null_addrlen_not_null_enotsup(voi
 	test_state_nrf_accept.nrf_addr.sa_family = WRONG_VALUE;
 	test_state_nrf_accept.ret = accept_fd;
 
-	__wrap_nrf_accept_Stub(nrf_accept_stub);
-	__wrap_nrf_close_ExpectAndReturn(accept_fd, 0);
+	__cmock_nrf_accept_Stub(nrf_accept_stub);
+	__cmock_nrf_close_ExpectAndReturn(accept_fd, 0);
 
 	ret = accept(fd, (struct sockaddr *)&address, (socklen_t *)&addrlen);
 
@@ -686,7 +686,7 @@ void test_nrf91_socket_offload_accept_addr_not_null_addrlen_not_null_enotsup(voi
 	TEST_ASSERT_EQUAL(errno, ENOTSUP);
 	TEST_ASSERT_EQUAL(addrlen, addrlen_unchanged);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -706,20 +706,20 @@ void test_nrf91_socket_offload_accept_ipv4_success(void)
 	/* `z_reserve_fd` reserves fd = 1 first */
 	int z_fd = 1;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM, 0, nrf_fd);
 	fd = socket(AF_INET, SOCK_STREAM, 0);
 
 	address.sin_family = AF_INET;
 	address.sin_port = htons(PORT);
 
-	__wrap_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in), 0);
-	__wrap_nrf_bind_IgnoreArg_address();
+	__cmock_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in), 0);
+	__cmock_nrf_bind_IgnoreArg_address();
 
 	ret = bind(fd, (struct sockaddr *)&address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
+	__cmock_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
 
 	ret = listen(fd, backlog);
 
@@ -728,14 +728,14 @@ void test_nrf91_socket_offload_accept_ipv4_success(void)
 	test_state_nrf_accept.nrf_addr.sa_family = NRF_AF_INET;
 	test_state_nrf_accept.ret = nrf_accept_fd;
 
-	__wrap_nrf_accept_Stub(nrf_accept_stub);
+	__cmock_nrf_accept_Stub(nrf_accept_stub);
 
 	ret = accept(fd, (struct sockaddr *)&address, (socklen_t *)&addrlen);
 
 	TEST_ASSERT_EQUAL(ret, z_fd);
 	TEST_ASSERT_EQUAL(addrlen, addrlen_unchanged);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -757,20 +757,20 @@ void test_nrf91_socket_offload_accept_ipv6_success(void)
 	/* `z_reserve_fd` reserves fd = 1 first */
 	int z_fd = 1;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM, 0, nrf_fd);
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM, 0, nrf_fd);
 	fd = socket(AF_INET6, SOCK_STREAM, 0);
 
 	address.sin6_family = AF_INET6;
 	address.sin6_port = htons(PORT);
 
-	__wrap_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in6), 0);
-	__wrap_nrf_bind_IgnoreArg_address();
+	__cmock_nrf_bind_ExpectAndReturn(nrf_fd, NULL, sizeof(struct nrf_sockaddr_in6), 0);
+	__cmock_nrf_bind_IgnoreArg_address();
 
 	ret = bind(fd, (struct sockaddr *)&address, sizeof(address));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
+	__cmock_nrf_listen_ExpectAndReturn(nrf_fd, backlog, 0);
 
 	ret = listen(fd, backlog);
 
@@ -779,14 +779,14 @@ void test_nrf91_socket_offload_accept_ipv6_success(void)
 	test_state_nrf_accept.nrf_addr.sa_family = NRF_AF_INET6;
 	test_state_nrf_accept.ret = nrf_accept_fd;
 
-	__wrap_nrf_accept_Stub(nrf_accept_stub);
+	__cmock_nrf_accept_Stub(nrf_accept_stub);
 
 	ret = accept(fd, (struct sockaddr *)&address, (socklen_t *)&addrlen);
 
 	TEST_ASSERT_EQUAL(ret, z_fd);
 	TEST_ASSERT_EQUAL(addrlen, addrlen_unchanged);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -815,22 +815,22 @@ void test_nrf91_socket_offload_setsockopt_rcvtimeo_success(void)
 	int proto = IPPROTO_TCP;
 	struct timeval data = { 0 };
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_setsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO,
+	__cmock_nrf_setsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO,
 					      NULL, sizeof(struct nrf_timeval), 0);
-	__wrap_nrf_setsockopt_IgnoreArg_option_value();
+	__cmock_nrf_setsockopt_IgnoreArg_option_value();
 
 	ret = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &data, sizeof(data));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 	ret = close(fd);
 
 	TEST_ASSERT_EQUAL(ret, 0);
@@ -846,22 +846,22 @@ void test_nrf91_socket_offload_setsockopt_sndtimeo_success(void)
 	int proto = IPPROTO_TCP;
 	struct timeval data = { 0 };
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_setsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_SNDTIMEO,
+	__cmock_nrf_setsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_SNDTIMEO,
 					      NULL, sizeof(struct nrf_timeval), 0);
-	__wrap_nrf_setsockopt_IgnoreArg_option_value();
+	__cmock_nrf_setsockopt_IgnoreArg_option_value();
 
 	ret = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &data, sizeof(data));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -878,22 +878,22 @@ void test_nrf91_socket_offload_setsockopt_tls_session_cache_success(void)
 	int proto = IPPROTO_TCP;
 	uint8_t data = 0;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_setsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SECURE, NRF_SO_SEC_SESSION_CACHE,
+	__cmock_nrf_setsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SECURE, NRF_SO_SEC_SESSION_CACHE,
 					      NULL, sizeof(nrf_sec_session_cache_t), 0);
-	__wrap_nrf_setsockopt_IgnoreArg_option_value();
+	__cmock_nrf_setsockopt_IgnoreArg_option_value();
 
 	ret = setsockopt(fd, SOL_TLS, TLS_SESSION_CACHE, &data, sizeof(data));
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -921,23 +921,23 @@ void test_nrf91_socket_offload_getsockopt_rcvtimeo_error(void)
 	struct timeval data = { 0 };
 	int data_len = sizeof(data);
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO,
+	__cmock_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO,
 					      NULL, NULL, -1);
-	__wrap_nrf_getsockopt_IgnoreArg_option_value();
-	__wrap_nrf_getsockopt_IgnoreArg_option_len();
+	__cmock_nrf_getsockopt_IgnoreArg_option_value();
+	__cmock_nrf_getsockopt_IgnoreArg_option_len();
 
 	ret = getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &data, &data_len);
 
 	TEST_ASSERT_EQUAL(ret, -1);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -955,23 +955,23 @@ void test_nrf91_socket_offload_getsockopt_sndtimeo_error(void)
 	struct timeval data = { 0 };
 	int data_len = sizeof(data);
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_SNDTIMEO,
+	__cmock_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_SNDTIMEO,
 					      NULL, NULL, -1);
-	__wrap_nrf_getsockopt_IgnoreArg_option_value();
-	__wrap_nrf_getsockopt_IgnoreArg_option_len();
+	__cmock_nrf_getsockopt_IgnoreArg_option_value();
+	__cmock_nrf_getsockopt_IgnoreArg_option_len();
 
 	ret = getsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &data, &data_len);
 
 	TEST_ASSERT_EQUAL(ret, -1);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -989,17 +989,17 @@ void test_nrf91_socket_offload_getsockopt_rcvtimeo_success(void)
 	struct timeval data = { 0 };
 	int data_len = sizeof(data);
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO,
+	__cmock_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_RCVTIMEO,
 					      NULL, NULL, 0);
-	__wrap_nrf_getsockopt_IgnoreArg_option_value();
-	__wrap_nrf_getsockopt_IgnoreArg_option_len();
+	__cmock_nrf_getsockopt_IgnoreArg_option_value();
+	__cmock_nrf_getsockopt_IgnoreArg_option_len();
 
 	/* Change `data_len` before calling so that we can see if the
 	 * function changes it on return
@@ -1011,7 +1011,7 @@ void test_nrf91_socket_offload_getsockopt_rcvtimeo_success(void)
 	TEST_ASSERT_EQUAL(ret, 0);
 	TEST_ASSERT_EQUAL(data_len, sizeof(struct timeval));
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1029,17 +1029,17 @@ void test_nrf91_socket_offload_getsockopt_sndtimeo_success(void)
 	struct timeval data = { 0 };
 	int data_len = sizeof(data);
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_SNDTIMEO,
+	__cmock_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_SNDTIMEO,
 					      NULL, NULL, 0);
-	__wrap_nrf_getsockopt_IgnoreArg_option_value();
-	__wrap_nrf_getsockopt_IgnoreArg_option_len();
+	__cmock_nrf_getsockopt_IgnoreArg_option_value();
+	__cmock_nrf_getsockopt_IgnoreArg_option_len();
 
 	/* Change `data_len` before calling so that we can see if the
 	 * function changes it on return
@@ -1051,7 +1051,7 @@ void test_nrf91_socket_offload_getsockopt_sndtimeo_success(void)
 	TEST_ASSERT_EQUAL(ret, 0);
 	TEST_ASSERT_EQUAL(data_len, sizeof(struct timeval));
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1069,25 +1069,25 @@ void test_nrf91_socket_offload_getsockopt_so_error_success(void)
 	int data = 1;
 	int data_len = 42;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
 
 	TEST_ASSERT_EQUAL(fd, 0);
 
-	__wrap_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_ERROR,
+	__cmock_nrf_getsockopt_ExpectAndReturn(nrf_fd, NRF_SOL_SOCKET, NRF_SO_ERROR,
 					      NULL, NULL, 0);
-	__wrap_nrf_getsockopt_IgnoreArg_option_value();
-	__wrap_nrf_getsockopt_IgnoreArg_option_len();
-	__wrap_nrf_modem_os_errno_set_Expect(data);
+	__cmock_nrf_getsockopt_IgnoreArg_option_value();
+	__cmock_nrf_getsockopt_IgnoreArg_option_len();
+	__cmock_nrf_modem_os_errno_set_Expect(data);
 
 	ret = getsockopt(fd, SOL_SOCKET, SO_ERROR, &data, &data_len);
 
 	TEST_ASSERT_EQUAL(ret, 0);
 	TEST_ASSERT_EQUAL(data, errno);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1117,7 +1117,7 @@ void test_nrf91_socket_offload_recvfrom_from_null_error(void)
 	int flags = MSG_WAITALL;
 	socklen_t fromlen = 0;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1131,14 +1131,14 @@ void test_nrf91_socket_offload_recvfrom_from_null_error(void)
 	/* Expect that with `from` NULL the modem library call receives a forced
 	 * `fromlen` NULL as well despite passing a pointer to the Zephyr call
 	 */
-	__wrap_nrf_recvfrom_ExpectAndReturn(nrf_fd, data, data_len, NRF_MSG_WAITALL,
+	__cmock_nrf_recvfrom_ExpectAndReturn(nrf_fd, data, data_len, NRF_MSG_WAITALL,
 					    NULL, NULL, -1);
 
 	ret = recvfrom(fd, data, data_len, flags, NULL, &fromlen);
 
 	TEST_ASSERT_EQUAL(ret, -1);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1158,7 +1158,7 @@ void test_nrf91_socket_offload_recvfrom_from_null_success(void)
 	int flags = MSG_WAITALL;
 	socklen_t fromlen = 0;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1172,14 +1172,14 @@ void test_nrf91_socket_offload_recvfrom_from_null_success(void)
 	/* Expect that with `from` NULL the modem library call receives a forced
 	 * `fromlen` NULL as well despite passing a pointer to the Zephyr call
 	 */
-	__wrap_nrf_recvfrom_ExpectAndReturn(nrf_fd, data, data_len, NRF_MSG_WAITALL,
+	__cmock_nrf_recvfrom_ExpectAndReturn(nrf_fd, data, data_len, NRF_MSG_WAITALL,
 					    NULL, NULL, 8);
 
 	ret = recvfrom(fd, data, data_len, flags, NULL, &fromlen);
 
 	TEST_ASSERT_EQUAL(ret, 8);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1200,7 +1200,7 @@ void test_nrf91_socket_offload_recvfrom_ipv4_success(void)
 	struct sockaddr from = { 0 };
 	socklen_t fromlen = 0;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1215,7 +1215,7 @@ void test_nrf91_socket_offload_recvfrom_ipv4_success(void)
 	test_state_nrf_recvfrom.address_len = sizeof(struct nrf_sockaddr_in);
 	test_state_nrf_recvfrom.ret = 8;
 
-	__wrap_nrf_recvfrom_Stub(nrf_recvfrom_stub);
+	__cmock_nrf_recvfrom_Stub(nrf_recvfrom_stub);
 
 	ret = recvfrom(fd, data, data_len, flags, &from, &fromlen);
 
@@ -1223,7 +1223,7 @@ void test_nrf91_socket_offload_recvfrom_ipv4_success(void)
 	TEST_ASSERT_EQUAL(from.sa_family, AF_INET);
 	TEST_ASSERT_EQUAL(fromlen, sizeof(struct sockaddr_in));
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1244,7 +1244,7 @@ void test_nrf91_socket_offload_recvfrom_ipv6_success(void)
 	struct sockaddr from = { 0 };
 	socklen_t fromlen = 0;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1259,7 +1259,7 @@ void test_nrf91_socket_offload_recvfrom_ipv6_success(void)
 	test_state_nrf_recvfrom.address_len = sizeof(struct nrf_sockaddr_in6);
 	test_state_nrf_recvfrom.ret = 8;
 
-	__wrap_nrf_recvfrom_Stub(nrf_recvfrom_stub);
+	__cmock_nrf_recvfrom_Stub(nrf_recvfrom_stub);
 
 	ret = recvfrom(fd, data, data_len, flags, &from, &fromlen);
 
@@ -1267,7 +1267,7 @@ void test_nrf91_socket_offload_recvfrom_ipv6_success(void)
 	TEST_ASSERT_EQUAL(from.sa_family, AF_INET6);
 	TEST_ASSERT_EQUAL(fromlen, sizeof(struct sockaddr_in6));
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1296,7 +1296,7 @@ void test_nrf91_socket_offload_sendto_to_null_success(void)
 	size_t data_len = sizeof(data);
 	int flags = MSG_DONTWAIT;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1310,14 +1310,14 @@ void test_nrf91_socket_offload_sendto_to_null_success(void)
 	/* Observe that the `tolen` parameter will be changed to zero when
 	 * the `to` parameter is NULL
 	 */
-	__wrap_nrf_sendto_ExpectAndReturn(nrf_fd, data, data_len,
+	__cmock_nrf_sendto_ExpectAndReturn(nrf_fd, data, data_len,
 					  NRF_MSG_DONTWAIT, NULL, 0, 8);
 
 	ret = sendto(fd, data, data_len, flags, NULL, 42);
 
 	TEST_ASSERT_EQUAL(ret, 8);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1337,7 +1337,7 @@ void test_nrf91_socket_offload_sendto_ipv4_error(void)
 	int flags = MSG_DONTWAIT;
 	struct sockaddr to = { .sa_family = family };
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1352,16 +1352,16 @@ void test_nrf91_socket_offload_sendto_ipv4_error(void)
 	 * `nrf_sockaddr_in` when the `to` parameter has `sa_family` with value
 	 * `AF_INET`
 	 */
-	__wrap_nrf_sendto_ExpectAndReturn(nrf_fd, data, data_len,
+	__cmock_nrf_sendto_ExpectAndReturn(nrf_fd, data, data_len,
 					  NRF_MSG_DONTWAIT, NULL,
 					  sizeof(struct nrf_sockaddr_in), -1);
-	__wrap_nrf_sendto_IgnoreArg_dest_addr();
+	__cmock_nrf_sendto_IgnoreArg_dest_addr();
 
 	ret = sendto(fd, data, data_len, flags, &to, 42);
 
 	TEST_ASSERT_EQUAL(ret, -1);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1381,7 +1381,7 @@ void test_nrf91_socket_offload_sendto_ipv4_success(void)
 	int flags = MSG_DONTWAIT;
 	struct sockaddr to = { .sa_family = family };
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1396,16 +1396,16 @@ void test_nrf91_socket_offload_sendto_ipv4_success(void)
 	 * `nrf_sockaddr_in` when the `to` parameter has `sa_family` with value
 	 * `AF_INET`
 	 */
-	__wrap_nrf_sendto_ExpectAndReturn(nrf_fd, data, data_len,
+	__cmock_nrf_sendto_ExpectAndReturn(nrf_fd, data, data_len,
 					  NRF_MSG_DONTWAIT, NULL,
 					  sizeof(struct nrf_sockaddr_in), 8);
-	__wrap_nrf_sendto_IgnoreArg_dest_addr();
+	__cmock_nrf_sendto_IgnoreArg_dest_addr();
 
 	ret = sendto(fd, data, data_len, flags, &to, 42);
 
 	TEST_ASSERT_EQUAL(ret, 8);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1425,7 +1425,7 @@ void test_nrf91_socket_offload_sendto_ipv6_success(void)
 	int flags = MSG_DONTWAIT;
 	struct sockaddr to = { .sa_family = family };
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET6, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1440,16 +1440,16 @@ void test_nrf91_socket_offload_sendto_ipv6_success(void)
 	 * `nrf_sockaddr_in` when the `to` parameter has `sa_family` with value
 	 * `AF_INET`
 	 */
-	__wrap_nrf_sendto_ExpectAndReturn(nrf_fd, data, data_len,
+	__cmock_nrf_sendto_ExpectAndReturn(nrf_fd, data, data_len,
 					  NRF_MSG_DONTWAIT, NULL,
 					  sizeof(struct nrf_sockaddr_in6), 8);
-	__wrap_nrf_sendto_IgnoreArg_dest_addr();
+	__cmock_nrf_sendto_IgnoreArg_dest_addr();
 
 	ret = sendto(fd, data, data_len, flags, &to, 42);
 
 	TEST_ASSERT_EQUAL(ret, 8);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1469,7 +1469,7 @@ void test_nrf91_socket_offload_sendto_not_ipv4_not_ipv6_eafnosupport(void)
 	int flags = MSG_DONTWAIT;
 	struct sockaddr to = { 0 };
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1485,7 +1485,7 @@ void test_nrf91_socket_offload_sendto_not_ipv4_not_ipv6_eafnosupport(void)
 	TEST_ASSERT_EQUAL(ret, -1);
 	TEST_ASSERT_EQUAL(errno, EAFNOSUPPORT);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1512,7 +1512,7 @@ void test_nrf91_socket_offload_sendmsg_msg_null_einval(void)
 	int proto = IPPROTO_TCP;
 	int flags = MSG_DONTWAIT;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1528,7 +1528,7 @@ void test_nrf91_socket_offload_sendmsg_msg_null_einval(void)
 	TEST_ASSERT_EQUAL(ret, -1);
 	TEST_ASSERT_EQUAL(errno, EINVAL);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1549,7 +1549,7 @@ void test_nrf91_socket_offload_sendmsg_fits_buf(void)
 	int chunk_1 = 42;
 	int chunk_2 = 43;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1567,16 +1567,16 @@ void test_nrf91_socket_offload_sendmsg_fits_buf(void)
 	msg.msg_iov = chunks;
 	msg.msg_iovlen = 2;
 
-	__wrap_nrf_sendto_ExpectAndReturn(nrf_fd, NULL, 2 * sizeof(int),
+	__cmock_nrf_sendto_ExpectAndReturn(nrf_fd, NULL, 2 * sizeof(int),
 					  NRF_MSG_DONTWAIT,
 					  NULL, 0, 2 * sizeof(int));
-	__wrap_nrf_sendto_IgnoreArg_message();
+	__cmock_nrf_sendto_IgnoreArg_message();
 
 	ret = sendmsg(fd, &msg, flags);
 
 	TEST_ASSERT_EQUAL(ret, 2 * sizeof(int));
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1602,7 +1602,7 @@ void test_nrf91_socket_offload_sendmsg_not_fits_buf(void)
 	int chunk_2 = 43;
 	int chunk_3 = 44;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1623,26 +1623,26 @@ void test_nrf91_socket_offload_sendmsg_not_fits_buf(void)
 	msg.msg_iovlen = 3;
 
 	/* First send doesn't send all data of the first chunk */
-	__wrap_nrf_sendto_ExpectAndReturn(nrf_fd, &chunk_1, sizeof(int),
+	__cmock_nrf_sendto_ExpectAndReturn(nrf_fd, &chunk_1, sizeof(int),
 					  NRF_MSG_DONTWAIT,
 					  NULL, 0, sizeof(int) - 1);
 	/* Second send will send the remaining part of the first chunk */
-	__wrap_nrf_sendto_ExpectAndReturn(nrf_fd, ((uint8_t *)&chunk_1) + sizeof(int) - 1, 1,
+	__cmock_nrf_sendto_ExpectAndReturn(nrf_fd, ((uint8_t *)&chunk_1) + sizeof(int) - 1, 1,
 					  NRF_MSG_DONTWAIT,
 					  NULL, 0, 1);
-	__wrap_nrf_sendto_ExpectAndReturn(nrf_fd, &chunk_2, sizeof(int),
+	__cmock_nrf_sendto_ExpectAndReturn(nrf_fd, &chunk_2, sizeof(int),
 					  NRF_MSG_DONTWAIT,
 					  NULL, 0, sizeof(int));
-	__wrap_nrf_sendto_ExpectAndReturn(nrf_fd, &chunk_3, sizeof(int),
+	__cmock_nrf_sendto_ExpectAndReturn(nrf_fd, &chunk_3, sizeof(int),
 					  NRF_MSG_DONTWAIT,
 					  NULL, 0, sizeof(int));
-	__wrap_nrf_sendto_IgnoreArg_message();
+	__cmock_nrf_sendto_IgnoreArg_message();
 
 	ret = sendmsg(fd, &msg, flags);
 
 	TEST_ASSERT_EQUAL(ret, 3 * sizeof(int));
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1658,7 +1658,7 @@ void test_nrf91_socket_offload_ioctl_poll_prepare(void)
 	int type = SOCK_STREAM;
 	int proto = IPPROTO_TCP;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1673,7 +1673,7 @@ void test_nrf91_socket_offload_ioctl_poll_prepare(void)
 
 	TEST_ASSERT_EQUAL(ret, -EXDEV);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1689,7 +1689,7 @@ void test_nrf91_socket_offload_ioctl_poll_update(void)
 	int type = SOCK_STREAM;
 	int proto = IPPROTO_TCP;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1705,7 +1705,7 @@ void test_nrf91_socket_offload_ioctl_poll_update(void)
 
 	TEST_ASSERT_EQUAL(ret, -EOPNOTSUPP);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1722,7 +1722,7 @@ void test_nrf91_socket_offload_fcntl_einval(void)
 	int proto = IPPROTO_TCP;
 	int wrong_command = ~(F_SETFL | F_GETFL);
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1738,7 +1738,7 @@ void test_nrf91_socket_offload_fcntl_einval(void)
 	TEST_ASSERT_EQUAL(ret, -1);
 	TEST_ASSERT_EQUAL(errno, EINVAL);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1754,7 +1754,7 @@ void test_nrf91_socket_offload_fcntl_f_setfl(void)
 	int type = SOCK_STREAM;
 	int proto = IPPROTO_TCP;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1765,13 +1765,13 @@ void test_nrf91_socket_offload_fcntl_f_setfl(void)
 	 * need a working socket
 	 */
 
-	__wrap_nrf_fcntl_ExpectAndReturn(nrf_fd, NRF_F_SETFL, NRF_O_NONBLOCK, 0);
+	__cmock_nrf_fcntl_ExpectAndReturn(nrf_fd, NRF_F_SETFL, NRF_O_NONBLOCK, 0);
 
 	ret = fcntl(fd, F_SETFL, O_NONBLOCK);
 
 	TEST_ASSERT_EQUAL(ret, 0);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1787,7 +1787,7 @@ void test_nrf91_socket_offload_fcntl_f_getfl(void)
 	int type = SOCK_STREAM;
 	int proto = IPPROTO_TCP;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1798,13 +1798,13 @@ void test_nrf91_socket_offload_fcntl_f_getfl(void)
 	 * need a working socket
 	 */
 
-	__wrap_nrf_fcntl_ExpectAndReturn(nrf_fd, NRF_F_GETFL, 0, NRF_O_NONBLOCK);
+	__cmock_nrf_fcntl_ExpectAndReturn(nrf_fd, NRF_F_GETFL, 0, NRF_O_NONBLOCK);
 
 	ret = fcntl(fd, F_GETFL);
 
 	TEST_ASSERT_EQUAL(ret, O_NONBLOCK);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1821,7 +1821,7 @@ void test_nrf91_socket_offload_poll_non_offloaded_socket(void)
 	int proto = IPPROTO_TCP;
 	struct pollfd fds[3] = { 0 };
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1843,7 +1843,7 @@ void test_nrf91_socket_offload_poll_non_offloaded_socket(void)
 	TEST_ASSERT_EQUAL(fds[1].revents, POLLNVAL);
 	TEST_ASSERT_EQUAL(fds[2].revents, POLLNVAL);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 
@@ -1864,7 +1864,7 @@ void test_nrf91_socket_offload_poll_all_events_success(void)
 		      POLLERR | POLLNVAL |
 		      POLLHUP;
 
-	__wrap_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
+	__cmock_nrf_socket_ExpectAndReturn(NRF_AF_INET, NRF_SOCK_STREAM,
 					  NRF_IPPROTO_TCP, nrf_fd);
 
 	fd = socket(family, type, proto);
@@ -1884,14 +1884,14 @@ void test_nrf91_socket_offload_poll_all_events_success(void)
 						    NRF_POLLHUP;
 	test_state_nrf_poll.ret = 0;
 
-	__wrap_nrf_poll_Stub(nrf_poll_stub);
+	__cmock_nrf_poll_Stub(nrf_poll_stub);
 
 	ret = poll(fds, 1, 0);
 
 	TEST_ASSERT_EQUAL(ret, 0);
 	TEST_ASSERT_EQUAL(fds[0].revents, revents);
 
-	__wrap_nrf_close_ExpectAndReturn(nrf_fd, 0);
+	__cmock_nrf_close_ExpectAndReturn(nrf_fd, 0);
 
 	ret = close(fd);
 

--- a/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
+++ b/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
@@ -224,10 +224,10 @@ void test_trace_thread_handler_get_single(void)
 	struct nrf_modem_trace_data *header_write;
 	struct nrf_modem_trace_data *data_write;
 
-	__wrap_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
-	__wrap_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
-	__wrap_trace_backend_write_Stub(trace_backend_write_stub);
-	__wrap_trace_backend_deinit_Stub(trace_backend_deinit_stub);
+	__cmock_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
+	__cmock_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
+	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
+	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
 	NRF_MODEM_LIB_ON_INIT_callback();
 
@@ -255,10 +255,10 @@ void test_trace_thread_handler_get_single(void)
 
 void test_trace_thread_handler_get_multi(void)
 {
-	__wrap_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
-	__wrap_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
-	__wrap_trace_backend_write_Stub(trace_backend_write_stub);
-	__wrap_trace_backend_deinit_Stub(trace_backend_deinit_stub);
+	__cmock_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
+	__cmock_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
+	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
+	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
 	NRF_MODEM_LIB_ON_INIT_callback();
 
@@ -298,10 +298,10 @@ void test_trace_thread_handler_write_efault(void)
 	struct nrf_modem_trace_data header = { 0 };
 	struct nrf_modem_trace_data data = { 0 };
 
-	__wrap_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
-	__wrap_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
-	__wrap_trace_backend_write_Stub(trace_backend_write_stub);
-	__wrap_trace_backend_deinit_Stub(trace_backend_deinit_stub);
+	__cmock_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
+	__cmock_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
+	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
+	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
 	NRF_MODEM_LIB_ON_INIT_callback();
 
@@ -322,10 +322,10 @@ void test_trace_thread_handler_write_efault(void)
 
 void test_trace_thread_handler_get_einprogress(void)
 {
-	__wrap_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
-	__wrap_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
-	__wrap_trace_backend_write_Stub(trace_backend_write_stub);
-	__wrap_trace_backend_deinit_Stub(trace_backend_deinit_stub);
+	__cmock_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
+	__cmock_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
+	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
+	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
 	NRF_MODEM_LIB_ON_INIT_callback();
 
@@ -338,10 +338,10 @@ void test_trace_thread_handler_get_einprogress(void)
 
 void test_trace_thread_handler_get_enodata(void)
 {
-	__wrap_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
-	__wrap_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
-	__wrap_trace_backend_write_Stub(trace_backend_write_stub);
-	__wrap_trace_backend_deinit_Stub(trace_backend_deinit_stub);
+	__cmock_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
+	__cmock_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
+	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
+	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
 	NRF_MODEM_LIB_ON_INIT_callback();
 
@@ -354,10 +354,10 @@ void test_trace_thread_handler_get_enodata(void)
 
 void test_trace_thread_handler_get_eshutdown(void)
 {
-	__wrap_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
-	__wrap_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
-	__wrap_trace_backend_write_Stub(trace_backend_write_stub);
-	__wrap_trace_backend_deinit_Stub(trace_backend_deinit_stub);
+	__cmock_trace_backend_init_ExpectAndReturn(nrf_modem_trace_processed, 0);
+	__cmock_nrf_modem_trace_get_Stub(nrf_modem_trace_get_stub);
+	__cmock_trace_backend_write_Stub(trace_backend_write_stub);
+	__cmock_trace_backend_deinit_Stub(trace_backend_deinit_stub);
 
 	NRF_MODEM_LIB_ON_INIT_callback();
 

--- a/tests/lib/nrf_modem_lib/trace_backends/rtt/src/main.c
+++ b/tests/lib/nrf_modem_lib/trace_backends/rtt/src/main.c
@@ -60,8 +60,8 @@ void test_trace_backend_init_rtt(void)
 
 	trace_rtt_channel = 1;
 
-	__wrap_SEGGER_RTT_AllocUpBuffer_ExpectAnyArgsAndReturn(trace_rtt_channel);
-	__wrap_SEGGER_RTT_AllocUpBuffer_AddCallback(&rtt_allocupbuffer_callback);
+	__cmock_SEGGER_RTT_AllocUpBuffer_ExpectAnyArgsAndReturn(trace_rtt_channel);
+	__cmock_SEGGER_RTT_AllocUpBuffer_AddCallback(&rtt_allocupbuffer_callback);
 
 	ret = trace_backend_init(callback);
 
@@ -73,7 +73,7 @@ void test_trace_backend_init_rtt_ebusy(void)
 	int ret;
 
 	/* Simulate failure by returning negative RTT channel. */
-	__wrap_SEGGER_RTT_AllocUpBuffer_ExpectAnyArgsAndReturn(-1);
+	__cmock_SEGGER_RTT_AllocUpBuffer_ExpectAnyArgsAndReturn(-1);
 
 	ret = trace_backend_init(callback);
 	TEST_ASSERT_EQUAL(-EBUSY, ret);
@@ -98,12 +98,12 @@ void test_trace_backend_write_rtt(void)
 	/* Since the trace buffer size is larger than NRF_MODEM_LIB_TRACE_BACKEND_RTT_BUF_SIZE,
 	 * the modem_trace module should fragment the buffer and call the RTT API twice.
 	 */
-	__wrap_SEGGER_RTT_WriteNoLock_ExpectAndReturn(
+	__cmock_SEGGER_RTT_WriteNoLock_ExpectAndReturn(
 		trace_rtt_channel, sample_trace_data, BACKEND_RTT_BUF_SIZE, BACKEND_RTT_BUF_SIZE);
 
 	uint32_t remaining = sizeof(sample_trace_data) - BACKEND_RTT_BUF_SIZE;
 
-	__wrap_SEGGER_RTT_WriteNoLock_ExpectAndReturn(
+	__cmock_SEGGER_RTT_WriteNoLock_ExpectAndReturn(
 		trace_rtt_channel, &sample_trace_data[BACKEND_RTT_BUF_SIZE], remaining, remaining);
 
 	/* Simulate the reception of modem trace and expect the RTT API to be called. */

--- a/tests/lib/nrf_modem_lib/trace_backends/uart/src/main.c
+++ b/tests/lib/nrf_modem_lib/trace_backends/uart/src/main.c
@@ -133,10 +133,10 @@ void test_trace_backend_init_uart(void)
 {
 	int ret;
 
-	__wrap_pinctrl_lookup_state_ExpectAnyArgsAndReturn(0);
-	__wrap_pinctrl_configure_pins_ExpectAnyArgsAndReturn(0);
-	__wrap_nrfx_uarte_init_ExpectAnyArgsAndReturn(NRFX_SUCCESS);
-	__wrap_nrfx_uarte_init_AddCallback(&nrfx_uarte_init_callback);
+	__cmock_pinctrl_lookup_state_ExpectAnyArgsAndReturn(0);
+	__cmock_pinctrl_configure_pins_ExpectAnyArgsAndReturn(0);
+	__cmock_nrfx_uarte_init_ExpectAnyArgsAndReturn(NRFX_SUCCESS);
+	__cmock_nrfx_uarte_init_AddCallback(&nrfx_uarte_init_callback);
 
 	ret = trace_backend_init(empty_callback);
 
@@ -149,9 +149,9 @@ void test_trace_backend_init_uart_ebusy(void)
 	int ret;
 
 	/* Simulate uart init failure. */
-	__wrap_pinctrl_lookup_state_ExpectAnyArgsAndReturn(0);
-	__wrap_pinctrl_configure_pins_ExpectAnyArgsAndReturn(0);
-	__wrap_nrfx_uarte_init_ExpectAnyArgsAndReturn(NRFX_ERROR_BUSY);
+	__cmock_pinctrl_lookup_state_ExpectAnyArgsAndReturn(0);
+	__cmock_pinctrl_configure_pins_ExpectAnyArgsAndReturn(0);
+	__cmock_nrfx_uarte_init_ExpectAnyArgsAndReturn(NRFX_ERROR_BUSY);
 
 	ret = trace_backend_init(empty_callback);
 
@@ -165,9 +165,9 @@ void test_trace_backend_deinit_uart(void)
 
 	test_trace_backend_init_uart();
 
-	__wrap_nrfx_uarte_uninit_Expect(p_uarte_inst_in_use);
-	__wrap_pinctrl_lookup_state_ExpectAnyArgsAndReturn(0);
-	__wrap_pinctrl_configure_pins_ExpectAnyArgsAndReturn(0);
+	__cmock_nrfx_uarte_uninit_Expect(p_uarte_inst_in_use);
+	__cmock_pinctrl_lookup_state_ExpectAnyArgsAndReturn(0);
+	__cmock_pinctrl_configure_pins_ExpectAnyArgsAndReturn(0);
 
 	ret = trace_backend_deinit();
 
@@ -188,7 +188,7 @@ void test_trace_backend_write_uart(void)
 
 	test_trace_backend_init_uart();
 
-	__wrap_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
+	__cmock_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
 					     max_uart_frag_size, NRFX_SUCCESS);
 
 	/* Simulate reception of a modem trace and let trace_test_thread run. */
@@ -198,7 +198,7 @@ void test_trace_backend_write_uart(void)
 	/* Simulate uart callback. Done sending 1st part of modem trace. */
 	uart_tx_done_simulate(sample_trace_data, max_uart_frag_size);
 
-	__wrap_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use,
+	__cmock_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use,
 					     &sample_trace_data[max_uart_frag_size],
 					     sizeof(sample_trace_data) - max_uart_frag_size,
 					     NRFX_SUCCESS);
@@ -231,7 +231,7 @@ void test_trace_backend_write_uart_nrfx_uarte_evt_tx_done(void)
 
 	test_trace_backend_init_uart();
 
-	__wrap_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
+	__cmock_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
 					     max_uart_frag_size, NRFX_SUCCESS);
 
 	/* Simulate reception of a modem trace and let trace_test_thread run. */
@@ -269,7 +269,7 @@ void test_trace_backend_write_uart_nrfx_error_no_mem(void)
 	/* Make the nrfx_uarte_tx return error. This should make the modem trace module
 	 * abort sending the second part of the trace buffer.
 	 */
-	__wrap_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
+	__cmock_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
 					     max_uart_frag_size, NRFX_ERROR_NO_MEM);
 
 	/* Simulate reception of a modem trace and let trace_test_thread run. */
@@ -289,7 +289,7 @@ void test_trace_backend_write_uart_nrfx_uarte_evt_error(void)
 
 	test_trace_backend_init_uart();
 
-	__wrap_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
+	__cmock_nrfx_uarte_tx_ExpectAndReturn(p_uarte_inst_in_use, sample_trace_data,
 					     sizeof(sample_trace_data), NRFX_SUCCESS);
 
 	/* Simulate reception of a modem trace and let trace_test_thread run. */

--- a/tests/lib/sms/src/sms_test.c
+++ b/tests/lib/sms/src/sms_test.c
@@ -61,12 +61,12 @@ static void sms_reg_helper(void)
 {
 	char resp[] = "+CNMI: 0,0,0,0,1\r\n";
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp, sizeof(resp));
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp, sizeof(resp));
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=3,2,0,1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=3,2,0,1", 0);
 
 	test_handle = sms_register_listener(sms_callback, NULL);
 	TEST_ASSERT_EQUAL(0, test_handle);
@@ -74,7 +74,7 @@ static void sms_reg_helper(void)
 
 static void sms_unreg_helper(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=0,0,0,0", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=0,0,0,0", 0);
 
 	sms_unregister_listener(test_handle);
 	test_handle = -1;
@@ -94,7 +94,7 @@ void test_sms_reregister(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=3,2,0,1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=3,2,0,1", 0);
 	/* Notify that SMS client has been unregistered */
 	at_monitor_dispatch("+CMS ERROR: 524\r\n");
 
@@ -137,9 +137,9 @@ void test_sms_init_fail_register_too_many(void)
 /** Test error return value for AT+CNMI? */
 void test_sms_init_fail_cnmi_query_ret_err(void)
 {
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", -EINVAL);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", -EINVAL);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
 	int handle = sms_register_listener(sms_callback, NULL);
 
 	TEST_ASSERT_EQUAL(-EINVAL, handle);
@@ -154,31 +154,31 @@ void test_sms_init_fail_cnmi_resp_unexpected_value(void)
 	char resp_cnmi_fail3[] = "+CNMI: 0,0,3,0,1\r\n";
 	char resp_cnmi_fail4[] = "+CNMI: 0,0,0,4,1\r\n";
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp_cnmi_fail1, sizeof(resp_cnmi_fail1));
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp_cnmi_fail1, sizeof(resp_cnmi_fail1));
 	handle = sms_register_listener(sms_callback, NULL);
 	TEST_ASSERT_EQUAL(-EBUSY, handle);
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp_cnmi_fail2, sizeof(resp_cnmi_fail2));
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp_cnmi_fail2, sizeof(resp_cnmi_fail2));
 	handle = sms_register_listener(sms_callback, NULL);
 	TEST_ASSERT_EQUAL(-EBUSY, handle);
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp_cnmi_fail3, sizeof(resp_cnmi_fail3));
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp_cnmi_fail3, sizeof(resp_cnmi_fail3));
 	handle = sms_register_listener(sms_callback, NULL);
 	TEST_ASSERT_EQUAL(-EBUSY, handle);
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp_cnmi_fail4, sizeof(resp_cnmi_fail4));
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp_cnmi_fail4, sizeof(resp_cnmi_fail4));
 	handle = sms_register_listener(sms_callback, NULL);
 	TEST_ASSERT_EQUAL(-EBUSY, handle);
 }
@@ -189,10 +189,10 @@ void test_sms_init_fail_cnmi_resp_erroneous(void)
 	/* Make sscanf() fail */
 	char resp[] = "+CNMI: 0,\"moi\",0,0,1,\r\n";
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp, sizeof(resp));
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp, sizeof(resp));
 	int handle = sms_register_listener(sms_callback, NULL);
 
 	TEST_ASSERT_EQUAL(-EBADMSG, handle);
@@ -203,12 +203,12 @@ void test_sms_init_fail_cnmi_set_ret_err(void)
 {
 	char resp[] = "+CNMI: 0,0,0,0,1\r\n";
 
-	__wrap_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
-	__wrap_nrf_modem_at_cmd_IgnoreArg_buf();
-	__wrap_nrf_modem_at_cmd_IgnoreArg_len();
-	__wrap_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp, sizeof(resp));
+	__cmock_nrf_modem_at_cmd_ExpectAndReturn(NULL, 0, "AT+CNMI?", 0);
+	__cmock_nrf_modem_at_cmd_IgnoreArg_buf();
+	__cmock_nrf_modem_at_cmd_IgnoreArg_len();
+	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(resp, sizeof(resp));
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=3,2,0,1", -EIO);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=3,2,0,1", -EIO);
 	int handle = sms_register_listener(sms_callback, NULL);
 
 	TEST_ASSERT_EQUAL(-EIO, handle);
@@ -238,7 +238,7 @@ void test_sms_uninit_cnmi_ret_err_negative(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=0,0,0,0", -ENOEXEC);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=0,0,0,0", -ENOEXEC);
 
 	sms_unregister_listener(test_handle);
 
@@ -252,7 +252,7 @@ void test_sms_uninit_cnmi_ret_err_positive(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=0,0,0,0", 196939);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=0,0,0,0", 196939);
 
 	sms_unregister_listener(test_handle);
 	test_handle = -1;
@@ -265,7 +265,7 @@ void test_sms_reregister_cnmi_query_ret_err(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=3,2,0,1", -EBUSY);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMI=3,2,0,1", -EBUSY);
 	/* Notify that SMS client has been unregistered */
 	at_monitor_dispatch("+CMS ERROR: 524\r\n");
 
@@ -298,7 +298,7 @@ void test_send_len3_number10plus(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=15\r0021000A912143658709000003CD771A\x1A", 0);
 
 	int ret = sms_send_text("+1234567890", "Moi");
@@ -308,7 +308,7 @@ void test_send_len3_number10plus(void)
 	/* Receive SMS-STATUS-REPORT */
 	test_sms_data.type = SMS_TYPE_STATUS_REPORT;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	test_sms_header_exists = false;
 	at_monitor_dispatch("+CDS: 24\r\n06550A912143658709122022118314801220221183148000\r\n");
@@ -323,7 +323,7 @@ void test_send_len1_number20plus(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=18\r00210014912143658709214365870900000131\x1A", 0);
 
 	int ret = sms_send_text("+12345678901234567890", "1");
@@ -333,7 +333,7 @@ void test_send_len1_number20plus(void)
 	/* Receive SMS-STATUS-REPORT */
 	test_sms_data.type = SMS_TYPE_STATUS_REPORT;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	test_sms_header_exists = false;
 	at_monitor_dispatch("+CDS: 24\r\n06550A912143658709122022118314801220221183148000\r\n");
@@ -347,7 +347,7 @@ void test_send_len1_number20plus(void)
  */
 void test_send_len7_number11(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=20\r0021000B912143658709F100000731D98C56B3DD00\x1A", 0);
 
 	int ret = sms_send_text("12345678901", "1234567");
@@ -362,7 +362,7 @@ void test_send_len7_number11(void)
  */
 void test_send_len8_number1(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=15\r0021000191F100000831D98C56B3DD70\x1A", 0);
 
 	int ret = sms_send_text("1", "12345678");
@@ -376,7 +376,7 @@ void test_send_len8_number1(void)
  */
 void test_send_len9_number5(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=18\r00210005912143F500000931D98C56B3DD7039\x1A", 0);
 
 	int ret = sms_send_text("12345", "123456789");
@@ -390,11 +390,11 @@ void test_send_len9_number5(void)
  */
 void test_send_concat_220chars_2msgs(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r0061010C912143658709210000A005000301020162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966\x1A",
 		0);
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=78\r0061020C9121436587092100004A0500030102026835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD703918\x1A",
 		0);
 
@@ -410,11 +410,11 @@ void test_send_concat_220chars_2msgs(void)
  */
 void test_send_concat_291chars_2msgs(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r0061030C912143658709210000A005000302020162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966\x1A",
 		0);
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=140\r0061040C912143658709210000910500030202026835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031\x1A",
 		0);
 
@@ -430,23 +430,23 @@ void test_send_concat_291chars_2msgs(void)
  */
 void test_send_concat_700chars_5msgs(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r0061050C912143658709210000A005000303050162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966\x1A",
 		0);
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r0061060C912143658709210000A00500030305026835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C\x1A",
 		0);
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r0061070C912143658709210000A00500030305036EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172\x1A",
 		0);
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r0061080C912143658709210000A00500030305046031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564\x1A",
 		0);
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=97\r0061090C9121436587092100005F05000303050566B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC100\x1A",
 		0);
 
@@ -461,7 +461,7 @@ void test_send_concat_700chars_5msgs(void)
  */
 void test_send_special_characters(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=49\r00210005912143F500002C5378799C0EB3416374581E1ED3CBF2B90EB4A1803628D02605DAF0401B1F68F3026D7AA00DD005\x1A",
 		0);
 
@@ -483,11 +483,11 @@ void test_send_special_characters(void)
  */
 void test_send_concat_special_character_split(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=150\r00610A05912143F500009F05000304020162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC900\x1A",
 		0);
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=27\r00610B05912143F500001305000304020236E5373C2E9FD3EBF63B1E\x1A",
 		0);
 
@@ -500,7 +500,7 @@ void test_send_concat_special_character_split(void)
 /** Text is empty. Message will be sent successfully. */
 void test_send_text_empty(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=12\r002100099121436587F9000000\x1A", 0);
 
 	int ret = sms_send_text("123456789", "");
@@ -511,7 +511,7 @@ void test_send_text_empty(void)
 /** Text is NULL. Message will be sent successfully. */
 void test_send_text_null(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=12\r002100099121436587F9000000\x1A", 0);
 
 	int ret = sms_send_text("123456789", NULL);
@@ -540,7 +540,7 @@ void test_send_fail_number_null(void)
 /** Failing AT command response to CMGS command. */
 void test_send_fail_atcmd(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=15\r0021000A912143658709000003CD771A\x1A", -ENOMEM);
 
 	int ret = sms_send_text("+1234567890", "Moi");
@@ -551,7 +551,7 @@ void test_send_fail_atcmd(void)
 /** Failing AT command response to CMGS command when sending concatenated message. */
 void test_send_fail_atcmd_concat(void)
 {
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=153\r00610C0C912143658709210000A005000305020162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966B49AED86CBC162B219AD66BBE172B0986C46ABD96EB81C2C269BD16AB61B2E078BC966\x1A",
 		304); // TODO
 
@@ -630,7 +630,7 @@ void test_recv_len3_number13(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890123\",22\r\n"
 		"0791534874894320040D91214365870921F300001220900285438003CD771A\r\n");
@@ -664,7 +664,7 @@ void test_recv_len1_number9(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234B67A9\",20\r\n"
 		"079153487489432004099121436BA7F90000122090028543800131\r\n");
@@ -695,7 +695,7 @@ void test_recv_len8_number20(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", -EBUSY);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", -EBUSY);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+12345678901234567890\",30\r\n"
 		"0791534874894320041491214365870921436587090000122090028543800831D98C56B3DD70\r\n");
@@ -729,7 +729,7 @@ void test_recv_concat_len291_msgs2(void)
 		"123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123");
 	test_sms_header.concatenated.seq_number = 1;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	sms_callback_called_occurred = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
@@ -742,7 +742,7 @@ void test_recv_concat_len291_msgs2(void)
 		"456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901");
 	test_sms_header.concatenated.seq_number = 2;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_occurred = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"0791534874894320440A912143658709000012201232054480910500037E02026835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031\r\n");
@@ -785,7 +785,7 @@ void test_recv_concat_len755_msgs5(void)
 		"abcdefghijklmnopqr");
 	test_sms_header.concatenated.seq_number = 1;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	sms_callback_called_occurred = false;
 	at_monitor_dispatch("+CMT: \"1234567890\",159\r\n"
@@ -804,7 +804,7 @@ void test_recv_concat_len755_msgs5(void)
 		"abcdefghijklmnopqr");
 	test_sms_header.concatenated.seq_number = 4;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_occurred = false;
 	at_monitor_dispatch("+CMT: \"1234567890\",159\r\n"
 		"0791534874894370440A912143658709000012202280656080A0050003800504C2E231B96C3EA3D3EA35BBED7EC3E3F239BD6EBFE3F37A50583C2697CD67745ABD66B7DD6F785C3EA7D7ED777C5E0F0A8BC7E4B2F98C4EABD7ECB6FB0D8FCBE7F4BAFD8ECFEB4161F1985C369FD169F59ADD76BFE171F99C5EB7DFF1793D282C1E93CBE6333AAD5EB3DBEE373C2E9FD3EBF63B3EAF0785C56372D97C46A7D56B76DBFD86C7E5\r\n");
@@ -820,7 +820,7 @@ void test_recv_concat_len755_msgs5(void)
 		"abcdefghijklmnopqrstuvwxyz abcdefghi");
 	test_sms_header.concatenated.seq_number = 2;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_occurred = false;
 	at_monitor_dispatch("+CMT: \"1234567890\",159\r\n"
 		"0791534874894370440A912143658709000012202280656080A0050003800502E6F4BAFD8ECFEB4161F1985C369FD169F59ADD76BFE171F99C5EB7DFF1793D282C1E93CBE6333AAD5EB3DBEE373C2E9FD3EBF63B3EAF0785C56372D97C46A7D56B76DBFD86C7E5737ADD7EC7E7F5A0B0784C2E9BCFE8B47ACD6EBBDFF0B87C4EAFDBEFF8BC1E14168FC965F3199D56AFD96DF71B1E97CFE975FB1D9FD783C2E231B96C3EA3D3\r\n");
@@ -836,7 +836,7 @@ void test_recv_concat_len755_msgs5(void)
 		"abcdefghijklmnopqrstuvwxyz ");
 	test_sms_header.concatenated.seq_number = 3;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_occurred = false;
 	at_monitor_dispatch("+CMT: \"1234567890\",159\r\n"
 		"0791534874894310440A912143658709000012202280656080A0050003800503D46B76DBFD86C7E5737ADD7EC7E7F5A0B0784C2E9BCFE8B47ACD6EBBDFF0B87C4EAFDBEFF8BC1E14168FC965F3199D56AFD96DF71B1E97CFE975FB1D9FD783C2E231B96C3EA3D3EA35BBED7EC3E3F239BD6EBFE3F37A50583C2697CD67745ABD66B7DD6F785C3EA7D7ED777C5E0F0A8BC7E4B2F98C4EABD7ECB6FB0D8FCBE7F4BAFD8ECFEB41\r\n");
@@ -852,7 +852,7 @@ void test_recv_concat_len755_msgs5(void)
 		"abcdefghijklmnopqrstuvwxyz");
 	test_sms_header.concatenated.seq_number = 5;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_occurred = false;
 	at_monitor_dispatch("+CMT: \"1234567890\",151\r\n"
 		"0791534874894310440A91214365870900001220228065608096050003800505E6F4BAFD8ECFEB4161F1985C369FD169F59ADD76BFE171F99C5EB7DFF1793D282C1E93CBE6333AAD5EB3DBEE373C2E9FD3EBF63B3EAF0785C56372D97C46A7D56B76DBFD86C7E5737ADD7EC7E7F5A0B0784C2E9BCFE8B47ACD6EBBDFF0B87C4EAFDBEFF8BC1E14168FC965F3199D56AFD96DF71B1E97CFE975FB1D9FD703\r\n");
@@ -880,7 +880,7 @@ void test_recv_special_characters(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+123456789\",20\r\n"
 		"079153487489432004099121436587F90000122090028543802F5378799C0EB3416374581E1ED3CBF2B90EB4A1803628D02605DAF0401B1F68F3026D7AA00D10B429BB00\r\n");
@@ -918,7 +918,7 @@ void test_recv_concat_escape_character_last(void)
 		"12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012");
 	test_sms_header.concatenated.seq_number = 1;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	sms_callback_called_occurred = false;
 	at_monitor_dispatch("+CMT: \"1234567890\",159\r\n"
@@ -930,7 +930,7 @@ void test_recv_concat_escape_character_last(void)
 	sprintf(test_sms_data.payload, "%c1234567890", 0xA4);
 	test_sms_header.concatenated.seq_number = 2;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_occurred = false;
 	at_monitor_dispatch("+CMT: \"1234567890\",159\r\n"
 		"0791534874894370440A9121436587090000122022806550801305000351020236E5986C46ABD96EB81C0C\r\n");
@@ -962,7 +962,7 @@ void test_recv_dcs1111_gsm7bit(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+12345\",30\r\n"
 		"07915348748943200405912143F500F0122090028543800831D98C56B3DD70\r\n");
@@ -993,7 +993,7 @@ void test_recv_dcs1111_8bit(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+12345\",30\r\n"
 		"07915348748943200405912143F500F4122090028543800F0102030405060708090A0B0C0D0E0F\r\n");
@@ -1028,7 +1028,7 @@ void test_recv_port_addr(void)
 	test_sms_header.concatenated.ref_number = 124;
 	test_sms_header.concatenated.seq_number = 1;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"12345678\",22\r\n"
 		"004408812143658700041210032143652b1b0b05040b84000000037c01010102030405060708090A0B0C0D0E0F\r\n");
@@ -1072,7 +1072,7 @@ void test_recv_empty_sms_text(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",18\r\n"
 		"00040A91214365870900001220900285438000\r\n");
@@ -1085,7 +1085,7 @@ void test_recv_invalid_hex_characters(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",18\r\n"
 		"00040A91214365870900001220A00285438009123456KLAB\r\n");
@@ -1101,7 +1101,7 @@ void test_recv_invalid_header_too_short(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",18\r\n"
 		"00040A91214365870900001220A0028543800\r\n");
@@ -1114,7 +1114,7 @@ void test_recv_fail_number21(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+123456789012345678901\",32\r\n"
 		"0004169121436587092143658709F10000122090028543800831D98C56B3DD70\r\n");
@@ -1127,7 +1127,7 @@ void test_recv_cmt_erroneous(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	/* Size missing (22\r\n) */
 	at_monitor_dispatch("+CMT: \"+1234567890\","
@@ -1141,7 +1141,7 @@ void test_recv_cmt_empty(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \r\n");
 
@@ -1153,7 +1153,7 @@ void test_recv_fail_invalid_dcs_ucs2(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"004408812143658700081210032143652b1c0b05040b84000000037c0101010203040506070809\r\n");
@@ -1166,7 +1166,7 @@ void test_recv_fail_invalid_dcs_reserved_value(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"0044088121436587000C1210032143652b1c0b05040b84000000037c0101010203040506070809\r\n");
@@ -1179,7 +1179,7 @@ void test_recv_fail_invalid_dcs_unsupported_format(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"004408812143658700801210032143652b1c0b05040b84000000037c0101010203040506070809\r\n");
@@ -1192,7 +1192,7 @@ void test_recv_fail_len161(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00040A912143658709000012201232054480A131D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031\r\n");
@@ -1209,7 +1209,7 @@ void test_recv_fail_internal_pdu_buffer_too_short(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00040A912143658709000012201232054480A031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E560\r\n");
@@ -1226,7 +1226,7 @@ void test_recv_fail_internal_payload_buffer_too_short(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"0B912143658709214365870904149121436587092143658709000012201232054480A031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E560313233343536\r\n");
@@ -1252,7 +1252,7 @@ void test_recv_invalid_udl_shorter_than_ud_7bit(void)
 	test_sms_header.time.second = 44;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00040A9121436587090000122012320544802031D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031\r\n");
@@ -1282,7 +1282,7 @@ void test_recv_invalid_udl_longer_than_ud_7bit_len41(void)
 	test_sms_header.time.second = 44;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00040A9121436587090000122012320544802A31D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E56031\r\n");
@@ -1312,7 +1312,7 @@ void test_recv_invalid_udl_longer_than_ud_7bit_len40(void)
 	test_sms_header.time.second = 44;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00040A9121436587090000122012320544802A31D98C56B3DD7039584C36A3D56C375C0E1693CD6835DB0D9783C564335ACD76C3E560\r\n");
@@ -1338,7 +1338,7 @@ void test_recv_invalid_udl_longer_than_ud_8bit(void)
 	test_sms_header.time.second = 44;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00040A9121436587090004122012320544800A010203040506070809\r\n");
@@ -1364,7 +1364,7 @@ void test_recv_invalid_udl_shorter_than_ud_8bit(void)
 	test_sms_header.time.second = 44;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00040A9121436587090004122012320544800A0102030405060708090A0B0C0D0E0F\r\n");
@@ -1377,7 +1377,7 @@ void test_recv_fail_udhl_longer_than_udh(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00440A912143658709000012201232054480050500037E0201AAAA\r\n");
@@ -1390,7 +1390,7 @@ void test_recv_fail_udhl_longer_than_ud(void)
 {
 	sms_reg_helper();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = false;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00440A91214365870900001220123205448004030201\r\n");
@@ -1421,7 +1421,7 @@ void test_recv_udh_with_datalen0(void)
 	test_sms_header.concatenated.ref_number = 171;
 	test_sms_header.concatenated.seq_number = 1;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00440A91214365870900001220123205448006050003AB0101\r\n");
@@ -1455,7 +1455,7 @@ void test_recv_udh_with_datalen0_fill_byte(void)
 	test_sms_header.concatenated.ref_number = 171;
 	test_sms_header.concatenated.seq_number = 1;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00440A91214365870900001220123205448007050003AB010100\r\n");
@@ -1486,7 +1486,7 @@ void test_recv_udh_with_datalen1(void)
 	test_sms_header.concatenated.ref_number = 171;
 	test_sms_header.concatenated.seq_number = 1;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"00440A91214365870900001220123205448008050003AB010162\r\n");
@@ -1521,7 +1521,7 @@ void test_recv_invalid_udh_too_long_ie(void)
 	test_sms_header.app_port.present = false;
 	test_sms_header.concatenated.present = false;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"12345678\",22\r\n"
 		"004408812143658700041210032143652B1B0A05040B84111100037C010102030405060708090A0B0C0D0E0F\r\n");
@@ -1565,7 +1565,7 @@ void test_recv_invalid_udh_concat_ignored_portaddr_valid(void)
 
 	test_sms_header.concatenated.present = false;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"12345678\",22\r\n"
 		"004408812143658700041210032143652B2F1E00022A0100032A000200032A020000032A020304021100080511112222220102030405060708090A0B0C0D0E0F\r\n");
@@ -1609,7 +1609,7 @@ void test_recv_invalid_udh_portaddr_ignored_concat_valid(void)
 	test_sms_header.concatenated.ref_number = 4369;
 	test_sms_header.concatenated.seq_number = 1;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"12345678\",22\r\n"
 		"004408812143658700041210032143652B2C1B01000804111101010400050712345678901234A1061234567890120102030405060708090A0B0C0D0E0F\r\n");
@@ -1637,7 +1637,7 @@ void test_recv_large_positive_time_zone_offset(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = 55; /* +13:45 */
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890123\",22\r\n"
 		"0791534874894320040D91214365870921F300001220900285435503CD771A\r\n");
@@ -1665,7 +1665,7 @@ void test_recv_large_negative_time_zone_offset(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = -55; /* -13:45 */
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890123\",22\r\n"
 		"0791534874894320040D91214365870921F300001220900285435D03CD771A\r\n");
@@ -1683,7 +1683,7 @@ void send_basic(void)
 {
 	helper_sms_data_clear();
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn(
+	__cmock_nrf_modem_at_printf_ExpectAndReturn(
 		"AT+CMGS=15\r0021000A912143658709000003CD771A\x1A", 0);
 	int ret = sms_send_text("+1234567890", "Moi");
 
@@ -1692,7 +1692,7 @@ void send_basic(void)
 	/* Receive SMS-STATUS-REPORT */
 	test_sms_data.type = SMS_TYPE_STATUS_REPORT;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	test_sms_header_exists = false;
 	at_monitor_dispatch("+CDS: 24\r\n06550A912143658709122022118314801220221183148000\r\n");
@@ -1720,7 +1720,7 @@ void recv_basic(void)
 	test_sms_header.time.second = 34;
 	test_sms_header.time.timezone = 8;
 
-	__wrap_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
+	__cmock_nrf_modem_at_printf_ExpectAndReturn("AT+CNMA=1", 0);
 	sms_callback_called_expected = true;
 	at_monitor_dispatch("+CMT: \"+1234567890\",22\r\n"
 		"0791534874894320040A91214365870900001220900285438003CD771A\r\n");
@@ -1779,7 +1779,7 @@ void test_recv_loop(void)
 /* This is needed because AT Monitor library is initialized in SYS_INIT. */
 static int sms_test_sys_init(const struct device *unused)
 {
-	__wrap_nrf_modem_at_notif_handler_set_ExpectAnyArgsAndReturn(0);
+	__cmock_nrf_modem_at_notif_handler_set_ExpectAnyArgsAndReturn(0);
 
 	return 0;
 }

--- a/tests/subsys/net/lib/azure_iot_hub/dps/src/azure_iot_hub_dps_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/dps/src/azure_iot_hub_dps_test.c
@@ -72,10 +72,10 @@ void setUp(void)
 {
 	mock_azure_iot_hub_mqtt_Init();
 	mock_settings_Init();
-	__wrap_settings_subsys_init_IgnoreAndReturn(0);
-	__wrap_settings_load_subtree_IgnoreAndReturn(0);
-	__wrap_settings_save_one_IgnoreAndReturn(0);
-	__wrap_settings_delete_IgnoreAndReturn(0);
+	__cmock_settings_subsys_init_IgnoreAndReturn(0);
+	__cmock_settings_load_subtree_IgnoreAndReturn(0);
+	__cmock_settings_save_one_IgnoreAndReturn(0);
+	__cmock_settings_delete_IgnoreAndReturn(0);
 	az_precondition_failed_set_callback(az_precondition_failed_cb);
 
 	dps_state = DPS_STATE_UNINIT;
@@ -85,7 +85,7 @@ void tearDown(void)
 {
 	mock_azure_iot_hub_mqtt_Verify();
 	mock_settings_Verify();
-	__wrap_mqtt_helper_disconnect_IgnoreAndReturn(0);
+	__cmock_mqtt_helper_disconnect_IgnoreAndReturn(0);
 	azure_iot_hub_dps_reset();
 }
 
@@ -252,7 +252,7 @@ void test_azure_iot_hub_dps_device_id_delete(void)
 
 void test_azure_iot_hub_dps_reset_connected(void)
 {
-	__wrap_mqtt_helper_disconnect_ExpectAndReturn(0);
+	__cmock_mqtt_helper_disconnect_ExpectAndReturn(0);
 
 	dps_reg_ctx.assigned_hub = az_span_create_from_str(TEST_IOT_HUB_HOSTNAME);
 	dps_reg_ctx.assigned_device_id = az_span_create_from_str(TEST_EXPECTED_DEVICE_ID);
@@ -297,8 +297,8 @@ void test_azure_iot_hub_dps_start(void)
 		.id_scope.size = TEST_ID_SCOPE_LEN,
 	};
 
-	__wrap_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
-	__wrap_mqtt_helper_connect_Stub(mqtt_helper_connect_stub);
+	__cmock_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_connect_Stub(mqtt_helper_connect_stub);
 
 	err = azure_iot_hub_dps_init(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -322,8 +322,8 @@ void test_azure_iot_hub_dps_start_kconfig_defaults(void)
 		.handler = dps_handler,
 	};
 
-	__wrap_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
-	__wrap_mqtt_helper_connect_Stub(mqtt_helper_connect_stub_defaults);
+	__cmock_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_connect_Stub(mqtt_helper_connect_stub_defaults);
 
 	err = azure_iot_hub_dps_init(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -342,7 +342,7 @@ void test_azure_iot_hub_dps_start_kconfig_defaults(void)
 
 void test_on_reg_completed_no_msg(void)
 {
-	__wrap_mqtt_helper_disconnect_ExpectAndReturn(0);
+	__cmock_mqtt_helper_disconnect_ExpectAndReturn(0);
 
 	dps_state = DPS_STATE_CONNECTED;
 	dps_reg_ctx.cb = dps_handler;
@@ -375,7 +375,7 @@ void test_on_publish_assigned(void)
 
 	dps_reg_ctx.cb = dps_handler;
 
-	__wrap_mqtt_helper_disconnect_ExpectAndReturn(0);
+	__cmock_mqtt_helper_disconnect_ExpectAndReturn(0);
 	on_publish(topic, payload);
 	TEST_ASSERT_EQUAL(0, k_sem_take(&reg_status_assigned_sem, K_SECONDS(1)));
 }
@@ -396,7 +396,7 @@ void test_on_publish_request_error(void)
 
 	dps_reg_ctx.cb = dps_handler;
 
-	__wrap_mqtt_helper_disconnect_ExpectAndReturn(0);
+	__cmock_mqtt_helper_disconnect_ExpectAndReturn(0);
 	on_publish(topic, payload);
 	TEST_ASSERT_EQUAL(0, k_sem_take(&reg_failed_sem, K_SECONDS(1)));
 }
@@ -419,9 +419,9 @@ void test_on_publish_assigning(void)
 		.size = sizeof(payload_reg_update) - 1,
 	};
 
-	__wrap_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
-	__wrap_mqtt_helper_connect_Stub(mqtt_helper_connect_stub_defaults);
-	__wrap_mqtt_helper_publish_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_connect_Stub(mqtt_helper_connect_stub_defaults);
+	__cmock_mqtt_helper_publish_ExpectAnyArgsAndReturn(0);
 
 	err = azure_iot_hub_dps_init(&config);
 	TEST_ASSERT_EQUAL(0, err);
@@ -456,7 +456,7 @@ void test_on_publish_invalid_topic(void)
 
 	dps_reg_ctx.cb = dps_handler;
 
-	__wrap_mqtt_helper_disconnect_ExpectAndReturn(0);
+	__cmock_mqtt_helper_disconnect_ExpectAndReturn(0);
 	on_publish(topic, payload);
 	TEST_ASSERT_EQUAL(0, k_sem_take(&reg_failed_sem, K_SECONDS(2)));
 }
@@ -476,7 +476,7 @@ void test_on_publish_invalid_payload(void)
 
 	dps_reg_ctx.cb = dps_handler;
 
-	__wrap_mqtt_helper_disconnect_ExpectAndReturn(0);
+	__cmock_mqtt_helper_disconnect_ExpectAndReturn(0);
 	on_publish(topic, payload);
 	TEST_ASSERT_EQUAL(0, k_sem_take(&reg_failed_sem, K_SECONDS(2)));
 }

--- a/tests/subsys/net/lib/azure_iot_hub/iot_hub/src/azure_iot_hub_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/iot_hub/src/azure_iot_hub_test.c
@@ -279,8 +279,8 @@ void test_azure_iot_hub_connect_runtime_config_values(void)
 		},
 	};
 
-	__wrap_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
-	__wrap_mqtt_helper_connect_Stub(mqtt_helper_connect_run_time_stub);
+	__cmock_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_connect_Stub(mqtt_helper_connect_run_time_stub);
 
 	iot_hub_state = STATE_DISCONNECTED;
 
@@ -294,8 +294,8 @@ void test_azure_iot_hub_connect_runtime_config_values(void)
 
 void test_azure_iot_hub_connect_kconfig_values(void)
 {
-	__wrap_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
-	__wrap_mqtt_helper_connect_Stub(mqtt_helper_connect_kconfig_stub);
+	__cmock_mqtt_helper_init_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_helper_connect_Stub(mqtt_helper_connect_kconfig_stub);
 
 	iot_hub_state = STATE_DISCONNECTED;
 
@@ -329,7 +329,7 @@ void test_azure_iot_hub_connect_not_disconnected(void)
 
 void test_azure_iot_hub_disconnect(void)
 {
-	__wrap_mqtt_helper_disconnect_ExpectAndReturn(0);
+	__cmock_mqtt_helper_disconnect_ExpectAndReturn(0);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -353,7 +353,7 @@ void test_azure_iot_hub_send(void)
 		.qos = MQTT_QOS_0_AT_MOST_ONCE,
 	};
 
-	__wrap_mqtt_helper_publish_Stub(mqtt_helper_publish_stub);
+	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_stub);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -382,7 +382,7 @@ void test_azure_iot_hub_send_1_property(void)
 		.topic.property_count = 1,
 	};
 
-	__wrap_mqtt_helper_publish_Stub(mqtt_helper_publish_1_prop_stub);
+	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_1_prop_stub);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -424,7 +424,7 @@ void test_azure_iot_hub_send_2_properties(void)
 		.topic.property_count = ARRAY_SIZE(properties),
 	};
 
-	__wrap_mqtt_helper_publish_Stub(mqtt_helper_publish_2_props_stub);
+	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_2_props_stub);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -521,7 +521,7 @@ void test_azure_iot_hub_send_twin_get_request(void)
 		},
 	};
 
-	__wrap_mqtt_helper_publish_Stub(mqtt_helper_publish_twin_request_stub);
+	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_twin_request_stub);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -542,7 +542,7 @@ void test_azure_iot_hub_send_twin_update_reported(void)
 		},
 	};
 
-	__wrap_mqtt_helper_publish_Stub(mqtt_helper_publish_twin_update_reported_stub);
+	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_twin_update_reported_stub);
 
 	iot_hub_state = STATE_CONNECTED;
 
@@ -600,7 +600,7 @@ void test_azure_iot_hub_method_respond(void)
 
 	iot_hub_state = STATE_CONNECTED;
 
-	__wrap_mqtt_helper_publish_Stub(mqtt_helper_publish_method_respond_stub);
+	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_method_respond_stub);
 
 	TEST_ASSERT_EQUAL(0, azure_iot_hub_method_respond(&result));
 }
@@ -652,7 +652,7 @@ void test_azure_iot_hub_method_respond_mqtt_fail(void)
 
 	iot_hub_state = STATE_CONNECTED;
 
-	__wrap_mqtt_helper_publish_Stub(mqtt_helper_publish_fail_stub);
+	__cmock_mqtt_helper_publish_Stub(mqtt_helper_publish_fail_stub);
 
 	TEST_ASSERT_EQUAL(-ENXIO, azure_iot_hub_method_respond(&result));
 }

--- a/tests/subsys/net/lib/azure_iot_hub/mqtt/src/azure_iot_hub_mqtt_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/mqtt/src/azure_iot_hub_mqtt_test.c
@@ -64,7 +64,7 @@ static K_SEM_DEFINE(error_msg_size_sem, 0, 1);
 void setUp(void)
 {
 	mock_mqtt_Init();
-	__wrap_mqtt_keepalive_time_left_IgnoreAndReturn(0);
+	__cmock_mqtt_keepalive_time_left_IgnoreAndReturn(0);
 
 	/* Suspend the polling thread to have full control over polling. */
 	k_thread_suspend(azure_iot_hub_mqtt_thread);
@@ -281,7 +281,7 @@ void test_mqtt_helper_connect_when_disconnected(void)
 		},
 	};
 
-	__wrap_mqtt_client_init_Expect(&mqtt_client);
+	__cmock_mqtt_client_init_Expect(&mqtt_client);
 
 	/* Make getddrinfo return a pointer that points to NULL. Otherwise the unit under test
 	 * would be dereferencing uninitialized memory location. The behavior of the unit
@@ -289,14 +289,14 @@ void test_mqtt_helper_connect_when_disconnected(void)
 	 */
 	struct zsock_addrinfo *test_res = NULL;
 
-	__wrap_getaddrinfo_ExpectAndReturn(NULL, NULL, NULL, NULL, 0);
-	__wrap_getaddrinfo_IgnoreArg_host();
-	__wrap_getaddrinfo_IgnoreArg_hints();
-	__wrap_getaddrinfo_IgnoreArg_res();
-	__wrap_getaddrinfo_ReturnThruPtr_res(&test_res);
+	__cmock_getaddrinfo_ExpectAndReturn(NULL, NULL, NULL, NULL, 0);
+	__cmock_getaddrinfo_IgnoreArg_host();
+	__cmock_getaddrinfo_IgnoreArg_hints();
+	__cmock_getaddrinfo_IgnoreArg_res();
+	__cmock_getaddrinfo_ReturnThruPtr_res(&test_res);
 
-	__wrap_freeaddrinfo_ExpectAnyArgs();
-	__wrap_mqtt_connect_ExpectAndReturn(&mqtt_client, 0);
+	__cmock_freeaddrinfo_ExpectAnyArgs();
+	__cmock_mqtt_connect_ExpectAndReturn(&mqtt_client, 0);
 
 	mqtt_state = MQTT_STATE_DISCONNECTED;
 
@@ -308,10 +308,10 @@ void test_mqtt_helper_connect_when_disconnected_mqtt_api_error(void)
 {
 	struct mqtt_helper_conn_params conn_params_dummy;
 
-	__wrap_mqtt_client_init_Expect(&mqtt_client);
-	__wrap_getaddrinfo_ExpectAnyArgsAndReturn(0);
-	__wrap_freeaddrinfo_ExpectAnyArgs();
-	__wrap_mqtt_connect_ExpectAndReturn(&mqtt_client, -2);
+	__cmock_mqtt_client_init_Expect(&mqtt_client);
+	__cmock_getaddrinfo_ExpectAnyArgsAndReturn(0);
+	__cmock_freeaddrinfo_ExpectAnyArgs();
+	__cmock_mqtt_connect_ExpectAndReturn(&mqtt_client, -2);
 
 	mqtt_state = MQTT_STATE_DISCONNECTED;
 
@@ -372,8 +372,8 @@ void test_on_suback(void)
 
 void test_on_publish(void)
 {
-	__wrap_mqtt_readall_publish_payload_Stub(mqtt_readall_publish_payload_stub);
-	__wrap_mqtt_publish_qos1_ack_ExpectAnyArgsAndReturn(0);
+	__cmock_mqtt_readall_publish_payload_Stub(mqtt_readall_publish_payload_stub);
+	__cmock_mqtt_publish_qos1_ack_ExpectAnyArgsAndReturn(0);
 
 	send_mqtt_event(MQTT_EVT_PUBLISH, TEST_MESSAGE_ID);
 
@@ -397,7 +397,7 @@ void test_on_publish_too_large_incoming_msg(void)
 
 void test_mqtt_helper_disconnect_when_connected(void)
 {
-	__wrap_mqtt_disconnect_ExpectAndReturn(&mqtt_client, 0);
+	__cmock_mqtt_disconnect_ExpectAndReturn(&mqtt_client, 0);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -407,7 +407,7 @@ void test_mqtt_helper_disconnect_when_connected(void)
 
 void test_mqtt_helper_disconnect_when_connected_mqtt_api_error(void)
 {
-	__wrap_mqtt_disconnect_ExpectAndReturn(&mqtt_client, -1);
+	__cmock_mqtt_disconnect_ExpectAndReturn(&mqtt_client, -1);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -440,7 +440,7 @@ void test_mqtt_helper_subscribe_when_connected(void)
 		.message_id = TEST_MESSAGE_ID,
 	};
 
-	__wrap_mqtt_subscribe_ExpectAndReturn(&mqtt_client, &sub_list, 0);
+	__cmock_mqtt_subscribe_ExpectAndReturn(&mqtt_client, &sub_list, 0);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -460,7 +460,7 @@ void test_mqtt_helper_subscribe_mqtt_api_error(void)
 {
 	struct mqtt_subscription_list sub_list_dummy = { 0 };
 
-	__wrap_mqtt_subscribe_ExpectAndReturn(&mqtt_client, &sub_list_dummy, -EINVAL);
+	__cmock_mqtt_subscribe_ExpectAndReturn(&mqtt_client, &sub_list_dummy, -EINVAL);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -486,7 +486,7 @@ void test_mqtt_helper_publish_when_connected(void)
 		.message_id = TEST_MESSAGE_ID,
 	};
 
-	__wrap_mqtt_publish_ExpectAndReturn(&mqtt_client, &pub_param, 0);
+	__cmock_mqtt_publish_ExpectAndReturn(&mqtt_client, &pub_param, 0);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -534,9 +534,9 @@ void test_mqtt_helper_poll_loop_disconnecting(void)
 void test_mqtt_helper_poll_loop_timeout(void)
 {
 	/* Let poll() return 0 first and then -1 on subsequent call to end the test. */
-	__wrap_poll_ExpectAnyArgsAndReturn(0);
-	__wrap_poll_ExpectAnyArgsAndReturn(-1);
-	__wrap_mqtt_live_ExpectAndReturn(&mqtt_client, 0);
+	__cmock_poll_ExpectAnyArgsAndReturn(0);
+	__cmock_poll_ExpectAnyArgsAndReturn(-1);
+	__cmock_mqtt_live_ExpectAndReturn(&mqtt_client, 0);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -551,8 +551,8 @@ void test_mqtt_helper_poll_loop_timeout(void)
  */
 void test_mqtt_helper_poll_loop_pollin(void)
 {
-	__wrap_poll_Stub(poll_stub_pollin);
-	__wrap_mqtt_input_ExpectAndReturn(&mqtt_client, 0);
+	__cmock_poll_Stub(poll_stub_pollin);
+	__cmock_mqtt_input_ExpectAndReturn(&mqtt_client, 0);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -566,7 +566,7 @@ void test_mqtt_helper_poll_loop_pollin(void)
  */
 void test_mqtt_helper_poll_loop_pollnval(void)
 {
-	__wrap_poll_Stub(poll_stub_pollnval);
+	__cmock_poll_Stub(poll_stub_pollnval);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -580,7 +580,7 @@ void test_mqtt_helper_poll_loop_pollnval(void)
  */
 void test_mqtt_helper_poll_loop_pollhup(void)
 {
-	__wrap_poll_Stub(poll_stub_pollhup);
+	__cmock_poll_Stub(poll_stub_pollhup);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 
@@ -594,7 +594,7 @@ void test_mqtt_helper_poll_loop_pollhup(void)
  */
 void test_mqtt_helper_poll_loop_pollerr(void)
 {
-	__wrap_poll_Stub(poll_stub_pollerr);
+	__cmock_poll_Stub(poll_stub_pollerr);
 
 	mqtt_state = MQTT_STATE_CONNECTED;
 

--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -86,7 +86,7 @@ function(cmock_linker_trick func_name_path)
     set(linker_str "-Wl")
   endif()
   foreach(src ${contents})
-    set(linker_str "${linker_str},--wrap=${src}")
+    set(linker_str "${linker_str},--defsym,${src}=__cmock_${src}")
   endforeach()
   zephyr_link_libraries(${linker_str})
 endfunction()
@@ -120,7 +120,7 @@ endfunction()
 # Function takes original header and prepares two version
 # - version with system calls removed and static inline functions
 #   converted to standard function declarations
-# - version with addtional __wrap_ prefix for all functions that
+# - version with addtional __cmock_ prefix for all functions that
 #   is used to generate cmock
 function(cmock_headers_prepare in_header out_header wrap_header)
   execute_process(

--- a/tests/unity/example_test/src/example_test.c
+++ b/tests/unity/example_test/src/example_test.c
@@ -29,8 +29,8 @@ void test_uut_init(void)
 {
 	int err;
 
-	__wrap_foo_init_ExpectAndReturn(NULL, 0);
-	__wrap_foo_execute_ExpectAndReturn(0);
+	__cmock_foo_init_ExpectAndReturn(NULL, 0);
+	__cmock_foo_execute_ExpectAndReturn(0);
 
 	err = uut_init(NULL);
 	TEST_ASSERT_EQUAL(0, err);

--- a/tests/unity/wrap_test/src/wrap_test.c
+++ b/tests/unity/wrap_test/src/wrap_test.c
@@ -15,7 +15,7 @@
 
 void test_syscall(void)
 {
-	__wrap_syscall_Expect();
+	__cmock_syscall_Expect();
 
 	call_syscall();
 }
@@ -29,7 +29,7 @@ void test_static_inline_fn(void)
 {
 	const int EXPECT_STATIC_INLINE = 1;
 
-	__wrap_static_inline_fn_ExpectAndReturn(EXPECT_STATIC_INLINE);
+	__cmock_static_inline_fn_ExpectAndReturn(EXPECT_STATIC_INLINE);
 
 	TEST_ASSERT_EQUAL(EXPECT_STATIC_INLINE, call_static_inline_fn());
 }
@@ -38,7 +38,7 @@ void test_inline_static_fn(void)
 {
 	const int EXPECT_INLINE_STATIC = 2;
 
-	__wrap_inline_static_fn_ExpectAndReturn(EXPECT_INLINE_STATIC);
+	__cmock_inline_static_fn_ExpectAndReturn(EXPECT_INLINE_STATIC);
 
 	TEST_ASSERT_EQUAL(EXPECT_INLINE_STATIC, call_inline_static_fn());
 }
@@ -47,7 +47,7 @@ void test_always_inline_fn(void)
 {
 	const int EXPECT_ALWAYS_INLINE = 3;
 
-	__wrap_always_inline_fn_ExpectAndReturn(EXPECT_ALWAYS_INLINE);
+	__cmock_always_inline_fn_ExpectAndReturn(EXPECT_ALWAYS_INLINE);
 
 	TEST_ASSERT_EQUAL(EXPECT_ALWAYS_INLINE, call_always_inline_fn());
 }
@@ -56,7 +56,7 @@ void test_after_macro(void)
 {
 	const int EXPECT_AFTER_MACRO = 4;
 
-	__wrap_after_macro_ExpectAndReturn(EXPECT_AFTER_MACRO);
+	__cmock_after_macro_ExpectAndReturn(EXPECT_AFTER_MACRO);
 
 	TEST_ASSERT_EQUAL(EXPECT_AFTER_MACRO, call_after_macro());
 }
@@ -65,7 +65,7 @@ void test_extra_whitespace(void)
 {
 	const int EXPECT_EXTRA_WHITESPACE = 5;
 
-	__wrap_extra_whitespace_ExpectAndReturn(EXPECT_EXTRA_WHITESPACE);
+	__cmock_extra_whitespace_ExpectAndReturn(EXPECT_EXTRA_WHITESPACE);
 
 	TEST_ASSERT_EQUAL(EXPECT_EXTRA_WHITESPACE, call_extra_whitespace());
 }
@@ -74,7 +74,7 @@ void test_multiline_def(void)
 {
 	const int EXPECT_MULTILINE_DEF = 6;
 
-	__wrap_multiline_def_ExpectAndReturn(1, 2, EXPECT_MULTILINE_DEF);
+	__cmock_multiline_def_ExpectAndReturn(1, 2, EXPECT_MULTILINE_DEF);
 
 	TEST_ASSERT_EQUAL(EXPECT_MULTILINE_DEF, call_multiline_def(1, 2));
 }


### PR DESCRIPTION
As discussed in #8766, prefix wrap functions generated by cmock with __wrap_cmock.

This makes it easier to identify and distinguish wrapped functions generated by cmock from other wrapped functions, such as those that are handwritten.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>