### PR TITLE
application: serial_lte_modem: Support nRF Cloud appId

### DIFF
--- a/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/GNSS_AT_commands.rst
@@ -208,6 +208,28 @@ When the ``<signify>`` parameter is not specified, it does not signify the locat
    The application signifies the location info to nRF Cloud in a best-effort way.
    The minimal report interval is 5 seconds.
 
+.. note::
+   The application supports nRF Cloud cloud2device appId ``MODEM`` to send AT command from cloud:
+
+   * cloud2device schema::
+
+       {"appId":"MODEM", "messageType":"CMD", "data":"<AT_command>"}.
+
+   * device2cloud schema::
+
+       {"appId":"MODEM", "messageType":"RSP", "data":"<AT_response>"}.
+
+   The application executes the AT command in a best-effort way.
+
+.. note::
+   The application supports nRF Cloud cloud2device appId ``DEVICE`` to gracefully disconnect from cloud:
+
+   * cloud2device schema::
+
+       {"appId":"DEVICE", "messageType":"DISCON"}.
+
+   There is no response sending to nRF Cloud for this appId.
+
 Unsolicited notification
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -144,6 +144,7 @@ nRF9160: Serial LTE modem
 
 * Added an RFC1350 TFTP client, currently supporting only *READ REQUEST*.
 * Added new AT command #XSHUTDOWN to put nRF9160 SiP to System OFF mode.
+* Added support to nRF Cloud C2D appId "MODEM" and "DEVICE".
 
 nRF5340 Audio
 -------------


### PR DESCRIPTION
Support appId "MODEM" to send AT command from nRF Cloud to SLM.
C2D ``{"appId":"MODEM", "messageType":"CMD", "data":"<AT_command>"}``
D2D ``{"appId":"MODEM", "messageType":"RSP", "data":"<AT_response>"}``

Support appId "DEVICE" to gracefully disconnect from nRF Cloud.
C2D ``{"appId":"DEVICE", "messageType":"DISCON"}``

Reference [MODEM](https://github.com/nRFCloud/application-protocols/tree/v1/schemas/cloudToDevice/modem)
Reference [DEVICE](https://github.com/nRFCloud/application-protocols/tree/v1/schemas/cloudToDevice/device)

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>