### PR TITLE
drivers: wifi: nrf700x: Fix QSPI define

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/qspi/inc/qspi_if.h
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/inc/qspi_if.h
@@ -14,7 +14,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
-#ifdef CONFIG_NRFX_QSPI
+#ifdef CONFIG_NRF700X_ON_QSPI
 #include <nrfx_qspi.h>
 #endif
 
@@ -23,7 +23,7 @@
 #define RPU_READY_BIT BIT(2) /* RPU IS READY - RO*/
 
 struct qspi_config {
-#ifdef CONFIG_NRFX_QSPI
+#ifdef CONFIG_NRF700X_ON_QSPI
 	nrf_qspi_addrmode_t addrmode;
 	nrf_qspi_readoc_t readoc;
 	nrf_qspi_writeoc_t writeoc;
@@ -39,9 +39,9 @@ struct qspi_config {
 	struct k_sem lock;
 	unsigned int addrmask;
 	unsigned char qspi_slave_latency;
-#ifdef CONFIG_NRFX_QSPI
+#ifdef CONFIG_NRF700X_ON_QSPI
 	nrf_qspi_encryption_t p_cfg;
-#endif /*CONFIG_NRFX_QSPI*/
+#endif /*CONFIG_NRF700X_ON_QSPI*/
 	int test_hlread;
 	char *test_name;
 	int test_start;


### PR DESCRIPTION
NRFX_QSPI is a generic define that is also enabled by the NRFX flash driver, the NRF700X driver should be using NRF700X based define.

This fixes the build failure with nrf52840.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>