### PR TITLE
lib: flash_patch: Init DISABLE_FLASH_PATCH before HW_UNIQUE_KEY_LOAD

### DIFF
--- a/lib/flash_patch/flash_patch.c
+++ b/lib/flash_patch/flash_patch.c
@@ -38,5 +38,5 @@ static int disable_flash_patch(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(disable_flash_patch, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
+SYS_INIT(disable_flash_patch, PRE_KERNEL_1, 0);
 #endif


### PR DESCRIPTION
Enable CONFIG_DISABLE_FLASH_PATCH to work with CONFIG_HW_UNIQUE_KEY_LOAD

Init DISABLE_FLASH_PATCH before HW_UNIQUE_KEY_LOAD so the processor can reboot before the HUK flag check.

Ref: NCSIDB-732
Ref: https://github.com/LairdCP/sdk-nrf/commit/9a9d1a5c4f5483a7c55b259df69346b702987238

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>