### PR TITLE
cmake: nsib: Refactor to avoid unnecessary indirection

### DIFF
--- a/subsys/bootloader/cmake/debug_keys.cmake
+++ b/subsys/bootloader/cmake/debug_keys.cmake
@@ -7,12 +7,12 @@
 
 set(PRIV_CMD
   ${PYTHON_EXECUTABLE}
-  ${NRF_BOOTLOADER_SCRIPTS}/keygen.py --private
+  ${NRF_DIR}/scripts/bootloader/keygen.py --private
   )
 
 set(PUB_CMD
   ${PYTHON_EXECUTABLE}
-  ${NRF_BOOTLOADER_SCRIPTS}/keygen.py --public
+  ${NRF_DIR}/scripts/bootloader/keygen.py --public
   )
 
 # Check if PEM file is specified by user, if not, create one.

--- a/subsys/bootloader/cmake/provision_hex.cmake
+++ b/subsys/bootloader/cmake/provision_hex.cmake
@@ -10,8 +10,6 @@ if (DEFINED CONFIG_SB_MONOTONIC_COUNTER)
 endif()
 
 # Build and include hex file containing provisioned data for the bootloader.
-set(NRF_SCRIPTS            ${NRF_DIR}/scripts)
-set(NRF_BOOTLOADER_SCRIPTS ${NRF_SCRIPTS}/bootloader)
 set(PROVISION_HEX_NAME     provision.hex)
 set(PROVISION_HEX          ${PROJECT_BINARY_DIR}/${PROVISION_HEX_NAME})
 
@@ -63,7 +61,7 @@ add_custom_command(
   ${PROVISION_HEX}
   COMMAND
   ${PYTHON_EXECUTABLE}
-  ${NRF_BOOTLOADER_SCRIPTS}/provision.py
+  ${NRF_DIR}/scripts/bootloader/provision.py
   ${s0_arg}
   ${s1_arg}
   --provision-addr $<TARGET_PROPERTY:partition_manager,PM_PROVISION_ADDRESS>

--- a/subsys/bootloader/cmake/sign.cmake
+++ b/subsys/bootloader/cmake/sign.cmake
@@ -15,7 +15,7 @@ set(SIGNATURE_PUBLIC_KEY_FILE ${GENERATED_PATH}/public.pem)
 if (CONFIG_SB_SIGNING_PYTHON)
   set(PUB_GEN_CMD
     ${PYTHON_EXECUTABLE}
-    ${NRF_BOOTLOADER_SCRIPTS}/keygen.py
+    ${NRF_DIR}/scripts/bootloader/keygen.py
     --public
     --in ${SIGNATURE_PRIVATE_KEY_FILE}
     --out ${SIGNATURE_PUBLIC_KEY_FILE}
@@ -98,7 +98,7 @@ foreach (slot ${slots})
 
   set(hash_cmd
     ${PYTHON_EXECUTABLE}
-    ${NRF_BOOTLOADER_SCRIPTS}/hash.py
+    ${NRF_DIR}/scripts/bootloader/hash.py
     --in ${to_sign}
     > ${hash_file}
     )
@@ -106,7 +106,7 @@ foreach (slot ${slots})
   if (CONFIG_SB_SIGNING_PYTHON)
     set(sign_cmd
       ${PYTHON_EXECUTABLE}
-      ${NRF_BOOTLOADER_SCRIPTS}/do_sign.py
+      ${NRF_DIR}/scripts/bootloader/do_sign.py
       --private-key ${SIGNATURE_PRIVATE_KEY_FILE}
       --in ${hash_file}
       > ${signature_file}
@@ -117,7 +117,7 @@ foreach (slot ${slots})
       -sha256
       -sign ${SIGNATURE_PRIVATE_KEY_FILE} ${hash_file} |
       ${PYTHON_EXECUTABLE}
-      ${NRF_BOOTLOADER_SCRIPTS}/asn1parse.py
+      ${NRF_DIR}/scripts/bootloader/asn1parse.py
       --alg ecdsa
       --contents signature
       > ${signature_file}
@@ -164,7 +164,7 @@ foreach (slot ${slots})
     ${signed_bin}
     COMMAND
     ${PYTHON_EXECUTABLE}
-    ${NRF_BOOTLOADER_SCRIPTS}/validation_data.py
+    ${NRF_DIR}/scripts/bootloader/validation_data.py
     --input ${to_sign}
     --output-hex ${signed_hex}
     --output-bin ${signed_bin}


### PR DESCRIPTION
It is bad practice to use variables for paths unless they are either very long, heavily used, or configurable.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>