### PR TITLE
scripts: cred_store: Add cred store script

### DIFF
--- a/scripts/cred_store/at_client.py
+++ b/scripts/cred_store/at_client.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+from exceptions import ATCommandError, NoATClientException
+
+ERR_CODE_TO_MSG = {
+    513: 'Not found',
+    514: 'Not allowed',
+    515: 'Memory full',
+    518: 'Not allowed in active state',
+    519: 'Already exists',
+    523: 'Key generation failed',
+}
+
+class ATClient():
+    def __init__(self, serial_dev):
+        if serial_dev is None:
+            raise RuntimeError('Serial device is None')
+
+        self.device = serial_dev
+
+    def __at_command_ok(self, cmd):
+        """Send AT command and return a bool whether the modem response was OK/ERROR."""
+        try:
+            self.at_command(cmd)
+        except ATCommandError as err:
+            print(err)
+            return False
+        return True
+
+    def __response_line(self):
+        """Read a single line from device and return a decoded and trimmed string."""
+        line = self.device.readline()
+        if line == b'':
+            raise TimeoutError
+        return line.decode('utf-8').strip()
+
+    def __read_response(self, cmd):
+        """Read full response for a command until it reaches OK or an error."""
+        response = []
+        while True:
+            line = self.__response_line()
+
+            if line == 'OK':
+                break
+            elif line == 'ERROR':
+                raise ATCommandError(f'Error returned for AT command: {cmd}')
+            elif line.startswith('+CME ERROR'):
+                code = line.replace('+CME ERROR: ', '')
+                msg = (
+                    f'Error returned for AT command: {cmd}\n'
+                    f'Error code: {code}\n'
+                    f'Error message: {ERR_CODE_TO_MSG[int(code)]}'
+                )
+                raise ATCommandError(msg)
+            else:
+                response.append(line)
+
+        return response
+
+    def connect(self, dev, baudrate = 115200, timeout = 1):
+        """Open a serial connection to the serial device"""
+
+        self.device.port = dev
+        self.device.baudrate = baudrate
+        self.device.timeout = timeout
+        self.device.open()
+
+    def verify(self):
+        """Check if modem responds to 'AT'
+
+        Raises NoATClientException if unsuccessful after 3 attempts.
+        """
+        retries = 3
+        try:
+            while not self.__at_command_ok('AT'):
+                retries = retries - 1
+                if retries == 0:
+                    raise NoATClientException
+        except TimeoutError:
+            raise NoATClientException
+        return True
+
+    def enable_error_codes(self):
+        """Change error responses to include error code"""
+        if not self.__at_command_ok('AT+CMEE=1'):
+            print('Failed to enable error notifications')
+
+    def at_command(self, cmd):
+        """Send AT command to modem and return the response as a list of response lines.
+
+        Raises ATCommandError if the modem responds with an error.
+        """
+
+        if not self.device.is_open:
+            raise ConnectionError('Serial device not connected')
+
+        self.device.reset_input_buffer()
+        self.device.write((cmd + '\r\n').encode('utf-8'))
+        return self.__read_response(cmd)

--- a/scripts/cred_store/cli.py
+++ b/scripts/cred_store/cli.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+import argparse
+import sys
+import serial
+
+from exceptions import ATCommandError, NoATClientException
+from at_client import ATClient
+from cred_store import CredStore, CredType
+
+FUN_MODE_OFFLINE = 4
+KEY_TYPES = list(map(lambda type: type.name, CredType))
+
+def parse_args(in_args):
+    parser = argparse.ArgumentParser(description='Manage certificates stored in a cellular modem.')
+    parser.add_argument('dev', help='Serial device used to communicate with the modem.')
+    parser.add_argument('--baudrate', type=int, default=115200, help='Serial baudrate')
+    parser.add_argument('--timeout', type=int, default=1,
+        help='Serial communication timeout in seconds')
+
+    subparsers = parser.add_subparsers(
+        title='subcommands', dest='subcommand', help='Certificate related commands'
+    )
+
+    # add list command
+    list_parser = subparsers.add_parser('list', help='List all keys stored in the modem')
+    list_parser.add_argument('--tag', type=int,
+        help='Only list keys in secure tag')
+    list_parser.add_argument('--type', choices=KEY_TYPES, default='ANY',
+        help='Only list key with given type')
+
+    # add write command
+    write_parser = subparsers.add_parser('write', help='Write key/cert to a secure tag')
+    write_parser.add_argument('tag', type=int,
+        help='Secure tag to write key to')
+    write_parser.add_argument('type',
+        choices=['ROOT_CA_CERT','CLIENT_CERT','CLIENT_KEY'],
+        help='Key type to write')
+    write_parser.add_argument('file',
+        type=argparse.FileType('r', encoding='UTF-8'),
+        help='PEM file to read from')
+
+    # add delete command
+    delete_parser = subparsers.add_parser('delete', help='Delete value from a secure tag')
+    delete_parser.add_argument('tag', type=int,
+        help='Secure tag to delete key')
+    delete_parser.add_argument('type', choices=KEY_TYPES,
+        help='Key type to delete')
+
+    # add generate command and args
+    generate_parser = subparsers.add_parser('generate', help='Generate private key')
+    generate_parser.add_argument('tag', type=int,
+        help='Secure tag to store generated key')
+    generate_parser.add_argument('file', type=argparse.FileType('wb'),
+        help='File to store CSR in DER format')
+
+    return parser.parse_args(in_args)
+
+def exec_cmd(args, cred_store):
+    if args.subcommand:
+        cred_store.func_mode(FUN_MODE_OFFLINE)
+
+    if args.subcommand == 'list':
+        type = CredType[args.type]
+        if type != CredType.ANY and args.tag is None:
+            raise RuntimeError("Cannot use --type without a --tag.")
+        creds = cred_store.list(args.tag, type)
+        table_format = "{:<12} {:<18} {:<64}"
+        print(table_format.format('Secure tag','Key type','SHA'))
+        for c in creds:
+            columns = [
+                c.tag,
+                c.type.name,
+                c.sha
+            ]
+            print(table_format.format(*columns))
+    elif args.subcommand=='write':
+        type = CredType[args.type]
+        cred_store.write(args.tag, type, args.file)
+    elif args.subcommand=='delete':
+        type = CredType[args.type]
+        if cred_store.delete(args.tag, type):
+            print(f'{type.name} in secure tag {args.tag} deleted')
+        else:
+            raise RuntimeError('delete failed')
+    elif args.subcommand=='generate':
+        cred_store.keygen(args.tag, args.file)
+        print(f'New private key generated in secure tag {args.tag}')
+        print(f'Wrote CSR in DER format to {args.file.name}')
+
+def main(in_args, cred_store):
+    at_client = cred_store.at_client
+    try:
+        args = parse_args(in_args)
+        if args.dev:
+            at_client.connect(args.dev, args.baudrate, args.timeout)
+            at_client.verify()
+            at_client.enable_error_codes()
+        exec_cmd(args, cred_store)
+    except serial.SerialException as err:
+        print(f'Serial error: {err}')
+    except NoATClientException:
+        print('The device does not respond to AT commands. Please flash at_client sample.')
+    except ATCommandError as err:
+        print(err)
+
+if __name__ == '__main__':
+    main(sys.argv[1:], CredStore(ATClient(serial.Serial())))

--- a/scripts/cred_store/cred_store.py
+++ b/scripts/cred_store/cred_store.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+import base64
+import io
+from enum import Enum
+from typing import List
+
+FUN_MODE_OFFLINE = 4
+
+class CredType(Enum):
+    ANY = -1
+    ROOT_CA_CERT = 0
+    CLIENT_CERT = 1
+    CLIENT_KEY = 2
+    PSK = 3
+    PSK_ID = 4
+    PUB_KEY = 5
+    DEV_ID_PUB_KEY = 6
+    RESERVED = 7
+    ENDORSEMENT_KEY = 8
+    OWNERSHIP_KEY = 9
+    NORDIC_ID_ROOT_CA = 10
+    NORDIC_PUB_KEY = 11
+
+class Credential:
+    def __init__(self, tag: int, type: int, sha: str):
+        self.tag = tag
+        self.type = CredType(type)
+        self.sha = sha
+
+def is_ok(response_lines):
+    return len(response_lines) == 0
+
+class CredStore:
+    def __init__(self, at_client):
+        self.at_client = at_client
+
+    def func_mode(self, mode):
+        """Set modem functioning mode. See AT Command Reference Guide for valid modes."""
+        return self.at_client.at_command(f'AT+CFUN={mode}') == []
+
+    def list(self, tag = None, type: CredType = CredType.ANY) -> List[Credential]:
+        cmd = 'AT%CMNG=1'
+
+        if tag is None and type != CredType.ANY:
+            raise RuntimeError('Cannot list with type without a tag')
+
+        # optional secure tag
+        if tag is not None:
+            cmd = f'{cmd},{tag}'
+
+            # optional key type
+            if type != CredType.ANY:
+                cmd = f'{cmd},{CredType(type).value}'
+
+        response_lines = self.at_client.at_command(cmd)
+        columns = map(lambda line: line.replace('%CMNG: ', '').replace('"', '').split(','), response_lines)
+        cred_map = map(lambda columns:
+                Credential(int(columns[0]), int(columns[1]), columns[2].strip()),
+                columns
+            )
+
+        return list(cred_map)
+
+    def write(self, tag: int, type: CredType, file: io.TextIOBase):
+        cert = '\n' + file.read().rstrip()
+        return is_ok(self.at_client.at_command(f'AT%CMNG=0,{tag},{type.value},"{cert}"'))
+
+    def delete(self, tag: int, type: CredType):
+        return is_ok(self.at_client.at_command(f'AT%CMNG=3,{tag},{type.value}'))
+
+    def keygen(self, tag: int, file: io.BufferedIOBase, attributes: str = ''):
+        cmd = f'AT%KEYGEN={tag},2,0'
+
+        if attributes != '':
+            cmd = f'{cmd},"{attributes}"'
+
+        response_lines = self.at_client.at_command(cmd)
+        for l in response_lines:
+            if not l.startswith('%KEYGEN'):
+                continue
+            keygen_output = l.replace('%KEYGEN: "', '')
+            csr_der_b64 = keygen_output.split('.')[0]
+            csr_der_bytes = base64.urlsafe_b64decode(csr_der_b64 + '===')
+            file.write(csr_der_bytes)
+
+        file.close()

--- a/scripts/cred_store/exceptions.py
+++ b/scripts/cred_store/exceptions.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+class NoATClientException(Exception):
+    'Raised when the device does not have an AT client'
+
+class ATCommandError(Exception):
+    'Raised when an AT command responds with ERROR'

--- a/scripts/cred_store/test_at_client.py
+++ b/scripts/cred_store/test_at_client.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+"""
+Test for cert_manager.py
+"""
+
+import pytest
+
+from unittest.mock import Mock
+from at_client import ATClient
+from exceptions import ATCommandError, NoATClientException
+
+def encode_cmd(cmd):
+    return f'{cmd}\r\n'.encode('utf-8')
+
+def response_lines(lines):
+    return map(encode_cmd, lines)
+
+# pylint: disable=no-self-use
+class TestATClient:
+
+    @pytest.fixture
+    def at_client(self):
+        self.serial = Mock()
+        return ATClient(self.serial)
+
+    @pytest.fixture
+    def ok_resp(self, at_client):
+        self.serial.readline.return_value = 'OK\r\n'.encode('utf-8')
+
+    @pytest.fixture
+    def not_at_client_resp(self, at_client):
+        self.serial.readline.side_effect = [b'AT: command not found', b'']
+
+    @pytest.fixture
+    def error_resp(self, at_client):
+        self.serial.readline.return_value = 'ERROR\r\n'.encode('utf-8')
+
+    @pytest.fixture
+    def error_code_resp(self, at_client):
+        self.serial.readline.return_value = '+CME ERROR: 514\r\n'.encode('utf-8')
+
+    @pytest.fixture
+    def error_ok_resp(self, at_client):
+        self.serial.readline.side_effect = [b'ERROR', b'OK']
+
+    def test_create_without_serial_device(self):
+        with pytest.raises(RuntimeError):
+            ATClient(None)
+
+    def test_at_command_with_serial_closed(self, at_client):
+        with pytest.raises(ConnectionError):
+            self.serial.is_open = False
+            at_client.at_command('AT')
+
+    def test_verify_with_serial_closed(self, at_client):
+        with pytest.raises(ConnectionError):
+            self.serial.is_open = False
+            at_client.verify()
+
+    def test_exposes_serial_device(self, at_client):
+        assert at_client.device is self.serial
+
+    def test_connect_sets_port(self, at_client):
+        at_client.connect('/dev/tty.usb')
+        assert self.serial.port == '/dev/tty.usb'
+
+    def test_connect_sets_baudrate(self, at_client):
+        at_client.connect('foo', 123)
+        assert self.serial.baudrate == 123
+
+    def test_connect_sets_timeout(self, at_client):
+        at_client.connect('foo', timeout=3)
+        assert self.serial.timeout == 3
+
+    def test_connect_opens_serial_connection_to_device(self, at_client):
+        at_client.connect('foo')
+        self.serial.open.assert_called()
+
+    def test_verify_fails_for_wrong_response(self, at_client, not_at_client_resp):
+        """Test that the AT client verifiation raises NoATClientException when readline returns
+        unexpected lines and an empty string (timeout).
+        """
+        with pytest.raises(NoATClientException):
+            at_client.verify()
+
+    def test_verify_sends_at_command(self, at_client, ok_resp):
+        at_client.verify()
+        self.serial.write.assert_called_with('AT\r\n'.encode('utf-8'))
+
+    def test_verify_fails_on_error(self, at_client, error_resp):
+        with pytest.raises(NoATClientException):
+            at_client.verify()
+
+    def test_verify_retries_on_first_error(self, at_client, error_ok_resp):
+        assert at_client.verify()
+
+    def test_enable_error_codes_sends_cmd(self, at_client, ok_resp):
+        at_client.enable_error_codes()
+        self.serial.write.assert_called_with(encode_cmd('AT+CMEE=1'))
+
+    def test_at_command_error(self, at_client, error_resp):
+        with pytest.raises(ATCommandError):
+            at_client.at_command('AT')
+
+    def test_at_command_error_code(self, at_client, error_code_resp):
+        with pytest.raises(ATCommandError):
+            at_client.at_command('AT')
+
+    def test_at_command_error_code_maps_to_message(self, at_client, error_code_resp):
+        with pytest.raises(ATCommandError) as excinfo:
+            at_client.at_command('AT')
+        assert 'Not allowed' in str(excinfo.value)
+
+    def test_at_command_with_single_line_response(self, at_client):
+        self.serial.readline.side_effect = [b'single', b'OK']
+        assert at_client.at_command('AT+CGSN') == ['single']
+
+    def test_at_command_with_multi_line_response(self, at_client):
+        self.serial.readline.side_effect = [b'foo', b'bar', b'OK']
+        assert at_client.at_command('AT+CGSN') == ['foo', 'bar']

--- a/scripts/cred_store/test_cli.py
+++ b/scripts/cred_store/test_cli.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+import pytest
+
+from unittest.mock import Mock, ANY, patch
+from cli import main
+
+from cred_store import CredType
+from exceptions import NoATClientException
+
+# pylint: disable=no-self-use
+class TestCli():
+
+    @pytest.fixture
+    def at_client(self):
+        at_client = Mock()
+        return at_client
+
+    @pytest.fixture
+    def cred_store(self, at_client):
+        cred_store = Mock()
+        cred_store.at_client = at_client
+        return cred_store
+
+    @pytest.fixture
+    def offline(self, cred_store):
+        cred_store.funk_mode.return_value = True
+
+    @pytest.fixture
+    def empty_cred_list(self, cred_store):
+        cred_store.list.return_value = []
+
+    def test_device_passed_to_connect(self, cred_store, at_client, offline, empty_cred_list):
+        main(['/dev/tty.usb', 'list'], cred_store)
+        at_client.connect.assert_called_with('/dev/tty.usb', ANY, ANY)
+
+    def test_baudrate_passed_to_connect(self, cred_store, at_client, offline, empty_cred_list):
+        main(['fakedev', '--baudrate', '9600', 'list'], cred_store)
+        at_client.connect.assert_called_with(ANY, 9600, ANY)
+
+    def test_timeout_passed_to_connect(self, cred_store, at_client, offline, empty_cred_list):
+        main(['fakedev', '--timeout', '3', 'list'], cred_store)
+        at_client.connect.assert_called_with(ANY, ANY, 3)
+
+    def test_at_client_verify(self, cred_store, at_client, offline, empty_cred_list):
+        main(['fakedev', 'list'], cred_store)
+        at_client.verify.assert_called()
+
+    @patch('builtins.print')
+    def test_at_client_verify_fail(self, mock_print, cred_store, at_client):
+        at_client.verify.side_effect = NoATClientException()
+        main(['fakedev', 'list'], cred_store)
+        assert 'does not respond to AT commands' in mock_print.call_args[0][0]
+
+    def test_at_client_enable_error_codes(self, cred_store, at_client, offline, empty_cred_list):
+        main(['fakedev', 'list'], cred_store)
+        at_client.enable_error_codes.assert_called()
+
+    def test_list_default(self, cred_store, offline, empty_cred_list):
+        main(['fakedev', 'list'], cred_store)
+        cred_store.list.assert_called_with(None, CredType.ANY)
+
+    def test_list_with_tag(self, cred_store, offline, empty_cred_list):
+        main(['fakedev', 'list', '--tag', '123'], cred_store)
+        cred_store.list.assert_called_with(123, ANY)
+
+    def test_list_with_type(self, cred_store, offline, empty_cred_list):
+        main(['fakedev', 'list', '--tag', '123', '--type', 'CLIENT_KEY'], cred_store)
+        cred_store.list.assert_called_with(ANY, CredType.CLIENT_KEY)
+
+    def test_write_tag_and_type(self, cred_store, offline):
+        cred_store.write.return_value = True
+        main(['fakedev', 'write', '123', 'ROOT_CA_CERT', 'test_cli.py'], cred_store)
+        cred_store.write.assert_called_with(123, CredType.ROOT_CA_CERT, ANY)
+
+    @patch('builtins.open')
+    def test_write_file(self, mock_file, cred_store, offline):
+        cred_store.write.return_value = True
+        main(['fakedev', 'write', '123', 'ROOT_CA_CERT', 'foo.pem'], cred_store)
+        mock_file.assert_called_with('foo.pem', 'r', ANY, ANY, ANY)
+
+    def test_delete(self, cred_store, offline):
+        cred_store.delete.return_value = True
+        main(['fakedev', 'delete', '123', 'CLIENT_KEY'], cred_store)
+        cred_store.delete.assert_called_with(123, CredType.CLIENT_KEY)
+
+    @patch('builtins.open')
+    def test_generate_tag(self, mock_file, cred_store, offline):
+        cred_store.keygen.return_value = True
+        main(['fakedev', 'generate', '123', 'foo.der'], cred_store)
+        cred_store.keygen.assert_called_with(123, ANY)
+
+    @patch('builtins.open')
+    def test_generate_file(self, mock_file, cred_store, offline):
+        cred_store.keygen.return_value = True
+        main(['fakedev', 'generate', '123', 'foo.der'], cred_store)
+        mock_file.assert_called_with('foo.der', 'wb', ANY, ANY, ANY)

--- a/scripts/cred_store/test_cred_store.py
+++ b/scripts/cred_store/test_cred_store.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+import io
+import pytest
+
+from unittest.mock import Mock
+from cred_store import *
+from exceptions import ATCommandError
+
+# pylint: disable=no-self-use
+class TestCredStore:
+    """Test suite for CredStore
+
+    Most of the tests depend on a fixture that defines the at_client response instead of defining
+    the response in each test.
+    """
+
+    @pytest.fixture
+    def cred_store(self):
+        self.at_client = Mock()
+        return CredStore(self.at_client)
+
+    @pytest.fixture
+    def list_all_resp(self, cred_store):
+        cred_store.at_client.at_command.return_value = [
+            '%CMNG: 12345678, 0, "978C...02C4"',
+            '%CMNG: 567890, 1, "C485...CF09"'
+        ]
+
+    @pytest.fixture
+    def ok_resp(self, cred_store):
+        cred_store.at_client.at_command.return_value = []
+
+    @pytest.fixture
+    def csr_resp(self, cred_store):
+        # KEYGEN value is base64-encoded 'foo' and base64-encoded 'bar' joined by '.'
+        cred_store.at_client.at_command.return_value = ['', '%KEYGEN: "Zm9v.YmFy"']
+
+    @pytest.fixture
+    def at_error(self, cred_store):
+        cred_store.at_client.at_command.side_effect = ATCommandError('')
+
+    def test_exposes_at_client(self, cred_store):
+        assert cred_store.at_client is self.at_client
+
+    def test_func_mode_offline(self, cred_store):
+        cred_store.func_mode(4)
+        self.at_client.at_command.assert_called_with('AT+CFUN=4')
+
+    def test_func_mode_min(self, cred_store):
+        cred_store.func_mode(0)
+        self.at_client.at_command.assert_called_with('AT+CFUN=0')
+
+    def test_func_mode_fail(self, cred_store, at_error):
+        with pytest.raises(ATCommandError):
+            cred_store.func_mode(4)
+
+    def test_list_sends_cmng_command(self, cred_store, list_all_resp):
+        cred_store.list()
+        self.at_client.at_command.assert_called_with('AT%CMNG=1')
+
+    def test_list_with_tag_part_of_cmng(self, cred_store, list_all_resp):
+        cred_store.list(12345678)
+        self.at_client.at_command.assert_called_with('AT%CMNG=1,12345678')
+
+    def test_list_with_tag_and_type_part_of_cmng(self, cred_store, list_all_resp):
+        cred_store.list(12345678, CredType(0))
+        self.at_client.at_command.assert_called_with('AT%CMNG=1,12345678,0')
+
+    def test_list_credentials_contains_tag(self, cred_store, list_all_resp):
+        first = cred_store.list()[0]
+        assert first.tag == 12345678
+
+    def test_list_credentials_contains_type(self, cred_store, list_all_resp):
+        first = cred_store.list()[0]
+        assert first.type == CredType(0)
+
+    def test_list_credentials_contains_sha(self, cred_store, list_all_resp):
+        first = cred_store.list()[0]
+        assert first.sha == '978C...02C4'
+
+    def test_list_all_credentials_returns_multiple_credentials(self, cred_store, list_all_resp):
+        result = cred_store.list()
+        assert len(result) == 2
+        assert result[0].sha == '978C...02C4'
+        assert result[1].sha == 'C485...CF09'
+
+    def test_list_type_without_tag(self, cred_store):
+        with pytest.raises(RuntimeError):
+            cred_store.list(None, CredType(0))
+
+    def test_list_fail(self, cred_store, at_error):
+        with pytest.raises(ATCommandError):
+            cred_store.list()
+
+    def test_delete_success(self, cred_store, ok_resp):
+        assert cred_store.delete(567890, CredType(1))
+        self.at_client.at_command.assert_called_with('AT%CMNG=3,567890,1')
+
+    def test_delete_fail(self, cred_store, at_error):
+        with pytest.raises(ATCommandError):
+            cred_store.delete(123, CredType(1))
+
+    def test_write_success(self, cred_store, ok_resp):
+        cert_text = '''-----BEGIN CERTIFICATE-----
+dGVzdA==
+-----END CERTIFICATE-----'''
+        fake_file = io.StringIO(cert_text)
+        assert cred_store.write(567890, CredType.CLIENT_KEY, fake_file)
+        self.at_client.at_command.assert_called_with(f'AT%CMNG=0,567890,2,"\n{cert_text}"')
+
+    def test_write_fail(self, cred_store, at_error):
+        with pytest.raises(ATCommandError):
+            cred_store.write(567890, CredType.CLIENT_KEY, io.StringIO())
+
+    def test_generate_sends_keygen_cmd(self, cred_store, csr_resp):
+        fake_binary_file = Mock()
+        cred_store.keygen(12345678, fake_binary_file)
+        self.at_client.at_command.assert_called_with(f'AT%KEYGEN=12345678,2,0')
+
+    def test_generate_with_attributes(self, cred_store, csr_resp):
+        cred_store.keygen(12345678, Mock(), 'O=Nordic Semiconductor,L=Trondheim,C=no')
+        self.at_client.at_command.assert_called_with(
+            f'AT%KEYGEN=12345678,2,0,"O=Nordic Semiconductor,L=Trondheim,C=no"')
+
+    def test_generate_writes_csr_to_stream(self, cred_store, csr_resp):
+        fake_binary_file = Mock()
+        cred_store.keygen(12345678, fake_binary_file)
+        fake_binary_file.write.assert_called_with(b'foo')
+
+    def test_generate_fail(self, cred_store, at_error):
+        with pytest.raises(ATCommandError):
+            cred_store.keygen(12345678, Mock())


### PR DESCRIPTION
This commit introduces a new set of scripts for managing certificates stored in the modem on a cellular device. It's mainly a wrapper around the AT-command %CMNG with the exception of %KEYGEN. It also uses pythons serial library to communicate with the modem. This makes it possible to manage certificates in the modem from the command line in a cross-platform manner.

Execute cli.py to use it from the command line:
python3 cli.py /dev/tty.usbmodem0009600834341 list

To get the full help message use --help:
python3 cli.py --help

I have not introduced a separate documentation page other than the built in help. This command is part of a larger task to simplify the cloud certificate provisioning for AWS and Azure. The documentation for how to use this command will be part of the doc update PRs for AWS/Azure respectively.

Signed-off-by: Gregers Gram Rygg <gregers.gram.rygg@nordicsemi.no>