### PR TITLE
applications: nrf5340_audio: Switching BISes in a BIG robustness update

### DIFF
--- a/applications/nrf5340_audio/src/audio/streamctrl.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl.c
@@ -334,7 +334,7 @@ static void button_evt_handler(struct button_evt event)
 #endif /*CONFIG_AUDIO_TEST_TONE*/
 
 		if (ret) {
-			LOG_WRN("Failed button 4 press");
+			LOG_WRN("Failed button 4 press, ret: %d", ret);
 		}
 
 		break;
@@ -348,7 +348,7 @@ static void button_evt_handler(struct button_evt event)
 #else
 		ret = le_audio_user_defined_button_press(LE_AUDIO_USER_DEFINED_ACTION_2);
 		if (ret) {
-			LOG_WRN("User defined button 5 action failed");
+			LOG_WRN("User defined button 5 action failed, ret: %d", ret);
 		}
 #endif
 		break;

--- a/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
+++ b/applications/nrf5340_audio/src/bluetooth/le_audio_bis_gateway.c
@@ -484,6 +484,8 @@ int le_audio_enable(le_audio_receive_cb recv_cb)
 
 	ARG_UNUSED(recv_cb);
 
+	LOG_INF("Starting broadcast gateway %s", CONFIG_BT_AUDIO_BROADCAST_NAME);
+
 	ret = initialize();
 	if (ret) {
 		LOG_ERR("Failed to initialize");


### PR DESCRIPTION
OCT-2441
On a button press the system should cleanly switch to the next BIS in the BIG and wrap when it hits the end.
This update syncs to all streams and switches between them. Rejecting and buffers not sent to the active stream.

Signed-off-by: Graham Wacey <graham.wacey@nordicsemi.no>