### PR TITLE
drivers: wifi : Adds support for handling WIPHY capabilities, RX MLME frames 

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_api.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_api.h
@@ -859,6 +859,34 @@ enum wifi_nrf_status wifi_nrf_fmac_set_wowlan(void *fmac_dev_ctx,
 					      unsigned int var);
 
 /**
+ * wifi_nrf_fmac_get_wiphy() - Get PHY configuration.
+ * @fmac_dev_ctx: Pointer to the UMAC IF context for a RPU WLAN device.
+ * @if_idx: Index of the interface on which the CMD needs to be sent.
+ *
+ * This function is used to get PHY configuration from RPU.
+ *
+ * Returns: Status
+ *		Pass: %WIFI_NRF_STATUS_SUCCESS
+ *		Fail: %WIFI_NRF_STATUS_FAIL
+ */
+enum wifi_nrf_status wifi_nrf_fmac_get_wiphy(void *fmac_dev_ctx, unsigned char if_idx);
+
+/**
+ * wifi_nrf_fmac_register_frame() - Register to get MGMT frames.
+ * @fmac_dev_ctx: Pointer to the UMAC IF context for a RPU WLAN device.
+ * @if_idx: Index of the interface on which the CMD needs to be sent.
+ * @frame_info: Information regarding the management frame.
+ *
+ * Register with RPU to receive MGMT frames.
+ *
+ * Returns: Status
+ *		Pass: %WIFI_NRF_STATUS_SUCCESS
+ *		Fail: %WIFI_NRF_STATUS_FAIL
+ */
+enum wifi_nrf_status wifi_nrf_fmac_register_frame(void *dev_ctx, unsigned char if_idx,
+						  struct nrf_wifi_umac_mgmt_frame_info *frame_info);
+
+/**
  * wifi_nrf_fmac_set_wiphy_params() - set wiphy parameters
  * @fmac_dev_ctx: Pointer to the UMAC IF context for a RPU WLAN device.
  * @wiphy_info: wiphy parameters

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs.h
@@ -230,6 +230,10 @@ struct wifi_nrf_fmac_callbk_fns {
 	void (*twt_teardown_callbk_fn)(void *if_priv,
 		struct nrf_wifi_umac_cmd_teardown_twt *twt_teardown_event_info,
 		unsigned int event_len);
+
+	void (*event_get_wiphy)(void *if_priv,
+		struct nrf_wifi_event_get_wiphy *get_wiphy,
+		unsigned int event_len);
 };
 
 

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_A/host_rpu_umac_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_A/host_rpu_umac_if.h
@@ -3122,10 +3122,11 @@ struct nrf_wifi_interface_info {
 
 struct nrf_wifi_event_mcs_info {
 #define NRF_WIFI_HT_MCS_MASK_LEN 10
+#define NRF_WIFI_HT_MCS_RES_LEN 3
 	unsigned short nrf_wifi_rx_highest;
 	unsigned char nrf_wifi_rx_mask[NRF_WIFI_HT_MCS_MASK_LEN];
 	unsigned char nrf_wifi_tx_params;
-	unsigned char nrf_wifi_reserved[3];
+	unsigned char nrf_wifi_reserved[NRF_WIFI_HT_MCS_RES_LEN];
 } __NRF_WIFI_PKD;
 
 struct nrf_wifi_event_sta_ht_cap {

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_B/host_rpu_umac_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_B/host_rpu_umac_if.h
@@ -3200,10 +3200,11 @@ struct nrf_wifi_interface_info {
 
 struct nrf_wifi_event_mcs_info {
 #define NRF_WIFI_HT_MCS_MASK_LEN 10
+#define NRF_WIFI_HT_MCS_RES_LEN 3
 	unsigned short nrf_wifi_rx_highest;
 	unsigned char nrf_wifi_rx_mask[NRF_WIFI_HT_MCS_MASK_LEN];
 	unsigned char nrf_wifi_tx_params;
-	unsigned char nrf_wifi_reserved[3];
+	unsigned char nrf_wifi_reserved[NRF_WIFI_HT_MCS_RES_LEN];
 } __NRF_WIFI_PKD;
 
 struct nrf_wifi_event_sta_ht_cap {

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/event.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/event.c
@@ -398,6 +398,17 @@ static enum wifi_nrf_status umac_event_ctrl_process(struct wifi_nrf_fmac_dev_ctx
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
+	case NRF_WIFI_UMAC_EVENT_NEW_WIPHY:
+		if (callbk_fns->event_get_wiphy)
+			callbk_fns->event_get_wiphy(vif_ctx->os_vif_ctx,
+						    event_data,
+						    event_len);
+		else
+			wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+					      "%s: No callback registered for event %d\n",
+					      __func__,
+					      umac_hdr->cmd_evnt);
+		break;
 	case NRF_WIFI_UMAC_EVENT_CMD_STATUS:
 	case NRF_WIFI_UMAC_EVENT_BEACON_HINT:
 	case NRF_WIFI_UMAC_EVENT_CONNECT:

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
@@ -3028,6 +3028,81 @@ out:
 	return status;
 }
 
+enum wifi_nrf_status wifi_nrf_fmac_get_wiphy(void *dev_ctx, unsigned char if_idx)
+{
+	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
+	struct nrf_wifi_cmd_get_wiphy *get_wiphy = NULL;
+	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
+
+	fmac_dev_ctx = dev_ctx;
+
+	if (!dev_ctx || (if_idx >= MAX_NUM_VIFS)) {
+		goto out;
+	}
+
+	get_wiphy = wifi_nrf_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv,
+					      sizeof(*get_wiphy));
+
+	if (!get_wiphy) {
+		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+				      "%s: Unable to allocate memory\n",
+				      __func__);
+		goto out;
+	}
+
+	get_wiphy->umac_hdr.cmd_evnt = NRF_WIFI_UMAC_CMD_GET_WIPHY;
+	get_wiphy->umac_hdr.ids.wdev_id = if_idx;
+	get_wiphy->umac_hdr.ids.valid_fields |= NRF_WIFI_INDEX_IDS_WDEV_ID_VALID;
+
+	status = umac_cmd_cfg(fmac_dev_ctx,
+			      get_wiphy,
+			      sizeof(*get_wiphy));
+out:
+	if (get_wiphy) {
+		wifi_nrf_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
+				       get_wiphy);
+	}
+
+	return status;
+}
+
+enum wifi_nrf_status wifi_nrf_fmac_register_frame(void *dev_ctx, unsigned char if_idx,
+						  struct nrf_wifi_umac_mgmt_frame_info *frame_info)
+{
+	enum wifi_nrf_status status = WIFI_NRF_STATUS_FAIL;
+	struct nrf_wifi_umac_cmd_mgmt_frame_reg *frame_reg_cmd = NULL;
+	struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx = NULL;
+
+	fmac_dev_ctx = dev_ctx;
+
+	if (!dev_ctx || (if_idx >= MAX_NUM_VIFS) || !frame_info) {
+		goto out;
+	}
+
+	frame_reg_cmd =
+		wifi_nrf_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv, sizeof(*frame_reg_cmd));
+
+	if (!frame_reg_cmd) {
+		wifi_nrf_osal_log_err(fmac_dev_ctx->fpriv->opriv, "%s: Unable to allocate memory\n",
+				      __func__);
+		goto out;
+	}
+
+	frame_reg_cmd->umac_hdr.cmd_evnt = NRF_WIFI_UMAC_CMD_REGISTER_FRAME;
+	frame_reg_cmd->umac_hdr.ids.wdev_id = if_idx;
+	frame_reg_cmd->umac_hdr.ids.valid_fields |= NRF_WIFI_INDEX_IDS_WDEV_ID_VALID;
+
+	wifi_nrf_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
+		&frame_reg_cmd->info, frame_info, sizeof(frame_reg_cmd->info));
+
+	status = umac_cmd_cfg(fmac_dev_ctx, frame_reg_cmd, sizeof(*frame_reg_cmd));
+out:
+	if (frame_reg_cmd) {
+		wifi_nrf_osal_mem_free(fmac_dev_ctx->fpriv->opriv, frame_reg_cmd);
+	}
+
+	return status;
+}
 
 enum wifi_nrf_status wifi_nrf_fmac_conf_btcoex(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 					       struct rpu_btcoex *params)

--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_wpa_supp_if.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_wpa_supp_if.h
@@ -46,6 +46,12 @@ int wifi_nrf_nl80211_send_mlme(void *if_priv, const u8 *data, size_t data_len, i
 			       unsigned int freq, int no_cck, int offchanok, unsigned int wait_time,
 			       int cookie);
 
+int wifi_nrf_supp_get_wiphy(void *if_priv);
+
+int wifi_nrf_supp_register_frame(void *if_priv,
+			u16 type, const u8 *match, size_t match_len,
+			bool multicast);
+
 int wifi_nrf_wpa_supp_set_key(void *if_priv,
 			   const unsigned char *ifname,
 			   enum wpa_alg alg,
@@ -97,8 +103,18 @@ void wifi_nrf_wpa_supp_event_mgmt_tx_status(void *if_priv,
 						struct nrf_wifi_umac_event_mlme *mlme_event,
 						unsigned int event_len);
 
+
 void wifi_nrf_wpa_supp_event_proc_unprot_mgmt(void *if_priv,
 						struct nrf_wifi_umac_event_mlme *unprot_mgmt,
 						unsigned int event_len);
+
+void wifi_nrf_wpa_supp_event_get_wiphy(void *if_priv,
+						struct nrf_wifi_event_get_wiphy *get_wiphy,
+						unsigned int event_len);
+
+void wifi_nrf_wpa_supp_event_mgmt_rx_callbk_fn(void *if_priv,
+						struct nrf_wifi_umac_event_mlme *mgmt_rx_event,
+						unsigned int event_len);
+
 #endif /* CONFIG_WPA_SUPP */
 #endif /*  __ZEPHYR_WPA_SUPP_IF_H__ */

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -451,6 +451,8 @@ static int wifi_nrf_drv_main_zep(const struct device *dev)
 	callbk_fns.get_interface_callbk_fn = wifi_nrf_wpa_supp_event_proc_get_if;
 	callbk_fns.mgmt_tx_status = wifi_nrf_wpa_supp_event_mgmt_tx_status;
 	callbk_fns.unprot_mlme_mgmt_rx_callbk_fn = wifi_nrf_wpa_supp_event_proc_unprot_mgmt;
+	callbk_fns.event_get_wiphy = wifi_nrf_wpa_supp_event_get_wiphy;
+	callbk_fns.mgmt_rx_callbk_fn = wifi_nrf_wpa_supp_event_mgmt_rx_callbk_fn;
 #endif /* CONFIG_WPA_SUPP */
 
 	rpu_drv_priv_zep.fmac_priv = wifi_nrf_fmac_init(&data_config,
@@ -544,6 +546,8 @@ static const struct zep_wpa_supp_dev_ops wpa_supp_ops = {
 	.set_key = wifi_nrf_wpa_supp_set_key,
 	.signal_poll = wifi_nrf_wpa_supp_signal_poll,
 	.send_mlme = wifi_nrf_nl80211_send_mlme,
+	.get_wiphy = wifi_nrf_supp_get_wiphy,
+	.register_frame = wifi_nrf_supp_register_frame,
 };
 #endif /* CONFIG_WPA_SUPP */
 #endif /* !CONFIG_NRF700X_RADIO_TEST */

--- a/west.yml
+++ b/west.yml
@@ -104,7 +104,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: d92b1bd441b41a146f04fb658fd120b70000ac73
+      revision: 23d54fde78f15bde4b2cf263802b30893bce864e
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: v1.9.99-ncs3


### PR DESCRIPTION
Adds support for handling WIPHY capabilities, RX MLME frames to fix the following MBO issues

[SHEL-859] : Not able to send BTM response for the BTM request frame from the AP.
[SHEL-888] : Supported Operating classes IE missing in the Assoc Request frame.
[SHEL-877] : DUT not responding to AP beacon request frame using case 3 values