### PR TITLE
applications: asset_tracker_v2: impact detection: select adxl372

### DIFF
--- a/applications/asset_tracker_v2/doc/sensor_module.rst
+++ b/applications/asset_tracker_v2/doc/sensor_module.rst
@@ -86,7 +86,7 @@ Motion impact detection
 =======================
 
 Motion impact is detected when the magnitude (root sum squared) of acceleration exceeds the configured threshold value.
-To enable motion impact detection, you must include :kconfig:option:`CONFIG_EXTERNAL_SENSORS_IMPACT_DETECTION` and :kconfig:option:`CONFIG_ADXL372` when building the application.
+To enable motion impact detection, you must include :kconfig:option:`CONFIG_EXTERNAL_SENSORS_IMPACT_DETECTION` when building the application.
 
 The threshold is configured using the :kconfig:option:`CONFIG_ADXL372_ACTIVITY_THRESHOLD` option.
 The accelerometer records acceleration magnitude when it is in the active mode and reports the peak magnitude once it reverts to the inactive mode.

--- a/applications/asset_tracker_v2/src/ext_sensors/Kconfig
+++ b/applications/asset_tracker_v2/src/ext_sensors/Kconfig
@@ -11,7 +11,7 @@ if EXTERNAL_SENSORS
 
 config EXTERNAL_SENSORS_IMPACT_DETECTION
 	bool "Impact detection"
-	depends on ADXL372
+	select ADXL372
 	help
 	  Enable this option to use the impact detection feature.
 	  Please note that this increases power consumption.


### PR DESCRIPTION
This patch makes CONFIG_EXTERNAL_SENSORS_IMPACT_DETECTION pull in the sensor driver as a dependency so it doesn't need to be explicitly specified.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>