### PR TITLE
samples: nrf9160: lwm2m_client: Usage of time_t instead of 32-bit time

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_accelerometer.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_accelerometer.c
@@ -38,7 +38,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 #define MIN_RANGE_VALUE (-ACCEL_RANGE_G * SENSOR_G / 1000000.0)
 #define MAX_RANGE_VALUE (ACCEL_RANGE_G * SENSOR_G / 1000000.0)
 
-static int32_t timestamp;
+static time_t timestamp;
 
 int lwm2m_init_accel(void)
 {

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_app_utils.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_app_utils.c
@@ -15,18 +15,12 @@ LOG_MODULE_REGISTER(app_lwm2m_utils, CONFIG_APP_LOG_LEVEL);
 
 void set_ipso_obj_timestamp(int ipso_obj_id, unsigned int obj_inst_id)
 {
-	int32_t timestamp;
+	int ret;
 	char path[MAX_LWM2M_PATH_LEN];
-
-	int ret = lwm2m_engine_get_s32(LWM2M_PATH(LWM2M_OBJECT_DEVICE_ID, 0,
-					CURRENT_TIME_RID), &timestamp);
-	if (ret) {
-		LOG_ERR("Unable to retrieve timestamp");
-	}
 
 	snprintk(path, MAX_LWM2M_PATH_LEN, "%d/%u/%d", ipso_obj_id, obj_inst_id, TIMESTAMP_RID);
 
-	ret = lwm2m_engine_set_s32(path, timestamp);
+	ret = lwm2m_engine_set_time(path, time(NULL));
 	if (ret) {
 		LOG_ERR("Unable to set timestamp");
 	}

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_buzzer.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_buzzer.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(app_lwm2m_buzzer, CONFIG_APP_LOG_LEVEL);
 
 #define BUZZER_APP_TYPE "Buzzer"
 
-static int32_t lwm2m_timestamp;
+static time_t lwm2m_timestamp;
 
 static int buzzer_state_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res_inst_id,
 			   uint8_t *data, uint16_t data_len, bool last_block, size_t total_size)

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_gas_res_sensor.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_gas_res_sensor.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 #define GENERIC_SENSOR_TYPE "Gas resistance sensor"
 #define GAS_RES_UNIT "Ω"
 
-static int32_t timestamp;
+static time_t timestamp;
 
 int lwm2m_init_gas_res_sensor(void)
 {

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_humid_sensor.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_humid_sensor.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 
 #define HUMID_UNIT "%"
 
-static int32_t timestamp;
+static time_t timestamp;
 
 int lwm2m_init_humid_sensor(void)
 {

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_light_sensor.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_light_sensor.c
@@ -33,7 +33,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 #define COLOUR_SENSOR_APP_NAME "Colour sensor"
 #define LIGHT_UNIT "RGB-IR"
 
-static int32_t timestamp[2];
+static time_t timestamp[2];
 
 int lwm2m_init_light_sensor(void)
 {

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_location.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_location.c
@@ -25,7 +25,7 @@ static time_t gnss_mktime(struct nrf_modem_gnss_datetime *date)
 		.tm_min = date->minute,
 		.tm_hour = date->hour,
 		.tm_mday = date->day,
-		.tm_mon = date->month,
+		.tm_mon = date->month - 1,
 		.tm_year = date->year - 1900
 	};
 	return timeutil_timegm(&tm);
@@ -41,7 +41,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		double altitude = event->pvt.altitude;
 		double speed = event->pvt.speed;
 		double radius = event->pvt.accuracy;
-		uint32_t timestamp = gnss_mktime(&event->pvt.datetime);
+		time_t timestamp = gnss_mktime(&event->pvt.datetime);
 
 		lwm2m_engine_set_float(LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0, LATITUDE_RID),
 				       &latitude);
@@ -53,7 +53,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 			LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0, LOCATION_RADIUS_RID), &radius);
 		lwm2m_engine_set_float(
 			LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0, LOCATION_SPEED_RID), &speed);
-		lwm2m_engine_set_u32(LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0,
+		lwm2m_engine_set_time(LWM2M_PATH(LWM2M_OBJECT_LOCATION_ID, 0,
 						LOCATION_TIMESTAMP_RID),
 				     timestamp);
 

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_onoff_switch.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_onoff_switch.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 #define SWITCH2_OBJ_INST_ID 1
 #define SWITCH2_APP_NAME "On/Off Switch 2"
 
-static int32_t lwm2m_timestamp[2];
+static time_t lwm2m_timestamp[2];
 
 int lwm2m_init_onoff_switch(void)
 {

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_press_sensor.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_press_sensor.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 
 #define PRESS_UNIT "kPa"
 
-static int32_t timestamp;
+static time_t timestamp;
 
 int lwm2m_init_press_sensor(void)
 {

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_push_button.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_push_button.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 #define BUTTON2_OBJ_INST_ID 1
 #define BUTTON2_APP_NAME "Push button 2"
 
-static int32_t lwm2m_timestamp[2];
+static time_t lwm2m_timestamp[2];
 
 int lwm2m_init_push_button(void)
 {

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_temp_sensor.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_temp_sensor.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_APP_LOG_LEVEL);
 
 #define TEMP_UNIT "°C"
 
-static int32_t timestamp;
+static time_t timestamp;
 
 int lwm2m_init_temp_sensor(void)
 {


### PR DESCRIPTION
Use time_t instead of 32-bit time in location object timestamp and the IPSO objects.