### PR TITLE
manifest: Update zephyr to enable TF-M by default for Actinius NS boards

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.2.99-ncs1
+      revision: 707ff27ecaad44b00cc015bcf0c46db700a4267f
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Include change in sdk-zephyr:
Enable TF-M by default for Actinius NS boards

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>