### PR TITLE
applications: asset_tracker_v2: update bsec to bsec2

### DIFF
--- a/applications/asset_tracker_v2/doc/sensor_module.rst
+++ b/applications/asset_tracker_v2/doc/sensor_module.rst
@@ -104,14 +104,14 @@ The sensor module supports integration with the BSEC signal processing library u
 If enabled, the BSEC library is used instead of the BME680 Zephyr driver to provide sensor readings from the BME680 for temperature, humidity, and atmospheric pressure.
 In addition, the BSEC driver provides an additional sensor reading, indoor air quality (IAQ), which is a metric given in between 0-500 range, which estimates the air quality of the environment.
 
-As the BSEC library requires a separate license, it is not a default part of |NCS|, but can be downloaded externally and imported into the |NCS| source tree.
+.. note::
+   Using the BSEC library requires accepting a separate license agreement.
+   For details, see `BSEC2`_.
 
 Perform the following steps to enable BSEC:
 
-1. Download the BSEC library, using the `Bosch BSEC`_ link.
-#. Extract and store the folder containing the library contents in the path specified by :ref:`CONFIG_EXTERNAL_SENSORS_BME680_BSEC_PATH <CONFIG_EXTERNAL_SENSORS_BME680_BSEC_PATH>` option or update the path configuration to reference the library location.
-#. Disable the Zephyr BME680 driver by setting :kconfig:option:`CONFIG_BME680` to false.
-#. Enable the external sensors API BSEC integration layer by enabling :ref:`CONFIG_EXTERNAL_SENSORS_BME680_BSEC <CONFIG_EXTERNAL_SENSORS_BME680_BSEC>` option.
+1. To disable the Zephyr BME680 driver, set the :kconfig:option:`CONFIG_BME680` Kconfig option to false.
+#. To enable the external sensors API BSEC integration layer, use the :ref:`CONFIG_EXTERNAL_SENSORS_BME680_BSEC <CONFIG_EXTERNAL_SENSORS_BME680_BSEC>` Kconfig option.
 
 Air quality readings are provided with the :c:enumerator:`SENSOR_EVT_ENVIRONMENTAL_DATA_READY` event.
 
@@ -139,11 +139,6 @@ External sensors API BSEC configurations
 
 CONFIG_EXTERNAL_SENSORS_BME680_BSEC
    This option configures the Bosch BSEC library for the BME680.
-
-.. _CONFIG_EXTERNAL_SENSORS_BME680_BSEC_PATH:
-
-CONFIG_EXTERNAL_SENSORS_BME680_BSEC_PATH
-   This option sets the path for the Bosch BSEC library folder.
 
 .. _CONFIG_EXTERNAL_SENSORS_BSEC_SAMPLE_MODE_ULTRA_LOW_POWER:
 

--- a/applications/asset_tracker_v2/src/ext_sensors/CMakeLists.txt
+++ b/applications/asset_tracker_v2/src/ext_sensors/CMakeLists.txt
@@ -9,23 +9,22 @@ target_sources_ifdef(CONFIG_EXTERNAL_SENSORS app PRIVATE ${CMAKE_CURRENT_SOURCE_
 
 if (CONFIG_EXTERNAL_SENSORS_BME680_BSEC)
         target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ext_sensors_bsec.c)
-        set(bsec_dir ${CONFIG_EXTERNAL_SENSORS_BME680_BSEC_PATH})
         if (CONFIG_FP_SOFTABI)
-                set(BSEC_LIB_DIR ${bsec_dir}/algo/normal_version/bin/gcc/Cortex_M33)
+                set(BSEC_LIB_DIR ${ZEPHYR_BASE}/../modules/lib/bsec2/src/cortex-m4)
+		zephyr_compile_definitions(BME68X_DO_NOT_USE_FPU)
         endif()
         if (CONFIG_FP_HARDABI)
-                set(BSEC_LIB_DIR ${bsec_dir}/algo/normal_version/bin/gcc/Cortex_M33F)
+                set(BSEC_LIB_DIR ${ZEPHYR_BASE}/../modules/lib/bsec2/src/cortex-m33/fpv5-sp-d16-hard)
         endif()
 
         if(NOT EXISTS "${BSEC_LIB_DIR}/libalgobsec.a")
-                assert(0 "Could not find BSEC library. Minimum version is 1.4.8.0_Generic_Release")
+                assert(0 "Could not find BSEC library.")
         endif()
 
-        target_include_directories(app PRIVATE ${bsec_dir}/examples/bsec_iot_example)
-        target_include_directories(app PRIVATE ${BSEC_LIB_DIR})
+        target_include_directories(app PRIVATE ${ZEPHYR_BASE}/../modules/lib/bme68x/src/bme68x)
+        target_include_directories(app PRIVATE ${ZEPHYR_BASE}/../modules/lib/bsec2/src/inc/)
 
-        target_sources(app PRIVATE ${bsec_dir}/examples/bsec_iot_example/bsec_integration.c)
-        target_sources(app PRIVATE ${bsec_dir}/examples/bsec_iot_example/bme680.c)
+        target_sources(app PRIVATE ${ZEPHYR_BASE}/../modules/lib/bme68x/src/bme68x/bme68x.c)
 
         add_library(bsec_lib STATIC IMPORTED GLOBAL)
         add_dependencies(bsec_lib math_lib bsec_target)

--- a/applications/asset_tracker_v2/src/ext_sensors/Kconfig
+++ b/applications/asset_tracker_v2/src/ext_sensors/Kconfig
@@ -32,9 +32,7 @@ config EXTERNAL_SENSORS_BME680_BSEC
 	bool "Use Bosch BME680 library"
 	depends on !BME680
 	help
-	  Enable the use of Bosch BSEC library. The library itself is not a part of
-	  NCS and must be downloaded from Bosch Sensortec and placed in the path referenced to by
-	  the CONFIG_EXTERNAL_SENSORS_BME680_BSEC_PATH.
+	  Enable the use of Bosch BSEC library.
 	  This configuration depends on the BME680 zephyr driver being disabled.
 
 if EXTERNAL_SENSORS_BME680_BSEC
@@ -72,19 +70,13 @@ endchoice # EXTERNAL_SENSORS_BME680_BSEC_MODE
 
 config EXTERNAL_SENSORS_BSEC_TEMPERATURE_OFFSET
 	int "BSEC temperature offset in degree celsius * 100"
-	default 120 if BOARD_THINGY91_NRF9160_NS
+	default 200 if BOARD_THINGY91_NRF9160_NS
 	default 100
 	help
 	  BSEC temperature offset. To account for external heat sources on the board.
 	  The actual value is divided by 100. This is due to the Kconfig parser
 	  not supporting floating point types.
-	  The default value 120 is translated to 1.2 degrees celsius offset.
-
-config EXTERNAL_SENSORS_BME680_BSEC_PATH
-	string "Path to Bosch BSEC library folder"
-	default "$(ZEPHYR_NRF_MODULE_DIR)/ext/BSEC_1.4.8.0_Generic_Release_updated_v3"
-	help
-	  Path to the folder where the Bosch BSEC library is placed.
+	  The default value 200 is translated to 2.0 degrees celsius offset.
 
 endif # EXTERNAL_SENSORS_BME680_BSEC
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -32,6 +32,7 @@
 .. _`Zephyr issue #27356`: https://github.com/zephyrproject-rtos/zephyr/issues/27356
 .. _`Zephyr issue #38516`: https://github.com/zephyrproject-rtos/zephyr/issues/38516
 .. _`Zephyr SDK`: https://github.com/zephyrproject-rtos/sdk-ng/releases
+.. _`BSEC2`: https://github.com/boschsensortec/Bosch-BSEC2-Library
 
 .. _`sdk-mcuboot`: https://github.com/nrfconnect/sdk-mcuboot
 .. _`MCUboot repository`: https://github.com/mcu-tools/mcuboot

--- a/west.yml
+++ b/west.yml
@@ -33,6 +33,8 @@ manifest:
       url-base: https://github.com/memfault
     - name: ant-nrfconnect
       url-base: https://github.com/ant-nrfconnect
+    - name: boschsensortec
+      url-base: https://github.com/boschsensortec
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -181,6 +183,16 @@ manifest:
       remote: ant-nrfconnect
       groups:
         - ant
+    - name: bsec2
+      repo-path: Bosch-BSEC2-Library
+      path: modules/lib/bsec2
+      revision: v1.4.2200
+      remote: boschsensortec
+    - name: bme68x
+      repo-path: Bosch-BME68x-Library
+      path: modules/lib/bme68x
+      revision: v1.1.40407
+      remote: boschsensortec
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
This patch updates the Bosch BSEC library to the current version that is hosted on GitHub.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>

Fixes CIA-866.