### PR TITLE
drivers: wifi: Decrease the tx pending queue length

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -42,7 +42,7 @@ config NRF700X_WORKQ_MAX_ITEMS
 
 config NRF700x_MAX_TX_PENDING_QLEN
 	int "Maximum number of pending TX packets"
-	default 1024
+	default 48
 
 config NRF700X_RADIO_TEST
 	bool "Radio test mode of the nRF700x driver"


### PR DESCRIPTION
Decrease the pending tx queue length to 48 from 1024 to fix OOM issues.

Signed-off-by: Ravi Dondaputi <ravi.dondaputi@nordicsemi.no>