### PR TITLE
west: Zephyr revision update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 8fb465f43f6a90ac4c4ce89265047e04f7d5ee5b
+      revision: pull/1011/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This commit updates zephyr revision to the version with spsc_pbuff cache updated.

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>