### PR TITLE
lib: at_cmd_parser: add support for picolibc

### DIFF
--- a/lib/at_cmd_parser/Kconfig
+++ b/lib/at_cmd_parser/Kconfig
@@ -6,4 +6,4 @@
 
 config AT_CMD_PARSER
 	bool "AT command parser library"
-	depends on NEWLIB_LIBC || EXTERNAL_LIBC
+	depends on NEWLIB_LIBC || EXTERNAL_LIBC || PICOLIBC


### PR DESCRIPTION
This adds support for building the at_cmd_parser library with picolibc. This is a requirement to be able to use picolibc with the Carrier Library.

Signed-off-by: Markus Rekdal <markus.rekdal@nordicsemi.no>