### PR TITLE
manifest: pull Matter Wi-Fi network diagnostics implementation

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -69,7 +69,9 @@ Bluetooth mesh
 Matter
 ------
 
-|no_changes_yet_note|
+* Added:
+
+  * Support for Wi-Fi Network Diagnostic Cluster (which counts the number of packets received and transmitted on the Wi-Fi interface).
 
 See `Matter samples`_ for the list of changes for the Matter samples.
 

--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: v2.2.0
+      revision: 336ab07c7426ea66a9a97b0eaa053835ddf4993f
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This change adds support the the wifinetworkdiagnostics cluster.
Following statistics can be read:
  * multicast RX/TX
  * unicast RX/TX
  * beacons lost/TX

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>