### PR TITLE
drivers: wifi: Fix crash in case of driver initialization failure

### DIFF
--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_net_if.c
@@ -226,6 +226,12 @@ void wifi_nrf_if_init_zep(struct net_if *iface)
 		return;
 	}
 
+	if (!device_is_ready(dev)) {
+		LOG_ERR("%s: Device %s is not ready\n",
+			__func__, dev->name);
+		return;
+	}
+
 	vif_ctx_zep = dev->data;
 
 	if (!vif_ctx_zep) {
@@ -309,6 +315,12 @@ int wifi_nrf_if_start_zep(const struct device *dev)
 	if (!dev) {
 		LOG_ERR("%s: Invalid parameters\n",
 			__func__);
+		goto out;
+	}
+
+	if (!device_is_ready(dev)) {
+		LOG_ERR("%s: Device %s is not ready\n",
+			__func__, dev->name);
 		goto out;
 	}
 


### PR DESCRIPTION
In case of driver initialization failure it is expected that the net_if init is not called by the Zephyr, but that is not the case, Zephyr still calls net_if init and start, so, add a check to verify device status before proceeding.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>