### PR TITLE
manifest: adapt samples to new ot cb register api

### DIFF
--- a/samples/openthread/cli/src/low_power.c
+++ b/samples/openthread/cli/src/low_power.c
@@ -12,10 +12,9 @@
 
 #include "low_power.h"
 
-static void on_thread_state_changed(uint32_t flags, void *context)
+static void on_thread_state_changed(otChangedFlags flags, struct openthread_context *ot_context,
+				    void *user_data)
 {
-	struct openthread_context *ot_context = context;
-
 	if (flags & OT_CHANGED_THREAD_ROLE) {
 		if (otThreadGetDeviceRole(ot_context->instance) == OT_DEVICE_ROLE_CHILD) {
 			const struct device *cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
@@ -30,7 +29,11 @@ static void on_thread_state_changed(uint32_t flags, void *context)
 	}
 }
 
+static struct openthread_state_changed_cb ot_state_chaged_cb = {
+	.state_changed_cb = on_thread_state_changed
+};
+
 void low_power_enable(void)
 {
-	openthread_set_state_changed_cb(on_thread_state_changed);
+	openthread_state_changed_cb_register(openthread_get_default_context(), &ot_state_chaged_cb);
 }

--- a/samples/openthread/coap_client/src/coap_client.c
+++ b/samples/openthread/coap_client/src/coap_client.c
@@ -29,8 +29,7 @@ LOG_MODULE_REGISTER(coap_client, CONFIG_COAP_CLIENT_LOG_LEVEL);
 #define COMMAND_REQUEST_MULTICAST 'm'
 #define COMMAND_REQUEST_PROVISIONING 'p'
 
-static void on_nus_received(struct bt_conn *conn, const uint8_t *const data,
-			    uint16_t len)
+static void on_nus_received(struct bt_conn *conn, const uint8_t *const data, uint16_t len)
 {
 	LOG_INF("Received data: %c", data[0]);
 
@@ -157,6 +156,5 @@ void main(void)
 
 #endif /* CONFIG_BT_NUS */
 
-	coap_client_utils_init(on_ot_connect, on_ot_disconnect,
-			       on_mtd_mode_toggle);
+	coap_client_utils_init(on_ot_connect, on_ot_disconnect, on_mtd_mode_toggle);
 }

--- a/samples/openthread/coap_client/src/coap_client_utils.c
+++ b/samples/openthread/coap_client/src/coap_client_utils.c
@@ -213,10 +213,9 @@ static void update_device_state(void)
 	on_mtd_mode_toggle(mode.mRxOnWhenIdle);
 }
 
-static void on_thread_state_changed(uint32_t flags, void *context)
+static void on_thread_state_changed(otChangedFlags flags, struct openthread_context *ot_context,
+				    void *user_data)
 {
-	struct openthread_context *ot_context = context;
-
 	if (flags & OT_CHANGED_THREAD_ROLE) {
 		switch (otThreadGetDeviceRole(ot_context->instance)) {
 		case OT_DEVICE_ROLE_CHILD:
@@ -235,6 +234,9 @@ static void on_thread_state_changed(uint32_t flags, void *context)
 		}
 	}
 }
+static struct openthread_state_changed_cb ot_state_chaged_cb = {
+	.state_changed_cb = on_thread_state_changed
+};
 
 static void submit_work_if_connected(struct k_work *work)
 {
@@ -259,7 +261,7 @@ void coap_client_utils_init(ot_connection_cb_t on_connect,
 	k_work_init(&multicast_light_work, toggle_mesh_lights);
 	k_work_init(&provisioning_work, send_provisioning_request);
 
-	openthread_set_state_changed_cb(on_thread_state_changed);
+	openthread_state_changed_cb_register(openthread_get_default_context(), &ot_state_chaged_cb);
 	openthread_start(openthread_get_default_context());
 
 	if (IS_ENABLED(CONFIG_OPENTHREAD_MTD_SED)) {

--- a/samples/openthread/coap_server/src/coap_server.c
+++ b/samples/openthread/coap_server/src/coap_server.c
@@ -104,10 +104,9 @@ static void on_button_changed(uint32_t button_state, uint32_t has_changed)
 	}
 }
 
-static void on_thread_state_changed(uint32_t flags, void *context)
+static void on_thread_state_changed(otChangedFlags flags, struct openthread_context *ot_context,
+				    void *user_data)
 {
-	struct openthread_context *ot_context = context;
-
 	if (flags & OT_CHANGED_THREAD_ROLE) {
 		switch (otThreadGetDeviceRole(ot_context->instance)) {
 		case OT_DEVICE_ROLE_CHILD:
@@ -125,6 +124,8 @@ static void on_thread_state_changed(uint32_t flags, void *context)
 		}
 	}
 }
+static struct openthread_state_changed_cb ot_state_chaged_cb = { .state_changed_cb =
+									 on_thread_state_changed };
 
 void main(void)
 {
@@ -155,7 +156,7 @@ void main(void)
 		goto end;
 	}
 
-	openthread_set_state_changed_cb(on_thread_state_changed);
+	openthread_state_changed_cb_register(openthread_get_default_context(), &ot_state_chaged_cb);
 	openthread_start(openthread_get_default_context());
 
 end:

--- a/subsys/caf/modules/net_state_ot.c
+++ b/subsys/caf/modules/net_state_ot.c
@@ -144,11 +144,11 @@ static void set_net_state(enum net_state state)
 	send_net_state_event(state);
 }
 
-static void on_thread_state_changed(uint32_t flags, void *context)
+static void on_thread_state_changed(otChangedFlags flags, struct openthread_context *ot_context,
+				    void *user_data)
 {
 	static bool has_role;
 
-	struct openthread_context *ot_context = context;
 	bool has_neighbors = check_neighbors(ot_context->instance);
 	bool route_available = check_routes(ot_context->instance);
 
@@ -187,10 +187,13 @@ static void on_thread_state_changed(uint32_t flags, void *context)
 		set_net_state(NET_STATE_DISCONNECTED);
 	}
 }
+static struct openthread_state_changed_cb ot_state_chaged_cb = {
+	.state_changed_cb = on_thread_state_changed
+};
 
 static void connect_ot(void)
 {
-	openthread_set_state_changed_cb(on_thread_state_changed);
+	openthread_state_changed_cb_register(openthread_get_default_context(), &ot_state_chaged_cb);
 	openthread_start(openthread_get_default_context());
 
 	LOG_INF("OT connection requested");

--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a0eba5b06796254ae6ccd622566c3e7b831a3559
+      revision: 37be9499df167bc549c6e142fcaed4a431788752
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Use new OpenThread callback register api
(https://github.com/nrfconnect/sdk-zephyr/pull/1030).

Signed-off-by: Piotr Jasiński <piotr.jasinski@nordicsemi.no>