### PR TITLE
Bluetooth: Mesh: Fix TID issues in DM models

### DIFF
--- a/subsys/bluetooth/mesh/vnd/dm_cli.c
+++ b/subsys/bluetooth/mesh/vnd/dm_cli.c
@@ -193,7 +193,7 @@ int bt_mesh_dm_cli_measurement_start(struct bt_mesh_dm_cli *cli,
 
 	net_buf_simple_add_u8(&msg, BT_MESH_DM_START_OP);
 	net_buf_simple_add_le16(&msg, (start->mode << 15) | (start->addr & 0x7FFF));
-	net_buf_simple_add_u8(&msg, start->reuse_transaction ? cli->tid : cli->tid++);
+	net_buf_simple_add_u8(&msg, start->reuse_transaction ? cli->tid : ++cli->tid);
 	if (start->cfg) {
 		if ((start->cfg->ttl == 1 || start->cfg->ttl > 127) || start->cfg->timeout < 10) {
 			return -EBADMSG;

--- a/subsys/bluetooth/mesh/vnd/dm_srv.c
+++ b/subsys/bluetooth/mesh/vnd/dm_srv.c
@@ -233,9 +233,12 @@ static int handle_start(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx
 	uint8_t tid = net_buf_simple_pull_u8(buf);
 
 	if (tid_check_and_update(&srv->prev_transaction, tid, ctx) != 0) {
-		/* Ignore duplicate message */
-		err = EAGAIN;
-		goto rsp;
+		/* Ignore duplicate message.
+		 * (Do not send a response, because this might arrive before
+		 * the successful response which is sent after ranging and
+		 * confuse clients)
+		 */
+		return 0;
 	}
 
 	if (srv->is_busy) {


### PR DESCRIPTION
This fixes two TID-related issues in the DM models:

  - TID in client should be preincremented, not post, to avoid off-by-one problems when switching between reuse_transaction and not reusing transaction
  - Failing the TID check on the server should ignore the message without sending a response, to avoid clients which retransmit messages receiving an EAGAIN before the ranging is done and getting confused.

Signed-off-by: Ludvig Samuelsen Jordet <ludvig.jordet@nordicsemi.no>