### PR TITLE
matter: pull fix for ram and rom report

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -128,7 +128,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: ab6343ae4ecd728b9263536f68dbad05d7868ddf
+      revision: 9a828bbf44262e37bb560200f59e14af02b9f1a6
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Stop filtering out gdwarf-4 when passing flags from Zephyr to Matter's GN build system. Older pyelftools versions are not able to parse DWARF5 format, so ram and rom report would not be generated.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>