### PR TITLE
doc: fast_pair: Document factory reset

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -486,6 +486,10 @@ Bluetooth libraries and services
 
   * Changed the :kconfig:option:`CONFIG_BT_ADV_PROV_FAST_PAIR_BATTERY_DATA_MODE` Kconfig option (default value) to not include Fast Pair battery data in the Fast Pair advertising payload by default.
 
+* :ref:`bt_fast_pair_readme` service:
+
+  * Added the :c:func:`bt_fast_pair_factory_reset` function to clear the Fast Pair storage.
+
 Bootloader libraries
 --------------------
 

--- a/doc/nrf/ug_bt_fast_pair.rst
+++ b/doc/nrf/ug_bt_fast_pair.rst
@@ -155,3 +155,7 @@ No application interaction is required.
 The Fast Pair GATT service modifies default values of related Kconfig options to follow Fast Pair requirements.
 The service also enables the needed functionalities using Kconfig select statement.
 For details, see the :ref:`bt_fast_pair_readme` Bluetooth service documentation in the |NCS|.
+
+The Fast Pair GATT service uses a non-volatile memory to store the Fast Pair user data such as Account Keys and the Personalized Name.
+This data can be cleared by calling the :c:func:`bt_fast_pair_factory_reset` function.
+For details, see the :c:func:`bt_fast_pair_factory_reset` function documentation.


### PR DESCRIPTION
Adds documentation related to the Fast Pair factory reset feature.

Jira: NCSDK-19046