### PR TITLE
doc: Add changelog entry for fixing bt_rpc_gatt_host and mds.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -222,7 +222,13 @@ Binary libraries
 Bluetooth libraries and services
 --------------------------------
 
-|no_changes_yet_note|
+* :ref:`mds_readme`:
+
+  * Fixed URI generation in the :c:func:`data_uri_read` function.
+
+* :ref:`ble_rpc` library:
+
+  * Fixed a possible memory leak in the :c:func:`bt_gatt_indicate_rpc_handler` function.
 
 Bootloader libraries
 --------------------


### PR DESCRIPTION
Add entry for fixing a possible memory leak in bt_rpc_gatt_host. Add entry for fixing string termination in mds.

Signed-off-by: Dominik Chat <dominik.chat@nordicsemi.no>