### PR TITLE
bluetooth: controller: Improved error message

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -378,8 +378,7 @@ static bool fetch_and_process_hci_msg(uint8_t *p_hci_buffer)
 	} else if (msg_type == SDC_HCI_MSG_TYPE_DATA) {
 		data_packet_process(p_hci_buffer);
 	} else {
-		__ASSERT(false, "sdc_hci_msg_type_t has changed. This if-else needs a new branch");
-		return false;
+		BT_ERR("Unexpected msg_type: %u. This if-else needs a new branch", msg_type);
 	}
 
 	return true;


### PR DESCRIPTION
Printing an error message instead of asserting.

Signed-off-by: Erik Sandgren <erik.sandgren@nordicsemi.no>