### PR TITLE
doc: Remove old NFC library entries from changelog

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -428,14 +428,6 @@ Libraries for NFC
     * Added support for zero-latency interrupts for NFC.
     * Aligned the :file:`ncs/nrf/subsys/nfc/lib/platform.c` file with new library implementation.
 
-* :ref:`lib_nfc_ndef`:
-
-  * Fixed a write to a constant field in the :c:func:`ac_rec_payload_parse` function.
-
-* :ref:`nfc_t4t_isodep_readme`:
-
-  * Fixed out of bounds access in the :c:func:`ats_parse` function.
-
 Other libraries
 ---------------
 


### PR DESCRIPTION
Remove entries not removed with 2.2.0 release

Signed-off-by: Dominik Chat <dominik.chat@nordicsemi.no>