### PR TITLE
manifest: sdk-hostap: Pull fix for POSIX

### DIFF
--- a/samples/wifi/shell/sample.yaml
+++ b/samples/wifi/shell/sample.yaml
@@ -59,3 +59,10 @@ tests:
       - nrf7002dk_nrf5340_cpuapp
     platform_allow: nrf7002dk_nrf5340_cpuapp
     tags: ci_build
+  sample.nrf7002.shell.posix_names:
+    build_only: true
+    extra_args: CONFIG_POSIX_API=n CONIFG_NET_SOCKETS_POSIX_NAMES=y
+    integration_platforms:
+      - nrf7002dk_nrf5340_cpuapp
+    platform_allow: nrf7002dk_nrf5340_cpuapp
+    tags: ci_build

--- a/west.yml
+++ b/west.yml
@@ -103,7 +103,7 @@ manifest:
     # changes.
     - name: sdk-hostap
       path: modules/lib/hostap
-      revision: 207e0508be39a4896ec584037888b747b9ace558
+      revision: ccda6879cfd92a8081dd0ca6876865f492837a27
     - name: mcuboot
       repo-path: sdk-mcuboot
       revision: 4f775a87611a084a2f6ad9a8a5034e080ddcc579


### PR DESCRIPTION
This fixes applications that don't use POSIX_API but only POSIX_NAMES.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>