### PR TITLE
samples: bluetooth: mesh: explicitly enable lpn

### DIFF
--- a/samples/bluetooth/mesh/light_switch/src/main.c
+++ b/samples/bluetooth/mesh/light_switch/src/main.c
@@ -31,6 +31,10 @@ static void bt_ready(int err)
 		return;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
+		bt_mesh_lpn_set(true);
+	}
+
 	if (IS_ENABLED(CONFIG_SETTINGS)) {
 		settings_load();
 	}


### PR DESCRIPTION
If device with configured LPN feature starts it enables the scanner despite whether it has been provisioned or hasn't. If device has been already provisioned the scanner consumes unnecessary power. If lpn feature is enabled explicitly then ble mesh disables the scanner if BT_MESH_LPN_ESTABLISHMENT=y has been configured.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>