### PR TITLE
manifest: Update Zephyr version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 24d82de42102f1453a25b68a0994c05639dd5e0c
+      revision: c0689b16ff127d1b71a4cc20310d476e1807e26e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above

--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 22a520600be9b74f2338fa2465d788ab2ff8772a
+      revision: f4a75a5dcff35c70d65ae2bc10c15f946fc6f8d8
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This commit pulls in the local sdk-zephyr fixes for the printk-based logging and newlib POSIX definition conflicts.

Ref: NCSDK-18426
Ref: NCSIDB-890