### PR TITLE
samples: nrf9160: Select UART2 for nRF5340

### DIFF
--- a/samples/nrf9160/slm_shell/README.rst
+++ b/samples/nrf9160/slm_shell/README.rst
@@ -15,10 +15,9 @@ Requirements
 
 SLM application should be configured to use UART_2 on nRF9160 side.
 
-The sample supports the following development kit:
+The sample supports the following development kits:
 
-* PCA10056 nRF52840
-* PCA10095 nRF5340 (for the APP core only)
+.. table-from-sample-yaml::
 
 Connect the DK with a nRF9160 DK based on the pin configuration in DTS overlay files of both sides.
 
@@ -41,7 +40,7 @@ The following table shows how to connect PCA10056 UART_1 to nRF9160 UART_2 for c
    * - GPIO GND
      - GPIO GND
 
-The following table shows how to connect PCA10095 UART_1 to nRF9160 UART_2 for communication through UART:
+The following table shows how to connect PCA10095 UART_2 to nRF9160 UART_2 for communication through UART:
 
 .. list-table::
    :align: center
@@ -49,9 +48,9 @@ The following table shows how to connect PCA10095 UART_1 to nRF9160 UART_2 for c
 
    * - nRF5340 DK
      - nRF9160 DK
-   * - UART TX P1.01
+   * - UART TX P1.04
      - UART RX P0.11
-   * - UART RX P1.00
+   * - UART RX P1.05
      - UART TX P0.10
    * - GPIO OUT P0.23 (Button1)
      - GPIO IN P0.31

--- a/samples/nrf9160/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/nrf9160/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-# Configuration file for nRF52840DK.
+# Configuration file for nRF53400DK.
 # This file is merged with prj.conf in the application folder, and options
 # set here will take precedence if they are present in both files.
 
-CONFIG_NRFX_UARTE1=y
-CONFIG_UART_1_INTERRUPT_DRIVEN=n
-CONFIG_UART_1_ASYNC=y
-CONFIG_UART_1_NRF_HW_ASYNC=y
-CONFIG_UART_1_NRF_HW_ASYNC_TIMER=2
+CONFIG_NRFX_UARTE2=y
+CONFIG_UART_2_INTERRUPT_DRIVEN=n
+CONFIG_UART_2_ASYNC=y
+CONFIG_UART_2_NRF_HW_ASYNC=y
+CONFIG_UART_2_NRF_HW_ASYNC_TIMER=2
 CONFIG_MODEM_SLM_WAKEUP_PIN=23

--- a/samples/nrf9160/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/nrf9160/slm_shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -6,35 +6,35 @@
 
 / {
 	chosen {
-		ncs,slm-uart = &uart1;
+		ncs,slm-uart = &uart2;
 	};
 };
 
-&uart1 {
+&uart2 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
 
-	pinctrl-0 = <&uart1_default>;
-	pinctrl-1 = <&uart1_sleep>;
+	pinctrl-0 = <&uart2_default>;
+	pinctrl-1 = <&uart2_sleep>;
 	pinctrl-names = "default", "sleep";
 };
 
 &pinctrl {
-	uart1_default: uart1_default {
+	uart2_default: uart2_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 1)>;
+			psels = <NRF_PSEL(UART_TX, 1, 4)>;
 		};
 		group2 {
-			psels = <NRF_PSEL(UART_RX, 1, 0)>;
+			psels = <NRF_PSEL(UART_RX, 1, 5)>;
 			bias-pull-up;
 		};
 	};
 
-	uart1_sleep: uart1_sleep {
+	uart2_sleep: uart2_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 1)>,
-				<NRF_PSEL(UART_RX, 1, 0)>;
+			psels = <NRF_PSEL(UART_TX, 1, 4)>,
+				<NRF_PSEL(UART_RX, 1, 5)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
For nRF5340DK
UART1 is forwarded to network core.
P1.00 / P1.01 are physical connected to Segger and only exposed of DK 0.11.0.
Thus change UART2 and pin P1.04/ P1.05 for all nRF5340DK.

Signed-off-by: Pirun Lee <pirun.lee@nordicsemi.no>