### PR TITLE
caf: sensor_data_aggregator: Fix buffers definition

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -602,6 +602,9 @@ Common Application Framework (CAF)
 
     * :c:struct:`sensor_data_aggregator_event` now uses the :c:struct:`sensor_value` struct data buffer and carries a number of sensor values in a single sample, which is sufficient to describe data layout.
 
+    * The way buffers are declared is updated when the instance is created.
+      Now the memory-region devicetree property works independently for each instance and does not require the specific instance name.
+
 * :ref:`caf_sensor_manager`:
 
   * Clean up :file:`sensor_event.h` and :file:`sensor_manager.h` files.

--- a/subsys/caf/modules/sensor_data_aggregator.c
+++ b/subsys/caf/modules/sensor_data_aggregator.c
@@ -20,57 +20,48 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_CAF_SENSOR_DATA_AGGREGATOR_LOG_LEVEL);
 
 #define DT_DRV_COMPAT caf_aggregator
 
-#define __DEFINE_DATA(i, agg_id, size)								\
-	static uint8_t agg_ ## agg_id ## _buff_ ## i ## _data[size] __aligned(4)
+/* The name of the structure array that describes the aggregator buffers */
+#define __AGG_BUFFS_NAME(agg_node) DT_CAT3(agg_, agg_node, _buffs)
 
-#if (DT_INST_NODE_HAS_PROP(agg_id, memory_region))
+/* This macros are used only if no memory region is used and the aggregator buffers are created
+ * in BSS.
+ */
+#define __DATA_BUFF_NAME(agg_node, n) DT_CAT5(agg_, agg_node,  _buff_,  n,  _data)
+#define __DEFINE_DATA(n, agg_node, size)                         \
+	static struct sensor_value __DATA_BUFF_NAME(agg_node, n) \
+		[ceiling_fraction(size, sizeof(struct sensor_value))]
+/* End of BSS version only macros. */
 
-#define __INITIALIZE_BUF(i, agg_id)								\
-	{											\
-		(struct sensor_value *) DT_REG_ADDR(DT_INST_PHANDLE(agg_id, memory_region)) +	\
-		i * (DT_INST_PROP(agg_id, buf_data_length))					\
-	},
+#define __INITIALIZE_BUFF(n, agg_node)                                                        \
+	COND_CODE_1(DT_NODE_HAS_PROP(agg_node, memory_region),                                \
+		({(struct sensor_value *) (DT_REG_ADDR(DT_PHANDLE(agg_node, memory_region)) + \
+			n * (DT_PROP(agg_node, buf_data_length)))}),                          \
+		({__DATA_BUFF_NAME(agg_node, n)})                                             \
+	)
 
+#define __XDEFINE_BUF_DATA(agg_node)                                                    \
+	COND_CODE_0(DT_NODE_HAS_PROP(agg_node, memory_region),                          \
+		(LISTIFY(DT_PROP(agg_node, buf_count), __DEFINE_DATA, (;),              \
+			agg_node, DT_PROP(agg_node, buf_data_length));),                \
+		()                                                                      \
+	)                                                                               \
+	static struct aggregator_buffer __AGG_BUFFS_NAME(agg_node)[] = {                \
+		LISTIFY(DT_PROP(agg_node, buf_count), __INITIALIZE_BUFF, (,), agg_node) \
+	};                                                                              \
+	BUILD_ASSERT((DT_PROP(agg_node, buf_data_length) %                              \
+		(DT_PROP(agg_node, sample_size) * sizeof(struct sensor_value))) == 0,   \
+		"Wrong sensor data or buffer size in " DT_NODE_FULL_NAME(agg_node));
 
+#define __DEFINE_BUF_DATA(i) __XDEFINE_BUF_DATA(DT_DRV_INST(i))
 
-/* buf_len has to be equal to i*sample_size*sizeof(struct sensor_value). */
-#define __DEFINE_BUF_DATA(i)									\
-	static struct aggregator_buffer agg_ ## i ## _bufs[] = {				\
-		UTIL_LISTIFY(DT_INST_PROP(i, buf_count), __INITIALIZE_BUF, i)			\
-	};											\
-	BUILD_ASSERT((DT_INST_PROP(i, buf_data_length) %					\
-		(DT_INST_PROP(i, sample_size) * sizeof(struct sensor_value))) == 0,		\
-		"Wrong sensor data or buffer size");
+#define __DEFINE_AGGREGATOR(i)                               \
+	[i].sensor_descr = DT_INST_PROP(i, sensor_descr),    \
+	[i].values_in_sample = DT_INST_PROP(i, sample_size), \
+	[i].buf_count = DT_INST_PROP(i, buf_count),          \
+	[i].buf_len = DT_INST_PROP(i, buf_data_length),      \
+	[i].agg_buffers = __AGG_BUFFS_NAME(DT_DRV_INST(i)),  \
+	[i].active_buf  = __AGG_BUFFS_NAME(DT_DRV_INST(i)),
 
-#else
-#define __INITIALIZE_BUF(i, agg_id)								\
-	{(struct sensor_value *) &agg_ ## agg_id ## _buff_ ## i ## _data}
-
-/* buf_len has to be equal to i*sample_size*sizeof(struct sensor_value). */
-#define __DEFINE_BUF_DATA(i)									\
-	LISTIFY(DT_INST_PROP(i, buf_count), __DEFINE_DATA, (;), i,				\
-		DT_INST_PROP(i, buf_data_length));						\
-	static struct aggregator_buffer agg_ ## i ## _bufs[] = {				\
-		LISTIFY(DT_INST_PROP(i, buf_count), __INITIALIZE_BUF, (,), i)			\
-	};											\
-	BUILD_ASSERT((DT_INST_PROP(i, buf_data_length) %					\
-		(DT_INST_PROP(i, sample_size) * sizeof(struct sensor_value))) == 0,		\
-		"Wrong sensor data or buffer size");
-
-#endif
-
-#define __DEFINE_AGGREGATOR(i)								\
-	[i].sensor_descr = DT_INST_PROP(i, sensor_descr),				\
-	[i].values_in_sample = DT_INST_PROP(i, sample_size),				\
-	[i].buf_count = DT_INST_PROP(i, buf_count),					\
-	[i].buf_len = DT_INST_PROP(i, buf_data_length),					\
-	[i].agg_buffers = (struct aggregator_buffer *) &agg_ ## i ## _bufs,		\
-	[i].active_buf = (struct aggregator_buffer *) &agg_ ## i ## _bufs,
-
-#define __DEFINE_AGG							\
-	static struct aggregator aggregators[] = {			\
-		DT_INST_FOREACH_STATUS_OKAY(__DEFINE_AGGREGATOR)	\
-	}
 
 struct aggregator_buffer {
 	struct sensor_value *samples;	/* Dynamic data. */


### PR DESCRIPTION
This commit fixes buffer definitions to correctly
match the processed instance.
Before that fix the app_id predefined node was checked to have memory_region property.
Now every node is tested separately.