### PR TITLE
drivers: wifi: Fix net_mgmt stack overflow

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -22,6 +22,11 @@ config NRF_WIFI_LOW_POWER
 	bool "Enable low power mode in nRF Wi-Fi chipsets"
 	default y
 
+# Making calls to RPU from net_mgmt callbacks
+config NET_MGMT_EVENT_STACK_SIZE
+	int "Stack size for net mgmt event"
+	default 2048
+
 if WIFI_NRF700X
 
 config NRF700X_REV_A


### PR DESCRIPTION
commit 03cd64b20b ("drivers : wifi: Add support for multicast filters") introduced net_mgmt handlers in the driver and from the callbacks calls to RPU are made this increases the stack size of net_mgmt stack and causes overflow.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>