### PR TITLE
samples: matter: Configuration with nRF21540 EK in integration builds

### DIFF
--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -44,12 +44,12 @@ tests:
       - nrf21540dk_nrf52840
     platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
   # ---------------
-  sample.matter.lock.release.nrf5340dk:
+  sample.matter.lock.release.nrf21540_ek:
     build_only: true
-    extra_args: CONF_FILE=prj_release.conf
+    extra_args: CONF_FILE=prj_release.conf SHIELD=nrf21540_ek
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
   sample.matter.lock.smp_dfu_ffs:
     build_only: true
     extra_args: CONFIG_CHIP_LIB_SHELL=y CONFIG_CHIP_DFU_OVER_BT_SMP=y CONFIG_CHIP_COMMISSIONABLE_DEVICE_TYPE=y


### PR DESCRIPTION
Add one Matter sample configuration with nRF21540 EK in integration builds

Signed-off-by: Janusz Gąsior <janusz.gasior@nordicsemi.no>