### PR TITLE
samples: lwm2m_client: check return value

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/modules/sensor_module.c
+++ b/samples/nrf9160/lwm2m_client/src/modules/sensor_module.c
@@ -184,9 +184,14 @@ static int light_sensor_worker(int (*read_cb)(uint32_t *), const char *path, enu
 	char *old_str;
 	uint32_t old;
 	uint32_t new;
+	int ret;
 
 	/* Get latest registered light value */
-	lwm2m_engine_get_res_buf(path, (void **)&old_str, NULL, NULL, NULL);
+	ret = lwm2m_engine_get_res_buf(path, (void **)&old_str, NULL, NULL, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
 	old = strtol(old_str, NULL, 0);
 
 	/* Read sensor, try again later if busy */

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/connmon.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/connmon.c
@@ -15,7 +15,6 @@
 #include <modem/modem_info.h>
 
 #include "stubs.h"
-#include "lwm2m_object.h"
 
 /* LTE-FDD bearer & NB-IoT bearer */
 #define LTE_FDD_BEARER 6U

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/device.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/device.c
@@ -7,7 +7,6 @@
 #include <zephyr/fff.h>
 
 #include <zephyr/kernel.h>
-#include <version.h>
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/net/lwm2m.h>


### PR DESCRIPTION
* Check return value
* Remove unused includes from test code

Issues spotted by Coverity.