### PR TITLE
QSPI encryption support

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/qspi/inc/qspi_if.h
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/inc/qspi_if.h
@@ -104,3 +104,7 @@ int func_rpu_wake(void);
 int func_rpu_sleep_status(void);
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 #endif /* __QSPI_IF_H__ */
+
+#define QSPI_KEY_LEN_BYTES 16
+int qspi_configure_encryption(uint8_t *key);
+int qspi_enable_encryption(void);

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/qspi_if.c
@@ -1100,19 +1100,6 @@ int qspi_init(struct qspi_config *config)
 
 	k_sem_init(&qspi_config->lock, 1, 1);
 
-#if defined(CONFIG_SOC_SERIES_NRF53X)
-	/* once encryption is enabled, do not reinit until bitfile re-load */
-	if (!config->enc_enabled) {
-		if (config->encryption)
-			nrfx_qspi_dma_encrypt(&config->p_cfg);
-
-		if (config->CMD_CNONCE)
-			qspi_cmd_encryption(&qspi_perip, &config->p_cfg);
-
-		if (config->encryption)
-			config->enc_enabled = true;
-	}
-#endif
 	LOG_INF("QSPI freq = %d MHz\n", INST_0_SCK_FREQUENCY/MHZ(1));
 	LOG_INF("QSPI latency = %d\n", qspi_config->qspi_slave_latency);
 	return rc;
@@ -1258,4 +1245,29 @@ int qspi_cmd_sleep_rpu(const struct device *dev)
 	}
 
 	return ret;
+}
+
+// Encryption public API
+
+int qspi_enable_encryption(void)
+{
+#if defined(CONFIG_SOC_SERIES_NRF53X)
+	nrfx_qspi_dma_encrypt(&qspi_config->p_cfg);
+
+	qspi_cmd_encryption(&qspi_perip, &qspi_config->p_cfg);
+
+	qspi_config->encryption = true;
+
+	return 0;
+#endif
+}
+
+
+int qspi_configure_encryption(uint8_t *key)
+{
+#if defined(CONFIG_SOC_SERIES_NRF53X)
+	memcpy(qspi_config->p_cfg.key, key, 16);
+
+	return 0;
+#endif
 }

--- a/samples/wifi/sta/Kconfig
+++ b/samples/wifi/sta/Kconfig
@@ -46,4 +46,9 @@ config STA_SAMPLE_PASSWORD
 	string "Passphrase (WPA2) or password (WPA3)"
 	help
 	  Specify the Password to connect
+
+config NRF700X_QSPI_ENCRYPTION_KEY
+	string "16 bytes QSPI encryption key, only for testing purposes"
+	help
+	  Specify the QSPI encryption key
 endmenu

--- a/samples/wifi/sta/README.rst
+++ b/samples/wifi/sta/README.rst
@@ -23,6 +23,14 @@ This sample can perform Wi-Fi operations such as connect and disconnect in the 2
 
 Using this sample, the development kit can connect to the specified access point in :abbr:`STA (Station)` mode.
 
+Quad Serial Peripheral Interface (QSPI) encryption
+**************************************************
+
+This sample demonstrates QSPI encryption API usage, the key can be set by the :kconfig:option:`CONFIG_NRF700X_QSPI_ENCRYPTION_KEY` Kconfig option.
+
+If encryption of the QSPI traffic is required for the production devices, then matching keys must be programmed in both the nRF7002 OTP and non-volatile storage associated with the host.
+The key from non-volatile storage must be set as the encryption key using the APIs.
+
 Building and running
 ********************
 


### PR DESCRIPTION
* Expose APIs to configure and enable QSPI encryption (it cannot be disabled)
* Demonstrate API usage in STA sample with factory default OTP key (all F's)