### PR TITLE
samples: matter: apply fix for increased flash wear

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -448,6 +448,7 @@ Matter samples
 * :ref:`matter_light_bulb_sample`:
 
   * Introduced support for Matter over Wi-Fi on standalone ``nrf7002dk_nrf5340_cpuapp`` and on ``nrf5340dk_nrf5340_cpuapp`` with the ``nrf7002_ek`` shield attached.
+  * Introduced the deferred attribute persister class to reduce the flash wear caused by handling the ``MoveToLevel`` command from the Level Control cluster.
 
 NFC samples
 -----------

--- a/samples/matter/light_bulb/src/app_task.cpp
+++ b/samples/matter/light_bulb/src/app_task.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app/DeferredAttributePersistenceProvider.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -78,6 +79,18 @@ bool sIsNetworkEnabled = false;
 bool sHaveBLEConnections = false;
 
 const struct pwm_dt_spec sLightPwmDevice = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led1));
+
+// Define a custom attribute persister which makes actual write of the CurrentLevel attribute value
+// to the non-volatile storage only when it has remained constant for 5 seconds. This is to reduce
+// the flash wearout when the attribute changes frequently as a result of MoveToLevel command.
+// DeferredAttribute object describes a deferred attribute, but also holds a buffer with a value to
+// be written, so it must live so long as the DeferredAttributePersistenceProvider object.
+DeferredAttribute gCurrentLevelPersister(ConcreteAttributePath(kLightEndpointId, Clusters::LevelControl::Id,
+							       Clusters::LevelControl::Attributes::CurrentLevel::Id));
+DeferredAttributePersistenceProvider gDeferredAttributePersister(Server::GetInstance().GetDefaultAttributePersister(),
+								 Span<DeferredAttribute>(&gCurrentLevelPersister, 1),
+								 System::Clock::Milliseconds32(5000));
+
 } /* namespace */
 
 namespace LedConsts
@@ -204,6 +217,7 @@ CHIP_ERROR AppTask::Init()
 	(void)initParams.InitializeStaticResourcesBeforeServerInit();
 
 	ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
+	app::SetAttributePersistenceProvider(&gDeferredAttributePersister);
 	ConfigurationMgr().LogDeviceConfig();
 	PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
 

--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 6e8f8b13db07d31951dd1ef6743bed246d005991
+      revision: 844eddf590d9eb24d89113c115e57c814c0ff7b5
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
MoveToLevel command of LevelControl cluster, used in light bulb sample, causes a fast change of CurrentLevel attribute that is persisted to flash. It leads to lots of flash writes that needlessly utilizes the flash.

Use the deferred attribute persister for CurrentLevel attribute to write it to flash only when it remains constant for 5 seconds.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>