### PR TITLE
sample: wifi_provisioning: allow driver to choose channel 

### DIFF
--- a/samples/wifi/provisioning/common/wifi_config.c
+++ b/samples/wifi/provisioning/common/wifi_config.c
@@ -89,7 +89,7 @@ static int wifi_config_save(struct wifi_config *config)
 
 	rc = settings_save_one(WIFI_CONFIG_KEY, config, sizeof(struct wifi_config));
 	if (rc != 0) {
-		LOG_WRN("Error! Cannot write condig.");
+		LOG_WRN("Cannot write config.");
 		return -EIO;
 	}
 	return 0;
@@ -101,7 +101,7 @@ static int wifi_config_read(struct wifi_config *config)
 
 	rc = load_immediate_value(WIFI_CONFIG_KEY, config, sizeof(struct wifi_config));
 	if (rc != 0) {
-		LOG_WRN("Error! Cannot read config.");
+		LOG_WRN("Cannot read config.");
 		return -EIO;
 	}
 	return 0;
@@ -113,7 +113,7 @@ static int wifi_config_delete(void)
 
 	rc = settings_delete(WIFI_CONFIG_KEY);
 	if (rc != 0) {
-		LOG_WRN("Error! Cannot delete config.");
+		LOG_WRN("Cannot delete config.");
 		return -EIO;
 	}
 	return 0;

--- a/samples/wifi/provisioning/common/wifi_prov_handler.c
+++ b/samples/wifi/provisioning/common/wifi_prov_handler.c
@@ -202,7 +202,7 @@ static void prov_set_config_handler(Request *req, Response *rsp)
 		memcpy(config.bssid, req->config.wifi.bssid.bytes, req->config.wifi.bssid.size);
 	}
 	/* Channel */
-	config.channel = req->config.wifi.channel;
+	config.channel = WIFI_CHANNEL_ANY;
 	/* Password and security */
 	if (req->config.has_passphrase == true) {
 		memcpy(config.password, req->config.passphrase.bytes, req->config.passphrase.size);


### PR DESCRIPTION
Allow driver to choose channel, so that it can roam when channel changes.