### PR TITLE
applications: machine_learning: Pass chosen pm-ext-flash to mcuboot

### DIFF
--- a/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};


### PR DESCRIPTION
Change explicitly passes the chosen pm-ext-flash to the mcuboot child image. This is needed to allow MCUboot access external FLASH during the DFU.

Jira: NCSDK-18532