### PR TITLE
manifest: Update Matter sdk revision that includes a factory data fix

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -936,6 +936,13 @@ KRKNWK-15846: Android CHIP Tool crashes when subscribing in the :guilabel:`LIGHT
   Also, the Subscription window in the :guilabel:`LIGHT ON/OFF & LEVEL CLUSTER` contains faulty GUI layout (overlapping captions) used when passing minimum and maximum subscription interval values.
   This affects the Android CHIP Tool revision used for the |NCS| v2.2.0, v2.1.1, and v2.1.2 releases.
 
+.. rst-class:: v2-2-0 v2-1-2 v2-1-1
+
+KRKNWK-15913: Factory data set parsing issues
+  The ``user`` field in the factory data set is not properly parsed. The field should be of the ``MAP`` type instead of the ``BSTR`` type.
+
+  **Workaround:** Manually cherry-pick and apply commit with fix to ``sdk-connectedhomeip`` (commit hash: ``3875c6f78c77212a3f62a5c825ff9b4e5054bbb4``).
+
 .. rst-class:: v2-1-2 v2-1-1
 
 KRKNWK-15749: Invalid ZAP Tool revision used

--- a/west.yml
+++ b/west.yml
@@ -123,7 +123,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 081dbbe18d43510f1931cfd890955aef0005e719
+      revision: 3875c6f78c77212a3f62a5c825ff9b4e5054bbb4
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
In the newest version of the Matter SDK, there is a fix for the factory data set that allows using the "user" data field in code. There is also updated documentation for creating a factory data partition.

Added a known issue for NCS 2.2.0, 2.1.2, and 2.1.1 that are impacted by that issue.
