### PR TITLE
application: serial_lte_modem: Shorten UART recovery delay

### DIFF
--- a/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.overlay
@@ -26,8 +26,11 @@
 &pinctrl {
 	uart2_default_alt: uart2_default_alt {
 		group1 {
+			psels = <NRF_PSEL(UART_RX, 0, 11)>;
+			bias-pull-up;
+		};
+		group2 {
 			psels = <NRF_PSEL(UART_TX, 0, 10)>,
-				<NRF_PSEL(UART_RX, 0, 11)>,
 				<NRF_PSEL(UART_RTS, 0, 12)>,
 				<NRF_PSEL(UART_CTS, 0, 13)>;
 		};

--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -956,7 +956,7 @@ static void uart_callback(const struct device *dev, struct uart_event *evt, void
 			k_work_submit(&raw_send_work);
 		}
 		if (enable_rx_retry && !uart_recovery_pending) {
-			k_work_schedule(&uart_recovery_work, K_MSEC(UART_ERROR_DELAY_MS));
+			k_work_schedule(&uart_recovery_work, K_MSEC(UART_RX_MARGIN_MS));
 			enable_rx_retry = false;
 			uart_recovery_pending = true;
 		}


### PR DESCRIPTION
When SLM detect UART DISABLED by breaks or framing errors, it tries to recovery with a delay. However the delay of 500ms is too long and could miss first data from MCU after MCU resets. Update the delay to 10ms.

Also add a PULLUP for UART_2.RX pin when used.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>