### PR TITLE
partition_manager: mcuboot: Use separate RAM region for MCUBoot

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -30,6 +30,14 @@ Changelog
 
 The following sections provide detailed lists of changes by component.
 
+MCUboot
+=======
+
+* Updated:
+
+  * MCUBoot now uses the Secure RAM region on Trustzone-enabled devices.
+    The option :kconfig:option:`CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM` was added to allow MCUBoot to use all the available RAM.
+
 Application development
 =======================
 

--- a/modules/mcuboot/Kconfig
+++ b/modules/mcuboot/Kconfig
@@ -112,4 +112,14 @@ config ADD_MCUBOOT_MEDIATE_SIM_FLASH_DTS
 	  multi image update of the network core or to allow serial recovery of
 	  the network core.
 
+config MCUBOOT_USE_ALL_AVAILABLE_RAM
+	bool "Allow MCUBoot to use all available RAM (security implications)"
+	depends on ARM_TRUSTZONE_M
+	default y if BOARD_THINGY91_NRF9160_NS || BOARD_THINGY91_NRF9160
+	default y if BOARD_THINGY53_NRF5340_CPUAPP_NS || BOARD_THINGY53_NRF5340_CPUAPP
+	help
+	  By default MCUBoot uses only the secure RAM partition. Enabling this
+	  may allow secrets to be leaked to non-secure through the non-secure
+	  RAM partition.
+
 endmenu

--- a/modules/mcuboot/boot/zephyr/Kconfig
+++ b/modules/mcuboot/boot/zephyr/Kconfig
@@ -55,6 +55,11 @@ config MCUBOOT_NRF_CLEANUP_PERIPHERAL
 	depends on SOC_FAMILY_NRF
 	default y
 
+config MCUBOOT_NRF_CLEANUP_NONSECURE_RAM
+	bool "Perform non-secure RAM cleanup before chain-load the application"
+	depends on SOC_FAMILY_NRF && ARM_TRUSTZONE_M
+	default y if MCUBOOT_USE_ALL_AVAILABLE_RAM
+
 config BOOT_SIGNATURE_KEY_FILE
 	string "MCUBoot PEM key file"
 	depends on !MCUBOOT_BUILD_STRATEGY_FROM_SOURCE

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -91,6 +91,9 @@ endif()
 
 if (CONFIG_TRUSTED_EXECUTION_NONSECURE OR CONFIG_TRUSTED_EXECUTION_SECURE)
   ncs_add_partition_manager_config(pm.yml.trustzone)
+  if (CONFIG_BOOTLOADER_MCUBOOT)
+    ncs_add_partition_manager_config(pm.yml.mcuboot)
+  endif()
 endif()
 
 if (CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP)

--- a/subsys/partition_manager/pm.yml.mcuboot
+++ b/subsys/partition_manager/pm.yml.mcuboot
@@ -1,0 +1,8 @@
+#include <autoconf.h>
+
+mcuboot_sram:
+#ifdef CONFIG_MCUBOOT_USE_ALL_AVAILABLE_RAM
+  span: [sram_primary, sram_nonsecure, sram_secure]
+#else
+  span: sram_secure
+#endif

--- a/west.yml
+++ b/west.yml
@@ -105,7 +105,7 @@ manifest:
       revision: 8d3f26d7da1b49815fbd0fe8335189cfac4ded85
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: v1.9.99-ncs4-rc1
+      revision: d97046ef74ccb932531521a8380c4a831cb344f4
       path: bootloader/mcuboot
     - name: mbedtls
       path: modules/crypto/mbedtls


### PR DESCRIPTION
On TrustZone enabled devices MCUBoot would sometimes default into using non-secure RAM regions. This change forces MCUBoot to use the secure RAM region. Using the non-secure RAM may potentially leak information from secure non-aware to non-secure.

The override Kconfig symbol `MCUBOOT_USE_ALL_AVAILABLE_RAM` was added to make sure that users who are aware of the risks of leaking data from MCUBoot but, still needs the additional RAM in the bootloader.

Ref. SI-227

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>