### PR TITLE
drivers: wifi: Fix QSPI clock frequency for wakeup

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
@@ -1064,7 +1064,7 @@ int qspi_cmd_wakeup_rpu(const struct device *dev, uint8_t data)
 	int ret;
 	/* Use lowest 8MHz for waking up RPU */
 	const nrf_qspi_phy_conf_t qspi_phy_8mhz = {
-		.sck_freq = qspi_freq_to_sckfreq(8 * 1000 * 1000),
+		.sck_freq = qspi_freq_to_sckfreq(8),
 		.sck_delay = QSPI_SCK_DELAY,
 		.spi_mode = NRF_QSPI_MODE_0
 	};


### PR DESCRIPTION
QSPI clock frequency is in order of MHz, not HZ. The QSPI IFCONFIG1 register only has 4 bits for QSPI clock frequency.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>