### PR TITLE
matter: pull fixes for heap usage

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: fb603e956f290197d1ce2f7776dda42bfb5f5497
+      revision: 628801f62ac6deba484802a17fb64aac7da9d73c
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Pull a fix for build error with CHIP_MALLOC_SYS_HEAP Kconfig option and increase the default value of
NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE for Matter applications.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>