### PR TITLE
tests: zigbee: Use standarized pins with gpio_loopback

### DIFF
--- a/tests/subsys/zigbee/osif/serial/serial_async_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/boards/nrf52840dk_nrf52840.overlay
@@ -24,8 +24,8 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
 				<NRF_PSEL(UART_RX, 1, 2)>,
-				<NRF_PSEL(UART_RTS, 0, 5)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_RTS, 1, 3)>,
+				<NRF_PSEL(UART_CTS, 1, 4)>;
 		};
 	};
 
@@ -33,8 +33,8 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
 				<NRF_PSEL(UART_RX, 1, 2)>,
-				<NRF_PSEL(UART_RTS, 0, 5)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_RTS, 1, 3)>,
+				<NRF_PSEL(UART_CTS, 1, 4)>;
 			low-power-enable;
 		};
 	};

--- a/tests/subsys/zigbee/osif/serial/serial_async_api/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -16,18 +16,18 @@
 &pinctrl {
 	uart1_default_alt: uart1_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 0)>,
-				<NRF_PSEL(UART_RX, 1, 1)>,
-				<NRF_PSEL(UART_RTS, 0, 2)>,
+			psels = <NRF_PSEL(UART_TX, 0, 4)>,
+				<NRF_PSEL(UART_RX, 0, 5)>,
+				<NRF_PSEL(UART_RTS, 0, 6)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 		};
 	};
 
 	uart1_sleep_alt: uart1_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 0)>,
-				<NRF_PSEL(UART_RX, 1, 1)>,
-				<NRF_PSEL(UART_RTS, 0, 2)>,
+			psels = <NRF_PSEL(UART_TX, 0, 4)>,
+				<NRF_PSEL(UART_RX, 0, 5)>,
+				<NRF_PSEL(UART_RTS, 0, 6)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
 		};

--- a/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
@@ -1,7 +1,8 @@
 tests:
   zigbee.osif.serial.async:
+    depends_on: gpio
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
     tags: osif_serial
     harness: ztest
     harness_config:
-      fixture: shorted_uart_1
+      fixture: gpio_loopback

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/boards/nrf52840dk_nrf52840.overlay
@@ -24,8 +24,8 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
 				<NRF_PSEL(UART_RX, 1, 2)>,
-				<NRF_PSEL(UART_RTS, 0, 5)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_RTS, 1, 3)>,
+				<NRF_PSEL(UART_CTS, 1, 4)>;
 		};
 	};
 
@@ -33,8 +33,8 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
 				<NRF_PSEL(UART_RX, 1, 2)>,
-				<NRF_PSEL(UART_RTS, 0, 5)>,
-				<NRF_PSEL(UART_CTS, 0, 7)>;
+				<NRF_PSEL(UART_RTS, 1, 3)>,
+				<NRF_PSEL(UART_CTS, 1, 4)>;
 			low-power-enable;
 		};
 	};

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -16,18 +16,18 @@
 &pinctrl {
 	uart1_default_alt: uart1_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 0)>,
-				<NRF_PSEL(UART_RX, 1, 1)>,
-				<NRF_PSEL(UART_RTS, 0, 2)>,
+			psels = <NRF_PSEL(UART_TX, 0, 4)>,
+				<NRF_PSEL(UART_RX, 0, 5)>,
+				<NRF_PSEL(UART_RTS, 0, 6)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 		};
 	};
 
 	uart1_sleep_alt: uart1_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 0)>,
-				<NRF_PSEL(UART_RX, 1, 1)>,
-				<NRF_PSEL(UART_RTS, 0, 2)>,
+			psels = <NRF_PSEL(UART_TX, 0, 4)>,
+				<NRF_PSEL(UART_RX, 0, 5)>,
+				<NRF_PSEL(UART_RTS, 0, 6)>,
 				<NRF_PSEL(UART_CTS, 0, 7)>;
 			low-power-enable;
 		};

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
@@ -1,7 +1,8 @@
 tests:
   zigbee.osif.serial.basic:
+    depends_on: gpio
     platform_allow: nrf52840dk_nrf52840 nrf52833dk_nrf52833 nrf5340dk_nrf5340_cpuapp
     tags: osif_serial
     harness: ztest
     harness_config:
-      fixture: shorted_uart_1
+      fixture: gpio_loopback


### PR DESCRIPTION
Changed pins used for UART1 peripheral to standarized ones to allow running tests at CI.