### PR TITLE
provision.py: Fix provision size check

### DIFF
--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -16,6 +16,7 @@ import os
 # Size of LCS storage in OTP in bytes
 LCS_STATE_SIZE = 0x8
 IMPLEMENTATION_ID_SIZE = 0x20
+NUM_BYTES_PROVISIONED_ELSEWHERE = LCS_STATE_SIZE + IMPLEMENTATION_ID_SIZE
 
 def generate_provision_hex_file(s0_address, s1_address, hashes, provision_address, output, max_size,
                                 num_counter_slots_version):
@@ -89,9 +90,11 @@ def main():
 
     s0_address = args.s0_addr
     s1_address = args.s1_addr if args.s1_addr is not None else s0_address
-    # The LCS is stored in the OTP before the rest of the provisioning
-    # data so add it to the given base address
-    provision_address = args.provision_addr + LCS_STATE_SIZE + IMPLEMENTATION_ID_SIZE
+    # The LCS and implementation ID is stored in the OTP before the
+    # rest of the provisioning data so add it to the given base
+    # address
+    provision_address = args.provision_addr + NUM_BYTES_PROVISIONED_ELSEWHERE
+    max_size          = args.max_size       - NUM_BYTES_PROVISIONED_ELSEWHERE
 
     hashes = []
     if args.public_key_files:
@@ -106,7 +109,7 @@ def main():
                                 hashes=hashes,
                                 provision_address=provision_address,
                                 output=args.output,
-                                max_size=args.max_size,
+                                max_size=max_size,
                                 num_counter_slots_version=args.num_counter_slots_version)
 
 


### PR DESCRIPTION
Fix the provision size check.

provision.py would accept the size even though it was NUM_BYTES_PROVISIONED_ELSEWHERE too big.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>