### PR TITLE
net: lib: nrf_cloud: Include alerts source only when enabled

### DIFF
--- a/include/net/nrf_cloud_alerts.h
+++ b/include/net/nrf_cloud_alerts.h
@@ -78,7 +78,15 @@ struct nrf_cloud_alert_info {
  *
  * @return 0 if alert is successfully sent, otherwise, a negative error number.
  */
+#if defined(CONFIG_NRF_CLOUD_ALERTS) || defined(__DOXYGEN__)
 int nrf_cloud_alert_send(enum nrf_cloud_alert_type type, float value, const char *description);
+#else
+static inline int nrf_cloud_alert_send(enum nrf_cloud_alert_type type, float value,
+				       const char *description)
+{
+	return 0;
+}
+#endif /* CONFIG_NRF_CLOUD_ALERTS */
 
 /**
  * @brief Transmit the specified alert to nRF Cloud using REST.
@@ -93,11 +101,22 @@ int nrf_cloud_alert_send(enum nrf_cloud_alert_type type, float value, const char
  *
  * @return 0 if alert is successfully sent, otherwise, a negative error number.
  */
+#if defined(CONFIG_NRF_CLOUD_ALERTS) || defined(__DOXYGEN__)
 int nrf_cloud_rest_alert_send(struct nrf_cloud_rest_context *const rest_ctx,
 			      const char *const device_id,
 			      enum nrf_cloud_alert_type type,
 			      float value,
 			      const char *description);
+#else
+static inline int nrf_cloud_rest_alert_send(struct nrf_cloud_rest_context *const rest_ctx,
+					    const char *const device_id,
+					    enum nrf_cloud_alert_type type,
+					    float value,
+					    const char *description)
+{
+	return 0;
+}
+#endif /* CONFIG_NRF_CLOUD_ALERTS */
 
 /**
  * @brief Enable or disable use of alerts.

--- a/subsys/net/lib/nrf_cloud/CMakeLists.txt
+++ b/subsys/net/lib/nrf_cloud/CMakeLists.txt
@@ -8,7 +8,9 @@ zephyr_library_sources(
 	src/nrf_cloud_codec.c
 	src/nrf_cloud_mem.c
 	src/nrf_cloud_client_id.c
-	src/nrf_cloud_fota_common.c
+	src/nrf_cloud_fota_common.c)
+zephyr_library_sources_ifdef(
+	CONFIG_NRF_CLOUD_ALERTS
 	src/nrf_cloud_alerts.c)
 zephyr_library_sources_ifdef(
 	CONFIG_MODEM_JWT

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -258,7 +258,11 @@ static int handle_device_control_update(const struct nct_evt *const evt,
 		return -ENOENT;
 	}
 
+#if IS_ENABLED(CONFIG_NRF_CLOUD_ALERTS)
 	ctrl_data.alerts_enabled = nrf_cloud_alert_control_get();
+#else
+	ctrl_data.alerts_enabled = false;
+#endif /* CONFIG_NRF_CLOUD_ALERTS */
 	ctrl_data.log_level = nrf_cloud_log_control_get();
 
 	err = nrf_cloud_decode_control(&evt->param.cc->data, &status, &ctrl_data);
@@ -268,7 +272,9 @@ static int handle_device_control_update(const struct nct_evt *const evt,
 
 	*control_found = (status != NRF_CLOUD_CTRL_NOT_PRESENT);
 	if (*control_found) {
+#if IS_ENABLED(CONFIG_NRF_CLOUD_ALERTS)
 		nrf_cloud_alert_control_set(ctrl_data.alerts_enabled);
+#endif /* CONFIG_NRF_CLOUD_ALERTS */
 		nrf_cloud_log_control_set(ctrl_data.log_level);
 	}
 


### PR DESCRIPTION
Include the nrf_cloud_alerts.c source file in the build only when alerts are enabled.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>

Fixes failing CI