### PR TITLE
applications: nrf5340_audio: minor bugfixes

### DIFF
--- a/applications/nrf5340_audio/src/audio/Kconfig
+++ b/applications/nrf5340_audio/src/audio/Kconfig
@@ -232,6 +232,8 @@ config WALKIE_TALKIE_DEMO
 
 config MONO_TO_ALL_RECEIVERS
 	bool "Send mono (first/left channel) to all receivers"
+	default y if BT_AUDIO_UNICAST_CLIENT_ASE_SNK_COUNT = 1
+	default y if BT_AUDIO_BROADCAST_SRC_STREAM_COUNT = 1
 	default n
 	help
 	  With this flag set, the gateway will encode and send the same (first/left)

--- a/applications/nrf5340_audio/src/audio/audio_system.c
+++ b/applications/nrf5340_audio/src/audio/audio_system.c
@@ -163,7 +163,7 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 
 		if (sw_codec_cfg.encoder.enabled) {
 			streamctrl_encoded_data_send(encoded_data, encoded_data_size,
-				sw_codec_cfg.encoder.num_ch);
+						     sw_codec_cfg.encoder.num_ch);
 		}
 		STACK_USAGE_PRINT("encoder_thread", &encoder_thread_data);
 	}

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_headset.c
@@ -334,11 +334,6 @@ static void syncable_cb(struct bt_audio_broadcast_sink *sink, bool encrypted)
 		return;
 	}
 
-	if (encrypted) {
-		LOG_ERR("Cannot sync to encrypted broadcast source");
-		return;
-	}
-
 	LOG_INF("Syncing to broadcast stream index %d", active_stream_index);
 
 	ret = bt_audio_broadcast_sink_sync(broadcast_sink, bis_index_bitfields[active_stream_index],


### PR DESCRIPTION
- Allow encrypted BISes in headset
- Automatically set MONO_TO_ALL_RECEIVERS if only 1 receiver
- OCT-2440

Signed-off-by: Alexander Svensen <alexander.svensen@nordicsemi.no>