### PR TITLE
samples: matter: fix invalid check in external flasher

### DIFF
--- a/samples/matter/lock/src/flash-external.py
+++ b/samples/matter/lock/src/flash-external.py
@@ -84,7 +84,7 @@ def main():
     if len(app_data) > args.app_size:
         die(f'Application core image exceeds partition size: {len(app_data)} > {args.app_size}')
 
-    if len(app_data) > args.app_size:
+    if len(net_data) > args.net_size:
         die(f'Network core image exceeds partition size: {len(net_data)} > {args.net_size}')
 
     snr = select_board_snr()


### PR DESCRIPTION
Check net core size instead of doing duplicated
app image size validation.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>