### PR TITLE
quarantine_windows: revert nrf5340_audio quarantine

### DIFF
--- a/scripts/quarantine_windows.yaml
+++ b/scripts/quarantine_windows.yaml
@@ -32,12 +32,3 @@
   platforms:
     - all
   comment: "ruby package not available in Windows toolchain"
-
-- scenarios:
-    - applications.nrf5340_audio.gateway_dfu_external
-    - applications.nrf5340_audio.gateway_dfu_internal
-    - applications.nrf5340_audio.headset_dfu_external
-    - applications.nrf5340_audio.headset_dfu_internal
-  platforms:
-    - all
-  comment: "skip until fix sdk-nrf/pull/9898 is merged"


### PR DESCRIPTION
CMAKE issue in nrf5340_audio is fixed and merged (pull/9898).

Signed-off-by: Rafal Wozniakowski <rafal.wozniakowski@nordicsemi.no>