### PR TITLE
ci: add script for printing docker image name

### DIFF
--- a/scripts/print_docker_image.sh
+++ b/scripts/print_docker_image.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+BASEDIR=$(dirname "$0")
+TOOLCHAIN_VERSION=$($BASEDIR/print_toolchain_checksum.sh)
+DOCKER_VERSION=$(cat $BASEDIR/ncs-docker-version.txt)
+
+echo "docker-dtr.nordicsemi.no/sw-production/ncs-build:${TOOLCHAIN_VERSION}_${DOCKER_VERSION}"

--- a/scripts/print_toolchain_checksum.sh
+++ b/scripts/print_toolchain_checksum.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BASEDIR=$(dirname "$0")
+REQUIREMENTS=$BASEDIR/requirements-fixed.txt
+TOOLS_VERSIONS=$BASEDIR/tools-versions-linux.txt
+TOOLCHAIN_VERSION=$(cat $REQUIREMENTS $TOOLS_VERSIONS | sha256sum | head -c 10)
+
+echo "${TOOLCHAIN_VERSION}"


### PR DESCRIPTION
Adding helper script for printing docker image name used in CI. 

Signed-off-by: Kari Hamalainen <kari.hamalainen@nordicsemi.no>