### PR TITLE
script: fix likely_merged heuristic

### DIFF
--- a/scripts/west_commands/ncs_west_helpers.py
+++ b/scripts/west_commands/ncs_west_helpers.py
@@ -295,7 +295,7 @@ class RepoAnalyzer:
                 # Heuristic #1:
                 ed(uc) < self._edit_dist_threshold or
                 # Heuristic #2:
-                commit_shortlog(uc).startswith(sl)
+                commit_shortlog(uc).startswith(shortlog_no_sauce(sl)[:-3])
             ]
 
             if len(matches) != 0:


### PR DESCRIPTION
Heuristic #2 does not match truncated commit messages.
This change removes sauce and ignores '...' in order to match correctly.

Upstream has/will stop truncating messages, but we will likely see more until
we are fully up-to-date with upstream.

Details:
	Upstream Msg   = "Bluetooth: Mesh: Filter out unknown conns and disconns in pb-gatt srv"
	Downstream Msg = "[nrf fromtree] Bluetooth: Mesh: Filter out unknown conns and disconns..."
	`[:-3]` catches cases where users uses e.g. "..."