### PR TITLE
Mosh test cmds

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -268,6 +268,8 @@ nRF9160 samples
 
     * External location service handling to test :ref:`lib_location` library functionality commonly used by applications.
       The :ref:`lib_nrf_cloud` library is used with MQTT for location requests to the cloud.
+    * New command ``th pipeline`` for executing several MoSh commands sequentially in one thread.
+    * New command ``sleep`` for introducing wait periods in between commands when using ``th pipeline``.
 
   * Updated:
 

--- a/samples/nrf9160/modem_shell/README.rst
+++ b/samples/nrf9160/modem_shell/README.rst
@@ -598,6 +598,44 @@ Examples
 
 ----
 
+.. _pipelining_commands:
+
+Running commands in different threads and pipelining commands
+=============================================================
+
+MoSh command: ``th``
+
+You can run ``iperf3`` and ``ping`` in separate threads either in the background or in the foreground.
+Subcommand ``pipeline`` allows running any commands sequentially in the foreground.
+
+Examples
+--------
+
+* Start iperf test in the background.
+  Meanwhile, start ping in the foreground.
+  Print the output buffer of iperf thread once done:
+
+  .. code-block:: console
+
+     th startbg iperf3 --client 111.222.111.222 --port 10000 -l 3540 --time 30 -V -R
+     th startfg ping -d 8.8.8.8
+     th results 1
+
+* Establish MQTT connection to nRF Cloud, wait 10 seconds for the connection establishment, and request current location:
+
+  .. code-block:: console
+
+     th pipeline "cloud connect" "sleep 10" "location get"
+
+----
+
+Sleep
+=====
+
+When pipelining commands using ``th pipeline``, you can use the ``sleep`` command to pause the execution for a given period to allow previous command to return before executing next one.
+See :ref:`pipelining_commands` for usage.
+
+
 Cloud
 =====
 

--- a/samples/nrf9160/modem_shell/src/shell.c
+++ b/samples/nrf9160/modem_shell/src/shell.c
@@ -181,6 +181,19 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 }
 #endif
 
+int sleep_shell(const struct shell *shell, size_t argc, char **argv)
+{
+	long sleep_duration = strtol(argv[1], NULL, 10);
+
+	if (sleep_duration > 0) {
+		k_sleep(K_SECONDS(sleep_duration));
+		return 0;
+	}
+	mosh_print("sleep: duration must be greater than zero");
+
+	return -EINVAL;
+}
+
 #if defined(CONFIG_MOSH_IPERF3)
 static int cmd_iperf3(const struct shell *shell, size_t argc, char **argv)
 {
@@ -234,3 +247,7 @@ SHELL_CMD_REGISTER(rest, NULL,
 	"REST client.",
 	rest_shell);
 #endif
+
+SHELL_CMD_ARG_REGISTER(sleep, NULL,
+	"Sleep for n seconds.",
+	sleep_shell, 1, 0);

--- a/samples/nrf9160/modem_shell/src/th/th_ctrl.h
+++ b/samples/nrf9160/modem_shell/src/th/th_ctrl.h
@@ -13,7 +13,11 @@
 void th_ctrl_init(void);
 void th_ctrl_result_print(int nbr);
 void th_ctrl_status_print(void);
-void th_ctrl_start(const struct shell *shell, size_t argc, char **argv, bool bg_thread);
+void th_ctrl_start(const struct shell *shell,
+		   size_t argc,
+		   char **argv,
+		   bool bg_thread,
+		   bool pipeline);
 void th_ctrl_kill(int nbr);
 void th_ctrl_kill_em_all(void);
 

--- a/samples/nrf9160/modem_shell/src/th/th_shell.c
+++ b/samples/nrf9160/modem_shell/src/th/th_shell.c
@@ -21,20 +21,30 @@ static int print_help(const struct shell *shell, size_t argc, char **argv)
 static int cmd_th_startbg(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc < 2) {
-		mosh_error("please, give also the command to be run");
+		mosh_error("Missing the command to be run");
 		return -EINVAL;
 	}
-	th_ctrl_start(shell, argc, argv, true);
+	th_ctrl_start(shell, argc, argv, true, false);
 	return 0;
 }
 
 static int cmd_th_startfg(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc < 2) {
-		mosh_error("please, give also the command to be run");
+		mosh_error("Missing the command to be run");
 		return -EINVAL;
 	}
-	th_ctrl_start(shell, argc, argv, false);
+	th_ctrl_start(shell, argc, argv, false, false);
+	return 0;
+}
+
+static int cmd_th_start_pipeline(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc < 2) {
+		mosh_error("Missing the command to be run");
+		return -EINVAL;
+	}
+	th_ctrl_start(shell, argc, argv, false, true);
 	return 0;
 }
 
@@ -79,10 +89,13 @@ static int cmd_th(const struct shell *shell, size_t argc, char **argv)
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_bg,
-	SHELL_CMD(startbg, NULL, "iperf3 | ping <params>\nStart a background thread.\n",
+	SHELL_CMD(startbg, NULL, "iperf3 | ping <params>\nStart a background thread.",
 		  cmd_th_startbg),
 	SHELL_CMD(startfg, NULL, "iperf3 | ping <params>\nStart a foreground thread.",
 		  cmd_th_startfg),
+	SHELL_CMD(pipeline, NULL, "\"<cmd> <params>\" \"<cmd> <params>\" \"<cmd> <params>\"...\n"
+				  "Execute any MoSh commands sequentially in one thread.",
+		  cmd_th_start_pipeline),
 	SHELL_CMD_ARG(
 		results, NULL,
 		"th results <thread nbr>\nGet results for the background thread.",


### PR DESCRIPTION
Added new commands "pipeline" and "sleep" to enable running several mosh commands sequentially and, if desired, sleeping in between n seconds.