### PR TITLE
net: lib: download_client: increase thread default stack size

### DIFF
--- a/samples/nrf9160/gnss/overlay-pgps.conf
+++ b/samples/nrf9160/gnss/overlay-pgps.conf
@@ -28,6 +28,3 @@ CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
 # P-GPS needs more heap
 CONFIG_HEAP_MEM_POOL_SIZE=8192
-
-# Download client library stack size needs to be increased with P-GPS
-CONFIG_DOWNLOAD_CLIENT_STACK_SIZE=1280

--- a/samples/nrf9160/modem_shell/overlay-pgps.conf
+++ b/samples/nrf9160/modem_shell/overlay-pgps.conf
@@ -23,9 +23,6 @@ CONFIG_MPU_ALLOW_FLASH_WRITE=y
 # Library that maintains the current date and UTC time
 CONFIG_DATE_TIME=y
 
-# Download client library stack size needs to be increased with P-GPS
-CONFIG_DOWNLOAD_CLIENT_STACK_SIZE=1280
-
 # Disable other features to make the application fit onto flash
 CONFIG_MOSH_IPERF3=n
 CONFIG_MOSH_CURL=n

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -94,7 +94,7 @@ comment "Thread and stack buffers"
 config DOWNLOAD_CLIENT_STACK_SIZE
 	int "Thread stack size"
 	range 768 4096
-	default 1024
+	default 1280
 
 config DOWNLOAD_CLIENT_MAX_HOSTNAME_SIZE
 	int "Maximum hostname length (stack)"


### PR DESCRIPTION
Increased thread default stack size because the previous value was not enough anymore and `modem_shell` nightly tests started crashing.