### PR TITLE
nrfxlib: pull fix for PSA storage when using legacy config

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -115,7 +115,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 51f60b21b708368be1437c613129a54f4682d593
+      revision: pull/889/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
PSA storage could not be enabled via Kconfig when using the legacy configuration.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>