### PR TITLE
applications: machine_learning: Remove ml_result_signin_event

### DIFF
--- a/applications/machine_learning/README.rst
+++ b/applications/machine_learning/README.rst
@@ -554,8 +554,6 @@ The nRF Machine Learning application also uses the following dedicated applicati
 ``ml_runner``
   The module uses :ref:`ei_wrapper` API to control running the machine learning model.
   It provides the prediction results using :c:struct:`ml_result_event`.
-  The module runs the machine learning model and provides results only if there is an active subscriber.
-  An application module can inform that it is actively listening for results using :c:struct:`ml_result_signin_event`.
 
 ``ml_app_mode``
   The module controls Application mode. It switches between running the machine learning model and forwarding the data.

--- a/applications/machine_learning/src/events/Kconfig
+++ b/applications/machine_learning/src/events/Kconfig
@@ -24,12 +24,6 @@ config ML_APP_INIT_LOG_ML_RESULT_EVENTS
 	depends on LOG
 	default y
 
-config ML_APP_INIT_LOG_ML_RESULT_SIGNIN_EVENTS
-	bool "Log machine learning result signin event"
-	depends on ML_APP_ML_RESULT_EVENTS
-	depends on LOG
-	default y
-
 config ML_APP_MODE_EVENTS
 	bool "Enable machine learning mode events"
 

--- a/applications/machine_learning/src/events/ml_result_event.c
+++ b/applications/machine_learning/src/events/ml_result_event.c
@@ -17,27 +17,9 @@ static void log_ml_result_event(const struct app_event_header *aeh)
 			event->label, event->value, event->anomaly);
 }
 
-static void log_ml_result_signin_event(const struct app_event_header *aeh)
-{
-	const struct ml_result_signin_event *event = cast_ml_result_signin_event(aeh);
-
-	APP_EVENT_MANAGER_LOG(aeh, "module: \"%s\" %s ml_result_event",
-			module_name_get(module_id_get(event->module_idx)),
-			event->state ? "signs in to" : "signs off from");
-}
-
 static void profile_ml_result_event(struct log_event_buf *buf,
 				    const struct app_event_header *aeh)
 {
-}
-
-static void profile_ml_result_signin_event(struct log_event_buf *buf,
-					   const struct app_event_header *aeh)
-{
-	const struct ml_result_signin_event *event = cast_ml_result_signin_event(aeh);
-
-	nrf_profiler_log_encode_uint32(buf, event->module_idx);
-	nrf_profiler_log_encode_uint8(buf, event->state);
 }
 
 APP_EVENT_INFO_DEFINE(ml_result_event,
@@ -50,16 +32,4 @@ APP_EVENT_TYPE_DEFINE(ml_result_event,
 		  &ml_result_event_info,
 		  APP_EVENT_FLAGS_CREATE(
 			IF_ENABLED(CONFIG_ML_APP_INIT_LOG_ML_RESULT_EVENTS,
-				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));
-
-APP_EVENT_INFO_DEFINE(ml_result_signin_event,
-		  ENCODE(NRF_PROFILER_ARG_U32, NRF_PROFILER_ARG_U8),
-		  ENCODE("module", "state"),
-		  profile_ml_result_signin_event);
-
-APP_EVENT_TYPE_DEFINE(ml_result_signin_event,
-		  log_ml_result_signin_event,
-		  &ml_result_signin_event_info,
-		  APP_EVENT_FLAGS_CREATE(
-			IF_ENABLED(CONFIG_ML_APP_INIT_LOG_ML_RESULT_SIGNIN_EVENTS,
 				(APP_EVENT_TYPE_FLAGS_INIT_LOG_ENABLE))));

--- a/applications/machine_learning/src/events/ml_result_event.h
+++ b/applications/machine_learning/src/events/ml_result_event.h
@@ -19,7 +19,6 @@
 
 #include <app_event_manager.h>
 #include <app_event_manager_profiler_tracer.h>
-#include <caf/events/module_state_event.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,23 +38,7 @@ struct ml_result_event {
 	float anomaly;
 };
 
-/** @brief Sign in event
- *
- * The event that is called by modules
- * to mark that the module actively listens for the result event.
- */
-struct ml_result_signin_event {
-	/** Event header. */
-	struct app_event_header header;
-
-	/** The index of the module. */
-	size_t module_idx;
-	/** Requested state: true to sign in, false to sign off. */
-	bool state;
-};
-
 APP_EVENT_TYPE_DECLARE(ml_result_event);
-APP_EVENT_TYPE_DECLARE(ml_result_signin_event);
 
 #ifdef __cplusplus
 }

--- a/applications/machine_learning/src/modules/led_state.c
+++ b/applications/machine_learning/src/modules/led_state.c
@@ -92,16 +92,6 @@ static const struct ml_result_led_effect *get_led_effect(const char *label)
 	return result;
 }
 
-static void ml_result_set_signin_state(bool state)
-{
-	struct ml_result_signin_event *event = new_ml_result_signin_event();
-
-	event->module_idx = MODULE_IDX(MODULE);
-	event->state = state;
-	APP_EVENT_SUBMIT(event);
-	LOG_INF("Currently %s result event", state ? "signed in" : "signed off from");
-}
-
 static void display_sensor_sim(const char *label)
 {
 	static const struct ml_result_led_effect *sensor_sim_effect;
@@ -154,10 +144,8 @@ static void display_ml_result(const char *label, bool force_update)
 
 	if (is_led_effect_blocking(&ml_result_effect->effect)) {
 		blocking_led_effect = &ml_result_effect->effect;
-		ml_result_set_signin_state(false);
 	} else {
 		blocking_led_effect = NULL;
-		ml_result_set_signin_state(true);
 	}
 }
 
@@ -287,7 +275,6 @@ static bool handle_module_state_event(const struct module_state_event *event)
 		__ASSERT_NO_MSG(!initialized);
 		module_set_state(MODULE_STATE_READY);
 		initialized = true;
-		ml_result_set_signin_state(true);
 	}
 
 	return false;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -162,6 +162,11 @@ nRF5340 Audio
   * BIS headsets can now switch between two broadcast sources (two hardcoded broadcast names).
   * Documentation in the :ref:`nrf53_audio_app_ui` and :ref:`nrf53_audio_app_testing_steps_cis` sections with information about using **VOL** buttons to switch headset channels.
 
+nRF Machine Learning (Edge Impulse)
+-----------------------------------
+
+* Removed the usage of ``ml_runner_signin_event`` from the application.
+
 nRF Desktop
 -----------
 


### PR DESCRIPTION
ml_result_signin_event have no impact on the application workflow.
It is used by a presentation layer (CAF: Leds) to control application's
behavior by starting/stopping machine learning model predictions.
This is bad by design, thus remove the event.

Jira: NCSDK-18011