### PR TITLE
drivers: wifi: Config option to limit scan results

### DIFF
--- a/drivers/wifi/nrf700x/Kconfig.nrf700x
+++ b/drivers/wifi/nrf700x/Kconfig.nrf700x
@@ -102,4 +102,8 @@ config RX_MAX_DATA_SIZE
 	int "Maximum size of RX data"
 	default 1600
 
+config NRF700X_SCAN_LIMIT
+	int "Maximum number of scan results returned to application. Use negative values for unlimited scan results."
+	default -1
+
 endif

--- a/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
+++ b/drivers/wifi/nrf700x/zephyr/inc/zephyr_fmac_main.h
@@ -40,6 +40,7 @@ struct wifi_nrf_vif_ctx_zep {
 	scan_result_cb_t disp_scan_cb;
 	bool scan_in_progress;
 	int scan_type;
+	unsigned int scan_res_cnt;
 
 	struct net_eth_addr mac_addr;
 

--- a/drivers/wifi/nrf700x/zephyr/src/zephyr_disp_scan.c
+++ b/drivers/wifi/nrf700x/zephyr/src/zephyr_disp_scan.c
@@ -74,6 +74,7 @@ int wifi_nrf_disp_scan_zep(const struct device *dev,
 
 	vif_ctx_zep->scan_type = SCAN_DISPLAY;
 	vif_ctx_zep->scan_in_progress = true;
+	vif_ctx_zep->scan_res_cnt = 0;
 
 	ret = 0;
 out:
@@ -130,9 +131,15 @@ void wifi_nrf_event_proc_disp_scan_res_zep(void *vif_ctx,
 
 	vif_ctx_zep = vif_ctx;
 
-	cb = (scan_result_cb_t) vif_ctx_zep->disp_scan_cb;
+	cb = (scan_result_cb_t)vif_ctx_zep->disp_scan_cb;
 
 	for (i = 0; i < scan_res->event_bss_count; i++) {
+		/* Limit the scan results to the configured maximum */
+		if ((CONFIG_NRF700X_SCAN_LIMIT >= 0) &&
+		    (vif_ctx_zep->scan_res_cnt >= CONFIG_NRF700X_SCAN_LIMIT)) {
+			break;
+		}
+
 		memset(&res, 0x0, sizeof(res));
 
 		r = &scan_res->display_results[i];
@@ -163,6 +170,8 @@ void wifi_nrf_event_proc_disp_scan_res_zep(void *vif_ctx,
 		vif_ctx_zep->disp_scan_cb(vif_ctx_zep->zep_net_if_ctx,
 					  0,
 					  &res);
+
+		vif_ctx_zep->scan_res_cnt++;
 
 		/* NET_MGMT dropping events if too many are queued */
 		k_yield();


### PR DESCRIPTION
Add a Kconfig option to limit scan results to specified value. This partially addresses the following Jira issues:

[SHEL-872]

Signed-off-by: Sachin D Kulkarni <sachin.kulkarni@nordicsemi.no>