### PR TITLE
manifest: Update Zephyr revision with networking cherrypicks

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: eb7519d36a0c2819d5d52328751395a9f0234880
+      revision: pull/982/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr revision introducing IPv4 fragmentation and Echo Request length support.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>