### PR TITLE
manifest: Bring nrfxlib with Kconfig fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: v2.2.0
+      revision: bebb88e59655efb172b295a77d5a1eb62dc4552e
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Fixes issues in nrf_security related to the
configuration MBEDTLS_MAC_MD5_ENABLED.

Ref: NCSDK-17995

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>