### PR TITLE
Bluetooth: Controller: Add support for receiving PASTs

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -25,6 +25,7 @@ config BT_LL_SOFTDEVICE
 	select BT_CTLR_ADV_PERIODIC_SUPPORT
 	select BT_CTLR_SYNC_PERIODIC_SUPPORT
 	select BT_CTLR_SYNC_TRANSFER_SENDER_SUPPORT
+	select BT_CTLR_SYNC_TRANSFER_RECEIVER_SUPPORT
 	select BT_CTLR_PHY_2M_SUPPORT if HAS_HW_NRF_RADIO_BLE_2M
 	select BT_CTLR_PHY_CODED_SUPPORT if HAS_HW_NRF_RADIO_BLE_CODED
 	select BT_HAS_HCI_VS
@@ -314,5 +315,13 @@ config BT_CTLR_SYNC_TRANSFER_SENDER
 	  Enable support for sending Periodic Advertising Sync Transfer as
 	  defined in the Bluetooth Core Specification, Version 5.3 | Vol 6,
 	  Part B, Section 4.6.23.
+
+config BT_CTLR_SYNC_TRANSFER_RECEIVER
+	bool "Periodic Advertising Sync Transfer - Receiver [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  Enable support for receiving Periodic Advertising Sync Transfer as
+	  defined in the Bluetooth Core Specification, Version 5.3 | Vol 6,
+	  Part B, Section 4.6.24.
 endmenu
 endif  # BT_LL_SOFTDEVICE

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -552,6 +552,22 @@ static int configure_supported_features(void)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER)) {
+		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+			err = sdc_support_periodic_adv_sync_transfer_receiver_central();
+			if (err) {
+				return -ENOTSUP;
+			}
+		}
+
+		if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+			err = sdc_support_periodic_adv_sync_transfer_receiver_peripheral();
+			if (err) {
+				return -ENOTSUP;
+			}
+		}
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
 		err = sdc_support_le_coded_phy();
 		if (err) {

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -356,6 +356,11 @@ static void supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_periodic_advertising_set_info_transfer = 1;
 #endif
 
+#if defined(CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER)
+	cmds->hci_le_set_periodic_advertising_sync_transfer_parameters = 1;
+	cmds->hci_le_set_default_periodic_advertising_sync_transfer_parameters = 1;
+#endif
+
 	cmds->hci_le_read_transmit_power = 1;
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
@@ -478,6 +483,9 @@ static void le_supported_features(sdc_hci_le_le_features_t *features)
 	features->le_periodic_advertising = 1;
 #ifdef CONFIG_BT_CTLR_SYNC_TRANSFER_SENDER
 	features->periodic_advertising_sync_transfer_sender = 1;
+#endif
+#ifdef CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER
+	features->periodic_advertising_sync_transfer_receiver = 1;
 #endif
 #endif
 
@@ -1040,6 +1048,18 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 			sizeof(sdc_hci_cmd_le_periodic_adv_set_info_transfer_return_t);
 		return sdc_hci_cmd_le_periodic_adv_set_info_transfer((void *)cmd_params,
 								     (void *)event_out_params);
+#endif
+
+#if defined(CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER)
+	case SDC_HCI_OPCODE_CMD_LE_SET_PERIODIC_ADV_SYNC_TRANSFER_PARAMS:
+		*param_length_out +=
+			sizeof(sdc_hci_cmd_le_set_periodic_adv_sync_transfer_params_return_t);
+		return sdc_hci_cmd_le_set_periodic_adv_sync_transfer_params(
+			(void *)cmd_params, (void *)event_out_params);
+
+	case SDC_HCI_OPCODE_CMD_LE_SET_DEFAULT_PERIODIC_ADV_SYNC_TRANSFER_PARAMS:
+		return sdc_hci_cmd_le_set_default_periodic_adv_sync_transfer_params(
+			(void *)cmd_params);
 #endif
 
 	default:


### PR DESCRIPTION
Enable support for receiving PAST in a central or peripheral role.

Signed-off-by: Timothy Keys <timothy.keys@nordicsemi.no>