### PR TITLE
scripts: hid_configurator: Allow using older Python version

### DIFF
--- a/scripts/hid_configurator/configurator_cli.py
+++ b/scripts/hid_configurator/configurator_cli.py
@@ -177,7 +177,12 @@ def perform_led_stream(dev, args):
 
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(allow_abbrev=False)
+    try:
+        parser = argparse.ArgumentParser(allow_abbrev=False)
+    except TypeError:
+        # The allow_abbrev argument was added in Python 3.5.
+        # Skip setting the value if used Python version does not support it.
+        parser = argparse.ArgumentParser()
 
     parser.add_argument(dest='device', default=None, nargs='?',
                         help='Device specified by type, board name or HW ID '


### PR DESCRIPTION
The `allow_abbrev` argument for `ArgumentParser` was introduced in `Python 3.5`. Change allows to skip providing the argument if not supported. This is needed to allow using script with older Python version.

Jira: NCSDK-19283