### PR TITLE
manifest: sdk-hostap: Pull BSS age underflow fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: c1f1e0593d5bde73ba5d512b44fb765472829574
+      revision: pull/53/head
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 34b3ac78780f861fb6a6eeffa42e6c7242c4eec9


### PR DESCRIPTION
Fixes random connection failures seen across (SHEL-1136).

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>