### PR TITLE
bluetooth: align memory passed to sdc_enable

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -142,9 +142,9 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_PERIPHERAL) ||
 		      (SDC_EXTRA_MEMORY))
 
 #if CONFIG_BT_SDC_ADDITIONAL_MEMORY
-uint8_t sdc_mempool[MEMPOOL_SIZE];
+__aligned(8) uint8_t sdc_mempool[MEMPOOL_SIZE];
 #else
-static uint8_t sdc_mempool[MEMPOOL_SIZE];
+static __aligned(8) uint8_t sdc_mempool[MEMPOOL_SIZE];
 #endif
 
 #if IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER)


### PR DESCRIPTION
otherwise sdc_enable may use not the same amount of memory as returned by sdc_cfg_set

Signed-off-by: Sergey Korotkov <sergey.korotkov@nordicsemi.no>