### PR TITLE
mpsl: fem: nrf21540_gpio_spi: fix built-in model init

### DIFF
--- a/subsys/mpsl/fem/nrf21540_gpio_spi/models/mpsl_fem_nrf21540_power_model_builtin.c
+++ b/subsys/mpsl/fem/nrf21540_gpio_spi/models/mpsl_fem_nrf21540_power_model_builtin.c
@@ -46,7 +46,7 @@ K_TIMER_DEFINE(model_update_timer, model_update_timeout, NULL);
 static int model_periodic_update_start(const struct device *unused)
 {
 	/* Perform initial model update */
-	model_update_work_handler(NULL);
+	k_work_submit(&model_update_work);
 
 	k_timer_start(&model_update_timer,
 				K_MSEC(CONFIG_MPSL_FEM_BUILTIN_POWER_MODEL_UPDATE_PERIOD),


### PR DESCRIPTION
The MPSL-based temperature driver is not reentrant. Current implementation of the nRF21540 GPIO+SPI built-in model calls it from a different execution context than other modules. That leads to preemption of the temperature driver that effectively locks the entire application in an endless loop. This commit unifies the execution context of the temperature driver in the nRF21540 GPIO+SPI built-in model and fixes the bug that results from this preemption.

Signed-off-by: Jędrzej Ciupis <jedrzej.ciupis@nordicsemi.no>