### PR TITLE
tests: unity: introduce mock_prefix in the unity configuration file

### DIFF
--- a/tests/unity/unity_cfg.yaml.template
+++ b/tests/unity/unity_cfg.yaml.template
@@ -35,3 +35,4 @@
     :suite_teardown: >
        extern int test_suiteTearDown(int); return test_suiteTearDown(num_failures);
     :main_name: unity_main
+    :mock_prefix: 'cmock_'


### PR DESCRIPTION
Introduced the mock_prefix Unity configuration option in the template
yaml file. The option is required to ensure that the mocked headers
are included in the test runner, as otherwise the generated memory
management functions shall not be used, potentially causing false
negatives in the test.

Signed-off-by: Kacper Radoszewski <kacper.radoszewski@nordicsemi.no>