### PR TITLE
DNR: WIP: Update ncs-toolchain-version-minimum.txt

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -13,14 +13,17 @@
     - "!ncs_version.h.in"
 
 "CI-tool-test-linux":
+  - "scripts/ncs-toolchain-version-minimum.txt"
   - "scripts/requirements*.txt"
   - "scripts/tools-versions-linux.txt"
 
 "CI-tool-test-win":
+  - "scripts/ncs-toolchain-version-minimum.txt"
   - "scripts/requirements*.txt"
   - "scripts/tools-versions-win10.txt"
 
 "CI-tool-test-darwin":
+  - "scripts/ncs-toolchain-version-minimum.txt"
   - "scripts/requirements*.txt"
   - "scripts/tools-versions-darwin.txt"
 

--- a/scripts/ncs-toolchain-version-minimum.txt
+++ b/scripts/ncs-toolchain-version-minimum.txt
@@ -1,3 +1,3 @@
 # This file specifies the minimum nRF Connect SDK Toolchain that will be
 # working with this release.
-nrf-connect-sdk-toolchain=2.2.0
+nrf-connect-sdk-toolchain=2.2.99-1


### PR DESCRIPTION
This change will build and tag a bundle for `v2.2.99-1` 
This will be used for the `v2.3.0` release. 

Right before release we change this to `v2.3.0` and it will create a symlink to the exact same tools as `v2.2.99-1`.  
