### PR TITLE
openthread: add experimental TCP support

### DIFF
--- a/doc/_scripts/software_maturity/software_maturity_features.yaml
+++ b/doc/_scripts/software_maturity/software_maturity_features.yaml
@@ -26,6 +26,7 @@ features:
     Thread MTD + Bluetooth LE multiprotocol: OPENTHREAD_MTD && BT
     Thread Radio Co-Processor (RCP): OPENTHREAD_COPROCESSOR && OPENTHREAD_COPROCESSOR_RCP
     Thread + nRF21540 (GPIO): NET_L2_OPENTHREAD && (MPSL_FEM_NRF21540_GPIO_SUPPORT || MPSL_FEM_GENERIC_TWO_CTRL_PINS_SUPPORT)
+    Thread TCP: OPENTHREAD_TCP_ENABLE
   matter:
     Matter over Thread: CHIP && NET_L2_OPENTHREAD
     Matter over Wi-Fi: CHIP_OVER_WIFI

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -86,7 +86,9 @@ The following list summarizes the most important changes inherited from the upst
 Thread
 ------
 
-|no_changes_yet_note|
+* Added:
+
+  * Enabled experimental TCP support as required by Thread 1.3 Specification.
 
 See `Thread samples`_ for the list of changes for the Thread samples.
 

--- a/doc/nrf/ug_thread_supported_features.rst
+++ b/doc/nrf/ug_thread_supported_features.rst
@@ -29,6 +29,7 @@ The OpenThread implementation of the Thread protocol supports all features defin
 * Features introduced with Thread 1.3.0:
 
   * Service Registration Protocol (SRP) client
+  * Transport Control Protocol (TCP)
 
 In |NCS|, you can choose which version of the Thread protocol to use in your application.
 By default, |NCS| supports Thread 1.3, which includes support for Thread 1.2.
@@ -131,7 +132,13 @@ DNS-based Service Discovery
 Thread 1.3 Specification introduces DNS-SD Service Registration Protocol, which lets devices advertise the fact that they provide services while avoiding the use of multicast in the discovery.
 |NCS| provides the required SRP client functionality.
 
+Transport Control Protocol
+==========================
+
+While |NCS| has had TCP support through Zephyr (:ref:`IP stack supported features <zephyr:ip_stack_overview>`), the Thread 1.3 Specification defines a set of parameters and features that make TCP more efficient for the limited IEEE 802.15.4 networks.
+An alternative TCP stack implementation incorporated from the OpenThread project can be enabled by users working on Thread-based TCP applications.
+
 Limitations for Thread 1.3 support
 ==================================
 
-Transport Control Protocol (TCP) as defined by the Thread 1.3 Specification is not currently supported by |NCS|.
+Transport Control Protocol (TCP) as defined by the Thread 1.3 Specification is only supported in experimental mode by |NCS|.

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -91,6 +91,7 @@ The following configuration files are available:
 * :file:`overlay-debug.conf` - Enables debugging the Thread sample with GDB thread awareness.
 * :file:`overlay-ci.conf` - Disables boot banner and shell prompt.
 * :file:`overlay-multiprotocol.conf` - Enables Bluetooth LE support in this sample.
+* :file:`overlay-tcp.conf` - Enables experimental TCP support in this sample.
 
 FEM support
 ===========

--- a/samples/openthread/cli/overlay-tcp.conf
+++ b/samples/openthread/cli/overlay-tcp.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# TCP configuration
+CONFIG_OPENTHREAD_TCP_ENABLE=y
+CONFIG_OPENTHREAD_CLI_TCP_ENABLE=y

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -6,7 +6,7 @@ tests:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
-    extra_args: OVERLAY_CONFIG=overlay-ci.conf;overlay-multiprotocol.conf
+    extra_args: OVERLAY_CONFIG=overlay-ci.conf;overlay-multiprotocol.conf;overlay-tcp.conf
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpuapp_ns
@@ -34,7 +34,7 @@ tests:
     build_only: true
     platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf52840dongle_nrf52840 nrf21540dk_nrf52840
     tags: ci_build
-    extra_args: OVERLAY_CONFIG=overlay-usb.conf;overlay-ci.conf;overlay-multiprotocol.conf
+    extra_args: OVERLAY_CONFIG=overlay-usb.conf;overlay-ci.conf;overlay-multiprotocol.conf;overlay-tcp.conf
                 DTC_OVERLAY_FILE=usb.overlay
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
@@ -44,7 +44,7 @@ tests:
       - nrf21540dk_nrf52840
   # Build integration regression protection.
   sample.nrf_security.openthread.integration:
-      build_only: True
+      build_only: true
       extra_args: CONFIG_NRF_SECURITY=y
       platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840
       integration_platforms:

--- a/subsys/net/openthread/Kconfig.defconfig
+++ b/subsys/net/openthread/Kconfig.defconfig
@@ -195,4 +195,7 @@ endif
 
 endif
 
+config OPENTHREAD_TCP_ENABLE
+	select EXPERIMENTAL
+
 endif


### PR DESCRIPTION
Enable users to use OpenThread TCP implementation.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>