### PR TITLE
Wi-Fi: Use custom control interface for Zephyr

### DIFF
--- a/samples/wifi/shell/overlay-wpa_cli.conf
+++ b/samples/wifi/shell/overlay-wpa_cli.conf
@@ -1,0 +1,1 @@
+CONFIG_WPA_CLI=y

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1cab6854e3ca13f72d9b413cd2e5f6d1d4ba0f88
+      revision: 1767131c6d062019d2f30580aeff28f45bf99458
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -103,7 +103,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 7856cabe59a96466cafd27cad7e2fed0bb18cfc5
+      revision: 4bf4967a83e8c3a00c58dca4bcb967c18b182e86
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 4f775a87611a084a2f6ad9a8a5034e080ddcc579


### PR DESCRIPTION
Pull changes to use custom control interface for communicating to WPA supplicant. This is based on #9658 will rebased once that is merged, but still useful to run CI and get hostap changes merged.