### PR TITLE
drivers: wifi: Store the negotiated TWT flow id at host level.

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
@@ -47,6 +47,10 @@ struct wifi_nrf_vif_ctx_zep {
 #ifdef CONFIG_WPA_SUPP
 	struct zep_wpa_supp_dev_callbk_fns supp_callbk_fns;
 #endif /* CONFIG_WPA_SUPP */
+	/* Used to store the negotiated twt flow id
+	 * for "twt_teardown_all" command.
+	 */
+	unsigned char neg_twt_flow_id;
 };
 
 struct wifi_nrf_vif_ctx_map {


### PR DESCRIPTION
[NRF7X-17] Store the negotaited twt flow id at host level, for later use to tear down all TWT sessions.

Signed-off-by: Ajay Parida <ajay.parida@nordicsemi.no>