### PR TITLE
DNM drivers: wifi: Fix dependency for Wi-Fi BLE coex

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Usually BOARD_DIR is an absolute path and sourced through '<ZEPHYR_ROOT>/boards/Kconfig'.
+# But for compliance and doc generation it's a glob and this line ensures that
+# boards in sdk-nrf are sourced properly in those occasions.
+orsource "./$(BOARD_DIR)/Kconfig.board"
+orsource "./$(BOARD_DIR)/Kconfig"
+
 rsource "subsys/net/openthread/Kconfig.defconfig"
 
 menu "Nordic nRF Connect"

--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -72,8 +72,8 @@ config NRF700X_WIFI_UTIL
 
 config NRF700X_WIFI_BT_COEX
 	bool "Enable Wi-Fi Bluetooth coexistence support"
-	depends on SOC_NRF5340_CPUAPP_QKAA && NRF700X_RADIO_COEX && !NRF700X_REV_A
-	default y if SOC_NRF5340_CPUAPP_QKAA && NRF700X_RADIO_COEX && !NRF700X_REV_A
+	depends on BOARD_NRF7002DK_NRF5340_CPUAPP && NRF700X_RADIO_COEX && !NRF700X_REV_A
+	default y if BOARD_NRF7002DK_NRF5340_CPUAPP && NRF700X_RADIO_COEX && !NRF700X_REV_A
 
 # Performance fine tuning options
 


### PR DESCRIPTION
Need to enable this only for nRF7002 DK.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>

To demonstrate Zephyr Kconfig not considering NCS boards