### PR TITLE
manifest: remove tfm-mcuboot from imported projects

### DIFF
--- a/doc/nrf/introduction.rst
+++ b/doc/nrf/introduction.rst
@@ -178,4 +178,4 @@ For more information about the documentation conventions and templates, see :ref
 The following table lists all the repositories (and their respective revisions) that are included as part of |NCS| |version| release:
 
 .. manifest-revisions-table::
-   :show-first: zephyr, nrfxlib, mcuboot, trusted-firmware-m, find-my, homekit, matter, nrf-802154, tfm-mcuboot, mbedtls-nrf, memfault-firmware-sdk
+   :show-first: zephyr, nrfxlib, mcuboot, trusted-firmware-m, find-my, homekit, matter, nrf-802154, mbedtls-nrf, memfault-firmware-sdk

--- a/scripts/tag_west_repos.sh
+++ b/scripts/tag_west_repos.sh
@@ -52,7 +52,6 @@ PROJECT_TAGS[nrf-802154]=""
 PROJECT_TAGS[zephyr]=""
 PROJECT_TAGS[mcuboot]=""
 PROJECT_TAGS[trusted-firmware-m]=""
-PROJECT_TAGS[tfm-mcuboot]=""
 PROJECT_TAGS[mbedtls-nrf]=""
 
 

--- a/west.yml
+++ b/west.yml
@@ -120,10 +120,6 @@ manifest:
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
       revision: 3017e45d1276ed739ddbd9650546b8bc02748d8a
-    - name: tfm-mcuboot # This is used by the trusted-firmware-m module.
-      repo-path: sdk-mcuboot
-      path: modules/tee/tfm-mcuboot
-      revision: v1.7.2-ncs3
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter


### PR DESCRIPTION
Remove TF-M mcuboot variant from imported projects. This is not used.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>