### PR TITLE
doc fix: fix missing definitions from header file

### DIFF
--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -2005,7 +2005,8 @@ PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_NRF_MODEM=y" \
                          "CONFIG_ZIGBEE_ROLE_END_DEVICE=y" \
                          "CONFIG_ZIGBEE_FACTORY_RESET=y" \
-                         "CONFIG_NRF_CLOUD_GATEWAY=y"
+                         "CONFIG_NRF_CLOUD_GATEWAY=y" \
+                         "CONFIG_BT_CENTRAL"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
Definitions inside if clause are not appearing.
This adds the missing defintion to the doxygen file.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>