### PR TITLE
samples: doc: tfm_secure_peripheral: IRQ output from SPE

### DIFF
--- a/samples/tfm/tfm_secure_peripheral/README.rst
+++ b/samples/tfm/tfm_secure_peripheral/README.rst
@@ -146,7 +146,7 @@ The sample displays the following output in the console from the firmware in NSP
         SPP: send message: Success
         SPP: process signals: Success
 
-The sample displays the following output in the console from the firmware in NSPE:
+The sample displays the following output in the console from the firmware in SPE:
 
 .. code-block:: console
 


### PR DESCRIPTION
The README.rst erroneously said the IRQ output is from the NSPE firmware. This is now corrected to say the output is from the SPE. NCSDK-17721

Signed-off-by: Endre Sund <endre.sund@nordicsemi.no>