### PR TITLE
net: ftp_client: Fix doxygen markers for response codes

### DIFF
--- a/include/net/ftp_client.h
+++ b/include/net/ftp_client.h
@@ -32,106 +32,106 @@ enum ftp_reply_code {
 	 * reply before proceeding with a new command
 	 */
 
-	/* Restart marker replay . In this case, the text is exact and not left
-	 * to the particular implementation; it must read: MARK yyyy = mmmm
-	 * where yyyy is User-process data stream marker, and mmmm server's
-	 * equivalent marker (note the spaces between markers and "=")
+	/** Restart marker replay. In this case, the text is exact and not left
+	 *  to the particular implementation; it must read: MARK yyyy = mmmm
+	 *  where yyyy is User-process data stream marker, and mmmm server's
+	 *  equivalent marker (note the spaces between markers and "=")
 	 */
 	FTP_CODE_110 = 110,
-	/* Service ready in nnn minutes */
+	/** Service ready in nnn minutes */
 	FTP_CODE_120 = 120,
-	/* Data connection already open; transfer starting */
+	/** Data connection already open; transfer starting */
 	FTP_CODE_125 = 125,
-	/* File status okay; about to open data connection */
+	/** File status okay; about to open data connection */
 	FTP_CODE_150 = 150,
 
 	/* 200 Series	The requested action has been successfully completed */
 
-	/* Command OK*/
+	/** Command OK*/
 	FTP_CODE_200 = 200,
-	/* Command not implemented, superfluous at this site */
+	/** Command not implemented, superfluous at this site */
 	FTP_CODE_202 = 202,
-	/* System status, or system help reply */
+	/** System status, or system help reply */
 	FTP_CODE_211 = 211,
-	/* Directory status */
+	/** Directory status */
 	FTP_CODE_212 = 212,
-	/* File status*/
+	/** File status*/
 	FTP_CODE_213 = 213,
-	/* Help message. Explains how to use the server or the meaning of a
-	 * particular non-standard command. This reply is useful only to the
-	 * human user
+	/** Help message. Explains how to use the server or the meaning of a
+	 *  particular non-standard command. This reply is useful only to the
+	 *  human user
 	 */
 	FTP_CODE_214 = 214,
-	/* NAME system type. Where NAME is an official system name from the
-	 * registry kept by IANA.
+	/** NAME system type. Where NAME is an official system name from the
+	 *  registry kept by IANA.
 	 */
 	FTP_CODE_215 = 215,
-	/* Service ready for new user */
+	/** Service ready for new user */
 	FTP_CODE_220 = 220,
-	/* Service closing control connection */
+	/** Service closing control connection */
 	FTP_CODE_221 = 221,
-	/* Data connection open; no transfer in progress */
+	/** Data connection open; no transfer in progress */
 	FTP_CODE_225 = 225,
-	/* Closing data connection. Requested file action successful (for
-	 * example, file transfer or file abort)
+	/** Closing data connection. Requested file action successful (for
+	 *  example, file transfer or file abort)
 	 */
 	FTP_CODE_226 = 226,
-	/* Entering Passive Mode (h1,h2,h3,h4,p1,p2) */
+	/** Entering Passive Mode (h1,h2,h3,h4,p1,p2) */
 	FTP_CODE_227 = 227,
-	/* Entering Long Passive Mode (long address, port) */
+	/** Entering Long Passive Mode (long address, port) */
 	FTP_CODE_228 = 228,
-	/* Entering Extended Passive Mode (|||port|) */
+	/** Entering Extended Passive Mode (|||port|) */
 	FTP_CODE_229 = 229,
-	/* User logged in, proceed. Logged out if appropriate */
+	/** User logged in, proceed. Logged out if appropriate */
 	FTP_CODE_230 = 230,
-	/* User logged out; service terminated */
+	/** User logged out; service terminated */
 	FTP_CODE_231 = 231,
-	/* Logout command noted, will complete when transfer done */
+	/** Logout command noted, will complete when transfer done */
 	FTP_CODE_233 = 233,
-	/* Specifies that the server accepts the authentication mechanism
-	 * specified by the client, and the exchange of security data is
-	 * complete. A higher level nonstandard code created by Microsoft
+	/** Specifies that the server accepts the authentication mechanism
+	 *  specified by the client, and the exchange of security data is
+	 *  complete. A higher level nonstandard code created by Microsoft
 	 */
 	FTP_CODE_234 = 234,
-	/* Requested file action okay, completed */
+	/** Requested file action okay, completed */
 	FTP_CODE_250 = 250,
-	/* "PATHNAME" created */
+	/** "PATHNAME" created */
 	FTP_CODE_257 = 257,
 
 	/* 300 Series	The command has been accepted, but the requested action
 	 *is on hold, pending receipt of further information
 	 */
 
-	/* User name okay, need password */
+	/** User name okay, need password */
 	FTP_CODE_331 = 331,
-	/* Need account for login */
+	/** Need account for login */
 	FTP_CODE_332 = 332,
-	/* Requested file action pending further information */
+	/** Requested file action pending further information */
 	FTP_CODE_350 = 350,
 
-	/*** 400 Series	The command was not accepted and the requested action
+	/* 400 Series	The command was not accepted and the requested action
 	 * did not take place, but the error condition is temporary and the
 	 * action may be requested again
 	 */
 
-	/* Service not available, closing control connection. This may be a
-	 * reply to any command if the service knows it must shut down
+	/** Service not available, closing control connection. This may be a
+	 *  reply to any command if the service knows it must shut down
 	 */
 	FTP_CODE_421 = 421,
-	/* Can't open data connection */
+	/** Cannot open data connection */
 	FTP_CODE_425 = 425,
-	/* Connection closed; transfer aborted */
+	/** Connection closed; transfer aborted */
 	FTP_CODE_426 = 426,
-	/* Invalid username or password */
+	/** Invalid username or password */
 	FTP_CODE_430 = 430,
-	/* Requested host unavailable */
+	/** Requested host unavailable */
 	FTP_CODE_434 = 434,
-	/* Requested file action not taken */
+	/** Requested file action not taken */
 	FTP_CODE_450 = 450,
-	/* Requested action aborted. Local error in processing */
+	/** Requested action aborted. Local error in processing */
 	FTP_CODE_451 = 451,
-	/* Requested action not taken. Insufficient storage space in system.
-	 * File unavailable (e.g., file busy)
+	/** Requested action not taken. Insufficient storage space in system.
+	 *  File unavailable (for example, file busy)
 	 */
 	FTP_CODE_452 = 452,
 
@@ -140,84 +140,84 @@ enum ftp_reply_code {
 	 * line too long
 	 */
 
-	/* General error */
+	/** General error */
 	FTP_CODE_500 = 500,
-	/* Syntax error in parameters or arguments */
+	/** Syntax error in parameters or arguments */
 	FTP_CODE_501 = 501,
-	/* Command not implemented */
+	/** Command not implemented */
 	FTP_CODE_502 = 502,
-	/* Bad sequence of commands */
+	/** Bad sequence of commands */
 	FTP_CODE_503 = 503,
-	/* Command not implemented for that parameter */
+	/** Command not implemented for that parameter */
 	FTP_CODE_504 = 504,
-	/* Not logged in */
+	/** Not logged in */
 	FTP_CODE_530 = 530,
-	/* Need account for storing files */
+	/** Need account for storing files */
 	FTP_CODE_532 = 532,
-	/* Could Not Connect to Server - Policy Requires SSL */
+	/** Could Not Connect to Server - Policy Requires SSL */
 	FTP_CODE_534 = 534,
-	/* Requested action not taken. File unavailable (e.g., file not found,
-	 * no access)
+	/** Requested action not taken. File unavailable (for example, file not
+	 *  found, no access)
 	 */
 	FTP_CODE_550 = 550,
-	/* Requested action aborted. Page type unknown */
+	/** Requested action aborted. Page type unknown */
 	FTP_CODE_551 = 551,
-	/* Requested file action aborted. Exceeded storage allocation (for
-	 * current directory or dataset)
+	/** Requested file action aborted. Exceeded storage allocation (for
+	 *  current directory or dataset)
 	 */
 	FTP_CODE_552 = 552,
-	/* Requested action not taken. File name not allowed */
+	/** Requested action not taken. File name not allowed */
 	FTP_CODE_553 = 553,
 
-	/*** Replies regarding confidentiality and integrity */
+	/* Replies regarding confidentiality and integrity */
 
-	/* Integrity protected reply */
+	/** Integrity protected reply */
 	FTP_CODE_631 = 631,
-	/* Confidentiality and integrity protected reply */
+	/** Confidentiality and integrity protected reply */
 	FTP_CODE_632 = 632,
-	/* Confidentiality protected reply */
+	/** Confidentiality protected reply */
 	FTP_CODE_633 = 633,
 
-	/*** Nordic proprietary reply codes */
+	/* Nordic proprietary reply codes */
 
-	/* DUMMY */
+	/** DUMMY */
 	FTP_CODE_900 = 900,
 
 	/** Fatal errors */
-	/* Disconnected by remote server */
+	/** Disconnected by remote server */
 	FTP_CODE_901 = 901,
-	/* Connection aborted */
+	/** Connection aborted */
 	FTP_CODE_902 = 902,
-	/* Socket poll error */
+	/** Socket poll error */
 	FTP_CODE_903 = 903,
-	/* Unexpected poll event */
+	/** Unexpected poll event */
 	FTP_CODE_904 = 904,
-	/* Network down */
+	/** Network down */
 	FTP_CODE_905 = 905,
-	/* Unexpected error */
+	/** Unexpected error */
 	FTP_CODE_909 = 909,
 
-	/** Non-fatal errors */
-	/* Data transfer timeout */
+	/* Non-fatal errors */
+	/** Data transfer timeout */
 	FTP_CODE_910 = 910,
 
 	/* 10000 Series Common Winsock Error Codes[2] (These are not FTP
 	 * return codes)
 	 */
 
-	/* Connection reset by peer. The connection was forcibly closed by the
-	 * remote host
+	/** Connection reset by peer. The connection was forcibly closed by the
+	 *  remote host
 	 */
 	FTP_CODE_10054 = 10054,
-	/* Cannot connect to remote server */
+	/** Cannot connect to remote server */
 	FTP_CODE_10060 = 10060,
-	/* Cannot connect to remote server. The connection is actively refused
-	 * by the server
+	/** Cannot connect to remote server. The connection is actively refused
+	 *  by the server
 	 */
 	FTP_CODE_10061 = 10061,
-	/* Directory not empty */
+	/** Directory not empty */
 	FTP_CODE_10066 = 10066,
-	/* Too many users, server is full */
+	/** Too many users, server is full */
 	FTP_CODE_10068 = 10068
 };
 


### PR DESCRIPTION
The response code API documentation did not use a valid doxygen syntax, resuling in the documentation not being rendered correctly.

NCSDK-18150

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>