### PR TITLE
caf: Sizes of enums inside events

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -261,7 +261,11 @@ Other libraries
 Common Application Framework (CAF)
 ----------------------------------
 
-|no_changes_yet_note|
+* :ref:`caf_overview_events`:
+
+  * Improved inter-core compatibility.
+  * Added a macro intended to set the size of events member enums to 32 bits when the Event Manager Proxy is enabled.
+  * Applied macro to all affected CAF events.
 
 Shell libraries
 ---------------

--- a/include/caf/events/ble_common_event.h
+++ b/include/caf/events/ble_common_event.h
@@ -50,7 +50,10 @@ enum peer_state {
 	PEER_STATE_CONN_FAILED,
 
 	/** Number of peer states. */
-	PEER_STATE_COUNT
+	PEER_STATE_COUNT,
+
+	/** Unused in code, required for inter-core compatibility. */
+	APP_EM_ENFORCE_ENUM_SIZE(PEER_STATE)
 };
 
 /** @brief Peer operations.
@@ -94,7 +97,10 @@ enum peer_operation {
 	PEER_OPERATION_CANCEL,
 
 	/** Number of peer operations. */
-	PEER_OPERATION_COUNT
+	PEER_OPERATION_COUNT,
+
+	/** Unused in code, required for inter-core compatibility. */
+	APP_EM_ENFORCE_ENUM_SIZE(PEER_OPERATION)
 };
 
 /** @brief Bluetooth LE peer event.

--- a/include/caf/events/click_event.h
+++ b/include/caf/events/click_event.h
@@ -41,7 +41,10 @@ enum click {
 	CLICK_DOUBLE,
 
 	/** Number of click types. */
-	CLICK_COUNT
+	CLICK_COUNT,
+
+	/** Unused in code, required for inter-core compatibility. */
+	APP_EM_ENFORCE_ENUM_SIZE(CLICK)
 };
 
 /** @brief Click event.

--- a/include/caf/events/module_state_event.h
+++ b/include/caf/events/module_state_event.h
@@ -205,7 +205,10 @@ enum module_state {
 	MODULE_STATE_ERROR,
 
 	/** Number of module states. */
-	MODULE_STATE_COUNT
+	MODULE_STATE_COUNT,
+
+	/** Unused in code, required for inter-core compatibility. */
+	APP_EM_ENFORCE_ENUM_SIZE(MODULE_STATE)
 };
 
 /** @brief Module state event.

--- a/include/caf/events/net_state_event.h
+++ b/include/caf/events/net_state_event.h
@@ -27,7 +27,10 @@ enum net_state {
 	NET_STATE_DISCONNECTED,
 	NET_STATE_CONNECTED,
 
-	NET_STATE_COUNT
+	NET_STATE_COUNT,
+
+	/** Unused in code, required for inter-core compatibility. */
+	APP_EM_ENFORCE_ENUM_SIZE(NET_STATE)
 };
 
 /** @brief NET state event. */

--- a/include/caf/events/power_manager_event.h
+++ b/include/caf/events/power_manager_event.h
@@ -42,7 +42,10 @@ enum power_manager_level {
 	/**
 	 * @brief Number of supported levels
 	 */
-	POWER_MANAGER_LEVEL_MAX
+	POWER_MANAGER_LEVEL_MAX,
+
+	/** Unused in code, required for inter-core compatibility. */
+	APP_EM_ENFORCE_ENUM_SIZE(POWER_MANAGER_LEVEL)
 };
 
 

--- a/include/caf/events/sensor_event.h
+++ b/include/caf/events/sensor_event.h
@@ -43,7 +43,10 @@ enum sensor_state {
 	SENSOR_STATE_ERROR,
 
 	/** Number of sensor states. */
-	SENSOR_STATE_COUNT
+	SENSOR_STATE_COUNT,
+
+	/** Unused in code, required for inter-core compatibility. */
+	APP_EM_ENFORCE_ENUM_SIZE(SENSOR_STATE)
 };
 
 /** @brief Sensor state event.

--- a/subsys/app_event_manager/app_event_manager_priv.h
+++ b/subsys/app_event_manager/app_event_manager_priv.h
@@ -63,6 +63,13 @@ extern "C" {
 #define _APP_EM_SUBS_PRIO_EARLY  05
 #define _APP_EM_SUBS_PRIO_NORMAL 10
 
+/* Enum element enforcing 32-bit size, required for inter-core compatibility.
+ * Shall be added as the last element of enum.
+ */
+#define APP_EM_ENFORCE_ENUM_SIZE(ename) COND_CODE_1(IS_ENABLED(CONFIG_EVENT_MANAGER_PROXY),	\
+	(ename##_FORCE_ENUM_SIZE = UINT32_MAX),							\
+	()											\
+)
 
 /* Convenience macros generating section names. */
 


### PR DESCRIPTION
Added macro intended to define last state of the
enums handled by event_manager_proxy.
Applied to all caf events enums.

Signed-off-by: Mateusz Michalek <mateusz.michalek@nordicsemi.no>