### PR TITLE
manifest: Update sdk-zephyr SHA to bring thingy53 DTS fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: v3.2.99-ncs1
+      revision: pull/1010/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The commit updates sdk-zephyr SHA to bring fix for thingy53_nrf5340 not building due to missing chosen nordic,pm-ext-flash.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>