### PR TITLE
scripts: sbom: Add GN external project support for Matter

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -783,6 +783,7 @@ This section provides detailed lists of changes by :ref:`script <scripts>`.
 * :ref:`west_sbom`:
 
   * Updated so that the output contains source repository and version information for each file.
+  * The script now supports Matter because it has access to GN external projects and can get the source files from them.
 
 MCUboot
 =======

--- a/scripts/west_commands/sbom/README.rst
+++ b/scripts/west_commands/sbom/README.rst
@@ -123,6 +123,14 @@ You can also mix them, for example, to generate a report for the application and
 
   The :ref:`west_sbom Extracting from build` section describes in detail how to extract a list of files from a build directory.
 
+  You can use ``-d`` option multiple times.
+  For example, to include both the ``mcuboot`` child image and the main application, use the following command:
+
+  .. parsed-literal::
+     :class: highlight
+
+     west ncs-sbom -d *build* -d *build/mcuboot*
+
   .. note::
       All files that are not dependencies of the :file:`zephyr/zephyr.elf` target are not taken as an input.
       If you modify the :file:`.elf` file after the linking, the modifications are not applied.
@@ -367,3 +375,10 @@ There are two additional methods for improving the correctness of the above algo
      :class: highlight
 
      -d build_directory *target.elf*:*file.map*
+
+Integration with the GN meta-build system
+=========================================
+
+The ``ncs-sbom`` script reads a list of all commands needed to build provided targets.
+If there is a ``gn gen`` command, the script enters the command's build directory and tries to extract files from it using the same method as described earlier.
+The results are integrated with the main build directory results.

--- a/scripts/west_commands/sbom/args.py
+++ b/scripts/west_commands/sbom/args.py
@@ -45,6 +45,7 @@ git-info
 class ArgsClass:
     ''' Lists all command line arguments for better type hinting. '''
     _initialized: bool = False
+    _processed: bool = False
     # arguments added by west
     help: 'bool|None'
     zephyr_base: 'str|None'
@@ -66,6 +67,7 @@ class ArgsClass:
     ar: 'str|None'
     ninja: 'str|None'
     help_detectors: bool
+    debug_build_input_cache: 'str|None'
 
 
 def split_arg_list(text: str) -> 'list[str]':
@@ -116,7 +118,7 @@ def add_arguments(parser: argparse.ArgumentParser):
                              'detector')
     parser.add_argument('--allowed-in-map-file-only',
                         default='libgcc.a,'
-                                'libc_nano.a,libc++_nano.a,libm_nano.a,'
+                                'libc_nano.a,libc++_nano.a,libm_nano.a,libstdc++_nano.a,'
                                 'libc.a,libc++.a,libm.a',
                         help='Comma separated list of file names which can be detected in a map '
                              'file, but not visible in the build system. Usually, automatically '
@@ -137,6 +139,8 @@ def add_arguments(parser: argparse.ArgumentParser):
                              'By default, it will be automatically detected.')
     parser.add_argument('--help-detectors', action='store_true',
                         help='Show help for each available detector and exit.')
+    # Hidden arguments (for debug purposes only)
+    parser.add_argument('--debug-build-input-cache', default=None, help=argparse.SUPPRESS)
 
 
 def copy_arguments(source):
@@ -156,6 +160,10 @@ def init_args(allowed_detectors: dict):
                                          allow_abbrev=False)
         add_arguments(parser)
         copy_arguments(parser.parse_args())
+
+    if args._processed:
+        return
+    args._processed = True
 
     if args.help_detectors:
         print(DETECTORS_HELP)

--- a/scripts/west_commands/sbom/common.py
+++ b/scripts/west_commands/sbom/common.py
@@ -24,17 +24,17 @@ class SbomException(Exception):
 
 def command_execute(*cmd_args: 'tuple[str|Path]', cwd: 'str|Path|None' = None,
                     return_path: bool = False, allow_stderr: bool = False,
-                    return_error_code: bool = False) -> 'Path|str':
+                    return_error_code: bool = False, shell: bool = False) -> 'Path|str':
     '''Execute subprocess wrapper that handles errors and output redirections.'''
     cmd_args = tuple(str(x) for x in cmd_args)
     if cwd is not None:
         cwd = str(cwd)
-    with NamedTemporaryFile(delete=(not return_path), mode='w+') as out_file, \
-            NamedTemporaryFile(mode='w+') as err_file:
+    with NamedTemporaryFile(delete=(not return_path), mode='w+', encoding='8859') as out_file, \
+            NamedTemporaryFile(mode='w+', encoding='8859') as err_file:
         try:
             t = dbg_time(f'Starting {cmd_args} in {cwd or "current directory"}',
                          level=log.VERBOSE_VERY)
-            cp = subprocess.run(cmd_args, stdout=out_file, stderr=err_file, cwd=cwd)
+            cp = subprocess.run(cmd_args, stdout=out_file, stderr=err_file, cwd=cwd, shell=shell)
             log.dbg(f'Subprocess done in {t}s', level=log.VERBOSE_VERY)
         except Exception as e:
             log.err(f'Running command "{cmd_args[0]}" failed!')
@@ -74,7 +74,14 @@ def command_execute(*cmd_args: 'tuple[str|Path]', cwd: 'str|Path|None' = None,
 
 process_executor = None
 thread_executor = None
-executor_workers = None
+
+def get_executor_workers():
+    ''' Returns number of worker executors used in "concurrent_pool_iter". '''
+    from args import args
+    executor_workers = args.processes if args.processes > 0 else os.cpu_count()
+    if executor_workers is None or executor_workers < 1:
+        executor_workers = 1
+    return executor_workers
 
 
 def concurrent_pool_iter(func: Callable, iterable: Iterable, use_process: bool=False,
@@ -88,17 +95,13 @@ def concurrent_pool_iter(func: Callable, iterable: Iterable, use_process: bool=F
     @param use_process  Runs function on separate process when True, thread if False
     @param threshold    If number of elements in iterable is less than threshold, no parallel
                         threads or processes will be started.
-    @returns            Iterator over tuples cotaining: return value of func, input element, index
+    @returns            Iterator over tuples containing: return value of func, input element, index
                         of that element (starting from 0)
     '''
-    from args import args
-    global process_executor, thread_executor, executor_workers
+    global process_executor, thread_executor
     collected = iterable if isinstance(iterable, tuple) else tuple(iterable)
     if len(collected) >= threshold:
-        if executor_workers is None:
-            executor_workers = args.processes if args.processes > 0 else os.cpu_count()
-            if executor_workers is None or executor_workers < 1:
-                executor_workers = 1
+        executor_workers = get_executor_workers()
         if use_process:
             if process_executor is None:
                 process_executor = concurrent.futures.ProcessPoolExecutor(executor_workers)

--- a/scripts/west_commands/sbom/data/license-texts.yaml
+++ b/scripts/west_commands/sbom/data/license-texts.yaml
@@ -181,6 +181,18 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 
+- id: Apache-2.0
+  text: |
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
 - id: BSD-3-Clause
   text: |
     Redistribution and use in source and binary forms, with or without modification, are permitted
@@ -395,6 +407,44 @@
     a copy of the GCC Runtime Library Exception along with this program;
     see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
     <http://www.gnu.org/licenses/>
+
+- id: GPL-3.0-or-later WITH GCC-exception-3.1
+  text: |
+    This file is part of the GNU ISO C++ Library.  This library is free
+    software; you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the
+    Free Software Foundation; either version 3, or (at your option)
+    any later version.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    Under Section 7 of GPL version 3, you are granted additional
+    permissions described in the GCC Runtime Library Exception, version
+    3.1, as published by the Free Software Foundation.
+    You should have received a copy of the GNU General Public License and
+    a copy of the GCC Runtime Library Exception along with this program;
+    see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+    <http://www.gnu.org/licenses/>.
+
+- id: GPL-3.0-or-later WITH GCC-exception-3.1
+  text: |
+    This file is part of the GNU ISO C++ Library.  This library is free
+    software; you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the
+    Free Software Foundation; either version 3, or (at your option)
+    any later version.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    Under Section 7 of GPL version 3, you are granted additional
+    permissions described in the GCC Runtime Library Exception, version
+    3.1, as published by the, 2009 Free Software Foundation.
+    You should have received a copy of the GNU General Public License and
+    a copy of the GCC Runtime Library Exception along with this program;
+    see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+    <http://www.gnu.org/licenses/>.
 
 - id: ISC
   text: |

--- a/scripts/west_commands/sbom/input_build.py
+++ b/scripts/west_commands/sbom/input_build.py
@@ -8,362 +8,41 @@ Get input files from an application build directory.
 '''
 
 import os
+import pickle
+import platform
 import re
-from enum import Enum
+import shutil
 from pathlib import Path
-from types import SimpleNamespace
 from west import log, util
 from args import args
-from data_structure import Data, FileInfo
+from data_structure import Data, FileInfo, DataBaseClass
 from common import SbomException, command_execute
+from ninja_build_extractor import BuildArchive, NinjaBuildExtractor, BuildObject
 
 
 DEFAULT_BUILD_DIR = 'build'
 DEFAULT_TARGET = 'zephyr/zephyr.elf'
+DEFAULT_GN_TARGET = 'default'
+SOURCE_CODE_SUFFIXES = ['.c', '.cpp', '.cxx', '.cc', '.c++', '.s']
 
 
-class FileType(Enum):
-    '''Defines type of files that are significant for this module.'''
-    ARCHIVE = 'archive'
-    OBJ = 'obj'
-    OTHER = 'other'
-
-
-def detect_file_type(file: Path) -> FileType:
-    '''Simple detector for type of a file based on its header.'''
-    with open(file, 'r', encoding='8859') as fd:
-        header = fd.read(16)
-    if header.startswith('!<arch>\n'):
-        return FileType.ARCHIVE
-    elif header.startswith('\x7FELF'):
-        return FileType.OBJ
-    else:
-        return FileType.OTHER
-
-
-class InputBuild:
+class MapFileItem(DataBaseClass):
     '''
-    Class for extracting list of input files for a specific build direcory.
+    Holds information about a single entry extracted from a map file.
+    Attributes:
+        path        Path to linked an object file or a library.
+        optional    True if the entry is a linker stuff and don't have to be included in
+                    the report.
+        content     A dictionary with object file names contained in this library
+                    as keys. Values are initially False and they will be changed to True
+                    when the file is detected in the build system.
+        extracted   Initially False and it will be changed to True when the file is
+                    detected in the build system.
     '''
-
-    data: Data
-    build_dir: Path
-    deps: 'dict[set[str]]'
-
-
-    def __init__(self, data: Data, build_dir: Path):
-        '''
-        Initialize build directory input object that will fill "data" object and get
-        information from "build_dir".
-        '''
-        self.map_items = None
-        self.data = data
-        self.build_dir = Path(build_dir)
-        deps_file_name = command_execute(args.ninja, '-t', 'deps', cwd=self.build_dir,
-                                         return_path=True)
-        self.parse_deps_file(deps_file_name)
-
-
-    def parse_deps_file(self, deps_file_name: str):
-        '''
-        Reads all dependencies stored in the .ninja_deps file and sores it in self.deps dictionary.
-        '''
-        self.deps = dict()
-        target_line_re = re.compile(r'([^\s]+)\s*:\s*(#.*)?')
-        dep_line_re = re.compile(r'\s+(.*?)\s*(#.*)?')
-        empty_line_re = re.compile(r'\s*(#.*)?')
-        with open(deps_file_name, 'r') as fd:
-            line_no = 0
-            while True:
-                line = fd.readline()
-                line_no += 1
-                if len(line) == 0:
-                    break
-                line = line.rstrip()
-                m = target_line_re.fullmatch(line)
-                if m is not None:
-                    dep = set()
-                    self.deps[m.group(1)] = dep
-                    continue
-                m = dep_line_re.fullmatch(line)
-                if m is not None:
-                    dep.add(m.group(1))
-                    continue
-                m = empty_line_re.fullmatch(line)
-                if m is None:
-                    raise SbomException(f'Cannot parse ninja dependencies output '
-                                        f'"{deps_file_name}" on line {line_no}!')
-
-
-    def query_inputs(self, target: str) -> 'tuple[set[str], set[str], set[str], bool]':
-        '''
-        Parse output of "ninja -t query <target>" command to find out all input targets.
-        The result is a tuple containing:
-            - set of explicit inputs
-            - set of implicit inputs
-            - set of "order only" inputs
-            - bool set to True if provided target is a "phony" target
-        '''
-        lines = command_execute(args.ninja, '-t', 'query', target, cwd=self.build_dir)
-        ex_begin = f'Cannot parse output of "{args.ninja} -t query target" on line'
-        lines = lines.split('\n')
-        lines = tuple(filter(lambda line: len(line.strip()) > 0, lines))
-        line_no = 0
-        explicit = set()
-        implicit = set()
-        order_only = set()
-        phony = False
-        while line_no < len(lines):
-            m = re.fullmatch(r'\S.*:', lines[line_no])
-            if m is None:
-                raise SbomException(f'{ex_begin} {line_no + 1}. Expecting target.')
-            line_no += 1
-            while line_no < len(lines):
-                m = re.fullmatch(r'(\s*)(.*):(.*)', lines[line_no])
-                if m is None:
-                    raise SbomException(f'{ex_begin} {line_no + 1}. Expecting direction.')
-                if m.group(1) == '':
-                    break
-                line_no += 1
-                ind1 = len(m.group(1))
-                dir = m.group(2)
-                phony = phony or (re.search(r'(\s|^)phony(\s|$)', m.group(3)) is not None)
-                if dir == 'input':
-                    inputs = True
-                else:
-                    if dir != 'outputs':
-                        raise SbomException(f'{ex_begin} {line_no + 1}. Expecting "input:" '
-                                            f'or "outputs:".')
-                    inputs = False
-                while line_no < len(lines):
-                    m = re.fullmatch(r'(\s*)(\|?\|?)\s*(.*)', lines[line_no])
-                    if m is None:
-                        raise SbomException(f'{ex_begin} {line_no + 1}. Expecting {dir} target.')
-                    if len(m.group(1)) <= ind1:
-                        break
-                    line_no += 1
-                    target = str(m.group(3))
-                    if inputs:
-                        if m.group(2) == '':
-                            explicit.add(target)
-                        elif m.group(2) == '|':
-                            implicit.add(target)
-                        else:
-                            order_only.add(target)
-        return (explicit, implicit, order_only, phony)
-
-
-    def query_inputs_recursive(self, target: str, done: 'set|None' = None,
-                               inputs_tuple=None) -> 'set[str]':
-        '''
-        Reads recursively set of all input targets for specified "target".
-        Optional set "done" contains all targets that are already scanned. It will be updated.
-        If you have already result of query_inputs(target), then you can pass it
-        to "inputs_tuple" to avoid repeating time consuming operations.
-        '''
-        if done is None:
-            done = set()
-        if inputs_tuple is None:
-            explicit, implicit, _, _ = self.query_inputs(target)
-        else:
-            explicit, implicit, _, _ = inputs_tuple
-        inputs = explicit.union(implicit)
-        result = set()
-        for input in inputs:
-            file_path = (self.build_dir / input).resolve()
-            if input in done:
-                continue
-            done.add(input)
-            if file_path.exists():
-                result.add(input)
-            else:
-                sub_inputs_tuple = self.query_inputs(input)
-                phony = sub_inputs_tuple[3]
-                if not phony:
-                    raise SbomException(f'The input "{input}" does not exist or '
-                                        f'it is invalid build target.')
-                sub_result = self.query_inputs_recursive(input, done, sub_inputs_tuple)
-                result.update(sub_result)
-        return result
-
-
-    def read_file_list_from_map(self, map_file: Path) -> 'dict()':
-        '''
-        Parse map file for list of all linked files. The returned dict has absolute resolved path
-        as key and value is a SimpleNamespace. It contains:
-            - path: Path      - Path to linked an object file or a library
-            - optional: bool  - True if the entry is a linker stuff and don't have
-                                to be included in the report
-            - content: dict() - A dictionary with object file names contained in this library
-                                as keys. Value is always False, it will be changed to True when
-                                the file is extracted from the build system.
-            - extracted: bool - Always False. It will be changed to True when the file is extracted
-                                from the build system.
-        '''
-        with open(map_file, 'r') as fd:
-            map_content = fd.read()
-        items = dict()
-        file_entry_re = (r'^(?:[ \t]+\.[^\s]+(?:\r?\n)?[ \t]+0x[0-9a-fA-F]{16}[ \t]+'
-                         r'0x[0-9a-fA-F]+|LOAD)[ \t]+(.*?)(?:\((.*)\))?$')
-        linker_stuff_re = r'(?:\s+|^)linker\s+|\s+linker(?:\s+|$)'
-        for match in re.finditer(file_entry_re, map_content, re.M):
-            file = match.group(1)
-            file_path = (self.build_dir / file).resolve()
-            if str(file_path) not in items:
-                exists = file_path.is_file()
-                possibly_linker = (match.group(2) is None and
-                                   re.search(linker_stuff_re, file, re.I) is not None)
-                if (not exists) and (not possibly_linker):
-                    raise SbomException(f'The input file {file}, extracted from a map file, '
-                                        f'does not exists.')
-                content = dict()
-                item = SimpleNamespace(
-                    path=file_path,
-                    optional=(not exists) and possibly_linker,
-                    content=content,
-                    extracted=False)
-                items[str(file_path)] = item
-            else:
-                item = items[str(file_path)]
-                content = item.content
-            if match.group(2) is not None:
-                file = Path(match.group(2)).name
-                content[file] = False
-        return items
-
-
-    @staticmethod
-    def verify_archive_inputs(archive_path: Path, inputs: 'set(str)') -> bool:
-        '''
-        Checks if every file from the library "archive_path" is in the set of "inputs" targets.
-        '''
-        arch_files = command_execute(args.ar, '-t', archive_path)
-        arch_files = arch_files.split('\n')
-        arch_files = (f.strip().replace('/', os.sep).replace('\\', os.sep).strip(os.sep)
-                      for f in arch_files)
-        arch_files = filter(lambda file: len(file.strip()) > 0, arch_files)
-        for arch_file in arch_files:
-            for input in inputs:
-                if input == arch_file:
-                    break
-                if input.endswith(os.sep + arch_file):
-                    break
-            else:
-                return False
-        return True
-
-
-    def process_archive(self, archive_path: Path, archive_target: str) -> 'set(Path)':
-        '''
-        Return set of dependencies of the "archive_target" target which is a library
-        file at "archive_path". Return "archive_path" if we cannot find any dependencies.
-        It also checks if list of direct dependencies is the same as extracted from
-        the library using "ar" tool. It marks this file and its content at the list
-        from map file as extracted.
-        '''
-        if str(archive_path) in self.map_items:
-            map_item = self.map_items[str(archive_path)]
-            map_item.extracted = True
-        else:
-            log.wrn(f'Target depends on archive "{archive_path}", but it is not in a map file.')
-            map_item = None
-        archive_inputs = self.query_inputs_recursive(archive_target)
-        if not self.verify_archive_inputs(archive_path, archive_inputs):
-            if map_item is not None:
-                map_item.content = dict()
-            return {archive_path}
-        leafs = set()
-        for input in archive_inputs:
-            input_path = (self.build_dir / input).resolve()
-            input_type = detect_file_type(input_path)
-            if map_item is not None:
-                if input_path.name in map_item.content:
-                    map_item.content[input_path.name] = True
-            if input_type == FileType.OTHER:
-                leafs.add(input_path)
-            else:
-                if input_type != FileType.OBJ:
-                    raise SbomException(f'File "{input_path}" contained in "{archive_path}" is '
-                                        f'not an object file.')
-                leafs.update(self.process_obj(input_path, input))
-        return leafs
-
-
-    def process_obj(self, input_path: Path, input_target: str) -> 'set(Path)':
-        '''
-        Return set of dependencies of the "input_target" target which is a object
-        file at "input_path". Return "input_path" if we cannot find any dependencies.
-        '''
-        if input_target not in self.deps:
-            return {input_path}
-        deps = self.deps[input_target]
-        deps = deps.union(self.query_inputs_recursive(input_target))
-        return set((self.build_dir / x).resolve() for x in deps)
-
-
-    def generate_from_target(self, target: str):
-        '''
-        Generate list of files from a build directory used to create a specific target (elf file).
-        The 'target' parameter can contains ':' followed by the custom map file path.
-        Also, verifies that list from a map file is fully covered by the build system.
-        '''
-        if target.find(':') >= 0:
-            pos = target.find(':')
-            map_file = self.build_dir / target[(pos + 1):]
-            target = target[:pos]
-        else:
-            map_file = (self.build_dir / target).with_suffix('.map')
-
-        if not map_file.exists():
-            raise SbomException(f'Cannot find map file for "{target}" '
-                                f'in build directory "{self.build_dir}". '
-                                f'Expected location "{map_file}".')
-        log.dbg(f'Map file: {map_file}')
-
-        self.map_items = self.read_file_list_from_map(map_file)
-
-        self.data.inputs.append(f'The "{target}" file from the build directory '
-                                f'"{self.build_dir.resolve()}"')
-        elf_inputs = self.query_inputs_recursive(target)
-        leafs = set()
-        for input in elf_inputs:
-            input_path = (self.build_dir / input).resolve()
-            input_type = detect_file_type(input_path)
-            if input_type == FileType.ARCHIVE:
-                leafs.update(self.process_archive(input_path, input))
-            else:
-                if str(input_path) in self.map_items:
-                    item = self.map_items[str(input_path)]
-                    item.extracted = True
-                    item.content = dict()
-                if input_type == FileType.OBJ:
-                    leafs.update(self.process_obj(input_path, input))
-                else:
-                    leafs.add(input_path)
-
-        valid = True
-        for name, item in self.map_items.items():
-            if item.path.name in args.allowed_in_map_file_only:
-                leafs.add(item.path)
-                item.extracted = True
-                item.content = dict()
-            if (not item.extracted) and (not item.optional):
-                valid = False
-                log.err(f'Input "{name}", extracted from a map file, is not detected in a '
-                        f'build system.')
-            for file, value in item.content.items():
-                if not value:
-                    valid = False
-                    log.err(f'File "{file}" from "{name}", extracted from a map file, '
-                            f'is not detected in a build system.')
-        if not valid:
-            raise SbomException('Detected differences between a map file and a build system.')
-
-        for leaf in leafs:
-            file = FileInfo()
-            file.file_path = leaf
-            file.file_rel_path = Path(os.path.relpath(leaf, util.west_topdir()))
-            self.data.files.append(file)
+    path: Path = Path()
+    optional: bool = False
+    content: 'dict[str, bool]' = {}
+    extracted: bool = False
 
 
 def check_external_tools(build_dir: Path):
@@ -410,13 +89,415 @@ def check_external_tools(build_dir: Path):
 
 
 def get_default_build_dir() -> 'str|None':
-    '''Returns default build directory if exists.'''
+    '''
+    Returns default build directory if exists.
+    '''
     default_build_dir = Path(DEFAULT_BUILD_DIR).resolve()
     default_target = default_build_dir / DEFAULT_TARGET
     if default_build_dir.exists() and default_target.exists():
         return DEFAULT_BUILD_DIR
     else:
         return None
+
+
+class ExternalToolDetector:
+    '''
+    Detects external build tools used in the project.
+    Commonly they are added as CMake's ExternalProject.
+    So far, only GN is detected.
+    '''
+
+    GN_MATCHER_RE = re.compile(r'(^|\/|\\)gn(\.exe|\.bat|\.cmd|\.py)?"?$')
+    ARGS_MATCHER = re.compile(r'(?:[\'"](?:\\.|.)*?[\'"]|[^\s])+')
+
+    gn_build_directories: 'set[str]'
+
+
+    def __init__(self):
+        '''
+        Initialize this instance with empty results.
+        '''
+        self.gn_build_directories = set()
+
+
+    def parse_gn_command(self, command: str, current_dir: str):
+        '''
+        Minimalists GN command parser that extracts directory for the "gn gen" command.
+        '''
+        gn_args :'list[str]' = []
+        for arg in self.ARGS_MATCHER.finditer(command):
+            arg = arg.group(0).strip('"\'')
+            if arg.startswith('-'):
+                continue
+            gn_args.append(arg)
+        if len(gn_args) > 1 and gn_args[1].lower() == 'gen':
+            gn_build_dir = '.'
+            if len(gn_args) > 2:
+                gn_build_dir = gn_args[2]
+            gn_path = (Path(current_dir) / gn_build_dir).resolve()
+            self.gn_build_directories.add(str(gn_path))
+
+
+    def parse_command(self, command: str, current_dir: str):
+        '''
+        Parse a single command to check if it is a GN command.
+        '''
+        parts = command.split(' ')
+        cmd = parts[0].strip()
+        if self.GN_MATCHER_RE.search(cmd) is not None:
+            self.parse_gn_command(command, current_dir)
+
+
+    def detect(self, target: str, build_dir: str):
+        '''
+        Detects known external tools used in the build. Results will be added to the
+        "gn_build_directories" property. Detection is based on "ninja -t commands" output
+        that lists all the commands executed to fully build the target.
+        '''
+        lines : str = command_execute(args.ninja, '-t', 'commands', target, cwd=build_dir)
+        for line in lines.split('\n'):
+            current_dir = build_dir
+            if re.match(r'cmd(\.exe)?\s+\/C\s+', line, re.IGNORECASE):
+                line = re.sub(r'^cmd(?:\.exe)?\s+\/C\s+(?:"(.+)"|(.+))$', r'\1\2', line, 0, re.IGNORECASE)
+            commands = line.split(' && ')
+            for command in commands:
+                command = command.strip()
+                if command.startswith('cd '):
+                    if platform.system() == 'Windows':
+                        out = command_execute(shutil.which('cmd.exe'), '/C', f'{command} && cd', cwd=current_dir)
+                    else:
+                        out = command_execute(f'{command} && pwd', shell=True, cwd=current_dir)
+                    for out_line in out.split('\n'):
+                        out_line = out_line.strip()
+                        if out_line != '':
+                            current_dir = out_line
+                else:
+                    self.parse_command(command, current_dir)
+
+
+class InputBuild:
+    '''
+    Class for extracting list of input files for a specific build directory.
+    '''
+
+    data: 'Data | None'
+    build_dir: Path
+
+
+    def __init__(self, data: 'Data | None', build_dir: Path):
+        '''
+        Initialize build directory input object that will fill "data" object and get
+        information from "build_dir".
+        '''
+        self.data = data
+        self.build_dir = Path(build_dir)
+
+
+    def read_file_list_from_map(self, map_file: Path,
+                                items: 'dict[str, MapFileItem]|None' = None
+                                ) -> 'dict[str, MapFileItem]':
+        '''
+        Parse map file for list of all linked files. The returned dict has absolute resolved path
+        as key and value is a MapFileItem.
+        '''
+        with open(map_file, 'r') as fd:
+            map_content = fd.read()
+        if items is None:
+            items = dict()
+        file_entry_re = (r'^(?:[ \t]+\.[^\s]+(?:\r?\n)?[ \t]+0x[0-9a-fA-F]{16}[ \t]+'
+                         r'0x[0-9a-fA-F]+|LOAD)[ \t]+(.*?)(?:\((.*)\))?$')
+        linker_stuff_re = r'(?:\s+|^)linker\s+|\s+linker(?:\s+|$)'
+        for match in re.finditer(file_entry_re, map_content, re.M):
+            file = match.group(1)
+            file_path = (self.build_dir / file).resolve()
+            if str(file_path) not in items:
+                exists = file_path.is_file()
+                possibly_linker = (match.group(2) is None and
+                                   re.search(linker_stuff_re, file, re.I) is not None)
+                if (not exists) and (not possibly_linker):
+                    raise SbomException(f'The input file {file}, extracted from a map file, '
+                                        f'does not exists.')
+                content = dict()
+                item = MapFileItem()
+                item.path = file_path
+                item.optional = possibly_linker and not exists
+                item.content = content
+                items[str(file_path)] = item
+            else:
+                item = items[str(file_path)]
+                content = item.content
+            if match.group(2) is not None:
+                file = Path(match.group(2)).name
+                content[file] = False
+        return items
+
+
+    def mark_map_archive(self, map_item: MapFileItem, archive: BuildArchive, visited: set = None):
+        '''
+        Mark entries in "map_item.content" that are in the "archive".
+        '''
+        file_names: 'set[str]' = set()
+        if visited is None:
+            visited = set()
+        for source in archive.sources.values():
+            file_names.add(source.name.lower())
+        for obj in archive.objects.values():
+            file_names.add(obj.path.name.lower())
+            for source in obj.sources.values():
+                file_names.add(source.name.lower())
+        for archive_entry in map_item.content.keys():
+            entry_name = Path(archive_entry).name.lower()
+            if entry_name in file_names:
+                map_item.content[archive_entry] = True
+        for sub in archive.archives.values():
+            if sub not in visited:
+                visited.add(sub)
+                self.mark_map_archive(map_item, sub, visited)
+
+
+    @staticmethod
+    def mark_map_sources(map_items: 'dict[str, MapFileItem]', sources: 'dict[str, Path]'):
+        '''
+        Mark map items that are in the sources dictionary.
+        '''
+        for source in sources.values():
+            path_str = str(source)
+            if path_str in map_items:
+                map_items[path_str].extracted = True
+
+
+    def mark_map_objects(self, map_items: 'dict[str, MapFileItem]', objects: 'dict[str, BuildObject]'):
+        '''
+        Mark map items that are in the objects dictionary and its sources.
+        '''
+        for obj in objects.values():
+            self.mark_map_sources(map_items, obj.sources)
+            path_str = str(obj.path)
+            if path_str in map_items:
+                map_items[path_str].extracted = True
+
+
+    def validate_with_map_files(self, inputs: 'list[BuildArchive]', maps: 'list[str]'):
+        '''
+        Read linked files from a map files and validate if all needed files are
+        correctly detected in the "inputs" parameter.
+        '''
+        map_items: 'dict[str, MapFileItem]' = dict()
+
+        for map_file in maps:
+            self.read_file_list_from_map(map_file, map_items)
+
+        for input in inputs:
+            for archive in input.archives.values():
+                if str(archive.path) in map_items:
+                    map_items[str(archive.path)].extracted = True
+                    self.mark_map_archive(map_items[str(archive.path)], archive)
+                self.mark_map_sources(map_items, archive.sources)
+                self.mark_map_objects(map_items, archive.objects)
+            self.mark_map_sources(map_items, input.sources)
+            self.mark_map_objects(map_items, input.objects)
+
+        for map_item in map_items.values():
+            content_extacted = (len(map_item.content) > 0)
+            for extracted in map_item.content.values():
+                if not extracted:
+                    content_extacted = False
+                    break
+            extracted = content_extacted or map_item.extracted
+            if (not extracted) and (not map_item.optional):
+                if map_item.path.name in args.allowed_in_map_file_only:
+                    input = BuildArchive()
+                    input.sources[str(map_item.path.name)] = map_item.path
+                    inputs.append(input)
+                else:
+                    raise SbomException(f'Input "{map_item.path}", extracted from a map file, '
+                                        'is not detected in a build system.')
+            if map_item.extracted and (not content_extacted) and (len(map_item.content) > 0):
+                for input in inputs:
+                    for archive in input.archives.values():
+                        if archive.path == map_item.path:
+                            archive.is_leaf = True
+
+
+    def all_deps_of_archive(self, archive: BuildArchive, visited: set = None) -> 'set[Path]':
+        '''
+        Recursively scans the archive and returns a list of all dependencies.
+        '''
+        if visited is None:
+            visited = set()
+        all_deps: 'set[Path]' = set(archive.sources.values())
+        for obj in archive.objects.values():
+            all_deps.add(obj.path)
+            all_deps.update(obj.sources.values())
+        for sub in archive.archives.values():
+            if sub not in visited:
+                visited.add(sub)
+                all_deps.update(self.all_deps_of_archive(sub, visited))
+        return all_deps
+
+
+    def check_archive_with_ar(self, archive: BuildArchive):
+        '''
+        Checks if every file in archive is correctly extracted using the "ar" tool.
+        '''
+        all_deps = set(map(lambda path: path.name, self.all_deps_of_archive(archive)))
+        arch_files = command_execute(args.ar, '-t', str(archive.path))
+        arch_files = arch_files.split('\n')
+        arch_files = (f.strip().replace('/', os.sep).replace('\\', os.sep).strip(os.sep)
+                      for f in arch_files)
+        arch_files = filter(lambda file: len(file.strip()) > 0, arch_files)
+        for arch_file in arch_files:
+            if arch_file not in all_deps:
+                log.dbg(f'Cannot find "{arch_file}" in dependencies of "{archive.path}"')
+                return False
+        return True
+
+
+    def validate_with_ar(self, inputs: 'list[BuildArchive]'):
+        '''
+        Read list of object files from each archive from "inputs" parameter and compare
+        the list with files detected in the build system. If list does not match
+        mark a library as a leaf, so it will be listed directly in the report instead of
+        its contents.
+        '''
+        for input in inputs:
+            for archive in input.archives.values():
+                archive.is_leaf = not self.check_archive_with_ar(archive)
+
+
+    def add_file_info(self, path: Path):
+        '''
+        Add output file information using given path.
+        If file is empty and it is not a source code, ignore it.
+        '''
+        if (path.stat().st_size > 0) or (path.suffix.lower() in SOURCE_CODE_SUFFIXES):
+            file = FileInfo()
+            file.file_path = path
+            file.file_rel_path = Path(os.path.relpath(path, util.west_topdir()))
+            self.data.files.append(file)
+
+
+    def add_object_info(self, obj: BuildObject):
+        '''
+        Add output object file information using from "obj". If the object file has
+        the sources, they will be added instead of the object file.
+        '''
+        any_source = False
+        for source in obj.sources.values():
+            self.add_file_info(source)
+            any_source = any_source or (source.suffix.lower() in SOURCE_CODE_SUFFIXES)
+        if not any_source:
+            self.add_file_info(obj.path)
+
+
+    @staticmethod
+    def merge_inputs(inputs: 'list[BuildArchive]'):
+        '''
+        Merges all archives from "inputs" parameter that are referring the same file.
+        '''
+        archives = {}
+        for input in inputs:
+            for archive_target in list(input.archives.keys()):
+                archive = input.archives[archive_target]
+                if archive.path in archives:
+                    dst = archives[archive.path]
+                    archive.merged_with = dst
+                    dst.archives.update(archive.archives)
+                    dst.objects.update(archive.objects)
+                    dst.sources.update(archive.sources)
+                    del input.archives[archive_target]
+                else:
+                    archives[archive.path] = archive
+        def update_dict(archive: BuildArchive, visited: set):
+            for key in list(archive.archives.keys()):
+                sub = archive.archives[key]
+                if hasattr(sub, 'merged_with'):
+                    archive.archives[key] = sub.merged_with
+                if sub not in visited:
+                    visited.add(sub)
+                    update_dict(sub, visited)
+        visited = set()
+        for input in inputs:
+            update_dict(input, visited)
+
+
+    def generate(self, targets_with_maps: 'list[str]'):
+        '''
+        Generate a list of files from specified targets. Targets can optionally have a map
+        file name after the ':' sign.
+        '''
+        # Prepare list of targets and associated map files.
+        targets = []
+        maps = []
+        for target_with_map in targets_with_maps:
+            if target_with_map.find(':') >= 0:
+                pos = target_with_map.find(':')
+                map_file = self.build_dir / target_with_map[(pos + 1):]
+                target = target_with_map[:pos]
+            else:
+                map_file = (self.build_dir / target_with_map).with_suffix('.map')
+                target = target_with_map
+
+            if not map_file.exists():
+                raise SbomException(f'Cannot find map file for "{target_with_map}" '
+                                    f'in build directory "{self.build_dir}". '
+                                    f'Expected location "{map_file}".')
+            log.dbg(f'Map file {map_file} for target "{target}"')
+            targets.append(target)
+            maps.append(map_file)
+            self.data.inputs.append(f'The "{target}" file from the build directory '
+                                    f'"{self.build_dir.resolve()}"')
+
+        # Detect external tools
+        ext_detector = ExternalToolDetector()
+        for target in targets:
+            ext_detector.detect(target, self.build_dir)
+
+        inputs: 'list[BuildArchive]' = []
+
+        # Load list of files from a cache file (debug purposes only)
+        if args.debug_build_input_cache is not None:
+            try:
+                with open(args.debug_build_input_cache, 'rb') as f:
+                    inputs = pickle.load(f)
+            except: # pylint: disable=bare-except
+                # This is a hidden debug-only option, so we can ignore all exceptions
+                pass
+
+        # Extract list of files with the NinjaBuildExtractor
+        if len(inputs) == 0:
+            log.dbg(f'Extracting files from root build directory "{self.build_dir}"')
+            root_extractor = NinjaBuildExtractor(self.build_dir)
+            inputs.append(root_extractor.extract(targets))
+            for directory in ext_detector.gn_build_directories:
+                log.dbg(f'Extracting files from GN build directory "{directory}"')
+                gn_extractor = NinjaBuildExtractor(directory, True)
+                inputs.append(gn_extractor.extract([DEFAULT_GN_TARGET]))
+            # Save list of files to a cache file (debug purposes only)
+            if args.debug_build_input_cache is not None:
+                with open(args.debug_build_input_cache, 'wb') as f:
+                    pickle.dump(inputs, f)
+
+        self.merge_inputs(inputs)
+
+        # Do additional validation
+        self.validate_with_ar(inputs)
+        self.validate_with_map_files(inputs, maps)
+
+        # Pass extracted and validated files as an SBOM input files.
+        for input in inputs:
+            for archive in input.archives.values():
+                if archive.is_leaf:
+                    self.add_file_info(archive.path)
+                else:
+                    for source in archive.sources.values():
+                        self.add_file_info(source)
+                    for obj in archive.objects.values():
+                        self.add_object_info(obj)
+            for source in input.sources.values():
+                self.add_file_info(source)
+            for obj in input.objects.values():
+                self.add_object_info(obj)
 
 
 def generate_input(data: Data):
@@ -431,5 +512,4 @@ def generate_input(data: Data):
                 targets = [DEFAULT_TARGET]
             log.dbg(f'INPUT: build directory: {build_dir}, targets: {targets}')
             b = InputBuild(data, build_dir)
-            for target in targets:
-                b.generate_from_target(target)
+            b.generate(targets)

--- a/scripts/west_commands/sbom/ninja_build_extractor.py
+++ b/scripts/west_commands/sbom/ninja_build_extractor.py
@@ -1,0 +1,444 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+'''
+Get input files from an application build directory.
+'''
+
+import re
+import time
+from enum import Enum
+from pathlib import Path
+from threading import Lock
+from west import log
+from args import args
+from data_structure import DataBaseClass
+from common import SbomException, command_execute, concurrent_pool_iter, get_executor_workers
+
+
+COMMAND_LINE_MAX_SIZE = 7000 # Size of command line parameters in Windows is limited.
+
+
+class BuildObject(DataBaseClass):
+    '''
+    Holds information about a single object file.
+    (internal) Special instance of this class with `path` set to `None` is a placeholder
+    for all source files that are not inside any particular object file.
+    '''
+    path: 'Path | None' = None
+    parent: 'BuildArchive'
+    sources: 'dict[str, Path]' = {}
+
+
+class BuildArchive(DataBaseClass):
+    '''
+    Holds information about a single archive file (library).
+    Special instance of this class with `path` set to `None` is a build
+    root that contains all source and object files that are not inside
+    any particular archive and ALL archive files.
+    (internal) The `objects` dictionary item with key "" (empty string) is a placeholder
+    for all source files that are not inside any particular object file.
+    '''
+    path: 'Path | None' = None
+    archives: 'dict[str, BuildArchive]' = {}
+    objects: 'dict[str, BuildObject]' = {}
+    sources: 'dict[str, Path]' = {}
+
+
+class FileType(Enum):
+    '''Defines type of files that are significant for this module.'''
+    ARCHIVE = 'archive'
+    OBJ = 'obj'
+    STAMP = 'stamp'
+    MISSING = 'missing'
+    OTHER = 'other'
+
+
+class NinjaBuildExtractor:
+    '''
+    Class for extracting list of input files for a specific ninja build direcory.
+    '''
+
+    build_dir: Path
+    include_order_only: bool
+    deps: 'dict[set[str]]'
+
+    archives: 'list[BuildArchive]'
+    process_target_queue: 'list[tuple[str, BuildObject, BuildArchive]]'
+    cache: 'dict[str, set[str]]'
+    query_cache: 'dict[str, tuple[set[str], set[str], set[str], bool]]'
+    file_type_cache: 'dict[str, FileType]'
+    lock: Lock
+    target_details: 'dict[str, tuple[Path, FileType]]'
+    root: BuildArchive
+    archives: 'list[BuildArchive]'
+
+
+    def __init__(self, build_dir: Path, include_order_only=False):
+        '''
+        Initialize build directory input object that will fill "data" object and get
+        information from "build_dir".
+        '''
+        self.process_target_queue = list()
+        self.cache = dict()
+        self.query_cache = dict()
+        self.file_type_cache = dict()
+        self.build_dir = Path(build_dir)
+        self.include_order_only = include_order_only
+        self.lock = Lock()
+        self.target_details = dict()
+        self.root = BuildArchive()
+        self.root.path = None
+        dummy_object = BuildObject()
+        dummy_object.parent = self.root
+        self.root.objects[''] = dummy_object
+        self.archives = []
+        deps_file_name = command_execute(args.ninja, '-t', 'deps', cwd=self.build_dir,
+                                         return_path=True)
+        self.parse_deps_file(deps_file_name)
+
+
+    def detect_file_type(self, file: Path) -> FileType:
+        '''
+        Simple detector for type of a file based on its header.
+        '''
+        str_file_name = str(file)
+        if str_file_name in self.file_type_cache:
+            return self.file_type_cache[str_file_name]
+        if not file.exists():
+            self.file_type_cache[str_file_name] = FileType.MISSING
+            return FileType.MISSING
+        with open(file, 'r', encoding='8859') as fd:
+            header = fd.read(16)
+        if header.startswith('!<arch>\n'):
+            self.file_type_cache[str_file_name] = FileType.ARCHIVE
+            return FileType.ARCHIVE
+        elif header.startswith('\x7FELF'):
+            self.file_type_cache[str_file_name] = FileType.OBJ
+            return FileType.OBJ
+        elif file.suffix.lower() == '.stamp':
+            self.file_type_cache[str_file_name] = FileType.STAMP
+            return FileType.STAMP
+        else:
+            self.file_type_cache[str_file_name] = FileType.OTHER
+            return FileType.OTHER
+
+
+    def parse_deps_file(self, deps_file_name: str):
+        '''
+        Reads all dependencies stored in the .ninja_deps file and sores it in self.deps dictionary.
+        '''
+        self.deps = dict()
+        target_line_re = re.compile(r'([^\s]+)\s*:\s*(#.*)?')
+        dep_line_re = re.compile(r'\s+(.*?)\s*(#.*)?')
+        empty_line_re = re.compile(r'\s*(#.*)?')
+        with open(deps_file_name, 'r') as fd:
+            line_no = 0
+            while True:
+                line = fd.readline()
+                line_no += 1
+                if len(line) == 0:
+                    break
+                line = line.rstrip()
+                m = target_line_re.fullmatch(line)
+                if m is not None:
+                    dep = set()
+                    self.deps[m.group(1)] = dep
+                    continue
+                m = dep_line_re.fullmatch(line)
+                if m is not None:
+                    dep.add(m.group(1))
+                    continue
+                m = empty_line_re.fullmatch(line)
+                if m is None:
+                    raise SbomException(f'Cannot parse ninja dependencies output '
+                                        f'"{deps_file_name}" on line {line_no}!')
+
+
+    def prefetch_query_inputs(self, targets: 'list[str]'):
+        '''
+        Execute "ninja -t query <targets...>" and cache multiple targets to speed up
+        future queries. Querying for multiple targets at once is much faster than one at a time.
+        '''
+        query_args = [args.ninja, '-t', 'query']
+        query_len = len(' '.join(query_args))
+        for i in range(len(targets)): # pylint: disable=consider-using-enumerate
+            query_args.append(targets[i])
+            query_len += len(targets[i]) + 1
+            if (i == len(targets) - 1) or (query_len >= COMMAND_LINE_MAX_SIZE):
+                self.lock.release()
+                try:
+                    lines = command_execute(*query_args, cwd=self.build_dir)
+                finally:
+                    self.lock.acquire()
+                self.parse_query_output(lines)
+                query_args = [args.ninja, '-t', 'query']
+                query_len = len(' '.join(query_args))
+
+
+    def query_inputs(self, target: str) -> 'tuple[set[str], set[str], set[str], bool]':
+        '''
+        Parse output of "ninja -t query <target>" command to find out all input targets.
+        The result is a tuple containing:
+            - set of explicit inputs
+            - set of implicit inputs
+            - set of "order only" inputs
+            - bool set to True if provided target is a "phony" target
+        '''
+        if target in self.query_cache:
+            return self.query_cache[target]
+        self.lock.release()
+        try:
+            lines = command_execute(args.ninja, '-t', 'query', target, cwd=self.build_dir)
+        finally:
+            self.lock.acquire()
+        self.parse_query_output(lines)
+        if target not in self.query_cache:
+            raise SbomException(f'Invalid output of "{args.ninja} -t query"')
+        return self.query_cache[target]
+
+
+    def parse_query_output(self, lines: 'list[str]'):
+        ex_begin = f'Cannot parse output of "{args.ninja} -t query" on line'
+        lines = lines.split('\n')
+        lines = tuple(filter(lambda line: len(line.strip()) > 0, lines))
+        line_no = 0
+        while line_no < len(lines):
+            m = re.fullmatch(r'(\S.*)\s*:', lines[line_no])
+            if m is None:
+                raise SbomException(f'{ex_begin} {line_no + 1}. Expecting target.')
+            target = m.group(1)
+            explicit = set()
+            implicit = set()
+            order_only = set()
+            phony = False
+            line_no += 1
+            while line_no < len(lines):
+                m = re.fullmatch(r'(\s*)(.*):(.*)', lines[line_no])
+                if m is None:
+                    raise SbomException(f'{ex_begin} {line_no + 1}. Expecting direction.')
+                if m.group(1) == '':
+                    break
+                line_no += 1
+                ind1 = len(m.group(1))
+                dir = m.group(2)
+                phony = phony or (re.search(r'(\s|^)phony(\s|$)', m.group(3)) is not None)
+                if dir == 'input':
+                    inputs = True
+                else:
+                    if dir != 'outputs':
+                        raise SbomException(f'{ex_begin} {line_no + 1}. Expecting "input:" '
+                                            f'or "outputs:".')
+                    inputs = False
+                while line_no < len(lines):
+                    m = re.fullmatch(r'(\s*)(\|?\|?)\s*(.*)', lines[line_no])
+                    if m is None:
+                        raise SbomException(f'{ex_begin} {line_no + 1}. Expecting {dir} target.')
+                    if len(m.group(1)) <= ind1:
+                        break
+                    line_no += 1
+                    input_target = str(m.group(3))
+                    if inputs:
+                        if m.group(2) == '':
+                            explicit.add(input_target)
+                        elif m.group(2) == '|':
+                            implicit.add(input_target)
+                        else:
+                            order_only.add(input_target)
+            self.query_cache[target] = (explicit, implicit, order_only, phony)
+
+
+    def query_inputs_recursive(self, target: str, done: 'set|None' = None,
+                               inputs_tuple=None) -> 'set[str]':
+        '''
+        Reads recursively set of all input targets for specified "target".
+        Optional set "done" contains all targets that are already scanned. It will be updated.
+        If you have already result of query_inputs(target), then you can pass it
+        to "inputs_tuple" to avoid repeating time consuming operations.
+        '''
+        if target in self.cache:
+            while self.cache[target] is None:
+                self.lock.release()
+                time.sleep(0.1)
+                self.lock.acquire()
+            return self.cache[target]
+        self.cache[target] = None
+        if done is None:
+            done = set()
+        if inputs_tuple is None:
+            explicit, implicit, order_only, _ = self.query_inputs(target)
+        else:
+            explicit, implicit, order_only, _ = inputs_tuple
+        inputs = explicit.union(implicit)
+        if self.include_order_only:
+            inputs = inputs.union(order_only)
+        result = set()
+        if target in self.deps:
+            result.update(self.deps[target])
+        for input in inputs:
+            file_path = (self.build_dir / input).resolve()
+            if input in done:
+                continue
+            done.add(input)
+            file_type = self.detect_file_type(file_path)
+            if file_type == FileType.STAMP:
+                sub_result = self.query_inputs_recursive(input, done)
+                result.update(sub_result)
+            elif file_type != FileType.MISSING:
+                result.add(input)
+            else:
+                sub_inputs_tuple = self.query_inputs(input)
+                phony = sub_inputs_tuple[3]
+                if not phony:
+                    log.wrn(f'The input "{input}" does not exist or it is invalid build target.')
+                sub_result = self.query_inputs_recursive(input, done, sub_inputs_tuple)
+                result.update(sub_result)
+        self.cache[target] = result
+        return result
+
+
+    def process_target_delayed(self, target: str, obj: BuildObject, direct_parent_archive: 'BuildArchive | None'):
+        '''
+        Calls self.process_target(), but if it potentially requires execution of external process,
+        postpone it by putting it into the queue.
+        '''
+        if (target in self.cache) and (self.cache[target] is not None):
+            self.process_target(target, obj, direct_parent_archive)
+            return
+        self.process_target_queue.append((target, obj, direct_parent_archive))
+
+
+    def process_target_inputs(self, target: str, obj: BuildObject, direct_parent_archive: 'BuildArchive | None'):
+        '''
+        Calls self.process_target_delayed() for each detected target input.
+        '''
+        inputs = self.query_inputs_recursive(target)
+        for input in inputs:
+            self.process_target_delayed(input, obj, direct_parent_archive)
+
+
+    def get_target_details(self, target: str) -> 'tuple[Path, FileType]':
+        '''
+        Returns details of specific target - tuple containing:
+            - a full resolved target Path
+            - a target type from FileType enum
+        The results are cached in 'self.target_details'.
+        '''
+        if target not in self.target_details:
+            target_path = (self.build_dir / target).resolve()
+            target_type = self.detect_file_type(target_path)
+            self.target_details[target] = (target_path, target_type)
+        return self.target_details[target]
+
+
+    def process_target(self, target: str, obj: BuildObject, direct_parent_archive: 'BuildArchive | None'):
+        '''
+        Process a single target which means adding the target to appropriate place in the results and
+        processing all dependent targets.
+        Parameters:
+            target:                a target name
+            obj:                   a build object file which is a parent of this target
+            direct_parent_archive: if not None, this target depends directly on it
+        '''
+        target_path, target_type = self.get_target_details(target)
+        if target_type == FileType.ARCHIVE:
+            if target in self.archives:
+                new_archive = self.archives[target]
+            else:
+                new_archive = BuildArchive()
+                new_archive.path = target_path
+                dummy_object = BuildObject()
+                dummy_object.parent = new_archive
+                new_archive.objects[''] = dummy_object
+                self.archives[target] = new_archive
+                self.process_target_inputs(target, dummy_object, new_archive)
+            if direct_parent_archive is not None:
+                direct_parent_archive.archives[target] = new_archive
+        elif target_type == FileType.OBJ:
+            archive = obj.parent
+            if target in archive.objects:
+                return
+            new_obj = BuildObject()
+            new_obj.path = target_path
+            new_obj.parent = archive
+            archive.objects[target] = new_obj
+            self.process_target_inputs(target, new_obj, None)
+        elif target_type == FileType.OTHER:
+            archive = obj.parent
+            if target in obj.sources:
+                return
+            obj.sources[target] = target_path
+            self.process_target_inputs(target, obj, None)
+        else:
+            raise ValueError('Invalid input_type.')
+
+
+    @staticmethod
+    def remove_dummy_objects(archives: 'dict[str, BuildArchive]'):
+        '''
+        Internally all files that does not depend on any object file are
+        placed in dummy object with path None and empty string as a key.
+        This function moves them into the sources field of a BuildArchive.
+        '''
+        for archive in archives.values():
+            if '' in archive.objects:
+                archive.sources.update(archive.objects[''].sources)
+                del archive.objects['']
+
+
+    def prefetch_targets(self, targets: 'list[str]'):
+        '''
+        Calls "prefetch_query_inputs" function on provided list of targets using multiple
+        threads.
+        '''
+        def prefetch_chunk(exec_args):
+            with self.lock:
+                self.prefetch_query_inputs(exec_args)
+        executor_workers = get_executor_workers()
+        targets = list(filter(lambda target: target not in self.query_cache, set(targets)))
+        if len(targets) <= 4 * executor_workers:
+            self.prefetch_query_inputs(targets)
+        else:
+            chunk_size = (len(targets) + executor_workers - 1) // executor_workers
+            chunks = [targets[i:i + chunk_size] for i in range(0, len(targets), chunk_size)]
+            self.lock.release()
+            try:
+                for _ in concurrent_pool_iter(prefetch_chunk, chunks):
+                    pass
+            finally:
+                self.lock.acquire()
+
+
+    def extract(self, targets: 'list[str]') -> BuildArchive:
+        '''
+        Returns a build archive that contains all the input files extracted from
+        the specified targets. The returned value is in a BuildArchive object.
+        '''
+        def process_target_execute(exec_args):
+            with self.lock:
+                self.process_target(*exec_args)
+
+        with self.lock:
+            self.process_target_queue = list()
+            self.archives = dict()
+            for target in targets:
+                inputs = self.query_inputs_recursive(target)
+                for input in inputs:
+                    self.process_target_delayed(input, self.root.objects[''], None)
+            while len(self.process_target_queue) > 0:
+                queue = self.process_target_queue
+                self.process_target_queue = list()
+                self.prefetch_targets(list(map(lambda item: item[0], queue)))
+                self.lock.release()
+                try:
+                    for _ in concurrent_pool_iter(process_target_execute, queue):
+                        pass
+                finally:
+                    self.lock.acquire()
+            self.remove_dummy_objects(self.archives)
+            self.remove_dummy_objects({ '': self.root })
+            self.root.archives.update(self.archives)
+
+        return self.root


### PR DESCRIPTION
The matter project uses GN to build its libraries (not the build system from Zephyr). They are included as CMake ExternalProject. This commit adds detection of such GN ExternalProject and interprets its output ninja file.

This commit also introduces significant source code restructure because ninja build files from GN and Zephyr's CMake files have to be interpreted by one common code.