### PR TITLE
doc: vsc: rework links after doc reorg

### DIFF
--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -430,7 +430,7 @@ You can install the |nRFVSC| to open and compile projects in the |NCS|.
 
 .. note::
 
-   If you are building the application or sample using SEGGER Embedded Studio IDE or on the command line and want to migrate to |VSC|, follow the instructions in the `migrating from other IDEs to VS Code <Migrating IDE_>`_ documentation.
+   If you are building the application or sample using SEGGER Embedded Studio IDE or on the command line and want to migrate to |VSC|, use the `Add an existing application <Migrating IDE_>`_ option in the |nRFVSC| to migrate your application.
 
 .. vsc_mig_note_end
 

--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -172,7 +172,7 @@ These tools present all available options and allow you to select the ones that 
 
 The nRF Kconfig GUI in the |nRFVSC| organizes the Kconfig options in a hierarchical list and lets you select the desired options.
 To save the changes made using the nRF Kconfig GUI, click the :guilabel:`Save` button.
-Read the `nRF Kconfig`_ documentation for more information.
+Read the `Configuring with nRF Kconfig`_ page in the |nRFVSC| documentation for more information.
 
 See :ref:`zephyr:menuconfig` in the Zephyr documentation for instructions on how to run menuconfig or guiconfig.
 
@@ -194,9 +194,9 @@ See :ref:`zephyr:setting_configuration_values` in the Zephyr documentation for i
    This may result in a bloated configuration compared to changing the setting directly in :file:`prj.conf`.
    See the section Stuck symbols in menuconfig and guiconfig on the :ref:`kconfig_tips_and_tricks` in the Zephyr documentation for more information.
 
-If you work with |VSC|, you can use one of the following options:
+If you work with |nRFVSC|, you can use one of the following options:
 
-* Select an extra Kconfig fragment file when `Building an application`_.
+* Select an extra Kconfig fragment file when you `build an application <How to build an application_>`_.
 * Edit the Kconfig options using the nRF Kconfig GUI and save changes permanently to an existing or new :file:`prj.conf` file.
   See the extension's documentation for more information.
 
@@ -213,7 +213,7 @@ You can provide additional options for building your application to the CMake pr
 These options are specified when CMake is run, thus not during the actual build, but when configuring the build.
 
 If you work with the |nRFVSC|, you can specify project-specific CMake options when you add the build configuration for a new |NCS| project.
-See `Building an application`_ in the |nRFVSC| documentation.
+See `How to build an application`_ in the |nRFVSC| documentation.
 
 If you work on the command line, pass the additional options to the ``west build`` command.
 The options must be added after a ``--`` at the end of the command.
@@ -252,7 +252,7 @@ Selecting a build type in |VSC|
 
 To select the build type in the |nRFVSC|:
 
-1. When `Building an application`_ as described in the |nRFVSC| documentation, follow the steps for setting up the build configuration.
+1. When `building an application <How to build an application_>`_ as described in the |nRFVSC| documentation, follow the steps for setting up the build configuration.
 #. In the **Add Build Configuration** screen, select the desired :file:`.conf` file from the :guilabel:`Configuration` drop-down menu.
 #. Fill in other configuration options, if applicable, and click :guilabel:`Build Configuration`.
 

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -23,7 +23,7 @@ Building with |VSC|
 
 |vsc_extension_instructions|
 
-For instructions specifically for building, see `Building an application`_.
+For instructions specifically for building, see `How to build an application`_.
 If you want to build and program with custom options, read about the advanced `Custom launch and debug configurations`_ and `Application-specific flash options`_.
 
 .. include:: gs_installing.rst

--- a/doc/nrf/gs_testing.rst
+++ b/doc/nrf/gs_testing.rst
@@ -20,8 +20,8 @@ How to connect with |nRFVSC|
 ****************************
 
 The |nRFVSC| is a complete IDE for developing applications for nRF91, nRF53 and nRF52 Series devices.
-The extension pack includes nRF Terminal, which is an integrated serial port and RTT terminal to connect to your board.
-For detailed instructions, see the `nRF Terminal documentation`_ on the `nRF Connect for Visual Studio Code`_ documentation site.
+The extension pack includes an integrated serial port and RTT terminal, which you can use to connect to your board.
+For detailed instructions, see the `How to connect to the terminal`_ section on the `nRF Connect for Visual Studio Code`_ documentation site.
 
 .. note::
 
@@ -126,7 +126,7 @@ To connect to the nRF9160-based kit with LTE Link Monitor, perform the following
 Debugging an application
 ************************
 
-To debug an application, set up the debug session as described in `Debugging an application`_ in the |nRFVSC| documentation.
+To debug an application, set up the debug session as described in the `How to debug an application`_ section in the |nRFVSC| documentation.
 nRF Debug is the default debugger for |nRFVSC|.
 
 If you use a multi-core SoC, for example from the nRF53 Series, and you only wish to debug the application core firmware, a single debug session is sufficient.
@@ -135,7 +135,7 @@ When debugging the network core, the application core debug session runs in the 
 
 Complete the following steps to start debugging the network core:
 
-1. Set up sessions for the application core and network core as mentioned in `Debugging an application`_.
+1. Set up sessions for the application core and network core as mentioned in the `Debugging applications for a multi-core System on Chip`_ section in the |nRFVSC| documentation.
 #. Select the appropriate CPU for debugging in each session, corresponding to the application core and the network core of your SoC, respectively.
 #. Once both sessions are established, execute the code on the application core.
 
@@ -159,7 +159,7 @@ nRF Debug in the |nRFVSC| automatically loads the Trusted Firmware-M debug symbo
 Debug configuration
 ===================
 
-When you are following the `Debugging an application`_ process in the |nRFVSC| and select the :guilabel:`Enable debug options` checkbox in the **Add Build Configuration** page, the following Kconfig options are set to ``y`` when you add the configuration:
+When you are following the `How to debug an application`_ process in the |nRFVSC| and select the :guilabel:`Enable debug options` checkbox in the **Add Build Configuration** page, the following Kconfig options are set to ``y`` when you add the configuration:
 
 * :kconfig:option:`CONFIG_DEBUG_OPTIMIZATIONS` - This option limits the optimizations made by the compiler to only those that do not impact debugging.
 * :kconfig:option:`CONFIG_DEBUG_THREAD_INFO` - This option adds additional information to the thread object, so that the debugger can discover the threads.
@@ -214,7 +214,7 @@ One of such modules is for example Zephyr's :ref:`zephyr:thread_analyzer`.
 Debug tools
 ===========
 
-The main recommended tool for debugging in the |NCS| is `nRF Debug <Debugging an application_>`_ of the |nRFVSC|.
+The main recommended tool for debugging in the |NCS| is `nRF Debug <Debugging applications for a multi-core System on Chip_>`_ of the |nRFVSC|.
 The tool uses `Microsoft's debug adaptor`_ and integrates custom debugging features specific for the |NCS|.
 
 * When working with the |nRFVSC|, use nRF Debug after adding the required Kconfig options to the :file:`prj.conf` file.

--- a/doc/nrf/gs_updating.rst
+++ b/doc/nrf/gs_updating.rst
@@ -25,7 +25,7 @@ Updating in |VSC|
 =================
 
 The |nRFVSC| lets you update the associated |NCS| repositories within the :guilabel:`Source Control View`.
-For detailed instructions, see the `West integration`_ section of the extension's documentation.
+For detailed instructions, see the `west module management`_ page in the extension's documentation.
 
 Updating in Toolchain Manager
 =============================

--- a/doc/nrf/includes/build_and_run.txt
+++ b/doc/nrf/includes/build_and_run.txt
@@ -1,4 +1,4 @@
 This sample can be found under |sample path| in the |NCS| folder structure.
 
-To build the sample with |VSC|, follow the steps listed on the `Building nRF Connect SDK application quick guide`_ page in the |nRFVSC| documentation.
+To build the sample with |VSC|, follow the steps listed on the `How to build an application`_ page in the |nRFVSC| documentation.
 See :ref:`gs_programming` for other building and programming scenarios and :ref:`gs_testing` for general information about testing and debugging in the |NCS|.

--- a/doc/nrf/includes/build_and_run_ns.txt
+++ b/doc/nrf/includes/build_and_run_ns.txt
@@ -4,5 +4,5 @@ When built as firmware image for the ``_ns`` build target, the sample has Cortex
 Because of this, it automatically includes the :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
 To read more about CMSE, see :ref:`app_boards_spe_nspe`.
 
-To build the sample with |VSC|, follow the steps listed on the `Building nRF Connect SDK application quick guide`_ page in the |nRFVSC| documentation.
+To build the sample with |VSC|, follow the steps listed on the `How to build an application`_ page in the |nRFVSC| documentation.
 See :ref:`gs_programming` for other building and programming scenarios and :ref:`gs_testing` for general information about testing and debugging in the |NCS|.

--- a/doc/nrf/includes/vsc_build_and_run.txt
+++ b/doc/nrf/includes/vsc_build_and_run.txt
@@ -2,4 +2,4 @@
 
    If you installed the |NCS| using the :ref:`gs_app_tcm`, you can click the :guilabel:`Open VS Code` button next to the version you installed.
 
-#. Complete the steps listed on the `Building nRF Connect SDK application quick guide`_ page in the |nRFVSC| documentation.
+#. Complete the steps listed on the `How to build an application`_ page in the |nRFVSC| documentation.

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -2615,7 +2615,7 @@ SEGGER Embedded Studio Nordic Edition
 .. note::
     SEGGER Embedded Studio Nordic Edition support has been deprecated with the |NCS| v2.0.0 release.
     |VSC| is now the default IDE for the |NCS|.
-    See the `migrating from other IDEs to VS Code <Migrating IDE_>`_ page in the |VSC| documentation for information about how to migrate.
+    Use the `Add an existing application <Migrating IDE_>`_ option in the |nRFVSC| to migrate your application.
 
 .. rst-class:: v1-4-2 v1-4-1 v1-4-0
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -137,19 +137,17 @@
 .. _`Getting started guide for nRF Asset Tracker for Azure`: https://nordicsemiconductor.github.io/asset-tracker-cloud-docs/v2.1.x/docs/azure/GettingStarted/Index.html
 
 .. _`nRF Connect for Visual Studio Code`: https://nrfconnect.github.io/vscode-nrf-connect
-.. _`nRF Kconfig`: https://nrfconnect.github.io/vscode-nrf-connect/kconfig/nrfkconfig.html
-.. _`Installing using Visual Studio Code`: https://nrfconnect.github.io/vscode-nrf-connect/connect/install.html
-.. _`Installing on Linux`: https://nrfconnect.github.io/vscode-nrf-connect/connect/install.html#installing-on-linux
-.. _`Creating an application`: https://nrfconnect.github.io/vscode-nrf-connect/connect/create_app.html
-.. _`Building an application`: https://nrfconnect.github.io/vscode-nrf-connect/connect/build_app.html
-.. _`Building nRF Connect SDK application quick guide`: https://nrfconnect.github.io/vscode-nrf-connect/connect/build_app_ncs.html
-.. _`Testing an application`: https://nrfconnect.github.io/vscode-nrf-connect/connect/test_app.html
-.. _`Debugging an application`: https://nrfconnect.github.io/vscode-nrf-connect/connect/debug_app.html
-.. _`West integration`: https://nrfconnect.github.io/vscode-nrf-connect/connect/west.html
-.. _`Custom launch and debug configurations`: https://nrfconnect.github.io/vscode-nrf-connect/connect/advanced_features.html#custom-launch-and-debug-configurations
-.. _`Application-specific flash options`: https://nrfconnect.github.io/vscode-nrf-connect/connect/advanced_features.html#application-specific-flash-options
-.. _`nRF Terminal documentation`: https://nrfconnect.github.io/vscode-nrf-connect/terminal/install.html
-.. _`Migrating IDE` : https://nrfconnect.github.io/vscode-nrf-connect/connect/migrating_ide.html
+.. _`Configuring with nRF Kconfig`: https://nrfconnect.github.io/vscode-nrf-connect/guides/ncs_configure_app.html
+.. _`Installing using Visual Studio Code`:
+.. _`Installing on Linux`: https://nrfconnect.github.io/vscode-nrf-connect/get_started/install.html
+.. _`How to build an application`:
+.. _`Migrating IDE`: https://nrfconnect.github.io/vscode-nrf-connect/get_started/build_app_ncs.html
+.. _`How to debug an application`:
+.. _`How to connect to the terminal`: https://nrfconnect.github.io/vscode-nrf-connect/get_started/quick_debug.html
+.. _`Debugging applications for a multi-core System on Chip`: https://nrfconnect.github.io/vscode-nrf-connect/guides/debug_concepts.html
+.. _`west module management`: https://nrfconnect.github.io/vscode-nrf-connect/guides/west_module_management.html
+.. _`Custom launch and debug configurations`: https://nrfconnect.github.io/vscode-nrf-connect/guides/debug_advanced.html
+.. _`Application-specific flash options`: https://nrfconnect.github.io/vscode-nrf-connect/guides/build_customize_config.html
 
 .. ### Source: developer.nordicsemi.com
 

--- a/doc/nrf/migration/migration_guide_1.x_to_2.x.rst
+++ b/doc/nrf/migration/migration_guide_1.x_to_2.x.rst
@@ -28,7 +28,7 @@ Default IDE change
 |VSC| extension IDE has replaced SEGGER Embedded Studio as the default supported IDE for working with the |NCS|.
 
 Required action:
-   If you are building the application or sample using SEGGER Embedded Studio or on the command line and want to migrate to |VSC| extension IDE, follow the instructions in the `migrating from other IDEs to VS Code <Migrating IDE_>`_ documentation.
+   If you are building the application or sample using SEGGER Embedded Studio or on the command line and want to migrate to |VSC| extension IDE, use the `Add an existing application <Migrating IDE_>`_ option in the |nRFVSC| to migrate your application.
 
 Pin control transition
 **********************

--- a/doc/nrf/releases/release-notes-2.0.0.rst
+++ b/doc/nrf/releases/release-notes-2.0.0.rst
@@ -1084,7 +1084,7 @@ Documentation
     Linux users can install the |NCS| by using the `Installing using Visual Studio Code <Installing on Linux_>`_ instructions or by following the steps on the :ref:`gs_installing` page.
   * Documentation on the SEGGER Embedded Studio, as this tool will no longer be supported moving forward.
     The previous |NCS| releases still support SEGGER Embedded Studio (Nordic edition).
-    To migrate from SEGGER Embedded Studio IDE or on the command line to |VSC|, follow the instructions in the `migrating from other IDEs to VS Code <Migrating IDE_>`_ documentation.
+    To migrate from SEGGER Embedded Studio IDE or on the command line to |VSC|, use the `Add an existing application <Migrating IDE_>`_ option in the |nRFVSC| to migrate your application.
   * Added |VSC| instructions on the following documentation:
 
     * :ref:`gs_modifying`

--- a/doc/nrf/ug_nrf52_gs.rst
+++ b/doc/nrf/ug_nrf52_gs.rst
@@ -55,7 +55,7 @@ Installing the required software
 On your computer, install `nRF Connect for Desktop`_.
 After installing and starting the application, install the Programmer app.
 
-You must also install a terminal emulator, such as :ref:`PuTTY <putty>` or the `nRF Terminal <nRF Terminal documentation_>`_ extension which is part of the |nRFVSC|.
+You must also install a terminal emulator, such as :ref:`PuTTY <putty>` or the nRF Terminal, which is part of the `nRF Connect for Visual Studio Code`_ extension.
 The steps detailed in :ref:`nrf52_gs_connecting` use PuTTY, but any terminal emulator will work.
 
 On your mobile device, install the `nRF Connect for Mobile`_ mobile application from the corresponding application store.

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -396,9 +396,9 @@ You can build and program separate images or combined images using the |nRFVSC|.
 Separate images
 ---------------
 
-To build and program the application core, follow the instructions in `Building an application`_ and use ``nrf5340dk_nrf5340_cpuapp`` or ``nrf5340dk_nrf5340_cpuapp_ns`` as the build target.
+To build and program the application core, follow the instructions in `How to build an application`_ and use ``nrf5340dk_nrf5340_cpuapp`` or ``nrf5340dk_nrf5340_cpuapp_ns`` as the build target.
 
-To build and program the network core, follow the instructions in `Building an application`_ and use ``nrf5340dk_nrf5340_cpunet`` as the build target.
+To build and program the network core, follow the instructions in `How to build an application`_ and use ``nrf5340dk_nrf5340_cpunet`` as the build target.
 
 .. _ug_nrf5340_VSC_multi_image:
 

--- a/doc/nrf/ug_thread_certification.rst
+++ b/doc/nrf/ug_thread_certification.rst
@@ -74,7 +74,7 @@ Complete the following steps to prepare for the certification tests:
         cd ncs/nrf/samples/openthread/cli/
         west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG="overlay-ci.conf;overlay-multiprotocol.conf" -DCONFIG_OPENTHREAD_LIBRARY=y -DCONFIG_LOG=n -DCONFIG_ASSERT=n
 
-   * If building using Visual Studio Code, you must first `create the application <Creating an application_>`_ using the CLI sample, and then `build the application <Building an application_>`_.
+   * If building using Visual Studio Code, you must first `create and build the application <How to build an application_>`_ using the CLI sample.
      Select the :file:`overlay-ci.conf` and :file:`overlay-multiprotocol.conf` overlay files in the :guilabel:`Kconfig fragment` drop-down menu and add the following lines to the **Additional CMake arguments** text field:
 
      .. code-block::


### PR DESCRIPTION
Edited links to VSC extension after VSC doc reorg. VSC-1303.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>