### PR TITLE
DNM Fix zephyr sdk 0.15.1 issues

### DIFF
--- a/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_cmd_mode_uart.c
+++ b/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_cmd_mode_uart.c
@@ -2096,9 +2096,10 @@ static void cmd_uart_l_tx_process_ack(ptt_evt_id_t evt_id)
 	struct ptt_evt_data_s *data = ptt_event_get_data(evt_id);
 
 	assert(data != NULL);
+	assert(data->arr != NULL);
 
 	/* if ACK is not NULL */
-	if ((data->arr != NULL) && (data->len != 0)) {
+	if (data->len != 0) {
 		struct ptt_evt_ctx_data_s *ctx_data = ptt_event_get_ctx_data(uart_cmd_evt);
 
 		assert(ctx_data != NULL);

--- a/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
+++ b/subsys/zigbee/lib/zigbee_fota/src/zigbee_fota.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(zigbee_fota, CONFIG_ZIGBEE_FOTA_LOG_LEVEL);
 #define MANDATORY_HEADER_LEN   sizeof(zb_zcl_ota_upgrade_file_header_t)
 #define OPTIONAL_HEADER_LEN    sizeof(zb_zcl_ota_upgrade_file_header_optional_t)
 #define TOTAL_HEADER_LEN       (MANDATORY_HEADER_LEN + OPTIONAL_HEADER_LEN)
-#define SUBELEMENT_HEADER_SIZE 6
+#define SUBELEMENT_HEADER_SIZE sizeof(zb_zcl_ota_upgrade_sub_element_hdr_t)
 
 struct zb_ota_dfu_context {
 	uint32_t        ota_header_size;
@@ -240,8 +240,8 @@ static zb_uint8_t ota_process_subelement_header(zb_uint8_t *data, uint32_t len,
 	ota_ctx.ota_subelement_fill_level += *bytes_copied;
 
 	if (ota_ctx.ota_subelement_fill_level == SUBELEMENT_HEADER_SIZE) {
-		zb_zcl_ota_upgrade_sub_element_t *hdr =
-			(zb_zcl_ota_upgrade_sub_element_t *)header_buf;
+		zb_zcl_ota_upgrade_sub_element_hdr_t *hdr =
+			(zb_zcl_ota_upgrade_sub_element_hdr_t *)header_buf;
 		int err = 0;
 
 		LOG_INF("Subelement header received.");

--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 72a1dc2669632cf9dc98c2313ce6cdae02ffde3a
+      revision: pull/868/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Do not merge.
This PR combines changes from following PRs.

It is opened to verify if sdk-nrf test suite passes on zephyr-sdk:0.15.1