### PR TITLE
samples: matter: lock: simplify flashing to external flash

### DIFF
--- a/samples/matter/lock/CMakeLists.txt
+++ b/samples/matter/lock/CMakeLists.txt
@@ -68,4 +68,22 @@ chip_configure_data_model(app
     INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/lock.zap
 )
+
+if(CONFIG_THREAD_WIFI_SWITCHING)
+    find_package(Python3)
+    set(app_idx ${CONFIG_APPLICATION_IDX})
+    add_custom_target(flash-external
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/src/flash-external.py
+            --app ${APPLICATION_BINARY_DIR}/zephyr/app_update.bin
+            --app-offset ${PM_APP_${app_idx}_CORE_APP_OFFSET}
+            --app-size ${PM_APP_${app_idx}_CORE_APP_SIZE}
+            --net ${APPLICATION_BINARY_DIR}/zephyr/net_core_app_update.bin
+            --net-offset ${PM_APP_${app_idx}_CORE_NET_OFFSET}
+            --net-size ${PM_APP_${app_idx}_CORE_NET_SIZE}
+        USES_TERMINAL
+        DEPENDS
+            ${APPLICATION_BINARY_DIR}/zephyr/app_update.bin
+            ${APPLICATION_BINARY_DIR}/zephyr/net_core_app_update.bin
+    )
+endif()
 # NORDIC SDK APP END

--- a/samples/matter/lock/Kconfig
+++ b/samples/matter/lock/Kconfig
@@ -29,11 +29,36 @@ config STATE_LEDS
 config THREAD_WIFI_SWITCHING
 	bool "Switching between Thread and Wi-Fi network support"
 	depends on SOC_SERIES_NRF53X
+	depends on NET_L2_OPENTHREAD || CHIP_WIFI
 	select EXPERIMENTAL
 	help
 	  Enable the functionality that allows a user to switch between Matter over Thread and Matter
 	  over Wi-Fi variants of the application, stored in the respective partitions in the external
 	  flash memory.
+
+if THREAD_WIFI_SWITCHING
+
+config APPLICATION_IDX
+	int
+	default 1 if NET_L2_OPENTHREAD
+	default 2 if CHIP_WIFI
+
+config APPLICATION_OTHER_IDX
+	int
+	default 2 if NET_L2_OPENTHREAD
+	default 1 if CHIP_WIFI
+
+config APPLICATION_LABEL
+	string
+	default "Thread" if NET_L2_OPENTHREAD
+	default "Wi-Fi" if CHIP_WIFI
+
+config APPLICATION_OTHER_LABEL
+	string
+	default "Wi-Fi" if NET_L2_OPENTHREAD
+	default "Thread" if CHIP_WIFI
+
+endif
 
 # Sample configuration used for Thread networking
 if NET_L2_OPENTHREAD

--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -91,7 +91,7 @@ This sample supports the following build types, depending on the selected board:
 
 * ``debug`` -- Debug version of the application - can be used to enable additional features for verifying the application behavior, such as logs or command-line shell.
 * ``release`` -- Release version of the application - can be used to enable only the necessary application functionalities to optimize its performance.
-* ``thread_wifi_switched`` -- Debug version of the application with the ability to switch between Thread and Wi-Fi network support in the field - can be used for the nRF5340 DK with the nRF7002 EK shield attached.
+* ``thread_wifi_switched`` -- Debug version of the application with the ability to :ref:`switch between Thread and Wi-Fi network support <matter_lock_sample_switching_thread_wifi>` in the field - can be used for the nRF5340 DK with the nRF7002 EK shield attached.
 * ``no_dfu`` -- Debug version of the application without Device Firmware Upgrade feature support - can be used for the nRF52840 DK, nRF5340 DK, nRF7002 DK, and nRF21540 DK.
 
 .. note::
@@ -328,6 +328,57 @@ Upgrading the device firmware
 =============================
 
 To upgrade the device firmware, complete the steps listed for the selected method in the :doc:`matter:nrfconnect_examples_software_update` tutorial of the Matter documentation.
+
+.. _matter_lock_sample_switching_thread_wifi:
+
+Switching between Thread and Wi-Fi
+==================================
+
+The ``thread_wifi_switched`` build type allows you to build the door lock application that supports dynamic switching between Matter over Thread and Matter over Wi-Fi.
+This feature requires that both variants of the application are built and placed in appropriate partitions of the external flash.
+After that, when a user triggers the switch, the device is rebooted into the MCUboot bootloader, which swaps the current variant.
+
+To test switching between Thread and Wi-Fi, complete the following steps:
+
+#. Build the door lock application for Matter over Thread:
+
+   .. code-block:: console
+
+      west build -b nrf5340dk_nrf5340_cpuapp -- -DCONF_FILE=prj_thread_wifi_switched.conf -DSHIELD=nrf7002_ek -DCONFIG_CHIP_WIFI=n
+
+#. Program the application to the kit using the following command:
+
+   .. code-block:: console
+
+      west flash --erase
+
+#. Program the application to a partition of the external flash using the following command:
+
+   .. code-block:: console
+
+      west build -t flash-external
+
+#. Build the door lock application for Matter over Wi-Fi:
+
+   .. code-block:: console
+
+      west build -b nrf5340dk_nrf5340_cpuapp -p always -- -DCONF_FILE=prj_thread_wifi_switched.conf -DSHIELD=nrf7002_ek
+
+#. Program the application to another partition of the external flash using the following command:
+
+   .. code-block:: console
+
+      west build -t flash-external
+
+#. |connect_terminal_ANSI|
+#. Press **Button 3** for more than ten seconds to trigger switching to the Matter over Wi-Fi variant of the application.
+#. Observe logs showing the progress of the operation until the device shuts down.
+#. Wait until the device boots again.
+#. Find the following log message which indicates that the expected variant of the application is running:
+
+   .. code-block:: console
+
+      D: 823 [DL]WiFiManager has been initialized
 
 Dependencies
 ************

--- a/samples/matter/lock/src/flash-external.py
+++ b/samples/matter/lock/src/flash-external.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+"""
+Utility for programming nRF53 application into the external flash
+"""
+
+import argparse
+from intelhex import IntelHex
+import os
+import subprocess
+import tempfile
+
+# Base address of the memory-mapped QSPI flash on nRF53 SoCs
+NRF53_XIP_REGION_BASE = 0x10000000
+
+
+def program(app_data, app_offset, net_data, net_offset):
+    with tempfile.TemporaryDirectory() as outdir:
+        dest_file = os.path.join(outdir, 'external.hex')
+
+        ihex = IntelHex()
+        ihex.putsz(NRF53_XIP_REGION_BASE + app_offset, app_data)
+        ihex.putsz(NRF53_XIP_REGION_BASE + net_offset, net_data)
+        ihex.write_hex_file(dest_file)
+
+        subprocess.check_call(['nrfjprog', '--program', dest_file, '--reset'])
+
+
+def main():
+    # Type for an integer of arbitrary base
+    def any_base_int(s): return int(s, 0)
+
+    parser = argparse.ArgumentParser(description="Program firmware into external flash")
+    parser.add_argument('--app', required=True, type=argparse.FileType('rb'),
+                        help="Application core image in MCUboot format")
+    parser.add_argument('--app-offset', type=any_base_int, required=True,
+                        help='Offset of target partition for application core image')
+    parser.add_argument('--app-size', type=any_base_int, required=True,
+                        help='Size of target partition for application core image')
+    parser.add_argument('--net', required=True, type=argparse.FileType('rb'),
+                        help="Network core image in MCUboot format")
+    parser.add_argument('--net-offset', type=any_base_int, required=True,
+                        help='Offset of target partition for network core image')
+    parser.add_argument('--net-size', type=any_base_int, required=True,
+                        help='Size of target partition for network core image')
+    args = parser.parse_args()
+
+    app_data = args.app.read()
+    net_data = args.net.read()
+
+    if len(app_data) > args.app_size:
+        raise ValueError(
+            f'Application core image exceeds partition size: {len(app_data)} > {args.app_size}')
+
+    if len(app_data) > args.app_size:
+        raise ValueError(
+            f'Network core image exceeds partition size: {len(net_data)} > {args.net_size}')
+
+    program(app_data, args.app_offset, net_data, args.net_offset)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/matter/lock/src/software_images_swapper.cpp
+++ b/samples/matter/lock/src/software_images_swapper.cpp
@@ -6,8 +6,6 @@
 
 #include "software_images_swapper.h"
 
-#include <pm_config.h>
-
 #include <dfu/dfu_multi_image.h>
 #include <dfu/dfu_target.h>
 #include <dfu/dfu_target_mcuboot.h>
@@ -18,12 +16,8 @@
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 
-int SoftwareImagesSwapper::Swap(ApplicationImageId applicationId, SoftwareImagesSwapDoneCallback swapDoneCallback)
+int SoftwareImagesSwapper::Swap(const ImageLocation &source, SoftwareImagesSwapDoneCallback swapDoneCallback)
 {
-	uint32_t app_address;
-	uint32_t app_size;
-	uint32_t net_address;
-	uint32_t net_size;
 	int result;
 
 	if (mSwapInProgress) {
@@ -31,22 +25,6 @@ int SoftwareImagesSwapper::Swap(ApplicationImageId applicationId, SoftwareImages
 	}
 
 	if (!swapDoneCallback) {
-		return -EINVAL;
-	}
-
-	if (applicationId == ApplicationImageId::Image_1) {
-		app_address = PM_APP_1_CORE_APP_ADDRESS;
-		app_size = PM_APP_1_CORE_APP_SIZE;
-		net_address = PM_APP_1_CORE_NET_ADDRESS;
-		net_size = PM_APP_1_CORE_NET_SIZE;
-	} else if (applicationId == ApplicationImageId::Image_2) {
-		app_address = PM_APP_2_CORE_APP_ADDRESS;
-		app_size = PM_APP_2_CORE_APP_SIZE;
-		net_address = PM_APP_2_CORE_NET_ADDRESS;
-		net_size = PM_APP_2_CORE_NET_SIZE;
-	} else {
-		LOG_ERR("Requested to swap application image with invalid identifier: %d",
-			static_cast<int>(applicationId));
 		return -EINVAL;
 	}
 
@@ -62,13 +40,13 @@ int SoftwareImagesSwapper::Swap(ApplicationImageId applicationId, SoftwareImages
 
 	mSwapInProgress = true;
 
-	result = SwapImage(app_address, app_size, 0);
+	result = SwapImage(source.app_address, source.app_size, 0);
 	if (result != 0) {
 		mSwapInProgress = false;
 		goto exit;
 	}
 
-	result = SwapImage(net_address, net_size, 1);
+	result = SwapImage(source.net_address, source.net_size, 1);
 	if (result != 0) {
 		mSwapInProgress = false;
 		goto exit;

--- a/samples/matter/lock/src/software_images_swapper.h
+++ b/samples/matter/lock/src/software_images_swapper.h
@@ -12,9 +12,11 @@ typedef void (*SoftwareImagesSwapDoneCallback)(void);
 
 class SoftwareImagesSwapper {
 public:
-	enum class ApplicationImageId : uint8_t {
-		Image_1 = 0,
-		Image_2,
+	struct ImageLocation {
+		const uint32_t app_address;
+		const uint32_t app_size;
+		const uint32_t net_address;
+		const uint32_t net_size;
 	};
 
 	static SoftwareImagesSwapper &Instance()
@@ -23,7 +25,7 @@ public:
 		return sSoftwareImagesSwapper;
 	};
 
-	int Swap(ApplicationImageId applicationId, SoftwareImagesSwapDoneCallback swapDoneCallback);
+	int Swap(const ImageLocation &source, SoftwareImagesSwapDoneCallback swapDoneCallback);
 
 private:
 	const struct device *mFlashDevice = DEVICE_DT_GET(DT_CHOSEN(nordic_pm_ext_flash));


### PR DESCRIPTION
When application is built with support for switching between Thread and Wi-Fi, define another CMake target:
'flash-external' that allows a user to easily program the application variant into the right partition of the external flash memory.

Extend the documentation with the procedure to test this feature.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>