### PR TITLE
doc: Rename lwm2m_shell to lwm2m_carrier_shell

### DIFF
--- a/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/CHANGELOG.rst
@@ -41,7 +41,7 @@ Changes
   This is intended to provide convenient access to the API for development and debugging.
 
   * Enabled or disabled by using :kconfig:option:`CONFIG_LWM2M_CARRIER_SHELL` and :kconfig:option:`CONFIG_LWM2M_CARRIER_SETTINGS`.
-  * For examples of using the shell, see the :ref:`lwm2m_carrier` sample documentation and the :ref:`lwm2m_shell` section in the library documentation.
+  * For examples of using the shell, see the :ref:`lwm2m_carrier` sample documentation and the :ref:`lwm2m_carrier_shell` section in the library documentation.
 
 * Added a new ``__weak`` function :c:func:`lwm2m_carrier_custom_init`.
 

--- a/doc/nrf/libraries/bin/lwm2m_carrier/app_integration.rst
+++ b/doc/nrf/libraries/bin/lwm2m_carrier/app_integration.rst
@@ -60,7 +60,7 @@ Enable the library by setting the :kconfig:option:`CONFIG_LWM2M_CARRIER` Kconfig
 The :ref:`lwm2m_carrier` sample project configuration (:file:`nrf/samples/nrf9160/lwm2m_carrier/prj.conf`) contains all the configurations that are needed by the LwM2M carrier library.
 
 To overwrite the carrier default settings, you can provide the initialization parameter :c:type:`lwm2m_carrier_config_t` with the Kconfig options specified in the following sections.
-You can also use the provided :ref:`lwm2m_shell` to quickly get started and experiment with the API.
+You can also use the provided :ref:`lwm2m_carrier_shell` to quickly get started and experiment with the API.
 
 .. _general_options_lwm2m:
 
@@ -296,7 +296,7 @@ Following are the various LwM2M carrier library events that are also listed in :
 
     * :c:macro:`LWM2M_CARRIER_ERROR_INTERNAL` - This error indicates an irrecoverable error between the modem and carrier library. The LwM2M carrier library recovers only upon reboot.
 
-.. _lwm2m_shell:
+.. _lwm2m_carrier_shell:
 
 LwM2M carrier shell configuration
 *********************************

--- a/samples/nrf9160/lwm2m_carrier/sample_description.rst
+++ b/samples/nrf9160/lwm2m_carrier/sample_description.rst
@@ -99,7 +99,7 @@ The sample provides predefined configuration files for typical use cases.
 The following files are available:
 
 * :file:`prj.conf` - Standard default configuration file.
-* :file:`overlay-shell.conf` - Enables the :ref:`lwm2m_shell` and :ref:`lib_at_shell`.
+* :file:`overlay-shell.conf` - Enables the :ref:`lwm2m_carrier_shell` and :ref:`lib_at_shell`.
 
 The sample can either be configured by editing the :file:`prj.conf` file and the relevant overlay files, or through menuconfig or guiconfig.
 
@@ -159,7 +159,7 @@ If you connected to the carrier (test) servers or live (production) servers, rea
 Testing with the LwM2M shell
 ----------------------------
 
-See :ref:`lwm2m_shell` for more information about the LwM2M carrier shell and shell commands.
+See :ref:`lwm2m_carrier_shell` for more information about the LwM2M carrier shell and shell commands.
 To test with the sample, complete the following steps:
 
 1. Make sure the sample was built with the shell overlay as described in :ref:`lwm2m_carrier_shell_overlay`.


### PR DESCRIPTION
RST reference lwm2m_shell was defined in upstream Zephyr but we cannot link there because nRF documentation mask the same reference to point into the Carrier library.

Therefore I'm renaming the Carrier library reference to `ref::lwm2m_carrier_shell`

