### PR TITLE
lib: nrf_modem: trace: fix typo in log message

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_lib_trace.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib_trace.c
@@ -256,7 +256,7 @@ static int trace_init(void)
 		return err;
 	}
 
-	LOG_INF("Trace tread ready");
+	LOG_INF("Trace thread ready");
 	k_sem_give(&trace_sem);
 
 #if CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE


### PR DESCRIPTION
Add a missing 'h' in one of the log messages.

Signed-off-by: Didrik Rokhaug <didrik.rokhaug@gmail.com>