### PR TITLE
bluetooth: fix feature bits 40 and above

### DIFF
--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -451,70 +451,70 @@ static void supported_features(sdc_hci_ip_lmp_features_t *features)
 	features->le_supported = 1;
 }
 
-static void le_supported_features(sdc_hci_le_le_features_t *features)
+static void le_supported_features(sdc_hci_cmd_le_read_local_supported_features_return_t *features)
 {
 	memset(features, 0, sizeof(*features));
 
-	features->le_encryption = 1;
-	features->extended_reject_indication = 1;
-	features->slave_initiated_features_exchange = 1;
-	features->le_ping = 1;
+	features->params.le_encryption = 1;
+	features->params.extended_reject_indication = 1;
+	features->params.slave_initiated_features_exchange = 1;
+	features->params.le_ping = 1;
 
 #ifdef CONFIG_BT_CTLR_DATA_LENGTH
-	features->le_data_packet_length_extension = 1;
+	features->params.le_data_packet_length_extension = 1;
 #endif
 
 #ifdef CONFIG_BT_CTLR_PRIVACY
-	features->ll_privacy = 1;
+	features->params.ll_privacy = 1;
 #endif
 
 #ifdef CONFIG_BT_CTLR_EXT_SCAN_FP
-	features->extended_scanner_filter_policies = 1;
+	features->params.extended_scanner_filter_policies = 1;
 #endif
 
 #ifdef CONFIG_BT_CTLR_PHY_2M
-	features->le_2m_phy = 1;
+	features->params.le_2m_phy = 1;
 #endif
 
 #ifdef CONFIG_BT_CTLR_PHY_CODED
-	features->le_coded_phy = 1;
+	features->params.le_coded_phy = 1;
 #endif
 
 #ifdef CONFIG_BT_CTLR_ADV_EXT
-	features->le_extended_advertising = 1;
+	features->params.le_extended_advertising = 1;
 #endif
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC) || defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
-	features->le_periodic_advertising = 1;
+	features->params.le_periodic_advertising = 1;
 #ifdef CONFIG_BT_CTLR_SYNC_TRANSFER_SENDER
-	features->periodic_advertising_sync_transfer_sender = 1;
+	features->params.periodic_advertising_sync_transfer_sender = 1;
 #endif
 #ifdef CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER
-	features->periodic_advertising_sync_transfer_recipient = 1;
+	features->params.periodic_advertising_sync_transfer_recipient = 1;
 #endif
 #endif
 
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
-	features->connectionless_cte_transmitter = 1;
+	features->params.connectionless_cte_transmitter = 1;
 #endif
 
-	features->channel_selection_algorithm_2 = 1;
+	features->params.channel_selection_algorithm_2 = 1;
 
 #if defined(CONFIG_BT_CTLR_LE_POWER_CONTROL)
-	features->le_power_control_request = 1;
-	features->le_power_change_indication = 1;
+	features->params.le_power_control_request = 1;
+	features->params.le_power_change_indication = 1;
 #endif
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)
-	features->periodic_advertising_adi_support = 1;
+	features->params.periodic_advertising_adi_support = 1;
 #endif
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RSP)
-	features->connection_cte_response = 1;
+	features->params.connection_cte_response = 1;
 #endif
 
 #if defined(CONFIG_BT_CTLR_SCA_UPDATE)
-	features->sleep_clock_accuracy_updates = 1;
+	features->params.sleep_clock_accuracy_updates = 1;
 #endif
 }
 


### PR DESCRIPTION
The struct sdc_hci_le_le_features_t has a smaller size than the command return value (because it doesn't reserve space for RFU bits), leading to a smaller memset() than necessary.

Signed-off-by: Olivier Lesage <olivier.lesage@nordicsemi.no>