### PR TITLE
applications: nrf5340_audio: Update LC3 config path and BIS compile warning

### DIFF
--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -176,7 +176,7 @@ config LC3_BITRATE_MIN
 	int "Min bitrate for LC3"
 	default 32000
 
-osource "../modules/lib/lc3/Kconfig"
+osource "../nrfxlib/lc3/Kconfig"
 
 endmenu # LC3
 endmenu # SW Codec

--- a/applications/nrf5340_audio/src/bluetooth/CMakeLists.txt
+++ b/applications/nrf5340_audio/src/bluetooth/CMakeLists.txt
@@ -5,12 +5,13 @@
 #
 
 target_sources(app PRIVATE
-	       ${CMAKE_CURRENT_SOURCE_DIR}/ble_audio_services.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/ble_core.c
 	       ${CMAKE_CURRENT_SOURCE_DIR}/ble_hci_vsc.c
 )
 
 if (CONFIG_TRANSPORT_CIS)
+	target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ble_audio_services.c)
+
 	# HEADSET
 	if (CONFIG_AUDIO_DEV EQUAL 1)
 		target_sources(app PRIVATE


### PR DESCRIPTION

Updated the LC3 Kconfig path.
Updated CMakelists for only including ble_audio_services.c for CIS.

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>