### PR TITLE
samples: bluetooth: peripheral_uart: Change from ms to us

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -241,6 +241,10 @@ Bluetooth samples
     The vendor-specific commands for setting the SoC output power and the front-end module gain are not available when the :kconfig:option:`CONFIG_DTM_POWER_CONTROL_AUTOMATIC` Kconfig option is enabled.
   * Added support for +1 dBm, +2 dBm, and +3 dBm output power on the nRF5340 DK.
 
+* :ref:`peripheral_uart` sample:
+
+  * Fixed the unit of the :kconfig:option:`CONFIG_BT_NUS_UART_RX_WAIT_TIME` Kconfig option to comply with the UART API.
+
 Bluetooth mesh samples
 ----------------------
 

--- a/samples/bluetooth/peripheral_uart/Kconfig
+++ b/samples/bluetooth/peripheral_uart/Kconfig
@@ -29,9 +29,9 @@ config BT_NUS_SECURITY_ENABLED
 
 config BT_NUS_UART_RX_WAIT_TIME
 	int "Timeout for UART RX complete event"
-	default 50
+	default 50000
 	help
-	  Wait for RX complete event time in milliseconds
+	  Wait for RX complete event time in microseconds
 
 config BT_NUS_UART_ASYNC_ADAPTER
 	bool "Enable UART async adapter"


### PR DESCRIPTION
Wait time has been changed from ms to us in Zephyr, and is now updated in the peripheral_uart's Kconfig file in this commit.

Signed-off-by <edvin.holmseth@nordicsemi.no>