### PR TITLE
samples: matter: Fixed brightness persisting in light bulb

### DIFF
--- a/samples/matter/light_bulb/src/light_bulb.matter
+++ b/samples/matter/light_bulb/src/light_bulb.matter
@@ -1584,7 +1584,7 @@ endpoint 1 {
     ram      attribute maxLevel default = 0xFE;
     ram      attribute options;
     ram      attribute onOffTransitionTime;
-    ram      attribute onLevel default = 0xFE;
+    ram      attribute onLevel;
     ram      attribute onTransitionTime;
     ram      attribute offTransitionTime;
     ram      attribute defaultMoveRate default = 50;

--- a/samples/matter/light_bulb/src/light_bulb.zap
+++ b/samples/matter/light_bulb/src/light_bulb.zap
@@ -7302,7 +7302,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0xFE",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/samples/matter/light_bulb/src/zap-generated/CHIPClusters.h
+++ b/samples/matter/light_bulb/src/zap-generated/CHIPClusters.h
@@ -31,7 +31,6 @@ namespace chip
 {
 namespace Controller
 {
-
 	class DLL_EXPORT OtaSoftwareUpdateProviderCluster : public ClusterBase {
 	public:
 		OtaSoftwareUpdateProviderCluster(Messaging::ExchangeManager &exchangeManager,

--- a/samples/matter/light_bulb/src/zap-generated/IMClusterCommandHandler.cpp
+++ b/samples/matter/light_bulb/src/zap-generated/IMClusterCommandHandler.cpp
@@ -38,15 +38,12 @@ namespace chip
 {
 namespace app
 {
-
 	// Cluster specific command parsing
 
 	namespace Clusters
 	{
-
 		namespace AdministratorCommissioning
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -111,7 +108,6 @@ namespace app
 
 		namespace GeneralCommissioning
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -176,7 +172,6 @@ namespace app
 
 		namespace GeneralDiagnostics
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -221,7 +216,6 @@ namespace app
 
 		namespace GroupKeyManagement
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -295,7 +289,6 @@ namespace app
 
 		namespace Groups
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -384,7 +377,6 @@ namespace app
 
 		namespace Identify
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -437,7 +429,6 @@ namespace app
 
 		namespace LevelControl
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -545,7 +536,6 @@ namespace app
 
 		namespace NetworkCommissioning
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -640,7 +630,6 @@ namespace app
 
 		namespace OtaSoftwareUpdateRequestor
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -685,7 +674,6 @@ namespace app
 
 		namespace OnOff
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -774,7 +762,6 @@ namespace app
 
 		namespace OperationalCredentials
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{
@@ -888,7 +875,6 @@ namespace app
 
 		namespace ThreadNetworkDiagnostics
 		{
-
 			void DispatchServerCommand(CommandHandler *apCommandObj,
 						   const ConcreteCommandPath &aCommandPath, TLV::TLVReader &aDataTlv)
 			{

--- a/samples/matter/light_bulb/src/zap-generated/endpoint_config.h
+++ b/samples/matter/light_bulb/src/zap-generated/endpoint_config.h
@@ -497,7 +497,7 @@
 			{ 0x00000010, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE),                                              \
 			  ZAP_SIMPLE_DEFAULT(0x0000) }, /* OnOffTransitionTime */                                                     \
 			{ 0x00000011, ZAP_TYPE(INT8U), 1, ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(NULLABLE),                \
-			  ZAP_SIMPLE_DEFAULT(0xFE) }, /* OnLevel */                                                                   \
+			  ZAP_SIMPLE_DEFAULT(0xFF) }, /* OnLevel */                                                                   \
 			{ 0x00000012, ZAP_TYPE(INT16U), 2,                                                                            \
 			  ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_EMPTY_DEFAULT() }, /* OnTransitionTime     \
 													       */                     \


### PR DESCRIPTION
The light brightness is always set to 100% after turning off and on the light again. Instead it should go back to the value set before turning off. The reason is that OnLevel attribute value should be by default set to null instead of max.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>