### PR TITLE
doc: relax pyyaml requirements

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -5,7 +5,7 @@ sphinx-ncs-theme>=1.0.3,<1.1
 m2r2>=0.3.2
 sphinxcontrib-plantuml
 pygit2<=1.10
-pyyaml==5.4.1
+pyyaml
 azure-storage-blob
 sphinx_markdown_tables
 breathe>=4.34


### PR DESCRIPTION
Documentation doesn't need any special version of PyYAML, so do not set any version.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>