### PR TITLE
manifest: TF-M with bugfix in output length

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -119,7 +119,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 2b98fc3dfb1f6fb415e62f77812e61306ca93692
+      revision: 3017e45d1276ed739ddbd9650546b8bc02748d8a
     - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
       repo-path: sdk-mcuboot
       path: modules/tee/tfm-mcuboot

--- a/west.yml
+++ b/west.yml
@@ -115,7 +115,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 4a898d4e0de49935e2b798774b54603f682cb1c0
+      revision: fa844f13b472fcc730721a1b74def258aa19fb0f
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
This brings a commit from upstream TF-M which solves an issue when some crypto services do not properly set the output length to zero if they fail.

Ref: NCSDK-18172

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>

test-sdk-nrf: sdk-nrf-PR-9400