### PR TITLE
bluetooth: Fixing ifdef around periphera/central count config

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -659,7 +659,7 @@ static int configure_memory_usage(void)
 	int required_memory;
 	sdc_cfg_t cfg;
 
-#if defined(CONFIG_BT_CENTRAL) || defined(CONFIG_BT_LL_SOFTDEVICE_MULTIROLE)
+#if !defined(CONFIG_BT_LL_SOFTDEVICE_PERIPHERAL)
 	cfg.central_count.count = SDC_CENTRAL_COUNT;
 
 	/* NOTE: sdc_cfg_set() returns a negative errno on error. */
@@ -672,7 +672,7 @@ static int configure_memory_usage(void)
 	}
 #endif
 
-#if defined(CONFIG_BT_PERIPHERAL) || defined(CONFIG_BT_LL_SOFTDEVICE_MULTIROLE)
+#if !defined(CONFIG_BT_LL_SOFTDEVICE_CENTRAL)
 	cfg.peripheral_count.count = CONFIG_BT_CTLR_SDC_PERIPHERAL_COUNT;
 
 	required_memory =


### PR DESCRIPTION
When user doesn't want any peripheral links, we still have to call
sdc_cfg_set and tell sdc that it should allocate memory for 0
peripherals, otherwise sdc will set off space for 1 link by default.

Some of our tests where not setting any of the role configs.
And we where getting the "Allocated memory too low" error during boot.

Signed-off-by: Martin Tverdal <martin.tverdal@nordicsemi.no>