### PR TITLE
net: lwm2m_client_utils: LwM2M firmware utils update

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_adv_firmware.c
@@ -466,6 +466,11 @@ static struct lwm2m_engine_obj_inst *firmware_create(uint16_t obj_inst_id)
 {
 	int i = 0, j = 0;
 
+	/* Secure outside called lwm2m_create_obj_inst() create is still possible */
+	if (obj_inst_id >= MAX_INSTANCE_COUNT) {
+		return NULL;
+	}
+
 	init_res_instance(res_inst[obj_inst_id], ARRAY_SIZE(res_inst[obj_inst_id]));
 
 	/* initialize instance resource data */

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -218,7 +218,7 @@ static int write_image_type_to_settings(int inst, int img_type)
 
 static void target_image_type_store(uint16_t instance, int img_type)
 {
-	if (instance == UNUSED_OBJ_ID) {
+	if (instance >= FOTA_INSTANCE_COUNT) {
 		LOG_WRN("Image type storage failure");
 		return;
 	}
@@ -252,7 +252,7 @@ static void reboot_work_handler(void)
 /************** Wrappers between normal FOTA object and Advanced FOTA object ********/
 static uint8_t get_state(uint16_t id)
 {
-	if (id == UNUSED_OBJ_ID || id >= FOTA_INSTANCE_COUNT) {
+	if (id >= FOTA_INSTANCE_COUNT) {
 		LOG_WRN("Get state blocked by id, state");
 		return 0;
 	}
@@ -268,7 +268,7 @@ static uint8_t get_state(uint16_t id)
 
 static void set_state(uint16_t id, uint8_t state)
 {
-	if (id == UNUSED_OBJ_ID) {
+	if (id >= FOTA_INSTANCE_COUNT) {
 		LOG_WRN("Set state blocked by id, state %d", state);
 		return;
 	}
@@ -284,7 +284,7 @@ static void set_state(uint16_t id, uint8_t state)
 
 static void set_result(uint16_t id, uint8_t result)
 {
-	if (id == UNUSED_OBJ_ID) {
+	if (id >= FOTA_INSTANCE_COUNT) {
 		LOG_WRN("Set result blocked by id,  result %d", result);
 		return;
 	}


### PR DESCRIPTION
Fixed possible "Out of bound memory access" fota target dfu
type store.

Added check for advanced fota object create that generic create
can't write allocated buffers.

https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&types=BUG&pullRequest=63&id=balaji-nordic_sdk-nrf&open=AYYXFihjlWDr5KsWueqU