### PR TITLE
ci: actions: use 16 cores to build the doc

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
 
     steps:
       - name: Checkout the code


### PR DESCRIPTION
 - default is 2 cores
 - need to compare build time and cost