### PR TITLE
manifest: sdk-zephyr: Pull zero payload fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 1767131c6d062019d2f30580aeff28f45bf99458
+      revision: c4b528788ce7927f0f8a7da487a8f5c8bbe5643e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This fixes NRF7X-16 (keep alive with zero payload is dropped).

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>