### PR TITLE
ci: Quarantine modem_shell.esp_wifi sample

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -29,3 +29,9 @@
   platforms:
     - all
   comment: "Disable zephyr Regression and PSA Arch tests, we maintain copies of these in sdk-nrf"
+
+- scenarios:
+    - sample.nrf9160.modem_shell.esp_wifi
+  platforms:
+    - nrf9160dk_nrf9160_ns
+  comment: "Not passing using zephyr-sdk:0.15.1"


### PR DESCRIPTION
Building sample with zephyr-sdk:0.15.1 toolchain failed. Quarantined to unblock integration.

Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>