### PR TITLE
test: unity: add possibility to exclude words during mock generation

### DIFF
--- a/tests/lib/location/CMakeLists.txt
+++ b/tests/lib/location/CMakeLists.txt
@@ -14,9 +14,9 @@ test_runner_generate(src/location_test.c)
 
 cmock_handle(../../../include/modem/modem_key_mgmt.h)
 cmock_handle(../../../include/net/rest_client.h)
-cmock_handle(${ZEPHYR_BASE}/../nrfxlib/nrf_modem/include/nrf_modem_gnss.h)
-cmock_handle(${ZEPHYR_BASE}/../nrfxlib/nrf_modem/include/nrf_modem_at.h EXCLUDE ".*nrf_modem_at_scanf")
+cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/nrf_modem_gnss.h)
+cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/nrf_modem_at.h FUNC_EXCLUDE ".*nrf_modem_at_scanf")
 
-zephyr_include_directories(${ZEPHYR_BASE}/../nrfxlib/nrf_modem/include)
+zephyr_include_directories(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include)
 
 target_sources(app PRIVATE src/location_test.c)

--- a/tests/lib/lte_lc_api/CMakeLists.txt
+++ b/tests/lib/lte_lc_api/CMakeLists.txt
@@ -13,7 +13,7 @@ project(lte_lc_api_test)
 test_runner_generate(src/lte_lc_api_test.c)
 
 cmock_handle(${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_modem/include/nrf_modem_at.h
-	     EXCLUDE ".*nrf_modem_at_scanf")
+	     FUNC_EXCLUDE ".*nrf_modem_at_scanf")
 
 # When mocking nrf_modem_at then nrf_modem/include must manually be added
 # because CONFIG_NRF_MODEM_LINK_BINARY=n

--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -152,7 +152,7 @@ function(cmock_linker_wrap_trick header_file_path)
   set(flist_file "${header_file_path}.flist")
 
   if(DEFINED CMOCK_FUNC_EXCLUDE)
-    string(JOIN "--exclude;" exclude_arg ${CMOCK_FUNC_EXCLUDE})
+    string(JOIN ";--exclude;" exclude_arg ${CMOCK_FUNC_EXCLUDE})
     set(exclude_arg "--exclude" ${exclude_arg})
   endif()
 

--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -6,10 +6,11 @@
 
 # Internal macro for creating unity configuration yaml.
 # The name of the output file is returned in `out_config_file`.
-# mock_name:       name of file that is mocked. Can be empty to create common file with no excludes.
-# exclude_list:    holds list of functions / match strings that should be placed in strippables.
-# out_config_file: return setting with path and name to generate config file
-macro(configure_unity_conf_file mock_name exclude_list out_config_file)
+# mock_name:         name of file that is mocked. Can be empty to create common file with no excludes.
+# exclude_fn_list:   holds list of functions that should be placed in strippables.
+# exclude_word_list: holds list of words that should be placed in strippables.
+# out_config_file:   return setting with path and name to generate config file
+macro(configure_unity_conf_file mock_name exclude_fn_list exclude_word_list out_config_file)
   set(unity_config_template unity_cfg.yaml.template)
   set(unity_config_file_name unity_cfg.yaml)
   set(out_dir ${APPLICATION_BINARY_DIR}/mocks)
@@ -19,14 +20,18 @@ macro(configure_unity_conf_file mock_name exclude_list out_config_file)
                    ${out_dir}/${unity_config_file_name}
     )
     set(${out_config_file} ${out_dir}/${unity_config_file_name})
-  elseif("${exclude_list}" STREQUAL "")
+  elseif("${exclude_fn_list}" STREQUAL "" AND "${exclude_word_list}" STREQUAL "")
     # Just return the common file.
     set(${out_config_file} ${out_dir}/${unity_config_file_name})
   else()
     set(CMOCK_STRIPPABLES ":strippables:\n")
-    foreach(ex ${exclude_list})
+    foreach(ex ${exclude_fn_list})
       string(CONFIGURE "        - '(?:${ex}\\s*\\(+.*?\\)+)'\n" strip_regex)
       set(CMOCK_STRIPPABLES "${CMOCK_STRIPPABLES}${strip_regex}")
+    endforeach()
+    foreach(ex ${exclude_word_list})
+      string(CONFIGURE "        - '(?:${ex})'\n" strip_word)
+      set(CMOCK_STRIPPABLES "${CMOCK_STRIPPABLES}${strip_word}")
     endforeach()
     set(${out_config_file} ${out_dir}/${mock_name}.${unity_config_file_name})
     configure_file(${NRF_DIR}/tests/unity/${unity_config_template} ${${out_config_file}})
@@ -39,7 +44,7 @@ zephyr_library()
 set_property(GLOBAL PROPERTY CMOCK_DIR ${ZEPHYR_BASE}/../test/cmock)
 get_property(CMOCK_DIR GLOBAL PROPERTY CMOCK_DIR)
 
-configure_unity_conf_file("" "" unused)
+configure_unity_conf_file("" "" "" unused)
 
 find_program(
   RUBY_EXECUTABLE
@@ -71,7 +76,7 @@ function(test_runner_generate test_file_path)
   file(MAKE_DIRECTORY "${UNITY_PRODUCTS_DIR}")
   get_filename_component(test_file_name "${test_file_path}" NAME)
   set(output_file "${UNITY_PRODUCTS_DIR}/runner_${test_file_name}")
-  configure_unity_conf_file("${file_name}" "" conf_file)
+  configure_unity_conf_file("${file_name}" "" "" conf_file)
 
   add_custom_command(
     COMMAND ${RUBY_EXECUTABLE}
@@ -90,16 +95,17 @@ endfunction()
 
 #
 # Usage
-#   cmock_generate(<header_path> <dst_path> [EXCLUDE <pattern>])
+#   cmock_generate(<header_path> <dst_path> [FUNC_EXCLUDE <pattern>] [WORD_EXCLUDE <pattern>])
 #
 # Generate cmock for provided header file.
 #
 # header_path:       Path to header
 # dst_path:          Location of generated header
-# EXCLUDE <pattern>: Exclude functions matching pattern. Pattern can be a simple style regex.
+# FUNC_EXCLUDE <pattern>: Exclude functions matching pattern. Pattern can be a simple style regex.
+# WORD_EXCLUDE <pattern>: Exclude words matching pattern. Pattern can be a simple style regex.
 #
 function(cmock_generate header_path dst_path)
-  cmake_parse_arguments(CMOCK "" "" "EXCLUDE" ${ARGN})
+  cmake_parse_arguments(CMOCK "" "" "FUNC_EXCLUDE:WORD_EXCLUDE" ${ARGN})
   get_property(CMOCK_DIR GLOBAL PROPERTY CMOCK_DIR)
   set(MOCK_PREFIX cmock_)
 
@@ -107,7 +113,7 @@ function(cmock_generate header_path dst_path)
   set(MOCK_FILE ${dst_path}/${MOCK_PREFIX}${file_name}.c)
 
   file(MAKE_DIRECTORY "${dst_path}")
-  configure_unity_conf_file("${file_name}" "${CMOCK_EXCLUDE}" conf_file)
+  configure_unity_conf_file("${file_name}" "${CMOCK_FUNC_EXCLUDE}" "${CMOCK_WORD_EXCLUDE}" conf_file)
 
   add_custom_command(OUTPUT ${MOCK_FILE}
     COMMAND ${RUBY_EXECUTABLE}
@@ -140,13 +146,13 @@ endfunction()
 # Function takes header file and generates a file containing list of functions.
 # File is then passed to 'cmock_linker_trick' which adds linker option for each
 # function listed in the file.
-# EXCLUDE <pattern>: Exclude functions matching pattern. Pattern can be a simple style regex.
+# FUNC_EXCLUDE <pattern>: Exclude functions matching pattern. Pattern can be a simple style regex.
 function(cmock_linker_wrap_trick header_file_path)
-  cmake_parse_arguments(CMOCK "" "" "EXCLUDE" ${ARGN})
+  cmake_parse_arguments(CMOCK "" "" "FUNC_EXCLUDE" ${ARGN})
   set(flist_file "${header_file_path}.flist")
 
-  if(DEFINED CMOCK_EXCLUDE)
-    string(JOIN "--exclude;" exclude_arg ${CMOCK_EXCLUDE})
+  if(DEFINED CMOCK_FUNC_EXCLUDE)
+    string(JOIN "--exclude;" exclude_arg ${CMOCK_FUNC_EXCLUDE})
     set(exclude_arg "--exclude" ${exclude_arg})
   endif()
 
@@ -198,16 +204,23 @@ endfunction()
 #for example if file under test is include mocked header as <foo/header.h> then
 # mock and replaced header should be placed in <mock_path>/foo with <mock_path>
 # added as include path.
-# EXCLUDE <pattern>: Exclude functions matching pattern. Pattern can be a simple style regex.
+# EXCLUDE <pattern>: Exclude functions matching pattern. Deprecated, use FUNC_EXCLUDE instead.
+# FUNC_EXCLUDE <pattern>: Exclude functions matching pattern. Pattern can be a simple style regex.
+# WORD_EXCLUDE <pattern>: Exclude words matching pattern. Pattern can be a simple style regex.
 function(cmock_handle header_file)
-  cmake_parse_arguments(CMOCK "" "" "EXCLUDE" ${ARGN})
+  cmake_parse_arguments(CMOCK "" "" "EXCLUDE;FUNC_EXCLUDE;WORD_EXCLUDE" ${ARGN})
   get_property(CMOCK_DIR GLOBAL PROPERTY CMOCK_DIR)
   set(CMOCK_PRODUCTS_DIR ${APPLICATION_BINARY_DIR}/mocks)
+
+  if (DEFINED CMOCK_EXCLUDE)
+    message(DEPRECATION " cmock_handle(EXCLUDE) is deprecated, use FUNC_EXCLUDE instead")
+    list(APPEND CMOCK_FUNC_EXCLUDE ${CMOCK_EXCLUDE})
+  endif()
 
   #get optional offset macro
   set (extra_macro_args ${CMOCK_UNPARSED_ARGUMENTS})
   list(LENGTH extra_macro_args num_extra_args)
-  if (${num_extra_args} EQUAL 1)
+  if (NOT ${num_extra_args} EQUAL 0)
     list(GET extra_macro_args 0 optional_offset)
     set(dst_path "${CMOCK_PRODUCTS_DIR}/${optional_offset}")
   else()
@@ -221,9 +234,9 @@ function(cmock_handle header_file)
   set(wrap_header "${dst_path}/internal/${header_name}")
 
   cmock_headers_prepare(${header_file} ${mod_header_path} ${wrap_header})
-  cmock_generate(${wrap_header} ${dst_path} EXCLUDE ${CMOCK_EXCLUDE})
+  cmock_generate(${wrap_header} ${dst_path} FUNC_EXCLUDE ${CMOCK_FUNC_EXCLUDE} WORD_EXCLUDE ${CMOCK_WORD_EXCLUDE})
 
-  cmock_linker_wrap_trick(${mod_header_path} EXCLUDE ${CMOCK_EXCLUDE})
+  cmock_linker_wrap_trick(${mod_header_path} FUNC_EXCLUDE ${CMOCK_FUNC_EXCLUDE})
 
   target_include_directories(app BEFORE PRIVATE ${CMOCK_PRODUCTS_DIR})
   message(STATUS "Generating cmock for header ${header_file}")

--- a/tests/unity/wrap_test/CMakeLists.txt
+++ b/tests/unity/wrap_test/CMakeLists.txt
@@ -13,7 +13,9 @@ project(wrap_test)
 test_runner_generate(src/wrap_test.c)
 
 # create mocks for test_code functions
-cmock_handle(src/test_code/test_code.h test_code)
+cmock_handle(src/test_code/test_code.h test_code
+  WORD_EXCLUDE "IGNORE_ME"
+)
 
 # add module test_code
 target_sources(app PRIVATE src/test_code/test_code.c)

--- a/tests/unity/wrap_test/src/call/call.c
+++ b/tests/unity/wrap_test/src/call/call.c
@@ -43,3 +43,8 @@ int call_multiline_def(int arg, int len)
 {
 	return multiline_def(arg, len);
 }
+
+void call_exclude_word_fn(void)
+{
+	exclude_word_fn();
+}

--- a/tests/unity/wrap_test/src/call/call.h
+++ b/tests/unity/wrap_test/src/call/call.h
@@ -13,5 +13,6 @@ int call_always_inline_fn(void);
 int call_after_macro(void);
 int call_extra_whitespace(void);
 int call_multiline_def(int arg, int len);
+void call_exclude_word_fn(void);
 
 #endif /* __CALL_H */

--- a/tests/unity/wrap_test/src/test_code/test_code.c
+++ b/tests/unity/wrap_test/src/test_code/test_code.c
@@ -5,3 +5,7 @@
  */
 
 #include "test_code/test_code.h"
+
+void exclude_word_fn(void)
+{
+}

--- a/tests/unity/wrap_test/src/test_code/test_code.h
+++ b/tests/unity/wrap_test/src/test_code/test_code.h
@@ -86,4 +86,8 @@ typedef struct __attribute__ ((__packed__)) {
 int multiline_def(int arg,
 					int len);
 
+/* Test WORD_EXCLUDE parameter for cmock_handle() */
+#define IGNORE_ME
+IGNORE_ME void exclude_word_fn(void);
+
 #endif /* __TEST_CODE_H */

--- a/tests/unity/wrap_test/src/wrap_test.c
+++ b/tests/unity/wrap_test/src/wrap_test.c
@@ -79,6 +79,13 @@ void test_multiline_def(void)
 	TEST_ASSERT_EQUAL(EXPECT_MULTILINE_DEF, call_multiline_def(1, 2));
 }
 
+void test_word_exclude(void)
+{
+	__cmock_exclude_word_fn_Expect();
+
+	call_exclude_word_fn();
+}
+
 /* It is required to be added to each test. That is because unity is using
  * different main signature (returns int) and zephyr expects main which does
  * not return value.


### PR DESCRIPTION
The regexp only matched functions, but not words. These should be supported as well, since there might be some compiler-specific keywords or macros that CMock does not understand that should be stripped before mock generation.

Let words be excluded during mock generation by setting `WORD_EXCLUDE`, rename `EXCLUDE` to `FUNC_EXCLUDE`.