### PR TITLE
manifest: pull Matter fix for Wi-Fi disconnected status after scan

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 737e23dac503e5284167496c6f1498c6eeebe194
+      revision: ab6343ae4ecd728b9263536f68dbad05d7868ddf
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Pull a fix for a bug of reporting incorrect connection status after the scan procedure is issued.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>