### PR TITLE
lib: ftp_client: handle FTP_DATA_TIMEOUT_SEC

### DIFF
--- a/subsys/net/lib/ftp_client/src/ftp_client.c
+++ b/subsys/net/lib/ftp_client/src/ftp_client.c
@@ -351,9 +351,6 @@ static int poll_data_task_done(void)
 
 	do {
 		ret = do_ftp_recv_ctrl(true, FTP_CODE_226);
-		if (ret < 0) {
-			break;
-		}
 		if (ret == FTP_CODE_226) {
 			break;
 		}
@@ -365,6 +362,8 @@ static int poll_data_task_done(void)
 				client.ctrl_callback(ctrl_buf, strlen(ctrl_buf));
 				break;
 			}
+		} else if (ret < 0) {
+			break;
 		}
 	} while (1);
 


### PR DESCRIPTION
Make FTP client to wait until FTP_DATA_TIMEOUT_SEC seconds while receiving control response from FTP server.

Reference PR#9637

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>