### PR TITLE
samples: nrf9160: modem_shell: use LwM2M UDP queue mode

### DIFF
--- a/samples/nrf9160/modem_shell/overlay-lwm2m.conf
+++ b/samples/nrf9160/modem_shell/overlay-lwm2m.conf
@@ -60,6 +60,22 @@ CONFIG_LWM2M_SERVER_OBJECT_VERSION_1_1=y
 # DTLS settings
 CONFIG_LWM2M_DTLS_SUPPORT=y
 
+# Enable LwM2M Queue Mode
+CONFIG_LWM2M_QUEUE_MODE_ENABLED=y
+# Enable TLS session caching to prevent doing a full TLS handshake for every send.
+CONFIG_LWM2M_TLS_SESSION_CACHING=y
+# Socket close is skipped at RX off idle state to optimize power consumption.
+# Socket close call activates RCC connection to send Alert message to the server.
+# Alert is now sent before opening a new connection.
+CONFIG_LWM2M_RD_CLIENT_SUSPEND_SOCKET_AT_IDLE=y
+# Sets the duration that the LwM2M engine will poll for data after transmission before
+# the socket is closed.
+CONFIG_LWM2M_QUEUE_MODE_UPTIME=30
+# Lifetime 12 hours.
+CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME=43200
+# Send registration update 10 minutes before connection lifetime expiration.
+CONFIG_LWM2M_SECONDS_TO_UPDATE_EARLY=600
+
 # Support HEX style PSK values (double the size + NULL char)
 CONFIG_LWM2M_SECURITY_KEY_SIZE=33
 


### PR DESCRIPTION
Changed the LwM2M overlay to use UDP queue mode with a long connection lifetime. This removes the need to send frequent updates to keep the LwM2M connection alive.