### PR TITLE
applications: asset_tracker_v2: Use `time_t` for timestamps

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/lwm2m/lwm2m_codec.c
@@ -25,10 +25,10 @@ LOG_MODULE_REGISTER(cloud_codec, CONFIG_CLOUD_CODEC_LOG_LEVEL);
 /* Some resources does not have designated buffers. Therefore we define those in here. */
 static uint8_t bearers[2] = { LTE_FDD_BEARER, NB_IOT_BEARER };
 static int battery_voltage;
-static int32_t pressure_ts;
-static int32_t temperature_ts;
-static int32_t humidity_ts;
-static int32_t button_ts;
+static time_t pressure_ts;
+static time_t temperature_ts;
+static time_t humidity_ts;
+static time_t button_ts;
 static int64_t current_time;
 
 /* Minimum and maximum values for the BME680 present on the Thingy:91. */

--- a/applications/asset_tracker_v2/tests/lwm2m_codec/src/lwm2m_codec_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec/src/lwm2m_codec_test.c
@@ -32,10 +32,10 @@
 
 static uint8_t bearers[2] = { LTE_FDD_BEARER, NB_IOT_BEARER };
 static int battery_voltage;
-static int32_t pressure_ts;
-static int32_t temperature_ts;
-static int32_t humidity_ts;
-static int32_t button_ts;
+static time_t pressure_ts;
+static time_t temperature_ts;
+static time_t humidity_ts;
+static time_t button_ts;
 static int64_t current_time;
 static double temp_min_range_val = BME680_TEMP_MIN_RANGE_VALUE;
 static double temp_max_range_val = BME680_TEMP_MAX_RANGE_VALUE;


### PR DESCRIPTION
Use `time_t` for timestamps to avoid run-time warning.