### PR TITLE
samples: radio_test: Use MPSL output power splitter

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -433,6 +433,10 @@ Other samples
     * Front-end module support is now provided by the :ref:`nrfxlib:mpsl_fem` API instead of the custom driver that was part of this sample.
     * On the nRF5340 development kit, the :ref:`nrf5340_remote_shell` is now a mandatory sample that must be programmed to the application core.
     * On the nRF5340 development kit, this sample uses the :ref:`shell_ipc_readme` library to forward shell data through the physical application core UART interface.
+    * Added support for the :ref:`nrfxlib:mpsl_fem` TX power split feature.
+      The new ``total_output_power`` shell command is introduced for sample builds with front-end module support.
+      It enables automatic setting of the SoC output power in a radio peripheral and front-end module gain to achieve requested output power or less if an exact value is not supported.
+    * Added support for +1 dBm, +2 dBm and +3 dBm output power on nRF5340 DK.
 
 Drivers
 =======

--- a/samples/bluetooth/direct_test_mode/src/fem/fem.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/fem.c
@@ -256,6 +256,26 @@ void fem_txrx_stop(void)
 	mpsl_fem_deactivate_now(MPSL_FEM_ALL);
 }
 
+int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_t freq_mhz)
+{
+	int8_t output_power;
+	int32_t err;
+	mpsl_tx_power_split_t power_split = { 0 };
+
+	output_power = mpsl_fem_tx_power_split(power, &power_split, freq_mhz);
+
+	*radio_tx_power = power_split.radio_tx_power;
+
+	err = mpsl_fem_pa_gain_set(&power_split.fem);
+	if (err) {
+		/* Should not happen */
+		printk("Failed to set front-end module gain (err %d)\n", err);
+		__ASSERT_NO_MSG(false);
+	}
+
+	return output_power;
+}
+
 int fem_init(NRF_TIMER_Type *timer_instance, uint8_t compare_channel_mask)
 {
 	if (!timer_instance || (compare_channel_mask == 0)) {

--- a/samples/bluetooth/direct_test_mode/src/fem/fem.h
+++ b/samples/bluetooth/direct_test_mode/src/fem/fem.h
@@ -125,7 +125,7 @@ void fem_txrx_stop(void);
  */
 int fem_antenna_select(enum fem_antenna ant);
 
-/**@brief @brief Get the radio ramp-up time in transmit mode.
+/**@brief Get the radio ramp-up time in transmit mode.
  *
  * @param[in] fast The radio is in the fast ramp-up mode.
  * @param[in] mode Radio mode.
@@ -142,6 +142,24 @@ uint32_t fem_radio_tx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode);
  * @retval Radio ramp-up time in microseconds.
  */
 uint32_t fem_radio_rx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode);
+
+/**@brief Set the front-end module gain and returns output power to be set on the radio peripheral
+ *        to get requested output power.
+ *
+ * This function calculates power value for RADIO peripheral register and
+ * sets front-end module gain value.
+ *
+ * @note If the exact value of @p power cannot be achieved, this function attempts to use less
+ *       power to not exceed the limits.
+ *
+ * @param[in] power TX power requested for transmission on air.
+ * @param[out] radio_tx_power Tx power value to be set on the radio peripheral.
+ * @param[in] freq_mhz Frequency in MHz. The output power is valid only for this frequency.
+ *
+ * @return The power in dBm that is achieved as device output power. It can be different from
+ *         the value requested by @p power.
+ */
+int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_t freq_mhz);
 
 #ifdef __cplusplus
 }

--- a/samples/peripheral/radio_test/Kconfig
+++ b/samples/peripheral/radio_test/Kconfig
@@ -14,5 +14,15 @@ config RADIO_TEST_USB
 	  Use USB instead of UART as the Radio Test shell transport.
 	  For nRF5340 the USB from application core is used as communication interface.
 
+config RADIO_TEST_POWER_CONTROL_AUTOMATIC
+	bool "Automatic power control"
+	depends on FEM
+	default y
+	help
+	  Set SoC output power and front-end module gain to achieve Tx output power requested
+	  by user. If the exact value cannot be achieved, power is set to closest value which does
+	  not exceed the limits. If this option is disabled, user has to set SoC output power and
+	  fem gain with separate commands.
+
 rsource "../../bluetooth/direct_test_mode/src/fem/Kconfig"
 source "Kconfig.zephyr"

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -69,6 +69,7 @@ See :ref:`radio_test_ui` for a list of available commands.
    For the IEEE 802.15.4 mode, the start channel and the end channel must be within the channel range of 11 to 26.
    Use the ``start_channel`` and ``end_channel`` commands to control this setting.
 
+
 .. _radio_test_ui:
 
 User interface
@@ -94,6 +95,7 @@ User interface
    * - output_power
      - <sub_cmd>
      - Output power set.
+       If a front-end module is attached and the :kconfig:option:`CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC` Kconfig option is enabled, it has the same effect as the ``total_output_power`` command.
    * - parameters_print
      -
      - Print current delay, channel, and other parameters.
@@ -130,6 +132,34 @@ User interface
    * - transmit_pattern
      - <sub_cmd>
      - Set transmission pattern.
+   * - total_output_power
+     - <tx output power>
+     - Set total output power in dBm.
+       This value includes SoC output power and front-end module gain.
+
+Tx output power
+===============
+
+This sample has a few commands that you can use to test the device output power.
+The behavior of the commands vary depending on the hardware configuration and Kconfig options as follows:
+
+* Radio Test without front-end module support:
+
+  * The ``output_power`` command sets the SoC output command with a subcommand set.
+    The output power is set directly in the radio peripheral.
+
+* Radio Test with front-end module support in default configuration (the :kconfig:option:`CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC` Kconfig option is enabled):
+
+  * The ``output_power`` command sets the total output power, including front-end module gain.
+  * The ``total_output_power`` command sets the total output power, including front-end module gain with a value in dBm unit provided by user.
+  * For these commands, the radio peripheral and FEM gain is calculated and set automatically to meet your requirements.
+  * If an exact output power value cannot be set, a lower value is used.
+
+* Radio Test with front-end module support and manual Tx output power control (the kconfig:option:`CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC` Kconfig option is disabled):
+
+  * The ``output_power`` command sets the SoC output command with a subcommands set.
+  * The ``fem`` command with the ``tx_gain`` subcommand sets the front-end module gain to an arbitrary value for given front-end module.
+  * You can use this configuration to perform tests on your hardware design.
 
 Building and running
 ********************

--- a/samples/peripheral/radio_test/sample.yaml
+++ b/samples/peripheral/radio_test/sample.yaml
@@ -34,3 +34,12 @@ tests:
       - nrf5340dk_nrf5340_cpunet
     platform_allow: nrf5340dk_nrf5340_cpunet
     tags: ci_build
+  sample.peripheral.radio_test.nrf5340_nrf21540.no_automatic_power:
+    build_only: true
+    extra_args: SHIELD=nrf21540_ek
+    extra_configs:
+      - CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC=n
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf5340dk_nrf5340_cpunet
+    tags: ci_build

--- a/samples/peripheral/radio_test/src/radio_test.h
+++ b/samples/peripheral/radio_test/src/radio_test.h
@@ -10,6 +10,20 @@
 #include <zephyr/types.h>
 #include <hal/nrf_radio.h>
 
+#ifdef NRF53_SERIES
+#ifndef RADIO_TXPOWER_TXPOWER_Pos3dBm
+	#define RADIO_TXPOWER_TXPOWER_Pos3dBm (0x03UL)
+#endif /* RADIO_TXPOWER_TXPOWER_Pos3dBm */
+
+#ifndef RADIO_TXPOWER_TXPOWER_Pos2dBm
+	#define RADIO_TXPOWER_TXPOWER_Pos2dBm (0x02UL)
+#endif /* RADIO_TXPOWER_TXPOWER_Pos2dBm */
+
+#ifndef RADIO_TXPOWER_TXPOWER_Pos1dBm
+	#define RADIO_TXPOWER_TXPOWER_Pos1dBm (0x01UL)
+#endif /* RADIO_TXPOWER_TXPOWER_Pos1dBm */
+#endif /* NRF53_SERIES */
+
 /** Maximum radio RX or TX payload. */
 #define RADIO_MAX_PAYLOAD_LEN	256
 /** IEEE 802.15.4 maximum payload length. */
@@ -77,7 +91,7 @@ struct radio_test_config {
 	union {
 		struct {
 			/** Radio output power. */
-			uint8_t txpower;
+			int8_t txpower;
 
 			/** Radio channel. */
 			uint8_t channel;
@@ -85,7 +99,7 @@ struct radio_test_config {
 
 		struct {
 			/** Radio output power. */
-			uint8_t txpower;
+			int8_t txpower;
 
 			/** Radio transmission pattern. */
 			enum transmit_pattern pattern;
@@ -113,7 +127,7 @@ struct radio_test_config {
 
 		struct {
 			/** Radio output power. */
-			uint8_t txpower;
+			int8_t txpower;
 
 			/** Radio start channel (frequency). */
 			uint8_t channel_start;
@@ -138,7 +152,7 @@ struct radio_test_config {
 
 		struct {
 			/** Radio output power. */
-			uint8_t txpower;
+			int8_t txpower;
 
 			/** Radio transmission pattern. */
 			enum transmit_pattern pattern;


### PR DESCRIPTION
Add the MPSL output power splitter feature in the
Radio Test sample. The total output power can be
splitted and set automatically to the SoC RADIO
peripheral and to the FEM.