### PR TITLE
manifest: Update sdk-mcuboot from upstream Zephyr fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -106,7 +106,7 @@ manifest:
       revision: 207e0508be39a4896ec584037888b747b9ace558
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 4f775a87611a084a2f6ad9a8a5034e080ddcc579
+      revision: pull/238/head
       path: bootloader/mcuboot
     - name: mbedtls
       path: modules/crypto/mbedtls


### PR DESCRIPTION
Updates sdk-mcuboot sha to point to upstream Zephyr fork update.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>