### PR TITLE
2.2.0 post release doc update

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -19,7 +19,7 @@ ZEPHYR_BASE = utils.get_projdir("zephyr")
 project = "nRF Connect SDK"
 copyright = "2019-2022, Nordic Semiconductor"
 author = "Nordic Semiconductor"
-version = release = "2.2.0"
+version = release = "2.2.99"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -32,6 +32,7 @@ A "99" at the end of the version number of this documentation indicates continuo
    libraries/index
    scripts
    release_notes
+   known_issues
    software_maturity
    documentation
    glossary

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _known_issues:
 
 Known issues
@@ -387,7 +385,7 @@ nRF5340
 
 .. rst-class:: v2-2-0 v2-1-2 v2-1-1 v2-1-0
 
-NCSDK-16856: Increased power consumption observed for the Low Power UART on nRF5340 DK
+NCSDK-16856: Increased power consumption observed for the Low Power UART sample on nRF5340 DK
   The power consumption of the :ref:`lpuart_sample` sample measured using the nRF5340 DK v2.0.0 is about 200 uA higher than expected.
 
   **Workaround:** Disconnect flow control lines for VCOM2 with the SW7 DIP switch on the board.

--- a/doc/nrf/release_notes.rst
+++ b/doc/nrf/release_notes.rst
@@ -10,8 +10,9 @@ This page is included only in the latest documentation, because it might contain
 
 .. note::
    A "99" at the end of the version number of this documentation indicates continuous updates on the main branch since the previous major.minor release.
-   When looking at this latest documentation, be aware of the following aspect:
+   When looking at this latest documentation, be aware of the following aspects:
 
+   * Changes between releases are tracked on the :ref:`ncs_release_notes_changelog` page, but the main branch might contain additional changes that are not listed on that page.
    * The release note pages that are available in the latest documentation might differ slightly from the release notes that were included in the respective |NCS| release at its release date.
      Therefore, to see the official version of the release notes for a specific |NCS| release, switch to the documentation for the corresponding |NCS| version using the selector in the upper right-hand corner.
 
@@ -19,6 +20,7 @@ This page is included only in the latest documentation, because it might contain
    :maxdepth: 1
    :caption: Subpages:
 
+   releases/release-notes-changelog
    releases/release-notes-2.2.0
    releases/release-notes-2.1.2
    releases/release-notes-2.1.1

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _ncs_release_notes_changelog:
 
 Changelog for |NCS| v2.2.99

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -21,7 +21,7 @@ NRFXLIB_BASE = utils.get_projdir("nrfxlib")
 project = "nrfxlib"
 copyright = "2019-2022, Nordic Semiconductor"
 author = "Nordic Semiconductor"
-version = release = "2.2.0"
+version = release = "2.2.99"
 
 sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))

--- a/doc/versions.json
+++ b/doc/versions.json
@@ -34,8 +34,8 @@
   ],
   "COMPONENTS_BY_VERSION": {
     "latest": {
-      "ncs": "2.2.0",
-      "nrfxlib": "2.2.0",
+      "ncs": "2.2.99",
+      "nrfxlib": "2.2.99",
       "zephyr": "3.2.99",
       "mcuboot": "1.9.99",
       "nrfx": "2.10",

--- a/samples/bluetooth/peripheral_cgms/README.rst
+++ b/samples/bluetooth/peripheral_cgms/README.rst
@@ -29,7 +29,7 @@ You may also use nRF Connect app to interact with the CGMS module.
 Building and running
 ********************
 
-.. |sample path| replace:: :file:`samples/bluetooth/peripheral_cgm`
+.. |sample path| replace:: :file:`samples/bluetooth/peripheral_cgms`
 
 .. include:: /includes/build_and_run_ns.txt
 


### PR DESCRIPTION
2.2.0 post release doc update.
Currently based on https://github.com/nrfconnect/sdk-nrf/pull/9489
Needs to be rebased after #9489 is merged.

- [x] Update conf.py in nrf and nrfxlib
- [x] update versions.json
- [x] Add known issues back to index
- [x] Remove orphan tag in KI
- [x] Add back changelog to index
- [x] Edits to changelog
- [x] Remove orphan tag in changelog