### PR TITLE
checkpatch: conf: align with upstream

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,5 +1,3 @@
---mailback
---no-tree
 --emacs
 --summary-file
 --show-types
@@ -8,11 +6,12 @@
 --typedefsfile=scripts/checkpatch/typedefsfile
 
 --ignore BRACES
---ignore ENOSYS
 --ignore PRINTK_WITHOUT_KERN_LEVEL
 --ignore SPLIT_STRING
 --ignore VOLATILE
 --ignore CONFIG_EXPERIMENTAL
+--ignore PREFER_KERNEL_TYPES
+--ignore PREFER_SECTION
 --ignore AVOID_EXTERNS
 --ignore NETWORKING_BLOCK_COMMENT_STYLE
 --ignore DATE_TIME
@@ -20,8 +19,16 @@
 --ignore CONST_STRUCT
 --ignore FILE_PATH_CHANGES
 --ignore SPDX_LICENSE_TAG
---ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
+--ignore C99_COMMENT_TOLERANCE
+--ignore REPEATED_WORD
+--ignore UNDOCUMENTED_DT_STRING
+--ignore DT_SPLIT_BINDING_PATCH
+--ignore DT_SCHEMA_BINDING_PATCH
 --ignore TRAILING_SEMICOLON
+--ignore COMPLEX_MACRO
+--ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
+--ignore ENOSYS
+--ignore IS_ENABLED_CONFIG
 --ignore EMBEDDED_FUNCTION_NAME
 --exclude ext
 --exclude samples/matter/.*/src


### PR DESCRIPTION
Our checkpatch configuration file was outdated. Align it with the corresponding upstream one.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>