### PR TITLE
doc: fix spm note in known issues

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1877,7 +1877,7 @@ Secure Partition Manager (SPM)
 ==============================
 
 .. note::
-    The Secure Partition Manager (SPM) was deprecated in |NCS| v2.1.0 and removed in |NCS| v2.3.0. It is replaced by :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
+    The Secure Partition Manager (SPM) is deprecated as of |NCS| v2.1.0 and removed after |NCS| v2.2.0. It is replaced by :ref:`Trusted Firmware-M (TF-M) <ug_tfm>`.
 
 .. rst-class:: v2-2-0 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0 v1-5-2 v1-5-1 v1-5-0 v1-4-2 v1-4-1 v1-4-0 v1-3-2 v1-3-1 v1-3-0
 


### PR DESCRIPTION
An SPM note in known issues mentions NCS v2.3.0
before it is released. Changed the note.

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>