### PR TITLE
samples: nrf9160: spi3 high drive for ext flash

### DIFF
--- a/applications/asset_tracker_v2/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/applications/asset_tracker_v2/boards/nrf9160dk_nrf9160_ns.overlay
@@ -42,3 +42,10 @@
 		};
 	};
 };
+
+/* Enable high drive mode for the SPI3 pins to get a square signal at 8 MHz */
+&spi3_default {
+	group1 {
+		nordic,drive-mode = <NRF_DRIVE_H0H1>;
+	};
+};

--- a/applications/asset_tracker_v2/doc/cloud_module.rst
+++ b/applications/asset_tracker_v2/doc/cloud_module.rst
@@ -95,7 +95,7 @@ This enables the cloud to issue FOTA updates and update the application and mode
 For additional documentation on the various FOTA implementations, refer to the respective client library documentation linked to in :ref:`Integration layers <integration_layers>`.
 
 Full modem FOTA updates are only supported by nRF Cloud.
-This application implements full modem FOTA only for the nRF9160 development kit version 1.0.1 and higher.
+This application implements full modem FOTA only for the nRF9160 development kit version 0.14.0 and higher.
 To enable full modem FOTA, add the ``-DOVERLAY_CONFIG=overlay-full_modem_fota.conf`` parameter to your build command.
 
 Also, specify your development kit version by appending it to the board name.

--- a/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/nrf_cloud_integration.c
@@ -49,7 +49,7 @@ static cloud_wrap_evt_handler_t wrapper_evt_handler;
 #if defined(CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE)
 /* Full modem FOTA requires external flash to hold the full modem image.
  * Below is the external flash device present on the nRF9160 DK version
- * 1.0.1 and higher.
+ * 0.14.0 and higher.
  */
 static struct dfu_target_fmfu_fdev ext_flash_dev = {
 	.size = 0,

--- a/doc/nrf/libraries/networking/nrf_cloud_pgps.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud_pgps.rst
@@ -88,7 +88,7 @@ There are three ways to define this storage location:
 * To use a dedicated partition, enable the :kconfig:option:`CONFIG_NRF_CLOUD_PGPS_STORAGE_PARTITION` option.
 
   By default, this partition is stored in the main SoC flash.
-  This partition can optionally be located in external flash for the nRF9160 development kit version 1.0.1 and later.
+  This partition can optionally be located in external flash for the nRF9160 development kit version 0.14.0 and later.
   This conserves space in the main flash for storing code or other data.
   Currently, you cannot combine storing P-GPS data in external flash with full modem FOTA.
 

--- a/samples/nrf9160/http_update/full_modem_update/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/samples/nrf9160/http_update/full_modem_update/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,15 +1,10 @@
 /*
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 &spi3 {
-	compatible = "nordic,nrf-spim";
-	status = "okay";
-	pinctrl-0 = <&spi3_default_alt>;
-	pinctrl-1 = <&spi3_sleep_alt>;
-	pinctrl-names = "default", "sleep";
 	cs-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
 	mx25r64: mx25r6435f@0 {
 		compatible = "jedec,spi-nor";
@@ -20,22 +15,9 @@
 	};
 };
 
-&pinctrl {
-	spi3_default_alt: spi3_default_alt {
-		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 11)>,
-				<NRF_PSEL(SPIM_MISO, 0, 12)>;
-		};
+/* Enable high drive mode for the SPI3 pins to get a square signal at 8 MHz */
+&spi3_default {
+	group1 {
+		nordic,drive-mode = <NRF_DRIVE_H0H1>;
 	};
-
-	spi3_sleep_alt: spi3_sleep_alt {
-		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 11)>,
-				<NRF_PSEL(SPIM_MISO, 0, 12)>;
-			low-power-enable;
-		};
-	};
-
 };

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/README.rst
@@ -134,7 +134,7 @@ Reboot after download completion is handled by the :file:`src/fota_support.c` fi
 In a real-world setting, these two behaviors could be directly implemented in the :file:`src/connection.c` file.
 In this sample, they are separated for clarity.
 
-This sample supports full modem FOTA for the nRF9160 development kit version 1.0.1 and higher.
+This sample supports full modem FOTA for the nRF9160 development kit version 0.14.0 and higher.
 To enable full modem FOTA, add the following parameter to your build command:
 
 ``-DOVERLAY_CONFIG=overlay_full_modem_fota.conf``
@@ -182,7 +182,7 @@ When enabled, this location method scans the MAC addresses of nearby access poin
 
 See :ref:`nrf_cloud_mqtt_multi_service_building_wifi` for details on how to enable Wi-Fi location tracking.
 
-This sample supports placing P-GPS data in external flash for the nRF9160 development kit version 1.0.1 and later.
+This sample supports placing P-GPS data in external flash for the nRF9160 development kit version 0.14.0 and later.
 Currently, you cannot combine this with full modem FOTA.
 To enable this, add the following parameter to your build command:
 

--- a/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/fota_support.c
+++ b/samples/nrf9160/nrf_cloud_mqtt_multi_service/src/fota_support.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(fota_support, CONFIG_MQTT_MULTI_SERVICE_LOG_LEVEL);
 #if defined(CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE)
 /* Full modem FOTA requires external flash to hold the full modem image.
  * Below is the external flash device present on the nRF9160 DK version
- * 1.0.1 and higher.
+ * 0.14.0 and higher.
  */
 #define FULL_MODEM_FOTA_FLASH_DEVICE DEVICE_DT_GET_ONE(jedec_spi_nor)
 #else

--- a/samples/nrf9160/nrf_cloud_rest_fota/README.rst
+++ b/samples/nrf9160/nrf_cloud_rest_fota/README.rst
@@ -19,7 +19,7 @@ The sample supports the following development kits:
 .. include:: /includes/tfm.txt
 
 .. note::
-   Full modem FOTA requires development kit version 1.0.1 or higher.
+   Full modem FOTA requires development kit version 0.14.0 or higher.
 
 The sample requires an `nRF Cloud`_ account.
 
@@ -111,6 +111,9 @@ To create a FOTA test version of this sample, add the following parameter to you
 To enable full modem FOTA, add the following parameter to your build command:
 
 ``-DOVERLAY_CONFIG=overlay_full_modem_fota.conf``
+
+Also, specify your development kit version by appending it to the board name.
+For example, if your development kit version is 1.0.1, use the board name ``nrf9160dk_nrf9160_ns@1_0_1`` in your build command.
 
 Dependencies
 ************

--- a/samples/nrf9160/nrf_cloud_rest_fota/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
+++ b/samples/nrf9160/nrf_cloud_rest_fota/boards/nrf9160dk_nrf9160_ns_0_14_0.overlay
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/ {
-	chosen {
-		nordic,pm-ext-flash = &mx25r64;
-	};
-};
-
 /* Enable high drive mode for the SPI3 pins to get a square signal at 8 MHz */
 &spi3_default {
 	group1 {

--- a/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
+++ b/samples/nrf9160/nrf_cloud_rest_fota/src/main.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(nrf_cloud_rest_fota, CONFIG_NRF_CLOUD_REST_FOTA_SAMPLE_LOG_L
 
 #if defined(CONFIG_NRF_CLOUD_FOTA_FULL_MODEM_UPDATE)
 /* Full modem FOTA requires external flash to hold the full modem image.
- * Below is the external flash device present on the nRF9160 DK version 1.0.1 and higher.
+ * Below is the external flash device present on the nRF9160 DK version 0.14.0 and higher.
  */
 #define EXT_FLASH_DEVICE jedec_spi_nor
 #endif


### PR DESCRIPTION
Enable high drive mode on SPI3 for samples and applications that use the external flash on the nrF9160 DK. This improves the SPI signal to avoid communication issues at 8 MHz.

Updated documentation and comments that said you need the nRF9160 DK version 1.0.1 or higher to use the external flash, because the high drive mode solves the issue for all versions with external flash (version 0.14.0 or higher).

Also removed the re-definition of pinctrl for spi3, and other properties in the overlay which are already default.

Signed-off-by: Gregers Gram Rygg <gregers.gram.rygg@nordicsemi.no>