### PR TITLE
net: lib: wifi_credentials: fix build warning

### DIFF
--- a/subsys/net/lib/wifi_credentials/wifi_credentials.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials.c
@@ -152,8 +152,7 @@ int wifi_credentials_set_personal_struct(const struct wifi_credentials_personal 
 {
 	int ret;
 
-	if (creds->header.ssid == NULL ||
-	    creds->header.ssid_len > WIFI_SSID_MAX_LEN ||
+	if (creds->header.ssid_len > WIFI_SSID_MAX_LEN ||
 	    creds->header.ssid_len == 0) {
 		LOG_ERR("Cannot set WiFi credentials, SSID has invalid format");
 		return -EINVAL;


### PR DESCRIPTION
This patch removes a redundant check that causes a build warning.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>