### PR TITLE
doc: Drop read only functionality for bl_storage library from app

### DIFF
--- a/doc/nrf/libraries/bootloader/bl_storage.rst
+++ b/doc/nrf/libraries/bootloader/bl_storage.rst
@@ -8,7 +8,9 @@ Bootloader storage
    :depth: 2
 
 The bootloader storage library is used to read and write both one-time programmable (OTP) data and a non-volatile counter.
-It can be used by both the |NSIB| (NSIB) and the application, but the application has read access only.
+
+If the |NSIB| (NSIB) is enabled, it should be the only user of this library.
+The application image can only include this library when the NSIB is disabled.
 
 The library has the following functions for either reading or writing, or in some cases both reading and writing:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -547,6 +547,7 @@ Bootloader libraries
 
     * PSA compatible lifecycle state.
     * PSA compatible implementation ID.
+    * Removed the option of application using the library to read OTP memory when the |NSIB| (NSIB) is enabled.
 
 Modem libraries
 ---------------


### PR DESCRIPTION
If the application rely on reading out the OTP based on the bl_storage format, the NISB and the application must always be compiled with the same version of the bl_storage library.
But as the format of OTP within the bl_storage might change in future, it is likely that the application is build with a newer version causing read failures if a DFU is performed.

Therefore we remove the feature to use the library within the application.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>

This relates to changes made in #9033 