### PR TITLE
manifest: sdk-hostap: Pull fix to improve boot delay

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 4bf4967a83e8c3a00c58dca4bcb967c18b182e86
+      revision: ca396ab4472f9c6a6a2c3fe7f253911f63b7140b
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 4f775a87611a084a2f6ad9a8a5034e080ddcc579


### PR DESCRIPTION
This improves boot delay by a second (and also improves scan delay).

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>