### PR TITLE
treewide: Prevent python argparse from abbreviating arguments

### DIFF
--- a/applications/nrf5340_audio/tools/buildprog/ble5-ctr-rpmsg_sign.py
+++ b/applications/nrf5340_audio/tools/buildprog/ble5-ctr-rpmsg_sign.py
@@ -284,7 +284,8 @@ def __main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description='This script sign and generate netcore hex and upgradable binary for the\
-         nRF5340 Audio project on Windows and Linux')
+         nRF5340 Audio project on Windows and Linux',
+        allow_abbrev=False)
     parser.add_argument('-i', '--input_file', type=str,
                         help='Input hex file name. Higher priority than -I')
     parser.add_argument('-b', '--build_dir', required=True, type=str,

--- a/applications/nrf5340_audio/tools/buildprog/buildprog.py
+++ b/applications/nrf5340_audio/tools/buildprog/buildprog.py
@@ -213,6 +213,7 @@ def __main():
             "This script builds and programs the nRF5340 "
             "Audio project on Windows and Linux"
         ),
+        allow_abbrev=False
     )
     parser.add_argument(
         "-r",

--- a/applications/nrf5340_audio/tools/buildprog/fw_info_data.py
+++ b/applications/nrf5340_audio/tools/buildprog/fw_info_data.py
@@ -58,7 +58,8 @@ def inject_fw_info(input_file, offset, output_hex, magic_value, fw_version, fw_v
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Inject fw info metadata at specified offset. Generate HEX file',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument('-i', '--input', required=True, type=argparse.FileType('r', encoding='UTF-8'),
                         help='Input hex file.')

--- a/doc/_scripts/cache_create.py
+++ b/doc/_scripts/cache_create.py
@@ -201,7 +201,7 @@ def main(args) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument(
         "-o",

--- a/doc/_scripts/cache_upload.py
+++ b/doc/_scripts/cache_upload.py
@@ -72,7 +72,7 @@ def main(args) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument(
         "-i",

--- a/doc/_scripts/fix_markdown.py
+++ b/doc/_scripts/fix_markdown.py
@@ -19,7 +19,7 @@ import sys
 
 def main():
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument("dir", nargs=1)
     args = parser.parse_args()

--- a/doc/_scripts/merge_search_indexes.py
+++ b/doc/_scripts/merge_search_indexes.py
@@ -200,7 +200,7 @@ def main(build_dir: Path) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument(
         "-b",

--- a/doc/_scripts/software_maturity/software_maturity_scanner.py
+++ b/doc/_scripts/software_maturity/software_maturity_scanner.py
@@ -620,7 +620,7 @@ if __name__ == "__main__":
     build_output = os.environ.get("TWISTER_OUT_DIR", None)
     access_key = os.environ.get("AZURE_REPORT_CACHE_ACCESS_KEY", None)
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument(
         "-bo",

--- a/samples/matter/lock/src/flash-external.py
+++ b/samples/matter/lock/src/flash-external.py
@@ -34,7 +34,8 @@ def main():
     # Type for an integer of arbitrary base
     def any_base_int(s): return int(s, 0)
 
-    parser = argparse.ArgumentParser(description="Program firmware into external flash")
+    parser = argparse.ArgumentParser(description="Program firmware into external flash",
+                                     allow_abbrev=False)
     parser.add_argument('--app', required=True, type=argparse.FileType('rb'),
                         help="Application core image in MCUboot format")
     parser.add_argument('--app-offset', type=any_base_int, required=True,

--- a/samples/nrf9160/fmfu_smp_svr/update_modem.py
+++ b/samples/nrf9160/fmfu_smp_svr/update_modem.py
@@ -32,7 +32,7 @@ def run(uart, modem_firmware_zip, baudrate):
                     .format(time.time() - start_time))
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("firmware", default=None,
             help="Path to nrf9160 modem firmware zip folder")
     parser.add_argument("uart", default=None,

--- a/samples/nrf9160/lwm2m_client/scripts/coiote.py
+++ b/samples/nrf9160/lwm2m_client/scripts/coiote.py
@@ -317,7 +317,8 @@ if __name__ == "__main__":
         print(json.dumps(resp, indent=4))
 
     parser = argparse.ArgumentParser(
-        description='Coiote device management')
+        description='Coiote device management',
+        allow_abbrev=False)
     parser.set_defaults(func=None)
     parser.add_argument("-d", "--debug", action="store_true", default=False, help="Output debug information.")
     subparsers = parser.add_subparsers(title='commands')

--- a/samples/nrf9160/lwm2m_client/scripts/device.py
+++ b/samples/nrf9160/lwm2m_client/scripts/device.py
@@ -169,7 +169,8 @@ if __name__ == "__main__":
     def store(args):
         dev.store_psk(args.tag, args.identity, args.psk)
 
-    parser = argparse.ArgumentParser(description='nRF91 Secure Tag management')
+    parser = argparse.ArgumentParser(description='nRF91 Secure Tag management',
+                                     allow_abbrev=False)
     parser.set_defaults(func=None)
     parser.add_argument('-d', help='Enable debug logs', action='store_true')
 

--- a/samples/nrf9160/lwm2m_client/scripts/provision.py
+++ b/samples/nrf9160/lwm2m_client/scripts/provision.py
@@ -24,7 +24,8 @@ if __name__ == "__main__":
         pass
 
     parser = argparse.ArgumentParser(
-        description='nRF91 device provisioning example')
+        description='nRF91 device provisioning example',
+        allow_abbrev=False)
     parser.add_argument('-f', help='Build and flash the AT client', action='store_true')
     parser.add_argument('-d', help='Enable debug logs', action='store_true')
     parser.add_argument('-p', '--purge', dest='purge', help='Wipe the security tags and remove the device from the server', action='store_true')

--- a/scripts/bootloader/asn1parse.py
+++ b/scripts/bootloader/asn1parse.py
@@ -39,7 +39,8 @@ def get_ecdsa_signature(der, clength):
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Decode DER format using OpenSSL.',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument('-a', '--alg', required=True, choices=['rsa', 'ecdsa'],
                         help='Expected algorithm')

--- a/scripts/bootloader/dfu_multi_image_tool.py
+++ b/scripts/bootloader/dfu_multi_image_tool.py
@@ -95,7 +95,9 @@ def show_header(input_file: str) -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description='DFU Multi Image tool', fromfile_prefix_chars='@')
+    parser = argparse.ArgumentParser(description='DFU Multi Image tool',
+                                     fromfile_prefix_chars='@',
+                                     allow_abbrev=False)
     subcommands = parser.add_subparsers(dest='subcommand', title='valid subcommands')
 
     create_parser = subcommands.add_parser(

--- a/scripts/bootloader/do_sign.py
+++ b/scripts/bootloader/do_sign.py
@@ -14,7 +14,8 @@ from ecdsa import SigningKey
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Sign data from stdin or file.',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument('-k', '--private-key', required=True, type=argparse.FileType('rb'),
                         help='Private key to use.')

--- a/scripts/bootloader/generate_zip.py
+++ b/scripts/bootloader/generate_zip.py
@@ -19,7 +19,8 @@ def parse_args():
         description="Generate zip file for binary artifact. Provide a list of 'key=value' pairs separated by space for"
                     "information that should be stored in manifest.json. To provide information specific for one of "
                     "the files, prepend the 'key' with the name of the file (only the basename, not the path)",
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument('--output', required=True, type=argparse.FileType(mode='w'), help='Output zip path')
     parser.add_argument('--bin-files', required=True, type=argparse.FileType(mode='r'), nargs='+',

--- a/scripts/bootloader/hash.py
+++ b/scripts/bootloader/hash.py
@@ -14,7 +14,8 @@ from intelhex import IntelHex
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Hash data from file.',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument('--infile', '-i', '--in', '-in', required=True,
                         help='Hash the contents of the specified file. If a *.hex file is given, the contents will '

--- a/scripts/bootloader/keygen.py
+++ b/scripts/bootloader/keygen.py
@@ -30,7 +30,8 @@ def generate_legal_key():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Generate PEM file.',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     priv_pub_group = parser.add_mutually_exclusive_group(required=True)
     priv_pub_group.add_argument('--private', required=False, action='store_true',

--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -49,7 +49,8 @@ Reduce the number of public keys or counter slots and try again."""
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Generate provisioning hex file.',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
     parser.add_argument('--s0-addr', type=lambda x: int(x, 0), required=True, help='Address of image slot s0')
     parser.add_argument('--s1-addr', type=lambda x: int(x, 0), required=False, help='Address of image slot s1')
     parser.add_argument('--provision-addr', type=lambda x: int(x, 0),

--- a/scripts/bootloader/validation_data.py
+++ b/scripts/bootloader/validation_data.py
@@ -67,7 +67,8 @@ def append_validation_data(signature, input_file, public_key, offset, output_hex
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Append validation metadata at specified offset. Generate HEX and BIN file',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument('-i', '--input', required=True, type=argparse.FileType('r', encoding='UTF-8'),
                         help='Input hex file.')

--- a/scripts/bootloader/zb_add_ota_header.py
+++ b/scripts/bootloader/zb_add_ota_header.py
@@ -153,7 +153,8 @@ def hex2int(x):
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Append Zigbee OTA header to BIN file',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument('--application', required=True,
                         help='The application firmware file.')

--- a/scripts/ci/check_license.py
+++ b/scripts/ci/check_license.py
@@ -47,7 +47,8 @@ def parse_args():
     '''Parse command line arguments.'''
     default_allow_list = Path(__file__).parent / 'license_allow_list.yaml'
     parser = argparse.ArgumentParser(
-        description='Check for allowed licenses.')
+        description='Check for allowed licenses.',
+        allow_abbrev=False)
     parser.add_argument('-c', '--commits', default='HEAD~1..',
                         help='Commit range in the form: a..[b], default is HEAD~1..HEAD')
     parser.add_argument('-o', '--output', type=Path, default='licenses.xml',

--- a/scripts/get_pulls_in_range.py
+++ b/scripts/get_pulls_in_range.py
@@ -138,7 +138,8 @@ def parse_args() -> argparse.Namespace:
         with larger commit ranges. To save and restore results from earlier
         runs, use the --sqlite-db option. This avoids requesting information
         from the GitHub API server that is already available locally.
-        ''')
+        ''',
+        allow_abbrev=False)
 
     parser.add_argument('gh_repo',
                         help='''repository in <organization>/<repo> format,

--- a/scripts/hid_configurator/configurator_cli.py
+++ b/scripts/hid_configurator/configurator_cli.py
@@ -177,7 +177,7 @@ def perform_led_stream(dev, args):
 
 
 def parse_arguments():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
 
     parser.add_argument(dest='device', default=None, nargs='?',
                         help='Device specified by type, board name or HW ID '

--- a/scripts/memfault/mds_ble_gateway.py
+++ b/scripts/memfault/mds_ble_gateway.py
@@ -371,7 +371,8 @@ class Memfault(BLEMemfault):
 def parse_args():
     """ Parse command line arguments. """
 
-    parser = argparse.ArgumentParser(description='Memfault BLE gateway')
+    parser = argparse.ArgumentParser(description='Memfault BLE gateway',
+                                     allow_abbrev=False)
     parser.add_argument('--snr', type=str, required=True, help='Segger chip ID')
     parser.add_argument('--com', type=str, required=True,
                         help='COM port name. For example COM0 or /dev/ttyACM0')

--- a/scripts/nrf_profiler/calc_stats.py
+++ b/scripts/nrf_profiler/calc_stats.py
@@ -10,7 +10,8 @@ import logging
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Calculating stats for events.')
+    parser = argparse.ArgumentParser(description='Calculating stats for events.',
+                                     allow_abbrev=False)
     parser.add_argument('dataset_name', help='Name of dataset')
     parser.add_argument('--start_time', help='Measurement start time[s]')
     parser.add_argument('--end_time', help='Measurement end time[s]')

--- a/scripts/nrf_profiler/data_collector.py
+++ b/scripts/nrf_profiler/data_collector.py
@@ -45,7 +45,8 @@ def main():
     signal.signal(signal.SIGINT, signal_handler)
 
     parser = argparse.ArgumentParser(
-        description='Collecting data from Nordic nrf_profiler for given time and saving to files.')
+        description='Collecting data from Nordic nrf_profiler for given time and saving to files.',
+        allow_abbrev=False)
     parser.add_argument('time', type=int, help='Time of collecting data [s]')
     parser.add_argument('dataset_name', help='Name of dataset')
     parser.add_argument('--log', help='Log level')

--- a/scripts/nrf_profiler/merge_data.py
+++ b/scripts/nrf_profiler/merge_data.py
@@ -36,7 +36,7 @@ def main():
     descr = "Merge data from Peripheral and Central. Synchronization events" \
             " should be registered at the beginning and at the end of" \
             " measurements (used to compensate clock drift)."
-    parser = argparse.ArgumentParser(description=descr)
+    parser = argparse.ArgumentParser(description=descr, allow_abbrev=False)
     parser.add_argument("peripheral_dataset", help="Name of Peripheral dataset")
     parser.add_argument("peripheral_sync_event",
                         help="Event used for synchronization - Peripheral")

--- a/scripts/nrf_profiler/plot_from_files.py
+++ b/scripts/nrf_profiler/plot_from_files.py
@@ -9,7 +9,8 @@ import logging
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Plotting events from given files.')
+        description='Plotting events from given files.',
+        allow_abbrev=False)
     parser.add_argument('dataset_name', help='Name of dataset')
     parser.add_argument('--log', help='Log level')
     args = parser.parse_args()

--- a/scripts/nrf_profiler/real_time_plot.py
+++ b/scripts/nrf_profiler/real_time_plot.py
@@ -53,7 +53,8 @@ def main():
     signal.signal(signal.SIGINT, signal_handler)
 
     parser = argparse.ArgumentParser(
-        description='Collecting data from Nordic nrf_profiler for given time, plotting and saving to files.')
+        description='Collecting data from Nordic nrf_profiler for given time, plotting and saving to files.',
+        allow_abbrev=False)
     parser.add_argument('dataset_name', help='Name of dataset')
     parser.add_argument('--log', help='Log level')
     args = parser.parse_args()

--- a/scripts/nrf_provision/fast_pair/fp_provision_cli.py
+++ b/scripts/nrf_provision/fast_pair/fp_provision_cli.py
@@ -63,7 +63,8 @@ def prepare_fast_pair_provisioning(out_file, address, model_id, anti_spoofing_ke
 
 
 def parse_arguments():
-    p = argparse.ArgumentParser(description='Fast Pair Provisioning Tool')
+    p = argparse.ArgumentParser(description='Fast Pair Provisioning Tool',
+                                allow_abbrev=False)
 
     p.add_argument("-o", "--out_file", type=str, required=True, help="Name of the output file")
     p.add_argument("-a", "--address", type=lambda x: int(x,16), required=True,

--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -891,7 +891,8 @@ This script generates a file for each partition - "pm_config.h".
 This file contains all addresses and sizes of all partitions.
 
 "pm_config.h" is in the same folder as the given 'pm.yml' file.''',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
     parser.add_argument('--input-files', required=True, type=str, nargs='+',
                         help='List of paths to input yaml files.')
 
@@ -915,7 +916,7 @@ This file contains all addresses and sizes of all partitions.
     main_args, region_args = parser.parse_known_args()
 
     # Create new instance to parse regions
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     for x in main_args.regions:
         # Generate arguments for each region dynamically
         parser.add_argument(f'--{x}-size', required=True, type=lambda z: int(z, 0))

--- a/scripts/partition_manager_output.py
+++ b/scripts/partition_manager_output.py
@@ -166,7 +166,8 @@ def write_kconfig_file(gpm_config, regions_config, out_path):
 def parse_args():
     parser = argparse.ArgumentParser(
         description='''Creates files based on Partition Manager results.''',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
 
     parser.add_argument('--input-partitions', required=True, type=str, nargs='+',
                         help='Paths to the input .yml files, one per domain.')

--- a/scripts/partition_manager_report.py
+++ b/scripts/partition_manager_report.py
@@ -75,7 +75,8 @@ def print_region(domain, region, size, pm_config):
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Parse given Partition Manager output YAML file and print a pretty report',
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False)
     parser.add_argument('-i', '--input', required=True, type=str, nargs='+',
                         help='Path to the domain specific YAML files from Partition Manager')
 

--- a/scripts/shell/bt_nus_shell.py
+++ b/scripts/shell/bt_nus_shell.py
@@ -24,7 +24,7 @@ from pc_ble_driver_py.ble_adapter import BLEAdapter, BLEAdapterObserver, EvtSync
 
 CFG_TAG = 1
 
-parser = argparse.ArgumentParser(description='BLE serial daemon.')
+parser = argparse.ArgumentParser(description='BLE serial daemon.', allow_abbrev=False)
 parser.add_argument('--com', help='COM port name (e.g. COM110).',
                     nargs='*', required=True, default="")
 parser.add_argument('--snr', help='segger id.',

--- a/scripts/unity/func_name_list.py
+++ b/scripts/unity/func_name_list.py
@@ -24,7 +24,7 @@ def func_names_from_header(in_file, out_file, exclude=None):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("-i", "--input", type=str,
                         help="input header file", required=True)
     parser.add_argument("-o", "--output", type=str,

--- a/scripts/unity/header_prepare.py
+++ b/scripts/unity/header_prepare.py
@@ -72,7 +72,7 @@ def header_prepare(in_file, out_file, out_wrap_file):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("-i", "--input", type=str,
                         help="input header file", required=True)
     parser.add_argument("-o", "--output", type=str,

--- a/scripts/west_commands/sbom/args.py
+++ b/scripts/west_commands/sbom/args.py
@@ -152,7 +152,8 @@ def init_args(allowed_detectors: dict):
     if not args._initialized:
         # Parse command line arguments if running outside west
         parser = argparse.ArgumentParser(description=COMMAND_DESCRIPTION,
-                                        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+                                         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                         allow_abbrev=False)
         add_arguments(parser)
         copy_arguments(parser.parse_args())
 


### PR DESCRIPTION
Fixes an issue whereby the python argparse library will allow abbreviated commands by default which leads to possible future issues if new commands are added.