### PR TITLE
bluetooth: controller: Implement hci driver close functionality

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -54,6 +54,8 @@ Bluetooth LE
 * Added:
 
   * Support for :c:func:`hci_driver_close`, so :c:func:`bt_disable` can now be used to disable the SoftDevice Controller.
+  * The Kconfig option :kconfig:option:`CONFIG_BT_UNINIT_MPSL_ON_DISABLE` that, when enabled, uninitializes the MPSL when :c:func:`bt_disable` is used.
+    This releases all peripherals used by the MPSL.
 
 For details, see :ref:`nrfxlib:softdevice_controller_changelog`.
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -51,7 +51,9 @@ See `Samples`_ for lists of changes for the protocol-related samples.
 Bluetooth LE
 ------------
 
-|no_changes_yet_note|
+* Added:
+
+  * Support for :c:func:`hci_driver_close`, so :c:func:`bt_disable` can now be used to disable the SoftDevice Controller.
 
 For details, see :ref:`nrfxlib:softdevice_controller_changelog`.
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -292,5 +292,13 @@ config BT_CTLR_LE_POWER_CONTROL
 	  Enable support for LE Power Control feature that defined in the Bluetooth
 	  Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.31.
 
+config BT_UNINIT_MPSL_ON_DISABLE
+	bool "Uninitializes MPSL on BT disable"
+	depends on MPSL_DYNAMIC_INTERRUPTS
+	help
+	  This option unitializes MPSL on BT disable. HCI driver close calls
+	  mpsl_lib_uninit, which releases all peripherals and allows the user to
+	  override any interrupt handlers used by MPSL.
+
 endmenu
 endif  # BT_LL_SOFTDEVICE

--- a/subsys/bluetooth/controller/ecdh.c
+++ b/subsys/bluetooth/controller/ecdh.c
@@ -297,6 +297,14 @@ void hci_ecdh_init(void)
 #endif /* !defined(CONFIG_BT_CTLR_ECDH_IN_MPSL_WORK) */
 }
 
+void hci_ecdh_uninit(void)
+{
+#if !defined(CONFIG_BT_CTLR_ECDH_IN_MPSL_WORK)
+	k_thread_abort(&ecdh_thread_data);
+#endif /* !defined(CONFIG_BT_CTLR_ECDH_IN_MPSL_WORK) */
+}
+
+
 uint8_t hci_cmd_le_read_local_p256_public_key(void)
 {
 	if (!atomic_cas(&cmd, 0, GEN_PUBLIC_KEY)) {

--- a/subsys/bluetooth/controller/ecdh.c
+++ b/subsys/bluetooth/controller/ecdh.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
 #include <zephyr/kernel.h>
 #include <zephyr/sys/atomic.h>
 

--- a/subsys/bluetooth/controller/ecdh.h
+++ b/subsys/bluetooth/controller/ecdh.h
@@ -4,6 +4,8 @@
 
 void hci_ecdh_init(void);
 
+void hci_ecdh_uninit(void);
+
 uint8_t hci_cmd_le_read_local_p256_public_key(void);
 
 uint8_t hci_cmd_le_generate_dhkey(struct bt_hci_cp_le_generate_dhkey *p_params);

--- a/subsys/bluetooth/controller/ecdh.h
+++ b/subsys/bluetooth/controller/ecdh.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
 #include <stdint.h>
 
 #include <zephyr/bluetooth/hci.h>


### PR DESCRIPTION
This allows use of bt_disable with sdc. Init/uninit MPSL on HCI driver close/open with added kconfig, this means we can use the peripherals and interrupts used by MPSL after calling bt_disable.

