### PR TITLE
samples: matter: Fixed a bug with PWM polarity

### DIFF
--- a/samples/matter/light_bulb/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -21,7 +21,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led1: pwm_led_1 {
-			pwms = < &pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			pwms = < &pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 };


### PR DESCRIPTION
Due to leds and buttons polarity refactor some time ago our configuration of PWM for nRF7002 started to work in the opposite way than expected.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>