### PR TITLE
lib: location: Improve LTE-GNSS interworking and GNSS priority mode

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -520,6 +520,7 @@ Modem libraries
 
   * Added:
     * MQTT support for nRF Cloud Wi-Fi positioning.
+    * Improved LTE - GNSS interworking and added possibility to trigger GNSS priority mode if GNSS does not get long enough time windows due to LTE idle mode operations.
 
 * :ref:`lte_lc_readme` library:
 

--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -267,6 +267,24 @@ struct location_gnss_config {
 	 * @note Only supported with modem firmware v1.3.2 or later.
 	 */
 	bool visibility_detection;
+
+	/**
+	 * @brief Enable GNSS priority mode if GNSS does not get enough runtime due to LTE idle mode
+	 * operations.
+	 *
+	 * @details If set to true, the library triggers GNSS priority mode if five consecutive PVT
+	 * messages indicate that GNSS is blocked by LTE idle mode operations. This is especially
+	 * helpful if A-GPS or P-GPS is not enabled or downloading assistance data fails and GNSS
+	 * module has to decode navigation data from the satellite broadcast. Priority mode is
+	 * disabled automatically after the first fix or after 40 seconds.
+	 *
+	 * If the device attempts to send data during the priority mode, it will be buffered and
+	 * sent after the priority time window ends. In case of mobile terminated data reception
+	 * during the priority mode the network will typically buffer the data and sent them to the
+	 * device once the priority time window ends. However, it is possible that the network drops
+	 * the data, or some protocol timer expires causing data transfer to fail.
+	 */
+	bool priority_mode;
 };
 
 /** LTE cellular positioning configuration. */

--- a/lib/location/location.c
+++ b/lib/location/location.c
@@ -132,6 +132,7 @@ static void location_config_method_defaults_set(
 		method->gnss.accuracy = LOCATION_ACCURACY_NORMAL;
 		method->gnss.num_consecutive_fixes = 3;
 		method->gnss.visibility_detection = false;
+		method->gnss.priority_mode = false;
 	} else if (method_type == LOCATION_METHOD_CELLULAR) {
 		method->cellular.timeout = 30 * MSEC_PER_SEC;
 		method->cellular.service = LOCATION_SERVICE_ANY;

--- a/samples/nrf9160/modem_shell/src/location/location_shell.c
+++ b/samples/nrf9160/modem_shell/src/location/location_shell.c
@@ -58,7 +58,7 @@ static const char location_get_usage_str[] =
 	"[--timeout <msecs>] [--interval <secs>]\n"
 	"[--gnss_accuracy <acc>] [--gnss_num_fixes <number of fixes>]\n"
 	"[--gnss_timeout <timeout in msecs>] [--gnss_visibility]\n"
-	"[--gnss_cloud_nmea] [--gnss_cloud_pvt]\n"
+	"[--gnss_priority] [--gnss_cloud_nmea] [--gnss_cloud_pvt]\n"
 	"[--cellular_timeout <timeout in msecs>] [--cellular_service <service_string>]\n"
 	"[--wifi_timeout <timeout in msecs>] [--wifi_service <service_string>]\n"
 	"Options:\n"
@@ -75,6 +75,7 @@ static const char location_get_usage_str[] =
 	"                      set to 'high', default: 3)\n"
 	"  --gnss_timeout,     GNSS timeout in milliseconds. Zero means timeout is disabled.\n"
 	"  --gnss_visibility,  Enables GNSS obstructed visibility detection\n"
+	"  --gnss_priority,    Enables GNSS priority mode\n"
 	"  --gnss_cloud_nmea,  Send acquired GNSS location to nRF Cloud formatted as NMEA\n"
 	"  --gnss_cloud_pvt,   Send acquired GNSS location to nRF Cloud formatted as PVT\n"
 	"  --cellular_timeout, Cellular timeout in milliseconds. Zero means timeout is disabled.\n"
@@ -94,6 +95,7 @@ enum {
 	LOCATION_SHELL_OPT_GNSS_TIMEOUT,
 	LOCATION_SHELL_OPT_GNSS_NUM_FIXES,
 	LOCATION_SHELL_OPT_GNSS_VISIBILITY,
+	LOCATION_SHELL_OPT_GNSS_PRIORITY_MODE,
 	LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_NMEA,
 	LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_PVT,
 	LOCATION_SHELL_OPT_CELLULAR_TIMEOUT,
@@ -112,6 +114,7 @@ static struct option long_options[] = {
 	{ "gnss_timeout", required_argument, 0, LOCATION_SHELL_OPT_GNSS_TIMEOUT },
 	{ "gnss_num_fixes", required_argument, 0, LOCATION_SHELL_OPT_GNSS_NUM_FIXES },
 	{ "gnss_visibility", no_argument, 0, LOCATION_SHELL_OPT_GNSS_VISIBILITY },
+	{ "gnss_priority", no_argument, 0, LOCATION_SHELL_OPT_GNSS_PRIORITY_MODE },
 	{ "gnss_cloud_nmea", no_argument, 0, LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_NMEA },
 	{ "gnss_cloud_pvt", no_argument, 0, LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_PVT },
 	{ "cellular_timeout", required_argument, 0, LOCATION_SHELL_OPT_CELLULAR_TIMEOUT },
@@ -345,6 +348,8 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 
 	bool gnss_visibility = false;
 
+	bool gnss_priority_mode = false;
+
 	int cellular_timeout = 0;
 	bool cellular_timeout_set = false;
 	enum location_service cellular_service = LOCATION_SERVICE_ANY;
@@ -470,6 +475,10 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 			gnss_visibility = true;
 			break;
 
+		case LOCATION_SHELL_OPT_GNSS_PRIORITY_MODE:
+			gnss_priority_mode = true;
+			break;
+
 		case LOCATION_SHELL_OPT_MODE:
 			if (strcmp(optarg, "fallback") == 0) {
 				req_mode = LOCATION_REQ_MODE_FALLBACK;
@@ -551,6 +560,7 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 						gnss_num_fixes;
 				}
 				config.methods[i].gnss.visibility_detection = gnss_visibility;
+				config.methods[i].gnss.priority_mode = gnss_priority_mode;
 			} else if (config.methods[i].method == LOCATION_METHOD_CELLULAR) {
 				config.methods[i].cellular.service = cellular_service;
 				if (cellular_timeout_set) {


### PR DESCRIPTION
Added feature to location lib which triggers GNSS priority mode if 5 consecutive PVT events indicate that GNSS is blocked by LTE. This feature is also taken into use in Asset Tracker v2. Moreover, fixed a minor bug that prohibited GNSS from being started in case LTE is enabled, but coverage at startup is so bad that RRC connection establishment is not even attempted.

Signed-off-by: Tuomas Hiltunen <tuomas.hiltunen@nordicsemi.no>