### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 87d3e9506abd24f32f4b930860f566c826885b6d
+      revision: pull/984/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a fix in the uart_nrfx_uarte driver that prevents NULL pointer dereference in specific configurations.

Ref. NCSDK-16573

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>