### PR TITLE
doc: fix terms in docs

### DIFF
--- a/applications/machine_learning/README.rst
+++ b/applications/machine_learning/README.rst
@@ -67,7 +67,7 @@ The labels that are assigned by the machine learning model are specific to the g
 
 By default, the application uses pretrained machine leaning models deployed in `Edge Impulse studio`_:
 
-* Thingy:53 uses the `NCS hardware accelerometer machine learning model`_.
+* Thingy:53 uses the `nRF Connect SDK hardware accelerometer machine learning model`_.
   The model uses the data from the built-in accelerometer to recognize the following gestures:
 
   * ``idle`` - The device is placed on a flat surface.
@@ -76,7 +76,7 @@ By default, the application uses pretrained machine leaning models deployed in `
   * ``tap`` - The device is tapped while placed on a flat surface.
 
   Unknown gestures, such as shaking the device, are recognized as anomaly.
-* Both the nRF52840 Development Kit and nRF5340 Development Kit use the `NCS simulated sensor machine learning model`_.
+* Both the nRF52840 Development Kit and nRF5340 Development Kit use the `nRF Connect SDK simulated sensor machine learning model`_.
   The model uses simulated sensor data to recognize the following simulated wave types:
 
   * ``sine``

--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -618,7 +618,7 @@ Syntax
   * ``2`` - ``TLS_HOSTNAME``.
     ``<value>`` is a string.
   * ``4`` - ``TLS_CIPHERSUITE_USED`` (get-only).
-    It accepts the IANA assigned ciphersuite identifier of the chosen ciphersuite.
+    It accepts the IANA assigned cipher suite identifier of the chosen cipher suite.
   * ``5`` - ``TLS_PEER_VERIFY``.
     ``<value>`` is an integer and can be either ``0`` or ``1``.
   * ``12`` - ``TLS_SESSION_CACHE``.

--- a/doc/nrf/doc_templates.rst
+++ b/doc/nrf/doc_templates.rst
@@ -7,7 +7,8 @@ The |NCS| documentation provides templates for documenting sample applications a
 
 Use these templates to start documenting your application or library.
 
-You can find the templates in ``ncs/nrf/doc/nrf/templates``. This folder also contains an RST "cheat sheet" to help you getting started with RST.
+You can find the templates in :file:`ncs/nrf/doc/nrf/templates`.
+This folder also contains an RST :file:`cheat sheet` to help you getting started with RST.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -457,8 +457,8 @@ Nordic Thingy:53
 
 .. rst-class:: v2-2-0
 
-NCSDK-18263: NCS samples may fail to boot on Thingy:53
-  NCS samples and applications that are not listed under :ref:`thingy53_compatible_applications` fail to boot on Nordic Thingy:53.
+NCSDK-18263: |NCS| samples may fail to boot on Thingy:53
+  |NCS| samples and applications that are not listed under :ref:`thingy53_compatible_applications` fail to boot on Nordic Thingy:53.
   The MCUboot bootloader is not built together with these samples, but the Thingy:53's :ref:`static Partition Manager memory map <ug_pm_static>` requires it (the application image does not start at the beginning of the internal ``FLASH``.)
 
   **Workaround:** Revert the ``9a8680372fdb6e09f3d6537c8c6751dd5c50bf86`` commit in the sdk-zephyr repository and revert the ``1f9765df5acbb36afff0ce40c94ba65d44d19d70`` commit in sdk-nrf.

--- a/doc/nrf/libraries/others/ei_wrapper.rst
+++ b/doc/nrf/libraries/others/ei_wrapper.rst
@@ -27,7 +27,7 @@ Configuration
 Enable the Edge Impulse wrapper by :kconfig:option:`CONFIG_EI_WRAPPER` option.
 The option is enabled by default if :kconfig:option:`CONFIG_EDGE_IMPULSE` is set.
 
-The Edge Impulse NCS library can be configured with the following Kconfig options:
+The Edge Impulse |NCS| library can be configured with the following Kconfig options:
 
 * :kconfig:option:`CONFIG_EI_WRAPPER_DATA_BUF_SIZE`
 * :kconfig:option:`CONFIG_EI_WRAPPER_THREAD_STACK_SIZE`

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -776,8 +776,8 @@
 .. _`Continuous motion recognition tutorial`: https://docs.edgeimpulse.com/docs/continuous-motion-recognition
 .. _`Edge Impulse's data forwarder`: https://docs.edgeimpulse.com/docs/cli-data-forwarder
 .. _`Edge Impulse CLI installation guide`: https://docs.edgeimpulse.com/docs/cli-installation
-.. _`NCS simulated sensor machine learning model`: https://studio.edgeimpulse.com/public/18121/latest
-.. _`NCS hardware accelerometer machine learning model`: https://studio.edgeimpulse.com/public/33129/latest
+.. _`nRF Connect SDK simulated sensor machine learning model`: https://studio.edgeimpulse.com/public/18121/latest
+.. _`nRF Connect SDK hardware accelerometer machine learning model`: https://studio.edgeimpulse.com/public/33129/latest
 .. _`Nordic Semi Thingy:53 page`: https://docs.edgeimpulse.com/docs/development-platforms/officially-supported-mcu-targets/nordic-semi-thingy53
 .. _`Nordic Semi nRF5340 DK page`: https://docs.edgeimpulse.com/docs/nordic-semi-nrf5340-dk
 

--- a/doc/nrf/releases/release-notes-1.5.2.rst
+++ b/doc/nrf/releases/release-notes-1.5.2.rst
@@ -27,11 +27,11 @@ The |NCS| v1.5.2 is not available for installation from the :ref:`Toolchain Mana
 To upgrade from v1.5.1 to v1.5.2, complete the following steps:
 
 1. If not done already, install nRF Connect SDK v1.5.1 by following the :ref:`Toolchain Manager <gs_app_tcm>` section.
-#. In the command line, go to the :file:`nrf` directory in the NCS installation directory.
+#. In the command line, go to the :file:`nrf` directory in the :file:`ncs` installation directory.
    The default location is :file:`C:\\Users\\<username>\\ncs\\v1.5.1\\nrf`.
 #. Fetch the v1.5.2 release tag with the ``git fetch origin v1.5.2`` command.
 #. Checkout the release tag with the ``git checkout v1.5.2`` command.
-#. Update the NCS installation with the ``west update`` command.
+#. Update the |NCS| installation with the ``west update`` command.
 
 Release tag
 ***********

--- a/doc/nrf/releases/release-notes-1.7.0.rst
+++ b/doc/nrf/releases/release-notes-1.7.0.rst
@@ -301,7 +301,7 @@ Zigbee
   * Fixed the KRKNWK-10490 known issue that would cause a deadlock in the NCP frame fragmentation logic.
   * Fixed the KRKNWK-6071 known issue with inaccurate ZBOSS alarms.
   * Fixed the KRKNWK-5535 known issue where the device would assert if flooded with multiple Network Address requests.
-  * Fixed an issue where the NCS would assert in the host application when the host started just after SoC's SysReset.
+  * Fixed an issue where the |NCS| would assert in the host application when the host started just after SoC's SysReset.
 
 Other samples
 -------------

--- a/doc/nrf/releases/release-notes-1.9.0.rst
+++ b/doc/nrf/releases/release-notes-1.9.0.rst
@@ -180,7 +180,7 @@ nRF9160: Asset Tracker v2
     * :ref:`asset_tracker_v2_cloud_module`
     * :ref:`api_cloud_wrapper`
     * :ref:`asset_tracker_v2_data_module`
-    * GNSS module (removed in NCS 2.2.0)
+    * GNSS module
     * :ref:`asset_tracker_v2_modem_module`
     * :ref:`api_modules_common`
     * :ref:`asset_tracker_v2_sensor_module`

--- a/doc/nrf/releases/release-notes-2.0.0.rst
+++ b/doc/nrf/releases/release-notes-2.0.0.rst
@@ -358,7 +358,7 @@ nRF9160 samples
   * :ref:`nrf_cloud_mqtt_multi_service` sample, demonstrating a simple but robust integration of location services, FOTA, sensor sampling, and more.
   * Shell functionality to HTTP Update samples.
   * :ref:`nrf_cloud_rest_cell_pos_sample` sample, demonstrating how to use the :ref:`lib_nrf_cloud_rest` library to perform cellular positioning requests.
-  * :ref:`ciphersuites` sample, demonstrating how to use TLS ciphersuites.
+  * :ref:`ciphersuites` sample, demonstrating how to use TLS cipher suites.
 
 * Secure Partition Manager (rather than TF-M) is enabled by default for the applications and samples that support Thingy:91.
 

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -103,7 +103,7 @@ Updating the build scripts
 ==========================
 
 To make it possible to enable a child image from a parent image, you must include the child image in the build script.
-If you need to perform this operation out-of-tree (that is, without modifying NCS code), or from the top-level CMakeLists.txt in your sample, see :ref:`ug_multi_image_add_child_image_oot`.
+If you need to perform this operation out-of-tree (that is, without modifying |NCS| code), or from the top-level CMakeLists.txt in your sample, see :ref:`ug_multi_image_add_child_image_oot`.
 
 To do so, place the code from the following example in the CMake tree that is conditional on a configuration option.
 In the |NCS|, the code is included in the :file:`CMakeLists.txt` file for the samples, and in the MCUboot repository.
@@ -147,7 +147,7 @@ Adding a child image using Zephyr modules
 =========================================
 
 Any call to ``add_child_image`` must be done *after* :file:`nrf/cmake/extensions.cmake` is invoked, but *before* :file:`multi_image.cmake` is invoked.
-In some scenarios, this is not possible without modifying the NCS build code, for example, from top-level sample files and project :file:`CMakeLists.txt` files.
+In some scenarios, this is not possible without modifying the |NCS| build code, for example, from top-level sample files and project :file:`CMakeLists.txt` files.
 
 To avoid this issue, use the *Modules* mechanism provided by the Zephyr build system.
 The following example shows how to add the required module from a top-level sample :file:`CMakeLists.txt`.

--- a/doc/nrf/ug_tfm.rst
+++ b/doc/nrf/ug_tfm.rst
@@ -113,9 +113,9 @@ By default, one of the ports is used by the non-secure UART0 peripheral from the
 There are several options to get UART output from the secure TF-M:
 
 * Disable the output for the network core and change the pins used by TF-M.
-  The network core will usually have an NCS child image.
+  The network core will usually have an |NCS| child image.
   To configure a child image, see Configuration of the child image section described in :ref:`ug_nrf5340_multi_image`.
-  To configure logging in an NCS image, see :ref:`ug_logging`.
+  To configure logging in an |NCS| image, see :ref:`ug_logging`.
   To change the pins used by TF-M, the RXD (:kconfig:option:`CONFIG_TFM_UART1_RXD_PIN`) and TXD (:kconfig:option:`CONFIG_TFM_UART1_TXD_PIN`) Kconfig options in the application image can be set to **P1.00** (32) and **P1.01** (33).
 
 * The secure and non-secure UART peripherals can be wired to the same pins.

--- a/samples/nrf9160/ciphersuites/README.rst
+++ b/samples/nrf9160/ciphersuites/README.rst
@@ -1,14 +1,14 @@
 .. _ciphersuites:
 
-nRF9160: TLS ciphersuites
+nRF9160: TLS cipher suites
 ##########################
 
 .. contents::
    :local:
    :depth: 2
 
-The Transport Layer Security (TLS) ciphersuites sample demonstrates a minimal implementation of a client application that attempts to connect to a host by trying different TLS ciphersuites.
-This sample shows the ciphersuites and lists them as supported or not supported by the host, and provides a summary of the support.
+The Transport Layer Security (TLS) cipher suites sample demonstrates a minimal implementation of a client application that attempts to connect to a host by trying different TLS cipher suites.
+This sample shows the cipher suites and lists them as supported or not supported by the host, and provides a summary of the support.
 
 Requirements
 ************
@@ -26,10 +26,10 @@ The sample first initializes the :ref:`nrfxlib:nrf_modem` and AT communications.
 Next, it provisions a root CA certificate to the modem using the :ref:`modem_key_mgmt` library.
 Provisioning must be done before connecting to the LTE network because the certificates can only be provisioned when the device is not connected.
 
-The sample then iterates through a list of TLS ciphersuites, attempting connection to the host with each one of them.
-The sample connects successfully to the host (``www.example.com``) with the ciphersuites that are supported by the host, while unsupported ciphersuites cause a connection failure, setting ``errno`` to ``95``.
+The sample then iterates through a list of TLS cipher suites, attempting connection to the host with each one of them.
+The sample connects successfully to the host (``www.example.com``) with the cipher suites that are supported by the host, while unsupported cipher suites cause a connection failure, setting ``errno`` to ``95``.
 
-Finally, the sample provides a summary of the ciphersuites that are supported and not supported by the host, ``example.com``.
+Finally, the sample provides a summary of the cipher suites that are supported and not supported by the host, ``example.com``.
 
 Obtaining a certificate
 =======================
@@ -53,7 +53,7 @@ Check and configure the following Kconfig options:
 .. _CONFIG_EXTENDED_CIPHERSUITE_LIST:
 
 CONFIG_EXTENDED_CIPHERSUITE_LIST
-   The sample configuration extends the ciphersuite list with extra ciphersuites that are only supported by modem firmware v1.3.x, where x is greater than or equal to 1 and modem firmware v1.2.x, where x is greater than or equal to 7.
+   The sample configuration extends the cipher suite list with extra cipher suites that are only supported by modem firmware v1.3.x, where x is greater than or equal to 1 and modem firmware v1.2.x, where x is greater than or equal to 7.
 
 Building and running
 ********************
@@ -70,7 +70,7 @@ Testing
 1. |connect_kit|
 #. |connect_terminal|
 #. Observe that the sample starts, provisions certificates, and connects to the LTE network.
-#. Observe that the sample iterates through a list of ciphersuites, attempting a connection to ``example.com`` with each one of them, showing either a successful or an unsuccessful connection.
+#. Observe that the sample iterates through a list of cipher suites, attempting a connection to ``example.com`` with each one of them, showing either a successful or an unsuccessful connection.
 
 Sample output
 =============


### PR DESCRIPTION
Fixed following terms in docs:
NCS to nRF Connect SDK
cipersuites to cipher suites

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>