### PR TITLE
nRF Desktop: allow overwriting an unauthenticated bond from other local identities

### DIFF
--- a/applications/nrf_desktop/Kconfig.ble
+++ b/applications/nrf_desktop/Kconfig.ble
@@ -49,6 +49,14 @@ config BT_ID_UNPAIR_MATCHING_BONDS
 	  Enabling this option is needed to pass the Fast Pair Validator's
 	  end-to-end integration tests.
 
+config BT_ID_ALLOW_UNAUTH_OVERWRITE
+	default y
+	help
+	  Allow overwriting of an unauthenticated bond from a different local
+	  identity. This setting improves the user experience as it is no
+	  longer required to delete the bonding information from the old
+	  identity to pair using the new one.
+
 config BT_DATA_LEN_UPDATE
 	default n
 	help

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -247,6 +247,8 @@ nRF Desktop
   See :ref:`nrf_desktop_porting_guide` for details.
 * The :kconfig:option:`CONFIG_BT_ID_UNPAIR_MATCHING_BONDS` is enabled by default.
   This is done to pass the Fast Pair Validator's end-to-end integration tests and to improve the user experience during the erase advertising procedure.
+* The :kconfig:option:`CONFIG_BT_ID_ALLOW_UNAUTH_OVERWRITE` is enabled by default for the HID peripherals.
+  This setting improves the user experience as it is no longer required to delete the bonding information from the old identity to pair using the new one.
 
 Thingy:53 Zigbee weather station
 --------------------------------

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: ac1d486c3dfb8af1faec2a16e5bb29e8962ef2f1
+      revision: 24d82de42102f1453a25b68a0994c05639dd5e0c
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Enabled the configuration option for the nRF Desktop Peripherals that
allows overwriting an unauthenticated bond from other local identities.