### PR TITLE
esb: subsys: Support direct dynamic interrupts

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -103,7 +103,9 @@ See `Zigbee samples`_ for the list of changes for the Zigbee samples.
 ESB
 ---
 
-|no_changes_yet_note|
+* Added:
+
+  * The :kconfig:option:`CONFIG_ESB_DYNAMIC_INTERRUPTS` Kconfig option to enable direct dynamic interrupts.
 
 nRF IEEE 802.15.4 radio driver
 ------------------------------

--- a/subsys/esb/Kconfig
+++ b/subsys/esb/Kconfig
@@ -80,4 +80,12 @@ endchoice
 
 endmenu
 
+config ESB_DYNAMIC_INTERRUPTS
+	bool "Use direct dynamic interrupts"
+	depends on DYNAMIC_INTERRUPTS && DYNAMIC_DIRECT_INTERRUPTS
+	help
+	  This option configures ESB IRQ handlers using direct dynamic
+	  interrupts. This allows reconfiguring ESB_SYS_TIMER_IRQn, ESB_EVT_IRQ,
+	  and RADIO_IRQn handlers during runtime when ESB is uninitialized.
+
 endif # NRF_ENHANCED_SHOCKBURST


### PR DESCRIPTION
Use direct dynamic interrupts for ESB IRQ handlers when configured.
Allows reconfiguring ESB_SYS_TIMER_IRQn, ESB_EVT_IRQ,
and RADIO_IRQn handlers during runtime when ESB is uninitialized.

Signed-off-by: Sigurd Olav Nevstad <sigurdolav.nevstad@nordicsemi.no>