### PR TITLE
cmake: Fix overlay additions of child images not persisting

### DIFF
--- a/cmake/extensions.cmake
+++ b/cmake/extensions.cmake
@@ -96,6 +96,7 @@ function(add_overlay image overlay_file overlay_type)
     set(${image}_${overlay_type} "${old_overlays};${overlay_file}" CACHE STRING
       "Extra config fragments for ${image} child image" FORCE
     )
+    set(${image}_${overlay_type} "${old_overlays};${overlay_file}" PARENT_SCOPE)
   endif()
 endfunction()
 


### PR DESCRIPTION
Fixes an issue whereby child image overlays were added but were not processed until cmake was re-ran on the project causing an invalid build configuration.