### PR TITLE
Port QSPI power mangement fixes from flash driver

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
@@ -397,6 +397,7 @@ static int qspi_device_init(const struct device *dev)
 	if (!qspi_initialized) {
 		res = nrfx_qspi_init(&QSPIconfig, qspi_handler, dev_data);
 		ret = qspi_get_zephyr_ret_code(res);
+		NRF_QSPI->IFTIMING |= qspi_config->RDC4IO;
 		qspi_initialized = (ret == 0);
 	}
 


### PR DESCRIPTION
  * 95d867e8ed ("drivers/flash/nrf_qspi_nor: fix for missing device deactivation.")
  * da3ec7dbfa ("drivers: flash: Fix regression on nrf52840 anomaly 122 workaround")

Get lower power numbers when Wi-Fi is enabled (current consumption jumps from 2->7ma).
