### PR TITLE
lib: lte_lc: Fix issue where memcmp() may give false result

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -606,6 +606,11 @@ Modem libraries
 
   * Added :c:func:`modem_info_get_hw_version` function to obtain the hardware version string using the ``AT%HWVERSION`` command.
 
+* :ref:`lte_lc_readme` library:
+
+  * Fixed an issue where cell update events could be sent without the cell information from the modem actually being updated.
+
+
 Libraries for networking
 ------------------------
 

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -222,7 +222,7 @@ static void at_handler_cereg(const char *response)
 	}
 
 	/* Cell update event */
-	if (memcmp(&cell, &prev_cell, sizeof(struct lte_lc_cell))) {
+	if ((cell.id != prev_cell.id) || (cell.tac != prev_cell.tac)) {
 		evt.type = LTE_LC_EVT_CELL_UPDATE;
 
 		memcpy(&prev_cell, &cell, sizeof(struct lte_lc_cell));
@@ -256,7 +256,8 @@ static void at_handler_cereg(const char *response)
 	}
 
 	/* PSM configuration update event */
-	if (memcmp(&psm_cfg, &prev_psm_cfg, sizeof(struct lte_lc_psm_cfg))) {
+	if ((psm_cfg.tau != prev_psm_cfg.tau) ||
+	    (psm_cfg.active_time != prev_psm_cfg.active_time)) {
 		evt.type = LTE_LC_EVT_PSM_UPDATE;
 
 		memcpy(&prev_psm_cfg, &psm_cfg, sizeof(struct lte_lc_psm_cfg));


### PR DESCRIPTION
Comparing structs using memcmp() may cause unexpected results if the structs have padding.
In this case, it may lead to spurious events to the application with cell updates when in reality the cell information has not changed.

This patch fixes the issue by comparing only relevant struct members directly.
Also the non-padded psm_cfg struct comparison is changed for consistency and readability.

Fixes CIA-857

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>