### PR TITLE
samples: nrf9160: download: Reconnect to server on connect reset event

### DIFF
--- a/samples/nrf9160/download/src/main.c
+++ b/samples/nrf9160/download/src/main.c
@@ -157,9 +157,13 @@ static int callback(const struct download_client_evt *event)
 
 	case DOWNLOAD_CLIENT_EVT_ERROR:
 		printk("Error %d during download\n", event->error);
-		lte_lc_power_off();
-		/* Stop download */
-		return -1;
+		if (event->error == -ECONNRESET) {
+			/* With ECONNRESET, allow library to attempt a reconnect by returning 0 */
+		} else {
+			lte_lc_power_off();
+			/* Stop download */
+			return -1;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
If the download client returns a ECONNRESET error event while downloading, attempt to reconnect to the server and continue the download by returning 0 from the callback function.

Signed-off-by: Richard McCrae <richard.mccrae@nordicsemi.no>