### PR TITLE
samples: identity_key_usage: Mark the sample as build_only

### DIFF
--- a/samples/keys/identity_key_usage/sample.yaml
+++ b/samples/keys/identity_key_usage/sample.yaml
@@ -15,3 +15,4 @@ common:
 tests:
   sample.keys.identity_key_usage:
     tags: keys ci_build
+    build_only: True


### PR DESCRIPTION
Mark the identity_key_usage sample as build_only to avoid a runtime failure in CI.

The sample requires that certain things are already stored in UICR before it runs, but we have no way of doing that with twister so we stop testing this at runtime.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>