### PR TITLE
manifest: Remove zephyr fork of mbedtls from allowlist

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -82,7 +82,6 @@ manifest:
           - loramac-node
           - lvgl
           - lz4
-          - mbedtls
           - mipi-sys-t
           - nanopb
           - net-tools


### PR DESCRIPTION
Remove the zephyr fork of mbedtls from the allowlist. We have our own fork of mbedtls.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>