### PR TITLE
doc: Add a section about custom transport

### DIFF
--- a/applications/asset_tracker_v2/doc/debug_module.rst
+++ b/applications/asset_tracker_v2/doc/debug_module.rst
@@ -38,6 +38,18 @@ This enables the application to be able to collect coredump data before a reboot
 To enable Memfault, you must include the :file:`../overlay-memfault.conf` when building the application.
 To get started with Memfault, see :ref:`using_memfault`.
 
+.. _asset_tracker_v2_ext_transport:
+
+Custom transport
+----------------
+
+The data that is collected from the device can be routed through a custom transport to the Memfault cloud instead of using Memfault's own HTTPS transport.
+To do this, enable the :ref:`CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT <CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT>` Kconfig option.
+If this option is enabled, the debug module forwards the captured Memfault data through the :c:enumerator:`DEBUG_EVT_MEMFAULT_DATA_READY` event.
+If the :ref:`CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT <CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT>` Kconfig option is disabled, the debug module uses the `Memfault firmware SDK's <Memfault firmware SDK_>`_ own internal HTTP transport.
+Transporting Memfault data through a pre-established transport can save overhead related to maintaining multiple connections at the same time.
+Currently, only the AWS IoT configuration supports this configuration.
+
 Configuration options
 *********************
 

--- a/applications/asset_tracker_v2/src/events/debug_module_event.h
+++ b/applications/asset_tracker_v2/src/events/debug_module_event.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 enum debug_module_event_type {
-	/** Event carrying memfault data that should be forwarded via the configured cloud
+	/** Event carrying Memfault data that should be forwarded via the configured cloud
 	 *  backend to Memfault cloud. Only sent if
 	 *  CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT is enabled.
 	 *  Payload is of type @ref debug_module_memfault_data.

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -159,6 +159,7 @@ nRF9160: Asset Tracker v2
 * Added:
 
   * Wi-Fi support for nRF9160 DK + nRF7002 EK configuration.
+  * A section about :ref:`Custom transport <asset_tracker_v2_ext_transport>` in the :ref:`asset_tracker_v2_debug_module` documentation.
 
 * Updated:
 


### PR DESCRIPTION
To add a section about custom transport in the
debug module documentation of nRF9160: Asset Tracker v2 application

CIA-877

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>