### PR TITLE
applications: asset_tracker_v2: Remove filtered A-GPS Kconfig options

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker_v2/src/cloud/cloud_codec/cloud_codec.h
@@ -232,11 +232,6 @@ struct cloud_data_agps_request {
 	struct nrf_modem_gnss_agps_data_frame request;
 	/** Flag signifying that the data entry is to be encoded. */
 	bool queued : 1;
-	/** Flag indicating that the ephemerides will only include visible satellites */
-	bool filtered : 1;
-	/** Angle above the horizon to constrain the filtered set to. */
-	uint8_t mask_angle;
-
 };
 struct cloud_data_pgps_request {
 	/** Number of requested predictions. */

--- a/applications/asset_tracker_v2/src/modules/Kconfig.location_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.location_module
@@ -29,16 +29,6 @@ config LOCATION_MODULE_NEIGHBOR_CELLS_DATA_CONVERT_RSRQ_TO_DB
 	  Don't convert RSRQ to dB when building for nRF Cloud, this is handled during encoding
 	  using the nRF Cloud cellular positioning library.
 
-config LOCATION_MODULE_AGPS_FILTERED
-	bool "Request only visible satellite ephemerides"
-	default NRF_CLOUD_AGPS_FILTERED
-	depends on NRF_CLOUD_AGPS_FILTERED
-
-config LOCATION_MODULE_ELEVATION_MASK
-	int "Minimum elevation angle for visible satellites"
-	default NRF_CLOUD_AGPS_ELEVATION_MASK
-	depends on NRF_CLOUD_AGPS_FILTERED
-
 # The cloud interface for A-GPS, P-GPS and cell location is handled by the application
 config LOCATION_METHOD_GNSS_AGPS_EXTERNAL
 	default y if NRF_CLOUD_AGPS

--- a/applications/asset_tracker_v2/src/modules/data_module.c
+++ b/applications/asset_tracker_v2/src/modules/data_module.c
@@ -762,12 +762,6 @@ static int agps_request_encode(struct nrf_modem_gnss_agps_data_frame *incoming_r
 	cloud_agps_request.cell = modem_info.network.cellid_dec;
 	cloud_agps_request.area = modem_info.network.area_code.value;
 	cloud_agps_request.queued = true;
-#if defined(CONFIG_LOCATION_MODULE_AGPS_FILTERED)
-	cloud_agps_request.filtered = CONFIG_LOCATION_MODULE_AGPS_FILTERED;
-#endif
-#if defined(CONFIG_LOCATION_MODULE_ELEVATION_MASK)
-	cloud_agps_request.mask_angle = CONFIG_LOCATION_MODULE_ELEVATION_MASK;
-#endif
 
 	err = cloud_codec_encode_agps_request(&codec, &cloud_agps_request);
 	switch (err) {


### PR DESCRIPTION
Remove unused Kconfig options that enables filtering of ephemerides. These options was intended to be used when encoding A-GPS requests sent to AWS, Azure, and LwM2M. But encoding for filtered ephemerides was never implemented for those clouds implementations.

If users wants to try out filtered ephemerides they can build for nRF Cloud where this feature is still supported through `CONFIG_NRF_CLOUD_AGPS_FILTERED` and
`CONFIG_NRF_CLOUD_AGPS_ELEVATION_MASK` options.