### PR TITLE
CODEOWNERS: extend codeowners for lwM2M tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -260,7 +260,7 @@ Kconfig*                                  @tejlmand
 /tests/subsys/net/lib/aws_*/              @simensrostad
 /tests/subsys/net/lib/azure_iot_hub/      @jtguggedal
 /tests/subsys/net/lib/fota_download/      @hakonfam @sigvartmh
-/tests/subsys/net/lib/lwm2m_client_utils/ @SeppoTakalo @jarlamsa @jheiskan81 @juhaylinen @VeijoPesonen
+/tests/subsys/net/lib/lwm2m_*/            @SeppoTakalo @jarlamsa @jheiskan81 @juhaylinen @VeijoPesonen
 /tests/subsys/net/lib/nrf_cloud/          @tony-le-24
 /tests/subsys/net/lib/wifi_credentials*/  @maxd-nordic
 /tests/subsys/partition_manager/region/   @hakonfam @sigvartmh


### PR DESCRIPTION
As a result of adding new test for lwm2m_fota_utils then CODEOWNERS list should be updated.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>