### PR TITLE
applications: nrf_desktop: Avoid using Zephyr Bluetooth role Kconfigs

### DIFF
--- a/applications/nrf_desktop/configuration/common/dev_descr.h
+++ b/applications/nrf_desktop/configuration/common/dev_descr.h
@@ -16,8 +16,8 @@
 
 /* This structure enforces the header file is included only once in the build.
  * Violating this requirement triggers a multiple definition error at link time.
- * The header file is included only by dev_descr module for BT_PERIPHERAL or
- * by ble_discovery module for BT_CENTRAL.
+ * The header file is included only by dev_descr module for nRF Desktop BLE
+ * Peripheral or by ble_discovery for nRF Desktop BLE Central.
  */
 const struct {} dev_descr_include_once;
 

--- a/applications/nrf_desktop/configuration/common/led_state.h
+++ b/applications/nrf_desktop/configuration/common/led_state.h
@@ -69,12 +69,7 @@ enum led_id_nrf_desktop {
 
 #define LED_UNAVAILABLE 0xFF
 
-#if (defined(CONFIG_BT_PERIPHERAL) && defined(CONFIG_BT_CENTRAL)) || \
-    (!defined(CONFIG_BT_PERIPHERAL) && !defined(CONFIG_BT_CENTRAL))
-#error Device should be either Bluetooth peripheral or central
-#endif
-
-#if defined(CONFIG_BT_PERIPHERAL)
+#if defined(CONFIG_DESKTOP_BT_PERIPHERAL)
 /* By default, peripheral uses a separate Bluetooth local identity per every Bluetooth peer.
  * The default local identity cannot be used, because application cannot reset it.
  * One Bluetooth local identity is reserved for the erase advertising.

--- a/applications/nrf_desktop/doc/ble_conn_params.rst
+++ b/applications/nrf_desktop/doc/ble_conn_params.rst
@@ -27,18 +27,18 @@ Configuration
 *************
 
 The module requires the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
-The module is automatically enabled for every nRF Desktop central device (:kconfig:option:`CONFIG_BT_CENTRAL`).
+The module is automatically enabled for every nRF Desktop central device (:ref:`CONFIG_DESKTOP_BT_CENTRAL <config_desktop_app_options>`).
 
-Enable :kconfig:option:`CONFIG_DESKTOP_BLE_USB_MANAGED_CI` to manage Bluetooth connections' parameters reacting on the USB state change.
-The connection intervals for all of the Bluetooth connected peripherals are set to :kconfig:option:`CONFIG_DESKTOP_BLE_USB_MANAGED_CI_VALUE` (100 ms by default) while USB is suspended.
+Enable :ref:`CONFIG_DESKTOP_BLE_USB_MANAGED_CI <config_desktop_app_options>` to manage Bluetooth connections' parameters reacting on the USB state change.
+The connection intervals for all of the Bluetooth connected peripherals are set to :ref:`CONFIG_DESKTOP_BLE_USB_MANAGED_CI_VALUE <config_desktop_app_options>` (100 ms by default) while USB is suspended.
 The connections' peripheral latencies are set to 0.
 The connection parameter change is reverted when USB is active.
-The :kconfig:option:`CONFIG_DESKTOP_BLE_USB_MANAGED_CI` is enabled by default.
+The :ref:`CONFIG_DESKTOP_BLE_USB_MANAGED_CI <config_desktop_app_options>` is enabled by default.
 
 Implementation details
 **********************
 
-The |ble_conn_params| receives the peripheral's connection parameters update request as ``ble_peer_conn_params_event``.
+The |ble_conn_params| receives the peripheral's connection parameters update request as :c:struct:`ble_peer_conn_params_event`.
 The module updates only the connection latency.
 The connection interval and supervision timeout are not changed according to the peripheral's request.
 

--- a/applications/nrf_desktop/doc/ble_passkey.rst
+++ b/applications/nrf_desktop/doc/ble_passkey.rst
@@ -23,7 +23,7 @@ Configuration
 *************
 
 The module requires the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
-The module can be used only for Bluetooth Peripheral devices (:kconfig:option:`CONFIG_BT_PERIPHERAL`).
+The module can be used only for nRF Desktop Bluetooth Peripheral devices (:ref:`CONFIG_DESKTOP_BT_PERIPHERAL <config_desktop_app_options>`).
 
 Use the option :ref:`CONFIG_DESKTOP_BLE_ENABLE_PASSKEY <config_desktop_app_options>` to enable the module.
 Make sure to enable and configure the :ref:`nrf_desktop_passkey` if you decide to use this option.

--- a/applications/nrf_desktop/doc/hid_forward.rst
+++ b/applications/nrf_desktop/doc/hid_forward.rst
@@ -29,19 +29,18 @@ Configuration
 Complete the following steps to configure the module:
 
 1. Complete the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
-#. Make sure that the :ref:`CONFIG_DESKTOP_HID_STATE_ENABLE <config_desktop_app_options>` option is disabled.
-   The nRF Desktop central does not generate its own HID input reports.
-   It only forwards HID input reports that it receives from the peripherals connected over Bluetooth.
+   Make sure that both :ref:`CONFIG_DESKTOP_ROLE_HID_DONGLE <config_desktop_app_options>` and :ref:`CONFIG_DESKTOP_BT_CENTRAL <config_desktop_app_options>` are enabled.
 #. Enable and configure the :ref:`hogp_readme` (:kconfig:option:`CONFIG_BT_HOGP`).
+   An nRF Desktop dongle does not generate its own HID input reports.
+   The dongle uses |hid_forward| to forward the HID reports.
+   The reports are received by the HID service client from the peripherals connected over Bluetooth.
 
    .. note::
        Make sure to define the maximum number of supported HID reports (:kconfig:option:`CONFIG_BT_HOGP_REPORTS_MAX`).
 
-#. Make sure to enable the :kconfig:option:`CONFIG_BT_CENTRAL` Kconfig option.
-#. Enable |hid_forward| using the :ref:`CONFIG_DESKTOP_HID_FORWARD_ENABLE <config_desktop_app_options>` option.
-   This option is available only if you enable both options from the previous steps.
-   The module is used on Bluetooth Central to forward the HID reports that are received by the HID service client.
-#. Depending on your hardware, enable one of the following options:
+#. The :ref:`CONFIG_DESKTOP_HID_FORWARD_ENABLE <config_desktop_app_options>` option enables the |hid_forward| and is automatically selected by the :ref:`CONFIG_DESKTOP_ROLE_HID_DONGLE <config_desktop_app_options>` option.
+#. nRF Desktop dongle can forward either mouse or keyboard boot reports.
+   The forwarded boot report type is specified using the following Kconfig options:
 
    * :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_KEYBOARD <config_desktop_app_options>` - This option enables forwarding keyboard boot reports.
    * :ref:`CONFIG_DESKTOP_HID_BOOT_INTERFACE_MOUSE <config_desktop_app_options>` - This option enables forwarding mouse boot reports.

--- a/applications/nrf_desktop/doc/hids.rst
+++ b/applications/nrf_desktop/doc/hids.rst
@@ -27,13 +27,9 @@ Configuration
 Complete the following steps to configure the module:
 
 1. Complete the basic Bluetooth configuration, as described in :ref:`nrf_desktop_bluetooth_guide`.
-   During this configuration, you must enable the :kconfig:option:`CONFIG_BT_PERIPHERAL` Kconfig option for every nRF Desktop peripheral.
-   When this option is enabled, the :ref:`CONFIG_DESKTOP_HID_PERIPHERAL <config_desktop_app_options>` is set to ``y``, which enables the following two additional options, among others:
-
-   * :kconfig:option:`CONFIG_BT_HIDS` - This is required because the HID Service module is based on the :ref:`hids_readme` implementation of the GATT Service.
-   * :ref:`CONFIG_DESKTOP_HIDS_ENABLE <config_desktop_app_options>` - This enables the ``hids`` application module.
-
-   This step also enables the |GATT_HID|.
+   Make sure that both :ref:`CONFIG_DESKTOP_ROLE_HID_PERIPHERAL <config_desktop_app_options>` and :ref:`CONFIG_DESKTOP_BT_PERIPHERAL <config_desktop_app_options>` options are enabled.
+   The HID Service application module is enabled by the :ref:`CONFIG_DESKTOP_HIDS_ENABLE <config_desktop_app_options>` option which is selected by :ref:`CONFIG_DESKTOP_BT_PERIPHERAL <config_desktop_app_options>` together with other GATT Services that are required for a HID device.
+#. The :ref:`CONFIG_DESKTOP_HIDS_ENABLE <config_desktop_app_options>` option selects :kconfig:option:`CONFIG_BT_HIDS` to automatically enable the :ref:`hids_readme`.
 #. Enable the :ref:`bt_conn_ctx_readme` (:kconfig:option:`CONFIG_BT_CONN_CTX`).
    This is required by the |GATT_HID|.
 #. Configure the :ref:`hids_readme`.

--- a/applications/nrf_desktop/src/modules/CMakeLists.txt
+++ b/applications/nrf_desktop/src/modules/CMakeLists.txt
@@ -10,10 +10,10 @@ target_sources_ifdef(CONFIG_DESKTOP_BLE_BOND_ENABLE
 target_sources_ifdef(CONFIG_DESKTOP_BLE_ENABLE_PASSKEY
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ble_passkey.c)
 
-target_sources_ifdef(CONFIG_BT_PERIPHERAL
+target_sources_ifdef(CONFIG_DESKTOP_BT_PERIPHERAL
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ble_latency.c)
 
-target_sources_ifdef(CONFIG_BT_CENTRAL
+target_sources_ifdef(CONFIG_DESKTOP_BT_CENTRAL
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ble_conn_params.c)
 
 target_sources_ifdef(CONFIG_DESKTOP_BLE_DISCOVERY_ENABLE
@@ -67,7 +67,7 @@ target_sources_ifdef(CONFIG_DESKTOP_BAS_ENABLE
 target_sources_ifdef(CONFIG_DESKTOP_QOS_ENABLE
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/qos.c)
 
-target_sources_ifdef(CONFIG_BT_PERIPHERAL
+target_sources_ifdef(CONFIG_DESKTOP_BT_PERIPHERAL
 		     app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/dev_descr.c)
 
 target_sources_ifdef(CONFIG_DESKTOP_HIDS_ENABLE

--- a/applications/nrf_desktop/src/modules/Kconfig.ble
+++ b/applications/nrf_desktop/src/modules/Kconfig.ble
@@ -31,7 +31,7 @@ config DESKTOP_BLE_BOND_ENABLE
 
 config DESKTOP_BLE_USE_DEFAULT_ID
 	bool "Use default Bluetooth local identity"
-	depends on BT_PERIPHERAL
+	depends on DESKTOP_BT_PERIPHERAL
 	help
 	  Bluetooth default local identity is used as ID 0. This identity
 	  cannot be reset. After bond for the default identity is removed,
@@ -53,13 +53,13 @@ config DESKTOP_BLE_PEER_CONTROL_BUTTON
 
 config DESKTOP_BLE_PEER_SELECT
 	bool "Enable switching between peers"
-	depends on BT_PERIPHERAL
+	depends on DESKTOP_BT_PERIPHERAL
 	help
 	  Short click to switch peer. Double click to accept choice.
 
 config DESKTOP_BLE_NEW_PEER_SCAN_REQUEST
 	bool "Enable scanning on request"
-	depends on BT_CENTRAL
+	depends on DESKTOP_BT_CENTRAL
 	help
 	  Short click to start new peer scanning. When enabled the device will
 	  look for non-bonded devices only when requested.
@@ -82,7 +82,7 @@ config DESKTOP_BLE_PEER_ERASE
 
 config DESKTOP_BLE_PEER_ERASE_ON_START
 	bool "Enable peer erase (on system start)"
-	depends on BT_PERIPHERAL
+	depends on DESKTOP_BT_PERIPHERAL
 	help
 	  Hold dedicated button during system start to start erase advertising.
 endif
@@ -97,7 +97,7 @@ endif
 
 config DESKTOP_BLE_DONGLE_PEER_ENABLE
 	bool "Enable dongle peer"
-	depends on BT_PERIPHERAL
+	depends on DESKTOP_BT_PERIPHERAL
 	help
 	  Enable additional peer to connect with dongle.
 
@@ -150,7 +150,7 @@ endif
 
 comment "BLE connection parameters"
 
-if BT_PERIPHERAL
+if DESKTOP_BT_PERIPHERAL
 
 config DESKTOP_BLE_SECURITY_FAIL_TIMEOUT_S
 	int "Security fail timeout [s]"
@@ -175,7 +175,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 endif
 
-if BT_CENTRAL
+if DESKTOP_BT_CENTRAL
 
 config DESKTOP_BLE_USB_MANAGED_CI
 	bool "Manage connection intervals on the USB state change"

--- a/applications/nrf_desktop/src/modules/Kconfig.ble_passkey
+++ b/applications/nrf_desktop/src/modules/Kconfig.ble_passkey
@@ -8,7 +8,7 @@ menuconfig DESKTOP_BLE_ENABLE_PASSKEY
 	bool "Bluetooth LE passkey module"
 	depends on !DESKTOP_PASSKEY_NONE
 	depends on !BT_FAST_PAIR
-	depends on BT_PERIPHERAL
+	depends on DESKTOP_BT_PERIPHERAL
 	help
 	  Enable passkey based pairing for increased security.
 

--- a/applications/nrf_desktop/src/modules/Kconfig.ble_scan
+++ b/applications/nrf_desktop/src/modules/Kconfig.ble_scan
@@ -8,7 +8,7 @@ menuconfig DESKTOP_BLE_SCAN_ENABLE
 	bool "Bluetooth LE scan module"
 	select BT_SCAN
 	select BT_SCAN_FILTER_ENABLE
-	depends on BT_CENTRAL
+	depends on DESKTOP_BT_CENTRAL
 	help
 	  Enable device to scan for peripheral devices.
 

--- a/applications/nrf_desktop/src/modules/Kconfig.config_channel
+++ b/applications/nrf_desktop/src/modules/Kconfig.config_channel
@@ -16,7 +16,7 @@ config DESKTOP_CONFIG_CHANNEL_ENABLE
 config DESKTOP_CONFIG_CHANNEL_OUT_REPORT
 	bool "Enable additional HID output report"
 	depends on DESKTOP_CONFIG_CHANNEL_ENABLE
-	depends on BT_PERIPHERAL
+	depends on DESKTOP_ROLE_HID_PERIPHERAL
 	help
 	  Use additional HID output report for configuration channel data
 	  transfer. The HID output report is used only by nRF Desktop dongle,

--- a/applications/nrf_desktop/src/modules/Kconfig.hid_forward
+++ b/applications/nrf_desktop/src/modules/Kconfig.hid_forward
@@ -9,8 +9,8 @@ menu "BLE HID Client"
 config DESKTOP_HID_FORWARD_ENABLE
 	bool "Enable HID forward"
 	depends on BT_HOGP
-	depends on BT_CENTRAL
-	depends on !DESKTOP_HID_STATE_ENABLE
+	depends on DESKTOP_ROLE_HID_DONGLE
+	depends on DESKTOP_BT_CENTRAL
 	help
 	  This option enables HID over GATT Client.
 	  The reports received from the BLE are forwarded to the USB.

--- a/applications/nrf_desktop/src/modules/Kconfig.hid_state
+++ b/applications/nrf_desktop/src/modules/Kconfig.hid_state
@@ -8,7 +8,7 @@ menu "HID State"
 
 config DESKTOP_HID_STATE_ENABLE
 	bool "Enable HID state"
-	depends on BT_PERIPHERAL
+	depends on DESKTOP_ROLE_HID_PERIPHERAL
 	help
 	  The module generates HID reports based on user input.
 

--- a/applications/nrf_desktop/src/modules/Kconfig.qos
+++ b/applications/nrf_desktop/src/modules/Kconfig.qos
@@ -9,7 +9,7 @@ menu "BLE QOS Service"
 config DESKTOP_QOS_ENABLE
 	bool "QoS service"
 	depends on DESKTOP_BLE_QOS_ENABLE
-	depends on BT_PERIPHERAL
+	depends on DESKTOP_BT_PERIPHERAL
 	help
 	  This option enables QoS service.
 

--- a/applications/nrf_desktop/src/modules/ble_bond.c
+++ b/applications/nrf_desktop/src/modules/ble_bond.c
@@ -83,11 +83,11 @@ static const struct state_switch state_switch[] = {
 
 #if CONFIG_DESKTOP_BLE_PEER_ERASE
 	{STATE_IDLE,              CLICK_LONG,   STATE_ERASE_PEER,        erase_start},
-#if CONFIG_BT_PERIPHERAL
+#if CONFIG_DESKTOP_BT_PERIPHERAL
 	{STATE_ERASE_PEER,        CLICK_DOUBLE, STATE_ERASE_ADV,         erase_adv_confirm},
-#elif CONFIG_BT_CENTRAL
+#elif CONFIG_DESKTOP_BT_CENTRAL
 	{STATE_ERASE_PEER,        CLICK_DOUBLE, STATE_IDLE,              erase_confirm},
-#endif /* CONFIG_BT_PERIPHERAL */
+#endif
 
 #if CONFIG_DESKTOP_BLE_DONGLE_PEER_ERASE_BOND_BUTTON
 	{STATE_DONGLE,            CLICK_LONG,   STATE_DONGLE_ERASE_PEER, erase_start},
@@ -109,9 +109,9 @@ enum ble_bond_opt {
 
 const static char * const opt_descr[] = {
 	[BLE_BOND_OPT_PEER_ERASE] = "peer_erase",
-#ifdef CONFIG_BT_CENTRAL
+#ifdef CONFIG_DESKTOP_BT_CENTRAL
 	[BLE_BOND_OPT_PEER_SEARCH] = "peer_search",
-#endif /* CONFIG_BT_CENTRAL */
+#endif /* CONFIG_DESKTOP_BT_CENTRAL */
 };
 
 static enum state state;
@@ -122,7 +122,7 @@ static bool dongle_peer_selected_on_init;
 static bool erase_adv_was_extended;
 
 
-#if CONFIG_BT_PERIPHERAL
+#if CONFIG_DESKTOP_BT_PERIPHERAL
 /* nRF Desktop peripheral requires a minimum of three Bluetooth identities:
  * - BT_ID_DEFAULT is not used as it cannot be reset.
  * - one identity is used for bonding with a peer.
@@ -132,14 +132,14 @@ static bool erase_adv_was_extended;
  */
 BUILD_ASSERT(CONFIG_BT_ID_MAX >= (IS_ENABLED(CONFIG_DESKTOP_BLE_DONGLE_PEER_ENABLE) ? 4 : 3));
 #define BT_STACK_ID_LUT_SIZE (CONFIG_BT_ID_MAX - 1)
-#elif CONFIG_BT_CENTRAL
+#elif CONFIG_DESKTOP_BT_CENTRAL
 #define BT_STACK_ID_LUT_SIZE 0
 #else
 #error Device must be Bluetooth peripheral or central.
 #endif
 
 /* The Bluetooth Identity look-up table cannot be used in the Bluetooth Central
- * configuration (CONFIG_BT_CENTRAL), along with the definitions of special
+ * configuration (CONFIG_DESKTOP_BT_CENTRAL), along with the definitions of special
  * peer IDs.
  */
 static uint8_t bt_stack_id_lut[BT_STACK_ID_LUT_SIZE];
@@ -213,14 +213,14 @@ static int settings_set(const char *key, size_t len_rd,
 	return 0;
 }
 
-#ifdef CONFIG_BT_PERIPHERAL
+#ifdef CONFIG_DESKTOP_BT_PERIPHERAL
 SETTINGS_STATIC_HANDLER_DEFINE(ble_bond, MODULE_NAME, NULL, settings_set, NULL,
 			       NULL);
-#endif /* CONFIG_BT_PERIPHERAL */
+#endif /* CONFIG_DESKTOP_BT_PERIPHERAL */
 
 static uint8_t get_bt_stack_peer_id(uint8_t id)
 {
-	if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_BT_PERIPHERAL)) {
 		if ((state == STATE_ERASE_PEER) || (state == STATE_ERASE_ADV) ||
 		(state == STATE_DONGLE_ERASE_PEER) || (state == STATE_DONGLE_ERASE_ADV)) {
 			return bt_stack_id_lut[TEMP_PEER_ID];
@@ -479,7 +479,7 @@ static void erase_start(void)
 
 static void erase_confirm(void)
 {
-	__ASSERT_NO_MSG(IS_ENABLED(CONFIG_BT_CENTRAL));
+	__ASSERT_NO_MSG(IS_ENABLED(CONFIG_DESKTOP_BT_CENTRAL));
 
 	remove_peers(BT_ID_DEFAULT);
 
@@ -494,7 +494,7 @@ static void erase_confirm(void)
 
 static void erase_adv_confirm(void)
 {
-	__ASSERT_NO_MSG(IS_ENABLED(CONFIG_BT_PERIPHERAL));
+	__ASSERT_NO_MSG(IS_ENABLED(CONFIG_DESKTOP_BT_PERIPHERAL));
 
 	/* Update state to ensure that proper bt_stack_id will be used. */
 	if (state == STATE_IDLE) {
@@ -620,7 +620,7 @@ static void timeout_handler(struct k_work *work)
 
 static void init_bt_stack_id_lut(void)
 {
-	if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_BT_PERIPHERAL)) {
 		for (size_t i = 0; i < ARRAY_SIZE(bt_stack_id_lut); i++) {
 			/* BT_ID_DEFAULT cannot be reset. */
 			bt_stack_id_lut[i] = i + 1;
@@ -661,7 +661,7 @@ static void load_identities(void)
 static void silence_unused(void)
 {
 	/* These things will be opt-out by the compiler. */
-	if (!IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+	if (!IS_ENABLED(CONFIG_DESKTOP_BT_PERIPHERAL)) {
 		ARG_UNUSED(settings_set);
 	};
 
@@ -756,13 +756,14 @@ static int init(void)
 	}
 
 	if ((IS_ENABLED(CONFIG_DESKTOP_BLE_PEER_CONTROL)) ||
-	   (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE) && IS_ENABLED(CONFIG_BT_PERIPHERAL))) {
+	    (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE) &&
+	     IS_ENABLED(CONFIG_DESKTOP_BT_PERIPHERAL))) {
 		k_work_init_delayable(&timeout, timeout_handler);
 	}
 
 	load_identities();
 
-	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
+	if (IS_ENABLED(CONFIG_DESKTOP_BT_PERIPHERAL) &&
 	    !storage_data_is_valid()) {
 		storage_data_overwrite();
 		bt_stack_id_lut_valid = true;
@@ -933,7 +934,7 @@ static void config_set(const uint8_t opt_id, const uint8_t *data, const size_t s
 
 	switch (opt_id) {
 	case BLE_BOND_OPT_PEER_SEARCH:
-		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		if (IS_ENABLED(CONFIG_DESKTOP_BT_CENTRAL)) {
 			LOG_INF("Remote scan request");
 			scan_request();
 		} else {
@@ -943,7 +944,7 @@ static void config_set(const uint8_t opt_id, const uint8_t *data, const size_t s
 
 	case BLE_BOND_OPT_PEER_ERASE:
 		LOG_INF("Remote peer erase request");
-		if (IS_ENABLED(CONFIG_BT_PERIPHERAL)) {
+		if (IS_ENABLED(CONFIG_DESKTOP_BT_PERIPHERAL)) {
 			if ((!IS_ENABLED(CONFIG_DESKTOP_BLE_DONGLE_PEER_ERASE_BOND_CONF_CHANNEL)
 				&& (state == STATE_DONGLE))) {
 				LOG_WRN("Peer erase not supported");
@@ -958,7 +959,7 @@ static void config_set(const uint8_t opt_id, const uint8_t *data, const size_t s
 
 			k_work_reschedule(&timeout, ERASE_ADV_TIMEOUT);
 
-		} else if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		} else if (IS_ENABLED(CONFIG_DESKTOP_BT_CENTRAL)) {
 			erase_confirm();
 		}
 		break;
@@ -1087,7 +1088,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 		return false;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
+	if (IS_ENABLED(CONFIG_DESKTOP_BT_PERIPHERAL) &&
 	    is_ble_peer_event(aeh)) {
 		return ble_peer_event_handler(cast_ble_peer_event(aeh));
 	}
@@ -1123,7 +1124,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 }
 APP_EVENT_LISTENER(MODULE, app_event_handler);
 APP_EVENT_SUBSCRIBE(MODULE, module_state_event);
-#if IS_ENABLED(CONFIG_BT_PERIPHERAL)
+#if IS_ENABLED(CONFIG_DESKTOP_BT_PERIPHERAL)
 APP_EVENT_SUBSCRIBE(MODULE, ble_peer_event);
 #endif
 #if IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE)

--- a/applications/nrf_desktop/src/modules/ble_qos.c
+++ b/applications/nrf_desktop/src/modules/ble_qos.c
@@ -786,7 +786,7 @@ static void ble_qos_thread_fn(void)
 		memcpy(event->chmap, chmap, CHMAP_BLE_BITMASK_SIZE);
 		APP_EVENT_SUBMIT(event);
 
-		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		if (IS_ENABLED(CONFIG_DESKTOP_BT_CENTRAL)) {
 			err = bt_le_set_chan_map(chmap);
 			if (err) {
 				LOG_WRN("bt_le_set_chan_map: %d", err);


### PR DESCRIPTION
Use application-specific configuration options instead of `CONFIG_BT_PERIPHERAL` and `CONFIG_BT_CENTRAL`. Change also applies the needed documentation updates.

Jira: NCSDK-17243