### PR TITLE
bluetooth: controller: Fix unexpected low TX power with FEM connected

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -2212,6 +2212,11 @@ SoftDevice Controller
 
 In addition to the known issues listed here, see also :ref:`softdevice_controller_limitations` for permanent limitations.
 
+.. rst-class:: v2-2-0 v2-1-3 v2-1-2 v2-1-1 v2-1-0
+
+DRGN-18568: When the :kconfig:option:`CONFIG_MPSL_FEM` Kconfig option is used, the actual value of radio output power is lower than expected.
+  The actual value is lower than the default one in case the :kconfig:option:`CONFIG_BT_CTLR_TX_PWR_ANTENNA` or :kconfig:option:`CONFIG_BT_CTLR_TX_PWR` Kconfig options are used together with the :kconfig:option:`CONFIG_MPSL_FEM` Kconfig option.
+
 .. rst-class:: v2-2-0 v2-1-3 v2-1-2 v2-1-1 v2-1-0 v2-0-2 v2-0-1 v2-0-0 v1-9-2 v1-9-1 v1-9-0 v1-8-0
 
 DRGN-16013: Initiating connections over extended advertising is not supported when external radio coexistence and FEM support are enabled

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -612,13 +612,6 @@ static int configure_supported_features(void)
 		}
 	}
 
-#if RADIO_TXP_DEFAULT != 0
-	err = sdc_default_tx_power_set(RADIO_TXP_DEFAULT);
-	if (err) {
-		return -ENOTSUP;
-	}
-#endif
-
 	if (IS_ENABLED(CONFIG_BT_CTLR_LE_POWER_CONTROL)) {
 		if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
 			err = sdc_support_le_power_control_central();
@@ -850,6 +843,14 @@ static int hci_driver_open(void)
 			}
 		}
 	}
+
+#if RADIO_TXP_DEFAULT != 0
+	err = sdc_default_tx_power_set(RADIO_TXP_DEFAULT);
+	if (err) {
+		MULTITHREADING_LOCK_RELEASE();
+		return -ENOTSUP;
+	}
+#endif
 
 	err = sdc_enable(receive_signal_raise, sdc_mempool);
 	if (err) {


### PR DESCRIPTION
Solved by setting the default radio output power when enabling Bluetooth. That is, after the FEM is initialized.

Previously the initial default radio output power would be selected as if there was no FEM connected. For example 6 dBm.
Then, when packets are to be transmitted, we would recalculate how much power we would need on the outputting device. That is, 6 dBm minus the FEM gain.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>