### PR TITLE
application: serial_lte_modem: Add post FOTA handling for bootloader …

### DIFF
--- a/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FOTA_AT_commands.rst
@@ -31,6 +31,7 @@ Syntax
   * ``0`` - Cancel FOTA (during download only).
   * ``1`` - Start FOTA for application update.
   * ``2`` - Start FOTA for modem delta update.
+  * ``3`` - Start FOTA for bootloader update (optional if :ref:`nRF Secure Immutable Bootloader (NSIB) <bootloader>` enabled).
   * ``6`` - Read application image size and version (optional for application FOTA).
   * ``7`` - Read modem scratch space size and offset (optional for modem FOTA).
   * ``8`` - Erase MCUboot secondary slot (optional for application FOTA).
@@ -106,6 +107,28 @@ Example
    #XFOTA: 1,0,0
    ...
    #XFOTA: 4,0
+   AT#XRESET
+   OK
+   READY
+   #XFOTA: 5,0
+
+   Application download and activate if NSIB is enabled
+   AT#XFOTA=1,"http://remote.host/fota/slm_app_update.bin+slm_app_update.bin"
+   OK
+   #XFOTA: 1,0,0
+   ...
+   #XFOTA:4,0
+   AT#XRESET
+   OK
+   READY
+   #XFOTA: 5,0
+
+   Bootloader download and activate if NSIB is enabled
+   AT#XFOTA=3,"http://remote.host/fota/signed_by_mcuboot_and_b0_s0_image_update.bin+signed_by_mcuboot_and_b0_s1_image_update.bin"
+   OK
+   #XFOTA: 1,0,0
+   ...
+   #XFOTA:4,0
    AT#XRESET
    OK
    READY
@@ -195,5 +218,16 @@ Examples
    AT#XFOTA=?
 
    #XFOTA: (0,1,2,6,7,8,9),<file_url>,<sec_tag>,<apn>
+
+   OK
+
+Examples(if NSIB is enabled)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+   AT#XFOTA=?
+
+   #XFOTA: (0,1,2,3,6,7,8,9),<file_url>,<sec_tag>,<apn>
 
    OK

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -33,6 +33,7 @@ enum slm_fota_operation {
 	SLM_FOTA_STOP,
 	SLM_FOTA_START_APP,
 	SLM_FOTA_START_MFW,
+	SLM_FOTA_START_BL,
 	SLM_FOTA_PAUSE_RESUME,
 	SLM_FOTA_APP_READ = 6,
 	SLM_FOTA_MFW_READ,
@@ -318,7 +319,12 @@ int handle_at_fota(enum at_cmd_type cmd_type)
 		}
 		if (op == SLM_FOTA_STOP) {
 			err = fota_download_cancel();
+#if defined(CONFIG_SECURE_BOOT)
+		} else if (op == SLM_FOTA_START_APP || op == SLM_FOTA_START_MFW ||
+			   op == SLM_FOTA_START_BL) {
+#else
 		} else if (op == SLM_FOTA_START_APP || op == SLM_FOTA_START_MFW) {
+#endif
 			char uri[FILE_URI_MAX];
 			uint16_t pdn_id;
 			int size = FILE_URI_MAX;
@@ -332,7 +338,7 @@ int handle_at_fota(enum at_cmd_type cmd_type)
 			if (at_params_valid_count_get(&at_param_list) > 3) {
 				at_params_unsigned_int_get(&at_param_list, 3, &sec_tag);
 			}
-			if (op == SLM_FOTA_START_APP) {
+			if (op == SLM_FOTA_START_APP || op == SLM_FOTA_START_BL) {
 				type = DFU_TARGET_IMAGE_TYPE_MCUBOOT;
 			} else {
 				type = DFU_TARGET_IMAGE_TYPE_MODEM_DELTA;
@@ -343,6 +349,16 @@ int handle_at_fota(enum at_cmd_type cmd_type)
 			} else {
 				err = do_fota_start(op, uri, sec_tag, 0, type);
 			}
+#if defined(CONFIG_SECURE_BOOT)
+			if (op == SLM_FOTA_START_BL) {
+				bool s0_active;
+
+				/* Override fota_type with SLM specified type */
+				fota_type = SLM_DFU_TARGET_IMAGE_TYPE_BL1;
+				(void)fota_download_s0_active_get(&s0_active);
+				LOG_INF("orig s0_active %d", s0_active);
+			}
+#endif
 #if FOTA_FUTURE_FEATURE
 		} else if (op == SLM_FOTA_PAUSE_RESUME) {
 			if (paused) {
@@ -369,11 +385,19 @@ int handle_at_fota(enum at_cmd_type cmd_type)
 		} break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
+#if defined(CONFIG_SECURE_BOOT)
+		sprintf(rsp_buf,
+			"\r\n#XFOTA: (%d,%d,%d,%d,%d,%d,%d,%d),<file_uri>,<sec_tag>,<apn>\r\n",
+			SLM_FOTA_STOP, SLM_FOTA_START_APP, SLM_FOTA_START_MFW, SLM_FOTA_START_BL,
+			SLM_FOTA_APP_READ, SLM_FOTA_MFW_READ,
+			SLM_FOTA_ERASE_APP, SLM_FOTA_ERASE_MFW);
+#else
 		sprintf(rsp_buf,
 			"\r\n#XFOTA: (%d,%d,%d,%d,%d,%d,%d),<file_uri>,<sec_tag>,<apn>\r\n",
 			SLM_FOTA_STOP, SLM_FOTA_START_APP, SLM_FOTA_START_MFW,
 			SLM_FOTA_APP_READ, SLM_FOTA_MFW_READ,
 			SLM_FOTA_ERASE_APP, SLM_FOTA_ERASE_MFW);
+#endif
 		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;

--- a/applications/serial_lte_modem/src/slm_at_fota.h
+++ b/applications/serial_lte_modem/src/slm_at_fota.h
@@ -28,6 +28,11 @@ enum fota_status {
 };
 
 /**
+ * @brief Define SLM specified FOTA type for Bootloader
+ */
+#define SLM_DFU_TARGET_IMAGE_TYPE_BL1	(DFU_TARGET_IMAGE_TYPE_MODEM_DELTA + 1)
+
+/**
  * @brief Initialize FOTA AT command parser.
  *
  * @retval 0 If the operation was successful.


### PR DESCRIPTION
…update

SWAP_TYPE logic of mcuboot bootloader is different than application. Add SLM_FOTA_START_BL for bootloader FOTA and record actived slot for post FOTA handling.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>