### PR TITLE
manifest: MCUBoot: Skip updating sec counters

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -107,7 +107,7 @@ manifest:
       revision: 903c774b73802123e165dc001368406642d47972
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 20f8d86f787331daa6812a32f12077189cebd31f
+      revision: 34b3ac78780f861fb6a6eeffa42e6c7242c4eec9
       path: bootloader/mcuboot
     - name: mbedtls-nrf
       path: mbedtls


### PR DESCRIPTION
Nordic specific code for MCUBOOT is needed to
support hardware security counters.

Ref: NCSDK-9045

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>