### PR TITLE
application: nrf5339_audio: Disable default build empty net core

### DIFF
--- a/applications/nrf5340_audio/Kconfig.defaults
+++ b/applications/nrf5340_audio/Kconfig.defaults
@@ -25,10 +25,8 @@ config THREAD_NAME
 	bool
 	default y
 
-# Empty net core image is needed whether DFU is enabled or not
-config NCS_SAMPLE_EMPTY_NET_CORE_CHILD_IMAGE
-	bool "Dummy Net core application"
-	default y
+config NCS_INCLUDE_RPMSG_CHILD_IMAGE
+	default n
 
 # Workaround to not use fatal_error.c in NCS. Note that the system may still
 # reset on error depending on the build configuraion

--- a/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
+++ b/applications/nrf5340_audio/dfu/conf/Kconfig.dfu
@@ -21,6 +21,11 @@ config B0N_MINIMAL
 
 if AUDIO_DFU = 1 || AUDIO_DFU = 2
 
+# Empty net core image is needed when DFU is enabled
+config NCS_SAMPLE_EMPTY_NET_CORE_CHILD_IMAGE
+	bool "Dummy Net core application"
+	default y
+
 config AUDIO_DFU_ENABLE
 	bool
 	default y

--- a/applications/nrf5340_audio/sample.yaml
+++ b/applications/nrf5340_audio/sample.yaml
@@ -17,25 +17,25 @@ tests:
     platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns
     tags: ci_build
     extra_args: CONF_FILE="prj_release.conf" CONFIG_AUDIO_DEV=2
-  applications.nrf5340_audio.headset_dfu_internal:
+  applications.nrf5340_audio.hs_d_i:
     build_only: true
     platform_allow: nrf5340_audio_dk_nrf5340_cpuapp
     platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns
     tags: ci_build
     extra_args: CONF_FILE="prj_release.conf" CONFIG_AUDIO_DEV=1 CONFIG_AUDIO_DFU=1
-  applications.nrf5340_audio.gateway_dfu_internal:
+  applications.nrf5340_audio.gw_d_i:
     build_only: true
     platform_allow: nrf5340_audio_dk_nrf5340_cpuapp
     platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns
     tags: ci_build
     extra_args: CONF_FILE="prj_release.conf" CONFIG_AUDIO_DEV=2 CONFIG_AUDIO_DFU=1
-  applications.nrf5340_audio.headset_dfu_external:
+  applications.nrf5340_audio.hs_d_e:
     build_only: true
     platform_allow: nrf5340_audio_dk_nrf5340_cpuapp
     platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns
     tags: ci_build
     extra_args: CONF_FILE="prj_release.conf" CONFIG_AUDIO_DEV=1 CONFIG_AUDIO_DFU=2
-  applications.nrf5340_audio.gateway_dfu_external:
+  applications.nrf5340_audio.gw_d_e:
     build_only: true
     platform_allow: nrf5340_audio_dk_nrf5340_cpuapp
     platform_exclude: nrf5340_audio_dk_nrf5340_cpuapp_ns


### PR DESCRIPTION
Build empty net core only when DFU is enabled.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>