### PR TITLE
samples: nrf9160: modem_shell: update lwm2m_pgps build config

### DIFF
--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -58,7 +58,7 @@ tests:
     tags: ci_build
   sample.nrf9160.modem_shell.lwm2m_pgps:
     build_only: true
-    extra_args: OVERLAY_CONFIG="overlay-lwm2m.conf overlay-lwm2m_pgps.conf overlay-pgps.conf"
+    extra_args: OVERLAY_CONFIG="overlay-lwm2m.conf;overlay-lwm2m_pgps.conf;overlay-pgps.conf"
     integration_platforms:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns


### PR DESCRIPTION
Changed spaces to semicolons in OVERLAY_CONFIG for lwm2m_pgps build config.