### PR TITLE
bluetooth: adv_prov: fast_pair: Disable battery data by default

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -299,6 +299,10 @@ Bluetooth libraries and services
 
   * Fixed a possible memory leak in the :c:func:`bt_gatt_indicate_rpc_handler` function.
 
+* :ref:`bt_le_adv_prov_readme` library:
+
+  * Changed the :kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_MODE` Kconfig option (default value) to not include Fast Pair battery data in the Fast Pair advertising payload by default.
+
 Bootloader libraries
 --------------------
 

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
@@ -12,7 +12,7 @@ menuconfig BT_ADV_PROV_FAST_PAIR
 
 	  If device is in pairing mode, provider uses Fast Pair discoverable
 	  advertising. Otherwise, Fast Pair not discoverable advertising is used.
-	  By default, battery data is included in not discoverable advertising payload.
+	  By default, battery data is not included in advertising payload.
 
 	  Application can control the generated payload using provider's Kconfig
 	  options or dedicated API.

--- a/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
+++ b/subsys/bluetooth/adv_prov/providers/Kconfig.fast_pair
@@ -36,7 +36,7 @@ config BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING
 
 choice BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_MODE
 	prompt "Select advertising battery data mode"
-	default BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_SHOW_UI
+	default BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_NONE
 	help
 	  The provider also exposes API to change battery data advertising mode in runtime.
 


### PR DESCRIPTION
Do not include Fast Pair battery data in Fast Pair advertising payload by default.

Jira: NCSDK-18568