### PR TITLE
CODEOWNERS: Replace codeowner from Mesh team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -226,7 +226,7 @@ Kconfig*                                  @tejlmand
 /modules/tfm/                             @SebastianBoe @joerchan
 /subsys/zigbee/                           @tomchy @sebastiandraus
 /tests/                                   @gopiotr
-/tests/bluetooth/tester/                  @carlescufi @trond-snekvik
+/tests/bluetooth/tester/                  @carlescufi @ludvigsj
 /tests/crypto/                            @torsteingrindvik @magnev
 /tests/drivers/flash_patch/               @oyvindronningstad
 /tests/drivers/fprotect/                  @oyvindronningstad


### PR DESCRIPTION
Replace Trond as codeowner for bluetooth/tester, as he is no longer working with Bluetooth (Mesh).

Signed-off-by: Ludvig Samuelsen Jordet <ludvig.jordet@nordicsemi.no>