### PR TITLE
cmake: update PROTOC setting to cache type STRING

### DIFF
--- a/share/ncs-package/cmake/NcsConfig.cmake
+++ b/share/ncs-package/cmake/NcsConfig.cmake
@@ -33,13 +33,11 @@ if(NOT NO_BOILERPLATE)
     if(${NcsToolchain_FOUND})
       message("-- Using NCS Toolchain ${NcsToolchain_VERSION} for building. (${NcsToolchain_DIR})")
 
-      if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Windows)
-        set(env_list_delimeter ";")
-      else()
-        set(env_list_delimeter ":")
-      endif()
+      set(CUSTOM_COMMAND_PATH ${NCS_TOOLCHAIN_BIN_PATH} $ENV{PATH})
+      cmake_path(CONVERT "${CUSTOM_COMMAND_PATH}" TO_NATIVE_PATH_LIST CUSTOM_COMMAND_PATH)
+      string(REPLACE ";" "\\\;" CUSTOM_COMMAND_PATH "${CUSTOM_COMMAND_PATH}")
 
-      set(CUSTOM_COMMAND_ENV       ${CMAKE_COMMAND} -E env PATH=${NCS_TOOLCHAIN_BIN_PATH}${env_list_delimeter}$ENV{PATH})
+      set(CUSTOM_COMMAND_ENV       ${CMAKE_COMMAND} -E env "PATH=${CUSTOM_COMMAND_PATH}")
       set(GIT_EXECUTABLE           ${NCS_TOOLCHAIN_GIT}     CACHE FILEPATH "NCS Toolchain Git")
 
       set(DTC                      ${NCS_TOOLCHAIN_DTC}     CACHE FILEPATH "NCS Toolchain DTC")
@@ -50,8 +48,8 @@ if(NOT NO_BOILERPLATE)
       set(PYTHON_PREFER            ${NCS_TOOLCHAIN_PYTHON}  CACHE FILEPATH "NCS Toolchain Python")
 
       if(DEFINED NCS_TOOLCHAIN_PROTOC)
-        set(PROTOC                     ${CUSTOM_COMMAND_ENV} ${NCS_TOOLCHAIN_PROTOC} CACHE FILEPATH "NCS Toolchain protoc")
-        set(PROTOBUF_PROTOC_EXECUTABLE ${PROTOC}                                     CACHE FILEPATH "NCS Toolchain protoc")
+        set(PROTOC                     ${CUSTOM_COMMAND_ENV} ${NCS_TOOLCHAIN_PROTOC} CACHE STRING "NCS Toolchain protoc")
+        set(PROTOBUF_PROTOC_EXECUTABLE ${CUSTOM_COMMAND_ENV} ${NCS_TOOLCHAIN_PROTOC} CACHE STRING "NCS Toolchain protoc")
       endif()
 
       set(ZEPHYR_TOOLCHAIN_VARIANT ${NCS_TOOLCHAIN_VARIANT}        CACHE STRING "NCS Toolchain Variant")
@@ -62,6 +60,12 @@ if(NOT NO_BOILERPLATE)
 
       if(${CMAKE_GENERATOR} STREQUAL Ninja)
         set(CMAKE_MAKE_PROGRAM ${NCS_TOOLCHAIN_NINJA} CACHE INTERNAL "NCS Toolchain ninja")
+      endif()
+
+      if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Windows)
+        set(env_list_delimeter ";")
+      else()
+        set(env_list_delimeter ":")
       endif()
 
       # If NCS_TOOLCHAIN_ENV_PATH is set, then we must ensure to prepend it


### PR DESCRIPTION
Fixes: NCSIDB-816

Previous fix, e2662c11abcad726692d56df03a1730f267dec00, of NCSIDB-816 was incomplete as it didn't work properly on Windows OS.

Part of the reason is that `;` is separating elements in environment setting PATH, but in CMake it acts as a element separator for lists. This can normally be handled with proper escaping, but the variables expanded inside other variables combined with the cache type FILEPATH results in escaped `;` to be regular `;`.

This means that on Windows the PATH setting would always become a space separated string upon custom command invocation.

This commit fixes above issues by:
- Escape `;` in the custom command path, this ensure that on Windows OS where `;` is used, then CMake will refrain from treating the string as a list.
- Use cache type STRING instead of FILEPATH This ensures CMake will refrain from manipulating the setting. Apparently the CMake processing of a FILEPATH setting to handle relative path also removes escaped `;` in the process.
- Use `cmake_path(CONVERT ...)` This allows to construct regular CMake lists of paths, and thereafter ensure the list is a proper OS separated list.
- Removed the use of PROTOC to set PROTOBUF_PROTOC_EXECUTABLE, as doing so removed one level of escaped `;`.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>