### PR TITLE
manifest: rename mbedtls to match zephyr manifest name

### DIFF
--- a/doc/nrf/introduction.rst
+++ b/doc/nrf/introduction.rst
@@ -185,4 +185,4 @@ For more information about the documentation conventions and templates, see :ref
 The following table lists all the repositories (and their respective revisions) that are included as part of |NCS| |version| release:
 
 .. manifest-revisions-table::
-   :show-first: zephyr, nrfxlib, mcuboot, trusted-firmware-m, find-my, homekit, matter, nrf-802154, mbedtls-nrf, memfault-firmware-sdk
+   :show-first: zephyr, nrfxlib, mcuboot, trusted-firmware-m, find-my, homekit, matter, nrf-802154, mbedtls, memfault-firmware-sdk

--- a/scripts/tag_west_repos.sh
+++ b/scripts/tag_west_repos.sh
@@ -52,7 +52,7 @@ PROJECT_TAGS[nrf-802154]=""
 PROJECT_TAGS[zephyr]=""
 PROJECT_TAGS[mcuboot]=""
 PROJECT_TAGS[trusted-firmware-m]=""
-PROJECT_TAGS[mbedtls-nrf]=""
+PROJECT_TAGS[mbedtls]=""
 
 
 

--- a/west.yml
+++ b/west.yml
@@ -108,8 +108,8 @@ manifest:
       repo-path: sdk-mcuboot
       revision: 9d2f9b5742c5cabcb87b7f7f22ff5269b13403bf
       path: bootloader/mcuboot
-    - name: mbedtls-nrf
-      path: mbedtls
+    - name: mbedtls
+      path: modules/crypto/mbedtls
       repo-path: sdk-mbedtls
       revision: v3.1.0-ncs2
     - name: nrfxlib


### PR DESCRIPTION
Rename MBedTLS manifest entry to match the name in the zephyr manifest. This indicates that this repository is synchronized against the version in the zephyr manifest.
Update MBedTLS path to match the path in the zephyr manifest.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>