### PR TITLE
app_event_manager: Allow to disable shell integration

### DIFF
--- a/doc/nrf/libraries/others/app_event_manager.rst
+++ b/doc/nrf/libraries/others/app_event_manager.rst
@@ -360,10 +360,11 @@ For details, refer to :ref:`app_event_manager_api`.
 Shell integration
 =================
 
-Shell integration is available to display additional information and to dynamically enable or disable logging for given event types.
+Shell integration (:kconfig:option:`CONFIG_APP_EVENT_MANAGER_SHELL`) is available to display additional information and to dynamically enable or disable logging for given event types.
+The shell integration is enabled by default.
 
 The Application Event Manager is integrated with Zephyr's :ref:`zephyr:shell_api` module.
-When the shell is turned on, an additional subcommand set (:command:`app_event_manager`) is added.
+When the shell integration is turned on, an additional subcommand set (:command:`app_event_manager`) is added.
 
 This subcommand set contains the following commands:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -747,6 +747,11 @@ Other libraries
   * Improved the calculation of MPSL timeslot length by using the :ref:`nrf_dm` library functionality.
   * Renamed the ``access_address`` field to ``rng_seed`` in the :c:struct:`dm_request` structure.
 
+* :ref:`app_event_manager`:
+
+  * Added :kconfig:option:`CONFIG_APP_EVENT_MANAGER_SHELL` Kconfig option.
+    The option can be used to disable Event Manager shell commands.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/subsys/app_event_manager/CMakeLists.txt
+++ b/subsys/app_event_manager/CMakeLists.txt
@@ -6,6 +6,6 @@
 
 zephyr_include_directories(.)
 zephyr_sources(app_event_manager.c)
-zephyr_sources_ifdef(CONFIG_SHELL app_event_manager_shell.c)
+zephyr_sources_ifdef(CONFIG_APP_EVENT_MANAGER_SHELL app_event_manager_shell.c)
 
 zephyr_linker_sources(SECTIONS aem.ld)

--- a/subsys/app_event_manager/Kconfig
+++ b/subsys/app_event_manager/Kconfig
@@ -30,6 +30,15 @@ config APP_EVENT_MANAGER_TRACE_EVENT_DATA
 	help
 	  This option allows to gather information about events for tracing purposes.
 
+config APP_EVENT_MANAGER_SHELL
+	bool "Enable shell integration"
+	depends on SHELL
+	default y
+	help
+	  Enable Event Manager shell commands to display information about
+	  listeners, subscribers and events. The commands also allow to
+	  dynamically enable or disable logging for given event types.
+
 module = APP_EVENT_MANAGER
 module-str = Application Event Manager
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Change introduces a Kconfig option that allows to disable Event Manager shell integration.

Jira: NCSDK-18166