### PR TITLE
applications: nrf5340_audio: Move MCS discover to proper position

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig.defaults
@@ -103,7 +103,7 @@ config BT_VCS
 	default y
 
 config BT_MCC
-	default n if STREAM_BIDIRECTIONAL
+	default n if WALKIE_TALKIE_DEMO
 	default y
 
 
@@ -163,7 +163,7 @@ config BT_VCS_CLIENT
 	default y
 
 config BT_MCS
-	default n if STREAM_BIDIRECTIONAL
+	default n if WALKIE_TALKIE_DEMO
 	default y
 
 config BT_GATT_DYNAMIC_DB


### PR DESCRIPTION
Move MCS discover in security update callback.
Enable MCS/MCC for CIS bidirectional stream.

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>