### PR TITLE
Bluetooth: Mesh: Increase BT RX stack for mesh

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -63,7 +63,7 @@ config BT_RX_STACK_SIZE
 	int
 	depends on BT_HCI_HOST || BT_RECV_BLOCKING
 	default 512 if BT_HCI_RAW
-	default 2048 if BT_MESH
+	default 2400 if BT_MESH
 	default 2200 if BT_SETTINGS
 	default 1536 if BT_SMP
 	default 1024


### PR DESCRIPTION
Increases the BT_RX_STACK_SIZE for mesh application to prevent stack overflow during provisioning for mesh samples. The new size is decided on the basis of the highest observed sample stack size usage of 2368 bytes

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>