### PR TITLE
samples: peripheral: lpuart: Decrease current draw on nRF5340 DK 2.0.0

### DIFF
--- a/samples/peripheral/lpuart/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/peripheral/lpuart/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -20,12 +20,18 @@
 };
 
 &uart0_default {
+	/* Disconnect CTS and RTS lines from pins.
+	 * This is a temporary workaround for increased current consumption
+	 * observed on nRF5340 DKs only (~200 uA more on v0.9.0 and ~400 uA
+	 * more on v2.0.0).
+	 */
+	group1 {
+		psels = <NRF_PSEL(UART_TX, 0, 20)>,
+			<NRF_PSEL_DISCONNECTED(UART_RTS)>;
+	};
 	group2 {
-		/* Remove assignment of P0.21 as CTS. This is a temporary
-		 * workaround for increased current consumption observed
-		 * on nRF5340 DKs only (~200 uA more on v0.9.0 and ~400 uA
-		 * more on v2.0.0). */
-		psels = <NRF_PSEL(UART_RX, 0, 22)>;
+		psels = <NRF_PSEL(UART_RX, 0, 22)>,
+			<NRF_PSEL_DISCONNECTED(UART_CTS)>;
 	};
 };
 


### PR DESCRIPTION
This is a follow-up to commit f3b63e17a15f1c77f0f3dc4966b7e1e6d72b1539.

Extend the temporary workaround from the above commit by disconnecting also the RTS line from the pin it is assigned to by default. This suppresses extra power consumption of ~200 uA observed on nRF5340 DK v2.0.0.

Ref. NCSDK-16856

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>