### PR TITLE
doc improvement: Using nRF Cloud UG: adding link to a script and related doc

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -775,6 +775,10 @@
 .. _`nRF Cloud Location Services`: https://api.nrfcloud.com/v1#tag/Location-Services
 .. _`nRF Cloud RegisterPublicKeys Endpoint`: https://api.nrfcloud.com/v1/#operation/RegisterPublicKeys
 
+.. _`device_credentials_installer.py`: https://github.com/nRFCloud/utils/blob/master/python/modem-firmware-1.3%2B/device_credentials_installer.py
+.. _`nrf_cloud_provision.py`: https://github.com/nRFCloud/utils/blob/master/python/modem-firmware-1.3%2B/README.md#nrf-cloud-device-provisioning
+.. _`nRF Cloud Utilities documentation`: https://github.com/nRFCloud/utils/blob/master/python/modem-firmware-1.3%2B/README.md
+
 .. ### Source: zigbeealliance.org & csa-iot.org
 
 .. _`Zigbee Alliance`:

--- a/doc/nrf/ug_nrf_cloud.rst
+++ b/doc/nrf/ug_nrf_cloud.rst
@@ -87,12 +87,17 @@ A device can successfully connect to `nRF Cloud`_ using MQTT if the following re
 
 * Preconnect provisioning
 
-  Run the  :file:`device_credentials_installer.py` Python script.
-  You need to specify a number of parameters including the device ID.
+  1. Run the `device_credentials_installer.py`_ Python script to create and install credentials on the device:
 
-  The script instructs the device to securely generate and store a private key, which never leaves the device.
-  It programs  the specified CA certificate into the device.
-  The private key never leaves the device, which makes this a more secure option.
+     * You need to specify a number of parameters including the device ID.
+     * The script instructs the device to securely generate and store a private key.
+     * The private key never leaves the device, which makes this a more secure option.
+     * It creates a device certificate and signs it with the specified CA.
+     * It writes the device certificate and AWS CA certificate to the device.
+
+  #. Run the `nrf_cloud_provision.py`_ script to provision and associate the device with your nRF Cloud account.
+
+  For more details about the scripts, refer to the `nRF Cloud Utilities documentation`_.
 
   See `Securely generating credentials on the nRF9160`_  and `nRF Cloud Provisioning`_ for more details.
 


### PR DESCRIPTION
The document mentions an nRF Cloud utility script but was lacking a link to it. Added a link to it and related documentation.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>