### PR TITLE
bluetooth: fast_pair: Add Personalized Name documentation

### DIFF
--- a/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
+++ b/doc/nrf/libraries/bluetooth_services/services/fast_pair.rst
@@ -20,9 +20,6 @@ Characteristics
 The Fast Pair GATT characteristics are described in detail in the `Fast Pair GATT Characteristics`_ documentation.
 The implementation in the |NCS| follows these requirements.
 
-.. note::
-   The Additional Data characteristic is not supported yet.
-
 Configuration
 *************
 
@@ -35,6 +32,8 @@ The following Kconfig options are also available for this module:
   MbedTLS is used by default, whereas Tinycrypt is used by default for cases of building with TF-M as the Secure Execution Environment (:kconfig:option:`CONFIG_BUILD_WITH_TFM`).
   This is because in such case the MbedTLS API cannot be directly used by the Fast Pair service.
   The Oberon backend can be used to limit memory consumption.
+* :kconfig:option:`CONFIG_BT_FAST_PAIR_EXT_PN` - The option enables the `Fast Pair Personalized Name extension`_.
+* :kconfig:option:`CONFIG_BT_FAST_PAIR_STORAGE_EXT_PN_LEN_MAX` - The option specifies the maximum length of a stored Fast Pair Personalized Name.
 
 See the Kconfig help for details.
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -822,6 +822,8 @@
 .. _`Fast Pair GATT Characteristics`: https://developers.google.com/nearby/fast-pair/specifications/characteristics
 .. _`Fast Pair Procedure`: https://developers.google.com/nearby/fast-pair/specifications/service/gatt
 .. _`Verifying Fast Pair`: https://developers.google.com/nearby/fast-pair/help#verifying_fast_pair
+.. _`Fast Pair Personalized Name extension`: https://developers.google.com/nearby/fast-pair/specifications/extensions/personalizedname
+.. _`Fast Pair Certification Guidelines for Personalized Name`: https://developers.google.com/nearby/fast-pair/certification-guideline#2_personalized_name
 
 .. _`Protocol Buffers`: https://developers.google.com/protocol-buffers
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -459,6 +459,7 @@ See `Bluetooth mesh samples`_ for the list of changes for the Bluetooth mesh sam
 
   * Disabled automatic security re-establishment request as a peripheral (:kconfig:option:`CONFIG_BT_GATT_AUTO_SEC_REQ`) to allow the Fast Pair Seeker to control the security re-establishment.
   * Added API to check Account Key presence (:c:func:`bt_fast_pair_has_account_key`).
+  * Added support for the Personalized Name extension.
 
 Bootloader libraries
 --------------------

--- a/samples/bluetooth/peripheral_fast_pair/README.rst
+++ b/samples/bluetooth/peripheral_fast_pair/README.rst
@@ -236,6 +236,14 @@ Test not discoverable advertising by completing `Testing`_ and the following add
 #. Press **Button 2** to increase the audio volume.
 #. Press **Button 4** to decrease the audio volume.
 
+Personalized Name extension
+----------------------------
+
+Testing Personalized Name extension is described in `Fast Pair Certification Guidelines for Personalized Name`_.
+
+.. note::
+   To mitigate Android Personalized Name write issues, whenever you change the Personalized Name on an Android phone, you have to disconnect the phone from the Fast Pair Provider and wait for the phone to reconnect and write the new Personalized Name.
+
 Dependencies
 ************
 


### PR DESCRIPTION
Adds documentation to Personalized Name Fast Pair extension.

Jira: NCSDK-17114