### PR TITLE
manifest: pull Matter over Wi-Fi scan refinements

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -123,7 +123,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 3e163426bc037d81e7996a696a0eb79389f6f62d
+      revision: 515c7c67c59cbe1b3b97b235f8c93e63131dee7a
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This patch addresses two issues:
* unreliable connect when using specific channel number
* possibility of saturation of CHIP work queue with scan result events

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>