### PR TITLE
Generic API for monitoring LwM2M FOTA libray

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -137,6 +137,7 @@ nRF9160: Asset Tracker v2
 * Updated:
 
   * Use defines from the :ref:`lib_nrf_cloud` library for nRF Cloud related string values.
+  * The application now integrates the :ref:`lib_lwm2m_client_utils` FOTA callback functionality.
 
 nRF9160: Serial LTE modem
 -------------------------
@@ -191,6 +192,12 @@ nRF9160 samples
   * Added:
 
     * Support for the nRF7002 DK PCA10143.
+
+* :ref:`lwm2m_client` sample:
+
+  * Updated:
+
+    * The sample now integrates the :ref:`lib_lwm2m_client_utils` FOTA callback functionality.
 
 Peripheral samples
 ------------------
@@ -285,6 +292,16 @@ Libraries for networking
   * Added:
 
     * A public header file :file:`nrf_cloud_defs.h` that contains common defines for interacting with nRF Cloud and the :ref:`lib_nrf_cloud` library.
+
+* :ref:`lib_lwm2m_client_utils` library:
+
+  * Updated:
+
+    * :file:`lwm2m_client_utils.h` includes new API for FOTA to register application callback to receive state changes and requests for the update process.
+
+  * Removed:
+
+    * The old API ``lwm2m_firmware_get_update_state_cb()``.
 
 Libraries for NFC
 -----------------


### PR DESCRIPTION
### lwm2m_client_utils
- Updated Fota API for give function callback for indicate state changes and request permission for start Update process.
- Removed old API lwm2m_firmware_get_update_state_cb().
- Updated Unit test's.

### asset_tracker_v2
- Integrated new LwM2M FOTA callback functionality and remove old state resource callback usage. Now app can handle all event's by 1 generic callback.
- Updated Unit test's

### lwm2m_client sample

- Integrated new LwM2M FOTA callback functionality.
- Added new state for firmware update prepare process and verify FOTA callback update process poll functionality.
