### PR TITLE
labeler: add ble mesh label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,3 +16,10 @@
 
 "changelog-entry-required":
   - all: ["!doc/nrf/releases/release-notes-changelog.rst"]
+
+"ble mesh":
+  - "subsys/bluetooth/mesh/*"
+  - "include/bluetooth/mesh/*"
+  - "samples/bluetooth/mesh/*"
+  - "doc/nrf/libraries/bluetooth_services/mesh/*"
+  - "doc/nrf/ug_bt_mesh*"


### PR DESCRIPTION
The ble mesh team created PR bot that gathers PRs from different repos to report them in MS Team channel to follow up review state. To operate well PR Bot needs label. This PR adds assigning`ble mesh` label.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>