### PR TITLE
TF-M: Fix UART1 baudrate handling

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -2691,6 +2691,16 @@ NCSDK-17501: Partition Manager: Ignored alignment for partitions
 
   **Workaround:** Edit the affected configurations file so that ``align`` is correctly placed inside the ``placement`` section of the config file.
 
+.. rst-class:: v2-2-0
+
+NCSDK-19536: TF-M does not compile when the board is missing a uart1 node and TF-M logging is enabled
+  TF-M does not compile when a uart1 node is not defined in a board's devicetree configuration and TF-M logging is enabled.
+
+  **Workaround:** Use one of the following workarounds:
+
+  * Add uart1 node with baudrate property in the devicetree configuration.
+  * Disable TF-M logging by enabling the :kconfig:option:`CONFIG_TFM_LOG_LEVEL_SILENCE` option.
+
 .. rst-class:: v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0
 
 NCSDK-15909: TF-M failing to build with with Zephyr SDK 0.14.2

--- a/modules/tfm/tfm/boards/board/device_cfg.h
+++ b/modules/tfm/tfm/boards/board/device_cfg.h
@@ -19,6 +19,8 @@
 #include <autoconf.h>
 #include <zephyr/devicetree.h>
 
-#define DEFAULT_UART_BAUDRATE DT_PROP_OR(DT_NODELABEL(uart1), current_speed, 115200)
+#define TFM_UART uart##NRF_SECURE_UART_INSTANCE
+
+#define DEFAULT_UART_BAUDRATE DT_PROP_OR(DT_NODELABEL(TFM_UART), current_speed, 115200)
 
 #endif /* DEVICE_CFG_H__ */

--- a/modules/tfm/tfm/boards/board/device_cfg.h
+++ b/modules/tfm/tfm/boards/board/device_cfg.h
@@ -19,6 +19,6 @@
 #include <autoconf.h>
 #include <zephyr/devicetree.h>
 
-#define DEFAULT_UART_BAUDRATE DT_PROP(DT_NODELABEL(uart1), current_speed)
+#define DEFAULT_UART_BAUDRATE DT_PROP_OR(DT_NODELABEL(uart1), current_speed, 115200)
 
 #endif /* DEVICE_CFG_H__ */


### PR DESCRIPTION
Add known issue for TF-M not compiling when a uart1 node is not defined
in the board devicetree configuration.

Add fall-back value for TF-M in case a node does not exists for uart1.
The fall-back value is the same as default before we added support for
using devicetree definition.

NCSDK-19536

Update device_cfg.h to look for baudrate from the correct uart node
instance when enabling the shared UART0 option for TF-M.

