### PR TITLE
samples: bluetooth: nrf_dm: Fix twister configuration file

### DIFF
--- a/samples/bluetooth/nrf_dm/sample.yaml
+++ b/samples/bluetooth/nrf_dm/sample.yaml
@@ -4,6 +4,8 @@ sample:
 tests:
   sample.bluetooth.nrf_dm.timeslot:
     build_only: true
+    extra_configs:
+      - CONFIG_DM_HIGH_PRECISION_CALC=n
     integration_platforms:
       - nrf52dk_nrf52832
       - nrf52833dk_nrf52833


### PR DESCRIPTION
By default, high-precision calculations are enabled for the sample. 
Commit disables high-precision calculations for the `sample.bluetooth.nrf_dm.timeslot` test case.
