### PR TITLE
applications: asset_tracker_v2: Remove `spm.conf`

### DIFF
--- a/applications/asset_tracker_v2/child_image/spm.conf
+++ b/applications/asset_tracker_v2/child_image/spm.conf
@@ -1,9 +1,0 @@
-#
-# Copyright (c) 2021 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
-#
-
-## Disable serial and UART interface.
-CONFIG_SERIAL=n
-CONFIG_UART_CONSOLE=n


### PR DESCRIPTION
Remove `spm.conf`.
The application no longer uses the Secure Partition Manager (SPM) so the configuration file is unneeded.