### PR TITLE
Add boot_reset_request_hook for nrf53 MCUboot

### DIFF
--- a/modules/mcuboot/hooks/nrf53_hooks.c
+++ b/modules/mcuboot/hooks/nrf53_hooks.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/flash/flash_simulator.h>
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"
+#include "bootutil/boot_hooks.h"
 #include "bootutil/fault_injection_hardening.h"
 #include "flash_map_backend/flash_map_backend.h"
 
@@ -125,5 +126,15 @@ int boot_serial_uploaded_hook(int img_index, const struct flash_area *area,
 		return network_core_update(false);
 	}
 
+	return 0;
+}
+
+int boot_reset_request_hook(bool force)
+{
+	ARG_UNUSED(force);
+
+	if (pcd_fw_copy_status_get() == PCD_STATUS_COPY) {
+		return BOOT_RESET_REQUEST_HOOK_BUSY;
+	}
 	return 0;
 }

--- a/west.yml
+++ b/west.yml
@@ -105,7 +105,7 @@ manifest:
       revision: 8d3f26d7da1b49815fbd0fe8335189cfac4ded85
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: d97046ef74ccb932531521a8380c4a831cb344f4
+      revision: pull/227/head
       path: bootloader/mcuboot
     - name: mbedtls
       path: modules/crypto/mbedtls


### PR DESCRIPTION
Two commits:
 1) update manifest to bring in boot_reset_request_hook;
 2) boot_reset_request_hook hook implementation that allows to prevent MCUboot reseting by command when NET code still in progress.