### PR TITLE
applications: nrf5340_audio: Fix bidirectional CIS gateway

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_system.c
+++ b/applications/nrf5340_audio/src/audio/audio_system.c
@@ -62,7 +62,8 @@ static void audio_gateway_configure(void)
 		ERR_CHK_MSG(-EINVAL, "No codec selected");
 	}
 
-	if (IS_ENABLED(CONFIG_MONO_TO_ALL_RECEIVERS)) {
+	if (IS_ENABLED(CONFIG_MONO_TO_ALL_RECEIVERS) ||
+	    IS_ENABLED(CONFIG_STREAM_BIDIRECTIONAL)) {
 		sw_codec_cfg.encoder.num_ch = SW_CODEC_MONO;
 	} else {
 		sw_codec_cfg.encoder.num_ch = SW_CODEC_STEREO;


### PR DESCRIPTION
Fix CIS gateway when built for bidirectional feature support.

Regression in commit 4e8478ae15cf ("applications:
nrf5340_audio: Create same data flag").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>