### PR TITLE
ci: github workflow: Fix ubuntu version in docs build workflow

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout the code


### PR DESCRIPTION
Github switch ubuntu-latest to 22.04 which made
libclang1-9 and libclang-cpp9 libs failing to install. As a fix Ubuntu version is locked to 20.04

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>