### PR TITLE
manifest: Update Zephyr revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 95f57f43fc2d6409e34d079bb702d5c9fdb3b642
+      revision: ac1d486c3dfb8af1faec2a16e5bb29e8962ef2f1
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Pull in a local sdk-zephyr fix that solves a problem with Zephyr apps (a sample and a test) that require the full variant of newlib.

Ref. NCSDK-18339
Ref. NCSDK-18340

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>