### PR TITLE
manifest: Fixed Matter repo checkout for Windows

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -123,7 +123,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 3875c6f78c77212a3f62a5c825ff9b4e5054bbb4
+      revision: d6fd524187597a3c59231946bf98c95438bea26f
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
The Matter repository contains some file created, as a result of conflicts resolving. Because of that repository checkout fails on Windows.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>