### PR TITLE
bluetooth: mesh: Fix Light PI regulator-related issues.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -383,6 +383,7 @@ Bluetooth mesh samples
   * Updated:
 
     * Enabled :kconfig:option:`CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE` configuration option.
+    * The specification-defined illuminance regulator (:kconfig:option:`CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC`) now selects the :kconfig:option:`CONFIG_FPU` option by default, thus it is not required to enable it explicitly in the project file.
 
 nRF9160 samples
 ---------------

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -94,7 +94,10 @@ Bluetooth LE
 Bluetooth mesh
 --------------
 
-|no_changes_yet_note|
+* Fixed:
+
+    * An issue in the :ref:`bt_mesh_light_ctrl_srv_readme` model where multiple scene recall messages for the same scene do not repeatedly trigger the same scene recall.
+      This prevents the interruption of an ongoing transition.
 
 Matter
 ------

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -99,6 +99,10 @@ Bluetooth mesh
     * An issue in the :ref:`bt_mesh_light_ctrl_srv_readme` model where multiple scene recall messages for the same scene do not repeatedly trigger the same scene recall.
       This prevents the interruption of an ongoing transition.
 
+* Updated:
+
+  * The :ref:`bt_mesh_light_ctrl_srv_readme` model to make sure that the illuminance regulator starts running when a fresh value of the ambient LuxLevel is reported when the controller is enabled.
+
 Matter
 ------
 

--- a/samples/bluetooth/mesh/light_ctrl/README.rst
+++ b/samples/bluetooth/mesh/light_ctrl/README.rst
@@ -30,7 +30,8 @@ Overview
 ********
 
 This sample can be used to control the state of light sources.
-In addition to generic on and off functions, it allows changing the light level (brightness) of a LED light.
+In addition to generic on and off functions, it allows changing the light level (brightness) of an LED light.
+It also allows the LED light to react to supported sensor messages.
 
 The sample instantiates the :ref:`bt_mesh_lightness_srv_readme` model and the :ref:`bt_mesh_light_ctrl_srv_readme` model.
 As both Light Lightness Server and the Light LC Server extend the Generic OnOff Server, the two models need to be instantiated on separate elements.
@@ -121,6 +122,10 @@ Configuration
 |config|
 
 |nrf5340_mesh_sample_note|
+
+The Kconfig option :kconfig:option:`CONFIG_BT_MESH_LIGHT_CTRL_REG_SPEC` is set by default as it is necessary for the :ref:`bt_mesh_light_ctrl_srv_readme` model according to the `Bluetooth mesh model specification`_.
+The option enables a separate module called illuminance regulator.
+For more information about the module, see the documentation on :ref:`bt_mesh_light_ctrl_reg_readme` and :ref:`bt_mesh_light_ctrl_reg_spec_readme`.
 
 Source file setup
 =================

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -286,7 +286,7 @@ if BT_MESH_LIGHT_CTRL_REG
 
 config BT_MESH_LIGHT_CTRL_REG_SPEC
 	bool "Spec Lightness PI Regulator"
-	depends on FPU
+	select FPU
 	default y
 	help
 	  Enable specification-defined lightness PI regulator implementation.

--- a/subsys/bluetooth/mesh/light_ctrl_srv.c
+++ b/subsys/bluetooth/mesh/light_ctrl_srv.c
@@ -1441,11 +1441,14 @@ static void scene_recall(struct bt_mesh_model *model, const uint8_t data[],
 	}
 #endif
 	if (scene->enabled) {
-		ctrl_enable(srv);
+		if (!is_enabled(srv)) {
+			ctrl_enable(srv);
+		}
 
-		if (!!scene->light) {
+		if (!!scene->light && !atomic_test_bit(&srv->flags, FLAG_ON)) {
 			turn_on(srv, transition, true);
-		} else {
+		} else if (atomic_test_bit(&srv->flags, FLAG_ON)) {
+			transition_start(srv, LIGHT_CTRL_STATE_STANDBY, 0);
 			light_onoff_pub(srv, srv->state, true);
 		}
 	} else {


### PR DESCRIPTION
Fix Light PI regulator-related issues.

- make sure regulator is enabled for Light LC model
- recall controller state only when current state differs
- run regulator when ambient lux level is reported