### PR TITLE
applications: machine_learning: Configurable sensor sleep timeout

### DIFF
--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/sensor_manager_def.h
@@ -27,7 +27,7 @@ static struct sm_trigger sensor_trigger = {
 			 IS_ENABLED(CONFIG_ADXL362_ACCEL_RANGE_4G) ? 4.0 :
 			 IS_ENABLED(CONFIG_ADXL362_ACCEL_RANGE_2G) ? 2.0 : 1/0)
 			 / 2048.0),
-		.timeout_ms = 10 * 1000
+		.timeout_ms = (CONFIG_APP_SENSOR_SLEEP_TO) * 1000
 	}
 };
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/sensor_manager_def.h
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/sensor_manager_def.h
@@ -27,7 +27,7 @@ static struct sm_trigger sensor_trigger = {
 			 IS_ENABLED(CONFIG_ADXL362_ACCEL_RANGE_4G) ? 4.0 :
 			 IS_ENABLED(CONFIG_ADXL362_ACCEL_RANGE_2G) ? 2.0 : 1/0)
 			 / 2048.0),
-		.timeout_ms = 10 * 1000
+		.timeout_ms = (CONFIG_APP_SENSOR_SLEEP_TO) * 1000
 	}
 };
 

--- a/applications/machine_learning/src/modules/Kconfig
+++ b/applications/machine_learning/src/modules/Kconfig
@@ -13,4 +13,12 @@ rsource "Kconfig.ml_runner"
 rsource "Kconfig.usb_state"
 rsource "Kconfig.sensor_sim_ctrl"
 
+config APP_SENSOR_SLEEP_TO
+	int "Sensor default time in seconds before sensor goes to sleep"
+	default 10
+	help
+	  The number of seconds of inactivity before sensor goes into sleep mode.
+	  This configuration is used only for physical sensors that have triggers configured.
+	  It is ignored for simulated sensors.
+
 endmenu

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -196,6 +196,8 @@ nRF5340 Audio
 nRF Machine Learning (Edge Impulse)
 -----------------------------------
 
+* Added configuration option (:kconfig:option:`CONFIG_APP_SENSOR_SLEEP_TO`) to set the sensor idling timeout before suspending the sensor.
+
 * Removed the usage of ``ml_runner_signin_event`` from the application.
 
 nRF Desktop


### PR DESCRIPTION
This commit adds possibility to configure from Kconfig level sensor inactivity time before sleep.

JIRA: NCSDK-19517