### PR TITLE
samples: matter: lock: enhance script for flashing QSPI

### DIFF
--- a/samples/matter/lock/README.rst
+++ b/samples/matter/lock/README.rst
@@ -372,6 +372,12 @@ To test switching between Thread and Wi-Fi, complete the following steps:
 
       west flash --erase
 
+#. Erase the entire content of the external flash using the following command:
+
+   .. code-block:: console
+
+      nrfjprog --qspieraseall
+
 #. Program the application to a partition of the external flash using the following command:
 
    .. code-block:: console


### PR DESCRIPTION
Enhance the script for programming the switched Thread/Wi-Fi lock sample into the QSPI external flash by prompting a user to select a board serial number if there are multiple boards connected. Also, use nrfjprog '--verify' flag to ensure that that flashing has succeeded.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>