### PR TITLE
manifest: pull Matter fix for the newlibc heap size

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.2.0-rc1
+      revision: ca68be2ae5417c65357e97a74ab33664943775b9
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
We cannot guarantee that for every build configuration for all Matter samples we can have 16kB of RAM available for newlibc heap, so let's decrease it to 12kB, which is also enough ([KRKNWK-15795](https://projecttools.nordicsemi.no/jira/browse/KRKNWK-15795))

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>