### PR TITLE
boards: Add Arduino Header to nRF5340_Audio_DK

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
@@ -79,6 +79,30 @@
 		};
 	};
 
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 8)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 9)>;
+			bias-pull-up;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 8)>,
+				<NRF_PSEL(UART_RX, 1, 9)>;
+			low-power-enable;
+		};
+	};
+	spi4_default: spi4_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 9)>;
+		};
+	};
 	spi4_sleep: spi4_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 8)>,

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dts
@@ -15,6 +15,44 @@
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 	};
 
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
+			   <1 0 &gpio0 5 0>,	/* A1 */
+			   <2 0 &gpio0 6 0>,	/* A2 */
+			   <3 0 &gpio0 7 0>,	/* A3 */
+			   <4 0 &gpio0 25 0>,	/* A4 */ 
+			   <5 0 &gpio0 26 0>,	/* A5 */
+			   <6 0 &gpio1 9 0>,	/* D0 */
+			   <7 0 &gpio1 8 0>,	/* D1 */
+			   <8 0 &gpio0 31 0>,	/* D2 */
+			   <9 0 &gpio1 0 0>,	/* D3 */
+			   <10 0 &gpio1 1 0>,	/* D4 */
+			   <11 0 &gpio1 14 0>,	/* D5 */
+			   <12 0 &gpio1 7 0>,	/* D6 */
+			   <13 0 &gpio1 11 0>,	/* D7 */
+			   <14 0 &gpio1 10 0>,	/* D8 */
+			   <15 0 &gpio1 13 0>,	/* D9 */
+			   <16 0 &gpio1 12 0>,	/* D10 */
+			   <17 0 &gpio1 9 0>,	/* D11 */
+			   <18 0 &gpio1 10 0>,	/* D12 */
+			   <19 0 &gpio1 8 0>,	/* D13 */
+			   <20 0 &gpio1 2 0>,	/* D14 */
+			   <21 0 &gpio1 3 0>;	/* D15 */
+	};
+	arduino_adc: analog-connector {
+		compatible = "arduino,uno-adc";
+		#io-channel-cells = <1>;
+		io-channel-map = <0 &adc 0>,	/* A0 = P0.4 = AIN0 */
+				 <1 &adc 1>,	/* A1 = P0.5 = AIN1 */
+				 <2 &adc 2>,	/* A2 = P0.6 = AIN2 */
+				 <3 &adc 3>,	/* A3 = P0.7 = AIN3 */
+				 <4 &adc 4>,	/* A4 = P0.25 = AIN4 */
+				 <5 &adc 5>;	/* A5 = P0.26 = AIN5 */
+	};
 	gpio_fwd: nrf-gpio-forwarder {
 		compatible = "nordic,nrf-gpio-forwarder";
 		status = "okay";
@@ -105,6 +143,22 @@
 	status = "okay";
 };
 
+arduino_serial: &uart1 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-1 = <&uart1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi4 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	pinctrl-0 = <&spi4_default>;
+	pinctrl-1 = <&spi4_sleep>;
+	pinctrl-names = "default", "sleep";
+};
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";


### PR DESCRIPTION
Adds Arduino Header compatibility to nRF5340_Audio_DK, allowing the use of shields and samples that depend on arduino_xxx labels such as /zephyr/samples/subsys/display/lvgl

Signed-off-by: João Dullius <joaodullius@bpmrep.com.br>