### PR TITLE
drivers: wifi: nrf700x: Fix Wi-Fi management dependency

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -11,7 +11,8 @@ DT_COMPAT_NORDIC_NRF7002_SPI := nordic,nrf7002-spi
 config WIFI_NRF700X
 	bool "nRF700x driver"
 	depends on WIFI
-	select WIFI_USE_NATIVE_NETWORKING
+	select NET_L2_WIFI_MGMT if NETWORKING
+	select WIFI_USE_NATIVE_NETWORKING if NETWORKING
 	help
 	  Nordic Wi-Fi Driver
 


### PR DESCRIPTION
NRF700X driver used wifi_mgmt APIs but doesn't advertise the dependency, instead it relies on WPA supplicant, so, add this dependency explicitly.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>