### PR TITLE
Revert "workflows: compliance: Disable BinaryFiles check"

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -76,7 +76,7 @@ jobs:
         git log --pretty=oneline | head -n 10
         # For now we run KconfigBasic, but we should transition to Kconfig
         $ZEPHYR_BASE/scripts/ci/check_compliance.py --annotate -e Kconfig \
-        -e BinaryFiles -c origin/${BASE_REF}..
+        -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
This reverts commit d1fda3388b1eede80e2206d7db04a9d92620005f.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>