### PR TITLE
cmake: multi image: place results from ncs_file() in cache

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -313,6 +313,15 @@ function(add_child_image_from_source)
         DTS ${ACI_NAME}_DTC_OVERLAY_FILE
         BUILD ${CONF_FILE_BUILD_TYPE}
         )
+      # Place the result in the CMake cache and remove local scoped variable.
+      foreach(file CONF_FILE DTC_OVERLAY_FILE)
+        if(DEFINED ${ACI_NAME}_${file})
+          set(${ACI_NAME}_${file} ${${ACI_NAME}_${file}} CACHE STRING
+            "Default ${ACI_NAME} configuration file" FORCE
+            )
+	  set(${ACI_NAME}_${file})
+        endif()
+      endforeach()
 
       # Check for configuration fragment. The contents of these are appended
       # to the project configuration, as opposed to the CONF_FILE which is used
@@ -330,11 +339,6 @@ function(add_child_image_from_source)
       set(child_image_dts_overlay ${ACI_CONF_DIR}/${ACI_NAME}.overlay)
       if (EXISTS ${child_image_dts_overlay})
         add_overlay_dts(${ACI_NAME} ${child_image_dts_overlay})
-      endif()
-      if(DEFINED ${ACI_NAME}_CONF_FILE)
-        set(${ACI_NAME}_CONF_FILE ${${ACI_NAME}_CONF_FILE} CACHE STRING
-          "Default ${ACI_NAME} configuration file"
-          )
       endif()
     endif()
     # Construct a list of variables that, when present in the root


### PR DESCRIPTION
When using ncs_file() for looking up configuration and overlay files for child images, then the result is returned in a local scoped variable.

To ensure correct behavior between CMake invocations then this result must be stored in the CMake cache.
To further increase the robustness of the build system then the local scoped variable is cleared so that only the CMake cache variable remains.

This fixes an issue where Kconfig fragments or devicetree overlays for a child image would only be applied on first CMake invocation but not on subsequent invocations because the file(s) would not be stored in the CMake cache and the algorithm for applying child image board specific files are only executed on first run.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

------

This PR supersedes #9679  