### PR TITLE
manifest: pull Matter patch which increases the net_mgmt stack size

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -123,7 +123,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: c9ba5705daa6450b230e2d1ff67e4383b592876e
+      revision: 6708679fb934eeee568976ad5990762cd7f72e3c
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Once we were hit by the net_mgmt thread stack overflow while show casing
the Matter over WiFi solution in WiFi RF congested environment.
Increase the default stack size of net_mgmt from 768 to 1k.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>