### PR TITLE
Bluetooth: Mesh: Fix DM model result struct error

### DIFF
--- a/include/bluetooth/mesh/vnd/dm_cli.h
+++ b/include/bluetooth/mesh/vnd/dm_cli.h
@@ -81,11 +81,11 @@ struct bt_mesh_dm_cli_handlers {
 	 *
 	 * @param[in] cli Client that received the status message.
 	 * @param[in] ctx Context of the message.
-	 * @param[in] result Result contained in the message.
+	 * @param[in] results Results contained in the message.
 	 */
 	void (*const result_handler)(struct bt_mesh_dm_cli *cli,
 				     struct bt_mesh_msg_ctx *ctx,
-				     const struct bt_mesh_dm_cli_result *result);
+				     const struct bt_mesh_dm_cli_results *results);
 };
 
 /** Distance Measurement Client instance. */
@@ -188,7 +188,7 @@ int bt_mesh_dm_cli_config(struct bt_mesh_dm_cli *cli,
  */
 int bt_mesh_dm_cli_measurement_start(struct bt_mesh_dm_cli *cli, struct bt_mesh_msg_ctx *ctx,
 				    const struct bt_mesh_dm_cli_start *start,
-				    struct bt_mesh_dm_cli_result *rsp);
+				    struct bt_mesh_dm_cli_results *rsp);
 
 /** @brief Get measurement results from a Distance Measurement server.
  *
@@ -211,7 +211,7 @@ int bt_mesh_dm_cli_measurement_start(struct bt_mesh_dm_cli *cli, struct bt_mesh_
  * @retval -EBADMSG Invalid entry count provided.
  */
 int bt_mesh_dm_cli_results_get(struct bt_mesh_dm_cli *cli, struct bt_mesh_msg_ctx *ctx,
-			       uint8_t entry_cnt, struct bt_mesh_dm_cli_result *rsp);
+			       uint8_t entry_cnt, struct bt_mesh_dm_cli_results *rsp);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_dm_cli_op[];

--- a/subsys/bluetooth/mesh/shell/shell_dm_cli.c
+++ b/subsys/bluetooth/mesh/shell/shell_dm_cli.c
@@ -57,7 +57,7 @@ static int cmd_cfg(const struct shell *shell, size_t argc, char *argv[])
 }
 
 static void result_print(const struct shell *shell,
-			 struct bt_mesh_dm_cli_result *rsp)
+			 struct bt_mesh_dm_cli_results *rsp)
 {
 	shell_print(shell, "Status: %s (err: %d)", rsp->status ? "Fail" : "Success", rsp->status);
 
@@ -121,7 +121,7 @@ static int cmd_dm_start(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	struct bt_mesh_dm_cli *cli = mod->user_data;
-	struct bt_mesh_dm_cli_result rsp;
+	struct bt_mesh_dm_cli_results rsp;
 
 	err = bt_mesh_dm_cli_measurement_start(cli, NULL, &set, &rsp);
 
@@ -148,7 +148,7 @@ static int cmd_result_get(const struct shell *shell, size_t argc, char *argv[])
 	}
 
 	struct bt_mesh_dm_cli *cli = mod->user_data;
-	struct bt_mesh_dm_cli_result rsp;
+	struct bt_mesh_dm_cli_results rsp;
 
 	err = bt_mesh_dm_cli_results_get(cli, NULL, count, &rsp);
 

--- a/subsys/bluetooth/mesh/vnd/dm_cli.c
+++ b/subsys/bluetooth/mesh/vnd/dm_cli.c
@@ -69,11 +69,11 @@ static int handle_result_status(struct bt_mesh_model *model, struct bt_mesh_msg_
 				struct net_buf_simple *buf)
 {
 	struct bt_mesh_dm_cli *cli = model->user_data;
-	struct bt_mesh_dm_cli_result status = {
+	struct bt_mesh_dm_cli_results status = {
 		.res = cli->res_arr,
 		.entry_cnt = 0
 	};
-	struct bt_mesh_dm_cli_result *rsp;
+	struct bt_mesh_dm_cli_results *rsp;
 
 	status.status = net_buf_simple_pull_u8(buf);
 
@@ -182,7 +182,7 @@ int bt_mesh_dm_cli_config(struct bt_mesh_dm_cli *cli,
 int bt_mesh_dm_cli_measurement_start(struct bt_mesh_dm_cli *cli,
 				     struct bt_mesh_msg_ctx *ctx,
 				     const struct bt_mesh_dm_cli_start *start,
-				     struct bt_mesh_dm_cli_result *rsp)
+				     struct bt_mesh_dm_cli_results *rsp)
 {
 	if (!BT_MESH_ADDR_IS_UNICAST(start->addr)) {
 		return -EBADMSG;
@@ -211,7 +211,7 @@ int bt_mesh_dm_cli_measurement_start(struct bt_mesh_dm_cli *cli,
 int bt_mesh_dm_cli_results_get(struct bt_mesh_dm_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
 			       uint8_t entry_cnt,
-			       struct bt_mesh_dm_cli_result *rsp)
+			       struct bt_mesh_dm_cli_results *rsp)
 {
 	if (entry_cnt > cli->entry_cnt) {
 		return -EBADMSG;


### PR DESCRIPTION
Fixes misaligned name in the Distance measurment model for the client result struct.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>