### PR TITLE
samples: nrf9160: modem_shell: Misc small improvements

### DIFF
--- a/include/modem/location.h
+++ b/include/modem/location.h
@@ -338,7 +338,7 @@ struct location_config {
 	 * @brief Position update interval in seconds.
 	 *
 	 * @details Set to 0 for a single position update. For periodic position updates
-	 * the valid range is 10...65535 seconds.
+	 * the valid range is 1...65535 seconds.
 	 */
 	uint16_t interval;
 	/**

--- a/lib/location/location_core.c
+++ b/lib/location/location_core.c
@@ -267,11 +267,6 @@ int location_core_validate_params(const struct location_config *config)
 		return -EINVAL;
 	}
 
-	if ((config->interval > 0) && (config->interval < 10)) {
-		LOG_ERR("Interval for periodic location updates must be longer than 10 seconds");
-		return -EINVAL;
-	}
-
 	for (int i = 0; i < config->methods_count; i++) {
 		/* Check if the method is valid */
 		method_api = location_method_api_get(config->methods[i].method);

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -921,7 +921,7 @@ To build the MoSh sample with nRF9160 DK and nRF7002 EK Wi-Fi support, use the `
 
 For example:
 
-.. code-block: console
+.. code-block:: console
 
    west build -p -b nrf9160dk_nrf9160ns -- -DSHIELD=nrf7002_ek -DDTC_OVERLAY_FILE=nrf9160dk_with_nrf7002ek.overlay -DOVERLAY_CONFIG=overlay-nrf7002ek-wifi-scan-only.conf
 
@@ -934,7 +934,7 @@ To build the MoSh sample with ESP8266 Wi-Fi chip support, use the ``-DDTC_OVERLA
 
 For example:
 
-.. code-block: console
+.. code-block:: console
 
    west build -p -b nrf9160dk_nrf9160_ns -d build -- -DDTC_OVERLAY_FILE=esp_8266_nrf9160ns.overlay -DOVERLAY_CONFIG=overlay-esp-wifi.conf
 

--- a/samples/nrf9160/modem_shell/overlay-debug.conf
+++ b/samples/nrf9160/modem_shell/overlay-debug.conf
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Forces a maximal log level for all modules.
+# Modules saturates their specified level if it is greater than this option,
+# otherwise they use the level specified by this option instead of their default
+# or whatever was manually set. Levels are:
+#
+# 0 OFF, logging is turned off
+# 1 ERROR, maximal level set to LOG_LEVEL_ERR
+# 2 WARNING, maximal level set to LOG_LEVEL_WRN
+# 3 INFO, maximal level set to LOG_LEVEL_INFO
+# 4 DEBUG, maximal level set to LOG_LEVEL_DBG
+CONFIG_LOG_MAX_LEVEL=4
+
+# Increase log buffer size to prevent logs being dropped.
+CONFIG_LOG_BUFFER_SIZE=2048
+
+# LTE link control library
+CONFIG_LTE_LINK_CONTROL_LOG_LEVEL_DBG=y
+
+# Location library
+CONFIG_LOCATION_LOG_LEVEL_DBG=y
+
+# SMS library
+CONFIG_SMS_LOG_LEVEL_DBG=y
+
+# nRF Cloud
+CONFIG_NRF_CLOUD_LOG_LEVEL_DBG=y
+CONFIG_NRF_CLOUD_GPS_LOG_LEVEL_DBG=y
+CONFIG_NRF_CLOUD_REST_LOG_LEVEL_DBG=y
+
+# REST client library
+CONFIG_REST_CLIENT_LOG_LEVEL_DBG=y
+
+# Date time
+CONFIG_DATE_TIME_LOG_LEVEL_DBG=y
+
+# Settings
+CONFIG_SETTINGS_LOG_LEVEL_DBG=y

--- a/samples/nrf9160/modem_shell/sample.yaml
+++ b/samples/nrf9160/modem_shell/sample.yaml
@@ -7,6 +7,13 @@ tests:
       - nrf9160dk_nrf9160_ns
     platform_allow: nrf9160dk_nrf9160_ns
     tags: ci_build
+  sample.nrf9160.modem_shell_debug:
+    build_only: true
+    extra_args: OVERLAY_CONFIG=overlay-debug.conf
+    integration_platforms:
+      - nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns
+    tags: ci_build
   sample.nrf9160.modem_shell.cloud_mqtt_only:
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-cloud_mqtt.conf

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -457,20 +457,6 @@ void test_error_too_many_methods(void)
 	TEST_ASSERT_EQUAL(-EINVAL, err);
 }
 
-/* Test location request with invalid interval. */
-void test_error_invalid_interval(void)
-{
-	int err;
-	struct location_config config = { 0 };
-	enum location_method methods[] = {LOCATION_METHOD_GNSS, LOCATION_METHOD_CELLULAR};
-
-	location_config_defaults_set(&config, 2, methods);
-	config.interval = 1;
-
-	err = location_request(&config);
-	TEST_ASSERT_EQUAL(-EINVAL, err);
-}
-
 /* Test cancelling location request when there is no pending location request. */
 void test_error_cancel_no_operation(void)
 {
@@ -726,19 +712,16 @@ void test_location_request_timeout_cellular_gnss_mode_all(void)
 }
 
 /********* TESTS PERIODIC POSITIONING REQUESTS ***********************/
-/* Use this to disable periodic tests temporarily to save time while developing other tests */
-#define LOCATION_TEST_SKIP_PERIODIC 0
 
 /* Test periodic location request and cancel it once some iterations are done. */
 void test_location_gnss_periodic(void)
 {
-#if !LOCATION_TEST_SKIP_PERIODIC
 	int err;
 	struct location_config config = { 0 };
 	enum location_method methods[] = {LOCATION_METHOD_GNSS};
 
 	location_config_defaults_set(&config, 1, methods);
-	config.interval = 10;
+	config.interval = 1;
 	config.methods[0].gnss.timeout = 120 * MSEC_PER_SEC;
 	config.methods[0].gnss.accuracy = LOCATION_ACCURACY_NORMAL;
 
@@ -828,7 +811,7 @@ void test_location_gnss_periodic(void)
 	__cmock_nrf_modem_at_cmd_ReturnArrayThruPtr_buf(
 		(char *)xmonitor_resp, sizeof(xmonitor_resp));
 
-	k_sleep(K_MSEC(11000));
+	k_sleep(K_MSEC(1500));
 	at_monitor_dispatch("+CSCON: 0");
 
 	__cmock_nrf_modem_gnss_read_ExpectAndReturn(
@@ -852,19 +835,17 @@ void test_location_gnss_periodic(void)
 	err = location_request_cancel();
 	TEST_ASSERT_EQUAL(0, err);
 	k_sleep(K_MSEC(1));
-#endif
 }
 
 /* Test periodic location request and cancel it once some iterations are done. */
 void test_location_cellular_periodic(void)
 {
-#if !LOCATION_TEST_SKIP_PERIODIC
 	int err;
 	struct location_config config = { 0 };
 	enum location_method methods[] = {LOCATION_METHOD_CELLULAR};
 
 	location_config_defaults_set(&config, 1, methods);
-	config.interval = 10;
+	config.interval = 1;
 
 	test_location_event_data.id = LOCATION_EVT_LOCATION;
 	test_location_event_data.location.latitude = 61.50375;
@@ -919,7 +900,7 @@ void test_location_cellular_periodic(void)
 	 * Note that we could first send results and then location library would send NCELLMEAS and
 	 * the test wouldn't see a failure so these things would need to be checked from the logs.
 	 */
-	k_sleep(K_MSEC(11000));
+	k_sleep(K_MSEC(1500));
 	/* Trigger NCELLMEAS response which further triggers the rest of the location calculation */
 	at_monitor_dispatch(ncellmeas_resp);
 
@@ -936,7 +917,6 @@ void test_location_cellular_periodic(void)
 	err = location_request_cancel();
 	TEST_ASSERT_EQUAL(0, err);
 	k_sleep(K_MSEC(1));
-#endif
 }
 
 /* This is needed because AT Monitor library is initialized in SYS_INIT. */


### PR DESCRIPTION
Small improvements:

- Location library: Remove 10s limit from interval. Location request interval have had 10s minimum for periodic location request. (NCSDK-18355)
- MoSh: Some build commands didn't show up in the generated document due to a bug in RST syntax.
- MoSh: Add debug overlay. This is a good concept in Asset Tracker for enabling a set of commonly used logs for debugging.