### PR TITLE
quarantine_windows: update quarantine

### DIFF
--- a/scripts/quarantine_windows.yaml
+++ b/scripts/quarantine_windows.yaml
@@ -10,8 +10,10 @@
 - scenarios:
     - applications.asset_tracker_v2.cloud.cloud_codec.json_common.aws
     - applications.asset_tracker_v2.cloud.cloud_codec.json_common.azure
-    - samples.edge_impulse.wrapper
-    - samples.event_manager
+    - sample.app_event_manager
+    - sample.app_event_manager_shell
+    - sample.caf_sensor_manager.correctness_test
+    - sample.edge_impulse.wrapper
   platforms:
     - native_posix
     - qemu_cortex_m3
@@ -23,6 +25,8 @@
     - asset_tracker_v2.location_module_test.tester
     - asset_tracker_v2.lwm2m_codec
     - asset_tracker_v2.lwm2m_integration
+    - asset_tracker_v2.nrf_cloud_codec_test
+    - asset_tracker_v2.nrf_cloud_codec_mocked_cjson_test
     - asset_tracker_v2.ui_module_test.tester
   platforms:
     - all
@@ -30,6 +34,7 @@
 
 - scenarios:
     - samples.bluetooth.alexa_gadget
+    - sample.nrf7002.provisioning
   platforms:
     - all
   comment: "nanopb package not available in Windows toolchain"


### PR DESCRIPTION
`native_posix` and `qemu_cortex_m3` platforms are not supported on Windows CI. New samples dedicated for `native_posix` and/or `qemu_cortex_m3` platforms were added on quarantine list:
```
    - sample.app_event_manager
    - sample.app_event_manager_shell
    - sample.caf_sensor_manager.correctness_test
    - sample.edge_impulse.wrapper
    - asset_tracker_v2.nrf_cloud_codec_test
    - asset_tracker_v2.nrf_cloud_codec_mocked_cjson_test
```

Sample `sample.nrf7002.provisioning` requires installed `nanopb` package (https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/wifi/provisioning/sample_description.html#dependencies), which is not available with Windows toolchain. So, this sample was also added to quarantine.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>