### PR TITLE
quarantine_windows: update quarantine

### DIFF
--- a/scripts/quarantine_windows.yaml
+++ b/scripts/quarantine_windows.yaml
@@ -39,3 +39,12 @@
   platforms:
     - all
   comment: "nanopb package not available in Windows toolchain"
+
+- scenarios:
+    - applications.nrf5340_audio.gateway_dfu_external
+    - applications.nrf5340_audio.gateway_dfu_internal
+    - applications.nrf5340_audio.headset_dfu_external
+    - applications.nrf5340_audio.headset_dfu_internal
+  platforms:
+    - all
+  comment: "skip until fix sdk-nrf/pull/9898 is merged"


### PR DESCRIPTION
New CI builds for nrf5340_audio are failing on Windows CI due to backslash in CMAKE path. New tests added to the list:

    - applications.nrf5340_audio.gateway_dfu_external
    - applications.nrf5340_audio.gateway_dfu_internal
    - applications.nrf5340_audio.headset_dfu_external
    - applications.nrf5340_audio.headset_dfu_internal

untill fix sdk-nrf/pull/9580 is merged.

Signed-off-by: Rafal Wozniakowski <rafal.wozniakowski@nordicsemi.no>