### PR TITLE
workflows: compliance: Disable BinaryFiles check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -76,7 +76,7 @@ jobs:
         git log --pretty=oneline | head -n 10
         # For now we run KconfigBasic, but we should transition to Kconfig
         $ZEPHYR_BASE/scripts/ci/check_compliance.py --annotate -e Kconfig \
-        -c origin/${BASE_REF}..
+        -e BinaryFiles -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
The new compliance BinaryFiles check fails when uploading certain binary files in sdk-nrf, particularly Visio files. Disable it for now until we can fix this properly.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>