### PR TITLE
doc: nrf: mention MMSS sample as alternative to ATv2

### DIFF
--- a/doc/nrf/ug_nrf9160_gs.rst
+++ b/doc/nrf/ug_nrf9160_gs.rst
@@ -69,6 +69,9 @@ Application firmware
   For the iBasis SIM card provided with the nRF9160 DK, see `iBasis IoT network coverage`_.
   If your location has support for both, you can choose either one.
 
+  Alternatively, for a more concise nRF Cloud firmware application, you can build and install the :ref:`nrf_cloud_mqtt_multi_service` sample.
+  See :ref:`gs_programming` for details on building a firmware sample application.
+
 Application firmware for Device Firmware Update (DFU)
   The images in the :file:`img_fota_dfu_bin` and :file:`img_fota_dfu_hex` folders contain firmware images for DFU.
   When following this guide, you can ignore these images.

--- a/doc/nrf/ug_thingy91_gsg.rst
+++ b/doc/nrf/ug_thingy91_gsg.rst
@@ -96,6 +96,8 @@ Thingy:91 (v1.5.0 or lower) comes preloaded with the nRF9160: Asset Tracker firm
 The data is transmitted to nRF Cloud.
 
 Before you start using the Thingy:91, it is recommended that you update the application firmware to :ref:`asset_tracker_v2`.
+Alternatively, for a more concise nRF Cloud firmware application, you can build and install the :ref:`nrf_cloud_mqtt_multi_service` sample.
+See :ref:`gs_programming` for details on building a firmware sample application.
 You must also update the modem firmware.
 You can update the application and modem firmware on a Thingy:91 through a :term:`Universal Serial Bus (USB)` cable using MCUboot.
 MCUboot is a secure bootloader that is used to update applications if you do not have an external debugger.


### PR DESCRIPTION
In the getting started guide for the DK and T91,
mention the nRF Cloud MQTT multi-service sample
as an alternative to ATv2.
NCSDK-18118

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>