### PR TITLE
samples: matter: fix coexistence for nRF7002 EK

### DIFF
--- a/samples/matter/light_bulb/child_image/hci_rpmsg/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/matter/light_bulb/child_image/hci_rpmsg/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Support Wi-Fi-BLE coexistence when nRF7002 EK shield is used */
+	nrf_radio_coex: nrf7002-coex {
+		status = "okay";
+		compatible = "nordic,nrf700x-coex";
+		status0-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;   /* D2 */
+		req-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>; 	/* D3 */
+		grant-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;    /* D4 */
+		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;  /* D6 */
+	};
+};

--- a/samples/matter/light_switch/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/matter/light_switch/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Support Wi-Fi-BLE coexistence when nRF7002 EK shield is used */
+	nrf_radio_coex: nrf7002-coex {
+		status = "okay";
+		compatible = "nordic,nrf700x-coex";
+		status0-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;   /* D2 */
+		req-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>; 	/* D3 */
+		grant-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;    /* D4 */
+		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;  /* D6 */
+	};
+};

--- a/samples/matter/lock/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/matter/lock/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Support Wi-Fi-BLE coexistence when nRF7002 EK shield is used */
+	nrf_radio_coex: nrf7002-coex {
+		status = "okay";
+		compatible = "nordic,nrf700x-coex";
+		status0-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;   /* D2 */
+		req-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>; 	/* D3 */
+		grant-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;    /* D4 */
+		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;  /* D6 */
+	};
+};

--- a/samples/matter/template/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/matter/template/child_image/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	/* Support Wi-Fi-BLE coexistence when nRF7002 EK shield is used */
+	nrf_radio_coex: nrf7002-coex {
+		status = "okay";
+		compatible = "nordic,nrf700x-coex";
+		status0-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;   /* D2 */
+		req-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>; 	/* D3 */
+		grant-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;    /* D4 */
+		swctrl1-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;  /* D6 */
+	};
+};

--- a/samples/matter/window_covering/sample.yaml
+++ b/samples/matter/window_covering/sample.yaml
@@ -30,10 +30,10 @@ tests:
     extra_args: CONFIG_CHIP_LIB_SHELL=y
     integration_platforms:
       - nrf5340dk_nrf5340_cpuapp
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
   sample.matter.window_cover.no_dfu:
     build_only: true
     extra_args: CONFIG_CHIP_LIB_SHELL=y CONF_FILE=prj_no_dfu.conf
     integration_platforms:
       - nrf21540dk_nrf52840
-    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf52840dk_nrf52840 nrf21540dk_nrf52840 nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
Add nrf_radio_coex DTS node to the hci_rpmsg child image to make the Wi-Fi-BLE coexistence work when nRF7002 EK shield is attached to nRF5340 DK. Otherwise, the following error is printed on boot because the coexistence if enabled in the application core firmware by default:
```
  IPC endpoint bond timeout
```

Also, remove nRF7002 DK from the list of alowed platforms in the window covering sample that is Thread-only.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>