### PR TITLE
wifi : Bugfix for RRM, BTM request handling

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
@@ -1524,6 +1524,8 @@ struct nrf_wifi_umac_assoc_info {
 	struct nrf_wifi_ie wpa_ie;
 	unsigned char use_mfp;
 	signed char control_port;
+	unsigned int prev_bssid_flag;
+	unsigned char prev_bssid[NRF_WIFI_ETH_ADDR_LEN];
 } __NRF_WIFI_PKD;
 
 /**

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
@@ -1650,6 +1650,14 @@ enum wifi_nrf_status wifi_nrf_fmac_assoc(void *dev_ctx,
 	connect_common_info->control_port =
 		assoc_info->control_port;
 
+	if (assoc_info->prev_bssid_flag) {
+		wifi_nrf_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
+			connect_common_info->prev_bssid,
+			assoc_info->prev_bssid,
+			NRF_WIFI_ETH_ADDR_LEN);
+		connect_common_info->nrf_wifi_flags |= NRF_WIFI_CONNECT_COMMON_INFO_PREV_BSSID;
+	}
+
 	status = umac_cmd_cfg(fmac_dev_ctx,
 			      assoc_cmd,
 			      sizeof(*assoc_cmd));

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/fmac_api.c
@@ -1644,6 +1644,9 @@ enum wifi_nrf_status wifi_nrf_fmac_assoc(void *dev_ctx,
 	connect_common_info->valid_fields |=
 		NRF_WIFI_CONNECT_COMMON_INFO_USE_MFP_VALID;
 
+	connect_common_info->nrf_wifi_flags |=
+		NRF_WIFI_CMD_CONNECT_COMMON_INFO_USE_RRM;
+
 	connect_common_info->control_port =
 		assoc_info->control_port;
 

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_wpa_supp_if.c
@@ -1474,6 +1474,7 @@ int wifi_nrf_supp_get_capa(void *if_priv, struct wpa_driver_capa *capa)
 	capa->flags |= WPA_DRIVER_FLAGS_SAE;
 	capa->flags |= WPA_DRIVER_FLAGS_SET_KEYS_AFTER_ASSOC_DONE;
 	capa->rrm_flags |= WPA_DRIVER_FLAGS_SUPPORT_RRM;
+	capa->rrm_flags |= WPA_DRIVER_FLAGS_SUPPORT_BEACON_REPORT;
 
 	capa->enc |= WPA_DRIVER_CAPA_ENC_WEP40 |
 			WPA_DRIVER_CAPA_ENC_WEP104 |

--- a/west.yml
+++ b/west.yml
@@ -102,7 +102,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: d0fe3f71f80e0cfd9685726904df4369d64f5514
+      revision: 954a37928703f4141b07ab5ca5f33cd7fdb35aa7
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 68b46483a17528d79ff6aa3ba7242c8ab5ed102c


### PR DESCRIPTION
[SHEL-877]: DUT did not respond to AP beacon request frame 
Enable misisng RRM capability in Assoc request.
Update clock to fix BSS expiration issue.

[SHEL-859]: No BTM response for request from AP
Include PREV_BSSID flag for re-assoc
Use frequencies in params during scan
Handle deauth during BSS transition

Signed-off-by: Sridhar Nuvusetty <sridhar.nuvusetty@nordicsemi.no>