### PR TITLE
CODEOWNERS: Set Aurora as owners of scripts/bootloaders

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -171,6 +171,7 @@ Kconfig*                                  @tejlmand
 /scripts/tools-versions-*.txt             @tejlmand @grho @shantha-14 @ihansse
 /scripts/requirements-*.txt               @tejlmand @grho @shantha-14 @ihansse
 /scripts/west_commands/sbom/              @doki-nordic @maje-emb
+/scripts/bootloader/                      @hakonfam @sigvartmh
 /share/zephyrbuild-package/               @tejlmand
 /share/ncs-package/                       @tejlmand
 /subsys/bluetooth/                        @alwa-nordic @carlescufi @KAGA164


### PR DESCRIPTION
Set Aurora as owners of scripts/bootloaders instead of vestavind.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>