### PR TITLE
event_manager_proxy: Fix placing sections before _end symbol

### DIFF
--- a/subsys/event_manager_proxy/CMakeLists.txt
+++ b/subsys/event_manager_proxy/CMakeLists.txt
@@ -9,4 +9,4 @@ zephyr_sources(event_manager_proxy.c)
 # Note:
 # Linker script file for the em_proxy has to be placed after the content of the em.ld file
 # from event_manager module that has SORT_KEY set to 'default'.
-zephyr_linker_sources(SECTIONS em_proxy.ld SORT_KEY 'zzz_place_after_em_ld_file')
+zephyr_linker_sources(RAM_SECTIONS em_proxy.ld SORT_KEY 'zzz_place_after_em_ld_file')


### PR DESCRIPTION
Event manager proxy linker script file was placing its sections behind _end symbol. Any call to malloc could overwrite and corrupt emp data. Fix by specifying
RAM_SECTIONS for event manager proxy linker script.

Signed-off-by: Emil Obalski <Emil.Obalski@nordicsemi.no>