### PR TITLE
mpsl: fem: increase initialization priority

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -49,6 +49,13 @@ config BT_LL_SOFTDEVICE_BUILD_TYPE_LIB
 
 endchoice
 
+config BT_HCI_INIT_PRIORITY
+	int "Initialization priority of the HCI driver"
+	default KERNEL_INIT_PRIORITY_DEVICE
+	help
+	  Set the initialization priority number. Do not mess with it unless
+	  you know what you are doing.
+
 # BT_HCI_TX_STACK_SIZE is declared in Zephyr and also here for a second time,
 # for set the valid default size of the HCI Tx stack.
 config BT_HCI_TX_STACK_SIZE

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -973,4 +973,9 @@ static int hci_driver_init(const struct device *unused)
 	return err;
 }
 
-SYS_INIT(hci_driver_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+#if defined(CONFIG_MPSL_FEM)
+BUILD_ASSERT(CONFIG_MPSL_FEM_INIT_PRIORITY < CONFIG_BT_HCI_INIT_PRIORITY,
+	     "HCI driver would be initialized before its dependency, MPSL FEM");
+#endif /* defined(CONFIG_MPSL_FEM) */
+
+SYS_INIT(hci_driver_init, POST_KERNEL, CONFIG_BT_HCI_INIT_PRIORITY);

--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -93,6 +93,13 @@ config MPSL_FEM_SIMPLE_GPIO
 
 endchoice	# MPSL_FEM_CHOICE
 
+config MPSL_FEM_INIT_PRIORITY
+	int "Initialization priority of the front-end module interface"
+	default KERNEL_INIT_PRIORITY_DEFAULT
+	help
+	  Set the initialization priority number. Do not mess with it unless
+	  you know what you are doing.
+
 if (MPSL_FEM_NRF21540_GPIO || MPSL_FEM_NRF21540_GPIO_SPI) && MPSL_FEM
 
 config MPSL_FEM_NRF21540_TX_GAIN_DB

--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -293,7 +293,7 @@ static int mpsl_fem_init(const struct device *dev)
 	return fem_nrf21540_gpio_configure();
 }
 
-SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_MPSL_FEM_INIT_PRIORITY);
 
 #else /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 
@@ -335,7 +335,7 @@ static int mpsl_fem_host_init(const struct device *dev)
 
 }
 
-SYS_INIT(mpsl_fem_host_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(mpsl_fem_host_init, PRE_KERNEL_1, CONFIG_MPSL_FEM_INIT_PRIORITY);
 
 #endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 

--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -293,7 +293,7 @@ static int mpsl_fem_init(const struct device *dev)
 	return fem_nrf21540_gpio_configure();
 }
 
-SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #else /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 

--- a/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
+++ b/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
@@ -391,7 +391,7 @@ static int mpsl_fem_init(const struct device *dev)
 	return fem_nrf21540_gpio_spi_configure();
 }
 
-SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 

--- a/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
+++ b/subsys/mpsl/fem/nrf21540_gpio_spi/mpsl_fem_nrf21540_gpio_spi.c
@@ -391,7 +391,7 @@ static int mpsl_fem_init(const struct device *dev)
 	return fem_nrf21540_gpio_spi_configure();
 }
 
-SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_MPSL_FEM_INIT_PRIORITY);
 
 #endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 

--- a/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
+++ b/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
@@ -206,7 +206,7 @@ static int mpsl_fem_init(const struct device *dev)
 	return fem_simple_gpio_configure();
 }
 
-SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #else /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 

--- a/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
+++ b/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
@@ -206,7 +206,7 @@ static int mpsl_fem_init(const struct device *dev)
 	return fem_simple_gpio_configure();
 }
 
-SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(mpsl_fem_init, POST_KERNEL, CONFIG_MPSL_FEM_INIT_PRIORITY);
 
 #else /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 
@@ -229,7 +229,7 @@ static int mpsl_fem_host_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(mpsl_fem_host_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(mpsl_fem_host_init, PRE_KERNEL_1, CONFIG_MPSL_FEM_INIT_PRIORITY);
 
 #endif /* !defined(CONFIG_MPSL_FEM_PIN_FORWARDER) */
 


### PR DESCRIPTION
Front-End Module initialization is a dependency of HCI driver initialization. Increase its priority so that there's a clear hierarchy between them.

Signed-off-by: Jędrzej Ciupis <jedrzej.ciupis@nordicsemi.no>