### PR TITLE
nrf_profiler: Allow to disable shell integration

### DIFF
--- a/doc/nrf/libraries/others/nrf_profiler.rst
+++ b/doc/nrf/libraries/others/nrf_profiler.rst
@@ -207,7 +207,8 @@ Shell integration
 *****************
 
 The nRF Profiler is integrated with Zephyr's :ref:`zephyr:shell_api` module.
-When the shell is turned on, an additional subcommand set (:command:`nrf_profiler`) is added.
+You can use the :kconfig:option:`CONFIG_NRF_PROFILER_SHELL` option to add an additional subcommand set (:command:`nrf_profiler`) to the shell.
+The option is enabled by default.
 
 This subcommand set contains the following commands:
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -760,6 +760,11 @@ Other libraries
   * Added :kconfig:option:`CONFIG_APP_EVENT_MANAGER_SHELL` Kconfig option.
     The option can be used to disable Event Manager shell commands.
 
+* :ref:`nrf_profiler`:
+
+  * Added the :kconfig:option:`CONFIG_NRF_PROFILER_SHELL` Kconfig option.
+    The option can be used to disable the nRF Profiler shell commands.
+
 Common Application Framework (CAF)
 ----------------------------------
 

--- a/subsys/nrf_profiler/CMakeLists.txt
+++ b/subsys/nrf_profiler/CMakeLists.txt
@@ -5,4 +5,4 @@
 #
 
 zephyr_sources_ifdef(CONFIG_NRF_PROFILER_NORDIC profiler_nordic.c)
-zephyr_sources_ifdef(CONFIG_SHELL nrf_profiler_common_shell.c)
+zephyr_sources_ifdef(CONFIG_NRF_PROFILER_SHELL  profiler_common_shell.c)

--- a/subsys/nrf_profiler/Kconfig
+++ b/subsys/nrf_profiler/Kconfig
@@ -25,6 +25,14 @@ config NRF_PROFILER_MAX_LENGTH_OF_CUSTOM_EVENTS_DESCRIPTIONS
 	int "Maximum number of characters used to describe single event type"
 	default 128
 
+config NRF_PROFILER_SHELL
+	bool "Enable shell integration"
+	depends on SHELL
+	default y
+	help
+	  Enable nRF Profiler shell commands to list the profiled event types
+	  and to enable or disable profiling of specified event types.
+
 choice
 	prompt "Profiler selection"
 	default NRF_PROFILER_NORDIC


### PR DESCRIPTION
Change introduces a Kconfig option that allows to disable nRF Profiler shell integration.

Jira: NCSDK-18166