### PR TITLE
samples: Fix memory leaks and out-of-bounds accesses in samples.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -134,7 +134,17 @@ Samples
 Bluetooth samples
 -----------------
 
-|no_changes_yet_note|
+* :ref:`peripheral_uart` sample:
+
+  * Changed:
+
+    * Fixed a possible memory leak in the :c:func:`uart_init` function.
+
+* :ref:`peripheral_hids_keyboard` sample:
+
+  * Changed:
+
+    * Fixed a possible out-of-bounds memory access issue in the :c:func:`hid_kbd_state_key_set` and :c:func:`hid_kbd_state_key_clear` functions.
 
 Bluetooth mesh samples
 ----------------------

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -719,7 +719,7 @@ static int hid_kbd_state_key_set(uint8_t key)
 		hid_keyboard_state.ctrl_keys_state |= ctrl_mask;
 		return 0;
 	}
-	for (size_t i = 0; i < KEY_CTRL_CODE_MAX; ++i) {
+	for (size_t i = 0; i < KEY_PRESS_MAX; ++i) {
 		if (hid_keyboard_state.keys_state[i] == 0) {
 			hid_keyboard_state.keys_state[i] = key;
 			return 0;
@@ -738,7 +738,7 @@ static int hid_kbd_state_key_clear(uint8_t key)
 		hid_keyboard_state.ctrl_keys_state &= ~ctrl_mask;
 		return 0;
 	}
-	for (size_t i = 0; i < KEY_CTRL_CODE_MAX; ++i) {
+	for (size_t i = 0; i < KEY_PRESS_MAX; ++i) {
 		if (hid_keyboard_state.keys_state[i] == key) {
 			hid_keyboard_state.keys_state[i] = 0;
 			return 0;


### PR DESCRIPTION
Fix memory leaks in the peripheral_uart sample.
Fix out-of-bounds accesses in the peripheral_hids_keyboard sample.

Signed-off-by: Dominik Chat <dominik.chat@nordicsemi.no>