### PR TITLE
doc: Add __DOXYGEN__ to predefinition list

### DIFF
--- a/doc/nrf/nrf.doxyfile.in
+++ b/doc/nrf/nrf.doxyfile.in
@@ -1949,7 +1949,8 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
+PREDEFINED             =  __DOXYGEN__ \
+                         "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_THREAD_MONITOR=y" \
                          "CONFIG_THREAD_CUSTOM_DATA=y" \
                          "CONFIG_ERRNO=y" \

--- a/include/modem/nrf_modem_lib_trace.h
+++ b/include/modem/nrf_modem_lib_trace.h
@@ -55,7 +55,7 @@ int nrf_modem_lib_trace_level_set(enum nrf_modem_lib_trace_level trace_level);
 /** @brief Get the last measured rolling average bitrate of the trace backend.
  *
  * This function returns the last measured rolling average bitrate of the trace backend
- * calculated over the last @kconfig(CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS) period.
+ * calculated over the last @kconfig{CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_BITRATE_PERIOD_MS} period.
  *
  * @return Rolling average bitrate of the trace backend
  */


### PR DESCRIPTION
Add `__DOXYGEN__` to predefinition list so that header files can use it to build documentation for symbols that are disabled by default.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>