### PR TITLE
subsys: nfc: Fix write to constant and out of bound write

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -602,7 +602,9 @@ Libraries for networking
 Libraries for NFC
 -----------------
 
-|no_changes_yet_note|
+* :ref:`lib_nfc_ndef`:
+
+  * Fixed a write to a constant field in the :c:func:`ac_rec_payload_parse` function.
 
 Other libraries
 ---------------

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -606,6 +606,10 @@ Libraries for NFC
 
   * Fixed a write to a constant field in the :c:func:`ac_rec_payload_parse` function.
 
+* :ref:`nfc_t4t_isodep_readme`:
+
+  * Fixed out of bounds access in the :c:func:`ats_parse` function.
+
 Other libraries
 ---------------
 

--- a/subsys/nfc/t4t/isodep.c
+++ b/subsys/nfc/t4t/isodep.c
@@ -269,6 +269,13 @@ static int ats_parse(const uint8_t *data, size_t len)
 	/* Check if ATS contains historical bytes. */
 	if (index < len) {
 		t4t_isodep.tag.historical_len = len - index;
+		/* Maximum parsing length of the historical bytes is limited to 15
+		 * NFC Forum Digital Specification 2.0 14.6.2.
+		 */
+		if (t4t_isodep.tag.historical_len > NFC_T4T_ISODEP_HIST_MAX_LEN) {
+			t4t_isodep.tag.historical_len = NFC_T4T_ISODEP_HIST_MAX_LEN;
+		}
+
 		memcpy(t4t_isodep.tag.historical, &data[index],
 		       t4t_isodep.tag.historical_len);
 	}


### PR DESCRIPTION
Fix write to a constant by memset in ndef.
Fix out of bound write by memcpy in isodep.