### PR TITLE
lib: nrf_modem: fix unresponsive diagnostics 

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -503,6 +503,7 @@ Modem libraries
   * Updated:
 
     * The minimal value of :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHMEM_RX_SIZE` to meet the requirements of modem firmware 1.3.4.
+    * The :c:func:`nrf_modem_lib_diag_stats_get` function now returns an error if called when the :ref:`nrf_modem_lib_readme` library has not been initialized.
 
 * :ref:`lib_location` library:
 

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -165,6 +165,8 @@ struct nrf_modem_lib_diag_stats {
  * @brief Retrieve heap runtime statistics.
  *
  * Retrieve runtime statistics for the shared memory and library heaps.
+ *
+ * @return int Zero on success, non-zero otherwise.
  */
 int nrf_modem_lib_diag_stats_get(struct nrf_modem_lib_diag_stats *stats);
 

--- a/lib/nrf_modem_lib/diag.c
+++ b/lib/nrf_modem_lib/diag.c
@@ -27,6 +27,11 @@ static struct k_work_delayable diag_work;
 
 int nrf_modem_lib_diag_stats_get(struct nrf_modem_lib_diag_stats *stats)
 {
+	/* Prevent runtime stats get of uninitialized heap which causes unresponsiveness. */
+	if (!nrf_modem_is_initialized()) {
+		return -EPERM;
+	}
+
 	if (!stats) {
 		return -EFAULT;
 	}


### PR DESCRIPTION
If `nrf_modem_lib_diag_stats_get` is called when
Modem library is not initialized, the
`sys_heap_runtime_stats_get` function will become
unresponsive because the Modem library heaps
are not initialized.