### PR TITLE
application: tf-m asset_tracker_v2 disable logging in low power profile

### DIFF
--- a/applications/asset_tracker_v2/overlay-low-power.conf
+++ b/applications/asset_tracker_v2/overlay-low-power.conf
@@ -24,3 +24,6 @@ CONFIG_AT_HOST_LIBRARY=n
 
 # Disable logging
 CONFIG_LOG=n
+
+# Disable TFM logging
+CONFIG_TFM_LOG_LEVEL_SILENCE=y


### PR DESCRIPTION
Setting the TF-M log level to silence will also disable the secure UART1 device.

Ref: NCSDK-17220

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>