### PR TITLE
manifest: sdk-zephyr: Pull Gpio diag and Kconfig OpenThread changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -52,7 +52,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 06319fe47a8e4ca759580e88a059e5e3a691955d
+      revision: 032f3de154e64709a442a6756575e8c879a06a2d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This PR adds gpio diag commands implementation for OpenThread modules and necessary helpers.

It also includes cleanup of Kconfig and CMakeLists.

Signed-off-by: Maciej Baczmanski <maciej.baczmanski@nordicsemi.no>