### PR TITLE
net: lib: nrf_cloud: Use separate buffer for caching predictions from external flash

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -262,7 +262,7 @@ Libraries for networking
 
 * :ref:`lib_fota_download` library:
 
-  * Fixed a bug were the :c:func:`download_client_callback` function was continuing to read the offset value even if :c:func:`dfu_target_offset_get` returned an error.
+  * Fixed a bug where the :c:func:`download_client_callback` function was continuing to read the offset value even if :c:func:`dfu_target_offset_get` returned an error.
   * Fixed a bug where the cleanup of the downloading state was not happening when an error event was raised.
 
 * :ref:`lib_nrf_cloud` library:
@@ -270,6 +270,10 @@ Libraries for networking
   * Updated:
 
     * The MQTT disconnect event is now handled by the FOTA module, allowing for updates to be completed while disconnected and reported properly when reconnected.
+
+* :ref:`lib_nrf_cloud` library:
+
+  * Fixed a bug where the same buffer was incorrectly shared between caching a P-GPS prediction and loading a new one, when external flash was used.
 
 Libraries for NFC
 -----------------

--- a/include/net/nrf_cloud_pgps.h
+++ b/include/net/nrf_cloud_pgps.h
@@ -276,7 +276,11 @@ int nrf_cloud_pgps_process_update(uint8_t *buf, size_t len);
 
 /** @brief Call this function regardless of whether the download succeeded or failed.
  *
- * Not needed for custom download transports.
+ * The library calls this automatically for HTTP(S) transports.
+ *
+ * For custom transports, the application must call this for transport error, error from
+ * a call to nrf_cloud_pgps_process_update(), as well as successful completion. Further,
+ * when an error occurs, the application must terminate the transfer.
  *
  * @retval 0 No failure.
  * @return a negative value indicates an error.

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_pgps_utils.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_pgps_utils.h
@@ -49,8 +49,8 @@ typedef int (*npgps_buffer_handler_t)(uint8_t *buf, size_t len);
 typedef void (*npgps_eot_handler_t)(int err);
 
 /* access control functions */
-int npgps_lock(void);
-void npgps_unlock(void);
+int npgps_download_lock(void);
+void npgps_download_unlock(void);
 
 /* settings functions */
 int npgps_save_header(struct nrf_cloud_pgps_header *header);

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_pgps.c
@@ -98,7 +98,11 @@ static uint32_t storage_size;
 static pgps_event_handler_t evt_handler;
 static uint8_t *write_buf;
 
-static off_t prediction_buf_flash_offset = UINT32_MAX;
+#if defined(CONFIG_PM_PARTITION_REGION_PGPS_EXTERNAL)
+static off_t prediction_cache_flash_offset = UINT32_MAX;
+static uint8_t prediction_cache[PGPS_PREDICTION_STORAGE_SIZE];
+#endif
+
 static uint8_t prediction_buf[PGPS_PREDICTION_STORAGE_SIZE];
 static atomic_t accept_packets;
 static atomic_t pgps_need_assistance;
@@ -122,7 +126,9 @@ K_TIMER_DEFINE(prediction_timer, prediction_timer_handler, NULL);
 
 static void discard_prediction_buffer(void)
 {
-	prediction_buf_flash_offset = UINT32_MAX;
+#if defined(CONFIG_PM_PARTITION_REGION_PGPS_EXTERNAL)
+	prediction_cache_flash_offset = UINT32_MAX;
+#endif
 }
 
 static int get_prediction_block(int pnum)
@@ -134,20 +140,21 @@ static struct nrf_cloud_pgps_prediction *get_cached_prediction(off_t off)
 {
 #if defined(CONFIG_PM_PARTITION_REGION_PGPS_EXTERNAL)
 	/* Check if the cached prediction is the one we want; if not, read it now */
-	if (prediction_buf_flash_offset != off) {
+	if (prediction_cache_flash_offset != off) {
 		int err;
 
 		err = flash_area_read(prediction_flash_area, off,
-				      prediction_buf, sizeof(prediction_buf));
+				      prediction_cache, sizeof(prediction_cache));
+
 		if (err) {
 			LOG_ERR("Error %d reading prediction from flash offset 0x%lx",
 				err, off);
 			return NULL;
 		}
-		prediction_buf_flash_offset = off;
+		prediction_cache_flash_offset = off;
 	}
 
-	return (struct nrf_cloud_pgps_prediction *)prediction_buf;
+	return (struct nrf_cloud_pgps_prediction *)prediction_cache;
 #else
 	/* The parameter off is really the address in built-in flash for the prediction */
 	return (struct nrf_cloud_pgps_prediction *)off;
@@ -316,6 +323,10 @@ static int validate_stored_predictions(uint16_t *first_bad_day,
 	/* build catalog of predictions by block */
 	for (i = 0; i < count; i++) {
 		pred = (struct nrf_cloud_pgps_prediction *)get_prediction_slot(i, &off);
+		if (pred == NULL) {
+			LOG_ERR("Prediction at idx:%d not accessible", i);
+			continue;
+		}
 
 		pnum = determine_prediction_num(&index.header, pred);
 		if (pnum < 0) {
@@ -1193,6 +1204,11 @@ static int open_storage(uint32_t offset, bool preserve)
 	if (preserve && (block_offset != 0) && (block_offset < flash_page_size)) {
 		int slot = offset / PGPS_PREDICTION_STORAGE_SIZE;
 		uint8_t *buf = (uint8_t *)get_prediction_slot(slot, NULL);
+		if (buf == NULL) {
+			LOG_ERR("Slot %d cannot be accessed, so it cannot be preserved", slot);
+			err = -EINVAL;
+			return err;
+		}
 
 #if PGPS_DEBUG
 		LOG_DBG("preserving %u bytes", block_offset);
@@ -1201,9 +1217,11 @@ static int open_storage(uint32_t offset, bool preserve)
 		err = stream_flash_buffered_write(&stream, buf, block_offset, false);
 		if (err) {
 			LOG_ERR("Error writing back %u original bytes", block_offset);
+			return err;
 		}
 	}
-	return err;
+
+	return 0;
 }
 
 static int store_prediction(uint8_t *p, size_t len, uint32_t sentinel, bool last)
@@ -1432,6 +1450,7 @@ static int consume_pgps_data(uint8_t pnum, const char *buf, size_t buf_len)
 	size_t parsed_len = 0;
 	int64_t gps_sec;
 	bool finished = false;
+	int err = 0;
 
 	gps_sec = 0;
 
@@ -1483,8 +1502,6 @@ static int consume_pgps_data(uint8_t pnum, const char *buf, size_t buf_len)
 			LOG_ERR("Prediction did not include GPS day and time of day; ignoring");
 			LOG_HEXDUMP_DBG(prediction_ptr, buf_len, "bad data");
 		} else {
-			int err;
-
 			LOG_INF("Storing prediction num:%u idx:%u for gps sec:%d",
 				pnum, index.loading_count, (int32_t)gps_sec);
 
@@ -1494,12 +1511,11 @@ static int consume_pgps_data(uint8_t pnum, const char *buf, size_t buf_len)
 					 finished || (index.storage_extent == 1));
 			index.predictions[pnum] = npgps_block_to_pointer(index.store_block);
 
-			if (pgps_need_assistance &&
-			    (finished || (index.loading_count > 1))) {
-				nrf_cloud_pgps_notify_prediction();
-			}
-
 			if (!finished) {
+				if (pgps_need_assistance && (index.loading_count > 1)) {
+					nrf_cloud_pgps_notify_prediction();
+				}
+
 				if (evt_handler) {
 					struct nrf_cloud_pgps_event evt = {
 						.type = PGPS_EVT_LOADING,
@@ -1508,6 +1524,10 @@ static int consume_pgps_data(uint8_t pnum, const char *buf, size_t buf_len)
 					evt_handler(&evt);
 				}
 			} else {
+				if (pgps_need_assistance) {
+					nrf_cloud_pgps_notify_prediction();
+				}
+
 				LOG_INF("All P-GPS data received. Done.");
 				state = PGPS_READY;
 				if (evt_handler) {
@@ -1525,7 +1545,8 @@ static int consume_pgps_data(uint8_t pnum, const char *buf, size_t buf_len)
 			index.store_block = npgps_alloc_block();
 			if (index.store_block == NO_BLOCK) {
 				LOG_ERR("No more free blocks!");
-				return -ENOMEM;
+				err = -ENOMEM;
+				goto fail;
 			}
 			index.storage_extent--;
 			if (index.storage_extent == 0) {
@@ -1535,37 +1556,34 @@ static int consume_pgps_data(uint8_t pnum, const char *buf, size_t buf_len)
 				err = flush_storage();
 				if (err) {
 					LOG_ERR("Error flushing storage:%d", err);
-					return err;
+					goto fail;
 				}
 				err = open_storage(npgps_block_to_offset(index.store_block),
 						   false);
 				if (err) {
 					LOG_ERR("Error opening storage again:%d", err);
-					return err;
+					goto fail;
 				}
 			}
 		}
 	} else {
 		LOG_ERR("Parsing incomplete; aborting.");
-		state = PGPS_NONE;
-		return -EINVAL;
+		err = -EINVAL;
+		goto fail;
 	}
 
 	return 0;
+
+fail:
+	state = PGPS_NONE;
+	return err;
 }
 
 int nrf_cloud_pgps_begin_update(void)
 {
 	int err;
 
-	/* If CONFIG_NRF_CLOUD_DOWNLOAD_TRANSPORT_CUSTOM is enabled,
-	 * the application must call the function
-	 * nrf_cloud_pgps_finish_update() regardless of whether the
-	 * download was successful or not.
-	 * The HTTP transport calls this function directly; no external call
-	 * necessary.
-	 */
-	err = npgps_lock();
+	err = npgps_download_lock();
 	if (err) {
 		LOG_ERR("PGPS download already active.");
 		return err;
@@ -1592,7 +1610,7 @@ int nrf_cloud_pgps_begin_update(void)
 	if (index.store_block == NO_BLOCK) {
 		LOG_ERR("No free flash space!");
 		state = PGPS_NONE;
-		npgps_unlock();
+		npgps_download_unlock();
 		return -ENOMEM;
 	}
 	index.storage_extent = npgps_get_block_extent(index.store_block);
@@ -1602,7 +1620,7 @@ int nrf_cloud_pgps_begin_update(void)
 			   index.partial_request);
 	if (err) {
 		state = PGPS_NONE;
-		npgps_unlock();
+		npgps_download_unlock();
 		return err;
 	}
 
@@ -1615,21 +1633,19 @@ int nrf_cloud_pgps_begin_update(void)
 
 int nrf_cloud_pgps_finish_update(void)
 {
-	npgps_unlock();
+	npgps_download_unlock();
 	return 0;
 }
 
 #if defined(CONFIG_NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_HTTP)
 static void end_transfer_handler(int transfer_result)
 {
-	if (IS_ENABLED(CONFIG_NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_HTTP)) {
-		if (transfer_result == 0) {
-			LOG_DBG("Download completed without error.");
-		} else {
-			LOG_ERR("Download failed: %d", transfer_result);
-		}
-		nrf_cloud_pgps_finish_update();
+	if (transfer_result == 0) {
+		LOG_DBG("Download completed without error.");
+	} else {
+		LOG_ERR("Download failed: %d", transfer_result);
 	}
+	nrf_cloud_pgps_finish_update();
 }
 #endif /* CONFIG_NRF_CLOUD_PGPS_DOWNLOAD_TRANSPORT_HTTP */
 


### PR DESCRIPTION
When using external flash, we cannot share the same buffer for caching predictions as for storing partially downloaded predictions.  Allocate a separate buffer for caching.

Jira: NCSDK-18376

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>