### PR TITLE
manifest: Remove fff from zephyr allow list

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,6 @@ manifest:
           - cmsis
           - edtt
           - fatfs
-          - fff
           - hal_nordic
           - hal_st # required for ST sensors (unrelated to STM32 MCUs)
           - hal_wurthelektronik


### PR DESCRIPTION
fff has been moved in-tree into zephyr, the entry can be removed as it is no longer a separate module.