### PR TITLE
lib: nrf_modem: increase minimum NRF_MODEM_LIB_SHMEM_RX_SIZE

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -449,6 +449,12 @@ Bootloader libraries
 Modem libraries
 ---------------
 
+* :ref:`nrf_modem_lib_readme` library:
+
+  * Updated:
+
+    * The minimal value of :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHMEM_RX_SIZE` to meet the requirements of modem firmware 1.3.4.
+
 * :ref:`lib_location` library:
 
   * Added:

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -174,7 +174,7 @@ config NRF_MODEM_LIB_SHMEM_TX_SIZE
 
 config NRF_MODEM_LIB_SHMEM_RX_SIZE
 	int "RX region size"
-	range 1544 32768
+	range 2488 32768
 	default 8192
 	help
 	  Size of the shared memory region owned by the modem.


### PR DESCRIPTION
With modem firmware 1.3.4 the minimum NRF_MODEM_LIB_SHMEM_RX_SIZE is increased.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>