### PR TITLE
Manifest: Update Zephyr to add PAST a mode parameter

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 336c245949839b1d8b01c297d821101c939265ec
+      revision: e2bec540218d91ac8ce5015cc101b3bdc701eaef
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Update needed for PAST host qualification.

Signed-off-by: Timothy Keys <timothy.keys@nordicsemi.no>