### PR TITLE
lib: bin: lwm2m_carrier: enable library to be used without LTE LC

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -447,7 +447,9 @@ This section provides detailed lists of changes by :ref:`library <libraries>`.
 Binary libraries
 ----------------
 
-|no_changes_yet_note|
+* :ref:`liblwm2m_carrier_readme` library:
+
+  * Removed the dependency on the :ref:`lte_lc_readme` library.
 
 Bluetooth libraries and services
 --------------------------------

--- a/lib/bin/lwm2m_carrier/Kconfig
+++ b/lib/bin/lwm2m_carrier/Kconfig
@@ -26,7 +26,6 @@ menuconfig LWM2M_CARRIER
 	depends on NET_SOCKETS
 	depends on NET_SOCKETS_OFFLOAD
 	# Networking NCS
-	depends on LTE_LINK_CONTROL && !LTE_AUTO_INIT_AND_CONNECT
 	depends on DOWNLOAD_CLIENT
 	# Credentials NCS
 	depends on MODEM_KEY_MGMT

--- a/lib/bin/lwm2m_carrier/include/lwm2m_settings.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_settings.h
@@ -14,8 +14,8 @@
 #ifndef LWM2M_SETTINGS_H__
 #define LWM2M_SETTINGS_H__
 
-#include <modem/lte_lc.h>
-#include <lwm2m_carrier.h>
+#include <stdint.h>
+#include <stdbool.h>
 
 /**
  * @brief Check if automatic startup is enabled.
@@ -40,13 +40,13 @@ int lwm2m_settings_auto_startup_set(bool new_auto_startup);
  */
 bool lwm2m_settings_enable_custom_config_get(void);
 
- /**
-  * Enable or disable the LwM2M custom settings.
-  *
-  * @param new_enable_custom_config Whether to enable LwM2M custom settings or not.
-  *
-  * @retval 0 on success, non-zero on failure.
-  */
+/**
+ * Enable or disable the LwM2M custom settings.
+ *
+ * @param new_enable_custom_config Whether to enable LwM2M custom settings or not.
+ *
+ * @retval 0 on success, non-zero on failure.
+ */
 int lwm2m_settings_enable_custom_config_set(bool new_enable_custom_config);
 
 /**
@@ -56,13 +56,13 @@ int lwm2m_settings_enable_custom_config_set(bool new_enable_custom_config);
  */
 uint32_t lwm2m_settings_carriers_enabled_get(void);
 
- /**
-  * Set enabled carriers.
-  *
-  * @param new_carriers_enabled Bitmask corresponding to carrier oper_id values.
-  *
-  * @retval 0 on success, non-zero on failure.
-  */
+/**
+ * Set enabled carriers.
+ *
+ * @param new_carriers_enabled Bitmask corresponding to carrier oper_id values.
+ *
+ * @retval 0 on success, non-zero on failure.
+ */
 int lwm2m_settings_carriers_enabled_set(uint32_t new_carriers_enabled);
 
 /**
@@ -89,13 +89,13 @@ int lwm2m_settings_bootstrap_from_smartcard_set(bool new_bootstrap_from_smartcar
  */
 bool lwm2m_settings_enable_custom_server_config_get(void);
 
- /**
-  * Enable or disable the LwM2M server custom settings.
-  *
-  * @param new_enable_custom_server_config Whether to enable LwM2M custom server settings or not.
-  *
-  * @retval 0 on success, non-zero on failure.
-  */
+/**
+ * Enable or disable the LwM2M server custom settings.
+ *
+ * @param new_enable_custom_server_config Whether to enable LwM2M custom server settings or not.
+ *
+ * @retval 0 on success, non-zero on failure.
+ */
 int lwm2m_settings_enable_custom_server_config_set(bool new_enable_custom_server_config);
 
 /**
@@ -212,7 +212,6 @@ uint32_t lwm2m_settings_server_sec_tag_get(void);
  */
 int lwm2m_settings_server_sec_tag_set(const uint32_t new_server_sec_tag);
 
-
 /**
  * @brief Retrieve the APN from the custom LwM2M settings.
  *
@@ -252,13 +251,13 @@ int lwm2m_settings_pdn_type_set(uint32_t new_pdn_type);
  */
 bool lwm2m_settings_enable_custom_device_config_get(void);
 
- /**
-  * Enable or disable the LwM2M device custom settings.
-  *
-  * @param new_enable_custom_device_config Whether to enable LwM2M custom device settings or not.
-  *
-  * @retval 0 on success, non-zero on failure.
-  */
+/**
+ * Enable or disable the LwM2M device custom settings.
+ *
+ * @param new_enable_custom_device_config Whether to enable LwM2M custom device settings or not.
+ *
+ * @retval 0 on success, non-zero on failure.
+ */
 int lwm2m_settings_enable_custom_device_config_set(bool new_enable_custom_device_config);
 
 /**

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -12,7 +12,6 @@
 #include <zephyr/kernel.h>
 #include <string.h>
 #include <nrf_modem.h>
-#include <modem/lte_lc.h>
 #include <modem/pdn.h>
 #include <modem/nrf_modem_lib.h>
 #include <modem/sms.h>
@@ -564,6 +563,9 @@ int lwm2m_os_download_file_size_get(size_t *size)
 	return download_client_file_size_get(&http_downloader, size);
 }
 
+#if defined(CONFIG_LTE_LINK_CONTROL)
+#include <modem/lte_lc.h>
+
 /* LTE LC module abstractions. */
 
 size_t lwm2m_os_lte_modes_get(int32_t *modes)
@@ -615,6 +617,70 @@ void lwm2m_os_lte_mode_request(int32_t prefer)
 
 	(void)lte_lc_system_mode_set(mode, preference);
 }
+#else
+#include <nrf_modem_at.h>
+
+size_t lwm2m_os_lte_modes_get(int32_t *modes)
+{
+	int err, ltem_mode, nbiot_mode, gps_mode, preference;
+
+	/* It's expected to have all 4 arguments matched */
+	err = nrf_modem_at_scanf("AT%XSYSTEMMODE?", "%%XSYSTEMMODE: %d,%d,%d,%d",
+				 &ltem_mode, &nbiot_mode, &gps_mode, &preference);
+	if (err != 4) {
+		LOG_ERR("Failed to get system mode, error: %d", err);
+		return 0;
+	}
+
+	if (ltem_mode && nbiot_mode) {
+		modes[0] = LWM2M_OS_LTE_MODE_CAT_M1;
+		modes[1] = LWM2M_OS_LTE_MODE_CAT_NB1;
+		return 2;
+	} else if (ltem_mode) {
+		modes[0] = LWM2M_OS_LTE_MODE_CAT_M1;
+		return 1;
+	} else if (nbiot_mode) {
+		modes[0] = LWM2M_OS_LTE_MODE_CAT_NB1;
+		return 1;
+	}
+
+	return 0;
+}
+
+void lwm2m_os_lte_mode_request(int32_t prefer)
+{
+	int err, ltem_mode, nbiot_mode, gps_mode, preference;
+	static int application_preference;
+
+	/* It's expected to have all 4 arguments matched */
+	err = nrf_modem_at_scanf("AT%XSYSTEMMODE?", "%%XSYSTEMMODE: %d,%d,%d,%d",
+				 &ltem_mode, &nbiot_mode, &gps_mode, &preference);
+	if (err != 4) {
+		LOG_ERR("Failed to get system mode, error: %d", err);
+		return;
+	}
+
+	switch (prefer) {
+	case LWM2M_OS_LTE_MODE_CAT_M1:
+		application_preference = preference;
+		preference = 1;
+		break;
+	case LWM2M_OS_LTE_MODE_CAT_NB1:
+		application_preference = preference;
+		preference = 2;
+		break;
+	case LWM2M_OS_LTE_MODE_NONE:
+		preference = application_preference;
+		break;
+	}
+
+	err = nrf_modem_at_printf("AT%%XSYSTEMMODE=%d,%d,%d,%d",
+				  ltem_mode, nbiot_mode, gps_mode, preference);
+	if (err) {
+		LOG_ERR("Could not send AT command, error: %d", err);
+	}
+}
+#endif
 
 /* PDN abstractions */
 

--- a/lib/bin/lwm2m_carrier/os/lwm2m_settings.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_settings.c
@@ -11,6 +11,7 @@
 #include <lwm2m_settings.h>
 #include <lwm2m_carrier.h>
 #include <zephyr/settings/settings.h>
+#include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lwm2m_settings, CONFIG_LOG_DEFAULT_LEVEL);

--- a/lib/bin/lwm2m_carrier/os/lwm2m_shell.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_shell.c
@@ -14,7 +14,6 @@
 #include <lwm2m_settings.h>
 #include <zephyr/shell/shell.h>
 #include <modem/modem_key_mgmt.h>
-#include <modem/lte_lc.h>
 #include <nrf_modem_at.h>
 
 #define RED	"\e[0;31m"


### PR DESCRIPTION
Removed the dependency of the LwM2M carrier library on the LTE Link Controller module. Provided alternative implementations of OS layer functions and event handling, which shall make use of appropriate AT commands directly.

Signed-off-by: Kacper Radoszewski <kacper.radoszewski@nordicsemi.no>