### PR TITLE
applications: asset_tracker_v2: LwM2M Fota fix

### DIFF
--- a/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
+++ b/applications/asset_tracker_v2/src/cloud/lwm2m_integration/lwm2m_integration.c
@@ -289,10 +289,9 @@ static int firmware_update_state_cb(uint8_t update_state)
 		return 0;
 	case STATE_UPDATING:
 		LOG_DBG("STATE_UPDATING, result: %d", update_result);
-		cloud_wrap_evt.type = CLOUD_WRAP_EVT_FOTA_DONE;
 		/* Disable further callbacks from FOTA */
 		lwm2m_firmware_set_update_state_cb(NULL);
-		break;
+		return 0;
 	default:
 		LOG_ERR("Unknown state: %d", update_state);
 		cloud_wrap_evt.type = CLOUD_WRAP_EVT_FOTA_ERROR;

--- a/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
+++ b/applications/asset_tracker_v2/tests/lwm2m_integration/src/lwm2m_integration_test.c
@@ -395,7 +395,7 @@ void test_lwm2m_integration_fota_updating(void)
 	last_cb_type = UINT8_MAX;
 
 	firmware_update_state_cb(STATE_UPDATING);
-	TEST_ASSERT_EQUAL(CLOUD_WRAP_EVT_FOTA_DONE, last_cb_type);
+	TEST_ASSERT_EQUAL(UINT8_MAX, last_cb_type);
 }
 
 void test_lwm2m_integration_fota_unexpected_event(void)


### PR DESCRIPTION
Removed duplicate CLOUD_WRAP_EVT_FOTA_DONE. Update state was generated first and reboot a second. Proper solution is remove from update trigger.

Now It triggers CLOUD_WRAP_EVT_FOTA_DONE when Reboot is requested after flash operation.

Fixed Unit test.