### PR TITLE
sample: tfm_psa_template add immediate log out configuration

### DIFF
--- a/samples/tfm/tfm_psa_template/prj.conf
+++ b/samples/tfm/tfm_psa_template/prj.conf
@@ -50,3 +50,6 @@ CONFIG_MCUBOOT_UTIL_LOG_LEVEL_WRN=y
 
 # Enable the serial mcumgr transport.
 CONFIG_MCUMGR_SMP_UART=y
+
+# Ensure clean log output
+CONFIG_LOG_MODE_IMMEDIATE=y


### PR DESCRIPTION
Changed the logging mode for the twister test build to be synchronous This should result in a cleaner log output for testing.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>