### PR TITLE
samples: nrf9160: modem_shell: add curl and iperf3 support with P-GPS

### DIFF
--- a/samples/nrf9160/modem_shell/overlay-pgps.conf
+++ b/samples/nrf9160/modem_shell/overlay-pgps.conf
@@ -22,7 +22,3 @@ CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
 # Library that maintains the current date and UTC time
 CONFIG_DATE_TIME=y
-
-# Disable other features to make the application fit onto flash
-CONFIG_MOSH_IPERF3=n
-CONFIG_MOSH_CURL=n


### PR DESCRIPTION
Removed disabling of curl and iperf3 support from the P-GPS overlay.