### PR TITLE
ESB front-end modules support

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -101,7 +101,11 @@ See `Zigbee samples`_ for the list of changes for the Zigbee samples.
 ESB
 ---
 
-|no_changes_yet_note|
+  * Added support for front-end modules.
+  * The ESB module requires linking the :ref:`MPSL library <nrfxlib:mpsl_lib>`.
+  * The number of PPI/DPPI channels used is increased from 3 to 6.
+  * Assigned events 6-7 from the EGU0 instance to the ESB module.
+  * Changed the type parameter of the function :c:func:`esb_set_tx_power` to ``int8_t``.
 
 nRF IEEE 802.15.4 radio driver
 ------------------------------
@@ -200,6 +204,7 @@ nRF9160 samples
 
     * Support for nRF7002 EK shield and Wi-Fi based location.
 
+
 Peripheral samples
 ------------------
 
@@ -259,7 +264,11 @@ Wi-Fi samples
 Other samples
 -------------
 
-|no_changes_yet_note|
+* :ref:`esb_prx_ptx` sample:
+
+  * Added:
+
+    * Support for front-end modules and :ref:`zephyr:nrf21540dk_nrf52840`.
 
 Drivers
 =======

--- a/doc/nrf/ug_esb.rst
+++ b/doc/nrf/ug_esb.rst
@@ -39,6 +39,7 @@ Features
  * Packet acknowledgment and automatic packet retransmission functionality
  * Individual TX and RX FIFOs for every pipe
  * Backward compatible with legacy nRF24Lxx Enhanced ShockBurst
+ * Support for external front-end modules.
 
 .. _esb_config:
 
@@ -59,9 +60,12 @@ ESB requires exclusive access to all fixed and configured resources for the :ref
    * - Timer
      - NRF_TIMER2
      - configurable
-   * - PPI channels
-     - 5-11
-     - configurable
+   * - DPPI/PPI channels
+     - 6 channels
+     - automatically allocated
+   * - Event generator unit
+     - NRF_EGU0 events 6 - 7
+     - fixed
    * - Software interrupt
      - 0
      - fixed
@@ -71,6 +75,10 @@ ESB requires exclusive access to all fixed and configured resources for the :ref
 
 The radio and timer interrupt handlers run at priority level 0 (highest level), and the ESB callback functions run at priority level 1.
 Other interrupts used by the application must use priority level 2 or lower (level 2 to 7) to ensure correct operation.
+
+ESB requires the :ref:`MPSL library <nrfxlib:mpsl_lib>` for front-end module support.
+This library is always linked into the build, however, it is not initialized by default to provide your application and the ESB protocol with access to all hardware resources.
+See :ref:`ug_radio_fem_direct_support` for more details.
 
 .. _esb_backwards:
 
@@ -267,6 +275,12 @@ Therefore, there might be multiple radio interrupts between each event that is a
 A single :c:macro:`ESB_EVENT_TX_SUCCESS` or :c:macro:`ESB_EVENT_TX_FAILED` event indicates one or more successful or failed operations, respectively.
 An :c:macro:`ESB_EVENT_RX_RECEIVED` event indicates that there is at least one new packet in the RX FIFO.
 The event handler should make sure to completely empty the RX FIFO when appropriate.
+
+Front-end module support
+========================
+
+The ESB protocol supports external front-end modules.
+See :ref:`ug_radio_fem` for more details.
 
 .. _esb_errata:
 

--- a/include/esb.h
+++ b/include/esb.h
@@ -40,7 +40,7 @@ extern "C" {
 		.event_handler = 0,					       \
 		.bitrate = ESB_BITRATE_2MBPS,				       \
 		.crc = ESB_CRC_16BIT,					       \
-		.tx_output_power = ESB_TX_POWER_0DBM,			       \
+		.tx_output_power = 0,			                       \
 		.retransmit_delay = 600,				       \
 		.retransmit_count = 3,					       \
 		.tx_mode = ESB_TXMODE_AUTO,				       \
@@ -59,7 +59,7 @@ extern "C" {
 		.event_handler = 0,					       \
 		.bitrate = ESB_BITRATE_2MBPS,				       \
 		.crc = ESB_CRC_8BIT,					       \
-		.tx_output_power = ESB_TX_POWER_0DBM,			       \
+		.tx_output_power = 0,			                       \
 		.retransmit_delay = 600,				       \
 		.retransmit_count = 3,					       \
 		.tx_mode = ESB_TXMODE_AUTO,				       \
@@ -218,7 +218,7 @@ struct esb_config {
 	/* General RF parameters */
 	enum esb_bitrate bitrate;		/**< Bitrate mode. */
 	enum esb_crc crc;			/**< CRC mode. */
-	enum esb_tx_power tx_output_power;	/**< Radio TX power. */
+	int8_t tx_output_power;	                /**< Radio TX power. */
 
 	uint16_t retransmit_delay; /**< The delay between each retransmission of
 				  *  unacknowledged packets.
@@ -432,12 +432,13 @@ int esb_get_rf_channel(uint32_t *channel);
 
 /** @brief Set the radio output power.
  *
- *  @param[in] tx_output_power	Output power.
+ *  @param[in] tx_output_power	Output power in dBm. The @ref esb_tx_power values can be used
+ *                              to provide backward compatibility.
  *
  * @retval 0 If successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int esb_set_tx_power(enum esb_tx_power tx_output_power);
+int esb_set_tx_power(int8_t tx_output_power);
 
 /** @brief Set the packet retransmit delay.
  *

--- a/samples/esb/README.rst
+++ b/samples/esb/README.rst
@@ -60,6 +60,11 @@ The Receiver sample can be found under :file:`samples/esb/prx` in the |NCS| fold
 
 See :ref:`gs_programming` for information about how to build and program the application.
 
+FEM support
+===========
+
+.. include:: /includes/sample_fem_support.txt
+
 Testing
 =======
 

--- a/samples/esb/prx/sample.yaml
+++ b/samples/esb/prx/sample.yaml
@@ -18,8 +18,9 @@ tests:
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52810
       - nrf5340dk_nrf5340_cpunet
+      - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
-      nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
+      nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet nrf21540dk_nrf52840
     tags: esb ci_build
   sample.esb.prx.dynamic_irq:
     build_only: true
@@ -31,4 +32,11 @@ tests:
       - nrf5340dk_nrf5340_cpunet
       - nrf52840dk_nrf52840
     platform_allow: nrf5340dk_nrf5340_cpunet nrf52840dk_nrf52840
+    tags: esb ci_build
+  sample.esb.prx.nrf5340_nrf21540:
+    build_only: true
+    extra_args: SHIELD=nrf21540_ek
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf5340dk_nrf5340_cpunet
     tags: esb ci_build

--- a/samples/esb/ptx/sample.yaml
+++ b/samples/esb/ptx/sample.yaml
@@ -18,8 +18,9 @@ tests:
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52810
       - nrf5340dk_nrf5340_cpunet
+      - nrf21540dk_nrf52840
     platform_allow: nrf52dk_nrf52832 nrf52833dk_nrf52833 nrf52840dk_nrf52840
-      nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet
+      nrf52dk_nrf52810 nrf5340dk_nrf5340_cpunet nrf21540dk_nrf52840
     tags: esb ci_build
   sample.esb.ptx.dynamic_irq:
     build_only: true
@@ -31,4 +32,11 @@ tests:
       - nrf5340dk_nrf5340_cpunet
       - nrf52840dk_nrf52840
     platform_allow: nrf5340dk_nrf5340_cpunet nrf52840dk_nrf52840
+    tags: esb ci_build
+  sample.esb.ptx.nrf5340_nrf21540:
+    build_only: true
+    extra_args: SHIELD=nrf21540_ek
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+    platform_allow: nrf5340dk_nrf5340_cpunet
     tags: esb ci_build

--- a/subsys/esb/CMakeLists.txt
+++ b/subsys/esb/CMakeLists.txt
@@ -5,4 +5,7 @@
 #
 
 zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_ESB esb.c)
+zephyr_library_sources(esb.c)
+
+zephyr_library_sources_ifdef(CONFIG_HAS_HW_NRF_PPI esb_ppi.c)
+zephyr_library_sources_ifdef(CONFIG_HAS_HW_NRF_DPPIC esb_dppi.c)

--- a/subsys/esb/Kconfig
+++ b/subsys/esb/Kconfig
@@ -8,6 +8,8 @@ menuconfig ESB
 	bool "Enhanced ShockBurst"
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	select NRFX_DPPI if HAS_HW_NRF_DPPIC
+	select MPSL
+	select MPSL_FEM_ONLY if !ESB_DYNAMIC_INTERRUPTS
 	default n
 	help
 	  Enable ESB functionality.
@@ -107,3 +109,7 @@ config ESB_DYNAMIC_INTERRUPTS
 	  and RADIO_IRQn handlers during runtime when ESB is uninitialized.
 
 endif # NRF_ENHANCED_SHOCKBURST
+
+module=ESB
+module-str=ESB
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/subsys/esb/esb_dppi.c
+++ b/subsys/esb/esb_dppi.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <hal/nrf_egu.h>
+#include <hal/nrf_radio.h>
+#include <hal/nrf_timer.h>
+
+#include <nrfx_dppi.h>
+
+#include <zephyr/logging/log.h>
+
+#include "esb_peripherals.h"
+#include "esb_ppi_api.h"
+
+LOG_MODULE_DECLARE(esb, CONFIG_ESB_LOG_LEVEL);
+
+static uint8_t radio_address_timer_stop;
+static uint8_t timer_compare0_radio_disable;
+static uint8_t timer_compare1_radio_txen;
+static uint8_t disabled_egu;
+static uint8_t egu_timer_start;
+static uint8_t egu_ramp_up;
+
+static nrf_dppi_channel_group_t ramp_up_dppi_group;
+
+void esb_ppi_for_txrx_set(bool rx, bool timer_start)
+{
+	uint32_t channels_mask;
+
+	nrf_egu_event_clear(ESB_EGU, ESB_EGU_EVENT);
+	nrf_egu_event_clear(ESB_EGU, ESB_EGU_DPPI_EVENT);
+
+	nrf_egu_publish_set(ESB_EGU, ESB_EGU_EVENT, egu_timer_start);
+	nrf_egu_publish_set(ESB_EGU, ESB_EGU_DPPI_EVENT, egu_ramp_up);
+
+	nrf_dppi_channels_include_in_group(NRF_DPPIC, BIT(egu_ramp_up), ramp_up_dppi_group);
+
+	nrf_egu_subscribe_set(ESB_EGU, ESB_EGU_DPPI_TASK, egu_timer_start);
+	nrf_radio_subscribe_set(NRF_RADIO, rx ? NRF_RADIO_TASK_RXEN : NRF_RADIO_TASK_TXEN,
+				egu_ramp_up);
+	nrf_dppi_subscribe_set(NRF_DPPIC,
+				nrf_dppi_group_disable_task_get((uint8_t)ramp_up_dppi_group),
+				egu_ramp_up);
+	nrf_egu_subscribe_set(ESB_EGU, ESB_EGU_TASK, disabled_egu);
+
+	if (timer_start) {
+		nrf_timer_subscribe_set(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_START,
+					egu_timer_start);
+	}
+
+	channels_mask = (BIT(egu_timer_start) |
+			 BIT(egu_ramp_up));
+
+	nrf_dppi_channels_enable(NRF_DPPIC, channels_mask);
+}
+
+void esb_ppi_for_txrx_clear(bool rx, bool timer_start)
+{
+	uint32_t channels_mask;
+
+	channels_mask = (BIT(egu_timer_start) |
+			 BIT(egu_ramp_up));
+
+	nrf_dppi_channels_disable(NRF_DPPIC, channels_mask);
+
+	nrf_egu_publish_clear(ESB_EGU, ESB_EGU_EVENT);
+	nrf_egu_publish_clear(ESB_EGU, ESB_EGU_DPPI_EVENT);
+
+	nrf_egu_subscribe_clear(ESB_EGU, ESB_EGU_DPPI_TASK);
+	nrf_radio_subscribe_clear(NRF_RADIO, rx ? NRF_RADIO_TASK_RXEN : NRF_RADIO_TASK_TXEN);
+	nrf_dppi_subscribe_clear(NRF_DPPIC,
+				 nrf_dppi_group_disable_task_get((uint8_t)ramp_up_dppi_group));
+	nrf_egu_subscribe_clear(ESB_EGU, ESB_EGU_TASK);
+
+	nrf_dppi_channels_remove_from_group(NRF_DPPIC, BIT(egu_ramp_up), ramp_up_dppi_group);
+
+
+	if (timer_start) {
+		nrf_timer_subscribe_clear(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_START);
+	}
+}
+
+void esb_ppi_for_fem_set(void)
+{
+	nrf_egu_publish_set(ESB_EGU, ESB_EGU_EVENT, egu_timer_start);
+	nrf_timer_subscribe_set(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_START,
+				egu_timer_start);
+
+	nrf_dppi_channels_enable(NRF_DPPIC, BIT(egu_timer_start));
+}
+
+void esb_ppi_for_fem_clear(void)
+{
+	nrf_dppi_channels_disable(NRF_DPPIC, BIT(egu_timer_start));
+
+	nrf_egu_publish_clear(ESB_EGU, ESB_EGU_EVENT);
+	nrf_timer_subscribe_clear(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_START);
+}
+
+void esb_ppi_for_retransmission_set(void)
+{
+	nrf_egu_event_clear(ESB_EGU, ESB_EGU_EVENT);
+
+	nrf_timer_publish_set(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE1,
+			      timer_compare1_radio_txen);
+
+	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, timer_compare1_radio_txen);
+	nrf_egu_subscribe_set(ESB_EGU, ESB_EGU_TASK, disabled_egu);
+
+	nrf_dppi_channels_enable(NRF_DPPIC, BIT(timer_compare1_radio_txen));
+}
+
+void esb_ppi_for_retransmission_clear(void)
+{
+	nrf_dppi_channels_disable(NRF_DPPIC, BIT(timer_compare1_radio_txen));
+
+	nrf_timer_publish_clear(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE1);
+
+	nrf_radio_subscribe_clear(NRF_RADIO, NRF_RADIO_TASK_TXEN);
+	nrf_egu_subscribe_clear(ESB_EGU, ESB_EGU_TASK);
+}
+
+void esb_ppi_for_wait_for_ack_set(void)
+{
+	uint32_t channels_mask;
+
+	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_ADDRESS, radio_address_timer_stop);
+	nrf_timer_publish_set(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0,
+			      timer_compare0_radio_disable);
+
+	nrf_timer_subscribe_set(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN,
+				radio_address_timer_stop);
+	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_DISABLE, timer_compare0_radio_disable);
+
+	channels_mask = (BIT(radio_address_timer_stop) |
+			 BIT(timer_compare0_radio_disable));
+
+	nrf_dppi_channels_enable(NRF_DPPIC, channels_mask);
+}
+
+void esb_ppi_for_wait_for_ack_clear(void)
+{
+	uint32_t channels_mask;
+
+	channels_mask = (BIT(radio_address_timer_stop) |
+			 BIT(timer_compare0_radio_disable));
+
+	nrf_dppi_channels_disable(NRF_DPPIC, channels_mask);
+
+	nrf_radio_publish_clear(NRF_RADIO, NRF_RADIO_EVENT_ADDRESS);
+	nrf_timer_publish_clear(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0);
+
+	nrf_timer_subscribe_clear(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
+	nrf_radio_subscribe_clear(NRF_RADIO, NRF_RADIO_TASK_DISABLE);
+}
+
+uint32_t esb_ppi_radio_disabled_get(void)
+{
+	return disabled_egu;
+}
+
+int esb_ppi_init(void)
+{
+	nrfx_err_t err;
+
+	err = nrfx_dppi_channel_alloc(&radio_address_timer_stop);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_alloc(&timer_compare0_radio_disable);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_alloc(&timer_compare1_radio_txen);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_alloc(&disabled_egu);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_alloc(&egu_timer_start);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_alloc(&egu_ramp_up);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_group_alloc(&ramp_up_dppi_group);
+	if (err != NRFX_SUCCESS) {
+		LOG_ERR("gppi_group_alloc failed with: %d\n", err);
+		return -ENODEV;
+	}
+
+	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_DISABLED, disabled_egu);
+	nrf_dppi_channels_enable(NRF_DPPIC, BIT(disabled_egu));
+
+	return 0;
+
+error:
+	LOG_ERR("gppi_channel_alloc failed with: %d\n", err);
+	return -ENODEV;
+}
+
+void esb_ppi_disable_all(void)
+{
+	uint32_t channels_mask = (BIT(egu_ramp_up) |
+				  BIT(disabled_egu) |
+				  BIT(egu_timer_start) |
+				  BIT(radio_address_timer_stop) |
+				  BIT(timer_compare0_radio_disable) |
+				  BIT(timer_compare1_radio_txen));
+
+	nrf_dppi_channels_disable(NRF_DPPIC, channels_mask);
+}
+
+void esb_ppi_deinit(void)
+{
+	nrfx_err_t err;
+
+	nrf_dppi_channels_disable(NRF_DPPIC, BIT(disabled_egu));
+	nrf_radio_publish_clear(NRF_RADIO, NRF_RADIO_EVENT_DISABLED);
+
+	err = nrfx_dppi_channel_free(radio_address_timer_stop);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_free(timer_compare0_radio_disable);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_free(timer_compare1_radio_txen);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_free(disabled_egu);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_free(egu_timer_start);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_channel_free(egu_ramp_up);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_dppi_group_free(ramp_up_dppi_group);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	return;
+
+/* Should not happen. */
+error:
+	__ASSERT(false, "Failed to free DPPI resources");
+}

--- a/subsys/esb/esb_peripherals.h
+++ b/subsys/esb/esb_peripherals.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef ESB_PERIPHERALS_H_
+#define ESB_PERIPHERALS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <nrfx.h>
+#include <nrfx_timer.h>
+
+#include <hal/nrf_egu.h>
+
+/** The ESB event IRQ number when running on an nRF5 device. */
+#define ESB_EVT_IRQ        SWI0_IRQn
+/** The handler for @ref ESB_EVT_IRQ when running on an nRF5 device. */
+#define ESB_EVT_IRQHandler SWI0_IRQHandler
+
+/** ESB timer instance number. */
+#define ESB_TIMER_INSTANCE_NO CONFIG_ESB_SYS_TIMER_INSTANCE
+
+#define ESB_TIMER_IRQ          NRFX_CONCAT_3(TIMER, ESB_TIMER_INSTANCE_NO, _IRQn)
+#define ESB_TIMER_IRQ_HANDLER  NRFX_CONCAT_3(nrfx_timer_,		    \
+					     ESB_TIMER_INSTANCE_NO, \
+					     _irq_handler)
+
+/** ESB nRF Timer instance */
+#define ESB_NRF_TIMER_INSTANCE \
+	NRFX_CONCAT_2(NRF_TIMER, ESB_TIMER_INSTANCE_NO)
+
+/** ESB nrfx timer instance. */
+#define ESB_TIMER_INSTANCE NRFX_TIMER_INSTANCE(ESB_TIMER_INSTANCE_NO)
+
+/** ESB EGU instance, events and tasks configuration. */
+#define ESB_EGU       NRF_EGU0
+#define ESB_EGU_EVENT NRF_EGU_EVENT_TRIGGERED6
+#define ESB_EGU_TASK  NRF_EGU_TASK_TRIGGER6
+
+/** ESB additional EGU event and task for devices with DPPI. */
+#define ESB_EGU_DPPI_EVENT NRF_EGU_EVENT_TRIGGERED7
+#define ESB_EGU_DPPI_TASK  NRF_EGU_TASK_TRIGGER7
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESB_PERIPHERALS_H_ */

--- a/subsys/esb/esb_ppi.c
+++ b/subsys/esb/esb_ppi.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <hal/nrf_egu.h>
+#include <hal/nrf_radio.h>
+#include <hal/nrf_timer.h>
+
+#include <nrfx_ppi.h>
+
+#include <zephyr/logging/log.h>
+
+#include "esb_peripherals.h"
+#include "esb_ppi_api.h"
+
+LOG_MODULE_DECLARE(esb, CONFIG_ESB_LOG_LEVEL);
+
+static nrf_ppi_channel_t radio_address_timer_stop;
+static nrf_ppi_channel_t timer_compare0_radio_disable;
+static nrf_ppi_channel_t timer_compare1_radio_txen;
+static nrf_ppi_channel_t egu_ramp_up;
+static nrf_ppi_channel_t egu_timer_start;
+static nrf_ppi_channel_t disabled_egu;
+
+static nrf_ppi_channel_group_t ramp_up_ppi_group;
+
+void esb_ppi_for_fem_set(void)
+{
+	uint32_t egu_event = nrf_egu_event_address_get(ESB_EGU, ESB_EGU_EVENT);
+	uint32_t timer_task = nrf_timer_task_address_get(ESB_NRF_TIMER_INSTANCE,
+							 NRF_TIMER_TASK_START);
+
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, egu_timer_start, egu_event, timer_task);
+	nrf_ppi_channel_enable(NRF_PPI, egu_timer_start);
+}
+
+void esb_ppi_for_fem_clear(void)
+{
+	nrf_ppi_channel_disable(NRF_PPI, egu_timer_start);
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, egu_timer_start, 0, 0);
+}
+
+void esb_ppi_for_txrx_set(bool rx, bool timer_start)
+{
+	uint32_t channels_mask;
+	uint32_t egu_event = nrf_egu_event_address_get(ESB_EGU, ESB_EGU_EVENT);
+	uint32_t egu_task = nrf_egu_task_address_get(ESB_EGU, ESB_EGU_TASK);
+	uint32_t group_disable_task =
+			nrf_ppi_task_group_disable_address_get(NRF_PPI, ramp_up_ppi_group);
+	uint32_t radio_en_task = nrf_radio_task_address_get(NRF_RADIO,
+						rx ? NRF_RADIO_TASK_RXEN : NRF_RADIO_TASK_TXEN);
+	uint32_t radio_disabled_event = nrf_radio_event_address_get(NRF_RADIO,
+						NRF_RADIO_EVENT_DISABLED);
+	uint32_t timer_task = nrf_timer_task_address_get(ESB_NRF_TIMER_INSTANCE,
+							 NRF_TIMER_TASK_START);
+
+	nrf_egu_event_clear(ESB_EGU, ESB_EGU_EVENT);
+	nrf_ppi_channel_and_fork_endpoint_setup(NRF_PPI, egu_ramp_up, egu_event, radio_en_task,
+						group_disable_task);
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, disabled_egu, radio_disabled_event, egu_task);
+
+	channels_mask = BIT(egu_ramp_up) | BIT(disabled_egu);
+
+	if (timer_start) {
+		nrf_ppi_channel_endpoint_setup(NRF_PPI, egu_timer_start, egu_event, timer_task);
+		channels_mask |= BIT(egu_timer_start);
+	}
+
+	nrf_ppi_channel_include_in_group(NRF_PPI, egu_ramp_up, ramp_up_ppi_group);
+	nrf_ppi_channels_enable(NRF_PPI, channels_mask);
+}
+
+void esb_ppi_for_txrx_clear(bool rx, bool timer_start)
+{
+	uint32_t channels_mask = (BIT(egu_ramp_up) | BIT(disabled_egu));
+
+	ARG_UNUSED(rx);
+
+	if (timer_start) {
+		channels_mask |= BIT(egu_timer_start);
+	}
+
+	nrf_ppi_channels_disable(NRF_PPI, channels_mask);
+
+	nrf_ppi_channel_and_fork_endpoint_setup(NRF_PPI, egu_ramp_up, 0, 0, 0);
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, disabled_egu, 0, 0);
+
+	if (timer_start) {
+		nrf_ppi_channel_endpoint_setup(NRF_PPI, egu_timer_start, 0, 0);
+	}
+
+	nrf_ppi_channel_remove_from_group(NRF_PPI, egu_ramp_up, ramp_up_ppi_group);
+}
+
+void esb_ppi_for_retransmission_set(void)
+{
+	uint32_t channels_mask;
+
+	uint32_t egu_task = nrf_egu_task_address_get(ESB_EGU, ESB_EGU_TASK);
+	uint32_t radio_disabled_event = nrf_radio_event_address_get(NRF_RADIO,
+						NRF_RADIO_EVENT_DISABLED);
+	nrf_egu_event_clear(ESB_EGU, ESB_EGU_EVENT);
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, disabled_egu, radio_disabled_event, egu_task);
+
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, timer_compare1_radio_txen,
+		nrf_timer_event_address_get(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE1),
+		nrf_radio_task_address_get(NRF_RADIO, NRF_RADIO_TASK_TXEN));
+
+	channels_mask = BIT(disabled_egu) | BIT(timer_compare1_radio_txen);
+
+	nrf_ppi_channels_enable(NRF_PPI, channels_mask);
+}
+
+void esb_ppi_for_retransmission_clear(void)
+{
+	uint32_t channels_mask;
+
+	channels_mask = (BIT(disabled_egu) |
+			 BIT(timer_compare1_radio_txen));
+
+	nrf_ppi_channels_disable(NRF_PPI, channels_mask);
+
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, disabled_egu, 0, 0);
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, timer_compare1_radio_txen, 0, 0);
+}
+
+void esb_ppi_for_wait_for_ack_set(void)
+{
+	uint32_t ppi_channels_mask;
+
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, radio_address_timer_stop,
+		nrf_radio_event_address_get(NRF_RADIO, NRF_RADIO_EVENT_ADDRESS),
+		nrf_timer_task_address_get(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN));
+
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, timer_compare0_radio_disable,
+		nrf_timer_event_address_get(ESB_NRF_TIMER_INSTANCE, NRF_TIMER_EVENT_COMPARE0),
+		nrf_radio_task_address_get(NRF_RADIO, NRF_RADIO_TASK_DISABLE));
+
+	ppi_channels_mask = (BIT(radio_address_timer_stop) |
+			     BIT(timer_compare0_radio_disable));
+
+	nrf_ppi_channels_enable(NRF_PPI, ppi_channels_mask);
+}
+
+void esb_ppi_for_wait_for_ack_clear(void)
+{
+	uint32_t ppi_channels_mask;
+
+	ppi_channels_mask = (BIT(radio_address_timer_stop) |
+			     BIT(timer_compare0_radio_disable));
+
+	nrf_ppi_channels_disable(NRF_PPI, ppi_channels_mask);
+
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, radio_address_timer_stop, 0, 0);
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, timer_compare0_radio_disable, 0, 0);
+}
+
+int esb_ppi_init(void)
+{
+	nrfx_err_t err;
+
+	err = nrfx_ppi_channel_alloc(&egu_ramp_up);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_alloc(&disabled_egu);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_alloc(&egu_timer_start);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_alloc(&radio_address_timer_stop);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_alloc(&timer_compare0_radio_disable);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_alloc(&timer_compare1_radio_txen);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_group_alloc(&ramp_up_ppi_group);
+	if (err != NRFX_SUCCESS) {
+		LOG_ERR("gppi_group_alloc failed with: %d\n", err);
+		return -ENODEV;
+	}
+
+	return 0;
+
+error:
+	LOG_ERR("gppi_channel_alloc failed with: %d\n", err);
+	return -ENODEV;
+}
+
+uint32_t esb_ppi_radio_disabled_get(void)
+{
+	return nrf_radio_event_address_get(NRF_RADIO, NRF_RADIO_EVENT_DISABLED);
+}
+
+void esb_ppi_disable_all(void)
+{
+	uint32_t channels_mask = (BIT(egu_ramp_up) |
+				  BIT(disabled_egu) |
+				  BIT(egu_timer_start) |
+				  BIT(radio_address_timer_stop) |
+				  BIT(timer_compare0_radio_disable) |
+				  BIT(timer_compare1_radio_txen));
+
+	nrf_ppi_channels_disable(NRF_PPI, channels_mask);
+}
+
+void esb_ppi_deinit(void)
+{
+	nrfx_err_t err;
+
+	err = nrfx_ppi_channel_free(egu_ramp_up);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_free(disabled_egu);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_free(egu_timer_start);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_free(radio_address_timer_stop);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_free(timer_compare0_radio_disable);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_channel_free(timer_compare1_radio_txen);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	err = nrfx_ppi_group_free(ramp_up_ppi_group);
+	if (err != NRFX_SUCCESS) {
+		goto error;
+	}
+
+	return;
+
+/* Should not happen. */
+error:
+	__ASSERT(false, "Failed to free PPI resources");
+}

--- a/subsys/esb/esb_ppi_api.h
+++ b/subsys/esb/esb_ppi_api.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef ESB_FEM_H__
+#define ESB_FEM_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+/** @brief Set PPI/DPPI for Tx or Rx radio operations.
+ *
+ * Connections created by this function in a PPI variant:
+ *                       1         2
+ *       RADIO_DISABLED ---> EGU -----> radio ramp up task
+ *                                \---> self disable
+ *
+ *       if (start_timer)
+ *                    3
+ *            EGU ---------> TIMER_START
+ *
+ * Connection created by this function in a DPPI variant:
+ *                      1          2
+ *      RADIO_DISABLED ---> EGU1 -----> EGU2
+ *                               |
+ *                        if (start_timer)
+ *                               \----> TIMER_START
+ *             3
+ *      EGU2 -----> radio ramp up task
+ *           |
+ *           \----> self disable
+ *
+ * @param[in] rx Radio Rx mode, otherwise Tx mode.
+ * @param[in] timer_start Indicates whether the timer is to be started on the EGU event.
+ */
+void esb_ppi_for_txrx_set(bool rx, bool timer_start);
+
+/** @brief Clear PPI/DPPI connection for Tx or Rx radio operations
+ *
+ * @param[in] rx Radio Rx mode, otherwise Tx mode.
+ * @param[in] timer_start Clear timer connections if the timer was set using
+ *                        the @ref esb_ppi_for_txrx_set function.
+ */
+void esb_ppi_for_txrx_clear(bool rx, bool timer_start);
+
+/** @brief Configure PPIs/DPPIs for the external front-end module. The EGU event will be connected
+ *         to the TIMER_START event. As a result, the front-end module ramp-up will be scheduled\
+ *         during the radio ramp-up period, with timing based on the FEM implementation used.
+ */
+void esb_ppi_for_fem_set(void);
+
+/** @brief Clear PPIs/DDPIs for the external front-end module.
+ */
+void esb_ppi_for_fem_clear(void);
+
+/** @brief Configure PPIs/DPPIs for packet retransmission.
+ *
+ * Connections created by this function:
+ *
+ *                      1
+ *      RADIO_DISABLED ---> EGU
+ *                       4
+ *      TIMER_COMPARE_1 ---> RADIO_TXEN
+ *
+ */
+void esb_ppi_for_retransmission_set(void);
+
+/** @brief Clear PPIs/DPPIs configuration for packet retransmission.
+ */
+void esb_ppi_for_retransmission_clear(void);
+
+/** @brief Configure PPIs/DPPIs for an ACK packet transmission.
+ *
+ * Connections created by this function:
+ *
+ *                     5
+ *      RADIO_ADDRESS ---> TIMER_SHUTDOWN
+ *                       6
+ *      TIMER_COMPARE_0 ---> RADIO_DISABLE
+ *
+ */
+void esb_ppi_for_wait_for_ack_set(void);
+
+/** @brief Clear PPIs/DPPIs configuration for an ACK packet transmission.
+ */
+void esb_ppi_for_wait_for_ack_clear(void);
+
+/** @brief Get radio disable event address or DPPI channel.
+ *
+ * @retval RADIO_DISABLED event address if PPI is used.
+ *         DDPI channel number connected to RADIO_DISABLED event if DPPI is used.
+ */
+uint32_t esb_ppi_radio_disabled_get(void);
+
+/** @brief Disable all PPI/DPPI channels used by ESB.
+ */
+void esb_ppi_disable_all(void);
+
+/** @brief Initialize PPIs/DPPIs for ESB.
+ *
+ * This function allocates PPI/DPPI channels for the ESB protocol.
+ *
+ * @retval If the operation was successful.
+ *         Otherwise, a (negative) error code is returned.
+ */
+int esb_ppi_init(void);
+
+/** @brief Deinitialize PPIs/DPPIs.
+ *
+ * This function frees the PPI/DPPI channels allocated by ESB.
+ */
+void esb_ppi_deinit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESB_FEM_H__ */

--- a/subsys/mpsl/Kconfig
+++ b/subsys/mpsl/Kconfig
@@ -6,7 +6,6 @@
 
 config MPSL_FEM_ONLY
 	bool "Support only radio front-end module (FEM)"
-	depends on MPSL_FEM
 	help
 	  Support only radio front-end module (FEM) feature. The MPSL library is linked
 	  into a build without the initialization. Using other MPSL features is not possible.


### PR DESCRIPTION
This PR add support for external front-end modules in the ESB protocol.
An ESB is integrated with MPSL FEM API so linking MPSL into the ESB module is now required.