### PR TITLE
lib: location: A-GPS improvements

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -298,6 +298,10 @@ Other libraries
 
 * :ref:`lib_location` library:
 
+  * Updated:
+
+    * GNSS filtered ephemerides are no longer used when the :kconfig:option:`CONFIG_NRF_CLOUD_AGPS_FILTERED_RUNTIME` Kconfig option is enabled.
+
   * Fixed:
 
     * An issue causing the A-GPS data download to be delayed until the RRC connection release.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -296,7 +296,11 @@ Libraries for NFC
 Other libraries
 ---------------
 
-|no_changes_yet_note|
+* :ref:`lib_location` library:
+
+  * Fixed:
+
+    * An issue causing the A-GPS data download to be delayed until the RRC connection release.
 
 * Secure Partition Manager (SPM):
 

--- a/lib/location/method_gnss.c
+++ b/lib/location/method_gnss.c
@@ -46,7 +46,7 @@ BUILD_ASSERT(
 	"CONFIG_LOCATION_METHOD_GNSS_PGPS_EXTERNAL must be enabled");
 #endif
 
-/* Maximun waiting time before GNSS is started regardless of RRC or PSM state [min]. This prevents
+/* Maximum waiting time before GNSS is started regardless of RRC or PSM state [min]. This prevents
  * Location library from getting stuck indefinitely if the application keeps LTE connection
  * constantly active.
  */
@@ -261,16 +261,12 @@ static void method_gnss_agps_request_work_fn(struct k_work *item)
 	rest_ctx.auth = (char *)jwt_buf;
 
 	struct nrf_cloud_rest_agps_request request = {
-						     NRF_CLOUD_REST_AGPS_REQ_CUSTOM,
-						     &agps_request,
-						     NULL,
-#if defined(CONFIG_NRF_CLOUD_AGPS_FILTERED_RUNTIME)
-						     true,
-						     CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK
-#else
-						     false, 0
-#endif
-						     };
+		NRF_CLOUD_REST_AGPS_REQ_CUSTOM,
+		&agps_request,
+		NULL,
+		false,
+		0
+	};
 
 	struct lte_lc_cells_info net_info = {0};
 	struct location_utils_modem_params_info modem_params = { 0 };

--- a/samples/nrf9160/modem_shell/src/cloud/cloud_mqtt_shell.c
+++ b/samples/nrf9160/modem_shell/src/cloud/cloud_mqtt_shell.c
@@ -11,13 +11,6 @@
 #include <zephyr/shell/shell.h>
 #include "mosh_print.h"
 
-#if defined(CONFIG_NRF_CLOUD_AGPS)
-#include <net/nrf_cloud_agps.h>
-#endif
-#if defined(CONFIG_NRF_CLOUD_PGPS)
-#include <net/nrf_cloud_pgps.h>
-#endif
-
 #define CLOUD_CMD_MAX_LENGTH 150
 
 BUILD_ASSERT(
@@ -30,9 +23,6 @@ extern struct k_work_q mosh_common_work_q;
 extern const struct shell *mosh_shell;
 
 static struct k_work_delayable cloud_reconnect_work;
-#if defined(CONFIG_NRF_CLOUD_PGPS)
-static struct k_work notify_pgps_work;
-#endif
 static struct k_work cloud_cmd_work;
 static struct k_work shadow_update_work;
 
@@ -64,19 +54,6 @@ static void cloud_reconnect_work_fn(struct k_work *work)
 		mosh_error("nrf_cloud_connect, error: %d", err);
 	}
 }
-
-#if defined(CONFIG_NRF_CLOUD_PGPS)
-static void notify_pgps(struct k_work *work)
-{
-	ARG_UNUSED(work);
-	int err;
-
-	err = nrf_cloud_pgps_notify_prediction();
-	if (err) {
-		mosh_error("Error requesting notification of prediction availability: %d", err);
-	}
-}
-#endif /* defined(CONFIG_NRF_CLOUD_PGPS) */
 
 static void cloud_cmd_execute(struct k_work *work)
 {
@@ -253,9 +230,6 @@ static void cmd_cloud_connect(const struct shell *shell, size_t argc, char **arg
 
 		k_work_init(&cloud_cmd_work, cloud_cmd_execute);
 		k_work_init(&shadow_update_work, nrf_cloud_update_shadow);
-#if defined(CONFIG_NRF_CLOUD_PGPS)
-		k_work_init(&notify_pgps_work, notify_pgps);
-#endif
 		k_work_init_delayable(&cloud_reconnect_work, cloud_reconnect_work_fn);
 	}
 


### PR DESCRIPTION
A-GPS data download did not start immediately when GNSS location was requested, but only after the RRC connection was released. This caused unnecessary delay with the first GNSS fix. The root cause was the order in which the work items got submitted into the work queue.

Earlier filtered ephemerides were always enabled by the library when `CONFIG_NRF_CLOUD_AGPS_FILTERED_RUNTIME` was selected. Because the library does not have an API for filtered ephemerides runtime configuration, it makes more sense to not use filtered ephemerides in this case. Filtered ephemerides are only used when `CONFIG_NRF_CLOUD_AGPS_FILTERED` is selected and `CONFIG_NRF_CLOUD_AGPS_FILTERED_RUNTIME` not selected.

Removed unnecessary A-GPS and P-GPS related code from modem_shell `cloud_mqtt_shell.c`.