### PR TITLE
quarantine_windows: remove nanopb register

### DIFF
--- a/scripts/quarantine_windows.yaml
+++ b/scripts/quarantine_windows.yaml
@@ -34,13 +34,6 @@
   comment: "ruby package not available in Windows toolchain"
 
 - scenarios:
-    - samples.bluetooth.alexa_gadget
-    - sample.nrf7002.provisioning
-  platforms:
-    - all
-  comment: "nanopb package not available in Windows toolchain"
-
-- scenarios:
     - applications.nrf5340_audio.gateway_dfu_external
     - applications.nrf5340_audio.gateway_dfu_internal
     - applications.nrf5340_audio.headset_dfu_external


### PR DESCRIPTION
`nanopb` is now included into windows toolchain, so there is no longer needs to keep in quarantine samples depend on `nanopb`.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>