### PR TITLE
manifest: updated Matter module to pull heap related bug fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: f74a5eaefff3003edbed4dc0206803f1e972f912
+      revision: 16f75f4b094a088bacc8c2c45573ddca68bb47df
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Updated Matter module revision to pull bug fix that increases heap size and adds two null checks to prevent falling into hard fault.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>