### PR TITLE
applications: nrf5340_audio: Sink and source endpoint check

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -496,6 +496,11 @@ static void discover_sink_cb(struct bt_conn *conn, struct bt_codec *codec, struc
 		return;
 	}
 
+	if (headsets[channel_index].sink_ep == NULL) {
+		LOG_WRN("No sink endpoints found");
+		return;
+	}
+
 	LOG_DBG("Sink discover complete: err %d", params->err);
 
 	(void)memset(params, 0, sizeof(*params));
@@ -558,6 +563,11 @@ static void discover_source_cb(struct bt_conn *conn, struct bt_codec *codec, str
 
 	if (ep != NULL) {
 		headsets[channel_index].source_ep = ep;
+		return;
+	}
+
+	if (headsets[channel_index].source_ep == NULL) {
+		LOG_WRN("No source endpoints found");
 		return;
 	}
 


### PR DESCRIPTION
Checking if a headset actually
has an endpoint

Signed-off-by: Erik Robstad <erik.robstad@nordicsemi.no>