### PR TITLE
application: serial_lte_modem: BUG-Fix rsp_buf multiple access

### DIFF
--- a/applications/serial_lte_modem/doc/FTP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/FTP_AT_commands.rst
@@ -117,7 +117,7 @@ TFTP client #XTFTP
 The ``#XTFTP`` command allows you to send TFTP commands.
 
    .. note::
-      The maximum supported file size is 2100 bytes.
+      The maximum supported file size is 2048 bytes.
       TFTP write request is not supported yet.
 
 Set command

--- a/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/MQTT_AT_commands.rst
@@ -338,7 +338,7 @@ Syntax
 * The ``<msg>`` parameter is a string.
   It contains the payload on the topic being published.
 
-  The maximum size of the payload is 256 bytes when not empty.
+  The maximum size of the payload is 1024 bytes when not empty.
   If the payload is empty (for example, ``""``), SLM enters ``slm_data_mode``.
 * The ``<qos>`` parameter is an integer.
   It indicates the MQTT Quality of Service types.

--- a/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/SOCKET_AT_commands.rst
@@ -924,7 +924,7 @@ Syntax
    #XSEND[=<data>]
 
 * The ``<data>`` parameter is a string that contains the data to be sent.
-  The maximum size of the data is 1252 bytes.
+  The maximum size of the data is 1024 bytes.
   When the parameter is not specified, SLM enters ``slm_data_mode``.
 
 Response syntax
@@ -1038,7 +1038,7 @@ Syntax
 * The ``<port>`` parameter is an unsigned 16-bit integer (0 - 65535).
   It represents the port of the UDP service on remote peer.
 * The ``<data>`` parameter is a string that contains the data to be sent.
-  Its maximum size is 1252 bytes.
+  Its maximum size is 1024 bytes.
   When the parameter is not specified, SLM enters ``slm_data_mode``.
 
 Response syntax

--- a/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
+++ b/applications/serial_lte_modem/doc/TCPIP_AT_commands.rst
@@ -263,7 +263,7 @@ Syntax
    #XTCPSEND=<data>
 
 * The ``<data>`` parameter is a string that contains the data to be sent.
-  The maximum size of the data is 1252 bytes.
+  The maximum size of the data is 1024 bytes.
   When the parameter is not specified, SLM enters ``slm_data_mode``.
 
 Response syntax
@@ -609,7 +609,7 @@ Syntax
    #XUDPSEND=<data>
 
 * The ``<data>`` parameter is a string that contains the data to be sent.
-  The maximum size of the data is 1252 bytes.
+  The maximum size of the data is 1024 bytes.
   When the parameter is not specified, SLM enters ``slm_data_mode``.
 
 Response syntax

--- a/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
+++ b/applications/serial_lte_modem/src/ftp_c/slm_at_ftp.c
@@ -105,11 +105,11 @@ static ftp_op_list_t ftp_op_list[FTP_OP_MAX] = {
 	{FTP_OP_MPUT, "mput", do_ftp_mput},
 };
 
-RING_BUF_DECLARE(ftp_data_buf, SLM_MAX_PAYLOAD);
+RING_BUF_DECLARE(ftp_data_buf, SLM_MAX_MESSAGE_SIZE);
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
+extern uint8_t data_buf[SLM_MAX_MESSAGE_SIZE];
 
 void ftp_ctrl_callback(const uint8_t *msg, uint16_t len)
 {
@@ -121,35 +121,44 @@ void ftp_ctrl_callback(const uint8_t *msg, uint16_t len)
 	if (FTP_PROPRIETARY(code)) {
 		switch (code) {
 		case FTP_CODE_901:
-			sprintf(rsp_buf, "\r\n#XFTP: %d,\"disconnected\"\r\n", -ECONNRESET);
+			if (ftp_verbose_on) {
+				rsp_send("\r\n#XFTP: %d,\"disconnected\"\r\n", -ECONNRESET);
+			}
 			break;
 		case FTP_CODE_902:
-			sprintf(rsp_buf, "\r\n#XFTP: %d,\"disconnected\"\r\n", -ECONNABORTED);
+			if (ftp_verbose_on) {
+				rsp_send("\r\n#XFTP: %d,\"disconnected\"\r\n", -ECONNABORTED);
+			}
 			break;
 		case FTP_CODE_903:
-			sprintf(rsp_buf, "\r\n#XFTP: %d,\"disconnected\"\r\n", -EIO);
+			if (ftp_verbose_on) {
+				rsp_send("\r\n#XFTP: %d,\"disconnected\"\r\n", -EIO);
+			}
 			break;
 		case FTP_CODE_904:
-			sprintf(rsp_buf, "\r\n#XFTP: %d,\"disconnected\"\r\n", -EAGAIN);
+			if (ftp_verbose_on) {
+				rsp_send("\r\n#XFTP: %d,\"disconnected\"\r\n", -EAGAIN);
+			}
 			break;
 		case FTP_CODE_905:
-			sprintf(rsp_buf, "\r\n#XFTP: %d,\"disconnected\"\r\n", -ENETDOWN);
+			if (ftp_verbose_on) {
+				rsp_send("\r\n#XFTP: %d,\"disconnected\"\r\n", -ENETDOWN);
+			}
 			break;
 		default:
-			sprintf(rsp_buf, "\r\n#XFTP: %d,\"disconnected\"\r\n", -ENOEXEC);
+			if (ftp_verbose_on) {
+				rsp_send("\r\n#XFTP: %d,\"disconnected\"\r\n", -ENOEXEC);
+			}
 			break;
 		}
 		if (ftp_data_mode_handler && exit_datamode(-EAGAIN)) {
 			ftp_data_mode_handler = NULL;
 		}
-		if (ftp_verbose_on) {
-			rsp_send(rsp_buf, strlen(rsp_buf));
-		}
 		return;
 	}
 
 	if (ftp_verbose_on) {
-		rsp_send((uint8_t *)msg, len);
+		data_send((uint8_t *)msg, len);
 	}
 }
 
@@ -168,8 +177,8 @@ static int ftp_data_send(void)
 	uint32_t sz_send = 0;
 
 	if (ring_buf_is_empty(&ftp_data_buf) == 0) {
-		sz_send = ring_buf_get(&ftp_data_buf, rsp_buf, sizeof(rsp_buf));
-		data_send(rsp_buf, sz_send);
+		sz_send = ring_buf_get(&ftp_data_buf, data_buf, sizeof(data_buf));
+		data_send(data_buf, sz_send);
 	}
 
 	return sz_send;
@@ -284,14 +293,13 @@ static int do_ftp_verbose(void)
 
 	if (slm_util_cmd_casecmp(vb_mode, "ON")) {
 		ftp_verbose_on = true;
-		sprintf(rsp_buf, "\r\nVerbose mode on\r\n");
+		rsp_send("\r\nVerbose mode on\r\n");
 	} else if (slm_util_cmd_casecmp(vb_mode, "OFF")) {
 		ftp_verbose_on = false;
-		sprintf(rsp_buf, "\r\nVerbose mode off\r\n");
+		rsp_send("\r\nVerbose mode off\r\n");
 	} else {
 		return -EINVAL;
 	}
-	rsp_send(rsp_buf, strlen(rsp_buf));
 
 	return 0;
 }
@@ -491,8 +499,8 @@ static int do_ftp_put(void)
 		}
 		ftp_data_mode_handler = ftp_put_handler;
 	} else {
-		char data[TCP_MAX_PAYLOAD_IPV4] = {0};
-		int size = TCP_MAX_PAYLOAD_IPV4;
+		char data[SLM_MAX_PAYLOAD_SIZE] = {0};
+		int size = sizeof(data);
 		int err;
 
 		err = util_string_get(&at_param_list, 3, data, &size);
@@ -534,8 +542,8 @@ static int do_ftp_uput(void)
 		}
 		ftp_data_mode_handler = ftp_uput_handler;
 	} else {
-		char data[TCP_MAX_PAYLOAD_IPV4] = {0};
-		int size = TCP_MAX_PAYLOAD_IPV4;
+		char data[SLM_MAX_PAYLOAD_SIZE] = {0};
+		int size = sizeof(data);
 		int err;
 
 		err = util_string_get(&at_param_list, 2, data, &size);
@@ -580,8 +588,8 @@ static int do_ftp_mput(void)
 		}
 		ftp_data_mode_handler = ftp_mput_handler;
 	} else {
-		char data[TCP_MAX_PAYLOAD_IPV4] = {0};
-		int size = TCP_MAX_PAYLOAD_IPV4;
+		char data[SLM_MAX_PAYLOAD_SIZE] = {0};
+		int size = sizeof(data);
 		int err;
 
 		err = util_string_get(&at_param_list, 3, data, &size);

--- a/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
+++ b/applications/serial_lte_modem/src/gnss/slm_at_gnss.c
@@ -99,7 +99,7 @@ static char device_id[NRF_CLOUD_CLIENT_ID_MAX_LEN];
 /* global variable defined in different files */
 extern struct k_work_q slm_work_q;
 extern struct at_param_list at_param_list;
-extern char rsp_buf[CONFIG_SLM_SOCKET_RX_MAX * 2];
+extern uint8_t at_buf[SLM_AT_MAX_CMD_LEN];
 
 static bool is_gnss_activated(void)
 {
@@ -127,13 +127,12 @@ static bool is_gnss_activated(void)
 static void gnss_status_notify(int status)
 {
 	if (run_type == RUN_TYPE_AGPS) {
-		sprintf(rsp_buf, "\r\n#XAGPS: 1,%d\r\n", status);
+		rsp_send("\r\n#XAGPS: 1,%d\r\n", status);
 	} else if (run_type == RUN_TYPE_PGPS) {
-		sprintf(rsp_buf, "\r\n#XPGPS: 1,%d\r\n", status);
+		rsp_send("\r\n#XPGPS: 1,%d\r\n", status);
 	} else {
-		sprintf(rsp_buf, "\r\n#XGPS: 1,%d\r\n", status);
+		rsp_send("\r\n#XGPS: 1,%d\r\n", status);
 	}
-	rsp_send(rsp_buf, strlen(rsp_buf));
 	run_status = status;
 }
 
@@ -417,8 +416,7 @@ static void cell_pos_req_wk(struct k_work *work)
 			}
 		} else {
 			LOG_WRN("No request of MCELL");
-			sprintf(rsp_buf, "\r\n#XCELLPOS: \r\n");
-			rsp_send(rsp_buf, strlen(rsp_buf));
+			rsp_send("\r\n#XCELLPOS: \r\n");
 			run_type = RUN_TYPE_NONE;
 		}
 	}
@@ -588,13 +586,11 @@ static void fix_rep_wk(struct k_work *work)
 	}
 
 	/* GIS accuracy: http://wiki.gis.com/wiki/index.php/Decimal_degrees, use default .6lf */
-	sprintf(rsp_buf,
-		"\r\n#XGPS: %lf,%lf,%f,%f,%f,%f,\"%04u-%02u-%02u %02u:%02u:%02u\"\r\n",
+	rsp_send("\r\n#XGPS: %lf,%lf,%f,%f,%f,%f,\"%04u-%02u-%02u %02u:%02u:%02u\"\r\n",
 		pvt.latitude, pvt.longitude, pvt.altitude,
 		pvt.accuracy, pvt.speed, pvt.heading,
 		pvt.datetime.year, pvt.datetime.month, pvt.datetime.day,
 		pvt.datetime.hour, pvt.datetime.minute, pvt.datetime.seconds);
-	rsp_send(rsp_buf, strlen(rsp_buf));
 
 	for (int i = 0; i < NRF_MODEM_GNSS_MAX_SATELLITES; ++i) {
 		if (pvt.sv[i].sv) { /* SV number 0 indicates no satellite */
@@ -622,8 +618,7 @@ static void fix_rep_wk(struct k_work *work)
 
 		/* GGA,hhmmss.ss,llll.ll,a,yyyyy.yy,a,x,xx,x.x,x.x,M,x.x,M,x.x,xxxx \r\n */
 		if (location_signify) {
-			sprintf(rsp_buf, "\r\n#XGPS: %s", nmea.nmea_str);
-			rsp_send(rsp_buf, strlen(rsp_buf));
+			rsp_send("\r\n#XGPS: %s", nmea.nmea_str);
 		}
 	}
 
@@ -734,16 +729,14 @@ static void on_cloud_evt_ready(void)
 	}
 
 	nrf_cloud_ready = true;
-	sprintf(rsp_buf, "\r\n#XNRFCLOUD: %d,%d\r\n", nrf_cloud_ready, location_signify);
-	rsp_send(rsp_buf, strlen(rsp_buf));
+	rsp_send("\r\n#XNRFCLOUD: %d,%d\r\n", nrf_cloud_ready, location_signify);
 	at_monitor_resume(&ncell_meas);
 }
 
 static void on_cloud_evt_disconnected(void)
 {
 	nrf_cloud_ready = false;
-	sprintf(rsp_buf, "\r\n#XNRFCLOUD: %d,%d\r\n", nrf_cloud_ready, location_signify);
-	rsp_send(rsp_buf, strlen(rsp_buf));
+	rsp_send("\r\n#XNRFCLOUD: %d,%d\r\n", nrf_cloud_ready, location_signify);
 	at_monitor_pause(&ncell_meas);
 }
 
@@ -763,9 +756,8 @@ static void on_cloud_evt_cell_pos_data_received(const struct nrf_cloud_data *con
 			LOG_INF("TTFF %ds", (int)k_uptime_delta(&ttft_start)/1000);
 			ttft_start = 0;
 		}
-		sprintf(rsp_buf, "\r\n#XCELLPOS: %d,%lf,%lf,%d\r\n",
+		rsp_send("\r\n#XCELLPOS: %d,%lf,%lf,%d\r\n",
 			result.type, result.lat, result.lon, result.unc);
-		rsp_send(rsp_buf, strlen(rsp_buf));
 		run_type = RUN_TYPE_NONE;
 	} else if (err == 1) {
 		LOG_WRN("No position found");
@@ -786,27 +778,27 @@ static void cloud_cmd_wk(struct k_work *work)
 	ARG_UNUSED(work);
 
 	/* Send AT command to modem */
-	ret = nrf_modem_at_cmd(rsp_buf, sizeof(rsp_buf), "%s", rsp_buf);
+	ret = nrf_modem_at_cmd(at_buf, sizeof(at_buf), "%s", at_buf);
 	if (ret < 0) {
 		LOG_ERR("AT command failed: %d", ret);
 		return;
 	} else if (ret > 0) {
 		LOG_WRN("AT command error, type: %d", nrf_modem_at_err_type(ret));
 	}
-	LOG_INF("MODEM RSP %s", rsp_buf);
+	LOG_INF("MODEM RSP %s", at_buf);
 	/* replace \" with \' in JSON string-type value */
-	for (int i = 0; i < strlen(rsp_buf); i++) {
-		if (rsp_buf[i] == '\"') {
-			rsp_buf[i] = '\'';
+	for (int i = 0; i < strlen(at_buf); i++) {
+		if (at_buf[i] == '\"') {
+			at_buf[i] = '\'';
 		}
 	}
 	/* format JSON reply */
-	cmd_rsp = k_malloc(strlen(rsp_buf) + sizeof(MODEM_AT_RSP));
+	cmd_rsp = k_malloc(strlen(at_buf) + sizeof(MODEM_AT_RSP));
 	if (cmd_rsp == NULL) {
 		LOG_WRN("Unable to allocate buffer");
 		return;
 	}
-	sprintf(cmd_rsp, MODEM_AT_RSP, rsp_buf);
+	sprintf(cmd_rsp, MODEM_AT_RSP, at_buf);
 	/* Send AT response to cloud */
 	ret = do_cloud_send_msg(cmd_rsp, strlen(cmd_rsp));
 	if (ret) {
@@ -854,7 +846,7 @@ static bool handle_cloud_cmd(const char *buf_in)
 		at_cmd = cJSON_GetObjectItemCaseSensitive(cloud_cmd_json, "data");
 		if (cJSON_GetStringValue(at_cmd) != NULL) {
 			LOG_INF("MODEM CMD %s", at_cmd->valuestring);
-			strcpy(rsp_buf, at_cmd->valuestring);
+			strcpy(at_buf, at_cmd->valuestring);
 			k_work_submit_to_queue(&slm_work_q, &cloud_cmd);
 			ret = true;
 		}
@@ -886,8 +878,7 @@ static void on_cloud_evt_data_received(const struct nrf_cloud_data *const data)
 				return;
 			}
 		}
-		sprintf(rsp_buf, "\r\n#XNRFCLOUD: %s\r\n", (char *)data->ptr);
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("\r\n#XNRFCLOUD: %s\r\n", (char *)data->ptr);
 	}
 }
 
@@ -1027,15 +1018,12 @@ int handle_at_gps(enum at_cmd_type cmd_type)
 		} break;
 
 	case AT_CMD_TYPE_READ_COMMAND:
-		sprintf(rsp_buf, "\r\n#XGPS: %d,%d\r\n", (int)is_gnss_activated(), run_status);
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("\r\n#XGPS: %d,%d\r\n", (int)is_gnss_activated(), run_status);
 		err = 0;
 		break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "\r\n#XGPS: (%d,%d),<interval>,<timeout>\r\n",
-			GPS_STOP, GPS_START);
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("\r\n#XGPS: (%d,%d),<interval>,<timeout>\r\n", GPS_STOP, GPS_START);
 		err = 0;
 		break;
 
@@ -1095,16 +1083,14 @@ int handle_at_nrf_cloud(enum at_cmd_type cmd_type)
 		} break;
 
 	case AT_CMD_TYPE_READ_COMMAND: {
-		sprintf(rsp_buf, "\r\n#XNRFCLOUD: %d,%d,%d,\"%s\"\r\n", nrf_cloud_ready,
+		rsp_send("\r\n#XNRFCLOUD: %d,%d,%d,\"%s\"\r\n", nrf_cloud_ready,
 			location_signify, CONFIG_NRF_CLOUD_SEC_TAG, device_id);
-		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 	} break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "\r\n#XNRFCLOUD: (%d,%d,%d),<signify>\r\n",
+		rsp_send("\r\n#XNRFCLOUD: (%d,%d,%d),<signify>\r\n",
 			nRF_CLOUD_DISCONNECT, nRF_CLOUD_CONNECT, nRF_CLOUD_SEND);
-		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;
 
@@ -1182,15 +1168,12 @@ int handle_at_agps(enum at_cmd_type cmd_type)
 		} break;
 
 	case AT_CMD_TYPE_READ_COMMAND:
-		sprintf(rsp_buf, "\r\n#XAGPS: %d,%d\r\n", (int)is_gnss_activated(), run_status);
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("\r\n#XAGPS: %d,%d\r\n", (int)is_gnss_activated(), run_status);
 		err = 0;
 		break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "\r\n#XAGPS: (%d,%d),<interval>,<timeout>\r\n",
-			AGPS_STOP, AGPS_START);
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("\r\n#XAGPS: (%d,%d),<interval>,<timeout>\r\n", AGPS_STOP, AGPS_START);
 		err = 0;
 		break;
 
@@ -1270,15 +1253,12 @@ int handle_at_pgps(enum at_cmd_type cmd_type)
 		} break;
 
 	case AT_CMD_TYPE_READ_COMMAND:
-		sprintf(rsp_buf, "\r\n#XPGPS: %d,%d\r\n", (int)is_gnss_activated(), run_status);
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("\r\n#XPGPS: %d,%d\r\n", (int)is_gnss_activated(), run_status);
 		err = 0;
 		break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "\r\n#XPGPS: (%d,%d),<interval>,<timeout>\r\n",
-			PGPS_STOP, PGPS_START);
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("\r\n#XPGPS: (%d,%d),<interval>,<timeout>\r\n", PGPS_STOP, PGPS_START);
 		err = 0;
 		break;
 
@@ -1309,8 +1289,7 @@ int handle_at_gps_delete(enum at_cmd_type cmd_type)
 		break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "\r\n#XGPSDEL: <mask>\r\n");
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("\r\n#XGPSDEL: <mask>\r\n");
 		err = 0;
 		break;
 
@@ -1354,16 +1333,14 @@ int handle_at_cellpos(enum at_cmd_type cmd_type)
 		} break;
 
 	case AT_CMD_TYPE_READ_COMMAND:
-		sprintf(rsp_buf, "\r\n#XCELLPOS: %d,%d\r\n", (int)is_gnss_activated(),
+		rsp_send("\r\n#XCELLPOS: %d,%d\r\n", (int)is_gnss_activated(),
 			(run_type == RUN_TYPE_CELL_POS) ? 1 : 0);
-		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "\r\n#XCELLPOS: (%d,%d,%d)\r\n",
+		rsp_send("\r\n#XCELLPOS: (%d,%d,%d)\r\n",
 			CELLPOS_STOP, CELLPOS_START_SCELL, CELLPOS_START_MCELL);
-		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;
 

--- a/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
+++ b/applications/serial_lte_modem/src/gpio/slm_at_gpio.c
@@ -16,7 +16,6 @@ LOG_MODULE_REGISTER(slm_gpio, CONFIG_SLM_LOG_LEVEL);
 
 /* global variable defined in different resources */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 static const struct device *gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 static sys_slist_t slm_gpios = SYS_SLIST_STATIC_INIT(&slm_gpios);
@@ -143,16 +142,14 @@ static int do_gpio_pin_configure_read(void)
 	int err = 0;
 	struct slm_gpio_pin_node *cur = NULL, *next = NULL;
 
-	sprintf(rsp_buf, "\r\n#XGPIOCFG\r\n");
-	rsp_send(rsp_buf, strlen(rsp_buf));
+	rsp_send("\r\n#XGPIOCFG\r\n");
 
 	if (sys_slist_peek_head(&slm_gpios) != NULL) {
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&slm_gpios, cur,
 						  next, node) {
 			if (cur) {
 				LOG_DBG("%hu,%hu", cur->op, cur->pin);
-				sprintf(rsp_buf, "%hu,%hu\r\n", cur->op, cur->pin);
-				rsp_send(rsp_buf, strlen(rsp_buf));
+				rsp_send("%hu,%hu\r\n", cur->op, cur->pin);
 			}
 		}
 	}
@@ -185,8 +182,7 @@ static int do_gpio_pin_operate(uint16_t op, gpio_pin_t pin, uint16_t value)
 						return ret;
 					}
 					LOG_DBG("Read value: %d", ret);
-					sprintf(rsp_buf, "\r\n#XGPIO: %d,%d\r\n", pin, ret);
-					rsp_send(rsp_buf, strlen(rsp_buf));
+					rsp_send("\r\n#XGPIO: %d,%d\r\n", pin, ret);
 				} else if (op == SLM_GPIO_OP_TOGGLE) {
 					LOG_DBG("Toggle pin: %d", cur->pin);
 					ret = gpio_pin_toggle(gpio_dev, pin);

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -74,34 +74,27 @@ K_WORK_DELAYABLE_DEFINE(modem_failure_reinit_work, on_modem_failure_reinit);
 
 void nrf_modem_fault_handler(struct nrf_modem_fault_info *fault_info)
 {
-	char rsp[64];
-
-	sprintf(rsp, "\r\n#XMODEM: FAULT,0x%x,0x%x\r\n", fault_info->reason,
+	rsp_send("\r\n#XMODEM: FAULT,0x%x,0x%x\r\n", fault_info->reason,
 		fault_info->program_counter);
-	rsp_send(rsp, strlen(rsp));
 	/* For now we wait 10 ms to give the trace handler time to process trace data. */
 	k_work_reschedule(&modem_failure_shutdown_work, K_MSEC(10));
 }
 
 static void on_modem_failure_shutdown(struct k_work *work)
 {
-	char rsp[32];
 	int ret = nrf_modem_lib_shutdown();
 
 	ARG_UNUSED(work);
-	sprintf(rsp, "\r\n#XMODEM: SHUTDOWN,%d\r\n", ret);
-	rsp_send(rsp, strlen(rsp));
+	rsp_send("\r\n#XMODEM: SHUTDOWN,%d\r\n", ret);
 	k_work_reschedule(&modem_failure_reinit_work, K_MSEC(10));
 }
 
 static void on_modem_failure_reinit(struct k_work *work)
 {
-	char rsp[32];
 	int ret = nrf_modem_lib_init(NORMAL_MODE);
 
 	ARG_UNUSED(work);
-	sprintf(rsp, "\r\n#XMODEM: INIT,%d\r\n", ret);
-	rsp_send(rsp, strlen(rsp));
+	rsp_send("\r\n#XMODEM: INIT,%d\r\n", ret);
 }
 #endif /* CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC */
 

--- a/applications/serial_lte_modem/src/slm_at_cmng.c
+++ b/applications/serial_lte_modem/src/slm_at_cmng.c
@@ -36,7 +36,6 @@ enum slm_cmng_type {
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 /**@brief handle AT#XCMNG commands
  *  AT#XCMNG=<opcode>[,<sec_tag>[,<type>[,<content>]]]
@@ -49,7 +48,7 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 	uint16_t op, type;
 	nrf_sec_tag_t sec_tag;
 	uint8_t *content;
-	size_t len = SLM_AT_CMD_RESPONSE_MAX_LEN;
+	size_t len = SLM_AT_MAX_RSP_LEN;
 
 	switch (cmd_type) {
 	case AT_CMD_TYPE_SET_COMMAND:
@@ -96,7 +95,7 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 				LOG_ERR("Parameter missed");
 				return -EINVAL;
 			}
-			content = k_malloc(SLM_AT_CMD_RESPONSE_MAX_LEN);
+			content = k_malloc(SLM_AT_MAX_RSP_LEN);
 			err = util_string_get(&at_param_list, 4, content,
 						   &len);
 			if (err != 0) {
@@ -120,7 +119,7 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 				LOG_ERR("Not support READ for type: %d", type);
 				return -EPERM;
 			}
-			content = k_malloc(SLM_AT_CMD_RESPONSE_MAX_LEN);
+			content = k_malloc(SLM_AT_MAX_RSP_LEN);
 			err = modem_key_mgmt_read(
 				slm_tls_map_sectag(sec_tag, type),
 				0, content, &len);
@@ -129,9 +128,8 @@ int handle_at_xcmng(enum at_cmd_type cmd_type)
 					err);
 			} else {
 				*(content + len) = '\0';
-				sprintf(rsp_buf, "%%CMNG: %d,%d,\"\","
+				rsp_send("%%CMNG: %d,%d,\"\","
 					"\"%s\"\r\n", sec_tag, type, content);
-				rsp_send(rsp_buf, strlen(rsp_buf));
 			}
 			k_free(content);
 		} else if (op == AT_CMNG_OP_DELETE) {

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -49,7 +49,6 @@ int slm_setting_fota_init(void);
 int slm_setting_fota_save(void);
 
 /* global variable defined in different files */
-extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 extern struct at_param_list at_param_list;
 extern uint8_t fota_type;
 extern uint8_t fota_stage;
@@ -83,12 +82,11 @@ static void do_fota_app_read(uint8_t area_id)
 		return;
 	}
 
-	sprintf(rsp_buf, "\r\n#XFOTA: %d,%d,%d,\"%d.%d.%d+%d\"\r\n", area_id,
+	rsp_send("\r\n#XFOTA: %d,%d,%d,\"%d.%d.%d+%d\"\r\n", area_id,
 		header.mcuboot_version,
 		header.h.v1.image_size,
 		header.h.v1.sem_ver.major, header.h.v1.sem_ver.minor,
 		header.h.v1.sem_ver.revision, header.h.v1.sem_ver.build_num);
-	rsp_send(rsp_buf, strlen(rsp_buf));
 }
 
 static int do_fota_mfw_read(void)
@@ -109,8 +107,7 @@ static int do_fota_mfw_read(void)
 		return err;
 	}
 
-	sprintf(rsp_buf, "\r\n#XFOTA: %d,%d\r\n", area, offset);
-	rsp_send(rsp_buf, strlen(rsp_buf));
+	rsp_send("\r\n#XFOTA: %d,%d\r\n", area, offset);
 
 	return 0;
 }
@@ -242,9 +239,8 @@ static int do_fota_start(int op, const char *file_uri, int sec_tag,
 	}
 	/* Send an URC if failed to start */
 	if (ret) {
-		sprintf(rsp_buf, "\r\n#XFOTA: %d,%d,%d\r\n", FOTA_STAGE_DOWNLOAD,
+		rsp_send("\r\n#XFOTA: %d,%d,%d\r\n", FOTA_STAGE_DOWNLOAD,
 			FOTA_STATUS_ERROR, ret);
-		rsp_send(rsp_buf, strlen(rsp_buf));
 	}
 
 	fota_type = type;
@@ -259,27 +255,27 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 		fota_stage = FOTA_STAGE_DOWNLOAD;
 		fota_status = FOTA_STATUS_OK;
 		fota_info = evt->progress;
-		sprintf(rsp_buf, "\r\n#XFOTA: %d,%d,%d\r\n", fota_stage, fota_status, fota_info);
+		rsp_send("\r\n#XFOTA: %d,%d,%d\r\n", fota_stage, fota_status, fota_info);
 		break;
 	case FOTA_DOWNLOAD_EVT_FINISHED:
 		fota_stage = FOTA_STAGE_ACTIVATE;
 		fota_info = 0;
-		sprintf(rsp_buf, "\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
+		rsp_send("\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
 		/* Save, in case reboot by reset */
 		slm_setting_fota_save();
 		break;
 	case FOTA_DOWNLOAD_EVT_ERASE_PENDING:
 		fota_stage = FOTA_STAGE_DOWNLOAD_ERASE_PENDING;
-		sprintf(rsp_buf, "\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
+		rsp_send("\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
 		break;
 	case FOTA_DOWNLOAD_EVT_ERASE_DONE:
 		fota_stage = FOTA_STAGE_DOWNLOAD_ERASED;
-		sprintf(rsp_buf, "\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
+		rsp_send("\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
 		break;
 	case FOTA_DOWNLOAD_EVT_ERROR:
 		fota_status = FOTA_STATUS_ERROR;
 		fota_info = evt->cause;
-		sprintf(rsp_buf, "\r\n#XFOTA: %d,%d,%d\r\n", fota_stage, fota_status, fota_info);
+		rsp_send("\r\n#XFOTA: %d,%d,%d\r\n", fota_stage, fota_status, fota_info);
 		/* FOTA session terminated */
 		slm_setting_fota_init();
 		break;
@@ -287,7 +283,7 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 	case FOTA_DOWNLOAD_EVT_CANCELLED:
 		fota_status = FOTA_STATUS_CANCELLED;
 		fota_info = 0;
-		sprintf(rsp_buf, "\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
+		rsp_send("\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
 		/* FOTA session terminated */
 		slm_setting_fota_init();
 		break;
@@ -295,7 +291,6 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 	default:
 		return;
 	}
-	rsp_send(rsp_buf, strlen(rsp_buf));
 }
 
 /**@brief handle AT#XFOTA commands
@@ -386,19 +381,16 @@ int handle_at_fota(enum at_cmd_type cmd_type)
 
 	case AT_CMD_TYPE_TEST_COMMAND:
 #if defined(CONFIG_SECURE_BOOT)
-		sprintf(rsp_buf,
-			"\r\n#XFOTA: (%d,%d,%d,%d,%d,%d,%d,%d),<file_uri>,<sec_tag>,<apn>\r\n",
+		rsp_send("\r\n#XFOTA: (%d,%d,%d,%d,%d,%d,%d,%d),<file_uri>,<sec_tag>,<apn>\r\n",
 			SLM_FOTA_STOP, SLM_FOTA_START_APP, SLM_FOTA_START_MFW, SLM_FOTA_START_BL,
 			SLM_FOTA_APP_READ, SLM_FOTA_MFW_READ,
 			SLM_FOTA_ERASE_APP, SLM_FOTA_ERASE_MFW);
 #else
-		sprintf(rsp_buf,
-			"\r\n#XFOTA: (%d,%d,%d,%d,%d,%d,%d),<file_uri>,<sec_tag>,<apn>\r\n",
+		rsp_send("\r\n#XFOTA: (%d,%d,%d,%d,%d,%d,%d),<file_uri>,<sec_tag>,<apn>\r\n",
 			SLM_FOTA_STOP, SLM_FOTA_START_APP, SLM_FOTA_START_MFW,
 			SLM_FOTA_APP_READ, SLM_FOTA_MFW_READ,
 			SLM_FOTA_ERASE_APP, SLM_FOTA_ERASE_MFW);
 #endif
-		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;
 
@@ -431,12 +423,11 @@ void slm_fota_post_process(void)
 	if (fota_stage != FOTA_STAGE_INIT) {
 		/* report final result of last fota */
 		if (fota_status == FOTA_STATUS_OK) {
-			sprintf(rsp_buf, "\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
+			rsp_send("\r\n#XFOTA: %d,%d\r\n", fota_stage, fota_status);
 		} else {
-			sprintf(rsp_buf, "\r\n#XFOTA: %d,%d,%d\r\n", fota_stage, fota_status,
+			rsp_send("\r\n#XFOTA: %d,%d,%d\r\n", fota_stage, fota_status,
 				fota_info);
 		}
-		rsp_send(rsp_buf, strlen(rsp_buf));
 	}
 	/* FOTA session completed */
 	slm_setting_fota_init();

--- a/applications/serial_lte_modem/src/slm_at_host.h
+++ b/applications/serial_lte_modem/src/slm_at_host.h
@@ -51,11 +51,22 @@ void slm_at_host_uninit(void);
 /**
  * @brief Send AT command response
  *
- * @param str Response message
- * @param len Length of response message
+ * @param fmt Response message format string
  *
  */
-void rsp_send(const char *str, size_t len);
+void rsp_send(const char *fmt, ...);
+
+/**
+ * @brief Send AT command response of OK
+ *
+ */
+void rsp_send_ok(void);
+
+/**
+ * @brief Send AT command response of ERROR
+ *
+ */
+void rsp_send_error(void);
 
 /**
  * @brief Send raw data received in data mode

--- a/applications/serial_lte_modem/src/slm_at_icmp.c
+++ b/applications/serial_lte_modem/src/slm_at_icmp.c
@@ -45,7 +45,6 @@ static struct k_work ping_work;
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 static inline void setip(uint8_t *buffer, uint32_t ipaddr)
 {
@@ -413,9 +412,8 @@ wait_for_data:
 	}
 
 	/* Result */
-	sprintf(rsp_buf, "#XPING: %d.%03d seconds\r\n",
+	rsp_send("#XPING: %d.%03d seconds\r\n",
 		(uint32_t)(delta_t)/1000, (uint32_t)(delta_t)%1000);
-	rsp_send(rsp_buf, strlen(rsp_buf));
 
 close_end:
 	(void)close(fd);
@@ -456,9 +454,8 @@ void ping_task(struct k_work *item)
 		int avg_s = avg / 1000;
 		int avg_f = avg % 1000;
 
-		sprintf(rsp_buf, "#XPING: average %d.%03d seconds\r\n",
+		rsp_send("#XPING: average %d.%03d seconds\r\n",
 			avg_s, avg_f);
-		rsp_send(rsp_buf, strlen(rsp_buf));
 
 		LOG_INF("Approximate round trip times in milli-seconds:\n"
 			"    Minimum = %dms, Maximum = %dms, Average = %dms",
@@ -477,8 +474,7 @@ static int ping_test_handler(const char *target)
 	ret = getaddrinfo(target, NULL, NULL, &res);
 	if (ret != 0) {
 		LOG_ERR("getaddrinfo(dest) error: %d", ret);
-		sprintf(rsp_buf, "\"%s\"\r\n", gai_strerror(ret));
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("\"%s\"\r\n", gai_strerror(ret));
 		return -EAGAIN;
 	}
 

--- a/applications/serial_lte_modem/src/slm_at_sms.c
+++ b/applications/serial_lte_modem/src/slm_at_sms.c
@@ -26,7 +26,6 @@ static int sms_handle;
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 static void sms_callback(struct sms_data *const data, void *context)
 {
@@ -34,6 +33,7 @@ static void sms_callback(struct sms_data *const data, void *context)
 	static uint8_t total_msgs;
 	static uint8_t count;
 	static char messages[MAX_CONCATENATED_MESSAGE - 1][SMS_MAX_PAYLOAD_LEN_CHARS + 1];
+	char rsp_buf[MAX_CONCATENATED_MESSAGE * SMS_MAX_PAYLOAD_LEN_CHARS + 64];
 
 	ARG_UNUSED(context);
 
@@ -56,7 +56,7 @@ static void sms_callback(struct sms_data *const data, void *context)
 			strcat(rsp_buf, "\",\"");
 			strcat(rsp_buf, data->payload);
 			strcat(rsp_buf, "\"\r\n");
-			rsp_send(rsp_buf, strlen(rsp_buf));
+			rsp_send("%s", rsp_buf);
 		} else {
 			LOG_DBG("concatenated message %d, %d, %d",
 				header->concatenated.ref_number,
@@ -109,7 +109,7 @@ static void sms_callback(struct sms_data *const data, void *context)
 					strcat(rsp_buf, messages[i]);
 				}
 				strcat(rsp_buf, "\"\r\n");
-				rsp_send(rsp_buf, strlen(rsp_buf));
+				rsp_send("%s", rsp_buf);
 			} else {
 				return;
 			}
@@ -217,9 +217,8 @@ int handle_at_sms(enum at_cmd_type cmd_type)
 		break;
 
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "\r\n#XSMS: (%d,%d,%d),<number>,<message>\r\n",
+		rsp_send("\r\n#XSMS: (%d,%d,%d),<number>,<message>\r\n",
 			AT_SMS_STOP, AT_SMS_START, AT_SMS_SEND);
-		rsp_send(rsp_buf, strlen(rsp_buf));
 		err = 0;
 		break;
 

--- a/applications/serial_lte_modem/src/slm_defines.h
+++ b/applications/serial_lte_modem/src/slm_defines.h
@@ -13,20 +13,19 @@
 #define INVALID_SEC_TAG      -1
 #define INVALID_ROLE         -1
 
-#define SLM_AT_CMD_RESPONSE_MAX_LEN 2100 /** re-define CONFIG_AT_CMD_RESPONSE_MAX_LEN */
+/** The maximum allowed length of an AT command/response passed through the SLM */
+#define SLM_AT_MAX_CMD_LEN   4096
+#define SLM_AT_MAX_RSP_LEN   2100
+
+/** The maximum allowed length of data send/receive through the SLM */
+#define SLM_MAX_PAYLOAD_SIZE 1024 /** max size of payload sent in command mode */
+#define SLM_MAX_MESSAGE_SIZE 2048 /** align with NRF_MODEM_TLS_MAX_MESSAGE_SIZE */
+
 #define SLM_MAX_SOCKET_COUNT 8    /** re-define NRF_MODEM_MAX_SOCKET_COUNT */
 
 #define SLM_MAX_URL          128  /** max size of URL string */
 #define SLM_MAX_USERNAME     32   /** max size of username in login */
 #define SLM_MAX_PASSWORD     32   /** max size of password in login */
-
-#define MODEM_MTU            1280
-#define TCP_MAX_PAYLOAD_IPV4 (MODEM_MTU - NET_IPV4TCPH_LEN)
-#define UDP_MAX_PAYLOAD_IPV4 (MODEM_MTU - NET_IPV4UDPH_LEN)
-#define TCP_MAX_PAYLOAD_IPV6 (MODEM_MTU - NET_IPV6TCPH_LEN)
-#define UDP_MAX_PAYLOAD_IPV6 (MODEM_MTU - NET_IPV6UDPH_LEN)
-#define SLM_MAX_PAYLOAD      (MODEM_MTU - NET_IPV4UDPH_LEN)
-#define SLM_MAX_PAYLOAD6     (MODEM_MTU - NET_IPV6UDPH_LEN)
 
 #define SLM_NRF52_BLK_SIZE   4096 /** nRF52 flash block size for write operation */
 #define SLM_NRF52_BLK_TIME   2000 /** nRF52 flash block write time in millisecond (1.x second) */

--- a/applications/serial_lte_modem/src/twi/slm_at_twi.c
+++ b/applications/serial_lte_modem/src/twi/slm_at_twi.c
@@ -28,10 +28,10 @@ static const struct device *slm_twi_dev[] = {
 	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(i2c3)),
 };
 static uint8_t twi_data[TWI_DATA_LEN * 2 + 1];
+static char rsp_buf[256];
 
 /* global variable defined in different files */
 extern struct at_param_list at_param_list;
-extern char rsp_buf[SLM_AT_CMD_RESPONSE_MAX_LEN];
 
 static void do_twi_list(void)
 {
@@ -45,7 +45,7 @@ static void do_twi_list(void)
 	}
 	if (strlen(rsp_buf) > 0) {
 		strcat(rsp_buf, "\r\n");
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("%s", rsp_buf);
 	}
 }
 
@@ -98,10 +98,9 @@ static int do_twi_read(uint16_t index, uint16_t dev_addr, uint8_t num_read)
 	memset(rsp_buf, 0, sizeof(rsp_buf));
 	ret = slm_util_htoa(twi_data, num_read, rsp_buf, num_read * 2);
 	if (ret > 0) {
-		sprintf(rsp_buf + ret, "\r\n#XTWIR: ");
-		rsp_send(rsp_buf + ret, strlen(rsp_buf + ret));
-		rsp_send(rsp_buf, ret);
-		rsp_send("\r\n", 2);
+		rsp_send("\r\n#XTWIR: ");
+		data_send(rsp_buf, ret);
+		rsp_send("\r\n");
 		ret = 0;
 	} else {
 		LOG_ERR("hex convert error: %d", ret);
@@ -138,10 +137,9 @@ static int do_twi_write_read(uint16_t index, uint16_t dev_addr, const uint8_t *t
 	memset(rsp_buf, 0, sizeof(rsp_buf));
 	ret = slm_util_htoa(twi_data, num_read, rsp_buf, num_read * 2);
 	if (ret > 0) {
-		sprintf(rsp_buf + ret, "\r\n#XTWIWR: ");
-		rsp_send(rsp_buf + ret, strlen(rsp_buf + ret));
-		rsp_send(rsp_buf, ret);
-		rsp_send("\r\n", 2);
+		rsp_send("\r\n#XTWIWR: ");
+		data_send(rsp_buf, ret);
+		rsp_send("\r\n");
 		ret = 0;
 	} else {
 		LOG_ERR("hex convert error: %d", ret);
@@ -213,8 +211,7 @@ int handle_at_twi_write(enum at_cmd_type cmd_type)
 		err = do_twi_write(index, dev_addr, twi_data, (uint16_t)ascii_len);
 		break;
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "#XTWIW: <index>,<dev_addr>,<data>\r\n");
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("#XTWIW: <index>,<dev_addr>,<data>\r\n");
 		err = 0;
 		break;
 	default:
@@ -266,8 +263,7 @@ int handle_at_twi_read(enum at_cmd_type cmd_type)
 		}
 		break;
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "#XTWIR: <index>,<dev_addr>,<num_read>\r\n");
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("#XTWIR: <index>,<dev_addr>,<num_read>\r\n");
 		err = 0;
 		break;
 	default:
@@ -325,8 +321,7 @@ int handle_at_twi_write_read(enum at_cmd_type cmd_type)
 		}
 		break;
 	case AT_CMD_TYPE_TEST_COMMAND:
-		sprintf(rsp_buf, "#XTWIWR: <index>,<dev_addr>,<data>,<num_read>\r\n");
-		rsp_send(rsp_buf, strlen(rsp_buf));
+		rsp_send("#XTWIWR: <index>,<dev_addr>,<data>,<num_read>\r\n");
 		err = 0;
 		break;
 	default:


### PR DESCRIPTION
The global buf_rsp[] is not protected from multiple access, could result in data overwrite issue during async UART transmit.

Proposed fix:
.make buf_rsp[] static in slm_at_host.c file and add semaphore to protect from multiple access.
.add new data_buf[] to be shared by TCP/UDP/HTTP/MQTT/FTP as the buffer for received data, instead of using buf_rsp[].

API rsp_send() is to send AT response or URC using buf_rsp[]. 
API data_send() is to send raw data from other buffers.

Other optimizations made to slm_at_host:
.reset UART RX when entering data mode for stability
.remove legacy datamode_quit_work to speed up data mode exiting
.use standalone memory for data mode, same size of 4K
.re-use the data mode ringbuffer for delayed UART sending
.send indication only for unsolicited and downlink data

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>