### PR TITLE
quarantine_windows: add native_posix sample

### DIFF
--- a/scripts/quarantine_windows.yaml
+++ b/scripts/quarantine_windows.yaml
@@ -12,6 +12,7 @@
     - applications.asset_tracker_v2.cloud.cloud_codec.json_common.azure
     - sample.app_event_manager
     - sample.app_event_manager_shell
+    - sample.app_event_manager_shell.native_posix
     - sample.caf_sensor_manager.correctness_test
     - sample.edge_impulse.wrapper
   platforms:


### PR DESCRIPTION
`sample.app_event_manager_shell.native_posix` should be not built on Windows OS.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>