### PR TITLE
manifest: Update sdk-mcuboot revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -106,7 +106,7 @@ manifest:
       revision: 20ebeeffbdc617a3447c28e62754e3a882f7eb55
     - name: mcuboot
       repo-path: sdk-mcuboot
-      revision: 6fec3ff088e3fd49a522eb4b73326174c7288332
+      revision: 6242c860864bc6a1ed45f4f1af0e57b53cf3b858
       path: bootloader/mcuboot
     - name: mbedtls
       path: modules/crypto/mbedtls


### PR DESCRIPTION
Update sdk-mcuboot revision to bring:
  [nrf fromtree] boot: zephyr: Only call sys_clock_disable ...
     picked from 90b8f69040
  [nrf noup] zephyr: Disable Thingy:53 board specific USB CDC config

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>