### PR TITLE
mpsl: cx: add API to enable and disable nRF700x coexistence

### DIFF
--- a/include/mpsl/mpsl_cx_nrf700x.h
+++ b/include/mpsl/mpsl_cx_nrf700x.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file mpsl_cx_nrf700x.h
+ *
+ * @defgroup mpsl_cx_nrf700x Multiprotocol Service Layer nRF700x Coexistence
+ *
+ * @brief MPSL nRF700x Coexistence
+ * @{
+ */
+
+#ifndef MPSL_CX_NRF700X__
+#define MPSL_CX_NRF700X__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+/**
+ * @brief Enables or disables nRF700x Coexistence Interface.
+ *
+ * The nRF700x Coexistence Interface is enabled by default. Depending on the current state of
+ * GRANT pin of the nRF700x, clients of MPSL CX APIs will either be granted or denied access
+ * to RF when the interface is enabled.
+ *
+ * Whenever nRF700x enters shutdown mode, the nRF700x Coexistence Interface must be disabled
+ * by calling this function with @p enable equal @c false. Otherwise, all clients of MPSL CX APIs
+ * will unconditionally be denied access to RF until nRF700x leaves shutdown mode.
+ *
+ * Once the nRF700x Coexistence Interface is disable, it can only be enabled again by calling
+ * this function with @p enable equal @c true. Since the interface is enabled by default, unless
+ * the application disabled it there is no need to call this function to have the nRF700x
+ * Coexistence Interface enabled.
+ *
+ * @note This function is blocking. When it returns, the caller can assume the interface is already
+ * in requested state.
+ *
+ * @param[in]  enable  Indicates if the nRF700x Coexistence Interface should be enabled or disabled.
+ */
+void mpsl_cx_nrf700x_set_enabled(bool enable);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MPSL_CX_NRF700X__ */
+
+/**@} */

--- a/subsys/mpsl/cx/CMakeLists.txt
+++ b/subsys/mpsl/cx/CMakeLists.txt
@@ -12,3 +12,7 @@ if (CONFIG_MPSL_CX_THREAD OR CONFIG_MPSL_CX_BT_1WIRE OR CONFIG_MPSL_CX_BT_3WIRE 
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_BT_3WIRE bluetooth/mpsl_cx_3w_bluetooth.c)
     zephyr_library_sources_ifdef(CONFIG_MPSL_CX_NRF700X nrf700x/mpsl_cx_nrf700x.c)
 endif()
+
+if (CONFIG_MPSL_CX_NRF700X AND CONFIG_SOC_SERIES_NRF53X)
+    zephyr_library_sources(nrf700x/mpsl_cx_nrf700x_rpc.c)
+endif()

--- a/subsys/mpsl/cx/Kconfig
+++ b/subsys/mpsl/cx/Kconfig
@@ -22,6 +22,8 @@ config MPSL_CX
 	bool "Radio Coexistence interface support"
 	depends on MPSL_CX_ANY_SUPPORT
 	default WIFI && (BT || NRF_802154_RADIO_DRIVER || NRF_802154_SER_HOST)
+	select NRF_RPC if SOC_SERIES_NRF53X
+	select NRF_RPC_CBOR if SOC_SERIES_NRF53X
 	help
 	  Controls if Radio Coexistence interface is to be configured and enabled
 	  when MPSL is initialized.
@@ -34,6 +36,8 @@ config MPSL_CX_PIN_FORWARDER
 	depends on SOC_NRF5340_CPUAPP
 	depends on MPSL_CX
 	default y
+	select NRF_RPC
+	select NRF_RPC_CBOR
 
 if MPSL_CX
 

--- a/subsys/mpsl/cx/nrf700x/mpsl_cx_nrf700x.c
+++ b/subsys/mpsl/cx/nrf700x/mpsl_cx_nrf700x.c
@@ -12,6 +12,7 @@
 
 #if !defined(CONFIG_MPSL_CX_PIN_FORWARDER)
 #include <mpsl_cx_abstract_interface.h>
+#include <mpsl/mpsl_cx_nrf700x.h>
 #else
 #include <string.h>
 #include <soc_secure.h>
@@ -59,6 +60,8 @@ static const struct gpio_dt_spec grant_spec   = GPIO_DT_SPEC_GET(CX_NODE, grant_
 static mpsl_cx_cb_t callback;
 static struct gpio_callback grant_cb;
 
+static bool enabled = true;
+
 static int32_t grant_pin_is_asserted(bool *is_asserted)
 {
 	int ret;
@@ -77,7 +80,7 @@ static mpsl_cx_op_map_t granted_ops_map(bool grant_is_asserted)
 {
 	mpsl_cx_op_map_t granted_ops = MPSL_CX_OP_IDLE_LISTEN | MPSL_CX_OP_RX;
 
-	if (grant_is_asserted) {
+	if (grant_is_asserted || !enabled) {
 		granted_ops |= MPSL_CX_OP_TX;
 	}
 
@@ -278,6 +281,11 @@ static int mpsl_cx_init(const struct device *dev)
 }
 
 SYS_INIT(mpsl_cx_init, POST_KERNEL, CONFIG_MPSL_CX_INIT_PRIORITY);
+
+void mpsl_cx_nrf700x_set_enabled(bool enable)
+{
+	enabled = enable;
+}
 
 #else // !defined(CONFIG_MPSL_CX_PIN_FORWARDER)
 static int mpsl_cx_init(const struct device *dev)

--- a/subsys/mpsl/cx/nrf700x/mpsl_cx_nrf700x_rpc.c
+++ b/subsys/mpsl/cx/nrf700x/mpsl_cx_nrf700x_rpc.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ *   This file implements Remote Procedure Calls (RPC) required to enable and disable
+ *   the nRF700x Coexistence Interface from the nRF5340 application core.
+ *
+ */
+
+#include <mpsl/mpsl_cx_nrf700x.h>
+#include <zephyr/device.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(mpsl_cx_nrf700x_rpc, LOG_LEVEL_ERR);
+
+#if defined(CONFIG_NRF_RPC_CBOR)
+#include <nrf_rpc/nrf_rpc_ipc.h>
+#include <nrf_rpc_cbor.h>
+
+NRF_RPC_IPC_TRANSPORT(
+	mpsl_cx_nrf700x_rpc_tr, DEVICE_DT_GET(DT_NODELABEL(ipc0)), "mpsl_cx_nrf700x_rpc_tr_ept");
+NRF_RPC_GROUP_DEFINE(
+	mpsl_cx_nrf700x_rpc_grp, "mpsl_cx_nrf700x", &mpsl_cx_nrf700x_rpc_tr, NULL, NULL, NULL);
+
+#define MPSL_CX_NRF700X_SET_ENABLED_CBOR_CMD  0x01
+#endif
+
+#define IS_RPC_CLIENT CONFIG_SOC_NRF5340_CPUAPP
+#define IS_RPC_SERVER CONFIG_SOC_NRF5340_CPUNET
+
+#if IS_RPC_CLIENT
+void mpsl_cx_nrf700x_set_enabled(bool enable)
+{
+	struct nrf_rpc_cbor_ctx ctx;
+
+	NRF_RPC_CBOR_ALLOC(&mpsl_cx_nrf700x_rpc_grp, ctx, 1);
+
+	zcbor_bool_put(ctx.zs, enable);
+
+	nrf_rpc_cbor_cmd_rsp_no_err(
+		&mpsl_cx_nrf700x_rpc_grp, MPSL_CX_NRF700X_SET_ENABLED_CBOR_CMD, &ctx);
+
+	nrf_rpc_cbor_decoding_done(&mpsl_cx_nrf700x_rpc_grp, &ctx);
+}
+#endif /* IS_RPC_CLIENT */
+
+#if IS_RPC_SERVER
+void remote_handler_mpsl_cx_nrf700x_set_enabled(const struct nrf_rpc_group *group,
+						struct nrf_rpc_cbor_ctx *ctx,
+						void *handler_data)
+{
+	bool enable;
+
+	if (!zcbor_bool_decode(ctx->zs, &enable)) {
+		nrf_rpc_cbor_decoding_done(group, ctx);
+		return;
+	}
+
+	nrf_rpc_cbor_decoding_done(group, ctx);
+
+	mpsl_cx_nrf700x_set_enabled(enable);
+
+	struct nrf_rpc_cbor_ctx nctx;
+
+	NRF_RPC_CBOR_ALLOC(group, nctx, 0);
+
+	nrf_rpc_cbor_rsp_no_err(group, &nctx);
+}
+
+NRF_RPC_CBOR_CMD_DECODER(mpsl_cx_nrf700x_rpc_grp,
+			 remote_handler_mpsl_cx_nrf700x_set_enabled,
+			 MPSL_CX_NRF700X_SET_ENABLED_CBOR_CMD,
+			 remote_handler_mpsl_cx_nrf700x_set_enabled,
+			 NULL);
+#endif /* IS_RPC_SERVER */
+
+#if IS_RPC_CLIENT || IS_RPC_SERVER
+
+static void err_handler(const struct nrf_rpc_err_report *report)
+{
+	LOG_ERR("nRF RPC error %d ocurred. See nRF RPC logs for more details.",
+		report->code);
+	k_oops();
+}
+
+static int serialization_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return nrf_rpc_init(err_handler);
+}
+
+SYS_INIT(serialization_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+
+#endif /* IS_RPC_CLIENT && IS_RPC_SERVER */


### PR DESCRIPTION
This commit implements API that allows the application to enable and disable nRF700x Coexistence Interface, along with its serialization using nrf_rpc library.

Signed-off-by: Jędrzej Ciupis <jedrzej.ciupis@nordicsemi.no>