### PR TITLE
caf: ble_adv: Allow build with PM events disabled

### DIFF
--- a/subsys/caf/modules/ble_adv.c
+++ b/subsys/caf/modules/ble_adv.c
@@ -438,7 +438,9 @@ static void broadcast_module_state(enum state prev_state, enum state new_state)
 	}
 
 	if (req_wakeup) {
-		APP_EVENT_SUBMIT(new_wake_up_event());
+		if (IS_ENABLED(CONFIG_CAF_BLE_ADV_PM_EVENTS)) {
+			APP_EVENT_SUBMIT(new_wake_up_event());
+		}
 		req_wakeup = false;
 	}
 }


### PR DESCRIPTION
This commit allows code build when CONFIG_CAF_BLE_ADV_PM_EVENTS is disabled.
QUICK FIX.