### PR TITLE
applications: asset_tracker_v2: Remove fresh flag for dynamic modem data

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
@@ -168,15 +168,6 @@ struct cloud_data_modem_dynamic {
 	char mccmnc[7];
 	/** Flag signifying that the data entry is to be encoded. */
 	bool queued : 1;
-
-	/** Flags to signify if the corresponding data value is fresh and can be used. */
-	bool area_code_fresh	: 1;
-	bool cell_id_fresh	: 1;
-	bool rsrp_fresh		: 1;
-	bool ip_address_fresh	: 1;
-	bool mccmnc_fresh	: 1;
-	bool band_fresh		: 1;
-	bool nw_mode_fresh	: 1;
 };
 
 struct cloud_data_ui {

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/json_common.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/json_common.c
@@ -144,7 +144,6 @@ int json_common_modem_dynamic_data_add(cJSON *parent,
 	int err;
 	uint32_t mccmnc;
 	char *end_ptr;
-	bool values_added = false;
 
 	if (!data->queued) {
 		return -ENODATA;
@@ -164,85 +163,57 @@ int json_common_modem_dynamic_data_add(cJSON *parent,
 		goto exit;
 	}
 
-	if (data->band_fresh) {
-		err = json_add_number(modem_val_obj, MODEM_CURRENT_BAND, data->band);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_CURRENT_BAND, data->band);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->nw_mode_fresh) {
-		err = json_add_str(modem_val_obj, MODEM_NETWORK_MODE,
-				   (data->nw_mode == LTE_LC_LTE_MODE_LTEM) ? "LTE-M" :
-				   (data->nw_mode == LTE_LC_LTE_MODE_NBIOT) ? "NB-IoT" : "Unknown");
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_str(modem_val_obj, MODEM_NETWORK_MODE,
+			   (data->nw_mode == LTE_LC_LTE_MODE_LTEM) ? "LTE-M" :
+			   (data->nw_mode == LTE_LC_LTE_MODE_NBIOT) ? "NB-IoT" : "Unknown");
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->rsrp_fresh) {
-		err = json_add_number(modem_val_obj, MODEM_RSRP, data->rsrp);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_RSRP, data->rsrp);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->area_code_fresh) {
-		err = json_add_number(modem_val_obj, MODEM_AREA_CODE, data->area);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_AREA_CODE, data->area);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->mccmnc_fresh) {
-		/* Convert mccmnc to unsigned long integer. */
-		errno = 0;
-		mccmnc = strtoul(data->mccmnc, &end_ptr, 10);
+	/* Convert mccmnc to unsigned long integer. */
+	errno = 0;
+	mccmnc = strtoul(data->mccmnc, &end_ptr, 10);
 
-		if ((errno == ERANGE) || (*end_ptr != '\0')) {
-			LOG_ERR("MCCMNC string could not be converted.");
-			err = -ENOTEMPTY;
-			goto exit;
-		}
-
-		err = json_add_number(modem_val_obj, MODEM_MCCMNC, mccmnc);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	if ((errno == ERANGE) || (*end_ptr != '\0')) {
+		LOG_ERR("MCCMNC string could not be converted.");
+		err = -ENOTEMPTY;
+		goto exit;
 	}
 
-	if (data->cell_id_fresh) {
-		err = json_add_number(modem_val_obj, MODEM_CELL_ID, data->cell);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_MCCMNC, mccmnc);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->ip_address_fresh) {
-		err = json_add_str(modem_val_obj, MODEM_IP_ADDRESS, data->ip);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_CELL_ID, data->cell);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (!values_added) {
-		err = -ENODATA;
-		data->queued = false;
-		LOG_WRN("No valid dynamic modem data values present, entry unqueued");
+	err = json_add_str(modem_val_obj, MODEM_IP_ADDRESS, data->ip);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
 		goto exit;
 	}
 

--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/nrf_cloud/nrf_cloud_codec.c
@@ -255,7 +255,6 @@ static int modem_dynamic_data_add(struct cloud_data_modem_dynamic *data, cJSON *
 	int err;
 	uint32_t mccmnc;
 	char *end_ptr;
-	bool values_added = false;
 
 	if (!data->queued) {
 		return -ENODATA;
@@ -273,85 +272,57 @@ static int modem_dynamic_data_add(struct cloud_data_modem_dynamic *data, cJSON *
 		return -ENOMEM;
 	}
 
-	if (data->band_fresh) {
-		err = json_add_number(modem_val_obj, MODEM_CURRENT_BAND, data->band);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_CURRENT_BAND, data->band);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->nw_mode_fresh) {
-		err = json_add_str(modem_val_obj, MODEM_NETWORK_MODE,
-				   (data->nw_mode == LTE_LC_LTE_MODE_LTEM) ? "LTE-M" :
-				   (data->nw_mode == LTE_LC_LTE_MODE_NBIOT) ? "NB-IoT" : "Unknown");
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_str(modem_val_obj, MODEM_NETWORK_MODE,
+			   (data->nw_mode == LTE_LC_LTE_MODE_LTEM) ? "LTE-M" :
+			   (data->nw_mode == LTE_LC_LTE_MODE_NBIOT) ? "NB-IoT" : "Unknown");
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->rsrp_fresh) {
-		err = json_add_number(modem_val_obj, MODEM_RSRP, data->rsrp);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_RSRP, data->rsrp);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->area_code_fresh) {
-		err = json_add_number(modem_val_obj, MODEM_AREA_CODE, data->area);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_AREA_CODE, data->area);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->mccmnc_fresh) {
-		/* Convert mccmnc to unsigned long integer. */
-		errno = 0;
-		mccmnc = strtoul(data->mccmnc, &end_ptr, 10);
+	/* Convert mccmnc to unsigned long integer. */
+	errno = 0;
+	mccmnc = strtoul(data->mccmnc, &end_ptr, 10);
 
-		if ((errno == ERANGE) || (*end_ptr != '\0')) {
-			LOG_ERR("MCCMNC string could not be converted.");
-			err = -ENOTEMPTY;
-			goto exit;
-		}
-
-		err = json_add_number(modem_val_obj, MODEM_MCCMNC, mccmnc);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	if ((errno == ERANGE) || (*end_ptr != '\0')) {
+		LOG_ERR("MCCMNC string could not be converted.");
+		err = -ENOTEMPTY;
+		goto exit;
 	}
 
-	if (data->cell_id_fresh) {
-		err = json_add_number(modem_val_obj, MODEM_CELL_ID, data->cell);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_MCCMNC, mccmnc);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (data->ip_address_fresh) {
-		err = json_add_str(modem_val_obj, MODEM_IP_ADDRESS, data->ip);
-		if (err) {
-			LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
-			goto exit;
-		}
-		values_added = true;
+	err = json_add_number(modem_val_obj, MODEM_CELL_ID, data->cell);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
+		goto exit;
 	}
 
-	if (!values_added) {
-		err = -ENODATA;
-		data->queued = false;
-		LOG_WRN("No valid dynamic modem data values present, entry unqueued");
+	err = json_add_str(modem_val_obj, MODEM_IP_ADDRESS, data->ip);
+	if (err) {
+		LOG_ERR("Encoding error: %d returned at %s:%d", err, __FILE__, __LINE__);
 		goto exit;
 	}
 
@@ -735,18 +706,16 @@ static int add_batch_data(cJSON *array, enum batch_data_type type, void *buf, si
 			}
 
 			/* Retrieve and construct RSRP APP_ID message from dynamic modem data */
-			if (modem_dynamic[i].rsrp_fresh) {
-				len = snprintk(rsrp, sizeof(rsrp), "%d", modem_dynamic[i].rsrp);
-				if ((len < 0) || (len >= sizeof(rsrp))) {
-					LOG_ERR("Cannot convert RSRP value, buffer too small");
-					return -ENOMEM;
-				}
+			len = snprintk(rsrp, sizeof(rsrp), "%d", modem_dynamic[i].rsrp);
+			if ((len < 0) || (len >= sizeof(rsrp))) {
+				LOG_ERR("Cannot convert RSRP value, buffer too small");
+				return -ENOMEM;
+			}
 
-				err = add_data(array, NULL, APP_ID_RSRP, rsrp, &modem_dynamic[i].ts,
-					       true, NULL, false);
-				if (err && err != -ENODATA) {
-					return err;
-				}
+			err = add_data(array, NULL, APP_ID_RSRP, rsrp, &modem_dynamic[i].ts,
+				true, NULL, false);
+			if (err && err != -ENODATA) {
+				return err;
 			}
 
 			break;

--- a/applications/asset_tracker_v2/src/events/modem_module_event.h
+++ b/applications/asset_tracker_v2/src/events/modem_module_event.h
@@ -181,18 +181,6 @@ struct modem_module_dynamic_modem_data {
 	char mccmnc[7];
 	uint8_t band;
 	enum lte_lc_lte_mode nw_mode;
-
-	/* Flags to signify if the corresponding data value has been updated and is considered
-	 * fresh.
-	 */
-	bool area_code_fresh	: 1;
-	bool cell_id_fresh	: 1;
-	bool rsrp_fresh		: 1;
-	bool ip_address_fresh	: 1;
-	bool mccmnc_fresh	: 1;
-	bool band_fresh		: 1;
-	bool nw_mode_fresh	: 1;
-	bool apn_fresh		: 1;
 };
 
 struct modem_module_battery_data {

--- a/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.modem_module
@@ -14,15 +14,6 @@ menuconfig MODEM_MODULE
 
 if MODEM_MODULE
 
-config MODEM_SEND_ALL_SAMPLED_DATA
-	bool "Include all sampled data upon a sample request"
-	default y if LWM2M_INTEGRATION
-	help
-	  If this option is disabled the modem module will only include data values that have
-	  changed from the last sample request. Currently this option is only supported for
-	  dynamic modem data. This is to save costs related to data transfers and to lower the
-	  device's overall current consumption due to less CPU and radio-activity.
-
 config MODEM_THREAD_STACK_SIZE
 	int "Modem module thread stack size"
 	default 2048

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -1290,14 +1290,6 @@ static void on_all_states(struct data_msg_data *msg)
 			.mcc = msg->module.modem.data.modem_dynamic.mcc,
 			.mnc = msg->module.modem.data.modem_dynamic.mnc,
 			.ts = msg->module.modem.data.modem_dynamic.timestamp,
-
-			.area_code_fresh = msg->module.modem.data.modem_dynamic.area_code_fresh,
-			.nw_mode_fresh = msg->module.modem.data.modem_dynamic.nw_mode_fresh,
-			.band_fresh = msg->module.modem.data.modem_dynamic.band_fresh,
-			.cell_id_fresh = msg->module.modem.data.modem_dynamic.cell_id_fresh,
-			.rsrp_fresh = msg->module.modem.data.modem_dynamic.rsrp_fresh,
-			.ip_address_fresh = msg->module.modem.data.modem_dynamic.ip_address_fresh,
-			.mccmnc_fresh = msg->module.modem.data.modem_dynamic.mccmnc_fresh,
 			.queued = true
 		};
 

--- a/applications/asset_tracker_v2/tests/json_common/src/main.c
+++ b/applications/asset_tracker_v2/tests/json_common/src/main.c
@@ -331,13 +331,6 @@ static void test_encode_modem_dynamic_data_object(void)
 		.ip = "10.81.183.99",
 		.ts = 1000,
 		.queued = true,
-		.band_fresh = true,
-		.nw_mode_fresh = true,
-		.area_code_fresh = true,
-		.cell_id_fresh = true,
-		.rsrp_fresh = true,
-		.ip_address_fresh = true,
-		.mccmnc_fresh = true
 	};
 
 	ret = json_common_modem_dynamic_data_add(dummy.root_obj,
@@ -392,13 +385,6 @@ static void test_encode_modem_dynamic_data_array(void)
 		.ip = "10.81.183.99",
 		.ts = 1000,
 		.queued = true,
-		.band_fresh = true,
-		.nw_mode_fresh = true,
-		.area_code_fresh = true,
-		.cell_id_fresh = true,
-		.rsrp_fresh = true,
-		.ip_address_fresh = true,
-		.mccmnc_fresh = true
 	};
 
 	ret = json_common_modem_dynamic_data_add(dummy.array_obj,
@@ -845,13 +831,6 @@ static void test_encode_batch_data_object(void)
 		[0].ip = "10.81.183.99",
 		[0].ts = 1000,
 		[0].queued = true,
-		[0].band_fresh = true,
-		[0].nw_mode_fresh = true,
-		[0].area_code_fresh = true,
-		[0].cell_id_fresh = true,
-		[0].rsrp_fresh = true,
-		[0].ip_address_fresh = true,
-		[0].mccmnc_fresh = true,
 		/* Second entry */
 		[1].band = 20,
 		[1].nw_mode = LTE_LC_LTE_MODE_LTEM,
@@ -862,13 +841,6 @@ static void test_encode_batch_data_object(void)
 		[1].ip = "10.81.183.99",
 		[1].ts = 1000,
 		[1].queued = true,
-		[1].band_fresh = true,
-		[1].nw_mode_fresh = true,
-		[1].area_code_fresh = true,
-		[1].cell_id_fresh = true,
-		[1].rsrp_fresh = true,
-		[1].ip_address_fresh = true,
-		[1].mccmnc_fresh = true,
 	};
 	struct cloud_data_modem_static modem_static[2] = {
 		[0].imei = "352656106111232",

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
@@ -559,13 +559,6 @@ void test_codec_helpers_set_modem_dynamic_data(void)
 		.apn = "telenor.iot",
 		.ts = 1000,
 		.queued = true,
-		.band_fresh = true,
-		.nw_mode_fresh = true,
-		.area_code_fresh = true,
-		.cell_id_fresh = true,
-		.rsrp_fresh = true,
-		.ip_address_fresh = true,
-		.mccmnc_fresh = true,
 	};
 	int64_t current_time = UNIX_TIMESTAMP_DUMMY;
 	uint8_t bearers[2] = { LTE_FDD_BEARER, NB_IOT_BEARER };

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec/src/nrf_cloud_codec_test.c
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec/src/nrf_cloud_codec_test.c
@@ -178,13 +178,6 @@ const static struct cloud_data_modem_dynamic modem_dyn_data_example = {
 	.ip = "10.81.183.99",
 	.ts = 1000,
 	.queued = true,
-	.band_fresh = true,
-	.nw_mode_fresh = true,
-	.area_code_fresh = true,
-	.cell_id_fresh = true,
-	.rsrp_fresh = true,
-	.ip_address_fresh = true,
-	.mccmnc_fresh = true,
 };
 
 #define SENSORS_BATCH_EXAMPLE \


### PR DESCRIPTION
Remove fresh flag for dynamic modem data. We can never guarantee that data gathered in a sample request actually arrive at the broker. We have retransmission functionality via the QoS library for MQTT based clouds, but retransmission are limited to x amount of attempts.

The fresh flag is associated with individual parameters sampled on the device that is not equal to the last sampled value. If the device considers a sampled value as old, it will not be included in the next cloud publication. The problem is that we don't know if the value that was sampled the previous sample cycle was actually sent.

This functionality is application specific so the reasonable path is to help customers (if there is a demand for it) to implement this kind of functionality in their application. Rather than having it in the Asset Tracker v2 as a standard feature.