### PR TITLE
Fix pre-processor warning when testing with azure config and add native_posix to atv2 integration platforms

### DIFF
--- a/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
+++ b/applications/asset_tracker_v2/doc/asset_tracker_v2_description.rst
@@ -18,7 +18,9 @@ The Asset Tracker v2 application is built on the following principles:
 Requirements
 ************
 
-.. table-from-sample-yaml::
+.. table-from-rows:: /includes/sample_board_rows.txt
+   :header: heading
+   :rows: thingy91_nrf9160_ns, nrf9160dk_nrf9160_ns
 
 .. include:: /includes/tfm.txt
 

--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -71,6 +71,7 @@ tests:
     extra_configs:
       - CONFIG_AZURE_IOT_HUB_DPS_HOSTNAME="global.azure-devices-provisioning.net"
       - CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE="IDSCOPE"
+      - CONFIG_MQTT_HELPER_PROVISION_CERTIFICATES=n
     extra_args: OVERLAY_CONFIG="overlay-azure.conf"
     tags: ci_build
   applications.asset_tracker_v2.debug:

--- a/applications/asset_tracker_v2/sample.yaml
+++ b/applications/asset_tracker_v2/sample.yaml
@@ -8,6 +8,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
+      - native_posix
     tags: ci_build
   applications.asset_tracker_v2.nrf_cloud-pgps:
     build_only: true
@@ -34,6 +35,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
+      - native_posix
     extra_configs:
       - CONFIG_AWS_IOT_BROKER_HOST_NAME="example-hostname.aws.com"
     extra_args: OVERLAY_CONFIG="overlay-aws.conf"
@@ -68,6 +70,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
+      - native_posix
     extra_configs:
       - CONFIG_AZURE_IOT_HUB_DPS_HOSTNAME="global.azure-devices-provisioning.net"
       - CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE="IDSCOPE"
@@ -81,6 +84,7 @@ tests:
     integration_platforms:
       - nrf9160dk_nrf9160_ns
       - thingy91_nrf9160_ns
+      - native_posix
     extra_args: OVERLAY_CONFIG=overlay-debug.conf
     tags: ci_build
   applications.asset_tracker_v2.debug-memfault:


### PR DESCRIPTION
- Added native_posix to the integration_platforms list of the platforms that are allowed to be built for native_posix. This is to ensure that these configs get built by CI.

- Fix compiler warning in azure config by disabling the KConfig option CONFIG_MQTT_HELPER_PROVISION_CERTIFICATES for azure config.

