### PR TITLE
drivers: sensor: bh1749: Add wait-for-ready functionality

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -415,6 +415,10 @@ This section provides detailed lists of changes by :ref:`driver <drivers>`.
 * Reduced log verbosity of :ref:`pmw3360`.
 * Reduced log verbosity of :ref:`paw3212`.
 
+* :ref:`lib_bh1749`:
+
+  * Fixed an issue where the driver would attempt to use APIs before the sensor was ready, which in turn could make the application hang.
+
 Libraries
 =========
 

--- a/drivers/sensor/bh1749/CMakeLists.txt
+++ b/drivers/sensor/bh1749/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 #  Copyright (c) 2019 Nordic Semiconductor ASA
 #
-#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 zephyr_library()

--- a/drivers/sensor/bh1749/CMakeLists.txt
+++ b/drivers/sensor/bh1749/CMakeLists.txt
@@ -7,4 +7,3 @@
 zephyr_library()
 zephyr_library_sources(bh1749.c)
 zephyr_library_sources_ifdef(CONFIG_BH1749_TRIGGER bh1749_trigger.c)
-

--- a/drivers/sensor/bh1749/Kconfig
+++ b/drivers/sensor/bh1749/Kconfig
@@ -16,4 +16,13 @@ config BH1749_TRIGGER
 	bool "Trigger for BH1749"
 	depends on GPIO
 
+config BH1749_READY_WAIT_TIME_MSEC
+	int "Time to wait for sensor to be ready"
+	default 10
+	help
+	  BH1749 requires certain configurations to happen with a delay, so that it may take some
+	  time before the sensor is ready to be used.
+	  This option configurues a wait time in milliseconds that the driver will wait for the the sensor
+	  to be ready in cases where it is still initializing.
+
 endif # BH1749

--- a/drivers/sensor/bh1749/Kconfig
+++ b/drivers/sensor/bh1749/Kconfig
@@ -1,7 +1,7 @@
 #
 #  Copyright (c) 2019 Nordic Semiconductor ASA
 #
-#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 menuconfig BH1749

--- a/drivers/sensor/bh1749/bh1749.c
+++ b/drivers/sensor/bh1749/bh1749.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2019, 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2023 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr/device.h>

--- a/drivers/sensor/bh1749/bh1749.c
+++ b/drivers/sensor/bh1749/bh1749.c
@@ -50,7 +50,7 @@ static int bh1749_sample_fetch(const struct device *dev, enum sensor_channel cha
 		return -ENOTSUP;
 	}
 
-	if (unlikely(!data->ready)) {
+	if (!bh1749_is_ready(dev)) {
 		LOG_INF("Device is not initialized yet");
 		return -EBUSY;
 	}
@@ -105,7 +105,7 @@ static int bh1749_channel_get(const struct device *dev,
 {
 	struct bh1749_data *data = dev->data;
 
-	if (unlikely(!data->ready)) {
+	if (!bh1749_is_ready(dev)) {
 		LOG_INF("Device is not initialized yet");
 		return -EBUSY;
 	}
@@ -210,7 +210,7 @@ static void bh1749_async_init(struct k_work *work)
 		data->async_init_step++;
 
 		if (data->async_init_step == ASYNC_INIT_STEP_COUNT) {
-			data->ready = true;
+			atomic_set(&data->ready, 1);
 			LOG_INF("BH1749 initialized");
 		} else {
 			k_work_schedule(init_work,

--- a/drivers/sensor/bh1749/bh1749.h
+++ b/drivers/sensor/bh1749/bh1749.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr/types.h>

--- a/drivers/sensor/bh1749/bh1749_trigger.c
+++ b/drivers/sensor/bh1749/bh1749_trigger.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2019, 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2019 - 2023 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <zephyr/device.h>

--- a/drivers/sensor/bh1749/bh1749_trigger.c
+++ b/drivers/sensor/bh1749/bh1749_trigger.c
@@ -50,6 +50,11 @@ int bh1749_attr_set(const struct device *dev,
 	const struct i2c_dt_spec *i2c = &config->i2c;
 	int err;
 
+	if (!bh1749_is_ready(dev)) {
+		LOG_INF("Device is not initialized yet");
+		return -EBUSY;
+	}
+
 	if (chan != SENSOR_CHAN_ALL) {
 		return -ENOTSUP;
 	}
@@ -99,6 +104,11 @@ int bh1749_trigger_set(const struct device *dev,
 	const struct i2c_dt_spec *i2c = &config->i2c;
 	uint8_t interrupt_source = 0;
 	int err;
+
+	if (!bh1749_is_ready(dev)) {
+		LOG_INF("Device is not initialized yet");
+		return -EBUSY;
+	}
 
 	err = gpio_pin_interrupt_configure_dt(&config->int_gpio,
 					      GPIO_INT_DISABLE);


### PR DESCRIPTION
The BH1749 requires some initialization to happen iwith a certain delay, and hence the driver achieves that using delayable work items on the system workqueue.

In some cases this results in a race where an application may attempt to use sensor APIs before the sensor is fully initialized. This can cause issues both with the sensor and subsystems that the driver uses, for instance GPIOTE.
In turn, this could cause the application to hang indefinitely
in an interrupt handler. See nRF9160 errata 4 for more details.

This patch introduces a wait time of 10 milliseconds for the driver to complete initialization before any public API is usable.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>