### PR TITLE
manifest: Update Zephyr for cherry-pick MCC fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: c6184a9ff7382e5c699c35b11c9b4e096a7f247d
+      revision: 95f57f43fc2d6409e34d079bb702d5c9fdb3b642
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update Zephyr for cherry-pick a fix for MCC which used by nRF5340 audio project.

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>