### PR TITLE
subsys: dm: rpc: Fix typo in CONFIG #ifdef

### DIFF
--- a/subsys/dm/rpc/client/dm_rpc_client.c
+++ b/subsys/dm/rpc/client/dm_rpc_client.c
@@ -100,7 +100,7 @@ static void process_data(const struct dm_rpc_process_data *data, struct dm_resul
 		result->dist_estimates.mcpd.best = data->report.distance_estimates.mcpd.best;
 		result->dist_estimates.mcpd.rssi_openspace =
 						data->report.distance_estimates.mcpd.rssi_openspace;
-#ifdef CONFIG_DM__HIGH_PRECISION_CALC
+#ifdef CONFIG_DM_HIGH_PRECISION_CALC
 		result->dist_estimates.mcpd.high_precision = high_precision_estimate;
 #endif
 	}


### PR DESCRIPTION
The setting being checked (CONFIG_DM_HIGH_PRECISION_CALC) was misspelled.