### PR TITLE
CODEOWNERS: wifi: Assign ownership of firmware headers and patches

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -65,6 +65,10 @@ Kconfig*                                  @tejlmand
 /drivers/sensor/paw3212/                  @anangl @pdunaj @MarekPieta
 /drivers/sensor/pmw3360/                  @anangl @pdunaj @MarekPieta
 /drivers/wifi/nrf700x/                    @krish2718 @sachinthegreen @sr1dh48r @rlubos
+/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_B/  @udaynordic @srkanordic
+/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fw_A/  @udaynordic @srkanordic
+/drivers/wifi/nrf700x/osal/hw_if/hal/inc/fw_B/  @udaynordic @srkanordic
+/drivers/wifi/nrf700x/osal/hw_if/hal/inc/fw_A/  @udaynordic @srkanordic
 /dts/                                     @mbolivar-nordic @anangl
 /ext/                                     @carlescufi
 /include/                                 @anangl @rlubos


### PR DESCRIPTION
Assign ownership of Wi-Fi firmware headers and patch files to Uday and Sriram.

Signed-off-by: Sachin D Kulkarni <sachin.kulkarni@nordicsemi.no>