### PR TITLE
lib: at_cmd_parser: Customer command prefix in URC

### DIFF
--- a/lib/at_cmd_parser/at_utils.h
+++ b/lib/at_cmd_parser/at_utils.h
@@ -44,7 +44,8 @@
 static inline bool is_notification(char chr)
 {
 	if ((chr == AT_STANDARD_NOTIFICATION_PREFIX) ||
-	    (chr == AT_PROP_NOTIFICATION_PREFX)) {
+	    (chr == AT_PROP_NOTIFICATION_PREFX) ||
+	    (chr == AT_CUSTOM_COMMAND_PREFX)) {
 		return true;
 	}
 

--- a/tests/lib/at_cmd_parser/at_utils/src/main.c
+++ b/tests/lib/at_cmd_parser/at_utils/src/main.c
@@ -20,7 +20,7 @@ char *string_return     = "mfw_nrf9160_0.7.0-23.prealpha";
 static void test_notification_detection(void)
 {
 	for (char c = 0; c < 127; ++c) {
-		if ((c == '%') || (c == '+')) {
+		if ((c == '%') || (c == '+') || (c == '#')) {
 			continue;
 		}
 
@@ -31,6 +31,8 @@ static void test_notification_detection(void)
 	zassert_true(is_notification('%'),
 		     "Notification char was not detected");
 	zassert_true(is_notification('+'),
+		     "Notification char was not detected");
+	zassert_true(is_notification('#'),
 		     "Notification char was not detected");
 }
 


### PR DESCRIPTION
Support "#" as prefix for AT command response and notification. 
Example: `#XDFUSIZE: 17048,17048`

Update library test suite accordingly.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>