### PR TITLE
doc: known issues version tag line break

### DIFF
--- a/doc/_static/css/nrf.css
+++ b/doc/_static/css/nrf.css
@@ -100,6 +100,7 @@
 
 .versiontag-list {
   overflow-wrap: break-word;
+  word-break: break-all;
 }
 
 #known-issues dl dt {


### PR DESCRIPTION
Fixed an issue where the version tags did not line break properly in Firefox.

Signed-off-by: Gaute Svanes Lunde <gaute.lunde@nordicsemi.no>