### PR TITLE
samples: nrf9160: modem_shell: Change timeout arguments to seconds

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -197,6 +197,12 @@ Bluetooth mesh samples
 nRF9160 samples
 ---------------
 
+* :ref:`modem_shell_application` sample:
+
+  * Updated:
+
+    * Timeout command-line arguments for the ``location get`` command changed from integers in milliseconds to floating-point values in seconds.
+
 * :ref:`nrf_cloud_rest_cell_pos_sample` sample:
 
   * Added:

--- a/samples/nrf9160/modem_shell/overlay-debug.conf
+++ b/samples/nrf9160/modem_shell/overlay-debug.conf
@@ -19,9 +19,6 @@ CONFIG_LOG_MAX_LEVEL=4
 # Increase log buffer size to prevent logs being dropped.
 CONFIG_LOG_BUFFER_SIZE=2048
 
-# LTE link control library
-CONFIG_LTE_LINK_CONTROL_LOG_LEVEL_DBG=y
-
 # Location library
 CONFIG_LOCATION_LOG_LEVEL_DBG=y
 
@@ -41,3 +38,6 @@ CONFIG_DATE_TIME_LOG_LEVEL_DBG=y
 
 # Settings
 CONFIG_SETTINGS_LOG_LEVEL_DBG=y
+
+# LTE link control library
+#CONFIG_LTE_LINK_CONTROL_LOG_LEVEL_DBG=y

--- a/samples/nrf9160/modem_shell/src/location/location_shell.c
+++ b/samples/nrf9160/modem_shell/src/location/location_shell.c
@@ -68,35 +68,37 @@ static const char location_usage_str[] =
 
 static const char location_get_usage_str[] =
 	"Usage: location get [--mode <mode>] [--method <method>]\n"
-	"[--timeout <msecs>] [--interval <secs>]\n"
+	"[--timeout <secs>] [--interval <secs>]\n"
 	"[--gnss_accuracy <acc>] [--gnss_num_fixes <number of fixes>]\n"
-	"[--gnss_timeout <timeout in msecs>] [--gnss_visibility]\n"
+	"[--gnss_timeout <timeout in secs>] [--gnss_visibility]\n"
 	"[--gnss_priority] [--gnss_cloud_nmea] [--gnss_cloud_pvt]\n"
-	"[--cellular_timeout <timeout in msecs>] [--cellular_service <service_string>]\n"
-	"[--wifi_timeout <timeout in msecs>] [--wifi_service <service_string>]\n"
+	"[--cellular_timeout <timeout in secs>] [--cellular_service <service_string>]\n"
+	"[--wifi_timeout <timeout in secs>] [--wifi_service <service_string>]\n"
+	"\n"
 	"Options:\n"
-	"  -m, --method,       Location method: 'gnss', 'cellular' or 'wifi'. Multiple\n"
-	"                      '--method' parameters may be given to indicate list of\n"
-	"                      methods in priority order.\n"
-	"  --mode,             Location request mode: 'fallback' (default) or 'all'.\n"
-	"  --interval,         Position update interval in seconds\n"
-	"                      (default: 0 = single position)\n"
-	"  -t, --timeout,      Timeout for the entire location request in milliseconds.\n"
-	"                      Zero means timeout is disabled.\n"
-	"  --gnss_accuracy,    Used GNSS accuracy: 'low', 'normal' or 'high'\n"
-	"  --gnss_num_fixes,   Number of consecutive fix attempts (if gnss_accuracy\n"
-	"                      set to 'high', default: 3)\n"
-	"  --gnss_timeout,     GNSS timeout in milliseconds. Zero means timeout is disabled.\n"
-	"  --gnss_visibility,  Enables GNSS obstructed visibility detection\n"
-	"  --gnss_priority,    Enables GNSS priority mode\n"
-	"  --gnss_cloud_nmea,  Send acquired GNSS location to nRF Cloud formatted as NMEA\n"
-	"  --gnss_cloud_pvt,   Send acquired GNSS location to nRF Cloud formatted as PVT\n"
-	"  --cellular_timeout, Cellular timeout in milliseconds. Zero means timeout is disabled.\n"
-	"  --cellular_service, Used cellular positioning service:\n"
-	"                      'any' (default), 'nrf' or 'here'\n"
-	"  --wifi_timeout,     Wi-Fi timeout in milliseconds. Zero means timeout is disabled.\n"
-	"  --wifi_service,     Used Wi-Fi positioning service:\n"
-	"                      'any' (default), 'nrf' or 'here'\n";
+	"  -m, --method, [str]         Location method: 'gnss', 'cellular' or 'wifi'. Multiple\n"
+	"                              '--method' parameters may be given to indicate list of\n"
+	"                              methods in priority order.\n"
+	"  --mode, [str]               Location request mode: 'fallback' (default) or 'all'.\n"
+	"  --interval, [int]           Position update interval in seconds\n"
+	"                              (default: 0 = single position)\n"
+	"  -t, --timeout, [float]      Timeout for the entire location request in seconds.\n"
+	"                              Zero means timeout is disabled.\n"
+	"  --gnss_accuracy, [str]      Used GNSS accuracy: 'low', 'normal' or 'high'\n"
+	"  --gnss_num_fixes, [int]     Number of consecutive fix attempts (if gnss_accuracy\n"
+	"                              set to 'high', default: 3)\n"
+	"  --gnss_timeout, [float]     GNSS timeout in seconds. Zero means timeout is disabled.\n"
+	"  --gnss_visibility,          Enables GNSS obstructed visibility detection\n"
+	"  --gnss_priority,            Enables GNSS priority mode\n"
+	"  --gnss_cloud_nmea,          Send acquired GNSS location to nRF Cloud formatted as NMEA\n"
+	"  --gnss_cloud_pvt,           Send acquired GNSS location to nRF Cloud formatted as PVT\n"
+	"  --cellular_timeout, [float] Cellular timeout in seconds.\n"
+	"                              Zero means timeout is disabled.\n"
+	"  --cellular_service, [str]   Used cellular positioning service:\n"
+	"                              'any' (default), 'nrf' or 'here'\n"
+	"  --wifi_timeout, [float]     Wi-Fi timeout in seconds. Zero means timeout is disabled.\n"
+	"  --wifi_service, [str]       Used Wi-Fi positioning service:\n"
+	"                              'any' (default), 'nrf' or 'here'\n";
 
 /******************************************************************************/
 
@@ -527,10 +529,10 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 	int interval = 0;
 	bool interval_set = false;
 
-	int timeout = 0;
+	float timeout = 0;
 	bool timeout_set = false;
 
-	int gnss_timeout = 0;
+	float gnss_timeout = 0;
 	bool gnss_timeout_set = false;
 
 	enum location_accuracy gnss_accuracy = 0;
@@ -543,11 +545,11 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 
 	bool gnss_priority_mode = false;
 
-	int cellular_timeout = 0;
+	float cellular_timeout = 0;
 	bool cellular_timeout_set = false;
 	enum location_service cellular_service = LOCATION_SERVICE_ANY;
 
-	int wifi_timeout = 0;
+	float wifi_timeout = 0;
 	bool wifi_timeout_set = false;
 	enum location_service wifi_service = LOCATION_SERVICE_ANY;
 
@@ -589,11 +591,8 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 	while ((opt = getopt_long(argc, argv, "m:t:", long_options, &long_index)) != -1) {
 		switch (opt) {
 		case LOCATION_SHELL_OPT_GNSS_TIMEOUT:
-			gnss_timeout = atoi(optarg);
+			gnss_timeout = atof(optarg);
 			gnss_timeout_set = true;
-			if (gnss_timeout == 0) {
-				gnss_timeout = SYS_FOREVER_MS;
-			}
 			break;
 
 		case LOCATION_SHELL_OPT_GNSS_NUM_FIXES:
@@ -607,11 +606,8 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 			gnss_location_to_cloud = true;
 			break;
 		case LOCATION_SHELL_OPT_CELLULAR_TIMEOUT:
-			cellular_timeout = atoi(optarg);
+			cellular_timeout = atof(optarg);
 			cellular_timeout_set = true;
-			if (cellular_timeout == 0) {
-				cellular_timeout = SYS_FOREVER_MS;
-			}
 			break;
 
 		case LOCATION_SHELL_OPT_CELLULAR_SERVICE:
@@ -623,11 +619,8 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 			break;
 
 		case LOCATION_SHELL_OPT_WIFI_TIMEOUT:
-			wifi_timeout = atoi(optarg);
+			wifi_timeout = atof(optarg);
 			wifi_timeout_set = true;
-			if (wifi_timeout == 0) {
-				wifi_timeout = SYS_FOREVER_MS;
-			}
 			break;
 
 		case LOCATION_SHELL_OPT_WIFI_SERVICE:
@@ -643,11 +636,8 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 			interval_set = true;
 			break;
 		case 't':
-			timeout = atoi(optarg);
+			timeout = atof(optarg);
 			timeout_set = true;
-			if (timeout == 0) {
-				timeout = SYS_FOREVER_MS;
-			}
 			break;
 
 		case LOCATION_SHELL_OPT_GNSS_ACCURACY:
@@ -743,7 +733,8 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 		for (uint8_t i = 0; i < method_count; i++) {
 			if (config.methods[i].method == LOCATION_METHOD_GNSS) {
 				if (gnss_timeout_set) {
-					config.methods[i].gnss.timeout = gnss_timeout;
+					config.methods[i].gnss.timeout = (gnss_timeout == 0) ?
+						SYS_FOREVER_MS : gnss_timeout * MSEC_PER_SEC;
 				}
 				if (gnss_accuracy_set) {
 					config.methods[i].gnss.accuracy = gnss_accuracy;
@@ -757,12 +748,15 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 			} else if (config.methods[i].method == LOCATION_METHOD_CELLULAR) {
 				config.methods[i].cellular.service = cellular_service;
 				if (cellular_timeout_set) {
-					config.methods[i].cellular.timeout = cellular_timeout;
+					config.methods[i].cellular.timeout =
+						(cellular_timeout == 0) ?
+						SYS_FOREVER_MS : cellular_timeout * MSEC_PER_SEC;
 				}
 			} else if (config.methods[i].method == LOCATION_METHOD_WIFI) {
 				config.methods[i].wifi.service = wifi_service;
 				if (wifi_timeout_set) {
-					config.methods[i].wifi.timeout = wifi_timeout;
+					config.methods[i].wifi.timeout = (wifi_timeout == 0) ?
+						SYS_FOREVER_MS : wifi_timeout * MSEC_PER_SEC;
 				}
 			}
 		}
@@ -771,7 +765,8 @@ int location_shell(const struct shell *shell, size_t argc, char **argv)
 			config.interval = interval;
 		}
 		if (timeout_set) {
-			config.timeout = timeout;
+			config.timeout = (timeout == 0) ?
+				SYS_FOREVER_MS : timeout * MSEC_PER_SEC;
 		}
 		config.mode = req_mode;
 


### PR DESCRIPTION
Different timeout command line arguments have been integers in milliseconds. For convenience they are now seconds. And to enable testing of specific milliseconds, which the Location library API still takes as an input, they are now floats so you can give 10123ms as 10.123 floating point value.

Removing also CONFIG_LTE_LINK_CONTROL_LOG_LEVEL_DBG=y from overlay-debug.conf mainly because it has exhaustive event dispatching logging:
```
<dbg> lte_lc_helpers: event_handler_list_dispatch: Dispatching events: 
<dbg> lte_lc_helpers: event_handler_list_dispatch:  - handler=0x02ECD9
```