### PR TITLE
manifest: pull Matter Wi-Fi connection recovery mechanism

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -79,6 +79,7 @@ Matter
   * The Bluetooth LE advertising arbiter class that enables easier coexistence of application components that want to advertise their Bluetooth LE services.
   * Support for erasing settings partition during DFU over Bluetooth LE SMP for the Nordic nRF52 Series' SoCs.
   * Enabled Wi-Fi and Bluetooth LE coexistence.
+  * Mechanism to retry a failed Wi-Fi connection.
 
 * Updated:
 

--- a/west.yml
+++ b/west.yml
@@ -123,7 +123,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: 6105af8af0c381de167882a19adec7772d3b998b
+      revision: bf493678c95ede66a234b3952dd8e184875d716e
       submodules:
         - name: nlio
           path: third_party/nlio/repo


### PR DESCRIPTION
This change adds an implementation of Wi-Fi connection recovery which retries to scan networks in case the requested SSID is not present at the moment.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>