### PR TITLE
net: lib: azure_iot_hub: Ignore state change to the same state

### DIFF
--- a/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
+++ b/subsys/net/lib/azure_iot_hub/src/azure_iot_hub.c
@@ -83,6 +83,12 @@ AZ_HUB_STATIC void iot_hub_state_set(enum iot_hub_state new_state)
 {
 	bool notify_error = false;
 
+	if (iot_hub_state == new_state) {
+		LOG_DBG("Skipping transition to the same state (%s)",
+			state_name_get(iot_hub_state));
+		return;
+	}
+
 	/* Check for legal state transitions. */
 	switch (iot_hub_state) {
 	case STATE_UNINIT:


### PR DESCRIPTION
Fixes an issue where error messages are printed when the library attempts to set the state to the same as current state. This may happen during normal operation and should not be treated as an error situation.

Fixes CIA-848

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>