### PR TITLE
manifest: Update memfault-firmware-sdk to 0.37.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -165,7 +165,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 0.35.0
+      revision: 0.37.2
       remote: memfault
     - name: cirrus
       repo-path: sdk-mcu-drivers


### PR DESCRIPTION
This version of the Memfault Firmware SDK includes a fix to build with CONFIG_POSIX_API=y. This is required to compile the modem_shell sample with Memfault support.

See release notes for details: https://github.com/memfault/memfault-firmware-sdk/blob/0.37.2/CHANGES.md