### PR TITLE
bluetooth: fast_pair: Add factory reset

### DIFF
--- a/include/bluetooth/services/fast_pair.h
+++ b/include/bluetooth/services/fast_pair.h
@@ -167,6 +167,16 @@ bool bt_fast_pair_has_account_key(void);
 int bt_fast_pair_battery_set(enum bt_fast_pair_battery_comp battery_comp,
 			     struct bt_fast_pair_battery battery);
 
+/** Perform a reset to the default factory settings for Google Fast Pair Service.
+ *
+ * Clears the Fast Pair storage. If the reset operation is interrupted by system reboot or power
+ * outage, the reset is automatically resumed at the stage of loading the Fast Pair storage.
+ * It prevents the Fast Pair storage from ending in unwanted state after the reset interruption.
+ *
+ * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
+ */
+int bt_fast_pair_factory_reset(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/services/fast_pair/fp_advertising.c
+++ b/subsys/bluetooth/services/fast_pair/fp_advertising.c
@@ -17,7 +17,7 @@ LOG_MODULE_DECLARE(fast_pair, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
 #include "fp_common.h"
 #include "fp_crypto.h"
 #include "fp_registration_data.h"
-#include "fp_storage.h"
+#include "fp_storage_ak.h"
 
 #define LEN_BITS				4
 #define TYPE_BITS				4
@@ -89,7 +89,7 @@ static size_t bt_fast_pair_adv_data_size_discoverable(void)
 
 size_t bt_fast_pair_adv_data_size(struct bt_fast_pair_adv_config fp_adv_config)
 {
-	int account_key_cnt = fp_storage_account_key_count();
+	int account_key_cnt = fp_storage_ak_count();
 	size_t res = 0;
 	int err;
 
@@ -176,7 +176,7 @@ static int fp_adv_data_fill_non_discoverable(struct net_buf_simple *buf, size_t 
 			return err;
 		}
 
-		err = fp_storage_account_keys_get(ak, &account_key_get_cnt);
+		err = fp_storage_ak_get(ak, &account_key_get_cnt);
 		if (err) {
 			return err;
 		}
@@ -218,7 +218,7 @@ int bt_fast_pair_adv_data_fill(struct bt_data *bt_adv_data, uint8_t *buf, size_t
 			       struct bt_fast_pair_adv_config fp_adv_config)
 {
 	struct net_buf_simple nb;
-	int account_key_cnt = fp_storage_account_key_count();
+	int account_key_cnt = fp_storage_ak_count();
 	size_t adv_data_len = bt_fast_pair_adv_data_size(fp_adv_config);
 	enum fp_field_type ak_filter_type;
 	int err;

--- a/subsys/bluetooth/services/fast_pair/fp_keys.c
+++ b/subsys/bluetooth/services/fast_pair/fp_keys.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(fast_pair, CONFIG_BT_FAST_PAIR_LOG_LEVEL);
 #include "fp_keys.h"
 #include "fp_crypto.h"
 #include "fp_common.h"
-#include "fp_storage.h"
+#include "fp_storage_ak.h"
 #include "fp_storage_pn.h"
 
 #define EMPTY_AES_KEY_BYTE	0xff
@@ -255,7 +255,7 @@ static int key_gen_account_key(const struct bt_conn *conn,
 	/* This function call assigns the Account Key internally to the Fast Pair Keys
 	 * module. The assignment happens in the provided callback method.
 	 */
-	return fp_storage_account_key_find(NULL, key_gen_account_key_check, &context);
+	return fp_storage_ak_find(NULL, key_gen_account_key_check, &context);
 }
 
 int fp_keys_generate_key(const struct bt_conn *conn, struct fp_keys_keygen_params *keygen_params)
@@ -340,7 +340,7 @@ int fp_keys_store_account_key(const struct bt_conn *conn, const struct fp_accoun
 		LOG_WRN("Received invalid Account Key");
 		return -EINVAL;
 	}
-	err = fp_storage_account_key_save(account_key);
+	err = fp_storage_ak_save(account_key);
 	if (!err) {
 		LOG_DBG("Account Key stored");
 	} else {

--- a/subsys/bluetooth/services/fast_pair/fp_storage/CMakeLists.txt
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/CMakeLists.txt
@@ -6,8 +6,12 @@
 
 add_library(fp_storage STATIC)
 
-if(CONFIG_BT_FAST_PAIR_STORAGE)
-  target_sources(fp_storage PRIVATE fp_storage.c)
+if(CONFIG_BT_FAST_PAIR_STORAGE_MANAGER)
+  zephyr_linker_sources(SECTIONS fp_storage_manager.ld)
+  target_sources(fp_storage PRIVATE fp_storage_manager.c)
+endif()
+if(CONFIG_BT_FAST_PAIR_STORAGE_AK)
+  target_sources(fp_storage PRIVATE fp_storage_ak.c)
 endif()
 if(CONFIG_BT_FAST_PAIR_STORAGE_EXT_PN)
   target_sources(fp_storage PRIVATE fp_storage_pn.c)

--- a/subsys/bluetooth/services/fast_pair/fp_storage/Kconfig.fp_storage
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/Kconfig.fp_storage
@@ -13,6 +13,18 @@ config BT_FAST_PAIR_STORAGE
 
 if BT_FAST_PAIR_STORAGE
 
+config BT_FAST_PAIR_STORAGE_MANAGER
+	bool
+	default y
+	help
+	  Add Fast Pair storage manager source files.
+
+config BT_FAST_PAIR_STORAGE_AK
+	bool
+	default y
+	help
+	  Add Fast Pair storage of Account Keys source files.
+
 config BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX
 	int "Maximum number of stored Account Keys"
 	range 5 10

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.c
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <zephyr/settings/settings.h>
+#include <bluetooth/services/fast_pair.h>
+
+#include "fp_storage_manager.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(fp_storage, CONFIG_FP_STORAGE_LOG_LEVEL);
+
+#define SETTINGS_SM_SUBTREE_NAME "fp_sm"
+#define SETTINGS_RESET_IN_PROGRESS_NAME "reset"
+#define SETTINGS_NAME_SEPARATOR_STR "/"
+#define SETTINGS_RESET_IN_PROGRESS_FULL_NAME \
+	(SETTINGS_SM_SUBTREE_NAME SETTINGS_NAME_SEPARATOR_STR SETTINGS_RESET_IN_PROGRESS_NAME)
+
+BUILD_ASSERT(SETTINGS_NAME_SEPARATOR == '/');
+
+static bool reset_in_progress;
+static int settings_set_err;
+
+static int fp_settings_load_reset_in_progress(size_t len, settings_read_cb read_cb, void *cb_arg)
+{
+	int rc;
+
+	if (len != sizeof(reset_in_progress)) {
+		return -EINVAL;
+	}
+
+	rc = read_cb(cb_arg, &reset_in_progress, len);
+	if (rc < 0) {
+		return rc;
+	}
+
+	if (rc != len) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static void modules_reset_prepare(void)
+{
+	STRUCT_SECTION_FOREACH(fp_storage_manager_module, module) {
+		module->module_reset_prepare();
+	}
+}
+
+static int fp_settings_set(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg)
+{
+	int err = 0;
+	const char *key = SETTINGS_RESET_IN_PROGRESS_NAME;
+
+	if (!strncmp(name, key, sizeof(SETTINGS_RESET_IN_PROGRESS_NAME))) {
+		err = fp_settings_load_reset_in_progress(len, read_cb, cb_arg);
+	} else {
+		err = -ENOENT;
+	}
+
+	if (reset_in_progress && !err && !settings_set_err) {
+		modules_reset_prepare();
+	}
+
+	/* The first reported settings set error will be remembered by the module.
+	 * The error will then be propagated by the commit callback.
+	 * Errors returned in the settings set callback are not propagated further.
+	 */
+	if (err && !settings_set_err) {
+		settings_set_err = err;
+	}
+
+	return err;
+}
+
+static int reset_in_progress_set(bool in_progress)
+{
+	int err;
+
+	err = settings_save_one(SETTINGS_RESET_IN_PROGRESS_FULL_NAME, &in_progress,
+				sizeof(in_progress));
+	if (err) {
+		return err;
+	}
+
+	reset_in_progress = in_progress;
+
+	return 0;
+}
+
+static int modules_reset(void)
+{
+	STRUCT_SECTION_FOREACH(fp_storage_manager_module, module) {
+		int err;
+
+		err = module->module_reset_perform();
+		if (err) {
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+static int fp_settings_commit(void)
+{
+	int err;
+
+	if (settings_set_err) {
+		return settings_set_err;
+	}
+
+	if (reset_in_progress) {
+		LOG_WRN("Fast Pair factory reset has been interrupted or aborted. Retrying");
+		err = modules_reset();
+		if (err) {
+			LOG_ERR("Unable to reset modules (err %d)", err);
+			return err;
+		}
+
+		err = reset_in_progress_set(false);
+		if (err) {
+			LOG_ERR("Unable to clear reset in progress flag (err %d)", err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+SETTINGS_STATIC_HANDLER_DEFINE(fp_storage_manager, SETTINGS_SM_SUBTREE_NAME, NULL,
+			       fp_settings_set, fp_settings_commit, NULL);
+
+int bt_fast_pair_factory_reset(void)
+{
+	int err;
+
+	err = reset_in_progress_set(true);
+	if (err) {
+		return err;
+	}
+
+	modules_reset_prepare();
+
+	err = modules_reset();
+	if (err) {
+		LOG_ERR("Unable to reset modules (err %d)", err);
+		return err;
+	}
+
+	err = reset_in_progress_set(false);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}

--- a/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.ld
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/fp_storage_manager.ld
@@ -1,0 +1,1 @@
+ITERABLE_SECTION_ROM(fp_storage_manager_module, 4)

--- a/subsys/bluetooth/services/fast_pair/fp_storage/include/fp_storage_ak.h
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/include/fp_storage_ak.h
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#ifndef _FP_STORAGE_H_
-#define _FP_STORAGE_H_
+#ifndef _FP_STORAGE_AK_H_
+#define _FP_STORAGE_AK_H_
 
 #include <sys/types.h>
 #include "fp_common.h"
 
 /**
- * @defgroup fp_storage Fast Pair storage module
- * @brief Internal API for Fast Pair storage
+ * @defgroup fp_storage_ak Fast Pair storage of Account Keys module
+ * @brief Internal API for Fast Pair storage of Account Keys
  *
  * @{
  */
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 /**
- * @typedef fp_storage_account_key_check_cb
+ * @typedef fp_storage_ak_check_cb
  * @brief Callback used to check if a given Account Key satisfies user-defined
  *        conditions.
  *
@@ -32,8 +32,7 @@ extern "C" {
  * @return True if Account Key satisfies user-defined conditions.
  *         False otherwise.
  */
-typedef bool (*fp_storage_account_key_check_cb)(const struct fp_account_key *account_key,
-						void *context);
+typedef bool (*fp_storage_ak_check_cb)(const struct fp_account_key *account_key, void *context);
 
 /** Save Account Key.
  *
@@ -41,14 +40,14 @@ typedef bool (*fp_storage_account_key_check_cb)(const struct fp_account_key *acc
  *
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
-int fp_storage_account_key_save(const struct fp_account_key *account_key);
+int fp_storage_ak_save(const struct fp_account_key *account_key);
 
 /** Get number of stored Account Keys.
  *
  * @return Number of stored Account Keys, if the operation was successful.
  *	   Otherwise, a (negative) error code is returned.
  */
-int fp_storage_account_key_count(void);
+int fp_storage_ak_count(void);
 
 /** Get stored Account Key List.
  *
@@ -61,7 +60,7 @@ int fp_storage_account_key_count(void);
  *
  * @return 0 If the operation was successful. Otherwise, a (negative) error code is returned.
  */
-int fp_storage_account_keys_get(struct fp_account_key *buf, size_t *key_count);
+int fp_storage_ak_get(struct fp_account_key *buf, size_t *key_count);
 
 /** Iterate over stored Account Keys to find a key that matches user-defined conditions.
  *  If such a key is found, the iteration process stops and this function returns.
@@ -74,15 +73,14 @@ int fp_storage_account_keys_get(struct fp_account_key *buf, size_t *key_count);
  *
  * @return 0 If the Account Key was found. Otherwise, a (negative) error code is returned.
  */
-int fp_storage_account_key_find(struct fp_account_key *account_key,
-				fp_storage_account_key_check_cb account_key_check_cb,
-				void *context);
+int fp_storage_ak_find(struct fp_account_key *account_key,
+		       fp_storage_ak_check_cb account_key_check_cb, void *context);
 
 /** Clear storage data loaded to RAM.
  *
  * The function is used only by fp_storage unit test.
  */
-void fp_storage_ram_clear(void);
+void fp_storage_ak_ram_clear(void);
 
 #ifdef __cplusplus
 }
@@ -92,4 +90,4 @@ void fp_storage_ram_clear(void);
  * @}
  */
 
-#endif /* _FP_STORAGE_H_ */
+#endif /* _FP_STORAGE_AK_H_ */

--- a/subsys/bluetooth/services/fast_pair/fp_storage/include_priv/fp_storage_ak_priv.h
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/include_priv/fp_storage_ak_priv.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#ifndef _FP_STORAGE_PRIV_H_
-#define _FP_STORAGE_PRIV_H_
+#ifndef _FP_STORAGE_AK_PRIV_H_
+#define _FP_STORAGE_AK_PRIV_H_
 
 #include <zephyr/sys/__assert.h>
 #include <zephyr/settings/settings.h>
@@ -13,11 +13,11 @@
 #include "fp_common.h"
 
 /**
- * @defgroup fp_storage_priv Fast Pair storage module private
- * @brief Private data of the Fast Pair storage module
+ * @defgroup fp_storage_ak_priv Fast Pair storage of Account Keys module private
+ * @brief Private data of the Fast Pair storage of Account Keys module
  *
  * Private data structures, definitions and functionalities of the Fast Pair
- * storage module. Used only by the module and by the unit test to prepopulate
+ * storage of Account Keys module. Used only by the module and by the unit test to prepopulate
  * settings with mocked data.
  * @{
  */
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-/** Settings subtree name for Fast Pair storage. */
+/** Settings subtree name for Fast Pair Account Key storage. */
 #define SETTINGS_AK_SUBTREE_NAME "fp_ak"
 
 /** Settings key name prefix for Account Key. */
@@ -105,4 +105,4 @@ static inline uint8_t next_account_key_id(uint8_t account_key_id)
  * @}
  */
 
-#endif /* _FP_STORAGE_PRIV_H_ */
+#endif /* _FP_STORAGE_AK_PRIV_H_ */

--- a/subsys/bluetooth/services/fast_pair/fp_storage/include_priv/fp_storage_manager.h
+++ b/subsys/bluetooth/services/fast_pair/fp_storage/include_priv/fp_storage_manager.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef FP_STORAGE_MANAGER_H_
+#define FP_STORAGE_MANAGER_H_
+
+/**
+ * @defgroup fp_storage_manager Fast Pair storage manager
+ * @brief The subsystem manages Fast Pair storage modules.
+ *
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @typedef fp_storage_manager_module_reset_perform
+ * Callback used to perform a reset of the Fast Pair storage module.
+ *
+ * @return 0 if the operation was successful. Otherwise, a (negative) error code is returned.
+ */
+typedef int (*fp_storage_manager_module_reset_perform)(void);
+
+/**
+ * @typedef fp_storage_manager_module_reset_prepare
+ * Callback used to inform the Fast Pair storage module that the reset operation is due to begin.
+ */
+typedef void (*fp_storage_manager_module_reset_prepare)(void);
+
+/** Structure describing Fast Pair storage module. */
+struct fp_storage_manager_module {
+	/** Function used to perform a reset of the Fast Pair storage module. */
+	fp_storage_manager_module_reset_perform module_reset_perform;
+
+	/** Function used to inform the Fast Pair storage module that the reset operation is due to
+	 * begin. This function is always called before @ref module_reset_perform.
+	 */
+	fp_storage_manager_module_reset_prepare module_reset_prepare;
+};
+
+/** Register Fast Pair storage module.
+ *
+ * The macro statically registers a Fast Pair storage module to Fast Pair storage manager.
+ * The module is controlled by the Fast Pair storage manager to ensure storage data integrity among
+ * all storage modules. The Fast Pair storage manager uses provided callbacks to interact with
+ * storage modules.
+ *
+ * @param _name				Storage module name.
+ * @param _module_reset_perform_fn	Function used to perform a reset of the storage module.
+ * @param _module_reset_prepare_fn	Function used to inform the storage module that the reset
+ *					operation is due to begin.
+ */
+#define FP_STORAGE_MANAGER_MODULE_REGISTER(_name, _module_reset_perform_fn,	\
+					   _module_reset_prepare_fn)		\
+	BUILD_ASSERT(_module_reset_perform_fn != NULL);				\
+	BUILD_ASSERT(_module_reset_prepare_fn != NULL);				\
+	STRUCT_SECTION_ITERABLE(fp_storage_manager_module, _name) = {		\
+		.module_reset_perform = _module_reset_perform_fn,		\
+		.module_reset_prepare = _module_reset_prepare_fn,		\
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* FP_STORAGE_MANAGER_H_ */

--- a/tests/subsys/bluetooth/fast_pair/storage/src/common_utils.c
+++ b/tests/subsys/bluetooth/fast_pair/storage/src/common_utils.c
@@ -7,7 +7,7 @@
 #include <zephyr/ztest.h>
 
 #include "fp_common.h"
-#include "fp_storage.h"
+#include "fp_storage_ak.h"
 
 #define ACCOUNT_KEY_MAX_CNT	CONFIG_BT_FAST_PAIR_STORAGE_ACCOUNT_KEY_MAX
 #define ACCOUNT_KEY_LEN		FP_ACCOUNT_KEY_LEN
@@ -45,13 +45,13 @@ void cu_account_keys_validate_unloaded(void)
 	struct fp_account_key all_keys[ACCOUNT_KEY_MAX_CNT];
 	size_t key_count = ACCOUNT_KEY_MAX_CNT;
 
-	err = fp_storage_account_key_count();
+	err = fp_storage_ak_count();
 	zassert_equal(err, -ENODATA, "Expected error before settings load");
 
-	err = fp_storage_account_keys_get(all_keys, &key_count);
+	err = fp_storage_ak_get(all_keys, &key_count);
 	zassert_equal(err, -ENODATA, "Expected error before settings load");
 
-	err = fp_storage_account_key_find(&all_keys[0], unloaded_account_key_find_cb, NULL);
+	err = fp_storage_ak_find(&all_keys[0], unloaded_account_key_find_cb, NULL);
 	zassert_equal(err, -ENODATA, "Expected error before settings load");
 }
 
@@ -62,9 +62,9 @@ void cu_account_keys_validate_loaded(uint8_t seed_first, uint8_t stored_cnt)
 	struct fp_account_key read_keys[ACCOUNT_KEY_MAX_CNT];
 	size_t read_cnt = ACCOUNT_KEY_MAX_CNT;
 
-	key_cnt = fp_storage_account_key_count();
+	key_cnt = fp_storage_ak_count();
 
-	res = fp_storage_account_keys_get(read_keys, &read_cnt);
+	res = fp_storage_ak_get(read_keys, &read_cnt);
 	zassert_ok(res, "Getting Account Keys failed");
 	zassert_equal(key_cnt, read_cnt, "Invalid key count");
 	zassert_equal(key_cnt, MIN(stored_cnt, ACCOUNT_KEY_MAX_CNT), "Invalid key count");

--- a/tests/subsys/bluetooth/fast_pair/storage/src/test_corrupted_data.c
+++ b/tests/subsys/bluetooth/fast_pair/storage/src/test_corrupted_data.c
@@ -7,8 +7,8 @@
 #include <zephyr/ztest.h>
 #include <zephyr/settings/settings.h>
 
-#include "fp_storage.h"
-#include "fp_storage_priv.h"
+#include "fp_storage_ak.h"
+#include "fp_storage_ak_priv.h"
 
 #include "storage_mock.h"
 #include "common_utils.h"
@@ -31,14 +31,14 @@ static void teardown_fn(void)
 	zassert_not_equal(err, 0, "Expected error in settings load");
 	cu_account_keys_validate_unloaded();
 
-	fp_storage_ram_clear();
+	fp_storage_ak_ram_clear();
 	storage_mock_clear();
 }
 
 /* Self test is done to ensure that the test method is valid. */
 static void test_self_teardown_fn(void)
 {
-	fp_storage_ram_clear();
+	fp_storage_ak_ram_clear();
 	storage_mock_clear();
 	cu_account_keys_validate_unloaded();
 }


### PR DESCRIPTION
Adds API to perform factory reset of Fast Pair storage modules. Adds Fast Pair storage manager to ensure integrity of Fast Pair storage modules in case of power down event while performing factory reset.

Jira: NCSDK-14100