### PR TITLE
dfu: dfu_target: Reset a properly downloaded image on dfu_target_reset()

### DIFF
--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -42,6 +42,7 @@ struct dfu_target {
 	int (*write)(const void *const buf, size_t len);
 	int (*done)(bool successful);
 	int (*schedule_update)(int img_num);
+	int (*reset)();
 };
 
 /**
@@ -104,7 +105,7 @@ int dfu_target_offset_get(size_t *offset);
 int dfu_target_write(const void *const buf, size_t len);
 
 /**
- * @brief Deinitialize the resources that were needed for the current DFU
+ * @brief Release the resources that were needed for the current DFU
  *	  target.
  *
  * @param[in] successful Indicate whether the process completed successfully or
@@ -116,7 +117,7 @@ int dfu_target_write(const void *const buf, size_t len);
 int dfu_target_done(bool successful);
 
 /**
- * @brief Deinitialize the resources that were needed for the current DFU
+ * @brief Release the resources that were needed for the current DFU
  *	  target if any and resets the current DFU target.
  *
  * @return 0 for an successful deinitialization and reset or a negative error

--- a/include/dfu/dfu_target_full_modem.h
+++ b/include/dfu/dfu_target_full_modem.h
@@ -99,7 +99,7 @@ int dfu_target_full_modem_offset_get(size_t *offset);
 int dfu_target_full_modem_write(const void *const buf, size_t len);
 
 /**
- * @brief De-initialize resources and finalize firmware upgrade if successful.
+ * @brief Release resources and finalize firmware upgrade if successful.
 
  * @param[in] successful Indicate whether the firmware was successfully
  *            received.
@@ -118,6 +118,15 @@ int dfu_target_full_modem_done(bool successful);
  * @return 0, it is always successful.
  **/
 int dfu_target_full_modem_schedule_update(int img_num);
+
+/**
+ * @brief Release resources and erase the download area.
+ *
+ * Cancel any ongoing updates.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int dfu_target_full_modem_reset(void);
 
 #endif /* DFU_TARGET_FULL_MODEM_H__ */
 

--- a/include/dfu/dfu_target_mcuboot.h
+++ b/include/dfu/dfu_target_mcuboot.h
@@ -88,6 +88,16 @@ int dfu_target_mcuboot_done(bool successful);
  **/
 int dfu_target_mcuboot_schedule_update(int img_num);
 
+/**
+ * @brief Release resources and erase the download area.
+ *
+ * Cancels any ongoing updates.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int dfu_target_mcuboot_reset(void);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dfu/dfu_target_modem_delta.h
+++ b/include/dfu/dfu_target_modem_delta.h
@@ -81,6 +81,15 @@ int dfu_target_modem_delta_done(bool successful);
  **/
 int dfu_target_modem_delta_schedule_update(int img_num);
 
+/**
+ * @brief Release resources and erase the download area.
+ *
+ * Cancels any ongoing updates.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int dfu_target_modem_delta_reset(void);
+
 #endif /* DFU_TARGET_MODEM_H__ */
 
 /**@} */

--- a/include/dfu/dfu_target_stream.h
+++ b/include/dfu/dfu_target_stream.h
@@ -90,7 +90,7 @@ int dfu_target_stream_offset_get(size_t *offset);
 int dfu_target_stream_write(const uint8_t *buf, size_t len);
 
 /**
- * @brief De-initialize resources and finalize stream flash write if successful.
+ * @brief Release resources and finalize stream flash write if successful.
 
  * @param[in] successful Indicate whether the firmware was successfully
  * received.
@@ -98,6 +98,15 @@ int dfu_target_stream_write(const uint8_t *buf, size_t len);
  * @return Non-negative value on success, negative errno otherwise.
  */
 int dfu_target_stream_done(bool successful);
+
+/**
+ * @brief Release resources and erase the download area.
+ *
+ * Cancels any ongoing updates.
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int dfu_target_stream_reset(void);
 
 #endif /* DFU_TARGET_STREAM_H__ */
 

--- a/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_full_modem.c
@@ -48,8 +48,7 @@ int dfu_target_full_modem_cfg(const struct dfu_target_full_modem_params *params)
 	return 0;
 }
 
-int dfu_target_full_modem_init(size_t file_size, int img_num,
-			       dfu_target_callback_t callback)
+int dfu_target_full_modem_init(size_t file_size, int img_num, dfu_target_callback_t callback)
 {
 	if (!configured) {
 		return -EPERM;
@@ -60,17 +59,27 @@ int dfu_target_full_modem_init(size_t file_size, int img_num,
 
 int dfu_target_full_modem_offset_get(size_t *out)
 {
+	if (!configured) {
+		return -EPERM;
+	}
+
 	return dfu_target_stream_offset_get(out);
 }
 
 int dfu_target_full_modem_write(const void *const buf, size_t len)
 {
+	if (!configured) {
+		return -EPERM;
+	}
+
 	return dfu_target_stream_write(buf, len);
 }
 
 int dfu_target_full_modem_done(bool successful)
 {
-	configured = false;
+	if (!configured) {
+		return -EPERM;
+	}
 
 	if (successful) {
 		LOG_INF("Modem firmware downloaded to flash device");
@@ -83,5 +92,17 @@ int dfu_target_full_modem_schedule_update(int img_num)
 {
 	ARG_UNUSED(img_num);
 
+	if (!configured) {
+		return -EPERM;
+	}
+
 	return 0;
+}
+
+int dfu_target_full_modem_reset(void)
+{
+	if (!configured) {
+		return -EPERM;
+	}
+	return dfu_target_stream_reset();
 }

--- a/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_mcuboot.c
@@ -230,3 +230,9 @@ int dfu_target_mcuboot_schedule_update(int img_num)
 
 	return err;
 }
+
+int dfu_target_mcuboot_reset(void)
+{
+	stream_buf_bytes = 0;
+	return dfu_target_stream_reset();
+}

--- a/subsys/dfu/dfu_target/src/dfu_target_stream.c
+++ b/subsys/dfu/dfu_target/src/dfu_target_stream.c
@@ -216,3 +216,19 @@ int dfu_target_stream_done(bool successful)
 
 	return err;
 }
+
+int dfu_target_stream_reset(void)
+{
+	int ret;
+
+	stream.buf_bytes = 0;
+	stream.bytes_written = 0;
+
+	/* Erase just the first page. Stream write will take care of erasing remaining pages
+	 * on a next buffered_write round
+	 */
+	ret = stream_flash_erase_page(&stream, stream.offset);
+
+	current_id = NULL;
+	return ret;
+}


### PR DESCRIPTION
There is now three ways to end the DFU flashing process:
* Mark the download as aborted. This is done by calling dfu_target_done(false). Continuing is possible at later time.
* Mark the downloaded image succesfull by calling dfu_target_done(true)
* Cancels or rejects existing image by calling dfu_target_reset()

Previously the cancellation was not actually implemented and it only marked the image download as aborted. So effectively there was no way to prevent flashing of a image that had been downloaded and scheduled to be updated. Now reset() will erase the area, or at least first sector, which prevents the update and allows new image to be downloaded.

