### PR TITLE
application: serial_lte_modem: Add TFTP client

### DIFF
--- a/applications/serial_lte_modem/doc/FTP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FTP_AT_commands.rst
@@ -110,3 +110,108 @@ Test command
 ------------
 
 The test command is not supported.
+
+TFTP client #XTFTP
+==================
+
+The ``#XTFTP`` command allows you to send TFTP commands.
+
+   .. note::
+      The maximum supported file size is 2100 bytes.
+      TFTP write request is not supported yet.
+
+Set command
+-----------
+
+The set command allows you to send TFTP commands based on RFC1350.
+
+Syntax
+~~~~~~
+
+::
+
+   AT#XTFTP=<op>,<url>,<port>,<file_path>[,<mode>]
+
+* The ``<op>`` parameter can accept one of the following values:
+
+  * ``1`` - TFTP read request using IP protocol family version 4.
+  * *Currently not supported* ``2`` - TFTP write request using IP protocol family version 4.
+  * ``3`` - TFTP read request using IP protocol family version 6.
+  * *Currently not supported* ``4`` - TFTP write request using IP protocol family version 6.
+
+* The ``<url>`` parameter is a string.
+  It indicates the hostname or the IP address of the TFTP server.
+  Its maximum size is 128 bytes.
+  When the parameter is an IP address, it supports both IPv4 and IPv6.
+* The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
+  It represents the TFTP service port on the remote server.
+  Default port 69 is applied if this parameter is omitted or set to ``0``.
+* The ``<file_path>`` parameter is a string.
+  It indicates the file path on the TFTP server to read from or write to.
+  Its maximum size is 128 bytes.
+* The ``<mode>`` parameter is a string.
+  It indicates the three modes defined in TFTP protocol.
+  Valid values are ``netascii``, ``octet`` and ``mail``.
+  The default value ``octet`` is applied if this parameter is omitted.
+
+Response syntax
+~~~~~~~~~~~~~~~
+
+::
+
+   #XTFTP: <size>, "success"
+   <data>
+
+   #XTFTP: <error>, "<error_msg>"
+
+* The ``<size>`` value is an integer.
+  When positive, it indicates the size of data in bytes read from TFTP server.
+* The ``<data>`` value is the arbitrary data read from TFTP server.
+* The ``<error>`` value is an integer.
+  It is a negative integer based on the type of error.
+* The ``<error_msg>`` value is a string.
+  It is the description that corresponds to the ``<error>`` value.
+
+Examples
+~~~~~~~~
+
+::
+
+   AT#XTFTP=1,"tftp.server",,"test_tftp_fake.txt"
+   #XTFTP: -4, "remote error"
+   ERROR
+
+   AT#XTFTP=1,"tftp.server",,"test_tftp.txt"
+   #XTFTP: 45,"success"
+   Test file for SLM TFTP client.
+   Does it work?
+   OK
+
+   AT#XTFTP=2,"tftp.server",,"test_upload.txt"
+   ERROR
+
+Read command
+------------
+
+The read command is not supported.
+
+Test command
+------------
+
+The test command tests the existence of the command and provides information about the type of its subparameters.
+
+Syntax
+~~~~~~
+
+::
+
+   AT#XTFTP=?
+
+Examples
+~~~~~~~~
+
+::
+
+   AT#XTFTP=?
+   #XTFTP: (1,2,3,4),<url>,<port>,<file_path>,<mode>
+   OK

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -187,6 +187,11 @@ CONFIG_SLM_CELL_POS - nRF Cloud cellular positioning support in SLM
 CONFIG_SLM_FTPC - FTP client support in SLM
    This option enables additional AT commands for using the FTP client service.
 
+.. _CONFIG_SLM_TFTPC:
+
+CONFIG_SLM_TFTPC - TFTP client support in SLM
+   This option enables additional AT commands for using the TFTP client service.
+
 .. _CONFIG_SLM_MQTTC:
 
 CONFIG_SLM_MQTTC - MQTT client support in SLM

--- a/applications/serial_lte_modem/src/ftp_c/CMakeLists.txt
+++ b/applications/serial_lte_modem/src/ftp_c/CMakeLists.txt
@@ -6,3 +6,4 @@
 
 zephyr_include_directories(.)
 target_sources_ifdef(CONFIG_SLM_FTPC app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/slm_at_ftp.c)
+target_sources_ifdef(CONFIG_SLM_TFTPC app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/slm_at_tftp.c)

--- a/applications/serial_lte_modem/src/ftp_c/Kconfig
+++ b/applications/serial_lte_modem/src/ftp_c/Kconfig
@@ -7,3 +7,8 @@ config SLM_FTPC
 	bool "FTP client support in SLM"
 	default y
 	select FTP_CLIENT
+
+config SLM_TFTPC
+	bool "TFTP client support in SLM"
+	default y
+	select TFTP_LIB

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_tftp.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <stdio.h>
+#include <string.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/tftp.h>
+#include "slm_util.h"
+#include "slm_at_host.h"
+
+LOG_MODULE_REGISTER(slm_tftp, CONFIG_SLM_LOG_LEVEL);
+
+#define TFTP_MAX_FILEPATH	128
+#define TFTP_DEFAULT_PORT       69
+
+/**@brief Socketopt operations. */
+enum slm_ftp_operation {
+	TFTP_DUMMY,
+	TFTP_GET,	/** IPv4 TFTP Read */
+	TFTP_PUT,	/** IPv4 TFTP Write */
+	TFTP_GET6,	/** IPv6 TFTP Read */
+	TFTP_PUT6,	/** IPv6 TFTP Write */
+	/* count */
+	TFTP_OP_MAX
+};
+
+/* global variable defined in different files */
+extern struct at_param_list at_param_list;
+extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
+
+static int do_tftp_get(int family, const char *server, uint16_t port, const char *filepath,
+			const char *mode)
+{
+	int ret;
+	struct sockaddr sa = {
+		.sa_family = AF_UNSPEC
+	};
+
+	ret = util_resolve_host(0, server, port, family, &sa);
+	if (ret) {
+		LOG_ERR("getaddrinfo() error: %s", gai_strerror(ret));
+		return -EAGAIN;
+	}
+
+	struct tftpc client = {
+		.user_buf = rsp_buf,
+		.user_buf_size = sizeof(rsp_buf)
+	};
+
+	ret = tftp_get(&sa, &client, filepath, mode);
+	if (ret != 0) {
+		switch (ret) {
+		case TFTPC_DUPLICATE_DATA:
+			strcpy(rsp_buf, "\r\n#XTFTP: -1, \"duplicate data\"\r\n");
+			break;
+		case TFTPC_BUFFER_OVERFLOW:
+			strcpy(rsp_buf, "\r\n#XTFTP: -2, \"buffer overflow\"\r\n");
+			break;
+		case TFTPC_REMOTE_ERROR:
+			strcpy(rsp_buf, "\r\n#XTFTP: -4, \"remote error\"\r\n");
+			break;
+		case TFTPC_RETRIES_EXHAUSTED:
+			strcpy(rsp_buf, "\r\n#XTFTP: -5, \"retries exhausted\"\r\n");
+			break;
+		case TFTPC_UNKNOWN_FAILURE:
+		default:
+			strcpy(rsp_buf, "\r\n#XTFTP: -3, \"unknown failure\"\r\n");
+			break;
+		}
+	} else {
+		char result[32];
+
+		sprintf(result, "\r\n#XTFTP: %d,\"success\"\r\n", client.user_buf_size);
+		rsp_send(result, strlen(result));
+	}
+	/* API does not add null-terminator */
+	if (client.user_buf_size < sizeof(rsp_buf)) {
+		rsp_buf[client.user_buf_size] = 0x00;
+	}
+	rsp_send(rsp_buf, strlen(rsp_buf));
+	return ret;
+}
+
+
+
+/**@brief handle AT#XTFTP commands
+ *  AT#XTFTP=<op>,<url>,<port>,<file_path>[,<mode>]
+ *  AT#XTFTP? READ is not supported
+ *  AT#XTFTP=?
+ */
+int handle_at_tftp(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	uint16_t op;
+	int param_count = at_params_valid_count_get(&at_param_list);
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		err = at_params_unsigned_short_get(&at_param_list, 1, &op);
+		if (err) {
+			return err;
+		}
+		if (op == TFTP_GET || op == TFTP_GET6) {
+			uint16_t port;
+			char url[SLM_MAX_URL];
+			char filepath[TFTP_MAX_FILEPATH];
+			char mode[16];   /** "netascii", "octet", "mail" */
+			int size;
+
+			size = sizeof(url);
+			err = util_string_get(&at_param_list, 2, url, &size);
+			if (err) {
+				return err;
+			}
+			(void)at_params_unsigned_short_get(&at_param_list, 3, &port);
+			if (port == 0) {
+				port = TFTP_DEFAULT_PORT;
+			}
+			size = sizeof(filepath);
+			err = util_string_get(&at_param_list, 4, filepath, &size);
+			if (err) {
+				return err;
+			}
+			if (param_count > 5) {
+				size = sizeof(mode);
+				err = util_string_get(&at_param_list, 5, mode, &size);
+				if (err) {
+					return err;
+				}
+				if (!slm_util_cmd_casecmp(mode, "netascii") &&
+				    !slm_util_cmd_casecmp(mode, "octet") &&
+				    !slm_util_cmd_casecmp(mode, "mail")) {
+					return -EINVAL;
+				}
+			} else {
+				strcpy(mode, "octet");
+			}
+
+			if (op == TFTP_GET) {
+				err = do_tftp_get(AF_INET, url, port, filepath, mode);
+			} else {
+				err = do_tftp_get(AF_INET6, url, port, filepath, mode);
+			}
+		} else if (op == TFTP_PUT || op == TFTP_PUT6) {
+			LOG_WRN("TFTP Put not supported");
+			err = -ENOSYS;
+		} else {
+			err = -EINVAL;
+		} break;
+
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf, "\r\n#XTFTP: (%d,%d,%d,%d),<url>,<port>,<file_path>,<mode>\r\n",
+			TFTP_GET, TFTP_PUT, TFTP_GET6, TFTP_PUT6);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -419,6 +419,9 @@ int handle_at_cellpos(enum at_cmd_type cmd_type);
 #if defined(CONFIG_SLM_FTPC)
 int handle_at_ftp(enum at_cmd_type cmd_type);
 #endif
+#if defined(CONFIG_SLM_TFTPC)
+int handle_at_tftp(enum at_cmd_type cmd_type);
+#endif
 
 #if defined(CONFIG_SLM_MQTTC)
 int handle_at_mqtt_connect(enum at_cmd_type cmd_type);
@@ -524,6 +527,10 @@ static struct slm_at_cmd {
 #if defined(CONFIG_SLM_FTPC)
 	/* FTP commands */
 	{"AT#XFTP", handle_at_ftp},
+#endif
+#if defined(CONFIG_SLM_TFTPC)
+	/* TFTP commands */
+	{"AT#XTFTP", handle_at_tftp},
 #endif
 
 #if defined(CONFIG_SLM_MQTTC)

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -126,7 +126,7 @@ nRF9160: Asset Tracker v2
 nRF9160: Serial LTE modem
 -------------------------
 
-|no_changes_yet_note|
+* Added an RFC1350 TFTP client, currently supporting only *READ REQUEST*.
 
 nRF5340 Audio
 -------------


### PR DESCRIPTION
Add RFC1350 TFTP client, using Zephyr tftp library.
``AT#XTFTP=<op>,<url>,<port>,<file_path>[,<mode>]``

Currently only support TFTP Read.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>