### PR TITLE
applications: nrf_desktop: Add log when motion sensor option is set

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/motion_sensor.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_sensor.c
@@ -419,8 +419,11 @@ static void update_config(const uint8_t opt_id, const uint8_t *data,
 			return;
 		}
 
-		if (set_option(option, sys_get_le32(data))) {
+		uint32_t value = sys_get_le32(data);
+
+		if (set_option(option, value)) {
 			store_config(opt_id, data, size);
+			LOG_INF("Option: %s set to %" PRIu32, opt_descr[opt_id], value);
 		}
 	} else {
 		LOG_WRN("Unsupported set opt_id: %" PRIu8, opt_id);

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -153,6 +153,8 @@ nRF5340 Audio
 nRF Desktop
 -----------
 
+* Added an application log informing about the configuration option value update in the :ref:`nrf_desktop_motion`.
+
 * Changed:
 
    * Implemented adjustments to avoid flooding logs:


### PR DESCRIPTION
Change introduces an application log informing about motion sensor configuration update. The log is used in CI tests.

Jira: NCSDK-18753