### PR TITLE
bl_storage: Change the monotonic_counter API

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -443,7 +443,19 @@ Bluetooth libraries and services
 Bootloader libraries
 --------------------
 
-|no_changes_yet_note|
+* :ref:`doc_bl_storage` library:
+
+  * Updated:
+
+    * The monotonic counter functions can now return errors.
+    * The :c:func:`get_monotonic_version` function is split into functions :c:func:`get_monotonic_version` and :c:func:`get_monotonic_slot`.
+    * The monotonic counter functions now have a counter description parameter to be able to distinguish between different counters.
+
+* :ref:`doc_bl_validation` library:
+
+  * Updated:
+
+    * The :c:func:`get_monotonic_version` function can now return an error.
 
 Modem libraries
 ---------------

--- a/include/bl_storage.h
+++ b/include/bl_storage.h
@@ -33,6 +33,9 @@ extern "C" {
 /* We truncate the 32 byte sha256 down to 16 bytes before storing it */
 #define SB_PUBLIC_KEY_HASH_LEN 16
 
+/* Counter used by NSIB to check the firmware version */
+#define BL_MONOTONIC_COUNTERS_DESC_NSIB 0x1
+
 /** Storage for the PRoT Security Lifecycle state, that consists of 4 states:
  *  - Device assembly and test
  *  - PRoT Provisioning
@@ -134,17 +137,26 @@ void invalidate_public_key(uint32_t key_idx);
 /**
  * @brief Get the number of monotonic counter slots.
  *
- * @return The number of slots. If the provision page does not contain the
- *         information, 0 is returned.
+ * @param[in]   counter_desc  Counter description.
+ * @param[out]  counter_slots Number of slots occupied by the counter.
+ *
+ * @retval 0        Success
+ * @retval -EINVAL  Cannot find counters with description @p counter_desc or the pointer to
+ *                  @p counter_slots is NULL.
  */
-uint16_t num_monotonic_counter_slots(void);
+int num_monotonic_counter_slots(uint16_t counter_desc, uint16_t *counter_slots);
 
 /**
  * @brief Get the current HW monotonic counter.
  *
- * @return The current value of the counter.
+ * @param[in]  counter_desc  Counter description.
+ * @param[out] counter_value The value of the current counter.
+ *
+ * @retval 0        Success
+ * @retval -EINVAL  Cannot find counters with description @p counter_desc or the pointer to
+ *                  @p counter_value is NULL.
  */
-uint16_t get_monotonic_counter(void);
+int get_monotonic_counter(uint16_t counter_desc, uint16_t *counter_value);
 
 /**
  * @brief Set the current HW monotonic counter.
@@ -153,6 +165,7 @@ uint16_t get_monotonic_counter(void);
  *       Values are stored with their bits flipped. This is to squeeze one more
  *       value out of the counter.
  *
+ * @param[in]  counter_desc Counter description.
  * @param[in]  new_counter  The new counter value. Must be larger than the
  *                          current value.
  *
@@ -162,7 +175,7 @@ uint16_t get_monotonic_counter(void);
  * @retval -ENOMEM  There are no more free counter slots (see
  *                  @kconfig{CONFIG_SB_NUM_VER_COUNTER_SLOTS}).
  */
-int set_monotonic_counter(uint16_t new_counter);
+int set_monotonic_counter(uint16_t counter_desc, uint16_t new_counter);
 
 /**
  * @brief The PSA life cycle states a device can be in.

--- a/include/bl_validation.h
+++ b/include/bl_validation.h
@@ -74,20 +74,23 @@ struct bl_validate_fw_ext_api {
  */
 int set_monotonic_version(uint16_t version, uint16_t slot);
 
-/** Write the stored 15 bit version to the 16 bit output variable 'version_out'.
+/** Write the stored 15-bit version to the 16-bit output parameter 'version_out'.
  *
- * @param[out]  version_out  Firmware version. Can be any unsigned 15 bit value.
+ * @param[out]  version_out  Firmware version. Can be any unsigned 15-bit value.
  *
  * @retval 0       Success
- * @retval -EINVAL Error during reading the version or *version is NULL.
+ * @retval -EINVAL Error during reading the version or version is NULL.
  */
-void get_monotonic_version(uint16_t *version_out);
+int get_monotonic_version(uint16_t *version_out);
 
-/** Write the stored slot to the output variable 'slot_out'.
+/** Write the stored slot to the output parameter 'slot_out'.
  *
  * @param[out]  slot_out  Slot where firmware is located. Can be 0 or 1.
+ *
+ * @retval 0       Success
+ * @retval -EINVAL Error during reading the version or version is NULL.
  */
-void get_monotonic_slot(uint16_t *slot_out);
+int get_monotonic_slot(uint16_t *slot_out);
 
   /** @} */
 

--- a/include/bl_validation.h
+++ b/include/bl_validation.h
@@ -74,7 +74,6 @@ struct bl_validate_fw_ext_api {
  */
 int set_monotonic_version(uint16_t version, uint16_t slot);
 
-
 /** Read 15 bit version and 1 bit slot from a 16 bit monotonic counter.
  *
  * @param[out]  slot_out  Slot where firmware is located. Can be NULL.

--- a/include/bl_validation.h
+++ b/include/bl_validation.h
@@ -74,13 +74,20 @@ struct bl_validate_fw_ext_api {
  */
 int set_monotonic_version(uint16_t version, uint16_t slot);
 
-/** Read 15 bit version and 1 bit slot from a 16 bit monotonic counter.
+/** Write the stored 15 bit version to the 16 bit output variable 'version_out'.
  *
- * @param[out]  slot_out  Slot where firmware is located. Can be NULL.
+ * @param[out]  version_out  Firmware version. Can be any unsigned 15 bit value.
  *
- * @return Firmware version. Can be any unsigned 15 bit value.
+ * @retval 0       Success
+ * @retval -EINVAL Error during reading the version or *version is NULL.
  */
-uint16_t get_monotonic_version(uint16_t *slot_out);
+void get_monotonic_version(uint16_t *version_out);
+
+/** Write the stored slot to the output variable 'slot_out'.
+ *
+ * @param[out]  slot_out  Slot where firmware is located. Can be 0 or 1.
+ */
+void get_monotonic_slot(uint16_t *slot_out);
 
   /** @} */
 

--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -70,7 +70,22 @@ static void validate_and_boot(const struct fw_info *fw_info, uint16_t slot)
 	printk("Firmware version %d\r\n", fw_info->version);
 
 	uint16_t stored_version;
-	get_monotonic_version(&stored_version);
+	int err = get_monotonic_version(&stored_version);
+
+	if (err) {
+		printk("Failed to read the monotonic counter!\n\r");
+		printk("We assume this is due to the firmware version not being enabled.\n\r");
+
+		/*
+		 * Errors in reading the firmware version are assumed to be
+		 * due to the firmware version not being enabled. When the
+		 * firmware version is disabled, no version checking should
+		 * be done. The version is then set to 0 as it is not permitted
+		 * in fwinfo and will therefore pass all version checks.
+		 */
+		stored_version = 0;
+	}
+
 	if (fw_info->version > stored_version) {
 		set_monotonic_version(fw_info->version, slot);
 	}

--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -87,7 +87,20 @@ static void validate_and_boot(const struct fw_info *fw_info, uint16_t slot)
 	}
 
 	if (fw_info->version > stored_version) {
-		set_monotonic_version(fw_info->version, slot);
+		int err = set_monotonic_version(fw_info->version, slot);
+
+		if (err) {
+			/*
+			 * Errors in writing the firmware version are assumed to be
+			 * due to the firmware version not being enabled. When the
+			 * firmware version is disabled, no version updates should
+			 * be done and this case can be ignored.
+			 *
+			 * The body of this if-statement is intentionally empty.
+			 * It is left here solely for documentation purposes,
+			 * describing why we ignore the error.
+			 */
+		}
 	}
 
 	bl_boot(fw_info);

--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -69,7 +69,9 @@ static void validate_and_boot(const struct fw_info *fw_info, uint16_t slot)
 
 	printk("Firmware version %d\r\n", fw_info->version);
 
-	if (fw_info->version > get_monotonic_version(NULL)) {
+	uint16_t stored_version;
+	get_monotonic_version(&stored_version);
+	if (fw_info->version > stored_version) {
 		set_monotonic_version(fw_info->version, slot);
 	}
 

--- a/subsys/bootloader/bl_storage/bl_storage.c
+++ b/subsys/bootloader/bl_storage/bl_storage.c
@@ -176,36 +176,52 @@ static const struct monotonic_counter *get_counter_struct(uint16_t description)
 	return NULL;
 }
 
-
-uint16_t num_monotonic_counter_slots(void)
+int num_monotonic_counter_slots(uint16_t counter_desc, uint16_t *counter_slots)
 {
-	const struct monotonic_counter *counter
-			= get_counter_struct(COUNTER_DESC_VERSION);
-	uint16_t num_slots = 0;
+	const struct monotonic_counter *counter = get_counter_struct(counter_desc);
 
-	if (counter != NULL) {
-		num_slots = nrfx_nvmc_otp_halfword_read((uint32_t)&counter->num_counter_slots);
+	if (counter == NULL || counter_slots == NULL) {
+		return -EINVAL;
 	}
-	return num_slots != 0xFFFF ? num_slots : 0;
-}
 
+	uint16_t num_slots = nrfx_nvmc_otp_halfword_read((uint32_t)&counter->num_counter_slots);
+
+	if (num_slots == 0xFFFF) {
+		/* We consider the 0xFFFF as invalid since it is the default value of the OTP */
+		*counter_slots = 0;
+		return -EINVAL;
+	}
+
+	*counter_slots = num_slots;
+	return 0;
+}
 
 /** Function for getting the current value and the first free slot.
  *
- * @param[out]  free_slot  Pointer to the first free slot. Can be NULL.
+ * @param[in]   counter_desc  Counter description
+ * @param[out]  counter_value The current value of the requested counter.
+ * @param[out]  free_slot     Pointer to the first free slot. Can be NULL.
  *
- * @return The current value of the counter (the highest value before the first
- *         free slot).
+ * @retval 0        Success
+ * @retval -EINVAL  Cannot find counters with description @p counter_desc or the pointer to
+ *                  @p counter_value is NULL.
  */
-static uint16_t get_counter(const uint16_t **free_slot)
+static int get_counter(uint16_t counter_desc, uint16_t *counter_value, const uint16_t **free_slot)
 {
 	uint16_t highest_counter = 0;
 	const uint16_t *addr = NULL;
-	const uint16_t *slots =
-			get_counter_struct(COUNTER_DESC_VERSION)->counter_slots;
-	uint16_t num_slots = num_monotonic_counter_slots();
+	const struct monotonic_counter *counter_obj = get_counter_struct(counter_desc);
+	const uint16_t *slots;
+	uint16_t num_counter_slots;
 
-	for (uint32_t i = 0; i < num_slots; i++) {
+	if (counter_obj == NULL || counter_value == NULL) {
+		return -EINVAL;
+	}
+
+	slots = counter_obj->counter_slots;
+	num_counter_slots = nrfx_nvmc_otp_halfword_read((uint32_t)&counter_obj->num_counter_slots);
+
+	for (uint32_t i = 0; i < num_counter_slots; i++) {
 		uint16_t counter = ~nrfx_nvmc_otp_halfword_read((uint32_t)&slots[i]);
 
 		if (counter == 0) {
@@ -220,22 +236,28 @@ static uint16_t get_counter(const uint16_t **free_slot)
 	if (free_slot != NULL) {
 		*free_slot = addr;
 	}
-	return highest_counter;
+
+	*counter_value = highest_counter;
+	return 0;
 }
 
-
-uint16_t get_monotonic_counter(void)
+int get_monotonic_counter(uint16_t counter_desc, uint16_t *counter_value)
 {
-	return get_counter(NULL);
+	return get_counter(counter_desc, counter_value, NULL);
 }
 
-
-int set_monotonic_counter(uint16_t new_counter)
+int set_monotonic_counter(uint16_t counter_desc, uint16_t new_counter)
 {
 	const uint16_t *next_counter_addr;
-	uint16_t counter = get_counter(&next_counter_addr);
+	uint16_t current_cnt_value;
+	int err;
 
-	if (new_counter <= counter) {
+	err = get_counter(counter_desc, &current_cnt_value, &next_counter_addr);
+	if (err != 0) {
+		return err;
+	}
+
+	if (new_counter <= current_cnt_value) {
 		/* Counter value must increase. */
 		return -EINVAL;
 	}

--- a/subsys/bootloader/bl_validation/bl_validation.c
+++ b/subsys/bootloader/bl_validation/bl_validation.c
@@ -29,6 +29,7 @@ int set_monotonic_version(uint16_t version, uint16_t slot)
 	} else if (err != 0) {
 		printk("set_monotonic_counter() error: %d\n\r", err);
 	}
+
 	return err;
 }
 

--- a/subsys/bootloader/bl_validation/bl_validation.c
+++ b/subsys/bootloader/bl_validation/bl_validation.c
@@ -33,19 +33,23 @@ int set_monotonic_version(uint16_t version, uint16_t slot)
 	return err;
 }
 
-uint16_t get_monotonic_version(uint16_t *slot_out)
+void get_monotonic_version(uint16_t * version_out)
 {
 	uint16_t monotonic_version_and_slot = get_monotonic_counter();
 
-	bool slot = !(monotonic_version_and_slot & 1);
-	uint16_t version = monotonic_version_and_slot >> 1;
-
-	if (slot_out) {
-		*slot_out = slot;
+	if(version_out) {
+		*version_out = monotonic_version_and_slot >> 1;
 	}
-	return version;
 }
 
+void get_monotonic_slot(uint16_t * slot_out)
+{
+	uint16_t monotonic_version_and_slot = get_monotonic_counter();
+
+	if(slot_out) {
+		*slot_out = monotonic_version_and_slot & 1;
+	}
+}
 
 #ifndef CONFIG_BL_VALIDATE_FW_EXT_API_UNUSED
 #ifdef CONFIG_BL_VALIDATE_FW_EXT_API_REQUIRED
@@ -297,9 +301,11 @@ static bool validate_firmware(uint32_t fw_dst_address, uint32_t fw_src_address,
 		return false;
 	}
 
-	if (fwinfo->version < get_monotonic_version(NULL)) {
+	uint16_t stored_version;
+	get_monotonic_version(&stored_version);
+	if (fwinfo->version < stored_version) {
 		PRINT("Firmware version (%u) is smaller than monotonic counter (%u).\n\r",
-			fwinfo->version, get_monotonic_version(NULL));
+			fwinfo->version, stored_version);
 		return false;
 	}
 

--- a/tests/subsys/bootloader/bl_storage/src/main.c
+++ b/tests/subsys/bootloader/bl_storage/src/main.c
@@ -29,7 +29,7 @@ void test_monotonic_counter(void)
 	zassert_equal(CONFIG_FW_INFO_FIRMWARE_VERSION + 1,
 		get_monotonic_counter() >> 1, NULL);
 	printk("Rebooting. Should fail to validate because of "
-		"monotonic counter.\n");
+		   "monotonic counter.\n");
 	sys_reboot(0);
 }
 
@@ -40,14 +40,14 @@ void test_lcs_single(void)
 
 	ret = read_life_cycle_state(&lcs);
 	zassert_equal(0, ret, "read lcs failed %d", ret);
-	zassert_equal(lcs, BL_STORAGE_LCS_ASSEMBLY,
-			"got wrong lcs, expected %d got %d", BL_STORAGE_LCS_ASSEMBLY, lcs);
+	zassert_equal(lcs, BL_STORAGE_LCS_ASSEMBLY, "got wrong lcs, expected %d got %d",
+		      BL_STORAGE_LCS_ASSEMBLY, lcs);
 	ret = update_life_cycle_state(BL_STORAGE_LCS_PROVISIONING);
 	zassert_equal(0, ret, "write lcs failed %d", ret);
 	ret = read_life_cycle_state(&lcs);
 	zassert_equal(0, ret, "read lcs failed with %d", ret);
-	zassert_equal(lcs, BL_STORAGE_LCS_PROVISIONING,
-			"got wrong lcs, expected %d got %d", BL_STORAGE_LCS_PROVISIONING, lcs);
+	zassert_equal(lcs, BL_STORAGE_LCS_PROVISIONING, "got wrong lcs, expected %d got %d",
+		      BL_STORAGE_LCS_PROVISIONING, lcs);
 }
 
 /* The rest of bl_storage's functionality is tested via the bl_validation


### PR DESCRIPTION
The montonic_counter implementation has some code for supporting
multiple counters, but the API only supports one counter. This commit
updates the API and finalizes this support, but still does not add
another counter.

Introduce a counter description into the monotonic_counter API to be
able to distinguish between multiple counters.

Also introduce some error handling in case the counters are not found.

bl_validation uses the affected API and has been updated. It's API
also needed to be updated to deal with new error handling.

Ref: NCSDK-9045

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>
