### PR TITLE
manifest: Update mcuboot version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -107,7 +107,7 @@ manifest:
       revision: 49fddb8f5bb9511cf8d9e56bf680576b26fe2fc8
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 96fe9dd6c7ab672953d537175c6414e70965c7ab
+      revision: 78fd7ff9f31d88b9119734965e2afdda0cb9689a
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Updates mcuboot version to resolve an issue with serial recovery writing to flash drivers with memory alignment requirements (e.g. QSPI).

Fixes NCSDK-18422