### PR TITLE
lib: pdn: Handle CGEV ME DETACH and NW DETACH

### DIFF
--- a/applications/asset_tracker_v2/src/modules/modem_module.c
+++ b/applications/asset_tracker_v2/src/modules/modem_module.c
@@ -282,6 +282,9 @@ void pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)
 	case PDN_EVENT_IPV6_DOWN:
 		LOG_DBG("PDN_EVENT_IPV6_DOWN");
 		break;
+	case PDN_EVENT_NETWORK_DETACH:
+		LOG_DBG("PDN_EVENT_NETWORK_DETACH");
+		break;
 	default:
 		LOG_WRN("Unexpected PDN event!");
 		break;

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -446,6 +446,12 @@ Libraries for networking
 
   * Removed the old API ``lwm2m_firmware_get_update_state_cb()``.
 
+* :ref:`pdn_readme` library:
+
+  * Added:
+
+    * ``PDN_EVENT_NETWORK_DETACH`` event to indicate a full network detach.
+
 Libraries for NFC
 -----------------
 

--- a/include/modem/pdn.h
+++ b/include/modem/pdn.h
@@ -55,11 +55,12 @@ struct pdn_pdp_opt {
 
 /** @brief PDN library event */
 enum pdn_event {
-	PDN_EVENT_CNEC_ESM,	/**< +CNEC ESM error code */
-	PDN_EVENT_ACTIVATED,	/**< PDN connection activated */
-	PDN_EVENT_DEACTIVATED,	/**< PDN connection deactivated */
-	PDN_EVENT_IPV6_UP,	/**< PDN has IPv6 connectivity */
-	PDN_EVENT_IPV6_DOWN,	/**< PDN has lost IPv6 connectivity */
+	PDN_EVENT_CNEC_ESM,		/**< +CNEC ESM error code */
+	PDN_EVENT_ACTIVATED,		/**< PDN connection activated */
+	PDN_EVENT_DEACTIVATED,		/**< PDN connection deactivated */
+	PDN_EVENT_IPV6_UP,		/**< PDN has IPv6 connectivity */
+	PDN_EVENT_IPV6_DOWN,		/**< PDN has lost IPv6 connectivity */
+	PDN_EVENT_NETWORK_DETACH,	/**< Network detached */
 };
 
 /** @brief PDN authentication method */

--- a/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
+++ b/samples/nrf9160/modem_shell/src/link/link_shell_pdn.c
@@ -39,6 +39,7 @@ static const char *const event_str[] = {
 	[PDN_EVENT_DEACTIVATED] = "deactivated",
 	[PDN_EVENT_IPV6_UP] = "IPv6 up",
 	[PDN_EVENT_IPV6_DOWN] = "IPv6 down",
+	[PDN_EVENT_NETWORK_DETACH] = "network detach",
 };
 
 void link_pdn_event_handler(uint8_t cid, enum pdn_event event, int reason)

--- a/samples/nrf9160/pdn/README.rst
+++ b/samples/nrf9160/pdn/README.rst
@@ -75,6 +75,8 @@ The sample shows the following output, which may vary based on the network provi
 
    Event: PDP context 0 deactivated
    Event: PDP context 1 deactivated
+   Event: PDP context 0 network detach
+   Event: PDP context 1 network detach
    Bye
 
 Dependencies

--- a/samples/nrf9160/pdn/src/main.c
+++ b/samples/nrf9160/pdn/src/main.c
@@ -28,6 +28,7 @@ static const char * const event_str[] = {
 	[PDN_EVENT_DEACTIVATED] = "deactivated",
 	[PDN_EVENT_IPV6_UP] = "IPv6 up",
 	[PDN_EVENT_IPV6_DOWN] = "IPv6 down",
+	[PDN_EVENT_NETWORK_DETACH] = "network detach",
 };
 
 static void snprintaddr(char *str, size_t size, struct nrf_sockaddr *addr)


### PR DESCRIPTION
Handle +CGEV: ME DETACH and +CGEV: NW DETACH notifications in on_cgev(). This notification does not contain <cid> and will be sent to all PDN contexts. It will be sent instead of ME PDN DEACT and NW PDN DEACT on power off in an upcoming nRF9160 modem release.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>