### PR TITLE
net: lib: lwm2m_client_utils: Fix unchecked return value

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_device.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_device.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <version.h>
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/net/lwm2m.h>

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
@@ -94,7 +94,10 @@ static int write_credential_type(int sec_obj_inst, int sec_tag, int res_id,
 	if (cred_len == 0) {
 		bool exist;
 
-		modem_key_mgmt_exists(sec_tag, type, &exist);
+		ret = modem_key_mgmt_exists(sec_tag, type, &exist);
+		if (ret) {
+			return ret;
+		}
 		if (exist) {
 			return -EEXIST;
 		}


### PR DESCRIPTION
Minor fix, return value was not checked when we checked if certificate already existed in modem.

