### PR TITLE
manifest: nrfxlib with PSA driver wrapper fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -116,7 +116,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: bebb88e59655efb172b295a77d5a1eb62dc4552e
+      revision: 51f60b21b708368be1437c613129a54f4682d593
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Brings nrfxlib with some fixes in the
PSA crypto driver wrapper file related
to the import key function.

Ref: NCSDK-17707

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>