### PR TITLE
applications: nrf5340_audio: Create same data flag

### DIFF
--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -230,6 +230,13 @@ config WALKIE_TALKIE_DEMO
 	  The walkie talkie demo will set up a bidirectional stream using PDM
 	  microphones on each side.
 
+config MONO_TO_ALL_RECEIVERS
+	bool "Send mono (first/left channel) to all receivers"
+	default n
+	help
+	  With this flag set, the gateway will encode and send the same (first/left)
+	  channel on all ISO channels.
+
 endmenu # Stream
 
 #----------------------------------------------------------------------------#

--- a/applications/nrf5340_audio/src/audio/audio_system.c
+++ b/applications/nrf5340_audio/src/audio/audio_system.c
@@ -53,7 +53,7 @@ static void audio_gateway_configure(void)
 
 #if (CONFIG_STREAM_BIDIRECTIONAL)
 	sw_codec_cfg.decoder.enabled = true;
-	sw_codec_cfg.decoder.channel_mode = SW_CODEC_MONO;
+	sw_codec_cfg.decoder.num_ch = SW_CODEC_MONO;
 #endif /* (CONFIG_STREAM_BIDIRECTIONAL) */
 
 	if (IS_ENABLED(CONFIG_SW_CODEC_LC3)) {
@@ -62,7 +62,12 @@ static void audio_gateway_configure(void)
 		ERR_CHK_MSG(-EINVAL, "No codec selected");
 	}
 
-	sw_codec_cfg.encoder.channel_mode = SW_CODEC_STEREO;
+	if (IS_ENABLED(CONFIG_MONO_TO_ALL_RECEIVERS)) {
+		sw_codec_cfg.encoder.num_ch = SW_CODEC_MONO;
+	} else {
+		sw_codec_cfg.encoder.num_ch = SW_CODEC_STEREO;
+	}
+
 	sw_codec_cfg.encoder.enabled = true;
 }
 
@@ -76,7 +81,7 @@ static void audio_headset_configure(void)
 
 #if (CONFIG_STREAM_BIDIRECTIONAL)
 	sw_codec_cfg.encoder.enabled = true;
-	sw_codec_cfg.encoder.channel_mode = SW_CODEC_MONO;
+	sw_codec_cfg.encoder.num_ch = SW_CODEC_MONO;
 
 	if (IS_ENABLED(CONFIG_SW_CODEC_LC3)) {
 		sw_codec_cfg.encoder.bitrate = CONFIG_LC3_BITRATE;
@@ -85,7 +90,7 @@ static void audio_headset_configure(void)
 	}
 #endif /* (CONFIG_STREAM_BIDIRECTIONAL) */
 
-	sw_codec_cfg.decoder.channel_mode = SW_CODEC_MONO;
+	sw_codec_cfg.decoder.num_ch = SW_CODEC_MONO;
 	sw_codec_cfg.decoder.enabled = true;
 }
 
@@ -157,8 +162,8 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 		}
 
 		if (sw_codec_cfg.encoder.enabled) {
-			/* Send encoded data over IPM */
-			streamctrl_encoded_data_send(encoded_data, encoded_data_size);
+			streamctrl_encoded_data_send(encoded_data, encoded_data_size,
+				sw_codec_cfg.encoder.num_ch);
 		}
 		STACK_USAGE_PRINT("encoder_thread", &encoder_thread_data);
 	}

--- a/applications/nrf5340_audio/src/audio/streamctrl.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl.c
@@ -205,13 +205,15 @@ uint8_t stream_state_get(void)
 	return strm_state;
 }
 
-void streamctrl_encoded_data_send(void const *const data, size_t len)
+void streamctrl_encoded_data_send(void const *const data, size_t size, uint8_t num_ch)
 {
 	int ret;
 	static int prev_ret;
 
+	struct encoded_audio enc_audio = {.data = data, .size = size, .num_ch = num_ch};
+
 	if (strm_state == STATE_STREAMING) {
-		ret = le_audio_send(data, len);
+		ret = le_audio_send(enc_audio);
 
 		if (ret != 0 && ret != prev_ret) {
 			LOG_WRN("Problem with sending LE audio data, ret: %d", ret);

--- a/applications/nrf5340_audio/src/audio/streamctrl.h
+++ b/applications/nrf5340_audio/src/audio/streamctrl.h
@@ -24,10 +24,11 @@ uint8_t stream_state_get(void);
 
 /** @brief Send encoded data over the stream
  *
- * @param data  Data to send
- * @param len   Length of data to send
+ * @param data		Data to send
+ * @param size		Size of data
+ * @param num_ch	Number of audio channels
  */
-void streamctrl_encoded_data_send(void const *const data, size_t len);
+void streamctrl_encoded_data_send(void const *const data, size_t size, uint8_t num_ch);
 
 /** @brief Drives streamctrl state machine
  *

--- a/applications/nrf5340_audio/src/audio/sw_codec_select.c
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.c
@@ -50,7 +50,7 @@ int sw_codec_encode(void *pcm_data, size_t pcm_size, uint8_t **encoded_data, siz
 			return ret;
 		}
 
-		switch (m_config.encoder.channel_mode) {
+		switch (m_config.encoder.num_ch) {
 		case SW_CODEC_MONO: {
 			ret = sw_codec_lc3_enc_run(pcm_data_mono[m_config.encoder.audio_ch],
 						   pcm_block_size_mono, LC3_USE_BITRATE_FROM_INIT,
@@ -82,7 +82,7 @@ int sw_codec_encode(void *pcm_data, size_t pcm_size, uint8_t **encoded_data, siz
 			break;
 		}
 		default:
-			LOG_ERR("Unsupported channel mode: %d", m_config.encoder.channel_mode);
+			LOG_ERR("Unsupported number of channels: %d", m_config.encoder.num_ch);
 			return -ENODEV;
 		}
 
@@ -121,7 +121,7 @@ int sw_codec_decode(uint8_t const *const encoded_data, size_t encoded_size, bool
 		/* Typically used for right channel if stereo signal */
 		char pcm_data_mono_right[PCM_NUM_BYTES_MONO] = { 0 };
 
-		switch (m_config.decoder.channel_mode) {
+		switch (m_config.decoder.num_ch) {
 		case SW_CODEC_MONO: {
 			if (bad_frame && IS_ENABLED(CONFIG_SW_CODEC_OVERRIDE_PLC)) {
 				memset(pcm_data_mono, 0, PCM_NUM_BYTES_MONO);
@@ -182,7 +182,7 @@ int sw_codec_decode(uint8_t const *const encoded_data, size_t encoded_size, bool
 			break;
 		}
 		default:
-			LOG_ERR("Unsupported channel mode: %d", m_config.encoder.channel_mode);
+			LOG_ERR("Unsupported number of channels: %d", m_config.encoder.num_ch);
 			return -ENODEV;
 		}
 
@@ -266,12 +266,12 @@ int sw_codec_init(struct sw_codec_config sw_codec_cfg)
 			LOG_DBG("Encode: %dHz %dbits %dus %dbps %d channel(s)",
 				CONFIG_AUDIO_SAMPLE_RATE_HZ, CONFIG_AUDIO_BIT_DEPTH_BITS,
 				CONFIG_AUDIO_FRAME_DURATION_US, sw_codec_cfg.encoder.bitrate,
-				sw_codec_cfg.encoder.channel_mode);
+				sw_codec_cfg.encoder.num_ch);
 
 			ret = sw_codec_lc3_enc_init(
 				CONFIG_AUDIO_SAMPLE_RATE_HZ, CONFIG_AUDIO_BIT_DEPTH_BITS,
 				CONFIG_AUDIO_FRAME_DURATION_US, sw_codec_cfg.encoder.bitrate,
-				sw_codec_cfg.encoder.channel_mode, &pcm_bytes_req_enc);
+				sw_codec_cfg.encoder.num_ch, &pcm_bytes_req_enc);
 
 			if (ret) {
 				return ret;
@@ -286,12 +286,12 @@ int sw_codec_init(struct sw_codec_config sw_codec_cfg)
 
 			LOG_DBG("Decode: %dHz %dbits %dus %d channel(s)",
 				CONFIG_AUDIO_SAMPLE_RATE_HZ, CONFIG_AUDIO_BIT_DEPTH_BITS,
-				CONFIG_AUDIO_FRAME_DURATION_US, sw_codec_cfg.decoder.channel_mode);
+				CONFIG_AUDIO_FRAME_DURATION_US, sw_codec_cfg.decoder.num_ch);
 
 			ret = sw_codec_lc3_dec_init(CONFIG_AUDIO_SAMPLE_RATE_HZ,
 						    CONFIG_AUDIO_BIT_DEPTH_BITS,
 						    CONFIG_AUDIO_FRAME_DURATION_US,
-						    sw_codec_cfg.decoder.channel_mode);
+						    sw_codec_cfg.decoder.num_ch);
 
 			if (ret) {
 				return ret;

--- a/applications/nrf5340_audio/src/audio/sw_codec_select.h
+++ b/applications/nrf5340_audio/src/audio/sw_codec_select.h
@@ -37,7 +37,7 @@ enum sw_codec_select {
 	SW_CODEC_LC3, /* Low Complexity Communication Codec */
 };
 
-enum sw_codec_select_ch {
+enum sw_codec_num_ch {
 	SW_CODEC_ZERO_CHANNELS,
 	SW_CODEC_MONO, /* Only use one channel */
 	SW_CODEC_STEREO, /* Use both channels */
@@ -46,13 +46,13 @@ enum sw_codec_select_ch {
 struct sw_codec_encoder {
 	bool enabled;
 	int bitrate;
-	enum sw_codec_select_ch channel_mode;
+	uint8_t num_ch;
 	enum audio_channel audio_ch; /* Only used if channel mode is mono */
 };
 
 struct sw_codec_decoder {
 	bool enabled;
-	enum sw_codec_select_ch channel_mode;
+	uint8_t num_ch;
 	enum audio_channel audio_ch; /* Only used if channel mode is mono */
 };
 

--- a/applications/nrf5340_audio/src/bluetooth/le_audio.h
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio.h
@@ -141,6 +141,16 @@ enum le_audio_user_defined_action {
 };
 
 /**
+ * @brief Encoded audio data and information.
+ * Container for SW codec (typically LC3) compressed audio data.
+ */
+struct encoded_audio {
+	uint8_t const * const data;
+	size_t size;
+	uint8_t num_ch;
+};
+
+/**
  * @brief Generic function for a user defined button press
  *
  * @param action	User defined action
@@ -191,7 +201,7 @@ int le_audio_volume_mute(void);
 
 /**
  * @brief	Either resume or pause the Bluetooth LE Audio stream,
- *              depending on the current state of the stream
+ *		depending on the current state of the stream
  *
  * @return	0 for success, error otherwise
  */
@@ -200,14 +210,13 @@ int le_audio_play_pause(void);
 /**
  * @brief Send Bluetooth LE Audio data
  *
- * @param data	Data to send
- * @param size	Size of data to send
+ * @param enc_audio	Encoded audio struct
  *
  * @return	0 for success,
  *		-ENXIO if the feature is disabled,
  *		error otherwise
  */
-int le_audio_send(uint8_t const *const data, size_t size);
+int le_audio_send(struct encoded_audio enc_audio);
 
 /**
  * @brief Enable Bluetooth LE Audio

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -568,7 +568,7 @@ int le_audio_play_pause(void)
 	return 0;
 }
 
-int le_audio_send(uint8_t const *const data, size_t size)
+int le_audio_send(struct encoded_audio enc_audio)
 {
 	LOG_WRN("Not possible to send audio data from broadcast sink");
 	return -ENXIO;

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -1165,14 +1165,21 @@ int le_audio_play_pause(void)
 	return 0;
 }
 
-int le_audio_send(uint8_t const *const data, size_t size)
+int le_audio_send(struct encoded_audio enc_audio)
 {
 	int ret;
+	size_t data_size_pr_stream;
 	struct bt_iso_tx_info tx_info = { 0 };
-	size_t sdu_size = LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_BT_AUDIO_BITRATE);
 
-	if (size != (sdu_size * 2)) {
-		LOG_ERR("Not enough data for stereo stream");
+	if ((enc_audio.num_ch == 1) || (enc_audio.num_ch == ARRAY_SIZE(headsets))) {
+		data_size_pr_stream = enc_audio.size / enc_audio.num_ch;
+	} else {
+		LOG_ERR("Num encoded channels must be 1 or equal to num headsets");
+		return -EINVAL;
+	}
+
+	if (data_size_pr_stream != LE_AUDIO_SDU_SIZE_OCTETS(CONFIG_BT_AUDIO_BITRATE)) {
+		LOG_ERR("The encoded data size does not match the SDU size");
 		return -ECANCELED;
 	}
 
@@ -1203,13 +1210,18 @@ int le_audio_send(uint8_t const *const data, size_t size)
 		audio_datapath_just_in_time_check_and_adjust(tx_info.ts);
 	}
 
-	ret = iso_stream_send(data, sdu_size, headsets[AUDIO_CH_L]);
+	ret = iso_stream_send(enc_audio.data, data_size_pr_stream, headsets[AUDIO_CH_L]);
 	if (ret) {
 		LOG_DBG("Failed to send data to left channel");
 	}
 
 #if !CONFIG_STREAM_BIDIRECTIONAL
-	ret = iso_stream_send(&data[sdu_size], sdu_size, headsets[AUDIO_CH_R]);
+	if (enc_audio.num_ch == 1) {
+		ret = iso_stream_send(enc_audio.data, data_size_pr_stream, headsets[AUDIO_CH_R]);
+	} else {
+		ret = iso_stream_send(&enc_audio.data[data_size_pr_stream], data_size_pr_stream,
+			headsets[AUDIO_CH_R]);
+	}
 	if (ret) {
 		LOG_DBG("Failed to send data to right channel");
 	}


### PR DESCRIPTION
Created a flag for sending identical (mono/left) data to all receivers

Signed-off-by: Kristoffer Rist Skøien <kristoffer.skoien@nordicsemi.no>