### PR TITLE
net: fota_download: Save 6K flash by not using fd for state checking

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -226,7 +226,10 @@ Modem libraries
 Libraries for networking
 ------------------------
 
-|no_changes_yet_note|
+* :ref:`lib_fota_download` library:
+
+  * Fixed a bug were the :c:func:`download_client_callback` function was continuing to read the offset value even if :c:func:`dfu_target_offset_get` returned an error.
+  * Fixed a bug where the cleanup of the downloading state was not happening when an error event was raised.
 
 Libraries for NFC
 -----------------

--- a/tests/subsys/net/lib/fota_download/src/test_fota_download.c
+++ b/tests/subsys/net/lib/fota_download/src/test_fota_download.c
@@ -294,6 +294,14 @@ static void test_fota_download_start_generic(const char * const resource_locator
 
 ZTEST_SUITE(fota_download_tests, NULL, NULL, NULL, NULL, NULL);
 
+ZTEST(fota_download_tests, test_fota_download_cancel_before_init)
+{
+	/* Verify that calling fota_download_cancel without initializing results in an error. */
+	int err = fota_download_cancel();
+
+	zassert_equal(err, -EAGAIN);
+}
+
 ZTEST(fota_download_tests, test_download_single)
 {
 	test_fota_download_start_generic(S0_A, S0_A, S1_ACTIVE);
@@ -342,8 +350,9 @@ ZTEST(fota_download_tests, test_download_with_offset)
 	k_sem_take(&download_with_offset_sem, K_SECONDS(2));
 	zassert_false(fail_on_offset_get, NULL);
 
+	/* Expect the fota_download_cancel to fail as the download_with_offset() failed. */
 	err = fota_download_cancel();
-	zassert_ok(err, NULL);
+	zassert_equal(err, -EAGAIN);
 
 
 	/* Check that application is being notified when
@@ -359,8 +368,9 @@ ZTEST(fota_download_tests, test_download_with_offset)
 	k_sem_take(&download_with_offset_sem, K_SECONDS(2));
 	zassert_false(fail_on_connect, NULL);
 
+	/* Expect the fota_download_cancel to fail as the download_with_offset() failed. */
 	err = fota_download_cancel();
-	zassert_ok(err, NULL);
+	zassert_equal(err, -EAGAIN);
 
 
 	/* Check that application is being notified when
@@ -376,8 +386,9 @@ ZTEST(fota_download_tests, test_download_with_offset)
 	k_sem_take(&download_with_offset_sem, K_SECONDS(2));
 	zassert_false(fail_on_start, NULL);
 
+	/* Expect the fota_download_cancel to fail as the download_with_offset() failed. */
 	err = fota_download_cancel();
-	zassert_ok(err, NULL);
+	zassert_equal(err, -EAGAIN);
 
 
 	/* Successfully restart download with offset */
@@ -393,4 +404,8 @@ ZTEST(fota_download_tests, test_download_with_offset)
 
 	err = fota_download_cancel();
 	zassert_ok(err, NULL);
+
+	/* Try cancelling again and expect error. */
+	err = fota_download_cancel();
+	zassert_equal(err, -EAGAIN);
 }


### PR DESCRIPTION
Initializing the `fd` member variable of the `download_client` struct resulted in a 6K increase in flash size of all applications using this module. The purpose of initing the `fd` member to -1 was to make the fota_download_cancel return error in case the download was not in prgoress. It is now made to re-use the existing `downloading` variable to do the same.

The reason for 6K increase in flash was that intializing the member (in this case fd) to -1 involves the linker placing the entire struct in both RAM and flash (the init value is stored in flash and the CPU will populate the struct in RAM with the init value in flash during startup).

Also modified the tests to ensure that the API `fota_download_cancel` returns `-EAGAIN` when a download is not in progress.

As a side effect, this uncovered two bugs which are also fixed in this.
1) `download_client_callback` was continuing to read offset value even if dfu_target_offset_get returned fail. This can lead to undefined behavior.
2) The state variable `downloading` was not set to false when an error event was raised. This lead to a dependency on the app calling `fota_download_cancel()` to cleanup the state.

The related commit: ae56a415b1ae8a63edb9381298579cc18a7c7be7

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>