### PR TITLE
samples: tfm: provisioning_image Fix typo in yaml

### DIFF
--- a/samples/tfm/provisioning_image/sample.yaml
+++ b/samples/tfm/provisioning_image/sample.yaml
@@ -14,5 +14,5 @@ common:
         - "Writing the identity key to KMU"
         - "Success!"
 tests:
-  sample.keys.identity_key_generate.random_key:
+  sample.tfm.provisioning_image:
     tags: keys ci_build


### PR DESCRIPTION
It  fixes a naming issue in the yaml file of the provisioning sample which may cause issues with the CI.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>