### PR TITLE
application: serial_lte_modem: Reduce memcpy in UART_TX

### DIFF
--- a/applications/serial_lte_modem/doc/slm_data_mode.rst
+++ b/applications/serial_lte_modem/doc/slm_data_mode.rst
@@ -106,7 +106,7 @@ Otherwise, if SLM imposes flow control, it disables the UART reception when it r
 SLM reenables UART receptions after the transmission of the data previously received has freed up buffer space.
 The buffer size is set to 3884 bytes by default.
 
-.. note:
+.. note::
    There is no unsolicited notification defined for this event.
    UART hardware flow control is responsible for imposing and revoking flow control.
 


### PR DESCRIPTION
Only do memcpy when data is from flash data section, i.e. const
string. If buffer address is from UNSECURE SRAM, can send by DMA
directly. It can eliminate unnecessary heap allocation/release,
as well as reduce AT response time.

Update TS 27.007 formatting to send final modem response all from
SRAM address and in one UART TX transaction.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>