### PR TITLE
CODEOWNERS: Replace trond-snekvik with ludvigsj in Bluetooth tester

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -226,7 +226,7 @@ Kconfig*                                  @tejlmand
 /modules/tfm/                             @SebastianBoe @joerchan
 /subsys/zigbee/                           @tomchy @sebastiandraus
 /tests/                                   @gopiotr
-/tests/bluetooth/tester/                  @carlescufi @trond-snekvik
+/tests/bluetooth/tester/                  @carlescufi @ludvigsj
 /tests/crypto/                            @torsteingrindvik @magnev
 /tests/drivers/flash_patch/               @oyvindronningstad
 /tests/drivers/fprotect/                  @oyvindronningstad


### PR DESCRIPTION
Replaces trond-snekvik with ludvigsj as code owner in the Bluetooth tester, as this assignment is part of the Bluetooth Mesh codeownership, which has been transferred to Ludvig.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>