### PR TITLE
application: serial_lte_modem: nRF52 DFU update

### DIFF
--- a/applications/serial_lte_modem/doc/DFU_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/DFU_AT_commands.rst
@@ -59,8 +59,8 @@ Syntax
   It is associated with the certificate or PSK.
   Specifying the ``<sec_tag>`` is mandatory when using HTTPS.
 
-Response syntax
-~~~~~~~~~~~~~~~
+Unsolicited notification
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -82,10 +82,10 @@ Get the image files for the legacy DFU from ``http://myserver.com/path/*.*``:
 ::
 
    AT#XDFUGET=1,"http://myserver.com","path/nrf52840_xxaa.dat","path/nrf52840_xxaa.bin"
+   OK
    #XDFUGET: 1,14
    ...
    #XDFUGET: 1,100
-   OK
 
 Erase the previous image after DFU:
 
@@ -99,10 +99,10 @@ Get the image files for the |NCS| DFU from ``http://myserver.com/path/*.*``:
 ::
 
    AT#XDFUGET=1,"https://myserver.com","path/nrf52_app_update.bin","",1234
+   OK
    #XDFUGET: 0,14
    ...
    #XDFUGET: 0,100
-   OK
 
 Read command
 ------------

--- a/applications/serial_lte_modem/src/dfu/dfu_target_nrf52.c
+++ b/applications/serial_lte_modem/src/dfu/dfu_target_nrf52.c
@@ -22,6 +22,7 @@
 #include <zephyr/logging/log.h>
 #include <nrfx.h>
 #include <zephyr/dfu/mcuboot.h>
+#include <zephyr/storage/flash_map.h>
 #include <dfu/dfu_target.h>
 #include <dfu/dfu_target_stream.h>
 
@@ -72,7 +73,11 @@ int dfu_target_nrf52_init(size_t file_size, dfu_target_callback_t cb)
 		return -EFBIG;
 	}
 
-	flash_dev = DEVICE_GET_DT(DT_NODELABEL(PM_MCUBOOT_SECONDARY_DEV));
+	flash_dev = FLASH_AREA_DEVICE(mcuboot_secondary);
+	if (!device_is_ready(flash_dev)) {
+		LOG_ERR("Failed to get device for secondary partition");
+		return -EFAULT;
+	}
 
 	err = dfu_target_stream_init(&(struct dfu_target_stream_init){
 		.id = "NRF52",

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -156,9 +156,15 @@ nRF9160: Asset Tracker v2
 nRF9160: Serial LTE modem
 -------------------------
 
-* Added an RFC1350 TFTP client, currently supporting only *READ REQUEST*.
-* Added new AT command #XSHUTDOWN to put nRF9160 SiP to System OFF mode.
-* Added support to nRF Cloud C2D appId "MODEM" and "DEVICE".
+* Added:
+
+  * RFC1350 TFTP client, currently supporting only *READ REQUEST*.
+  * AT command #XSHUTDOWN to put nRF9160 SiP to System Off mode.
+  * Support of nRF Cloud C2D appId "MODEM" and "DEVICE".
+
+* Updated:
+
+  * The response for the #XDFUGET command, using unsolicited notification to report download progress.
 
 nRF5340 Audio
 -------------


### PR DESCRIPTION
First an bug fix for the nRF52 DFU target, as the DTS macro to get flash device has been removed.

Second, update #XDFUGET response, send OK instantly and send URC to report download progress.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>