### PR TITLE
net: lib: nrf_cloud: handle MQTT disconn during FOTA

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -229,6 +229,12 @@ Libraries for networking
   * Fixed a bug were the :c:func:`download_client_callback` function was continuing to read the offset value even if :c:func:`dfu_target_offset_get` returned an error.
   * Fixed a bug where the cleanup of the downloading state was not happening when an error event was raised.
 
+* :ref:`lib_nrf_cloud` library:
+
+  * Updated:
+
+    * The MQTT disconnect event is now handled by the FOTA module, allowing for updates to be completed while disconnected and reported properly when reconnected.
+
 Libraries for NFC
 -----------------
 

--- a/include/net/nrf_cloud.h
+++ b/include/net/nrf_cloud.h
@@ -323,7 +323,9 @@ enum nrf_cloud_fota_validate_status {
 	/** Validation result could not be determined */
 	NRF_CLOUD_FOTA_VALIDATE_UNKNOWN,
 	/** The validation process is finished */
-	NRF_CLOUD_FOTA_VALIDATE_DONE
+	NRF_CLOUD_FOTA_VALIDATE_DONE,
+	/** An error occurred before validation */
+	NRF_CLOUD_FOTA_VALIDATE_ERROR,
 };
 
 /** @brief Status flags for tracking the update process of the b1 bootloader (MCUBOOT) */


### PR DESCRIPTION
Handle the MQTT disconnect event in nrf_cloud_fota so that FOTA updates can continue and also be properly reported when connection is restored.
IRIS-4866

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>