### PR TITLE
manifest: pull Matter fix for WPA3 Wi-Fi connection

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -72,6 +72,11 @@ Matter
 * Added:
 
   * Support for Wi-Fi Network Diagnostic Cluster (which counts the number of packets received and transmitted on the Wi-Fi interface).
+  * Default support for nRF7002 revision B.
+
+* Fixed:
+
+  * Connection timing out when attaching to a Wi-Fi Access Point that requires Wi-Fi Protected Access 3 (WPA3).
 
 * Updated:
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -115,9 +115,6 @@
    The controller device is used to pair and control the Matter accessory device remotely over a network, interacting with it using Bluetooth® LE and the regular IPv6 communication.
 .. |matter_chip_tool_pc_default_line| replace:: CHIP Tool for Linux or macOS is the default implementation of the :ref:`ug_matter_configuring_controller` role, recommended for the nRF Connect platform.
 .. |matter_chip_tool_android_recommended_line| replace:: CHIP Tool for Android (also known as Android CHIPTool) is the recommended :ref:`ug_matter_configuring_controller` for mobile, which allows you to test Matter applications using an Android smartphone.
-.. |matter_wifi_revb_ncs220_test_note| replace:: All Matter samples in the |NCS| v2.2.0 that offer Wi-Fi support have been tested using the nRF7002 DK (PCA10143) rev. A and are built with rev. A support by default.
-   You can configure Matter samples to use rev. B by setting the :kconfig:option:`CONFIG_NRF700X_REV_A` Kconfig option to ``n``.
-   Make sure that you build the samples for the revision of the nRF7002 DK that you are using.
 
 .. ### Other shortcuts
 

--- a/samples/matter/light_bulb/README.rst
+++ b/samples/matter/light_bulb/README.rst
@@ -20,9 +20,6 @@ You can use this sample as a reference for creating your own application.
 Requirements
 ************
 
-.. note::
-    |matter_wifi_revb_ncs220_test_note|
-
 The sample supports the following development kits:
 
 .. table-from-sample-yaml::

--- a/samples/matter/light_switch/README.rst
+++ b/samples/matter/light_switch/README.rst
@@ -17,9 +17,6 @@ You can use this sample as a reference for creating your own application.
 Requirements
 ************
 
-.. note::
-    |matter_wifi_revb_ncs220_test_note|
-
 The sample supports the following development kits:
 
 .. table-from-sample-yaml::

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -17,9 +17,6 @@ You can use this sample as a reference for creating your application.
 Requirements
 ************
 
-.. note::
-    |matter_wifi_revb_ncs220_test_note|
-
 The sample supports the following development kits:
 
 .. table-from-sample-yaml::

--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -40,7 +40,7 @@ tests:
     tags: ci_build
   sample.matter.lock.smp_dfu_ffs_wifi:
     build_only: true
-    extra_args: CONFIG_NET_SHELL=y CONFIG_NRF700X_REV_A=y CONFIG_CHIP_DFU_OVER_BT_SMP=y CONFIG_CHIP_LIB_SHELL=y
+    extra_args: CONFIG_NET_SHELL=y CONFIG_CHIP_DFU_OVER_BT_SMP=y CONFIG_CHIP_LIB_SHELL=y
       CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y CONFIG_CHIP_ROTATING_DEVICE_ID=y CONFIG_CHIP_DEVICE_TYPE=10
     integration_platforms:
       - nrf7002dk_nrf5340_cpuapp

--- a/samples/matter/template/README.rst
+++ b/samples/matter/template/README.rst
@@ -18,9 +18,6 @@ See the :ref:`ug_matter_creating_accessory` page for an overview of the process 
 Requirements
 ************
 
-.. note::
-    |matter_wifi_revb_ncs220_test_note|
-
 The sample supports the following development kits:
 
 .. table-from-sample-yaml::


### PR DESCRIPTION
This PR also removes the default support for nRF7002 revision A in Matter, 
since now we only maintain revision B.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>