### PR TITLE
samples: esb: Fix dynamic interrupts and add dynamic interrupts test cases

### DIFF
--- a/samples/esb/prx/sample.yaml
+++ b/samples/esb/prx/sample.yaml
@@ -20,4 +20,15 @@ tests:
       - nrf5340dk_nrf5340_cpunet
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
       nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
-    tags: ci_build
+    tags: esb ci_build
+  sample.esb.prx.dynamic_irq:
+    build_only: true
+    extra_configs:
+      - CONFIG_ESB_DYNAMIC_INTERRUPTS=y
+      - CONFIG_DYNAMIC_INTERRUPTS=y
+      - CONFIG_DYNAMIC_DIRECT_INTERRUPTS=y
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+      - nrf52840dk_nrf52840
+    platform_allow: nrf5340dk_nrf5340_cpunet nrf52840dk_nrf52840
+    tags: esb ci_build

--- a/samples/esb/ptx/sample.yaml
+++ b/samples/esb/ptx/sample.yaml
@@ -20,4 +20,15 @@ tests:
       - nrf5340dk_nrf5340_cpunet
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
       nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
-    tags: ci_build
+    tags: esb ci_build
+  sample.esb.ptx.dynamic_irq:
+    build_only: true
+    extra_configs:
+      - CONFIG_ESB_DYNAMIC_INTERRUPTS=y
+      - CONFIG_DYNAMIC_INTERRUPTS=y
+      - CONFIG_DYNAMIC_DIRECT_INTERRUPTS=y
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+      - nrf52840dk_nrf52840
+    platform_allow: nrf5340dk_nrf5340_cpunet nrf52840dk_nrf52840
+    tags: esb ci_build

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -1088,9 +1088,10 @@ void ESB_EVT_IRQHandler(const void *args)
 	ISR_DIRECT_PM();
 }
 
-void ESB_SYS_TIMER_IRQHandler(const void *args)
+void ESB_TIMER_IRQHandler(const void *args)
 {
 	ARG_UNUSED(args);
+	ESB_TIMER_IRQ_HANDLER();
 	ISR_DIRECT_PM();
 }
 
@@ -1178,18 +1179,18 @@ int esb_init(const struct esb_config *config)
 	esb_irq_disable();
 
 	ARM_IRQ_DIRECT_DYNAMIC_CONNECT(RADIO_IRQn, CONFIG_ESB_RADIO_IRQ_PRIORITY,
-					0, reschedule);
+				       0, reschedule);
 	ARM_IRQ_DIRECT_DYNAMIC_CONNECT(ESB_EVT_IRQ, CONFIG_ESB_EVENT_IRQ_PRIORITY,
-					0, reschedule);
-	ARM_IRQ_DIRECT_DYNAMIC_CONNECT(ESB_SYS_TIMER_IRQn, CONFIG_ESB_EVENT_IRQ_PRIORITY,
-					0, reschedule);
+				       0, reschedule);
+	ARM_IRQ_DIRECT_DYNAMIC_CONNECT(ESB_TIMER_IRQ, CONFIG_ESB_EVENT_IRQ_PRIORITY,
+				       0, reschedule);
 
 	irq_connect_dynamic(RADIO_IRQn, CONFIG_ESB_RADIO_IRQ_PRIORITY,
-			   RADIO_IRQHandler, NULL, 0);
+			    RADIO_IRQHandler, NULL, 0);
 	irq_connect_dynamic(ESB_EVT_IRQ, CONFIG_ESB_EVENT_IRQ_PRIORITY,
-			   ESB_EVT_IRQHandler,  NULL, 0);
-	irq_connect_dynamic(ESB_SYS_TIMER_IRQn, CONFIG_ESB_EVENT_IRQ_PRIORITY,
-			   ESB_SYS_TIMER_IRQHandler, NULL, 0);
+			    ESB_EVT_IRQHandler,  NULL, 0);
+	irq_connect_dynamic(ESB_TIMER_IRQ, CONFIG_ESB_EVENT_IRQ_PRIORITY,
+			    ESB_TIMER_IRQHandler, NULL, 0);
 
 #else /* !IS_ENABLED(CONFIG_ESB_DYNAMIC_INTERRUPTS) */
 


### PR DESCRIPTION
Fix the timer dynamic interrupt name and add the Twister test cases for building the
ESB samples with support for dynamic interrupts enabled.