### PR TITLE
nrf_cloud: unittest: editted cloud unit tests to be run automatically

### DIFF
--- a/tests/subsys/net/lib/nrf_cloud/cloud/prj_qemu_cortex_m3.conf
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/prj_qemu_cortex_m3.conf
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# ZTEST with new API
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+
+# Disable networking
+CONFIG_NETWORKING=n
+
+# Disable sockets and POSIX wrappers
+CONFIG_NET_SOCKETS=n
+CONFIG_NET_SOCKETS_POSIX_NAMES=n
+
+# Dependencies
+CONFIG_NEWLIB_LIBC=y
+CONFIG_NEWLIB_LIBC_FLOAT_PRINTF=y
+
+# For the unit test to run in qemu_cortex_m3,
+# we need the following KConfig values to be set.
+# See https://github.com/zephyrproject-rtos/zephyr/issues/15565
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_TEST_RANDOM_GENERATOR=y

--- a/tests/subsys/net/lib/nrf_cloud/cloud/testcase.yaml
+++ b/tests/subsys/net/lib/nrf_cloud/cloud/testcase.yaml
@@ -1,7 +1,9 @@
 tests:
   net.lib.nrf_cloud.cloud:
-    platform_allow: nrf9160dk_nrf9160_ns
+    platform_allow: nrf9160dk_nrf9160_ns native_posix qemu_cortex_m3
     integration_platforms:
       - nrf9160dk_nrf9160_ns
+      - native_posix
+      - qemu_cortex_m3
     tags: nrf_cloud_test nrf_cloud_lib
     timeout: 90


### PR DESCRIPTION
Added integration platforms of qemu_cortex_m3 and native_posix, also added Kconfigs overlay for qemu_cortex_m3. These will make the unit tests run automatically with sdk-nrf integration.

See IRIS-4986

Signed-off-by: Tony Le <tony.le@nordicsemi.no>