### PR TITLE
applications: nrf_desktop: Add prompt to Kconfig option enabling BAS

### DIFF
--- a/applications/nrf_desktop/doc/bas.rst
+++ b/applications/nrf_desktop/doc/bas.rst
@@ -22,8 +22,8 @@ Module events
 Configuration
 *************
 
-The module is enabled with the :ref:`CONFIG_DESKTOP_BAS_ENABLE <config_desktop_app_options>` option.
-The option is selected by :ref:`CONFIG_DESKTOP_HID_PERIPHERAL <config_desktop_app_options>` -- Battery Service is required for the HID peripheral device.
+The module is enabled with the :ref:`CONFIG_DESKTOP_BAS_ENABLE <config_desktop_app_options>` option, that is implied by the :ref:`CONFIG_DESKTOP_BT_PERIPHERAL <config_desktop_app_options>` option.
+The Battery Service is required for the HID peripheral device.
 
 Implementation details
 **********************

--- a/applications/nrf_desktop/src/modules/Kconfig.bas
+++ b/applications/nrf_desktop/src/modules/Kconfig.bas
@@ -7,9 +7,11 @@
 menu "BLE BAS Service"
 
 config DESKTOP_BAS_ENABLE
-	bool
+	bool "Enable GATT Battery Service"
+	depends on BT
 	help
-	  This option enables battery service.
+	  This option enables GATT Battery Service application
+	  module.
 
 if DESKTOP_BAS_ENABLE
 


### PR DESCRIPTION
The prompt can be used to allow user explicitly enable/disable module. Change also adds Bluetooth dependency.

Jira: NCSDK-19129