### PR TITLE
application: serial_lte_modem: Support TCP/UDP client config

### DIFF
--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -164,6 +164,28 @@ Syntax
   If it is given, a TLS client will be started.
   It indicates to the modem the credential of the security tag used for establishing a secure connection.
 
+::
+
+   #XTCPCLI=<op>,<name>[,<value>]
+
+* The ``<op>`` parameter can accept the following value:
+
+  * ``3`` - Config socket option for TCP or TLS client.
+
+For a complete list of the supported SET ``<name>`` accepted parameters, see the `SETSOCKETOPT Service Spec Reference`_.
+In case of TLS client, the ``<name>`` parameter can accept one of the following values:
+
+  * ``2`` - ``TLS_HOSTNAME``.
+    ``<value>`` is a string.
+  * ``5`` - ``TLS_PEER_VERIFY``.
+    ``<value>`` is an integer and can be either ``0`` or ``1``.
+  * ``12`` - ``TLS_SESSION_CACHE``.
+    ``<value>`` is an integer and can be either ``0`` or ``1``.
+  * ``13`` - ``TLS_SESSION_CACHE_PURGE``.
+    ``<value>`` can accept any integer value.
+  * ``14`` - ``TLS_DTLS_HANDSHAKE_TIMEO``.
+    ``<value>`` is the timeout in seconds and can be one of the following integers: ``1``, ``3``, ``7``, ``15``, ``31``, ``63``, ``123``.
+
 Response syntax
 ~~~~~~~~~~~~~~~
 
@@ -240,7 +262,7 @@ Examples
 ::
 
    AT#XTCPCLI=?
-   #XTCPCLI: (0,1,2),<url>,<port>,<sec_tag>
+   #XTCPCLI: (0,1,2,3),<url>,<port>,<sec_tag>
    OK
 
 TCP send data #XTCPSEND
@@ -519,6 +541,28 @@ Syntax
   If it is given, a DTLS client will be started.
   It indicates to the modem the credential of the security tag used for establishing a secure connection.
 
+::
+
+   #XUDPCLI=<op>,<name>[,<value>]
+
+* The ``<op>`` parameter can accept the following value:
+
+  * ``3`` - Config socket option for UDP or DTLS client.
+
+For a complete list of the supported SET ``<name>`` accepted parameters, see the `SETSOCKETOPT Service Spec Reference`_.
+In case of DTLS client, the ``<name>`` parameter can accept one of the following values:
+
+  * ``2`` - ``TLS_HOSTNAME``.
+    ``<value>`` is a string.
+  * ``5`` - ``TLS_PEER_VERIFY``.
+    ``<value>`` is an integer and can be either ``0`` or ``1``.
+  * ``12`` - ``TLS_SESSION_CACHE``.
+    ``<value>`` is an integer and can be either ``0`` or ``1``.
+  * ``13`` - ``TLS_SESSION_CACHE_PURGE``.
+    ``<value>`` can accept any integer value.
+  * ``14`` - ``TLS_DTLS_HANDSHAKE_TIMEO``.
+    ``<value>`` is the timeout in seconds and can be one of the following integers: ``1``, ``3``, ``7``, ``15``, ``31``, ``63``, ``123``.
+
 Response syntax
 ~~~~~~~~~~~~~~~
 
@@ -588,7 +632,7 @@ Examples
 ::
 
    AT#XUDPCLI=?
-   #XUDPCLI: (0,1,2),<url>,<port>,<sec_tag>
+   #XUDPCLI: (0,1,2,3),<url>,<port>,<sec_tag>
    OK
 
 UDP send data #XUDPSEND

--- a/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
+++ b/applications/serial_lte_modem/src/slm_at_tcp_proxy.c
@@ -28,7 +28,8 @@ enum slm_tcp_proxy_operation {
 	SERVER_START,
 	CLIENT_CONNECT = SERVER_START,
 	SERVER_START6,
-	CLIENT_CONNECT6 = SERVER_START6
+	CLIENT_CONNECT6 = SERVER_START6,
+	CLIENT_CONFIG
 };
 
 /**@brief Proxy roles. */
@@ -56,6 +57,11 @@ extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 /** forward declaration of thread function **/
 static void tcpcli_thread_func(void *p1, void *p2, void *p3);
 static void tcpsvr_thread_func(void *p1, void *p2, void *p3);
+
+/* global functions defined in different files */
+int do_socketopt_set(int socket, int option, int value);
+int do_secure_socketopt_set_int(int socket, int option, int value);
+int do_secure_socketopt_set_str(int socket, int option, const char *value);
 
 static int do_tcp_server_start(uint16_t port)
 {
@@ -774,6 +780,49 @@ int handle_at_tcp_client(enum at_cmd_type cmd_type)
 			err = do_tcp_client_connect(url, port);
 		} else if (op == CLIENT_DISCONNECT) {
 			err = do_tcp_client_disconnect();
+		} else if (op == CLIENT_CONFIG) {
+			uint16_t name;
+			int value_int = 0;
+
+			if (proxy.sock == INVALID_SOCKET) {
+				return -EINVAL;
+			}
+			err = at_params_unsigned_short_get(&at_param_list, 2, &name);
+			if (err) {
+				return err;
+			}
+			if (param_count > 3) {
+				enum at_param_type type = at_params_type_get(&at_param_list, 3);
+				/* only possible for TLS_HOSTNAME in SOL_TLS */
+				if (type == AT_PARAM_TYPE_STRING) {
+					char value_str[SLM_MAX_URL] = {0};
+					int size = SLM_MAX_URL;
+
+					err = util_string_get(&at_param_list, 3, value_str, &size);
+					if (err) {
+						return err;
+					}
+					if (proxy.sec_tag == INVALID_SEC_TAG) {
+						return do_secure_socketopt_set_str(proxy.sock,
+										  name, value_str);
+					}
+					return -EINVAL;
+				} else if (type == AT_PARAM_TYPE_NUM_INT) {
+					err = at_params_int_get(&at_param_list, 3, &value_int);
+					if (err) {
+						return err;
+					}
+				} else {
+					return -EINVAL;
+				}
+			}
+			if (proxy.sec_tag != INVALID_SEC_TAG) {
+				err = do_secure_socketopt_set_int(proxy.sock, name, value_int);
+			} else {
+				err = do_socketopt_set(proxy.sock, name, value_int);
+			}
+		} else {
+			err = -EINVAL;
 		} break;
 
 	case AT_CMD_TYPE_READ_COMMAND:
@@ -783,8 +832,8 @@ int handle_at_tcp_client(enum at_cmd_type cmd_type)
 		break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "\r\n#XTCPCLI: (%d,%d,%d),<url>,<port>,<sec_tag>\r\n",
-			CLIENT_DISCONNECT, CLIENT_CONNECT, CLIENT_CONNECT6);
+		sprintf(rsp_buf, "\r\n#XTCPCLI: (%d,%d,%d, %d),<url>,<port>,<sec_tag>\r\n",
+			CLIENT_DISCONNECT, CLIENT_CONNECT, CLIENT_CONNECT6, CLIENT_CONFIG);
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;


### PR DESCRIPTION
Allow TCP/TLS or UDP/DTLS client to configure socket options. 
Add new ``<op>`` code to handle the request.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>