### PR TITLE
samples: matter: lock: add QSPI parititions for wifi/thread variants

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -202,7 +202,9 @@ Thread samples
 Matter samples
 --------------
 
-|no_changes_yet_note|
+* :ref:`matter_lock_sample`:
+
+  * Added `thread_wifi_switched` build type that enables switching between Thread and Wi-Fi network support in the field.
 
 NFC samples
 -----------

--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -18,7 +18,9 @@ if(CONF_FILE)
     get_filename_component(CONFIG_FILE_NAME ${CONF_FILE} NAME)
 endif()
 
-if(NOT CONFIG_FILE_NAME STREQUAL "prj_no_dfu.conf")
+if(CONFIG_FILE_NAME STREQUAL "prj_thread_wifi_switched.conf")
+    set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_thread_wifi_switched.yml)
+elseif(NOT CONFIG_FILE_NAME STREQUAL "prj_no_dfu.conf")
     set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static_dfu.yml)
 endif()
 

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -26,6 +26,15 @@ config STATE_LEDS
 	  the device into a network or the factory reset initiation. Note that setting this option to
 	  'n' does not disable the LED indicating the state of the simulated bolt.
 
+config THREAD_WIFI_SWITCHING
+	bool "Switching between Thread and Wi-Fi network support"
+	depends on SOC_SERIES_NRF53X
+	select EXPERIMENTAL
+	help
+	  Enable the functionality that allows a user to switch between Matter over Thread and Matter
+	  over Wi-Fi variants of the application, stored in the respective partitions in the external
+	  flash memory.
+
 # Sample configuration used for Thread networking
 if NET_L2_OPENTHREAD
 

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -91,6 +91,7 @@ This sample supports the following build types, depending on the selected board:
 
 * ``debug`` -- Debug version of the application - can be used to enable additional features for verifying the application behavior, such as logs or command-line shell.
 * ``release`` -- Release version of the application - can be used to enable only the necessary application functionalities to optimize its performance.
+* ``thread_wifi_switched`` -- Debug version of the application with the ability to switch between Thread and Wi-Fi network support in the field - can be used for the nRF5340 DK with the nRF7002 EK shield attached.
 * ``no_dfu`` -- Debug version of the application without Device Firmware Upgrade feature support - can be used for the nRF52840 DK, nRF5340 DK, nRF7002 DK, and nRF21540 DK.
 
 .. note::

--- a/samples/matter/lock/child_image/hci_rpmsg/prj_thread_wifi_switched.conf
+++ b/samples/matter/lock/child_image/hci_rpmsg/prj_thread_wifi_switched.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.hci_rpmsg.defaults to set options common for all
+# samples using hci_rpmsg. This file should contain only options specific for this sample
+# hci_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.hci_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/lock/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_thread_wifi_switched.overlay
+++ b/samples/matter/lock/child_image/mcuboot/boards/nrf5340dk_nrf5340_cpuapp_thread_wifi_switched.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};

--- a/samples/matter/lock/child_image/mcuboot/prj_thread_wifi_switched.conf
+++ b/samples/matter/lock/child_image/mcuboot/prj_thread_wifi_switched.conf
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.mcuboot.defaults to set options common for all
+# samples using mcuboot. This file should contain only options specific for this sample
+# mcuboot configuration or overrides of default values.
+
+CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
+
+# Bootloader size optimization
+# Disable not used modules that cannot be set in Kconfig.mcuboot.defaults due to overriding
+# in board files.
+CONFIG_CONSOLE=n
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n
+CONFIG_USE_SEGGER_RTT=n
+CONFIG_GPIO=n

--- a/samples/matter/lock/child_image/multiprotocol_rpmsg/prj_thread_wifi_switched.conf
+++ b/samples/matter/lock/child_image/multiprotocol_rpmsg/prj_thread_wifi_switched.conf
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This target uses Kconfig.multiprotocol_rpmsg.defaults to set options common for all
+# samples using multiprotocol_rpmsg. This file should contain only options specific for this sample
+# multiprotocol_rpmsg configuration or overrides of default values.
+
+# Disable not used modules that cannot be set in Kconfig.multiprotocol_rpmsg.defaults due to overriding
+# in board files.
+
+CONFIG_SERIAL=n
+CONFIG_UART_CONSOLE=n

--- a/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_thread_wifi_switched.yml
+++ b/samples/matter/lock/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_thread_wifi_switched.yml
@@ -1,0 +1,96 @@
+mcuboot:
+    address: 0x0
+    size: 0x8000
+    region: flash_primary
+mcuboot_pad:
+    address: 0x8000
+    size: 0x200
+app:
+    address: 0x8200
+    size: 0xf2e00
+mcuboot_primary:
+    orig_span: &id001
+        - mcuboot_pad
+        - app
+    span: *id001
+    address: 0x8000
+    size: 0xf3000
+    region: flash_primary
+mcuboot_primary_app:
+    orig_span: &id002
+        - app
+    span: *id002
+    address: 0x8200
+    size: 0xf2e00
+factory_data:
+    address: 0xfb000
+    size: 0x1000
+    region: flash_primary
+settings_storage:
+    address: 0xfc000
+    size: 0x4000
+    region: flash_primary
+mcuboot_primary_1:
+    address: 0x0
+    size: 0x40000
+    device: flash_ctrl
+    region: ram_flash
+mcuboot_secondary:
+    address: 0x0
+    size: 0xf3000
+    device: MX25R64
+    region: external_flash
+mcuboot_secondary_1:
+    address: 0xf3000
+    size: 0x40000
+    device: MX25R64
+    region: external_flash
+app_1_core_app_download:
+    address: 0x133000
+    size: 0xf3000
+    device: MX25R64
+    region: external_flash
+app_1_core_net_download:
+    address: 0x226000
+    size: 0x40000
+    device: MX25R64
+    region: external_flash
+app_2_core_app_download:
+    address: 0x266000
+    size: 0xf3000
+    device: MX25R64
+    region: external_flash
+app_2_core_net_download:
+    address: 0x359000
+    size: 0x40000
+    device: MX25R64
+    region: external_flash
+app_1_core_app:
+    address: 0x399000
+    size: 0xf3000
+    device: MX25R64
+    region: external_flash
+app_1_core_net:
+    address: 0x48c000
+    size: 0x40000
+    device: MX25R64
+    region: external_flash
+app_2_core_app:
+    address: 0x4cc000
+    size: 0xf3000
+    device: MX25R64
+    region: external_flash
+app_2_core_net:
+    address: 0x5bf000
+    size: 0x40000
+    device: MX25R64
+    region: external_flash
+external_flash:
+    address: 0x5ff000
+    size: 0x201000
+    device: MX25R64
+    region: external_flash
+pcd_sram:
+    address: 0x20000000
+    size: 0x2000
+    region: sram_primary

--- a/samples/matter/lock/prj_thread_wifi_switched.conf
+++ b/samples/matter/lock/prj_thread_wifi_switched.conf
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# This sample uses Kconfig.defaults to set options common for all
+# samples. This file should contain only options specific for this sample
+# or overrides of default values.
+
+# Enable CHIP
+CONFIG_CHIP=y
+CONFIG_CHIP_PROJECT_CONFIG="src/chip_project_config.h"
+# 32774 == 0x8006 (example lock-app)
+CONFIG_CHIP_DEVICE_PRODUCT_ID=32774
+CONFIG_STD_CPP14=y
+
+# Add support for LEDs and buttons on Nordic development kits
+CONFIG_DK_LIBRARY=y
+
+# Bluetooth Low Energy configuration
+CONFIG_BT_DEVICE_NAME="MatterLock"
+
+# Other settings
+CONFIG_THREAD_NAME=y
+CONFIG_MPU_STACK_GUARD=y
+CONFIG_RESET_ON_FATAL_ERROR=n
+
+# Enable switching between Thread and Wi-Fi variants
+CONFIG_THREAD_WIFI_SWITCHING=y


### PR DESCRIPTION
Define partitions in the external flash of nRF5340 DK to support switching between Wi-Fi and Thread variants of the Lock application.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>