### PR TITLE
lib: modem_info: validate modem_info_name_get argument

### DIFF
--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -423,7 +423,7 @@ int modem_info_name_get(enum modem_info info, char *name)
 {
 	int len;
 
-	if (name == NULL) {
+	if (name == NULL || info < 0 || info >= MODEM_INFO_COUNT) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Adds a check to avoid out-of-bounds enum.

Signed-off-by: Bernt Johan Damslora <bernt.damslora@nordicsemi.no>