### PR TITLE
doc: Multicell location library: rewording deprecation

### DIFF
--- a/doc/nrf/libraries/networking/multicell_location.rst
+++ b/doc/nrf/libraries/networking/multicell_location.rst
@@ -9,7 +9,7 @@ Multicell location
 
 .. note::
 
-   This library is deprecated since v2.3.0 and relevant functionality is available through the :ref:`lib_location` library.
+   This library has been marked as :ref:`deprecated <api_deprecation>` after the release of the |NCS| v2.2.0 and relevant functionality is available through the :ref:`lib_location` library.
 
 The Multicell location library provides a way to acquire the location of the device based on LTE cell measurements.
 

--- a/doc/nrf/software_maturity.rst
+++ b/doc/nrf/software_maturity.rst
@@ -77,6 +77,8 @@ See the following table for more details:
      - Incomplete verification
      - Not applicable.
 
+.. _api_deprecation:
+
 API deprecation
 ***************
 

--- a/include/net/multicell_location.h
+++ b/include/net/multicell_location.h
@@ -18,7 +18,7 @@ extern "C" {
  * @{
  * @brief Library for performing multicell location requests towards the cloud.
  *
- * @deprecated Since v2.3.0.
+ * @deprecated After nRF Connect SDK v2.2.0.
  */
 
 struct multicell_location {


### PR DESCRIPTION
Instead of mentioning NCS v2.3.0, indicated that the library will be deprecated in a future release.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>