### PR TITLE
Bluetooth: Controller: Add support for PAwR advertiser

### DIFF
--- a/samples/bluetooth/direct_test_mode/src/fem/fem.c
+++ b/samples/bluetooth/direct_test_mode/src/fem/fem.c
@@ -262,7 +262,7 @@ int8_t fem_tx_output_power_prepare(int8_t power, int8_t *radio_tx_power, uint16_
 	int32_t err;
 	mpsl_tx_power_split_t power_split = { 0 };
 
-	output_power = mpsl_fem_tx_power_split(power, &power_split, freq_mhz);
+	output_power = mpsl_fem_tx_power_split(power, &power_split, freq_mhz, false);
 
 	*radio_tx_power = power_split.radio_tx_power;
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -202,6 +202,7 @@ choice BT_LL_SOFTDEVICE_VARIANT
 						     MPSL_CX_BT_3WIRE || \
 						     BT_CTLR_SYNC_PERIODIC || \
 						     BT_CTLR_SCA_UPDATE || \
+						     BT_CTLR_SDC_PAWR_ADV || \
 						     SOC_NRF5340_CPUNET)
 	default BT_LL_SOFTDEVICE_CENTRAL if BT_OBSERVER
 	default BT_LL_SOFTDEVICE_PERIPHERAL if BT_BROADCASTER
@@ -310,5 +311,52 @@ config BT_UNINIT_MPSL_ON_DISABLE
 	  mpsl_lib_uninit, which releases all peripherals and allows the user to
 	  override any interrupt handlers used by MPSL.
 
+config BT_CTLR_SDC_PAWR_ADV
+	bool "LE Periodic Advertising with Responses Advertising State [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	depends on BT_PER_ADV
+	depends on BT_CTLR_SYNC_TRANSFER_SENDER
+	help
+	  Enable support for Periodic Advertising with Respsonses - Advertiser.
+
+if BT_CTLR_SDC_PAWR_ADV
+config BT_CTLR_SDC_PAWR_ADV_COUNT
+	int "Periodic Advertising with Responses - Advertiser sets"
+	range 0 10
+	default 1
+	help
+	  Maximum number of concurrent Periodic Advertising with Responses
+	  advertisers supported.
+
+config BT_CTLR_SDC_PERIODIC_ADV_RSP_TX_BUFFER_COUNT
+	int "Number of PAwR advertiser TX buffers"
+	range 1 128
+	default 1
+	help
+	  Maximum number of subevent indications that can be buffered at a time.
+	  When using a larger value the controller will send data requests for more
+	  subevents at a time.
+
+config BT_CTLR_SDC_PERIODIC_ADV_RSP_TX_MAX_DATA_SIZE
+	int "Maximum size of PawR advertiser TX buffers"
+	range 1 249
+	default 73
+	help
+	  Maximum size of subevent indications. Decreasing this will reduce memory
+	  usage and increase scheduling performance. The controller will disallow
+	  sending a subevent indication with a larger payload.
+
+config BT_CTLR_SDC_PERIODIC_ADV_RSP_RX_BUFFER_COUNT
+	int "Number of PAwR advertiser RX buffers"
+	range 0 255
+	default 2
+	help
+	  Maximum number of periodic advertising response reports that can be
+	  buffered at a time. This should be increased when a short response slot
+	  spacing is used so that the controller is able to buffer all responses
+	  until the host is able to pull the periodic advertising response reports.
+
+	  A value of 0 will disable reception of subevent responses.
+endif
 endmenu
 endif  # BT_LL_SOFTDEVICE

--- a/subsys/bluetooth/controller/hci_internal.c
+++ b/subsys/bluetooth/controller/hci_internal.c
@@ -42,6 +42,7 @@ static bool command_generates_command_complete_event(uint16_t hci_opcode)
 	case SDC_HCI_OPCODE_CMD_LE_READ_REMOTE_FEATURES:
 	case SDC_HCI_OPCODE_CMD_LE_ENABLE_ENCRYPTION:
 	case SDC_HCI_OPCODE_CMD_LE_EXT_CREATE_CONN:
+	case SDC_HCI_OPCODE_CMD_LE_EXT_CREATE_CONN_V2:
 	case SDC_HCI_OPCODE_CMD_LE_PERIODIC_ADV_CREATE_SYNC:
 	case SDC_HCI_OPCODE_CMD_LE_REQUEST_PEER_SCA:
 	case SDC_HCI_OPCODE_CMD_LE_READ_REMOTE_TRANSMIT_POWER_LEVEL:
@@ -331,6 +332,11 @@ static void supported_commands(sdc_hci_ip_supported_commands_t *cmds)
 	cmds->hci_le_set_periodic_advertising_data = 1;
 	cmds->hci_le_set_periodic_advertising_enable = 1;
 #endif /* CONFIG_BT_PER_ADV*/
+#if defined(CONFIG_BT_CTLR_SDC_PAWR_ADV)
+	cmds->hci_le_set_periodic_advertising_subevent_data = 1;
+	cmds->hci_le_extended_create_connection_v2 = 1;
+	cmds->hci_le_set_periodic_advertising_parameters_v2 = 1;
+#endif /* CONFIG_BT_CTLR_SDC_PAWR_ADV */
 #endif /* CONFIG_BT_BROADCASTER */
 
 #if defined(CONFIG_BT_OBSERVER)
@@ -515,6 +521,10 @@ static void le_supported_features(sdc_hci_cmd_le_read_local_supported_features_r
 
 #if defined(CONFIG_BT_CTLR_SCA_UPDATE)
 	features->params.sleep_clock_accuracy_updates = 1;
+#endif
+
+#if defined(CONFIG_BT_CTLR_SDC_PAWR_ADV)
+	features->params.periodic_advertising_with_responses_advertiser = 1;
 #endif
 }
 
@@ -1074,6 +1084,19 @@ static uint8_t le_controller_cmd_put(uint8_t const * const cmd,
 #if defined(CONFIG_BT_CTLR_SCA_UPDATE)
 	case SDC_HCI_OPCODE_CMD_LE_REQUEST_PEER_SCA:
 		return sdc_hci_cmd_le_request_peer_sca((void *)cmd_params);
+#endif
+
+#if defined(CONFIG_BT_CTLR_SDC_PAWR_ADV)
+	case SDC_HCI_OPCODE_CMD_LE_EXT_CREATE_CONN_V2:
+		return sdc_hci_cmd_le_ext_create_conn_v2((void *)cmd_params);
+	case SDC_HCI_OPCODE_CMD_LE_SET_PERIODIC_ADV_PARAMS_V2:
+		*param_length_out += sizeof(sdc_hci_cmd_le_set_periodic_adv_params_v2_return_t);
+		return sdc_hci_cmd_le_set_periodic_adv_params_v2((void *)cmd_params,
+								 (void *)event_out_params);
+	case SDC_HCI_OPCODE_CMD_LE_SET_PERIODIC_ADV_SUBEVENT_DATA:
+		*param_length_out += sizeof(sdc_hci_cmd_le_set_periodic_adv_subevent_data_return_t);
+		return sdc_hci_cmd_le_set_periodic_adv_subevent_data((void *)cmd_params,
+								     (void *)event_out_params);
 #endif
 
 	default:

--- a/subsys/esb/esb.c
+++ b/subsys/esb/esb.c
@@ -559,7 +559,7 @@ static void update_radio_tx_power(void)
 	mpsl_tx_power_split_t tx_power;
 
 	(void)mpsl_fem_tx_power_split(esb_cfg.tx_output_power, &tx_power,
-				      (RADIO_BASE_FREQUENCY + esb_addr.rf_channel));
+				      (RADIO_BASE_FREQUENCY + esb_addr.rf_channel), false);
 
 	err = mpsl_fem_pa_gain_set(&tx_power.fem);
 	if (err) {

--- a/west.yml
+++ b/west.yml
@@ -114,7 +114,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 1b804d7371ed7a04dc0f67dc0e0117ca3d5c1e98
+      revision: fe3f47a2dd4ff806304a74ae91fd721348dc787d
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Includes changes needed to support Periodic Advertising with Responses - Advertiser in addition to other fixes and improvements to the softdevice controller.