### PR TITLE
manifest: update homekit revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -150,7 +150,7 @@ manifest:
       revision: c6af068b7f05207b28d68880740e4b9ec1e4b50a
     - name: homekit
       repo-path: sdk-homekit
-      revision: v2.2.0-rc2
+      revision: eb616619cef4c9bf5a1938d25fc2030c5aceba0d
       groups:
         - homekit
     - name: find-my


### PR DESCRIPTION
Updated memory requirement tables for NCS 2.2.0.
- [x] nrfconnect/sdk-homekit#449

Signed-off-by: Mariusz Poslinski <mariusz.poslinski@nordicsemi.no>