### PR TITLE
matter: fix mcuboot configuration

### DIFF
--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/window_covering/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/matter/window_covering/child_image/mcuboot/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/window_covering/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/window_covering/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};


### PR DESCRIPTION
Two remaining Matter samples/apps have not been updated after #9169. Consequently, pm_config.h refers to unset DT_CHOSEN(nordic_pm_ext_flash).

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>