### PR TITLE
samples: bluetooth: peripheral_fast_pair: fix coverity issue

### DIFF
--- a/samples/bluetooth/peripheral_fast_pair/src/hids_helper.c
+++ b/samples/bluetooth/peripheral_fast_pair/src/hids_helper.c
@@ -92,7 +92,7 @@ int hids_helper_volume_ctrl(enum hids_helper_volume_change volume_change)
 {
 	static const uint16_t usage_id_vol_up = 0x00E9;
 	static const uint16_t usage_id_vol_down = 0x00EA;
-	static const uint16_t usage_id_empty;
+	static const uint16_t usage_id_empty = 0x0000;
 
 	uint8_t buf[REPORT_SIZE_CONSUMER_CTRL];
 


### PR DESCRIPTION
Fixed Coverity issue in the volume change logic of the Peripheral Fast Pair sample.

Ref: NCSDK-18106

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>