### PR TITLE
applications: asset_tracker_v2: Correct log level

### DIFF
--- a/applications/asset_tracker_v2/src/modules/cloud_module.c
+++ b/applications/asset_tracker_v2/src/modules/cloud_module.c
@@ -474,7 +474,7 @@ static void connect_cloud(void)
 	 */
 	err = cloud_wrap_connect();
 	if (err) {
-		LOG_ERR("cloud_connect failed, error: %d", err);
+		LOG_DBG("cloud_connect failed, error: %d", err);
 	}
 
 	connect_retries++;

--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -266,7 +266,7 @@ void pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)
 
 	switch (event) {
 	case PDN_EVENT_CNEC_ESM:
-		LOG_ERR("Event: PDP context %d, %s", cid, pdn_esm_strerror(reason));
+		LOG_DBG("Event: PDP context %d, %s", cid, pdn_esm_strerror(reason));
 		break;
 	case PDN_EVENT_ACTIVATED:
 		LOG_DBG("PDN_EVENT_ACTIVATED");


### PR DESCRIPTION
Correct the log level for some logs to prevent users from getting the impression that something is wrong:

 - PDN context error codes. Not all of these are fatal.
 - Cloud connection failure. This is typical if the cloud connection is already in progress or already connected.