### PR TITLE
samples: nrf9160: modem_shell: ppp: ipv6 fixed

### DIFF
--- a/samples/nrf9160/modem_shell/src/ppp/ppp_ctrl.c
+++ b/samples/nrf9160/modem_shell/src/ppp/ppp_ctrl.c
@@ -130,6 +130,7 @@ static int ppp_ctrl_start_net_if(void)
 	       sizeof(ctx->ipcp.my_options.dns2_address));
 
 	free(pdp_context_info);
+	net_if_flag_set(iface, NET_IF_POINTOPOINT);
 	net_if_up(iface);
 
 	return 0;


### PR DESCRIPTION
One of the recent Zephyr changes
(sdk-zephyr commit: e862beeb9c8d1ca10233b29f287c8f9caf60beb2) changed IPv6 with PPP so that IPv6 stack got involved more 
(ND started and ended that no route)  because pkt family is now set already at net_context level.
Thus, we need to set flag NET_IF_POINTOPOINT for ppp net iface. 
Jira: MOSH-403

test-sdk-nrf: sdk-nrf-pr-10131