### PR TITLE
Twt tx

### DIFF
--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs.h
@@ -404,7 +404,18 @@ struct wifi_nrf_fmac_priv {
 
 	struct wifi_nrf_fmac_callbk_fns callbk_fns;
 
-	bool twt_sleep_status;
+};
+
+/**
+ * enum wifi_nrf_fmac_twt_state - The TWT state of device.
+ * @WIFI_NRF_FMAC_TWT_STATE_SLEEP: The RPU in TWT sleep state
+ * @WIFI_NRF_FMAC_TWT_STATE_AWAKE: The RPU in TWT awake state
+ *
+ * This enum lists the possible RPU TWT operational states.
+ */
+enum wifi_nrf_fmac_twt_state {
+	WIFI_NRF_FMAC_TWT_STATE_SLEEP,
+	WIFI_NRF_FMAC_TWT_STATE_AWAKE
 };
 
 
@@ -433,6 +444,7 @@ struct wifi_nrf_fmac_priv {
  * @lmac_ver: LMAC version information.
  * @num_sta: Present number of STAs created on the device.
  * @num_ap: Present number of APs created on the device.
+ * @twt_sleep_status: Current RPU TWT sleep status.
  *
  * This structure maintains the context information necessary for the
  * a single instance of an FullMAC based RPU.
@@ -455,6 +467,7 @@ struct wifi_nrf_fmac_dev_ctx {
 	bool fw_deinit_done;
 	bool alpha2_valid;
 	unsigned char alpha2[3];
+	enum wifi_nrf_fmac_twt_state twt_sleep_status;
 };
 
 

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs.h
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/inc/fmac_structs.h
@@ -405,7 +405,6 @@ struct wifi_nrf_fmac_priv {
 	struct wifi_nrf_fmac_callbk_fns callbk_fns;
 
 	bool twt_sleep_status;
-	int last_tx_done_desc;
 };
 
 

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
@@ -1314,7 +1314,6 @@ enum wifi_nrf_status tx_init(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx)
 		goto out;
 	}
 
-	fmac_dev_ctx->fpriv->last_tx_done_desc  = -1;
 	fmac_dev_ctx->fpriv->twt_sleep_status  = false;
 
 	status = WIFI_NRF_STATUS_SUCCESS;

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
@@ -975,7 +975,8 @@ enum wifi_nrf_status tx_done_process(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 	pkts_pending = tx_buff_req_free(fmac_dev_ctx, config->tx_desc_num, &queue);
 
 	if (pkts_pending) {
-		if (!fpriv->twt_sleep_status) {
+		if (fmac_dev_ctx->twt_sleep_status ==
+		    WIFI_NRF_FMAC_TWT_STATE_AWAKE) {
 
 			pkt_info = &fmac_dev_ctx->tx_config.pkt_info_p[desc];
 
@@ -1065,7 +1066,8 @@ enum wifi_nrf_status wifi_nrf_fmac_tx(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx
 	}
 
 
-	if (fpriv->twt_sleep_status) {
+	if (fmac_dev_ctx->twt_sleep_status ==
+	    WIFI_NRF_FMAC_TWT_STATE_SLEEP) {
 		goto out;
 	}
 
@@ -1314,7 +1316,7 @@ enum wifi_nrf_status tx_init(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx)
 		goto out;
 	}
 
-	fmac_dev_ctx->fpriv->twt_sleep_status  = false;
+	fmac_dev_ctx->twt_sleep_status = WIFI_NRF_FMAC_TWT_STATE_AWAKE;
 
 	status = WIFI_NRF_STATUS_SUCCESS;
 out:

--- a/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
+++ b/drivers/wifi/nrf700x/osal/fw_if/umac_if/src/tx.c
@@ -972,9 +972,6 @@ enum wifi_nrf_status tx_done_process(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx,
 
 	fmac_dev_ctx->host_stats.total_tx_done_pkts += pkt;
 
-	/* Save the tx_desc_num for use in case of UNBLOCK_TX event received */
-	fpriv->last_tx_done_desc = config->tx_desc_num;
-
 	pkts_pending = tx_buff_req_free(fmac_dev_ctx, config->tx_desc_num, &queue);
 
 	if (pkts_pending) {
@@ -1316,8 +1313,10 @@ enum wifi_nrf_status tx_init(struct wifi_nrf_fmac_dev_ctx *fmac_dev_ctx)
 
 		goto out;
 	}
+
 	fmac_dev_ctx->fpriv->last_tx_done_desc  = -1;
 	fmac_dev_ctx->fpriv->twt_sleep_status  = false;
+
 	status = WIFI_NRF_STATUS_SUCCESS;
 out:
 	return status;

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_twt.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_twt.c
@@ -216,7 +216,7 @@ void wifi_nrf_event_proc_twt_sleep_zep(void *vif_ctx,
 		wifi_nrf_osal_spinlock_take(fmac_dev_ctx->fpriv->opriv,
 					    fmac_dev_ctx->tx_config.tx_lock);
 
-		fmac_priv->twt_sleep_status = true;
+		fmac_dev_ctx->twt_sleep_status = WIFI_NRF_FMAC_TWT_STATE_SLEEP;
 
 		wifi_nrf_osal_spinlock_rel(fmac_dev_ctx->fpriv->opriv,
 					   fmac_dev_ctx->tx_config.tx_lock);
@@ -225,6 +225,7 @@ void wifi_nrf_event_proc_twt_sleep_zep(void *vif_ctx,
 		wifi_nrf_osal_spinlock_take(fmac_dev_ctx->fpriv->opriv,
 					    fmac_dev_ctx->tx_config.tx_lock);
 
+		fmac_dev_ctx->twt_sleep_status = WIFI_NRF_FMAC_TWT_STATE_AWAKE;
 #ifdef CONFIG_NRF700X_DATA_TX
 		for (ac = WIFI_NRF_FMAC_AC_BE;
 		     ac <= WIFI_NRF_FMAC_AC_MAX; ++ac) {
@@ -234,7 +235,6 @@ void wifi_nrf_event_proc_twt_sleep_zep(void *vif_ctx,
 			}
 		}
 #endif
-		fmac_priv->twt_sleep_status = false;
 
 		wifi_nrf_osal_spinlock_rel(fmac_dev_ctx->fpriv->opriv,
 					   fmac_dev_ctx->tx_config.tx_lock);


### PR DESCRIPTION
Changes for twt tx issue. 
After TWT block event it is possible that firmware still sending tx_done events. Host will no more send pkts as RPU is in sleep state.It will just clear the descriptor if it is not done yet. 
On un-block event host will try to send pkts from pending pkts if the desciptor and pkts are available. Host will no more maintanis "last_tx_done_desc" variable depending upon which tx was being attempted.