### PR TITLE
caf: ble_adv: Prevent leaving off state on disconnection

### DIFF
--- a/subsys/caf/modules/ble_adv.c
+++ b/subsys/caf/modules/ble_adv.c
@@ -750,8 +750,10 @@ static bool handle_ble_peer_event(const struct ble_peer_event *event)
 		break;
 
 	case PEER_STATE_DISCONNECTED:
-		req_fast_adv = true;
-		update_state(STATE_DELAYED_ACTIVE);
+		if (state != STATE_OFF) {
+			req_fast_adv = true;
+			update_state(STATE_DELAYED_ACTIVE);
+		}
 		break;
 
 	case PEER_STATE_CONN_FAILED:


### PR DESCRIPTION
The module shall not leave off state on peer disconnection. The module shall be in off state until wake_up_event is received.

Jira: NCSDK-18578