### PR TITLE
manifest: update MCUboot revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -107,7 +107,7 @@ manifest:
       revision: 5ee5972d527ede375f982fcedaeea26f2fb03f10
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: a343542d83ee5b4085d669732b37177b66379ad2
+      revision: 2da20eb0f92974ce1dbcc700a25c43dcddc72b29
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Updated the MCUboot revision to move the Thingy:53 board configuration from being hosted upstream to downstream.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>