### PR TITLE
ci: docbuild: Build docs only if requires

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -6,6 +6,14 @@ on:
     branches:
       - main
       - 'v*-branch'
+    paths:
+      - '.github/workflows/docbuild.yml'
+      - '*.rst'
+      - '**/Kconfig'
+      - 'doc/**'
+      - 'include/**'
+      - 'scripts/requirements-doc.txt'
+      - 'west.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
It is unnecessary to build documentation on PRs where there is no changes to any source files for documentation.
Now build only if:
* There is changes to RST files
* There is changes to doc/ tree
* There is changes to public headers
* There is Kconfig changes
* There is changes to west.yml

