### PR TITLE
Revert "doc: Added links to RST files in bluetooth_mesh_one header files"

### DIFF
--- a/include/bluetooth/mesh/dk_prov.h
+++ b/include/bluetooth/mesh/dk_prov.h
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/dk_prov.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/dk_prov.html.
- */
-
 /**
  * @file
  * @brief Bluetooth mesh provisioning handler for Nordic DKs.

--- a/include/bluetooth/mesh/gen_battery.h
+++ b/include/bluetooth/mesh/gen_battery.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_battery.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_battery.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_battery Generic Battery models

--- a/include/bluetooth/mesh/gen_battery_cli.h
+++ b/include/bluetooth/mesh/gen_battery_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_battery_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_battery_cli.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_battery_cli Generic Battery Client model

--- a/include/bluetooth/mesh/gen_battery_srv.h
+++ b/include/bluetooth/mesh/gen_battery_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_battery_srv.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_battery_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_battery_srv Generic Battery Server model

--- a/include/bluetooth/mesh/gen_dtt.h
+++ b/include/bluetooth/mesh/gen_dtt.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_dtt.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_dtt.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_dtt Generic Default Transition Time models

--- a/include/bluetooth/mesh/gen_dtt_cli.h
+++ b/include/bluetooth/mesh/gen_dtt_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_dtt_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_dtt_cli.html.
- */
-
 /**
  *
  * @file

--- a/include/bluetooth/mesh/gen_dtt_srv.h
+++ b/include/bluetooth/mesh/gen_dtt_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_dtt_srv.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_dtt_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_dtt_srv Generic Default Transition Time Server

--- a/include/bluetooth/mesh/gen_loc.h
+++ b/include/bluetooth/mesh/gen_loc.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_loc.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_loc.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_loc Generic Location models

--- a/include/bluetooth/mesh/gen_loc_cli.h
+++ b/include/bluetooth/mesh/gen_loc_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_loc_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_loc_cli.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_loc_cli Generic Location Client model

--- a/include/bluetooth/mesh/gen_loc_srv.h
+++ b/include/bluetooth/mesh/gen_loc_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_loc_srv.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_loc_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_loc_srv Generic Location Server model

--- a/include/bluetooth/mesh/gen_lvl.h
+++ b/include/bluetooth/mesh/gen_lvl.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_lvl.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_lvl.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_lvl Bluetooth mesh Generic Level models

--- a/include/bluetooth/mesh/gen_lvl_cli.h
+++ b/include/bluetooth/mesh/gen_lvl_cli.h
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_lvl_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_lvl_cli.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_lvl_cli Generic Level Client model

--- a/include/bluetooth/mesh/gen_lvl_srv.h
+++ b/include/bluetooth/mesh/gen_lvl_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_lvl_srv.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_lvl_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_lvl_srv Bluetooth mesh Generic Level Server model

--- a/include/bluetooth/mesh/gen_onoff.h
+++ b/include/bluetooth/mesh/gen_onoff.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_onoff.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_onoff.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_onoff Generic OnOff Models

--- a/include/bluetooth/mesh/gen_onoff_cli.h
+++ b/include/bluetooth/mesh/gen_onoff_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_onoff_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_onoff_cli.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_onoff_cli Generic OnOff Client model

--- a/include/bluetooth/mesh/gen_onoff_srv.h
+++ b/include/bluetooth/mesh/gen_onoff_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_onoff_srv.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_onoff_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_onoff_srv Generic OnOff Server model

--- a/include/bluetooth/mesh/gen_plvl.h
+++ b/include/bluetooth/mesh/gen_plvl.h
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_plvl.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_plvl.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_plvl Generic Power Level Models

--- a/include/bluetooth/mesh/gen_plvl_cli.h
+++ b/include/bluetooth/mesh/gen_plvl_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_plvl_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_plvl_cli.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_plvl_cli Generic Power Level Client model

--- a/include/bluetooth/mesh/gen_plvl_srv.h
+++ b/include/bluetooth/mesh/gen_plvl_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_plvl_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_plvl_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_plvl_srv Generic Power Level Server model

--- a/include/bluetooth/mesh/gen_ponoff.h
+++ b/include/bluetooth/mesh/gen_ponoff.h
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_ponoff.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_ponoff.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_ponoff Generic Power OnOff Models

--- a/include/bluetooth/mesh/gen_ponoff_cli.h
+++ b/include/bluetooth/mesh/gen_ponoff_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_ponoff_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_ponoff_cli.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_ponoff_cli Generic Power OnOff Client

--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_ponoff_srv.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_ponoff_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_ponoff_srv Generic Power OnOff Server model

--- a/include/bluetooth/mesh/gen_prop.h
+++ b/include/bluetooth/mesh/gen_prop.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_prop.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_prop.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_prop Generic Property models

--- a/include/bluetooth/mesh/gen_prop_cli.h
+++ b/include/bluetooth/mesh/gen_prop_cli.h
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_prop_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_prop_cli.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_prop_cli Generic Property Client model

--- a/include/bluetooth/mesh/gen_prop_srv.h
+++ b/include/bluetooth/mesh/gen_prop_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/gen_prop_srv.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/gen_prop_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_prop_srv Generic Property server models

--- a/include/bluetooth/mesh/light_ctl.h
+++ b/include/bluetooth/mesh/light_ctl.h
@@ -3,14 +3,6 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/light_ctl.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/light_ctl.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_light_ctl Light CTL models

--- a/include/bluetooth/mesh/light_ctl_cli.h
+++ b/include/bluetooth/mesh/light_ctl_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/light_ctl_cli.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/light_ctl_cli.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_light_ctl_cli Light CTL Client model

--- a/include/bluetooth/mesh/light_ctl_srv.h
+++ b/include/bluetooth/mesh/light_ctl_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/light_ctl_srv.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/light_ctl_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_light_ctl_srv Light CTL Server model

--- a/include/bluetooth/mesh/light_temp_srv.h
+++ b/include/bluetooth/mesh/light_temp_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/*
- * The RST file for this library can be found in
- * doc/nrf/libraries/bluetooth_services/mesh/light_temp_srv.rst.
- * Rendered documentation is available at
- * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/bluetooth_services/mesh/light_temp_srv.html.
- */
-
 /**
  * @file
  * @defgroup bt_mesh_light_temp_srv Light Temperature Server model


### PR DESCRIPTION

This reverts commit cce264603fb9e97cfe97a12c6f53ca7c7d23319d. 
This reverts the comments made to update the header files with source RST path and link to the documentation.