### PR TITLE
tests: tfm: Added cc3xx and oberon crypto backends to test variants

### DIFF
--- a/tests/tfm/tfm_regression_test/testcase.yaml
+++ b/tests/tfm/tfm_regression_test/testcase.yaml
@@ -22,5 +22,18 @@ tests:
     extra_args: CONFIG_TFM_IPC=y CONFIG_TFM_ISOLATION_LEVEL=1
     timeout: 200
 
-  tfm.regression_ipc_lvl2:
+  tfm.regression_ipc_lvl2.mbedtls_builtin:
+    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+    timeout: 200
+
+  tfm.regression_ipc_lvl2.cc3xx:
+    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+    timeout: 200
+
+  tfm.regression_ipc_lvl2.oberon:
+    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
+    timeout: 200
+
+  tfm.regression_ipc_lvl2.cc3xx_oberon:
+    extra_args: CONFIG_PSA_CRYPTO_DRIVER_CC3XX=y CONFIG_PSA_CRYPTO_DRIVER_OBERON=y
     timeout: 200


### PR DESCRIPTION
- Added both cc3xx and oberon crypto backends to increase test coverage

Ref: NCSDK-17185

Signed-off-by: Magne Værnes <magne.varnes@nordicsemi.no>

test-sdk-nrf: sdk-nrf-PR-9340