### PR TITLE
samples: matter: Thread/Wi-Fi switchable sample in integration builds

### DIFF
--- a/samples/matter/lock/sample.yaml
+++ b/samples/matter/lock/sample.yaml
@@ -48,3 +48,9 @@ tests:
       - nrf5340dk_nrf5340_cpuapp
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp nrf7002dk_nrf5340_cpuapp
+  sample.matter.lock.switchable.nrf7002_ek:
+    build_only: true
+    extra_args: SHIELD=nrf7002_ek CONF_FILE=prj_thread_wifi_switched.conf CONFIG_CHIP_WIFI=n
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp


### PR DESCRIPTION
Add configuration with enabled Thread/Wi-Fi switch in integration builds

Signed-off-by: Janusz Gąsior <janusz.gasior@nordicsemi.no>