### PR TITLE
lib: location: add warning trace for short GNSS time windows

### DIFF
--- a/lib/location/location_core.c
+++ b/lib/location/location_core.c
@@ -88,6 +88,7 @@ static const struct location_method_api method_gnss_api = {
 	.init             = method_gnss_init,
 	.location_get     = method_gnss_location_get,
 	.cancel           = method_gnss_cancel,
+	.timeout          = method_gnss_timeout,
 #if defined(CONFIG_LOCATION_DATA_DETAILS)
 	.details_get      = method_gnss_details_get,
 #endif
@@ -101,6 +102,7 @@ static const struct location_method_api method_cellular_api = {
 	.init             = method_cellular_init,
 	.location_get     = method_cellular_location_get,
 	.cancel           = method_cellular_cancel,
+	.timeout          = method_cellular_cancel,
 #if defined(CONFIG_LOCATION_DATA_DETAILS)
 	.details_get      = NULL,
 #endif
@@ -114,6 +116,7 @@ static const struct location_method_api method_wifi_api = {
 	.init             = method_wifi_init,
 	.location_get     = method_wifi_location_get,
 	.cancel           = method_wifi_cancel,
+	.timeout          = method_wifi_cancel,
 #if defined(CONFIG_LOCATION_DATA_DETAILS)
 	.details_get      = NULL,
 #endif
@@ -649,7 +652,7 @@ static void location_core_method_timeout_work_fn(struct k_work *work)
 
 	LOG_INF("Method specific timeout expired");
 
-	location_method_api_get(current_method)->cancel();
+	location_method_api_get(current_method)->timeout();
 	location_core_event_cb_timeout();
 }
 
@@ -662,7 +665,7 @@ static void location_core_timeout_work_fn(struct k_work *work)
 
 	LOG_INF("Timeout for entire location request expired");
 
-	location_method_api_get(current_method)->cancel();
+	location_method_api_get(current_method)->timeout();
 	/* config->timeout needs to expire without fallbacks */
 
 	current_event_data.id = LOCATION_EVT_TIMEOUT;

--- a/lib/location/location_core.h
+++ b/lib/location/location_core.h
@@ -14,6 +14,7 @@ struct location_method_api {
 	int  (*validate_params)(const struct location_method_config *config);
 	int  (*location_get)(const struct location_method_config *config);
 	int  (*cancel)();
+	int  (*timeout)();
 #if defined(CONFIG_LOCATION_DATA_DETAILS)
 	void  (*details_get)(struct location_data_details *details);
 #endif

--- a/lib/location/method_cellular.h
+++ b/lib/location/method_cellular.h
@@ -7,8 +7,8 @@
 #ifndef METHOD_CELLULAR_H
 #define METHOD_CELLULAR_H
 
-int method_cellular_location_get(const struct location_method_config *config);
 int method_cellular_init(void);
+int method_cellular_location_get(const struct location_method_config *config);
 int method_cellular_cancel(void);
 
 #endif /* METHOD_CELLULAR_H */

--- a/lib/location/method_gnss.h
+++ b/lib/location/method_gnss.h
@@ -8,12 +8,11 @@
 #define METHOD_GNSS_H
 
 int method_gnss_init(void);
-void method_gnss_fix_work_fn(struct k_work *item);
 int method_gnss_location_get(const struct location_method_config *config);
+int method_gnss_cancel(void);
+int method_gnss_timeout(void);
 #if defined(CONFIG_LOCATION_DATA_DETAILS)
 void method_gnss_details_get(struct location_data_details *details);
 #endif
-
-int method_gnss_cancel(void);
 
 #endif /* METHOD_GNSS_H */

--- a/lib/location/method_wifi.h
+++ b/lib/location/method_wifi.h
@@ -7,8 +7,8 @@
 #ifndef METHOD_WIFI_H
 #define METHOD_WIFI_H
 
-int method_wifi_location_get(const struct location_method_config *config);
 int method_wifi_init(void);
+int method_wifi_location_get(const struct location_method_config *config);
 int method_wifi_cancel(void);
 
 #endif /* METHOD_WIFI_H */


### PR DESCRIPTION
Added a warning trace when GNSS method times out and GNSS has indicated that the average granted time windows have been too short.