### PR TITLE
samples: radio_test: Fix sample building with Skyworks FEM

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -2739,6 +2739,17 @@ NCSDK-14015: Execution halts during boot
 NCSDK-13949: TF-M Secure Image copies FICR to RAM on nRF9160
   TF-M Secure Image copies the FICR to RAM address between ``0x2003E000`` and ``0x2003F000`` during boot on nRF9160.
 
+Samples
+*******
+
+.. rst-class:: v2-2-0
+
+NCSDK-18847: :ref:`radio_test` sample does not build with support for Skyworks front-end module.
+  When building a sample with support for a front-end module different from nRF21540, the sample uses a non-existing configuration to initialize Tx power data.
+  This causes a compilation error because the source file containing code for a generic front-end module is not included in the build.
+
+  **Workaround:** Do not use the :kconfig:option:`CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC` Kconfig option and replace ``CONFIG_GENERIC_FEM`` with ``CONFIG_MPSL_FEM_SIMPLE_GPIO`` in the :file:`CMakeLists.txt` file of the sample.
+
 Zephyr
 ******
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -203,7 +203,10 @@ nRF9160 samples
 Peripheral samples
 ------------------
 
-* Added support for nrf7002 board for :ref:`radio_test`.
+* :ref:`radio_test` sample:
+
+  * Added support for the nRF7002 board.
+  * Fixed sample building with support for the Skyworks front-end module.
 
 Trusted Firmware-M (TF-M) samples
 ---------------------------------

--- a/samples/bluetooth/direct_test_mode/src/fem/fem.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/fem.c
@@ -276,6 +276,15 @@ int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_
 	return output_power;
 }
 
+uint32_t fem_default_tx_gain_get(void)
+{
+	if (fem_api->tx_default_gain_get) {
+		return fem_api->tx_default_gain_get();
+	}
+
+	return 0;
+}
+
 int fem_init(NRF_TIMER_Type *timer_instance, uint8_t compare_channel_mask)
 {
 	if (!timer_instance || (compare_channel_mask == 0)) {

--- a/samples/bluetooth/direct_test_mode/src/fem/fem.h
+++ b/samples/bluetooth/direct_test_mode/src/fem/fem.h
@@ -161,6 +161,12 @@ uint32_t fem_radio_rx_ramp_up_delay_get(bool fast, nrf_radio_mode_t mode);
  */
 int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_t freq_mhz);
 
+/** @brief Get the front-end module default Tx gain.
+ *
+ * @return The front-end module default Tx gain value.
+ */
+uint32_t fem_default_tx_gain_get(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/peripheral/radio_test/CMakeLists.txt
+++ b/samples/peripheral/radio_test/CMakeLists.txt
@@ -35,10 +35,15 @@ project(NONE)
 # Application sources
 target_sources_ifdef(CONFIG_FEM app
 			PRIVATE ../../bluetooth/direct_test_mode/src/fem/fem.c)
-target_sources_ifdef(CONFIG_NRF21540_FEM app
-			PRIVATE ../../bluetooth/direct_test_mode/src/fem/nrf21540.c)
-target_sources_ifdef(CONFIG_GENERIC_FEM app
-			PRIVATE ../../bluetooth/direct_test_mode/src/fem/generic_fem.c)
+
+if (CONFIG_MPSL_FEM_NRF21540_GPIO OR CONFIG_MPSL_FEM_NRF21540_GPIO_SPI)
+target_sources(app PRIVATE ../../bluetooth/direct_test_mode/src/fem/nrf21540.c)
+endif()
+
+if (CONFIG_MPSL_FEM_SIMPLE_GPIO)
+  target_sources(app PRIVATE ../../bluetooth/direct_test_mode/src/fem/generic_fem.c)
+endif()
+
 zephyr_include_directories(../../bluetooth/direct_test_mode/src/fem/)
 
 FILE(GLOB app_sources src/*.c)

--- a/samples/peripheral/radio_test/src/radio_cmd.c
+++ b/samples/peripheral/radio_test/src/radio_cmd.c
@@ -60,11 +60,7 @@ static struct radio_param_config {
 } config = {
 	.tx_pattern = TRANSMIT_PATTERN_RANDOM,
 	.mode = NRF_RADIO_MODE_BLE_1MBIT,
-#if CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC
-	.txpower = CONFIG_MPSL_FEM_NRF21540_TX_GAIN_DB,
-#else
 	.txpower = RADIO_TXPOWER_TXPOWER_0dBm,
-#endif /* CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC */
 	.channel_start = 0,
 	.channel_end = 80,
 	.delay_ms = 10,
@@ -1371,6 +1367,13 @@ SHELL_CMD_REGISTER(fem,
 static int radio_cmd_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+#if CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC
+	/* When front-end module is used, set output power to the front-end module
+	 * default gain.
+	 */
+	config.txpower = fem_default_tx_gain_get();
+#endif /* CONFIG_RADIO_TEST_POWER_CONTROL_AUTOMATIC */
 
 	return radio_test_init(&test_config);
 }


### PR DESCRIPTION
Fixed sample building with support for
Skyworks front-end module.