### PR TITLE
mcuboot: Fix nRF5340 hook not being able to be removed

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -33,7 +33,11 @@ The following sections provide detailed lists of changes by component.
 MCUboot
 =======
 
-|no_changes_yet_note|
+* Added:
+
+  * An option to prevent inclusion of default nRF5340 network core DFU image hook, which allows a custom implementation by users if the :kconfig:option:`CONFIG_BOOT_IMAGE_ACCESS_HOOK_NRF5340` Kconfig option is disabled (enabled by default).
+    CMake can be used to add additional hook files.
+    See :file:`modules/mcuboot/hooks/CMakeLists.txt` for an example of how to achieve this.
 
 Application development
 =======================

--- a/modules/mcuboot/boot/zephyr/Kconfig
+++ b/modules/mcuboot/boot/zephyr/Kconfig
@@ -95,6 +95,16 @@ config BOOT_IMAGE_ACCESS_HOOKS
 	default y if UPDATEABLE_IMAGE_NUMBER > 1 && SOC_NRF5340_CPUAPP && PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY
 	depends on MCUBOOT
 
+config BOOT_IMAGE_ACCESS_HOOK_NRF5340
+	bool "Enable default nRF5340 hook"
+	default y if BOOT_IMAGE_ACCESS_HOOKS
+	depends on BOOT_IMAGE_ACCESS_HOOKS
+	help
+	  This enables the default nRF5340 image hook for MCUboot, which
+	  supports upgrading the network core image from the application core.
+	  To disable or override this feature, disable this option and add a
+	  custom file using CMake.
+
 DT_COMPAT_SIM_FLASH:= zephyr,sim-flash
 DT_SIM_FLASH_PATH := $(dt_nodelabel_path,flash_sim0)
 

--- a/modules/mcuboot/hooks/CMakeLists.txt
+++ b/modules/mcuboot/hooks/CMakeLists.txt
@@ -5,7 +5,9 @@
 #
 
 if(CONFIG_BOOT_IMAGE_ACCESS_HOOKS)
-  zephyr_library()
-  zephyr_library_sources(nrf53_hooks.c)
-  zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
+  if(CONFIG_BOOT_IMAGE_ACCESS_HOOK_NRF5340)
+    zephyr_library()
+    zephyr_library_sources(nrf53_hooks.c)
+    zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
+  endif()
 endif()


### PR DESCRIPTION
This fixes a regression whereby if custom image hooks are enabled on the nRF5340, the default one will be included and cannot be disabled whereas previously in ncs 2.1 and older, it could be overridden.

Fixes: NCSDK-19337