### PR TITLE
applications: nrf5340_audio: Set encryption bool for big_create

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -330,7 +330,7 @@ config BT_AUDIO_BROADCAST_ENCRYPTED
 	depends on TRANSPORT_BIS
 	default n
 	help
-	  Encrypt the broadcast to limit the connectability
+	  Encrypt the broadcast to limit the connection possibilities.
 
 config BT_AUDIO_BROADCAST_ENCRYPTION_KEY
 	string "Broadcast encryption key"

--- a/applications/nrf5340_audio/src/bluetooth/Kconfig
+++ b/applications/nrf5340_audio/src/bluetooth/Kconfig
@@ -331,7 +331,6 @@ config BT_AUDIO_BROADCAST_ENCRYPTED
 	default n
 	help
 	  Encrypt the broadcast to limit the connectability
-	  (NOTE: Encrypting broadcast source is not yet supported by host.)
 
 config BT_AUDIO_BROADCAST_ENCRYPTION_KEY
 	string "Broadcast encryption key"

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
@@ -296,6 +296,7 @@ static int initialize(void)
 	create_param.params = subgroup_params;
 	create_param.qos = &lc3_preset.qos;
 	create_param.packing = BT_ISO_PACKING_SEQUENTIAL;
+	create_param.encryption = false;
 
 	LOG_DBG("Creating broadcast source");
 

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -155,6 +155,7 @@ nRF5340 Audio
 
   * Support for Front End Module nRF21540.
   * Possibility to create a Public Broadcast Announcement (PBA) needed for Auracast.
+  * Encryption for BISes.
 
 * Updated:
 


### PR DESCRIPTION
- Set uninitialized member to default false

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>