### PR TITLE
Revert "kconfig: optional sourcing of BOARD_DIR in nrf"

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -4,12 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Usually BOARD_DIR is an absolute path and sourced through '<ZEPHYR_ROOT>/boards/Kconfig'.
-# But for compliance and doc generation it's a glob and this line ensures that
-# boards in sdk-nrf are sourced properly in those occasions.
-orsource "$(BOARD_DIR)/Kconfig.board"
-orsource "$(BOARD_DIR)/Kconfig"
-
 rsource "subsys/net/openthread/Kconfig.defconfig"
 
 menu "Nordic nRF Connect"


### PR DESCRIPTION
This reverts commit 6e98492bdd7530ddf8621a8699f31af382235160. It is suspected of causing CI plans to go red.

Signed-off-by: Marti Bolivar <marti.bolivar@nordicsemi.no>