### PR TITLE
applications: nrf5340_audio: Improve scan parameter for CIS gateway

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_gateway.c
@@ -752,6 +752,15 @@ static void on_device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 static void ble_acl_start_scan(void)
 {
 	int ret;
+	/* Scan interval as two times of ISO interval */
+	int scan_interval =
+		bt_codec_cfg_get_frame_duration_us(&lc3_preset_nrf5340.codec) / 1000 / 0.625 * 2;
+	/* Scan window as two times of ISO interval */
+	int scan_window =
+		bt_codec_cfg_get_frame_duration_us(&lc3_preset_nrf5340.codec) / 1000 / 0.625 * 2;
+	struct bt_le_scan_param *scan_param =
+		BT_LE_SCAN_PARAM(BT_LE_SCAN_TYPE_PASSIVE, BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+				 scan_interval, scan_window);
 
 	/* Reset number of bonds found */
 	bonded_num = 0;
@@ -762,7 +771,7 @@ static void ble_acl_start_scan(void)
 		LOG_INF("All bonded slots filled, will not accept new devices");
 	}
 
-	ret = bt_le_scan_start(BT_LE_SCAN_PASSIVE, on_device_found);
+	ret = bt_le_scan_start(scan_param, on_device_found);
 	if (ret && ret != -EALREADY) {
 		LOG_WRN("Scanning failed to start: %d", ret);
 		return;

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_cis_headset.c
@@ -162,7 +162,7 @@ static void print_codec(const struct bt_codec *codec)
 		uint32_t bitrate =
 			octets_per_sdu * 8 * (1000000 / bt_codec_cfg_get_frame_duration_us(codec));
 
-		LOG_INF("\tOctets per frame: %d (%d kbps)", octets_per_sdu, bitrate);
+		LOG_INF("\tOctets per frame: %d (%d bps)", octets_per_sdu, bitrate);
 		LOG_INF("\tFrames per SDU: %d", bt_codec_cfg_get_frame_blocks_per_sdu(codec, true));
 	} else {
 		LOG_WRN("Codec is not LC3, codec_id: 0x%2x", codec->id);


### PR DESCRIPTION
Set scan interval and window to two times of CIS ISO interval which improve the reconnection behavior.

Fix a typo in CIS headset bitrate printing.
OCT-2438
Signed-off-by: Jui-Chou Chung <jui-chou.chung@nordicsemi.no>