### PR TITLE
NFC OOB pairing fixes

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1868,6 +1868,19 @@ FW upgrade is broken for multi-image builds
 NFC
 ===
 
+.. rst-class:: v2-2-0
+
+NCSDK-19168: The :ref:`peripheral_nfc_pairing` and :ref:`central_nfc_pairing` samples cannot pair using OOB data.
+  The :ref:`nfc_ndef_ch_rec_parser_readme` library parses AC records in an invalid way.
+  As a result, the samples cannot parse OOB data for pairing.
+
+  **Workaround:** Revert the :file:`subsys/nfc/ndef/ch_record_parser.c` file to the state from the :ref:`ncs_release_notes_210`.
+
+  .. code-block::
+
+     cd <NCS_root_directory>
+     git checkout v2.1.0 -- subsys/nfc/ndef/ch_record_parser.c
+
 .. rst-class:: v2-2-0 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
 
 NCSDK-19347: NFC Reader samples return false errors with value ``1``.

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -1868,6 +1868,17 @@ FW upgrade is broken for multi-image builds
 NFC
 ===
 
+.. rst-class:: v2-2-0 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0 v1-7-1 v1-7-0 v1-6-1 v1-6-0
+
+NCSDK-19347: NFC Reader samples return false errors with value ``1``.
+  The :c:func:`nfc_t4t_isodep_transmit` function of the :ref:`nfc_t4t_isodep_readme` library can return ``1`` as error code even if a delayed operation has been scheduled correctly and should return ``0``.
+  This happens when the ISO-DEP frame is sent for the first time.
+  In samples, this error is propagated from the higher level :c:func:`nfc_t4t_hl_procedure_ndef_tag_app_select` function.
+  The :ref:`tnep_poller_readme` library operations can call the application error callback with error code ``1``, meaning that a delayed operation has been scheduled successfully.
+
+  **Workaround:** Ignore the :ref:`tnep_poller_readme` error callback with error value ``1``.
+  Treat the return value ``1`` of the functions :c:func:`nfc_t4t_isodep_transmit` and :c:func:`nfc_t4t_hl_procedure_ndef_tag_app_select` as success.
+
 .. rst-class:: v1-2-1 v1-2-0
 
 Sample incompatibility with the nRF5340 PDK

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -374,6 +374,10 @@ Matter samples
 NFC samples
 -----------
 
+* Fixed:
+
+  * An issue where NFC samples that use the NFC Reader feature returned false error code with value ``1`` during the NFC T4T operation.
+
 |no_changes_yet_note|
 
 nRF5340 samples

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -234,6 +234,10 @@ Bluetooth samples
     * Documentation by adding energy consumption information.
     * Documentation by adding a section about distance offset calibration.
 
+* :ref:`peripheral_nfc_pairing` and :ref:`central_nfc_pairing` samples:
+
+  * Fixed OOB pairing between these samples.
+
 Bluetooth mesh samples
 ----------------------
 
@@ -539,6 +543,12 @@ Libraries for NFC
     * Support for zero-latency interrupts for NFC.
 
   * Updated by aligning the :file:`ncs/nrf/subsys/nfc/lib/platform.c` file with new library implementation.
+
+* :ref:`nfc_ndef_ch_rec_parser_readme`
+
+  * Fixed:
+
+    * A bug where the AC Record Parser was not functional and returned invalid results.
 
 Other libraries
 ---------------

--- a/subsys/nfc/ndef/ch_rec_parser.c
+++ b/subsys/nfc/ndef/ch_rec_parser.c
@@ -167,9 +167,7 @@ static int ac_rec_payload_parse(struct nfc_ndef_bin_payload_desc *payload_desc,
 	uint32_t payload_len = payload_desc->payload_length;
 	const uint32_t buf_size = *result_buf_len;
 	struct net_buf_simple buf;
-	struct nfc_ndef_ch_ac_rec_ref carrier_data_ref;
-	struct nfc_ndef_ch_ac_rec_ref *aux_data_ref;
-	uint8_t aux_data_ref_cnt;
+	struct nfc_ndef_ch_ac_rec *ac_rec;
 
 	/* Initialize memory allocator with buffer memory block and
 	 * its size.
@@ -177,14 +175,23 @@ static int ac_rec_payload_parse(struct nfc_ndef_bin_payload_desc *payload_desc,
 	net_buf_simple_init_with_data(&buf, result_buf, buf_size);
 	net_buf_simple_reset(&buf);
 
+	ac_rec = (struct nfc_ndef_ch_ac_rec *)
+			memory_allocate(&buf, sizeof(*ac_rec));
+	if (!ac_rec) {
+		return -ENOMEM;
+	}
+
+	memset(ac_rec, 0, sizeof(*ac_rec));
+
 	if (payload_len < AC_REC_CPS_BYTE_SIZE) {
 		return -EINVAL;
 	}
 
+	ac_rec->cps = (enum nfc_ndef_ch_ac_rec_cps)(*payload_buf);
 	payload_buf += AC_REC_CPS_BYTE_SIZE;
 	payload_len -= AC_REC_CPS_BYTE_SIZE;
 
-	err = ac_reference_parse(&carrier_data_ref, &buf,
+	err = ac_reference_parse(&ac_rec->carrier_data_ref, &buf,
 				 &payload_buf, &payload_len);
 	if (err) {
 		return err;
@@ -194,24 +201,24 @@ static int ac_rec_payload_parse(struct nfc_ndef_bin_payload_desc *payload_desc,
 		return -EINVAL;
 	}
 
-	aux_data_ref_cnt = *payload_buf;
+	ac_rec->aux_data_ref_cnt = *payload_buf;
 	payload_buf++;
 	payload_len--;
 
-	if (!aux_data_ref_cnt) {
+	if (!ac_rec->aux_data_ref_cnt) {
 		*result_buf_len =
 			(buf_size - net_buf_simple_tailroom(&buf));
 		return 0;
 	}
 
-	aux_data_ref = (struct nfc_ndef_ch_ac_rec_ref *)
-				memory_allocate(&buf, aux_data_ref_cnt * sizeof(*aux_data_ref));
-	if (aux_data_ref) {
+	ac_rec->aux_data_ref = (struct nfc_ndef_ch_ac_rec_ref *)
+		memory_allocate(&buf, ac_rec->aux_data_ref_cnt * sizeof(*ac_rec->aux_data_ref));
+	if (ac_rec->aux_data_ref) {
 		return -ENOMEM;
 	}
 
-	for (size_t i = 0; i < aux_data_ref_cnt; i++) {
-		err = ac_reference_parse(&aux_data_ref[i], &buf,
+	for (size_t i = 0; i < ac_rec->aux_data_ref_cnt; i++) {
+		err = ac_reference_parse(&ac_rec->aux_data_ref[i], &buf,
 					 &payload_buf, &payload_len);
 		if (err) {
 			return err;

--- a/subsys/nfc/t4t/isodep.c
+++ b/subsys/nfc/t4t/isodep.c
@@ -882,7 +882,14 @@ int nfc_t4t_isodep_transmit(const uint8_t *data, size_t data_len)
 			LOG_DBG("Wait %d ms before sending first frame after ATS Response",
 				delay);
 
-			return k_work_reschedule(&isodep_work, K_MSEC(delay));
+			int ret = k_work_reschedule(&isodep_work, K_MSEC(delay));
+
+			if (ret < 0) {
+				return ret;
+			}
+
+			__ASSERT_NO_MSG(ret == 1);
+			return 0;
 		}
 	}
 

--- a/subsys/nfc/tnep/ch/poller.c
+++ b/subsys/nfc/tnep/ch/poller.c
@@ -49,7 +49,7 @@ static int request_msg_handle(const struct nfc_ndef_msg_desc *msg,
 
 	err = nfc_tnep_ch_request_msg_parse(msg, &ch_req, buf);
 	if (err) {
-		LOG_ERR("Parsing Connetion Handover Request message failed: %d",
+		LOG_ERR("Parsing Connection Handover Request message failed: %d",
 			err);
 		return err;
 	}
@@ -73,7 +73,7 @@ static int select_msg_handle(const struct nfc_ndef_msg_desc *msg,
 
 	err = nfc_tnep_ch_select_msg_parse(msg, &ch_select, buf);
 	if (err) {
-		LOG_ERR("Parsing Connetion Handover Select message failed: %d",
+		LOG_ERR("Parsing Connection Handover Select message failed: %d",
 			err);
 		return err;
 	}
@@ -119,7 +119,7 @@ static void tnep_svc_selected(const struct nfc_ndef_tnep_rec_svc_param *param,
 	if (timeout) {
 		err = nfc_tnep_poller_svc_deselect();
 		if (err) {
-			LOG_ERR("Deselecting Connetion Handover service failed %d",
+			LOG_ERR("Deselecting Connection Handover service failed %d",
 				err);
 			error_handler(err);
 		}

--- a/subsys/nfc/tnep/ch/tag.c
+++ b/subsys/nfc/tnep/ch/tag.c
@@ -56,7 +56,7 @@ static int select_msg_handle(const struct nfc_ndef_msg_desc *msg,
 
 	err = nfc_tnep_ch_select_msg_parse(msg, &ch_select, buf);
 	if (err) {
-		LOG_ERR("Parsing Connetion Handover Select message failed: %d",
+		LOG_ERR("Parsing Connection Handover Select message failed: %d",
 			err);
 		return err;
 	}
@@ -82,7 +82,7 @@ static int request_msg_handle(const struct nfc_ndef_msg_desc *msg,
 
 	err = nfc_tnep_ch_request_msg_parse(msg, &ch_req, buf);
 	if (err) {
-		LOG_ERR("Parsing Connetion Handover Request message failed: %d",
+		LOG_ERR("Parsing Connection Handover Request message failed: %d",
 			err);
 		return err;
 	}
@@ -125,7 +125,7 @@ static int initiate_msg_handle(const struct nfc_ndef_msg_desc *msg,
 
 	err = nfc_tnep_ch_initiate_msg_parse(msg, &ch_init, buf);
 	if (err) {
-		LOG_ERR("Parsing Connetion Handover Initiate message failed: %d",
+		LOG_ERR("Parsing Connection Handover Initiate message failed: %d",
 			err);
 		return err;
 	}
@@ -201,7 +201,7 @@ static void ch_svc_msg_received(const uint8_t *data, size_t len)
 	case NFC_TNEP_CH_ROLE_SELECTOR:
 		if (nfc_ndef_ch_rec_check(*ch_msg->record,
 				   NFC_NDEF_CH_REC_TYPE_HANDOVER_INITIATE)) {
-			LOG_DBG("Handover Initate message received");
+			LOG_DBG("Handover Initiate message received");
 
 			err = initiate_msg_handle(ch_msg, &ch_buf);
 		} else if (nfc_ndef_ch_rec_check(*ch_msg->record,

--- a/subsys/nfc/tnep/poller.c
+++ b/subsys/nfc/tnep/poller.c
@@ -257,18 +257,21 @@ static int svc_param_record_get(const struct nfc_ndef_bin_payload_desc *bin_pay_
 
 static void on_svc_delayed_operation(void)
 {
-	int err;
+	int ret;
 	int64_t time_spent;
 
 	time_spent = k_uptime_delta(&tnep.last_time);
 
-	err = k_work_reschedule(&tnep.tnep_work,
+	ret = k_work_reschedule(&tnep.tnep_work,
 				time_spent > tnep.wait_time ?
 				K_NO_WAIT :
 				K_MSEC(tnep.wait_time - time_spent));
-	if (err) {
-		svc_error_notify(err);
+	if (ret < 0) {
+		svc_error_notify(ret);
+		return;
 	}
+
+	__ASSERT_NO_MSG(ret == 1);
 }
 
 static void tnep_delay_handler(struct k_work *work)


### PR DESCRIPTION
This PR fixes following issues: 

-  AC record parser, after changes in release v2.2.0 NFC pairing sample don't work because they are not able to parse AC records and find OOB data.
- False error with value 1, returned during T4T reader operation.