### PR TITLE
lib: modem_info: fix RSRP reporting

### DIFF
--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -153,6 +153,7 @@ int modem_info_params_get(struct modem_param_info *modem)
 			&modem->network.nbiot_mode,
 			&modem->network.gps_mode,
 			&modem->network.apn,
+			&modem->network.rsrp,
 #endif
 #if IS_ENABLED(CONFIG_MODEM_INFO_ADD_SIM_ICCID)
 			&modem->sim.iccid,


### PR DESCRIPTION
Modem RSRP didn't get updated when modem_info_params_get() was called. Because of this for example the MQTT A-GPS requests sent to nRF Cloud always had -140 dBm RSRP.