### PR TITLE
manifest: Update to sdk-nrfxlib pr #871

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.mbedtls_minimal.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.mbedtls_minimal.defconfig
@@ -87,19 +87,7 @@ config PSA_WANT_KEY_TYPE_AES
 	bool
 	default n
 
-config PSA_WANT_KEY_TYPE_ARIA
-	bool
-	default n
-
-config PSA_WANT_KEY_TYPE_CAMELLIA
-	bool
-	default n
-
 config PSA_WANT_KEY_TYPE_CHACHA20
-	bool
-	default n
-
-config PSA_WANT_KEY_TYPE_DES
 	bool
 	default n
 

--- a/modules/trusted-firmware-m/Kconfig.psa.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.psa.defconfig
@@ -85,7 +85,7 @@ config PSA_WANT_ALG_CTR
 	default y
 config PSA_WANT_ALG_OFB
 	bool
-	default y
+	default n
 
 # PSA_WANT_ALG_XTS - Currently not supported
 

--- a/modules/trusted-firmware-m/Kconfig.psa.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.psa.defconfig
@@ -11,16 +11,7 @@ config PSA_WANT_KEY_TYPE_HMAC
 config PSA_WANT_KEY_TYPE_AES
 	bool
 	default y
-config PSA_WANT_KEY_TYPE_ARIA
-	bool
-	default y
-config PSA_WANT_KEY_TYPE_CAMELLIA
-	bool
-	default y
 config PSA_WANT_KEY_TYPE_CHACHA20
-	bool
-	default y
-config PSA_WANT_KEY_TYPE_DES
 	bool
 	default y
 config PSA_WANT_KEY_TYPE_ECC_KEY_PAIR

--- a/modules/trusted-firmware-m/Kconfig.psa.defconfig
+++ b/modules/trusted-firmware-m/Kconfig.psa.defconfig
@@ -49,7 +49,7 @@ config PSA_WANT_ALG_HMAC
 	default y
 config PSA_WANT_ALG_SHA_1
 	bool
-	default y
+	default n
 config PSA_WANT_ALG_SHA_224
 	bool
 	default y

--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: pull/819/head
+      revision: pull/871/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bea6b16089ae1abcb1db4c5979c10d0184b696f8
+      revision: pull/956/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -116,7 +116,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: b0df02792c6ec1b20eda697e68bdca3d44ad7050
+      revision: pull/819/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
-Enables nrf_cc3xx for TF-M builds

ref: NCSDK-18152

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>