### PR TITLE
partition manager: Fix custom flash map selection

### DIFF
--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -8,19 +8,13 @@ menu "Partition Manager"
 
 config PARTITION_MANAGER_ENABLED
 	bool "Partition manager is enabled (read-only option)"
+	select FLASH_MAP_CUSTOM
 	help
 	  Option which can be checked to see whether or not the
 	  partition manager is enabled in the current build. Note that this
 	  should ideally be a hidden option, but it can't due to limitations
 	  in how parent images impose options on child images. Don't
 	  change the value of this option.
-
-# Override this option to use custom flash map implementation when partition
-# manager is enabled.
-config FLASH_MAP_CUSTOM
-	bool
-	default y
-	depends on PARTITION_MANAGER_ENABLED
 
 # These values are now set by partition manager, so hide the option.
 config SRAM_SIZE


### PR DESCRIPTION
Fixes an issue if PM is enabled using menuconfig whereby custom flash map will not be enabled when it should be.