### PR TITLE
manifest: Update sdk-zephyr version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -50,7 +50,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 5cdbe42e49680de7b0c6d7102d61385d56e7e663
+      revision: pull/1008/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updates sdk-zephyr to include a fix for NCSDK-18426 which makes printk a select instead of an imply for minimal footprint logging.