### PR TITLE
manifest: update Zephyr with OpenThread fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 87d3e9506abd24f32f4b930860f566c826885b6d
+      revision: 32ad565f7d8bcd0a009b168f355150dbbe8be15f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Fix `radio.c` platform implementation when asserts are disabled.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>