### PR TITLE
applications: nrf5340_audio: Enable sensor

### DIFF
--- a/applications/nrf5340_audio/Kconfig.defaults
+++ b/applications/nrf5340_audio/Kconfig.defaults
@@ -61,6 +61,10 @@ config NFCT_PINS_AS_GPIOS
 	bool
 	default y
 
+config SENSOR
+	bool
+	default y
+
 # I2S
 config NRFX_I2S
 	bool


### PR DESCRIPTION
Sensor needs to be enabled for all build configurations

Signed-off-by: Kristoffer Rist Skøien <kristoffer.skoien@nordicsemi.no>