### PR TITLE
kconfig: optional sourcing of BOARD_DIR in nrf

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# Usually BOARD_DIR is an absolute path and sourced through '<ZEPHYR_ROOT>/boards/Kconfig'.
+# But for compliance and doc generation it's a glob and this line ensures that
+# boards in sdk-nrf are sourced properly in those occasions.
+orsource "$(BOARD_DIR)/Kconfig.board"
+orsource "$(BOARD_DIR)/Kconfig"
+
 rsource "subsys/net/openthread/Kconfig.defconfig"
 
 menu "Nordic nRF Connect"


### PR DESCRIPTION
Add Kconfig osource of BOARD_DIR prefixed with ZEPHYR_NRF_MODULE_DIR.

A regular build will set BOARD_DIR to an absolute path, and thus the prefixing with ZEPHYR_NRF_MODULE_DIR will point to an invalid path. This is expected and desired because the actual BOARD_DIR is sourced from Zephyr repository Kconfig tree and we don't want to source it twice.

For documentation build and compliance, the BOARD_DIR is a glob pattern and this commit ensures that board Kconfig files in the sdk-nrf tree are sourced in those cases.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>