### PR TITLE
samples: openthread: add low power mode to CLI

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -323,13 +323,17 @@ Trusted Firmware-M (TF-M) samples
 Thread samples
 --------------
 
+* Added:
+
+  * ``overlay-low_power.conf`` and ``low_power.overlay`` to the CLI sample to facilitate power consumption measurements.
+
 * Changed:
 
   * Overlay structure changed:
     * ``overlay-rtt.conf`` removed from all samples.
     * ``overlay-log.conf`` now uses RTT backend by default.
-    * Logs removed from default configuration (moved to ``overlay-logging.conf``)
-    * Asserts removed from default configuration (moved to ``overlay-debug.conf``)
+    * Logs removed from default configuration (moved to ``overlay-logging.conf``).
+    * Asserts removed from default configuration (moved to ``overlay-debug.conf``).
 
 Matter samples
 --------------

--- a/samples/openthread/cli/CMakeLists.txt
+++ b/samples/openthread/cli/CMakeLists.txt
@@ -14,3 +14,4 @@ target_sources(app PRIVATE src/main.c)
 # NORDIC SDK APP END
 
 target_sources_ifdef(CONFIG_BT app PRIVATE src/ble.c)
+target_sources_ifdef(CONFIG_CLI_SAMPLE_LOW_POWER app PRIVATE src/low_power.c)

--- a/samples/openthread/cli/Kconfig
+++ b/samples/openthread/cli/Kconfig
@@ -11,3 +11,6 @@ endmenu
 module = OT_COMMAND_LINE_INTERFACE
 module-str = ot_cli
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+config CLI_SAMPLE_LOW_POWER
+	bool "Enable low power mode for the CLI sample"

--- a/samples/openthread/cli/README.rst
+++ b/samples/openthread/cli/README.rst
@@ -91,6 +91,8 @@ The following configuration files are available:
 * :file:`overlay-ci.conf` - Disables boot banner and shell prompt.
 * :file:`overlay-multiprotocol.conf` - Enables Bluetooth LE support in this sample.
 * :file:`overlay-tcp.conf` - Enables experimental TCP support in this sample.
+* :file:`overlay-low_power.conf` - Enables low power consumption mode in this sample.
+  Additionally, you need to set :makevar:`DTC_OVERLAY_FILE` to :file:`low_power.overlay`.
 
 FEM support
 ===========
@@ -356,7 +358,7 @@ To test the Thread 1.2 and Thread 1.3 features, complete the following steps:
 
 #. Run the following commands on the router kit:
 
-   a. Reattach the router kit as SED with a polling period of three seconds:
+   a. Reattach the router kit as Sleepy End Device (SED) with a polling period of three seconds:
 
       .. code-block:: console
 
@@ -517,6 +519,20 @@ To test the Thread 1.2 and Thread 1.3 features, complete the following steps:
             host: my-host.default.service.arpa.
             addresses: [fdde:ad00:beef:0:e0fc:dc28:1d12:8c2]
          Done
+
+Power consumption measurements
+==============================
+
+You can use the Thread CLI sample to perform power consumption measurements for Sleepy End Devices.
+
+After building and flashing with :file:`overlay-low_power.conf` and :file:`low_power.overlay`, the device will start regular operation with the UART console enabled.
+This allows for easy configuration of the device, specifically the Sleepy End Device polling period or the Synchronized Sleepy End Device (SSED) CSL period and other relevant parameters.
+
+When the device becomes attached to a Thread Router it will automatically suspend UART operation and power down unused RAM.
+In this mode, you can not use the CLI to control the device.
+Instead, the device will periodically wake up from deep sleep mode and turn on the radio to receive any messages from its parent.
+
+If the device is connected to a `Power Profiler Kit II (PPK2)`_, you can perform detailed power consumption measurements.
 
 Dependencies
 ************

--- a/samples/openthread/cli/low_power.overlay
+++ b/samples/openthread/cli/low_power.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&adc {
+	status = "disabled";
+};
+&uart1 {
+	status = "disabled";
+};
+&pwm0 {
+	status = "disabled";
+};
+&i2c0 {
+	status = "disabled";
+};
+&spi0 {
+	status = "disabled";
+};
+&spi1 {
+	status = "disabled";
+};
+&spi2 {
+	status = "disabled";
+};
+&spi3 {
+	status = "disabled";
+};
+&usbd {
+	status = "disabled";
+};

--- a/samples/openthread/cli/overlay-low_power.conf
+++ b/samples/openthread/cli/overlay-low_power.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_CLI_SAMPLE_LOW_POWER=y
+CONFIG_OPENTHREAD_MTD=y
+CONFIG_RAM_POWER_DOWN_LIBRARY=y
+CONFIG_PM_DEVICE=y
+
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048

--- a/samples/openthread/cli/sample.yaml
+++ b/samples/openthread/cli/sample.yaml
@@ -42,6 +42,17 @@ tests:
       - nrf52840dk_nrf52840
       - nrf52840dongle_nrf52840
       - nrf21540dk_nrf52840
+  sample.openthread.cli.low_power:
+    build_only: true
+    platform_allow: nrf5340dk_nrf5340_cpuapp nrf5340dk_nrf5340_cpuapp_ns nrf52840dk_nrf52840 nrf21540dk_nrf52840
+    tags: ci_build
+    extra_args: OVERLAY_CONFIG=overlay-ci.conf;overlay-low_power.conf
+                DTC_OVERLAY_FILE=low_power.overlay
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+      - nrf5340dk_nrf5340_cpuapp_ns
+      - nrf52840dk_nrf52840
+      - nrf21540dk_nrf52840
   # Build integration regression protection.
   sample.nrf_security.openthread.integration:
       build_only: true

--- a/samples/openthread/cli/src/low_power.c
+++ b/samples/openthread/cli/src/low_power.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <openthread/thread.h>
+#include <zephyr/net/openthread.h>
+#include <zephyr/device.h>
+#include <zephyr/pm/device.h>
+#include <ram_pwrdn.h>
+
+#include "low_power.h"
+
+static void on_thread_state_changed(uint32_t flags, void *context)
+{
+	struct openthread_context *ot_context = context;
+
+	if (flags & OT_CHANGED_THREAD_ROLE) {
+		if (otThreadGetDeviceRole(ot_context->instance) == OT_DEVICE_ROLE_CHILD) {
+			const struct device *cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+
+			if (!device_is_ready(cons)) {
+				return;
+			}
+
+			pm_device_action_run(cons, PM_DEVICE_ACTION_SUSPEND);
+			power_down_unused_ram();
+		}
+	}
+}
+
+void low_power_enable(void)
+{
+	openthread_set_state_changed_cb(on_thread_state_changed);
+}

--- a/samples/openthread/cli/src/low_power.h
+++ b/samples/openthread/cli/src/low_power.h
@@ -1,0 +1,24 @@
+/**
+ * @file
+ * @defgroup low_power Low Power API
+ * @{
+ */
+
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef __LOW_POWER_H__
+#define __LOW_POWER_H__
+
+/** @brief Initialize Low Power mode.
+ */
+void low_power_enable(void);
+
+#endif
+
+/**
+ * @}
+ */

--- a/samples/openthread/cli/src/main.c
+++ b/samples/openthread/cli/src/main.c
@@ -11,6 +11,10 @@
 #include "ble.h"
 #endif
 
+#if defined(CONFIG_CLI_SAMPLE_LOW_POWER)
+#include "low_power.h"
+#endif
+
 #include <zephyr/drivers/uart.h>
 #include <zephyr/usb/usb_device.h>
 
@@ -66,8 +70,11 @@ void main(void)
 
 	LOG_INF(WELLCOME_TEXT);
 
-#if CONFIG_BT
+#if defined(CONFIG_BT)
 	ble_enable();
 #endif
 
+#if defined(CONFIG_CLI_SAMPLE_LOW_POWER)
+	low_power_enable();
+#endif
 }


### PR DESCRIPTION
Extend CLI sample with with a low power mode option intended for power consumption measurements.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>