### PR TITLE
doc: using zephyr module_file custom role

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "ncs_cache",
     "zephyr.external_content",
     "zephyr.doxyrunner",
+    "zephyr.link-roles",
     "sphinx_tabs.tabs",
     "software_maturity_table",
     "sphinx_togglebutton",
@@ -150,6 +151,11 @@ html_redirect_pages = [
 # -- Options for zephyr.warnings_filter ----------------------------------------
 
 warnings_filter_config = str(NRF_BASE / "doc" / "nrf" / "known-warnings.txt")
+
+# Options for zephyr.link-roles ------------------------------------------------
+
+link_roles_manifest_project = "nrf"
+link_roles_manifest_baseurl = "https://github.com/nrfconnect/sdk-nrf"
 
 # Options for external_content -------------------------------------------------
 

--- a/doc/nrf/libraries/networking/azure_iot_hub.rst
+++ b/doc/nrf/libraries/networking/azure_iot_hub.rst
@@ -18,7 +18,7 @@ The library also has integrated support for a proprietary FOTA solution.
 For more information on Azure FOTA, see the documentation on :ref:`lib_azure_fota` library and :ref:`azure_fota_sample` sample.
 
 The library uses `Azure SDK for Embedded C`_ for message processing and other operations.
-For more information on how Azure SDK for Embedded C is integrated in this library, see `Azure SDK for Embedded C IoT client libraries`_.
+For more information on how Azure SDK for Embedded C is integrated in this library, see :module_file:`Azure SDK for Embedded C IoT client libraries<azure-sdk-for-c: sdk/docs/iot/README.md>`.
 
 .. important::
    If the server sends a device-bound message when the device is unavailable for a period of time, for instance while in LTE Power Saving Mode, the server will most likely terminate the TCP connection.


### PR DESCRIPTION
Adds the extension link-roles from zephyr to introduce the custom role `:module_file:` which can link to files within modules.

it uses the following syntax:
```:module_file:`module: path/to/file.txt` ```
or
```:module_file:`my link text <module: path/to/file.txt` ```

Example of use:

```:module_file:`check out the README <azure-sdk-for-c: sdk/docs/iot/README.md>` ```