### PR TITLE
doc: matter: change link to Matter spec

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -111,7 +111,6 @@
 .. _`Matter nRF Connect releases`: https://github.com/nrfconnect/sdk-connectedhomeip/releases
 .. _`Matter Certification Policy`: https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/policies/matter_certificate_policy.adoc
 .. _`Kconfig.mcuboot.defaults`: https://github.com/project-chip/connectedhomeip/blob/master/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
-.. _`Matter specification repository`: https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/policies/
 .. _`Matter SDK tagged as v1.0.0`: https://github.com/project-chip/connectedhomeip/releases/tag/v1.0.0
 
 .. _`DCL Quick Start Guide`: https://github.com/zigbee-alliance/distributed-compliance-ledger/blob/master/docs/quickStartGuide.adoc
@@ -830,7 +829,7 @@
 
 .. _`Zigbee Alliance`:
 .. _`Connectivity Standards Alliance`: https://csa-iot.org
-.. _`Zigbee Specification`: https://zigbeealliance.org/developer_resources/
+.. _`CSA Specifications Download Request`: https://csa-iot.org/developer-resource/specifications-download-request/
 .. _`Zigbee Cluster Library specification`: https://zigbeealliance.org/wp-content/uploads/2019/12/07-5123-06-zigbee-cluster-library-specification.pdf
 
 .. _`Matter Resource Kit`: https://groups.csa-iot.org/wg/all-users/home/matter-resource-kit
@@ -838,13 +837,14 @@
 .. _`CSA's Testing Providers`: https://csa-iot.org/certification/testing-providers/
 .. _`CSA's Certification Team`: https://csa-iot.org/contact-us/
 .. _`Connectivity Standards Alliance members`: https://csa-iot.org/members/
-.. _`Join CSA`:
-.. _`CSA's Become Member page`: https://csa-iot.org/become-member/
+.. _`Join CSA`: https://csa-iot.org/become-member/
 .. _`CSA Member Resources page`: https://groups.csa-iot.org/wg/all-users/home/member-resources
 .. _`Matter Attestation Form`: https://groups.csa-iot.org/wg/members-all/document/folder/2255
 .. _`Matter Attestation of Security template`: https://groups.csa-iot.org/wg/members-all/document/27432
 .. _`Connectivity Standards Alliance Certification Web Tool`: https://zigbeecertifiedproducts.knack.com/zigbee-certified#home/
 .. _`CSA Certified Products Database`: https://csa-iot.org/csa-iot_products/
+
+.. _`Distributed Compliance Ledger`: https://webui.dcl.csa-iot.org/
 
 .. ### Source: Chocolatey
 
@@ -1027,9 +1027,6 @@
 .. _`GN website`: https://gn.googlesource.com/gn/#getting-a-binary
 
 .. _`Power Saving Mode (PSM)`: https://www.sharetechnote.com/html/Handbook_LTE_PSM.html
-
-.. _`Distributed Compliance Ledger`:
-.. _`Distributed Compliance Ledger website`: https://webui.dcl.csa-iot.org/
 
 .. _`Leshan Demo Server web UI`:
 .. _`public Leshan Demo Server`: https://leshan.eclipseprojects.io

--- a/doc/nrf/ug_matter_device_attestation.rst
+++ b/doc/nrf/ug_matter_device_attestation.rst
@@ -207,7 +207,7 @@ The procedure is structured into the following steps:
 4. The commissioner validates the information received from the commissionee.
    During the validation, the commissioner confirms the attestation information received against information contained on the device.
    For example, the Vendor ID from the attestation information packet is vetted against the Vendor ID in the DAC and the Basic Information cluster, the Certificate ID from the CD is verified against the entry in the DCL, and so on.
-   For the detailed list of what information undergoes verification, see chapter 6.2.3.1 (Attestation Validation Information) in the Matter specification, available to CSA members.
+   For the detailed list of what information undergoes verification, see chapter 6.2.3.1 (Attestation Validation Information) in the `Matter Core Specification <CSA Specifications Download Request_>`_.
 
 A device that passes the Device Attestation procedure has been verified as an authentic Matter device.
 The commissioner can then proceed to the next stage of :ref:`ug_matter_network_topologies_commissioning`, which may succeed or not.

--- a/doc/nrf/ug_matter_device_certification.rst
+++ b/doc/nrf/ug_matter_device_certification.rst
@@ -65,8 +65,8 @@ Before you start applying for the Matter certification, you must join CSA, as de
 
 Joining CSA allows you to meet the following requirements:
 
-* Familiarity with the Matter specification, which is the standard for the certification.
-  You can access the specification from the `Matter Resource Kit`_ after you join CSA.
+* Familiarity with the Matter Core Specification, which is the standard for the certification.
+  You can download it from the `CSA Specifications Download Request`_ page.
 * Assignment of Vendor ID (VID), which is required when applying for certification.
   You can apply to `CSA's Certification Team`_ to obtain VID.
   The VID codes are valid immediately upon assignment.
@@ -130,7 +130,7 @@ Matter Attestation of Security
 ++++++++++++++++++++++++++++++
 
 For a Matter component to be certified, CSA's policies require an Attestation of Security that provides detailed information about the security level of the Matter component.
-The attestation document lists robustness security requirements based on the Matter specification.
+The attestation document lists robustness security requirements based on the Matter Core Specification.
 The product developer must indicate the level of compliance and briefly justify the choice.
 
 The attestation must be filled by the person responsible for end product certification who meets the following requirements:
@@ -175,7 +175,7 @@ To be considered of the same family, the other products must meet the following 
 
 * All products must share the same device type as the first product.
 * All products must be variants of the first product, which should also be the most feature complete.
-* All products must conform with the Matter specification, regardless of differences.
+* All products must conform with the Matter specifications, regardless of differences.
 
 .. figure:: images/matter_device_certification_process_pf.svg
    :alt: Matter's Product Family certification overview

--- a/doc/nrf/ug_matter_device_dcl.rst
+++ b/doc/nrf/ug_matter_device_dcl.rst
@@ -18,7 +18,7 @@ The DCL is based on the Tendermint protocol, which is used for running the block
 
 During the :ref:`ug_matter_device_attestation` procedure, the DCL acts as the secure distribution point of the list of active and revoked Product Attestation Authority root certificates.
 
-The ledger is publicly available at the `Distributed Compliance Ledger website`_.
+The ledger is publicly available at the `Distributed Compliance Ledger website <Distributed Compliance Ledger_>`_.
 
 .. _ug_matter_device_certification_dcl_definition_roles:
 

--- a/doc/nrf/ug_matter_device_prerequisites.rst
+++ b/doc/nrf/ug_matter_device_prerequisites.rst
@@ -14,21 +14,21 @@ Connectivity Standards Alliance membership
 
 The most important prerequisite is becoming member of the `Connectivity Standards Alliance`_, which grants you access to a variety of Matter member resources, lets you contribute to the Matter Specification GitHub repository, and allows you to add information to the `Distributed Compliance Ledger`_, among other things.
 
-You can become a CSA member by applying on the `CSA's Become Member page`_.
+You can become a CSA member by applying on the `CSA's Become Member page <Join CSA_>`_.
 You need at least the Adopter membership level in order to use approved specifications to build products and certify them.
 Once you join CSA, you need to apply for membership in the Matter Working Group to get access to Matter resources and community.
 
-Matter specification and other documents
-========================================
+Matter specifications and other documents
+=========================================
 
 To develop products for Matter, you need to be familiar with several official documents, which you will gain access to after joining Matter Working Group.
 Most important of these documents are the following:
 
-* Matter Specification
-* Matter Device Library
-* Matter Application Clusters
+* Matter Core Specification
+* Matter Device Library Specification
+* Matter Application Cluster Specification
 
-These documents describe the Matter protocol and are available to CSA members from the restricted `Matter specification repository`_.
+These documents describe the Matter protocol and are available to CSA members from the `CSA Specifications Download Request`_ page.
 
 Being familiar with the following documents is crucial for the success of your :ref:`ug_matter_device_certification` procedure:
 

--- a/doc/nrf/ug_matter_intro_overview.rst
+++ b/doc/nrf/ug_matter_intro_overview.rst
@@ -29,7 +29,7 @@ The following are some of the key features of Matter:
 * Breaking new ground with a reference, open-source Matter stack delivered by `Connectivity Standards Alliance`_.
 * Enabling accelerated adoption in smart home, building and commercial use.
 
-The following pages provide a brief overview of the Matter structure.
+The following pages provide a brief overview of the Matter structure, in accordance with `Matter specifications <CSA Specifications Download Request_>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/nrf/ug_matter_overview_data_model.rst
+++ b/doc/nrf/ug_matter_overview_data_model.rst
@@ -10,7 +10,7 @@ Matter Data Model and device types
 .. ug_matter_data_model_desc_start
 
 The Data Model layer describes the supported remote operations of a Matter node using the concepts of attributes, commands and events, grouped into logical blocks called clusters.
-The clusters included in the Matter specification have well-defined scope and behavior to assure interoperability between Matter nodes developed by different vendors.
+The clusters included in the `Matter Application Cluster Specification <CSA Specifications Download Request_>`_ have well-defined scope and behavior to assure interoperability between Matter nodes developed by different vendors.
 A cluster can be abstract, meaning that it can underlie several device types to reduce the time and cost of introducing new product categories to Matter.
 
 .. figure:: images/matter_components_DM.svg
@@ -42,8 +42,8 @@ Clusters
    * Server -- responsible for holding values for Attributes, Commands, and Events.
    * Client -- responsible for performing interactions with other Server Clusters.
 
-   The supported Matter application clusters are described in the Application Clusters specification, available to the `Connectivity Standards Alliance`_ members.
-   Sets of clusters on one or more endpoint can form a :ref:`device type <ug_matter_device_types>`, that is an officially defined collection of requirements that is conformant with the Device Library specification.
+   The supported Matter application clusters are described in the Application Cluster Specification, available from the `CSA Specifications Download Request`_ page.
+   Sets of clusters on one or more endpoint can form a :ref:`device type <ug_matter_device_types>`, that is an officially defined collection of requirements that is conformant with the Device Library Specification.
 
 Attributes
    Attributes are data entities that represent a physical quantity or state.
@@ -68,7 +68,7 @@ The following figure illustrates the Data Model structure of a common door lock 
 Each Matter node must ensure that its Endpoint 0 satisfies the requirements of the Root Node device type.
 This device type enforces the availability of clusters used in the process of :ref:`Matter commissioning <ug_matter_overview_commissioning>` and further administering of a Matter node.
 
-Besides the Root Node endpoint, the door lock device provides Endpoint 1, which implements the Door Lock Device Type functionality as defined in the Matter specification.
+Besides the Root Node endpoint, the door lock device provides Endpoint 1, which implements the Door Lock Device Type functionality as defined in the Matter Device Library Specification.
 This device type enforces the availability of the ``Identify`` and ``DoorLock`` clusters.
 
 Identify cluster
@@ -103,7 +103,7 @@ Matter device types
 A Matter device type is an officially defined collection of requirements for one or more endpoints.
 Device types are intended to ensure interoperability of different device brands on the market.
 
-All device types are defined in the Device Library specification, which is available to `Connectivity Standards Alliance`_ members.
+All device types are defined in the Device Library Specification, which is available from the `CSA Specifications Download Request`_ page.
 Each device type definition is composed of the following elements:
 
 * Device type ID
@@ -119,9 +119,9 @@ A device type can require other device types for its composition, making it a *c
 Device type overview
 ********************
 
-The following tables list the application device types that are supported in the Matter specification.
+The following tables list the *application device types* that are supported in Matter.
 
-* The description for each device type is taken from the Device Library specification.
+* The description for each device type is taken from the Device Library Specification.
 * The state of the device specifies whether a device type can be subject to certification.
   The `Provisional` state indicates that the device type implementation is not yet fully tested and certified, even though the implementation may be ready and you can use it on your own risk.
 * The dedicated sample column provides the link to the sample in the |NCS| that implements the given device type, if available.
@@ -134,7 +134,7 @@ Lighting device types
 =====================
 
 +-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
-| Device type       | Description (from Device Library specification)                              | State of the device | Dedicated sample in the |NCS|         |
+| Device type       | Description (from Device Library Specification)                              | State of the device | Dedicated sample in the |NCS|         |
 +===================+==============================================================================+=====================+=======================================+
 | On/Off Light      | The On/Off Light is a lighting device that is capable of being switched on   | Certifiable         |                                       |
 |                   | or off by means of a bound controller device such as an on/off light switch  |                     |                                       |
@@ -168,7 +168,7 @@ Smart Plugs/Outlets device types
 ================================
 
 +-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
-| Device type       | Description (from Device Library specification)                              | State of the device | Dedicated sample in the |NCS|         |
+| Device type       | Description (from Device Library Specification)                              | State of the device | Dedicated sample in the |NCS|         |
 +===================+==============================================================================+=====================+=======================================+
 | On/Off Plug-in    | An On/Off Plug-in Unit is a device that is capable of being switched on      | Certifiable         |                                       |
 | Unit              | or off by means of a bound controller device such as an on/off light switch  |                     |                                       |
@@ -191,7 +191,7 @@ Switches and Controls device types
 ==================================
 
 +-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
-| Device type       | Description (from Device Library specification)                              | State of the device | Dedicated sample in the |NCS|         |
+| Device type       | Description (from Device Library Specification)                              | State of the device | Dedicated sample in the |NCS|         |
 +===================+==============================================================================+=====================+=======================================+
 | On/Off Light      | An On/Off Light Switch is a controller device that,                          | Certifiable         |                                       |
 | Switch            | when bound to a lighting device such as an on/off light, is capable of       |                     |                                       |
@@ -229,7 +229,7 @@ Sensor device types
 ===================
 
 +-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
-| Device type       | Description (from Device Library specification)                              | State of the device | Dedicated sample in the |NCS|         |
+| Device type       | Description (from Device Library Specification)                              | State of the device | Dedicated sample in the |NCS|         |
 +===================+==============================================================================+=====================+=======================================+
 | Contact Sensor    | A Contact Sensor device reports boolean state (open/close                    | Certifiable         |                                       |
 |                   | or contact/no-contact).                                                      |                     |                                       |
@@ -264,7 +264,7 @@ Closure device types
 ====================
 
 +-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
-| Device type       | Description (from Device Library specification)                              | State of the device | Dedicated sample in the |NCS|         |
+| Device type       | Description (from Device Library Specification)                              | State of the device | Dedicated sample in the |NCS|         |
 +===================+==============================================================================+=====================+=======================================+
 | Door Lock         | A Door Lock is a device used to secure a door. It is possible to actuate     | Certifiable         | :ref:`matter_lock_sample`             |
 |                   | a door lock either by means of a manual or a remote method.                  |                     |                                       |
@@ -285,7 +285,7 @@ HVAC device types
 =================
 
 +-------------------+------------------------------------------------------------------------------+---------------------+---------------------------------------+
-| Device type       | Description (from Device Library specification)                              | State of the device | Dedicated sample in the |NCS|         |
+| Device type       | Description (from Device Library Specification)                              | State of the device | Dedicated sample in the |NCS|         |
 +===================+==============================================================================+=====================+=======================================+
 | Heating/Cooling   | A Heating/Cooling Unit is a device capable of heating or cooling a space     | Provisional         |                                       |
 | Unit              | in a house. It is not mandatory to provide both functionalities              |                     |                                       |

--- a/doc/nrf/ug_matter_overview_dfu.rst
+++ b/doc/nrf/ug_matter_overview_dfu.rst
@@ -12,7 +12,7 @@ Most of the Matter devices will require such an update at some point during thei
 The software image is provided by another Matter node, which acquired information about it and downloaded it from a centralized and reliable source.
 The download takes place over a special transfer protocol and user consent is required for the image to be applied on the target Matter device.
 
-This page provides an overview of the Matter OTA process, described in detail in the `Matter specification <Matter specification repository_>`_, and mentions :ref:`ug_matter_overview_dfu_image_nordic` to the process.
+This page provides an overview of the Matter OTA process, described in detail in the `Matter Core Specification <CSA Specifications Download Request_>`_, and mentions :ref:`ug_matter_overview_dfu_image_nordic` to the process.
 
 .. _ug_matter_overview_dfu_roles:
 
@@ -87,7 +87,7 @@ Matter OTA process
 ******************
 
 The following chart shows a simplified overview of the Matter OTA process.
-For detailed description, see the official Matter specification.
+For detailed description, see the Matter Core Specification.
 
 The Matter OTA image download always happens in the background, without affecting the device's normal operation.
 
@@ -144,7 +144,7 @@ The software image must use fixed encoding and it must include the mandatory fie
 +-----------------------+--------+-----------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``HeaderSize``        | uint32 |                                               | Indicates the total size of the TLV-encoded header field.                                                                                            |
 +-----------------------+--------+-----------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ``Header``            | TLV    | TLV encoding type and value.                  | Includes the `ota-image-header-struct` with a predefined order. See section 11.20.2.4 of the Matter specification for more information.              |
+| ``Header``            | TLV    | TLV encoding type and value.                  | Includes the `ota-image-header-struct` with a predefined order. See section 11.20.2.4 of the `Matter Core Specification`_ for more information.      |
 +-----------------------+--------+-----------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``Payload``           | n/a    | Software image contents.                      | Includes the new software to be installed on the OTA Requestor. When using the |NCS|, this field also includes `Nordic Matter platform additions`_.  |
 +-----------------------+--------+-----------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/doc/nrf/ug_matter_overview_network_topologies.rst
+++ b/doc/nrf/ug_matter_overview_network_topologies.rst
@@ -40,7 +40,7 @@ Binding
   A feature that allows establishing a relationship between Matter endpoints on a single or two separate Matter nodes.
   The relationships are described by binding entries stored persistently in the device memory and managed by the Binding Cluster.
   Bindings are used to assign target or targets of a client cluster on the node, so that the device knows which remote device it should act upon.
-  The behavior induced by establishing a binding is application-defined and is not limited anyhow by the Matter specification, which opens the way for different custom scenarios.
+  The behavior induced by establishing a binding is application-defined and is not limited anyhow by the Matter Core Specification, which opens the way for different custom scenarios.
   For example, you can create a relationship in which a button press on light switch device results in changing the state of one or group of light bulb devices.
 
 Bridge

--- a/doc/nrf/ug_zigbee_commissioning.rst
+++ b/doc/nrf/ug_zigbee_commissioning.rst
@@ -19,7 +19,7 @@ For more information, see the `Support for Zigbee commissioning`_ section in the
 Start of commissioning
 **********************
 
-There are several ways the commissioning process can be started, according to the Zigbee specification:
+There are several ways the commissioning process can be started, according to the `Zigbee Specification <CSA Specifications Download Request_>`_:
 
 * Automatically after device initialization.
 * With a user action, for example a button press or a command.

--- a/doc/nrf/ug_zigbee_qsg.rst
+++ b/doc/nrf/ug_zigbee_qsg.rst
@@ -75,7 +75,7 @@ If you want to learn more about Zigbee topics and terminology mentioned in this 
 
 * :ref:`ug_zigbee_architectures` page to learn more about the Zigbee architecture available in the |NCS|
 * `Common ZCL terms and definitions`_ section in the ZBOSS user guide
-* Zigbee topologies in section 1.1.4 of the `Zigbee Specification`_
+* Zigbee topologies in section 1.1.4 of the `Zigbee Specification <CSA Specifications Download Request_>`_
 * :ref:`zigbee_ug_sed` section on the :ref:`ug_zigbee_configuring` page
 
 Requirements

--- a/doc/nrf/ug_zigbee_supported_features.rst
+++ b/doc/nrf/ug_zigbee_supported_features.rst
@@ -23,4 +23,4 @@ Experimental support also means that the feature is either not certified or no s
 
 See the :ref:`nrfxlib:zboss` page in nrfxlib and the `external ZBOSS development guide and API documentation`_ for more information about the ZBOSS library.
 
-For more information about Zigbee, visit the `Connectivity Standards Alliance`_ page and read `Zigbee Specification`_.
+For more information about Zigbee, download the `Zigbee Specification <CSA Specifications Download Request_>`_ from Connectivity Standards Alliance.


### PR DESCRIPTION
Updated links to Matter specification download.
Removed notes about restricted access.
Updated related Zigbee links.
Updated naming for consistency with the Matter page. KRKNWK-16070.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>