### PR TITLE
samples: matter: Removed unnecessary IPC overlay

### DIFF
--- a/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/app.overlay
+++ b/applications/matter_weather_station/configuration/thingy53_nrf5340_cpuapp/app.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
- #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	zephyr,user {
 		battery-charge-gpios = <&gpio1 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
@@ -30,10 +28,6 @@
 	aliases {
 		buzzer-pwm = &buzzer;
 	};
-};
-
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 &zephyr_udc0 {

--- a/samples/matter/light_bulb/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_bulb/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
@@ -26,10 +24,6 @@
 			pwms = < &pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
-};
-
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 &pwm0 {

--- a/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/light_switch/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,16 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/lock/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,16 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/samples/matter/template/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/template/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,16 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/matter/window_covering/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
@@ -29,10 +27,6 @@
 			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
-};
-
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */


### PR DESCRIPTION
Removed a workaround regarding IPC priority, which is not needed anymore in Matter samples.
