### PR TITLE
applications: nrf5340_audio: Move uart_scripts to nrf

### DIFF
--- a/scripts/tools-versions-darwin.txt
+++ b/scripts/tools-versions-darwin.txt
@@ -8,3 +8,4 @@ west=1.0.0
 nanopb=0.4.6
 zephyr-sdk=0.16.0
 doxygen=1.9.2
+minicom=2.8

--- a/scripts/tools-versions-linux.txt
+++ b/scripts/tools-versions-linux.txt
@@ -11,3 +11,5 @@ zephyr-sdk=0.16.0
 ccache=3.7.7
 dfu_util=0.9-1
 doxygen=1.9.6
+minicom=2.8
+terminator=2.1.2

--- a/scripts/tools-versions-win10.txt
+++ b/scripts/tools-versions-win10.txt
@@ -8,3 +8,4 @@ west=1.0.0
 nanopb=0.4.6
 zephyr-sdk=0.16.0
 doxygen=1.9.2
+putty=0.74


### PR DESCRIPTION
OCT-2021
Move the uart_terminal scripts to the nrf/scripts.