### PR TITLE
manifest: Update sdk-zephyr head with Bluetooth mesh fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: bea6b16089ae1abcb1db4c5979c10d0184b696f8
+      revision: 28ef52cc995a9ef1869d9c16a70a1cecd4ecd003
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update sdk-zephyr head to pull Bluetooth mesh fixes from nrfconnect/sdk-zephyr#992.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>