### PR TITLE
samples: peripheral: 802154_phy_test: fix compilation error

### DIFF
--- a/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_cmd_mode_uart.c
+++ b/samples/peripheral/802154_phy_test/src/ctrl/ptt_zb_perf_cmd_mode_uart.c
@@ -2096,9 +2096,10 @@ static void cmd_uart_l_tx_process_ack(ptt_evt_id_t evt_id)
 	struct ptt_evt_data_s *data = ptt_event_get_data(evt_id);
 
 	assert(data != NULL);
+	assert(data->arr != NULL);
 
 	/* if ACK is not NULL */
-	if ((data->arr != NULL) && (data->len != 0)) {
+	if (data->len != 0) {
 		struct ptt_evt_ctx_data_s *ctx_data = ptt_event_get_ctx_data(uart_cmd_evt);
 
 		assert(ctx_data != NULL);


### PR DESCRIPTION
This commit fixes a compilation error that results from comparing an array to NULL in an `if` condition, which always yields true.

Signed-off-by: Jędrzej Ciupis <jedrzej.ciupis@nordicsemi.no>