### PR TITLE
tests: mcuboot: Fix license

### DIFF
--- a/tests/modules/mcuboot/direct_xip/child_image/mcuboot.conf
+++ b/tests/modules/mcuboot/direct_xip/child_image/mcuboot.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2022 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 CONFIG_BOOT_DIRECT_XIP=y


### PR DESCRIPTION
The license reference was using the old naming convention, switch to the new one.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>