### PR TITLE
applications: nrf_desktop: Add app auth cbs if using Fast Pair

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.ble_passkey
+++ b/applications/nrf_desktop/src/modules/Kconfig.ble_passkey
@@ -7,9 +7,14 @@
 menuconfig DESKTOP_BLE_ENABLE_PASSKEY
 	bool "Bluetooth LE passkey module"
 	depends on !DESKTOP_PASSKEY_NONE
+	depends on !BT_FAST_PAIR
 	depends on BT_PERIPHERAL
 	help
 	  Enable passkey based pairing for increased security.
+
+	  The feature should not be used together with Fast Pair,
+	  because Fast Pair currently does not support devices that
+	  use screen or keyboard for Bluetooth authentication.
 
 if DESKTOP_BLE_ENABLE_PASSKEY
 

--- a/applications/nrf_desktop/src/modules/Kconfig.fast_pair
+++ b/applications/nrf_desktop/src/modules/Kconfig.fast_pair
@@ -15,6 +15,14 @@ menuconfig DESKTOP_FAST_PAIR
 
 if DESKTOP_FAST_PAIR
 
+config DESKTOP_FAST_PAIR_LIMIT_NORMAL_PAIRING
+	bool "Allow normal Bluetooth pairing only in pairing mode"
+	default y
+	help
+	  Register Bluetooth authentication callbacks and reject normal
+	  Bluetooth pairing when outside of pairing mode (if the used Bluetooth
+	  local identity already has a bonded peer).
+
 config DESKTOP_FAST_PAIR_MAX_LOCAL_ID_BONDS
 	int
 	default CAF_BLE_STATE_MAX_LOCAL_ID_BONDS

--- a/applications/nrf_desktop/src/modules/fast_pair.c
+++ b/applications/nrf_desktop/src/modules/fast_pair.c
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <zephyr/bluetooth/conn.h>
 #include <bluetooth/adv_prov/fast_pair.h>
 
-#define MODULE nrf_desktop_fast_pair
+#define MODULE fast_pair_app
 #include <caf/events/module_state_event.h>
 #include <caf/events/ble_common_event.h>
 
@@ -23,7 +24,7 @@ static void bond_cnt_cb(const struct bt_bond_info *info, void *user_data)
 	(*cnt)++;
 }
 
-static inline size_t bond_cnt(uint8_t local_id)
+static size_t bond_cnt(uint8_t local_id)
 {
 	size_t cnt = 0;
 
@@ -32,18 +33,99 @@ static inline size_t bond_cnt(uint8_t local_id)
 	return cnt;
 }
 
-static inline bool can_pair(uint8_t bt_local_id)
+static bool can_pair(uint8_t bt_local_id)
 {
 	return (bond_cnt(bt_local_id) < CONFIG_DESKTOP_FAST_PAIR_MAX_LOCAL_ID_BONDS);
 }
 
-static inline void update_fast_pair_ui_indication(void)
+static bool in_pairing_mode(uint8_t bt_local_id)
+{
+	/* Implementation assumes that given local identity advertises in pairing mode until
+	 * it has a bonded peer.
+	 */
+	return (bond_cnt(bt_local_id) == 0);
+}
+
+static void update_fast_pair_ui_indication(void)
 {
 	bool show_ui_pairing = can_pair(local_id);
 
 	bt_le_adv_prov_fast_pair_show_ui_pairing(show_ui_pairing);
-	LOG_INF("%s Fast Pair not discoverable advertising UI indication",
-		(show_ui_pairing) ? ("Show") : ("Hide"));
+
+	if (in_pairing_mode(local_id)) {
+		LOG_INF("Fast Pair discoverable advertising");
+	} else {
+		LOG_INF("%s Fast Pair not discoverable advertising UI indication",
+			(show_ui_pairing) ? ("Show") : ("Hide"));
+	}
+}
+
+static enum bt_security_err pairing_accept(struct bt_conn *conn,
+					   const struct bt_conn_pairing_feat *const feat)
+{
+	ARG_UNUSED(feat);
+
+	enum bt_security_err ret;
+	struct bt_conn_info info;
+	int err = bt_conn_get_info(conn, &info);
+
+	if (err) {
+		LOG_ERR("Cannot get conn info (err %d)", err);
+		return BT_SECURITY_ERR_UNSPECIFIED;
+	}
+
+	if (in_pairing_mode(info.id)) {
+		LOG_INF("Accept normal Bluetooth pairing");
+		ret = BT_SECURITY_ERR_SUCCESS;
+	} else {
+		LOG_WRN("Normal Bluetooth pairing not allowed outside of pairing mode");
+		ret = BT_SECURITY_ERR_PAIR_NOT_ALLOWED;
+	}
+
+	return ret;
+}
+
+static int register_app_auth_cbs(void)
+{
+	if (!IS_ENABLED(CONFIG_DESKTOP_FAST_PAIR_LIMIT_NORMAL_PAIRING)) {
+		return 0;
+	}
+
+	/* If the peer follows the Fast Pair pairing flow, the Fast Pair service overlays the
+	 * Bluetooth authentication callbacks and takes over Bluetooth pairing. This allows the
+	 * service to perform all of the required operations without interacting with the
+	 * application.
+	 */
+	static const struct bt_conn_auth_cb conn_auth_callbacks = {
+		.pairing_accept = pairing_accept,
+	};
+
+	return bt_conn_auth_cb_register(&conn_auth_callbacks);
+}
+
+static bool handle_module_state_event(const struct module_state_event *event)
+{
+	if (check_state(event, MODULE_ID(main), MODULE_STATE_READY)) {
+		int err = register_app_auth_cbs();
+
+		if (!err) {
+			module_set_state(MODULE_STATE_READY);
+		} else {
+			LOG_ERR("Cannot register authentication callbacks (err %d)", err);
+			module_set_state(MODULE_STATE_ERROR);
+		}
+	}
+
+	return false;
+}
+
+static bool handle_ble_peer_event(const struct ble_peer_event *event)
+{
+	if (event->state == PEER_STATE_DISCONNECTED) {
+		update_fast_pair_ui_indication();
+	}
+
+	return false;
 }
 
 static bool handle_ble_peer_operation_event(const struct ble_peer_operation_event *event)
@@ -63,17 +145,12 @@ static bool handle_ble_peer_operation_event(const struct ble_peer_operation_even
 	return false;
 }
 
-static bool handle_ble_peer_event(const struct ble_peer_event *event)
-{
-	if (event->state == PEER_STATE_DISCONNECTED) {
-		update_fast_pair_ui_indication();
-	}
-
-	return false;
-}
-
 static bool app_event_handler(const struct app_event_header *aeh)
 {
+	if (is_module_state_event(aeh)) {
+		return handle_module_state_event(cast_module_state_event(aeh));
+	}
+
 	if (is_ble_peer_event(aeh)) {
 		return handle_ble_peer_event(cast_ble_peer_event(aeh));
 	}
@@ -89,5 +166,6 @@ static bool app_event_handler(const struct app_event_header *aeh)
 }
 
 APP_EVENT_LISTENER(MODULE, app_event_handler);
+APP_EVENT_SUBSCRIBE(MODULE, module_state_event);
 APP_EVENT_SUBSCRIBE_EARLY(MODULE, ble_peer_event);
 APP_EVENT_SUBSCRIBE_EARLY(MODULE, ble_peer_operation_event);


### PR DESCRIPTION
Change introduces application's Bluetooth authentication callbacks. The callbacks are used to reject pairing if not in pairing mode.

Jira: NCSDK-17784