### PR TITLE
ci: Fix documentation build on RST files

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -8,7 +8,7 @@ on:
       - 'v*-branch'
     paths:
       - '.github/workflows/docbuild.yml'
-      - '*.rst'
+      - '**.rst'
       - '**/Kconfig'
       - 'doc/**'
       - 'include/**'


### PR DESCRIPTION
  ci: Fix documentation build CI
  
  We need to use "**" to match path separators.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>