### PR TITLE
shields: overlay : fix coex pins swap

### DIFF
--- a/boards/shields/nrf7002_ek/nrf7002_ek_coex.overlay
+++ b/boards/shields/nrf7002_ek/nrf7002_ek_coex.overlay
@@ -7,8 +7,8 @@
 	nrf_radio_coex: nrf7002-coex {
 		status = "okay";
 		compatible = "nordic,nrf700x-coex";
-		req-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;       /* D2 */
-		status0-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;   /* D3 */
+		status0-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;       /* D2 */
+		req-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;   /* D3 */
 		grant-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;    /* D4 */
 		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;  /* D6 */
 	};


### PR DESCRIPTION
Fix the req, status0 pins swap in the overlay file. This device pinout swap was taken care of in the DK but missed for the EK.

Signed-off-by: Bansidhar Mangalwedhekar <bansidhar.mangalwedhekar@nordicsemi.no>