### PR TITLE
Bluetooth: Mesh: Reduce number of maximum scenes

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -653,11 +653,14 @@ menuconfig BT_MESH_SCENE_SRV
 
 config BT_MESH_SCENES_MAX
 	int "Max number of scenes"
-	default 4
+	default 16
 	range 1 65535
 	depends on BT_MESH_SCENE_SRV
 	help
-	  Max number of scenes that can be stored by a single Scene Server.
+	  Maximum number of scenes that can be stored by a single Scene Server.
+	  According to the specification, this value should be 16.
+	  The Bluetooth Mesh Model specification v1.0.1 (MshMDLv1.0.1) defines the
+	  Scene Register state as a 16-element array of 16-bit values representing a Scene Number.
 
 config BT_MESH_SCENE_CLI
 	bool "Scene Client"


### PR DESCRIPTION
Reduces the upper limit for configuring the maximum number of scene entries to 16.

MshMDLv 1.0.1 - 5.1.3.1: "The Scene Register state is a 16-element array of 16-bit values representing a Scene Number."

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>