### PR TITLE
test-spec: Don't trigger DFU tests on changes to network tests

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -131,8 +131,6 @@
   - "subsys/net/lib/download_client/**/*"
   - "tests/subsys/bootloader/**/*"
   - "tests/subsys/dfu/**/*"
-  - "tests/subsys/fw_info/**/*"
-  - "tests/subsys/net/**/*"
 
 "CI-all-test":
   - "**/*partition_manager*/**/*"


### PR DESCRIPTION
This triggering is unnecessary. Test jobs should only trigger if there is changes to tests them self, or libraries it uses.
