### PR TITLE
tests: bluetooth: tester: Remove qemu_x86 platform from testcase.yaml

### DIFF
--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -1,9 +1,4 @@
 tests:
-  bluetooth.general.tester:
-    platform_allow: qemu_x86
-    tags: bluetooth
-    harness: bluetooth
-
   bluetooth.general.tester.build:
     build_only: true
     platform_allow: nrf52840dk_nrf52840


### PR DESCRIPTION
qemu_x86 won't be supported by CI. native_posix won't build as tester app requires UART_PIPE, which requires SERIAL_SUPPORT_INTERRUPT, which is not supported by native_posix platform. Tester doesn't fit into qemu_cortex_m3. Thus the only option is to remove runnable platform.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>