### PR TITLE
applications: nrf5340_audio: Fix bidirectional not work after disconnection

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -275,9 +275,19 @@ static void stream_configured_cb(struct bt_audio_stream *stream,
 	}
 
 	if (unicast_group) {
-		ret = bt_audio_stream_qos(headsets[channel_index].headset_conn, unicast_group);
-		if (ret) {
-			LOG_ERR("Unable to set up QoS for headset %d: %d", channel_index, ret);
+#if CONFIG_STREAM_BIDIRECTIONAL
+		if ((headsets[channel_index].sink_stream->ep->status.state ==
+		     BT_AUDIO_EP_STATE_CODEC_CONFIGURED) &&
+		    (headsets[channel_index].source_stream->ep->status.state ==
+		     BT_AUDIO_EP_STATE_CODEC_CONFIGURED))
+#endif
+		{
+			ret = bt_audio_stream_qos(headsets[channel_index].headset_conn,
+						  unicast_group);
+			if (ret) {
+				LOG_ERR("Unable to set up QoS for headset %d: %d", channel_index,
+					ret);
+			}
 		}
 	}
 }


### PR DESCRIPTION

Added checking for making sure all streams are configured, then trigger the QoS setting for bidirectional.

Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>