### PR TITLE
samples: lwm2m_client: Disable eDRX if disabled in kconfig

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -417,6 +417,13 @@ static void modem_connect(void)
 	int ret;
 
 #if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
+	if (!IS_ENABLED(CONFIG_LTE_EDRX_REQ)) {
+		ret = lte_lc_edrx_req(false);
+		if (ret < 0) {
+			LOG_ERR("EDRX request error %d", ret);
+		}
+	}
+
 	ret = lte_lc_psm_req(true);
 	if (ret < 0) {
 		LOG_ERR("lte_lc_psm_req, error: (%d)", ret);


### PR DESCRIPTION
Some networks enable eDRX by default. Send eDRX disable request if eDRX is disabled in kconfig.

Signed-off-by: Juha Ylinen <juha.ylinen@nordicsemi.no>