### PR TITLE
matter: increase MRP intervals for Thread

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -91,6 +91,7 @@ Matter
   * Default heap implementation to use Zephyr's ``sys_heap`` (:kconfig:option:`CONFIG_CHIP_MALLOC_SYS_HEAP`) to better control the RAM usage of Matter applications.
   * :ref:`ug_matter_device_certification` page with a section about certification document templates.
   * :ref:`ug_matter_overview_commissioning` page with information about :ref:`ug_matter_network_topologies_commissioning_onboarding_formats`.
+  * Default retry intervals used by Matter Reliability Protocol for Matter over Thread to account for longer round-trip times in Thread networks with multiple intermediate nodes.
 
 See `Matter samples`_ for the list of changes for the Matter samples.
 

--- a/samples/matter/light_bulb/src/chip_project_config.h
+++ b/samples/matter/light_bulb/src/chip_project_config.h
@@ -24,4 +24,5 @@
  * Until this is improved in OpenThread we need to increase the retransmission
  * interval to survive the stall.
  */
+#define CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL (1000_ms32)
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (1000_ms32)

--- a/west.yml
+++ b/west.yml
@@ -123,7 +123,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 6708679fb934eeee568976ad5990762cd7f72e3c
+      revision: 292ead8ffa823fb4d0a9ac1acac5ce68d321abf3
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
Increase default MRP intervals advertised by Thread devices to account for longer round-trip times in Thread networks.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>