### PR TITLE
net: lib: aws_iot: Added support for run-time endpoint host name config

### DIFF
--- a/doc/nrf/libraries/networking/aws_iot.rst
+++ b/doc/nrf/libraries/networking/aws_iot.rst
@@ -90,6 +90,8 @@ Complete the following steps to set the required library options:
 
 1. In the `AWS IoT console`_, navigate to :guilabel:`IoT core` > :guilabel:`Settings`.
 #. Find the ``Device data endpoint`` address and set :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME` to this address string.
+   The address can also be provided at runtime by setting the :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_APP` option.
+   See :ref:`lib_set_aws_hostname` for more details.
 #. Set the option :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC` to the name of the *Thing* created earlier in the process.
    This is not needed if the application sets the client ID at run time.
    If you still want to set a custom client ID, make sure that the :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_APP` is disabled and set the :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC` option to your desired client ID.
@@ -118,6 +120,8 @@ Other options:
 * :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_APP`
 * :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC`
 * :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_MAX_LEN`
+* :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_MAX_LEN`
+* :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_APP`
 
 
 .. note::
@@ -155,6 +159,15 @@ Setting client ID at run-time
 
 The AWS IoT library also supports passing in the client ID at run time.
 To enable this feature, set the ``client_id`` entry in the :c:struct:`aws_iot_config` structure that is passed in the :c:func:`aws_iot_init` function when initializing the library, and set the :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_APP` Kconfig option.
+
+.. _lib_set_aws_hostname:
+
+Setting the AWS host name at runtime
+====================================
+
+The AWS IoT library also supports passing the endpoint address at runtime by setting the :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_APP` option.
+If this option is set, the ``host_name`` and ``host_name_len`` must be set in the :c:struct:`aws_iot_config` structure before it is passed into the :c:func:`aws_iot_init` function.
+The length of your AWS host name (:kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME`) must be shorter than the default value of :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_MAX_LEN`, for proper initialization of the library.
 
 AWS FOTA
 ========

--- a/include/net/aws_iot.h
+++ b/include/net/aws_iot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -187,6 +187,13 @@ struct aws_iot_config {
 	char *client_id;
 	/** Length of client_id string. */
 	size_t client_id_len;
+	/** AWS IoT endpoint host name for broker connection, used when
+	 *  @kconfig{CONFIG_AWS_IOT_BROKER_HOST_NAME_APP} is set. If not the
+	 *  static @kconfig{AWS_IOT_BROKER_HOST_NAME} is used.
+	 */
+	char *host_name;
+	/** Length of host_name string. */
+	size_t host_name_len;
 };
 
 /** @brief Initialize the module.

--- a/subsys/net/lib/aws_iot/Kconfig
+++ b/subsys/net/lib/aws_iot/Kconfig
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Nordic Semiconductor
+# Copyright (c) 2022 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -45,8 +45,12 @@ config AWS_IOT_STATIC_IPV4_ADDR
 config AWS_IOT_SEC_TAG
 	int "Security tag to use for AWS IoT connection"
 
+config AWS_IOT_BROKER_HOST_NAME_APP
+	bool "AWS IoT sever hostname provided by application run-time"
+
 config AWS_IOT_BROKER_HOST_NAME
 	string "AWS IoT server hostname"
+	depends on !AWS_IOT_BROKER_HOST_NAME_APP
 
 config AWS_IOT_PORT
 	int "AWS server port"
@@ -69,6 +73,10 @@ config AWS_IOT_IPV6
 config AWS_IOT_APP_SUBSCRIPTION_LIST_COUNT
 	int "Amount of entries in the application subscription list"
 	default 0
+
+config AWS_IOT_BROKER_HOST_NAME_MAX_LEN
+	int "Maximum length of broker host name"
+	default 64
 
 config AWS_IOT_CLIENT_ID_MAX_LEN
 	int "Maximum length of cliend id"


### PR DESCRIPTION
The current state of the AWS IoT library lacks support for configuring the AWS endpoint during runtime. It is only possible to provide the URL using Kconfig. This commit adds support to provide the URL from the application during run-time by enabling a new Kconfig option. This makes the library usable in more use cases. I tested it locally on my own custom nRF52840 based gateway board. I was Succesfully able to connect and publish messages to AWS using both the old method and the new method.

Signed-off-by: Paul Jans <paul.jans.1999@hotmail.com>