### PR TITLE
samples: matter: refine lock multi-variant swap buffering

### DIFF
--- a/samples/matter/lock/src/software_images_swapper.h
+++ b/samples/matter/lock/src/software_images_swapper.h
@@ -29,7 +29,7 @@ public:
 
 private:
 	const struct device *mFlashDevice = DEVICE_DT_GET(DT_CHOSEN(nordic_pm_ext_flash));
-	static constexpr uint16_t kBufferSize = 256;
+	static constexpr uint16_t kBufferSize = 4096;
 
 	bool mSwapInProgress = false;
 	SoftwareImagesSwapDoneCallback swapDoneCallback;


### PR DESCRIPTION
* avoid using kernel heap
* increase the buffer size to speed up swapping
* take care of buffer edge cases
* this decreases the swap time by ~4 seconds

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>