### PR TITLE
script: fix ncs-upmerger commit message

### DIFF
--- a/.github/workflows/create-upmerge-PRs.yml
+++ b/.github/workflows/create-upmerge-PRs.yml
@@ -33,7 +33,7 @@ jobs:
           west init -l nrf
           west update zephyr
           git config --global user.email "noreply@nordicsemi.no"
-          git config --global user.name "NordicBuilder"
+          git config --global user.name "Nordic Builder"
           echo "SDK_ZEPHYR=$(west list zephyr -f {url} | awk -F// '{print $NF}')" >> $GITHUB_ENV
 
       - name: Try closing existing auto-upmerge PRs

--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -551,7 +551,7 @@ class NcsUpmerger(NcsWestCommand):
                     log.inf(f'    {i}. {uc.oid} {commit_shortlog(uc)}')
             project.git('revert --no-edit ' + str(dc.oid))
         log.inf(f'Merging: {z_rev} to project: {project.name}')
-        msg = f"[nrf mergeup] Merge upstream automatically up to commit {z_sha}\nAuto-upmerge by ncs-upmerger"
+        msg = f"[nrf mergeup] Merge upstream automatically up to commit {z_sha}\n\nThis auto-upmerge was performed with ncs-upmerger script."
         project.git('merge --no-edit --no-ff --signoff -m "' + msg + '" ' + str(self.zephyr_rev))
 
 


### PR DESCRIPTION
Currently generated commit message does not pass compliance checks. In order to fix it additional line break is needed.
Also name NordicBuilder does not pass compliance but Nordic Builder seems to be ok.

Signed-off-by: Kari Hamalainen <kari.hamalainen@nordicsemi.no>