### PR TITLE
doc: samples: radio test: Specify which radio this sample is using.

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -343,6 +343,7 @@ Peripheral samples
 
   * Added support for the nRF7002 board.
   * Fixed sample building with support for the Skyworks front-end module.
+  * Updated documentation to clarify that this sample is dedicated for the short-range radio (Bluetooth LE, IEEE 802.15.4 and proprietary modes).
 
 Trusted Firmware-M (TF-M) samples
 ---------------------------------

--- a/samples/peripheral/radio_test/README.rst
+++ b/samples/peripheral/radio_test/README.rst
@@ -1,13 +1,13 @@
 .. _radio_test:
 
-Radio test
-##########
+Radio test (short-range)
+########################
 
 .. contents::
    :local:
    :depth: 2
 
-The Radio test sample demonstrates how to configure the radio in a specific mode and then test its performance.
+The Radio test sample demonstrates how to configure the 2.4 GHz short-range radio (Bluetooth® LE, IEEE 802.15.4 and proprietary) in a specific mode and then test its performance.
 The sample provides a set of predefined commands that allow you to configure the radio in three modes:
 
 * Constant RX or TX carrier


### PR DESCRIPTION
This update specifies which radio can be tested with this sample. Currently, Nordic supports multiple radio technologies and this sample only tests the short range 2.4 GHz radio (BLE, IEEE 802.15.4 and proprietary).
In particular the update was needed to distinguish from the Wi-Fi Radio test.