### PR TITLE
applications: nrf_desktop: Move BLE adv providers' Kconfig defaults

### DIFF
--- a/applications/nrf_desktop/doc/ble_adv.rst
+++ b/applications/nrf_desktop/doc/ble_adv.rst
@@ -39,7 +39,7 @@ Advertised data
 ===============
 
 The :ref:`caf_ble_adv` relies on :ref:`bt_le_adv_prov_readme` to manage advertising data and scan response data.
-nRF Desktop application configures the data providers in :file:`src/util/Kconfig`.
+nRF Desktop application configures the data providers in :file:`src/modules/Kconfig.caf_ble_adv.default`.
 By default, the application enables a set of data providers available in the |NCS| and adds a custom provider of UUID16 values of Battery Service (BAS) and Human Interface Device Service (HIDS).
 The UUID16 of a given GATT Service is added to the advertising data only if the service is enabled in the configuration and the Bluetooth local identity in use has no bond.
 

--- a/applications/nrf_desktop/src/modules/Kconfig.caf_ble_adv.default
+++ b/applications/nrf_desktop/src/modules/Kconfig.caf_ble_adv.default
@@ -23,4 +23,34 @@ config CAF_BLE_ADV_FILTER_ACCEPT_LIST
 	help
 	  By default, nRF Desktop peripherals enable filter accept list.
 
+config BT_ADV_PROV_FLAGS
+	default y
+
+config BT_ADV_PROV_GAP_APPEARANCE
+	default y
+
+config BT_ADV_PROV_DEVICE_NAME
+	default y
+
+config BT_ADV_PROV_SWIFT_PAIR
+	default y
+
+config BT_ADV_PROV_FAST_PAIR
+	default y if BT_FAST_PAIR
+
+config BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING
+	depends on BT_ADV_PROV_FAST_PAIR
+	default n
+	help
+	  nRF Desktop peripheral supports one bond per local identity. Disable
+	  the UI indication during Fast Pair not discoverable advertising to
+	  prevent bonding failures.
+
+config BT_ADV_PROV_TX_POWER
+	default y
+
+config DESKTOP_ADV_PROV_UUID16_ALL
+	depends on (DESKTOP_HIDS_ENABLE || DESKTOP_BAS_ENABLE)
+	default y
+
 endif # CAF_BLE_ADV

--- a/applications/nrf_desktop/src/util/Kconfig
+++ b/applications/nrf_desktop/src/util/Kconfig
@@ -6,42 +6,12 @@
 
 menu "Utilities"
 
-if BT_ADV_PROV
-
-config BT_ADV_PROV_FLAGS
-	default y
-
-config BT_ADV_PROV_GAP_APPEARANCE
-	default y
-
-config BT_ADV_PROV_DEVICE_NAME
-	default y
-
-config BT_ADV_PROV_SWIFT_PAIR
-	default y
-
-config BT_ADV_PROV_FAST_PAIR
-	default y if BT_FAST_PAIR
-
-config BT_ADV_PROV_FAST_PAIR_SHOW_UI_PAIRING
-	depends on BT_ADV_PROV_FAST_PAIR
-	default n
-	help
-	  nRF Desktop peripheral supports one bond per local identity. Disable
-	  the UI indication during Fast Pair not discoverable advertising to
-	  prevent bonding failures.
-
-config BT_ADV_PROV_TX_POWER
-	default y
-
 config DESKTOP_ADV_PROV_UUID16_ALL
 	bool "UUID16 advertising provider"
+	depends on BT_ADV_PROV
 	depends on (DESKTOP_HIDS_ENABLE || DESKTOP_BAS_ENABLE)
-	default y
 	help
 	  Adds all UUID16 to the advertising payload if used Bluetooth local
 	  identity has no bond.
-
-endif # BT_ADV_PROV
 
 endmenu


### PR DESCRIPTION
Change moves Kconfig defaults for BLE advertising providers to the CAF BLE advertising module's Kconfig defaults file. The BLE advertising providers are used only by the CAF Bluetooth advertising module.

Jira: NCSDK-19129