### PR TITLE
net: lwm2m_client_utils: Fix Resource lenght corrupt

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -161,7 +161,7 @@ static int set(const char *key, size_t len_rd, settings_read_cb read_cb, void *c
 	}
 
 	if (path.level == LWM2M_PATH_LEVEL_RESOURCE) {
-		lwm2m_engine_set_res_data_len((char *)key, len + 1);
+		lwm2m_engine_set_res_data_len((char *)key, len);
 	}
 
 	return 0;

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
@@ -419,7 +419,7 @@ static int set(const char *key, size_t len_rd, settings_read_cb read_cb, void *c
 		return -ENOENT;
 	}
 
-	lwm2m_engine_set_res_data_len((char *)key,  len + 1);
+	lwm2m_engine_set_res_data_len((char *)key,  len);
 
 	if (path.obj_id == LWM2M_OBJECT_SECURITY_ID && path.res_id == SECURITY_BOOTSTRAP_FLAG_ID) {
 		bool is_bootstrap;


### PR DESCRIPTION
Removed unnecessary +1 for lenght which corrupt resource data size.

This will fix next sdk-zephyr buffer validation issue.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>