### PR TITLE
Bluetooth: Mesh: Use deferred log for Friendship

### DIFF
--- a/samples/bluetooth/mesh/ble_peripheral_lbs_coex/prj.conf
+++ b/samples/bluetooth/mesh/ble_peripheral_lbs_coex/prj.conf
@@ -5,6 +5,10 @@
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
 
+# Deffered logging helps improve LPN power consumption
+# when friendship is established.
+CONFIG_LOG_MODE_DEFERRED=y
+
 # General configuration
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_FLASH=y

--- a/samples/bluetooth/mesh/chat/prj.conf
+++ b/samples/bluetooth/mesh/chat/prj.conf
@@ -5,6 +5,10 @@
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
 
+# Deffered logging helps improve LPN power consumption
+# when friendship is established.
+CONFIG_LOG_MODE_DEFERRED=y
+
 # General configuration
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_FLASH=y

--- a/samples/bluetooth/mesh/light/prj.conf
+++ b/samples/bluetooth/mesh/light/prj.conf
@@ -5,6 +5,10 @@
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
 
+# Deffered logging helps improve LPN power consumption
+# when friendship is established.
+CONFIG_LOG_MODE_DEFERRED=y
+
 # General configuration
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_FLASH=y

--- a/samples/bluetooth/mesh/light_ctrl/prj.conf
+++ b/samples/bluetooth/mesh/light_ctrl/prj.conf
@@ -5,6 +5,10 @@
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
 
+# Deffered logging helps improve LPN power consumption
+# when friendship is established.
+CONFIG_LOG_MODE_DEFERRED=y
+
 # General configuration
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_FLASH=y

--- a/samples/bluetooth/mesh/light_switch/prj.conf
+++ b/samples/bluetooth/mesh/light_switch/prj.conf
@@ -5,6 +5,10 @@
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
 
+# Deffered logging helps improve LPN power consumption
+# when friendship is established.
+CONFIG_LOG_MODE_DEFERRED=y
+
 # General configuration
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/samples/bluetooth/mesh/sensor_client/prj.conf
+++ b/samples/bluetooth/mesh/sensor_client/prj.conf
@@ -5,6 +5,10 @@
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
 
+# Deffered logging helps improve LPN power consumption
+# when friendship is established.
+CONFIG_LOG_MODE_DEFERRED=y
+
 # General configuration
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/samples/bluetooth/mesh/sensor_server/prj.conf
+++ b/samples/bluetooth/mesh/sensor_server/prj.conf
@@ -5,6 +5,10 @@
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
 
+# Deffered logging helps improve LPN power consumption
+# when friendship is established.
+CONFIG_LOG_MODE_DEFERRED=y
+
 # General configuration
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_FLASH=y

--- a/samples/bluetooth/mesh/silvair_enocean/prj.conf
+++ b/samples/bluetooth/mesh/silvair_enocean/prj.conf
@@ -5,6 +5,10 @@
 #
 CONFIG_NCS_SAMPLES_DEFAULTS=y
 
+# Deffered logging helps improve LPN power consumption
+# when friendship is established.
+CONFIG_LOG_MODE_DEFERRED=y
+
 # General configuration
 CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096


### PR DESCRIPTION
Adds deferred log option to all samples that is configured for friendship. This improves performance while devices is communicating over low power communication channel by avoiding unnecessary delays due to logging events.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>