### PR TITLE
scripts: west_commands: add ncs-change commnand

### DIFF
--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -11,6 +11,9 @@ west-commands:
       - name: ncs-upmerger
         class: NcsUpmerger
         help: perform upmerge for project (e.g. Zephyr)
+      - name: ncs-change
+        class: NcsChange
+        help: change project details in the manifest
   - file: scripts/west_commands/sbom/ncs_sbom_command.py
     commands:
       - name: ncs-sbom

--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -552,6 +552,66 @@ class NcsUpmerger(NcsWestCommand):
         project.git('merge --no-edit ' + str(self.zephyr_rev))
 
 
+class NcsChange(NcsWestCommand):
+    def __init__(self):
+        super().__init__(
+            'ncs-change',
+            'change project details in the manifest',
+            'Change project config in west.yml.')
+
+    def do_add_parser(self, parser_adder):
+        parser = parser_adder.add_parser(
+            self.name,
+            help=self.help, 
+            description=self.description
+        )
+
+        parser.add_argument('name',
+                            help="name of the updated project")
+        parser.add_argument("--revision",
+                            help="what revision to use")
+        parser.add_argument("--path",
+                            help="what path to use")
+        parser.add_argument("--url",
+                            help="what url to use")
+
+        return parser
+
+    def do_run(self, args, unknown_args):
+
+        manifest = Manifest.from_file(import_flags=ImportFlag.IGNORE_PROJECTS)
+        m = ruamel.yaml.YAML()
+        m.indent(mapping=2, sequence=4, offset=2)
+        m.preserve_quotes = True
+
+        with open(manifest.path, "r") as fh:
+            x = m.load(fh.read())
+            project_found = False
+            for p in x["manifest"]["projects"]:
+                if p["name"] == args.name:
+                    project_found = True
+                    if args.revision:
+                        self.inf(f'Revision of project {p["name"]} changed:\n'
+                                 f'  Old: {p["revision"]}\n'
+                                 f'  New: {args.revision}')
+                        p["revision"] = args.revision
+                    if args.path:
+                        self.inf(f'Path of project {p["name"]} changed:\n'
+                                 f'  Old: {p["path"]}\n'
+                                 f'  New: {args.path}')
+                        p["path"] = args.path
+                    if args.url:
+                        self.inf(f'Url of project {p["name"]} changed:\n'
+                                 f'  Old: {p["url"]}\n'
+                                 f'  New: {args.url}')
+                        p["url"] = args.url
+
+            if not project_found:
+                self.wrn(f'Project {args.name} not found')
+
+        with open(manifest.path, "w") as fh:
+            m.dump(x, fh)
+
 def _name_and_path(project):
     # This is just a compatibility shim to keep things going until we
     # can rely on project.name_and_path's availability in west 0.7.


### PR DESCRIPTION
Add command to change project details in the manifest.
Example of usage:

Change revision for openthread project:
west change  --revision 36b2ac9fd02988319e9dcebc578d8f9a9f5ff892 openthread 

Change path for openthread project:
west change --path modules/lib/openthread openthread 

Signed-off-by: Mariusz Poslinski <mariusz.poslinski@nordicsemi.no>