### PR TITLE
samples: nrf9160: default to newlibc nano

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -35,6 +35,12 @@ endchoice
 config WARN_EXPERIMENTAL
 	default y
 
+# Zephyr default is newlib and not newlib-nano for consistency between architectures.
+# To reduce FLASH footprint, newlib-nano is preferred default in NCS when newlib is selected.
+config NEWLIB_LIBC_NANO
+	default y
+	depends on NEWLIB_LIBC && HAS_NEWLIB_LIBC_NANO
+
 # This is a temporary solution to whitelist
 # BOARD_THINGY91_NRF9160_NS in compliance
 config BOARD_THINGY91_NRF9160_NS

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec/src/nrf_cloud_codec_test.c
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec/src/nrf_cloud_codec_test.c
@@ -103,15 +103,15 @@ const static struct cloud_data_battery bat_data_example = {
 	"\"appId\":\"GNSS\","\
 	"\"messageType\":\"DATA\","\
 	"\"ts\":1563968747123,"\
-	"\"data\":{\"lng\":30.03,\"lat\":40.04,\"acc\":180,\"alt\":245,\"spd\":5,\"hdg\":39}"\
+	"\"data\":{\"lng\":30,\"lat\":40,\"acc\":180,\"alt\":245,\"spd\":5,\"hdg\":39}"\
 "}]"
 
 const static struct cloud_data_gnss gnss_data_example = {
 	.queued = true,
 	.gnss_ts = 1563968747123,
 	.pvt = {
-		.longi = 30.03,
-		.lat = 40.04,
+		.longi = 30,
+		.lat = 40,
 		.alt = 245,
 		.acc = 180,
 		.spd = 5,


### PR DESCRIPTION
The nano flavour of newlibc used to be the default before NCS v2.2.0.

This changed when the commit in https://github.com/zephyrproject-rtos/zephyr/pull/51340 was merged downstream, increasing the FLASH size of all nrf9160 samples by about 40KB, due to their requirement on some variadic C functions whose implementation is much larger in vanilla newlibc.

This patch reverts the change from upstream and maintains the newlibc nano flavour as the default, avoiding a size increase across all nrf9160 samples.