### PR TITLE
applications: asset_tracker_v2: Ignore error code when enabling mdev

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -834,8 +834,9 @@ static int setup(void)
 
 	err = lte_lc_modem_events_enable();
 	if (err) {
-		LOG_ERR("lte_lc_modem_events_enable failed, error: %d", err);
-		return err;
+		LOG_WRN("lte_lc_modem_events_enable failed, error: %d", err);
+		LOG_DBG("Modem firmware versions older than 1.3.0 do not support "
+			"enabling modem domain events");
 	}
 
 	err = modem_data_init();


### PR DESCRIPTION
Modem domain events are not supported for modem firmware versions older than 1.3.0. Therefore we ignore error codes returned by `lte_lc_modem_events_enable` to prevent the application from rebooting. In case an older modem firmware version is used.