### PR TITLE
tests: Cleanup setUp and tearDown functions

### DIFF
--- a/applications/asset_tracker_v2/tests/debug_module/src/debug_module_test.c
+++ b/applications/asset_tracker_v2/tests/debug_module/src/debug_module_test.c
@@ -7,14 +7,15 @@
 #include <unity.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <cmock_modules_common.h>
-#include <cmock_app_event_manager.h>
-#include <cmock_app_event_manager_priv.h>
-#include <cmock_watchdog_app.h>
 #include <memfault/metrics/cmock_metrics.h>
 #include <memfault/core/cmock_data_packetizer.h>
 #include <memfault/ports/cmock_watchdog.h>
 #include <memfault/panics/cmock_coredump.h>
+
+#include "cmock_modules_common.h"
+#include "cmock_app_event_manager.h"
+#include "cmock_app_event_manager_priv.h"
+#include "cmock_watchdog_app.h"
 
 #include "app_module_event.h"
 #include "location_module_event.h"
@@ -56,30 +57,6 @@ extern int unity_main(void);
  * infuse callback events directly from the test runner.
  */
 watchdog_evt_handler_t debug_module_watchdog_callback;
-
-/* Suite teardown finalizes with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
-}
-
-void setUp(void)
-{
-	cmock_watchdog_app_Init();
-	cmock_modules_common_Init();
-	cmock_app_event_manager_Init();
-	cmock_app_event_manager_priv_Init();
-}
-
-void tearDown(void)
-{
-	cmock_watchdog_app_Verify();
-	cmock_modules_common_Verify();
-	cmock_app_event_manager_Verify();
-	cmock_app_event_manager_priv_Verify();
-}
 
 static void latch_watchdog_callback(watchdog_evt_handler_t handler, int no_of_calls)
 {

--- a/applications/asset_tracker_v2/tests/location_module/src/location_module_test.c
+++ b/applications/asset_tracker_v2/tests/location_module/src/location_module_test.c
@@ -6,12 +6,13 @@
 #include <unity.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <cmock_modules_common.h>
-#include <cmock_app_event_manager.h>
-#include <cmock_app_event_manager_priv.h>
-#include <cmock_location.h>
-#include <cmock_lte_lc.h>
-#include <cmock_nrf_modem_gnss.h>
+
+#include "cmock_modules_common.h"
+#include "cmock_app_event_manager.h"
+#include "cmock_app_event_manager_priv.h"
+#include "cmock_location.h"
+#include "cmock_lte_lc.h"
+#include "cmock_nrf_modem_gnss.h"
 
 #include "app_module_event.h"
 #include "location_module_event.h"
@@ -75,23 +76,8 @@ struct event_type __event_type_modem_module_event;
  */
 extern int unity_main(void);
 
-
-/* Suite teardown finalizes with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
-}
-
-
 void setUp(void)
 {
-	cmock_modules_common_Init();
-	cmock_app_event_manager_Init();
-	cmock_location_Init();
-	cmock_nrf_modem_gnss_Init();
-
 	location_module_event_count = 0;
 	expected_location_module_event_count = 0;
 	memset(&expected_location_module_events, 0, sizeof(expected_location_module_events));
@@ -104,11 +90,6 @@ void tearDown(void)
 		k_sem_take(&location_module_event_sem, K_SECONDS(1));
 	}
 	TEST_ASSERT_EQUAL(expected_location_module_event_count, location_module_event_count);
-
-	cmock_modules_common_Verify();
-	cmock_app_event_manager_Verify();
-	cmock_location_Verify();
-	cmock_nrf_modem_gnss_Verify();
 }
 
 static void validate_location_module_evt(struct app_event_header *aeh, int no_of_calls)
@@ -531,6 +512,7 @@ void test_location_fail_init(void)
 {
 	setup_location_module_in_init_state();
 
+	__cmock__event_submit_Stub(&validate_location_module_evt);
 	__cmock_location_init_ExpectAndReturn(&location_event_handler, -EINVAL);
 
 	/* Set expected GNSS module events. */

--- a/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_codec_helpers/src/lwm2m_codec_helpers_test.c
@@ -34,13 +34,6 @@
 #define UNIX_TIMESTAMP_DUMMY 1670233084418
 
 extern int unity_main(void);
-extern int generic_suiteTearDown(int num_failures);
-
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
-}
 
 /* Used to verify that the uut properly sets the value that is returned by date_time_now() to
  * the Current Time resource 3/0/13.

--- a/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
@@ -53,21 +53,9 @@ static void set_update_state_callback_stub(lwm2m_firmware_get_update_state_cb_t 
 
 extern int unity_main(void);
 
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
-}
-
 /* Setup and teardown functions. */
 void setUp(void)
 {
-	cmock_lwm2m_client_utils_Init();
-	cmock_lwm2m_Init();
-	cmock_lte_lc_Init();
-
 	__cmock_lwm2m_init_image_ExpectAndReturn(0);
 	__cmock_lwm2m_init_firmware_ExpectAndReturn(0);
 	__cmock_lwm2m_init_security_ExpectAndReturn(&client,
@@ -87,13 +75,6 @@ void setUp(void)
 	__cmock_lwm2m_firmware_set_update_state_cb_AddCallback(&set_update_state_callback_stub);
 
 	TEST_ASSERT_EQUAL(0, cloud_wrap_init(cloud_wrap_event_handler));
-}
-
-void tearDown(void)
-{
-	cmock_lwm2m_client_utils_Verify();
-	cmock_lwm2m_Verify();
-	cmock_lte_lc_Verify();
 }
 
 /* Callbacks stubs that latches events handlers in mocked libraries so that they can be triggered

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec/src/nrf_cloud_codec_test.c
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec/src/nrf_cloud_codec_test.c
@@ -27,14 +27,6 @@ void tearDown(void)
 	cJSON_FreeString(codec.buf);
 }
 
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
-}
-
 #define CONF_RECV_EXAMPLE \
 "{"\
 	"\"config\":{"\

--- a/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/src/nrf_cloud_codec_mocked_test.c
+++ b/applications/asset_tracker_v2/tests/nrf_cloud_codec_mocked_cjson/src/nrf_cloud_codec_mocked_test.c
@@ -21,30 +21,11 @@ static int ret;
 
 void setUp(void)
 {
-	cmock_cJSON_to_mock_Init();
-	cmock_date_time_Init();
-	cmock_json_helpers_Init();
-
 	__cmock_cJSON_Init_Ignore();
 	ret = cloud_codec_init(NULL, NULL);
 	TEST_ASSERT_EQUAL(0, ret);
 
 	memset(&codec, 0, sizeof(codec));
-}
-
-void tearDown(void)
-{
-	cmock_cJSON_to_mock_Verify();
-	cmock_date_time_Verify();
-	cmock_json_helpers_Verify();
-}
-
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
 }
 
 /**

--- a/applications/asset_tracker_v2/tests/ui_module/src/ui_module_test.c
+++ b/applications/asset_tracker_v2/tests/ui_module/src/ui_module_test.c
@@ -7,10 +7,11 @@
 #include <unity.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <cmock_modules_common.h>
-#include <cmock_app_event_manager_priv.h>
-#include <cmock_app_event_manager.h>
-#include <cmock_dk_buttons_and_leds.h>
+
+#include "cmock_modules_common.h"
+#include "cmock_app_event_manager_priv.h"
+#include "cmock_app_event_manager.h"
+#include "cmock_dk_buttons_and_leds.h"
 
 #include "events/app_module_event.h"
 #include "events/data_module_event.h"
@@ -66,19 +67,8 @@ struct event_type __event_type_util_module_event;
  */
 extern int unity_main(void);
 
-/* Suite teardown finalizes with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
-}
-
 void setUp(void)
 {
-	cmock_modules_common_Init();
-	cmock_app_event_manager_Init();
-
 	/* Reset internal module states. */
 	state = 0;
 	sub_state = 0;
@@ -86,12 +76,6 @@ void setUp(void)
 
 	/* Clear internal LED pattern transition list. */
 	transition_list_clear();
-}
-
-void tearDown(void)
-{
-	cmock_modules_common_Verify();
-	cmock_app_event_manager_Verify();
 }
 
 /* Stub used to verify parameters passed into module_start(). */

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -12,10 +12,11 @@
 #include <modem/location.h>
 #include <modem/lte_lc.h>
 #include <mock_nrf_modem_at.h>
-#include <cmock_nrf_modem_at.h>
-#include <cmock_nrf_modem_gnss.h>
-#include <cmock_modem_key_mgmt.h>
-#include <cmock_rest_client.h>
+
+#include "cmock_nrf_modem_at.h"
+#include "cmock_nrf_modem_gnss.h"
+#include "cmock_modem_key_mgmt.h"
+#include "cmock_rest_client.h"
 
 /* NOTE: Sleep, e.g. k_sleep(K_MSEC(1)), is used after many location library API
  *       function calls because otherwise some of the threaded work in location library
@@ -111,10 +112,6 @@ void setUp(void)
 	k_sem_reset(&event_handler_called_sem);
 
 	mock_nrf_modem_at_Init();
-	cmock_nrf_modem_at_Init();
-	cmock_nrf_modem_gnss_Init();
-	cmock_rest_client_Init();
-	cmock_modem_key_mgmt_Init();
 }
 
 void tearDown(void)
@@ -128,10 +125,6 @@ void tearDown(void)
 	TEST_ASSERT_EQUAL(location_callback_called_expected, location_callback_called_occurred);
 
 	mock_nrf_modem_at_Verify();
-	cmock_nrf_modem_at_Verify();
-	cmock_nrf_modem_gnss_Verify();
-	cmock_rest_client_Verify();
-	cmock_modem_key_mgmt_Verify();
 }
 
 static void location_event_handler(const struct location_event_data *event_data)

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -11,8 +11,9 @@
 #include <zephyr/device.h>
 #include <modem/lte_lc.h>
 #include <nrf_errno.h>
-#include <cmock_nrf_modem_at.h>
 #include <mock_nrf_modem_at.h>
+
+#include "cmock_nrf_modem_at.h"
 
 void wrap_lc_init(void)
 {
@@ -33,7 +34,6 @@ void wrap_lc_init(void)
 
 void setUp(void)
 {
-	cmock_nrf_modem_at_Init();
 	mock_nrf_modem_at_Init();
 	wrap_lc_init();
 }
@@ -46,7 +46,6 @@ void tearDown(void)
 
 	ret = lte_lc_deinit();
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
-	cmock_nrf_modem_at_Verify();
 	mock_nrf_modem_at_Verify();
 }
 

--- a/tests/lib/modem_jwt/src/jwt_test.c
+++ b/tests/lib/modem_jwt/src/jwt_test.c
@@ -9,11 +9,16 @@
 #include <string.h>
 #include <zephyr/kernel.h>
 #include <modem/modem_jwt.h>
-#include <cmock_nrf_modem_at.h>
 
+#include "cmock_nrf_modem_at.h"
+
+
+/* Return value to be returned by the stub for nrf_modem_at_cmd. */
+static int at_cmd_stub_ret_val;
 
 void setUp(void)
 {
+	at_cmd_stub_ret_val = 0;
 }
 
 void tearDown(void)
@@ -39,14 +44,9 @@ static const char jwt_token[] =
 
 int cmd_cb(void *buf, size_t len, const char *fmt, int cmock_num_calls)
 {
-	if (cmock_num_calls == 0) {
-		/* Fail first call */
-		return -1;
-	}
-
 	strncpy(buf, jwt_token, len - 1);
 	((char *)buf)[len-1] = 0;
-	return 0;
+	return at_cmd_stub_ret_val;
 }
 
 void test_modem_jwt_generate(void)
@@ -55,7 +55,6 @@ void test_modem_jwt_generate(void)
 	int rc;
 
 	/* Few failure cases */
-
 	rc = modem_jwt_generate(NULL);
 	TEST_ASSERT_EQUAL_INT(-EINVAL, rc);
 
@@ -69,10 +68,14 @@ void test_modem_jwt_generate(void)
 	__cmock_nrf_modem_at_cmd_Stub(cmd_cb);
 
 	/* First call should fail, pass through the error code */
+	at_cmd_stub_ret_val = -1;
+
 	rc = modem_jwt_generate(&jwt);
 	TEST_ASSERT_EQUAL_INT(-1, rc);
 
 	/* Success case, default parameters */
+	at_cmd_stub_ret_val = 0;
+
 	rc = modem_jwt_generate(&jwt);
 	TEST_ASSERT_EQUAL_INT(0, rc);
 
@@ -94,6 +97,9 @@ void test_modem_jwt_get_uuids(void)
 	struct nrf_device_uuid dev = {0};
 	struct nrf_modem_fw_uuid mfw = {0};
 	int rc;
+
+	at_cmd_stub_ret_val = 0;
+	__cmock_nrf_modem_at_cmd_Stub(cmd_cb);
 
 	rc = modem_jwt_get_uuids(&dev, &mfw);
 	TEST_ASSERT_EQUAL_INT(0, rc);

--- a/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
+++ b/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
@@ -22,9 +22,6 @@ LOG_MODULE_REGISTER(trace_test, CONFIG_NRF_MODEM_LIB_TRACE_TEST_LOG_LEVEL);
 
 extern int unity_main(void);
 
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
 static void clear_rw_frags(void);
 
 static const char *trace_level_set_fmt = "AT%%XMODEMTRACE=1,%d";
@@ -53,10 +50,6 @@ static void nrf_modem_at_printf_ExpectTraceLevelAndReturn(
 
 void setUp(void)
 {
-	cmock_nrf_modem_Init();
-	cmock_nrf_modem_trace_Init();
-	cmock_trace_backend_Init();
-
 	nrf_modem_trace_get_error = 0;
 	nrf_modem_trace_get_cmock_num_calls = 0;
 	trace_backend_write_error = 0;
@@ -66,13 +59,6 @@ void setUp(void)
 		"AT%%XMODEMTRACE=1,%d", NRF_MODEM_LIB_TRACE_LEVEL_FULL, 0);
 
 	clear_rw_frags();
-}
-
-void tearDown(void)
-{
-	cmock_nrf_modem_Verify();
-	cmock_nrf_modem_trace_Verify();
-	cmock_trace_backend_Verify();
 }
 
 static void NRF_MODEM_LIB_ON_INIT_callback(void)
@@ -210,11 +196,6 @@ int trace_backend_deinit_stub(int cmock_num_calls)
 	k_sem_give(&backend_deinit_sem);
 
 	return 0;
-}
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
 }
 
 void test_trace_thread_handler_get_single(void)

--- a/tests/lib/nrf_modem_lib/trace_backends/rtt/src/main.c
+++ b/tests/lib/nrf_modem_lib/trace_backends/rtt/src/main.c
@@ -21,20 +21,7 @@ static int callback(size_t len)
 
 extern int unity_main(void);
 
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
 static int trace_rtt_channel;
-
-void setUp(void)
-{
-	cmock_SEGGER_RTT_Init();
-}
-
-void tearDown(void)
-{
-	cmock_SEGGER_RTT_Verify();
-}
 
 static int rtt_allocupbuffer_callback(const char *sName, void *pBuffer, unsigned int BufferSize,
 				      unsigned int Flags, int no_of_calls)
@@ -47,11 +34,6 @@ static int rtt_allocupbuffer_callback(const char *sName, void *pBuffer, unsigned
 	TEST_ASSERT_EQUAL(SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL, Flags);
 
 	return trace_rtt_channel;
-}
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
 }
 
 void test_trace_backend_init_rtt(void)

--- a/tests/lib/nrf_modem_lib/trace_backends/uart/src/main.c
+++ b/tests/lib/nrf_modem_lib/trace_backends/uart/src/main.c
@@ -16,9 +16,6 @@
 
 extern int unity_main(void);
 
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
 static const nrfx_uarte_t *p_uarte_inst_in_use;
 /* Variable to store the event_handler registered by the modem_trace module.*/
 static nrfx_uarte_event_handler_t uarte_callback;
@@ -34,17 +31,8 @@ void nrfx_isr(const void *irq_handler)
 	TEST_ASSERT(false);
 }
 
-void setUp(void)
-{
-	cmock_nrfx_uarte_Init();
-	cmock_pinctrl_Init();
-}
-
 void tearDown(void)
 {
-	cmock_nrfx_uarte_Verify();
-	cmock_pinctrl_Verify();
-
 	p_uarte_inst_in_use = NULL;
 	uarte_callback = NULL;
 }
@@ -122,11 +110,6 @@ static void trace_test_thread(void)
 
 K_THREAD_DEFINE(trace_test_thread_id, TRACE_TEST_THREAD_STACK_SIZE, trace_test_thread,
 		NULL, NULL, NULL, TRACE_THREAD_PRIORITY, 0, 0);
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
-}
 
 /* Test that uart trace backend returns zero when NRFX UART Init succeeds. */
 void test_trace_backend_init_uart(void)

--- a/tests/lib/sms/src/sms_test.c
+++ b/tests/lib/sms/src/sms_test.c
@@ -11,7 +11,8 @@
 #include <zephyr/device.h>
 #include <modem/sms.h>
 #include <modem/at_monitor.h>
-#include <cmock_nrf_modem_at.h>
+
+#include "cmock_nrf_modem_at.h"
 
 
 static struct sms_data test_sms_data = {0};
@@ -46,15 +47,11 @@ void setUp(void)
 	test_handle = 0;
 	sms_callback_called_occurred = false;
 	sms_callback_called_expected = false;
-
-	cmock_nrf_modem_at_Init();
 }
 
 void tearDown(void)
 {
 	TEST_ASSERT_EQUAL(sms_callback_called_expected, sms_callback_called_occurred);
-
-	cmock_nrf_modem_at_Verify();
 }
 
 static void sms_reg_helper(void)

--- a/tests/subsys/net/lib/azure_iot_hub/dps/src/azure_iot_hub_dps_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/dps/src/azure_iot_hub_dps_test.c
@@ -47,7 +47,6 @@
 #define TEST_EXPECTED_USER_NAME_DEFAULT_LEN	(sizeof(TEST_EXPECTED_USER_NAME_DEFAULT) - 1)
 
 extern int unity_main(void);
-extern int generic_suiteTearDown(int num_failures);
 
 /* Pull in variables and functions from the DPS library. */
 extern enum dps_state dps_state;
@@ -70,8 +69,6 @@ static K_SEM_DEFINE(reg_assigning_sem, 0, 1);
 /* Test suite configuration functions */
 void setUp(void)
 {
-	cmock_azure_iot_hub_mqtt_Init();
-	cmock_settings_Init();
 	__cmock_settings_subsys_init_IgnoreAndReturn(0);
 	__cmock_settings_load_subtree_IgnoreAndReturn(0);
 	__cmock_settings_save_one_IgnoreAndReturn(0);
@@ -83,16 +80,8 @@ void setUp(void)
 
 void tearDown(void)
 {
-	cmock_azure_iot_hub_mqtt_Verify();
-	cmock_settings_Verify();
 	__cmock_mqtt_helper_disconnect_IgnoreAndReturn(0);
 	azure_iot_hub_dps_reset();
-}
-
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
 }
 
 /* Stubs */

--- a/tests/subsys/net/lib/azure_iot_hub/iot_hub/src/azure_iot_hub_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/iot_hub/src/azure_iot_hub_test.c
@@ -83,24 +83,9 @@ extern int unity_main(void);
 extern void iot_hub_state_set(enum iot_hub_state state);
 extern enum iot_hub_state iot_hub_state;
 
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
 void setUp(void)
 {
-	cmock_azure_iot_hub_mqtt_Init();
-
 	iot_hub_state = STATE_UNINIT;
-}
-
-void tearDown(void)
-{
-	cmock_azure_iot_hub_mqtt_Verify();
-}
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
 }
 
 /* Stubs */

--- a/tests/subsys/net/lib/azure_iot_hub/mqtt/src/azure_iot_hub_mqtt_test.c
+++ b/tests/subsys/net/lib/azure_iot_hub/mqtt/src/azure_iot_hub_mqtt_test.c
@@ -49,9 +49,6 @@ extern void mqtt_helper_poll_loop(void);
 extern void on_publish(const struct mqtt_evt *mqtt_evt);
 extern char payload_buf[];
 
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
 /* Semaphores used by tests to wait for a certain callbacks */
 static K_SEM_DEFINE(connack_success_sem, 0, 1);
 static K_SEM_DEFINE(connack_failed_sem, 0, 1);
@@ -63,8 +60,6 @@ static K_SEM_DEFINE(error_msg_size_sem, 0, 1);
 
 void setUp(void)
 {
-	cmock_mqtt_Init();
-	cmock_socket_Init();
 	__cmock_mqtt_keepalive_time_left_IgnoreAndReturn(0);
 
 	/* Suspend the polling thread to have full control over polling. */
@@ -72,17 +67,6 @@ void setUp(void)
 
 	/* Force all tests to start in uninitialized state. */
 	mqtt_state = MQTT_STATE_UNINIT;
-}
-
-void tearDown(void)
-{
-	cmock_mqtt_Verify();
-	cmock_socket_Verify();
-}
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
 }
 
 /* Stubs */

--- a/tests/unity/example_test/src/example_test.c
+++ b/tests/unity/example_test/src/example_test.c
@@ -17,14 +17,6 @@ void setUp(void)
 	runtime_CONFIG_UUT_PARAM_CHECK = false;
 }
 
-/* Suite teardown shall finalize with mandatory call to generic_suiteTearDown. */
-extern int generic_suiteTearDown(int num_failures);
-
-int test_suiteTearDown(int num_failures)
-{
-	return generic_suiteTearDown(num_failures);
-}
-
 void test_uut_init(void)
 {
 	int err;


### PR DESCRIPTION
- The `cmock_*_Init()` and `cmock_*_Verify()` are not needed to be placed in `setUp()` and `tearDown()` functions in the unit tests. These are automically called by the generated function `CMock_Init()` in `runner_*_test.c`.

- The `test_suiteTearDown()` is not needed as there is a weak definition of the same function doing the same thing in `generic_teardown.c` within unity framework.

- Used double quotes instead of angular brackets when including cmock generated headers because
-- They are not system headers or library headers to be included that way
-- They are generated in subfolders of current working directory
-- The _Init and _Verify functions are not automatically called by Cmock if these headers are not included this way. I believe the `generate_runner.rb` assumes that all cmock files are included with double quotes and not angular braces which is a normal way of including these headers.

- Fixed a couple of test bugs in modem_jwt test and location_module test that were uncovered due to these changes.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>