### PR TITLE
applications: asset_tracker_v2: Remove native_posix from lwm2m.debug

### DIFF
--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -133,7 +133,7 @@ tests:
   applications.asset_tracker_v2.lwm2m.debug:
     build_only: true
     build_on_all: true
-    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns native_posix
+    platform_allow: nrf9160dk_nrf9160_ns thingy91_nrf9160_ns
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns


### PR DESCRIPTION
The lwm2m.debug configuraiton wont build on native_posix because of dependency on LTE connection. Hence removing native_posix from platform_allow list.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>