### PR TITLE
wifi : Reduce NRF700x_MAX_TX_PENDING_QLEN to 48 ..

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -42,7 +42,7 @@ config NRF700X_WORKQ_MAX_ITEMS
 
 config NRF700x_MAX_TX_PENDING_QLEN
 	int "Maximum number of pending TX packets"
-	default 1024
+	default 48
 
 config NRF700X_RADIO_TEST
 	bool "Radio test mode of the nRF700x driver"

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
@@ -749,10 +749,6 @@ enum wifi_nrf_status tx_process(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 			    peer_id);
 
 	if (status != WIFI_NRF_STATUS_SUCCESS) {
-		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: tx_enqueue failed\n",
-				      __func__);
-
 		goto out;
 	}
 


### PR DESCRIPTION
Resolves the following issues :
SHEL-960 : Host is not refilling extram buffers after running UDP-Tx SHEL-967 : Observed lockup while running UDP_TX in legacy mode SHEL-812 : Observing DUT lockup after 2mins of UDP_TX stress test

Signed-off-by: Sridhar Nuvusetty <sridhar.nuvusetty@nordicsemi.no>