### PR TITLE
application: serial_lte_modem: Adjust UART configuration

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -33,27 +33,8 @@ config SLM_EXTERNAL_XTAL
 	default y
 
 #
-# Inter-Connect
+# AT command terminator
 #
-config SLM_UART_HWFC_RUNTIME
-	bool "Support of UART HWFC runtime configuration"
-	help
-		Selected if hw-flow-control is enabled in devicetree
-choice
-	prompt "UART for interconnect"
-	help
-		Selects which UART to use for interconnect:
-		-  UART 0
-		-  UART 2
-	config SLM_CONNECT_UART_0
-		bool "UART 0"
-		select SLM_UART_HWFC_RUNTIME if $(dt_nodelabel_bool_prop,uart0,hw-flow-control)
-
-	config SLM_CONNECT_UART_2
-		bool "UART 2"
-		select SLM_UART_HWFC_RUNTIME if $(dt_nodelabel_bool_prop,uart2,hw-flow-control)
-endchoice
-
 choice
 	prompt "Termination mode"
 	default SLM_CR_LF_TERMINATION

--- a/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.conf
+++ b/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,7 +10,6 @@
 
 # Use UART_0 (when working with PC terminal)
 # unmask the following config
-CONFIG_SLM_CONNECT_UART_0=y
 CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
 CONFIG_UART_0_NRF_HW_ASYNC=y
 CONFIG_SLM_WAKEUP_PIN=6
@@ -18,7 +17,6 @@ CONFIG_SLM_INDICATE_PIN=2
 
 # Use UART_2 (when working with external MCU)
 # unmask the following config
-#CONFIG_SLM_CONNECT_UART_2=y
 #CONFIG_UART_2_NRF_HW_ASYNC_TIMER=2
 #CONFIG_UART_2_NRF_HW_ASYNC=y
 #CONFIG_SLM_WAKEUP_PIN=31

--- a/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/ {
+	chosen {
+		ncs,slm-uart = &uart0;
+	};
+};
+
 &uart0 {
 	status = "okay";
 };

--- a/applications/serial_lte_modem/boards/thingy91_nrf9160_ns.conf
+++ b/applications/serial_lte_modem/boards/thingy91_nrf9160_ns.conf
@@ -9,7 +9,6 @@
 # set here will take precedence if they are present in both files.
 
 # Configuration related to external sensors.
-CONFIG_SLM_CONNECT_UART_0=y
 CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
 CONFIG_UART_0_NRF_HW_ASYNC=y
 CONFIG_SLM_WAKEUP_PIN=26

--- a/applications/serial_lte_modem/boards/thingy91_nrf9160_ns.overlay
+++ b/applications/serial_lte_modem/boards/thingy91_nrf9160_ns.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+/ {
+	chosen {
+		ncs,slm-uart = &uart0;
+	};
+};
+
 &uart2 {
 	status="disabled";
 };

--- a/applications/serial_lte_modem/doc/Generic_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/Generic_AT_commands.rst
@@ -300,18 +300,18 @@ Set command
 -----------
 
 The set command changes the UART baud rate and hardware flow control settings.
-Hardware flow control settings can be changed only if :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is selected.
+Hardware flow control settings can be changed only if ``hw-flow-control`` is enabled in device tree.
 These settings are stored in the flash memory and applied during the application startup.
 
 Syntax
 ~~~~~~
 
-The following is the syntax when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is selected:
+The following is the syntax when ``hw-flow-control`` is enabled in device tree.:
 ::
 
    #XSLMUART[=<baud_rate>,<hwfc>]
 
-The following is the syntax when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is not selected:
+The following is the syntax when ``hw-flow-control`` is disabled in device tree.:
 ::
 
    #XSLMUART[=<baud_rate>]
@@ -405,13 +405,13 @@ Syntax
 Response syntax
 ~~~~~~~~~~~~~~~
 
-The following is the syntax when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is selected:
+The following is the syntax when ``hw-flow-control`` is enabled in device tree:
 
 ::
 
    #XSLMUART: (list of the available baud rate options),(disable or enable hwfc)
 
-The following is the syntax when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` not selected:
+The following is the syntax when ``hw-flow-control`` is disabled in device tree:
 
 ::
 
@@ -420,14 +420,14 @@ The following is the syntax when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_
 Example
 ~~~~~~~
 
-The following is an example when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is selected:
+The following is an example when ``hw-flow-control`` is enabled in device tree:
 
 ::
 
    AT#XSLMUART=?
    #XSLMUART: (1200,2400,4800,9600,14400,19200,38400,57600,115200,230400,460800,921600,1000000),(0,1)
 
-The following is an example when :ref:`CONFIG_SLM_UART_HWFC_RUNTIME <CONFIG_SLM_UART_HWFC_RUNTIME>` is not selected:
+The following is an example when ``hw-flow-control`` is disabled in device tree.:
 
 ::
 

--- a/applications/serial_lte_modem/doc/slm_description.rst
+++ b/applications/serial_lte_modem/doc/slm_description.rst
@@ -58,26 +58,6 @@ CONFIG_SLM_EXTERNAL_XTAL - Use external XTAL for UARTE
    This option configures the application to use an external XTAL for UARTE.
    See the `nRF9160 Product Specification`_ (section 6.19 UARTE) for more information.
 
-.. _CONFIG_SLM_UART_HWFC_RUNTIME:
-
-CONFIG_SLM_UART_HWFC_RUNTIME - Support of UART HWFC runtime configuration
-   This option let the application configure HWFC during runtime rather than while compiling by using ``#XSLMUART``.
-   This option is automatically selected when the **hw-flow-control** is defined in the DTS overlay.
-
-.. _CONFIG_SLM_CONNECT_UART_0:
-
-CONFIG_SLM_CONNECT_UART_0 - UART 0
-   This option selects UART 0 for the UART connection.
-   Select this option if you want to test the application with a PC.
-
-   This option is automatically selected when the build target is ``thingy91_nrf9160_ns``.
-
-.. _CONFIG_SLM_CONNECT_UART_2:
-
-CONFIG_SLM_CONNECT_UART_2 - UART 2
-   This option selects UART 2 for the UART connection.
-   Select this option if you want to test the application with an external CPU.
-
 .. _CONFIG_SLM_START_SLEEP:
 
 CONFIG_SLM_START_SLEEP - Enter sleep on startup
@@ -92,8 +72,8 @@ CONFIG_SLM_WAKEUP_PIN - Interface GPIO to exit from sleep or idle
 
    * On the nRF9160 DK:
 
-     * **P0.6** (Button 1 on the nRF9160 DK) is used when :ref:`CONFIG_SLM_CONNECT_UART_0 <CONFIG_SLM_CONNECT_UART_0>` is selected.
-     * **P0.31** is used when :ref:`CONFIG_SLM_CONNECT_UART_2 <CONFIG_SLM_CONNECT_UART_2>` is selected.
+     * **P0.6** (Button 1 on the nRF9160 DK) is used when UART_0 is used.
+     * **P0.31** is used when UART_1 is used.
 
    * On Thingy:91, **P0.26** (Multi-function button on Thingy:91) is used.
 
@@ -107,8 +87,8 @@ CONFIG_SLM_INDICATE_PIN - Interface GPIO to indicate data available or unsolicit
    This option specifies which interface GPIO to use for indicating data available or unsolicited event notifications from the modem.
    On the nRF9160 DK, it is set by default as follows:
 
-   * **P0.2** (LED 1 on the nRF9160 DK) is used when :ref:`CONFIG_SLM_CONNECT_UART_0 <CONFIG_SLM_CONNECT_UART_0>` is selected.
-   * **P0.30** is used when :ref:`CONFIG_SLM_CONNECT_UART_2 <CONFIG_SLM_CONNECT_UART_2>` is selected.
+   * **P0.2** (LED 1 on the nRF9160 DK) is used when UART_0 is selected.
+   * **P0.30** is used when UART_2 is selected.
 
    It is not defined when the target is Thingy:91.
 
@@ -347,7 +327,7 @@ To connect to the nRF9160 DK with a PC
 
 .. slm_connecting_9160dk_pc_instr_start
 
-1. Verify that :ref:`CONFIG_SLM_CONNECT_UART_0 <CONFIG_SLM_CONNECT_UART_0>` is defined in the application.
+1. Verify that ``UART_0`` is selected in the application.
    It is defined in the default configuration.
 
 2. Use LTE Link Monitor to connect to the development kit.
@@ -397,30 +377,43 @@ To connect with an external MCU using UART_2, change the configuration files for
 
 * In the :file:`nrf9160dk_nrf9160_ns.conf` file::
 
-   # Use UART_0 (when working with PC terminal)
-   # unmask the following config
-   #CONFIG_SLM_CONNECT_UART_0=y
-   #CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
-   #CONFIG_UART_0_NRF_HW_ASYNC=y
-   #CONFIG_SLM_WAKEUP_PIN=6
-   #CONFIG_SLM_INDICATE_PIN=2
+     # Use UART_0 (when working with PC terminal)
+     # unmask the following config
+     #CONFIG_UART_0_NRF_HW_ASYNC_TIMER=2
+     #CONFIG_UART_0_NRF_HW_ASYNC=y
+     #CONFIG_SLM_WAKEUP_PIN=6
+     #CONFIG_SLM_INDICATE_PIN=2
 
-   # Use UART_2 (when working with external MCU)
-   # unmask the following config
-   CONFIG_SLM_CONNECT_UART_2=y
-   CONFIG_UART_2_NRF_HW_ASYNC_TIMER=2
-   CONFIG_UART_2_NRF_HW_ASYNC=y
-   CONFIG_SLM_WAKEUP_PIN=31
-   CONFIG_SLM_INDICATE_PIN=30
+     # Use UART_2 (when working with external MCU)
+     # unmask the following config
+     CONFIG_UART_2_NRF_HW_ASYNC_TIMER=2
+     CONFIG_UART_2_NRF_HW_ASYNC=y
+     CONFIG_SLM_WAKEUP_PIN=31
+     CONFIG_SLM_INDICATE_PIN=30
 
 
 * In the :file:`nrf9160dk_nrf9160_ns.overlay` file::
 
-   &uart0 {
-      status = "disabled";
+     / {
+         chosen {
+                  ncs,slm-uart = &uart2;
+                }
+       };
 
-   &uart2 {
-      status = "okay";
+     &uart0 {
+        status = "disabled";
+     };
+
+     &uart2 {
+        compatible = "nordic,nrf-uarte";
+        current-speed = <115200>;
+        status = "okay";
+        hw-flow-control;
+
+        pinctrl-0 = <&uart2_default_alt>;
+        pinctrl-1 = <&uart2_sleep_alt>;
+        pinctrl-names = "default", "sleep";
+     };
 
 
 The following table shows how to connect an nRF52 Series development kit to the nRF9160 DK to be able to communicate through UART:
@@ -444,7 +437,7 @@ The following table shows how to connect an nRF52 Series development kit to the 
    * - GPIO IN P0.26
      - GPIO OUT P0.30
 
-Use the following UART instances:
+Use the following UART devices:
 
 * nRF52840 or nRF52832 - UART0
 * nRF9160 - UART2


### PR DESCRIPTION
Use Zephyr chosen nodes to select UART instance
Use Zephyr DTS API to detect selected UART instance
Log UART instance in use and its configuration
Remove below SLM configuration items
.CONFIG_SLM_CONNECT_UART_0
.CONFIG_SLM_CONNECT_UART_2
.CONFIG_SLM_UART_HWFC_RUNTIME

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>