### PR TITLE
drivers: sensor_stub: Clean up

### DIFF
--- a/drivers/sensor/sensor_stub/sensor_stub.c
+++ b/drivers/sensor/sensor_stub/sensor_stub.c
@@ -55,21 +55,21 @@ static int sensor_stub_init(const struct device *dev)
 }
 
 #define SENSOR_STUB_DEFINE(_idx)                                                                   \
-	extern int CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _fetch)(                  \
+	extern int _CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _fetch)(                 \
 		const struct device *dev, enum sensor_channel ch);                                 \
-	extern int CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _get)(                    \
+	extern int _CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _get)(                   \
 		const struct device *dev, enum sensor_channel ch, struct sensor_value *val);       \
-	extern int CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _init)(                   \
+	extern int _CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _init)(                  \
 		const struct device *dev);                                                         \
 												   \
 	static const struct sensor_driver_api sensor_stub_api_funcs_##_idx = {                     \
-		.sample_fetch = CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _fetch),     \
-		.channel_get  = CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _get)        \
+		.sample_fetch = _CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _fetch),    \
+		.channel_get  = _CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _get)       \
 	};                                                                                         \
 												   \
 	static struct sensor_stub_data data_##_idx;                                                \
 	const struct sensor_stub_config config_##_idx = {                                          \
-		.init = CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _init)               \
+		.init = _CONCAT(DT_STRING_TOKEN(DT_DRV_INST(_idx), generator), _init)              \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(_idx, sensor_stub_init, NULL, &data_##_idx, &config_##_idx,          \
 				      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,	                   \

--- a/drivers/sensor/sensor_stub/sensor_stub.c
+++ b/drivers/sensor/sensor_stub/sensor_stub.c
@@ -6,15 +6,8 @@
 
 #define DT_DRV_COMPAT nordic_sensor_stub
 
-#include <errno.h>
-#include <stdint.h>
-#include <stddef.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
-#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
 #include <drivers/sensor_stub.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
[drivers: sensor: sensor_stub: Remove unused includes](https://github.com/nrfconnect/sdk-nrf/commit/4f0dd661c8cbbde54aef603fba8874014d9aa92e) 

Removes included files that are not needed.

---

[drivers: sensor: sensor_stub: Use common macro for concatenation](https://github.com/nrfconnect/sdk-nrf/commit/14e9ec25bdb0edbed82bbcf82f3ec8cb1d98e7f4) 

Use the common _CONCAT() macro defined in Zephyr.

Fixes NCSDK-18923