### PR TITLE
subsys: bl_storage: Change API for counters

### DIFF
--- a/include/bl_storage.h
+++ b/include/bl_storage.h
@@ -33,6 +33,12 @@ extern "C" {
 /* We truncate the 32 byte sha256 down to 16 bytes before storing it */
 #define SB_PUBLIC_KEY_HASH_LEN 16
 
+/* Type referring to counter collection. */
+#define TYPE_COUNTERS 1
+
+/* Counter used by NSIB to check the firmware version */
+#define BL_MONOTONIC_COUNTERS_DESC_NSIB 0x1
+
 /** Storage for the PRoT Security Lifecycle state, that consists of 4 states:
  *  - Device assembly and test
  *  - PRoT Provisioning
@@ -134,17 +140,26 @@ void invalidate_public_key(uint32_t key_idx);
 /**
  * @brief Get the number of monotonic counter slots.
  *
- * @return The number of slots. If the provision page does not contain the
- *         information, 0 is returned.
+ * @param[in]   counter_desc  Counter description.
+ * @param[out]  counter_slots Number of slots occupied by the counter.
+ *
+ * @retval 0        Success
+ * @retval -EINVAL  Cannot find counters with description @p counter_desc or the pointer to
+ *                  @p counter_slots is NULL.
  */
-uint16_t num_monotonic_counter_slots(void);
+int num_monotonic_counter_slots(uint16_t counter_desc, uint16_t *counter_slots);
 
 /**
  * @brief Get the current HW monotonic counter.
  *
- * @return The current value of the counter.
+ * @param[in]  counter_desc  Counter description.
+ * @param[out] counter_value The value of the current counter.
+ *
+ * @retval 0        Success
+ * @retval -EINVAL  Cannot find counters with description @p counter_desc or the pointer to
+ *                  @p counter_value is NULL.
  */
-uint16_t get_monotonic_counter(void);
+int get_monotonic_counter(uint16_t counter_desc, uint16_t *counter_value);
 
 /**
  * @brief Set the current HW monotonic counter.
@@ -153,6 +168,7 @@ uint16_t get_monotonic_counter(void);
  *       Values are stored with their bits flipped. This is to squeeze one more
  *       value out of the counter.
  *
+ * @param[in]  counter_desc Counter description.
  * @param[in]  new_counter  The new counter value. Must be larger than the
  *                          current value.
  *
@@ -162,7 +178,7 @@ uint16_t get_monotonic_counter(void);
  * @retval -ENOMEM  There are no more free counter slots (see
  *                  @kconfig{CONFIG_SB_NUM_VER_COUNTER_SLOTS}).
  */
-int set_monotonic_counter(uint16_t new_counter);
+int set_monotonic_counter(uint16_t counter_desc, uint16_t new_counter);
 
 /**
  * @brief The PSA life cycle states a device can be in.

--- a/include/bl_validation.h
+++ b/include/bl_validation.h
@@ -76,14 +76,15 @@ struct bl_validate_fw_ext_api {
  */
 int set_monotonic_version(uint16_t version, uint16_t slot);
 
-
 /** Read version and slot from monotonic counter.
  *
  * @param[out]  slot_out  Slot where firmware is located. Can be NULL.
+ * @param[out]  version   Firmware version
  *
- * @return Firmware version
+ * @retval 0       Success
+ * @retval -EINVAL Error during reading the version or *version is NULL.
  */
-uint16_t get_monotonic_version(uint16_t *slot_out);
+int get_monotonic_version(uint16_t *slot_out, uint16_t *version);
 
   /** @} */
 

--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -69,7 +69,15 @@ static void validate_and_boot(const struct fw_info *fw_info, uint16_t slot)
 
 	printk("Firmware version %d\r\n", fw_info->version);
 
-	if (fw_info->version > get_monotonic_version(NULL)) {
+	uint16_t version;
+	int err = get_monotonic_version(NULL, &version);
+
+	if (err) {
+		printk("Failed to read the monotonic counter!\n\r");
+		return;
+	}
+
+	if (fw_info->version > version) {
 		set_monotonic_version(fw_info->version, slot);
 	}
 

--- a/subsys/bootloader/bl_storage/bl_storage.c
+++ b/subsys/bootloader/bl_storage/bl_storage.c
@@ -12,16 +12,19 @@
 #include <nrfx_nvmc.h>
 #include <pm_config.h>
 
-/** A single monotonic counter. It consists of a description value, a 'type',
- *  to know what this counter counts. Further, it has a number of slots
- *  allocated to it. Each time the counter is updated, a new slot is written.
- *  This way, the counter can be updated without erasing anything. This is
- *  necessary so the counter can be used in the OTP section of the UICR
- *  (available on e.g. nRF91 and nRF53).
+/** This library implements monotonic counters where each time the
+ *  counter is increased, a new slot is written. This way, the
+ *  counter can be updated without erase. This is, among other things,
+ *  necessary so the counter can be used in the OTP section of the
+ *  UICR (available on e.g. nRF91 and nRF53).
  */
 struct monotonic_counter {
-	uint16_t description; /* Counter description. What the counter is used for. See COUNTER_DESC_*. */
-	uint16_t num_counter_slots; /* Number of entries in 'counter_slots' list. */
+	/* Counter description. What the counter is used for. See
+	 * BL_MONOTONIC_COUNTERS_DESC_*.
+	 */
+	uint16_t description;
+	/* Number of entries in 'counter_slots' list. */
+	uint16_t num_counter_slots;
 	uint16_t counter_slots[1];
 };
 
@@ -139,7 +142,7 @@ void invalidate_public_key(uint32_t key_idx)
 /** Get the counter_collection data structure in the provision data. */
 static const struct counter_collection *get_counter_collection(void)
 {
-	struct counter_collection *collection = (struct counter_collection *)
+	const struct counter_collection *collection = (struct counter_collection *)
 		&BL_STORAGE->key_data[num_public_keys_read()];
 	return nrfx_nvmc_otp_halfword_read((uint32_t)&collection->type) == TYPE_COUNTERS
 		? collection : NULL;
@@ -152,59 +155,75 @@ static const struct counter_collection *get_counter_collection(void)
  */
 static const struct monotonic_counter *get_counter_struct(uint16_t description)
 {
-	const struct counter_collection *counters = get_counter_collection();
+	const struct counter_collection *cnt_collection = get_counter_collection();
 
-	if (counters == NULL) {
+	if (cnt_collection == NULL) {
 		return NULL;
 	}
 
-	const struct monotonic_counter *current = counters->counters;
+	const struct monotonic_counter *current = cnt_collection->counters;
+	size_t num_counters = nrfx_nvmc_otp_halfword_read((uint32_t)&cnt_collection->num_counters);
 
-	for (size_t i = 0; i < nrfx_nvmc_otp_halfword_read(
-		(uint32_t)&counters->num_counters); i++) {
-		uint16_t num_slots = nrfx_nvmc_otp_halfword_read(
-					(uint32_t)&current->num_counter_slots);
-
+	for (size_t i = 0; i < num_counters; i++) {
 		if (nrfx_nvmc_otp_halfword_read((uint32_t)&current->description) == description) {
 			return current;
 		}
 
+		uint32_t num_counter_slots = (uint32_t)&current->num_counter_slots;
+		uint16_t num_slots = nrfx_nvmc_otp_halfword_read(num_counter_slots);
 		current = (const struct monotonic_counter *)
 					&current->counter_slots[num_slots];
 	}
 	return NULL;
 }
 
-
-uint16_t num_monotonic_counter_slots(void)
+int num_monotonic_counter_slots(uint16_t counter_desc, uint16_t *counter_slots)
 {
 	const struct monotonic_counter *counter
-			= get_counter_struct(COUNTER_DESC_VERSION);
+			= get_counter_struct(counter_desc);
 	uint16_t num_slots = 0;
 
-	if (counter != NULL) {
-		num_slots = nrfx_nvmc_otp_halfword_read((uint32_t)&counter->num_counter_slots);
+	if (counter == NULL || counter_slots == NULL) {
+		return -EINVAL;
 	}
-	return num_slots != 0xFFFF ? num_slots : 0;
-}
 
+	num_slots = nrfx_nvmc_otp_halfword_read((uint32_t)&counter->num_counter_slots);
+	if (num_slots == 0xFFFF) {
+		/* We consider the 0xFFFF as invalid since it is the default value of the OTP */
+		*counter_slots = 0;
+		return -EINVAL;
+	}
+
+	*counter_slots = num_slots;
+	return 0;
+}
 
 /** Function for getting the current value and the first free slot.
  *
- * @param[out]  free_slot  Pointer to the first free slot. Can be NULL.
+ * @param[in]   counter_desc  Counter description
+ * @param[out]  counter_value The current value of the requested counter.
+ * @param[out]  free_slot     Pointer to the first free slot. Can be NULL.
  *
- * @return The current value of the counter (the highest value before the first
- *         free slot).
+ * @retval 0        Success
+ * @retval -EINVAL  Cannot find counters with description @p counter_desc or the pointer to
+ *                  @p counter_value is NULL.
  */
-static uint16_t get_counter(const uint16_t **free_slot)
+static int get_counter(uint16_t counter_desc, uint16_t *counter_value, const uint16_t **free_slot)
 {
 	uint16_t highest_counter = 0;
 	const uint16_t *addr = NULL;
-	const uint16_t *slots =
-			get_counter_struct(COUNTER_DESC_VERSION)->counter_slots;
-	uint16_t num_slots = num_monotonic_counter_slots();
+	const struct monotonic_counter *counter_obj = get_counter_struct(counter_desc);
+	const uint16_t *slots;
+	uint16_t num_counter_slots;
 
-	for (uint32_t i = 0; i < num_slots; i++) {
+	if (counter_obj == NULL || counter_value == NULL) {
+		return -EINVAL;
+	}
+
+	slots = counter_obj->counter_slots;
+	num_counter_slots = nrfx_nvmc_otp_halfword_read((uint32_t)&counter_obj->num_counter_slots);
+
+	for (uint32_t i = 0; i < num_counter_slots; i++) {
 		uint16_t counter = ~nrfx_nvmc_otp_halfword_read((uint32_t)&slots[i]);
 
 		if (counter == 0) {
@@ -219,22 +238,28 @@ static uint16_t get_counter(const uint16_t **free_slot)
 	if (free_slot != NULL) {
 		*free_slot = addr;
 	}
-	return highest_counter;
+
+	*counter_value = highest_counter;
+	return 0;
 }
 
-
-uint16_t get_monotonic_counter(void)
+int get_monotonic_counter(uint16_t counter_desc, uint16_t *counter_value)
 {
-	return get_counter(NULL);
+	return get_counter(counter_desc, counter_value, NULL);
 }
 
-
-int set_monotonic_counter(uint16_t new_counter)
+int set_monotonic_counter(uint16_t counter_desc, uint16_t new_counter)
 {
 	const uint16_t *next_counter_addr;
-	uint16_t counter = get_counter(&next_counter_addr);
+	uint16_t current_cnt_value;
+	int err;
 
-	if (new_counter <= counter) {
+	err = get_counter(counter_desc, &current_cnt_value, &next_counter_addr);
+	if (err != 0) {
+		return err;
+	}
+
+	if (new_counter <= current_cnt_value) {
 		/* Counter value must increase. */
 		return -EINVAL;
 	}

--- a/tests/subsys/bootloader/bl_storage/src/main.c
+++ b/tests/subsys/bootloader/bl_storage/src/main.c
@@ -11,25 +11,44 @@
 
 void test_monotonic_counter(void)
 {
-	int ret;
+	uint16_t counter_value;
+	uint16_t counter_slots;
+	int err;
+	/* The initial counter is written by B0 and the function
+	 * set_monotonic_version.  This function calculates the counter
+	 * with the formula: counter = (version << 1) | !slot So for the
+	 * version 10 (as configured in the FW info of this test) the
+	 * value of the counter will actually be 21 when we start this
+	 * test.
+	 */
+	err = get_monotonic_counter(BL_MONOTONIC_COUNTERS_DESC_NSIB, &counter_value);
+	zassert_equal(0, err, NULL);
+	printk("Counter value from get_montonic_counter() = %d\n", counter_value);
 
-	printk("get_monotonic_counter() = %d\n", get_monotonic_counter());
+	zassert_equal(0,
+		num_monotonic_counter_slots(BL_MONOTONIC_COUNTERS_DESC_NSIB, &counter_slots), NULL);
 
-	zassert_equal(CONFIG_SB_NUM_VER_COUNTER_SLOTS,
-		num_monotonic_counter_slots(), NULL);
-	zassert_equal(CONFIG_FW_INFO_FIRMWARE_VERSION,
-		get_monotonic_counter() >> 1,
-		NULL);
+	zassert_equal(CONFIG_SB_NUM_VER_COUNTER_SLOTS, counter_slots, NULL);
+
+	zassert_equal(CONFIG_FW_INFO_FIRMWARE_VERSION, counter_value >> 1, NULL);
+
 	zassert_equal(-EINVAL,
-		set_monotonic_counter(CONFIG_FW_INFO_FIRMWARE_VERSION << 1),
+		set_monotonic_counter(BL_MONOTONIC_COUNTERS_DESC_NSIB,
+							  CONFIG_FW_INFO_FIRMWARE_VERSION << 1),
 		NULL);
-	zassert_equal(-EINVAL, set_monotonic_counter(0), NULL);
-	ret = set_monotonic_counter((CONFIG_FW_INFO_FIRMWARE_VERSION + 1) << 1);
-	zassert_equal(0, ret, "ret %d\r\n", ret);
-	zassert_equal(CONFIG_FW_INFO_FIRMWARE_VERSION + 1,
-		get_monotonic_counter() >> 1, NULL);
+
+	zassert_equal(-EINVAL, set_monotonic_counter(BL_MONOTONIC_COUNTERS_DESC_NSIB, 0), NULL);
+
+	err = set_monotonic_counter(BL_MONOTONIC_COUNTERS_DESC_NSIB,
+					(CONFIG_FW_INFO_FIRMWARE_VERSION + 1) << 1);
+	zassert_equal(0, err, NULL);
+
+	err = get_monotonic_counter(BL_MONOTONIC_COUNTERS_DESC_NSIB, &counter_value);
+	zassert_equal(0, err, NULL);
+	zassert_equal(CONFIG_FW_INFO_FIRMWARE_VERSION + 1, counter_value >> 1, NULL);
+
 	printk("Rebooting. Should fail to validate because of "
-		"monotonic counter.\n");
+		   "monotonic counter.\n");
 	sys_reboot(0);
 }
 


### PR DESCRIPTION
The montonic_counter implementation has some code for supporting multiple counters, but the API only supports one counter. This commit updates the API and finalizes this support, but still does not add another counter.

Introduce a counter description into the monotonic_counter API to be able to distinguish between multiple counters.

Also introduce some error handling in case the counters are not found.

bl_validation uses the affected API and has been updated. It's API also needed to be updated to deal with new error handling.

Ref: NCSDK-9045

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>