### PR TITLE
applications: nrf5340_audio: Support more than one BIS on headsets

### DIFF
--- a/applications/nrf5340_audio/README.rst
+++ b/applications/nrf5340_audio/README.rst
@@ -674,6 +674,8 @@ The application uses the following buttons on the supported development kit:
 |               |   Use this tone to check the synchronization of headsets.                              |
 |               | * Pressed on the gateway during playback multiple times: Changes the tone frequency.   |
 |               |   The available values are 1000 Hz, 2000 Hz, and 4000 Hz.                              |
+|               | * Pressed on a BIS headset during playback: Change audio stream, if more than one is   |
+|               |   available.                                                                           |
 +---------------+----------------------------------------------------------------------------------------+
 | **BTN 5**     | Depending on the moment it is pressed:                                                 |
 |               |                                                                                        |
@@ -1253,6 +1255,8 @@ Testing the BIS mode is identical to `Testing the default CIS mode`_, except for
   For example, you can decrease or increase the volume separately for each receiver during playback.
 * When pressing the **PLAY/PAUSE** button on a headset, the streaming state only changes for that given headset.
 * Pressing the **PLAY/PAUSE** button on the gateway will respectively start or stop the stream for all headsets listening in.
+* Pressing the **BTN 4** button on a headset will change the active audio stream.
+  The default configuration of the BIS mode supports two audio streams (left and right).
 
 .. _nrf53_audio_app_testing_steps_cis_walkie_talkie:
 

--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -123,6 +123,12 @@ config AUDIO_HEADSET_CHANNEL_COMPILE_TIME
 	  Set channel selection at compile-time.
 endchoice
 
+config AUDIO_TEST_TONE
+	bool "Testing audio chain using a test tone"
+	default y
+	help
+	  Use button 4 to set the test tone.
+
 if AUDIO_HEADSET_CHANNEL_COMPILE_TIME
 
 config AUDIO_HEADSET_CHANNEL
@@ -267,7 +273,7 @@ config ENCODER_STACK_SIZE
 config AUDIO_DATAPATH_STACK_SIZE
 	int "Stack size for audio datapath thread"
 	default 4096 if AUDIO_BIT_DEPTH_16
-	default 7168 if AUDIO_BIT_DEPTH_32
+	default 8192 if AUDIO_BIT_DEPTH_32
 
 endmenu # Stack sizes
 endmenu # Audio

--- a/applications/nrf5340_audio/src/audio/Kconfig.defaults
+++ b/applications/nrf5340_audio/src/audio/Kconfig.defaults
@@ -35,6 +35,13 @@ config LC3_DEC_CHAN_MAX
 	int
 	default 1
 
+if TRANSPORT_BIS # Depends on TRANSPORT_BIS
+
+config AUDIO_TEST_TONE
+	default n
+
+endif # TRANSPORT_BIS
+
 endif # AUDIO_DEV = 1 (HEADSET)
 
 # GATEWAY

--- a/applications/nrf5340_audio/src/bluetooth/ble_audio_services.c
+++ b/applications/nrf5340_audio/src/bluetooth/ble_audio_services.c
@@ -448,7 +448,7 @@ int ble_mcs_state_update(struct bt_conn *conn)
 
 int ble_mcs_play_pause(struct bt_conn *conn)
 {
-	int ret;
+	int ret = 0;
 	struct mpl_cmd cmd;
 
 	if (media_player_state == BT_MCS_MEDIA_STATE_PLAYING) {

--- a/applications/nrf5340_audio/src/bluetooth/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio.h
@@ -128,6 +128,14 @@ typedef void (*le_audio_receive_cb)(const uint8_t *const data, size_t size, bool
 				    uint32_t sdu_ref);
 
 /**
+ * @brief Generic function for a user defined button press
+ *
+ * @return	0 for success,
+ *		error otherwise
+ */
+int le_audio_user_defined_button_press(void);
+
+/**
  * @brief Get configuration for audio stream
  *
  * @param bitrate	Pointer to bitrate used

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -24,21 +24,41 @@ LOG_MODULE_REGISTER(bis_headset, CONFIG_BLE_LOG_LEVEL);
 BUILD_ASSERT(CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT <= 2,
 	     "A maximum of two broadcast streams are currently supported");
 
+struct audio_codec_info {
+	uint8_t id;
+	uint16_t cid;
+	uint16_t vid;
+	int frequency;
+	int frame_duration_us;
+	int chan_allocation;
+	int octets_per_sdu;
+	int bitrate;
+	int blocks_per_sdu;
+};
+
+struct active_stream {
+	struct bt_audio_stream *stream;
+	struct audio_codec_info *codec;
+};
+
 static struct bt_audio_broadcast_sink *broadcast_sink;
 
-static struct bt_audio_stream streams[CONFIG_LC3_DEC_CHAN_MAX];
-static struct bt_audio_stream *streams_p[ARRAY_SIZE(streams)];
+static struct bt_audio_stream audio_streams[CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT];
+static struct bt_audio_stream *audio_streams_p[ARRAY_SIZE(audio_streams)];
+static struct audio_codec_info audio_codec_info[CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT];
+static uint32_t bis_index_bitfields[CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT];
+
+static struct active_stream active_audio_stream;
+
+/* The values of sync_stream_cnt and active_stream_index must never become larger
+ * than the sizes of the arrays above (audio_streams etc.)
+ */
+static uint8_t sync_stream_cnt;
+static uint8_t active_stream_index;
 
 /* We need to set a location as a pre-compile, this changed in initialize */
-static struct bt_codec codec =
+static struct bt_codec codec_capabilities =
 	BT_CODEC_LC3_CONFIG_48_4(BT_AUDIO_LOCATION_FRONT_LEFT, BT_AUDIO_CONTEXT_TYPE_MEDIA);
-
-/* Create a mask for the maximum BIS we can sync to using the number of streams
- * broadcasted. We add an additional 1 since the bis indexes start from 1 and not
- * 0.
- */
-static const uint32_t bis_index_mask = BIT_MASK(CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT + 1U);
-static uint32_t bis_index_bitfield;
 
 static le_audio_receive_cb receive_cb;
 static bool init_routine_completed;
@@ -46,27 +66,39 @@ static bool playing_state = true;
 
 static int bis_headset_cleanup(bool from_sync_lost_cb);
 
-static void print_codec(const struct bt_codec *codec)
+static void print_codec(const struct audio_codec_info *codec)
+{
+	if (codec->id == BT_CODEC_LC3_ID) {
+		LOG_INF("Codec config for LC3:");
+		LOG_INF("\tFrequency: %d Hz", codec->frequency);
+		LOG_INF("\tFrame Duration: %d us", codec->frame_duration_us);
+		LOG_INF("\tOctets per frame: %d (%d kbps)", codec->octets_per_sdu, codec->bitrate);
+		LOG_INF("\tFrames per SDU: %d", codec->blocks_per_sdu);
+		if (codec->chan_allocation >= 0) {
+			LOG_INF("\tChannel allocation: 0x%x", codec->chan_allocation);
+		}
+	} else {
+		LOG_WRN("Codec is not LC3, codec_id: 0x%2hhx", codec->id);
+	}
+}
+
+static void get_codec_info(const struct bt_codec *codec, struct audio_codec_info *codec_info)
 {
 	if (codec->id == BT_CODEC_LC3_ID) {
 		/* LC3 uses the generic LTV format - other codecs might do as well */
-		uint32_t chan_allocation;
-
-		LOG_INF("Codec config for LC3:");
-		LOG_INF("\tFrequency: %d Hz", bt_codec_cfg_get_freq(codec));
-		LOG_INF("\tFrame Duration: %d us", bt_codec_cfg_get_frame_duration_us(codec));
-		if (bt_codec_cfg_get_chan_allocation_val(codec, &chan_allocation) == 0) {
-			LOG_INF("\tChannel allocation: 0x%x", chan_allocation);
-		}
-
-		uint32_t octets_per_sdu = bt_codec_cfg_get_octets_per_frame(codec);
-		uint32_t bitrate =
-			octets_per_sdu * 8 * (1000000 / bt_codec_cfg_get_frame_duration_us(codec));
-
-		LOG_INF("\tOctets per frame: %d (%d kbps)", octets_per_sdu, bitrate);
-		LOG_INF("\tFrames per SDU: %d", bt_codec_cfg_get_frame_blocks_per_sdu(codec, true));
+		LOG_DBG("Retrieve the codec configuration for LC3");
+		codec_info->id = codec->id;
+		codec_info->cid = codec->cid;
+		codec_info->vid = codec->vid;
+		codec_info->frequency = bt_codec_cfg_get_freq(codec);
+		codec_info->frame_duration_us = bt_codec_cfg_get_frame_duration_us(codec);
+		bt_codec_cfg_get_chan_allocation_val(codec, &codec_info->chan_allocation);
+		codec_info->octets_per_sdu = bt_codec_cfg_get_octets_per_frame(codec);
+		codec_info->bitrate =
+			(codec_info->octets_per_sdu * 8 * 1000000) / codec_info->frame_duration_us;
+		codec_info->blocks_per_sdu = bt_codec_cfg_get_frame_blocks_per_sdu(codec, true);
 	} else {
-		LOG_WRN("Codec is not LC3, codec_id: 0x%2x", codec->id);
+		LOG_WRN("Codec is not LC3, codec_id: 0x%2hhx", codec->id);
 	}
 }
 
@@ -102,7 +134,7 @@ static void stream_started_cb(struct bt_audio_stream *stream)
 	ret = ctrl_events_le_audio_event_send(LE_AUDIO_EVT_STREAMING);
 	ERR_CHK(ret);
 
-	LOG_INF("Stream started");
+	LOG_INF("Stream index %d started", active_stream_index);
 }
 
 static void stream_stopped_cb(struct bt_audio_stream *stream)
@@ -112,7 +144,7 @@ static void stream_stopped_cb(struct bt_audio_stream *stream)
 	ret = ctrl_events_le_audio_event_send(LE_AUDIO_EVT_NOT_STREAMING);
 	ERR_CHK(ret);
 
-	LOG_INF("Stream stopped");
+	LOG_INF("Stream index %d stopped", active_stream_index);
 }
 
 static void stream_recv_cb(struct bt_audio_stream *stream, const struct bt_iso_recv_info *info,
@@ -207,56 +239,63 @@ static void pa_sync_lost_cb(struct bt_audio_broadcast_sink *sink)
 static void base_recv_cb(struct bt_audio_broadcast_sink *sink, const struct bt_audio_base *base)
 {
 	int ret;
-	uint32_t base_bis_index_bitfield = 0U;
-	enum audio_channel channel;
+	bool suitable_stream_found = false;
 
 	if (init_routine_completed) {
 		return;
 	}
 
-	/* Test to ensure there are enough streams for each subgroup */
-	if (base->subgroup_count > CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT) {
-		LOG_WRN("Too many channels in subgroup");
-		return;
-	}
+	LOG_DBG("Received BASE with %zu subgroup(s) from broadcast sink", base->subgroup_count);
 
-	channel_assignment_get(&channel);
-
-	channel = BIT(channel);
-
-	LOG_DBG("Received BASE with %d subgroup(s) from broadcast sink", base->subgroup_count);
+	sync_stream_cnt = 0;
 
 	/* Search each subgroup for the BIS of interest */
 	for (int i = 0; i < base->subgroup_count; i++) {
 		for (int j = 0; j < base->subgroups[i].bis_count; j++) {
 			const uint8_t index = base->subgroups[i].bis_data[j].index;
 
-			LOG_DBG("BIS %d   index = %d", j, index);
+			LOG_DBG("BIS %d   index = %hhu", j, index);
 
-			/* If this is a BIS of interest then attach to and start a stream */
-			if (index == channel) {
-				if (bitrate_check((struct bt_codec *)&base->subgroups[i].codec)) {
-					base_bis_index_bitfield |= BIT(index);
+			if (bitrate_check((struct bt_codec *)&base->subgroups[i].codec)) {
+				suitable_stream_found = true;
 
-					streams[i].codec =
-						(struct bt_codec *)&base->subgroups[i].codec;
-					print_codec(streams[i].codec);
+				bis_index_bitfields[sync_stream_cnt] = BIT(index);
 
-					LOG_DBG("Stream %d in subgroup %d from broadcast sink", i,
-						j);
+				audio_streams[sync_stream_cnt].codec =
+					(struct bt_codec *)&base->subgroups[i].codec;
+				get_codec_info(audio_streams[sync_stream_cnt].codec,
+					       &audio_codec_info[sync_stream_cnt]);
+				print_codec(&audio_codec_info[sync_stream_cnt]);
+
+				LOG_DBG("Stream %d in subgroup %d from broadcast sink",
+					sync_stream_cnt, i);
+
+				sync_stream_cnt += 1;
+				if (sync_stream_cnt >= ARRAY_SIZE(audio_streams)) {
+					break;
 				}
 			}
 		}
+
+		if (sync_stream_cnt >= ARRAY_SIZE(audio_streams)) {
+			break;
+		}
 	}
 
-	if (base_bis_index_bitfield) {
+	/* Set the initial active stream based on the defined channel of the device */
+	channel_assignment_get((enum audio_channel *)&active_stream_index);
+	active_audio_stream.stream = &audio_streams[active_stream_index];
+	active_audio_stream.codec = &audio_codec_info[active_stream_index];
+
+	if (suitable_stream_found) {
 		ret = ctrl_events_le_audio_event_send(LE_AUDIO_EVT_CONFIG_RECEIVED);
 		ERR_CHK(ret);
-		bis_index_bitfield = base_bis_index_bitfield & bis_index_mask;
 
+		LOG_DBG("Channel %s active",
+			((active_stream_index == AUDIO_CH_L) ? CH_L_TAG : CH_R_TAG));
 		LOG_DBG("Waiting for syncable");
 	} else {
-		LOG_WRN("Found no suitable streams");
+		LOG_WRN("Found no suitable stream");
 	}
 }
 
@@ -264,7 +303,9 @@ static void syncable_cb(struct bt_audio_broadcast_sink *sink, bool encrypted)
 {
 	int ret;
 
-	if (streams[0].ep->status.state == BT_AUDIO_EP_STATE_STREAMING || !playing_state) {
+	if (active_audio_stream.stream->ep->status.state == BT_AUDIO_EP_STATE_STREAMING ||
+	    !playing_state) {
+		LOG_DBG("Syncable received, but either in paused_state or already in a stream");
 		return;
 	}
 
@@ -273,9 +314,10 @@ static void syncable_cb(struct bt_audio_broadcast_sink *sink, bool encrypted)
 		return;
 	}
 
-	LOG_INF("Syncing to broadcast");
+	LOG_INF("Syncing to broadcast stream index %d", active_stream_index);
 
-	ret = bt_audio_broadcast_sink_sync(broadcast_sink, bis_index_bitfield, streams_p, NULL);
+	ret = bt_audio_broadcast_sink_sync(broadcast_sink, bis_index_bitfields[active_stream_index],
+					   audio_streams_p, NULL);
 	if (ret) {
 		LOG_WRN("Unable to sync to broadcast source, ret: %d", ret);
 		return;
@@ -292,7 +334,7 @@ static struct bt_audio_broadcast_sink_cb broadcast_sink_cbs = { .scan_recv = sca
 								.syncable = syncable_cb };
 
 static struct bt_pacs_cap capabilities = {
-	.codec = &codec,
+	.codec = &codec_capabilities,
 };
 
 static void initialize(le_audio_receive_cb recv_cb)
@@ -324,10 +366,13 @@ static void initialize(le_audio_receive_cb recv_cb)
 
 		bt_audio_broadcast_sink_register_cb(&broadcast_sink_cbs);
 
-		for (int i = 0; i < ARRAY_SIZE(streams); i++) {
-			streams_p[i] = &streams[i];
-			streams[i].ops = &stream_ops;
+		for (int i = 0; i < ARRAY_SIZE(audio_streams); i++) {
+			audio_streams_p[i] = &audio_streams[i];
+			audio_streams[i].ops = &stream_ops;
 		}
+
+		active_audio_stream.stream = NULL;
+		active_audio_stream.codec = NULL;
 
 		initialized = true;
 	}
@@ -358,26 +403,55 @@ static int bis_headset_cleanup(bool from_sync_lost_cb)
 		broadcast_sink = NULL;
 	}
 
-	bis_index_bitfield = 0U;
 	init_routine_completed = false;
 
 	return 0;
 }
 
+int le_audio_user_defined_button_press(void)
+{
+	int ret = 0;
+
+	playing_state = false;
+
+	ret = ctrl_events_le_audio_event_send(LE_AUDIO_EVT_NOT_STREAMING);
+	ERR_CHK(ret);
+
+	ret = bt_audio_broadcast_sink_stop(broadcast_sink);
+	if (ret) {
+		LOG_WRN("Failed to pause playing");
+	}
+
+	/* Wrap streams */
+	if (++active_stream_index >= sync_stream_cnt) {
+		active_stream_index = 0;
+	}
+
+	active_audio_stream.stream = &audio_streams[active_stream_index];
+	active_audio_stream.codec = &audio_codec_info[active_stream_index];
+
+	playing_state = true;
+
+	LOG_DBG("Changed to stream %d", active_stream_index);
+
+	return ret;
+}
+
 int le_audio_config_get(uint32_t *bitrate, uint32_t *sampling_rate)
 {
-	int frames_per_sec = 1000000 / bt_codec_cfg_get_frame_duration_us(streams[0].codec);
-	int bits_per_frame = bt_codec_cfg_get_octets_per_frame(streams[0].codec) * 8;
+	if (active_audio_stream.codec == NULL) {
+		return -ECANCELED;
+	}
 
-	*sampling_rate = bt_codec_cfg_get_freq(streams[0].codec);
-	*bitrate = frames_per_sec * bits_per_frame;
+	*sampling_rate = active_audio_stream.codec->frequency;
+	*bitrate = active_audio_stream.codec->bitrate;
 
 	return 0;
 }
 
 int le_audio_volume_up(void)
 {
-	if (streams[0].ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
+	if (active_audio_stream.stream->ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
 		return -ECANCELED;
 	}
 
@@ -386,7 +460,7 @@ int le_audio_volume_up(void)
 
 int le_audio_volume_down(void)
 {
-	if (streams[0].ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
+	if (active_audio_stream.stream->ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
 		return -ECANCELED;
 	}
 
@@ -395,7 +469,7 @@ int le_audio_volume_down(void)
 
 int le_audio_volume_mute(void)
 {
-	if (streams[0].ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
+	if (active_audio_stream.stream->ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
 		return -ECANCELED;
 	}
 

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -1043,6 +1043,11 @@ static int initialize(le_audio_receive_cb recv_cb)
 	return 0;
 }
 
+int le_audio_user_defined_button_press(void)
+{
+	return 0;
+}
+
 int le_audio_config_get(uint32_t *bitrate, uint32_t *sampling_rate)
 {
 	return 0;

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -570,6 +570,11 @@ static int initialize(le_audio_receive_cb recv_cb)
 	return 0;
 }
 
+int le_audio_user_defined_button_press(void)
+{
+	return 0;
+}
+
 int le_audio_config_get(uint32_t *bitrate, uint32_t *sampling_rate)
 {
 	/* Get the configuration for the sink stream */

--- a/applications/nrf5340_audio/src/main.c
+++ b/applications/nrf5340_audio/src/main.c
@@ -99,7 +99,7 @@ static int bonding_clear_check(void)
 	int ret;
 	bool pressed;
 
-	ret = button_pressed(BUTTON_MUTE, &pressed);
+	ret = button_pressed(BUTTON_5, &pressed);
 	if (ret) {
 		return ret;
 	}

--- a/applications/nrf5340_audio/src/modules/button_assignments.h
+++ b/applications/nrf5340_audio/src/modules/button_assignments.h
@@ -16,14 +16,14 @@
 
 #include <zephyr/drivers/gpio.h>
 
-/**@brief List of buttons and associated metadata
+/** @brief List of buttons and associated metadata
  */
 enum button_pin_names {
 	BUTTON_VOLUME_DOWN = DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
 	BUTTON_VOLUME_UP = DT_GPIO_PIN(DT_ALIAS(sw1), gpios),
 	BUTTON_PLAY_PAUSE = DT_GPIO_PIN(DT_ALIAS(sw2), gpios),
-	BUTTON_TEST_TONE = DT_GPIO_PIN(DT_ALIAS(sw3), gpios),
-	BUTTON_MUTE = DT_GPIO_PIN(DT_ALIAS(sw4), gpios),
+	BUTTON_4 = DT_GPIO_PIN(DT_ALIAS(sw3), gpios),
+	BUTTON_5 = DT_GPIO_PIN(DT_ALIAS(sw4), gpios),
 };
 
 #endif /* _BUTTON_ASSIGNMENTS_H_ */

--- a/applications/nrf5340_audio/src/modules/button_handler.c
+++ b/applications/nrf5340_audio/src/modules/button_handler.c
@@ -45,13 +45,13 @@ const static struct btn_config btn_cfg[] = {
 		.btn_cfg_mask = DT_GPIO_FLAGS(DT_ALIAS(sw2), gpios),
 	},
 	{
-		.btn_name = STRINGIFY(BUTTON_TEST_TONE),
-		.btn_pin = BUTTON_TEST_TONE,
+		.btn_name = STRINGIFY(BUTTON_4),
+		.btn_pin = BUTTON_4,
 		.btn_cfg_mask = DT_GPIO_FLAGS(DT_ALIAS(sw3), gpios),
 	},
 	{
-		.btn_name = STRINGIFY(BUTTON_MUTE),
-		.btn_pin = BUTTON_MUTE,
+		.btn_name = STRINGIFY(BUTTON_5),
+		.btn_pin = BUTTON_5,
 		.btn_cfg_mask = DT_GPIO_FLAGS(DT_ALIAS(sw4), gpios),
 	}
 };

--- a/applications/nrf5340_audio/src/modules/dfu_entry.c
+++ b/applications/nrf5340_audio/src/modules/dfu_entry.c
@@ -136,7 +136,7 @@ void dfu_entry_check(void)
 	int ret;
 	bool pressed;
 
-	ret = button_pressed(BUTTON_TEST_TONE, &pressed);
+	ret = button_pressed(BUTTON_4, &pressed);
 	if (ret) {
 		return;
 	}

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -172,6 +172,7 @@ nRF5340 Audio
   * Added a walkie talkie demo for bidirectional CIS.
   * Added minimal Media Control Service (MCS) functionality to the Play/Pause button.
   * Added Coordinated Set Identification Service (CSIS) for the CIS headset.
+  * Added functionality for supporting multiple streams on BIS headsets.
 
 * Updated:
 


### PR DESCRIPTION
Only one BIS is active at a given time

Signed-off-by: Graham Wacey <graham.wacey@nordicsemi.no>
Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>