### PR TITLE
samples: matter: Added extracing config file name from CONF_FILE

### DIFF
--- a/samples/matter/light_bulb/CMakeLists.txt
+++ b/samples/matter/light_bulb/CMakeLists.txt
@@ -12,7 +12,12 @@ get_filename_component(MATTER_MODULE_ROOT $ENV{ZEPHYR_BASE}/../modules/lib/matte
 set(mcuboot_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.mcuboot.root)
 set(multiprotocol_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root)
 
-if(NOT CONF_FILE STREQUAL "prj_no_dfu.conf")
+# For prj.conf the CONF_FILE is empty. In other case extract the exact file name from the path string.
+if(CONF_FILE)
+    get_filename_component(CONFIG_FILE_NAME ${CONF_FILE} NAME)
+endif()
+
+if(NOT CONFIG_FILE_NAME STREQUAL "prj_no_dfu.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)
 endif()
 

--- a/samples/matter/light_switch/CMakeLists.txt
+++ b/samples/matter/light_switch/CMakeLists.txt
@@ -13,7 +13,12 @@ set(mcuboot_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kco
 set(multiprotocol_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root)
 set(hci_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.root)
 
-if(NOT CONF_FILE STREQUAL "prj_no_dfu.conf")
+# For prj.conf the CONF_FILE is empty. In other case extract the exact file name from the path string.
+if(CONF_FILE)
+    get_filename_component(CONFIG_FILE_NAME ${CONF_FILE} NAME)
+endif()
+
+if(NOT CONFIG_FILE_NAME STREQUAL "prj_no_dfu.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)
 endif()
 

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -13,7 +13,12 @@ set(mcuboot_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kco
 set(multiprotocol_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root)
 set(hci_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.root)
 
-if(NOT CONF_FILE STREQUAL "prj_no_dfu.conf")
+# For prj.conf the CONF_FILE is empty. In other case extract the exact file name from the path string.
+if(CONF_FILE)
+    get_filename_component(CONFIG_FILE_NAME ${CONF_FILE} NAME)
+endif()
+
+if(NOT CONFIG_FILE_NAME STREQUAL "prj_no_dfu.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)
 endif()
 

--- a/samples/matter/template/CMakeLists.txt
+++ b/samples/matter/template/CMakeLists.txt
@@ -13,7 +13,12 @@ set(mcuboot_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kco
 set(multiprotocol_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root)
 set(hci_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.root)
 
-if(NOT CONF_FILE STREQUAL "prj_no_dfu.conf")
+# For prj.conf the CONF_FILE is empty. In other case extract the exact file name from the path string.
+if(CONF_FILE)
+    get_filename_component(CONFIG_FILE_NAME ${CONF_FILE} NAME)
+endif()
+
+if(NOT CONFIG_FILE_NAME STREQUAL "prj_no_dfu.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)
 endif()
 

--- a/samples/matter/window_covering/CMakeLists.txt
+++ b/samples/matter/window_covering/CMakeLists.txt
@@ -12,7 +12,12 @@ get_filename_component(MATTER_MODULE_ROOT $ENV{ZEPHYR_BASE}/../modules/lib/matte
 set(mcuboot_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.mcuboot.root)
 set(multiprotocol_rpmsg_KCONFIG_ROOT ${MATTER_MODULE_ROOT}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root)
 
-if(NOT CONF_FILE STREQUAL "prj_no_dfu.conf")
+# For prj.conf the CONF_FILE is empty. In other case extract the exact file name from the path string.
+if(CONF_FILE)
+    get_filename_component(CONFIG_FILE_NAME ${CONF_FILE} NAME)
+endif()
+
+if(NOT CONFIG_FILE_NAME STREQUAL "prj_no_dfu.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)
 endif()
 


### PR DESCRIPTION
Currently in CMakeLists there is a check that assumes CONF_FILE to be always equal to exact prj.conf file name. However in some cases it can be also absolute path to file on disc and the check will fail.

Added extracting the exact config file name from CONF_FILE value and used it in the check.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>