### PR TITLE
manifest: Pull TF-M fix for crypto stack size not defined

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -119,7 +119,7 @@ manifest:
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
-      revision: 1b7ee9d3cb09cb0081f49c3d20220cdf7d5f7b3c
+      revision: f2ae8d497d4411147a372fbe5558670f09189650
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter


### PR DESCRIPTION
Pull fix for TF-M crypto stack size not built when NCS TF-M is built in the vanilla configuration.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>