### PR TITLE
Bluetooth: Mesh: Remove model_send and model_ackd_send

### DIFF
--- a/subsys/bluetooth/mesh/gen_battery_cli.c
+++ b/subsys/bluetooth/mesh/gen_battery_cli.c
@@ -111,8 +111,12 @@ int bt_mesh_battery_cli_get(struct bt_mesh_battery_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_BATTERY_OP_GET,
 				 BT_MESH_BATTERY_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_BATTERY_OP_GET);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_BATTERY_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_BATTERY_OP_STATUS, rsp);
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }

--- a/subsys/bluetooth/mesh/gen_battery_srv.c
+++ b/subsys/bluetooth/mesh/gen_battery_srv.c
@@ -124,5 +124,5 @@ int bt_mesh_battery_srv_pub(struct bt_mesh_battery_srv *srv,
 				 BT_MESH_BATTERY_MSG_LEN_STATUS);
 	bt_mesh_model_msg_init(&msg, BT_MESH_BATTERY_OP_STATUS);
 	bt_mesh_gen_bat_encode_status(&msg, status);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_dtt_cli.c
+++ b/subsys/bluetooth/mesh/gen_dtt_cli.c
@@ -70,9 +70,14 @@ int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 				 BT_MESH_DTT_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_DTT_OP_GET);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp_transition_time ? &cli->ack_ctx : NULL,
-			       BT_MESH_DTT_OP_STATUS, rsp_transition_time);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_DTT_OP_STATUS,
+		.user_data = rsp_transition_time,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp_transition_time ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
@@ -88,9 +93,14 @@ int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 	net_buf_simple_add_u8(&msg,
 			      model_transition_encode((int32_t)transition_time));
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp_transition_time ? &cli->ack_ctx : NULL,
-			       BT_MESH_DTT_OP_STATUS, rsp_transition_time);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_DTT_OP_STATUS,
+		.user_data = rsp_transition_time,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp_transition_time ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_dtt_set_unack(struct bt_mesh_dtt_cli *cli,
@@ -106,5 +116,5 @@ int bt_mesh_dtt_set_unack(struct bt_mesh_dtt_cli *cli,
 	net_buf_simple_add_u8(&msg,
 			      model_transition_encode((int32_t)transition_time));
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_dtt_srv.c
+++ b/subsys/bluetooth/mesh/gen_dtt_srv.c
@@ -186,5 +186,5 @@ int bt_mesh_dtt_srv_pub(struct bt_mesh_dtt_srv *srv,
 				 BT_MESH_DTT_MSG_LEN_STATUS);
 	encode_status(&msg, srv->transition_time);
 
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_loc_cli.c
+++ b/subsys/bluetooth/mesh/gen_loc_cli.c
@@ -101,9 +101,14 @@ int bt_mesh_loc_cli_global_get(struct bt_mesh_loc_cli *cli,
 
 	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_GLOBAL_GET);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LOC_OP_GLOBAL_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LOC_OP_GLOBAL_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_loc_cli_global_set(struct bt_mesh_loc_cli *cli,
@@ -117,9 +122,14 @@ int bt_mesh_loc_cli_global_set(struct bt_mesh_loc_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_GLOBAL_SET);
 	bt_mesh_loc_global_encode(&msg, loc);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LOC_OP_GLOBAL_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LOC_OP_GLOBAL_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_loc_cli_global_set_unack(struct bt_mesh_loc_cli *cli,
@@ -132,7 +142,7 @@ int bt_mesh_loc_cli_global_set_unack(struct bt_mesh_loc_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_GLOBAL_SET_UNACK);
 	bt_mesh_loc_global_encode(&msg, loc);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_loc_cli_local_get(struct bt_mesh_loc_cli *cli,
@@ -144,9 +154,14 @@ int bt_mesh_loc_cli_local_get(struct bt_mesh_loc_cli *cli,
 
 	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_LOCAL_GET);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LOC_OP_LOCAL_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LOC_OP_LOCAL_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_loc_cli_local_set(struct bt_mesh_loc_cli *cli,
@@ -160,9 +175,14 @@ int bt_mesh_loc_cli_local_set(struct bt_mesh_loc_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_LOCAL_SET);
 	bt_mesh_loc_local_encode(&msg, loc);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LOC_OP_LOCAL_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LOC_OP_LOCAL_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_loc_cli_local_set_unack(struct bt_mesh_loc_cli *cli,
@@ -175,5 +195,5 @@ int bt_mesh_loc_cli_local_set_unack(struct bt_mesh_loc_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_LOCAL_SET_UNACK);
 	bt_mesh_loc_local_encode(&msg, loc);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_loc_srv.c
+++ b/subsys/bluetooth/mesh/gen_loc_srv.c
@@ -255,7 +255,7 @@ int bt_mesh_loc_srv_global_pub(struct bt_mesh_loc_srv *srv,
 	bt_mesh_loc_global_encode(&msg, global);
 	srv->pub_op = BT_MESH_LOC_OP_GLOBAL_STATUS;
 
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }
 
 int bt_mesh_loc_srv_local_pub(struct bt_mesh_loc_srv *srv,
@@ -269,5 +269,5 @@ int bt_mesh_loc_srv_local_pub(struct bt_mesh_loc_srv *srv,
 	bt_mesh_loc_local_encode(&msg, local);
 	srv->pub_op = BT_MESH_LOC_OP_LOCAL_STATUS;
 
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_lvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_lvl_cli.c
@@ -87,9 +87,14 @@ int bt_mesh_lvl_cli_get(struct bt_mesh_lvl_cli *cli,
 				 BT_MESH_LVL_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_GET);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LVL_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LVL_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
@@ -111,9 +116,14 @@ int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LVL_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LVL_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_lvl_cli_set_unack(struct bt_mesh_lvl_cli *cli,
@@ -134,7 +144,7 @@ int bt_mesh_lvl_cli_set_unack(struct bt_mesh_lvl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
@@ -156,9 +166,14 @@ int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
 		model_transition_buf_add(&msg, delta_set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LVL_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LVL_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_lvl_cli_delta_set_unack(
@@ -179,7 +194,7 @@ int bt_mesh_lvl_cli_delta_set_unack(
 		model_transition_buf_add(&msg, delta_set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
@@ -202,9 +217,14 @@ int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
 		model_transition_buf_add(&msg, move_set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LVL_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LVL_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_lvl_cli_move_set_unack(struct bt_mesh_lvl_cli *cli,
@@ -226,5 +246,5 @@ int bt_mesh_lvl_cli_move_set_unack(struct bt_mesh_lvl_cli *cli,
 		model_transition_buf_add(&msg, move_set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -325,5 +325,5 @@ int bt_mesh_lvl_srv_pub(struct bt_mesh_lvl_srv *srv,
 				 BT_MESH_LVL_MSG_MAXLEN_STATUS);
 	encode_status(status, &msg);
 
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_onoff_cli.c
+++ b/subsys/bluetooth/mesh/gen_onoff_cli.c
@@ -109,9 +109,14 @@ int bt_mesh_onoff_cli_get(struct bt_mesh_onoff_cli *cli,
 				 BT_MESH_ONOFF_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_ONOFF_OP_GET);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_ONOFF_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_ONOFF_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_onoff_cli_set(struct bt_mesh_onoff_cli *cli,
@@ -132,9 +137,14 @@ int bt_mesh_onoff_cli_set(struct bt_mesh_onoff_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_ONOFF_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_ONOFF_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_onoff_cli_set_unack(struct bt_mesh_onoff_cli *cli,
@@ -154,5 +164,5 @@ int bt_mesh_onoff_cli_set_unack(struct bt_mesh_onoff_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -221,5 +221,5 @@ int bt_mesh_onoff_srv_pub(struct bt_mesh_onoff_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_ONOFF_OP_STATUS,
 				 BT_MESH_ONOFF_MSG_MAXLEN_STATUS);
 	encode_status(&msg, status);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_plvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_plvl_cli.c
@@ -163,9 +163,14 @@ int bt_mesh_plvl_cli_power_get(struct bt_mesh_plvl_cli *cli,
 				 BT_MESH_PLVL_MSG_LEN_LEVEL_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_LEVEL_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_PLVL_OP_LEVEL_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_PLVL_OP_LEVEL_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_plvl_cli_power_set(struct bt_mesh_plvl_cli *cli,
@@ -183,9 +188,14 @@ int bt_mesh_plvl_cli_power_set(struct bt_mesh_plvl_cli *cli,
 		model_transition_buf_add(&buf, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_PLVL_OP_LEVEL_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_PLVL_OP_LEVEL_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_plvl_cli_power_set_unack(struct bt_mesh_plvl_cli *cli,
@@ -202,7 +212,7 @@ int bt_mesh_plvl_cli_power_set_unack(struct bt_mesh_plvl_cli *cli,
 		model_transition_buf_add(&buf, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_plvl_cli_range_get(struct bt_mesh_plvl_cli *cli,
@@ -213,9 +223,14 @@ int bt_mesh_plvl_cli_range_get(struct bt_mesh_plvl_cli *cli,
 				 BT_MESH_PLVL_MSG_LEN_RANGE_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_RANGE_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_PLVL_OP_RANGE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_PLVL_OP_RANGE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_plvl_cli_range_set(struct bt_mesh_plvl_cli *cli,
@@ -229,9 +244,14 @@ int bt_mesh_plvl_cli_range_set(struct bt_mesh_plvl_cli *cli,
 	net_buf_simple_add_le16(&buf, range->min);
 	net_buf_simple_add_le16(&buf, range->max);
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_PLVL_OP_RANGE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_PLVL_OP_RANGE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_plvl_cli_range_set_unack(struct bt_mesh_plvl_cli *cli,
@@ -244,7 +264,7 @@ int bt_mesh_plvl_cli_range_set_unack(struct bt_mesh_plvl_cli *cli,
 	net_buf_simple_add_le16(&buf, range->min);
 	net_buf_simple_add_le16(&buf, range->max);
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
@@ -254,9 +274,14 @@ int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
 				 BT_MESH_PLVL_MSG_LEN_DEFAULT_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_DEFAULT_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_PLVL_OP_DEFAULT_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_PLVL_OP_DEFAULT_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_plvl_cli_default_set(struct bt_mesh_plvl_cli *cli,
@@ -268,9 +293,14 @@ int bt_mesh_plvl_cli_default_set(struct bt_mesh_plvl_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_DEFAULT_SET);
 	net_buf_simple_add_le16(&buf, default_power);
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_PLVL_OP_DEFAULT_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_PLVL_OP_DEFAULT_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_plvl_cli_default_set_unack(struct bt_mesh_plvl_cli *cli,
@@ -282,7 +312,7 @@ int bt_mesh_plvl_cli_default_set_unack(struct bt_mesh_plvl_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_DEFAULT_SET_UNACK);
 	net_buf_simple_add_le16(&buf, default_power);
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_plvl_cli_last_get(struct bt_mesh_plvl_cli *cli,
@@ -292,7 +322,12 @@ int bt_mesh_plvl_cli_last_get(struct bt_mesh_plvl_cli *cli,
 				 BT_MESH_PLVL_MSG_LEN_LAST_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_LAST_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_PLVL_OP_LAST_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_PLVL_OP_LAST_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -101,7 +101,7 @@ static int pub(struct bt_mesh_plvl_srv *srv, struct bt_mesh_msg_ctx *ctx,
 				 BT_MESH_PLVL_MSG_MAXLEN_LEVEL_STATUS);
 	lvl_status_encode(&msg, status);
 
-	return model_send(srv->plvl_model, ctx, &msg);
+	return bt_mesh_msg_send(srv->plvl_model, ctx, &msg);
 }
 
 static void rsp_plvl_status(struct bt_mesh_model *model,

--- a/subsys/bluetooth/mesh/gen_ponoff_cli.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_cli.c
@@ -75,9 +75,14 @@ int bt_mesh_ponoff_cli_on_power_up_get(struct bt_mesh_ponoff_cli *cli,
 				 BT_MESH_PONOFF_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&msg, BT_MESH_PONOFF_OP_GET);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       (rsp ? &cli->ack_ctx : NULL),
-			       BT_MESH_PONOFF_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_PONOFF_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_ponoff_cli_on_power_up_set(struct bt_mesh_ponoff_cli *cli,
@@ -94,9 +99,14 @@ int bt_mesh_ponoff_cli_on_power_up_set(struct bt_mesh_ponoff_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_PONOFF_OP_SET);
 	net_buf_simple_add_u8(&msg, on_power_up);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       (rsp ? &cli->ack_ctx : NULL),
-			       BT_MESH_PONOFF_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_PONOFF_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_ponoff_cli_on_power_up_set_unack(
@@ -112,5 +122,5 @@ int bt_mesh_ponoff_cli_on_power_up_set_unack(
 	bt_mesh_model_msg_init(&msg, BT_MESH_PONOFF_OP_SET_UNACK);
 	net_buf_simple_add_u8(&msg, on_power_up);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -410,5 +410,5 @@ int bt_mesh_ponoff_srv_pub(struct bt_mesh_ponoff_srv *srv,
 	bt_mesh_model_msg_init(&msg, BT_MESH_PONOFF_OP_STATUS);
 	net_buf_simple_add_u8(&msg, srv->on_power_up);
 
-	return model_send(srv->ponoff_model, ctx, &msg);
+	return bt_mesh_msg_send(srv->ponoff_model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_prop_cli.c
+++ b/subsys/bluetooth/mesh/gen_prop_cli.c
@@ -215,10 +215,15 @@ static int props_get(struct bt_mesh_prop_cli *cli, struct bt_mesh_msg_ctx *ctx,
 	struct prop_list_ctx block_ctx = {
 		.list = rsp,
 	};
-	int status = model_ackd_send(cli->model, ctx, &msg,
-				     rsp ? &cli->ack_ctx : NULL,
-				     op_get(BT_MESH_PROP_OP_PROPS_STATUS, kind),
-				     &block_ctx);
+	int status;
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = op_get(BT_MESH_PROP_OP_PROPS_STATUS, kind),
+		.user_data = &block_ctx,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	status = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 
 	if (status == 0) {
 		status = block_ctx.status;
@@ -252,9 +257,14 @@ int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,
 	bt_mesh_model_msg_init(&msg, op_get(BT_MESH_PROP_OP_PROP_GET, kind));
 	net_buf_simple_add_le16(&msg, id);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       op_get(BT_MESH_PROP_OP_PROP_STATUS, kind), rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = op_get(BT_MESH_PROP_OP_PROP_STATUS, kind),
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_prop_cli_user_prop_set(struct bt_mesh_prop_cli *cli,
@@ -269,11 +279,14 @@ int bt_mesh_prop_cli_user_prop_set(struct bt_mesh_prop_cli *cli,
 	net_buf_simple_add_le16(&msg, val->meta.id);
 	net_buf_simple_add_mem(&msg, val->value, val->size);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       op_get(BT_MESH_PROP_OP_PROP_STATUS,
-				      BT_MESH_PROP_SRV_KIND_USER),
-			       rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = op_get(BT_MESH_PROP_OP_PROP_STATUS, BT_MESH_PROP_SRV_KIND_USER),
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_prop_cli_user_prop_set_unack(struct bt_mesh_prop_cli *cli,
@@ -287,7 +300,7 @@ int bt_mesh_prop_cli_user_prop_set_unack(struct bt_mesh_prop_cli *cli,
 	net_buf_simple_add_le16(&msg, val->meta.id);
 	net_buf_simple_add_mem(&msg, val->value, val->size);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
@@ -303,11 +316,14 @@ int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
 	net_buf_simple_add_u8(&msg, val->meta.user_access);
 	net_buf_simple_add_mem(&msg, val->value, val->size);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       op_get(BT_MESH_PROP_OP_PROP_STATUS,
-				      BT_MESH_PROP_SRV_KIND_ADMIN),
-			       rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = op_get(BT_MESH_PROP_OP_PROP_STATUS, BT_MESH_PROP_SRV_KIND_ADMIN),
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_prop_cli_admin_prop_set_unack(struct bt_mesh_prop_cli *cli,
@@ -322,7 +338,7 @@ int bt_mesh_prop_cli_admin_prop_set_unack(struct bt_mesh_prop_cli *cli,
 	net_buf_simple_add_u8(&msg, val->meta.user_access);
 	net_buf_simple_add_mem(&msg, val->value, val->size);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
@@ -337,11 +353,14 @@ int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
 	net_buf_simple_add_le16(&msg, prop->id);
 	net_buf_simple_add_u8(&msg, prop->user_access);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       op_get(BT_MESH_PROP_OP_PROP_STATUS,
-				      BT_MESH_PROP_SRV_KIND_MFR),
-			       rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = op_get(BT_MESH_PROP_OP_PROP_STATUS, BT_MESH_PROP_SRV_KIND_MFR),
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_prop_cli_mfr_prop_set_unack(struct bt_mesh_prop_cli *cli,
@@ -355,5 +374,5 @@ int bt_mesh_prop_cli_mfr_prop_set_unack(struct bt_mesh_prop_cli *cli,
 	net_buf_simple_add_le16(&msg, prop->id);
 	net_buf_simple_add_u8(&msg, prop->user_access);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_prop_srv.c
+++ b/subsys/bluetooth/mesh/gen_prop_srv.c
@@ -711,7 +711,7 @@ int bt_mesh_prop_srv_pub_list(struct bt_mesh_prop_srv *srv,
 
 	pub_list_build(srv, &msg, 1);
 
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }
 
 int bt_mesh_prop_srv_pub(struct bt_mesh_prop_srv *srv,
@@ -739,5 +739,5 @@ int bt_mesh_prop_srv_pub(struct bt_mesh_prop_srv *srv,
 	net_buf_simple_add_u8(&msg, val->meta.user_access);
 	net_buf_simple_add_mem(&msg, val->value, val->size);
 
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/light_ctl_cli.c
+++ b/subsys/bluetooth/mesh/light_ctl_cli.c
@@ -214,8 +214,14 @@ static int get_msg(struct bt_mesh_light_ctl_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(msg, opcode, BT_MESH_LIGHT_CTL_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&msg, opcode);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL, ret_opcode, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = ret_opcode,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_ctl_get(struct bt_mesh_light_ctl_cli *cli,
@@ -242,9 +248,14 @@ int bt_mesh_light_ctl_set(struct bt_mesh_light_ctl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_CTL_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTL_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_ctl_set_unack(struct bt_mesh_light_ctl_cli *cli,
@@ -262,7 +273,7 @@ int bt_mesh_light_ctl_set_unack(struct bt_mesh_light_ctl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_light_temp_get(struct bt_mesh_light_ctl_cli *cli,
@@ -288,9 +299,14 @@ int bt_mesh_light_temp_set(struct bt_mesh_light_ctl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_TEMP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_TEMP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_temp_set_unack(
@@ -307,7 +323,7 @@ int bt_mesh_light_temp_set_unack(
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_light_ctl_default_get(struct bt_mesh_light_ctl_cli *cli,
@@ -330,9 +346,14 @@ int bt_mesh_light_ctl_default_set(struct bt_mesh_light_ctl_cli *cli,
 	net_buf_simple_add_le16(&msg, set->temp);
 	net_buf_simple_add_le16(&msg, set->delta_uv);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_CTL_DEFAULT_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTL_DEFAULT_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_ctl_default_set_unack(
@@ -346,7 +367,7 @@ int bt_mesh_light_ctl_default_set_unack(
 	net_buf_simple_add_le16(&msg, set->temp);
 	net_buf_simple_add_le16(&msg, set->delta_uv);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_light_temp_range_get(
@@ -368,9 +389,14 @@ int bt_mesh_light_temp_range_set(
 	net_buf_simple_add_le16(&msg, set->min);
 	net_buf_simple_add_le16(&msg, set->max);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_TEMP_RANGE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_TEMP_RANGE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_temp_range_set_unack(
@@ -383,5 +409,5 @@ int bt_mesh_light_temp_range_set_unack(
 	net_buf_simple_add_le16(&msg, set->min);
 	net_buf_simple_add_le16(&msg, set->max);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/light_ctl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctl_srv.c
@@ -492,7 +492,7 @@ int bt_mesh_light_ctl_pub(struct bt_mesh_light_ctl_srv *srv,
 				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_STATUS);
 
 	ctl_encode_status(&msg, status);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }
 
 int bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
@@ -502,7 +502,7 @@ int bt_mesh_light_ctl_range_pub(struct bt_mesh_light_ctl_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_TEMP_RANGE_STATUS,
 				 BT_MESH_LIGHT_CTL_MSG_LEN_TEMP_RANGE_STATUS);
 	range_encode_status(&msg, srv, status);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }
 
 int bt_mesh_light_ctl_default_pub(struct bt_mesh_light_ctl_srv *srv,
@@ -511,5 +511,5 @@ int bt_mesh_light_ctl_default_pub(struct bt_mesh_light_ctl_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_CTL_DEFAULT_STATUS,
 				 BT_MESH_LIGHT_CTL_MSG_LEN_DEFAULT_MSG);
 	default_encode_status(&msg, srv);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/light_ctrl_cli.c
+++ b/subsys/bluetooth/mesh/light_ctrl_cli.c
@@ -220,8 +220,14 @@ int bt_mesh_light_ctrl_cli_mode_get(struct bt_mesh_light_ctrl_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHT_CTRL_OP_MODE_GET, 0);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_MODE_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_CTRL_OP_MODE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_MODE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_ctrl_cli_mode_set(struct bt_mesh_light_ctrl_cli *cli,
@@ -232,8 +238,14 @@ int bt_mesh_light_ctrl_cli_mode_set(struct bt_mesh_light_ctrl_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_MODE_SET);
 	net_buf_simple_add_u8(&buf, enabled);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_CTRL_OP_MODE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_MODE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_ctrl_cli_mode_set_unack(struct bt_mesh_light_ctrl_cli *cli,
@@ -244,7 +256,7 @@ int bt_mesh_light_ctrl_cli_mode_set_unack(struct bt_mesh_light_ctrl_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_MODE_SET_UNACK);
 	net_buf_simple_add_u8(&buf, enabled);
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_light_ctrl_cli_occupancy_enabled_get(
@@ -254,8 +266,14 @@ int bt_mesh_light_ctrl_cli_occupancy_enabled_get(
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHT_CTRL_OP_OM_GET, 0);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_OM_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_CTRL_OP_OM_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_OM_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_ctrl_cli_occupancy_enabled_set(
@@ -266,8 +284,14 @@ int bt_mesh_light_ctrl_cli_occupancy_enabled_set(
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_OM_SET);
 	net_buf_simple_add_u8(&buf, enabled);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_CTRL_OP_OM_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_OM_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_ctrl_cli_occupancy_enabled_set_unack(
@@ -278,7 +302,7 @@ int bt_mesh_light_ctrl_cli_occupancy_enabled_set_unack(
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_OM_SET_UNACK);
 	net_buf_simple_add_u8(&buf, enabled);
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_light_ctrl_cli_light_onoff_get(struct bt_mesh_light_ctrl_cli *cli,
@@ -288,8 +312,14 @@ int bt_mesh_light_ctrl_cli_light_onoff_get(struct bt_mesh_light_ctrl_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_GET, 0);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_ctrl_cli_light_onoff_set(struct bt_mesh_light_ctrl_cli *cli,
@@ -305,8 +335,14 @@ int bt_mesh_light_ctrl_cli_light_onoff_set(struct bt_mesh_light_ctrl_cli *cli,
 		model_transition_buf_add(&buf, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_ctrl_cli_light_onoff_set_unack(
@@ -323,7 +359,7 @@ int bt_mesh_light_ctrl_cli_light_onoff_set_unack(
 		model_transition_buf_add(&buf, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_light_ctrl_cli_prop_get(struct bt_mesh_light_ctrl_cli *cli,
@@ -340,8 +376,14 @@ int bt_mesh_light_ctrl_cli_prop_get(struct bt_mesh_light_ctrl_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_PROP_GET);
 	net_buf_simple_add_le16(&buf, id);
 
-	err = model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			      BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, &ack);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_PROP_STATUS,
+		.user_data = &ack,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 	if (err) {
 		return err;
 	}
@@ -381,8 +423,14 @@ int bt_mesh_light_ctrl_cli_prop_set(struct bt_mesh_light_ctrl_cli *cli,
 		return err;
 	}
 
-	err = model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			      BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, &ack);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_PROP_STATUS,
+		.user_data = &ack,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 	if (err) {
 		return err;
 	}
@@ -418,7 +466,7 @@ int bt_mesh_light_ctrl_cli_prop_set_unack(struct bt_mesh_light_ctrl_cli *cli,
 		return err;
 	}
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_light_ctrl_cli_coeff_get(struct bt_mesh_light_ctrl_cli *cli,
@@ -435,8 +483,14 @@ int bt_mesh_light_ctrl_cli_coeff_get(struct bt_mesh_light_ctrl_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHT_CTRL_OP_PROP_GET);
 	net_buf_simple_add_le16(&buf, id);
 
-	err = model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			      BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, &ack);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_PROP_STATUS,
+		.user_data = &ack,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 	if (err) {
 		return err;
 	}
@@ -464,8 +518,14 @@ int bt_mesh_light_ctrl_cli_coeff_set(struct bt_mesh_light_ctrl_cli *cli,
 	net_buf_simple_add_le16(&buf, id);
 	net_buf_simple_add_mem(&buf, &val, sizeof(float));
 
-	err = model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			      BT_MESH_LIGHT_CTRL_OP_PROP_STATUS, &ack);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_CTRL_OP_PROP_STATUS,
+		.user_data = &ack,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 	if (err) {
 		return err;
 	}
@@ -488,5 +548,5 @@ int bt_mesh_light_ctrl_cli_coeff_set_unack(struct bt_mesh_light_ctrl_cli *cli,
 	net_buf_simple_add_le16(&buf, id);
 	net_buf_simple_add_mem(&buf, &val, sizeof(float));
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -263,7 +263,7 @@ static int light_onoff_status_send(struct bt_mesh_light_ctrl_srv *srv,
 				 3);
 	light_onoff_encode(srv, &buf, prev_state);
 
-	return model_send(srv->model, ctx, &buf);
+	return bt_mesh_msg_send(srv->model, ctx, &buf);
 }
 
 static void onoff_encode(struct bt_mesh_light_ctrl_srv *srv,
@@ -719,7 +719,7 @@ static void mode_rsp(struct bt_mesh_light_ctrl_srv *srv,
 	bt_mesh_model_msg_init(&rsp, BT_MESH_LIGHT_CTRL_OP_MODE_STATUS);
 	net_buf_simple_add_u8(&rsp, is_enabled(srv));
 
-	model_send(srv->model, ctx, &rsp);
+	bt_mesh_msg_send(srv->model, ctx, &rsp);
 }
 
 static int handle_mode_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
@@ -784,7 +784,7 @@ static void om_rsp(struct bt_mesh_light_ctrl_srv *srv,
 	net_buf_simple_add_u8(&rsp,
 			      atomic_test_bit(&srv->flags, FLAG_OCC_MODE));
 
-	model_send(srv->model, ctx, &rsp);
+	bt_mesh_msg_send(srv->model, ctx, &rsp);
 }
 
 static int handle_om_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
@@ -1269,7 +1269,7 @@ static int prop_tx(struct bt_mesh_light_ctrl_srv *srv,
 		return -ENOENT;
 	}
 
-	model_send(srv->setup_srv, ctx, &buf);
+	bt_mesh_msg_send(srv->setup_srv, ctx, &buf);
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/light_hsl_cli.c
+++ b/subsys/bluetooth/mesh/light_hsl_cli.c
@@ -261,8 +261,14 @@ static int get_msg(struct bt_mesh_light_hsl_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(msg, opcode, BT_MESH_LIGHT_HSL_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&msg, opcode);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL, ret_opcode, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = ret_opcode,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_hsl_get(struct bt_mesh_light_hsl_cli *cli,
@@ -287,9 +293,14 @@ int bt_mesh_light_hsl_set(struct bt_mesh_light_hsl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_HSL_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_HSL_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_hsl_set_unack(struct bt_mesh_light_hsl_cli *cli,
@@ -305,7 +316,7 @@ int bt_mesh_light_hsl_set_unack(struct bt_mesh_light_hsl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_light_hsl_target_get(struct bt_mesh_light_hsl_cli *cli,
@@ -334,9 +345,14 @@ int bt_mesh_light_hsl_default_set(struct bt_mesh_light_hsl_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_LIGHT_HSL_OP_DEFAULT_SET);
 	light_hsl_buf_push(&msg,  set);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_HSL_OP_DEFAULT_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_HSL_OP_DEFAULT_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_hsl_default_set_unack(struct bt_mesh_light_hsl_cli *cli,
@@ -348,7 +364,7 @@ int bt_mesh_light_hsl_default_set_unack(struct bt_mesh_light_hsl_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_LIGHT_HSL_OP_DEFAULT_SET_UNACK);
 	light_hsl_buf_push(&msg,  set);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_light_hsl_range_get(struct bt_mesh_light_hsl_cli *cli,
@@ -369,9 +385,14 @@ int bt_mesh_light_hsl_range_set(struct bt_mesh_light_hsl_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_LIGHT_HSL_OP_RANGE_SET);
 	light_hue_sat_range_buf_push(&msg, set);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_HSL_OP_RANGE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_HSL_OP_RANGE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_hsl_range_set_unack(
@@ -383,7 +404,7 @@ int bt_mesh_light_hsl_range_set_unack(
 	bt_mesh_model_msg_init(&msg, BT_MESH_LIGHT_HSL_OP_RANGE_SET_UNACK);
 	light_hue_sat_range_buf_push(&msg, set);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_light_hue_get(struct bt_mesh_light_hsl_cli *cli,
@@ -408,9 +429,14 @@ int bt_mesh_light_hue_set(struct bt_mesh_light_hsl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_HUE_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_HUE_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_hue_set_unack(struct bt_mesh_light_hsl_cli *cli,
@@ -426,7 +452,7 @@ int bt_mesh_light_hue_set_unack(struct bt_mesh_light_hsl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_light_saturation_get(struct bt_mesh_light_hsl_cli *cli,
@@ -451,9 +477,14 @@ int bt_mesh_light_saturation_set(struct bt_mesh_light_hsl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_SAT_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_SAT_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_saturation_set_unack(struct bt_mesh_light_hsl_cli *cli,
@@ -469,5 +500,5 @@ int bt_mesh_light_saturation_set_unack(struct bt_mesh_light_hsl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/light_hsl_srv.c
+++ b/subsys/bluetooth/mesh/light_hsl_srv.c
@@ -617,5 +617,5 @@ int bt_mesh_light_hsl_srv_pub(struct bt_mesh_light_hsl_srv *srv,
 				 BT_MESH_LIGHT_HSL_MSG_MAXLEN_STATUS);
 	hsl_status_encode(&buf, BT_MESH_LIGHT_HSL_OP_STATUS, status);
 
-	return model_send(srv->model, ctx, &buf);
+	return bt_mesh_msg_send(srv->model, ctx, &buf);
 }

--- a/subsys/bluetooth/mesh/light_hue_srv.c
+++ b/subsys/bluetooth/mesh/light_hue_srv.c
@@ -472,5 +472,5 @@ int bt_mesh_light_hue_srv_pub(struct bt_mesh_light_hue_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_HUE_OP_STATUS,
 				 BT_MESH_LIGHT_HSL_MSG_MAXLEN_HUE_STATUS);
 	encode_status(&msg, status);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/light_sat_srv.c
+++ b/subsys/bluetooth/mesh/light_sat_srv.c
@@ -503,5 +503,5 @@ int bt_mesh_light_sat_srv_pub(struct bt_mesh_light_sat_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_SAT_OP_STATUS,
 				 BT_MESH_LIGHT_HSL_MSG_MAXLEN_SAT_STATUS);
 	encode_status(&msg, status);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/light_temp_srv.c
+++ b/subsys/bluetooth/mesh/light_temp_srv.c
@@ -523,5 +523,5 @@ int bt_mesh_light_temp_srv_pub(struct bt_mesh_light_temp_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_TEMP_STATUS,
 				 BT_MESH_LIGHT_CTL_MSG_MAXLEN_TEMP_STATUS);
 	encode_status(&msg, status);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/light_xyl_cli.c
+++ b/subsys/bluetooth/mesh/light_xyl_cli.c
@@ -177,8 +177,14 @@ static int get_msg(struct bt_mesh_light_xyl_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(msg, opcode, BT_MESH_LIGHT_XYL_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&msg, opcode);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL, ret_opcode, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = ret_opcode,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_xyl_get(struct bt_mesh_light_xyl_cli *cli,
@@ -205,9 +211,14 @@ int bt_mesh_light_xyl_set(struct bt_mesh_light_xyl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_XYL_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_XYL_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_xyl_set_unack(struct bt_mesh_light_xyl_cli *cli,
@@ -225,7 +236,7 @@ int bt_mesh_light_xyl_set_unack(struct bt_mesh_light_xyl_cli *cli,
 		model_transition_buf_add(&msg, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_light_xyl_target_get(struct bt_mesh_light_xyl_cli *cli,
@@ -256,9 +267,14 @@ int bt_mesh_light_xyl_default_set(struct bt_mesh_light_xyl_cli *cli,
 	net_buf_simple_add_le16(&msg, set->xy.x);
 	net_buf_simple_add_le16(&msg, set->xy.y);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_XYL_OP_DEFAULT_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_XYL_OP_DEFAULT_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_xyl_default_set_unack(struct bt_mesh_light_xyl_cli *cli,
@@ -272,7 +288,7 @@ int bt_mesh_light_xyl_default_set_unack(struct bt_mesh_light_xyl_cli *cli,
 	net_buf_simple_add_le16(&msg, set->xy.x);
 	net_buf_simple_add_le16(&msg, set->xy.y);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_light_xyl_range_get(struct bt_mesh_light_xyl_cli *cli,
@@ -300,9 +316,14 @@ int bt_mesh_light_xyl_range_set(struct bt_mesh_light_xyl_cli *cli,
 	net_buf_simple_add_le16(&msg, set->min.y);
 	net_buf_simple_add_le16(&msg, set->max.y);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHT_XYL_OP_RANGE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHT_XYL_OP_RANGE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_light_xyl_range_set_unack(struct bt_mesh_light_xyl_cli *cli,
@@ -321,5 +342,5 @@ int bt_mesh_light_xyl_range_set_unack(struct bt_mesh_light_xyl_cli *cli,
 	net_buf_simple_add_le16(&msg, set->min.y);
 	net_buf_simple_add_le16(&msg, set->max.y);
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/light_xyl_srv.c
+++ b/subsys/bluetooth/mesh/light_xyl_srv.c
@@ -672,7 +672,7 @@ int bt_mesh_light_xyl_srv_pub(struct bt_mesh_light_xyl_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_XYL_OP_STATUS,
 				 BT_MESH_LIGHT_XYL_MSG_MAXLEN_STATUS);
 	xyl_encode_status(&msg, status, BT_MESH_LIGHT_XYL_OP_STATUS);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }
 
 int bt_mesh_light_xyl_srv_target_pub(struct bt_mesh_light_xyl_srv *srv,
@@ -682,7 +682,7 @@ int bt_mesh_light_xyl_srv_target_pub(struct bt_mesh_light_xyl_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_XYL_OP_TARGET_STATUS,
 				 BT_MESH_LIGHT_XYL_MSG_MAXLEN_STATUS);
 	xyl_encode_status(&msg, status, BT_MESH_LIGHT_XYL_OP_TARGET_STATUS);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }
 
 int bt_mesh_light_xyl_srv_range_pub(struct bt_mesh_light_xyl_srv *srv,
@@ -692,7 +692,7 @@ int bt_mesh_light_xyl_srv_range_pub(struct bt_mesh_light_xyl_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_XYL_OP_RANGE_STATUS,
 				 BT_MESH_LIGHT_XYL_MSG_LEN_RANGE_STATUS);
 	range_encode_status(&msg, srv, status_code);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }
 
 int bt_mesh_light_xyl_srv_default_pub(struct bt_mesh_light_xyl_srv *srv,
@@ -701,5 +701,5 @@ int bt_mesh_light_xyl_srv_default_pub(struct bt_mesh_light_xyl_srv *srv,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LIGHT_XYL_OP_DEFAULT_STATUS,
 				 BT_MESH_LIGHT_XYL_MSG_LEN_DEFAULT);
 	default_encode_status(srv, &msg);
-	return model_send(srv->model, ctx, &msg);
+	return bt_mesh_msg_send(srv->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/lightness_cli.c
+++ b/subsys/bluetooth/mesh/lightness_cli.c
@@ -182,9 +182,14 @@ int lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
 				 BT_MESH_LIGHTNESS_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&buf, op_get(LIGHTNESS_OP_TYPE_GET, repr));
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       op_get(LIGHTNESS_OP_TYPE_STATUS, repr), rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = op_get(LIGHTNESS_OP_TYPE_STATUS, repr),
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int lightness_cli_light_set(struct bt_mesh_lightness_cli *cli,
@@ -202,9 +207,14 @@ int lightness_cli_light_set(struct bt_mesh_lightness_cli *cli,
 		model_transition_buf_add(&buf, set->transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       op_get(LIGHTNESS_OP_TYPE_STATUS, repr), rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = op_get(LIGHTNESS_OP_TYPE_STATUS, repr),
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int lightness_cli_light_set_unack(struct bt_mesh_lightness_cli *cli,
@@ -222,7 +232,7 @@ int lightness_cli_light_set_unack(struct bt_mesh_lightness_cli *cli,
 		model_transition_buf_add(&buf, set->transition);
 	}
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_lightness_cli_light_get(struct bt_mesh_lightness_cli *cli,
@@ -255,9 +265,14 @@ int bt_mesh_lightness_cli_range_get(struct bt_mesh_lightness_cli *cli,
 				 BT_MESH_LIGHTNESS_MSG_LEN_RANGE_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHTNESS_OP_RANGE_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHTNESS_OP_RANGE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHTNESS_OP_RANGE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_lightness_cli_range_set(struct bt_mesh_lightness_cli *cli,
@@ -271,9 +286,14 @@ int bt_mesh_lightness_cli_range_set(struct bt_mesh_lightness_cli *cli,
 	net_buf_simple_add_le16(&buf, to_actual(range->min));
 	net_buf_simple_add_le16(&buf, to_actual(range->max));
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHTNESS_OP_RANGE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHTNESS_OP_RANGE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_lightness_cli_range_set_unack(
@@ -286,7 +306,7 @@ int bt_mesh_lightness_cli_range_set_unack(
 	net_buf_simple_add_le16(&buf, to_actual(range->min));
 	net_buf_simple_add_le16(&buf, to_actual(range->max));
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_lightness_cli_default_get(struct bt_mesh_lightness_cli *cli,
@@ -296,9 +316,14 @@ int bt_mesh_lightness_cli_default_get(struct bt_mesh_lightness_cli *cli,
 				 BT_MESH_LIGHTNESS_MSG_LEN_DEFAULT_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHTNESS_OP_DEFAULT_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHTNESS_OP_DEFAULT_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHTNESS_OP_DEFAULT_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_lightness_cli_default_set(struct bt_mesh_lightness_cli *cli,
@@ -310,9 +335,14 @@ int bt_mesh_lightness_cli_default_set(struct bt_mesh_lightness_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHTNESS_OP_DEFAULT_SET);
 	net_buf_simple_add_le16(&buf, to_actual(default_light));
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHTNESS_OP_DEFAULT_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHTNESS_OP_DEFAULT_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_lightness_cli_default_set_unack(struct bt_mesh_lightness_cli *cli,
@@ -324,7 +354,7 @@ int bt_mesh_lightness_cli_default_set_unack(struct bt_mesh_lightness_cli *cli,
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHTNESS_OP_DEFAULT_SET_UNACK);
 	net_buf_simple_add_le16(&buf, to_actual(default_light));
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_lightness_cli_last_get(struct bt_mesh_lightness_cli *cli,
@@ -334,7 +364,12 @@ int bt_mesh_lightness_cli_last_get(struct bt_mesh_lightness_cli *cli,
 				 BT_MESH_LIGHTNESS_MSG_LEN_LAST_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_LIGHTNESS_OP_LAST_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_LIGHTNESS_OP_LAST_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_LIGHTNESS_OP_LAST_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }

--- a/subsys/bluetooth/mesh/lightness_srv.c
+++ b/subsys/bluetooth/mesh/lightness_srv.c
@@ -122,7 +122,7 @@ static int pub(struct bt_mesh_lightness_srv *srv, struct bt_mesh_msg_ctx *ctx,
 				 BT_MESH_LIGHTNESS_MSG_MAXLEN_STATUS);
 	lvl_status_encode(&msg, status, repr);
 
-	return model_send(srv->lightness_model, ctx, &msg);
+	return bt_mesh_msg_send(srv->lightness_model, ctx, &msg);
 }
 
 static void rsp_lightness_status(struct bt_mesh_model *model,

--- a/subsys/bluetooth/mesh/model_utils.c
+++ b/subsys/bluetooth/mesh/model_utils.c
@@ -102,47 +102,13 @@ int32_t model_delay_decode(uint8_t encoded_delay)
 	return encoded_delay * DELAY_TIME_STEP_MS;
 }
 
-int model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
-	       struct net_buf_simple *buf)
+int32_t model_ackd_timeout_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx)
 {
-	if (!ctx && !model->pub) {
-		return -ENOTSUP;
-	}
+	uint8_t ttl = (ctx ? ctx->send_ttl : model->pub->ttl);
+	int32_t time = (CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_BASE +
+		ttl * CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_PER_HOP);
 
-	if (ctx) {
-		return bt_mesh_model_send(model, ctx, buf, NULL, 0);
-	}
-
-	net_buf_simple_reset(model->pub->msg);
-	net_buf_simple_add_mem(model->pub->msg, buf->data, buf->len);
-
-	return bt_mesh_model_publish(model);
-}
-
-int model_ackd_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
-		    struct net_buf_simple *buf,
-		    struct bt_mesh_msg_ack_ctx *ack, uint32_t rsp_op,
-		    void *user_data)
-{
-	if (ack &&
-	    bt_mesh_msg_ack_ctx_prepare(ack, rsp_op, ctx ? ctx->addr : model->pub->addr,
-					user_data) != 0) {
-		return -EALREADY;
-	}
-
-	int retval = model_send(model, ctx, buf);
-
-	if (ack) {
-		if (retval == 0) {
-			uint8_t ttl = (ctx ? ctx->send_ttl : model->pub->ttl);
-			int32_t time = (CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_BASE +
-				ttl * CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_PER_HOP);
-			return bt_mesh_msg_ack_ctx_wait(ack, K_MSEC(time));
-		}
-
-		bt_mesh_msg_ack_ctx_clear(ack);
-	}
-	return retval;
+	return time;
 }
 
 bool bt_mesh_model_pub_is_unicast(const struct bt_mesh_model *model)

--- a/subsys/bluetooth/mesh/model_utils.h
+++ b/subsys/bluetooth/mesh/model_utils.h
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <bluetooth/mesh/model_types.h>
 #include <bluetooth/mesh/gen_dtt_srv.h>
+#include "mesh/msg.h"
 
 #if IS_ENABLED(CONFIG_EMDS)
 /**
@@ -28,58 +29,6 @@
  * @note Arguments are evaluated twice.
  */
 #define ROUNDED_DIV(A, B) (((A) + ((B) / 2)) / (B))
-
-/** @brief Send a model message.
- *
- * Sends a model message with the given context. If the context is NULL, this
- * updates the publish message, and publishes with the configured parameters.
- *
- * @param model Model to send on.
- * @param ctx Context to send with, or NULL to publish on the configured
- * publish parameters.
- * @param buf Message to send.
- *
- * @retval 0 The message was sent successfully.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
- * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
- * not configured.
- * @retval -EAGAIN The device has not been provisioned.
- */
-int model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
-	       struct net_buf_simple *buf);
-
-/** @brief Send an acknowledged model message.
- *
- * If a message context is not provided, the message is published using the
- * model's configured publish parameters, if supported. If a response context
- * is provided, the call is blocking until the response context is either
- * released or the request times out.
- *
- * If a response context is provided, the call blocks for
- * 200 + TTL * 50 milliseconds, or until the acknowledgment is received.
- *
- * @param model Model to send the message on.
- * @param ctx Message context, or NULL to send with the configured publish
- * parameters.
- * @param buf Message to send.
- * @param ack Message response context, or NULL if no response is expected.
- * @param rsp_op Expected response opcode.
- * @param user_data User defined parameter.
- *
- * @retval 0 The message was sent successfully.
- * @retval -EALREADY A blocking request is already in progress.
- * @retval -ENOTSUP A message context was not provided and publishing is not
- * supported.
- * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
- * not configured.
- * @retval -EAGAIN The device has not been provisioned.
- * @retval -ETIMEDOUT The request timed out without a response.
- */
-int model_ackd_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
-		    struct net_buf_simple *buf,
-		    struct bt_mesh_msg_ack_ctx *ack, uint32_t rsp_op,
-		    void *user_data);
 
 /** @brief Compare the TID of an incoming message with the previous
  * transaction, and update it if it's new.
@@ -140,6 +89,8 @@ model_transition_is_invalid(const struct bt_mesh_model_transition *transition)
 		(transition->time > BT_MESH_MODEL_TRANSITION_TIME_MAX_MS ||
 		 transition->delay > BT_MESH_MODEL_DELAY_TIME_MAX_MS));
 }
+
+int32_t model_ackd_timeout_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx);
 
 #endif /* MODEL_UTILS_H__ */
 

--- a/subsys/bluetooth/mesh/scene_cli.c
+++ b/subsys/bluetooth/mesh/scene_cli.c
@@ -146,8 +146,14 @@ int bt_mesh_scene_cli_get(struct bt_mesh_scene_cli *cli,
 				 BT_MESH_SCENE_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_SCENE_OP_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_SCENE_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SCENE_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_scene_cli_register_get(struct bt_mesh_scene_cli *cli,
@@ -158,8 +164,14 @@ int bt_mesh_scene_cli_register_get(struct bt_mesh_scene_cli *cli,
 				 BT_MESH_SCENE_MSG_LEN_REGISTER_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_SCENE_OP_REGISTER_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_SCENE_OP_REGISTER_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SCENE_OP_REGISTER_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_scene_cli_store(struct bt_mesh_scene_cli *cli,
@@ -176,8 +188,14 @@ int bt_mesh_scene_cli_store(struct bt_mesh_scene_cli *cli,
 
 	net_buf_simple_add_le16(&buf, scene);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_SCENE_OP_REGISTER_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SCENE_OP_REGISTER_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_scene_cli_store_unack(struct bt_mesh_scene_cli *cli,
@@ -193,7 +211,7 @@ int bt_mesh_scene_cli_store_unack(struct bt_mesh_scene_cli *cli,
 
 	net_buf_simple_add_le16(&buf, scene);
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_scene_cli_delete(struct bt_mesh_scene_cli *cli,
@@ -210,8 +228,14 @@ int bt_mesh_scene_cli_delete(struct bt_mesh_scene_cli *cli,
 
 	net_buf_simple_add_le16(&buf, scene);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_SCENE_OP_REGISTER_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SCENE_OP_REGISTER_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_scene_cli_delete_unack(struct bt_mesh_scene_cli *cli,
@@ -227,7 +251,7 @@ int bt_mesh_scene_cli_delete_unack(struct bt_mesh_scene_cli *cli,
 
 	net_buf_simple_add_le16(&buf, scene);
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_scene_cli_recall(struct bt_mesh_scene_cli *cli,
@@ -250,8 +274,14 @@ int bt_mesh_scene_cli_recall(struct bt_mesh_scene_cli *cli,
 		model_transition_buf_add(&buf, transition);
 	}
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_SCENE_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SCENE_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_scene_cli_recall_unack(
@@ -273,5 +303,5 @@ int bt_mesh_scene_cli_recall_unack(
 		model_transition_buf_add(&buf, transition);
 	}
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }

--- a/subsys/bluetooth/mesh/scene_srv.c
+++ b/subsys/bluetooth/mesh/scene_srv.c
@@ -147,7 +147,7 @@ static int scene_status_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx
 
 	scene_status_encode(srv, &buf, state);
 
-	return model_send(model, ctx, &buf);
+	return bt_mesh_msg_send(model, ctx, &buf);
 }
 
 static void curr_scene_state_get(struct bt_mesh_scene_srv *srv, struct bt_mesh_scene_state *state)
@@ -250,7 +250,7 @@ static int scene_register_status_send(struct bt_mesh_model *model,
 		net_buf_simple_add_le16(&buf, srv->all[i]);
 	}
 
-	return model_send(model, ctx, &buf);
+	return bt_mesh_msg_send(model, ctx, &buf);
 }
 
 static int handle_register_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,

--- a/subsys/bluetooth/mesh/scheduler_cli.c
+++ b/subsys/bluetooth/mesh/scheduler_cli.c
@@ -120,8 +120,14 @@ int bt_mesh_scheduler_cli_get(struct bt_mesh_scheduler_cli *cli,
 			BT_MESH_SCHEDULER_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&buf, BT_MESH_SCHEDULER_OP_GET);
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			BT_MESH_SCHEDULER_OP_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SCHEDULER_OP_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_scheduler_cli_action_get(struct bt_mesh_scheduler_cli *cli,
@@ -140,8 +146,14 @@ int bt_mesh_scheduler_cli_action_get(struct bt_mesh_scheduler_cli *cli,
 	net_buf_simple_add_u8(&buf, idx);
 	cli->ack_idx = rsp ? idx : BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT;
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			BT_MESH_SCHEDULER_OP_ACTION_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SCHEDULER_OP_ACTION_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_scheduler_cli_action_set(struct bt_mesh_scheduler_cli *cli,
@@ -161,8 +173,14 @@ int bt_mesh_scheduler_cli_action_set(struct bt_mesh_scheduler_cli *cli,
 	scheduler_action_pack(&buf, idx, entry);
 	cli->ack_idx = rsp ? idx : BT_MESH_SCHEDULER_ACTION_ENTRY_COUNT;
 
-	return model_ackd_send(cli->model, ctx, &buf, rsp ? &cli->ack_ctx : NULL,
-			BT_MESH_SCHEDULER_OP_ACTION_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SCHEDULER_OP_ACTION_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &buf, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_scheduler_cli_action_set_unack(struct bt_mesh_scheduler_cli *cli,
@@ -180,5 +198,5 @@ int bt_mesh_scheduler_cli_action_set_unack(struct bt_mesh_scheduler_cli *cli,
 
 	scheduler_action_pack(&buf, idx, entry);
 
-	return model_send(cli->model, ctx, &buf);
+	return bt_mesh_msg_send(cli->model, ctx, &buf);
 }

--- a/subsys/bluetooth/mesh/scheduler_srv.c
+++ b/subsys/bluetooth/mesh/scheduler_srv.c
@@ -598,7 +598,7 @@ static int send_scheduler_status(struct bt_mesh_model *model,
 			BT_MESH_SCHEDULER_MSG_LEN_STATUS);
 	encode_status(srv, &buf);
 
-	return model_send(model, ctx, &buf);
+	return bt_mesh_msg_send(model, ctx, &buf);
 }
 
 static int send_scheduler_action_status(struct bt_mesh_model *model,
@@ -615,7 +615,7 @@ static int send_scheduler_action_status(struct bt_mesh_model *model,
 
 	encode_action_status(srv, &buf, idx, is_reduced);
 
-	return model_send(model, ctx, &buf);
+	return bt_mesh_msg_send(model, ctx, &buf);
 }
 
 static int action_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,

--- a/subsys/bluetooth/mesh/sensor_cli.c
+++ b/subsys/bluetooth/mesh/sensor_cli.c
@@ -577,8 +577,14 @@ int bt_mesh_sensor_cli_desc_all_get(struct bt_mesh_sensor_cli *cli,
 		.count = count ? *count : 0,
 	};
 
-	err = model_ackd_send(cli->model, ctx, &msg, sensors ? &cli->ack_ctx : NULL,
-			      BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS, &list_rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS,
+		.user_data = &list_rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, sensors ? &rsp_ctx : NULL);
 	if (count && !err) {
 		*count = list_rsp.count;
 	}
@@ -607,8 +613,14 @@ int bt_mesh_sensor_cli_desc_get(struct bt_mesh_sensor_cli *cli,
 		.count = 1,
 	};
 
-	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			      BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS, &list_rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS,
+		.user_data = &list_rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 	if (!rsp || err) {
 		return err;
 	}
@@ -643,8 +655,14 @@ int bt_mesh_sensor_cli_cadence_get(struct bt_mesh_sensor_cli *cli,
 		.cadence = rsp,
 	};
 
-	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_SENSOR_OP_CADENCE_STATUS, &rsp_data);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_CADENCE_STATUS,
+		.user_data = &rsp_data,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 	if (!rsp || err) {
 		return err;
 	}
@@ -688,8 +706,14 @@ int bt_mesh_sensor_cli_cadence_set(
 		return err;
 	}
 
-	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			      BT_MESH_SENSOR_OP_CADENCE_STATUS, &rsp_data);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_CADENCE_STATUS,
+		.user_data = &rsp_data,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 	if (!rsp || err) {
 		return err;
 	}
@@ -729,7 +753,7 @@ int bt_mesh_sensor_cli_cadence_set_unack(
 		return err;
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
@@ -751,8 +775,14 @@ int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
 		.count = count ? *count : 0,
 	};
 
-	err = model_ackd_send(cli->model, ctx, &msg, ids ? &cli->ack_ctx : NULL,
-			      BT_MESH_SENSOR_OP_SETTINGS_STATUS, &rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_SETTINGS_STATUS,
+		.user_data = &rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, ids ? &rsp_ctx : NULL);
 	if (!count || err) {
 		return err;
 	}
@@ -783,8 +813,14 @@ int bt_mesh_sensor_cli_setting_get(struct bt_mesh_sensor_cli *cli,
 		.setting = rsp,
 	};
 
-	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			      BT_MESH_SENSOR_OP_SETTING_STATUS, &rsp_data);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_SETTINGS_STATUS,
+		.user_data = &rsp_data,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 	if (!rsp || err) {
 		return err;
 	}
@@ -822,8 +858,14 @@ int bt_mesh_sensor_cli_setting_set(struct bt_mesh_sensor_cli *cli,
 		.setting = rsp,
 	};
 
-	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_SENSOR_OP_SETTING_STATUS, &rsp_data);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_SETTINGS_STATUS,
+		.user_data = &rsp_data,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 	if (!rsp || err) {
 		return err;
 	}
@@ -858,7 +900,7 @@ int bt_mesh_sensor_cli_setting_set_unack(
 		return err;
 	}
 
-	return model_send(cli->model, ctx, &msg);
+	return bt_mesh_msg_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_sensor_cli_all_get(struct bt_mesh_sensor_cli *cli,
@@ -879,8 +921,14 @@ int bt_mesh_sensor_cli_all_get(struct bt_mesh_sensor_cli *cli,
 		memset(sensors, 0, sizeof(*sensors) * (*count));
 	}
 
-	err = model_ackd_send(cli->model, ctx, &msg, sensors ? &cli->ack_ctx : NULL,
-			      BT_MESH_SENSOR_OP_STATUS, &rsp_data);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_STATUS,
+		.user_data = &rsp_data,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, sensors ? &rsp_ctx : NULL);
 	if (!count || err) {
 		return err;
 	}
@@ -912,8 +960,14 @@ int bt_mesh_sensor_cli_get(struct bt_mesh_sensor_cli *cli,
 	struct sensor_data_list_rsp rsp_data = { .count = 1,
 						 .sensors = &sensor_data };
 
-	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			      BT_MESH_SENSOR_OP_STATUS, &rsp_data);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_STATUS,
+		.user_data = &rsp_data,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 	if (!rsp || err) {
 		return err;
 	}
@@ -958,8 +1012,14 @@ int bt_mesh_sensor_cli_series_entry_get(
 		.col = column,
 	};
 
-	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			      BT_MESH_SENSOR_OP_COLUMN_STATUS, &rsp_data);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_COLUMN_STATUS,
+		.user_data = &rsp_data,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 	if (!rsp || err) {
 		return err;
 	}
@@ -1012,8 +1072,14 @@ int bt_mesh_sensor_cli_series_entries_get(
 		.count = count ? *count : 0,
 	};
 
-	err = model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_SENSOR_OP_SERIES_STATUS, &rsp_data);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_SENSOR_OP_SERIES_STATUS,
+		.user_data = &rsp_data,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	err = bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 	if (!count || err) {
 		return err;
 	}

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -584,7 +584,7 @@ static int cadence_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		return err;
 	}
 
-	model_send(model, NULL, &rsp);
+	bt_mesh_msg_send(model, NULL, &rsp);
 
 respond:
 	if (ack) {
@@ -770,7 +770,7 @@ static int setting_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 
 	BT_DBG("0x%04x: 0x%04x", id, setting_id);
 
-	model_send(model, NULL, &rsp);
+	bt_mesh_msg_send(model, NULL, &rsp);
 
 respond:
 	if (ack) {
@@ -1130,7 +1130,7 @@ int bt_mesh_sensor_srv_pub(struct bt_mesh_sensor_srv *srv,
 
 	sensor_cadence_update(sensor, value);
 
-	err = model_send(srv->model, ctx, &msg);
+	err = bt_mesh_msg_send(srv->model, ctx, &msg);
 	if (err) {
 		return err;
 	}

--- a/subsys/bluetooth/mesh/time_cli.c
+++ b/subsys/bluetooth/mesh/time_cli.c
@@ -159,8 +159,14 @@ static int get_msg(struct bt_mesh_time_cli *cli, struct bt_mesh_msg_ctx *ctx,
 	BT_MESH_MODEL_BUF_DEFINE(msg, opcode, BT_MESH_TIME_MSG_LEN_GET);
 	bt_mesh_model_msg_init(&msg, opcode);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL, ret_opcode, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = ret_opcode,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_time_cli_time_get(struct bt_mesh_time_cli *cli,
@@ -181,9 +187,14 @@ int bt_mesh_time_cli_time_set(struct bt_mesh_time_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_TIME_OP_TIME_SET);
 	bt_mesh_time_encode_time_params(&msg, set);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_TIME_OP_TIME_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_TIME_OP_TIME_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_time_cli_zone_get(struct bt_mesh_time_cli *cli,
@@ -205,9 +216,15 @@ int bt_mesh_time_cli_zone_set(struct bt_mesh_time_cli *cli,
 	net_buf_simple_add_u8(&msg,
 			      (uint8_t)(set->new_offset + ZONE_CHANGE_ZERO_POINT));
 	bt_mesh_time_buf_put_tai_sec(&msg, set->timestamp);
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_TIME_OP_TIME_ZONE_STATUS, rsp);
+
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_TIME_OP_TIME_ZONE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_time_cli_tai_utc_delta_get(
@@ -230,9 +247,15 @@ int bt_mesh_time_cli_tai_utc_delta_set(
 	net_buf_simple_add_le16(
 		&msg, (uint16_t)(set->delta_new + UTC_CHANGE_ZERO_POINT));
 	bt_mesh_time_buf_put_tai_sec(&msg, set->timestamp);
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_TIME_OP_TAI_UTC_DELTA_STATUS, rsp);
+
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_TIME_OP_TAI_UTC_DELTA_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_time_cli_role_get(struct bt_mesh_time_cli *cli,
@@ -251,7 +274,12 @@ int bt_mesh_time_cli_role_set(struct bt_mesh_time_cli *cli,
 	bt_mesh_model_msg_init(&msg, BT_MESH_TIME_OP_TIME_ROLE_SET);
 	net_buf_simple_add_u8(&msg, *set);
 
-	return model_ackd_send(cli->model, ctx, &msg,
-			       rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_TIME_OP_TIME_ROLE_STATUS, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_TIME_OP_TIME_ROLE_STATUS,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }

--- a/subsys/bluetooth/mesh/time_srv.c
+++ b/subsys/bluetooth/mesh/time_srv.c
@@ -183,7 +183,7 @@ static int send_time_status(struct bt_mesh_model *model,
 		bt_mesh_time_encode_time_params(&msg, &status);
 	}
 
-	return model_send(model, ctx, &msg);
+	return bt_mesh_msg_send(model, ctx, &msg);
 }
 
 static int handle_time_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,

--- a/subsys/bluetooth/mesh/vnd/dm_cli.c
+++ b/subsys/bluetooth/mesh/vnd/dm_cli.c
@@ -175,8 +175,14 @@ int bt_mesh_dm_cli_config(struct bt_mesh_dm_cli *cli,
 		net_buf_simple_add_u8(&msg, set->delay);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_DM_CONFIG_STATUS_OP, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_DM_CONFIG_STATUS_OP,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_dm_cli_measurement_start(struct bt_mesh_dm_cli *cli,
@@ -204,8 +210,14 @@ int bt_mesh_dm_cli_measurement_start(struct bt_mesh_dm_cli *cli,
 		net_buf_simple_add_u8(&msg, start->cfg->delay);
 	}
 
-	return model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_DM_RESULT_STATUS_OP, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_DM_RESULT_STATUS_OP,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }
 
 int bt_mesh_dm_cli_results_get(struct bt_mesh_dm_cli *cli,
@@ -223,6 +235,12 @@ int bt_mesh_dm_cli_results_get(struct bt_mesh_dm_cli *cli,
 	net_buf_simple_add_u8(&msg, BT_MESH_DM_RESULT_GET_OP);
 	net_buf_simple_add_u8(&msg, entry_cnt);
 
-	return model_ackd_send(cli->model, ctx, &msg, rsp ? &cli->ack_ctx : NULL,
-			       BT_MESH_DM_RESULT_STATUS_OP, rsp);
+	struct bt_mesh_msg_rsp_ctx rsp_ctx = {
+		.ack = &cli->ack_ctx,
+		.op = BT_MESH_DM_RESULT_STATUS_OP,
+		.user_data = rsp,
+		.timeout = model_ackd_timeout_get(cli->model, ctx),
+	};
+
+	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, rsp ? &rsp_ctx : NULL);
 }

--- a/subsys/bluetooth/mesh/vnd/silvair_enocean_srv.c
+++ b/subsys/bluetooth/mesh/vnd/silvair_enocean_srv.c
@@ -198,7 +198,7 @@ static void status_pub(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		net_buf_simple_add_mem(&buf, addr, 6);
 	}
 
-	(void)model_send(model, ctx, &buf);
+	(void)bt_mesh_msg_send(model, ctx, &buf);
 }
 
 static void timeout(struct k_work *work)

--- a/tests/subsys/bluetooth/mesh/light_ctrl/src/main.c
+++ b/tests/subsys/bluetooth/mesh/light_ctrl/src/main.c
@@ -151,7 +151,7 @@ int tid_check_and_update(struct bt_mesh_tid_ctx *prev_transaction, uint8_t tid,
 	return 0;
 }
 
-int model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	       struct net_buf_simple *buf)
 {
 	ztest_check_expected_value(model);
@@ -266,10 +266,10 @@ static void expect_light_onoff_pub(uint8_t *expected_msg, size_t len, k_timeout_
 {
 	ztest_expect_value(bt_mesh_model_msg_init, opcode,
 			   BT_MESH_LIGHT_CTRL_OP_LIGHT_ONOFF_STATUS);
-	ztest_expect_value(model_send, model, &mock_ligth_ctrl_model);
-	ztest_expect_value(model_send, ctx, NULL);
-	ztest_expect_value(model_send, buf->len, len);
-	ztest_expect_data(model_send, buf->data, expected_msg);
+	ztest_expect_value(bt_mesh_msg_send, model, &mock_ligth_ctrl_model);
+	ztest_expect_value(bt_mesh_msg_send, ctx, NULL);
+	ztest_expect_value(bt_mesh_msg_send, buf->len, len);
+	ztest_expect_data(bt_mesh_msg_send, buf->data, expected_msg);
 	ztest_expect_value(bt_mesh_onoff_srv_pub, srv, &light_ctrl_srv.onoff);
 	ztest_expect_value(bt_mesh_onoff_srv_pub, status->present_on_off,
 			   expected_onoff_status.present_on_off);

--- a/tests/subsys/bluetooth/mesh/scheduler_model/src/main.c
+++ b/tests/subsys/bluetooth/mesh/scheduler_model/src/main.c
@@ -147,7 +147,7 @@ void bt_mesh_time_encode_time_params(struct net_buf_simple *buf,
 {
 }
 
-int model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	       struct net_buf_simple *buf)
 {
 	return 0;

--- a/tests/subsys/bluetooth/mesh/silvair_enocean_model/CMakeLists.txt
+++ b/tests/subsys/bluetooth/mesh/silvair_enocean_model/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(app
 target_include_directories(app
     PRIVATE
     ${ZEPHYR_BASE}/../nrf/subsys/bluetooth/mesh
+    ${ZEPHYR_BASE}/subsys/bluetooth
     )
 
 target_compile_options(app

--- a/tests/subsys/bluetooth/mesh/silvair_enocean_model/src/main.c
+++ b/tests/subsys/bluetooth/mesh/silvair_enocean_model/src/main.c
@@ -174,7 +174,7 @@ int bt_mesh_model_data_store(struct bt_mesh_model *model, bool vnd,
 	return 0;
 }
 
-int model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	       struct net_buf_simple *buf)
 {
 	ztest_check_expected_value(model);
@@ -264,10 +264,10 @@ static void expect_status(struct bt_mesh_msg_ctx *ctx,
 
 	ztest_expect_value(bt_mesh_model_msg_init, opcode,
 			   BT_MESH_SILVAIR_ENOCEAN_PROXY_OP);
-	ztest_expect_value(model_send, model, &mock_model);
-	ztest_expect_value(model_send, ctx, ctx);
-	ztest_expect_value(model_send, buf->len, len);
-	ztest_expect_data(model_send, buf->data, expected_msg);
+	ztest_expect_value(bt_mesh_msg_send, model, &mock_model);
+	ztest_expect_value(bt_mesh_msg_send, ctx, ctx);
+	ztest_expect_value(bt_mesh_msg_send, buf->len, len);
+	ztest_expect_data(bt_mesh_msg_send, buf->data, expected_msg);
 }
 
 static void mock_button_action(uint8_t changed,


### PR DESCRIPTION
Remove `model_ackd_send` and `model_send` from model_utils.c as they are implemented in upstream in msg.c as `bt_mesh_msg_ackd_send` and `bt_mesh_msg_send` accordingly.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>