### PR TITLE
Bluetooth: Mesh: Don't reset NULL buffer in DM srv

### DIFF
--- a/include/bluetooth/mesh/vnd/dm_srv.h
+++ b/include/bluetooth/mesh/vnd/dm_srv.h
@@ -30,8 +30,6 @@ struct bt_mesh_dm_srv {
 	struct bt_mesh_tid_ctx prev_transaction;
 	/** Access model pointer. */
 	struct bt_mesh_model *model;
-	/** Publish parameters. */
-	struct bt_mesh_model_pub pub;
 #if CONFIG_BT_SETTINGS
 	/** Storage timer */
 	struct k_work_delayable store_timer;
@@ -90,7 +88,7 @@ struct bt_mesh_dm_srv {
  */
 #define BT_MESH_MODEL_DM_SRV(_srv)                                                       \
 	BT_MESH_MODEL_VND_CB(BT_MESH_VENDOR_COMPANY_ID, BT_MESH_MODEL_ID_DM_SRV,         \
-			     _bt_mesh_dm_srv_op, &(_srv)->pub,                           \
+			     _bt_mesh_dm_srv_op, NULL,                                   \
 			     BT_MESH_MODEL_USER_DATA(struct bt_mesh_dm_srv, _srv),       \
 			     &_bt_mesh_dm_srv_cb)
 

--- a/subsys/bluetooth/mesh/vnd/dm_srv.c
+++ b/subsys/bluetooth/mesh/vnd/dm_srv.c
@@ -458,7 +458,6 @@ static void bt_mesh_dm_srv_reset(struct bt_mesh_model *model)
 	srv->cfg.ttl = CONFIG_BT_MESH_DM_SRV_DEFAULT_TTL;
 	srv->cfg.timeout = CONFIG_BT_MESH_DM_SRV_DEFAULT_TIMEOUT,
 	srv->cfg.delay = CONFIG_BT_MESH_DM_SRV_REFLECTOR_DELAY,
-	net_buf_simple_reset(srv->pub.msg);
 
 #if CONFIG_BT_SETTINGS
 	(void)bt_mesh_model_data_store(srv->model, true, NULL, NULL, 0);


### PR DESCRIPTION
This removes a reset of a NULL buffer in the DM server model reset handler.

Signed-off-by: Ludvig Samuelsen Jordet <ludvig.jordet@nordicsemi.no>