### PR TITLE
[v2.1-branch] cmake: variant build now re-uses original configuration

### DIFF
--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -28,3 +28,5 @@ if(DEFINED NRF_SUPPORTED_BUILD_TYPES)
                 message(FATAL_ERROR "${CMAKE_BUILD_TYPE} variant is not supported")
         endif()
 endif()
+
+list(PREPEND CMAKE_MODULE_PATH ${NRF_DIR}/cmake/modules)

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+include_guard(GLOBAL)
+
+if(CONFIG_NCS_IS_VARIANT_IMAGE)
+  # A variant build should reuse same .config and thus autoconf.h, therefore
+  # copy files from original and bypass Kconfig invocation.
+  set(AUTOCONF_H ${PROJECT_BINARY_DIR}/include/generated/autoconf.h)
+  set(DOTCONFIG  ${PROJECT_BINARY_DIR}/.config)
+
+  set(preload_autoconf_h ${PRELOAD_BINARY_DIR}/zephyr/include/generated/autoconf.h)
+  set(preload_dotconfig  ${PRELOAD_BINARY_DIR}/zephyr/.config)
+
+  file(COPY ${preload_dotconfig}  DESTINATION ${PROJECT_BINARY_DIR})
+  file(COPY ${preload_autoconf_h} DESTINATION ${PROJECT_BINARY_DIR}/include/generated)
+  file(APPEND ${AUTOCONF_H} "#define CONFIG_NCS_IS_VARIANT_IMAGE 1")
+
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${AUTOCONF_H})
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${DOTCONFIG})
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${preload_autoconf_h})
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${preload_dotconfig})
+
+  import_kconfig("CONFIG" ${DOTCONFIG})
+else()
+  include(${ZEPHYR_BASE}/cmake/modules/kconfig.cmake)
+endif()

--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -93,6 +93,12 @@ else()
     PROPERTY source_dir
     ${APPLICATION_SOURCE_DIR}
     )
+
+  set_property(
+    TARGET app_subimage
+    PROPERTY binary_dir
+    ${CMAKE_BINARY_DIR}
+    )
 endif(IMAGE_NAME)
 
 function(add_child_image)
@@ -238,7 +244,14 @@ function(add_child_image_from_source)
       PROPERTY source_dir
       )
 
+    get_property(
+      binary_dir
+      TARGET ${ACI_PRELOAD_IMAGE}_subimage
+      PROPERTY binary_dir
+      )
+
     list(APPEND extra_cmake_args "-DCONFIG_NCS_IS_VARIANT_IMAGE=y")
+    list(APPEND extra_cmake_args "-DPRELOAD_BINARY_DIR=${binary_dir}")
   else()
     set(source_dir ${ACI_SOURCE_DIR})
 
@@ -448,18 +461,26 @@ function(add_child_image_from_source)
     ${source_dir}
     )
 
-  foreach(kconfig_target
-      menuconfig
-      guiconfig
-      ${EXTRA_KCONFIG_TARGETS}
-      )
+  set_property(
+    TARGET ${ACI_NAME}_subimage
+    PROPERTY binary_dir
+    ${CMAKE_BINARY_DIR}/${ACI_NAME}
+    )
 
-    add_custom_target(${ACI_NAME}_${kconfig_target}
-      ${CMAKE_MAKE_PROGRAM} ${kconfig_target}
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${ACI_NAME}
-      USES_TERMINAL
-      )
-  endforeach()
+  if (NOT ACI_PRELOAD_IMAGE)
+    foreach(kconfig_target
+        menuconfig
+        guiconfig
+        ${EXTRA_KCONFIG_TARGETS}
+        )
+
+      add_custom_target(${ACI_NAME}_${kconfig_target}
+        ${CMAKE_MAKE_PROGRAM} ${kconfig_target}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${ACI_NAME}
+        USES_TERMINAL
+        )
+    endforeach()
+  endif()
 
   if (NOT "${ACI_NAME}" STREQUAL "${${ACI_DOMAIN}_PM_DOMAIN_DYNAMIC_PARTITION}")
     set_property(

--- a/samples/Kconfig
+++ b/samples/Kconfig
@@ -105,11 +105,6 @@ menu "Image build variants"
 # These are set by CMake, and they need a prompt.
 # Keep them in a separate menu to avoid cluttering the top-level menu
 
-config NCS_IS_VARIANT_IMAGE
-	bool "Image is a variant build of another image [READ ONLY]"
-	help
-	   Image is a variant build of another image.
-
 config NCS_MCUBOOT_IN_BUILD
 	bool "MCUBoot is included in the build [READ ONLY]"
 	help


### PR DESCRIPTION
Fixes: NCSDK-18108

Instead of passing on settings for variant builds then simply copy existing .config and autoconf.h header for re-use. This ensures that any changes done in the original image are automatically re-used in the variant build.

Because files are now copied then we must amend
CONFIG_NCS_IS_VARIANT_IMAGE to autoconf.h to ensure it's picked up by the adjusted linker script template.

Because CONFIG_NCS_IS_VARIANT_IMAGE is passed as CMake variable we can remove its definition in Kconfig and thus avoid misuse of the setting as well as user confusion.

Disable menuconfig and friends for variant builds.

Backport of commit e4be060f8b00bc386dbf9cc133f194bf8a1ccdc2 to v2.1-branch