### PR TITLE
twister: quarantine: Update quarantine description

### DIFF
--- a/scripts/quarantine.yaml
+++ b/scripts/quarantine.yaml
@@ -5,7 +5,7 @@
 # - scenarios:
 #    - None
 #  platforms:
-#    - None
+#    - all
 
 - scenarios:
     - sample.tfm.psa_test_crypto


### PR DESCRIPTION
Using None as a platform causes twister to fail (None is not recognized as a valid platform name). Using 'all' instead solves the problem. Update the comment description to reflact this.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>