### PR TITLE
doc: KI and LTE Gateway sample update for west build

### DIFF
--- a/doc/nrf/known_issues.rst
+++ b/doc/nrf/known_issues.rst
@@ -357,7 +357,7 @@ LTE Sensor Gateway fails to run
   .. parsed-literal::
     :class: highlight
 
-    west build --board nrf9160dk_nrf52840_ns@1.1.0
+    west build --board nrf9160dk_nrf52840@1.1.0
 
   The :ref:`lte_sensor_gateway` sample:
 

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -104,7 +104,7 @@ Program the board controller as follows:
       .. parsed-literal::
          :class: highlight
 
-         west build --board nrf9160dk_nrf52840_ns@1.1.0
+         west build --board nrf9160dk_nrf52840@1.1.0
 
 #. Verify that the programming was successful.
    Use a terminal emulator, like PuTTY, to connect to the second serial port and check the output.


### PR DESCRIPTION
There is no secure/non-secure on the nRF52840,
So, the board target for the Bluetooth: HCI low power UART sample is updated for following documents:

Known Issues
LTE gateway Sample

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>