### PR TITLE
changelog: Add changelog entry for DFU reset changes

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -647,6 +647,8 @@ DFU libraries
 
     * Added new types :c:enum:`DFU_TARGET_IMAGE_TYPE_ANY_MODEM` and :c:enum:`DFU_TARGET_IMAGE_TYPE_ANY_APPLICATION`.
       This makes any supported modem update type acceptable when downloading.
+    * Calling the :c:func:`dfu_target_reset()` function clears all images that have already been downloaded into a target area.
+      This allows cancelling any update packages even if they are already marked to be updated.
 
 Scripts
 =======


### PR DESCRIPTION
Code changes are worked on separate PR

https://github.com/nrfconnect/sdk-nrf/pull/9304

Reason for doing separate PR is the constant rebases and rebuilds due to one line changes require significant HW testing time.
This PR will be in conflict once https://github.com/nrfconnect/sdk-nrf/pull/9277 goes in, and I don't want to trigger HW tests bacause of that.
