### PR TITLE
drivers: wifi: Enable low power mode by default

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -17,6 +17,7 @@ config WIFI_NRF700X
 
 config NRF_WIFI_LOW_POWER
 	bool "Enable low power mode in nRF Wi-Fi chipsets"
+	default y
 
 if WIFI_NRF700X
 


### PR DESCRIPTION
Enable low power mode by default.

Signed-off-by: Ravi Dondaputi <ravi.dondaputi@nordicsemi.no>