### PR TITLE
Bluetooth: Mesh: Fixed extended advertiser for nRF5340

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -126,6 +126,8 @@
 
 .. |thingy53_sample_note| replace:: If you build this application for Thingy:53, it enables additional features. See :ref:`thingy53_app_guide` for details.
 
+.. |nrf5340_mesh_sample_note| replace:: For nRF5340 and Thingy:53, the extended advertiser has to be set manually for the network core, because the Bluetooth® Low Energy does not know that the Bluetooth mesh is enabled when built for this core. This is already done for this sample by setting ``CONFIG_BT_EXT_ADV=y`` for the network core.
+
 .. |nrf5340_audio_note| replace:: The |NCS| includes the :ref:`nrf53_audio_app` application, a complete project that integrates the LE Audio standard with custom reference hardware based on the nRF5340 SiP.
 
 .. |trusted_execution| replace:: nRF5340 and nRF9160

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -118,6 +118,8 @@ Configuration
 
 |config|
 
+|nrf5340_mesh_sample_note|
+
 Source file setup
 =================
 

--- a/samples/bluetooth/mesh/light/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/mesh/light/child_image/hci_rpmsg.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_EXT_ADV=y

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -120,6 +120,8 @@ Configuration
 
 |config|
 
+|nrf5340_mesh_sample_note|
+
 Source file setup
 =================
 

--- a/samples/bluetooth/mesh/light_ctrl/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/mesh/light_ctrl/child_image/hci_rpmsg.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_EXT_ADV=y

--- a/samples/bluetooth/mesh/light_switch/README.rst
+++ b/samples/bluetooth/mesh/light_switch/README.rst
@@ -193,6 +193,8 @@ Configuration
 
 |config|
 
+|nrf5340_mesh_sample_note|
+
 Source file setup
 =================
 

--- a/samples/bluetooth/mesh/light_switch/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/mesh/light_switch/child_image/hci_rpmsg.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_EXT_ADV=y

--- a/samples/bluetooth/mesh/sensor_server/README.rst
+++ b/samples/bluetooth/mesh/sensor_server/README.rst
@@ -106,6 +106,8 @@ Configuration
 
 |config|
 
+|nrf5340_mesh_sample_note|
+
 Source file setup
 =================
 

--- a/samples/bluetooth/mesh/sensor_server/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/mesh/sensor_server/child_image/hci_rpmsg.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_EXT_ADV=y

--- a/samples/bluetooth/mesh/silvair_enocean/README.rst
+++ b/samples/bluetooth/mesh/silvair_enocean/README.rst
@@ -112,6 +112,8 @@ Configuration
 
 |config|
 
+|nrf5340_mesh_sample_note|
+
 Source file setup
 =================
 

--- a/samples/bluetooth/mesh/silvair_enocean/child_image/hci_rpmsg.conf
+++ b/samples/bluetooth/mesh/silvair_enocean/child_image/hci_rpmsg.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_BT_EXT_ADV=y


### PR DESCRIPTION
The extended advertiser is not enalbed for the nRF5340 and Thingy:53 by default as Bluetooth is running on the network core.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>