### PR TITLE
doc: Fix doc for TF-M PSA and regression tests

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -368,6 +368,14 @@ nRF9160 samples
     * Board overlay file for nRF9160 DK with external flash.
     * Overlay file to enable P-GPS data storage in external flash.
 
+Trusted Firmware-M (TF-M) samples
+---------------------------------
+
+* Added:
+
+  * :ref:`tfm_psa_test` for validating compliance with PSA Certified requirements.
+  * :ref:`tfm_regression_test` to run secure and non-secure Trusted Firmware-M (TF-M) regression tests.
+
 Thread samples
 --------------
 

--- a/tests/tfm/tfm_psa_test/README.rst
+++ b/tests/tfm/tfm_psa_test/README.rst
@@ -1,49 +1,62 @@
 .. _tfm_psa_test:
 
-TF-M Platform Security Architecture Test Sample
-###############################################
+TF-M: Platform security architecture test
+#########################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+The TF-M platform security architecture test sample provides a basis for validating compliance with PSA Certified requirements using the Arm® Platform Security Architecture (PSA) test suites.
+
+Requirements
+************
+
+The test supports the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf9160dk_nrf9160_ns
 
 Overview
 ********
 
+The PSA tests are implemented in the psa-arch-tests repo: https://github.com/ARM-software/psa-arch-tests.
 Run PSA test suites tests with Zephyr and TFM.
 
-The PSA tests are implemented in the psa-arch-tests repo: https://github.com/ARM-software/psa-arch-tests
+To choose a test suite, use the ``CONFIG_TFM_PSA_TEST_*`` Kconfig options.
+Only one of these suites can be run at a time.
 
-This sample is supported for platforms that have a port in psa-arch-tests.
-See sample.yaml for a list of supported platforms.
+Configuration
+*************
 
-Building and Running
+The following Kconfig options can be used to choose a test suite:
+
+* :kconfig:option:`CONFIG_TFM_PSA_TEST_CRYPTO`
+* :kconfig:option:`CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE`
+* :kconfig:option:`CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE`
+* :kconfig:option:`CONFIG_TFM_PSA_TEST_STORAGE`
+* :kconfig:option:`CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION`
+
+|config|
+
+Building and running
 ********************
 
-You must choose a suite via the CONFIG_TFM_PSA_TEST_* configs.
+.. |test path| replace:: :file:`tests/tfm/tfm_psa_test/`
 
-Only one of these suites can be run at a time, with the test suite set via one
-of the following kconfig options:
+.. include:: /includes/build_and_run_test.txt
 
-* ``CONFIG_TFM_PSA_TEST_CRYPTO``
-* ``CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE``
-* ``CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE``
-* ``CONFIG_TFM_PSA_TEST_STORAGE``
-* ``CONFIG_TFM_PSA_TEST_INITIAL_ATTESTATION``
+You can indicate the desired test suite by using a configuration flag when building (replace ``<build_target>`` with your board name, for example ``nrf5340dk_nrf5340_cpuapp_ns``):
 
-You can indicate the desired test suite at build time via a config flag:
+.. code-block:: console
 
-   .. code-block:: bash
-
-     $ west build samples/tfm_integration/tfm_psa_test/ \
-       -p -b nrf5340dk_nrf5340_cpuapp_ns -t run -- \
-       -DCONFIG_TFM_PSA_TEST_STORAGE=y
+    west build -b <build_target> nrf/tests/tfm/tfm_psa_test -- -DCONFIG_TFM_PSA_TEST_STORAGE=y
 
 Note that not all test suites are valid on all boards.
 
-On Target
-=========
-
-Refer to :ref:`tfm_ipc` for detailed instructions.
-
-Sample Output
-=============
+Output
+======
 
    .. code-block:: console
 

--- a/tests/tfm/tfm_regression_test/README.rst
+++ b/tests/tfm/tfm_regression_test/README.rst
@@ -1,30 +1,48 @@
 .. _tfm_regression_test:
 
-TF-M Regression Test Sample
-###########################
+TF-M: Regression tests
+######################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Use this test sample to run secure and non-secure Trusted Firmware-M (TF-M) regression tests.
+
+Requirements
+************
+
+The tests support the following development kits:
+
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: nrf5340dk_nrf5340_cpuapp_ns, nrf9160dk_nrf9160_ns
 
 Overview
 ********
 
-Run both the Secure and Non-secure TF-M Regression tests using the Zephyr build system.
+Run both the secure and non-secure TF-M regression tests using the Zephyr build system.
 
-The build system will replace the Zephyr application with the Non-Secure TF-M test application,
-while the Secure tests will be included in the TF-M build itself.
+The build system will replace the Zephyr application with the non-secure TF-M test application, while the secure tests will be included in the TF-M build itself.
 
-The TF-M regression tests are implemented in the tf-m-tests repo: https://git.trustedfirmware.org/TF-M/tf-m-tests.git/
+The TF-M regression tests are implemented in the tf-m-tests repo: https://git.trustedfirmware.org/TF-M/tf-m-tests.git/.
 
-Building and Running
+Configuration
+*************
+
+Tests for both the secure and non-secure area are enabled by default, but can be controlled via the Kconfig options :kconfig:option:`CONFIG_TFM_REGRESSION_S` and :kconfig:option:`CONFIG_TFM_REGRESSION_NS` respectively.
+
+|config|
+
+Building and running
 ********************
 
-Tests for both the secure and non-secure domain are enabled by default, controlled via the CONFIG_TFM_REGRESSION_S and CONFIG_TFM_REGRESSION_NS configs.
+.. |test path| replace:: :file:`tests/tfm/tfm_regression_test/`
 
-On Target
-=========
+.. include:: /includes/build_and_run_test.txt
 
-Refer to :ref:`tfm_ipc` for detailed instructions.
-
-Sample Output
-=============
+Output
+======
 
    .. code-block:: console
 


### PR DESCRIPTION
Fixing the structure and content of the two
TF-M tests that were moved from Zephyr into NCS.

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>