### PR TITLE
samples: matter: Fixed DFu for release configuration

### DIFF
--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp_factory_data.overlay
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp_factory_data.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp_release.overlay
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/child_image/mcuboot/boards/thingy53_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_bulb/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
+++ b/samples/matter/light_bulb/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_bulb/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
+++ b/samples/matter/light_bulb/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_bulb/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp_release.overlay
+++ b/samples/matter/light_bulb/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_switch/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
+++ b/samples/matter/light_switch/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_switch/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
+++ b/samples/matter/light_switch/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/light_switch/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp_release.overlay
+++ b/samples/matter/light_switch/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/lock/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
+++ b/samples/matter/lock/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/lock/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
+++ b/samples/matter/lock/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/lock/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp_release.overlay
+++ b/samples/matter/lock/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/template/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
+++ b/samples/matter/template/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/template/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
+++ b/samples/matter/template/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/template/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp_release.overlay
+++ b/samples/matter/template/child_image/mcuboot/boards/nrf7002dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/window_covering/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
+++ b/samples/matter/window_covering/child_image/mcuboot/boards/nrf52840dk_nrf52840_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/window_covering/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
+++ b/samples/matter/window_covering/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_release.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};


### PR DESCRIPTION
In PRs 9169 and 9487 the board overlays were added to mcuboot childimage configuration to set pm-ext-flash to mx25r64. In those PRs only default target was considered, but not release configuration. Missing overlays for release configuration result in swapping DFU images failure.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>