### PR TITLE
caf: Clean up sensor manager files

### DIFF
--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/sensor_manager_def.h
@@ -16,7 +16,7 @@
 const struct {} sensor_manager_def_include_once;
 
 
-static const struct sm_sampled_channel accel_chan[] = {
+static const struct caf_sampled_channel accel_chan[] = {
 	{
 		.chan = SENSOR_CHAN_ACCEL_X,
 		.data_cnt = 1,

--- a/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/sensor_manager_def.h
@@ -16,7 +16,7 @@
 const struct {} sensor_manager_def_include_once;
 
 
-static const struct sm_sampled_channel accel_chan[] = {
+static const struct caf_sampled_channel accel_chan[] = {
 	{
 		.chan = SENSOR_CHAN_ACCEL_X,
 		.data_cnt = 1,

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/sensor_manager_def.h
@@ -31,7 +31,7 @@ static struct sm_trigger sensor_trigger = {
 	}
 };
 
-static const struct sm_sampled_channel accel_chan[] = {
+static const struct caf_sampled_channel accel_chan[] = {
 	{
 		.chan = SENSOR_CHAN_ACCEL_XYZ,
 		.data_cnt = 3,

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/sensor_manager_def.h
@@ -31,7 +31,7 @@ static struct sm_trigger sensor_trigger = {
 	}
 };
 
-static const struct sm_sampled_channel accel_chan[] = {
+static const struct caf_sampled_channel accel_chan[] = {
 	{
 		.chan = SENSOR_CHAN_ACCEL_XYZ,
 		.data_cnt = 3,

--- a/doc/nrf/libraries/caf/caf_overview.rst
+++ b/doc/nrf/libraries/caf/caf_overview.rst
@@ -220,6 +220,15 @@ CAF sensor events
    :project: nrf
    :members:
 
+CAF sensor common
+=================
+
+| Header file: :file:`include/caf/caf_sensor_common.h`
+
+.. doxygengroup:: caf_sensor_common
+   :project: nrf
+   :members:
+
 CAF sensor data aggregator events
 =================================
 

--- a/doc/nrf/libraries/caf/sensor_data_aggregator.rst
+++ b/doc/nrf/libraries/caf/sensor_data_aggregator.rst
@@ -48,7 +48,7 @@ Two aggregators are defined here and each one is responsible to handle data of t
 The aggregator is defined as a separate node in the devicetree and consists of the following parameters:
 
 * ``compatible`` - This is DTS binding and should be set to ``caf,aggregator``.
-* ``sensor_descr`` - This parameter represents the description of the sensor and should be the same as the description in the :ref:`caf_sensor_sampler`.
+* ``sensor_descr`` - This parameter represents the description of the sensor and should be the same as the description in the :ref:`caf_sensor_manager`.
 * ``buf_data_length`` - This parameter represents the length of the buffer in bytes.
   Its default value is ``120``.
   You should set the value as a multiple of sensor sample size times the size of :c:struct:`sensor_value` (``i*sample_size*sizeof(struct sensor_value)``).

--- a/doc/nrf/libraries/caf/sensor_manager.rst
+++ b/doc/nrf/libraries/caf/sensor_manager.rst
@@ -46,11 +46,11 @@ To use the module, you must complete the following requirements:
       * :c:member:`sm_sensor_config.event_descr` - Sensor event description.
         The event description is used to identify the sensor in the application.
       * :c:member:`sm_sensor_config.chans` - Channel configuration.
-        This is an array of :c:struct:`sm_sampled_channel` struct that configures the sensor channel with the following information:
+        This is an array of :c:struct:`caf_sampled_channel` struct that configures the sensor channel with the following information:
 
-        * :c:member:`sm_sampled_channel.chan` - Sensor channel.
+        * :c:member:`caf_sampled_channel.chan` - Sensor channel.
           Depends on the particular sensor.
-        * :c:member:`sm_sampled_channel.data_cnt` - Number of values in :c:member:`sm_sampled_channel.chan`.
+        * :c:member:`caf_sampled_channel.data_cnt` - Number of values in :c:member:`caf_sampled_channel.chan`.
 
       * :c:member:`sm_sensor_config.chan_cnt` - Size of the :c:member:`sm_sensor_config.chans` array.
       * :c:member:`sm_sensor_config.sampling_period_ms` - Sensor sampling period, in milliseconds.
@@ -61,7 +61,7 @@ To use the module, you must complete the following requirements:
       .. code-block:: c
 
          #include <caf/sensor_manager.h>
-         static const struct sm_sampled_channel accel_chan[] = {
+         static const struct caf_sampled_channel accel_chan[] = {
                  {
                          .chan = SENSOR_CHAN_ACCEL_XYZ,
                          .data_cnt = 3,
@@ -124,7 +124,7 @@ To use the sensor trigger, complete the following steps:
 
         #include <caf/sensor_manager.h>
 
-        static const struct sm_sampled_channel accel_chan[] = {
+        static const struct caf_sampled_channel accel_chan[] = {
                 {
                         .chan = SENSOR_CHAN_ACCEL_XYZ,
                         .data_cnt = 3,

--- a/doc/nrf/libraries/caf/sensor_manager.rst
+++ b/doc/nrf/libraries/caf/sensor_manager.rst
@@ -1,4 +1,3 @@
-.. _caf_sensor_sampler:
 .. _caf_sensor_manager:
 
 CAF: Sensor manager module

--- a/doc/nrf/releases/release-notes-1.7.0.rst
+++ b/doc/nrf/releases/release-notes-1.7.0.rst
@@ -325,7 +325,7 @@ Common Application Framework (CAF)
 
 * Added :ref:`caf_net_state`.
 * Added :ref:`caf_power_manager`.
-* Updated :ref:`caf_sensor_sampler` with a limit to the number of ``sensor_event`` events that it submits.
+* Updated :ref:`caf_sensor_manager` with a limit to the number of ``sensor_event`` events that it submits.
 
 Edge Impulse
 ------------

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -545,6 +545,11 @@ Common Application Framework (CAF)
 
   * :c:struct:`sensor_data_aggregator_event` now uses the :c:struct:`sensor_value` struct data buffer and carries a number of sensor values in a single sample, which is sufficient to describe data layout.
 
+* :ref:`caf_sensor_manager`:
+
+  * Clean up :file:`sensor_event.h` and :file:`sensor_manager.h` files.
+    Move unrelated declarations to a separate :file:`caf_sensor_common.h` file.
+
 Shell libraries
 ---------------
 

--- a/include/caf/caf_sensor_common.h
+++ b/include/caf/caf_sensor_common.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _CAF_SENSOR_COMMON_H_
+#define _CAF_SENSOR_COMMON_H_
+
+/**
+ * @file
+ * @defgroup caf_sensor_common CAF Sensor Common
+ * @{
+ * @brief CAF Sensor Common.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/drivers/sensor.h>
+
+
+/* This value has to be equal to fractional part of the sensor_value. */
+#define FLOAT_TO_SENSOR_VAL_CONST 1000000
+
+#define FLOAT_TO_SENSOR_VALUE(float_val)							\
+	{											\
+		.val1 = (int32_t)(float_val),							\
+		.val2 = (int32_t)(((float_val) - (int32_t)(float_val)) *			\
+						FLOAT_TO_SENSOR_VAL_CONST),			\
+	}
+
+/**
+ * @brief Description of single channel
+ *
+ * The description of the channel to do the measurement on.
+ */
+struct caf_sampled_channel {
+	/** @brief Channel identifier */
+	enum sensor_channel chan;
+	/** @brief Number of data samples in selected channel */
+	uint8_t data_cnt;
+};
+
+/**
+ * @brief Helper function for checking if one sensor_value is greater than the other.
+ *
+ * @param sensor_val1 First compered sensor value.
+ * @param sensor_val2 Second compered sensor value.
+ * @return True if sensor_val1 is greater than sensor_val2, false otherwise.
+ */
+static inline bool sensor_value_greater_then(struct sensor_value sensor_val1,
+					     struct sensor_value sensor_val2)
+{
+	return ((sensor_val1.val1 > sensor_val2.val1) ||
+		((sensor_val1.val1 == sensor_val2.val1) && (sensor_val1.val2 > sensor_val2.val2)));
+}
+
+/**
+ * @brief Helper function for calculating absolute value of difference of two sensor_values.
+ *
+ * @param sensor_val1 First sensor value.
+ * @param sensor_val2 Second sensor value.
+ * @return Absolute value of difference between sensor_val1 and sensor_val2.
+ */
+static inline struct sensor_value sensor_value_abs_difference(struct sensor_value sensor_val1,
+							      struct sensor_value sensor_val2)
+{
+	struct sensor_value result;
+
+	result.val1 = abs(sensor_val1.val1 - sensor_val2.val1);
+	result.val2 = abs(sensor_val1.val2 - sensor_val2.val2);
+	if (result.val2 > FLOAT_TO_SENSOR_VAL_CONST) {
+		result.val2 = result.val2 - FLOAT_TO_SENSOR_VAL_CONST;
+		result.val1++;
+	}
+	return result;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* _CAF_SENSOR_COMMON_H_ */

--- a/include/caf/events/sensor_event.h
+++ b/include/caf/events/sensor_event.h
@@ -23,8 +23,6 @@
 extern "C" {
 #endif
 
-/* This value has to be equal to fractional part of the sensor_value. */
-#define FLOAT_TO_SENSOR_VAL_CONST 1000000
 
 /** @brief Sensor states. */
 enum sensor_state {
@@ -137,41 +135,6 @@ static inline size_t sensor_event_get_data_cnt(const struct sensor_event *event)
 static inline struct sensor_value *sensor_event_get_data_ptr(const struct sensor_event *event)
 {
 	return (struct sensor_value *)event->dyndata.data;
-}
-
-/**
- * @brief Helper function for checking if one sensor_value is greater than the other.
- *
- * @param sensor_val1 First compered sensor value.
- * @param sensor_val2 Second compered sensor value.
- * @return True if sensor_val1 is greater than sensor_val2, false otherwise.
- */
-static inline bool sensor_value_greater_then(struct sensor_value sensor_val1,
-					     struct sensor_value sensor_val2)
-{
-	return ((sensor_val1.val1 > sensor_val2.val1) ||
-		((sensor_val1.val1 == sensor_val2.val1) && (sensor_val1.val2 > sensor_val2.val2)));
-}
-
-/**
- * @brief Helper function for calculating absolute value of difference of two sensor_values.
- *
- * @param sensor_val1 First sensor value.
- * @param sensor_val2 Second sensor value.
- * @return Absolute value of difference between sensor_val1 and sensor_val2.
- */
-static inline struct sensor_value sensor_value_abs_difference(struct sensor_value sensor_val1,
-							      struct sensor_value sensor_val2)
-{
-	struct sensor_value result;
-
-	result.val1 = abs(sensor_val1.val1 - sensor_val2.val1);
-	result.val2 = abs(sensor_val1.val2 - sensor_val2.val2);
-	if (result.val2 > FLOAT_TO_SENSOR_VAL_CONST) {
-		result.val2 = result.val2 - FLOAT_TO_SENSOR_VAL_CONST;
-		result.val1++;
-	}
-	return result;
 }
 
 #ifdef __cplusplus

--- a/include/caf/sensor_manager.h
+++ b/include/caf/sensor_manager.h
@@ -14,13 +14,8 @@ extern "C" {
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
 #include <caf/events/sensor_event.h>
+#include <caf/caf_sensor_common.h>
 
-#define FLOAT_TO_SENSOR_VALUE(float_val)							\
-	{											\
-		.val1 = (int32_t)(float_val),							\
-		.val2 = (int32_t)(((float_val) - (int32_t)(float_val)) *			\
-						FLOAT_TO_SENSOR_VAL_CONST),			\
-	}
 
 enum act_type {
 	ACT_TYPE_ABS,
@@ -35,18 +30,6 @@ struct sm_trigger_activation {
 struct sm_trigger {
 	struct sensor_trigger cfg;
 	struct sm_trigger_activation activation;
-};
-
-/**
- * @brief Description of single channel
- *
- * The description of the channel to do the measurement on.
- */
-struct sm_sampled_channel {
-	/** @brief Channel identifier */
-	enum sensor_channel chan;
-	/** @brief Number of data samples in selected channel */
-	uint8_t data_cnt;
 };
 
 /**
@@ -72,7 +55,7 @@ struct sm_sensor_config {
 	 *
 	 * Channels in the sensor that should be handled by sensor manager module
 	 */
-	const struct sm_sampled_channel *chans;
+	const struct caf_sampled_channel *chans;
 	/**
 	 * @brief Number of channels
 	 *

--- a/samples/caf_sensor_manager/configuration/sensor_manager_def.h
+++ b/samples/caf_sensor_manager/configuration/sensor_manager_def.h
@@ -16,7 +16,7 @@
 const struct {} sensor_manager_def_include_once;
 
 
-static const struct sm_sampled_channel accel_chan[] = {
+static const struct caf_sampled_channel accel_chan[] = {
 	{
 		.chan = SENSOR_CHAN_ACCEL_X,
 		.data_cnt = 1,

--- a/subsys/caf/events/Kconfig
+++ b/subsys/caf/events/Kconfig
@@ -114,27 +114,6 @@ config CAF_INIT_LOG_LED_READY_EVENTS
 	  Log LED events used to notify that LED is ready for next stream
 	  effect.
 
-config CAF_SENSOR_EVENTS
-	bool "Enable sensor events"
-	help
-	  Enable support for sensor events.
-
-config CAF_INIT_LOG_SENSOR_EVENTS
-	bool "Log sensor events"
-	depends on CAF_SENSOR_EVENTS
-	depends on LOG
-	default y
-	help
-	  Log sensor events, used to notify about sensor measured data.
-
-config CAF_INIT_LOG_SENSOR_STATE_EVENTS
-	bool "Log sensor state events"
-	depends on CAF_SENSOR_EVENTS
-	depends on LOG
-	default y
-	help
-	  Log sensor state events, used to notify about sensor state change.
-
 config CAF_NET_STATE_EVENTS
 	bool "Enable network state events"
 	help
@@ -153,5 +132,6 @@ rsource "Kconfig.force_power_down_event"
 rsource "Kconfig.keep_alive_event"
 rsource "Kconfig.module_state_event"
 rsource "Kconfig.power_manager_event"
+rsource "Kconfig.sensor_event"
 
 endmenu

--- a/subsys/caf/events/Kconfig.sensor_event
+++ b/subsys/caf/events/Kconfig.sensor_event
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config CAF_SENSOR_EVENTS
+	bool "Enable sensor events"
+	help
+	  Enable support for sensor events.
+
+config CAF_INIT_LOG_SENSOR_EVENTS
+	bool "Log sensor events"
+	depends on CAF_SENSOR_EVENTS
+	depends on LOG
+	default y
+	help
+	  Log sensor events, used to notify about sensor measured data.
+
+config CAF_INIT_LOG_SENSOR_STATE_EVENTS
+	bool "Log sensor state events"
+	depends on CAF_SENSOR_EVENTS
+	depends on LOG
+	default y
+	help
+	  Log sensor state events, used to notify about sensor state change.

--- a/subsys/caf/modules/sensor_manager.c
+++ b/subsys/caf/modules/sensor_manager.c
@@ -224,7 +224,7 @@ static void sample_sensor(struct sensor_data *sd, const struct sm_sensor_config 
 	int err = sensor_sample_fetch(sc->dev);
 
 	for (size_t i = 0; !err && (i < sc->chan_cnt); i++) {
-		const struct sm_sampled_channel *sampled_chan = &sc->chans[i];
+		const struct caf_sampled_channel *sampled_chan = &sc->chans[i];
 
 		err = sensor_channel_get(sc->dev, sampled_chan->chan, &data[data_idx]);
 		data_idx += sampled_chan->data_cnt;

--- a/tests/subsys/caf/sensor_manager/configuration/common/sensor_manager_def.h
+++ b/tests/subsys/caf/sensor_manager/configuration/common/sensor_manager_def.h
@@ -16,7 +16,7 @@
 const struct {} sensor_manager_def_include_once;
 
 
-static const struct sm_sampled_channel accel_chan[] = {
+static const struct caf_sampled_channel accel_chan[] = {
 	{
 		.chan = SENSOR_CHAN_ACCEL_X,
 		.data_cnt = 1,


### PR DESCRIPTION
Reorganize configuration files and move common declarations to a common file.

This is required for NCSDK-17492.

Signed-off-by: Emil Obalski <Emil.Obalski@nordicsemi.no>
Signed-off-by: Anna Wojdylo <Anna.Wojdylo@nordicsemi.no>