### PR TITLE
matter: update ZAP submodule revision

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -60,7 +60,7 @@ See `Bluetooth mesh samples`_ for the list of changes for the Bluetooth mesh sam
 Matter
 ------
 
-|no_changes_yet_note|
+* Updated the ZAP submodule revision to fix opening the ZAP files included in Matter samples in |NCS|.
 
 See `Matter samples`_ for the list of changes for the Matter samples.
 

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.1.2
+      revision: e99aa9daa4a5acd36e8be5347bb104d8c4d3f6c6
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This is needed to fix opening ZAP files included in Matter samples in NCS.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>