### PR TITLE
manifest: sdk-hostap: Advertise encryption support

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_wpa_supp_if.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_wpa_supp_if.h
@@ -116,5 +116,7 @@ void wifi_nrf_wpa_supp_event_mgmt_rx_callbk_fn(void *if_priv,
 						struct nrf_wifi_umac_event_mlme *mgmt_rx_event,
 						unsigned int event_len);
 
+int wifi_nrf_supp_get_capa(void *if_priv, struct wpa_driver_capa *capa);
+
 #endif /* CONFIG_WPA_SUPP */
 #endif /*  __ZEPHYR_WPA_SUPP_IF_H__ */

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_fmac_main.c
@@ -548,6 +548,7 @@ static const struct zep_wpa_supp_dev_ops wpa_supp_ops = {
 	.send_mlme = wifi_nrf_nl80211_send_mlme,
 	.get_wiphy = wifi_nrf_supp_get_wiphy,
 	.register_frame = wifi_nrf_supp_register_frame,
+	.get_capa = wifi_nrf_supp_get_capa,
 };
 #endif /* CONFIG_WPA_SUPP */
 #endif /* !CONFIG_NRF700X_RADIO_TEST */

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
@@ -1358,3 +1358,38 @@ void wifi_nrf_wpa_supp_event_mgmt_rx_callbk_fn(void *if_priv,
 			mlme_event->frequency,
 			mlme_event->rx_signal_dbm);
 }
+
+int wifi_nrf_supp_get_capa(void *if_priv, struct wpa_driver_capa *capa)
+{
+	enum wifi_nrf_status status = WIFI_NRF_STATUS_SUCCESS;
+	struct wifi_nrf_vif_ctx_zep *vif_ctx_zep = NULL;
+	struct wifi_nrf_ctx_zep *rpu_ctx_zep = NULL;
+
+	if (!if_priv || !capa) {
+		LOG_ERR("%s: Invalid parameters\n", __func__);
+		goto out;
+	}
+
+	vif_ctx_zep = if_priv;
+	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
+
+	/* TODO: Get these from RPU*/
+	os_memset(capa, 0, sizeof(*capa));
+	/* Use SME */
+	capa->flags = 0;
+	capa->flags |= WPA_DRIVER_FLAGS_SME;
+	capa->flags |= WPA_DRIVER_FLAGS_SAE;
+	capa->flags |= WPA_DRIVER_FLAGS_SET_KEYS_AFTER_ASSOC_DONE;
+	capa->rrm_flags |= WPA_DRIVER_FLAGS_SUPPORT_RRM;
+
+	capa->enc |= WPA_DRIVER_CAPA_ENC_WEP40 |
+			WPA_DRIVER_CAPA_ENC_WEP104 |
+			WPA_DRIVER_CAPA_ENC_TKIP |
+			WPA_DRIVER_CAPA_ENC_CCMP |
+			WPA_DRIVER_CAPA_ENC_CCMP |
+			WPA_DRIVER_CAPA_ENC_CCMP_256 |
+			WPA_DRIVER_CAPA_ENC_GCMP_256;
+
+out:
+	return status;
+}

--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 903c774b73802123e165dc001368406642d47972
+      revision: c1f1e0593d5bde73ba5d512b44fb765472829574
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 34b3ac78780f861fb6a6eeffa42e6c7242c4eec9


### PR DESCRIPTION
Advertise encryption support to the WPA supplicant.

Fixes SHEL-800 (WEP not working).

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>