### PR TITLE
applications: nrf_desktop: Add CONFIG_CAF_BLE_COMMON_EVENTS dependency

### DIFF
--- a/applications/nrf_desktop/doc/led_state.rst
+++ b/applications/nrf_desktop/doc/led_state.rst
@@ -33,6 +33,11 @@ The module controls LEDs defined by enumerators in :c:enum:`led_id`:
 
 For the complete description of peer management, see :ref:`nrf_desktop_ble_bond`.
 
+.. note::
+   If a configuration does not support Bluetooth (:kconfig:option:`CONFIG_CAF_BLE_COMMON_EVENTS` is disabled), the Bluetooth peer state will not be notified.
+   In that case, the Bluetooth peer state LED is set only once during the boot.
+   The set LED effect represents :c:enumerator:`LED_PEER_STATE_DISCONNECTED` state for the default peer.
+
 Module events
 *************
 

--- a/applications/nrf_desktop/src/modules/dfu.c
+++ b/applications/nrf_desktop/src/modules/dfu.c
@@ -689,7 +689,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 	GEN_CONFIG_EVENT_HANDLERS(STRINGIFY(MODULE), opt_descr, update_config,
 				  fetch_config);
 
-	if (is_ble_peer_event(aeh)) {
+	if (IS_ENABLED(CONFIG_CAF_BLE_COMMON_EVENTS) && is_ble_peer_event(aeh)) {
 		device_in_use = true;
 
 		return false;
@@ -727,4 +727,6 @@ APP_EVENT_LISTENER(MODULE, app_event_handler);
 APP_EVENT_SUBSCRIBE(MODULE, hid_report_event);
 APP_EVENT_SUBSCRIBE_EARLY(MODULE, config_event);
 APP_EVENT_SUBSCRIBE(MODULE, module_state_event);
+#ifdef CONFIG_CAF_BLE_COMMON_EVENTS
 APP_EVENT_SUBSCRIBE(MODULE, ble_peer_event);
+#endif /* CONFIG_CAF_BLE_COMMON_EVENTS */

--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -1619,7 +1619,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 				cast_hid_report_subscription_event(aeh));
 	}
 
-	if (is_ble_peer_event(aeh)) {
+	if (IS_ENABLED(CONFIG_CAF_BLE_COMMON_EVENTS) && is_ble_peer_event(aeh)) {
 		return handle_ble_peer_event(cast_ble_peer_event(aeh));
 	}
 
@@ -1639,7 +1639,9 @@ static bool app_event_handler(const struct app_event_header *aeh)
 }
 
 APP_EVENT_LISTENER(MODULE, app_event_handler);
+#ifdef CONFIG_CAF_BLE_COMMON_EVENTS
 APP_EVENT_SUBSCRIBE(MODULE, ble_peer_event);
+#endif /* CONFIG_CAF_BLE_COMMON_EVENTS */
 APP_EVENT_SUBSCRIBE(MODULE, usb_hid_event);
 #ifdef CONFIG_DESKTOP_HID_REPORT_KEYBOARD_SUPPORT
 APP_EVENT_SUBSCRIBE(MODULE, hid_report_event);


### PR DESCRIPTION
Change guards CAF BLE events with CONFIG_CAF_BLE_COMMON_EVENTS to prevent build failures for configurations without Bluetooth.

Jira: NCSDK-17243