### PR TITLE
tests: subsys: bluetooth: mesh: Add native_posix to integ platforms

### DIFF
--- a/tests/subsys/bluetooth/mesh/sensor_subsys/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/sensor_subsys/testcase.yaml
@@ -3,4 +3,5 @@ tests:
     platform_allow: native_posix qemu_cortex_m3
     tags: bluetooth ci_build
     integration_platforms:
+        - native_posix
         - qemu_cortex_m3

--- a/tests/subsys/bluetooth/mesh/silvair_enocean_model/testcase.yaml
+++ b/tests/subsys/bluetooth/mesh/silvair_enocean_model/testcase.yaml
@@ -3,4 +3,5 @@ tests:
     platform_allow: native_posix qemu_cortex_m3
     tags: bluetooth ci_build
     integration_platforms:
+        - native_posix
         - qemu_cortex_m3


### PR DESCRIPTION
Added native_posix to the integration_platforms list so that the CI runs these tests on native_posix too.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>