### PR TITLE
Fix memory leak in bt_rpc_gatt_host and string termination in mds

### DIFF
--- a/subsys/bluetooth/rpc/host/bt_rpc_gatt_host.c
+++ b/subsys/bluetooth/rpc/host/bt_rpc_gatt_host.c
@@ -911,6 +911,7 @@ static void bt_gatt_indicate_rpc_handler(const struct nrf_rpc_group *group,
 
 	return;
 decoding_error:
+	k_free(params);
 	report_decoding_error(BT_GATT_INDICATE_RPC_CMD, handler_data);
 }
 

--- a/subsys/bluetooth/services/mds.c
+++ b/subsys/bluetooth/services/mds.c
@@ -167,8 +167,8 @@ static ssize_t data_uri_read(struct bt_conn *conn, const struct bt_gatt_attr *at
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 
-	strncpy(uri, MDS_URI_BASE, uri_base_length);
-	strncpy(&uri[uri_base_length], info.device_serial, uri_sn_length);
+	memcpy(uri, MDS_URI_BASE, uri_base_length);
+	memcpy(&uri[uri_base_length], info.device_serial, uri_sn_length);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, uri,
 				 uri_length);


### PR DESCRIPTION
Fix memory leak in the bt_rpc_gatt_host.c file.
Fix string termination in the mds.c file.